### PR TITLE
[skip ci] fix re runs not detected in pipeline triage tool

### DIFF
--- a/.github/actions/analyze-workflow-data/analyze-workflow-data.js
+++ b/.github/actions/analyze-workflow-data/analyze-workflow-data.js
@@ -856,7 +856,7 @@ function getWorkflowStats(runs) {
       // First time seeing this run ID
       uniqueRuns.set(runId, {
         run,
-        attempts: 0,
+        attempts: 1, // Initialize to 1 since this is the first attempt
         isSuccessful: false,
         requiredRetry: false,
         succeededOnFirstTry: false,

--- a/.github/actions/analyze-workflow-data/analyze-workflow-data.js
+++ b/.github/actions/analyze-workflow-data/analyze-workflow-data.js
@@ -1074,7 +1074,9 @@ async function generateSummaryBox(grouped, context) {
       .sort((a, b) => {
         // Sort by date (newest first), then by run_attempt (highest first) as tiebreaker
         const dateDiff = new Date(b.created_at) - new Date(a.created_at);
-        if (dateDiff !== 0) return dateDiff;
+        if (dateDiff !== 0) {
+          return dateDiff;
+        }
         const attemptA = a.run_attempt || 1;
         const attemptB = b.run_attempt || 1;
         return attemptB - attemptA; // Prefer higher attempt number

--- a/.github/actions/analyze-workflow-data/analyze-workflow-data.js
+++ b/.github/actions/analyze-workflow-data/analyze-workflow-data.js
@@ -1350,7 +1350,9 @@ async function run() {
               .sort((a, b) => {
                 // Sort by date (newest first), then by run_attempt (highest first) as tiebreaker
                 const dateDiff = new Date(b.created_at) - new Date(a.created_at);
-                if (dateDiff !== 0) return dateDiff;
+                if (dateDiff !== 0){
+                  return dateDiff;
+                }
                 const attemptA = a.run_attempt || 1;
                 const attemptB = b.run_attempt || 1;
                 return attemptB - attemptA; // Prefer higher attempt number
@@ -1419,7 +1421,9 @@ async function run() {
           .sort((a, b) => {
             // Sort by date (newest first), then by run_attempt (highest first) as tiebreaker
             const dateDiff = new Date(b.created_at) - new Date(a.created_at);
-            if (dateDiff !== 0) return dateDiff;
+            if (dateDiff !== 0) {
+              return dateDiff;
+            }
             const attemptA = a.run_attempt || 1;
             const attemptB = b.run_attempt || 1;
             return attemptB - attemptA; // Prefer higher attempt number
@@ -1530,7 +1534,9 @@ async function run() {
         .sort((a, b) => {
           // Sort by date (newest first), then by run_attempt (highest first) as tiebreaker
           const dateDiff = new Date(b.created_at) - new Date(a.created_at);
-          if (dateDiff !== 0) return dateDiff;
+          if (dateDiff !== 0){
+            return dateDiff;
+          }
           const attemptA = a.run_attempt || 1;
           const attemptB = b.run_attempt || 1;
           return attemptB - attemptA; // Prefer higher attempt number
@@ -1555,7 +1561,9 @@ async function run() {
         .sort((a, b) => {
           // Sort by date (newest first), then by run_attempt (highest first) as tiebreaker
           const dateDiff = new Date(b.created_at) - new Date(a.created_at);
-          if (dateDiff !== 0) return dateDiff;
+          if (dateDiff !== 0) {
+            return dateDiff;
+          }
           const attemptA = a.run_attempt || 1;
           const attemptB = b.run_attempt || 1;
           return attemptB - attemptA; // Prefer higher attempt number
@@ -1622,7 +1630,9 @@ async function run() {
         .sort((a, b) => {
           // Sort by date (newest first), then by run_attempt (highest first) as tiebreaker
           const dateDiff = new Date(b.created_at) - new Date(a.created_at);
-          if (dateDiff !== 0) return dateDiff;
+          if (dateDiff !== 0) {
+            return dateDiff;
+          }
           const attemptA = a.run_attempt || 1;
           const attemptB = b.run_attempt || 1;
           return attemptB - attemptA; // Prefer higher attempt number

--- a/.github/actions/fetch-workflow-data/fetch-workflow-data.js
+++ b/.github/actions/fetch-workflow-data/fetch-workflow-data.js
@@ -755,7 +755,9 @@ async function run() {
         .sort((a, b) => {
           // Sort by date (newest first), then by run_attempt (highest first) as tiebreaker
           const dateDiff = new Date(b.created_at) - new Date(a.created_at);
-          if (dateDiff !== 0) return dateDiff;
+          if (dateDiff !== 0) {
+            return dateDiff;
+          }
           const attemptA = a.run_attempt || 1;
           const attemptB = b.run_attempt || 1;
           return attemptB - attemptA; // Prefer higher attempt number
@@ -1027,7 +1029,9 @@ async function run() {
           .sort((a, b) => {
             // Sort by date (newest first), then by run_attempt (highest first) as tiebreaker
             const dateDiff = new Date(b.created_at) - new Date(a.created_at);
-            if (dateDiff !== 0) return dateDiff;
+            if (dateDiff !== 0) {
+              return dateDiff;
+            }
             const attemptA = a.run_attempt || 1;
             const attemptB = b.run_attempt || 1;
             return attemptB - attemptA; // Prefer higher attempt number

--- a/.github/workflows/aggregate-workflow-data.yaml
+++ b/.github/workflows/aggregate-workflow-data.yaml
@@ -244,6 +244,6 @@ jobs:
       - name: Post regressions to Slack
         uses: ./.github/actions/slack-report-analyze-workflow-data
         with:
-          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_AGGREGATE_PIPELINE_STATUS_ALERT }}
+          slack_webhook_url: ${{ secrets.SLACK_TESTING_CHANNEL }}
           regressed_workflows: ${{ needs.analyze-data.outputs.regressed_workflows }}
           alert_all_message: ${{ needs.analyze-data.outputs.alert_all_message }}

--- a/.github/workflows/aggregate-workflow-data.yaml
+++ b/.github/workflows/aggregate-workflow-data.yaml
@@ -244,6 +244,6 @@ jobs:
       - name: Post regressions to Slack
         uses: ./.github/actions/slack-report-analyze-workflow-data
         with:
-          slack_webhook_url: ${{ secrets.SLACK_TESTING_CHANNEL }}
+          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_AGGREGATE_PIPELINE_STATUS_ALERT }}
           regressed_workflows: ${{ needs.analyze-data.outputs.regressed_workflows }}
           alert_all_message: ${{ needs.analyze-data.outputs.alert_all_message }}


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/31678

### Problem description
Workflows that were re-run were always seen as failures even if the re-run succeeded because the rerun info was skipped due to the original run being in the cache

### What's changed
Added a checking mechanism to search for all the latest attempts on the most recent runs for the workflows we care about so that new attempts are always detected.

### Checklist
- [x] [Aggregate Workflow Data](https://github.com/tenstorrent/tt-metal/actions/workflows/aggregate-workflow-data.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/19043497899/job/54386040223#:~:text=%5BRECHECK%5D%20Filtered%20to,attempts%20to%20mergedRuns