### PR TITLE
#31425: Migrate QueueId to metal

### DIFF
--- a/tests/ttnn/unit_tests/gtests/test_async_runtime.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_async_runtime.cpp
@@ -130,7 +130,7 @@ TEST_F(MultiCommandQueueSingleDeviceFixture, TestAsyncRuntimeAllocatedBuffers) {
 
             // Run operation on cq 0
             Tensor output_tensor;
-            with_command_queue_id(workload_dispatch_cq, [&]() { output_tensor = ttnn::sqrt(input_tensor); });
+            ttnn::with_command_queue_id(workload_dispatch_cq, [&]() { output_tensor = ttnn::sqrt(input_tensor); });
 
             auto dummy_buffer_0 =
                 tt::tt_metal::tensor_impl::allocate_device_buffer(device_, TensorSpec(shape, tensor_layout));

--- a/tt_metal/CMakeLists.txt
+++ b/tt_metal/CMakeLists.txt
@@ -88,6 +88,7 @@ set(TT_METAL_PUBLIC_API
     api/tt-metalium/program.hpp
     api/tt-metalium/program_cache.hpp
     api/tt-metalium/program_descriptors.hpp
+    api/tt-metalium/queue_id.hpp
     api/tt-metalium/routing_table_generator.hpp
     api/tt-metalium/runtime_args_data.hpp
     api/tt-metalium/shape.hpp

--- a/tt_metal/api/tt-metalium/queue_id.hpp
+++ b/tt_metal/api/tt-metalium/queue_id.hpp
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <optional>
+#include <tt_stl/strong_type.hpp>
+#include <cstdint>
+
+namespace tt::tt_metal {
+using QueueId = tt::stl::StrongType<uint8_t, struct QueueIdTag>;
+
+inline std::optional<uint8_t> raw_optional(const std::optional<QueueId>& cq_id) {
+    return cq_id.has_value() ? std::make_optional(cq_id.value().get()) : std::nullopt;
+}
+
+}  // namespace tt::tt_metal

--- a/ttnn/api/ttnn/common/queue_id.hpp
+++ b/ttnn/api/ttnn/common/queue_id.hpp
@@ -9,7 +9,7 @@
 namespace ttnn {
 /*
     Moved to metal as a part of tensor lowering. ttnn::QueueId remains to avoid breaking existing code and users, but
-all new development should use tt::tt_metal::QueueId instead.
+    all new development should use tt::tt_metal::QueueId instead.
 */
 using QueueId = tt::tt_metal::QueueId;
 

--- a/ttnn/api/ttnn/common/queue_id.hpp
+++ b/ttnn/api/ttnn/common/queue_id.hpp
@@ -4,31 +4,12 @@
 
 #pragma once
 
-#include <optional>
-#include <tt_stl/strong_type.hpp>
-#include <cstdint>
+#include <tt-metalium/queue_id.hpp>
 
 namespace ttnn {
 /*
-    Type must be moved to metal.
-    Background:
-    We have two software command queues available to overlap some work and reduce latency.
-    For example, Op2 can be prepared in a different queue while the first queue is blocked, waiting for data readout by
-    Op1. TT-NN operations allow specifying which queue should be used. The default queue is 0, and the possible values
-    are 0 and 1.
+    Moved to metal as a part of tensor lowering.
 */
-using QueueId = tt::stl::StrongType<uint8_t, struct QueueIdTag>;
+using QueueId = tt::tt_metal::QueueId;
 
 }  // namespace ttnn
-
-// Exporting to tt::tt_metal namespace because ttnn
-// defines some of its own types (think Tensor) in tt::tt_metal namespace.
-namespace tt::tt_metal {
-
-using QueueId = ttnn::QueueId;
-
-inline std::optional<uint8_t> raw_optional(const std::optional<QueueId>& cq_id) {
-    return cq_id.has_value() ? std::make_optional(cq_id.value().get()) : std::nullopt;
-}
-
-}  // namespace tt::tt_metal

--- a/ttnn/api/ttnn/common/queue_id.hpp
+++ b/ttnn/api/ttnn/common/queue_id.hpp
@@ -8,7 +8,8 @@
 
 namespace ttnn {
 /*
-    Moved to metal as a part of tensor lowering.
+    Moved to metal as a part of tensor lowering. ttnn::QueueId remains to avoid breaking existing code and users, but
+   all new development should use tt::tt_metal::QueueId instead.
 */
 using QueueId = tt::tt_metal::QueueId;
 

--- a/ttnn/api/ttnn/common/queue_id.hpp
+++ b/ttnn/api/ttnn/common/queue_id.hpp
@@ -9,7 +9,7 @@
 namespace ttnn {
 /*
     Moved to metal as a part of tensor lowering. ttnn::QueueId remains to avoid breaking existing code and users, but
-   all new development should use tt::tt_metal::QueueId instead.
+all new development should use tt::tt_metal::QueueId instead.
 */
 using QueueId = tt::tt_metal::QueueId;
 

--- a/ttnn/core/graph/graph_argument_serializer.cpp
+++ b/ttnn/core/graph/graph_argument_serializer.cpp
@@ -46,7 +46,7 @@ std::ostream& operator<<(
     return os;
 }
 
-std::ostream& operator<<(std::ostream& os, const tt::stl::StrongType<unsigned char, ttnn::QueueIdTag>& h) {
+std::ostream& operator<<(std::ostream& os, const tt::stl::StrongType<unsigned char, tt::tt_metal::QueueIdTag>& h) {
     return os << *h;
 }
 
@@ -185,7 +185,7 @@ void GraphArgumentSerializer::initialize() {
     GraphArgumentSerializer::register_type<tt::tt_metal::Shape>();
     GraphArgumentSerializer::register_type<tt::tt_metal::Tensor>();
     GraphArgumentSerializer::register_type<tt::tt_metal::Tile>();
-    GraphArgumentSerializer::register_type<tt::stl::StrongType<unsigned char, ttnn::QueueIdTag>>();
+    GraphArgumentSerializer::register_type<tt::stl::StrongType<unsigned char, tt::tt_metal::QueueIdTag>>();
     GraphArgumentSerializer::register_type<ttnn::types::CoreGrid>();
     GraphArgumentSerializer::register_type<
         std::variant<ttnn::GrayskullComputeKernelConfig, ttnn::WormholeComputeKernelConfig>>();

--- a/ttnn/core/graph/graph_argument_serializer.cpp
+++ b/ttnn/core/graph/graph_argument_serializer.cpp
@@ -185,7 +185,7 @@ void GraphArgumentSerializer::initialize() {
     GraphArgumentSerializer::register_type<tt::tt_metal::Shape>();
     GraphArgumentSerializer::register_type<tt::tt_metal::Tensor>();
     GraphArgumentSerializer::register_type<tt::tt_metal::Tile>();
-    GraphArgumentSerializer::register_type<tt::stl::StrongType<unsigned char, tt::tt_metal::QueueIdTag>>();
+    GraphArgumentSerializer::register_type<tt::stl::StrongType<uint8_t, tt::tt_metal::QueueIdTag>>();
     GraphArgumentSerializer::register_type<ttnn::types::CoreGrid>();
     GraphArgumentSerializer::register_type<
         std::variant<ttnn::GrayskullComputeKernelConfig, ttnn::WormholeComputeKernelConfig>>();

--- a/ttnn/core/graph/graph_argument_serializer.cpp
+++ b/ttnn/core/graph/graph_argument_serializer.cpp
@@ -46,7 +46,7 @@ std::ostream& operator<<(
     return os;
 }
 
-std::ostream& operator<<(std::ostream& os, const tt::stl::StrongType<unsigned char, tt::tt_metal::QueueIdTag>& h) {
+std::ostream& operator<<(std::ostream& os, const tt::stl::StrongType<uint8_t, tt::tt_metal::QueueIdTag>& h) {
     return os << *h;
 }
 


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/31425)

### Problem description
`ttnn::QueueId` is  an alias of `tt::tt_metal::QueueId`, and the header file suggests that it should be moved into metal. This is part of the larger effort of lowering Tensor to metal.

### What's changed

- Moved header from `ttnn/api/ttnn/common/queue_id.hpp` → `tt_metal/api/tt-metalium/queue_id.hpp`
- Kept forwarding header in `ttnn` to maintain backwards compatibility

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes ([link to run](https://github.com/tenstorrent/tt-metal/actions/runs/18954426391))
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes