### PR TITLE
[skip ci] reduce slack message on triage tool

### DIFF
--- a/.github/actions/slack-report-analyze-workflow-data/action.yaml
+++ b/.github/actions/slack-report-analyze-workflow-data/action.yaml
@@ -29,6 +29,19 @@ runs:
           exit 0
         fi
 
+        # TEMPORARY: Add fake regression for testing - REMOVE BEFORE MERGING
+        echo "🧪 TESTING MODE: Adding fake regression for testing purposes"
+        jq '. + [{
+          "name": "[TEST] Fake Regression Workflow",
+          "workflow_url": "https://github.com/tenantplatform/tt-metal/actions/workflows/test.yaml",
+          "run_url": "https://github.com/tenantplatform/tt-metal/actions/runs/123456789",
+          "commit_url": "https://github.com/tenantplatform/tt-metal/commit/abcdef123456",
+          "commit_short": "abcdef1",
+          "owners": [{"id": "U123456", "name": "test-user"}],
+          "failing_jobs": ["test-job-1", "test-job-2"],
+          "original_owner_names_for_generic_exit": []
+        }]' "$tmp_file" > "${tmp_file}.new" && mv "${tmp_file}.new" "$tmp_file"
+
         # Check if there are any regressions
         REGRESSION_COUNT=$(jq -r 'if (type=="array") then length else 0 end' "$tmp_file")
         if [ "$REGRESSION_COUNT" -eq 0 ]; then

--- a/.github/actions/slack-report-analyze-workflow-data/action.yaml
+++ b/.github/actions/slack-report-analyze-workflow-data/action.yaml
@@ -29,6 +29,19 @@ runs:
           exit 0
         fi
 
+        # TEMPORARY: Add fake regression for testing - REMOVE BEFORE MERGING
+        echo "🧪 TESTING MODE: Adding fake regression for testing purposes"
+        jq '. + [{
+          "name": "[TEST] Fake Regression Workflow",
+          "workflow_url": "https://github.com/tenantplatform/tt-metal/actions/workflows/test.yaml",
+          "run_url": "https://github.com/tenantplatform/tt-metal/actions/runs/123456789",
+          "commit_url": "https://github.com/tenantplatform/tt-metal/commit/abcdef123456",
+          "commit_short": "abcdef1",
+          "owners": [{"id": "U123456", "name": "test-user"}],
+          "failing_jobs": ["test-job-1", "test-job-2"],
+          "original_owner_names_for_generic_exit": []
+        }]' "$tmp_file" > "${tmp_file}.new" && mv "${tmp_file}.new" "$tmp_file"
+
         # Check if there are any regressions
         REGRESSION_COUNT=$(jq -r 'if (type=="array") then length else 0 end' "$tmp_file")
         if [ "$REGRESSION_COUNT" -eq 0 ]; then
@@ -77,12 +90,26 @@ runs:
             "Malformed regressions payload"
           end' "$tmp_file")
 
-        # Extract workflow names from alert_all_message for simple listing
+        # Count total failing workflows from alert_all_message
         # The alert message format is: "*Alerts: failing workflows on main*\n• Workflow Name <url|open> mentions jobs"
-        # We extract just the workflow names (between "• " and "<" or end of line)
-        FAILING_WORKFLOWS_LIST=""
+        # We count lines starting with "• " to get the total number of failing workflows
+        FAILING_WORKFLOWS_COUNT_MESSAGE=""
         if [ -n "$ALERT_RAW" ]; then
-          FAILING_WORKFLOWS_LIST=$(printf '%b' "$ALERT_RAW" | grep -E '^• ' | sed -E 's/^• ([^<]*).*/\1/' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | jq -R -s 'split("\n") | map(select(length > 0)) | if length > 0 then ("\n\n*Note: All currently failing workflows:*\n" + (map("- " + .) | join("\n"))) else "" end' -r)
+          # Decode the alert message and count workflow lines
+          decoded_alert=$(printf '%b' "$ALERT_RAW")
+          total_failing_count=$(echo "$decoded_alert" | grep -E '^• ' | wc -l | tr -d ' ')
+
+          # Subtract regressions (already shown in detail) to get "other" failing workflows
+          other_failing_count=$((total_failing_count - REGRESSION_COUNT))
+
+          # Format the message (singular vs plural)
+          if [ "$other_failing_count" -gt 0 ]; then
+            if [ "$other_failing_count" -eq 1 ]; then
+              FAILING_WORKFLOWS_COUNT_MESSAGE="1 other pipeline is failing"
+            else
+              FAILING_WORKFLOWS_COUNT_MESSAGE="$other_failing_count other pipelines are failing"
+            fi
+          fi
         fi
 
         # Build the payload using blocks for guaranteed line breaks, with text fallback
@@ -91,15 +118,15 @@ runs:
         PAYLOAD=$(jq -cn \
           --arg header "$HEADER" \
           --arg body "$TEXT" \
-          --arg failing_list "$FAILING_WORKFLOWS_LIST" \
+          --arg failing_count_msg "$FAILING_WORKFLOWS_COUNT_MESSAGE" \
           '
           {
-            "text": ($header + "\n" + $body + $failing_list),
+            "text": ($header + "\n" + $body + (if ($failing_count_msg | length > 0) then "\n\n" + $failing_count_msg else "" end)),
             "blocks": ([
               { "type": "section", "text": { "type": "mrkdwn", "text": $header } },
               { "type": "section", "text": { "type": "mrkdwn", "text": $body } }
-            ] + (if ($failing_list | length > 0) then
-              [ { "type": "section", "text": { "type": "mrkdwn", "text": $failing_list } } ]
+            ] + (if ($failing_count_msg | length > 0) then
+              [ { "type": "section", "text": { "type": "mrkdwn", "text": $failing_count_msg } } ]
             else [] end))
           }
         ')
@@ -111,7 +138,7 @@ runs:
       shell: bash
       run: echo "ℹ️ Skipping Slack notification because there are no regressions to report."
 
-    - name: Report Github Pipeline Status Slack Action
+    - name: Report GitHub Pipeline Status Slack Action
       if: steps.build.outputs.has_regressions == 'true'
       uses: slackapi/slack-github-action@v1.26.0
       with:

--- a/.github/actions/slack-report-analyze-workflow-data/action.yaml
+++ b/.github/actions/slack-report-analyze-workflow-data/action.yaml
@@ -24,6 +24,7 @@ runs:
         tmp_file="$(mktemp)"
         printf '%s' "$REGRESSED_RAW" > "$tmp_file"
         if ! jq -e . "$tmp_file" >/dev/null 2>&1; then
+          echo "⚠️ Failed to parse regression list JSON. Skipping Slack notification."
           echo "has_regressions=false" >> "$GITHUB_OUTPUT"
           exit 0
         fi
@@ -31,9 +32,11 @@ runs:
         # Check if there are any regressions
         REGRESSION_COUNT=$(jq -r 'if (type=="array") then length else 0 end' "$tmp_file")
         if [ "$REGRESSION_COUNT" -eq 0 ]; then
+          echo "✅ No regressions detected. Skipping Slack notification (only posting when there are regressions)."
           echo "has_regressions=false" >> "$GITHUB_OUTPUT"
           exit 0
         fi
+        echo "📊 Found $REGRESSION_COUNT regression(s). Preparing Slack notification..."
         echo "has_regressions=true" >> "$GITHUB_OUTPUT"
 
         # Generate the main regression text with detailed information
@@ -102,6 +105,11 @@ runs:
         ')
 
         echo "payload=$PAYLOAD" >> "$GITHUB_OUTPUT"
+
+    - name: Skip Slack notification (no regressions)
+      if: steps.build.outputs.has_regressions != 'true'
+      shell: bash
+      run: echo "ℹ️ Skipping Slack notification because there are no regressions to report."
 
     - name: Report Github Pipeline Status Slack Action
       if: steps.build.outputs.has_regressions == 'true'

--- a/.github/actions/slack-report-analyze-workflow-data/action.yaml
+++ b/.github/actions/slack-report-analyze-workflow-data/action.yaml
@@ -10,7 +10,7 @@ inputs:
   alert_all_message:
     description: "Optional Slack-ready alert text from analyze step output 'alert_all_message'"
     required: false
-  runs:
+runs:
   using: "composite"
   steps:
     - name: Build Slack message from regressions

--- a/.github/actions/slack-report-analyze-workflow-data/action.yaml
+++ b/.github/actions/slack-report-analyze-workflow-data/action.yaml
@@ -107,13 +107,13 @@ runs:
           --arg failing_list "$FAILING_WORKFLOWS_LIST" \
           '
           {
-            text: ($header + "\n" + $body + $failing_list),
-            blocks: [
+            "text": ($header + "\n" + $body + $failing_list),
+            "blocks": ([
               { "type": "section", "text": { "type": "mrkdwn", "text": $header } },
               { "type": "section", "text": { "type": "mrkdwn", "text": $body } }
             ] + (if ($failing_list | length > 0) then
               [ { "type": "section", "text": { "type": "mrkdwn", "text": $failing_list } } ]
-            else [] end)
+            else [] end))
           }
         ')
 

--- a/.github/actions/slack-report-analyze-workflow-data/action.yaml
+++ b/.github/actions/slack-report-analyze-workflow-data/action.yaml
@@ -29,19 +29,6 @@ runs:
           exit 0
         fi
 
-        # TEMPORARY: Add fake regression for testing - REMOVE BEFORE MERGING
-        echo "🧪 TESTING MODE: Adding fake regression for testing purposes"
-        jq '. + [{
-          "name": "[TEST] Fake Regression Workflow",
-          "workflow_url": "https://github.com/tenantplatform/tt-metal/actions/workflows/test.yaml",
-          "run_url": "https://github.com/tenantplatform/tt-metal/actions/runs/123456789",
-          "commit_url": "https://github.com/tenantplatform/tt-metal/commit/abcdef123456",
-          "commit_short": "abcdef1",
-          "owners": [{"id": "U123456", "name": "test-user"}],
-          "failing_jobs": ["test-job-1", "test-job-2"],
-          "original_owner_names_for_generic_exit": []
-        }]' "$tmp_file" > "${tmp_file}.new" && mv "${tmp_file}.new" "$tmp_file"
-
         # Check if there are any regressions
         REGRESSION_COUNT=$(jq -r 'if (type=="array") then length else 0 end' "$tmp_file")
         if [ "$REGRESSION_COUNT" -eq 0 ]; then

--- a/.github/actions/slack-report-analyze-workflow-data/action.yaml
+++ b/.github/actions/slack-report-analyze-workflow-data/action.yaml
@@ -10,7 +10,7 @@ inputs:
   alert_all_message:
     description: "Optional Slack-ready alert text from analyze step output 'alert_all_message'"
     required: false
-runs:
+  runs:
   using: "composite"
   steps:
     - name: Build Slack message from regressions
@@ -24,11 +24,19 @@ runs:
         tmp_file="$(mktemp)"
         printf '%s' "$REGRESSED_RAW" > "$tmp_file"
         if ! jq -e . "$tmp_file" >/dev/null 2>&1; then
-          echo "payload={\"text\":\"Failed to parse regression list\"}" >> "$GITHUB_OUTPUT"
+          echo "has_regressions=false" >> "$GITHUB_OUTPUT"
           exit 0
         fi
 
-        # This part is unchanged: it generates the main regression text
+        # Check if there are any regressions
+        REGRESSION_COUNT=$(jq -r 'if (type=="array") then length else 0 end' "$tmp_file")
+        if [ "$REGRESSION_COUNT" -eq 0 ]; then
+          echo "has_regressions=false" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+        echo "has_regressions=true" >> "$GITHUB_OUTPUT"
+
+        # Generate the main regression text with detailed information
         TEXT=$(jq -r '
           def mentionOwners(owners):
             if (owners | type) == "array" and (owners | length) > 0 then
@@ -54,9 +62,7 @@ runs:
               " (failed " + (item.failing_jobs | join(", ")) + ")"
             else "" end;
 
-          if (type=="array" and length==0) then
-            "✅ No new regressions."
-          elif (type=="array") then
+          if (type=="array" and length > 0) then
             "❌ *Regressions (Pass → Fail):*\n" + (map(
               "- " + .name
               + (if .workflow_url then " — <" + .workflow_url + "|workflow>" else "" end)
@@ -68,43 +74,37 @@ runs:
             "Malformed regressions payload"
           end' "$tmp_file")
 
-        # MINIMAL CHANGE: Define message parts and build a Block Kit payload
-        # 1. Define the components of the message as separate variables
-        HEADER="Aggregate Workflow Data run: <https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}|this run>"
-        ALERT=$(printf '%b' "$ALERT_RAW") # Safely interprets newlines like \n
+        # Extract workflow names from alert_all_message for simple listing
+        # The alert message format is: "*Alerts: failing workflows on main*\n• Workflow Name <url|open> mentions jobs"
+        # We extract just the workflow names (between "• " and "<" or end of line)
+        FAILING_WORKFLOWS_LIST=""
+        if [ -n "$ALERT_RAW" ]; then
+          FAILING_WORKFLOWS_LIST=$(printf '%b' "$ALERT_RAW" | grep -E '^• ' | sed -E 's/^• ([^<]*).*/\1/' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | jq -R -s 'split("\n") | map(select(length > 0)) | if length > 0 then ("\n\n*Note: All currently failing workflows:*\n" + (map("- " + .) | join("\n"))) else "" end' -r)
+        fi
 
-        # 2. Build the payload using blocks for guaranteed line breaks, with text fallback
+        # Build the payload using blocks for guaranteed line breaks, with text fallback
+        HEADER="Aggregate Workflow Data run: <https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}|this run>"
+
         PAYLOAD=$(jq -cn \
           --arg header "$HEADER" \
           --arg body "$TEXT" \
-          --arg alert "$ALERT" \
+          --arg failing_list "$FAILING_WORKFLOWS_LIST" \
           '
-          def chunk_lines(lines; size):
-            if (lines|length) == 0 then []
-            else [ (lines[0:size] | join("\n")) ] + chunk_lines(lines[size:]; size)
-            end;
-
-          ($alert | split("\n")) as $alert_lines |
-          (
-            [
+          {
+            text: ($header + "\n" + $body + $failing_list),
+            blocks: [
               { "type": "section", "text": { "type": "mrkdwn", "text": $header } },
               { "type": "section", "text": { "type": "mrkdwn", "text": $body } }
-            ]
-            + (if ($alert | length > 0) then
-                 [ { "type": "divider" } ]
-                 + (chunk_lines($alert_lines; 15)
-                    | map({ "type": "section", "text": { "type": "mrkdwn", "text": . } }))
-               else [] end)
-          ) as $blocks
-          | {
-              text: ($header + "\n" + $body + (if $alert == "" then "" else "\n\n" + $alert end)),
-              blocks: $blocks
-            }
+            ] + (if ($failing_list | length > 0) then
+              [ { "type": "section", "text": { "type": "mrkdwn", "text": $failing_list } } ]
+            else [] end)
+          }
         ')
 
         echo "payload=$PAYLOAD" >> "$GITHUB_OUTPUT"
 
     - name: Report Github Pipeline Status Slack Action
+      if: steps.build.outputs.has_regressions == 'true'
       uses: slackapi/slack-github-action@v1.26.0
       with:
         payload: ${{ steps.build.outputs.payload }}

--- a/.github/workflows/aggregate-workflow-data.yaml
+++ b/.github/workflows/aggregate-workflow-data.yaml
@@ -244,6 +244,6 @@ jobs:
       - name: Post regressions to Slack
         uses: ./.github/actions/slack-report-analyze-workflow-data
         with:
-          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_AGGREGATE_PIPELINE_STATUS_ALERT }}
+          slack_webhook_url: ${{ secrets.SLACK_TESTING_CHANNEL }}
           regressed_workflows: ${{ needs.analyze-data.outputs.regressed_workflows }}
           alert_all_message: ${{ needs.analyze-data.outputs.alert_all_message }}

--- a/.github/workflows/aggregate-workflow-data.yaml
+++ b/.github/workflows/aggregate-workflow-data.yaml
@@ -244,6 +244,6 @@ jobs:
       - name: Post regressions to Slack
         uses: ./.github/actions/slack-report-analyze-workflow-data
         with:
-          slack_webhook_url: ${{ secrets.SLACK_TESTING_CHANNEL }}
+          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_AGGREGATE_PIPELINE_STATUS_ALERT }}
           regressed_workflows: ${{ needs.analyze-data.outputs.regressed_workflows }}
           alert_all_message: ${{ needs.analyze-data.outputs.alert_all_message }}


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/31600

### Problem description
The pipeline triage tool was sending too many messages and too much information on each message.

### What's changed
The tool now only sends messages when there's a regression, though it will still notify of all the failing workflows when a message is sent. However, the new message for the stayed failing pipelines is much more compact:

<img width="1524" height="288" alt="image" src="https://github.com/user-attachments/assets/0da989cd-7efd-4a15-87ee-822582b3732f" />


### Checklist
- [x] [Aggregate Workflow Data](https://github.com/tenstorrent/tt-metal/actions/workflows/aggregate-workflow-data.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/19039203907