### PR TITLE
Dataflow 2.0 API: Default constructor for Noc class added

### DIFF
--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -2385,6 +2385,7 @@ private:
     }
 
 public:
+    Noc() : noc_id_(noc_index) {}
     explicit Noc(uint8_t noc_id) : noc_id_(noc_id) {}
 
     uint8_t get_noc_id() const { return noc_id_; }


### PR DESCRIPTION
### Ticket
N/A

### Problem description
In a lot of noc use cases the noc id is implied to use the default `noc_index`. In the current Noc class constructor in dataflow 2.0 APIs, the noc id has to be passed in as an argument.

### What's changed
Added a default constructor for the Noc class that sets the internal noc_id_ to the default `noc_index`, removing the need to pass in a noc id argument when creating a Noc object.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/19046895258) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/19046898268) CI tests passes