### PR TITLE
Adding wrapper for directly supplying addresses to 2.0 apis

### DIFF
--- a/docs/source/tt-metalium/tt_metal/apis/kernel_apis/data_movement/get_noc_addr_from_bank_id.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/kernel_apis/data_movement/get_noc_addr_from_bank_id.rst
@@ -1,4 +1,4 @@
 get_noc_addr_from_bank_id
 =========================
 
-.. doxygenfunction:: get_noc_addr_from_bank_id
+.. doxygenfunction:: get_noc_addr_from_bank_id(uint32_t bank_id, uint32_t bank_address_offset, uint8_t noc)

--- a/docs/source/tt-metalium/tt_metal/apis/kernel_apis/data_movement/get_noc_multicast_addr.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/kernel_apis/data_movement/get_noc_multicast_addr.rst
@@ -1,4 +1,4 @@
 get_noc_multicast_addr
 ======================
 
-.. doxygenfunction:: get_noc_multicast_addr
+.. doxygenfunction:: get_noc_multicast_addr(uint32_t noc_x_start, uint32_t noc_y_start, uint32_t noc_x_end, uint32_t noc_y_end, uint32_t addr, uint8_t noc)

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -15,6 +15,7 @@
 #include <stdint.h>
 #include <tuple>
 #include <utility>
+#include <type_traits>
 
 #include "dataflow_api_addrgen.h"
 #include "core_config.h"
@@ -2344,6 +2345,8 @@ void reset_noc_trid_barrier_counter(uint32_t id_mask = NOC_CLEAR_OUTSTANDING_REQ
 
 namespace experimental {
 
+struct MulticastEndpoint;  // Forward declaration can be removed when 2.0 objects are split into different headers
+
 template <typename T>
 struct noc_traits_t {
     static_assert(sizeof(T) == 0, "NoC transactions are not supported for this type");
@@ -2435,15 +2438,13 @@ public:
         uint32_t read_req_vc = NOC_UNICAST_WRITE_VC,
         uint32_t trid = INVALID_TXN_ID) const {
         // TODO (#31407): Add support for read with transaction id
-        ASSERT(txn_id_mode == TxnIdMode::DISABLED);
-        if constexpr (txn_id_mode == TxnIdMode::DISABLED) {
-            noc_async_read<max_page_size, enable_noc_tracing>(
-                get_src_ptr<AddressType::NOC>(src, src_args),
-                get_dst_ptr<AddressType::LOCAL_L1>(dst, dst_args),
-                size_bytes,
-                noc_id_,
-                read_req_vc);
-        }
+        static_assert(txn_id_mode == TxnIdMode::DISABLED);
+        noc_async_read<max_page_size, enable_noc_tracing>(
+            get_src_ptr<AddressType::NOC>(src, src_args),
+            get_dst_ptr<AddressType::LOCAL_L1>(dst, dst_args),
+            size_bytes,
+            noc_id_,
+            read_req_vc);
     }
 
     /** @brief Initiates an asynchronous write.
@@ -2510,6 +2511,64 @@ public:
                 noc_id_,
                 vc);
         }
+    }
+
+    /** @brief Initiates an asynchronous write of a 32-bit value to a NOC destination.
+     *
+     * Typically used for writing registers, but can be used for memory locations as well.
+     * The advantage over using noc_async_write is that we don't use a Tensix L1 memory source location; the write value
+     * is written directly into a register. Unlike using noc_async_write, there are also no address alignment concerns.
+     * The destination can be either a Tensix core+L1 memory address or a PCIe controller; This API does not support
+     * DRAM addresses. Note: Due to HW bug on Blackhole, inline writes to L1 will use a scratch location in L1 memory.
+     *
+     * @see async_write_barrier.
+     *
+     * @param dst Destination object (e.g., UnicastEndpoint)
+     * @param val The value to be written
+     * @param dst_args Additional arguments for destination address calculation
+     * @param be Byte-enable mask controls which bytes are written to at an L1 destination
+     * @param vc Virtual channel to use for the transaction
+     * @param trid Transaction ID to use for the transaction (default: INVALID_TXN_ID)
+     * @tparam txn_id_mode Whether transaction id will be used for the noc transaction (default: DISABLED)
+     * @tparam dst_type Whether the write is targeting L1 or a Stream Register
+     * @tparam response_mode Posted noc transactions do not get ack from receiver, non-posted ones do (default:
+     * NON_POSTED)
+     */
+    template <
+        TxnIdMode txn_id_mode = TxnIdMode::DISABLED,
+        InlineWriteDst dst_type = InlineWriteDst::DEFAULT,
+        ResponseMode response_mode = ResponseMode::NON_POSTED,
+        typename Dst>
+    void inline_dw_write(
+        const Dst& dst,
+        uint32_t val,
+        const dst_args_t<Dst>& dst_args,
+        uint8_t be = 0xF,
+        uint32_t vc = NOC_UNICAST_WRITE_VC,
+        uint32_t trid = INVALID_TXN_ID) const {
+        static_assert(txn_id_mode == TxnIdMode::DISABLED);
+        static_assert(!std::is_same_v<Dst, MulticastEndpoint>);  // Can be removed when #30023 is resolved
+        WAYPOINT("NWIW");
+        auto dst_addr = get_dst_ptr<AddressType::NOC>(dst, dst_args);
+        DEBUG_SANITIZE_NOC_ADDR(noc_id_, dst_addr, 4);
+        DEBUG_SANITIZE_NO_DRAM_ADDR(noc_id_, dst_addr, 4);
+#if defined(ARCH_BLACKHOLE) && defined(WATCHER_ENABLED)
+        if constexpr (dst_type == InlineWriteDst::L1) {
+            uint32_t src_addr = noc_get_interim_inline_value_addr(noc_id_, dst_addr);
+            DEBUG_SANITIZE_NOC_WRITE_TRANSACTION(noc_id_, dst_addr, src_addr, 4);
+        }
+#endif
+
+        noc_fast_write_dw_inline<noc_mode, dst_type>(
+            noc_id_,
+            write_at_cmd_buf,
+            val,
+            dst_addr,
+            be,
+            vc,
+            std::is_same_v<Dst, MulticastEndpoint>,
+            response_mode == ResponseMode::POSTED);
+        WAYPOINT("NWID");
     }
 
     /** @brief Initiates a read barrier for synchronization.
@@ -2796,6 +2855,127 @@ public:
 
 private:
     uint32_t local_l1_addr_;
+};
+
+/**
+ * @brief Experimental wrapper around calculating unicast noc address given x, y, and address. This allows direct address to be supplied to NoC apis
+ *
+ * @note This API is experimental and subject to change.
+ */
+struct UnicastEndpoint {
+    uint64_t get_noc_unicast_addr(uint32_t noc_x, uint32_t noc_y, uint32_t addr, uint8_t noc) const {
+        return ::get_noc_addr(noc_x, noc_y, addr, noc);
+    }
+};
+
+/**
+ * @brief Experimental wrapper around calculating multicast noc address given 2D multicast rectangle and address. This allows direct address to be supplied to NoC apis
+ *
+ * @note This API is experimental and subject to change.
+ */
+struct MulticastEndpoint {
+    uint64_t get_noc_multicast_addr(
+        uint32_t noc_x_start, uint32_t noc_y_start, uint32_t noc_x_end, uint32_t noc_y_end, uint32_t addr, uint8_t noc)
+        const {
+        return ::get_noc_multicast_addr(noc_x_start, noc_y_start, noc_x_end, noc_y_end, addr, noc);
+    }
+};
+
+/**
+ * @brief Experimental wrapper around calculating noc address targeting a bank managed by the allocator (either DRAM or
+ * L1) given bank id and address. This allows direct address to be supplied to NoC apis
+ *
+ * @note This API is experimental and subject to change.
+ */
+enum AllocatorBankType { L1, DRAM };
+
+template <AllocatorBankType bank_type>
+struct AllocatorBank {
+    uint64_t get_noc_addr_from_bank_id(uint32_t bank_id, uint32_t addr, uint8_t noc) const {
+        return ::get_noc_addr_from_bank_id<bank_type == AllocatorBankType::DRAM>(bank_id, addr, noc);
+    }
+};
+
+template <>
+struct noc_traits_t<UnicastEndpoint> {
+    struct src_args_type {
+        uint32_t noc_x{};
+        uint32_t noc_y{};
+        uint32_t addr{};
+    };
+    struct dst_args_type {
+        uint32_t noc_x{};
+        uint32_t noc_y{};
+        uint32_t addr{};
+    };
+    template <Noc::AddressType address_type>
+    static auto src_addr(const UnicastEndpoint& src, const Noc& noc, const src_args_type& args) {
+        static_assert(address_type == Noc::AddressType::NOC);
+        uint64_t noc_addr = src.get_noc_unicast_addr(args.noc_x, args.noc_y, args.addr, noc.get_noc_id());
+        return noc_addr;
+    }
+    template <Noc::AddressType address_type>
+    static auto dst_addr(const UnicastEndpoint& dst, const Noc& noc, const dst_args_type& args) {
+        static_assert(address_type == Noc::AddressType::NOC);
+        uint64_t noc_addr = dst.get_noc_unicast_addr(args.noc_x, args.noc_y, args.addr, noc.get_noc_id());
+        return noc_addr;
+    }
+};
+
+template <>
+struct noc_traits_t<MulticastEndpoint> {
+    struct src_args_type {
+        uint32_t noc_x_start{};
+        uint32_t noc_y_start{};
+        uint32_t noc_x_end{};
+        uint32_t noc_y_end{};
+        uint32_t addr{};
+    };
+    struct dst_args_type {
+        uint32_t noc_x_start{};
+        uint32_t noc_y_start{};
+        uint32_t noc_x_end{};
+        uint32_t noc_y_end{};
+        uint32_t addr{};
+    };
+    template <Noc::AddressType address_type>
+    static auto src_addr(const MulticastEndpoint& src, const Noc& noc, const src_args_type& args) {
+        static_assert(address_type == Noc::AddressType::NOC);
+        uint64_t noc_addr = src.get_noc_multicast_addr(
+            args.noc_x_start, args.noc_y_start, args.noc_x_end, args.noc_y_end, args.addr, noc.get_noc_id());
+        return noc_addr;
+    }
+    template <Noc::AddressType address_type>
+    static auto dst_addr(const MulticastEndpoint& dst, const Noc& noc, const dst_args_type& args) {
+        static_assert(address_type == Noc::AddressType::NOC);
+        uint64_t noc_addr = dst.get_noc_multicast_addr(
+            args.noc_x_start, args.noc_y_start, args.noc_x_end, args.noc_y_end, args.addr, noc.get_noc_id());
+        return noc_addr;
+    }
+};
+
+template <AllocatorBankType bank_type>
+struct noc_traits_t<AllocatorBank<bank_type>> {
+    struct src_args_type {
+        uint32_t bank_id{};
+        uint32_t addr{};
+    };
+    struct dst_args_type {
+        uint32_t bank_id{};
+        uint32_t addr{};
+    };
+    template <Noc::AddressType address_type>
+    static auto src_addr(const AllocatorBank<bank_type>& src, const Noc& noc, const src_args_type& args) {
+        static_assert(address_type == Noc::AddressType::NOC);
+        uint64_t noc_addr = src.template get_noc_addr_from_bank_id(args.bank_id, args.addr, noc.get_noc_id());
+        return noc_addr;
+    }
+    template <Noc::AddressType address_type>
+    static auto dst_addr(const AllocatorBank<bank_type>& dst, const Noc& noc, const dst_args_type& args) {
+        static_assert(address_type == Noc::AddressType::NOC);
+        uint64_t noc_addr = dst.template get_noc_addr_from_bank_id(args.bank_id, args.addr, noc.get_noc_id());
+        return noc_addr;
+    }
 };
 
 // TODO(#29597): The traits classes for TensorAccessor and related classes could be moved to tensor_accessor.h


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/29599

### Problem description
Need to track direct address usage in 2.0 apis. Idea here is to introduce a wrapper around different ways of addressing memory

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/19016451010/attempts/1) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/18959829390) 
- [x] New/Existing tests provide coverage for changes (updated one test to use these apis as an example)