### PR TITLE
Telemetry: Added warning message for common FSD mistake

### DIFF
--- a/tt_telemetry/telemetry/ethernet/ethernet_metrics.cpp
+++ b/tt_telemetry/telemetry/ethernet/ethernet_metrics.cpp
@@ -55,6 +55,9 @@ void create_ethernet_metrics(
         }
     }
     log_info(tt::LogAlways, "Found {} endpoints to monitor in factory system descriptor", endpoints.size());
+    if (endpoints.size() == 0 && fsd.eth_connections().connection().size() > 0) {
+        log_warning(tt::LogAlways, "Found 0 endpoints to monitor despite {} existing in factory system descriptor. Please check that the hostname in the FSD file matches the actual system hostname of this machine.", fsd.eth_connections().connection().size());
+    }
 
     // For each, create a metric
     for (const auto& endpoint : endpoints) {


### PR DESCRIPTION
### Ticket
[#31360](https://github.com/tenstorrent/tt-metal/issues/31360)

### Problem description
The FSD requires hostnames to be specified. Frequently -- e.g., when testing on IRD or by generating standard FSD files, which have a placeholder hostname -- the hostname is not updated and telemetry comes up but without monitoring any connections. 

### What's changed
A warning message for this common case, where the FSD file clearly specifies connections but where tt-telemetry finds none to monitor because it cannot match the hostname.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes