### PR TITLE
[skip ci] Changing Cache and Github API Calls in Triage Tool

### DIFF
--- a/.github/actions/fetch-workflow-data/action.yml
+++ b/.github/actions/fetch-workflow-data/action.yml
@@ -30,6 +30,9 @@ inputs:
   workflow_configs:
     description: 'JSON array of workflow configurations to filter by (array of objects with wkflw_name or wkflw_prefix)'
     required: false
+  workflow_ids:
+    description: 'JSON array of workflow file paths to fetch runs for (e.g., [".github/workflows/workflow.yaml"])'
+    required: false
 
 outputs:
   total-runs:

--- a/.github/actions/fetch-workflow-data/fetch-workflow-data.js
+++ b/.github/actions/fetch-workflow-data/fetch-workflow-data.js
@@ -265,7 +265,7 @@ function groupRunsByName(runs) {
  * @param {object} context - GitHub Actions context
  * @returns {Promise<number|null>} Run ID or null if not found
  */
-async function findPreviousAggregateRun(octokit, context, branch = 'main') {
+async function findPreviousAggregateRun(octokit, context, branch = '31803-increase-caching-threshold-for-triage-pipeline') {
   try {
     core.info('[CACHE] Searching for previous successful aggregate-workflow-data run...');
     const workflowId = '.github/workflows/aggregate-workflow-data.yaml';

--- a/.github/actions/fetch-workflow-data/fetch-workflow-data.js
+++ b/.github/actions/fetch-workflow-data/fetch-workflow-data.js
@@ -1342,7 +1342,7 @@ async function run() {
     let newCommitsCount = 0;
     let skippedCachedCommits = 0;
     let consecutiveCachedCommits = 0;
-    const MAX_CONSECUTIVE_CACHED = 10; // If we see 10 consecutive cached commits, assume we've caught up
+    const MAX_CONSECUTIVE_CACHED = 100; // If we see 10 consecutive cached commits, assume we've caught up
     try {
       const sinceIso = getCutoffDate(days).toISOString();
       core.info(`[COMMITS] Fetching commits since ${sinceIso}`);

--- a/.github/actions/fetch-workflow-data/fetch-workflow-data.js
+++ b/.github/actions/fetch-workflow-data/fetch-workflow-data.js
@@ -265,7 +265,7 @@ function groupRunsByName(runs) {
  * @param {object} context - GitHub Actions context
  * @returns {Promise<number|null>} Run ID or null if not found
  */
-async function findPreviousAggregateRun(octokit, context, branch = '31803-increase-caching-threshold-for-triage-pipeline') {
+async function findPreviousAggregateRun(octokit, context, branch = 'main') {
   try {
     core.info('[CACHE] Searching for previous successful aggregate-workflow-data run...');
     const workflowId = '.github/workflows/aggregate-workflow-data.yaml';
@@ -548,7 +548,7 @@ async function run() {
     let cachedLastSuccessTimestamps = {};
 
     // Find and restore artifacts from previous successful run
-    const previousRunId = await findPreviousAggregateRun(octokit, github.context, branch);
+    const previousRunId = await findPreviousAggregateRun(octokit, github.context, '31803-increase-caching-threshold-for-triage-pipeline');
     if (previousRunId) {
       core.info(`[CACHE] Starting artifact restoration from run ${previousRunId}`);
       try {

--- a/.github/actions/fetch-workflow-data/fetch-workflow-data.js
+++ b/.github/actions/fetch-workflow-data/fetch-workflow-data.js
@@ -149,7 +149,7 @@ async function findPreviousAggregateRun(octokit, context) {
       owner: context.repo.owner,
       repo: context.repo.repo,
       workflow_id: workflowId,
-      branch: 'main',
+      branch: '31803-increase-caching-threshold-for-triage-pipeline',
       status: 'completed',
       per_page: 10
     });

--- a/.github/actions/fetch-workflow-data/fetch-workflow-data.js
+++ b/.github/actions/fetch-workflow-data/fetch-workflow-data.js
@@ -548,7 +548,7 @@ async function run() {
     let cachedLastSuccessTimestamps = {};
 
     // Find and restore artifacts from previous successful run
-    const previousRunId = await findPreviousAggregateRun(octokit, github.context, '31803-increase-caching-threshold-for-triage-pipeline');
+    const previousRunId = await findPreviousAggregateRun(octokit, github.context, branch);
     if (previousRunId) {
       core.info(`[CACHE] Starting artifact restoration from run ${previousRunId}`);
       try {

--- a/.github/actions/fetch-workflow-data/fetch-workflow-data.js
+++ b/.github/actions/fetch-workflow-data/fetch-workflow-data.js
@@ -43,7 +43,7 @@ async function fetchAllWorkflowRuns(github, context, days, cachedRunIds = null, 
   core.info(`[FETCH] days: ${days}, cachedRunIds: ${cachedIds.size}, eventType: ${eventType || 'all'}`);
 
   let consecutiveCachedRuns = 0;
-  const MAX_CONSECUTIVE_CACHED = 10; // If we see 10 consecutive cached runs, assume we've caught up
+  const MAX_CONSECUTIVE_CACHED = 50; // If we see 10 consecutive cached runs, assume we've caught up
   let skippedOldRuns = 0;
   let skippedCachedRuns = 0;
   let addedNewRuns = 0;
@@ -1342,7 +1342,7 @@ async function run() {
     let newCommitsCount = 0;
     let skippedCachedCommits = 0;
     let consecutiveCachedCommits = 0;
-    const MAX_CONSECUTIVE_CACHED = 100; // If we see 10 consecutive cached commits, assume we've caught up
+    const MAX_CONSECUTIVE_CACHED = 50; // If we see 10 consecutive cached commits, assume we've caught up
     try {
       const sinceIso = getCutoffDate(days).toISOString();
       core.info(`[COMMITS] Fetching commits since ${sinceIso}`);

--- a/.github/actions/fetch-workflow-data/fetch-workflow-data.js
+++ b/.github/actions/fetch-workflow-data/fetch-workflow-data.js
@@ -43,7 +43,7 @@ async function fetchAllWorkflowRuns(github, context, days, cachedRunIds = null, 
   core.info(`[FETCH] days: ${days}, cachedRunIds: ${cachedIds.size}, eventType: ${eventType || 'all'}`);
 
   let consecutiveCachedRuns = 0;
-  const MAX_CONSECUTIVE_CACHED = 50; // If we see 10 consecutive cached runs, assume we've caught up
+  const MAX_CONSECUTIVE_CACHED = 200; // If we see 10 consecutive cached runs, assume we've caught up
   let skippedOldRuns = 0;
   let skippedCachedRuns = 0;
   let addedNewRuns = 0;
@@ -1342,7 +1342,7 @@ async function run() {
     let newCommitsCount = 0;
     let skippedCachedCommits = 0;
     let consecutiveCachedCommits = 0;
-    const MAX_CONSECUTIVE_CACHED = 50; // If we see 10 consecutive cached commits, assume we've caught up
+    const MAX_CONSECUTIVE_CACHED = 200; // If we see 10 consecutive cached commits, assume we've caught up
     try {
       const sinceIso = getCutoffDate(days).toISOString();
       core.info(`[COMMITS] Fetching commits since ${sinceIso}`);

--- a/.github/workflows/aggregate-workflow-data.yaml
+++ b/.github/workflows/aggregate-workflow-data.yaml
@@ -38,13 +38,46 @@ jobs:
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           days: ${{ github.event.inputs.days || 15 }}
+          workflow_ids: |
+            [
+              ".github/workflows/all-post-commit-workflows.yaml",
+              ".github/workflows/blackhole-post-commit.yaml",
+              ".github/workflows/blackhole-nightly-tests.yaml",
+              ".github/workflows/blackhole-demo-tests.yaml",
+              ".github/workflows/galaxy-profiler-tests.yaml",
+              ".github/workflows/galaxy-multi-user-isolation-tests.yaml",
+              ".github/workflows/galaxy-deepseek-tests.yaml",
+              ".github/workflows/galaxy-model-perf-tests.yaml",
+              ".github/workflows/galaxy-demo-tests.yaml",
+              ".github/workflows/galaxy-unit-tests.yaml",
+              ".github/workflows/galaxy-frequent-tests.yaml",
+              ".github/workflows/galaxy-stress-tests.yaml",
+              ".github/workflows/galaxy-nightly-tests.yaml",
+              ".github/workflows/galaxy-quick.yaml",
+              ".github/workflows/t3000-model-perf-tests.yaml",
+              ".github/workflows/t3000-nightly-tests.yaml",
+              ".github/workflows/t3000-frequent-tests.yaml",
+              ".github/workflows/t3000-profiler-tests.yaml",
+              ".github/workflows/t3000-perplexity-tests.yaml",
+              ".github/workflows/t3000-demo-tests.yaml",
+              ".github/workflows/t3000-unit-tests.yaml",
+              ".github/workflows/fast-dispatch-frequent-tests.yaml",
+              ".github/workflows/perf-device-models.yaml",
+              ".github/workflows/perf-models.yaml",
+              ".github/workflows/fast-dispatch-full-regressions-and-models.yaml",
+              ".github/workflows/single-card-demo-tests.yaml",
+              ".github/workflows/tt-metal-l2-nightly.yaml",
+              ".github/workflows/ttnn-run-sweeps.yaml",
+              ".github/workflows/vllm-nightly-tests.yaml",
+              ".github/workflows/metal-run-microbenchmarks.yaml",
+              ".github/workflows/apc-nightly-debug.yaml"
+            ]
           workflow_configs: |
             [
               {"display": "All post-commit tests", "wkflw_name": "All post-commit tests"},
               {"display": "Blackhole post-commit tests", "wkflw_name": "Blackhole post-commit tests"},
               {"display": "(Blackhole) prefix", "wkflw_prefix": "(Blackhole)"},
-              {"display": "(TG) prefix", "wkflw_prefix": "(TG)"},
-              {"display": "Galaxy prefix", "wkflw_prefix": "Galaxy"},
+              {"display": "Galaxy prefix", "wkflw_prefix": "(Galaxy)"},
               {"display": "(T3K) prefix", "wkflw_prefix": "(T3K)"},
               {"display": "(Single-card) prefix", "wkflw_prefix": "(Single-card)"},
               {"display": "Nightly tt-metal L2 tests", "wkflw_name": "Nightly tt-metal L2 tests"},

--- a/.github/workflows/aggregate-workflow-data.yaml
+++ b/.github/workflows/aggregate-workflow-data.yaml
@@ -4,7 +4,7 @@ on:
     branches:
       - mchiou/0-aggregate-workflow-report
   schedule:
-    - cron: '*/5 * * * *' # every 5 minutes
+    - cron: '*/10 * * * *' # every 10 minutes
   workflow_dispatch:
     inputs:
       days:

--- a/.github/workflows/aggregate-workflow-data.yaml
+++ b/.github/workflows/aggregate-workflow-data.yaml
@@ -276,6 +276,6 @@ jobs:
       - name: Post regressions to Slack
         uses: ./.github/actions/slack-report-analyze-workflow-data
         with:
-          slack_webhook_url: ${{ secrets.SLACK_TESTING_CHANNEL }}
+          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_AGGREGATE_PIPELINE_STATUS_ALERT }}
           regressed_workflows: ${{ needs.analyze-data.outputs.regressed_workflows }}
           alert_all_message: ${{ needs.analyze-data.outputs.alert_all_message }}

--- a/.github/workflows/aggregate-workflow-data.yaml
+++ b/.github/workflows/aggregate-workflow-data.yaml
@@ -243,6 +243,6 @@ jobs:
       - name: Post regressions to Slack
         uses: ./.github/actions/slack-report-analyze-workflow-data
         with:
-          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_AGGREGATE_PIPELINE_STATUS_ALERT }}
+          slack_webhook_url: ${{ secrets.SLACK_TESTING_CHANNEL }}
           regressed_workflows: ${{ needs.analyze-data.outputs.regressed_workflows }}
           alert_all_message: ${{ needs.analyze-data.outputs.alert_all_message }}


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/31803

### Problem description
The previous caching mechanism and fetching logic caused many unnecessary runs to be downloaded, and also enabled new runs to not be properly downloaded. 

### What's changed
Instead of downloading 100 pages worth of run data across all runs, now targeted api calls are used to download run data only from the pipelines we care about. At the same time, the caching threshold to determine when to stop looking for new runs has been increased to 50, so only after the tool detects 50 runs in a row that are already in the cache will it stop looking for new runs.

### Checklist
- [x] [Aggregate Workflow Data](https://github.com/tenstorrent/tt-metal/actions/workflows/aggregate-workflow-data.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/19080088940
