### PR TITLE
#0: Remove const on input_tensor as it's not respected

### DIFF
--- a/ttnn/cpp/ttnn/operations/conv/conv1d/conv1d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv1d/conv1d.cpp
@@ -34,7 +34,7 @@ using namespace tt;
 namespace conv1d {
 
 Result conv1d(
-    const ttnn::Tensor& input_tensor,
+    ttnn::Tensor& input_tensor,
     const ttnn::Tensor& weight_tensor,
     MeshDevice* device,
     uint32_t in_channels,
@@ -54,10 +54,9 @@ Result conv1d(
     bool return_output_dim,
     bool return_weights_and_bias) {
     // reshape input tensor to 4D, if it is not already
-    const ttnn::Tensor& input_tensor_4d =
-        (input_tensor.logical_shape().rank() < 4)
-            ? ttnn::reshape(input_tensor, Shape({batch_size, input_length, 1, in_channels}))
-            : input_tensor;
+    ttnn::Tensor input_tensor_4d = (input_tensor.logical_shape().rank() < 4)
+                                       ? ttnn::reshape(input_tensor, Shape({batch_size, input_length, 1, in_channels}))
+                                       : input_tensor;
 
     // padding for conv2d based on conv1d padding
     std::variant<std::array<uint32_t, 2>, std::array<uint32_t, 4>> conv2d_padding;
@@ -110,7 +109,7 @@ Result conv1d(
     };
 }
 Result Conv1dOperation::invoke(
-    const ttnn::Tensor& input_tensor,
+    ttnn::Tensor& input_tensor,
     const ttnn::Tensor& weight_tensor,
     MeshDevice* device,
     uint32_t in_channels,

--- a/ttnn/cpp/ttnn/operations/conv/conv1d/conv1d.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv1d/conv1d.hpp
@@ -29,7 +29,7 @@ using Result = std::variant<
 using Conv1dConfig = ttnn::operations::conv::conv2d::Conv2dConfig;
 
 Result conv1d(
-    const ttnn::Tensor& input_tensor,
+    ttnn::Tensor& input_tensor,
     const ttnn::Tensor& weight_tensor,
     MeshDevice* device,
     uint32_t in_channels,
@@ -54,7 +54,7 @@ Result conv1d(
 // The input and weight tensors are reshaped to 4D tensors before invoking the Conv2dOperation.
 struct Conv1dOperation {
     static Result invoke(
-        const ttnn::Tensor& input_tensor,
+        ttnn::Tensor& input_tensor,
         const ttnn::Tensor& weight_tensor,
         MeshDevice* device,
         uint32_t in_channels,

--- a/ttnn/cpp/ttnn/operations/conv/conv1d/conv1d_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv1d/conv1d_pybind.cpp
@@ -60,7 +60,7 @@ void py_bind_conv1d(py::module& module) {
         )doc",
         ttnn::pybind_overload_t{
             [](const decltype(ttnn::conv1d)& self,
-               const ttnn::Tensor& input_tensor,
+               ttnn::Tensor& input_tensor,
                const ttnn::Tensor& weight_tensor,
                ttnn::MeshDevice* device,
                uint32_t in_channels,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
@@ -58,7 +58,7 @@ ResultWithOptions result_to_result_with_options(
 }
 
 ResultWithOptions conv2d(
-    const ttnn::Tensor& input_tensor,
+    ttnn::Tensor& input_tensor,
     const ttnn::Tensor& weight_tensor,
     MeshDevice* device,
     uint32_t in_channels,
@@ -194,7 +194,7 @@ ResultWithOptions conv2d(
 // number of such slices.
 // Conv2dConfig does not control the final output, but rather the conv2d_L1 function that is called internally.
 Result conv2d_DRAM(
-    const ttnn::Tensor& input_tensor,
+    ttnn::Tensor& input_tensor,
     const ttnn::Tensor& weight_tensor,
     MeshDevice* device,
     uint32_t in_channels,
@@ -431,7 +431,7 @@ Result conv2d_DRAM(
 }
 
 Result conv2d_L1(
-    const ttnn::Tensor& input_tensor_,
+    ttnn::Tensor& input_tensor_,
     const ttnn::Tensor& weight_tensor_,
     MeshDevice* device,
     uint32_t in_channels,
@@ -757,7 +757,7 @@ Result conv2d_L1(
 }
 
 ResultWithOptions Conv2dOperation::invoke(
-    const ttnn::Tensor& input_tensor,
+    ttnn::Tensor& input_tensor,
     const ttnn::Tensor& weight_tensor,
     MeshDevice* device,
     uint32_t in_channels,
@@ -1016,10 +1016,10 @@ ttnn::Tensor Conv2dSliceAttr::run_L1_op(
 
     // Force Conv2d_L1 to always output tiled layout to reduce CB Memory usage.
     conv_config_l1.output_layout = Layout::TILE;
-
+    auto this_input_tensor = sliced_input_tensor;
     auto conv2d_result = conv2d_L1(
-        sliced_input_tensor,
-       weight_tensor,
+        this_input_tensor,
+        weight_tensor,
         device,
         input_channels,
         output_channels,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.hpp
@@ -36,7 +36,7 @@ using ResultWithOptions = std::variant<
         std::tuple<ttnn::Tensor, std::optional<ttnn::Tensor>>>>;
 
 Result conv2d_L1(
-    const ttnn::Tensor& input_tensor,
+    ttnn::Tensor& input_tensor,
     const ttnn::Tensor& weight_tensor,
     MeshDevice* device,
     uint32_t in_channels,
@@ -56,7 +56,7 @@ Result conv2d_L1(
     const std::optional<const MemoryConfig>& memory_config = std::nullopt);
 
 Result conv2d_DRAM(
-    const ttnn::Tensor& input_tensor,
+    ttnn::Tensor& input_tensor,
     const ttnn::Tensor& weight_tensor,
     MeshDevice* device,
     uint32_t in_channels,
@@ -77,7 +77,7 @@ Result conv2d_DRAM(
     const std::optional<const Conv2dSliceConfig>& dram_slice_config_ = std::nullopt);
 
 ResultWithOptions conv2d(
-    const ttnn::Tensor& input_tensor,
+    ttnn::Tensor& input_tensor,
     const ttnn::Tensor& weight_tensor,
     MeshDevice* device,
     uint32_t in_channels,
@@ -101,7 +101,7 @@ ResultWithOptions conv2d(
 
 struct Conv2dOperation {
     static ResultWithOptions invoke(
-        const ttnn::Tensor& input_tensor,
+        ttnn::Tensor& input_tensor,
         const ttnn::Tensor& weight_tensor,
         MeshDevice* device,
         uint32_t in_channels,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_pybind.cpp
@@ -70,7 +70,7 @@ void py_bind_conv2d(py::module& module) {
         )doc",
         ttnn::pybind_overload_t{
             [](const decltype(ttnn::conv2d)& self,
-               const ttnn::Tensor& input_tensor,
+               ttnn::Tensor& input_tensor,
                const ttnn::Tensor& weight_tensor,
                ttnn::MeshDevice* device,
                uint32_t in_channels,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.hpp
@@ -182,7 +182,7 @@ ttnn::Shape flatten_4d_shape(const ttnn::Shape& input_shape);
 std::tuple<ttnn::Tensor, sliding_window::ParallelConfig, sliding_window::ParallelConfig>
 shard_or_reshard_tensor_if_required(
     MeshDevice* device,
-    const ttnn::Tensor& input_tensor_,
+    ttnn::Tensor& input_tensor_,
     const Conv2dConfig& conv_config,
     uint32_t batch_size,
     uint32_t height,
@@ -202,7 +202,7 @@ bool auto_enable_kernel_folding(
     std::array<uint32_t, 4>& padding_n4);
 
 Tensor fold_input_tensor_if_required(
-    const ttnn::Tensor& input_tensor,
+    ttnn::Tensor& input_tensor,
     MeshDevice* device,
     uint32_t& input_height,
     uint32_t& input_width,

--- a/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/conv_transpose2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/conv_transpose2d.cpp
@@ -24,7 +24,7 @@ using sliding_window::SlidingWindowConfig;
 namespace conv_transpose2d {
 
 Result conv_transpose2d(
-    const ttnn::Tensor& input_tensor,
+    ttnn::Tensor& input_tensor,
     const ttnn::Tensor& weight_tensor,
     MeshDevice* device,
     uint32_t in_channels,
@@ -313,7 +313,7 @@ Result conv_transpose2d(
 }
 
 Result ConvTranpose2dOperation::invoke(
-    const ttnn::Tensor& input_tensor,
+    ttnn::Tensor& input_tensor,
     const ttnn::Tensor& weight_tensor,
     MeshDevice* device,
     uint32_t in_channels,

--- a/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/conv_transpose2d.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/conv_transpose2d.hpp
@@ -26,7 +26,7 @@ using Result = std::variant<
 
 struct ConvTranpose2dOperation {
     static Result invoke(
-        const ttnn::Tensor& input_tensor,
+        ttnn::Tensor& input_tensor,
         const ttnn::Tensor& weight_tensor,
         IDevice* device,
         uint32_t in_channels,
@@ -50,7 +50,7 @@ struct ConvTranpose2dOperation {
         bool return_weights_and_bias = false);
 
     static Result invoke(
-        const ttnn::Tensor& input_tensor,
+        ttnn::Tensor& input_tensor,
         const ttnn::Tensor& weight_tensor,
         MeshDevice* device,
         uint32_t in_channels,

--- a/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/conv_transpose2d_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/conv_transpose2d_pybind.cpp
@@ -84,7 +84,7 @@ void py_bind_conv_transpose2d(py::module& module) {
 
         ttnn::pybind_overload_t{
             [](const decltype(ttnn::conv_transpose2d)& self,
-               const ttnn::Tensor& input_tensor,
+               ttnn::Tensor& input_tensor,
                const ttnn::Tensor& weight_tensor,
                ttnn::MeshDevice* device,
                uint32_t in_channels,


### PR DESCRIPTION
### Problem description
Input tensor to conv2d is marked as const, but it's not actually const. The deallocate_activiation will delete the tensor. Currently deallocate_actiavtion has been implemented using a hack.

### What's changed
Removed const for input_tensor to conv2d and removed the deallocate activation hack.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes