### PR TITLE
Remove Rank Binding/MGD Dependencies from Validation

### DIFF
--- a/tests/scripts/multihost/run_dual_galaxy_tests.sh
+++ b/tests/scripts/multihost/run_dual_galaxy_tests.sh
@@ -21,8 +21,8 @@ run_dual_galaxy_unit_tests() {
   local mpi_args_reversed="--host g10glx04,g10glx03 $mpi_args_base"
   local rank_binding="tests/tt_metal/distributed/config/dual_galaxy_rank_bindings.yaml"
 
-  tt-run --rank-binding "$rank_binding" --mpi-args "$mpi_args" ./build/test/tt_metal/tt_fabric/test_physical_discovery ; fail+=$?
-  tt-run --rank-binding "$rank_binding" --mpi-args "$mpi_args" ./build/tools/scaleout/run_cluster_validation ; fail+=$?
+  mpirun-ulfm $mpi_args -x TT_METAL_HOME=$(pwd) -x LD_LIBRARY_PATH=$(pwd)/build/lib ./build/test/tt_metal/tt_fabric/test_physical_discovery ; fail+=$?
+  mpirun-ulfm $mpi_args -x TT_METAL_HOME=$(pwd) -x LD_LIBRARY_PATH=$(pwd)/build/lib ./build/tools/scaleout/run_cluster_validation --print-connectivity --send-traffic --hard-fail ; fail+=$?
   tt-run --rank-binding "$rank_binding" --mpi-args "$mpi_args" ./build/test/tt_metal/tt_fabric/test_system_health --gtest_filter="Cluster.ReportIntermeshLinks" ; fail+=$?
   tt-run --rank-binding "$rank_binding" --mpi-args "$mpi_args" ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="MultiHost.TestDualGalaxyControlPlaneInit" ; fail+=$?
   tt-run --rank-binding "$rank_binding" --mpi-args "$mpi_args" ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="MultiHost.TestDualGalaxyFabric2DSanity" ; fail+=$?

--- a/tests/scripts/multihost/run_dual_t3k_tests.sh
+++ b/tests/scripts/multihost/run_dual_t3k_tests.sh
@@ -21,8 +21,8 @@ run_dual_t3k_unit_tests() {
   local rank_binding="tests/tt_metal/distributed/config/dual_t3k_rank_bindings.yaml"
   local strict_rank_binding="tests/tt_metal/distributed/config/dual_t3k_strict_connection_rank_bindings.yaml"
 
-  tt-run --rank-binding "$rank_binding" --mpi-args "$mpi_args" ./build/test/tt_metal/tt_fabric/test_physical_discovery ; fail+=$?
-  tt-run --rank-binding "$rank_binding" --mpi-args "$mpi_args" ./build/tools/scaleout/run_cluster_validation  --print-connectivity --send-traffic --hard-fail ; fail+=$?
+  mpirun $mpi_args -x TT_METAL_HOME=$(pwd) -x LD_LIBRARY_PATH=$(pwd)/build/lib ./build/test/tt_metal/tt_fabric/test_physical_discovery ; fail+=$?
+  mpirun $mpi_args -x TT_METAL_HOME=$(pwd) -x LD_LIBRARY_PATH=$(pwd)/build/lib ./build/tools/scaleout/run_cluster_validation  --print-connectivity --send-traffic --hard-fail ; fail+=$?
   tt-run --rank-binding "$rank_binding" --mpi-args "$mpi_args" ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config tests/tt_metal/perf_microbenchmark/routing/test_dual_t3k.yaml ; fail+=$?
   tt-run --rank-binding "$rank_binding" --mpi-args "$mpi_args" ./build/test/tt_metal/multi_host_fabric_tests ; fail+=$?
   tt-run --rank-binding "$rank_binding" --mpi-args "$mpi_args" ./build/test/tt_metal/test_mesh_socket_main --test_config tests/tt_metal/multihost/fabric_tests/mesh_socket_dual_t3k.yaml ; fail+=$?

--- a/tt_metal/fabric/topology_mapper.hpp
+++ b/tt_metal/fabric/topology_mapper.hpp
@@ -279,6 +279,7 @@ private:
     const tt::tt_metal::PhysicalSystemDescriptor& physical_system_descriptor_;
     const LocalMeshBinding& local_mesh_binding_;
     const std::vector<std::pair<AsicPosition, FabricNodeId>> fixed_asic_position_pinnings_;
+    bool generate_mapping_locally_ = false;
 
     // Bidirectional mapping between FabricNodeId and AsicID
     std::unordered_map<FabricNodeId, tt::tt_metal::AsicID> fabric_node_id_to_asic_id_;


### PR DESCRIPTION
### Ticket
No Ticket.

### Problem description
- Changes introduced in https://github.com/tenstorrent/tt-metal/pull/29318 remove implicit support for reusing Mesh + Host Rank IDs across hosts when initializing the Control Plane
- This is because the globally aware topology mapping relies on these attributes being unique across hosts
- Previously, this mapping was done per host, and aliasing was okay as long as Fabric was not initialized or used
- This is problematic for the Cluster Validation tool, which relies on the Control Plane for ethernet query APIs
- All invocations for the tool currently use `tt-run` with a rank binding + Mesh Graph Descriptor specified, which breaks abstraction layers and makes the tool harder to use
- Physical Cluster Validation should not require the user to pass in a logical topology that is meant to be overlayed in a downstream pipeline stage
- Additionally, this means that a user can't launch a distributed process across multiple hosts without specifying a Multi/Big-Mesh MGD (use case here is just regular multi-processing without distributed fabric initialization)

### What's changed
- Changes introduce a `generate_mapping_locally_` state variable to `TopologyMapper`
- This is set to true if the MGD only has a single host rank and mesh id (for single host workloads, this change is a nop)
- For Multi-Host workloads, if this is set to true, each host will generate its own `FabricNodeID` to Physical Chip Mapping. Fabric Ids will alias across hosts and no cross host fabric routers will be initialized
- **This allows Cluster Validation to detect links + send traffic without an MGD being intialized**

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes