### PR TITLE
Add idle eth and galaxy ttsim c++ tests

### DIFF
--- a/.github/workflows/all-post-commit-workflows.yaml
+++ b/.github/workflows/all-post-commit-workflows.yaml
@@ -165,6 +165,20 @@ jobs:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+  ttsim-unit-tests:
+    if: ${{ github.event.pull_request.head.repo.fork == false }}
+    needs: build-artifact
+    secrets: inherit
+    strategy:
+      fail-fast: false
+    uses: ./.github/workflows/ttsim.yaml
+    with:
+      basic-docker-image: ${{ needs.build-artifact.outputs.basic-dev-docker-image }}
+      test-docker-image: ${{ needs.build-artifact.outputs.ci-test-docker-image }}
+      package-artifact-name: ${{ needs.build-artifact.outputs.packages-artifact-name }}
+      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+      run-metal-cpp-unit-tests: true
 
   run-profiler-regression:
     needs: [build-artifact]

--- a/.github/workflows/ttsim.yaml
+++ b/.github/workflows/ttsim.yaml
@@ -15,10 +15,21 @@ on:
       wheel-artifact-name:
         required: true
         type: string
+      build-artifact-name: # Used only when run-metal-cpp-unit-tests is true
+        required: false
+        type: string
       ttsim-ref:
         required: false
         type: string
-        default: "6a29a2ca053cf30f6540b3af8131398987cd02a5"
+        default: "4f05a65a961d4a3ca14f65ff9633030e0a35358e"
+      timeout:
+        required: false
+        type: number
+        default: 5
+      run-metal-cpp-unit-tests:
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   ttsim-integration:
@@ -265,3 +276,135 @@ jobs:
             tests/ttnn/unit_tests/operations/transformers/test_prefetcher_TG.py \
             tests/ttnn/unit_tests/operations/data_movement/test_reallocate.py \
             tests/ttnn/unit_tests/operations/data_movement/test_tosa_gather.py
+  ttsim-cpp-unit-tests:
+    if: ${{ inputs.run-metal-cpp-unit-tests }}
+    runs-on: tt-ubuntu-2204-small-stable
+    name: "TTSim C++ tests - ${{ matrix.arch }}"
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: wormhole_b0
+            build_suffix: release_wh
+            soc_desc: wormhole_b0_80_arch.yaml
+          - arch: blackhole
+            build_suffix: release_bh
+            soc_desc: blackhole_140_arch.yaml
+    container:
+      image: harbor.ci.tenstorrent.net/${{ inputs.test-docker-image || 'docker-image-unresolved!'}}
+      volumes:
+        - ${{ github.workspace }}/docker-job:/work
+    defaults:
+      run:
+        shell: bash
+        working-directory: /work # https://github.com/actions/runner/issues/878
+    env:
+      TT_METAL_SIMULATOR_HOME: /work/sim
+      TT_METAL_SIMULATOR: /work/sim/libttsim.so
+      TT_METAL_SLOW_DISPATCH_MODE: 1
+    steps:
+      - name: Setup Job
+        uses: tenstorrent/tt-metal/.github/actions/setup-job@5b5c6ff5b54025e165d189371cda93d2b9ef6115
+        timeout-minutes: 10
+        with:
+          build-artifact-name: ${{ inputs.build-artifact-name }}
+          wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
+
+      - name: Checkout ttsim
+        uses: actions/checkout@v4
+        with:
+          repository: tenstorrent/ttsim
+          ref: ${{ inputs.ttsim-ref }}
+          path: docker-job/ttsim
+          token: ${{ secrets.TTSIM_TOKEN }}
+
+      - name: Build ttsim
+        run: |
+          cd /work/ttsim/src
+          ../scripts/make.py _out/${{ matrix.build_suffix }}/libttsim.so
+
+      - name: Install ttsim
+        run: |
+          mkdir -p $TT_METAL_SIMULATOR_HOME
+          cp /work/ttsim/src/_out/${{ matrix.build_suffix }}/libttsim.so $TT_METAL_SIMULATOR_HOME/
+          cp /work/tt_metal/soc_descriptors/${{ matrix.soc_desc }} $TT_METAL_SIMULATOR_HOME/soc_descriptor.yaml
+
+      - name: C++ tests
+        timeout-minutes: ${{ inputs.timeout }}
+        run: |
+          ./build/test/tt_metal/unit_tests_api --gtest_filter="MeshDeviceFixture.IdleEthTestNocStreamRegs"
+          ./build/test/tt_metal/unit_tests_api --gtest_filter="MeshDispatchFixture.IdleEthDRAMLoopbackSingleCore"
+          ./build/test/tt_metal/unit_tests_debug_tools --gtest_filter="DPrintMeshFixture.IdleEthTestPrint"
+          # BH doesn't work on watcher, triggers: ERROR: decode_and_execute_fence: unsupported fence_mode=0x31
+          if [[ "${{ matrix.arch }}" != "blackhole" ]]; then
+            # WH works (very long test, by default for erisc runs at least 0x5f5e1000U cycles)
+            # ./build/test/tt_metal/unit_tests_debug_tools --gtest_filter="MeshWatcherFixture.TensixTestWatcherPause"
+            ./build/test/tt_metal/unit_tests_debug_tools --gtest_filter="MeshWatcherFixture.TestWatcherRingBufferIErisc"
+            ./build/test/tt_metal/unit_tests_debug_tools --gtest_filter="MeshWatcherFixture.TestWatcherStackUsage0"
+            ./build/test/tt_metal/unit_tests_debug_tools --gtest_filter="MeshWatcherFixture.TestWatcherStackUsage16"
+          fi
+          ./build/test/tt_metal/unit_tests_dispatch --gtest_filter="MeshDispatchFixture.TensixIdleEthTestSemaphores"
+          ./build/test/tt_metal/unit_tests_dispatch --gtest_filter="MeshDispatchFixture.EthTestBlank"
+          ./build/test/tt_metal/unit_tests_eth --gtest_filter="BlackholeSingleCardFixture.IdleEthKernelOnIdleErisc0"
+          ./build/test/tt_metal/unit_tests_eth --gtest_filter="BlackholeSingleCardFixture.IdleEthKernelOnIdleErisc1"
+          ./build/test/tt_metal/unit_tests_eth --gtest_filter="BlackholeSingleCardFixture.IdleEthKernelOnBothIdleEriscs"
+  ttsim-galaxy-cpp-unit-tests:
+    if: ${{ inputs.run-metal-cpp-unit-tests }}
+    runs-on: tt-ubuntu-2204-large-stable
+    name: "TTSim Galaxy C++ tests - ${{ matrix.arch }}"
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: wormhole_b0
+            build_suffix: release_wh
+            cluster_desc: tests/tt_metal/tt_fabric/custom_mock_cluster_descriptors/6u_cluster_desc.yaml
+            soc_desc: wormhole_b0_80_arch.yaml
+          - arch: blackhole
+            build_suffix: release_bh
+            cluster_desc: tests/tt_metal/tt_fabric/custom_mock_cluster_descriptors/bh_6u_cluster_desc.yaml
+            soc_desc: blackhole_140_arch.yaml
+    container:
+      image: harbor.ci.tenstorrent.net/${{ inputs.test-docker-image || 'docker-image-unresolved!'}}
+      volumes:
+        - ${{ github.workspace }}/docker-job:/work
+    defaults:
+      run:
+        shell: bash
+        working-directory: /work # https://github.com/actions/runner/issues/878
+    env:
+      TT_METAL_SIMULATOR_HOME: /work/sim
+      TT_METAL_SIMULATOR: /work/sim/libttsim.so
+      TT_METAL_SLOW_DISPATCH_MODE: 1
+      TT_METAL_MOCK_CLUSTER_DESC_PATH: ${{ matrix.cluster_desc }}
+    steps:
+      - name: Setup Job
+        uses: tenstorrent/tt-metal/.github/actions/setup-job@5b5c6ff5b54025e165d189371cda93d2b9ef6115
+        timeout-minutes: 10
+        with:
+          build-artifact-name: ${{ inputs.build-artifact-name }}
+          wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
+
+      - name: Checkout ttsim
+        uses: actions/checkout@v4
+        with:
+          repository: tenstorrent/ttsim
+          ref: ${{ inputs.ttsim-ref }}
+          path: docker-job/ttsim
+          token: ${{ secrets.TTSIM_TOKEN }}
+
+      - name: Build ttsim
+        run: |
+          cd /work/ttsim/src
+          ../scripts/make.py _out/${{ matrix.build_suffix }}/libttsim.so
+
+      - name: Install ttsim
+        run: |
+          mkdir -p $TT_METAL_SIMULATOR_HOME
+          cp /work/ttsim/src/_out/${{ matrix.build_suffix }}/libttsim.so $TT_METAL_SIMULATOR_HOME/
+          cp /work/tt_metal/soc_descriptors/${{ matrix.soc_desc }} $TT_METAL_SIMULATOR_HOME/soc_descriptor.yaml
+
+      - name: C++ tests
+        run: |
+          ./build/test/tt_metal/unit_tests_api --gtest_filter="*StreamRegWrite*"
+          ./build/test/tt_metal/unit_tests_api --gtest_filter="*InlineWrite*"

--- a/tests/tt_metal/tt_fabric/custom_mock_cluster_descriptors/bh_6u_cluster_desc.yaml
+++ b/tests/tt_metal/tt_fabric/custom_mock_cluster_descriptors/bh_6u_cluster_desc.yaml
@@ -1,0 +1,986 @@
+arch:
+  0: blackhole
+  1: blackhole
+  2: blackhole
+  3: blackhole
+  4: blackhole
+  5: blackhole
+  6: blackhole
+  7: blackhole
+  8: blackhole
+  9: blackhole
+  10: blackhole
+  11: blackhole
+  12: blackhole
+  13: blackhole
+  14: blackhole
+  15: blackhole
+  16: blackhole
+  17: blackhole
+  18: blackhole
+  19: blackhole
+  20: blackhole
+  21: blackhole
+  22: blackhole
+  23: blackhole
+  24: blackhole
+  25: blackhole
+  26: blackhole
+  27: blackhole
+  28: blackhole
+  29: blackhole
+  30: blackhole
+  31: blackhole
+chips:
+  {}
+chip_unique_ids:
+  31: 18000057687498386527
+  30: 17827664586283018711
+  29: 17729666324248329701
+  12: 9254315971673938759
+  11: 8558251823949636304
+  10: 8398519000950122463
+  9: 7867658919614253179
+  8: 7696263324851467796
+  7: 7329613958042834261
+  6: 5899180777263775392
+  5: 4586942773988671685
+  4: 3978929061170089408
+  3: 3695165867672513834
+  2: 2554916885567530593
+  1: 1610994841858702283
+  0: 1192549272172692402
+  13: 10185481421470358783
+  14: 10589431952890382549
+  15: 10899240716452696746
+  16: 11480234328424954291
+  17: 11580537769140083001
+  18: 11674716623568841816
+  19: 12208914407662252145
+  20: 12334303447139205565
+  21: 12612950382095961218
+  22: 13114962889080518959
+  23: 13309925733935710392
+  24: 13862837609779861109
+  25: 15162063362952523353
+  26: 16202007236135034767
+  27: 16744895884727654151
+  28: 16780866337068792972
+ethernet_connections:
+  -
+    - chip: 0
+      chan: 2
+    - chip: 2
+      chan: 4
+  -
+    - chip: 0
+      chan: 3
+    - chip: 2
+      chan: 5
+  -
+    - chip: 0
+      chan: 4
+    - chip: 14
+      chan: 2
+  -
+    - chip: 0
+      chan: 5
+    - chip: 14
+      chan: 3
+  -
+    - chip: 0
+      chan: 6
+    - chip: 21
+      chan: 0
+  -
+    - chip: 0
+      chan: 7
+    - chip: 21
+      chan: 1
+  -
+    - chip: 1
+      chan: 2
+    - chip: 20
+      chan: 4
+  -
+    - chip: 1
+      chan: 3
+    - chip: 20
+      chan: 5
+  -
+    - chip: 1
+      chan: 4
+    - chip: 30
+      chan: 4
+  -
+    - chip: 1
+      chan: 5
+    - chip: 30
+      chan: 5
+  -
+    - chip: 1
+      chan: 6
+    - chip: 9
+      chan: 0
+  -
+    - chip: 1
+      chan: 7
+    - chip: 9
+      chan: 1
+  -
+    - chip: 2
+      chan: 6
+    - chip: 6
+      chan: 0
+  -
+    - chip: 2
+      chan: 7
+    - chip: 6
+      chan: 1
+  -
+    - chip: 3
+      chan: 2
+    - chip: 8
+      chan: 4
+  -
+    - chip: 3
+      chan: 3
+    - chip: 8
+      chan: 5
+  -
+    - chip: 3
+      chan: 4
+    - chip: 10
+      chan: 2
+  -
+    - chip: 3
+      chan: 5
+    - chip: 10
+      chan: 3
+  -
+    - chip: 3
+      chan: 6
+    - chip: 28
+      chan: 0
+  -
+    - chip: 3
+      chan: 7
+    - chip: 28
+      chan: 1
+  -
+    - chip: 4
+      chan: 0
+    - chip: 10
+      chan: 6
+  -
+    - chip: 4
+      chan: 1
+    - chip: 10
+      chan: 7
+  -
+    - chip: 4
+      chan: 2
+    - chip: 28
+      chan: 4
+  -
+    - chip: 4
+      chan: 3
+    - chip: 28
+      chan: 5
+  -
+    - chip: 4
+      chan: 4
+    - chip: 15
+      chan: 2
+  -
+    - chip: 4
+      chan: 5
+    - chip: 15
+      chan: 3
+  -
+    - chip: 4
+      chan: 6
+    - chip: 25
+      chan: 6
+  -
+    - chip: 4
+      chan: 7
+    - chip: 25
+      chan: 7
+  -
+    - chip: 5
+      chan: 2
+    - chip: 23
+      chan: 4
+  -
+    - chip: 5
+      chan: 3
+    - chip: 23
+      chan: 5
+  -
+    - chip: 5
+      chan: 4
+    - chip: 19
+      chan: 2
+  -
+    - chip: 5
+      chan: 5
+    - chip: 19
+      chan: 3
+  -
+    - chip: 5
+      chan: 6
+    - chip: 22
+      chan: 0
+  -
+    - chip: 5
+      chan: 7
+    - chip: 22
+      chan: 1
+  -
+    - chip: 6
+      chan: 4
+    - chip: 21
+      chan: 2
+  -
+    - chip: 6
+      chan: 5
+    - chip: 21
+      chan: 3
+  -
+    - chip: 6
+      chan: 6
+    - chip: 31
+      chan: 6
+  -
+    - chip: 6
+      chan: 7
+    - chip: 31
+      chan: 7
+  -
+    - chip: 7
+      chan: 2
+    - chip: 10
+      chan: 4
+  -
+    - chip: 7
+      chan: 3
+    - chip: 10
+      chan: 5
+  -
+    - chip: 7
+      chan: 4
+    - chip: 19
+      chan: 4
+  -
+    - chip: 7
+      chan: 5
+    - chip: 19
+      chan: 5
+  -
+    - chip: 7
+      chan: 6
+    - chip: 15
+      chan: 0
+  -
+    - chip: 7
+      chan: 7
+    - chip: 15
+      chan: 1
+  -
+    - chip: 8
+      chan: 6
+    - chip: 31
+      chan: 0
+  -
+    - chip: 8
+      chan: 7
+    - chip: 31
+      chan: 1
+  -
+    - chip: 9
+      chan: 2
+    - chip: 16
+      chan: 4
+  -
+    - chip: 9
+      chan: 3
+    - chip: 16
+      chan: 5
+  -
+    - chip: 9
+      chan: 4
+    - chip: 18
+      chan: 4
+  -
+    - chip: 9
+      chan: 5
+    - chip: 18
+      chan: 5
+  -
+    - chip: 9
+      chan: 6
+    - chip: 12
+      chan: 6
+  -
+    - chip: 9
+      chan: 7
+    - chip: 12
+      chan: 7
+  -
+    - chip: 11
+      chan: 4
+    - chip: 23
+      chan: 2
+  -
+    - chip: 11
+      chan: 5
+    - chip: 23
+      chan: 3
+  -
+    - chip: 11
+      chan: 6
+    - chip: 27
+      chan: 0
+  -
+    - chip: 11
+      chan: 7
+    - chip: 27
+      chan: 1
+  -
+    - chip: 12
+      chan: 0
+    - chip: 19
+      chan: 6
+  -
+    - chip: 12
+      chan: 1
+    - chip: 19
+      chan: 7
+  -
+    - chip: 12
+      chan: 2
+    - chip: 22
+      chan: 4
+  -
+    - chip: 12
+      chan: 3
+    - chip: 22
+      chan: 5
+  -
+    - chip: 12
+      chan: 4
+    - chip: 15
+      chan: 4
+  -
+    - chip: 12
+      chan: 5
+    - chip: 15
+      chan: 5
+  -
+    - chip: 13
+      chan: 0
+    - chip: 24
+      chan: 6
+  -
+    - chip: 13
+      chan: 1
+    - chip: 24
+      chan: 7
+  -
+    - chip: 13
+      chan: 2
+    - chip: 17
+      chan: 4
+  -
+    - chip: 13
+      chan: 3
+    - chip: 17
+      chan: 5
+  -
+    - chip: 13
+      chan: 4
+    - chip: 16
+      chan: 2
+  -
+    - chip: 13
+      chan: 5
+    - chip: 16
+      chan: 3
+  -
+    - chip: 13
+      chan: 6
+    - chip: 29
+      chan: 6
+  -
+    - chip: 13
+      chan: 7
+    - chip: 29
+      chan: 7
+  -
+    - chip: 14
+      chan: 4
+    - chip: 30
+      chan: 2
+  -
+    - chip: 14
+      chan: 5
+    - chip: 30
+      chan: 3
+  -
+    - chip: 14
+      chan: 6
+    - chip: 25
+      chan: 0
+  -
+    - chip: 14
+      chan: 7
+    - chip: 25
+      chan: 1
+  -
+    - chip: 15
+      chan: 6
+    - chip: 18
+      chan: 6
+  -
+    - chip: 15
+      chan: 7
+    - chip: 18
+      chan: 7
+  -
+    - chip: 16
+      chan: 0
+    - chip: 20
+      chan: 6
+  -
+    - chip: 16
+      chan: 1
+    - chip: 20
+      chan: 7
+  -
+    - chip: 16
+      chan: 6
+    - chip: 22
+      chan: 6
+  -
+    - chip: 16
+      chan: 7
+    - chip: 22
+      chan: 7
+  -
+    - chip: 17
+      chan: 0
+    - chip: 26
+      chan: 6
+  -
+    - chip: 17
+      chan: 1
+    - chip: 26
+      chan: 7
+  -
+    - chip: 17
+      chan: 6
+    - chip: 27
+      chan: 6
+  -
+    - chip: 17
+      chan: 7
+    - chip: 27
+      chan: 7
+  -
+    - chip: 18
+      chan: 0
+    - chip: 30
+      chan: 6
+  -
+    - chip: 18
+      chan: 1
+    - chip: 30
+      chan: 7
+  -
+    - chip: 18
+      chan: 2
+    - chip: 25
+      chan: 4
+  -
+    - chip: 18
+      chan: 3
+    - chip: 25
+      chan: 5
+  -
+    - chip: 20
+      chan: 2
+    - chip: 24
+      chan: 4
+  -
+    - chip: 20
+      chan: 3
+    - chip: 24
+      chan: 5
+  -
+    - chip: 21
+      chan: 4
+    - chip: 25
+      chan: 2
+  -
+    - chip: 21
+      chan: 5
+    - chip: 25
+      chan: 3
+  -
+    - chip: 21
+      chan: 6
+    - chip: 28
+      chan: 6
+  -
+    - chip: 21
+      chan: 7
+    - chip: 28
+      chan: 7
+  -
+    - chip: 22
+      chan: 2
+    - chip: 29
+      chan: 4
+  -
+    - chip: 22
+      chan: 3
+    - chip: 29
+      chan: 5
+  -
+    - chip: 23
+      chan: 6
+    - chip: 29
+      chan: 0
+  -
+    - chip: 23
+      chan: 7
+    - chip: 29
+      chan: 1
+  -
+    - chip: 24
+      chan: 2
+    - chip: 26
+      chan: 4
+  -
+    - chip: 24
+      chan: 3
+    - chip: 26
+      chan: 5
+  -
+    - chip: 27
+      chan: 4
+    - chip: 29
+      chan: 2
+  -
+    - chip: 27
+      chan: 5
+    - chip: 29
+      chan: 3
+  -
+    - chip: 28
+      chan: 2
+    - chip: 31
+      chan: 4
+  -
+    - chip: 28
+      chan: 3
+    - chip: 31
+      chan: 5
+ethernet_connections_to_remote_devices:
+  []
+chips_with_mmio:
+  - 0: 8
+  - 1: 4
+  - 2: 9
+  - 3: 25
+  - 4: 29
+  - 5: 16
+  - 6: 11
+  - 7: 18
+  - 8: 30
+  - 9: 6
+  - 10: 26
+  - 11: 20
+  - 12: 19
+  - 13: 7
+  - 14: 13
+  - 15: 28
+  - 16: 5
+  - 17: 3
+  - 18: 14
+  - 19: 23
+  - 20: 2
+  - 21: 15
+  - 22: 22
+  - 23: 21
+  - 24: 1
+  - 25: 10
+  - 26: 0
+  - 27: 17
+  - 28: 31
+  - 29: 24
+  - 30: 12
+  - 31: 27
+io_device_type: PCIe
+harvesting:
+  0:
+    noc_translation: true
+    harvest_mask: 256
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 288
+    pcie_harvesting_mask: 1
+    l2cpu_harvesting_mask: 0
+  1:
+    noc_translation: true
+    harvest_mask: 2
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 288
+    pcie_harvesting_mask: 1
+    l2cpu_harvesting_mask: 0
+  2:
+    noc_translation: true
+    harvest_mask: 16
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 288
+    pcie_harvesting_mask: 1
+    l2cpu_harvesting_mask: 0
+  3:
+    noc_translation: true
+    harvest_mask: 1
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 288
+    pcie_harvesting_mask: 1
+    l2cpu_harvesting_mask: 0
+  4:
+    noc_translation: true
+    harvest_mask: 512
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 288
+    pcie_harvesting_mask: 1
+    l2cpu_harvesting_mask: 0
+  5:
+    noc_translation: true
+    harvest_mask: 2048
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 288
+    pcie_harvesting_mask: 1
+    l2cpu_harvesting_mask: 0
+  6:
+    noc_translation: true
+    harvest_mask: 4
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 288
+    pcie_harvesting_mask: 1
+    l2cpu_harvesting_mask: 0
+  7:
+    noc_translation: true
+    harvest_mask: 128
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 288
+    pcie_harvesting_mask: 1
+    l2cpu_harvesting_mask: 0
+  8:
+    noc_translation: true
+    harvest_mask: 8192
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 288
+    pcie_harvesting_mask: 1
+    l2cpu_harvesting_mask: 0
+  9:
+    noc_translation: true
+    harvest_mask: 16
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 288
+    pcie_harvesting_mask: 1
+    l2cpu_harvesting_mask: 0
+  10:
+    noc_translation: true
+    harvest_mask: 8
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 288
+    pcie_harvesting_mask: 1
+    l2cpu_harvesting_mask: 0
+  11:
+    noc_translation: true
+    harvest_mask: 16
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 288
+    pcie_harvesting_mask: 1
+    l2cpu_harvesting_mask: 0
+  12:
+    noc_translation: true
+    harvest_mask: 8192
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 288
+    pcie_harvesting_mask: 1
+    l2cpu_harvesting_mask: 0
+  13:
+    noc_translation: true
+    harvest_mask: 16
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 288
+    pcie_harvesting_mask: 1
+    l2cpu_harvesting_mask: 0
+  14:
+    noc_translation: true
+    harvest_mask: 64
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 288
+    pcie_harvesting_mask: 1
+    l2cpu_harvesting_mask: 0
+  15:
+    noc_translation: true
+    harvest_mask: 512
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 288
+    pcie_harvesting_mask: 1
+    l2cpu_harvesting_mask: 0
+  16:
+    noc_translation: true
+    harvest_mask: 64
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 288
+    pcie_harvesting_mask: 1
+    l2cpu_harvesting_mask: 0
+  17:
+    noc_translation: true
+    harvest_mask: 2048
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 288
+    pcie_harvesting_mask: 1
+    l2cpu_harvesting_mask: 0
+  18:
+    noc_translation: true
+    harvest_mask: 256
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 288
+    pcie_harvesting_mask: 1
+    l2cpu_harvesting_mask: 0
+  19:
+    noc_translation: true
+    harvest_mask: 32
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 288
+    pcie_harvesting_mask: 1
+    l2cpu_harvesting_mask: 0
+  20:
+    noc_translation: true
+    harvest_mask: 128
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 288
+    pcie_harvesting_mask: 1
+    l2cpu_harvesting_mask: 0
+  21:
+    noc_translation: true
+    harvest_mask: 16
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 288
+    pcie_harvesting_mask: 1
+    l2cpu_harvesting_mask: 0
+  22:
+    noc_translation: true
+    harvest_mask: 1
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 288
+    pcie_harvesting_mask: 1
+    l2cpu_harvesting_mask: 0
+  23:
+    noc_translation: true
+    harvest_mask: 8
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 288
+    pcie_harvesting_mask: 1
+    l2cpu_harvesting_mask: 0
+  24:
+    noc_translation: true
+    harvest_mask: 1024
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 288
+    pcie_harvesting_mask: 1
+    l2cpu_harvesting_mask: 0
+  25:
+    noc_translation: true
+    harvest_mask: 2
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 288
+    pcie_harvesting_mask: 1
+    l2cpu_harvesting_mask: 0
+  26:
+    noc_translation: true
+    harvest_mask: 4
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 288
+    pcie_harvesting_mask: 1
+    l2cpu_harvesting_mask: 0
+  27:
+    noc_translation: true
+    harvest_mask: 4
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 288
+    pcie_harvesting_mask: 1
+    l2cpu_harvesting_mask: 0
+  28:
+    noc_translation: true
+    harvest_mask: 2048
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 288
+    pcie_harvesting_mask: 1
+    l2cpu_harvesting_mask: 0
+  29:
+    noc_translation: true
+    harvest_mask: 32
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 288
+    pcie_harvesting_mask: 1
+    l2cpu_harvesting_mask: 0
+  30:
+    noc_translation: true
+    harvest_mask: 2048
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 288
+    pcie_harvesting_mask: 1
+    l2cpu_harvesting_mask: 0
+  31:
+    noc_translation: true
+    harvest_mask: 1
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 288
+    pcie_harvesting_mask: 1
+    l2cpu_harvesting_mask: 0
+chip_to_boardtype:
+  0: ubb_blackhole
+  1: ubb_blackhole
+  2: ubb_blackhole
+  3: ubb_blackhole
+  4: ubb_blackhole
+  5: ubb_blackhole
+  6: ubb_blackhole
+  7: ubb_blackhole
+  8: ubb_blackhole
+  9: ubb_blackhole
+  10: ubb_blackhole
+  11: ubb_blackhole
+  12: ubb_blackhole
+  13: ubb_blackhole
+  14: ubb_blackhole
+  15: ubb_blackhole
+  16: ubb_blackhole
+  17: ubb_blackhole
+  18: ubb_blackhole
+  19: ubb_blackhole
+  20: ubb_blackhole
+  21: ubb_blackhole
+  22: ubb_blackhole
+  23: ubb_blackhole
+  24: ubb_blackhole
+  25: ubb_blackhole
+  26: ubb_blackhole
+  27: ubb_blackhole
+  28: ubb_blackhole
+  29: ubb_blackhole
+  30: ubb_blackhole
+  31: ubb_blackhole
+chip_to_bus_id:
+  0: 0x0042
+  1: 0x0004
+  2: 0x0041
+  3: 0x0082
+  4: 0x0087
+  5: 0x00c3
+  6: 0x0045
+  7: 0x0084
+  8: 0x0081
+  9: 0x0008
+  10: 0x0083
+  11: 0x00c1
+  12: 0x00c8
+  13: 0x0006
+  14: 0x0043
+  15: 0x0088
+  16: 0x0007
+  17: 0x0005
+  18: 0x0048
+  19: 0x00c4
+  20: 0x0003
+  21: 0x0046
+  22: 0x00c7
+  23: 0x00c2
+  24: 0x0002
+  25: 0x0047
+  26: 0x0001
+  27: 0x00c5
+  28: 0x0086
+  29: 0x00c6
+  30: 0x0044
+  31: 0x0085
+boards:
+  -
+    - board_id: 4884208488465
+    - board_type: ubb_blackhole
+    - chips:
+        - 31
+        - 30
+        - 29
+        - 12
+        - 11
+        - 10
+        - 9
+        - 8
+        - 7
+        - 6
+        - 5
+        - 4
+        - 3
+        - 2
+        - 1
+        - 0
+        - 13
+        - 14
+        - 15
+        - 16
+        - 17
+        - 18
+        - 19
+        - 20
+        - 21
+        - 22
+        - 23
+        - 24
+        - 25
+        - 26
+        - 27
+        - 28
+asic_locations:
+  0: 2
+  1: 4
+  2: 1
+  3: 2
+  4: 7
+  5: 3
+  6: 5
+  7: 4
+  8: 1
+  9: 8
+  10: 3
+  11: 1
+  12: 8
+  13: 6
+  14: 3
+  15: 8
+  16: 7
+  17: 5
+  18: 8
+  19: 4
+  20: 3
+  21: 6
+  22: 7
+  23: 2
+  24: 2
+  25: 7
+  26: 1
+  27: 5
+  28: 6
+  29: 6
+  30: 4
+  31: 5


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Need coverage of eth support for ttsim

### What's changed
Add ttsim c++ tests job. This is expected to be expanded in the future with additional tests for active erisc, etc.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/19041152192
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [x] New/Existing tests provide coverage for changes