### PR TITLE
Revert "[Fabric] Support 2D torus encoding (#29079)"

### DIFF
--- a/tt_metal/fabric/compressed_routing_path.cpp
+++ b/tt_metal/fabric/compressed_routing_path.cpp
@@ -10,7 +10,7 @@ namespace tt::tt_fabric {
 // 1D routing specialization
 template <>
 void intra_mesh_routing_path_t<1, false>::calculate_chip_to_all_routing_fields(
-    uint16_t /*src_chip_id*/, uint16_t num_chips, uint16_t ew_dim) {
+    uint16_t /*src_chip_id*/, uint16_t num_chips, uint16_t /*ew_dim*/) {
     uint32_t* route_ptr = reinterpret_cast<uint32_t*>(&paths);
     route_ptr[0] = 0;
     for (uint16_t hops = 1; hops < num_chips; ++hops) {

--- a/tt_metal/fabric/compressed_routing_path.cpp
+++ b/tt_metal/fabric/compressed_routing_path.cpp
@@ -2,18 +2,15 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <cstring>
 #include "compressed_routing_path.hpp"
-#include "tt_metal/impl/context/metal_context.hpp"
-#include "tt_metal/api/tt-metalium/control_plane.hpp"
-#include "tt_metal/fabric/fabric_context.hpp"
+#include <cstring>
 
 namespace tt::tt_fabric {
 
 // 1D routing specialization
 template <>
 void intra_mesh_routing_path_t<1, false>::calculate_chip_to_all_routing_fields(
-    const FabricNodeId& /*src_fabric_node_id*/, uint16_t num_chips) {
+    uint16_t /*src_chip_id*/, uint16_t num_chips, uint16_t ew_dim) {
     uint32_t* route_ptr = reinterpret_cast<uint32_t*>(&paths);
     route_ptr[0] = 0;
     for (uint16_t hops = 1; hops < num_chips; ++hops) {
@@ -25,118 +22,39 @@ void intra_mesh_routing_path_t<1, false>::calculate_chip_to_all_routing_fields(
 // 1D compressed routing specialization. No-op
 template <>
 void intra_mesh_routing_path_t<1, true>::calculate_chip_to_all_routing_fields(
-    const FabricNodeId& /*src_fabric_node_id*/, uint16_t /*num_chips*/) {
+    uint16_t /*src_chip_id*/, uint16_t /*num_chips*/, uint16_t /*ew_dim*/) {
     // No-op
 }
 
-// 2D compressed routing specialization: ControlPlane singleton-based implementation
+// 2D compressed routing specialization
 template <>
 void intra_mesh_routing_path_t<2, true>::calculate_chip_to_all_routing_fields(
-    const FabricNodeId& src_fabric_node_id, uint16_t num_chips) {
-    auto& src_chip_id = src_fabric_node_id.chip_id;
-    auto& mesh_id = src_fabric_node_id.mesh_id;
-
-    auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
-
-    std::vector<chan_id_t> candidate_src_chan_ids;
-    for (auto dir : {RoutingDirection::E, RoutingDirection::W, RoutingDirection::N, RoutingDirection::S}) {
-        auto chans = control_plane.get_active_fabric_eth_routing_planes_in_direction(src_fabric_node_id, dir);
-        candidate_src_chan_ids.insert(candidate_src_chan_ids.end(), chans.begin(), chans.end());
-    }
-
+    uint16_t src_chip_id, uint16_t num_chips, uint16_t ew_dim) {
     for (uint16_t dst_chip_id = 0; dst_chip_id < num_chips; ++dst_chip_id) {
-        if (dst_chip_id == src_chip_id) {
+        if (src_chip_id == dst_chip_id) {
+            // Self route - no movement needed
             paths[dst_chip_id].set(0, 0, 0, 0, 0);
             continue;
         }
 
-        tt::tt_fabric::FabricNodeId dst_fabric_node_id(mesh_id, dst_chip_id);
-        std::vector<uint16_t> best_chip_sequence;
-        for (chan_id_t start_chan : candidate_src_chan_ids) {
-            auto candidate_route = control_plane.get_fabric_route(src_fabric_node_id, dst_fabric_node_id, start_chan);
-            if (candidate_route.empty()) {
-                continue;
-            }
-            // Build chip sequence ("intra"-mesh only)
-            std::vector<uint16_t> seq;
-            seq.reserve(candidate_route.size());
-            tt::tt_fabric::FabricNodeId last_added = src_fabric_node_id;
-            for (const auto& step : candidate_route) {
-                const tt::tt_fabric::FabricNodeId& node = step.first;
-                if (node.mesh_id != mesh_id) {
-                    break;  // ignore inter-mesh tail
-                }
-                if (node == last_added) {
-                    continue;  // skip intra-chip channel change
-                }
-                seq.push_back(static_cast<uint16_t>(node.chip_id));
-                last_added = node;
-            }
-            // pick up shortest path
-            if (!seq.empty() && (best_chip_sequence.empty() || seq.size() < best_chip_sequence.size())) {
-                best_chip_sequence.swap(seq);
-            }
-        }
+        // Calculate 2D coordinates
+        uint16_t src_col = src_chip_id / ew_dim;
+        uint16_t src_row = src_chip_id % ew_dim;
+        uint16_t dst_col = dst_chip_id / ew_dim;
+        uint16_t dst_row = dst_chip_id % ew_dim;
 
-        TT_ASSERT(
-            !best_chip_sequence.empty(),
-            "Failed to find intra-mesh route from chip {} to chip {} in mesh {}",
-            src_chip_id,
-            dst_chip_id,
-            *mesh_id);
+        // Calculate hops needed in each dimension
+        uint8_t ns_hops = (dst_col != src_col) ? ((dst_col > src_col) ? (dst_col - src_col) : (src_col - dst_col)) : 0;
+        uint8_t ew_hops = (dst_row != src_row) ? ((dst_row > src_row) ? (dst_row - src_row) : (src_row - dst_row)) : 0;
 
-        uint8_t ns_hops = 0;
-        uint8_t ew_hops = 0;
-        uint8_t ns_direction = 0;
-        uint8_t ew_direction = 0;
+        // Encode directions
+        // ns_direction: 0=north, 1=south
+        // ew_direction: 0=west, 1=east
+        uint8_t ns_direction = (dst_col > src_col) ? 1 : 0;
+        uint8_t ew_direction = (dst_row > src_row) ? 1 : 0;
+        uint8_t turn_after_ns = ns_hops;  // XY routing: complete NS first, then EW
 
-        auto is_ns = [](RoutingDirection d) { return d == RoutingDirection::N || d == RoutingDirection::S; };
-        auto is_ew = [](RoutingDirection d) { return d == RoutingDirection::E || d == RoutingDirection::W; };
-
-        auto make_node = [mesh_id](uint16_t chip) { return tt::tt_fabric::FabricNodeId(mesh_id, chip); };
-        auto next_dir = [&](uint16_t from_chip, uint16_t to_chip) {
-            return control_plane.get_forwarding_direction(make_node(from_chip), make_node(to_chip));
-        };
-        auto ns_bit = [](RoutingDirection d) { return (uint8_t)(d == RoutingDirection::S); };
-        auto ew_bit = [](RoutingDirection d) { return (uint8_t)(d == RoutingDirection::E); };
-        auto it = best_chip_sequence.cbegin();
-        uint16_t prev_chip = src_chip_id;
-        auto consume_axis = [&](auto is_axis, auto dir_to_bit, uint8_t& hops, uint8_t& dir_bit) {
-            if (it == best_chip_sequence.cend()) {
-                return;
-            }
-            uint16_t curr_chip = *it;
-            auto dir_opt = next_dir(prev_chip, curr_chip);
-            if (!dir_opt.has_value() || dir_opt.value() == RoutingDirection::NONE) {
-                TT_ASSERT(false, "Invalid direction between chips {} and {}", prev_chip, curr_chip);
-            }
-            if (!is_axis(*dir_opt)) {
-                return;  // start of other axis
-            }
-
-            dir_bit = dir_to_bit(*dir_opt);
-            do {
-                ++hops;
-                prev_chip = curr_chip;
-                ++it;
-                if (it == best_chip_sequence.cend()) {
-                    break;
-                }
-                curr_chip = *it;
-                dir_opt = next_dir(prev_chip, curr_chip);
-                if (!dir_opt.has_value()) {
-                    break;
-                }
-            } while (dir_opt.has_value() && is_axis(*dir_opt));
-        };
-
-        if (it != best_chip_sequence.cend()) {
-            // Consume NS first (if present), then EW
-            consume_axis(is_ns, ns_bit, ns_hops, ns_direction);
-            consume_axis(is_ew, ew_bit, ew_hops, ew_direction);
-        }
-
-        paths[dst_chip_id].set(ns_hops, ew_hops, ns_direction, ew_direction, ns_hops);
+        paths[dst_chip_id].set(ns_hops, ew_hops, ns_direction, ew_direction, turn_after_ns);
     }
 }
 

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -1678,9 +1678,12 @@ void ControlPlane::write_all_to_all_routing_fields<1, false>(MeshId mesh_id) con
         (this->topology_mapper_ == nullptr)
             ? this->routing_table_generator_->mesh_graph->get_chip_ids(mesh_id, host_rank_id)
             : this->topology_mapper_->get_chip_ids(mesh_id, host_rank_id);
-    auto mesh_shape = this->get_physical_mesh_shape(mesh_id);
+    uint16_t num_chips = MAX_CHIPS_LOWLAT_1D < local_mesh_chip_id_container.size()
+                             ? MAX_CHIPS_LOWLAT_1D
+                             : static_cast<uint16_t>(local_mesh_chip_id_container.size());
+
     intra_mesh_routing_path_t<1, false> routing_path;
-    routing_path.calculate_chip_to_all_routing_fields(FabricNodeId(mesh_id, 0), MAX_CHIPS_LOWLAT_1D);
+    routing_path.calculate_chip_to_all_routing_fields(0, num_chips);
 
     // For each source chip in the current mesh
     for (const auto& [_, src_chip_id] : local_mesh_chip_id_container) {
@@ -1743,6 +1746,7 @@ void ControlPlane::write_all_to_all_routing_fields<2, true>(MeshId mesh_id) cons
     // Get mesh shape for 2D routing calculation
     MeshShape mesh_shape = this->get_physical_mesh_shape(mesh_id);
     uint16_t num_chips = mesh_shape[0] * mesh_shape[1];
+    uint16_t ew_dim = mesh_shape[1];  // east-west dimension
     TT_ASSERT(num_chips <= 256, "Number of chips exceeds 256 for mesh {}", *mesh_id);
     TT_ASSERT(
         mesh_shape[0] <= 16 && mesh_shape[1] <= 16,
@@ -1755,7 +1759,7 @@ void ControlPlane::write_all_to_all_routing_fields<2, true>(MeshId mesh_id) cons
         intra_mesh_routing_path_t<2, true> routing_path;
         FabricNodeId src_fabric_node_id(mesh_id, src_chip_id);
 
-        routing_path.calculate_chip_to_all_routing_fields(src_fabric_node_id, mesh_shape[0] * mesh_shape[1]);
+        routing_path.calculate_chip_to_all_routing_fields(src_chip_id, num_chips, ew_dim);
         auto physical_chip_id = this->logical_mesh_chip_id_to_physical_chip_id_mapping_.at(src_fabric_node_id);
         write_to_all_tensix_cores(
             &routing_path,

--- a/tt_metal/hostdevcommon/api/hostdevcommon/fabric_common.h
+++ b/tt_metal/hostdevcommon/api/hostdevcommon/fabric_common.h
@@ -11,9 +11,6 @@
 
 namespace tt::tt_fabric {
 
-// Forward declaration to avoid including heavy host-only headers here
-class FabricNodeId;
-
 using chan_id_t = std::uint8_t;
 using routing_plane_id_t = std::uint8_t;
 
@@ -169,7 +166,7 @@ struct __attribute__((packed)) intra_mesh_routing_path_t {
 
 #if !defined(KERNEL_BUILD) && !defined(FW_BUILD)
     // Routing calculation methods
-    void calculate_chip_to_all_routing_fields(const FabricNodeId& src_fabric_node_id, uint16_t num_chips);
+    void calculate_chip_to_all_routing_fields(uint16_t src_chip_id, uint16_t num_chips, uint16_t ew_dim = 0);
 #else
     // Device-side methods (declared here, implemented in fabric_routing_path_interface.h):
     inline bool decode_route_to_buffer(uint16_t dst_chip_id, volatile uint8_t* out_route_buffer) const;


### PR DESCRIPTION
This reverts commit 8303cade1aea6ec5f45e67924e6d3f4e7e957f11.

This commit was found to cause some issues with Galaxy vllm (https://github.com/tenstorrent/tt-metal/actions/runs/19110589193) and other pipelines.

## Pipelines
- [ ] Galaxy vllm: https://github.com/tenstorrent/tt-metal/actions/runs/19123353741