### PR TITLE
#31466: Migrate `ttnn::experimental` to `tt::tt_metal::experimental` for xtensor files

### DIFF
--- a/tests/ttnn/unit_tests/gtests/tensor/test_partition.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_partition.cpp
@@ -31,10 +31,10 @@ namespace ttnn {
 namespace {
 
 using ::testing::SizeIs;
-using ::ttnn::experimental::xtensor::chunk;
-using ::ttnn::experimental::xtensor::chunk_ndim;
-using ::ttnn::experimental::xtensor::concat;
-using ::ttnn::experimental::xtensor::concat_ndim;
+using ::tt::tt_metal::experimental::xtensor::chunk;
+using ::tt::tt_metal::experimental::xtensor::chunk_ndim;
+using ::tt::tt_metal::experimental::xtensor::concat;
+using ::tt::tt_metal::experimental::xtensor::concat_ndim;
 
 TEST(PartitionTest, ChunkBasicNonDivisible3) {
     // Create a 1D tensor: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
@@ -261,7 +261,8 @@ TEST(PartitionTest, ChunkDoesNotAccessData) {
         for (const auto& chunked_xexpr : chunks) {
             EXPECT_THAT(chunked_xexpr, SizeIs(kDim0Size * page_size));
             EXPECT_EQ(
-                experimental::xtensor::get_shape_from_xarray(chunked_xexpr), ttnn::Shape({kDim0Size, 1, page_size}));
+                tt::tt_metal::experimental::xtensor::get_shape_from_xarray(chunked_xexpr),
+                ttnn::Shape({kDim0Size, 1, page_size}));
         }
     } else {
         FAIL() << "segfault occurred when calling `chunk`";

--- a/tests/ttnn/unit_tests/gtests/tensor/test_xtensor_adapter.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_xtensor_adapter.cpp
@@ -17,7 +17,7 @@ namespace ttnn {
 namespace {
 
 using ::testing::ElementsAre;
-using ::ttnn::experimental::xtensor::XtensorAdapter;
+using ::tt::tt_metal::experimental::xtensor::XtensorAdapter;
 
 TEST(XtensorAdapterTest, BasicConstruction) {
     std::vector<float> data = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f};

--- a/tests/ttnn/unit_tests/gtests/tensor/test_xtensor_conversion.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_xtensor_conversion.cpp
@@ -32,11 +32,11 @@ namespace {
 
 using ::testing::ElementsAre;
 using ::testing::Eq;
-using ::ttnn::experimental::xtensor::from_xtensor;
-using ::ttnn::experimental::xtensor::get_shape_from_xarray;
-using ::ttnn::experimental::xtensor::span_to_xtensor_view;
-using ::ttnn::experimental::xtensor::to_xtensor;
-using ::ttnn::experimental::xtensor::xtensor_to_span;
+using ::tt::tt_metal::experimental::xtensor::from_xtensor;
+using ::tt::tt_metal::experimental::xtensor::get_shape_from_xarray;
+using ::tt::tt_metal::experimental::xtensor::span_to_xtensor_view;
+using ::tt::tt_metal::experimental::xtensor::to_xtensor;
+using ::tt::tt_metal::experimental::xtensor::xtensor_to_span;
 
 TensorSpec get_tensor_spec(const ttnn::Shape& shape) {
     return TensorSpec(

--- a/tt-train/sources/ttml/core/tt_tensor_utils.hpp
+++ b/tt-train/sources/ttml/core/tt_tensor_utils.hpp
@@ -51,7 +51,7 @@ template <class T = float, ttnn::DataType TensorType = ttnn::DataType::BFLOAT16>
     ttnn::distributed::MeshDevice* device,
     ttnn::Layout layout = ttnn::Layout::TILE,
     const ttnn::distributed::TensorToMesh* mesh_mapper = nullptr) {
-    auto shape = ttnn::experimental::xtensor::get_shape_from_xarray(buffer);
+    auto shape = tt::tt_metal::experimental::xtensor::get_shape_from_xarray(buffer);
     auto buffer_view = xtensor_to_span(buffer);
     return from_vector<T, TensorType>(
         std::vector<T>(buffer_view.begin(), buffer_view.end()), shape, device, layout, mesh_mapper);

--- a/tt-train/sources/ttml/core/xtensor_utils.hpp
+++ b/tt-train/sources/ttml/core/xtensor_utils.hpp
@@ -58,16 +58,16 @@ set to N at compile time. xtensor_fixed<T, xshape<I, J, K> : tensor whose shape 
 namespace ttml::core {
 template <class T>
 xt::xarray<T> span_to_xtensor_view(std::span<T> vec, const ttnn::Shape& shape) {
-    return ttnn::experimental::xtensor::span_to_xtensor_view(vec, shape);
+    return tt::tt_metal::experimental::xtensor::span_to_xtensor_view(vec, shape);
 }
 template <class T>
 auto xtensor_to_span(const xt::xarray<T>& xtensor) {
-    return ttnn::experimental::xtensor::xtensor_to_span(xtensor);
+    return tt::tt_metal::experimental::xtensor::xtensor_to_span(xtensor);
 }
 
 template <typename T>
 xt::xarray<T> concat(const std::vector<xt::xarray<T>>& v, size_t axis = 0) {
-    return ttnn::experimental::xtensor::concat(v, axis).expr();
+    return tt::tt_metal::experimental::xtensor::concat(v, axis).expr();
 }
 
 }  // namespace ttml::core

--- a/ttnn/api/ttnn/tensor/xtensor/conversion_utils.hpp
+++ b/ttnn/api/ttnn/tensor/xtensor/conversion_utils.hpp
@@ -10,7 +10,7 @@
 #include "ttnn/tensor/tensor.hpp"
 #include <ttnn/tensor/xtensor/xtensor_all_includes.hpp>
 
-namespace ttnn::experimental::xtensor {
+namespace tt::tt_metal::experimental::xtensor {
 
 // Returns the shape of the xtensor as `tt::tt_metal::Shape`.
 template <typename E>
@@ -122,4 +122,4 @@ xt::xarray<T> to_xtensor(const tt::tt_metal::Tensor& tensor) {
     return xt::xarray<T>(span_to_xtensor_view(tt::stl::Span<T>(vec.data(), vec.size()), shape));
 }
 
-}  // namespace ttnn::experimental::xtensor
+}  // namespace tt::tt_metal::experimental::xtensor

--- a/ttnn/api/ttnn/tensor/xtensor/partition.hpp
+++ b/ttnn/api/ttnn/tensor/xtensor/partition.hpp
@@ -10,7 +10,7 @@
 #include <xtensor/views/xstrided_view.hpp>
 #include "ttnn/tensor/tensor.hpp"
 
-namespace ttnn::experimental::xtensor {
+namespace tt::tt_metal::experimental::xtensor {
 namespace detail {
 
 // Helper to compute the type of an unowned strided view over an `xt::xexpression`.
@@ -59,4 +59,4 @@ XtensorAdapter<typename Expression::value_type> concat_ndim(
 // Deprecated: Use high-level APIs defined in distributed_tensor.hpp
 tt::tt_metal::Tensor concat(const std::vector<tt::tt_metal::Tensor>& tensors, int dim = 0);
 
-}  // namespace ttnn::experimental::xtensor
+}  // namespace tt::tt_metal::experimental::xtensor

--- a/ttnn/core/tensor/xtensor/partition.cpp
+++ b/ttnn/core/tensor/xtensor/partition.cpp
@@ -19,7 +19,7 @@
 #include <xtensor/core/xtensor_forward.hpp>
 #include <xtensor/views/xview.hpp>
 
-namespace ttnn::experimental::xtensor {
+namespace tt::tt_metal::experimental::xtensor {
 namespace {
 
 ttsl::SmallVector<int> normalize_dims(const ttsl::SmallVector<int>& dims, size_t tensor_dims) {
@@ -303,4 +303,4 @@ EXPLICIT_INSTANTIATIONS_FOR_TYPE(uint32_t)
 
 #undef EXPLICIT_INSTANTIATIONS_FOR_TYPE
 
-}  // namespace ttnn::experimental::xtensor
+}  // namespace tt::tt_metal::experimental::xtensor


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/31466)

### Problem description
This is part of the larger effort of lowering Tensor to metal.

### What's changed

- Changed `ttnn::experimental::xtensor` namespace to `tt::tt_metal::experimental::xtensor`

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes ([link to run](https://github.com/tenstorrent/tt-metal/actions/runs/19048114649))
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes