### PR TITLE
#28570: Enable QB-GE in multi-card CI

### DIFF
--- a/.github/workflows/blackhole-multi-card-demo-tests.yaml
+++ b/.github/workflows/blackhole-multi-card-demo-tests.yaml
@@ -49,6 +49,10 @@ jobs:
             runner-label: P300-viommu
             extra-tag: pipeline-yyz2-lfc
             num_devices: 2
+          - name: QuietBox Global Edition tests
+            runner-label: BH-QB-GE
+            extra-tag: pipeline-perf
+            num_devices: 4
     with:
       runner-label: ${{ matrix.test-group.runner-label }}
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}

--- a/.github/workflows/blackhole-multi-card-demo-tests.yaml
+++ b/.github/workflows/blackhole-multi-card-demo-tests.yaml
@@ -33,22 +33,22 @@ jobs:
       fail-fast: false
       matrix:
         test-group:
-          - name: LLMBox Demo tests
-            runner-label: BH-LLMBox
-            extra-tag: pipeline-perf
-            num_devices: 4
-          - name: DeskBox Demo tests
-            runner-label: BH-DeskBox
-            extra-tag: pipeline-functional
-            num_devices: 2
-          - name: LoudBox Demo tests
-            runner-label: BH-LoudBox
-            extra-tag: pipeline-perf
-            num_devices: 8
-          - name: P300 Demo tests
-            runner-label: P300-viommu
-            extra-tag: pipeline-yyz2-lfc
-            num_devices: 2
+          # - name: LLMBox Demo tests
+          #   runner-label: BH-LLMBox
+          #   extra-tag: pipeline-perf
+          #   num_devices: 4
+          # - name: DeskBox Demo tests
+          #   runner-label: BH-DeskBox
+          #   extra-tag: pipeline-functional
+          #   num_devices: 2
+          # - name: LoudBox Demo tests
+          #   runner-label: BH-LoudBox
+          #   extra-tag: pipeline-perf
+          #   num_devices: 8
+          # - name: P300 Demo tests
+          #   runner-label: P300-viommu
+          #   extra-tag: pipeline-yyz2-lfc
+          #   num_devices: 2
           - name: QuietBox Global Edition tests
             runner-label: BH-QB-GE
             extra-tag: pipeline-perf

--- a/.github/workflows/blackhole-multi-card-demo-tests.yaml
+++ b/.github/workflows/blackhole-multi-card-demo-tests.yaml
@@ -33,22 +33,22 @@ jobs:
       fail-fast: false
       matrix:
         test-group:
-          # - name: LLMBox Demo tests
-          #   runner-label: BH-LLMBox
-          #   extra-tag: pipeline-perf
-          #   num_devices: 4
-          # - name: DeskBox Demo tests
-          #   runner-label: BH-DeskBox
-          #   extra-tag: pipeline-functional
-          #   num_devices: 2
-          # - name: LoudBox Demo tests
-          #   runner-label: BH-LoudBox
-          #   extra-tag: pipeline-perf
-          #   num_devices: 8
-          # - name: P300 Demo tests
-          #   runner-label: P300-viommu
-          #   extra-tag: pipeline-yyz2-lfc
-          #   num_devices: 2
+          - name: LLMBox Demo tests
+            runner-label: BH-LLMBox
+            extra-tag: pipeline-perf
+            num_devices: 4
+          - name: DeskBox Demo tests
+            runner-label: BH-DeskBox
+            extra-tag: pipeline-functional
+            num_devices: 2
+          - name: LoudBox Demo tests
+            runner-label: BH-LoudBox
+            extra-tag: pipeline-perf
+            num_devices: 8
+          - name: P300 Demo tests
+            runner-label: P300-viommu
+            extra-tag: pipeline-yyz2-lfc
+            num_devices: 2
           - name: QuietBox Global Edition tests
             runner-label: BH-QB-GE
             extra-tag: pipeline-perf

--- a/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
@@ -24,14 +24,14 @@ jobs:
       fail-fast: false
       matrix:
         runner-group:
-          - name: LLMBox unit tests
-            runner-label: BH-LLMBox
-          - name: DeskBox unit tests
-            runner-label: BH-DeskBox
-          - name: LoudBox unit tests
-            runner-label: BH-LoudBox
-          - name: P300 unit tests
-            runner-label: P300-viommu
+          # - name: LLMBox unit tests
+          #   runner-label: BH-LLMBox
+          # - name: DeskBox unit tests
+          #   runner-label: BH-DeskBox
+          # - name: LoudBox unit tests
+          #   runner-label: BH-LoudBox
+          # - name: P300 unit tests
+          #   runner-label: P300-viommu
           - name: QuietBox Global Edition unit tests
             runner-label: BH-QB-GE
         test-group:

--- a/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
@@ -32,6 +32,8 @@ jobs:
             runner-label: BH-LoudBox
           - name: P300 unit tests
             runner-label: P300-viommu
+          - name: QuietBox Global Edition unit tests
+            runner-label: BH-QB-GE
         test-group:
           - name: fabric 1D unit tests
             cmd: |

--- a/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
@@ -24,14 +24,14 @@ jobs:
       fail-fast: false
       matrix:
         runner-group:
-          # - name: LLMBox unit tests
-          #   runner-label: BH-LLMBox
-          # - name: DeskBox unit tests
-          #   runner-label: BH-DeskBox
-          # - name: LoudBox unit tests
-          #   runner-label: BH-LoudBox
-          # - name: P300 unit tests
-          #   runner-label: P300-viommu
+          - name: LLMBox unit tests
+            runner-label: BH-LLMBox
+          - name: DeskBox unit tests
+            runner-label: BH-DeskBox
+          - name: LoudBox unit tests
+            runner-label: BH-LoudBox
+          - name: P300 unit tests
+            runner-label: P300-viommu
           - name: QuietBox Global Edition unit tests
             runner-label: BH-QB-GE
         test-group:

--- a/.github/workflows/blackhole-nightly-tests.yaml
+++ b/.github/workflows/blackhole-nightly-tests.yaml
@@ -97,6 +97,10 @@ jobs:
             runner-label: P300-viommu
             extra-tag: pipeline-yyz2-lfc
             num_devices: 2
+          - name: QuietBox Global Edition tests
+            runner-label: BH-QB-GE
+            extra-tag: pipeline-perf
+            num_devices: 4
     with:
       runner-label: ${{ matrix.test-group.runner-label }}
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}

--- a/.github/workflows/blackhole-nightly-tests.yaml
+++ b/.github/workflows/blackhole-nightly-tests.yaml
@@ -81,22 +81,22 @@ jobs:
       fail-fast: false
       matrix:
         test-group:
-          - name: LLMBox Demo tests
-            runner-label: BH-LLMBox
-            extra-tag: pipeline-perf
-            num_devices: 4
-          - name: DeskBox Demo tests
-            runner-label: BH-DeskBox
-            extra-tag: pipeline-functional
-            num_devices: 2
-          - name: LoudBox Demo tests
-            runner-label: BH-LoudBox
-            extra-tag: pipeline-perf
-            num_devices: 8
-          - name: P300 Demo tests
-            runner-label: P300-viommu
-            extra-tag: pipeline-yyz2-lfc
-            num_devices: 2
+          # - name: LLMBox Demo tests
+          #   runner-label: BH-LLMBox
+          #   extra-tag: pipeline-perf
+          #   num_devices: 4
+          # - name: DeskBox Demo tests
+          #   runner-label: BH-DeskBox
+          #   extra-tag: pipeline-functional
+          #   num_devices: 2
+          # - name: LoudBox Demo tests
+          #   runner-label: BH-LoudBox
+          #   extra-tag: pipeline-perf
+          #   num_devices: 8
+          # - name: P300 Demo tests
+          #   runner-label: P300-viommu
+          #   extra-tag: pipeline-yyz2-lfc
+          #   num_devices: 2
           - name: QuietBox Global Edition tests
             runner-label: BH-QB-GE
             extra-tag: pipeline-perf

--- a/.github/workflows/blackhole-nightly-tests.yaml
+++ b/.github/workflows/blackhole-nightly-tests.yaml
@@ -81,22 +81,22 @@ jobs:
       fail-fast: false
       matrix:
         test-group:
-          # - name: LLMBox Demo tests
-          #   runner-label: BH-LLMBox
-          #   extra-tag: pipeline-perf
-          #   num_devices: 4
-          # - name: DeskBox Demo tests
-          #   runner-label: BH-DeskBox
-          #   extra-tag: pipeline-functional
-          #   num_devices: 2
-          # - name: LoudBox Demo tests
-          #   runner-label: BH-LoudBox
-          #   extra-tag: pipeline-perf
-          #   num_devices: 8
-          # - name: P300 Demo tests
-          #   runner-label: P300-viommu
-          #   extra-tag: pipeline-yyz2-lfc
-          #   num_devices: 2
+          - name: LLMBox Demo tests
+            runner-label: BH-LLMBox
+            extra-tag: pipeline-perf
+            num_devices: 4
+          - name: DeskBox Demo tests
+            runner-label: BH-DeskBox
+            extra-tag: pipeline-functional
+            num_devices: 2
+          - name: LoudBox Demo tests
+            runner-label: BH-LoudBox
+            extra-tag: pipeline-perf
+            num_devices: 8
+          - name: P300 Demo tests
+            runner-label: P300-viommu
+            extra-tag: pipeline-yyz2-lfc
+            num_devices: 2
           - name: QuietBox Global Edition tests
             runner-label: BH-QB-GE
             extra-tag: pipeline-perf

--- a/tests/tt_metal/tt_fabric/system_health/test_system_health.cpp
+++ b/tests/tt_metal/tt_fabric/system_health/test_system_health.cpp
@@ -405,6 +405,10 @@ TEST(Cluster, TestMeshFullConnectivity) {
         num_expected_chips = 8;
         num_expected_mmio_chips = 8;
         num_connections_per_side = 2;
+    } else if (cluster_type == tt::tt_metal::ClusterType::P300_X2) {
+        num_expected_chips = 4;
+        num_expected_mmio_chips = 4;
+        num_connections_per_side = 2;
     } else {
         GTEST_SKIP() << "Mesh check not supported for system type " << enchantum::to_string(cluster_type);
     }


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/28570

### What's changed
Enable QB-GE in blackhole nightly (multi-card unit + demos)
Enable `TestMeshFullConnectivity` on P300_X2

### Checklist
- [x] BH multi-card unit tests https://github.com/tenstorrent/tt-metal/actions/runs/19306402441
- [x] BH multi-card demos https://github.com/tenstorrent/tt-metal/actions/runs/19306407365 (device perf prefill failure/skips are due to known issue on main)