### PR TITLE
Capture more info into build_key

### DIFF
--- a/tests/tt_metal/tt_metal/test_compile_sets_kernel_binaries.cpp
+++ b/tests/tt_metal/tt_metal/test_compile_sets_kernel_binaries.cpp
@@ -188,7 +188,7 @@ int main(int argc, char** argv) {
             TT_FATAL(compute_kernel != nullptr && riscv0_kernel != nullptr && riscv1_kernel != nullptr, "Error");
 
             // Run iteration to get golden
-            auto mask = tt_metal::BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key;
+            auto mask = tt_metal::BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key();
             tt_metal::detail::CompileProgram(device, program);
             compute_binaries.insert({mask, tt_metal::KernelImpl::from(*compute_kernel).binaries(mask)});
             TT_FATAL(compute_binaries.at(mask).size() == 3, "Expected 3 Compute binaries!");
@@ -230,7 +230,7 @@ int main(int argc, char** argv) {
                     for (int j = 0; j < num_compiles; j++) {
                         auto mask = tt_metal::BuildEnvManager::get_instance()
                                         .get_device_build_env(device->build_id())
-                                        .build_key;
+                                        .build_key();
                         tt_metal::detail::CompileProgram(device, program);
                         uint32_t programmable_core_index =
                             tt_metal::MetalContext::instance().hal().get_programmable_core_type_index(

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -161,7 +161,7 @@ void MetalContext::initialize(
         // Combine build_key and fw_compile_hash using XOR to create unique firmware build key
         // Uses full 64-bit fw_compile_hash for proper change detection
         uint64_t fw_build_key =
-            BuildEnvManager::get_instance().get_device_build_env(device_id).build_key ^ fw_compile_hash;
+            BuildEnvManager::get_instance().get_device_build_env(device_id).build_key() ^ fw_compile_hash;
 
         if (!firmware_built_keys_.contains(fw_build_key)) {
             BuildEnvManager::get_instance().build_firmware(device_id);

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -520,13 +520,13 @@ detail::KernelMeta Kernel::meta(IDevice* device) const {
 
 uint32_t KernelImpl::get_binary_packed_size(IDevice* device, int index) const {
     // In testing situations we can query the size w/o a binary
-    auto iter = binaries_.find(BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key);
+    auto iter = binaries_.find(BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key());
     return iter != this->binaries_.end() ? iter->second[index]->get_packed_size() : 0;
 }
 
 uint32_t KernelImpl::get_binary_text_size(IDevice* device, int index) const {
     // In testing situations we can query the size w/o a binary
-    auto iter = binaries_.find(BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key);
+    auto iter = binaries_.find(BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key());
     return iter != this->binaries_.end() ? iter->second[index]->get_text_size() : 0;
 }
 
@@ -607,7 +607,7 @@ void DataMovementKernel::read_binaries(IDevice* device) {
     [[maybe_unused]] uint32_t binary_size = binary_mem.get_packed_size();
     log_debug(LogLoader, "RISC={}, name={}, size={} (bytes)", riscv_id, this->name(), binary_size);
     this->set_binaries(
-        BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key, std::move(binaries));
+        BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key(), std::move(binaries));
 }
 
 void EthernetKernel::read_binaries(IDevice* device) {
@@ -643,7 +643,7 @@ void EthernetKernel::read_binaries(IDevice* device) {
     [[maybe_unused]] uint32_t binary_size = binary_mem.get_packed_size();
     log_debug(LogLoader, "ERISC={}, name={}, size={} (bytes)", erisc_id, this->name(), binary_size);
     this->set_binaries(
-        BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key, std::move(binaries));
+        BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key(), std::move(binaries));
 }
 
 void ComputeKernel::read_binaries(IDevice* device) {
@@ -664,7 +664,7 @@ void ComputeKernel::read_binaries(IDevice* device) {
         binaries.push_back(&binary_mem);
     }
     this->set_binaries(
-        BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key, std::move(binaries));
+        BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key(), std::move(binaries));
 }
 
 bool DataMovementKernel::configure(
@@ -675,7 +675,7 @@ bool DataMovementKernel::configure(
     auto device_id = device->id();
     auto worker_core = device->worker_core_from_logical_core(logical_core);
     const ll_api::memory& binary_mem =
-        *this->binaries(BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key)[0];
+        *this->binaries(BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key())[0];
     int riscv_id = static_cast<std::underlying_type<DataMovementProcessor>::type>(this->config_.processor);
     llrt::write_binary_to_address(binary_mem, device_id, worker_core, base_address + offsets[riscv_id]);
 
@@ -688,7 +688,7 @@ bool EthernetKernel::configure(
     auto device_id = device->id();
     auto ethernet_core = device->ethernet_core_from_logical_core(logical_core);
     const ll_api::memory& binary_mem =
-        *this->binaries(BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key)[0];
+        *this->binaries(BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key())[0];
 
     if (hal.get_core_kernel_stored_in_config_buffer(this->get_kernel_programmable_core_type())) {
         uint32_t offset_idx = hal.get_processor_index(
@@ -716,7 +716,7 @@ bool ComputeKernel::configure(
     auto device_id = device->id();
     auto worker_core = device->worker_core_from_logical_core(logical_core);
     const std::vector<const ll_api::memory*>& binaries =
-        this->binaries(BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key);
+        this->binaries(BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key());
     for (int trisc_id = 0; trisc_id <= 2; trisc_id++) {
         llrt::write_binary_to_address(
             *binaries[trisc_id], device_id, worker_core, base_address + offsets[2 + trisc_id]);

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -324,7 +324,7 @@ uint32_t finalize_kernel_bins(
         for (auto kernel_id : kg->kernel_ids) {
             const auto& kernel = kernels.at(kernel_id);
             const auto& binaries = KernelImpl::from(*kernel).binaries(
-                BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key);
+                BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key());
             uint32_t num_binaries = kernel->expected_num_binaries();
             TT_ASSERT(kernel->get_kernel_programmable_core_type() == programmable_core_type);
             for (uint32_t i = 0; i < num_binaries; i++) {

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -1076,7 +1076,7 @@ void detail::ProgramImpl::populate_dispatch_data(IDevice* device) {
         for (const auto& [kernel_id, kernel] : kernels) {
             auto& kernel_impl = KernelImpl::from(*kernel);
             const auto& binaries = kernel_impl.binaries(
-                BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key);
+                BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key());
             std::vector<uint32_t> dst_base_addrs;
             std::vector<uint32_t> page_offsets;
             std::vector<uint32_t> lengths;
@@ -1292,7 +1292,7 @@ void detail::ProgramImpl::allocate_kernel_bin_buf_on_device(IDevice* device) {
 void ProgramImpl::generate_dispatch_commands(IDevice* device, bool use_prefetcher_cache) {
     uint64_t command_hash = *device->get_active_sub_device_manager_id();
 
-    uint64_t device_hash = BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key;
+    uint64_t device_hash = BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key();
     if (not MetalContext::instance().hal().is_coordinate_virtualization_enabled()) {
         // When coordinate virtualization is not enabled, explicitly encode the device
         // id into the device hash, to always assert on programs being reused across devices.
@@ -1334,7 +1334,7 @@ void ProgramImpl::generate_dispatch_commands(IDevice* device, bool use_prefetche
 void ProgramImpl::generate_trace_dispatch_commands(IDevice* device, bool use_prefetcher_cache) {
     uint64_t command_hash = *device->get_active_sub_device_manager_id();
 
-    uint64_t device_hash = BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key;
+    uint64_t device_hash = BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key();
     if (not MetalContext::instance().hal().is_coordinate_virtualization_enabled()) {
         // When coordinate virtualization is not enabled, explicitly encode the device
         // id into the device hash, to always assert on programs being reused across devices.
@@ -1375,8 +1375,8 @@ void detail::ProgramImpl::compile(IDevice* device, bool force_slow_dispatch) {
     // ZoneScoped;
     auto& build_env = BuildEnvManager::get_instance().get_device_build_env(device->build_id());
 
-    if (compiled_.contains(build_env.build_key)) {
-        Inspector::program_compile_already_exists(this, device, build_env.build_key);
+    if (compiled_.contains(build_env.build_key())) {
+        Inspector::program_compile_already_exists(this, device, build_env.build_key());
         return;
     }
     // Clear the determined sub_device_ids when we compile the program for the first time
@@ -1385,7 +1385,7 @@ void detail::ProgramImpl::compile(IDevice* device, bool force_slow_dispatch) {
         this->sub_device_ids_[device->id()].erase(device->get_active_sub_device_manager_id());
     }
 
-    Inspector::program_compile_started(this, device, build_env.build_key);
+    Inspector::program_compile_started(this, device, build_env.build_key());
 
     TT_FATAL(
         device->is_initialized(),
@@ -1408,7 +1408,7 @@ void detail::ProgramImpl::compile(IDevice* device, bool force_slow_dispatch) {
                     this->set_cb_data_fmt(kernel->logical_coreranges(), build_options);
                     this->set_cb_tile_dims(kernel->logical_coreranges(), build_options);
 
-                    auto kernel_hash = KernelCompileHash(kernel, build_options, build_env.build_key);
+                    auto kernel_hash = KernelCompileHash(kernel, build_options, build_env.build_key());
 
                     const std::string kernel_path_suffix = kernel->name() + "/" + std::to_string(kernel_hash) + "/";
                     kernel->set_full_name(kernel_path_suffix);
@@ -1444,9 +1444,9 @@ void detail::ProgramImpl::compile(IDevice* device, bool force_slow_dispatch) {
         detail::MemoryReporter::inst().flush_program_memory_usage(get_id(), device);
     }
 
-    compiled_.insert(build_env.build_key);
+    compiled_.insert(build_env.build_key());
 
-    Inspector::program_compile_finished(this, device, build_env.build_key);
+    Inspector::program_compile_finished(this, device, build_env.build_key());
 }
 
 void detail::ProgramImpl::set_runtime_id(ProgramId id) { this->runtime_id = id; }

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -279,8 +279,8 @@ void JitBuildEnv::init(
     // Firmware build path is a combination of build_key and fw_compile_hash
     // If either change, the firmware build path will change and FW will be rebuilt
     // if it's not already in MetalContext::firmware_built_keys_
-    this->out_firmware_root_ = fmt::format("{}{}/firmware/{}/", this->out_root_, build_key, fw_compile_hash);
-    this->out_kernel_root_ = fmt::format("{}{}/kernels/", this->out_root_, build_key);
+    this->out_firmware_root_ = fmt::format("{}{}/firmware/{}/", this->out_root_, build_key_, fw_compile_hash);
+    this->out_kernel_root_ = fmt::format("{}{}/kernels/", this->out_root_, build_key_);
 }
 
 JitBuildState::JitBuildState(const JitBuildEnv& env, const JitBuiltStateConfig& build_config) :

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -15,6 +15,7 @@
 #include <string>
 #include <string_view>
 
+#include <enchantum/enchantum.hpp>
 #include <fmt/base.h>
 #include <fmt/format.h>
 #include <fmt/ranges.h>

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -120,15 +120,6 @@ void JitBuildEnv::init(
 
     this->out_root_ = this->out_root_  + git_hash + "/";
 #endif
-    // Firmware build path is a combination of build_key and fw_compile_hash
-    // If either change, the firmware build path will change and FW will be rebuilt
-    // if it's not already in MetalContext::firmware_built_keys_
-    const std::filesystem::path firmware_path = std::filesystem::path(this->out_root_) / std::to_string(build_key) /
-                                                std::to_string(fw_compile_hash) / "firmware/";
-    this->out_firmware_root_ = firmware_path.string();
-    const std::filesystem::path kernel_path =
-        std::filesystem::path(this->out_root_) / std::to_string(build_key) / "kernels/";
-    this->out_kernel_root_ = kernel_path.string();
 
     // Tools
     const static bool use_ccache = std::getenv("TT_METAL_CCACHE_KERNEL_SUPPORT") != nullptr;
@@ -275,6 +266,21 @@ void JitBuildEnv::init(
 
     this->lflags_ = common_flags;
     this->lflags_ += "-Wl,-z,max-page-size=16 -Wl,-z,common-page-size=16 -nostartfiles ";
+
+    // Need to capture more info in build key to prevent stale binaries from being reused.
+    jit_build::utils::FNV1a hasher;
+    hasher.update(build_key);
+    hasher.update(enchantum::to_underlying(this->arch_));
+    hasher.update(cflags_.begin(), cflags_.end());
+    hasher.update(lflags_.begin(), lflags_.end());
+    hasher.update(defines_.begin(), defines_.end());
+    build_key_ = hasher.digest();
+
+    // Firmware build path is a combination of build_key and fw_compile_hash
+    // If either change, the firmware build path will change and FW will be rebuilt
+    // if it's not already in MetalContext::firmware_built_keys_
+    this->out_firmware_root_ = fmt::format("{}{}/firmware/{}/", this->out_root_, build_key, fw_compile_hash);
+    this->out_kernel_root_ = fmt::format("{}{}/kernels/", this->out_root_, build_key);
 }
 
 JitBuildState::JitBuildState(const JitBuildEnv& env, const JitBuiltStateConfig& build_config) :

--- a/tt_metal/jit_build/build.hpp
+++ b/tt_metal/jit_build/build.hpp
@@ -59,6 +59,7 @@ public:
     const std::string& get_out_firmware_root_path() const {
         return out_firmware_root_;
     }  // Path to the firmware directory for this device
+    uint64_t get_build_key() const { return build_key_; }
 
 private:
     tt::ARCH arch_{tt::ARCH::Invalid};
@@ -78,6 +79,8 @@ private:
     std::string defines_;
     std::string includes_;
     std::string lflags_;
+
+    std::uint64_t build_key_{};
 };
 
 // All the state used for a build in an abstract base class

--- a/tt_metal/jit_build/build_env_manager.cpp
+++ b/tt_metal/jit_build/build_env_manager.cpp
@@ -174,8 +174,6 @@ void BuildEnvManager::add_build_env(ChipId device_id, uint8_t num_hw_cqs) {
     auto device_kernel_defines = initialize_device_kernel_defines(device_id, num_hw_cqs);
     const size_t fw_compile_hash =
         std::hash<std::string>{}(tt::tt_metal::MetalContext::instance().rtoptions().get_compile_hash_string());
-
-    device_id_to_build_env_[device_id].build_key = build_key;
     device_id_to_build_env_[device_id].build_env.init(
         build_key, fw_compile_hash, tt::tt_metal::MetalContext::instance().get_cluster().arch(), device_kernel_defines);
     device_id_to_build_env_[device_id].firmware_build_states =
@@ -234,7 +232,7 @@ std::vector<BuildEnvInfo> BuildEnvManager::get_all_build_envs_info() {
     std::vector<BuildEnvInfo> build_env_info;
     build_env_info.reserve(device_id_to_build_env_.size());
     for (const auto& [device_id, build_env] : device_id_to_build_env_) {
-        build_env_info.emplace_back(device_id, build_env.build_key, build_env.build_env.get_out_firmware_root_path());
+        build_env_info.emplace_back(device_id, build_env.build_key(), build_env.build_env.get_out_firmware_root_path());
     }
     return build_env_info;
 }

--- a/tt_metal/jit_build/build_env_manager.hpp
+++ b/tt_metal/jit_build/build_env_manager.hpp
@@ -22,7 +22,7 @@ using ProgCoreMapping =
 
 // A struct to hold device-specific build environment
 struct DeviceBuildEnv {
-    uint64_t build_key = 0;
+    uint64_t build_key() const { return build_env.get_build_key(); }
     JitBuildEnv build_env;
     std::vector<JitBuildState> firmware_build_states;
     std::vector<JitBuildState> kernel_build_states;

--- a/tt_metal/jit_build/jit_build_utils.hpp
+++ b/tt_metal/jit_build/jit_build_utils.hpp
@@ -4,11 +4,40 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 
 namespace tt::jit_build::utils {
 
 bool run_command(const std::string& cmd, const std::string& log_file, bool verbose);
 void create_file(const std::string& file_path_str);
+
+// Need a stable hash for things to persist across runs.
+// std::hash is not guaranteed to be stable across runs / implementations.
+class FNV1a {
+public:
+    // https://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function
+    static constexpr uint64_t FNV_PRIME = 0x100000001b3;
+    static constexpr uint64_t FNV_OFFSET = 0xcbf29ce484222325;
+
+    FNV1a(uint64_t offset = FNV_OFFSET) : hash_(offset) {}
+
+    void update(uint64_t data) {
+        hash_ ^= data;
+        hash_ *= FNV_PRIME;
+    }
+
+    template <typename ForwardIterator>
+    void update(ForwardIterator begin, ForwardIterator end) {
+        for (auto it = begin; it != end; ++it) {
+            update(static_cast<uint64_t>(*it));
+        }
+    }
+
+    uint64_t digest() const { return hash_; }
+
+private:
+    uint64_t hash_;
+};
 
 }  // namespace tt::jit_build::utils


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/31362

### Problem description
We should capture more info into build key or compilation hash.  For example, device profiler enable/disable is currently not captured, so we can't build both with device profiler and without in the same process. It will also cause issues if we reuse build cache across processes.

### What's changed
- Added a stable hash algorithm into jit_build_utils (std::hash is not consistent across runs/implementations)
- Capture arch, cflags, lflags and defines into build key.

### Checklist
- [X] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/18954512422) CI passes (T3k fast tests failing on [main](https://github.com/tenstorrent/tt-metal/actions/runs/18957533112/job/54180542450) too).
- [X] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/18954508355) CI with demo tests passes (if applicable)