### PR TITLE
Stopped deallocating DRAM input convs

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
@@ -4000,6 +4000,7 @@ def test_conv_yolov10x(
     ],
 )
 @pytest.mark.parametrize("slice_type, num_slices", [
+    (None, None),
     (L1Full,1), # no slicing
     (SliceHeight, 2),
 ])
@@ -4109,7 +4110,10 @@ def test_conv2d_act_dealloc(
         slice_config=slice_config,
         dtype=output_dtype,
     )
-    assert not tt_input_tensor.is_allocated(), "Input tensor is allocated"
+    if tt_input_tensor.memory_config().buffer_type == ttnn.BufferType.DRAM:
+        assert tt_input_tensor.is_allocated(), "DRAM input tensor is not allocated"
+    else:
+        assert not tt_input_tensor.is_allocated(), "Input tensor is allocated"
 
 
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
@@ -667,7 +667,10 @@ Result conv2d_L1(
                 true,
                 conv_config.config_tensors_in_dram);
 
-            if (should_deallocate_act) {
+            // In cases where input tensor is in DRAM and it gets sharded, we need to deallocate the sharded input
+            // tensor at this point (it will be deallocated automatically because nothing is using it, but reallocating
+            // halo output will be affected so we need to deallocate it manually before reallocating halo output)
+            if (conv_config.deallocate_activation && !input_tensor_post_tm.memory_config().is_dram()) {
                 input_tensor_post_tm.deallocate(/*force*/ true);
             }
 

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_pybind.cpp
@@ -364,6 +364,7 @@ void py_bind_conv2d(py::module& module) {
         Boolean that indicates whether the activation tensor should be deallocated after the conv op is done.
         If true, the activation tensor will be deallocated after the halo micro-op is done.
         Should not be used if the input to the conv op is used by another op.
+        Has no effect if input tensor is in DRAM.
         )doc");
     py_conv_config.def_readwrite("reallocate_halo_output", &Conv2dConfig::reallocate_halo_output, R"doc(
         reallocate_halo_output is a boolean that indicates whether the halo output tensor should be moved to reduce memory fragmentation, before the conv micro-op is called.

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
@@ -753,8 +753,7 @@ std::tuple<ttnn::Tensor, ParallelConfig, ParallelConfig> shard_or_reshard_tensor
                 parallel_config.shard_scheme != TensorMemoryLayout::HEIGHT_SHARDED) {
                 // Workaround #13979 ttnn::tilize doesn't support BLOCK_SHARDED layout
                 Tensor input_tensor_tilized = ttnn::to_layout(input_tensor, Layout::TILE);
-                if (conv_config.deallocate_activation &&
-                    input_tensor.memory_config().buffer_type() != BufferType::DRAM) {
+                if (conv_config.deallocate_activation && !input_tensor.memory_config().is_dram()) {
                     input_tensor.deallocate(/*force*/ true);
                     input_tensor_tilized = ttnn::move(input_tensor_tilized);
                 }
@@ -783,8 +782,7 @@ std::tuple<ttnn::Tensor, ParallelConfig, ParallelConfig> shard_or_reshard_tensor
                     input_tensor.device());
                 ttnn::to_memory_config(
                     input_tensor, input_tensor_sharded_memory_config_to_layout, std::nullopt, resharded_input_tensor);
-                if (conv_config.deallocate_activation &&
-                    input_tensor.memory_config().buffer_type() != BufferType::DRAM) {
+                if (conv_config.deallocate_activation && !input_tensor.memory_config().is_dram()) {
                     input_tensor.deallocate(/*force*/ true);
                     resharded_input_tensor = ttnn::move(resharded_input_tensor);
                 }
@@ -1614,7 +1612,7 @@ Tensor fold_input_tensor_if_required(
         auto folding_result = compute_kernel_stride_folding_params(
             input_height, input_width, in_channels, kernel_size, stride, padding_n4, conv_config);
         auto folded_input_tensor = fold_tensor(input_tensor, device, stride, kernel_size, padding_n4);
-        if (conv_config.deallocate_activation && input_tensor.memory_config().buffer_type() != BufferType::DRAM) {
+        if (conv_config.deallocate_activation && !input_tensor.memory_config().is_dram()) {
             auto tensor_to_deallocate = input_tensor;
             tensor_to_deallocate.deallocate(true);
         }

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op.hpp
@@ -29,7 +29,7 @@ struct Conv2dConfig {
     // Fused activation function as UnaryWithParam
     std::optional<ttnn::operations::unary::UnaryWithParam> activation = std::nullopt;
 
-    // If user tensor will be deallocated if it's on device.
+    // If user tensor will be deallocated if it's on device in L1 (will have no effect if input tensor is in DRAM).
     bool deallocate_activation = false;
 
     // If true && dellocate_activation is true, then after halo device op is done,


### PR DESCRIPTION
### Ticket
closes https://github.com/tenstorrent/tt-metal/issues/30734

### Problem description
Previously setting `Conv2d.deallocate_activation` deallocated inputs even if it was in DRAM.

### What's changed
- Stopped `Conv2d.deallocate_activation` deallocating DRAM inputs

### Checklist
- [X] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/19102150256)
- [X] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/19102166243)
- [X] [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI [relevants test pass](https://github.com/tenstorrent/tt-metal/actions/runs/19102171224)
- [X] [Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/blob/main/.github/workflows/tt-metal-l2-nightly.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/19102337480)