### PR TITLE
Fold: Correct output dtype and add BFLOAT8_B test coverage for dram tensors

### DIFF
--- a/tests/ttnn/unit_tests/operations/conv/data_movement/test_fold_op.py
+++ b/tests/ttnn/unit_tests/operations/conv/data_movement/test_fold_op.py
@@ -79,7 +79,7 @@ def fold_torch(input_tensor, stride_h, stride_w, padding=None):
 @pytest.mark.parametrize("nhw", [(3, 64, 64), (1, 224, 224), (1, 384, 512), (1, 512, 672)])
 @pytest.mark.parametrize("channels", [3, 32, 320])
 @pytest.mark.parametrize("stride", [(16, 16), (32, 32)])
-@pytest.mark.parametrize("padding", [(0, 0), (8, 8), (4, 12, 2, 6)])
+@pytest.mark.parametrize("padding", [(0, 0), (8, 8), (20, 12, 15, 17)])
 @pytest.mark.parametrize("input_layout", [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT])
 @pytest.mark.parametrize("input_dtype", [ttnn.bfloat8_b, ttnn.bfloat16])
 def test_fold_with_permute_for_dram_tensor(device, nhw, channels, stride, padding, input_layout, input_dtype):

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_multi_core_dram_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_multi_core_dram_program_factory.cpp
@@ -39,11 +39,14 @@ Fold::MultiCoreDRAMFold::cached_program_t fold_multi_core_tiled_interleaved(
 
     tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.dtype());
     uint32_t single_tile_size = tt::tile_size(cb_data_format);
+    tt::DataFormat out_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
+    uint32_t out_single_tile_size = tt::tile_size(out_cb_data_format);
 
     ttnn::Shape output_padded_shape = output.padded_shape();
     ttnn::Shape input_padded_shape = input_tensor.padded_shape();
 
-    log_debug(tt::LogOp, "cb_data_format: {}", cb_data_format);
+    log_debug(tt::LogOp, "in_cb_data_format: {}", cb_data_format);
+    log_debug(tt::LogOp, "out_cb_data_format: {}", out_cb_data_format);
     log_debug(tt::LogOp, "single_tile_size: {}", single_tile_size);
     log_debug(tt::LogOp, "input_tensor_shape: {}", input_padded_shape);
     log_debug(tt::LogOp, "output_tensor_shape: {}", output_padded_shape);
@@ -58,7 +61,7 @@ Fold::MultiCoreDRAMFold::cached_program_t fold_multi_core_tiled_interleaved(
     uint32_t num_blocks =
         std::ceil(static_cast<float>(ntiles) / (tiles_per_complete_row));  // Total number of blocks for batch * height
 
-    uint32_t aligned_stick_nbytes = tt::align(stick_nbytes, TILE_WIDTH * tt::datum_size(cb_data_format));
+    uint32_t aligned_stick_nbytes = tt::align(stick_nbytes, TILE_WIDTH * tt::datum_size(out_cb_data_format));
     log_debug(
         tt::LogOp, "tiles_per_channel_dim: {}, ntiles: {}, num_blocks: {}", tiles_per_channel_dim, ntiles, num_blocks);
 
@@ -84,8 +87,9 @@ Fold::MultiCoreDRAMFold::cached_program_t fold_multi_core_tiled_interleaved(
 
     uint32_t src1_cb_index = tt::CBIndex::c_1;
     tt::tt_metal::CircularBufferConfig cb_src1_config =
-        tt::tt_metal::CircularBufferConfig(num_input_tiles * single_tile_size, {{src1_cb_index, cb_data_format}})
-            .set_page_size(src1_cb_index, single_tile_size);
+        tt::tt_metal::CircularBufferConfig(
+            num_input_tiles * out_single_tile_size, {{src1_cb_index, out_cb_data_format}})
+            .set_page_size(src1_cb_index, out_single_tile_size);
     tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_src1_config);
 
     // Configure compile-time arguments for reader kernel
@@ -105,7 +109,7 @@ Fold::MultiCoreDRAMFold::cached_program_t fold_multi_core_tiled_interleaved(
         aligned_stick_nbytes,
         tiles_per_channel_dim,
         tiles_per_width_dim,
-        datum_size(cb_data_format),
+        datum_size(out_cb_data_format),
         src1_cb_index,
     };
     TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/22378

### Problem description
The fold operation needed output dtype handling improvements and enhanced test coverage for BFLOAT8_B data types.

### What's changed
  - Fixed output dtype mapping: BFLOAT8_B inputs now correctly output BFLOAT16, preserving FLOAT32/UINT16 as-is
  - Enhanced circular buffer handling: Updated program factory with separate input/output data formats and tile sizes for proper dtype conversion
  - Added BFLOAT8_B test coverage: Extended tests with input_dtype parameter for BFLOAT8_B/BFLOAT16 variants

### Checklist
- [X] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI [passing](https://github.com/tenstorrent/tt-metal/actions/runs/19024629596)
- [X] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI [passing](https://github.com/tenstorrent/tt-metal/actions/runs/19024632221)
- [X] [(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml) CI [passing](https://github.com/tenstorrent/tt-metal/actions/runs/19024643049).
- [X] [Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) CI [passing](https://github.com/tenstorrent/tt-metal/actions/runs/19061720439)