### PR TITLE
#0: Fix propagation of CoreType in DPRINT

### DIFF
--- a/tt_metal/impl/debug/dprint_server.cpp
+++ b/tt_metal/impl/debug/dprint_server.cpp
@@ -70,10 +70,13 @@ inline float bfloat16_to_float(uint16_t bfloat_val) {
     return f;
 }
 
-string GetRiscName(CoreType core_type, int risc_id, bool abbreviated = false) {
+string GetRiscName(ChipId device_id, const umd::CoreDescriptor& logical_core, int risc_id, bool abbreviated = false) {
+    CoreCoord virtual_core =
+        tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_coordinate_from_logical_coordinates(
+            device_id, logical_core.coord, logical_core.type);
+    auto programmable_core_type = llrt::get_core_type(device_id, virtual_core);
     const auto& hal = tt::tt_metal::MetalContext::instance().hal();
-    return hal.get_processor_class_name(
-        ::tt::tt_metal::hal_programmable_core_type_from_core_type(core_type), risc_id, abbreviated);
+    return hal.get_processor_class_name(programmable_core_type, risc_id, abbreviated);
 }
 
 void AssertSize(uint8_t sz, uint8_t expected_sz) {
@@ -1193,7 +1196,7 @@ string DPrintServer::Impl::get_formatted_output_data(const RiscKey& risc_key, co
 
         const string& device_id_str = to_string(device_id);
         const string& core_coord_str = core_desc.coord.str();
-        const string& risc_name = GetRiscName(core_desc.type, risc_id, true);
+        const string& risc_name = GetRiscName(device_id, core_desc, risc_id, true);
         output += fmt::format("{}:{}:{}: ", device_id_str, core_coord_str, risc_name);
     }
 
@@ -1221,7 +1224,7 @@ ostream* DPrintServer::Impl::get_output_stream(const RiscKey& risc_key) {
                 tt::tt_metal::get_core_type_name(logical_core.type),
                 logical_core.coord.x,
                 logical_core.coord.y,
-                GetRiscName(logical_core.type, risc_id));
+                GetRiscName(chip_id, logical_core, risc_id));
             risc_to_file_stream_[risc_key] = new ofstream(filename);
         }
         output_stream = risc_to_file_stream_[risc_key];

--- a/tt_metal/llrt/hal.cpp
+++ b/tt_metal/llrt/hal.cpp
@@ -90,7 +90,12 @@ std::pair<HalProcessorClassType, uint32_t> HalCoreInfoType::get_processor_class_
         }
         processor_index -= processor_count;
     }
-    TT_ASSERT(processor_class_idx < this->processor_classes_.size());
+    TT_ASSERT(
+        processor_class_idx < this->processor_classes_.size(),
+        "{} {} {}",
+        processor_class_idx,
+        this->processor_classes_.size(),
+        processor_index);
     return {static_cast<HalProcessorClassType>(processor_class_idx), processor_index};
 }
 

--- a/tt_metal/llrt/hal.cpp
+++ b/tt_metal/llrt/hal.cpp
@@ -90,12 +90,7 @@ std::pair<HalProcessorClassType, uint32_t> HalCoreInfoType::get_processor_class_
         }
         processor_index -= processor_count;
     }
-    TT_ASSERT(
-        processor_class_idx < this->processor_classes_.size(),
-        "{} {} {}",
-        processor_class_idx,
-        this->processor_classes_.size(),
-        processor_index);
+    TT_ASSERT(processor_class_idx < this->processor_classes_.size());
     return {static_cast<HalProcessorClassType>(processor_class_idx), processor_index};
 }
 

--- a/tt_metal/llrt/hal.hpp
+++ b/tt_metal/llrt/hal.hpp
@@ -674,8 +674,6 @@ constexpr HalProgrammableCoreType hal_programmable_core_type_from_core_type(Core
         case CoreType::TENSIX: return HalProgrammableCoreType::TENSIX;
         case CoreType::ACTIVE_ETH: return HalProgrammableCoreType::ACTIVE_ETH;
         case CoreType::IDLE_ETH: return HalProgrammableCoreType::IDLE_ETH;
-        case CoreType::ETH:
-            return HalProgrammableCoreType::ACTIVE_ETH;  // We need this because translations only support ETH
         default: TT_FATAL(false, "CoreType is not recognized by the HAL in {}", __FUNCTION__);
     }
 }


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
DPRINT on BH was failing for Idle Eth.
We were always passing `HalProgrammableCoreType::ACTIVE_ETH` for all Eth core types due to using `CoreType::ETH` to look up the programmable type. This caused errors when dprinting idle eth, which has 2 riscs, since it's looked up as an active erisc which only has 1 by default.

### What's changed
Look up the actual CoreType, ie `CoreType::ACTIVE_ETH` or `CoreType::IDLE_ETH`, before looking up the programmable core type in order to correctly use the correct settings for erisc.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/19074830742
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/19074836670
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [x] New/Existing tests provide coverage for changes