### PR TITLE
Deprecate storage-only cores

### DIFF
--- a/tests/tt_metal/tt_metal/api/allocator/test_l1_banking_allocator.cpp
+++ b/tests/tt_metal/tt_metal/api/allocator/test_l1_banking_allocator.cpp
@@ -30,21 +30,8 @@ uint64_t get_alloc_limit(const std::shared_ptr<distributed::MeshDevice>& mesh_de
     const metal_SocDescriptor& soc_desc =
         tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(device->id());
     uint32_t l1_unreserved_base = mesh_device->allocator()->get_base_allocator_addr(tt::tt_metal::HalMemType::L1);
-    auto dispatch_core_config = tt::tt_metal::get_dispatch_core_config();
-    auto storage_core_bank_size =
-        tt::get_storage_core_bank_size(device->id(), mesh_device->num_hw_cqs(), dispatch_core_config);
-    const uint32_t allocator_alignment = mesh_device->allocator()->get_alignment(tt::tt_metal::BufferType::L1);
-    const uint32_t interleaved_l1_bank_size = storage_core_bank_size.has_value()
-                                                  ? storage_core_bank_size.value()
-                                                  : (soc_desc.worker_l1_size - l1_unreserved_base);
-    uint32_t storage_core_unreserved_base =
-        ((tt::tt_metal::MetalContext::instance().hal().get_dev_addr(
-              tt::tt_metal::HalProgrammableCoreType::TENSIX, tt::tt_metal::HalL1MemAddrType::MAILBOX) +
-          allocator_alignment - 1) /
-         allocator_alignment) *
-        allocator_alignment;
-    uint64_t alloc_limit = interleaved_l1_bank_size - storage_core_unreserved_base;
-    return alloc_limit;
+    const uint32_t interleaved_l1_bank_size = soc_desc.worker_l1_size - l1_unreserved_base;
+    return interleaved_l1_bank_size;
 }
 
 }  // namespace unit_tests::test_l1_banking_allocator

--- a/tests/tt_metal/tt_metal/api/test_kernel_creation.cpp
+++ b/tests/tt_metal/tt_metal/api/test_kernel_creation.cpp
@@ -52,36 +52,6 @@ TEST_F(MeshDispatchFixture, TensixCreateKernelsOnComputeCores) {
     }
 }
 
-TEST_F(MeshDispatchFixture, DISABLED_TensixCreateKernelsOnStorageCores) {
-    for (unsigned int id = 0; id < this->devices_.size(); id++) {
-        auto mesh_device = this->devices_.at(id);
-        if (mesh_device->storage_only_cores().empty()) {
-            GTEST_SKIP() << "This test only runs on devices with storage only cores";
-        }
-
-        distributed::MeshWorkload workload;
-        auto zero_coord = distributed::MeshCoordinate(0, 0);
-        auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
-        tt_metal::Program program = CreateProgram();
-        workload.add_program(device_range, std::move(program));
-        auto& program_ = workload.get_programs().at(device_range);
-
-        const std::set<CoreCoord>& storage_only_cores = mesh_device->storage_only_cores();
-        std::set<CoreRange> storage_only_core_ranges;
-        for (CoreCoord core : storage_only_cores) {
-            storage_only_core_ranges.emplace(core);
-        }
-        CoreRangeSet storage_core_range_set(storage_only_core_ranges);
-        EXPECT_ANY_THROW(
-            tt_metal::CreateKernel(
-                program_,
-                "tests/tt_metal/tt_metal/test_kernels/dataflow/dram_copy.cpp",
-                storage_core_range_set,
-                DataMovementConfig{
-                    .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default}););
-    }
-}
-
 TEST_F(MeshDispatchFixture, DISABLED_TensixIdleEthCreateKernelsOnDispatchCores) {
     if (this->IsSlowDispatch()) {
         GTEST_SKIP() << "This test is only supported in fast dispatch mode";

--- a/tt_metal/api/tt-metalium/device.hpp
+++ b/tt_metal/api/tt-metalium/device.hpp
@@ -146,7 +146,9 @@ public:
     // core.x represents connectivity to one other chip, i.e. cores with <x> all connect to same chip
     // core.y represents different channels along one <x>
     virtual const std::set<CoreCoord>& ethernet_cores() const = 0;
-    virtual const std::set<CoreCoord>& storage_only_cores() const = 0;
+    [[deprecated(
+        "Storage-only cores do not exist. Cleanup code that calls this API.")]] virtual const std::set<CoreCoord>&
+    storage_only_cores() const = 0;
 
     virtual uint32_t get_noc_unicast_encoding(uint8_t noc_index, const CoreCoord& core) const = 0;
     virtual uint32_t get_noc_multicast_encoding(uint8_t noc_index, const CoreRange& cores) const = 0;

--- a/tt_metal/core_descriptors/blackhole_140_arch.yaml
+++ b/tt_metal/core_descriptors/blackhole_140_arch.yaml
@@ -12,8 +12,6 @@ unharvested:
         start: [0, 0]
         end: [12, 9]
 
-      storage_cores: # Relative to grid of tensix cores
-        []
 
       dispatch_cores:
         [[-1, 0], [-1, 1], [-1, 2], [-1, 3], [-1, 4], [-1, 5], [-1, 6], [-1, 7], [-1, 8], [-1, 9]]
@@ -26,8 +24,6 @@ unharvested:
         start: [0, 0]
         end: [12, 9]
 
-      storage_cores: # Relative to grid of tensix cores
-        []
 
       dispatch_cores:
         [[-1, 0], [-1, 1], [-1, 2], [-1, 3], [-1, 4], [-1, 5], [-1, 6], [-1, 7], [-1, 8], [-1, 9]]
@@ -42,8 +38,6 @@ unharvested:
         start: [0, 0]
         end: [11, 9]
 
-      storage_cores: # Relative to grid of tensix cores
-        []
 
       dispatch_cores:
         [[-1, 0], [-1, 1], [-1, 2], [-1, 3], [-1, 4], [-1, 5], [-1, 6], [-1, 7], [-1, 8], [-1, 9]]
@@ -56,8 +50,6 @@ unharvested:
         start: [0, 0]
         end: [11, 9]
 
-      storage_cores: # Relative to grid of tensix cores
-        []
 
       dispatch_cores:
         [[-1, 0], [-1, 1], [-1, 2], [-1, 3], [-1, 4], [-1, 5], [-1, 6], [-1, 7], [-1, 8], [-1, 9]]
@@ -72,8 +64,6 @@ unharvested:
         start: [0, 0]
         end: [10, 9]
 
-      storage_cores: # Relative to grid of tensix cores
-        []
 
       dispatch_cores:
         [[-1, 0], [-1, 1], [-1, 2], [-1, 3], [-1, 4], [-1, 5], [-1, 6], [-1, 7], [-1, 8], [-1, 9]]
@@ -86,8 +76,6 @@ unharvested:
         start: [0, 0]
         end: [10, 9]
 
-      storage_cores: # Relative to grid of tensix cores
-        []
 
       dispatch_cores:
         [[-1, 0], [-1, 1], [-1, 2], [-1, 3], [-1, 4], [-1, 5], [-1, 6], [-1, 7], [-1, 8], [-1, 9]]

--- a/tt_metal/core_descriptors/blackhole_140_arch_eth_dispatch.yaml
+++ b/tt_metal/core_descriptors/blackhole_140_arch_eth_dispatch.yaml
@@ -12,9 +12,6 @@ unharvested:
         start: [0, 0]
         end: [13, 9]
 
-      storage_cores:
-        []
-
       dispatch_cores:
         [[0, 0], [0, 1], [0, 2], [0, 3], [0, 4], [0, 5], [0, 6], [0, 7], [0, 8], [0, 9], [0, 10], [0, 11], [0, 12], [0, 13]]
 
@@ -25,9 +22,6 @@ unharvested:
       compute_with_storage_grid_range: # Logical only start and end [x, y]
         start: [0, 0]
         end: [13, 9]
-
-      storage_cores:
-        []
 
       dispatch_cores:
         [[0, 0], [0, 1], [0, 2], [0, 3], [0, 4], [0, 5], [0, 6], [0, 7], [0, 8], [0, 9], [0, 10], [0, 11], [0, 12], [0, 13]]
@@ -42,9 +36,6 @@ unharvested:
         start: [0, 0]
         end: [12, 9]
 
-      storage_cores:
-        []
-
       dispatch_cores:
         [[0, 0], [0, 1], [0, 2], [0, 3], [0, 4], [0, 5], [0, 6], [0, 7], [0, 8], [0, 9], [0, 10], [0, 11], [0, 12], [0, 13]]
 
@@ -55,9 +46,6 @@ unharvested:
       compute_with_storage_grid_range: # Logical only start and end [x, y]
         start: [0, 0]
         end: [12, 9]
-
-      storage_cores:
-        []
 
       dispatch_cores:
         [[0, 0], [0, 1], [0, 2], [0, 3], [0, 4], [0, 5], [0, 6], [0, 7], [0, 8], [0, 9], [0, 10], [0, 11], [0, 12], [0, 13]]
@@ -72,9 +60,6 @@ unharvested:
         start: [0, 0]
         end: [11, 9]
 
-      storage_cores:
-        []
-
       dispatch_cores:
         [[0, 0], [0, 1], [0, 2], [0, 3], [0, 4], [0, 5], [0, 6], [0, 7], [0, 8], [0, 9], [0, 10], [0, 11], [0, 12], [0, 13]]
 
@@ -85,9 +70,6 @@ unharvested:
       compute_with_storage_grid_range: # Logical only start and end [x, y]
         start: [0, 0]
         end: [11, 9]
-
-      storage_cores:
-        []
 
       dispatch_cores:
         [[0, 0], [0, 1], [0, 2], [0, 3], [0, 4], [0, 5], [0, 6], [0, 7], [0, 8], [0, 9], [0, 10], [0, 11], [0, 12], [0, 13]]

--- a/tt_metal/core_descriptors/blackhole_140_arch_fabric_mux.yaml
+++ b/tt_metal/core_descriptors/blackhole_140_arch_fabric_mux.yaml
@@ -15,8 +15,6 @@ unharvested:
         start: [0, 0]
         end: [13, 8]
 
-      storage_cores: # Relative to grid of tensix cores
-        []
 
       # First half for fabric mux, second half for dispatch (14 cores total -> 8/6 each)
       fabric_mux_cores:
@@ -33,8 +31,6 @@ unharvested:
         start: [0, 0]
         end: [13, 8]
 
-      storage_cores: # Relative to grid of tensix cores
-        []
 
       # First half for fabric mux, second half for dispatch (14 cores total -> 8/6 each)
       fabric_mux_cores:
@@ -51,8 +47,6 @@ unharvested:
         start: [0, 0]
         end: [12, 9]
 
-      storage_cores: # Relative to grid of tensix cores
-        []
 
       # First half for fabric mux, second half for dispatch (10 cores total -> 5 each)
       fabric_mux_cores:
@@ -69,8 +63,6 @@ unharvested:
         start: [0, 0]
         end: [12, 9]
 
-      storage_cores: # Relative to grid of tensix cores
-        []
 
       # Same allocation for 2 CQ configuration
       fabric_mux_cores:
@@ -89,8 +81,6 @@ unharvested:
         start: [0, 0]
         end: [12, 8]
 
-      storage_cores: # Relative to grid of tensix cores
-        []
 
       # First half for fabric mux, second half for dispatch (13 cores total -> 8/5 each)
       fabric_mux_cores:
@@ -107,8 +97,6 @@ unharvested:
         start: [0, 0]
         end: [12, 8]
 
-      storage_cores: # Relative to grid of tensix cores
-        []
 
       # First half for fabric mux, second half for dispatch (13 cores total -> 8/5 each)
       fabric_mux_cores:
@@ -126,8 +114,6 @@ unharvested:
         start: [0, 0]
         end: [11, 9]
 
-      storage_cores: # Relative to grid of tensix cores
-        []
 
       # First half for fabric mux, second half for dispatch (10 cores total -> 5 each)
       fabric_mux_cores:
@@ -144,8 +130,6 @@ unharvested:
         start: [0, 0]
         end: [11, 9]
 
-      storage_cores: # Relative to grid of tensix cores
-        []
 
       # Same allocation for 2 CQ configuration
       fabric_mux_cores:
@@ -164,8 +148,6 @@ unharvested:
         start: [0, 0]
         end: [11, 8]
 
-      storage_cores: # Relative to grid of tensix cores
-        []
 
       # First half for fabric mux, second half for dispatch (12 cores total -> 6 each)
       fabric_mux_cores:
@@ -182,8 +164,6 @@ unharvested:
         start: [0, 0]
         end: [11, 8]
 
-      storage_cores: # Relative to grid of tensix cores
-        []
 
       # First half for fabric mux, second half for dispatch (12 cores total -> 6 each)
       fabric_mux_cores:
@@ -201,8 +181,6 @@ unharvested:
         start: [0, 0]
         end: [10, 9]
 
-      storage_cores: # Relative to grid of tensix cores
-        []
 
       # First half for fabric mux, second half for dispatch (10 cores total -> 5 each)
       fabric_mux_cores:
@@ -219,8 +197,6 @@ unharvested:
         start: [0, 0]
         end: [10, 9]
 
-      storage_cores: # Relative to grid of tensix cores
-        []
 
       # Same allocation for 2 CQ configuration
       fabric_mux_cores:

--- a/tt_metal/core_descriptors/blackhole_simulation_1x2_arch.yaml
+++ b/tt_metal/core_descriptors/blackhole_simulation_1x2_arch.yaml
@@ -12,8 +12,6 @@ unharvested:
         start: [0, 0]
         end: [1, 0]
 
-      storage_cores: # Relative to grid of tensix cores
-        []
 
       dispatch_cores:
         []
@@ -25,8 +23,6 @@ unharvested:
         start: [0, 0]
         end: [1, 0]
 
-      storage_cores: # Relative to grid of tensix cores
-        []
 
       dispatch_cores:
         []

--- a/tt_metal/core_descriptors/blackhole_versim_1x1_arch.yaml
+++ b/tt_metal/core_descriptors/blackhole_versim_1x1_arch.yaml
@@ -12,8 +12,6 @@ blackhole:
         start: [0, 0]
         end: [0, 0]
 
-      storage_cores:
-        []
 
       dispatch_cores:
         []

--- a/tt_metal/core_descriptors/quasar_simulation_1x3_arch.yaml
+++ b/tt_metal/core_descriptors/quasar_simulation_1x3_arch.yaml
@@ -12,8 +12,6 @@ unharvested:
         start: [0, 1]
         end: [0, 1]
 
-      storage_cores: # Relative to grid of tensix cores
-        []
 
       dispatch_cores:
         []
@@ -26,8 +24,6 @@ unharvested:
         start: [0, 1]
         end: [0, 1]
 
-      storage_cores: # Relative to grid of tensix cores
-        []
 
       dispatch_cores:
         []

--- a/tt_metal/core_descriptors/wormhole_b0_80_arch.yaml
+++ b/tt_metal/core_descriptors/wormhole_b0_80_arch.yaml
@@ -12,9 +12,6 @@ galaxy:
         start: [0, 0]
         end: [7, 8]
 
-      storage_cores:
-        []
-
       dispatch_cores:
         [[0, -1], [1, -1], [2, -1], [3, -1], [4, -1], [5, -1], [6, -1], [7, -1]]
 
@@ -25,9 +22,6 @@ galaxy:
       compute_with_storage_grid_range: # Logical only start and end [x, y]
         start: [0, 0]
         end: [7, 8]
-
-      storage_cores:
-        []
 
       dispatch_cores:
         [[0, -1], [1, -1], [2, -1], [3, -1], [4, -1], [5, -1], [6, -1], [7, -1]]
@@ -40,9 +34,6 @@ galaxy:
         start: [0, 0]
         end: [6, 9]
 
-      storage_cores:
-        []
-
       dispatch_cores:
         [[-1, 0], [-1, 1], [-1, 2], [-1, 3], [-1, 4], [-1, 5], [-1, 6], [-1, 7]]
 
@@ -53,9 +44,6 @@ galaxy:
       compute_with_storage_grid_range: # Logical only start and end [x, y]
         start: [0, 0]
         end: [6, 9]
-
-      storage_cores:
-        []
 
       dispatch_cores:
         [[-1, 0], [-1, 1], [-1, 2], [-1, 3], [-1, 4], [-1, 5], [-1, 6], [-1, 7]]
@@ -74,9 +62,6 @@ nebula_x1:
         start: [0, 0]
         end: [7, 1]
 
-      storage_cores:
-        []
-
       dispatch_cores:
         [[0, -1], [1, -1], [2, -1], [3, -1], [4, -1], [5, -1], [6, -1], [7, -1]]
 
@@ -99,9 +84,6 @@ nebula_x1:
       tg_compute_with_storage_grid_range: # Logical only start and end [x, y]
         start: [0, 0]
         end: [7, 1]
-
-      storage_cores:
-        []
 
       dispatch_cores:
         [[0, -1], [1, -1], [2, -1], [3, -1], [4, -1], [5, -1], [6, -1], [7, -1]]
@@ -126,9 +108,6 @@ nebula_x1:
         start: [0, 0]
         end: [7, 1]
 
-      storage_cores:
-        []
-
       dispatch_cores:
         [[-1, 0], [-1, 1], [-1, 2], [-1, 3], [-1, 4], [-1, 5], [-1, 6], [-1, 7]]
 
@@ -151,9 +130,6 @@ nebula_x1:
       tg_compute_with_storage_grid_range: # Logical only start and end [x, y]
         start: [0, 0]
         end: [7, 1]
-
-      storage_cores:
-        []
 
       dispatch_cores:
         [[-1, 0], [-1, 1], [-1, 2], [-1, 3], [-1, 4], [-1, 5], [-1, 6], [-1, 7]]
@@ -176,9 +152,6 @@ nebula_x2:
         start: [0, 0]
         end: [7, 6]
 
-      storage_cores: # Relative to grid of tensix cores
-        []
-
       dispatch_cores:
         [[0, -1], [1, -1], [2, -1], [3, -1], [4, -1], [5, -1], [6, -1], [7, -1]]
 
@@ -189,9 +162,6 @@ nebula_x2:
       compute_with_storage_grid_range: # Logical only start and end [x, y]
         start: [0, 0]
         end: [7, 6]
-
-      storage_cores: # Relative to grid of tensix cores
-        []
 
       dispatch_cores:
         [[0, -1], [1, -1], [2, -1], [3, -1], [4, -1], [5, -1], [6, -1], [7, -1]]
@@ -204,9 +174,6 @@ nebula_x2:
         start: [0, 0]
         end: [6, 7]
 
-      storage_cores: # Relative to grid of tensix cores
-        []
-
       dispatch_cores:
         [[-1, 0], [-1, 1], [-1, 2], [-1, 3], [-1, 4], [-1, 5], [-1, 6], [-1, 7]]
 
@@ -217,9 +184,6 @@ nebula_x2:
       compute_with_storage_grid_range: # Logical only start and end [x, y]
         start: [0, 0]
         end: [6, 7]
-
-      storage_cores: # Relative to grid of tensix cores
-        []
 
       dispatch_cores:
         [[-1, 0], [-1, 1], [-1, 2], [-1, 3], [-1, 4], [-1, 5], [-1, 6], [-1, 7]]

--- a/tt_metal/core_descriptors/wormhole_b0_80_arch_eth_dispatch.yaml
+++ b/tt_metal/core_descriptors/wormhole_b0_80_arch_eth_dispatch.yaml
@@ -12,8 +12,6 @@ galaxy:
         start: [0, 0]
         end: [7, 9]
 
-      storage_cores:
-        []
 
       dispatch_cores:
         [[0, 4], [0, 5], [0, 10], [0, 11], [0, 12], [0, 13]]
@@ -26,8 +24,6 @@ galaxy:
         start: [0, 0]
         end: [7, 9]
 
-      storage_cores:
-        []
 
       dispatch_cores:
         [[0, 4], [0, 5], [0, 10], [0, 11], [0, 12], [0, 13]]
@@ -42,8 +38,6 @@ nebula_x1:
         start: [0, 0]
         end: [7, 7]
 
-      storage_cores:
-        []
 
       dispatch_cores:
         [[0, 4], [0, 5], [0, 10], [0, 11], [0, 12], [0, 13]]
@@ -56,8 +50,6 @@ nebula_x1:
         start: [0, 0]
         end: [7, 7]
 
-      storage_cores:
-        []
 
       dispatch_cores:
         [[0, 4], [0, 5], [0, 10], [0, 11], [0, 12], [0, 13]]
@@ -72,8 +64,6 @@ nebula_x2:
         start: [0, 0]
         end: [7, 7]
 
-      storage_cores: # Relative to grid of tensix cores
-        []
 
       dispatch_cores:
         [[0, 4], [0, 5], [0, 10], [0, 11], [0, 12], [0, 13]]
@@ -86,8 +76,6 @@ nebula_x2:
         start: [0, 0]
         end: [7, 7]
 
-      storage_cores: # Relative to grid of tensix cores
-        []
 
       dispatch_cores:
         [[0, 4], [0, 5], [0, 10], [0, 11], [0, 12], [0, 13]]

--- a/tt_metal/core_descriptors/wormhole_b0_80_arch_fabric_mux.yaml
+++ b/tt_metal/core_descriptors/wormhole_b0_80_arch_fabric_mux.yaml
@@ -14,8 +14,6 @@ galaxy:
         start: [0, 0]
         end: [7, 8]
 
-      storage_cores:
-        []
 
       # First half for fabric mux, second half for dispatch
       fabric_mux_cores:
@@ -32,8 +30,6 @@ galaxy:
         start: [0, 0]
         end: [7, 8]
 
-      storage_cores:
-        []
 
       # Same allocation for 2 CQ configuration
       fabric_mux_cores:
@@ -51,8 +47,6 @@ galaxy:
         start: [0, 0]
         end: [6, 9]
 
-      storage_cores:
-        []
 
       fabric_mux_cores:
         [[-1, 0], [-1, 1], [-1, 2], [-1, 3], [-1, 4], [-1, 5]]
@@ -68,8 +62,6 @@ galaxy:
         start: [0, 0]
         end: [6, 9]
 
-      storage_cores:
-        []
 
       fabric_mux_cores:
         [[-1, 0], [-1, 1], [-1, 2], [-1, 3], [-1, 4], [-1, 5]]
@@ -91,8 +83,6 @@ nebula_x1:
         start: [0, 0]
         end: [7, 1]
 
-      storage_cores:
-        []
 
       fabric_mux_cores:
         [[0, -1], [1, -1], [2, -1]]
@@ -120,8 +110,6 @@ nebula_x1:
         start: [0, 0]
         end: [7, 1]
 
-      storage_cores:
-        []
 
       fabric_mux_cores:
         [[0, -1], [1, -1], [2, -1]]
@@ -150,8 +138,6 @@ nebula_x1:
         start: [0, 0]
         end: [7, 1]
 
-      storage_cores:
-        []
 
       fabric_mux_cores:
         [[-1, 0], [-1, 1], [-1, 2]]
@@ -179,8 +165,6 @@ nebula_x1:
         start: [0, 0]
         end: [7, 1]
 
-      storage_cores:
-        []
 
       fabric_mux_cores:
         [[-1, 0], [-1, 1], [-1, 2]]
@@ -206,8 +190,6 @@ nebula_x2:
         start: [0, 0]
         end: [7, 6]
 
-      storage_cores: # Relative to grid of tensix cores
-        []
 
       fabric_mux_cores:
         [[0, -1], [1, -1], [2, -1]]
@@ -223,8 +205,6 @@ nebula_x2:
         start: [0, 0]
         end: [7, 6]
 
-      storage_cores: # Relative to grid of tensix cores
-        []
 
       fabric_mux_cores:
         [[0, -1], [1, -1], [2, -1]]
@@ -241,8 +221,6 @@ nebula_x2:
         start: [0, 0]
         end: [6, 7]
 
-      storage_cores: # Relative to grid of tensix cores
-        []
 
       fabric_mux_cores:
         [[-1, 0], [-1, 1], [-1, 2]]
@@ -258,8 +236,6 @@ nebula_x2:
         start: [0, 0]
         end: [6, 7]
 
-      storage_cores: # Relative to grid of tensix cores
-        []
 
       fabric_mux_cores:
         [[-1, 0], [-1, 1], [-1, 2]]

--- a/tt_metal/core_descriptors/wormhole_b0_versim_1x1_arch.yaml
+++ b/tt_metal/core_descriptors/wormhole_b0_versim_1x1_arch.yaml
@@ -12,8 +12,6 @@ galaxy:
         start: [1, 1]
         end: [1, 1]
 
-      storage_cores:
-        []
 
       dispatch_cores:
         []
@@ -25,8 +23,6 @@ galaxy:
         start: [1, 1]
         end: [1, 1]
 
-      storage_cores:
-        []
 
       dispatch_cores:
         []
@@ -41,8 +37,6 @@ nebula_x1:
         start: [0, 0]
         end: [0, 0]
 
-      storage_cores:
-        []
 
       dispatch_cores:
         []
@@ -54,8 +48,6 @@ nebula_x1:
         start: [1, 1]
         end: [1, 1]
 
-      storage_cores:
-        []
 
       dispatch_cores:
         []
@@ -70,8 +62,6 @@ nebula_x2:
         start: [0, 0]
         end: [0, 0]
 
-      storage_cores:
-        []
 
       dispatch_cores:
         []
@@ -83,8 +73,6 @@ nebula_x2:
         start: [1, 1]
         end: [1, 1]
 
-      storage_cores:
-        []
 
       dispatch_cores:
         []

--- a/tt_metal/impl/allocator/allocator_types.hpp
+++ b/tt_metal/impl/allocator/allocator_types.hpp
@@ -16,7 +16,6 @@ namespace tt::tt_metal {
 // Setup what each core-type is
 enum class AllocCoreType {
     Dispatch,
-    StorageOnly,
     ComputeOnly,
     ComputeAndStore,
     Invalid,
@@ -36,7 +35,6 @@ struct AllocatorConfig {
     uint32_t l1_unreserved_base = 0;
     CoreRangeSet worker_grid;
     size_t worker_l1_size = 0;
-    std::optional<uint32_t> storage_core_bank_size = 0;
     size_t l1_small_size = 0;
     size_t trace_region_size = 0;
     std::unordered_map<CoreCoord, AllocCoreType> core_type_from_noc_coord_table;

--- a/tt_metal/impl/allocator/l1_banking_allocator.cpp
+++ b/tt_metal/impl/allocator/l1_banking_allocator.cpp
@@ -31,49 +31,18 @@ namespace tt {
 
 namespace tt_metal {
 
-struct num_banks_t {
-    uint32_t total;
-    uint32_t num_l1_banks;
-    uint32_t num_l1_small_banks;
-    uint32_t per_storage_core;
-};
-
-num_banks_t compute_total_and_storage_only_num_l1_banks(const AllocatorConfig& alloc_config) {
-    auto num_in_category = [](const std::unordered_map<CoreCoord, AllocCoreType>& core_allocation_types,
-                              const AllocCoreType& alloc_type) {
-        int num_cores = 0;
-        for (const auto& core_allocation_type : core_allocation_types) {
-            if (core_allocation_type.second == alloc_type) {
-                num_cores++;
-            }
-        }
-        return num_cores;
-    };
-
-    auto num_compute_and_storage_cores =
-        num_in_category(alloc_config.core_type_from_noc_coord_table, AllocCoreType::ComputeAndStore);
-    auto num_storage_only_cores =
-        num_in_category(alloc_config.core_type_from_noc_coord_table, AllocCoreType::StorageOnly);
-    uint32_t num_banks_per_storage_core = 0;
-    if (num_storage_only_cores > 0) {
-        TT_ASSERT(alloc_config.storage_core_bank_size.has_value());
-        TT_ASSERT(alloc_config.worker_l1_size % alloc_config.storage_core_bank_size.value() == 0);
-        num_banks_per_storage_core = alloc_config.worker_l1_size / alloc_config.storage_core_bank_size.value();
-    }
-    // L1 small region carve out is only for compute cores
-    uint32_t num_l1_small_banks = (alloc_config.l1_small_size > 0) ? num_compute_and_storage_cores : 0;
-    uint32_t num_l1_banks = num_compute_and_storage_cores + (num_banks_per_storage_core * num_storage_only_cores);
-    return num_banks_t{
-        .total = num_l1_banks + num_l1_small_banks,
-        .num_l1_banks = num_l1_banks,
-        .num_l1_small_banks = num_l1_small_banks,
-        .per_storage_core = num_banks_per_storage_core,
-    };
-}
-
 void Allocator::init_compute_and_storage_l1_bank_manager() {
     TT_FATAL(config_->worker_grid.contains(config_->compute_grid), "Compute grid must be a subset of worker grid");
-    num_banks_t num_banks = compute_total_and_storage_only_num_l1_banks(*config_);
+
+    uint32_t num_l1_banks = 0;
+    for (const auto& core_allocation_type : config_->core_type_from_noc_coord_table) {
+        if (core_allocation_type.second == AllocCoreType::ComputeAndStore) {
+            num_l1_banks++;
+        }
+    }
+
+    uint32_t num_l1_small_banks = (config_->l1_small_size > 0) ? num_l1_banks : 0;
+
     auto logical_to_noc_coord = [this](CoreCoord logical_core) {
         TT_ASSERT(
             config_->worker_log_to_virtual_routing_x.find(logical_core.x) !=
@@ -100,15 +69,15 @@ void Allocator::init_compute_and_storage_l1_bank_manager() {
     std::vector<uint32_t> shuffled_bank_id = {};
     if (not config_->l1_bank_remap.empty()) {
         TT_ASSERT(
-            num_banks.num_l1_banks == config_->l1_bank_remap.size(),
+            num_l1_banks == config_->l1_bank_remap.size(),
             "override l1_bank_remap.size()={} which is not equal to the expected expected_num_l1_banks={} from "
             "soc-desc",
             config_->l1_bank_remap.size(),
-            num_banks.num_l1_banks);
+            num_l1_banks);
         std::copy(config_->l1_bank_remap.begin(), config_->l1_bank_remap.end(), std::back_inserter(shuffled_bank_id));
     } else {
         // randomize remap
-        for (uint32_t id = 0; id < num_banks.num_l1_banks; id++) {
+        for (uint32_t id = 0; id < num_l1_banks; id++) {
             shuffled_bank_id.push_back(id);
         }
         auto rng = std::default_random_engine(0);
@@ -118,7 +87,7 @@ void Allocator::init_compute_and_storage_l1_bank_manager() {
     std::unordered_map<uint32_t, int64_t> bank_id_to_bank_offset;
     std::unordered_map<uint32_t, int64_t> small_bank_id_to_bank_offset;
     if (config_->l1_small_size > 0) {
-        TT_ASSERT(num_banks.num_l1_small_banks > 0);
+        TT_ASSERT(num_l1_small_banks > 0);
     }
 
     // If l1_small_size exists, then it gets the top of L1 (offset 0)
@@ -139,54 +108,22 @@ void Allocator::init_compute_and_storage_l1_bank_manager() {
                 small_bank_id_to_bank_offset.insert({remapped_bank_id, 0});
             }
             bank_id++;
-        } else if (config_->core_type_from_noc_coord_table.at(noc_core) == AllocCoreType::StorageOnly) {
-            std::vector<uint32_t> bank_ids;
-            for (int storage_bank_index = 0; storage_bank_index < num_banks.per_storage_core; storage_bank_index++) {
-                uint32_t remapped_bank_id = shuffled_bank_id[bank_id];
-                bank_ids.push_back(remapped_bank_id);
-                bank_id_to_logical_core_.insert({remapped_bank_id, logical_core});
-                int64_t bank_offset_bytes = 0;
-                if (config_->storage_core_bank_size.value() != config_->worker_l1_size) {
-                    uint64_t storage_core_offset = storage_bank_index * config_->storage_core_bank_size.value();
-                    bank_offset_bytes = static_cast<int64_t>(storage_core_offset) -
-                                        config_->storage_core_bank_size
-                                            .value();  // Assuming top-down here --  Not sure if this is hacky... need
-                                                       // to specialize based off top-down cofnig flag or not?
-                } else if (num_banks.per_storage_core != 1) {
-                    TT_THROW(
-                        "Expected 1 bank per storage core if L1 bank size equals total worker L1 size but have {} "
-                        "banks",
-                        num_banks.per_storage_core);
-                }
-                bank_id_to_bank_offset.insert({remapped_bank_id, bank_offset_bytes});
-                bank_id++;
-            }
-            logical_core_to_bank_ids_[BufferType::L1].insert({logical_core, bank_ids});
         }
     }
     TT_ASSERT(bank_id == shuffled_bank_id.size());
-    TT_ASSERT(bank_id_to_bank_offset.size() == num_banks.num_l1_banks);
-    TT_ASSERT(small_bank_id_to_bank_offset.size() == num_banks.num_l1_small_banks);
+    TT_ASSERT(bank_id_to_bank_offset.size() == num_l1_banks);
+    TT_ASSERT(small_bank_id_to_bank_offset.size() == num_l1_small_banks);
     TT_ASSERT(
-        (bank_id_to_bank_offset.size() + small_bank_id_to_bank_offset.size()) == num_banks.total,
+        (bank_id_to_bank_offset.size() + small_bank_id_to_bank_offset.size()) == num_l1_banks,
         "init_compute_and_storage_l1_bank_manager() -- banks setup={} must be equal to the number of banks "
         "expected={}",
         bank_id_to_bank_offset.size(),
         small_bank_id_to_bank_offset.size(),
-        num_banks.total);
-
-    // Storage only cores only need to reserve mailbox space to hold barriers
-    uint32_t mem_mailbox_base =
-        MetalContext::instance().hal().get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::MAILBOX);
-    uint32_t storage_core_unreserved_base =
-        ((mem_mailbox_base + config_->l1_alignment - 1) / config_->l1_alignment) * config_->l1_alignment;
+        num_l1_banks);
 
     // There is only l1_bank_size bytes available for L1 buffers to be allocated in
-    uint64_t l1_bank_size = config_->storage_core_bank_size.has_value()
-                                ? config_->storage_core_bank_size.value()
-                                : (config_->worker_l1_size - config_->l1_unreserved_base);
-    uint64_t interleaved_address_limit =
-        static_cast<uint64_t>(config_->worker_l1_size - l1_bank_size) + storage_core_unreserved_base;
+    uint64_t l1_bank_size = config_->worker_l1_size - config_->l1_unreserved_base;
+    uint64_t interleaved_address_limit = static_cast<uint64_t>(config_->worker_l1_size - l1_bank_size);
     uint64_t allocatable_l1_size =
         static_cast<uint64_t>(config_->worker_l1_size) - config_->l1_unreserved_base - config_->l1_small_size;
     // Assuming top down allocation for L1 buffers so the allocatable memory space is the top l1_bank_size bytes of L1
@@ -200,10 +137,8 @@ void Allocator::init_compute_and_storage_l1_bank_manager() {
         config_->disable_interleaved);
     log_debug(
         tt::LogMetal,
-        "Configured partition params: mem_mailbox_base:0x{:X}, storage_core_bank_size:0x{:X}, worker_l1_size:0x{:X}, "
+        "Configured partition params: worker_l1_size:0x{:X}, "
         "l1_unreserved_base:0x{:X}, l1_small_size:0x{:X}, disable_interleaved:{}, l1_alignment:{}",
-        mem_mailbox_base,
-        config_->storage_core_bank_size.has_value() ? config_->storage_core_bank_size.value() : 0,
         config_->worker_l1_size,
         config_->l1_unreserved_base,
         config_->l1_small_size,
@@ -214,10 +149,9 @@ void Allocator::init_compute_and_storage_l1_bank_manager() {
     uint64_t small_alloc_offset = config_->l1_unreserved_base + allocatable_l1_size;
     log_debug(
         tt::LogMetal,
-        "Derived partition params: storage_core_unreserved_base:0x{:X}, l1_bank_size:0x{:X}, "
+        "Derived partition params: l1_bank_size:0x{:X}, "
         "interleaved_address_limit:0x{:X}, "
         "allocatable_l1_size:0x{:X}, small_interleaved_address_limit:0x{:X}, small_alloc_offset:0x{:X}",
-        storage_core_unreserved_base,
         l1_bank_size,
         interleaved_address_limit,
         allocatable_l1_size,
@@ -270,7 +204,6 @@ AllocatorConfig L1BankingAllocator::generate_config(
          .l1_unreserved_base = align(worker_l1_unreserved_start, hal.get_alignment(HalMemType::DRAM)),
          .worker_grid = CoreRangeSet(CoreRange(CoreCoord(0, 0), CoreCoord(logical_size.x - 1, logical_size.y - 1))),
          .worker_l1_size = static_cast<size_t>(soc_desc.worker_l1_size),
-         .storage_core_bank_size = get_storage_core_bank_size(device_id, num_hw_cqs, dispatch_core_config),
          .l1_small_size = align(l1_small_size, hal.get_alignment(HalMemType::DRAM)),
          .trace_region_size = align(trace_region_size, hal.get_alignment(HalMemType::DRAM)),
          .core_type_from_noc_coord_table = {},  // Populated later
@@ -281,9 +214,7 @@ AllocatorConfig L1BankingAllocator::generate_config(
          .l1_alignment = hal.get_alignment(HalMemType::L1),
          .disable_interleaved = false});
     TT_FATAL(
-        config.l1_small_size < (config.storage_core_bank_size.has_value()
-                                    ? config.storage_core_bank_size.value()
-                                    : config.worker_l1_size - config.l1_unreserved_base),
+        config.l1_small_size < config.worker_l1_size - config.l1_unreserved_base,
         "Reserved size must be less than bank size");
     TT_FATAL(
         config.l1_small_size % config.l1_alignment == 0,
@@ -309,11 +240,6 @@ AllocatorConfig L1BankingAllocator::generate_config(
         const auto noc_coord =
             cluster.get_virtual_coordinate_from_logical_coordinates(device_id, core, CoreType::WORKER);
         config.core_type_from_noc_coord_table[noc_coord] = AllocCoreType::ComputeAndStore;
-    }
-    for (const CoreCoord& core : tt::get_logical_storage_cores(device_id, num_hw_cqs, dispatch_core_config)) {
-        const auto noc_coord =
-            cluster.get_virtual_coordinate_from_logical_coordinates(device_id, core, CoreType::WORKER);
-        config.core_type_from_noc_coord_table[noc_coord] = AllocCoreType::StorageOnly;
     }
     for (const CoreCoord& core : tt::get_logical_dispatch_cores(device_id, num_hw_cqs, dispatch_core_config)) {
         const auto noc_coord =

--- a/tt_metal/impl/allocator/l1_banking_allocator.cpp
+++ b/tt_metal/impl/allocator/l1_banking_allocator.cpp
@@ -113,13 +113,6 @@ void Allocator::init_compute_and_storage_l1_bank_manager() {
     TT_ASSERT(bank_id == shuffled_bank_id.size());
     TT_ASSERT(bank_id_to_bank_offset.size() == num_l1_banks);
     TT_ASSERT(small_bank_id_to_bank_offset.size() == num_l1_small_banks);
-    TT_ASSERT(
-        (bank_id_to_bank_offset.size() + small_bank_id_to_bank_offset.size()) == num_l1_banks,
-        "init_compute_and_storage_l1_bank_manager() -- banks setup={} must be equal to the number of banks "
-        "expected={}",
-        bank_id_to_bank_offset.size(),
-        small_bank_id_to_bank_offset.size(),
-        num_l1_banks);
 
     // There is only l1_bank_size bytes available for L1 buffers to be allocated in
     uint64_t l1_bank_size = config_->worker_l1_size - config_->l1_unreserved_base;

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -670,18 +670,14 @@ void MetalContext::reset_cores(ChipId device_id) {
         }
     }
 
-    // Reset Tensix cores, ignore storage only cores
+    // Reset Tensix cores
     CoreCoord grid_size = cluster_->get_soc_desc(device_id).get_grid_size(CoreType::TENSIX);
-    const auto& storage_only_cores = tt::get_logical_storage_cores(device_id, num_hw_cqs_, dispatch_core_config_);
-    auto storage_only_cores_set = std::unordered_set<CoreCoord>(storage_only_cores.begin(), storage_only_cores.end());
     for (uint32_t y = 0; y < grid_size.y; y++) {
         for (uint32_t x = 0; x < grid_size.x; x++) {
             CoreCoord logical_core(x, y);
             CoreCoord worker_core =
                 cluster_->get_virtual_coordinate_from_logical_coordinates(device_id, logical_core, CoreType::WORKER);
-            if (!storage_only_cores_set.contains(logical_core)) {
-                cluster_->assert_risc_reset_at_core(tt_cxy_pair(device_id, worker_core), tt::umd::RiscType::ALL);
-            }
+            cluster_->assert_risc_reset_at_core(tt_cxy_pair(device_id, worker_core), tt::umd::RiscType::ALL);
         }
     }
 
@@ -699,10 +695,8 @@ void MetalContext::assert_cores(ChipId device_id) {
     auto dispatch_cores = tt::tt_metal::get_virtual_dispatch_cores(device_id);
     auto routing_cores = tt::tt_metal::get_virtual_dispatch_routing_cores(device_id);
 
-    // Assert riscs on Tensix, minus storage cores
+    // Assert riscs on Tensix
     CoreCoord grid_size = cluster_->get_soc_desc(device_id).get_grid_size(CoreType::TENSIX);
-    const auto& storage_only_cores = tt::get_logical_storage_cores(device_id, num_hw_cqs_, dispatch_core_config_);
-    auto storage_only_cores_set = std::unordered_set<CoreCoord>(storage_only_cores.begin(), storage_only_cores.end());
     for (uint32_t y = 0; y < grid_size.y; y++) {
         for (uint32_t x = 0; x < grid_size.x; x++) {
             CoreCoord logical_core(x, y);
@@ -710,15 +704,13 @@ void MetalContext::assert_cores(ChipId device_id) {
                 cluster_->get_virtual_coordinate_from_logical_coordinates(device_id, logical_core, CoreType::WORKER);
 
             if (!dispatch_cores.contains(worker_core) && !routing_cores.contains(worker_core)) {
-                if (!storage_only_cores_set.contains(logical_core)) {
-                    if (!tt::tt_metal::MetalContext::instance().hal().get_eth_fw_is_cooperative() &&
-                        this->get_control_plane().get_active_ethernet_cores(device_id, false).contains(logical_core)) {
-                        // Cannot put these cores into reset because they are running base FW
-                        // Below will return to base FW
-                        continue;
-                    }
-                    cluster_->assert_risc_reset_at_core(tt_cxy_pair(device_id, worker_core), tt::umd::RiscType::ALL);
+                if (!tt::tt_metal::MetalContext::instance().hal().get_eth_fw_is_cooperative() &&
+                    this->get_control_plane().get_active_ethernet_cores(device_id, false).contains(logical_core)) {
+                    // Cannot put these cores into reset because they are running base FW
+                    // Below will return to base FW
+                    continue;
                 }
+                cluster_->assert_risc_reset_at_core(tt_cxy_pair(device_id, worker_core), tt::umd::RiscType::ALL);
             } else {
                 log_debug(tt::LogMetal, "{} will not be Reset when closing Device {}", worker_core.str(), device_id);
             }
@@ -1294,29 +1286,25 @@ void MetalContext::initialize_and_launch_firmware(ChipId device_id) {
     auto go_msg = dev_msgs_factory.create<dev_msgs::go_msg_t>();
     go_msg.view().signal() = dev_msgs::RUN_MSG_INIT;
 
-    const auto& storage_only_cores = tt::get_logical_storage_cores(device_id, num_hw_cqs_, dispatch_core_config_);
-    auto storage_only_cores_set = std::unordered_set<CoreCoord>(storage_only_cores.begin(), storage_only_cores.end());
     for (uint32_t y = 0; y < logical_grid_size.y; y++) {
         for (uint32_t x = 0; x < logical_grid_size.x; x++) {
             CoreCoord logical_core(x, y);
-            if (!storage_only_cores_set.count(logical_core)) {
-                CoreCoord worker_core = cluster_->get_virtual_coordinate_from_logical_coordinates(
-                    device_id, logical_core, CoreType::WORKER);
-                // Setup the absolute logical coordinates of this worker which are relative to true origin. not the sub
-                // device. When running the user kernel, which potentially is on a sub device, send that info using the
-                // launch message using dispatch.
-                core_info.view().absolute_logical_x() = logical_core.x;
-                core_info.view().absolute_logical_y() = logical_core.y;
-                // Must write to core before starting it
-                cluster_->write_core_immediate(
-                    core_info.data(),
-                    core_info.size(),
-                    {device_id, worker_core},
-                    hal_->get_dev_addr(llrt::get_core_type(device_id, worker_core), HalL1MemAddrType::CORE_INFO));
-                initialize_firmware(
-                    device_id, HalProgrammableCoreType::TENSIX, worker_core, launch_msg.view(), go_msg.view());
-                not_done_cores.insert(worker_core);
-            }
+            CoreCoord worker_core =
+                cluster_->get_virtual_coordinate_from_logical_coordinates(device_id, logical_core, CoreType::WORKER);
+            // Setup the absolute logical coordinates of this worker which are relative to true origin. not the sub
+            // device. When running the user kernel, which potentially is on a sub device, send that info using the
+            // launch message using dispatch.
+            core_info.view().absolute_logical_x() = logical_core.x;
+            core_info.view().absolute_logical_y() = logical_core.y;
+            // Must write to core before starting it
+            cluster_->write_core_immediate(
+                core_info.data(),
+                core_info.size(),
+                {device_id, worker_core},
+                hal_->get_dev_addr(llrt::get_core_type(device_id, worker_core), HalL1MemAddrType::CORE_INFO));
+            initialize_firmware(
+                device_id, HalProgrammableCoreType::TENSIX, worker_core, launch_msg.view(), go_msg.view());
+            not_done_cores.insert(worker_core);
         }
     }
 

--- a/tt_metal/impl/debug/watcher_device_reader.cpp
+++ b/tt_metal/impl/debug/watcher_device_reader.cpp
@@ -363,24 +363,13 @@ void WatcherDeviceReader::Dump(FILE* file) {
 
     DumpData dump_data;
 
-    // Ignore storage-only cores
-    std::unordered_set<CoreCoord> storage_only_cores;
-    uint8_t num_hw_cqs = tt::tt_metal::MetalContext::instance().get_dispatch_core_manager().get_num_hw_cqs();
-    DispatchCoreConfig dispatch_core_config =
-        tt::tt_metal::MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_config();
-    for (auto core_coord : tt::get_logical_storage_cores(device_id, num_hw_cqs, dispatch_core_config)) {
-        storage_only_cores.insert(core_coord);
-    }
-
     // Dump worker cores
     CoreCoord grid_size =
         tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(device_id).get_grid_size(CoreType::TENSIX);
     for (uint32_t y = 0; y < grid_size.y; y++) {
         for (uint32_t x = 0; x < grid_size.x; x++) {
             CoreCoord coord = {x, y};
-            if (storage_only_cores.find(coord) == storage_only_cores.end()) {
-                Core::Create(coord, HalProgrammableCoreType::TENSIX, *this, dump_data).Dump();
-            }
+            Core::Create(coord, HalProgrammableCoreType::TENSIX, *this, dump_data).Dump();
         }
     }
 

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -182,9 +182,6 @@ std::unique_ptr<Allocator> Device::initialize_allocator(
     for (const CoreCoord& core : tt::get_logical_compute_cores(id_, num_hw_cqs_, dispatch_core_config)) {
         this->compute_cores_.insert(core);
     }
-    for (const CoreCoord& core : tt::get_logical_storage_cores(id_, num_hw_cqs_, dispatch_core_config)) {
-        this->storage_only_cores_.insert(core);
-    }
     for (const tt::umd::CoreCoord& core : soc_desc.get_cores(CoreType::ETH, CoordSystem::LOGICAL)) {
         this->ethernet_cores_.insert({core.x, core.y});
     }
@@ -306,9 +303,6 @@ void Device::init_command_queue_device() {
         MetalContext::instance().get_cluster().write_core(
             &zero, sizeof(uint32_t), tt_cxy_pair(id_, virtual_core), go_message_index_addr);
     };
-    const auto& storage_only_cores = tt::get_logical_storage_cores(
-        id_, num_hw_cqs_, MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_config());
-    auto storage_only_cores_set = std::unordered_set<CoreCoord>(storage_only_cores.begin(), storage_only_cores.end());
     std::optional<std::unique_lock<std::mutex>> watcher_lock;
     if (tt::tt_metal::MetalContext::instance().rtoptions().get_watcher_enabled()) {
         watcher_lock = MetalContext::instance().watcher_server()->get_lock();
@@ -316,10 +310,8 @@ void Device::init_command_queue_device() {
     for (uint32_t y = 0; y < logical_grid_size().y; y++) {
         for (uint32_t x = 0; x < logical_grid_size().x; x++) {
             CoreCoord logical_core(x, y);
-            if (!storage_only_cores_set.count(logical_core)) {
-                reset_launch_message_rd_ptr(logical_core, CoreType::WORKER);
-                reset_go_message_index(logical_core, CoreType::WORKER);
-            }
+            reset_launch_message_rd_ptr(logical_core, CoreType::WORKER);
+            reset_go_message_index(logical_core, CoreType::WORKER);
         }
     }
     for (const auto& logical_core : this->get_active_ethernet_cores()) {
@@ -376,7 +368,7 @@ void Device::configure_fabric() {
     detail::ConfigureDeviceWithProgram(this, *fabric_program_, using_fast_dispatch_);
 
     // Note: the l1_barrier below is needed to be sure writes to cores that
-    // don't get the GO mailbox (eg, storage cores) have all landed
+    // don't get the GO mailbox have all landed
     tt::tt_metal::MetalContext::instance().get_cluster().l1_barrier(this->id());
     std::vector<std::vector<CoreCoord>> logical_cores_used_in_program = fabric_program_->impl().logical_cores();
     const auto& hal = MetalContext::instance().hal();
@@ -470,7 +462,6 @@ bool Device::close() {
     sub_device_manager_tracker_.reset(nullptr);
 
     this->compute_cores_.clear();
-    this->storage_only_cores_.clear();
     this->ethernet_cores_.clear();
     this->command_queue_programs_.clear();
     this->command_queues_.clear();

--- a/tt_metal/impl/dispatch/dispatch_query_manager.cpp
+++ b/tt_metal/impl/dispatch/dispatch_query_manager.cpp
@@ -83,11 +83,6 @@ std::vector<CoreCoord> get_consistent_logical_cores(
     return current_cores;
 }
 
-std::vector<CoreCoord> populate_all_logical_storage_cores(
-    uint8_t num_hw_cqs, const tt::tt_metal::DispatchCoreConfig& dispatch_core_config) {
-    return get_consistent_logical_cores(num_hw_cqs, dispatch_core_config, tt::get_logical_storage_cores);
-}
-
 std::vector<CoreCoord> populate_all_logical_dispatch_cores(
     uint8_t num_hw_cqs, const tt::tt_metal::DispatchCoreConfig& dispatch_core_config) {
     return get_consistent_logical_cores(num_hw_cqs, dispatch_core_config, tt::get_logical_dispatch_cores);
@@ -113,21 +108,12 @@ void DispatchQueryManager::reset(uint8_t num_hw_cqs) {
     go_signal_noc_ = dispatch_s_enabled_ ? NOC::NOC_1 : NOC::NOC_0;
     // Reset the dispatch cores reported by the manager. Will be re-populated when the associated query is made
     dispatch_cores_ = {};
-    // Populate dispatch and storage
+    // Populate dispatch
     logical_dispatch_cores_on_user_chips_ = populate_all_logical_dispatch_cores(num_hw_cqs_, dispatch_core_config());
-    logical_storage_cores_on_user_chips_ = populate_all_logical_storage_cores(num_hw_cqs_, dispatch_core_config());
-}
-
-const std::vector<CoreCoord>& DispatchQueryManager::get_logical_storage_cores(uint32_t device_id) const {
-    return tt::get_logical_storage_cores(device_id, num_hw_cqs_, dispatch_core_config());
 }
 
 const std::vector<CoreCoord>& DispatchQueryManager::get_logical_dispatch_cores(uint32_t device_id) const {
     return tt::get_logical_dispatch_cores(device_id, num_hw_cqs_, dispatch_core_config());
-}
-
-const std::vector<CoreCoord>& DispatchQueryManager::get_logical_storage_cores_on_user_chips() const {
-    return logical_storage_cores_on_user_chips_;
 }
 
 const std::vector<CoreCoord>& DispatchQueryManager::get_logical_dispatch_cores_on_user_chips() const {

--- a/tt_metal/impl/dispatch/dispatch_query_manager.hpp
+++ b/tt_metal/impl/dispatch/dispatch_query_manager.hpp
@@ -37,10 +37,8 @@ public:
     bool distributed_dispatcher() const;
     NOC go_signal_noc() const;
     // General Dispatch related queries - configs and core placement
-    const std::vector<CoreCoord>& get_logical_storage_cores(uint32_t device_id) const;
     const std::vector<CoreCoord>& get_logical_dispatch_cores(uint32_t device_id) const;
     const std::vector<CoreCoord>& get_logical_dispatch_cores_on_user_chips() const;
-    const std::vector<CoreCoord>& get_logical_storage_cores_on_user_chips() const;
     tt_cxy_pair get_dispatch_core(uint8_t cq_id) const;
 
 private:
@@ -52,10 +50,8 @@ private:
     uint8_t num_hw_cqs_ = 0;
     DispatchCoreConfig dispatch_core_config_;  // The config this object was initialized with, need to store it so we
                                                // know when to reset if it changes.
-    // Store the list of reserved storage and dispatch cores on
-    // user exposed chips. Expected to be identical across chips.
+    // Store the list of dispatch cores on user exposed chips. Expected to be identical across chips.
     std::vector<CoreCoord> logical_dispatch_cores_on_user_chips_;
-    std::vector<CoreCoord> logical_storage_cores_on_user_chips_;
     // Make this mutable, since this is JIT populated
     // through a const instance when queried
     mutable std::vector<tt_cxy_pair> dispatch_cores_;

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -106,28 +106,14 @@ size_t get_ringbuffer_size(IDevice* device, HalProgrammableCoreType programmable
 
 void validate_kernel_placement(bool force_slow_dispatch, std::shared_ptr<Kernel> kernel) {
     // Placement rules:
-    //  Slow dispatch:
-    //      - kernels cannot be on storage only cores
     //  Fast dispatch (tensix):
-    //      - kernels cannot be on storage only cores an
     //      - tensix kernels cannot be on dispatch cores
     //  Fast dispatch (ethernet):
-    //      - kernels cannot be on storage only cores
     //      - eth kernels cannot be on idle eth cores
     bool slow_dispatch = std::getenv("TT_METAL_SLOW_DISPATCH_MODE") != nullptr;
 
     const auto& dispatch_core_config = MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_config();
     tt::CoreType dispatch_core_type = dispatch_core_config.get_core_type();
-    const std::vector<CoreCoord>& storage_cores =
-        MetalContext::instance().get_dispatch_query_manager().get_logical_storage_cores_on_user_chips();
-    bool on_storage_only_core =
-        std::any_of(storage_cores.begin(), storage_cores.end(), [&kernel](const CoreCoord& storage_core) {
-            return kernel->is_on_logical_core(storage_core);
-        });
-    TT_FATAL(
-        not on_storage_only_core,
-        "Illegal kernel placement for {}. Kernels cannot be placed on storage only cores!",
-        kernel->name());
 
     // Kernels used to implement fast dispatch can be placed on dispatch cores
     if (not slow_dispatch and not force_slow_dispatch) {

--- a/tt_metal/impl/sub_device/sub_device_manager.cpp
+++ b/tt_metal/impl/sub_device/sub_device_manager.cpp
@@ -284,7 +284,6 @@ void SubDeviceManager::populate_sub_allocators() {
              .l1_unreserved_base = global_allocator_config.l1_unreserved_base,
              .worker_grid = compute_cores,
              .worker_l1_size = global_allocator_config.l1_unreserved_base + local_l1_size_,
-             .storage_core_bank_size = std::nullopt,
              .l1_small_size = 0,
              .trace_region_size = 0,
              .core_type_from_noc_coord_table = {},  // Populated later
@@ -295,9 +294,7 @@ void SubDeviceManager::populate_sub_allocators() {
              .l1_alignment = global_allocator_config.l1_alignment,
              .disable_interleaved = true});
         TT_FATAL(
-            config.l1_small_size < (config.storage_core_bank_size.has_value()
-                                        ? config.storage_core_bank_size.value()
-                                        : config.worker_l1_size - config.l1_unreserved_base),
+            config.l1_small_size < config.worker_l1_size - config.l1_unreserved_base,
             "Reserved size must be less than bank size");
         TT_FATAL(
             config.l1_small_size % config.l1_alignment == 0,

--- a/tt_metal/jit_build/build_env_manager.cpp
+++ b/tt_metal/jit_build/build_env_manager.cpp
@@ -60,17 +60,7 @@ std::map<std::string, std::string> initialize_device_kernel_defines(ChipId devic
     // # of L1 banks needs to match allocator. For L1BankingAllocator this is the # of storage cores. TODO: when
     // allocator is pulled out of device, use it to get that info here.
     const auto& dispatch_core_config = MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_config();
-    const size_t num_compute_and_storage_cores =
-        tt::get_logical_compute_cores(device_id, num_hw_cqs, dispatch_core_config).size();
-    const size_t num_storage_only_cores =
-        tt::get_logical_storage_cores(device_id, num_hw_cqs, dispatch_core_config).size();
-    size_t num_banks_per_storage_core = 0;
-    if (num_storage_only_cores > 0) {
-        num_banks_per_storage_core =
-            static_cast<size_t>(soc_d.worker_l1_size) /
-            tt::get_storage_core_bank_size(device_id, num_hw_cqs, dispatch_core_config).value();
-    }
-    const size_t num_l1_banks = num_compute_and_storage_cores + (num_storage_only_cores * num_banks_per_storage_core);
+    const size_t num_l1_banks = tt::get_logical_compute_cores(device_id, num_hw_cqs, dispatch_core_config).size();
 
     bool is_dram_pow2 = ceil(log2(num_dram_banks)) == log2(num_dram_banks);
     bool is_l1_pow2 = ceil(log2(num_l1_banks)) == log2(num_l1_banks);

--- a/tt_metal/llrt/core_descriptor.cpp
+++ b/tt_metal/llrt/core_descriptor.cpp
@@ -148,30 +148,6 @@ const core_descriptor_t& get_core_descriptor_config(
                                                                                                                 : "col"]
                             [std::to_string(num_hw_cqs)];
 
-    // Parse the yaml into core_descriptor_t
-    std::vector<RelativeCoreCoord> storage_cores;
-    for (const auto& core_node : desc_yaml["storage_cores"]) {
-        RelativeCoreCoord coord = {};
-        if (core_node.IsSequence()) {
-            // Logical coord
-            coord = RelativeCoreCoord({.x = core_node[0].as<int>(), .y = core_node[1].as<int>()});
-        } else {
-            TT_THROW("Only logical relative coords supported for storage_cores cores");
-        }
-        storage_cores.push_back(coord);
-    }
-    std::optional<uint32_t> storage_core_bank_size = std::nullopt;
-    if (not storage_cores.empty()) {
-        try {
-            storage_core_bank_size = desc_yaml["storage_core_bank_size"].as<uint32_t>();
-        } catch (std::runtime_error& ex) {
-            TT_THROW(
-                "Core descriptor yaml for {} needs to specify storage_core_bank_size since there are {} storage cores!",
-                get_string_lowercase(arch),
-                storage_cores.size());
-        }
-    }
-
     auto compute_with_storage_start = desc_yaml["compute_with_storage_grid_range"]["start"];
     auto compute_with_storage_end = desc_yaml["compute_with_storage_grid_range"]["end"];
     if (tt::tt_metal::MetalContext::instance().get_cluster().is_galaxy_cluster() and product_name == "nebula_x1") {
@@ -280,14 +256,6 @@ const core_descriptor_t& get_core_descriptor_config(
         std::back_inserter(logical_compute_cores),
         [&grid_size](RelativeCoreCoord rel_coord) { return get_core_coord_from_relative(rel_coord, grid_size); });
 
-    std::vector<CoreCoord> logical_storage_cores;
-    logical_storage_cores.reserve(storage_cores.size());
-    std::transform(
-        storage_cores.cbegin(),
-        storage_cores.cend(),
-        std::back_inserter(logical_storage_cores),
-        [&grid_size](RelativeCoreCoord rel_coord) { return get_core_coord_from_relative(rel_coord, grid_size); });
-
     std::vector<CoreCoord> logical_dispatch_cores;
     logical_dispatch_cores.reserve(dispatch_cores.size());
     std::transform(
@@ -310,12 +278,9 @@ const core_descriptor_t& get_core_descriptor_config(
         core_descriptor_t{
             .compute_grid_size = compute_grid_size,
             .relative_compute_cores = std::move(compute_cores),
-            .relative_storage_cores = std::move(storage_cores),
-            .storage_core_bank_size = storage_core_bank_size,
             .relative_dispatch_cores = std::move(dispatch_cores),
             .relative_fabric_mux_cores = std::move(fabric_mux_cores),
             .logical_compute_cores = std::move(logical_compute_cores),
-            .logical_storage_cores = std::move(logical_storage_cores),
             .logical_dispatch_cores = std::move(logical_dispatch_cores),
             .logical_fabric_mux_cores = std::move(logical_fabric_mux_cores),
         }));
@@ -347,20 +312,6 @@ const std::tuple<uint32_t, CoreRange>& get_physical_worker_grid_config(
             {config_hash, std::make_tuple(tensix_num_worker_cores, tensix_worker_physical_grid)});
     }
     return physical_grid_config_cache.at(config_hash);
-}
-
-std::optional<uint32_t> get_storage_core_bank_size(
-    ChipId device_id, const uint8_t num_hw_cqs, const tt_metal::DispatchCoreConfig& dispatch_core_config) {
-    const core_descriptor_t& core_desc = get_core_descriptor_config(device_id, num_hw_cqs, dispatch_core_config);
-    if (core_desc.storage_core_bank_size.has_value()) {
-        TT_FATAL(
-            core_desc.storage_core_bank_size.value() %
-                    tt_metal::MetalContext::instance().hal().get_alignment(tt_metal::HalMemType::L1) ==
-                0,
-            "Storage core bank size must be {} B aligned",
-            tt_metal::MetalContext::instance().hal().get_alignment(tt_metal::HalMemType::L1));
-    }
-    return core_desc.storage_core_bank_size;
 }
 
 }  // namespace tt

--- a/tt_metal/llrt/core_descriptor.hpp
+++ b/tt_metal/llrt/core_descriptor.hpp
@@ -23,13 +23,10 @@ namespace tt {
 struct core_descriptor_t {
     CoreCoord compute_grid_size;
     std::vector<tt_metal::RelativeCoreCoord> relative_compute_cores;
-    std::vector<tt_metal::RelativeCoreCoord> relative_storage_cores;
-    std::optional<uint32_t> storage_core_bank_size = std::nullopt;
     std::vector<tt_metal::RelativeCoreCoord> relative_dispatch_cores;
     std::vector<tt_metal::RelativeCoreCoord> relative_fabric_mux_cores;
 
     std::vector<CoreCoord> logical_compute_cores;
-    std::vector<CoreCoord> logical_storage_cores;
     std::vector<CoreCoord> logical_dispatch_cores;
     std::vector<CoreCoord> logical_fabric_mux_cores;
 };
@@ -49,15 +46,6 @@ const core_descriptor_t& get_core_descriptor_config(
 
 const std::tuple<uint32_t, CoreRange>& get_physical_worker_grid_config(
     ChipId chip, uint8_t num_hw_cqs, const tt_metal::DispatchCoreConfig& dispatch_core_config);
-
-std::optional<uint32_t> get_storage_core_bank_size(
-    ChipId device_id, uint8_t num_hw_cqs, const tt_metal::DispatchCoreConfig& dispatch_core_config);
-
-inline const std::vector<CoreCoord>& get_logical_storage_cores(
-    ChipId device_id, const uint8_t num_hw_cqs, const tt_metal::DispatchCoreConfig& dispatch_core_config) {
-    const core_descriptor_t& core_desc = get_core_descriptor_config(device_id, num_hw_cqs, dispatch_core_config);
-    return core_desc.logical_storage_cores;
-}
 
 inline const CoreCoord& get_compute_grid_size(
     ChipId device_id, const uint8_t num_hw_cqs, const tt_metal::DispatchCoreConfig& dispatch_core_config) {


### PR DESCRIPTION
Storage-only cores are not a thing since Grayskull. Code still exists to support them, which adds bloat and got in the way of some new development.

### Ticket
No issue

### Problem description
For example, to reduce some initialization times we desire to NOC multicast to tensix cores from Host, but cannot do so cleanly as the tensix storage-only cores must be avoided (i.e. the possibility of them since they are defined in SW). So at this time it is preferable to remove support for this non-existent hardware feature.

### What's changed
Searched and removed as appropriate all code pertaining to storage-only cores. Stubbed a `device` API as it may be used by other layers.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [?] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) _*mostly*_ CI passes (failures seem to be job setup problem: https://github.com/tenstorrent/tt-metal/actions/runs/19124757744) (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes