### PR TITLE
[DM] Test DRAM sharded stateful transaction ID read and generalize API names

### DIFF
--- a/tests/tt_metal/tt_metal/data_movement/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/README.md
@@ -42,7 +42,7 @@ Both API versions run the same test cases but use different underlying implement
 | Conv Hardcoded              | 21-23                | Uses existing conv tests to analyse their bandwidth and latency. **(Slow Dispatch)**    |
 | Interleaved Page Read/Write | 61-69, 71-75         | Reads and writes pages between interleaved buffers and a Tensix core.                   |
 | One Packet Read/Write       | 80-83                | Reads or writes packets between two Tensix cores.                                       |
-| DRAM Sharded Read           | 84-86                | Reads from sharded DRAM into one core.                                                  |
+| DRAM Sharded Read           | 84-87                | Reads from sharded DRAM into one core.                                                  |
 | Multi Interleaved           | 110-127              | Reads and writes pages between interleaved DRAM buffers and multiple Tensix cores.      |
 | Core Bidrectional           | 140-148              | Tensix core reads from and writes to another Tensix core simultaneously.                |
 | Deinterleave                | 200-201              | Tests deinterleaving. **(Slow Dispatch)**                                               |

--- a/tests/tt_metal/tt_metal/data_movement/dram_sharded/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/dram_sharded/README.md
@@ -12,6 +12,8 @@ Runs the reader kernel on a Tensix core. After initializing a sharded DRAM buffe
 
 Test attributes such as number of DRAM banks to shard into and number of tiles per bank, as well as latency measures like kernel and pre-determined scope cycles are recorded by the profiler. Resulting data is cross-checked with original data and validated through a pcc check.
 
+An additional flag can be set to use a stateful read with transaction IDs, for testing the functionality of those APIs.
+
 Test expectations are that pcc checks pass and sufficient test attribute data is captured by the profiler for higher level bandwidth/regression checks.
 
 ## Running the Tests
@@ -30,6 +32,8 @@ The tests use the Mesh Device API with fast dispatch mode:
 | page_size_bytes           | uint32_t              | Size of a page in bytes. |
 | l1_data_format            | DataFormat            | Type of data in transaction. |
 | cores                     | CoreRangeSet          | Tensix core that the kernel is run on. |
+| use_trid                  | bool                  | Whether to use transaction IDs. |
+| num_of_trids              | uint32_t              | Number of transaction IDs to use. |
 
 ## Test Cases
 Each test case uses bfloat16 as L1 data format.
@@ -39,3 +43,4 @@ Each test case has multiple runs, and each run has a unique runtime host id, ass
 1. DRAM Sharded Read Directed Ideal: Tests the most optimal transactions for reading packets by maximizing the number of pages, banks, and transactions to amortize initialization overhead and saturate the bandwidth.
 2. DRAM Sharded Read Tile Numbers: Tests reading over varying number of pages per DRAM bank.
 3. DRAM Sharded Read Bank Numbers: Tests reading over varying numbers of DRAM banks.
+4. DRAM Sharded Read Trid Directed Ideal: Tests reading from DRAM sharded with transaction IDs.

--- a/tests/tt_metal/tt_metal/data_movement/dram_sharded/kernels/dram_sharded_read.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/dram_sharded/kernels/dram_sharded_read.cpp
@@ -29,7 +29,7 @@ void kernel_main() {
 
     {
         DeviceZoneScopedN("RISCV0");
-        for (uint32_t i = 0; i < num_of_transactions; i++) {
+        for (uint32_t n = 0; n < num_of_transactions; n++) {
             dst_addr = l1_addr;
             for (uint32_t bank_id = 0; bank_id < num_banks; bank_id++) {
                 uint64_t src_noc_addr = get_noc_addr_from_bank_id<true>(bank_id, src_addr);

--- a/tests/tt_metal/tt_metal/data_movement/dram_sharded/kernels/dram_sharded_read_trid.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/dram_sharded/kernels/dram_sharded_read_trid.cpp
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include <cstdint>
+#include "dataflow_api.h"
+#include "tensix_types.h"
+
+// #include "debug/dprint.h"
+// #include "debug/dprint_pages.h"
+
+// DRAM to L1 read
+void kernel_main() {
+    uint32_t src_addr = get_arg_val<uint32_t>(0);
+    uint32_t l1_addr = get_arg_val<uint32_t>(1);
+
+    constexpr uint32_t num_of_transactions = get_compile_time_arg_val(0);
+    constexpr uint32_t num_banks = get_compile_time_arg_val(1);
+    constexpr uint32_t pages_per_bank = get_compile_time_arg_val(2);
+    constexpr uint32_t page_size_bytes = get_compile_time_arg_val(3);
+    constexpr uint32_t test_id = get_compile_time_arg_val(4);
+    constexpr uint32_t num_of_trids = get_compile_time_arg_val(5);
+
+    DeviceTimestampedData("Number of transactions", num_of_transactions);
+    DeviceTimestampedData("Transaction size in bytes", num_banks * pages_per_bank * page_size_bytes);
+    DeviceTimestampedData("Test id", test_id);
+
+    uint32_t dst_addr = l1_addr;
+    uint32_t curr_trid = 0;
+    {
+        DeviceZoneScopedN("RISCV0");
+        for (uint32_t i = 0; i < num_of_transactions; i++) {
+            dst_addr = l1_addr;
+
+            for (uint32_t bank_id = 0; bank_id < num_banks; bank_id++) {
+                uint64_t src_noc_addr = get_noc_addr_from_bank_id<true>(bank_id, src_addr);
+                noc_async_read_one_packet_set_state(src_noc_addr, page_size_bytes);
+
+                for (uint32_t i = 0; i < pages_per_bank; i++) {
+                    noc_async_read_tile_dram_sharded_set_trid(curr_trid);
+                    noc_async_read_tile_dram_sharded_with_state_with_trid(
+                        src_noc_addr, i * page_size_bytes, dst_addr, curr_trid);
+                    dst_addr += page_size_bytes;
+                    curr_trid = (curr_trid + 1) % num_of_trids;  // keep trid between 0 and num_of_trids-1
+                }
+            }
+        }
+        for (uint32_t t = 0; t < num_of_trids; t++) {
+            noc_async_read_barrier_with_trid(t);
+        }
+        // noc_async_read_barrier();
+    }
+}

--- a/tests/tt_metal/tt_metal/data_movement/dram_sharded/kernels/dram_sharded_read_trid.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/dram_sharded/kernels/dram_sharded_read_trid.cpp
@@ -32,11 +32,9 @@ void kernel_main() {
         DeviceZoneScopedN("RISCV0");
         for (uint32_t i = 0; i < num_of_transactions; i++) {
             dst_addr = l1_addr;
-
             for (uint32_t bank_id = 0; bank_id < num_banks; bank_id++) {
                 uint64_t src_noc_addr = get_noc_addr_from_bank_id<true>(bank_id, src_addr);
                 noc_async_read_one_packet_set_state(src_noc_addr, page_size_bytes);
-
                 for (uint32_t i = 0; i < pages_per_bank; i++) {
                     noc_async_read_tile_dram_sharded_set_trid(curr_trid);
                     noc_async_read_tile_dram_sharded_with_state_with_trid(
@@ -49,6 +47,5 @@ void kernel_main() {
         for (uint32_t t = 0; t < num_of_trids; t++) {
             noc_async_read_barrier_with_trid(t);
         }
-        // noc_async_read_barrier();
     }
 }

--- a/tests/tt_metal/tt_metal/data_movement/dram_sharded/kernels/dram_sharded_read_trid.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/dram_sharded/kernels/dram_sharded_read_trid.cpp
@@ -35,10 +35,9 @@ void kernel_main() {
             for (uint32_t bank_id = 0; bank_id < num_banks; bank_id++) {
                 uint64_t src_noc_addr = get_noc_addr_from_bank_id<true>(bank_id, src_addr);
                 noc_async_read_one_packet_set_state(src_noc_addr, page_size_bytes);
-                noc_async_read_tile_dram_sharded_set_trid(curr_trid);
+                noc_async_read_set_trid(curr_trid);
                 for (uint32_t i = 0; i < pages_per_bank; i++) {
-                    noc_async_read_tile_dram_sharded_with_state_with_trid(
-                        src_noc_addr, i * page_size_bytes, dst_addr, curr_trid);
+                    noc_async_read_tile_with_state_with_trid(src_noc_addr, i * page_size_bytes, dst_addr, curr_trid);
                     dst_addr += page_size_bytes;
                 }
                 curr_trid = (curr_trid + 1) % num_of_trids;  // keep trid between 0 and num_of_trids-1

--- a/tests/tt_metal/tt_metal/data_movement/dram_sharded/kernels/dram_sharded_read_trid.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/dram_sharded/kernels/dram_sharded_read_trid.cpp
@@ -35,13 +35,13 @@ void kernel_main() {
             for (uint32_t bank_id = 0; bank_id < num_banks; bank_id++) {
                 uint64_t src_noc_addr = get_noc_addr_from_bank_id<true>(bank_id, src_addr);
                 noc_async_read_one_packet_set_state(src_noc_addr, page_size_bytes);
+                noc_async_read_tile_dram_sharded_set_trid(curr_trid);
                 for (uint32_t i = 0; i < pages_per_bank; i++) {
-                    noc_async_read_tile_dram_sharded_set_trid(curr_trid);
                     noc_async_read_tile_dram_sharded_with_state_with_trid(
                         src_noc_addr, i * page_size_bytes, dst_addr, curr_trid);
                     dst_addr += page_size_bytes;
-                    curr_trid = (curr_trid + 1) % num_of_trids;  // keep trid between 0 and num_of_trids-1
                 }
+                curr_trid = (curr_trid + 1) % num_of_trids;  // keep trid between 0 and num_of_trids-1
             }
         }
         for (uint32_t t = 0; t < num_of_trids; t++) {

--- a/tests/tt_metal/tt_metal/data_movement/dram_sharded/kernels/dram_sharded_read_trid.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/dram_sharded/kernels/dram_sharded_read_trid.cpp
@@ -37,7 +37,8 @@ void kernel_main() {
                 noc_async_read_one_packet_set_state(src_noc_addr, page_size_bytes);
                 noc_async_read_set_trid(curr_trid);
                 for (uint32_t i = 0; i < pages_per_bank; i++) {
-                    noc_async_read_tile_with_state_with_trid(src_noc_addr, i * page_size_bytes, dst_addr, curr_trid);
+                    noc_async_read_one_packet_with_state_with_trid(
+                        src_noc_addr, i * page_size_bytes, dst_addr, curr_trid);
                     dst_addr += page_size_bytes;
                 }
                 curr_trid = (curr_trid + 1) % num_of_trids;  // keep trid between 0 and num_of_trids-1

--- a/tests/tt_metal/tt_metal/data_movement/dram_sharded/kernels/dram_sharded_read_trid.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/dram_sharded/kernels/dram_sharded_read_trid.cpp
@@ -27,7 +27,7 @@ void kernel_main() {
     DeviceTimestampedData("Test id", test_id);
 
     uint32_t dst_addr = l1_addr;
-    uint32_t curr_trid = 0;
+    uint32_t curr_trid = 1;  // Start trids from 1, 0 may break in the future
     {
         DeviceZoneScopedN("RISCV0");
         for (uint32_t n = 0; n < num_of_transactions; n++) {
@@ -41,10 +41,10 @@ void kernel_main() {
                         src_noc_addr, i * page_size_bytes, dst_addr, curr_trid);
                     dst_addr += page_size_bytes;
                 }
-                curr_trid = (curr_trid + 1) % num_of_trids;  // keep trid between 0 and num_of_trids-1
+                curr_trid = (curr_trid % (num_of_trids - 1)) + 1;  // keep trid between 1 and num_of_trids-1
             }
         }
-        for (uint32_t t = 0; t < num_of_trids; t++) {
+        for (uint32_t t = 1; t < num_of_trids; t++) {
             noc_async_read_barrier_with_trid(t);
         }
     }

--- a/tests/tt_metal/tt_metal/data_movement/dram_sharded/kernels/dram_sharded_read_trid.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/dram_sharded/kernels/dram_sharded_read_trid.cpp
@@ -30,7 +30,7 @@ void kernel_main() {
     uint32_t curr_trid = 0;
     {
         DeviceZoneScopedN("RISCV0");
-        for (uint32_t i = 0; i < num_of_transactions; i++) {
+        for (uint32_t n = 0; n < num_of_transactions; n++) {
             dst_addr = l1_addr;
             for (uint32_t bank_id = 0; bank_id < num_banks; bank_id++) {
                 uint64_t src_noc_addr = get_noc_addr_from_bank_id<true>(bank_id, src_addr);

--- a/tests/tt_metal/tt_metal/data_movement/dram_sharded/test_dram_sharded.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/dram_sharded/test_dram_sharded.cpp
@@ -240,7 +240,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementDRAMShardedReadBankNumbers) {
     }
 }
 
-/* ========== Directed Ideal Test Case; Test id = 84 ========== */
+/* ========== Directed Ideal Test Case with Transaction IDs; Test id = 87 ========== */
 TEST_F(GenericMeshDeviceFixture, TensixDataMovementDRAMShardedReadTridDirectedIdeal) {
     auto mesh_device = get_mesh_device();
 

--- a/tests/tt_metal/tt_metal/data_movement/dram_sharded/test_dram_sharded.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/dram_sharded/test_dram_sharded.cpp
@@ -28,6 +28,8 @@ struct DramShardedConfig {
     uint32_t page_size_bytes = 0;
     DataFormat l1_data_format = DataFormat::Invalid;
     CoreRangeSet cores;
+    bool use_trid = false;
+    uint32_t num_of_trids = 0;
 };
 
 /// @brief Reads from Sharded DRAM to L1 using stateful API
@@ -86,10 +88,17 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const DramSh
         (uint32_t)test_config.page_size_bytes,
         (uint32_t)test_config.test_id};
 
+    string kernel_path = "tests/tt_metal/tt_metal/data_movement/dram_sharded/kernels/dram_sharded_read";
+    if (test_config.use_trid) {
+        kernel_path += "_trid";
+        reader_compile_args.push_back((uint32_t)test_config.num_of_trids);
+    }
+    kernel_path += ".cpp";
+
     // Kernels
     auto reader_kernel = CreateKernel(
         program,
-        "tests/tt_metal/tt_metal/data_movement/dram_sharded/kernels/dram_sharded_read.cpp",
+        kernel_path,
         test_config.cores,
         DataMovementConfig{
             .processor = DataMovementProcessor::RISCV_0,
@@ -229,6 +238,35 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementDRAMShardedReadBankNumbers) {
             EXPECT_TRUE(run_dm(mesh_device, test_config));
         }
     }
+}
+
+/* ========== Directed Ideal Test Case; Test id = 84 ========== */
+TEST_F(GenericMeshDeviceFixture, TensixDataMovementDRAMShardedReadTridDirectedIdeal) {
+    auto mesh_device = get_mesh_device();
+
+    // Parameters
+    DataFormat l1_data_format = DataFormat::Float16_b;
+    uint32_t page_size_bytes = tt::tile_size(l1_data_format);
+    uint32_t num_of_transactions = 256;
+
+    // Cores
+    CoreRange core_range({0, 0}, {0, 0});
+    CoreRangeSet core_range_set({core_range});
+
+    // Test config
+    unit_tests::dm::dram_sharded::DramShardedConfig test_config = {
+        .test_id = 87,
+        .num_of_transactions = num_of_transactions,
+        .num_banks = mesh_device->num_dram_channels(),
+        .pages_per_bank = 32,
+        .page_size_bytes = page_size_bytes,
+        .l1_data_format = l1_data_format,
+        .cores = core_range_set,
+        .use_trid = true,
+        .num_of_trids = 16};
+
+    // Run
+    EXPECT_TRUE(run_dm(mesh_device, test_config));
 }
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/data_movement/python/test_mappings/test_bounds.yaml
+++ b/tests/tt_metal/tt_metal/data_movement/python/test_mappings/test_bounds.yaml
@@ -108,6 +108,14 @@
     riscv_0:
       bandwidth: 60
 
+"DRAM Sharded Read Transaction ID Directed Ideal":
+  wormhole_b0:
+    riscv_0:
+      bandwidth: 30
+  blackhole:
+    riscv_0:
+      bandwidth: 60
+
 "Multi Interleaved Directed Ideal":
   wormhole_b0:
     riscv_1:

--- a/tests/tt_metal/tt_metal/data_movement/python/test_mappings/test_information.yaml
+++ b/tests/tt_metal/tt_metal/data_movement/python/test_mappings/test_information.yaml
@@ -200,6 +200,9 @@ tests:
   86:
     name: "DRAM Sharded Read Bank Numbers"
 
+  87:
+    name: "DRAM Sharded Read Transaction ID Directed Ideal"
+
   100:
     name: "Multicast Schemes (Loopback Enabled)"
 

--- a/tests/tt_metal/tt_metal/data_movement/transaction_id/kernels/writer_reader.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/transaction_id/kernels/writer_reader.cpp
@@ -9,7 +9,8 @@
 void kernel_main() {
     // Compile-time arguments
     constexpr uint32_t l1_local_addr = get_compile_time_arg_val(0);
-    constexpr uint32_t num_of_transactions = get_compile_time_arg_val(1);
+    constexpr uint32_t num_of_transactions =
+        get_compile_time_arg_val(1) < 16 ? get_compile_time_arg_val(1) : 15;  // to avoid trid 0
     constexpr uint32_t bytes_per_transaction = get_compile_time_arg_val(2);
     constexpr uint32_t test_id = get_compile_time_arg_val(3);
     constexpr uint32_t packed_sub0_core_coordinates = get_compile_time_arg_val(4);
@@ -30,7 +31,8 @@ void kernel_main() {
         uint32_t tmp_local_addr = l1_local_addr;
 
         // Send out writes with transaction ids
-        for (uint32_t i = 0; i < num_of_transactions; i++) {  // Using 0-(num_of_transactions-1) as the transaction ids
+        // Avoid using transaction id 0 in case fast dispatch breaks it in the future
+        for (uint32_t i = 1; i <= num_of_transactions; i++) {  // Using 1-(num_of_transactions) as the transaction ids
             noc_async_write_set_trid(i);
             noc_async_write(tmp_local_addr, sub0_dst_noc_addr, bytes_per_transaction);
             tmp_local_addr += bytes_per_transaction;
@@ -40,7 +42,7 @@ void kernel_main() {
         tmp_local_addr = l1_local_addr;
 
         // Wait for writes with transaction ids to depart
-        for (uint32_t i = 0; i < num_of_transactions; i++) {  // Using 0-(num_of_transactions-1) as the transaction ids
+        for (uint32_t i = 1; i <= num_of_transactions; i++) {  // Using 1-(num_of_transactions) as the transaction ids
             noc_async_write_flushed_with_trid(i);
             noc_async_read(sub1_src_noc_addr, tmp_local_addr, bytes_per_transaction);
             tmp_local_addr += bytes_per_transaction;

--- a/tests/tt_metal/tt_metal/data_movement/transaction_id/kernels/writer_reader_one_packet.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/transaction_id/kernels/writer_reader_one_packet.cpp
@@ -8,7 +8,8 @@
 void kernel_main() {
     // Compile-time arguments
     constexpr uint32_t l1_local_addr = get_compile_time_arg_val(0);
-    constexpr uint32_t num_of_trids = get_compile_time_arg_val(1);
+    constexpr uint32_t num_of_trids =
+        get_compile_time_arg_val(1) < 16 ? get_compile_time_arg_val(1) : 15;  // to avoid trid 0
     constexpr uint32_t bytes_per_transaction = get_compile_time_arg_val(2);
     constexpr uint32_t test_id = get_compile_time_arg_val(3);
     constexpr uint32_t packed_sub0_core_coordinates = get_compile_time_arg_val(4);
@@ -29,7 +30,8 @@ void kernel_main() {
         uint32_t tmp_local_addr = l1_local_addr;
 
         // Send out writes with transaction ids
-        for (uint32_t i = 0; i < num_of_trids; i++) {
+        // Avoid using transaction id 0 in case fast dispatch breaks it in the future
+        for (uint32_t i = 1; i <= num_of_trids; i++) {
             noc_async_write_one_packet_with_trid(tmp_local_addr, sub0_dst_noc_addr, bytes_per_transaction, i);
             tmp_local_addr += bytes_per_transaction;
             sub0_dst_noc_addr += bytes_per_transaction;
@@ -38,7 +40,7 @@ void kernel_main() {
         tmp_local_addr = l1_local_addr;
 
         // Wait for writes with transaction ids to depart
-        for (uint32_t i = 0; i < num_of_trids; i++) {
+        for (uint32_t i = 1; i <= num_of_trids; i++) {
             noc_async_write_flushed_with_trid(i);
             noc_async_read_one_packet(sub1_src_noc_addr, tmp_local_addr, bytes_per_transaction);
             tmp_local_addr += bytes_per_transaction;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/8_dram_adjacent_core_read/kernels/reader_dram.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/8_dram_adjacent_core_read/kernels/reader_dram.cpp
@@ -48,7 +48,7 @@ void kernel_main() {
                 noc_async_read_one_packet_set_state<true>(src_base_addr, current_page_size, vc);
             }
 
-            noc_async_read_tile_with_state_with_trid(
+            noc_async_read_one_packet_with_state_with_trid(
                 src_base_addr, l1_read_addr, l1_write_addr, curr_block_trid);
             l1_read_addr += current_page_size;
             l1_write_addr += current_page_size;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/8_dram_adjacent_core_read/kernels/reader_dram.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/8_dram_adjacent_core_read/kernels/reader_dram.cpp
@@ -36,7 +36,7 @@ void kernel_main() {
     for (uint32_t block = 0; block < num_blocks; ++block) {
         uint32_t l1_write_addr = get_write_ptr(cb_id);
 
-        noc_async_read_tile_dram_sharded_set_trid(curr_block_trid);
+        noc_async_read_set_trid(curr_block_trid);
 
         for (uint32_t h = 0; h < num_pages; ++h) {
             uint32_t current_page_size = page_size;
@@ -48,7 +48,7 @@ void kernel_main() {
                 noc_async_read_one_packet_set_state<true>(src_base_addr, current_page_size, vc);
             }
 
-            noc_async_read_tile_dram_sharded_with_state_with_trid(
+            noc_async_read_tile_with_state_with_trid(
                 src_base_addr, l1_read_addr, l1_write_addr, curr_block_trid);
             l1_read_addr += current_page_size;
             l1_write_addr += current_page_size;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/9_dram_adjacent_read_remote_l1_write/kernels/reader_dram.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/9_dram_adjacent_read_remote_l1_write/kernels/reader_dram.cpp
@@ -57,7 +57,8 @@ void kernel_main() {
         noc_async_read_set_trid(curr_block_trid);
 
         for (uint32_t h = 0; h < num_pages; ++h) {
-            noc_async_read_tile_with_state_with_trid(src_base_addr, src_read_addr, l1_write_addr, curr_block_trid);
+            noc_async_read_one_packet_with_state_with_trid(
+                src_base_addr, src_read_addr, l1_write_addr, curr_block_trid);
             src_read_addr += page_size;
             l1_write_addr += page_size;
         }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/9_dram_adjacent_read_remote_l1_write/kernels/reader_dram.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/9_dram_adjacent_read_remote_l1_write/kernels/reader_dram.cpp
@@ -54,11 +54,10 @@ void kernel_main() {
     uint32_t l1_write_addr_start = get_write_ptr(cb_id);
     uint32_t l1_write_addr = l1_write_addr_start;
     for (uint32_t block = 0; block < num_blocks; ++block) {
-        noc_async_read_tile_dram_sharded_set_trid(curr_block_trid);
+        noc_async_read_set_trid(curr_block_trid);
 
         for (uint32_t h = 0; h < num_pages; ++h) {
-            noc_async_read_tile_dram_sharded_with_state_with_trid(
-                src_base_addr, src_read_addr, l1_write_addr, curr_block_trid);
+            noc_async_read_tile_with_state_with_trid(src_base_addr, src_read_addr, l1_write_addr, curr_block_trid);
             src_read_addr += page_size;
             l1_write_addr += page_size;
         }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/common/kernels/reader_dram.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/common/kernels/reader_dram.cpp
@@ -76,11 +76,11 @@ void kernel_main() {
         }
         uint32_t l1_write_addr = l1_write_addr_start;
         for (uint32_t block = 0; block < curr_num_blocks; ++block) {
-            noc_async_read_tile_dram_sharded_set_trid(curr_block_trid);
+            noc_async_read_set_trid(curr_block_trid);
 
             uint32_t temp_l1_write_addr = l1_write_addr;
             for (uint32_t h = 0; h < curr_num_pages; ++h) {
-                noc_async_read_tile_dram_sharded_with_state_with_trid(
+                noc_async_read_tile_with_state_with_trid(
                     src_base_addr, src_read_addr, temp_l1_write_addr, curr_block_trid);
                 src_read_addr += curr_page_size;
                 temp_l1_write_addr += curr_page_size;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/common/kernels/reader_dram.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/common/kernels/reader_dram.cpp
@@ -80,7 +80,7 @@ void kernel_main() {
 
             uint32_t temp_l1_write_addr = l1_write_addr;
             for (uint32_t h = 0; h < curr_num_pages; ++h) {
-                noc_async_read_tile_with_state_with_trid(
+                noc_async_read_one_packet_with_state_with_trid(
                     src_base_addr, src_read_addr, temp_l1_write_addr, curr_block_trid);
                 src_read_addr += curr_page_size;
                 temp_l1_write_addr += curr_page_size;

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dedicated_noc_writer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dedicated_noc_writer.cpp
@@ -110,7 +110,7 @@ void kernel_main() {
     noc_async_read_one_packet_set_state<true>(src_addr, page_size, vc, noc_index);
     for (uint32_t i = 0; i < iteration; i++) {
         uint32_t trid = i % (NOC_MAX_TRANSACTION_ID + 1);
-        noc_async_read_tile_dram_sharded_with_state_with_trid(src_addr, DRAM_ALIGNMENT, l1_read_addr, trid, noc_index);
+        noc_async_read_tile_with_state_with_trid(src_addr, DRAM_ALIGNMENT, l1_read_addr, trid, noc_index);
     }
 
     for (uint32_t i = 0; i <= NOC_MAX_TRANSACTION_ID; i++) {

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dedicated_noc_writer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dedicated_noc_writer.cpp
@@ -110,7 +110,7 @@ void kernel_main() {
     noc_async_read_one_packet_set_state<true>(src_addr, page_size, vc, noc_index);
     for (uint32_t i = 0; i < iteration; i++) {
         uint32_t trid = i % (NOC_MAX_TRANSACTION_ID + 1);
-        noc_async_read_tile_with_state_with_trid(src_addr, DRAM_ALIGNMENT, l1_read_addr, trid, noc_index);
+        noc_async_read_one_packet_with_state_with_trid(src_addr, DRAM_ALIGNMENT, l1_read_addr, trid, noc_index);
     }
 
     for (uint32_t i = 0; i <= NOC_MAX_TRANSACTION_ID; i++) {

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dynamic_noc_writer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dynamic_noc_writer.cpp
@@ -166,8 +166,8 @@ void kernel_main() {
     noc_async_read_one_packet_set_state<true>(src_addr_1, page_size, vc, 1 - noc_index);
     for (uint32_t i = 0; i < iteration; i++) {
         uint32_t trid = i % (NOC_MAX_TRANSACTION_ID + 1);
-        noc_async_read_tile_with_state_with_trid(src_addr_0, DRAM_ALIGNMENT, l1_read_addr, trid, noc_index);
-        noc_async_read_tile_with_state_with_trid(src_addr_1, DRAM_ALIGNMENT, l1_read_addr, trid, 1 - noc_index);
+        noc_async_read_one_packet_with_state_with_trid(src_addr_0, DRAM_ALIGNMENT, l1_read_addr, trid, noc_index);
+        noc_async_read_one_packet_with_state_with_trid(src_addr_1, DRAM_ALIGNMENT, l1_read_addr, trid, 1 - noc_index);
     }
     for (uint32_t i = 0; i <= NOC_MAX_TRANSACTION_ID; i++) {
         noc_async_read_barrier_with_trid(i, noc_index);

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dynamic_noc_writer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dynamic_noc_writer.cpp
@@ -166,10 +166,8 @@ void kernel_main() {
     noc_async_read_one_packet_set_state<true>(src_addr_1, page_size, vc, 1 - noc_index);
     for (uint32_t i = 0; i < iteration; i++) {
         uint32_t trid = i % (NOC_MAX_TRANSACTION_ID + 1);
-        noc_async_read_tile_dram_sharded_with_state_with_trid(
-            src_addr_0, DRAM_ALIGNMENT, l1_read_addr, trid, noc_index);
-        noc_async_read_tile_dram_sharded_with_state_with_trid(
-            src_addr_1, DRAM_ALIGNMENT, l1_read_addr, trid, 1 - noc_index);
+        noc_async_read_tile_with_state_with_trid(src_addr_0, DRAM_ALIGNMENT, l1_read_addr, trid, noc_index);
+        noc_async_read_tile_with_state_with_trid(src_addr_1, DRAM_ALIGNMENT, l1_read_addr, trid, 1 - noc_index);
     }
     for (uint32_t i = 0; i <= NOC_MAX_TRANSACTION_ID; i++) {
         noc_async_read_barrier_with_trid(i, noc_index);

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -2039,7 +2039,7 @@ inline void RISC_POST_HEARTBEAT(uint32_t& heartbeat) {
 // clang-format off
 /**
  * Initiates an asynchronous read for a single packet with size <= NOC_MAX_BURST_SIZE (i.e. maximum packet size).
- * Must first set the transaction id using \a noc_async_read_tile_dram_sharded_set_trid and the stateful registers
+ * Must first set the transaction id using \a noc_async_read_set_trid and the stateful registers
  * using an API such as \a noc_async_read_one_packet_set_state.
  *
  * Return value: None
@@ -2055,9 +2055,9 @@ inline void RISC_POST_HEARTBEAT(uint32_t& heartbeat) {
  */
 // clang-format on
 template <bool skip_ptr_update = false>
-FORCE_INLINE void noc_async_read_tile_dram_sharded_with_state_with_trid(
+FORCE_INLINE void noc_async_read_tile_with_state_with_trid(
     uint32_t src_base_addr, uint32_t src_addr, uint32_t dest_addr, uint32_t trid = 0, uint8_t noc = noc_index) {
-    RECORD_NOC_EVENT(NocEventType::READ_DRAM_SHARDED_WITH_STATE);
+    RECORD_NOC_EVENT(NocEventType::READ_WITH_STATE_AND_TRID);
 
     WAYPOINT("NRDW");
     ncrisc_noc_fast_read_with_transaction_id<noc_mode, skip_ptr_update>(
@@ -2078,7 +2078,7 @@ FORCE_INLINE void noc_async_read_tile_dram_sharded_with_state_with_trid(
  */
 // clang-format on
 FORCE_INLINE
-void noc_async_read_tile_dram_sharded_set_trid(uint32_t trid = 0, uint8_t noc = noc_index) {
+void noc_async_read_set_trid(uint32_t trid = 0, uint8_t noc = noc_index) {
     RECORD_NOC_EVENT(NocEventType::READ_SET_TRID);
 
     WAYPOINT("NSTW");

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -2055,7 +2055,7 @@ inline void RISC_POST_HEARTBEAT(uint32_t& heartbeat) {
  */
 // clang-format on
 template <bool skip_ptr_update = false>
-FORCE_INLINE void noc_async_read_tile_with_state_with_trid(
+FORCE_INLINE void noc_async_read_one_packet_with_state_with_trid(
     uint32_t src_base_addr, uint32_t src_addr, uint32_t dest_addr, uint32_t trid = 0, uint8_t noc = noc_index) {
     RECORD_NOC_EVENT(NocEventType::READ_WITH_STATE_AND_TRID);
 

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_dram_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_dram_sharded.cpp
@@ -93,7 +93,7 @@ void kernel_main() {
         noc_async_read_set_trid(curr_block_trid);
 
         for (uint32_t h = 0; h < in1_num_pages; ++h) {
-            noc_async_read_tile_with_state_with_trid(
+            noc_async_read_one_packet_with_state_with_trid(
                 in1_base_addr, l1_read_addr_in1, l1_write_addr_in1, curr_block_trid);
             l1_read_addr_in1 += in1_page_size;
             l1_write_addr_in1 += in1_page_size;

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_dram_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_dram_sharded.cpp
@@ -90,10 +90,10 @@ void kernel_main() {
     uint32_t l1_write_addr_in1_start = get_write_ptr(cb_id_in1);
     l1_write_addr_in1 = l1_write_addr_in1_start;
     for (uint32_t block = 0; block < num_blocks; ++block) {
-        noc_async_read_tile_dram_sharded_set_trid(curr_block_trid);
+        noc_async_read_set_trid(curr_block_trid);
 
         for (uint32_t h = 0; h < in1_num_pages; ++h) {
-            noc_async_read_tile_dram_sharded_with_state_with_trid(
+            noc_async_read_tile_with_state_with_trid(
                 in1_base_addr, l1_read_addr_in1, l1_write_addr_in1, curr_block_trid);
             l1_read_addr_in1 += in1_page_size;
             l1_write_addr_in1 += in1_page_size;

--- a/ttnn/cpp/ttnn/operations/prefetcher/prefetcher/device/kernels/reader_dram.cpp
+++ b/ttnn/cpp/ttnn/operations/prefetcher/prefetcher/device/kernels/reader_dram.cpp
@@ -66,12 +66,12 @@ void kernel_main() {
 
             for (uint32_t block = 0; block < num_blocks; block++) {
                 // Set trid for current block
-                noc_async_read_tile_dram_sharded_set_trid(curr_block_trid);
+                noc_async_read_set_trid(curr_block_trid);
 
                 // Issue noc async read commands for current block
                 uint32_t temp_l1_write_addr = l1_write_addr;
                 for (uint32_t h = 0; h < curr_block_num_pages; ++h) {
-                    noc_async_read_tile_dram_sharded_with_state_with_trid<skip_ptr_update>(
+                    noc_async_read_tile_with_state_with_trid<skip_ptr_update>(
                         src_base_addr, src_read_addr, temp_l1_write_addr, curr_block_trid);
                     src_read_addr += curr_page_size;
                     temp_l1_write_addr += curr_page_size;

--- a/ttnn/cpp/ttnn/operations/prefetcher/prefetcher/device/kernels/reader_dram.cpp
+++ b/ttnn/cpp/ttnn/operations/prefetcher/prefetcher/device/kernels/reader_dram.cpp
@@ -71,7 +71,7 @@ void kernel_main() {
                 // Issue noc async read commands for current block
                 uint32_t temp_l1_write_addr = l1_write_addr;
                 for (uint32_t h = 0; h < curr_block_num_pages; ++h) {
-                    noc_async_read_tile_with_state_with_trid<skip_ptr_update>(
+                    noc_async_read_one_packet_with_state_with_trid<skip_ptr_update>(
                         src_base_addr, src_read_addr, temp_l1_write_addr, curr_block_trid);
                     src_read_addr += curr_page_size;
                     temp_l1_write_addr += curr_page_size;


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/29739)

### Problem description
Data movement test suite does not have coverage for reads from DRAM sharded banks using transaction IDs and stateful APIs. Additionally these APIs are not necessarily specific to DRAM sharded scenarios and so are misleadingly named.

### What's changed
- Added a case which tests stateful reading using transaction IDs from DRAM sharded banks
- Renamed `noc_async_read_tile_dram_sharded_with_state_with_trid` to `noc_async_read_one_packet_with_state_with_trid`
- Renamed `noc_async_read_tile_dram_sharded_set_trid` to `noc_async_read_set_trid`

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes