### PR TITLE
Update cumsum tests and documentation

### DIFF
--- a/tests/ttnn/unit_tests/operations/reduce/test_cumsum.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_cumsum.py
@@ -30,7 +30,7 @@ def is_supported(shape, dim, ttnn_dtype):
     if dim < tensor_rank:
         accumulation_length = shape[dim]
         if ttnn_dtype == ttnn.bfloat16 and accumulation_length > 10000:
-            return False  # for bfloat16, accmulation errors can happen easily on long tensor
+            return False  # for bfloat16, accumulation errors can happen easily on long tensor
 
     return True
 
@@ -71,7 +71,6 @@ def test_cumsum(size, dim, dtypes, device):
 
         expected_output_dtype = ttnn_dtype if ttnn_dtype is not None else input_tensor.dtype
 
-        # For now, int32 version only supports >3-D tensors and `dim` outher than x and y axes
         if not is_supported(size, dim, expected_output_dtype):
             pytest.skip("Unsupported configuration by ttnn.cumsum")
 

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/cumsum/cumsum_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/cumsum/cumsum_pybind.cpp
@@ -50,21 +50,16 @@ void bind_reduction_cumsum_operation(py::module& module) {
                  - Layouts
                  - Ranks
                  - dim
-               * - BFLOAT16, FLOAT32
+               * - BFLOAT16, FLOAT32, INT32, UINT32
                  - TILE
                  - 1, 2, 3, 4, 5
                  - -rank <= dim < rank
-               * - INT32, UINT32
-                 - TILE
-                 - 3, 4, 5
-                 - dim in {0, 1, ..., rank - 3} or dim in {-rank, -rank + 1, ..., -3}
 
         Memory Support:
             - Interleaved: DRAM and L1
 
         Limitations:
             - Preallocated output must have the same shape as the input
-            - Preallocated output for integer types is not supported
 
         Example:
             .. code-block:: python


### PR DESCRIPTION
### Ticket
#29863

### Problem description
While `ttnn.cumsum` indicates rank and `dim` limitations for int32/uint32, as well as preallocated outputs, these work in practice.

### What's changed
- Update pybinds documentation to reflect actual type support
- Update tests to not skip int32/uint32 test cases
- Adjust absolute and relative tolerance thresholds

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes [OK, timed out on unrelated pipeline](https://github.com/tenstorrent/tt-metal/actions/runs/19067753321)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable) [OK](https://github.com/tenstorrent/tt-metal/actions/runs/19076164790)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [x] New/Existing tests provide coverage for changes