### PR TITLE
Generic Reduce - Update Validation and Docs for Integer Types

### DIFF
--- a/tests/ttnn/unit_tests/operations/reduce/test_max.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_max.py
@@ -15,13 +15,14 @@ from models.common.utility_functions import torch_random, is_grayskull
 @pytest.mark.parametrize("h", [32, 64, 41, 37])
 @pytest.mark.parametrize("w", [32, 64, 31, 63])
 @pytest.mark.parametrize("dim", [-1, -2])
-def test_max(device, batch_size, h, w, dim):
+@pytest.mark.parametrize("dtype", [ttnn.float32, ttnn.bfloat16])
+def test_max(device, batch_size, h, w, dim, dtype):
     torch.manual_seed(0)
 
     torch_input_tensor = torch_random((batch_size, h, w), -100, 100, dtype=torch.bfloat16)
     torch_output_tensor, _ = torch.max(torch_input_tensor, dim=dim)
 
-    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
+    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device, dtype=dtype)
 
     output_tensor = ttnn.max(input_tensor, dim=dim)
     output_tensor = ttnn.to_layout(output_tensor, ttnn.TILE_LAYOUT)

--- a/tests/ttnn/unit_tests/operations/reduce/test_reduction_min.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_reduction_min.py
@@ -16,13 +16,14 @@ from models.common.utility_functions import torch_random
 @pytest.mark.parametrize("w", [32, 64, 31, 63])
 @pytest.mark.parametrize("dim", [-1, -2])
 @pytest.mark.parametrize("keepdim", [True, False])
-def test_min(device, batch_size, h, w, dim, keepdim):
+@pytest.mark.parametrize("dtype", [ttnn.float32, ttnn.bfloat16])
+def test_min(device, batch_size, h, w, dim, keepdim, dtype):
     torch.manual_seed(0)
 
     torch_input_tensor = torch_random((batch_size, h, w), -100, 100, dtype=torch.bfloat16)
     torch_output_tensor, _ = torch.min(torch_input_tensor, dim=dim, keepdim=keepdim)
 
-    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
+    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device, dtype=dtype)
 
     output_tensor = ttnn.min(input_tensor, dim=dim, keepdim=keepdim)
     output_tensor = ttnn.to_layout(output_tensor, ttnn.TILE_LAYOUT)

--- a/tests/ttnn/unit_tests/operations/reduce/test_sum.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_sum.py
@@ -16,7 +16,7 @@ from models.common.utility_functions import torch_random
 @pytest.mark.parametrize("w", [32, 64, 31, 63])
 @pytest.mark.parametrize("dim", [-1, -2, (2, 1)])
 @pytest.mark.parametrize("keepdim", [True, False])
-@pytest.mark.parametrize("dtype", [ttnn.float32, ttnn.bfloat16, ttnn.bfloat8_b])
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16])
 def test_sum(device, batch_size, h, w, dim, keepdim, dtype):
     torch.manual_seed(0)
 
@@ -36,13 +36,14 @@ def test_sum(device, batch_size, h, w, dim, keepdim, dtype):
 @pytest.mark.parametrize("batch_size", [1, 16])
 @pytest.mark.parametrize("h", [32, 64, 41, 37])
 @pytest.mark.parametrize("w", [32, 64, 31, 63])
-def test_sum_global(device, batch_size, h, w):
+@pytest.mark.parametrize("dtype", [ttnn.float32, ttnn.bfloat16, ttnn.bfloat8_b])
+def test_sum_global(device, batch_size, h, w, dtype):
     torch.manual_seed(0)
 
     torch_input_tensor = torch_random((batch_size, h, w), -100, 100, dtype=torch.bfloat16)
     torch_output_tensor = torch.sum(torch_input_tensor)
 
-    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
+    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device, dtype=dtype)
 
     output_tensor = ttnn.sum(input_tensor)
     output_tensor = ttnn.to_layout(output_tensor, ttnn.TILE_LAYOUT)

--- a/tests/ttnn/unit_tests/operations/reduce/test_sum.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_sum.py
@@ -16,13 +16,14 @@ from models.common.utility_functions import torch_random
 @pytest.mark.parametrize("w", [32, 64, 31, 63])
 @pytest.mark.parametrize("dim", [-1, -2, (2, 1)])
 @pytest.mark.parametrize("keepdim", [True, False])
-def test_sum(device, batch_size, h, w, dim, keepdim):
+@pytest.mark.parametrize("dtype", [ttnn.float32, ttnn.bfloat16, ttnn.bfloat8_b])
+def test_sum(device, batch_size, h, w, dim, keepdim, dtype):
     torch.manual_seed(0)
 
     torch_input_tensor = torch_random((batch_size, h, w), -100, 100, dtype=torch.bfloat16)
     torch_output_tensor = torch.sum(torch_input_tensor, dim=dim, keepdim=keepdim)
 
-    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
+    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device, dtype=dtype)
 
     output_tensor = ttnn.sum(input_tensor, dim=dim, keepdim=keepdim)
     output_tensor = ttnn.to_layout(output_tensor, ttnn.TILE_LAYOUT)

--- a/tests/ttnn/unit_tests/operations/reduce/test_sum.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_sum.py
@@ -16,14 +16,13 @@ from models.common.utility_functions import torch_random
 @pytest.mark.parametrize("w", [32, 64, 31, 63])
 @pytest.mark.parametrize("dim", [-1, -2, (2, 1)])
 @pytest.mark.parametrize("keepdim", [True, False])
-@pytest.mark.parametrize("dtype", [ttnn.bfloat16])
-def test_sum(device, batch_size, h, w, dim, keepdim, dtype):
+def test_sum(device, batch_size, h, w, dim, keepdim):
     torch.manual_seed(0)
 
     torch_input_tensor = torch_random((batch_size, h, w), -100, 100, dtype=torch.bfloat16)
     torch_output_tensor = torch.sum(torch_input_tensor, dim=dim, keepdim=keepdim)
 
-    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device, dtype=dtype)
+    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
 
     output_tensor = ttnn.sum(input_tensor, dim=dim, keepdim=keepdim)
     output_tensor = ttnn.to_layout(output_tensor, ttnn.TILE_LAYOUT)

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op.cpp
@@ -49,6 +49,10 @@ void Reduce::validate(const std::vector<Tensor>& input_tensors) const {
         input_tensor.storage_type());
     TT_FATAL(input_tensor.buffer() != nullptr, "Operands to reduce need to be allocated in buffers on device!");
     TT_FATAL((input_tensor.layout() == Layout::TILE), "Inputs to reduce must be tilized");
+    TT_FATAL(
+        input_tensor.dtype() == DataType::BFLOAT16 || input_tensor.dtype() == DataType::FLOAT32,
+        "Only FLOAT32 and BFLOAT16 are supported for generic reduction - got {}",
+        input_tensor.dtype());
 }
 
 std::vector<ttnn::TensorSpec> Reduce::compute_output_specs(const std::vector<Tensor>& input_tensors) const {

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op.cpp
@@ -50,8 +50,9 @@ void Reduce::validate(const std::vector<Tensor>& input_tensors) const {
     TT_FATAL(input_tensor.buffer() != nullptr, "Operands to reduce need to be allocated in buffers on device!");
     TT_FATAL((input_tensor.layout() == Layout::TILE), "Inputs to reduce must be tilized");
     TT_FATAL(
-        input_tensor.dtype() == DataType::BFLOAT16 || input_tensor.dtype() == DataType::FLOAT32,
-        "Only FLOAT32 and BFLOAT16 are supported for generic reduction - got {}",
+        input_tensor.dtype() == DataType::BFLOAT16 || input_tensor.dtype() == DataType::FLOAT32 ||
+            input_tensor.dtype() == DataType::BFLOAT8_B,
+        "Only FLOAT32, BFLOAT16, and BFLOAT8_B are supported for generic reduction - got {}",
         input_tensor.dtype());
 }
 

--- a/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions_pybind.hpp
@@ -47,12 +47,6 @@ void bind_reduction_operation(py::module& module, const reduction_operation_t& o
                   - ROW_MAJOR, TILE
                 * - BFLOAT16
                   - ROW_MAJOR, TILE
-                * - BFLOAT8_B
-                  - ROW_MAJOR, TILE
-                * - INT32
-                  - ROW_MAJOR, TILE
-                * - UINT32
-                  - ROW_MAJOR, TILE
 
             The output tensor will match the data type and layout of the input tensor.
 

--- a/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions_pybind.hpp
@@ -47,6 +47,8 @@ void bind_reduction_operation(py::module& module, const reduction_operation_t& o
                   - ROW_MAJOR, TILE
                 * - BFLOAT16
                   - ROW_MAJOR, TILE
+                * - BFLOAT8_B
+                  - ROW_MAJOR, TILE
 
             The output tensor will match the data type and layout of the input tensor.
 


### PR DESCRIPTION
### Ticket
#31295

### Problem description
Generic reductions currently accept all data types with no validation. The kernels lack integer support and the LLKs required for integer reductions are not ready yet (see [issue](https://github.com/tenstorrent/tt-metal/issues/21071)).

### What's changed
Added validation to prevent integer types and updated documentation to remove their support.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/18941296591)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests [matches main](https://github.com/tenstorrent/tt-metal/actions/runs/18941289288) (Welford Llama issue)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [x] New/Existing tests provide coverage for changes