### PR TITLE
[TTT] Fix split_list to handle uneven splits and undefined variable

### DIFF
--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -44,12 +44,13 @@ class SamplingParams:
 
 # Split lists into chunks
 def split_list(lst, n):
-    """Split list into n equal parts"""
-    chunk_size = len(lst) // n
+    """Split list into n nearly equal parts"""
+    k, m = divmod(len(lst), n)
     chunks = []
     start = 0
     for i in range(n):
-        chunks.append(list(lst[start : start + chunk_size]))  # Convert to list explicitly
+        end = start + k + (1 if i < m else 0)
+        chunks.append(list(lst[start:end]))  # Convert to list explicitly
         start = end
     return chunks
 


### PR DESCRIPTION
### Ticket
N/A

### Problem description
The split_list function contained two issues:
1. It referenced `end` variable and before assignment, causing an error.
2. When the list length was not evenly divisible by n, the leftover elements were ignored.

### What's changed
- Fixed the undefined variable issue by properly defining `end`.
- Updated the logic to use `divmod(len(lst), n)` so that all elements are included in the result, distributing any remainder evenly among the first few chunks.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes