### PR TITLE
#22118: delete GS test code and avoid direct WH config

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_attn_matmul.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_attn_matmul.py
@@ -78,7 +78,8 @@ def test_attn_matmul_fp32(num_loops, in_dtype, device):
 
             compute_grid_size = device.compute_with_storage_grid_size()
 
-            compute_kernel_config = ttnn.WormholeComputeKernelConfig(
+            compute_kernel_config = ttnn.init_device_compute_kernel_config(
+                device.arch(),
                 math_fidelity=ttnn.MathFidelity.LoFi,
                 math_approx_mode=True,
                 fp32_dest_acc_en=True,
@@ -421,7 +422,8 @@ def test_group_attn_matmul_fp32(
         else:
             output_mem_config = interleaved_mem_config
 
-        compute_kernel_config = ttnn.WormholeComputeKernelConfig(
+        compute_kernel_config = ttnn.init_device_compute_kernel_config(
+            device.arch(),
             math_fidelity=ttnn.MathFidelity.LoFi,
             math_approx_mode=True,
             fp32_dest_acc_en=True,

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_distributed_layernorm_post_allgather.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_distributed_layernorm_post_allgather.py
@@ -22,7 +22,8 @@ def reference_layernorm(x, gamma, beta, epsilon, is_rmsnorm):
 
 
 def run_layernorm_part_2(inp_shape, n_devices, is_rmsnorm, input_dtype, output_dtype, device, fp32_enabled=False):
-    kernel_config = ttnn.WormholeComputeKernelConfig(
+    kernel_config = ttnn.init_device_compute_kernel_config(
+        device.arch(),
         math_fidelity=ttnn.MathFidelity.HiFi4,  # Highest fidelity
         math_approx_mode=False,
         fp32_dest_acc_en=fp32_enabled,

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_layernorm.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_layernorm.py
@@ -10,7 +10,7 @@ import torch
 import ttnn
 
 
-from models.common.utility_functions import pad_by_zero, torch2tt_tensor, comp_pcc, is_grayskull
+from models.common.utility_functions import pad_by_zero, torch2tt_tensor, comp_pcc
 
 
 def ref_layernorm(x, gamma, beta, eps):
@@ -46,12 +46,12 @@ def run_layernorm_mix_precision_tests(test_id, in_dtype, gamma_dtype, in0_mem_co
         gamma_t = pad_by_zero(gamma, device, in0_mem_config, gamma_dtype)[0]
         beta_t = pad_by_zero(beta, device, in0_mem_config, gamma_dtype)[0]
 
-        if not is_grayskull():
-            compute_kernel_config = ttnn.WormholeComputeKernelConfig(
-                math_fidelity=ttnn.MathFidelity.HiFi4,
-                math_approx_mode=True,
-                fp32_dest_acc_en=True if in_dtype == ttnn.float32 else False,
-            )
+        compute_kernel_config = ttnn.init_device_compute_kernel_config(
+            device.arch(),
+            math_fidelity=ttnn.MathFidelity.HiFi4,
+            math_approx_mode=True,
+            fp32_dest_acc_en=True if in_dtype == ttnn.float32 else False,
+        )
 
         if test_id == 0:
             ttz = ttnn.layer_norm(
@@ -59,7 +59,7 @@ def run_layernorm_mix_precision_tests(test_id, in_dtype, gamma_dtype, in0_mem_co
                 residual_input_tensor=in1_t,
                 epsilon=epsf,
                 memory_config=out_mem_config,
-                compute_kernel_config=compute_kernel_config if not is_grayskull() else None,
+                compute_kernel_config=compute_kernel_config,
             )
         if test_id == 1:
             ttz = ttnn.layer_norm(
@@ -68,7 +68,7 @@ def run_layernorm_mix_precision_tests(test_id, in_dtype, gamma_dtype, in0_mem_co
                 epsilon=epsf,
                 weight=gamma_t,
                 memory_config=out_mem_config,
-                compute_kernel_config=compute_kernel_config if not is_grayskull() else None,
+                compute_kernel_config=compute_kernel_config,
             )
         if test_id == 2:
             ttz = ttnn.layer_norm(
@@ -78,7 +78,7 @@ def run_layernorm_mix_precision_tests(test_id, in_dtype, gamma_dtype, in0_mem_co
                 weight=gamma_t,
                 bias=beta_t,
                 memory_config=out_mem_config,
-                compute_kernel_config=compute_kernel_config if not is_grayskull() else None,
+                compute_kernel_config=compute_kernel_config,
             )
         if test_id == 3:
             ttz = ttnn.rms_norm(
@@ -86,7 +86,7 @@ def run_layernorm_mix_precision_tests(test_id, in_dtype, gamma_dtype, in0_mem_co
                 residual_input_tensor=in1_t,
                 epsilon=epsf,
                 memory_config=out_mem_config,
-                compute_kernel_config=compute_kernel_config if not is_grayskull() else None,
+                compute_kernel_config=compute_kernel_config,
             )
         if test_id == 4:
             ttz = ttnn.rms_norm(
@@ -95,7 +95,7 @@ def run_layernorm_mix_precision_tests(test_id, in_dtype, gamma_dtype, in0_mem_co
                 epsilon=epsf,
                 weight=gamma_t,
                 memory_config=out_mem_config,
-                compute_kernel_config=compute_kernel_config if not is_grayskull() else None,
+                compute_kernel_config=compute_kernel_config,
             )
         if test_id == 5:
             ttz = ttnn.rms_norm(
@@ -105,14 +105,11 @@ def run_layernorm_mix_precision_tests(test_id, in_dtype, gamma_dtype, in0_mem_co
                 weight=gamma_t,
                 bias=beta_t,
                 memory_config=out_mem_config,
-                compute_kernel_config=compute_kernel_config if not is_grayskull() else None,
+                compute_kernel_config=compute_kernel_config,
             )
         if test_id == 6:
             ttz = ttnn.layer_norm(
-                in0_t,
-                epsilon=epsf,
-                memory_config=out_mem_config,
-                compute_kernel_config=compute_kernel_config if not is_grayskull() else None,
+                in0_t, epsilon=epsf, memory_config=out_mem_config, compute_kernel_config=compute_kernel_config
             )
         if test_id == 7:
             ttz = ttnn.layer_norm(
@@ -120,7 +117,7 @@ def run_layernorm_mix_precision_tests(test_id, in_dtype, gamma_dtype, in0_mem_co
                 epsilon=epsf,
                 weight=gamma_t,
                 memory_config=out_mem_config,
-                compute_kernel_config=compute_kernel_config if not is_grayskull() else None,
+                compute_kernel_config=compute_kernel_config,
             )
         if test_id == 8:
             ttz = ttnn.layer_norm(
@@ -129,14 +126,11 @@ def run_layernorm_mix_precision_tests(test_id, in_dtype, gamma_dtype, in0_mem_co
                 weight=gamma_t,
                 bias=beta_t,
                 memory_config=out_mem_config,
-                compute_kernel_config=compute_kernel_config if not is_grayskull() else None,
+                compute_kernel_config=compute_kernel_config,
             )
         if test_id == 9:
             ttz = ttnn.rms_norm(
-                in0_t,
-                epsilon=epsf,
-                memory_config=out_mem_config,
-                compute_kernel_config=compute_kernel_config if not is_grayskull() else None,
+                in0_t, epsilon=epsf, memory_config=out_mem_config, compute_kernel_config=compute_kernel_config
             )
         if test_id == 10:
             ttz = ttnn.rms_norm(
@@ -144,7 +138,7 @@ def run_layernorm_mix_precision_tests(test_id, in_dtype, gamma_dtype, in0_mem_co
                 epsilon=epsf,
                 weight=gamma_t,
                 memory_config=out_mem_config,
-                compute_kernel_config=compute_kernel_config if not is_grayskull() else None,
+                compute_kernel_config=compute_kernel_config,
             )
         if test_id == 11:
             ttz = ttnn.rms_norm(
@@ -153,7 +147,7 @@ def run_layernorm_mix_precision_tests(test_id, in_dtype, gamma_dtype, in0_mem_co
                 weight=gamma_t,
                 bias=beta_t,
                 memory_config=out_mem_config,
-                compute_kernel_config=compute_kernel_config if not is_grayskull() else None,
+                compute_kernel_config=compute_kernel_config,
             )
 
         tt_got_back = ttz.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
@@ -218,8 +212,6 @@ def run_layernorm_mix_precision_tests(test_id, in_dtype, gamma_dtype, in0_mem_co
     ],
 )
 def test_layernorm_mix_precision(test_id, in_dtype, gamma_dtype, in0_mem_config, out_mem_config, device):
-    if is_grayskull() and in_dtype == ttnn.float32:
-        pytest.skip("Skipping float32 tests on Grayskull")
     run_layernorm_mix_precision_tests(test_id, in_dtype, gamma_dtype, in0_mem_config, out_mem_config, device)
 
 

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_layernorm_sharded.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_layernorm_sharded.py
@@ -13,7 +13,7 @@ import math
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import (
     comp_pcc,
 )
-from models.common.utility_functions import torch2tt_tensor, is_wormhole_b0, skip_for_blackhole
+from models.common.utility_functions import torch2tt_tensor
 
 
 def rms_norm(x, dim, gamma, beta, eps):

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_layernorm_sharded.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_layernorm_sharded.py
@@ -13,7 +13,7 @@ import math
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import (
     comp_pcc,
 )
-from models.common.utility_functions import torch2tt_tensor, is_wormhole_b0, is_grayskull, skip_for_blackhole
+from models.common.utility_functions import torch2tt_tensor, is_wormhole_b0, skip_for_blackhole
 
 
 def rms_norm(x, dim, gamma, beta, eps):
@@ -68,9 +68,6 @@ def rms_norm(x, dim, gamma, beta, eps):
 def test_layernorm_sharded_mix_precision_rm(
     test_id, in_dtype, gamma_dtype, gamma_beta_mem_config, out_mem_config, device, width_padding
 ):
-    if is_grayskull() and in_dtype == ttnn.float32:
-        pytest.skip("Skipping float32 tests on Grayskull")
-
     torch.manual_seed(1234)
     in0_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM)
 
@@ -147,10 +144,9 @@ def test_layernorm_sharded_mix_precision_rm(
         inplace=True,
     )
 
-    if not is_grayskull():
-        compute_kernel_config = ttnn.WormholeComputeKernelConfig(
-            math_fidelity=ttnn.MathFidelity.HiFi4, math_approx_mode=True, fp32_dest_acc_en=True
-        )
+    compute_kernel_config = ttnn.init_device_compute_kernel_config(
+        device.arch(), math_fidelity=ttnn.MathFidelity.HiFi4, math_approx_mode=True, fp32_dest_acc_en=True
+    )
 
     if test_id == 0:
         ttz = ttnn.layer_norm(
@@ -159,7 +155,7 @@ def test_layernorm_sharded_mix_precision_rm(
             epsilon=epsf,
             memory_config=out_mem_config,
             program_config=program_config,
-            compute_kernel_config=compute_kernel_config if not is_grayskull() else None,
+            compute_kernel_config=compute_kernel_config,
         )
     if test_id == 1:
         ttz = ttnn.layer_norm(
@@ -169,7 +165,7 @@ def test_layernorm_sharded_mix_precision_rm(
             weight=gamma_t,
             memory_config=out_mem_config,
             program_config=program_config,
-            compute_kernel_config=compute_kernel_config if not is_grayskull() else None,
+            compute_kernel_config=compute_kernel_config,
         )
     if test_id == 2:
         ttz = ttnn.layer_norm(
@@ -180,7 +176,7 @@ def test_layernorm_sharded_mix_precision_rm(
             bias=beta_t,
             memory_config=out_mem_config,
             program_config=program_config,
-            compute_kernel_config=compute_kernel_config if not is_grayskull() else None,
+            compute_kernel_config=compute_kernel_config,
         )
     if test_id == 3:
         ttz = ttnn.rms_norm(
@@ -189,7 +185,7 @@ def test_layernorm_sharded_mix_precision_rm(
             epsilon=epsf,
             memory_config=out_mem_config,
             program_config=program_config,
-            compute_kernel_config=compute_kernel_config if not is_grayskull() else None,
+            compute_kernel_config=compute_kernel_config,
         )
     if test_id == 4:
         ttz = ttnn.rms_norm(
@@ -199,7 +195,7 @@ def test_layernorm_sharded_mix_precision_rm(
             weight=gamma_t,
             memory_config=out_mem_config,
             program_config=program_config,
-            compute_kernel_config=compute_kernel_config if not is_grayskull() else None,
+            compute_kernel_config=compute_kernel_config,
         )
     if test_id == 5:
         ttz = ttnn.rms_norm(
@@ -210,7 +206,7 @@ def test_layernorm_sharded_mix_precision_rm(
             bias=beta_t,
             memory_config=out_mem_config,
             program_config=program_config,
-            compute_kernel_config=compute_kernel_config if not is_grayskull() else None,
+            compute_kernel_config=compute_kernel_config,
         )
     if test_id == 6:
         ttz = ttnn.layer_norm(
@@ -218,7 +214,7 @@ def test_layernorm_sharded_mix_precision_rm(
             epsilon=epsf,
             memory_config=out_mem_config,
             program_config=program_config,
-            compute_kernel_config=compute_kernel_config if not is_grayskull() else None,
+            compute_kernel_config=compute_kernel_config,
         )
     if test_id == 7:
         ttz = ttnn.layer_norm(
@@ -227,7 +223,7 @@ def test_layernorm_sharded_mix_precision_rm(
             weight=gamma_t,
             memory_config=out_mem_config,
             program_config=program_config,
-            compute_kernel_config=compute_kernel_config if not is_grayskull() else None,
+            compute_kernel_config=compute_kernel_config,
         )
     if test_id == 8:
         ttz = ttnn.layer_norm(
@@ -237,7 +233,7 @@ def test_layernorm_sharded_mix_precision_rm(
             bias=beta_t,
             memory_config=out_mem_config,
             program_config=program_config,
-            compute_kernel_config=compute_kernel_config if not is_grayskull() else None,
+            compute_kernel_config=compute_kernel_config,
         )
     if test_id == 9:
         ttz = ttnn.rms_norm(
@@ -245,7 +241,7 @@ def test_layernorm_sharded_mix_precision_rm(
             epsilon=epsf,
             memory_config=out_mem_config,
             program_config=program_config,
-            compute_kernel_config=compute_kernel_config if not is_grayskull() else None,
+            compute_kernel_config=compute_kernel_config,
         )
     if test_id == 10:
         ttz = ttnn.rms_norm(
@@ -254,7 +250,7 @@ def test_layernorm_sharded_mix_precision_rm(
             weight=gamma_t,
             memory_config=out_mem_config,
             program_config=program_config,
-            compute_kernel_config=compute_kernel_config if not is_grayskull() else None,
+            compute_kernel_config=compute_kernel_config,
         )
     if test_id == 11:
         ttz = ttnn.rms_norm(
@@ -264,7 +260,7 @@ def test_layernorm_sharded_mix_precision_rm(
             bias=beta_t,
             memory_config=out_mem_config,
             program_config=program_config,
-            compute_kernel_config=compute_kernel_config if not is_grayskull() else None,
+            compute_kernel_config=compute_kernel_config,
         )
 
     ttz = ttnn.sharded_to_interleaved(ttz, in0_mem_config)
@@ -342,9 +338,6 @@ def test_layernorm_sharded_mix_precision_rm(
 def test_layernorm_1d_sharded_mix_precision_rm(
     test_id, M, K, subblock_w, in_dtype, gamma_dtype, gamma_beta_mem_config, out_mem_config, shard_orientation, device
 ):
-    if is_grayskull() and in_dtype == ttnn.float32:
-        pytest.skip("Skipping float32 tests on Grayskull")
-
     torch.manual_seed(1234)
     in0_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM)
 
@@ -420,7 +413,8 @@ def test_layernorm_1d_sharded_mix_precision_rm(
         block_w=shard_shape[1] // 32,
         inplace=True,
     )
-    compute_kernel_config = ttnn.WormholeComputeKernelConfig(
+    compute_kernel_config = ttnn.init_device_compute_kernel_config(
+        device.arch(),
         math_fidelity=fidelity,
         math_approx_mode=True,
         fp32_dest_acc_en=False,

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_matmul.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_matmul.py
@@ -4,7 +4,7 @@
 
 import pytest
 from loguru import logger
-from models.common.utility_functions import is_wormhole_b0, is_grayskull
+from models.common.utility_functions import is_wormhole_b0
 from models.common.utility_functions import torch2tt_tensor, tt2torch_tensor, pad_by_zero, roundup32
 import torch
 import ttnn
@@ -110,7 +110,6 @@ def test_matmul_1d_in0_batched(
         assert passing
 
 
-@pytest.mark.skipif(is_grayskull(), reason="GS does not support fp32")
 @pytest.mark.parametrize("packer_l1_acc", [True, False], ids=["pack_l1", "no_pack_l1"])
 @pytest.mark.parametrize("fp32_acc_mode", [True, False], ids=["fp32", "no_fp32"])
 @pytest.mark.parametrize("batch", [16, 96])
@@ -189,7 +188,8 @@ def test_linear_fp32_acc_l1(
             mcast_in0=True,
         )
 
-        compute_kernel_config = ttnn.WormholeComputeKernelConfig(
+        compute_kernel_config = ttnn.init_device_compute_kernel_config(
+            device.arch(),
             math_fidelity=ttnn.MathFidelity.LoFi,
             math_approx_mode=True,
             fp32_dest_acc_en=fp32_acc_mode,
@@ -216,7 +216,6 @@ def test_linear_fp32_acc_l1(
         assert passing
 
 
-@pytest.mark.skipif(is_grayskull(), reason="GS does not support fp32")
 @pytest.mark.parametrize("packer_l1_acc", [True, False], ids=["pack_l1", "no_pack_l1"])
 @pytest.mark.parametrize("fp32_acc_mode", [True, False], ids=["fp32", "no_fp32"])
 @pytest.mark.parametrize("in0_sharded", [True, False], ids=["in0_sharded", "in0_unsharded"])
@@ -294,7 +293,8 @@ def test_matmul_no_mcast_fp32_acc_l1(
             per_core_N=N // 32,
         )
 
-        compute_kernel_config = ttnn.WormholeComputeKernelConfig(
+        compute_kernel_config = ttnn.init_device_compute_kernel_config(
+            device.arch(),
             math_fidelity=ttnn.MathFidelity.LoFi,
             math_approx_mode=True,
             fp32_dest_acc_en=fp32_acc_mode,
@@ -321,7 +321,6 @@ def test_matmul_no_mcast_fp32_acc_l1(
         assert passing
 
 
-@pytest.mark.skipif(is_grayskull(), reason="GS does not support fp32")
 @pytest.mark.parametrize("packer_l1_acc", [True, False], ids=["pack_l1", "no_pack_l1"])
 @pytest.mark.parametrize(
     "fp32_acc_mode",
@@ -406,7 +405,8 @@ def test_matmul_1d_fp32_input_output(
             mcast_in0=True,
         )
 
-        compute_kernel_config = ttnn.WormholeComputeKernelConfig(
+        compute_kernel_config = ttnn.init_device_compute_kernel_config(
+            device.arch(),
             math_fidelity=ttnn.MathFidelity.LoFi,
             math_approx_mode=True,
             fp32_dest_acc_en=fp32_acc_mode,
@@ -433,7 +433,6 @@ def test_matmul_1d_fp32_input_output(
         assert passing
 
 
-@pytest.mark.skipif(is_grayskull(), reason="GS does not support fp32")
 @pytest.mark.parametrize("packer_l1_acc", [True, False], ids=["pack_l1", "no_pack_l1"])
 @pytest.mark.parametrize(
     "fp32_acc_mode",
@@ -517,7 +516,8 @@ def test_matmul_no_mcast_fp32_input_output(
             per_core_N=N // 32,
         )
 
-        compute_kernel_config = ttnn.WormholeComputeKernelConfig(
+        compute_kernel_config = ttnn.init_device_compute_kernel_config(
+            device.arch(),
             math_fidelity=ttnn.MathFidelity.LoFi,
             math_approx_mode=True,
             fp32_dest_acc_en=fp32_acc_mode,
@@ -583,8 +583,6 @@ def test_matmul_no_untilize_output_param(
     compute_grid_size = device.compute_with_storage_grid_size()
     if grid_size[0] > compute_grid_size.x or grid_size[1] > compute_grid_size.y:
         pytest.skip(f"Need {grid_size} grid size to run this test but core grid is {compute_grid_size}")
-    if is_grayskull() and (fp32_acc_mode or packer_l1_acc):
-        pytest.skip(f"Need Grayskull doesn't support fp32_acc_mode or packer_l1_acc")
     num_cores = grid_size[0] * grid_size[1]
     in0_shape = [B, H, M, K]
     in1_shape = [B, H, K, N]
@@ -632,18 +630,13 @@ def test_matmul_no_untilize_output_param(
             per_core_N=N // 32,
         )
 
-        if is_grayskull():
-            compute_kernel_config = ttnn.GrayskullComputeKernelConfig(
-                math_fidelity=ttnn.MathFidelity.LoFi,
-                math_approx_mode=True,
-            )
-        else:
-            compute_kernel_config = ttnn.WormholeComputeKernelConfig(
-                math_fidelity=ttnn.MathFidelity.LoFi,
-                math_approx_mode=True,
-                fp32_dest_acc_en=fp32_acc_mode,
-                packer_l1_acc=packer_l1_acc,
-            )
+        compute_kernel_config = ttnn.init_device_compute_kernel_config(
+            device.arch(),
+            math_fidelity=ttnn.MathFidelity.LoFi,
+            math_approx_mode=True,
+            fp32_dest_acc_en=fp32_acc_mode,
+            packer_l1_acc=packer_l1_acc,
+        )
 
         output_t = ttnn.matmul(
             in0_t,

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_matmul_dram_sharded.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_matmul_dram_sharded.py
@@ -146,7 +146,8 @@ def run_test_matmul_in1_dram_sharded(
         fused_activation=None,
     )
 
-    compute_kernel_config = ttnn.WormholeComputeKernelConfig(
+    compute_kernel_config = ttnn.init_device_compute_kernel_config(
+        device.arch(),
         math_fidelity=fidelity,
         math_approx_mode=True,
         fp32_dest_acc_en=True,
@@ -336,7 +337,8 @@ def run_test_matmul_in1_dram_sharded_mm_chain(
         fused_activation=None,
     )
 
-    compute_kernel_config = ttnn.WormholeComputeKernelConfig(
+    compute_kernel_config = ttnn.init_device_compute_kernel_config(
+        device.arch(),
         math_fidelity=fidelity,
         math_approx_mode=True,
         fp32_dest_acc_en=True,
@@ -560,7 +562,8 @@ def test_matmul_2d_in1_dram_sharded(
         fuse_batch=fuse_batch,
     )
 
-    compute_kernel_config = ttnn.WormholeComputeKernelConfig(
+    compute_kernel_config = ttnn.init_device_compute_kernel_config(
+        device.arch(),
         math_fidelity=fidelity,
         math_approx_mode=True,
         fp32_dest_acc_en=fp32_acc_mode,

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_rs_matmul_1d_gather_in0.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_rs_matmul_1d_gather_in0.py
@@ -5,7 +5,7 @@
 import pytest
 from loguru import logger
 import ttnn
-from models.common.utility_functions import is_wormhole_b0, skip_for_wormhole_b0, is_blackhole
+from models.common.utility_functions import is_wormhole_b0, is_blackhole
 from models.common.utility_functions import torch2tt_tensor, tt2torch_tensor, pad_by_zero, roundup32
 import torch
 import itertools

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_softmax.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_softmax.py
@@ -17,7 +17,7 @@ from tt_lib.utils import (
 )
 from models.common.utility_functions import print_diff_argmax, comp_pcc
 from models.common.utility_functions import torch2tt_tensor, tt2torch_tensor, pad_by_zero
-from models.common.utility_functions import is_grayskull, is_blackhole, skip_for_blackhole
+from models.common.utility_functions import is_blackhole, skip_for_blackhole
 
 
 @pytest.mark.parametrize(
@@ -27,9 +27,6 @@ from models.common.utility_functions import is_grayskull, is_blackhole, skip_for
 )
 @pytest.mark.parametrize("inplace", [True, False])
 def test_softmax(device, inplace, dtype):
-    if is_grayskull() and dtype == ttnn.float32:
-        pytest.skip("Skipping float32 tests on Grayskull and Blackhole. For Blackhole see #12349")
-
     torch.manual_seed(0)
     sm_op = ttnn.softmax_in_place if inplace else ttnn.softmax
 
@@ -40,23 +37,22 @@ def test_softmax(device, inplace, dtype):
 
         tt_input_tensor = ttnn.from_torch(input_tensor, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device)
 
-        if not is_grayskull():
-            if dtype == ttnn.float32:
-                compute_kernel_config = ttnn.WormholeComputeKernelConfig(
-                    math_fidelity=ttnn.MathFidelity.HiFi4,
-                    math_approx_mode=False,
-                    fp32_dest_acc_en=True,
-                )
-            else:
-                compute_kernel_config = ttnn.WormholeComputeKernelConfig(
-                    math_fidelity=ttnn.MathFidelity.HiFi4,
-                    math_approx_mode=False,
-                    fp32_dest_acc_en=False,
-                )
+        if dtype == ttnn.float32:
+            compute_kernel_config = ttnn.init_device_compute_kernel_config(
+                device.arch(),
+                math_fidelity=ttnn.MathFidelity.HiFi4,
+                math_approx_mode=False,
+                fp32_dest_acc_en=True,
+            )
+        else:
+            compute_kernel_config = ttnn.init_device_compute_kernel_config(
+                device.arch(),
+                math_fidelity=ttnn.MathFidelity.HiFi4,
+                math_approx_mode=False,
+                fp32_dest_acc_en=False,
+            )
 
-        tt_output_tensor_on_device = sm_op(
-            tt_input_tensor, compute_kernel_config=compute_kernel_config if not is_grayskull() else None
-        )
+        tt_output_tensor_on_device = sm_op(tt_input_tensor, compute_kernel_config=compute_kernel_config)
         tt_output_tensor = ttnn.to_layout(tt_output_tensor_on_device, ttnn.ROW_MAJOR_LAYOUT)
         tt_output_tensor = ttnn.from_device(tt_output_tensor)
         tt_output_tensor = ttnn.to_torch(tt_output_tensor)
@@ -147,9 +143,6 @@ def test_softmax_mix_precision(device, inplace, in_dtype):
     ids=["float32", "bfloat16", "bfloat8_b"],
 )
 def test_scale_mask_softmax_inplace(device, in_dtype, in0_mem_config, causal_mask, seq_len):
-    if is_grayskull() and in_dtype == ttnn.float32:
-        pytest.skip("Skipping float32 tests on Grayskull")
-
     torch.manual_seed(0)
     fuse_head = 2
 
@@ -183,26 +176,23 @@ def test_scale_mask_softmax_inplace(device, in_dtype, in0_mem_config, causal_mas
         input_tensor, dtype=in_dtype, layout=ttnn.TILE_LAYOUT, device=device, memory_config=in0_mem_config
     )
 
-    if not is_grayskull():
-        if in_dtype == ttnn.float32:
-            compute_kernel_config = ttnn.WormholeComputeKernelConfig(
-                math_fidelity=ttnn.MathFidelity.HiFi4,
-                math_approx_mode=False,
-                fp32_dest_acc_en=True,
-            )
-        else:
-            compute_kernel_config = ttnn.WormholeComputeKernelConfig(
-                math_fidelity=ttnn.MathFidelity.HiFi4,
-                math_approx_mode=False,
-                fp32_dest_acc_en=False,
-            )
+    if in_dtype == ttnn.float32:
+        compute_kernel_config = ttnn.init_device_compute_kernel_config(
+            device.arch(),
+            math_fidelity=ttnn.MathFidelity.HiFi4,
+            math_approx_mode=False,
+            fp32_dest_acc_en=True,
+        )
+    else:
+        compute_kernel_config = ttnn.init_device_compute_kernel_config(
+            device.arch(),
+            math_fidelity=ttnn.MathFidelity.HiFi4,
+            math_approx_mode=False,
+            fp32_dest_acc_en=False,
+        )
 
     tt_output = ttnn.scale_mask_softmax_in_place(
-        in1_t,
-        scale,
-        attention_mask_t,
-        is_causal_mask=causal_mask,
-        compute_kernel_config=compute_kernel_config if not is_grayskull() else None,
+        in1_t, scale, attention_mask_t, is_causal_mask=causal_mask, compute_kernel_config=compute_kernel_config
     )
 
     tt_output_tensor = ttnn.to_layout(tt_output, ttnn.ROW_MAJOR_LAYOUT)

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_softmax.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_softmax.py
@@ -17,7 +17,6 @@ from tt_lib.utils import (
 )
 from models.common.utility_functions import print_diff_argmax, comp_pcc
 from models.common.utility_functions import torch2tt_tensor, tt2torch_tensor, pad_by_zero
-from models.common.utility_functions import is_blackhole, skip_for_blackhole
 
 
 @pytest.mark.parametrize(

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_softmax_sharded.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_softmax_sharded.py
@@ -17,7 +17,6 @@ from tt_lib.utils import (
 )
 from models.common.utility_functions import print_diff_argmax, comp_pcc
 from models.common.utility_functions import torch2tt_tensor, tt2torch_tensor, pad_by_zero
-from models.common.utility_functions import is_grayskull
 
 
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 8192}], indirect=True)
@@ -115,9 +114,6 @@ def test_softmax_causal_mask(device, in_dtype, in0_mem_config):
     ids=["float32", "bfloat8_b"],
 )
 def test_softmax(device, in_dtype, in0_mem_config, causal_mask):
-    if is_grayskull() and in_dtype == ttnn.float32:
-        pytest.skip("Skipping float32 tests on Grayskull")
-
     torch.manual_seed(0)
     sm_op = ttnn.scale_mask_softmax_in_place
 
@@ -208,9 +204,6 @@ def test_softmax(device, in_dtype, in0_mem_config, causal_mask):
     ids=["float32", "bfloat8_b"],
 )
 def test_scale_mask_softmax_rm(device, in_dtype, in0_mem_config, causal_mask):
-    if is_grayskull() and in_dtype == ttnn.float32:
-        pytest.skip("Skipping float32 tests on Grayskull")
-
     torch.manual_seed(0)
     sm_op = ttnn.scale_mask_softmax_in_place
 

--- a/tests/ttnn/unit_tests/operations/fused/test_distributed_layernorm.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_distributed_layernorm.py
@@ -65,7 +65,8 @@ def run_distributed_layernorm(
     fp32_enabled=False,
     iterations=1,
 ):
-    compute_kernel_config = ttnn.WormholeComputeKernelConfig(
+    compute_kernel_config = ttnn.init_device_compute_kernel_config(
+        device.arch(),
         math_fidelity=ttnn.MathFidelity.HiFi4,  # Highest fidelity
         math_approx_mode=False,
         fp32_dest_acc_en=fp32_enabled,

--- a/tests/ttnn/unit_tests/operations/fused/test_group_norm.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_group_norm.py
@@ -709,7 +709,8 @@ def test_group_norm_compute_config(device, N, C, H, W, num_groups):
         return tt_output_tensor_host
 
     # Execute low-accuracy groupnorm
-    config_low = ttnn.WormholeComputeKernelConfig(
+    config_low = ttnn.init_device_compute_kernel_config(
+        device.arch(),
         math_fidelity=ttnn.MathFidelity.LoFi,
         math_approx_mode=True,
         fp32_dest_acc_en=False,
@@ -719,7 +720,8 @@ def test_group_norm_compute_config(device, N, C, H, W, num_groups):
     _, pcc_low = comp_pcc(torch_output_tensor, tt_output_low)
 
     # Execute high-accuracy groupnorm
-    config_high = ttnn.WormholeComputeKernelConfig(
+    config_high = ttnn.init_device_compute_kernel_config(
+        device.arch(),
         math_fidelity=ttnn.MathFidelity.HiFi4,
         math_approx_mode=False,
         fp32_dest_acc_en=True,

--- a/tests/ttnn/unit_tests/operations/fused/test_softmax.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_softmax.py
@@ -9,7 +9,7 @@ import torch.nn.functional as F
 
 import ttnn
 from tests.ttnn.utils_for_testing import assert_with_pcc, assert_with_ulp
-from models.common.utility_functions import skip_for_wormhole_b0, torch_random
+from models.common.utility_functions import torch_random
 
 
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 0}], indirect=True)

--- a/tests/ttnn/unit_tests/operations/matmul/test_experimental.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_experimental.py
@@ -11,7 +11,6 @@ from models.common.utility_functions import (
     is_wormhole_b0,
     torch_random,
     is_wormhole_b0,
-    is_grayskull,
     is_blackhole,
 )
 from tests.ttnn.utils_for_testing import assert_with_pcc
@@ -203,7 +202,8 @@ def test_ttnn_matmul_dram_sharded(device, m_size, k_size, n_size):
         fused_activation=None,
     )
 
-    compute_kernel_config = ttnn.WormholeComputeKernelConfig(
+    compute_kernel_config = ttnn.init_device_compute_kernel_config(
+        device.arch(),
         math_fidelity=ttnn.MathFidelity.HiFi2,
         math_approx_mode=True,
         fp32_dest_acc_en=True,

--- a/tests/ttnn/unit_tests/operations/matmul/test_linear.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_linear.py
@@ -244,7 +244,8 @@ def test_linear_fp32_acc(device, m_size, k_size, n_size):
     input_tensor_b = ttnn.from_torch(torch_input_tensor_b, layout=ttnn.TILE_LAYOUT, device=device)
 
     if is_wormhole_b0():
-        compute_kernel_config = ttnn.WormholeComputeKernelConfig(
+        compute_kernel_config = ttnn.init_device_compute_kernel_config(
+            device.arch(),
             math_fidelity=ttnn.MathFidelity.HiFi4,
             math_approx_mode=False,
             fp32_dest_acc_en=True,
@@ -358,7 +359,8 @@ def test_linear_with_fp32_dest_acc_and_bias(device):
     torch_input_tensor_a = torch.rand([64, 1, 256, 384])
     torch_input_tensor_b = torch.rand([1, 1, 1152, 384])
     torch_input_tensor_c = torch.rand([1, 1, 1, 1152])
-    compute_kernel_config = ttnn.WormholeComputeKernelConfig(
+    compute_kernel_config = ttnn.init_device_compute_kernel_config(
+        device.arch(),
         math_fidelity=ttnn.MathFidelity.HiFi2,
         math_approx_mode=False,
         fp32_dest_acc_en=True,

--- a/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
@@ -448,7 +448,8 @@ def test_matmul_in1_dram_sharded_tiny_tile(
         fused_activation=None,
     )
 
-    compute_kernel_config = ttnn.WormholeComputeKernelConfig(
+    compute_kernel_config = ttnn.init_device_compute_kernel_config(
+        mesh_device.arch(),
         math_fidelity=ttnn.MathFidelity.LoFi,
         math_approx_mode=True,
         fp32_dest_acc_en=True,
@@ -577,7 +578,8 @@ def run_matmul_2d_multiple_output_blocks_per_core(
         fuse_batch=fuse_batch,
     )
 
-    compute_kernel_config = ttnn.WormholeComputeKernelConfig(
+    compute_kernel_config = ttnn.init_device_compute_kernel_config(
+        device.arch(),
         math_fidelity=ttnn.MathFidelity.LoFi,
         math_approx_mode=True,
         fp32_dest_acc_en=False,
@@ -744,7 +746,8 @@ def run_matmul_2d_tiny_tile(
         fused_activation=None,
     )
 
-    compute_kernel_config = ttnn.WormholeComputeKernelConfig(
+    compute_kernel_config = ttnn.init_device_compute_kernel_config(
+        device.arch(),
         math_fidelity=ttnn.MathFidelity.LoFi,
         math_approx_mode=True,
         fp32_dest_acc_en=False,
@@ -901,7 +904,8 @@ def run_matmul_1d_tiny_tile(
         mcast_in0=True,
     )
 
-    compute_kernel_config = ttnn.WormholeComputeKernelConfig(
+    compute_kernel_config = ttnn.init_device_compute_kernel_config(
+        device.arch(),
         math_fidelity=ttnn.MathFidelity.LoFi,
         math_approx_mode=True,
         fp32_dest_acc_en=False,
@@ -1108,7 +1112,8 @@ def run_matmul_1d_multiple_output_blocks_per_core(
         mcast_in0=mcast_in0,
     )
 
-    compute_kernel_config = ttnn.WormholeComputeKernelConfig(
+    compute_kernel_config = ttnn.init_device_compute_kernel_config(
+        device.arch(),
         math_fidelity=ttnn.MathFidelity.LoFi,
         math_approx_mode=True,
         fp32_dest_acc_en=False,
@@ -1271,8 +1276,12 @@ def test_padded_2d_matmul(device, side, tile_count):
         act,
         weight,
         program_config=program_config,
-        compute_kernel_config=ttnn.WormholeComputeKernelConfig(
-            math_fidelity=ttnn.MathFidelity.HiFi2, math_approx_mode=False, fp32_dest_acc_en=True, packer_l1_acc=False
+        compute_kernel_config=ttnn.init_device_compute_kernel_config(
+            device.arch(),
+            math_fidelity=ttnn.MathFidelity.HiFi2,
+            math_approx_mode=False,
+            fp32_dest_acc_en=True,
+            packer_l1_acc=False,
         ),
     )
     lower = ttnn.to_torch(lower_tt).float()
@@ -1354,8 +1363,12 @@ def test_padded_1d_matmul(mesh_device, side, has_program_config):
         weight,
         core_grid=None if has_program_config else ttnn.CoreGrid(x=4, y=4),
         program_config=program_config,
-        compute_kernel_config=ttnn.WormholeComputeKernelConfig(
-            math_fidelity=ttnn.MathFidelity.HiFi2, math_approx_mode=False, fp32_dest_acc_en=True, packer_l1_acc=False
+        compute_kernel_config=ttnn.init_device_compute_kernel_config(
+            device.arch(),
+            math_fidelity=ttnn.MathFidelity.HiFi2,
+            math_approx_mode=False,
+            fp32_dest_acc_en=True,
+            packer_l1_acc=False,
         ),
     )
 
@@ -1445,8 +1458,8 @@ def test_matmul_does_dot_product(device, w):
 
     output = ttnn.to_torch(output)
 
-    assert torch_output_tensor.shape == ()
-    assert output.shape == ()
+    assert len(torch_output_tensor.shape) == 0
+    assert len(output.shape) == 0
     assert torch.allclose(torch_output_tensor, output, atol=1e-2)
 
 
@@ -1981,7 +1994,8 @@ def test_matmul_in0_in1_bias_sharded(
         ),
     )
 
-    compute_kernel_config = ttnn.WormholeComputeKernelConfig(
+    compute_kernel_config = ttnn.init_device_compute_kernel_config(
+        device.arch(),
         math_fidelity=ttnn.MathFidelity.LoFi,
         math_approx_mode=True,
         fp32_dest_acc_en=True,
@@ -2245,7 +2259,8 @@ def test_sharded_matmul_with_multiple_out_block_values(device, out_block_h, out_
     memory_config = ttnn.MemoryConfig(
         memory_layout=ttnn.TensorMemoryLayout.BLOCK_SHARDED, buffer_type=ttnn.BufferType.L1, shard_spec=None
     )
-    compute_kernel_config = ttnn.WormholeComputeKernelConfig(
+    compute_kernel_config = ttnn.init_device_compute_kernel_config(
+        device.arch(),
         math_fidelity=ttnn.MathFidelity.LoFi,
         math_approx_mode=True,
         fp32_dest_acc_en=False,

--- a/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
@@ -1364,7 +1364,7 @@ def test_padded_1d_matmul(mesh_device, side, has_program_config):
         core_grid=None if has_program_config else ttnn.CoreGrid(x=4, y=4),
         program_config=program_config,
         compute_kernel_config=ttnn.init_device_compute_kernel_config(
-            device.arch(),
+            mesh_device.arch(),
             math_fidelity=ttnn.MathFidelity.HiFi2,
             math_approx_mode=False,
             fp32_dest_acc_en=True,

--- a/tests/ttnn/unit_tests/operations/reduce/test_max.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_max.py
@@ -8,7 +8,7 @@ import torch
 
 import ttnn
 from tests.ttnn.utils_for_testing import assert_with_pcc
-from models.common.utility_functions import torch_random, is_grayskull
+from models.common.utility_functions import torch_random
 
 
 @pytest.mark.parametrize("batch_size", [1, 16])
@@ -116,11 +116,6 @@ def test_max_global(device, batch_size, h, w):
 @pytest.mark.parametrize("keepdim", [True, False])
 def test_max_dim(device, input_shape_and_dim, keepdim):
     input_shape, max_dim = input_shape_and_dim
-    if is_grayskull() and (
-        input_shape[-1] % 32 != 0 or input_shape[-2] % 32 != 0 or input_shape[max_dim] % 32 != 0 or max_dim <= -2
-    ):
-        pytest.skip("May fail on GS if run all the tests in this file. #17084")
-
     torch_input_tensor = torch_random(input_shape, -100, 100, dtype=torch.bfloat16)
     torch_output_tensor, _ = torch.max(torch_input_tensor, dim=max_dim, keepdim=keepdim)
 


### PR DESCRIPTION
### Ticket
Link to Github Issue #22118

### Problem description
Need cleanup:
- remove GS related test code
- change WormholeComputeKernelConfig to the Kernel Config init function that hides the arch specific details
- change shape check to rank check: https://github.com/tenstorrent/tt-metal/pull/22106#discussion_r2089760912

### What's changed
- perform the cleanup for matmul/fused/reduce

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes all affected tests are ok https://github.com/tenstorrent/tt-metal/actions/runs/18986759738 (t3k failing on main, galaxy backed up)
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes