### PR TITLE
Refactor rtoptions: Centralize environment variable handling

### DIFF
--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -47,7 +47,7 @@ std::string normalize_path(const char* path, const std::string& subdir = "") {
 }
 
 // Helper function to check if environment variable value is "1" (enabled)
-inline bool is_env_enabled(const char* value) { return value && value[0] == '1'; }
+bool is_env_enabled(const char* value) { return value && value[0] == '1'; }
 }  // namespace
 
 RunTimeOptions::RunTimeOptions() :

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -68,10 +68,6 @@ RunTimeOptions::RunTimeOptions() :
 
     // ENV Can Override
     const char* root_dir_str = std::getenv(TT_METAL_RUNTIME_ROOT_ENV_VAR);
-    if (root_dir_str == nullptr) {
-        // Fallback to TT_METAL_HOME for backwards compatibility
-        root_dir_str = std::getenv("TT_METAL_HOME");
-    }
     if (root_dir_str != nullptr) {
         this->root_dir = std::string(root_dir_str);
         log_debug(tt::LogMetal, "ENV override root_dir: {}", this->root_dir);
@@ -95,7 +91,7 @@ RunTimeOptions::RunTimeOptions() :
             "Failed to determine TT-Metal root directory. "
             "Root directory must be set via one of the following methods:\n"
             "1. Automatically determined when using a package install\n"
-            "2. Set TT_METAL_RUNTIME_ROOT (or TT_METAL_HOME) environment variable to the path containing tt_metal/\n"
+            "2. Set TT_METAL_RUNTIME_ROOT environment variable to the path containing tt_metal/\n"
             "3. Call RunTimeOptions::set_root_dir() API before creating RunTimeOptions\n"
             "4. Run from the root of the repository\n"
             "Current working directory: {}",

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -182,7 +182,8 @@ RunTimeOptions::RunTimeOptions() :
     profiler_sync_enabled(false),
     profiler_mid_run_dump(false),
     profiler_trace_profiler(false),
-    profiler_buffer_usage_enabled(false) {
+    profiler_buffer_usage_enabled(false),
+    watcher_disabled_features() {
 // Default assume package install path
 #ifdef TT_METAL_INSTALL_ROOT
     if (std::filesystem::is_directory(std::filesystem::path(TT_METAL_INSTALL_ROOT))) {

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -182,8 +182,7 @@ RunTimeOptions::RunTimeOptions() :
     profiler_sync_enabled(false),
     profiler_mid_run_dump(false),
     profiler_trace_profiler(false),
-    profiler_buffer_usage_enabled(false),
-    watcher_disabled_features() {
+    profiler_buffer_usage_enabled(false) {
 // Default assume package install path
 #ifdef TT_METAL_INSTALL_ROOT
     if (std::filesystem::is_directory(std::filesystem::path(TT_METAL_INSTALL_ROOT))) {

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -33,6 +33,131 @@ const char* RunTimeDebugFeatureNames[RunTimeDebugFeatureCount] = {
 
 const char* RunTimeDebugClassNames[RunTimeDebugClassCount] = {"N/A", "worker", "dispatch", "all"};
 
+// ============================================================================
+// ENVIRONMENT VARIABLE IDs
+// ============================================================================
+// Full definition of EnvVarID enum (forward-declared in rtoptions.hpp)
+enum class EnvVarID {
+    // ========================================
+    // PATH CONFIGURATION
+    // ========================================
+
+    TT_METAL_CACHE,                           // Cache directory for compiled kernels
+    TT_METAL_KERNEL_PATH,                     // Path to kernel source files
+    TT_METAL_SIMULATOR,                       // Path to simulator executable
+    TT_METAL_MOCK_CLUSTER_DESC_PATH,          // Mock cluster descriptor path
+    TT_METAL_VISIBLE_DEVICES,                 // Comma-separated list of visible device IDs
+    ARCH_NAME,                                // Architecture name (simulation mode)
+    TT_MESH_GRAPH_DESC_PATH,                  // Custom fabric mesh graph descriptor
+    TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE,  // Core grid override
+
+    // ========================================
+    // KERNEL EXECUTION CONTROL
+    // ========================================
+    TT_METAL_NULL_KERNELS,          // Skip kernel execution (testing)
+    TT_METAL_KERNELS_EARLY_RETURN,  // Kernels return early
+
+    // ========================================
+    // MEMORY INITIALIZATION
+    // ========================================
+    TT_METAL_CLEAR_L1,    // Clear L1 memory on device init
+    TT_METAL_CLEAR_DRAM,  // Clear DRAM on device init
+
+    // ========================================
+    // DEBUG & TESTING
+    // ========================================
+    TT_METAL_WATCHER_TEST_MODE,          // Enable watcher test mode
+    TT_METAL_KERNEL_MAP,                 // Enable kernel build mapping
+    TT_METAL_DISPATCH_DATA_COLLECTION,   // Enable dispatch debug data collection
+    TT_METAL_GTEST_ETH_DISPATCH,         // Use Ethernet cores for dispatch in tests
+    TT_METAL_SKIP_LOADING_FW,            // Skip firmware loading
+    TT_METAL_SKIP_DELETING_BUILT_CACHE,  // Skip cache deletion on cleanup
+
+    // ========================================
+    // HARDWARE CONFIGURATION
+    // ========================================
+    TT_METAL_ENABLE_HW_CACHE_INVALIDATION,  // Enable HW cache invalidation
+    TT_METAL_DISABLE_RELAXED_MEM_ORDERING,  // Disable relaxed memory ordering
+    TT_METAL_ENABLE_GATHERING,              // Enable instruction gathering
+    TT_METAL_FABRIC_TELEMETRY,              // Enable fabric telemetry
+    TT_FABRIC_PROFILE_RX_CH_FWD,            // Enable fabric RX channel forwarding profiling
+    TT_METAL_FORCE_REINIT,                  // Force context reinitialization
+    TT_METAL_FABRIC_BLACKHOLE_TWO_ERISC,    // Enable 2-ERISC mode with fabric
+    TT_METAL_LOG_KERNELS_COMPILE_COMMANDS,  // Log kernel compilation commands
+    TT_METAL_SLOW_DISPATCH_MODE,            // Use slow dispatch mode
+    TT_METAL_SKIP_ETH_CORES_WITH_RETRAIN,   // Skip Ethernet cores during retrain
+    TT_METAL_VALIDATE_PROGRAM_BINARIES,     // Validate kernel binary integrity
+    TT_METAL_DISABLE_DMA_OPS,               // Disable DMA operations
+    TT_METAL_ENABLE_ERISC_IRAM,             // Enable ERISC IRAM (inverted logic)
+    RELIABILITY_MODE,                       // Fabric reliability mode (strict/relaxed)
+    TT_METAL_MULTI_AERISC,                  // Enable experimental multi-erisc mode
+    TT_METAL_USE_MGD_1_0,                   // Use mesh graph descriptor 1.0
+    TT_METAL_USE_MGD_2_0,                   // Use mesh graph descriptor 2.0
+    TT_METAL_FORCE_JIT_COMPILE,             // Force JIT compilation
+
+    // ========================================
+    // PROFILING & PERFORMANCE
+    // ========================================
+    TT_METAL_DEVICE_PROFILER,                      // Enable device profiling
+    TT_METAL_DEVICE_PROFILER_DISPATCH,             // Enable dispatch core profiling
+    TT_METAL_PROFILER_SYNC,                        // Enable synchronous profiling
+    TT_METAL_DEVICE_PROFILER_NOC_EVENTS,           // Enable NoC events profiling
+    TT_METAL_DEVICE_PROFILER_NOC_EVENTS_RPT_PATH,  // NoC events report path
+    TT_METAL_MEM_PROFILER,                         // Enable memory/buffer profiling
+    TT_METAL_TRACE_PROFILER,                       // Enable trace profiling
+    TT_METAL_PROFILER_TRACE_TRACKING,              // Enable trace tracking
+    TT_METAL_PROFILER_MID_RUN_DUMP,                // Force mid-run profiler dumps
+    TT_METAL_PROFILER_CPP_POST_PROCESS,            // Enable C++ post-processing for profiler
+    TT_METAL_TRACY_MID_RUN_PUSH,                   // Force Tracy mid-run pushes
+    TT_METAL_GTEST_NUM_HW_CQS,                     // Number of HW command queues in tests
+    TT_METAL_ARC_DEBUG_BUFFER_SIZE,                // ARC processor debug buffer size
+    TT_METAL_OPERATION_TIMEOUT_SECONDS,            // Operation timeout duration
+
+    // ========================================
+    // WATCHER SYSTEM
+    // ========================================
+    TT_METAL_WATCHER,                                         // Enable watcher system
+    TT_METAL_WATCHER_DUMP_ALL,                                // Dump all watcher data
+    TT_METAL_WATCHER_APPEND,                                  // Append mode for watcher output
+    TT_METAL_WATCHER_NOINLINE,                                // Disable watcher function inlining
+    TT_METAL_WATCHER_PHYS_COORDS,                             // Use physical coordinates in watcher
+    TT_METAL_WATCHER_TEXT_START,                              // Include text start info in watcher
+    TT_METAL_WATCHER_SKIP_LOGGING,                            // Disable watcher logging
+    TT_METAL_WATCHER_DISABLE_ASSERT,                          // Disable watcher assert feature
+    TT_METAL_WATCHER_DISABLE_PAUSE,                           // Disable watcher pause feature
+    TT_METAL_WATCHER_DISABLE_RING_BUFFER,                     // Disable watcher ring buffer
+    TT_METAL_WATCHER_DISABLE_STACK_USAGE,                     // Disable watcher stack usage tracking
+    TT_METAL_WATCHER_DISABLE_SANITIZE_NOC,                    // Disable watcher NoC sanitization
+    TT_METAL_WATCHER_DISABLE_SANITIZE_READ_ONLY_L1,           // Disable read-only L1 sanitization
+    TT_METAL_WATCHER_DISABLE_SANITIZE_WRITE_ONLY_L1,          // Disable write-only L1 sanitization
+    TT_METAL_WATCHER_DISABLE_WAYPOINT,                        // Disable watcher waypoint feature
+    TT_METAL_WATCHER_DISABLE_DISPATCH,                        // Disable watcher dispatch feature
+    TT_METAL_WATCHER_ENABLE_NOC_SANITIZE_LINKED_TRANSACTION,  // Enable NoC linked transaction sanitization
+
+    // ========================================
+    // INSPECTOR
+    // ========================================
+    TT_METAL_INSPECTOR,                              // Enable/disable inspector
+    TT_METAL_INSPECTOR_LOG_PATH,                     // Inspector log output path
+    TT_METAL_INSPECTOR_INITIALIZATION_IS_IMPORTANT,  // Track initialization closely
+    TT_METAL_INSPECTOR_WARN_ON_WRITE_EXCEPTIONS,     // Warn on write exceptions
+    TT_METAL_RISCV_DEBUG_INFO,                       // Enable RISC-V debug info
+    TT_METAL_INSPECTOR_RPC_SERVER_ADDRESS,           // Inspector RPC server address (host:port)
+    TT_METAL_INSPECTOR_RPC,                          // Enable/disable inspector RPC server
+
+    // ========================================
+    // DEBUG PRINTING (DPRINT)
+    // ========================================
+    TT_METAL_DPRINT_CORES,                     // Worker cores for debug printing
+    TT_METAL_DPRINT_ETH_CORES,                 // Ethernet cores for debug printing
+    TT_METAL_DPRINT_CHIPS,                     // Chip IDs for debug printing
+    TT_METAL_DPRINT_RISCVS,                    // RISC-V processors for debug printing
+    TT_METAL_DPRINT_FILE,                      // Debug print output file
+    TT_METAL_DPRINT_ONE_FILE_PER_RISC,         // Separate file per RISC-V processor
+    TT_METAL_DPRINT_PREPEND_DEVICE_CORE_RISC,  // Prepend device/core/RISC info
+
+};
+
 // Environment variable name for TT-Metal root directory
 constexpr auto TT_METAL_RUNTIME_ROOT_ENV_VAR = "TT_METAL_RUNTIME_ROOT";
 
@@ -149,6 +274,10 @@ const std::string& RunTimeOptions::get_system_kernel_dir() const { return this->
 // ============================================================================
 // Central handler that processes environment variables based on their ID
 // Uses switch statement for efficient dispatch
+//
+// IMPORTANT: Most cases assume 'value' is non-null (enforced by InitializeFromEnvVars loop guard).
+// Only TT_METAL_INSPECTOR_LOG_PATH and TT_METAL_RISCV_DEBUG_INFO explicitly handle nullptr
+// for default value initialization.
 
 void RunTimeOptions::HandleEnvVar(EnvVarID id, const char* value) {
     switch (id) {
@@ -336,42 +465,42 @@ void RunTimeOptions::HandleEnvVar(EnvVarID id, const char* value) {
         // Sets the fabric reliability mode (STRICT, RELAXED, or DYNAMIC).
         // Default: nullopt (uses system default)
         // Usage: export RELIABILITY_MODE=STRICT (or strict/0), RELAXED (or relaxed/1), DYNAMIC (or dynamic/2)
-        case EnvVarID::RELIABILITY_MODE:
-            if (value) {
-                std::string mode_str(value);
-                // Convert to lowercase for case-insensitive comparison
-                std::transform(mode_str.begin(), mode_str.end(), mode_str.begin(), [](unsigned char c) {
-                    return std::tolower(c);
-                });
-                if (mode_str == "strict" || mode_str == "0") {
-                    this->reliability_mode = tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE;
-                } else if (mode_str == "relaxed" || mode_str == "1") {
-                    this->reliability_mode = tt::tt_fabric::FabricReliabilityMode::RELAXED_SYSTEM_HEALTH_SETUP_MODE;
-                } else if (mode_str == "dynamic" || mode_str == "2") {
-                    this->reliability_mode = tt::tt_fabric::FabricReliabilityMode::DYNAMIC_RECONFIGURATION_SETUP_MODE;
-                }
+        case EnvVarID::RELIABILITY_MODE: {
+            std::string mode_str(value);
+            // Convert to lowercase for case-insensitive comparison
+            std::transform(
+                mode_str.begin(), mode_str.end(), mode_str.begin(), [](unsigned char c) { return std::tolower(c); });
+            if (mode_str == "strict" || mode_str == "0") {
+                this->reliability_mode = tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE;
+            } else if (mode_str == "relaxed" || mode_str == "1") {
+                this->reliability_mode = tt::tt_fabric::FabricReliabilityMode::RELAXED_SYSTEM_HEALTH_SETUP_MODE;
+            } else if (mode_str == "dynamic" || mode_str == "2") {
+                this->reliability_mode = tt::tt_fabric::FabricReliabilityMode::DYNAMIC_RECONFIGURATION_SETUP_MODE;
             }
             break;
+        }
 
         // TT_METAL_MULTI_AERISC
         // Experimental multi-ERISC mode flag that enables 2-ERISC mode.
         // Default: false (single ERISC mode)
         // Usage: export TT_METAL_MULTI_AERISC=1
         case EnvVarID::TT_METAL_MULTI_AERISC:
-            if (value) {
-                log_info(tt::LogMetal, "Enabling experimental multi-erisc mode");
-                this->enable_2_erisc_mode = true;
-            }
+            log_info(tt::LogMetal, "Enabling experimental multi-erisc mode");
+            this->enable_2_erisc_mode = true;
             break;
+
+        // TT_METAL_USE_MGD_1_0
+        // Enables use of Mesh Graph Descriptor 1.0 format (deprecated, will be removed).
+        // Default: false
+        // Usage: export TT_METAL_USE_MGD_1_0=1
+        case EnvVarID::TT_METAL_USE_MGD_1_0: this->use_mesh_graph_descriptor_1_0 = true; break;
 
         // TT_METAL_USE_MGD_2_0
         // Enables use of Mesh Graph Descriptor 2.0 format for fabric configuration.
-        // Default: false
+        // Default: false (uses MGD 1.0)
         // Usage: export TT_METAL_USE_MGD_2_0=1
         case EnvVarID::TT_METAL_USE_MGD_2_0:
-            if (value) {
-                this->use_mesh_graph_descriptor_2_0 = (std::strncmp(value, "0", 1) != 0);
-            }
+            this->use_mesh_graph_descriptor_2_0 = (std::strncmp(value, "0", 1) != 0);
             break;
 
         // TT_METAL_FORCE_JIT_COMPILE
@@ -379,11 +508,7 @@ void RunTimeOptions::HandleEnvVar(EnvVarID id, const char* value) {
         // This overrides the dependency tracking optimization.
         // Default: false (uses dependency tracking)
         // Usage: export TT_METAL_FORCE_JIT_COMPILE=1
-        case EnvVarID::TT_METAL_FORCE_JIT_COMPILE:
-            if (value) {
-                this->force_jit_compile = true;
-            }
-            break;
+        case EnvVarID::TT_METAL_FORCE_JIT_COMPILE: this->force_jit_compile = true; break;
 
         // TT_METAL_FORCE_REINIT
         // Force context reinitialization on each run.
@@ -606,17 +731,16 @@ void RunTimeOptions::HandleEnvVar(EnvVarID id, const char* value) {
         // Enables the watcher system for debugging. When set, enables watcher on all features.
         // Default: disabled
         // Usage: export TT_METAL_WATCHER=1
-        case EnvVarID::TT_METAL_WATCHER:
-            if (value) {
-                int sleep_val = 0;
-                sscanf(value, "%d", &sleep_val);
-                if (strstr(value, "ms") == nullptr) {
-                    sleep_val *= 1000;
-                }
-                this->watcher_settings.enabled = true;
-                this->watcher_settings.interval_ms = sleep_val;
+        case EnvVarID::TT_METAL_WATCHER: {
+            int sleep_val = 0;
+            sscanf(value, "%d", &sleep_val);
+            if (strstr(value, "ms") == nullptr) {
+                sleep_val *= 1000;
             }
+            this->watcher_settings.enabled = true;
+            this->watcher_settings.interval_ms = sleep_val;
             break;
+        }
 
         // TT_METAL_WATCHER_DUMP_ALL
         // Enables dumping all watcher data, including potentially unsafe state information.
@@ -743,11 +867,9 @@ void RunTimeOptions::HandleEnvVar(EnvVarID id, const char* value) {
         // Default: true (enabled)
         // Usage: export TT_METAL_INSPECTOR=1
         case EnvVarID::TT_METAL_INSPECTOR:
-            if (value) {
-                this->inspector_settings.enabled = true;
-                if (strcmp(value, "0") == 0) {
-                    this->inspector_settings.enabled = false;
-                }
+            this->inspector_settings.enabled = true;
+            if (strcmp(value, "0") == 0) {
+                this->inspector_settings.enabled = false;
             }
             break;
 
@@ -768,11 +890,9 @@ void RunTimeOptions::HandleEnvVar(EnvVarID id, const char* value) {
         // Default: false (not important)
         // Usage: export TT_METAL_INSPECTOR_INITIALIZATION_IS_IMPORTANT=1
         case EnvVarID::TT_METAL_INSPECTOR_INITIALIZATION_IS_IMPORTANT:
-            if (value) {
-                this->inspector_settings.initialization_is_important = true;
-                if (strcmp(value, "0") == 0) {
-                    this->inspector_settings.initialization_is_important = false;
-                }
+            this->inspector_settings.initialization_is_important = true;
+            if (strcmp(value, "0") == 0) {
+                this->inspector_settings.initialization_is_important = false;
             }
             break;
 
@@ -781,11 +901,9 @@ void RunTimeOptions::HandleEnvVar(EnvVarID id, const char* value) {
         // Default: true (warnings enabled)
         // Usage: export TT_METAL_INSPECTOR_WARN_ON_WRITE_EXCEPTIONS=0
         case EnvVarID::TT_METAL_INSPECTOR_WARN_ON_WRITE_EXCEPTIONS:
-            if (value) {
-                this->inspector_settings.warn_on_write_exceptions = true;
-                if (strcmp(value, "0") == 0) {
-                    this->inspector_settings.warn_on_write_exceptions = false;
-                }
+            this->inspector_settings.warn_on_write_exceptions = true;
+            if (strcmp(value, "0") == 0) {
+                this->inspector_settings.warn_on_write_exceptions = false;
             }
             break;
 
@@ -809,36 +927,33 @@ void RunTimeOptions::HandleEnvVar(EnvVarID id, const char* value) {
         // Sets the RPC server address for the inspector. Format: "host:port" or just "host" (uses default port).
         // Default: localhost:50051
         // Usage: export TT_METAL_INSPECTOR_RPC_SERVER_ADDRESS=127.0.0.1:8080
-        case EnvVarID::TT_METAL_INSPECTOR_RPC_SERVER_ADDRESS:
-            if (value) {
-                // Parse address into host and port
-                std::string addr(value);
-                size_t colon_pos = addr.find(':');
-                if (colon_pos != std::string::npos) {
-                    this->inspector_settings.rpc_server_host = addr.substr(0, colon_pos);
-                    try {
-                        this->inspector_settings.rpc_server_port = std::stoi(addr.substr(colon_pos + 1));
-                    } catch (const std::invalid_argument&) {
-                        TT_THROW("Invalid port in TT_METAL_INSPECTOR_RPC_SERVER_ADDRESS: {}", value);
-                    } catch (const std::out_of_range&) {
-                        TT_THROW("Port out of range in TT_METAL_INSPECTOR_RPC_SERVER_ADDRESS: {}", value);
-                    }
-                } else {
-                    this->inspector_settings.rpc_server_host = addr;
+        case EnvVarID::TT_METAL_INSPECTOR_RPC_SERVER_ADDRESS: {
+            // Parse address into host and port
+            std::string addr(value);
+            size_t colon_pos = addr.find(':');
+            if (colon_pos != std::string::npos) {
+                this->inspector_settings.rpc_server_host = addr.substr(0, colon_pos);
+                try {
+                    this->inspector_settings.rpc_server_port = std::stoi(addr.substr(colon_pos + 1));
+                } catch (const std::invalid_argument&) {
+                    TT_THROW("Invalid port in TT_METAL_INSPECTOR_RPC_SERVER_ADDRESS: {}", value);
+                } catch (const std::out_of_range&) {
+                    TT_THROW("Port out of range in TT_METAL_INSPECTOR_RPC_SERVER_ADDRESS: {}", value);
                 }
+            } else {
+                this->inspector_settings.rpc_server_host = addr;
             }
             break;
+        }
 
         // TT_METAL_INSPECTOR_RPC
         // Enables or disables the inspector RPC server. Set to '0' to disable, any other value enables it.
         // Default: true (enabled)
         // Usage: export TT_METAL_INSPECTOR_RPC=1
         case EnvVarID::TT_METAL_INSPECTOR_RPC:
-            if (value) {
-                this->inspector_settings.rpc_server_enabled = true;
-                if (std::strncmp(value, "0", 1) == 0) {
-                    this->inspector_settings.rpc_server_enabled = false;
-                }
+            this->inspector_settings.rpc_server_enabled = true;
+            if (std::strncmp(value, "0", 1) == 0) {
+                this->inspector_settings.rpc_server_enabled = false;
             }
             break;
 
@@ -909,7 +1024,7 @@ void RunTimeOptions::HandleEnvVar(EnvVarID id, const char* value) {
 void RunTimeOptions::InitializeFromEnvVars() {
     // Use enchantum to automatically iterate over all EnvVarID enum values
     for (const auto [id, name] : enchantum::entries_generator<EnvVarID>) {
-        const char* value = std::getenv(std::string(name).c_str());
+        const char* value = std::getenv(name.data());
 
         // Only process if the environment variable is set
         if (value) {

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -374,6 +374,17 @@ void RunTimeOptions::HandleEnvVar(EnvVarID id, const char* value) {
             }
             break;
 
+        // TT_METAL_FORCE_JIT_COMPILE
+        // Force JIT compilation even if dependencies are up-to-date.
+        // This overrides the dependency tracking optimization.
+        // Default: false (uses dependency tracking)
+        // Usage: export TT_METAL_FORCE_JIT_COMPILE=1
+        case EnvVarID::TT_METAL_FORCE_JIT_COMPILE:
+            if (value) {
+                this->force_jit_compile = true;
+            }
+            break;
+
         // TT_METAL_FORCE_REINIT
         // Force context reinitialization on each run.
         // Default: false (normal initialization)

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -4,6 +4,7 @@
 
 #include "rtoptions.hpp"
 
+#include <algorithm>
 #include <ctype.h>
 #include <stdio.h>
 #include <cstdlib>
@@ -11,9 +12,9 @@
 #include <filesystem>
 #include <stdexcept>
 #include <string>
-
+#include <enchantum/enchantum.hpp>
+#include "tt_stl/assert.hpp"
 #include <tt-logger/tt-logger.hpp>
-#include <tt_stl/assert.hpp>
 #include <umd/device/types/core_coordinates.hpp>
 
 using std::vector;
@@ -32,15 +33,32 @@ const char* RunTimeDebugFeatureNames[RunTimeDebugFeatureCount] = {
 
 const char* RunTimeDebugClassNames[RunTimeDebugClassCount] = {"N/A", "worker", "dispatch", "all"};
 
-constexpr auto TT_METAL_RUNTIME_ROOT_ENV_VAR = "TT_METAL_RUNTIME_ROOT";
-constexpr auto TT_METAL_KERNEL_PATH_ENV_VAR = "TT_METAL_KERNEL_PATH";
-// Set this var to change the cache dir.
-constexpr auto TT_METAL_CACHE_ENV_VAR = "TT_METAL_CACHE";
 // Used for demonstration purposes and will be removed in the future.
 // Env variable to override the core grid configuration
 constexpr auto TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE_ENV_VAR = "TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE";
 
-RunTimeOptions::RunTimeOptions() {
+// Environment variable name for TT-Metal root directory
+constexpr auto TT_METAL_RUNTIME_ROOT_ENV_VAR = "TT_METAL_RUNTIME_ROOT";
+
+namespace {
+// Helper function to normalize directory paths using std::filesystem
+std::string normalize_path(const char* path, const std::string& subdir = "") {
+    std::filesystem::path p(path);
+    if (!subdir.empty()) {
+        p /= subdir;
+    }
+    return p.lexically_normal().string();
+}
+}  // namespace
+
+RunTimeOptions::RunTimeOptions() :
+    system_kernel_dir("/usr/share/tenstorrent/kernels/"),
+    profiler_enabled(false),
+    profile_dispatch_cores(false),
+    profiler_sync_enabled(false),
+    profiler_mid_run_dump(false),
+    profiler_trace_profiler(false),
+    profiler_buffer_usage_enabled(false) {
 // Default assume package install path
 #ifdef TT_METAL_INSTALL_ROOT
     if (std::filesystem::is_directory(std::filesystem::path(TT_METAL_INSTALL_ROOT))) {
@@ -51,6 +69,10 @@ RunTimeOptions::RunTimeOptions() {
 
     // ENV Can Override
     const char* root_dir_str = std::getenv(TT_METAL_RUNTIME_ROOT_ENV_VAR);
+    if (root_dir_str == nullptr) {
+        // Fallback to TT_METAL_HOME for backwards compatibility
+        root_dir_str = std::getenv("TT_METAL_HOME");
+    }
     if (root_dir_str != nullptr) {
         this->root_dir = std::string(root_dir_str);
         log_debug(tt::LogMetal, "ENV override root_dir: {}", this->root_dir);
@@ -74,7 +96,7 @@ RunTimeOptions::RunTimeOptions() {
             "Failed to determine TT-Metal root directory. "
             "Root directory must be set via one of the following methods:\n"
             "1. Automatically determined when using a package install\n"
-            "2. Set TT_METAL_RUNTIME_ROOT environment variable to the path containing tt_metal/\n"
+            "2. Set TT_METAL_RUNTIME_ROOT (or TT_METAL_HOME) environment variable to the path containing tt_metal/\n"
             "3. Call RunTimeOptions::set_root_dir() API before creating RunTimeOptions\n"
             "4. Run from the root of the repository\n"
             "Current working directory: {}",
@@ -89,261 +111,11 @@ RunTimeOptions::RunTimeOptions() {
         this->root_dir = p.string();
     }
 
-    // Check if user has specified a cache path.
-    const char* cache_dir_str = std::getenv(TT_METAL_CACHE_ENV_VAR);
-    if (cache_dir_str != nullptr) {
-        this->is_cache_dir_env_var_set = true;
-        this->cache_dir_ = std::string(cache_dir_str) + "/tt-metal-cache/";
-    }
+    InitializeFromEnvVars();
 
-    const char* kernel_dir_str = std::getenv(TT_METAL_KERNEL_PATH_ENV_VAR);
-    if (kernel_dir_str != nullptr) {
-        this->is_kernel_dir_env_var_set = true;
-        this->kernel_dir = std::string(kernel_dir_str) + "/";
-    }
-    this->system_kernel_dir = "/usr/share/tenstorrent/kernels/";
-
-    const char* custom_fabric_mesh_graph_desc_path_str = std::getenv("TT_MESH_GRAPH_DESC_PATH");
-    if (custom_fabric_mesh_graph_desc_path_str != nullptr) {
-        this->is_custom_fabric_mesh_graph_desc_path_set = true;
-        this->custom_fabric_mesh_graph_desc_path = std::string(custom_fabric_mesh_graph_desc_path_str);
-    }
-
-    const char* core_grid_override_todeprecate_str = std::getenv(TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE_ENV_VAR);
-    if (core_grid_override_todeprecate_str != nullptr) {
-        this->is_core_grid_override_todeprecate_env_var_set = true;
-        this->core_grid_override_todeprecate = std::string(core_grid_override_todeprecate_str);
-    }
-
-    build_map_enabled = (getenv("TT_METAL_KERNEL_MAP") != nullptr);
-
-    ParseWatcherEnv();
-    ParseInspectorEnv();
-
-    test_mode_enabled = (getenv("TT_METAL_WATCHER_TEST_MODE") != nullptr);
-
-    profiler_enabled = false;
-    profile_dispatch_cores = false;
-    profiler_sync_enabled = false;
-    profiler_mid_run_dump = false;
-    profiler_buffer_usage_enabled = false;
-    profiler_trace_profiler = false;
-    profiler_trace_tracking = false;
-    profiler_cpp_post_process = false;
-
-    const char* profiler_enabled_str = std::getenv("TT_METAL_DEVICE_PROFILER");
-#if defined(TRACY_ENABLE)
-    if (profiler_enabled_str != nullptr && profiler_enabled_str[0] == '1') {
-        profiler_enabled = true;
-        const char* profile_dispatch_str = std::getenv("TT_METAL_DEVICE_PROFILER_DISPATCH");
-        if (profile_dispatch_str != nullptr && profile_dispatch_str[0] == '1') {
-            profile_dispatch_cores = true;
-        }
-        const char* profiler_sync_enabled_str = std::getenv("TT_METAL_PROFILER_SYNC");
-        if (profiler_sync_enabled_str != nullptr && profiler_sync_enabled_str[0] == '1') {
-            profiler_sync_enabled = true;
-        }
-        const char* profiler_trace_profiler_str = std::getenv("TT_METAL_TRACE_PROFILER");
-        if (profiler_trace_profiler_str != nullptr && profiler_trace_profiler_str[0] == '1') {
-            profiler_trace_profiler = true;
-        }
-        const char* profiler_trace_tracking_str = std::getenv("TT_METAL_PROFILER_TRACE_TRACKING");
-        if (profiler_trace_tracking_str != nullptr && profiler_trace_tracking_str[0] == '1') {
-            profiler_trace_tracking = true;
-        }
-        const char* profiler_mid_run_dump_str = std::getenv("TT_METAL_PROFILER_MID_RUN_DUMP");
-        if (profiler_mid_run_dump_str != nullptr && profiler_mid_run_dump_str[0] == '1') {
-            profiler_mid_run_dump = true;
-        }
-        const char* profiler_cpp_post_process_str = std::getenv("TT_METAL_PROFILER_CPP_POST_PROCESS");
-        if (profiler_cpp_post_process_str != nullptr && profiler_cpp_post_process_str[0] == '1') {
-            profiler_cpp_post_process = true;
-        }
-    }
-
-    const char *profiler_noc_events_str = std::getenv("TT_METAL_DEVICE_PROFILER_NOC_EVENTS");
-    if (profiler_noc_events_str != nullptr && profiler_noc_events_str[0] == '1') {
-        profiler_enabled = true;
-        profiler_noc_events_enabled = true;
-    }
-
-    const char *profiler_noc_events_report_path_str = std::getenv("TT_METAL_DEVICE_PROFILER_NOC_EVENTS_RPT_PATH");
-    if (profiler_noc_events_report_path_str != nullptr) {
-        profiler_noc_events_report_path = profiler_noc_events_report_path_str;
-    }
-
-    const char *profile_buffer_usage_str = std::getenv("TT_METAL_MEM_PROFILER");
-    if (profile_buffer_usage_str != nullptr && profile_buffer_usage_str[0] == '1') {
-        profiler_buffer_usage_enabled = true;
-    }
-#else
-    TT_FATAL(
-        !(profiler_enabled_str != nullptr && profiler_enabled_str[0] == '1'),
-        "TT_METAL_DEVICE_PROFILER env var is set to 1. This requires a Tracy-enabled build of tt-metal.");
-#endif
     TT_FATAL(
         !(get_feature_enabled(RunTimeDebugFeatureDprint) && get_profiler_enabled()),
         "Cannot enable both debug printing and profiling");
-
-    null_kernels = (std::getenv("TT_METAL_NULL_KERNELS") != nullptr);
-
-    kernels_early_return = (std::getenv("TT_METAL_KERNELS_EARLY_RETURN") != nullptr);
-
-    this->clear_l1 = false;
-    const char* clear_l1_enabled_str = std::getenv("TT_METAL_CLEAR_L1");
-    if (clear_l1_enabled_str != nullptr && clear_l1_enabled_str[0] == '1') {
-        this->clear_l1 = true;
-    }
-
-    this->clear_dram = false;
-    const char* clear_dram_enabled_str = std::getenv("TT_METAL_CLEAR_DRAM");
-    if (clear_dram_enabled_str != nullptr && clear_dram_enabled_str[0] == '1') {
-        this->clear_dram = true;
-    }
-
-    const char* skip_eth_cores_with_retrain_str = std::getenv("TT_METAL_SKIP_ETH_CORES_WITH_RETRAIN");
-    if (skip_eth_cores_with_retrain_str != nullptr) {
-        if (skip_eth_cores_with_retrain_str[0] == '0') {
-            skip_eth_cores_with_retrain = false;
-        }
-        if (skip_eth_cores_with_retrain_str[0] == '1') {
-            skip_eth_cores_with_retrain = true;
-        }
-    }
-
-    const char* riscv_debug_info_enabled_str = std::getenv("TT_METAL_RISCV_DEBUG_INFO");
-    bool enable_riscv_debug_info = get_inspector_enabled();
-    if (riscv_debug_info_enabled_str != nullptr) {
-        enable_riscv_debug_info = true;
-        if (strcmp(riscv_debug_info_enabled_str, "0") == 0) {
-            enable_riscv_debug_info = false;
-        }
-    }
-    set_riscv_debug_info_enabled(enable_riscv_debug_info);
-
-    const char* validate_kernel_binaries = std::getenv("TT_METAL_VALIDATE_PROGRAM_BINARIES");
-    set_validate_kernel_binaries(validate_kernel_binaries != nullptr && validate_kernel_binaries[0] == '1');
-
-    const char* num_cqs = getenv("TT_METAL_GTEST_NUM_HW_CQS");
-    if (num_cqs != nullptr) {
-        try {
-            set_num_hw_cqs(std::stoi(num_cqs));
-        } catch (const std::invalid_argument& ia) {
-            TT_THROW("Invalid TT_METAL_GTEST_NUM_HW_CQS: {}", num_cqs);
-        }
-    }
-
-    using_slow_dispatch = getenv("TT_METAL_SLOW_DISPATCH_MODE") != nullptr;
-
-    const char* dispatch_data_collection_str = std::getenv("TT_METAL_DISPATCH_DATA_COLLECTION");
-    if (dispatch_data_collection_str != nullptr) {
-        enable_dispatch_data_collection = true;
-    }
-
-    if (getenv("TT_METAL_GTEST_ETH_DISPATCH")) {
-        this->dispatch_core_type = tt_metal::DispatchCoreType::ETH;
-    }
-
-    if (getenv("TT_METAL_SKIP_LOADING_FW")) {
-        this->skip_loading_fw = true;
-    }
-
-    if (getenv("TT_METAL_SKIP_DELETING_BUILT_CACHE")) {
-        this->skip_deleting_built_cache = true;
-    }
-
-    if (getenv("TT_METAL_ENABLE_HW_CACHE_INVALIDATION")) {
-        this->enable_hw_cache_invalidation = true;
-    }
-
-    // Parse RELIABILITY_MODE: "strict" or "relaxed"
-    if (const char* reliability_mode_str = getenv("RELIABILITY_MODE"); reliability_mode_str != nullptr) {
-        std::string mode(reliability_mode_str);
-        if (mode == "relaxed") {
-            reliability_mode = tt::tt_fabric::FabricReliabilityMode::RELAXED_SYSTEM_HEALTH_SETUP_MODE;
-        } else if (mode == "strict") {
-            reliability_mode = tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE;
-        }
-    }
-
-    // Enable mock cluster if TT_METAL_MOCK is set to a descriptor path
-    // This is used for initializing UMD without any hardware using a mock cluster descriptor
-    if (const char* mock_path = std::getenv("TT_METAL_MOCK_CLUSTER_DESC_PATH")) {
-        this->mock_cluster_desc_path = std::string(mock_path);
-        this->runtime_target_device_ = tt::TargetDevice::Mock;
-    }
-
-    // Enable simulator if TT_METAL_SIMULATOR is set to a simulator path
-    // This must be set after the mock cluster path is set to have the correct TargetDevice
-    if (std::getenv("TT_METAL_SIMULATOR")) {
-        this->simulator_path = std::getenv("TT_METAL_SIMULATOR");
-        this->runtime_target_device_ = tt::TargetDevice::Simulator;
-    }
-
-    if (auto str = getenv("TT_METAL_ENABLE_ERISC_IRAM")) {
-        bool disabled = strcmp(str, "0") == 0;
-        this->erisc_iram_enabled = !disabled;
-        this->erisc_iram_enabled_env_var = !disabled;
-    }
-    this->fast_dispatch = (std::getenv("TT_METAL_SLOW_DISPATCH_MODE") == nullptr);
-
-    if (getenv("TT_METAL_DISABLE_RELAXED_MEM_ORDERING")) {
-        this->disable_relaxed_memory_ordering = true;
-    }
-
-    if (getenv("TT_METAL_ENABLE_GATHERING")) {
-        this->enable_gathering = true;
-    }
-
-    const char* arc_debug_enabled_str = std::getenv("TT_METAL_ARC_DEBUG_BUFFER_SIZE");
-    if (arc_debug_enabled_str != nullptr) {
-        sscanf(arc_debug_enabled_str, "%u", &arc_debug_buffer_size);
-    }
-
-    const char* disable_dma_ops_str = std::getenv("TT_METAL_DISABLE_DMA_OPS");
-    if (disable_dma_ops_str != nullptr) {
-        if (disable_dma_ops_str[0] == '1') {
-            this->disable_dma_ops = true;
-        }
-    }
-
-    if (getenv("TT_METAL_FABRIC_TELEMETRY")) {
-        enable_fabric_telemetry = true;
-    }
-
-    if (getenv("TT_FABRIC_PROFILE_RX_CH_FWD")) {
-        fabric_profiling_settings.enable_rx_ch_fwd = true;
-    }
-
-    if (getenv("TT_METAL_FORCE_REINIT")) {
-        force_context_reinit = true;
-    }
-
-    if (getenv("TT_METAL_FABRIC_BLACKHOLE_TWO_ERISC")) {
-        this->enable_2_erisc_mode_with_fabric = true;
-    }
-
-    if (getenv("TT_METAL_DISABLE_MULTI_AERISC")) {
-        log_info(tt::LogMetal, "Disabling multi-erisc mode with TT_METAL_DISABLE_MULTI_AERISC");
-        this->enable_2_erisc_mode = false;
-    }
-    if (this->runtime_target_device_ != tt::TargetDevice::Silicon) {
-        log_info(tt::LogMetal, "Disabling multi-erisc mode with simulator/mock target device");
-        this->enable_2_erisc_mode = false;
-    }
-
-    if (getenv("TT_METAL_LOG_KERNELS_COMPILE_COMMANDS")) {
-        this->log_kernels_compilation_commands = true;
-    }
-
-    if (getenv("TT_METAL_FORCE_JIT_COMPILE")) {
-        this->force_jit_compile = true;
-    }
-
-    const char* timeout_duration_for_operations_value = std::getenv("TT_METAL_OPERATION_TIMEOUT_SECONDS");
-    float timeout_duration_for_operations =
-        timeout_duration_for_operations_value ? std::stof(timeout_duration_for_operations_value) : 0.f;
-    this->timeout_duration_for_operations = std::chrono::duration<float>(timeout_duration_for_operations);
 }
 
 void RunTimeOptions::set_root_dir(const std::string& root_dir) {
@@ -354,14 +126,14 @@ const std::string& RunTimeOptions::get_root_dir() const { return root_dir; }
 
 const std::string& RunTimeOptions::get_cache_dir() const {
     if (!this->is_cache_dir_specified()) {
-        TT_THROW("Env var {} is not set.", TT_METAL_CACHE_ENV_VAR);
+        TT_THROW("Env var {} is not set.", "TT_METAL_CACHE");
     }
     return this->cache_dir_;
 }
 
 const std::string& RunTimeOptions::get_kernel_dir() const {
     if (!this->is_kernel_dir_specified()) {
-        TT_THROW("Env var {} is not set.", TT_METAL_KERNEL_PATH_ENV_VAR);
+        TT_THROW("Env var {} is not set.", "TT_METAL_KERNEL_PATH");
     }
 
     return this->kernel_dir;
@@ -377,26 +149,782 @@ const std::string& RunTimeOptions::get_core_grid_override_todeprecate() const {
 
 const std::string& RunTimeOptions::get_system_kernel_dir() const { return this->system_kernel_dir; }
 
-void RunTimeOptions::ParseWatcherEnv() {
-    const char* watcher_enable_str = getenv("TT_METAL_WATCHER");
-    if (watcher_enable_str != nullptr) {
-        int sleep_val = 0;
-        sscanf(watcher_enable_str, "%d", &sleep_val);
-        if (strstr(watcher_enable_str, "ms") == nullptr) {
-            sleep_val *= 1000;
+// ============================================================================
+// ENVIRONMENT VARIABLE HANDLER
+// ============================================================================
+// Central handler that processes environment variables based on their ID
+// Uses switch statement for efficient dispatch
+
+void RunTimeOptions::HandleEnvVar(EnvVarID id, const char* value) {
+    switch (id) {
+        // ========================================
+        // PATH CONFIGURATION
+        // ========================================
+
+        // TT_METAL_CACHE
+        // Directory for caching compiled kernels and other build artifacts.
+        // Default: Defaults to system temp directory if not set
+        // Usage: export TT_METAL_CACHE=/path/to/cache
+        case EnvVarID::TT_METAL_CACHE:
+            this->is_cache_dir_env_var_set = true;
+            this->cache_dir_ = normalize_path(value, "tt-metal-cache");
+            break;
+
+        // TT_METAL_KERNEL_PATH
+        // Path to kernel source files.
+        // Default: Uses TT_METAL_RUNTIME_ROOT/tt_metal/kernels if not set
+        // Usage: export TT_METAL_KERNEL_PATH=/path/to/kernels
+        case EnvVarID::TT_METAL_KERNEL_PATH:
+            this->is_kernel_dir_env_var_set = true;
+            this->kernel_dir = normalize_path(value) + "/";
+            break;
+
+        // TT_METAL_SIMULATOR
+        // Path to simulator executable. When set, overrides mock cluster mode if both are set.
+        // Default: Hardware mode (no simulator)
+        // Usage: export TT_METAL_SIMULATOR=/path/to/simulator
+        case EnvVarID::TT_METAL_SIMULATOR:
+            this->simulator_path = std::string(value);
+            // Simulator takes precedence over Mock (will be set even if Mock was set first)
+            this->runtime_target_device_ = tt::TargetDevice::Simulator;
+            break;
+
+        // TT_METAL_MOCK_CLUSTER_DESC_PATH
+        // Path to mock cluster descriptor for testing without hardware.
+        // Note: If both MOCK and SIMULATOR are set, SIMULATOR takes precedence
+        // Default: Hardware mode (no mock cluster)
+        // Usage: export TT_METAL_MOCK_CLUSTER_DESC_PATH=/path/to/mock_cluster_desc.yaml
+        case EnvVarID::TT_METAL_MOCK_CLUSTER_DESC_PATH:
+            this->mock_cluster_desc_path = std::string(value);
+            // Only set Mock target if Simulator hasn't been set already
+            if (this->simulator_path.empty()) {
+                this->runtime_target_device_ = tt::TargetDevice::Mock;
+            }
+            break;
+
+        // TT_METAL_VISIBLE_DEVICES
+        // Comma-separated list of device IDs to make visible to the runtime.
+        // Default: All devices visible
+        // Usage: export TT_METAL_VISIBLE_DEVICES=0,1,2
+        case EnvVarID::TT_METAL_VISIBLE_DEVICES: this->visible_devices = std::string(value); break;
+
+        // ARCH_NAME
+        // Sets the architecture name (only necessary during simulation).
+        // Default: Hardware-detected architecture
+        // Usage: export ARCH_NAME=wormhole_b0
+        case EnvVarID::ARCH_NAME: this->arch_name = std::string(value); break;
+
+        // TT_MESH_GRAPH_DESC_PATH
+        // Custom fabric mesh graph descriptor path.
+        // Default: Default fabric mesh configuration
+        // Usage: export TT_MESH_GRAPH_DESC_PATH=/path/to/mesh_desc.yaml
+        case EnvVarID::TT_MESH_GRAPH_DESC_PATH:
+            this->is_custom_fabric_mesh_graph_desc_path_set = true;
+            this->custom_fabric_mesh_graph_desc_path = std::string(value);
+            break;
+
+        // TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE
+        // Override core grid configuration (this is meant to be deprecated).
+        // Default: Hardware-detected core grid
+        // Usage: export TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE=custom_grid
+        case EnvVarID::TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE:
+            this->is_core_grid_override_todeprecate_env_var_set = true;
+            this->core_grid_override_todeprecate = std::string(value);
+            break;
+
+        // ========================================
+        // KERNEL EXECUTION CONTROL
+        // ========================================
+
+        // TT_METAL_NULL_KERNELS
+        // Skip actual kernel execution, useful for testing dispatch logic without running kernels.
+        // Default: false (kernels execute normally)
+        // Usage: export TT_METAL_NULL_KERNELS=1
+        case EnvVarID::TT_METAL_NULL_KERNELS: this->null_kernels = true; break;
+
+        // TT_METAL_KERNELS_EARLY_RETURN
+        // Kernels return early, skipping execution but maintaining same size as normal.
+        // Default: false (kernels execute fully)
+        // Usage: export TT_METAL_KERNELS_EARLY_RETURN=1
+        case EnvVarID::TT_METAL_KERNELS_EARLY_RETURN: this->kernels_early_return = true; break;
+
+        // ========================================
+        // MEMORY INITIALIZATION
+        // ========================================
+
+        // TT_METAL_CLEAR_L1
+        // Clear L1 memory on device initialization.
+        // Default: 0 (don't clear)
+        // Usage: export TT_METAL_CLEAR_L1=1
+        case EnvVarID::TT_METAL_CLEAR_L1: this->clear_l1 = (value[0] == '1'); break;
+
+        // TT_METAL_CLEAR_DRAM
+        // Clear DRAM memory on device initialization.
+        // Default: 0 (don't clear)
+        // Usage: export TT_METAL_CLEAR_DRAM=1
+        case EnvVarID::TT_METAL_CLEAR_DRAM: this->clear_dram = (value[0] == '1'); break;
+        // ========================================
+        // DEBUG & TESTING
+        // ========================================
+
+        // TT_METAL_WATCHER_TEST_MODE
+        // Enable test mode for watcher functionality.
+        // Default: false (normal mode)
+        // Usage: export TT_METAL_WATCHER_TEST_MODE=1
+        case EnvVarID::TT_METAL_WATCHER_TEST_MODE: this->test_mode_enabled = true; break;
+
+        // TT_METAL_KERNEL_MAP
+        // Enable kernel build mapping for debugging.
+        // Default: false (mapping disabled)
+        // Usage: export TT_METAL_KERNEL_MAP=1
+        case EnvVarID::TT_METAL_KERNEL_MAP: this->build_map_enabled = true; break;
+
+        // TT_METAL_DISPATCH_DATA_COLLECTION
+        // Enable collection of dispatch debugging data.
+        // Default: false (collection disabled)
+        // Usage: export TT_METAL_DISPATCH_DATA_COLLECTION=1
+        case EnvVarID::TT_METAL_DISPATCH_DATA_COLLECTION: this->enable_dispatch_data_collection = true; break;
+
+        // TT_METAL_GTEST_ETH_DISPATCH
+        // Use Ethernet cores for dispatch in tests.
+        // Default: Worker cores (default dispatch type)
+        // Usage: export TT_METAL_GTEST_ETH_DISPATCH=1
+        case EnvVarID::TT_METAL_GTEST_ETH_DISPATCH: this->dispatch_core_type = tt_metal::DispatchCoreType::ETH; break;
+
+        // TT_METAL_SKIP_LOADING_FW
+        // Skip loading firmware during device initialization.
+        // Default: false (load firmware)
+        // Usage: export TT_METAL_SKIP_LOADING_FW=1
+        case EnvVarID::TT_METAL_SKIP_LOADING_FW: this->skip_loading_fw = true; break;
+
+        // TT_METAL_SKIP_DELETING_BUILT_CACHE
+        // Skip deleting built cache files on cleanup.
+        // Default: false (delete cache)
+        // Usage: export TT_METAL_SKIP_DELETING_BUILT_CACHE=1
+        case EnvVarID::TT_METAL_SKIP_DELETING_BUILT_CACHE: this->skip_deleting_built_cache = true; break;
+
+        // ========================================
+        // HARDWARE CONFIGURATION
+        // ========================================
+
+        // TT_METAL_ENABLE_HW_CACHE_INVALIDATION
+        // Enable hardware to automatically invalidate Blackhole's data cache.
+        // Default: false (cache invalidation disabled)
+        // Usage: export TT_METAL_ENABLE_HW_CACHE_INVALIDATION=1
+        case EnvVarID::TT_METAL_ENABLE_HW_CACHE_INVALIDATION: this->enable_hw_cache_invalidation = true; break;
+
+        // TT_METAL_DISABLE_RELAXED_MEM_ORDERING
+        // Disable relaxed memory ordering optimizations on Blackhole.
+        // Default: false (relaxed ordering enabled)
+        // Usage: export TT_METAL_DISABLE_RELAXED_MEM_ORDERING=1
+        case EnvVarID::TT_METAL_DISABLE_RELAXED_MEM_ORDERING: this->disable_relaxed_memory_ordering = true; break;
+
+        // TT_METAL_ENABLE_GATHERING
+        // Enable data gathering on Blackhole.
+        // Default: false (gathering disabled)
+        // Usage: export TT_METAL_ENABLE_GATHERING=1
+        case EnvVarID::TT_METAL_ENABLE_GATHERING: this->enable_gathering = true; break;
+
+        // TT_METAL_FABRIC_TELEMETRY
+        // Enable fabric telemetry data collection.
+        // Default: false (telemetry disabled)
+        // Usage: export TT_METAL_FABRIC_TELEMETRY=1
+        case EnvVarID::TT_METAL_FABRIC_TELEMETRY: this->enable_fabric_telemetry = true; break;
+
+        // TT_FABRIC_PROFILE_RX_CH_FWD
+        // Enables fabric RX channel forwarding profiling.
+        // Default: false
+        // Usage: export TT_FABRIC_PROFILE_RX_CH_FWD=1
+        case EnvVarID::TT_FABRIC_PROFILE_RX_CH_FWD: this->fabric_profiling_settings.enable_rx_ch_fwd = true; break;
+
+        // RELIABILITY_MODE
+        // Sets the fabric reliability mode (STRICT, RELAXED, or DYNAMIC).
+        // Default: nullopt (uses system default)
+        // Usage: export RELIABILITY_MODE=STRICT (or strict/0), RELAXED (or relaxed/1), DYNAMIC (or dynamic/2)
+        case EnvVarID::RELIABILITY_MODE:
+            if (value) {
+                std::string mode_str(value);
+                // Convert to lowercase for case-insensitive comparison
+                std::transform(mode_str.begin(), mode_str.end(), mode_str.begin(), ::tolower);
+                if (mode_str == "strict" || mode_str == "0") {
+                    this->reliability_mode = tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE;
+                } else if (mode_str == "relaxed" || mode_str == "1") {
+                    this->reliability_mode = tt::tt_fabric::FabricReliabilityMode::RELAXED_SYSTEM_HEALTH_SETUP_MODE;
+                } else if (mode_str == "dynamic" || mode_str == "2") {
+                    this->reliability_mode = tt::tt_fabric::FabricReliabilityMode::DYNAMIC_RECONFIGURATION_SETUP_MODE;
+                }
+            }
+            break;
+
+        // TT_METAL_MULTI_AERISC
+        // Experimental multi-ERISC mode flag that enables 2-ERISC mode.
+        // Default: false (single ERISC mode)
+        // Usage: export TT_METAL_MULTI_AERISC=1
+        case EnvVarID::TT_METAL_MULTI_AERISC:
+            if (value) {
+                log_info(tt::LogMetal, "Enabling experimental multi-erisc mode");
+                this->enable_2_erisc_mode = true;
+            }
+            break;
+
+        // TT_METAL_USE_MGD_2_0
+        // Enables use of Mesh Graph Descriptor 2.0 format for fabric configuration.
+        // Default: false
+        // Usage: export TT_METAL_USE_MGD_2_0=1
+        case EnvVarID::TT_METAL_USE_MGD_2_0:
+            if (value) {
+                this->use_mesh_graph_descriptor_2_0 = true;
+                if (std::strncmp(value, "0", 1) == 0) {
+                    this->use_mesh_graph_descriptor_2_0 = false;
+                }
+            }
+            break;
+
+        // TT_METAL_FORCE_REINIT
+        // Force context reinitialization on each run.
+        // Default: false (normal initialization)
+        // Usage: export TT_METAL_FORCE_REINIT=1
+        case EnvVarID::TT_METAL_FORCE_REINIT: this->force_context_reinit = true; break;
+
+        // TT_METAL_FABRIC_BLACKHOLE_TWO_ERISC
+        // Enable two ERISC mode with fabric on Blackhole architecture.
+        // Default: false (single ERISC mode)
+        // Usage: export TT_METAL_FABRIC_BLACKHOLE_TWO_ERISC=1
+        case EnvVarID::TT_METAL_FABRIC_BLACKHOLE_TWO_ERISC: this->enable_2_erisc_mode_with_fabric = true; break;
+
+        // TT_METAL_LOG_KERNELS_COMPILE_COMMANDS
+        // Log kernel compilation commands for debugging.
+        // Default: false (no logging)
+        // Usage: export TT_METAL_LOG_KERNELS_COMPILE_COMMANDS=1
+        case EnvVarID::TT_METAL_LOG_KERNELS_COMPILE_COMMANDS: this->log_kernels_compilation_commands = true; break;
+
+        // TT_METAL_SLOW_DISPATCH_MODE
+        // Use slow dispatch mode for debugging.
+        // Default: false (fast dispatch mode)
+        // Usage: export TT_METAL_SLOW_DISPATCH_MODE=1
+        case EnvVarID::TT_METAL_SLOW_DISPATCH_MODE:
+            this->using_slow_dispatch = true;
+            this->fast_dispatch = false;
+            break;
+
+        // TT_METAL_SKIP_ETH_CORES_WITH_RETRAIN
+        // Skip Ethernet cores during retraining process.
+        // Default: true (skip retraining)
+        // Usage: export TT_METAL_SKIP_ETH_CORES_WITH_RETRAIN=1
+        case EnvVarID::TT_METAL_SKIP_ETH_CORES_WITH_RETRAIN:
+            this->skip_eth_cores_with_retrain = (value[0] == '1');
+            break;
+
+        // TT_METAL_VALIDATE_PROGRAM_BINARIES
+        // Validate kernel binary integrity before execution.
+        // Default: 0 (no validation)
+        // Usage: export TT_METAL_VALIDATE_PROGRAM_BINARIES=1
+        case EnvVarID::TT_METAL_VALIDATE_PROGRAM_BINARIES: this->set_validate_kernel_binaries(value[0] == '1'); break;
+
+        // TT_METAL_DISABLE_DMA_OPS
+        // Disable DMA operations for debugging.
+        // Default: 0 (DMA enabled)
+        // Usage: export TT_METAL_DISABLE_DMA_OPS=1
+        case EnvVarID::TT_METAL_DISABLE_DMA_OPS:
+            if (value[0] == '1') {
+                this->disable_dma_ops = true;
+            }
+            break;
+
+        // TT_METAL_ENABLE_ERISC_IRAM
+        // Enable ERISC IRAM functionality (inverted: 0=disabled, 1=enabled).
+        // Default: 1 (enabled)
+        // Usage: export TT_METAL_ENABLE_ERISC_IRAM=0  # to disable
+        case EnvVarID::TT_METAL_ENABLE_ERISC_IRAM: {
+            bool disabled = (value[0] == '0');
+            this->erisc_iram_enabled = !disabled;
+            this->erisc_iram_enabled_env_var = !disabled;
+            break;
         }
-        watcher_settings.enabled = true;
-        watcher_settings.interval_ms = sleep_val;
+
+        // ========================================
+        // PROFILING & PERFORMANCE
+        // ========================================
+
+        // TT_METAL_DEVICE_PROFILER
+        // Enables device profiling (requires TRACY_ENABLE compilation flag).
+        // Default: false (profiling disabled)
+        // Usage: export TT_METAL_DEVICE_PROFILER=1
+        case EnvVarID::TT_METAL_DEVICE_PROFILER:
+#if !defined(TRACY_ENABLE)
+            TT_FATAL(false, "TT_METAL_DEVICE_PROFILER requires a Tracy-enabled build of tt-metal.");
+#else
+            if (value && value[0] == '1') {
+                this->profiler_enabled = true;
+            }
+#endif
+            break;
+
+        // TT_METAL_DEVICE_PROFILER_DISPATCH
+        // Enables profiling of dispatch cores. Requires TT_METAL_DEVICE_PROFILER=1 to be effective.
+        // Default: 0 (dispatch profiling disabled)
+        // Usage: export TT_METAL_DEVICE_PROFILER_DISPATCH=1
+        case EnvVarID::TT_METAL_DEVICE_PROFILER_DISPATCH: {
+            // Only enable dispatch profiling if device profiler is also enabled
+            if (this->profiler_enabled && value && value[0] == '1') {
+                this->profile_dispatch_cores = true;
+            }
+            break;
+        }
+
+        // TT_METAL_PROFILER_SYNC
+        // Enables synchronous profiling mode for more accurate timing.
+        // Default: false (asynchronous profiling)
+        // Usage: export TT_METAL_PROFILER_SYNC=1
+        case EnvVarID::TT_METAL_PROFILER_SYNC: {
+            // Only enable sync profiling if device profiler is also enabled
+            if (this->profiler_enabled && value && value[0] == '1') {
+                this->profiler_sync_enabled = true;
+            }
+            break;
+        }
+
+        // TT_METAL_DEVICE_PROFILER_NOC_EVENTS
+        // Enables NoC (Network-on-Chip) events profiling.
+        // Default: false (NoC events not profiled)
+        // Usage: export TT_METAL_DEVICE_PROFILER_NOC_EVENTS=1
+        case EnvVarID::TT_METAL_DEVICE_PROFILER_NOC_EVENTS:
+            if (value && value[0] == '1') {
+                this->profiler_enabled = true;
+                this->profiler_noc_events_enabled = true;
+            }
+            break;
+
+        // TT_METAL_DEVICE_PROFILER_NOC_EVENTS_RPT_PATH
+        // Sets the report path for NoC events profiling output files.
+        // Default: Default report location
+        // Usage: export TT_METAL_DEVICE_PROFILER_NOC_EVENTS_RPT_PATH=/path/to/reports
+        case EnvVarID::TT_METAL_DEVICE_PROFILER_NOC_EVENTS_RPT_PATH:
+            this->profiler_noc_events_report_path = std::string(value);
+            break;
+
+        // TT_METAL_MEM_PROFILER
+        // Enables memory/buffer usage profiling for tracking memory allocation patterns.
+        // Default: false (memory profiling disabled)
+        // Usage: export TT_METAL_MEM_PROFILER=1
+        case EnvVarID::TT_METAL_MEM_PROFILER:
+            if (value && value[0] == '1') {
+                this->profiler_buffer_usage_enabled = true;
+            }
+            break;
+
+        // TT_METAL_TRACE_PROFILER
+        // Enables trace profiler for detailed execution tracing.
+        // Default: false (trace profiling disabled)
+        // Usage: export TT_METAL_TRACE_PROFILER=1
+        case EnvVarID::TT_METAL_TRACE_PROFILER: {
+            // Only enable trace profiling if device profiler is also enabled
+            if (this->profiler_enabled && value && value[0] == '1') {
+                this->profiler_trace_profiler = true;
+            }
+            break;
+        }
+
+        // TT_METAL_PROFILER_TRACE_TRACKING
+        // Enables trace tracking for detailed execution tracing.
+        // Default: false (trace tracking disabled)
+        // Usage: export TT_METAL_PROFILER_TRACE_TRACKING=1
+        case EnvVarID::TT_METAL_PROFILER_TRACE_TRACKING: {
+            // Only enable trace tracking if device profiler is also enabled
+            if (this->profiler_enabled && value && value[0] == '1') {
+                this->profiler_trace_tracking = true;
+            }
+            break;
+        }
+
+        // TT_METAL_PROFILER_MID_RUN_DUMP
+        // Forces Tracy profiler dumps during execution for real-time profiling.
+        // Default: false (no mid-run dumps)
+        // Usage: export TT_METAL_PROFILER_MID_RUN_DUMP=1
+        case EnvVarID::TT_METAL_PROFILER_MID_RUN_DUMP: {
+            // Only enable mid-run dumps if device profiler is also enabled
+            if (this->profiler_enabled && value && value[0] == '1') {
+                this->profiler_mid_run_dump = true;
+            }
+            break;
+        }
+
+        // TT_METAL_PROFILER_CPP_POST_PROCESS
+        // Enable C++ post-processing for profiler output. Requires TT_METAL_DEVICE_PROFILER=1 to be effective.
+        // Default: false
+        // Usage: export TT_METAL_PROFILER_CPP_POST_PROCESS=1
+        case EnvVarID::TT_METAL_PROFILER_CPP_POST_PROCESS: {
+            // Only enable C++ post-processing if device profiler is also enabled
+            if (this->profiler_enabled && value && value[0] == '1') {
+                this->profiler_cpp_post_process = true;
+            }
+            break;
+        }
+
+        // TT_METAL_TRACY_MID_RUN_PUSH
+        // Forces Tracy profiler pushes during execution for real-time profiling.
+        // Default: false (no mid-run pushes)
+        // Usage: export TT_METAL_TRACY_MID_RUN_PUSH=1
+        case EnvVarID::TT_METAL_TRACY_MID_RUN_PUSH: this->tracy_mid_run_push = true; break;
+
+        // TT_METAL_GTEST_NUM_HW_CQS
+        // Number of hardware command queues to use in tests.
+        // Default: 1
+        // Usage: export TT_METAL_GTEST_NUM_HW_CQS=4
+        case EnvVarID::TT_METAL_GTEST_NUM_HW_CQS: try { this->set_num_hw_cqs(std::stoi(value));
+            } catch (const std::invalid_argument& ia) {
+                TT_THROW("Invalid TT_METAL_GTEST_NUM_HW_CQS: {}", value);
+            } catch (const std::out_of_range&) {
+                TT_THROW("TT_METAL_GTEST_NUM_HW_CQS value out of range: {}", value);
+            }
+            break;
+
+        // TT_METAL_ARC_DEBUG_BUFFER_SIZE
+        // Buffer size in DRAM for storing ARC processor debug samples.
+        // Default: 0 (disabled)
+        // Usage: export TT_METAL_ARC_DEBUG_BUFFER_SIZE=1024
+        case EnvVarID::TT_METAL_ARC_DEBUG_BUFFER_SIZE: sscanf(value, "%u", &this->arc_debug_buffer_size); break;
+
+        // TT_METAL_OPERATION_TIMEOUT_SECONDS
+        // Timeout duration for device operations in seconds.
+        // Default: 0.0 (no timeout)
+        // Usage: export TT_METAL_OPERATION_TIMEOUT_SECONDS=30.0
+        case EnvVarID::TT_METAL_OPERATION_TIMEOUT_SECONDS: {
+            float timeout_duration = std::stof(value);
+            this->timeout_duration_for_operations = std::chrono::duration<float>(timeout_duration);
+            break;
+        }
+
+        // ========================================
+        // WATCHER SYSTEM
+        // ========================================
+
+        // TT_METAL_WATCHER
+        // Enables the watcher system for debugging. When set, enables watcher on all features.
+        // Default: disabled
+        // Usage: export TT_METAL_WATCHER=1
+        case EnvVarID::TT_METAL_WATCHER:
+            if (value) {
+                int sleep_val = 0;
+                sscanf(value, "%d", &sleep_val);
+                if (strstr(value, "ms") == nullptr) {
+                    sleep_val *= 1000;
+                }
+                this->watcher_settings.enabled = true;
+                this->watcher_settings.interval_ms = sleep_val;
+            }
+            break;
+
+        // TT_METAL_WATCHER_DUMP_ALL
+        // Enables dumping all watcher data, including potentially unsafe state information.
+        // Default: false (safe data only)
+        // Usage: export TT_METAL_WATCHER_DUMP_ALL=1
+        case EnvVarID::TT_METAL_WATCHER_DUMP_ALL: this->watcher_settings.dump_all = true; break;
+
+        // TT_METAL_WATCHER_APPEND
+        // Enables append mode for watcher output files instead of overwriting.
+        // Default: false (overwrite mode)
+        // Usage: export TT_METAL_WATCHER_APPEND=1
+        case EnvVarID::TT_METAL_WATCHER_APPEND: this->watcher_settings.append = true; break;
+
+        // TT_METAL_WATCHER_NOINLINE
+        // Disables inlining for watcher functions to reduce binary size.
+        // Default: false (inlining enabled)
+        // Usage: export TT_METAL_WATCHER_NOINLINE=1
+        case EnvVarID::TT_METAL_WATCHER_NOINLINE: this->watcher_settings.noinline = true; break;
+
+        // TT_METAL_WATCHER_PHYS_COORDS
+        // Uses physical coordinates in watcher output instead of logical coordinates.
+        // Default: false (logical coordinates)
+        // Usage: export TT_METAL_WATCHER_PHYS_COORDS=1
+        case EnvVarID::TT_METAL_WATCHER_PHYS_COORDS: this->watcher_settings.phys_coords = true; break;
+
+        // TT_METAL_WATCHER_TEXT_START
+        // Includes text start information in watcher output for debugging.
+        // Default: false (no text start info)
+        // Usage: export TT_METAL_WATCHER_TEXT_START=1
+        case EnvVarID::TT_METAL_WATCHER_TEXT_START: this->watcher_settings.text_start = true; break;
+
+        // TT_METAL_WATCHER_SKIP_LOGGING
+        // Disables watcher logging to reduce overhead.
+        // Default: false (logging enabled)
+        // Usage: export TT_METAL_WATCHER_SKIP_LOGGING=1
+        case EnvVarID::TT_METAL_WATCHER_SKIP_LOGGING: this->watcher_settings.skip_logging = true; break;
+
+        // TT_METAL_WATCHER_DISABLE_ASSERT
+        // Disables watcher assert feature when set to any value.
+        // Default: enabled
+        // Usage: export TT_METAL_WATCHER_DISABLE_ASSERT=1
+        case EnvVarID::TT_METAL_WATCHER_DISABLE_ASSERT:
+            this->watcher_disabled_features.insert(this->watcher_assert_str);
+            break;
+
+        // TT_METAL_WATCHER_DISABLE_PAUSE
+        // Disables watcher pause feature when set to any value.
+        // Default: enabled
+        // Usage: export TT_METAL_WATCHER_DISABLE_PAUSE=1
+        case EnvVarID::TT_METAL_WATCHER_DISABLE_PAUSE:
+            this->watcher_disabled_features.insert(this->watcher_pause_str);
+            break;
+
+        // TT_METAL_WATCHER_DISABLE_RING_BUFFER
+        // Disables watcher ring buffer feature when set to any value.
+        // Default: enabled
+        // Usage: export TT_METAL_WATCHER_DISABLE_RING_BUFFER=1
+        case EnvVarID::TT_METAL_WATCHER_DISABLE_RING_BUFFER:
+            this->watcher_disabled_features.insert(this->watcher_ring_buffer_str);
+            break;
+
+        // TT_METAL_WATCHER_DISABLE_STACK_USAGE
+        // Disables watcher stack usage tracking when set to any value.
+        // Default: enabled
+        // Usage: export TT_METAL_WATCHER_DISABLE_STACK_USAGE=1
+        case EnvVarID::TT_METAL_WATCHER_DISABLE_STACK_USAGE:
+            this->watcher_disabled_features.insert(this->watcher_stack_usage_str);
+            break;
+
+        // TT_METAL_WATCHER_DISABLE_SANITIZE_NOC
+        // Disables watcher NoC sanitization when set to any value.
+        // Default: enabled
+        // Usage: export TT_METAL_WATCHER_DISABLE_SANITIZE_NOC=1
+        case EnvVarID::TT_METAL_WATCHER_DISABLE_SANITIZE_NOC:
+            this->watcher_disabled_features.insert(this->watcher_noc_sanitize_str);
+            break;
+
+        // TT_METAL_WATCHER_DISABLE_SANITIZE_READ_ONLY_L1
+        // Disables watcher read-only L1 sanitization when set to any value.
+        // Default: enabled
+        // Usage: export TT_METAL_WATCHER_DISABLE_SANITIZE_READ_ONLY_L1=1
+        case EnvVarID::TT_METAL_WATCHER_DISABLE_SANITIZE_READ_ONLY_L1:
+            this->watcher_disabled_features.insert(this->watcher_sanitize_read_only_l1_str);
+            break;
+
+        // TT_METAL_WATCHER_DISABLE_SANITIZE_WRITE_ONLY_L1
+        // Disables watcher write-only L1 sanitization when set to any value.
+        // Default: enabled
+        // Usage: export TT_METAL_WATCHER_DISABLE_SANITIZE_WRITE_ONLY_L1=1
+        case EnvVarID::TT_METAL_WATCHER_DISABLE_SANITIZE_WRITE_ONLY_L1:
+            this->watcher_disabled_features.insert(this->watcher_sanitize_write_only_l1_str);
+            break;
+
+        // TT_METAL_WATCHER_DISABLE_WAYPOINT
+        // Disables watcher waypoint feature when set to any value.
+        // Default: enabled
+        // Usage: export TT_METAL_WATCHER_DISABLE_WAYPOINT=1
+        case EnvVarID::TT_METAL_WATCHER_DISABLE_WAYPOINT:
+            this->watcher_disabled_features.insert(this->watcher_waypoint_str);
+            break;
+
+        // TT_METAL_WATCHER_DISABLE_DISPATCH
+        // Disables watcher dispatch feature when set to any value.
+        // Default: enabled
+        // Usage: export TT_METAL_WATCHER_DISABLE_DISPATCH=1
+        case EnvVarID::TT_METAL_WATCHER_DISABLE_DISPATCH:
+            this->watcher_disabled_features.insert(this->watcher_dispatch_str);
+            break;
+
+        // TT_METAL_WATCHER_ENABLE_NOC_SANITIZE_LINKED_TRANSACTION
+        // Enables NoC sanitization for linked transactions to catch more subtle errors.
+        // Default: false (linked transaction sanitization disabled)
+        // Usage: export TT_METAL_WATCHER_ENABLE_NOC_SANITIZE_LINKED_TRANSACTION=1
+        case EnvVarID::TT_METAL_WATCHER_ENABLE_NOC_SANITIZE_LINKED_TRANSACTION:
+            this->watcher_settings.noc_sanitize_linked_transaction = true;
+            break;
+
+        // ========================================
+        // INSPECTOR
+        // ========================================
+
+        // TT_METAL_INSPECTOR
+        // Enables or disables the inspector system. Set to '0' to disable, any other value enables it.
+        // Default: true (enabled)
+        // Usage: export TT_METAL_INSPECTOR=1
+        case EnvVarID::TT_METAL_INSPECTOR:
+            if (value) {
+                this->inspector_settings.enabled = true;
+                if (strcmp(value, "0") == 0) {
+                    this->inspector_settings.enabled = false;
+                }
+            }
+            break;
+
+        // TT_METAL_INSPECTOR_LOG_PATH
+        // Sets the log path for inspector output.
+        // Default: Defaults to {TT_METAL_RUNTIME_ROOT}/generated/inspector
+        // Usage: export TT_METAL_INSPECTOR_LOG_PATH=/path/to/inspector/logs
+        case EnvVarID::TT_METAL_INSPECTOR_LOG_PATH:
+            if (value) {
+                this->inspector_settings.log_path = std::filesystem::path(value);
+            } else {
+                this->inspector_settings.log_path = std::filesystem::path(this->get_root_dir()) / "generated/inspector";
+            }
+            break;
+
+        // TT_METAL_INSPECTOR_INITIALIZATION_IS_IMPORTANT
+        // Controls whether initialization is considered important for inspector. Set to '0' to disable.
+        // Default: false (not important)
+        // Usage: export TT_METAL_INSPECTOR_INITIALIZATION_IS_IMPORTANT=1
+        case EnvVarID::TT_METAL_INSPECTOR_INITIALIZATION_IS_IMPORTANT:
+            if (value) {
+                this->inspector_settings.initialization_is_important = true;
+                if (strcmp(value, "0") == 0) {
+                    this->inspector_settings.initialization_is_important = false;
+                }
+            }
+            break;
+
+        // TT_METAL_INSPECTOR_WARN_ON_WRITE_EXCEPTIONS
+        // Controls whether to warn on write exceptions in inspector. Set to '0' to disable warnings.
+        // Default: true (warnings enabled)
+        // Usage: export TT_METAL_INSPECTOR_WARN_ON_WRITE_EXCEPTIONS=0
+        case EnvVarID::TT_METAL_INSPECTOR_WARN_ON_WRITE_EXCEPTIONS:
+            if (value) {
+                this->inspector_settings.warn_on_write_exceptions = true;
+                if (strcmp(value, "0") == 0) {
+                    this->inspector_settings.warn_on_write_exceptions = false;
+                }
+            }
+            break;
+
+        // TT_METAL_RISCV_DEBUG_INFO
+        // Enable RISC-V debug info. Defaults to inspector setting, override with 0/1.
+        // Default: Inherits from inspector setting
+        // Usage: export TT_METAL_RISCV_DEBUG_INFO=1  # or =0 to disable
+        case EnvVarID::TT_METAL_RISCV_DEBUG_INFO: {
+            bool enable_riscv_debug_info = this->get_inspector_enabled();  // Default from inspector
+            if (value) {
+                enable_riscv_debug_info = true;  // Default to true if set
+                if (strcmp(value, "0") == 0) {
+                    enable_riscv_debug_info = false;  // Only "0" = false
+                }
+            }
+            this->set_riscv_debug_info_enabled(enable_riscv_debug_info);
+            break;
+        }
+
+        // TT_METAL_INSPECTOR_RPC_SERVER_ADDRESS
+        // Sets the RPC server address for the inspector. Format: "host:port" or just "host" (uses default port).
+        // Default: localhost:50051
+        // Usage: export TT_METAL_INSPECTOR_RPC_SERVER_ADDRESS=127.0.0.1:8080
+        case EnvVarID::TT_METAL_INSPECTOR_RPC_SERVER_ADDRESS:
+            if (value) {
+                // Parse address into host and port
+                std::string addr(value);
+                size_t colon_pos = addr.find(':');
+                if (colon_pos != std::string::npos) {
+                    this->inspector_settings.rpc_server_host = addr.substr(0, colon_pos);
+                    try {
+                        this->inspector_settings.rpc_server_port = std::stoi(addr.substr(colon_pos + 1));
+                    } catch (...) {
+                        TT_THROW("Invalid port in TT_METAL_INSPECTOR_RPC_SERVER_ADDRESS: {}", value);
+                    }
+                } else {
+                    this->inspector_settings.rpc_server_host = addr;
+                }
+            }
+            break;
+
+        // TT_METAL_INSPECTOR_RPC
+        // Enables or disables the inspector RPC server. Set to '0' to disable, any other value enables it.
+        // Default: true (enabled)
+        // Usage: export TT_METAL_INSPECTOR_RPC=1
+        case EnvVarID::TT_METAL_INSPECTOR_RPC:
+            if (value) {
+                this->inspector_settings.rpc_server_enabled = true;
+                if (std::strncmp(value, "0", 1) == 0) {
+                    this->inspector_settings.rpc_server_enabled = false;
+                }
+            }
+            break;
+
+        // ========================================
+        // DEBUG PRINTING (DPRINT)
+        // ========================================
+        // Note: Most DPRINT variables are handled by ParseFeatureEnv() in constructor
+        // These cases exist for documentation and potential future direct handling
+
+        // TT_METAL_DPRINT_CORES
+        // Specifies worker cores for debug printing. Supports 'all', ranges '(1,1)-(2,2)', or lists '(1,1),(2,2)'.
+        // Default: disabled (no debug printing)
+        // Usage: export TT_METAL_DPRINT_CORES=all
+        case EnvVarID::TT_METAL_DPRINT_CORES:
+            // Handled by ParseFeatureEnv() - this is for documentation
+            break;
+
+        // TT_METAL_DPRINT_ETH_CORES
+        // Specifies Ethernet cores for debug printing. Same syntax as DPRINT_CORES.
+        // Default: disabled (no debug printing on ETH cores)
+        // Usage: export TT_METAL_DPRINT_ETH_CORES=(0,0),(1,0)
+        case EnvVarID::TT_METAL_DPRINT_ETH_CORES:
+            // Handled by ParseFeatureEnv() - this is for documentation
+            break;
+
+        // TT_METAL_DPRINT_CHIPS
+        // Specifies chip IDs for debug printing. Supports 'all' or comma-separated list of chip IDs.
+        // Default: all chips
+        // Usage: export TT_METAL_DPRINT_CHIPS=0,1,2
+        case EnvVarID::TT_METAL_DPRINT_CHIPS:
+            // Handled by ParseFeatureEnv() - this is for documentation
+            break;
+
+        // TT_METAL_DPRINT_RISCVS
+        // Specifies RISC-V processors for debug printing. Complex processor selection syntax.
+        // Default: all RISC-V processors
+        // Usage: export TT_METAL_DPRINT_RISCVS=BR+NCRISC+TRISC0
+        case EnvVarID::TT_METAL_DPRINT_RISCVS:
+            // Handled by ParseFeatureEnv() - this is for documentation
+            break;
+
+        // TT_METAL_DPRINT_FILE
+        // Output file path for debug printing. If not specified, prints to stdout.
+        // Default: stdout
+        // Usage: export TT_METAL_DPRINT_FILE=/tmp/debug_output.log
+        case EnvVarID::TT_METAL_DPRINT_FILE:
+            // Handled by ParseFeatureEnv() - this is for documentation
+            break;
+
+        // TT_METAL_DPRINT_ONE_FILE_PER_RISC
+        // Creates separate output files for each RISC-V processor when set.
+        // Default: false (single output file)
+        // Usage: export TT_METAL_DPRINT_ONE_FILE_PER_RISC=1
+        case EnvVarID::TT_METAL_DPRINT_ONE_FILE_PER_RISC:
+            // Handled by ParseFeatureEnv() - this is for documentation
+            break;
+
+        // TT_METAL_DPRINT_PREPEND_DEVICE_CORE_RISC
+        // Prepends device/core/RISC information to each debug print line. Set to '0' to disable.
+        // Default: true (prepend enabled)
+        // Usage: export TT_METAL_DPRINT_PREPEND_DEVICE_CORE_RISC=0
+        case EnvVarID::TT_METAL_DPRINT_PREPEND_DEVICE_CORE_RISC:
+            // Handled by ParseFeatureEnv() - this is for documentation
+            break;
+    }
+}
+
+void RunTimeOptions::InitializeFromEnvVars() {
+    // Use enchantum to automatically iterate over all EnvVarID enum values
+    for (const auto [id, name] : enchantum::entries_generator<EnvVarID>) {
+        const char* value = std::getenv(std::string(name).c_str());
+
+        // Only process if the environment variable is set
+        if (value) {
+            HandleEnvVar(id, value);
+        }
     }
 
-    watcher_settings.dump_all = (getenv("TT_METAL_WATCHER_DUMP_ALL") != nullptr);
-    watcher_settings.append = (getenv("TT_METAL_WATCHER_APPEND") != nullptr);
-    watcher_settings.noinline = (getenv("TT_METAL_WATCHER_NOINLINE") != nullptr);
-    watcher_settings.phys_coords = (getenv("TT_METAL_WATCHER_PHYS_COORDS") != nullptr);
-    watcher_settings.text_start = (getenv("TT_METAL_WATCHER_TEXT_START") != nullptr);
-    watcher_settings.skip_logging = (getenv("TT_METAL_WATCHER_SKIP_LOGGING") != nullptr);
-    watcher_settings.noc_sanitize_linked_transaction =
-        (getenv("TT_METAL_WATCHER_ENABLE_NOC_SANITIZE_LINKED_TRANSACTION") != nullptr);
+    // TT_METAL_INSPECTOR_LOG_PATH: Set default path if not specified
+    if (std::getenv("TT_METAL_INSPECTOR_LOG_PATH") == nullptr) {
+        HandleEnvVar(EnvVarID::TT_METAL_INSPECTOR_LOG_PATH, nullptr);
+    }
+
+    // TT_METAL_RISCV_DEBUG_INFO: Inherit from inspector if not explicitly set
+    if (std::getenv("TT_METAL_RISCV_DEBUG_INFO") == nullptr) {
+        HandleEnvVar(EnvVarID::TT_METAL_RISCV_DEBUG_INFO, nullptr);
+    }
+    ParseWatcherEnv();
+}
+
+void RunTimeOptions::ParseWatcherEnv() {
     // Auto unpause is for testing only, no env var.
     watcher_settings.auto_unpause = false;
 
@@ -432,52 +960,6 @@ void RunTimeOptions::ParseWatcherEnv() {
         TT_ASSERT(
             watcher_disabled_features.find(watcher_noc_sanitize_str) == watcher_disabled_features.end(),
             "TT_METAL_WATCHER_ENABLE_NOC_SANITIZE_LINKED_TRANSACTION requires TT_METAL_WATCHER_DISABLE_NOC_SANITIZE=0");
-    }
-}
-
-void RunTimeOptions::ParseInspectorEnv() {
-    const char* inspector_enable_str = getenv("TT_METAL_INSPECTOR");
-    if (inspector_enable_str != nullptr) {
-        inspector_settings.enabled = true;
-        if (strcmp(inspector_enable_str, "0") == 0) {
-            inspector_settings.enabled = false;
-        }
-    }
-
-    const char* inspector_log_path_str = getenv("TT_METAL_INSPECTOR_LOG_PATH");
-    if (inspector_log_path_str != nullptr) {
-        inspector_settings.log_path = std::filesystem::path(inspector_log_path_str);
-    } else {
-        inspector_settings.log_path = std::filesystem::path(get_root_dir()) / "generated/inspector";
-    }
-
-    const char* inspector_initialization_is_important_str = getenv("TT_METAL_INSPECTOR_INITIALIZATION_IS_IMPORTANT");
-    if (inspector_initialization_is_important_str != nullptr) {
-        inspector_settings.initialization_is_important = true;
-        if (strcmp(inspector_initialization_is_important_str, "0") == 0) {
-            inspector_settings.initialization_is_important = false;
-        }
-    }
-
-    const char* inspector_warn_on_write_exceptions_str = getenv("TT_METAL_INSPECTOR_WARN_ON_WRITE_EXCEPTIONS");
-    if (inspector_warn_on_write_exceptions_str != nullptr) {
-        inspector_settings.warn_on_write_exceptions = true;
-        if (strcmp(inspector_warn_on_write_exceptions_str, "0") == 0) {
-            inspector_settings.warn_on_write_exceptions = false;
-        }
-    }
-
-    const char* inspector_rpc_server_address_str = getenv("TT_METAL_INSPECTOR_RPC_SERVER_ADDRESS");
-    if (inspector_rpc_server_address_str != nullptr) {
-        inspector_settings.rpc_server_address = std::string(inspector_rpc_server_address_str);
-    }
-
-    const char* inspector_rpc_str = getenv("TT_METAL_INSPECTOR_RPC");
-    if (inspector_rpc_str != nullptr) {
-        inspector_settings.rpc_server_enabled = true;
-        if (std::strncmp(inspector_rpc_str, "0", 1) == 0) {
-            inspector_settings.rpc_server_enabled = false;
-        }
     }
 }
 
@@ -633,8 +1115,8 @@ void RunTimeOptions::ParseFeatureOneFilePerRisc(RunTimeDebugFeatures feature, co
     feature_targets[feature].one_file_per_risc = (env_var_str != nullptr);
 }
 
-void RunTimeOptions::ParseFeaturePrependDeviceCoreRisc(RunTimeDebugFeatures feature, const std::string &env_var) {
-    char *env_var_str = std::getenv(env_var.c_str());
+void RunTimeOptions::ParseFeaturePrependDeviceCoreRisc(RunTimeDebugFeatures feature, const std::string& env_var) {
+    char* env_var_str = std::getenv(env_var.c_str());
     feature_targets[feature].prepend_device_core_risc =
         (env_var_str != nullptr) ? (strcmp(env_var_str, "1") == 0) : true;
 }

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -91,7 +91,6 @@ enum class EnvVarID {
     TT_METAL_ENABLE_ERISC_IRAM,             // Enable ERISC IRAM (inverted logic)
     RELIABILITY_MODE,                       // Fabric reliability mode (strict/relaxed)
     TT_METAL_MULTI_AERISC,                  // Enable experimental multi-erisc mode
-    TT_METAL_USE_MGD_1_0,                   // Use mesh graph descriptor 1.0
     TT_METAL_USE_MGD_2_0,                   // Use mesh graph descriptor 2.0
     TT_METAL_FORCE_JIT_COMPILE,             // Force JIT compilation
 
@@ -488,12 +487,6 @@ void RunTimeOptions::HandleEnvVar(EnvVarID id, const char* value) {
             log_info(tt::LogMetal, "Enabling experimental multi-erisc mode");
             this->enable_2_erisc_mode = true;
             break;
-
-        // TT_METAL_USE_MGD_1_0
-        // Enables use of Mesh Graph Descriptor 1.0 format (deprecated, will be removed).
-        // Default: false
-        // Usage: export TT_METAL_USE_MGD_1_0=1
-        case EnvVarID::TT_METAL_USE_MGD_1_0: this->use_mesh_graph_descriptor_1_0 = true; break;
 
         // TT_METAL_USE_MGD_2_0
         // Enables use of Mesh Graph Descriptor 2.0 format for fabric configuration.

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -1017,7 +1017,7 @@ void RunTimeOptions::HandleEnvVar(EnvVarID id, const char* value) {
 void RunTimeOptions::InitializeFromEnvVars() {
     // Use enchantum to automatically iterate over all EnvVarID enum values
     for (const auto [id, name] : enchantum::entries_generator<EnvVarID>) {
-        const char* value = std::getenv(name.data());
+        const char* value = std::getenv(std::string(name).c_str());
 
         // Only process if the environment variable is set
         if (value) {

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -200,7 +200,7 @@ class RunTimeOptions {
     std::string visible_devices;
 
     // Sets the architecture name (only necessary during simulation)
-    std::string arch_name = "";
+    std::string arch_name;
 
     // Forces Tracy profiler pushes during execution for real-time profiling
     bool tracy_mid_run_push = false;
@@ -354,11 +354,11 @@ public:
         return feature_targets[feature].processors;
     }
     void set_feature_processors(RunTimeDebugFeatures feature, tt_metal::HalProcessorSet processors) {
-        feature_targets[feature].processors = std::move(processors);
+        feature_targets[feature].processors = processors;
     }
     std::string get_feature_file_name(RunTimeDebugFeatures feature) const { return feature_targets[feature].file_name; }
-    void set_feature_file_name(RunTimeDebugFeatures feature, std::string file_name) {
-        feature_targets[feature].file_name = std::move(file_name);
+    void set_feature_file_name(RunTimeDebugFeatures feature, const std::string& file_name) {
+        feature_targets[feature].file_name = file_name;
     }
     bool get_feature_one_file_per_risc(RunTimeDebugFeatures feature) const {
         return feature_targets[feature].one_file_per_risc;
@@ -373,8 +373,8 @@ public:
         feature_targets[feature].prepend_device_core_risc = prepend_device_core_risc;
     }
     TargetSelection get_feature_targets(RunTimeDebugFeatures feature) const { return feature_targets[feature]; }
-    void set_feature_targets(RunTimeDebugFeatures feature, TargetSelection targets) {
-        feature_targets[feature] = std::move(targets);
+    void set_feature_targets(RunTimeDebugFeatures feature, const TargetSelection& targets) {
+        feature_targets[feature] = targets;
     }
 
     bool get_record_noc_transfers() const { return record_noc_transfer_data; }

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -85,6 +85,7 @@ enum class EnvVarID {
     RELIABILITY_MODE,                       // Fabric reliability mode (strict/relaxed)
     TT_METAL_MULTI_AERISC,                  // Enable experimental multi-erisc mode
     TT_METAL_USE_MGD_2_0,                   // Use mesh graph descriptor 2.0
+    TT_METAL_FORCE_JIT_COMPILE,             // Force JIT compilation
 
     // ========================================
     // PROFILING & PERFORMANCE

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -16,9 +16,7 @@
 #include <map>
 #include <set>
 #include <string>
-#include <utility>
 #include <vector>
-
 #include "llrt/hal.hpp"
 #include "core_coord.hpp"
 #include "dispatch_core_common.hpp"  // For DispatchCoreConfig
@@ -30,6 +28,126 @@
 namespace tt {
 
 namespace llrt {
+// ============================================================================
+// ENVIRONMENT VARIABLE IDs
+enum class EnvVarID {
+    // ========================================
+    // PATH CONFIGURATION
+    // ========================================
+
+    TT_METAL_CACHE,                           // Cache directory for compiled kernels
+    TT_METAL_KERNEL_PATH,                     // Path to kernel source files
+    TT_METAL_SIMULATOR,                       // Path to simulator executable
+    TT_METAL_MOCK_CLUSTER_DESC_PATH,          // Mock cluster descriptor path
+    TT_METAL_VISIBLE_DEVICES,                 // Comma-separated list of visible device IDs
+    ARCH_NAME,                                // Architecture name (simulation mode)
+    TT_MESH_GRAPH_DESC_PATH,                  // Custom fabric mesh graph descriptor
+    TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE,  // Core grid override
+
+    // ========================================
+    // KERNEL EXECUTION CONTROL
+    // ========================================
+    TT_METAL_NULL_KERNELS,          // Skip kernel execution (testing)
+    TT_METAL_KERNELS_EARLY_RETURN,  // Kernels return early
+
+    // ========================================
+    // MEMORY INITIALIZATION
+    // ========================================
+    TT_METAL_CLEAR_L1,    // Clear L1 memory on device init
+    TT_METAL_CLEAR_DRAM,  // Clear DRAM on device init
+
+    // ========================================
+    // DEBUG & TESTING
+    // ========================================
+    TT_METAL_WATCHER_TEST_MODE,          // Enable watcher test mode
+    TT_METAL_KERNEL_MAP,                 // Enable kernel build mapping
+    TT_METAL_DISPATCH_DATA_COLLECTION,   // Enable dispatch debug data collection
+    TT_METAL_GTEST_ETH_DISPATCH,         // Use Ethernet cores for dispatch in tests
+    TT_METAL_SKIP_LOADING_FW,            // Skip firmware loading
+    TT_METAL_SKIP_DELETING_BUILT_CACHE,  // Skip cache deletion on cleanup
+
+    // ========================================
+    // HARDWARE CONFIGURATION
+    // ========================================
+    TT_METAL_ENABLE_HW_CACHE_INVALIDATION,  // Enable HW cache invalidation
+    TT_METAL_DISABLE_RELAXED_MEM_ORDERING,  // Disable relaxed memory ordering
+    TT_METAL_ENABLE_GATHERING,              // Enable instruction gathering
+    TT_METAL_FABRIC_TELEMETRY,              // Enable fabric telemetry
+    TT_FABRIC_PROFILE_RX_CH_FWD,            // Enable fabric RX channel forwarding profiling
+    TT_METAL_FORCE_REINIT,                  // Force context reinitialization
+    TT_METAL_FABRIC_BLACKHOLE_TWO_ERISC,    // Enable 2-ERISC mode with fabric
+    TT_METAL_LOG_KERNELS_COMPILE_COMMANDS,  // Log kernel compilation commands
+    TT_METAL_SLOW_DISPATCH_MODE,            // Use slow dispatch mode
+    TT_METAL_SKIP_ETH_CORES_WITH_RETRAIN,   // Skip Ethernet cores during retrain
+    TT_METAL_VALIDATE_PROGRAM_BINARIES,     // Validate kernel binary integrity
+    TT_METAL_DISABLE_DMA_OPS,               // Disable DMA operations
+    TT_METAL_ENABLE_ERISC_IRAM,             // Enable ERISC IRAM (inverted logic)
+    RELIABILITY_MODE,                       // Fabric reliability mode (strict/relaxed)
+    TT_METAL_MULTI_AERISC,                  // Enable experimental multi-erisc mode
+    TT_METAL_USE_MGD_2_0,                   // Use mesh graph descriptor 2.0
+
+    // ========================================
+    // PROFILING & PERFORMANCE
+    // ========================================
+    TT_METAL_DEVICE_PROFILER,                      // Enable device profiling
+    TT_METAL_DEVICE_PROFILER_DISPATCH,             // Enable dispatch core profiling
+    TT_METAL_PROFILER_SYNC,                        // Enable synchronous profiling
+    TT_METAL_DEVICE_PROFILER_NOC_EVENTS,           // Enable NoC events profiling
+    TT_METAL_DEVICE_PROFILER_NOC_EVENTS_RPT_PATH,  // NoC events report path
+    TT_METAL_MEM_PROFILER,                         // Enable memory/buffer profiling
+    TT_METAL_TRACE_PROFILER,                       // Enable trace profiling
+    TT_METAL_PROFILER_TRACE_TRACKING,              // Enable trace tracking
+    TT_METAL_PROFILER_MID_RUN_DUMP,                // Force mid-run profiler dumps
+    TT_METAL_PROFILER_CPP_POST_PROCESS,            // Enable C++ post-processing for profiler
+    TT_METAL_TRACY_MID_RUN_PUSH,                   // Force Tracy mid-run pushes
+    TT_METAL_GTEST_NUM_HW_CQS,                     // Number of HW command queues in tests
+    TT_METAL_ARC_DEBUG_BUFFER_SIZE,                // ARC processor debug buffer size
+    TT_METAL_OPERATION_TIMEOUT_SECONDS,            // Operation timeout duration
+
+    // ========================================
+    // WATCHER SYSTEM
+    // ========================================
+    TT_METAL_WATCHER,                                         // Enable watcher system
+    TT_METAL_WATCHER_DUMP_ALL,                                // Dump all watcher data
+    TT_METAL_WATCHER_APPEND,                                  // Append mode for watcher output
+    TT_METAL_WATCHER_NOINLINE,                                // Disable watcher function inlining
+    TT_METAL_WATCHER_PHYS_COORDS,                             // Use physical coordinates in watcher
+    TT_METAL_WATCHER_TEXT_START,                              // Include text start info in watcher
+    TT_METAL_WATCHER_SKIP_LOGGING,                            // Disable watcher logging
+    TT_METAL_WATCHER_DISABLE_ASSERT,                          // Disable watcher assert feature
+    TT_METAL_WATCHER_DISABLE_PAUSE,                           // Disable watcher pause feature
+    TT_METAL_WATCHER_DISABLE_RING_BUFFER,                     // Disable watcher ring buffer
+    TT_METAL_WATCHER_DISABLE_STACK_USAGE,                     // Disable watcher stack usage tracking
+    TT_METAL_WATCHER_DISABLE_SANITIZE_NOC,                    // Disable watcher NoC sanitization
+    TT_METAL_WATCHER_DISABLE_SANITIZE_READ_ONLY_L1,           // Disable read-only L1 sanitization
+    TT_METAL_WATCHER_DISABLE_SANITIZE_WRITE_ONLY_L1,          // Disable write-only L1 sanitization
+    TT_METAL_WATCHER_DISABLE_WAYPOINT,                        // Disable watcher waypoint feature
+    TT_METAL_WATCHER_DISABLE_DISPATCH,                        // Disable watcher dispatch feature
+    TT_METAL_WATCHER_ENABLE_NOC_SANITIZE_LINKED_TRANSACTION,  // Enable NoC linked transaction sanitization
+
+    // ========================================
+    // INSPECTOR
+    // ========================================
+    TT_METAL_INSPECTOR,                              // Enable/disable inspector
+    TT_METAL_INSPECTOR_LOG_PATH,                     // Inspector log output path
+    TT_METAL_INSPECTOR_INITIALIZATION_IS_IMPORTANT,  // Track initialization closely
+    TT_METAL_INSPECTOR_WARN_ON_WRITE_EXCEPTIONS,     // Warn on write exceptions
+    TT_METAL_RISCV_DEBUG_INFO,                       // Enable RISC-V debug info
+    TT_METAL_INSPECTOR_RPC_SERVER_ADDRESS,           // Inspector RPC server address (host:port)
+    TT_METAL_INSPECTOR_RPC,                          // Enable/disable inspector RPC server
+
+    // ========================================
+    // DEBUG PRINTING (DPRINT)
+    // ========================================
+    TT_METAL_DPRINT_CORES,                     // Worker cores for debug printing
+    TT_METAL_DPRINT_ETH_CORES,                 // Ethernet cores for debug printing
+    TT_METAL_DPRINT_CHIPS,                     // Chip IDs for debug printing
+    TT_METAL_DPRINT_RISCVS,                    // RISC-V processors for debug printing
+    TT_METAL_DPRINT_FILE,                      // Debug print output file
+    TT_METAL_DPRINT_ONE_FILE_PER_RISC,         // Separate file per RISC-V processor
+    TT_METAL_DPRINT_PREPEND_DEVICE_CORE_RISC,  // Prepend device/core/RISC info
+
+};
 
 inline std::string g_root_dir;
 inline std::once_flag g_root_once;
@@ -57,6 +175,7 @@ enum RunTimeDebugClass {
 
 extern const char* RunTimeDebugFeatureNames[RunTimeDebugFeatureCount];
 extern const char* RunTimeDebugClassNames[RunTimeDebugClassCount];
+class RunTimeOptions;
 
 // TargetSelection stores the targets for a given debug feature. I.e. for which chips, cores, harts
 // to enable the feature.
@@ -90,8 +209,10 @@ struct InspectorSettings {
     bool initialization_is_important = false;
     bool warn_on_write_exceptions = true;
     std::filesystem::path log_path;
-    std::string rpc_server_address = "localhost:50051";
+    std::string rpc_server_host = "localhost";
+    uint16_t rpc_server_port = 50051;
     bool rpc_server_enabled = true;
+    std::string rpc_server_address() const { return rpc_server_host + ":" + std::to_string(rpc_server_port); }
 };
 
 class RunTimeOptions {
@@ -194,7 +315,14 @@ class RunTimeOptions {
     // Forces MetalContext re-init on Device creation. Workaround for upstream issues that require re-init each time
     // (#25048) TODO: Once all of init is moved to MetalContext, investigate removing this option.
     bool force_context_reinit = false;
+    // Comma-separated list of device IDs to make visible to the runtime
+    std::string visible_devices;
 
+    // Sets the architecture name (only necessary during simulation)
+    std::string arch_name = "";
+
+    // Forces Tracy profiler pushes during execution for real-time profiling
+    bool tracy_mid_run_push = false;
     // feature flag to enable 2-erisc mode with fabric on Blackhole, until it is enabled by default
     bool enable_2_erisc_mode_with_fabric = false;
 
@@ -214,6 +342,9 @@ class RunTimeOptions {
     TargetDevice runtime_target_device_ = TargetDevice::Silicon;
     // Timeout duration for operations
     std::chrono::duration<float> timeout_duration_for_operations = std::chrono::duration<float>(0.0f);
+
+    // Using MGD 2.0 syntax for mesh graph descriptor
+    bool use_mesh_graph_descriptor_2_0 = false;
 
     // Reliability mode override parsed from environment (RELIABILITY_MODE)
     std::optional<tt::tt_fabric::FabricReliabilityMode> reliability_mode = std::nullopt;
@@ -264,6 +395,10 @@ public:
     void set_watcher_text_start(bool text_start) { watcher_settings.text_start = text_start; }
     bool get_watcher_skip_logging() const { return watcher_settings.skip_logging; }
     void set_watcher_skip_logging(bool skip_logging) { watcher_settings.skip_logging = skip_logging; }
+    //
+    bool get_inspector_rpc_server_enabled() const { return inspector_settings.rpc_server_enabled; }
+    const std::string& get_inspector_rpc_server_host() const { return inspector_settings.rpc_server_host; }
+    uint16_t get_inspector_rpc_server_port() const { return inspector_settings.rpc_server_port; }
     bool get_watcher_noc_sanitize_linked_transaction() const {
         return watcher_settings.noc_sanitize_linked_transaction;
     }
@@ -291,11 +426,10 @@ public:
     }
     bool get_inspector_warn_on_write_exceptions() const { return inspector_settings.warn_on_write_exceptions; }
     void set_inspector_warn_on_write_exceptions(bool warn) { inspector_settings.warn_on_write_exceptions = warn; }
-    const std::string& get_inspector_rpc_server_address() const { return inspector_settings.rpc_server_address; }
-    void set_inspector_rpc_server_address(const std::string& address) { inspector_settings.rpc_server_address = address; }
-    bool get_inspector_rpc_server_enabled() const { return inspector_settings.rpc_server_enabled; }
+    std::string get_inspector_rpc_server_address() const {
+        return inspector_settings.rpc_server_host + ":" + std::to_string(inspector_settings.rpc_server_port);
+    }
     void set_inspector_rpc_server_enabled(bool enabled) { inspector_settings.rpc_server_enabled = enabled; }
-
     // Info from DPrint environment variables, setters included so that user can
     // override with a SW call.
     bool get_feature_enabled(RunTimeDebugFeatures feature) const { return feature_targets[feature].enabled; }
@@ -338,7 +472,7 @@ public:
         return feature_targets[feature].processors;
     }
     void set_feature_processors(RunTimeDebugFeatures feature, tt_metal::HalProcessorSet processors) {
-        feature_targets[feature].processors = processors;
+        feature_targets[feature].processors = std::move(processors);
     }
     std::string get_feature_file_name(RunTimeDebugFeatures feature) const { return feature_targets[feature].file_name; }
     void set_feature_file_name(RunTimeDebugFeatures feature, std::string file_name) {
@@ -432,6 +566,10 @@ public:
 
     bool get_clear_dram() const { return clear_dram; }
     void set_clear_dram(bool clear) { clear_dram = clear; }
+
+    std::string get_visible_devices() const { return visible_devices; }
+    std::string get_arch_name() const { return arch_name; }
+    bool get_tracy_mid_run_push() const { return tracy_mid_run_push; }
 
     bool get_skip_loading_fw() const { return skip_loading_fw; }
 
@@ -527,6 +665,8 @@ public:
     TargetDevice get_target_device() const { return runtime_target_device_; }
 
     std::chrono::duration<float> get_timeout_duration_for_operations() const { return timeout_duration_for_operations; }
+    // Mesh graph descriptor version accessor
+    bool get_use_mesh_graph_descriptor_2_0() const { return use_mesh_graph_descriptor_2_0; }
 
     bool get_force_jit_compile() const { return force_jit_compile; }
     void set_force_jit_compile(bool enable) { force_jit_compile = enable; }
@@ -548,7 +688,8 @@ private:
     void ParseFeatureFileName(RunTimeDebugFeatures feature, const std::string& env_var);
     void ParseFeatureOneFilePerRisc(RunTimeDebugFeatures feature, const std::string& env_var);
     void ParseFeaturePrependDeviceCoreRisc(RunTimeDebugFeatures feature, const std::string& env_var);
-
+    void HandleEnvVar(EnvVarID id, const char* value);  // Handle single environment variable
+    void InitializeFromEnvVars();                       // Initialize all environment variables from table
     // Helper function to parse watcher-specific environment variables.
     void ParseWatcherEnv();
 
@@ -562,13 +703,12 @@ private:
     const std::string watcher_stack_usage_str = "STACK_USAGE";
     const std::string watcher_dispatch_str = "DISPATCH";
     const std::string watcher_eth_link_status_str = "ETH_LINK_STATUS";
+    const std::string watcher_sanitize_read_only_l1_str = "SANITIZE_READ_ONLY_L1";
+    const std::string watcher_sanitize_write_only_l1_str = "SANITIZE_WRITE_ONLY_L1";
     std::set<std::string> watcher_disabled_features;
     bool watcher_feature_disabled(const std::string& name) const {
         return watcher_disabled_features.find(name) != watcher_disabled_features.end();
     }
-
-    // Helper function to parse inspector-specific environment variables.
-    void ParseInspectorEnv();
 };
 
 // Function declarations for operation timeout and synchronization

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -28,127 +28,8 @@
 namespace tt {
 
 namespace llrt {
-// ============================================================================
-// ENVIRONMENT VARIABLE IDs
-enum class EnvVarID {
-    // ========================================
-    // PATH CONFIGURATION
-    // ========================================
-
-    TT_METAL_CACHE,                           // Cache directory for compiled kernels
-    TT_METAL_KERNEL_PATH,                     // Path to kernel source files
-    TT_METAL_SIMULATOR,                       // Path to simulator executable
-    TT_METAL_MOCK_CLUSTER_DESC_PATH,          // Mock cluster descriptor path
-    TT_METAL_VISIBLE_DEVICES,                 // Comma-separated list of visible device IDs
-    ARCH_NAME,                                // Architecture name (simulation mode)
-    TT_MESH_GRAPH_DESC_PATH,                  // Custom fabric mesh graph descriptor
-    TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE,  // Core grid override
-
-    // ========================================
-    // KERNEL EXECUTION CONTROL
-    // ========================================
-    TT_METAL_NULL_KERNELS,          // Skip kernel execution (testing)
-    TT_METAL_KERNELS_EARLY_RETURN,  // Kernels return early
-
-    // ========================================
-    // MEMORY INITIALIZATION
-    // ========================================
-    TT_METAL_CLEAR_L1,    // Clear L1 memory on device init
-    TT_METAL_CLEAR_DRAM,  // Clear DRAM on device init
-
-    // ========================================
-    // DEBUG & TESTING
-    // ========================================
-    TT_METAL_WATCHER_TEST_MODE,          // Enable watcher test mode
-    TT_METAL_KERNEL_MAP,                 // Enable kernel build mapping
-    TT_METAL_DISPATCH_DATA_COLLECTION,   // Enable dispatch debug data collection
-    TT_METAL_GTEST_ETH_DISPATCH,         // Use Ethernet cores for dispatch in tests
-    TT_METAL_SKIP_LOADING_FW,            // Skip firmware loading
-    TT_METAL_SKIP_DELETING_BUILT_CACHE,  // Skip cache deletion on cleanup
-
-    // ========================================
-    // HARDWARE CONFIGURATION
-    // ========================================
-    TT_METAL_ENABLE_HW_CACHE_INVALIDATION,  // Enable HW cache invalidation
-    TT_METAL_DISABLE_RELAXED_MEM_ORDERING,  // Disable relaxed memory ordering
-    TT_METAL_ENABLE_GATHERING,              // Enable instruction gathering
-    TT_METAL_FABRIC_TELEMETRY,              // Enable fabric telemetry
-    TT_FABRIC_PROFILE_RX_CH_FWD,            // Enable fabric RX channel forwarding profiling
-    TT_METAL_FORCE_REINIT,                  // Force context reinitialization
-    TT_METAL_FABRIC_BLACKHOLE_TWO_ERISC,    // Enable 2-ERISC mode with fabric
-    TT_METAL_LOG_KERNELS_COMPILE_COMMANDS,  // Log kernel compilation commands
-    TT_METAL_SLOW_DISPATCH_MODE,            // Use slow dispatch mode
-    TT_METAL_SKIP_ETH_CORES_WITH_RETRAIN,   // Skip Ethernet cores during retrain
-    TT_METAL_VALIDATE_PROGRAM_BINARIES,     // Validate kernel binary integrity
-    TT_METAL_DISABLE_DMA_OPS,               // Disable DMA operations
-    TT_METAL_ENABLE_ERISC_IRAM,             // Enable ERISC IRAM (inverted logic)
-    RELIABILITY_MODE,                       // Fabric reliability mode (strict/relaxed)
-    TT_METAL_MULTI_AERISC,                  // Enable experimental multi-erisc mode
-    TT_METAL_USE_MGD_2_0,                   // Use mesh graph descriptor 2.0
-    TT_METAL_FORCE_JIT_COMPILE,             // Force JIT compilation
-
-    // ========================================
-    // PROFILING & PERFORMANCE
-    // ========================================
-    TT_METAL_DEVICE_PROFILER,                      // Enable device profiling
-    TT_METAL_DEVICE_PROFILER_DISPATCH,             // Enable dispatch core profiling
-    TT_METAL_PROFILER_SYNC,                        // Enable synchronous profiling
-    TT_METAL_DEVICE_PROFILER_NOC_EVENTS,           // Enable NoC events profiling
-    TT_METAL_DEVICE_PROFILER_NOC_EVENTS_RPT_PATH,  // NoC events report path
-    TT_METAL_MEM_PROFILER,                         // Enable memory/buffer profiling
-    TT_METAL_TRACE_PROFILER,                       // Enable trace profiling
-    TT_METAL_PROFILER_TRACE_TRACKING,              // Enable trace tracking
-    TT_METAL_PROFILER_MID_RUN_DUMP,                // Force mid-run profiler dumps
-    TT_METAL_PROFILER_CPP_POST_PROCESS,            // Enable C++ post-processing for profiler
-    TT_METAL_TRACY_MID_RUN_PUSH,                   // Force Tracy mid-run pushes
-    TT_METAL_GTEST_NUM_HW_CQS,                     // Number of HW command queues in tests
-    TT_METAL_ARC_DEBUG_BUFFER_SIZE,                // ARC processor debug buffer size
-    TT_METAL_OPERATION_TIMEOUT_SECONDS,            // Operation timeout duration
-
-    // ========================================
-    // WATCHER SYSTEM
-    // ========================================
-    TT_METAL_WATCHER,                                         // Enable watcher system
-    TT_METAL_WATCHER_DUMP_ALL,                                // Dump all watcher data
-    TT_METAL_WATCHER_APPEND,                                  // Append mode for watcher output
-    TT_METAL_WATCHER_NOINLINE,                                // Disable watcher function inlining
-    TT_METAL_WATCHER_PHYS_COORDS,                             // Use physical coordinates in watcher
-    TT_METAL_WATCHER_TEXT_START,                              // Include text start info in watcher
-    TT_METAL_WATCHER_SKIP_LOGGING,                            // Disable watcher logging
-    TT_METAL_WATCHER_DISABLE_ASSERT,                          // Disable watcher assert feature
-    TT_METAL_WATCHER_DISABLE_PAUSE,                           // Disable watcher pause feature
-    TT_METAL_WATCHER_DISABLE_RING_BUFFER,                     // Disable watcher ring buffer
-    TT_METAL_WATCHER_DISABLE_STACK_USAGE,                     // Disable watcher stack usage tracking
-    TT_METAL_WATCHER_DISABLE_SANITIZE_NOC,                    // Disable watcher NoC sanitization
-    TT_METAL_WATCHER_DISABLE_SANITIZE_READ_ONLY_L1,           // Disable read-only L1 sanitization
-    TT_METAL_WATCHER_DISABLE_SANITIZE_WRITE_ONLY_L1,          // Disable write-only L1 sanitization
-    TT_METAL_WATCHER_DISABLE_WAYPOINT,                        // Disable watcher waypoint feature
-    TT_METAL_WATCHER_DISABLE_DISPATCH,                        // Disable watcher dispatch feature
-    TT_METAL_WATCHER_ENABLE_NOC_SANITIZE_LINKED_TRANSACTION,  // Enable NoC linked transaction sanitization
-
-    // ========================================
-    // INSPECTOR
-    // ========================================
-    TT_METAL_INSPECTOR,                              // Enable/disable inspector
-    TT_METAL_INSPECTOR_LOG_PATH,                     // Inspector log output path
-    TT_METAL_INSPECTOR_INITIALIZATION_IS_IMPORTANT,  // Track initialization closely
-    TT_METAL_INSPECTOR_WARN_ON_WRITE_EXCEPTIONS,     // Warn on write exceptions
-    TT_METAL_RISCV_DEBUG_INFO,                       // Enable RISC-V debug info
-    TT_METAL_INSPECTOR_RPC_SERVER_ADDRESS,           // Inspector RPC server address (host:port)
-    TT_METAL_INSPECTOR_RPC,                          // Enable/disable inspector RPC server
-
-    // ========================================
-    // DEBUG PRINTING (DPRINT)
-    // ========================================
-    TT_METAL_DPRINT_CORES,                     // Worker cores for debug printing
-    TT_METAL_DPRINT_ETH_CORES,                 // Ethernet cores for debug printing
-    TT_METAL_DPRINT_CHIPS,                     // Chip IDs for debug printing
-    TT_METAL_DPRINT_RISCVS,                    // RISC-V processors for debug printing
-    TT_METAL_DPRINT_FILE,                      // Debug print output file
-    TT_METAL_DPRINT_ONE_FILE_PER_RISC,         // Separate file per RISC-V processor
-    TT_METAL_DPRINT_PREPEND_DEVICE_CORE_RISC,  // Prepend device/core/RISC info
-
-};
+// Forward declaration - full definition in rtoptions.cpp
+enum class EnvVarID;
 
 inline std::string g_root_dir;
 inline std::once_flag g_root_once;
@@ -176,7 +57,6 @@ enum RunTimeDebugClass {
 
 extern const char* RunTimeDebugFeatureNames[RunTimeDebugFeatureCount];
 extern const char* RunTimeDebugClassNames[RunTimeDebugClassCount];
-class RunTimeOptions;
 
 // TargetSelection stores the targets for a given debug feature. I.e. for which chips, cores, harts
 // to enable the feature.
@@ -344,6 +224,8 @@ class RunTimeOptions {
     // Timeout duration for operations
     std::chrono::duration<float> timeout_duration_for_operations = std::chrono::duration<float>(0.0f);
 
+    // Using MGD 1.0 syntax for mesh graph descriptor in Fabric Control Plane
+    bool use_mesh_graph_descriptor_1_0 = false;
     // Using MGD 2.0 syntax for mesh graph descriptor
     bool use_mesh_graph_descriptor_2_0 = false;
 
@@ -668,6 +550,10 @@ public:
     // Mesh graph descriptor version accessor
     bool get_use_mesh_graph_descriptor_2_0() const { return use_mesh_graph_descriptor_2_0; }
 
+    // Using MGD 1.0 syntax for mesh graph descriptor in Fabric Control Plane
+    // TODO: This will be removed after MGD 1.0 is deprecated
+    bool get_use_mesh_graph_descriptor_1_0() const { return use_mesh_graph_descriptor_1_0; }
+
     bool get_force_jit_compile() const { return force_jit_compile; }
     void set_force_jit_compile(bool enable) { force_jit_compile = enable; }
 
@@ -688,7 +574,8 @@ private:
     void ParseFeatureFileName(RunTimeDebugFeatures feature, const std::string& env_var);
     void ParseFeatureOneFilePerRisc(RunTimeDebugFeatures feature, const std::string& env_var);
     void ParseFeaturePrependDeviceCoreRisc(RunTimeDebugFeatures feature, const std::string& env_var);
-    void HandleEnvVar(EnvVarID id, const char* value);  // Handle single environment variable
+    void HandleEnvVar(
+        EnvVarID id, const char* value);  // Handle single env var (value usually non-null, see cpp for details)
     void InitializeFromEnvVars();                       // Initialize all environment variables from table
     // Helper function to parse watcher-specific environment variables.
     void ParseWatcherEnv();

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -395,7 +395,6 @@ public:
     void set_watcher_text_start(bool text_start) { watcher_settings.text_start = text_start; }
     bool get_watcher_skip_logging() const { return watcher_settings.skip_logging; }
     void set_watcher_skip_logging(bool skip_logging) { watcher_settings.skip_logging = skip_logging; }
-    //
     bool get_inspector_rpc_server_enabled() const { return inspector_settings.rpc_server_enabled; }
     const std::string& get_inspector_rpc_server_host() const { return inspector_settings.rpc_server_host; }
     uint16_t get_inspector_rpc_server_port() const { return inspector_settings.rpc_server_port; }

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -224,8 +224,6 @@ class RunTimeOptions {
     // Timeout duration for operations
     std::chrono::duration<float> timeout_duration_for_operations = std::chrono::duration<float>(0.0f);
 
-    // Using MGD 1.0 syntax for mesh graph descriptor in Fabric Control Plane
-    bool use_mesh_graph_descriptor_1_0 = false;
     // Using MGD 2.0 syntax for mesh graph descriptor
     bool use_mesh_graph_descriptor_2_0 = false;
 
@@ -549,10 +547,6 @@ public:
     std::chrono::duration<float> get_timeout_duration_for_operations() const { return timeout_duration_for_operations; }
     // Mesh graph descriptor version accessor
     bool get_use_mesh_graph_descriptor_2_0() const { return use_mesh_graph_descriptor_2_0; }
-
-    // Using MGD 1.0 syntax for mesh graph descriptor in Fabric Control Plane
-    // TODO: This will be removed after MGD 1.0 is deprecated
-    bool get_use_mesh_graph_descriptor_1_0() const { return use_mesh_graph_descriptor_1_0; }
 
     bool get_force_jit_compile() const { return force_jit_compile; }
     void set_force_jit_compile(bool enable) { force_jit_compile = enable; }


### PR DESCRIPTION
Supersedes Previous PR : https://github.com/tenstorrent/tt-metal/pull/30803
# Consolidate Environment Variable Parsing

## Overview
Consolidated scattered and redundant `getenv()` calls into a centralized switch-based system with inline documentation for all environment variables.

## Problem
- Redundant `getenv()` calls scattered across multiple functions
- Duplicate parsing logic
- No central documentation

## Solution
- **EnvVarID Enum**: Type-safe enumeration of all variables
- **HandleEnvVar()**: Single switch statement with all parsing logic
- **Inline Documentation**: Description, defaults, and examples for each variable

## Changes
- Consolidated 70+ environment variables into one location
- Removed redundant initialization code
- Applied code formatting fixes

## Testing
 All tests passing locally (device init, device pool, hardware validation)

**CI Workflows:**
- All post-commit: https://github.com/tenstorrent/tt-metal/actions/runs/19307654899
- BH post-commit: https://github.com/tenstorrent/tt-metal/actions/runs/19307647345

## Files Modified
- `tt_metal/llrt/rtoptions.cpp` 
- `tt_metal/llrt/rtoptions.hpp` 

## Benefits
- Single source of truth for all environment variables
- Eliminated code duplication
- Self-documenting with inline comments
- Easier to maintain and extend