### PR TITLE
[TT_CNN][PDL] extend builder support for maxpool; pdl stem update

### DIFF
--- a/models/experimental/panoptic_deeplab/reference/pytorch_stem.py
+++ b/models/experimental/panoptic_deeplab/reference/pytorch_stem.py
@@ -35,6 +35,9 @@ class StemBlock(nn.Module):
         self.conv3 = nn.Conv2d(64, 128, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)
         self.conv3.norm = nn.SyncBatchNorm(128, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)
 
+        # Max pooling layer
+        self.maxpool = nn.MaxPool2d(kernel_size=3, stride=2, padding=1, dilation=1, ceil_mode=False)
+
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         # Conv1 + BatchNorm + ReLU
         x = self.conv1(x)
@@ -52,6 +55,6 @@ class StemBlock(nn.Module):
         x = F.relu(x)
 
         # Max pooling with kernel_size=3, stride=2, padding=1
-        x = F.max_pool2d(x, kernel_size=3, stride=2, padding=1, dilation=1, ceil_mode=False)
+        x = self.maxpool(x)
 
         return x

--- a/models/experimental/panoptic_deeplab/tests/pcc/test_tt_model.py
+++ b/models/experimental/panoptic_deeplab/tests/pcc/test_tt_model.py
@@ -148,7 +148,7 @@ def test_model_panoptic_deeplab(device, model_category, model_location_generator
                 ttnn_center,
                 to_channel_first=False,
                 output_channels=ttnn_model.instance_head.get_center_output_channels_for_slicing(),
-                exp_pcc=0.803,
+                exp_pcc=0.792,
             )
         )
         all_passed.append(
@@ -158,7 +158,7 @@ def test_model_panoptic_deeplab(device, model_category, model_location_generator
                 ttnn_offset,
                 to_channel_first=False,
                 output_channels=ttnn_model.instance_head.get_offset_output_channels_for_slicing(),
-                exp_pcc=0.988,
+                exp_pcc=0.991,
             )
         )
 

--- a/models/experimental/panoptic_deeplab/tests/test_device_perf_pdl.py
+++ b/models/experimental/panoptic_deeplab/tests/test_device_perf_pdl.py
@@ -12,7 +12,7 @@ from models.experimental.panoptic_deeplab.reference.pytorch_model import PANOPTI
     [
         (
             "pytest models/experimental/panoptic_deeplab/tests/pcc/test_tt_model.py::test_model_panoptic_deeplab -k test_panoptic_deeplab",
-            52_637_788,
+            51_749_520,
             PANOPTIC_DEEPLAB,
             PANOPTIC_DEEPLAB,
             1,
@@ -22,7 +22,7 @@ from models.experimental.panoptic_deeplab.reference.pytorch_model import PANOPTI
         ),
         (
             "pytest models/experimental/panoptic_deeplab/tests/pcc/test_tt_model.py::test_model_panoptic_deeplab -k test_deeplab_v3_plus",
-            35_506_710,
+            34_387_871,
             DEEPLAB_V3_PLUS,
             DEEPLAB_V3_PLUS,
             1,

--- a/models/experimental/panoptic_deeplab/tt/tt_stem.py
+++ b/models/experimental/panoptic_deeplab/tt/tt_stem.py
@@ -4,7 +4,7 @@
 import ttnn
 from loguru import logger
 
-from models.tt_cnn.tt.builder import TtConv2d, TtMaxPool2d, ChannelSliceStrategyConfiguration
+from models.tt_cnn.tt.builder import TtConv2d, TtMaxPool2d
 from models.common.lightweightmodule import LightweightModule
 
 
@@ -27,84 +27,35 @@ class TtStem(LightweightModule):
         parameters,
         device: ttnn.MeshDevice,
         dtype: ttnn.DataType = ttnn.bfloat8_b,
-        channel_slice_factor: int = 4,
         model_configs=None,
     ):
         super().__init__()
         self.device = device
-        self.channel_slice_factor = channel_slice_factor
         self.model_configs = model_configs
 
-        logger.debug(f"Initializing TtStem with TT CNN Builder API - channel_slice_factor: {channel_slice_factor}")
+        logger.debug(f"Initializing TtStem with TT CNN Builder API")
 
         # Extract layer parameters (Conv2dConfiguration or MaxPool2dConfiguration objects)
         conv1_params = parameters["conv1"]
         conv2_params = parameters["conv2"]
         conv3_params = parameters["conv3"]
-        maxpool_params = parameters.get("maxpool", None)
 
         # Initialize conv layers using TT CNN Builder
         self.conv1, self.conv1_out_shape = self._create_conv_layer(conv1_params, "stem.conv1")
         self.conv2, self.conv2_out_shape = self._create_conv_layer(conv2_params, "stem.conv2")
         self.conv3, self.conv3_out_shape = self._create_conv_layer(conv3_params, "stem.conv3")
 
-        # Initialize maxpool using TT CNN Builder
-        if maxpool_params and "pool_config" in maxpool_params:
-            # Use MaxPool2dConfiguration from preprocessing
-            pool_config = maxpool_params["pool_config"]
-
-            # Apply channel slicing override if needed
-            if self.channel_slice_factor > 1:
-                from dataclasses import replace
-
-                pool_config = replace(
-                    pool_config, slice_strategy=ChannelSliceStrategyConfiguration(num_slices=self.channel_slice_factor)
-                )
-
-            self.maxpool = TtMaxPool2d(pool_config, device)
-            # Compute maxpool output shape
-            kernel_h, kernel_w = pool_config.kernel_size
-            stride_h, stride_w = pool_config.stride
-            pad_h, pad_w = pool_config.padding
-            dil_h, dil_w = pool_config.dilation
-            out_h = (pool_config.input_height + 2 * pad_h - dil_h * (kernel_h - 1) - 1) // stride_h + 1
-            out_w = (pool_config.input_width + 2 * pad_w - dil_w * (kernel_w - 1) - 1) // stride_w + 1
-            self.maxpool_out_shape = (pool_config.batch_size, out_h, out_w, pool_config.channels)
-            logger.debug(
-                f"MaxPool initialized with TT CNN Builder - config: {pool_config}, out_shape={self.maxpool_out_shape}"
+        # Apply model-specific overrides if model_configs is provided
+        if self.model_configs is not None:
+            maxpool_config = self.model_configs.apply_maxpool_overrides(
+                parameters["maxpool"]["pool_config"], maxpool_path="stem.maxpool"
             )
+            logger.debug(f"Applied config overrides for stem.maxpool")
         else:
-            # Fallback: create maxpool config based on conv3 output shape
-            # MaxPool expects the UNRESHAPED (flattened) input from TT CNN Builder
-            logger.warning(
-                "MaxPool config not found (PyTorch uses functional maxpool), creating from conv3 output shape"
-            )
-            from models.tt_cnn.tt.builder import MaxPool2dConfiguration
+            maxpool_config = parameters["maxpool"]["pool_config"]
+            logger.debug(f"No model_configs provided for stem.maxpool, using base config")
 
-            # TT CNN conv outputs flattened [B, 1, H*W, C], so use the logical NHWC shape for maxpool config
-            _, conv3_out_h, conv3_out_w, conv3_out_c = self.conv3_out_shape
-            pool_config = MaxPool2dConfiguration(
-                input_height=conv3_out_h,
-                input_width=conv3_out_w,
-                channels=conv3_out_c,
-                batch_size=1,
-                kernel_size=(3, 3),
-                stride=(2, 2),
-                padding=(1, 1),
-                slice_strategy=ChannelSliceStrategyConfiguration(num_slices=self.channel_slice_factor)
-                if self.channel_slice_factor > 1
-                else None,
-            )
-            self.maxpool = TtMaxPool2d(pool_config, device)
-            # Compute maxpool output shape
-            kernel_h, kernel_w = pool_config.kernel_size
-            stride_h, stride_w = pool_config.stride
-            pad_h, pad_w = pool_config.padding
-            dil_h, dil_w = pool_config.dilation
-            out_h = (pool_config.input_height + 2 * pad_h - dil_h * (kernel_h - 1) - 1) // stride_h + 1
-            out_w = (pool_config.input_width + 2 * pad_w - dil_w * (kernel_w - 1) - 1) // stride_w + 1
-            self.maxpool_out_shape = (pool_config.batch_size, out_h, out_w, pool_config.channels)
-
+        self.maxpool = TtMaxPool2d(maxpool_config, device)
         logger.debug("TtStem initialization complete")
 
     def _create_conv_layer(self, params, conv_path: str):
@@ -130,8 +81,6 @@ class TtStem(LightweightModule):
             logger.debug(f"No model_configs provided for {conv_path}, using base config")
 
         # Compute output shape (NHWC format) based on conv2d formula
-        # out_h = floor((in_h + 2*pad_h - dilation_h * (kernel_h - 1) - 1) / stride_h + 1)
-        # out_w = floor((in_w + 2*pad_w - dilation_w * (kernel_w - 1) - 1) / stride_w + 1)
         kernel_h, kernel_w = final_config.kernel_size
         stride_h, stride_w = final_config.stride
         pad_h, pad_w = final_config.padding

--- a/models/tt_cnn/tt/builder.py
+++ b/models/tt_cnn/tt/builder.py
@@ -322,6 +322,9 @@ class MaxPool2dConfiguration:
     deallocate_input: bool = False
     reallocate_halo_output: bool = True
 
+    dtype: ttnn.DataType = ttnn.bfloat16
+    output_layout: ttnn.Layout = ttnn.ROW_MAJOR_LAYOUT
+
     slice_strategy: Optional[SliceStrategy] = None
 
     def __post_init__(self):
@@ -699,6 +702,8 @@ class TtMaxPool2d:
             "in_place_halo": self.configuration.in_place,
             "deallocate_input": self.configuration.deallocate_input,
             "reallocate_halo_output": self.configuration.reallocate_halo_output,
+            "dtype": self.configuration.dtype,
+            "output_layout": self.configuration.output_layout,
         }
 
     def _apply_channel_slicing(self, x):

--- a/tests/ttnn/nightly/unit_tests/operations/pool/test_maxpool2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/pool/test_maxpool2d.py
@@ -644,9 +644,9 @@ def test_max_pool2d_output_formats_and_layouts(
     "stride",
     ((2, 2),),
 )
-@pytest.mark.parametrize("dtype", [ttnn.bfloat16])
+@pytest.mark.parametrize("dtype", [ttnn.bfloat8_b])
 def test_panoptic_maxpool_sliced(device, input_shape_nchw, kernel_size, padding, dilation, stride, dtype, tensor_map):
-    num_slices = 4
+    num_slices = 2
 
     batch_size, channels, input_h, input_w = input_shape_nchw
     assert channels % num_slices == 0, "Channels must be divisible by num_slices"
@@ -669,7 +669,7 @@ def test_panoptic_maxpool_sliced(device, input_shape_nchw, kernel_size, padding,
     out_h, out_w = torch_output.shape[2], torch_output.shape[3]
 
     ttnn_input_nhwc = ttnn.from_torch(
-        torch_input_nchw.permute(0, 2, 3, 1), device=device, layout=ttnn.ROW_MAJOR_LAYOUT, dtype=dtype
+        torch_input_nchw.permute(0, 2, 3, 1), device=device, layout=ttnn.TILE_LAYOUT, dtype=dtype
     )
     output_slices = []
     for i in range(num_slices):
@@ -692,6 +692,8 @@ def test_panoptic_maxpool_sliced(device, input_shape_nchw, kernel_size, padding,
             padding=list(padding),
             dilation=list(dilation),
             ceil_mode=False,
+            dtype=ttnn.bfloat8_b,
+            output_layout=ttnn.TILE_LAYOUT,
         )
         ttnn.deallocate(x_slice_reshaped)
 


### PR DESCRIPTION
builder support for maxpool output type and layout; pdl stem maxpool update

### Problem description
- tt_cnn builder max pool add an option to set output type and layout.
- pdl remove stem max pool init hacks; 
- pdl update stem max pool to use 2 slices and run with bfloat8_b output; gaining perf on the concat layer
- stem 4,823 us -> 3,597 us

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/19072176809/job/54478948026) CI with demo tests passes (if applicable)
- [x] [Single card device perf regression](https://github.com/tenstorrent/tt-metal/actions/runs/19072179844/job/54478947234) CI passes (if applicable)
