### PR TITLE
[skip ci] ci: rename secret reference from `TEMP_METAL_PAT` to `LLK_UPLIFT_PAT` across all llk workflow configurations

### DIFF
--- a/.github/workflows/llk-auto-uplift-trigger.yaml
+++ b/.github/workflows/llk-auto-uplift-trigger.yaml
@@ -68,7 +68,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
-          token: ${{ secrets.TEMP_METAL_PAT }}
+          token: ${{ secrets.LLK_UPLIFT_PAT }}
           fetch-depth: 0
           ref: main
           clean: true
@@ -94,7 +94,7 @@ jobs:
           cd ${{ env.SUBMODULE_PATH }}
           OLD_SHA=$(git rev-parse --short=7 HEAD)
 
-          git remote set-url origin https://${{ secrets.TEMP_METAL_PAT }}@github.com/tenstorrent/tt-llk.git
+          git remote set-url origin https://${{ secrets.LLK_UPLIFT_PAT }}@github.com/tenstorrent/tt-llk.git
           git fetch origin main
           git checkout main
           git pull origin main
@@ -211,7 +211,7 @@ jobs:
         if: steps.update.outputs.has-changes == 'true'
         uses: peter-evans/create-pull-request@v7
         with:
-          token: ${{ secrets.TEMP_METAL_PAT }}
+          token: ${{ secrets.LLK_UPLIFT_PAT }}
           commit-message: "chore: update LLK submodule to ${{ steps.update.outputs.new-sha }}"
           title: "chore: update LLK submodule to ${{ steps.update.outputs.new-sha }}"
           branch: ${{ env.BRANCH_NAME }}
@@ -253,7 +253,7 @@ jobs:
       - name: Trigger and monitor workflow
         if: matrix.should-run == 'true'
         env:
-          GH_TOKEN: ${{ secrets.TEMP_METAL_PAT }}
+          GH_TOKEN: ${{ secrets.LLK_UPLIFT_PAT }}
         run: |
           PR_NUMBER="${{ needs.update-submodule.outputs.pr-number }}"
           WORKFLOW="${{ matrix.workflow }}"
@@ -380,12 +380,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.TEMP_METAL_PAT }}
+          token: ${{ secrets.LLK_UPLIFT_PAT }}
 
       - name: Check latest test runs
         id: check
         env:
-          GH_TOKEN: ${{ secrets.TEMP_METAL_PAT }}
+          GH_TOKEN: ${{ secrets.LLK_UPLIFT_PAT }}
         run: |
           # Find PR and get decisions
           PR_NUMBER=$(gh pr list --head "${{ env.BRANCH_NAME }}" --json number --jq '.[0].number // empty')
@@ -490,7 +490,7 @@ jobs:
 
       - name: Finalize PR
         env:
-          GH_TOKEN: ${{ secrets.TEMP_METAL_PAT }}
+          GH_TOKEN: ${{ secrets.LLK_UPLIFT_PAT }}
         run: |
           PR_NUMBER="${{ inputs.recheck_tests == true && needs.recheck-tests.outputs.pr-number || needs.update-submodule.outputs.pr-number }}"
 
@@ -596,7 +596,7 @@ jobs:
       - name: Auto-approve by codeowners
         if: success()
         env:
-          GH_TOKEN: ${{ secrets.TEMP_METAL_PAT }}
+          GH_TOKEN: ${{ secrets.LLK_UPLIFT_PAT }}
         run: |
           echo "🚀 Triggering auto-approval"
           gh workflow run "code-analysis.yaml" \

--- a/.github/workflows/test-llk-metal-integration.yaml
+++ b/.github/workflows/test-llk-metal-integration.yaml
@@ -64,7 +64,7 @@ env:
   WORKFLOW_TIMEOUT: ${{ inputs.workflow_timeout || 720 }}
   METAL_REPO: tenstorrent/tt-metal
   LLK_REPO: tenstorrent/tt-llk
-  GH_TOKEN: ${{ secrets.TEMP_METAL_PAT }}
+  GH_TOKEN: ${{ secrets.LLK_UPLIFT_PAT }}
   MAX_RETRIES: 3
   POLL_INTERVAL: 120
 
@@ -95,7 +95,7 @@ jobs:
         with:
           repository: tenstorrent/tt-metal
           submodules: recursive
-          token: ${{ secrets.TEMP_METAL_PAT }}
+          token: ${{ secrets.LLK_UPLIFT_PAT }}
           fetch-depth: 0
           ref: main
           clean: true
@@ -112,7 +112,7 @@ jobs:
           cd "$SUBMODULE_PATH"
 
           # Ensure correct remote and fetch mirrored branch
-          git remote set-url origin https://${{ secrets.TEMP_METAL_PAT }}@github.com/tenstorrent/tt-llk.git
+          git remote set-url origin https://${{ secrets.LLK_UPLIFT_PAT }}@github.com/tenstorrent/tt-llk.git
           if git fetch origin "$MIRRORED_BRANCH:$MIRRORED_BRANCH" 2>/dev/null; then
             echo "branch-exists=true" >> $GITHUB_OUTPUT
             echo "✅ Mirrored branch '$MIRRORED_BRANCH' exists in submodule"


### PR DESCRIPTION
### Ticket
None

### Problem description
We've been using 3 different PAT name for the same token throughout different repositories. Time to unify them under one name. It makes maintenance easier.

### What's changed
Use `LLK_UPLIFT_PAT` everywhere.
The new name better reflects the nature and specific purpose of this PAT for LLK submodule uplift operations.