### PR TITLE
Telemetry: Add TT_METAL_RUNTIME_ROOT to Docker

### DIFF
--- a/tt_telemetry/docker/Dockerfile
+++ b/tt_telemetry/docker/Dockerfile
@@ -14,6 +14,9 @@ FROM base AS release
 # (PYTHON_ENV_DIR is already set in the base image)
 ENV TT_METAL_HOME=/tt-metal
 
+# Set TT_METAL_RUNTIME_ROOT
+ENV TT_METAL_RUNTIME_ROOT=/tt-metal
+
 # Clone tt-metal
 RUN /bin/bash -c "git clone --filter=blob:none --recurse-submodules --tags \
     https://github.com/tenstorrent/tt-metal.git ${TT_METAL_HOME} \
@@ -40,6 +43,9 @@ FROM base AS dev
 
 # Set up TT_METAL_HOME environment
 ENV TT_METAL_HOME=/tt-metal
+
+# TT_METAL_RUNTIME_ROOT
+ENV TT_METAL_RUNTIME_ROOT=/tt-metal
 
 # Set working directory to TT_METAL_HOME
 WORKDIR ${TT_METAL_HOME}

--- a/tt_telemetry/docker/Dockerfile
+++ b/tt_telemetry/docker/Dockerfile
@@ -14,7 +14,7 @@ FROM base AS release
 # (PYTHON_ENV_DIR is already set in the base image)
 ENV TT_METAL_HOME=/tt-metal
 
-# Set TT_METAL_RUNTIME_ROOT
+# Set TT_METAL_RUNTIME_ROOT, required by Metal run-time options to be set to tt_metal/ base
 ENV TT_METAL_RUNTIME_ROOT=/tt-metal
 
 # Clone tt-metal
@@ -44,7 +44,7 @@ FROM base AS dev
 # Set up TT_METAL_HOME environment
 ENV TT_METAL_HOME=/tt-metal
 
-# TT_METAL_RUNTIME_ROOT
+# Set TT_METAL_RUNTIME_ROOT, required by Metal run-time options to be set to tt_metal/ base
 ENV TT_METAL_RUNTIME_ROOT=/tt-metal
 
 # Set working directory to TT_METAL_HOME


### PR DESCRIPTION
### Ticket
N/A

### Problem description
TT_METAL_RUNTIME_ROOT must be set now but was not being set in the telemetry Docker container.

### What's changed
Set TT_METAL_RUNTIME_ROOT to base directory where telemetry binary and frontend sources are deployed inside of the Docker.


### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes