### PR TITLE
Compile the model for all supported seqlen before prefill tracing

### DIFF
--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -79,6 +79,36 @@ class Generator:
         self.trace_ids_decode = defaultdict(lambda: None)  # {device_sampling_bool: {device_id: trace_id}}
         self.trace_inputs_decode = defaultdict(lambda: None)
         self.trace_output_decode = defaultdict(lambda: None)
+        self.prefill_traces_warmup = False
+
+    def warmup_prefill_traces(
+        self,
+        page_table,
+        kv_cache,
+        enable_trace,
+    ):
+        self.prefill_traces_warmup = True
+        for model_id in range(self.data_parallel):
+            for supported_length in [128, 256, 512, 1024, 2048, 4096, 8192]:
+                # Only sequence lengths used by Llama-3.1-8B since we only support trace for Llama-3.1-8B for now
+                warmup_tokens = torch.zeros(1, supported_length, dtype=torch.long)
+                warmup_prompt_lens = torch.tensor([supported_length], dtype=torch.long)
+                warmup_empty_slots = list(range(1))
+
+                # TODO: Currently working on enabling trace for all models that use tt_transformers
+                if not self.model_args[0].can_enable_trace(supported_length):
+                    continue
+
+                logger.info(f"Warming up prefill traces for sequence length: {supported_length}")
+                self.prefill_forward_text(
+                    warmup_tokens,
+                    page_table,
+                    kv_cache,
+                    warmup_prompt_lens,
+                    warmup_empty_slots,
+                    enable_trace,
+                    model_id,
+                )
 
     def _capture_trace_prefill(
         self,
@@ -187,6 +217,7 @@ class Generator:
         prompt_lens=None,
         empty_slots=None,
         enable_trace=True,
+        model_id_warmup=None,
         **kwargs,
     ):
         if page_table is not None:
@@ -194,6 +225,13 @@ class Generator:
         else:
             # Only paged attention is supported for prefill
             enable_trace = False
+
+        if not self.prefill_traces_warmup and enable_trace:
+            self.warmup_prefill_traces(
+                page_table,
+                kv_cache,
+                enable_trace,
+            )
 
         batch_size, batch_seq_len = tokens.shape
         max_batch_size_per_model = self.model_args[0].max_batch_size
@@ -207,7 +245,8 @@ class Generator:
 
         out_list = []
         for idx, user_id in enumerate(empty_slots):
-            model_id = user_id // max_batch_size_per_model
+            # if model_id is not None, it means that prefill is called from warmup_prefill_traces
+            model_id = user_id // max_batch_size_per_model if model_id_warmup is None else model_id_warmup
             group_user_id = user_id % max_batch_size_per_model if page_table is None else 0
             seq_len = int(prompt_lens[idx])
             last_token_idx = seq_len - 1
@@ -290,7 +329,7 @@ class Generator:
                 seq_len = int(prompt_lens[idx])
                 last_token_idx = seq_len - 1
                 user_id = empty_slots[idx]
-                model_id = user_id // max_batch_size_per_model
+                model_id = user_id // max_batch_size_per_model if model_id_warmup is None else model_id_warmup
 
                 # Since we give unpadded_seq_len, only the tile containing the last token is returned
                 output_logits[idx] = self.model[model_id].process_output_prefill(

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -87,6 +87,9 @@ class Generator:
         kv_cache,
         enable_trace,
     ):
+        if self.prefill_traces_warmup or not enable_trace:
+            return
+
         self.prefill_traces_warmup = True
         for model_id in range(self.data_parallel):
             for supported_length in [128, 256, 512, 1024, 2048, 4096, 8192]:
@@ -226,12 +229,11 @@ class Generator:
             # Only paged attention is supported for prefill
             enable_trace = False
 
-        if not self.prefill_traces_warmup and enable_trace:
-            self.warmup_prefill_traces(
-                page_table,
-                kv_cache,
-                enable_trace,
-            )
+        self.warmup_prefill_traces(
+            page_table,
+            kv_cache,
+            enable_trace,
+        )
 
         batch_size, batch_seq_len = tokens.shape
         max_batch_size_per_model = self.model_args[0].max_batch_size

--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -1847,7 +1847,11 @@ class ModelArgs:
         else:
             allowed_seq_lens = [128, 256, 512, 1024, 2048, 4096, 8192]
 
-        return prefill_seq_len in allowed_seq_lens and prefill_seq_len <= self.max_prefill_chunk_size
+        return (
+            prefill_seq_len in allowed_seq_lens
+            and prefill_seq_len <= self.max_prefill_chunk_size
+            and prefill_seq_len <= self.max_seq_len
+        )
 
     def get_state_dict_prefix(self, module_name, layer_num, is_vision=False):
         text_prefix = self.state_dict_text_prefix


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/31437)

### Problem description
The problem is explained in the issue linked above.

### What's changed
- Compile and record all traces that are supported at the beginning
- If we use DP, we need to capture the trace for each submesh independently
- tt_transformers does not have batched prefill, so that's why we use `batch_size = 1` in the `warmup_prefill_traces`  --when we have `batch_size = 32` in `prefill_forward_text` we would just take one prompt from the batch and process it. That's why we use `batch_size = 1` in the newly added function since the workflow is the same, unlike how it's done for llama_70b for TG where they have implemented the batched prefill, so the workflow won't be the same for `batch_size = 1` and `batch_size = 32` : https://github.com/tenstorrent/tt-metal/blob/6ff23d72ee88fc9e2fc76f80394c19d2a4abbbbd/models/demos/llama3_70b_galaxy/tt/generator.py#L89


### Checklist
- [x] [All post commit] https://github.com/tenstorrent/tt-metal/actions/runs/19235874322
- [x] (For models and ops writers) [Single-card demo tests] https://github.com/tenstorrent/tt-metal/actions/runs/19235883397
- [x] [Galaxy demo tests, for Llama] https://github.com/tenstorrent/tt-metal/actions/runs/19241011252
- [x] (For runtime and ops writers) [T3000 unit tests] https://github.com/tenstorrent/tt-metal/actions/runs/19235896397
- [x] (For models and ops writers) [T3000 demo tests] https://github.com/tenstorrent/tt-metal/actions/runs/19235902822

## Note : Tests for Llama3-70b failed in the linked tests because of insufficient trace region size, so I will link two runs where I hardcoded the `trace_region_size` for Llama-8B and Llama-70B (other models will use the default region size passed through `@parametrize` for device_params) in order to tests to pass. When my next PR gets merged (https://github.com/tenstorrent/tt-metal/pull/32086), the `trace_region_size` won't be hardcoded in the `simple_text_demo.py` when parametrizing `device_params`, instead it will be overridden per model and per arch.

Galaxy run : https://github.com/tenstorrent/tt-metal/actions/runs/19276400784
T3K demo test run : https://github.com/tenstorrent/tt-metal/actions/runs/19276406689