### PR TITLE
GroupNorm: use L1 alignment instead of DRAM so we can accommodate 64 multicast cores

### DIFF
--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_reader_mcast_sender_unary_gn.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_reader_mcast_sender_unary_gn.cpp
@@ -374,14 +374,14 @@ void kernel_main() {
                                 get_noc_addr(noc_coord_x[i], noc_coord_y[i], global_means_ptr);
                             uint64_t noc_vars_addr =
                                 get_noc_addr(noc_coord_x[i], noc_coord_y[i], global_vars_ptr);
-                            noc_async_read_one_packet(noc_means_addr, global_means_ptr + i * NOC_DRAM_READ_ALIGNMENT_BYTES, NOC_DRAM_READ_ALIGNMENT_BYTES);
-                            noc_async_read_one_packet(noc_vars_addr, global_vars_ptr + i * NOC_DRAM_READ_ALIGNMENT_BYTES, NOC_DRAM_READ_ALIGNMENT_BYTES);
+                            noc_async_read_one_packet(noc_means_addr, global_means_ptr + i * NOC_L1_READ_ALIGNMENT_BYTES, NOC_L1_READ_ALIGNMENT_BYTES);
+                            noc_async_read_one_packet(noc_vars_addr, global_vars_ptr + i * NOC_L1_READ_ALIGNMENT_BYTES, NOC_L1_READ_ALIGNMENT_BYTES);
                         }
                         noc_async_read_barrier();
                     }
 
                     // Read mean and variance arrays from cb_ex_global, then combine using Welford
-                    constexpr uint32_t stride = NOC_DRAM_READ_ALIGNMENT_BYTES / 2;
+                    constexpr uint32_t stride = NOC_L1_READ_ALIGNMENT_BYTES / 2;
                     auto global_result = combine_welford_stats<num_mcast_cores, num_channels_per_group * num_rows_per_group, stride>(p_global_means, p_global_vars);
 
                     // Write this to cb_ex_global


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/31783

### Problem description
See the issue for detailed description

### What's changed
See the issue for detailed description of the approach


### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/19083608259/job/54519331490 1 unrelated failure - exists on main and reproduced locally on main.
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/19083611778/job/54543772529
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes