### PR TITLE
Minor cleanup to ttsim build steps

### DIFF
--- a/.github/workflows/ttsim.yaml
+++ b/.github/workflows/ttsim.yaml
@@ -92,8 +92,8 @@ jobs:
 
       - name: Build ttsim
         run: |
-          cd /work/ttsim/src
-          ../scripts/make.py _out/${{ matrix.build_suffix }}/libttsim.so
+          cd /work/ttsim
+          ./make.py src/_out/${{ matrix.build_suffix }}/libttsim.so
 
       - name: Install ttsim
         run: |
@@ -181,8 +181,8 @@ jobs:
 
       - name: Build ttsim
         run: |
-          cd /work/ttsim/src
-          ../scripts/make.py _out/${{ matrix.build_suffix }}/libttsim.so
+          cd /work/ttsim
+          ./make.py src/_out/${{ matrix.build_suffix }}/libttsim.so
 
       - name: Install ttsim
         run: |
@@ -320,8 +320,8 @@ jobs:
 
       - name: Build ttsim
         run: |
-          cd /work/ttsim/src
-          ../scripts/make.py _out/${{ matrix.build_suffix }}/libttsim.so
+          cd /work/ttsim
+          ./make.py src/_out/${{ matrix.build_suffix }}/libttsim.so
 
       - name: Install ttsim
         run: |
@@ -395,8 +395,8 @@ jobs:
 
       - name: Build ttsim
         run: |
-          cd /work/ttsim/src
-          ../scripts/make.py _out/${{ matrix.build_suffix }}/libttsim.so
+          cd /work/ttsim
+          ./make.py src/_out/${{ matrix.build_suffix }}/libttsim.so
 
       - name: Install ttsim
         run: |


### PR DESCRIPTION
### Ticket
none

### Problem description
ttsim build steps were somewhat outdated.

### What's changed
Use slightly simpler way to build the ttsim binary, so that old symlink can be deleted.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes