### PR TITLE
Adjust perf check target for Llama3.2-90B

### DIFF
--- a/.github/workflows/t3000-demo-tests-impl.yaml
+++ b/.github/workflows/t3000-demo-tests-impl.yaml
@@ -23,26 +23,26 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          { name: "t3k_mixtral_tests", arch: wormhole_b0, cmd: run_t3000_mixtral_tests, timeout: 50, owner_id: U03PUAKE719}, # Harry Zhou
-          { name: "t3k llama3_load_checkpoints tests", arch: wormhole_b0, cmd: run_t3000_llama3_load_checkpoints_tests, timeout: 30, owner_id: U07RY6B5FLJ}, #Gongyu Wang
-          { name: "t3k_falcon40b_tests", arch: wormhole_b0, cmd: run_t3000_falcon40b_tests, timeout: 50, owner_id: U053W15B6JF}, #Djordje Ivanovic
-          { name: "t3k_llama3_tests", arch: wormhole_b0, cmd: run_t3000_llama3_tests, timeout: 60, owner_id: U03PUAKE719}, # Miguel Tairum
-          { name: "t3k_qwen25_tests", arch: wormhole_b0, cmd: run_t3000_qwen25_tests, timeout: 60, owner_id: U03HY7MK4BT}, # Mark O'Connor
-          { name: "t3k_llama3_vision_tests", arch: wormhole_b0, cmd: run_t3000_llama3_vision_tests, timeout: 30, owner_id: U03FJB5TM5Y}, #Colman Glagovich
+          # { name: "t3k_mixtral_tests", arch: wormhole_b0, cmd: run_t3000_mixtral_tests, timeout: 50, owner_id: U03PUAKE719}, # Harry Zhou
+          # { name: "t3k llama3_load_checkpoints tests", arch: wormhole_b0, cmd: run_t3000_llama3_load_checkpoints_tests, timeout: 30, owner_id: U07RY6B5FLJ}, #Gongyu Wang
+          # { name: "t3k_falcon40b_tests", arch: wormhole_b0, cmd: run_t3000_falcon40b_tests, timeout: 50, owner_id: U053W15B6JF}, #Djordje Ivanovic
+          # { name: "t3k_llama3_tests", arch: wormhole_b0, cmd: run_t3000_llama3_tests, timeout: 60, owner_id: U03PUAKE719}, # Miguel Tairum
+          # { name: "t3k_qwen25_tests", arch: wormhole_b0, cmd: run_t3000_qwen25_tests, timeout: 60, owner_id: U03HY7MK4BT}, # Mark O'Connor
+          # { name: "t3k_llama3_vision_tests", arch: wormhole_b0, cmd: run_t3000_llama3_vision_tests, timeout: 30, owner_id: U03FJB5TM5Y}, #Colman Glagovich
           { name: "t3k_llama3_90b_vision_tests", arch: wormhole_b0, cmd: run_t3000_llama3_90b_vision_tests, timeout: 20, owner_id: U07RY6B5FLJ},  #Gongyu Wang
-          { name: "t3k_llama3_70b_tests", arch: wormhole_b0, cmd: run_t3000_llama3_70b_tests, timeout: 60, owner_id: U03FJB5TM5Y}, #Colman Glagovich
-          { name: "t3k_falcon7b_tests", arch: wormhole_b0, cmd: run_t3000_falcon7b_tests, timeout: 90, owner_id: U05RWH3QUPM}, #Salar Hosseini
-          { name: "t3k_resnet50_tests", arch: wormhole_b0, cmd: run_t3000_resnet50_tests, timeout: 50, owner_id: U0837MYG788}, # Marko Radosavljevic
-          { name: "t3k_sentence_bert_tests", arch: wormhole_b0, cmd: run_t3000_sentence_bert_tests, timeout: 75, owner_id: U045U3DEKM4}, # Mohamed Bahnas (Aniruddha Tupe)
-          { name: "t3k sd35_large tests", arch: wormhole_b0, cmd: run_t3000_sd35large_tests, timeout: 60, owner_id: U03FJB5TM5Y}, #Colman Glagovich
-          { name: "t3k flux1-dev tests", arch: wormhole_b0, cmd: run_t3000_flux1_tests, timeout: 30, owner_id: U08TED0JM9D}, #Samuel Adesoye
-          { name: "t3k_mistral_tests", arch: wormhole_b0, cmd: run_t3000_mistral_tests, timeout: 90, owner_id: U0896VBAKFC}, # Pratikkumar Prajapati
-          # Temporary: Run Qwen 3 tests last as they update to a newer transformers version.
-          # This requirements and comment removed when https://github.com/tenstorrent/tt-metal/pull/22608 merges.
-          { name: "t3k_qwen3_tests", arch: wormhole_b0, cmd: run_t3000_qwen3_tests, timeout: 60, owner_id: U03HY7MK4BT}, # Mark O'Connor
-          { name: "t3k_qwen25_vl_tests", arch: wormhole_b0, cmd: run_t3000_qwen25_vl_tests, timeout: 30, owner_id: U07RY6B5FLJ},  #Gongyu Wang
-          { name: "t3k_gemma3_tests", arch: wormhole_b0, cmd: run_t3000_gemma3_tests, timeout: 30, owner_id: U08TJ70UFRT},  # Harry Andrews
-          { name: "t3k_mochi_tests", arch: wormhole_b0, cmd: run_t3000_mochi_tests, timeout: 60, owner_id: U09ELB03XRU}, # Stephen Osborne
+          # { name: "t3k_llama3_70b_tests", arch: wormhole_b0, cmd: run_t3000_llama3_70b_tests, timeout: 60, owner_id: U03FJB5TM5Y}, #Colman Glagovich
+          # { name: "t3k_falcon7b_tests", arch: wormhole_b0, cmd: run_t3000_falcon7b_tests, timeout: 90, owner_id: U05RWH3QUPM}, #Salar Hosseini
+          # { name: "t3k_resnet50_tests", arch: wormhole_b0, cmd: run_t3000_resnet50_tests, timeout: 50, owner_id: U0837MYG788}, # Marko Radosavljevic
+          # { name: "t3k_sentence_bert_tests", arch: wormhole_b0, cmd: run_t3000_sentence_bert_tests, timeout: 75, owner_id: U045U3DEKM4}, # Mohamed Bahnas (Aniruddha Tupe)
+          # { name: "t3k sd35_large tests", arch: wormhole_b0, cmd: run_t3000_sd35large_tests, timeout: 60, owner_id: U03FJB5TM5Y}, #Colman Glagovich
+          # { name: "t3k flux1-dev tests", arch: wormhole_b0, cmd: run_t3000_flux1_tests, timeout: 30, owner_id: U08TED0JM9D}, #Samuel Adesoye
+          # { name: "t3k_mistral_tests", arch: wormhole_b0, cmd: run_t3000_mistral_tests, timeout: 90, owner_id: U0896VBAKFC}, # Pratikkumar Prajapati
+          # # Temporary: Run Qwen 3 tests last as they update to a newer transformers version.
+          # # This requirements and comment removed when https://github.com/tenstorrent/tt-metal/pull/22608 merges.
+          # { name: "t3k_qwen3_tests", arch: wormhole_b0, cmd: run_t3000_qwen3_tests, timeout: 60, owner_id: U03HY7MK4BT}, # Mark O'Connor
+          # { name: "t3k_qwen25_vl_tests", arch: wormhole_b0, cmd: run_t3000_qwen25_vl_tests, timeout: 30, owner_id: U07RY6B5FLJ},  #Gongyu Wang
+          # { name: "t3k_gemma3_tests", arch: wormhole_b0, cmd: run_t3000_gemma3_tests, timeout: 30, owner_id: U08TJ70UFRT},  # Harry Andrews
+          # { name: "t3k_mochi_tests", arch: wormhole_b0, cmd: run_t3000_mochi_tests, timeout: 60, owner_id: U09ELB03XRU}, # Stephen Osborne
         ]
 
     name: ${{ matrix.test-group.name }}

--- a/.github/workflows/t3000-demo-tests-impl.yaml
+++ b/.github/workflows/t3000-demo-tests-impl.yaml
@@ -23,26 +23,26 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          # { name: "t3k_mixtral_tests", arch: wormhole_b0, cmd: run_t3000_mixtral_tests, timeout: 50, owner_id: U03PUAKE719}, # Harry Zhou
-          # { name: "t3k llama3_load_checkpoints tests", arch: wormhole_b0, cmd: run_t3000_llama3_load_checkpoints_tests, timeout: 30, owner_id: U07RY6B5FLJ}, #Gongyu Wang
-          # { name: "t3k_falcon40b_tests", arch: wormhole_b0, cmd: run_t3000_falcon40b_tests, timeout: 50, owner_id: U053W15B6JF}, #Djordje Ivanovic
-          # { name: "t3k_llama3_tests", arch: wormhole_b0, cmd: run_t3000_llama3_tests, timeout: 60, owner_id: U03PUAKE719}, # Miguel Tairum
-          # { name: "t3k_qwen25_tests", arch: wormhole_b0, cmd: run_t3000_qwen25_tests, timeout: 60, owner_id: U03HY7MK4BT}, # Mark O'Connor
-          # { name: "t3k_llama3_vision_tests", arch: wormhole_b0, cmd: run_t3000_llama3_vision_tests, timeout: 30, owner_id: U03FJB5TM5Y}, #Colman Glagovich
+          { name: "t3k_mixtral_tests", arch: wormhole_b0, cmd: run_t3000_mixtral_tests, timeout: 50, owner_id: U03PUAKE719}, # Harry Zhou
+          { name: "t3k llama3_load_checkpoints tests", arch: wormhole_b0, cmd: run_t3000_llama3_load_checkpoints_tests, timeout: 30, owner_id: U07RY6B5FLJ}, #Gongyu Wang
+          { name: "t3k_falcon40b_tests", arch: wormhole_b0, cmd: run_t3000_falcon40b_tests, timeout: 50, owner_id: U053W15B6JF}, #Djordje Ivanovic
+          { name: "t3k_llama3_tests", arch: wormhole_b0, cmd: run_t3000_llama3_tests, timeout: 60, owner_id: U03PUAKE719}, # Miguel Tairum
+          { name: "t3k_qwen25_tests", arch: wormhole_b0, cmd: run_t3000_qwen25_tests, timeout: 60, owner_id: U03HY7MK4BT}, # Mark O'Connor
+          { name: "t3k_llama3_vision_tests", arch: wormhole_b0, cmd: run_t3000_llama3_vision_tests, timeout: 30, owner_id: U03FJB5TM5Y}, #Colman Glagovich
           { name: "t3k_llama3_90b_vision_tests", arch: wormhole_b0, cmd: run_t3000_llama3_90b_vision_tests, timeout: 20, owner_id: U07RY6B5FLJ},  #Gongyu Wang
-          # { name: "t3k_llama3_70b_tests", arch: wormhole_b0, cmd: run_t3000_llama3_70b_tests, timeout: 60, owner_id: U03FJB5TM5Y}, #Colman Glagovich
-          # { name: "t3k_falcon7b_tests", arch: wormhole_b0, cmd: run_t3000_falcon7b_tests, timeout: 90, owner_id: U05RWH3QUPM}, #Salar Hosseini
-          # { name: "t3k_resnet50_tests", arch: wormhole_b0, cmd: run_t3000_resnet50_tests, timeout: 50, owner_id: U0837MYG788}, # Marko Radosavljevic
-          # { name: "t3k_sentence_bert_tests", arch: wormhole_b0, cmd: run_t3000_sentence_bert_tests, timeout: 75, owner_id: U045U3DEKM4}, # Mohamed Bahnas (Aniruddha Tupe)
-          # { name: "t3k sd35_large tests", arch: wormhole_b0, cmd: run_t3000_sd35large_tests, timeout: 60, owner_id: U03FJB5TM5Y}, #Colman Glagovich
-          # { name: "t3k flux1-dev tests", arch: wormhole_b0, cmd: run_t3000_flux1_tests, timeout: 30, owner_id: U08TED0JM9D}, #Samuel Adesoye
-          # { name: "t3k_mistral_tests", arch: wormhole_b0, cmd: run_t3000_mistral_tests, timeout: 90, owner_id: U0896VBAKFC}, # Pratikkumar Prajapati
-          # # Temporary: Run Qwen 3 tests last as they update to a newer transformers version.
-          # # This requirements and comment removed when https://github.com/tenstorrent/tt-metal/pull/22608 merges.
-          # { name: "t3k_qwen3_tests", arch: wormhole_b0, cmd: run_t3000_qwen3_tests, timeout: 60, owner_id: U03HY7MK4BT}, # Mark O'Connor
-          # { name: "t3k_qwen25_vl_tests", arch: wormhole_b0, cmd: run_t3000_qwen25_vl_tests, timeout: 30, owner_id: U07RY6B5FLJ},  #Gongyu Wang
-          # { name: "t3k_gemma3_tests", arch: wormhole_b0, cmd: run_t3000_gemma3_tests, timeout: 30, owner_id: U08TJ70UFRT},  # Harry Andrews
-          # { name: "t3k_mochi_tests", arch: wormhole_b0, cmd: run_t3000_mochi_tests, timeout: 60, owner_id: U09ELB03XRU}, # Stephen Osborne
+          { name: "t3k_llama3_70b_tests", arch: wormhole_b0, cmd: run_t3000_llama3_70b_tests, timeout: 60, owner_id: U03FJB5TM5Y}, #Colman Glagovich
+          { name: "t3k_falcon7b_tests", arch: wormhole_b0, cmd: run_t3000_falcon7b_tests, timeout: 90, owner_id: U05RWH3QUPM}, #Salar Hosseini
+          { name: "t3k_resnet50_tests", arch: wormhole_b0, cmd: run_t3000_resnet50_tests, timeout: 50, owner_id: U0837MYG788}, # Marko Radosavljevic
+          { name: "t3k_sentence_bert_tests", arch: wormhole_b0, cmd: run_t3000_sentence_bert_tests, timeout: 75, owner_id: U045U3DEKM4}, # Mohamed Bahnas (Aniruddha Tupe)
+          { name: "t3k sd35_large tests", arch: wormhole_b0, cmd: run_t3000_sd35large_tests, timeout: 60, owner_id: U03FJB5TM5Y}, #Colman Glagovich
+          { name: "t3k flux1-dev tests", arch: wormhole_b0, cmd: run_t3000_flux1_tests, timeout: 30, owner_id: U08TED0JM9D}, #Samuel Adesoye
+          { name: "t3k_mistral_tests", arch: wormhole_b0, cmd: run_t3000_mistral_tests, timeout: 90, owner_id: U0896VBAKFC}, # Pratikkumar Prajapati
+          # Temporary: Run Qwen 3 tests last as they update to a newer transformers version.
+          # This requirements and comment removed when https://github.com/tenstorrent/tt-metal/pull/22608 merges.
+          { name: "t3k_qwen3_tests", arch: wormhole_b0, cmd: run_t3000_qwen3_tests, timeout: 60, owner_id: U03HY7MK4BT}, # Mark O'Connor
+          { name: "t3k_qwen25_vl_tests", arch: wormhole_b0, cmd: run_t3000_qwen25_vl_tests, timeout: 30, owner_id: U07RY6B5FLJ},  #Gongyu Wang
+          { name: "t3k_gemma3_tests", arch: wormhole_b0, cmd: run_t3000_gemma3_tests, timeout: 30, owner_id: U08TJ70UFRT},  # Harry Andrews
+          { name: "t3k_mochi_tests", arch: wormhole_b0, cmd: run_t3000_mochi_tests, timeout: 60, owner_id: U09ELB03XRU}, # Stephen Osborne
         ]
 
     name: ${{ matrix.test-group.name }}

--- a/models/tt_transformers/demo/simple_vision_demo.py
+++ b/models/tt_transformers/demo/simple_vision_demo.py
@@ -538,6 +538,7 @@ def test_multimodal_demo_text(
             # Empirical data from CI runs (see https://github.com/tenstorrent/tt-metal/pull/31605) shows that decode performance can vary significantly, sometimes falling well below the nominal target.
             # This wide tolerance is necessary to avoid spurious test failures until CI infrastructure is stabilized or performance variance is reduced.
             ("T3K", "Llama-3.2-90B", 1): (3, 4.17),
+        }
 
         perf_targets = {}
         if run_config in targets_prefill_tok_s:

--- a/models/tt_transformers/demo/simple_vision_demo.py
+++ b/models/tt_transformers/demo/simple_vision_demo.py
@@ -566,4 +566,4 @@ def test_multimodal_demo_text(
         )
 
         if perf_targets:
-            verify_perf(measurements, perf_targets, high_tol_percentage=1.15)
+            verify_perf(measurements, perf_targets, high_tol_percentage=perf_tolerance or 1.15)

--- a/models/tt_transformers/demo/simple_vision_demo.py
+++ b/models/tt_transformers/demo/simple_vision_demo.py
@@ -532,8 +532,9 @@ def test_multimodal_demo_text(
             ("T3K", "Llama-3.2-90B", 1): 15.3,
         }
         targets_decode_tok_s_u = {
-            ("N300", "Llama-3.2-11B", 16): 17,
-            ("T3K", "Llama-3.2-90B", 1): 4.3,
+            ("N300", "Llama-3.2-11B", 16): (17, None),  # None to default to tolerance percentage (1.15)
+            # 1.55 to override default tolerance percentage (1.15); observing variance across different CI machines
+            ("T3K", "Llama-3.2-90B", 1): (8, 1.55),
         }
 
         perf_targets = {}
@@ -544,9 +545,11 @@ def test_multimodal_demo_text(
 
             perf_targets = {
                 "prefill_t/s": targets_prefill_tok_s[run_config],
-                "decode_t/s": targets_decode_tok_s_u[run_config] * max_batch_size,
-                "decode_t/s/u": targets_decode_tok_s_u[run_config],
+                "decode_t/s": targets_decode_tok_s_u[run_config][0] * max_batch_size,
+                "decode_t/s/u": targets_decode_tok_s_u[run_config][0],
             }
+
+            perf_tolerance = targets_decode_tok_s_u[run_config][1]
 
         # Save benchmark data for CI
         N_warmup_iter = {"inference_prefill": 0, "inference_decode": 0}

--- a/models/tt_transformers/demo/simple_vision_demo.py
+++ b/models/tt_transformers/demo/simple_vision_demo.py
@@ -549,7 +549,7 @@ def test_multimodal_demo_text(
                 "decode_t/s/u": targets_decode_tok_s_u[run_config][0],
             }
 
-            perf_tolerance = targets_decode_tok_s_u[run_config][1]
+            perf_tolerance = targets_decode_tok_s_u[run_config][1] or 1.15  # default to 15% tolerance
 
         # Save benchmark data for CI
         N_warmup_iter = {"inference_prefill": 0, "inference_decode": 0}
@@ -566,4 +566,4 @@ def test_multimodal_demo_text(
         )
 
         if perf_targets:
-            verify_perf(measurements, perf_targets, high_tol_percentage=perf_tolerance or 1.15)
+            verify_perf(measurements, perf_targets, high_tol_percentage=perf_tolerance)

--- a/models/tt_transformers/demo/simple_vision_demo.py
+++ b/models/tt_transformers/demo/simple_vision_demo.py
@@ -534,9 +534,10 @@ def test_multimodal_demo_text(
         targets_decode_tok_s_u = {
             ("N300", "Llama-3.2-11B", 16): (17, None),  # None to default to tolerance percentage (1.15)
             # second value to override default tolerance percentage (1.15); observing variance across different CI machines
-            # data on variance across t3k machines in CI: https://github.com/tenstorrent/tt-metal/pull/31605
+            # For T3K Llama-3.2-90B, the decode_t/s/u target is set to 3 with a wide tolerance (4.17, i.e. 317%) due to high variance observed across CI machines.
+            # Empirical data from CI runs (see https://github.com/tenstorrent/tt-metal/pull/31605) shows that decode performance can vary significantly, sometimes falling well below the nominal target.
+            # This wide tolerance is necessary to avoid spurious test failures until CI infrastructure is stabilized or performance variance is reduced.
             ("T3K", "Llama-3.2-90B", 1): (3, 4.17),
-        }
 
         perf_targets = {}
         if run_config in targets_prefill_tok_s:

--- a/models/tt_transformers/demo/simple_vision_demo.py
+++ b/models/tt_transformers/demo/simple_vision_demo.py
@@ -535,10 +535,7 @@ def test_multimodal_demo_text(
             ("N300", "Llama-3.2-11B", 16): (17, None),  # None to default to tolerance percentage (1.15)
             # second value to override default tolerance percentage (1.15); observing variance across different CI machines
             # data on variance across t3k machines in CI: https://github.com/tenstorrent/tt-metal/pull/31605
-            ("T3K", "Llama-3.2-90B", 1): (
-                3,
-                4.17,
-            ),
+            ("T3K", "Llama-3.2-90B", 1): (3, 4.17),
         }
 
         perf_targets = {}

--- a/models/tt_transformers/demo/simple_vision_demo.py
+++ b/models/tt_transformers/demo/simple_vision_demo.py
@@ -533,8 +533,12 @@ def test_multimodal_demo_text(
         }
         targets_decode_tok_s_u = {
             ("N300", "Llama-3.2-11B", 16): (17, None),  # None to default to tolerance percentage (1.15)
-            # 1.76 to override default tolerance percentage (1.15); observing variance across different CI machines
-            ("T3K", "Llama-3.2-90B", 1): (12.5, 1.76),
+            # second value to override default tolerance percentage (1.15); observing variance across different CI machines
+            # data on variance across t3k machines in CI: https://github.com/tenstorrent/tt-metal/pull/31605
+            ("T3K", "Llama-3.2-90B", 1): (
+                3,
+                4.17,
+            ),
         }
 
         perf_targets = {}

--- a/models/tt_transformers/demo/simple_vision_demo.py
+++ b/models/tt_transformers/demo/simple_vision_demo.py
@@ -533,8 +533,8 @@ def test_multimodal_demo_text(
         }
         targets_decode_tok_s_u = {
             ("N300", "Llama-3.2-11B", 16): (17, None),  # None to default to tolerance percentage (1.15)
-            # 1.55 to override default tolerance percentage (1.15); observing variance across different CI machines
-            ("T3K", "Llama-3.2-90B", 1): (8, 1.55),
+            # 1.76 to override default tolerance percentage (1.15); observing variance across different CI machines
+            ("T3K", "Llama-3.2-90B", 1): (12.5, 1.76),
         }
 
         perf_targets = {}


### PR DESCRIPTION
### Ticket
Closes https://github.com/tenstorrent/tt-metal/issues/31574

### Problem description
Copied from the issue:
> Example pipeline: https://github.com/tenstorrent/tt-metal/actions/runs/18936263062/job/54064324363#step:6:398
Decode perf is below target (~1 tok/s/u lower).

Additionally, there seem to be different performance across different CI machines, looking at more CI runs:
| machine | t/s/u |
| --- | --- |
| f10cs06 | 3.1 |
f10cs08 | 12.4 |
f10cs09 | 12.4 |

Note that each machine has multiple recent runs that shows the numbers in the table.

### What's changed
two changes:
- adjust the target performance 
- add support for high variance on t/s/u check

### Checklist
- [x] [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes
  - https://github.com/tenstorrent/tt-metal/actions/runs/19069528119
- [x] revert  [f9bae59](https://github.com/tenstorrent/tt-metal/pull/31605/commits/f9bae59bbbe8f473104104a515e06afe388cf681)
  - through [3d4a71d](https://github.com/tenstorrent/tt-metal/pull/31605/commits/3d4a71d8b07725c32b403ba1c605e91922b82e8d) 