### PR TITLE
Add fixes for trace, mesh device

### DIFF
--- a/tests/scripts/multihost/run_dual_galaxy_tests.sh
+++ b/tests/scripts/multihost/run_dual_galaxy_tests.sh
@@ -31,6 +31,7 @@ run_dual_galaxy_unit_tests() {
   tt-run --rank-binding "$rank_binding" --mpi-args "$mpi_args_reversed" bash -c "source ./python_env/bin/activate && pytest -svv \"tests/ttnn/unit_tests/operations/ccl/test_all_to_all_dispatch_6U.py::test_all_to_all_dispatch_no_trace[silicon_arch_name=wormhole_b0-dram-l1-dtype=DataType.BFLOAT16-topology=None-num_links=1-s2-hidden_size=7168-select_experts_k=8-experts=256-batches_per_device=32-cluster_axis=1-8x8_grid-trace_mode=False-fabric_1d_line]\"" ; fail+=$?
   tt-run --rank-binding "$rank_binding" --mpi-args "$mpi_args_reversed" bash -c "source ./python_env/bin/activate && pytest -svv \"tests/nightly/tg/ccl/test_minimal_reduce_scatter_async.py::test_reduce_scatter_async_big_mesh\"" ; fail+=$?
   tt-run --rank-binding "$rank_binding" --mpi-args "$mpi_args_reversed" bash -c "source ./python_env/bin/activate && pytest -svv \"tests/nightly/tg/ccl/test_minimal_all_gather_async.py::test_all_gather_async_big_mesh\"" ; fail+=$?
+  tt-run --rank-binding "$rank_binding" --mpi-args "$mpi_args_reversed" bash -c "source ./python_env/bin/activate && pytest -svv \"tests/ttnn/unit_tests/base_functionality/test_multi_host_clusters.py::test_dual_galaxy_mesh_device_trace\"" ; fail+=$?
 
   # Record the end time
   end_time=$(date +%s)

--- a/tests/ttnn/unit_tests/base_functionality/test_multi_host_clusters.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_multi_host_clusters.py
@@ -1,0 +1,83 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import ttnn
+import torch
+
+
+# Multi host trace tests
+
+
+@pytest.mark.parametrize(
+    "mesh_device",
+    [
+        pytest.param((8, 16), id="8x16_dev_grid"),
+        pytest.param((16, 8), id="16x8_dev_grid"),
+    ],
+    indirect=["mesh_device"],
+)
+@pytest.mark.parametrize(
+    "tensor_shard_shape",
+    [
+        pytest.param((8, 4), id="8x4_shard"),
+        pytest.param((4, 8), id="4x8_shard"),
+        pytest.param((8, 8), id="8x8_shard"),
+        pytest.param((8, 16), id="8x16_shard"),
+        pytest.param((16, 8), id="16x8_shard"),
+    ],
+)
+@pytest.mark.parametrize("device_params", [{"trace_region_size": 500000}], indirect=True)
+def test_quad_galaxy_mesh_device_trace(mesh_device, tensor_shard_shape):
+    torch_input_0 = torch.randint(0, 100, (1, 1, 32, 32), dtype=torch.uint16)
+    input_0_dev = ttnn.from_torch(
+        torch_input_0,
+        device=mesh_device,
+        layout=ttnn.TILE_LAYOUT,
+        dtype=ttnn.uint16,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, dims=(None, None), mesh_shape=tensor_shard_shape),
+    )
+    output_dev = ttnn.relu(input_0_dev)
+    trace_id = ttnn.begin_trace_capture(mesh_device, cq_id=0)
+    ttnn.relu(input_0_dev)
+    ttnn.end_trace_capture(mesh_device, trace_id, cq_id=0)
+    ttnn.synchronize_device(mesh_device)
+    ttnn.execute_trace(mesh_device, trace_id, cq_id=0, blocking=True)
+    ttnn.release_trace(mesh_device, trace_id)
+
+
+@pytest.mark.parametrize(
+    "mesh_device",
+    [
+        pytest.param((8, 8), id="8x8_dev_grid"),
+    ],
+    indirect=["mesh_device"],
+)
+@pytest.mark.parametrize(
+    "tensor_shard_shape",
+    [
+        pytest.param((8, 4), id="8x4_shard"),
+        pytest.param((4, 8), id="4x8_shard"),
+        pytest.param((8, 8), id="8x8_shard"),
+    ],
+)
+@pytest.mark.parametrize("device_params", [{"trace_region_size": 500000}], indirect=True)
+def test_dual_galaxy_mesh_device_trace(mesh_device, tensor_shard_shape):
+    torch_input_0 = torch.randint(0, 100, (1, 1, 32, 32), dtype=torch.uint16)
+    input_0_dev = ttnn.from_torch(
+        torch_input_0,
+        device=mesh_device,
+        layout=ttnn.TILE_LAYOUT,
+        dtype=ttnn.uint16,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, dims=(None, None), mesh_shape=tensor_shard_shape),
+    )
+    output_dev = ttnn.relu(input_0_dev)
+    trace_id = ttnn.begin_trace_capture(mesh_device, cq_id=0)
+    ttnn.relu(input_0_dev)
+    ttnn.end_trace_capture(mesh_device, trace_id, cq_id=0)
+    ttnn.synchronize_device(mesh_device)
+    ttnn.execute_trace(mesh_device, trace_id, cq_id=0, blocking=True)
+    ttnn.release_trace(mesh_device, trace_id)

--- a/tt_metal/api/tt-metalium/mesh_device_view.hpp
+++ b/tt_metal/api/tt-metalium/mesh_device_view.hpp
@@ -113,6 +113,10 @@ public:
     // Throws if the coordinate is out of bounds of this view.
     bool is_local(const MeshCoordinate& coord) const;
 
+    // Returns the coordinate range of all local devices in this view.
+    // The range is a bounding box that encompasses all local coordinates.
+    MeshCoordinateRange get_local_mesh_coord_range() const;
+
 private:
     DistributedMeshContainer<IDevice*> devices_;
     MeshContainer<tt::tt_fabric::FabricNodeId> fabric_node_ids_;

--- a/tt_metal/distributed/fd_mesh_command_queue.hpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.hpp
@@ -61,7 +61,7 @@ private:
     // When running trace, the dispatch commands responsible for forwarding go signals must be
     // captured on these subgrids.
     void capture_go_signal_trace_on_unused_subgrids(
-        const MeshCoordinateRange& active_sub_grids,
+        const MeshCoordinateRangeSet& active_sub_grids_set,
         const SubDeviceId& sub_device_id,
         uint32_t expected_num_workers_completed,
         bool mcast_go_signals,


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/31558)

### Problem description
Trace was throwing non-local device error and segfaults for BigMesh.

### What's changed
- Add proper support in FD command queue for Trace in BigMesh.
- Add tests covering all permutations of device grids and tensor shapes for quad.
- Add a getter in mesh device to get local core range

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes