### PR TITLE
Tracy flag deprecated in test dispatch 

### DIFF
--- a/.github/workflows/test-dispatch.yaml
+++ b/.github/workflows/test-dispatch.yaml
@@ -23,11 +23,6 @@ on:
           - RelWithDebInfo
           - ASan
           - TSan
-      tracy:
-        required: false
-        type: boolean
-        default: false
-        description: "Build with tracy enabled"
       command:
         required: true
         type: string
@@ -57,7 +52,6 @@ jobs:
     secrets: inherit
     with:
       build-type: ${{ inputs.build-type }}
-      tracy: ${{ inputs.tracy }}
       version: ${{ inputs.version }}
       build-wheel: true
       ref: ${{ inputs.commit || github.sha }}


### PR DESCRIPTION
### Problem description
Since tracy is enabled by default, "Build with tracy enabled" flag from test-dispatch is deprecated 

### What's changed
Removed tracy enable flag from a workflow

### Checklist
- [ ] Custom test dispatch https://github.com/tenstorrent/tt-metal/actions/runs/18970083475