### PR TITLE
[tt-train] Changes to profiler setup and .md file

### DIFF
--- a/tt-train/docs/PROFILER.md
+++ b/tt-train/docs/PROFILER.md
@@ -100,7 +100,7 @@ The directory contains the following files:
 | `profile_log_device.csv` | Device-side profiling data captured during execution. |
 | `tracy_profile_log_host.tracy` | Host-side Tracy profiler log, which can be opened with the Tracy GUI.|
 
-Custom markers can be emitted via `ctx().get_profiler().read_results("my_custom_marker")`
+Custom markers can be emitted via `ctx().get_profiler().read_results(device, "my_custom_marker")`
 
 ---
 

--- a/tt-train/docs/PROFILER.md
+++ b/tt-train/docs/PROFILER.md
@@ -1,6 +1,9 @@
 # TT‑Metal Profiler Guide
 
-> **Quick start**: Build with profiling enabled, run your experiment with a single command, then open the companion notebook to explore the generated `.csv`.
+> **Quick start:**
+> 1. Build with `build_metal.sh`
+> 2. Run `tt-train/run_profiler.sh` with the appropriate binary
+> 3. Open `tt-train/notebooks/profiler_results.ipynb` notebook and run using the generated `ops_perf_results_<timestamp>.csv`
 
 ---
 
@@ -18,10 +21,10 @@
 
 ## Features
 
-- **One‑line build** with all profiler hooks enabled.
-- **Environment‑variable toggles**—no code changes required.
-- Generates a **single comma‑separated log (**``**)** ready for pandas / Excel.
-- Companion **Jupyter Notebook** for rich visualisation.
+- **One‑line build**
+- **Environment‑variable toggles**—no code changes required
+- Generates **comma‑separated log files** ready for pandas / Excel and **.tracy** file for the Tracy GUI
+- Companion **Jupyter Notebook** for rich visualisation
 
 ---
 
@@ -30,7 +33,7 @@
 | Requirement  | Version    | Notes                                             |
 | ------------ | ---------- | ------------------------------------------------- |
 | Ubuntu / WSL | 20.04 +    | Tested on 22.04 as well                           |
-| Python       | 3.9 +      | `python -m venv venv && source venv/bin/activate` |
+| Python       | 3.9 +      | `./create_venv.sh && source python_env/bin/activate` |
 | CMake        | ≥ 3.20     |                                                   |
 | Ninja        | (optional) | Faster parallel builds                            |
 
@@ -41,9 +44,7 @@
 ## Build & Install
 
 ```bash
-./build_metal.sh -b Release \
-                 --enable-profile \
-                 --build-tt-train
+./build_metal.sh -b Release --build-tt-train
 ```
 
 The flags do the following:
@@ -51,31 +52,33 @@ The flags do the following:
 | Flag               | Purpose                                                   |
 | ------------------ | --------------------------------------------------------- |
 | `-b Release`       | Compile with full optimisation.                           |
-| `--enable-profile` | Injects profiler hooks into every kernel.                 |
+| ~~`--enable-profile`~~ | *(No longer needed)* Injects profiler hooks into every kernel, now enabled by default. |
 | `--build-tt-train` | Builds the `tt-train` helper used by the NanoGPT example. |
 
-After completion the relevant binaries live under `build/tt-train/`.
+After completion the relevant binaries live under `${TT_METAL_HOME}/build/tt-train/`.
 
 ---
 
 ## Running the Profiler
 
-Enable python environment (created in tt-metal) and run following command:
+Activate python environment (created in tt-metal) and run following command:
 
 ```bash
+env -u TT_METAL_DPRINT_CORES \
 TT_METAL_WATCHER_NOINLINE=1 \
 TT_METAL_WATCHER_DEBUG_DELAY=10 \
 TT_METAL_READ_DEBUG_DELAY_CORES=0,0 \
 TT_METAL_WRITE_DEBUG_DELAY_CORES=0,0 \
 TT_METAL_READ_DEBUG_DELAY_RISCVS=BR \
 TT_METAL_WRITE_DEBUG_DELAY_RISCVS=BR \
-python -m tracy -r -v -p build/tt-train/sources/examples/nano_gpt/nano_gpt
+python -m tracy -r -v -p ${TT_METAL_HOME}/build/tt-train/sources/examples/nano_gpt/nano_gpt
 ```
 
 ### What do those variables mean?
 
 | Variable                                 | Default | Description                                                                         |
 | ---------------------------------------- | ------- | ----------------------------------------------------------------------------------- |
+| `TT_METAL_DPRINT_CORES`                  | `0,0`   | DPRINT and profiler cannot be enabled at the same time. |
 | `TT_METAL_WATCHER_NOINLINE`              | `0`     | Forces watchdog helpers to stay **out‑of‑line** for clearer flame graphs.           |
 | `TT_METAL_WATCHER_DEBUG_DELAY`           | `0` ms  | Extra delay (ms) after each kernel for debugger attachment.                         |
 | `TT_METAL_READ/WRITE_DEBUG_DELAY_CORES`  | `"0,0"` | Comma‑separated *(x,y)* coordinates of cores for which to inject read/write delays. |
@@ -87,13 +90,17 @@ python -m tracy -r -v -p build/tt-train/sources/examples/nano_gpt/nano_gpt
 
 ## Output Artifacts
 
-After the run finishes, you will find a **single CSV log** in the current working directory:
+After the run finishes, all profiler outputs are stored under:
+`${TT_METAL_HOME}/generated/profiler/reports/<timestamp>/`
 
-```text
-trace_<timestamp>.csv
-```
+The directory contains the following files:
+| File | Description |
+|------|--------------|
+| `ops_perf_results_<timestamp>.csv` | The file contains one row per kernel launch with timestamps, core coordinates, cycle counts etc. |
+| `profile_log_device.csv` | Device-side profiling data captured during execution. |
+| `tracy_profile_log_host.tracy` | Host-side Tracy profiler log, which can be opened with the Tracy GUI.|
 
-The file contains one row per kernel launch with timestamps, core coordinates, cycle counts, and any custom markers you emit via `ctx().get_profiler().mark(...)`.
+Custom markers can be emitted via `ctx().get_profiler().read_results("my_custom_marker")`
 
 ---
 

--- a/tt-train/run_profiler.sh
+++ b/tt-train/run_profiler.sh
@@ -1,7 +1,8 @@
+env -u TT_METAL_DPRINT_CORES \
 TT_METAL_WATCHER_NOINLINE=1 \
 TT_METAL_WATCHER_DEBUG_DELAY=10 \
 TT_METAL_READ_DEBUG_DELAY_CORES=0,0 \
 TT_METAL_WRITE_DEBUG_DELAY_CORES=0,0 \
 TT_METAL_READ_DEBUG_DELAY_RISCVS=BR \
 TT_METAL_WRITE_DEBUG_DELAY_RISCVS=BR \
-python -m tracy -r -v -p ../build/tt-train/sources/examples/nano_gpt/nano_gpt
+python -m tracy -r -v -p ${TT_METAL_HOME}/build/tt-train/sources/examples/nano_gpt/nano_gpt

--- a/tt-train/sources/examples/nano_gpt/main.cpp
+++ b/tt-train/sources/examples/nano_gpt/main.cpp
@@ -446,6 +446,7 @@ int main(int argc, char **argv) {
     argv = app.ensure_utf8(argv);
 
     const char *tt_metal_home = std::getenv("TT_METAL_HOME");
+    TT_FATAL(tt_metal_home != nullptr, "TT_METAL_HOME environment variable is not set");
     std::string config_name = std::string(tt_metal_home) + "/tt-train/configs/training_shakespeare_nanogpt.yaml";
 
     std::string run_name = "";

--- a/tt-train/sources/examples/nano_gpt/main.cpp
+++ b/tt-train/sources/examples/nano_gpt/main.cpp
@@ -38,7 +38,6 @@ namespace {
 constexpr auto gpt2_tokenizer_file_name = "/gpt2-tokenizer.json";
 }
 
-
 using Model = std::shared_ptr<ttml::models::BaseTransformer>;
 
 void model_to_eval(Model &model) {
@@ -446,7 +445,8 @@ int main(int argc, char **argv) {
     CLI::App app{"NanoGPT Example"};
     argv = app.ensure_utf8(argv);
 
-    std::string config_name = std::string(CONFIGS_FOLDER) + "/training_shakespeare_nanogpt.yaml";
+    const char *tt_metal_home = std::getenv("TT_METAL_HOME");
+    std::string config_name = std::string(tt_metal_home) + "/tt-train/configs/training_shakespeare_nanogpt.yaml";
 
     std::string run_name = "";
     bool is_eval = false;
@@ -474,7 +474,6 @@ int main(int argc, char **argv) {
 
         auto distributed_ctx = ctx.get_distributed_context();
         fmt::print("Size {}, Rank {}: Initializing MPI context\n", *distributed_ctx->size(), *distributed_ctx->rank());
-
     }
 
     if (device_config.enable_ddp || device_config.enable_tp) {
@@ -930,6 +929,7 @@ int main(int argc, char **argv) {
     }
 
     ttml::autograd::ctx().get_profiler().read_results(device, "before close device", 0);
+    ttml::autograd::ctx().close_device();
     ttml::autograd::ctx().close_profiler();
     return 0;
 }


### PR DESCRIPTION
### Problem description
- run_profiler.sh can only be run from `${TT_METAL_HOME}/tt-train`, and TT_METAL_DPRINT_CORES might be set when running Tracy.
- In nano_gpt/main.cpp, `CONFIGS_FOLDER="${CMAKE_SOURCE_DIR}/configs"` resolves to `${TT_METAL_HOME}/configs`, which doesn't exists when building tt-train from `${TT_METAL_HOME}`.
- PROFILER.md description is outdated

### What's changed
1. run_profiler.sh
- Unsets TT_METAL_DPRINT_CORES before running Tracy (DPRINT and profiler cannot be enabled simultaneously).
- Run Tracy relative to `${TT_METAL_HOME}` so it's more flexible.
2. nano_gpt/main.cpp
- Calls close_device() before close_profiler() to enable device-side profiling.
- Use TT_METAL_HOME environment variable in std::string config_name instead of CONFIGS_FOLDER to allow running from `${TT_METAL_HOME}/build/tt-train` without hardcoded path.
3. PROFILER.md
- Updated the TT-Metal profiler guide to include the latest build process and Tracy output files.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] New/Existing tests provide coverage for changes