### PR TITLE
Fix regression in all broadcast for galaxy testing

### DIFF
--- a/tests/nightly/t3000/ccl/test_new_all_broadcast.py
+++ b/tests/nightly/t3000/ccl/test_new_all_broadcast.py
@@ -16,6 +16,7 @@ def run_with_trace(
     num_links,
     output_mem_config,
     num_iter=20,
+    cluster_axis=None,
     subdevice_id=None,
 ):
     # Compile Run
@@ -23,6 +24,7 @@ def run_with_trace(
     tt_out_tensor = ttnn.all_broadcast(
         input_tensor_mesh,
         num_links=num_links,
+        cluster_axis=cluster_axis,
         memory_config=output_mem_config,
         topology=all_broadcast_topology,
         subdevice_id=subdevice_id,
@@ -36,6 +38,7 @@ def run_with_trace(
         tt_out_tensor = ttnn.all_broadcast(
             input_tensor_mesh,
             num_links=num_links,
+            cluster_axis=cluster_axis,
             memory_config=output_mem_config,
             topology=all_broadcast_topology,
             subdevice_id=subdevice_id,
@@ -187,6 +190,7 @@ def run_all_broadcast_impl(
             input_tensor_mesh_list[0],
             num_links,
             output_mem_config,
+            cluster_axis=cluster_axis,
             num_iter=num_iters,
             subdevice_id=worker_sub_device_id,
         )
@@ -197,6 +201,7 @@ def run_all_broadcast_impl(
                 input_tensor_mesh_list[i],
                 num_links=num_links,
                 memory_config=output_mem_config,
+                cluster_axis=cluster_axis,
                 topology=all_broadcast_topology,
                 subdevice_id=worker_sub_device_id,
             )

--- a/tests/nightly/tg/ccl/test_all_broadcast.py
+++ b/tests/nightly/tg/ccl/test_all_broadcast.py
@@ -41,9 +41,11 @@ def test_all_broadcast_trace(
     num_iters,
     function_level_defaults,
 ):
+    cluster_axis = 0
     if layout == ttnn.ROW_MAJOR_LAYOUT and input_dtype == ttnn.bfloat8_b:
         pytest.skip("bfloat8_b not supported for row-major")
     if num_devices < 8:
+        cluster_axis = 1
         mesh_mapper_config = ttnn.MeshMapperConfig(
             [ttnn.PlacementReplicate(), ttnn.PlacementShard(-1)], ttnn.MeshShape(1, num_devices)
         )
@@ -59,6 +61,7 @@ def test_all_broadcast_trace(
         input_dtype,
         layout,
         function_level_defaults,
+        cluster_axis=cluster_axis,
         all_broadcast_topology=ttnn.Topology.Linear,
         num_iters=num_iters,
         rand_tensor=True,


### PR DESCRIPTION
Hoping to turn CI Nightly and frequent galaxy green

The cluster axis flag was not properly set in the test and was internally getting ignored. This is now fixed

Galaxy Nightly: https://github.com/tenstorrent/tt-metal/actions/runs/19046749676
Galaxy Frequent: https://github.com/tenstorrent/tt-metal/actions/runs/19048215917

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes