### PR TITLE
#0: Remove channel slicing in panoptic unit tests

### DIFF
--- a/tests/ttnn/unit_tests/operations/data_movement/test_slice_for_conv.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_slice_for_conv.py
@@ -109,7 +109,7 @@ def test_slice_write_height_sharded(device, dims, slice_dim, slice_size, cores, 
     ],
 )
 @pytest.mark.parametrize("slice_dim", [1, 2])
-@pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT])
+@pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT])
 @pytest.mark.parametrize("orientation", [ttnn.ShardOrientation.ROW_MAJOR, ttnn.ShardOrientation.COL_MAJOR])
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32])
 def test_slice_write_width_sharded(device, dims, slice_dim, slice_size, cores, layout, orientation, dtype):
@@ -121,6 +121,7 @@ def test_slice_write_width_sharded(device, dims, slice_dim, slice_size, cores, l
     strides = [1, 1, 1, 1]
     torch.manual_seed(2005)
     torch_input = torch.randint(-10, 10, dims)
+    torch_input = torch.tensor(range(dims[-1]), dtype=torch.int32).reshape(1, 1, 1, dims[-1]).broadcast_to(dims)
 
     ttnn_output = ttnn.zeros(dims, device=device, layout=layout, dtype=dtype)
     ttnn_output = ttnn.to_memory_config(ttnn_output, ttnn.DRAM_MEMORY_CONFIG)

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.cpp
@@ -168,6 +168,7 @@ std::vector<CBInfo> get_cb_info(
     const uint32_t partial_tile_size = tt::tile_size(partial_df);
 
     const bool is_1d_conv = input_shape[0] != 1 && input_shape[1] == 1;
+    const bool is_dilated_conv = dilation[0] > 1 || dilation[1] > 1;
 
     {
         // Weights CB
@@ -291,7 +292,7 @@ std::vector<CBInfo> get_cb_info(
     cb_info.emplace_back(CBInfo{
         .name = Conv2dCb::READER_INDICES,
         .num_pages = 1,
-        .page_size = is_1d_conv && conv_config.config_tensors_in_dram
+        .page_size = (is_1d_conv || is_dilated_conv) && conv_config.config_tensors_in_dram
                          ? pconfig.per_core_out_matrix_height_ntile * tt::constants::TILE_HEIGHT *
                                6  // 3 indices per output, 2B per index
                          : pconfig.per_core_out_matrix_height_ntile * tt::constants::TILE_HEIGHT * 2,  // 2B per index

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
@@ -1317,6 +1317,7 @@ static std::pair<uint32_t, Conv2dConfig> calculate_conv_dram_slice_L1_usage(
             input_slice_height_start = std::max<int>(0, input_slice_height_start);
             input_slice_height_end = std::min<int>(params.input_height, input_slice_height_end);
             if (input_slice_height_start >= input_slice_height_end) {
+                slice_index++;
                 continue;
             }
         } else {
@@ -1339,6 +1340,7 @@ static std::pair<uint32_t, Conv2dConfig> calculate_conv_dram_slice_L1_usage(
             input_slice_width_start = std::max<int>(0, input_slice_width_start);
             input_slice_width_end = std::min<int>(params.input_width, input_slice_width_end);
             if (input_slice_width_start >= input_slice_width_end) {
+                slice_index++;
                 continue;
             }
         }

--- a/ttnn/cpp/ttnn/operations/sliding_window/op_slicing/op_slicing.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/op_slicing/op_slicing.cpp
@@ -148,17 +148,10 @@ void run_sliced_op(
             {output_slice_height_start, output_slice_width_start},
             {output_slice_height_end, output_slice_width_end});
 
-        // slice_write supports all sharding layouts for tiled inputs. For row major, height & block sharding are
-        // supported.
-        if (sliced_output_tensor.memory_config().memory_layout() != TensorMemoryLayout::HEIGHT_SHARDED &&
-            sliced_output_tensor.memory_config().memory_layout() != TensorMemoryLayout::BLOCK_SHARDED &&
-            output_tensor.layout() == Layout::ROW_MAJOR) {
-            sliced_output_tensor = ttnn::to_memory_config(
-                sliced_output_tensor, MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::L1});
-        }
         if (sliced_output_tensor.layout() != Layout::ROW_MAJOR && output_layout == Layout::ROW_MAJOR) {
             sliced_output_tensor = ttnn::untilize(sliced_output_tensor);
         }
+
         if (sliced_output_tensor.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED) {
             // slice_write expects the output tensor to be correctly shaped when its in interleaved memory layout.
             sliced_output_tensor = ttnn::reshape(


### PR DESCRIPTION
### Problem description
Panoptic uses channel slicing which is very inefficient. 

### What's changed
Use width slicing instead by using RM Layout

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes