### PR TITLE
Add device support for slice operation with tensor args

### DIFF
--- a/tests/ttnn/unit_tests/operations/data_movement/test_slice.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_slice.py
@@ -1084,14 +1084,40 @@ def test_ttnn_slice_whisper(input_shape, input_start, input_ends, input_steps, m
 @pytest.mark.parametrize(
     "input_shape, dim, start, end, step, layout",
     (
-        # ([4, 4], 1, [0, 1], [1, 2], 1, ttnn.ROW_MAJOR_LAYOUT),
-        # ([1, 28, 56, 96], 2, [0, 0, 0, 0], [1, 16, 32, 32], 2, ttnn.ROW_MAJOR_LAYOUT),
-        # ([10], 1, [2], [7], 1, ttnn.ROW_MAJOR_LAYOUT),
-        ([3, 16, 128, 2880], 2, [0, 0, 32, 0], [3, 16, 64, 2880], 1, ttnn.TILE_LAYOUT),
+        ([4, 4], 1, [0, 1], [1, 2], 1, ttnn.ROW_MAJOR_LAYOUT),
+        ([1, 28, 56, 96], 2, [0, 0, 0, 0], [1, 16, 32, 32], 2, ttnn.ROW_MAJOR_LAYOUT),
+        ([10], 1, [2], [7], 1, ttnn.ROW_MAJOR_LAYOUT),
     ),
 )
+def test_slice_tensor_args(input_shape, dim, start, end, step, layout, device):
+    torch_input = torch.randn(input_shape, dtype=torch.bfloat16)
+
+    torch_start_tensor = torch.tensor(start)
+    torch_end_tensor = torch.tensor(end)
+
+    slices = tuple(slice(start[i], end[i]) for i in range(len(start)))
+
+    # Slice the tensor using the slices for each dimension
+    torch_output_tensor = torch_input[slices]
+
+    ttnn_start_tensor = ttnn.from_torch(torch_start_tensor)
+    ttnn_end_tensor = ttnn.from_torch(torch_end_tensor)
+
+    ttnn_tensor = ttnn.from_torch(torch_input, layout=layout, dtype=ttnn.bfloat16, device=device)
+
+    ttnn_output = ttnn.slice(ttnn_tensor, ttnn_start_tensor, ttnn_end_tensor)
+
+    ttnn_output_tensor = ttnn.to_torch(ttnn_output)
+
+    assert_with_pcc(torch_output_tensor, ttnn_output_tensor, 0.999)
+
+
+@pytest.mark.parametrize(
+    "input_shape, dim, start, end, step, layout",
+    (([1, 16, 128, 2880], 2, [0, 0, 32, 0], [1, 16, 64, 2880], 1, ttnn.TILE_LAYOUT),),
+)
 @pytest.mark.parametrize("mesh_device", [pytest.param((1, 32), id="1x32_grid")], indirect=True)
-def test_slice_tensor_args(mesh_device, input_shape, dim, start, end, step, layout):
+def test_slice_tensor_args_mesh_device(mesh_device, input_shape, dim, start, end, step, layout):
     if mesh_device.get_num_devices() != 32:
         pytest.skip("Not TG!")
 
@@ -1120,118 +1146,29 @@ def test_slice_tensor_args(mesh_device, input_shape, dim, start, end, step, layo
         mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
     )
 
-    print("before running slice")
-    # Calculate num_devices from the slice pattern (input_shape[dim] / output_shape[dim])
     num_devices_calc = input_shape[dim] // (end[dim] - start[dim])
     ttnn_output = ttnn.slice(
         ttnn_tensor, ttnn_start_tensor, ttnn_end_tensor, slice_dim=dim, num_devices=num_devices_calc
     )
-    print("after running slice")
 
     ttnn_output_tensor = ttnn.to_torch(ttnn_output, mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=0))
-    print("shape of ttnn output:", ttnn_output_tensor.shape)
-    print("shape of torch output:", torch_output_tensor.shape)
-
-    num_devices = 32
-    batch_size = input_shape[0]  # First dimension of input
-
-    ttnn_reshaped = ttnn_output_tensor.view(num_devices, batch_size, *ttnn_output_tensor.shape[1:])
-
-    ttnn_device_output = ttnn_reshaped[0]  # Shape: [3, 16, 32, 2880]
-
-    print("shape of ttnn device output:", ttnn_device_output.shape)
-    assert_with_pcc(torch_output_tensor, ttnn_device_output, 0.999)
+    for i in range(32):
+        assert_with_pcc(torch_output_tensor[0, :, :, :], ttnn_output_tensor[i, :, :, :], 0.999)
 
 
 @pytest.mark.parametrize(
     "input_shape, dim, start, end, step, layout",
     (
         ([1, 1, 128, 2880], 2, [0, 0, 0, 0], [1, 1, 32, 2880], 1, ttnn.TILE_LAYOUT),
-        ([1, 1, 128, 2880], 2, [0, 0, 32, 0], [1, 1, 64, 2880], 1, ttnn.TILE_LAYOUT),
-        ([1, 1, 128, 2880], 2, [0, 0, 64, 0], [1, 1, 96, 2880], 1, ttnn.TILE_LAYOUT),
-        ([1, 1, 128, 2880], 2, [0, 0, 96, 0], [1, 1, 128, 2880], 1, ttnn.TILE_LAYOUT),
-        ([1, 1, 256, 2880], 2, [0, 0, 0, 0], [1, 1, 64, 2880], 1, ttnn.TILE_LAYOUT),
-        ([1, 1, 256, 2880], 2, [0, 0, 64, 0], [1, 1, 128, 2880], 1, ttnn.TILE_LAYOUT),
-        ([1, 1, 256, 2880], 2, [0, 0, 128, 0], [1, 1, 192, 2880], 1, ttnn.TILE_LAYOUT),
-        ([1, 1, 256, 2880], 2, [0, 0, 192, 0], [1, 1, 256, 2880], 1, ttnn.TILE_LAYOUT),
-        ([1, 1, 512, 2880], 2, [0, 0, 0, 0], [1, 1, 128, 2880], 1, ttnn.TILE_LAYOUT),
-        ([1, 1, 512, 2880], 2, [0, 0, 128, 0], [1, 1, 256, 2880], 1, ttnn.TILE_LAYOUT),
-        ([1, 1, 512, 2880], 2, [0, 0, 256, 0], [1, 1, 384, 2880], 1, ttnn.TILE_LAYOUT),
-        ([1, 1, 512, 2880], 2, [0, 0, 384, 0], [1, 1, 512, 2880], 1, ttnn.TILE_LAYOUT),
-        ([1, 1, 1024, 2880], 2, [0, 0, 0, 0], [1, 1, 256, 2880], 1, ttnn.TILE_LAYOUT),
-        ([1, 1, 1024, 2880], 2, [0, 0, 256, 0], [1, 1, 512, 2880], 1, ttnn.TILE_LAYOUT),
-        ([1, 1, 1024, 2880], 2, [0, 0, 512, 0], [1, 1, 768, 2880], 1, ttnn.TILE_LAYOUT),
-        ([1, 1, 1024, 2880], 2, [0, 0, 768, 0], [1, 1, 1024, 2880], 1, ttnn.TILE_LAYOUT),
-        ([1, 1, 2048, 2880], 2, [0, 0, 0, 0], [1, 1, 512, 2880], 1, ttnn.TILE_LAYOUT),
         ([1, 1, 2048, 2880], 2, [0, 0, 512, 0], [1, 1, 1024, 2880], 1, ttnn.TILE_LAYOUT),
-        ([1, 1, 2048, 2880], 2, [0, 0, 1024, 0], [1, 1, 1536, 2880], 1, ttnn.TILE_LAYOUT),
-        ([1, 1, 2048, 2880], 2, [0, 0, 1536, 0], [1, 1, 2048, 2880], 1, ttnn.TILE_LAYOUT),
-        # 4096
-        ([1, 1, 4096, 2880], 2, [0, 0, 0, 0], [1, 1, 1024, 2880], 1, ttnn.TILE_LAYOUT),
-        ([1, 1, 4096, 2880], 2, [0, 0, 1024, 0], [1, 1, 2048, 2880], 1, ttnn.TILE_LAYOUT),
         ([1, 1, 4096, 2880], 2, [0, 0, 2048, 0], [1, 1, 3072, 2880], 1, ttnn.TILE_LAYOUT),
-        ([1, 1, 4096, 2880], 2, [0, 0, 3072, 0], [1, 1, 4096, 2880], 1, ttnn.TILE_LAYOUT),
-        # 8192
-        ([1, 1, 8192, 2880], 2, [0, 0, 0, 0], [1, 1, 2048, 2880], 1, ttnn.TILE_LAYOUT),
-        ([1, 1, 8192, 2880], 2, [0, 0, 2048, 0], [1, 1, 4096, 2880], 1, ttnn.TILE_LAYOUT),
-        ([1, 1, 8192, 2880], 2, [0, 0, 4096, 0], [1, 1, 6144, 2880], 1, ttnn.TILE_LAYOUT),
-        ([1, 1, 8192, 2880], 2, [0, 0, 6144, 0], [1, 1, 8192, 2880], 1, ttnn.TILE_LAYOUT),
-        # 16384
-        ([1, 1, 16384, 2880], 2, [0, 0, 0, 0], [1, 1, 4096, 2880], 1, ttnn.TILE_LAYOUT),
-        ([1, 1, 16384, 2880], 2, [0, 0, 4096, 0], [1, 1, 8192, 2880], 1, ttnn.TILE_LAYOUT),
-        ([1, 1, 16384, 2880], 2, [0, 0, 8192, 0], [1, 1, 12288, 2880], 1, ttnn.TILE_LAYOUT),
-        ([1, 1, 16384, 2880], 2, [0, 0, 12288, 0], [1, 1, 16384, 2880], 1, ttnn.TILE_LAYOUT),
-        # 32768
-        ([1, 1, 32768, 2880], 2, [0, 0, 0, 0], [1, 1, 8192, 2880], 1, ttnn.TILE_LAYOUT),
-        ([1, 1, 32768, 2880], 2, [0, 0, 8192, 0], [1, 1, 16384, 2880], 1, ttnn.TILE_LAYOUT),
-        ([1, 1, 32768, 2880], 2, [0, 0, 16384, 0], [1, 1, 24576, 2880], 1, ttnn.TILE_LAYOUT),
-        ([1, 1, 32768, 2880], 2, [0, 0, 24576, 0], [1, 1, 32768, 2880], 1, ttnn.TILE_LAYOUT),
-        # 65536
-        ([1, 1, 65536, 2880], 2, [0, 0, 0, 0], [1, 1, 16384, 2880], 1, ttnn.TILE_LAYOUT),
-        ([1, 1, 65536, 2880], 2, [0, 0, 16384, 0], [1, 1, 32768, 2880], 1, ttnn.TILE_LAYOUT),
-        ([1, 1, 65536, 2880], 2, [0, 0, 32768, 0], [1, 1, 49152, 2880], 1, ttnn.TILE_LAYOUT),
         ([1, 1, 65536, 2880], 2, [0, 0, 49152, 0], [1, 1, 65536, 2880], 1, ttnn.TILE_LAYOUT),
-        # 131072 (128*1024)
-        ([1, 1, 131072, 2880], 2, [0, 0, 0, 0], [1, 1, 32768, 2880], 1, ttnn.TILE_LAYOUT),
-        ([1, 1, 131072, 2880], 2, [0, 0, 32768, 0], [1, 1, 65536, 2880], 1, ttnn.TILE_LAYOUT),
-        ([1, 1, 131072, 2880], 2, [0, 0, 65536, 0], [1, 1, 98304, 2880], 1, ttnn.TILE_LAYOUT),
-        ([1, 1, 131072, 2880], 2, [0, 0, 98304, 0], [1, 1, 131072, 2880], 1, ttnn.TILE_LAYOUT),
     ),
 )
-def test_slice_tensor_args_before(input_shape, dim, start, end, step, layout, device):
+def test_slice_tensor_args_device_path(input_shape, dim, start, end, step, layout, device):
     # Create tensor where each tile has a unique value for easy tile debugging
     torch_input = torch.randn(input_shape, dtype=torch.bfloat16)
-    """
-    # Calculate tile dimensions (32x32 tiles)
-    tile_height, tile_width = 32, 32
-    height_tiles = input_shape[2] // tile_height  # Number of tile rows
-    width_tiles = input_shape[3] // tile_width    # Number of tile columns
 
-    print(f"DEBUG: Input shape {input_shape} = {height_tiles}x{width_tiles} tiles")
-
-    # Fill each tile with its unique tile ID
-    tile_id = 0
-    for tile_row in range(height_tiles):
-        for tile_col in range(width_tiles):
-            # Calculate pixel coordinates for this tile
-            start_h = tile_row * tile_height
-            end_h = start_h + tile_height
-            start_w = tile_col * tile_width
-            end_w = start_w + tile_width
-
-            # Fill entire tile with the tile_id value
-            torch_input[0, 0, start_h:end_h, start_w:end_w] = float(tile_id)
-            tile_id += 1
-
-    print(f"DEBUG: Created {tile_id} tiles total")
-    print(f"DEBUG: Tile 0 (top-left): {torch_input[0, 0, 0, 0]} at [0,0]")
-    print(f"DEBUG: Tile 1 (top, second): {torch_input[0, 0, 0, 32]} at [0,32]")
-    print(f"DEBUG: Tile {width_tiles} (second row, first): {torch_input[0, 0, 32, 0]} at [32,0]")
-
-    # For the slice [0,0,0,0] to [1,1,32,2880], we should get:
-    # - First row of tiles (tiles 0 to width_tiles-1)
-    print(f"DEBUG: Expected output should contain tiles 0 to {width_tiles-1}")
-    """
     torch_start_tensor = torch.tensor(start)
     torch_end_tensor = torch.tensor(end)
 
@@ -1245,15 +1182,12 @@ def test_slice_tensor_args_before(input_shape, dim, start, end, step, layout, de
 
     ttnn_tensor = ttnn.from_torch(torch_input, layout=layout, dtype=ttnn.bfloat16, device=device)
 
-    # Calculate num_devices from the slice pattern (input_shape[dim] / output_shape[dim])
+    # Calculate num_devices from the slice pattern
     num_devices_calc = input_shape[dim] // (end[dim] - start[dim])
     ttnn_output = ttnn.slice(
         ttnn_tensor, ttnn_start_tensor, ttnn_end_tensor, slice_dim=dim, num_devices=num_devices_calc
     )
 
     ttnn_output_tensor = ttnn.to_torch(ttnn_output)
-    print("ttnn_output_tensor shape:", ttnn_output_tensor.shape)
-    print("output tensor:", ttnn_output_tensor)
-    print("expected tensor: ", torch_output_tensor)
 
     assert_with_pcc(torch_output_tensor, ttnn_output_tensor, 0.999)

--- a/ttnn/cpp/ttnn/operations/ccl/mesh_partition/device/mesh_partition_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/mesh_partition/device/mesh_partition_program_factory.cpp
@@ -88,7 +88,7 @@ MeshPartitionDeviceOperation::MeshPartition::create_at(
         .slice_start = begins,
         .slice_end = ends,
         .step = strides,
-        .output_mem_config = operation_attributes.output_mem_config};  // here
+        .output_mem_config = operation_attributes.output_mem_config};
 
     auto input_tensors = std::vector<ttnn::Tensor>{tensor_args.input_tensor};
     auto output_tensors = std::vector<ttnn::Tensor>{tensor_return_value};

--- a/ttnn/cpp/ttnn/operations/ccl/mesh_partition/device/mesh_partition_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/mesh_partition/device/mesh_partition_program_factory.cpp
@@ -88,7 +88,7 @@ MeshPartitionDeviceOperation::MeshPartition::create_at(
         .slice_start = begins,
         .slice_end = ends,
         .step = strides,
-        .output_mem_config = operation_attributes.output_mem_config};
+        .output_mem_config = operation_attributes.output_mem_config};  // here
 
     auto input_tensors = std::vector<ttnn::Tensor>{tensor_args.input_tensor};
     auto output_tensors = std::vector<ttnn::Tensor>{tensor_return_value};

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/reader_unary_unpad_dims_interleaved_start_id_tensor_args.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/reader_unary_unpad_dims_interleaved_start_id_tensor_args.cpp
@@ -1,0 +1,163 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include "dataflow_api.h"
+
+void kernel_main() {
+    constexpr uint32_t cb_id_in0 = get_compile_time_arg_val(0);
+    constexpr uint32_t cb_id_tensor = get_compile_time_arg_val(1);
+    constexpr uint32_t num_dims = get_compile_time_arg_val(2);
+    constexpr auto src_args = TensorAccessorArgs<3>();
+    constexpr auto start_args = TensorAccessorArgs<src_args.next_compile_time_args_offset()>();
+    constexpr auto end_args = TensorAccessorArgs<start_args.next_compile_time_args_offset()>();
+
+    // Tile constants
+    constexpr uint32_t TILE_WIDTH = 32;
+    constexpr uint32_t TILE_HEIGHT = 32;
+
+    const uint32_t src_addr = get_common_arg_val<uint32_t>(0);
+    const uint32_t start_addr = get_common_arg_val<uint32_t>(1);
+    const uint32_t end_addr = get_common_arg_val<uint32_t>(2);
+
+    volatile tt_l1_ptr uint32_t* num_unpadded_tiles = (volatile tt_l1_ptr uint32_t*)(get_common_arg_addr(3));
+    volatile tt_l1_ptr uint32_t* num_padded_tiles = num_unpadded_tiles + num_dims;
+
+    const uint32_t start_id = get_arg_val<uint32_t>(0);
+    const uint32_t num_tiles = get_arg_val<uint32_t>(1);
+
+    tt_l1_ptr uint32_t* id_per_dim = (tt_l1_ptr uint32_t*)(get_arg_addr(2));
+
+    constexpr uint32_t tile_size = get_tile_size(cb_id_in0);
+
+    const auto s0 = TensorAccessor(src_args, src_addr, tile_size);
+
+    // Create TensorAccessors for start and end tensors
+    const auto start_tensor_accessor = TensorAccessor(start_args, start_addr, tile_size);
+    const auto end_tensor_accessor = TensorAccessor(end_args, end_addr, tile_size);
+
+    // Read start and end indices from tensors using TensorAccessor
+    uint32_t start_indices[num_dims];
+    uint32_t end_indices[num_dims];
+
+    // Read start tensor data using separate circular buffer
+    cb_reserve_back(cb_id_tensor, 1);
+    uint32_t start_buffer_l1_addr = get_write_ptr(cb_id_tensor);
+    noc_async_read_tile(0, start_tensor_accessor, start_buffer_l1_addr);
+    noc_async_read_barrier();
+
+    volatile tt_l1_ptr uint32_t* start_data = (volatile tt_l1_ptr uint32_t*)start_buffer_l1_addr;
+
+    for (uint32_t i = 0; i < num_dims; i++) {
+        start_indices[i] = start_data[i];
+    }
+    cb_pop_front(cb_id_tensor, 1);
+
+    // Read end tensor data using separate circular buffer
+    cb_reserve_back(cb_id_tensor, 1);
+    uint32_t end_buffer_l1_addr = get_write_ptr(cb_id_tensor);
+    noc_async_read_tile(0, end_tensor_accessor, end_buffer_l1_addr);
+    noc_async_read_barrier();
+
+    volatile tt_l1_ptr uint32_t* end_data = (volatile tt_l1_ptr uint32_t*)end_buffer_l1_addr;
+
+    for (uint32_t i = 0; i < num_dims; i++) {
+        end_indices[i] = end_data[i];
+    }
+    cb_pop_front(cb_id_tensor, 1);
+
+    // Debug the tensor indices we read
+    DPRINT << "TENSOR_ARGS_DEBUG: start_indices=[";
+    for (uint32_t i = 0; i < num_dims; i++) {
+        DPRINT << start_indices[i];
+        if (i < num_dims - 1) {
+            DPRINT << ",";
+        }
+    }
+    DPRINT << "], end_indices=[";
+    for (uint32_t i = 0; i < num_dims; i++) {
+        DPRINT << end_indices[i];
+        if (i < num_dims - 1) {
+            DPRINT << ",";
+        }
+    }
+    DPRINT << "]" << ENDL();
+
+    uint32_t calculated_start_offset = 0;
+
+    // For the last 2 dimensions (height and width in tiles)
+    if (num_dims >= 2) {
+        uint32_t start_h_tiles = start_indices[num_dims - 2] / TILE_HEIGHT;
+        uint32_t start_w_tiles = start_indices[num_dims - 1] / TILE_WIDTH;
+
+        // Get input shape from common args to calculate pages per row
+        volatile tt_l1_ptr uint32_t* input_shape_args =
+            (volatile tt_l1_ptr uint32_t*)(get_common_arg_addr(3 + 2 * num_dims));
+        uint32_t input_width = input_shape_args[num_dims - 1];
+        uint32_t input_height = input_shape_args[num_dims - 2];
+        uint32_t num_pages_width = input_width / TILE_WIDTH;
+
+        calculated_start_offset += start_h_tiles * num_pages_width + start_w_tiles;
+
+        // For higher dimensions, add their contribution
+        if (num_dims > 2) {
+            uint32_t upper_dims_offset = 0;
+            uint32_t multiplier = (input_height / TILE_HEIGHT) * num_pages_width;
+
+            for (int32_t i = num_dims - 3; i >= 0; i--) {
+                upper_dims_offset = upper_dims_offset * input_shape_args[i] + start_indices[i];
+            }
+            calculated_start_offset += upper_dims_offset * multiplier;
+        }
+    }
+
+    // Add the calculated offset to the base start_id
+    uint32_t src_tile_id = start_id + calculated_start_offset;
+
+    DPRINT << "TENSOR_ARGS_DEBUG: num_unpadded_tiles=[";
+    for (uint32_t i = 0; i < num_dims; i++) {
+        DPRINT << num_unpadded_tiles[i];
+        if (i < num_dims - 1) {
+            DPRINT << ",";
+        }
+    }
+    DPRINT << "], num_padded_tiles=[";
+    for (uint32_t i = 0; i < num_dims; i++) {
+        DPRINT << num_padded_tiles[i];
+        if (i < num_dims - 1) {
+            DPRINT << ",";
+        }
+    }
+    DPRINT << "]" << ENDL();
+
+    DPRINT << "TENSOR_ARGS_DEBUG: start_id=" << start_id << ", num_tiles=" << num_tiles
+           << ", final_src_tile_id=" << src_tile_id << ENDL();
+
+    for (uint32_t i = 0; i < num_tiles; ++i) {
+        uint32_t old_src_tile_id = src_tile_id;
+
+        cb_reserve_back(cb_id_in0, 1);
+        uint32_t src_buffer_l1_addr = get_write_ptr(cb_id_in0);
+        noc_async_read_tile(src_tile_id, s0, src_buffer_l1_addr);
+        noc_async_read_barrier();
+        DPRINT << "printing data read from tile " << i << ENDL();
+        volatile tt_l1_ptr uint16_t* dst_noc2 = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(src_buffer_l1_addr);
+        for (uint16_t value = 0; value < 1024; value++) {
+            DPRINT << "value at " << (uint16_t)value << " is: " << BF16((uint16_t)dst_noc2[value]) << ENDL();
+        }
+        cb_push_back(cb_id_in0, 1);
+
+        src_tile_id++;
+        for (uint32_t j = 0; j < num_dims; ++j) {
+            id_per_dim[j]++;
+            if (id_per_dim[j] == num_unpadded_tiles[j]) {
+                id_per_dim[j] = 0;
+                src_tile_id += num_padded_tiles[j];
+
+            } else {
+                break;
+            }
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_op.cpp
@@ -192,14 +192,6 @@ std::vector<ttnn::TensorSpec> SliceDeviceOperation::compute_output_specs(
             num_parts);
 
         out_shape[slice_dimension] = slice_size;
-
-        printf(
-            "TENSOR_ARGS_SHAPE_DEBUG: input_shape[%u]=%u, num_devices=%u, output_shape[%u]=%u\n",
-            slice_dimension,
-            original_size,
-            num_parts,
-            slice_dimension,
-            slice_size);
     } else {
         // Regular path using slice_start, slice_end, step
         auto output_dim_i = [this](size_t i) {
@@ -232,10 +224,8 @@ operation::ProgramWithCallbacks SliceDeviceOperation::create_program(
     const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const {
     const auto& input_tensor_a = input_tensors.at(0);
     auto& output_tensor = output_tensors.at(0);
-    printf("creating slice program...\n");
-
     if (this->use_tensor_args) {
-        // Use tensor args path
+        // Use tensor args device path
         return detail::slice_multi_core_with_tensor_args(input_tensors, output_tensors);
     } else {
         // Use regular path with Shape args

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_op.cpp
@@ -164,11 +164,50 @@ std::vector<ttnn::TensorSpec> SliceDeviceOperation::compute_output_specs(
     const auto& input_tensor = input_tensors[0];
     SmallVector<uint32_t> out_shape(input_tensor.logical_shape().rank());
 
-    auto output_dim_i = [this](size_t i) {
-        return (this->slice_end[i] - this->slice_start[i] + this->step[i] - 1) / this->step[i];
-    };
-    for (uint32_t i = 0; i < out_shape.size(); i++) {
-        out_shape[i] = output_dim_i(i);
+    if (this->use_tensor_args) {
+        TT_FATAL(
+            this->slice_dim.has_value() && this->num_devices.has_value(),
+            "slice_dim and num_devices must be provided for tensor args path");
+
+        uint32_t slice_dimension = this->slice_dim.value();
+        uint32_t num_parts = this->num_devices.value();
+
+        for (uint32_t i = 0; i < out_shape.size(); i++) {
+            out_shape[i] = input_tensor.logical_shape()[i];
+        }
+        TT_FATAL(
+            slice_dimension < out_shape.size(),
+            "slice_dim ({}) must be less than tensor rank ({})",
+            slice_dimension,
+            out_shape.size());
+
+        uint32_t original_size = out_shape[slice_dimension];
+        uint32_t slice_size = original_size / num_parts;
+
+        TT_FATAL(
+            original_size % num_parts == 0,
+            "Input dimension {} (size={}) must be evenly divisible by num_devices ({})",
+            slice_dimension,
+            original_size,
+            num_parts);
+
+        out_shape[slice_dimension] = slice_size;
+
+        printf(
+            "TENSOR_ARGS_SHAPE_DEBUG: input_shape[%u]=%u, num_devices=%u, output_shape[%u]=%u\n",
+            slice_dimension,
+            original_size,
+            num_parts,
+            slice_dimension,
+            slice_size);
+    } else {
+        // Regular path using slice_start, slice_end, step
+        auto output_dim_i = [this](size_t i) {
+            return (this->slice_end[i] - this->slice_start[i] + this->step[i] - 1) / this->step[i];
+        };
+        for (uint32_t i = 0; i < out_shape.size(); i++) {
+            out_shape[i] = output_dim_i(i);
+        }
     }
     ttnn::Shape output_tensor_shape(std::move(out_shape));
     return {ttnn::TensorSpec(
@@ -193,7 +232,15 @@ operation::ProgramWithCallbacks SliceDeviceOperation::create_program(
     const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const {
     const auto& input_tensor_a = input_tensors.at(0);
     auto& output_tensor = output_tensors.at(0);
-    return detail::slice_multi_core(input_tensor_a, output_tensor, this->slice_start, this->slice_end, this->step);
+    printf("creating slice program...\n");
+
+    if (this->use_tensor_args) {
+        // Use tensor args path
+        return detail::slice_multi_core_with_tensor_args(input_tensors, output_tensors);
+    } else {
+        // Use regular path with Shape args
+        return detail::slice_multi_core(input_tensor_a, output_tensor, this->slice_start, this->slice_end, this->step);
+    }
 }
 
 }  // namespace ttnn::operations::data_movement

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_op.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_op.hpp
@@ -19,6 +19,9 @@ struct SliceDeviceOperation {
     const ttnn::Shape slice_end;
     const ttnn::Shape step;
     const tt::tt_metal::MemoryConfig output_mem_config;
+    const bool use_tensor_args = false;
+    const std::optional<uint32_t> slice_dim = std::nullopt;
+    const std::optional<uint32_t> num_devices = std::nullopt;
 
     void validate_with_output_tensors(
         const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const;

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory.cpp
@@ -1084,9 +1084,13 @@ operation::ProgramWithCallbacks slice_tile_multi_core_tensor_args(
     tt::tt_metal::CreateCircularBuffer(program, total_cores, cb_tensor_config);
 
     std::uint32_t num_dims = static_cast<std::uint32_t>(input_tensor.padded_shape().rank());
+    auto tile_shape = input_tensor.tensor_spec().tile().get_tile_shape();
+    uint32_t tile_width = tile_shape[1];
+    uint32_t tile_height = tile_shape[0];
 
     // Reader compile-time args
-    std::vector<uint32_t> reader_compile_time_args = {src0_cb_index, tensor_cb_index, num_dims};
+    std::vector<uint32_t> reader_compile_time_args = {
+        src0_cb_index, tensor_cb_index, num_dims, tile_width, tile_height};
     TensorAccessorArgs(*src_buffer).append_to(reader_compile_time_args);
     TensorAccessorArgs(*start_buffer).append_to(reader_compile_time_args);
     TensorAccessorArgs(*end_buffer).append_to(reader_compile_time_args);

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory.cpp
@@ -1005,7 +1005,8 @@ operation::ProgramWithCallbacks slice_multi_core_with_tensor_args(
         case Layout::TILE: return slice_tile_multi_core_tensor_args(a, start_tensor, end_tensor, output);
         case Layout::ROW_MAJOR:
             // For now, only support TILE layout with tensor args
-            TT_FATAL(false, "ROW_MAJOR layout with tensor args not implemented yet");
+            TT_FATAL(
+                false, "ROW_MAJOR layout is not supported with tensor args. Only TILE layout is currently supported.");
         default: TT_ASSERT(false, "Unsupported Layout");
     }
     return {};

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory.cpp
@@ -189,7 +189,6 @@ operation::ProgramWithCallbacks slice_rm_multi_core(
     const Tensor& a, Tensor& output, const ttnn::Shape& output_tensor_start, const ttnn::Shape& output_tensor_end) {
     tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
 
-    printf("running slice_rm_multi_core...\n");
     // This should allocate a DRAM buffer on the device
     tt::tt_metal::IDevice* device = a.device();
 
@@ -226,7 +225,6 @@ operation::ProgramWithCallbacks slice_rm_multi_core(
 
     std::vector<uint32_t> reader_compile_time_args_vec;
     TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args_vec);
-    printf("running reader kernel: slice_reader_unary_unpad_dims_rm_interleaved_start_id.cpp\n");
     tt::tt_metal::KernelHandle unary_reader_kernel_id = tt::tt_metal::CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/"
@@ -234,7 +232,6 @@ operation::ProgramWithCallbacks slice_rm_multi_core(
         total_cores,
         tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args_vec));
 
-    printf("running writer kernel: slice_writer_unary_stick_layout_interleaved_start_id.cpp\n");
     tt::tt_metal::KernelHandle unary_writer_kernel_id = tt::tt_metal::CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/"
@@ -329,7 +326,6 @@ operation::ProgramWithCallbacks slice_rm_strided_single_core_n_dims(
     const ttnn::Shape& output_tensor_start,
     const ttnn::Shape& output_tensor_end,
     const ttnn::Shape& step) {
-    printf("running slice_rm_strided_single_core_n_dims...\n");
     // TODO: multi core implementation - work division is not trivial as we need to determine the N/C/H/W start and end
     // points for each split, and base that off stride
     tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
@@ -587,7 +583,6 @@ inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_
 
 operation::ProgramWithCallbacks slice_rm_multi_core_sharded(
     const Tensor& a, Tensor& output, const ttnn::Shape& output_tensor_start, const ttnn::Shape& output_tensor_end) {
-    printf("running slice_rm_multi_core_sharded...\n");
     const ttnn::Shape output_shape = output.padded_shape();
 
     tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
@@ -859,7 +854,6 @@ inline __attribute__((always_inline)) void set_slice_runtime_args_tile(
 
 operation::ProgramWithCallbacks slice_tile_multi_core(
     const Tensor& a, Tensor& output, const ttnn::Shape& output_tensor_start, const ttnn::Shape& output_tensor_end) {
-    printf("running slice_tile_multi_core...\n");
     tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
 
     // This should allocate a DRAM buffer on the device
@@ -981,7 +975,6 @@ operation::ProgramWithCallbacks slice_multi_core(
     const ttnn::Shape& output_tensor_start,
     const ttnn::Shape& output_tensor_end,
     const ttnn::Shape& step) {
-    printf("running slice_multi_core.......\n");
     bool has_step = false;
     for (int i = 0; i < step.size(); i++) {
         if (step[i] != 1) {
@@ -1007,8 +1000,6 @@ operation::ProgramWithCallbacks slice_multi_core_with_tensor_args(
     const Tensor& start_tensor = input_tensors[1];
     const Tensor& end_tensor = input_tensors[2];
     Tensor& output = output_tensors[0];
-
-    printf("running slice_multi_core with tensor args.......\n");
 
     switch (a.layout()) {
         case Layout::TILE: return slice_tile_multi_core_tensor_args(a, start_tensor, end_tensor, output);
@@ -1040,8 +1031,6 @@ inline __attribute__((always_inline)) void set_slice_runtime_args_tensor_args(
 
 operation::ProgramWithCallbacks slice_tile_multi_core_tensor_args(
     const Tensor& input_tensor, const Tensor& start_tensor, const Tensor& end_tensor, Tensor& output_tensor) {
-    printf("running slice_tile_multi_core_tensor_args...\n");
-
     tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
     tt::tt_metal::IDevice* device = input_tensor.device();
 
@@ -1212,12 +1201,6 @@ inline __attribute__((always_inline)) void set_slice_runtime_args_tensor_args(
         reader_common_args[0] = input_buffer->address();
         reader_common_args[1] = start_tensor.buffer()->address();
         reader_common_args[2] = end_tensor.buffer()->address();
-
-        printf(
-            "TENSOR_ARGS_HOST_DEBUG: input_buffer_addr=0x%x, start_tensor_addr=0x%x, end_tensor_addr=0x%x\n",
-            input_buffer->address(),
-            start_tensor.buffer()->address(),
-            end_tensor.buffer()->address());
 
         num_unpadded_tiles_per_dim[0] = num_unpadded_Xt;
         num_unpadded_tiles_per_dim[1] = num_unpadded_Yt;

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory.hpp
@@ -27,20 +27,4 @@ tt::tt_metal::operation::ProgramWithCallbacks slice_multi_core_with_tensor_args(
 tt::tt_metal::operation::ProgramWithCallbacks slice_tile_multi_core_tensor_args(
     const Tensor& input_tensor, const Tensor& start_tensor, const Tensor& end_tensor, Tensor& output_tensor);
 
-void set_slice_runtime_args_tensor_args(
-    const Tensor& input_tensor,
-    const Tensor& start_tensor,
-    const Tensor& end_tensor,
-    const Tensor& output_tensor,
-    const uint32_t& num_cores_total,
-    const uint32_t& num_cores,
-    const std::vector<CoreCoord>& cores,
-    const uint32_t& num_cores_group_1,
-    const uint32_t& num_cores_group_2,
-    const uint32_t& num_tiles_per_core_group_1,
-    const uint32_t& num_tiles_per_core_group_2,
-    const Program& program,
-    const tt::tt_metal::KernelHandle& unary_reader_kernel_id,
-    const tt::tt_metal::KernelHandle& unary_writer_kernel_id);
-
 }  // namespace ttnn::operations::data_movement::detail

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory.hpp
@@ -21,4 +21,26 @@ tt::tt_metal::operation::ProgramWithCallbacks slice_rm_multi_core_stride(
     const ttnn::Shape& slice_end,
     const ttnn::Shape& slice_step);
 
+tt::tt_metal::operation::ProgramWithCallbacks slice_multi_core_with_tensor_args(
+    const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors);
+
+tt::tt_metal::operation::ProgramWithCallbacks slice_tile_multi_core_tensor_args(
+    const Tensor& input_tensor, const Tensor& start_tensor, const Tensor& end_tensor, Tensor& output_tensor);
+
+void set_slice_runtime_args_tensor_args(
+    const Tensor& input_tensor,
+    const Tensor& start_tensor,
+    const Tensor& end_tensor,
+    const Tensor& output_tensor,
+    const uint32_t& num_cores_total,
+    const uint32_t& num_cores,
+    const std::vector<CoreCoord>& cores,
+    const uint32_t& num_cores_group_1,
+    const uint32_t& num_cores_group_2,
+    const uint32_t& num_tiles_per_core_group_1,
+    const uint32_t& num_tiles_per_core_group_2,
+    const Program& program,
+    const tt::tt_metal::KernelHandle& unary_reader_kernel_id,
+    const tt::tt_metal::KernelHandle& unary_writer_kernel_id);
+
 }  // namespace ttnn::operations::data_movement::detail

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/slice.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/slice.cpp
@@ -23,7 +23,6 @@ ttnn::Tensor SliceOperation::invoke(
     const std::optional<MemoryConfig>& memory_config_arg,
     const std::optional<Tensor>& optional_output_tensor,
     const std::optional<float>& pad_value) {
-    printf("invoke0\n");
     // Ensure start and end vectors have matching sizes and correct tensor rank
 
     const auto& input_shape = input_tensor.logical_shape();
@@ -31,7 +30,6 @@ ttnn::Tensor SliceOperation::invoke(
     auto input_layout = input_tensor.layout();
 
     if (input_rank == 0) {
-        printf("Input rank is 0, returning input tensor as is.\n");
         return input_tensor;
     }
     TT_FATAL(
@@ -62,16 +60,13 @@ ttnn::Tensor SliceOperation::invoke(
         if (input_tensor.storage_type() == StorageType::DEVICE) {
             auto tensor = ttnn::to_memory_config(input_tensor, memory_config, std::nullopt);
             tensor = ttnn::to_layout(tensor, input_layout);
-            printf("Returning adjusted tensor.\n");
             return tensor;
         }
-        printf("Returning input tensor as is.\n");
         return input_tensor;
     });
 
     // No-op check
     if (no_step && starts_zero && ends_max) {
-        printf("No-op slice detected, returning input tensor as is.\n");
         return ret_adjustment(input_tensor);
     }
 
@@ -94,17 +89,10 @@ ttnn::Tensor SliceOperation::invoke(
     }
 
     auto output_dim_i = [&modified_begins, &modified_step](size_t i, const ttnn::SmallVector<uint32_t>& modified_ends) {
-        printf(
-            "Calculating output dimension for index %zu: begin=%u, end=%u, step=%u\n",
-            i,
-            modified_begins[i],
-            modified_ends[i],
-            modified_step[i]);
         return (modified_ends[i] - modified_begins[i] + modified_step[i] - 1) / modified_step[i];
     };
 
     auto check_handled_tile_alignment = [&modified_begins, &input_rank, &tile_shape]() -> bool {
-        printf("Checking tile alignment for slicing...\n");
         return (
             modified_begins[input_rank - 1] % tile_shape[1] == 0 &&
             modified_begins[input_rank - 2] % tile_shape[0] == 0);
@@ -159,7 +147,6 @@ ttnn::Tensor SliceOperation::invoke(
     if (empty) {
         TT_FATAL(
             input.storage_type() == StorageType::DEVICE, "Host tensor slice cannot return a scalar or empty tensor");
-        printf("Slice results in empty tensor, returning empty tensor of shape \n");
         return ttnn::empty(
             actual_shape,
             input_tensor.dtype(),
@@ -167,7 +154,6 @@ ttnn::Tensor SliceOperation::invoke(
             input_tensor.device(),
             memory_config_arg.value_or(input_tensor.memory_config()));
     }
-    printf("Proceeding with slice operation...\n");
     auto res = tt::tt_metal::operation::run(
                    SliceDeviceOperation{
                        ttnn::Shape(modified_begins),
@@ -182,14 +168,12 @@ ttnn::Tensor SliceOperation::invoke(
     res = ttnn::experimental::view(res, actual_shape, final_padded_shape);
 
     auto dim_needs_fill = [&input_shape, &actual_shape, &final_padded_shape](int i) {
-        printf("Checking if dimension %d needs fill...\n", i);
         return ((actual_shape[i] != final_padded_shape[i]) && (input_shape[i] != actual_shape[i]));
     };
 
     if (pad_value.has_value() && (dim_needs_fill(-1) || dim_needs_fill(-2))) {
         res = ttnn::fill_implicit_tile_padding(res, pad_value.value());
     }
-    printf("Slice operation completed, returning result tensor.\n");
 
     return ret_adjustment(res);
 }
@@ -203,7 +187,6 @@ ttnn::Tensor SliceOperation::invoke(
     const std::optional<MemoryConfig>& memory_config_arg,
     const std::optional<Tensor>& optional_output_tensor,
     const std::optional<float>& pad_value) {
-    printf("invoke1\n");
     tt::stl::Span<const T> start(output_tensor_start.begin(), output_tensor_start.end());
     tt::stl::Span<const T> end(output_tensor_end.begin(), output_tensor_end.end());
     tt::stl::Span<const T> step_vec(step.begin(), step.end());
@@ -222,7 +205,6 @@ ttnn::Tensor SliceOperation::invoke(
     const std::optional<float>& pad_value,
     const std::optional<uint32_t>& slice_dim,
     const std::optional<uint32_t>& num_devices) {
-    printf("invoke2 - tensor args path\n");
     TT_FATAL(
         output_tensor_start.logical_shape().rank() == 1,
         "The start tensor for slicing must be in 1D shape, but got {}D",
@@ -237,7 +219,6 @@ ttnn::Tensor SliceOperation::invoke(
 
     // Check if layout is supported (only TILE layout for now)
     if (input_tensor.layout() != Layout::TILE) {
-        printf("Non-TILE layout detected, falling back to host conversion\n");
         use_device_only_path = false;
     }
 
@@ -245,7 +226,6 @@ ttnn::Tensor SliceOperation::invoke(
     if (step.has_value()) {
         for (auto s : step.value()) {
             if (s != 1) {
-                printf("Step > 1 detected, falling back to host conversion\n");
                 use_device_only_path = false;
                 break;
             }
@@ -255,22 +235,22 @@ ttnn::Tensor SliceOperation::invoke(
     // Validate tensors are on device for both paths
     TT_FATAL(
         input_tensor.storage_type() == StorageType::DEVICE, "Input tensor must be on device for tensor args slice");
-    TT_FATAL(
-        output_tensor_start.storage_type() == StorageType::DEVICE,
-        "Start tensor must be on device for tensor args slice");
-    TT_FATAL(
-        output_tensor_end.storage_type() == StorageType::DEVICE, "End tensor must be on device for tensor args slice");
 
     auto memory_config = optional_output_tensor.has_value() ? optional_output_tensor.value().memory_config()
                                                             : memory_config_arg.value_or(input_tensor.memory_config());
 
     if (use_device_only_path) {
-        printf("Using device-only tensor args path for slice operation\n");
-
         // Validate required parameters for device-only path
         TT_FATAL(
             slice_dim.has_value() && num_devices.has_value(),
             "slice_dim and num_devices must be provided for device-only tensor args slice");
+
+        TT_FATAL(
+            output_tensor_start.storage_type() == StorageType::DEVICE,
+            "Start tensor must be on device for tensor args slice");
+        TT_FATAL(
+            output_tensor_end.storage_type() == StorageType::DEVICE,
+            "End tensor must be on device for tensor args slice");
 
         // Create dummy shapes for SliceDeviceOperation (will be ignored when use_tensor_args=true)
         uint32_t input_rank = input_tensor.logical_shape().rank();
@@ -288,12 +268,8 @@ ttnn::Tensor SliceOperation::invoke(
                 {},
                 {optional_output_tensor})
                 .at(0);
-
-        printf("Tensor args slice operation completed\n");
         return res;
     } else {
-        printf("Falling back to host conversion for tensor args slice operation\n");
-
         // convert the Tensor to Vector
         std::vector<T> output_tensor_start_vector = output_tensor_start.to_vector<T>();
         std::vector<T> output_tensor_end_vector = output_tensor_end.to_vector<T>();
@@ -306,7 +282,6 @@ ttnn::Tensor SliceOperation::invoke(
         // generate the step value if it is not provided
         ttnn::SmallVector<T> step_value = step.value_or(ttnn::SmallVector<T>(output_tensor_start_span.size(), 1));
 
-        printf("Calling regular slice operation with converted values\n");
         return SliceOperation::invoke<T>(
             input_tensor,
             output_tensor_start_span,

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/slice.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/slice.hpp
@@ -58,7 +58,9 @@ struct SliceOperation {
         const std::optional<ttnn::SmallVector<T>>& step,
         const std::optional<MemoryConfig>& memory_config_arg = std::nullopt,
         const std::optional<Tensor>& optional_output_tensor = std::nullopt,
-        const std::optional<float>& pad_value = std::nullopt);
+        const std::optional<float>& pad_value = std::nullopt,
+        const std::optional<uint32_t>& slice_dim = std::nullopt,
+        const std::optional<uint32_t>& num_devices = std::nullopt);
 };
 
 }  // namespace data_movement

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/slice_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/slice_pybind.cpp
@@ -58,6 +58,8 @@ void bind_slice(py::module& module) {
                const std::optional<ttnn::MemoryConfig>& memory_config,
                const std::optional<Tensor>& optional_output_tensor,
                const std::optional<float>& pad_value,
+               // used to calculate the output shape for slice op with tensor args running on device
+               // to avoid host-device data transfer for mesh dveice and trace cases
                const std::optional<uint32_t>& slice_dim,
                const std::optional<uint32_t>& num_devices) {
                 return self(

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/slice_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/slice_pybind.cpp
@@ -57,9 +57,19 @@ void bind_slice(py::module& module) {
                const std::optional<ttnn::SmallVector<uint32_t>>& step,
                const std::optional<ttnn::MemoryConfig>& memory_config,
                const std::optional<Tensor>& optional_output_tensor,
-               const std::optional<float>& pad_value) {
+               const std::optional<float>& pad_value,
+               const std::optional<uint32_t>& slice_dim,
+               const std::optional<uint32_t>& num_devices) {
                 return self(
-                    input_tensor, slice_start, slice_end, step, memory_config, optional_output_tensor, pad_value);
+                    input_tensor,
+                    slice_start,
+                    slice_end,
+                    step,
+                    memory_config,
+                    optional_output_tensor,
+                    pad_value,
+                    slice_dim,
+                    num_devices);
             },
             py::arg("input_tensor"),
             py::arg("starts"),
@@ -69,6 +79,8 @@ void bind_slice(py::module& module) {
             py::arg("memory_config") = std::nullopt,
             py::arg("output_tensor") = std::nullopt,
             py::arg("pad_value") = std::nullopt,
+            py::arg("slice_dim") = std::nullopt,
+            py::arg("num_devices") = std::nullopt,
         },
         ttnn::pybind_overload_t{
             [](const OperationType& self,

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/slice_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/slice_pybind.cpp
@@ -59,7 +59,7 @@ void bind_slice(py::module& module) {
                const std::optional<Tensor>& optional_output_tensor,
                const std::optional<float>& pad_value,
                // used to calculate the output shape for slice op with tensor args running on device
-               // to avoid host-device data transfer for mesh dveice and trace cases
+               // to avoid host-device data transfer for mesh device and trace cases
                const std::optional<uint32_t>& slice_dim,
                const std::optional<uint32_t>& num_devices) {
                 return self(


### PR DESCRIPTION
### Ticket
Link to Github Issue https://github.com/tenstorrent/tt-metal/issues/27240

### Problem description
The current implementation of the slice operation that has start and end indices as tensor args interacts with host and converts these tensors to vectors. This leads to a failure when using mesh device instead of a single device or when tracing

### What's changed
- This PR adds device support for slice operation with start and end indices as tensor args
- It only supports the cases needed for GPT-OSS, which are single step and tile layout
- The other cases still run the default slice implementation (with host interaction)
- This version needs to have slice dimension and number of devices as inputs to compute the output shape without interacting with the host

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/19073416688
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes