### PR TITLE
Make Sure Tilize is Using FP32 Accumulation on FP32 Inputs

### DIFF
--- a/tests/ttnn/unit_tests/operations/data_movement/test_tilize.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_tilize.py
@@ -48,4 +48,3 @@ def test_tilize_fp32_truncation(device, shape, use_multicore):
     input_tensor = ttnn.tilize(input_tensor, use_multicore=use_multicore)
     output_tensor = ttnn.to_torch(input_tensor)
     assert torch.allclose(input_a, output_tensor)
-    print(output_tensor)

--- a/tests/ttnn/unit_tests/operations/data_movement/test_tilize.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_tilize.py
@@ -36,3 +36,16 @@ def test_tilize_test(input_shapes, tilize_args, device, function_level_defaults)
     ]
     comparison_func = comparison_funcs.comp_equal
     run_single_pytorch_test("tilize", input_shapes, datagen_func, comparison_func, device, tilize_args)
+
+
+@pytest.mark.parametrize("shape", [(64, 128), (512, 512)])
+@pytest.mark.parametrize("use_multicore", [False, True])
+def test_tilize_fp32_truncation(device, shape, use_multicore):
+    torch.manual_seed(2005)
+    input_a = torch.full(shape, 1.9908e-05, dtype=torch.float32)
+    device = ttnn.open_device(device_id=0)
+    input_tensor = ttnn.from_torch(input_a, device=device, layout=ttnn.ROW_MAJOR_LAYOUT)
+    input_tensor = ttnn.tilize(input_tensor, use_multicore=use_multicore)
+    output_tensor = ttnn.to_torch(input_tensor)
+    assert torch.allclose(input_a, output_tensor)
+    print(output_tensor)

--- a/tests/ttnn/unit_tests/operations/data_movement/test_tilize.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_tilize.py
@@ -43,7 +43,7 @@ def test_tilize_test(input_shapes, tilize_args, device, function_level_defaults)
 def test_tilize_fp32_truncation(device, shape, use_multicore):
     torch.manual_seed(2005)
     input_a = torch.full(shape, 1.9908e-05, dtype=torch.float32)
-    device = ttnn.open_device(device_id=0)
+    # Use the fixture-provided device directly
     input_tensor = ttnn.from_torch(input_a, device=device, layout=ttnn.ROW_MAJOR_LAYOUT)
     input_tensor = ttnn.tilize(input_tensor, use_multicore=use_multicore)
     output_tensor = ttnn.to_torch(input_tensor)

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_program_factory.cpp
@@ -541,7 +541,7 @@ operation::ProgramWithCallbacks tilize_multi_core_interleaved(const Tensor& a, T
             core_range_cliff,
             ComputeConfig{
                 .fp32_dest_acc_en = fp32_llk_acc,
-                .compile_args = compute_args,
+                .compile_args = compute_args_cliff,
             });
     }
 

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_program_factory.cpp
@@ -19,7 +19,6 @@ using namespace tt::tt_metal;
 namespace ttnn::operations::data_movement::detail {
 
 operation::ProgramWithCallbacks tilize_single_core(const Tensor& a, Tensor& output) {
-    std::cout << "testing single core interleaved tilize" << std::endl;  // --- IGNORE ---
     tt::tt_metal::Program program{};
 
     CoreRange core({0, 0}, {0, 0});
@@ -163,7 +162,6 @@ operation::ProgramWithCallbacks tilize_single_core(const Tensor& a, Tensor& outp
 }
 
 operation::ProgramWithCallbacks tilize_multi_core_block(const Tensor& a, Tensor& output) {
-    std::cout << "testing multicore block interleaved tilize" << std::endl;  // --- IGNORE ---
     tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
     tt::DataFormat input_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(a.dtype());
     uint32_t input_single_tile_size = tt::tile_size(input_cb_data_format);
@@ -491,8 +489,6 @@ operation::ProgramWithCallbacks tilize_multi_core_interleaved(const Tensor& a, T
         }
     }
 
-    std::cout << "testing multicore interleaved tilize" << std::endl;  // --- IGNORE ---
-
     create_cb(tt::CBIndex::c_0, program, all_cores, input_single_tile_size, ntiles_per_block, input_cb_data_format);
 
     auto [output_cb_index, _] = create_cb(
@@ -639,7 +635,6 @@ operation::ProgramWithCallbacks tilize_multi_core_interleaved(const Tensor& a, T
 }
 
 operation::ProgramWithCallbacks tilize_multi_core_sharded(const Tensor& input, Tensor& output) {
-    std::cout << "testing multicore sharded tilize" << std::endl;  // --- IGNORE ---
     tt::tt_metal::Program program{};
 
     tt::DataFormat input_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input.dtype());

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/untilize_with_unpadding.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/untilize_with_unpadding.cpp
@@ -60,8 +60,7 @@ ttnn::Tensor ExecuteUntilizeWithUnpadding::invoke(
     const std::optional<MemoryConfig>& memory_config,
     bool use_multicore,
     bool use_pack_untilize) {
-    // MT: Currently only uint32 is moved to DST directly, fp32 is converted to fp16b
-    bool fp32_dest_acc_en = input_tensor.dtype() == DataType::UINT32;
+    bool fp32_dest_acc_en = input_tensor.dtype() == DataType::UINT32 || input_tensor.dtype() == DataType::FLOAT32;
 
     ttnn::SmallVector<uint32_t> output_end_vector;
     ttnn::Shape output_end;


### PR DESCRIPTION
### Ticket
[Tilize Issue](https://github.com/tenstorrent/tt-metal/issues/21023)
[Repeat Issue](https://github.com/tenstorrent/tt-metal/issues/29021)
[Truncation Issue](https://github.com/tenstorrent/tt-metal/issues/30400)


### Problem description
Without passing fp32 accumulation flag into compute kernel, tilize LLK converts to fp16, resulting in truncation for low values.

### What's changed
Ensure tilize uses fp32 accumulation when necessary.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/19155376602) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/19155378811) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/runs/19082837148) CI passes (if applicable)
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/runs/19082839754) CI passes (if applicable)