### PR TITLE
[tt-train] Fix tensor parallel blow up

### DIFF
--- a/tt-train/configs/training_shakespeare_tinyllama_tp_galaxy.yaml
+++ b/tt-train/configs/training_shakespeare_tinyllama_tp_galaxy.yaml
@@ -23,7 +23,7 @@ training_config:
     num_blocks: 22
     vocab_size: 32000
     max_sequence_length: 2048
-    runner_type: memory_efficient
+    runner_type: default
     theta: 10000.0
     weight_tying: "disabled"
 eval_config:

--- a/tt-train/sources/examples/nano_gpt/main.cpp
+++ b/tt-train/sources/examples/nano_gpt/main.cpp
@@ -839,13 +839,6 @@ int main(int argc, char **argv) {
                 loss_float = get_loss_value(loss);
                 ttml::autograd::ctx().get_profiler().read_results(device, "model_forward_done");
 
-                if (device_config.enable_tp) {
-                    auto ones_grad = ttnn::ones_like(loss->get_value());
-                    ones_grad = ttnn::multiply(
-                        ones_grad, 1.F / static_cast<float>(ttml::autograd::ctx().get_device().num_devices()));
-                    loss->set_grad(ones_grad);
-                }
-
                 loss->backward();
             } else {
                 output->backward();

--- a/tt-train/sources/ttml/modules/distributed/linear.cpp
+++ b/tt-train/sources/ttml/modules/distributed/linear.cpp
@@ -32,9 +32,6 @@ RowParallelLinear::RowParallelLinear(
 autograd::TensorPtr RowParallelLinear::operator()(const autograd::TensorPtr& tensor) {
     auto x = tensor;
     if (!m_input_is_parallel) {
-        // noop during forward and all reduce during backward
-        x = ops::distributed::broadcast(x);
-
         // reduce scatter with mean
         x = ops::distributed::reduce_scatter(x, tensor->get_rank() - 1U);
         x = ops::mul(x, 1.F / static_cast<float>(autograd::ctx().get_device().num_devices()));

--- a/tt-train/sources/ttml/modules/distributed/linear.cpp
+++ b/tt-train/sources/ttml/modules/distributed/linear.cpp
@@ -41,7 +41,7 @@ autograd::TensorPtr RowParallelLinear::operator()(const autograd::TensorPtr& ten
     }
     // do not pass bias
     x = ops::linear_op(x, m_weight, /* bias */ nullptr);
-    x = ops::distributed::all_reduce(x);
+    x = ops::distributed::all_reduce(x, /* noop_backward */ true);
     if (m_bias != nullptr) {
         x = ops::add(x, m_bias);
     }

--- a/tt-train/sources/ttml/nanobind/nb_ops.cpp
+++ b/tt-train/sources/ttml/nanobind/nb_ops.cpp
@@ -92,7 +92,11 @@ void py_module(nb::module_& m) {
 
     {
         auto py_distributed = static_cast<nb::module_>(m.attr("distributed"));
-        py_distributed.def("all_reduce", &ttml::ops::distributed::all_reduce, nb::arg("tensor"));
+        py_distributed.def(
+            "all_reduce",
+            &ttml::ops::distributed::all_reduce,
+            nb::arg("tensor"),
+            nb::arg("noop_backward") = false);
         py_distributed.def(
             "reduce_scatter", &ttml::ops::distributed::reduce_scatter, nb::arg("tensor"), nb::arg("dim"));
         py_distributed.def("all_gather", &ttml::ops::distributed::all_gather, nb::arg("tensor"), nb::arg("dim"));

--- a/tt-train/sources/ttml/ops/distributed/comm_ops.cpp
+++ b/tt-train/sources/ttml/ops/distributed/comm_ops.cpp
@@ -33,11 +33,14 @@ autograd::TensorPtr all_gather(const autograd::TensorPtr& tensor, int dim) {
     return out;
 }
 
-autograd::TensorPtr all_reduce(const autograd::TensorPtr& tensor) {
+autograd::TensorPtr all_reduce(const autograd::TensorPtr& tensor, bool noop_backward) {
     auto out = autograd::create_tensor(ttnn_fixed::distributed::all_reduce(tensor->get_value()));
-    autograd::GradFunction grad = [tensor, out]() {
-        auto reduced_grad = ttnn_fixed::distributed::all_reduce(out->get_grad());
-        tensor->add_grad(reduced_grad);
+    autograd::GradFunction grad = [tensor, out, noop_backward]() {
+        if (noop_backward) {
+            tensor->add_grad(out->get_grad());
+        } else {
+            tensor->add_grad(ttnn_fixed::distributed::all_reduce(out->get_grad()));
+        }
     };
     auto links = autograd::get_links(tensor);
     out->set_node(autograd::ctx().add_backward_node(std::move(grad), links));

--- a/tt-train/sources/ttml/ops/distributed/comm_ops.hpp
+++ b/tt-train/sources/ttml/ops/distributed/comm_ops.hpp
@@ -9,7 +9,7 @@
 namespace ttml::ops::distributed {
 
 autograd::TensorPtr reduce_scatter(const autograd::TensorPtr& tensor, int dim);
-autograd::TensorPtr all_reduce(const autograd::TensorPtr& tensor);
+autograd::TensorPtr all_reduce(const autograd::TensorPtr& tensor, bool noop_backward = false);
 autograd::TensorPtr all_gather(const autograd::TensorPtr& tensor, int dim);
 autograd::TensorPtr broadcast(const autograd::TensorPtr& tensor);
 


### PR DESCRIPTION
### Problem description
Tensor parallel blows up in main branch
```
2025-11-03 22:08:50.953 | info     |            Test | Small tensor algorithm selected (softmax_backward_w_small.cpp:18)
Step: 1, Loss: 10.8125
Full step time 378782.902 ms, cache entries: 85
dataloader host only step time 0.003 ms
dataloader step time 0.387 ms
Step: 2, Loss: 4.081342e+20
Full step time 548.406 ms, cache entries: 85
dataloader host only step time 0.003 ms
dataloader step time 0.482 ms
```

### What's changed
* Avoid double all_reduce in backward pass (broadcast and all_reduce conflict)
* Remove redundant broadcast

**Fairscale** does similar trick:
* https://github.com/facebookresearch/fairscale/blob/main/fairscale/nn/model_parallel/mappings.py#L102
* https://github.com/facebookresearch/fairscale/blob/main/fairscale/nn/model_parallel/layers.py#L382

### Checklist
- [x] [All post commit / run 1](https://github.com/tenstorrent/tt-metal/actions/runs/19055061707) CI passes
- [x] [All post commit / run 2](https://github.com/tenstorrent/tt-metal/actions/runs/19056613173) CI passes
- [x] [All post commit / run 3](https://github.com/tenstorrent/tt-metal/actions/runs/19057485841) CI passes
- [x] New/Existing tests provide coverage for changes