### PR TITLE
[skip ci] Add vllm tests for automatic host-device sampling

### DIFF
--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -182,7 +182,7 @@ jobs:
             owner_id: U091SNDA4TS, # Tomasz Cheda
           },
           {
-            name: "[BH-LB] Llama-3.1-8B-Instruct v0 fallbackstructured-output",
+            name: "[BH-LB] Llama-3.1-8B-Instruct v0 fallback structured-output",
             model: "meta-llama/Llama-3.1-8B-Instruct",
             server-timeout: 35,
             benchmark-timeout: 10,

--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -165,6 +165,37 @@ jobs:
             additional-args: "--num_scheduler_steps 1",
             owner_id: U091SNDA4TS, # Tomasz Cheda
           },
+          # device sampling + structured output tests
+          {
+            name: "[WH-GLX] Llama-3.3-70B-Instruct v0 fallback structured-output",
+            model: "meta-llama/Llama-3.3-70B-Instruct",
+            server-timeout: 35,
+            benchmark-timeout: 10,
+            runner-label: topology-6u,
+            arch: arch-wormhole_b0,
+            mesh-device: TG,
+            tt-llama-text-ver: llama3_70b_galaxy,
+            override-tt-config: "{\"dispatch_core_axis\": \"col\", \"sample_on_device_mode\": \"all\", \"fabric_config\": \"FABRIC_1D_RING\", \"worker_l1_size\": 1344544, \"trace_region_size\": 184915840}",
+            multimodal: false,
+            structured-output: true,
+            additional-args: "--num_scheduler_steps 1",
+            owner_id: U091SNDA4TS, # Tomasz Cheda
+          },
+          {
+            name: "[BH-LB] Llama-3.1-8B-Instruct v0 fallbackstructured-output",
+            model: "meta-llama/Llama-3.1-8B-Instruct",
+            server-timeout: 35,
+            benchmark-timeout: 10,
+            runner-label: bh-loudbox,
+            arch: arch-blackhole,
+            mesh-device: P150x8,
+            tt-llama-text-ver: tt_transformers,
+            override-tt-config: "{\"data_parallel\": 8, \"sample_on_device_mode\": \"decode_only\"}",
+            multimodal: false,
+            structured-output: true,
+            additional-args: "--num_scheduler_steps 1",
+            owner_id: U091SNDA4TS, # Tomasz Cheda
+          },
         ]
     runs-on:
       - ${{ matrix.test-group.runner-label }}


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/vllm/issues/209

### Problem description
https://github.com/tenstorrent/vllm/issues/209 added a customer requested new mode / behaviour in vLLM. It is not covered by any of the current pipelines.

### What's changed
Added two tests for that mode to ensure that functionality is not broken.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes