### PR TITLE
#31420:  Do not run data collection steps when the model perf test step does not run

### DIFF
--- a/.github/matrices/all-models.json
+++ b/.github/matrices/all-models.json
@@ -1,8 +1,0 @@
-{
-  "include": [
-    {"model": "falcon7b", "arch": "wormhole_b0", "platform": "N300", "test-path": "models/demos/falcon7b_common/tests", "timeout": 20, "runs-on": ["N300", "pipeline-perf", "bare-metal"], "machine-type": "bare_metal", "extra-args": ""},
-    {"model": "mamba", "arch": "wormhole_b0", "platform": "N300", "test-path": "models/demos/wormhole/mamba/tests", "timeout": 20, "runs-on": ["N300", "pipeline-perf", "bare-metal"], "machine-type": "bare_metal", "extra-args": ""},
-    {"model": "yolov8s", "arch": "wormhole_b0", "platform": "N300", "test-path": "models/demos/yolov8s/tests/perf/", "timeout": 45, "runs-on": ["N300", "pipeline-perf", "bare-metal"], "machine-type": "bare_metal", "extra-args": ""},
-    {"model": "yolov8s", "arch": "blackhole", "platform": "P150", "test-path": "models/demos/yolov8s/tests/perf/", "timeout": 45, "runs-on": ["P150", "pipeline-perf", "bare-metal"], "machine-type": "bare_metal", "extra-args": ""}
-  ]
-}

--- a/.github/matrices/all-models.json
+++ b/.github/matrices/all-models.json
@@ -1,0 +1,8 @@
+{
+  "include": [
+    {"model": "falcon7b", "arch": "wormhole_b0", "platform": "N300", "test-path": "models/demos/falcon7b_common/tests", "timeout": 20, "runs-on": ["N300", "pipeline-perf", "bare-metal"], "machine-type": "bare_metal", "extra-args": ""},
+    {"model": "mamba", "arch": "wormhole_b0", "platform": "N300", "test-path": "models/demos/wormhole/mamba/tests", "timeout": 20, "runs-on": ["N300", "pipeline-perf", "bare-metal"], "machine-type": "bare_metal", "extra-args": ""},
+    {"model": "yolov8s", "arch": "wormhole_b0", "platform": "N300", "test-path": "models/demos/yolov8s/tests/perf/", "timeout": 45, "runs-on": ["N300", "pipeline-perf", "bare-metal"], "machine-type": "bare_metal", "extra-args": ""},
+    {"model": "yolov8s", "arch": "blackhole", "platform": "P150", "test-path": "models/demos/yolov8s/tests/perf/", "timeout": 45, "runs-on": ["P150", "pipeline-perf", "bare-metal"], "machine-type": "bare_metal", "extra-args": ""}
+  ]
+}

--- a/.github/workflows/galaxy-model-perf-tests-impl.yaml
+++ b/.github/workflows/galaxy-model-perf-tests-impl.yaml
@@ -83,6 +83,7 @@ jobs:
           {
             name: "Galaxy DiT Flux.1 model perf tests",
             model-type: "Flux.1-Dev",
+            model-name: "flux1-dev",
             arch: wormhole_b0,
             save-perf-data: true,
             timeout: 60,
@@ -102,6 +103,7 @@ jobs:
           {
             name: "Galaxy Mochi model perf tests",
             model-type: "mochi",
+            model-name: "mochi",
             arch: wormhole_b0,
             save-perf-data: true,
             timeout: 60,
@@ -159,7 +161,7 @@ jobs:
           run_args: |
             ${{ matrix.test-group.cmd }}
       - name: Save environment data
-        if: ${{ matrix.test-group.save-perf-data && !cancelled() }}
+        if: ${{ matrix.test-group.save-perf-data && (inputs.model == 'all' || inputs.model == matrix.test-group.model-name) && !cancelled() }}
         uses: ./.github/actions/docker-run
         with:
           docker_image: ${{ inputs.docker-image }}
@@ -171,7 +173,7 @@ jobs:
           install_wheel: true
           run_args: python3 .github/scripts/data_analysis/create_benchmark_with_environment_json.py
       - name: Upload benchmark data
-        if: ${{ matrix.test-group.save-perf-data && !cancelled() }}
+        if: ${{ matrix.test-group.save-perf-data && (inputs.model == 'all' || inputs.model == matrix.test-group.model-name) && !cancelled() }}
         uses: ./.github/actions/upload-data-via-sftp
         with:
           ssh-private-key: ${{ secrets.SFTP_BENCHMARK_WRITER_KEY }}
@@ -180,7 +182,7 @@ jobs:
           hostname: ${{ secrets.SFTP_BENCHMARK_WRITER_HOSTNAME }}
       - name: Check perf report exists
         id: check-perf-report
-        if: ${{ !(matrix.test-group.save-perf-data) && !cancelled() }}
+        if: ${{ !(matrix.test-group.save-perf-data) && (inputs.model == 'all' || inputs.model == matrix.test-group.model-name) && !cancelled() }}
         run: |
           TODAY=$(date +%Y_%m_%d)
           PERF_REPORT_FILENAME_MODELS="Models_Perf_${TODAY}.csv"
@@ -212,14 +214,14 @@ jobs:
             fi
           fi
       - name: Upload Models perf report
-        if: ${{ !cancelled() && steps.check-perf-report.conclusion == 'success' && !matrix.test-group.tracy}}
+        if: ${{ !cancelled() && steps.check-perf-report.conclusion == 'success' && !matrix.test-group.tracy && (inputs.model == 'all' || inputs.model == matrix.test-group.model-name) }}
         uses: actions/upload-artifact@v4
         timeout-minutes: 10
         with:
           name: perf-report-csv-${{ matrix.test-group.model-type }}-${{ matrix.test-group.arch }}-${{ matrix.test-group.machine-type }}
           path: "${{ steps.check-perf-report.outputs.perf_report_filename }}"
       - name: Upload CCL perf report
-        if: ${{ !cancelled() && steps.check-perf-report.conclusion == 'success' && matrix.test-group.tracy}}
+        if: ${{ !cancelled() && steps.check-perf-report.conclusion == 'success' && matrix.test-group.tracy && (inputs.model == 'all' || inputs.model == matrix.test-group.model-name) }}
         uses: actions/upload-artifact@v4
         timeout-minutes: 10
         with:
@@ -233,7 +235,7 @@ jobs:
           owner: ${{ matrix.test-group.owner_id }}
       - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
         timeout-minutes: 10
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && (inputs.model == 'all' || inputs.model == matrix.test-group.model-name) }}
         with:
           path: generated/test_reports/
           prefix: "test_reports_"

--- a/.github/workflows/galaxy-model-perf-tests.yaml
+++ b/.github/workflows/galaxy-model-perf-tests.yaml
@@ -15,7 +15,9 @@ on:
           - llama_unit_tests
           - llama70b_prefill
           - sd35
+          - flux1-dev
           - sentence_bert
+          - mochi
   schedule:
     - cron: "0 10 * * *"  # Every day at 10:00 UTC
 

--- a/.github/workflows/t3000-model-perf-tests-impl.yaml
+++ b/.github/workflows/t3000-model-perf-tests-impl.yaml
@@ -82,6 +82,7 @@ jobs:
           env python3 models/perf/merge_perf_results.py
       - name: Check perf report exists
         id: check-perf-report
+        if: ${{ inputs.model == 'all' || inputs.model == matrix.test-group.model-name }}
         run: |
           TODAY=$(date +%Y_%m_%d)
           PERF_REPORT_FILENAME_MODELS="Models_Perf_${TODAY}.csv"
@@ -93,6 +94,7 @@ jobs:
             exit 1
           fi
       - name: Upload Models perf report
+        if: ${{ inputs.model == 'all' || inputs.model == matrix.test-group.model-name }}
         uses: actions/upload-artifact@v4
         timeout-minutes: 10
         with:
@@ -105,7 +107,7 @@ jobs:
           owner: ${{ matrix.test-group.owner_id }}
       - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
         timeout-minutes: 10
-        if: ${{ !cancelled() }}
+        if: ${{ (inputs.model == 'all' || inputs.model == matrix.test-group.model-name) && !cancelled() }}
         with:
           path: generated/test_reports/
           prefix: "test_reports_"

--- a/.github/workflows/t3000-model-perf-tests.yaml
+++ b/.github/workflows/t3000-model-perf-tests.yaml
@@ -15,6 +15,8 @@ on:
           - resnet50
           - sentence_bert
           - stable_diffusion_35_large
+          - mochi
+          - flux1-dev
   schedule:
     - cron: "0 */12 * * *" # This cron schedule runs the workflow every 12 hours
 


### PR DESCRIPTION
### Ticket

#31420 

### Problem description

When the developer chooses to run model performance workflows for Galaxy or T3K workflow for a specific model, for the skipped model performance steps, the data collections steps still run and generate errors.

### What's changed

Add conditionals to the data collection steps so that they also only run if the model performance tests step runs.

Misc: Added two new models.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes