### PR TITLE
#18952: [skip ci] Fix the rest of the benchmark upload workflows to not fail when no generated perf reports exist

### DIFF
--- a/.github/workflows/blackhole-demo-tests-impl.yaml
+++ b/.github/workflows/blackhole-demo-tests-impl.yaml
@@ -92,14 +92,22 @@ jobs:
           fi
           ${{ matrix.test-group.cmd }}
       - name: Save environment data
-        if: ${{ contains(matrix.test-group.name, 'llama') && !cancelled() }}
+        id: save-environment-data
+        if: ${{ !cancelled() }}
         timeout-minutes: 15
         env:
           ARCH_NAME: ${{ matrix.test-group.arch }}
-        run: python3 /work/.github/scripts/data_analysis/create_benchmark_with_environment_json.py
+        run: |
+          if [ -d "generated/benchmark_data" ]; then
+            echo "has_benchmark_data=true" >> $GITHUB_OUTPUT
+            python3 .github/scripts/data_analysis/create_benchmark_with_environment_json.py
+          else
+            echo "::warning::Benchmark data directory 'generated/benchmark_data' does not exist"
+            echo "has_benchmark_data=false" >> $GITHUB_OUTPUT
+          fi
 
       - name: Upload benchmark data
-        if: ${{ contains(matrix.test-group.name, 'llama') && !cancelled() }}
+        if: ${{ !cancelled() && steps.save-environment-data.conclusion == 'success' && steps.save-environment-data.outputs.has_benchmark_data == 'true' }}
         uses: tenstorrent/tt-metal/.github/actions/upload-data-via-sftp@main
         with:
           ssh-private-key: ${{ secrets.SFTP_BENCHMARK_WRITER_KEY }}

--- a/.github/workflows/blackhole-multi-card-demo-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-demo-tests-impl.yaml
@@ -103,14 +103,22 @@ jobs:
         run: |
           tt-smi -s
       - name: Save environment data
-        if: ${{ contains(matrix.test-group.name, 'llama') && !cancelled() }}
+        id: save-environment-data
+        if: ${{ !cancelled() }}
         timeout-minutes: 15
         env:
           ARCH_NAME: ${{ matrix.test-group.arch }}
-        run: python3 /work/.github/scripts/data_analysis/create_benchmark_with_environment_json.py
+        run: |
+          if [ -d "generated/benchmark_data" ]; then
+            echo "has_benchmark_data=true" >> $GITHUB_OUTPUT
+            python3 .github/scripts/data_analysis/create_benchmark_with_environment_json.py
+          else
+            echo "::warning::Benchmark data directory 'generated/benchmark_data' does not exist"
+            echo "has_benchmark_data=false" >> $GITHUB_OUTPUT
+          fi
 
       - name: Upload benchmark data
-        if: ${{ contains(matrix.test-group.name, 'llama') && !cancelled() }}
+        if: ${{ !cancelled() && steps.save-environment-data.conclusion == 'success' && steps.save-environment-data.outputs.has_benchmark_data == 'true' }}
         uses: tenstorrent/tt-metal/.github/actions/upload-data-via-sftp@main
         with:
           ssh-private-key: ${{ secrets.SFTP_BENCHMARK_WRITER_KEY }}
@@ -184,14 +192,22 @@ jobs:
           ${{ matrix.test-group.cmd }}
 
       - name: Save environment data
-        if: ${{ contains(matrix.test-group.name, 'llama') && !cancelled() }}
+        id: save-environment-data
+        if: ${{ !cancelled() }}
         timeout-minutes: 15
         env:
           ARCH_NAME: ${{ matrix.test-group.arch }}
-        run: python3 .github/scripts/data_analysis/create_benchmark_with_environment_json.py
+        run: |
+          if [ -d "generated/benchmark_data" ]; then
+            echo "has_benchmark_data=true" >> $GITHUB_OUTPUT
+            python3 .github/scripts/data_analysis/create_benchmark_with_environment_json.py
+          else
+            echo "::warning::Benchmark data directory 'generated/benchmark_data' does not exist"
+            echo "has_benchmark_data=false" >> $GITHUB_OUTPUT
+          fi
 
       - name: Upload benchmark data
-        if: ${{ contains(matrix.test-group.name, 'llama') && !cancelled() }}
+        if: ${{ !cancelled() && steps.save-environment-data.conclusion == 'success' && steps.save-environment-data.outputs.has_benchmark_data == 'true' }}
         uses: tenstorrent/tt-metal/.github/actions/upload-data-via-sftp@main
         with:
           ssh-private-key: ${{ secrets.SFTP_BENCHMARK_WRITER_KEY }}

--- a/.github/workflows/galaxy-deepseek-tests-impl.yaml
+++ b/.github/workflows/galaxy-deepseek-tests-impl.yaml
@@ -84,11 +84,18 @@ jobs:
           slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
           owner: ${{ matrix.test-group.owner_id }}
       # - name: Save environment data
-      #   if: ${{ (matrix.test-group.name == 'Galaxy Falcon7b demo tests' || matrix.test-group.name == 'Galaxy DeepSeek tests') && !cancelled() }}
+      #   id: save-environment-data
+      #   if: ${{ !cancelled() }}
       #   run: |
-      #     python3 .github/scripts/data_analysis/create_benchmark_with_environment_json.py
+      #     if [ -d "generated/benchmark_data" ]; then
+      #       echo "has_benchmark_data=true" >> $GITHUB_OUTPUT
+      #       python3 .github/scripts/data_analysis/create_benchmark_with_environment_json.py
+      #     else
+      #       echo "::warning::Benchmark data directory 'generated/benchmark_data' does not exist"
+      #       echo "has_benchmark_data=false" >> $GITHUB_OUTPUT
+      #     fi
       # - name: Upload benchmark data
-      #   if: ${{ (matrix.test-group.name == 'Galaxy Falcon7b demo tests' || matrix.test-group.name == 'Galaxy DeepSeek tests') && !cancelled() }}
+      #   if: ${{ !cancelled() && steps.save-environment-data.conclusion == 'success' && steps.save-environment-data.outputs.has_benchmark_data == 'true' }}
       #   uses: tenstorrent/tt-metal/.github/actions/upload-data-via-sftp@main
       #   with:
       #     ssh-private-key: ${{ secrets.SFTP_BENCHMARK_WRITER_KEY }}

--- a/.github/workflows/galaxy-demo-tests-impl.yaml
+++ b/.github/workflows/galaxy-demo-tests-impl.yaml
@@ -79,11 +79,18 @@ jobs:
           slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
           owner: ${{ matrix.test-group.owner_id }}
       - name: Save environment data
-        if: ${{ (matrix.test-group.name == 'Galaxy Falcon7b demo tests' || matrix.test-group.name == 'Galaxy Llama3 demo tests') && !cancelled() }}
+        id: save-environment-data
+        if: ${{ !cancelled() }}
         run: |
-          python3 .github/scripts/data_analysis/create_benchmark_with_environment_json.py
+          if [ -d "generated/benchmark_data" ]; then
+            echo "has_benchmark_data=true" >> $GITHUB_OUTPUT
+            python3 .github/scripts/data_analysis/create_benchmark_with_environment_json.py
+          else
+            echo "::warning::Benchmark data directory 'generated/benchmark_data' does not exist"
+            echo "has_benchmark_data=false" >> $GITHUB_OUTPUT
+          fi
       - name: Upload benchmark data
-        if: ${{ (matrix.test-group.name == 'Galaxy Falcon7b demo tests' || matrix.test-group.name == 'Galaxy Llama3 demo tests') && !cancelled() }}
+        if: ${{ !cancelled() && steps.save-environment-data.conclusion == 'success' && steps.save-environment-data.outputs.has_benchmark_data == 'true' }}
         uses: tenstorrent/tt-metal/.github/actions/upload-data-via-sftp@main
         with:
           ssh-private-key: ${{ secrets.SFTP_BENCHMARK_WRITER_KEY }}

--- a/.github/workflows/galaxy-model-perf-tests-impl.yaml
+++ b/.github/workflows/galaxy-model-perf-tests-impl.yaml
@@ -158,9 +158,19 @@ jobs:
           install_wheel: true
           run_args: |
             ${{ matrix.test-group.cmd }}
+      - name: Check if benchmark data directory exists
+        id: check-benchmark-data-directory
+        if: ${{ matrix.test-group.save-perf-data && !cancelled() }}
+        run: |
+          if [ -d "generated/benchmark_data" ]; then
+            echo "has_benchmark_data=true" >> $GITHUB_OUTPUT
+          else
+            echo "::warning::Benchmark data directory 'generated/benchmark_data' does not exist"
+            echo "has_benchmark_data=false" >> $GITHUB_OUTPUT
+          fi
       - name: Save environment data
         id: save-environment-data
-        if: ${{ matrix.test-group.save-perf-data && !cancelled() }}
+        if: ${{ matrix.test-group.save-perf-data && !cancelled() && steps.check-benchmark-data-directory.outputs.has_benchmark_data == 'true' }}
         uses: ./.github/actions/docker-run
         with:
           docker_image: ${{ inputs.docker-image }}
@@ -171,15 +181,9 @@ jobs:
             -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
           install_wheel: true
           run_args: |
-            if [ -d "generated/benchmark_data" ]; then
-              echo "has_benchmark_data=true" >> $GITHUB_OUTPUT
-              python3 .github/scripts/data_analysis/create_benchmark_with_environment_json.py
-            else
-              echo "::warning::Benchmark data directory 'generated/benchmark_data' does not exist"
-              echo "has_benchmark_data=false" >> $GITHUB_OUTPUT
-            fi
+            python3 .github/scripts/data_analysis/create_benchmark_with_environment_json.py
       - name: Upload benchmark data
-        if: ${{ !cancelled() && steps.save-environment-data.conclusion == 'success' && steps.save-environment-data.outputs.has_benchmark_data == 'true' }}
+        if: ${{ matrix.test-group.save-perf-data && !cancelled() && steps.save-environment-data.conclusion == 'success' }}
         uses: ./.github/actions/upload-data-via-sftp
         with:
           ssh-private-key: ${{ secrets.SFTP_BENCHMARK_WRITER_KEY }}

--- a/.github/workflows/galaxy-model-perf-tests-impl.yaml
+++ b/.github/workflows/galaxy-model-perf-tests-impl.yaml
@@ -159,6 +159,7 @@ jobs:
           run_args: |
             ${{ matrix.test-group.cmd }}
       - name: Save environment data
+        id: save-environment-data
         if: ${{ matrix.test-group.save-perf-data && !cancelled() }}
         uses: ./.github/actions/docker-run
         with:
@@ -169,9 +170,16 @@ jobs:
             -e ARCH_NAME=${{ matrix.test-group.arch }}
             -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
           install_wheel: true
-          run_args: python3 .github/scripts/data_analysis/create_benchmark_with_environment_json.py
+          run_args: |
+            if [ -d "generated/benchmark_data" ]; then
+              echo "has_benchmark_data=true" >> $GITHUB_OUTPUT
+              python3 .github/scripts/data_analysis/create_benchmark_with_environment_json.py
+            else
+              echo "::warning::Benchmark data directory 'generated/benchmark_data' does not exist"
+              echo "has_benchmark_data=false" >> $GITHUB_OUTPUT
+            fi
       - name: Upload benchmark data
-        if: ${{ matrix.test-group.save-perf-data && !cancelled() }}
+        if: ${{ !cancelled() && steps.save-environment-data.conclusion == 'success' && steps.save-environment-data.outputs.has_benchmark_data == 'true' }}
         uses: ./.github/actions/upload-data-via-sftp
         with:
           ssh-private-key: ${{ secrets.SFTP_BENCHMARK_WRITER_KEY }}

--- a/.github/workflows/perf-device-models-impl.yaml
+++ b/.github/workflows/perf-device-models-impl.yaml
@@ -368,11 +368,19 @@ jobs:
           echo "device_perf_report_filename=$DEVICE_PERF_REPORT_FILENAME" >> "$GITHUB_OUTPUT"
 
       - name: Save environment data
+        id: save-environment-data
         if: ${{ !cancelled() }}
-        run: python3 /work/.github/scripts/data_analysis/create_benchmark_with_environment_json.py
+        run: |
+          if [ -d "generated/benchmark_data" ]; then
+            echo "has_benchmark_data=true" >> $GITHUB_OUTPUT
+            python3 .github/scripts/data_analysis/create_benchmark_with_environment_json.py
+          else
+            echo "::warning::Benchmark data directory 'generated/benchmark_data' does not exist"
+            echo "has_benchmark_data=false" >> $GITHUB_OUTPUT
+          fi
 
       - name: Upload benchmark data
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.save-environment-data.conclusion == 'success' && steps.save-environment-data.outputs.has_benchmark_data == 'true' }}
         uses: tenstorrent/tt-metal/.github/actions/upload-data-via-sftp@main
         with:
           ssh-private-key: ${{ secrets.SFTP_BENCHMARK_WRITER_KEY }}

--- a/.github/workflows/single-card-demo-tests-impl.yaml
+++ b/.github/workflows/single-card-demo-tests-impl.yaml
@@ -235,7 +235,7 @@ jobs:
           ${{ matrix.test-group.cmd }}
       - name: Save environment data
         id: save-environment-data
-        if: ${{ !cancelled() }}
+        if: ${{ matrix.test-group.runner-label == 'N300' && matrix.test-group.performance && !cancelled()  }}
         shell: bash
         run: |
           if [ -d "generated/benchmark_data" ]; then

--- a/.github/workflows/single-card-demo-tests-impl.yaml
+++ b/.github/workflows/single-card-demo-tests-impl.yaml
@@ -235,7 +235,7 @@ jobs:
           ${{ matrix.test-group.cmd }}
       - name: Save environment data
         id: save-environment-data
-        if: ${{ matrix.test-group.runner-label == 'N300' && matrix.test-group.performance && !cancelled()  }}
+        if: ${{ matrix.test-group.runner-label == 'N300' && matrix.test-group.performance && !cancelled() }}
         shell: bash
         run: |
           if [ -d "generated/benchmark_data" ]; then

--- a/.github/workflows/single-card-demo-tests-impl.yaml
+++ b/.github/workflows/single-card-demo-tests-impl.yaml
@@ -234,11 +234,19 @@ jobs:
           source /work/tests/scripts/single_card/run_single_card_demo_tests.sh
           ${{ matrix.test-group.cmd }}
       - name: Save environment data
-        if: ${{ matrix.test-group.runner-label == 'N300' && matrix.test-group.performance && !cancelled() && matrix.test-group.name != 'whisper' && matrix.test-group.name != 'mobilenetv2' }}
+        id: save-environment-data
+        if: ${{ !cancelled() }}
         shell: bash
-        run: python3 .github/scripts/data_analysis/create_benchmark_with_environment_json.py
+        run: |
+          if [ -d "generated/benchmark_data" ]; then
+            echo "has_benchmark_data=true" >> $GITHUB_OUTPUT
+            python3 .github/scripts/data_analysis/create_benchmark_with_environment_json.py
+          else
+            echo "::warning::Benchmark data directory 'generated/benchmark_data' does not exist"
+            echo "has_benchmark_data=false" >> $GITHUB_OUTPUT
+          fi
       - name: Upload benchmark data
-        if: ${{ matrix.test-group.runner-label == 'N300' && matrix.test-group.performance && !cancelled() && matrix.test-group.name != 'whisper' && matrix.test-group.name != 'mobilenetv2' }}
+        if: ${{ !cancelled() && steps.save-environment-data.conclusion == 'success' && steps.save-environment-data.outputs.has_benchmark_data == 'true' }}
         uses: ./.github/actions/upload-data-via-sftp
         with:
           ssh-private-key: ${{ secrets.SFTP_BENCHMARK_WRITER_KEY }}

--- a/.github/workflows/t3000-demo-tests-impl.yaml
+++ b/.github/workflows/t3000-demo-tests-impl.yaml
@@ -90,12 +90,20 @@ jobs:
           ${{ matrix.test-group.cmd }}
 
       - name: Save environment data
-        if: ${{ (matrix.test-group.name == 't3k_falcon7b_tests' || matrix.test-group.name == 't3k_falcon40b_tests' || matrix.test-group.name == 't3k_mixtral_tests' || matrix.test-group.name == 't3k_qwen25_tests' || matrix.test-group.name == 't3k_qwen3_tests' || matrix.test-group.name == 't3k_llama3_tests' || matrix.test-group.name == 't3k_llama3_70b_tests' || matrix.test-group.name == 't3k_llama3_vision_tests') && !cancelled() }}
+        id: save-environment-data
+        if: ${{ !cancelled() }}
         shell: bash
-        run: python3 .github/scripts/data_analysis/create_benchmark_with_environment_json.py
+        run: |
+          if [ -d "generated/benchmark_data" ]; then
+            echo "has_benchmark_data=true" >> $GITHUB_OUTPUT
+            python3 .github/scripts/data_analysis/create_benchmark_with_environment_json.py
+          else
+            echo "::warning::Benchmark data directory 'generated/benchmark_data' does not exist"
+            echo "has_benchmark_data=false" >> $GITHUB_OUTPUT
+          fi
 
       - name: Upload benchmark data
-        if: ${{ (matrix.test-group.name == 't3k_falcon7b_tests' || matrix.test-group.name == 't3k_falcon40b_tests' || matrix.test-group.name == 't3k_mixtral_tests' || matrix.test-group.name == 't3k_qwen25_tests' || matrix.test-group.name == 't3k_qwen3_tests' || matrix.test-group.name == 't3k_llama3_tests' || matrix.test-group.name == 't3k_llama3_70b_tests' || matrix.test-group.name == 't3k_llama3_vision_tests') && !cancelled() }}
+        if: ${{ !cancelled() && steps.save-environment-data.conclusion == 'success' && steps.save-environment-data.outputs.has_benchmark_data == 'true' }}
         uses: ./.github/actions/upload-data-via-sftp
         with:
           ssh-private-key: ${{ secrets.SFTP_BENCHMARK_WRITER_KEY }}


### PR DESCRIPTION
### Ticket
Closes #18952

### Problem description
When no benchmark reports exist, the report generation and upload step both fail

### What's changed
Follow-up to https://github.com/tenstorrent/tt-metal/pull/31583

- Simplify the workflow conditions to always run `save benchmark data` instead of hardcoding the specific models that need it
- Warn+skip the report generation step if no generated report dir exists
- Run upload step if generated report dir exists AND report generation script passed

### Checklist
- [x] BH demos https://github.com/tenstorrent/tt-metal/actions/runs/18981345197
- [x] BH multi-card demos https://github.com/tenstorrent/tt-metal/actions/runs/18981355131
- [x] Galaxy demos https://github.com/tenstorrent/tt-metal/actions/runs/18981381374 (failures are not related to change)
- [x] Galaxy model perf https://github.com/tenstorrent/tt-metal/actions/runs/19041041947 (failures are not related to change)
- [x] Single card device perf https://github.com/tenstorrent/tt-metal/actions/runs/18981411522
- [x] Single card demos https://github.com/tenstorrent/tt-metal/actions/runs/18982468631
- [x] T3k demos https://github.com/tenstorrent/tt-metal/actions/runs/18981462262 (failures are not related to change)
