### PR TITLE
add function for sem cnt reset  for deepseek ccl

### DIFF
--- a/models/demos/deepseek_v3/tt/ccl.py
+++ b/models/demos/deepseek_v3/tt/ccl.py
@@ -187,3 +187,9 @@ class CCL:
 
         # Merge static config with runtime CCL parameters
         return {**ccl_config, **ccl_params}
+
+    def reset_sem_counters(self):
+        """Reset the semaphore counters for all axes."""
+        self.gather_sem_cnt = [0 for _ in range(self.num_axes)]
+        self.reduce_scatter_sem_cnt = [0 for _ in range(self.num_axes)]
+        self.barrier_sem_cnt = [0 for _ in range(self.num_axes)]


### PR DESCRIPTION
This pull request introduces a new method to help manage semaphore counters for collective communication operations in the `ccl.py` module. The main change is the addition of a utility function to reset internal counters, which can be useful for ensuring correct state during repeated or iterative operations.

Semaphore counter management:

* Added a `reset_sem_counters` method to reset the `gather_sem_cnt`, `reduce_scatter_sem_cnt`, and `barrier_sem_cnt` lists to zero for all axes in the class.### Ticket


### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes
