### PR TITLE
[skip ci] assign blackhole ttnn stress tests to ttnncore

### DIFF
--- a/.github/actions/analyze-workflow-data/owners.json
+++ b/.github/actions/analyze-workflow-data/owners.json
@@ -20,6 +20,8 @@
       { "id": "U08BH66EXAL", "name": "Radoica Draskic" }
     ] },
 
+    { "job-name-component": "blackhole‑ttnn‑stress‑tests (LoudBox ttnn stress tests, BH‑LoudBox) / ttnn stress tests blackhole BH‑LoudBox", "owner": { "id": "S0988UJEW8K", "name": "ttnncore" } },
+
     { "job-name-component": "t3000-demo-tests / t3k_mixtral_tests", "owner": { "id": "U03PUAKE719", "name": "Harry Zhou" } },
     { "job-name-component": "t3k_mixtral_tests", "owner": { "id": "U03PUAKE719", "name": "Harry Zhou" } },
 

--- a/.github/actions/analyze-workflow-data/owners.json
+++ b/.github/actions/analyze-workflow-data/owners.json
@@ -21,6 +21,7 @@
     ] },
 
     { "job-name-component": "blackhole‑ttnn‑stress‑tests (LoudBox ttnn stress tests, BH‑LoudBox) / ttnn stress tests blackhole BH‑LoudBox", "owner": { "id": "S0988UJEW8K", "name": "ttnncore" } },
+    { "job-name-component": "ttnn stress tests blackhole BH‑LoudBox", "owner": { "id": "S0988UJEW8K", "name": "ttnncore" } },
 
     { "job-name-component": "t3000-demo-tests / t3k_mixtral_tests", "owner": { "id": "U03PUAKE719", "name": "Harry Zhou" } },
     { "job-name-component": "t3k_mixtral_tests", "owner": { "id": "U03PUAKE719", "name": "Harry Zhou" } },


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/31791

### Problem description
Blackhole ttnn stress tests have no owner.

### What's changed
Adds ttnncore as the owner

### Checklist
NA