### PR TITLE
Unify all_gather kernel binaries to hasten compile

### DIFF
--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_program_factory.cpp
@@ -152,7 +152,7 @@ void AllGatherDeviceOperation::AllGatherProgram::override_runtime_arguments(
 
         all_gather_async_minimal_default_helper_override_runtime_arguments(
             program,
-            shared_variables.program_artifacts.reader_kernel_ids,
+            shared_variables.program_artifacts.reader_kernel_id,
             shared_variables.program_artifacts.writer_kernel_ids,
             shared_variables.program_artifacts.all_cores,
             operation_attributes.num_links,

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_program_factory.cpp
@@ -153,7 +153,7 @@ void AllGatherDeviceOperation::AllGatherProgram::override_runtime_arguments(
         all_gather_async_minimal_default_helper_override_runtime_arguments(
             program,
             shared_variables.program_artifacts.reader_kernel_id,
-            shared_variables.program_artifacts.writer_kernel_ids,
+            shared_variables.program_artifacts.writer_kernel_id,
             shared_variables.program_artifacts.all_cores,
             operation_attributes.num_links,
             shared_variables.program_artifacts.num_directions_per_link,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_op.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_op.hpp
@@ -126,7 +126,7 @@ struct AllGatherAsync {
 };
 
 struct AllGatherProgramArtifacts {
-    std::vector<tt::tt_metal::KernelHandle> reader_kernel_ids;
+    tt::tt_metal::KernelHandle reader_kernel_id;
     std::vector<tt::tt_metal::KernelHandle> writer_kernel_ids;
     std::vector<tt::tt_metal::CoreCoord> all_cores;
     uint32_t num_directions_per_link;
@@ -162,7 +162,7 @@ AllGatherProgramArtifacts build_all_gather_async_minimal_default_program_artifac
 // Runtime argument override function
 void all_gather_async_minimal_default_helper_override_runtime_arguments(
     tt::tt_metal::Program& program,
-    const std::vector<tt::tt_metal::KernelHandle>& reader_kernel_ids,
+    tt::tt_metal::KernelHandle reader_kernel_id,
     const std::vector<tt::tt_metal::KernelHandle>& writer_kernel_ids,
     const std::vector<tt::tt_metal::CoreCoord>& all_cores,
     uint32_t num_links,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_op.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_op.hpp
@@ -127,7 +127,7 @@ struct AllGatherAsync {
 
 struct AllGatherProgramArtifacts {
     tt::tt_metal::KernelHandle reader_kernel_id;
-    std::vector<tt::tt_metal::KernelHandle> writer_kernel_ids;
+    tt::tt_metal::KernelHandle writer_kernel_id;
     std::vector<tt::tt_metal::CoreCoord> all_cores;
     uint32_t num_directions_per_link;
     uint32_t num_workers_per_direction;
@@ -163,7 +163,7 @@ AllGatherProgramArtifacts build_all_gather_async_minimal_default_program_artifac
 void all_gather_async_minimal_default_helper_override_runtime_arguments(
     tt::tt_metal::Program& program,
     tt::tt_metal::KernelHandle reader_kernel_id,
-    const std::vector<tt::tt_metal::KernelHandle>& writer_kernel_ids,
+    tt::tt_metal::KernelHandle writer_kernel_id,
     const std::vector<tt::tt_metal::CoreCoord>& all_cores,
     uint32_t num_links,
     uint32_t num_directions_per_link,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_program_minimal_variants.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_program_minimal_variants.cpp
@@ -355,22 +355,22 @@ AllGatherProgramArtifacts build_all_gather_async_minimal_default_program_artifac
             const auto& mux_core = all_cores[core_id++];
 
             if (mux_connection_valid(dir)) {
-                mux_core_ranges.push_back(CoreRange(mux_core));
+                mux_core_ranges.emplace_back(mux_core);
             }
 
             for (uint32_t worker = 0; worker < num_workers_per_direction; worker++) {
                 const auto& worker_core = all_cores[core_id++];
 
                 if (worker == 0) {
-                    termination_master_core_ranges.push_back(worker_core);
+                    termination_master_core_ranges.emplace_back(worker_core);
                 }
 
                 if (dir) {
-                    sender_forward_core_ranges.insert(CoreRange(worker_core));
+                    sender_forward_core_ranges.emplace(worker_core);
                 } else {
-                    sender_backward_core_ranges.insert(CoreRange(worker_core));
+                    sender_backward_core_ranges.emplace(worker_core);
                 }
-                sender_worker_core_ranges.push_back(CoreRange(worker_core));
+                sender_worker_core_ranges.emplace_back(worker_core);
             }
         }
     }


### PR DESCRIPTION
### Ticket
#31454 

### Problem description
- CCLs are very slow to compile, this is a major issue for training ~~as they don't use program cache~~
- Turns out, kernels were compiled individual for _each core_ , could be dozens now with multiple links and mux, which was needless.

### What's changed
- Refactor all gather kernels to move a bunch of CT args to RT args
- Change kernel creation flow such that kernels are created at once for all cores, and then RT args are adjusted accordingly.
- Iter 0 time for running AG is about 5x faster


### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/19080309527
- [x] Galaxy Nightly https://github.com/tenstorrent/tt-metal/actions/runs/19080336011
- [x] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work https://github.com/tenstorrent/tt-metal/actions/runs/19080344551 (no new failures)
- [x] T3K nightly. https://github.com/tenstorrent/tt-metal/actions/runs/19080351426
- [x] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release) https://github.com/tenstorrent/tt-metal/actions/runs/19080357147 (no new failures)
- [x] New/Existing tests provide coverage for changes