### PR TITLE
[TTT] Keep an actual copy of a page_table for comparison

### DIFF
--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -577,8 +577,9 @@ class Generator:
         if self.prev_page_table is None or any(
             not torch.equal(prev, curr) for prev, curr in zip(self.prev_page_table, page_table)
         ):
+            # If the page table has changed, it means that the inputs have shuffled, so we need to copy them from host again
             reset_inputs = True
-            self.prev_page_table = page_table
+            self.prev_page_table = tuple(pt.clone() for pt in page_table)
 
         if reset_inputs:
             for i in range(self.data_parallel):


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/31453

### Problem description
KV cache corruption when running more than 32 requests through vLLM

### What's changed
We use a local copy of the page table to know if the table has changed.
Instead of keeping a reference, keep an actual copy of the page table tensors.

### Checklist
- [Shield CI](https://github.com/tenstorrent/tt-shield/actions/runs/19119077288) ✅ (Benchmarks and ifeval passing)
- [vLLM Nightly](https://github.com/tenstorrent/tt-metal/actions/runs/19119090343/job/54637037295) ✅ (Qwen2.5 fails unrelated)