### PR TITLE
[skip ci] Disable llmbox from merge gate due to capacity constraints

### DIFF
--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -162,7 +162,7 @@ jobs:
       matrix:
         platform: [
           "N300-viommu",
-          "N300-llmbox-viommu",
+          # "N300-llmbox-viommu", # re-enable when we have more capacity
         ]
     uses: ./.github/workflows/smoke.yaml
     with:
@@ -185,7 +185,7 @@ jobs:
       matrix:
         platform: [
           "N300-viommu",
-          "N300-llmbox-viommu",
+          # "N300-llmbox-viommu", # re-enable when we have more capacity
         ]
     uses: ./.github/workflows/smoke.yaml
     with:


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Merge Queue is backlogged due to LLMBox backlog.

### What's changed
Omit llmbox (for now)