### PR TITLE
Remove Avg Pool Run Twice Skips

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/pool/test_avgpool2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/pool/test_avgpool2d.py
@@ -207,11 +207,6 @@ def run_avg_pool2d(
         compute_kernel_config=compute_kernel_config,
     )
 
-    # TODO always use run_twice after resolution of https://github.com/tenstorrent/tt-metal/issues/26093
-    # skip run_twice for blackhole with wide Bfloat8 tensors as this currently causes PCC failures
-    if is_blackhole() and in_dtype == ttnn.bfloat8_b and in_c > 256:
-        run_twice = False
-
     if run_twice:
         ttnn.deallocate(ttnn_output, True)
         ttnn_output = ttnn.avg_pool2d(


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/26093

### Problem description
Avg pool failed with PCC errors on BH for wide Bfloat8 tensors.

### What's changed
It was determined that this failure was the result of an LLK bug which caused `untliize_block` to be incorrectly configured if `tilizeA_B_reduce_init` had been called previously by another kernel.  Thus, on the first pass, untilize worked properly, then pool ran (calling `tilizeA_B_reduce_init`) and the output was correct, but then on the next run the output from untilize was incorrect setting pool up for failure.

This PR simply removes the skips as the LLK issue was fixed in this recent PR:

https://github.com/tenstorrent/tt-llk/pull/802

### Checklist
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable):
https://github.com/tenstorrent/tt-metal/actions/runs/19150970289
- [x] [Nightly Blackhole](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-nightly-tests.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/19150973803
Failing on main, this PR hits same unrelated error
- [x] [Nightly L2](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/19173766895
- [x] New/Existing tests provide coverage for changes