### PR TITLE
Upgrade opencv-python to 4.8.1.78 for security

### DIFF
--- a/models/demos/yolov10x/web_demo/client/requirements.txt
+++ b/models/demos/yolov10x/web_demo/client/requirements.txt
@@ -1,4 +1,4 @@
-opencv-python==4.12.0.88
+opencv-python==4.8.1.78
 streamlit==1.26.0
 streamlit-webrtc==0.47.0
 orjson==3.10.12

--- a/models/demos/yolov10x/web_demo/client/requirements.txt
+++ b/models/demos/yolov10x/web_demo/client/requirements.txt
@@ -1,4 +1,4 @@
-opencv-python==4.6.0.66
+opencv-python==4.12.0.88
 streamlit==1.26.0
 streamlit-webrtc==0.47.0
 orjson==3.10.12

--- a/models/demos/yolov11/web_demo/client/requirements.txt
+++ b/models/demos/yolov11/web_demo/client/requirements.txt
@@ -1,4 +1,4 @@
-opencv-python==4.12.0.88
+opencv-python==4.8.1.78
 streamlit==1.26.0
 streamlit-webrtc==0.47.0
 orjson==3.10.12

--- a/models/demos/yolov11/web_demo/client/requirements.txt
+++ b/models/demos/yolov11/web_demo/client/requirements.txt
@@ -1,4 +1,4 @@
-opencv-python==4.6.0.66
+opencv-python==4.12.0.88
 streamlit==1.26.0
 streamlit-webrtc==0.47.0
 orjson==3.10.12

--- a/models/demos/yolov11m/web_demo/client/requirements.txt
+++ b/models/demos/yolov11m/web_demo/client/requirements.txt
@@ -1,4 +1,4 @@
-opencv-python==4.12.0.88
+opencv-python==4.8.1.78
 streamlit==1.26.0
 streamlit-webrtc==0.47.0
 orjson==3.10.12

--- a/models/demos/yolov11m/web_demo/client/requirements.txt
+++ b/models/demos/yolov11m/web_demo/client/requirements.txt
@@ -1,4 +1,4 @@
-opencv-python==4.6.0.66
+opencv-python==4.12.0.88
 streamlit==1.26.0
 streamlit-webrtc==0.47.0
 orjson==3.10.12

--- a/models/demos/yolov4/web_demo/client/requirements.txt
+++ b/models/demos/yolov4/web_demo/client/requirements.txt
@@ -1,4 +1,4 @@
-opencv-python==4.12.0.88
+opencv-python==4.8.1.78
 streamlit==1.26.0
 streamlit-webrtc==0.47.0
 orjson==3.10.12

--- a/models/demos/yolov4/web_demo/client/requirements.txt
+++ b/models/demos/yolov4/web_demo/client/requirements.txt
@@ -1,4 +1,4 @@
-opencv-python==4.6.0.66
+opencv-python==4.12.0.88
 streamlit==1.26.0
 streamlit-webrtc==0.47.0
 orjson==3.10.12

--- a/models/demos/yolov6l/web_demo/client/requirements.txt
+++ b/models/demos/yolov6l/web_demo/client/requirements.txt
@@ -1,4 +1,4 @@
-opencv-python==4.12.0.88
+opencv-python==4.8.1.78
 streamlit==1.26.0
 streamlit-webrtc==0.47.0
 orjson==3.10.12

--- a/models/demos/yolov6l/web_demo/client/requirements.txt
+++ b/models/demos/yolov6l/web_demo/client/requirements.txt
@@ -1,4 +1,4 @@
-opencv-python==4.6.0.66
+opencv-python==4.12.0.88
 streamlit==1.26.0
 streamlit-webrtc==0.47.0
 orjson==3.10.12

--- a/models/demos/yolov7/web_demo/client/requirements.txt
+++ b/models/demos/yolov7/web_demo/client/requirements.txt
@@ -1,4 +1,4 @@
-opencv-python==4.12.0.88
+opencv-python==4.8.1.78
 streamlit==1.26.0
 streamlit-webrtc==0.47.0
 orjson==3.10.12

--- a/models/demos/yolov7/web_demo/client/requirements.txt
+++ b/models/demos/yolov7/web_demo/client/requirements.txt
@@ -1,4 +1,4 @@
-opencv-python==4.6.0.66
+opencv-python==4.12.0.88
 streamlit==1.26.0
 streamlit-webrtc==0.47.0
 orjson==3.10.12

--- a/models/demos/yolov8s/web_demo/client/requirements.txt
+++ b/models/demos/yolov8s/web_demo/client/requirements.txt
@@ -1,4 +1,4 @@
-opencv-python==4.12.0.88
+opencv-python==4.8.1.78
 streamlit==1.26.0
 streamlit-webrtc==0.47.0
 orjson==3.10.12

--- a/models/demos/yolov8s/web_demo/client/requirements.txt
+++ b/models/demos/yolov8s/web_demo/client/requirements.txt
@@ -1,4 +1,4 @@
-opencv-python==4.6.0.66
+opencv-python==4.12.0.88
 streamlit==1.26.0
 streamlit-webrtc==0.47.0
 orjson==3.10.12

--- a/models/demos/yolov8s_world/web_demo/client/requirements.txt
+++ b/models/demos/yolov8s_world/web_demo/client/requirements.txt
@@ -1,4 +1,4 @@
-opencv-python==4.12.0.88
+opencv-python==4.8.1.78
 streamlit==1.26.0
 streamlit-webrtc==0.47.0
 orjson==3.10.12

--- a/models/demos/yolov8s_world/web_demo/client/requirements.txt
+++ b/models/demos/yolov8s_world/web_demo/client/requirements.txt
@@ -1,4 +1,4 @@
-opencv-python==4.6.0.66
+opencv-python==4.12.0.88
 streamlit==1.26.0
 streamlit-webrtc==0.47.0
 orjson==3.10.12

--- a/models/demos/yolov8x/web_demo/client/requirements.txt
+++ b/models/demos/yolov8x/web_demo/client/requirements.txt
@@ -1,4 +1,4 @@
-opencv-python==4.12.0.88
+opencv-python==4.8.1.78
 streamlit==1.26.0
 streamlit-webrtc==0.47.0
 orjson==3.10.12

--- a/models/demos/yolov8x/web_demo/client/requirements.txt
+++ b/models/demos/yolov8x/web_demo/client/requirements.txt
@@ -1,4 +1,4 @@
-opencv-python==4.6.0.66
+opencv-python==4.12.0.88
 streamlit==1.26.0
 streamlit-webrtc==0.47.0
 orjson==3.10.12

--- a/models/demos/yolov9c/web_demo/client/requirements.txt
+++ b/models/demos/yolov9c/web_demo/client/requirements.txt
@@ -1,4 +1,4 @@
-opencv-python==4.12.0.88
+opencv-python==4.8.1.78
 streamlit==1.26.0
 streamlit-webrtc==0.47.0
 orjson==3.10.12

--- a/models/demos/yolov9c/web_demo/client/requirements.txt
+++ b/models/demos/yolov9c/web_demo/client/requirements.txt
@@ -1,4 +1,4 @@
-opencv-python==4.6.0.66
+opencv-python==4.12.0.88
 streamlit==1.26.0
 streamlit-webrtc==0.47.0
 orjson==3.10.12

--- a/models/experimental/yolov3/reference/models/common.py
+++ b/models/experimental/yolov3/reference/models/common.py
@@ -479,7 +479,7 @@ class DetectMultiBackend(nn.Module):
                 stride, names = int(d["stride"]), d["names"]
         elif dnn:  # ONNX OpenCV DNN
             LOGGER.info(f"Loading {w} for ONNX OpenCV DNN inference...")
-            check_requirements("opencv-python>=4.12.0.88")
+            check_requirements("opencv-python>=4.8.1.78")
             net = cv2.dnn.readNetFromONNX(w)
         elif onnx:  # ONNX Runtime
             LOGGER.info(f"Loading {w} for ONNX Runtime inference...")

--- a/models/experimental/yolov3/reference/models/common.py
+++ b/models/experimental/yolov3/reference/models/common.py
@@ -479,7 +479,7 @@ class DetectMultiBackend(nn.Module):
                 stride, names = int(d["stride"]), d["names"]
         elif dnn:  # ONNX OpenCV DNN
             LOGGER.info(f"Loading {w} for ONNX OpenCV DNN inference...")
-            check_requirements("opencv-python>=4.5.4")
+            check_requirements("opencv-python>=4.12.0.88")
             net = cv2.dnn.readNetFromONNX(w)
         elif onnx:  # ONNX Runtime
             LOGGER.info(f"Loading {w} for ONNX Runtime inference...")

--- a/tt_metal/python_env/requirements-dev.txt
+++ b/tt_metal/python_env/requirements-dev.txt
@@ -61,7 +61,7 @@ numba>=0.58.1
 librosa==0.10.0
 timm>=1.0.0
 ultralytics==8.3.107
-opencv-python-headless==4.12.0.88
+opencv-python-headless==4.8.1.78
 diffusers==0.35.1
 accelerate==1.7.0
 ftfy==6.1.1

--- a/tt_metal/python_env/requirements-dev.txt
+++ b/tt_metal/python_env/requirements-dev.txt
@@ -61,7 +61,7 @@ numba>=0.58.1
 librosa==0.10.0
 timm>=1.0.0
 ultralytics==8.3.107
-opencv-python-headless==4.8.1.78
+opencv-python-headless==4.12.0.88
 diffusers==0.35.1
 accelerate==1.7.0
 ftfy==6.1.1


### PR DESCRIPTION
### Ticket
N/A

### Problem description
opencv-python versions before v4.8.1.78 bundled libwebp binaries in wheels that are vulnerable to https://github.com/advisories/GHSA-j7hp-h8jx-5ppr.

### What's changed
Updated to opencv-python 4.8.1.78

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/19126980942
- [x] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/19127033105
- [x] New/Existing tests provide coverage for changes