### PR TITLE
#0: Fix finish calls to do a host synchronize for the mesh device to prevent races between hosts in a BigMesh

### DIFF
--- a/tt_metal/distributed/fd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.cpp
@@ -518,9 +518,7 @@ void FDMeshCommandQueue::finish(tt::stl::Span<const SubDeviceId> sub_device_ids)
     // Barrier across all hosts of the mesh
     auto distributed_context = tt::tt_metal::MetalContext::instance().get_control_plane().get_distributed_context(
         mesh_device_->get_view().mesh_id());
-    if (*(distributed_context->size()) > 1) {
-        distributed_context->barrier();
-    }
+    distributed_context->barrier();
 }
 
 void FDMeshCommandQueue::write_shard_to_device(

--- a/tt_metal/distributed/multihost/single_host_context.cpp
+++ b/tt_metal/distributed/multihost/single_host_context.cpp
@@ -39,11 +39,9 @@ bool SingleHostContext::is_revoked() { return false; }
 
 void SingleHostContext::abort(int error_code) const { std::exit(error_code); }
 
-/* Remaining methods throw for single-host context */
-void SingleHostContext::barrier() const {
-    TT_THROW("method barrier is unsupported for single-host distributed contexts.");
-}
+void SingleHostContext::barrier() const { return; }
 
+/* Remaining methods throw for single-host context */
 void SingleHostContext::send(tt::stl::Span<std::byte> buf, Rank dest, Tag tag) const {
     TT_THROW("method send is unsupported for single-host distributed contexts.");
 }

--- a/tt_metal/distributed/sd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/sd_mesh_command_queue.cpp
@@ -114,9 +114,7 @@ void SDMeshCommandQueue::finish(tt::stl::Span<const SubDeviceId>) {
     // Barrier across all hosts of the mesh
     auto distributed_context = tt::tt_metal::MetalContext::instance().get_control_plane().get_distributed_context(
         mesh_device_->get_view().mesh_id());
-    if (*(distributed_context->size()) > 1) {
-        distributed_context->barrier();
-    }
+    distributed_context->barrier();
 }
 
 void SDMeshCommandQueue::finish_nolock(tt::stl::Span<const SubDeviceId>) {}

--- a/tt_metal/distributed/sd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/sd_mesh_command_queue.cpp
@@ -7,6 +7,7 @@
 #include "tt_metal/common/thread_pool.hpp"
 #include <mesh_device.hpp>
 #include <mesh_event.hpp>
+#include <tt-metalium/control_plane.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/graph_tracking.hpp>
 #include <utility>
@@ -108,6 +109,13 @@ void SDMeshCommandQueue::finish(tt::stl::Span<const SubDeviceId>) {
     for (const auto& device : mesh_device_->get_devices()) {
         tt::tt_metal::MetalContext::instance().get_cluster().dram_barrier(device->id());
         tt::tt_metal::MetalContext::instance().get_cluster().l1_barrier(device->id());
+    }
+
+    // Barrier across all hosts of the mesh
+    auto distributed_context = tt::tt_metal::MetalContext::instance().get_control_plane().get_distributed_context(
+        mesh_device_->get_view().mesh_id());
+    if (*(distributed_context->size()) > 1) {
+        distributed_context->barrier();
     }
 }
 


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
When calling finish/synchronize on a MeshDevice, we expect that all reads/writes/programs etc complete across all the devices before we move on. This is currently not the case on a BigMesh, since the finish function is only blocking until completion for the local devices on a host only. This means that hosts can race ahead of each other before all of them have finished.
This was observed running BigMesh CCL tests using Slow Dispatch, as these CCLs depend on a global semaphore being written to all devices before executing the CCL, but there was a race since the hosts weren't synced, leading to a hang.

### What's changed
Add a barrier across all hosts the own part of the MeshDevice at the end of finish. This guarantees that all devices in the mesh have completed before proceeding.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/19076469881
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [x] New/Existing tests provide coverage for changes
Multi-Host: https://github.com/tenstorrent/tt-metal/actions/runs/19082589607