### PR TITLE
[OFT] dropping in_place maxpool (as it's to be deprecated)

### DIFF
--- a/models/experimental/oft/demo/demo.py
+++ b/models/experimental/oft/demo/demo.py
@@ -54,7 +54,7 @@ from tests.ttnn.unit_tests.base_functionality.test_bh_20_cores_sharding import s
     "model_dtype, fallback_feedforward, fallback_lateral, fallback_oft, use_host_decoder, pcc_scores_oft, pcc_positions_oft, pcc_dimensions_oft, pcc_angles_oft",
     # fmt: off
     [
-       ( torch.float32, False, False, False, False, 0.905, 0.979, 0.999, 0.9288),
+       ( torch.float32, False, False, False, False, 0.905, 0.978, 0.999, 0.926),
     ],
     # fmt: on
 )

--- a/models/experimental/oft/tests/pcc/test_oftnet.py
+++ b/models/experimental/oft/tests/pcc/test_oftnet.py
@@ -37,10 +37,10 @@ from loguru import logger
     "model_dtype, use_host_oft, pcc_scores_oft, pcc_positions_oft, pcc_dimensions_oft, pcc_angles_oft",
     # fmt: off
     [
-       ( torch.bfloat16, False, 0.84, 0.889, 0.998, 0.904),
-       ( torch.bfloat16,  True, 0.862, 0.964, 0.999, 0.894),
-       ( torch.float32, False, 0.905, 0.979, 0.999, 0.928),
-       ( torch.float32,  True, 0.916, 0.881, 0.998, 0.918)
+       ( torch.bfloat16, False, 0.834, 0.890, 0.998, 0.908),
+       ( torch.bfloat16,  True, 0.855, 0.962, 0.999, 0.908),
+       ( torch.float32, False, 0.912, 0.978, 0.999, 0.926),
+       ( torch.float32,  True, 0.917, 0.882, 0.998, 0.918)
     ],
     # fmt: on
     ids=[

--- a/models/experimental/oft/tests/test_device_perf_oft.py
+++ b/models/experimental/oft/tests/test_device_perf_oft.py
@@ -31,7 +31,7 @@ from models.perf.device_perf_utils import run_model_device_perf_test
         ),
         (
             "pytest models/experimental/oft/demo/demo.py::test_demo_inference",
-            207_612_082,
+            206_531_096,
             "oft_full_demo",
             "oft_full_demo",
             1,

--- a/models/experimental/oft/tt/tt_resnet.py
+++ b/models/experimental/oft/tt/tt_resnet.py
@@ -131,7 +131,8 @@ class TTResNetFeatures:
                 padding=(conv_pt.maxpool.padding, conv_pt.maxpool.padding),
                 dilation=(conv_pt.maxpool.dilation, conv_pt.maxpool.dilation),
                 deallocate_input=True,
-                in_place=True,
+                output_layout=ttnn.TILE_LAYOUT,
+                dtype=ttnn.bfloat8_b,
             ),
             device=device,
         )
@@ -251,7 +252,8 @@ class TTResNetFeatures:
 
         host_gn = ttnn.to_torch(conv1).permute(0, 3, 1, 2)
         host_relu = ttnn.to_torch(conv1).permute(0, 3, 1, 2).reshape(1, 64, 192, 640)
-
+        logger.warning(f"{conv1.shape=} {conv1.dtype=} {conv1.layout=} {conv1.memory_config()=}")
+        conv1 = ttnn.typecast(conv1, ttnn.bfloat8_b)
         conv_1 = self.maxpool(conv1)
 
         conv_1 = ttnn.to_memory_config(

--- a/models/experimental/oft/tt/tt_resnet.py
+++ b/models/experimental/oft/tt/tt_resnet.py
@@ -252,7 +252,9 @@ class TTResNetFeatures:
 
         host_gn = ttnn.to_torch(conv1).permute(0, 3, 1, 2)
         host_relu = ttnn.to_torch(conv1).permute(0, 3, 1, 2).reshape(1, 64, 192, 640)
-        logger.warning(f"{conv1.shape=} {conv1.dtype=} {conv1.layout=} {conv1.memory_config()=}")
+
+        # typecast to bfloat8_b for maxpool to stay in L1
+        # cannot change previous op output, as groupnorm uses bfloat16-only
         conv1 = ttnn.typecast(conv1, ttnn.bfloat8_b)
         conv_1 = self.maxpool(conv1)
 


### PR DESCRIPTION
Dropping in_place maxpool (as it's to be deprecated) and using bfp8 max pool; perf improves and pcc drops slightly;

### Checklist
- [x] https://github.com/tenstorrent/tt-metal/actions/runs/19097578715
- [x] https://github.com/tenstorrent/tt-metal/actions/runs/19097581891