### PR TITLE
[skip ci]: ttnn: control executable check by --skip-executable-check flag

### DIFF
--- a/ttnn/ttnn/distributed/ttrun.py
+++ b/ttnn/ttnn/distributed/ttrun.py
@@ -266,7 +266,9 @@ def print_command(cmd: List[str], prefix: str = TT_RUN_PREFIX) -> None:
     type=click.Path(exists=True, path_type=Path),
     help="Mock cluster rank binding configuration file (YAML)",
 )
-@click.option("--skip-executable-check", is_flag=True, help="Skip the check if program executable exists on the local host")
+@click.option(
+    "--skip-executable-check", is_flag=True, help="Skip the check if program executable exists on the local host"
+)
 @click.pass_context
 def main(
     ctx: click.Context,

--- a/ttnn/ttnn/distributed/ttrun.py
+++ b/ttnn/ttnn/distributed/ttrun.py
@@ -266,6 +266,7 @@ def print_command(cmd: List[str], prefix: str = TT_RUN_PREFIX) -> None:
     type=click.Path(exists=True, path_type=Path),
     help="Mock cluster rank binding configuration file (YAML)",
 )
+@click.option("--skip-executable-check", is_flag=True, help="Skip the check if program executable exists on the local host")
 @click.pass_context
 def main(
     ctx: click.Context,
@@ -275,6 +276,7 @@ def main(
     mpi_args: Optional[List[str]],
     debug_gdbserver: bool,
     mock_cluster_rank_binding: Optional[Path],
+    skip_executable_check: bool,
 ) -> None:
     """tt-run - MPI process launcher for TT-Metal and TTNN distributed applications
 
@@ -400,9 +402,10 @@ def main(
         raise click.ClickException("No program specified. Please provide a program to run.")
 
     # Validate program executable exists
-    program_path = Path(program[0])
-    if not program_path.exists() and not shutil.which(program[0]):
-        raise click.ClickException(f"Program not found: {program[0]}")
+    if not skip_executable_check:
+        program_path = Path(program[0])
+        if not program_path.exists() and not shutil.which(program[0]):
+            raise click.ClickException(f"Program not found: {program[0]}")
 
     # Build MPI command
     mpi_cmd = build_mpi_command(config, program, mpi_args, debug_gdbserver=debug_gdbserver)


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/31506

### Problem description
tt-run expect the remote program to be present on the launcher (host that executes tt-run). This breaks the behavior of MPI Operator where Launcher is just a tiny pod with MPI, and Workers are executing the actual work and need to have dependencies.


### What's changed
New flag - `--skip-executable-check` (false by default) that skips the check.