### PR TITLE
Enable llama 70b prefill tracing in TT Transformers

### DIFF
--- a/.github/workflows/blackhole-multi-card-demo-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-demo-tests-impl.yaml
@@ -157,11 +157,11 @@ jobs:
             arch: blackhole
             cmd: HF_MODEL=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.3-70B-Instruct TT_CACHE_PATH=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.3-70B-Instruct pytest models/tt_transformers/demo/simple_text_demo.py -k "performance and ci-32"
             owner_id: U03PUAKE719 # Miguel Tairum
-          - name: "llama3.3-70b ${{ inputs.runner-label }} batch-1 TP device perf decode"
+          - name: "llama3.3-70b ${{ inputs.runner-label }} batch-1 TP device perf prefill"
             arch: blackhole
             cmd: HF_MODEL=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.3-70B-Instruct pytest models/tt_transformers/tests/test_device_perf.py -k "prefill-llama3_70b-2-1024-10-1-1-False"
             owner_id: U08GELBB1AP # Ambrose Ling
-          - name: "llama3.3-70b ${{ inputs.runner-label }} batch-1 TP device perf prefill"
+          - name: "llama3.3-70b ${{ inputs.runner-label }} batch-1 TP device perf decode"
             arch: blackhole
             cmd: HF_MODEL=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.3-70B-Instruct pytest models/tt_transformers/tests/test_device_perf.py -k "decode-llama3_70b-2-1024-10-1-1-False"
             owner_id: U08GELBB1AP # Ambrose Ling

--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -1836,7 +1836,7 @@ class ModelArgs:
         """
         # Trace in prefill is currently supported only for Llama-3.1-8B, Llama-3.1-70B, Llama-3.3-70B
         # TODO: (https://github.com/tenstorrent/tt-metal/issues/25722) Support all other models that use tt_transformers
-        if self.base_model_name != "Llama-3.1-8B" and "70B" not in self.base_model_name:
+        if self.base_model_name not in ["Llama-3.1-8B", "Llama-3.1-70B", "Llama-3.3-70B"]:
             return False
         if hasattr(self, "sliding_window") and getattr(self, "sliding_window") != None:
             return False

--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -1834,9 +1834,9 @@ class ModelArgs:
         There is no support to pass them as a tensor, and then inside the trace read it as a number.
         # TODO: Support sliding window attention - This PR disabled tracing if a model uses sliding window attention, because this PR mainly covers models without sliding window attention. (for example,Llama-8B).
         """
-        # Trace in prefill is currently supported only for Llama-3.1-8B
+        # Trace in prefill is currently supported only for Llama-3.1-8B, Llama-3.1-70B, Llama-3.3-70B
         # TODO: (https://github.com/tenstorrent/tt-metal/issues/25722) Support all other models that use tt_transformers
-        if self.base_model_name != "Llama-3.1-8B":
+        if self.base_model_name != "Llama-3.1-8B" and "70B" not in self.base_model_name:
             return False
         if hasattr(self, "sliding_window") and getattr(self, "sliding_window") != None:
             return False


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/24441
extending work done here: https://github.com/tenstorrent/tt-metal/pull/29827

### Problem description
Allow compiling all prefill traces for all sequence lengths for Llama 70b before model run to avoid memory clobbering and enable prefill tracing 


### Whats changed
- Add check for llama 70b model to enable prefill traces
- Fix a error in the blackhole demo card pipeline test names
- TTFT dropped from 186.48m to 153.57 ms for BH LB 

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Multi card Demo](https://github.com/tenstorrent/tt-metal/actions/runs/19111888369)