### PR TITLE
[skip ci] change dev docker tag to semantic version #31087

### DIFF
--- a/.github/workflows/build-docker-artifact.yaml
+++ b/.github/workflows/build-docker-artifact.yaml
@@ -84,45 +84,30 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v3
         with:
-          fetch-depth: 1
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Compute tags
         id: tags
         run: |
-          HASH=$(cat \
-            .github/workflows/build-docker-artifact.yaml \
-            dockerfile/Dockerfile \
-            docs/requirements-docs.txt \
-            install_dependencies.sh \
-            tests/sweep_framework/requirements-sweeps.txt \
-            tt_metal/python_env/requirements-dev.txt \
-            tt_metal/sfpi-info.sh \
-            tt_metal/sfpi-version \
-            scripts/ttexalens_ref.txt \
-            tools/triage/requirements.txt \
-            | sha1sum | cut -d' ' -f1)
-          echo "ci-build-tag=ghcr.io/${{ github.repository }}/tt-metalium/${{ env.CI_BUILD_IMAGE_NAME }}:${HASH}" >> $GITHUB_OUTPUT
-          echo "ci-test-tag=ghcr.io/${{ github.repository }}/tt-metalium/${{ env.CI_TEST_IMAGE_NAME }}:${HASH}" >> $GITHUB_OUTPUT
-          echo "dev-tag=ghcr.io/${{ github.repository }}/tt-metalium/${{ env.DEV_IMAGE_NAME }}:${HASH}" >> $GITHUB_OUTPUT
-
-          BASIC_DEV_HASH=$(cat dockerfile/Dockerfile.basic-dev | sha1sum | cut -d' ' -f1)
-          echo "basic-dev-tag=ghcr.io/${{ github.repository }}/tt-metalium/${{ env.BASIC_DEV_IMAGE_NAME }}:${BASIC_DEV_HASH}" >> $GITHUB_OUTPUT
-          BASIC_TTNN_RUNTIME_HASH=$(cat \
-            dockerfile/Dockerfile.basic-dev \
-            install_dependencies.sh \
-            tt_metal/sfpi-info.sh \
-            tt_metal/sfpi-version \
-            | sha1sum | cut -d' ' -f1)
-          echo "basic-ttnn-runtime-tag=ghcr.io/${{ github.repository }}/tt-metalium/${{ env.BASIC_TTNN_RUNTIME_IMAGE_NAME }}:${BASIC_TTNN_RUNTIME_HASH}" >> $GITHUB_OUTPUT
-
-          MANYLINUX_HASH=$(cat \
-            .github/workflows/build-docker-artifact.yaml \
-            dockerfile/Dockerfile.manylinux \
-            install_dependencies.sh \
-            tt_metal/sfpi-info.sh \
-            tt_metal/sfpi-version \
-            | sha1sum | cut -d' ' -f1)
-          echo "manylinux-tag=ghcr.io/${{ github.repository }}/tt-metalium/${{ env.MANYLINUX_IMAGE_NAME }}:${MANYLINUX_HASH}" >> $GITHUB_OUTPUT
+          # Get the latest semantic version tag matching v[0-9]+.[0-9]+.0 pattern
+          LATEST_VERSION=$(git tag | grep -E '^v[0-9]+\.[0-9]+\.0$' | sort -V | tail -n 1)
+          
+          # Fallback to git describe if no matching tag is found
+          if [ -z "$LATEST_VERSION" ]; then
+            echo "No semantic version tag found, using git describe"
+            LATEST_VERSION=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
+          fi
+          
+          echo "Using version: $LATEST_VERSION"
+          
+          # Use semantic version for all tags
+          echo "ci-build-tag=ghcr.io/${{ github.repository }}/tt-metalium/${{ env.CI_BUILD_IMAGE_NAME }}:${LATEST_VERSION}" >> $GITHUB_OUTPUT
+          echo "ci-test-tag=ghcr.io/${{ github.repository }}/tt-metalium/${{ env.CI_TEST_IMAGE_NAME }}:${LATEST_VERSION}" >> $GITHUB_OUTPUT
+          echo "dev-tag=ghcr.io/${{ github.repository }}/tt-metalium/${{ env.DEV_IMAGE_NAME }}:${LATEST_VERSION}" >> $GITHUB_OUTPUT
+          echo "basic-dev-tag=ghcr.io/${{ github.repository }}/tt-metalium/${{ env.BASIC_DEV_IMAGE_NAME }}:${LATEST_VERSION}" >> $GITHUB_OUTPUT
+          echo "basic-ttnn-runtime-tag=ghcr.io/${{ github.repository }}/tt-metalium/${{ env.BASIC_TTNN_RUNTIME_IMAGE_NAME }}:${LATEST_VERSION}" >> $GITHUB_OUTPUT
+          echo "manylinux-tag=ghcr.io/${{ github.repository }}/tt-metalium/${{ env.MANYLINUX_IMAGE_NAME }}:${LATEST_VERSION}" >> $GITHUB_OUTPUT
 
       # Assume if dev-tag exists, the others will exist too
       - name: Query images exist

--- a/.github/workflows/build-docker-artifact.yaml
+++ b/.github/workflows/build-docker-artifact.yaml
@@ -99,15 +99,66 @@ jobs:
             LATEST_VERSION=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
           fi
           
-          echo "Using version: $LATEST_VERSION"
+          echo "Base semantic version: $LATEST_VERSION"
           
-          # Use semantic version for all tags
-          echo "ci-build-tag=ghcr.io/${{ github.repository }}/tt-metalium/${{ env.CI_BUILD_IMAGE_NAME }}:${LATEST_VERSION}" >> $GITHUB_OUTPUT
-          echo "ci-test-tag=ghcr.io/${{ github.repository }}/tt-metalium/${{ env.CI_TEST_IMAGE_NAME }}:${LATEST_VERSION}" >> $GITHUB_OUTPUT
-          echo "dev-tag=ghcr.io/${{ github.repository }}/tt-metalium/${{ env.DEV_IMAGE_NAME }}:${LATEST_VERSION}" >> $GITHUB_OUTPUT
-          echo "basic-dev-tag=ghcr.io/${{ github.repository }}/tt-metalium/${{ env.BASIC_DEV_IMAGE_NAME }}:${LATEST_VERSION}" >> $GITHUB_OUTPUT
-          echo "basic-ttnn-runtime-tag=ghcr.io/${{ github.repository }}/tt-metalium/${{ env.BASIC_TTNN_RUNTIME_IMAGE_NAME }}:${LATEST_VERSION}" >> $GITHUB_OUTPUT
-          echo "manylinux-tag=ghcr.io/${{ github.repository }}/tt-metalium/${{ env.MANYLINUX_IMAGE_NAME }}:${LATEST_VERSION}" >> $GITHUB_OUTPUT
+          # Generate unique suffix based on content hash of key files for CI/Dev/Test images
+          CONTENT_HASH=$(cat \
+            .github/workflows/build-docker-artifact.yaml \
+            dockerfile/Dockerfile \
+            docs/requirements-docs.txt \
+            install_dependencies.sh \
+            tests/sweep_framework/requirements-sweeps.txt \
+            tt_metal/python_env/requirements-dev.txt \
+            tt_metal/sfpi-info.sh \
+            tt_metal/sfpi-version \
+            scripts/ttexalens_ref.txt \
+            tools/triage/requirements.txt \
+            | sha1sum | cut -c1-8)
+          
+          # Generate unique suffix for basic-dev image
+          BASIC_DEV_HASH=$(cat dockerfile/Dockerfile.basic-dev | sha1sum | cut -c1-8)
+          
+          # Generate unique suffix for basic-ttnn-runtime image
+          BASIC_TTNN_RUNTIME_HASH=$(cat \
+            dockerfile/Dockerfile.basic-dev \
+            install_dependencies.sh \
+            tt_metal/sfpi-info.sh \
+            tt_metal/sfpi-version \
+            | sha1sum | cut -c1-8)
+          
+          # Generate unique suffix for manylinux image
+          MANYLINUX_HASH=$(cat \
+            .github/workflows/build-docker-artifact.yaml \
+            dockerfile/Dockerfile.manylinux \
+            install_dependencies.sh \
+            tt_metal/sfpi-info.sh \
+            tt_metal/sfpi-version \
+            | sha1sum | cut -c1-8)
+          
+          # Combine semantic version with content hash for unique, meaningful tags
+          CI_BUILD_VERSION="${LATEST_VERSION}-${CONTENT_HASH}"
+          CI_TEST_VERSION="${LATEST_VERSION}-${CONTENT_HASH}"
+          DEV_VERSION="${LATEST_VERSION}-${CONTENT_HASH}"
+          BASIC_DEV_VERSION="${LATEST_VERSION}-${BASIC_DEV_HASH}"
+          BASIC_TTNN_RUNTIME_VERSION="${LATEST_VERSION}-${BASIC_TTNN_RUNTIME_HASH}"
+          MANYLINUX_VERSION="${LATEST_VERSION}-${MANYLINUX_HASH}"
+          
+          echo "=== Docker Image Tags ==="
+          echo "CI Build:             ${CI_BUILD_VERSION}"
+          echo "CI Test:              ${CI_TEST_VERSION}"
+          echo "Dev:                  ${DEV_VERSION}"
+          echo "Basic Dev:            ${BASIC_DEV_VERSION}"
+          echo "Basic TTNN Runtime:   ${BASIC_TTNN_RUNTIME_VERSION}"
+          echo "Manylinux:            ${MANYLINUX_VERSION}"
+          echo "========================="
+          
+          # Output the tags
+          echo "ci-build-tag=ghcr.io/${{ github.repository }}/tt-metalium/${{ env.CI_BUILD_IMAGE_NAME }}:${CI_BUILD_VERSION}" >> $GITHUB_OUTPUT
+          echo "ci-test-tag=ghcr.io/${{ github.repository }}/tt-metalium/${{ env.CI_TEST_IMAGE_NAME }}:${CI_TEST_VERSION}" >> $GITHUB_OUTPUT
+          echo "dev-tag=ghcr.io/${{ github.repository }}/tt-metalium/${{ env.DEV_IMAGE_NAME }}:${DEV_VERSION}" >> $GITHUB_OUTPUT
+          echo "basic-dev-tag=ghcr.io/${{ github.repository }}/tt-metalium/${{ env.BASIC_DEV_IMAGE_NAME }}:${BASIC_DEV_VERSION}" >> $GITHUB_OUTPUT
+          echo "basic-ttnn-runtime-tag=ghcr.io/${{ github.repository }}/tt-metalium/${{ env.BASIC_TTNN_RUNTIME_IMAGE_NAME }}:${BASIC_TTNN_RUNTIME_VERSION}" >> $GITHUB_OUTPUT
+          echo "manylinux-tag=ghcr.io/${{ github.repository }}/tt-metalium/${{ env.MANYLINUX_IMAGE_NAME }}:${MANYLINUX_VERSION}" >> $GITHUB_OUTPUT
 
       # Assume if dev-tag exists, the others will exist too
       - name: Query images exist


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/metal-internal-workflows/issues/894)

### Problem description
Kanishk Srivastava's request on 10/30/2025:
So I am assuming that whenever an official release for tt-metal is made (v0.x.0), the dev image that was used in the CI to pass the package and release workflow gets tagged as:
ghcr.io/tenstorrent/tt-metal/tt-metalium/ubuntu-22.04-dev-amd64:v0.x.0


### What's changed
 
For the docker build image, we remove the hash which was created by reading a list of files, we just get the latest release tag and use it directly

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes