### PR TITLE
Fuse bias in ttnn::linear for dram interleaved tensors

### DIFF
--- a/models/demos/gemma3/tests/perf_targets/targets_test_perf_vision_cross_attention_transformer.json
+++ b/models/demos/gemma3/tests/perf_targets/targets_test_perf_vision_cross_attention_transformer.json
@@ -1,7 +1,7 @@
 {
     "gemma-3-4b-it": {
         "N150": {
-            "model_forward_inference": 0.8154604666666667
+            "model_forward_inference": 0.7746874433333334
         },
         "N300": {
             "model_forward_inference": 0.5668675333333334
@@ -9,7 +9,7 @@
     },
     "gemma-3-27b-it": {
         "N150": {
-            "model_forward_inference": 0.8156708666666668
+            "model_forward_inference": 0.7746874433333334
         },
         "N300": {
             "model_forward_inference": 0.5553348666666668

--- a/models/demos/wormhole/stable_diffusion/tt/vae/ttnn_vae_resnet.py
+++ b/models/demos/wormhole/stable_diffusion/tt/vae/ttnn_vae_resnet.py
@@ -121,7 +121,7 @@ class ResnetBlock:
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
         )
 
-        hidden_states = ttnn.silu(hidden_states)
+        hidden_states = ttnn.silu(hidden_states, output_tensor=hidden_states)
 
         hidden_states = self.conv1(hidden_states)
 

--- a/models/experimental/oft/demo/demo.py
+++ b/models/experimental/oft/demo/demo.py
@@ -54,7 +54,7 @@ from tests.ttnn.unit_tests.base_functionality.test_bh_20_cores_sharding import s
     "model_dtype, fallback_feedforward, fallback_lateral, fallback_oft, use_host_decoder, pcc_scores_oft, pcc_positions_oft, pcc_dimensions_oft, pcc_angles_oft",
     # fmt: off
     [
-       ( torch.float32, False, False, False, False, 0.906, 0.978, 0.999, 0.929),
+       ( torch.float32, False, False, False, False, 0.905, 0.979, 0.999, 0.9288),
     ],
     # fmt: on
 )

--- a/models/experimental/oft/tests/pcc/test_oftnet.py
+++ b/models/experimental/oft/tests/pcc/test_oftnet.py
@@ -37,10 +37,10 @@ from loguru import logger
     "model_dtype, use_host_oft, pcc_scores_oft, pcc_positions_oft, pcc_dimensions_oft, pcc_angles_oft",
     # fmt: off
     [
-       ( torch.bfloat16, False, 0.822, 0.893, 0.998, 0.904),
+       ( torch.bfloat16, False, 0.84, 0.889, 0.998, 0.904),
        ( torch.bfloat16,  True, 0.862, 0.964, 0.999, 0.894),
-       ( torch.float32, False, 0.906, 0.978, 0.999, 0.929),
-       ( torch.float32,  True, 0.914, 0.881, 0.998, 0.918)
+       ( torch.float32, False, 0.905, 0.979, 0.999, 0.928),
+       ( torch.float32,  True, 0.916, 0.881, 0.998, 0.918)
     ],
     # fmt: on
     ids=[
@@ -158,7 +158,7 @@ def test_oftnet(
 
         all_passed.append(passed)
         special_char = "✅" if passed else "❌"
-        logger.warning(f"{special_char} Output {i} {layer_name}: {passed=}, {pcc=}, {abs=:.3f}, {rel=:.3f}")
+        logger.warning(f"{special_char} Output {i} {layer_name}: {passed=}, {pcc=}, {exp_pcc=}, {abs=:.3f}, {rel=:.3f}")
         if passed and float(pcc) - exp_pcc > 0.001:
             logger.warning(
                 f"⚠️  Output {i} {layer_name} PCC is better than expected by {float(pcc)-exp_pcc:.3f}. Please update expected PCC value to {math.floor(float(pcc) * 1000) / 1000:.3f}."

--- a/models/experimental/panoptic_deeplab/tests/test_device_perf_pdl.py
+++ b/models/experimental/panoptic_deeplab/tests/test_device_perf_pdl.py
@@ -12,7 +12,7 @@ from models.experimental.panoptic_deeplab.reference.pytorch_model import PANOPTI
     [
         (
             "pytest models/experimental/panoptic_deeplab/tests/pcc/test_tt_model.py::test_model_panoptic_deeplab -k test_panoptic_deeplab",
-            57_238_691,
+            52_637_788,
             PANOPTIC_DEEPLAB,
             PANOPTIC_DEEPLAB,
             1,
@@ -22,7 +22,7 @@ from models.experimental.panoptic_deeplab.reference.pytorch_model import PANOPTI
         ),
         (
             "pytest models/experimental/panoptic_deeplab/tests/pcc/test_tt_model.py::test_model_panoptic_deeplab -k test_deeplab_v3_plus",
-            39_294_523,
+            35_506_710,
             DEEPLAB_V3_PLUS,
             DEEPLAB_V3_PLUS,
             1,

--- a/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
@@ -80,7 +80,7 @@ def test_sdxl_unet_perf_device():
 
 @pytest.mark.models_device_performance_bare_metal
 def test_sdxl_vae_decode_perf_device():
-    expected_device_perf_cycles_per_iteration = 954_689_017
+    expected_device_perf_cycles_per_iteration = 932_430_106
     command = f"pytest models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_autoencoder_kl.py::test_vae -k 'test_decode'"
     cols = ["DEVICE FW", "DEVICE KERNEL", "DEVICE BRISC KERNEL"]
 
@@ -105,7 +105,7 @@ def test_sdxl_vae_decode_perf_device():
 
 @pytest.mark.models_device_performance_bare_metal
 def test_sdxl_vae_encode_perf_device():
-    expected_device_perf_cycles_per_iteration = 502_563_162
+    expected_device_perf_cycles_per_iteration = 492_473_727
     command = f"pytest models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_autoencoder_kl.py::test_vae -k 'test_encode'"
     cols = ["DEVICE FW", "DEVICE KERNEL", "DEVICE BRISC KERNEL"]
 

--- a/models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_autoencoder_kl.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_autoencoder_kl.py
@@ -20,7 +20,7 @@ from loguru import logger
     "input_shape, pcc, vae_block",
     [
         ((1, 4, 128, 128), 0.933, "decoder"),
-        ((1, 3, 1024, 1024), 0.977, "encoder"),
+        ((1, 3, 1024, 1024), 0.9769, "encoder"),
     ],
     ids=("test_decode", "test_encode"),
 )

--- a/models/experimental/stable_diffusion_xl_refiner/tests/test_sdxl_refiner_perf.py
+++ b/models/experimental/stable_diffusion_xl_refiner/tests/test_sdxl_refiner_perf.py
@@ -48,7 +48,7 @@ def test_unet(
 
 @pytest.mark.models_device_performance_bare_metal
 def test_sdxl_refiner_perf_device():
-    expected_device_perf_cycles_per_iteration = 1_049_370_231
+    expected_device_perf_cycles_per_iteration = 999_962_816
 
     command = f"pytest models/experimental/stable_diffusion_xl_refiner/tests/test_sdxl_refiner_perf.py::test_unet"
     cols = ["DEVICE FW", "DEVICE KERNEL", "DEVICE BRISC KERNEL"]


### PR DESCRIPTION
By default ttnn::linear will not fuse bias. 
There is not easy way to get it fused (besides providing full program config or core grid).
Reason for this is that there are paths within matmul op that do not implement bias (MatmulMultiCoreProgramConfig config).

Path for default program config is overly conservative ATM and just disables bias fusing.
In case all input and output tensors are dram interleaved it's safe to fuse bias.

Motivation for this comes from Conv2d where a class of Conv2ds is implemented as ttnn::linear.
In case inputs are dram interleaved Covn2d just calls ttnn::linear w/o specifying advance params in order to get best generality.
In this case currently bias doesn't get fused, so dram interleaved version of binary add is triggered which can be extremely  slow.

Main motivation for this work is to get significant e2e speed up on OFT model, but other models are benefiting as well.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/19010305694)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/19010310841)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/runs/19019310424) 
- [x] [(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/19016418884)
- [x] [Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/runs/19017658176) 
- [x] [(Blackhole) Blackhole nightly tests](https://github.com/tenstorrent/tt-metal/actions/runs/19019305975)