### PR TITLE
#31905: [skip ci] Switch to deskbox sim hw while POR system is offline

### DIFF
--- a/.github/workflows/blackhole-multi-card-demo-tests.yaml
+++ b/.github/workflows/blackhole-multi-card-demo-tests.yaml
@@ -39,7 +39,7 @@ jobs:
             num_devices: 4
           - name: DeskBox Demo tests
             runner-label: BH-DeskBox
-            extra-tag: pipeline-perf
+            extra-tag: pipeline-functional
             num_devices: 2
           - name: LoudBox Demo tests
             runner-label: BH-LoudBox

--- a/.github/workflows/blackhole-nightly-tests.yaml
+++ b/.github/workflows/blackhole-nightly-tests.yaml
@@ -87,7 +87,7 @@ jobs:
             num_devices: 4
           - name: DeskBox Demo tests
             runner-label: BH-DeskBox
-            extra-tag: pipeline-perf
+            extra-tag: pipeline-functional
             num_devices: 2
           - name: LoudBox Demo tests
             runner-label: BH-LoudBox

--- a/.github/workflows/release-build-test-publish.yaml
+++ b/.github/workflows/release-build-test-publish.yaml
@@ -113,7 +113,7 @@ jobs:
             num_devices: 4
           - name: DeskBox Demo tests
             runner-label: BH-DeskBox
-            extra-tag: pipeline-perf
+            extra-tag: pipeline-functional
             num_devices: 2
           - name: LoudBox Demo tests
             runner-label: BH-LoudBox

--- a/.github/workflows/upstream-tests.yaml
+++ b/.github/workflows/upstream-tests.yaml
@@ -224,22 +224,27 @@ jobs:
         bh-config:
           - runner-label: BH-LLMBox
             image-name: ${{ needs.get-image-tags.outputs.bh-llmbox-image-tag }}
+            extra-tag: pipeline-perf
           - runner-label: BH-DeskBox
             image-name: ${{ needs.get-image-tags.outputs.bh-deskbox-image-tag }}
+            extra-tag: pipeline-functional
           - runner-label: BH-LoudBox
             image-name: ${{ needs.get-image-tags.outputs.bh-loudbox-image-tag }}
+            extra-tag: pipeline-perf
           - runner-label: BH-QB-GE
             image-name: ${{ needs.get-image-tags.outputs.bh-qb-ge-image-tag }}
+            extra-tag: pipeline-perf
     runs-on:
       - ${{ matrix.bh-config.runner-label }}
       - in-service
-      - pipeline-perf
+      - ${{ matrix.bh-config.extra-tag }}
     steps:
       - name: Run image
         timeout-minutes: 30
         env:
-          HF_MODEL: /localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.1-8B-Instruct
-          TT_CACHE_PATH: /localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.1-8B-Instruct
+          # For different environments, BH VLAN vs. cloud
+          HF_MODEL: ${{ matrix.bh-config.extra-tag == 'pipeline-perf' && '/localdev/blackhole_demos/huggingface_data' || '/mnt/MLPerf/tt_dnn-models' }}/meta-llama/Llama-3.1-8B-Instruct
+          TT_CACHE_PATH: ${{ matrix.bh-config.extra-tag == 'pipeline-perf' && '/localdev/blackhole_demos/huggingface_data' || '/mnt/MLPerf/tt_dnn-models' }}/meta-llama/Llama-3.1-8B-Instruct
         run: docker run --network none -v /dev/hugepages-1G:/dev/hugepages-1G --device /dev/tenstorrent -v $HF_MODEL:$HF_MODEL:ro -e HF_MODEL -e TT_CACHE_PATH ${{ matrix.bh-config.image-name }}
   test-bh-p300-image:
     needs:


### PR DESCRIPTION
### Ticket
#31905

### Problem description
Baremetal deskbox bh-db-02 is offline, so jobs targetting `pipeline-perf` are stuck in queue

### What's changed
Switch to `pipeline-functional` for now while system is offline