### PR TITLE
Cleanup `core_coord.hpp`

### DIFF
--- a/tt_metal/api/tt-metalium/core_coord.hpp
+++ b/tt_metal/api/tt-metalium/core_coord.hpp
@@ -219,43 +219,46 @@ using CoreRange [[deprecated("Use tt::tt_metal::CoreRange")]] = tt::tt_metal::Co
 using CoreRangeSet [[deprecated("Use tt::tt_metal::CoreRangeSet")]] = tt::tt_metal::CoreRangeSet;
 
 // Deprecated function wrappers - use tt::tt_metal namespace versions instead
-[[deprecated("Use tt::tt_metal::corerange_to_cores")]]
-inline std::vector<CoreCoord> corerange_to_cores(
+// template to depriorize the wrappers in overloading to avoid ambigous selection from compiler.
+
+template <bool _compiler_depriotize_this = true>
+[[deprecated("Use tt::tt_metal::corerange_to_cores")]] inline std::vector<CoreCoord> corerange_to_cores(
     const CoreRangeSet& crs, std::optional<uint32_t> max_cores = std::nullopt, bool row_wise = false) {
     return tt::tt_metal::corerange_to_cores(crs, max_cores, row_wise);
 }
 
-[[deprecated("Use tt::tt_metal::grid_to_cores")]]
-inline std::vector<CoreCoord> grid_to_cores(
+template <bool _compiler_depriotize_this = true>
+[[deprecated("Use tt::tt_metal::grid_to_cores")]] inline std::vector<CoreCoord> grid_to_cores(
     uint32_t num_cores, uint32_t grid_size_x, uint32_t grid_size_y, bool row_wise = false) {
     return tt::tt_metal::grid_to_cores(num_cores, grid_size_x, grid_size_y, row_wise);
 }
 
-[[deprecated("Use tt::tt_metal::grid_to_cores")]]
-inline std::vector<CoreCoord> grid_to_cores(CoreCoord start, CoreCoord end, bool row_wise = false) {
+template <bool _compiler_depriotize_this = true>
+[[deprecated("Use tt::tt_metal::grid_to_cores")]] inline std::vector<CoreCoord> grid_to_cores(
+    CoreCoord start, CoreCoord end, bool row_wise = false) {
     return tt::tt_metal::grid_to_cores(start, end, row_wise);
 }
 
-[[deprecated("Use tt::tt_metal::grid_to_cores_with_noop")]]
-inline std::vector<CoreCoord> grid_to_cores_with_noop(
+template <bool _compiler_depriotize_this = true>
+[[deprecated("Use tt::tt_metal::grid_to_cores_with_noop")]] inline std::vector<CoreCoord> grid_to_cores_with_noop(
     uint32_t bbox_x, uint32_t bbox_y, uint32_t grid_size_x, uint32_t grid_size_y, bool row_wise = false) {
     return tt::tt_metal::grid_to_cores_with_noop(bbox_x, bbox_y, grid_size_x, grid_size_y, row_wise);
 }
 
-[[deprecated("Use tt::tt_metal::grid_to_cores_with_noop")]]
-inline std::vector<CoreCoord> grid_to_cores_with_noop(
+template <bool _compiler_depriotize_this = true>
+[[deprecated("Use tt::tt_metal::grid_to_cores_with_noop")]] inline std::vector<CoreCoord> grid_to_cores_with_noop(
     const CoreRangeSet& used_cores, const CoreRangeSet& all_cores, bool row_wise = false) {
     return tt::tt_metal::grid_to_cores_with_noop(used_cores, all_cores, row_wise);
 }
 
-[[deprecated("Use tt::tt_metal::select_contiguous_range_from_corerangeset")]]
-inline std::optional<CoreRange> select_contiguous_range_from_corerangeset(
-    const CoreRangeSet& crs, uint32_t x, uint32_t y) {
+template <bool _compiler_depriotize_this = true>
+[[deprecated("Use tt::tt_metal::select_contiguous_range_from_corerangeset")]] inline std::optional<CoreRange>
+select_contiguous_range_from_corerangeset(const CoreRangeSet& crs, uint32_t x, uint32_t y) {
     return tt::tt_metal::select_contiguous_range_from_corerangeset(crs, x, y);
 }
 
-[[deprecated("Use tt::tt_metal::select_from_corerangeset")]]
-inline CoreRangeSet select_from_corerangeset(
+template <bool _compiler_depriotize_this = true>
+[[deprecated("Use tt::tt_metal::select_from_corerangeset")]] inline CoreRangeSet select_from_corerangeset(
     const CoreRangeSet& crs, uint32_t start_index, uint32_t end_index, bool row_wise = false) {
     return tt::tt_metal::select_from_corerangeset(crs, start_index, end_index, row_wise);
 }

--- a/tt_metal/api/tt-metalium/core_coord.hpp
+++ b/tt_metal/api/tt-metalium/core_coord.hpp
@@ -221,43 +221,43 @@ using CoreRangeSet [[deprecated("Use tt::tt_metal::CoreRangeSet")]] = tt::tt_met
 // Deprecated function wrappers - use tt::tt_metal namespace versions instead
 // template to depriorize the wrappers in overloading to avoid ambigous selection from compiler.
 
-template <bool _compiler_depriotize_this = true>
+template <bool _compiler_deprioritize_this = true>
 [[deprecated("Use tt::tt_metal::corerange_to_cores")]] inline std::vector<CoreCoord> corerange_to_cores(
     const CoreRangeSet& crs, std::optional<uint32_t> max_cores = std::nullopt, bool row_wise = false) {
     return tt::tt_metal::corerange_to_cores(crs, max_cores, row_wise);
 }
 
-template <bool _compiler_depriotize_this = true>
+template <bool _compiler_deprioritize_this = true>
 [[deprecated("Use tt::tt_metal::grid_to_cores")]] inline std::vector<CoreCoord> grid_to_cores(
     uint32_t num_cores, uint32_t grid_size_x, uint32_t grid_size_y, bool row_wise = false) {
     return tt::tt_metal::grid_to_cores(num_cores, grid_size_x, grid_size_y, row_wise);
 }
 
-template <bool _compiler_depriotize_this = true>
+template <bool _compiler_deprioritize_this = true>
 [[deprecated("Use tt::tt_metal::grid_to_cores")]] inline std::vector<CoreCoord> grid_to_cores(
     CoreCoord start, CoreCoord end, bool row_wise = false) {
     return tt::tt_metal::grid_to_cores(start, end, row_wise);
 }
 
-template <bool _compiler_depriotize_this = true>
+template <bool _compiler_deprioritize_this = true>
 [[deprecated("Use tt::tt_metal::grid_to_cores_with_noop")]] inline std::vector<CoreCoord> grid_to_cores_with_noop(
     uint32_t bbox_x, uint32_t bbox_y, uint32_t grid_size_x, uint32_t grid_size_y, bool row_wise = false) {
     return tt::tt_metal::grid_to_cores_with_noop(bbox_x, bbox_y, grid_size_x, grid_size_y, row_wise);
 }
 
-template <bool _compiler_depriotize_this = true>
+template <bool _compiler_deprioritize_this = true>
 [[deprecated("Use tt::tt_metal::grid_to_cores_with_noop")]] inline std::vector<CoreCoord> grid_to_cores_with_noop(
     const CoreRangeSet& used_cores, const CoreRangeSet& all_cores, bool row_wise = false) {
     return tt::tt_metal::grid_to_cores_with_noop(used_cores, all_cores, row_wise);
 }
 
-template <bool _compiler_depriotize_this = true>
+template <bool _compiler_deprioritize_this = true>
 [[deprecated("Use tt::tt_metal::select_contiguous_range_from_corerangeset")]] inline std::optional<CoreRange>
 select_contiguous_range_from_corerangeset(const CoreRangeSet& crs, uint32_t x, uint32_t y) {
     return tt::tt_metal::select_contiguous_range_from_corerangeset(crs, x, y);
 }
 
-template <bool _compiler_depriotize_this = true>
+template <bool _compiler_deprioritize_this = true>
 [[deprecated("Use tt::tt_metal::select_from_corerangeset")]] inline CoreRangeSet select_from_corerangeset(
     const CoreRangeSet& crs, uint32_t start_index, uint32_t end_index, bool row_wise = false) {
     return tt::tt_metal::select_from_corerangeset(crs, start_index, end_index, row_wise);

--- a/tt_metal/api/tt-metalium/core_coord.hpp
+++ b/tt_metal/api/tt-metalium/core_coord.hpp
@@ -43,19 +43,6 @@ struct fmt::formatter<CoreCoord> {
 
 constexpr bool operator<=(const CoreCoord& a, const CoreCoord& b) { return (a < b) or (a == b); }
 
-struct RelativeCoreCoord {
-    long x = 0;
-    long y = 0;
-
-    std::string str() const;
-};
-
-constexpr bool operator==(const RelativeCoreCoord& a, const RelativeCoreCoord& b) { return a.x == b.x && a.y == b.y; }
-
-constexpr bool operator!=(const RelativeCoreCoord& a, const RelativeCoreCoord& b) { return !(a == b); }
-
-CoreCoord get_core_coord_from_relative(const RelativeCoreCoord& in, const CoreCoord& grid_size);
-
 class CoreRange {
 public:
     CoreCoord start_coord;
@@ -258,11 +245,6 @@ struct hash<CoreRange> {
 };
 
 template <>
-struct hash<RelativeCoreCoord> {
-    std::size_t operator()(RelativeCoreCoord const& o) const;
-};
-
-template <>
 struct hash<CoreRangeSet> {
     std::size_t operator()(const CoreRangeSet& core_range_set) const;
 };
@@ -279,16 +261,6 @@ struct to_json_t<CoreCoord> {
 template <>
 struct from_json_t<CoreCoord> {
     CoreCoord operator()(const nlohmann::json& json) noexcept;
-};
-
-template <>
-struct to_json_t<RelativeCoreCoord> {
-    nlohmann::json operator()(const RelativeCoreCoord& relative_core_coord) noexcept;
-};
-
-template <>
-struct from_json_t<RelativeCoreCoord> {
-    RelativeCoreCoord operator()(const nlohmann::json& json) noexcept;
 };
 
 template <>

--- a/tt_metal/api/tt-metalium/core_coord.hpp
+++ b/tt_metal/api/tt-metalium/core_coord.hpp
@@ -30,16 +30,11 @@ struct to_json_t;
 }  // namespace stl
 }  // namespace tt
 
+namespace tt::tt_metal {
+
 using CoreCoord = tt_xy_pair;
 
 class CoreRangeSet;
-
-template <>
-struct fmt::formatter<CoreCoord> {
-    constexpr auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.end(); }
-
-    auto format(const CoreCoord& core_coord, format_context& ctx) const -> format_context::iterator;
-};
 
 constexpr bool operator<=(const CoreCoord& a, const CoreCoord& b) { return (a < b) or (a == b); }
 
@@ -110,13 +105,6 @@ constexpr bool operator<(const CoreRange& left, const CoreRange& right) {
         left.start_coord < right.start_coord ||
         (left.start_coord == right.start_coord && left.end_coord < right.end_coord));
 }
-
-template <>
-struct fmt::formatter<CoreRange> {
-    constexpr auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.end(); }
-
-    auto format(const CoreRange& core_range, format_context& ctx) const -> format_context::iterator;
-};
 
 class CoreRangeSet {
 public:
@@ -223,30 +211,50 @@ std::optional<CoreRange> select_contiguous_range_from_corerangeset(const CoreRan
 
 bool operator!=(const CoreRangeSet& a, const CoreRangeSet& b);
 
-template <>
-struct fmt::formatter<CoreRangeSet> {
-    constexpr auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.end(); }
-
-    auto format(const CoreRangeSet& core_range_set, format_context& ctx) const -> format_context::iterator;
-};
+}  // namespace tt::tt_metal
 
 // Adding to tt::tt_metal namespace as we transition to moving this out of global namespace eventually.
-namespace tt::tt_metal {
-using ::CoreCoord;
-using ::CoreRange;
-using ::CoreRangeSet;
-}  // namespace tt::tt_metal
+using tt::tt_metal::CoreCoord;
+using tt::tt_metal::CoreRange;
+using tt::tt_metal::CoreRangeSet;
+// using tt::tt_metal::corerange_to_cores;
+// using tt::tt_metal::grid_to_cores;
+// using tt::tt_metal::grid_to_cores_with_noop;
+// using tt::tt_metal::select_contiguous_range_from_corerangeset;
+// using tt::tt_metal::select_from_corerangeset;
+
+template <>
+struct fmt::formatter<tt::tt_metal::CoreRangeSet> {
+    constexpr auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.end(); }
+
+    auto format(const tt::tt_metal::CoreRangeSet& core_range_set, format_context& ctx) const
+        -> format_context::iterator;
+};
+
+template <>
+struct fmt::formatter<tt::tt_metal::CoreRange> {
+    constexpr auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.end(); }
+
+    auto format(const tt::tt_metal::CoreRange& core_range, format_context& ctx) const -> format_context::iterator;
+};
+
+template <>
+struct fmt::formatter<tt::tt_metal::CoreCoord> {
+    constexpr auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.end(); }
+
+    auto format(const tt::tt_metal::CoreCoord& core_coord, format_context& ctx) const -> format_context::iterator;
+};
 
 namespace std {
 
 template <>
-struct hash<CoreRange> {
-    std::size_t operator()(const CoreRange& core_range) const;
+struct hash<tt::tt_metal::CoreRange> {
+    std::size_t operator()(const tt::tt_metal::CoreRange& core_range) const;
 };
 
 template <>
-struct hash<CoreRangeSet> {
-    std::size_t operator()(const CoreRangeSet& core_range_set) const;
+struct hash<tt::tt_metal::CoreRangeSet> {
+    std::size_t operator()(const tt::tt_metal::CoreRangeSet& core_range_set) const;
 };
 
 }  // namespace std
@@ -254,33 +262,33 @@ struct hash<CoreRangeSet> {
 namespace ttsl::json {
 
 template <>
-struct to_json_t<CoreCoord> {
-    nlohmann::json operator()(const CoreCoord& core_coord) noexcept;
+struct to_json_t<tt::tt_metal::CoreCoord> {
+    nlohmann::json operator()(const tt::tt_metal::CoreCoord& core_coord) noexcept;
 };
 
 template <>
-struct from_json_t<CoreCoord> {
-    CoreCoord operator()(const nlohmann::json& json) noexcept;
+struct from_json_t<tt::tt_metal::CoreCoord> {
+    tt::tt_metal::CoreCoord operator()(const nlohmann::json& json) noexcept;
 };
 
 template <>
-struct to_json_t<CoreRange> {
-    nlohmann::json operator()(const CoreRange& core_range) noexcept;
+struct to_json_t<tt::tt_metal::CoreRange> {
+    nlohmann::json operator()(const tt::tt_metal::CoreRange& core_range) noexcept;
 };
 
 template <>
-struct from_json_t<CoreRange> {
-    CoreRange operator()(const nlohmann::json& json) noexcept;
+struct from_json_t<tt::tt_metal::CoreRange> {
+    tt::tt_metal::CoreRange operator()(const nlohmann::json& json) noexcept;
 };
 
 template <>
-struct to_json_t<CoreRangeSet> {
-    nlohmann::json operator()(const CoreRangeSet& core_range_set) noexcept;
+struct to_json_t<tt::tt_metal::CoreRangeSet> {
+    nlohmann::json operator()(const tt::tt_metal::CoreRangeSet& core_range_set) noexcept;
 };
 
 template <>
-struct from_json_t<CoreRangeSet> {
-    CoreRangeSet operator()(const nlohmann::json& json) noexcept;
+struct from_json_t<tt::tt_metal::CoreRangeSet> {
+    tt::tt_metal::CoreRangeSet operator()(const nlohmann::json& json) noexcept;
 };
 
 }  // namespace ttsl::json

--- a/tt_metal/api/tt-metalium/core_coord.hpp
+++ b/tt_metal/api/tt-metalium/core_coord.hpp
@@ -216,12 +216,12 @@ bool operator!=(const CoreRangeSet& a, const CoreRangeSet& b);
 // Adding to tt::tt_metal namespace as we transition to moving this out of global namespace eventually.
 using tt::tt_metal::CoreCoord;
 using tt::tt_metal::CoreRange;
+using tt::tt_metal::corerange_to_cores;
 using tt::tt_metal::CoreRangeSet;
-// using tt::tt_metal::corerange_to_cores;
-// using tt::tt_metal::grid_to_cores;
-// using tt::tt_metal::grid_to_cores_with_noop;
-// using tt::tt_metal::select_contiguous_range_from_corerangeset;
-// using tt::tt_metal::select_from_corerangeset;
+using tt::tt_metal::grid_to_cores;
+using tt::tt_metal::grid_to_cores_with_noop;
+using tt::tt_metal::select_contiguous_range_from_corerangeset;
+using tt::tt_metal::select_from_corerangeset;
 
 template <>
 struct fmt::formatter<tt::tt_metal::CoreRangeSet> {

--- a/tt_metal/api/tt-metalium/core_coord.hpp
+++ b/tt_metal/api/tt-metalium/core_coord.hpp
@@ -214,14 +214,51 @@ bool operator!=(const CoreRangeSet& a, const CoreRangeSet& b);
 }  // namespace tt::tt_metal
 
 // Adding to tt::tt_metal namespace as we transition to moving this out of global namespace eventually.
-using tt::tt_metal::CoreCoord;
-using tt::tt_metal::CoreRange;
-using tt::tt_metal::corerange_to_cores;
-using tt::tt_metal::CoreRangeSet;
-using tt::tt_metal::grid_to_cores;
-using tt::tt_metal::grid_to_cores_with_noop;
-using tt::tt_metal::select_contiguous_range_from_corerangeset;
-using tt::tt_metal::select_from_corerangeset;
+using CoreCoord [[deprecated("Use tt::tt_metal::CoreCoord")]] = tt::tt_metal::CoreCoord;
+using CoreRange [[deprecated("Use tt::tt_metal::CoreRange")]] = tt::tt_metal::CoreRange;
+using CoreRangeSet [[deprecated("Use tt::tt_metal::CoreRangeSet")]] = tt::tt_metal::CoreRangeSet;
+
+// Deprecated function wrappers - use tt::tt_metal namespace versions instead
+[[deprecated("Use tt::tt_metal::corerange_to_cores")]]
+inline std::vector<CoreCoord> corerange_to_cores(
+    const CoreRangeSet& crs, std::optional<uint32_t> max_cores = std::nullopt, bool row_wise = false) {
+    return tt::tt_metal::corerange_to_cores(crs, max_cores, row_wise);
+}
+
+[[deprecated("Use tt::tt_metal::grid_to_cores")]]
+inline std::vector<CoreCoord> grid_to_cores(
+    uint32_t num_cores, uint32_t grid_size_x, uint32_t grid_size_y, bool row_wise = false) {
+    return tt::tt_metal::grid_to_cores(num_cores, grid_size_x, grid_size_y, row_wise);
+}
+
+[[deprecated("Use tt::tt_metal::grid_to_cores")]]
+inline std::vector<CoreCoord> grid_to_cores(CoreCoord start, CoreCoord end, bool row_wise = false) {
+    return tt::tt_metal::grid_to_cores(start, end, row_wise);
+}
+
+[[deprecated("Use tt::tt_metal::grid_to_cores_with_noop")]]
+inline std::vector<CoreCoord> grid_to_cores_with_noop(
+    uint32_t bbox_x, uint32_t bbox_y, uint32_t grid_size_x, uint32_t grid_size_y, bool row_wise = false) {
+    return tt::tt_metal::grid_to_cores_with_noop(bbox_x, bbox_y, grid_size_x, grid_size_y, row_wise);
+}
+
+[[deprecated("Use tt::tt_metal::grid_to_cores_with_noop")]]
+inline std::vector<CoreCoord> grid_to_cores_with_noop(
+    const CoreRangeSet& used_cores, const CoreRangeSet& all_cores, bool row_wise = false) {
+    return tt::tt_metal::grid_to_cores_with_noop(used_cores, all_cores, row_wise);
+}
+
+[[deprecated("Use tt::tt_metal::select_contiguous_range_from_corerangeset")]]
+inline std::optional<CoreRange> select_contiguous_range_from_corerangeset(
+    const CoreRangeSet& crs, uint32_t x, uint32_t y) {
+    return tt::tt_metal::select_contiguous_range_from_corerangeset(crs, x, y);
+}
+
+[[deprecated("Use tt::tt_metal::select_from_corerangeset")]]
+inline CoreRangeSet select_from_corerangeset(
+    const CoreRangeSet& crs, uint32_t start_index, uint32_t end_index, bool row_wise = false) {
+    return tt::tt_metal::select_from_corerangeset(crs, start_index, end_index, row_wise);
+}
 
 template <>
 struct fmt::formatter<tt::tt_metal::CoreRangeSet> {

--- a/tt_metal/api/tt-metalium/host_api.hpp
+++ b/tt_metal/api/tt-metalium/host_api.hpp
@@ -32,9 +32,6 @@
  * https://www.tablesgenerator.com/markdown_tables
  * */
 
-class CoreRange;
-class CoreRangeSet;
-
 namespace tt {
 
 namespace tt_metal {
@@ -48,6 +45,8 @@ class CircularBuffer;
 struct Event;
 class Buffer;
 class GlobalSemaphore;
+class CoreRange;
+class CoreRangeSet;
 
 // ==================================================
 //                  HOST API: Device management

--- a/tt_metal/common/core_coord.cpp
+++ b/tt_metal/common/core_coord.cpp
@@ -22,14 +22,7 @@
 #include "tracy/Tracy.hpp"
 #include "common/core_coord.hpp"
 
-auto fmt::formatter<CoreCoord>::format(const CoreCoord& core_coord, format_context& ctx) const
-    -> format_context::iterator {
-    std::stringstream ss;
-    ss << core_coord.str();
-    return fmt::format_to(ctx.out(), "{}", ss.str());
-}
-
-using tt::tt_metal::RelativeCoreCoord;
+namespace tt::tt_metal {
 
 std::string RelativeCoreCoord::str() const { return "(x=" + std::to_string(x) + ",y=" + std::to_string(y) + ")"; }
 
@@ -161,13 +154,6 @@ CoreRange::CoreIterator CoreRange::end() const {
 bool CoreRange::CoreIterator::operator==(const CoreIterator& other) const { return current_ == other.current_; }
 
 bool CoreRange::CoreIterator::operator!=(const CoreIterator& other) const { return !(current_ == other.current_); }
-
-auto fmt::formatter<CoreRange>::format(const CoreRange& core_range, format_context& ctx) const
-    -> format_context::iterator {
-    std::stringstream ss;
-    ss << core_range.str();
-    return fmt::format_to(ctx.out(), "{}", ss.str());
-}
 
 CoreRangeSet::CoreRangeSet(tt::stl::Span<const CoreRange> core_ranges) :
     ranges_(core_ranges.begin(), core_ranges.end()) {
@@ -656,6 +642,22 @@ std::optional<CoreRange> select_contiguous_range_from_corerangeset(const CoreRan
 }
 
 bool operator!=(const CoreRangeSet& a, const CoreRangeSet& b) { return !(a == b); }
+
+}  // namespace tt::tt_metal
+
+auto fmt::formatter<CoreCoord>::format(const CoreCoord& core_coord, format_context& ctx) const
+    -> format_context::iterator {
+    std::stringstream ss;
+    ss << core_coord.str();
+    return fmt::format_to(ctx.out(), "{}", ss.str());
+}
+
+auto fmt::formatter<CoreRange>::format(const CoreRange& core_range, format_context& ctx) const
+    -> format_context::iterator {
+    std::stringstream ss;
+    ss << core_range.str();
+    return fmt::format_to(ctx.out(), "{}", ss.str());
+}
 
 auto fmt::formatter<CoreRangeSet>::format(const CoreRangeSet& core_range_set, format_context& ctx) const
     -> format_context::iterator {

--- a/tt_metal/common/core_coord.cpp
+++ b/tt_metal/common/core_coord.cpp
@@ -29,6 +29,8 @@ auto fmt::formatter<CoreCoord>::format(const CoreCoord& core_coord, format_conte
     return fmt::format_to(ctx.out(), "{}", ss.str());
 }
 
+using tt::tt_metal::RelativeCoreCoord;
+
 std::string RelativeCoreCoord::str() const { return "(x=" + std::to_string(x) + ",y=" + std::to_string(y) + ")"; }
 
 CoreCoord get_core_coord_from_relative(const RelativeCoreCoord& in, const CoreCoord& grid_size) {
@@ -664,6 +666,8 @@ auto fmt::formatter<CoreRangeSet>::format(const CoreRangeSet& core_range_set, fo
 
 namespace std {
 
+using tt::tt_metal::RelativeCoreCoord;
+
 std::size_t hash<RelativeCoreCoord>::operator()(RelativeCoreCoord const& o) const {
     std::size_t seed = 0;
     seed = std::hash<std::size_t>()(o.x) ^ std::hash<std::size_t>()(o.y) << 1;
@@ -697,11 +701,13 @@ CoreCoord from_json_t<CoreCoord>::operator()(const nlohmann::json& json) noexcep
     return {from_json<uint32_t>(json.at("x")), from_json<uint32_t>(json.at("y"))};
 }
 
-nlohmann::json to_json_t<RelativeCoreCoord>::operator()(const RelativeCoreCoord& relative_core_coord) noexcept {
+nlohmann::json to_json_t<tt::tt_metal::RelativeCoreCoord>::operator()(
+    const tt::tt_metal::RelativeCoreCoord& relative_core_coord) noexcept {
     return {{"x", to_json(relative_core_coord.x)}, {"y", to_json(relative_core_coord.y)}};
 }
 
-RelativeCoreCoord from_json_t<RelativeCoreCoord>::operator()(const nlohmann::json& json) noexcept {
+tt::tt_metal::RelativeCoreCoord from_json_t<tt::tt_metal::RelativeCoreCoord>::operator()(
+    const nlohmann::json& json) noexcept {
     return {from_json<int32_t>(json.at("x")), from_json<int32_t>(json.at("y"))};
 }
 

--- a/tt_metal/common/core_coord.cpp
+++ b/tt_metal/common/core_coord.cpp
@@ -20,6 +20,7 @@
 #include <vector>
 
 #include "tracy/Tracy.hpp"
+#include "common/core_coord.hpp"
 
 auto fmt::formatter<CoreCoord>::format(const CoreCoord& core_coord, format_context& ctx) const
     -> format_context::iterator {

--- a/tt_metal/common/core_coord.hpp
+++ b/tt_metal/common/core_coord.hpp
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <string>
+#include <tt-metalium/core_coord.hpp>
+
+struct RelativeCoreCoord {
+    long x = 0;
+    long y = 0;
+
+    std::string str() const;
+};
+
+constexpr bool operator==(const RelativeCoreCoord& a, const RelativeCoreCoord& b) { return a.x == b.x && a.y == b.y; }
+
+constexpr bool operator!=(const RelativeCoreCoord& a, const RelativeCoreCoord& b) { return !(a == b); }
+
+CoreCoord get_core_coord_from_relative(const RelativeCoreCoord& in, const CoreCoord& grid_size);
+
+template <>
+struct std::hash<RelativeCoreCoord> {
+    std::size_t operator()(const RelativeCoreCoord& o) const;
+};
+
+template <>
+struct ttsl::json::to_json_t<RelativeCoreCoord> {
+    nlohmann::json operator()(const RelativeCoreCoord& relative_core_coord) noexcept;
+};
+
+template <>
+struct ttsl::json::from_json_t<RelativeCoreCoord> {
+    RelativeCoreCoord operator()(const nlohmann::json& json) noexcept;
+};

--- a/tt_metal/common/core_coord.hpp
+++ b/tt_metal/common/core_coord.hpp
@@ -7,6 +7,8 @@
 #include <string>
 #include <tt-metalium/core_coord.hpp>
 
+namespace tt::tt_metal {
+
 struct RelativeCoreCoord {
     long x = 0;
     long y = 0;
@@ -20,17 +22,19 @@ constexpr bool operator!=(const RelativeCoreCoord& a, const RelativeCoreCoord& b
 
 CoreCoord get_core_coord_from_relative(const RelativeCoreCoord& in, const CoreCoord& grid_size);
 
+}  // namespace tt::tt_metal
+
 template <>
-struct std::hash<RelativeCoreCoord> {
-    std::size_t operator()(const RelativeCoreCoord& o) const;
+struct std::hash<tt::tt_metal::RelativeCoreCoord> {
+    std::size_t operator()(const tt::tt_metal::RelativeCoreCoord& o) const;
 };
 
 template <>
-struct ttsl::json::to_json_t<RelativeCoreCoord> {
-    nlohmann::json operator()(const RelativeCoreCoord& relative_core_coord) noexcept;
+struct ttsl::json::to_json_t<tt::tt_metal::RelativeCoreCoord> {
+    nlohmann::json operator()(const tt::tt_metal::RelativeCoreCoord& relative_core_coord) noexcept;
 };
 
 template <>
-struct ttsl::json::from_json_t<RelativeCoreCoord> {
-    RelativeCoreCoord operator()(const nlohmann::json& json) noexcept;
+struct ttsl::json::from_json_t<tt::tt_metal::RelativeCoreCoord> {
+    tt::tt_metal::RelativeCoreCoord operator()(const nlohmann::json& json) noexcept;
 };

--- a/tt_metal/llrt/core_descriptor.cpp
+++ b/tt_metal/llrt/core_descriptor.cpp
@@ -15,7 +15,7 @@
 #include <unordered_set>
 
 #include <tt_stl/assert.hpp>
-#include "core_coord.hpp"
+#include "common/core_coord.hpp"
 #include "hal.hpp"
 #include "hal_types.hpp"
 #include "metal_soc_descriptor.h"

--- a/tt_metal/llrt/core_descriptor.cpp
+++ b/tt_metal/llrt/core_descriptor.cpp
@@ -15,6 +15,7 @@
 #include <unordered_set>
 
 #include <tt_stl/assert.hpp>
+#include "core_coord.hpp"
 #include "hal.hpp"
 #include "hal_types.hpp"
 #include "metal_soc_descriptor.h"
@@ -28,6 +29,8 @@
 #include <umd/device/types/xy_pair.hpp>
 
 namespace tt {
+
+using tt_metal::RelativeCoreCoord;
 
 // Convert "x,y" to YAML::Node sequence [x, y]
 inline YAML::Node string_to_yaml_node(const std::string& input) {

--- a/tt_metal/llrt/core_descriptor.hpp
+++ b/tt_metal/llrt/core_descriptor.hpp
@@ -22,11 +22,11 @@ namespace tt {
 
 struct core_descriptor_t {
     CoreCoord compute_grid_size;
-    std::vector<RelativeCoreCoord> relative_compute_cores;
-    std::vector<RelativeCoreCoord> relative_storage_cores;
+    std::vector<tt_metal::RelativeCoreCoord> relative_compute_cores;
+    std::vector<tt_metal::RelativeCoreCoord> relative_storage_cores;
     std::optional<uint32_t> storage_core_bank_size = std::nullopt;
-    std::vector<RelativeCoreCoord> relative_dispatch_cores;
-    std::vector<RelativeCoreCoord> relative_fabric_mux_cores;
+    std::vector<tt_metal::RelativeCoreCoord> relative_dispatch_cores;
+    std::vector<tt_metal::RelativeCoreCoord> relative_fabric_mux_cores;
 
     std::vector<CoreCoord> logical_compute_cores;
     std::vector<CoreCoord> logical_storage_cores;

--- a/tt_metal/llrt/core_descriptor.hpp
+++ b/tt_metal/llrt/core_descriptor.hpp
@@ -16,6 +16,7 @@
 
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/dispatch_core_common.hpp>
+#include "common/core_coord.hpp"
 
 namespace tt {
 


### PR DESCRIPTION
### Ticket
Closes #30564 

### Problem description
Runtime is reducing our exposed API surface area.
There are concepts (RelativeCoreCoord) unused by external users, and functions and structs are exposed in global namespace instead of `tt` or `tt_metal` namespace. 

### What's changed
Moved the definition of `RelativeCoreCoord` out of public API.
Moved all functions and definitions into the `tt_metal` namespace while ensuring non-breakage by aliasing it to the global namespace (was the other way around prior).

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes
