### PR TITLE
Rewrite hang detection logic in `conftest.py`

### DIFF
--- a/.github/workflows/ttnn-post-commit.yaml
+++ b/.github/workflows/ttnn-post-commit.yaml
@@ -121,7 +121,7 @@ jobs:
       image: ${{ ((inputs.runner-label != 'P100') && format('harbor.ci.tenstorrent.net/{0}', inputs.docker-image)) || inputs.docker-image || 'docker-image-unresolved!' }}
       env:
         ARCH_NAME: ${{ inputs.arch }}
-        LOGURU_LEVEL: INFO
+        LOGURU_LEVEL: DEBUG
         PYTHONPATH: /work
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691

--- a/conftest.py
+++ b/conftest.py
@@ -953,11 +953,6 @@ def _watchdog_main(parent_pid, cmd_queue):
       {"cmd": "cancel", "test_id": str}
       {"cmd": "shutdown"}
     """
-    try:
-        parent_pgid = os.getpgid(parent_pid)
-    except Exception:
-        parent_pgid = None
-
     deadlines = {}  # test_id -> { 'deadline': float, 'pid': int }
 
     def kill_target(pid: int):

--- a/conftest.py
+++ b/conftest.py
@@ -959,18 +959,22 @@ def _ensure_watchdog_started(config):
 
     # Clean up stale process reference if present
     if process is not None and not process.is_alive():
+        logger.warning(f"Stale watchdog process found, joining and cleaning up")
         try:
-            process.join(timeout=0.1)
+            process.join(timeout=1)
         except Exception:
             pass
 
     try:
         cmd_queue = multiprocess.Queue()
+        time.sleep(1)
         process = multiprocess.Process(target=_watchdog_main, args=(parent_pid, cmd_queue), daemon=True)
         process.start()
+        time.sleep(1)
         config.stash[watchdog_cmd_queue_key] = cmd_queue
         config.stash[watchdog_process_key] = process
         logger.info(f"Watchdog[{worker_id}] started: watchdog_pid={process.pid} parent_pid={parent_pid}")
+        time.sleep(1)
         return cmd_queue
     except Exception as e:
         logger.error(f"Failed to start watchdog for parent={parent_pid}: {e}")

--- a/conftest.py
+++ b/conftest.py
@@ -1069,10 +1069,13 @@ def pytest_timeout_set_timer(item, settings):
     using_xdist = int(os.getenv("PYTEST_XDIST_WORKER_COUNT", "0"))
 
     needs_watchdog = metal_timeout_enabled is not None or using_xdist
-    cmd_queue = item.config.stash.get(watchdog_cmd_queue_key, None)
 
     if needs_watchdog:
-        if cmd_queue is None:
+        cmd_queue = _ensure_watchdog_started(item.config)
+        process = item.config.stash.get(watchdog_process_key, None)
+
+        if process is not None and not process.is_alive():
+            logger.warning("Watchdog process not alive; restarting")
             cmd_queue = _ensure_watchdog_started(item.config)
 
         if cmd_queue is None:

--- a/conftest.py
+++ b/conftest.py
@@ -12,6 +12,7 @@ from operator import contains, eq, getitem
 from pathlib import Path
 import json
 import multiprocess
+from queue import Empty
 import signal
 import time
 import psutil

--- a/conftest.py
+++ b/conftest.py
@@ -958,9 +958,9 @@ def _watchdog_main(parent_pid, cmd_queue):
     except Exception:
         parent_pgid = None
 
-    deadlines = {}  # test_id -> monotonic deadline
+    deadlines = {}  # test_id -> { 'deadline': float, 'pid': int }
 
-    def kill_parent():
+    def kill_target(pid: int):
         try:
             try:
                 # Attempt debug collection before termination
@@ -971,11 +971,15 @@ def _watchdog_main(parent_pid, cmd_queue):
                 except Exception:
                     pass
 
-            # Kill process group first if available; fall back to PID
-            if parent_pgid is not None:
-                os.killpg(parent_pgid, signal.SIGKILL)
+            # Prefer to kill the target's process group to include its children
+            try:
+                pgid = os.getpgid(pid)
+            except Exception:
+                pgid = None
+            if pgid is not None and pgid > 0:
+                os.killpg(pgid, signal.SIGKILL)
             else:
-                os.kill(parent_pid, signal.SIGKILL)
+                os.kill(pid, signal.SIGKILL)
         finally:
             # Ensure watchdog exits
             os._exit(0)
@@ -991,10 +995,11 @@ def _watchdog_main(parent_pid, cmd_queue):
 
         # Check for any expired deadlines
         if deadlines:
-            expired = [tid for tid, dl in deadlines.items() if dl <= now]
+            expired = [tid for tid, info in deadlines.items() if info["deadline"] <= now]
             if expired:
-                # Any expiration triggers termination of the worker process
-                kill_parent()
+                # Kill the associated worker process for the first expired timer
+                target_pid = deadlines[expired[0]]["pid"]
+                kill_target(target_pid)
 
         if not msg:
             continue
@@ -1004,7 +1009,8 @@ def _watchdog_main(parent_pid, cmd_queue):
             try:
                 test_id = str(msg["test_id"])
                 timeout_secs = float(msg["timeout"])  # seconds from now
-                deadlines[test_id] = time.monotonic() + timeout_secs
+                target_pid = int(msg["pid"])  # worker pid to kill on expiry
+                deadlines[test_id] = {"deadline": time.monotonic() + timeout_secs, "pid": target_pid}
                 try:
                     logger.debug(f"Watchdog armed for {test_id} in {timeout_secs} seconds")
                 except Exception:
@@ -1075,7 +1081,7 @@ def pytest_timeout_set_timer(item, settings):
     if (metal_timeout_enabled is not None or using_xdist) and cmd_queue is not None:
         secs = float(settings.timeout)
         try:
-            cmd_queue.put({"cmd": "start", "test_id": item.nodeid, "timeout": secs})
+            cmd_queue.put({"cmd": "start", "test_id": item.nodeid, "timeout": secs, "pid": os.getpid()})
             logger.debug(f"Watchdog timer set for {item.nodeid} in {secs} seconds")
         except Exception as e:
             logger.error(f"Failed to arm watchdog timer: {e}")

--- a/tools/triage/inspector_data.py
+++ b/tools/triage/inspector_data.py
@@ -172,7 +172,8 @@ def run(args, context) -> InspectorData:
     # Check for Inspector log directory
     log_directory = get_log_directory(log_directory)
     if not os.path.exists(log_directory):
-        raise ValueError(f"Log directory {log_directory} does not exist. Please provide a valid path.")
+        print(f"Log directory {log_directory} does not exist. Creating it.")
+        os.makedirs(log_directory, exist_ok=True)
 
     # Try to load serialized RPC data
     try:

--- a/tools/triage/parse_inspector_logs.py
+++ b/tools/triage/parse_inspector_logs.py
@@ -470,7 +470,9 @@ def get_data(log_directory: str | None = None) -> InspectorLogsData:
     if os.path.exists(log_directory):
         return InspectorLogsData(log_directory)
     else:
-        raise ValueError(f"Log directory {log_directory} does not exist. Please provide a valid path.")
+        print(f"Log directory {log_directory} does not exist. Creating it.")
+        os.makedirs(log_directory, exist_ok=True)
+        return InspectorLogsData(log_directory)
 
 
 def main():

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_pool_2d.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_pool_2d.cpp
@@ -268,7 +268,7 @@ void MAIN {
                         reduce_tile_math(math_tile_idx, num_faces_in_input_tile);
                     }
                 }
-                cb_pop_front(curr_in_cb_id, 1);
+                // cb_pop_front(curr_in_cb_id, 1);
             }
             tile_regs_commit();
             tile_regs_wait();


### PR DESCRIPTION
### Ticket
NA

### Problem description
Existing timer mechanism used in `pytest -n auto` scheme did not work for kernel hangs.

We observed that the test process could not receive nor act upon a SIGALRM signal from the OS in the event of a kernel hang. Likely, the process was in some uninterruptible state.

### What's changed
- Change timeout approach one more time
- This time, a global watchdog process is spawned at the beginning of the pytest application
- When tests start, they send a message to the watchdog process to register a timer
- If a test hangs, the watchdog will terminate the test process

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/19150236160) CI passes
- [x] New/Existing tests provide coverage for changes