### PR TITLE
[skip ci] ci: fix condition for running tests during LLK uplift

### DIFF
--- a/.github/workflows/llk-auto-uplift-trigger.yaml
+++ b/.github/workflows/llk-auto-uplift-trigger.yaml
@@ -244,7 +244,7 @@ jobs:
             should-run: ${{ needs.update-submodule.outputs.should-run-blackhole }}
           - workflow: "tt-metal-l2-nightly.yaml"
             name: "TT-Metal L2 Nightly APC"
-            should-run: ${{ needs.update-submodule.outputs.should-run-wormhole == 'true' || needs.update-submodule.outputs.should-run-blackhole == 'true' }}
+            should-run: ${{ (needs.update-submodule.outputs.should-run-wormhole == 'true' || needs.update-submodule.outputs.should-run-blackhole == 'true') && 'true' || 'false' }}
     steps:
       - name: Checkout
         if: matrix.should-run == 'true'


### PR DESCRIPTION
### Ticket
None

### Problem description
Previous change that landed in metal today, https://github.com/tenstorrent/tt-metal/pull/31899, introduced a problem for running C++ tests from L2 Nightly workflow. Jobs weren't starting because of unsatisfied condition.

### What's changed
Updated the should-run condition for the "TT-Metal L2 Nightly APC" workflow to explicitly convert the boolean result to a string value ('true' or 'false')