### PR TITLE
GroupNorm: Allow mean/var to be tracked for multiple groups at once

### DIFF
--- a/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
@@ -146,7 +146,7 @@ def test_sdxl_refiner_unet_perf_device():
 
 @pytest.mark.models_device_performance_bare_metal
 def test_sdxl_vae_decode_perf_device():
-    expected_device_perf_cycles_per_iteration = 932_430_106
+    expected_device_perf_cycles_per_iteration = 648_256_413
     command = f"pytest models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_autoencoder_kl.py::test_vae -k 'test_decode'"
     cols = ["DEVICE FW", "DEVICE KERNEL", "DEVICE BRISC KERNEL"]
 
@@ -171,7 +171,7 @@ def test_sdxl_vae_decode_perf_device():
 
 @pytest.mark.models_device_performance_bare_metal
 def test_sdxl_vae_encode_perf_device():
-    expected_device_perf_cycles_per_iteration = 492_473_727
+    expected_device_perf_cycles_per_iteration = 325_723_130
     command = f"pytest models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_autoencoder_kl.py::test_vae -k 'test_encode'"
     cols = ["DEVICE FW", "DEVICE KERNEL", "DEVICE BRISC KERNEL"]
 

--- a/tests/ttnn/unit_tests/operations/fused/test_group_norm.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_group_norm.py
@@ -43,7 +43,7 @@ def manual_group_norm(input_tensor, num_groups, eps=1e-2):
 @pytest.mark.parametrize("C", [320])
 @pytest.mark.parametrize("H", [32])
 @pytest.mark.parametrize("W", [32])
-@pytest.mark.parametrize("num_groups", [32])
+@pytest.mark.parametrize("num_groups", [16])
 @pytest.mark.parametrize("use_welford", welford_flavors, ids=welford_ids)
 def test_group_norm_with_height_sharded(device, N, C, H, W, num_groups, use_welford):
     torch.manual_seed(0)

--- a/tests/ttnn/unit_tests/operations/fused/test_group_norm_DRAM.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_group_norm_DRAM.py
@@ -71,7 +71,7 @@ def test_group_norm_DRAM(device, N, C, H, W, num_groups, num_out_blocks, cores_y
     use_reciprocals = welford_mode == "welford_reciprocal"
 
     # torch input tensor
-    torch_input_tensor = torch.rand((N, C, H, W), dtype=torch.bfloat16)
+    torch_input_tensor = torch.rand(N * C * H * W).reshape((N, C, H, W)).to(torch.bfloat16)
     torch_weight = torch.rand((C,), dtype=torch.bfloat16)
     torch_bias = torch.rand((C,), dtype=torch.bfloat16)
     torch_output_tensor = torch.nn.functional.group_norm(

--- a/tests/ttnn/unit_tests/operations/fused/test_group_norm_DRAM.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_group_norm_DRAM.py
@@ -71,7 +71,7 @@ def test_group_norm_DRAM(device, N, C, H, W, num_groups, num_out_blocks, cores_y
     use_reciprocals = welford_mode == "welford_reciprocal"
 
     # torch input tensor
-    torch_input_tensor = torch.rand(N * C * H * W).reshape((N, C, H, W)).to(torch.bfloat16)
+    torch_input_tensor = torch.rand((N, C, H, W), dtype=torch.bfloat16)
     torch_weight = torch.rand((C,), dtype=torch.bfloat16)
     torch_bias = torch.rand((C,), dtype=torch.bfloat16)
     torch_output_tensor = torch.nn.functional.group_norm(

--- a/tests/ttnn/unit_tests/operations/fused/test_layer_norm.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_layer_norm.py
@@ -37,8 +37,8 @@ def test_layer_norm_with_weight_and_bias(device, h, w, use_welford):
     torch.manual_seed(0)
 
     torch_input_tensor = torch.rand((h, w), dtype=torch.bfloat16)
-    torch_weight = torch.ones((w,), dtype=torch.bfloat16)
-    torch_bias = torch.zeros((w,), dtype=torch.bfloat16)
+    torch_weight = torch.rand((w,), dtype=torch.bfloat16)
+    torch_bias = torch.rand((w,), dtype=torch.bfloat16)
 
     torch_output_tensor = torch.nn.functional.layer_norm(
         torch_input_tensor, normalized_shape=[w], weight=torch_weight, bias=torch_bias

--- a/tests/ttnn/unit_tests/operations/fused/test_layer_norm.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_layer_norm.py
@@ -37,8 +37,8 @@ def test_layer_norm_with_weight_and_bias(device, h, w, use_welford):
     torch.manual_seed(0)
 
     torch_input_tensor = torch.rand((h, w), dtype=torch.bfloat16)
-    torch_weight = torch.rand((w,), dtype=torch.bfloat16)
-    torch_bias = torch.rand((w,), dtype=torch.bfloat16)
+    torch_weight = torch.ones((w,), dtype=torch.bfloat16)
+    torch_bias = torch.zeros((w,), dtype=torch.bfloat16)
 
     torch_output_tensor = torch.nn.functional.layer_norm(
         torch_input_tensor, normalized_shape=[w], weight=torch_weight, bias=torch_bias

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_welfords_sfpu_entry.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_welfords_sfpu_entry.h
@@ -12,29 +12,75 @@ namespace ckernel {
 
 inline void llk_math_welfords_sfpu_init() { _llk_math_welfords_sfpu_init_(); }
 
-template <
-    uint32_t input_dst_index,
-    uint32_t mean_dst_index,
-    uint32_t m2_dst_index,
-    bool reformat_dst_to_col_on_end,
-    bool convert_M2_to_var_on_end,
-    uint32_t reciprocal_size>
-inline void llk_math_welfords_sfpu(
-    uint32_t current_row,
-    uint32_t final_row,
-    uint32_t num_skip_rows,
-    const std::array<uint32_t, reciprocal_size>& reciprocal_lut) {
+inline void llk_math_welfords_sfpu_clear_previous_mean_and_m2() { ckernel::sfpu::_clear_previous_mean_and_m2_(); }
+
+template <uint32_t reciprocal_size>
+inline void llk_math_welfords_sfpu_calculate_welfords_tile_(
+    uint32_t input_dst_idx, uint32_t start_idx, const std::array<uint32_t, reciprocal_size>& reciprocal_lut) {
     _llk_math_welfords_sfpu_params_(
-        ckernel::sfpu::_calculate_welfords_online_<reciprocal_size>,
-        input_dst_index,
-        mean_dst_index,
-        m2_dst_index,
-        current_row,
-        final_row,
-        num_skip_rows,
-        reciprocal_lut,
-        reformat_dst_to_col_on_end,
-        convert_M2_to_var_on_end);
+        ckernel::sfpu::_calculate_welfords_tile_<reciprocal_size>, input_dst_idx, start_idx, reciprocal_lut);
 }
 
+template <uint32_t reciprocal_size>
+inline void llk_math_welfords_sfpu_calculate_welfords_partial_tile_(
+    uint32_t input_dst_idx,
+    uint32_t start_idx,
+    uint32_t start_row,
+    uint32_t num_rows,
+    const std::array<uint32_t, reciprocal_size>& reciprocal_lut) {
+    _llk_math_welfords_sfpu_params_(
+        ckernel::sfpu::_calculate_welfords_partial_tile_<reciprocal_size>,
+        input_dst_idx,
+        start_idx,
+        start_row,
+        num_rows,
+        reciprocal_lut);
+}
+
+inline void llk_math_welfords_sfpu_store_mean_m2_to_dst(uint32_t mean_dst_idx) {
+    _llk_math_welfords_sfpu_params_(ckernel::sfpu::_store_mean_m2_to_dst_, mean_dst_idx);
+}
+
+inline void llk_math_welfords_sfpu_load_mean_m2_from_dst(uint32_t mean_dst_idx) {
+    _llk_math_welfords_sfpu_params_(ckernel::sfpu::_load_mean_m2_from_dst_, mean_dst_idx);
+}
+
+template <std::size_t reciprocal_size>
+inline void llk_math_welfords_sfpu_store_mean_var_to_dst_row(
+    uint32_t mean_dst_idx, uint32_t scale_idx, const std::array<uint32_t, reciprocal_size>& reciprocal_lut) {
+    _llk_math_welfords_sfpu_params_(
+        ckernel::sfpu::_store_mean_var_to_dst_row_<reciprocal_size>, mean_dst_idx, scale_idx, reciprocal_lut);
+}
+
+template <std::size_t reciprocal_size>
+inline void llk_math_welfords_sfpu_store_mean_var_to_dst_raw(
+    uint32_t mean_dst_idx, uint32_t scale_idx, const std::array<uint32_t, reciprocal_size>& reciprocal_lut) {
+    _llk_math_welfords_sfpu_params_(
+        ckernel::sfpu::_store_mean_var_to_dst_raw_<reciprocal_size>, mean_dst_idx, scale_idx, reciprocal_lut);
+}
+
+// ----------------------------------------------------------------------------
+// The below functions are flavors of above 3 to use with group_id argument
+// ----------------------------------------------------------------------------
+inline void llk_math_welfords_sfpu_store_mean_m2_to_dst(uint32_t mean_dst_idx, uint32_t group_id) {
+    _llk_math_welfords_sfpu_params_(ckernel::sfpu::_store_mean_m2_to_dst_group_, mean_dst_idx, group_id);
+}
+
+inline void llk_math_welfords_sfpu_load_mean_m2_from_dst(uint32_t mean_dst_idx, uint32_t group_id) {
+    _llk_math_welfords_sfpu_params_(ckernel::sfpu::_load_mean_m2_from_dst_group_, mean_dst_idx, group_id);
+}
+
+template <std::size_t reciprocal_size>
+inline void llk_math_welfords_sfpu_store_mean_var_to_dst_raw(
+    uint32_t mean_dst_idx,
+    uint32_t group_id,
+    uint32_t scale_idx,
+    const std::array<uint32_t, reciprocal_size>& reciprocal_lut) {
+    _llk_math_welfords_sfpu_params_(
+        ckernel::sfpu::_store_mean_var_to_dst_raw_group_<reciprocal_size>,
+        mean_dst_idx,
+        group_id,
+        scale_idx,
+        reciprocal_lut);
+}
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_welfords_sfpu_entry.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_welfords_sfpu_entry.h
@@ -22,14 +22,14 @@ inline void llk_math_welfords_sfpu_calculate_welfords_tile_(
 }
 
 template <uint32_t reciprocal_size>
-inline void llk_math_welfords_sfpu_calculate_welfords_tile_(
+inline void llk_math_welfords_sfpu_calculate_welfords_partial_tile_(
     uint32_t input_dst_idx,
     uint32_t start_idx,
     uint32_t start_row,
     uint32_t num_rows,
     const std::array<uint32_t, reciprocal_size>& reciprocal_lut) {
     _llk_math_welfords_sfpu_params_(
-        ckernel::sfpu::_calculate_welfords_tile_w_offset_<reciprocal_size>,
+        ckernel::sfpu::_calculate_welfords_partial_tile_w_<reciprocal_size>,
         input_dst_idx,
         start_idx,
         start_row,
@@ -46,10 +46,10 @@ inline void llk_math_welfords_sfpu_load_mean_m2_from_dst(uint32_t mean_dst_idx) 
 }
 
 template <std::size_t reciprocal_size>
-inline void llk_math_welfords_sfpu_store_mean_var_to_dst_col(
+inline void llk_math_welfords_sfpu_store_mean_var_to_dst_row(
     uint32_t mean_dst_idx, uint32_t scale_idx, const std::array<uint32_t, reciprocal_size>& reciprocal_lut) {
     _llk_math_welfords_sfpu_params_(
-        ckernel::sfpu::_store_mean_var_to_dst_col_<reciprocal_size>, mean_dst_idx, scale_idx, reciprocal_lut);
+        ckernel::sfpu::_store_mean_var_to_dst_row_<reciprocal_size>, mean_dst_idx, scale_idx, reciprocal_lut);
 }
 
 template <std::size_t reciprocal_size>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_welfords_sfpu_entry.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_welfords_sfpu_entry.h
@@ -29,7 +29,7 @@ inline void llk_math_welfords_sfpu_calculate_welfords_partial_tile_(
     uint32_t num_rows,
     const std::array<uint32_t, reciprocal_size>& reciprocal_lut) {
     _llk_math_welfords_sfpu_params_(
-        ckernel::sfpu::_calculate_welfords_partial_tile_w_<reciprocal_size>,
+        ckernel::sfpu::_calculate_welfords_partial_tile_<reciprocal_size>,
         input_dst_idx,
         start_idx,
         start_row,

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_welfords_sfpu_entry.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_welfords_sfpu_entry.h
@@ -12,31 +12,59 @@ namespace ckernel {
 
 inline void llk_math_welfords_sfpu_init() { _llk_math_welfords_sfpu_init_(); }
 
-template <
-    uint32_t input_dst_index,
-    uint32_t mean_dst_index,
-    uint32_t m2_dst_index,
-    bool reformat_dst_to_col_on_end,
-    bool convert_M2_to_var_on_end,
-    uint32_t reciprocal_size>
-inline void llk_math_welfords_sfpu(
-    uint32_t current_row,
-    uint32_t final_row,
-    uint32_t num_skip_rows,
-    uint32_t group_id,
-    const std::array<uint32_t, reciprocal_size>& reciprocal_lut) {
+inline void llk_math_welfords_sfpu_clear_previous_mean_and_m2() { ckernel::sfpu::_clear_previous_mean_and_m2_(); }
+
+template <uint32_t reciprocal_size>
+inline void llk_math_welfords_sfpu_calculate_welfords_tile_(
+    uint32_t input_dst_index, uint32_t start_idx, const std::array<uint32_t, reciprocal_size>& reciprocal_lut) {
     _llk_math_welfords_sfpu_params_(
-        ckernel::sfpu::_calculate_welfords_online_<reciprocal_size>,
-        input_dst_index,
-        mean_dst_index,
-        m2_dst_index,
-        current_row,
-        final_row,
-        num_skip_rows,
-        group_id,
-        reciprocal_lut,
-        reformat_dst_to_col_on_end,
-        convert_M2_to_var_on_end);
+        ckernel::sfpu::_calculate_welfords_tile_<reciprocal_size>, input_dst_index, start_idx, reciprocal_lut);
 }
 
+inline void llk_math_welfords_sfpu_store_mean_m2_to_dst(uint32_t mean_dst_index) {
+    _llk_math_welfords_sfpu_params_(ckernel::sfpu::_store_mean_m2_to_dst_, mean_dst_index);
+}
+
+inline void llk_math_welfords_sfpu_load_mean_m2_from_dst(uint32_t mean_dst_index) {
+    _llk_math_welfords_sfpu_params_(ckernel::sfpu::_load_mean_m2_from_dst_, mean_dst_index);
+}
+
+template <std::size_t reciprocal_size>
+inline void llk_math_welfords_sfpu_store_mean_var_to_dst_col(
+    uint32_t mean_dst_index, uint32_t scale_idx, const std::array<uint32_t, reciprocal_size>& reciprocal_lut) {
+    _llk_math_welfords_sfpu_params_(
+        ckernel::sfpu::_store_mean_var_to_dst_col_<reciprocal_size>, mean_dst_index, scale_idx, reciprocal_lut);
+}
+
+template <std::size_t reciprocal_size>
+inline void llk_math_welfords_sfpu_store_mean_var_to_dst_raw(
+    uint32_t mean_dst_index, uint32_t scale_idx, const std::array<uint32_t, reciprocal_size>& reciprocal_lut) {
+    _llk_math_welfords_sfpu_params_(
+        ckernel::sfpu::_store_mean_var_to_dst_raw_<reciprocal_size>, mean_dst_index, scale_idx, reciprocal_lut);
+}
+
+// ----------------------------------------------------------------------------
+// The below functions are flavors of above 3 to use with group_id argument
+// ----------------------------------------------------------------------------
+inline void llk_math_welfords_sfpu_store_mean_m2_to_dst(uint32_t mean_dst_index, uint32_t group_id) {
+    _llk_math_welfords_sfpu_params_(ckernel::sfpu::_store_mean_m2_to_dst_group_, mean_dst_index, group_id);
+}
+
+inline void llk_math_welfords_sfpu_load_mean_m2_from_dst(uint32_t mean_dst_index, uint32_t group_id) {
+    _llk_math_welfords_sfpu_params_(ckernel::sfpu::_load_mean_m2_from_dst_group_, mean_dst_index, group_id);
+}
+
+template <std::size_t reciprocal_size>
+inline void llk_math_welfords_sfpu_store_mean_var_to_dst_raw(
+    uint32_t mean_dst_index,
+    uint32_t group_id,
+    uint32_t scale_idx,
+    const std::array<uint32_t, reciprocal_size>& reciprocal_lut) {
+    _llk_math_welfords_sfpu_params_(
+        ckernel::sfpu::_store_mean_var_to_dst_raw_group_<reciprocal_size>,
+        mean_dst_index,
+        group_id,
+        scale_idx,
+        reciprocal_lut);
+}
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_welfords_sfpu_entry.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_welfords_sfpu_entry.h
@@ -23,6 +23,7 @@ inline void llk_math_welfords_sfpu(
     uint32_t current_row,
     uint32_t final_row,
     uint32_t num_skip_rows,
+    uint32_t group_id,
     const std::array<uint32_t, reciprocal_size>& reciprocal_lut) {
     _llk_math_welfords_sfpu_params_(
         ckernel::sfpu::_calculate_welfords_online_<reciprocal_size>,
@@ -32,6 +33,7 @@ inline void llk_math_welfords_sfpu(
         current_row,
         final_row,
         num_skip_rows,
+        group_id,
         reciprocal_lut,
         reformat_dst_to_col_on_end,
         convert_M2_to_var_on_end);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_welfords_sfpu_entry.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_welfords_sfpu_entry.h
@@ -16,53 +16,69 @@ inline void llk_math_welfords_sfpu_clear_previous_mean_and_m2() { ckernel::sfpu:
 
 template <uint32_t reciprocal_size>
 inline void llk_math_welfords_sfpu_calculate_welfords_tile_(
-    uint32_t input_dst_index, uint32_t start_idx, const std::array<uint32_t, reciprocal_size>& reciprocal_lut) {
+    uint32_t input_dst_idx, uint32_t start_idx, const std::array<uint32_t, reciprocal_size>& reciprocal_lut) {
     _llk_math_welfords_sfpu_params_(
-        ckernel::sfpu::_calculate_welfords_tile_<reciprocal_size>, input_dst_index, start_idx, reciprocal_lut);
+        ckernel::sfpu::_calculate_welfords_tile_<reciprocal_size>, input_dst_idx, start_idx, reciprocal_lut);
 }
 
-inline void llk_math_welfords_sfpu_store_mean_m2_to_dst(uint32_t mean_dst_index) {
-    _llk_math_welfords_sfpu_params_(ckernel::sfpu::_store_mean_m2_to_dst_, mean_dst_index);
+template <uint32_t reciprocal_size>
+inline void llk_math_welfords_sfpu_calculate_welfords_tile_(
+    uint32_t input_dst_idx,
+    uint32_t start_idx,
+    uint32_t start_row,
+    uint32_t num_rows,
+    const std::array<uint32_t, reciprocal_size>& reciprocal_lut) {
+    _llk_math_welfords_sfpu_params_(
+        ckernel::sfpu::_calculate_welfords_tile_w_offset_<reciprocal_size>,
+        input_dst_idx,
+        start_idx,
+        start_row,
+        num_rows,
+        reciprocal_lut);
 }
 
-inline void llk_math_welfords_sfpu_load_mean_m2_from_dst(uint32_t mean_dst_index) {
-    _llk_math_welfords_sfpu_params_(ckernel::sfpu::_load_mean_m2_from_dst_, mean_dst_index);
+inline void llk_math_welfords_sfpu_store_mean_m2_to_dst(uint32_t mean_dst_idx) {
+    _llk_math_welfords_sfpu_params_(ckernel::sfpu::_store_mean_m2_to_dst_, mean_dst_idx);
+}
+
+inline void llk_math_welfords_sfpu_load_mean_m2_from_dst(uint32_t mean_dst_idx) {
+    _llk_math_welfords_sfpu_params_(ckernel::sfpu::_load_mean_m2_from_dst_, mean_dst_idx);
 }
 
 template <std::size_t reciprocal_size>
 inline void llk_math_welfords_sfpu_store_mean_var_to_dst_col(
-    uint32_t mean_dst_index, uint32_t scale_idx, const std::array<uint32_t, reciprocal_size>& reciprocal_lut) {
+    uint32_t mean_dst_idx, uint32_t scale_idx, const std::array<uint32_t, reciprocal_size>& reciprocal_lut) {
     _llk_math_welfords_sfpu_params_(
-        ckernel::sfpu::_store_mean_var_to_dst_col_<reciprocal_size>, mean_dst_index, scale_idx, reciprocal_lut);
+        ckernel::sfpu::_store_mean_var_to_dst_col_<reciprocal_size>, mean_dst_idx, scale_idx, reciprocal_lut);
 }
 
 template <std::size_t reciprocal_size>
 inline void llk_math_welfords_sfpu_store_mean_var_to_dst_raw(
-    uint32_t mean_dst_index, uint32_t scale_idx, const std::array<uint32_t, reciprocal_size>& reciprocal_lut) {
+    uint32_t mean_dst_idx, uint32_t scale_idx, const std::array<uint32_t, reciprocal_size>& reciprocal_lut) {
     _llk_math_welfords_sfpu_params_(
-        ckernel::sfpu::_store_mean_var_to_dst_raw_<reciprocal_size>, mean_dst_index, scale_idx, reciprocal_lut);
+        ckernel::sfpu::_store_mean_var_to_dst_raw_<reciprocal_size>, mean_dst_idx, scale_idx, reciprocal_lut);
 }
 
 // ----------------------------------------------------------------------------
 // The below functions are flavors of above 3 to use with group_id argument
 // ----------------------------------------------------------------------------
-inline void llk_math_welfords_sfpu_store_mean_m2_to_dst(uint32_t mean_dst_index, uint32_t group_id) {
-    _llk_math_welfords_sfpu_params_(ckernel::sfpu::_store_mean_m2_to_dst_group_, mean_dst_index, group_id);
+inline void llk_math_welfords_sfpu_store_mean_m2_to_dst(uint32_t mean_dst_idx, uint32_t group_id) {
+    _llk_math_welfords_sfpu_params_(ckernel::sfpu::_store_mean_m2_to_dst_group_, mean_dst_idx, group_id);
 }
 
-inline void llk_math_welfords_sfpu_load_mean_m2_from_dst(uint32_t mean_dst_index, uint32_t group_id) {
-    _llk_math_welfords_sfpu_params_(ckernel::sfpu::_load_mean_m2_from_dst_group_, mean_dst_index, group_id);
+inline void llk_math_welfords_sfpu_load_mean_m2_from_dst(uint32_t mean_dst_idx, uint32_t group_id) {
+    _llk_math_welfords_sfpu_params_(ckernel::sfpu::_load_mean_m2_from_dst_group_, mean_dst_idx, group_id);
 }
 
 template <std::size_t reciprocal_size>
 inline void llk_math_welfords_sfpu_store_mean_var_to_dst_raw(
-    uint32_t mean_dst_index,
+    uint32_t mean_dst_idx,
     uint32_t group_id,
     uint32_t scale_idx,
     const std::array<uint32_t, reciprocal_size>& reciprocal_lut) {
     _llk_math_welfords_sfpu_params_(
         ckernel::sfpu::_store_mean_var_to_dst_raw_group_<reciprocal_size>,
-        mean_dst_index,
+        mean_dst_idx,
         group_id,
         scale_idx,
         reciprocal_lut);

--- a/tt_metal/include/compute_kernel_api/welford.h
+++ b/tt_metal/include/compute_kernel_api/welford.h
@@ -94,11 +94,11 @@ ALWI void welford_tile(
  *                           be computed using float division.
  *
  * @param scale_factor       The reciprocal of this value (1/scale_factor) is multiplied with the M2 value in the DST
- * register at tile offset 2 to compute the variance.
- * @param group_id           The group that the tile belongs to. The dst regs can hold welford values for a maximum of
- *                           16 groups at a time.
+ *                           register at tile offset 2 to compute the variance.
+ * @param group_id           The group for which the variance is computed. The dst regs can hold welford values for a
+ *                           maximum of 16 groups.
  * @param reciprocal_lut     The reference to the reciprocal lookup table. If an empty array is passed (reciprocal_size
- * is 0), the reciprocal will be computed using float division.
+ *                           is 0), the reciprocal will be computed using float division.
  *
  * @return                   None. The mean and variance tiles are updated in place. TILE_WIDTH (32) number of values
  *                           are written to the DST register.

--- a/tt_metal/include/compute_kernel_api/welford.h
+++ b/tt_metal/include/compute_kernel_api/welford.h
@@ -58,13 +58,14 @@ ALWI void welford_tile(
     MATH((llk_math_welfords_sfpu_calculate_welfords_tile_<reciprocal_size>(input_dst_idx, start_idx, reciprocal_lut)));
 }
 
-/* ----------------------------------------------------------------------------
- *  The below function is a flavor of *welford_tile* to use with row_offset argument. Refer to the
- *  docstring of *welford_tile* for more details.
- *  @param row_offset The offset of the row to start from. Only rows starting from this offset are
- *                    processed in the tile. Should be 0 <= row_offset <= 31. row_offset should be a
- *                    multiple of 4. *num_rows* should be a multiple of 4.
- * -----------------------------------------------------------------------------
+/* -------------------------------------------------------------------------------------------------
+ *  The below function is a flavor of *welford_tile* that processes a subset of rows in the tile.
+ *  Refer to the docstring of *welford_tile* for more details.
+ *  @param start_row The offset of the row to start from. Only rows starting from this offset are
+ *                    processed in the tile. Should be 0 <= start_row <= 31.
+ *  @param num_rows The number of rows to process. Should be 0 <= num_rows <= 32. Also,
+ *                  0 <= start_row + num_rows <= 32.
+ * -------------------------------------------------------------------------------------------------
  */
 template <uint32_t reciprocal_size>
 ALWI void welford_partial_tile(

--- a/tt_metal/include/compute_kernel_api/welford.h
+++ b/tt_metal/include/compute_kernel_api/welford.h
@@ -13,114 +13,152 @@
 
 namespace ckernel {
 /**
- * @brief Performs a Welford's online algorithm update for mean and m2 on a tile in the DST register.
- *
- * This operation computes the running mean and m2 for a stream of data, enabling numerically stable
- * calculation of statistics in a single pass. The DST register buffer must be in acquired state via @ref
- * tile_regs_acquire call. This call is blocking and is only available on the compute engine.
- *
- * @tparam input_dst_index   The index of the tile in DST register buffer containing the new input.
- *                           Must be less than the size of the DST register.
- * @tparam mean_dst_index    The index of the tile in DST register buffer containing the current running mean.
- *                           Must be less than the size of the DST register.
- *                           This tile can be left uninitialized when current_row is 0.
- * @tparam m2_dst_index      M2 is the short hand name for the sum of squares
- *                           The index of the tile in DST register buffer containing the running m2.
- *                           Must be less than the size of the DST register.
- *                           This tile can be left uninitialized when current_row is 0.
- * @tparam reformat_dst_to_col_on_end      When true, the dst reg at tile offset 1 and dst reg at tile offset 2 are
- * converted to column vectors when current_row + (samples processed in this call) == final_row. In addition, it also
- * converts M2 at tile offset 2 to variance.
- * @tparam reciprocal_size   The size of the reciprocal lookup table. If 0, the reciprocal will
- *                           be computed using float division instead.
- *
- * @param current_row     The current row index (starting from 0). Should follow 0 <= current_row <= TILE_HEIGHT (32)
- * and current_row
- *                        <= final_row. When current_row is 0, the previous mean and m2 are ignored.
- * @param final_row       The final row index. This index is not included in the update. Should follow current_row <=
- * final_row.A2D This dictates the total number of rows to update, starting from current_row.
- * @param num_skip_rows   Number of initial rows to skip in the update.
- *                        Setting this to a value greater than 0 skips the first num_skip_rows rows of the update.
- *                        Should follow 0 <= num_skip_rows <= TILE_HEIGHT (32).
- * @param group_id        The group that the tile belongs to. The dst regs can hold welford values for a maximum of
- *                        16 groups at a time.
- * @param reciprocal_lut  The reference to the reciprocal lookup table. If an empty array is passed (reciprocal_size is
- * 0), the reciprocal will be computed using float division.
- *
- * @note All TILE_WIDTH (32) columns of the input tile are processed by this function.
- *
- * @return None. Mean and m2 tiles are updated in place.
- */
-
-template <
-    uint32_t input_dst_index,
-    uint32_t mean_dst_index,
-    uint32_t m2_dst_index,
-    bool reformat_dst_to_col_on_end,
-    uint32_t reciprocal_size>
-ALWI void welford_tile(
-    uint32_t current_row,
-    uint32_t final_row,
-    uint32_t num_skip_rows,
-    uint32_t group_id,
-    const std::array<uint32_t, reciprocal_size>& reciprocal_lut) {
-    MATH((llk_math_welfords_sfpu<
-          input_dst_index,
-          mean_dst_index,
-          m2_dst_index,
-          reformat_dst_to_col_on_end,
-          /*convert_M2_to_var_on_end=*/false,
-          reciprocal_size>(current_row, final_row, num_skip_rows, group_id, reciprocal_lut)));
-}
-
-/**
- * @brief Converts the accumulated M2 (sum of squares of differences from the mean) to variance and packs the final mean
- * and variance tiles into the DST register.
- *
- * This function should be called after all rows of the input tile have been processed by Welford's algorithm.
- * The DST register buffer must be in the acquired state via @ref tile_regs_acquire.
+ * @brief Initializes the Welford's algorithm.
+ * Programs the address mod and replay buffers for the Welford's algorithm.
  * This call is blocking and is only available on the compute engine.
- * The function multiplies the M2 value in the DST register at tile offset 2 by the reciprocal of the scale factor to
- * compute the variance, and stores the result in the same location. Both the mean and variance are packed into the DST
- * register. TILE_WIDTH number of values are written to the first face of the DST register, with each value strided
- * by 2.
- *
- * @tparam mean_dst_index    The index of the tile in DST register buffer containing the means.
- *                           Must be less than the size of the DST register.
- * @tparam m2_dst_index      M2 is the short hand name for the sum of squares.
- *                           The index of the tile in DST register buffer containing the m2s.
- *                           Must be less than the size of the DST register.
- * @tparam reciprocal_size   The size of the reciprocal lookup table. If 0, the reciprocal will
- *                           be computed using float division.
- *
- * @param scale_factor       The reciprocal of this value (1/scale_factor) is multiplied with the M2 value in the DST
- *                           register at tile offset 2 to compute the variance.
- * @param group_id           The group for which the variance is computed. The dst regs can hold welford values for a
- *                           maximum of 16 groups.
- * @param reciprocal_lut     The reference to the reciprocal lookup table. If an empty array is passed (reciprocal_size
- *                           is 0), the reciprocal will be computed using float division.
- *
- * @return                   None. The mean and variance tiles are updated in place. TILE_WIDTH (32) number of values
- *                           are written to the DST register.
- *                           All TILE_WIDTH (32) number of values are written to the first face of the DST register.
- *                           Each valid value is followed by an invalid value.
- */
-template <uint32_t mean_dst_index, uint32_t m2_dst_index, uint32_t reciprocal_size>
-ALWI void welford_M2_to_var(
-    uint32_t scale_factor, uint32_t group_id, const std::array<uint32_t, reciprocal_size>& reciprocal_lut) {
-    MATH((llk_math_welfords_sfpu<
-          /*input_dst_index=*/0,
-          mean_dst_index,
-          m2_dst_index,
-          /*reformat_dst_to_col_on_end=*/false,
-          /*convert_M2_to_var_on_end=*/true,
-          reciprocal_size>(scale_factor, /*final_row=*/0, /*num_skip_rows=*/0, group_id, reciprocal_lut)));
-}
-
-/**
- * Uses a copy of the ternery_sfpu_init
- * Programs the replay for fast LLK. Needed otherwise LLK wont work
  */
 ALWI void welford_init() { MATH((llk_math_welfords_sfpu_init())); }
 
+/**
+ * @brief Clears stale mean and m2 values stored in the registers.
+ * This call is blocking and is only available on the compute engine.
+ * This function should be called before calling `welford_tile` for a new set of values.
+ */
+ALWI void welford_clear_previous_mean_and_m2() { MATH((llk_math_welfords_sfpu_clear_previous_mean_and_m2())); }
+
+/**
+ * @brief Performs a Welford's online algorithm update for mean and m2 on a tile in the DST register
+ *
+ * This operation computes the running mean and m2 for a stream of data, enabling numerically stable
+ * calculation of statistics in a single pass. The DST register buffer must be in acquired state via
+ * @ref tile_regs_acquire call. This call is blocking and is only available on the compute engine.
+ *
+ * @tparam reciprocal_size   The size of the reciprocal lookup table. If 0, the reciprocal will
+ *                           be computed using float division instead.
+ * @param input_dst_index   The index of the tile in DST register buffer containing the new input.
+ *                           Must be less than the size of the DST register. *
+ * @param start_idx       The index of the first element in the tile; used to index the reciprocal
+ *                        lookup table.
+ * @param reciprocal_lut  The reference to the reciprocal lookup table. If an empty array is passed
+ *                        the reciprocal will be computed using float division.
+ *
+ * @note All 32x32 elements (TILE_WIDTH * TILE_HEIGHT = 1024) of the input tile are processed by
+ * this function.
+ *
+ * @return None. The mean and m2 values are held in the registers.
+ */
+
+template <uint32_t reciprocal_size>
+ALWI void welford_tile(
+    uint32_t input_dst_index, uint32_t start_idx, const std::array<uint32_t, reciprocal_size>& reciprocal_lut) {
+    MATH(
+        (llk_math_welfords_sfpu_calculate_welfords_tile_<reciprocal_size>(input_dst_index, start_idx, reciprocal_lut)));
+}
+
+/**
+ * @brief Stores the mean and m2 values to the tile in the dst reg.
+ *
+ * This function stores the mean and m2 values to the tile in the dst reg. It is to be called to
+ * temporarily store the mean and m2 values when using the SFPU for other calculations.
+ * This call should be followed by a call to `welford_load_mean_m2_from_dst` to load the values back
+ * into the SFPU when choosing to continue with the Welford's algorithm with the next set of values.
+ * @param mean_dst_index The index of the tile in the dst reg to store the mean values. The m2
+ * values are stored in the consecutive tile after the mean.
+ * @return None. The mean and m2 values are stored in the tile in the dst reg.
+ */
+ALWI void welford_store_mean_m2_to_dst(uint32_t mean_dst_index) {
+    MATH((llk_math_welfords_sfpu_store_mean_m2_to_dst(mean_dst_index)));
+}
+
+/**
+ * @brief Loads the mean and m2 values from the tile in the dst reg into the SFPU.
+ *
+ * This function loads the mean and m2 values from the tile in the dst reg into the SFPU. It is to
+ * be called after a call to `welford_store_mean_m2_to_dst` to load the values back into the SFPU.
+ * @param mean_dst_index The index of the tile in the dst reg to load the mean values. The m2
+ * values are loaded from the consecutive tile after the mean.
+ * @return None. The mean and m2 values are loaded into the SFPU.
+ */
+ALWI void welford_load_mean_m2_from_dst(uint32_t mean_dst_index) {
+    MATH((llk_math_welfords_sfpu_load_mean_m2_from_dst(mean_dst_index)));
+}
+/**
+ * @brief Converts the accumulated M2 (sum of squares of differences from the mean) to variance and
+ * stores the final mean and variance in the first column of the tiles in the dst reg.
+ *
+ * This function should be called after all elements of the input tile have been processed by
+ * `welford_tile`. It can also be called after a call to `welford_load_mean_m2_from_dst` to load
+ * the mean and m2 values back into the SFPU. The DST register buffer must be in the acquired state
+ * via @ref tile_regs_acquire.
+ * This call is blocking and is only available on the compute engine.
+ * @tparam reciprocal_size   The size of the reciprocal lookup table. If 0, the reciprocal will
+ *                           be computed using float division.
+ *
+ * @param mean_dst_index     The index of the tile in DST register buffer where the mean values will
+ *                           be stored. The variance values are stored in the consecutive tile after
+ *                           the mean. Must be less than the size of the DST register.
+ * @param scale_idx          The index of the scale value to use for the variance calculation. This
+ *                           value is used to convert the M2 to variance.
+ * @param reciprocal_lut     The reference to the reciprocal lookup table. If an empty array is
+ *                           passed (reciprocal_size is 0), the reciprocal will be computed using
+ *                           float division.
+ * @return                   None. The mean and variance tiles are updated in place. The first
+ *                           column of each tile will hold the respective values.
+ */
+template <std::size_t reciprocal_size>
+ALWI void welford_store_mean_var_to_dst_col(
+    uint32_t mean_dst_index, uint32_t scale_idx, const std::array<uint32_t, reciprocal_size>& reciprocal_lut) {
+    MATH(
+        (llk_math_welfords_sfpu_store_mean_var_to_dst_col<reciprocal_size>(mean_dst_index, scale_idx, reciprocal_lut)));
+}
+
+/**
+ * @brief Stores the mean and variance values to the tile in the dst reg in the "raw" format.
+ *
+ * This function stores the mean and variance values to the tile in the dst reg in the "raw" format.
+ * It is to be called to temporarily store the mean and variance values when using the SFPU for
+ * other calculations. This call should be followed by a call to `welford_load_mean_var_from_dst`
+ * to load the values back into the SFPU. The DST register buffer must be in the acquired state via
+ * @ref tile_regs_acquire. This call is blocking and is only available on the compute engine.
+ * @tparam reciprocal_size The size of the reciprocal lookup table. If 0, the reciprocal will
+ *                         be computed using float division.
+ * @param mean_dst_index The index of the tile in the dst reg to store the mean values.
+ *                       The variance values are stored in the consecutive tile after the mean.
+ *                       Must be less than the size of the DST register.
+ * @param scale_idx The index of the scale value to use for the variance calculation. This
+ *                           value is used to convert the M2 to variance.
+ * @param reciprocal_lut The lookup table containing the reciprocals of the sample counts.
+ * @return None. The mean and variance values are stored in the tile in the dst reg in the "raw"
+ *         format. The first four rows of the first face of the tile will hold the values, with a
+ *         stride of 2.
+ */
+template <std::size_t reciprocal_size>
+ALWI void welford_store_mean_var_to_dst_raw(
+    uint32_t mean_dst_index, uint32_t scale_idx, const std::array<uint32_t, reciprocal_size>& reciprocal_lut) {
+    MATH(
+        (llk_math_welfords_sfpu_store_mean_var_to_dst_raw<reciprocal_size>(mean_dst_index, scale_idx, reciprocal_lut)));
+}
+
+// ----------------------------------------------------------------------------
+// The below functions are flavors of above 3 to use with group_id argument
+// Refer to the docstring of the above 3 functions for more details.
+// @param group_id The group id to store the data for.
+// ----------------------------------------------------------------------------
+ALWI void welford_store_mean_m2_to_dst(uint32_t mean_dst_index, uint32_t group_id) {
+    MATH((llk_math_welfords_sfpu_store_mean_m2_to_dst(mean_dst_index, group_id)));
+}
+
+ALWI void welford_load_mean_m2_from_dst(uint32_t mean_dst_index, uint32_t group_id) {
+    MATH((llk_math_welfords_sfpu_load_mean_m2_from_dst(mean_dst_index, group_id)));
+}
+
+template <std::size_t reciprocal_size>
+ALWI void welford_store_mean_var_to_dst_raw(
+    uint32_t mean_dst_index,
+    uint32_t scale_idx,
+    const std::array<uint32_t, reciprocal_size>& reciprocal_lut,
+    uint32_t group_id) {
+    MATH((llk_math_welfords_sfpu_store_mean_var_to_dst_raw<reciprocal_size>(
+        mean_dst_index, scale_idx, reciprocal_lut, group_id)));
+}
 }  // namespace ckernel

--- a/tt_metal/include/compute_kernel_api/welford.h
+++ b/tt_metal/include/compute_kernel_api/welford.h
@@ -160,11 +160,12 @@ ALWI void welford_store_mean_var_to_dst_raw(
     MATH((llk_math_welfords_sfpu_store_mean_var_to_dst_raw<reciprocal_size>(mean_dst_idx, scale_idx, reciprocal_lut)));
 }
 
-// ----------------------------------------------------------------------------
-// The below functions are flavors of above 3 to use with group_id argument
-// Refer to the docstring of the above 3 functions for more details.
-// @param group_id The group id to store the data for.
-// ----------------------------------------------------------------------------
+/* -------------------------------------------------------------------------------------------------
+ * The below functions are flavors of above 3 to use with group_id argument
+ * Refer to the docstring of the above 3 functions for more details.
+ * @param group_id The group id to store the data for.
+ * -------------------------------------------------------------------------------------------------
+ */
 ALWI void welford_store_mean_m2_to_dst(uint32_t mean_dst_idx, uint32_t group_id) {
     MATH((llk_math_welfords_sfpu_store_mean_m2_to_dst(mean_dst_idx, group_id)));
 }

--- a/tt_metal/include/compute_kernel_api/welford.h
+++ b/tt_metal/include/compute_kernel_api/welford.h
@@ -27,9 +27,9 @@ ALWI void welford_init() {
 /**
  * @brief Clears stale mean and m2 values stored in the registers.
  * This call is blocking and is only available on the compute engine.
- * This function should be called before calling `welford_tile` for a new set of values.
+ * This function should be called before calling `welford_update` for a new set of values.
  */
-ALWI void welford_clear_previous_mean_and_m2() { MATH((llk_math_welfords_sfpu_clear_previous_mean_and_m2())); }
+ALWI void welford_clear() { MATH((llk_math_welfords_sfpu_clear_previous_mean_and_m2())); }
 
 /**
  * @brief Performs a Welford's online algorithm update for mean and m2 on a tile in the DST register
@@ -54,7 +54,7 @@ ALWI void welford_clear_previous_mean_and_m2() { MATH((llk_math_welfords_sfpu_cl
  */
 
 template <uint32_t reciprocal_size>
-ALWI void welford_tile(
+ALWI void welford_update(
     uint32_t input_dst_idx, uint32_t start_idx, const std::array<uint32_t, reciprocal_size>& reciprocal_lut) {
     // Check limits on the reciprocal lookup table.
     ASSERT((reciprocal_size == 0) || (start_idx < reciprocal_size));
@@ -63,8 +63,8 @@ ALWI void welford_tile(
 }
 
 /* -------------------------------------------------------------------------------------------------
- *  The below function is a flavor of *welford_tile* that processes a subset of rows in the tile.
- *  Refer to the docstring of *welford_tile* for more details.
+ *  The below function is a flavor of *welford_update* that processes a subset of rows in the tile.
+ *  Refer to the docstring of *welford_update* for more details.
  *  @param start_row The offset of the row to start from. Only rows starting from this offset are
  *                    processed in the tile. Should be 0 <= start_row <= 31.
  *  @param num_rows The number of rows to process. Should be 0 <= num_rows <= 32. Also,
@@ -72,7 +72,7 @@ ALWI void welford_tile(
  * -------------------------------------------------------------------------------------------------
  */
 template <uint32_t reciprocal_size>
-ALWI void welford_partial_tile(
+ALWI void welford_update_rows(
     uint32_t input_dst_idx,
     uint32_t start_idx,
     uint32_t start_row,
@@ -93,13 +93,13 @@ ALWI void welford_partial_tile(
  *
  * This function stores the mean and m2 values to the tile in the dst reg. It is to be called to
  * temporarily store the mean and m2 values when using the SFPU for other calculations.
- * This call should be followed by a call to `welford_load_mean_m2_from_dst` to load the values back
+ * This call should be followed by a call to `welford_restore_state` to load the values back
  * into the SFPU when choosing to continue with the Welford's algorithm with the next set of values.
  * @param mean_dst_idx The index of the tile in the dst reg to store the mean values. The m2
  * values are stored in the consecutive tile after the mean.
  * @return None. The mean and m2 values are stored in the tile in the dst reg.
  */
-ALWI void welford_store_mean_m2_to_dst(uint32_t mean_dst_idx) {
+ALWI void welford_save_state(uint32_t mean_dst_idx) {
     MATH((llk_math_welfords_sfpu_store_mean_m2_to_dst(mean_dst_idx)));
 }
 
@@ -107,12 +107,12 @@ ALWI void welford_store_mean_m2_to_dst(uint32_t mean_dst_idx) {
  * @brief Loads the mean and m2 values from the tile in the dst reg into the SFPU.
  *
  * This function loads the mean and m2 values from the tile in the dst reg into the SFPU. It is to
- * be called after a call to `welford_store_mean_m2_to_dst` to load the values back into the SFPU.
+ * be called after a call to `welford_save_state` to load the values back into the SFPU.
  * @param mean_dst_idx The index of the tile in the dst reg to load the mean values. The m2
  * values are loaded from the consecutive tile after the mean.
  * @return None. The mean and m2 values are loaded into the SFPU.
  */
-ALWI void welford_load_mean_m2_from_dst(uint32_t mean_dst_idx) {
+ALWI void welford_restore_state(uint32_t mean_dst_idx) {
     MATH((llk_math_welfords_sfpu_load_mean_m2_from_dst(mean_dst_idx)));
 }
 /**
@@ -120,7 +120,7 @@ ALWI void welford_load_mean_m2_from_dst(uint32_t mean_dst_idx) {
  * stores the final mean and variance in the first row of the tiles in the dst reg.
  *
  * This function should be called after all elements of the input tile have been processed by
- * `welford_tile`. It can also be called after a call to `welford_load_mean_m2_from_dst` to load
+ * `welford_update`. It can also be called after a call to `welford_restore_state` to load
  * the mean and m2 values back into the SFPU. The DST register buffer must be in the acquired state
  * via @ref tile_regs_acquire.
  * This call is blocking and is only available on the compute engine.
@@ -139,7 +139,7 @@ ALWI void welford_load_mean_m2_from_dst(uint32_t mean_dst_idx) {
  *                         row of each tile will hold the respective values.
  */
 template <std::size_t reciprocal_size>
-ALWI void welford_store_mean_var_to_dst_row(
+ALWI void welford_finalize_to_row(
     uint32_t mean_dst_idx, uint32_t scale_idx, const std::array<uint32_t, reciprocal_size>& reciprocal_lut) {
     // Check limits on the reciprocal lookup table.
     ASSERT((reciprocal_size == 0) || (scale_idx < reciprocal_size));
@@ -155,7 +155,7 @@ ALWI void welford_store_mean_var_to_dst_row(
  * SFPU for other calculations. The DST register buffer must be in the acquired state via
  * @ref tile_regs_acquire. This call is blocking and is only available on the compute engine.
  * In raw format, the mean and variance values are stored in the first four rows of the first face
- * of the tile, with a stride of 2. Use `welford_store_mean_var_to_dst_row` if you need to store the
+ * of the tile, with a stride of 2. Use `welford_finalize_to_row` if you need to store the
  * values in the first row of the tile.
  * @tparam reciprocal_size The size of the reciprocal lookup table. If 0, the reciprocal will
  *                         be computed using float division.
@@ -170,7 +170,7 @@ ALWI void welford_store_mean_var_to_dst_row(
  *         stride of 2.
  */
 template <std::size_t reciprocal_size>
-ALWI void welford_store_mean_var_to_dst_raw(
+ALWI void welford_finalize_to_face(
     uint32_t mean_dst_idx, uint32_t scale_idx, const std::array<uint32_t, reciprocal_size>& reciprocal_lut) {
     // Check limits on the reciprocal lookup table.
     ASSERT((reciprocal_size == 0) || (scale_idx < reciprocal_size));
@@ -184,16 +184,16 @@ ALWI void welford_store_mean_var_to_dst_raw(
  * @param group_id The group id to store the data for.
  * -------------------------------------------------------------------------------------------------
  */
-ALWI void welford_store_mean_m2_to_dst(uint32_t mean_dst_idx, uint32_t group_id) {
+ALWI void welford_save_state(uint32_t mean_dst_idx, uint32_t group_id) {
     MATH((llk_math_welfords_sfpu_store_mean_m2_to_dst(mean_dst_idx, group_id)));
 }
 
-ALWI void welford_load_mean_m2_from_dst(uint32_t mean_dst_idx, uint32_t group_id) {
+ALWI void welford_restore_state(uint32_t mean_dst_idx, uint32_t group_id) {
     MATH((llk_math_welfords_sfpu_load_mean_m2_from_dst(mean_dst_idx, group_id)));
 }
 
 template <std::size_t reciprocal_size>
-ALWI void welford_store_mean_var_to_dst_raw(
+ALWI void welford_finalize_to_face(
     uint32_t mean_dst_idx,
     uint32_t group_id,
     uint32_t scale_idx,

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/welford_groupnorm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/welford_groupnorm.cpp
@@ -24,59 +24,6 @@
 
 namespace NAMESPACE {
 void MAIN {
-    // clang-format off
-    // Definitions
-    //   block_h: This the length of the row we wish to processes in terms of tiles
-    //
-    //   out_block_...: This is the length of our Circular Buffer, sometimes the length of out tensors(block_h) are larger than L1 space, so we
-    //   have to process chunks of this data at a time
-    //   this chunk is called an out_block
-    //
-    //   num_out_blocks: This is the number of chunks specified by the use, such that a CBs (length defined by out_block) fit in L1
-    //   (Users should minimize the number of num_out_blocks for better perf)
-    //
-    //   ...normal:  If num_out_blocks evenly divides block_h, then all chunks are the size normal
-    //
-    //   ...last: If num_out_blocks does not divides block_h, the leftovers are put into a chunk of length last
-    //
-    //   sender: This refers to a core that does aggregation calculations
-    //   for the group of cores
-    //
-    //   receiver: This the cores that receive the aggregated results from sender, they only do
-    //   local computations that they send to the sender for final aggregation
-    //
-    // This is a high level desciption of the stages of this kernel, tags will be added to show where in the code each
-    // stage starts and ends
-    //
-    // Batch Loop:
-    //   Group Loop:
-    //     This is the process which repeats for every group
-    //     Average and Variance Calc: μ[x] and σ^2[x]
-    //       Local Reduce:
-    //           This is where we calculate μ[x] and σ^2[x]
-    //           After summing up, we pass the intermediate results to cb_ex_partial
-    //           The reader kernels then aggregate all of the local scalars into two tiles
-    //       Global Reduce:
-    //           Only the core designated as the sender reduces this tile to produce the global μ[x] and σ^2[x]
-    //           It's reader core the sends this data out to all other cores as cb_ex_global
-    //     cb_ex2pe Calculation:
-    //       First we add variance with cb_eps
-    //       Then we take the sqrt
-    //       Lastly we take the reciprocal and we have the denominator of our calculation
-    //     Final Val Calc:
-    //       First we subtract each value from our core's subtensor by the average value
-    //       We next apply our input mask to zero our the values we wish to ignore
-    //       Next we multiply our residual with our denominator
-    //       Optional Gamma:
-    //           We multiply this value to gamma
-    //       Optional Beta:
-    //           We add beta to this value
-    //
-    // We are now done! Nice
-    //   To look at where the code starts and stops seach for
-    //   Start LABEL or End Label
-    //   Ex: Start Local Reduce or End Local Reduce
-    // clang-format on
     constexpr uint32_t is_mcast_sender = get_named_compile_time_arg_val("is_mcast_sender");
     constexpr uint32_t do_gamma = get_named_compile_time_arg_val("do_gamma");
     constexpr uint32_t do_beta = get_named_compile_time_arg_val("do_beta");
@@ -136,13 +83,13 @@ void MAIN {
     // interm cbs
     constexpr uint32_t cb_repack = tt::CBIndex::c_26;
     constexpr uint32_t cb_repack_out = tt::CBIndex::c_31;
+    constexpr uint32_t cb_x = tt::CBIndex::c_24;
     constexpr uint32_t cb_xmm = tt::CBIndex::c_25;
     constexpr uint32_t cb_ex_partial = tt::CBIndex::c_8;
     constexpr uint32_t cb_ex_global = tt::CBIndex::c_15;
     constexpr uint32_t cb_ex2pe = tt::CBIndex::c_27;
 
     // interm cbs reuse
-    constexpr uint32_t cb_reread_out = tt::CBIndex::c_23;
     constexpr uint32_t cb_reread_write_out = tt::CBIndex::c_22;
 
     // output cb
@@ -154,22 +101,6 @@ void MAIN {
                                     ? (((do_gamma and not do_beta) or (not do_gamma and do_beta)) ? cb_in : cb_out0)
                                     : cb_out0;
 #endif
-    // tile offset
-    uint32_t index_subblock_w_offset = 0;
-    uint32_t index_h_offset = 0;
-    uint32_t index_w_offset = 0;
-    uint32_t index_b_offset = 0;
-    uint32_t index_g_offset = 0;
-    uint32_t row_offset = num_cols_per_group;
-    uint32_t tile_offset;
-    // data offset
-    uint32_t num_datum_per_row_offeset = 0;
-    // inplace out cbs
-    bool copy_or_add = true;
-    uint32_t group_reset_index = 0;
-    uint32_t index_block_w = 0;
-    bool apply_gamma_beta[block_w];
-    constexpr uint32_t data_per_core_N_per_group = (per_core_N * TILE_WIDTH / group);
 
 #ifdef UNTILIZE_OUT
     constexpr int cb_outgamma = cb_in;
@@ -213,9 +144,8 @@ void MAIN {
     binary_op_init_common(cb_in0, cb_in0, cb_in0);
 #endif
 
-    index_b_offset = 0;
     constexpr uint32_t out_block_h_normal = block_h / num_out_blocks;
-    uint32_t out_block_hw_normal = out_block_h_normal * block_w;
+    constexpr uint32_t out_block_hw_normal = out_block_h_normal * block_w;
     uint32_t num_out_blocks_padded = num_out_blocks;
     uint32_t extra_out_block = false;
     uint32_t out_block_h_last = out_block_h_normal;
@@ -242,18 +172,20 @@ void MAIN {
         p_reciprocal = reinterpret_cast<std::array<uint32_t, reciprocal_size>*>(p_cb);
     }
 
-    // Start Batch Loop
+    cb_wait_front(cb_eps, 1);
+    cb_wait_front(cb_input_mask, num_tiles_input_mask);
+
+    if constexpr (do_gamma) {
+        cb_wait_front(cb_gamma, per_core_N);
+    }
+    if constexpr (do_beta) {
+        cb_wait_front(cb_beta, per_core_N);
+    }
+
     for (uint32_t b = 0; b < batch; ++b) {
-        index_g_offset = 0;
+        uint32_t tile_offset = 0;
 
-        row_offset = num_cols_per_group;
-        copy_or_add = true;
-        group_reset_index = 0;
-        index_block_w = 0;
-        tile_offset = 0;
-
-        // Start Group Loop
-        for (uint32_t g = 0; g < group; ++g) {
+        for (uint32_t g = 0; g < num_groups; ++g) {
             // Start Welford's Calculation
             uint32_t curr_xy_coord = 0;
             uint32_t curr_xy_limit = 0;
@@ -279,16 +211,15 @@ void MAIN {
                 // Transpose (from cb_in0) and Welford
                 cb_wait_front(cb_in0, out_block_hw_normal);
 
-                index_h_offset = 0;
+                uint32_t index_h_offset = 0;
 
                 for (uint32_t i = 0; i < out_block_h_actual; ++i) {
                     curr_xy_limit += num_channels_per_group;
-                    index_subblock_w_offset = 0;
+                    uint32_t index_subblock_w_offset = 0;
                     for (uint32_t j = 0; j < num_subblocks_w; ++j) {
                         // Run Welford's algorithm
                         for (uint32_t w = 0; w < subblock_w; ++w) {
                             uint32_t index = w + index_subblock_w_offset + index_h_offset;
-                            uint32_t index_mask = w + index_subblock_w_offset;
 #ifdef TILIZE_IN
                             transpose_wh_init_short(cb_in);
                             transpose_wh_tile(cb_in, index, 0);
@@ -301,7 +232,7 @@ void MAIN {
                             auto this_tile_offset = (j + w) ? 0 : tile_offset;
                             welford_tile<dst0, 1, 2, false, reciprocal_size>(
                                 curr_xy_coord, curr_xy_limit, this_tile_offset, *p_reciprocal);
-                            curr_xy_coord += std::min(32 - this_tile_offset, curr_xy_limit - curr_xy_coord);
+                            curr_xy_coord += std::min(TILE_WIDTH - this_tile_offset, curr_xy_limit - curr_xy_coord);
                         }
                         index_subblock_w_offset += subblock_w;
                     }
@@ -314,7 +245,8 @@ void MAIN {
 #endif
             }
 
-            welford_M2_to_var<1, 2, reciprocal_size>(curr_xy_limit, *p_reciprocal);  // Convert M2 to variance
+            // Convert M2 to variance
+            welford_M2_to_var<1, 2, reciprocal_size>(curr_xy_limit, *p_reciprocal);
 
             // Update for next group
             tile_offset = (tile_offset + num_channels_per_group) % TILE_WIDTH;
@@ -327,16 +259,18 @@ void MAIN {
             cb_push_back(cb_ex_partial, 2);
             // End Local Reduce
             // End Welford's Calculation
+        }
 
-            // Start Variance Calc
-            //  global reduce results
-            cb_wait_front(cb_eps, 1);
-            cb_wait_front(cb_ex_global, 2);
-            cb_reserve_back(cb_ex2pe, 1);
-            // (Var + eps)
+        // Start Variance Calc
+        //  global reduce results
+        cb_wait_front(cb_ex_global, 2 * num_groups);
+        cb_reserve_back(cb_ex2pe, num_groups);
+        // (Var + eps)
+        add_tiles_init(cb_ex_global, cb_eps);
+        reconfig_data_format_srcb(cb_in0, cb_eps);
+        for (uint32_t g = 0; g < num_groups; ++g) {
             tile_regs_acquire();
-            add_tiles_init(cb_ex_global, cb_eps);
-            add_tiles(cb_ex_global, cb_eps, 1, 0, dst0);
+            add_tiles(cb_ex_global, cb_eps, 1 + (g << 1), 0, dst0);
             // 1/[sqrt(Var + eps)]
             rsqrt_tile_init<true>();
             rsqrt_tile<true>(dst0);
@@ -344,296 +278,239 @@ void MAIN {
             tile_regs_wait();
             pack_tile(dst0, cb_ex2pe);
             tile_regs_release();
-            cb_push_back(cb_ex2pe, 1);
-            // End Variance Calc
+        }
+        cb_push_back(cb_ex2pe, num_groups);
+        // End Variance Calc
 
-            bool start_copy_or_add = copy_or_add;
-            uint32_t start_group_reset_index = group_reset_index;
-            uint32_t start_index_block_w = index_block_w;
+        cb_wait_front(cb_ex2pe, num_groups);
 
-            uint32_t out_block_h_offset = 0;
-            // Start Final Val Calc
-            for (uint32_t out_block_index = 0; out_block_index < num_out_blocks_padded; out_block_index++) {
-                uint32_t out_block_h_actual, out_block_hw_actual;
-                if (extra_out_block && (out_block_index == (num_out_blocks_padded - 1))) {
-                    out_block_h_actual = out_block_h_last;
-                    out_block_hw_actual = out_block_hw_last;
-                } else {
-                    out_block_h_actual = out_block_h_normal;
-                    out_block_hw_actual = out_block_hw_normal;
-                }
+        // Start Final Val Calc
+        for (uint32_t out_block_index = 0; out_block_index < num_out_blocks_padded; out_block_index++) {
+            uint32_t out_block_h_actual, out_block_hw_actual;
+            if (extra_out_block && (out_block_index == (num_out_blocks_padded - 1))) {
+                out_block_h_actual = out_block_h_last;
+                out_block_hw_actual = out_block_hw_last;
+            } else {
+                out_block_h_actual = out_block_h_normal;
+                out_block_hw_actual = out_block_hw_normal;
+            }
 
-                cb_wait_front(cb_in0, out_block_hw_normal);
-                // x - E[x]
-                sub_tiles_bcast_scalar_init_short(cb_in0, cb_ex_global);
-                cb_reserve_back(cb_xmm, out_block_hw_normal);
-                for (uint32_t i = 0; i < out_block_h_actual; i++) {
-                    index_subblock_w_offset = 0;
-                    for (uint32_t j = 0; j < num_subblocks_w; j++) {
+            for (uint32_t mt = 0; mt < out_block_h_actual; ++mt) {
+                // This indicates the smallest group that is yet to be processed for this block
+                // As we iterate over nt, some of the groups will be completed, and we will update
+                // this variable
+                uint32_t min_group = 0;
+
+                // This indicates the number of channels left to be processed for the min_group
+                // As we iterate over nt, some of the channels will be completed, and we will
+                // update this variable
+                // It is mainly used when we move from one tile to the next, if there are channels
+                // left to be processed for the min_group, we will process them in the next tile
+                uint32_t channels_left = num_channels_per_group;
+
+                // This tracks the correct index to use for the mask.
+                // For each group, there are block_w number of mask tiles. As we iterate over nt,
+                // we will update this variable to track the correct index to use for the mask.
+                uint32_t block_w_index = 0;
+
+                for (uint32_t nt = 0; nt < per_core_N; ++nt) {
+                    cb_wait_front(cb_in0, 1);
+
+                    uint32_t tile_offset = 0;
+                    for (uint32_t g = min_group; g < num_groups; ++g) {
+                        cb_reserve_back(cb_xmm, 2);
+
+                        // // Now let us do the actual computation for the current group here
+                        // // a. x-u
+                        sub_tiles_bcast_scalar_init_short(cb_in0, cb_ex_global);
+                        reconfig_data_format_srcb(cb_eps, cb_ex_global);
+
                         tile_regs_acquire();
-                        for (uint32_t w = 0; w < subblock_w; w++) {
-                            uint32_t index = w + index_subblock_w_offset;
-                            sub_tiles_bcast_scalar(cb_in0, cb_ex_global, index, 0, w);
-                        }
+                        // UNPACK({tt::compute::common::print_full_tile(cb_in0, 0, true);});
+                        // UNPACK({tt::compute::common::print_full_tile(cb_ex_global, 0 + (g << 1), true);});
+                        sub_tiles_bcast_scalar(cb_in0, cb_ex_global, 0, 0 + (g << 1), dst0);
                         tile_regs_commit();
                         tile_regs_wait();
-                        for (uint32_t i = 0; i < subblock_w; i++) {
-                            pack_tile(i, cb_xmm);
-                        }
+                        pack_tile(dst0, cb_xmm);
                         tile_regs_release();
-                        index_subblock_w_offset += subblock_w;
-                    }
-                    cb_pop_front(cb_in0, block_w);
-                }
-                if (extra_out_block && (out_block_index == (num_out_blocks_padded - 1))) {
-                    cb_pop_front(cb_in0, out_block_hw_normal - out_block_hw_last);
-                }
-                cb_push_back(cb_xmm, out_block_hw_normal);
 
-                // zero out the garbage values by mult mask again
-                cb_wait_front(cb_input_mask, block_w);
-                reconfig_data_format_srcb(cb_ex_global, cb_input_mask);
-                mul_tiles_init(cb_xmm, cb_input_mask);
-                for (uint32_t i = 0; i < out_block_h_actual; i++) {
-                    index_subblock_w_offset = 0;
-                    for (uint32_t j = 0; j < num_subblocks_w; ++j) {
-                        cb_wait_front(cb_xmm, subblock_w);
+                        // // b. 1/[sqrt(Var + eps)] * mask
+                        const uint32_t mask_offset = g * block_w;
+                        const uint32_t mask_index = mask_offset + block_w_index;
+
+                        mul_tiles_bcast_scalar_init_short(cb_input_mask, cb_ex2pe);
+                        reconfig_data_format_srcb(cb_ex_global, cb_ex2pe);
                         tile_regs_acquire();
-                        for (uint32_t w = 0; w < subblock_w; ++w) {
-                            uint32_t index_mask = w + index_subblock_w_offset;
-                            mul_tiles(cb_xmm, cb_input_mask, w, index_mask, w);
-                        }
-                        tile_regs_commit();
-                        cb_pop_front(cb_xmm, subblock_w);
-                        cb_reserve_back(cb_xmm, subblock_w);
-                        tile_regs_wait();
-                        for (uint32_t i = 0; i < subblock_w; ++i) {
-                            pack_tile(i, cb_xmm);
-                        }
-                        tile_regs_release();
-                        cb_push_back(cb_xmm, subblock_w);
-                        index_subblock_w_offset += subblock_w;
-                    }
-                }
-                if (extra_out_block && (out_block_index == (num_out_blocks_padded - 1))) {
-                    cb_pop_front(cb_xmm, out_block_hw_normal - out_block_hw_last);
-                    cb_push_back(cb_xmm, out_block_hw_normal - out_block_hw_last);
-                }
-                reconfig_data_format_srcb(cb_input_mask, cb_xmm);
-
-                // (x - Ex) * 1/[sqrt(Var + eps)]
-                index_h_offset = 0;
-                mul_tiles_bcast_scalar_init_short(cb_xmm, cb_ex2pe);
-                cb_wait_front(cb_ex2pe, 1);
-                for (uint32_t i = 0; i < out_block_h_actual; i++) {
-                    index_subblock_w_offset = 0;
-                    for (uint32_t j = 0; j < num_subblocks_w; j++) {
-                        cb_wait_front(cb_xmm, subblock_w);
-                        tile_regs_acquire();
-                        for (uint32_t w = 0; w < subblock_w; w++) {
-                            mul_tiles_bcast_scalar(cb_xmm, cb_ex2pe, w, 0, w);
-                        }
-                        tile_regs_commit();
-                        cb_pop_front(cb_xmm, subblock_w);
-                        cb_reserve_back(cb_xmm, subblock_w);
-                        tile_regs_wait();
-                        for (uint32_t i = 0; i < subblock_w; i++) {
-                            pack_tile(i, cb_xmm);
-                        }
-                        tile_regs_release();
-                        cb_push_back(cb_xmm, subblock_w);
-                        index_subblock_w_offset += subblock_w;
-                    }
-                    index_h_offset += block_w;
-                }
-                if (extra_out_block && (out_block_index == (num_out_blocks_padded - 1))) {
-                    cb_pop_front(cb_xmm, out_block_hw_normal - out_block_hw_last);
-                    cb_push_back(cb_xmm, out_block_hw_normal - out_block_hw_last);
-                }
-                cb_wait_front(cb_xmm, out_block_hw_normal);
-
-                copy_or_add = start_copy_or_add;
-                group_reset_index = start_group_reset_index;
-                index_block_w = start_index_block_w;
-
-                // add or copy with previous output results
-                uint32_t block_w_curr = index_g_offset == (per_core_N - block_w_last) ? block_w_last : block_w;
-
-                cb_wait_front(cb_reread_out, out_block_hw_normal);
-                cb_reserve_back(cb_reread_write_out, out_block_hw_normal);
-                for (uint32_t w = 0; w < block_w_curr; ++w) {
-                    uint32_t index_h_offset = 0;
-                    uint32_t index_h1_offset = 0;
-
-                    if (copy_or_add == true) {
-                        copy_tile_init(cb_xmm);
-                    } else {
-                        add_tiles_init(cb_reread_out, cb_xmm);
-                    }
-
-                    for (uint32_t i = 0; i < out_block_h_actual; ++i) {
-                        tile_regs_acquire();
-                        uint32_t index_reread_out = w + index_h_offset;
-                        uint32_t index_xmm = w + index_h1_offset;
-
-                        if (copy_or_add == true) {
-                            copy_tile(cb_xmm, index_xmm, dst0);
-                        } else {
-                            add_tiles(cb_reread_out, cb_xmm, index_reread_out, index_xmm, dst0);
-                        }
+                        // UNPACK({tt::compute::common::print_full_tile(cb_input_mask, mask_index, true);});
+                        // UNPACK({tt::compute::common::print_full_tile(cb_ex2pe, g, true);});
+                        mul_tiles_bcast_scalar(cb_input_mask, cb_ex2pe, mask_index, g, dst0);
                         tile_regs_commit();
                         tile_regs_wait();
-                        pack_tile<true>(dst0, cb_reread_write_out, index_reread_out);
+                        pack_tile(dst0, cb_xmm);
                         tile_regs_release();
+                        cb_push_back(cb_xmm, 2);
 
-                        index_h_offset += block_w_curr;
-                        index_h1_offset += block_w;
-                    }
+                        // // c. a * b
+                        cb_wait_front(cb_xmm, 2);
+                        mul_tiles_init(cb_xmm, cb_xmm);
+                        reconfig_data_format_srcb(cb_input_mask, cb_xmm);
+                        tile_regs_acquire();
+                        // UNPACK({tt::compute::common::print_full_tile(cb_xmm, 0, true);});
+                        // UNPACK({tt::compute::common::print_full_tile(cb_xmm, 1, true);});
+                        mul_tiles(cb_xmm, cb_xmm, 0, 1, dst0);
+                        tile_regs_commit();
+                        cb_pop_front(cb_xmm, 2);
+                        cb_reserve_back(cb_xmm, 1);
+                        tile_regs_wait();
+                        pack_tile(dst0, cb_xmm);
+                        tile_regs_release();
+                        cb_push_back(cb_xmm, 1);
 
-                    // update group tile offset
-                    if (index_block_w >= block_w_curr - 1) {
-                        index_block_w = 0;
+                        // // d. Add to cb_xmm (accumulate results)
+                        // // First we get the result in dst0
+                        if (tile_offset == 0) {
+                            // When tile_offset is 0, this is the first group for this tile,
+                            // so we can copy the results to cb_x without needing to add them
+                            copy_tile_init(cb_xmm);
 
-                        if (group_reset_index == num_groups_per_reset - 1) {
-                            copy_or_add = true;
-
-                            group_reset_index = 0;
-                        } else {
-                            copy_or_add = false;
-
-                            group_reset_index += 1;
-                        }
-                    } else {
-                        copy_or_add = true;
-                        index_block_w += 1;
-                    }
-
-                    bool is_past_end_of_group =
-                        (((w + index_g_offset) + 1) * TILE_WIDTH) > ((g + 1) * data_per_core_N_per_group);
-                    apply_gamma_beta[w] = !is_past_end_of_group;
-                }
-                cb_pop_front(cb_xmm, out_block_hw_normal);
-                cb_pop_front(cb_reread_out, out_block_hw_normal);
-                cb_push_back(cb_reread_write_out, out_block_hw_normal);
-
-                // Start Optional Gamma:
-                if constexpr (do_gamma) {
-                    index_h_offset = 0;
-                    cb_reserve_back(cb_outgamma, out_block_hw_normal);
-                    cb_wait_front(cb_gamma, per_core_N);
-                    cb_wait_front(cb_reread_write_out, out_block_hw_normal);
-                    for (uint32_t i = 0; i < out_block_h_actual; ++i) {
-                        for (uint32_t j = 0; j < block_w_curr; ++j) {
-                            if (apply_gamma_beta[j]) {
-                                mul_bcast_rows_init_short(cb_reread_write_out, cb_gamma);
-                            } else {
-                                copy_tile_init(cb_reread_write_out);
-                            }
+                            cb_wait_front(cb_xmm, 1);
                             tile_regs_acquire();
-                            uint32_t index = j + index_h_offset;
-                            uint32_t index_gamma = j + index_g_offset;
-                            if (apply_gamma_beta[j]) {
-                                mul_tiles_bcast_rows(cb_reread_write_out, cb_gamma, index, index_gamma, dst0);
-                            } else {
-                                copy_tile(cb_reread_write_out, index, dst0);
-                            }
+                            // UNPACK({DPRINT << "Copying tiles" << ENDL();});
+                            // UNPACK({tt::compute::common::print_full_tile(cb_xmm, 0, true);});
+                            copy_tile(cb_xmm, 0, dst0);
                             tile_regs_commit();
-                            tile_regs_wait();
-                            pack_tile(dst0, cb_outgamma);
-                            tile_regs_release();
-                        }
-                        index_h_offset += block_w_curr;
-                    }
-                    cb_push_back(cb_outgamma, out_block_hw_normal);
-                    cb_pop_front(cb_reread_write_out, out_block_hw_normal);
-                    cb_wait_front(cb_outgamma, out_block_hw_normal);
-                }
-                // End Optional Gamma
-                //
-                // Start Optional Beta
-                if constexpr (do_beta) {
-                    index_h_offset = 0;
-                    cb_reserve_back(cb_outbeta, out_block_hw_normal);
-                    cb_wait_front(cb_beta, per_core_N);
-                    for (uint32_t i = 0; i < out_block_h_actual; ++i) {
-                        for (uint32_t j = 0; j < block_w_curr; ++j) {
-                            if (apply_gamma_beta[j]) {
-                                add_bcast_rows_init_short(cb_inbeta, cb_beta);
-                            } else {
-                                copy_tile_init(cb_inbeta);
-                            }
+                            cb_pop_front(cb_xmm, 1);
+                        } else {
+                            // This is not the first group for this tile, so we need to add
+                            // the results over what is already in cb_x
+                            add_tiles_init(cb_x, cb_xmm);
+
+                            cb_wait_front(cb_xmm, 1);
+                            cb_wait_front(cb_x, 1);
                             tile_regs_acquire();
-                            uint32_t index = j + index_h_offset;
-                            uint32_t index_beta = j + index_g_offset;
-                            if (apply_gamma_beta[j]) {
-                                add_tiles_bcast_rows(cb_inbeta, cb_beta, index, index_beta, dst0);
-                            } else {
-                                copy_tile(cb_inbeta, index, dst0);
-                            }
+                            // UNPACK({DPRINT << "Adding tiles" << ENDL();});
+                            // UNPACK({tt::compute::common::print_full_tile(cb_x, 0, true);});
+                            // UNPACK({tt::compute::common::print_full_tile(cb_xmm, 0, true);});
+                            add_tiles(cb_x, cb_xmm, 0, 0, dst0);
                             tile_regs_commit();
-                            tile_regs_wait();
-                            pack_tile(dst0, cb_outbeta);
-                            tile_regs_release();
+                            cb_pop_front(cb_xmm, 1);
+                            cb_pop_front(cb_x, 1);
                         }
-                        index_h_offset += block_w_curr;
+
+                        // Then we pack the result into cb_x
+                        cb_reserve_back(cb_x, 1);
+                        tile_regs_wait();
+                        pack_tile(dst0, cb_x);
+                        tile_regs_release();
+                        cb_push_back(cb_x, 1);
+
+                        uint32_t cols_available = TILE_WIDTH - tile_offset;
+                        uint32_t cols_consumed = std::min(cols_available, channels_left);
+                        channels_left -= cols_consumed;
+                        tile_offset += cols_consumed;
+
+                        // There are still channels left to be processed for the current group
+                        // This can only be done in the next tile. So we don't do any more groups
+                        // for this tile.
+                        if (channels_left > 0) {
+                            // For the next tile, we need to use the next mask index
+                            ++block_w_index;
+                            break;
+                        }
+
+                        // Since we know that channels_left is 0, it also means that we have
+                        // processed all the channels for the current group.
+                        // We update the min_group so we never revisit this group again.
+                        ++min_group;
+                        channels_left = num_channels_per_group;
+                        block_w_index = 0;
+
+                        // All available columns have been used for this tile, so we don't do any
+                        // more groups for this tile.
+                        if (tile_offset == TILE_WIDTH) {
+                            break;
+                        }
                     }
-                    cb_push_back(cb_outbeta, out_block_hw_normal);
-                    cb_pop_front(cb_inbeta, out_block_hw_normal);
-                    cb_wait_front(cb_outbeta, out_block_hw_normal);
+                    cb_pop_front(cb_in0, 1);
+
+                    if constexpr (do_gamma) {
+                        mul_bcast_rows_init_short(cb_x, cb_gamma);
+                        reconfig_data_format_srcb(cb_xmm, cb_gamma);
+
+                        cb_wait_front(cb_x, 1);
+                        tile_regs_acquire();
+                        // UNPACK({DPRINT << "gamma tiles" << ENDL();});
+                        // UNPACK({tt::compute::common::print_full_tile(cb_x, 0, true);});
+                        // UNPACK({tt::compute::common::print_full_tile(cb_gamma, nt, true);});
+                        mul_tiles_bcast_rows(cb_x, cb_gamma, 0, nt, dst0);
+                        tile_regs_commit();
+                        cb_pop_front(cb_x, 1);
+                        cb_reserve_back(cb_x, 1);
+                        tile_regs_wait();
+                        pack_tile(dst0, cb_x);
+                        tile_regs_release();
+                        cb_push_back(cb_x, 1);
+                    }
+
+                    if constexpr (do_beta) {
+                        add_bcast_rows_init_short(cb_x, cb_beta);
+                        reconfig_data_format_srcb(cb_gamma, cb_beta);
+
+                        cb_wait_front(cb_x, 1);
+                        tile_regs_acquire();
+                        // UNPACK({DPRINT << "beta tiles" << ENDL();});
+                        // UNPACK({tt::compute::common::print_full_tile(cb_x, 0, true);});
+                        // UNPACK({tt::compute::common::print_full_tile(cb_beta, nt, true);});
+                        add_tiles_bcast_rows(cb_x, cb_beta, 0, nt, dst0);
+                        tile_regs_commit();
+                        cb_pop_front(cb_x, 1);
+                        cb_reserve_back(cb_x, 1);
+                        tile_regs_wait();
+                        pack_tile(dst0, cb_x);
+                        tile_regs_release();
+                        cb_push_back(cb_x, 1);
+                    }
+
+                    // Write out the final output
+                    copy_tile_init(cb_x);
+                    reconfig_data_format_srcb(cb_beta, cb_x);
+
+                    cb_wait_front(cb_x, 1);
+                    tile_regs_acquire();
+                    // UNPACK({DPRINT << "out tiles" << ENDL();});
+                    // UNPACK({tt::compute::common::print_full_tile(cb_x, 0, true);});
+                    copy_tile(cb_x, 0, dst0);
+                    tile_regs_commit();
+                    cb_pop_front(cb_x, 1);
+                    cb_reserve_back(cb_out0, 1);
+                    tile_regs_wait();
+                    pack_tile(dst0, cb_out0);
+                    tile_regs_release();
+                    cb_push_back(cb_out0, 1);
                 }
-                // End Optional Beta
+            }
 
 #ifdef UNTILIZE_OUT
-                // untilize
-                untilize_init(cb_untilize_in);
-                cb_wait_front(cb_untilize_in, per_core_MN);
-                for (uint32_t m = 0; m < per_core_M; ++m) {
-                    cb_reserve_back(cb_untilize_out, per_core_N);
-                    untilize_block(cb_untilize_in, per_core_N, cb_untilize_out);
-                    cb_push_back(cb_untilize_out, per_core_N);
-                    cb_pop_front(cb_untilize_in, per_core_N);
-                }
-                untilize_uninit(cb_untilize_in);
+            // untilize
+            untilize_init(cb_untilize_in);
+            cb_wait_front(cb_untilize_in, per_core_MN);
+            for (uint32_t m = 0; m < per_core_M; ++m) {
+                cb_reserve_back(cb_untilize_out, per_core_N);
+                untilize_block(cb_untilize_in, per_core_N, cb_untilize_out);
+                cb_push_back(cb_untilize_out, per_core_N);
+                cb_pop_front(cb_untilize_in, per_core_N);
+            }
+            untilize_uninit(cb_untilize_in);
 #endif
-            }
-            // End Final Val Calc
-            if constexpr (GROUP_SIZE_IS_POWER_OF_2) {
-                if (row_offset == TILE_WIDTH) {
-                    index_g_offset += block_w;
-                    row_offset = num_cols_per_group;
-
-                } else {
-                    index_g_offset += block_w_minus_one;
-                    row_offset += num_cols_per_group;
-                }
-            } else if constexpr (GROUP_SIZE_SMALLER_THAN_TILE_W) {
-                if (row_offset == TILE_WIDTH) {
-                    index_g_offset += block_w_minus_one;
-                    row_offset = num_cols_per_group;
-
-                } else if (row_offset > TILE_WIDTH) {
-                    index_g_offset += block_w_minus_one;
-                    row_offset = row_offset + group_row_offset;
-
-                } else {
-                    row_offset += num_cols_per_group;
-                }
-            } else {
-                if (row_offset > TILE_WIDTH) {
-                    index_g_offset += block_w_minus_one;
-                    row_offset = row_offset - tile_w_minux_group_size;
-                } else {
-                    row_offset += num_cols_per_group;
-                    index_g_offset += block_w_minus_two;
-                }
-            }
-            cb_pop_front(cb_ex_global, 2);
-            cb_pop_front(cb_ex2pe, 1);
-            cb_pop_front(cb_input_mask, block_w);
         }
-        // End Group Loop
-        index_b_offset += num_tiles_per_batch;
+        // End Final Val Calc
+
+        cb_pop_front(cb_ex_global, 2 * num_groups);
+        cb_pop_front(cb_ex2pe, num_groups);
     }
+
+    cb_pop_front(cb_eps, 1);
+    cb_pop_front(cb_input_mask, num_tiles_input_mask);
 
     // Pop all the cb_beta and cb_gamma if used
     if constexpr (do_beta) {
@@ -642,8 +519,5 @@ void MAIN {
     if constexpr (do_gamma) {
         cb_pop_front(cb_gamma, per_core_N);
     }
-    cb_pop_front(cb_eps, 1);
-
-    // End Batch Loop
 }
 }  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/welford_groupnorm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/welford_groupnorm.cpp
@@ -24,48 +24,29 @@
 
 namespace NAMESPACE {
 void MAIN {
-    constexpr uint32_t is_mcast_sender = get_named_compile_time_arg_val("is_mcast_sender");
     constexpr uint32_t do_gamma = get_named_compile_time_arg_val("do_gamma");
     constexpr uint32_t do_beta = get_named_compile_time_arg_val("do_beta");
     constexpr uint32_t num_cores_per_mcast_group = get_named_compile_time_arg_val("num_cores_per_mcast_group");
 
     constexpr uint32_t batch = get_named_compile_time_arg_val("batch");
-    constexpr uint32_t group = get_named_compile_time_arg_val("group");
+    constexpr uint32_t num_groups = get_named_compile_time_arg_val("group");
 
     constexpr uint32_t block_h = get_named_compile_time_arg_val("block_h");
     constexpr uint32_t block_w = get_named_compile_time_arg_val("block_w");
-    constexpr uint32_t block_hw = get_named_compile_time_arg_val("block_hw");
-
-    constexpr uint32_t subblock_w = get_named_compile_time_arg_val("subblock_w");
-    constexpr uint32_t num_subblocks_w = get_named_compile_time_arg_val("num_subblocks_w");
 
     constexpr uint32_t per_core_M = get_named_compile_time_arg_val("per_core_M");
     constexpr uint32_t per_core_N = get_named_compile_time_arg_val("per_core_N");
     constexpr uint32_t per_core_MN = get_named_compile_time_arg_val("per_core_MN");
 
-    constexpr uint32_t per_core_N_tile_bytes = get_named_compile_time_arg_val("per_core_N_tile_bytes");
-    constexpr uint32_t num_groups_per_reset = get_named_compile_time_arg_val("num_groups_per_reset");
-
     constexpr uint32_t single_tile_size_bytes = get_named_compile_time_arg_val("single_tile_size_bytes");
-    constexpr uint32_t num_tiles_per_batch = get_named_compile_time_arg_val("num_tiles_per_batch");
 
     constexpr uint32_t num_tiles_input_mask = get_named_compile_time_arg_val("num_tiles_input_mask");
-    constexpr uint32_t num_cols_per_group = get_named_compile_time_arg_val("num_cols_per_group");
 
-    constexpr uint32_t block_w_last = get_named_compile_time_arg_val("block_w_last");
-    constexpr uint32_t GROUP_SIZE_IS_POWER_OF_2 = get_named_compile_time_arg_val("GROUP_SIZE_IS_POWER_OF_2");
-    constexpr uint32_t GROUP_SIZE_SMALLER_THAN_TILE_W = get_named_compile_time_arg_val("GROUP_SIZE_SMALLER_THAN_TILE_W");
-    constexpr uint32_t group_row_offset = get_named_compile_time_arg_val("group_row_offset");
     constexpr uint32_t num_out_blocks = get_named_compile_time_arg_val("num_out_blocks");
+
     // These are numbers in absolute terms, on a per group, per batch without tiling
     constexpr uint32_t num_channels_per_group = get_named_compile_time_arg_val("num_channels_per_group");
-    constexpr uint32_t num_rows_per_group = get_named_compile_time_arg_val("num_rows_per_group");
-
     constexpr uint32_t reciprocal_size = get_named_compile_time_arg_val("reciprocal_size");
-
-    constexpr uint32_t block_w_minus_one = block_w - 1;
-    constexpr uint32_t block_w_minus_two = block_w - 2;
-    constexpr uint32_t tile_w_minux_group_size = TILE_WIDTH - num_cols_per_group;
 
     // dst regs
     constexpr uint32_t dst0 = 0;

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/welford_groupnorm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/welford_groupnorm.cpp
@@ -224,7 +224,7 @@ void MAIN {
                         uint32_t cols_consumed = std::min(cols_available, channels_left);
 
                         welford_load_mean_m2_from_dst(mean_dst, g);
-                        welford_tile<reciprocal_size>(
+                        welford_partial_tile<reciprocal_size>(
                             input_dst, curr_xy_coord, group_offset, cols_consumed, *p_reciprocal);
                         welford_store_mean_m2_to_dst(mean_dst, g);
 

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/welford_groupnorm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/welford_groupnorm.cpp
@@ -50,6 +50,9 @@ void MAIN {
 
     // dst regs
     constexpr uint32_t dst0 = 0;
+    constexpr uint32_t input_dst = 0;
+    constexpr uint32_t mean_dst = 1;
+    constexpr uint32_t var_dst = 2;
 
     // input cbs
     constexpr uint32_t cb_in0 = tt::CBIndex::c_0;
@@ -172,6 +175,11 @@ void MAIN {
         uint32_t block_xy_coord = 0;
         uint32_t block_xy_limit = num_channels_per_group;
 
+        // welford_clear_previous_mean_and_m2();
+        // for (uint32_t g = 0; g < num_groups; ++g) {
+        //     welford_store_mean_m2_to_dst(mean_dst, g);
+        // }
+
         for (uint32_t out_block_index = 0; out_block_index < num_out_blocks_padded; out_block_index++) {
             uint32_t out_block_h_actual, out_block_hw_actual;
             if (extra_out_block && (out_block_index == (num_out_blocks_padded - 1))) {
@@ -213,9 +221,9 @@ void MAIN {
                     uint32_t group_offset = 0;
                     for (uint32_t g = min_group; g < num_groups; ++g) {
                         // Start Welford's Calculation
-                        welford_tile<dst0, 1, 2, false, reciprocal_size>(
-                            curr_xy_coord, block_xy_limit, group_offset, g, *p_reciprocal);
-
+                        // welford_load_mean_m2_from_dst(mean_dst, g);
+                        // welford_tile<reciprocal_size>(input_dst, curr_xy_coord, *p_reciprocal);
+                        // welford_store_mean_m2_to_dst(mean_dst, g);
                         uint32_t cols_available = TILE_WIDTH - group_offset;
                         uint32_t cols_consumed = std::min(cols_available, channels_left);
                         channels_left -= cols_consumed;
@@ -251,7 +259,8 @@ void MAIN {
 
         for (uint32_t g = 0; g < num_groups; ++g) {
             // Convert M2 to variance
-            welford_M2_to_var<1, 2, reciprocal_size>(block_xy_coord, g, *p_reciprocal);
+            // welford_load_mean_m2_from_dst(mean_dst, g);
+            // welford_store_mean_var_to_dst_raw(mean_dst, block_xy_coord - 1, *p_reciprocal, g);
         }
 
         tile_regs_commit();

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/welford_groupnorm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/welford_groupnorm.cpp
@@ -52,7 +52,6 @@ void MAIN {
     constexpr uint32_t dst0 = 0;
     constexpr uint32_t input_dst = 0;
     constexpr uint32_t mean_dst = 1;
-    constexpr uint32_t var_dst = 2;
 
     // input cbs
     constexpr uint32_t cb_in0 = tt::CBIndex::c_0;

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/welford_groupnorm_sharded_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/welford_groupnorm_sharded_v2.cpp
@@ -279,7 +279,6 @@ void MAIN {
 #else
                     sub_tiles_bcast_scalar(cb_in0, cb_ex_global, tile_id, 0 + (g << 1), dst0);
 #endif
-                    // dprint_tensix_dest_reg(dst0);
                     tile_regs_commit();
                     tile_regs_wait();
                     pack_tile(dst0, cb_xmm);

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/welford_groupnorm_sharded_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/welford_groupnorm_sharded_v2.cpp
@@ -207,8 +207,7 @@ void MAIN {
                         transpose_wh_init_short(cb_in0);
                         transpose_wh_tile(cb_in0, index, 0);
 #endif
-                        auto num_group_cols_in_tile =
-                            std::min(TILE_WIDTH - this_tile_offset, curr_xy_limit - curr_xy_coord);
+                        auto num_group_cols_in_tile = std::min(TILE_WIDTH - this_tile_offset, channels_per_group);
                         welford_load_mean_m2_from_dst(mean_dst);
                         welford_tile<0>(
                             input_dst, curr_xy_coord, this_tile_offset, num_group_cols_in_tile, empty_reciprocal_lut);

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/welford_groupnorm_sharded_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/welford_groupnorm_sharded_v2.cpp
@@ -10,6 +10,7 @@
 #define BCAST_LLKOP EltwiseBinaryType::ELWMUL
 #define BCAST_DIM BroadcastType::COL
 
+#include "tt-metalium/constants.hpp"
 #include "compute_kernel_api/reduce.h"
 #include "compute_kernel_api/bcast.h"
 #include "compute_kernel_api/eltwise_binary.h"
@@ -25,40 +26,20 @@ namespace NAMESPACE {
 void MAIN {
     constexpr uint32_t do_gamma = get_compile_time_arg_val(1);
     constexpr uint32_t do_beta = get_compile_time_arg_val(2);
-    constexpr uint32_t num_cores_per_mcast_group = get_compile_time_arg_val(3);
 
-    constexpr uint32_t batch = get_compile_time_arg_val(4);
-    constexpr uint32_t group = get_compile_time_arg_val(5);
+    constexpr uint32_t num_batches = get_compile_time_arg_val(4);
+    constexpr uint32_t num_groups = get_compile_time_arg_val(5);
 
-    constexpr uint32_t num_cols_per_group = get_compile_time_arg_val(6);
-
-    volatile uint32_t block_h = get_compile_time_arg_val(7);
+    constexpr uint32_t block_h = get_compile_time_arg_val(7);
     constexpr uint32_t block_w = get_compile_time_arg_val(8);
     constexpr uint32_t block_hw = get_compile_time_arg_val(9);
-
-    constexpr uint32_t subblock_w = get_compile_time_arg_val(10);
-    constexpr uint32_t num_subblocks_w = get_compile_time_arg_val(11);
 
     constexpr uint32_t per_core_M = get_compile_time_arg_val(12);
     constexpr uint32_t per_core_N = get_compile_time_arg_val(13);
     constexpr uint32_t per_core_MN = get_compile_time_arg_val(14);
 
-    constexpr uint32_t per_core_N_tile_bytes = get_compile_time_arg_val(15);
-    constexpr uint32_t num_groups_per_reset = get_compile_time_arg_val(16);
-
-    constexpr uint32_t single_tile_size_bytes = get_compile_time_arg_val(17);
-    constexpr uint32_t num_tiles_per_batch = get_compile_time_arg_val(18);
-
     constexpr uint32_t num_tiles_input_mask = get_compile_time_arg_val(19);
-    constexpr uint32_t block_w_last = get_compile_time_arg_val(20);
-    constexpr uint32_t GROUP_SIZE_IS_POWER_OF_2 = get_compile_time_arg_val(21);
-    constexpr uint32_t GROUP_SIZE_SMALLER_THAN_TILE_W = get_compile_time_arg_val(22);
-    constexpr uint32_t group_row_offset = get_compile_time_arg_val(23);
-    constexpr uint32_t channels_per_group = get_compile_time_arg_val(24);
-
-    constexpr uint32_t block_w_minus_one = block_w - 1;
-    constexpr uint32_t block_w_minus_two = block_w - 2;
-    constexpr uint32_t tile_w_minux_group_size = TILE_WIDTH - num_cols_per_group;
+    constexpr uint32_t num_channels_per_group = get_compile_time_arg_val(24);
 
     // dst regs
     constexpr uint32_t dst0 = 0;
@@ -77,6 +58,7 @@ void MAIN {
     constexpr uint32_t cb_repack = tt::CBIndex::c_11;
     constexpr uint32_t cb_repack_out = tt::CBIndex::c_12;
     constexpr uint32_t cb_x = tt::CBIndex::c_13;
+    constexpr uint32_t cb_xmm = tt::CBIndex::c_2;
     constexpr uint32_t cb_ex_partial = tt::CBIndex::c_8;
     constexpr uint32_t cb_ex_global = tt::CBIndex::c_15;
     constexpr uint32_t cb_ex2pe = tt::CBIndex::c_17;
@@ -84,7 +66,6 @@ void MAIN {
     // output cb
     constexpr uint32_t cb_out0 = tt::CBIndex::c_16;
 #ifdef UNTILIZE_OUT
-    // not used in cases of negative mask
     constexpr uint32_t cb_out = tt::CBIndex::c_30;
 #else
     constexpr uint32_t cb_out = (do_gamma or do_beta)
@@ -92,22 +73,8 @@ void MAIN {
                                     : cb_out0;
 #endif
 
-    // tile offset
-    uint32_t index_subblock_w_offset = 0;
-    uint32_t index_h_offset = 0;
-    uint32_t index_b_offset = 0;
-    uint32_t index_g_offset = 0;
-    uint32_t tile_offset = 0;
-    // inplace out cbs
-    bool copy_or_add = true;
-    uint32_t group_reset_index = 0;
-    uint32_t index_block_w = 0;
-    uint32_t row_offset = num_cols_per_group;
-
 #ifdef UNTILIZE_OUT
-#ifndef FUSE_NEGATIVE_MASK
     constexpr int cb_outgamma = cb_in;
-    constexpr int cb_inbeta = do_gamma ? cb_outgamma : cb_out;
     constexpr int cb_outbeta = do_gamma ? cb_out : cb_in;
     constexpr int cb_untilize_in = (do_gamma and not do_beta) ? cb_outgamma : do_beta ? cb_outbeta : cb_out;
     constexpr int cb_untilize_out =
@@ -117,33 +84,8 @@ void MAIN {
         cb_out0;
 #endif
 #else
-    constexpr int cb_outgamma = cb_in;
-    constexpr int cb_inbeta = cb_in;
-    constexpr int cb_outbeta = cb_in;
-    constexpr int cb_untilize_in = cb_in;
-    constexpr int cb_untilize_out =
-#ifdef READER_REPACK
-        cb_repack_out;
-#else
-        cb_out0;
-#endif
-#endif
-#else
     constexpr int cb_outgamma = do_beta ? cb_in : cb_out0;
-    constexpr int cb_inbeta = do_gamma ? cb_outgamma : cb_out;
     constexpr int cb_outbeta = cb_out0;
-#endif
-
-    // Used in cases of negative mask provided
-    constexpr uint32_t cb_in_negative_mask = tt::CBIndex::c_14;
-
-    // Sharded v2 does not use reciprocal lookup table, so we pass an empty array
-    constexpr std::array<uint32_t, 0> empty_reciprocal_lut{};
-
-#ifdef FUSE_NEGATIVE_MASK
-    constexpr bool use_negative_mask = true;
-#else
-    constexpr bool use_negative_mask = false;
 #endif
 
 // tilize input from RM to tile layout
@@ -168,139 +110,126 @@ void MAIN {
     tilize_uninit(cb_in_rm, cb_in);
     cb_wait_front(cb_in, per_core_MN);
 #else
+    binary_op_init_common(cb_in0, cb_in0, cb_in0);
+#endif
+
+    // Sharded v2 does not use reciprocal lookup table, so we pass an empty array
+    constexpr std::array<uint32_t, 0> empty_reciprocal_lut{};
+
+    cb_wait_front(cb_eps, 1);
+    cb_wait_front(cb_input_mask, num_tiles_input_mask);
+
+    if constexpr (do_gamma) {
+        cb_wait_front(cb_gamma, per_core_N);
+    }
+    if constexpr (do_beta) {
+        cb_wait_front(cb_beta, per_core_N);
+    }
+
+    for (uint32_t b = 0; b < num_batches; ++b) {
+        uint32_t tile_id = b * block_hw;
+        cb_reserve_back(cb_ex_partial, 2);
+        reconfig_data_format_srcb(cb_in0);
+        transpose_wh_init(cb_in0, cb_ex_partial);
+        tile_regs_acquire();
+        welford_init();
+
+        uint32_t block_xy_coord = 0;
+
+        for (uint32_t g = 0; g < num_groups; ++g) {
+            welford_store_mean_m2_to_dst(mean_dst, g);
+        }
+
+        for (uint32_t i = 0; i < block_h; ++i) {
+            // This indicates the smallest group that is yet to be processed for this block
+            // As we iterate over nt, some of the groups will be completed, and we will update
+            // this variable
+            uint32_t min_group = 0;
+
+            // This indicates the number of channels left to be processed for the min_group
+            // As we iterate over nt, some of the channels will be completed, and we will
+            // update this variable
+            // It is mainly used when we move from one tile to the next, if there are channels
+            // left to be processed for the min_group, we will process them in the next tile
+            uint32_t channels_left = num_channels_per_group;
+
+            // This tracks the global index of the first element in a given group in a tile.
+            // It is used by the Welford's algorithm to scale the running mean and m2.
+            // This moves reverse of channels_left, except that it is the global index.
+            uint32_t curr_xy_coord = block_xy_coord;
+
+            for (uint32_t nt = 0; nt < per_core_N; ++nt) {
 #ifdef TILIZE_IN
-    binary_op_init_common(cb_in, cb_ex_global, cb_x);
+                transpose_wh_init_short(cb_in);
+                transpose_wh_tile(cb_in, tile_id, input_dst);
 #else
-    binary_op_init_common(cb_in0, cb_ex_global, cb_x);
+                transpose_wh_init_short(cb_in0);
+                transpose_wh_tile(cb_in0, tile_id, input_dst);
 #endif
-#endif
 
-    index_b_offset = 0;
-    for (uint32_t b = 0; b < batch; ++b) {
-        index_g_offset = 0;
-        tile_offset = 0;
-        for (uint32_t g = 0; g < group; ++g) {
-            uint32_t curr_xy_coord = 0;
-            uint32_t curr_xy_limit = 0;
+                uint32_t group_offset = 0;
+                for (uint32_t g = min_group; g < num_groups; ++g) {
+                    // Start Welford's Calculation
+                    uint32_t cols_available = tt::constants::TILE_WIDTH - group_offset;
+                    uint32_t cols_consumed = std::min(cols_available, channels_left);
 
-            // Compute Welford values and write to cb_ex_partial
-            index_h_offset = index_b_offset + index_g_offset;
-            cb_reserve_back(cb_ex_partial, 2);
-            welford_init();
-            tile_regs_acquire();
-            welford_clear_previous_mean_and_m2();
-            welford_store_mean_m2_to_dst(mean_dst);
+                    welford_load_mean_m2_from_dst(mean_dst, g);
+                    welford_partial_tile<0>(
+                        input_dst, curr_xy_coord, group_offset, cols_consumed, empty_reciprocal_lut);
+                    welford_store_mean_m2_to_dst(mean_dst, g);
 
-            for (uint32_t i = 0; i < block_h; ++i) {
-                curr_xy_limit += channels_per_group;
-                index_subblock_w_offset = 0;
-                for (uint32_t j = 0; j < num_subblocks_w; ++j) {
-                    for (uint32_t w = 0; w < subblock_w; ++w) {
-                        uint32_t index = w + index_subblock_w_offset + index_h_offset;
+                    channels_left -= cols_consumed;
+                    group_offset += cols_consumed;
+                    curr_xy_coord += cols_consumed;
 
-                        // Check if this is the first tile in the row and set tile_offset accordingly
-                        auto this_tile_offset = (j + w) ? 0 : tile_offset;
-#ifdef TILIZE_IN
-                        transpose_wh_init_short(cb_in);
-                        transpose_wh_tile(cb_in, index, 0);
-#else
-                        transpose_wh_init_short(cb_in0);
-                        transpose_wh_tile(cb_in0, index, 0);
-#endif
-                        auto num_group_cols_in_tile = std::min(TILE_WIDTH - this_tile_offset, channels_per_group);
-                        welford_load_mean_m2_from_dst(mean_dst);
-                        welford_tile<0>(
-                            input_dst, curr_xy_coord, this_tile_offset, num_group_cols_in_tile, empty_reciprocal_lut);
-                        welford_store_mean_m2_to_dst(mean_dst);
-                        curr_xy_coord += num_group_cols_in_tile;
+                    // There are still channels left to be processed for the current group
+                    // This can only be done in the next tile. So we don't do any more groups
+                    // for this tile.
+                    if (channels_left > 0) {
+                        break;
                     }
-                    index_subblock_w_offset += subblock_w;
+
+                    // Since we know that channels_left is 0, it also means that we have
+                    // processed all the channels for the current group.
+                    // We update the min_group so we never revisit this group again.
+                    ++min_group;
+                    channels_left = num_channels_per_group;
+                    curr_xy_coord = block_xy_coord;
+
+                    // All available columns have been used for this tile, so we don't do any
+                    // more groups for this tile.
+                    if (group_offset == tt::constants::TILE_WIDTH) {
+                        break;
+                    }
                 }
-                index_h_offset += per_core_N;
+                ++tile_id;
             }
+            block_xy_coord += num_channels_per_group;
+        }
+
+        for (uint32_t g = 0; g < num_groups; ++g) {
             // Convert M2 to variance
-            welford_load_mean_m2_from_dst(mean_dst);
-            welford_store_mean_var_to_dst_raw<0>(mean_dst, curr_xy_limit - 1, empty_reciprocal_lut);
-            // Update for next group
-            tile_offset = (tile_offset + channels_per_group) % TILE_WIDTH;
+            welford_load_mean_m2_from_dst(mean_dst, g);
+            welford_store_mean_var_to_dst_raw<0>(mean_dst, g, block_xy_coord - 1, empty_reciprocal_lut);
+        }
 
-            tile_regs_commit();
-            tile_regs_wait();
-            pack_tile_block(mean_dst, cb_ex_partial, 2);
-            tile_regs_release();
-            cb_push_back(cb_ex_partial, 2);
+        tile_regs_commit();
+        tile_regs_wait();
+        pack_tile_block(mean_dst, cb_ex_partial, 2);
+        tile_regs_release();
+        cb_push_back(cb_ex_partial, 2);
 
-            // x - E[x]
-            reconfig_data_format_srcb(cb_x, cb_ex_global);
-#ifdef TILIZE_IN
-            sub_tiles_bcast_scalar_init_short(cb_in, cb_ex_global);
-#else
-            sub_tiles_bcast_scalar_init_short(cb_in0, cb_ex_global);
-#endif
-            // Wait for final welford values in cb_ex_global
-            cb_wait_front(cb_ex_global, 2);
-            index_h_offset = index_b_offset + index_g_offset;
-            for (uint32_t i = 0; i < block_h; i++) {
-                index_subblock_w_offset = 0;
-                for (uint32_t j = 0; j < num_subblocks_w; j++) {
-                    tile_regs_acquire();
-                    for (uint32_t w = 0; w < subblock_w; w++) {
-                        uint32_t index = w + index_subblock_w_offset + index_h_offset;
-#ifdef TILIZE_IN
-                        sub_tiles_bcast_scalar(cb_in, cb_ex_global, index, 0, w);
-#else
-                        sub_tiles_bcast_scalar(cb_in0, cb_ex_global, index, 0, w);
-#endif
-                    }
-                    tile_regs_commit();
-                    cb_reserve_back(cb_x, subblock_w);
-                    tile_regs_wait();
-                    for (uint32_t k = 0; k < subblock_w; k++) {
-                        pack_tile(k, cb_x);
-                    }
-                    cb_push_back(cb_x, subblock_w);
-                    tile_regs_release();
-                    index_subblock_w_offset += subblock_w;
-                }
-                index_h_offset += per_core_N;
-            }
-
-            // Mask out the garbage values
-            reconfig_data_format_srcb(cb_ex_global, cb_input_mask);
-            mul_tiles_init(cb_x, cb_input_mask);
-            cb_wait_front(cb_input_mask, block_w);
-            for (uint32_t i = 0; i < block_h; i++) {
-                index_subblock_w_offset = 0;
-                for (uint32_t j = 0; j < num_subblocks_w; ++j) {
-                    cb_wait_front(cb_x, subblock_w);
-                    tile_regs_acquire();
-                    for (uint32_t w = 0; w < subblock_w; ++w) {
-                        uint32_t index_mask = w + index_subblock_w_offset;
-                        mul_tiles(cb_x, cb_input_mask, w, index_mask, w);
-                    }
-                    tile_regs_commit();
-
-                    cb_pop_front(cb_x, subblock_w);
-                    cb_reserve_back(cb_x, subblock_w);
-
-                    tile_regs_wait();
-                    for (uint32_t i = 0; i < subblock_w; ++i) {
-                        pack_tile(i, cb_x);
-                    }
-                    cb_push_back(cb_x, subblock_w);
-                    tile_regs_release();
-                    index_subblock_w_offset += subblock_w;
-                }
-            }
-            cb_pop_front(cb_input_mask, block_w);
-            reconfig_data_format_srcb(cb_input_mask, cb_eps);
-
-            // (Var + eps)
-            cb_wait_front(cb_eps, 1);
-            cb_reserve_back(cb_ex2pe, 1);
+        // Start Variance Calc
+        // Wait for final welford values in cb_ex_global
+        cb_wait_front(cb_ex_global, 2 * num_groups);
+        cb_reserve_back(cb_ex2pe, num_groups);
+        // (Var + eps)
+        add_tiles_init(cb_ex_global, cb_eps);
+        reconfig_data_format_srcb(cb_in0, cb_eps);
+        for (uint32_t g = 0; g < num_groups; ++g) {
             tile_regs_acquire();
-            add_tiles_init(cb_ex_global, cb_eps);
-            add_tiles(cb_ex_global, cb_eps, 1, 0, dst0);
+            add_tiles(cb_ex_global, cb_eps, 1 + (g << 1), 0, dst0);
+
             // 1/[sqrt(Var + eps)]
             rsqrt_tile_init<true>();
             rsqrt_tile<true>(dst0);
@@ -308,270 +237,213 @@ void MAIN {
             tile_regs_wait();
             pack_tile(dst0, cb_ex2pe);
             tile_regs_release();
-            cb_push_back(cb_ex2pe, 1);
-            cb_pop_front(cb_ex_global, 2);
+        }
+        cb_push_back(cb_ex2pe, num_groups);
+        // End Variance Calc
 
-            //  (x - Ex) * 1/[sqrt(Var + eps)]
-            mul_tiles_bcast_scalar_init_short(cb_x, cb_ex2pe);
+        cb_wait_front(cb_ex2pe, num_groups);
 
-            cb_wait_front(cb_ex2pe, 1);
-            cb_wait_front(cb_x, block_hw);
+        // Start Final Val Calc
+        tile_id = b * block_hw;
+        for (uint32_t i = 0; i < block_h; ++i) {
+            // This indicates the smallest group that is yet to be processed for this block
+            // As we iterate over nt, some of the groups will be completed, and we will update
+            // this variable
+            uint32_t min_group = 0;
 
-            for (uint32_t i = 0; i < block_h; i++) {
-                index_subblock_w_offset = 0;
-                for (uint32_t j = 0; j < num_subblocks_w; j++) {
+            // This indicates the number of channels left to be processed for the min_group
+            // As we iterate over nt, some of the channels will be completed, and we will
+            // update this variable
+            // It is mainly used when we move from one tile to the next, if there are channels
+            // left to be processed for the min_group, we will process them in the next tile
+            uint32_t channels_left = num_channels_per_group;
+
+            // This tracks the correct index to use for the mask.
+            // For each group, there are block_w number of mask tiles. As we iterate over nt,
+            // we will update this variable to track the correct index to use for the mask.
+            uint32_t block_w_index = 0;
+
+            for (uint32_t nt = 0; nt < per_core_N; ++nt) {
+                uint32_t group_offset = 0;
+                for (uint32_t g = min_group; g < num_groups; ++g) {
+                    cb_reserve_back(cb_xmm, 2);
+
+                    // // Now let us do the actual computation for the current group here
+                    // // a. x-u
+                    sub_tiles_bcast_scalar_init_short(cb_in0, cb_ex_global);
+                    reconfig_data_format_srcb(cb_eps, cb_ex_global);
+
                     tile_regs_acquire();
-                    for (uint32_t w = 0; w < subblock_w; w++) {
-                        uint32_t index = w + index_subblock_w_offset;
-                        mul_tiles_bcast_scalar(cb_x, cb_ex2pe, index, 0, w);
-                    }
+#ifdef TILIZE_IN
+                    sub_tiles_bcast_scalar(cb_in, cb_ex_global, tile_id, 0 + (g << 1), dst0);
+#else
+                    sub_tiles_bcast_scalar(cb_in0, cb_ex_global, tile_id, 0 + (g << 1), dst0);
+#endif
+                    // dprint_tensix_dest_reg(dst0);
                     tile_regs_commit();
-                    cb_pop_front(cb_x, subblock_w);
-                    cb_reserve_back(cb_x, subblock_w);
                     tile_regs_wait();
-                    for (uint32_t i = 0; i < subblock_w; i++) {
-                        pack_tile(i, cb_x);
-                    }
-                    cb_push_back(cb_x, subblock_w);
+                    pack_tile(dst0, cb_xmm);
                     tile_regs_release();
-                }
-            }
-            cb_pop_front(cb_ex2pe, 1);
-            cb_wait_front(cb_x, block_hw);
-            //  add or copy with previous output results
-            uint32_t block_w_curr = index_g_offset == (per_core_N - block_w_last) ? block_w_last : block_w;
 
-            // if we are using negative mask, we are overlapping tilized in and out, otherwise they are 2 separate
-            // buffers.
-            if constexpr (use_negative_mask == false) {
-                for (uint32_t w = 0; w < block_w_curr; ++w) {
-                    index_h_offset = index_b_offset + index_g_offset;
-                    uint32_t index_h1_offset = 0;
+                    // // b. 1/[sqrt(Var + eps)] * mask
+                    const uint32_t mask_offset = g * block_w;
+                    const uint32_t mask_index = mask_offset + block_w_index;
 
-                    if (copy_or_add == true) {
-                        copy_tile_init(cb_x);
+                    mul_tiles_bcast_scalar_init_short(cb_input_mask, cb_ex2pe);
+                    reconfig_data_format_srca(cb_input_mask);
+                    reconfig_data_format_srcb(cb_ex_global, cb_ex2pe);
+                    tile_regs_acquire();
+                    mul_tiles_bcast_scalar(cb_input_mask, cb_ex2pe, mask_index, g, dst0);
+                    tile_regs_commit();
+                    tile_regs_wait();
+                    pack_tile(dst0, cb_xmm);
+                    tile_regs_release();
+                    cb_push_back(cb_xmm, 2);
+
+                    // // c. a * b
+                    cb_wait_front(cb_xmm, 2);
+                    mul_tiles_init(cb_xmm, cb_xmm);
+                    reconfig_data_format_srca(cb_xmm);
+                    reconfig_data_format_srcb(cb_ex2pe, cb_xmm);
+                    tile_regs_acquire();
+                    mul_tiles(cb_xmm, cb_xmm, 0, 1, dst0);
+                    tile_regs_commit();
+                    cb_pop_front(cb_xmm, 2);
+                    cb_reserve_back(cb_xmm, 1);
+                    tile_regs_wait();
+                    pack_tile(dst0, cb_xmm);
+                    tile_regs_release();
+                    cb_push_back(cb_xmm, 1);
+
+                    // // d. Add to cb_xmm (accumulate results)
+                    // // First we get the result in dst0
+                    if (group_offset == 0) {
+                        // When group_offset is 0, this is the first group for this tile,
+                        // so we can copy the results to cb_x without needing to add them
+                        copy_tile_init(cb_xmm);
+
+                        cb_wait_front(cb_xmm, 1);
+                        tile_regs_acquire();
+                        copy_tile(cb_xmm, 0, dst0);
+                        tile_regs_commit();
+                        cb_pop_front(cb_xmm, 1);
                     } else {
-                        add_tiles_init(cb_out, cb_x);
-                    }
+                        // This is not the first group for this tile, so we need to add
+                        // the results over what is already in cb_x
+                        add_tiles_init(cb_x, cb_xmm);
 
-                    for (uint32_t i = 0; i < block_h; ++i) {
+                        cb_wait_front(cb_xmm, 1);
+                        cb_wait_front(cb_x, 1);
                         tile_regs_acquire();
-                        uint32_t index_x = w + index_h1_offset;
-                        uint32_t index = w + index_h_offset;
-
-                        if (copy_or_add == true) {
-                            copy_tile(cb_x, index_x, dst0);
-                        } else {
-                            add_tiles(cb_out, cb_x, index, index_x, dst0);
-                        }
+                        add_tiles(cb_x, cb_xmm, 0, 0, dst0);
                         tile_regs_commit();
-                        tile_regs_wait();
-                        pack_tile<true>(dst0, cb_out, index);
-                        tile_regs_release();
-
-                        index_h_offset += per_core_N;
-                        index_h1_offset += block_w;
+                        cb_pop_front(cb_xmm, 1);
+                        cb_pop_front(cb_x, 1);
                     }
 
-                    // update group tile offset
-                    if (index_block_w >= block_w_curr - 1) {
-                        index_block_w = 0;
+                    // Then we pack the result into cb_x
+                    cb_reserve_back(cb_x, 1);
+                    tile_regs_wait();
+                    pack_tile(dst0, cb_x);
+                    tile_regs_release();
+                    cb_push_back(cb_x, 1);
 
-                        if (group_reset_index == num_groups_per_reset - 1) {
-                            copy_or_add = true;
+                    uint32_t cols_available = tt::constants::TILE_WIDTH - group_offset;
+                    uint32_t cols_consumed = std::min(cols_available, channels_left);
+                    channels_left -= cols_consumed;
+                    group_offset += cols_consumed;
 
-                            group_reset_index = 0;
-                        } else {
-                            copy_or_add = false;
+                    // There are still channels left to be processed for the current group
+                    // This can only be done in the next tile. So we don't do any more groups
+                    // for this tile.
+                    if (channels_left > 0) {
+                        // For the next tile, we need to use the next mask index
+                        ++block_w_index;
+                        break;
+                    }
 
-                            group_reset_index += 1;
-                        }
-                    } else {
-                        copy_or_add = true;
-                        index_block_w += 1;
+                    // Since we know that channels_left is 0, it also means that we have
+                    // processed all the channels for the current group.
+                    // We update the min_group so we never revisit this group again.
+                    ++min_group;
+                    channels_left = num_channels_per_group;
+                    block_w_index = 0;
+
+                    // All available columns have been used for this tile, so we don't do any
+                    // more groups for this tile.
+                    if (group_offset == tt::constants::TILE_WIDTH) {
+                        break;
                     }
                 }
-            } else {
-                // zero out values in cb_tilized_in input by multiplying with negative mask for the current group
-                cb_wait_front(cb_in_negative_mask, block_w);
-                reconfig_data_format_srcb(cb_x, cb_in_negative_mask);
-                mul_tiles_init(cb_in, cb_in_negative_mask);
+                ++tile_id;
 
-                for (uint32_t w = 0; w < block_w_curr; w++) {
-                    index_h_offset = index_b_offset + index_g_offset;
-                    uint32_t index_h1_offset = 0;
+                if constexpr (do_gamma) {
+                    mul_bcast_rows_init_short(cb_x, cb_gamma);
+                    reconfig_data_format_srcb(cb_xmm, cb_gamma);
 
-                    for (uint32_t i = 0; i < block_h; i++) {
-                        tile_regs_acquire();
-                        uint32_t index_in = w + index_h_offset;
-                        uint32_t index_mask = w;
-
-                        mul_tiles(cb_in, cb_in_negative_mask, index_in, index_mask, dst0);
-                        tile_regs_commit();
-
-                        tile_regs_wait();
-                        pack_tile<true>(dst0, cb_in, index_in);
-                        tile_regs_release();
-
-                        index_h_offset += per_core_N;
-                    }
+                    cb_wait_front(cb_x, 1);
+                    tile_regs_acquire();
+                    mul_tiles_bcast_rows(cb_x, cb_gamma, 0, nt, dst0);
+                    tile_regs_commit();
+                    cb_pop_front(cb_x, 1);
+                    cb_reserve_back(cb_x, 1);
+                    tile_regs_wait();
+                    pack_tile(dst0, cb_x);
+                    tile_regs_release();
+                    cb_push_back(cb_x, 1);
                 }
 
-                reconfig_data_format_srcb(cb_in_negative_mask, cb_x);
-                add_tiles_init(cb_in, cb_x);
-                // data in cb_x has valid data only for current group
-                // cb_in has cleared data for that group
-                // just add them together
-                for (uint32_t w = 0; w < block_w_curr; ++w) {
-                    index_h_offset = index_b_offset + index_g_offset;
-                    uint32_t index_h1_offset = 0;
+                if constexpr (do_beta) {
+                    add_bcast_rows_init_short(cb_x, cb_beta);
+                    reconfig_data_format_srcb(cb_gamma, cb_beta);
 
-                    for (uint32_t i = 0; i < block_h; ++i) {
-                        tile_regs_acquire();
-                        uint32_t index_x = w + index_h1_offset;
-                        uint32_t index = w + index_h_offset;
-
-                        add_tiles(cb_in, cb_x, index, index_x, dst0);
-                        tile_regs_commit();
-                        tile_regs_wait();
-                        pack_tile<true>(dst0, cb_in, index);
-                        tile_regs_release();
-
-                        index_h_offset += per_core_N;
-                        index_h1_offset += block_w;
-                    }
+                    cb_wait_front(cb_x, 1);
+                    tile_regs_acquire();
+                    add_tiles_bcast_rows(cb_x, cb_beta, 0, nt, dst0);
+                    tile_regs_commit();
+                    cb_pop_front(cb_x, 1);
+                    cb_reserve_back(cb_x, 1);
+                    tile_regs_wait();
+                    pack_tile(dst0, cb_x);
+                    tile_regs_release();
+                    cb_push_back(cb_x, 1);
                 }
-                cb_pop_front(cb_in_negative_mask, block_w);
-            }
 
-            cb_pop_front(cb_x, block_hw);
+                // Write out the final output
+                copy_tile_init(cb_x);
+                reconfig_data_format_srcb(cb_beta, cb_x);
 
-            if constexpr (GROUP_SIZE_IS_POWER_OF_2) {
-                if (row_offset == TILE_WIDTH) {
-                    index_g_offset += block_w;
-                    row_offset = num_cols_per_group;
-
-                } else {
-                    index_g_offset += block_w_minus_one;
-                    row_offset += num_cols_per_group;
-                }
-            } else if constexpr (GROUP_SIZE_SMALLER_THAN_TILE_W) {
-                if (row_offset == TILE_WIDTH) {
-                    index_g_offset += block_w_minus_one;
-                    row_offset = num_cols_per_group;
-
-                } else if (row_offset > TILE_WIDTH) {
-                    index_g_offset += block_w_minus_one;
-                    row_offset = row_offset + group_row_offset;
-
-                } else {
-                    row_offset += num_cols_per_group;
-                }
-            } else {
-                if (row_offset > TILE_WIDTH) {
-                    index_g_offset += block_w_minus_one;
-                    row_offset = row_offset - tile_w_minux_group_size;
-                } else {
-                    row_offset += num_cols_per_group;
-                    index_g_offset += block_w_minus_two;
-                }
+                cb_wait_front(cb_x, 1);
+                tile_regs_acquire();
+                copy_tile(cb_x, 0, dst0);
+                tile_regs_commit();
+                cb_pop_front(cb_x, 1);
+#ifdef UNTILIZE_OUT
+                auto write_cb = cb_untilize_in;
+#else
+                auto write_cb = cb_out0;
+#endif
+                cb_reserve_back(write_cb, 1);
+                tile_regs_wait();
+                pack_tile(dst0, write_cb);
+                tile_regs_release();
+                cb_push_back(write_cb, 1);
             }
         }
-        index_b_offset += num_tiles_per_batch;
+
+        cb_pop_front(cb_ex_global, 2 * num_groups);
+        cb_pop_front(cb_ex2pe, num_groups);
     }
 
-    if constexpr (use_negative_mask == false) {
-        cb_push_back(cb_out, per_core_MN);
-        cb_pop_front(cb_in, per_core_MN);
+    cb_pop_front(cb_eps, 1);
+    cb_pop_front(cb_input_mask, num_tiles_input_mask);
 
-    } else {
-        // nothing, for the negative mask implementation, cb_in is the only cb in use, and it already has the data
-        // required for the rest of kernel.
-    }
-
-    if constexpr (do_gamma) {
-        index_h_offset = 0;
-        if constexpr (use_negative_mask == false) {
-            mul_bcast_rows_init_short(cb_out, cb_gamma);
-            cb_reserve_back(cb_outgamma, per_core_MN);
-            cb_wait_front(cb_gamma, per_core_N);
-            for (uint32_t i = 0; i < per_core_M; ++i) {
-                for (uint32_t j = 0; j < per_core_N; ++j) {
-                    tile_regs_acquire();
-                    uint32_t index = j + index_h_offset;
-                    mul_tiles_bcast_rows(cb_out, cb_gamma, index, j, dst0);
-                    tile_regs_commit();
-                    tile_regs_wait();
-                    pack_tile(dst0, cb_outgamma);
-                    tile_regs_release();
-                }
-                index_h_offset += per_core_N;
-            }
-
-            cb_push_back(cb_outgamma, per_core_MN);
-            cb_pop_front(cb_out, per_core_MN);
-            cb_wait_front(cb_outgamma, per_core_MN);
-        } else {
-            // cb in has data required for gamma, so we do it inplace
-            mul_bcast_rows_init_short(cb_in, cb_gamma);
-            cb_wait_front(cb_gamma, per_core_N);
-            cb_wait_front(cb_in, per_core_MN);
-            for (uint32_t i = 0; i < per_core_M; i++) {
-                for (uint32_t j = 0; j < per_core_N; j++) {
-                    tile_regs_acquire();
-                    mul_tiles_bcast_rows(cb_in, cb_gamma, 0, j, dst0);
-                    tile_regs_commit();
-                    cb_pop_front(cb_in, 1);
-                    cb_reserve_back(cb_in, 1);
-                    tile_regs_wait();
-                    pack_tile(dst0, cb_in);
-                    cb_push_back(cb_in, 1);
-                    tile_regs_release();
-                }
-            }
-        }
-    }
-
+    // Pop all the cb_beta and cb_gamma if used
     if constexpr (do_beta) {
-        if constexpr (use_negative_mask == false) {
-            index_h_offset = 0;
-            add_bcast_rows_init_short(cb_inbeta, cb_beta);
-            cb_reserve_back(cb_outbeta, per_core_MN);
-            cb_wait_front(cb_beta, per_core_N);
-            for (uint32_t i = 0; i < per_core_M; ++i) {
-                for (uint32_t j = 0; j < per_core_N; ++j) {
-                    tile_regs_acquire();
-                    uint32_t index = j + index_h_offset;
-                    add_tiles_bcast_rows(cb_inbeta, cb_beta, index, j, dst0);
-                    tile_regs_commit();
-                    tile_regs_wait();
-                    pack_tile(dst0, cb_outbeta);
-                    tile_regs_release();
-                }
-                index_h_offset += per_core_N;
-            }
-            cb_push_back(cb_outbeta, per_core_MN);
-            cb_pop_front(cb_inbeta, per_core_MN);
-            cb_wait_front(cb_outbeta, per_core_MN);
-        } else {
-            // cb_in has data required for beta, so we do it inplace
-            add_bcast_rows_init_short(cb_in, cb_beta);
-            cb_wait_front(cb_beta, per_core_N);
-            cb_wait_front(cb_in, per_core_MN);
-            for (uint32_t i = 0; i < per_core_M; i++) {
-                for (uint32_t j = 0; j < per_core_N; j++) {
-                    tile_regs_acquire();
-                    add_tiles_bcast_rows(cb_in, cb_beta, 0, j, dst0);
-                    tile_regs_commit();
-                    cb_pop_front(cb_in, 1);
-                    cb_reserve_back(cb_in, 1);
-                    tile_regs_wait();
-                    pack_tile(dst0, cb_in);
-                    cb_push_back(cb_in, 1);
-                    tile_regs_release();
-                }
-            }
-        }
+        cb_pop_front(cb_beta, per_core_N);
+    }
+    if constexpr (do_gamma) {
+        cb_pop_front(cb_gamma, per_core_N);
     }
 
 #ifdef UNTILIZE_OUT

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/welford_groupnorm_sharded_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/welford_groupnorm_sharded_v2.cpp
@@ -129,7 +129,6 @@ void MAIN {
     for (uint32_t b = 0; b < num_batches; ++b) {
         uint32_t tile_id = b * block_hw;
         cb_reserve_back(cb_ex_partial, 2);
-        reconfig_data_format_srcb(cb_in0);
         transpose_wh_init(cb_in0, cb_ex_partial);
         tile_regs_acquire();
         welford_init();
@@ -225,7 +224,7 @@ void MAIN {
         cb_reserve_back(cb_ex2pe, num_groups);
         // (Var + eps)
         add_tiles_init(cb_ex_global, cb_eps);
-        reconfig_data_format_srcb(cb_in0, cb_eps);
+        reconfig_data_format_srcb(cb_eps);
         for (uint32_t g = 0; g < num_groups; ++g) {
             tile_regs_acquire();
             add_tiles(cb_ex_global, cb_eps, 1 + (g << 1), 0, dst0);
@@ -271,7 +270,7 @@ void MAIN {
                     // // Now let us do the actual computation for the current group here
                     // // a. x-u
                     sub_tiles_bcast_scalar_init_short(cb_in0, cb_ex_global);
-                    reconfig_data_format_srcb(cb_eps, cb_ex_global);
+                    reconfig_data_format(cb_in0, cb_ex_global);
 
                     tile_regs_acquire();
 #ifdef TILIZE_IN
@@ -289,8 +288,7 @@ void MAIN {
                     const uint32_t mask_index = mask_offset + block_w_index;
 
                     mul_tiles_bcast_scalar_init_short(cb_input_mask, cb_ex2pe);
-                    reconfig_data_format_srca(cb_input_mask);
-                    reconfig_data_format_srcb(cb_ex_global, cb_ex2pe);
+                    reconfig_data_format(cb_in0, cb_input_mask, cb_ex_global, cb_ex2pe);
                     tile_regs_acquire();
                     mul_tiles_bcast_scalar(cb_input_mask, cb_ex2pe, mask_index, g, dst0);
                     tile_regs_commit();
@@ -302,8 +300,7 @@ void MAIN {
                     // // c. a * b
                     cb_wait_front(cb_xmm, 2);
                     mul_tiles_init(cb_xmm, cb_xmm);
-                    reconfig_data_format_srca(cb_xmm);
-                    reconfig_data_format_srcb(cb_ex2pe, cb_xmm);
+                    reconfig_data_format(cb_input_mask, cb_xmm, cb_ex2pe, cb_xmm);
                     tile_regs_acquire();
                     mul_tiles(cb_xmm, cb_xmm, 0, 1, dst0);
                     tile_regs_commit();
@@ -329,6 +326,7 @@ void MAIN {
                     } else {
                         // This is not the first group for this tile, so we need to add
                         // the results over what is already in cb_x
+                        reconfig_data_format_srca(cb_xmm, cb_x);
                         add_tiles_init(cb_x, cb_xmm);
 
                         cb_wait_front(cb_xmm, 1);
@@ -394,7 +392,7 @@ void MAIN {
 
                 if constexpr (do_beta) {
                     add_bcast_rows_init_short(cb_x, cb_beta);
-                    reconfig_data_format_srcb(cb_gamma, cb_beta);
+                    reconfig_data_format_srcb(do_gamma ? cb_gamma : cb_xmm, cb_beta);
 
                     cb_wait_front(cb_x, 1);
                     tile_regs_acquire();
@@ -410,7 +408,7 @@ void MAIN {
 
                 // Write out the final output
                 copy_tile_init(cb_x);
-                reconfig_data_format_srcb(cb_beta, cb_x);
+                reconfig_data_format_srcb(do_beta ? cb_beta : cb_xmm, cb_x);
 
                 cb_wait_front(cb_x, 1);
                 tile_regs_acquire();

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_reader_mcast_receiver_unary_gn.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_reader_mcast_receiver_unary_gn.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -6,57 +6,10 @@
 #include "dataflow_api.h"
 #include "hostdevcommon/common_values.hpp"
 #include "welford_combine.h"
+#include "tt-metalium/constants.hpp"
+#include "noc_parameters.h"
 
 void kernel_main() {
-    // clang-format off
-    // Definitions
-    //   block_h: This the length of the row we wish to processes in terms of tiles
-    //
-    //   out_block_...: This is the length of our Circular Buffer, sometimes the length of out tensors(block_h) are larger than L1 space, so we
-    //   have to process chunks of this data at a time
-    //   this chunk is called an out_block
-    //
-    //   num_out_blocks: This is the number of chunks specified by the use, such that a CBs (length defined by out_block) fit in L1
-    //   (Users should minimize the number of num_out_blocks for better perf)
-    //
-    //   ...normal:  If num_out_blocks evenly divides block_h, then all chunks are the size normal
-    //
-    //   ...last: If num_out_blocks does not divides block_h, the leftovers are put into a chunk of length last
-    //
-    //   sender: This refers to a core that does aggregation calculations
-    //   for the group of cores
-    //
-    //   receiver: This the cores that receive the aggregated results from sender, they only do
-    //   local computations that they send to the sender for final aggregation
-    //
-    // GROUPNORM RECEIVER DESCRIPTION
-    // This is a high level description of the stages of this kernel, tags will be added to show where in the code each
-    // stage starts and ends
-    //
-    // Batch Loop:
-    //   Group Loop:
-    //     This is the process which repeats for every group
-    //     First Read of data:
-    //       If Receiver:
-    //           Send partial reduction of Average to Sender Core
-    //       If Sender:
-    //           Pack Partials:
-    //               Accumulate partial reductions into single tile
-    //               Calculates the Global average sum
-    //           Send Global:
-    //               Send Global Average to all Receiver cores
-    //     Second Read of data:
-    //       If Receiver:
-    //           Send partial reduction of Varience to Sender Core
-    //       If Sender:
-    //           Pack Partials:
-    //               Accumulate partial reductions into single tile
-    //               Calculates the Global Varience sum
-    //           Send Global:
-    //               Send Global Varience to all Receiver cores
-    //          Third Read of data:
-    //
-    //      // clang-format on
     uint32_t reduce_receiver_semaphore_addr = get_semaphore(get_named_compile_time_arg_val("reduce_receiver_semaphore_id"));
     uint32_t reduce_sender_semaphore_addr = get_semaphore(get_named_compile_time_arg_val("reduce_sender_semaphore_id"));
 
@@ -92,38 +45,35 @@ void kernel_main() {
 
     constexpr uint32_t block_w_minus_one = block_w - 1;
     constexpr uint32_t block_w_minus_two = block_w - 2;
-    constexpr uint32_t TILE_WIDTH = 32;
-    constexpr uint32_t tile_w_minux_group_size = TILE_WIDTH - num_cols_per_group;
-    uint32_t row_offset = num_cols_per_group;
-    uint32_t index_g_offset = 0;
-    uint32_t index_b_offset = 0;
+    constexpr uint32_t tile_w_minux_group_size = tt::constants::TILE_WIDTH - num_cols_per_group;
 
-    uint32_t src_addr = get_arg_val<uint32_t>(0);
+    const uint32_t src_addr = get_arg_val<uint32_t>(0);
     const uint32_t out_addr = get_arg_val<uint32_t>(1);
-    uint32_t start_id = get_arg_val<uint32_t>(2);
+    const uint32_t start_id = get_arg_val<uint32_t>(2);
     const uint32_t out_start_id = get_arg_val<uint32_t>(3);
-    uint32_t num_channels_tiles = get_arg_val<uint32_t>(4);
+    const uint32_t num_channels_tiles = get_arg_val<uint32_t>(4);
+
     const uint32_t mcast_sender_noc_x = get_arg_val<uint32_t>(5);
     const uint32_t mcast_sender_noc_y = get_arg_val<uint32_t>(6);
+    const auto reduce_sender_semaphore_addr_ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(reduce_sender_semaphore_addr);
+    const auto reduce_receiver_semaphore_noc_addr =
+        get_noc_addr(mcast_sender_noc_x, mcast_sender_noc_y, reduce_receiver_semaphore_addr);
 
-    constexpr uint32_t cb_ex_partial = tt::CBIndex::c_8;  // E[x] partial reduce
-    constexpr uint32_t cb_ex_global = tt::CBIndex::c_15;  // E[x] global reduce
-    constexpr uint32_t cb_in0 = tt::CBIndex::c_0;         // input cb
+    constexpr uint32_t cb_ex_partial = tt::CBIndex::c_8;
+    constexpr uint32_t cb_ex_global = tt::CBIndex::c_15;
+    constexpr uint32_t cb_in0 = tt::CBIndex::c_0;
     constexpr uint32_t cb_repack = tt::CBIndex::c_26;
     constexpr uint32_t cb_repack_out = tt::CBIndex::c_31;
     constexpr uint32_t cb_out0 = tt::CBIndex::c_16;
-    constexpr uint32_t cb_reread_out = tt::CBIndex::c_23;
 
-    const uint32_t single_tile_size_bytes = get_tile_size(cb_ex_partial);  // tile size
+    constexpr uint32_t single_tile_size_bytes = get_tile_size(cb_ex_partial);
+    constexpr uint32_t src0_tile_bytes = get_tile_size(cb_in0);
 
-    volatile tt_l1_ptr uint32_t* reduce_sender_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(reduce_sender_semaphore_addr);
-
-    const uint64_t reduce_receiver_semaphore_noc_addr =
-        get_noc_addr(mcast_sender_noc_x, mcast_sender_noc_y, reduce_receiver_semaphore_addr);
+    const auto src_a = TensorAccessor(src0_args, src_addr, src0_tile_bytes);
 
 #if defined(READER_REPACK) and defined(TILIZE_IN)
-    uint32_t in0_l1_read_addr = get_read_ptr(cb_in0);
+    const uint32_t in0_l1_read_addr = get_read_ptr(cb_in0);
     uint64_t noc_addr_in0 = get_noc_addr(in0_l1_read_addr);
     for (uint32_t m = 0; m < per_core_M; ++m) {
         cb_reserve_back(cb_repack, per_core_N);
@@ -139,120 +89,91 @@ void kernel_main() {
 #endif
 
     constexpr uint32_t out_block_h_normal = block_h / num_out_blocks;
-    uint32_t out_block_hw_normal = out_block_h_normal * block_w;
+    constexpr uint32_t out_block_hw_normal = out_block_h_normal * block_w;
     uint32_t num_out_blocks_padded = num_out_blocks;
     uint32_t extra_out_block = false;
     uint32_t out_block_h_last = out_block_h_normal;
     uint32_t out_block_hw_last = out_block_hw_normal;
-    const uint32_t num_reads_of_input = 2;
-    if constexpr(block_h % num_out_blocks != 0) {
+    if constexpr (block_h % num_out_blocks != 0) {
         extra_out_block = true;
         num_out_blocks_padded++;
         out_block_h_last = block_h % num_out_blocks;
         out_block_hw_last = out_block_h_last * block_w;
     }
 
-    index_b_offset = 0;
+    uint32_t index_b_offset = 0;
 
-    // Start Batch Loop:
     for (uint32_t b = 0; b < num_batches; ++b) {
-        index_g_offset = 0;
-        row_offset = num_cols_per_group;
+        uint32_t index_g_offset = 0;
+        uint32_t row_offset = num_cols_per_group;
 
-        // Start Group Loop:
-        for (uint32_t i = 0; i < num_groups; ++i) {
-            // The following loop is for the 2 passes of input tensor required for GroupNorm
-            // First Pass: Calculates average and variance value
-            // Second Pass: Calculates final value
-            // Definition: num_read_of_input = 2
-            for (uint32_t cur_read_iteration = 0; cur_read_iteration < num_reads_of_input; ++cur_read_iteration) {
-                uint32_t out_block_start_id_offset = 0;
-                for (uint32_t out_block_index = 0; out_block_index < num_out_blocks_padded; out_block_index++) {
-                    uint32_t out_block_h_actual, out_block_hw_actual;
-                    if (extra_out_block && (out_block_index == (num_out_blocks_padded - 1))) {
-                        out_block_h_actual = out_block_h_last;
-                        out_block_hw_actual = out_block_hw_last;
-                    } else {
-                        out_block_h_actual = out_block_h_normal;
-                        out_block_hw_actual = out_block_hw_normal;
-                    }
+        cb_reserve_back(cb_ex_global, 2 * num_groups);
+        auto global_means_ptr = get_write_ptr(cb_ex_global);
+        auto global_vars_ptr = global_means_ptr + single_tile_size_bytes;
+
+        for (uint32_t m = 0; m < num_groups; ++m) {
+            uint32_t out_block_start_id_offset = 0;
+            for (uint32_t out_block_index = 0; out_block_index < num_out_blocks_padded; out_block_index++) {
+                uint32_t out_block_h_actual, out_block_hw_actual;
+                if (extra_out_block && (out_block_index == (num_out_blocks_padded - 1))) {
+                    out_block_h_actual = out_block_h_last;
+                    out_block_hw_actual = out_block_hw_last;
+                } else {
+                    out_block_h_actual = out_block_h_normal;
+                    out_block_hw_actual = out_block_hw_normal;
+                }
+
 #if !defined(READER_REPACK) or !defined(TILIZE_IN)
-                    const uint32_t src0_tile_bytes = get_tile_size(cb_in0);
-                    const auto src_a = TensorAccessor(src0_args, src_addr, src0_tile_bytes);
-                    uint32_t l1_write_addr;
-                    l1_write_addr = get_write_ptr(cb_in0);
-                    cb_reserve_back(cb_in0, out_block_hw_normal);
-                    for (uint32_t mt = 0; mt < out_block_h_actual; mt++) {
-                        for (uint32_t nt = 0; nt < block_w; nt++) {
-                            noc_async_read_tile(
-                                start_id + out_block_start_id_offset + (mt * num_channels_tiles) + nt + index_b_offset +
-                                    index_g_offset,
-                                src_a,
-                                l1_write_addr);
-                            l1_write_addr += src0_tile_bytes;
-                            noc_async_read_barrier();
-                        }
+                uint32_t l1_write_addr = get_write_ptr(cb_in0);
+                cb_reserve_back(cb_in0, out_block_hw_normal);
+                for (uint32_t mt = 0; mt < out_block_h_actual; mt++) {
+                    for (uint32_t nt = 0; nt < block_w; nt++) {
+                        noc_async_read_tile(
+                            start_id + out_block_start_id_offset + (mt * num_channels_tiles) + nt + index_b_offset +
+                                index_g_offset,
+                            src_a,
+                            l1_write_addr);
+                        l1_write_addr += src0_tile_bytes;
+                        noc_async_read_barrier();
                     }
-                    cb_push_back(cb_in0, out_block_hw_normal);
+                }
+                cb_push_back(cb_in0, out_block_hw_normal);
 #endif
-                    if (cur_read_iteration == 1) {
-                        const auto dst_a = TensorAccessor(out_args, out_addr, single_tile_size_bytes);
-
-                        // add or copy with previous output results
-                        uint32_t block_w_curr = index_g_offset == (per_core_N - block_w_last) ? block_w_last : block_w;
-
-                        const uint32_t dst_tile_bytes = get_tile_size(cb_reread_out);
-                        uint32_t l1_write_addr;
-                        l1_write_addr = get_write_ptr(cb_reread_out);
-                        cb_reserve_back(cb_reread_out, out_block_hw_normal);
-
-                        for (uint32_t mt = 0; mt < out_block_h_actual; mt++) {
-                            for (uint32_t nt = 0; nt < block_w_curr; nt++) {
-                                noc_async_read_tile(
-                                    out_start_id + out_block_start_id_offset + (mt * num_channels_tiles) + nt +
-                                        index_b_offset + index_g_offset,
-                                    dst_a,
-                                    l1_write_addr);
-                                l1_write_addr += dst_tile_bytes;
-                                noc_async_read_barrier();
-                            }
-                        }
-                        cb_push_back(cb_reread_out, out_block_hw_normal);
-                    }
-                    out_block_start_id_offset += out_block_h_actual * num_channels_tiles;
-                }
-
-                if (cur_read_iteration == 0) {
-                    cb_reserve_back(cb_ex_global, 2);
-                    cb_wait_front(cb_ex_partial, 2);
-
-                    // Read mean and variance arrays from cb_ex_partial, then combine using Welford
-                    auto p_local_means = reinterpret_cast<volatile uint16_t*>(get_read_ptr(cb_ex_partial));
-                    auto p_local_vars = p_local_means + TILE_WIDTH * TILE_HEIGHT;
-
-                    auto local_result = combine_welford_stats<32, num_channels_per_group * num_rows_per_group / 32, 2>(p_local_means, p_local_vars);
-
-                    // Write this to cb_ex_global
-                    auto p_global_means = reinterpret_cast<volatile uint16_t*>(get_write_ptr(cb_ex_global));
-                    auto p_global_vars = p_global_means + TILE_WIDTH * TILE_HEIGHT;
-                    p_global_means[0] = local_result.mean;
-                    p_global_vars[0] = local_result.variance;
-
-                    // Signal to sender that our partial data is ready
-                    noc_semaphore_inc(reduce_receiver_semaphore_noc_addr, 1);
-
-                    // Wait for sender to signal that it has sent the global data
-                    noc_semaphore_wait(reduce_sender_semaphore_addr_ptr, VALID);
-                    noc_semaphore_set(reduce_sender_semaphore_addr_ptr, INVALID);
-
-                    cb_pop_front(cb_ex_partial, 2);
-                    cb_push_back(cb_ex_global, 2);
-
-                }
+                out_block_start_id_offset += out_block_h_actual * num_channels_tiles;
             }
 
+            cb_wait_front(cb_ex_partial, 2);
+
+            // Read mean and variance arrays from cb_ex_partial, then combine using Welford
+            auto local_read_ptr = get_read_ptr(cb_ex_partial);
+            auto p_local_means = reinterpret_cast<volatile uint16_t*>(local_read_ptr);
+            auto p_local_vars = reinterpret_cast<volatile uint16_t*>(local_read_ptr + single_tile_size_bytes);
+
+            auto local_result = combine_welford_stats<
+                tt::constants::TILE_WIDTH,
+                num_channels_per_group * num_rows_per_group / tt::constants::TILE_WIDTH,
+                2>(p_local_means, p_local_vars);
+
+            // Write this to cb_ex_global
+            volatile uint16_t* p_global_means = reinterpret_cast<volatile uint16_t*>(global_means_ptr);
+            volatile uint16_t* p_global_vars = reinterpret_cast<volatile uint16_t*>(global_vars_ptr);
+            p_global_means[0] = local_result.mean;
+            p_global_vars[0] = local_result.variance;
+
+            // Signal to sender that our partial data is ready
+            noc_semaphore_inc(reduce_receiver_semaphore_noc_addr, 1);
+
+            // Wait for sender to signal that it has sent the global data
+            noc_semaphore_wait(reduce_sender_semaphore_addr_ptr, VALID);
+            noc_semaphore_set(reduce_sender_semaphore_addr_ptr, INVALID);
+
+            cb_pop_front(cb_ex_partial, 2);
+
+            global_means_ptr += 2 * single_tile_size_bytes;
+            global_vars_ptr += 2 * single_tile_size_bytes;
+
             if constexpr (GROUP_SIZE_IS_POWER_OF_2) {
-                if (row_offset == TILE_WIDTH) {
+                if (row_offset == tt::constants::TILE_WIDTH) {
                     index_g_offset += block_w;
                     row_offset = num_cols_per_group;
 
@@ -261,11 +182,11 @@ void kernel_main() {
                     row_offset += num_cols_per_group;
                 }
             } else if constexpr (GROUP_SIZE_SMALLER_THAN_TILE_W) {
-                if (row_offset == TILE_WIDTH) {
+                if (row_offset == tt::constants::TILE_WIDTH) {
                     index_g_offset += block_w_minus_one;
                     row_offset = num_cols_per_group;
 
-                } else if (row_offset > TILE_WIDTH) {
+                } else if (row_offset > tt::constants::TILE_WIDTH) {
                     index_g_offset += block_w_minus_one;
                     row_offset = row_offset + group_row_offset;
 
@@ -273,7 +194,7 @@ void kernel_main() {
                     row_offset += num_cols_per_group;
                 }
             } else {
-                if (row_offset > TILE_WIDTH) {
+                if (row_offset > tt::constants::TILE_WIDTH) {
                     index_g_offset += block_w_minus_one;
                     row_offset = row_offset - tile_w_minux_group_size;
                 } else {
@@ -281,17 +202,43 @@ void kernel_main() {
                     index_g_offset += block_w_minus_two;
                 }
             }
-        }  // End Group Loop:
+        }
+
+        cb_push_back(cb_ex_global, 2 * num_groups);
+
+        uint32_t mt_offset = 0;
+        for (uint32_t out_block_index = 0; out_block_index < num_out_blocks_padded; out_block_index++) {
+            uint32_t out_block_h_actual, out_block_hw_actual;
+            if (extra_out_block && (out_block_index == (num_out_blocks_padded - 1))) {
+                out_block_h_actual = out_block_h_last;
+                out_block_hw_actual = out_block_hw_last;
+            } else {
+                out_block_h_actual = out_block_h_normal;
+                out_block_hw_actual = out_block_hw_normal;
+            }
+#if !defined(READER_REPACK) or !defined(TILIZE_IN)
+            for (uint32_t mt = 0; mt < out_block_h_actual; ++mt) {
+                for (uint32_t nt = 0; nt < per_core_N; ++nt) {
+                    cb_reserve_back(cb_in0, 1);
+                    const uint32_t l1_write_addr = get_write_ptr(cb_in0);
+                    noc_async_read_tile(start_id + index_b_offset + mt_offset + nt, src_a, l1_write_addr);
+                    noc_async_read_barrier();
+                    cb_push_back(cb_in0, 1);
+                }
+                mt_offset += num_channels_tiles;
+            }
+#endif
+        }
         index_b_offset += num_tiles_per_batch;
-    }  // End Batch Loop:
+    }
 
 #if defined(READER_REPACK) and defined(UNTILIZE_OUT)
     uint32_t l1_write_addr_repack = get_write_ptr(cb_out0);
     for (uint32_t m = 0; m < per_core_M; ++m) {
         cb_wait_front(cb_repack_out, per_core_N);
-        uint32_t in0_l1_read_addr = get_read_ptr(cb_repack_out);
+        const uint32_t in0_l1_read_addr = get_read_ptr(cb_repack_out);
         uint64_t noc_addr_in0 = get_noc_addr(in0_l1_read_addr);
-        for (uint32_t i = 0; i < TILE_HEIGHT; ++i) {
+        for (uint32_t i = 0; i < tt::constants::TILE_HEIGHT; ++i) {
             noc_async_read(noc_addr_in0, l1_write_addr_repack, per_core_N_bytes);
             noc_addr_in0 += per_core_N_bytes_with_stride;
             l1_write_addr_repack += per_core_N_bytes;

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_reader_mcast_receiver_unary_sharded_gn_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_reader_mcast_receiver_unary_sharded_gn_v2.cpp
@@ -82,19 +82,6 @@ void kernel_main() {
                 combine_welford_stats<tt::constants::TILE_WIDTH, block_hw * tt::constants::TILE_WIDTH, local_stride>(
                     p_local_means, p_local_vars);
 
-            // DPRINT << "p_local_means: " << ENDL();
-            for (uint32_t idx = 0; idx < tt::constants::TILE_WIDTH; ++idx) {
-                // DPRINT << BF16(p_local_means[2 * idx]) << " ";
-            }
-            // DPRINT << ENDL();
-            // DPRINT << "local_result.mean: " << BF16(local_result.mean) << ENDL();
-            // DPRINT << "p_local_vars: " << ENDL();
-            for (uint32_t idx = 0; idx < tt::constants::TILE_WIDTH; ++idx) {
-                // DPRINT << BF16(p_local_vars[2 * idx]) << " ";
-            }
-            // DPRINT << ENDL();
-            // DPRINT << "local_result.variance: " << BF16(local_result.variance) << ENDL();
-
             // Write this to cb_ex_global
             auto p_global_means = reinterpret_cast<volatile uint16_t*>(global_means_ptr);
             auto p_global_vars = reinterpret_cast<volatile uint16_t*>(global_vars_ptr);

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_reader_mcast_receiver_unary_sharded_gn_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_reader_mcast_receiver_unary_sharded_gn_v2.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <stdint.h>
+#include "tt-metalium/constants.hpp"
 #include "dataflow_api.h"
 #include "hostdevcommon/common_values.hpp"
 #include "welford_combine.h"
@@ -11,16 +12,16 @@ void kernel_main() {
     uint32_t reduce_receiver_semaphore_addr = get_semaphore(get_compile_time_arg_val(0));
     uint32_t reduce_sender_semaphore_addr = get_semaphore(get_compile_time_arg_val(1));
 
-    constexpr uint32_t num_batch_group = get_compile_time_arg_val(2);
+    constexpr uint32_t num_batches = get_compile_time_arg_val(2);
 
     constexpr uint32_t per_core_N = get_compile_time_arg_val(3);
     const uint32_t per_core_N_bytes = get_compile_time_arg_val(4);
     const uint32_t per_core_N_bytes_with_stride = get_compile_time_arg_val(5);
     constexpr uint32_t per_core_M = get_compile_time_arg_val(6);
-    constexpr uint32_t TILE_HEIGHT = get_compile_time_arg_val(7);
 
     // These are numbers in absolute terms, on a per group, per batch without tiling
     constexpr uint32_t block_hw = get_compile_time_arg_val(8);
+    constexpr uint32_t num_groups = get_compile_time_arg_val(9);
 
     const uint32_t mcast_sender_noc_x = get_arg_val<uint32_t>(0);
     const uint32_t mcast_sender_noc_y = get_arg_val<uint32_t>(1);
@@ -38,7 +39,12 @@ void kernel_main() {
     constexpr uint32_t cb_repack_out = tt::CBIndex::c_12;
     constexpr uint32_t cb_out0 = tt::CBIndex::c_16;
 
-    constexpr uint32_t TILE_WIDTH = 32;
+    constexpr uint32_t single_tile_size_bytes = get_tile_size(cb_ex_partial);
+
+    // This is the stride between two consecutive local means/variances in the cb_ex_partial
+    constexpr uint32_t local_stride = 2;
+    constexpr uint32_t single_row_size_bytes = single_tile_size_bytes / tt::constants::TILE_HEIGHT;
+    constexpr uint32_t local_stride_per_group = local_stride * single_row_size_bytes;
 
 #if defined(READER_REPACK) and defined(TILIZE_IN)
     uint32_t in0_l1_read_addr = get_read_ptr(cb_in0);
@@ -46,7 +52,7 @@ void kernel_main() {
     for (uint32_t m = 0; m < per_core_M; ++m) {
         cb_reserve_back(cb_repack, per_core_N);
         uint32_t l1_write_addr_repack = get_write_ptr(cb_repack);
-        for (uint32_t i = 0; i < TILE_HEIGHT; ++i) {
+        for (uint32_t i = 0; i < tt::constants::TILE_HEIGHT; ++i) {
             noc_async_read(noc_addr_in0, l1_write_addr_repack, per_core_N_bytes);
             noc_addr_in0 += per_core_N_bytes;
             l1_write_addr_repack += per_core_N_bytes_with_stride;
@@ -56,33 +62,60 @@ void kernel_main() {
     }
 #endif
 
-    for (uint32_t i = 0; i < num_batch_group; ++i) {
-        // wait for local data ready
-        cb_reserve_back(cb_ex_global, 2);
-        cb_wait_front(cb_ex_partial, 2);
-
+    for (uint32_t i = 0; i < num_batches; ++i) {
         // Read mean and variance arrays from cb_ex_partial, then combine using Welford
-        auto p_local_means = reinterpret_cast<volatile uint16_t*>(get_read_ptr(cb_ex_partial));
-        auto p_local_vars = p_local_means + TILE_WIDTH * TILE_HEIGHT;
 
-        auto local_result = combine_welford_stats<TILE_WIDTH, block_hw * TILE_WIDTH, 2>(p_local_means, p_local_vars);
+        // wait for local data ready
+        cb_wait_front(cb_ex_partial, 2);
+        auto local_means_ptr = get_read_ptr(cb_ex_partial);
+        auto local_vars_ptr = local_means_ptr + single_tile_size_bytes;
 
-        // Write this to cb_ex_global
-        auto p_global_means = reinterpret_cast<volatile uint16_t*>(get_write_ptr(cb_ex_global));
-        auto p_global_vars = p_global_means + TILE_WIDTH * TILE_HEIGHT;
-        p_global_means[0] = local_result.mean;
-        p_global_vars[0] = local_result.variance;
+        cb_reserve_back(cb_ex_global, 2 * num_groups);
+        auto global_means_ptr = get_write_ptr(cb_ex_global);
+        auto global_vars_ptr = global_means_ptr + single_tile_size_bytes;
 
-        // Signal to sender that our partial data is ready
-        noc_semaphore_inc(reduce_receiver_semaphore_noc_addr, 1);
+        for (uint32_t m = 0; m < num_groups; ++m) {
+            auto p_local_means = reinterpret_cast<volatile uint16_t*>(local_means_ptr);
+            auto p_local_vars = reinterpret_cast<volatile uint16_t*>(local_vars_ptr);
 
-        // Wait for sender to signal that it has sent the global data
-        noc_semaphore_wait(reduce_sender_semaphore_addr_ptr, VALID);
-        noc_semaphore_set(reduce_sender_semaphore_addr_ptr, INVALID);
+            auto local_result =
+                combine_welford_stats<tt::constants::TILE_WIDTH, block_hw * tt::constants::TILE_WIDTH, local_stride>(
+                    p_local_means, p_local_vars);
 
-        // Push the global data to cb_ex_global
-        cb_push_back(cb_ex_global, 2);
+            // DPRINT << "p_local_means: " << ENDL();
+            for (uint32_t idx = 0; idx < tt::constants::TILE_WIDTH; ++idx) {
+                // DPRINT << BF16(p_local_means[2 * idx]) << " ";
+            }
+            // DPRINT << ENDL();
+            // DPRINT << "local_result.mean: " << BF16(local_result.mean) << ENDL();
+            // DPRINT << "p_local_vars: " << ENDL();
+            for (uint32_t idx = 0; idx < tt::constants::TILE_WIDTH; ++idx) {
+                // DPRINT << BF16(p_local_vars[2 * idx]) << " ";
+            }
+            // DPRINT << ENDL();
+            // DPRINT << "local_result.variance: " << BF16(local_result.variance) << ENDL();
+
+            // Write this to cb_ex_global
+            auto p_global_means = reinterpret_cast<volatile uint16_t*>(global_means_ptr);
+            auto p_global_vars = reinterpret_cast<volatile uint16_t*>(global_vars_ptr);
+            p_global_means[0] = local_result.mean;
+            p_global_vars[0] = local_result.variance;
+
+            // Signal to sender that our partial data is ready
+            noc_semaphore_inc(reduce_receiver_semaphore_noc_addr, 1);
+
+            // Wait for sender to signal that it has sent the global data
+            noc_semaphore_wait(reduce_sender_semaphore_addr_ptr, VALID);
+            noc_semaphore_set(reduce_sender_semaphore_addr_ptr, INVALID);
+
+            local_means_ptr += local_stride_per_group;
+            local_vars_ptr += local_stride_per_group;
+            global_means_ptr += 2 * single_tile_size_bytes;
+            global_vars_ptr += 2 * single_tile_size_bytes;
+        }
+
         cb_pop_front(cb_ex_partial, 2);
+        cb_push_back(cb_ex_global, 2 * num_groups);
     }
 
 #if defined(READER_REPACK) and defined(UNTILIZE_OUT)
@@ -91,7 +124,7 @@ void kernel_main() {
         cb_wait_front(cb_repack_out, per_core_N);
         uint32_t in0_l1_read_addr = get_read_ptr(cb_repack_out);
         uint64_t noc_addr_in0 = get_noc_addr(in0_l1_read_addr);
-        for (uint32_t i = 0; i < TILE_HEIGHT; ++i) {
+        for (uint32_t i = 0; i < tt::constants::TILE_HEIGHT; ++i) {
             noc_async_read(noc_addr_in0, l1_write_addr_repack, per_core_N_bytes);
             noc_addr_in0 += per_core_N_bytes_with_stride;
             l1_write_addr_repack += per_core_N_bytes;

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_reader_mcast_sender_unary_gn.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_reader_mcast_sender_unary_gn.cpp
@@ -21,37 +21,22 @@ void kernel_main() {
     constexpr uint32_t per_core_N = get_named_compile_time_arg_val("per_core_N");
     const uint32_t per_core_N_bytes = get_named_compile_time_arg_val("per_core_N_bytes");
     const uint32_t per_core_N_bytes_with_stride = get_named_compile_time_arg_val("per_core_N_bytes_with_stride");
-    constexpr uint32_t datum_size_bytes = get_named_compile_time_arg_val("datum_size_bytes");
     constexpr uint32_t per_core_M = get_named_compile_time_arg_val("per_core_M");
-    constexpr uint32_t TILE_HEIGHT = get_named_compile_time_arg_val("TILE_HEIGHT");
 
     constexpr uint32_t block_h = get_named_compile_time_arg_val("block_h");
     constexpr uint32_t block_w = get_named_compile_time_arg_val("block_w");
-    constexpr uint32_t block_hw = get_named_compile_time_arg_val("block_hw");
 
-    constexpr uint32_t num_cols_per_group = get_named_compile_time_arg_val("num_cols_per_group");
     constexpr uint32_t num_tiles_per_batch = get_named_compile_time_arg_val("num_tiles_per_batch");
 
-    constexpr uint32_t block_w_last = get_named_compile_time_arg_val("block_w_last");
-    constexpr uint32_t GROUP_SIZE_IS_POWER_OF_2 = get_named_compile_time_arg_val("GROUP_SIZE_IS_POWER_OF_2");
-    constexpr uint32_t GROUP_SIZE_SMALLER_THAN_TILE_W = get_named_compile_time_arg_val("GROUP_SIZE_SMALLER_THAN_TILE_W");
-    constexpr uint32_t group_row_offset = get_named_compile_time_arg_val("group_row_offset");
     constexpr uint32_t num_out_blocks = get_named_compile_time_arg_val("num_out_blocks");
     // These are numbers in absolute terms, on a per batch, per group, per core basis without tiling
     constexpr uint32_t num_channels_per_group = get_named_compile_time_arg_val("num_channels_per_group");
     constexpr uint32_t num_rows_per_group = get_named_compile_time_arg_val("num_rows_per_group");
 
     constexpr auto src0_args = TensorAccessorArgs<0>();
-    constexpr auto out_args = TensorAccessorArgs<src0_args.next_compile_time_args_offset()>();
-
-    constexpr uint32_t block_w_minus_one = block_w - 1;
-    constexpr uint32_t block_w_minus_two = block_w - 2;
-    constexpr uint32_t tile_w_minux_group_size = tt::constants::TILE_WIDTH - num_cols_per_group;
 
     const uint32_t src_addr = get_arg_val<uint32_t>(0);
-    const uint32_t out_addr = get_arg_val<uint32_t>(1);
     const uint32_t start_id = get_arg_val<uint32_t>(2);
-    const uint32_t out_start_id = get_arg_val<uint32_t>(3);
     const uint32_t num_channels_tiles = get_arg_val<uint32_t>(4);
 
     const bool has_mcast_first_group = get_arg_val<uint32_t>(5);
@@ -186,6 +171,12 @@ void kernel_main() {
     constexpr uint32_t single_tile_size_bytes = get_tile_size(cb_ex_partial);
     constexpr uint32_t src0_tile_bytes = get_tile_size(cb_in0);
 
+    // This is the stride between two consecutive local means/variances in the cb_ex_partial
+    constexpr uint32_t local_stride = 2;
+    constexpr uint32_t global_stride = NOC_L1_READ_ALIGNMENT_BYTES / 2;
+    constexpr uint32_t single_row_size_bytes = single_tile_size_bytes / tt::constants::TILE_HEIGHT;
+    constexpr uint32_t local_stride_per_group = local_stride * single_row_size_bytes;
+
     const auto src_a = TensorAccessor(src0_args, src_addr, src0_tile_bytes);
 
 #if defined(READER_REPACK) and defined(TILIZE_IN)
@@ -194,7 +185,7 @@ void kernel_main() {
     for (uint32_t m = 0; m < per_core_M; ++m) {
         cb_reserve_back(cb_repack, per_core_N);
         uint32_t l1_write_addr_repack = get_write_ptr(cb_repack);
-        for (uint32_t i = 0; i < TILE_HEIGHT; ++i) {
+        for (uint32_t i = 0; i < tt::constants::TILE_HEIGHT; ++i) {
             noc_async_read(noc_addr_in0, l1_write_addr_repack, per_core_N_bytes);
             noc_addr_in0 += per_core_N_bytes;
             l1_write_addr_repack += per_core_N_bytes_with_stride;
@@ -219,60 +210,52 @@ void kernel_main() {
 
     uint32_t index_b_offset = 0;
     for (uint32_t b = 0; b < num_batches; ++b) {
-        uint32_t index_g_offset = 0;
-        uint32_t row_offset = num_cols_per_group;
+        uint32_t mt_offset = 0;
+        for (uint32_t out_block_index = 0; out_block_index < num_out_blocks_padded; out_block_index++) {
+            uint32_t out_block_h_actual, out_block_hw_actual;
+            if (extra_out_block && (out_block_index == (num_out_blocks_padded - 1))) {
+                out_block_h_actual = out_block_h_last;
+                out_block_hw_actual = out_block_hw_last;
+            } else {
+                out_block_h_actual = out_block_h_normal;
+                out_block_hw_actual = out_block_hw_normal;
+            }
+
+#if !defined(READER_REPACK) or !defined(TILIZE_IN)
+            for (uint32_t mt = 0; mt < out_block_h_actual; ++mt) {
+                for (uint32_t nt = 0; nt < per_core_N; ++nt) {
+                    cb_reserve_back(cb_in0, 1);
+                    const uint32_t l1_write_addr = get_write_ptr(cb_in0);
+                    noc_async_read_tile(start_id + index_b_offset + mt_offset + nt, src_a, l1_write_addr);
+                    noc_async_read_barrier();
+                    cb_push_back(cb_in0, 1);
+                }
+                mt_offset += num_channels_tiles;
+            }
+#endif
+        }
+
+        cb_wait_front(cb_ex_partial, 2);
+        auto local_means_ptr = get_read_ptr(cb_ex_partial);
+        auto local_vars_ptr = local_means_ptr + single_tile_size_bytes;
 
         cb_reserve_back(cb_ex_global, 2 * num_groups);
         auto global_means_ptr = get_write_ptr(cb_ex_global);
         auto global_vars_ptr = global_means_ptr + single_tile_size_bytes;
 
         for (uint32_t m = 0; m < num_groups; ++m) {
-            uint32_t out_block_start_id_offset = 0;
-            for (uint32_t out_block_index = 0; out_block_index < num_out_blocks_padded; out_block_index++) {
-                uint32_t out_block_h_actual, out_block_hw_actual;
-                if (extra_out_block && (out_block_index == (num_out_blocks_padded - 1))) {
-                    out_block_h_actual = out_block_h_last;
-                    out_block_hw_actual = out_block_hw_last;
-                } else {
-                    out_block_h_actual = out_block_h_normal;
-                    out_block_hw_actual = out_block_hw_normal;
-                }
-
-#if !defined(READER_REPACK) or !defined(TILIZE_IN)
-                cb_reserve_back(cb_in0, out_block_hw_normal);
-                uint32_t l1_write_addr = get_write_ptr(cb_in0);
-                uint32_t mt_offset = 0;
-                for (uint32_t mt = 0; mt < out_block_h_actual; mt++) {
-                    for (uint32_t nt = 0; nt < block_w; nt++) {
-                        noc_async_read_tile(
-                            start_id + index_b_offset + index_g_offset + out_block_start_id_offset + mt_offset + nt,
-                            src_a,
-                            l1_write_addr);
-                        l1_write_addr += src0_tile_bytes;
-                        noc_async_read_barrier();
-                    }
-                    mt_offset += num_channels_tiles;
-                }
-                cb_push_back(cb_in0, out_block_hw_normal);
-#endif
-                out_block_start_id_offset += out_block_h_actual * num_channels_tiles;
-            }
-
-            cb_wait_front(cb_ex_partial, 2);
-
             // Read mean and variance arrays from cb_ex_partial, then combine using Welford
-            auto local_read_ptr = get_read_ptr(cb_ex_partial);
-            auto p_local_means = reinterpret_cast<volatile uint16_t*>(local_read_ptr);
-            auto p_local_vars = reinterpret_cast<volatile uint16_t*>(local_read_ptr + single_tile_size_bytes);
+            auto p_local_means = reinterpret_cast<volatile uint16_t*>(local_means_ptr);
+            auto p_local_vars = reinterpret_cast<volatile uint16_t*>(local_vars_ptr);
 
             auto local_result = combine_welford_stats<
                 tt::constants::TILE_WIDTH,
                 num_channels_per_group * num_rows_per_group / tt::constants::TILE_WIDTH,
-                2>(p_local_means, p_local_vars);
+                local_stride>(p_local_means, p_local_vars);
 
             // Write this to cb_ex_global
-            volatile uint16_t* p_global_means = reinterpret_cast<volatile uint16_t*>(global_means_ptr);
-            volatile uint16_t* p_global_vars = reinterpret_cast<volatile uint16_t*>(global_vars_ptr);
+            auto p_global_means = reinterpret_cast<volatile uint16_t*>(global_means_ptr);
+            auto p_global_vars = reinterpret_cast<volatile uint16_t*>(global_vars_ptr);
             p_global_means[0] = local_result.mean;
             p_global_vars[0] = local_result.variance;
 
@@ -286,21 +269,17 @@ void kernel_main() {
                     uint64_t noc_vars_addr = get_noc_addr(noc_coord_x[i], noc_coord_y[i], global_vars_ptr);
                     noc_async_read_one_packet(
                         noc_means_addr,
-                        global_means_ptr + i * NOC_DRAM_READ_ALIGNMENT_BYTES,
-                        NOC_DRAM_READ_ALIGNMENT_BYTES);
+                        global_means_ptr + i * NOC_L1_READ_ALIGNMENT_BYTES,
+                        NOC_L1_READ_ALIGNMENT_BYTES);
                     noc_async_read_one_packet(
-                        noc_vars_addr,
-                        global_vars_ptr + i * NOC_DRAM_READ_ALIGNMENT_BYTES,
-                        NOC_DRAM_READ_ALIGNMENT_BYTES);
+                        noc_vars_addr, global_vars_ptr + i * NOC_L1_READ_ALIGNMENT_BYTES, NOC_L1_READ_ALIGNMENT_BYTES);
                 }
                 noc_async_read_barrier();
             }
 
-            cb_pop_front(cb_ex_partial, 2);
-
             // Read mean and variance arrays from cb_ex_global, then combine using Welford
             auto global_result =
-                combine_welford_stats<num_mcast_cores, num_channels_per_group * num_rows_per_group, 16>(
+                combine_welford_stats<num_mcast_cores, num_channels_per_group * num_rows_per_group, global_stride>(
                     p_global_means, p_global_vars);
 
             // Write this to cb_ex_global
@@ -348,44 +327,16 @@ void kernel_main() {
                 noc_async_write_barrier();
             }
 
+            local_means_ptr += local_stride_per_group;
+            local_vars_ptr += local_stride_per_group;
             global_means_ptr += 2 * single_tile_size_bytes;
             global_vars_ptr += 2 * single_tile_size_bytes;
-
-            if constexpr (GROUP_SIZE_IS_POWER_OF_2) {
-                if (row_offset == tt::constants::TILE_WIDTH) {
-                    index_g_offset += block_w;
-                    row_offset = num_cols_per_group;
-
-                } else {
-                    index_g_offset += block_w_minus_one;
-                    row_offset += num_cols_per_group;
-                }
-            } else if constexpr (GROUP_SIZE_SMALLER_THAN_TILE_W) {
-                if (row_offset == tt::constants::TILE_WIDTH) {
-                    index_g_offset += block_w_minus_one;
-                    row_offset = num_cols_per_group;
-
-                } else if (row_offset > tt::constants::TILE_WIDTH) {
-                    index_g_offset += block_w_minus_one;
-                    row_offset = row_offset + group_row_offset;
-
-                } else {
-                    row_offset += num_cols_per_group;
-                }
-            } else {
-                if (row_offset > tt::constants::TILE_WIDTH) {
-                    index_g_offset += block_w_minus_one;
-                    row_offset = row_offset - tile_w_minux_group_size;
-                } else {
-                    row_offset += num_cols_per_group;
-                    index_g_offset += block_w_minus_two;
-                }
-            }
         }
 
+        cb_pop_front(cb_ex_partial, 2);
         cb_push_back(cb_ex_global, 2 * num_groups);
 
-        uint32_t mt_offset = 0;
+        mt_offset = 0;
         for (uint32_t out_block_index = 0; out_block_index < num_out_blocks_padded; out_block_index++) {
             uint32_t out_block_h_actual, out_block_hw_actual;
             if (extra_out_block && (out_block_index == (num_out_blocks_padded - 1))) {

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_reader_mcast_sender_unary_gn.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_reader_mcast_sender_unary_gn.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -10,55 +10,6 @@
 #include "noc_parameters.h"
 
 void kernel_main() {
-    // clang-format off
-    // Definitions
-    //   block_h: This the length of the row we wish to processes in terms of tiles
-    //
-    //   out_block_...: This is the length of our Circular Buffer, sometimes the length of out tensors(block_h) are larger than L1 space, so we
-    //   have to process chunks of this data at a time
-    //   this chunk is called an out_block
-    //
-    //   num_out_blocks: This is the number of chunks specified by the use, such that a CBs (length defined by out_block) fit in L1
-    //   (Users should minimize the number of num_out_blocks for better perf)
-    //
-    //   ...normal:  If num_out_blocks evenly divides block_h, then all chunks are the size normal
-    //
-    //   ...last: If num_out_blocks does not divides block_h, the leftovers are put into a chunk of length last
-    //
-    //   sender: This refers to a core that does aggregation calculations
-    //   for the group of cores
-    //
-    //   receiver: This the cores that receive the aggregated results from sender, they only do
-    //   local computations that they send to the sender for final aggregation
-    //
-    // GROUPNORM SENDER DESCIPTION
-    // This is a high level desciption of the stages of this kernel, tags will be added to show where in the code each
-    // stage starts and ends
-    //
-    // Batch Loop:
-    //   Group Loop:
-    //     This is the process which repeats for every group
-    //     First Read of data:
-    //       If Receiver:
-    //           Send partial reduction of Average to Sender Core
-    //       If Sender:
-    //           Pack Partials:
-    //               Accumulate partial reductions into single tile
-    //               Calculates the Global average sum
-    //           Send Global:
-    //               Send Global Average to all Receiver cores
-    //     Second Read of data:
-    //       If Receiver:
-    //           Send partial reduction of Varience to Sender Core
-    //       If Sender:
-    //           Pack Partials:
-    //               Accumulate partial reductions into single tile
-    //               Calculates the Global Varience sum
-    //           Send Global:
-    //               Send Global Varience to all Receiver cores
-    //          Third Read of data:
-    //
-    //      // clang-format on
     uint32_t reduce_receiver_semaphore_addr = get_semaphore(get_named_compile_time_arg_val("reduce_receiver_semaphore_id"));
     uint32_t reduce_sender_semaphore_addr = get_semaphore(get_named_compile_time_arg_val("reduce_sender_semaphore_id"));
 
@@ -96,15 +47,12 @@ void kernel_main() {
     constexpr uint32_t block_w_minus_one = block_w - 1;
     constexpr uint32_t block_w_minus_two = block_w - 2;
     constexpr uint32_t tile_w_minux_group_size = tt::constants::TILE_WIDTH - num_cols_per_group;
-    uint32_t row_offset = num_cols_per_group;
-    uint32_t index_g_offset = 0;
-    uint32_t index_b_offset = 0;
 
-    uint32_t src_addr = get_arg_val<uint32_t>(0);
+    const uint32_t src_addr = get_arg_val<uint32_t>(0);
     const uint32_t out_addr = get_arg_val<uint32_t>(1);
-    uint32_t start_id = get_arg_val<uint32_t>(2);
+    const uint32_t start_id = get_arg_val<uint32_t>(2);
     const uint32_t out_start_id = get_arg_val<uint32_t>(3);
-    uint32_t num_channels_tiles = get_arg_val<uint32_t>(4);
+    const uint32_t num_channels_tiles = get_arg_val<uint32_t>(4);
 
     const bool has_mcast_first_group = get_arg_val<uint32_t>(5);
     const bool has_mcast_last_group = get_arg_val<uint32_t>(6);
@@ -126,7 +74,7 @@ void kernel_main() {
     uint32_t mcast_last_group_dest_noc_start_y;
     uint32_t mcast_last_group_dest_noc_end_x;
     uint32_t mcast_last_group_dest_noc_end_y;
-    // volatile tt_l1_ptr uint32_t * noc_coord;
+
     tt_l1_ptr uint32_t* noc_coord_x;
     tt_l1_ptr uint32_t* noc_coord_y;
 
@@ -222,24 +170,26 @@ void kernel_main() {
             0);
     }
 
-    volatile tt_l1_ptr uint32_t* reduce_sender_semaphore_addr_ptr =
+    const auto reduce_sender_semaphore_addr_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(reduce_sender_semaphore_addr);
     *reduce_sender_semaphore_addr_ptr = VALID;
-    volatile tt_l1_ptr uint32_t* reduce_receiver_semaphore_addr_ptr =
+    const auto reduce_receiver_semaphore_addr_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(reduce_receiver_semaphore_addr);
 
     constexpr uint32_t cb_ex_partial = tt::CBIndex::c_8;
-    constexpr uint32_t cb_ex_global = tt::CBIndex::c_15;  // E[x] global reduce
-    constexpr uint32_t cb_in0 = tt::CBIndex::c_0;  // sharded cb
+    constexpr uint32_t cb_ex_global = tt::CBIndex::c_15;
+    constexpr uint32_t cb_in0 = tt::CBIndex::c_0;
     constexpr uint32_t cb_repack = tt::CBIndex::c_26;
     constexpr uint32_t cb_repack_out = tt::CBIndex::c_31;
     constexpr uint32_t cb_out0 = tt::CBIndex::c_16;
-    constexpr uint32_t cb_reread_out = tt::CBIndex::c_23;
 
-    const uint32_t single_tile_size_bytes = get_tile_size(cb_ex_partial);
+    constexpr uint32_t single_tile_size_bytes = get_tile_size(cb_ex_partial);
+    constexpr uint32_t src0_tile_bytes = get_tile_size(cb_in0);
+
+    const auto src_a = TensorAccessor(src0_args, src_addr, src0_tile_bytes);
 
 #if defined(READER_REPACK) and defined(TILIZE_IN)
-    uint32_t in0_l1_read_addr = get_read_ptr(cb_in0);
+    const uint32_t in0_l1_read_addr = get_read_ptr(cb_in0);
     uint64_t noc_addr_in0 = get_noc_addr(in0_l1_read_addr);
     for (uint32_t m = 0; m < per_core_M; ++m) {
         cb_reserve_back(cb_repack, per_core_N);
@@ -254,120 +204,82 @@ void kernel_main() {
     }
 #endif
 
-    uint32_t out_block_h_normal = block_h / num_out_blocks;
-    uint32_t out_block_hw_normal = out_block_h_normal * block_w;
+    constexpr uint32_t out_block_h_normal = block_h / num_out_blocks;
+    constexpr uint32_t out_block_hw_normal = out_block_h_normal * block_w;
     uint32_t num_out_blocks_padded = num_out_blocks;
     uint32_t extra_out_block = false;
     uint32_t out_block_h_last = out_block_h_normal;
     uint32_t out_block_hw_last = out_block_hw_normal;
-    const uint32_t num_reads_of_input = 2;
     if constexpr (block_h % num_out_blocks != 0) {
         extra_out_block = true;
         num_out_blocks_padded++;
         out_block_h_last = block_h % num_out_blocks;
         out_block_hw_last = out_block_h_last * block_w;
     }
-    uint32_t cb_ex_external_tiles_required = num_out_blocks_padded * num_mcast_cores * 16 / single_tile_size_bytes;
-    if ((num_out_blocks_padded * num_mcast_cores * 16) % single_tile_size_bytes) {
-        cb_ex_external_tiles_required++;
-    }
 
-    index_b_offset = 0;
+    uint32_t index_b_offset = 0;
     for (uint32_t b = 0; b < num_batches; ++b) {
-        index_g_offset = 0;
-        row_offset = num_cols_per_group;
+        uint32_t index_g_offset = 0;
+        uint32_t row_offset = num_cols_per_group;
+
+        cb_reserve_back(cb_ex_global, 2 * num_groups);
+        auto global_means_ptr = get_write_ptr(cb_ex_global);
+        auto global_vars_ptr = global_means_ptr + single_tile_size_bytes;
 
         for (uint32_t m = 0; m < num_groups; ++m) {
-            // The following loop is for the 2 passes of input tensor required for GroupNorm
-            // First Pass: Calculates average and variance value
-            // Second Pass: Calculates final value
-            // Definition: num_read_of_input = 2
-            for (uint32_t cur_read_iteration = 0; cur_read_iteration < num_reads_of_input; ++cur_read_iteration) {
-                uint32_t out_block_start_id_offset = 0;
-                uint32_t cb_ex_external_bytes_written = 0;
-
-                for (uint32_t out_block_index = 0; out_block_index < num_out_blocks_padded; out_block_index++) {
-                        uint32_t out_block_h_actual, out_block_hw_actual;
-                    if (extra_out_block && (out_block_index == (num_out_blocks_padded - 1))) {
-                        out_block_h_actual = out_block_h_last;
-                            out_block_hw_actual = out_block_hw_last;
-                    } else {
-                        out_block_h_actual = out_block_h_normal;
-                            out_block_hw_actual = out_block_hw_normal;
-                    }
-
-#if !defined(READER_REPACK) or !defined(TILIZE_IN)
-                    const uint32_t src0_tile_bytes = get_tile_size(cb_in0);
-                    const auto src_a = TensorAccessor(src0_args, src_addr, src0_tile_bytes);
-                    uint32_t l1_write_addr;
-                    l1_write_addr = get_write_ptr(cb_in0);
-                    cb_reserve_back(cb_in0, out_block_hw_normal);
-                    for (uint32_t mt = 0; mt < out_block_h_actual; mt++) {
-                        for (uint32_t nt = 0; nt < block_w; nt++) {
-                            noc_async_read_tile(
-                                start_id + out_block_start_id_offset + (mt * num_channels_tiles) + nt +
-                                    index_b_offset + index_g_offset,
-                                src_a,
-                                l1_write_addr);
-                            l1_write_addr += src0_tile_bytes;
-                            noc_async_read_barrier();
-                        }
-                    }
-                    cb_push_back(cb_in0, out_block_hw_normal);
-#endif
-                    if (cur_read_iteration == 1) {
-                        const auto dst_a = TensorAccessor(out_args, out_addr, single_tile_size_bytes);
-
-                        // add or copy with previous output results
-                        uint32_t block_w_curr =
-                            index_g_offset == (per_core_N - block_w_last) ? block_w_last : block_w;
-
-                        const uint32_t dst_tile_bytes = get_tile_size(cb_reread_out);
-                        uint32_t l1_write_addr;
-                        l1_write_addr = get_write_ptr(cb_reread_out);
-                        cb_reserve_back(cb_reread_out, out_block_hw_normal);
-
-                        for (uint32_t mt = 0; mt < out_block_h_actual; mt++) {
-                            for (uint32_t nt = 0; nt < block_w_curr; nt++) {
-                                noc_async_read_tile(
-                                    out_start_id + out_block_start_id_offset + (mt * num_channels_tiles) + nt +
-                                        index_b_offset + index_g_offset,
-                                    dst_a,
-                                    l1_write_addr);
-                                l1_write_addr += dst_tile_bytes;
-                                noc_async_read_barrier();
-                            }
-                        }
-                        cb_push_back(cb_reread_out, out_block_hw_normal);
-                    }
-                    out_block_start_id_offset += out_block_h_actual * num_channels_tiles;
+            uint32_t out_block_start_id_offset = 0;
+            for (uint32_t out_block_index = 0; out_block_index < num_out_blocks_padded; out_block_index++) {
+                uint32_t out_block_h_actual, out_block_hw_actual;
+                if (extra_out_block && (out_block_index == (num_out_blocks_padded - 1))) {
+                    out_block_h_actual = out_block_h_last;
+                    out_block_hw_actual = out_block_hw_last;
+                } else {
+                    out_block_h_actual = out_block_h_normal;
+                    out_block_hw_actual = out_block_hw_normal;
                 }
 
-                if (cur_read_iteration == 0) {
-                    cb_reserve_back(cb_ex_global, 2);
-                    cb_wait_front(cb_ex_partial, 2);
+#if !defined(READER_REPACK) or !defined(TILIZE_IN)
+                cb_reserve_back(cb_in0, out_block_hw_normal);
+                uint32_t l1_write_addr = get_write_ptr(cb_in0);
+                uint32_t mt_offset = 0;
+                for (uint32_t mt = 0; mt < out_block_h_actual; mt++) {
+                    for (uint32_t nt = 0; nt < block_w; nt++) {
+                        noc_async_read_tile(
+                            start_id + index_b_offset + index_g_offset + out_block_start_id_offset + mt_offset + nt,
+                            src_a,
+                            l1_write_addr);
+                        l1_write_addr += src0_tile_bytes;
+                        noc_async_read_barrier();
+                    }
+                    mt_offset += num_channels_tiles;
+                }
+                cb_push_back(cb_in0, out_block_hw_normal);
+#endif
+                out_block_start_id_offset += out_block_h_actual * num_channels_tiles;
+            }
 
-                    // Read mean and variance arrays from cb_ex_partial, then combine using Welford
-                    auto local_read_ptr = get_read_ptr(cb_ex_partial);
-                    auto p_local_means = reinterpret_cast<volatile uint16_t*>(local_read_ptr);
-                    auto p_local_vars = reinterpret_cast<volatile uint16_t*>(local_read_ptr + single_tile_size_bytes);
+            cb_wait_front(cb_ex_partial, 2);
 
-                    auto local_result = combine_welford_stats<tt::constants::TILE_WIDTH, num_channels_per_group * num_rows_per_group / tt::constants::TILE_WIDTH, 2>(p_local_means, p_local_vars);
+            // Read mean and variance arrays from cb_ex_partial, then combine using Welford
+            auto local_read_ptr = get_read_ptr(cb_ex_partial);
+            auto p_local_means = reinterpret_cast<volatile uint16_t*>(local_read_ptr);
+            auto p_local_vars = reinterpret_cast<volatile uint16_t*>(local_read_ptr + single_tile_size_bytes);
 
-                    // Write this to cb_ex_global
-                    auto global_means_ptr = get_write_ptr(cb_ex_global);
-                    volatile uint16_t* p_global_means = reinterpret_cast<volatile uint16_t*>(global_means_ptr);
-                    auto global_vars_ptr = global_means_ptr + single_tile_size_bytes;
-                    volatile uint16_t* p_global_vars = reinterpret_cast<volatile uint16_t*>(global_vars_ptr);
-                    p_global_means[0] = local_result.mean;
-                    p_global_vars[0] = local_result.variance;
+            auto local_result = combine_welford_stats<
+                tt::constants::TILE_WIDTH,
+                num_channels_per_group * num_rows_per_group / tt::constants::TILE_WIDTH,
+                2>(p_local_means, p_local_vars);
 
-                    cb_pop_front(cb_ex_partial, 2);
+            // Write this to cb_ex_global
+            volatile uint16_t* p_global_means = reinterpret_cast<volatile uint16_t*>(global_means_ptr);
+            volatile uint16_t* p_global_vars = reinterpret_cast<volatile uint16_t*>(global_vars_ptr);
+            p_global_means[0] = local_result.mean;
+            p_global_vars[0] = local_result.variance;
 
-                    if constexpr (num_mcast_cores > 1) {
-                        // Wait until all other cores have signaled that their partial data is ready
-                        noc_semaphore_wait(reduce_receiver_semaphore_addr_ptr, num_mcast_cores - 1);
-                        noc_semaphore_set(reduce_receiver_semaphore_addr_ptr, 0);
+            if constexpr (num_mcast_cores > 1) {
+                // Wait until all other cores have signaled that their partial data is ready
+                noc_semaphore_wait(reduce_receiver_semaphore_addr_ptr, num_mcast_cores - 1);
+                noc_semaphore_set(reduce_receiver_semaphore_addr_ptr, 0);
 
                         for (uint32_t i = 1; i < num_mcast_cores; ++i) {
                             uint64_t noc_means_addr =
@@ -384,57 +296,54 @@ void kernel_main() {
                     constexpr uint32_t stride = NOC_L1_READ_ALIGNMENT_BYTES / 2;
                     auto global_result = combine_welford_stats<num_mcast_cores, num_channels_per_group * num_rows_per_group, stride>(p_global_means, p_global_vars);
 
-                    // Write this to cb_ex_global
-                    p_global_means[0] = global_result.mean;
-                    p_global_vars[0] = global_result.variance;
+            // Write this to cb_ex_global
+            p_global_means[0] = global_result.mean;
+            p_global_vars[0] = global_result.variance;
 
-                    if constexpr (num_mcast_cores > 1) {
-                        // mcast to other cores
-                        noc_async_write_multicast(
-                            global_means_ptr,
-                            multicast_data_noc | global_means_ptr,
-                            2 * single_tile_size_bytes,
-                            num_mcast_cores_mid_group,
-                            true);
-                        noc_semaphore_set_multicast(
-                            reduce_sender_semaphore_addr,
-                            reduce_sender_semaphore_noc_addr,
-                            num_mcast_cores_mid_group,
-                            false);
+            if constexpr (num_mcast_cores > 1) {
+                // mcast to other cores
+                noc_async_write_multicast(
+                    global_means_ptr,
+                    multicast_data_noc | global_means_ptr,
+                    2 * single_tile_size_bytes,
+                    num_mcast_cores_mid_group,
+                    true);
+                noc_semaphore_set_multicast(
+                    reduce_sender_semaphore_addr, reduce_sender_semaphore_noc_addr, num_mcast_cores_mid_group, false);
 
-                        if (has_mcast_first_group) {
-                            noc_async_write_multicast(
-                                global_means_ptr,
-                                multicast_first_group_data_noc | global_means_ptr,
-                                2 * single_tile_size_bytes,
-                                num_mcast_cores_first_group,
-                                true);
-                            noc_semaphore_set_multicast(
-                                reduce_sender_semaphore_addr,
-                                reduce_sender_first_group_semaphore_noc_addr,
-                                num_mcast_cores_first_group,
-                                false);
-                        }
-
-                        if (has_mcast_last_group) {
-                            noc_async_write_multicast(
-                                global_means_ptr,
-                                multicast_last_group_data_noc | global_means_ptr,
-                                2 * single_tile_size_bytes,
-                                num_mcast_cores_last_group,
-                                true);
-                            noc_semaphore_set_multicast(
-                                reduce_sender_semaphore_addr,
-                                reduce_sender_last_group_semaphore_noc_addr,
-                                num_mcast_cores_last_group,
-                                false);
-                        }
-                        noc_async_write_barrier();
-                    }
-
-                    cb_push_back(cb_ex_global, 2);
+                if (has_mcast_first_group) {
+                    noc_async_write_multicast(
+                        global_means_ptr,
+                        multicast_first_group_data_noc | global_means_ptr,
+                        2 * single_tile_size_bytes,
+                        num_mcast_cores_first_group,
+                        true);
+                    noc_semaphore_set_multicast(
+                        reduce_sender_semaphore_addr,
+                        reduce_sender_first_group_semaphore_noc_addr,
+                        num_mcast_cores_first_group,
+                        false);
                 }
+
+                if (has_mcast_last_group) {
+                    noc_async_write_multicast(
+                        global_means_ptr,
+                        multicast_last_group_data_noc | global_means_ptr,
+                        2 * single_tile_size_bytes,
+                        num_mcast_cores_last_group,
+                        true);
+                    noc_semaphore_set_multicast(
+                        reduce_sender_semaphore_addr,
+                        reduce_sender_last_group_semaphore_noc_addr,
+                        num_mcast_cores_last_group,
+                        false);
+                }
+                noc_async_write_barrier();
             }
+
+            global_means_ptr += 2 * single_tile_size_bytes;
+            global_vars_ptr += 2 * single_tile_size_bytes;
+
             if constexpr (GROUP_SIZE_IS_POWER_OF_2) {
                 if (row_offset == tt::constants::TILE_WIDTH) {
                     index_g_offset += block_w;
@@ -466,6 +375,32 @@ void kernel_main() {
                 }
             }
         }
+
+        cb_push_back(cb_ex_global, 2 * num_groups);
+
+        uint32_t mt_offset = 0;
+        for (uint32_t out_block_index = 0; out_block_index < num_out_blocks_padded; out_block_index++) {
+            uint32_t out_block_h_actual, out_block_hw_actual;
+            if (extra_out_block && (out_block_index == (num_out_blocks_padded - 1))) {
+                out_block_h_actual = out_block_h_last;
+                out_block_hw_actual = out_block_hw_last;
+            } else {
+                out_block_h_actual = out_block_h_normal;
+                out_block_hw_actual = out_block_hw_normal;
+            }
+#if !defined(READER_REPACK) or !defined(TILIZE_IN)
+            for (uint32_t mt = 0; mt < out_block_h_actual; ++mt) {
+                for (uint32_t nt = 0; nt < per_core_N; ++nt) {
+                    cb_reserve_back(cb_in0, 1);
+                    const uint32_t l1_write_addr = get_write_ptr(cb_in0);
+                    noc_async_read_tile(start_id + index_b_offset + mt_offset + nt, src_a, l1_write_addr);
+                    noc_async_read_barrier();
+                    cb_push_back(cb_in0, 1);
+                }
+                mt_offset += num_channels_tiles;
+            }
+#endif
+        }
         index_b_offset += num_tiles_per_batch;
     }
 
@@ -473,7 +408,7 @@ void kernel_main() {
     uint32_t l1_write_addr_repack = get_write_ptr(cb_out0);
     for (uint32_t m = 0; m < per_core_M; ++m) {
         cb_wait_front(cb_repack_out, per_core_N);
-        uint32_t in0_l1_read_addr = get_read_ptr(cb_repack_out);
+        const uint32_t in0_l1_read_addr = get_read_ptr(cb_repack_out);
         uint64_t noc_addr_in0 = get_noc_addr(in0_l1_read_addr);
         for (uint32_t i = 0; i < tt::constants::TILE_HEIGHT; ++i) {
             noc_async_read(noc_addr_in0, l1_write_addr_repack, per_core_N_bytes);

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_reader_mcast_sender_unary_gn.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_reader_mcast_sender_unary_gn.cpp
@@ -21,21 +21,13 @@ void kernel_main() {
     constexpr uint32_t per_core_N = get_named_compile_time_arg_val("per_core_N");
     const uint32_t per_core_N_bytes = get_named_compile_time_arg_val("per_core_N_bytes");
     const uint32_t per_core_N_bytes_with_stride = get_named_compile_time_arg_val("per_core_N_bytes_with_stride");
-    constexpr uint32_t datum_size_bytes = get_named_compile_time_arg_val("datum_size_bytes");
     constexpr uint32_t per_core_M = get_named_compile_time_arg_val("per_core_M");
-    constexpr uint32_t TILE_HEIGHT = get_named_compile_time_arg_val("TILE_HEIGHT");
 
     constexpr uint32_t block_h = get_named_compile_time_arg_val("block_h");
     constexpr uint32_t block_w = get_named_compile_time_arg_val("block_w");
-    constexpr uint32_t block_hw = get_named_compile_time_arg_val("block_hw");
 
-    constexpr uint32_t num_cols_per_group = get_named_compile_time_arg_val("num_cols_per_group");
     constexpr uint32_t num_tiles_per_batch = get_named_compile_time_arg_val("num_tiles_per_batch");
 
-    constexpr uint32_t block_w_last = get_named_compile_time_arg_val("block_w_last");
-    constexpr uint32_t GROUP_SIZE_IS_POWER_OF_2 = get_named_compile_time_arg_val("GROUP_SIZE_IS_POWER_OF_2");
-    constexpr uint32_t GROUP_SIZE_SMALLER_THAN_TILE_W = get_named_compile_time_arg_val("GROUP_SIZE_SMALLER_THAN_TILE_W");
-    constexpr uint32_t group_row_offset = get_named_compile_time_arg_val("group_row_offset");
     constexpr uint32_t num_out_blocks = get_named_compile_time_arg_val("num_out_blocks");
     // These are numbers in absolute terms, on a per batch, per group, per core basis without tiling
     constexpr uint32_t num_channels_per_group = get_named_compile_time_arg_val("num_channels_per_group");
@@ -194,7 +186,7 @@ void kernel_main() {
     for (uint32_t m = 0; m < per_core_M; ++m) {
         cb_reserve_back(cb_repack, per_core_N);
         uint32_t l1_write_addr_repack = get_write_ptr(cb_repack);
-        for (uint32_t i = 0; i < TILE_HEIGHT; ++i) {
+        for (uint32_t i = 0; i < tt::constants::TILE_HEIGHT; ++i) {
             noc_async_read(noc_addr_in0, l1_write_addr_repack, per_core_N_bytes);
             noc_addr_in0 += per_core_N_bytes;
             l1_write_addr_repack += per_core_N_bytes_with_stride;

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_reader_mcast_sender_unary_gn.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_reader_mcast_sender_unary_gn.cpp
@@ -21,13 +21,21 @@ void kernel_main() {
     constexpr uint32_t per_core_N = get_named_compile_time_arg_val("per_core_N");
     const uint32_t per_core_N_bytes = get_named_compile_time_arg_val("per_core_N_bytes");
     const uint32_t per_core_N_bytes_with_stride = get_named_compile_time_arg_val("per_core_N_bytes_with_stride");
+    constexpr uint32_t datum_size_bytes = get_named_compile_time_arg_val("datum_size_bytes");
     constexpr uint32_t per_core_M = get_named_compile_time_arg_val("per_core_M");
+    constexpr uint32_t TILE_HEIGHT = get_named_compile_time_arg_val("TILE_HEIGHT");
 
     constexpr uint32_t block_h = get_named_compile_time_arg_val("block_h");
     constexpr uint32_t block_w = get_named_compile_time_arg_val("block_w");
+    constexpr uint32_t block_hw = get_named_compile_time_arg_val("block_hw");
 
+    constexpr uint32_t num_cols_per_group = get_named_compile_time_arg_val("num_cols_per_group");
     constexpr uint32_t num_tiles_per_batch = get_named_compile_time_arg_val("num_tiles_per_batch");
 
+    constexpr uint32_t block_w_last = get_named_compile_time_arg_val("block_w_last");
+    constexpr uint32_t GROUP_SIZE_IS_POWER_OF_2 = get_named_compile_time_arg_val("GROUP_SIZE_IS_POWER_OF_2");
+    constexpr uint32_t GROUP_SIZE_SMALLER_THAN_TILE_W = get_named_compile_time_arg_val("GROUP_SIZE_SMALLER_THAN_TILE_W");
+    constexpr uint32_t group_row_offset = get_named_compile_time_arg_val("group_row_offset");
     constexpr uint32_t num_out_blocks = get_named_compile_time_arg_val("num_out_blocks");
     // These are numbers in absolute terms, on a per batch, per group, per core basis without tiling
     constexpr uint32_t num_channels_per_group = get_named_compile_time_arg_val("num_channels_per_group");
@@ -186,7 +194,7 @@ void kernel_main() {
     for (uint32_t m = 0; m < per_core_M; ++m) {
         cb_reserve_back(cb_repack, per_core_N);
         uint32_t l1_write_addr_repack = get_write_ptr(cb_repack);
-        for (uint32_t i = 0; i < tt::constants::TILE_HEIGHT; ++i) {
+        for (uint32_t i = 0; i < TILE_HEIGHT; ++i) {
             noc_async_read(noc_addr_in0, l1_write_addr_repack, per_core_N_bytes);
             noc_addr_in0 += per_core_N_bytes;
             l1_write_addr_repack += per_core_N_bytes_with_stride;

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_reader_mcast_sender_unary_sharded_gn_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_reader_mcast_sender_unary_sharded_gn_v2.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <stdint.h>
+#include "tt-metalium/constants.hpp"
 #include "dataflow_api.h"
 #include "hostdevcommon/common_values.hpp"
 #include "welford_combine.h"
@@ -12,19 +13,16 @@ void kernel_main() {
     uint32_t reduce_sender_semaphore_addr = get_semaphore(get_compile_time_arg_val(1));
 
     constexpr uint32_t num_mcast_cores = get_compile_time_arg_val(2);
-    constexpr uint32_t num_batch_group = get_compile_time_arg_val(3);
+    constexpr uint32_t num_batches = get_compile_time_arg_val(3);
 
     constexpr uint32_t per_core_N = get_compile_time_arg_val(4);
     const uint32_t per_core_N_bytes = get_compile_time_arg_val(5);
     const uint32_t per_core_N_bytes_with_stride = get_compile_time_arg_val(6);
-    constexpr uint32_t datum_size_bytes = get_compile_time_arg_val(7);
     constexpr uint32_t per_core_M = get_compile_time_arg_val(8);
-    constexpr uint32_t TILE_HEIGHT = get_compile_time_arg_val(9);
 
     // These are numbers in absolute terms, on a per group, per batch, per core with tiling
     constexpr uint32_t block_hw = get_compile_time_arg_val(10);
-
-    constexpr uint32_t TILE_WIDTH = 32;
+    constexpr uint32_t num_groups = get_compile_time_arg_val(11);
 
     const bool has_mcast_first_group = get_arg_val<uint32_t>(0);
     const bool has_mcast_last_group = get_arg_val<uint32_t>(1);
@@ -156,8 +154,11 @@ void kernel_main() {
     constexpr uint32_t cb_repack_out = tt::CBIndex::c_12;
     constexpr uint32_t cb_out0 = tt::CBIndex::c_16;
 
-    const uint32_t single_tile_size_bytes = get_tile_size(cb_ex_partial);
-    const uint32_t num_bytes_read = datum_size_bytes;
+    constexpr uint32_t single_tile_size_bytes = get_tile_size(cb_ex_partial);
+    // This is the stride between two consecutive local means/variances in the cb_ex_partial
+    constexpr uint32_t local_stride = 2;
+    constexpr uint32_t single_row_size_bytes = single_tile_size_bytes / tt::constants::TILE_HEIGHT;
+    constexpr uint32_t local_stride_per_group = local_stride * single_row_size_bytes;
 
 #if defined(READER_REPACK) and defined(TILIZE_IN)
     uint32_t in0_l1_read_addr = get_read_ptr(cb_in0);
@@ -165,7 +166,7 @@ void kernel_main() {
     for (uint32_t m = 0; m < per_core_M; ++m) {
         cb_reserve_back(cb_repack, per_core_N);
         uint32_t l1_write_addr_repack = get_write_ptr(cb_repack);
-        for (uint32_t i = 0; i < TILE_HEIGHT; ++i) {
+        for (uint32_t i = 0; i < tt::constants::TILE_HEIGHT; ++i) {
             noc_async_read(noc_addr_in0, l1_write_addr_repack, per_core_N_bytes);
             noc_addr_in0 += per_core_N_bytes;
             l1_write_addr_repack += per_core_N_bytes_with_stride;
@@ -175,96 +176,134 @@ void kernel_main() {
     }
 #endif
 
-    for (uint32_t m = 0; m < num_batch_group; ++m) {
-        // wait for local data ready
-        cb_reserve_back(cb_ex_global, 2);
-        cb_wait_front(cb_ex_partial, 2);
-
+    for (uint32_t m = 0; m < num_batches; ++m) {
         // Read mean and variance arrays from cb_ex_partial, then combine using Welford
-        auto local_read_ptr = get_read_ptr(cb_ex_partial);
-        auto p_local_means = reinterpret_cast<volatile uint16_t*>(local_read_ptr);
-        auto p_local_vars = p_local_means + TILE_WIDTH * TILE_HEIGHT;
 
-        auto local_result = combine_welford_stats<TILE_WIDTH, block_hw * TILE_WIDTH, 2>(p_local_means, p_local_vars);
+        // wait for local data ready
+        cb_wait_front(cb_ex_partial, 2);
+        auto local_means_ptr = get_read_ptr(cb_ex_partial);
+        auto local_vars_ptr = local_means_ptr + single_tile_size_bytes;
 
-        // Write this to cb_ex_global
+        cb_reserve_back(cb_ex_global, 2 * num_groups);
         auto global_means_ptr = get_write_ptr(cb_ex_global);
-        auto p_global_means = reinterpret_cast<volatile uint16_t*>(global_means_ptr);
         auto global_vars_ptr = global_means_ptr + single_tile_size_bytes;
-        auto p_global_vars = reinterpret_cast<volatile uint16_t*>(global_vars_ptr);
-        p_global_means[0] = local_result.mean;
-        p_global_vars[0] = local_result.variance;
 
-        cb_pop_front(cb_ex_partial, 2);
+        for (uint32_t m = 0; m < num_groups; ++m) {
+            auto p_local_means = reinterpret_cast<volatile uint16_t*>(local_means_ptr);
+            auto p_local_vars = reinterpret_cast<volatile uint16_t*>(local_vars_ptr);
 
-        if constexpr (num_mcast_cores > 1) {
-            // wait for all other cores data ready
-            noc_semaphore_wait(reduce_receiver_semaphore_addr_ptr, num_mcast_cores - 1);
-            noc_semaphore_set(reduce_receiver_semaphore_addr_ptr, 0);
+            auto local_result =
+                combine_welford_stats<tt::constants::TILE_WIDTH, block_hw * tt::constants::TILE_WIDTH, local_stride>(
+                    p_local_means, p_local_vars);
 
-            for (uint32_t i = 1; i < num_mcast_cores; ++i) {
-                noc_async_read_one_packet(
+            // DPRINT << "p_local_means: " << ENDL();
+            for (uint32_t idx = 0; idx < tt::constants::TILE_WIDTH; ++idx) {
+                // DPRINT << BF16(p_local_means[2 * idx]) << " ";
+            }
+            // DPRINT << ENDL();
+            // DPRINT << "local_result.mean: " << BF16(local_result.mean) << ENDL();
+            // DPRINT << "p_local_vars: " << ENDL();
+            for (uint32_t idx = 0; idx < tt::constants::TILE_WIDTH; ++idx) {
+                // DPRINT << BF16(p_local_vars[2 * idx]) << " ";
+            }
+            // DPRINT << ENDL();
+            // DPRINT << "local_result.variance: " << BF16(local_result.variance) << ENDL();
+
+            // Write this to cb_ex_global
+            auto p_global_means = reinterpret_cast<volatile uint16_t*>(global_means_ptr);
+            auto p_global_vars = reinterpret_cast<volatile uint16_t*>(global_vars_ptr);
+            p_global_means[0] = local_result.mean;
+            p_global_vars[0] = local_result.variance;
+
+            if constexpr (num_mcast_cores > 1) {
+                // wait for all other cores data ready
+                noc_semaphore_wait(reduce_receiver_semaphore_addr_ptr, num_mcast_cores - 1);
+                noc_semaphore_set(reduce_receiver_semaphore_addr_ptr, 0);
+
+                for (uint32_t i = 1; i < num_mcast_cores; ++i) {
+                    noc_async_read_one_packet(
+                        multicast_data_noc | global_means_ptr,
+                        global_means_ptr + i * 2 * NOC_L1_READ_ALIGNMENT_BYTES,
+                        2 * NOC_L1_READ_ALIGNMENT_BYTES);
+                    noc_async_read_one_packet(
+                        multicast_data_noc | global_vars_ptr,
+                        global_vars_ptr + i * 2 * NOC_L1_READ_ALIGNMENT_BYTES,
+                        2 * NOC_L1_READ_ALIGNMENT_BYTES);
+                }
+                noc_async_read_barrier();
+            }
+
+            // Read mean and variance arrays from cb_ex_global, then combine using Welford
+            constexpr uint32_t stride = 2 * NOC_L1_READ_ALIGNMENT_BYTES / 2;
+            auto global_result =
+                combine_welford_stats<num_mcast_cores, block_hw * 32 * 32, stride>(p_global_means, p_global_vars);
+
+            DPRINT << "p_global_means: " << ENDL();
+            for (uint32_t idx = 0; idx < num_mcast_cores; ++idx) {
+                DPRINT << BF16(p_global_means[stride * idx]) << " ";
+            }
+            DPRINT << ENDL();
+            DPRINT << "global_result.mean: " << BF16(global_result.mean) << ENDL();
+
+            DPRINT << "p_global_vars: " << ENDL();
+            for (uint32_t idx = 0; idx < num_mcast_cores; ++idx) {
+                DPRINT << BF16(p_global_vars[stride * idx]) << " ";
+            }
+            DPRINT << ENDL();
+            DPRINT << "global_result.variance: " << BF16(global_result.variance) << ENDL();
+
+            // Write this to cb_ex_global
+            p_global_means[0] = global_result.mean;
+            p_global_vars[0] = global_result.variance;
+
+            // mcast to other cores
+            if constexpr (num_mcast_cores > 1) {
+                noc_async_write_multicast(
+                    global_means_ptr,
                     multicast_data_noc | global_means_ptr,
-                    global_means_ptr + i * NOC_DRAM_READ_ALIGNMENT_BYTES,
-                    NOC_DRAM_READ_ALIGNMENT_BYTES);
-                noc_async_read_one_packet(
-                    multicast_data_noc | global_vars_ptr,
-                    global_vars_ptr + i * NOC_DRAM_READ_ALIGNMENT_BYTES,
-                    NOC_DRAM_READ_ALIGNMENT_BYTES);
-            }
-            noc_async_read_barrier();
-        }
-
-        // Read mean and variance arrays from cb_ex_global, then combine using Welford
-        constexpr uint32_t stride = NOC_DRAM_READ_ALIGNMENT_BYTES / 2;
-        auto global_result =
-            combine_welford_stats<num_mcast_cores, block_hw * 32 * 32, stride>(p_global_means, p_global_vars);
-
-        // Write this to cb_ex_global
-        p_global_means[0] = global_result.mean;
-        p_global_vars[0] = global_result.variance;
-
-        // mcast to other cores
-        if constexpr (num_mcast_cores > 1) {
-            noc_async_write_multicast(
-                global_means_ptr,
-                multicast_data_noc | global_means_ptr,
-                num_bytes_read,
-                num_mcast_cores_mid_group,
-                true);
-            noc_semaphore_set_multicast(
-                reduce_sender_semaphore_addr, reduce_sender_semaphore_noc_addr, num_mcast_cores_mid_group, false);
-
-            if (has_mcast_first_group) {
-                noc_async_write_multicast(
-                    global_means_ptr,
-                    multicast_first_group_data_noc | global_means_ptr,
-                    num_bytes_read,
-                    num_mcast_cores_first_group,
+                    2 * single_tile_size_bytes,
+                    num_mcast_cores_mid_group,
                     true);
                 noc_semaphore_set_multicast(
-                    reduce_sender_semaphore_addr,
-                    reduce_sender_first_group_semaphore_noc_addr,
-                    num_mcast_cores_first_group,
-                    false);
+                    reduce_sender_semaphore_addr, reduce_sender_semaphore_noc_addr, num_mcast_cores_mid_group, false);
+
+                if (has_mcast_first_group) {
+                    noc_async_write_multicast(
+                        global_means_ptr,
+                        multicast_first_group_data_noc | global_means_ptr,
+                        2 * single_tile_size_bytes,
+                        num_mcast_cores_first_group,
+                        true);
+                    noc_semaphore_set_multicast(
+                        reduce_sender_semaphore_addr,
+                        reduce_sender_first_group_semaphore_noc_addr,
+                        num_mcast_cores_first_group,
+                        false);
+                }
+
+                if (has_mcast_last_group) {
+                    noc_async_write_multicast(
+                        global_means_ptr,
+                        multicast_last_group_data_noc | global_means_ptr,
+                        2 * single_tile_size_bytes,
+                        num_mcast_cores_last_group,
+                        true);
+                    noc_semaphore_set_multicast(
+                        reduce_sender_semaphore_addr,
+                        reduce_sender_last_group_semaphore_noc_addr,
+                        num_mcast_cores_last_group,
+                        false);
+                }
+                noc_async_write_barrier();
             }
 
-            if (has_mcast_last_group) {
-                noc_async_write_multicast(
-                    global_means_ptr,
-                    multicast_last_group_data_noc | global_means_ptr,
-                    num_bytes_read,
-                    num_mcast_cores_last_group,
-                    true);
-                noc_semaphore_set_multicast(
-                    reduce_sender_semaphore_addr,
-                    reduce_sender_last_group_semaphore_noc_addr,
-                    num_mcast_cores_last_group,
-                    false);
-            }
-            noc_async_write_barrier();
+            local_means_ptr += local_stride_per_group;
+            local_vars_ptr += local_stride_per_group;
+            global_means_ptr += 2 * single_tile_size_bytes;
+            global_vars_ptr += 2 * single_tile_size_bytes;
         }
-        cb_push_back(cb_ex_global, 2);
+        cb_pop_front(cb_ex_partial, 2);
+        cb_push_back(cb_ex_global, 2 * num_groups);
     }
 
 #if defined(READER_REPACK) and defined(UNTILIZE_OUT)
@@ -273,7 +312,7 @@ void kernel_main() {
         cb_wait_front(cb_repack_out, per_core_N);
         uint32_t in0_l1_read_addr = get_read_ptr(cb_repack_out);
         uint64_t noc_addr_in0 = get_noc_addr(in0_l1_read_addr);
-        for (uint32_t i = 0; i < TILE_HEIGHT; ++i) {
+        for (uint32_t i = 0; i < tt::constants::TILE_HEIGHT; ++i) {
             noc_async_read(noc_addr_in0, l1_write_addr_repack, per_core_N_bytes);
             noc_addr_in0 += per_core_N_bytes_with_stride;
             l1_write_addr_repack += per_core_N_bytes;

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_writer_unary_gn_rm_gb.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_writer_unary_gn_rm_gb.cpp
@@ -1,0 +1,221 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include "dataflow_api.h"
+#include "hostdevcommon/common_values.hpp"
+#include "tt-metalium/constants.hpp"
+#include "ttnn/deprecated/tt_dnn/kernels/dataflow/generate_reduce_scaler.hpp"
+#include "ttnn/deprecated/tt_dnn/kernels/dataflow/generate_bcast_scalar.hpp"
+
+void kernel_main() {
+    constexpr bool is_mcast_sender = get_named_compile_time_arg_val("is_mcast_sender") == 1;
+    constexpr bool fuse_gamma = get_named_compile_time_arg_val("fuse_gamma") == 1;
+    constexpr bool fuse_beta = get_named_compile_time_arg_val("fuse_beta") == 1;
+
+    constexpr uint32_t num_cols_tile_gamma_beta = get_named_compile_time_arg_val("num_cols_tile_gamma_beta");
+
+    constexpr uint32_t per_core_M = get_named_compile_time_arg_val("per_core_M");
+    constexpr uint32_t per_core_N = get_named_compile_time_arg_val("per_core_N");
+    constexpr uint32_t per_core_N_bytes = get_named_compile_time_arg_val("per_core_N_bytes");
+    constexpr uint32_t per_core_N_bytes_with_stride = get_named_compile_time_arg_val("per_core_N_bytes_with_stride");
+
+    constexpr uint32_t num_groups_per_core = get_named_compile_time_arg_val("num_groups_per_core");
+    constexpr uint32_t num_batches_per_core = get_named_compile_time_arg_val("num_batches_per_core");
+
+    constexpr uint32_t num_cols_per_group = get_named_compile_time_arg_val("num_cols_per_group");
+    constexpr uint32_t num_tiles_per_batch = get_named_compile_time_arg_val("num_tiles_per_batch");
+
+    constexpr uint32_t block_w_last = get_named_compile_time_arg_val("block_w_last");
+    constexpr uint32_t GROUP_SIZE_IS_POWER_OF_2 = get_named_compile_time_arg_val("GROUP_SIZE_IS_POWER_OF_2");
+    constexpr uint32_t GROUP_SIZE_SMALLER_THAN_TILE_W =
+        get_named_compile_time_arg_val("GROUP_SIZE_SMALLER_THAN_TILE_W");
+    constexpr uint32_t group_row_offset = get_named_compile_time_arg_val("group_row_offset");
+    constexpr uint32_t num_out_blocks = get_named_compile_time_arg_val("num_out_blocks");
+
+    constexpr uint32_t block_h = get_named_compile_time_arg_val("block_h");
+    constexpr uint32_t block_w = get_named_compile_time_arg_val("block_w");
+    constexpr uint32_t block_hw = get_named_compile_time_arg_val("block_hw");
+
+    constexpr uint32_t use_welford = get_named_compile_time_arg_val("groupnorm_mode") > 0;
+    constexpr uint32_t page_size = get_named_compile_time_arg_val("page_size");
+
+    constexpr auto out_args = TensorAccessorArgs<0>();
+    constexpr auto gamma_args = TensorAccessorArgs<out_args.next_compile_time_args_offset()>();
+    constexpr auto beta_args = TensorAccessorArgs<gamma_args.next_compile_time_args_offset()>();
+    constexpr auto input_mask_args = TensorAccessorArgs<beta_args.next_compile_time_args_offset()>();
+
+    constexpr uint32_t block_w_minus_one = block_w - 1;
+    constexpr uint32_t block_w_minus_two = block_w - 2;
+    constexpr uint32_t tile_w_minux_group_size = tt::constants::TILE_WIDTH - num_cols_per_group;
+
+    const uint32_t eps_val = get_arg_val<uint32_t>(2);
+    const uint32_t out_addr = get_arg_val<uint32_t>(3);
+    const uint32_t gamma_addr = get_arg_val<uint32_t>(4);
+    const uint32_t beta_addr = get_arg_val<uint32_t>(5);
+    const uint32_t input_mask_addr = get_arg_val<uint32_t>(6);
+    const uint32_t out_start_id = get_arg_val<uint32_t>(7);
+    const uint32_t gamma_tile_start_id = get_arg_val<uint32_t>(8);
+    const uint32_t beta_tile_start_id = get_arg_val<uint32_t>(9);
+    const uint32_t input_mask_tile_start_id = get_arg_val<uint32_t>(10);
+    const uint32_t num_channels_tiles = get_arg_val<uint32_t>(11);
+
+    constexpr uint32_t cb_eps = tt::CBIndex::c_3;
+    constexpr uint32_t cb_gamma = tt::CBIndex::c_5;
+    constexpr uint32_t cb_beta = tt::CBIndex::c_6;
+    constexpr uint32_t cb_input_mask = tt::CBIndex::c_28;
+    constexpr uint32_t cb_in = tt::CBIndex::c_29;
+
+    constexpr uint32_t single_tile_size_bytes = get_tile_size(cb_gamma);
+    constexpr uint32_t input_mask_single_tile_size_bytes = get_tile_size(cb_input_mask);
+
+    constexpr uint32_t cb_out0 = tt::CBIndex::c_16;
+#ifdef UNTILIZE_OUT
+    constexpr uint32_t cb_out = tt::CBIndex::c_30;
+#else
+    constexpr uint32_t cb_out =
+        (fuse_gamma or fuse_beta)
+            ? (((fuse_gamma and not fuse_beta) or (not fuse_gamma and fuse_beta)) ? cb_in : cb_out0)
+            : cb_out0;
+#endif
+
+    // input mask
+    const auto mask = TensorAccessor(input_mask_args, input_mask_addr, input_mask_single_tile_size_bytes);
+
+    constexpr uint32_t out_block_h_normal = block_h / num_out_blocks;
+    constexpr uint32_t out_block_hw_normal = out_block_h_normal * block_w;
+    uint32_t num_out_blocks_padded = num_out_blocks;
+    uint32_t extra_out_block = false;
+    uint32_t out_block_h_last = out_block_h_normal;
+    uint32_t out_block_hw_last = out_block_hw_normal;
+    if constexpr (block_h % num_out_blocks != 0) {
+        extra_out_block = true;
+        uint32_t residual = block_h - (num_out_blocks * out_block_h_normal);
+        num_out_blocks_padded += (residual / out_block_h_normal + 1);
+        out_block_h_last = residual % out_block_h_normal;
+        out_block_hw_last = out_block_h_last * block_w;
+    }
+
+    // Send eps, mask, gamma, and beta to the compute kernel
+    generate_bcast_col_scalar(cb_eps, eps_val);
+
+    cb_reserve_back(cb_input_mask, block_w * num_groups_per_core);
+    uint32_t l1_write_addr_input_mask = get_write_ptr(cb_input_mask);
+    uint32_t input_mask_tile_id = input_mask_tile_start_id;
+    for (uint32_t i = 0; i < num_groups_per_core; ++i) {
+        for (uint32_t j = 0; j < block_w; ++j) {
+            noc_async_read_tile(input_mask_tile_id, mask, l1_write_addr_input_mask);
+            input_mask_tile_id += 1;
+            noc_async_read_barrier();
+            l1_write_addr_input_mask += input_mask_single_tile_size_bytes;
+        }
+    }
+    cb_push_back(cb_input_mask, block_w * num_groups_per_core);
+
+    if constexpr (fuse_gamma) {
+        constexpr uint32_t gamma_tile_bytes = get_tile_size(cb_gamma);
+        const auto gamma = TensorAccessor(gamma_args, gamma_addr, page_size);
+
+        cb_reserve_back(cb_gamma, num_cols_tile_gamma_beta);
+
+        const uint32_t base_l1_write_addr_gamma = get_write_ptr(cb_gamma);
+        uint32_t l1_write_addr_gamma = base_l1_write_addr_gamma;
+
+        // We want this data to appear as the first row of the tile.
+        // This is 32B at the start of the first face, 32B at the start of the second face
+        // However we must read at a 64 byte granularity for Blackhole NOC compatibility on DRAM reads
+        // So instead of two 32B reads to the correct addresses, we read 64 bytes into the first face here
+        // Then later, copy the second set of 32 bytes into the start of the second face
+        // L1-L1 NOC transactions only need 16 byte alignment on BH, so this is legal after data is loaded
+        // to L1
+
+        // Read the first 64 bytes of the tile into the first face
+        for (uint32_t w = 0; w < num_cols_tile_gamma_beta; w++) {
+            uint32_t tile_id = gamma_tile_start_id + w;
+            uint64_t gamma_noc_addr = get_noc_addr(tile_id, gamma);
+
+            noc_async_read(gamma_noc_addr, l1_write_addr_gamma, 64);
+            l1_write_addr_gamma += gamma_tile_bytes;
+        }
+        noc_async_read_barrier();
+
+        // Copy the second set of 32 bytes into the second face
+        l1_write_addr_gamma = base_l1_write_addr_gamma;
+
+        for (uint32_t w = 0; w < num_cols_tile_gamma_beta; w++) {
+            uint64_t noc_read_addr = get_noc_addr(l1_write_addr_gamma + 32);
+            noc_async_read(noc_read_addr, l1_write_addr_gamma + 512, 32);
+            l1_write_addr_gamma += gamma_tile_bytes;
+        }
+
+        noc_async_read_barrier();
+        cb_push_back(cb_gamma, num_cols_tile_gamma_beta);
+    }
+
+    if constexpr (fuse_beta) {
+        // Just like gamma, we read at a 64 byte granularity for Blackhole NOC compatibility
+        // Then copy the second set of 32 bytes into the second face
+
+        constexpr uint32_t beta_tile_bytes = get_tile_size(cb_beta);
+        const auto beta = TensorAccessor(beta_args, beta_addr, page_size);
+
+        cb_reserve_back(cb_beta, num_cols_tile_gamma_beta);
+
+        const uint32_t base_l1_write_addr_beta = get_write_ptr(cb_beta);
+        uint32_t l1_write_addr_beta = base_l1_write_addr_beta;
+
+        // Read the first 64 bytes of the tile into the first face
+        for (uint32_t w = 0; w < num_cols_tile_gamma_beta; w++) {
+            uint32_t tile_id = beta_tile_start_id + w;
+            uint64_t beta_noc_addr = get_noc_addr(tile_id, beta);
+            noc_async_read(beta_noc_addr, l1_write_addr_beta, 64);
+            l1_write_addr_beta += beta_tile_bytes;
+        }
+        noc_async_read_barrier();
+
+        // Copy the second set of 32 bytes into the second face
+        l1_write_addr_beta = base_l1_write_addr_beta;
+
+        for (uint32_t w = 0; w < num_cols_tile_gamma_beta; w++) {
+            uint64_t noc_read_addr = get_noc_addr(l1_write_addr_beta + 32);
+            noc_async_read(noc_read_addr, l1_write_addr_beta + 512, 32);
+            l1_write_addr_beta += beta_tile_bytes;
+        }
+
+        noc_async_read_barrier();
+        cb_push_back(cb_beta, num_cols_tile_gamma_beta);
+    }
+
+    const auto dst_a = TensorAccessor(out_args, out_addr, single_tile_size_bytes);
+
+    uint32_t index_b_offset = 0;
+    for (uint32_t b = 0; b < num_batches_per_core; ++b) {
+        uint32_t out_block_index_offset = 0;
+        for (uint32_t out_block_index = 0; out_block_index < num_out_blocks_padded; out_block_index++) {
+            uint32_t out_block_h_actual, out_block_hw_actual;
+            if (extra_out_block && (out_block_index == (num_out_blocks_padded - 1))) {
+                out_block_h_actual = out_block_h_last;
+                out_block_hw_actual = out_block_hw_last;
+            } else {
+                out_block_h_actual = out_block_h_normal;
+                out_block_hw_actual = out_block_hw_normal;
+            }
+
+            uint32_t mt_offset = 0;
+            for (uint32_t mt = 0; mt < out_block_h_actual; mt++) {
+                for (uint32_t nt = 0; nt < per_core_N; ++nt) {
+                    cb_wait_front(cb_out, 1);
+                    const uint32_t l1_read_addr = get_read_ptr(cb_out);
+                    noc_async_write_tile(
+                        out_start_id + index_b_offset + out_block_index_offset + mt_offset + nt, dst_a, l1_read_addr);
+                    noc_async_write_barrier();
+                    cb_pop_front(cb_out, 1);
+                }
+                mt_offset += num_channels_tiles;
+            }
+            out_block_index_offset += out_block_h_actual * num_channels_tiles;
+        }
+        index_b_offset += num_tiles_per_batch;
+    }
+}

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_writer_unary_gn_rm_gb.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_writer_unary_gn_rm_gb.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <stdint.h>
+#include <cstdint>
 #include "dataflow_api.h"
 #include "hostdevcommon/common_values.hpp"
 #include "tt-metalium/constants.hpp"

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_writer_unary_sharded_gn_rm_gb_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_writer_unary_sharded_gn_rm_gb_v2.cpp
@@ -1,0 +1,115 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include "dataflow_api.h"
+#include "hostdevcommon/common_values.hpp"
+#include "ttnn/deprecated/tt_dnn/kernels/dataflow/generate_bcast_scalar.hpp"
+
+void kernel_main() {
+    constexpr bool is_mcast_sender = get_compile_time_arg_val(0) == 1;
+    constexpr bool fuse_gamma = get_compile_time_arg_val(1) == 1;
+    constexpr bool fuse_beta = get_compile_time_arg_val(2) == 1;
+
+    constexpr uint32_t num_cols_tile_gamma_beta = get_compile_time_arg_val(3);
+
+    constexpr uint32_t per_core_N = get_compile_time_arg_val(4);
+    constexpr uint32_t per_core_N_bytes = get_compile_time_arg_val(5);
+    constexpr uint32_t per_core_N_bytes_with_stride = get_compile_time_arg_val(6);
+
+    constexpr uint32_t num_groups_per_core = get_compile_time_arg_val(7);
+    constexpr uint32_t num_batches_per_core = get_compile_time_arg_val(8);
+    constexpr uint32_t block_w = get_compile_time_arg_val(9);
+
+    constexpr uint32_t size = get_compile_time_arg_val(10);
+
+    constexpr auto gamma_args = TensorAccessorArgs<11>();
+    constexpr auto beta_args = TensorAccessorArgs<gamma_args.next_compile_time_args_offset()>();
+    constexpr auto input_mask_args = TensorAccessorArgs<beta_args.next_compile_time_args_offset()>();
+
+    const uint32_t gamma_addr = get_arg_val<uint32_t>(3);
+    const uint32_t beta_addr = get_arg_val<uint32_t>(4);
+    const uint32_t input_mask_addr = get_arg_val<uint32_t>(5);
+
+    const uint32_t gamma_tile_start_id = get_arg_val<uint32_t>(7);
+    const uint32_t beta_tile_start_id = get_arg_val<uint32_t>(8);
+    const uint32_t input_mask_tile_start_id = get_arg_val<uint32_t>(9);
+
+    constexpr uint32_t cb_gamma = tt::CBIndex::c_5;
+    constexpr uint32_t cb_beta = tt::CBIndex::c_6;
+    constexpr uint32_t cb_out0 = tt::CBIndex::c_16;
+    constexpr uint32_t cb_input_mask = tt::CBIndex::c_7;
+    constexpr uint32_t cb_ones = tt::CBIndex::c_26;
+
+    const uint32_t single_tile_size_bytes = get_tile_size(cb_gamma);
+    const uint32_t input_mask_single_tile_size_bytes = get_tile_size(cb_input_mask);
+
+    // input mask
+    const auto mask = TensorAccessor(input_mask_args, input_mask_addr, input_mask_single_tile_size_bytes);
+
+    constexpr uint32_t eps_cb_id = tt::CBIndex::c_3;
+    const uint32_t eps = get_arg_val<uint32_t>(2);
+    generate_bcast_col_scalar(eps_cb_id, eps);
+
+    uint32_t input_mask_tile_id = input_mask_tile_start_id;
+    for (uint32_t i = 0; i < num_groups_per_core; ++i) {
+        cb_reserve_back(cb_input_mask, block_w);
+        uint32_t l1_write_addr_input_mask = get_write_ptr(cb_input_mask);
+        for (uint32_t j = 0; j < block_w; ++j) {
+            noc_async_read_tile(input_mask_tile_id, mask, l1_write_addr_input_mask);
+            l1_write_addr_input_mask += input_mask_single_tile_size_bytes;
+            input_mask_tile_id += 1;
+        }
+        noc_async_read_barrier();
+        cb_push_back(cb_input_mask, block_w);
+    }
+
+    if constexpr (fuse_gamma) {
+        constexpr uint32_t gamma_tile_bytes = get_tile_size(cb_gamma);
+        const auto gamma = TensorAccessor(gamma_args, gamma_addr, size);
+
+        cb_reserve_back(cb_gamma, num_cols_tile_gamma_beta);
+        auto l1_write_addr_gamma = get_write_ptr(cb_gamma);
+        for (uint32_t w = 0; w < num_cols_tile_gamma_beta; w++) {
+            uint32_t tile_id = gamma_tile_start_id + w;
+            uint64_t gamma_noc_addr = get_noc_addr(tile_id, gamma);
+#ifdef ARCH_BLACKHOLE
+            noc_async_read(gamma_noc_addr, l1_write_addr_gamma, 32 * 2);
+            gamma_noc_addr = get_noc_addr(l1_write_addr_gamma + 32);
+            noc_async_read_barrier();
+#else
+            noc_async_read(gamma_noc_addr, l1_write_addr_gamma, 32);
+            gamma_noc_addr += 32;
+#endif
+            noc_async_read(gamma_noc_addr, l1_write_addr_gamma + 512, 32);
+            l1_write_addr_gamma += gamma_tile_bytes;
+        }
+        noc_async_read_barrier();
+        cb_push_back(cb_gamma, num_cols_tile_gamma_beta);
+    }
+
+    if constexpr (fuse_beta) {
+        constexpr uint32_t beta_tile_bytes = get_tile_size(cb_beta);
+        const auto beta = TensorAccessor(beta_args, beta_addr, size);
+
+        cb_reserve_back(cb_beta, num_cols_tile_gamma_beta);
+        auto l1_write_addr_beta = get_write_ptr(cb_beta);
+        for (uint32_t w = 0; w < num_cols_tile_gamma_beta; w++) {
+            uint32_t tile_id = beta_tile_start_id + w;
+            uint64_t beta_noc_addr = get_noc_addr(tile_id, beta);
+#ifdef ARCH_BLACKHOLE
+            noc_async_read(beta_noc_addr, l1_write_addr_beta, 32 * 2);
+            beta_noc_addr = get_noc_addr(l1_write_addr_beta + 32);
+            noc_async_read_barrier();
+#else
+            noc_async_read(beta_noc_addr, l1_write_addr_beta, 32);
+            beta_noc_addr += 32;
+#endif
+            noc_async_read(beta_noc_addr, l1_write_addr_beta + 512, 32);
+            l1_write_addr_beta += beta_tile_bytes;
+        }
+        noc_async_read_barrier();
+        cb_push_back(cb_beta, num_cols_tile_gamma_beta);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_writer_unary_sharded_gn_rm_gb_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_writer_unary_sharded_gn_rm_gb_v2.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <stdint.h>
+#include "tt-metalium/constants.hpp"
 #include "dataflow_api.h"
 #include "hostdevcommon/common_values.hpp"
 #include "ttnn/deprecated/tt_dnn/kernels/dataflow/generate_bcast_scalar.hpp"
@@ -67,22 +68,38 @@ void kernel_main() {
 
     if constexpr (fuse_gamma) {
         constexpr uint32_t gamma_tile_bytes = get_tile_size(cb_gamma);
+        constexpr uint32_t gamma_element_bytes = gamma_tile_bytes / tt::constants::TILE_HW;
+        constexpr uint32_t gamma_face_bytes = gamma_element_bytes * tt::constants::FACE_HW;
+        constexpr uint32_t gamma_face_w_bytes = gamma_element_bytes * tt::constants::FACE_WIDTH;
         const auto gamma = TensorAccessor(gamma_args, gamma_addr, size);
 
         cb_reserve_back(cb_gamma, num_cols_tile_gamma_beta);
         auto l1_write_addr_gamma = get_write_ptr(cb_gamma);
+
+        // We want this data to appear as the first row of the tile.
+        // This is 32B at the start of the first face, 32B at the start of the second face
+        // However we must read at a 64 byte granularity for Blackhole NOC compatibility on DRAM reads
+        // So instead of two 32B reads to the correct addresses, we read 64 bytes into the first face here
+        // Then later, copy the second set of 32 bytes into the start of the second face
+        // L1-L1 NOC transactions only need 16 byte alignment on BH, so this is legal after data is loaded
+        // to L1
+
         for (uint32_t w = 0; w < num_cols_tile_gamma_beta; w++) {
             uint32_t tile_id = gamma_tile_start_id + w;
             uint64_t gamma_noc_addr = get_noc_addr(tile_id, gamma);
+
+            // Read the first 64 bytes of the tile into the first face
 #ifdef ARCH_BLACKHOLE
-            noc_async_read(gamma_noc_addr, l1_write_addr_gamma, 32 * 2);
-            gamma_noc_addr = get_noc_addr(l1_write_addr_gamma + 32);
+            noc_async_read(gamma_noc_addr, l1_write_addr_gamma, NOC_DRAM_READ_ALIGNMENT_BYTES);
+            gamma_noc_addr = get_noc_addr(l1_write_addr_gamma + gamma_face_w_bytes);
             noc_async_read_barrier();
 #else
-            noc_async_read(gamma_noc_addr, l1_write_addr_gamma, 32);
-            gamma_noc_addr += 32;
+            noc_async_read(gamma_noc_addr, l1_write_addr_gamma, gamma_face_w_bytes);
+            gamma_noc_addr += gamma_face_w_bytes;
 #endif
-            noc_async_read(gamma_noc_addr, l1_write_addr_gamma + 512, 32);
+
+            // Copy the second set of 32 bytes into the second face
+            noc_async_read(gamma_noc_addr, l1_write_addr_gamma + gamma_face_bytes, gamma_face_w_bytes);
             l1_write_addr_gamma += gamma_tile_bytes;
         }
         noc_async_read_barrier();
@@ -90,23 +107,34 @@ void kernel_main() {
     }
 
     if constexpr (fuse_beta) {
+        // Just like gamma, we read at a 64 byte granularity for Blackhole NOC compatibility
+        // Then copy the second set of 32 bytes into the second face
+
         constexpr uint32_t beta_tile_bytes = get_tile_size(cb_beta);
+        constexpr uint32_t beta_element_bytes = beta_tile_bytes / tt::constants::TILE_HW;
+        constexpr uint32_t beta_face_bytes = beta_element_bytes * tt::constants::FACE_HW;
+        constexpr uint32_t beta_face_w_bytes = beta_element_bytes * tt::constants::FACE_WIDTH;
         const auto beta = TensorAccessor(beta_args, beta_addr, size);
 
         cb_reserve_back(cb_beta, num_cols_tile_gamma_beta);
         auto l1_write_addr_beta = get_write_ptr(cb_beta);
+
         for (uint32_t w = 0; w < num_cols_tile_gamma_beta; w++) {
             uint32_t tile_id = beta_tile_start_id + w;
             uint64_t beta_noc_addr = get_noc_addr(tile_id, beta);
+
+            // Read the first 64 bytes of the tile into the first face
 #ifdef ARCH_BLACKHOLE
-            noc_async_read(beta_noc_addr, l1_write_addr_beta, 32 * 2);
-            beta_noc_addr = get_noc_addr(l1_write_addr_beta + 32);
+            noc_async_read(beta_noc_addr, l1_write_addr_beta, NOC_DRAM_READ_ALIGNMENT_BYTES);
+            beta_noc_addr = get_noc_addr(l1_write_addr_beta + beta_face_w_bytes);
             noc_async_read_barrier();
 #else
-            noc_async_read(beta_noc_addr, l1_write_addr_beta, 32);
-            beta_noc_addr += 32;
+            noc_async_read(beta_noc_addr, l1_write_addr_beta, beta_face_w_bytes);
+            beta_noc_addr += beta_face_w_bytes;
 #endif
-            noc_async_read(beta_noc_addr, l1_write_addr_beta + 512, 32);
+
+            // Copy the second set of 32 bytes into the second face
+            noc_async_read(beta_noc_addr, l1_write_addr_beta + beta_face_bytes, beta_face_w_bytes);
             l1_write_addr_beta += beta_tile_bytes;
         }
         noc_async_read_barrier();

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_writer_unary_sharded_gn_rm_gb_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_writer_unary_sharded_gn_rm_gb_v2.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <stdint.h>
+#include <cstdint>
 #include "tt-metalium/constants.hpp"
 #include "dataflow_api.h"
 #include "hostdevcommon/common_values.hpp"

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/writer_unary_gn_rm_gb.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/writer_unary_gn_rm_gb.cpp
@@ -5,6 +5,7 @@
 #include <stdint.h>
 #include "dataflow_api.h"
 #include "hostdevcommon/common_values.hpp"
+#include "tt-metalium/constants.hpp"
 #include "ttnn/deprecated/tt_dnn/kernels/dataflow/generate_reduce_scaler.hpp"
 #include "ttnn/deprecated/tt_dnn/kernels/dataflow/generate_bcast_scalar.hpp"
 
@@ -47,12 +48,9 @@ void kernel_main() {
 
     constexpr uint32_t block_w_minus_one = block_w - 1;
     constexpr uint32_t block_w_minus_two = block_w - 2;
-    constexpr uint32_t TILE_WIDTH = 32;
-    constexpr uint32_t tile_w_minux_group_size = TILE_WIDTH - num_cols_per_group;
-    uint32_t row_offset = num_cols_per_group;
-    uint32_t index_g_offset = 0;
-    uint32_t index_b_offset = 0;
+    constexpr uint32_t tile_w_minux_group_size = tt::constants::TILE_WIDTH - num_cols_per_group;
 
+    const uint32_t eps_val = get_arg_val<uint32_t>(2);
     const uint32_t out_addr = get_arg_val<uint32_t>(3);
     const uint32_t gamma_addr = get_arg_val<uint32_t>(4);
     const uint32_t beta_addr = get_arg_val<uint32_t>(5);
@@ -63,14 +61,14 @@ void kernel_main() {
     const uint32_t input_mask_tile_start_id = get_arg_val<uint32_t>(10);
     const uint32_t num_channels_tiles = get_arg_val<uint32_t>(11);
 
+    constexpr uint32_t cb_eps = tt::CBIndex::c_3;
     constexpr uint32_t cb_gamma = tt::CBIndex::c_5;
     constexpr uint32_t cb_beta = tt::CBIndex::c_6;
     constexpr uint32_t cb_input_mask = tt::CBIndex::c_28;
     constexpr uint32_t cb_in = tt::CBIndex::c_29;
 
-    // constexpr uint32_t block_w = 4;
-    const uint32_t single_tile_size_bytes = get_tile_size(cb_gamma);
-    const uint32_t input_mask_single_tile_size_bytes = get_tile_size(cb_input_mask);
+    constexpr uint32_t single_tile_size_bytes = get_tile_size(cb_gamma);
+    constexpr uint32_t input_mask_single_tile_size_bytes = get_tile_size(cb_input_mask);
 
     constexpr uint32_t cb_out0 = tt::CBIndex::c_16;
 #ifdef UNTILIZE_OUT
@@ -86,7 +84,7 @@ void kernel_main() {
     const auto mask = TensorAccessor(input_mask_args, input_mask_addr, input_mask_single_tile_size_bytes);
 
     constexpr uint32_t out_block_h_normal = block_h / num_out_blocks;
-    uint32_t out_block_hw_normal = out_block_h_normal * block_w;
+    constexpr uint32_t out_block_hw_normal = out_block_h_normal * block_w;
     uint32_t num_out_blocks_padded = num_out_blocks;
     uint32_t extra_out_block = false;
     uint32_t out_block_h_last = out_block_h_normal;
@@ -99,185 +97,124 @@ void kernel_main() {
         out_block_hw_last = out_block_h_last * block_w;
     }
 
-    index_b_offset = 0;
-    constexpr uint32_t row_tile_max_index = num_cols_tile_gamma_beta;
+    // Send eps, mask, gamma, and beta to the compute kernel
+    generate_bcast_col_scalar(cb_eps, eps_val);
 
-    for (uint32_t b = 0; b < num_batches_per_core; ++b) {
-        uint32_t input_mask_tile_id = input_mask_tile_start_id;
-        index_g_offset = 0;
-        row_offset = num_cols_per_group;
-
-        for (uint32_t i = 0; i < num_groups_per_core; ++i) {
-            cb_reserve_back(cb_input_mask, block_w);
-            uint32_t l1_write_addr_input_mask = get_write_ptr(cb_input_mask);
-            for (uint32_t j = 0; j < block_w; ++j) {
-                noc_async_read_tile(input_mask_tile_id, mask, l1_write_addr_input_mask);
-                l1_write_addr_input_mask += input_mask_single_tile_size_bytes;
-                input_mask_tile_id += 1;
-            }
+    cb_reserve_back(cb_input_mask, block_w * num_groups_per_core);
+    uint32_t l1_write_addr_input_mask = get_write_ptr(cb_input_mask);
+    uint32_t input_mask_tile_id = input_mask_tile_start_id;
+    for (uint32_t i = 0; i < num_groups_per_core; ++i) {
+        for (uint32_t j = 0; j < block_w; ++j) {
+            noc_async_read_tile(input_mask_tile_id, mask, l1_write_addr_input_mask);
+            input_mask_tile_id += 1;
             noc_async_read_barrier();
-            cb_push_back(cb_input_mask, block_w);
+            l1_write_addr_input_mask += input_mask_single_tile_size_bytes;
+        }
+    }
+    cb_push_back(cb_input_mask, block_w * num_groups_per_core);
 
-            if (i == 0 and b == 0) {
-                if constexpr (!use_welford) {
-                    constexpr uint32_t cb_in_2 = tt::CBIndex::c_2;
-                    const uint32_t scalar_w = get_arg_val<uint32_t>(1);
-                    generate_reduce_scaler(cb_in_2, scalar_w);
-                }
+    if constexpr (fuse_gamma) {
+        constexpr uint32_t gamma_tile_bytes = get_tile_size(cb_gamma);
+        const auto gamma = TensorAccessor(gamma_args, gamma_addr, page_size);
 
-                if constexpr (!use_welford && is_mcast_sender) {
-                    constexpr uint32_t cb_in_4 = tt::CBIndex::c_4;
-                    const uint32_t scalar_c = get_arg_val<uint32_t>(0);
-                    generate_reduce_scaler(cb_in_4, scalar_c);
-                }
+        cb_reserve_back(cb_gamma, num_cols_tile_gamma_beta);
 
-                constexpr uint32_t eps_cb_id = tt::CBIndex::c_3;
-                const uint32_t eps = get_arg_val<uint32_t>(2);
-                generate_bcast_col_scalar(eps_cb_id, eps);
+        const uint32_t base_l1_write_addr_gamma = get_write_ptr(cb_gamma);
+        uint32_t l1_write_addr_gamma = base_l1_write_addr_gamma;
 
-                if constexpr (fuse_gamma) {
-                    const uint32_t gamma_tile_bytes = get_tile_size(cb_gamma);
-                    const auto gamma = TensorAccessor(gamma_args, gamma_addr, page_size);
+        // We want this data to appear as the first row of the tile.
+        // This is 32B at the start of the first face, 32B at the start of the second face
+        // However we must read at a 64 byte granularity for Blackhole NOC compatibility on DRAM reads
+        // So instead of two 32B reads to the correct addresses, we read 64 bytes into the first face here
+        // Then later, copy the second set of 32 bytes into the start of the second face
+        // L1-L1 NOC transactions only need 16 byte alignment on BH, so this is legal after data is loaded
+        // to L1
 
-                    cb_reserve_back(cb_gamma, num_cols_tile_gamma_beta);
+        // Read the first 64 bytes of the tile into the first face
+        for (uint32_t w = 0; w < num_cols_tile_gamma_beta; w++) {
+            uint32_t tile_id = gamma_tile_start_id + w;
+            uint64_t gamma_noc_addr = get_noc_addr(tile_id, gamma);
 
-                    const uint32_t base_l1_write_addr_gamma = get_write_ptr(cb_gamma);
-                    uint32_t l1_write_addr_gamma = base_l1_write_addr_gamma;
+            noc_async_read(gamma_noc_addr, l1_write_addr_gamma, 64);
+            l1_write_addr_gamma += gamma_tile_bytes;
+        }
+        noc_async_read_barrier();
 
-                    // We want this data to appear as the first row of the tile.
-                    // This is 32B at the start of the first face, 32B at the start of the second face
-                    // However we must read at a 64 byte granularity for Blackhole NOC compatibility on DRAM reads
-                    // So instead of two 32B reads to the correct addresses, we read 64 bytes into the first face here
-                    // Then later, copy the second set of 32 bytes into the start of the second face
-                    // L1-L1 NOC transactions only need 16 byte alignment on BH, so this is legal after data is loaded
-                    // to L1
+        // Copy the second set of 32 bytes into the second face
+        l1_write_addr_gamma = base_l1_write_addr_gamma;
 
-                    // Read the first 64 bytes of the tile into the first face
-                    for (uint32_t w = 0; w < num_cols_tile_gamma_beta; w++) {
-                        uint32_t tile_id = gamma_tile_start_id + w;
-                        uint64_t gamma_noc_addr = get_noc_addr(tile_id, gamma);
+        for (uint32_t w = 0; w < num_cols_tile_gamma_beta; w++) {
+            uint64_t noc_read_addr = get_noc_addr(l1_write_addr_gamma + 32);
+            noc_async_read(noc_read_addr, l1_write_addr_gamma + 512, 32);
+            l1_write_addr_gamma += gamma_tile_bytes;
+        }
 
-                        noc_async_read(gamma_noc_addr, l1_write_addr_gamma, 64);
-                        l1_write_addr_gamma += gamma_tile_bytes;
-                    }
-                    noc_async_read_barrier();
+        noc_async_read_barrier();
+        cb_push_back(cb_gamma, num_cols_tile_gamma_beta);
+    }
 
-                    // Copy the second set of 32 bytes into the second face
-                    l1_write_addr_gamma = base_l1_write_addr_gamma;
+    if constexpr (fuse_beta) {
+        // Just like gamma, we read at a 64 byte granularity for Blackhole NOC compatibility
+        // Then copy the second set of 32 bytes into the second face
 
-                    for (uint32_t w = 0; w < num_cols_tile_gamma_beta; w++) {
-                        uint64_t noc_read_addr = get_noc_addr(l1_write_addr_gamma + 32);
-                        noc_async_read(noc_read_addr, l1_write_addr_gamma + 512, 32);
-                        l1_write_addr_gamma += gamma_tile_bytes;
-                    }
+        constexpr uint32_t beta_tile_bytes = get_tile_size(cb_beta);
+        const auto beta = TensorAccessor(beta_args, beta_addr, page_size);
 
-                    noc_async_read_barrier();
-                    cb_push_back(cb_gamma, num_cols_tile_gamma_beta);
-                }
+        cb_reserve_back(cb_beta, num_cols_tile_gamma_beta);
 
-                if constexpr (fuse_beta) {
-                    // Just like gamma, we read at a 64 byte granularity for Blackhole NOC compatibility
-                    // Then copy the second set of 32 bytes into the second face
+        const uint32_t base_l1_write_addr_beta = get_write_ptr(cb_beta);
+        uint32_t l1_write_addr_beta = base_l1_write_addr_beta;
 
-                    const uint32_t beta_tile_bytes = get_tile_size(cb_beta);
-                    const auto beta = TensorAccessor(beta_args, beta_addr, page_size);
+        // Read the first 64 bytes of the tile into the first face
+        for (uint32_t w = 0; w < num_cols_tile_gamma_beta; w++) {
+            uint32_t tile_id = beta_tile_start_id + w;
+            uint64_t beta_noc_addr = get_noc_addr(tile_id, beta);
+            noc_async_read(beta_noc_addr, l1_write_addr_beta, 64);
+            l1_write_addr_beta += beta_tile_bytes;
+        }
+        noc_async_read_barrier();
 
-                    cb_reserve_back(cb_beta, num_cols_tile_gamma_beta);
+        // Copy the second set of 32 bytes into the second face
+        l1_write_addr_beta = base_l1_write_addr_beta;
 
-                    const uint32_t base_l1_write_addr_beta = get_write_ptr(cb_beta);
-                    uint32_t l1_write_addr_beta = base_l1_write_addr_beta;
+        for (uint32_t w = 0; w < num_cols_tile_gamma_beta; w++) {
+            uint64_t noc_read_addr = get_noc_addr(l1_write_addr_beta + 32);
+            noc_async_read(noc_read_addr, l1_write_addr_beta + 512, 32);
+            l1_write_addr_beta += beta_tile_bytes;
+        }
 
-                    // Read the first 64 bytes of the tile into the first face
-                    for (uint32_t w = 0; w < num_cols_tile_gamma_beta; w++) {
-                        uint32_t tile_id = beta_tile_start_id + w;
-                        uint64_t beta_noc_addr = get_noc_addr(tile_id, beta);
-                        noc_async_read(beta_noc_addr, l1_write_addr_beta, 64);
-                        l1_write_addr_beta += beta_tile_bytes;
-                    }
-                    noc_async_read_barrier();
+        noc_async_read_barrier();
+        cb_push_back(cb_beta, num_cols_tile_gamma_beta);
+    }
 
-                    // Copy the second set of 32 bytes into the second face
-                    l1_write_addr_beta = base_l1_write_addr_beta;
+    const auto dst_a = TensorAccessor(out_args, out_addr, single_tile_size_bytes);
 
-                    for (uint32_t w = 0; w < num_cols_tile_gamma_beta; w++) {
-                        uint64_t noc_read_addr = get_noc_addr(l1_write_addr_beta + 32);
-                        noc_async_read(noc_read_addr, l1_write_addr_beta + 512, 32);
-                        l1_write_addr_beta += beta_tile_bytes;
-                    }
-
-                    noc_async_read_barrier();
-                    cb_push_back(cb_beta, num_cols_tile_gamma_beta);
-                }
-            }
-
-            // add or copy with previous output results
-            uint32_t block_w_curr = index_g_offset == (per_core_N - block_w_last) ? block_w_last : block_w;
-
-            const auto dst_a = TensorAccessor(out_args, out_addr, single_tile_size_bytes);
-
-            uint32_t out_block_start_id_offset = 0;
-            for (uint32_t out_block_index = 0; out_block_index < num_out_blocks_padded; out_block_index++) {
-                uint32_t out_block_h_actual, out_block_hw_actual;
-                if (extra_out_block && (out_block_index == (num_out_blocks_padded - 1))) {
-                    out_block_h_actual = out_block_h_last;
-                    out_block_hw_actual = out_block_hw_last;
-                } else {
-                    out_block_h_actual = out_block_h_normal;
-                    out_block_hw_actual = out_block_hw_normal;
-                }
-                cb_wait_front(cb_out, out_block_hw_normal);
-                uint32_t l1_read_addr = get_read_ptr(cb_out);
-
-                for (uint32_t mt = 0; mt < out_block_h_actual; mt++) {
-                    for (uint32_t nt = 0; nt < block_w_curr; nt++) {
-                        // Checks, only relevant to the last group, that we are not indexing out of bounds
-                        // for the cases where our last group does not span the length of our max tile span for a group
-                        if ((index_g_offset + nt) < row_tile_max_index) {
-                            noc_async_write_tile(
-                                out_start_id + out_block_start_id_offset + (mt * num_channels_tiles) + nt +
-                                    index_b_offset + index_g_offset,
-                                dst_a,
-                                l1_read_addr);
-                        }
-                        l1_read_addr += single_tile_size_bytes;
-                    }
-                    // l1_read_addr += (single_tile_size_bytes * (block_w-block_w_curr));
-                }
-                out_block_start_id_offset += out_block_h_actual * num_channels_tiles;
-                noc_async_write_barrier();
-                cb_pop_front(cb_out, out_block_hw_normal);
-            }
-
-            if constexpr (GROUP_SIZE_IS_POWER_OF_2) {
-                if (row_offset == TILE_WIDTH) {
-                    index_g_offset += block_w;
-                    row_offset = num_cols_per_group;
-
-                } else {
-                    index_g_offset += block_w_minus_one;
-                    row_offset += num_cols_per_group;
-                }
-            } else if constexpr (GROUP_SIZE_SMALLER_THAN_TILE_W) {
-                if (row_offset == TILE_WIDTH) {
-                    index_g_offset += block_w_minus_one;
-                    row_offset = num_cols_per_group;
-
-                } else if (row_offset > TILE_WIDTH) {
-                    index_g_offset += block_w_minus_one;
-                    row_offset = row_offset + group_row_offset;
-
-                } else {
-                    row_offset += num_cols_per_group;
-                }
+    uint32_t index_b_offset = 0;
+    for (uint32_t b = 0; b < num_batches_per_core; ++b) {
+        uint32_t out_block_index_offset = 0;
+        for (uint32_t out_block_index = 0; out_block_index < num_out_blocks_padded; out_block_index++) {
+            uint32_t out_block_h_actual, out_block_hw_actual;
+            if (extra_out_block && (out_block_index == (num_out_blocks_padded - 1))) {
+                out_block_h_actual = out_block_h_last;
+                out_block_hw_actual = out_block_hw_last;
             } else {
-                if (row_offset > TILE_WIDTH) {
-                    index_g_offset += block_w_minus_one;
-                    row_offset = row_offset - tile_w_minux_group_size;
-                } else {
-                    row_offset += num_cols_per_group;
-                    index_g_offset += block_w_minus_two;
-                }
+                out_block_h_actual = out_block_h_normal;
+                out_block_hw_actual = out_block_hw_normal;
             }
+
+            uint32_t mt_offset = 0;
+            for (uint32_t mt = 0; mt < out_block_h_actual; mt++) {
+                for (uint32_t nt = 0; nt < per_core_N; ++nt) {
+                    cb_wait_front(cb_out, 1);
+                    const uint32_t l1_read_addr = get_read_ptr(cb_out);
+                    noc_async_write_tile(
+                        out_start_id + index_b_offset + out_block_index_offset + mt_offset + nt, dst_a, l1_read_addr);
+                    noc_async_write_barrier();
+                    cb_pop_front(cb_out, 1);
+                }
+                mt_offset += num_channels_tiles;
+            }
+            out_block_index_offset += out_block_h_actual * num_channels_tiles;
         }
         index_b_offset += num_tiles_per_batch;
     }

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/writer_unary_gn_rm_gb.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/writer_unary_gn_rm_gb.cpp
@@ -5,7 +5,6 @@
 #include <stdint.h>
 #include "dataflow_api.h"
 #include "hostdevcommon/common_values.hpp"
-#include "tt-metalium/constants.hpp"
 #include "ttnn/deprecated/tt_dnn/kernels/dataflow/generate_reduce_scaler.hpp"
 #include "ttnn/deprecated/tt_dnn/kernels/dataflow/generate_bcast_scalar.hpp"
 
@@ -48,9 +47,12 @@ void kernel_main() {
 
     constexpr uint32_t block_w_minus_one = block_w - 1;
     constexpr uint32_t block_w_minus_two = block_w - 2;
-    constexpr uint32_t tile_w_minux_group_size = tt::constants::TILE_WIDTH - num_cols_per_group;
+    constexpr uint32_t TILE_WIDTH = 32;
+    constexpr uint32_t tile_w_minux_group_size = TILE_WIDTH - num_cols_per_group;
+    uint32_t row_offset = num_cols_per_group;
+    uint32_t index_g_offset = 0;
+    uint32_t index_b_offset = 0;
 
-    const uint32_t eps_val = get_arg_val<uint32_t>(2);
     const uint32_t out_addr = get_arg_val<uint32_t>(3);
     const uint32_t gamma_addr = get_arg_val<uint32_t>(4);
     const uint32_t beta_addr = get_arg_val<uint32_t>(5);
@@ -61,14 +63,14 @@ void kernel_main() {
     const uint32_t input_mask_tile_start_id = get_arg_val<uint32_t>(10);
     const uint32_t num_channels_tiles = get_arg_val<uint32_t>(11);
 
-    constexpr uint32_t cb_eps = tt::CBIndex::c_3;
     constexpr uint32_t cb_gamma = tt::CBIndex::c_5;
     constexpr uint32_t cb_beta = tt::CBIndex::c_6;
     constexpr uint32_t cb_input_mask = tt::CBIndex::c_28;
     constexpr uint32_t cb_in = tt::CBIndex::c_29;
 
-    constexpr uint32_t single_tile_size_bytes = get_tile_size(cb_gamma);
-    constexpr uint32_t input_mask_single_tile_size_bytes = get_tile_size(cb_input_mask);
+    // constexpr uint32_t block_w = 4;
+    const uint32_t single_tile_size_bytes = get_tile_size(cb_gamma);
+    const uint32_t input_mask_single_tile_size_bytes = get_tile_size(cb_input_mask);
 
     constexpr uint32_t cb_out0 = tt::CBIndex::c_16;
 #ifdef UNTILIZE_OUT
@@ -84,7 +86,7 @@ void kernel_main() {
     const auto mask = TensorAccessor(input_mask_args, input_mask_addr, input_mask_single_tile_size_bytes);
 
     constexpr uint32_t out_block_h_normal = block_h / num_out_blocks;
-    constexpr uint32_t out_block_hw_normal = out_block_h_normal * block_w;
+    uint32_t out_block_hw_normal = out_block_h_normal * block_w;
     uint32_t num_out_blocks_padded = num_out_blocks;
     uint32_t extra_out_block = false;
     uint32_t out_block_h_last = out_block_h_normal;
@@ -97,124 +99,185 @@ void kernel_main() {
         out_block_hw_last = out_block_h_last * block_w;
     }
 
-    // Send eps, mask, gamma, and beta to the compute kernel
-    generate_bcast_col_scalar(cb_eps, eps_val);
+    index_b_offset = 0;
+    constexpr uint32_t row_tile_max_index = num_cols_tile_gamma_beta;
 
-    cb_reserve_back(cb_input_mask, block_w * num_groups_per_core);
-    uint32_t l1_write_addr_input_mask = get_write_ptr(cb_input_mask);
-    uint32_t input_mask_tile_id = input_mask_tile_start_id;
-    for (uint32_t i = 0; i < num_groups_per_core; ++i) {
-        for (uint32_t j = 0; j < block_w; ++j) {
-            noc_async_read_tile(input_mask_tile_id, mask, l1_write_addr_input_mask);
-            input_mask_tile_id += 1;
-            noc_async_read_barrier();
-            l1_write_addr_input_mask += input_mask_single_tile_size_bytes;
-        }
-    }
-    cb_push_back(cb_input_mask, block_w * num_groups_per_core);
-
-    if constexpr (fuse_gamma) {
-        constexpr uint32_t gamma_tile_bytes = get_tile_size(cb_gamma);
-        const auto gamma = TensorAccessor(gamma_args, gamma_addr, page_size);
-
-        cb_reserve_back(cb_gamma, num_cols_tile_gamma_beta);
-
-        const uint32_t base_l1_write_addr_gamma = get_write_ptr(cb_gamma);
-        uint32_t l1_write_addr_gamma = base_l1_write_addr_gamma;
-
-        // We want this data to appear as the first row of the tile.
-        // This is 32B at the start of the first face, 32B at the start of the second face
-        // However we must read at a 64 byte granularity for Blackhole NOC compatibility on DRAM reads
-        // So instead of two 32B reads to the correct addresses, we read 64 bytes into the first face here
-        // Then later, copy the second set of 32 bytes into the start of the second face
-        // L1-L1 NOC transactions only need 16 byte alignment on BH, so this is legal after data is loaded
-        // to L1
-
-        // Read the first 64 bytes of the tile into the first face
-        for (uint32_t w = 0; w < num_cols_tile_gamma_beta; w++) {
-            uint32_t tile_id = gamma_tile_start_id + w;
-            uint64_t gamma_noc_addr = get_noc_addr(tile_id, gamma);
-
-            noc_async_read(gamma_noc_addr, l1_write_addr_gamma, 64);
-            l1_write_addr_gamma += gamma_tile_bytes;
-        }
-        noc_async_read_barrier();
-
-        // Copy the second set of 32 bytes into the second face
-        l1_write_addr_gamma = base_l1_write_addr_gamma;
-
-        for (uint32_t w = 0; w < num_cols_tile_gamma_beta; w++) {
-            uint64_t noc_read_addr = get_noc_addr(l1_write_addr_gamma + 32);
-            noc_async_read(noc_read_addr, l1_write_addr_gamma + 512, 32);
-            l1_write_addr_gamma += gamma_tile_bytes;
-        }
-
-        noc_async_read_barrier();
-        cb_push_back(cb_gamma, num_cols_tile_gamma_beta);
-    }
-
-    if constexpr (fuse_beta) {
-        // Just like gamma, we read at a 64 byte granularity for Blackhole NOC compatibility
-        // Then copy the second set of 32 bytes into the second face
-
-        constexpr uint32_t beta_tile_bytes = get_tile_size(cb_beta);
-        const auto beta = TensorAccessor(beta_args, beta_addr, page_size);
-
-        cb_reserve_back(cb_beta, num_cols_tile_gamma_beta);
-
-        const uint32_t base_l1_write_addr_beta = get_write_ptr(cb_beta);
-        uint32_t l1_write_addr_beta = base_l1_write_addr_beta;
-
-        // Read the first 64 bytes of the tile into the first face
-        for (uint32_t w = 0; w < num_cols_tile_gamma_beta; w++) {
-            uint32_t tile_id = beta_tile_start_id + w;
-            uint64_t beta_noc_addr = get_noc_addr(tile_id, beta);
-            noc_async_read(beta_noc_addr, l1_write_addr_beta, 64);
-            l1_write_addr_beta += beta_tile_bytes;
-        }
-        noc_async_read_barrier();
-
-        // Copy the second set of 32 bytes into the second face
-        l1_write_addr_beta = base_l1_write_addr_beta;
-
-        for (uint32_t w = 0; w < num_cols_tile_gamma_beta; w++) {
-            uint64_t noc_read_addr = get_noc_addr(l1_write_addr_beta + 32);
-            noc_async_read(noc_read_addr, l1_write_addr_beta + 512, 32);
-            l1_write_addr_beta += beta_tile_bytes;
-        }
-
-        noc_async_read_barrier();
-        cb_push_back(cb_beta, num_cols_tile_gamma_beta);
-    }
-
-    const auto dst_a = TensorAccessor(out_args, out_addr, single_tile_size_bytes);
-
-    uint32_t index_b_offset = 0;
     for (uint32_t b = 0; b < num_batches_per_core; ++b) {
-        uint32_t out_block_index_offset = 0;
-        for (uint32_t out_block_index = 0; out_block_index < num_out_blocks_padded; out_block_index++) {
-            uint32_t out_block_h_actual, out_block_hw_actual;
-            if (extra_out_block && (out_block_index == (num_out_blocks_padded - 1))) {
-                out_block_h_actual = out_block_h_last;
-                out_block_hw_actual = out_block_hw_last;
-            } else {
-                out_block_h_actual = out_block_h_normal;
-                out_block_hw_actual = out_block_hw_normal;
+        uint32_t input_mask_tile_id = input_mask_tile_start_id;
+        index_g_offset = 0;
+        row_offset = num_cols_per_group;
+
+        for (uint32_t i = 0; i < num_groups_per_core; ++i) {
+            cb_reserve_back(cb_input_mask, block_w);
+            uint32_t l1_write_addr_input_mask = get_write_ptr(cb_input_mask);
+            for (uint32_t j = 0; j < block_w; ++j) {
+                noc_async_read_tile(input_mask_tile_id, mask, l1_write_addr_input_mask);
+                l1_write_addr_input_mask += input_mask_single_tile_size_bytes;
+                input_mask_tile_id += 1;
+            }
+            noc_async_read_barrier();
+            cb_push_back(cb_input_mask, block_w);
+
+            if (i == 0 and b == 0) {
+                if constexpr (!use_welford) {
+                    constexpr uint32_t cb_in_2 = tt::CBIndex::c_2;
+                    const uint32_t scalar_w = get_arg_val<uint32_t>(1);
+                    generate_reduce_scaler(cb_in_2, scalar_w);
+                }
+
+                if constexpr (!use_welford && is_mcast_sender) {
+                    constexpr uint32_t cb_in_4 = tt::CBIndex::c_4;
+                    const uint32_t scalar_c = get_arg_val<uint32_t>(0);
+                    generate_reduce_scaler(cb_in_4, scalar_c);
+                }
+
+                constexpr uint32_t eps_cb_id = tt::CBIndex::c_3;
+                const uint32_t eps = get_arg_val<uint32_t>(2);
+                generate_bcast_col_scalar(eps_cb_id, eps);
+
+                if constexpr (fuse_gamma) {
+                    const uint32_t gamma_tile_bytes = get_tile_size(cb_gamma);
+                    const auto gamma = TensorAccessor(gamma_args, gamma_addr, page_size);
+
+                    cb_reserve_back(cb_gamma, num_cols_tile_gamma_beta);
+
+                    const uint32_t base_l1_write_addr_gamma = get_write_ptr(cb_gamma);
+                    uint32_t l1_write_addr_gamma = base_l1_write_addr_gamma;
+
+                    // We want this data to appear as the first row of the tile.
+                    // This is 32B at the start of the first face, 32B at the start of the second face
+                    // However we must read at a 64 byte granularity for Blackhole NOC compatibility on DRAM reads
+                    // So instead of two 32B reads to the correct addresses, we read 64 bytes into the first face here
+                    // Then later, copy the second set of 32 bytes into the start of the second face
+                    // L1-L1 NOC transactions only need 16 byte alignment on BH, so this is legal after data is loaded
+                    // to L1
+
+                    // Read the first 64 bytes of the tile into the first face
+                    for (uint32_t w = 0; w < num_cols_tile_gamma_beta; w++) {
+                        uint32_t tile_id = gamma_tile_start_id + w;
+                        uint64_t gamma_noc_addr = get_noc_addr(tile_id, gamma);
+
+                        noc_async_read(gamma_noc_addr, l1_write_addr_gamma, 64);
+                        l1_write_addr_gamma += gamma_tile_bytes;
+                    }
+                    noc_async_read_barrier();
+
+                    // Copy the second set of 32 bytes into the second face
+                    l1_write_addr_gamma = base_l1_write_addr_gamma;
+
+                    for (uint32_t w = 0; w < num_cols_tile_gamma_beta; w++) {
+                        uint64_t noc_read_addr = get_noc_addr(l1_write_addr_gamma + 32);
+                        noc_async_read(noc_read_addr, l1_write_addr_gamma + 512, 32);
+                        l1_write_addr_gamma += gamma_tile_bytes;
+                    }
+
+                    noc_async_read_barrier();
+                    cb_push_back(cb_gamma, num_cols_tile_gamma_beta);
+                }
+
+                if constexpr (fuse_beta) {
+                    // Just like gamma, we read at a 64 byte granularity for Blackhole NOC compatibility
+                    // Then copy the second set of 32 bytes into the second face
+
+                    const uint32_t beta_tile_bytes = get_tile_size(cb_beta);
+                    const auto beta = TensorAccessor(beta_args, beta_addr, page_size);
+
+                    cb_reserve_back(cb_beta, num_cols_tile_gamma_beta);
+
+                    const uint32_t base_l1_write_addr_beta = get_write_ptr(cb_beta);
+                    uint32_t l1_write_addr_beta = base_l1_write_addr_beta;
+
+                    // Read the first 64 bytes of the tile into the first face
+                    for (uint32_t w = 0; w < num_cols_tile_gamma_beta; w++) {
+                        uint32_t tile_id = beta_tile_start_id + w;
+                        uint64_t beta_noc_addr = get_noc_addr(tile_id, beta);
+                        noc_async_read(beta_noc_addr, l1_write_addr_beta, 64);
+                        l1_write_addr_beta += beta_tile_bytes;
+                    }
+                    noc_async_read_barrier();
+
+                    // Copy the second set of 32 bytes into the second face
+                    l1_write_addr_beta = base_l1_write_addr_beta;
+
+                    for (uint32_t w = 0; w < num_cols_tile_gamma_beta; w++) {
+                        uint64_t noc_read_addr = get_noc_addr(l1_write_addr_beta + 32);
+                        noc_async_read(noc_read_addr, l1_write_addr_beta + 512, 32);
+                        l1_write_addr_beta += beta_tile_bytes;
+                    }
+
+                    noc_async_read_barrier();
+                    cb_push_back(cb_beta, num_cols_tile_gamma_beta);
+                }
             }
 
-            uint32_t mt_offset = 0;
-            for (uint32_t mt = 0; mt < out_block_h_actual; mt++) {
-                for (uint32_t nt = 0; nt < per_core_N; ++nt) {
-                    cb_wait_front(cb_out, 1);
-                    const uint32_t l1_read_addr = get_read_ptr(cb_out);
-                    noc_async_write_tile(
-                        out_start_id + index_b_offset + out_block_index_offset + mt_offset + nt, dst_a, l1_read_addr);
-                    noc_async_write_barrier();
-                    cb_pop_front(cb_out, 1);
+            // add or copy with previous output results
+            uint32_t block_w_curr = index_g_offset == (per_core_N - block_w_last) ? block_w_last : block_w;
+
+            const auto dst_a = TensorAccessor(out_args, out_addr, single_tile_size_bytes);
+
+            uint32_t out_block_start_id_offset = 0;
+            for (uint32_t out_block_index = 0; out_block_index < num_out_blocks_padded; out_block_index++) {
+                uint32_t out_block_h_actual, out_block_hw_actual;
+                if (extra_out_block && (out_block_index == (num_out_blocks_padded - 1))) {
+                    out_block_h_actual = out_block_h_last;
+                    out_block_hw_actual = out_block_hw_last;
+                } else {
+                    out_block_h_actual = out_block_h_normal;
+                    out_block_hw_actual = out_block_hw_normal;
                 }
-                mt_offset += num_channels_tiles;
+                cb_wait_front(cb_out, out_block_hw_normal);
+                uint32_t l1_read_addr = get_read_ptr(cb_out);
+
+                for (uint32_t mt = 0; mt < out_block_h_actual; mt++) {
+                    for (uint32_t nt = 0; nt < block_w_curr; nt++) {
+                        // Checks, only relevant to the last group, that we are not indexing out of bounds
+                        // for the cases where our last group does not span the length of our max tile span for a group
+                        if ((index_g_offset + nt) < row_tile_max_index) {
+                            noc_async_write_tile(
+                                out_start_id + out_block_start_id_offset + (mt * num_channels_tiles) + nt +
+                                    index_b_offset + index_g_offset,
+                                dst_a,
+                                l1_read_addr);
+                        }
+                        l1_read_addr += single_tile_size_bytes;
+                    }
+                    // l1_read_addr += (single_tile_size_bytes * (block_w-block_w_curr));
+                }
+                out_block_start_id_offset += out_block_h_actual * num_channels_tiles;
+                noc_async_write_barrier();
+                cb_pop_front(cb_out, out_block_hw_normal);
             }
-            out_block_index_offset += out_block_h_actual * num_channels_tiles;
+
+            if constexpr (GROUP_SIZE_IS_POWER_OF_2) {
+                if (row_offset == TILE_WIDTH) {
+                    index_g_offset += block_w;
+                    row_offset = num_cols_per_group;
+
+                } else {
+                    index_g_offset += block_w_minus_one;
+                    row_offset += num_cols_per_group;
+                }
+            } else if constexpr (GROUP_SIZE_SMALLER_THAN_TILE_W) {
+                if (row_offset == TILE_WIDTH) {
+                    index_g_offset += block_w_minus_one;
+                    row_offset = num_cols_per_group;
+
+                } else if (row_offset > TILE_WIDTH) {
+                    index_g_offset += block_w_minus_one;
+                    row_offset = row_offset + group_row_offset;
+
+                } else {
+                    row_offset += num_cols_per_group;
+                }
+            } else {
+                if (row_offset > TILE_WIDTH) {
+                    index_g_offset += block_w_minus_one;
+                    row_offset = row_offset - tile_w_minux_group_size;
+                } else {
+                    row_offset += num_cols_per_group;
+                    index_g_offset += block_w_minus_two;
+                }
+            }
         }
         index_b_offset += num_tiles_per_batch;
     }

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/multi_core/groupnorm_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/multi_core/groupnorm_op_multi_core.cpp
@@ -1447,7 +1447,8 @@ operation::ProgramWithCallbacks groupnorm_multi_core_no_mcast(
     uint32_t in6_CB_size = gamma_beta_num_cols_tile_per_core * gamma_beta_single_tile_size;
     // input mask
     uint32_t input_mask_num_tiles_per_core = block_wt * num_groups_per_core;
-    uint32_t in_mask_CB_size = block_wt * in_mask_single_tile_size * 2;  // double buffer
+    uint32_t in_mask_CB_size = use_welford ? input_mask.value().physical_volume() * input_mask.value().element_size()
+                                           : block_wt * in_mask_single_tile_size * 2;
     // repack cb
     uint32_t repack_CB_size = per_core_Nt * in_single_tile_size * 2;  // double buffer
     // itermediate buffers
@@ -1459,13 +1460,13 @@ operation::ProgramWithCallbacks groupnorm_multi_core_no_mcast(
     uint32_t xmm_CB_size_group_2 = 0;
     uint32_t ex_partial_CB_size = single_tile_size * (use_welford ? 2 : 1);  // partial Ex
     uint32_t ex2_partial_CB_size = single_tile_size;                         // partial Ex2
-    uint32_t ex_global_CB_size = ex_partial_CB_size;                         // the final result Ex
-    uint32_t ex2_global_CB_size = ex2_partial_CB_size;                       // the final result Ex2
+    uint32_t ex_global_CB_size = ex_partial_CB_size * (use_welford ? num_groups_per_core : 1);  // the final result Ex
+    uint32_t ex2_global_CB_size = ex2_partial_CB_size;                                          // the final result Ex2
     uint32_t xmm2_CB_size_group_1 = interm_block_tiles_group_1 * single_tile_size;
     uint32_t xmm2_CB_size_group_2 = 0;
     uint32_t xmm3_CB_size_group_1 = interm_block_tiles_group_1 * single_tile_size;
     uint32_t xmm3_CB_size_group_2 = 0;
-    uint32_t ex2pe_CB_size = ex_partial_CB_size;
+    uint32_t ex2pe_CB_size = use_welford ? single_tile_size * num_groups_per_core : ex_partial_CB_size;
     uint32_t reciprocal_CB_size = reciprocals.has_value() ? reciprocals.value().buffer()->aligned_size_per_bank() : 0;
     // output buffer size
     uint32_t out_CB_size_group_1 = in0_block_tiles_group_1 * out_single_tile_size;
@@ -1492,6 +1493,13 @@ operation::ProgramWithCallbacks groupnorm_multi_core_no_mcast(
         // output buffer size
         out_CB_size_group_1 = in0_block_tiles_group_1 * out_single_tile_size;
         out_CB_size_group_2 = in0_block_tiles_group_2 * out_single_tile_size;
+    }
+
+    if (use_welford) {
+        x_CB_size_group_1 = single_tile_size * 1;
+        x_CB_size_group_2 = single_tile_size * 1;
+        xmm_CB_size_group_1 = single_tile_size * 3;
+        xmm_CB_size_group_2 = single_tile_size * 3;
     }
 
     log_debug(tt::LogOp, "per_core_Nt: {}", per_core_Nt);
@@ -2007,17 +2015,15 @@ operation::ProgramWithCallbacks groupnorm_multi_core_no_mcast(
         tt::tt_metal::CreateCircularBuffer(program, all_cores, repack_cb_config);
     }
     // x
-    if (!use_welford) {
-        uint32_t x_cb_index = tt::CBIndex::c_24;
-        tt::tt_metal::CircularBufferConfig x_cb_config_group_1 =
-            tt::tt_metal::CircularBufferConfig(x_CB_size_group_1, {{x_cb_index, cb_data_format}})
-                .set_page_size(x_cb_index, single_tile_size);
-        tt::tt_metal::CreateCircularBuffer(program, all_cores_group_1, x_cb_config_group_1);
-        tt::tt_metal::CircularBufferConfig x_cb_config_group_2 =
-            tt::tt_metal::CircularBufferConfig(x_CB_size_group_2, {{x_cb_index, cb_data_format}})
-                .set_page_size(x_cb_index, single_tile_size);
-        tt::tt_metal::CreateCircularBuffer(program, all_cores_group_2, x_cb_config_group_2);
-    }
+    uint32_t x_cb_index = tt::CBIndex::c_24;
+    tt::tt_metal::CircularBufferConfig x_cb_config_group_1 =
+        tt::tt_metal::CircularBufferConfig(x_CB_size_group_1, {{x_cb_index, cb_data_format}})
+            .set_page_size(x_cb_index, single_tile_size);
+    tt::tt_metal::CreateCircularBuffer(program, all_cores_group_1, x_cb_config_group_1);
+    tt::tt_metal::CircularBufferConfig x_cb_config_group_2 =
+        tt::tt_metal::CircularBufferConfig(x_CB_size_group_2, {{x_cb_index, cb_data_format}})
+            .set_page_size(x_cb_index, single_tile_size);
+    tt::tt_metal::CreateCircularBuffer(program, all_cores_group_2, x_cb_config_group_2);
     // xmm
     uint32_t xmm_cb_index = tt::CBIndex::c_25;
     tt::tt_metal::CircularBufferConfig xmm_cb_config_group_1 =

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/multi_core/groupnorm_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/multi_core/groupnorm_op_multi_core.cpp
@@ -289,6 +289,12 @@ operation::ProgramWithCallbacks groupnorm_multi_core_sharded(
             num_groups);
     }
 
+    TT_FATAL(
+        (!use_welford) || (num_groups_per_core <= 16),
+        "num_groups_per_core ({}) must be <= 16 when use_welfords is true. Increase the width of shard spec to address "
+        "this.",
+        num_groups_per_core);
+
     // subblock
     uint32_t num_rows_per_batch_per_core = per_core_M / num_batches_per_core;
     auto [block_wt, num_groups_per_reset] = find_max_tile_span(per_core_N, group_size);
@@ -1276,6 +1282,12 @@ operation::ProgramWithCallbacks groupnorm_multi_core_no_mcast(
     uint32_t num_batches_per_core_group_1 = num_batches > num_shards_r ? num_batches / num_shards_r : 1;
     uint32_t num_batches_per_core_group_2 = num_batches_per_core_group_1;  // need this to be non-zero even if unused
     uint32_t num_groups_per_core = num_groups > num_shards_c ? num_groups / num_shards_c : 1;
+
+    TT_FATAL(
+        (!use_welford) || (num_groups_per_core <= 16),
+        "num_groups_per_core ({}) must be <= 16 when use_welfords is true. Increase the width of core grid to address "
+        "this.",
+        num_groups_per_core);
 
     // Compute num_out_blocks if not provided. If this does not provide the best result, num_out_blocks should be
     // computed by testing different powers of 2. This is a heuristic.
@@ -2531,6 +2543,12 @@ operation::ProgramWithCallbacks groupnorm_multi_core_mcast(
     // each core contains multiple batches
     uint32_t num_batches_per_core_group_1 = num_batches > num_shards_r ? num_batches / num_shards_r : 1;
     uint32_t num_groups_per_core = num_groups > num_shards_c ? num_groups / num_shards_c : 1;
+
+    TT_FATAL(
+        (!use_welford) || (num_groups_per_core <= 16),
+        "num_groups_per_core ({}) must be <= 16 when use_welfords is true. Increase the width of core grid to address "
+        "this.",
+        num_groups_per_core);
 
     // Compute num_out_blocks if not provided. If this does not provide the best result, num_out_blocks should be
     // computed by testing different powers of 2. This is a heuristic.

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm.cpp
@@ -24,7 +24,6 @@
 #include "compute_kernel_api/transpose_wh_dest.h"
 #include "compute_kernel_api/tile_move_copy.h"
 #include "compute_kernel_api/eltwise_unary/eltwise_unary.h"
-#include "dprint_tensix.h"
 
 ALWI void ACQ() { acquire_dst(); }
 ALWI void REL() { release_dst(); }
@@ -97,11 +96,8 @@ void MAIN {
         add_tiles_init(cb_in, cb_inb);
         for (uint32_t wt = 0; wt < Wt; wt += blk) {
             ACQ();
-            // UNPACK(( { DPRINT  << "Waiting on cb_x" << ENDL(); } ));
             cb_wait_front(cb_in, blk);
-            // UNPACK(( { DPRINT  << "Waiting on cb_inb" << ENDL(); } ));
             cb_wait_front(cb_inb, blk);
-            // UNPACK(( { DPRINT  << "Done Waiting on cb_inb" << ENDL(); } ));
             cb_reserve_back(cb_x, blk);
             for (uint32_t j = 0; j < blk; j++) {
                 add_tiles(cb_in, cb_inb, j, j, j);
@@ -249,8 +245,6 @@ void MAIN {
          */
         cb_wait_front(cb_ex2pe, 1);
         for (uint32_t wt = 0; wt < Wt; wt += blk) {
-            // if (ht == 1) UNPACK(( DPRINT << "wt_2=" << wt << " " ));
-            // if (ht == 1) UNPACK(( DPRINT << "rem_2=" << rem << ENDL() ));
             reconfig_data_format(cb_xmm, cb_ex2pe);
             if constexpr (do_gamma == 0 && do_beta == 0) {
                 pack_reconfig_data_format(cb_out);

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_large_tensor.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_large_tensor.cpp
@@ -292,9 +292,6 @@ void MAIN {
                     pack_reconfig_data_format(cb_out);
                 }
                 cb_wait_front(cb_gamma, blk);
-                if (ncht == 1) {
-                    DPRINT << "\n\n\nFINAL VAL Pre Var Value wt: " << wt << ENDL();
-                }
                 cb_wait_front(cb_xmm, blk);
                 mul_bcast_rows_init_short(cb_xmm, cb_gamma);
                 for (uint32_t j = 0; j < blk; j++) {

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_large_tensor_welford.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_large_tensor_welford.cpp
@@ -10,31 +10,189 @@
 #include "compute_kernel_api.h"
 #include "compute_kernel_api/bcast.h"
 #include "compute_kernel_api/eltwise_binary.h"
-#include "compute_kernel_api/layernorm.h"
 #include "compute_kernel_api/eltwise_binary_sfpu.h"
 #include "compute_kernel_api/tile_move_copy.h"
 #include "compute_kernel_api/welford.h"
 #include "compute_kernel_api/eltwise_unary/eltwise_unary.h"
 #include "compute_kernel_api/eltwise_unary/rsqrt.h"
 #include "compute_kernel_api/transpose_wh.h"
-#include "compute_kernel_api/transpose_wh_dest.h"
 #include "ttnn/operations/normalization/kernel_util/compute/memory.h"
+
 namespace NAMESPACE {
 
-class cb_ping_pong {
-public:
-    cb_ping_pong(tt::CBIndex in_ping, tt::CBIndex in_pong) : ping(in_ping), pong(in_pong) {}
+template <
+    tt::CBIndex cb_in,
+    tt::CBIndex cb_inb,
+    tt::CBIndex cb_interm_pre_add,
+    tt::CBIndex cb_ex,
+    tt::CBIndex cb_ex2,
+    uint32_t input_dst,
+    uint32_t mean_dst,
+    uint32_t var_dst,
+    uint32_t Wt,
+    uint32_t tile_width,
+    uint32_t W,
+    uint32_t blk>
+void welford_fuse_pre_add(const std::array<uint32_t, W>& reciprocal_lut) {
+    // The number of valid rows in the last tile in width dimension
+    constexpr uint32_t last_tile_rows = W % tile_width;
+    constexpr bool is_last_tile_full = (last_tile_rows == 0);
 
-    inline auto read() { return ping; }
+    uint32_t sample_idx = 0;
 
-    inline auto write() { return pong; }
+    tile_regs_acquire();
+    welford_init();
+    welford_store_mean_m2_to_dst(mean_dst);
+    tile_regs_commit();
 
-    void swap() { std::swap(ping, pong); }
+    cb_reserve_back(cb_ex, 1);
+    cb_reserve_back(cb_ex2, 1);
+    tile_regs_wait();
+    pack_reconfig_data_format(cb_ex);
+    pack_tile(mean_dst, cb_ex);
+    pack_tile(var_dst, cb_ex2);
+    tile_regs_release();
+    cb_push_back(cb_ex, 1);
+    cb_push_back(cb_ex2, 1);
 
-private:
-    tt::CBIndex ping;
-    tt::CBIndex pong;
-};
+    for (uint32_t wt = 0; wt < Wt; wt += blk) {
+        // Fused pre-add
+        reconfig_data_format(cb_in, cb_inb);
+        add_tiles_init(cb_in, cb_inb);
+        cb_wait_front(cb_in, blk);
+        cb_wait_front(cb_inb, blk);
+        tile_regs_acquire();
+        for (uint32_t j = 0; j < blk; j++) {
+            add_tiles(cb_in, cb_inb, j, j, j);
+        }
+        tile_regs_commit();
+        cb_pop_front(cb_inb, blk);
+        cb_pop_front(cb_in, blk);
+
+        // Pack to intermediate CB (needed
+        // to workaround transpose_wh_dest bug)
+        pack_reconfig_data_format(cb_interm_pre_add);
+        cb_reserve_back(cb_interm_pre_add, blk);
+        tile_regs_wait();
+        for (uint32_t j = 0; j < blk; j++) {
+            pack_tile(j, cb_interm_pre_add);
+        }
+        tile_regs_release();
+        cb_push_back(cb_interm_pre_add, blk);
+
+        // Now run Welfords in these blk number of tiles
+        cb_wait_front(cb_interm_pre_add, blk);
+        cb_wait_front(cb_ex, 1);
+        cb_wait_front(cb_ex2, 1);
+        tile_regs_acquire();
+        reconfig_data_format_srca(cb_in, cb_ex);
+        copy_tile_init(cb_ex);
+        copy_tile(cb_ex, 0, mean_dst);
+        reconfig_data_format_srca(cb_ex, cb_ex2);
+        copy_tile_to_dst_init_short_with_dt(cb_ex, cb_ex2);
+        copy_tile(cb_ex2, 0, var_dst);
+        welford_load_mean_m2_from_dst(mean_dst);
+
+        reconfig_data_format_srca(cb_ex2, cb_interm_pre_add);
+        transpose_wh_init_short(cb_interm_pre_add);
+        for (uint32_t j = 0; j < blk; j++) {
+            // Welford's needs transposed input tile
+            transpose_wh_tile(cb_interm_pre_add, j, input_dst);
+
+            if constexpr (is_last_tile_full) {
+                // All tiles can go through the faster call which does 32 rows
+                welford_tile<W>(input_dst, sample_idx, reciprocal_lut);
+            } else {
+                // If it is the end tile, do it differently
+                if ((wt + j) == (Wt - 1)) {
+                    welford_tile<W>(input_dst, sample_idx, reciprocal_lut);
+                } else {
+                    welford_partial_tile<W>(input_dst, sample_idx, 0, last_tile_rows, reciprocal_lut);
+                }
+            }
+            sample_idx += tile_width;
+        }
+        welford_store_mean_m2_to_dst(mean_dst);
+        tile_regs_commit();
+        cb_pop_front(cb_interm_pre_add, blk);
+        cb_pop_front(cb_ex, 1);
+        cb_pop_front(cb_ex2, 1);
+
+        cb_reserve_back(cb_ex, 1);
+        cb_reserve_back(cb_ex2, 1);
+        tile_regs_wait();
+        pack_reconfig_data_format(cb_interm_pre_add, cb_ex);
+        pack_tile(mean_dst, cb_ex);
+        pack_tile(var_dst, cb_ex2);
+        tile_regs_release();
+        cb_push_back(cb_ex, 1);
+        cb_push_back(cb_ex2, 1);
+    }
+
+    cb_wait_front(cb_ex, 1);
+    cb_wait_front(cb_ex2, 1);
+    tile_regs_acquire();
+    copy_tile_init(cb_ex);
+    copy_tile(cb_ex, 0, mean_dst);
+    copy_tile_to_dst_init_short_with_dt(cb_ex, cb_ex2);
+    copy_tile(cb_ex2, 0, var_dst);
+    welford_load_mean_m2_from_dst(mean_dst);
+    // Store the mean and variance to the destination registers
+    welford_store_mean_var_to_dst_row<W>(mean_dst, W - 1, reciprocal_lut);
+    tile_regs_commit();
+    cb_pop_front(cb_ex, 1);
+    cb_pop_front(cb_ex2, 1);
+}
+
+/* @brief: Welford's algorithm for no fused pre-add
+ * @param: cb_in: input CB
+ * @param: input_dst: input tile for Welford's algorithm
+ * @param: mean_dst: mean tile for Welford's algorithm
+ * @param: Wt: width of the input in tiles
+ * @param: tile_width: width of each tile
+ * @param: W: width of the input
+ * @param: p_reciprocals: pointer to the reciprocal LUT
+ */
+template <tt::CBIndex cb_in, uint32_t input_dst, uint32_t mean_dst, uint32_t Wt, uint32_t tile_width, uint32_t W>
+void welford_no_fuse_pre_add(const std::array<uint32_t, W>& reciprocal_lut) {
+    // The number of valid rows in the last tile in width dimension
+    constexpr uint32_t last_tile_rows = W % tile_width;
+    constexpr bool is_last_tile_full = (last_tile_rows == 0);
+
+    uint32_t sample_idx = 0;
+    reconfig_data_format_srca(cb_in);
+    transpose_wh_init_short(cb_in);
+    tile_regs_acquire();
+    welford_init();
+
+    // Process all but the last tile
+    for (uint32_t wt = 0; wt < (Wt - 1); ++wt) {
+        cb_wait_front(cb_in, 1);
+        // Welford's needs transposed input tile
+        transpose_wh_tile(cb_in, 0, input_dst);
+        welford_tile<W>(input_dst, sample_idx, reciprocal_lut);
+
+        // Pop the input
+        cb_pop_front(cb_in, 1);
+        sample_idx += tile_width;
+    }
+
+    // Process the last tile
+    cb_wait_front(cb_in, 1);
+    transpose_wh_tile(cb_in, 0, input_dst);
+
+    if constexpr (is_last_tile_full) {
+        welford_tile<W>(input_dst, sample_idx, reciprocal_lut);
+    } else {
+        welford_partial_tile<W>(input_dst, sample_idx, 0, last_tile_rows, reciprocal_lut);
+    }
+
+    // Store the mean and variance to the destination registers
+    welford_store_mean_var_to_dst_row<W>(mean_dst, W - 1, reciprocal_lut);
+
+    tile_regs_commit();
+    cb_pop_front(cb_in, 1);
+}
 
 void MAIN {
     namespace kutil = norm::kernel_util;
@@ -62,13 +220,9 @@ void MAIN {
     constexpr auto cb_ex2pe = tt::CBIndex::c_21;           // Var[x]+ε
     constexpr auto cb_fusion = tt::CBIndex::c_22;          // stream gamma/beta
     constexpr auto cb_interm_pre_add = tt::CBIndex::c_23;  // intermediate for fused pre-add
-    auto cb_welford_ping = tt::CBIndex::c_4;               // Ping-pong buffer for storing Welford's mean/var
-    auto cb_welford_pong = tt::CBIndex::c_7;               // Ping-pong buffer for storing Welford's mean/var
     constexpr auto cb_reciprocals = tt::CBIndex::c_25;     // Pre-computed reciprocals for Welford's algorithm
-    constexpr auto cb_result_or_input = fuse_pre_add ? cb_interm_pre_add : cb_in;
 
     constexpr uint32_t onetile = 1;
-    constexpr uint32_t twotiles = 2;
 
     // Initialize the hardware based on the first op
     // that will be done
@@ -83,159 +237,104 @@ void MAIN {
 
     cb_wait_front(cb_eps, onetile);     // comes from the reader
 
-    constexpr uint32_t dst0 = 0;  // Input tile for Welford's
-    constexpr uint32_t dst1 = 1;  // Mean tile for Welford's
-    constexpr uint32_t dst2 = 2;  // Variance tile for Welford's
+    constexpr uint32_t dst0 = 0;
+    constexpr uint32_t input_dst = 0;  // Input tile for Welford's algorithm
+    constexpr uint32_t mean_dst = 1;   // Mean tile for Welford's
+    constexpr uint32_t var_dst = 2;    // Variance tile for Welford's
 
     // Get pointer to the reciprocal LUT
     using recip_lut_t = std::array<uint32_t, W>;
     auto p_reciprocals = kutil::compute::memory::get_pointer_to_cb_data<recip_lut_t>(cb_reciprocals, 0);
 
-    auto cb_welford = cb_ping_pong(cb_welford_ping, cb_welford_pong);
     for (uint32_t ncht = 0; ncht < NCHt; ncht++) {
-        // =====================================
-        // First pass over the input.
-        // Calculate E[x] and Var[x]
-        // =====================================
-        uint32_t num_cols_processed = 0;
-        for (uint32_t wt = 0; wt < Wt; wt += blk) {
-            if constexpr (fuse_pre_add) {
-                // Fused pre-add
-                reconfig_data_format(cb_in, cb_inb);
-                add_tiles_init(cb_in, cb_inb);
-                tile_regs_acquire();
-                for (uint32_t j = 0; j < blk; j++) {
-                    cb_wait_front(cb_in, j + 1);
-                    cb_wait_front(cb_inb, j + 1);
-                    add_tiles(cb_in, cb_inb, j, j, j);
-                }
-                tile_regs_commit();
-
-                cb_pop_front(cb_inb, blk);
-
-                // Pack to intermediate CB (needed
-                // to workaround transpose_wh_dest bug)
-                pack_reconfig_data_format(cb_interm_pre_add);
-                cb_reserve_back(cb_interm_pre_add, blk);
-                tile_regs_wait();
-                for (uint32_t j = 0; j < blk; j++) {
-                    pack_tile(j, cb_interm_pre_add);
-                }
-                tile_regs_release();
-                cb_push_back(cb_interm_pre_add, blk);
-            }
-
-            tile_regs_acquire();
-            if (wt > 0) {
-                // Copy previous accumulated (row tiles)
-                // mean and variance to dest regs
-                cb_wait_front(cb_welford.read(), twotiles);
-
-                reconfig_data_format_srca(cb_welford.read());
-                copy_tile_to_dst_init_short(cb_welford.read());
-                copy_tile(cb_welford.read(), 0, dst1);
-                copy_tile(cb_welford.read(), 1, dst2);
-
-                cb_pop_front(cb_welford.read(), twotiles);
-                welford_load_mean_m2_from_dst(dst1);
-            } else {
-                welford_clear_previous_mean_and_m2();
-            }
-
-            // Process block of Welford's
-            reconfig_data_format_srca(cb_result_or_input);
-            transpose_wh_init_short(cb_result_or_input);
-            welford_init();
-            for (uint32_t j = 0; j < blk; j++) {
-                cb_wait_front(cb_result_or_input, j + 1);
-                transpose_wh_tile(cb_result_or_input, j, dst0);
-                auto num_cols_in_tile = std::min(tile_width, W - num_cols_processed);
-                welford_partial_tile<W>(dst0, num_cols_processed, 0, num_cols_in_tile, *p_reciprocals);
-                num_cols_processed += num_cols_in_tile;
-            }
-            welford_store_mean_m2_to_dst(dst1);
-            tile_regs_commit();
-
-            // Pop the input or result CB
-            if constexpr (fuse_pre_add) {
-                cb_pop_front(cb_in, blk);
-                cb_pop_front(cb_interm_pre_add, blk);
-            } else {
-                cb_pop_front(cb_in, blk);
-            }
-
-            // Pack dst1 and dst2 into CBs
-            // Leave as row tiles
-            tile_regs_wait();
-            cb_reserve_back(cb_welford.write(), twotiles);
-            pack_reconfig_data_format(cb_welford.write());
-            pack_tile_block(dst1, cb_welford.write(), twotiles);
-            tile_regs_release();
-
-            cb_push_back(cb_welford.write(), twotiles);
-
-            cb_welford.swap();
+        // Depending on whether we need to fuse pre-add, the approach for welford is different.
+        // So we move it to a separate function.
+        if constexpr (fuse_pre_add) {
+            welford_fuse_pre_add<
+                cb_in,
+                cb_inb,
+                cb_interm_pre_add,
+                cb_ex,
+                cb_ex2,
+                input_dst,
+                mean_dst,
+                var_dst,
+                Wt,
+                tile_width,
+                W,
+                blk>(*p_reciprocals);
+        } else {
+            welford_no_fuse_pre_add<cb_in, input_dst, mean_dst, Wt, tile_width, W>(*p_reciprocals);
         }
-
-        // Transpose mean and variance back to
-        // columns and pack back to CBs
-        cb_wait_front(cb_welford.read(), twotiles);
-        transpose_wh_init_short(cb_welford.read());
-        reconfig_data_format_srca(cb_welford.read());
-        tile_regs_acquire();
-        transpose_wh_tile(cb_welford.read(), 0, dst1);
-        transpose_wh_tile(cb_welford.read(), 1, dst2);
-
-        welford_load_mean_m2_from_dst(dst1);
-        welford_store_mean_var_to_dst_row<W>(dst1, W - 1, *p_reciprocals);
-
-        tile_regs_commit();
-        tile_regs_wait();
+        // We should expect that either of the two would have have populated dst regs with mean and
+        // variance in mean_dst and var_dst respectively.
 
         cb_reserve_back(cb_ex, onetile);
         cb_reserve_back(cb_ex2, onetile);
+        tile_regs_wait();
         pack_reconfig_data_format(cb_ex);
-        pack_tile(dst1, cb_ex);
-        pack_reconfig_data_format(cb_ex2);
-        pack_tile(dst2, cb_ex2);
+        pack_tile(mean_dst, cb_ex);
+        pack_tile(var_dst, cb_ex2);
+        tile_regs_release();
         cb_push_back(cb_ex, onetile);
         cb_push_back(cb_ex2, onetile);
+
+        // Transpose mean and variance back to
+        // columns and pack back to CBs
+        reconfig_data_format_srca(cb_ex);
+        transpose_wh_init_short(cb_ex);
+
+        cb_wait_front(cb_ex, onetile);
+        cb_wait_front(cb_ex2, onetile);
+        tile_regs_acquire();
+        transpose_wh_tile(cb_ex, 0, mean_dst);
+        transpose_wh_tile(cb_ex2, 0, var_dst);
+        tile_regs_commit();
+        cb_pop_front(cb_ex, onetile);
+        cb_pop_front(cb_ex2, onetile);
+
+        cb_reserve_back(cb_ex, onetile);
+        cb_reserve_back(cb_ex2, onetile);
+        tile_regs_wait();
+        pack_reconfig_data_format(cb_ex);
+        pack_tile(mean_dst, cb_ex);
+        pack_reconfig_data_format(cb_ex2);
+        pack_tile(var_dst, cb_ex2);
         tile_regs_release();
+        cb_push_back(cb_ex, onetile);
+        cb_push_back(cb_ex2, onetile);
 
         // =====================================
         // Calculate 1/(√(Var(X) + ε))
         // =====================================
-        tile_regs_acquire();
-        tile_regs_wait();
+        reconfig_data_format(cb_ex2, cb_eps);
+        add_tiles_init(cb_ex2, cb_eps);
 
         cb_wait_front(cb_ex2, onetile);
-
-        reconfig_data_format(cb_ex2, cb_eps);
-
-        add_tiles_init(cb_ex2, cb_eps);
+        tile_regs_acquire();
         add_tiles(cb_ex2, cb_eps, 0, 0, dst0);
-
         rsqrt_tile_init();
         rsqrt_tile(dst0);
-
         tile_regs_commit();
+        cb_pop_front(cb_ex2, onetile);
 
         cb_reserve_back(cb_ex2pe, onetile);
+        tile_regs_wait();
         pack_tile(dst0, cb_ex2pe);
-        cb_push_back(cb_ex2pe, onetile);
         tile_regs_release();
-
-        cb_pop_front(cb_ex2, onetile);
-        cb_wait_front(cb_ex2pe, onetile);
+        cb_push_back(cb_ex2pe, onetile);
 
         // broadcasts the tile since cb_ex2pe is a column vector that contains the important data
+        cb_wait_front(cb_ex2pe, onetile);
         tile_regs_acquire();
-        tile_regs_wait();
         reconfig_data_format_srca(cb_ex2pe);
         unary_bcast_init<BroadcastType::COL>(cb_ex2pe, cb_ex2pe);
         unary_bcast<BroadcastType::COL>(cb_ex2pe, 0, dst0);
         cb_pop_front(cb_ex2pe, onetile);
         tile_regs_commit();
+
+        cb_reserve_back(cb_ex2pe, onetile);
+        tile_regs_wait();
         pack_tile(dst0, cb_ex2pe);
         tile_regs_release();
         cb_push_back(cb_ex2pe, onetile);
@@ -247,12 +346,12 @@ void MAIN {
         //(---------------*𝛄)+ß
         //  √(Var(x)+ε)
         // =====================================
+        cb_wait_front(cb_ex2pe, onetile);
+        cb_wait_front(cb_ex, onetile);
+
         for (uint32_t wt = 0; wt < Wt; wt += blk) {
-            tile_regs_acquire();
-            tile_regs_wait();
-            cb_reserve_back(cb_out, blk);
-            cb_wait_front(cb_ex, onetile);
             cb_wait_front(cb_in, blk);
+            tile_regs_acquire();
             reconfig_data_format(cb_in, cb_ex);
             sub_bcast_cols_init_short(cb_in, cb_ex);
             // x-E[x]
@@ -260,13 +359,13 @@ void MAIN {
                 sub_tiles_bcast_cols(cb_in, cb_ex, j, 0, j);
             }
             cb_pop_front(cb_in, blk);
-            reconfig_data_format_srca(cb_in, cb_ex2pe);
 
+            reconfig_data_format_srca(cb_in, cb_ex2pe);
             if constexpr (fuse_pre_add) {
                 // Fuse in = in + b
-                cb_wait_front(cb_inb, blk);
                 reconfig_data_format_srca(cb_ex2pe, cb_inb);
                 binary_dest_reuse_tiles_init<ELWADD, EltwiseBinaryReuseDestType::DEST_TO_SRCB>(cb_inb);
+                cb_wait_front(cb_inb, blk);
                 for (uint32_t j = 0; j < blk; j++) {
                     binary_dest_reuse_tiles<ELWADD, EltwiseBinaryReuseDestType::DEST_TO_SRCB>(cb_inb, j, j);
                 }
@@ -275,17 +374,19 @@ void MAIN {
             }
 
             // Multiply by 1/(√(Var(X) + ε))
-            cb_wait_front(cb_ex2pe, 1);
             binary_dest_reuse_tiles_init<ELWMUL, EltwiseBinaryReuseDestType::DEST_TO_SRCB>(cb_ex2pe);
             for (uint32_t j = 0; j < blk; j++) {
                 binary_dest_reuse_tiles<ELWMUL, EltwiseBinaryReuseDestType::DEST_TO_SRCB>(cb_ex2pe, 0, j);
             }
             tile_regs_commit();
+
             if constexpr (!(do_gamma == 1 or do_beta == 1)) {
                 cb_xmm = cb_out;
             }
+
             pack_reconfig_data_format(cb_xmm);
             cb_reserve_back(cb_xmm, blk);
+            tile_regs_wait();
             for (uint32_t j = 0; j < blk; j++) {
                 pack_tile(j, cb_xmm);
             }
@@ -294,12 +395,8 @@ void MAIN {
 
             if constexpr (do_gamma == 1) {
                 // Multiply by gamma
-                tile_regs_acquire();
-                tile_regs_wait();
                 reconfig_data_format(cb_xmm, cb_gamma);
-                if constexpr (!do_beta) {
-                    pack_reconfig_data_format(cb_out);
-                }
+                tile_regs_acquire();
                 cb_wait_front(cb_gamma, blk);
                 cb_wait_front(cb_xmm, blk);
                 mul_bcast_rows_init_short(cb_xmm, cb_gamma);
@@ -309,6 +406,11 @@ void MAIN {
                 tile_regs_commit();
                 cb_pop_front(cb_gamma, blk);
                 cb_pop_front(cb_xmm, blk);
+
+                if constexpr (!do_beta) {
+                    pack_reconfig_data_format(cb_out);
+                }
+                tile_regs_wait();
                 if constexpr (!do_beta) {
                     cb_reserve_back(cb_out, blk);
                     for (uint32_t j = 0; j < blk; j++) {
@@ -322,25 +424,26 @@ void MAIN {
                     }
                     cb_push_back(cb_xmm, blk);
                 }
-
                 tile_regs_release();
             }
+
             if constexpr (do_beta == 1) {
                 // Add beta
                 tile_regs_acquire();
-                tile_regs_wait();
                 reconfig_data_format(cb_xmm, cb_beta);
-                pack_reconfig_data_format(cb_out);
-                cb_wait_front(cb_beta, blk);
-                cb_wait_front(cb_xmm, blk);
                 add_bcast_rows_init_short(cb_xmm, cb_beta);
+                cb_wait_front(cb_xmm, blk);
+                cb_wait_front(cb_beta, blk);
                 for (uint32_t j = 0; j < blk; j++) {
                     add_tiles_bcast_rows(cb_xmm, cb_beta, j, j, j);
                 }
                 tile_regs_commit();
                 cb_pop_front(cb_beta, blk);
                 cb_pop_front(cb_xmm, blk);
+
+                pack_reconfig_data_format(cb_out);
                 cb_reserve_back(cb_out, blk);
+                tile_regs_wait();
                 for (uint32_t j = 0; j < blk; j++) {
                     pack_tile(j, cb_out);
                 }

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_large_tensor_welford.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_large_tensor_welford.cpp
@@ -150,7 +150,7 @@ void MAIN {
                 cb_wait_front(cb_result_or_input, j + 1);
                 transpose_wh_tile(cb_result_or_input, j, dst0);
                 auto num_cols_in_tile = std::min(tile_width, W - num_cols_processed);
-                welford_tile<W>(dst0, num_cols_processed, 0, num_cols_in_tile, *p_reciprocals);
+                welford_partial_tile<W>(dst0, num_cols_processed, 0, num_cols_in_tile, *p_reciprocals);
                 num_cols_processed += num_cols_in_tile;
             }
             welford_store_mean_m2_to_dst(dst1);
@@ -187,7 +187,7 @@ void MAIN {
         transpose_wh_tile(cb_welford.read(), 1, dst2);
 
         welford_load_mean_m2_from_dst(dst1);
-        welford_store_mean_var_to_dst_col<W>(dst1, W - 1, *p_reciprocals);
+        welford_store_mean_var_to_dst_row<W>(dst1, W - 1, *p_reciprocals);
 
         tile_regs_commit();
         tile_regs_wait();

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded_welford.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded_welford.cpp
@@ -263,19 +263,19 @@ void MAIN {
     for (uint32_t i = 0; i < block_ht; i++) {
         tile_regs_acquire();
         welford_clear_previous_mean_and_m2();
-        uint32_t num_cols_processed = 0;
+        uint32_t sample_idx = 0;
+
         // Do the full Welford tiles
         for (uint32_t w = 0; w < num_full_welford_tiles; w++) {
             transpose_wh_tile(cb_in, w + index_h_offset, welford_input_dst);
-            auto num_cols_in_tile = std::min(tile_width, partial_reduce_W - num_cols_processed);
-            welford_tile<per_core_recip_lut_size>(welford_input_dst, num_cols_processed, *p_reciprocals);
-            num_cols_processed += num_cols_in_tile;
+            welford_tile<per_core_recip_lut_size>(welford_input_dst, sample_idx, *p_reciprocals);
+            sample_idx += tile_width;
         }
         // Do the partial Welford tile, if any
         if (partial_welford_tile_w > 0) {
             transpose_wh_tile(cb_in, block_wt - 1, welford_input_dst);
             welford_partial_tile<per_core_recip_lut_size>(
-                welford_input_dst, num_cols_processed, 0, partial_welford_tile_w, *p_reciprocals);
+                welford_input_dst, sample_idx, 0, partial_welford_tile_w, *p_reciprocals);
         }
         welford_store_mean_var_to_dst_row<per_core_recip_lut_size>(
             welford_mean_dst, partial_reduce_W - 1, *p_reciprocals);

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded_welford.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded_welford.cpp
@@ -261,13 +261,13 @@ void MAIN {
         for (uint32_t w = 0; w < num_reduce_tiles_per_block_h; w++) {
             transpose_wh_tile(cb_in, w + index_h_offset, welford_input_dst);
             auto num_cols_in_tile = std::min(tile_width, partial_reduce_W - num_cols_processed);
-            welford_tile<per_core_recip_lut_size>(
+            welford_partial_tile<per_core_recip_lut_size>(
                 welford_input_dst, num_cols_processed, 0, num_cols_in_tile, *p_reciprocals);
             num_cols_processed += num_cols_in_tile;
             // welford_tile<welford_input_dst, welford_mean_dst, welford_var_dst, true, per_core_recip_lut_size>(
             //     w * tile_width, partial_reduce_W, 0, *p_reciprocals);
         }
-        welford_store_mean_var_to_dst_col<per_core_recip_lut_size>(
+        welford_store_mean_var_to_dst_row<per_core_recip_lut_size>(
             welford_mean_dst, partial_reduce_W - 1, *p_reciprocals);
         // We should transpose back to columns here
         // However, transpose_wh_dest() is currently buggy.

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded_welford.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded_welford.cpp
@@ -163,6 +163,12 @@ void MAIN {
     const uint32_t num_reduce_tiles_per_block_h = get_arg_val<uint32_t>(0);
     const uint32_t partial_reduce_W = (num_reduce_tiles_per_block_h - 1) * tile_width + last_tile_w;
 
+    // We split the Welford calls into full tiles and a final partial tile (if any)
+    const bool all_full_tiles = partial_reduce_W % tile_width == 0;
+    const uint32_t num_full_welford_tiles =
+        all_full_tiles ? num_reduce_tiles_per_block_h : num_reduce_tiles_per_block_h - 1;
+    const uint32_t partial_welford_tile_w = all_full_tiles ? 0 : last_tile_w;
+
     // This is the number of tile rows to process
     const uint32_t num_tiles_per_allgather_worker = is_allgather_worker ? get_arg_val<uint32_t>(1) : 0;
 
@@ -258,14 +264,18 @@ void MAIN {
         tile_regs_acquire();
         welford_clear_previous_mean_and_m2();
         uint32_t num_cols_processed = 0;
-        for (uint32_t w = 0; w < num_reduce_tiles_per_block_h; w++) {
+        // Do the full Welford tiles
+        for (uint32_t w = 0; w < num_full_welford_tiles; w++) {
             transpose_wh_tile(cb_in, w + index_h_offset, welford_input_dst);
             auto num_cols_in_tile = std::min(tile_width, partial_reduce_W - num_cols_processed);
-            welford_partial_tile<per_core_recip_lut_size>(
-                welford_input_dst, num_cols_processed, 0, num_cols_in_tile, *p_reciprocals);
+            welford_tile<per_core_recip_lut_size>(welford_input_dst, num_cols_processed, *p_reciprocals);
             num_cols_processed += num_cols_in_tile;
-            // welford_tile<welford_input_dst, welford_mean_dst, welford_var_dst, true, per_core_recip_lut_size>(
-            //     w * tile_width, partial_reduce_W, 0, *p_reciprocals);
+        }
+        // Do the partial Welford tile, if any
+        if (partial_welford_tile_w > 0) {
+            transpose_wh_tile(cb_in, block_wt - 1, welford_input_dst);
+            welford_partial_tile<per_core_recip_lut_size>(
+                welford_input_dst, num_cols_processed, 0, partial_welford_tile_w, *p_reciprocals);
         }
         welford_store_mean_var_to_dst_row<per_core_recip_lut_size>(
             welford_mean_dst, partial_reduce_W - 1, *p_reciprocals);

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded_welford.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded_welford.cpp
@@ -257,9 +257,13 @@ void MAIN {
     for (uint32_t i = 0; i < block_ht; i++) {
         tile_regs_acquire();
         welford_clear_previous_mean_and_m2();
+        uint32_t num_cols_processed = 0;
         for (uint32_t w = 0; w < num_reduce_tiles_per_block_h; w++) {
             transpose_wh_tile(cb_in, w + index_h_offset, welford_input_dst);
-            welford_tile<per_core_recip_lut_size>(welford_input_dst, w * tile_width, *p_reciprocals);
+            auto num_cols_in_tile = std::min(tile_width, partial_reduce_W - num_cols_processed);
+            welford_tile<per_core_recip_lut_size>(
+                welford_input_dst, num_cols_processed, 0, num_cols_in_tile, *p_reciprocals);
+            num_cols_processed += num_cols_in_tile;
             // welford_tile<welford_input_dst, welford_mean_dst, welford_var_dst, true, per_core_recip_lut_size>(
             //     w * tile_width, partial_reduce_W, 0, *p_reciprocals);
         }

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded_welford.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded_welford.cpp
@@ -262,23 +262,22 @@ void MAIN {
     index_h_offset = 0;
     for (uint32_t i = 0; i < block_ht; i++) {
         tile_regs_acquire();
-        welford_clear_previous_mean_and_m2();
+        welford_clear();
         uint32_t sample_idx = 0;
 
         // Do the full Welford tiles
         for (uint32_t w = 0; w < num_full_welford_tiles; w++) {
             transpose_wh_tile(cb_in, w + index_h_offset, welford_input_dst);
-            welford_tile<per_core_recip_lut_size>(welford_input_dst, sample_idx, *p_reciprocals);
+            welford_update<per_core_recip_lut_size>(welford_input_dst, sample_idx, *p_reciprocals);
             sample_idx += tile_width;
         }
         // Do the partial Welford tile, if any
         if (partial_welford_tile_w > 0) {
             transpose_wh_tile(cb_in, block_wt - 1, welford_input_dst);
-            welford_partial_tile<per_core_recip_lut_size>(
+            welford_update_rows<per_core_recip_lut_size>(
                 welford_input_dst, sample_idx, 0, partial_welford_tile_w, *p_reciprocals);
         }
-        welford_store_mean_var_to_dst_row<per_core_recip_lut_size>(
-            welford_mean_dst, partial_reduce_W - 1, *p_reciprocals);
+        welford_finalize_to_row<per_core_recip_lut_size>(welford_mean_dst, partial_reduce_W - 1, *p_reciprocals);
         // We should transpose back to columns here
         // However, transpose_wh_dest() is currently buggy.
         // So we transpose to an intermediate CB downstream

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_welford.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_welford.cpp
@@ -2,7 +2,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <cinttypes>
 #include <cstdint>
 
 #define BCAST_LLKOP EltwiseBinaryType::ELWMUL
@@ -10,19 +9,12 @@
 
 #include "compute_kernel_api/bcast.h"
 #include "compute_kernel_api/eltwise_binary.h"
-#include "compute_kernel_api/layernorm.h"
-#include "compute_kernel_api/tile_move_copy.h"
 #include "compute_kernel_api/eltwise_binary_sfpu.h"
 #include "compute_kernel_api/eltwise_unary/rsqrt.h"
-#include "compute_kernel_api/transpose_wh_dest.h"
-#include "compute_kernel_api/eltwise_unary/binop_with_scalar.h"
 #include "compute_kernel_api/welford.h"
 #include "compute_kernel_api/transpose_wh.h"
 #include "compute_kernel_api/compute_kernel_hw_startup.h"
 #include "ttnn/operations/normalization/kernel_util/compute/memory.h"
-
-ALWI void ACQ() { acquire_dst(); }
-ALWI void REL() { release_dst(); }
 
 namespace NAMESPACE {
 
@@ -65,9 +57,13 @@ void MAIN {
         }
     }();
 
-    constexpr int dst0 = 0;  // Input tile to Welford's algorithm
-    constexpr int dst1 = 1;  // Partial E[x] result for Welford's
-    constexpr int dst2 = 2;  // Partial Var[x] result for Welford's
+    constexpr uint32_t dst0 = 0;
+    constexpr uint32_t input_dst = 0;  // Input tile for Welford's algorithm
+    constexpr uint32_t mean_dst = 1;
+    constexpr uint32_t var_dst = 2;
+
+    // The number of valid rows in the last tile in width dimension
+    constexpr uint32_t last_tile_rows = (W % tile_width) == 0 ? tile_width : W % tile_width;
 
     cb_wait_front(cb_eps, 1);     // comes from the reader
 
@@ -90,49 +86,59 @@ void MAIN {
             reconfig_data_format(cb_in, cb_inb);
             pack_reconfig_data_format(cb_x);
             for (uint32_t wt = 0; wt < Wt; wt += blk) {
-                ACQ();
                 cb_wait_front(cb_in, blk);
                 cb_wait_front(cb_inb, blk);
-                cb_reserve_back(cb_x, blk);
+                tile_regs_acquire();
                 for (uint32_t j = 0; j < blk; j++) {
                     add_tiles(cb_in, cb_inb, j, j, j);
-                    pack_tile(j, cb_x);
                 }
-                REL();
-                cb_push_back(cb_x, blk);  // push the sum into the same buffer
+                tile_regs_commit();
                 cb_pop_front(cb_in, blk);
                 cb_pop_front(cb_inb, blk);
+
+                cb_reserve_back(cb_x, blk);
+                tile_regs_wait();
+                for (uint32_t j = 0; j < blk; j++) {
+                    pack_tile(j, cb_x);
+                }
+                tile_regs_release();
+                cb_push_back(cb_x, blk);  // push the sum into the same buffer
             }
             reconfig_data_format(cb_in, cb_x, cb_inb, cb_ex);
         }
 
         // Simultaneous calculation of E[x] and Var[x] using Welford's algorithm
-        ACQ();
-
         uint32_t start_N = 0;
         transpose_wh_init_short(cb_x);
+        tile_regs_acquire();
         welford_init();
-        for (uint32_t wt = 0; wt < Wt; wt += blk) {
-            cb_wait_front(cb_x, wt + blk);
-            for (uint32_t j = 0; j < blk; j++) {
-                // Welford's needs transposed input tile
-                transpose_wh_tile(cb_x, wt + j, dst0);
-                welford_tile<W>(dst0, start_N, *p_reciprocals);
-                start_N += tile_width;
-            }
+        // Process all but the last tile
+        for (uint32_t wt = 0; wt < (Wt - 1); ++wt) {
+            cb_wait_front(cb_x, wt + 1);
+            // Welford's needs transposed input tile
+            transpose_wh_tile(cb_x, wt, input_dst);
+            welford_tile<W>(input_dst, start_N, *p_reciprocals);
+            start_N += tile_width;
         }
-        welford_store_mean_var_to_dst_row<W>(dst1, W - 1, *p_reciprocals);
 
-        // Transpose dst1 and dst2 back to columns
+        // Process the last tile
+        cb_wait_front(cb_x, Wt);
+        transpose_wh_tile(cb_x, Wt - 1, input_dst);
+        welford_partial_tile<W>(input_dst, start_N, 0, last_tile_rows, *p_reciprocals);
+
+        // Store the mean and variance to the destination registers
+        welford_store_mean_var_to_dst_row<W>(mean_dst, W - 1, *p_reciprocals);
+        tile_regs_commit();
+
+        // Transpose mean and var back to columns
         cb_reserve_back(cb_ex, onetile);
         cb_reserve_back(cb_ex2, onetile);
-
+        tile_regs_wait();
         pack_reconfig_data_format(cb_ex);
-        pack_tile(dst1, cb_ex);
+        pack_tile(mean_dst, cb_ex);
         pack_reconfig_data_format(cb_ex2);
-        pack_tile(dst2, cb_ex2);
+        pack_tile(var_dst, cb_ex2);
         tile_regs_release();
-
         cb_push_back(cb_ex, onetile);
         cb_push_back(cb_ex2, onetile);
 
@@ -140,10 +146,9 @@ void MAIN {
         cb_wait_front(cb_ex2, onetile);
         reconfig_data_format_srca(cb_ex);
         transpose_wh_init_short(cb_ex);
-
         tile_regs_acquire();
-        transpose_wh_tile(cb_ex, 0, dst1);
-        transpose_wh_tile(cb_ex2, 0, dst2);
+        transpose_wh_tile(cb_ex, 0, mean_dst);
+        transpose_wh_tile(cb_ex2, 0, var_dst);
         tile_regs_commit();
 
         cb_pop_front(cb_ex, onetile);
@@ -151,17 +156,16 @@ void MAIN {
 
         cb_reserve_back(cb_ex, onetile);
         cb_reserve_back(cb_ex2, onetile);
-        pack_reconfig_data_format(cb_ex);
 
+        pack_reconfig_data_format(cb_ex);
         tile_regs_wait();
-        pack_tile(dst1, cb_ex);
+        pack_tile(mean_dst, cb_ex);
         pack_reconfig_data_format(cb_ex2);
-        pack_tile(dst2, cb_ex2);
+        pack_tile(var_dst, cb_ex2);
         tile_regs_release();
 
         cb_push_back(cb_ex, onetile);
         cb_push_back(cb_ex2, onetile);
-        REL();
 
         // x - E[x]
         // Reuse cb_x since we didn't pop anything from it
@@ -172,13 +176,17 @@ void MAIN {
         cb_reserve_back(cb_xmm, Wt);
         sub_bcast_cols_init_short(cb_x, cb_ex);
         for (uint32_t wt = 0; wt < Wt; wt += blk) {
-            ACQ();
+            tile_regs_acquire();
             for (uint32_t wtr = 0; wtr < blk; wtr++) {
                 sub_tiles_bcast_cols(cb_x, cb_ex, wt + wtr, 0, wtr);
+            }
+            tile_regs_commit();
+            tile_regs_wait();
+            for (uint32_t wtr = 0; wtr < blk; wtr++) {
                 pack_tile(wtr, cb_xmm);
             }
+            tile_regs_release();
             cb_push_back(cb_xmm, blk);
-            REL();
         }
         cb_pop_front(cb_ex, 1);
         cb_pop_front(cb_x, Wt);
@@ -193,17 +201,19 @@ void MAIN {
             reconfig_data_format(cb_ex2, cb_eps);
         }
         cb_wait_front(cb_ex2, onetile);  // should have 1 tile
-        ACQ();
+        tile_regs_acquire();
         add_tiles_init(cb_ex2, cb_eps);
         add_tiles(cb_ex2, cb_eps, 0, 0, dst0);
-
-        cb_reserve_back(cb_ex2pe, onetile);
         rsqrt_tile_init();
         rsqrt_tile(dst0);
-        pack_tile(dst0, cb_ex2pe);
-        cb_push_back(cb_ex2pe, onetile);
-        REL();
+        tile_regs_commit();
         cb_pop_front(cb_ex2, onetile);
+
+        cb_reserve_back(cb_ex2pe, onetile);
+        tile_regs_wait();
+        pack_tile(dst0, cb_ex2pe);
+        tile_regs_release();
+        cb_push_back(cb_ex2pe, onetile);
 
         // Remainder of the layernorm operation
         // norm(x) * gamma + beta,
@@ -217,38 +227,47 @@ void MAIN {
             } else {
                 pack_reconfig_data_format(cb_fusion);
             }
-            cb_reserve_back(cb_im_or_out, blk);
 
-            ACQ();
             mul_bcast_cols_init_short(cb_xmm, cb_ex2pe);
+            tile_regs_acquire();
             for (uint32_t wtr = 0; wtr < blk; wtr++) {
                 // cb_xmm[wt+wtr] since we pop Wt from cb_xmm after the entire loop
                 mul_tiles_bcast_cols(cb_xmm, cb_ex2pe, wt + wtr, 0, wtr);
+            }
+            tile_regs_commit();
+
+            cb_reserve_back(cb_im_or_out, blk);
+            tile_regs_wait();
+            for (uint32_t wtr = 0; wtr < blk; wtr++) {
                 pack_tile(wtr, cb_im_or_out);  // pack either to intermediate (cb_fusion or out0)
             }
+            tile_regs_release();
             cb_push_back(cb_im_or_out, blk);  // if no gamma/beta are provided, this will be passed on to the writer
-            REL();
 
             if constexpr (do_gamma) {
                 if constexpr (do_beta == 0) {
                     pack_reconfig_data_format(cb_out);
                 }
                 reconfig_data_format_srcb(cb_ex2pe, cb_gamma);
-                ACQ();
                 uint32_t cb_outg = do_beta ? cb_fusion : cb_out;
                 mul_bcast_rows_init_short(cb_fusion, cb_gamma);
-                cb_reserve_back(cb_outg, blk);
                 cb_wait_front(cb_gamma, wt + blk);  // we don't pop, TODO: only wait on first ht
                 cb_wait_front(cb_fusion, blk);
+                tile_regs_acquire();
                 for (uint32_t wtr = 0; wtr < blk; wtr++) {
                     mul_tiles_bcast_rows(cb_fusion, cb_gamma, wtr, wt + wtr, wtr);  // tile *= 1/(sum(exp(x)))
+                }
+                tile_regs_commit();
+                // We don't pop gamma since it's 1,1,1,Wt and we reuse it for all NCHt
+                cb_pop_front(cb_fusion, blk);
+
+                cb_reserve_back(cb_outg, blk);
+                tile_regs_wait();
+                for (uint32_t wtr = 0; wtr < blk; wtr++) {
                     pack_tile(wtr, cb_outg);  // pack either to intermediate (cb_fusion or out0)
                 }
-                cb_pop_front(cb_fusion, blk);
-                // we don't pop gamma
+                tile_regs_release();
                 cb_push_back(cb_outg, blk);
-                // We don't pop gamma since it's 1,1,1,Wt and we reuse it for all NCHt
-                REL();
             }
             if constexpr (do_beta) {
                 pack_reconfig_data_format(cb_out);
@@ -257,19 +276,25 @@ void MAIN {
                 } else {
                     reconfig_data_format_srcb(cb_ex2pe, cb_beta);
                 }
-                ACQ();
+
                 add_bcast_rows_init_short(cb_fusion, cb_beta);
-                cb_reserve_back(cb_out, blk);
                 cb_wait_front(cb_beta, wt + blk);  // TODO: optimization - only wait on first ht
                 cb_wait_front(cb_fusion, blk);
+                tile_regs_acquire();
                 for (uint32_t wtr = 0; wtr < blk; wtr++) {
                     add_tiles_bcast_rows(cb_fusion, cb_beta, wtr, wt + wtr, wtr);  // tile *= 1/(sum(exp(x)))
-                    pack_tile(wtr, cb_out);  // pack either to intermediate (cb_fusion or out0)
                 }
+                tile_regs_commit();
                 cb_pop_front(cb_fusion, blk);
                 // We don't pop beta since it's 1,1,1,Wt and we reuse it for all NCHt
+
+                cb_reserve_back(cb_out, blk);
+                tile_regs_wait();
+                for (uint32_t wtr = 0; wtr < blk; wtr++) {
+                    pack_tile(wtr, cb_out);  // pack either to intermediate (cb_fusion or out0)
+                }
+                tile_regs_release();
                 cb_push_back(cb_out, blk);
-                REL();
             }
         }
         cb_pop_front(cb_ex2pe, onetile);

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_welford.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_welford.cpp
@@ -107,7 +107,7 @@ void MAIN {
         }
 
         // Simultaneous calculation of E[x] and Var[x] using Welford's algorithm
-        tile_regs_acquire();
+        ACQ();
 
         uint32_t start_N = 0;
         transpose_wh_init_short(cb_x);
@@ -122,13 +122,12 @@ void MAIN {
                 start_N += tile_width;
             }
         }
-        welford_store_mean_var_to_dst_col<W>(dst1, start_N - 1, *p_reciprocals);
-        tile_regs_commit();
+        welford_store_mean_var_to_dst_col<W>(dst1, W - 1, *p_reciprocals);
 
         // Transpose dst1 and dst2 back to columns
         cb_reserve_back(cb_ex, onetile);
         cb_reserve_back(cb_ex2, onetile);
-        tile_regs_wait();
+
         pack_reconfig_data_format(cb_ex);
         pack_tile(dst1, cb_ex);
         pack_reconfig_data_format(cb_ex2);
@@ -163,6 +162,7 @@ void MAIN {
 
         cb_push_back(cb_ex, onetile);
         cb_push_back(cb_ex2, onetile);
+        REL();
 
         // x - E[x]
         // Reuse cb_x since we didn't pop anything from it

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_welford.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_welford.cpp
@@ -112,7 +112,6 @@ void MAIN {
         uint32_t start_N = 0;
         transpose_wh_init_short(cb_x);
         welford_init();
-        welford_clear_previous_mean_and_m2();
         for (uint32_t wt = 0; wt < Wt; wt += blk) {
             cb_wait_front(cb_x, wt + blk);
             for (uint32_t j = 0; j < blk; j++) {
@@ -122,7 +121,7 @@ void MAIN {
                 start_N += tile_width;
             }
         }
-        welford_store_mean_var_to_dst_col<W>(dst1, W - 1, *p_reciprocals);
+        welford_store_mean_var_to_dst_row<W>(dst1, W - 1, *p_reciprocals);
 
         // Transpose dst1 and dst2 back to columns
         cb_reserve_back(cb_ex, onetile);

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_welford.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_welford.cpp
@@ -117,17 +117,17 @@ void MAIN {
             cb_wait_front(cb_x, wt + 1);
             // Welford's needs transposed input tile
             transpose_wh_tile(cb_x, wt, input_dst);
-            welford_tile<W>(input_dst, start_N, *p_reciprocals);
+            welford_update<W>(input_dst, start_N, *p_reciprocals);
             start_N += tile_width;
         }
 
         // Process the last tile
         cb_wait_front(cb_x, Wt);
         transpose_wh_tile(cb_x, Wt - 1, input_dst);
-        welford_partial_tile<W>(input_dst, start_N, 0, last_tile_rows, *p_reciprocals);
+        welford_update_rows<W>(input_dst, start_N, 0, last_tile_rows, *p_reciprocals);
 
         // Store the mean and variance to the destination registers
-        welford_store_mean_var_to_dst_row<W>(mean_dst, W - 1, *p_reciprocals);
+        welford_finalize_to_row<W>(mean_dst, W - 1, *p_reciprocals);
         tile_regs_commit();
 
         // Transpose mean and var back to columns

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/multi_core/layernorm_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/multi_core/layernorm_op_multi_core.cpp
@@ -1315,11 +1315,10 @@ operation::ProgramWithCallbacks layernorm_multi_core_sharded(
         compute_defines["RMSNORM"] = "1";
     }
 
-    // Create the sharded reciprocal LUT tensor if using Welford.
-    // The size has to be a compile-time constant in the kernel,
-    // so we'll take the max of the padded and unpadded partial reduce widths.
-    uint32_t per_core_recip_lut_size = std::max(num_rows_per_all_to_all_worker, num_rows_per_all_to_all_worker_last);
-    per_core_recip_lut_size *= row_wise ? tt::constants::TILE_WIDTH : tt::constants::TILE_HEIGHT;
+    // The last core may not need the entire block_w worth of reciprocals,
+    // but the table size has to be a compile-time argument, so we use
+    // the max value that it'll be.
+    uint32_t per_core_recip_lut_size = block_w;
     auto [recip_tensor, reciprocal_CB_size_bytes] =
         create_reciprocal_tensor_if_needed(device, per_core_recip_lut_size, all_cores, use_welford);
 

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/multi_core/layernorm_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/multi_core/layernorm_op_multi_core.cpp
@@ -444,17 +444,6 @@ operation::ProgramWithCallbacks layernorm_multi_core(
     CircularBufferConfig cb_in3_config =
         CircularBufferConfig(in3_t * bfloat16_tile_size, {{tt::CBIndex::c_3, tt::DataFormat::Float16_b}})
             .set_page_size(tt::CBIndex::c_3, bfloat16_tile_size);
-    if (large_tensor_needed && use_welford_and_not_rms_norm) {
-        // The two ping-pong buffers for Welford's mean/var
-        CircularBufferConfig cb_welford_ping_config =
-            CircularBufferConfig(im4_t * single_tile_size, {{tt::CBIndex::c_4, cb_data_format}})
-                .set_page_size(tt::CBIndex::c_4, single_tile_size);
-        CreateCircularBuffer(program, all_cores, cb_welford_ping_config);
-        CircularBufferConfig cb_welford_pong_config =
-            CircularBufferConfig(im4_t * single_tile_size, {{tt::CBIndex::c_7, cb_data_format}})
-                .set_page_size(tt::CBIndex::c_7, single_tile_size);
-        CreateCircularBuffer(program, all_cores, cb_welford_pong_config);
-    }
     CreateCircularBuffer(program, all_cores, cb_in3_config);
     CircularBufferConfig cb_intermed2_config =
         CircularBufferConfig(im2_t * single_tile_size, {{tt::CBIndex::c_19, cb_data_format}})


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/29706

### Problem description
A single tensix core normalizes over multiples groups when running groupnorm kernel. For large tensors, the input is typically stored in DRAM.

At present, there are two loops to read the input for normalization:
```python
for batch:
  for group:
    for input:
       ...
```
The reads scale linearly with the number of groups processed by a core, increasing runtime.

### What's changed
We implement a version of loop inversion, by swapping the order of the last two loops. Thus,

```python
for batch:
  for input:
    for group:
       ...
```
Since a group can span multiple inputs and an input can span multiple groups, we store the partials of each group, which is updated online when processing the next input.

Note that not all groups are part of all inputs, so we keep track of that and update only those groups that are relevant for a given input tile.

## Performance
With this approach, we see upto 3x reduction in runtime as compared to earlier implementation of welfords. The table below summarizes the improvements.

Note: Speed up is reported as percentage improvement. i.e. if a kernel took 90 us now which earlier took 100 us, we say there is a 10% improvement. A negative number indicates slowdown, a positive number indicates speed up. Higher the better.

There are a handful of cases where the time is worse than before. It is to be noted that for cases where the entire tensor fits in L1, use of welfords is not recommended so this slowdown should have low impact.


### Speed Up - Blackhole

| Trace | Minimum | Median | Maximum |
|------|----------------|-------------------|----------------|
| Groupnorm (L1) | -10% | -6% | 67% |
| Groupnorm (DRAM) | 0% | 23% | 130% |
| Groupnorm (DRAM), Large | 25% | 96% | 189% |
| Layernorm | -1% | 4% | 46% |
| Layernorm sharded | 0% | 28% | 201% |

### Speed Up - Wormhole

| Trace | Minimum | Median | Maximum |
|------|----------------|-------------------|----------------|
| Groupnorm (L1) | -12% | -5% | 65% |
| Groupnorm (DRAM) | -2% | 23% | 183% |
| Groupnorm (DRAM), Large | 19% | 73% | 210% |
| Layernorm | -2% | 8% | 102% |
| Layernorm sharded | 0% | 35% | 261% |

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/19155524116
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/19155531301
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/19160399398
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/19243843123
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [x] New/Existing tests provide coverage for changes
- [x] L2 Nightly https://github.com/tenstorrent/tt-metal/actions/runs/19234868630
- [x] Frequent model and ttnn tests https://github.com/tenstorrent/tt-metal/actions/runs/19234877365 