### PR TITLE
[skip CI] Steps toward Quasar on TT-SIM

### DIFF
--- a/tt_metal/hw/firmware/src/tt-2xx/dmk.cc
+++ b/tt_metal/hw/firmware/src/tt-2xx/dmk.cc
@@ -38,13 +38,13 @@ uint32_t _start() {
     do_crt1((uint32_t tt_l1_ptr*)__kernel_data_lma);
 
     if constexpr (NOC_MODE == DM_DEDICATED_NOC) {
-        noc_local_state_init(NOC_INDEX);
+        // noc_local_state_init(NOC_INDEX); //TODO revisit this
     }
 #ifdef ALIGN_LOCAL_CBS_TO_REMOTE_CBS
     ALIGN_LOCAL_CBS_TO_REMOTE_CBS
 #endif
     wait_for_go_message();
-    asm("FENCE.i");
+    // asm("FENCE.i"); // TODO revisit once TT-SIM implemetnsor we run several kernels
     {
         DeviceZoneScopedMainChildN("BRISC-KERNEL");
         EARLY_RETURN_FOR_DEBUG

--- a/tt_metal/hw/firmware/src/tt-2xx/dmk.cc
+++ b/tt_metal/hw/firmware/src/tt-2xx/dmk.cc
@@ -44,7 +44,7 @@ uint32_t _start() {
     ALIGN_LOCAL_CBS_TO_REMOTE_CBS
 #endif
     wait_for_go_message();
-    // asm("FENCE.i"); // TODO revisit once TT-SIM implemetnsor we run several kernels
+    // asm("FENCE.i"); // TODO revisit once TT-SIM implements or we run several kernels
     {
         DeviceZoneScopedMainChildN("BRISC-KERNEL");
         EARLY_RETURN_FOR_DEBUG

--- a/tt_metal/hw/firmware/src/tt-2xx/dmk.cc
+++ b/tt_metal/hw/firmware/src/tt-2xx/dmk.cc
@@ -44,7 +44,7 @@ uint32_t _start() {
     ALIGN_LOCAL_CBS_TO_REMOTE_CBS
 #endif
     wait_for_go_message();
-    // asm("FENCE.i"); // TODO revisit once TT-SIM implemetnsor we run several kernels
+    asm("FENCE.i");
     {
         DeviceZoneScopedMainChildN("BRISC-KERNEL");
         EARLY_RETURN_FOR_DEBUG

--- a/tt_metal/hw/inc/tt-2xx/quasar/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/tt-2xx/quasar/noc_nonblocking_api.h
@@ -1169,7 +1169,6 @@ inline __attribute__((always_inline)) void noc_fast_write_dw_inline_set_state(
  * | update_val (template parameter)            | Whether to set the value to be written                 | bool     | true or false                    | False    |
  * | posted (template parameter)                | Whether the call is posted (i.e. ack requirement)      | bool     | true or false                    | False    |
  * | update_counter (template parameter)        | Whether to update the write counters                   | bool     | true or false                    | False    |
- * | dst_type (template parameter)              | Whether the write is targeting L1 or a Stream Register | InlineWriteDst     | DEFAULT, L1, REG       | False    |
  */
 // clang-format on
 template <
@@ -1178,8 +1177,7 @@ template <
     bool update_addr_hi = false,
     bool update_val = false,
     bool posted = false,
-    bool update_counter = true,
-    bool update_be_on_addr_lo = false>
+    bool update_counter = true>
 inline __attribute__((always_inline)) void noc_fast_write_dw_inline_with_state(
     uint32_t noc, uint32_t cmd_buf, uint32_t val = 0, uint64_t dest_addr = 0) {
     static_assert("Error: Only High or Low address update is supported" && (update_addr_lo && update_addr_hi) == 0);
@@ -1196,10 +1194,6 @@ inline __attribute__((always_inline)) void noc_fast_write_dw_inline_with_state(
 
     if constexpr (update_addr_lo) {
         NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_LO, dest_addr);
-        if constexpr (dst_type != InlineWriteDst::REG) {
-            uint32_t be32 = 0xF << (dest_addr & (NOC_WORD_BYTES - 1));
-            NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_AT_LEN_BE, be32);
-        }
     } else if constexpr (update_addr_hi) {
         NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_COORDINATE, dest_addr);
     }


### PR DESCRIPTION
### Problem description
A change up-tree broke Quasar test. Test isn't running on TT-SIM

### What's changed
Fix up-tree breakage by reverting the change, disable calls that TT-SIM didn't like (these aren't important at the moment, we need to revisit noc inits and TT-SIM is working to enable `fence.i`).

### Checklist
Skipping CI as these changes are Quasar specific and that isn't being tested yet