### PR TITLE
Unify reduce_scatter kernel binaries to hasten compile 

### DIFF
--- a/tests/nightly/t3000/ccl/test_minimal_reduce_scatter_async.py
+++ b/tests/nightly/t3000/ccl/test_minimal_reduce_scatter_async.py
@@ -1216,7 +1216,7 @@ def test_reduce_scatter_minimal_async_linear_sharded(
     )
 
 
-MESH_SHAPE = (2, 4)
+MESH_SHAPE = (1, 8)
 LAYOUT = ttnn.TILE_LAYOUT
 
 NUM_ITERS = 1
@@ -1274,7 +1274,7 @@ def _get_tensors(
     return tt_input, torch_reference
 
 
-@pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D_RING}], indirect=True)
 @pytest.mark.parametrize("mesh_device", [MESH_SHAPE], indirect=True)
 @pytest.mark.parametrize(
     "input_shape", [[128, 128], [8, 8, 128, 128], [8, 128, 128], [8, 8, 8, 8, 128, 128], [8, 8, 8, 16, 16]]
@@ -1282,8 +1282,8 @@ def _get_tensors(
 @pytest.mark.parametrize("dtype", [torch.bfloat16])
 @pytest.mark.parametrize("memory_config", [ttnn.DRAM_MEMORY_CONFIG])
 @pytest.mark.parametrize("dim", [0, 1, 2, 3, 4, 5])
-@pytest.mark.parametrize("cluster_axis", [0])
-@pytest.mark.parametrize("topology", [ttnn.Topology.Linear, ttnn.Topology.Ring])
+@pytest.mark.parametrize("cluster_axis", [1])
+@pytest.mark.parametrize("topology", [ttnn.Topology.Ring, ttnn.Topology.Linear])
 def test_nd(mesh_device, input_shape, dim, cluster_axis, dtype, memory_config, topology):
     if dim >= len(input_shape):
         pytest.skip("Invalid gather dim")

--- a/tests/nightly/t3000/ccl/test_minimal_reduce_scatter_async.py
+++ b/tests/nightly/t3000/ccl/test_minimal_reduce_scatter_async.py
@@ -1277,7 +1277,7 @@ def _get_tensors(
 @pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D_RING}], indirect=True)
 @pytest.mark.parametrize("mesh_device", [MESH_SHAPE], indirect=True)
 @pytest.mark.parametrize(
-    "input_shape", [[128, 128], [8, 8, 128, 128], [8, 128, 128], [8, 8, 8, 8, 128, 128], [8, 8, 8, 16, 16]]
+    "input_shape", [[256, 256], [8, 8, 256, 256], [8, 256, 256], [8, 8, 8, 8, 256, 256], [8, 8, 8, 16, 16]]
 )
 @pytest.mark.parametrize("dtype", [torch.bfloat16])
 @pytest.mark.parametrize("memory_config", [ttnn.DRAM_MEMORY_CONFIG])
@@ -1286,7 +1286,7 @@ def _get_tensors(
 @pytest.mark.parametrize("topology", [ttnn.Topology.Ring, ttnn.Topology.Linear])
 def test_nd(mesh_device, input_shape, dim, cluster_axis, dtype, memory_config, topology):
     if dim >= len(input_shape):
-        pytest.skip("Invalid gather dim")
+        pytest.skip("Invalid scatter dim")
 
     tt_input, torch_reference = _get_tensors(
         input_shape,

--- a/tests/nightly/t3000/ccl/test_minimal_reduce_scatter_async.py
+++ b/tests/nightly/t3000/ccl/test_minimal_reduce_scatter_async.py
@@ -1305,8 +1305,6 @@ def test_nd(mesh_device, input_shape, dim, cluster_axis, dtype, memory_config, t
     )
     semaphores = [ttnn.create_global_semaphore(mesh_device, ccl_sub_device_crs, 0) for _ in range(3)]
 
-    print(f"{tt_input.shape=}")
-
     for i in range(NUM_ITERS):
         tt_out_tensor = ttnn.experimental.reduce_scatter_minimal_async(
             tt_input,

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/reduce_scatter_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/reduce_scatter_program_factory.cpp
@@ -153,7 +153,7 @@ void ReduceScatterDeviceOperation::ReduceScatterProgram::override_runtime_argume
         const auto& shared_variables = cached_workload.shared_variables.at(range);
         update_runtime_arguments(
             program,
-            shared_variables.program_artifacts.reader_kernel_ids,
+            shared_variables.program_artifacts.reader_kernel_id,
             shared_variables.program_artifacts.writer_kernel_ids,
             shared_variables.program_artifacts.all_cores,
             operation_attributes.num_links,

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/reduce_scatter_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/reduce_scatter_program_factory.cpp
@@ -154,7 +154,7 @@ void ReduceScatterDeviceOperation::ReduceScatterProgram::override_runtime_argume
         update_runtime_arguments(
             program,
             shared_variables.program_artifacts.reader_kernel_id,
-            shared_variables.program_artifacts.writer_kernel_ids,
+            shared_variables.program_artifacts.writer_kernel_id,
             shared_variables.program_artifacts.all_cores,
             operation_attributes.num_links,
             shared_variables.program_artifacts.num_directions_per_link,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/dim_zero_line_reduce_scatter_minimal_async_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/dim_zero_line_reduce_scatter_minimal_async_reader.cpp
@@ -255,7 +255,7 @@ void kernel_main() {
          * incoming BWD intermediate. Use output address generator.
          * If true, output += intermediate. Otherwise, output = input + intermediate
          */
-        const uint32_t tile_id_start = do_accumulate_output(is_forward) ? output_tile_id_start : input_tile_id_start;
+        uint32_t tile_id_start = detail::do_accumulate_output(is_forward) ? output_tile_id_start : input_tile_id_start;
 
         uint32_t cb_in0 = cb_input_id;
         for (uint32_t b = 0; b < slice_B; ++b) {
@@ -264,7 +264,7 @@ void kernel_main() {
 
             while (tiles_read < tiles_to_read) {
                 // Wait for FWD writer to signal that it has done its final reduction
-                if (do_accumulate_output(is_forward)) {
+                if (detail::do_accumulate_output(is_forward)) {
                     noc_semaphore_wait_min(
                         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(fwd_bwd_sem_addr), ++fwd_sync_cnt);
                 }
@@ -276,7 +276,7 @@ void kernel_main() {
                 uint32_t l1_write_addr = get_write_ptr(cb_in0);
                 for (uint32_t j = 0; j < num_pages_to_read; ++j) {
                     uint32_t tile_id = tile_id_start + tiles_read + j;
-                    uint64_t noc_read_addr = do_accumulate_output(is_forward)
+                    uint64_t noc_read_addr = detail::do_accumulate_output(is_forward)
                                                  ? get_noc_addr(tile_id, output_tensor_addrgen)
                                                  : get_noc_addr(tile_id, input_tensor_addrgen);
                     noc_async_read(noc_read_addr, l1_write_addr, page_size);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/dim_zero_line_reduce_scatter_minimal_async_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/dim_zero_line_reduce_scatter_minimal_async_writer.cpp
@@ -37,33 +37,37 @@ constexpr uint32_t input_num_pages = get_compile_time_arg_val(6);
 constexpr uint32_t output_num_pages = get_compile_time_arg_val(7);
 constexpr uint32_t batch_num_pages = get_compile_time_arg_val(8);
 constexpr uint32_t slice_B = get_compile_time_arg_val(9);
-constexpr bool is_forward = get_compile_time_arg_val(10);
-constexpr bool is_first_device_in_direction = get_compile_time_arg_val(11);
-constexpr uint32_t num_targets_in_direction = get_compile_time_arg_val(12);
-constexpr bool do_final_reduction = get_compile_time_arg_val(13);
-constexpr bool sync_with_other_direction = get_compile_time_arg_val(14);
-constexpr uint32_t chunks_per_sync = get_compile_time_arg_val(15);
-constexpr uint32_t start_tiles_read = get_compile_time_arg_val(16);
-constexpr uint32_t start_tiles_to_read = get_compile_time_arg_val(17);
+constexpr bool sync_with_other_direction = get_compile_time_arg_val(10);
+constexpr uint8_t fabric_mux_num_buffers_per_channel = get_compile_time_arg_val(11);
+constexpr size_t fabric_mux_channel_buffer_size_bytes = get_compile_time_arg_val(12);
+constexpr size_t fabric_mux_status_address = get_compile_time_arg_val(13);
+constexpr size_t fabric_mux_termination_signal_address = get_compile_time_arg_val(14);
+constexpr uint32_t num_mux_clients = get_compile_time_arg_val(15);
 
-constexpr bool is_termination_master = get_compile_time_arg_val(18);
-constexpr uint8_t fabric_mux_x = get_compile_time_arg_val(19);
-constexpr uint8_t fabric_mux_y = get_compile_time_arg_val(20);
-constexpr uint8_t fabric_mux_num_buffers_per_channel = get_compile_time_arg_val(21);
-constexpr size_t fabric_mux_channel_buffer_size_bytes = get_compile_time_arg_val(22);
-constexpr size_t fabric_mux_channel_base_address = get_compile_time_arg_val(23);
-constexpr size_t fabric_mux_connection_info_address = get_compile_time_arg_val(24);
-constexpr size_t fabric_mux_connection_handshake_address = get_compile_time_arg_val(25);
-constexpr size_t fabric_mux_flow_control_address = get_compile_time_arg_val(26);
-constexpr size_t fabric_mux_buffer_index_address = get_compile_time_arg_val(27);
-constexpr size_t fabric_mux_status_address = get_compile_time_arg_val(28);
-constexpr uint8_t fabric_mux_channel_id = get_compile_time_arg_val(29);
-constexpr size_t fabric_mux_termination_signal_address = get_compile_time_arg_val(30);
-constexpr ccl_routing_utils::line_unicast_route_info_t unicast_route_info =
-    ccl_routing_utils::get_line_unicast_route_info_from_args<31>();
-constexpr ccl_routing_utils::line_multicast_route_info_t multicast_route_info =
-    ccl_routing_utils::get_line_multicast_route_info_from_args<31 + ccl_routing_utils::num_line_unicast_args>();
+constexpr uint32_t num_ct_args = 16;
 
+constexpr ccl_routing_utils::line_unicast_route_info_t forward_unicast_route_info =
+    ccl_routing_utils::get_line_unicast_route_info_from_args<num_ct_args>();
+constexpr ccl_routing_utils::line_multicast_route_info_t forward_multicast_route_info =
+    ccl_routing_utils::get_line_multicast_route_info_from_args<
+        num_ct_args + ccl_routing_utils::num_line_unicast_args>();
+constexpr ccl_routing_utils::line_unicast_route_info_t backward_unicast_route_info =
+    ccl_routing_utils::get_line_unicast_route_info_from_args<
+        num_ct_args + ccl_routing_utils::num_line_unicast_args + ccl_routing_utils::num_line_multicast_args>();
+constexpr ccl_routing_utils::line_multicast_route_info_t backward_multicast_route_info =
+    ccl_routing_utils::get_line_multicast_route_info_from_args<
+        num_ct_args + 2 * ccl_routing_utils::num_line_unicast_args + ccl_routing_utils::num_line_multicast_args>();
+
+namespace detail {
+
+inline bool do_forward_sync(const bool is_forward) {
+    if constexpr (!sync_with_other_direction) {
+        return false;
+    }
+
+    return is_forward;
+}
+}  // namespace detail
 void kernel_main() {
     ///////////////////////////////////////////////////
     // ARGS
@@ -80,8 +84,27 @@ void kernel_main() {
     uint32_t opposite_core_sem_noc0_y = get_arg_val<uint32_t>(arg_idx++);
     bool use_barrier_sem = get_arg_val<uint32_t>(arg_idx++);
     size_t barrier_sem = get_arg_val<uint32_t>(arg_idx++);
+    const bool is_forward = get_arg_val<uint32_t>(arg_idx++);
+    const bool is_first_device_in_direction = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t num_targets_in_direction = get_arg_val<uint32_t>(arg_idx++);
+    const bool do_final_reduction = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t chunks_per_sync = get_arg_val<uint32_t>(arg_idx++);
 
+    arg_idx++;  // start_pages_read_in_row unused by dim 0 kernel
+    arg_idx++;  // start_row_offset unused by dim 0 kernel
+
+    const uint32_t start_tiles_read = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t start_tiles_to_read = get_arg_val<uint32_t>(arg_idx++);
     bool mux_connection_valid = get_arg_val<uint32_t>(arg_idx++) == 1;
+    const bool is_termination_master = get_arg_val<uint32_t>(arg_idx++);
+    const uint8_t fabric_mux_x = get_arg_val<uint32_t>(arg_idx++);
+    const uint8_t fabric_mux_y = get_arg_val<uint32_t>(arg_idx++);
+    const size_t fabric_mux_channel_base_address = get_arg_val<uint32_t>(arg_idx++);
+    const size_t fabric_mux_connection_info_address = get_arg_val<uint32_t>(arg_idx++);
+    const size_t fabric_mux_connection_handshake_address = get_arg_val<uint32_t>(arg_idx++);
+    const size_t fabric_mux_flow_control_address = get_arg_val<uint32_t>(arg_idx++);
+    const size_t fabric_mux_buffer_index_address = get_arg_val<uint32_t>(arg_idx++);
+    const uint8_t fabric_mux_channel_id = get_arg_val<uint32_t>(arg_idx++);
     uint32_t termination_sync_address = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
     uint32_t local_fabric_mux_status_address = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
     uint32_t local_flow_control_address = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
@@ -89,10 +112,12 @@ void kernel_main() {
     uint32_t local_buffer_index_address = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
     uint32_t termination_master_noc_x = get_arg_val<uint32_t>(arg_idx++);
     uint32_t termination_master_noc_y = get_arg_val<uint32_t>(arg_idx++);
-    uint32_t num_mux_clients = get_arg_val<uint32_t>(arg_idx++);
+
+    const auto& unicast_route_info = (is_forward) ? forward_unicast_route_info : backward_unicast_route_info;
+    const auto& multicast_route_info = (is_forward) ? forward_multicast_route_info : backward_multicast_route_info;
 
     constexpr uint32_t ct_idx =
-        31 + ccl_routing_utils::num_line_unicast_args + ccl_routing_utils::num_line_multicast_args;
+        num_ct_args + 2 * (ccl_routing_utils::num_line_unicast_args + ccl_routing_utils::num_line_multicast_args);
 
 #ifdef INTERMEDIATE_IS_SHARDED
     constexpr uint32_t ct_offset = 7;
@@ -243,13 +268,13 @@ void kernel_main() {
                 static_cast<uint32_t>(1)});  // increment 1
     }
 
-    constexpr uint32_t intermediate_full_offset = is_forward ? 0 : input_num_pages;
+    const uint32_t intermediate_full_offset = is_forward ? 0 : input_num_pages;
 
     uint32_t chunk_count = 0;
     int slice_idx = is_forward ? ring_size - 1 : 0;
 
     for (uint32_t iter = 0; iter < num_targets_in_direction; ++iter) {
-        constexpr uint32_t cb_output_id = is_first_device_in_direction ? cb_reader_output_id : cb_compute_output_id;
+        const uint32_t cb_output_id = is_first_device_in_direction ? cb_reader_output_id : cb_compute_output_id;
         chunk_count = 0;
 
         uint32_t intermediate_tile_id_start = slice_idx * output_num_pages + intermediate_full_offset;
@@ -319,7 +344,7 @@ void kernel_main() {
         }
 
         // Next slice idx
-        if constexpr (is_forward) {
+        if (is_forward) {
             slice_idx--;
         } else {
             slice_idx++;
@@ -327,7 +352,7 @@ void kernel_main() {
     }
 
     // Do write of final reduction and sync local FWD/BWD cores
-    if constexpr (do_final_reduction) {
+    if (do_final_reduction) {
         // Write output
         uint32_t output_tile_id_start = 0;
         for (uint32_t b = 0; b < slice_B; ++b) {
@@ -348,13 +373,13 @@ void kernel_main() {
                     tiles_read++;
                 }
 
-                if constexpr (sync_with_other_direction && is_forward) {
+                if (detail::do_forward_sync(is_forward)) {
                     noc_async_write_barrier();
                 } else {
                     noc_async_writes_flushed();
                 }
                 cb_pop_front(cb_compute_output_id, tile_granularity);
-                if constexpr (sync_with_other_direction && is_forward) {
+                if (detail::do_forward_sync(is_forward)) {
                     // Tell local backwards reader that it can proceed
                     uint64_t fwd_bwd_sem_noc_addr =
                         safe_get_noc_addr(opposite_core_sem_noc0_x, opposite_core_sem_noc0_y, fwd_bwd_sem_addr, 0);
@@ -372,7 +397,7 @@ void kernel_main() {
     if (mux_connection_valid) {
         tt::tt_fabric::fabric_client_disconnect(*mux_connection_handle);
 
-        if constexpr (is_termination_master) {
+        if (is_termination_master) {
             auto* termination_sync_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(termination_sync_address);
             noc_semaphore_wait(termination_sync_ptr, num_mux_clients - 1);
             tt::tt_fabric::fabric_endpoint_terminate(fabric_mux_x, fabric_mux_y, fabric_mux_termination_signal_address);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/dim_zero_line_reduction.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/dim_zero_line_reduction.cpp
@@ -13,9 +13,11 @@ void MAIN {
     constexpr uint32_t output_cb = get_compile_time_arg_val(2);
     constexpr uint32_t tile_granularity = get_compile_time_arg_val(3);
     constexpr uint32_t slice_B = get_compile_time_arg_val(4);
-    constexpr uint32_t num_total_reduction_steps = get_compile_time_arg_val(5);
-    constexpr uint32_t start_tiles_read = get_compile_time_arg_val(6);
-    constexpr uint32_t start_tiles_to_read = get_compile_time_arg_val(7);
+
+    uint32_t arg_idx = 0;
+    const uint32_t num_total_reduction_steps = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t start_tiles_read = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t start_tiles_to_read = get_arg_val<uint32_t>(arg_idx++);
 
     binary_op_init_common(input_cb_id, intermediate_cb, output_cb);
     add_tiles_init(input_cb_id, intermediate_cb, false);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/dim_zero_ring_reduction.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/dim_zero_ring_reduction.cpp
@@ -14,9 +14,11 @@ void MAIN {
     constexpr uint32_t tile_granularity = get_compile_time_arg_val(3);
     constexpr uint32_t ring_size = get_compile_time_arg_val(4);
     constexpr uint32_t slice_B = get_compile_time_arg_val(5);
-    constexpr bool direction = get_compile_time_arg_val(6);
-    constexpr uint32_t start_tiles_read = get_compile_time_arg_val(7);
-    constexpr uint32_t start_tiles_to_read = get_compile_time_arg_val(8);
+
+    uint32_t arg_idx = 0;
+    uint32_t start_tiles_read = get_arg_val<uint32_t>(arg_idx++);
+    uint32_t start_tiles_to_read = get_arg_val<uint32_t>(arg_idx++);
+    const bool direction = get_arg_val<uint32_t>(arg_idx++);
 
     // Initialize binary operations - use the same constants consistently
     binary_op_init_common(input_cb_id, intermediate_cb, output_cb);
@@ -28,7 +30,7 @@ void MAIN {
             uint32_t tiles_read = start_tiles_read;
             uint32_t tiles_to_read = start_tiles_to_read;
 
-            if constexpr (!direction) {
+            if (!direction) {
                 uint32_t backwards_offset = std::min((tiles_to_read - tiles_read) / 2, tile_granularity);
                 tiles_read += backwards_offset;
             }
@@ -37,7 +39,7 @@ void MAIN {
             while (tiles_read < tiles_to_read) {
                 uint32_t tiles_remaining_to_read = tiles_to_read - tiles_read;
                 uint32_t num_pages_to_read = 0;
-                if constexpr (direction) {
+                if (direction) {
                     num_pages_to_read = std::min(tiles_remaining_to_read / 2, tile_granularity);
                 } else {
                     num_pages_to_read = std::min(tiles_remaining_to_read, tile_granularity);
@@ -60,7 +62,7 @@ void MAIN {
                 tiles_remaining_to_read = tiles_to_read - tiles_read;
                 if (tiles_remaining_to_read > 0) {
                     num_pages_to_read = 0;
-                    if constexpr (!direction) {
+                    if (!direction) {
                         num_pages_to_read = std::min(tiles_remaining_to_read / 2, tile_granularity);
                     } else {
                         num_pages_to_read = std::min(tiles_remaining_to_read, tile_granularity);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/line_reduce_scatter_minimal_async_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/line_reduce_scatter_minimal_async_writer.cpp
@@ -43,36 +43,38 @@ constexpr uint32_t input_tensor_Wt = get_compile_time_arg_val(12);
 constexpr uint32_t slice_C = get_compile_time_arg_val(13);
 constexpr uint32_t slice_Ht = get_compile_time_arg_val(14);
 constexpr uint32_t slice_Wt = get_compile_time_arg_val(15);
-constexpr bool is_forward = get_compile_time_arg_val(16);
-constexpr bool is_first_device_in_direction = get_compile_time_arg_val(17);
-constexpr uint32_t num_targets_in_direction = get_compile_time_arg_val(18);
-constexpr bool do_final_reduction = get_compile_time_arg_val(19);
-constexpr bool sync_with_other_direction = get_compile_time_arg_val(20);
-constexpr uint32_t chunks_per_sync = get_compile_time_arg_val(21);
-constexpr uint32_t dim = get_compile_time_arg_val(22);
-constexpr uint32_t start_pages_read_in_row = get_compile_time_arg_val(23);
-constexpr uint32_t start_row_offset = get_compile_time_arg_val(24);
-constexpr uint32_t start_tiles_read = get_compile_time_arg_val(25);
-constexpr uint32_t start_tiles_to_read = get_compile_time_arg_val(26);
+constexpr uint32_t dim = get_compile_time_arg_val(16);
+constexpr bool sync_with_other_direction = get_compile_time_arg_val(17);
+constexpr uint8_t fabric_mux_num_buffers_per_channel = get_compile_time_arg_val(18);
+constexpr size_t fabric_mux_channel_buffer_size_bytes = get_compile_time_arg_val(19);
+constexpr size_t fabric_mux_status_address = get_compile_time_arg_val(20);
+constexpr size_t fabric_mux_termination_signal_address = get_compile_time_arg_val(21);
+constexpr uint32_t num_mux_clients = get_compile_time_arg_val(22);
 
-constexpr bool is_termination_master = get_compile_time_arg_val(27);
-constexpr uint8_t fabric_mux_x = get_compile_time_arg_val(28);
-constexpr uint8_t fabric_mux_y = get_compile_time_arg_val(29);
-constexpr uint8_t fabric_mux_num_buffers_per_channel = get_compile_time_arg_val(30);
-constexpr size_t fabric_mux_channel_buffer_size_bytes = get_compile_time_arg_val(31);
-constexpr size_t fabric_mux_channel_base_address = get_compile_time_arg_val(32);
-constexpr size_t fabric_mux_connection_info_address = get_compile_time_arg_val(33);
-constexpr size_t fabric_mux_connection_handshake_address = get_compile_time_arg_val(34);
-constexpr size_t fabric_mux_flow_control_address = get_compile_time_arg_val(35);
-constexpr size_t fabric_mux_buffer_index_address = get_compile_time_arg_val(36);
-constexpr size_t fabric_mux_status_address = get_compile_time_arg_val(37);
-constexpr uint8_t fabric_mux_channel_id = get_compile_time_arg_val(38);
-constexpr size_t fabric_mux_termination_signal_address = get_compile_time_arg_val(39);
-constexpr ccl_routing_utils::line_unicast_route_info_t unicast_route_info =
-    ccl_routing_utils::get_line_unicast_route_info_from_args<40>();
-constexpr ccl_routing_utils::line_multicast_route_info_t multicast_route_info =
-    ccl_routing_utils::get_line_multicast_route_info_from_args<40 + ccl_routing_utils::num_line_unicast_args>();
+constexpr uint32_t num_ct_args = 23;
 
+constexpr ccl_routing_utils::line_unicast_route_info_t forward_unicast_route_info =
+    ccl_routing_utils::get_line_unicast_route_info_from_args<num_ct_args>();
+constexpr ccl_routing_utils::line_multicast_route_info_t forward_multicast_route_info =
+    ccl_routing_utils::get_line_multicast_route_info_from_args<
+        num_ct_args + ccl_routing_utils::num_line_unicast_args>();
+constexpr ccl_routing_utils::line_unicast_route_info_t backward_unicast_route_info =
+    ccl_routing_utils::get_line_unicast_route_info_from_args<
+        num_ct_args + ccl_routing_utils::num_line_unicast_args + ccl_routing_utils::num_line_multicast_args>();
+constexpr ccl_routing_utils::line_multicast_route_info_t backward_multicast_route_info =
+    ccl_routing_utils::get_line_multicast_route_info_from_args<
+        num_ct_args + 2 * ccl_routing_utils::num_line_unicast_args + ccl_routing_utils::num_line_multicast_args>();
+
+namespace detail {
+
+inline bool do_forward_sync(const bool is_forward) {
+    if constexpr (!sync_with_other_direction) {
+        return false;
+    }
+
+    return is_forward;
+}
+}  // namespace detail
 void kernel_main() {
     ///////////////////////////////////////////////////
     // ARGS
@@ -89,8 +91,25 @@ void kernel_main() {
     uint32_t opposite_core_sem_noc0_y = get_arg_val<uint32_t>(arg_idx++);
     bool use_barrier_sem = get_arg_val<uint32_t>(arg_idx++);
     size_t barrier_sem = get_arg_val<uint32_t>(arg_idx++);
-
+    const bool is_forward = get_arg_val<uint32_t>(arg_idx++);
+    const bool is_first_device_in_direction = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t num_targets_in_direction = get_arg_val<uint32_t>(arg_idx++);
+    const bool do_final_reduction = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t chunks_per_sync = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t start_pages_read_in_row = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t start_row_offset = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t start_tiles_read = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t start_tiles_to_read = get_arg_val<uint32_t>(arg_idx++);
     bool mux_connection_valid = get_arg_val<uint32_t>(arg_idx++) == 1;
+    const bool is_termination_master = get_arg_val<uint32_t>(arg_idx++);
+    const uint8_t fabric_mux_x = get_arg_val<uint32_t>(arg_idx++);
+    const uint8_t fabric_mux_y = get_arg_val<uint32_t>(arg_idx++);
+    const size_t fabric_mux_channel_base_address = get_arg_val<uint32_t>(arg_idx++);
+    const size_t fabric_mux_connection_info_address = get_arg_val<uint32_t>(arg_idx++);
+    const size_t fabric_mux_connection_handshake_address = get_arg_val<uint32_t>(arg_idx++);
+    const size_t fabric_mux_flow_control_address = get_arg_val<uint32_t>(arg_idx++);
+    const size_t fabric_mux_buffer_index_address = get_arg_val<uint32_t>(arg_idx++);
+    const uint8_t fabric_mux_channel_id = get_arg_val<uint32_t>(arg_idx++);
     uint32_t termination_sync_address = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
     uint32_t local_fabric_mux_status_address = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
     uint32_t local_flow_control_address = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
@@ -98,10 +117,12 @@ void kernel_main() {
     uint32_t local_buffer_index_address = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
     uint32_t termination_master_noc_x = get_arg_val<uint32_t>(arg_idx++);
     uint32_t termination_master_noc_y = get_arg_val<uint32_t>(arg_idx++);
-    uint32_t num_mux_clients = get_arg_val<uint32_t>(arg_idx++);
+
+    const auto& unicast_route_info = (is_forward) ? forward_unicast_route_info : backward_unicast_route_info;
+    const auto& multicast_route_info = (is_forward) ? forward_multicast_route_info : backward_multicast_route_info;
 
     constexpr uint32_t ct_idx =
-        40 + ccl_routing_utils::num_line_unicast_args + ccl_routing_utils::num_line_multicast_args;
+        num_ct_args + 2 * (ccl_routing_utils::num_line_unicast_args + ccl_routing_utils::num_line_multicast_args);
 
 #ifdef INTERMEDIATE_IS_SHARDED
     constexpr uint32_t ct_offset = 7;
@@ -252,7 +273,7 @@ void kernel_main() {
                 static_cast<uint32_t>(1)});  // increment 1
     }
 
-    constexpr uint32_t intermediate_full_offset = is_forward ? 0 : input_num_pages;
+    const uint32_t intermediate_full_offset = is_forward ? 0 : input_num_pages;
 
     uint32_t chunk_count = 0;
     for (uint32_t b = 0; b < input_tensor_B; b++) {
@@ -260,7 +281,7 @@ void kernel_main() {
 
         uint32_t batch_offset = input_batch_num_pages * b;
         for (uint32_t iter = 0; iter < num_targets_in_direction; ++iter) {
-            constexpr uint32_t cb_output_id = is_first_device_in_direction ? cb_reader_output_id : cb_compute_output_id;
+            const uint32_t cb_output_id = is_first_device_in_direction ? cb_reader_output_id : cb_compute_output_id;
             chunk_count = 0;
 
             uint32_t intermediate_tile_id_start;
@@ -356,7 +377,7 @@ void kernel_main() {
             }
 
             // Next slice idx
-            if constexpr (is_forward) {
+            if (is_forward) {
                 slice_idx--;
             } else {
                 slice_idx++;
@@ -364,7 +385,7 @@ void kernel_main() {
         }
 
         // Do write of final reduction and sync local FWD/BWD cores
-        if constexpr (do_final_reduction) {
+        if (do_final_reduction) {
             // Write output
             uint32_t output_tile_id_start = b * output_batch_num_pages;
             for (uint32_t c = 0; c < slice_C; ++c) {
@@ -385,13 +406,13 @@ void kernel_main() {
                         tiles_read++;
                     }
 
-                    if constexpr (sync_with_other_direction && is_forward) {
+                    if (detail::do_forward_sync(is_forward)) {
                         noc_async_write_barrier();
                     } else {
                         noc_async_writes_flushed();
                     }
                     cb_pop_front(cb_compute_output_id, tile_granularity);
-                    if constexpr (sync_with_other_direction && is_forward) {
+                    if (detail::do_forward_sync(is_forward)) {
                         // Tell local backwards reader that it can proceed
                         uint64_t fwd_bwd_sem_noc_addr =
                             safe_get_noc_addr(opposite_core_sem_noc0_x, opposite_core_sem_noc0_y, fwd_bwd_sem_addr, 0);
@@ -410,7 +431,7 @@ void kernel_main() {
     if (mux_connection_valid) {
         tt::tt_fabric::fabric_client_disconnect(*mux_connection_handle);
 
-        if constexpr (is_termination_master) {
+        if (is_termination_master) {
             auto* termination_sync_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(termination_sync_address);
             noc_semaphore_wait(termination_sync_ptr, num_mux_clients - 1);
             tt::tt_fabric::fabric_endpoint_terminate(fabric_mux_x, fabric_mux_y, fabric_mux_termination_signal_address);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/line_reduction.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/line_reduction.cpp
@@ -14,9 +14,11 @@ void MAIN {
     constexpr uint32_t tile_granularity = get_compile_time_arg_val(3);
     constexpr uint32_t input_tensor_B = get_compile_time_arg_val(4);
     constexpr uint32_t slice_C = get_compile_time_arg_val(5);
-    constexpr uint32_t num_total_reduction_steps = get_compile_time_arg_val(6);
-    constexpr uint32_t start_tiles_read = get_compile_time_arg_val(7);
-    constexpr uint32_t start_tiles_to_read = get_compile_time_arg_val(8);
+
+    uint32_t arg_idx = 0;
+    const uint32_t num_total_reduction_steps = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t start_tiles_read = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t start_tiles_to_read = get_arg_val<uint32_t>(arg_idx++);
 
     binary_op_init_common(input_cb_id, intermediate_cb, output_cb);
     add_tiles_init(input_cb_id, intermediate_cb, false);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/ring_reduce_scatter_minimal_async_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/ring_reduce_scatter_minimal_async_reader.cpp
@@ -46,9 +46,9 @@ void kernel_main() {
     size_t out_ready_sem = get_arg_val<uint32_t>(arg_idx++);
     const bool direction = get_arg_val<uint32_t>(arg_idx++);
     const uint32_t chunks_per_sync = get_arg_val<uint32_t>(arg_idx++);
-    const uint32_t start_pages_read_in_row = get_arg_val<uint32_t>(arg_idx++);
     const int32_t start_tiles_read = get_arg_val<uint32_t>(arg_idx++);
     const uint32_t start_tiles_to_read = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t start_pages_read_in_row = get_arg_val<uint32_t>(arg_idx++);
     const uint32_t start_row_offset = get_arg_val<uint32_t>(arg_idx++);
 
     constexpr uint32_t ct_idx = 16;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/ring_reduce_scatter_minimal_async_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/ring_reduce_scatter_minimal_async_reader.cpp
@@ -32,13 +32,7 @@ constexpr uint32_t slice_C = get_compile_time_arg_val(11);
 constexpr uint32_t slice_Ht = get_compile_time_arg_val(12);
 constexpr uint32_t slice_Wt = get_compile_time_arg_val(13);
 constexpr uint32_t fuse_op = get_compile_time_arg_val(14);
-constexpr bool direction = get_compile_time_arg_val(15);
-constexpr uint32_t chunks_per_sync = get_compile_time_arg_val(16);
-constexpr uint32_t dim = get_compile_time_arg_val(17);
-constexpr uint32_t start_pages_read_in_row = get_compile_time_arg_val(18);
-constexpr uint32_t start_row_offset = get_compile_time_arg_val(19);
-constexpr int32_t start_tiles_read = get_compile_time_arg_val(20);
-constexpr uint32_t start_tiles_to_read = get_compile_time_arg_val(21);
+constexpr uint32_t dim = get_compile_time_arg_val(15);
 
 void kernel_main() {
     ///////////////////////////////////////////////////
@@ -50,8 +44,14 @@ void kernel_main() {
     address_t input_tensor_address = get_arg_val<address_t>(arg_idx++);
     address_t intermediate_tensor_address = get_arg_val<address_t>(arg_idx++);
     size_t out_ready_sem = get_arg_val<uint32_t>(arg_idx++);
+    const bool direction = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t chunks_per_sync = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t start_pages_read_in_row = get_arg_val<uint32_t>(arg_idx++);
+    const int32_t start_tiles_read = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t start_tiles_to_read = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t start_row_offset = get_arg_val<uint32_t>(arg_idx++);
 
-    constexpr uint32_t ct_idx = 22;
+    constexpr uint32_t ct_idx = 16;
 
 #ifdef INPUT_IS_SHARDED
     constexpr uint32_t ct_offset = 7;
@@ -126,7 +126,7 @@ void kernel_main() {
             uint32_t cb_in0 = do_reduce ? cb_input_id : cb_reader_output_id;
 
             uint32_t actual_slice_idx;
-            if constexpr (direction) {
+            if (direction) {
                 actual_slice_idx = slice_idx < 0 ? slice_idx + ring_size : slice_idx;
             } else {
                 actual_slice_idx = slice_idx >= (int)ring_size ? (uint32_t)slice_idx - ring_size : (uint32_t)slice_idx;
@@ -157,7 +157,7 @@ void kernel_main() {
                 uint32_t tiles_read = start_tiles_read;
                 uint32_t tiles_to_read = start_tiles_to_read;
 
-                if constexpr (!direction) {
+                if (!direction) {
                     uint32_t backwards_offset = std::min((tiles_to_read - tiles_read) / 2, tile_granularity);
                     for (uint32_t k = 0; k < backwards_offset; ++k) {
                         input_pages_read_in_row++;
@@ -188,7 +188,7 @@ void kernel_main() {
                     chunk_count++;
 
                     uint32_t tiles_to_read_in_current_direction = 0;
-                    if constexpr (direction) {
+                    if (direction) {
                         tiles_to_read_in_current_direction = std::min(tiles_remaining_to_read / 2, tile_granularity);
                     } else {
                         tiles_to_read_in_current_direction = std::min(tiles_remaining_to_read, tile_granularity);
@@ -240,7 +240,7 @@ void kernel_main() {
                     tiles_remaining_to_read = tiles_to_read - tiles_read;
                     if (tiles_remaining_to_read > 0) {
                         uint32_t tiles_to_read_in_other_direction = 0;
-                        if constexpr (!direction) {
+                        if (!direction) {
                             tiles_to_read_in_other_direction = std::min(tiles_remaining_to_read / 2, tile_granularity);
                         } else {
                             tiles_to_read_in_other_direction = std::min(tiles_remaining_to_read, tile_granularity);
@@ -264,7 +264,7 @@ void kernel_main() {
             }
 
             // Next slice idx
-            if constexpr (direction) {
+            if (direction) {
                 slice_idx--;
             } else {
                 slice_idx++;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/ring_reduction.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/ring_reduction.cpp
@@ -15,9 +15,11 @@ void MAIN {
     constexpr uint32_t ring_size = get_compile_time_arg_val(4);
     constexpr uint32_t input_tensor_B = get_compile_time_arg_val(5);
     constexpr uint32_t slice_C = get_compile_time_arg_val(6);
-    constexpr bool direction = get_compile_time_arg_val(7);
-    constexpr uint32_t start_tiles_read = get_compile_time_arg_val(8);
-    constexpr uint32_t start_tiles_to_read = get_compile_time_arg_val(9);
+
+    uint32_t arg_idx = 0;
+    uint32_t start_tiles_read = get_arg_val<uint32_t>(arg_idx++);
+    uint32_t start_tiles_to_read = get_arg_val<uint32_t>(arg_idx++);
+    const bool direction = get_arg_val<uint32_t>(arg_idx++);
 
     // Initialize binary operations - use the same constants consistently
     binary_op_init_common(input_cb_id, intermediate_cb, output_cb);
@@ -30,7 +32,7 @@ void MAIN {
                 uint32_t tiles_read = start_tiles_read;
                 uint32_t tiles_to_read = start_tiles_to_read;
 
-                if constexpr (!direction) {
+                if (!direction) {
                     uint32_t backwards_offset = std::min((tiles_to_read - tiles_read) / 2, tile_granularity);
                     tiles_read += backwards_offset;
                 }
@@ -39,7 +41,7 @@ void MAIN {
                 while (tiles_read < tiles_to_read) {
                     uint32_t tiles_remaining_to_read = tiles_to_read - tiles_read;
                     uint32_t num_pages_to_read = 0;
-                    if constexpr (direction) {
+                    if (direction) {
                         num_pages_to_read = std::min(tiles_remaining_to_read / 2, tile_granularity);
                     } else {
                         num_pages_to_read = std::min(tiles_remaining_to_read, tile_granularity);
@@ -62,7 +64,7 @@ void MAIN {
                     tiles_remaining_to_read = tiles_to_read - tiles_read;
                     if (tiles_remaining_to_read > 0) {
                         num_pages_to_read = 0;
-                        if constexpr (!direction) {
+                        if (!direction) {
                             num_pages_to_read = std::min(tiles_remaining_to_read / 2, tile_granularity);
                         } else {
                             num_pages_to_read = std::min(tiles_remaining_to_read, tile_granularity);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_op.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_op.hpp
@@ -112,7 +112,7 @@ struct ReduceScatterMinimalAsync {
 
 struct ReduceScatterProgramArtifacts {
     tt::tt_metal::KernelHandle reader_kernel_id;
-    std::vector<tt::tt_metal::KernelHandle> writer_kernel_ids;
+    tt::tt_metal::KernelHandle writer_kernel_id;
     std::vector<tt::tt_metal::CoreCoord> all_cores;
     uint32_t num_directions_per_link;
     uint32_t num_workers_per_direction;
@@ -244,7 +244,7 @@ ReduceScatterProgramArtifacts build_ring_reduce_scatter_minimal_async_program_ar
 void line_reduce_scatter_minimal_async_helper_override_runtime_arguments(
     tt::tt_metal::Program& program,
     tt::tt_metal::KernelHandle reader_kernel_id,
-    const std::vector<tt::tt_metal::KernelHandle>& writer_kernel_ids,
+    tt::tt_metal::KernelHandle writer_kernel_id,
     const std::vector<tt::tt_metal::CoreCoord>& all_cores,
     uint32_t num_links,
     uint32_t num_directions_per_link,
@@ -260,7 +260,7 @@ void line_reduce_scatter_minimal_async_helper_override_runtime_arguments(
 void ring_reduce_scatter_minimal_async_helper_override_runtime_arguments(
     tt::tt_metal::Program& program,
     tt::tt_metal::KernelHandle reader_kernel_id,
-    const std::vector<tt::tt_metal::KernelHandle>& writer_kernel_ids,
+    tt::tt_metal::KernelHandle writer_kernel_id,
     const std::vector<tt::tt_metal::CoreCoord>& all_cores,
     uint32_t num_links,
     uint32_t num_directions_per_link,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_op.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_op.hpp
@@ -111,7 +111,7 @@ struct ReduceScatterMinimalAsync {
 };
 
 struct ReduceScatterProgramArtifacts {
-    std::vector<tt::tt_metal::KernelHandle> reader_kernel_ids;
+    tt::tt_metal::KernelHandle reader_kernel_id;
     std::vector<tt::tt_metal::KernelHandle> writer_kernel_ids;
     std::vector<tt::tt_metal::CoreCoord> all_cores;
     uint32_t num_directions_per_link;
@@ -243,7 +243,7 @@ ReduceScatterProgramArtifacts build_ring_reduce_scatter_minimal_async_program_ar
 
 void line_reduce_scatter_minimal_async_helper_override_runtime_arguments(
     tt::tt_metal::Program& program,
-    const std::vector<tt::tt_metal::KernelHandle>& reader_kernel_ids,
+    tt::tt_metal::KernelHandle reader_kernel_id,
     const std::vector<tt::tt_metal::KernelHandle>& writer_kernel_ids,
     const std::vector<tt::tt_metal::CoreCoord>& all_cores,
     uint32_t num_links,
@@ -259,7 +259,7 @@ void line_reduce_scatter_minimal_async_helper_override_runtime_arguments(
 
 void ring_reduce_scatter_minimal_async_helper_override_runtime_arguments(
     tt::tt_metal::Program& program,
-    const std::vector<tt::tt_metal::KernelHandle>& reader_kernel_ids,
+    tt::tt_metal::KernelHandle reader_kernel_id,
     const std::vector<tt::tt_metal::KernelHandle>& writer_kernel_ids,
     const std::vector<tt::tt_metal::CoreCoord>& all_cores,
     uint32_t num_links,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_program.cpp
@@ -221,13 +221,7 @@ std::vector<uint32_t> get_ring_reader_compile_args(
     const uint32_t slice_Ht,
     const uint32_t slice_Wt,
     const bool fuse_op,
-    const uint32_t dir,
-    const uint32_t chunks_per_sync_val,
-    const uint32_t normalized_dim,
-    const uint32_t start_pages_read_in_row,
-    const uint32_t start_row_offset,
-    const uint32_t start_tiles_read,
-    const uint32_t start_tiles_to_read) {
+    const uint32_t normalized_dim) {
     if (normalized_dim == 0) {
         return {
             ring_index,               // my_chip_id
@@ -240,10 +234,6 @@ std::vector<uint32_t> get_ring_reader_compile_args(
             output_tensor_num_pages,  // output_num_pages
             input_batch_num_pages,    // batch_num_pages
             slice_B,                  // slice_B
-            dir,                      // direction
-            chunks_per_sync_val,      // chunks_per_sync
-            start_tiles_read,         // start_tiles_read
-            start_tiles_to_read       // start_tiles_to_read
         };
     } else {
         return {
@@ -262,13 +252,7 @@ std::vector<uint32_t> get_ring_reader_compile_args(
             slice_Ht,                 // slice_Ht
             slice_Wt,                 // slice_Wt
             fuse_op,                  // fused op
-            dir,                      // direction
-            chunks_per_sync_val,      // chunks_per_sync
             normalized_dim,           // dim normalized to 4D
-            start_pages_read_in_row,  // start_pages_read_in_row
-            start_row_offset,         // start_row_offset
-            start_tiles_read,         // start_tiles_read
-            start_tiles_to_read       // start_tiles_to_read
         };
     }
 }
@@ -406,70 +390,45 @@ std::vector<uint32_t> get_line_reader_compile_args(
     const uint32_t slice_Ht,
     const uint32_t slice_Wt,
     const bool fuse_op,
-    const uint32_t is_forward,
-    const uint32_t is_first_device_in_direction,
-    const uint32_t num_targets_in_direction,
-    const uint32_t do_final_reduction,
     const uint32_t sync_with_other_direction,
-    const uint32_t chunks_per_sync_val,
-    const uint32_t normalized_dim,
-    const uint32_t start_pages_read_in_row,
-    const uint32_t start_row_offset,
-    const uint32_t start_tiles_read,
-    const uint32_t start_tiles_to_read) {
+    const uint32_t normalized_dim) {
     if (normalized_dim == 0) {
         return {
-            ring_index,                    // my_chip_id
-            ring_size,                     // ring_size
-            input_cb_index,                // cb_input_id
-            intermediate_cb_index,         // cb_intermediate_id
-            reader_output_cb_index,        // cb_reader_output_id
-            tile_granularity,              // tile_granularity
-            page_size,                     // page_size
-            input_tensor_num_pages,        // input_num_pages
-            output_tensor_num_pages,       // output_num_pages
-            input_batch_num_pages,         // batch_num_pages
-            slice_B,                       // slice_B
-            is_forward,                    // is_forward
-            is_first_device_in_direction,  // is_first_device_in_direction
-            num_targets_in_direction,      // num_targets_in_direction
-            do_final_reduction,            // do_final_reduction
-            sync_with_other_direction,     // sync_with_other_direction
-            chunks_per_sync_val,           // chunks_per_sync
-            start_tiles_read,              // start_tiles_read
-            start_tiles_to_read            // start_tiles_to_read
+            ring_index,                // my_chip_id
+            ring_size,                 // ring_size
+            input_cb_index,            // cb_input_id
+            intermediate_cb_index,     // cb_intermediate_id
+            reader_output_cb_index,    // cb_reader_output_id
+            tile_granularity,          // tile_granularity
+            page_size,                 // page_size
+            input_tensor_num_pages,    // input_num_pages
+            output_tensor_num_pages,   // output_num_pages
+            input_batch_num_pages,     // batch_num_pages
+            slice_B,                   // slice_B
+            sync_with_other_direction  // sync_with_other_direction
         };
     } else {
         return {
-            ring_index,                    // my_chip_id
-            ring_size,                     // ring_size
-            input_cb_index,                // cb_input_id
-            intermediate_cb_index,         // cb_intermediate_id
-            reader_output_cb_index,        // cb_reader_output_id
-            tile_granularity,              // tile_granularity
-            page_size,                     // page_size
-            input_tensor_num_pages,        // input_num_pages
-            input_batch_num_pages,         // input_batch_num_pages
-            input_channel_num_pages,       // input_channel_num_pages
-            output_batch_num_pages,        // output_batch_num_pages
-            output_channel_num_pages,      // output_channel_num_pages
-            input_tensor_B,                // input_tensor_B
-            input_tensor_Wt,               // input_tensor_Wt
-            slice_C,                       // slice_C
-            slice_Ht,                      // slice_Ht
-            slice_Wt,                      // slice_Wt
-            fuse_op,                       // fuse_op
-            is_forward,                    // is_forward
-            is_first_device_in_direction,  // is_first_device_in_direction
-            num_targets_in_direction,      // num_targets_in_direction
-            do_final_reduction,            // do_final_reduction
-            sync_with_other_direction,     // sync_with_other_direction
-            chunks_per_sync_val,           // chunks_per_sync
-            normalized_dim,                // dim
-            start_pages_read_in_row,       // start_pages_read_in_row
-            start_row_offset,              // start_row_offset
-            start_tiles_read,              // start_tiles_read
-            start_tiles_to_read            // start_tiles_to_read
+            ring_index,                 // my_chip_id
+            ring_size,                  // ring_size
+            input_cb_index,             // cb_input_id
+            intermediate_cb_index,      // cb_intermediate_id
+            reader_output_cb_index,     // cb_reader_output_id
+            tile_granularity,           // tile_granularity
+            page_size,                  // page_size
+            input_tensor_num_pages,     // input_num_pages
+            input_batch_num_pages,      // input_batch_num_pages
+            input_channel_num_pages,    // input_channel_num_pages
+            output_batch_num_pages,     // output_batch_num_pages
+            output_channel_num_pages,   // output_channel_num_pages
+            input_tensor_B,             // input_tensor_B
+            input_tensor_Wt,            // input_tensor_Wt
+            slice_C,                    // slice_C
+            slice_Ht,                   // slice_Ht
+            slice_Wt,                   // slice_Wt
+            fuse_op,                    // fuse_op
+            sync_with_other_direction,  // sync_with_other_direction
+            normalized_dim,             // dim
         };
     }
 }
@@ -822,7 +781,7 @@ ReduceScatterProgramArtifacts build_ring_reduce_scatter_minimal_async_program_ar
 
     const auto [all_core_range, all_cores] =
         choose_worker_cores(num_links, num_cores_per_link, mesh_device, sub_device_id, core_grid_offset);
-    std::set<CoreRange> sender_worker_core_ranges;
+    std::vector<CoreRange> sender_worker_core_ranges;
     std::set<CoreRange> sender_forward_core_ranges;
     std::set<CoreRange> sender_backward_core_ranges;
     std::set<CoreRange> mux_forward_core_ranges;
@@ -843,7 +802,7 @@ ReduceScatterProgramArtifacts build_ring_reduce_scatter_minimal_async_program_ar
                 } else {
                     sender_backward_core_ranges.insert(CoreRange(worker_core));
                 }
-                sender_worker_core_ranges.insert(CoreRange(worker_core));
+                sender_worker_core_ranges.emplace_back(worker_core);
             }
         }
     }
@@ -953,7 +912,6 @@ ReduceScatterProgramArtifacts build_ring_reduce_scatter_minimal_async_program_ar
     }
 
     // KERNEL CREATION
-    std::vector<KernelHandle> reader_kernel_ids;
     std::vector<KernelHandle> writer_kernel_ids;
     std::vector<KernelHandle> reduce_kernel_ids;
     std::vector<KernelHandle> mux_kernel_ids;
@@ -963,10 +921,55 @@ ReduceScatterProgramArtifacts build_ring_reduce_scatter_minimal_async_program_ar
     }
 
     // Kernel Runtime Args
-    CoreCoord opposite_core_coord;
     const uint32_t l1_unreserved_base_address =
         mesh_device->allocator()->get_base_allocator_addr(tt::tt_metal::HalMemType::L1);
     const size_t mux_base_l1_address = l1_unreserved_base_address;
+
+    std::vector<uint32_t> sender_reader_compile_args =
+        operations::experimental::ccl::detail::get_ring_reader_compile_args(
+            ring_index,
+            ring_size,
+            input_cb_index,
+            intermediate_cb_index,
+            reader_output_cb_index,
+            tile_granularity,
+            page_size,
+            output_tensor_num_pages,
+            input_batch_num_pages,
+            input_channel_num_pages,
+            input_tensor_B,
+            input_tensor_Wt,
+            slice_B,
+            slice_C,
+            slice_Ht,
+            slice_Wt,
+            fuse_op,
+            normalized_dim);
+
+    if (input_is_sharded) {
+        shard_builder::extend_sharding_compile_time_args(input_tensor, sender_reader_compile_args);
+    } else {
+        tt::tt_metal::TensorAccessorArgs(input_tensor.buffer()).append_to(sender_reader_compile_args);
+    }
+    if (intermediate_is_sharded) {
+        shard_builder::extend_sharding_compile_time_args(intermediate_tensor, sender_reader_compile_args);
+    } else {
+        tt::tt_metal::TensorAccessorArgs(intermediate_tensor.buffer()).append_to(sender_reader_compile_args);
+    }
+
+    std::string sender_reader_kernel_path =
+        normalized_dim == 0 ? "ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/"
+                              "device/kernels/dim_zero_ring_reduce_scatter_minimal_async_reader.cpp"
+                            : "ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/"
+                              "device/kernels/ring_reduce_scatter_minimal_async_reader.cpp";
+
+    auto reader_kernel_id = tt::tt_metal::CreateKernel(
+        program,
+        sender_reader_kernel_path,
+        sender_worker_core_range_set,
+        tt::tt_metal::ReaderDataMovementConfig(sender_reader_compile_args, reader_compute_defines));
+
+    auto worker_core_iter = sender_worker_core_range_set.ranges().cbegin();
     for (uint32_t link = 0; link < num_links; link++) {
         for (uint32_t dir = 0; dir < num_directions_per_link; dir++) {
             // Fabrix mux kernel
@@ -1011,13 +1014,8 @@ ReduceScatterProgramArtifacts build_ring_reduce_scatter_minimal_async_program_ar
             tt::tt_metal::SetRuntimeArgs(program, mux_kernel_id, {mux_logical_core}, mux_rt_args);
 
             for (uint32_t worker = 0; worker < num_workers_per_direction; worker++) {
-                CoreCoord core = all_cores[mux_core_offset + num_mux_cores_per_direction_per_link + worker];
+                auto core = *((worker_core_iter++)->begin());
                 CoreCoord virtual_core = mesh_device->worker_core_from_logical_core(core);
-                CoreCoord supplemental_core = all_cores
-                    [(link * num_cores_per_link) +
-                     ((1 - dir) * (num_mux_cores_per_direction_per_link + num_workers_per_direction)) +
-                     num_mux_cores_per_direction_per_link + worker];
-                opposite_core_coord = mesh_device->worker_core_from_logical_core(supplemental_core);
 
                 uint32_t worker_id = (link * num_workers_per_direction) + worker;
                 uint32_t num_workers = num_links * num_workers_per_direction;
@@ -1044,74 +1042,28 @@ ReduceScatterProgramArtifacts build_ring_reduce_scatter_minimal_async_program_ar
                 }
                 log_trace(tt::LogOp, "DEBUG: chunks_per_sync_val: {}", chunks_per_sync_val);
 
-                // Reader CT args
-                std::vector<uint32_t> sender_reader_compile_args =
-                    operations::experimental::ccl::detail::get_ring_reader_compile_args(
-                        ring_index,
-                        ring_size,
-                        input_cb_index,
-                        intermediate_cb_index,
-                        reader_output_cb_index,
-                        tile_granularity,
-                        page_size,
-                        output_tensor_num_pages,
-                        input_batch_num_pages,
-                        input_channel_num_pages,
-                        input_tensor_B,
-                        input_tensor_Wt,
-                        slice_B,
-                        slice_C,
-                        slice_Ht,
-                        slice_Wt,
-                        fuse_op,
-                        dir,
-                        chunks_per_sync_val,
-                        normalized_dim,
-                        start_pages_read_in_row,
-                        start_row_offset,
-                        start_tiles_read,
-                        start_tiles_to_read);
-                if (input_is_sharded) {
-                    shard_builder::extend_sharding_compile_time_args(input_tensor, sender_reader_compile_args);
-                } else {
-                    tt::tt_metal::TensorAccessorArgs(input_tensor.buffer()).append_to(sender_reader_compile_args);
-                }
-                if (intermediate_is_sharded) {
-                    shard_builder::extend_sharding_compile_time_args(intermediate_tensor, sender_reader_compile_args);
-                } else {
-                    tt::tt_metal::TensorAccessorArgs(intermediate_tensor.buffer())
-                        .append_to(sender_reader_compile_args);
-                }
-
-                std::string sender_reader_kernel_path =
-                    normalized_dim == 0 ? "ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/"
-                                          "device/kernels/dim_zero_ring_reduce_scatter_minimal_async_reader.cpp"
-                                        : "ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/"
-                                          "device/kernels/ring_reduce_scatter_minimal_async_reader.cpp";
-                auto worker_sender_reader_kernel_id = tt::tt_metal::CreateKernel(
-                    program,
-                    sender_reader_kernel_path,
-                    {core},
-                    tt::tt_metal::ReaderDataMovementConfig(sender_reader_compile_args, reader_compute_defines));
-                reader_kernel_ids.push_back(worker_sender_reader_kernel_id);
-
-                // Reader RT args
-                std::vector<uint32_t> sender_reader_runtime_args = {
+                std::vector<uint32_t> reader_rt_args = {
                     input_tensor.buffer()->address(),         // input_tensor_address
                     intermediate_tensor.buffer()->address(),  // intermediate_tensor_address
                     semaphore.at(dir).address(),              // out_ready_semaphore
+                    dir,                                      // direction
+                    chunks_per_sync_val,                      // chunks_per_sync
+                    start_pages_read_in_row,                  // start_pages_read_in_row
+                    start_tiles_read,                         // start_tiles_read
+                    start_tiles_to_read,                      // start_tiles_to_read
+                    start_row_offset,                         // start_row_offset (unused by dim0 kernel)
                 };
                 if (input_is_sharded) {
-                    shard_builder::extend_sharding_run_time_args(input_tensor, sender_reader_runtime_args);
+                    shard_builder::extend_sharding_run_time_args(input_tensor, reader_rt_args);
                 }
                 if (intermediate_is_sharded) {
-                    shard_builder::extend_sharding_run_time_args(intermediate_tensor, sender_reader_runtime_args);
+                    shard_builder::extend_sharding_run_time_args(intermediate_tensor, reader_rt_args);
                 }
                 if (fuse_op) {
-                    fused_op_signaler->push_reduce_scatter_fused_op_rt_args(sender_reader_runtime_args);
+                    fused_op_signaler->push_reduce_scatter_fused_op_rt_args(reader_rt_args);
                 }
-                tt::tt_metal::SetRuntimeArgs(
-                    program, worker_sender_reader_kernel_id, {core}, sender_reader_runtime_args);
+
+                tt::tt_metal::SetRuntimeArgs(program, reader_kernel_id, {core}, reader_rt_args);
 
                 CoreCoord termination_master_logical_core =
                     all_cores[mux_core_offset + num_mux_cores_per_direction_per_link + 0];
@@ -1255,7 +1207,7 @@ ReduceScatterProgramArtifacts build_ring_reduce_scatter_minimal_async_program_ar
     }
 
     return {
-        reader_kernel_ids,
+        reader_kernel_id,
         writer_kernel_ids,
         all_cores,
         num_directions_per_link,
@@ -1266,7 +1218,7 @@ ReduceScatterProgramArtifacts build_ring_reduce_scatter_minimal_async_program_ar
 
 void ring_reduce_scatter_minimal_async_helper_override_runtime_arguments(
     tt::tt_metal::Program& program,
-    const std::vector<tt::tt_metal::KernelHandle>& reader_kernel_ids,
+    const tt::tt_metal::KernelHandle reader_kernel_id,
     const std::vector<tt::tt_metal::KernelHandle>& writer_kernel_ids,
     const std::vector<tt::tt_metal::CoreCoord>& all_cores,
     uint32_t num_links,
@@ -1288,7 +1240,7 @@ void ring_reduce_scatter_minimal_async_helper_override_runtime_arguments(
                                            (dir * (num_mux_cores_per_direction_per_link + num_workers_per_direction));
                 CoreCoord core = all_cores[mux_core_offset + num_mux_cores_per_direction_per_link + worker];
                 std::vector<std::vector<RuntimeArgsData>> reader_runtime_args =
-                    GetRuntimeArgs(program, reader_kernel_ids[core_idx]);
+                    GetRuntimeArgs(program, reader_kernel_id);
                 std::vector<std::vector<RuntimeArgsData>> writer_runtime_args =
                     GetRuntimeArgs(program, writer_kernel_ids[core_idx]);
 
@@ -1337,7 +1289,7 @@ tt::tt_metal::operation::ProgramWithCallbacks ring_reduce_scatter_minimal_async_
     std::optional<uint32_t> num_buffers_per_channel,
     const CoreCoord core_grid_offset) {
     auto
-        [reader_kernel_ids,
+        [reader_kernel_id,
          writer_kernel_ids,
          all_cores,
          num_directions_per_link,
@@ -1368,7 +1320,7 @@ tt::tt_metal::operation::ProgramWithCallbacks ring_reduce_scatter_minimal_async_
                 core_grid_offset);
 
     auto override_runtime_arguments_callback =
-        [reader_kernel_ids,
+        [reader_kernel_id,
          writer_kernel_ids,
          all_cores,
          num_links,
@@ -1388,7 +1340,7 @@ tt::tt_metal::operation::ProgramWithCallbacks ring_reduce_scatter_minimal_async_
             auto semaphore = static_cast<const ttnn::ReduceScatterMinimalAsync*>(operation)->semaphore;
             ring_reduce_scatter_minimal_async_helper_override_runtime_arguments(
                 program,
-                reader_kernel_ids,
+                reader_kernel_id,
                 writer_kernel_ids,
                 all_cores,
                 num_links,
@@ -1401,7 +1353,6 @@ tt::tt_metal::operation::ProgramWithCallbacks ring_reduce_scatter_minimal_async_
                 input,
                 intermed,
                 output);
-
         };
 
     return {.program = std::move(program), .override_runtime_arguments_callback = override_runtime_arguments_callback};
@@ -1515,7 +1466,7 @@ ReduceScatterProgramArtifacts build_line_reduce_scatter_minimal_async_program_ar
 
     const auto [all_core_range, all_cores] =
         choose_worker_cores(num_links, num_cores_per_link, mesh_device, sub_device_id, core_grid_offset);
-    std::set<CoreRange> sender_worker_core_ranges;
+    std::vector<CoreRange> sender_worker_core_ranges;
     std::set<CoreRange> sender_forward_core_ranges;
     std::set<CoreRange> sender_backward_core_ranges;
     std::set<CoreRange> mux_forward_core_ranges;
@@ -1536,7 +1487,7 @@ ReduceScatterProgramArtifacts build_line_reduce_scatter_minimal_async_program_ar
                 } else {
                     sender_backward_core_ranges.insert(CoreRange(worker_core));
                 }
-                sender_worker_core_ranges.insert(CoreRange(worker_core));
+                sender_worker_core_ranges.emplace_back(worker_core);
             }
         }
     }
@@ -1646,8 +1597,6 @@ ReduceScatterProgramArtifacts build_line_reduce_scatter_minimal_async_program_ar
     }
 
     // KERNEL CREATION
-    // Reader
-    std::vector<KernelHandle> reader_kernel_ids;
     std::vector<KernelHandle> writer_kernel_ids;
     std::vector<KernelHandle> reduce_kernel_ids;
     std::vector<KernelHandle> mux_kernel_ids;
@@ -1655,11 +1604,68 @@ ReduceScatterProgramArtifacts build_line_reduce_scatter_minimal_async_program_ar
         fused_op_signaler->init_reduce_scatter(program, mesh_device, sender_worker_core_range_set);
     }
 
-    // Kernel Runtime Args
+    // Common Kernel Runtime Args
+    const bool sync_with_other_direction = !(is_first_chip || is_last_chip);
     uint32_t fwd_bwd_semaphore_address = tt::tt_metal::CreateSemaphore(program, sender_worker_core_range_set, 0);
     const uint32_t l1_unreserved_base_address =
         mesh_device->allocator()->get_base_allocator_addr(tt::tt_metal::HalMemType::L1);
     const size_t mux_base_l1_address = l1_unreserved_base_address;
+
+    // Reader
+    std::vector<uint32_t> sender_reader_compile_args =
+        operations::experimental::ccl::detail::get_line_reader_compile_args(
+            ring_index,
+            ring_size,
+            input_cb_index,
+            intermediate_cb_index,
+            reader_output_cb_index,
+            tile_granularity,
+            page_size,
+            input_tensor_num_pages,
+            output_tensor_num_pages,
+            input_batch_num_pages,
+            input_channel_num_pages,
+            output_batch_num_pages,
+            output_channel_num_pages,
+            input_tensor_B,
+            input_tensor_Wt,
+            slice_B,
+            slice_C,
+            slice_Ht,
+            slice_Wt,
+            fuse_op,
+            sync_with_other_direction,
+            normalized_dim);
+
+    if (input_is_sharded) {
+        shard_builder::extend_sharding_compile_time_args(input_tensor, sender_reader_compile_args);
+    } else {
+        tt::tt_metal::TensorAccessorArgs(input_tensor.buffer()).append_to(sender_reader_compile_args);
+    }
+    if (intermediate_is_sharded) {
+        shard_builder::extend_sharding_compile_time_args(intermediate_tensor, sender_reader_compile_args);
+    } else {
+        tt::tt_metal::TensorAccessorArgs(intermediate_tensor.buffer()).append_to(sender_reader_compile_args);
+    }
+    if (output_is_sharded) {
+        shard_builder::extend_sharding_compile_time_args(output_tensor, sender_reader_compile_args);
+    } else {
+        tt::tt_metal::TensorAccessorArgs(output_tensor.buffer()).append_to(sender_reader_compile_args);
+    }
+
+    std::string sender_reader_kernel_path =
+        normalized_dim == 0 ? "ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/"
+                              "device/kernels/dim_zero_line_reduce_scatter_minimal_async_reader.cpp"
+                            : "ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/"
+                              "device/kernels/line_reduce_scatter_minimal_async_reader.cpp";
+
+    auto reader_kernel_id = tt::tt_metal::CreateKernel(
+        program,
+        sender_reader_kernel_path,
+        sender_worker_core_range_set,
+        tt::tt_metal::ReaderDataMovementConfig(sender_reader_compile_args, reader_compute_defines));
+
+    auto worker_core_iter = sender_worker_core_range_set.ranges().cbegin();
     for (uint32_t link = 0; link < num_links; link++) {
         for (uint32_t dir = 0; dir < num_directions_per_link; dir++) {
             const bool is_forward = dir;
@@ -1709,7 +1715,8 @@ ReduceScatterProgramArtifacts build_line_reduce_scatter_minimal_async_program_ar
             }
 
             for (uint32_t worker = 0; worker < num_workers_per_direction; worker++) {
-                CoreCoord core = all_cores[mux_core_offset + num_mux_cores_per_direction_per_link + worker];
+                auto core = *((worker_core_iter++)->begin());
+                // CoreCoord core = all_cores[mux_core_offset + num_mux_cores_per_direction_per_link + worker];
                 CoreCoord virtual_core = mesh_device->worker_core_from_logical_core(core);
 
                 // FWD core needs BWD core coordinate for fwd/bwd final reduction sync.
@@ -1736,12 +1743,10 @@ ReduceScatterProgramArtifacts build_line_reduce_scatter_minimal_async_program_ar
                     is_first_device_in_direction ? 0 : num_targets_in_direction;
                 const bool do_final_reduction = !is_first_device_in_direction;
                 const int num_total_reduction_steps = num_intermediate_reduction_steps + (do_final_reduction ? 1 : 0);
-                const bool sync_with_other_direction = !(is_first_chip || is_last_chip);
 
-                uint32_t worker_id = (link * num_workers_per_direction) + worker;
-                uint32_t num_workers = num_links * num_workers_per_direction;
-
-                auto [start_tiles_read, start_tiles_to_read, start_pages_read_in_row, start_row_offset] =
+                const uint32_t worker_id = (link * num_workers_per_direction) + worker;
+                const uint32_t num_workers = num_links * num_workers_per_direction;
+                const auto [start_tiles_read, start_tiles_to_read, start_pages_read_in_row, start_row_offset] =
                     operations::experimental::ccl::detail::get_tile_offsets(
                         worker_id,
                         num_workers,
@@ -1763,76 +1768,24 @@ ReduceScatterProgramArtifacts build_line_reduce_scatter_minimal_async_program_ar
                 }
                 log_trace(tt::LogOp, "DEBUG: chunks_per_sync_val: {}", chunks_per_sync_val);
 
-                // Reader CT args
-                std::vector<uint32_t> sender_reader_compile_args =
-                    operations::experimental::ccl::detail::get_line_reader_compile_args(
-                        ring_index,
-                        ring_size,
-                        input_cb_index,
-                        intermediate_cb_index,
-                        reader_output_cb_index,
-                        tile_granularity,
-                        page_size,
-                        input_tensor_num_pages,
-                        output_tensor_num_pages,
-                        input_batch_num_pages,
-                        input_channel_num_pages,
-                        output_batch_num_pages,
-                        output_channel_num_pages,
-                        input_tensor_B,
-                        input_tensor_Wt,
-                        slice_B,
-                        slice_C,
-                        slice_Ht,
-                        slice_Wt,
-                        fuse_op,
-                        is_forward,
-                        is_first_device_in_direction,
-                        num_targets_in_direction,
-                        do_final_reduction,
-                        sync_with_other_direction,
-                        chunks_per_sync_val,
-                        normalized_dim,
-                        start_pages_read_in_row,
-                        start_row_offset,
-                        start_tiles_read,
-                        start_tiles_to_read);
-                if (input_is_sharded) {
-                    shard_builder::extend_sharding_compile_time_args(input_tensor, sender_reader_compile_args);
-                } else {
-                    tt::tt_metal::TensorAccessorArgs(input_tensor.buffer()).append_to(sender_reader_compile_args);
-                }
-                if (intermediate_is_sharded) {
-                    shard_builder::extend_sharding_compile_time_args(intermediate_tensor, sender_reader_compile_args);
-                } else {
-                    tt::tt_metal::TensorAccessorArgs(intermediate_tensor.buffer())
-                        .append_to(sender_reader_compile_args);
-                }
-                if (output_is_sharded) {
-                    shard_builder::extend_sharding_compile_time_args(output_tensor, sender_reader_compile_args);
-                } else {
-                    tt::tt_metal::TensorAccessorArgs(output_tensor.buffer()).append_to(sender_reader_compile_args);
-                }
-
-                std::string sender_reader_kernel_path =
-                    normalized_dim == 0 ? "ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/"
-                                          "device/kernels/dim_zero_line_reduce_scatter_minimal_async_reader.cpp"
-                                        : "ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/"
-                                          "device/kernels/line_reduce_scatter_minimal_async_reader.cpp";
-                auto worker_sender_reader_kernel_id = tt::tt_metal::CreateKernel(
-                    program,
-                    sender_reader_kernel_path,
-                    {core},
-                    tt::tt_metal::ReaderDataMovementConfig(sender_reader_compile_args, reader_compute_defines));
-                reader_kernel_ids.push_back(worker_sender_reader_kernel_id);
-
                 // Reader RT args
                 std::vector<uint32_t> reader_rt_args = {
                     input_tensor.buffer()->address(),         // input_tensor_address
                     intermediate_tensor.buffer()->address(),  // intermediate_tensor_address
                     output_tensor.buffer()->address(),        // output_tensor_address
                     semaphore.at(0).address(),                // remote transfer sync semaphore
-                    fwd_bwd_semaphore_address};
+                    fwd_bwd_semaphore_address,
+                    is_forward,                    // is_forward
+                    is_first_device_in_direction,  // is_first_device_in_direction
+                    num_targets_in_direction,      // num_targets_in_direction
+                    do_final_reduction,            // do_final_reduction
+                    chunks_per_sync_val,           // chunks_per_sync
+                    start_tiles_read,              // start_tiles_read
+                    start_tiles_to_read,           // start_tiles_to_read
+                    start_pages_read_in_row,       // start_pages_read_in_row (unused by dim0 kernel)
+                    start_row_offset,              // start_row_offset (unused by dim0 kernel)
+                };
+
                 if (input_is_sharded) {
                     shard_builder::extend_sharding_run_time_args(input_tensor, reader_rt_args);
                 }
@@ -1845,7 +1798,7 @@ ReduceScatterProgramArtifacts build_line_reduce_scatter_minimal_async_program_ar
                 if (fuse_op) {
                     fused_op_signaler->push_reduce_scatter_fused_op_rt_args(reader_rt_args);
                 }
-                tt::tt_metal::SetRuntimeArgs(program, worker_sender_reader_kernel_id, {core}, reader_rt_args);
+                tt::tt_metal::SetRuntimeArgs(program, reader_kernel_id, {core}, reader_rt_args);
                 CoreCoord termination_master_logical_core =
                     all_cores[mux_core_offset + num_mux_cores_per_direction_per_link + 0];
                 CoreCoord termination_master_virtual_core =
@@ -1991,7 +1944,7 @@ ReduceScatterProgramArtifacts build_line_reduce_scatter_minimal_async_program_ar
     }
 
     return {
-        reader_kernel_ids,
+        reader_kernel_id,
         writer_kernel_ids,
         all_cores,
         num_directions_per_link,
@@ -2002,7 +1955,7 @@ ReduceScatterProgramArtifacts build_line_reduce_scatter_minimal_async_program_ar
 
 void line_reduce_scatter_minimal_async_helper_override_runtime_arguments(
     tt::tt_metal::Program& program,
-    const std::vector<tt::tt_metal::KernelHandle>& reader_kernel_ids,
+    const tt::tt_metal::KernelHandle reader_kernel_id,
     const std::vector<tt::tt_metal::KernelHandle>& writer_kernel_ids,
     const std::vector<tt::tt_metal::CoreCoord>& all_cores,
     uint32_t num_links,
@@ -2024,7 +1977,7 @@ void line_reduce_scatter_minimal_async_helper_override_runtime_arguments(
                                            (dir * (num_mux_cores_per_direction_per_link + num_workers_per_direction));
                 CoreCoord core = all_cores[mux_core_offset + num_mux_cores_per_direction_per_link + worker];
                 std::vector<std::vector<RuntimeArgsData>> reader_runtime_args =
-                    GetRuntimeArgs(program, reader_kernel_ids[core_idx]);
+                    GetRuntimeArgs(program, reader_kernel_id);
                 std::vector<std::vector<RuntimeArgsData>> writer_runtime_args =
                     GetRuntimeArgs(program, writer_kernel_ids[core_idx]);
 
@@ -2073,7 +2026,7 @@ tt::tt_metal::operation::ProgramWithCallbacks line_reduce_scatter_minimal_async_
     std::optional<uint32_t> num_buffers_per_channel,
     const CoreCoord core_grid_offset) {
     auto
-        [reader_kernel_ids,
+        [reader_kernel_id,
          writer_kernel_ids,
          all_cores,
          num_directions_per_link,
@@ -2103,7 +2056,7 @@ tt::tt_metal::operation::ProgramWithCallbacks line_reduce_scatter_minimal_async_
                 num_buffers_per_channel,
                 core_grid_offset);
     auto override_runtime_arguments_callback =
-        [reader_kernel_ids,
+        [reader_kernel_id,
          writer_kernel_ids,
          all_cores,
          num_links,
@@ -2125,7 +2078,7 @@ tt::tt_metal::operation::ProgramWithCallbacks line_reduce_scatter_minimal_async_
             const auto& semaphore = static_cast<const ttnn::ReduceScatterMinimalAsync*>(operation)->semaphore;
             line_reduce_scatter_minimal_async_helper_override_runtime_arguments(
                 program,
-                reader_kernel_ids,
+                reader_kernel_id,
                 writer_kernel_ids,
                 all_cores,
                 num_links,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_program.cpp
@@ -1070,9 +1070,9 @@ ReduceScatterProgramArtifacts build_ring_reduce_scatter_minimal_async_program_ar
                     semaphore.at(dir).address(),              // out_ready_semaphore
                     dir,                                      // direction
                     chunks_per_sync_val,                      // chunks_per_sync
-                    start_pages_read_in_row,                  // start_pages_read_in_row
                     start_tiles_read,                         // start_tiles_read
                     start_tiles_to_read,                      // start_tiles_to_read
+                    start_pages_read_in_row,                  // start_pages_read_in_row
                     start_row_offset,                         // start_row_offset (unused by dim0 kernel)
                 };
                 if (input_is_sharded) {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_program.cpp
@@ -276,13 +276,7 @@ std::vector<uint32_t> get_ring_writer_compile_args(
     const uint32_t slice_C,
     const uint32_t slice_Ht,
     const uint32_t slice_Wt,
-    const uint32_t dir,
-    const uint32_t chunks_per_sync_val,
-    const uint32_t normalized_dim,
-    const uint32_t start_pages_read_in_row,
-    const uint32_t start_row_offset,
-    const uint32_t start_tiles_read,
-    const uint32_t start_tiles_to_read) {
+    const uint32_t normalized_dim) {
     if (normalized_dim == 0) {
         return {
             ring_index,                     // my_chip_id
@@ -295,10 +289,6 @@ std::vector<uint32_t> get_ring_writer_compile_args(
             output_tensor_num_pages,        // output_num_pages
             input_batch_num_pages,          // batch_num_pages
             slice_B,                        // slice_B
-            dir,                            // direction
-            chunks_per_sync_val,            // chunks_per_sync
-            start_tiles_read,               // start_tiles_read
-            start_tiles_to_read,            // tiles_to_read
         };
     } else {
         return {
@@ -317,13 +307,7 @@ std::vector<uint32_t> get_ring_writer_compile_args(
             slice_C,                        // slice_C
             slice_Ht,                       // slice_Ht
             slice_Wt,                       // slice_Wt
-            dir,                            // direction
-            chunks_per_sync_val,            // chunks_per_sync
-            normalized_dim,                 // dim normalized to 4D
-            start_pages_read_in_row,        // start_pages_read_in_row
-            start_row_offset,               // start_row_offset
-            start_tiles_read,               // start_tiles_read
-            start_tiles_to_read,            // tiles_to_read
+            normalized_dim                  // dim normalized to 4D
         };
     }
 }
@@ -452,67 +436,42 @@ std::vector<uint32_t> get_line_writer_compile_args(
     const uint32_t slice_C,
     const uint32_t slice_Ht,
     const uint32_t slice_Wt,
-    const uint32_t is_forward,
-    const uint32_t is_first_device_in_direction,
-    const uint32_t num_targets_in_direction,
-    const uint32_t do_final_reduction,
-    const uint32_t sync_with_other_direction,
-    const uint32_t chunks_per_sync_val,
     const uint32_t normalized_dim,
-    const uint32_t start_pages_read_in_row,
-    const uint32_t start_row_offset,
-    const uint32_t start_tiles_read,
-    const uint32_t start_tiles_to_read) {
+    const uint32_t sync_with_other_direction) {
     if (normalized_dim == 0) {
         return {
-            ring_size,                     // ring_size
-            compute_output_cb_index,       // cb_compute_output_id
-            reader_output_cb_index,        // cb_reader_output_id
-            tile_granularity,              // tile_granularity
-            page_size,                     // page_size
-            tiles_to_write_per_packet,     // contig_pages_advanced
-            input_tensor_num_pages,        // input_num_pages
-            output_tensor_num_pages,       // output_num_pages
-            input_batch_num_pages,         // batch_num_pages
-            slice_B,                       // slice_B
-            is_forward,                    // is_forward
-            is_first_device_in_direction,  // is_first_device_in_direction
-            num_targets_in_direction,      // num_targets_in_direction
-            do_final_reduction,            // do_final_reduction
-            sync_with_other_direction,     // sync_with_other_direction
-            chunks_per_sync_val,           // chunks_per_sync
-            start_tiles_read,              // start_tiles_read
-            start_tiles_to_read,           // start_tiles_to_read
+            ring_size,                  // ring_size
+            compute_output_cb_index,    // cb_compute_output_id
+            reader_output_cb_index,     // cb_reader_output_id
+            tile_granularity,           // tile_granularity
+            page_size,                  // page_size
+            tiles_to_write_per_packet,  // contig_pages_advanced
+            input_tensor_num_pages,     // input_num_pages
+            output_tensor_num_pages,    // output_num_pages
+            input_batch_num_pages,      // batch_num_pages
+            slice_B,                    // slice_B
+            sync_with_other_direction,  // sync_with_other_direction
         };
     } else {
         return {
-            ring_size,                     // ring_size
-            compute_output_cb_index,       // cb_compute_output_id
-            reader_output_cb_index,        // cb_reader_output_id
-            tile_granularity,              // tile_granularity
-            page_size,                     // page_size
-            tiles_to_write_per_packet,     // contig_pages_advanced
-            input_tensor_num_pages,        // input_num_pages
-            input_batch_num_pages,         // input_batch_num_pages
-            input_channel_num_pages,       // input_channel_num_pages
-            output_batch_num_pages,        // output_batch_num_pages
-            output_channel_num_pages,      // output_channel_num_pages
-            input_tensor_B,                // input_tensor_b
-            input_tensor_Wt,               // input_tensor_Wt
-            slice_C,                       // slice_C
-            slice_Ht,                      // slice_Ht
-            slice_Wt,                      // slice_Wt
-            is_forward,                    // is_forward
-            is_first_device_in_direction,  // is_first_device_in_direction
-            num_targets_in_direction,      // num_targets_in_direction
-            do_final_reduction,            // do_final_reduction
-            sync_with_other_direction,     // sync_with_other_direction
-            chunks_per_sync_val,           // chunks_per_sync
-            normalized_dim,                // dim
-            start_pages_read_in_row,       // start_pages_read_in_row
-            start_row_offset,              // start_row_offset
-            start_tiles_read,              // start_tiles_read
-            start_tiles_to_read,           // start_tiles_to_read
+            ring_size,                  // ring_size
+            compute_output_cb_index,    // cb_compute_output_id
+            reader_output_cb_index,     // cb_reader_output_id
+            tile_granularity,           // tile_granularity
+            page_size,                  // page_size
+            tiles_to_write_per_packet,  // contig_pages_advanced
+            input_tensor_num_pages,     // input_num_pages
+            input_batch_num_pages,      // input_batch_num_pages
+            input_channel_num_pages,    // input_channel_num_pages
+            output_batch_num_pages,     // output_batch_num_pages
+            output_channel_num_pages,   // output_channel_num_pages
+            input_tensor_B,             // input_tensor_b
+            input_tensor_Wt,            // input_tensor_Wt
+            slice_C,                    // slice_C
+            slice_Ht,                   // slice_Ht
+            slice_Wt,                   // slice_Wt
+            normalized_dim,             // dim
+            sync_with_other_direction   // sync_with_other_direction
         };
     }
 }
@@ -558,43 +517,53 @@ std::vector<uint32_t> get_line_reduce_compile_args(
 using namespace ccl;
 
 void append_fabric_mux_connection_ct_args(
-    const bool is_termination_master,
-    const CoreCoord& mux_virtual_core,
     const tt::tt_fabric::FabricMuxChannelType channel_type,
-    uint32_t worker_id,
     const tt::tt_fabric::FabricMuxConfig& mux_kernel_config,
+    uint32_t num_workers_per_direction,
     std::vector<uint32_t>& writer_ct_args) {
-    writer_ct_args.push_back(is_termination_master);
-    writer_ct_args.push_back(mux_virtual_core.x);
-    writer_ct_args.push_back(mux_virtual_core.y);
-    writer_ct_args.push_back(mux_kernel_config.get_num_buffers(channel_type));
-    writer_ct_args.push_back(mux_kernel_config.get_buffer_size_bytes(channel_type));
-    writer_ct_args.push_back(mux_kernel_config.get_channel_base_address(channel_type, worker_id));
-    writer_ct_args.push_back(mux_kernel_config.get_connection_info_address(channel_type, worker_id));
-    writer_ct_args.push_back(mux_kernel_config.get_connection_handshake_address(channel_type, worker_id));
-    writer_ct_args.push_back(mux_kernel_config.get_flow_control_address(channel_type, worker_id));
-    writer_ct_args.push_back(mux_kernel_config.get_buffer_index_address(channel_type, worker_id));
-    writer_ct_args.push_back(mux_kernel_config.get_status_address());
-    writer_ct_args.push_back(mux_kernel_config.get_channel_credits_stream_id(channel_type, worker_id));
-    writer_ct_args.push_back(mux_kernel_config.get_termination_signal_address());
+    writer_ct_args.push_back(mux_kernel_config.get_num_buffers(channel_type));  // fabric_mux_num_buffers_per_channel
+    writer_ct_args.push_back(
+        mux_kernel_config.get_buffer_size_bytes(channel_type));        // fabric_mux_channel_buffer_size_bytes
+    writer_ct_args.push_back(mux_kernel_config.get_status_address());  // fabric_mux_status_address
+    writer_ct_args.push_back(
+        mux_kernel_config.get_termination_signal_address());  // fabric_mux_termination_signal_address
+    writer_ct_args.push_back(num_workers_per_direction);      // num_mux_clients
 }
 
 void append_fabric_mux_connection_rt_args(
-    const bool& mux_connection_valid,
+    const bool mux_connection_valid,
+    const CoreCoord& mux_virtual_core,
+    const tt::tt_fabric::FabricMuxChannelType channel_type,
+    const tt::tt_fabric::FabricMuxConfig& mux_kernel_config,
     const CoreCoord& worker_logical_core,
+    const uint32_t worker_id,
+    const bool is_termination_master,
+    const CoreCoord termination_master_virtual_core,
     tt::tt_metal::Program& program,
-    CoreCoord termination_master_virtual_core,
-    uint32_t num_workers_per_direction,
     std::vector<uint32_t>& worker_rt_args) {
-    worker_rt_args.push_back(mux_connection_valid);
-    worker_rt_args.push_back(CreateSemaphore(program, {worker_logical_core}, 0));
-    worker_rt_args.push_back(CreateSemaphore(program, {worker_logical_core}, 0));
-    worker_rt_args.push_back(CreateSemaphore(program, {worker_logical_core}, 0));
-    worker_rt_args.push_back(CreateSemaphore(program, {worker_logical_core}, 0));
-    worker_rt_args.push_back(CreateSemaphore(program, {worker_logical_core}, 0));
-    worker_rt_args.push_back(termination_master_virtual_core.x);
-    worker_rt_args.push_back(termination_master_virtual_core.y);
-    worker_rt_args.push_back(num_workers_per_direction);
+    worker_rt_args.push_back(mux_connection_valid);   // mux_connection_valid
+    worker_rt_args.push_back(is_termination_master);  // is_termination_master
+    worker_rt_args.push_back(mux_virtual_core.x);     // fabric_mux_x
+    worker_rt_args.push_back(mux_virtual_core.y);     // fabric_mux_y
+    worker_rt_args.push_back(
+        mux_kernel_config.get_channel_base_address(channel_type, worker_id));  // fabric_mux_channel_base_address
+    worker_rt_args.push_back(
+        mux_kernel_config.get_connection_info_address(channel_type, worker_id));  // fabric_mux_connection_info_address
+    worker_rt_args.push_back(mux_kernel_config.get_connection_handshake_address(
+        channel_type, worker_id));  // fabric_mux_connection_handshake_address
+    worker_rt_args.push_back(
+        mux_kernel_config.get_flow_control_address(channel_type, worker_id));  // fabric_mux_flow_control_address
+    worker_rt_args.push_back(
+        mux_kernel_config.get_buffer_index_address(channel_type, worker_id));  // fabric_mux_buffer_index_address
+    worker_rt_args.push_back(
+        mux_kernel_config.get_channel_credits_stream_id(channel_type, worker_id));  // fabric_mux_channel_id
+    worker_rt_args.push_back(CreateSemaphore(program, {worker_logical_core}, 0));   // termination_sync_address
+    worker_rt_args.push_back(CreateSemaphore(program, {worker_logical_core}, 0));   // local_fabric_mux_status_address
+    worker_rt_args.push_back(CreateSemaphore(program, {worker_logical_core}, 0));   // local_flow_control_address
+    worker_rt_args.push_back(CreateSemaphore(program, {worker_logical_core}, 0));   // local_teardown_address
+    worker_rt_args.push_back(CreateSemaphore(program, {worker_logical_core}, 0));   // local_buffer_index_address
+    worker_rt_args.push_back(termination_master_virtual_core.x);                    // termination_master_noc_x
+    worker_rt_args.push_back(termination_master_virtual_core.y);                    // termination_master_noc_y
 }
 
 tt::tt_metal::operation::ProgramWithCallbacks reduce_scatter_minimal_async(
@@ -912,7 +881,6 @@ ReduceScatterProgramArtifacts build_ring_reduce_scatter_minimal_async_program_ar
     }
 
     // KERNEL CREATION
-    std::vector<KernelHandle> writer_kernel_ids;
     std::vector<KernelHandle> reduce_kernel_ids;
     std::vector<KernelHandle> mux_kernel_ids;
     std::vector<size_t> mux_termination_signal_addresses;
@@ -924,6 +892,16 @@ ReduceScatterProgramArtifacts build_ring_reduce_scatter_minimal_async_program_ar
     const uint32_t l1_unreserved_base_address =
         mesh_device->allocator()->get_base_allocator_addr(tt::tt_metal::HalMemType::L1);
     const size_t mux_base_l1_address = l1_unreserved_base_address;
+    const auto num_full_size_channels = num_workers_per_direction;
+    constexpr auto num_header_only_channels = 0;
+    const auto buffer_size_bytes_full_size_channel = tt::tt_fabric::get_tt_fabric_channel_buffer_size_bytes();
+    const auto mux_kernel_config = tt::tt_fabric::FabricMuxConfig(
+        num_full_size_channels,
+        num_header_only_channels,
+        num_buffers_full_size_channels,
+        0,
+        buffer_size_bytes_full_size_channel,
+        mux_base_l1_address);
 
     std::vector<uint32_t> sender_reader_compile_args =
         operations::experimental::ccl::detail::get_ring_reader_compile_args(
@@ -969,6 +947,67 @@ ReduceScatterProgramArtifacts build_ring_reduce_scatter_minimal_async_program_ar
         sender_worker_core_range_set,
         tt::tt_metal::ReaderDataMovementConfig(sender_reader_compile_args, reader_compute_defines));
 
+    // Writer
+    std::vector<uint32_t> sender_writer_compile_args =
+        operations::experimental::ccl::detail::get_ring_writer_compile_args(
+            ring_index,
+            ring_size,
+            compute_output_cb_index,
+            reader_output_cb_index,
+            tile_granularity,
+            page_size,
+            num_tiles_to_write_per_packet,
+            output_tensor_num_pages,
+            output_batch_num_pages,
+            input_batch_num_pages,
+            input_channel_num_pages,
+            output_channel_num_pages,
+            input_tensor_B,
+            input_tensor_Wt,
+            slice_B,
+            slice_C,
+            slice_Ht,
+            slice_Wt,
+            normalized_dim);
+
+    append_fabric_mux_connection_ct_args(
+        tt::tt_fabric::FabricMuxChannelType::FULL_SIZE_CHANNEL,
+        mux_kernel_config,
+        num_workers_per_direction,
+        sender_writer_compile_args);
+
+    sender_writer_compile_args.insert(
+        sender_writer_compile_args.end(), unicast_forward_args.begin(), unicast_forward_args.end());
+    sender_writer_compile_args.insert(
+        sender_writer_compile_args.end(), mcast_forward_args.begin(), mcast_forward_args.end());
+    sender_writer_compile_args.insert(
+        sender_writer_compile_args.end(), unicast_backward_args.begin(), unicast_backward_args.end());
+    sender_writer_compile_args.insert(
+        sender_writer_compile_args.end(), mcast_backward_args.begin(), mcast_backward_args.end());
+
+    if (intermediate_is_sharded) {
+        shard_builder::extend_sharding_compile_time_args(intermediate_tensor, sender_writer_compile_args);
+    } else {
+        tt::tt_metal::TensorAccessorArgs(intermediate_tensor.buffer()).append_to(sender_writer_compile_args);
+    }
+    if (output_is_sharded) {
+        shard_builder::extend_sharding_compile_time_args(output_tensor, sender_writer_compile_args);
+    } else {
+        tt::tt_metal::TensorAccessorArgs(output_tensor.buffer()).append_to(sender_writer_compile_args);
+    }
+
+    std::string sender_writer_kernel_path =
+        normalized_dim == 0 ? "ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/"
+                              "device/kernels/dim_zero_ring_reduce_scatter_minimal_async_writer.cpp"
+                            : "ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/"
+                              "device/kernels/ring_reduce_scatter_minimal_async_writer.cpp";
+
+    auto writer_kernel_id = tt::tt_metal::CreateKernel(
+        program,
+        sender_writer_kernel_path,
+        sender_worker_core_range_set,
+        tt::tt_metal::WriterDataMovementConfig(sender_writer_compile_args, writer_compute_defines));
+
     auto worker_core_iter = sender_worker_core_range_set.ranges().cbegin();
     for (uint32_t link = 0; link < num_links; link++) {
         for (uint32_t dir = 0; dir < num_directions_per_link; dir++) {
@@ -977,17 +1016,6 @@ ReduceScatterProgramArtifacts build_ring_reduce_scatter_minimal_async_program_ar
                                        (dir * (num_mux_cores_per_direction_per_link + num_workers_per_direction));
             CoreCoord mux_logical_core = all_cores[mux_core_offset];
             CoreCoord mux_virtual_core = mesh_device->worker_core_from_logical_core(mux_logical_core);
-
-            auto num_full_size_channels = num_workers_per_direction;
-            auto num_header_only_channels = 0;
-            size_t buffer_size_bytes_full_size_channel = tt::tt_fabric::get_tt_fabric_channel_buffer_size_bytes();
-            auto mux_kernel_config = tt::tt_fabric::FabricMuxConfig(
-                num_full_size_channels,
-                num_header_only_channels,
-                num_buffers_full_size_channels,
-                0,
-                buffer_size_bytes_full_size_channel,
-                mux_base_l1_address);
 
             auto mux_kernel_id = tt::tt_metal::CreateKernel(
                 program,
@@ -1070,82 +1098,8 @@ ReduceScatterProgramArtifacts build_ring_reduce_scatter_minimal_async_program_ar
                 CoreCoord termination_master_virtual_core =
                     mesh_device->worker_core_from_logical_core(termination_master_logical_core);
 
-                // Writer CT args
-                std::vector<uint32_t> sender_writer_compile_args =
-                    operations::experimental::ccl::detail::get_ring_writer_compile_args(
-                        ring_index,
-                        ring_size,
-                        compute_output_cb_index,
-                        reader_output_cb_index,
-                        tile_granularity,
-                        page_size,
-                        num_tiles_to_write_per_packet,
-                        output_tensor_num_pages,
-                        output_batch_num_pages,
-                        input_batch_num_pages,
-                        input_channel_num_pages,
-                        output_channel_num_pages,
-                        input_tensor_B,
-                        input_tensor_Wt,
-                        slice_B,
-                        slice_C,
-                        slice_Ht,
-                        slice_Wt,
-                        dir,
-                        chunks_per_sync_val,
-                        normalized_dim,
-                        start_pages_read_in_row,
-                        start_row_offset,
-                        start_tiles_read,
-                        start_tiles_to_read);
-                append_fabric_mux_connection_ct_args(
-                    worker == 0,
-                    mux_virtual_core,
-                    tt::tt_fabric::FabricMuxChannelType::FULL_SIZE_CHANNEL,
-                    worker,
-                    mux_kernel_config,
-                    sender_writer_compile_args);
-                if (dir) {
-                    sender_writer_compile_args.insert(
-                        sender_writer_compile_args.end(),
-                        unicast_forward_args.begin(),
-                        unicast_forward_args.end());
-                    sender_writer_compile_args.insert(
-                        sender_writer_compile_args.end(), mcast_forward_args.begin(), mcast_forward_args.end());
-                } else {
-                    sender_writer_compile_args.insert(
-                        sender_writer_compile_args.end(),
-                        unicast_backward_args.begin(),
-                        unicast_backward_args.end());
-                    sender_writer_compile_args.insert(
-                        sender_writer_compile_args.end(), mcast_backward_args.begin(), mcast_backward_args.end());
-                }
-                if (intermediate_is_sharded) {
-                    shard_builder::extend_sharding_compile_time_args(intermediate_tensor, sender_writer_compile_args);
-                } else {
-                    tt::tt_metal::TensorAccessorArgs(intermediate_tensor.buffer())
-                        .append_to(sender_writer_compile_args);
-                }
-                if (output_is_sharded) {
-                    shard_builder::extend_sharding_compile_time_args(output_tensor, sender_writer_compile_args);
-                } else {
-                    tt::tt_metal::TensorAccessorArgs(output_tensor.buffer()).append_to(sender_writer_compile_args);
-                }
-
-                std::string sender_writer_kernel_path =
-                    normalized_dim == 0 ? "ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/"
-                                          "device/kernels/dim_zero_ring_reduce_scatter_minimal_async_writer.cpp"
-                                        : "ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/"
-                                          "device/kernels/ring_reduce_scatter_minimal_async_writer.cpp";
-                auto worker_sender_writer_kernel_id = tt::tt_metal::CreateKernel(
-                    program,
-                    sender_writer_kernel_path,
-                    {core},
-                    tt::tt_metal::WriterDataMovementConfig(sender_writer_compile_args, writer_compute_defines));
-                writer_kernel_ids.push_back(worker_sender_writer_kernel_id);
-
                 // Writer RT args
-                std::vector<uint32_t> sender_writer_runtime_args = {
+                std::vector<uint32_t> writer_rt_args = {
                     intermediate_tensor.buffer()->address(),                     // intermediate_tensor_address
                     output_tensor.buffer()->address(),                           // output_tensor_address
                     virtual_core.x,                                              // out_ready_sem_noc0_x
@@ -1155,22 +1109,45 @@ ReduceScatterProgramArtifacts build_ring_reduce_scatter_minimal_async_program_ar
                     barrier_semaphore.has_value() && !using_persistent_buffers,  // use_barrier_sem
                     barrier_semaphore.has_value()                                // barrier_sem
                         ? barrier_semaphore.value().address()
-                        : 0};
+                        : 0,
+                    dir,                      // direction
+                    chunks_per_sync_val,      // chunks_per_sync
+                    start_pages_read_in_row,  // start_pages_read_in_row (unused by dim0 kernel)
+                    start_row_offset,         // start_row_offset (unused by dim0 kernel)
+                    start_tiles_read,         // start_tiles_read
+                    start_tiles_to_read,      // tiles_to_read
+
+                };
                 append_fabric_mux_connection_rt_args(
                     true,
+                    mux_virtual_core,
+                    tt::tt_fabric::FabricMuxChannelType::FULL_SIZE_CHANNEL,
+                    mux_kernel_config,
                     core,
-                    program,
+                    worker_id,
+                    worker == 0,
                     termination_master_virtual_core,
-                    num_workers_per_direction,
-                    sender_writer_runtime_args);
+                    program,
+                    writer_rt_args);
                 if (intermediate_is_sharded) {
-                    shard_builder::extend_sharding_run_time_args(intermediate_tensor, sender_writer_runtime_args);
+                    shard_builder::extend_sharding_run_time_args(intermediate_tensor, writer_rt_args);
                 }
                 if (output_is_sharded) {
-                    shard_builder::extend_sharding_run_time_args(output_tensor, sender_writer_runtime_args);
+                    shard_builder::extend_sharding_run_time_args(output_tensor, writer_rt_args);
                 }
-                tt::tt_metal::SetRuntimeArgs(
-                    program, worker_sender_writer_kernel_id, {core}, sender_writer_runtime_args);
+                tt::tt_metal::SetRuntimeArgs(program, writer_kernel_id, {core}, writer_rt_args);
+
+                // Reduce kernel
+                auto sender_reduce_kernel_config = tt::tt_metal::ComputeConfig{};
+                sender_reduce_kernel_config.compile_args = {
+                    input_cb_index,           // input_cb_id
+                    intermediate_cb_index,    // intermediate_cb
+                    compute_output_cb_index,  // output_cb
+                    tile_granularity,         // tile_granularity
+                    ring_size,                // ring_size
+                    input_tensor_B,           // input_tensor_B
+                    slice_C,                  // slice_C
+                    dir};                     // dir
 
                 // Reduce CT args
                 std::vector<uint32_t> sender_reduce_compile_args =
@@ -1208,7 +1185,7 @@ ReduceScatterProgramArtifacts build_ring_reduce_scatter_minimal_async_program_ar
 
     return {
         reader_kernel_id,
-        writer_kernel_ids,
+        writer_kernel_id,
         all_cores,
         num_directions_per_link,
         num_workers_per_direction,
@@ -1219,7 +1196,7 @@ ReduceScatterProgramArtifacts build_ring_reduce_scatter_minimal_async_program_ar
 void ring_reduce_scatter_minimal_async_helper_override_runtime_arguments(
     tt::tt_metal::Program& program,
     const tt::tt_metal::KernelHandle reader_kernel_id,
-    const std::vector<tt::tt_metal::KernelHandle>& writer_kernel_ids,
+    const tt::tt_metal::KernelHandle writer_kernel_id,
     const std::vector<tt::tt_metal::CoreCoord>& all_cores,
     uint32_t num_links,
     uint32_t num_directions_per_link,
@@ -1232,7 +1209,6 @@ void ring_reduce_scatter_minimal_async_helper_override_runtime_arguments(
     const Tensor& intermed,
     const Tensor& output) {
     // update senders
-    uint32_t core_idx = 0;
     for (uint32_t link = 0; link < num_links; link++) {
         for (uint32_t dir = 0; dir < num_directions_per_link; dir++) {
             for (uint32_t worker = 0; worker < num_workers_per_direction; worker++) {
@@ -1242,7 +1218,7 @@ void ring_reduce_scatter_minimal_async_helper_override_runtime_arguments(
                 std::vector<std::vector<RuntimeArgsData>> reader_runtime_args =
                     GetRuntimeArgs(program, reader_kernel_id);
                 std::vector<std::vector<RuntimeArgsData>> writer_runtime_args =
-                    GetRuntimeArgs(program, writer_kernel_ids[core_idx]);
+                    GetRuntimeArgs(program, writer_kernel_id);
 
                 // sender reader
                 auto& worker_reader_sender_runtime_args = reader_runtime_args[core.x][core.y];
@@ -1259,8 +1235,6 @@ void ring_reduce_scatter_minimal_async_helper_override_runtime_arguments(
                 if (barrier_semaphore.has_value()) {
                     worker_writer_sender_runtime_args[7] = barrier_semaphore.value().address();
                 }
-
-                core_idx++;
             }
         }
     }
@@ -1290,7 +1264,7 @@ tt::tt_metal::operation::ProgramWithCallbacks ring_reduce_scatter_minimal_async_
     const CoreCoord core_grid_offset) {
     auto
         [reader_kernel_id,
-         writer_kernel_ids,
+         writer_kernel_id,
          all_cores,
          num_directions_per_link,
          num_workers_per_direction,
@@ -1321,7 +1295,7 @@ tt::tt_metal::operation::ProgramWithCallbacks ring_reduce_scatter_minimal_async_
 
     auto override_runtime_arguments_callback =
         [reader_kernel_id,
-         writer_kernel_ids,
+         writer_kernel_id,
          all_cores,
          num_links,
          num_directions_per_link,
@@ -1341,7 +1315,7 @@ tt::tt_metal::operation::ProgramWithCallbacks ring_reduce_scatter_minimal_async_
             ring_reduce_scatter_minimal_async_helper_override_runtime_arguments(
                 program,
                 reader_kernel_id,
-                writer_kernel_ids,
+                writer_kernel_id,
                 all_cores,
                 num_links,
                 num_directions_per_link,
@@ -1597,7 +1571,6 @@ ReduceScatterProgramArtifacts build_line_reduce_scatter_minimal_async_program_ar
     }
 
     // KERNEL CREATION
-    std::vector<KernelHandle> writer_kernel_ids;
     std::vector<KernelHandle> reduce_kernel_ids;
     std::vector<KernelHandle> mux_kernel_ids;
     if (fuse_op) {
@@ -1610,6 +1583,18 @@ ReduceScatterProgramArtifacts build_line_reduce_scatter_minimal_async_program_ar
     const uint32_t l1_unreserved_base_address =
         mesh_device->allocator()->get_base_allocator_addr(tt::tt_metal::HalMemType::L1);
     const size_t mux_base_l1_address = l1_unreserved_base_address;
+
+    const auto num_full_size_channels = num_workers_per_direction;
+    const auto num_header_only_channels = 0;
+    const auto buffer_size_bytes_full_size_channel = tt::tt_fabric::get_tt_fabric_channel_buffer_size_bytes();
+
+    auto mux_kernel_config = tt::tt_fabric::FabricMuxConfig(
+        num_full_size_channels,
+        num_header_only_channels,
+        num_buffers_full_size_channels,
+        0,
+        buffer_size_bytes_full_size_channel,
+        mux_base_l1_address);
 
     // Reader
     std::vector<uint32_t> sender_reader_compile_args =
@@ -1665,6 +1650,68 @@ ReduceScatterProgramArtifacts build_line_reduce_scatter_minimal_async_program_ar
         sender_worker_core_range_set,
         tt::tt_metal::ReaderDataMovementConfig(sender_reader_compile_args, reader_compute_defines));
 
+    // Writer
+    std::vector<uint32_t> sender_writer_compile_args =
+        operations::experimental::ccl::detail::get_line_writer_compile_args(
+            ring_size,
+            compute_output_cb_index,
+            reader_output_cb_index,
+            tile_granularity,
+            page_size,
+            tiles_to_write_per_packet,
+            input_tensor_num_pages,
+            output_tensor_num_pages,
+            input_batch_num_pages,
+            input_channel_num_pages,
+            output_batch_num_pages,
+            output_channel_num_pages,
+            input_tensor_B,
+            input_tensor_Wt,
+            slice_B,
+            slice_C,
+            slice_Ht,
+            slice_Wt,
+            normalized_dim,
+            sync_with_other_direction);
+
+    append_fabric_mux_connection_ct_args(
+        tt::tt_fabric::FabricMuxChannelType::FULL_SIZE_CHANNEL,
+        mux_kernel_config,
+        num_workers_per_direction,
+        sender_writer_compile_args);
+
+    sender_writer_compile_args.insert(
+        sender_writer_compile_args.end(), unicast_forward_args.begin(), unicast_forward_args.end());
+    sender_writer_compile_args.insert(
+        sender_writer_compile_args.end(), mcast_forward_args.begin(), mcast_forward_args.end());
+    sender_writer_compile_args.insert(
+        sender_writer_compile_args.end(), unicast_backward_args.begin(), unicast_backward_args.end());
+    sender_writer_compile_args.insert(
+        sender_writer_compile_args.end(), mcast_backward_args.begin(), mcast_backward_args.end());
+
+    if (intermediate_is_sharded) {
+        shard_builder::extend_sharding_compile_time_args(intermediate_tensor, sender_writer_compile_args);
+    } else {
+        tt::tt_metal::TensorAccessorArgs(intermediate_tensor.buffer()).append_to(sender_writer_compile_args);
+    }
+    if (output_is_sharded) {
+        shard_builder::extend_sharding_compile_time_args(output_tensor, sender_writer_compile_args);
+    } else {
+        tt::tt_metal::TensorAccessorArgs(output_tensor.buffer()).append_to(sender_writer_compile_args);
+    }
+
+    std::string sender_writer_kernel_path =
+        normalized_dim == 0 ? "ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/"
+                              "device/kernels/dim_zero_line_reduce_scatter_minimal_async_writer.cpp"
+                            : "ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/"
+                              "device/kernels/line_reduce_scatter_minimal_async_writer.cpp";
+
+    auto writer_kernel_id = tt::tt_metal::CreateKernel(
+        program,
+        sender_writer_kernel_path,
+        sender_worker_core_range_set,
+        tt::tt_metal::WriterDataMovementConfig(sender_writer_compile_args, writer_compute_defines));
+
     auto worker_core_iter = sender_worker_core_range_set.ranges().cbegin();
     for (uint32_t link = 0; link < num_links; link++) {
         for (uint32_t dir = 0; dir < num_directions_per_link; dir++) {
@@ -1675,17 +1722,6 @@ ReduceScatterProgramArtifacts build_line_reduce_scatter_minimal_async_program_ar
                                        (dir * (num_mux_cores_per_direction_per_link + num_workers_per_direction));
             CoreCoord mux_logical_core = all_cores[mux_core_offset];
             CoreCoord mux_virtual_core = mesh_device->worker_core_from_logical_core(mux_logical_core);
-
-            auto num_full_size_channels = num_workers_per_direction;
-            auto num_header_only_channels = 0;
-            size_t buffer_size_bytes_full_size_channel = tt::tt_fabric::get_tt_fabric_channel_buffer_size_bytes();
-            auto mux_kernel_config = tt::tt_fabric::FabricMuxConfig(
-                num_full_size_channels,
-                num_header_only_channels,
-                num_buffers_full_size_channels,
-                0,
-                buffer_size_bytes_full_size_channel,
-                mux_base_l1_address);
 
             const bool mux_connection_valid =
                 (dir && forward_coord.has_value()) || (!dir && backward_coord.has_value());
@@ -1804,83 +1840,6 @@ ReduceScatterProgramArtifacts build_line_reduce_scatter_minimal_async_program_ar
                 CoreCoord termination_master_virtual_core =
                     mesh_device->worker_core_from_logical_core(termination_master_logical_core);
 
-                // Writer CT args
-                std::vector<uint32_t> sender_writer_compile_args =
-                    operations::experimental::ccl::detail::get_line_writer_compile_args(
-                        ring_size,
-                        compute_output_cb_index,
-                        reader_output_cb_index,
-                        tile_granularity,
-                        page_size,
-                        tiles_to_write_per_packet,
-                        input_tensor_num_pages,
-                        output_tensor_num_pages,
-                        input_batch_num_pages,
-                        input_channel_num_pages,
-                        output_batch_num_pages,
-                        output_channel_num_pages,
-                        input_tensor_B,
-                        input_tensor_Wt,
-                        slice_B,
-                        slice_C,
-                        slice_Ht,
-                        slice_Wt,
-                        is_forward,
-                        is_first_device_in_direction,
-                        num_targets_in_direction,
-                        do_final_reduction,
-                        sync_with_other_direction,
-                        chunks_per_sync_val,
-                        normalized_dim,
-                        start_pages_read_in_row,
-                        start_row_offset,
-                        start_tiles_read,
-                        start_tiles_to_read);
-                append_fabric_mux_connection_ct_args(
-                    worker == 0,
-                    mux_virtual_core,
-                    tt::tt_fabric::FabricMuxChannelType::FULL_SIZE_CHANNEL,
-                    worker,
-                    mux_kernel_config,
-                    sender_writer_compile_args);
-                if (is_forward) {
-                    sender_writer_compile_args.insert(
-                        sender_writer_compile_args.end(),
-                        unicast_forward_args.begin(),
-                        unicast_forward_args.end());
-                    sender_writer_compile_args.insert(
-                        sender_writer_compile_args.end(), mcast_forward_args.begin(), mcast_forward_args.end());
-                } else {
-                    sender_writer_compile_args.insert(
-                        sender_writer_compile_args.end(),
-                        unicast_backward_args.begin(),
-                        unicast_backward_args.end());
-                    sender_writer_compile_args.insert(
-                        sender_writer_compile_args.end(), mcast_backward_args.begin(), mcast_backward_args.end());
-                }
-                if (intermediate_is_sharded) {
-                    shard_builder::extend_sharding_compile_time_args(intermediate_tensor, sender_writer_compile_args);
-                } else {
-                    tt::tt_metal::TensorAccessorArgs(intermediate_tensor.buffer())
-                        .append_to(sender_writer_compile_args);
-                }
-                if (output_is_sharded) {
-                    shard_builder::extend_sharding_compile_time_args(output_tensor, sender_writer_compile_args);
-                } else {
-                    tt::tt_metal::TensorAccessorArgs(output_tensor.buffer()).append_to(sender_writer_compile_args);
-                }
-
-                std::string sender_writer_kernel_path =
-                    normalized_dim == 0 ? "ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/"
-                                          "device/kernels/dim_zero_line_reduce_scatter_minimal_async_writer.cpp"
-                                        : "ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/"
-                                          "device/kernels/line_reduce_scatter_minimal_async_writer.cpp";
-                auto worker_sender_writer_kernel_id = tt::tt_metal::CreateKernel(
-                    program,
-                    sender_writer_kernel_path,
-                    {core},
-                    tt::tt_metal::WriterDataMovementConfig(sender_writer_compile_args, writer_compute_defines));
-                writer_kernel_ids.push_back(worker_sender_writer_kernel_id);
                 std::vector<uint32_t> writer_rt_args = {
                     intermediate_tensor.buffer()->address(),  // intermediate_tensor_address
                     output_tensor.buffer()->address(),        // output_tensor_address
@@ -1893,13 +1852,27 @@ ReduceScatterProgramArtifacts build_line_reduce_scatter_minimal_async_program_ar
                     barrier_semaphore.has_value() && !using_persistent_buffers,  // use_barrier_sem
                     barrier_semaphore.has_value()                                // synchronize barrier semaphore
                         ? barrier_semaphore.value().address()
-                        : 0};
+                        : 0,
+                    is_forward,                    // is_forward
+                    is_first_device_in_direction,  // is_first_device_in_direction
+                    num_targets_in_direction,      // num_targets_in_direction
+                    do_final_reduction,            // do_final_reduction
+                    chunks_per_sync_val,           // chunks_per_sync
+                    start_pages_read_in_row,       // start_pages_read_in_row
+                    start_row_offset,              // start_row_offset
+                    start_tiles_read,              // start_tiles_read
+                    start_tiles_to_read,           // start_tiles_to_read
+                };
                 append_fabric_mux_connection_rt_args(
                     mux_connection_valid,
+                    mux_virtual_core,
+                    tt::tt_fabric::FabricMuxChannelType::FULL_SIZE_CHANNEL,
+                    mux_kernel_config,
                     core,
-                    program,
+                    worker_id,
+                    worker == 0,
                     termination_master_virtual_core,
-                    num_workers_per_direction,
+                    program,
                     writer_rt_args);
                 if (intermediate_is_sharded) {
                     shard_builder::extend_sharding_run_time_args(intermediate_tensor, writer_rt_args);
@@ -1907,7 +1880,28 @@ ReduceScatterProgramArtifacts build_line_reduce_scatter_minimal_async_program_ar
                 if (output_is_sharded) {
                     shard_builder::extend_sharding_run_time_args(output_tensor, writer_rt_args);
                 }
-                tt::tt_metal::SetRuntimeArgs(program, worker_sender_writer_kernel_id, {core}, writer_rt_args);
+
+                tt::tt_metal::SetRuntimeArgs(program, writer_kernel_id, {core}, writer_rt_args);
+                // Reduce kernel
+                auto sender_reduce_kernel_config = tt::tt_metal::ComputeConfig{};
+                sender_reduce_kernel_config.compile_args = {
+                    input_cb_index,
+                    intermediate_cb_index,
+                    compute_output_cb_index,
+                    tile_granularity,
+                    input_tensor_B,
+                    slice_C,
+                    num_total_reduction_steps,
+                    start_tiles_read,
+                    start_tiles_to_read,
+                };
+                auto reduce_kernel_id = tt::tt_metal::CreateKernel(
+                    program,
+                    "ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/"
+                    "line_reduction.cpp",
+                    {core},
+                    sender_reduce_kernel_config);
+                reduce_kernel_ids.push_back(reduce_kernel_id);
 
                 // Reduce CT args
                 std::vector<uint32_t> sender_reduce_compile_args =
@@ -1945,7 +1939,7 @@ ReduceScatterProgramArtifacts build_line_reduce_scatter_minimal_async_program_ar
 
     return {
         reader_kernel_id,
-        writer_kernel_ids,
+        writer_kernel_id,
         all_cores,
         num_directions_per_link,
         num_workers_per_direction,
@@ -1956,7 +1950,7 @@ ReduceScatterProgramArtifacts build_line_reduce_scatter_minimal_async_program_ar
 void line_reduce_scatter_minimal_async_helper_override_runtime_arguments(
     tt::tt_metal::Program& program,
     const tt::tt_metal::KernelHandle reader_kernel_id,
-    const std::vector<tt::tt_metal::KernelHandle>& writer_kernel_ids,
+    const tt::tt_metal::KernelHandle writer_kernel_id,
     const std::vector<tt::tt_metal::CoreCoord>& all_cores,
     uint32_t num_links,
     uint32_t num_directions_per_link,
@@ -1969,7 +1963,6 @@ void line_reduce_scatter_minimal_async_helper_override_runtime_arguments(
     const Tensor& intermed,
     const Tensor& output) {
     // update senders
-    uint32_t core_idx = 0;
     for (uint32_t link = 0; link < num_links; link++) {
         for (uint32_t dir = 0; dir < num_directions_per_link; dir++) {
             for (uint32_t worker = 0; worker < num_workers_per_direction; worker++) {
@@ -1979,7 +1972,7 @@ void line_reduce_scatter_minimal_async_helper_override_runtime_arguments(
                 std::vector<std::vector<RuntimeArgsData>> reader_runtime_args =
                     GetRuntimeArgs(program, reader_kernel_id);
                 std::vector<std::vector<RuntimeArgsData>> writer_runtime_args =
-                    GetRuntimeArgs(program, writer_kernel_ids[core_idx]);
+                    GetRuntimeArgs(program, writer_kernel_id);
 
                 // sender reader
                 auto& worker_reader_sender_runtime_args = reader_runtime_args[core.x][core.y];
@@ -1996,8 +1989,6 @@ void line_reduce_scatter_minimal_async_helper_override_runtime_arguments(
                 if (barrier_semaphore.has_value()) {
                     worker_writer_sender_runtime_args[9] = barrier_semaphore.value().address();
                 }
-
-                core_idx++;
             }
         }
     }
@@ -2027,7 +2018,7 @@ tt::tt_metal::operation::ProgramWithCallbacks line_reduce_scatter_minimal_async_
     const CoreCoord core_grid_offset) {
     auto
         [reader_kernel_id,
-         writer_kernel_ids,
+         writer_kernel_id,
          all_cores,
          num_directions_per_link,
          num_workers_per_direction,
@@ -2057,7 +2048,7 @@ tt::tt_metal::operation::ProgramWithCallbacks line_reduce_scatter_minimal_async_
                 core_grid_offset);
     auto override_runtime_arguments_callback =
         [reader_kernel_id,
-         writer_kernel_ids,
+         writer_kernel_id,
          all_cores,
          num_links,
          num_directions_per_link,
@@ -2079,7 +2070,7 @@ tt::tt_metal::operation::ProgramWithCallbacks line_reduce_scatter_minimal_async_
             line_reduce_scatter_minimal_async_helper_override_runtime_arguments(
                 program,
                 reader_kernel_id,
-                writer_kernel_ids,
+                writer_kernel_id,
                 all_cores,
                 num_links,
                 num_directions_per_link,


### PR DESCRIPTION
### Ticket
#31454 

### Problem description
- CCLs are very slow to compile, this is a major issue for training.
- Turns out, kernels were compiled individual for _each core_ , could be dozens now with multiple links and mux, which was needless.

### What's changed
- Refactor all reduce scatter kernels to move a bunch of CT args to RT args
- Change kernel creation flow such that kernels are created at once for all cores, and then RT args are adjusted accordingly.
- Tweaked RS ND test to properly cover Ring topology


### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/19148065860
- [x] Galaxy Nightly https://github.com/tenstorrent/tt-metal/actions/runs/19148079076
- [x] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work https://github.com/tenstorrent/tt-metal/actions/runs/19182061306 
- [x] T3K nightly. https://github.com/tenstorrent/tt-metal/actions/runs/19148097464
- [x] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release) https://github.com/tenstorrent/tt-metal/actions/runs/19148107986
- [x] New/Existing tests provide coverage for changes