### PR TITLE
Make Lite Fabric use NOC1, fix teardown

### DIFF
--- a/tt_metal/lite_fabric/hal/blackhole_impl.cpp
+++ b/tt_metal/lite_fabric/hal/blackhole_impl.cpp
@@ -9,7 +9,7 @@
 
 namespace {
 
-uint32_t GetStateAddress() {
+constexpr uint32_t GetStateAddress() {
     return LITE_FABRIC_CONFIG_START + offsetof(lite_fabric::FabricLiteMemoryMap, config) +
            offsetof(lite_fabric::FabricLiteConfig, current_state);
 }
@@ -173,7 +173,7 @@ std::vector<std::string> BlackholeLiteFabricHal::build_defines() {
         "ERISC",
         "RISC_B0_HW",
         "FW_BUILD",
-        "NOC_INDEX=0",
+        "NOC_INDEX=1",
         "DISPATCH_MESSAGE_ADDR=0",
         "COMPILE_FOR_LITE_FABRIC=1",
         "ROUTING_FW_ENABLED",

--- a/tt_metal/lite_fabric/hw/inc/channels.hpp
+++ b/tt_metal/lite_fabric/hw/inc/channels.hpp
@@ -42,6 +42,7 @@ FORCE_INLINE void send_next_data(
     uint32_t src_addr = sender_buffer_channel.get_cached_next_buffer_slot_addr();
 
     volatile auto* pkt_header = reinterpret_cast<volatile lite_fabric::FabricLiteHeader*>(src_addr);
+    pkt_header->debug = 0xd05e0000;
 
     if (pkt_header->get_base_send_type() == lite_fabric::NocSendTypeEnum::WRITE_REG) {
         const uint32_t reg_address = pkt_header->command_fields.write_reg.reg_address;

--- a/tt_metal/lite_fabric/hw/inc/header.hpp
+++ b/tt_metal/lite_fabric/hw/inc/header.hpp
@@ -95,7 +95,8 @@ struct FabricLiteHeader {
     // otherwise.
     uint8_t src_ch_id{};
     LiteFabricRoutingFields routing_fields{};
-    unsigned char unused[32]{};
+    uint32_t debug{};
+    unsigned char unused[28]{};
 
     explicit FabricLiteHeader() = default;
     lite_fabric::NocSendType get_noc_send_type() volatile const {

--- a/tt_metal/lite_fabric/hw/src/lite_fabric.cpp
+++ b/tt_metal/lite_fabric/hw/src/lite_fabric.cpp
@@ -95,12 +95,9 @@ __attribute__((noinline)) void service_lite_fabric() {
             reinterpret_cast<volatile lite_fabric::FabricLiteMemoryMap*>(LITE_FABRIC_CONFIG_START)
                 ->config.routing_enabled = lite_fabric::RoutingEnabledState::STOPPED;
             ConnectedRiscInterface::assert_connected_dm1_reset();
-            internal_::eth_write_remote_reg(
-                0,
-                static_cast<uint32_t>(reinterpret_cast<uintptr_t>(
-                    &(reinterpret_cast<volatile lite_fabric::FabricLiteMemoryMap*>(LITE_FABRIC_CONFIG_START)
-                          ->config.routing_enabled))),
-                static_cast<uint32_t>(lite_fabric::RoutingEnabledState::STOPPED));
+            constexpr uint32_t routing_enabled_address =
+                LITE_FABRIC_CONFIG_START + offsetof(lite_fabric::FabricLiteConfig, routing_enabled);
+            internal_::eth_send_packet<false>(0, routing_enabled_address >> 4, routing_enabled_address >> 4, 1);
             return;
     }
     lite_fabric::run_sender_channel_step<0>();


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-umd/issues/1558

### Problem description
- Conflict with the latest ERISC fw on NOC0
- Connected ethernet core left in running state after test finished

### What's changed
- Make Lite Fabric use NOC1 as there is a conflict with ERISC FW on ERISC0 using NOC0
- Improved teardown sequence to fix teardown bugs
  - The connected ethernet core was left running while the "MMIO" one was in reset.
- Update the test cases to loop for 100 times to help flush out bugs

### Checklist
APC
https://github.com/tenstorrent/tt-metal/actions/runs/18964860035
BH
https://github.com/tenstorrent/tt-metal/actions/runs/18964861657
BH Multi Card
https://github.com/tenstorrent/tt-metal/actions/runs/18964857351