### PR TITLE
fix: correct ODR due to leakage to global namespace

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu_types.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu_types.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-enum SfpuType {
+enum class SfpuType {
     tanh,
     hardtanh,
     gelu,


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-llk/issues/785

### Problem description
BH enum was declared as plain enum (C-style one). This exposed enum values like abs, max, min to the global namespace and created an ODR violation in some other part of the code. These unscoped enum values conflicted with standard C/C++ library functions like `std::abs`, `std::max`, `std::min`

### What's changed
This change makes the enum scoped (also called a "strongly-typed enum"), which means:
1. Enum values like `abs` are now accessed as `SfpuType::abs`
2. They no longer pollute the global namespace
3. No conflict with standard library functions

### Checklist
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/18961199234)