### PR TITLE
Add PHYSICAL_AERISC_ID define for Active ERISC

### DIFF
--- a/tt_metal/hw/inc/dataflow_cmd_bufs.h
+++ b/tt_metal/hw/inc/dataflow_cmd_bufs.h
@@ -7,13 +7,13 @@
 #include "noc_nonblocking_api.h"
 
 #if defined(KERNEL_BUILD)
-#if defined(COMPILE_FOR_BRISC)
+#if (defined(COMPILE_FOR_BRISC)) || (defined(COMPILE_FOR_AERISC) && (PHYSICAL_AERISC_ID == 0))
 constexpr uint32_t read_cmd_buf = NOC_MODE == DM_DEDICATED_NOC ? BRISC_RD_CMD_BUF : DYNAMIC_NOC_BRISC_RD_CMD_BUF;
 constexpr uint32_t write_cmd_buf = NOC_MODE == DM_DEDICATED_NOC ? BRISC_WR_CMD_BUF : DYNAMIC_NOC_BRISC_WR_CMD_BUF;
 constexpr uint32_t write_reg_cmd_buf =
     NOC_MODE == DM_DEDICATED_NOC ? BRISC_WR_REG_CMD_BUF : DYNAMIC_NOC_BRISC_WR_REG_CMD_BUF;
 constexpr uint32_t write_at_cmd_buf = NOC_MODE == DM_DEDICATED_NOC ? BRISC_AT_CMD_BUF : DYNAMIC_NOC_BRISC_AT_CMD_BUF;
-#elif defined(COMPILE_FOR_NCRISC)
+#elif (defined(COMPILE_FOR_NCRISC)) || (defined(COMPILE_FOR_AERISC) && (PHYSICAL_AERISC_ID == 1))
 constexpr uint32_t read_cmd_buf = NOC_MODE == DM_DEDICATED_NOC ? NCRISC_RD_CMD_BUF : DYNAMIC_NOC_NCRISC_RD_CMD_BUF;
 constexpr uint32_t write_cmd_buf = NOC_MODE == DM_DEDICATED_NOC ? NCRISC_WR_CMD_BUF : DYNAMIC_NOC_NCRISC_WR_CMD_BUF;
 constexpr uint32_t write_reg_cmd_buf =

--- a/tt_metal/hw/inc/debug/assert.h
+++ b/tt_metal/hw/inc/debug/assert.h
@@ -27,7 +27,7 @@ inline void assert_and_hang(uint32_t line_num, debug_assert_type_t assert_type =
     // This exits to base FW
     internal_::disable_erisc_app();
     // Subordinates do not have an erisc exit
-#if (defined(COMPILE_FOR_AERISC) && COMPILE_FOR_AERISC == 0 && defined(ENABLE_2_ERISC_MODE)) || !defined(ARCH_BLACKHOLE)
+#if (defined(COMPILE_FOR_AERISC) && (PHYSICAL_AERISC_ID == 0)) || !defined(ARCH_BLACKHOLE)
     erisc_exit();
 #endif
 #endif

--- a/tt_metal/hw/inc/debug/eth_link_status.h
+++ b/tt_metal/hw/inc/debug/eth_link_status.h
@@ -21,7 +21,7 @@ void hang_on_down_link() {
 
     // This exits to base FW
     internal_::disable_erisc_app();
-#if (defined(COMPILE_FOR_AERISC) && COMPILE_FOR_AERISC == 0 && defined(ENABLE_2_ERISC_MODE)) || !defined(ARCH_BLACKHOLE)
+#if (defined(COMPILE_FOR_AERISC) && (PHYSICAL_AERISC_ID == 0)) || !defined(ARCH_BLACKHOLE)
     erisc_exit();
 #endif
     while (1) {

--- a/tt_metal/hw/inc/debug/sanitize_noc.h
+++ b/tt_metal/hw/inc/debug/sanitize_noc.h
@@ -263,7 +263,7 @@ void __attribute__((noinline)) debug_sanitize_post_noc_addr_and_hang(
     // kernel is written. In this case we'll do an early exit back to base FW.
     internal_::disable_erisc_app();
     // Subordinates do not have an erisc exit
-#if (defined(COMPILE_FOR_AERISC) && COMPILE_FOR_AERISC == 0 && defined(ENABLE_2_ERISC_MODE)) || !defined(ARCH_BLACKHOLE)
+#if (defined(COMPILE_FOR_AERISC) && (PHYSICAL_AERISC_ID == 0)) || !defined(ARCH_BLACKHOLE)
     erisc_exit();
 #endif
 #endif

--- a/tt_metal/hw/inc/ethernet/erisc.h
+++ b/tt_metal/hw/inc/ethernet/erisc.h
@@ -27,7 +27,7 @@ inline __attribute__((always_inline)) void risc_context_switch() {
     ncrisc_noc_full_sync();
     rtos_context_switch_ptr();
     ncrisc_noc_counters_init();
-#elif defined(COMPILE_FOR_AERISC) && COMPILE_FOR_AERISC == 0 && defined(ENABLE_2_ERISC_MODE)
+#elif defined(COMPILE_FOR_AERISC) && (PHYSICAL_AERISC_ID == 0)
     // Only NoC0
     ncrisc_noc_full_sync<1>();
     service_eth_msg();
@@ -41,9 +41,9 @@ inline __attribute__((always_inline)) void risc_context_switch_without_noc_sync(
 #if defined(COMPILE_FOR_ERISC)
 #if defined(COOPERATIVE_ERISC)
     rtos_context_switch_ptr();
-#elif defined(COMPILE_FOR_AERISC) && COMPILE_FOR_AERISC == 0 && defined(ENABLE_2_ERISC_MODE)
+#elif defined(COMPILE_FOR_AERISC) && (PHYSICAL_AERISC_ID == 0)
     update_boot_results_eth_link_status_check();
-#elif defined(COMPILE_FOR_AERISC) && COMPILE_FOR_AERISC == 1
+#elif defined(COMPILE_FOR_AERISC) && (PHYSICAL_AERISC_ID == 1)
     lite_fabric::service_lite_fabric_channels();
 #endif
 #endif

--- a/tt_metal/hw/inc/tt-1xx/blackhole/eth_fw_api.h
+++ b/tt_metal/hw/inc/tt-1xx/blackhole/eth_fw_api.h
@@ -224,14 +224,14 @@ uint64_t get_next_link_status_check_timestamp() {
 }
 
 void update_next_link_status_check_timestamp() {
-#if defined(COMPILE_FOR_AERISC) && COMPILE_FOR_AERISC == 0 && defined(ENABLE_2_ERISC_MODE)
+#if defined(COMPILE_FOR_AERISC) && (PHYSICAL_AERISC_ID == 0)
     uint64_t timestamp = eth_read_wall_clock() + (ETH_CLOCK_CYCLE_1MS * ETH_UPDATE_LINK_STATUS_INTERVAL_MS);
     *reinterpret_cast<volatile tt_l1_ptr uint64_t*>(GET_MAILBOX_ADDRESS_DEV(link_status_check_timestamp)) = timestamp;
 #endif
 }
 
 void eth_set_interrupt_mode(uint32_t interrupt_number, uint32_t mode_val) {
-#if defined(COMPILE_FOR_AERISC) && COMPILE_FOR_AERISC == 0 && defined(ENABLE_2_ERISC_MODE)
+#if defined(COMPILE_FOR_AERISC) && (PHYSICAL_AERISC_ID == 0)
     auto reg_ptr = reinterpret_cast<volatile tt_reg_ptr uint32_t*>(
         ETH_RISC_CTRL_A_INTERRUPT_MODE_0__REG_ADDR + (4 * interrupt_number));
     *reg_ptr = mode_val;
@@ -239,7 +239,7 @@ void eth_set_interrupt_mode(uint32_t interrupt_number, uint32_t mode_val) {
 }
 
 void disable_interrupts() {
-#if defined(COMPILE_FOR_AERISC) && COMPILE_FOR_AERISC == 0 && defined(ENABLE_2_ERISC_MODE)
+#if defined(COMPILE_FOR_AERISC) && (PHYSICAL_AERISC_ID == 0)
     for (uint32_t i = 0; i < ETH_RISC_NUM_INTERRUPT_VECS; i++) {
         eth_set_interrupt_mode(i, 0);
     }
@@ -247,7 +247,7 @@ void disable_interrupts() {
 }
 
 FORCE_INLINE bool is_link_up() {
-#if defined(COMPILE_FOR_AERISC) && (COMPILE_FOR_AERISC == 0) && !defined(ENABLE_2_ERISC_MODE)
+#if defined(COMPILE_FOR_AERISC) && (PHYSICAL_AERISC_ID == 1)
     // Collect current link states
     // TODO: Until erisc0 is enabled, use MAILBOX_RISC1 for link status check. When both riscs are enabled, assign one
     // to use MAILBOX_OTHER Sending msgs to mailbox described in:
@@ -297,14 +297,14 @@ FORCE_INLINE bool is_port_up() {
 }
 
 static void service_eth_msg() {
-#if defined(COMPILE_FOR_AERISC) && COMPILE_FOR_AERISC == 0 && defined(ENABLE_2_ERISC_MODE)
+#if defined(COMPILE_FOR_AERISC) && (PHYSICAL_AERISC_ID == 0)
     invalidate_l1_cache();
     reinterpret_cast<void (*)()>((uint32_t)(((eth_api_table_t*)(MEM_SYSENG_ETH_API_TABLE))->service_eth_msg_ptr))();
 #endif
 }
 
 static void update_boot_results_eth_link_status_check() {
-#if defined(COMPILE_FOR_AERISC) && COMPILE_FOR_AERISC == 0 && defined(ENABLE_2_ERISC_MODE)
+#if defined(COMPILE_FOR_AERISC) && (PHYSICAL_AERISC_ID == 0)
     uint64_t curr_timestamp = eth_read_wall_clock();
     uint64_t next_timestamp = get_next_link_status_check_timestamp();
     // Debounce to only be called at every interval

--- a/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal.cpp
+++ b/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal.cpp
@@ -133,8 +133,14 @@ public:
     std::vector<std::string> defines(const Params& params) const override {
         auto defines = HalJitBuildQueryBase::defines(params);
         defines.push_back("ARCH_BLACKHOLE");
-        if (blackhole::is_2_erisc_mode() && params.core_type == HalProgrammableCoreType::ACTIVE_ETH) {
-            defines.push_back("ENABLE_2_ERISC_MODE");
+        // Push back the physical erisc id
+        if (params.core_type == HalProgrammableCoreType::ACTIVE_ETH) {
+            if (blackhole::is_2_erisc_mode()) {
+                defines.push_back("ENABLE_2_ERISC_MODE");
+                defines.push_back("PHYSICAL_AERISC_ID=" + std::to_string(params.processor_id));
+            } else {
+                defines.push_back("PHYSICAL_AERISC_ID=1");
+            }
         }
         return defines;
     }


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/25058

### Problem description
The logical processor for active_erisc.cc is always 0. But it can be run on different physical processors depending on the ERISC Mode.
- In Dual ERISC mode, it runs on processor 0
- In Single ERISC mode, it runs on processor 1

To check which physical processor is being used we need to check `COMPILE_FOR_AERISC` and also `ENABLE_2_ERISC_MODE `. The software-hardware interaction is different depending on these two combinations. This is the first PR to help enable dynamic NOC on Blackhole multi erisc mode.

### What's changed
- Add `PHYSICAL_AERISC_ID` which will simplify these checks
- Update `dataflow_cmd_bufs.h` to allocate separate cmd bufs for each ERISC

### Checklist
Blackhole Post Commit
https://github.com/tenstorrent/tt-metal/actions/runs/19054383127
APC
https://github.com/tenstorrent/tt-metal/actions/runs/19054380798
Blackhole Multi-Card
https://github.com/tenstorrent/tt-metal/actions/runs/19054379866
Blackhole Nightly
https://github.com/tenstorrent/tt-metal/actions/runs/19056158925