### PR TITLE
#31848: Re-enable new sim tests and move to merge gate

### DIFF
--- a/.github/actions/find-changed-files/action.yml
+++ b/.github/actions/find-changed-files/action.yml
@@ -27,9 +27,11 @@ outputs:
   docs-changed:
     value: ${{ steps.find-changed-files.outputs.docs-changed }}
   model-charts-changed:
-   value: ${{ steps.find-changed-files.outputs.model-charts-changed }}
+    value: ${{ steps.find-changed-files.outputs.model-charts-changed }}
   models-changed:
     value: ${{ steps.find-changed-files.outputs.models-changed }}
+  build-workflows-changed:
+    value: ${{ steps.find-changed-files.outputs.build-workflows-changed }}
 
 runs:
   using: "composite"

--- a/.github/scripts/utils/find-changed-files.sh
+++ b/.github/scripts/utils/find-changed-files.sh
@@ -22,6 +22,7 @@ ANY_CODE_CHANGED=false
 DOCS_CHANGED=false
 MODEL_CHARTS_CHANGED=false
 MODELS_CHANGED=false
+BUILD_WORKFLOWS_CHANGED=false
 
 while IFS= read -r FILE; do
     case "$FILE" in
@@ -78,6 +79,10 @@ while IFS= read -r FILE; do
             MODELS_CHANGED=true
             ANY_CODE_CHANGED=true
             ;;
+        .github/workflows/build-artifact.yaml|.github/workflows/build-docker-artifact.yaml|.github/workflows/ttsim.yaml)
+            BUILD_WORKFLOWS_CHANGED=true
+            ANY_CODE_CHANGED=true
+            ;;
     esac
 done <<< "$CHANGED_FILES"
 
@@ -127,6 +132,7 @@ declare -A changes=(
     [docs-changed]=$DOCS_CHANGED
     [model-charts-changed]=$MODEL_CHARTS_CHANGED
     [models-changed]=$MODELS_CHANGED
+    [build-workflows-changed]=$BUILD_WORKFLOWS_CHANGED
 )
 
 for var in "${!changes[@]}"; do

--- a/.github/workflows/all-post-commit-workflows.yaml
+++ b/.github/workflows/all-post-commit-workflows.yaml
@@ -223,21 +223,6 @@ jobs:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-  ttsim-unit-tests:
-    # Breaking, remove for now
-    if: false
-    needs: build-artifact
-    secrets: inherit
-    strategy:
-      fail-fast: false
-    uses: ./.github/workflows/ttsim.yaml
-    with:
-      basic-docker-image: ${{ needs.build-artifact.outputs.basic-dev-docker-image }}
-      test-docker-image: ${{ needs.build-artifact.outputs.ci-test-docker-image }}
-      package-artifact-name: ${{ needs.build-artifact.outputs.packages-artifact-name }}
-      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-      run-metal-cpp-unit-tests: true
   run-profiler-regression:
     needs: [build-artifact, find-changed-files]
 

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -255,6 +255,20 @@ jobs:
       runner: ${{ matrix.platform }}
       product: tt-nn
 
+  ttsim-unit-tests:
+    needs: build
+    secrets: inherit
+    strategy:
+      fail-fast: false
+    uses: ./.github/workflows/ttsim.yaml
+    with:
+      basic-docker-image: ${{ needs.build.outputs.basic-dev-docker-image }}
+      test-docker-image: ${{ needs.build.outputs.ci-test-docker-image }}
+      package-artifact-name: ${{ needs.build.outputs.packages-artifact-name }}
+      wheel-artifact-name: ${{ needs.build.outputs.wheel-artifact-name }}
+      build-artifact-name: ${{ needs.build.outputs.build-artifact-name }}
+      run-metal-cpp-unit-tests: true
+
   # GitHub has so many design limitations it's not even funny.
   # This job is purely so we can capture the essence of the workflow as a whole in our status checks.
   workflow-status:
@@ -268,14 +282,14 @@ jobs:
         contains(join(needs.*.result, ','), 'success') ||
         contains(join(needs.*.result, ','), 'failure')
       }}
-    needs: [static-checks, code-analysis, find-changes, build, build-docs, build-tsan, build-sweeps, metalium-smoke-tests, ttnn-smoke-tests, ttnn-basic-tests, metalium-basic-tests]
+    needs: [static-checks, code-analysis, find-changes, build, build-docs, build-tsan, build-sweeps, metalium-smoke-tests, ttnn-smoke-tests, ttnn-basic-tests, metalium-basic-tests, ttsim-unit-tests]
     runs-on: ubuntu-latest
     steps:
       - name: Check if all jobs passed
         uses: tenstorrent/tt-metal/.github/actions/workflow-status@main
         with:
           required-jobs: "static-checks, code-analysis, find-changes"
-          optional-jobs: "build, build-docs, build-tsan, build-sweeps, metalium-smoke-tests, ttnn-smoke-tests, ttnn-basic-tests, metalium-basic-tests"
+          optional-jobs: "build, build-docs, build-tsan, build-sweeps, metalium-smoke-tests, ttnn-smoke-tests, ttnn-basic-tests, metalium-basic-tests, ttsim-unit-tests"
         env:
           NEEDS_CONTEXT: '${{ toJSON(needs) }}'
       - if: (failure() && contains(join(needs.*.result, ','), 'failure') && github.event_name == 'merge_group')

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -90,6 +90,7 @@ jobs:
       tt-metalium-changed: ${{ steps.find-changes.outputs.tt-metalium-changed }}
       tt-nn-changed: ${{ steps.find-changes.outputs.tt-nn-changed }}
       tt-metalium-or-tt-nn-tests-changed: ${{ steps.find-changes.outputs.tt-metalium-or-tt-nn-tests-changed }}
+      build-workflows-changed: ${{ steps.find-changes.outputs.build-workflows-changed }}
     steps:
       - id: find-changes
         uses: tenstorrent/tt-metal/.github/actions/find-changed-files@v0.63.0

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -256,6 +256,7 @@ jobs:
       product: tt-nn
 
   ttsim-unit-tests:
+    if: ${{ github.event_name != 'pull_request' }}
     needs: build
     secrets: inherit
     strategy:

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -261,11 +261,7 @@ jobs:
 
   ttsim-unit-tests:
     if: ${{ github.ref_name == 'main' ||
-            needs.find-changes.outputs.build-workflows-changed == 'true' ||
-            needs.find-changes.outputs.cmake-changed == 'true' ||
-            needs.find-changes.outputs.tt-metalium-changed == 'true' ||
-            needs.find-changes.outputs.tt-nn-changed == 'true' ||
-            needs.find-changes.outputs.tt-metalium-or-tt-nn-tests-changed == 'true'
+            needs.find-changes.outputs.any-code-changed == 'true'
         }}
     needs: [build, find-changes]
     secrets: inherit

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -259,8 +259,14 @@ jobs:
       product: tt-nn
 
   ttsim-unit-tests:
-    if: ${{ github.event_name != 'pull_request' }}
-    needs: build
+    if: ${{ github.ref_name == 'main' ||
+            needs.find-changes.outputs.build-workflows-changed == 'true' ||
+            needs.find-changes.outputs.cmake-changed == 'true' ||
+            needs.find-changes.outputs.tt-metalium-changed == 'true' ||
+            needs.find-changes.outputs.tt-nn-changed == 'true' ||
+            needs.find-changes.outputs.tt-metalium-or-tt-nn-tests-changed == 'true'
+        }}
+    needs: [build, find-changes]
     secrets: inherit
     strategy:
       fail-fast: false
@@ -268,9 +274,9 @@ jobs:
     with:
       basic-docker-image: ${{ needs.build.outputs.basic-dev-docker-image }}
       test-docker-image: ${{ needs.build.outputs.ci-test-docker-image }}
-      package-artifact-name: ${{ needs.build.outputs.packages-artifact-name }}
       wheel-artifact-name: ${{ needs.build.outputs.wheel-artifact-name }}
       build-artifact-name: ${{ needs.build.outputs.build-artifact-name }}
+      run-ttsim-integration-tests: false
       run-metal-cpp-unit-tests: true
 
   # GitHub has so many design limitations it's not even funny.

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -98,7 +98,8 @@ jobs:
     if: ${{ github.ref_name == 'main' ||
             needs.find-changes.outputs.cmake-changed == 'true' ||
             needs.find-changes.outputs.any-code-changed == 'true' ||
-            needs.find-changes.outputs.docs-changed == 'true'
+            needs.find-changes.outputs.docs-changed == 'true' ||
+            needs.find-changes.outputs.build-workflows-changed == 'true'
         }}
     needs: find-changes
     uses: ./.github/workflows/build-artifact.yaml
@@ -126,7 +127,8 @@ jobs:
   build-tsan:
     if: ${{ github.ref_name == 'main' ||
             needs.find-changes.outputs.cmake-changed == 'true' ||
-            needs.find-changes.outputs.any-code-changed == 'true'
+            needs.find-changes.outputs.any-code-changed == 'true' ||
+            needs.find-changes.outputs.build-workflows-changed == 'true'
         }}
     needs: find-changes
     uses: ./.github/workflows/build-artifact.yaml
@@ -198,7 +200,8 @@ jobs:
   build-asan:
     if: ${{ github.ref_name == 'main' ||
             needs.find-changes.outputs.cmake-changed == 'true' ||
-            needs.find-changes.outputs.any-code-changed == 'true'
+            needs.find-changes.outputs.any-code-changed == 'true' ||
+            needs.find-changes.outputs.build-workflows-changed == 'true'
         }}
     needs: find-changes
     uses: ./.github/workflows/build-artifact.yaml

--- a/.github/workflows/pr-gate.yaml
+++ b/.github/workflows/pr-gate.yaml
@@ -268,6 +268,8 @@ jobs:
       test-docker-image: ${{ needs.build.outputs.ci-test-docker-image }}
       package-artifact-name: ${{ needs.build.outputs.packages-artifact-name }}
       wheel-artifact-name: ${{ needs.build.outputs.wheel-artifact-name }}
+      run-ttsim-integration-tests: true
+      run-metal-cpp-unit-tests: false
 
   docker-image:
     if: github.event_name == 'pull_request' && !github.event.pull_request.draft

--- a/.github/workflows/ttsim.yaml
+++ b/.github/workflows/ttsim.yaml
@@ -10,12 +10,12 @@ on:
         required: true
         type: string
       package-artifact-name:
-        required: true
+        required: false
         type: string
       wheel-artifact-name:
-        required: true
+        required: false
         type: string
-      build-artifact-name: # Used only when run-metal-cpp-unit-tests is true
+      build-artifact-name:
         required: false
         type: string
       ttsim-ref:
@@ -26,6 +26,10 @@ on:
         required: false
         type: number
         default: 15
+      run-ttsim-integration-tests:
+        required: false
+        type: boolean
+        default: false
       run-metal-cpp-unit-tests:
         required: false
         type: boolean
@@ -33,6 +37,7 @@ on:
 
 jobs:
   ttsim-integration:
+    if: ${{ inputs.run-ttsim-integration-tests }}
     runs-on: tt-ubuntu-2204-small-stable
     timeout-minutes: ${{ inputs.job-timeout }}
     name: "TTSim Integration - ${{ matrix.arch }}"
@@ -137,6 +142,7 @@ jobs:
             fi
           done
   ttnn-pytests:
+    if: ${{ inputs.run-ttsim-integration-tests }}
     runs-on: ubuntu-latest
     timeout-minutes: ${{ inputs.job-timeout }}
     name: "TTNN Pytests - ${{ matrix.arch }}"

--- a/.github/workflows/ttsim.yaml
+++ b/.github/workflows/ttsim.yaml
@@ -22,10 +22,10 @@ on:
         required: false
         type: string
         default: "4f05a65a961d4a3ca14f65ff9633030e0a35358e"
-      timeout:
+      job-timeout:
         required: false
         type: number
-        default: 5
+        default: 15
       run-metal-cpp-unit-tests:
         required: false
         type: boolean
@@ -34,6 +34,7 @@ on:
 jobs:
   ttsim-integration:
     runs-on: tt-ubuntu-2204-small-stable
+    timeout-minutes: ${{ inputs.job-timeout }}
     name: "TTSim Integration - ${{ matrix.arch }}"
     strategy:
       fail-fast: false
@@ -137,6 +138,7 @@ jobs:
           done
   ttnn-pytests:
     runs-on: ubuntu-latest
+    timeout-minutes: ${{ inputs.job-timeout }}
     name: "TTNN Pytests - ${{ matrix.arch }}"
     strategy:
       fail-fast: false
@@ -279,6 +281,7 @@ jobs:
   ttsim-cpp-unit-tests:
     if: ${{ inputs.run-metal-cpp-unit-tests }}
     runs-on: tt-ubuntu-2204-small-stable
+    timeout-minutes: ${{ inputs.job-timeout }}
     name: "TTSim C++ tests - ${{ matrix.arch }}"
     strategy:
       fail-fast: false
@@ -330,7 +333,7 @@ jobs:
           cp /work/tt_metal/soc_descriptors/${{ matrix.soc_desc }} $TT_METAL_SIMULATOR_HOME/soc_descriptor.yaml
 
       - name: C++ tests
-        timeout-minutes: ${{ inputs.timeout }}
+        timeout-minutes: 5
         run: |
           ./build/test/tt_metal/unit_tests_api --gtest_filter="MeshDeviceFixture.IdleEthTestNocStreamRegs"
           ./build/test/tt_metal/unit_tests_api --gtest_filter="MeshDispatchFixture.IdleEthDRAMLoopbackSingleCore"
@@ -351,6 +354,7 @@ jobs:
   ttsim-galaxy-cpp-unit-tests:
     if: ${{ inputs.run-metal-cpp-unit-tests }}
     runs-on: tt-ubuntu-2204-large-stable
+    timeout-minutes: ${{ inputs.job-timeout }}
     name: "TTSim Galaxy C++ tests - ${{ matrix.arch }}"
     strategy:
       fail-fast: false
@@ -405,6 +409,7 @@ jobs:
           cp /work/tt_metal/soc_descriptors/${{ matrix.soc_desc }} $TT_METAL_SIMULATOR_HOME/soc_descriptor.yaml
 
       - name: C++ tests
+        timeout-minutes: 5
         run: |
           ./build/test/tt_metal/unit_tests_api --gtest_filter="*StreamRegWrite*"
           ./build/test/tt_metal/unit_tests_api --gtest_filter="*InlineWrite*"


### PR DESCRIPTION
### Ticket
#31848 

### Problem description
New sim tests were disabled on main due to a regression between testing and merge.

### What's changed
Readd new sim tests and add them to merge gate.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [x] New/Existing tests provide coverage for changes