### PR TITLE
#18952: [skip ci] Make the benchmark data steps not fail when there's no data (only change model-perf pipeline for now)

### DIFF
--- a/.github/workflows/perf-models-impl.yaml
+++ b/.github/workflows/perf-models-impl.yaml
@@ -261,8 +261,8 @@ jobs:
           ARCH_NAME: ${{ matrix.test-info.arch }}
         run: |
           if [ -d "generated/benchmark_data" ]; then
-            python3 .github/scripts/data_analysis/create_benchmark_with_environment_json.py
             echo "has_benchmark_data=true" >> $GITHUB_OUTPUT
+            python3 .github/scripts/data_analysis/create_benchmark_with_environment_json.py
           else
             echo "::warning::Benchmark data directory 'generated/benchmark_data' does not exist"
             echo "has_benchmark_data=false" >> $GITHUB_OUTPUT

--- a/.github/workflows/perf-models-impl.yaml
+++ b/.github/workflows/perf-models-impl.yaml
@@ -254,14 +254,22 @@ jobs:
         if: ${{ !cancelled() }}
 
       - name: Save environment data
+        id: save-environment-data
         if: ${{ !cancelled() }}
         shell: bash
         env:
           ARCH_NAME: ${{ matrix.test-info.arch }}
-        run: python3 .github/scripts/data_analysis/create_benchmark_with_environment_json.py
+        run: |
+          if [ -d "generated/benchmark_data" ]; then
+            python3 .github/scripts/data_analysis/create_benchmark_with_environment_json.py
+            echo "has_benchmark_data=true" >> $GITHUB_OUTPUT
+          else
+            echo "::warning::Benchmark data directory 'generated/benchmark_data' does not exist"
+            echo "has_benchmark_data=false" >> $GITHUB_OUTPUT
+          fi
 
       - name: Upload benchmark data
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.save-environment-data.outputs.has_benchmark_data == 'true' }}
         uses: tenstorrent/tt-metal/.github/actions/upload-data-via-sftp@main
         with:
           ssh-private-key: ${{ secrets.SFTP_BENCHMARK_WRITER_KEY }}

--- a/.github/workflows/perf-models-impl.yaml
+++ b/.github/workflows/perf-models-impl.yaml
@@ -269,7 +269,7 @@ jobs:
           fi
 
       - name: Upload benchmark data
-        if: ${{ !cancelled() && steps.save-environment-data.outputs.has_benchmark_data == 'true' }}
+        if: ${{ !cancelled() && steps.save-environment-data.conclusion == 'success' && steps.save-environment-data.outputs.has_benchmark_data == 'true' }}
         uses: tenstorrent/tt-metal/.github/actions/upload-data-via-sftp@main
         with:
           ssh-private-key: ${{ secrets.SFTP_BENCHMARK_WRITER_KEY }}


### PR DESCRIPTION
### Ticket
#18952 (will roll this change out to other benchmark pipelines after this PR)

### Problem description
When no benchmark reports exist, the report generation and upload step both fail: https://github.com/tenstorrent/tt-metal/actions/runs/18975667471/job/54195269568
In model perf pipeline after the option to run only a single model was added by @dimitri-tenstorrent , this causes "fake" failures because models are skipped for some of the jobs which means there's no data -> report+upload jobs fail -> pipeline run is "red"

### What's changed
Warn+skip the report generation step if no generated report dir exists
Run upload step if generated report dir exists AND report generation script passed

### Checklist
- [x] Model perf (stable_diffusion runs in cnn_javelin but not other_magic_env, but other_magic_env now doesn't fail on report generation): https://github.com/tenstorrent/tt-metal/actions/runs/18976244126/job/54198304036