### PR TITLE
Moved gemma perf test to correct CI pipeline

### DIFF
--- a/.github/workflows/fast-dispatch-full-regressions-and-models-impl.yaml
+++ b/.github/workflows/fast-dispatch-full-regressions-and-models-impl.yaml
@@ -69,7 +69,6 @@ jobs:
             {"model":"vovnet"},
             {"model":"ufld_v2"},
             {"model":"yolov12x"},
-            {"model":"gemma-3-4b-it"},
             {"model":"ttt-mistral-7B-v0.3"},
             {"model":"stable_diffusion_xl_base","timeout":75},
             {"model":"stable_diffusion","timeout":45}
@@ -200,8 +199,6 @@ jobs:
               pytest tests/nightly/single_card/tt_transformers -k ${{ matrix.test-config.model }}
             elif [[ "${{ matrix.test-config.model }}" == *"qwen25_vl"* ]]; then
               pytest tests/nightly/single_card/qwen25_vl -k ${{ matrix.test-config.model }}
-            elif [[ "${{ matrix.test-config.model }}" == *"gemma-3"* ]]; then
-              pytest tests/nightly/single_card/gemma3 -k ${{ matrix.test-config.model }}
             else
               pytest tests/nightly/single_card/${{ matrix.test-config.model }}
             fi

--- a/.github/workflows/t3000-model-perf-tests-impl.yaml
+++ b/.github/workflows/t3000-model-perf-tests-impl.yaml
@@ -35,7 +35,7 @@ jobs:
           { name: "t3k DiT Mochi model perf tests", model-name: "mochi", model-type: "DiT", arch: wormhole_b0, cmd: run_t3000_mochi_tests, timeout: 75, owner_id: U09ELB03XRU}, # Stephen Osborne
           { name: "t3k DiT Wan2.2 model perf tests", model-name: "wan22", model-type: "DiT", arch: wormhole_b0, cmd: run_t3000_wan22_tests, timeout: 45, owner_id: U03FJB5TM5Y}, # Colman Glagovich
           { name: "t3k DiT Flux.1-dev model perf tests", model-name: "flux1-dev", model-type: "DiT", arch: wormhole_b0, cmd: run_t3000_flux1_tests, timeout: 75, owner_id: U08TED0JM9D}, # Samuel Adesoye
-          { name: "t3k ViT Gemma3 perf tests", model: "google/gemma-3-27b-it", model-type: "ViT", arch: wormhole_b0, cmd: run_t3000_gemma3_tests, timeout: 75, owner_id: U093901FR8U}, # Milos Stojko
+          { name: "t3k ViT Gemma3 perf tests", model: "gemma-3-27b-it", model-type: "ViT", arch: wormhole_b0, cmd: run_t3000_gemma3_tests, timeout: 75, owner_id: U093901FR8U}, # Milos Stojko
         ]
     name: ${{ matrix.test-group.name }}
     runs-on:

--- a/.github/workflows/t3000-model-perf-tests-impl.yaml
+++ b/.github/workflows/t3000-model-perf-tests-impl.yaml
@@ -35,7 +35,7 @@ jobs:
           { name: "t3k DiT Mochi model perf tests", model-name: "mochi", model-type: "DiT", arch: wormhole_b0, cmd: run_t3000_mochi_tests, timeout: 75, owner_id: U09ELB03XRU}, # Stephen Osborne
           { name: "t3k DiT Wan2.2 model perf tests", model-name: "wan22", model-type: "DiT", arch: wormhole_b0, cmd: run_t3000_wan22_tests, timeout: 45, owner_id: U03FJB5TM5Y}, # Colman Glagovich
           { name: "t3k DiT Flux.1-dev model perf tests", model-name: "flux1-dev", model-type: "DiT", arch: wormhole_b0, cmd: run_t3000_flux1_tests, timeout: 75, owner_id: U08TED0JM9D}, # Samuel Adesoye
-          { name: "t3k ViT Gemma3 perf tests", model: "google/gemma-3-27b-it", model-type: "ViT", arch: wormhole_b0, cmd: run_t3000_gemma3_tests, timeout: 75, owner_id: U094PKWHNJ0}, # Milos Stojko
+          { name: "t3k ViT Gemma3 perf tests", model: "google/gemma-3-27b-it", model-type: "ViT", arch: wormhole_b0, cmd: run_t3000_gemma3_tests, timeout: 75, owner_id: U093901FR8U}, # Milos Stojko
         ]
     name: ${{ matrix.test-group.name }}
     runs-on:

--- a/.github/workflows/t3000-model-perf-tests-impl.yaml
+++ b/.github/workflows/t3000-model-perf-tests-impl.yaml
@@ -35,6 +35,7 @@ jobs:
           { name: "t3k DiT Mochi model perf tests", model-name: "mochi", model-type: "DiT", arch: wormhole_b0, cmd: run_t3000_mochi_tests, timeout: 75, owner_id: U09ELB03XRU}, # Stephen Osborne
           { name: "t3k DiT Wan2.2 model perf tests", model-name: "wan22", model-type: "DiT", arch: wormhole_b0, cmd: run_t3000_wan22_tests, timeout: 45, owner_id: U03FJB5TM5Y}, # Colman Glagovich
           { name: "t3k DiT Flux.1-dev model perf tests", model-name: "flux1-dev", model-type: "DiT", arch: wormhole_b0, cmd: run_t3000_flux1_tests, timeout: 75, owner_id: U08TED0JM9D}, # Samuel Adesoye
+          { name: "t3k ViT Gemma3 perf tests", model: "google/gemma-3-27b-it", model-type: "ViT", arch: wormhole_b0, cmd: run_t3000_gemma3_tests, timeout: 75, owner_id: U094PKWHNJ0}, # Milos Stojko
         ]
     name: ${{ matrix.test-group.name }}
     runs-on:

--- a/.github/workflows/t3000-model-perf-tests-impl.yaml
+++ b/.github/workflows/t3000-model-perf-tests-impl.yaml
@@ -35,7 +35,7 @@ jobs:
           { name: "t3k DiT Mochi model perf tests", model-name: "mochi", model-type: "DiT", arch: wormhole_b0, cmd: run_t3000_mochi_tests, timeout: 75, owner_id: U09ELB03XRU}, # Stephen Osborne
           { name: "t3k DiT Wan2.2 model perf tests", model-name: "wan22", model-type: "DiT", arch: wormhole_b0, cmd: run_t3000_wan22_tests, timeout: 45, owner_id: U03FJB5TM5Y}, # Colman Glagovich
           { name: "t3k DiT Flux.1-dev model perf tests", model-name: "flux1-dev", model-type: "DiT", arch: wormhole_b0, cmd: run_t3000_flux1_tests, timeout: 75, owner_id: U08TED0JM9D}, # Samuel Adesoye
-          { name: "t3k ViT Gemma3 perf tests", model: "gemma-3-27b-it", model-type: "ViT", arch: wormhole_b0, cmd: run_t3000_gemma3_tests, timeout: 75, owner_id: U093901FR8U}, # Milos Stojko
+          { name: "t3k ViT Gemma3 perf tests", model-name: "gemma-3-27b-it", model-type: "ViT", arch: wormhole_b0, cmd: run_t3000_gemma3_tests, timeout: 75, owner_id: U093901FR8U}, # Milos Stojko
         ]
     name: ${{ matrix.test-group.name }}
     runs-on:

--- a/.github/workflows/t3000-model-perf-tests.yaml
+++ b/.github/workflows/t3000-model-perf-tests.yaml
@@ -15,6 +15,7 @@ on:
           - resnet50
           - sentence_bert
           - stable_diffusion_35_large
+          - gemma-3-27b-it
   schedule:
     - cron: "0 */12 * * *" # This cron schedule runs the workflow every 12 hours
 

--- a/models/demos/gemma3/tests/perf_targets/targets_test_perf_vision_cross_attention_transformer.json
+++ b/models/demos/gemma3/tests/perf_targets/targets_test_perf_vision_cross_attention_transformer.json
@@ -1,19 +1,5 @@
 {
-    "gemma-3-4b-it": {
-        "N150": {
-            "model_forward_inference": 0.7746874433333334
-        },
-        "N300": {
-            "model_forward_inference": 0.5668675333333334
-        }
-    },
     "gemma-3-27b-it": {
-        "N150": {
-            "model_forward_inference": 0.7746874433333334
-        },
-        "N300": {
-            "model_forward_inference": 0.5553348666666668
-        },
         "T3K": {
             "model_forward_inference": 0.4069084666666666
         }

--- a/models/demos/gemma3/tests/perf_targets/targets_test_perf_vision_cross_attention_transformer.json
+++ b/models/demos/gemma3/tests/perf_targets/targets_test_perf_vision_cross_attention_transformer.json
@@ -1,7 +1,7 @@
 {
     "gemma-3-27b-it": {
         "T3K": {
-            "model_forward_inference": 0.90
+            "model_forward_inference": 0.4069084666666666
         }
     }
 }

--- a/models/demos/gemma3/tests/perf_targets/targets_test_perf_vision_cross_attention_transformer.json
+++ b/models/demos/gemma3/tests/perf_targets/targets_test_perf_vision_cross_attention_transformer.json
@@ -1,7 +1,7 @@
 {
     "gemma-3-27b-it": {
         "T3K": {
-            "model_forward_inference": 0.4069084666666666
+            "model_forward_inference": 0.90
         }
     }
 }

--- a/models/demos/gemma3/tests/test_ci_dispatch.py
+++ b/models/demos/gemma3/tests/test_ci_dispatch.py
@@ -14,7 +14,7 @@ from loguru import logger
     ["google/gemma-3-4b-it", "google/gemma-3-27b-it"],
     ids=["gemma-3-4b-it", "gemma-3-27b-it"],
 )
-def test_ci_dispatch(hf_model_name, is_ci_env, is_ci_v2_env, model_location_generator):
+def test_ci_dispatch(hf_model_name, is_ci_env, model_location_generator):
     if not is_ci_env:
         pytest.skip("Skipping CI dispatch tests when running locally.")
 

--- a/models/demos/gemma3/tests/test_ci_dispatch.py
+++ b/models/demos/gemma3/tests/test_ci_dispatch.py
@@ -24,7 +24,7 @@ def test_ci_dispatch(hf_model_name, is_ci_env, is_ci_v2_env, model_location_gene
 
     logger.info(f"Running fast dispatch tests for {model_weights_path}")
 
-    functional_tests = [
+    tests = [
         "models/demos/gemma3/tests/test_mmp.py",
         "models/demos/siglip/tests/test_attention.py",
         "models/demos/gemma3/tests/test_patch_embedding.py",
@@ -45,14 +45,6 @@ def test_ci_dispatch(hf_model_name, is_ci_env, is_ci_v2_env, model_location_gene
         "models/tt_transformers/tests/test_decoder.py",
         "models/tt_transformers/tests/test_decoder_prefill.py",
     ]
-    performance_tests = [
-        "models/demos/gemma3/tests/test_perf_vision_cross_attention_transformer.py",
-    ]
-
-    if is_ci_v2_env:
-        tests = functional_tests
-    else:
-        tests = performance_tests
 
     # Pass the exit code of pytest to proper keep track of failures during runtime
     exit_code = pytest.main(tests + ["-x"])

--- a/tests/scripts/t3000/run_t3000_model_perf_tests.sh
+++ b/tests/scripts/t3000/run_t3000_model_perf_tests.sh
@@ -115,6 +115,24 @@ run_t3000_dit_tests() {
   fi
 }
 
+run_t3000_gemma3_tests() {
+  # Record the start time
+  fail=0
+  start_time=$(date +%s)
+
+  HF_MODEL=/mnt/MLPerf/tt_dnn-models/google/gemma-3-27b-it pytest models/demos/gemma3/tests/test_perf_vision_cross_attention_transformer.py ; fail+=$?
+
+  # Record the end time
+  end_time=$(date +%s)
+  duration=$((end_time - start_time))
+  echo "LOG_METAL: Gemma3 27B ViT test completed"
+  echo "LOG_METAL: run_t3000_gemma3_tests $duration seconds to complete"
+
+  if [[ $fail -ne 0 ]]; then
+    exit 1
+  fi
+}
+
 run_t3000_wan22_tests() {
   # Record the start time
   fail=0


### PR DESCRIPTION
### Ticket
[Link to Github Issue
](https://github.com/tenstorrent/tt-metal/issues/31758)

### Problem description
Perf tests should go to perf pipelines.

### What's changed
- Moved perf test for gemma vision to https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml.
- Additional change that followed naturally from this moving of the test - Removed Gemma from CI1 (only CI2 now) in files `tests/nightly/single_card/gemma3/test_ci_dispatch.py` and `models/demos/gemma3/tests/test_ci_dispatch.py`. This change is reflected in the .yaml file for single cards.
This was because this perf test was the only one still running on CI1.
- Small QOL detail - this workflow file (https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) now also supports that you run gemma only, without running the other models via the Github actions GUI: 
<img width="630" height="391" alt="image" src="https://github.com/user-attachments/assets/a46db7ae-4bea-41b4-a6fe-2aa69795ca80" />

### Tests
https://github.com/tenstorrent/tt-metal/actions/runs/19084022506
https://github.com/tenstorrent/tt-metal/actions/runs/19083427274
verified that it can indeed fail (intentional fail) - https://github.com/tenstorrent/tt-metal/actions/runs/19094199259/job/54551657309