### PR TITLE
Add validation for Eth FW Version consistency in GSD

### DIFF
--- a/tt_metal/fabric/physical_system_descriptor.hpp
+++ b/tt_metal/fabric/physical_system_descriptor.hpp
@@ -14,6 +14,7 @@
 #include <umd/device/types/cluster_descriptor_types.hpp>
 #include <tt-metalium/fabric_types.hpp>
 #include <umd/device/cluster_descriptor.hpp>
+#include <umd/device/utils/semver.hpp>
 #include <tt_stl/strong_type.hpp>
 #include <tt_stl/reflection.hpp>
 
@@ -198,6 +199,7 @@ public:
     const std::unordered_map<std::string, std::string>& get_host_mobo_name_map() const { return host_to_mobo_name_; }
     const std::unordered_map<std::string, uint32_t>& get_host_to_rank_map() const { return host_to_rank_; }
     const ExitNodeConnectionTable& get_exit_node_connection_table() const { return exit_node_connection_table_; }
+    const tt::umd::semver_t& get_ethernet_firmware_version() const { return ethernet_firmware_version_; }
     tt::TargetDevice get_target_device_type() const { return target_device_type_; }
     LocalEthernetMetrics query_local_ethernet_metrics() const;
 
@@ -206,6 +208,7 @@ public:
     std::unordered_map<std::string, std::string>& get_host_mobo_name_map() { return host_to_mobo_name_; }
     std::unordered_map<std::string, uint32_t>& get_host_to_rank_map() { return host_to_rank_; }
     ExitNodeConnectionTable& get_exit_node_connection_table() { return exit_node_connection_table_; }
+    tt::umd::semver_t& get_ethernet_firmware_version() { return ethernet_firmware_version_; }
 
     static const std::unique_ptr<tt::umd::Cluster> null_cluster;
 
@@ -224,6 +227,10 @@ private:
     void remove_unresolved_nodes();
     void resolve_hostname_uniqueness();
     void validate_graphs();
+    void validate_eth_fw_versions(
+        const tt::umd::semver_t& peer_ethernet_firmware_version,
+        const std::string& my_host_name,
+        const std::string& peer_host_name);
 
     const std::unique_ptr<tt::umd::Cluster>& cluster_;
     std::unique_ptr<umd::ClusterDescriptor> cluster_desc_ = nullptr;
@@ -237,6 +244,7 @@ private:
     std::unordered_map<std::string, uint32_t> host_to_rank_;
     ExitNodeConnectionTable exit_node_connection_table_;
     bool all_hostnames_unique_ = true;
+    tt::umd::semver_t ethernet_firmware_version_;
 };
 
 }  // namespace tt::tt_metal

--- a/tt_metal/fabric/protobuf/physical_system_descriptor.proto
+++ b/tt_metal/fabric/protobuf/physical_system_descriptor.proto
@@ -90,6 +90,12 @@ message ExitNodeConnectionTable {
     repeated ExitNodeConnection exit_connections = 2;
 }
 
+message EthernetFirmwareVersion {
+    uint32 major = 1;
+    uint32 minor = 2;
+    uint32 patch = 3;
+}
+
 // Top-level Physical System Descriptor message
 message PhysicalSystemDescriptor {
     PhysicalConnectivityGraph system_graph = 1;
@@ -98,4 +104,5 @@ message PhysicalSystemDescriptor {
     repeated HostToRankMap host_to_rank = 4;
     repeated ExitNodeConnectionTable exit_node_connection_table = 5;
     uint32 target_device_type = 6;
+    EthernetFirmwareVersion ethernet_firmware_version = 7;
 }

--- a/tt_metal/fabric/serialization/physical_system_descriptor_serialization.cpp
+++ b/tt_metal/fabric/serialization/physical_system_descriptor_serialization.cpp
@@ -195,6 +195,10 @@ void physical_system_descriptor_to_proto(
 
     // Set target device type
     proto_desc->set_target_device_type(static_cast<uint32_t>(descriptor.get_target_device_type()));
+    // Set ethernet firmware version
+    proto_desc->mutable_ethernet_firmware_version()->set_major(descriptor.get_ethernet_firmware_version().major);
+    proto_desc->mutable_ethernet_firmware_version()->set_minor(descriptor.get_ethernet_firmware_version().minor);
+    proto_desc->mutable_ethernet_firmware_version()->set_patch(descriptor.get_ethernet_firmware_version().patch);
 }
 
 // Convert protobuf to PhysicalSystemDescriptor
@@ -262,6 +266,11 @@ std::unique_ptr<PhysicalSystemDescriptor> proto_to_physical_system_descriptor(
 
         exit_node_connection_table[proto_table.host_name()] = std::move(exit_connections);
     }
+
+    // Set ethernet firmware version
+    descriptor->get_ethernet_firmware_version().major = proto_desc.ethernet_firmware_version().major();
+    descriptor->get_ethernet_firmware_version().minor = proto_desc.ethernet_firmware_version().minor();
+    descriptor->get_ethernet_firmware_version().patch = proto_desc.ethernet_firmware_version().patch();
 
     return descriptor;
 }


### PR DESCRIPTION
### Ticket
No Ticket.

### Problem description
 - All hosts in a distributed cluster are required to have the same Ethernet FW Version
 - If this condition is not met, undefined behaviour (such as random links going down) can be seen
 - This problem was seen on the ClosetBox after FW was inconsistently updated
 
### What's changed
- Store the Eth FW version for the local host and send this to the controller host
- Perform validation on controller host

creds @tt-aho for the idea 🚀 
### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes