### PR TITLE
Fix CI - Allow UINT32 in Generic Reduces

### DIFF
--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op.cpp
@@ -51,8 +51,8 @@ void Reduce::validate(const std::vector<Tensor>& input_tensors) const {
     TT_FATAL((input_tensor.layout() == Layout::TILE), "Inputs to reduce must be tilized");
     TT_FATAL(
         input_tensor.dtype() == DataType::BFLOAT16 || input_tensor.dtype() == DataType::FLOAT32 ||
-            input_tensor.dtype() == DataType::BFLOAT8_B,
-        "Only FLOAT32, BFLOAT16, and BFLOAT8_B are supported for generic reduction - got {}",
+            input_tensor.dtype() == DataType::BFLOAT8_B || input_tensor.dtype() == DataType::UINT32,
+        "Only FLOAT32, BFLOAT16, BFLOAT8_B, and UINT32 are supported for generic reduction - got {}",
         input_tensor.dtype());
 }
 


### PR DESCRIPTION
### Ticket
NA

### Problem description
Validation was updated in https://github.com/tenstorrent/tt-metal/commit/33e2ee92be658871c93135c8c4faa2a009a7f184 for generic reduces to only accept floating 8/16/32 bit inputs, as the kernel and underlying LLKs don't have full integer support.

It turns out the `VADv2` model is using the generic reduces with UNT32, so this validation causes a failure in pipeilnes.

### What's changed
Update the validation immediately to allow UINT32 through, in order to unblock this model.

Tests and documentation will be updated once support is better studied.

### Checklist
- [x] Frequent Model and TTNN Tests [VADv2 passes](https://github.com/tenstorrent/tt-metal/actions/runs/18972806289)