### PR TITLE
make the metal microbenchmark pipeline green

### DIFF
--- a/.github/workflows/metal-run-microbenchmarks-impl.yaml
+++ b/.github/workflows/metal-run-microbenchmarks-impl.yaml
@@ -23,12 +23,6 @@ jobs:
         test-group: [
           {
             arch: wormhole_b0,
-            runs-on: ["N300", "pipeline-perf", "bare-metal", "in-service"],
-            name: "N300 Moreh ubench",
-            cmd: "./tests/scripts/run_moreh_microbenchmark.sh",
-          },  # Yu Gao
-          {
-            arch: wormhole_b0,
             runs-on: ["arch-wormhole_b0", "pipeline-perf", "config-t3000", "in-service"],
             name: "T3K ubench - Fabric BW",
             cmd: "TT_METAL_CLEAR_L1=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ${TT_METAL_HOME}/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_ubench_at_least_2x2_mesh.yaml",

--- a/tests/tt_metal/microbenchmarks/ethernet/fabric_mux_bandwidth_golden.csv
+++ b/tests/tt_metal/microbenchmarks/ethernet/fabric_mux_bandwidth_golden.csv
@@ -5,7 +5,7 @@ full_size_channels,4,0,8,0,10000,4096,1,32,15.3842
 full_size_channels,8,0,8,0,10000,4096,1,32,15.2765
 full_size_channel_packet_size,8,0,8,0,10000,16,1,32,0.24635
 full_size_channel_packet_size,8,0,8,0,10000,1024,1,32,5.58161
-full_size_channel_packet_size,8,0,8,0,10000,2048,1,32,10.0571
+full_size_channel_packet_size,8,0,8,0,10000,2048,1,32,10.2622
 full_size_channel_packet_size,8,0,8,0,10000,4096,1,32,15.2756
 full_size_channel_buffers,8,0,1,0,10000,4096,1,32,15.9066
 full_size_channel_buffers,8,0,2,0,10000,4096,1,32,15.0639


### PR DESCRIPTION
- Update (raise) mux perf target
- Delete stale job

### Checklist
- [x] Metal Microbenchmark: https://github.com/tenstorrent/tt-metal/actions/runs/19086389620