### PR TITLE
[tt-train] Add 16 loudboxes setup to 3-tier training

### DIFF
--- a/tt-train/configs/training_shakespeare_nanogpt_3tier_fabric_16lboxes.yaml
+++ b/tt-train/configs/training_shakespeare_nanogpt_3tier_fabric_16lboxes.yaml
@@ -1,0 +1,40 @@
+training_config:
+  project_name: "tt_train_nano_gpt"
+  model_type: "gpt2"
+  seed: 5489
+  model_save_interval: 500
+  batch_size: 64
+  num_epochs: 1
+  max_steps: 5000
+  learning_rate: 0.0003
+  weight_decay: 0.01
+  use_moreh_adamw: true
+  use_kahan_summation: false
+  use_clip_grad_norm: false
+  clip_grad_norm_max_norm: 1.0
+  transformer_config:
+    num_heads: 6
+    embedding_dim: 384
+    dropout_prob: 0.2
+    num_blocks: 6
+    vocab_size: 96
+    max_sequence_length: 256
+    positional_embedding_type: trainable
+    runner_type: default
+    experimental:
+      use_composite_layernorm: false
+
+multihost_config:
+  enabled: true
+  num_workers: 14
+  socket_type: fabric
+
+eval_config:
+  repetition_penalty: 1.0
+  temperature: 0.7
+  top_k: 50
+  top_p: 1.0
+
+device_config:
+  enable_ddp: true
+  mesh_shape: [1, 8]

--- a/tt-train/sources/examples/python/multihost/hierarchical_parallel/configurations/16loudboxes/hosts.txt
+++ b/tt-train/sources/examples/python/multihost/hierarchical_parallel/configurations/16loudboxes/hosts.txt
@@ -1,0 +1,16 @@
+metal-wh-18.closetbox.tenstorrent.com slots=1
+metal-wh-08.closetbox.tenstorrent.com slots=1
+metal-wh-01.closetbox.tenstorrent.com slots=1
+metal-wh-02.closetbox.tenstorrent.com slots=1
+metal-wh-03.closetbox.tenstorrent.com slots=1
+metal-wh-04.closetbox.tenstorrent.com slots=1
+metal-wh-05.closetbox.tenstorrent.com slots=1
+metal-wh-06.closetbox.tenstorrent.com slots=1
+metal-wh-13.closetbox.tenstorrent.com slots=1
+metal-wh-14.closetbox.tenstorrent.com slots=1
+metal-wh-15.closetbox.tenstorrent.com slots=1
+metal-wh-16.closetbox.tenstorrent.com slots=1
+metal-wh-09.closetbox.tenstorrent.com slots=1
+metal-wh-10.closetbox.tenstorrent.com slots=1
+metal-wh-11.closetbox.tenstorrent.com slots=1
+metal-wh-12.closetbox.tenstorrent.com slots=1

--- a/tt-train/sources/examples/python/multihost/hierarchical_parallel/configurations/16loudboxes/mgd.yaml
+++ b/tt-train/sources/examples/python/multihost/hierarchical_parallel/configurations/16loudboxes/mgd.yaml
@@ -1,0 +1,153 @@
+ChipSpec: {
+  arch: wormhole_b0,
+  ethernet_ports: {
+    N: 2,
+    E: 2,
+    S: 2,
+    W: 2,
+  }
+}
+
+Board: [
+  { name: lbox,
+    type: Mesh,
+    topology: [1, 8]}
+]
+
+Mesh: [
+  {
+    id: 0,
+    board: lbox,
+    device_topology: [1, 8],
+    host_topology: [1, 1],
+
+  },
+  {
+    id: 1,
+    board: lbox,
+    device_topology: [1, 8],
+    host_topology: [1, 1],
+
+  },
+  {
+    id: 2,
+    board: lbox,
+    device_topology: [1, 8],
+    host_topology: [1, 1],
+  },
+  {
+    id: 3,
+    board: lbox,
+    device_topology: [1, 8],
+    host_topology: [1, 1],
+  },
+  {
+    id: 4,
+    board: lbox,
+    device_topology: [1, 8],
+    host_topology: [1, 1],
+  },
+  {
+    id: 5,
+    board: lbox,
+    device_topology: [1, 8],
+    host_topology: [1, 1],
+  },
+  {
+    id: 6,
+    board: lbox,
+    device_topology: [1, 8],
+    host_topology: [1, 1],
+  },
+  {
+    id: 7,
+    board: lbox,
+    device_topology: [1, 8],
+    host_topology: [1, 1],
+  },
+  {
+    id: 8,
+    board: lbox,
+    device_topology: [1, 8],
+    host_topology: [1, 1],
+  },
+  {
+    id: 9,
+    board: lbox,
+    device_topology: [1, 8],
+    host_topology: [1, 1],
+  },
+  {
+    id: 10,
+    board: lbox,
+    device_topology: [1, 8],
+    host_topology: [1, 1],
+  },
+  {
+    id: 11,
+    board: lbox,
+    device_topology: [1, 8],
+    host_topology: [1, 1],
+  },
+  {
+    id: 12,
+    board: lbox,
+    device_topology: [1, 8],
+    host_topology: [1, 1],
+  },
+  {
+    id: 13,
+    board: lbox,
+    device_topology: [1, 8],
+    host_topology: [1, 1],
+  },
+  {
+    id: 14,
+    board: lbox,
+    device_topology: [1, 8],
+    host_topology: [1, 1],
+  },
+  {
+    id: 15,
+    board: lbox,
+    device_topology: [1, 8],
+    host_topology: [1, 1],
+  },
+]
+
+RelaxedGraph: [
+  [M0, M1, 2],
+  [M0, M2, 2],
+  [M0, M3, 2],
+  [M1, M2, 2],
+  [M1, M3, 2],
+  [M2, M3, 2],
+
+  [M4, M5, 2],
+  [M4, M6, 2],
+  [M4, M7, 2],
+  [M5, M6, 2],
+  [M5, M7, 2],
+  [M6, M7, 2],
+
+  [M8, M9, 2],
+  [M8, M10, 2],
+  [M8, M11, 2],
+  [M9, M10, 2],
+  [M9, M11, 2],
+  [M10, M11, 2],
+
+  [M12, M13, 2],
+  [M12, M14, 2],
+  [M12, M15, 2],
+  [M13, M14, 2],
+  [M13, M15, 2],
+  [M14, M15, 2],
+
+  [M2, M5, 2],
+  [M3, M8, 2],
+  [M9, M14, 2],
+  [M0, M12, 2],
+  [M4, M15, 2],
+  [M7, M11, 2],
+]

--- a/tt-train/sources/examples/python/multihost/hierarchical_parallel/configurations/16loudboxes/rank_bindings.yaml
+++ b/tt-train/sources/examples/python/multihost/hierarchical_parallel/configurations/16loudboxes/rank_bindings.yaml
@@ -1,0 +1,37 @@
+rank_bindings:
+  - rank: 0
+    mesh_id: 0
+  - rank: 1
+    mesh_id: 1
+  - rank: 2
+    mesh_id: 2
+  - rank: 3
+    mesh_id: 3
+  - rank: 4
+    mesh_id: 4
+  - rank: 5
+    mesh_id: 5
+  - rank: 6
+    mesh_id: 6
+  - rank: 7
+    mesh_id: 7
+  - rank: 8
+    mesh_id: 8
+  - rank: 9
+    mesh_id: 9
+  - rank: 10
+    mesh_id: 10
+  - rank: 11
+    mesh_id: 11
+  - rank: 12
+    mesh_id: 12
+  - rank: 13
+    mesh_id: 13
+  - rank: 14
+    mesh_id: 14
+  - rank: 15
+    mesh_id: 15
+
+global_env:
+  TT_METAL_HOME: "/home/ttuser/git/tt-metal"
+mesh_graph_desc_path: "configurations/16loudboxes/mgd.yaml"

--- a/tt-train/sources/examples/python/multihost/hierarchical_parallel/configurations/5loudboxes/hosts.txt
+++ b/tt-train/sources/examples/python/multihost/hierarchical_parallel/configurations/5loudboxes/hosts.txt
@@ -1,5 +1,5 @@
-metal-wh-01 slots=1
-metal-wh-03 slots=1
-metal-wh-04 slots=1
-metal-wh-05 slots=1
-metal-wh-06 slots=1
+metal-wh-01.closetbox.tenstorrent.com slots=1
+metal-wh-03.closetbox.tenstorrent.com slots=1
+metal-wh-04.closetbox.tenstorrent.com slots=1
+metal-wh-05.closetbox.tenstorrent.com slots=1
+metal-wh-06.closetbox.tenstorrent.com slots=1

--- a/tt-train/sources/examples/python/multihost/hierarchical_parallel/runner.sh
+++ b/tt-train/sources/examples/python/multihost/hierarchical_parallel/runner.sh
@@ -63,7 +63,7 @@ fi
 ${TT_METAL_HOME}/tt-train/sources/examples/nano_gpt/3tier/all_machines_copy.sh --run --sync --user "$USER" --hostfile "$HOST_FILE"
 
 # install requirements
-mpirun --hostfile ${HOST_FILE} --tag-output pip install -r ${TT_METAL_HOME}/tt-train/sources/examples/python/multihost/hierarchical_parallel/requirements.txt
+mpirun-ulfm --hostfile ${HOST_FILE} --tag-output pip install -r ${TT_METAL_HOME}/tt-train/sources/examples/python/multihost/hierarchical_parallel/requirements.txt
 
 CMD="python3 ${TT_METAL_HOME}/tt-train/sources/examples/python/multihost/hierarchical_parallel/training.py -c ${CONFIG_FILE}"
 # use tt-run to run the training script across all machines


### PR DESCRIPTION
### Problem description
Run training workload on 16 loudboxes

### What's changed
* Add cluster config and workload config 
* Change `mpirun` to `mpirun-ulfm` (closetbox `mpirun` commands aren't proceeding @rreece)
* Modify existing lboxes configuration to adopt new names  

![nanogpt_16lboxes](https://github.com/user-attachments/assets/02ded54b-fc46-4eda-bb73-f21417c26ab3)


### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] New/Existing tests provide coverage for changes