### PR TITLE
Fix P300 QB GE Ethernet Channels/Connections in Cabling Generator

### DIFF
--- a/tools/scaleout/cabling_generator/cabling_generator.hpp
+++ b/tools/scaleout/cabling_generator/cabling_generator.hpp
@@ -134,7 +134,6 @@ private:
         const;
 
     // Caches for optimization
-    std::unordered_map<BoardType, Board> board_templates_;
     std::unordered_map<std::string, Node> node_templates_;  // Templates with host_id=0
 
     std::unique_ptr<ResolvedGraphInstance> root_instance_;

--- a/tools/scaleout/node/node.cpp
+++ b/tools/scaleout/node/node.cpp
@@ -257,7 +257,6 @@ public:
         // Add WARP400 connections
         auto* const warp400_connections = get_port_connections(&node, "WARP400");
         add_connection(warp400_connections, 1, 1, 2, 1);
-        add_connection(warp400_connections, 1, 2, 2, 2);
 
         return node;
     }


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
For the P300 boards, one of the internal trace channels was set to 4, but should have been 2.
This also revealed that we were missing validation in the board constructor to not have channels used in multiple ports.
For the P300 QB GE node, it only has the first WARP ports connected between the two cards, not both.

### What's changed
Change the internal trace from 4 to 2.
Add validation that channels are only associated with a single port for a board.
Remove adding the 2nd WARP connection for P300 QB GE node.
Minor cleanup to move the caching of boards from cabling generator to the board generator.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [x] New/Existing tests provide coverage for changes