### PR TITLE
fix 31853 bug

### DIFF
--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -1054,6 +1054,7 @@ void paged_read_into_cmddat_q(uint32_t read_ptr, PrefetchExecBufState& exec_buf_
     uint32_t pages_at_once =
         (max_trace_buffer_pages_in_cmd_dat_q > pages) ? pages : max_trace_buffer_pages_in_cmd_dat_q;
     uint32_t read_length = pages_at_once << log_page_size;
+    uint32_t pages_read = pages_at_once;
 
     auto addr_gen = TensorAccessor(tensor_accessor::make_interleaved_dspec</*is_dram=*/true>(), base_addr, page_size);
 
@@ -1067,7 +1068,7 @@ void paged_read_into_cmddat_q(uint32_t read_ptr, PrefetchExecBufState& exec_buf_
     }
 
     exec_buf_state.page_id = page_id;
-    exec_buf_state.pages -= pages_at_once;
+    exec_buf_state.pages -= pages_read;
     exec_buf_state.length += read_length;
 }
 


### PR DESCRIPTION
Bug: exec_buf_state.pages was updated with pages_at_once which was 0 after the while-loop Fix: save pages_at_once value to pages_read before the while-loop and then
     decrement exec_buf_state.pages with pages_read instead of pages_at_once

### Ticket
https://github.com/tenstorrent/tt-metal/issues/31853

### Problem description
In the cq_prefetch.cpp file, paged_read_into_cmddat_q function, the exec_buf_state.pages was wrongly updated with pages_at_once after the while-loop.  As a result of this bug, the exec_buf_state.pages doesn't get updated.

### What's changed
Save the pages_at_once value to pages_read before the loop and update exec_buf_state.pages with pages_read.  With the fix, when paged_read_into_cmddat_q is call with pages larger than the max_trace_buffer_pages_in_cmd_dat_q, the while-loop will now iterate through the remaining pages.

### Checklist
- [x] unit_tests_dispatch - pass
- [x] unit_tests_api - pass
- [x] unit_tests_device - pass
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
    => Exception T3000 fail in main as well due to something else.  Will rebase to latest main as T3000 is passing again.
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes