### PR TITLE
#0: [skip ci] Remove unnecessary label in blackhole-multi-card-post-commit-tests-impl.yaml

### DIFF
--- a/.github/workflows/blackhole-multi-card-post-commit-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-post-commit-tests-impl.yaml
@@ -37,7 +37,6 @@ jobs:
     runs-on:
       - in-service
       - arch-blackhole
-      - pipeline-functional
       - ${{ inputs.runner-label }}
     container:
       image: ${{ inputs.docker-image || 'docker-image-unresolved' }}


### PR DESCRIPTION
### Ticket
None

### Problem description
`pipeline-functional` not needed since it will exclude a subset of runners (only needed for model tests to differentiate perf vs func)

### What's changed
Remove label