### PR TITLE
Fix hang in batchnorm training mode, issue #30279

### DIFF
--- a/tests/ttnn/unit_tests/operations/fused/test_batch_norm.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_batch_norm.py
@@ -19,6 +19,7 @@ from models.common.utility_functions import comp_pcc
         torch.Size([5, 8, 32, 32]),
         torch.Size([7, 3, 23, 23]),
         torch.Size([3, 5, 64, 120]),
+        torch.Size([1, 128, 14, 14]),
     ],
 )
 @pytest.mark.parametrize(
@@ -35,8 +36,9 @@ from models.common.utility_functions import comp_pcc
 @pytest.mark.parametrize("bias", [True, False])
 @pytest.mark.parametrize("eps", [1.0, 1e-05])
 @pytest.mark.parametrize("momentum", [0.0, 0.1])
-def test_batch_norm_tests_fp32(
-    input_shapes, check_mean, check_var, weight, bias, eps, device, momentum, training, testing_dtype="float32"
+@pytest.mark.parametrize("testing_dtype", ["float32", "bfloat16"])
+def test_batch_norm_tests(
+    input_shapes, check_mean, check_var, weight, bias, eps, device, momentum, training, testing_dtype
 ):
     in_data, input_tensor = data_gen_with_range_batch_norm(
         input_shapes, 5, 10, device, is_input=True, testing_dtype=testing_dtype

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/batch_norm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/batch_norm.cpp
@@ -57,7 +57,7 @@ Tensor BatchNorm::invoke(
         batch_mean = mean_NHW(input, memory_config, compute_kernel_config);
         auto mean_sq = mean_NHW(ttnn::square(input, memory_config), memory_config, compute_kernel_config);
         batch_var = ttnn::subtract(mean_sq, ttnn::square(batch_mean, memory_config), std::nullopt, memory_config);
-        Tensor stats = ttnn::prim::running_statistics(
+        ttnn::prim::running_statistics(
             batch_mean, batch_var, momentum, running_mean, running_var, memory_config, compute_kernel_config);
     } else {
         TT_FATAL(


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/30279

### Problem description
Batch norm operation hangs for large input tensors, when ran in training mode.

### What's changed
Handling of several circular buffers was fixed in the running_statistics_sfpu kernel

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [x] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [x] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)