### PR TITLE
[skip ci] ci: run APC tests from L2 when doing uplift of LLK BH changes

### DIFF
--- a/.github/workflows/llk-auto-uplift-trigger.yaml
+++ b/.github/workflows/llk-auto-uplift-trigger.yaml
@@ -242,7 +242,7 @@ jobs:
             should-run: ${{ needs.update-submodule.outputs.should-run-blackhole }}
           - workflow: "tt-metal-l2-nightly.yaml"
             name: "TT-Metal L2 Nightly APC"
-            should-run: ${{ needs.update-submodule.outputs.should-run-wormhole }}
+            should-run: ${{ needs.update-submodule.outputs.should-run-wormhole == 'true' || needs.update-submodule.outputs.should-run-blackhole == 'true' }}
     steps:
       - name: Checkout
         if: matrix.should-run == 'true'
@@ -442,13 +442,6 @@ jobs:
               RESULTS+="- $(check_workflow "all-post-commit-workflows.yaml" "All Post Commit Workflows")"$'\n'
               ALL_PASSED=false
             fi
-
-            if check_workflow "tt-metal-l2-nightly.yaml" "TT-Metal L2 Nightly APC"; then
-              RESULTS+="- $(check_workflow "tt-metal-l2-nightly.yaml" "TT-Metal L2 Nightly APC")"$'\n'
-            else
-              RESULTS+="- $(check_workflow "tt-metal-l2-nightly.yaml" "TT-Metal L2 Nightly APC")"$'\n'
-              ALL_PASSED=false
-            fi
           fi
 
           if [ "$SHOULD_RUN_BH" = "true" ]; then
@@ -456,6 +449,15 @@ jobs:
               RESULTS+="- $(check_workflow "blackhole-post-commit.yaml" "Blackhole Post Commit")"$'\n'
             else
               RESULTS+="- $(check_workflow "blackhole-post-commit.yaml" "Blackhole Post Commit")"$'\n'
+              ALL_PASSED=false
+            fi
+          fi
+
+          if [ "$SHOULD_RUN_WH" = "true" ] || [ "$SHOULD_RUN_BH" = "true" ]; then
+            if check_workflow "tt-metal-l2-nightly.yaml" "TT-Metal L2 Nightly APC"; then
+              RESULTS+="- $(check_workflow "tt-metal-l2-nightly.yaml" "TT-Metal L2 Nightly APC")"$'\n'
+            else
+              RESULTS+="- $(check_workflow "tt-metal-l2-nightly.yaml" "TT-Metal L2 Nightly APC")"$'\n'
               ALL_PASSED=false
             fi
           fi
@@ -527,18 +529,6 @@ jobs:
               WH_URL=$(echo "$WH_RUNS" | jq -r '.url // ""')
               TEST_STATUS+="- ✅ **All Post Commit Workflows** passed: [View run]($WH_URL)"$'\n'
             fi
-
-            # Get TT-Metal L2 Nightly APC workflow results (filter by PR creation time if not recheck)
-            if [ "${{ inputs.recheck_tests }}" = "true" ]; then
-              L2_RUNS=$(gh run list --workflow "tt-metal-l2-nightly.yaml" --branch "${{ env.BRANCH_NAME }}" --limit 5 --json conclusion,url,status --jq 'map(select(.status == "completed")) | .[0] // empty' --repo "${{ github.repository }}")
-            else
-              L2_RUNS=$(gh run list --workflow "tt-metal-l2-nightly.yaml" --branch "${{ env.BRANCH_NAME }}" --limit 5 --json conclusion,url,status,createdAt --jq "map(select(.status == \"completed\" and .createdAt >= \"$PR_CREATED_AT\")) | .[0] // empty" --repo "${{ github.repository }}")
-            fi
-
-            if [ "$L2_RUNS" != "empty" ]; then
-              L2_URL=$(echo "$L2_RUNS" | jq -r '.url // ""')
-              TEST_STATUS+="- ✅ **TT-Metal L2 Nightly APC** passed: [View run]($L2_URL)"$'\n'
-            fi
           fi
 
           if [ "${{ needs.update-submodule.outputs.should-run-blackhole || 'false' }}" = "true" ] || [ "${{ inputs.recheck_tests }}" = "true" ]; then
@@ -552,6 +542,20 @@ jobs:
             if [ "$BH_RUNS" != "empty" ]; then
               BH_URL=$(echo "$BH_RUNS" | jq -r '.url // ""')
               TEST_STATUS+="- ✅ **Blackhole Post Commit** passed: [View run]($BH_URL)"$'\n'
+            fi
+          fi
+
+          if [ "${{ needs.update-submodule.outputs.should-run-wormhole || 'false' }}" = "true" ] || [ "${{ needs.update-submodule.outputs.should-run-blackhole || 'false' }}" = "true" ] || [ "${{ inputs.recheck_tests }}" = "true" ]; then
+            # Get TT-Metal L2 Nightly APC workflow results (filter by PR creation time if not recheck)
+            if [ "${{ inputs.recheck_tests }}" = "true" ]; then
+              L2_RUNS=$(gh run list --workflow "tt-metal-l2-nightly.yaml" --branch "${{ env.BRANCH_NAME }}" --limit 5 --json conclusion,url,status --jq 'map(select(.status == "completed")) | .[0] // empty' --repo "${{ github.repository }}")
+            else
+              L2_RUNS=$(gh run list --workflow "tt-metal-l2-nightly.yaml" --branch "${{ env.BRANCH_NAME }}" --limit 5 --json conclusion,url,status,createdAt --jq "map(select(.status == \"completed\" and .createdAt >= \"$PR_CREATED_AT\")) | .[0] // empty" --repo "${{ github.repository }}")
+            fi
+
+            if [ "$L2_RUNS" != "empty" ]; then
+              L2_URL=$(echo "$L2_RUNS" | jq -r '.url // ""')
+              TEST_STATUS+="- ✅ **TT-Metal L2 Nightly APC** passed: [View run]($L2_URL)"$'\n'
             fi
           fi
 

--- a/.github/workflows/llk-auto-uplift-trigger.yaml
+++ b/.github/workflows/llk-auto-uplift-trigger.yaml
@@ -165,10 +165,12 @@ jobs:
 
           # Create rich PR body
           cat > ../../../pr_body.md << EOF
+          <pre>
           ╔═════════════════════════════════════════════════╗
           ║    THIS IS AN AUTOMATED PULL REQUEST CREATED    ║
           ║              BY THE LLK UPLIFT BOT              ║
           ╚═════════════════════════════════════════════════╝
+          </pre>
           ## 📋 Summary
           This PR updates the LLK submodule to the latest version from the main branch.
 

--- a/.github/workflows/llk-auto-uplift-trigger.yaml
+++ b/.github/workflows/llk-auto-uplift-trigger.yaml
@@ -187,8 +187,8 @@ jobs:
           </details>
 
           ### 🏗️ Architecture Impact
-          $(if [ "$SHOULD_RUN_WH" = "true" ]; then echo "- ⚠️ **Wormhole** changes detected - will trigger all-post-commit tests"; fi)
-          $(if [ "$SHOULD_RUN_BH" = "true" ]; then echo "- ⚠️ **Blackhole** changes detected - will trigger blackhole-post-commit tests"; fi)
+          $(if [ "$SHOULD_RUN_WH" = "true" ]; then echo "- ⚠️ **Wormhole** changes detected - will trigger all-post-commit and tt-metal-l2-nightly tests"; fi)
+          $(if [ "$SHOULD_RUN_BH" = "true" ]; then echo "- ⚠️ **Blackhole** changes detected - will trigger blackhole-post-commit and tt-metal-l2-nightly tests"; fi)
           $(if [ "$SHOULD_RUN_WH" = "false" ] && [ "$SHOULD_RUN_BH" = "false" ]; then echo "- ℹ️ No architecture-specific changes detected"; fi)
 
           <!-- WORKFLOW_DECISIONS:should-run-wormhole=$SHOULD_RUN_WH,should-run-blackhole=$SHOULD_RUN_BH -->

--- a/.github/workflows/test-llk-metal-integration.yaml
+++ b/.github/workflows/test-llk-metal-integration.yaml
@@ -178,7 +178,7 @@ jobs:
           declare -A workflows
           workflows["all-post-commit-workflows.yaml"]="${{ inputs.run_all_post_commit }}"
           workflows["blackhole-post-commit.yaml"]="${{ inputs.run_blackhole_post_commit }}"
-          workflows["tt-metal-l2-nightly.yaml"]="${{ inputs.run_all_post_commit }}"
+          workflows["tt-metal-l2-nightly.yaml"]="${{ inputs.run_all_post_commit || inputs.run_blackhole_post_commit }}"
 
           declare -A run_ids
 
@@ -324,7 +324,7 @@ jobs:
           declare -A workflow_configs
           workflow_configs["all-post-commit-workflows.yaml"]="${{ inputs.run_all_post_commit }}:$ALL_POST_COMMIT_RUN_ID:all-post-commit-result"
           workflow_configs["blackhole-post-commit.yaml"]="${{ inputs.run_blackhole_post_commit }}:$BLACKHOLE_RUN_ID:blackhole-result"
-          workflow_configs["tt-metal-l2-nightly.yaml"]="${{ inputs.run_all_post_commit }}:$TT_METAL_L2_NIGHTLY_RUN_ID:tt-metal-l2-nightly-result"
+          workflow_configs["tt-metal-l2-nightly.yaml"]="${{ inputs.run_all_post_commit || inputs.run_blackhole_post_commit }}:$TT_METAL_L2_NIGHTLY_RUN_ID:tt-metal-l2-nightly-result"
           exit_code=0
           for workflow_file in "${!workflow_configs[@]}"; do
             IFS=':' read -r enabled run_id output_var <<< "${workflow_configs[$workflow_file]}"
@@ -417,7 +417,7 @@ jobs:
             declare -A test_configs
             test_configs["All Post-Commit Tests"]="${{ inputs.run_all_post_commit }}:${{ needs.setup-and-test.outputs.all-post-commit-result }}"
             test_configs["Blackhole Post-Commit Tests"]="${{ inputs.run_blackhole_post_commit }}:${{ needs.setup-and-test.outputs.blackhole-result }}"
-            test_configs["TT-Metal L2 Nightly APC Tests"]="${{ inputs.run_all_post_commit }}:${{ needs.setup-and-test.outputs.tt-metal-l2-nightly-result }}"
+            test_configs["TT-Metal L2 Nightly APC Tests"]="${{ inputs.run_all_post_commit || inputs.run_blackhole_post_commit }}:${{ needs.setup-and-test.outputs.tt-metal-l2-nightly-result }}"
 
             # Function to display test result
             display_test_result() {


### PR DESCRIPTION
### Ticket
None

### Problem description
During LLK submodule uplifts, we previously executed L2 APC tests only when there were Wormhole changes. Recently, some C++ Blackhole tests were moved to the L2 workflow. This requires us to run this workflow for LLK uplifts containing Blackhole changes as well.

### What's changed
With this change, configuration is the following:
- Wormhole changes only: Runs all-post-commit-workflows.yaml + tt-metal-l2-nightly.yaml
- Blackhole changes only: Runs blackhole-post-commit.yaml + **tt-metal-l2-nightly.yaml** (new)
- Both wormhole and blackhole changes: Runs all three workflows, but tt-metal-l2-nightly.yaml only once