### PR TITLE
Update outdated python-multipart lib for security

### DIFF
--- a/models/demos/yolov10x/web_demo/server/requirements.txt
+++ b/models/demos/yolov10x/web_demo/server/requirements.txt
@@ -1,5 +1,5 @@
 fastapi==0.85.1
 uvicorn==0.19.0
-python-multipart==0.0.5
+python-multipart==0.0.20
 
 -f https://download.pytorch.org/whl/cpu/torch_stable.html

--- a/models/demos/yolov11/web_demo/server/requirements.txt
+++ b/models/demos/yolov11/web_demo/server/requirements.txt
@@ -1,5 +1,5 @@
 fastapi==0.85.1
 uvicorn==0.19.0
-python-multipart==0.0.5
+python-multipart==0.0.20
 
 -f https://download.pytorch.org/whl/cpu/torch_stable.html

--- a/models/demos/yolov11m/web_demo/server/requirements.txt
+++ b/models/demos/yolov11m/web_demo/server/requirements.txt
@@ -1,5 +1,5 @@
 fastapi==0.85.1
 uvicorn==0.19.0
-python-multipart==0.0.5
+python-multipart==0.0.20
 
 -f https://download.pytorch.org/whl/cpu/torch_stable.html

--- a/models/demos/yolov4/web_demo/server/requirements.txt
+++ b/models/demos/yolov4/web_demo/server/requirements.txt
@@ -1,5 +1,5 @@
 fastapi==0.85.1
 uvicorn==0.19.0
-python-multipart==0.0.5
+python-multipart==0.0.20
 
 -f https://download.pytorch.org/whl/cpu/torch_stable.html

--- a/models/demos/yolov6l/web_demo/server/requirements.txt
+++ b/models/demos/yolov6l/web_demo/server/requirements.txt
@@ -1,5 +1,5 @@
 fastapi==0.85.1
 uvicorn==0.19.0
-python-multipart==0.0.5
+python-multipart==0.0.20
 
 -f https://download.pytorch.org/whl/cpu/torch_stable.html

--- a/models/demos/yolov7/web_demo/server/requirements.txt
+++ b/models/demos/yolov7/web_demo/server/requirements.txt
@@ -1,5 +1,5 @@
 fastapi==0.85.1
 uvicorn==0.19.0
-python-multipart==0.0.5
+python-multipart==0.0.20
 
 -f https://download.pytorch.org/whl/cpu/torch_stable.html

--- a/models/demos/yolov8s/web_demo/server/requirements.txt
+++ b/models/demos/yolov8s/web_demo/server/requirements.txt
@@ -1,5 +1,5 @@
 fastapi==0.85.1
 uvicorn==0.19.0
-python-multipart==0.0.5
+python-multipart==0.0.20
 
 -f https://download.pytorch.org/whl/cpu/torch_stable.html

--- a/models/demos/yolov8s_world/web_demo/server/requirements.txt
+++ b/models/demos/yolov8s_world/web_demo/server/requirements.txt
@@ -1,5 +1,5 @@
 fastapi==0.85.1
 uvicorn==0.19.0
-python-multipart==0.0.5
+python-multipart==0.0.20
 
 -f https://download.pytorch.org/whl/cpu/torch_stable.html

--- a/models/demos/yolov8x/web_demo/server/requirements.txt
+++ b/models/demos/yolov8x/web_demo/server/requirements.txt
@@ -1,5 +1,5 @@
 fastapi==0.85.1
 uvicorn==0.19.0
-python-multipart==0.0.5
+python-multipart==0.0.20
 
 -f https://download.pytorch.org/whl/cpu/torch_stable.html

--- a/models/demos/yolov9c/web_demo/server/requirements.txt
+++ b/models/demos/yolov9c/web_demo/server/requirements.txt
@@ -1,5 +1,5 @@
 fastapi==0.85.1
 uvicorn==0.19.0
-python-multipart==0.0.5
+python-multipart==0.0.20
 
 -f https://download.pytorch.org/whl/cpu/torch_stable.html


### PR DESCRIPTION
### Ticket
N/A

### Problem description
python-multilib <= v0.0.6 had security vulnerabilities.

### What's changed
python-multilib now set to latest 0.0.20

### Checklist

- [x] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/19126460489 (the straggler is timing out on main)
- [x] New/Existing tests provide coverage for changes