### PR TITLE
Update sparse matmul docstring

### DIFF
--- a/tests/ttnn/unit_tests/operations/matmul/test_sparse_matmul.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_sparse_matmul.py
@@ -11,7 +11,6 @@ import random
 import torch
 import ttnn
 
-from models.common.utility_functions import skip_for_blackhole
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
 
@@ -29,7 +28,7 @@ def test_sparse_matmul_with_nnz(device, mkn, num_experts, num_batches, tile_h, t
     in0 = torch.randn((b, s, m, k), dtype=torch.bfloat16)
     in1 = torch.randn((1, num_experts, k, n), dtype=torch.bfloat16)
 
-    sparsity_shape = (1, b, s, num_experts)
+    sparsity_shape = (b, s, 1, num_experts)
     sparsity = torch.rand(sparsity_shape)
 
     # Mark some as 0 to test the sparsity
@@ -99,7 +98,7 @@ def test_sparse_matmul_with_nnz(device, mkn, num_experts, num_batches, tile_h, t
 
     # Compute matmul using torch for each batch and check the results
     for b_i, s_i, e_i in itertools.product(range(b), range(s), range(num_experts)):
-        if sparsity[0, b_i, s_i, e_i] == 0.0:
+        if sparsity[b_i, s_i, 0, e_i] == 0.0:
             continue
         in0_batch = in0[b_i, s_i, :, :]
         in1_batch = in1[0, e_i, :, :]
@@ -124,7 +123,7 @@ def test_sparse_matmul_without_nnz(device, mkn, num_experts, num_batches, tile_h
     in0 = torch.randn((b, s, m, k), dtype=torch.bfloat16)
     in1 = torch.randn((1, num_experts, k, n), dtype=torch.bfloat16)
 
-    sparsity_shape = (1, b, s, num_experts)
+    sparsity_shape = (b, s, 1, num_experts)
     sparsity = torch.rand(sparsity_shape)
 
     # Mark some as 0 to test the sparsity
@@ -140,7 +139,7 @@ def test_sparse_matmul_without_nnz(device, mkn, num_experts, num_batches, tile_h
 
     in0_t = ttnn.from_torch(
         in0,
-        tile=ttnn.Tile((tile_h, tile_w)),
+        tile=ttnn.Tile((tile_h, 32)),
         dtype=ttnn.bfloat16,
         layout=ttnn.TILE_LAYOUT,
         device=device,
@@ -191,7 +190,7 @@ def test_sparse_matmul_without_nnz(device, mkn, num_experts, num_batches, tile_h
 
     # Compute matmul using torch for each batch and check the results
     for b_i, s_i, e_i in itertools.product(range(b), range(s), range(num_experts)):
-        if sparsity[0, b_i, s_i, e_i] == 0.0:
+        if sparsity[b_i, s_i, 0, e_i] == 0.0:
             continue
         in0_batch = in0[b_i, s_i, :, :]
         in1_batch = in1[0, e_i, :, :]
@@ -297,6 +296,96 @@ def test_batched_sparse_matmul_with_nnz(device, mkn, num_experts, tile_h, tile_w
 
 
 @pytest.mark.parametrize("mkn", [(16, 128, 512)])
+@pytest.mark.parametrize("num_experts", [(1, 32), (1, 128)])
+@pytest.mark.parametrize("tile_h", [16])
+@pytest.mark.parametrize("tile_w", [32])
+@pytest.mark.parametrize("in1_dtype", [ttnn.bfloat8_b])
+@pytest.mark.parametrize("core_grid", [(4, 4)])
+def test_batched_sparse_matmul_without_nnz(device, mkn, num_experts, tile_h, tile_w, in1_dtype, core_grid):
+    torch.manual_seed(0)
+    m, k, n = mkn
+    b, s = num_experts
+    in0 = torch.randn((b, s, m, k), dtype=torch.bfloat16)
+    in1 = torch.randn((b, s, k, n), dtype=torch.bfloat16)
+
+    sparsity_shape = (1, 1, b, s)
+    sparsity = torch.rand(sparsity_shape)
+
+    # Mark some as 0 to test the sparsity
+    sparsity[(sparsity == 0)] = 0.1  # First make sure there are no zeros
+    number_of_zeros = random.randint(0, sparsity.numel() - 1)
+    zero_indices = torch.randperm(sparsity.numel())[:number_of_zeros]
+    sparsity.view(-1)[zero_indices] = 0.0
+
+    sparsity = sparsity.to(dtype=torch.bfloat16)
+
+    in0_t = ttnn.from_torch(
+        in0,
+        tile=ttnn.Tile((tile_h, 32)),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    in1_t = ttnn.from_torch(
+        in1,
+        tile=ttnn.Tile((32, tile_w)),
+        dtype=in1_dtype,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    sparsity_t = ttnn.from_torch(
+        sparsity,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    core_x, core_y = core_grid
+    output_tile = ttnn.Tile([tile_h, tile_w])
+    output_t = ttnn.sparse_matmul(
+        in0_t,
+        in1_t,
+        sparsity=sparsity_t,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        output_tile=output_tile,
+        is_input_a_sparse=True,
+        is_input_b_sparse=True,
+        program_config=ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+            compute_with_storage_grid_size=ttnn.CoreCoord(core_x, core_y),
+            in0_block_w=2,
+            out_subblock_h=1,
+            out_subblock_w=1,
+            out_block_h=1,
+            out_block_w=1,
+            per_core_M=m // tile_h,
+            per_core_N=int(math.ceil(n / tile_w)) // (core_x * core_y),
+            fuse_batch=False,
+            fused_activation=None,
+            mcast_in0=True,
+        ),
+    )
+
+    output_tensor = ttnn.to_torch(output_t)
+
+    # Compute matmul using torch for each batch and check the results
+    for b_i, s_i in itertools.product(range(b), range(s)):
+        if sparsity[0, 0, b_i, s_i] == 0.0:
+            continue
+        in0_batch = in0[b_i, s_i, :, :]
+        in1_batch = in1[b_i, s_i, :, :]
+        pt_out = torch.matmul(in0_batch, in1_batch)
+
+        # Compare with output tensor
+        expected_pcc = 0.999
+        assert_with_pcc(pt_out, output_tensor[b_i, s_i, :, :], expected_pcc)
+
+
+@pytest.mark.parametrize("mkn", [(16, 128, 512)])
 @pytest.mark.parametrize("num_experts", [8, 32])
 @pytest.mark.parametrize("num_batches", [4])
 @pytest.mark.parametrize("tile_h", [16])
@@ -357,6 +446,98 @@ def test_sparse_matmul_inputA_with_nnz(device, mkn, num_experts, num_batches, ti
         in1_t,
         sparsity=sparsity_t,
         nnz=nnz,
+        is_input_a_sparse=True,
+        is_input_b_sparse=False,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        output_tile=output_tile,
+        program_config=ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+            compute_with_storage_grid_size=ttnn.CoreCoord(core_x, core_y),
+            in0_block_w=1,
+            out_subblock_h=1,
+            out_subblock_w=1,
+            out_block_h=1,
+            out_block_w=1,
+            per_core_M=m // tile_h,
+            per_core_N=int(math.ceil(n / tile_w)) // (core_x * core_y),
+            fuse_batch=False,
+            fused_activation=None,
+            mcast_in0=True,
+        ),
+    )
+
+    output_tensor = ttnn.to_torch(output_t)
+    logger.info(f"output_tensor.shape: {output_tensor.shape}")
+
+    # Compute matmul using torch for each batch and check the results
+    for b_i, e_i in itertools.product(range(b), range(num_experts)):
+        if sparsity[0, 0, b_i, e_i] == 0.0:
+            continue
+        in0_batch = in0[b_i, e_i, :, :]
+        in1_batch = in1[0, e_i, :, :]
+        pt_out = torch.matmul(in0_batch, in1_batch)
+
+        # Compare with output tensor
+        expected_pcc = 0.999
+        assert_with_pcc(pt_out, output_tensor[b_i, e_i, :, :], expected_pcc)
+
+
+@pytest.mark.parametrize("mkn", [(16, 128, 512)])
+@pytest.mark.parametrize("num_experts", [8, 32])
+@pytest.mark.parametrize("num_batches", [4])
+@pytest.mark.parametrize("tile_h", [16])
+@pytest.mark.parametrize("tile_w", [32])
+@pytest.mark.parametrize("in1_dtype", [ttnn.bfloat8_b])
+@pytest.mark.parametrize("core_grid", [(4, 4)])
+def test_sparse_matmul_inputA_without_nnz(device, mkn, num_experts, num_batches, tile_h, tile_w, in1_dtype, core_grid):
+    torch.manual_seed(0)
+    m, k, n = mkn
+    b = num_batches
+    in0 = torch.randn((b, num_experts, m, k), dtype=torch.bfloat16)
+    in1 = torch.randn((1, num_experts, k, n), dtype=torch.bfloat16)
+
+    sparsity_shape = (1, 1, b, num_experts)
+    sparsity = torch.rand(sparsity_shape)
+
+    # Mark some as 0 to test the sparsity
+    sparsity[(sparsity == 0)] = 0.1  # First make sure there are no zeros
+    number_of_zeros = random.randint(0, sparsity.numel() - 1)
+    zero_indices = torch.randperm(sparsity.numel())[:number_of_zeros]
+    sparsity.view(-1)[zero_indices] = 0.0
+
+    sparsity = sparsity.to(dtype=torch.bfloat16)
+
+    in0_t = ttnn.from_torch(
+        in0,
+        tile=ttnn.Tile((tile_h, 32)),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    in1_t = ttnn.from_torch(
+        in1,
+        tile=ttnn.Tile((32, tile_w)),
+        dtype=in1_dtype,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    sparsity_t = ttnn.from_torch(
+        sparsity,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    core_x, core_y = core_grid
+    output_tile = ttnn.Tile([tile_h, tile_w])
+    output_t = ttnn.sparse_matmul(
+        in0_t,
+        in1_t,
+        sparsity=sparsity_t,
         is_input_a_sparse=True,
         is_input_b_sparse=False,
         memory_config=ttnn.DRAM_MEMORY_CONFIG,

--- a/ttnn/cpp/ttnn/operations/matmul/matmul_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul_pybind.cpp
@@ -993,7 +993,7 @@ void py_module(py::module& module) {
         The two input tensors must be be tiled and each have a rank of 4.
         The sparsity tensor must be a rank 4 tensor in row major layout.
 
-        Based on the input tensor shapes and `is_input_a_sparse` and `is_input_b_sparse` values, the output tensor shape is computed. See table below.
+        Based on the input tensor shapes and `is_input_a_sparse` and `is_input_b_sparse` values, the output tensor shape is computed. See the supported modes table below.
 
         Args:
             input_tensor_a (ttnn.Tensor): the first tensor to be multiplied. Needs to be on the device.
@@ -1002,8 +1002,8 @@ void py_module(py::module& module) {
             sparsity (ttnn.Tensor): the sparsity tensor containing the mask values. Needs to be on the device. The data type must be bfloat16.
             program_config (ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig): the program configuration for the matmul operation. Only this config type is supported. ``mcast_in0`` must be set to True.
             nnz (int, optional): the number of non-zero values in the sparsity tensor. If not provided, it will be inferred from the sparsity tensor at runtime.
-            is_input_a_sparse (bool, optional): boolean indicating whether `input_tensor_a` is sparse. Defaults to `False`. Together with `is_input_b_sparse`, it determines how the sparsity tensor is interpreted. See table below.
-            is_input_b_sparse (bool, optional): boolean indicating whether `input_tensor_b` is sparse. Defaults to `True`. Together with `is_input_a_sparse`, it determines how the sparsity tensor is interpreted. See table below.
+            is_input_a_sparse (bool, optional): boolean indicating whether `input_tensor_a` is sparse. Defaults to `False`. Together with `is_input_b_sparse`, it determines how the sparsity tensor is interpreted. See the supported modes table below.
+            is_input_b_sparse (bool, optional): boolean indicating whether `input_tensor_b` is sparse. Defaults to `True`. Together with `is_input_a_sparse`, it determines how the sparsity tensor is interpreted. See the supported modes table below.
             memory_config (ttnn.MemoryConfig, optional): the memory configuration of the output tensor. Defaults to `None`, which will result in using ttnn.DRAM_MEMORY_CONFIG.
             dtype (ttnn.DataType, optional): the data type of the output tensor. Defaults to `None`.
             compute_kernel_config (ttnn.DeviceComputeKernelConfig, optional): the compute kernel configuration for the matmul operation. Defaults to `None`.
@@ -1062,7 +1062,7 @@ void py_module(py::module& module) {
 
                 * - dtype
                   - layout
-                * - BFLOAT8_B, BFLOAT4_B, BFLOAT16, FLOAT32
+                * - BFLOAT4_B, BFLOAT8_B, BFLOAT16, FLOAT32
                   - TILE
 
             .. list-table:: input_tensor_b
@@ -1070,7 +1070,7 @@ void py_module(py::module& module) {
 
                 * - dtype
                   - layout
-                * - BFLOAT8_B, BFLOAT4_B, BFLOAT16, FLOAT32
+                * - BFLOAT4_B, BFLOAT8_B, BFLOAT16, FLOAT32
                   - TILE
 
             .. list-table:: sparsity

--- a/ttnn/cpp/ttnn/operations/matmul/matmul_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul_pybind.cpp
@@ -1004,7 +1004,7 @@ void py_module(py::module& module) {
             nnz (int, optional): the number of non-zero values in the sparsity tensor. If not provided, it will be inferred from the sparsity tensor at runtime.
             is_input_a_sparse (bool, optional): boolean indicating whether `input_tensor_a` is sparse. Defaults to `False`. Together with `is_input_b_sparse`, it determines how the sparsity tensor is interpreted. See table below.
             is_input_b_sparse (bool, optional): boolean indicating whether `input_tensor_b` is sparse. Defaults to `True`. Together with `is_input_a_sparse`, it determines how the sparsity tensor is interpreted. See table below.
-            memory_config(ttnn.MemoryConfig, optional): the memory configuration of the output tensor. Defaults to `None`, which will result in using ttnn.DRAM_MEMORY_CONFIG.
+            memory_config (ttnn.MemoryConfig, optional): the memory configuration of the output tensor. Defaults to `None`, which will result in using ttnn.DRAM_MEMORY_CONFIG.
             dtype (ttnn.DataType, optional): the data type of the output tensor. Defaults to `None`.
             compute_kernel_config (ttnn.DeviceComputeKernelConfig, optional): the compute kernel configuration for the matmul operation. Defaults to `None`.
             core_grid (ttnn.CoreGrid, optional): the grid on which to distribute the sharded tensor on (writes to the cores L1s). Defaults to `None`.

--- a/ttnn/cpp/ttnn/operations/matmul/matmul_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul_pybind.cpp
@@ -988,36 +988,81 @@ void py_module(py::module& module) {
         module,
         ::ttnn::sparse_matmul,
         R"doc(
-        Performs sparse matrix multiplication on input tensors based on sparsity tensor that has scale factor for each token.
+        Returns the matrix product of two tensors. Based on `is_input_a_sparse`, `is_input_b_sparse` and the sparsity tensor, some parts of the output computation is skipped.
+
+        The two input tensors must be be tiled and each have a rank of 4.
+        The sparsity tensor must be a rank 4 tensor in row major layout.
+
+        Based on the input tensor shapes and `is_input_a_sparse` and `is_input_b_sparse` values, the output tensor shape is computed. See table below.
 
         Args:
-            input_tensor_a (ttnn.Tensor): the first tensor to be multiplied containing the weights of the experts. Needs to be on the device.
-            input_tensor_b (ttnn.Tensor): the second tensor to be multiplied, containing the tokens to be processed. Needs to be on the device.
+            input_tensor_a (ttnn.Tensor): the first tensor to be multiplied. Needs to be on the device.
+            input_tensor_b (ttnn.Tensor): the second tensor to be multiplied. Needs to be on the device.
         Keyword Args:
-            sparsity (ttnn.Tensor): the sparsity tensor containing the scale factor for each token for each expert. Needs to be on the device.
+            sparsity (ttnn.Tensor): the sparsity tensor containing the mask values. Needs to be on the device. The data type must be bfloat16.
+            program_config (ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig): the program configuration for the matmul operation. Only this config type is supported. ``mcast_in0`` must be set to True.
             nnz (int, optional): the number of non-zero values in the sparsity tensor. If not provided, it will be inferred from the sparsity tensor at runtime.
-            is_input_a_sparse (bool): boolean indicating whether input_tensor_a is sparse. If both a and b are true, corresponding inputs in both input_tensor_a and input_tensor_b are skipped according to sparsity tensor. Defaults to `False`.
-            is_input_b_sparse (bool): boolean indicating whether input_tensor_b is sparse. If both a and b are true, corresponding inputs in both input_tensor_a and input_tensor_b are skipped according to sparsity tensor. Defaults to `True`.
-            memory_config (ttnn.MemoryConfig, optional): the memory configuration of the output tensor. Defaults to `None`, which will result in using `ttnn.DRAM_MEMORY_CONFIG`.
+            is_input_a_sparse (bool, optional): boolean indicating whether `input_tensor_a` is sparse. Defaults to `False`. Together with `is_input_b_sparse`, it determines how the sparsity tensor is interpreted. See table below.
+            is_input_b_sparse (bool, optional): boolean indicating whether `input_tensor_b` is sparse. Defaults to `True`. Together with `is_input_a_sparse`, it determines how the sparsity tensor is interpreted. See table below.
+            memory_config(ttnn.MemoryConfig, optional): the memory configuration of the output tensor. Defaults to `None`, which will result in using ttnn.DRAM_MEMORY_CONFIG.
             dtype (ttnn.DataType, optional): the data type of the output tensor. Defaults to `None`.
-            program_config (MatmulProgramConfig, optional): the program configuration for the matmul operation. Defaults to `None`.
             compute_kernel_config (ttnn.DeviceComputeKernelConfig, optional): the compute kernel configuration for the matmul operation. Defaults to `None`.
             core_grid (ttnn.CoreGrid, optional): the grid on which to distribute the sharded tensor on (writes to the cores L1s). Defaults to `None`.
             output_tile (List of [int], optional): Specifies the output tile configuration. Defaults to `None`.
-            optional_output_tensor (ttnn.Tensor, optional): User provided on-device output tensor where the result of sparse_matmul is to be written. Defaults to `None`.
+            optional_output_tensor (ttnn.Tensor, optional): User provided on-device output tensor where the result of matmul is to be written. Defaults to `None`.
 
         Returns:
             ttnn.Tensor: the output tensor with sparse results.
 
+        Supported Modes
+            .. list-table::
+                :header-rows: 1
+
+                * - is_input_a_sparse
+                  - is_input_b_sparse
+                  - input_tensor_a shape
+                  - input_tensor_b shape
+                  - sparsity shape
+                  - nnz
+                  - output shape
+                * - True
+                  - True
+                  - [1, E, M, K]
+                  - [1, E, K, N]
+                  - [1, 1, 1, E]
+                  - None or 0 ≤ nnz ≤ E
+                  - [1, E, M, N]
+                * - False
+                  - True
+                  - [A, B, M, K]
+                  - [1, E, K, N]
+                  - [A, B, 1, E]
+                  - None or 0 ≤ nnz ≤ A * B * E
+                  - [A, B, 1, E, M, N]
+                * - True
+                  - False
+                  - [A, E, M, K]
+                  - [1, E, K, N]
+                  - [1, 1, A, E]
+                  - None or 0 ≤ nnz ≤ A * E
+                  - [A, E, M, N]
+                * - False
+                  - False
+                  - Invalid
+                  - --
+                  - --
+                  - --
+                  - --
+
         Note:
-            The tensors support the following data types and layouts:
+            The input tensors support the following data types and layouts:
 
             .. list-table:: input_tensor_a
                 :header-rows: 1
 
                 * - dtype
                   - layout
-                * - BFLOAT16
+                * - BFLOAT8_B, BFLOAT4_B, BFLOAT16, FLOAT32
                   - TILE
 
             .. list-table:: input_tensor_b
@@ -1025,10 +1070,8 @@ void py_module(py::module& module) {
 
                 * - dtype
                   - layout
-                * - BFLOAT4_B, BFLOAT8_B, BFLOAT16, FLOAT32
+                * - BFLOAT8_B, BFLOAT4_B, BFLOAT16, FLOAT32
                   - TILE
-
-            FLOAT32 is only supported if :attr:`nnz` is provided.
 
             .. list-table:: sparsity
                 :header-rows: 1
@@ -1038,37 +1081,95 @@ void py_module(py::module& module) {
                 * - BFLOAT16
                   - ROW_MAJOR
 
+        Memory Support:
+            The supported memory configurations for the two input tensors are program config dependent, as described below:
+
+            .. list-table:: Supported Memory Configurations
+                :header-rows: 1
+
+                * - Config
+                  - Input A
+                  - Input B
+                * - ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig with (mcast_in0=True)
+                  - Interleaved (L1/DRAM)
+                  - Interleaved (L1/DRAM)
+
         Example:
-            >>> # Sparse matmul for 64 batch, 128 sequence, 512 hidden dimensions, 8 experts
-            >>> expert_weights = ttnn.ones([1, 8, 512, 512])
-            >>> tokens = ttnn.ones([1, 64, 128, 512])
-            >>> # Create sparsity bitmask
-            >>> sparsity_bitmask = torch.zeros([1, 64, 128, 8])
-            >>> # Set some tokens to be processed by different experts (simplified pattern)
-            >>> sparsity_bitmask[0, 0, 0, 0] = 1.0  # First token goes to expert 0
-            >>> sparsity_bitmask[0, 0, 0, 10] = 1.0  # First token goes to expert 10 as well
-            >>> sparsity_bitmask[0, 0, 1, 2] = 0.7  # Second token goes to expert 2
-            >>> sparsity_bitmask[0, 1, 0, 1] = 0.3  # Another token goes to expert 1
-            >>> # Move sparsity bitmask to device
-            >>> sparsity_bitmask = ttnn.to_device(sparsity_bitmask, device)
-            >>> # Perform sparse matmul
-            >>> output = ttnn.sparse_matmul(expert_weights, tokens, sparsity=sparsity_bitmask, nnz=4)
+            >>> config = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+            >>>     compute_with_storage_grid_size=ttnn.CoreCoord(1, 2),
+            >>>     in0_block_w=1,
+            >>>     out_subblock_h=1,
+            >>>     out_subblock_w=1,
+            >>>     out_block_h=1,
+            >>>     out_block_w=1,
+            >>>     per_core_M=2,
+            >>>     per_core_N=1,
+            >>>     fuse_batch=False,
+            >>>     fused_activation=None,
+            >>>     mcast_in0=True)
+            >>> nnz = 4
+            # Case 1: When `is_input_a_sparse` is True and `is_input_b_sparse` is True
+            >>> tensor1 = ttnn.to_device(ttnn.from_torch(torch.randn((1, 8, 64, 32), dtype=torch.bfloat16)), device)
+            >>> tensor2 = ttnn.to_device(ttnn.from_torch(torch.randn((1, 8, 32, 64), dtype=torch.bfloat16)), device)
+            # Create a sparsity tensor
+            >>> sparsity_bitmask = torch.zeros((1, 1, 1, 8), dtype=torch.bfloat16)
+            >>> sparsity_bitmask.view(-1)[torch.randperm(sparsity_bitmask.numel())[:nnz]] = 1.0
+            >>> sparsity_bitmask = ttnn.to_device(ttnn.from_torch(sparsity_bitmask), device)
+            >>> output = ttnn.sparse_matmul(
+            >>>     tensor1, tensor2, sparsity=sparsity_bitmask, nnz=nnz, is_input_a_sparse=True, is_input_b_sparse=True, program_config=config)
             >>> print(output.shape)
-            [64, 128, 8, 512]
-
-
+            # [1, 8, 64, 64]
+            # When nnz is not provided, it will be inferred from the sparsity tensor at runtime
+            >>> output = ttnn.sparse_matmul(
+            >>>     tensor1, tensor2, sparsity=sparsity_bitmask, is_input_a_sparse=True, is_input_b_sparse=True, program_config=config)
+            >>> print(output.shape)
+            # [1, 8, 64, 64]
+            # Case 2: When `is_input_a_sparse` is False and `is_input_b_sparse` is True
+            >>> tensor1 = ttnn.to_device(ttnn.from_torch(torch.randn((2, 16, 64, 32), dtype=torch.bfloat16)), device)
+            >>> tensor2 = ttnn.to_device(ttnn.from_torch(torch.randn((1, 8, 32, 64), dtype=torch.bfloat16)), device)
+            # Create a sparsity tensor
+            >>> sparsity_bitmask = torch.zeros((2, 16, 1, 8), dtype=torch.bfloat16)
+            >>> sparsity_bitmask.view(-1)[torch.randperm(sparsity_bitmask.numel())[:nnz]] = 1.0
+            >>> sparsity_bitmask = ttnn.to_device(ttnn.from_torch(sparsity_bitmask), device)
+            >>> output = ttnn.sparse_matmul(
+            >>>     tensor1, tensor2, sparsity=sparsity_bitmask, nnz=nnz, is_input_a_sparse=False, is_input_b_sparse=True, program_config=config)
+            >>> print(output.shape)
+            # [2, 16, 1, 8, 64, 64]
+            # When nnz is not provided, it will be inferred from the sparsity tensor at runtime
+            >>> output = ttnn.sparse_matmul(
+            >>>     tensor1, tensor2, sparsity=sparsity_bitmask, is_input_a_sparse=False, is_input_b_sparse=True, program_config=config)
+            >>> print(output.shape)
+            # [2, 16, 1, 8, 64, 64]
+            # Case 3: When `is_input_a_sparse` is True and `is_input_b_sparse` is False
+            >>> tensor1 = ttnn.to_device(ttnn.from_torch(torch.randn((4, 8, 64, 32), dtype=torch.bfloat16)), device)
+            >>> tensor2 = ttnn.to_device(ttnn.from_torch(torch.randn((1, 8, 32, 64), dtype=torch.bfloat16)), device)
+            # Create a sparsity tensor
+            >>> sparsity_bitmask = torch.zeros((1, 1, 4, 8), dtype=torch.bfloat16)
+            >>> sparsity_bitmask.view(-1)[torch.randperm(sparsity_bitmask.numel())[:nnz]] = 1.0
+            >>> sparsity_bitmask = ttnn.to_device(ttnn.from_torch(sparsity_bitmask), device)
+            >>> output = ttnn.sparse_matmul(
+            >>>     tensor1, tensor2, sparsity=sparsity_bitmask, nnz=nnz, is_input_a_sparse=True, is_input_b_sparse=False, program_config=config)
+            >>> print(output.shape)
+            # [4, 8, 64, 64]
+            # When nnz is not provided, it will be inferred from the sparsity tensor at runtime
+            >>> output = ttnn.sparse_matmul(
+            >>>     tensor1, tensor2, sparsity=sparsity_bitmask, is_input_a_sparse=True, is_input_b_sparse=False, program_config=config)
+            >>> print(output.shape)
+            # [4, 8, 64, 64]
+            # Case 4: When `is_input_a_sparse` is False and `is_input_b_sparse` is False
+            # This is invalid
         )doc",
         ttnn::pybind_overload_t{
             [](decltype(::ttnn::sparse_matmul)& self,
                const ttnn::Tensor& input_tensor_a,
                const ttnn::Tensor& input_tensor_b,
                const ttnn::Tensor& sparsity,
+               const MatmulProgramConfig& program_config,
                const std::optional<uint32_t> nnz,
                const bool is_input_a_sparse,
                const bool is_input_b_sparse,
                const std::optional<const ttnn::MemoryConfig>& memory_config,
                const std::optional<const DataType> dtype,
-               const std::optional<const MatmulProgramConfig>& program_config,
                const std::optional<const DeviceComputeKernelConfig> compute_kernel_config,
                const std::optional<const ttnn::CoreGrid> core_grid,
                const std::optional<const tt::tt_metal::Tile>& output_tile,
@@ -1096,12 +1197,12 @@ void py_module(py::module& module) {
             py::arg("input_tensor_b"),
             py::kw_only(),
             py::arg("sparsity"),
+            py::arg("program_config"),
             py::arg("nnz") = std::nullopt,
             py::arg("is_input_a_sparse") = false,
             py::arg("is_input_b_sparse") = true,
             py::arg("memory_config") = std::nullopt,
             py::arg("dtype") = std::nullopt,
-            py::arg("program_config") = std::nullopt,
             py::arg("compute_kernel_config") = std::nullopt,
             py::arg("core_grid") = std::nullopt,
             py::arg("output_tile") = std::nullopt,


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/31488

### Problem description
Sparse Matmul docstrings were incorrect and inadequate

### What's changed
This PR adds the following:
1. Fixes description of matmul input tensors.
2. Add a table to show the 3 flavors of sparse matmul supported
3. Add a snippet showing example code for all 3 flavors
4. Clarify limitations on the configs supported.
5. Update unit test so all 3 flavors are tested with nnz and without nnz

The material is based on 3 PRs that were put in to enable these features. Ordered such that most recent is first:
1. https://github.com/tenstorrent/tt-metal/pull/30070
2. https://github.com/tenstorrent/tt-metal/pull/27275
3. https://github.com/tenstorrent/tt-metal/pull/25027

### Updated Content

#### Function signature
<img width="1326" height="234" alt="image" src="https://github.com/user-attachments/assets/0900c405-fd74-4054-b0a5-c0a838fb186e" />

#### Description
<img width="1326" height="857" alt="image" src="https://github.com/user-attachments/assets/ed159d6c-5a4d-4139-b6e1-c0c539dd76e2" />

#### Table
<img width="1326" height="299" alt="image" src="https://github.com/user-attachments/assets/338d8ea7-c9a4-41dc-af93-ca40976de52a" />

#### Code Snippets
<img width="1326" height="984" alt="image" src="https://github.com/user-attachments/assets/a8644b07-b521-408b-a3b0-a9f5fad1f003" />

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/18956820612/attempts/2 1 known timeout that is also on main
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/18956823661
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes