### PR TITLE
Add Stable Sort flag for TopK - Metal

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_topk.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_topk.h
@@ -13,21 +13,21 @@ using namespace sfpi;
 namespace ckernel {
 namespace sfpu {
 
-template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS = 8>
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, bool STABLE_SORT = false>
 inline void calculate_bitonic_topk_phases_steps(
     uint idir, uint i_end_phase, uint i_start_phase, uint i_end_step, uint i_start_step) {
-    _bitonic_topk_phases_steps<APPROXIMATION_MODE, is_fp32_dest_acc_en, ITERATIONS>(
+    _bitonic_topk_phases_steps<APPROXIMATION_MODE, is_fp32_dest_acc_en, STABLE_SORT>(
         idir, i_end_phase, i_start_phase, i_end_step, i_start_step);
 }
 
-template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, bool idir = false, int ITERATIONS = 8>
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, bool idir = false, bool STABLE_SORT = false>
 inline void calculate_bitonic_topk_merge(uint m_iter, uint k) {
-    _bitonic_topk_merge<APPROXIMATION_MODE, is_fp32_dest_acc_en, idir, ITERATIONS>(m_iter, k);
+    _bitonic_topk_merge<APPROXIMATION_MODE, is_fp32_dest_acc_en, idir, STABLE_SORT>(m_iter, k);
 }
 
-template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS = 8>
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, bool STABLE_SORT = false>
 inline void calculate_bitonic_topk_rebuild(uint idir, uint m_iter, uint k, uint logk, uint skip_second) {
-    _bitonic_topk_rebuild<APPROXIMATION_MODE, is_fp32_dest_acc_en, ITERATIONS>(idir, m_iter, k, logk, skip_second);
+    _bitonic_topk_rebuild<APPROXIMATION_MODE, is_fp32_dest_acc_en, STABLE_SORT>(idir, m_iter, k, logk, skip_second);
 }
 
 template <bool APPROXIMATION_MODE>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_topk.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_topk.h
@@ -16,7 +16,7 @@ inline void llk_math_eltwise_unary_sfpu_topk_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::topk_local_sort, APPROXIMATE>(sfpu::topk_init<APPROXIMATE>);
 }
 
-template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
+template <bool APPROXIMATE, bool is_fp32_dest_acc_en, bool STABLE_SORT = false>
 inline void llk_math_eltwise_unary_sfpu_topk_local_sort(
     uint dst_index,
     int idir,
@@ -26,7 +26,7 @@ inline void llk_math_eltwise_unary_sfpu_topk_local_sort(
     int i_start_step,
     int vector_mode = (int)VectorMode::RC_custom) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_bitonic_topk_phases_steps<APPROXIMATE, is_fp32_dest_acc_en>,
+        ckernel::sfpu::calculate_bitonic_topk_phases_steps<APPROXIMATE, is_fp32_dest_acc_en, STABLE_SORT>,
         dst_index,
         vector_mode,
         idir,
@@ -36,18 +36,18 @@ inline void llk_math_eltwise_unary_sfpu_topk_local_sort(
         i_start_step);
 }
 
-template <bool APPROXIMATE, bool is_fp32_dest_acc_en, bool idir = false>
+template <bool APPROXIMATE, bool is_fp32_dest_acc_en, bool idir = false, bool STABLE_SORT = false>
 inline void llk_math_eltwise_unary_sfpu_topk_merge(
     uint dst_index, int m_iter, int k, int vector_mode = (int)VectorMode::RC_custom) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_bitonic_topk_merge<APPROXIMATE, is_fp32_dest_acc_en, idir>,
+        ckernel::sfpu::calculate_bitonic_topk_merge<APPROXIMATE, is_fp32_dest_acc_en, idir, STABLE_SORT>,
         dst_index,
         vector_mode,
         m_iter,
         k);
 }
 
-template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
+template <bool APPROXIMATE, bool is_fp32_dest_acc_en, bool STABLE_SORT = false>
 inline void llk_math_eltwise_unary_sfpu_topk_rebuild(
     uint dst_index,
     bool idir,
@@ -57,7 +57,7 @@ inline void llk_math_eltwise_unary_sfpu_topk_rebuild(
     int skip_second,
     int vector_mode = (int)VectorMode::RC_custom) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_bitonic_topk_rebuild<APPROXIMATE, is_fp32_dest_acc_en>,
+        ckernel::sfpu::calculate_bitonic_topk_rebuild<APPROXIMATE, is_fp32_dest_acc_en, STABLE_SORT>,
         dst_index,
         vector_mode,
         idir,

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_topk.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_topk.h
@@ -13,21 +13,21 @@ using namespace sfpi;
 namespace ckernel {
 namespace sfpu {
 
-template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS = 8>
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, bool STABLE_SORT = false>
 inline void calculate_bitonic_topk_phases_steps(
     uint idir, uint i_end_phase, uint i_start_phase, uint i_end_step, uint i_start_step) {
-    _bitonic_topk_phases_steps<APPROXIMATION_MODE, is_fp32_dest_acc_en, ITERATIONS>(
+    _bitonic_topk_phases_steps<APPROXIMATION_MODE, is_fp32_dest_acc_en, STABLE_SORT>(
         idir, i_end_phase, i_start_phase, i_end_step, i_start_step);
 }
 
-template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, bool idir = false, int ITERATIONS = 8>
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, bool idir = false, bool STABLE_SORT = false>
 inline void calculate_bitonic_topk_merge(uint m_iter, uint k) {
-    _bitonic_topk_merge<APPROXIMATION_MODE, is_fp32_dest_acc_en, idir, ITERATIONS>(m_iter, k);
+    _bitonic_topk_merge<APPROXIMATION_MODE, is_fp32_dest_acc_en, idir, STABLE_SORT>(m_iter, k);
 }
 
-template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS = 8>
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, bool STABLE_SORT = false>
 inline void calculate_bitonic_topk_rebuild(uint idir, uint m_iter, uint k, uint logk, uint skip_second) {
-    _bitonic_topk_rebuild<APPROXIMATION_MODE, is_fp32_dest_acc_en, ITERATIONS>(idir, m_iter, k, logk, skip_second);
+    _bitonic_topk_rebuild<APPROXIMATION_MODE, is_fp32_dest_acc_en, STABLE_SORT>(idir, m_iter, k, logk, skip_second);
 }
 
 template <bool APPROXIMATION_MODE>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_topk.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_topk.h
@@ -16,7 +16,7 @@ inline void llk_math_eltwise_unary_sfpu_topk_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::topk_local_sort, APPROXIMATE>(sfpu::topk_init<APPROXIMATE>);
 }
 
-template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
+template <bool APPROXIMATE, bool is_fp32_dest_acc_en, bool STABLE_SORT = false>
 inline void llk_math_eltwise_unary_sfpu_topk_local_sort(
     uint dst_index,
     int idir,
@@ -26,7 +26,7 @@ inline void llk_math_eltwise_unary_sfpu_topk_local_sort(
     int i_start_step,
     int vector_mode = (int)VectorMode::RC_custom) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_bitonic_topk_phases_steps<APPROXIMATE, is_fp32_dest_acc_en>,
+        ckernel::sfpu::calculate_bitonic_topk_phases_steps<APPROXIMATE, is_fp32_dest_acc_en, STABLE_SORT>,
         dst_index,
         vector_mode,
         idir,
@@ -36,18 +36,18 @@ inline void llk_math_eltwise_unary_sfpu_topk_local_sort(
         i_start_step);
 }
 
-template <bool APPROXIMATE, bool is_fp32_dest_acc_en, bool idir = false>
+template <bool APPROXIMATE, bool is_fp32_dest_acc_en, bool idir = false, bool STABLE_SORT = false>
 inline void llk_math_eltwise_unary_sfpu_topk_merge(
     uint dst_index, int m_iter, int k, int vector_mode = (int)VectorMode::RC_custom) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_bitonic_topk_merge<APPROXIMATE, is_fp32_dest_acc_en, idir>,
+        ckernel::sfpu::calculate_bitonic_topk_merge<APPROXIMATE, is_fp32_dest_acc_en, idir, STABLE_SORT>,
         dst_index,
         vector_mode,
         m_iter,
         k);
 }
 
-template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
+template <bool APPROXIMATE, bool is_fp32_dest_acc_en, bool STABLE_SORT = false>
 inline void llk_math_eltwise_unary_sfpu_topk_rebuild(
     uint dst_index,
     bool idir,
@@ -57,7 +57,7 @@ inline void llk_math_eltwise_unary_sfpu_topk_rebuild(
     int skip_second,
     int vector_mode = (int)VectorMode::RC_custom) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_bitonic_topk_rebuild<APPROXIMATE, is_fp32_dest_acc_en>,
+        ckernel::sfpu::calculate_bitonic_topk_rebuild<APPROXIMATE, is_fp32_dest_acc_en, STABLE_SORT>,
         dst_index,
         vector_mode,
         idir,

--- a/tt_metal/include/compute_kernel_api.h
+++ b/tt_metal/include/compute_kernel_api.h
@@ -471,7 +471,7 @@ ALWI void silu_tile_init() { MATH((llk_math_eltwise_unary_sfpu_silu_init<APPROX>
  * | i_start_phase   | The start phase of the local sort (should be set to 0)                     | int32    | 0 to 5                                                | False    |
  * | i_end_step      | The end step to perform if i_start_phase == i_end_phase                    | int32    | 4 to 6                                                | False    |
  * | i_start_step    | The start step to perform if i_start_phase == i_end_phase                  | int32    | 4 to 6                                                | False    |
- * | STABLE_SORT     | Maintain order of indices for equal values                                 | bool     | true, false                                           | False    |
+ * | stable_sort     | Maintain order of indices for equal values                                 | bool     | true, false                                           | False    |
  */
 // clang-format on
 template <bool stable_sort = false>
@@ -509,7 +509,7 @@ ALWI void topk_local_sort(
  * | idst            | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
  * | m_iter          | The index of the merge & rebuild iteration of the algorithm                | int32    | 0 to 9                                                | True     |
  * | k               | The number of sorted values to return                                      | int32    | {4, 8, 16, 32, 64}                                    | True     |
- * | STABLE_SORT     | Maintain order of indices for equal values                                 | bool     | true, false                                           | False    |
+ * | stable_sort     | Maintain order of indices for equal values                                 | bool     | true, false                                           | False    |
  */
 // clang-format on
 template <bool idir = false, bool stable_sort = false>
@@ -547,7 +547,7 @@ ALWI void topk_merge(uint32_t idst, int m_iter, int k) {
  * | k               | The number of sorted values to return                                      | int32    | {4, 8, 16, 32, 64}                                    | True     |
  * | logk            | The log of K                                                               | int32    | 2 to 6                                                | True     |
  * | skip_second     | Whether or not to skip second tile                                         | int32    | 0 to 1                                                | True     |
- * | STABLE_SORT     | Maintain order of indices for equal values                                 | bool     | true, false                                           | False    |
+ * | stable_sort     | Maintain order of indices for equal values                                 | bool     | true, false                                           | False    |
  */
 // clang-format on
 template <bool stable_sort = false>

--- a/tt_metal/include/compute_kernel_api.h
+++ b/tt_metal/include/compute_kernel_api.h
@@ -474,10 +474,10 @@ ALWI void silu_tile_init() { MATH((llk_math_eltwise_unary_sfpu_silu_init<APPROX>
  * | STABLE_SORT     | Maintain order of indices for equal values                                 | bool     | true, false                                           | False    |
  */
 // clang-format on
-template <bool STABLE_SORT = false>
+template <bool stable_sort = false>
 ALWI void topk_local_sort(
     uint32_t idst, int idir, int i_end_phase, int i_start_phase = 0, int i_end_step = 0, int i_start_step = 0) {
-    MATH((llk_math_eltwise_unary_sfpu_topk_local_sort<true, DST_ACCUM_MODE, STABLE_SORT>(
+    MATH((llk_math_eltwise_unary_sfpu_topk_local_sort<true, DST_ACCUM_MODE, stable_sort>(
         idst, idir, i_end_phase, i_start_phase, i_end_step, i_start_step)));
 }
 
@@ -512,9 +512,9 @@ ALWI void topk_local_sort(
  * | STABLE_SORT     | Maintain order of indices for equal values                                 | bool     | true, false                                           | False    |
  */
 // clang-format on
-template <bool idir = false, bool STABLE_SORT = false>
+template <bool idir = false, bool stable_sort = false>
 ALWI void topk_merge(uint32_t idst, int m_iter, int k) {
-    MATH((llk_math_eltwise_unary_sfpu_topk_merge<true, DST_ACCUM_MODE, idir, STABLE_SORT>(idst, m_iter, k)));
+    MATH((llk_math_eltwise_unary_sfpu_topk_merge<true, DST_ACCUM_MODE, idir, stable_sort>(idst, m_iter, k)));
 }
 
 // topK rebuild
@@ -550,9 +550,9 @@ ALWI void topk_merge(uint32_t idst, int m_iter, int k) {
  * | STABLE_SORT     | Maintain order of indices for equal values                                 | bool     | true, false                                           | False    |
  */
 // clang-format on
-template <bool STABLE_SORT = false>
+template <bool stable_sort = false>
 ALWI void topk_rebuild(uint32_t idst, bool idir, int m_iter, int k, int logk, int skip_second) {
-    MATH((llk_math_eltwise_unary_sfpu_topk_rebuild<true, DST_ACCUM_MODE, STABLE_SORT>(
+    MATH((llk_math_eltwise_unary_sfpu_topk_rebuild<true, DST_ACCUM_MODE, stable_sort>(
         idst, idir, m_iter, k, logk, skip_second)));
 }
 

--- a/tt_metal/include/compute_kernel_api.h
+++ b/tt_metal/include/compute_kernel_api.h
@@ -471,11 +471,13 @@ ALWI void silu_tile_init() { MATH((llk_math_eltwise_unary_sfpu_silu_init<APPROX>
  * | i_start_phase   | The start phase of the local sort (should be set to 0)                     | int32    | 0 to 5                                                | False    |
  * | i_end_step      | The end step to perform if i_start_phase == i_end_phase                    | int32    | 4 to 6                                                | False    |
  * | i_start_step    | The start step to perform if i_start_phase == i_end_phase                  | int32    | 4 to 6                                                | False    |
+ * | STABLE_SORT     | Maintain order of indices for equal values                                 | bool     | true, false                                           | False    |
  */
 // clang-format on
+template <bool STABLE_SORT = false>
 ALWI void topk_local_sort(
     uint32_t idst, int idir, int i_end_phase, int i_start_phase = 0, int i_end_step = 0, int i_start_step = 0) {
-    MATH((llk_math_eltwise_unary_sfpu_topk_local_sort<true, DST_ACCUM_MODE>(
+    MATH((llk_math_eltwise_unary_sfpu_topk_local_sort<true, DST_ACCUM_MODE, STABLE_SORT>(
         idst, idir, i_end_phase, i_start_phase, i_end_step, i_start_step)));
 }
 
@@ -507,11 +509,12 @@ ALWI void topk_local_sort(
  * | idst            | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
  * | m_iter          | The index of the merge & rebuild iteration of the algorithm                | int32    | 0 to 9                                                | True     |
  * | k               | The number of sorted values to return                                      | int32    | {4, 8, 16, 32, 64}                                    | True     |
+ * | STABLE_SORT     | Maintain order of indices for equal values                                 | bool     | true, false                                           | False    |
  */
 // clang-format on
-template <bool idir = false>
+template <bool idir = false, bool STABLE_SORT = false>
 ALWI void topk_merge(uint32_t idst, int m_iter, int k) {
-    MATH((llk_math_eltwise_unary_sfpu_topk_merge<true, DST_ACCUM_MODE, idir>(idst, m_iter, k)));
+    MATH((llk_math_eltwise_unary_sfpu_topk_merge<true, DST_ACCUM_MODE, idir, STABLE_SORT>(idst, m_iter, k)));
 }
 
 // topK rebuild
@@ -544,10 +547,13 @@ ALWI void topk_merge(uint32_t idst, int m_iter, int k) {
  * | k               | The number of sorted values to return                                      | int32    | {4, 8, 16, 32, 64}                                    | True     |
  * | logk            | The log of K                                                               | int32    | 2 to 6                                                | True     |
  * | skip_second     | Whether or not to skip second tile                                         | int32    | 0 to 1                                                | True     |
+ * | STABLE_SORT     | Maintain order of indices for equal values                                 | bool     | true, false                                           | False    |
  */
 // clang-format on
+template <bool STABLE_SORT = false>
 ALWI void topk_rebuild(uint32_t idst, bool idir, int m_iter, int k, int logk, int skip_second) {
-    MATH((llk_math_eltwise_unary_sfpu_topk_rebuild<true, DST_ACCUM_MODE>(idst, idir, m_iter, k, logk, skip_second)));
+    MATH((llk_math_eltwise_unary_sfpu_topk_rebuild<true, DST_ACCUM_MODE, STABLE_SORT>(
+        idst, idir, m_iter, k, logk, skip_second)));
 }
 
 /**


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/20625

### Problem description
TopK sorting algo will sometimes swap indices which have the same value, while it does give the correct topk values, there are applications in metal for maintaining the original order when looking at the indices

### What's changed
- Modified SFPU code to ensure indices with the same value maintain their ordering at all steps
- Performed initial round of optimizations for stable sort, also improving code clarity
- Cleaned up the UNCONDITIONAL swaps in some of the phase steps for both stable and unstable implementations
- Removed an unused template parameter (ITERATIONS)

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/19125147831) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/19125151749) CI with demo tests passes (if applicable)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/runs/19125177760) CI passes (if applicable)