### PR TITLE
Improve CBReader API

### DIFF
--- a/tools/triage/dump_fast_dispatch.py
+++ b/tools/triage/dump_fast_dispatch.py
@@ -168,7 +168,7 @@ def read_wait_globals(
     last_wait_stream = _read_symbol_value(kernel_elf, "last_wait_stream", loc_mem_access)
     last_event = _read_symbol_value(kernel_elf, "last_event", loc_mem_access)
     try:
-        circular_buffer_fence = kernel_elf.get_global("dispatch_cb_reader", loc_mem_access).cb_fence
+        circular_buffer_fence = kernel_elf.get_global("dispatch_cb_reader", loc_mem_access).cb_fence_
     except:
         circular_buffer_fence = None
     command_pointer = _read_symbol_value(kernel_elf, "cmd_ptr", loc_mem_access)

--- a/tt_metal/impl/dispatch/kernels/cq_common.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_common.hpp
@@ -410,7 +410,7 @@ private:
     uint32_t local_count_{0};
 };
 
-// Unified reader that delegates release to a policy defined in the TU
+// Reader that releases a block of pages at a time.
 template <
     uint32_t my_sem_id,
     uint32_t cb_log_page_size,

--- a/tt_metal/impl/dispatch/kernels/cq_common.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_common.hpp
@@ -430,7 +430,10 @@ public:
 
     // Returns how much data is available. Will block until data is available. May release old pages before cmd_ptr to writer.
     // noc_nonposted_writes_num_issued[noc_index] must be updated before calling this function.
-    FORCE_INLINE uint32_t wait_for_availabe_data_and_release_old_pages(uint32_t& cmd_ptr) {
+    // If this function doesn't return sufficient data, there are two options:
+    // 1. Process all the available data and then call this function again.
+    // 2. Call get_cb_page_and_release_pages to attempt to get more data.
+    FORCE_INLINE uint32_t wait_for_available_data_and_release_old_pages(uint32_t& cmd_ptr) {
         if (this->available_space(cmd_ptr) == 0) {
             get_cb_page_and_release_pages(cmd_ptr);
         }

--- a/tt_metal/impl/dispatch/kernels/cq_common.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_common.hpp
@@ -538,6 +538,14 @@ public:
 
         return this->acquire_pages();
     }
+
+    // Returns how much data is available. Will block until data is available.
+    FORCE_INLINE uint32_t wait_for_availabe_data(uint32_t& cmd_ptr) {
+        if (available_space(cmd_ptr) == 0) {
+            get_cb_page(cmd_ptr);
+        }
+        return available_space(cmd_ptr);
+    }
 };
 
 constexpr uint32_t l1_to_local_cache_copy_chunk = 6;

--- a/tt_metal/impl/dispatch/kernels/cq_common.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_common.hpp
@@ -439,19 +439,6 @@ public:
         this->move_rd_to_next_block();
     }
 
-    // Get new CB pages and release old pages to writer. This should only be used when we know there is no data up until
-    // the fence. Returns the number of pages acquired. Updates cmd_ptr on wrap-around.
-    FORCE_INLINE uint32_t get_cb_page_and_release_pages(uint32_t& cmd_ptr) {
-        if (this->cb_fence_ == this->block_next_start_addr_[this->rd_block_idx_]) {
-            if (this->rd_block_idx_ == cb_blocks - 1) {
-                cmd_ptr = cb_base;
-                this->cb_fence_ = cb_base;
-            }
-            move_rd_to_next_block_and_release_pages();
-        }
-        return this->acquire_pages();
-    }
-
     // Returns how much data is available. Will block until data is available. May release old pages before cmd_ptr to writer.
     FORCE_INLINE uint32_t wait_for_availabe_data_and_release_old_pages(uint32_t& cmd_ptr) {
         if (available_space(cmd_ptr) == 0) {
@@ -505,6 +492,19 @@ private:
             released_prev_block_ = true;
         }
         this->block_noc_writes_to_clear_ = noc_nonposted_writes_num_issued[noc_index];
+    }
+
+    // Get new CB pages and release old pages to writer. This should only be used when we know there is no data up until
+    // the fence. Returns the number of pages acquired. Updates cmd_ptr on wrap-around.
+    FORCE_INLINE uint32_t get_cb_page_and_release_pages(uint32_t& cmd_ptr) {
+        if (this->cb_fence_ == this->block_next_start_addr_[this->rd_block_idx_]) {
+            if (this->rd_block_idx_ == cb_blocks - 1) {
+                cmd_ptr = cb_base;
+                this->cb_fence_ = cb_base;
+            }
+            move_rd_to_next_block_and_release_pages();
+        }
+        return this->acquire_pages();
     }
 
     bool released_prev_block_{false};

--- a/tt_metal/impl/dispatch/kernels/cq_common.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_common.hpp
@@ -370,7 +370,7 @@ public:
     }
 
     uint32_t available_space(uint32_t data_ptr) const {
-        return cb_fence__ - data_ptr;
+        return cb_fence_ - data_ptr;
     }
 
 protected:

--- a/tt_metal/impl/dispatch/kernels/cq_common.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_common.hpp
@@ -458,9 +458,10 @@ public:
         return available_space(cmd_ptr);
     }
 
-    // on_boundary is called when we're at the end of a block and need to release the pages and move to the next block.
-    // The first argument is the size of the remaining data in the block. The second argument is whether the next block
-    // is the first block in the circular buffer (in which case cmd_ptr is set to the base address).
+    // Get new CB pages and release old pages to writer. If we move to next block, we call on_boundary to allow the
+    // caller to handle the orphan data that would otherwise be lost.  The first argument to on_boundary is the size of
+    // the remaining data in the block. The second argument is whether the next block is the first block in the circular
+    // buffer (in which case cmd_ptr is set to the base address).
     template <typename OnBoundaryFn>
     FORCE_INLINE uint32_t get_cb_page_and_release_pages(uint32_t& cmd_ptr, OnBoundaryFn&& on_boundary) {
         if (this->cb_fence_ == this->block_next_start_addr_[this->rd_block_idx_]) {

--- a/tt_metal/impl/dispatch/kernels/cq_common.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_common.hpp
@@ -450,7 +450,7 @@ public:
         return this->acquire_pages();
     }
 
-    // Returns how much data is availble. Will block until data is available. May release old pages to writer.
+    // Returns how much data is available. Will block until data is available. May release old pages to writer.
     FORCE_INLINE uint32_t wait_for_availabe_data_and_return_old_pages(uint32_t& cmd_ptr) {
         if (available_space(cmd_ptr) == 0) {
             get_cb_page_and_release_pages(cmd_ptr);

--- a/tt_metal/impl/dispatch/kernels/cq_common.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_common.hpp
@@ -344,9 +344,7 @@ public:
 
     // Return availabe space (in bytes) after data_ptr. This data will always be contiguous in memory and will never
     // wrap around.
-    uint32_t available_bytes(uint32_t data_ptr) const {
-        return cb_fence_ - data_ptr;
-    }
+    uint32_t available_bytes(uint32_t data_ptr) const { return cb_fence_ - data_ptr; }
 
 protected:
     FORCE_INLINE void init() {
@@ -359,7 +357,6 @@ protected:
         this->cb_fence_ = cb_base;
         this->rd_block_idx_ = 0;
     }
-
 
     // Advance the block to the next index, wrapping around if necessary.
     FORCE_INLINE void move_rd_to_next_block() {
@@ -394,7 +391,6 @@ protected:
 
         return usable;
     }
-
 
     // Byte address fence delimiting the end of currently usable data (do not process beyond this address).
     uint32_t cb_fence_{0};
@@ -450,7 +446,7 @@ public:
 
     // Get new CB pages. If getting new pages would require switching the the next block, this will call on_boundary to
     // handle the orphan data that would otherwise be lost and will then release old pages to writer.
-    // 
+    //
     // The argument to on_boundary is whether the next block is the first block in the circular buffer (in which case
     // cmd_ptr is set to the base address after on_boundary is called).  noc_nonposted_writes_num_issued[noc_index] must
     // be updated before on_boundary returns.
@@ -467,7 +463,6 @@ public:
         }
         return this->acquire_pages();
     }
-
 
     FORCE_INLINE void release_all_pages(uint32_t curr_ptr) {
         release_block_pages();

--- a/tt_metal/impl/dispatch/kernels/cq_common.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_common.hpp
@@ -451,9 +451,9 @@ public:
     // Get new CB pages. If getting new pages would require switching the the next block, this will call on_boundary to
     // handle the orphan data that would otherwise be lost and will then release old pages to writer.
     // 
-    // The argument is whether the next block is the first block in the circular buffer (in which case cmd_ptr is set to
-    // the base address after on_boundary is called).  noc_nonposted_writes_num_issued[noc_index] must be updated before
-    // on_boundary returns.
+    // The argument to on_boundary is whether the next block is the first block in the circular buffer (in which case
+    // cmd_ptr is set to the base address after on_boundary is called).  noc_nonposted_writes_num_issued[noc_index] must
+    // be updated before on_boundary returns.
     template <typename OnBoundaryFn>
     FORCE_INLINE uint32_t get_cb_page_and_release_pages(uint32_t& cmd_ptr, OnBoundaryFn&& on_boundary) {
         if (this->cb_fence_ == this->block_next_start_addr_[this->rd_block_idx_]) {

--- a/tt_metal/impl/dispatch/kernels/cq_common.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_common.hpp
@@ -344,7 +344,7 @@ public:
 
     // Return availabe space (in bytes) after data_ptr. This data will always be contiguous in memory and will never
     // wrap around.
-    uint32_t available_space(uint32_t data_ptr) const {
+    uint32_t available_bytes(uint32_t data_ptr) const {
         return cb_fence_ - data_ptr;
     }
 
@@ -435,7 +435,7 @@ public:
     // 1. Process all the available data and then call this function again.
     // 2. Call get_cb_page_and_release_pages to attempt to get more data.
     FORCE_INLINE uint32_t wait_for_available_data_and_release_old_pages(uint32_t& cmd_ptr) {
-        if (this->available_space(cmd_ptr) == 0) {
+        if (this->available_bytes(cmd_ptr) == 0) {
             if (this->cb_fence_ == this->block_next_start_addr_[this->rd_block_idx_]) {
                 if (this->rd_block_idx_ == cb_blocks - 1) {
                     cmd_ptr = cb_base;
@@ -445,7 +445,7 @@ public:
             }
             this->acquire_pages();
         }
-        return this->available_space(cmd_ptr);
+        return this->available_bytes(cmd_ptr);
     }
 
     // Get new CB pages. If getting new pages would require switching the the next block, this will call on_boundary to
@@ -535,11 +535,11 @@ public:
     }
 
     // Returns how much data is available. Will block until data is available.
-    FORCE_INLINE uint32_t wait_for_availabe_data(uint32_t& cmd_ptr) {
-        if (this->available_space(cmd_ptr) == 0) {
+    FORCE_INLINE uint32_t wait_for_available_data(uint32_t& cmd_ptr) {
+        if (this->available_bytes(cmd_ptr) == 0) {
             get_cb_page(cmd_ptr);
         }
-        return this->available_space(cmd_ptr);
+        return this->available_bytes(cmd_ptr);
     }
 
     // Advance cmd_ptr by length. If we wrap around, wrap the fence (should only happen if we hit the end exactly).

--- a/tt_metal/impl/dispatch/kernels/cq_common.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_common.hpp
@@ -410,7 +410,7 @@ private:
     uint32_t local_count_{0};
 };
 
-// Reader that releases a block of pages at a time.
+// Reader that releases a block of pages at a time. At most one block of pages can be available at a time.
 template <
     uint32_t my_sem_id,
     uint32_t cb_log_page_size,

--- a/tt_metal/impl/dispatch/kernels/cq_common.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_common.hpp
@@ -452,7 +452,7 @@ public:
         return this->acquire_pages();
     }
 
-    // Returns how much data is available. Will block until data is available. May release old pages to writer.
+    // Returns how much data is available. Will block until data is available. May release old pages before cmd_ptr to writer.
     FORCE_INLINE uint32_t wait_for_availabe_data_and_release_old_pages(uint32_t& cmd_ptr) {
         if (available_space(cmd_ptr) == 0) {
             get_cb_page_and_release_pages(cmd_ptr);

--- a/tt_metal/impl/dispatch/kernels/cq_common.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_common.hpp
@@ -453,7 +453,7 @@ public:
     }
 
     // Returns how much data is available. Will block until data is available. May release old pages to writer.
-    FORCE_INLINE uint32_t wait_for_availabe_data_and_return_old_pages(uint32_t& cmd_ptr) {
+    FORCE_INLINE uint32_t wait_for_availabe_data_and_release_old_pages(uint32_t& cmd_ptr) {
         if (available_space(cmd_ptr) == 0) {
             get_cb_page_and_release_pages(cmd_ptr);
         }

--- a/tt_metal/impl/dispatch/kernels/cq_common.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_common.hpp
@@ -369,6 +369,8 @@ public:
         WAYPOINT("TAPD");
     }
 
+    // Return availabe space (in bytes) after data_ptr. This data will always be contiguous in memory and will never
+    // wrap around.
     uint32_t available_space(uint32_t data_ptr) const {
         return cb_fence_ - data_ptr;
     }

--- a/tt_metal/impl/dispatch/kernels/cq_common.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_common.hpp
@@ -553,6 +553,9 @@ public:
                 // We hit the nail on the head, wrap the fence
                 ASSERT(length == 0);
                 this->cb_fence_ = cb_base;
+                // TODO eliminate usage of block_next_start_addr_ in this CB reader. rd_block_idx_ will point to the
+                // last block, not the first block, so the limit calculation in acquire_pages will be incorrect. We
+                // don't really use blocks for anything, here, so we should get rid of them and simplify the code.
             }
         }
         cmd_ptr += length;

--- a/tt_metal/impl/dispatch/kernels/cq_common.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_common.hpp
@@ -450,6 +450,14 @@ public:
         return this->acquire_pages();
     }
 
+    // Returns how much data is availble. Will block until data is available. May release old pages to writer.
+    FORCE_INLINE uint32_t wait_for_availabe_data_and_return_old_pages(uint32_t& cmd_ptr) {
+        if (available_space(cmd_ptr) == 0) {
+            get_cb_page_and_release_pages(cmd_ptr);
+        }
+        return available_space(cmd_ptr);
+    }
+
     // on_boundary is called when we're at the end of a block and need to release the pages and move to the next block.
     template <typename OnBoundaryFn>
     FORCE_INLINE uint32_t get_cb_page_and_release_pages(uint32_t& cmd_ptr, OnBoundaryFn&& on_boundary) {

--- a/tt_metal/impl/dispatch/kernels/cq_common.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_common.hpp
@@ -450,7 +450,7 @@ public:
     // Get new CB pages and release old pages to writer. If we move to next block, we call on_boundary to allow the
     // caller to handle the orphan data that would otherwise be lost.  The first argument to on_boundary is the size of
     // the remaining data in the block. The second argument is whether the next block is the first block in the circular
-    // buffer (in which case cmd_ptr is set to the base address).
+    // buffer (in which case cmd_ptr is set to the base address after on_boundary is called).
     template <typename OnBoundaryFn>
     FORCE_INLINE uint32_t get_cb_page_and_release_pages(uint32_t& cmd_ptr, OnBoundaryFn&& on_boundary) {
         if (this->cb_fence_ == this->block_next_start_addr_[this->rd_block_idx_]) {

--- a/tt_metal/impl/dispatch/kernels/cq_common.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_common.hpp
@@ -342,7 +342,7 @@ public:
         WAYPOINT("TAPD");
     }
 
-    // Return availabe space (in bytes) after data_ptr. This data will always be contiguous in memory and will never
+    // Return available space (in bytes) after data_ptr. This data will always be contiguous in memory and will never
     // wrap around.
     uint32_t available_bytes(uint32_t data_ptr) const { return cb_fence_ - data_ptr; }
 

--- a/tt_metal/impl/dispatch/kernels/cq_common.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_common.hpp
@@ -459,6 +459,8 @@ public:
     }
 
     // on_boundary is called when we're at the end of a block and need to release the pages and move to the next block.
+    // The first argument is the size of the remaining data in the block. The second argument is whether the next block
+    // is the first block in the circular buffer (in which case cmd_ptr is set to the base address).
     template <typename OnBoundaryFn>
     FORCE_INLINE uint32_t get_cb_page_and_release_pages(uint32_t& cmd_ptr, OnBoundaryFn&& on_boundary) {
         if (this->cb_fence_ == this->block_next_start_addr_[this->rd_block_idx_]) {

--- a/tt_metal/impl/dispatch/kernels/cq_common.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_common.hpp
@@ -429,6 +429,7 @@ public:
     }
 
     // Returns how much data is available. Will block until data is available. May release old pages before cmd_ptr to writer.
+    // noc_nonposted_writes_num_issued[noc_index] must be updated before calling this function.
     FORCE_INLINE uint32_t wait_for_availabe_data_and_release_old_pages(uint32_t& cmd_ptr) {
         if (this->available_space(cmd_ptr) == 0) {
             get_cb_page_and_release_pages(cmd_ptr);
@@ -440,6 +441,7 @@ public:
     // caller to handle the orphan data that would otherwise be lost.  The first argument to on_boundary is the size of
     // the remaining data in the block. The second argument is whether the next block is the first block in the circular
     // buffer (in which case cmd_ptr is set to the base address after on_boundary is called).
+    // noc_nonposted_writes_num_issued[noc_index] must be updated before on_boundary returns.
     template <typename OnBoundaryFn>
     FORCE_INLINE uint32_t get_cb_page_and_release_pages(uint32_t& cmd_ptr, OnBoundaryFn&& on_boundary) {
         if (this->cb_fence_ == this->block_next_start_addr_[this->rd_block_idx_]) {

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
@@ -1174,8 +1174,8 @@ re_run_command:
             break;
 
         default:
-            DPRINT << "dispatcher_d invalid command:" << cmd_ptr << " " << dispatch_cb_reader.cb_fence << " "
-                   << dispatch_cb_base << " " << dispatch_cb_end << " " << dispatch_cb_reader.rd_block_idx << " "
+            DPRINT << "dispatcher_d invalid command:" << cmd_ptr << " " << dispatch_cb_reader.available_space(cmd_ptr) << " "
+                   << dispatch_cb_base << " " << dispatch_cb_end << " "
                    << "xx" << ENDL();
             DPRINT << HEX() << *(uint32_t*)cmd_ptr << ENDL();
             DPRINT << HEX() << *((uint32_t*)cmd_ptr + 1) << ENDL();
@@ -1216,8 +1216,8 @@ static inline bool process_cmd_h(uint32_t& cmd_ptr) {
             break;
 
         default:
-            DPRINT << "dispatcher_h invalid command:" << cmd_ptr << " " << dispatch_cb_reader.cb_fence << " "
-                   << " " << dispatch_cb_base << " " << dispatch_cb_end << " " << dispatch_cb_reader.rd_block_idx << " "
+            DPRINT << "dispatcher_h invalid command:" << cmd_ptr << " " << dispatch_cb_reader.available_space(cmd_ptr) << " "
+                   << " " << dispatch_cb_base << " " << dispatch_cb_end << " "
                    << "xx" << ENDL();
             DPRINT << HEX() << *(uint32_t*)cmd_ptr << ENDL();
             DPRINT << HEX() << *((uint32_t*)cmd_ptr + 1) << ENDL();

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
@@ -531,8 +531,6 @@ void process_write_paged() {
     //        << " dispatch_cb_page_size: " << dispatch_cb_page_size << ENDL();
 
     while (write_length != 0) {
-        // TODO #7360: Have more performant handling when page_size > dispatch_cb_page_size by not doing multiple writes
-        // for one buffer page
         // Transfer size is min(remaining_length, data_available_in_cb)
         uint32_t available_data = dispatch_cb_reader.wait_for_availabe_data_and_return_old_pages(data_ptr);
         uint32_t remaining_page_size = page_size - dst_addr_offset;

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
@@ -219,7 +219,7 @@ void completion_queue_reserve_back(uint32_t num_pages) {
     uint32_t completion_rd_ptr_and_toggle;
     uint32_t completion_rd_ptr;
     uint32_t completion_rd_toggle;
-    uint32_t available_bytes;
+    uint32_t available_space;
     do {
         invalidate_l1_cache();
         completion_rd_ptr_and_toggle = *get_cq_completion_read_ptr();
@@ -229,11 +229,11 @@ void completion_queue_reserve_back(uint32_t num_pages) {
         // so available space is distance from write ptr to read ptr
         // Toggles are equal means write ptr is ahead of read ptr
         // so available space is total space minus the distance from read to write ptr
-        available_bytes =
+        available_space =
             completion_rd_toggle != cq_write_interface.completion_fifo_wr_toggle
                 ? completion_rd_ptr - cq_write_interface.completion_fifo_wr_ptr
                 : (completion_queue_size_16B - (cq_write_interface.completion_fifo_wr_ptr - completion_rd_ptr));
-    } while (data_size_16B > available_bytes);
+    } while (data_size_16B > available_space);
 
     WAYPOINT("QRBD");
 }

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
@@ -219,7 +219,7 @@ void completion_queue_reserve_back(uint32_t num_pages) {
     uint32_t completion_rd_ptr_and_toggle;
     uint32_t completion_rd_ptr;
     uint32_t completion_rd_toggle;
-    uint32_t available_space;
+    uint32_t available_bytes;
     do {
         invalidate_l1_cache();
         completion_rd_ptr_and_toggle = *get_cq_completion_read_ptr();
@@ -229,11 +229,11 @@ void completion_queue_reserve_back(uint32_t num_pages) {
         // so available space is distance from write ptr to read ptr
         // Toggles are equal means write ptr is ahead of read ptr
         // so available space is total space minus the distance from read to write ptr
-        available_space =
+        available_bytes =
             completion_rd_toggle != cq_write_interface.completion_fifo_wr_toggle
                 ? completion_rd_ptr - cq_write_interface.completion_fifo_wr_ptr
                 : (completion_queue_size_16B - (cq_write_interface.completion_fifo_wr_ptr - completion_rd_ptr));
-    } while (data_size_16B > available_space);
+    } while (data_size_16B > available_bytes);
 
     WAYPOINT("QRBD");
 }
@@ -365,7 +365,7 @@ void relay_to_next_cb(uint32_t data_ptr, uint64_t wlength) {
 
     // First page should be valid since it has the command
     ASSERT(data_ptr <= dispatch_cb_end - dispatch_cb_page_size);
-    ASSERT(dispatch_cb_page_size <= dispatch_cb_reader.available_space(data_ptr));
+    ASSERT(dispatch_cb_page_size <= dispatch_cb_reader.available_bytes(data_ptr));
 
     // regular write, inline writes, and atomic writes use different cmd bufs, so we can init state for each
     // TODO: Add support for stateful atomics. We can preserve state once cb_acquire_pages is changed to a free running
@@ -401,11 +401,11 @@ void relay_to_next_cb(uint32_t data_ptr, uint64_t wlength) {
                 ASSERT(downstream_cb_data_ptr < downstream_cb_end);
             }
             // Get a page if needed
-            if (xfer_size > dispatch_cb_reader.available_space(data_ptr)) {
+            if (xfer_size > dispatch_cb_reader.available_bytes(data_ptr)) {
                 dispatch_cb_reader.get_cb_page_and_release_pages(
                     data_ptr,
                     [&](bool will_wrap) {
-                        uint32_t orphan_size = dispatch_cb_reader.available_space(data_ptr);
+                        uint32_t orphan_size = dispatch_cb_reader.available_bytes(data_ptr);
                         if (orphan_size != 0) {
                             relay_client.write<my_noc_index, true, NCRISC_WR_CMD_BUF>(
                                 data_ptr,
@@ -626,14 +626,14 @@ void process_write_packed(uint32_t flags, uint32_t* l1_cache) {
         sub_cmd_ptr++;
         uint64_t dst = get_noc_addr_helper(dst_noc, dst_addr);
         // Get a page if needed
-        if (xfer_size > dispatch_cb_reader.available_space(data_ptr)) {
+        if (xfer_size > dispatch_cb_reader.available_bytes(data_ptr)) {
             // Check for block completion and issue orphan writes for this block
             // before proceeding to next block
             uint32_t orphan_size = 0;
             dispatch_cb_reader.get_cb_page_and_release_pages(
                 data_ptr,
                 [&](bool will_wrap) {
-                    orphan_size = dispatch_cb_reader.available_space(data_ptr);
+                    orphan_size = dispatch_cb_reader.available_bytes(data_ptr);
                     if (os != 0) {
                         wait_for_barrier();
                         cq_noc_async_write_with_state<CQ_NOC_SNdL>(data_ptr, dst, os, num_dests);
@@ -757,7 +757,7 @@ void process_write_packed_large(uint32_t* l1_cache) {
 
         while (length != 0) {
             // More data needs to be written, but we've exhausted the CB. Acquire more pages.
-            if (dispatch_cb_reader.available_space(data_ptr) == 0) {
+            if (dispatch_cb_reader.available_bytes(data_ptr) == 0) {
                 dispatch_cb_reader.get_cb_page_and_release_pages(
                     data_ptr,
                     [&](bool /*will_wrap*/) {
@@ -768,7 +768,7 @@ void process_write_packed_large(uint32_t* l1_cache) {
                     });
             }
             // Transfer size is min(remaining_length, data_available_in_cb)
-            uint32_t available_data = dispatch_cb_reader.available_space(data_ptr);
+            uint32_t available_data = dispatch_cb_reader.available_bytes(data_ptr);
             uint32_t xfer_size;
             if (length > available_data) {
                 xfer_size = available_data;
@@ -807,7 +807,7 @@ void process_write_packed_large(uint32_t* l1_cache) {
         writes = 0;
 
         // Handle padded size and potential wrap
-        if (pad_size > dispatch_cb_reader.available_space(data_ptr)) {
+        if (pad_size > dispatch_cb_reader.available_bytes(data_ptr)) {
             dispatch_cb_reader.get_cb_page_and_release_pages(
                 data_ptr,
                 [&](bool will_wrap) {
@@ -1162,7 +1162,7 @@ re_run_command:
             break;
 
         default:
-            DPRINT << "dispatcher_d invalid command:" << cmd_ptr << " " << dispatch_cb_reader.available_space(cmd_ptr) << " "
+            DPRINT << "dispatcher_d invalid command:" << cmd_ptr << " " << dispatch_cb_reader.available_bytes(cmd_ptr) << " "
                    << dispatch_cb_base << " " << dispatch_cb_end << " "
                    << "xx" << ENDL();
             DPRINT << HEX() << *(uint32_t*)cmd_ptr << ENDL();
@@ -1204,7 +1204,7 @@ static inline bool process_cmd_h(uint32_t& cmd_ptr) {
             break;
 
         default:
-            DPRINT << "dispatcher_h invalid command:" << cmd_ptr << " " << dispatch_cb_reader.available_space(cmd_ptr) << " "
+            DPRINT << "dispatcher_h invalid command:" << cmd_ptr << " " << dispatch_cb_reader.available_bytes(cmd_ptr) << " "
                    << " " << dispatch_cb_base << " " << dispatch_cb_end << " "
                    << "xx" << ENDL();
             DPRINT << HEX() << *(uint32_t*)cmd_ptr << ENDL();

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
@@ -293,7 +293,7 @@ void process_write_host_h() {
         wlength -= length;
         while (length != 0) {
             // Get a page if needed
-            uint32_t available_data = dispatch_cb_reader.wait_for_availabe_data_and_return_old_pages(data_ptr);
+            uint32_t available_data = dispatch_cb_reader.wait_for_availabe_data_and_release_old_pages(data_ptr);
             uint32_t xfer_size = (length > available_data) ? available_data : length;
             uint32_t npages = (xfer_size + completion_queue_page_size - 1) / completion_queue_page_size;
             completion_queue_reserve_back(npages);
@@ -492,7 +492,7 @@ void process_write_linear(uint32_t num_mcast_dests) {
 
     while (length != 0) {
         // Transfer size is min(remaining_length, data_available_in_cb)
-        uint32_t available_data = dispatch_cb_reader.wait_for_availabe_data_and_return_old_pages(data_ptr);
+        uint32_t available_data = dispatch_cb_reader.wait_for_availabe_data_and_release_old_pages(data_ptr);
         uint32_t xfer_size = length > available_data ? available_data : length;
 
         cq_noc_async_write_with_state_any_len(data_ptr, dst_addr, xfer_size, num_mcast_dests);
@@ -532,7 +532,7 @@ void process_write_paged() {
 
     while (write_length != 0) {
         // Transfer size is min(remaining_length, data_available_in_cb)
-        uint32_t available_data = dispatch_cb_reader.wait_for_availabe_data_and_return_old_pages(data_ptr);
+        uint32_t available_data = dispatch_cb_reader.wait_for_availabe_data_and_release_old_pages(data_ptr);
         uint32_t remaining_page_size = page_size - dst_addr_offset;
         uint32_t xfer_size = remaining_page_size > available_data ? available_data : remaining_page_size;
         // Cap the transfer size to the NOC packet size - use of One Packet NOC API (better performance
@@ -1287,7 +1287,7 @@ void kernel_main() {
     bool done = false;
     uint32_t heartbeat = 0;
     while (!done) {
-        dispatch_cb_reader.wait_for_availabe_data_and_return_old_pages(cmd_ptr);
+        dispatch_cb_reader.wait_for_availabe_data_and_release_old_pages(cmd_ptr);
 
         DeviceZoneScopedN("CQ-DISPATCH");
         IDLE_ERISC_HEARTBEAT_AND_RETURN(heartbeat);

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
@@ -391,6 +391,7 @@ void relay_to_next_cb(uint32_t data_ptr, uint64_t wlength) {
                 xfer_size = length;
                 not_end_of_cmd = false;
             }
+            length -= xfer_size;
 
             if constexpr (preamble_size > 0) {
                 uint32_t flag;
@@ -407,7 +408,6 @@ void relay_to_next_cb(uint32_t data_ptr, uint64_t wlength) {
                     if (orphan_size != 0) {
                         relay_client.write<my_noc_index, true, NCRISC_WR_CMD_BUF>(
                             data_ptr, get_noc_addr_helper(downstream_noc_xy, downstream_cb_data_ptr), orphan_size);
-                        length -= orphan_size;
                         xfer_size -= orphan_size;
                         downstream_cb_data_ptr += orphan_size;
                         if (downstream_cb_data_ptr == downstream_cb_end) {
@@ -428,7 +428,6 @@ void relay_to_next_cb(uint32_t data_ptr, uint64_t wlength) {
                 NCRISC_WR_CMD_BUF>(
                 data_ptr, get_noc_addr_helper(downstream_noc_xy, downstream_cb_data_ptr), xfer_size, 1);
 
-            length -= xfer_size;
             data_ptr += xfer_size;
             downstream_cb_data_ptr += xfer_size;
             if (downstream_cb_data_ptr == downstream_cb_end) {

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
@@ -643,7 +643,10 @@ void process_write_packed(uint32_t flags, uint32_t* l1_cache) {
                 mcasts = 0;
             });
 
-            // This is done here so the common case doesn't have to restore the pointers
+            // Write the remainder of the transfer. All the remaining contents of the transfer is now available, since
+            // the size of a single transfer is at most the CB page size. This write has a different destination address
+            // than the default, so we restore the destination address to the start immediately afterwards to avoid the
+            // overhead in the common case.
             if (orphan_size != 0) {
                 uint32_t remainder_xfer_size = xfer_size - orphan_size;
                 // Creating full NOC addr not needed as we are not programming the noc coords

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
@@ -293,10 +293,10 @@ void process_write_host_h() {
         wlength -= length;
         while (length != 0) {
             // Get a page if needed
-            if (dispatch_cb_reader.cb_fence == data_ptr) {
+            if (dispatch_cb_reader.available_space(data_ptr) == 0) {
                 dispatch_cb_reader.get_cb_page_and_release_pages(data_ptr);
             }
-            uint32_t available_data = dispatch_cb_reader.cb_fence - data_ptr;
+            uint32_t available_data = dispatch_cb_reader.available_space(data_ptr);
             uint32_t xfer_size = (length > available_data) ? available_data : length;
             uint32_t npages = (xfer_size + completion_queue_page_size - 1) / completion_queue_page_size;
             completion_queue_reserve_back(npages);
@@ -404,7 +404,7 @@ void relay_to_next_cb(uint32_t data_ptr, uint64_t wlength) {
                 ASSERT(downstream_cb_data_ptr < downstream_cb_end);
             }
             // Get a page if needed
-            if (data_ptr + xfer_size > dispatch_cb_reader.cb_fence) {
+            if (xfer_size > dispatch_cb_reader.available_space(data_ptr)) {
                 dispatch_cb_reader.get_cb_page_and_release_pages(
                     data_ptr,
                     [&](uint32_t orphan_size, bool will_wrap) {
@@ -495,11 +495,11 @@ void process_write_linear(uint32_t num_mcast_dests) {
 
     while (length != 0) {
         // More data needs to be written, but we've exhausted the CB. Acquire more pages.
-        if (dispatch_cb_reader.cb_fence == data_ptr) {
+        if (dispatch_cb_reader.available_space(data_ptr) == 0) {
             dispatch_cb_reader.get_cb_page_and_release_pages(data_ptr);
         }
         // Transfer size is min(remaining_length, data_available_in_cb)
-        uint32_t available_data = dispatch_cb_reader.cb_fence - data_ptr;
+        uint32_t available_data = dispatch_cb_reader.available_space(data_ptr);
         uint32_t xfer_size = length > available_data ? available_data : length;
 
         cq_noc_async_write_with_state_any_len(data_ptr, dst_addr, xfer_size, num_mcast_dests);
@@ -541,11 +541,11 @@ void process_write_paged() {
         // TODO #7360: Have more performant handling when page_size > dispatch_cb_page_size by not doing multiple writes
         // for one buffer page
         // More data needs to be written, but we've exhausted the CB. Acquire more pages.
-        if (dispatch_cb_reader.cb_fence == data_ptr) {
+        if (dispatch_cb_reader.available_space(data_ptr) == 0) {
             dispatch_cb_reader.get_cb_page_and_release_pages(data_ptr);
         }
         // Transfer size is min(remaining_length, data_available_in_cb)
-        uint32_t available_data = dispatch_cb_reader.cb_fence - data_ptr;
+        uint32_t available_data = dispatch_cb_reader.available_space(data_ptr);
         uint32_t remaining_page_size = page_size - dst_addr_offset;
         uint32_t xfer_size = remaining_page_size > available_data ? available_data : remaining_page_size;
         // Cap the transfer size to the NOC packet size - use of One Packet NOC API (better performance
@@ -638,7 +638,7 @@ void process_write_packed(uint32_t flags, uint32_t* l1_cache) {
         sub_cmd_ptr++;
         uint64_t dst = get_noc_addr_helper(dst_noc, dst_addr);
         // Get a page if needed
-        if (data_ptr + xfer_size > dispatch_cb_reader.cb_fence) {
+        if (xfer_size > dispatch_cb_reader.available_space(data_ptr)) {
             // Check for block completion and issue orphan writes for this block
             // before proceeding to next block
             uint32_t orphan_size = 0;
@@ -769,7 +769,7 @@ void process_write_packed_large(uint32_t* l1_cache) {
 
         while (length != 0) {
             // More data needs to be written, but we've exhausted the CB. Acquire more pages.
-            if (data_ptr == dispatch_cb_reader.cb_fence) {
+            if (dispatch_cb_reader.available_space(data_ptr) == 0) {
                 dispatch_cb_reader.get_cb_page_and_release_pages(
                     data_ptr,
                     [&](uint32_t /*orphan_size*/, bool /*will_wrap*/) {
@@ -780,7 +780,7 @@ void process_write_packed_large(uint32_t* l1_cache) {
                     });
             }
             // Transfer size is min(remaining_length, data_available_in_cb)
-            uint32_t available_data = dispatch_cb_reader.cb_fence - data_ptr;
+            uint32_t available_data = dispatch_cb_reader.available_space(data_ptr);
             uint32_t xfer_size;
             if (length > available_data) {
                 xfer_size = available_data;
@@ -819,7 +819,7 @@ void process_write_packed_large(uint32_t* l1_cache) {
         writes = 0;
 
         // Handle padded size and potential wrap
-        if (data_ptr + pad_size > dispatch_cb_reader.cb_fence) {
+        if (pad_size > dispatch_cb_reader.available_space(data_ptr)) {
             dispatch_cb_reader.get_cb_page_and_release_pages(
                 data_ptr,
                 [&](uint32_t orphan_size, bool will_wrap) {
@@ -1300,7 +1300,7 @@ void kernel_main() {
     bool done = false;
     uint32_t heartbeat = 0;
     while (!done) {
-        if (cmd_ptr == dispatch_cb_reader.cb_fence) {
+        if (dispatch_cb_reader.available_space(cmd_ptr) == 0) {
             dispatch_cb_reader.get_cb_page_and_release_pages(cmd_ptr);
         }
 

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
@@ -491,7 +491,6 @@ void process_write_linear(uint32_t num_mcast_dests) {
     }
 
     while (length != 0) {
-        // More data needs to be written, but we've exhausted the CB. Acquire more pages.
         // Transfer size is min(remaining_length, data_available_in_cb)
         uint32_t available_data = dispatch_cb_reader.wait_for_availabe_data_and_return_old_pages(data_ptr);
         uint32_t xfer_size = length > available_data ? available_data : length;

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
@@ -365,7 +365,7 @@ void relay_to_next_cb(uint32_t data_ptr, uint64_t wlength) {
 
     // First page should be valid since it has the command
     ASSERT(data_ptr <= dispatch_cb_end - dispatch_cb_page_size);
-    ASSERT(data_ptr <= dispatch_cb_reader.cb_fence - dispatch_cb_page_size);
+    ASSERT(dispatch_cb_page_size <= dispatch_cb_reader.available_space(data_ptr));
 
     // regular write, inline writes, and atomic writes use different cmd bufs, so we can init state for each
     // TODO: Add support for stateful atomics. We can preserve state once cb_acquire_pages is changed to a free running

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
@@ -293,7 +293,7 @@ void process_write_host_h() {
         wlength -= length;
         while (length != 0) {
             // Get a page if needed
-            uint32_t available_data = dispatch_cb_reader.wait_for_availabe_data_and_release_old_pages(data_ptr);
+            uint32_t available_data = dispatch_cb_reader.wait_for_available_data_and_release_old_pages(data_ptr);
             uint32_t xfer_size = (length > available_data) ? available_data : length;
             uint32_t npages = (xfer_size + completion_queue_page_size - 1) / completion_queue_page_size;
             completion_queue_reserve_back(npages);
@@ -489,7 +489,7 @@ void process_write_linear(uint32_t num_mcast_dests) {
 
     while (length != 0) {
         // Transfer size is min(remaining_length, data_available_in_cb)
-        uint32_t available_data = dispatch_cb_reader.wait_for_availabe_data_and_release_old_pages(data_ptr);
+        uint32_t available_data = dispatch_cb_reader.wait_for_available_data_and_release_old_pages(data_ptr);
         uint32_t xfer_size = length > available_data ? available_data : length;
 
         cq_noc_async_write_with_state_any_len(data_ptr, dst_addr, xfer_size, num_mcast_dests);
@@ -529,7 +529,7 @@ void process_write_paged() {
 
     while (write_length != 0) {
         // Transfer size is min(remaining_length, data_available_in_cb)
-        uint32_t available_data = dispatch_cb_reader.wait_for_availabe_data_and_release_old_pages(data_ptr);
+        uint32_t available_data = dispatch_cb_reader.wait_for_available_data_and_release_old_pages(data_ptr);
         uint32_t remaining_page_size = page_size - dst_addr_offset;
         uint32_t xfer_size = remaining_page_size > available_data ? available_data : remaining_page_size;
         // Cap the transfer size to the NOC packet size - use of One Packet NOC API (better performance
@@ -1279,7 +1279,7 @@ void kernel_main() {
     bool done = false;
     uint32_t heartbeat = 0;
     while (!done) {
-        dispatch_cb_reader.wait_for_availabe_data_and_release_old_pages(cmd_ptr);
+        dispatch_cb_reader.wait_for_available_data_and_release_old_pages(cmd_ptr);
 
         DeviceZoneScopedN("CQ-DISPATCH");
         IDLE_ERISC_HEARTBEAT_AND_RETURN(heartbeat);

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -1714,24 +1714,13 @@ inline void relay_raw_data_to_downstream(
 
     while (remaining > 0) {
         // Ensure at least one upstream page is available
-        if (data_ptr == h_cmddat_q_reader.cb_fence) {
+        if (h_cmddat_q_reader.available_space(data_ptr) == 0) {
             h_cmddat_q_reader.get_cb_page(data_ptr);
         }
 
-        // Compute contiguous bytes available to read now without wrapping
-        uint32_t contiguous_until_wrap = cmddat_q_end - data_ptr;
-        uint32_t contiguous_until_fence;
-        if (data_ptr < h_cmddat_q_reader.cb_fence) {
-            contiguous_until_fence = h_cmddat_q_reader.cb_fence - data_ptr;
-        } else if (data_ptr > h_cmddat_q_reader.cb_fence) {
-            // Fence wrapped but data_ptr has not; only read until end-of-buffer
-            contiguous_until_fence = contiguous_until_wrap;
-        } else {
-            // Should not happen due to ensure above; treat as no data
-            continue;
-        }
+        uint32_t available_data = h_cmddat_q_reader.availabe_space(data_ptr);
 
-        uint32_t can_read_now = contiguous_until_fence;
+        uint32_t can_read_now = available_data;
         if (can_read_now > remaining) {
             can_read_now = remaining;
         }

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -1714,11 +1714,7 @@ inline void relay_raw_data_to_downstream(
 
     while (remaining > 0) {
         // Ensure at least one upstream page is available
-        if (h_cmddat_q_reader.available_space(data_ptr) == 0) {
-            h_cmddat_q_reader.get_cb_page(data_ptr);
-        }
-
-        uint32_t available_data = h_cmddat_q_reader.availabe_space(data_ptr);
+        uint32_t available_data = h_cmddat_q_reader.wait_for_availabe_data(data_ptr);
 
         uint32_t can_read_now = available_data;
         if (can_read_now > remaining) {
@@ -1772,10 +1768,7 @@ inline uint32_t relay_cb_get_cmds(uint32_t& data_ptr, uint32_t& downstream_data_
     while (true) {
         // DPRINT << "get_commands: " << data_ptr << " " << fence << " " << cmddat_q_base << " " << cmddat_q_end <<
         // ENDL();
-        if (data_ptr == h_cmddat_q_reader.cb_fence) {
-            // Ensure header is present
-            h_cmddat_q_reader.get_cb_page(data_ptr);
-        }
+        h_cmddat_q_reader.wait_for_availabe_data(data_ptr);
 
         volatile tt_l1_ptr CQPrefetchHToPrefetchDHeader* cmd_ptr =
             (volatile tt_l1_ptr CQPrefetchHToPrefetchDHeader*)data_ptr;

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -1715,7 +1715,7 @@ inline void relay_raw_data_to_downstream(
 
     while (remaining > 0) {
         // Ensure at least one upstream page is available
-        uint32_t available_data = h_cmddat_q_reader.wait_for_availabe_data(data_ptr);
+        uint32_t available_data = h_cmddat_q_reader.wait_for_available_data(data_ptr);
 
         uint32_t can_read_now = available_data;
         if (can_read_now > remaining) {
@@ -1769,7 +1769,7 @@ inline uint32_t relay_cb_get_cmds(uint32_t& data_ptr, uint32_t& downstream_data_
     while (true) {
         // DPRINT << "get_commands: " << data_ptr << " " << fence << " " << cmddat_q_base << " " << cmddat_q_end <<
         // ENDL();
-        h_cmddat_q_reader.wait_for_availabe_data(data_ptr);
+        h_cmddat_q_reader.wait_for_available_data(data_ptr);
 
         volatile tt_l1_ptr CQPrefetchHToPrefetchDHeader* cmd_ptr =
             (volatile tt_l1_ptr CQPrefetchHToPrefetchDHeader*)data_ptr;
@@ -1788,7 +1788,7 @@ inline uint32_t relay_cb_get_cmds(uint32_t& data_ptr, uint32_t& downstream_data_
             relay_client.release_pages<my_noc_index, upstream_noc_xy, upstream_cb_sem_id>(pages_to_free);
         } else {
             // Ensure the entire command payload is present before returning
-            uint32_t pages_ready = h_cmddat_q_reader.available_space(data_ptr) >> cmddat_q_log_page_size;
+            uint32_t pages_ready = h_cmddat_q_reader.available_bytes(data_ptr) >> cmddat_q_log_page_size;
             uint32_t pages_needed = (length + cmddat_q_page_size - 1) >> cmddat_q_log_page_size;
             int32_t pages_pending = pages_needed - pages_ready;
             int32_t npages = 0;


### PR DESCRIPTION
### Problem description
The current CBReader API exposes a lot of implementation details and some member variables are public.

### What's changed
Expose a new API. Clients don't need to worry about the CB fence and blocks - they can just see how much data is available and request more if desired.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes