### PR TITLE
#0: Remove Galaxy APC because of high queue times, instability, and open issue on Models team to create a small stable sliver of their test to potentially shift left

### DIFF
--- a/.github/workflows/all-post-commit-workflows.yaml
+++ b/.github/workflows/all-post-commit-workflows.yaml
@@ -192,23 +192,6 @@ jobs:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-  galaxy-apc-fast-tests:
-    if: ${{ github.event.pull_request.head.repo.fork == false }}
-    needs: build-artifact
-    secrets: inherit
-    strategy:
-      fail-fast: false
-      matrix:
-        test-group: [
-          { arch: wormhole_b0, runner-label: in-service-dedicated-apc, topology: topology-6u },
-        ]
-    uses: ./.github/workflows/galaxy-apc-fast-tests-impl.yaml
-    with:
-      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-      runner-label: ${{ matrix.test-group.runner-label }}
-      topology: ${{ matrix.test-group.topology }}
   build-docs:
     needs: build-artifact
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}

--- a/.github/workflows/apc-select-tests.yaml
+++ b/.github/workflows/apc-select-tests.yaml
@@ -235,25 +235,6 @@ jobs:
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       enable-watcher: ${{ inputs.enable-watcher || false }}
 
-  galaxy-apc-fast-tests:
-    needs: [parse-tests-json, build-artifact]
-    if: ${{ contains(needs.parse-tests-json.outputs.tests-to-run, 'galaxy-apc-fast-tests') }}
-    secrets: inherit
-    strategy:
-      fail-fast: false
-      matrix:
-        test-group: [
-          { arch: wormhole_b0, runner-label: in-service, topology: topology-6u },
-        ]
-    uses: ./.github/workflows/galaxy-apc-fast-tests-impl.yaml
-    with:
-      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-      runner-label: ${{ matrix.test-group.runner-label }}
-      enable-watcher: ${{ inputs.enable-watcher || false }}
-      topology: ${{ matrix.test-group.topology }}
-
   test-ttnn-tutorials:
     needs: [parse-tests-json, build-artifact]
     if: ${{ contains(needs.parse-tests-json.outputs.tests-to-run, 'test-ttnn-tutorials') }}

--- a/.github/workflows/galaxy-apc-fast-tests-impl.yaml
+++ b/.github/workflows/galaxy-apc-fast-tests-impl.yaml
@@ -1,4 +1,4 @@
-name: "[internal] Galaxy APC fast tests"
+name: "[internal] Galaxy fast tests"
 
 on:
   workflow_call:

--- a/.github/workflows/galaxy-apc-fast-tests.yaml
+++ b/.github/workflows/galaxy-apc-fast-tests.yaml
@@ -1,4 +1,4 @@
-name: "(Galaxy) APC fast tests"
+name: "(Galaxy) Fast tests"
 
 on:
   workflow_dispatch:  # Manual trigger only used to test galaxy apc fast tests


### PR DESCRIPTION
### Ticket

N/A - Team decision.

### Problem description

- Galaxy queue times have been high - both APC and non-APC
- Galaxy APC is flaky and provides low-quality signal to developers
- Models team (@djordje-tt) has an open issue to create a slimmer, more stable test for shifting left so that this is not needed

### What's changed

We have taken out the test.

Galaxy quick still has llama coverage on every push to main. Models team is free to use that as coverage in meantime as it provides feedback on EVERY commit.

Also, @djordje-tt has open issue to shift left.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/18980669537
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes