### PR TITLE
Cleanup `tt_backend_api_types.hpp`

### DIFF
--- a/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
+++ b/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
@@ -16,6 +16,7 @@
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include "impl/context/metal_context.hpp"
 #include <tt-metalium/control_plane.hpp>
+#include "common/tt_backend_api_types.hpp"
 
 namespace tt::tt_fabric {
 namespace fabric_router_tests {

--- a/tests/tt_metal/tt_fabric/feature_bringup/fabric_elastic_channels_host_test.cpp
+++ b/tests/tt_metal/tt_fabric/feature_bringup/fabric_elastic_channels_host_test.cpp
@@ -38,6 +38,7 @@
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/mesh_buffer.hpp>
 #include <tt-metalium/tt_align.hpp>
+#include "common/tt_backend_api_types.hpp"
 
 #include <array>
 #include <bit>

--- a/tests/tt_metal/tt_metal/api/test_soc_descriptor.cpp
+++ b/tests/tt_metal/tt_metal/api/test_soc_descriptor.cpp
@@ -20,6 +20,7 @@
 #include "tt_metal/test_utils/env_vars.hpp"
 #include <umd/device/coordinates/coordinate_manager.hpp>
 #include <umd/device/types/arch.hpp>
+#include "common/tt_backend_api_types.hpp"
 
 using namespace tt;
 using namespace tt::test_utils;

--- a/tests/tt_metal/tt_metal/common/mesh_dispatch_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/mesh_dispatch_fixture.hpp
@@ -17,6 +17,7 @@
 #include <tt-metalium/device_pool.hpp>
 #include <tt-metalium/distributed.hpp>
 #include "llrt.hpp"
+#include "common/tt_backend_api_types.hpp"
 
 namespace tt::tt_metal {
 

--- a/tests/tt_metal/tt_metal/device/test_device_init_and_teardown.cpp
+++ b/tests/tt_metal/tt_metal/device/test_device_init_and_teardown.cpp
@@ -22,6 +22,7 @@
 #include "tt_metal/test_utils/env_vars.hpp"
 #include <umd/device/types/arch.hpp>
 #include <tt-metalium/distributed.hpp>
+#include "common/tt_backend_api_types.hpp"
 
 namespace tt {
 namespace tt_metal {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_all_ethernet_links.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_all_ethernet_links.cpp
@@ -32,6 +32,7 @@
 #include <tt-metalium/persistent_kernel_cache.hpp>
 #include <thread>
 #include "impl/context/metal_context.hpp"
+#include "common/tt_backend_api_types.hpp"
 
 #include "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/eth_ubenchmark_types.hpp"
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_bidirectional_bandwidth_no_edm.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_bidirectional_bandwidth_no_edm.cpp
@@ -36,6 +36,7 @@
 #include <umd/device/types/arch.hpp>
 #include <umd/device/types/xy_pair.hpp>
 #include <tt-metalium/distributed.hpp>
+#include "common/tt_backend_api_types.hpp"
 
 using namespace tt;
 using namespace tt::test_utils;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_hop_latencies_no_edm.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_hop_latencies_no_edm.cpp
@@ -40,6 +40,7 @@
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/control_plane.hpp>
+#include "common/tt_backend_api_types.hpp"
 
 using tt::tt_metal::IDevice;
 using tt::tt_metal::distributed::MeshCoordinate;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_link_ping_latency_no_edm.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_link_ping_latency_no_edm.cpp
@@ -38,6 +38,7 @@
 #include <umd/device/types/arch.hpp>
 #include <umd/device/types/xy_pair.hpp>
 #include <tt-metalium/distributed.hpp>
+#include "common/tt_backend_api_types.hpp"
 
 using namespace tt;
 using namespace tt::test_utils;

--- a/tests/tt_metal/tt_metal/test_interleaved_layouts.cpp
+++ b/tests/tt_metal/tt_metal/test_interleaved_layouts.cpp
@@ -37,6 +37,7 @@
 #include "test_common.hpp"
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
+#include "common/tt_backend_api_types.hpp"
 
 namespace tt {
 namespace tt_metal {

--- a/tests/ttnn/unit_tests/gtests/ccl/test_ccl_helpers.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_ccl_helpers.cpp
@@ -15,6 +15,7 @@
 #include "ttnn/operations/ccl/shared_with_host/hetergeneous_data_structs.hpp"
 #include <umd/device/types/xy_pair.hpp>
 #include <umd/device/types/arch.hpp>
+#include "common/tt_backend_api_types.hpp"
 
 TEST(CclHelpers, CreateEriscDatamoverBuilder_Chan4_PageSize2048_RRBufferSharingMode) {
     std::size_t num_channels = 4;

--- a/tests/ttnn/unit_tests/gtests/ccl/test_ccl_helpers.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_ccl_helpers.cpp
@@ -15,7 +15,6 @@
 #include "ttnn/operations/ccl/shared_with_host/hetergeneous_data_structs.hpp"
 #include <umd/device/types/xy_pair.hpp>
 #include <umd/device/types/arch.hpp>
-#include "common/tt_backend_api_types.hpp"
 
 TEST(CclHelpers, CreateEriscDatamoverBuilder_Chan4_PageSize2048_RRBufferSharingMode) {
     std::size_t num_channels = 4;

--- a/tests/ttnn/unit_tests/gtests/ccl/test_erisc_data_mover_with_workers.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_erisc_data_mover_with_workers.cpp
@@ -50,6 +50,7 @@
 #include "ttnn/types.hpp"
 #include <umd/device/types/arch.hpp>
 #include <umd/device/types/xy_pair.hpp>
+#include "common/tt_backend_api_types.hpp"
 
 // #include <tt-metalium/kernel_types.hpp>
 

--- a/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp
@@ -37,6 +37,7 @@
 #include <umd/device/types/arch.hpp>
 #include <umd/device/types/cluster_descriptor_types.hpp>
 #include "gtest/gtest.h"
+#include "common/tt_backend_api_types.hpp"
 
 #include <algorithm>
 #include <cstddef>

--- a/tests/ttnn/unit_tests/gtests/test_graph_query_op_runtime.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_graph_query_op_runtime.cpp
@@ -26,6 +26,7 @@
 #include "ttnn/tensor/types.hpp"
 #include "ttnn/types.hpp"
 #include <umd/device/types/arch.hpp>
+#include "common/tt_backend_api_types.hpp"
 
 namespace tt {
 namespace tt_metal {

--- a/tests/ttnn/unit_tests/gtests/ttnn_test_fixtures.hpp
+++ b/tests/ttnn/unit_tests/gtests/ttnn_test_fixtures.hpp
@@ -21,6 +21,7 @@
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/tensor/tensor_impl.hpp"
 #include "hostdevcommon/common_values.hpp"
+#include "common/tt_backend_api_types.hpp"
 
 using namespace tt::tt_metal;  // For test
 

--- a/tt_metal/api/tt-metalium/tt_backend_api_types.hpp
+++ b/tt_metal/api/tt-metalium/tt_backend_api_types.hpp
@@ -144,11 +144,6 @@ constexpr static uint32_t tile_size(const DataFormat& format) {
     }
 }
 
-std::string get_string(ARCH arch);
-std::string get_string_lowercase(ARCH arch);
-std::string get_alias(ARCH arch);
-ARCH get_arch_from_string(const std::string& arch_str);
-
 }  // namespace tt
 
 template <>

--- a/tt_metal/api/tt-metalium/tt_backend_api_types.hpp
+++ b/tt_metal/api/tt-metalium/tt_backend_api_types.hpp
@@ -48,15 +48,6 @@ bool is_integer_format(DataFormat format);
 
 std::ostream& operator<<(std::ostream& os, const DataFormat& format);
 
-/**
- * Returns size of datum in bytes
- *
- * Return value: uint32_t
- *
- * | Argument    | Description    | Type                | Valid Range | Required |
- * |-------------|----------------|---------------------|-------------|----------|
- * | format      | Format of data | tt::DataFormat enum |             | Yes      |
- */
 constexpr uint32_t datum_size(const DataFormat& format) {
     switch (format) {
         case DataFormat::Bfp2:

--- a/tt_metal/api/tt-metalium/tt_backend_api_types.hpp
+++ b/tt_metal/api/tt-metalium/tt_backend_api_types.hpp
@@ -6,10 +6,7 @@
 
 #include <cstddef>
 #include <cstdint>
-#include <fstream>
 #include <functional>
-#include <stdexcept>
-#include <string>
 
 #include <fmt/base.h>
 #include <umd/device/types/arch.hpp>
@@ -48,42 +45,20 @@ enum class DataFormat : uint8_t {
 /**
  * @brief Evaluates to true if the data format is an integer type.
  */
-inline bool is_integer_format(DataFormat format) {
-    return (
-        (format == DataFormat::UInt32) || (format == DataFormat::Int8) || (format == DataFormat::UInt16) ||
-        (format == DataFormat::UInt8) || (format == DataFormat::Int32) || (format == DataFormat::RawUInt32) ||
-        (format == DataFormat::RawUInt16) || (format == DataFormat::RawUInt8));
-}
+bool is_integer_format(DataFormat format);
 
-inline std::ostream& operator<<(std::ostream& os, const DataFormat& format) {
-    switch (format) {
-        case DataFormat::Bfp2: os << "Bfp2"; break;
-        case DataFormat::Bfp2_b: os << "Bfp2_b"; break;
-        case DataFormat::Bfp4: os << "Bfp4"; break;
-        case DataFormat::Bfp4_b: os << "Bfp4_b"; break;
-        case DataFormat::Bfp8: os << "Bfp8"; break;
-        case DataFormat::Bfp8_b: os << "Bfp8_b"; break;
-        case DataFormat::Float16: os << "Float16"; break;
-        case DataFormat::Float16_b: os << "Float16_b"; break;
-        case DataFormat::Float32: os << "Float32"; break;
-        case DataFormat::Tf32: os << "Tf32"; break;
-        case DataFormat::Int8: os << "Int8"; break;
-        case DataFormat::UInt8: os << "UInt8"; break;
-        case DataFormat::Lf8: os << "Lf8"; break;
-        case DataFormat::UInt16: os << "UInt16"; break;
-        case DataFormat::UInt32: os << "UInt32"; break;
-        case DataFormat::Int32: os << "Int32"; break;
-        case DataFormat::RawUInt8: os << "RawUInt8"; break;
-        case DataFormat::RawUInt16: os << "RawUInt16"; break;
-        case DataFormat::RawUInt32: os << "RawUInt32"; break;
-        case DataFormat::Invalid: os << "Invalid"; break;
-        default: throw std::invalid_argument("Unknown format");
-    }
-    return os;
-}
+std::ostream& operator<<(std::ostream& os, const DataFormat& format);
 
-// Size of datum in bytes
-constexpr static uint32_t datum_size(const DataFormat& format) {
+/**
+ * Returns size of datum in bytes
+ *
+ * Return value: uint32_t
+ *
+ * | Argument    | Description    | Type                | Valid Range | Required |
+ * |-------------|----------------|---------------------|-------------|----------|
+ * | format      | Format of data | tt::DataFormat enum |             | Yes      |
+ */
+constexpr uint32_t datum_size(const DataFormat& format) {
     switch (format) {
         case DataFormat::Bfp2:
         case DataFormat::Bfp2_b:

--- a/tt_metal/api/tt-metalium/tt_backend_api_types.hpp
+++ b/tt_metal/api/tt-metalium/tt_backend_api_types.hpp
@@ -4,12 +4,11 @@
 
 #pragma once
 
-#include <cstddef>
 #include <cstdint>
 #include <functional>
+#include <stdexcept>
 
 #include <fmt/base.h>
-#include <umd/device/types/arch.hpp>
 
 namespace tt {
 

--- a/tt_metal/api/tt-metalium/tt_backend_api_types.hpp
+++ b/tt_metal/api/tt-metalium/tt_backend_api_types.hpp
@@ -6,6 +6,7 @@
 
 #include <cstdint>
 #include <functional>
+#include <ostream>
 #include <stdexcept>
 
 #include <fmt/base.h>

--- a/tt_metal/api/tt-metalium/tt_backend_api_types.hpp
+++ b/tt_metal/api/tt-metalium/tt_backend_api_types.hpp
@@ -49,7 +49,7 @@ bool is_integer_format(DataFormat format);
 
 std::ostream& operator<<(std::ostream& os, const DataFormat& format);
 
-constexpr uint32_t datum_size(const DataFormat& format) {
+constexpr static uint32_t datum_size(const DataFormat& format) {
     switch (format) {
         case DataFormat::Bfp2:
         case DataFormat::Bfp2_b:

--- a/tt_metal/common/tt_backend_api_types.cpp
+++ b/tt_metal/common/tt_backend_api_types.cpp
@@ -2,7 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "tt_backend_api_types.hpp"
+#include <tt-metalium/tt_backend_api_types.hpp>
+#include "common/tt_backend_api_types.hpp"
 
 #include <fmt/base.h>
 #include <enchantum/enchantum.hpp>

--- a/tt_metal/common/tt_backend_api_types.cpp
+++ b/tt_metal/common/tt_backend_api_types.cpp
@@ -57,6 +57,40 @@ tt::ARCH tt::get_arch_from_string(const std::string& arch_str) {
     return arch;
 }
 
+bool tt::is_integer_format(DataFormat format) {
+    return (
+        (format == DataFormat::UInt32) || (format == DataFormat::Int8) || (format == DataFormat::UInt16) ||
+        (format == DataFormat::UInt8) || (format == DataFormat::Int32) || (format == DataFormat::RawUInt32) ||
+        (format == DataFormat::RawUInt16) || (format == DataFormat::RawUInt8));
+}
+
+std::ostream& tt::operator<<(std::ostream& os, const DataFormat& format) {
+    switch (format) {
+        case DataFormat::Bfp2: os << "Bfp2"; break;
+        case DataFormat::Bfp2_b: os << "Bfp2_b"; break;
+        case DataFormat::Bfp4: os << "Bfp4"; break;
+        case DataFormat::Bfp4_b: os << "Bfp4_b"; break;
+        case DataFormat::Bfp8: os << "Bfp8"; break;
+        case DataFormat::Bfp8_b: os << "Bfp8_b"; break;
+        case DataFormat::Float16: os << "Float16"; break;
+        case DataFormat::Float16_b: os << "Float16_b"; break;
+        case DataFormat::Float32: os << "Float32"; break;
+        case DataFormat::Tf32: os << "Tf32"; break;
+        case DataFormat::Int8: os << "Int8"; break;
+        case DataFormat::UInt8: os << "UInt8"; break;
+        case DataFormat::Lf8: os << "Lf8"; break;
+        case DataFormat::UInt16: os << "UInt16"; break;
+        case DataFormat::UInt32: os << "UInt32"; break;
+        case DataFormat::Int32: os << "Int32"; break;
+        case DataFormat::RawUInt8: os << "RawUInt8"; break;
+        case DataFormat::RawUInt16: os << "RawUInt16"; break;
+        case DataFormat::RawUInt32: os << "RawUInt32"; break;
+        case DataFormat::Invalid: os << "Invalid"; break;
+        default: throw std::invalid_argument("Unknown format");
+    }
+    return os;
+}
+
 auto fmt::formatter<tt::DataFormat>::format(tt::DataFormat df, format_context& ctx) const -> format_context::iterator {
     const auto name = enchantum::to_string(df);
 

--- a/tt_metal/common/tt_backend_api_types.hpp
+++ b/tt_metal/common/tt_backend_api_types.hpp
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <string>
+#include <umd/device/types/arch.hpp>
+
+namespace tt {
+
+std::string get_string(ARCH arch);
+std::string get_string_lowercase(ARCH arch);
+std::string get_alias(ARCH arch);
+ARCH get_arch_from_string(const std::string& arch_str);
+
+}  // namespace tt

--- a/tt_metal/fabric/physical_system_descriptor.cpp
+++ b/tt_metal/fabric/physical_system_descriptor.cpp
@@ -5,6 +5,7 @@
 #include <yaml-cpp/yaml.h>
 #include <algorithm>
 #include <set>
+#include <fstream>
 
 #include <umd/device/cluster.hpp>
 #include <umd/device/soc_descriptor.hpp>

--- a/tt_metal/hal.cpp
+++ b/tt_metal/hal.cpp
@@ -3,7 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <hal.hpp>
-#include <tt_backend_api_types.hpp>
+#include <tt-metalium/tt_backend_api_types.hpp>
+#include "common/tt_backend_api_types.hpp"
 #include <umd/device/types/arch.hpp>
 #include <cstdint>
 #include <string>

--- a/tt_metal/impl/debug/dprint_server.cpp
+++ b/tt_metal/impl/debug/dprint_server.cpp
@@ -23,6 +23,7 @@
 #include <thread>
 #include <tuple>
 #include <vector>
+#include <fstream>
 
 #include <enchantum/enchantum.hpp>
 #include <tt-logger/tt-logger.hpp>

--- a/tt_metal/impl/debug/inspector/logger.hpp
+++ b/tt_metal/impl/debug/inspector/logger.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <fstream>
+
 #include "impl/debug/inspector/types.hpp"
 #include "mesh_coord.hpp"
 

--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -39,7 +39,7 @@
 #include "tools/profiler/noc_event_profiler_utils.hpp"
 #include "tracy/Tracy.hpp"
 #include "tt-metalium/profiler_types.hpp"
-#include "tt_backend_api_types.hpp"
+#include "common/tt_backend_api_types.hpp"
 #include "impl/context/metal_context.hpp"
 #include <umd/device/types/core_coordinates.hpp>
 #include <umd/device/types/arch.hpp>

--- a/tt_metal/jit_build/build.hpp
+++ b/tt_metal/jit_build/build.hpp
@@ -14,6 +14,7 @@
 
 #include "hal_types.hpp"
 #include "jit_build_options.hpp"
+#include <umd/device/types/arch.hpp>
 
 namespace tt::tt_metal {
 

--- a/tt_metal/jit_build/genfiles.cpp
+++ b/tt_metal/jit_build/genfiles.cpp
@@ -12,6 +12,8 @@
 #include <filesystem>
 #include <functional>
 #include <iostream>
+#include <ostream>
+#include <fstream>
 #include <stdexcept>
 #include <string>
 #include <thread>

--- a/tt_metal/lite_fabric/hal/blackhole_impl.cpp
+++ b/tt_metal/lite_fabric/hal/blackhole_impl.cpp
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <fstream>
+
 #include "blackhole_impl.hpp"
 #include "hw/inc/host_interface.hpp"
 #include "tt_metal/lite_fabric/hw/inc/blackhole/lf_dev_mem_map.hpp"

--- a/tt_metal/llrt/core_descriptor.cpp
+++ b/tt_metal/llrt/core_descriptor.cpp
@@ -18,7 +18,7 @@
 #include "hal.hpp"
 #include "hal_types.hpp"
 #include "metal_soc_descriptor.h"
-#include "tt_backend_api_types.hpp"
+#include "common/tt_backend_api_types.hpp"
 #include "impl/context/metal_context.hpp"
 #include <tt-metalium/control_plane.hpp>
 #include <umd/device/types/core_coordinates.hpp>

--- a/tt_metal/llrt/hal.hpp
+++ b/tt_metal/llrt/hal.hpp
@@ -31,6 +31,7 @@
 
 #include <tt_stl/overloaded.hpp>
 #include <umd/device/types/core_coordinates.hpp>
+#include <umd/device/types/arch.hpp>
 
 enum class AddressableCoreType : uint8_t;
 

--- a/tt_metal/llrt/tlb_config.cpp
+++ b/tt_metal/llrt/tlb_config.cpp
@@ -13,7 +13,8 @@
 
 #include "core_coord.hpp"
 #include "metal_soc_descriptor.h"
-#include "tt_backend_api_types.hpp"
+#include <tt-metalium/tt_backend_api_types.hpp>
+#include "common/tt_backend_api_types.hpp"
 #include <umd/device/arch/blackhole_implementation.hpp>
 #include <umd/device/cluster.hpp>
 #include <umd/device/types/core_coordinates.hpp>

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -45,7 +45,7 @@
 #include "llrt.hpp"
 #include <tt-logger/tt-logger.hpp>
 #include <tt-metalium/tt_metal_profiler.hpp>
-#include "tt-metalium/program.hpp"
+#include <tt-metalium/program.hpp>
 #include "program/program_impl.hpp"
 #include "impl/buffers/semaphore.hpp"
 #include "tracy/Tracy.hpp"
@@ -55,6 +55,7 @@
 #include <tt-metalium/graph_tracking.hpp>
 #include <tt_stl/overloaded.hpp>
 #include "get_platform_architecture.hpp"
+#include "common/tt_backend_api_types.hpp"
 
 namespace tt {
 

--- a/tt_telemetry/server/main.cpp
+++ b/tt_telemetry/server/main.cpp
@@ -12,6 +12,7 @@
 #include <iostream>
 #include <optional>
 #include <sstream>
+#include <fstream>
 
 #include <boost/functional/hash.hpp>
 #include <cxxopts.hpp>


### PR DESCRIPTION
### Ticket
Closes #31749 

### Problem description
Runtime team is reducing their API surface area.
There's functions within the`tt_backend_api_types.hpp` that are only used by runtime internal systems.

### What's changed
Split out the following functions into metal internal:
```c++
std::string get_string(ARCH arch);
std::string get_string_lowercase(ARCH arch);
std::string get_alias(ARCH arch);
ARCH get_arch_from_string(const std::string& arch_str);
```
As they are not used externally.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes