### PR TITLE
Add `StringMetric` support and firmware version metrics

### DIFF
--- a/tt_telemetry/frontend/static/js/hierarchical_telemetry_store.js
+++ b/tt_telemetry/frontend/static/js/hierarchical_telemetry_store.js
@@ -220,6 +220,48 @@ export class HierarchicalTelemetryStore {
         }
     }
 
+    // Updates telemetry state for a particular string-valued node. Will set the value directly
+    // and then propagate upwards if changed. If the value did not already exist and this is the
+    // first insertion, propagation will occur.
+    updateStringValue(path, value, timestamp = null) {
+        if (typeof value !== "string") {
+            console.error(`[HierarchicalTelemetryStore] Value is not string (${typeof value})`);
+        }
+
+        // Convert timestamp to Date if provided, otherwise use current time
+        const timestampDate = timestamp ? new Date(timestamp) : new Date();
+
+        // Update value and timestamp, preserving unit information
+        const oldData = this._dataByPath.get(path);
+        const forceUpdate = oldData === undefined;
+        let changed = !oldData || value !== oldData.value || timestampDate.getTime() !== oldData.timestamp.getTime();
+        const newData = {
+            value,
+            timestamp: timestampDate,
+            unitDisplayLabel: oldData ? oldData.unitDisplayLabel : null,
+            unitFullLabel: oldData ? oldData.unitFullLabel : null
+        };
+        this._dataByPath.set(path, newData);
+        console.log(`Set ${path} = ${value} at ${timestampDate.toISOString()}`);
+
+        // No change? We are done.
+        if (!changed && !forceUpdate) {
+            return;
+        }
+
+        // Split path into components. Then move upwards to propagate the boolean value and timestamp.
+        const parts = path.split("/");
+        for (let i = parts.length; i > 0; i--) {
+            const currentPath = parts.slice(0, i).join("/");
+            if (currentPath !== path) {
+                // _getAggregateHealthAndTimestamp only supports bools at leaf level, so we don't want to
+                // invoke it on our string
+                const aggregateData = this._getAggregateHealthAndTimestamp(currentPath);
+                this._dataByPath.set(currentPath, aggregateData);
+            }
+        }
+    }
+
     // Update function for unit label maps - iterates through the provided maps
     // and updates the internal ones (overwriting existing values and adding new ones)
     // Note: nlohmann::json serializes std::unordered_map<uint16_t, string> as array of pairs
@@ -387,6 +429,22 @@ export class HierarchicalTelemetryStore {
                     this.addPath(path, value, false, timestamp, unitCode);
                 } else {
                     this.updateDoubleValue(path, value, timestamp);
+                }
+                didUpdate = true;
+            }
+        }
+
+        // Process string metrics
+        if (snapshot.string_metrics) {
+            for (const [path, value] of Object.entries(snapshot.string_metrics)) {
+                const timestamp = snapshot.string_metric_timestamps ? snapshot.string_metric_timestamps[path] : null;
+                const unitCode = snapshot.string_metric_units ? snapshot.string_metric_units[path] : null;
+
+                // Check if this is a new path
+                if (!this._dataByPath.has(path)) {
+                    this.addPath(path, value, false, timestamp, unitCode);
+                } else {
+                    this.updateStringValue(path, value, timestamp);
                 }
                 didUpdate = true;
             }

--- a/tt_telemetry/frontend/static/js/hierarchical_telemetry_store.js
+++ b/tt_telemetry/frontend/static/js/hierarchical_telemetry_store.js
@@ -249,7 +249,7 @@ export class HierarchicalTelemetryStore {
             return;
         }
 
-        // Split path into components. Then move upwards to propagate the boolean value and timestamp.
+        // Split path into components. Then move upwards to propagate the string value and timestamp.
         const parts = path.split("/");
         for (let i = parts.length; i > 0; i--) {
             const currentPath = parts.slice(0, i).join("/");

--- a/tt_telemetry/frontend/static/js/metric-sidebar.js
+++ b/tt_telemetry/frontend/static/js/metric-sidebar.js
@@ -193,12 +193,16 @@ export class MetricSidebar extends LitElement {
 
         // Determine data type
         let dataType;
-        if (typeof this.metricValue === 'boolean') {
+        if (this.metricValue === null || this.metricValue === undefined) {
+            dataType = 'No Value';
+        } else if (typeof this.metricValue === 'boolean') {
             dataType = 'Boolean Health';
         } else if (typeof this.metricValue === 'string') {
             dataType = 'String Value';
-        } else {
+        } else if (typeof this.metricValue === 'number') {
             dataType = 'Numeric Value';
+        } else {
+            dataType = 'Unknown';
         }
 
         return {

--- a/tt_telemetry/frontend/static/js/metric-sidebar.js
+++ b/tt_telemetry/frontend/static/js/metric-sidebar.js
@@ -191,10 +191,20 @@ export class MetricSidebar extends LitElement {
             this.metricTimestamp.toLocaleString() :
             'Never';
 
+        // Determine data type
+        let dataType;
+        if (typeof this.metricValue === 'boolean') {
+            dataType = 'Boolean Health';
+        } else if (typeof this.metricValue === 'string') {
+            dataType = 'String Value';
+        } else {
+            dataType = 'Numeric Value';
+        }
+
         return {
             lastUpdated,
             updateFrequency: '5 seconds',
-            dataType: typeof this.metricValue === 'boolean' ? 'Boolean Health' : 'Numeric Value',
+            dataType: dataType,
             source: 'Hardware Monitor',
             threshold: typeof this.metricValue === 'boolean' ? 'N/A' : '> 100',
             unit: typeof this.metricValue === 'boolean' ? 'Status' : 'Count',

--- a/tt_telemetry/frontend/static/js/status-box.js
+++ b/tt_telemetry/frontend/static/js/status-box.js
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { LitElement, html, css } from 'https://cdn.jsdelivr.net/gh/lit/dist@3/all/lit-all.min.js';
-import { formatFloat } from './utils.js';
+import { formatValue } from './utils.js';
 
 // STATUS BOX COMPONENT - Individual clickable status boxes
 export class StatusBox extends LitElement {
@@ -393,8 +393,9 @@ export class StatusBox extends LitElement {
 
         if (this.type === 'valued') {
             statusClass = 'valued';
-            const valueDisplay = formatFloat(this.value);
-            const unitDisplay = this.unitDisplayLabel ? ` ${this.unitDisplayLabel}` : '';
+            const valueDisplay = formatValue(this.value);
+            // Don't show units for string values
+            const unitDisplay = (typeof this.value !== 'string' && this.unitDisplayLabel) ? ` ${this.unitDisplayLabel}` : '';
             content = html`
                 <div class="valued-name ${scaleClass}">${displayName}</div>
                 <div class="valued-value">${valueDisplay}${unitDisplay}</div>

--- a/tt_telemetry/frontend/static/js/status-box.js
+++ b/tt_telemetry/frontend/static/js/status-box.js
@@ -394,8 +394,8 @@ export class StatusBox extends LitElement {
         if (this.type === 'valued') {
             statusClass = 'valued';
             const valueDisplay = formatValue(this.value);
-            // Don't show units for string values
-            const unitDisplay = (typeof this.value !== 'string' && this.unitDisplayLabel) ? ` ${this.unitDisplayLabel}` : '';
+            // Don't show units for string values, null, or undefined
+            const unitDisplay = (this.value != null && typeof this.value !== 'string' && this.unitDisplayLabel) ? ` ${this.unitDisplayLabel}` : '';
             content = html`
                 <div class="valued-name ${scaleClass}">${displayName}</div>
                 <div class="valued-value">${valueDisplay}${unitDisplay}</div>

--- a/tt_telemetry/frontend/static/js/utils.js
+++ b/tt_telemetry/frontend/static/js/utils.js
@@ -74,8 +74,8 @@ export function formatValue(value, maxLength = 20) {
         if (Number.isInteger(value)) {
             return String(value);
         }
-        // Format to 2 decimal places and remove trailing zeros
-        return parseFloat(value.toFixed(2)).toString();
+        // Format to 2 decimal places (toFixed already returns a string)
+        return value.toFixed(2);
     }
 
     // Handle booleans
@@ -85,6 +85,9 @@ export function formatValue(value, maxLength = 20) {
 
     // Handle strings
     if (typeof value === 'string') {
+        if (maxLength <= 0) {
+            return '…';
+        }
         if (value.length <= maxLength) {
             return value;
         }

--- a/tt_telemetry/frontend/static/js/utils.js
+++ b/tt_telemetry/frontend/static/js/utils.js
@@ -54,28 +54,57 @@ export function arrayOfPairsToObject(pairsArray) {
 }
 
 /**
+ * Formats a value for display, handling numbers, strings, and booleans.
+ * For numbers: displays with up to 2 decimal places.
+ * For strings: truncates long strings with ellipsis.
+ * For booleans: returns string representation.
+ *
+ * @param {any} value - The value to format
+ * @param {number} maxLength - Maximum string length before truncation (default: 20)
+ * @returns {string} - Formatted string representation
+ */
+export function formatValue(value, maxLength = 20) {
+    if (value === null || value === undefined) {
+        return 'N/A';
+    }
+
+    // Handle numbers
+    if (typeof value === 'number') {
+        // If it's an integer, return without decimal places
+        if (Number.isInteger(value)) {
+            return String(value);
+        }
+        // Format to 2 decimal places and remove trailing zeros
+        return parseFloat(value.toFixed(2)).toString();
+    }
+
+    // Handle booleans
+    if (typeof value === 'boolean') {
+        return String(value);
+    }
+
+    // Handle strings
+    if (typeof value === 'string') {
+        if (value.length <= maxLength) {
+            return value;
+        }
+        // Truncate with ellipsis
+        return value.substring(0, maxLength - 1) + '…';
+    }
+
+    // Fallback for other types
+    return String(value);
+}
+
+/**
  * Formats a numeric value to display with up to 2 decimal places.
  * Removes trailing zeros and unnecessary decimal points.
  * Examples: 4 -> "4", 4.1 -> "4.1", 4.12 -> "4.12", 4.123 -> "4.12"
  *
  * @param {any} value - The value to format
  * @returns {string} - Formatted string representation
+ * @deprecated Use formatValue() instead for broader type support
  */
 export function formatFloat(value) {
-    if (value === null || value === undefined) {
-        return 'N/A';
-    }
-
-    // If it's not a number, return as-is
-    if (typeof value !== 'number') {
-        return String(value);
-    }
-
-    // If it's an integer, return without decimal places
-    if (Number.isInteger(value)) {
-        return String(value);
-    }
-
-    // Format to 2 decimal places and remove trailing zeros
-    return parseFloat(value.toFixed(2)).toString();
+    return formatValue(value);
 }

--- a/tt_telemetry/include/telemetry/arc/arc_metrics.hpp
+++ b/tt_telemetry/include/telemetry/arc/arc_metrics.hpp
@@ -69,10 +69,33 @@ private:
     std::function<std::optional<double>()> getter_func_;
 };
 
+class ARCStringMetric : public StringMetric {
+public:
+    // Constructor using FirmwareInfoProvider
+    ARCStringMetric(
+        tt::tt_metal::ASICDescriptor asic_descriptor,
+        tt::umd::FirmwareInfoProvider* firmware_provider,
+        const std::string& metric_name,
+        std::function<std::optional<std::string>()> getter_func,
+        MetricUnit units = MetricUnit::UNITLESS);
+
+    const std::vector<std::string> telemetry_path() const override;
+    void update(
+        const std::unique_ptr<tt::umd::Cluster>& cluster,
+        std::chrono::steady_clock::time_point start_of_update_cycle) override;
+
+private:
+    tt::tt_metal::ASICDescriptor asic_descriptor_;
+    tt::umd::FirmwareInfoProvider* firmware_provider_;
+    std::string metric_name_;
+    std::function<std::optional<std::string>()> getter_func_;
+};
+
 void create_arc_metrics(
     std::vector<std::unique_ptr<BoolMetric>>& bool_metrics,
     std::vector<std::unique_ptr<UIntMetric>>& uint_metrics,
     std::vector<std::unique_ptr<DoubleMetric>>& double_metrics,
+    std::vector<std::unique_ptr<StringMetric>>& string_metrics,
     const std::unique_ptr<tt::umd::Cluster>& cluster,
     const std::unique_ptr<TopologyHelper>& topology_translation,
     const std::unique_ptr<tt::tt_metal::Hal>& hal);

--- a/tt_telemetry/include/telemetry/metric.hpp
+++ b/tt_telemetry/include/telemetry/metric.hpp
@@ -13,6 +13,7 @@
 #include <vector>
 #include <chrono>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 
 #include <fmt/ranges.h>

--- a/tt_telemetry/include/telemetry/metric.hpp
+++ b/tt_telemetry/include/telemetry/metric.hpp
@@ -134,3 +134,19 @@ public:
 protected:
     double value_ = 0.0;
 };
+
+class StringMetric : public Metric {
+public:
+    StringMetric(MetricUnit metric_units = MetricUnit::UNITLESS) : Metric(metric_units) {}
+
+    std::string_view value() const { return value_; }
+
+    void set_value(std::string value) {
+        value_ = std::move(value);
+        changed_since_transmission_ = true;
+        set_timestamp_now();
+    }
+
+protected:
+    std::string value_;
+};

--- a/tt_telemetry/include/telemetry/metric.hpp
+++ b/tt_telemetry/include/telemetry/metric.hpp
@@ -10,7 +10,7 @@
  * Metric (i.e., telemetry point) types that we track. Various telemetry values derive from these.
  */
 
- #include <vector>
+#include <vector>
 #include <chrono>
 #include <string>
 #include <unordered_map>
@@ -92,8 +92,8 @@ public:
     }
 
     void set_value(bool value) {
+        changed_since_transmission_ = (value_ != value);
         value_ = value;
-        changed_since_transmission_ = true;
         set_timestamp_now();
     }
 
@@ -110,8 +110,8 @@ public:
     }
 
     void set_value(uint64_t value) {
+        changed_since_transmission_ = (value_ != value);
         value_ = value;
-        changed_since_transmission_ = true;
         set_timestamp_now();
     }
 
@@ -126,8 +126,8 @@ public:
     double value() const { return value_; }
 
     void set_value(double value) {
+        changed_since_transmission_ = (value_ != value);
         value_ = value;
-        changed_since_transmission_ = true;
         set_timestamp_now();
     }
 
@@ -142,8 +142,8 @@ public:
     std::string_view value() const { return value_; }
 
     void set_value(std::string value) {
+        changed_since_transmission_ = (value_ != value);
         value_ = std::move(value);
-        changed_since_transmission_ = true;
         set_timestamp_now();
     }
 

--- a/tt_telemetry/include/telemetry/telemetry_snapshot.hpp
+++ b/tt_telemetry/include/telemetry/telemetry_snapshot.hpp
@@ -242,6 +242,7 @@ private:
         }
 
         // Validate and merge string metrics
+        std::unordered_set<std::string> merged_string_paths;
         for (const auto& [path, value] : other.string_metrics) {
             // Check if this path exists in other metric types
             if (bool_metrics.find(path) != bool_metrics.end()) {
@@ -257,14 +258,19 @@ private:
                 continue;  // Skip this update
             }
             string_metrics[path] = value;
+            merged_string_paths.insert(path);
         }
 
-        // Merge string metadata
+        // Merge string metadata only for successfully merged paths
         for (const auto& [path, unit] : other.string_metric_units) {
-            string_metric_units[path] = unit;
+            if (merged_string_paths.find(path) != merged_string_paths.end()) {
+                string_metric_units[path] = unit;
+            }
         }
         for (const auto& [path, timestamp] : other.string_metric_timestamps) {
-            string_metric_timestamps[path] = timestamp;
+            if (merged_string_paths.find(path) != merged_string_paths.end()) {
+                string_metric_timestamps[path] = timestamp;
+            }
         }
     }
 

--- a/tt_telemetry/include/telemetry/telemetry_snapshot.hpp
+++ b/tt_telemetry/include/telemetry/telemetry_snapshot.hpp
@@ -177,6 +177,10 @@ private:
                 log_error(tt::LogAlways, "Metric type conflict: path '{}' exists as both bool and double", path);
                 continue;  // Skip this update
             }
+            if (string_metrics.find(path) != string_metrics.end()) {
+                log_error(tt::LogAlways, "Metric type conflict: path '{}' exists as both bool and string", path);
+                continue;  // Skip this update
+            }
             bool_metrics[path] = value;
         }
 
@@ -194,6 +198,10 @@ private:
             }
             if (double_metrics.find(path) != double_metrics.end()) {
                 log_error(tt::LogAlways, "Metric type conflict: path '{}' exists as both uint and double", path);
+                continue;  // Skip this update
+            }
+            if (string_metrics.find(path) != string_metrics.end()) {
+                log_error(tt::LogAlways, "Metric type conflict: path '{}' exists as both uint and string", path);
                 continue;  // Skip this update
             }
             uint_metrics[path] = value;
@@ -216,6 +224,10 @@ private:
             }
             if (uint_metrics.find(path) != uint_metrics.end()) {
                 log_error(tt::LogAlways, "Metric type conflict: path '{}' exists as both double and uint", path);
+                continue;  // Skip this update
+            }
+            if (string_metrics.find(path) != string_metrics.end()) {
+                log_error(tt::LogAlways, "Metric type conflict: path '{}' exists as both double and string", path);
                 continue;  // Skip this update
             }
             double_metrics[path] = value;

--- a/tt_telemetry/include/telemetry/telemetry_snapshot.hpp
+++ b/tt_telemetry/include/telemetry/telemetry_snapshot.hpp
@@ -36,6 +36,7 @@ struct TelemetrySnapshot {
     std::unordered_map<std::string, uint64_t> uint_metric_timestamps;
     std::unordered_map<std::string, uint16_t> double_metric_units;
     std::unordered_map<std::string, uint64_t> double_metric_timestamps;
+    std::unordered_map<std::string, uint16_t> string_metric_units;
     std::unordered_map<std::string, uint64_t> string_metric_timestamps;
 
     // Unit label maps
@@ -52,6 +53,7 @@ struct TelemetrySnapshot {
         uint_metric_timestamps.clear();
         double_metric_units.clear();
         double_metric_timestamps.clear();
+        string_metric_units.clear();
         string_metric_timestamps.clear();
         metric_unit_display_label_by_code.clear();
         metric_unit_full_label_by_code.clear();
@@ -118,6 +120,9 @@ private:
         // Update string metrics and their metadata
         for (const auto& [path, value] : other.string_metrics) {
             string_metrics[path] = value;
+        }
+        for (const auto& [path, unit] : other.string_metric_units) {
+            string_metric_units[path] = unit;
         }
         for (const auto& [path, timestamp] : other.string_metric_timestamps) {
             string_metric_timestamps[path] = timestamp;
@@ -243,6 +248,9 @@ private:
         }
 
         // Merge string metadata
+        for (const auto& [path, unit] : other.string_metric_units) {
+            string_metric_units[path] = unit;
+        }
         for (const auto& [path, timestamp] : other.string_metric_timestamps) {
             string_metric_timestamps[path] = timestamp;
         }
@@ -262,6 +270,7 @@ public:
          {"uint_metric_timestamps", t.uint_metric_timestamps},
          {"double_metric_units", t.double_metric_units},
          {"double_metric_timestamps", t.double_metric_timestamps},
+         {"string_metric_units", t.string_metric_units},
          {"string_metric_timestamps", t.string_metric_timestamps},
          {"metric_unit_display_label_by_code", t.metric_unit_display_label_by_code},
          {"metric_unit_full_label_by_code", t.metric_unit_full_label_by_code},
@@ -278,6 +287,7 @@ static inline void from_json(const nlohmann::json &j, TelemetrySnapshot &t) {
     j.at("uint_metric_timestamps").get_to(t.uint_metric_timestamps);
     j.at("double_metric_units").get_to(t.double_metric_units);
     j.at("double_metric_timestamps").get_to(t.double_metric_timestamps);
+    j.at("string_metric_units").get_to(t.string_metric_units);
     j.at("string_metric_timestamps").get_to(t.string_metric_timestamps);
     j.at("metric_unit_display_label_by_code").get_to(t.metric_unit_display_label_by_code);
     j.at("metric_unit_full_label_by_code").get_to(t.metric_unit_full_label_by_code);

--- a/tt_telemetry/server/prom_formatter.cpp
+++ b/tt_telemetry/server/prom_formatter.cpp
@@ -92,7 +92,7 @@ ParsedMetric parse_metric_path(std::string_view path) {
 // Prometheus requires backslashes, double-quotes, and newlines to be escaped
 std::string escape_label_value(std::string_view value) {
     std::string escaped;
-    escaped.reserve(value.size());
+    escaped.reserve(value.size() * 2);  // Reserve extra capacity for escaped characters
     for (char c : value) {
         if (c == '\\' || c == '"' || c == '\n') {
             escaped += '\\';

--- a/tt_telemetry/telemetry/arc/arc_metrics.cpp
+++ b/tt_telemetry/telemetry/arc/arc_metrics.cpp
@@ -275,8 +275,7 @@ void ARCStringMetric::update(
 
     // Update the metric value and timestamp
     std::string new_value = optional_value.value_or("");
-    std::string old_value = value_;
-    changed_since_transmission_ = new_value != old_value;
-    value_ = new_value;
+    changed_since_transmission_ = (new_value != value_);
+    value_ = std::move(new_value);
     set_timestamp_now();
 }

--- a/tt_telemetry/telemetry/arc/arc_metrics.cpp
+++ b/tt_telemetry/telemetry/arc/arc_metrics.cpp
@@ -30,6 +30,7 @@ void create_arc_metrics(
     std::vector<std::unique_ptr<BoolMetric>>& bool_metrics,
     std::vector<std::unique_ptr<UIntMetric>>& uint_metrics,
     std::vector<std::unique_ptr<DoubleMetric>>& double_metrics,
+    std::vector<std::unique_ptr<StringMetric>>& string_metrics,
     const std::unique_ptr<tt::umd::Cluster>& cluster,
     const std::unique_ptr<TopologyHelper>& topology_translation,
     const std::unique_ptr<tt::tt_metal::Hal>& hal) {
@@ -122,6 +123,29 @@ void create_arc_metrics(
                         "BoardTemperature",
                         [firmware_provider]() { return firmware_provider->get_board_temperature(); },
                         MetricUnit::CELSIUS));
+
+                    // Create String metrics for firmware version information
+                    // Note: Additional firmware versions (ARC, M3, Flash) are not yet exposed
+                    // and require UMD support. See related UMD issue for details.
+                    string_metrics.push_back(std::make_unique<ARCStringMetric>(
+                        asic_descriptor.value(),
+                        firmware_provider,
+                        "FirmwareBundleVersion",
+                        [firmware_provider]() -> std::optional<std::string> {
+                            return firmware_provider->get_firmware_version().to_string();
+                        },
+                        MetricUnit::UNITLESS));
+
+                    string_metrics.push_back(std::make_unique<ARCStringMetric>(
+                        asic_descriptor.value(),
+                        firmware_provider,
+                        "EthernetFirmwareVersion",
+                        [firmware_provider]() -> std::optional<std::string> {
+                            // Decode using tt_version constructor which handles the bit packing
+                            tt::umd::tt_version eth_ver(firmware_provider->get_eth_fw_version());
+                            return eth_ver.str();
+                        },
+                        MetricUnit::UNITLESS));
                 } else {
                     log_error(
                         tt::LogAlways,
@@ -216,6 +240,42 @@ void ARCDoubleMetric::update(
     // Update the metric value and timestamp
     double new_value = optional_value.value_or(0.0);
     double old_value = value_;
+    changed_since_transmission_ = new_value != old_value;
+    value_ = new_value;
+    set_timestamp_now();
+}
+
+/**************************************************************************************************
+| ARCStringMetric Class
+**************************************************************************************************/
+
+ARCStringMetric::ARCStringMetric(
+    tt::tt_metal::ASICDescriptor asic_descriptor,
+    tt::umd::FirmwareInfoProvider* firmware_provider,
+    const std::string& metric_name,
+    std::function<std::optional<std::string>()> getter_func,
+    MetricUnit units) :
+    StringMetric(units),
+    asic_descriptor_(asic_descriptor),
+    firmware_provider_(firmware_provider),
+    metric_name_(metric_name),
+    getter_func_(getter_func) {
+    TT_ASSERT(firmware_provider_ != nullptr, "FirmwareInfoProvider cannot be null");
+    value_ = "";
+}
+
+const std::vector<std::string> ARCStringMetric::telemetry_path() const {
+    return arc_telemetry_path(asic_descriptor_.tray_id, asic_descriptor_.asic_location, metric_name_);
+}
+
+void ARCStringMetric::update(
+    const std::unique_ptr<tt::umd::Cluster>& cluster, std::chrono::steady_clock::time_point start_of_update_cycle) {
+    // Get the value using the getter function
+    auto optional_value = getter_func_();
+
+    // Update the metric value and timestamp
+    std::string new_value = optional_value.value_or("");
+    std::string old_value = value_;
     changed_since_transmission_ = new_value != old_value;
     value_ = new_value;
     set_timestamp_now();

--- a/tt_telemetry/telemetry/telemetry_collector.cpp
+++ b/tt_telemetry/telemetry/telemetry_collector.cpp
@@ -222,6 +222,7 @@ static void send_initial_snapshot(const std::vector<std::shared_ptr<TelemetrySub
     for (size_t i = 0; i < string_metrics_.size(); i++) {
         std::string path = get_cluster_wide_telemetry_path(*string_metrics_[i]);
         snapshot->string_metrics[path] = string_metrics_[i]->value();
+        snapshot->string_metric_units[path] = static_cast<uint16_t>(string_metrics_[i]->units);
         snapshot->string_metric_timestamps[path] = string_metrics_[i]->timestamp();
     }
 
@@ -273,6 +274,7 @@ static void update_delta_snapshot_with_local_telemetry(std::shared_ptr<Telemetry
         }
         std::string path = get_cluster_wide_telemetry_path(*string_metrics_[i]);
         snapshot->string_metrics[path] = string_metrics_[i]->value();
+        snapshot->string_metric_units[path] = static_cast<uint16_t>(string_metrics_[i]->units);
         snapshot->string_metric_timestamps[path] = string_metrics_[i]->timestamp();
         string_metrics_[i]->mark_transmitted();
     }


### PR DESCRIPTION
### Ticket
Solves #31144 


  ### Problem description
  Cloud teams currently need to use both `tt-metrics` and `tt-smi` to gather firmware version information from Tenstorrent devices. `tt_telemetry` (which uses UMD) was missing the ability to expose firmware version metadata, forcing users to run separate tools for complete device monitoring.

  `tt-smi` provides firmware information like bundle version, Ethernet FW version, ARC FW version, M3 firmware versions, and flash versions, but `tt_telemetry` could only expose runtime metrics (clocks, power, temperature) without any firmware context.

  ### What's changed
  This PR introduces `StringMetric` support to the telemetry infrastructure and adds firmware version metrics.

  **Core Infrastructure Changes:**
  - Added `StringMetric` class with `std::string_view` accessor to the metric type hierarchy
  - Extended `TelemetrySnapshot` to handle string metrics with full serialization, validation, and merge logic
  - Enhanced Prometheus formatter with proper label escaping (backslash, quotes, newlines) for security
  - Refactored `process_metrics` template to support value converters that can modify labels (enables
  Prometheus info pattern)

  **Firmware Metrics Added:**
  - `FirmwareBundleVersion`: Exposes firmware bundle version using `FirmwareInfoProvider::get_firmware_version()` (e.g., `"18.12.1.0"`)
  - `EthernetFirmwareVersion`: Exposes Ethernet firmware version using `tt_version` decoder from raw `uint32_t`
  (e.g., `"7.1.0"`)

  **Implementation Details:**
  - String metrics exported using Prometheus info pattern (metric `value = 1`, actual string stored in `value` label)
  - Created `ARCStringMetric` class following existing pattern of `ARCUintMetric` and `ARCDoubleMetric`
  - All label values now properly escaped to prevent Prometheus format violations

  **Example Output:**
  ```prometheus
  FirmwareBundleVersion{hostname="sjc-wh-05",tray="1",chip="0",value="18.12.1.0"} 1
  EthernetFirmwareVersion{hostname="sjc-wh-05",tray="1",chip="0",value="7.1.0"} 1
  ```

  **Known Limitations:**
  Additional firmware versions (ARC/CM, M3 App/Bootloader, Flash) use different encoding formats and require UMD-level decoder support. Tracked in https://github.com/tenstorrent/tt-umd/issues/1567.
 

### Checklist

- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes