### PR TITLE
Speedup HF model creation with dummy weights

### DIFF
--- a/.github/workflows/t3000-frequent-tests-impl.yaml
+++ b/.github/workflows/t3000-frequent-tests-impl.yaml
@@ -23,25 +23,25 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          # { name: "t3k tteager tests", arch: wormhole_b0, cmd: run_t3000_tteager_tests, timeout: 30, owner_id: U05ACKAJTHS}, #Naif Tarafdar
-          # { name: "t3k ethernet tests", arch: wormhole_b0, cmd: run_t3000_ethernet_tests, timeout: 10, owner_id: ULMEPM2MA}, #Sean Nijjar
-          # { name: "t3k trace stress tests", arch: wormhole_b0, cmd: run_t3000_trace_stress_tests, timeout: 30, owner_id: U03NG0A5ND7}, #Aditya Saigal
-          # { name: "t3k falcon40b tests", arch: wormhole_b0, cmd: run_t3000_falcon40b_tests, timeout: 20, owner_id: U04S2UV6L8N}, #Sofija Jovic
-          # { name: "t3k llama3.2-vision tests", arch: wormhole_b0, cmd: run_t3000_llama3.2-11b-vision_freq_tests, timeout: 20, owner_id: U03FJB5TM5Y}, #Colman Glagovich
-          # { name: "t3k n300 mesh llama3.2-vision tests", arch: wormhole_b0, cmd: run_t3000_spoof_n300_llama3.2-11b-vision_freq_tests, timeout: 20, owner_id: U03FJB5TM5Y}, #Colman Glagovich
-          # { name: "t3k llama3.2-90b-vision tests", arch: wormhole_b0, cmd: run_t3000_llama3.2-90b-vision_freq_tests, timeout: 20, owner_id: U07RY6B5FLJ},  #Gongyu Wang
-          # { name: "t3k llama3 tests", arch: wormhole_b0, cmd: run_t3000_llama3_tests, timeout: 45, owner_id: U03PUAKE719}, #Miguel Tairum Cruz
-          # { name: "t3k llama3 accuracy tests", arch: wormhole_b0, cmd: run_t3000_llama3_accuracy_tests, timeout: 40, owner_id: U03PUAKE719}, #Miguel Tairum Cruz
-          # { name: "t3k llama3_70n90b accuracy tests", arch: wormhole_b0, cmd: run_t3000_llama3_70n90b_accuracy_tests, timeout: 20, owner_id: U03PUAKE719}, #
+          { name: "t3k tteager tests", arch: wormhole_b0, cmd: run_t3000_tteager_tests, timeout: 30, owner_id: U05ACKAJTHS}, #Naif Tarafdar
+          { name: "t3k ethernet tests", arch: wormhole_b0, cmd: run_t3000_ethernet_tests, timeout: 10, owner_id: ULMEPM2MA}, #Sean Nijjar
+          { name: "t3k trace stress tests", arch: wormhole_b0, cmd: run_t3000_trace_stress_tests, timeout: 30, owner_id: U03NG0A5ND7}, #Aditya Saigal
+          { name: "t3k falcon40b tests", arch: wormhole_b0, cmd: run_t3000_falcon40b_tests, timeout: 20, owner_id: U04S2UV6L8N}, #Sofija Jovic
+          { name: "t3k llama3.2-vision tests", arch: wormhole_b0, cmd: run_t3000_llama3.2-11b-vision_freq_tests, timeout: 20, owner_id: U03FJB5TM5Y}, #Colman Glagovich
+          { name: "t3k n300 mesh llama3.2-vision tests", arch: wormhole_b0, cmd: run_t3000_spoof_n300_llama3.2-11b-vision_freq_tests, timeout: 20, owner_id: U03FJB5TM5Y}, #Colman Glagovich
+          { name: "t3k llama3.2-90b-vision tests", arch: wormhole_b0, cmd: run_t3000_llama3.2-90b-vision_freq_tests, timeout: 20, owner_id: U07RY6B5FLJ},  #Gongyu Wang
+          { name: "t3k llama3 tests", arch: wormhole_b0, cmd: run_t3000_llama3_tests, timeout: 45, owner_id: U03PUAKE719}, #Miguel Tairum Cruz
+          { name: "t3k llama3 accuracy tests", arch: wormhole_b0, cmd: run_t3000_llama3_accuracy_tests, timeout: 40, owner_id: U03PUAKE719}, #Miguel Tairum Cruz
+          { name: "t3k llama3_70n90b accuracy tests", arch: wormhole_b0, cmd: run_t3000_llama3_70n90b_accuracy_tests, timeout: 20, owner_id: U03PUAKE719}, #
           { name: "t3k llama3_90b tests", arch: wormhole_b0, cmd: run_t3000_llama3_90b_tests, timeout: 30, owner_id: U07RY6B5FLJ}, #Gongyu Wang
           # { name: "t3k llama3_70b tests", arch: wormhole_b0, cmd: run_t3000_llama3_70b_tests, timeout: 45, owner_id: U03FJB5TM5Y}, #Colman Glagovich  # FIXME issue #14934
           # { name: "t3k mixtral tests", arch: wormhole_b0, cmd: run_t3000_mixtral_tests, timeout: 30, owner_id: U03PUAKE719}, #Miguel Tairum Cruz
-          # { name: "t3k resnet tests", arch: wormhole_b0, cmd: run_t3000_resnet_tests, timeout: 15, owner_id: U052J2QDDKQ}, #Pavle Josipovic
-          # { name: "t3k sd35_large tests", arch: wormhole_b0, cmd: run_t3000_sd35large_tests, timeout: 30, owner_id: U03FJB5TM5Y}, #Colman Glagovich
-          # { name: "t3k flux1 tests", arch: wormhole_b0, cmd: run_t3000_flux1_tests, timeout: 30, owner_id: U08TED0JM9D}, #Samuel Adesoye
-          # { name: "t3k mistral tests", arch: wormhole_b0, cmd: run_t3000_mistral_tests, timeout: 15, owner_id: U0896VBAKFC}, # Pratikkumar Prajapati
-          # { name: "t3k wan2.2 tests", arch: wormhole_b0, cmd: run_t3000_wan22_tests, timeout: 45, owner_id: U03FJB5TM5Y}, #Colman Glagovich
-          # { name: "t3k mochi tests", arch: wormhole_b0, cmd: run_t3000_mochi_tests, timeout: 60, owner_id: U09ELB03XRU}, # Stephen Osborne
+          { name: "t3k resnet tests", arch: wormhole_b0, cmd: run_t3000_resnet_tests, timeout: 15, owner_id: U052J2QDDKQ}, #Pavle Josipovic
+          { name: "t3k sd35_large tests", arch: wormhole_b0, cmd: run_t3000_sd35large_tests, timeout: 30, owner_id: U03FJB5TM5Y}, #Colman Glagovich
+          { name: "t3k flux1 tests", arch: wormhole_b0, cmd: run_t3000_flux1_tests, timeout: 30, owner_id: U08TED0JM9D}, #Samuel Adesoye
+          { name: "t3k mistral tests", arch: wormhole_b0, cmd: run_t3000_mistral_tests, timeout: 15, owner_id: U0896VBAKFC}, # Pratikkumar Prajapati
+          { name: "t3k wan2.2 tests", arch: wormhole_b0, cmd: run_t3000_wan22_tests, timeout: 45, owner_id: U03FJB5TM5Y}, #Colman Glagovich
+          { name: "t3k mochi tests", arch: wormhole_b0, cmd: run_t3000_mochi_tests, timeout: 60, owner_id: U09ELB03XRU}, # Stephen Osborne
         ]
     name: ${{ matrix.test-group.name }}
     runs-on:

--- a/.github/workflows/t3000-frequent-tests-impl.yaml
+++ b/.github/workflows/t3000-frequent-tests-impl.yaml
@@ -23,25 +23,25 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          { name: "t3k tteager tests", arch: wormhole_b0, cmd: run_t3000_tteager_tests, timeout: 30, owner_id: U05ACKAJTHS}, #Naif Tarafdar
-          { name: "t3k ethernet tests", arch: wormhole_b0, cmd: run_t3000_ethernet_tests, timeout: 10, owner_id: ULMEPM2MA}, #Sean Nijjar
-          { name: "t3k trace stress tests", arch: wormhole_b0, cmd: run_t3000_trace_stress_tests, timeout: 30, owner_id: U03NG0A5ND7}, #Aditya Saigal
-          { name: "t3k falcon40b tests", arch: wormhole_b0, cmd: run_t3000_falcon40b_tests, timeout: 20, owner_id: U04S2UV6L8N}, #Sofija Jovic
-          { name: "t3k llama3.2-vision tests", arch: wormhole_b0, cmd: run_t3000_llama3.2-11b-vision_freq_tests, timeout: 20, owner_id: U03FJB5TM5Y}, #Colman Glagovich
-          { name: "t3k n300 mesh llama3.2-vision tests", arch: wormhole_b0, cmd: run_t3000_spoof_n300_llama3.2-11b-vision_freq_tests, timeout: 20, owner_id: U03FJB5TM5Y}, #Colman Glagovich
-          { name: "t3k llama3.2-90b-vision tests", arch: wormhole_b0, cmd: run_t3000_llama3.2-90b-vision_freq_tests, timeout: 20, owner_id: U07RY6B5FLJ},  #Gongyu Wang
-          { name: "t3k llama3 tests", arch: wormhole_b0, cmd: run_t3000_llama3_tests, timeout: 45, owner_id: U03PUAKE719}, #Miguel Tairum Cruz
-          { name: "t3k llama3 accuracy tests", arch: wormhole_b0, cmd: run_t3000_llama3_accuracy_tests, timeout: 40, owner_id: U03PUAKE719}, #Miguel Tairum Cruz
-          { name: "t3k llama3_70n90b accuracy tests", arch: wormhole_b0, cmd: run_t3000_llama3_70n90b_accuracy_tests, timeout: 20, owner_id: U03PUAKE719}, #
+          # { name: "t3k tteager tests", arch: wormhole_b0, cmd: run_t3000_tteager_tests, timeout: 30, owner_id: U05ACKAJTHS}, #Naif Tarafdar
+          # { name: "t3k ethernet tests", arch: wormhole_b0, cmd: run_t3000_ethernet_tests, timeout: 10, owner_id: ULMEPM2MA}, #Sean Nijjar
+          # { name: "t3k trace stress tests", arch: wormhole_b0, cmd: run_t3000_trace_stress_tests, timeout: 30, owner_id: U03NG0A5ND7}, #Aditya Saigal
+          # { name: "t3k falcon40b tests", arch: wormhole_b0, cmd: run_t3000_falcon40b_tests, timeout: 20, owner_id: U04S2UV6L8N}, #Sofija Jovic
+          # { name: "t3k llama3.2-vision tests", arch: wormhole_b0, cmd: run_t3000_llama3.2-11b-vision_freq_tests, timeout: 20, owner_id: U03FJB5TM5Y}, #Colman Glagovich
+          # { name: "t3k n300 mesh llama3.2-vision tests", arch: wormhole_b0, cmd: run_t3000_spoof_n300_llama3.2-11b-vision_freq_tests, timeout: 20, owner_id: U03FJB5TM5Y}, #Colman Glagovich
+          # { name: "t3k llama3.2-90b-vision tests", arch: wormhole_b0, cmd: run_t3000_llama3.2-90b-vision_freq_tests, timeout: 20, owner_id: U07RY6B5FLJ},  #Gongyu Wang
+          # { name: "t3k llama3 tests", arch: wormhole_b0, cmd: run_t3000_llama3_tests, timeout: 45, owner_id: U03PUAKE719}, #Miguel Tairum Cruz
+          # { name: "t3k llama3 accuracy tests", arch: wormhole_b0, cmd: run_t3000_llama3_accuracy_tests, timeout: 40, owner_id: U03PUAKE719}, #Miguel Tairum Cruz
+          # { name: "t3k llama3_70n90b accuracy tests", arch: wormhole_b0, cmd: run_t3000_llama3_70n90b_accuracy_tests, timeout: 20, owner_id: U03PUAKE719}, #
           { name: "t3k llama3_90b tests", arch: wormhole_b0, cmd: run_t3000_llama3_90b_tests, timeout: 30, owner_id: U07RY6B5FLJ}, #Gongyu Wang
           # { name: "t3k llama3_70b tests", arch: wormhole_b0, cmd: run_t3000_llama3_70b_tests, timeout: 45, owner_id: U03FJB5TM5Y}, #Colman Glagovich  # FIXME issue #14934
           # { name: "t3k mixtral tests", arch: wormhole_b0, cmd: run_t3000_mixtral_tests, timeout: 30, owner_id: U03PUAKE719}, #Miguel Tairum Cruz
-          { name: "t3k resnet tests", arch: wormhole_b0, cmd: run_t3000_resnet_tests, timeout: 15, owner_id: U052J2QDDKQ}, #Pavle Josipovic
-          { name: "t3k sd35_large tests", arch: wormhole_b0, cmd: run_t3000_sd35large_tests, timeout: 30, owner_id: U03FJB5TM5Y}, #Colman Glagovich
-          { name: "t3k flux1 tests", arch: wormhole_b0, cmd: run_t3000_flux1_tests, timeout: 30, owner_id: U08TED0JM9D}, #Samuel Adesoye
-          { name: "t3k mistral tests", arch: wormhole_b0, cmd: run_t3000_mistral_tests, timeout: 15, owner_id: U0896VBAKFC}, # Pratikkumar Prajapati
-          { name: "t3k wan2.2 tests", arch: wormhole_b0, cmd: run_t3000_wan22_tests, timeout: 45, owner_id: U03FJB5TM5Y}, #Colman Glagovich
-          { name: "t3k mochi tests", arch: wormhole_b0, cmd: run_t3000_mochi_tests, timeout: 60, owner_id: U09ELB03XRU}, # Stephen Osborne
+          # { name: "t3k resnet tests", arch: wormhole_b0, cmd: run_t3000_resnet_tests, timeout: 15, owner_id: U052J2QDDKQ}, #Pavle Josipovic
+          # { name: "t3k sd35_large tests", arch: wormhole_b0, cmd: run_t3000_sd35large_tests, timeout: 30, owner_id: U03FJB5TM5Y}, #Colman Glagovich
+          # { name: "t3k flux1 tests", arch: wormhole_b0, cmd: run_t3000_flux1_tests, timeout: 30, owner_id: U08TED0JM9D}, #Samuel Adesoye
+          # { name: "t3k mistral tests", arch: wormhole_b0, cmd: run_t3000_mistral_tests, timeout: 15, owner_id: U0896VBAKFC}, # Pratikkumar Prajapati
+          # { name: "t3k wan2.2 tests", arch: wormhole_b0, cmd: run_t3000_wan22_tests, timeout: 45, owner_id: U03FJB5TM5Y}, #Colman Glagovich
+          # { name: "t3k mochi tests", arch: wormhole_b0, cmd: run_t3000_mochi_tests, timeout: 60, owner_id: U09ELB03XRU}, # Stephen Osborne
         ]
     name: ${{ matrix.test-group.name }}
     runs-on:

--- a/models/demos/gemma3/tt/model_config.py
+++ b/models/demos/gemma3/tt/model_config.py
@@ -1793,12 +1793,12 @@ class ModelArgs:
                     model = AutoModelForCausalLM.from_pretrained(
                         self.CKPT_DIR, config=config, torch_dtype="auto", local_files_only=True
                     )
-                    # model.load_state_dict({k: torch.randn_like(v) for k, v in model.state_dict().items()})
                     model.apply(model._init_weights)
                 except Exception as e:
                     logger.info(f"Error loading dummy weights using .from_pretrained. Using .from_config. Error: {e}")
                     model = AutoModelForCausalLM.from_config(config)
 
+                # model.load_state_dict({k: torch.randn_like(v) for k, v in model.state_dict().items()})
                 state_dict = model.state_dict()
             else:
                 reference_model = Transformer(self)
@@ -2314,11 +2314,11 @@ class ModelArgs:
                     model = AutoModel.from_pretrained(
                         self.CKPT_DIR, config=config, torch_dtype="auto", local_files_only=True
                     )
-                    # model.load_state_dict({k: torch.randn_like(v) for k, v in model.state_dict().items()})
                     model.apply(model._init_weights)
                 except Exception as e:
                     logger.info(f"Error loading dummy weights using .from_pretrained. Using .from_config. Error: {e}")
                     model = AutoModel.from_config(config)
+                # model.load_state_dict({k: torch.randn_like(v) for k, v in model.state_dict().items()})
             else:
                 if self.cache_hf_flag and self.cached_hf_model is None:
                     model = AutoModel.from_pretrained(self.CKPT_DIR)
@@ -2379,11 +2379,11 @@ class ModelArgs:
                     model = AutoModelForCausalLM.from_pretrained(
                         self.CKPT_DIR, config=config, torch_dtype="auto", local_files_only=True
                     )
-                    # model.load_state_dict({k: torch.randn_like(v) for k, v in model.state_dict().items()})
                     model.apply(model._init_weights)
                 except Exception as e:
                     logger.info(f"Error loading dummy weights using .from_pretrained. Using .from_config. Error: {e}")
                     model = AutoModelForCausalLM.from_config(config)
+                # model.load_state_dict({k: torch.randn_like(v) for k, v in model.state_dict().items()})
             else:
                 if self.is_gemma:
                     from transformers import Gemma3ForConditionalGeneration

--- a/models/demos/gemma3/tt/model_config.py
+++ b/models/demos/gemma3/tt/model_config.py
@@ -1793,8 +1793,10 @@ class ModelArgs:
                     model = AutoModelForCausalLM.from_pretrained(
                         self.CKPT_DIR, config=config, torch_dtype="auto", local_files_only=True
                     )
+                    # model.load_state_dict({k: torch.randn_like(v) for k, v in model.state_dict().items()})
                     model.apply(model._init_weights)
-                except:
+                except Exception as e:
+                    logger.info(f"Error loading dummy weights using .from_pretrained. Using .from_config. Error: {e}")
                     model = AutoModelForCausalLM.from_config(config)
 
                 state_dict = model.state_dict()
@@ -2312,8 +2314,10 @@ class ModelArgs:
                     model = AutoModel.from_pretrained(
                         self.CKPT_DIR, config=config, torch_dtype="auto", local_files_only=True
                     )
+                    # model.load_state_dict({k: torch.randn_like(v) for k, v in model.state_dict().items()})
                     model.apply(model._init_weights)
-                except:
+                except Exception as e:
+                    logger.info(f"Error loading dummy weights using .from_pretrained. Using .from_config. Error: {e}")
                     model = AutoModel.from_config(config)
             else:
                 if self.cache_hf_flag and self.cached_hf_model is None:
@@ -2375,8 +2379,10 @@ class ModelArgs:
                     model = AutoModelForCausalLM.from_pretrained(
                         self.CKPT_DIR, config=config, torch_dtype="auto", local_files_only=True
                     )
+                    # model.load_state_dict({k: torch.randn_like(v) for k, v in model.state_dict().items()})
                     model.apply(model._init_weights)
-                except:
+                except Exception as e:
+                    logger.info(f"Error loading dummy weights using .from_pretrained. Using .from_config. Error: {e}")
                     model = AutoModelForCausalLM.from_config(config)
             else:
                 if self.is_gemma:

--- a/models/demos/gemma3/tt/model_config.py
+++ b/models/demos/gemma3/tt/model_config.py
@@ -1787,7 +1787,16 @@ class ModelArgs:
                 config = AutoConfig.from_pretrained(self.LOCAL_HF_PARAMS[self.model_name])
                 config.num_layers = self.n_layers
                 config.num_hidden_layers = self.n_layers
-                model = AutoModelForCausalLM.from_config(config)
+
+                try:
+                    # .from_pretrained + _init_weights works faster than .from_config
+                    model = AutoModelForCausalLM.from_pretrained(
+                        self.CKPT_DIR, config=config, torch_dtype="auto", local_files_only=True
+                    )
+                    model.apply(model._init_weights)
+                except:
+                    model = AutoModelForCausalLM.from_config(config)
+
                 state_dict = model.state_dict()
             else:
                 reference_model = Transformer(self)
@@ -2297,7 +2306,15 @@ class ModelArgs:
                 config = AutoConfig.from_pretrained(self.LOCAL_HF_PARAMS[self.model_name])
                 config.num_layers = self.n_layers
                 config.num_hidden_layers = self.n_layers
-                model = AutoModel.from_config(config)
+
+                try:
+                    # .from_pretrained + _init_weights works faster than .from_config
+                    model = AutoModel.from_pretrained(
+                        self.CKPT_DIR, config=config, torch_dtype="auto", local_files_only=True
+                    )
+                    model.apply(model._init_weights)
+                except:
+                    model = AutoModel.from_config(config)
             else:
                 if self.cache_hf_flag and self.cached_hf_model is None:
                     model = AutoModel.from_pretrained(self.CKPT_DIR)
@@ -2352,7 +2369,15 @@ class ModelArgs:
                 config = AutoConfig.from_pretrained(self.LOCAL_HF_PARAMS[self.model_name])
                 config.num_layers = self.n_layers
                 config.num_hidden_layers = self.n_layers
-                model = AutoModelForCausalLM.from_config(config)
+
+                try:
+                    # .from_pretrained + _init_weights works faster than .from_config
+                    model = AutoModelForCausalLM.from_pretrained(
+                        self.CKPT_DIR, config=config, torch_dtype="auto", local_files_only=True
+                    )
+                    model.apply(model._init_weights)
+                except:
+                    model = AutoModelForCausalLM.from_config(config)
             else:
                 if self.is_gemma:
                     from transformers import Gemma3ForConditionalGeneration

--- a/models/tt_transformers/tests/test_model.py
+++ b/models/tt_transformers/tests/test_model.py
@@ -144,11 +144,11 @@ def test_model_inference(
             "llama32_90b": 0.9759,
             # TODO: Investigate HF_MODEL PCC drop compared to LLAMA_DIR (especially 3.2-3B)
             "Llama-3.1-8B": 0.965 if mode_accuracy else 0.954,
-            "Llama-3.1-70B": 0.979 if mode_accuracy else 0.97607,
-            "Llama-3.2-1B": 0.9990 if mode_accuracy else 0.9864,
-            "Llama-3.2-3B": 0.958 if mode_accuracy else 0.9479,
-            "Llama-3.2-11B": 0.955 if mode_accuracy else 0.944,
-            "Llama-3.2-90B": 0.9732,
+            "Llama-3.1-70B": 0.973,
+            "Llama-3.2-1B": 0.999 if mode_accuracy else 0.991,
+            "Llama-3.2-3B": 0.954 if mode_accuracy else 0.945,
+            "Llama-3.2-11B": 0.952 if mode_accuracy else 0.940,
+            "Llama-3.2-90B": 0.971,
             "Mistral-7B": 0.95 if mode_accuracy else 0.95,
         }[model_name]
 

--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -1919,7 +1919,20 @@ class ModelArgs:
                     config.num_hidden_layers = self.n_layers
 
                 model_cls = self.get_hf_model_cls()
-                model = model_cls.from_config(config, trust_remote_code=self.trust_remote_code_hf)
+
+                try:
+                    # .from_pretrained + _init_weights works faster than .from_config
+                    model = model_cls.from_pretrained(
+                        self.CKPT_DIR,
+                        config=config,
+                        torch_dtype="auto",
+                        trust_remote_code=self.trust_remote_code_hf,
+                        local_files_only=True,
+                    )
+                    model.apply(model._init_weights)
+                except:
+                    model = model_cls.from_config(config, trust_remote_code=self.trust_remote_code_hf)
+
                 state_dict = model.state_dict()
             else:
                 reference_model = Transformer(self)
@@ -2534,7 +2547,19 @@ class ModelArgs:
                 else:
                     config.num_layers = self.n_layers
                     config.num_hidden_layers = self.n_layers
-                model = model_cls.from_config(config, trust_remote_code=self.trust_remote_code_hf)
+
+                try:
+                    # .from_pretrained + _init_weights works faster than .from_config
+                    model = model_cls.from_pretrained(
+                        self.CKPT_DIR,
+                        config=config,
+                        torch_dtype="auto",
+                        trust_remote_code=self.trust_remote_code_hf,
+                        local_files_only=True,
+                    )
+                    model.apply(model._init_weights)
+                except:
+                    model = model_cls.from_config(config, trust_remote_code=self.trust_remote_code_hf)
             else:
                 if self.cache_hf_flag and self.cached_hf_model is None:
                     model = model_cls.from_pretrained(
@@ -2588,7 +2613,19 @@ class ModelArgs:
                 config = AutoConfig.from_pretrained(self.LOCAL_HF_PARAMS[self.model_name])
                 config.num_layers = self.n_layers
                 config.num_hidden_layers = self.n_layers
-                model = model_cls.from_config(config)
+
+                try:
+                    # .from_pretrained + _init_weights works faster than .from_config
+                    model = model_cls.from_pretrained(
+                        self.CKPT_DIR,
+                        config=config,
+                        torch_dtype="auto",
+                        trust_remote_code=self.trust_remote_code_hf,
+                        local_files_only=True,
+                    )
+                    model.apply(model._init_weights)
+                except:
+                    model = model_cls.from_config(config, trust_remote_code=self.trust_remote_code_hf)
             else:
                 if self.cached_hf_model is None:
                     model = model_cls.from_pretrained(self.CKPT_DIR, local_files_only=os.getenv("CI") == "true")

--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -1929,8 +1929,10 @@ class ModelArgs:
                         trust_remote_code=self.trust_remote_code_hf,
                         local_files_only=True,
                     )
+                    # model.load_state_dict({k: torch.randn_like(v) for k, v in model.state_dict().items()})
                     model.apply(model._init_weights)
-                except:
+                except Exception as e:
+                    logger.info(f"Error loading dummy weights using .from_pretrained. Using .from_config. Error: {e}")
                     model = model_cls.from_config(config, trust_remote_code=self.trust_remote_code_hf)
 
                 state_dict = model.state_dict()
@@ -2557,8 +2559,10 @@ class ModelArgs:
                         trust_remote_code=self.trust_remote_code_hf,
                         local_files_only=True,
                     )
+                    # model.load_state_dict({k: torch.randn_like(v) for k, v in model.state_dict().items()})
                     model.apply(model._init_weights)
-                except:
+                except Exception as e:
+                    logger.info(f"Error loading dummy weights using .from_pretrained. Using .from_config. Error: {e}")
                     model = model_cls.from_config(config, trust_remote_code=self.trust_remote_code_hf)
             else:
                 if self.cache_hf_flag and self.cached_hf_model is None:
@@ -2623,8 +2627,10 @@ class ModelArgs:
                         trust_remote_code=self.trust_remote_code_hf,
                         local_files_only=True,
                     )
+                    # model.load_state_dict({k: torch.randn_like(v) for k, v in model.state_dict().items()})
                     model.apply(model._init_weights)
-                except:
+                except Exception as e:
+                    logger.info(f"Error loading dummy weights using .from_pretrained. Using .from_config. Error: {e}")
                     model = model_cls.from_config(config, trust_remote_code=self.trust_remote_code_hf)
             else:
                 if self.cached_hf_model is None:

--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -1929,12 +1929,12 @@ class ModelArgs:
                         trust_remote_code=self.trust_remote_code_hf,
                         local_files_only=True,
                     )
-                    # model.load_state_dict({k: torch.randn_like(v) for k, v in model.state_dict().items()})
                     model.apply(model._init_weights)
                 except Exception as e:
                     logger.info(f"Error loading dummy weights using .from_pretrained. Using .from_config. Error: {e}")
                     model = model_cls.from_config(config, trust_remote_code=self.trust_remote_code_hf)
 
+                # model.load_state_dict({k: torch.randn_like(v) for k, v in model.state_dict().items()})
                 state_dict = model.state_dict()
             else:
                 reference_model = Transformer(self)
@@ -2559,11 +2559,11 @@ class ModelArgs:
                         trust_remote_code=self.trust_remote_code_hf,
                         local_files_only=True,
                     )
-                    # model.load_state_dict({k: torch.randn_like(v) for k, v in model.state_dict().items()})
                     model.apply(model._init_weights)
                 except Exception as e:
                     logger.info(f"Error loading dummy weights using .from_pretrained. Using .from_config. Error: {e}")
                     model = model_cls.from_config(config, trust_remote_code=self.trust_remote_code_hf)
+                # model.load_state_dict({k: torch.randn_like(v) for k, v in model.state_dict().items()})
             else:
                 if self.cache_hf_flag and self.cached_hf_model is None:
                     model = model_cls.from_pretrained(
@@ -2627,11 +2627,11 @@ class ModelArgs:
                         trust_remote_code=self.trust_remote_code_hf,
                         local_files_only=True,
                     )
-                    # model.load_state_dict({k: torch.randn_like(v) for k, v in model.state_dict().items()})
                     model.apply(model._init_weights)
                 except Exception as e:
                     logger.info(f"Error loading dummy weights using .from_pretrained. Using .from_config. Error: {e}")
                     model = model_cls.from_config(config, trust_remote_code=self.trust_remote_code_hf)
+                # model.load_state_dict({k: torch.randn_like(v) for k, v in model.state_dict().items()})
             else:
                 if self.cached_hf_model is None:
                     model = model_cls.from_pretrained(self.CKPT_DIR, local_files_only=os.getenv("CI") == "true")


### PR DESCRIPTION
### Ticket
#31862

### Problem description
Decrease latency for HF model creation with dummy weights.

### What's changed
Added "fast" implementation of HF model creation with random weights (see comparison table below). **Note**: works only if the weights are already downloaded.
Updated PCC targets (relaxed a bit after trying different seeds).
Added implementation of N(0, 1) weight initialization for HF which has PCC much closer to LLAMA_DIR PCC. See [the comment](https://github.com/tenstorrent/tt-metal/issues/31862#issuecomment-3492542811) for more details.

Comparison table of old (using .from_config) and new (using .from_pretrained and _init_weights) HF model initialization measured on a local machine.
| Model | old | new | gain |
|--------|--------|--------|--------|
| meta-llama/Llama-3.2-1B-Instruct | 14.554 | 9.378 | 36% |
| meta-llama/Llama-3.2-3B-Instruct | 21.868 | 14.158 | 35% |
| meta-llama/Llama-3.1-8B-Instruct | 30.781 | 20.5 | 33% |
| meta-llama/Llama-3.2-11B-Vision-Instruct | 193.432 | 157.187 | 19% |

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/19135460010) CI passes
- [x] [(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/19135454440) CI passes
- [x] [T3K unit tests](https://github.com/tenstorrent/tt-metal/actions/runs/19135438727) Failed tests are the same as in main and are not related to changes (also see [previous successful run](https://github.com/tenstorrent/tt-metal/actions/runs/19036305637))
- [x] [T3K frequent test (only llama3_90b)](https://github.com/tenstorrent/tt-metal/actions/runs/19114051285) CI passes
- [ ] Revert post-commit timeout to 30 mentioned in #31571 - was not done as "fast" model creation is available only with pre-downloaded weights