### PR TITLE
[skip ci] add handrewsTT to gpt-oss codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -263,7 +263,7 @@ models/common @yieldthought @mtairum @uaydonat @tenstorrent/metalium-codeowners-
 models/datasets/llm_dataset_utils.py @skhorasganiTT @uaydonat @tenstorrent/metalium-codeowners-large-changes
 models/demos @uaydonat @yieldthought @cglagovichTT @tenstorrent/metalium-codeowners-large-changes
 models/demos/deepseek_v3 @uaydonat @yieldthought @kpaigwar @pprajapatiTT @tenstorrent/metalium-codeowners-large-changes
-models/demos/gpt_oss @uaydonat @mtairum @sraizada-tt @tenstorrent/metalium-codeowners-large-changes
+models/demos/gpt_oss @uaydonat @mtairum @sraizada-tt @handrewsTT @tenstorrent/metalium-codeowners-large-changes
 models/**/bert*/ @TT-BrianLiu @uaydonat @tenstorrent/metalium-codeowners-large-changes
 models/demos/metal_BERT_large_11 @tt-aho @TT-BrianLiu @tenstorrent/metalium-codeowners-large-changes
 models/**/distilbert/ @tt-aho @uaydonat @tenstorrent/metalium-codeowners-large-changes


### PR DESCRIPTION
Adding user handrewsTT as codeowner to gpt-oss demo dir.