### PR TITLE
Ternary ops: remove `odst` in favour of `idst0`.

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_ternary_sfpu_where.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_ternary_sfpu_where.h
@@ -10,37 +10,34 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_ternary_sfpu_where(
-    uint dst_index0, uint dst_index1, uint dst_index2, uint odst, int vector_mode = (int)VectorMode::RC) {
+    uint dst_index0, uint dst_index1, uint dst_index2, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_ternary_sfpu_params_<APPROXIMATE>(
         ckernel::sfpu::_calculate_where_<APPROXIMATE, DataFormat::Float16_b, 8>,
         dst_index0,
         dst_index1,
         dst_index2,
-        odst,
         vector_mode);
 }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_ternary_sfpu_where_fp32(
-    uint dst_index0, uint dst_index1, uint dst_index2, uint odst, int vector_mode = (int)VectorMode::RC) {
+    uint dst_index0, uint dst_index1, uint dst_index2, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_ternary_sfpu_params_<APPROXIMATE>(
         ckernel::sfpu::_calculate_where_<APPROXIMATE, DataFormat::Float32, 8>,
         dst_index0,
         dst_index1,
         dst_index2,
-        odst,
         vector_mode);
 }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_ternary_sfpu_where_int32(
-    uint dst_index0, uint dst_index1, uint dst_index2, uint odst, int vector_mode = (int)VectorMode::RC) {
+    uint dst_index0, uint dst_index1, uint dst_index2, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_ternary_sfpu_params_<APPROXIMATE>(
         ckernel::sfpu::_calculate_where_<APPROXIMATE, DataFormat::Int32, 8>,
         dst_index0,
         dst_index1,
         dst_index2,
-        odst,
         vector_mode);
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_ternary_sfpu_where.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_ternary_sfpu_where.h
@@ -10,37 +10,34 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_ternary_sfpu_where(
-    uint dst_index0, uint dst_index1, uint dst_index2, uint odst, int vector_mode = (int)VectorMode::RC) {
+    uint dst_index0, uint dst_index1, uint dst_index2, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_ternary_sfpu_params_<APPROXIMATE>(
         ckernel::sfpu::_calculate_where_<APPROXIMATE, DataFormat::Float16_b, 8>,
         dst_index0,
         dst_index1,
         dst_index2,
-        odst,
         vector_mode);
 }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_ternary_sfpu_where_fp32(
-    uint dst_index0, uint dst_index1, uint dst_index2, uint odst, int vector_mode = (int)VectorMode::RC) {
+    uint dst_index0, uint dst_index1, uint dst_index2, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_ternary_sfpu_params_<APPROXIMATE>(
         ckernel::sfpu::_calculate_where_<APPROXIMATE, DataFormat::Float32, 8>,
         dst_index0,
         dst_index1,
         dst_index2,
-        odst,
         vector_mode);
 }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_ternary_sfpu_where_int32(
-    uint dst_index0, uint dst_index1, uint dst_index2, uint odst, int vector_mode = (int)VectorMode::RC) {
+    uint dst_index0, uint dst_index1, uint dst_index2, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_ternary_sfpu_params_<APPROXIMATE>(
         ckernel::sfpu::_calculate_where_<APPROXIMATE, DataFormat::Int32, 8>,
         dst_index0,
         dst_index1,
         dst_index2,
-        odst,
         vector_mode);
 }
 

--- a/tt_metal/include/compute_kernel_api/eltwise_unary/where.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_unary/where.h
@@ -14,29 +14,28 @@ namespace ckernel {
 // clang-format off
 /**
  * Performs an elementwise where operation with the three inputs: y = where(x0,x1,x2)
- * Output overwrites odst in DST.
+ * Output overwrites idst0 in DST.
  *
  * The DST register buffer must be in acquired state via *acquire_dst* call. This call is blocking and is only available
  * on the compute engine.
  *
  * | Argument              | Description                                                              | Type     | Valid Range                                           | Required |
  * |-----------------------|--------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
- * | idst0                 | The index of the tile in DST register buffer to use as condition operand | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | idst0                 | The index of the tile in DST register buffer to use as condition operand and output | uint32_t | Must be less than the size of the DST register buffer | True     |
  * | idst1                 | The index of the tile in DST register buffer to use as first operand     | uint32_t | Must be less than the size of the DST register buffer | True     |
  * | idst2                 | The index of the tile in DST register buffer to use as second operand    | uint32_t | Must be less than the size of the DST register buffer | True     |
- * | odst                  | The index of the tile in DST register buffer to use as output            | uint32_t | Must be less than the size of the DST register buffer | True     |
  */
 // clang-format on
-ALWI void where_tile(uint32_t idst0, uint32_t idst1, uint32_t idst2, uint32_t odst) {
-    MATH((llk_math_eltwise_ternary_sfpu_where<APPROX>(idst0, idst1, idst2, odst)));
+ALWI void where_tile(uint32_t idst0, uint32_t idst1, uint32_t idst2) {
+    MATH((llk_math_eltwise_ternary_sfpu_where<APPROX>(idst0, idst1, idst2)));
 }
 
-ALWI void where_fp32_tile(uint32_t idst0, uint32_t idst1, uint32_t idst2, uint32_t odst) {
-    MATH((llk_math_eltwise_ternary_sfpu_where_fp32<APPROX>(idst0, idst1, idst2, odst)));
+ALWI void where_fp32_tile(uint32_t idst0, uint32_t idst1, uint32_t idst2) {
+    MATH((llk_math_eltwise_ternary_sfpu_where_fp32<APPROX>(idst0, idst1, idst2)));
 }
 
-ALWI void where_int32_tile(uint32_t idst0, uint32_t idst1, uint32_t idst2, uint32_t odst) {
-    MATH((llk_math_eltwise_ternary_sfpu_where_int32<APPROX>(idst0, idst1, idst2, odst)));
+ALWI void where_int32_tile(uint32_t idst0, uint32_t idst1, uint32_t idst2) {
+    MATH((llk_math_eltwise_ternary_sfpu_where_int32<APPROX>(idst0, idst1, idst2)));
 }
 
 /**

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_sfpu_col_scalar_bcast_tts_tst.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_sfpu_col_scalar_bcast_tts_tst.cpp
@@ -81,7 +81,7 @@ ALWI void process_tile(
 
         // Perform the ternary operation
         TERNARY_SFPU_OP_INIT();
-        TERNARY_SFPU_OP_FUNC(0, 1, 2, 0);
+        TERNARY_SFPU_OP_FUNC(0, 1, 2);
 
         tile_regs_commit();
 

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_sfpu_col_scalar_bcast_ttt.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_sfpu_col_scalar_bcast_ttt.cpp
@@ -60,7 +60,7 @@ ALWI void process_tile(
 
         // Perform the ternary operation
         TERNARY_SFPU_OP_INIT();
-        TERNARY_SFPU_OP_FUNC(0, 1, 2, 0);
+        TERNARY_SFPU_OP_FUNC(0, 1, 2);
 
         tile_regs_commit();
 

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_sfpu_no_bcast_tts_tst.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_sfpu_no_bcast_tts_tst.cpp
@@ -67,7 +67,7 @@ void MAIN {
         }
 
         TERNARY_SFPU_OP_INIT();
-        TERNARY_SFPU_OP_FUNC(0, 1, 2, 0);
+        TERNARY_SFPU_OP_FUNC(0, 1, 2);
 
         tile_regs_commit();
         tile_regs_wait();

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_sfpu_no_bcast_ttt.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_sfpu_no_bcast_ttt.cpp
@@ -41,7 +41,7 @@ void MAIN {
         copy_tile(cb_pre_in3, 0, 2);  // Copy to dst reg 2
 
         TERNARY_SFPU_OP_INIT();
-        TERNARY_SFPU_OP_FUNC(0, 1, 2, 0);
+        TERNARY_SFPU_OP_FUNC(0, 1, 2);
 
         tile_regs_commit();
         tile_regs_wait();

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
@@ -483,11 +483,11 @@ std::pair<std::string, std::string> get_op_init_and_func_parameterized(
         case UnaryOpType::WHERE_TSS: {
             std::string where_call;
             if (input_dtype == DataType::INT32) {
-                where_call = fmt::format("where_int32_tile({0}, {1}, {2}, {0});", idst, 1, 2);
+                where_call = fmt::format("where_int32_tile({0}, {1}, {2});", idst, 1, 2);
             } else if (input_dtype == DataType::FLOAT32) {
-                where_call = fmt::format("where_fp32_tile({0}, {1}, {2}, {0});", idst, 1, 2);
+                where_call = fmt::format("where_fp32_tile({0}, {1}, {2});", idst, 1, 2);
             } else {
-                where_call = fmt::format("where_tile({0}, {1}, {2}, {0});", idst, 1, 2);
+                where_call = fmt::format("where_tile({0}, {1}, {2});", idst, 1, 2);
             }
             op_init_and_name = std::make_pair("where_tile_init();", where_call);
             break;

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/tanh_accurate/device/kernels/compute/tanh_accurate.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/tanh_accurate/device/kernels/compute/tanh_accurate.cpp
@@ -159,10 +159,10 @@ void MAIN {
             copy_tile(cb_tanh_exp, 0, 2);
             where_tile_init();
 #ifdef TANH_FP32
-            where_fp32_tile(0, 1, 2, 0);
+            where_fp32_tile(0, 1, 2);
 #endif
 #ifdef TANH_BF16
-            where_tile(0, 1, 2, 0);
+            where_tile(0, 1, 2);
 #endif
             tile_regs_commit();
             tile_regs_wait();

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/tanh_accurate/device/kernels/compute/tanhshrink.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/tanh_accurate/device/kernels/compute/tanhshrink.cpp
@@ -161,7 +161,7 @@ void MAIN {
             copy_tile(cb_tanh_exp, 0, 2);
             where_tile_init();
 #ifdef TANH_FP32
-            where_fp32_tile(0, 1, 2, 0);
+            where_fp32_tile(0, 1, 2);
             copy_dest_values(1, 0);
             copy_tile_init(cb_input);
             copy_tile(cb_input, 0, 0);
@@ -169,7 +169,7 @@ void MAIN {
             sub_binary_tile(0, 1, 0);
 #endif
 #ifdef TANH_BF16
-            where_tile(0, 1, 2, 0);
+            where_tile(0, 1, 2);
             binary_dest_reuse_tiles_init<EltwiseBinaryType::ELWSUB, EltwiseBinaryReuseDestType::DEST_TO_SRCB>(cb_input);
             binary_dest_reuse_tiles<EltwiseBinaryType::ELWSUB, EltwiseBinaryReuseDestType::DEST_TO_SRCB>(
                 cb_input, 0, 0);


### PR DESCRIPTION
### Ticket

https://github.com/tenstorrent/tt-metal/issues/31621

### Problem description

Right now the ternary op structure has 4 arguments: 3 input indexes and 1 output index.  However, all uses of `where` (the only ternary op) write the output to the same index as the first input index (see ticket for more details).

This change needs to be merged in sync with the relevant tt-llk changes.

### What's changed

Removed the `odst` argument from ternary op APIs and `where` APIs.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes