### PR TITLE
Improve accuracy and speed of accurate tanh (#25325)

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
@@ -1440,7 +1440,7 @@ def test_unary_threshold_ttnn(input_shapes, threshold, value, device):
     ],
 )
 def test_unary_clamp_tss_float_ttnn(input_shapes, min_val, max_val, torch_dtype, ttnn_dtype, device):
-    in_data1 = torch.empty(input_shapes, dtype=torch_dtype).uniform_(-100, 100)
+    in_data1 = torch.empty(input_shapes, dtype=torch_dtype).uniform_(-10, 10)
     input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
     min = min_val
     max = max_val
@@ -1465,12 +1465,12 @@ def test_unary_clamp_tss_float_ttnn(input_shapes, min_val, max_val, torch_dtype,
 @pytest.mark.parametrize(
     "torch_dtype, ttnn_dtype, atol",
     [
-        (torch.float32, ttnn.float32, 0.002),
+        (torch.float32, ttnn.float32, 0.001),
         (torch.bfloat16, ttnn.bfloat16, 0.008),
     ],
 )
 def test_unary_tanh_ttnn(input_shapes, torch_dtype, ttnn_dtype, atol, device):
-    in_data1 = torch.empty(input_shapes, dtype=torch_dtype).uniform_(-100, 100)
+    in_data1 = torch.empty(input_shapes, dtype=torch_dtype).uniform_(-10, 10)
     input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
     if ttnn_dtype == ttnn.bfloat8_b:
         in_data1 = ttnn.to_torch(input_tensor1, dtype=torch_dtype)
@@ -1499,7 +1499,7 @@ def test_unary_tanh_ttnn(input_shapes, torch_dtype, ttnn_dtype, atol, device):
     ],
 )
 def test_unary_tanh_approx_ttnn(input_shapes, torch_dtype, ttnn_dtype, device):
-    in_data1 = torch.empty(input_shapes, dtype=torch_dtype).uniform_(-100, 100)
+    in_data1 = torch.empty(input_shapes, dtype=torch_dtype).uniform_(-10, 10)
     input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
     if ttnn_dtype == ttnn.bfloat8_b:
         in_data1 = ttnn.to_torch(input_tensor1, dtype=torch_dtype)

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
@@ -18,7 +18,7 @@ sfpi_inline sfpi::vFloat _sfpu_tanh_continued_fraction_(sfpi::vFloat val) {
     // This approximation is derived from a continued fraction formula of tanh(x)
 
     // For negative numbers, we compute tanh(x) = -tanh(x)
-    sfpi::vFloat x = sfpi::setsgn(val, 0);  // set positive
+    sfpi::vFloat x = sfpi::abs(val);  // set positive
 
     // Compute numerator and denominator of continued fraction using Horner's method
     sfpi::vFloat x2 = x * x;
@@ -46,7 +46,7 @@ sfpi_inline sfpi::vFloat _sfpu_tanh_continued_fraction_(sfpi::vFloat val) {
 template <bool is_fp32_acc_to_dest_mode = true>
 sfpi_inline sfpi::vFloat _sfpu_tanh_polynomial_(sfpi::vFloat x) {
     // For negative numbers, we compute tanh(-x) = -tanh(x)
-    sfpi::vFloat val = sfpi::setsgn(x, 0);  // set positive
+    sfpi::vFloat val = sfpi::abs(x);  // set positive
 
     // Polynomial coefficients found using Sollya
     // val * (0.999004364013671875 + val * (3.0897438526153564453125e-2 + val * (-0.4890659749507904052734375 + val *

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
@@ -83,28 +83,28 @@ template <bool APPROXIMATION_MODE, int ITERATIONS = 8, bool is_fp32_dest_acc_en 
 inline void calculate_tanh() {
     if constexpr (APPROXIMATION_MODE) {
         // SFPU microcode
-        vUInt l0 = l_reg[LRegs::LReg0];
-        vUInt l1 = l_reg[LRegs::LReg1];
-        vUInt l2 = l_reg[LRegs::LReg2];
+        sfpi::vUInt l0 = l_reg[sfpi::LRegs::LReg0];
+        sfpi::vUInt l1 = l_reg[sfpi::LRegs::LReg1];
+        sfpi::vUInt l2 = l_reg[sfpi::LRegs::LReg2];
 
 #pragma GCC unroll 8
         for (int d = 0; d < ITERATIONS; d++) {
-            vFloat val = dst_reg[0];
-            val = lut(val, l0, l1, l2);
-            dst_reg[0] = val;
+            sfpi::vFloat val = sfpi::dst_reg[0];
+            val = sfpi::lut(val, l0, l1, l2);
+            sfpi::dst_reg[0] = val;
 
-            dst_reg++;
+            sfpi::dst_reg++;
         }
 
-        l_reg[LRegs::LReg0] = l0;
-        l_reg[LRegs::LReg1] = l1;
-        l_reg[LRegs::LReg2] = l2;
+        l_reg[sfpi::LRegs::LReg0] = l0;
+        l_reg[sfpi::LRegs::LReg1] = l1;
+        l_reg[sfpi::LRegs::LReg2] = l2;
     } else {  // APPROXIMATION_MODE is false
 
         for (int d = 0; d < ITERATIONS; d++) {
-            vFloat val = dst_reg[0];
+            sfpi::vFloat val = sfpi::dst_reg[0];
 
-            vFloat result;
+            sfpi::vFloat result;
 
             if constexpr (is_fp32_dest_acc_en) {
                 result = _sfpu_tanh_continued_fraction_<is_fp32_dest_acc_en>(val);
@@ -112,8 +112,8 @@ inline void calculate_tanh() {
                 result = _sfpu_tanh_polynomial_<is_fp32_dest_acc_en>(val);
             }
 
-            dst_reg[0] = result;
-            dst_reg++;
+            sfpi::dst_reg[0] = result;
+            sfpi::dst_reg++;
         }
     }
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
@@ -26,7 +26,6 @@ sfpi_inline sfpi::vFloat _sfpu_tanh_continued_fraction_(sfpi::vFloat val) {
     sfpi::vFloat x2 = x * x;
     sfpi::vFloat numerator = x * (135135.f + x2 * (17326.f + x2 * (378.f + x2)));
 
-    // constexpr float denominator_coefs[] = {28.f, 3150.f, 62370.f, 135135.f};
     constexpr float denominator_coefs[] = {135135.f, 62370.f, 3150.f, 28.f};
     sfpi::vFloat denominator = PolynomialEvaluator<4, sfpi::vFloat, float>::eval(denominator_coefs, x2);
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
@@ -49,13 +49,16 @@ sfpi_inline sfpi::vFloat _sfpu_tanh_polynomial_(sfpi::vFloat x) {
     // For negative numbers, we compute tanh(x) = -tanh(x)
     sfpi::vFloat val = sfpi::setsgn(x, 0);  // set positive
 
+    // val * (0.999004364013671875 + val * (3.0897438526153564453125e-2 + val * (-0.4890659749507904052734375 + val *
+    // (0.281917631626129150390625 + val * (-6.6649019718170166015625e-2 + val *
+    // (5.876733921468257904052734375e-3))))));
     sfpi::vFloat result = POLYVAL7<sfpi::vFloat>(
-        0.999004364013671875,
-        3.0897438526153564453125e-2,
-        -0.4890659749507904052734375,
-        sfpi::vConstFloatPrgm2,
-        sfpi::vConstFloatPrgm1,
         sfpi::vConstFloatPrgm0,
+        sfpi::vConstFloatPrgm1,
+        sfpi::vConstFloatPrgm2,
+        -0.4890659749507904052734375,
+        3.0897438526153564453125e-2,
+        0.999004364013671875,
         sfpi::vConst0,
         val);
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
@@ -8,8 +8,6 @@
 #include "ckernel_defs.h"
 #include "sfpu/ckernel_sfpu_polyval.h"
 
-using namespace sfpi;
-
 namespace ckernel {
 namespace sfpu {
 
@@ -120,12 +118,9 @@ inline void calculate_tanh() {
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en = false>
 inline void tanh_init() {
     if constexpr (APPROXIMATION_MODE) {
-        uint imm0;
-        uint imm1;
-        uint imm2;
-        imm0 = 0x1DFF;  // 0.90625*x
-        imm1 = 0x481A;  // 0.09375*x + 0.8125
-        imm2 = 0xFF00;  // 1
+        uint imm0 = 0x1DFF;  // 0.90625*x
+        uint imm1 = 0x481A;  // 0.09375*x + 0.8125
+        uint imm2 = 0xFF00;  // 1
         _sfpu_load_imm16_(0, imm0);
         _sfpu_load_imm16_(1, imm1);
         _sfpu_load_imm16_(2, imm2);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
@@ -12,38 +12,120 @@ using namespace sfpi;
 namespace ckernel {
 namespace sfpu {
 
-template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_tanh() {
-    // SFPU microcode
-    vUInt l0 = l_reg[LRegs::LReg0];
-    vUInt l1 = l_reg[LRegs::LReg1];
-    vUInt l2 = l_reg[LRegs::LReg2];
+template <bool is_fp32_acc_to_dest_mode = true>
+sfpi_inline sfpi::vFloat _sfpu_tanh_continued_fraction_(sfpi::vFloat val) {
+    // Formula found at
+    // https://varietyofsound.wordpress.com/2011/02/14/efficient-tanh-computation-using-lamberts-continued-fraction/
 
-#pragma GCC unroll 8
-    for (int d = 0; d < ITERATIONS; d++) {
-        vFloat val = dst_reg[0];
-        val = lut(val, l0, l1, l2);
-        dst_reg[0] = val;
+    // This approximation is derived from a continued fraction formula of tanh(x)
 
-        dst_reg++;
+    sfpi::vFloat x = sfpi::setsgn(val, 0);  // set positive
+
+    sfpi::vFloat x2 = x * x;
+    sfpi::vFloat numerator = x * (135135.f + x2 * (17326.f + x2 * (378.f + x2)));
+    sfpi::vFloat denominator = 135135.f + x2 * (62370.f + x2 * (3150.f + 28.f * x2));
+
+    sfpi::vFloat result = ckernel::sfpu::_sfpu_reciprocal_<2>(denominator);
+    result = result * numerator;
+
+    sfpi::vFloat threshold_value = sfpi::vConst1;
+    sfpi::vec_min_max(result, threshold_value);
+
+    result = sfpi::setsgn(result, val);  // restore sign (i.e. tanh(-x) = -tanh(x))
+
+    if constexpr (!is_fp32_acc_to_dest_mode) {
+        result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
     }
 
-    l_reg[LRegs::LReg0] = l0;
-    l_reg[LRegs::LReg1] = l1;
-    l_reg[LRegs::LReg2] = l2;
+    return result;
 }
 
-template <bool APPROXIMATION_MODE>
+template <bool is_fp32_acc_to_dest_mode = true>
+sfpi_inline sfpi::vFloat _sfpu_tanh_polynomial_(sfpi::vFloat x) {
+    sfpi::vFloat val = sfpi::setsgn(x, 0);  // set positive
+
+    sfpi::vFloat result =
+        val * (0.999004364013671875 +
+               val * (3.0897438526153564453125e-2 +
+                      val * (-0.4890659749507904052734375 +
+                             val * (sfpi::vConstFloatPrgm2 +
+                                    val * (sfpi::vConstFloatPrgm1 + val * (sfpi::vConstFloatPrgm0))))));
+
+    sfpi::vFloat threshold_value = sfpi::vConst1;
+    sfpi::vec_min_max(result, threshold_value);
+
+    result = sfpi::setsgn(result, x);  // restore sign (i.e. tanh(-x) = -tanh(x))
+
+    if constexpr (!is_fp32_acc_to_dest_mode) {
+        result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
+    }
+
+    return result;
+}
+
+template <bool APPROXIMATION_MODE, int ITERATIONS = 8, bool is_fp32_dest_acc_en = false>
+inline void calculate_tanh() {
+    if constexpr (APPROXIMATION_MODE) {
+        // SFPU microcode
+        vUInt l0 = l_reg[LRegs::LReg0];
+        vUInt l1 = l_reg[LRegs::LReg1];
+        vUInt l2 = l_reg[LRegs::LReg2];
+
+#pragma GCC unroll 8
+        for (int d = 0; d < ITERATIONS; d++) {
+            vFloat val = dst_reg[0];
+            val = lut(val, l0, l1, l2);
+            dst_reg[0] = val;
+
+            dst_reg++;
+        }
+
+        l_reg[LRegs::LReg0] = l0;
+        l_reg[LRegs::LReg1] = l1;
+        l_reg[LRegs::LReg2] = l2;
+    } else {  // APPROXIMATION_MODE is false
+
+        for (int d = 0; d < ITERATIONS; d++) {
+            vFloat val = dst_reg[0];
+
+            vFloat result;
+
+            if constexpr (is_fp32_dest_acc_en) {
+                result = _sfpu_tanh_continued_fraction_<is_fp32_dest_acc_en>(val);
+            } else {
+                result = _sfpu_tanh_polynomial_<is_fp32_dest_acc_en>(val);
+            }
+
+            dst_reg[0] = result;
+            dst_reg++;
+        }
+    }
+}
+
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en = false>
 inline void tanh_init() {
-    uint imm0;
-    uint imm1;
-    uint imm2;
-    imm0 = 0x1DFF;  // 0.90625*x
-    imm1 = 0x481A;  // 0.09375*x + 0.8125
-    imm2 = 0xFF00;  // 1
-    _sfpu_load_imm16_(0, imm0);
-    _sfpu_load_imm16_(1, imm1);
-    _sfpu_load_imm16_(2, imm2);
+    if constexpr (APPROXIMATION_MODE) {
+        uint imm0;
+        uint imm1;
+        uint imm2;
+        imm0 = 0x1DFF;  // 0.90625*x
+        imm1 = 0x481A;  // 0.09375*x + 0.8125
+        imm2 = 0xFF00;  // 1
+        _sfpu_load_imm16_(0, imm0);
+        _sfpu_load_imm16_(1, imm1);
+        _sfpu_load_imm16_(2, imm2);
+    } else {
+        if constexpr (is_fp32_dest_acc_en) {
+            // Continue fraction
+            ckernel::sfpu::_init_reciprocal_<false, false>();
+        } else {
+            // Polynomial approximation
+            // Store some polynomial coefficients in programmable registers
+            sfpi::vConstFloatPrgm0 = 5.876733921468257904052734375e-3;
+            sfpi::vConstFloatPrgm1 = -6.6649019718170166015625e-2;
+            sfpi::vConstFloatPrgm2 = 0.281917631626129150390625;
+        }
+    }
 }
 
 }  // namespace sfpu

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
@@ -32,8 +32,8 @@ sfpi_inline sfpi::vFloat _sfpu_tanh_continued_fraction_(sfpi::vFloat val) {
 
     sfpi::vFloat result = numerator * ckernel::sfpu::_sfpu_reciprocal_<2>(denominator);
 
-    // The limits of the continued fraction is +inf.
-    // Since tanh(x) -> +inf, we clamp output to 1.0
+    // For larger x, the continued fraction may exceed 1.0.
+    // Since tanh(x) is bounded by [-1, 1], we clamp output to 1.0.
     sfpi::vFloat threshold_value = sfpi::vConst1;
     sfpi::vec_min_max(result, threshold_value);
 
@@ -48,7 +48,7 @@ sfpi_inline sfpi::vFloat _sfpu_tanh_continued_fraction_(sfpi::vFloat val) {
 
 template <bool is_fp32_acc_to_dest_mode = true>
 sfpi_inline sfpi::vFloat _sfpu_tanh_polynomial_(sfpi::vFloat x) {
-    // For negative numbers, we compute tanh(x) = -tanh(x)
+    // For negative numbers, we compute tanh(-x) = -tanh(x)
     sfpi::vFloat val = sfpi::setsgn(x, 0);  // set positive
 
     // Polynomial coefficients found using Sollya
@@ -65,8 +65,8 @@ sfpi_inline sfpi::vFloat _sfpu_tanh_polynomial_(sfpi::vFloat x) {
         sfpi::vConst0,
         val);
 
-    // The limits of the polynomial approximation is +inf.
-    // Since tanh(x) -> +inf, we clamp output to 1.0
+    // For larger x, the polynomial approximation may exceed 1.0.
+    // Since tanh(x) is bounded by [-1, 1], we clamp output to 1.0.
     sfpi::vFloat threshold_value = sfpi::vConst1;
     sfpi::vec_min_max(result, threshold_value);
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
@@ -6,7 +6,7 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
-#include "ckernel_sfpu_polyval.h"
+#include "sfpu/ckernel_sfpu_polyval.h"
 
 using namespace sfpi;
 
@@ -49,14 +49,15 @@ sfpi_inline sfpi::vFloat _sfpu_tanh_polynomial_(sfpi::vFloat x) {
     // For negative numbers, we compute tanh(x) = -tanh(x)
     sfpi::vFloat val = sfpi::setsgn(x, 0);  // set positive
 
-    // Polynomial approximation (rank 6)
-    // Found using Sollya
-    sfpi::vFloat result =
-        val * (0.999004364013671875 +
-               val * (3.0897438526153564453125e-2 +
-                      val * (-0.4890659749507904052734375 +
-                             val * (sfpi::vConstFloatPrgm2 +
-                                    val * (sfpi::vConstFloatPrgm1 + val * (sfpi::vConstFloatPrgm0))))));
+    sfpi::vFloat result = POLYVAL7<sfpi::vFloat>(
+        0.999004364013671875,
+        3.0897438526153564453125e-2,
+        -0.4890659749507904052734375,
+        sfpi::vConstFloatPrgm2,
+        sfpi::vConstFloatPrgm1,
+        sfpi::vConstFloatPrgm0,
+        sfpi::vConst0,
+        val);
 
     // The limits of the polynomai approximation is +inf.
     // Since tanh(x) -> +inf, we clamp output to 1.0

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
@@ -25,10 +25,12 @@ sfpi_inline sfpi::vFloat _sfpu_tanh_continued_fraction_(sfpi::vFloat val) {
     // Compute numerator and denominator of continued fraction using Horner's method
     sfpi::vFloat x2 = x * x;
     sfpi::vFloat numerator = x * (135135.f + x2 * (17326.f + x2 * (378.f + x2)));
-    sfpi::vFloat denominator = 135135.f + x2 * (62370.f + x2 * (3150.f + 28.f * x2));
 
-    sfpi::vFloat result = ckernel::sfpu::_sfpu_reciprocal_<2>(denominator);
-    result = result * numerator;
+    // constexpr float denominator_coefs[] = {28.f, 3150.f, 62370.f, 135135.f};
+    constexpr float denominator_coefs[] = {135135.f, 62370.f, 3150.f, 28.f};
+    sfpi::vFloat denominator = PolynomialEvaluator<4, sfpi::vFloat, float>::eval(denominator_coefs, x2);
+
+    sfpi::vFloat result = numerator * ckernel::sfpu::_sfpu_reciprocal_<2>(denominator);
 
     // The limits of the continued fraction is +inf.
     // Since tanh(x) -> +inf, we clamp output to 1.0
@@ -49,6 +51,7 @@ sfpi_inline sfpi::vFloat _sfpu_tanh_polynomial_(sfpi::vFloat x) {
     // For negative numbers, we compute tanh(x) = -tanh(x)
     sfpi::vFloat val = sfpi::setsgn(x, 0);  // set positive
 
+    // Polynomial coefficients found using Sollya
     // val * (0.999004364013671875 + val * (3.0897438526153564453125e-2 + val * (-0.4890659749507904052734375 + val *
     // (0.281917631626129150390625 + val * (-6.6649019718170166015625e-2 + val *
     // (5.876733921468257904052734375e-3))))));

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
@@ -62,7 +62,7 @@ sfpi_inline sfpi::vFloat _sfpu_tanh_polynomial_(sfpi::vFloat x) {
         sfpi::vConst0,
         val);
 
-    // The limits of the polynomai approximation is +inf.
+    // The limits of the polynomial approximation is +inf.
     // Since tanh(x) -> +inf, we clamp output to 1.0
     sfpi::vFloat threshold_value = sfpi::vConst1;
     sfpi::vec_min_max(result, threshold_value);
@@ -129,7 +129,7 @@ inline void tanh_init() {
         _sfpu_load_imm16_(2, imm2);
     } else {
         if constexpr (is_fp32_dest_acc_en) {
-            // Continue fraction
+            // Continued fraction
             ckernel::sfpu::_init_reciprocal_<false, false>();
         } else {
             // Polynomial approximation

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
@@ -25,7 +25,7 @@ sfpi_inline sfpi::vFloat _sfpu_tanh_continued_fraction_(sfpi::vFloat val) {
     sfpi::vFloat numerator = x * (135135.f + x2 * (17326.f + x2 * (378.f + x2)));
 
     constexpr float denominator_coefs[] = {135135.f, 62370.f, 3150.f, 28.f};
-    sfpi::vFloat denominator = PolynomialEvaluator<4, sfpi::vFloat, float>::eval(denominator_coefs, x2);
+    sfpi::vFloat denominator = PolynomialEvaluator::eval(x2, 135135.f, 62370.f, 3150.f, 28.f);
 
     sfpi::vFloat result = numerator * ckernel::sfpu::_sfpu_reciprocal_<2>(denominator);
 
@@ -52,15 +52,25 @@ sfpi_inline sfpi::vFloat _sfpu_tanh_polynomial_(sfpi::vFloat x) {
     // val * (0.999004364013671875 + val * (3.0897438526153564453125e-2 + val * (-0.4890659749507904052734375 + val *
     // (0.281917631626129150390625 + val * (-6.6649019718170166015625e-2 + val *
     // (5.876733921468257904052734375e-3))))));
-    sfpi::vFloat result = POLYVAL7<sfpi::vFloat>(
-        sfpi::vConstFloatPrgm0,
-        sfpi::vConstFloatPrgm1,
-        sfpi::vConstFloatPrgm2,
-        -0.4890659749507904052734375,
-        3.0897438526153564453125e-2,
-        0.999004364013671875,
+    // sfpi::vFloat result = POLYVAL7<sfpi::vFloat>(
+    //     sfpi::vConstFloatPrgm0,
+    //     sfpi::vConstFloatPrgm1,
+    //     sfpi::vConstFloatPrgm2,
+    //     -0.4890659749507904052734375,
+    //     3.0897438526153564453125e-2,
+    //     0.999004364013671875,
+    //     sfpi::vConst0,
+    //     val);
+
+    sfpi::vFloat result = PolynomialEvaluator::eval(
+        val,
         sfpi::vConst0,
-        val);
+        0.999004364013671875,
+        3.0897438526153564453125e-2,
+        -0.4890659749507904052734375,
+        sfpi::vConstFloatPrgm2,
+        sfpi::vConstFloatPrgm1,
+        sfpi::vConstFloatPrgm0);
 
     // For larger x, the polynomial approximation may exceed 1.0.
     // Since tanh(x) is bounded by [-1, 1], we clamp output to 1.0.

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
@@ -52,16 +52,6 @@ sfpi_inline sfpi::vFloat _sfpu_tanh_polynomial_(sfpi::vFloat x) {
     // val * (0.999004364013671875 + val * (3.0897438526153564453125e-2 + val * (-0.4890659749507904052734375 + val *
     // (0.281917631626129150390625 + val * (-6.6649019718170166015625e-2 + val *
     // (5.876733921468257904052734375e-3))))));
-    // sfpi::vFloat result = POLYVAL7<sfpi::vFloat>(
-    //     sfpi::vConstFloatPrgm0,
-    //     sfpi::vConstFloatPrgm1,
-    //     sfpi::vConstFloatPrgm2,
-    //     -0.4890659749507904052734375,
-    //     3.0897438526153564453125e-2,
-    //     0.999004364013671875,
-    //     sfpi::vConst0,
-    //     val);
-
     sfpi::vFloat result = PolynomialEvaluator::eval(
         val,
         sfpi::vConst0,

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_tanh.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_tanh.h
@@ -10,15 +10,15 @@
 
 namespace ckernel {
 
-template <bool APPROXIMATE>
+template <bool APPROXIMATE, bool is_fp32_dest_acc_en = false>
 inline void llk_math_eltwise_unary_sfpu_tanh_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::tanh, APPROXIMATE>(sfpu::tanh_init<APPROXIMATE>);
+    llk_math_eltwise_unary_sfpu_init<SfpuType::tanh, APPROXIMATE>(sfpu::tanh_init<APPROXIMATE, is_fp32_dest_acc_en>);
 }
 
-template <bool APPROXIMATE>
+template <bool APPROXIMATE, bool is_fp32_dest_acc_en = false>
 inline void llk_math_eltwise_unary_sfpu_tanh(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_tanh<APPROXIMATE>, dst_index, vector_mode);
+        ckernel::sfpu::calculate_tanh<APPROXIMATE, 8, is_fp32_dest_acc_en>, dst_index, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
@@ -18,7 +18,7 @@ sfpi_inline sfpi::vFloat _sfpu_tanh_continued_fraction_(sfpi::vFloat val) {
     // This approximation is derived from a continued fraction formula of tanh(x)
 
     // For negative numbers, we compute tanh(x) = -tanh(x)
-    sfpi::vFloat x = sfpi::setsgn(val, 0);  // set positive
+    sfpi::vFloat x = sfpi::abs(val);  // set positive
 
     // Compute numerator and denominator of continued fraction using Horner's method
     sfpi::vFloat x2 = x * x;
@@ -46,7 +46,7 @@ sfpi_inline sfpi::vFloat _sfpu_tanh_continued_fraction_(sfpi::vFloat val) {
 template <bool is_fp32_acc_to_dest_mode = true>
 sfpi_inline sfpi::vFloat _sfpu_tanh_polynomial_(sfpi::vFloat x) {
     // For negative numbers, we compute tanh(-x) = -tanh(x)
-    sfpi::vFloat val = sfpi::setsgn(x, 0);  // set positive
+    sfpi::vFloat val = sfpi::abs(x);  // set positive
 
     // Polynomial coefficients found using Sollya
     // val * (0.999004364013671875 + val * (3.0897438526153564453125e-2 + val * (-0.4890659749507904052734375 + val *

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
@@ -83,28 +83,28 @@ template <bool APPROXIMATION_MODE, int ITERATIONS = 8, bool is_fp32_dest_acc_en 
 inline void calculate_tanh() {
     if constexpr (APPROXIMATION_MODE) {
         // SFPU microcode
-        vUInt l0 = l_reg[LRegs::LReg0];
-        vUInt l1 = l_reg[LRegs::LReg1];
-        vUInt l2 = l_reg[LRegs::LReg2];
+        sfpi::vUInt l0 = l_reg[sfpi::LRegs::LReg0];
+        sfpi::vUInt l1 = l_reg[sfpi::LRegs::LReg1];
+        sfpi::vUInt l2 = l_reg[sfpi::LRegs::LReg2];
 
 #pragma GCC unroll 8
         for (int d = 0; d < ITERATIONS; d++) {
-            vFloat val = dst_reg[0];
-            val = lut(val, l0, l1, l2);
-            dst_reg[0] = val;
+            sfpi::vFloat val = sfpi::dst_reg[0];
+            val = sfpi::lut(val, l0, l1, l2);
+            sfpi::dst_reg[0] = val;
 
-            dst_reg++;
+            sfpi::dst_reg++;
         }
 
-        l_reg[LRegs::LReg0] = l0;
-        l_reg[LRegs::LReg1] = l1;
-        l_reg[LRegs::LReg2] = l2;
+        l_reg[sfpi::LRegs::LReg0] = l0;
+        l_reg[sfpi::LRegs::LReg1] = l1;
+        l_reg[sfpi::LRegs::LReg2] = l2;
     } else {  // APPROXIMATION_MODE is false
 
         for (int d = 0; d < ITERATIONS; d++) {
-            vFloat val = dst_reg[0];
+            sfpi::vFloat val = sfpi::dst_reg[0];
 
-            vFloat result;
+            sfpi::vFloat result;
 
             if constexpr (is_fp32_dest_acc_en) {
                 result = _sfpu_tanh_continued_fraction_<is_fp32_dest_acc_en>(val);
@@ -112,8 +112,8 @@ inline void calculate_tanh() {
                 result = _sfpu_tanh_polynomial_<is_fp32_dest_acc_en>(val);
             }
 
-            dst_reg[0] = result;
-            dst_reg++;
+            sfpi::dst_reg[0] = result;
+            sfpi::dst_reg++;
         }
     }
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
@@ -13,38 +13,120 @@ using namespace sfpi;
 namespace ckernel {
 namespace sfpu {
 
-template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_tanh() {
-    // SFPU microcode
-    vUInt l0 = l_reg[LRegs::LReg0];
-    vUInt l1 = l_reg[LRegs::LReg1];
-    vUInt l2 = l_reg[LRegs::LReg2];
+template <bool is_fp32_acc_to_dest_mode = true>
+sfpi_inline sfpi::vFloat _sfpu_tanh_continued_fraction_(sfpi::vFloat val) {
+    // Formula found at
+    // https://varietyofsound.wordpress.com/2011/02/14/efficient-tanh-computation-using-lamberts-continued-fraction/
 
-#pragma GCC unroll 8
-    for (int d = 0; d < ITERATIONS; d++) {
-        vFloat val = dst_reg[0];
-        val = lut(val, l0, l1, l2);
-        dst_reg[0] = val;
+    // This approximation is derived from a continued fraction formula of tanh(x)
 
-        dst_reg++;
+    sfpi::vFloat x = sfpi::setsgn(val, 0);  // set positive
+
+    sfpi::vFloat x2 = x * x;
+    sfpi::vFloat numerator = x * (135135.f + x2 * (17326.f + x2 * (378.f + x2)));
+    sfpi::vFloat denominator = 135135.f + x2 * (62370.f + x2 * (3150.f + 28.f * x2));
+
+    sfpi::vFloat result = ckernel::sfpu::_sfpu_reciprocal_<2>(denominator);
+    result = result * numerator;
+
+    sfpi::vFloat threshold_value = sfpi::vConst1;
+    sfpi::vec_min_max(result, threshold_value);
+
+    result = sfpi::setsgn(result, val);  // restore sign (i.e. tanh(-x) = -tanh(x))
+
+    if constexpr (!is_fp32_acc_to_dest_mode) {
+        result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
     }
 
-    l_reg[LRegs::LReg0] = l0;
-    l_reg[LRegs::LReg1] = l1;
-    l_reg[LRegs::LReg2] = l2;
+    return result;
 }
 
-template <bool APPROXIMATION_MODE>
+template <bool is_fp32_acc_to_dest_mode = true>
+sfpi_inline sfpi::vFloat _sfpu_tanh_polynomial_(sfpi::vFloat x) {
+    sfpi::vFloat val = sfpi::setsgn(x, 0);  // set positive
+
+    sfpi::vFloat result =
+        val * (0.999004364013671875 +
+               val * (3.0897438526153564453125e-2 +
+                      val * (-0.4890659749507904052734375 +
+                             val * (sfpi::vConstFloatPrgm2 +
+                                    val * (sfpi::vConstFloatPrgm1 + val * (sfpi::vConstFloatPrgm0))))));
+
+    sfpi::vFloat threshold_value = sfpi::vConst1;
+    sfpi::vec_min_max(result, threshold_value);
+
+    result = sfpi::setsgn(result, x);  // restore sign (i.e. tanh(-x) = -tanh(x))
+
+    if constexpr (!is_fp32_acc_to_dest_mode) {
+        result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
+    }
+
+    return result;
+}
+
+template <bool APPROXIMATION_MODE, int ITERATIONS = 8, bool is_fp32_dest_acc_en = false>
+inline void calculate_tanh() {
+    if constexpr (APPROXIMATION_MODE) {
+        // SFPU microcode
+        vUInt l0 = l_reg[LRegs::LReg0];
+        vUInt l1 = l_reg[LRegs::LReg1];
+        vUInt l2 = l_reg[LRegs::LReg2];
+
+#pragma GCC unroll 8
+        for (int d = 0; d < ITERATIONS; d++) {
+            vFloat val = dst_reg[0];
+            val = lut(val, l0, l1, l2);
+            dst_reg[0] = val;
+
+            dst_reg++;
+        }
+
+        l_reg[LRegs::LReg0] = l0;
+        l_reg[LRegs::LReg1] = l1;
+        l_reg[LRegs::LReg2] = l2;
+    } else {  // APPROXIMATION_MODE is false
+
+        for (int d = 0; d < ITERATIONS; d++) {
+            vFloat val = dst_reg[0];
+
+            vFloat result;
+
+            if constexpr (is_fp32_dest_acc_en) {
+                result = _sfpu_tanh_continued_fraction_<is_fp32_dest_acc_en>(val);
+            } else {
+                result = _sfpu_tanh_polynomial_<is_fp32_dest_acc_en>(val);
+            }
+
+            dst_reg[0] = result;
+            dst_reg++;
+        }
+    }
+}
+
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en = false>
 inline void tanh_init() {
-    uint imm0;
-    uint imm1;
-    uint imm2;
-    imm0 = 0x1DFF;  // 0.90625*x
-    imm1 = 0x481A;  // 0.09375*x + 0.8125
-    imm2 = 0xFF00;  // 1
-    _sfpu_load_imm16_(0, imm0);
-    _sfpu_load_imm16_(1, imm1);
-    _sfpu_load_imm16_(2, imm2);
+    if constexpr (APPROXIMATION_MODE) {
+        uint imm0;
+        uint imm1;
+        uint imm2;
+        imm0 = 0x1DFF;  // 0.90625*x
+        imm1 = 0x481A;  // 0.09375*x + 0.8125
+        imm2 = 0xFF00;  // 1
+        _sfpu_load_imm16_(0, imm0);
+        _sfpu_load_imm16_(1, imm1);
+        _sfpu_load_imm16_(2, imm2);
+    } else {
+        if constexpr (is_fp32_dest_acc_en) {
+            // Continue fraction
+            ckernel::sfpu::_init_reciprocal_<false, false>();
+        } else {
+            // Polynomial approximation
+            // Store some polynomial coefficients in programmable registers
+            sfpi::vConstFloatPrgm0 = 5.876733921468257904052734375e-3;
+            sfpi::vConstFloatPrgm1 = -6.6649019718170166015625e-2;
+            sfpi::vConstFloatPrgm2 = 0.281917631626129150390625;
+        }
+    }
 }
 
 }  // namespace sfpu

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
@@ -26,7 +26,6 @@ sfpi_inline sfpi::vFloat _sfpu_tanh_continued_fraction_(sfpi::vFloat val) {
     sfpi::vFloat x2 = x * x;
     sfpi::vFloat numerator = x * (135135.f + x2 * (17326.f + x2 * (378.f + x2)));
 
-    // constexpr float denominator_coefs[] = {28.f, 3150.f, 62370.f, 135135.f};
     constexpr float denominator_coefs[] = {135135.f, 62370.f, 3150.f, 28.f};
     sfpi::vFloat denominator = PolynomialEvaluator<4, sfpi::vFloat, float>::eval(denominator_coefs, x2);
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
@@ -49,13 +49,16 @@ sfpi_inline sfpi::vFloat _sfpu_tanh_polynomial_(sfpi::vFloat x) {
     // For negative numbers, we compute tanh(x) = -tanh(x)
     sfpi::vFloat val = sfpi::setsgn(x, 0);  // set positive
 
+    // val * (0.999004364013671875 + val * (3.0897438526153564453125e-2 + val * (-0.4890659749507904052734375 + val *
+    // (0.281917631626129150390625 + val * (-6.6649019718170166015625e-2 + val *
+    // (5.876733921468257904052734375e-3))))));
     sfpi::vFloat result = POLYVAL7<sfpi::vFloat>(
-        0.999004364013671875,
-        3.0897438526153564453125e-2,
-        -0.4890659749507904052734375,
-        sfpi::vConstFloatPrgm2,
-        sfpi::vConstFloatPrgm1,
         sfpi::vConstFloatPrgm0,
+        sfpi::vConstFloatPrgm1,
+        sfpi::vConstFloatPrgm2,
+        -0.4890659749507904052734375,
+        3.0897438526153564453125e-2,
+        0.999004364013671875,
         sfpi::vConst0,
         val);
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
@@ -8,8 +8,6 @@
 #include "ckernel_defs.h"
 #include "sfpu/ckernel_sfpu_polyval.h"
 
-using namespace sfpi;
-
 namespace ckernel {
 namespace sfpu {
 
@@ -120,12 +118,9 @@ inline void calculate_tanh() {
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en = false>
 inline void tanh_init() {
     if constexpr (APPROXIMATION_MODE) {
-        uint imm0;
-        uint imm1;
-        uint imm2;
-        imm0 = 0x1DFF;  // 0.90625*x
-        imm1 = 0x481A;  // 0.09375*x + 0.8125
-        imm2 = 0xFF00;  // 1
+        uint imm0 = 0x1DFF;  // 0.90625*x
+        uint imm1 = 0x481A;  // 0.09375*x + 0.8125
+        uint imm2 = 0xFF00;  // 1
         _sfpu_load_imm16_(0, imm0);
         _sfpu_load_imm16_(1, imm1);
         _sfpu_load_imm16_(2, imm2);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
@@ -32,8 +32,8 @@ sfpi_inline sfpi::vFloat _sfpu_tanh_continued_fraction_(sfpi::vFloat val) {
 
     sfpi::vFloat result = numerator * ckernel::sfpu::_sfpu_reciprocal_<2>(denominator);
 
-    // The limits of the continued fraction is +inf.
-    // Since tanh(x) -> +inf, we clamp output to 1.0
+    // For larger x, the continued fraction may exceed 1.0.
+    // Since tanh(x) is bounded by [-1, 1], we clamp output to 1.0.
     sfpi::vFloat threshold_value = sfpi::vConst1;
     sfpi::vec_min_max(result, threshold_value);
 
@@ -48,7 +48,7 @@ sfpi_inline sfpi::vFloat _sfpu_tanh_continued_fraction_(sfpi::vFloat val) {
 
 template <bool is_fp32_acc_to_dest_mode = true>
 sfpi_inline sfpi::vFloat _sfpu_tanh_polynomial_(sfpi::vFloat x) {
-    // For negative numbers, we compute tanh(x) = -tanh(x)
+    // For negative numbers, we compute tanh(-x) = -tanh(x)
     sfpi::vFloat val = sfpi::setsgn(x, 0);  // set positive
 
     // Polynomial coefficients found using Sollya
@@ -65,8 +65,8 @@ sfpi_inline sfpi::vFloat _sfpu_tanh_polynomial_(sfpi::vFloat x) {
         sfpi::vConst0,
         val);
 
-    // The limits of the polynomial approximation is +inf.
-    // Since tanh(x) -> +inf, we clamp output to 1.0
+    // For larger x, the polynomial approximation may exceed 1.0.
+    // Since tanh(x) is bounded by [-1, 1], we clamp output to 1.0.
     sfpi::vFloat threshold_value = sfpi::vConst1;
     sfpi::vec_min_max(result, threshold_value);
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
@@ -6,7 +6,7 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
-#include "ckernel_sfpu_polyval.h"
+#include "sfpu/ckernel_sfpu_polyval.h"
 
 using namespace sfpi;
 
@@ -49,14 +49,15 @@ sfpi_inline sfpi::vFloat _sfpu_tanh_polynomial_(sfpi::vFloat x) {
     // For negative numbers, we compute tanh(x) = -tanh(x)
     sfpi::vFloat val = sfpi::setsgn(x, 0);  // set positive
 
-    // Polynomial approximation (rank 6)
-    // Found using Sollya
-    sfpi::vFloat result =
-        val * (0.999004364013671875 +
-               val * (3.0897438526153564453125e-2 +
-                      val * (-0.4890659749507904052734375 +
-                             val * (sfpi::vConstFloatPrgm2 +
-                                    val * (sfpi::vConstFloatPrgm1 + val * (sfpi::vConstFloatPrgm0))))));
+    sfpi::vFloat result = POLYVAL7<sfpi::vFloat>(
+        0.999004364013671875,
+        3.0897438526153564453125e-2,
+        -0.4890659749507904052734375,
+        sfpi::vConstFloatPrgm2,
+        sfpi::vConstFloatPrgm1,
+        sfpi::vConstFloatPrgm0,
+        sfpi::vConst0,
+        val);
 
     // The limits of the polynomai approximation is +inf.
     // Since tanh(x) -> +inf, we clamp output to 1.0

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
@@ -6,7 +6,7 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
-#include "noc_nonblocking_api.h"
+#include "ckernel_sfpu_polyval.h"
 
 using namespace sfpi;
 
@@ -17,11 +17,12 @@ template <bool is_fp32_acc_to_dest_mode = true>
 sfpi_inline sfpi::vFloat _sfpu_tanh_continued_fraction_(sfpi::vFloat val) {
     // Formula found at
     // https://varietyofsound.wordpress.com/2011/02/14/efficient-tanh-computation-using-lamberts-continued-fraction/
-
     // This approximation is derived from a continued fraction formula of tanh(x)
 
+    // For negative numbers, we compute tanh(x) = -tanh(x)
     sfpi::vFloat x = sfpi::setsgn(val, 0);  // set positive
 
+    // Compute numerator and denominator of continued fraction using Horner's method
     sfpi::vFloat x2 = x * x;
     sfpi::vFloat numerator = x * (135135.f + x2 * (17326.f + x2 * (378.f + x2)));
     sfpi::vFloat denominator = 135135.f + x2 * (62370.f + x2 * (3150.f + 28.f * x2));
@@ -29,6 +30,8 @@ sfpi_inline sfpi::vFloat _sfpu_tanh_continued_fraction_(sfpi::vFloat val) {
     sfpi::vFloat result = ckernel::sfpu::_sfpu_reciprocal_<2>(denominator);
     result = result * numerator;
 
+    // The limits of the continued fraction is +inf.
+    // Since tanh(x) -> +inf, we clamp output to 1.0
     sfpi::vFloat threshold_value = sfpi::vConst1;
     sfpi::vec_min_max(result, threshold_value);
 
@@ -43,8 +46,11 @@ sfpi_inline sfpi::vFloat _sfpu_tanh_continued_fraction_(sfpi::vFloat val) {
 
 template <bool is_fp32_acc_to_dest_mode = true>
 sfpi_inline sfpi::vFloat _sfpu_tanh_polynomial_(sfpi::vFloat x) {
+    // For negative numbers, we compute tanh(x) = -tanh(x)
     sfpi::vFloat val = sfpi::setsgn(x, 0);  // set positive
 
+    // Polynomial approximation (rank 6)
+    // Found using Sollya
     sfpi::vFloat result =
         val * (0.999004364013671875 +
                val * (3.0897438526153564453125e-2 +
@@ -52,6 +58,8 @@ sfpi_inline sfpi::vFloat _sfpu_tanh_polynomial_(sfpi::vFloat x) {
                              val * (sfpi::vConstFloatPrgm2 +
                                     val * (sfpi::vConstFloatPrgm1 + val * (sfpi::vConstFloatPrgm0))))));
 
+    // The limits of the polynomai approximation is +inf.
+    // Since tanh(x) -> +inf, we clamp output to 1.0
     sfpi::vFloat threshold_value = sfpi::vConst1;
     sfpi::vec_min_max(result, threshold_value);
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
@@ -25,10 +25,12 @@ sfpi_inline sfpi::vFloat _sfpu_tanh_continued_fraction_(sfpi::vFloat val) {
     // Compute numerator and denominator of continued fraction using Horner's method
     sfpi::vFloat x2 = x * x;
     sfpi::vFloat numerator = x * (135135.f + x2 * (17326.f + x2 * (378.f + x2)));
-    sfpi::vFloat denominator = 135135.f + x2 * (62370.f + x2 * (3150.f + 28.f * x2));
 
-    sfpi::vFloat result = ckernel::sfpu::_sfpu_reciprocal_<2>(denominator);
-    result = result * numerator;
+    // constexpr float denominator_coefs[] = {28.f, 3150.f, 62370.f, 135135.f};
+    constexpr float denominator_coefs[] = {135135.f, 62370.f, 3150.f, 28.f};
+    sfpi::vFloat denominator = PolynomialEvaluator<4, sfpi::vFloat, float>::eval(denominator_coefs, x2);
+
+    sfpi::vFloat result = numerator * ckernel::sfpu::_sfpu_reciprocal_<2>(denominator);
 
     // The limits of the continued fraction is +inf.
     // Since tanh(x) -> +inf, we clamp output to 1.0
@@ -49,6 +51,7 @@ sfpi_inline sfpi::vFloat _sfpu_tanh_polynomial_(sfpi::vFloat x) {
     // For negative numbers, we compute tanh(x) = -tanh(x)
     sfpi::vFloat val = sfpi::setsgn(x, 0);  // set positive
 
+    // Polynomial coefficients found using Sollya
     // val * (0.999004364013671875 + val * (3.0897438526153564453125e-2 + val * (-0.4890659749507904052734375 + val *
     // (0.281917631626129150390625 + val * (-6.6649019718170166015625e-2 + val *
     // (5.876733921468257904052734375e-3))))));

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
@@ -62,7 +62,7 @@ sfpi_inline sfpi::vFloat _sfpu_tanh_polynomial_(sfpi::vFloat x) {
         sfpi::vConst0,
         val);
 
-    // The limits of the polynomai approximation is +inf.
+    // The limits of the polynomial approximation is +inf.
     // Since tanh(x) -> +inf, we clamp output to 1.0
     sfpi::vFloat threshold_value = sfpi::vConst1;
     sfpi::vec_min_max(result, threshold_value);
@@ -129,7 +129,7 @@ inline void tanh_init() {
         _sfpu_load_imm16_(2, imm2);
     } else {
         if constexpr (is_fp32_dest_acc_en) {
-            // Continue fraction
+            // Continued fraction
             ckernel::sfpu::_init_reciprocal_<false, false>();
         } else {
             // Polynomial approximation

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
@@ -23,9 +23,7 @@ sfpi_inline sfpi::vFloat _sfpu_tanh_continued_fraction_(sfpi::vFloat val) {
     // Compute numerator and denominator of continued fraction using Horner's method
     sfpi::vFloat x2 = x * x;
     sfpi::vFloat numerator = x * (135135.f + x2 * (17326.f + x2 * (378.f + x2)));
-
-    constexpr float denominator_coefs[] = {135135.f, 62370.f, 3150.f, 28.f};
-    sfpi::vFloat denominator = PolynomialEvaluator<4, sfpi::vFloat, float>::eval(denominator_coefs, x2);
+    sfpi::vFloat denominator = PolynomialEvaluator::eval(x2, 135135.f, 62370.f, 3150.f, 28.f);
 
     sfpi::vFloat result = numerator * ckernel::sfpu::_sfpu_reciprocal_<2>(denominator);
 
@@ -52,15 +50,15 @@ sfpi_inline sfpi::vFloat _sfpu_tanh_polynomial_(sfpi::vFloat x) {
     // val * (0.999004364013671875 + val * (3.0897438526153564453125e-2 + val * (-0.4890659749507904052734375 + val *
     // (0.281917631626129150390625 + val * (-6.6649019718170166015625e-2 + val *
     // (5.876733921468257904052734375e-3))))));
-    sfpi::vFloat result = POLYVAL7<sfpi::vFloat>(
-        sfpi::vConstFloatPrgm0,
-        sfpi::vConstFloatPrgm1,
-        sfpi::vConstFloatPrgm2,
-        -0.4890659749507904052734375,
-        3.0897438526153564453125e-2,
-        0.999004364013671875,
+    sfpi::vFloat result = PolynomialEvaluator::eval(
+        val,
         sfpi::vConst0,
-        val);
+        0.999004364013671875,
+        3.0897438526153564453125e-2,
+        -0.4890659749507904052734375,
+        sfpi::vConstFloatPrgm2,
+        sfpi::vConstFloatPrgm1,
+        sfpi::vConstFloatPrgm0);
 
     // For larger x, the polynomial approximation may exceed 1.0.
     // Since tanh(x) is bounded by [-1, 1], we clamp output to 1.0.

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_tanh.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_tanh.h
@@ -10,15 +10,15 @@
 
 namespace ckernel {
 
-template <bool APPROXIMATE>
+template <bool APPROXIMATE, bool is_fp32_dest_acc_en = false>
 inline void llk_math_eltwise_unary_sfpu_tanh_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::tanh, APPROXIMATE>(sfpu::tanh_init<APPROXIMATE>);
+    llk_math_eltwise_unary_sfpu_init<SfpuType::tanh, APPROXIMATE>(sfpu::tanh_init<APPROXIMATE, is_fp32_dest_acc_en>);
 }
 
-template <bool APPROXIMATE>
+template <bool APPROXIMATE, bool is_fp32_dest_acc_en = false>
 inline void llk_math_eltwise_unary_sfpu_tanh(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_tanh<APPROXIMATE>, dst_index, vector_mode);
+        ckernel::sfpu::calculate_tanh<APPROXIMATE, 8, is_fp32_dest_acc_en>, dst_index, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/include/compute_kernel_api.h
+++ b/tt_metal/include/compute_kernel_api.h
@@ -141,10 +141,10 @@ ALWI void log_with_base_tile(uint32_t idst, uint32_t base_scale) {
 /**
  * Please refer to documentation for any_init.
  */
+template <bool fast_and_approx = false>
 ALWI void tanh_tile_init() {
-    MATH((llk_math_eltwise_unary_sfpu_tanh_init<APPROX, DST_ACCUM_MODE>()));  // TODO(AP): move out init
+    MATH((llk_math_eltwise_unary_sfpu_tanh_init<fast_and_approx, DST_ACCUM_MODE>()));  // TODO(AP): move out init
 }
-
 
 // TODO: Move to trigonometry.h
 // clang-format off
@@ -161,7 +161,10 @@ ALWI void tanh_tile_init() {
  * | idst            | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
  */
  // clang-format on
-ALWI void tanh_tile(uint32_t idst) { MATH((llk_math_eltwise_unary_sfpu_tanh<APPROX, DST_ACCUM_MODE>(idst))); }
+template <bool fast_and_approx = false>
+ALWI void tanh_tile(uint32_t idst) {
+    MATH((llk_math_eltwise_unary_sfpu_tanh<fast_and_approx, DST_ACCUM_MODE>(idst)));
+}
 
 /**
  * Please refer to documentation for any_init.

--- a/tt_metal/include/compute_kernel_api.h
+++ b/tt_metal/include/compute_kernel_api.h
@@ -140,6 +140,9 @@ ALWI void log_with_base_tile(uint32_t idst, uint32_t base_scale) {
 // TODO: Move to trigonometry.h
 /**
  * Please refer to documentation for any_init.
+ *
+ * If using fast and approximate implementation of tanh_tile(), then tanh_tile_init() should be also be called with
+ * fast_and_approx = true.
  */
 template <bool fast_and_approx = false>
 ALWI void tanh_tile_init() {
@@ -154,13 +157,16 @@ ALWI void tanh_tile_init() {
  * acquired state via *acquire_dst* call. This call is blocking and is only
  * available on the compute engine.
  *
+ * If using fast and approximate mode, then tanh_tile_init() should be also be called with fast_and_approx = true beforehand.
+ *
  * Return value: None
  *
  * | Argument        | Description                                                                | Type     | Valid Range                                           | Required |
  * |-----------------|----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
  * | idst            | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | fast_and_approx | Whether to use fast and approximate mode                                   | bool     | True or False                                         | False    |
  */
- // clang-format on
+// clang-format on
 template <bool fast_and_approx = false>
 ALWI void tanh_tile(uint32_t idst) {
     MATH((llk_math_eltwise_unary_sfpu_tanh<fast_and_approx, DST_ACCUM_MODE>(idst)));

--- a/tt_metal/include/compute_kernel_api.h
+++ b/tt_metal/include/compute_kernel_api.h
@@ -142,7 +142,7 @@ ALWI void log_with_base_tile(uint32_t idst, uint32_t base_scale) {
  * Please refer to documentation for any_init.
  */
 ALWI void tanh_tile_init() {
-    MATH((llk_math_eltwise_unary_sfpu_tanh_init<APPROX>()));  // TODO(AP): move out init
+    MATH((llk_math_eltwise_unary_sfpu_tanh_init<APPROX, DST_ACCUM_MODE>()));  // TODO(AP): move out init
 }
 
 
@@ -161,7 +161,7 @@ ALWI void tanh_tile_init() {
  * | idst            | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
  */
  // clang-format on
-ALWI void tanh_tile(uint32_t idst) { MATH((llk_math_eltwise_unary_sfpu_tanh<APPROX>(idst))); }
+ALWI void tanh_tile(uint32_t idst) { MATH((llk_math_eltwise_unary_sfpu_tanh<APPROX, DST_ACCUM_MODE>(idst))); }
 
 /**
  * Please refer to documentation for any_init.

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
@@ -189,6 +189,11 @@ std::pair<std::string, std::string> get_op_init_and_func_parameterized(
                 fmt::format("log1p_tile_init<{}u>();", (uint32_t)param0),
                 fmt::format("log1p_tile<{1}u>({0});", idst, (uint32_t)param0)};
             break;
+        case UnaryOpType::TANH:
+            op_init_and_name = {
+                fmt::format("tanh_tile_init<{}u>();", (uint32_t)param0),
+                fmt::format("tanh_tile<{1}u>({0});", idst, (uint32_t)param0)};
+            break;
         case UnaryOpType::HEAVISIDE:
             op_init_and_name = {
                 "heaviside_tile_init();",
@@ -865,7 +870,7 @@ UnaryWithParam string_to_unary_with_param(const std::string& name) {
     } else if (name == "log1p") {
         return UnaryWithParam(UnaryOpType::LOG1P, static_cast<float>(true));
     } else if (name == "tanh") {
-        return UnaryWithParam(UnaryOpType::TANH);
+        return UnaryWithParam(UnaryOpType::TANH, static_cast<float>(false));
     } else if (name == "log2") {
         return UnaryWithParam(UnaryOpType::LOG2, static_cast<float>(true));
     } else if (name == "log10") {

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.hpp
@@ -88,6 +88,7 @@ bool is_parametrized_type(T val) {
         case UnaryOpType::LOG10:
         case UnaryOpType::LOG2:
         case UnaryOpType::LOG1P:
+        case UnaryOpType::TANH:
         case UnaryOpType::SOFTSHRINK:
         case UnaryOpType::HARDSHRINK:
         case UnaryOpType::WHERE_TSS:

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
@@ -301,7 +301,8 @@ Tensor Tanh::invoke(
     UnaryOpType op_type = UnaryOpType::TANH;
 
     // if (approx || input_tensor.dtype() == DataType::BFLOAT8_B || input_tensor.dtype() == DataType::BFLOAT4_B) {
-    return detail::unary_impl(input_tensor, {UnaryWithParam{op_type}}, memory_config, optional_output_tensor);
+    return detail::unary_impl(
+        input_tensor, {UnaryWithParam{op_type, static_cast<float>(approx)}}, memory_config, optional_output_tensor);
 }
 
 Tensor Prelu::invoke(

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
@@ -300,12 +300,8 @@ Tensor Tanh::invoke(
     bool approx) {
     UnaryOpType op_type = UnaryOpType::TANH;
 
-    if (approx || input_tensor.dtype() == DataType::BFLOAT8_B || input_tensor.dtype() == DataType::BFLOAT4_B) {
-        return detail::unary_impl(input_tensor, {UnaryWithParam{op_type}}, memory_config, optional_output_tensor);
-
-    } else {
-        return ttnn::tanh_accurate(input_tensor, memory_config, optional_output_tensor);
-    }
+    // if (approx || input_tensor.dtype() == DataType::BFLOAT8_B || input_tensor.dtype() == DataType::BFLOAT4_B) {
+    return detail::unary_impl(input_tensor, {UnaryWithParam{op_type}}, memory_config, optional_output_tensor);
 }
 
 Tensor Prelu::invoke(

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
@@ -300,7 +300,6 @@ Tensor Tanh::invoke(
     bool approx) {
     UnaryOpType op_type = UnaryOpType::TANH;
 
-    // if (approx || input_tensor.dtype() == DataType::BFLOAT8_B || input_tensor.dtype() == DataType::BFLOAT4_B) {
     return detail::unary_impl(
         input_tensor, {UnaryWithParam{op_type, static_cast<float>(approx)}}, memory_config, optional_output_tensor);
 }


### PR DESCRIPTION
### Ticket
#25325

### Problem description

`ttnn.tanh` is inaccurate on small values. 

### What's changed

- This PR adds two approximations of `tanh_tile`:
    - `_sfpu_tanh_polynomial_` (`tanh-minimax`): default variant for bfloat16
    - `_sfpu_tanh_continued_fraction_` (`tanh-continued-fraction` or `tanh-cf`): default variant for float32
    These variants replace `tanh_accurate.cpp` (i.e. `fast_and_approximate_mode=False`)
- Introduce `fast_and_approx` flag to `tanh_tile` and `tanh_tile_init` (defaults to `False`)
- Adjust test tolerance thresholds and input range.  

#### Accuracy 

##### bfloat16

On bfloat16, the error of `tanh-minimax` is always < 1 ULP, even near 0.  

<img width="670" height="372" alt="tanh-accurate-bfloat16" src="https://github.com/user-attachments/assets/203467ba-4355-439f-aff4-39f11033e7e4" />


##### float32

On float32, `tanh-minimax` is sometimes less accurate than `tanh-accurate` when away from 0. To mitigate this, we introduce a second variant, called `tanh-continued-fraction` (green) that is significantly more accurate than both `tanh_accurate` and `tanh_minimax`. 

<img width="885" height="372" alt="tanh-accurate-float32" src="https://github.com/user-attachments/assets/5bd9d98a-2950-40bb-aafc-8333cb931530" />


#### Execution time

Both approximations are significantly faster than current tanh_accurate, `tanh-minimax` is ~5 times faster, whereas `tanh-continued-fraction` is ~3 times faster.  

On Wormhole

type | Name | Cycles/Datum | Cycles/Tile | Speedup vs. accurate
-- | -- | -- | -- | --
bfloat16 | tanh_accurate (main) | 5.06 | 5180.97 | 1
bfloat16 | tanh approx (main) | 0.23 | 230.47 | 22.5
bfloat16 | tanh-minimax-v1[6] (this)| 0.97 | 993.63 | 5.2
bfloat16 | tanh-cf (this) | 1.66 | 1665.58 | 3.1

### Methodology


For the float32 / continued fraction, I found a formula on a [blog](https://varietyofsound.wordpress.com/2011/02/14/efficient-tanh-computation-using-lamberts-continued-fraction/): 
The general idea is to compute a [continued fraction](https://en.wikipedia.org/wiki/Continued_fraction#Linear_fractional_transformations) of tanh and transform it into a 'a(x)/b(x)' expression (e.g. like a pade approximation).

For the bfloat16 approximation, I ran an approximation of tanh in [Sollya](https://www.sollya.org ), while setting 0-th coefficient to 0 (ensures `tanh(0) = 0`).

For both approximations, I reduce the range to the positive numbers (`setsgn(x, 0)`) because tanh is symmetrical: 
(1) For the polynomial approximation, this should improve accuracy a bit because the approximated range will be shorter
(2) Neither approximations converge towards 1. But that's okay as long as their limits at +inf is >1: I can set result to `min(approx, 1)`. Here's a visualization of this on Desmos: https://www.desmos.com/calculator/4eqnyfmz2c


Both (1) and (2) should be applicable to functions that contain symmetry. 
(2) adds constraints on the approximations (approximating function must be increasing and only cross threshold value once). On the other hand, the threshold does not have to be 'fixed', it could also be the input (i.e. could be used in activations functions whose value converges to y=x. 



### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes [OK](https://github.com/tenstorrent/tt-metal/actions/runs/18943795878)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable) [OK, failed tests also on main](https://github.com/tenstorrent/tt-metal/actions/runs/18943840882)
- [x] Nightly L2 tests : https://github.com/tenstorrent/tt-metal/actions/runs/19064823732
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/19064866603
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/19064869740
- [x] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models). [OK, failed test also on main](https://github.com/tenstorrent/tt-metal/actions/runs/19041872648)
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main) https://github.com/tenstorrent/tt-metal/actions/runs/19064955094
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release) https://github.com/tenstorrent/tt-metal/actions/runs/19064959654
- [x] New/Existing tests provide coverage for changes