### PR TITLE
#29825 Teach elf loader about 64 bits

### DIFF
--- a/tt_metal/llrt/tt_elffile.cpp
+++ b/tt_metal/llrt/tt_elffile.cpp
@@ -62,53 +62,53 @@ protected:
     // ReadImage's declaration.
     const std::string_view path_;
 
-public:
+public:  // NOLINT
     Impl(ElfFile& owner, std::string_view path) : owner_(owner), path_(path) {}
     virtual ~Impl() = default;
 
-private:
+public:  // NOLINT
     Impl(const Impl&) = delete;
     Impl& operator=(const Impl&) = delete;
     Impl(Impl&&) = delete;
     Impl& operator=(Impl&&) = delete;
 
-public:
+public:  // NOLINT
     static Impl* Make(ElfFile& owner, const std::string& path);
 
-public:
+public:  // NOLINT
     virtual void LoadImage() = 0;
     virtual void WeakenDataSymbols(std::span<const std::string_view> strong_names) = 0;
     virtual void XIPify() = 0;
 
-private:
+private:  // NOLINT
     template <bool Is64>
     class Elf;
 };
 
 template <bool Is64>
 class ElfFile::Impl::Elf final : public Impl {
-public:
+public:  // NOLINT
     using Ehdr = std::conditional_t<Is64, Elf64_Ehdr, Elf32_Ehdr>;
     using Phdr = std::conditional_t<Is64, Elf64_Phdr, Elf32_Phdr>;
     using Shdr = std::conditional_t<Is64, Elf64_Shdr, Elf32_Shdr>;
     using Sym = std::conditional_t<Is64, Elf64_Sym, Elf32_Sym>;
     using Rela = std::conditional_t<Is64, Elf64_Rela, Elf32_Rela>;
 
-private:
+private:  // NOLINT
     std::span<Phdr> phdrs_;
     std::span<Shdr> shdrs_;
 
     class Weakener;
 
-public:
+public:  // NOLINT
     Elf(ElfFile& owner, std::string_view path) : Impl(owner, path) {}
-    virtual ~Elf() override = default;
+    virtual ~Elf() override = default;  // NOLINT
 
-    virtual void LoadImage() override;
-    virtual void WeakenDataSymbols(std::span<const std::string_view> strong_names) override;
-    virtual void XIPify() override;
+    virtual void LoadImage() override;                                                        // NOLINT
+    virtual void WeakenDataSymbols(std::span<const std::string_view> strong_names) override;  // NOLINT
+    virtual void XIPify() override;                                                           // NOLINT
 
-private:
+private:  // NOLINT
     [[nodiscard]] auto GetHeader() const -> const Ehdr& { return *ByteOffset<Ehdr>(GetContents().data()); }
     [[nodiscard]] auto GetPhdrs() const -> std::span<const Phdr> { return phdrs_; }
     [[nodiscard]] auto GetShdrs() const -> std::span<const Shdr> { return shdrs_; }
@@ -185,7 +185,7 @@ private:
         *ByteOffset<uint32_t>(GetContents(shdr).data(), addr - shdr.sh_addr) = value;
     }
 
-private:
+private:  // NOLINT
     static unsigned char GetSymBind(const Sym& sym) {
         if constexpr (Is64) {
             return ELF64_ST_BIND(sym.st_info);

--- a/tt_metal/llrt/tt_elffile.cpp
+++ b/tt_metal/llrt/tt_elffile.cpp
@@ -368,7 +368,7 @@ void ElfFile::Impl::Elf<Is64>::LoadImage() {
         // Require loadable segments to be nicely aligned
         if (((phdr.p_offset | phdr.p_vaddr | phdr.p_paddr) & (sizeof(word_t) - 1)) ||
             // Only support loading into the first 4GB
-            (Is64 && ((phdr.p_vaddr | phdr.p_paddr) + phdr.p_memsz) >> 32 * Is64)) {
+            (Is64 && ((phdr.p_vaddr | phdr.p_paddr) + phdr.p_memsz) > UINT32_MAX)) {
             TT_THROW(
                 "{}: loadable segment {} is misaligned or misplaced, [{}({}),+{}/{})@{}",
                 path_,

--- a/tt_metal/llrt/tt_elffile.hpp
+++ b/tt_metal/llrt/tt_elffile.hpp
@@ -20,7 +20,7 @@ namespace ll_api {
 
 class ElfFile {
 public:
-    // ELF32
+    // On ELF64 systems, we're statically restricted to the first 4GB
     using address_t = std::uint32_t;  // Address in memory
     using offset_t = std::uint32_t;   // Offset within region
     using word_t = std::uint32_t;     // Contents


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/29825

### Problem description
Our elf loader was 32-bit only, quasar has a 64-bit core

### What's changed
Templatize the elf loader implementation.
Remove unnecessary string copy.


### Checklist
- [YES] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [YES] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes