### PR TITLE
Ayaacob/fix quasar prints

### DIFF
--- a/tt_metal/hw/firmware/src/tt-2xx/dm.cc
+++ b/tt_metal/hw/firmware/src/tt-2xx/dm.cc
@@ -120,11 +120,15 @@ int main() {
                 // While the go signal for kernel execution is not sent, check if the worker was signalled
                 // to reset its launch message read pointer.
                 if ((go_message_signal == RUN_MSG_RESET_READ_PTR) ||
-                    (go_message_signal == RUN_MSG_RESET_READ_PTR_FROM_HOST)) {
+                    (go_message_signal == RUN_MSG_RESET_READ_PTR_FROM_HOST) ||
+                    (go_message_signal == RUN_MSG_REPLAY_TRACE)) {
                     // Set the rd_ptr on workers to specified value
                     mailboxes->launch_msg_rd_ptr = 0;
-                    if (go_message_signal == RUN_MSG_RESET_READ_PTR) {
-                        DeviceTraceProfilerInit();
+                    if (go_message_signal == RUN_MSG_RESET_READ_PTR || go_message_signal == RUN_MSG_REPLAY_TRACE) {
+                        if (go_message_signal == RUN_MSG_REPLAY_TRACE) {
+                            DeviceIncrementTraceCount();
+                            DeviceTraceOnlyProfilerInit();
+                        }
                         uint32_t go_message_index = mailboxes->go_message_index;
                         // Querying the noc_index is safe here, since the RUN_MSG_RESET_READ_PTR go signal is currently
                         // guaranteed to only be seen after a RUN_MSG_GO signal, which will set the noc_index to a valid

--- a/tt_metal/impl/debug/dprint_server.cpp
+++ b/tt_metal/impl/debug/dprint_server.cpp
@@ -71,18 +71,9 @@ inline float bfloat16_to_float(uint16_t bfloat_val) {
 }
 
 string GetRiscName(CoreType core_type, int risc_id, bool abbreviated = false) {
-    if (core_type == CoreType::ETH) {
-        switch (risc_id) {
-            case 0: return abbreviated ? "ER" : "ERISC";
-            case 1:
-                return abbreviated ? "ER1" : "ERISC1";
-            default: return fmt::format("ERROR: UNSUPPORTED RISC_ID({}) for ETH", risc_id);
-        }
-    } else {
-        const auto& hal = tt::tt_metal::MetalContext::instance().hal();
-        return hal.get_processor_classes_names(tt::tt_metal::HalProgrammableCoreType::TENSIX, risc_id, abbreviated);
-    }
-    return fmt::format("UNKNOWN_RISC_ID({})", risc_id);
+    const auto& hal = tt::tt_metal::MetalContext::instance().hal();
+    return hal.get_processor_classes_names(
+        ::tt::tt_metal::hal_programmable_core_type_from_core_type(core_type), risc_id, abbreviated);
 }
 
 void AssertSize(uint8_t sz, uint8_t expected_sz) {

--- a/tt_metal/impl/debug/dprint_server.cpp
+++ b/tt_metal/impl/debug/dprint_server.cpp
@@ -72,7 +72,7 @@ inline float bfloat16_to_float(uint16_t bfloat_val) {
 
 string GetRiscName(CoreType core_type, int risc_id, bool abbreviated = false) {
     const auto& hal = tt::tt_metal::MetalContext::instance().hal();
-    return hal.get_processor_classes_names(
+    return hal.get_processor_class_name(
         ::tt::tt_metal::hal_programmable_core_type_from_core_type(core_type), risc_id, abbreviated);
 }
 

--- a/tt_metal/impl/debug/dprint_server.cpp
+++ b/tt_metal/impl/debug/dprint_server.cpp
@@ -80,28 +80,7 @@ string GetRiscName(CoreType core_type, int risc_id, bool abbreviated = false) {
         }
     } else {
         const auto& hal = tt::tt_metal::MetalContext::instance().hal();
-        auto [processor_class, processor_type] =
-            hal.get_processor_class_and_type_from_index(tt::tt_metal::HalProgrammableCoreType::TENSIX, risc_id);
-        switch (processor_class) {
-            case tt::tt_metal::HalProcessorClassType::DM:
-                switch (processor_type) {
-                    case 0: return abbreviated ? "BR" : "BRISC";
-                    case 1:
-                        return abbreviated ? "NC" : "NCRISC";
-                    default: return fmt::format("ERROR: UNSUPPORTED PROCESSOR_TYPE({}) for DM", processor_type);
-                }
-                break;
-            case tt::tt_metal::HalProcessorClassType::COMPUTE:
-                switch (processor_type) {
-                    case 0: return abbreviated ? "TR0" : "TRISC0";
-                    case 1: return abbreviated ? "TR1" : "TRISC1";
-                    case 2:
-                        return abbreviated ? "TR2" : "TRISC2";
-                    default: return fmt::format("ERROR: UNSUPPORTED PROCESSOR_TYPE({}) for COMPUTE", processor_type);
-                }
-                break;
-            default: return fmt::format("ERROR: UNSUPPORTED PROCESSOR_CLASS({})", processor_class);
-        }
+        return hal.get_processor_classes_names(tt::tt_metal::HalProgrammableCoreType::TENSIX, risc_id, abbreviated);
     }
     return fmt::format("UNKNOWN_RISC_ID({})", risc_id);
 }

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -162,7 +162,7 @@ void JitBuildEnv::init(
     }
 
     // Flags
-    string common_flags = "-std=c++17 -flto=auto -ffast-math -fno-exceptions ";
+    string common_flags = "-std=c++17 -flto=auto -ffast-math -fno-exceptions -v ";
 
     if (rtoptions.get_riscv_debug_info_enabled()) {
         common_flags += "-g ";

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -162,7 +162,7 @@ void JitBuildEnv::init(
     }
 
     // Flags
-    string common_flags = "-std=c++17 -flto=auto -ffast-math -fno-exceptions -v ";
+    string common_flags = "-std=c++17 -flto=auto -ffast-math -fno-exceptions ";
 
     if (rtoptions.get_riscv_debug_info_enabled()) {
         common_flags += "-g ";

--- a/tt_metal/llrt/hal.cpp
+++ b/tt_metal/llrt/hal.cpp
@@ -103,7 +103,7 @@ const std::string HalCoreInfoType::get_processor_classes_names(uint32_t processo
         }
         processor_index -= processor_count;
     }
-    TT_ASSERT(processor_class_idx < this->processor_classes_.size());
+    TT_ASSERT(processor_class_idx < this->processor_classes_names_.size());
     if (is_abbreviated) {
         return this->processor_classes_names_[processor_class_idx][processor_index].first;
     } else {

--- a/tt_metal/llrt/hal.cpp
+++ b/tt_metal/llrt/hal.cpp
@@ -94,7 +94,7 @@ std::pair<HalProcessorClassType, uint32_t> HalCoreInfoType::get_processor_class_
     return {static_cast<HalProcessorClassType>(processor_class_idx), processor_index};
 }
 
-const std::string HalCoreInfoType::get_processor_classes_names(uint32_t processor_index, bool is_abbreviated) const {
+std::string HalCoreInfoType::get_processor_classes_names(uint32_t processor_index, bool is_abbreviated) const {
     uint32_t processor_class_idx = 0;
     for (; processor_class_idx < this->processor_classes_.size(); processor_class_idx++) {
         auto processor_count = get_processor_types_count(processor_class_idx);

--- a/tt_metal/llrt/hal.cpp
+++ b/tt_metal/llrt/hal.cpp
@@ -94,16 +94,10 @@ std::pair<HalProcessorClassType, uint32_t> HalCoreInfoType::get_processor_class_
     return {static_cast<HalProcessorClassType>(processor_class_idx), processor_index};
 }
 
-std::string HalCoreInfoType::get_processor_classes_names(uint32_t processor_index, bool is_abbreviated) const {
-    uint32_t processor_class_idx = 0;
-    for (; processor_class_idx < this->processor_classes_.size(); processor_class_idx++) {
-        auto processor_count = get_processor_types_count(processor_class_idx);
-        if (processor_index < processor_count) {
-            break;
-        }
-        processor_index -= processor_count;
-    }
-    TT_ASSERT(processor_class_idx < this->processor_classes_names_.size());
+const std::string& HalCoreInfoType::get_processor_class_name(uint32_t processor_index, bool is_abbreviated) const {
+    auto [processor_class, processor_type_idx] = get_processor_class_and_type_from_index(processor_index);
+    uint32_t processor_class_idx = ttsl::as_underlying_type<HalProcessorClassType>(processor_class);
+    TT_ASSERT(ttsl::as_underlying_type<HalProcessorClassType>(processor_class) < this->processor_classes_names_.size());
     if (is_abbreviated) {
         return this->processor_classes_names_[processor_class_idx][processor_index].first;
     } else {

--- a/tt_metal/llrt/hal.cpp
+++ b/tt_metal/llrt/hal.cpp
@@ -94,6 +94,23 @@ std::pair<HalProcessorClassType, uint32_t> HalCoreInfoType::get_processor_class_
     return {static_cast<HalProcessorClassType>(processor_class_idx), processor_index};
 }
 
+const std::string HalCoreInfoType::get_processor_classes_names(uint32_t processor_index, bool is_abbreviated) const {
+    uint32_t processor_class_idx = 0;
+    for (; processor_class_idx < this->processor_classes_.size(); processor_class_idx++) {
+        auto processor_count = get_processor_types_count(processor_class_idx);
+        if (processor_index < processor_count) {
+            break;
+        }
+        processor_index -= processor_count;
+    }
+    TT_ASSERT(processor_class_idx < this->processor_classes_.size());
+    if (is_abbreviated) {
+        return this->processor_classes_names_[processor_class_idx][processor_index].first;
+    } else {
+        return this->processor_classes_names_[processor_class_idx][processor_index].second;
+    }
+}
+
 uint32_t generate_risc_startup_addr(uint32_t firmware_base) {
     // Options for handling brisc fw not starting at mem[0]:
     // 1) Program the register for the start address out of reset - no reset PC register on GS/WH/BH

--- a/tt_metal/llrt/hal.cpp
+++ b/tt_metal/llrt/hal.cpp
@@ -99,9 +99,9 @@ const std::string& HalCoreInfoType::get_processor_class_name(uint32_t processor_
     uint32_t processor_class_idx = ttsl::as_underlying_type<HalProcessorClassType>(processor_class);
     TT_ASSERT(ttsl::as_underlying_type<HalProcessorClassType>(processor_class) < this->processor_classes_names_.size());
     if (is_abbreviated) {
-        return this->processor_classes_names_[processor_class_idx][processor_index].first;
+        return this->processor_classes_names_[processor_class_idx][processor_type_idx].first;
     } else {
-        return this->processor_classes_names_[processor_class_idx][processor_index].second;
+        return this->processor_classes_names_[processor_class_idx][processor_type_idx].second;
     }
 }
 

--- a/tt_metal/llrt/hal.hpp
+++ b/tt_metal/llrt/hal.hpp
@@ -141,6 +141,7 @@ private:
     CoreType core_type_;
     // indices represents processor class and type positions, value is build configuration params
     std::vector<std::vector<HalJitBuildConfig>> processor_classes_;
+    std::vector<std::vector<std::pair<std::string, std::string>>> processor_classes_names_;
     std::vector<DeviceAddr> mem_map_bases_;
     std::vector<uint32_t> mem_map_sizes_;
     std::vector<uint32_t> eth_fw_mailbox_msgs_;
@@ -156,12 +157,14 @@ public:
         std::vector<DeviceAddr> mem_map_bases,
         std::vector<uint32_t> mem_map_sizes,
         std::vector<uint32_t> eth_fw_mailbox_msgs,
+        std::vector<std::vector<std::pair<std::string, std::string>>> processor_classes_names,
         bool supports_cbs,
         bool supports_receiving_multicast_cmds,
         dev_msgs::Factory dev_msgs_factory) :
         programmable_core_type_(programmable_core_type),
         core_type_(core_type),
         processor_classes_(std::move(processor_classes)),
+        processor_classes_names_(std::move(processor_classes_names)),
         mem_map_bases_(std::move(mem_map_bases)),
         mem_map_sizes_(std::move(mem_map_sizes)),
         eth_fw_mailbox_msgs_{std::move(eth_fw_mailbox_msgs)},
@@ -176,6 +179,7 @@ public:
     uint32_t get_processor_index(HalProcessorClassType processor_class, uint32_t processor_type_idx) const;
     std::pair<HalProcessorClassType, uint32_t> get_processor_class_and_type_from_index(uint32_t processor_index) const;
     const HalJitBuildConfig& get_jit_build_config(uint32_t processor_class_idx, uint32_t processor_type_idx) const;
+    const std::string get_processor_classes_names(uint32_t processor_index, bool is_abbreviated) const;
     const dev_msgs::Factory& get_dev_msgs_factory() const;
 };
 
@@ -434,6 +438,9 @@ public:
     const HalJitBuildConfig& get_jit_build_config(
         uint32_t programmable_core_type_index, uint32_t processor_class_idx, uint32_t processor_type_idx) const;
 
+    const std::string get_processor_classes_names(
+        HalProgrammableCoreType programmable_core_type, uint32_t processor_index, bool is_abbreviated) const;
+
     uint64_t relocate_dev_addr(uint64_t addr, uint64_t local_init_addr = 0, bool has_shared_local_mem = false) const {
         return relocate_func_(addr, local_init_addr, has_shared_local_mem);
     }
@@ -608,6 +615,12 @@ inline const HalJitBuildConfig& Hal::get_jit_build_config(
     uint32_t programmable_core_type_index, uint32_t processor_class_idx, uint32_t processor_type_idx) const {
     TT_ASSERT(programmable_core_type_index < this->core_info_.size());
     return this->core_info_[programmable_core_type_index].get_jit_build_config(processor_class_idx, processor_type_idx);
+}
+
+inline const std::string Hal::get_processor_classes_names(
+    HalProgrammableCoreType programmable_core_type, uint32_t processor_index, bool is_abbreviated) const {
+    auto idx = get_programmable_core_type_index(programmable_core_type);
+    return this->core_info_[idx].get_processor_classes_names(processor_index, is_abbreviated);
 }
 
 uint32_t generate_risc_startup_addr(uint32_t firmware_base);  // used by Tensix initializers to build HalJitBuildConfig

--- a/tt_metal/llrt/hal.hpp
+++ b/tt_metal/llrt/hal.hpp
@@ -439,7 +439,7 @@ public:
     const HalJitBuildConfig& get_jit_build_config(
         uint32_t programmable_core_type_index, uint32_t processor_class_idx, uint32_t processor_type_idx) const;
 
-    const std::string get_processor_class_name(
+    const std::string& get_processor_class_name(
         HalProgrammableCoreType programmable_core_type, uint32_t processor_index, bool is_abbreviated) const;
 
     uint64_t relocate_dev_addr(uint64_t addr, uint64_t local_init_addr = 0, bool has_shared_local_mem = false) const {
@@ -618,7 +618,7 @@ inline const HalJitBuildConfig& Hal::get_jit_build_config(
     return this->core_info_[programmable_core_type_index].get_jit_build_config(processor_class_idx, processor_type_idx);
 }
 
-inline const std::string Hal::get_processor_class_name(
+inline const std::string& Hal::get_processor_class_name(
     HalProgrammableCoreType programmable_core_type, uint32_t processor_index, bool is_abbreviated) const {
     auto idx = get_programmable_core_type_index(programmable_core_type);
     return this->core_info_[idx].get_processor_class_name(processor_index, is_abbreviated);

--- a/tt_metal/llrt/hal.hpp
+++ b/tt_metal/llrt/hal.hpp
@@ -141,6 +141,7 @@ private:
     CoreType core_type_;
     // indices represents processor class and type positions, value is build configuration params
     std::vector<std::vector<HalJitBuildConfig>> processor_classes_;
+    // indices represents processor class and type positions, values are abbreviated name and full name pairs
     std::vector<std::vector<std::pair<std::string, std::string>>> processor_classes_names_;
     std::vector<DeviceAddr> mem_map_bases_;
     std::vector<uint32_t> mem_map_sizes_;
@@ -179,7 +180,7 @@ public:
     uint32_t get_processor_index(HalProcessorClassType processor_class, uint32_t processor_type_idx) const;
     std::pair<HalProcessorClassType, uint32_t> get_processor_class_and_type_from_index(uint32_t processor_index) const;
     const HalJitBuildConfig& get_jit_build_config(uint32_t processor_class_idx, uint32_t processor_type_idx) const;
-    const std::string get_processor_classes_names(uint32_t processor_index, bool is_abbreviated) const;
+    const std::string& get_processor_class_name(uint32_t processor_index, bool is_abbreviated) const;
     const dev_msgs::Factory& get_dev_msgs_factory() const;
 };
 
@@ -438,7 +439,7 @@ public:
     const HalJitBuildConfig& get_jit_build_config(
         uint32_t programmable_core_type_index, uint32_t processor_class_idx, uint32_t processor_type_idx) const;
 
-    const std::string get_processor_classes_names(
+    const std::string get_processor_class_name(
         HalProgrammableCoreType programmable_core_type, uint32_t processor_index, bool is_abbreviated) const;
 
     uint64_t relocate_dev_addr(uint64_t addr, uint64_t local_init_addr = 0, bool has_shared_local_mem = false) const {
@@ -617,10 +618,10 @@ inline const HalJitBuildConfig& Hal::get_jit_build_config(
     return this->core_info_[programmable_core_type_index].get_jit_build_config(processor_class_idx, processor_type_idx);
 }
 
-inline const std::string Hal::get_processor_classes_names(
+inline const std::string Hal::get_processor_class_name(
     HalProgrammableCoreType programmable_core_type, uint32_t processor_index, bool is_abbreviated) const {
     auto idx = get_programmable_core_type_index(programmable_core_type);
-    return this->core_info_[idx].get_processor_classes_names(processor_index, is_abbreviated);
+    return this->core_info_[idx].get_processor_class_name(processor_index, is_abbreviated);
 }
 
 uint32_t generate_risc_startup_addr(uint32_t firmware_base);  // used by Tensix initializers to build HalJitBuildConfig

--- a/tt_metal/llrt/hal.hpp
+++ b/tt_metal/llrt/hal.hpp
@@ -673,7 +673,7 @@ constexpr HalProgrammableCoreType hal_programmable_core_type_from_core_type(Core
         case CoreType::ACTIVE_ETH: return HalProgrammableCoreType::ACTIVE_ETH;
         case CoreType::IDLE_ETH: return HalProgrammableCoreType::IDLE_ETH;
         case CoreType::ETH:
-            return HalProgrammableCoreType::ACTIVE_ETH;  // We neeed this becasue translations only support ETH
+            return HalProgrammableCoreType::ACTIVE_ETH;  // We need this because translations only support ETH
         default: TT_FATAL(false, "CoreType is not recognized by the HAL in {}", __FUNCTION__);
     }
 }

--- a/tt_metal/llrt/hal.hpp
+++ b/tt_metal/llrt/hal.hpp
@@ -672,6 +672,8 @@ constexpr HalProgrammableCoreType hal_programmable_core_type_from_core_type(Core
         case CoreType::TENSIX: return HalProgrammableCoreType::TENSIX;
         case CoreType::ACTIVE_ETH: return HalProgrammableCoreType::ACTIVE_ETH;
         case CoreType::IDLE_ETH: return HalProgrammableCoreType::IDLE_ETH;
+        case CoreType::ETH:
+            return HalProgrammableCoreType::ACTIVE_ETH;  // We neeed this becasue translations only support ETH
         default: TT_FATAL(false, "CoreType is not recognized by the HAL in {}", __FUNCTION__);
     }
 }

--- a/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal_active_eth.cpp
+++ b/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal_active_eth.cpp
@@ -153,11 +153,14 @@ HalCoreInfoType create_active_eth_mem_map() {
         (uint64_t)&((eth_status_t*)MEM_SYSENG_ETH_STATUS)->port_status;
 
     std::vector<std::vector<HalJitBuildConfig>> processor_classes;
+    std::vector<std::vector<std::pair<std::string, std::string>>> processor_classes_names;
     // rtoptions not included in here due to circular dependency
     if (is_2_erisc_mode()) {
         processor_classes = configure_for_2erisc();
+        processor_classes_names = {{{"DM", "DM"}, {"COMPUTE", "COMPUTE"}}};
     } else {
         processor_classes = configure_for_1erisc();
+        processor_classes_names = {{{"DM", "DM"}, {"COMPUTE", "COMPUTE"}}};
     }
 
     static_assert(sizeof(mailboxes_t) <= MEM_AERISC_MAILBOX_SIZE);
@@ -168,6 +171,7 @@ HalCoreInfoType create_active_eth_mem_map() {
         std::move(mem_map_bases),
         std::move(mem_map_sizes),
         std::move(fw_mailbox_addr),
+        std::move(processor_classes_names),
         false /*supports_cbs*/,
         false /*supports_receiving_multicast_cmds*/,
         active_eth_dev_msgs::create_factory()};

--- a/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal_active_eth.cpp
+++ b/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal_active_eth.cpp
@@ -157,10 +157,10 @@ HalCoreInfoType create_active_eth_mem_map() {
     // rtoptions not included in here due to circular dependency
     if (is_2_erisc_mode()) {
         processor_classes = configure_for_2erisc();
-        processor_classes_names = {{{"DM", "DM"}, {"COMPUTE", "COMPUTE"}}};
+        processor_classes_names = {{{"ER0", "ERISC0"}, {"ER1", "ERISC1"}}};
     } else {
         processor_classes = configure_for_1erisc();
-        processor_classes_names = {{{"DM", "DM"}, {"COMPUTE", "COMPUTE"}}};
+        processor_classes_names = {{{"ER", "ERISC"}}};
     }
 
     static_assert(sizeof(mailboxes_t) <= MEM_AERISC_MAILBOX_SIZE);

--- a/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal_idle_eth.cpp
+++ b/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal_idle_eth.cpp
@@ -104,6 +104,13 @@ HalCoreInfoType create_idle_eth_mem_map() {
              .memory_load = ll_api::memory::Loading::CONTIGUOUS_XIP},
         },
     };
+    std::vector<std::vector<std::pair<std::string, std::string>>> processor_classes_names = {
+        // DM
+        {
+            {"ER0", "ERISC0"},
+            {"ER1", "ERISC1"},
+        },
+    };
     static_assert(sizeof(mailboxes_t) <= MEM_IERISC_MAILBOX_SIZE);
     return {
         HalProgrammableCoreType::IDLE_ETH,
@@ -112,6 +119,7 @@ HalCoreInfoType create_idle_eth_mem_map() {
         std::move(mem_map_bases),
         std::move(mem_map_sizes),
         std::move(fw_mailbox_addr),
+        std::move(processor_classes_names),
         false /*supports_cbs*/,
         false /*supports_receiving_multicast_cmds*/,
         idle_eth_dev_msgs::create_factory()};

--- a/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal_tensix.cpp
+++ b/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal_tensix.cpp
@@ -123,6 +123,19 @@ HalCoreInfoType create_tensix_mem_map() {
              .memory_load = ll_api::memory::Loading::CONTIGUOUS_XIP},
         },
     };
+    std::vector<std::vector<std::pair<std::string, std::string>>> processor_classes_names = {
+        // DM
+        {
+            {"BR", "BRISC"},
+            {"NC", "NCRISC"},
+        },
+        // COMPUTE
+        {
+            {"TR0", "TRISC0"},
+            {"TR1", "TRISC1"},
+            {"TR2", "TRISC2"},
+        },
+    };
     static_assert(sizeof(mailboxes_t) <= MEM_MAILBOX_SIZE);
     return {
         HalProgrammableCoreType::TENSIX,
@@ -131,6 +144,7 @@ HalCoreInfoType create_tensix_mem_map() {
         std::move(mem_map_bases),
         std::move(mem_map_sizes),
         std::move(fw_mailbox_addr),
+        std::move(processor_classes_names),
         true /*supports_cbs*/,
         true /*supports_receiving_multicast_cmds*/,
         tensix_dev_msgs::create_factory()};

--- a/tt_metal/llrt/hal/tt-1xx/wormhole/wh_hal_active_eth.cpp
+++ b/tt_metal/llrt/hal/tt-1xx/wormhole/wh_hal_active_eth.cpp
@@ -120,6 +120,13 @@ HalCoreInfoType create_active_eth_mem_map(bool is_base_routing_fw_enabled) {
              .memory_load = ll_api::memory::Loading::DISCRETE},
         },
     };
+    std::vector<std::vector<std::pair<std::string, std::string>>> processor_classes_names = {
+        // DM
+        {
+            {"ER", "ERISC"},
+        },
+    };
+
     static_assert(sizeof(mailboxes_t) <= eth_l1_mem::address_map::ERISC_MEM_MAILBOX_SIZE);
     return {
         HalProgrammableCoreType::ACTIVE_ETH,
@@ -128,6 +135,7 @@ HalCoreInfoType create_active_eth_mem_map(bool is_base_routing_fw_enabled) {
         std::move(mem_map_bases),
         std::move(mem_map_sizes),
         std::move(fw_mailbox_addr),
+        std::move(processor_classes_names),
         false /*supports_cbs*/,
         false /*supports_receiving_multicast_cmds*/,
         active_eth_dev_msgs::create_factory()};

--- a/tt_metal/llrt/hal/tt-1xx/wormhole/wh_hal_idle_eth.cpp
+++ b/tt_metal/llrt/hal/tt-1xx/wormhole/wh_hal_idle_eth.cpp
@@ -100,6 +100,13 @@ HalCoreInfoType create_idle_eth_mem_map() {
              .memory_load = ll_api::memory::Loading::CONTIGUOUS_XIP},
         },
     };
+    std::vector<std::vector<std::pair<std::string, std::string>>> processor_classes_names = {
+        // DM
+        {
+            {"ER", "ERISC"},
+        },
+    };
+
     static_assert(sizeof(mailboxes_t) <= MEM_IERISC_MAILBOX_SIZE);
     return {
         HalProgrammableCoreType::IDLE_ETH,
@@ -108,6 +115,7 @@ HalCoreInfoType create_idle_eth_mem_map() {
         std::move(mem_map_bases),
         std::move(mem_map_sizes),
         std::move(fw_mailbox_addr),
+        std::move(processor_classes_names),
         false /*supports_cbs*/,
         false /*supports_receiving_multicast_cmds*/,
         idle_eth_dev_msgs::create_factory()};

--- a/tt_metal/llrt/hal/tt-1xx/wormhole/wh_hal_tensix.cpp
+++ b/tt_metal/llrt/hal/tt-1xx/wormhole/wh_hal_tensix.cpp
@@ -122,6 +122,20 @@ HalCoreInfoType create_tensix_mem_map() {
              .memory_load = ll_api::memory::Loading::CONTIGUOUS_XIP},
         },
     };
+    std::vector<std::vector<std::pair<std::string, std::string>>> processor_classes_names = {
+        // DM
+        {
+            {"BR", "BRISC"},
+            {"NC", "NCRISC"},
+        },
+        // COMPUTE
+        {
+            {"TR0", "TRISC0"},
+            {"TR1", "TRISC1"},
+            {"TR2", "TRISC2"},
+        },
+    };
+
     static_assert(sizeof(mailboxes_t) <= MEM_MAILBOX_SIZE);
     return {
         HalProgrammableCoreType::TENSIX,
@@ -130,6 +144,7 @@ HalCoreInfoType create_tensix_mem_map() {
         std::move(mem_map_bases),
         std::move(mem_map_sizes),
         std::move(fw_mailbox_addr),
+        std::move(processor_classes_names),
         true /*supports_cbs*/,
         true /*supports_receiving_multicast_cmds*/,
         tensix_dev_msgs::create_factory()};

--- a/tt_metal/llrt/hal/tt-2xx/quasar/qa_hal_active_eth.cpp
+++ b/tt_metal/llrt/hal/tt-2xx/quasar/qa_hal_active_eth.cpp
@@ -126,6 +126,7 @@ HalCoreInfoType create_active_eth_mem_map() {
     //     };
     //     processor_classes[processor_class_idx] = processor_types;
     // }
+    std::vector<std::vector<std::pair<std::string, std::string>>> processor_classes_names(0);
 
     static_assert(sizeof(mailboxes_t) <= MEM_AERISC_MAILBOX_SIZE);
     return {
@@ -135,6 +136,7 @@ HalCoreInfoType create_active_eth_mem_map() {
         std::move(mem_map_bases),
         std::move(mem_map_sizes),
         std::move(fw_mailbox_addr),
+        std::move(processor_classes_names),
         false /*supports_cbs*/,
         false /*supports_receiving_multicast_cmds*/,
         active_eth_dev_msgs::create_factory()};

--- a/tt_metal/llrt/hal/tt-2xx/quasar/qa_hal_idle_eth.cpp
+++ b/tt_metal/llrt/hal/tt-2xx/quasar/qa_hal_idle_eth.cpp
@@ -119,6 +119,7 @@ HalCoreInfoType create_idle_eth_mem_map() {
     //     };
     //     processor_classes[processor_class_idx] = processor_types;
     // }
+    std::vector<std::vector<std::pair<std::string, std::string>>> processor_classes_names(0);
 
     static_assert(sizeof(mailboxes_t) <= MEM_IERISC_MAILBOX_SIZE);
     return {
@@ -128,6 +129,7 @@ HalCoreInfoType create_idle_eth_mem_map() {
         std::move(mem_map_bases),
         std::move(mem_map_sizes),
         std::move(fw_mailbox_addr),
+        std::move(processor_classes_names),
         false /*supports_cbs*/,
         false /*supports_receiving_multicast_cmds*/,
         idle_eth_dev_msgs::create_factory()};

--- a/tt_metal/llrt/hal/tt-2xx/quasar/qa_hal_tensix.cpp
+++ b/tt_metal/llrt/hal/tt-2xx/quasar/qa_hal_tensix.cpp
@@ -121,6 +121,25 @@ HalCoreInfoType create_tensix_mem_map() {
         //      .memory_load = ll_api::memory::Loading::CONTIGUOUS_XIP},
         // },
     };
+    std::vector<std::vector<std::pair<std::string, std::string>>> processor_classes_names = {
+        // DM
+        {
+            {"DM0", "DM0"},
+            {"DM1", "DM1"},
+            {"DM2", "DM2"},
+            {"DM3", "DM3"},
+            {"DM4", "DM4"},
+            {"DM5", "DM5"},
+            {"DM6", "DM6"},
+            {"DM7", "DM7"},
+        },
+        // COMPUTE
+        {
+            {"TR0", "TRISC0"},
+            {"TR1", "TRISC1"},
+            {"TR2", "TRISC2"},
+        },
+    };
     static_assert(sizeof(mailboxes_t) <= MEM_MAILBOX_SIZE);
     return {
         HalProgrammableCoreType::TENSIX,
@@ -129,6 +148,7 @@ HalCoreInfoType create_tensix_mem_map() {
         std::move(mem_map_bases),
         std::move(mem_map_sizes),
         std::move(fw_mailbox_addr),
+        std::move(processor_classes_names),
         true /*supports_cbs*/,
         true /*supports_receiving_multicast_cmds*/,
         tensix_dev_msgs::create_factory()};


### PR DESCRIPTION
### Ticket
None

### Problem description
Currently when using DPRINT and WATCHER, the RISC name used is pre-configured for 1.x.x HW.

### What's changed
I used HAL to get the correct RISC name, using same approach as for the JIT build setup.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/18944060134) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/18944830442) CI with demo tests passes