### PR TITLE
Enable 2 erisc mode by default, fallback to 1 erisc if fw is not supported

### DIFF
--- a/tt_metal/fabric/erisc_datamover_builder.cpp
+++ b/tt_metal/fabric/erisc_datamover_builder.cpp
@@ -198,11 +198,9 @@ bool requires_forced_assignment_to_noc1() {
     // When creating a kernel on erisc0 and 2 erisc mode is disabled, the physical processor is erisc1 while erisc0 is
     // running base firmware. As base firmware may occasionally use noc0 force fabric on "erisc0" to use noc1
     //
-    // When 2 erisc mode is enabled on the runtime, erisc index == noc index is enforced hence the condition
-    // !get_enable_2_erisc_mode() below.
+    // When 2 erisc mode is enabled on the runtime, erisc index == noc index is enforced in tt_metal.cpp
     //
-    return tt::tt_metal::MetalContext::instance().hal().get_arch() == tt::ARCH::BLACKHOLE &&
-           get_num_riscv_cores() == 1 && !tt::tt_metal::MetalContext::instance().rtoptions().get_enable_2_erisc_mode();
+    return tt::tt_metal::MetalContext::instance().hal().get_arch() == tt::ARCH::BLACKHOLE && get_num_riscv_cores() == 1;
 }
 }  // anonymous namespace
 

--- a/tt_metal/fabric/fabric_init.cpp
+++ b/tt_metal/fabric/fabric_init.cpp
@@ -502,7 +502,8 @@ std::unique_ptr<tt::tt_metal::Program> create_and_compile_tt_fabric_program(tt::
             ct_args.push_back(router_channels_mask);
 
             auto proc = static_cast<tt::tt_metal::DataMovementProcessor>(risc_id);
-            if (tt::tt_metal::MetalContext::instance().rtoptions().get_enable_2_erisc_mode() &&
+            if (tt::tt_metal::MetalContext::instance().get_cluster().arch() == tt::ARCH::BLACKHOLE &&
+                tt::tt_metal::MetalContext::instance().rtoptions().get_enable_2_erisc_mode() &&
                 num_enabled_risc_cores == 1) {
                 // Force fabric to run on erisc1 due to stack usage exceeded with MUX on erisc0
                 proc = tt::tt_metal::DataMovementProcessor::RISCV_1;

--- a/tt_metal/fabric/fabric_init.cpp
+++ b/tt_metal/fabric/fabric_init.cpp
@@ -502,6 +502,11 @@ std::unique_ptr<tt::tt_metal::Program> create_and_compile_tt_fabric_program(tt::
             ct_args.push_back(router_channels_mask);
 
             auto proc = static_cast<tt::tt_metal::DataMovementProcessor>(risc_id);
+            if (tt::tt_metal::MetalContext::instance().rtoptions().get_enable_2_erisc_mode() &&
+                num_enabled_risc_cores == 1) {
+                // Force fabric to run on erisc1 due to stack usage exceeded with MUX on erisc0
+                proc = tt::tt_metal::DataMovementProcessor::RISCV_1;
+            }
 
             auto eth_logical_core = soc_desc.get_eth_core_for_channel(eth_chan, CoordSystem::LOGICAL);
             auto kernel = tt::tt_metal::CreateKernel(

--- a/tt_metal/hw/firmware/src/tt-1xx/subordinate_erisc.cc
+++ b/tt_metal/hw/firmware/src/tt-1xx/subordinate_erisc.cc
@@ -86,6 +86,7 @@ uint32_t wIndex __attribute__((used));
 uint32_t stackSize __attribute__((used));
 uint32_t sums[SUM_COUNT] __attribute__((used));
 uint32_t sumIDs[SUM_COUNT] __attribute__((used));
+uint32_t traceCount __attribute__((used));
 }  // namespace kernel_profiler
 #endif
 

--- a/tt_metal/impl/context/metal_context.hpp
+++ b/tt_metal/impl/context/metal_context.hpp
@@ -115,6 +115,7 @@ private:
     void clear_launch_messages_on_eth_cores(ChipId device_id);
     void construct_control_plane(const std::filesystem::path& mesh_graph_desc_path);
     void teardown_fabric_config();
+    void teardown_base_objects();
 
     void reset_cores(ChipId device_id);
     void assert_cores(ChipId device_id);

--- a/tt_metal/llrt/hal.cpp
+++ b/tt_metal/llrt/hal.cpp
@@ -33,13 +33,13 @@ bool operator==(const HalProcessorIdentifier& lhs, const HalProcessorIdentifier&
 
 // Hal Constructor determines the platform architecture by using UMD
 // Once it knows the architecture it can self initialize architecture specific memory maps
-Hal::Hal(tt::ARCH arch, bool is_base_routing_fw_enabled) : arch_(arch) {
+Hal::Hal(tt::ARCH arch, bool is_base_routing_fw_enabled, bool enable_2_erisc_mode) : arch_(arch) {
     switch (this->arch_) {
         case tt::ARCH::WORMHOLE_B0: initialize_wh(is_base_routing_fw_enabled); break;
 
         case tt::ARCH::QUASAR: initialize_qa(); break;
 
-        case tt::ARCH::BLACKHOLE: initialize_bh(); break;
+        case tt::ARCH::BLACKHOLE: initialize_bh(enable_2_erisc_mode); break;
 
         default: /*TT_THROW("Unsupported arch for HAL")*/; break;
     }

--- a/tt_metal/llrt/hal.hpp
+++ b/tt_metal/llrt/hal.hpp
@@ -262,7 +262,7 @@ public:
     using DispatchFeatureQueryFunc = std::function<bool(DispatchFeature)>;
     using SetIRAMTextSizeFunc = std::function<void(
         dev_msgs::launch_msg_t::View, HalProgrammableCoreType, HalProcessorClassType, uint32_t, uint32_t)>;
-    using VerifyFwVersionFunc = std::function<void(tt::umd::semver_t)>;
+    using VerifyFwVersionFunc = std::function<bool(tt::umd::semver_t)>;
 
 private:
     tt::ARCH arch_;
@@ -303,7 +303,7 @@ private:
     float inf_ = 0.0f;
 
     void initialize_wh(bool is_base_routing_fw_enabled);
-    void initialize_bh();
+    void initialize_bh(bool enable_2_erisc_mode);
     void initialize_qa();
 
     // Functions where implementation varies by architecture
@@ -326,7 +326,7 @@ private:
     VerifyFwVersionFunc verify_eth_fw_version_func_;
 
 public:
-    Hal(tt::ARCH arch, bool is_base_routing_fw_enabled);
+    Hal(tt::ARCH arch, bool is_base_routing_fw_enabled, bool enable_2_erisc_mode);
 
     tt::ARCH get_arch() const { return arch_; }
 
@@ -491,8 +491,8 @@ public:
 
     // Verify that the eth version is compatible with the HAL capabilities. Throws an exception if version is
     // not compatible.
-    void verify_eth_fw_version(tt::umd::semver_t eth_fw_version) const {
-        this->verify_eth_fw_version_func_(eth_fw_version);
+    bool verify_eth_fw_version(tt::umd::semver_t eth_fw_version) const {
+        return this->verify_eth_fw_version_func_(eth_fw_version);
     }
 };
 

--- a/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal.cpp
+++ b/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal.cpp
@@ -62,7 +62,7 @@ static constexpr float INF_BH = 1.7014e+38;
 namespace tt::tt_metal::blackhole {
 bool is_2_erisc_mode() {
     // rtoptions not included in here due to circular dependency
-    return true;  // getenv("TT_METAL_MULTI_AERISC") != nullptr;
+    return getenv("TT_METAL_DISABLE_MULTI_AERISC") == nullptr;
 }
 }  // namespace tt::tt_metal::blackhole
 

--- a/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal.cpp
+++ b/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal.cpp
@@ -62,7 +62,7 @@ static constexpr float INF_BH = 1.7014e+38;
 namespace tt::tt_metal::blackhole {
 bool is_2_erisc_mode() {
     // rtoptions not included in here due to circular dependency
-    return getenv("TT_METAL_MULTI_AERISC") != nullptr;
+    return true;  // getenv("TT_METAL_MULTI_AERISC") != nullptr;
 }
 }  // namespace tt::tt_metal::blackhole
 

--- a/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal.cpp
+++ b/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal.cpp
@@ -15,6 +15,7 @@
 #include "dev_mem_map.h"
 #include "eth_fw_api.h"
 #include "hal_types.hpp"
+#include "impl/context/metal_context.hpp"
 #include "llrt/hal.hpp"
 #include "noc/noc_overlay_parameters.h"
 #include "noc/noc_parameters.h"
@@ -59,26 +60,24 @@ static constexpr float EPS_BH = 1.19209e-7f;
 static constexpr float NAN_BH = 7.0040e+19;
 static constexpr float INF_BH = 1.7014e+38;
 
-namespace tt::tt_metal::blackhole {
-bool is_2_erisc_mode() {
-    // rtoptions not included in here due to circular dependency
-    return getenv("TT_METAL_DISABLE_MULTI_AERISC") == nullptr;
-}
-}  // namespace tt::tt_metal::blackhole
-
 namespace tt {
 
 namespace tt_metal {
 
 class HalJitBuildQueryBlackHole : public hal_1xx::HalJitBuildQueryBase {
+private:
+    bool enable_2_erisc_mode_;
+
 public:
+    HalJitBuildQueryBlackHole(bool enable_2_erisc_mode) : enable_2_erisc_mode_(enable_2_erisc_mode) {}
+
     std::vector<std::string> link_objs(const Params& params) const override {
         std::vector<std::string> objs;
         if (params.is_fw) {
             // Needed to setup gp, sp, etc. for all processors which are launched with assert/deassert PC method
             // For 2 erisc, erisc0 is launched from base firmware so it's not needed
             if (!(params.core_type == HalProgrammableCoreType::ACTIVE_ETH && params.processor_id == 0 &&
-                  blackhole::is_2_erisc_mode())) {
+                  enable_2_erisc_mode_)) {
                 objs.push_back("runtime/hw/lib/blackhole/tmu-crt0.o");
             }
         }
@@ -135,7 +134,7 @@ public:
         defines.push_back("ARCH_BLACKHOLE");
         // Push back the physical erisc id
         if (params.core_type == HalProgrammableCoreType::ACTIVE_ETH) {
-            if (blackhole::is_2_erisc_mode()) {
+            if (enable_2_erisc_mode_) {
                 defines.push_back("ENABLE_2_ERISC_MODE");
                 defines.push_back("PHYSICAL_AERISC_ID=" + std::to_string(params.processor_id));
             } else {
@@ -152,7 +151,7 @@ public:
                 case 0:
                     if (params.is_fw) {
                         srcs.push_back("tt_metal/hw/firmware/src/tt-1xx/active_erisc.cc");
-                        if (blackhole::is_2_erisc_mode()) {
+                        if (enable_2_erisc_mode_) {
                             // not tmu-crt0
                             srcs.push_back("tt_metal/hw/firmware/src/tt-1xx/active_erisc-crt0.cc");
                         }
@@ -190,7 +189,7 @@ public:
         // 72 B = Approx. stack usage at the time the kernel is launched
         // 2048 B - 64 B - 72 B = 1912 B free for kernel
         if (params.core_type == HalProgrammableCoreType::ACTIVE_ETH && params.processor_id == 0 &&
-            blackhole::is_2_erisc_mode()) {
+            enable_2_erisc_mode_) {
             cflags += "-Werror=stack-usage=1912 ";
         }
         return cflags;
@@ -214,9 +213,9 @@ public:
                         "{}/{}_{}aerisc.ld",
                         path,
                         fork,
-                        params.processor_id            ? "subordinate_"
-                        : blackhole::is_2_erisc_mode() ? "main_"
-                        : "");
+                        params.processor_id    ? "subordinate_"
+                        : enable_2_erisc_mode_ ? "main_"
+                                               : "");
                 }
                 break;
             case HalProgrammableCoreType::IDLE_ETH:
@@ -244,7 +243,7 @@ public:
     }
 };
 
-void Hal::initialize_bh() {
+void Hal::initialize_bh(bool enable_2_erisc_mode) {
     using namespace blackhole;
     static_assert(static_cast<int>(HalProgrammableCoreType::TENSIX) == static_cast<int>(ProgrammableCoreType::TENSIX));
     static_assert(
@@ -255,7 +254,7 @@ void Hal::initialize_bh() {
     HalCoreInfoType tensix_mem_map = blackhole::create_tensix_mem_map();
     this->core_info_.push_back(tensix_mem_map);
 
-    HalCoreInfoType active_eth_mem_map = blackhole::create_active_eth_mem_map();
+    HalCoreInfoType active_eth_mem_map = blackhole::create_active_eth_mem_map(enable_2_erisc_mode);
     this->core_info_.push_back(active_eth_mem_map);
 
     HalCoreInfoType idle_eth_mem_map = blackhole::create_idle_eth_mem_map();
@@ -403,10 +402,10 @@ void Hal::initialize_bh() {
         NOC_CFG(NOC_Y_ID_TRANSLATE_TABLE_4),
         NOC_CFG(NOC_Y_ID_TRANSLATE_TABLE_5)};
 
-    this->jit_build_query_ = std::make_unique<HalJitBuildQueryBlackHole>();
+    this->jit_build_query_ = std::make_unique<HalJitBuildQueryBlackHole>(enable_2_erisc_mode);
 
-    this->verify_eth_fw_version_func_ = [](tt::umd::semver_t fw_version) {
-        if (blackhole::is_2_erisc_mode()) {
+    this->verify_eth_fw_version_func_ = [=](tt::umd::semver_t fw_version) {
+        if (enable_2_erisc_mode) {
             tt::umd::semver_t min_version(1, 7, 0);
             if (!(fw_version >= min_version)) {
                 log_critical(
@@ -414,8 +413,10 @@ void Hal::initialize_bh() {
                     "In 2-erisc mode, the minimum supported ethernet firmware version is {}. Detected version is {}",
                     min_version.to_string(),
                     fw_version.to_string());
+                return false;
             }
         }
+        return true;
     };
 }
 

--- a/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal.cpp
+++ b/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal.cpp
@@ -408,9 +408,10 @@ void Hal::initialize_bh(bool enable_2_erisc_mode) {
         if (enable_2_erisc_mode) {
             tt::umd::semver_t min_version(1, 7, 0);
             if (!(fw_version >= min_version)) {
-                log_critical(
+                log_warning(
                     tt::LogLLRuntime,
-                    "In 2-erisc mode, the minimum supported ethernet firmware version is {}. Detected version is {}",
+                    "Blackhole multi erisc mode requires ethernet firmware version {} or higher, but detected version "
+                    "{}. Automatically falling back to single erisc mode for compatibility.",
                     min_version.to_string(),
                     fw_version.to_string());
                 return false;

--- a/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal.hpp
+++ b/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal.hpp
@@ -19,9 +19,7 @@ struct AllEthMailbox {
 };
 
 HalCoreInfoType create_tensix_mem_map();
-HalCoreInfoType create_active_eth_mem_map();
+HalCoreInfoType create_active_eth_mem_map(bool enable_2_erisc_mode);
 HalCoreInfoType create_idle_eth_mem_map();
-
-bool is_2_erisc_mode();
 
 }  // namespace tt::tt_metal::blackhole

--- a/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal_active_eth.cpp
+++ b/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal_active_eth.cpp
@@ -64,7 +64,7 @@ std::vector<std::vector<HalJitBuildConfig>> configure_for_2erisc() {
     };
 }
 
-HalCoreInfoType create_active_eth_mem_map() {
+HalCoreInfoType create_active_eth_mem_map(bool enable_2_erisc_mode) {
     std::uint32_t max_alignment = std::max(DRAM_ALIGNMENT, L1_ALIGNMENT);
 
     static_assert(MEM_IERISC_MAP_END % L1_ALIGNMENT == 0);
@@ -156,8 +156,7 @@ HalCoreInfoType create_active_eth_mem_map() {
 
     std::vector<std::vector<HalJitBuildConfig>> processor_classes;
     std::vector<std::vector<std::pair<std::string, std::string>>> processor_classes_names;
-    // rtoptions not included in here due to circular dependency
-    if (is_2_erisc_mode()) {
+    if (enable_2_erisc_mode) {
         processor_classes = configure_for_2erisc();
         processor_classes_names = {{{"ER0", "ERISC0"}, {"ER1", "ERISC1"}}};
     } else {

--- a/tt_metal/llrt/hal/tt-1xx/wormhole/wh_hal.cpp
+++ b/tt_metal/llrt/hal/tt-1xx/wormhole/wh_hal.cpp
@@ -365,6 +365,7 @@ void Hal::initialize_wh(bool is_base_routing_fw_enabled) {
 
     this->verify_eth_fw_version_func_ = [](tt::umd::semver_t /*eth_fw_version*/) {
         // No checks
+        return true;
     };
 }
 

--- a/tt_metal/llrt/hal/tt-2xx/quasar/qa_hal.cpp
+++ b/tt_metal/llrt/hal/tt-2xx/quasar/qa_hal.cpp
@@ -332,6 +332,7 @@ void Hal::initialize_qa() {
 
     this->verify_eth_fw_version_func_ = [](tt::umd::semver_t /*eth_fw_version*/) {
         // No checks
+        return true;
     };
 }
 

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -323,10 +323,10 @@ RunTimeOptions::RunTimeOptions() {
         this->enable_2_erisc_mode_with_fabric = true;
     }
 
-    // if (getenv("TT_METAL_MULTI_AERISC")) {
-    log_info(tt::LogMetal, "Enabling experimental multi-erisc mode");
-    this->enable_2_erisc_mode = true;
-    // }
+    if (getenv("TT_METAL_DISABLE_MULTI_AERISC")) {
+        log_info(tt::LogMetal, "Disabling multi-erisc mode");
+        this->enable_2_erisc_mode = false;
+    }
 
     if (getenv("TT_METAL_LOG_KERNELS_COMPILE_COMMANDS")) {
         this->log_kernels_compilation_commands = true;

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -327,6 +327,10 @@ RunTimeOptions::RunTimeOptions() {
         log_info(tt::LogMetal, "Disabling multi-erisc mode with TT_METAL_DISABLE_MULTI_AERISC");
         this->enable_2_erisc_mode = false;
     }
+    if (this->runtime_target_device_ != tt::TargetDevice::Silicon) {
+        log_info(tt::LogMetal, "Disabling multi-erisc mode with simulator/mock target device");
+        this->enable_2_erisc_mode = false;
+    }
 
     if (getenv("TT_METAL_LOG_KERNELS_COMPILE_COMMANDS")) {
         this->log_kernels_compilation_commands = true;

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -324,7 +324,7 @@ RunTimeOptions::RunTimeOptions() {
     }
 
     if (getenv("TT_METAL_DISABLE_MULTI_AERISC")) {
-        log_info(tt::LogMetal, "Disabling multi-erisc mode");
+        log_info(tt::LogMetal, "Disabling multi-erisc mode with TT_METAL_DISABLE_MULTI_AERISC");
         this->enable_2_erisc_mode = false;
     }
 

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -323,10 +323,10 @@ RunTimeOptions::RunTimeOptions() {
         this->enable_2_erisc_mode_with_fabric = true;
     }
 
-    if (getenv("TT_METAL_MULTI_AERISC")) {
-        log_info(tt::LogMetal, "Enabling experimental multi-erisc mode");
-        this->enable_2_erisc_mode = true;
-    }
+    // if (getenv("TT_METAL_MULTI_AERISC")) {
+    log_info(tt::LogMetal, "Enabling experimental multi-erisc mode");
+    this->enable_2_erisc_mode = true;
+    // }
 
     if (getenv("TT_METAL_LOG_KERNELS_COMPILE_COMMANDS")) {
         this->log_kernels_compilation_commands = true;

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -498,6 +498,8 @@ public:
     // Feature flag to enable 2-erisc mode on Blackhole
     bool get_enable_2_erisc_mode() const { return enable_2_erisc_mode; }
 
+    void set_enable_2_erisc_mode(bool enable) { enable_2_erisc_mode = enable; }
+
     bool is_custom_fabric_mesh_graph_desc_path_specified() const { return is_custom_fabric_mesh_graph_desc_path_set; }
     std::string get_custom_fabric_mesh_graph_desc_path() const { return custom_fabric_mesh_graph_desc_path; }
 

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -199,7 +199,7 @@ class RunTimeOptions {
     bool enable_2_erisc_mode_with_fabric = false;
 
     // feature flag to enable 2-erisc mode on Blackhole (general, not fabric-specific)
-    bool enable_2_erisc_mode = false;
+    bool enable_2_erisc_mode = true;
 
     // Log kernels compilation commands
     bool log_kernels_compilation_commands = false;

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -317,7 +317,6 @@ void Cluster::initialize_device_drivers() {
     this->start_driver(default_params);
     this->generate_virtual_to_umd_coord_mapping();
     this->generate_virtual_to_profiler_flat_id_mapping();
-    this->verify_eth_fw_capability();
 }
 
 void Cluster::assert_risc_reset() {
@@ -862,15 +861,16 @@ void Cluster::verify_sw_fw_versions(
     }
 }
 
-void Cluster::verify_eth_fw_capability() const {
-    // get_ethernet_fw_version is not supported in the simulation environment
+bool Cluster::verify_eth_fw_capability() const {
+    // get_ethernet_fw_version is not supported in the simulation environment. assume it's correct!
     if (rtoptions_.get_simulator_enabled()) {
-        return;
+        return true;
     }
     const auto fw_version = this->driver_->get_ethernet_firmware_version();
     if (fw_version) {
-        hal_.verify_eth_fw_version(fw_version.value());
+        return hal_.verify_eth_fw_version(fw_version.value());
     }
+    return true;
 }
 
 // DRAM barrier is used to implement host-to-device synchronization and should be used when all previous writes to DRAM

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -131,6 +131,7 @@ public:
 
     //! device driver and misc apis
     void verify_sw_fw_versions(int device_id, std::uint32_t sw_version, std::vector<std::uint32_t>& fw_versions) const;
+    bool verify_eth_fw_capability() const;
 
     void deassert_risc_reset_at_core(
         const tt_cxy_pair& physical_chip_coord,
@@ -371,8 +372,6 @@ private:
     void set_tunnels_from_mmio_device();
 
     bool supports_dma_operations(ChipId chip_id, uint32_t sz_in_bytes) const;
-
-    void verify_eth_fw_capability() const;
 
     ARCH arch_{tt::ARCH::Invalid};
     TargetDevice target_type_{0};

--- a/tt_metal/tools/profiler/kernel_profiler.hpp
+++ b/tt_metal/tools/profiler/kernel_profiler.hpp
@@ -101,7 +101,7 @@ __attribute__((noinline)) void init_profiler(
         sums[i] = 0;
     }
 
-#if defined(COMPILE_FOR_ERISC) || defined(COMPILE_FOR_IDLE_ERISC) || defined(COMPILE_FOR_AERISC) || \
+#if defined(COMPILE_FOR_IDLE_ERISC) || (defined(COMPILE_FOR_AERISC) && (COMPILE_FOR_AERISC == 0)) || \
     defined(COMPILE_FOR_BRISC)
     uint32_t runCounter = profiler_control_buffer[RUN_COUNTER];
     profiler_control_buffer[PROFILER_DONE] = 0;
@@ -195,7 +195,7 @@ inline __attribute__((always_inline)) void risc_finished_profiling() {
 }
 
 #if defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_BRISC) || defined(COMPILE_FOR_ERISC) || \
-    defined(COMPILE_FOR_IDLE_ERISC) || defined(COMPILE_FOR_AERISC)
+    defined(COMPILE_FOR_IDLE_ERISC) || (defined(COMPILE_FOR_AERISC) && (COMPILE_FOR_AERISC == 0))
 
 // Saves several NoC register states restores them
 // when the NocRegisterStateSave is destroyed
@@ -275,7 +275,7 @@ void profiler_noc_async_flush_posted_write(uint8_t noc = noc_index) {
 
 __attribute__((noinline)) void finish_profiler() {
     risc_finished_profiling();
-#if defined(COMPILE_FOR_ERISC) || defined(COMPILE_FOR_IDLE_ERISC) || defined(COMPILE_FOR_AERISC) || \
+#if defined(COMPILE_FOR_IDLE_ERISC) || (defined(COMPILE_FOR_AERISC) && (COMPILE_FOR_AERISC == 0)) || \
     defined(COMPILE_FOR_BRISC)
     if (profiler_control_buffer[PROFILER_DONE] == 1) {
         return;
@@ -351,9 +351,9 @@ __attribute__((noinline)) void finish_profiler() {
 }
 
 __attribute__((noinline)) void quick_push() {
-#if (                                                                                          \
-    defined(COMPILE_FOR_BRISC) || defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_ERISC) || \
-    defined(COMPILE_FOR_IDLE_ERISC) || defined(COMPILE_FOR_AERISC))
+#if (                                                                                               \
+    defined(COMPILE_FOR_BRISC) || defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_IDLE_ERISC) || \
+    (defined(COMPILE_FOR_AERISC) && (COMPILE_FOR_AERISC == 0)))
 
     // tt-metal/issues/22578 - forbid quick_push if any cmd buffer has NOC_CMD_VC_LINKED bit set
     auto linked_bit_is_set = [](const uint32_t reg_val) { return reg_val & NOC_CMD_VC_LINKED; };
@@ -426,9 +426,9 @@ __attribute__((noinline)) void quick_push() {
 // DRAM in the event that a long series of linked multicast will prevent
 // flushing and cause dropped events.
 void quick_push_if_linked(uint32_t cmd_buf, bool linked) {
-#if (                                                                                          \
-    defined(COMPILE_FOR_BRISC) || defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_ERISC) || \
-    defined(COMPILE_FOR_IDLE_ERISC) || defined(COMPILE_FOR_AERISC))
+#if (                                                                                               \
+    defined(COMPILE_FOR_BRISC) || defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_IDLE_ERISC) || \
+    (defined(COMPILE_FOR_AERISC) && (COMPILE_FOR_AERISC == 0)))
     if (!linked) {
         return;
     }

--- a/tt_telemetry/telemetry/hal/hal.cpp
+++ b/tt_telemetry/telemetry/hal/hal.cpp
@@ -15,7 +15,7 @@ std::unique_ptr<tt::tt_metal::Hal> create_hal(const std::unique_ptr<tt::umd::Clu
     // is_2_erisc_mode is true. But it can change to false on the Metal runtime to maintain backward compabaility with
     // older firmware.
     // This value doesn't affect the addresses of any buffers.
-    // Telemetry doesn't care about number of ERISC processors so it's ok to not be in sync with the value on Metal. 
+    // Telemetry doesn't care about number of ERISC processors as it reads all ERISCs anyway, so it's ok to not be in sync with the value on Metal. 
     bool is_2_erisc_mode = rtoptions.get_enable_2_erisc_mode();
     return std::make_unique<tt::tt_metal::Hal>(tt::tt_metal::get_platform_architecture(rtoptions), is_base_routing_fw_enabled, is_2_erisc_mode);
 }

--- a/tt_telemetry/telemetry/hal/hal.cpp
+++ b/tt_telemetry/telemetry/hal/hal.cpp
@@ -12,10 +12,10 @@ std::unique_ptr<tt::tt_metal::Hal> create_hal(const std::unique_ptr<tt::umd::Clu
     tt::umd::ClusterDescriptor* cluster_descriptor = cluster->get_cluster_description();
     bool is_base_routing_fw_enabled =
         tt::Cluster::is_base_routing_fw_enabled(tt::Cluster::get_cluster_type_from_cluster_desc(rtoptions, cluster_descriptor));
-    // is_2_erisc_mode is true. But it can change to false on the Metal runtime to maintain backward compabaility with
-    // older firmware.
-    // This value doesn't affect the addresses of any buffers.
-    // Telemetry doesn't care about number of ERISC processors as it reads all ERISCs anyway, so it's ok to not be in sync with the value on Metal. 
-    bool is_2_erisc_mode = rtoptions.get_enable_2_erisc_mode();
+    // Telemetry currently doesn't collect data on the granularity of each ERISC processor / RISCV.
+    // is_2_erisc_mode is hardcoded to True to show 2 ERISC processors on Blackhole with the Hal::get_num_risc_processors API.
+    // This parameter doesn't affect the addresses of any buffers in L1. If Metal only has 1 ERISC enabled for Blackhole then telemtry
+    // will simply read empty values for the other ERISC.
+    constexpr bool is_2_erisc_mode = true;
     return std::make_unique<tt::tt_metal::Hal>(tt::tt_metal::get_platform_architecture(rtoptions), is_base_routing_fw_enabled, is_2_erisc_mode);
 }

--- a/tt_telemetry/telemetry/hal/hal.cpp
+++ b/tt_telemetry/telemetry/hal/hal.cpp
@@ -12,5 +12,6 @@ std::unique_ptr<tt::tt_metal::Hal> create_hal(const std::unique_ptr<tt::umd::Clu
     tt::umd::ClusterDescriptor* cluster_descriptor = cluster->get_cluster_description();
     bool is_base_routing_fw_enabled =
         tt::Cluster::is_base_routing_fw_enabled(tt::Cluster::get_cluster_type_from_cluster_desc(rtoptions, cluster_descriptor));
-    return std::make_unique<tt::tt_metal::Hal>(tt::tt_metal::get_platform_architecture(rtoptions), is_base_routing_fw_enabled);
+    bool is_2_erisc_mode = rtoptions.get_enable_2_erisc_mode();
+    return std::make_unique<tt::tt_metal::Hal>(tt::tt_metal::get_platform_architecture(rtoptions), is_base_routing_fw_enabled, is_2_erisc_mode);
 }

--- a/tt_telemetry/telemetry/hal/hal.cpp
+++ b/tt_telemetry/telemetry/hal/hal.cpp
@@ -12,6 +12,10 @@ std::unique_ptr<tt::tt_metal::Hal> create_hal(const std::unique_ptr<tt::umd::Clu
     tt::umd::ClusterDescriptor* cluster_descriptor = cluster->get_cluster_description();
     bool is_base_routing_fw_enabled =
         tt::Cluster::is_base_routing_fw_enabled(tt::Cluster::get_cluster_type_from_cluster_desc(rtoptions, cluster_descriptor));
+    // is_2_erisc_mode is true. But it can change to false on the Metal runtime to maintain backward compabaility with
+    // older firmware.
+    // This value doesn't affect the addresses of any buffers.
+    // Telemetry doesn't care about number of ERISC processors so it's ok to not be in sync with the value on Metal. 
     bool is_2_erisc_mode = rtoptions.get_enable_2_erisc_mode();
     return std::make_unique<tt::tt_metal::Hal>(tt::tt_metal::get_platform_architecture(rtoptions), is_base_routing_fw_enabled, is_2_erisc_mode);
 }


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/31820

### Problem description
We want to enable 2 ERISC mode on Blackhole by default

### What's changed
- Updated rtoptions to set enable 2 erisc mode by default. To maintain backward compatibility with older fw versions, this will automatically fallback to reinitialize in 1 erisc mode if the fw doesn't meet the requirements. The fallback will incur an additional cost of 1 UMD reinit due to the way the Cluster is depending on the HAL.
- Inverted the env var to be `TT_METAL_DISABLE_MULTI_AERISC`. This will disable the multi erisc feature.
- Placed the Fabric router on ERISC1 as it is overflowing the stack on ERISC0 when the Fabric MUX is being used

### Checklist
Blackhole Post Commit
https://github.com/tenstorrent/tt-metal/actions/runs/19177916440
https://github.com/tenstorrent/tt-metal/actions/runs/19184363286
https://github.com/tenstorrent/tt-metal/actions/runs/19274707577
Blackhole Multi Card Demo
https://github.com/tenstorrent/tt-metal/actions/runs/19244821019
Blackhole Demo
https://github.com/tenstorrent/tt-metal/actions/runs/19153013602
Blackhole Multi Card Unit CI
https://github.com/tenstorrent/tt-metal/actions/runs/19083715077
APC
https://github.com/tenstorrent/tt-metal/actions/runs/19184579052
Galaxy Multi User Isolation
https://github.com/tenstorrent/tt-metal/actions/runs/19185143497
Blackhole Nightly
https://github.com/tenstorrent/tt-metal/actions/runs/19274691923