### PR TITLE
Add test utilities to TT-CNN

### DIFF
--- a/.github/workflows/tt-cnn-post-commit.yaml
+++ b/.github/workflows/tt-cnn-post-commit.yaml
@@ -69,12 +69,8 @@ jobs:
       matrix:
         os: ["ubuntu-22.04"]
         test-group:
-          - name: tt-cnn pipeline unit tests
-            cmd: pytest models/tt_cnn/tests/test_pipeline.py
-          - name: tt-cnn builder unit tests
-            cmd: pytest models/tt_cnn/tests/test_builder.py
-          - name: tt-cnn testing unit tests
-            cmd: pytest models/tt_cnn/tests/test_testing.py
+          - name: tt-cnn unit tests
+            cmd: pytest models/tt_cnn/tests
     name: ${{ matrix.test-group.name }} ${{ inputs.arch }} ${{ inputs.runner-label }}
     runs-on: >-
       ${{

--- a/.github/workflows/tt-cnn-post-commit.yaml
+++ b/.github/workflows/tt-cnn-post-commit.yaml
@@ -73,6 +73,8 @@ jobs:
             cmd: pytest models/tt_cnn/tests/test_pipeline.py
           - name: tt-cnn builder unit tests
             cmd: pytest models/tt_cnn/tests/test_builder.py
+          - name: tt-cnn testing unit tests
+            cmd: pytest models/tt_cnn/tests/test_testing.py
     name: ${{ matrix.test-group.name }} ${{ inputs.arch }} ${{ inputs.runner-label }}
     runs-on: >-
       ${{

--- a/models/demos/vanilla_unet/tests/test_unet_model.py
+++ b/models/demos/vanilla_unet/tests/test_unet_model.py
@@ -16,7 +16,7 @@ from models.demos.vanilla_unet.tt.common import (
 )
 from models.demos.vanilla_unet.tt.config import create_unet_configs_from_parameters
 from models.demos.vanilla_unet.tt.model import create_unet_from_configs
-from models.experimental.functional_unet.tt.model_preprocessing import create_unet_input_tensors
+from models.tt_cnn.tt.testing import create_random_input_tensor
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
 
@@ -37,7 +37,7 @@ def test_vanilla_unet_model(
         parameters=parameters, input_height=input_height, input_width=input_width, batch_size=batch
     )
 
-    torch_input_tensor, ttnn_input_tensor = create_unet_input_tensors(
+    torch_input_tensor, ttnn_input_tensor = create_random_input_tensor(
         batch=batch,
         input_channels=input_channels,
         input_height=input_height,

--- a/models/demos/vanilla_unet/tests/test_unet_model_multi_device.py
+++ b/models/demos/vanilla_unet/tests/test_unet_model_multi_device.py
@@ -16,7 +16,7 @@ from models.demos.vanilla_unet.tt.common import (
 )
 from models.demos.vanilla_unet.tt.config import create_unet_configs_from_parameters
 from models.demos.vanilla_unet.tt.model import create_unet_from_configs
-from models.experimental.functional_unet.tt.model_preprocessing import create_unet_input_tensors
+from models.tt_cnn.tt.testing import create_random_input_tensor
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
 
@@ -45,7 +45,7 @@ def test_vanilla_unet_model_multi_device(
         parameters=parameters, input_height=input_height, input_width=input_width, batch_size=batch
     )
 
-    torch_input_tensor, ttnn_input_tensor = create_unet_input_tensors(
+    torch_input_tensor, ttnn_input_tensor = create_random_input_tensor(
         batch=total_batch,
         input_channels=input_channels,
         input_height=input_height,

--- a/models/demos/vanilla_unet/tests/test_unet_perf.py
+++ b/models/demos/vanilla_unet/tests/test_unet_perf.py
@@ -20,7 +20,6 @@ from models.demos.vanilla_unet.tt.common import (
 )
 from models.demos.vanilla_unet.tt.config import create_unet_configs_from_parameters
 from models.demos.vanilla_unet.tt.model import create_unet_from_configs
-from models.experimental.functional_unet.tt.model_preprocessing import create_unet_input_tensors
 from models.perf.device_perf_utils import check_device_perf, prep_device_perf_report, run_device_perf
 from models.perf.perf_utils import prep_perf_report
 from models.tt_cnn.tt.pipeline import (
@@ -28,6 +27,7 @@ from models.tt_cnn.tt.pipeline import (
     create_pipeline_from_config,
     get_memory_config_for_persistent_dram_tensor,
 )
+from models.tt_cnn.tt.testing import create_random_input_tensor
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
 
@@ -111,7 +111,7 @@ def test_vanilla_unet_perf_e2e(
     model = create_unet_from_configs(configs, device)
     run_model = create_unet_pipeline_model(model)
 
-    torch_input_tensor, ttnn_input_tensor = create_unet_input_tensors(
+    torch_input_tensor, ttnn_input_tensor = create_random_input_tensor(
         batch=batch,
         input_channels=input_channels,
         input_height=input_height,
@@ -229,7 +229,7 @@ def test_vanilla_unet_perf_e2e_multi_device(
     model = create_unet_from_configs(configs, mesh_device)
     run_model = create_unet_pipeline_model(model)
 
-    torch_input_tensor, ttnn_input_tensor = create_unet_input_tensors(
+    torch_input_tensor, ttnn_input_tensor = create_random_input_tensor(
         batch=total_batch,
         input_channels=input_channels,
         input_height=input_height,

--- a/models/experimental/functional_unet/tests/test_unet_bottleneck.py
+++ b/models/experimental/functional_unet/tests/test_unet_bottleneck.py
@@ -8,8 +8,8 @@ import ttnn
 from loguru import logger
 
 
+from models.tt_cnn.tt.testing import create_random_input_tensor
 from models.experimental.functional_unet.tt.model_preprocessing import (
-    create_unet_input_tensors,
     create_unet_model_parameters,
 )
 from models.experimental.functional_unet.tt import unet_shallow_torch
@@ -25,13 +25,13 @@ from models.experimental.functional_unet.tests.common import (
 @pytest.mark.parametrize("groups", [4])
 @pytest.mark.parametrize("device_params", [{"l1_small_size": UNET_L1_SMALL_REGION_SIZE}], indirect=True)
 def test_unet_bottleneck(batch: int, groups: int, device: ttnn.Device, reset_seeds):
-    torch_input, ttnn_input = create_unet_input_tensors(batch, groups)
+    torch_input, ttnn_input = create_random_input_tensor(batch, groups)
     model = unet_shallow_torch.UNet.from_random_weights(groups=groups)
 
     parameters = create_unet_model_parameters(model, torch_input, groups=groups, device=device)
     ttnn_model = unet_shallow_ttnn.UNet(parameters, device)
 
-    torch_input, ttnn_input = create_unet_input_tensors(
+    torch_input, ttnn_input = create_random_input_tensor(
         batch, groups, input_channels=32, input_height=66, input_width=10
     )
     logger.info(f"Created reference input tensors: {list(torch_input.shape)}")
@@ -56,14 +56,14 @@ def test_unet_bottleneck_multi_device(batch: int, groups: int, mesh_device: ttnn
     weights_mesh_mapper = ttnn.ReplicateTensorToMesh(mesh_device)
     output_mesh_composer = ttnn.ConcatMeshToTensor(mesh_device, dim=0)
 
-    torch_input, ttnn_input = create_unet_input_tensors(batch, groups)
+    torch_input, ttnn_input = create_random_input_tensor(batch, groups)
     model = unet_shallow_torch.UNet.from_random_weights(groups=groups)
 
     parameters = create_unet_model_parameters(model, torch_input, groups=groups, device=mesh_device)
     ttnn_model = unet_shallow_ttnn.UNet(parameters, mesh_device, mesh_mapper=weights_mesh_mapper)
 
     num_devices = len(mesh_device.get_device_ids())
-    torch_input, ttnn_input = create_unet_input_tensors(
+    torch_input, ttnn_input = create_random_input_tensor(
         num_devices * batch,
         groups,
         input_channels=32,

--- a/models/experimental/functional_unet/tests/test_unet_downblock.py
+++ b/models/experimental/functional_unet/tests/test_unet_downblock.py
@@ -6,8 +6,8 @@ import pytest
 import ttnn
 from loguru import logger
 
+from models.tt_cnn.tt.testing import create_random_input_tensor
 from models.experimental.functional_unet.tt.model_preprocessing import (
-    create_unet_input_tensors,
     create_unet_model_parameters,
 )
 from models.experimental.functional_unet.tt import unet_shallow_torch
@@ -41,13 +41,13 @@ def test_unet_downblock(
     device: ttnn.Device,
     reset_seeds,
 ):
-    torch_input, ttnn_input = create_unet_input_tensors(batch, groups)
+    torch_input, ttnn_input = create_random_input_tensor(batch, groups)
     model = unet_shallow_torch.UNet.from_random_weights(groups=groups)
 
     parameters = create_unet_model_parameters(model, torch_input, groups=groups, device=device)
     ttnn_model = unet_shallow_ttnn.UNet(parameters, device)
 
-    torch_input, ttnn_input = create_unet_input_tensors(
+    torch_input, ttnn_input = create_random_input_tensor(
         batch,
         groups,
         input_channels=input_channels,
@@ -85,14 +85,14 @@ def test_unet_downblock_multi_device(
     weights_mesh_mapper = ttnn.ReplicateTensorToMesh(mesh_device)
     output_mesh_composer = ttnn.ConcatMeshToTensor(mesh_device, dim=0)
 
-    torch_input, ttnn_input = create_unet_input_tensors(batch, groups)
+    torch_input, ttnn_input = create_random_input_tensor(batch, groups)
     model = unet_shallow_torch.UNet.from_random_weights(groups=groups)
 
     parameters = create_unet_model_parameters(model, torch_input, groups=groups, device=mesh_device)
     ttnn_model = unet_shallow_ttnn.UNet(parameters, mesh_device, mesh_mapper=weights_mesh_mapper)
 
     num_devices = len(mesh_device.get_device_ids())
-    torch_input, ttnn_input = create_unet_input_tensors(
+    torch_input, ttnn_input = create_random_input_tensor(
         num_devices * batch,
         groups,
         input_channels=input_channels,

--- a/models/experimental/functional_unet/tests/test_unet_model.py
+++ b/models/experimental/functional_unet/tests/test_unet_model.py
@@ -7,8 +7,8 @@ import ttnn
 
 from ttnn.device import is_wormhole_b0
 
+from models.tt_cnn.tt.testing import create_random_input_tensor
 from models.experimental.functional_unet.tt.model_preprocessing import (
-    create_unet_input_tensors,
     create_unet_model_parameters,
 )
 from models.experimental.functional_unet.tt import unet_shallow_torch
@@ -22,7 +22,7 @@ from models.experimental.functional_unet.tests.common import (
 
 
 def run_unet_model(batch, groups, device, iterations=1):
-    torch_input, ttnn_input = create_unet_input_tensors(
+    torch_input, ttnn_input = create_random_input_tensor(
         batch,
         groups,
         channel_order="first",
@@ -48,7 +48,7 @@ def run_unet_model(batch, groups, device, iterations=1):
     )
 
     for _ in range(iterations - 1):
-        _, ttnn_input = create_unet_input_tensors(
+        _, ttnn_input = create_random_input_tensor(
             batch,
             groups,
             channel_order="first",

--- a/models/experimental/functional_unet/tests/test_unet_multi_device.py
+++ b/models/experimental/functional_unet/tests/test_unet_multi_device.py
@@ -7,8 +7,8 @@ import ttnn
 
 from loguru import logger
 
+from models.tt_cnn.tt.testing import create_random_input_tensor
 from models.experimental.functional_unet.tt.model_preprocessing import (
-    create_unet_input_tensors,
     create_unet_model_parameters,
 )
 from models.experimental.functional_unet.tt import unet_shallow_torch
@@ -33,7 +33,7 @@ def test_unet_multi_device_model(batch, groups, mesh_device, reset_seeds):
     weights_mesh_mapper = ttnn.ReplicateTensorToMesh(mesh_device)
     output_mesh_composer = ttnn.ConcatMeshToTensor(mesh_device, dim=0)
 
-    torch_input, ttnn_input = create_unet_input_tensors(batch, groups)
+    torch_input, ttnn_input = create_random_input_tensor(batch, groups)
     model = unet_shallow_torch.UNet.from_random_weights(groups=groups)
 
     parameters = create_unet_model_parameters(model, torch_input, groups=groups, device=mesh_device)
@@ -42,7 +42,7 @@ def test_unet_multi_device_model(batch, groups, mesh_device, reset_seeds):
     num_devices = len(mesh_device.get_device_ids())
     total_batch = num_devices * batch
     logger.info(f"Using {num_devices} devices for this test")
-    torch_input, ttnn_input = create_unet_input_tensors(
+    torch_input, ttnn_input = create_random_input_tensor(
         total_batch,
         groups,
         channel_order="first",

--- a/models/experimental/functional_unet/tests/test_unet_output_layer.py
+++ b/models/experimental/functional_unet/tests/test_unet_output_layer.py
@@ -5,8 +5,8 @@
 import pytest
 import ttnn
 
+from models.tt_cnn.tt.testing import create_random_input_tensor
 from models.experimental.functional_unet.tt.model_preprocessing import (
-    create_unet_input_tensors,
     create_unet_model_parameters,
 )
 from models.experimental.functional_unet.tt import unet_shallow_torch
@@ -18,13 +18,13 @@ from models.experimental.functional_unet.tests.common import verify_with_pcc, UN
 @pytest.mark.parametrize("batch, groups", [(1, 4)])
 @pytest.mark.parametrize("device_params", [{"l1_small_size": UNET_L1_SMALL_REGION_SIZE}], indirect=True)
 def test_unet_output_layer(batch, groups, device, reset_seeds):
-    torch_input, ttnn_input = create_unet_input_tensors(batch, groups)
+    torch_input, ttnn_input = create_random_input_tensor(batch, groups)
     model = unet_shallow_torch.UNet.from_random_weights(groups=groups)
 
     parameters = create_unet_model_parameters(model, torch_input, groups=groups, device=device)
     ttnn_model = unet_shallow_ttnn.UNet(parameters, device)
 
-    torch_input, ttnn_input = create_unet_input_tensors(batch, groups, input_channels=16)
+    torch_input, ttnn_input = create_random_input_tensor(batch, groups, input_channels=16)
     torch_output = model.output_layer(torch_input)
 
     # TODO: Either infer these for get them from the model implementation

--- a/models/experimental/functional_unet/tests/test_unet_preprocessing.py
+++ b/models/experimental/functional_unet/tests/test_unet_preprocessing.py
@@ -8,9 +8,7 @@ import ttnn
 
 from loguru import logger
 
-from models.experimental.functional_unet.tt.model_preprocessing import (
-    create_unet_input_tensors,
-)
+from models.tt_cnn.tt.testing import create_random_input_tensor
 
 from models.experimental.functional_unet.tt import unet_shallow_ttnn
 from models.experimental.functional_unet.tests.common import verify_with_pcc, UNET_L1_SMALL_REGION_SIZE
@@ -25,7 +23,7 @@ def nearest_16(x):
 @pytest.mark.parametrize("device_params", [{"l1_small_size": UNET_L1_SMALL_REGION_SIZE}], indirect=True)
 def test_unet_preprocessing(batch, groups, device, reset_seeds):
     input_memory_config = unet_shallow_ttnn.UNet.input_sharded_memory_config
-    torch_input, ttnn_input = create_unet_input_tensors(
+    torch_input, ttnn_input = create_random_input_tensor(
         batch, groups, channel_order="first", pad=False, fold=True, device=device, memory_config=input_memory_config
     )
     logger.info(f"Created input tensor with shape {list(ttnn_input.shape)}")

--- a/models/experimental/functional_unet/tests/test_unet_trace.py
+++ b/models/experimental/functional_unet/tests/test_unet_trace.py
@@ -10,8 +10,8 @@ from ttnn.device import is_wormhole_b0
 
 from loguru import logger
 
+from models.tt_cnn.tt.testing import create_random_input_tensor
 from models.experimental.functional_unet.tt.model_preprocessing import (
-    create_unet_input_tensors,
     create_unet_model_parameters,
 )
 from models.experimental.functional_unet.tt import unet_shallow_torch
@@ -75,7 +75,7 @@ def test_unet_trace_2cq(
     device,
     reset_seeds,
 ):
-    torch_input, ttnn_input = create_unet_input_tensors(batch, groups, channel_order="first", pad=False, fold=True)
+    torch_input, ttnn_input = create_random_input_tensor(batch, groups, channel_order="first", pad=False, fold=True)
 
     model = unet_shallow_torch.UNet.from_random_weights(groups=groups)
     torch_output_tensor = model(torch_input)
@@ -202,7 +202,7 @@ def test_unet_trace_2cq_multi_device(
     weights_mesh_mapper = ttnn.ReplicateTensorToMesh(mesh_device)
     output_mesh_composer = ttnn.ConcatMeshToTensor(mesh_device, dim=0)
 
-    torch_input, ttnn_input = create_unet_input_tensors(batch, groups)
+    torch_input, ttnn_input = create_random_input_tensor(batch, groups)
 
     model = unet_shallow_torch.UNet.from_random_weights(groups=groups)
 
@@ -213,7 +213,7 @@ def test_unet_trace_2cq_multi_device(
     logger.info(f"Using {num_devices} devices for this test")
 
     total_batch = num_devices * batch
-    torch_input, ttnn_input = create_unet_input_tensors(
+    torch_input, ttnn_input = create_random_input_tensor(
         total_batch, groups, channel_order="first", pad=False, fold=True, mesh_mapper=inputs_mesh_mapper
     )
     logger.info(f"Created reference input tensors: {list(torch_input.shape)}")

--- a/models/experimental/functional_unet/tests/test_unet_upblock.py
+++ b/models/experimental/functional_unet/tests/test_unet_upblock.py
@@ -8,8 +8,8 @@ import ttnn
 from loguru import logger
 
 
+from models.tt_cnn.tt.testing import create_random_input_tensor
 from models.experimental.functional_unet.tt.model_preprocessing import (
-    create_unet_input_tensors,
     create_unet_model_parameters,
 )
 from models.experimental.functional_unet.tt import unet_shallow_torch
@@ -44,20 +44,20 @@ def test_unet_upblock(
     device: ttnn.Device,
     reset_seeds,
 ):
-    torch_input, ttnn_input = create_unet_input_tensors(batch, groups)
+    torch_input, ttnn_input = create_random_input_tensor(batch, groups)
     model = unet_shallow_torch.UNet.from_random_weights(groups=groups)
 
     parameters = create_unet_model_parameters(model, torch_input, groups=groups, device=device)
     ttnn_model = unet_shallow_ttnn.UNet(parameters, device)
 
-    torch_input, ttnn_input = create_unet_input_tensors(
+    torch_input, ttnn_input = create_random_input_tensor(
         batch,
         groups,
         input_channels=input_channels,
         input_height=input_height,
         input_width=input_width,
     )
-    torch_residual, ttnn_residual = create_unet_input_tensors(
+    torch_residual, ttnn_residual = create_random_input_tensor(
         batch,
         groups,
         input_channels=residual_channels,
@@ -102,14 +102,14 @@ def test_unet_upblock_multi_device(
     weights_mesh_mapper = ttnn.ReplicateTensorToMesh(mesh_device)
     output_mesh_composer = ttnn.ConcatMeshToTensor(mesh_device, dim=0)
 
-    torch_input, ttnn_input = create_unet_input_tensors(batch, groups)
+    torch_input, ttnn_input = create_random_input_tensor(batch, groups)
     model = unet_shallow_torch.UNet.from_random_weights(groups=groups)
 
     parameters = create_unet_model_parameters(model, torch_input, groups=groups, device=mesh_device)
     ttnn_model = unet_shallow_ttnn.UNet(parameters, mesh_device, mesh_mapper=weights_mesh_mapper)
 
     num_devices = len(mesh_device.get_device_ids())
-    torch_input, ttnn_input = create_unet_input_tensors(
+    torch_input, ttnn_input = create_random_input_tensor(
         num_devices * batch,
         groups,
         input_channels=input_channels,
@@ -121,7 +121,7 @@ def test_unet_upblock_multi_device(
     logger.info(
         f"Created multi-device input tensors: shape={list(ttnn_input.shape)} on devices={mesh_device.get_device_ids()}"
     )
-    torch_residual, ttnn_residual = create_unet_input_tensors(
+    torch_residual, ttnn_residual = create_random_input_tensor(
         num_devices * batch,
         groups,
         input_channels=residual_channels,

--- a/models/experimental/functional_unet/tt/model_preprocessing.py
+++ b/models/experimental/functional_unet/tt/model_preprocessing.py
@@ -5,53 +5,11 @@
 import torch
 import ttnn
 
-from typing import Literal
-
 from ttnn.model_preprocessing import infer_ttnn_module_args
 
 from models.experimental.functional_unet.tt import unet_shallow_torch
 
-
-def pad_channels_up_to_target(input_tensor, target=16):
-    assert len(input_tensor.shape) == 4, "Expected input tensor to rank 4"
-    N, C, H, W = input_tensor.shape
-    if C < target:
-        return torch.nn.functional.pad(input_tensor, (0, 0, 0, 0, 0, target - C), mode="constant", value=0)
-    else:
-        return input_tensor
-
-
-def create_unet_input_tensors(
-    batch: int,
-    groups: int,
-    input_channels: int = 4,
-    input_height: int = 1056,
-    input_width: int = 160,
-    channel_order: Literal["first", "last"] = "last",
-    fold: bool = True,
-    pad: bool = True,
-    device=None,
-    memory_config=None,
-    mesh_mapper=None,
-):
-    torch_input_tensor = torch.randn(batch, input_channels * groups, input_height, input_width)
-
-    # We almost always (unless running full model) want to ensure we have least 16 because conv2d requires it
-    ttnn_input_tensor = pad_channels_up_to_target(torch_input_tensor, 16) if pad else torch_input_tensor
-
-    ttnn_input_tensor = ttnn_input_tensor if channel_order == "first" else ttnn_input_tensor.permute(0, 2, 3, 1)
-
-    if fold:
-        if channel_order == "first":
-            ttnn_input_tensor = ttnn_input_tensor.reshape(batch, 1, input_channels * groups, input_height * input_width)
-        else:
-            ttnn_input_tensor = ttnn_input_tensor.reshape(batch, 1, input_height * input_width, -1)
-
-    ttnn_input_tensor = ttnn.from_torch(
-        ttnn_input_tensor, dtype=ttnn.bfloat16, device=device, memory_config=memory_config, mesh_mapper=mesh_mapper
-    )
-
-    return torch_input_tensor, ttnn_input_tensor
+# Import from common location for backward compatibility
 
 
 def create_unet_model_parameters(

--- a/models/tt_cnn/tests/test_testing.py
+++ b/models/tt_cnn/tests/test_testing.py
@@ -1,0 +1,153 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import ttnn
+from models.tt_cnn.tt.testing import create_random_input_tensor
+
+
+class TestCreateRandomInputTensor:
+    """Tests for the create_random_input_tensor function"""
+
+    def test_tensor_creation_no_device(self):
+        """Test basic tensor creation without device"""
+        batch = 2
+        groups = 1
+        input_channels = 32
+        input_height = 64
+        input_width = 64
+
+        torch_tensor, ttnn_tensor = create_random_input_tensor(
+            batch=batch,
+            groups=groups,
+            input_channels=input_channels,
+            input_height=input_height,
+            input_width=input_width,
+            fold=True,
+            pad=True,
+            device=None,
+        )
+
+        # Check torch tensor shape (NCHW)
+        expected_torch_shape = (batch, input_channels * groups, input_height, input_width)
+        assert torch_tensor.shape == expected_torch_shape, f"Expected {expected_torch_shape}, got {torch_tensor.shape}"
+
+        # Check ttnn tensor - it should be folded by default with channel_order="last"
+        ttnn_torch = ttnn.to_torch(ttnn_tensor)
+        expected_ttnn_shape = (batch, 1, input_height * input_width, input_channels)
+        assert ttnn_torch.shape == expected_ttnn_shape, f"Expected {expected_ttnn_shape}, got {ttnn_torch.shape}"
+
+    def test_channel_order_first(self):
+        """Test with channel_order='first'"""
+        batch = 1
+        groups = 1
+        input_channels = 8
+        input_height = 32
+        input_width = 32
+
+        torch_tensor, ttnn_tensor = create_random_input_tensor(
+            batch=batch,
+            groups=groups,
+            input_channels=input_channels,
+            input_height=input_height,
+            input_width=input_width,
+            channel_order="first",
+            pad=False,
+            device=None,
+        )
+        ttnn_torch = ttnn.to_torch(ttnn_tensor)
+
+        # With fold=True and channel_order="first", shape should be (batch, 1, channels, H*W)
+        expected_shape = (batch, 1, input_channels, input_height * input_width)
+        assert ttnn_torch.shape == expected_shape, f"Expected {expected_shape}, got {ttnn_torch.shape}"
+
+    def test_channel_order_last(self):
+        """Test with channel_order='last'"""
+        batch = 1
+        groups = 1
+        input_channels = 8
+        input_height = 32
+        input_width = 32
+
+        torch_tensor, ttnn_tensor = create_random_input_tensor(
+            batch=batch,
+            groups=groups,
+            input_channels=input_channels,
+            input_height=input_height,
+            input_width=input_width,
+            channel_order="last",
+            device=None,
+        )
+        ttnn_torch = ttnn.to_torch(ttnn_tensor)
+
+        # With fold=True and channel_order="last", shape should be (batch, 1, H*W, channels)
+        expected_shape = (batch, 1, input_height * input_width, 16)  # padded to 16
+        assert ttnn_torch.shape == expected_shape, f"Expected {expected_shape}, got {ttnn_torch.shape}"
+
+    def test_no_fold(self):
+        """Test with fold=False"""
+        batch = 2
+        groups = 1
+        input_channels = 16
+        input_height = 64
+        input_width = 64
+
+        torch_tensor, ttnn_tensor = create_random_input_tensor(
+            batch=batch,
+            groups=groups,
+            input_channels=input_channels,
+            input_height=input_height,
+            input_width=input_width,
+            channel_order="last",
+            fold=False,
+            device=None,
+        )
+        ttnn_torch = ttnn.to_torch(ttnn_tensor)
+
+        # With fold=False and channel_order="last", shape should be (B, H, W, C)
+        expected_shape = (batch, input_height, input_width, input_channels)
+        assert ttnn_torch.shape == expected_shape, f"Expected {expected_shape}, got {ttnn_torch.shape}"
+
+    def test_groups_parameter(self):
+        """Test with groups > 1"""
+        batch = 1
+        groups = 2
+        input_channels = 8
+        input_height = 32
+        input_width = 32
+
+        torch_tensor, ttnn_tensor = create_random_input_tensor(
+            batch=batch,
+            groups=groups,
+            input_channels=input_channels,
+            input_height=input_height,
+            input_width=input_width,
+            channel_order="first",
+            device=None,
+        )
+
+        # Torch tensor should have channels = input_channels * groups
+        expected_torch_shape = (batch, input_channels * groups, input_height, input_width)
+        assert torch_tensor.shape == expected_torch_shape, f"Expected {expected_torch_shape}, got {torch_tensor.shape}"
+
+    def test_different_input_sizes(self):
+        """Test with different input dimensions"""
+        test_sizes = [
+            (32, 32),
+            (64, 64),
+            (128, 128),
+            (224, 224),
+            (480, 640),  # Non-square
+        ]
+
+        for height, width in test_sizes:
+            torch_tensor, ttnn_tensor = create_random_input_tensor(
+                batch=1,
+                groups=1,
+                input_channels=16,
+                input_height=height,
+                input_width=width,
+                device=None,
+            )
+
+            assert torch_tensor.shape[2:] == (height, width), f"Expected height={height}, width={width}"

--- a/models/tt_cnn/tests/test_testing.py
+++ b/models/tt_cnn/tests/test_testing.py
@@ -2,8 +2,17 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+import pytest
+import torch
+
 import ttnn
-from models.tt_cnn.tt.testing import create_random_input_tensor
+from models.tt_cnn.tt.builder import Conv2dConfiguration, MaxPool2dConfiguration
+from models.tt_cnn.tt.testing import (
+    create_random_input_tensor,
+    pad_channels_up_to_target,
+    verify_conv2d_from_config,
+    verify_maxpool2d_from_config,
+)
 
 
 class TestCreateRandomInputTensor:
@@ -151,3 +160,83 @@ class TestCreateRandomInputTensor:
             )
 
             assert torch_tensor.shape[2:] == (height, width), f"Expected height={height}, width={width}"
+
+
+class TestPadChannelsUpToTarget:
+    """Tests for the pad_channels_up_to_target helper function"""
+
+    def test_pad_channels_basic(self):
+        """Test basic padding functionality"""
+        input_tensor = torch.randn(1, 8, 32, 32)
+        padded = pad_channels_up_to_target(input_tensor, target=16)
+
+        assert padded.shape == (1, 16, 32, 32), f"Expected shape (1, 16, 32, 32), got {padded.shape}"
+        assert torch.allclose(padded[:, :8, :, :], input_tensor), "Original channels should be preserved"
+        assert torch.allclose(padded[:, 8:, :, :], torch.zeros(1, 8, 32, 32)), "Padded channels should be zeros"
+
+    def test_pad_channels_no_padding_needed(self):
+        """Test when channels already meet or exceed target"""
+        input_tensor = torch.randn(2, 16, 64, 64)
+        padded = pad_channels_up_to_target(input_tensor, target=16)
+        assert torch.equal(padded, input_tensor), "Tensor should be unchanged when channels equal target"
+
+        input_tensor = torch.randn(1, 32, 32, 32)
+        padded = pad_channels_up_to_target(input_tensor, target=16)
+        assert torch.equal(padded, input_tensor), "Tensor should be unchanged when channels exceed target"
+
+
+class TestLayerUnitTestGenerators:
+    """Tests for the layer unit test generator utilities"""
+
+    @pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
+    @pytest.mark.parametrize(
+        "input_height,input_width,in_channels,out_channels,kernel_size,padding,stride",
+        [
+            (32, 32, 16, 32, (3, 3), (1, 1), (1, 1)),  # Basic 3x3 conv
+            (56, 56, 64, 128, (1, 1), (0, 0), (1, 1)),  # 1x1 conv (ResNet-style)
+            (64, 64, 32, 64, (3, 3), (1, 1), (2, 2)),  # Stride 2 (downsampling)
+            (112, 112, 64, 128, (5, 5), (2, 2), (1, 1)),  # 5x5 kernel
+        ],
+    )
+    def test_verify_conv2d_from_config(
+        self, input_height, input_width, in_channels, out_channels, kernel_size, padding, stride, device
+    ):
+        """Test verify_conv2d_from_config with various configurations"""
+        config = Conv2dConfiguration.with_random_weights(
+            input_height=input_height,
+            input_width=input_width,
+            in_channels=in_channels,
+            out_channels=out_channels,
+            batch_size=1,
+            kernel_size=kernel_size,
+            padding=padding,
+            stride=stride,
+        )
+
+        verify_conv2d_from_config(config, device)
+
+    @pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
+    @pytest.mark.parametrize(
+        "input_height,input_width,channels,kernel_size,stride,ceil_mode",
+        [
+            (32, 32, 16, (2, 2), (2, 2), False),  # Basic 2x2 pool
+            (64, 64, 32, (4, 4), (4, 4), False),  # Larger 4x4 kernel
+            (33, 33, 16, (2, 2), (2, 2), True),  # Odd dimensions with ceil_mode
+            (56, 56, 32, (3, 3), (2, 2), False),  # 3x3 kernel with stride 2
+        ],
+    )
+    def test_verify_maxpool2d_from_config(
+        self, input_height, input_width, channels, kernel_size, stride, ceil_mode, device
+    ):
+        """Test verify_maxpool2d_from_config with various configurations"""
+        config = MaxPool2dConfiguration(
+            input_height=input_height,
+            input_width=input_width,
+            channels=channels,
+            batch_size=1,
+            kernel_size=kernel_size,
+            stride=stride,
+            ceil_mode=ceil_mode,
+        )
+
+        verify_maxpool2d_from_config(config, device)

--- a/models/tt_cnn/tt/testing.py
+++ b/models/tt_cnn/tt/testing.py
@@ -2,11 +2,15 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Literal
+from dataclasses import dataclass
+from typing import Dict, Literal, Optional
 
 import torch
+from loguru import logger
 
 import ttnn
+from models.perf.device_perf_utils import check_device_perf, prep_device_perf_report, run_device_perf
+from tests.ttnn.utils_for_testing import assert_with_pcc
 
 
 def pad_channels_up_to_target(input_tensor, target=16):
@@ -49,3 +53,211 @@ def create_random_input_tensor(
     )
 
     return torch_input_tensor, ttnn_input_tensor
+
+
+@dataclass
+class DevicePerformanceTestConfiguration:
+    """Configuration for device performance tests."""
+
+    model_name: str
+    test_command: str
+    batch_size: int
+    expected_throughput_fps: float
+    subdir: Optional[str] = None
+    num_iterations: int = 1
+    margin: float = 0.02
+    columns: Optional[list] = None
+    inference_time_key: str = "AVG DEVICE KERNEL SAMPLES/S"
+    comments: str = ""
+
+
+def run_device_perf_test(config: DevicePerformanceTestConfiguration) -> Dict[str, float]:
+    """Run a device performance test."""
+    if config.columns is None:
+        columns = ["DEVICE FW", "DEVICE KERNEL", "DEVICE BRISC KERNEL"]
+    else:
+        columns = config.columns
+    subdir = config.subdir or config.model_name
+
+    logger.info(f"Running device performance test for {config.model_name}...")
+    logger.info(f"Command: {config.test_command}")
+    logger.info(f"Expected throughput: {config.expected_throughput_fps} fps")
+
+    # Run device performance measurement
+    post_processed_results = run_device_perf(
+        config.test_command,
+        subdir=subdir,
+        num_iterations=config.num_iterations,
+        cols=columns,
+        batch_size=config.batch_size,
+    )
+
+    # Check against expected performance
+    expected_perf_cols = {config.inference_time_key: config.expected_throughput_fps}
+    expected_results = check_device_perf(
+        post_processed_results,
+        margin=config.margin,
+        expected_perf_cols=expected_perf_cols,
+        assert_on_fail=True,
+    )
+
+    # Prepare performance report
+    prep_device_perf_report(
+        model_name=config.model_name,
+        batch_size=config.batch_size,
+        post_processed_results=post_processed_results,
+        expected_results=expected_results,
+        comments=config.comments,
+    )
+
+    logger.info(f"Device performance test passed for {config.model_name}")
+
+    return {
+        "post_processed_results": post_processed_results,
+        "expected_results": expected_results,
+    }
+
+
+def verify_conv2d_from_config(
+    configuration,
+    device,
+    pcc_threshold: float = 0.999,
+) -> None:
+    """Verify a Conv2d layer from a configuration.
+
+    This creates inputs, runs both TT and PyTorch implementations,
+    and verifies correctness with PCC.
+
+    Args:
+        configuration: Conv2dConfiguration to test
+        device: ttnn.Device to run on
+        pcc_threshold: PCC threshold for verification (default: 0.999)
+
+    Raises:
+        AssertionError: If PCC check fails or shapes don't match
+
+    Example:
+        config = Conv2dConfiguration.with_random_weights(
+            input_height=224, input_width=224,
+            in_channels=64, out_channels=128,
+            batch_size=1, kernel_size=(3, 3), padding=(1, 1),
+        )
+
+        verify_conv2d_from_config(config, device)
+    """
+    from models.tt_cnn.tt.builder import TtConv2d
+
+    logger.info(f"Running test for conv2d with configuration:")
+    logger.info(
+        f"Config: {configuration.in_channels}->{configuration.out_channels}, "
+        f"kernel={configuration.kernel_size}, input={configuration.input_height}x{configuration.input_width}"
+    )
+
+    shape = (
+        configuration.batch_size,
+        configuration.in_channels,
+        configuration.input_height,
+        configuration.input_width,
+    )
+    torch_input = torch.randn(shape, dtype=torch.bfloat16).float()
+
+    nhwc = torch.permute(torch_input, (0, 2, 3, 1))
+    ttnn_input = ttnn.from_torch(nhwc, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT)
+
+    tt_layer = TtConv2d(configuration, device)
+    ttnn_output = tt_layer(ttnn_input)
+
+    torch_output = torch.nn.functional.conv2d(
+        torch_input,
+        ttnn.to_torch(configuration.weight),
+        ttnn.to_torch(configuration.bias).reshape(-1) if configuration.bias is not None else None,
+        stride=configuration.stride,
+        padding=configuration.padding,
+        dilation=configuration.dilation,
+        groups=configuration.groups,
+    )
+
+    output_height, output_width = torch_output.shape[-2:]
+    ttnn_output_torch = (
+        ttnn.to_torch(ttnn_output)
+        .reshape(configuration.batch_size, output_height, output_width, configuration.out_channels)
+        .permute(0, 3, 1, 2)
+    )
+
+    assert (
+        ttnn_output_torch.shape == torch_output.shape
+    ), f"Shape mismatch: ttnn={ttnn_output_torch.shape}, torch={torch_output.shape}"
+
+    pcc_passed, pcc_message = assert_with_pcc(torch_output, ttnn_output_torch, pcc_threshold)
+    logger.success(f"Test passed with PCC: {pcc_message:.5f} > {pcc_threshold:.5f}")
+
+
+def verify_maxpool2d_from_config(
+    configuration,
+    device,
+    pcc_threshold: float = 0.999,
+) -> None:
+    """Verify a MaxPool2d layer from a configuration.
+
+    This creates inputs, runs both TT and PyTorch implementations,
+    and verifies correctness with PCC.
+
+    Args:
+        configuration: MaxPool2dConfiguration to test
+        device: ttnn.Device to run on
+        pcc_threshold: PCC threshold for verification (default: 0.999)
+
+    Example:
+        config = MaxPool2dConfiguration(
+            input_height=224, input_width=224, channels=64,
+            batch_size=1, kernel_size=(2, 2), stride=(2, 2),
+        )
+
+        verify_maxpool2d_from_config(config, device)
+    """
+    from models.tt_cnn.tt.builder import TtMaxPool2d
+
+    logger.info(f"Running test for maxpool2d with configuration:")
+    logger.info(
+        f"Config: channels={configuration.channels}, kernel={configuration.kernel_size}, "
+        f"input={configuration.input_height}x{configuration.input_width}"
+    )
+
+    shape = (
+        configuration.batch_size,
+        configuration.channels,
+        configuration.input_height,
+        configuration.input_width,
+    )
+    torch_input = torch.randn(shape, dtype=torch.bfloat16).float()
+
+    nhwc = torch.permute(torch_input, (0, 2, 3, 1)).reshape(
+        1, 1, configuration.batch_size * configuration.input_height * configuration.input_width, configuration.channels
+    )
+    ttnn_input = ttnn.from_torch(nhwc, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
+
+    tt_layer = TtMaxPool2d(configuration, device)
+    ttnn_output = tt_layer(ttnn_input)
+
+    torch_output = torch.nn.functional.max_pool2d(
+        torch_input,
+        kernel_size=configuration.kernel_size,
+        stride=configuration.stride,
+        padding=configuration.padding,
+        dilation=configuration.dilation,
+        ceil_mode=configuration.ceil_mode,
+    )
+
+    output_height, output_width = torch_output.shape[-2:]
+    ttnn_output_torch = (
+        ttnn.to_torch(ttnn_output)
+        .reshape(configuration.batch_size, output_height, output_width, configuration.channels)
+        .permute(0, 3, 1, 2)
+    )
+
+    assert (
+        ttnn_output_torch.shape == torch_output.shape
+    ), f"Shape mismatch: ttnn={ttnn_output_torch.shape}, torch={torch_output.shape}"
+
+    pcc_passed, pcc_message = assert_with_pcc(torch_output, ttnn_output_torch, pcc_threshold)
+    logger.success(f"Test passed with PCC: {pcc_message:.5f} > {pcc_threshold:.5f}")

--- a/models/tt_cnn/tt/testing.py
+++ b/models/tt_cnn/tt/testing.py
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Literal
+
+import torch
+
+import ttnn
+
+
+def pad_channels_up_to_target(input_tensor, target=16):
+    assert len(input_tensor.shape) == 4, "Expected input tensor to rank 4"
+    N, C, H, W = input_tensor.shape
+    if C < target:
+        return torch.nn.functional.pad(input_tensor, (0, 0, 0, 0, 0, target - C), mode="constant", value=0)
+    else:
+        return input_tensor
+
+
+def create_random_input_tensor(
+    batch: int,
+    groups: int,
+    input_channels: int = 4,
+    input_height: int = 1056,
+    input_width: int = 160,
+    channel_order: Literal["first", "last"] = "last",
+    fold: bool = True,
+    pad: bool = True,
+    device=None,
+    memory_config=None,
+    mesh_mapper=None,
+):
+    torch_input_tensor = torch.randn(batch, input_channels * groups, input_height, input_width)
+
+    # We almost always (unless running full model) want to ensure we have least 16 because conv2d requires it
+    ttnn_input_tensor = pad_channels_up_to_target(torch_input_tensor, 16) if pad else torch_input_tensor
+
+    ttnn_input_tensor = ttnn_input_tensor if channel_order == "first" else ttnn_input_tensor.permute(0, 2, 3, 1)
+
+    if fold:
+        if channel_order == "first":
+            ttnn_input_tensor = ttnn_input_tensor.reshape(batch, 1, input_channels * groups, input_height * input_width)
+        else:
+            ttnn_input_tensor = ttnn_input_tensor.reshape(batch, 1, input_height * input_width, -1)
+
+    ttnn_input_tensor = ttnn.from_torch(
+        ttnn_input_tensor, dtype=ttnn.bfloat16, device=device, memory_config=memory_config, mesh_mapper=mesh_mapper
+    )
+
+    return torch_input_tensor, ttnn_input_tensor


### PR DESCRIPTION
## Summary

This PR introduces a testing utility module for TT-CNN that will reduce boilerplate and code duplication in model tests.

## What's Changed

####  Input Tensor Creation
Centralize input tensor creation:

- Added `create_random_input_tensor()` function (moved from `functional_unet`)
- Supports various tensor formats: NCHW/NHWC, folded/unfolded, padded/unpadded
- Migrated all references from `create_unet_input_tensors` to `create_random_input_tensor`

#### Layer Testing
Allows model writers to declare layer configs in one place and use them in unit tests and model implementation:

- `verify_conv2d_from_config(configuration, device, pcc_threshold)` - Automatically run correctness checks for Conv2d layers
- `verify_maxpool2d_from_config(configuration, device, pcc_threshold)` - Automatically run correctness checks for  MaxPool2d layers

#### Device Performance Testing
Create device performance test declaratively:
- `run_device_perf_test(config)` - Run device performance tests using provided `DevicePerformanceTestConfiguration`.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/19169297314
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable): https://github.com/tenstorrent/tt-metal/actions/runs/18949873308
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable): https://github.com/tenstorrent/tt-metal/actions/runs/18949878027
- [x] Frequent models: https://github.com/tenstorrent/tt-metal/actions/runs/18949891595