### PR TITLE
[skip ci] llms.md link for for vit.md

### DIFF
--- a/tech_reports/LLMs/llms.md
+++ b/tech_reports/LLMs/llms.md
@@ -1411,7 +1411,7 @@ Tracing doesn’t work with prefill; sequence length and matmul row counts will 
 
 ### 4.3 Op Configs
 
-Program and memory configurations are your greatest levers for performance. As a prerequisite for this section, you should understand [Tensor and Memory Layouts](../tensor_layouts/tensor_layouts.md) and the concepts in [ViT-TTNN](../VIT-TTNN/vit.md).
+Program and memory configurations are your greatest levers for performance. As a prerequisite for this section, you should understand [Tensor and Memory Layouts](../tensor_layouts/tensor_layouts.md) and the concepts in [ViT-TTNN](../ViT-TTNN/vit.md).
 
 Most `ttnn` operations have arguments for `program_config` and `memory_config`. You should optimize these for best performance.
 `memory_config` is used to determine the layout of the output tensor.


### PR DESCRIPTION
### Problem description
The link for the ViT tech report used to be broken.

### What's changed
The link now points to the right file. (you can click on it and it works)