### PR TITLE
Add TT_METAL_RUNTIME_ROOT environment variable to ttrun.py

### DIFF
--- a/ttnn/ttnn/distributed/ttrun.py
+++ b/ttnn/ttnn/distributed/ttrun.py
@@ -127,7 +127,9 @@ def get_rank_environment(binding: RankBinding, config: TTRunConfig) -> Dict[str,
         "TT_MESH_ID": str(binding.mesh_id),
         "TT_MESH_GRAPH_DESC_PATH": config.mesh_graph_desc_path,
         "TT_METAL_HOME": os.environ.get("TT_METAL_HOME", str(Path.home())),
-        "TT_METAL_RUNTIME_ROOT": os.environ.get("TT_METAL_RUNTIME_ROOT", os.environ.get("TT_METAL_HOME", str(Path.home()))),
+        "TT_METAL_RUNTIME_ROOT": os.environ.get(
+            "TT_METAL_RUNTIME_ROOT", os.environ.get("TT_METAL_HOME", str(Path.home()))
+        ),
         "PYTHONPATH": os.environ.get("PYTHONPATH", str(Path.home())),
         # 26640: TODO - Investigate why this needs to be set for multi-host CI environments
         "LD_LIBRARY_PATH": os.environ.get("LD_LIBRARY_PATH", DEFAULT_LD_LIBRARY_PATH.format(home=str(Path.home()))),

--- a/ttnn/ttnn/distributed/ttrun.py
+++ b/ttnn/ttnn/distributed/ttrun.py
@@ -127,6 +127,7 @@ def get_rank_environment(binding: RankBinding, config: TTRunConfig) -> Dict[str,
         "TT_MESH_ID": str(binding.mesh_id),
         "TT_MESH_GRAPH_DESC_PATH": config.mesh_graph_desc_path,
         "TT_METAL_HOME": os.environ.get("TT_METAL_HOME", str(Path.home())),
+        "TT_METAL_RUNTIME_ROOT": os.environ.get("TT_METAL_RUNTIME_ROOT", os.environ.get("TT_METAL_HOME", str(Path.home()))),
         "PYTHONPATH": os.environ.get("PYTHONPATH", str(Path.home())),
         # 26640: TODO - Investigate why this needs to be set for multi-host CI environments
         "LD_LIBRARY_PATH": os.environ.get("LD_LIBRARY_PATH", DEFAULT_LD_LIBRARY_PATH.format(home=str(Path.home()))),


### PR DESCRIPTION
### Ticket
NA

### Problem description
Need ttrun.py to work still after introduction of TT_METAL_RUNTIME_ROOT

### What's changed
Set TT_METAL_RUNTIME_ROOT by default.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/19082208855) CI passes
- [x] New/Existing tests provide coverage for changes