### PR TITLE
[skip ci] #22995, #23002, #23003: add pytests to mean, std, and var sweep tests

### DIFF
--- a/tests/sweep_framework/sweeps/reduction/mean/mean.py
+++ b/tests/sweep_framework/sweeps/reduction/mean/mean.py
@@ -6,6 +6,7 @@ from typing import Optional, Tuple
 from functools import partial
 import numpy as np
 
+import pytest
 import torch
 import random
 import ttnn
@@ -82,11 +83,8 @@ def invalidate_vector(test_vector) -> Tuple[bool, Optional[str]]:
     return False, None
 
 
-# This is the run instructions for the test, defined by the developer.
-# The run function must take the above-defined parameters as inputs.
-# The runner will call this run function with each test vector, and the returned results from this function will be stored.
-# If you defined a mesh_device_fixture above, the object you yielded will be passed into this function as 'device'. Otherwise, it will be the default ttnn device opened by the infra.
-def run(
+def run_mean(
+    device,
     input_shape,
     dim,
     keepdim,
@@ -94,8 +92,6 @@ def run(
     input_layout,
     input_a_memory_config,
     output_memory_config,
-    *,
-    device,
 ) -> list:
     data_seed = random.randint(0, 20000000)
     torch.manual_seed(data_seed)
@@ -125,3 +121,45 @@ def run(
     expected_pcc = 0.999
     tensors = [input_tensor_a, op_output_tensor]
     return get_run_return(torch_output_tensor, output_tensor, expected_pcc, tensors, e2e_perf)
+
+
+@pytest.mark.parametrize("input_shape", parameters["nightly"]["input_shape"])
+@pytest.mark.parametrize("dim", parameters["nightly"]["dim"])
+@pytest.mark.parametrize("keepdim", parameters["nightly"]["keepdim"])
+@pytest.mark.parametrize("input_a_dtype", parameters["nightly"]["input_a_dtype"])
+@pytest.mark.parametrize("input_layout", parameters["nightly"]["input_layout"])
+@pytest.mark.parametrize("input_a_memory_config", parameters["nightly"]["input_a_memory_config"])
+@pytest.mark.parametrize("output_memory_config", parameters["nightly"]["output_memory_config"])
+def test_mean(
+    device, input_shape, dim, keepdim, input_a_dtype, input_layout, input_a_memory_config, output_memory_config
+):
+    run_mean(
+        device, input_shape, dim, keepdim, input_a_dtype, input_layout, input_a_memory_config, output_memory_config
+    )
+
+
+# This is the run instructions for the test, defined by the developer.
+# The run function must take the above-defined parameters as inputs.
+# The runner will call this run function with each test vector, and the returned results from this function will be stored.
+# If you defined a mesh_device_fixture above, the object you yielded will be passed into this function as 'device'. Otherwise, it will be the default ttnn device opened by the infra.
+def run(
+    input_shape,
+    dim,
+    keepdim,
+    input_a_dtype,
+    input_layout,
+    input_a_memory_config,
+    output_memory_config,
+    *,
+    device,
+) -> list:
+    return run_mean(
+        device,
+        input_shape,
+        dim,
+        keepdim,
+        input_a_dtype,
+        input_layout,
+        input_a_memory_config,
+        output_memory_config,
+    )

--- a/tests/sweep_framework/sweeps/reduction/var/var.py
+++ b/tests/sweep_framework/sweeps/reduction/var/var.py
@@ -6,6 +6,7 @@ from typing import Optional, Tuple
 from functools import partial
 import numpy as np
 
+import pytest
 import torch
 import random
 import ttnn
@@ -85,11 +86,8 @@ def invalidate_vector(test_vector) -> Tuple[bool, Optional[str]]:
     return False, None
 
 
-# This is the run instructions for the test, defined by the developer.
-# The run function must take the above-defined parameters as inputs.
-# The runner will call this run function with each test vector, and the returned results from this function will be stored.
-# If you defined a mesh_device_fixture above, the object you yielded will be passed into this function as 'device'. Otherwise, it will be the default ttnn device opened by the infra.
-def run(
+def run_var(
+    device,
     input_shape,
     dim,
     keepdim,
@@ -97,8 +95,6 @@ def run(
     input_layout,
     input_a_memory_config,
     output_memory_config,
-    *,
-    device,
 ) -> list:
     data_seed = random.randint(0, 20000000)
     torch.manual_seed(data_seed)
@@ -128,3 +124,43 @@ def run(
     expected_pcc = 0.999
     tensors = [input_tensor_a, op_output_tensor]
     return get_run_return(torch_output_tensor, output_tensor, expected_pcc, tensors, e2e_perf)
+
+
+@pytest.mark.parametrize("input_shape", parameters["xfail"]["input_shape"])
+@pytest.mark.parametrize("dim", parameters["xfail"]["dim"])
+@pytest.mark.parametrize("keepdim", parameters["xfail"]["keepdim"])
+@pytest.mark.parametrize("input_a_dtype", parameters["xfail"]["input_a_dtype"])
+@pytest.mark.parametrize("input_layout", parameters["xfail"]["input_layout"])
+@pytest.mark.parametrize("input_a_memory_config", parameters["xfail"]["input_a_memory_config"])
+@pytest.mark.parametrize("output_memory_config", parameters["xfail"]["output_memory_config"])
+def test_var(
+    device, input_shape, dim, keepdim, input_a_dtype, input_layout, input_a_memory_config, output_memory_config
+):
+    run_var(device, input_shape, dim, keepdim, input_a_dtype, input_layout, input_a_memory_config, output_memory_config)
+
+
+# This is the run instructions for the test, defined by the developer.
+# The run function must take the above-defined parameters as inputs.
+# The runner will call this run function with each test vector, and the returned results from this function will be stored.
+# If you defined a mesh_device_fixture above, the object you yielded will be passed into this function as 'device'. Otherwise, it will be the default ttnn device opened by the infra.
+def run(
+    input_shape,
+    dim,
+    keepdim,
+    input_a_dtype,
+    input_layout,
+    input_a_memory_config,
+    output_memory_config,
+    *,
+    device,
+) -> list:
+    return run_var(
+        device,
+        input_shape,
+        dim,
+        keepdim,
+        input_a_dtype,
+        input_layout,
+        input_a_memory_config,
+        output_memory_config,
+    )


### PR DESCRIPTION
### Ticket
#22995, #23002, #23003

### Problem description
pytests were missing in some sweep tests

### What's changed
Add the pytests

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes