### PR TITLE
Use architecture-aware transaction sizes and strides in groupnorm welford combine

### DIFF
--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_reader_mcast_sender_unary_gn.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_reader_mcast_sender_unary_gn.cpp
@@ -381,7 +381,8 @@ void kernel_main() {
                     }
 
                     // Read mean and variance arrays from cb_ex_global, then combine using Welford
-                    auto global_result = combine_welford_stats<num_mcast_cores, num_channels_per_group * num_rows_per_group, 16>(p_global_means, p_global_vars);
+                    constexpr uint32_t stride = NOC_DRAM_READ_ALIGNMENT_BYTES / 2;
+                    auto global_result = combine_welford_stats<num_mcast_cores, num_channels_per_group * num_rows_per_group, stride>(p_global_means, p_global_vars);
 
                     // Write this to cb_ex_global
                     p_global_means[0] = global_result.mean;

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_reader_mcast_sender_unary_sharded_gn_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_reader_mcast_sender_unary_sharded_gn_v2.cpp
@@ -203,15 +203,22 @@ void kernel_main() {
             noc_semaphore_set(reduce_receiver_semaphore_addr_ptr, 0);
 
             for (uint32_t i = 1; i < num_mcast_cores; ++i) {
-                noc_async_read_one_packet(multicast_data_noc | global_means_ptr, global_means_ptr + i * 32, 32);
-                noc_async_read_one_packet(multicast_data_noc | global_vars_ptr, global_vars_ptr + i * 32, 32);
+                noc_async_read_one_packet(
+                    multicast_data_noc | global_means_ptr,
+                    global_means_ptr + i * NOC_DRAM_READ_ALIGNMENT_BYTES,
+                    NOC_DRAM_READ_ALIGNMENT_BYTES);
+                noc_async_read_one_packet(
+                    multicast_data_noc | global_vars_ptr,
+                    global_vars_ptr + i * NOC_DRAM_READ_ALIGNMENT_BYTES,
+                    NOC_DRAM_READ_ALIGNMENT_BYTES);
             }
             noc_async_read_barrier();
         }
 
         // Read mean and variance arrays from cb_ex_global, then combine using Welford
+        constexpr uint32_t stride = NOC_DRAM_READ_ALIGNMENT_BYTES / 2;
         auto global_result =
-            combine_welford_stats<num_mcast_cores, block_hw * 32 * 32, 16>(p_global_means, p_global_vars);
+            combine_welford_stats<num_mcast_cores, block_hw * 32 * 32, stride>(p_global_means, p_global_vars);
 
         // Write this to cb_ex_global
         p_global_means[0] = global_result.mean;


### PR DESCRIPTION
### Ticket
#0

### Problem description
Use a stride and noc async read size that respects architecture-specific alignments in groupnorm. It was previously hardcoded to Wormhole alignment (32 B).

Note: This was supposed to go in as part of https://github.com/tenstorrent/tt-metal/pull/31544 , but somehow was left out of the merge.

### What's changed
See above

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/19022829041
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/19022834355
- [x] Blackhole Demo tests: https://github.com/tenstorrent/tt-metal/actions/runs/19024058090
- [x] Blackhole Multi Card Demo tests: https://github.com/tenstorrent/tt-metal/actions/runs/19024056198/job/54324776052
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes