### PR TITLE
fixup logger type for fabric log messages

### DIFF
--- a/tt_metal/fabric/builder/fabric_static_sized_channels_allocator.cpp
+++ b/tt_metal/fabric/builder/fabric_static_sized_channels_allocator.cpp
@@ -78,15 +78,15 @@ FabricStaticSizedChannelsAllocator::FabricStaticSizedChannelsAllocator(
         options.direction);
 
     log_trace(
-        tt::LogOp,
+        tt::LogFabric,
         "is_dateline {} is_dateline_upstream {} is_dateline_upstream_adj_dev {}",
         is_dateline,
         is_dateline_upstream,
         is_dateline_upstream_adj_dev);
-    log_trace(tt::LogOp, "num_sender_buffer_slots: {}", num_sender_buffer_slots);
-    log_trace(tt::LogOp, "num_remote_sender_buffer_slots: {}", num_remote_sender_buffer_slots);
-    log_trace(tt::LogOp, "num_receiver_buffer_slots: {}", num_receiver_buffer_slots);
-    log_trace(tt::LogOp, "num_remote_receiver_buffer_slots: {}", num_remote_receiver_buffer_slots);
+    log_trace(tt::LogFabric, "num_sender_buffer_slots: {}", num_sender_buffer_slots);
+    log_trace(tt::LogFabric, "num_remote_sender_buffer_slots: {}", num_remote_sender_buffer_slots);
+    log_trace(tt::LogFabric, "num_receiver_buffer_slots: {}", num_receiver_buffer_slots);
+    log_trace(tt::LogFabric, "num_remote_receiver_buffer_slots: {}", num_remote_receiver_buffer_slots);
 
     size_t total_sender_slots = std::accumulate(
         num_sender_buffer_slots.begin(), num_sender_buffer_slots.begin() + num_used_sender_channels, size_t{0});
@@ -99,7 +99,7 @@ FabricStaticSizedChannelsAllocator::FabricStaticSizedChannelsAllocator(
         total_slot_count * channel_buffer_size_bytes,
         available_channel_buffering_space);
 
-    log_trace(tt::LogOp, "Available channel buffering space: {}", this->available_channel_buffering_space);
+    log_trace(tt::LogFabric, "Available channel buffering space: {}", this->available_channel_buffering_space);
 
     // set the sender channel sizes and num buffers
     for (uint32_t i = 0; i < num_used_sender_channels; i++) {
@@ -127,13 +127,13 @@ FabricStaticSizedChannelsAllocator::FabricStaticSizedChannelsAllocator(
     for (uint32_t i = 0; i < num_used_sender_channels; i++) {
         this->sender_channels_base_address[i] = sender_buffer_addr;
         sender_buffer_addr += this->sender_channels_size_bytes[i];
-        log_trace(tt::LogOp, "Sender {} channel_start: {}", i, this->sender_channels_base_address[i]);
+        log_trace(tt::LogFabric, "Sender {} channel_start: {}", i, this->sender_channels_base_address[i]);
     }
     uint32_t receiver_buffer_addr = sender_buffer_addr;
     for (uint32_t i = 0; i < num_used_receiver_channels; i++) {
         this->receiver_channels_base_address[i] = receiver_buffer_addr;
         receiver_buffer_addr += this->receiver_channels_size_bytes[i];
-        log_trace(tt::LogOp, "Receiver {} channel_start: {}", i, this->receiver_channels_base_address[i]);
+        log_trace(tt::LogFabric, "Receiver {} channel_start: {}", i, this->receiver_channels_base_address[i]);
     }
     uint32_t buffer_addr_end = receiver_buffer_addr;
     // set the base addresses for the remote channels
@@ -141,16 +141,16 @@ FabricStaticSizedChannelsAllocator::FabricStaticSizedChannelsAllocator(
     for (uint32_t i = 0; i < num_used_sender_channels; i++) {
         this->remote_sender_channels_base_address[i] = remote_sender_buffer_addr;
         remote_sender_buffer_addr += this->remote_sender_channels_size_bytes[i];
-        log_trace(tt::LogOp, "Remote Sender {} channel_start: {}", i, this->remote_sender_channels_base_address[i]);
+        log_trace(tt::LogFabric, "Remote Sender {} channel_start: {}", i, this->remote_sender_channels_base_address[i]);
     }
     uint32_t remote_receiver_buffer_addr = remote_sender_buffer_addr;
     for (uint32_t i = 0; i < num_used_receiver_channels; i++) {
         this->remote_receiver_channels_base_address[i] = remote_receiver_buffer_addr;
         remote_receiver_buffer_addr += this->remote_receiver_channels_size_bytes[i];
-        log_trace(tt::LogOp, "Remote Receiver {} channel_start: {}", i, this->remote_receiver_channels_base_address[i]);
+        log_trace(tt::LogFabric, "Remote Receiver {} channel_start: {}", i, this->remote_receiver_channels_base_address[i]);
     }
 
-    log_trace(tt::LogOp, "Available channel buffering space: {}", this->available_channel_buffering_space);
+    log_trace(tt::LogFabric, "Available channel buffering space: {}", this->available_channel_buffering_space);
 
     auto skip_current_sender_channel = [&](uint32_t idx) -> bool {
         // for dateline connection, skip the last sender channel check (2 for 1d, 4 for 2d)

--- a/tt_metal/fabric/ccl/ccl_common.cpp
+++ b/tt_metal/fabric/ccl/ccl_common.cpp
@@ -28,10 +28,10 @@ tt::tt_metal::KernelHandle generate_edm_kernel_impl(
     std::vector<uint32_t> const edm_kernel_rt_args = edm_builder.get_runtime_args();
     // Ethernet Kernels
     const std::vector<uint32_t> eth_sender_ct_args = edm_builder.get_compile_time_args((uint32_t)risc_id);
-    log_trace(tt::LogOp, "EDM core (x={},y={}):", eth_core.x, eth_core.y);
-    log_trace(tt::LogOp, "CT ARGS:");
+    log_trace(tt::LogFabric, "EDM core (x={},y={}):", eth_core.x, eth_core.y);
+    log_trace(tt::LogFabric, "CT ARGS:");
     for ([[maybe_unused]] const auto& s : eth_sender_ct_args) {
-        log_trace(tt::LogOp, "\t{}", s);
+        log_trace(tt::LogFabric, "\t{}", s);
     }
 
     auto kernel_config =

--- a/tt_metal/fabric/erisc_datamover_builder.cpp
+++ b/tt_metal/fabric/erisc_datamover_builder.cpp
@@ -658,19 +658,19 @@ void append_worker_to_fabric_edm_sender_rt_args(
 }
 
 size_t log_worker_to_fabric_edm_sender_rt_args(const std::vector<uint32_t>& args, size_t starting_arg_idx) {
-    log_trace(tt::LogOp, "Worker to fabric EDM Sender has {} RT Args: {}", args.size(), args);
-    log_trace(tt::LogOp, "arg[{}]: edm_noc_xy {}", starting_arg_idx, args[starting_arg_idx++]);
-    log_trace(tt::LogOp, "arg[{}]: edm_buffer_base_addr {}", starting_arg_idx, args[starting_arg_idx++]);
-    log_trace(tt::LogOp, "arg[{}]: num_buffers_per_channel {}", starting_arg_idx, args[starting_arg_idx++]);
-    log_trace(tt::LogOp, "arg[{}]: edm_l1_sem_addr {}", starting_arg_idx, args[starting_arg_idx++]);
-    log_trace(tt::LogOp, "arg[{}]: edm_connection_handshake_addr {}", starting_arg_idx, args[starting_arg_idx++]);
-    log_trace(tt::LogOp, "arg[{}]: edm_worker_location_info_addr {}", starting_arg_idx, args[starting_arg_idx++]);
-    log_trace(tt::LogOp, "arg[{}]: buffer_size_bytes {}", starting_arg_idx, args[starting_arg_idx++]);
-    log_trace(tt::LogOp, "arg[{}]: buffer_index_semaphore_id {}", starting_arg_idx, args[starting_arg_idx++]);
+    log_trace(tt::LogFabric, "Worker to fabric EDM Sender has {} RT Args: {}", args.size(), args);
+    log_trace(tt::LogFabric, "arg[{}]: edm_noc_xy {}", starting_arg_idx, args[starting_arg_idx++]);
+    log_trace(tt::LogFabric, "arg[{}]: edm_buffer_base_addr {}", starting_arg_idx, args[starting_arg_idx++]);
+    log_trace(tt::LogFabric, "arg[{}]: num_buffers_per_channel {}", starting_arg_idx, args[starting_arg_idx++]);
+    log_trace(tt::LogFabric, "arg[{}]: edm_l1_sem_addr {}", starting_arg_idx, args[starting_arg_idx++]);
+    log_trace(tt::LogFabric, "arg[{}]: edm_connection_handshake_addr {}", starting_arg_idx, args[starting_arg_idx++]);
+    log_trace(tt::LogFabric, "arg[{}]: edm_worker_location_info_addr {}", starting_arg_idx, args[starting_arg_idx++]);
+    log_trace(tt::LogFabric, "arg[{}]: buffer_size_bytes {}", starting_arg_idx, args[starting_arg_idx++]);
+    log_trace(tt::LogFabric, "arg[{}]: buffer_index_semaphore_id {}", starting_arg_idx, args[starting_arg_idx++]);
     log_trace(
-        tt::LogOp, "arg[{}]: sender_worker_flow_control_semaphore_id {}", starting_arg_idx, args[starting_arg_idx++]);
+        tt::LogFabric, "arg[{}]: sender_worker_flow_control_semaphore_id {}", starting_arg_idx, args[starting_arg_idx++]);
     log_trace(
-        tt::LogOp, "arg[{}]: sender_worker_buffer_index_semaphore_id {}", starting_arg_idx, args[starting_arg_idx++]);
+        tt::LogFabric, "arg[{}]: sender_worker_buffer_index_semaphore_id {}", starting_arg_idx, args[starting_arg_idx++]);
     return starting_arg_idx + 10;
 }
 
@@ -739,7 +739,7 @@ FabricEriscDatamoverBuilder::FabricEriscDatamoverBuilder(
 
     // Add this log right at the beginning of the constructor body
     log_debug(
-        tt::LogOp,
+        tt::LogFabric,
         "FabricEriscDatamoverBuilder config for device (local chip_id: {}, peer chip_id: {}): "
         "buffer_size={}, topology={}, num_sender_ch={}, num_receiver_ch={}, direction={}",
         local_fabric_node_id.chip_id,
@@ -1149,7 +1149,7 @@ FabricEriscDatamoverBuilder FabricEriscDatamoverBuilder::build(
     bool has_tensix_extension) {
     const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
     log_debug(
-        tt::LogOp,
+        tt::LogFabric,
         "Building FabricEriscDatamover for device {}:  "
         "channel_buffer_size={}, topology={}, num_sender_channels={}, num_receiver_channels={}",
         device->id(),
@@ -1197,7 +1197,7 @@ FabricEriscDatamoverBuilder FabricEriscDatamoverBuilder::build(
         std::move(remote_pool_allocators), std::move(remote_pool_types));
 
     log_debug(
-        tt::LogOp,
+        tt::LogFabric,
         "FABRIC NODE ID: M={},D={} eth=(x={},y={})\n"
         "\tnum_sender_channels={}, num_receiver_channels={}\n"
         "\tchannel_allocator={}\n"
@@ -1275,7 +1275,7 @@ FabricEriscDatamoverBuilder FabricEriscDatamoverBuilder::build(
 }
 
 // SenderWorkerAdapterSpec FabricEriscDatamoverBuilder::build_connection_to_worker_channel() const {
-//     log_trace(tt::LogOp, "Building connection to persistent fabric");
+//     log_trace(tt::LogFabric, "Building connection to persistent fabric");
 //     static constexpr uint32_t worker_chan = 0;
 //     TT_FATAL(
 //         sender_channels_buffer_index_semaphore_id[worker_chan] !=

--- a/tt_metal/fabric/erisc_datamover_builder_helper.cpp
+++ b/tt_metal/fabric/erisc_datamover_builder_helper.cpp
@@ -65,7 +65,7 @@ EdmLineFabricOpInterface::EdmLineFabricOpInterface(
     TT_ASSERT(device_sequence.size() == program_sequence.size());
 
     for (size_t i = 0; i < device_sequence.size(); i++) {
-        log_trace(tt::LogOp, "device[{}] id={}", i, device_sequence[i]->id());
+        log_trace(tt::LogFabric, "device[{}] id={}", i, device_sequence[i]->id());
     }
     auto get_min_link_count =
         [&](tt::tt_metal::IDevice* src_device, tt::tt_metal::IDevice* dest_device, size_t min_link_count) {
@@ -163,7 +163,7 @@ EdmLineFabricOpInterface::EdmLineFabricOpInterface(
         const auto src_curr_edm_config =
             tt::tt_fabric::FabricEriscDatamoverConfig(edm_buffer_size, topology, src_edm_options);
         log_debug(
-            tt::LogOp,
+            tt::LogFabric,
             "FabricEriscDatamoverConfig for src_device {}: buffer_size={}, topology={}",
             src_device->id(),
             edm_buffer_size,
@@ -171,7 +171,7 @@ EdmLineFabricOpInterface::EdmLineFabricOpInterface(
         const auto dest_curr_edm_config =
             tt::tt_fabric::FabricEriscDatamoverConfig(edm_buffer_size, topology, dest_edm_options);
         log_debug(
-            tt::LogOp,
+            tt::LogFabric,
             "FabricEriscDatamoverConfig for dest_device {}: buffer_size={}, topology={}",
             dest_device->id(),
             edm_buffer_size,
@@ -181,12 +181,12 @@ EdmLineFabricOpInterface::EdmLineFabricOpInterface(
         edm_builders_backward_direction[dest_device->id()].reserve(local_link_cores.size());
         for (size_t l = 0; l < this->num_links; l++) {
             log_trace(
-                tt::LogOp,
+                tt::LogFabric,
                 "Building forward direction EDM on chip {} on link {}",
                 src_device->id(),
                 edm_builders_forward_direction[src_device->id()].size());
             log_debug(
-                tt::LogOp,
+                tt::LogFabric,
                 "src_device {}, dest_device {}, is_dateline {}",
                 src_device->id(),
                 dest_device->id(),
@@ -203,7 +203,7 @@ EdmLineFabricOpInterface::EdmLineFabricOpInterface(
                     src_device_edm_type));
 
             log_trace(
-                tt::LogOp,
+                tt::LogFabric,
                 "Building backward direction EDM on chip {} on link {}",
                 dest_device->id(),
                 edm_builders_backward_direction[dest_device->id()].size());
@@ -322,13 +322,13 @@ EdmLineFabricOpInterface::EdmLineFabricOpInterface(
         sizeof(tt::tt_fabric::PacketHeader);
     const auto config = tt::tt_fabric::FabricEriscDatamoverConfig(edm_buffer_size, topology);
 
-    log_trace(tt::LogOp, "device id={}", local_device->id());
-    log_trace(tt::LogOp, "EDM Fabric Factory ctor on device: {}", local_device->id());
+    log_trace(tt::LogFabric, "device id={}", local_device->id());
+    log_trace(tt::LogFabric, "EDM Fabric Factory ctor on device: {}", local_device->id());
     if (forward_device.has_value()) {
-        log_trace(tt::LogOp, "\tConnect[FORWARD]: {} -> {}", local_device->id(), forward_device.value()->id());
+        log_trace(tt::LogFabric, "\tConnect[FORWARD]: {} -> {}", local_device->id(), forward_device.value()->id());
     }
     if (backward_device.has_value()) {
-        log_trace(tt::LogOp, "\tConnect[BACKWARD]: {} -> {}", local_device->id(), backward_device.value()->id());
+        log_trace(tt::LogFabric, "\tConnect[BACKWARD]: {} -> {}", local_device->id(), backward_device.value()->id());
     }
 
     // Construct the builders
@@ -351,7 +351,7 @@ EdmLineFabricOpInterface::EdmLineFabricOpInterface(
             continue;
         }
         log_trace(
-            tt::LogOp,
+            tt::LogFabric,
             "Device {} is connected to {} at index {}",
             local_device->id(),
             device_pairs[i].second.value()->id(),
@@ -373,7 +373,7 @@ EdmLineFabricOpInterface::EdmLineFabricOpInterface(
                 break;
             }
             log_trace(
-                tt::LogOp,
+                tt::LogFabric,
                 "DEBUG: build EDM: device: {}, &program: {}: core-logi(x={},y={})",
                 local_device->id(),
                 (void*)program,
@@ -454,7 +454,7 @@ void EdmLineFabricOpInterface::build_kernels() const {
                         edm_builder.get_configured_risc_count());
                     for (uint32_t risc_id = 0; risc_id < edm_builder.get_configured_risc_count(); risc_id++) {
                         log_trace(
-                            tt::LogOp,
+                            tt::LogFabric,
                             "Building EDM kernel on device {}, logical-core (y={},x={}), noc_core (y={},x={}), risc_id "
                             "{}",
                             device->id(),
@@ -520,7 +520,7 @@ EdmLineFabricOpInterface::generate_ordered_termination_info_farthest_to_nearest(
     std::vector<tt::tt_fabric::edm_termination_info_t> edm_termination_infos;
     edm_termination_infos.reserve(num_hops * 2 * this->num_links);
     for (int i = num_hops - 1; i >= 0; i--) {
-        log_trace(tt::LogOp, "Generating termination info for hop {}", i);
+        log_trace(tt::LogFabric, "Generating termination info for hop {}", i);
         TT_ASSERT(i + 1 != 0);
         TT_ASSERT(i + 1 < device_sequence.size());
         TT_ASSERT(
@@ -551,7 +551,7 @@ EdmLineFabricOpInterface::generate_ordered_termination_info_farthest_to_nearest(
                 {distance_sender, nearer_edm.my_noc_x, nearer_edm.my_noc_y, config.termination_signal_address});
         }
     }
-    log_trace(tt::LogOp, "Done Generating termination infos");
+    log_trace(tt::LogFabric, "Done Generating termination infos");
     return edm_termination_infos;
 }
 

--- a/tt_metal/fabric/fabric_init.cpp
+++ b/tt_metal/fabric/fabric_init.cpp
@@ -172,7 +172,7 @@ void build_tt_fabric_program(
         auto router_chans_and_direction = control_plane.get_active_fabric_eth_channels(fabric_node_id);
         for (const auto& [eth_chan, eth_direction] : router_chans_and_direction) {
             log_debug(
-                tt::LogOp,
+                tt::LogFabric,
                 "FabricEriscDatamoverConfig for device {}: eth_chan={}, direction={}",
                 device->id(),
                 eth_chan,


### PR DESCRIPTION
log messages were being incorrectly typed to LogOp; redirected to LogFabric now.
