### PR TITLE
Add Torus Validation System to Fabric Test Framework

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric.cpp
@@ -166,7 +166,12 @@ int main(int argc, char** argv) {
             topology,
             routing_type,
             fabric_tensix_config);
-        test_context.open_devices(test_config.fabric_setup);
+
+        bool open_devices_success = test_context.open_devices(test_config.fabric_setup);
+        if (!open_devices_success) {
+            log_info(tt::LogTest, "Skipping Test Group: {} due to unsupported fabric configuration", test_config.name);
+            continue;
+        }
         device_opened = true;
 
         for (uint32_t iter = 0; iter < test_config.num_top_level_iterations; ++iter) {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common.hpp
@@ -151,19 +151,10 @@ public:
 
         // Use the new ControlPlane validation API - always skip on mismatch
         const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
-        try {
-            if (!control_plane.is_fabric_config_valid(new_fabric_config)) {
-                log_warning(tt::LogTest, "Fabric configuration validation failed - can't open device");
-                return false;
-            }
-        } catch (const std::exception& e) {
-            log_warning(
-                tt::LogTest,
-                "Fabric configuration validation threw exception: {} - can't open device",
-                e.what());
+        if (!control_plane.is_fabric_config_valid(new_fabric_config)) {
+            log_warning(tt::LogTest, "Fabric configuration validation failed - can't open device");
             return false;
         }
-
 
         if (new_fabric_config != current_fabric_config_ || fabric_tensix_config != current_fabric_tensix_config_ ||
             reliability_mode != current_fabric_reliability_mode_) {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common.hpp
@@ -111,7 +111,7 @@ public:
             local_mesh_id_, MeshScope::LOCAL);
     }
 
-    void open_devices(const TestFabricSetup& fabric_setup) {
+    bool open_devices(const TestFabricSetup& fabric_setup) {
         const auto& topology = fabric_setup.topology;
         const auto& routing_type = fabric_setup.routing_type.value();
         const auto& fabric_tensix_config = fabric_setup.fabric_tensix_config.value();
@@ -149,6 +149,22 @@ public:
             new_fabric_config = it->second;
         }
 
+        // Use the new ControlPlane validation API - always skip on mismatch
+        const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+        try {
+            if (!control_plane.is_fabric_config_valid(new_fabric_config)) {
+                log_warning(tt::LogTest, "Fabric configuration validation failed - can't open device");
+                return false;
+            }
+        } catch (const std::exception& e) {
+            log_warning(
+                tt::LogTest,
+                "Fabric configuration validation threw exception: {} - can't open device",
+                e.what());
+            return false;
+        }
+
+
         if (new_fabric_config != current_fabric_config_ || fabric_tensix_config != current_fabric_tensix_config_ ||
             reliability_mode != current_fabric_reliability_mode_) {
             if (are_devices_open_) {
@@ -163,6 +179,7 @@ public:
         } else {
             log_info(tt::LogTest, "Reusing existing device setup with fabric config: {}", current_fabric_config_);
         }
+        return true;
     }
 
     void setup_workload() {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common.hpp
@@ -151,8 +151,15 @@ public:
 
         // Use the new ControlPlane validation API - always skip on mismatch
         const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
-        if (!control_plane.is_fabric_config_valid(new_fabric_config)) {
-            log_warning(tt::LogTest, "Fabric configuration validation failed - can't open device");
+        const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
+        try {
+            if (cluster.get_cluster_type() == tt::tt_metal::ClusterType::GALAXY &&
+                !control_plane.is_fabric_config_valid(new_fabric_config)) {
+                log_warning(tt::LogTest, "Fabric configuration validation failed - can't open device");
+                return false;
+            }
+        } catch (const std::exception& e) {
+            log_warning(tt::LogTest, "Fabric configuration validation failed: {} - can't open device", e.what());
             return false;
         }
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_context.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_context.hpp
@@ -351,7 +351,7 @@ public:
         }
     }
 
-    void open_devices(const TestFabricSetup& fabric_setup) { fixture_->open_devices(fabric_setup); }
+    bool open_devices(const TestFabricSetup& fabric_setup) { return fixture_->open_devices(fabric_setup); }
 
     void compile_programs() {
         fixture_->setup_workload();

--- a/tools/scaleout/CMakeLists.txt
+++ b/tools/scaleout/CMakeLists.txt
@@ -75,7 +75,6 @@ target_link_libraries(
 target_link_libraries(
     run_cluster_validation
     PRIVATE
-        TT::ScaleoutTools
         enchantum::enchantum
         protobuf::libprotobuf
         tt_metal

--- a/tools/scaleout/cabling_generator/cabling_generator.cpp
+++ b/tools/scaleout/cabling_generator/cabling_generator.cpp
@@ -14,6 +14,7 @@
 #include <filesystem>
 #include <fstream>
 #include <google/protobuf/text_format.h>
+#include <tt_stl/assert.hpp>
 #include <tt_stl/caseless_comparison.hpp>
 #include <tt_stl/reflection.hpp>
 #include <tt_stl/span.hpp>
@@ -213,7 +214,7 @@ std::unique_ptr<ResolvedGraphInstance> build_graph_instance(
         if (child_def.has_node_ref()) {
             // Leaf node - create node
             if (child_mapping.mapping_case() != tt::scaleout_tools::cabling_generator::proto::ChildMapping::kHostId) {
-                throw std::runtime_error("Node child must have host_id mapping: " + child_name);
+                TT_THROW("Node child must have host_id mapping: {}", child_name);
             }
 
             HostId host_id = HostId(child_mapping.host_id());
@@ -225,13 +226,16 @@ std::unique_ptr<ResolvedGraphInstance> build_graph_instance(
                 if (*host_id < deployment.hosts().size()) {
                     const auto& deployment_host = deployment.hosts()[*host_id];
                     if (!deployment_host.node_type().empty() && deployment_host.node_type() != node_descriptor_name) {
-                        throw std::runtime_error(
-                            "Node type mismatch for host " + deployment_host.host() + " (host_id " +
-                            std::to_string(*host_id) + "): " + "deployment specifies '" + deployment_host.node_type() +
-                            "' " + "but cluster configuration expects '" + node_descriptor_name + "'");
+                        TT_THROW(
+                            "Node type mismatch for host {} (host_id {}): deployment specifies '{}' "
+                            "but cluster configuration expects '{}'",
+                            deployment_host.host(),
+                            *host_id,
+                            deployment_host.node_type(),
+                            node_descriptor_name);
                     }
                 } else {
-                    throw std::runtime_error("Host ID " + std::to_string(*host_id) + " not found in deployment");
+                    TT_THROW("Host ID {} not found in deployment", *host_id);
                 }
             }
 
@@ -242,7 +246,7 @@ std::unique_ptr<ResolvedGraphInstance> build_graph_instance(
             // Non-leaf node - recursively build subgraph
             if (child_mapping.mapping_case() !=
                 tt::scaleout_tools::cabling_generator::proto::ChildMapping::kSubInstance) {
-                throw std::runtime_error("Graph child must have sub_instance mapping: " + child_name);
+                TT_THROW("Graph child must have sub_instance mapping: {}", child_name);
             }
 
             resolved->subgraphs[child_name] = build_graph_instance(

--- a/tools/scaleout/cabling_generator/cabling_generator.cpp
+++ b/tools/scaleout/cabling_generator/cabling_generator.cpp
@@ -192,7 +192,7 @@ HostId resolve_path_from_proto(
 
 // Builds a resolved graph instance from a graph instance and deployment descriptor.
 // deployment_descriptor is optional - if nullptr, no validation is performed.
-static std::unique_ptr<ResolvedGraphInstance> build_graph_instance_impl(
+std::unique_ptr<ResolvedGraphInstance> build_graph_instance_impl(
     const tt::scaleout_tools::cabling_generator::proto::GraphInstance& graph_instance,
     const tt::scaleout_tools::cabling_generator::proto::ClusterDescriptor& cluster_descriptor,
     const tt::scaleout_tools::deployment::proto::DeploymentDescriptor* deployment_descriptor,

--- a/tools/scaleout/cabling_generator/cabling_generator.cpp
+++ b/tools/scaleout/cabling_generator/cabling_generator.cpp
@@ -190,10 +190,12 @@ HostId resolve_path_from_proto(
 }
 
 // Build resolved graph instance from template and concrete host mappings
+// deployment_descriptor is optional - if std::nullopt, no validation is performed
 std::unique_ptr<ResolvedGraphInstance> build_graph_instance(
     const tt::scaleout_tools::cabling_generator::proto::GraphInstance& graph_instance,
     const tt::scaleout_tools::cabling_generator::proto::ClusterDescriptor& cluster_descriptor,
-    const tt::scaleout_tools::deployment::proto::DeploymentDescriptor& deployment_descriptor,
+    std::optional<std::reference_wrapper<const tt::scaleout_tools::deployment::proto::DeploymentDescriptor>>
+        deployment_descriptor,
     const std::string& instance_name,
     std::unordered_map<std::string, Node>& node_templates) {
     auto resolved = std::make_unique<ResolvedGraphInstance>();
@@ -217,20 +219,23 @@ std::unique_ptr<ResolvedGraphInstance> build_graph_instance(
             HostId host_id = HostId(child_mapping.host_id());
             const std::string& node_descriptor_name = child_def.node_ref().node_descriptor();
 
-            // Validate deployment node type if specified
-            if (*host_id < deployment_descriptor.hosts().size()) {
-                const auto& deployment_host = deployment_descriptor.hosts()[*host_id];
-                if (!deployment_host.node_type().empty() && deployment_host.node_type() != node_descriptor_name) {
-                    throw std::runtime_error(
-                        "Node type mismatch for host " + deployment_host.host() + " (host_id " +
-                        std::to_string(*host_id) + "): " + "deployment specifies '" + deployment_host.node_type() +
-                        "' " + "but cluster configuration expects '" + node_descriptor_name + "'");
+            // Validate deployment node type if deployment descriptor is provided
+            if (deployment_descriptor.has_value()) {
+                const auto& deployment = deployment_descriptor->get();
+                if (*host_id < deployment.hosts().size()) {
+                    const auto& deployment_host = deployment.hosts()[*host_id];
+                    if (!deployment_host.node_type().empty() && deployment_host.node_type() != node_descriptor_name) {
+                        throw std::runtime_error(
+                            "Node type mismatch for host " + deployment_host.host() + " (host_id " +
+                            std::to_string(*host_id) + "): " + "deployment specifies '" + deployment_host.node_type() +
+                            "' " + "but cluster configuration expects '" + node_descriptor_name + "'");
+                    }
+                } else {
+                    throw std::runtime_error("Host ID " + std::to_string(*host_id) + " not found in deployment");
                 }
-            } else {
-                throw std::runtime_error("Host ID " + std::to_string(*host_id) + " not found in deployment");
             }
 
-            // Find node descriptor and build node inside build_node
+            // Find node descriptor and build node
             resolved->nodes[child_name] = build_node(node_descriptor_name, host_id, cluster_descriptor, node_templates);
 
         } else if (child_def.has_graph_ref()) {
@@ -265,8 +270,6 @@ std::unique_ptr<ResolvedGraphInstance> build_graph_instance(
             HostId host_a_id = resolve_path_from_proto(path_a, graph_instance, cluster_descriptor);
             HostId host_b_id = resolve_path_from_proto(path_b, graph_instance, cluster_descriptor);
 
-            // Can't use create_port_connection here because we don't have all the nodes yet
-
             // Store connection with resolved HostId
             resolved->internal_connections[*port_type].emplace_back(
                 std::make_tuple(host_a_id, board_a_id, port_a_id), std::make_tuple(host_b_id, board_b_id, port_b_id));
@@ -294,9 +297,31 @@ void populate_deployment_hosts(
     }
 }
 
+void populate_deployment_hosts_from_hostnames(
+    const std::vector<std::string>& hostnames,
+    const std::map<HostId, Node*>& host_id_to_node,
+    std::vector<Host>& deployment_hosts) {
+    // Store deployment hosts with just hostname and motherboard (no physical location info)
+    deployment_hosts.reserve(hostnames.size());
+    for (size_t i = 0; i < hostnames.size(); ++i) {
+        HostId host_id = HostId(i);
+        auto it = host_id_to_node.find(host_id);
+        if (it == host_id_to_node.end()) {
+            throw std::runtime_error("Host ID " + std::to_string(i) + " not found in cluster configuration");
+        }
+        deployment_hosts.emplace_back(Host{
+            .hostname = hostnames[i],
+            .hall = "",
+            .aisle = "",
+            .rack = 0,
+            .shelf_u = 0,
+            .motherboard = it->second->motherboard});
+    }
+}
+
 }  // anonymous namespace
 
-// Constructor
+// Constructor with full deployment descriptor
 CablingGenerator::CablingGenerator(
     const std::string& cluster_descriptor_path, const std::string& deployment_descriptor_path) {
     // Load descriptors from file paths
@@ -324,6 +349,30 @@ CablingGenerator::CablingGenerator(
     populate_deployment_hosts(deployment_descriptor, node_templates_, deployment_hosts_);
 }
 
+// Constructor with just hostnames (no physical location info)
+CablingGenerator::CablingGenerator(
+    const std::string& cluster_descriptor_path, const std::vector<std::string>& hostnames) {
+    // Load cluster descriptor
+    auto cluster_descriptor =
+        load_descriptor_from_textproto<tt::scaleout_tools::cabling_generator::proto::ClusterDescriptor>(
+            cluster_descriptor_path);
+
+    // Build cluster with all connections and port validation (without deployment descriptor)
+    root_instance_ = build_graph_instance(cluster_descriptor.root_instance(), cluster_descriptor, "", node_templates_);
+
+    // Validate host_id uniqueness across all nodes
+    validate_host_id_uniqueness();
+
+    // Populate the host_id_to_node_ map
+    populate_host_id_to_node();
+
+    // Generate all logical chip connections
+    generate_logical_chip_connections();
+
+    // Populate deployment hosts from hostnames
+    populate_deployment_hosts_from_hostnames(hostnames, host_id_to_node_, deployment_hosts_);
+}
+
 // Getters for all data
 const std::vector<Host>& CablingGenerator::get_deployment_hosts() const { return deployment_hosts_; }
 
@@ -331,13 +380,16 @@ const std::vector<LogicalChannelConnection>& CablingGenerator::get_chip_connecti
     return chip_connections_;
 }
 
-// Method to emit textproto factory system descriptor
-void CablingGenerator::emit_factory_system_descriptor(const std::string& output_path) const {
+// Helper function to build factory system descriptor protobuf (shared between emit and generate_string methods)
+static tt::scaleout_tools::fsd::proto::FactorySystemDescriptor build_factory_system_descriptor(
+    const std::vector<Host>& deployment_hosts,
+    const std::map<HostId, Node*>& host_id_to_node,
+    const std::vector<LogicalChannelConnection>& chip_connections) {
     tt::scaleout_tools::fsd::proto::FactorySystemDescriptor fsd;
 
     // Add host information from deployment hosts (indexed by host_id)
-    for (size_t i = 0; i < deployment_hosts_.size(); ++i) {
-        const auto& deployment_host = deployment_hosts_[i];
+    for (size_t i = 0; i < deployment_hosts.size(); ++i) {
+        const auto& deployment_host = deployment_hosts[i];
         auto* host = fsd.add_hosts();
         host->set_hostname(deployment_host.hostname);
         host->set_hall(deployment_host.hall);
@@ -348,7 +400,7 @@ void CablingGenerator::emit_factory_system_descriptor(const std::string& output_
     }
 
     // Add board types
-    for (const auto& [host_id, node] : host_id_to_node_) {
+    for (const auto& [host_id, node] : host_id_to_node) {
         for (const auto& [tray_id, board] : node->boards) {
             auto* board_location = fsd.mutable_board_types()->add_board_locations();
             board_location->set_host_id(*host_id);
@@ -357,8 +409,8 @@ void CablingGenerator::emit_factory_system_descriptor(const std::string& output_
         }
     }
 
-    // Add ASIC connections from chip_connections_
-    for (const auto& [start, end] : chip_connections_) {
+    // Add ASIC connections from chip_connections
+    for (const auto& [start, end] : chip_connections) {
         auto* connection = fsd.mutable_eth_connections()->add_connection();
 
         auto* endpoint_a = connection->mutable_endpoint_a();
@@ -373,6 +425,13 @@ void CablingGenerator::emit_factory_system_descriptor(const std::string& output_
         endpoint_b->set_asic_location(end.asic_channel.asic_location);
         endpoint_b->set_chan_id(*end.asic_channel.channel_id);
     }
+
+    return fsd;
+}
+
+// Method to emit textproto factory system descriptor
+void CablingGenerator::emit_factory_system_descriptor(const std::string& output_path) const {
+    auto fsd = build_factory_system_descriptor(deployment_hosts_, host_id_to_node_, chip_connections_);
 
     // Create parent directory if it doesn't exist
     std::filesystem::path output_file_path(output_path);
@@ -398,6 +457,11 @@ void CablingGenerator::emit_factory_system_descriptor(const std::string& output_
 
     output_file << output_string;
     output_file.close();
+}
+
+// Method to generate factory system descriptor as protobuf object (uses shared helper)
+tt::scaleout_tools::fsd::proto::FactorySystemDescriptor CablingGenerator::generate_factory_system_descriptor() const {
+    return build_factory_system_descriptor(deployment_hosts_, host_id_to_node_, chip_connections_);
 }
 
 void CablingGenerator::emit_cabling_guide_csv(const std::string& output_path, bool loc_info) const {

--- a/tools/scaleout/cabling_generator/cabling_generator.hpp
+++ b/tools/scaleout/cabling_generator/cabling_generator.hpp
@@ -14,6 +14,10 @@
 #include <board/board.hpp>
 #include <umd/device/types/cluster_descriptor_types.hpp>
 
+namespace tt::scaleout_tools::fsd::proto {
+    class FactorySystemDescriptor;
+}
+
 namespace tt::scaleout_tools {
 
 // Strong types to prevent mixing with other uint32_t values
@@ -95,8 +99,11 @@ CableLength calc_cable_length(
 
 class CablingGenerator {
 public:
-    // Constructor
+    // Constructor with full deployment descriptor (includes physical location info)
     CablingGenerator(const std::string& cluster_descriptor_path, const std::string& deployment_descriptor_path);
+
+    // Constructor with just hostnames (no physical location info)
+    CablingGenerator(const std::string& cluster_descriptor_path, const std::vector<std::string>& hostnames);
 
     // Getters for all data
     const std::vector<Host>& get_deployment_hosts() const;
@@ -104,6 +111,9 @@ public:
 
     // Method to emit factory system descriptor
     void emit_factory_system_descriptor(const std::string& output_path) const;
+
+    // Method to generate factory system descriptor as protobuf object
+    tt::scaleout_tools::fsd::proto::FactorySystemDescriptor generate_factory_system_descriptor() const;
 
     // Method to emit cabling guide CSV
     void emit_cabling_guide_csv(const std::string& output_path, bool loc_info = true) const;

--- a/tools/scaleout/factory_system_descriptor/utils.cpp
+++ b/tools/scaleout/factory_system_descriptor/utils.cpp
@@ -24,30 +24,14 @@
 
 namespace tt::scaleout_tools {
 
-std::set<PhysicalChannelConnection> validate_fsd_against_gsd(
-    const std::string& fsd_filename,
-    const std::string& gsd_filename,
+std::set<PhysicalChannelConnection> validate_fsd_against_gsd_impl(
+    const tt::scaleout_tools::fsd::proto::FactorySystemDescriptor& generated_fsd,
+    const YAML::Node& discovered_gsd,
     bool strict_validation,
     bool assert_on_connection_mismatch,
     bool log_output) {
-    // Read the generated FSD using protobuf
-    tt::scaleout_tools::fsd::proto::FactorySystemDescriptor generated_fsd;
-    std::ifstream fsd_file(fsd_filename);
-    if (!fsd_file.is_open()) {
-        throw std::runtime_error("Failed to open FSD file: " + fsd_filename);
-    }
-
-    std::string fsd_content((std::istreambuf_iterator<char>(fsd_file)), std::istreambuf_iterator<char>());
-    fsd_file.close();
-
-    if (!google::protobuf::TextFormat::ParseFromString(fsd_content, &generated_fsd)) {
-        throw std::runtime_error("Failed to parse FSD protobuf from file: " + fsd_filename);
-    }
 
     const auto& hosts = generated_fsd.hosts();
-
-    // Read the discovered GSD (Global System Descriptor) - still using YAML
-    YAML::Node discovered_gsd = YAML::LoadFile(gsd_filename);
 
     // Compare the FSD with the discovered GSD
     // First, compare hostnames from the hosts field
@@ -498,6 +482,50 @@ std::set<PhysicalChannelConnection> validate_fsd_against_gsd(
         }
     }
     return missing_in_gsd;
+}
+
+std::set<PhysicalChannelConnection> validate_fsd_against_gsd(
+    const std::string& fsd_filename,
+    const std::string& gsd_filename,
+    bool strict_validation,
+    bool assert_on_connection_mismatch,
+    bool log_output) {
+    // Read the generated FSD using protobuf
+    tt::scaleout_tools::fsd::proto::FactorySystemDescriptor generated_fsd;
+    std::ifstream fsd_file(fsd_filename);
+    if (!fsd_file.is_open()) {
+        throw std::runtime_error("Failed to open FSD file: " + fsd_filename);
+    }
+
+    std::string fsd_content((std::istreambuf_iterator<char>(fsd_file)), std::istreambuf_iterator<char>());
+    fsd_file.close();
+
+    if (!google::protobuf::TextFormat::ParseFromString(fsd_content, &generated_fsd)) {
+        throw std::runtime_error("Failed to parse FSD protobuf from file: " + fsd_filename);
+    }
+
+    // Read the discovered GSD (Global System Descriptor) - still using YAML
+    YAML::Node discovered_gsd = YAML::LoadFile(gsd_filename);
+
+    // Call a shared validation function that does the actual work
+    return validate_fsd_against_gsd_impl(generated_fsd, discovered_gsd, strict_validation, assert_on_connection_mismatch, log_output);
+}
+
+std::set<PhysicalChannelConnection> validate_cabling_descriptor_against_gsd(
+    const std::string& cabling_descriptor_path,
+    const std::vector<std::string>& hostnames,
+    const YAML::Node& gsd_yaml_node,
+    bool strict_validation,
+    bool assert_on_connection_mismatch,
+    bool log_output) {
+    // Generate FSD from the cabling descriptor using CablingGenerator
+    CablingGenerator cabling_generator(cabling_descriptor_path, hostnames);
+
+    // Generate the FSD protobuf object in memory
+    auto generated_fsd = cabling_generator.generate_factory_system_descriptor();
+
+    // Call a shared validation function that does the actual work
+    return validate_fsd_against_gsd_impl(generated_fsd, gsd_yaml_node, strict_validation, assert_on_connection_mismatch, log_output);
 }
 
 }  // namespace tt::scaleout_tools

--- a/tools/scaleout/factory_system_descriptor/utils.hpp
+++ b/tools/scaleout/factory_system_descriptor/utils.hpp
@@ -7,6 +7,11 @@
 #include <string>
 #include <set>
 #include <cabling_generator/cabling_generator.hpp>
+#include <vector>
+
+namespace YAML {
+    class Node;
+}
 
 namespace tt::scaleout_tools {
 
@@ -22,6 +27,15 @@ namespace tt::scaleout_tools {
 std::set<PhysicalChannelConnection> validate_fsd_against_gsd(
     const std::string& fsd_filename,
     const std::string& gsd_filename,
+    bool strict_validation = true,
+    bool assert_on_connection_mismatch = true,
+    bool log_output = true);
+
+// Validate cabling descriptor against discovered system topology
+std::set<PhysicalChannelConnection> validate_cabling_descriptor_against_gsd(
+    const std::string& cabling_descriptor_path,
+    const std::vector<std::string>& hostnames,
+    const YAML::Node& gsd_yaml_node,
     bool strict_validation = true,
     bool assert_on_connection_mismatch = true,
     bool log_output = true);

--- a/tools/tests/scaleout/cabling_descriptors/wh_galaxy_x_torus_superpod.textproto
+++ b/tools/tests/scaleout/cabling_descriptors/wh_galaxy_x_torus_superpod.textproto
@@ -1,0 +1,20 @@
+graph_templates {
+  key: "5_wh_galaxy_x_torus_superpod"
+  value {
+    children {
+      name: "node1"
+      node_ref { node_descriptor: "WH_GALAXY_X_TORUS" }
+    }
+    internal_connections {
+    }
+  }
+}
+
+# Root instance with concrete host mappings
+root_instance {
+  template_name: "5_wh_galaxy_x_torus_superpod"
+  child_mappings {
+    key: "node1"
+    value { host_id: 0 }
+  }
+}

--- a/tools/tests/scaleout/cabling_descriptors/wh_galaxy_x_torus_superpod.textproto
+++ b/tools/tests/scaleout/cabling_descriptors/wh_galaxy_x_torus_superpod.textproto
@@ -1,5 +1,5 @@
 graph_templates {
-  key: "5_wh_galaxy_x_torus_superpod"
+  key: "wh_galaxy_x_torus"
   value {
     children {
       name: "node1"
@@ -12,7 +12,7 @@ graph_templates {
 
 # Root instance with concrete host mappings
 root_instance {
-  template_name: "5_wh_galaxy_x_torus_superpod"
+  template_name: "wh_galaxy_x_torus"
   child_mappings {
     key: "node1"
     value { host_id: 0 }

--- a/tools/tests/scaleout/cabling_descriptors/wh_galaxy_xy_torus_superpod.textproto
+++ b/tools/tests/scaleout/cabling_descriptors/wh_galaxy_xy_torus_superpod.textproto
@@ -1,0 +1,20 @@
+graph_templates {
+  key: "5_wh_galaxy_xy_torus_superpod"
+  value {
+    children {
+      name: "node1"
+      node_ref { node_descriptor: "WH_GALAXY_XY_TORUS" }
+    }
+    internal_connections {
+    }
+  }
+}
+
+# Root instance with concrete host mappings
+root_instance {
+  template_name: "5_wh_galaxy_xy_torus_superpod"
+  child_mappings {
+    key: "node1"
+    value { host_id: 0 }
+  }
+}

--- a/tools/tests/scaleout/cabling_descriptors/wh_galaxy_xy_torus_superpod.textproto
+++ b/tools/tests/scaleout/cabling_descriptors/wh_galaxy_xy_torus_superpod.textproto
@@ -1,5 +1,5 @@
 graph_templates {
-  key: "5_wh_galaxy_xy_torus_superpod"
+  key: "wh_galaxy_xy_torus"
   value {
     children {
       name: "node1"
@@ -12,7 +12,7 @@ graph_templates {
 
 # Root instance with concrete host mappings
 root_instance {
-  template_name: "5_wh_galaxy_xy_torus_superpod"
+  template_name: "wh_galaxy_xy_torus"
   child_mappings {
     key: "node1"
     value { host_id: 0 }

--- a/tools/tests/scaleout/cabling_descriptors/wh_galaxy_y_torus_superpod.textproto
+++ b/tools/tests/scaleout/cabling_descriptors/wh_galaxy_y_torus_superpod.textproto
@@ -1,0 +1,20 @@
+graph_templates {
+  key: "5_wh_galaxy_y_torus_superpod"
+  value {
+    children {
+      name: "node1"
+      node_ref { node_descriptor: "WH_GALAXY_Y_TORUS" }
+    }
+    internal_connections {
+    }
+  }
+}
+
+# Root instance with concrete host mappings
+root_instance {
+  template_name: "5_wh_galaxy_y_torus_superpod"
+  child_mappings {
+    key: "node1"
+    value { host_id: 0 }
+  }
+}

--- a/tools/tests/scaleout/cabling_descriptors/wh_galaxy_y_torus_superpod.textproto
+++ b/tools/tests/scaleout/cabling_descriptors/wh_galaxy_y_torus_superpod.textproto
@@ -1,5 +1,5 @@
 graph_templates {
-  key: "5_wh_galaxy_y_torus_superpod"
+  key: "wh_galaxy_y_torus"
   value {
     children {
       name: "node1"
@@ -12,7 +12,7 @@ graph_templates {
 
 # Root instance with concrete host mappings
 root_instance {
-  template_name: "5_wh_galaxy_y_torus_superpod"
+  template_name: "wh_galaxy_y_torus"
   child_mappings {
     key: "node1"
     value { host_id: 0 }

--- a/tt_metal/CMakeLists.txt
+++ b/tt_metal/CMakeLists.txt
@@ -255,6 +255,7 @@ target_link_libraries(
         lite_fabric
         FlatBuffers::FlatBuffers
         TT::Metalium::Logging
+        TT::ScaleoutTools
 )
 
 target_precompile_headers(tt_metal REUSE_FROM TT::CommonPCH)

--- a/tt_metal/api/tt-metalium/control_plane.hpp
+++ b/tt_metal/api/tt-metalium/control_plane.hpp
@@ -387,7 +387,7 @@ private:
 
     // This method performs validation through assertions and exceptions.
     void validate_torus_setup(tt::tt_fabric::FabricConfig fabric_config) const;
-    std::string get_cabling_descriptor_path(tt::tt_fabric::FabricConfig fabric_config) const;
+    std::string get_galaxy_cabling_descriptor_path(tt::tt_fabric::FabricConfig fabric_config) const;
 };
 
 }  // namespace tt::tt_fabric

--- a/tt_metal/api/tt-metalium/control_plane.hpp
+++ b/tt_metal/api/tt-metalium/control_plane.hpp
@@ -208,6 +208,10 @@ public:
     const std::unordered_map<tt_metal::distributed::multihost::Rank, std::pair<MeshId, MeshHostRankId>>&
     get_global_logical_bindings() const;
 
+    // Check if the physical system supports the specified fabric configuration
+    // Returns true if valid, false otherwise
+    bool is_fabric_config_valid(tt::tt_fabric::FabricConfig fabric_config) const;
+
 private:
     // Check if the provided mesh is local to this host
     bool is_local_mesh(MeshId mesh_id) const;
@@ -375,6 +379,14 @@ private:
     std::shared_ptr<tt::tt_metal::distributed::multihost::DistributedContext> host_local_context_;
     std::unique_ptr<tt::tt_metal::PhysicalSystemDescriptor> physical_system_descriptor_;
     std::unique_ptr<tt::tt_fabric::TopologyMapper> topology_mapper_;
+
+    // Performance caches for frequently accessed data
+    // Cache for faster asic_id to fabric_node_id lookup
+    mutable std::unordered_map<uint64_t, FabricNodeId> asic_id_to_fabric_node_cache_;
+
+    // This method performs validation through assertions and exceptions.
+    void validate_torus_setup(tt::tt_fabric::FabricConfig fabric_config) const;
+    std::string get_cabling_descriptor_path(tt::tt_fabric::FabricConfig fabric_config) const;
 };
 
 }  // namespace tt::tt_fabric

--- a/tt_metal/api/tt-metalium/control_plane.hpp
+++ b/tt_metal/api/tt-metalium/control_plane.hpp
@@ -209,7 +209,7 @@ public:
     get_global_logical_bindings() const;
 
     // Check if the physical system supports the specified fabric configuration
-    // Returns true if valid, false otherwise
+    // Returns true if valid, false otherwise.
     bool is_fabric_config_valid(tt::tt_fabric::FabricConfig fabric_config) const;
 
 private:
@@ -382,6 +382,7 @@ private:
 
     // Performance caches for frequently accessed data
     // Cache for faster asic_id to fabric_node_id lookup
+    // Valid for the lifetime of the physical_system_descriptor_; cleared when fabric context is reset
     mutable std::unordered_map<uint64_t, FabricNodeId> asic_id_to_fabric_node_cache_;
 
     // This method performs validation through assertions and exceptions.

--- a/tt_metal/fabric/CMakeLists.txt
+++ b/tt_metal/fabric/CMakeLists.txt
@@ -99,6 +99,7 @@ target_link_libraries(
         TT::Metalium::HostDevCommon
         FlatBuffers::FlatBuffers
         protobuf::libprotobuf
+        TT::ScaleoutTools
 )
 
 target_precompile_headers(fabric REUSE_FROM TT::CommonPCH)

--- a/tt_metal/fabric/CMakeLists.txt
+++ b/tt_metal/fabric/CMakeLists.txt
@@ -89,6 +89,7 @@ target_include_directories(fabric SYSTEM PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 target_link_libraries(
     fabric
     PRIVATE
+        TT::ScaleoutTools
         Metalium::Metal::LLRT
         umd::device
         metal_common_libs
@@ -99,7 +100,6 @@ target_link_libraries(
         TT::Metalium::HostDevCommon
         FlatBuffers::FlatBuffers
         protobuf::libprotobuf
-        TT::ScaleoutTools
 )
 
 target_precompile_headers(fabric REUSE_FROM TT::CommonPCH)

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -48,7 +48,6 @@
 #include <umd/device/types/xy_pair.hpp>
 #include <umd/device/cluster.hpp>
 #include "tt_metal/fabric/fabric_context.hpp"
-#include "fabric_host_utils.hpp"
 #include "tt_metal/fabric/serialization/router_port_directions.hpp"
 #include "tt_stl/small_vector.hpp"
 #include "tt_metal/fabric/physical_system_descriptor.hpp"

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -1910,7 +1910,10 @@ FabricContext& ControlPlane::get_fabric_context() const {
     return *this->fabric_context_;
 }
 
-void ControlPlane::clear_fabric_context() { this->fabric_context_.reset(nullptr); }
+void ControlPlane::clear_fabric_context() {
+    this->fabric_context_.reset(nullptr);
+    asic_id_to_fabric_node_cache_.clear();
+}
 
 void ControlPlane::initialize_fabric_tensix_datamover_config() {
     TT_FATAL(this->fabric_context_ != nullptr, "Fabric context must be initialized first");
@@ -2773,8 +2776,13 @@ bool ControlPlane::is_fabric_config_valid(tt::tt_fabric::FabricConfig fabric_con
     };
 
     if (torus_fabric_configs.count(fabric_config)) {
-        validate_torus_setup(fabric_config);
-        return true;  // Validation passed if no exception was thrown
+        try {
+            validate_torus_setup(fabric_config);
+            return true;  // Validation passed if no exception was thrown
+        } catch (const std::exception& e) {
+            log_warning(tt::LogFabric, "Fabric configuration validation failed: {}", e.what());
+            return false;
+        }
     }
 
     // Non-torus configurations are valid by default since we always have at least mesh topology,

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -23,12 +23,14 @@
 #include <unordered_set>
 #include <utility>
 #include <vector>
+#include <yaml-cpp/yaml.h>
 #include <tt_stl/assert.hpp>
 
 #include "control_plane.hpp"
 #include "core_coord.hpp"
 #include "compressed_routing_table.hpp"
 #include "compressed_routing_path.hpp"
+#include "tools/scaleout/factory_system_descriptor/utils.hpp"
 #include "hostdevcommon/fabric_common.h"
 #include "distributed_context.hpp"
 #include "fabric_types.hpp"
@@ -46,6 +48,7 @@
 #include <umd/device/types/xy_pair.hpp>
 #include <umd/device/cluster.hpp>
 #include "tt_metal/fabric/fabric_context.hpp"
+#include "fabric_host_utils.hpp"
 #include "tt_metal/fabric/serialization/router_port_directions.hpp"
 #include "tt_stl/small_vector.hpp"
 #include "tt_metal/fabric/physical_system_descriptor.hpp"
@@ -430,13 +433,21 @@ void ControlPlane::initialize_distributed_contexts() {
 }
 
 FabricNodeId ControlPlane::get_fabric_node_id_from_asic_id(uint64_t asic_id) const {
+    // Check cache first for faster lookup
+    auto cache_it = asic_id_to_fabric_node_cache_.find(asic_id);
+    if (cache_it != asic_id_to_fabric_node_cache_.end()) {
+        return cache_it->second;
+    }
+
     const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
     const auto& chip_unique_ids = cluster.get_unique_chip_ids();
 
     for (const auto& [physical_chip_id, unique_id] : chip_unique_ids) {
-        // TODO: We can maintain a map of unique_id to physical_chip_id for faster lookup
         if (unique_id == asic_id) {
-            return this->get_fabric_node_id_from_physical_chip_id(physical_chip_id);
+            FabricNodeId fabric_node_id = this->get_fabric_node_id_from_physical_chip_id(physical_chip_id);
+            // Cache the result for future lookups
+            asic_id_to_fabric_node_cache_.emplace(asic_id, fabric_node_id);
+            return fabric_node_id;
         }
     }
 
@@ -2747,6 +2758,79 @@ AnnotatedIntermeshConnections ControlPlane::generate_intermesh_connections_on_lo
     }
     return intermesh_connections;
 }
+
+bool ControlPlane::is_fabric_config_valid(tt::tt_fabric::FabricConfig fabric_config) const {
+    if (fabric_config == tt::tt_fabric::FabricConfig::DISABLED) {
+        return false;
+    }
+
+    static const std::unordered_set<tt::tt_fabric::FabricConfig> torus_fabric_configs = {
+        tt::tt_fabric::FabricConfig::FABRIC_2D_TORUS_X,
+        tt::tt_fabric::FabricConfig::FABRIC_2D_TORUS_Y,
+        tt::tt_fabric::FabricConfig::FABRIC_2D_TORUS_XY,
+        tt::tt_fabric::FabricConfig::FABRIC_2D_DYNAMIC_TORUS_X,
+        tt::tt_fabric::FabricConfig::FABRIC_2D_DYNAMIC_TORUS_Y,
+        tt::tt_fabric::FabricConfig::FABRIC_2D_DYNAMIC_TORUS_XY
+    };
+
+    if (torus_fabric_configs.count(fabric_config)) {
+        validate_torus_setup(fabric_config);
+        return true;  // Validation passed if no exception was thrown
+    }
+
+    // Non-torus configurations are valid by default since we always have at least mesh topology,
+    // and mesh configurations don't require special validation like torus does
+    return true;
+}
+
+void ControlPlane::validate_torus_setup(tt::tt_fabric::FabricConfig fabric_config) const {
+    TT_ASSERT(physical_system_descriptor_ != nullptr, "Physical system descriptor not initialized");
+
+    auto all_hostnames = physical_system_descriptor_->get_all_hostnames();
+    auto cabling_descriptor_path = get_cabling_descriptor_path(fabric_config);
+    // Check if the cabling descriptor file exists
+    TT_ASSERT(std::filesystem::exists(cabling_descriptor_path),
+              "Cabling descriptor file not found: {}", cabling_descriptor_path);
+
+    // Generate GSD YAML from the current physical system descriptor
+    YAML::Node gsd_yaml = physical_system_descriptor_->generate_yaml_node();
+
+    // Use the new validation function that handles CablingGenerator internally
+    tt::scaleout_tools::validate_cabling_descriptor_against_gsd(
+        cabling_descriptor_path,
+        all_hostnames,
+        gsd_yaml,
+        false,                      // strict_validation
+        false                       // assert_on_connection_mismatch
+    );
+
+    log_debug(tt::LogFabric, "Torus validation passed for configuration: {}", static_cast<int>(fabric_config));
+}
+
+std::string ControlPlane::get_cabling_descriptor_path(tt::tt_fabric::FabricConfig fabric_config) const {
+    static const std::string X_TORUS_PATH = "tools/tests/scaleout/cabling_descriptors/wh_galaxy_x_torus_superpod.textproto";
+    static const std::string Y_TORUS_PATH = "tools/tests/scaleout/cabling_descriptors/wh_galaxy_y_torus_superpod.textproto";
+    static const std::string XY_TORUS_PATH = "tools/tests/scaleout/cabling_descriptors/wh_galaxy_xy_torus_superpod.textproto";
+
+    // Get fabric type from config and map to cabling descriptor paths
+    FabricType fabric_type = get_fabric_type(fabric_config);
+
+    static const std::unordered_map<FabricType, std::string> cabling_map = {
+        {FabricType::TORUS_X, X_TORUS_PATH},
+        {FabricType::TORUS_Y, Y_TORUS_PATH},
+        {FabricType::TORUS_XY, XY_TORUS_PATH}
+    };
+
+    auto it = cabling_map.find(fabric_type);
+    if (it == cabling_map.end()) {
+        log_warning(tt::LogFabric, "Unknown torus configuration: {}", static_cast<int>(fabric_config));
+        return "";  // Return empty string for unknown configurations
+    }
+
+    const auto& root_dir = tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir();
+    return root_dir + it->second;
+}
+
 
 ControlPlane::~ControlPlane() = default;
 

--- a/tt_metal/fabric/physical_system_descriptor.cpp
+++ b/tt_metal/fabric/physical_system_descriptor.cpp
@@ -483,7 +483,7 @@ void PhysicalSystemDescriptor::generate_cross_host_connections() {
     }
 }
 
-void PhysicalSystemDescriptor::dump_to_yaml(const std::optional<std::string>& path_to_yaml) {
+YAML::Node PhysicalSystemDescriptor::generate_yaml_node() const {
     YAML::Node root;
     YAML::Node compute_nodes;
     YAML::Node local_eth_connections(YAML::NodeType::Sequence);
@@ -497,7 +497,7 @@ void PhysicalSystemDescriptor::dump_to_yaml(const std::optional<std::string>& pa
 
         std::map<TrayID, std::vector<ASICDescriptor>> grouped_asics;
 
-        for (const auto& asic : system_graph_.asic_connectivity_graph[host_name]) {
+        for (const auto& asic : system_graph_.asic_connectivity_graph.at(host_name)) {
             AsicID asic_id = asic.first;
             TrayID tray_id = asic_descriptors_.at(asic_id).tray_id;
             grouped_asics[tray_id].push_back(asic_descriptors_.at(asic_id));
@@ -525,7 +525,7 @@ void PhysicalSystemDescriptor::dump_to_yaml(const std::optional<std::string>& pa
         host_node["asic_info"] = tray_groups;
         compute_nodes[host_name] = host_node;
 
-        for (const auto& asic : system_graph_.asic_connectivity_graph[host_name]) {
+        for (const auto& asic : system_graph_.asic_connectivity_graph.at(host_name)) {
             auto src_asic_id = asic.first;
             const auto& src_asic_desc = asic_descriptors_.at(src_asic_id);
             for (const auto& edge : asic.second) {
@@ -571,9 +571,21 @@ void PhysicalSystemDescriptor::dump_to_yaml(const std::optional<std::string>& pa
     root["local_eth_connections"] = local_eth_connections;
     root["global_eth_connections"] = global_eth_connections;
 
+    return root;
+}
+
+void PhysicalSystemDescriptor::dump_to_yaml(const std::optional<std::string>& path_to_yaml) const {
+    YAML::Node root = generate_yaml_node();
+
     if (path_to_yaml.has_value()) {
         std::ofstream fout(path_to_yaml.value());
+        if (!fout.is_open()) {
+            TT_THROW("Failed to open file for writing: {}", path_to_yaml.value());
+        }
         fout << root;
+        if (fout.fail()) {
+            TT_THROW("Failed to write YAML content to file: {}", path_to_yaml.value());
+        }
     } else {
         std::cout << root << std::endl;
     }

--- a/tt_metal/fabric/physical_system_descriptor.hpp
+++ b/tt_metal/fabric/physical_system_descriptor.hpp
@@ -18,6 +18,10 @@
 #include <tt_stl/strong_type.hpp>
 #include <tt_stl/reflection.hpp>
 
+namespace YAML {
+class Node;
+}
+
 namespace tt::umd {
 class Cluster;
 }
@@ -213,7 +217,8 @@ public:
     static const std::unique_ptr<tt::umd::Cluster> null_cluster;
 
     // Utility APIs to Print Physical System Descriptor
-    void dump_to_yaml(const std::optional<std::string>& path_to_yaml = std::nullopt);
+    void dump_to_yaml(const std::optional<std::string>& path_to_yaml = std::nullopt) const;
+    YAML::Node generate_yaml_node() const;
     void emit_to_text_proto(const std::optional<std::string>& path_to_text_proto = std::nullopt);
 
 private:


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/31252

### Problem description
The existing fabric test framework lacked proper validation for torus configurations, leading to cryptic failures when tests were run on hardware that didn't support the expected topology. Tests would attempt to configure invalid torus setups without graceful error handling, making it difficult to distinguish between actual bugs and hardware compatibility issues.

### What's changed
Implemented a torus validation system using ScaleoutTools integration that validates fabric configurations against the actual hardware topology before attempting device setup. Added graceful test skipping when hardware doesn't support the requested torus configuration, and optimized performance with an ASIC ID lookup cache.

The changes include new cabling descriptor files for all torus configurations (X, Y, XY), is_fabric_config_valid() API for validation, and improved test framework that handles validation failures gracefully by skipping incompatible tests rather than failing.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes