### PR TITLE
Fix DRAM aligment on BH for moreh fold

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_fold.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_fold.py
@@ -7,7 +7,7 @@ import torch
 import ttnn
 
 from loguru import logger
-from models.common.utility_functions import comp_allclose_and_pcc, skip_for_blackhole
+from models.common.utility_functions import comp_allclose_and_pcc
 
 
 def run_fold_test(device, input_shape, output_size, kernel_size, dilation, padding, stride, dtype):

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_fold.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_fold.py
@@ -33,7 +33,6 @@ def run_fold_test(device, input_shape, output_size, kernel_size, dilation, paddi
     assert passing
 
 
-@skip_for_blackhole("Fails on BH. Issue #20577")
 @pytest.mark.parametrize(
     "input_shape,output_size,kernel_size,dilation,padding,stride",
     [


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/20577)

### Problem description
ttnn.operations.moreh.fold doesn't respect DRAM alignment when reading from DRAM.

### What's changed
Add temp CB to transfer from DRAM -> L1 which is DRAM aligned in cases where it's necessary.

### Checklist
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/19107853362)