### PR TITLE
fix gtest pipelines by adding a workaround for issue 31845

### DIFF
--- a/tests/ttnn/unit_tests/gtests/ccl/test_persistent_fabric_ccl_ops.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_persistent_fabric_ccl_ops.cpp
@@ -72,6 +72,8 @@ TEST(CclAsyncOp, ReduceScatterSmall_PersistentFabric) {
         *test_fixture.mesh_device_);
 
     auto output_tensor = ttnn::reduce_scatter(input_mesh_tensor, dim, 1);
+    // auto output_tensor = ttnn::reduce_scatter(input_mesh_tensor, dim); //Issue 31845, should be able to replace
+    // previous line with this
 
     // wait for op completion
     log_info(tt::LogTest, "Waiting for Op finish");

--- a/tests/ttnn/unit_tests/gtests/ccl/test_persistent_fabric_ccl_ops.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_persistent_fabric_ccl_ops.cpp
@@ -71,7 +71,7 @@ TEST(CclAsyncOp, ReduceScatterSmall_PersistentFabric) {
                 .mesh_shape_override = MeshShape{1, num_devices}}),
         *test_fixture.mesh_device_);
 
-    auto output_tensor = ttnn::reduce_scatter(input_mesh_tensor, dim);
+    auto output_tensor = ttnn::reduce_scatter(input_mesh_tensor, dim, 1);
 
     // wait for op completion
     log_info(tt::LogTest, "Waiting for Op finish");


### PR DESCRIPTION
### Ticket
Due to issue #31845 we can't operate on a submesh of devices in CCL OPs. By specifying cluster axis, the mesh device and the tensor built match patching the issue.

This is necessary to make t3k ttnn tests green

https://github.com/tenstorrent/tt-metal/actions/runs/19082037686

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes