### PR TITLE
[TT-DiT] Apply optimizations to Wan2.2

### DIFF
--- a/models/experimental/tt_dit/layers/normalization.py
+++ b/models/experimental/tt_dit/layers/normalization.py
@@ -159,8 +159,8 @@ class DistributedRMSNorm(Module):
 
         self.weight = (
             Parameter(
-                total_shape=[embedding_dim // n, n],
-                layout=ttnn.ROW_MAJOR_LAYOUT,
+                total_shape=[1, embedding_dim],
+                layout=ttnn.TILE_LAYOUT,
                 device=mesh_device,
                 mesh_axes=[None, mesh_axis],
             )
@@ -170,14 +170,9 @@ class DistributedRMSNorm(Module):
 
     def _prepare_torch_state(self, state: dict[str, torch.Tensor]) -> None:
         if "weight" in state:
-            state["weight"] = (
-                state["weight"]
-                .reshape(self.mesh_width, -1, self.TILE_SIZE)
-                .permute(1, 0, 2)
-                .reshape(-1, self.TILE_SIZE * self.mesh_width)
-            )
+            state["weight"] = state["weight"].reshape(1, self.embedding_dim)
 
-    def forward(self, x: ttnn.Tensor, compute_kernel_config=None) -> ttnn.Tensor:
+    def forward(self, x: ttnn.Tensor, num_heads_per_device=1, compute_kernel_config=None) -> ttnn.Tensor:
         expected_dim = self.embedding_dim // self.mesh_width
         if x.shape[-1] != expected_dim:
             msg = (
@@ -186,7 +181,9 @@ class DistributedRMSNorm(Module):
             )
             raise ValueError(msg)
 
-        stats = ttnn.rms_norm_pre_all_gather(x)
+        stats = ttnn.experimental.fused_rmsnorm_pre_allgather(
+            x, compute_kernel_config=compute_kernel_config or self.compute_kernel_config
+        )
 
         if tuple(self.mesh_device.shape)[self.mesh_axis] > 1:
             stats = ttnn.experimental.all_gather_async(
@@ -202,11 +199,12 @@ class DistributedRMSNorm(Module):
                 num_links=self.ccl_manager.num_links,
             )
 
-        x = ttnn.rms_norm_post_all_gather(
+        x = ttnn.experimental.fused_rmsnorm_post_allgather(
             x,
             stats,
-            weight=self.weight.data if self.weight is not None else None,
             epsilon=self.norm_eps,
+            num_heads_per_device=num_heads_per_device,
+            weight=self.weight.data if self.weight is not None else None,
             compute_kernel_config=compute_kernel_config or self.compute_kernel_config,
         )
         return x

--- a/models/experimental/tt_dit/layers/normalization.py
+++ b/models/experimental/tt_dit/layers/normalization.py
@@ -181,7 +181,6 @@ class DistributedRMSNorm(Module):
         rope_sin=None,
         trans_mat=None,
     ) -> ttnn.Tensor:
-        
         expected_dim = self.embedding_dim // self.mesh_width
         if x.shape[-1] != expected_dim:
             msg = (
@@ -189,7 +188,7 @@ class DistributedRMSNorm(Module):
                 f"embedding_dim / mesh_width = {expected_dim}"
             )
             raise ValueError(msg)
-        
+
         stats = ttnn.experimental.wan_fused_rmsnorm_pre_allgather(
             x, compute_kernel_config=compute_kernel_config or self.compute_kernel_config
         )

--- a/models/experimental/tt_dit/models/transformers/wan2_2/attention_wan.py
+++ b/models/experimental/tt_dit/models/transformers/wan2_2/attention_wan.py
@@ -125,14 +125,6 @@ class WanAttention:
             packer_l1_acc=True,
         )
 
-        self.rmsnorm_compute_kernel_config = ttnn.init_device_compute_kernel_config(
-            self.mesh_device.arch(),
-            math_fidelity=ttnn.MathFidelity.HiFi4,
-            math_approx_mode=False,
-            fp32_dest_acc_en=False,  # NOTE: Should be fp32
-            packer_l1_acc=True,
-        )
-
     def to_cached_state_dict(self, path_prefix):
         cache_dict = {}
 
@@ -211,8 +203,8 @@ class WanAttention:
         v_1BNF = self.to_v(kv_input, compute_kernel_config=self.mm_compute_kernel_config)
 
         # Norm spatial before splitting heads
-        q_1BNF = self.norm_q(q_1BNF, compute_kernel_config=self.rmsnorm_compute_kernel_config)
-        k_1BNF = self.norm_k(k_1BNF, compute_kernel_config=self.rmsnorm_compute_kernel_config)
+        q_BHNE = self.norm_q(q_1BNF, num_heads_per_device=self.n_local_heads)
+        k_BHNE = self.norm_k(k_1BNF, num_heads_per_device=self.n_local_heads)
 
         def create_heads(inp):
             out, _, _ = ttnn.experimental.nlp_create_qkv_heads(
@@ -223,8 +215,8 @@ class WanAttention:
             )
             return out
 
-        q_BHNE = create_heads(q_1BNF)
-        k_BHNE = create_heads(k_1BNF)
+        # q_BHNE = create_heads(q_1BNF)
+        # k_BHNE = create_heads(k_1BNF)
         v_BHNE = create_heads(v_1BNF)
 
         # Rope

--- a/models/experimental/tt_dit/models/transformers/wan2_2/attention_wan.py
+++ b/models/experimental/tt_dit/models/transformers/wan2_2/attention_wan.py
@@ -190,6 +190,12 @@ class WanAttention:
         spatial_1BND: fractured N on SP, fractured D on TP
         """
 
+        if rope_cos is not None:
+            # If ROPE is given, this is self-attention
+            assert rope_sin is not None
+            assert trans_mat is not None
+            assert prompt_1BLP is None
+
         if self.parallel_config.tensor_parallel.factor > 1:
             spatial_1BND = self.ccl_manager.all_gather_persistent_buffer(
                 spatial_1BND, dim=3, mesh_axis=self.parallel_config.tensor_parallel.mesh_axis
@@ -203,8 +209,12 @@ class WanAttention:
         v_1BNF = self.to_v(kv_input, compute_kernel_config=self.mm_compute_kernel_config)
 
         # Norm spatial before splitting heads
-        q_BHNE = self.norm_q(q_1BNF, num_heads_per_device=self.n_local_heads)
-        k_BHNE = self.norm_k(k_1BNF, num_heads_per_device=self.n_local_heads)
+        q_BHNE = self.norm_q(
+            q_1BNF, num_heads_per_device=self.n_local_heads, rope_cos=rope_cos, rope_sin=rope_sin, trans_mat=trans_mat
+        )
+        k_BHNE = self.norm_k(
+            k_1BNF, num_heads_per_device=self.n_local_heads, rope_cos=rope_cos, rope_sin=rope_sin, trans_mat=trans_mat
+        )
 
         def create_heads(inp):
             out, _, _ = ttnn.experimental.nlp_create_qkv_heads(
@@ -215,22 +225,9 @@ class WanAttention:
             )
             return out
 
-        # q_BHNE = create_heads(q_1BNF)
-        # k_BHNE = create_heads(k_1BNF)
         v_BHNE = create_heads(v_1BNF)
 
         # Rope
-        if rope_cos is not None:
-            assert rope_sin is not None
-            assert trans_mat is not None
-            assert prompt_1BLP is None
-
-            q_BHNE = ttnn.experimental.rotary_embedding_llama(
-                q_BHNE, rope_cos, rope_sin, trans_mat, compute_kernel_config=self.rope_compute_kernel_config
-            )
-            k_BHNE = ttnn.experimental.rotary_embedding_llama(
-                k_BHNE, rope_cos, rope_sin, trans_mat, compute_kernel_config=self.rope_compute_kernel_config
-            )
 
         if prompt_1BLP is None:
             # Self attention

--- a/models/experimental/tt_dit/models/transformers/wan2_2/transformer_wan.py
+++ b/models/experimental/tt_dit/models/transformers/wan2_2/transformer_wan.py
@@ -227,7 +227,8 @@ class WanTransformerBlock:
         )
 
         # Residual
-        spatial_1BND = spatial_1BND + spatial_attn_1BND * gate_msa_1B1D
+        # spatial_1BND = spatial_1BND + spatial_attn_1BND * gate_msa_1B1D
+        spatial_1BND = ttnn.addcmul(spatial_1BND, spatial_attn_1BND, gate_msa_1B1D)
 
         # Cross attention on prompt
         spatial_normed_1BND = self.norm2(spatial_1BND, compute_kernel_config=self.layernorm_compute_kernel_config)
@@ -251,7 +252,8 @@ class WanTransformerBlock:
         # NOTE: Cannot set core_grid for FF or you get L1 OOM. Needs to be fixed.
         spatial_ff_1BND = self.ff(spatial_normed_1BND, compute_kernel_config=self.ff_compute_kernel_config)
 
-        spatial_1BND = spatial_1BND + spatial_ff_1BND * c_gate_msa_1B1D
+        # spatial_1BND = spatial_1BND + spatial_ff_1BND * c_gate_msa_1B1D
+        spatial_1BND = ttnn.addcmul(spatial_1BND, spatial_ff_1BND, c_gate_msa_1B1D)
 
         return spatial_1BND
 

--- a/models/experimental/tt_dit/pipelines/wan/pipeline_wan.py
+++ b/models/experimental/tt_dit/pipelines/wan/pipeline_wan.py
@@ -127,6 +127,7 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
         expand_timesteps: bool = False,  # Wan2.2 ti2v
         dynamic_load=False,
         topology: ttnn.Topology = ttnn.Topology.Linear,
+        is_fsdp: bool = True,
     ):
         super().__init__()
 
@@ -159,6 +160,8 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
             num_links=num_links,
             topology=ttnn.Topology.Linear,  # NOTE: VAE always uses Linear topology. TODO: enable ring if given.
         )
+
+        self.is_fsdp = is_fsdp
         self.parallel_config = parallel_config
         self.vae_parallel_config = vae_parallel_config
         self.use_cache = use_cache
@@ -209,7 +212,7 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
             mesh_device=self.mesh_device,
             ccl_manager=self.dit_ccl_manager,
             parallel_config=self.parallel_config,
-            is_fsdp=True,
+            is_fsdp=self.is_fsdp,
         )
 
         if self.use_cache:
@@ -251,7 +254,7 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
             mesh_device=self.mesh_device,
             ccl_manager=self.dit_ccl_manager,
             parallel_config=self.parallel_config,
-            is_fsdp=True,
+            is_fsdp=self.is_fsdp,
         )
 
         if self.use_cache:

--- a/models/experimental/tt_dit/tests/models/wan2_2/test_performance_wan.py
+++ b/models/experimental/tt_dit/tests/models/wan2_2/test_performance_wan.py
@@ -16,13 +16,13 @@ from ....utils.test import line_params, ring_params
 
 
 @pytest.mark.parametrize(
-    "mesh_device, mesh_shape, sp_axis, tp_axis, num_links, dynamic_load, device_params, topology",
+    "mesh_device, mesh_shape, sp_axis, tp_axis, num_links, dynamic_load, device_params, topology, is_fsdp",
     [
-        [(2, 4), (2, 4), 0, 1, 1, True, line_params, ttnn.Topology.Linear],
+        [(2, 4), (2, 4), 0, 1, 1, True, line_params, ttnn.Topology.Linear, True],
         # WH (ring) on 4x8
-        [(4, 8), (4, 8), 1, 0, 4, False, ring_params, ttnn.Topology.Ring],
+        [(4, 8), (4, 8), 1, 0, 4, False, ring_params, ttnn.Topology.Ring, True],
         # BH (linear) on 4x8
-        [(4, 8), (4, 8), 1, 0, 2, False, line_params, ttnn.Topology.Linear],
+        [(4, 8), (4, 8), 1, 0, 2, False, line_params, ttnn.Topology.Linear, False],
     ],
     ids=[
         "2x4sp0tp1",
@@ -55,6 +55,7 @@ def test_pipeline_performance(
     height: int,
     is_ci_env: bool,
     galaxy_type: str,
+    is_fsdp: bool,
 ) -> None:
     """Performance test for Wan pipeline with detailed timing analysis."""
 
@@ -118,6 +119,7 @@ def test_pipeline_performance(
         boundary_ratio=0.875,
         dynamic_load=dynamic_load,
         topology=topology,
+        is_fsdp=is_fsdp,
     )
 
     # Warmup run (not timed)

--- a/models/experimental/tt_dit/tests/models/wan2_2/test_performance_wan.py
+++ b/models/experimental/tt_dit/tests/models/wan2_2/test_performance_wan.py
@@ -13,6 +13,7 @@ from models.experimental.tt_dit.pipelines.wan.pipeline_wan import WanPipeline
 from diffusers.utils import export_to_video
 from ....parallel.config import DiTParallelConfig, VaeHWParallelConfig, ParallelFactor
 from ....utils.test import line_params, ring_params
+from models.common.utility_functions import is_blackhole
 
 
 @pytest.mark.parametrize(
@@ -241,24 +242,32 @@ def test_pipeline_performance(
     if tuple(mesh_device.shape) == (2, 4) and height == 480:
         expected_metrics = {
             "text_encoding_time": 14.8,
-            "denoising_time": 909,
+            "denoising_time": 909.0,
             "vae_decoding_time": 64.6,
-            "total_time": 990,
+            "total_time": 990.0,
         }
     elif tuple(mesh_device.shape) == (4, 8) and height == 480:
         expected_metrics = {
             "text_encoding_time": 15.0,
-            "denoising_time": 163,
+            "denoising_time": 163.0,
             "vae_decoding_time": 18.2,
-            "total_time": 192,
+            "total_time": 192.0,
         }
     elif tuple(mesh_device.shape) == (4, 8) and height == 720:
-        expected_metrics = {
-            "text_encoding_time": 15.0,
-            "denoising_time": 502,
-            "vae_decoding_time": 39.6,
-            "total_time": 556,
-        }
+        if is_blackhole():
+            expected_metrics = {
+                "text_encoding_time": 15.0,
+                "denoising_time": 290.0,
+                "vae_decoding_time": 36.0,
+                "total_time": 341.0,
+            }
+        else:
+            expected_metrics = {
+                "text_encoding_time": 15.0,
+                "denoising_time": 440.0,
+                "vae_decoding_time": 42.0,
+                "total_time": 497.0,
+            }
     else:
         assert False, f"Unknown mesh device for performance comparison: {mesh_device}"
 

--- a/models/experimental/tt_dit/tests/models/wan2_2/test_pipeline_wan.py
+++ b/models/experimental/tt_dit/tests/models/wan2_2/test_pipeline_wan.py
@@ -13,13 +13,13 @@ from ....utils.test import line_params, ring_params
 
 
 @pytest.mark.parametrize(
-    "mesh_device, mesh_shape, sp_axis, tp_axis, num_links, dynamic_load, device_params, topology",
+    "mesh_device, mesh_shape, sp_axis, tp_axis, num_links, dynamic_load, device_params, topology, is_fsdp",
     [
-        [(2, 4), (2, 4), 0, 1, 1, True, line_params, ttnn.Topology.Linear],
+        [(2, 4), (2, 4), 0, 1, 1, True, line_params, ttnn.Topology.Linear, True],
         # WH (ring) on 4x8
-        [(4, 8), (4, 8), 1, 0, 4, False, ring_params, ttnn.Topology.Ring],
+        [(4, 8), (4, 8), 1, 0, 4, False, ring_params, ttnn.Topology.Ring, True],
         # BH (linear) on 4x8
-        [(4, 8), (4, 8), 1, 0, 2, False, line_params, ttnn.Topology.Linear],
+        [(4, 8), (4, 8), 1, 0, 2, False, line_params, ttnn.Topology.Linear, False],
     ],
     ids=[
         "2x4sp0tp1",
@@ -49,6 +49,7 @@ def test_pipeline_inference(
     topology,
     width,
     height,
+    is_fsdp,
 ):
     parent_mesh = mesh_device
     mesh_device = parent_mesh.create_submesh(ttnn.MeshShape(*mesh_shape))
@@ -86,6 +87,7 @@ def test_pipeline_inference(
         boundary_ratio=0.875,
         dynamic_load=dynamic_load,
         topology=topology,
+        is_fsdp=is_fsdp,
     )
 
     # Run inference

--- a/models/experimental/tt_dit/tests/models/wan2_2/test_stability_wan.py
+++ b/models/experimental/tt_dit/tests/models/wan2_2/test_stability_wan.py
@@ -14,13 +14,13 @@ import os
 
 
 @pytest.mark.parametrize(
-    "mesh_device, mesh_shape, sp_axis, tp_axis, num_links, dynamic_load, device_params, topology",
+    "mesh_device, mesh_shape, sp_axis, tp_axis, num_links, dynamic_load, device_params, topology, is_fsdp",
     [
-        [(2, 4), (2, 4), 0, 1, 1, True, line_params, ttnn.Topology.Linear],
+        [(2, 4), (2, 4), 0, 1, 1, True, line_params, ttnn.Topology.Linear, True],
         # WH (ring) on 4x8
-        [(4, 8), (4, 8), 1, 0, 4, False, ring_params, ttnn.Topology.Ring],
+        [(4, 8), (4, 8), 1, 0, 4, False, ring_params, ttnn.Topology.Ring, True],
         # BH (linear) on 4x8
-        [(4, 8), (4, 8), 1, 0, 2, False, line_params, ttnn.Topology.Linear],
+        [(4, 8), (4, 8), 1, 0, 2, False, line_params, ttnn.Topology.Linear, False],
     ],
     ids=[
         "2x4sp0tp1",
@@ -29,7 +29,20 @@ import os
     ],
     indirect=["mesh_device", "device_params"],
 )
-def test_stability(mesh_device, mesh_shape, sp_axis, tp_axis, num_links, dynamic_load, topology):
+@pytest.mark.parametrize(
+    "width, height",
+    [
+        (832, 480),
+        (1280, 720),
+    ],
+    ids=[
+        "resolution_480p",
+        "resolution_720p",
+    ],
+)
+def test_stability(
+    mesh_device, mesh_shape, sp_axis, tp_axis, num_links, dynamic_load, topology, is_fsdp, width, height
+):
     parent_mesh = mesh_device
     mesh_device = parent_mesh.create_submesh(ttnn.MeshShape(*mesh_shape))
 
@@ -58,8 +71,6 @@ def test_stability(mesh_device, mesh_shape, sp_axis, tp_axis, num_links, dynamic
     ]
     negative_prompt = "色调艳丽，过曝，静态，细节模糊不清，字幕，风格，作品，画作，画面，静止，整体发灰，最差质量，低质量，JPEG压缩残留，丑陋的，残缺的，多余的手指，画得不好的手部，画得不好的脸部，畸形的，毁容的，形态畸形的肢体，手指融合，静止不动的画面，杂乱的背景，三条腿，背景人很多，倒着走"
 
-    height = 480
-    width = 832
     num_frames = 81
     num_inference_steps = 40
 
@@ -78,6 +89,7 @@ def test_stability(mesh_device, mesh_shape, sp_axis, tp_axis, num_links, dynamic
         boundary_ratio=0.875,
         dynamic_load=dynamic_load,
         topology=topology,
+        is_fsdp=is_fsdp,
     )
 
     while True:

--- a/models/experimental/tt_dit/tests/models/wan2_2/test_transformer_wan.py
+++ b/models/experimental/tt_dit/tests/models/wan2_2/test_transformer_wan.py
@@ -22,16 +22,16 @@ from diffusers import WanTransformer3DModel as TorchWanTransformer3DModel
 
 
 @pytest.mark.parametrize(
-    "mesh_device, mesh_shape, sp_axis, tp_axis, num_links, device_params, topology",
+    "mesh_device, mesh_shape, sp_axis, tp_axis, num_links, device_params, topology, is_fsdp",
     [
-        [(2, 4), (2, 4), 0, 1, 1, line_params, ttnn.Topology.Linear],
-        [(2, 4), (2, 4), 1, 0, 1, line_params, ttnn.Topology.Linear],
+        [(2, 4), (2, 4), 0, 1, 1, line_params, ttnn.Topology.Linear, True],
+        [(2, 4), (2, 4), 1, 0, 1, line_params, ttnn.Topology.Linear, True],
         # WH (ring) on 4x8
-        [(4, 8), (4, 8), 0, 1, 4, ring_params, ttnn.Topology.Ring],
-        [(4, 8), (4, 8), 1, 0, 4, ring_params, ttnn.Topology.Ring],
+        [(4, 8), (4, 8), 0, 1, 4, ring_params, ttnn.Topology.Ring, True],
+        [(4, 8), (4, 8), 1, 0, 4, ring_params, ttnn.Topology.Ring, True],
         # BH (linear) on 4x8
-        [(4, 8), (4, 8), 0, 1, 2, line_params, ttnn.Topology.Linear],
-        [(4, 8), (4, 8), 1, 0, 2, line_params, ttnn.Topology.Linear],
+        [(4, 8), (4, 8), 0, 1, 2, line_params, ttnn.Topology.Linear, False],
+        [(4, 8), (4, 8), 1, 0, 2, line_params, ttnn.Topology.Linear, False],
     ],
     ids=[
         # "1x1sp0tp1",
@@ -59,7 +59,6 @@ from diffusers import WanTransformer3DModel as TorchWanTransformer3DModel
     ],
     ids=["5b-720p", "14b-480p", "14b-720p"],
 )
-@pytest.mark.parametrize("is_fsdp", [True], ids=["yes_fsdp"])
 def test_wan_transformer_block(
     mesh_device: ttnn.MeshDevice,
     mesh_shape: tuple[int, int],
@@ -209,7 +208,7 @@ def test_wan_transformer_block(
 
 
 @pytest.mark.parametrize(
-    "mesh_device, mesh_shape, sp_axis, tp_axis, num_links, device_params, topology",
+    "mesh_device, mesh_shape, sp_axis, tp_axis, num_links, device_params, topology, is_fsdp",
     [
         # [(1, 1), (1, 1), 0, 1, 1],
         # [(1, 2), (1, 2), 0, 1, 1],
@@ -218,14 +217,14 @@ def test_wan_transformer_block(
         # [(2, 1), (2, 1), 1, 0, 1],
         # [(2, 2), (2, 2), 0, 1, 1],
         # [(2, 2), (2, 2), 1, 0, 1],
-        [(2, 4), (2, 4), 0, 1, 1, line_params, ttnn.Topology.Linear],
-        [(2, 4), (2, 4), 1, 0, 1, line_params, ttnn.Topology.Linear],
+        [(2, 4), (2, 4), 0, 1, 1, line_params, ttnn.Topology.Linear, True],
+        [(2, 4), (2, 4), 1, 0, 1, line_params, ttnn.Topology.Linear, True],
         # WH (ring) on 4x8
-        [(4, 8), (4, 8), 0, 1, 4, ring_params, ttnn.Topology.Ring],
-        [(4, 8), (4, 8), 1, 0, 4, ring_params, ttnn.Topology.Ring],
+        [(4, 8), (4, 8), 0, 1, 4, ring_params, ttnn.Topology.Ring, True],
+        [(4, 8), (4, 8), 1, 0, 4, ring_params, ttnn.Topology.Ring, True],
         # BH (linear) on 4x8
-        [(4, 8), (4, 8), 0, 1, 2, line_params, ttnn.Topology.Linear],
-        [(4, 8), (4, 8), 1, 0, 2, line_params, ttnn.Topology.Linear],
+        [(4, 8), (4, 8), 0, 1, 2, line_params, ttnn.Topology.Linear, False],
+        [(4, 8), (4, 8), 1, 0, 2, line_params, ttnn.Topology.Linear, False],
     ],
     ids=[
         # "1x1sp0tp1",
@@ -268,6 +267,7 @@ def test_wan_transformer_model(
     prompt_seq_len: int,
     load_cache: bool,
     topology: ttnn.Topology,
+    is_fsdp: bool,
 ) -> None:
     torch_dtype = torch.float32
 
@@ -332,7 +332,7 @@ def test_wan_transformer_model(
         mesh_device=mesh_device,
         ccl_manager=ccl_manager,
         parallel_config=parallel_config,
-        is_fsdp=True,
+        is_fsdp=is_fsdp,
     )
 
     if load_cache:
@@ -386,13 +386,13 @@ def test_wan_transformer_model(
 
 
 @pytest.mark.parametrize(
-    "mesh_device, sp_axis, tp_axis, num_links, device_params, topology",
+    "mesh_device, sp_axis, tp_axis, num_links, device_params, topology, is_fsdp",
     [
-        [(2, 4), 0, 1, 1, line_params, ttnn.Topology.Linear],
+        [(2, 4), 0, 1, 1, line_params, ttnn.Topology.Linear, True],
         # WH (ring) on 4x8
-        [(4, 8), 1, 0, 4, ring_params, ttnn.Topology.Ring],
+        [(4, 8), 1, 0, 4, ring_params, ttnn.Topology.Ring, True],
         # BH (linear) on 4x8
-        [(4, 8), 1, 0, 2, line_params, ttnn.Topology.Linear],
+        [(4, 8), 1, 0, 2, line_params, ttnn.Topology.Linear, False],
     ],
     ids=[
         "2x4sp0tp1",
@@ -409,6 +409,7 @@ def test_wan_transformer_model_caching(
     num_links: int,
     subfolder: str,
     topology: ttnn.Topology,
+    is_fsdp: bool,
 ) -> None:
     torch_dtype = torch.float32
 
@@ -475,7 +476,7 @@ def test_wan_transformer_model_caching(
         mesh_device=mesh_device,
         ccl_manager=ccl_manager,
         parallel_config=parallel_config,
-        is_fsdp=True,
+        is_fsdp=is_fsdp,
     )
     start = time.time()
     tt_model.load_state_dict(torch_model.state_dict())
@@ -506,7 +507,7 @@ def test_wan_transformer_model_caching(
         mesh_device=mesh_device,
         ccl_manager=ccl_manager,
         parallel_config=parallel_config,
-        is_fsdp=True,
+        is_fsdp=is_fsdp,
     )
     loaded_cache_dict = load_cache_dict(cache_path)
     cache_model.from_cached_state_dict(loaded_cache_dict)

--- a/models/experimental/tt_dit/utils/matmul.py
+++ b/models/experimental/tt_dit/utils/matmul.py
@@ -86,6 +86,13 @@ grid_89_configs = {
     (9472, 3456, 5120): (8, 8, 8),
 }
 
+grid_13_9_configs = {
+    (9472, 5120, 1280): (8, 8, 8, (2, 2)),
+    (128, 5120, 1280): (2, 16, 4, (2, 2)),
+    (9472, 5120, 3456): (8, 8, 4, (1, 2)),
+    (9472, 3456, 5120): (8, 12, 4, (1, 2)),
+}
+
 
 def get_matmul_config(M, K, N, core_grid):
     # Default to 8x8x8 with subblock 2x2 when unknown
@@ -102,6 +109,10 @@ def get_matmul_config(M, K, N, core_grid):
         config_tuple = grid_88_configs.get((M, K, N))
     elif getattr(core_grid, "x", None) == 8 and getattr(core_grid, "y", None) == 9:
         config_tuple = grid_89_configs.get((M, K, N))
+    elif getattr(core_grid, "x", None) == 13 and getattr(core_grid, "y", None) == 9:
+        config_tuple = grid_13_9_configs.get((M, K, N))
+        subblock_h, subblock_w = config_tuple[3]
+        config_tuple = config_tuple[:3]
 
     if config_tuple is None:
         M_block_size, K_block_size, N_block_size = 8, 8, 8

--- a/models/experimental/tt_dit/utils/matmul.py
+++ b/models/experimental/tt_dit/utils/matmul.py
@@ -111,8 +111,9 @@ def get_matmul_config(M, K, N, core_grid):
         config_tuple = grid_89_configs.get((M, K, N))
     elif getattr(core_grid, "x", None) == 13 and getattr(core_grid, "y", None) == 9:
         config_tuple = grid_13_9_configs.get((M, K, N))
-        subblock_h, subblock_w = config_tuple[3]
-        config_tuple = config_tuple[:3]
+        if config_tuple is not None:
+            subblock_h, subblock_w = config_tuple[3]
+            config_tuple = config_tuple[:3]
 
     if config_tuple is None:
         M_block_size, K_block_size, N_block_size = 8, 8, 8

--- a/models/experimental/tt_dit/utils/matmul.py
+++ b/models/experimental/tt_dit/utils/matmul.py
@@ -93,6 +93,13 @@ grid_13_9_configs = {
     (9472, 3456, 5120): (8, 12, 4, (1, 2)),
 }
 
+grid_12_10_configs = {
+    (9472, 5120, 1280): (16, 8, 4, (2, 2)),
+    (128, 5120, 1280): (1, 16, 8, (1, 2)),
+    (9472, 5120, 3456): (16, 8, 4, (1, 2)),
+    (9472, 3456, 5120): (16, 4, 8, (1, 2)),
+}
+
 
 def get_matmul_config(M, K, N, core_grid):
     # Default to 8x8x8 with subblock 2x2 when unknown
@@ -111,6 +118,11 @@ def get_matmul_config(M, K, N, core_grid):
         config_tuple = grid_89_configs.get((M, K, N))
     elif getattr(core_grid, "x", None) == 13 and getattr(core_grid, "y", None) == 9:
         config_tuple = grid_13_9_configs.get((M, K, N))
+        if config_tuple is not None:
+            subblock_h, subblock_w = config_tuple[3]
+            config_tuple = config_tuple[:3]
+    elif getattr(core_grid, "x", None) == 12 and getattr(core_grid, "y", None) == 10:
+        config_tuple = grid_12_10_configs.get((M, K, N))
         if config_tuple is not None:
             subblock_h, subblock_w = config_tuple[3]
             config_tuple = config_tuple[:3]


### PR DESCRIPTION
### Ticket
In service of https://github.com/tenstorrent/tt-metal/issues/29148

### Problem description
There are a few optimizations we can merge into Wan2.2, both for WH and BH.

### What's changed
- use fused RMSNorm (https://github.com/tenstorrent/tt-metal/pull/31689) to save 1.294ms per layer
- no FSDP on BH Galaxy. DRAM capacity is high enough to obviate this. yields 4.857ms of savings.
- optimized matmul blockings for BH Galaxy - yields 0.24ms of savings

### Checklist
- [x] Galaxy frequent and model perf https://github.com/tenstorrent/tt-metal/actions/runs/19551130440 
