### PR TITLE
Fixes to enable multi-host simulation

### DIFF
--- a/tt_metal/distributed/sd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/sd_mesh_command_queue.cpp
@@ -74,14 +74,18 @@ void SDMeshCommandQueue::enqueue_mesh_workload(MeshWorkload& mesh_workload, bool
     }
     for (auto& [coord_range, program] : mesh_workload.get_programs()) {
         for (const auto& coord : coord_range) {
-            auto device = mesh_device_->get_device(coord);
-            tt_metal::detail::LaunchProgram(device, program, false);
+            if (mesh_device_->is_local(coord)) {
+                auto device = mesh_device_->get_device(coord);
+                tt_metal::detail::LaunchProgram(device, program, false);
+            }
         }
     }
     for (auto& [coord_range, program] : mesh_workload.get_programs()) {
         for (const auto& coord : coord_range) {
-            auto device = mesh_device_->get_device(coord);
-            tt_metal::detail::WaitProgramDone(device, program);
+            if (mesh_device_->is_local(coord)) {
+                auto device = mesh_device_->get_device(coord);
+                tt_metal::detail::WaitProgramDone(device, program);
+            }
         }
     }
 }

--- a/tt_metal/fabric/physical_system_descriptor.cpp
+++ b/tt_metal/fabric/physical_system_descriptor.cpp
@@ -909,8 +909,4 @@ HallID PhysicalSystemDescriptor::get_hall_id(const std::string& hostname) {
     TT_THROW("Querying Host Hall ID requires the Cable Spec which is not currently supported.");
 }
 
-bool PhysicalSystemDescriptor::is_using_mock_cluster() const {
-    return target_device_type_ == TargetDevice::Mock || target_device_type_ == TargetDevice::Simulator;
-}
-
 }  // namespace tt::tt_metal

--- a/tt_metal/fabric/physical_system_descriptor.hpp
+++ b/tt_metal/fabric/physical_system_descriptor.hpp
@@ -198,7 +198,7 @@ public:
     const std::unordered_map<std::string, std::string>& get_host_mobo_name_map() const { return host_to_mobo_name_; }
     const std::unordered_map<std::string, uint32_t>& get_host_to_rank_map() const { return host_to_rank_; }
     const ExitNodeConnectionTable& get_exit_node_connection_table() const { return exit_node_connection_table_; }
-    bool is_using_mock_cluster() const;
+    tt::TargetDevice get_target_device_type() const { return target_device_type_; }
     LocalEthernetMetrics query_local_ethernet_metrics() const;
 
     PhysicalConnectivityGraph& get_system_graph() { return system_graph_; }

--- a/tt_metal/fabric/protobuf/physical_system_descriptor.proto
+++ b/tt_metal/fabric/protobuf/physical_system_descriptor.proto
@@ -97,5 +97,5 @@ message PhysicalSystemDescriptor {
     repeated HostToMoboMap host_to_mobo_name = 3;
     repeated HostToRankMap host_to_rank = 4;
     repeated ExitNodeConnectionTable exit_node_connection_table = 5;
-    bool mock_cluster = 6;
+    uint32 target_device_type = 6;
 }

--- a/tt_metal/fabric/serialization/physical_system_descriptor_serialization.cpp
+++ b/tt_metal/fabric/serialization/physical_system_descriptor_serialization.cpp
@@ -14,6 +14,7 @@
 #include <google/protobuf/io/zero_copy_stream_impl.h>
 #include <fstream>
 #include <sstream>
+#include <enchantum/enchantum.hpp>
 
 namespace tt::tt_metal {
 
@@ -192,18 +193,22 @@ void physical_system_descriptor_to_proto(
         }
     }
 
-    // Set mock cluster flag
-    proto_desc->set_mock_cluster(descriptor.is_using_mock_cluster());
+    // Set target device type
+    proto_desc->set_target_device_type(static_cast<uint32_t>(descriptor.get_target_device_type()));
 }
 
 // Convert protobuf to PhysicalSystemDescriptor
 std::unique_ptr<PhysicalSystemDescriptor> proto_to_physical_system_descriptor(
     const tt::fabric::proto::PhysicalSystemDescriptor& proto_desc) {
+    auto target_device_type = enchantum::cast<TargetDevice>(proto_desc.target_device_type());
+    if (!target_device_type.has_value()) {
+        throw std::runtime_error("Invalid target device type: " + std::to_string(proto_desc.target_device_type()));
+    }
     auto descriptor = std::make_unique<PhysicalSystemDescriptor>(
         PhysicalSystemDescriptor::null_cluster,
         nullptr,
         nullptr,
-        proto_desc.mock_cluster() ? TargetDevice::Mock : TargetDevice::Silicon,
+        *target_device_type,
         false);  // Don't run discovery
 
     // Convert system graph


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Dispatching multi-host programs wasn't supported with slow dispatch.
Physical system descriptor was not properly serializing device type, resulting in Simulation device being converted to Mock device.

### What's changed
Skip non-local coordinates when dispatching programs with slow dispatch.
Fix physical system descriptor serialization to properly serialize TargetDevice.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes