### PR TITLE
Fix compilation with --without-python-bindings flag

### DIFF
--- a/cmake/helper_functions.cmake
+++ b/cmake/helper_functions.cmake
@@ -18,7 +18,7 @@ function(CREATE_EAGER_TEST_EXE TESTLIST)
             ${TEST_TARGET}
             PUBLIC
                 test_eager_common_libs
-                ttnn
+                TTNN::TTNN
                 Python3::Python
         )
         target_include_directories(
@@ -27,6 +27,7 @@ function(CREATE_EAGER_TEST_EXE TESTLIST)
                 ${PROJECT_SOURCE_DIR}
                 ${PROJECT_SOURCE_DIR}/tt_metal
                 ${PROJECT_SOURCE_DIR}/ttnn/cpp
+                ${PROJECT_SOURCE_DIR}/ttnn/api
                 ${PROJECT_SOURCE_DIR}/tt_metal/common
                 ${PROJECT_SOURCE_DIR}/tests
                 ${CMAKE_CURRENT_SOURCE_DIR}

--- a/tests/ttnn/benchmark/cpp/CMakeLists.txt
+++ b/tests/ttnn/benchmark/cpp/CMakeLists.txt
@@ -15,7 +15,7 @@ foreach(TEST_SRC ${BENCHMARK_SRCS})
     target_link_libraries(
         ${TEST_TARGET}
         PUBLIC
-            ttnn
+            TTNN::TTNN
             test_common_libs
             benchmark::benchmark
             Python3::Python
@@ -28,6 +28,7 @@ foreach(TEST_SRC ${BENCHMARK_SRCS})
             ${PROJECT_SOURCE_DIR}/tests
             ${PROJECT_SOURCE_DIR}/tests/tt_metal/test_utils
             ${PROJECT_SOURCE_DIR}/ttnn/cpp
+            ${PROJECT_SOURCE_DIR}/ttnn/api
             ${PROJECT_SOURCE_DIR}/ttnn/
             ${CMAKE_CURRENT_SOURCE_DIR}
     )


### PR DESCRIPTION
### Ticket
N/A

### Problem description
I noticed that compilation with --without-python-bindings flag fails, so I fixed it

### What's changed
- Link with TTNN::TTNN instead of ttnn, which is mapped to ttnncpp if there is no bindings.
- Added missing include path: `${PROJECT_SOURCE_DIR}/ttnn/api`

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes -- https://github.com/tenstorrent/tt-metal/actions/runs/19030965010 
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable) -- https://github.com/tenstorrent/tt-metal/actions/runs/19030981231