### PR TITLE
Upgrade python-protobuf to 3.20.2 for security

### DIFF
--- a/models/tt_transformers/requirements.txt
+++ b/models/tt_transformers/requirements.txt
@@ -1,3 +1,3 @@
 git+https://github.com/tenstorrent/llama-models.git@tt_metal_tag
 # transformers==4.53.0
-# protobuf==3.20.0
+# protobuf==3.20.2

--- a/tt_metal/python_env/requirements-dev.txt
+++ b/tt_metal/python_env/requirements-dev.txt
@@ -32,7 +32,7 @@ mypy==1.9.0
 git+https://github.com/tenstorrent/llama-models.git@tt_metal_tag
 
 # For Mistral-7B-v0.3 demo tests
-protobuf==3.20.0
+protobuf==3.20.2
 
 # For TT-Transformers Qwen3 support
 transformers == 4.53.0


### PR DESCRIPTION
### Ticket
N/A

### Problem description
protobuf-python has a security issue in 3.20.0

### What's changed
protobuf-python upgraded to 3.20.2

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/19127604870
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/19127628106
- [x] New/Existing tests provide coverage for changes