### PR TITLE
Enable input and output HEIGHT sharding support in permute

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/reader_permute_interleaved_rm_blocked_generic.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/reader_permute_interleaved_rm_blocked_generic.cpp
@@ -109,7 +109,7 @@ void kernel_main() {
         for (uint32_t x = x_start; x < x_end; ++x) {
             // Compute the address offset for this index
             uint64_t addr_offset = base_addr_offset + x * X_stride;
-            uint64_t src_noc_addr = get_noc_addr(addr_offset, s0, w_offset);
+            uint64_t src_noc_addr = s0.get_noc_addr(addr_offset, w_offset);
 
             // Perform async read of the current line (w_block_len elements) into L1
             noc_async_read(src_noc_addr, src_buffer_l1_addr + page_offset, w_read_size_bytes);

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/writer_permute_interleaved_rm_blocked_generic.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/writer_permute_interleaved_rm_blocked_generic.cpp
@@ -150,7 +150,7 @@ void kernel_main() {
             }
 
             // Compute the NoC address for the output
-            uint64_t dst_noc_addr = get_noc_addr(dest_linear_idx, s0, x_offset);
+            uint64_t dst_noc_addr = s0.get_noc_addr(dest_linear_idx, x_offset);
 
             // Compute the L1 address from which to write (offset by W-block pages)
             uint32_t l1_addr = transposed_buffer_read_addr + (w - w_start) * output_cb_page_size;

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_device_operation.cpp
@@ -42,7 +42,6 @@ void PermuteDeviceOperation::validate_on_program_cache_miss(
     TT_FATAL(
         attributes.dims.size() == tensor_args.input_tensor.logical_shape().rank(),
         "Permute dimensions must match input tensor rank");
-    TT_FATAL(tensor_args.input_tensor.is_sharded() == false, "Permute operation does not support sharded input tensor");
 }
 
 void PermuteDeviceOperation::validate_on_program_cache_hit(

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/permute.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/permute.cpp
@@ -8,6 +8,7 @@
 #include "ttnn/operations/data_movement/permute/device/permute_device_operation.hpp"
 
 #include <tt-metalium/constants.hpp>
+#include <tt-metalium/hal.hpp>
 #include "ttnn/operations/experimental/auto_format/auto_format.hpp"
 #include "ttnn/tensor/tensor_utils.hpp"
 
@@ -75,7 +76,7 @@ ttnn::Tensor permute_impl(
         } else if (N == 0 && C == 3 && H == 2 && W == 1) {
             output = transpose_wh(transpose_hc(transpose_wh(formatted_input_tensor)));
         } else {
-            TT_FATAL(false, "Sharded permute not supported for this permutation");
+            output = prim_permute(formatted_input_tensor);
         }
     } else {
         if (N == 0 && C == 1 && H == 2 && W == 3) {
@@ -191,8 +192,17 @@ ttnn::Tensor ExecutePermute::invoke(
     auto iorder = normalized_dims.size() < 4 ? adjust_order(normalized_dims) : normalized_dims;
 
     const auto input_layout = input_tensor.layout();
-    auto output_tensor =
-        detail::permute_launch(itensor, iorder, memory_config.value_or(input_tensor.memory_config()), pad_value);
+    const auto output_memory_config = memory_config.value_or(input_tensor.memory_config());
+
+    if (input_layout == Layout::ROW_MAJOR) {
+        uint32_t l1_alignment = tt::tt_metal::hal::get_l1_alignment();
+        TT_FATAL(
+            !output_memory_config.is_sharded() ||
+                (*output_memory_config.shard_spec()).shape[1] * input_tensor.element_size() % (l1_alignment) == 0,
+            "Shard page size must be aligned to {}B for L1 Tensor",
+            l1_alignment);
+    }
+    auto output_tensor = detail::permute_launch(itensor, iorder, output_memory_config, pad_value);
     output_tensor = ttnn::to_layout(output_tensor, input_layout);
 
     if (input_rank < 4) {


### PR DESCRIPTION
### Ticket
Github Issue https://github.com/tenstorrent/tt-metal/issues/31030

### Problem description
Height sharding was disabled, but using TensorAccessor provide this support.

### What's changed
Enabled sharding, fixed address function call, added test for sharding cases.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes