### PR TITLE
Deeplab V3 performance improvements

### DIFF
--- a/models/experimental/panoptic_deeplab/tests/pcc/test_aspp.py
+++ b/models/experimental/panoptic_deeplab/tests/pcc/test_aspp.py
@@ -112,6 +112,7 @@ def test_ttnn_aspp(device, model_location_generator):
     ttnn_aspp_output = ttnn_model.semantic_head.decoder["res5"]["project_conv"](ttnn_input)
 
     ttnn_aspp_output_torch = ttnn.to_torch(ttnn_aspp_output).permute(0, 3, 1, 2)
+    ttnn_aspp_output_torch = torch.reshape(ttnn_aspp_output_torch, (1, 256, 32, 64))
 
     pcc_passed, pcc_message = assert_with_pcc(pytorch_aspp_output, ttnn_aspp_output_torch, pcc=0.99)
 

--- a/models/experimental/panoptic_deeplab/tests/pcc/test_insemb.py
+++ b/models/experimental/panoptic_deeplab/tests/pcc/test_insemb.py
@@ -127,7 +127,7 @@ def test_ttnn_insemb(device, model_location_generator):
             ttnn_center_out_tt,
             to_channel_first=False,
             output_channels=ttnn_model.instance_head.get_center_output_channels_for_slicing(),
-            exp_pcc=0.885,
+            exp_pcc=0.887,
         )
     )
     all_passed.append(
@@ -137,7 +137,7 @@ def test_ttnn_insemb(device, model_location_generator):
             ttnn_offset_out_tt,
             to_channel_first=False,
             output_channels=ttnn_model.instance_head.get_offset_output_channels_for_slicing(),
-            exp_pcc=0.741,
+            exp_pcc=0.742,
         )
     )
 

--- a/models/experimental/panoptic_deeplab/tests/pcc/test_semseg.py
+++ b/models/experimental/panoptic_deeplab/tests/pcc/test_semseg.py
@@ -120,6 +120,6 @@ def test_ttnn_semseg(device, model_location_generator):
         ttnn_out_tt,
         to_channel_first=False,
         output_channels=ttnn_model.semantic_head.get_output_channels_for_slicing(),
-        exp_pcc=0.970,
+        exp_pcc=0.972,
     )
     assert passed, f"Semantic segmentation PCC test failed"

--- a/models/experimental/panoptic_deeplab/tests/pcc/test_tt_model.py
+++ b/models/experimental/panoptic_deeplab/tests/pcc/test_tt_model.py
@@ -137,7 +137,7 @@ def test_model_panoptic_deeplab(device, model_category, model_location_generator
             ttnn_semantic,
             to_channel_first=False,
             output_channels=ttnn_model.semantic_head.get_output_channels_for_slicing(),
-            exp_pcc=0.977,
+            exp_pcc=0.986,
         )
     )
     if model_category == PANOPTIC_DEEPLAB:
@@ -148,7 +148,7 @@ def test_model_panoptic_deeplab(device, model_category, model_location_generator
                 ttnn_center,
                 to_channel_first=False,
                 output_channels=ttnn_model.instance_head.get_center_output_channels_for_slicing(),
-                exp_pcc=0.792,
+                exp_pcc=0.805,
             )
         )
         all_passed.append(
@@ -158,7 +158,7 @@ def test_model_panoptic_deeplab(device, model_category, model_location_generator
                 ttnn_offset,
                 to_channel_first=False,
                 output_channels=ttnn_model.instance_head.get_offset_output_channels_for_slicing(),
-                exp_pcc=0.991,
+                exp_pcc=0.990,
             )
         )
 

--- a/models/experimental/panoptic_deeplab/tests/pcc/test_tt_model.py
+++ b/models/experimental/panoptic_deeplab/tests/pcc/test_tt_model.py
@@ -137,7 +137,7 @@ def test_model_panoptic_deeplab(device, model_category, model_location_generator
             ttnn_semantic,
             to_channel_first=False,
             output_channels=ttnn_model.semantic_head.get_output_channels_for_slicing(),
-            exp_pcc=0.989,
+            exp_pcc=0.977,
         )
     )
     if model_category == PANOPTIC_DEEPLAB:

--- a/models/experimental/panoptic_deeplab/tests/test_device_perf_pdl.py
+++ b/models/experimental/panoptic_deeplab/tests/test_device_perf_pdl.py
@@ -22,7 +22,7 @@ from models.experimental.panoptic_deeplab.reference.pytorch_model import PANOPTI
         ),
         (
             "pytest models/experimental/panoptic_deeplab/tests/pcc/test_tt_model.py::test_model_panoptic_deeplab -k test_deeplab_v3_plus",
-            34_387_871,
+            25_065_032,
             DEEPLAB_V3_PLUS,
             DEEPLAB_V3_PLUS,
             1,

--- a/models/experimental/panoptic_deeplab/tests/test_device_perf_pdl.py
+++ b/models/experimental/panoptic_deeplab/tests/test_device_perf_pdl.py
@@ -4,23 +4,22 @@
 
 import pytest
 from models.perf.device_perf_utils import run_model_device_perf_test
-from models.experimental.panoptic_deeplab.reference.pytorch_model import DEEPLAB_V3_PLUS
+from models.experimental.panoptic_deeplab.reference.pytorch_model import DEEPLAB_V3_PLUS, PANOPTIC_DEEPLAB
 
 
 @pytest.mark.parametrize(
     "command, expected_device_perf_ns_per_iteration, subdir, model_name, num_iterations, batch_size, margin, comments",
     [
-        # Skip panotpic test, currently broken
-        # (
-        #     "pytest models/experimental/panoptic_deeplab/tests/pcc/test_tt_model.py::test_model_panoptic_deeplab -k test_panoptic_deeplab",
-        #     51_749_520,
-        #     PANOPTIC_DEEPLAB,
-        #     PANOPTIC_DEEPLAB,
-        #     1,
-        #     1,
-        #     0.015,
-        #     "",
-        # ),
+        (
+            "pytest models/experimental/panoptic_deeplab/tests/pcc/test_tt_model.py::test_model_panoptic_deeplab -k test_panoptic_deeplab",
+            51_749_520,
+            PANOPTIC_DEEPLAB,
+            PANOPTIC_DEEPLAB,
+            1,
+            1,
+            0.015,
+            "",
+        ),
         (
             "pytest models/experimental/panoptic_deeplab/tests/pcc/test_tt_model.py::test_model_panoptic_deeplab -k test_deeplab_v3_plus",
             23_648_515,
@@ -32,12 +31,14 @@ from models.experimental.panoptic_deeplab.reference.pytorch_model import DEEPLAB
             "",
         ),
     ],
-    ids=["test_deeplab_v3_plus"],
+    ids=["test_panoptic_deeplab", "test_deeplab_v3_plus"],
 )
 @pytest.mark.models_device_performance_bare_metal
 def test_device_perf_pdl(
     command, expected_device_perf_ns_per_iteration, subdir, model_name, num_iterations, batch_size, margin, comments
 ):
+    if model_name == PANOPTIC_DEEPLAB:
+        pytest.skip("PANOPTIC_DEEPLAB is currently not supported")
     run_model_device_perf_test(
         command=command,
         expected_device_perf_ns_per_iteration=expected_device_perf_ns_per_iteration,

--- a/models/experimental/panoptic_deeplab/tests/test_device_perf_pdl.py
+++ b/models/experimental/panoptic_deeplab/tests/test_device_perf_pdl.py
@@ -4,25 +4,26 @@
 
 import pytest
 from models.perf.device_perf_utils import run_model_device_perf_test
-from models.experimental.panoptic_deeplab.reference.pytorch_model import PANOPTIC_DEEPLAB, DEEPLAB_V3_PLUS
+from models.experimental.panoptic_deeplab.reference.pytorch_model import DEEPLAB_V3_PLUS
 
 
 @pytest.mark.parametrize(
     "command, expected_device_perf_ns_per_iteration, subdir, model_name, num_iterations, batch_size, margin, comments",
     [
-        (
-            "pytest models/experimental/panoptic_deeplab/tests/pcc/test_tt_model.py::test_model_panoptic_deeplab -k test_panoptic_deeplab",
-            51_749_520,
-            PANOPTIC_DEEPLAB,
-            PANOPTIC_DEEPLAB,
-            1,
-            1,
-            0.015,
-            "",
-        ),
+        # Skip panotpic test, currently broken
+        # (
+        #     "pytest models/experimental/panoptic_deeplab/tests/pcc/test_tt_model.py::test_model_panoptic_deeplab -k test_panoptic_deeplab",
+        #     51_749_520,
+        #     PANOPTIC_DEEPLAB,
+        #     PANOPTIC_DEEPLAB,
+        #     1,
+        #     1,
+        #     0.015,
+        #     "",
+        # ),
         (
             "pytest models/experimental/panoptic_deeplab/tests/pcc/test_tt_model.py::test_model_panoptic_deeplab -k test_deeplab_v3_plus",
-            25_065_032,
+            23_648_515,
             DEEPLAB_V3_PLUS,
             DEEPLAB_V3_PLUS,
             1,

--- a/models/experimental/panoptic_deeplab/tests/test_device_perf_pdl.py
+++ b/models/experimental/panoptic_deeplab/tests/test_device_perf_pdl.py
@@ -31,7 +31,7 @@ from models.experimental.panoptic_deeplab.reference.pytorch_model import PANOPTI
             "",
         ),
     ],
-    ids=["test_panoptic_deeplab", "test_deeplab_v3_plus"],
+    ids=["test_deeplab_v3_plus"],
 )
 @pytest.mark.models_device_performance_bare_metal
 def test_device_perf_pdl(

--- a/models/experimental/panoptic_deeplab/tests/test_device_perf_pdl.py
+++ b/models/experimental/panoptic_deeplab/tests/test_device_perf_pdl.py
@@ -12,7 +12,7 @@ from models.experimental.panoptic_deeplab.reference.pytorch_model import DEEPLAB
     [
         (
             "pytest models/experimental/panoptic_deeplab/tests/pcc/test_tt_model.py::test_model_panoptic_deeplab -k test_panoptic_deeplab",
-            51_749_520,
+            32_661_399,
             PANOPTIC_DEEPLAB,
             PANOPTIC_DEEPLAB,
             1,
@@ -37,8 +37,6 @@ from models.experimental.panoptic_deeplab.reference.pytorch_model import DEEPLAB
 def test_device_perf_pdl(
     command, expected_device_perf_ns_per_iteration, subdir, model_name, num_iterations, batch_size, margin, comments
 ):
-    if model_name == PANOPTIC_DEEPLAB:
-        pytest.skip("PANOPTIC_DEEPLAB is currently not supported")
     run_model_device_perf_test(
         command=command,
         expected_device_perf_ns_per_iteration=expected_device_perf_ns_per_iteration,

--- a/models/experimental/panoptic_deeplab/tt/model_configs.py
+++ b/models/experimental/panoptic_deeplab/tt/model_configs.py
@@ -395,13 +395,10 @@ class ModelOptimisations:
         path = f"decoder.{stage}.fuse_conv.0"
 
         if iteration_index == 0 and stage in ["res3", "res2"]:
-            num_slices = 2 if stage == "res3" else 4
-            act_block_h = 32 if stage == "res3" else 64
-
             self.register_layer_override(
                 path,
-                slice_strategy=ChannelSliceStrategyConfiguration(num_slices=num_slices),
-                sharding_strategy=HeightShardedStrategyConfiguration(act_block_h_override=act_block_h),
+                slice_strategy=None,
+                sharding_strategy=HeightShardedStrategyConfiguration(act_block_h_override=0),
                 deallocate_activation=False,
                 activation=None,
             )

--- a/models/experimental/panoptic_deeplab/tt/model_configs.py
+++ b/models/experimental/panoptic_deeplab/tt/model_configs.py
@@ -222,14 +222,6 @@ class ModelOptimisations:
             sharding_strategy=HeightShardedStrategyConfiguration(act_block_h_override=128),  # 4 tiles
         )
 
-        # Conv3: 1x1 bottleneck convolutions (matmul path with width slicing)
-        for i in range(3):
-            self.register_layer_override(
-                f"res2.{i}.conv3",
-                slice_strategy=WidthSliceStrategyConfiguration(num_slices=2),
-                sharding_strategy=HeightShardedStrategyConfiguration(act_block_h_override=32),  # 1 tile
-            )
-
     def _setup_res3_stage(self):
         """
         Res3 (128x256->64x128): 4 bottleneck blocks, 512 output channels
@@ -252,18 +244,11 @@ class ModelOptimisations:
             start_idx=1,
         )
 
-        # Conv3: 1x1 bottleneck with width slicing
-        self.register_layer_override(
-            "res3.0.conv3",
-            slice_strategy=WidthSliceStrategyConfiguration(num_slices=2),
-            sharding_strategy=HeightShardedStrategyConfiguration(act_block_h_override=32),
-        )
-
         # Shortcut: Downsample layer in first block
         self.register_layer_override(
             "res3.0.shortcut",
-            slice_strategy=WidthSliceStrategyConfiguration(num_slices=2),
-            sharding_strategy=BlockShardedStrategyConfiguration(),
+            slice_strategy=WidthSliceStrategyConfiguration(num_slices=0),
+            sharding_strategy=HeightShardedStrategyConfiguration(),
         )
 
     def _setup_res4_stage(self):
@@ -290,6 +275,7 @@ class ModelOptimisations:
         self.register_layer_override(
             "res4.0.shortcut",
             sharding_strategy=BlockShardedStrategyConfiguration(),
+            enable_weights_double_buffer=True,
         )
 
     def _setup_res5_stage(self):
@@ -302,6 +288,7 @@ class ModelOptimisations:
                 f"res5.{i}.conv2",
                 sharding_strategy=BlockShardedStrategyConfiguration(),
                 slice_strategy=WidthSliceStrategyConfiguration(num_slices=2),
+                enable_weights_double_buffer=True,
             )
 
     def _setup_resnet_activation_fusion(self):
@@ -351,7 +338,6 @@ class ModelOptimisations:
         no_slice_branches = ["aspp.convs.0", "aspp.convs.4", "aspp.project"]
         self._register_multiple_layers(
             no_slice_branches,
-            slice_strategy=None,
             deallocate_activation=False,
         )
 
@@ -369,6 +355,7 @@ class ModelOptimisations:
                 sharding_strategy=BlockShardedStrategyConfiguration(act_block_h_override=act_block_h),
                 deallocate_activation=False,
                 activation=None,
+                enable_weights_double_buffer=True,
             )
 
     # -------------------------------------------------------------------------
@@ -389,7 +376,6 @@ class ModelOptimisations:
         projection_layers = [f"decoder.{stage}.project_conv" for stage in ["res5", "res4", "res3", "res2"]]
         self._register_multiple_layers(
             projection_layers,
-            slice_strategy=None,
             deallocate_activation=False,
         )
 

--- a/models/experimental/panoptic_deeplab/tt/tt_aspp.py
+++ b/models/experimental/panoptic_deeplab/tt/tt_aspp.py
@@ -130,7 +130,21 @@ class TtASPP(LightweightModule):
             else:
                 branch_out = conv(x)
 
-                if branch_out.shape[1] == 1 and branch_out.shape[2] == H * W:
+                # Reshape logic for aspp.convs.0 that now outputs flattened format [1,1,NHW,C] -> [N,H,W,C]
+                if i == 0:
+                    if branch_out.shape[1] == 1 and branch_out.shape[2] > 1:
+                        # Flattened format: [1, 1, NHW, C] -> [1, H, W, C]
+                        NHW = branch_out.shape[2]
+                        C_out = branch_out.shape[3]  # Use different variable name to avoid overwriting C
+                        # W = 2*H, so NHW = N*H*W = 1*H*2*H = 2*H^2, therefore H = sqrt(NHW/2)
+                        H_out = int((NHW // 2) ** 0.5)
+                        W_out = 2 * H_out
+                        if H_out * W_out == NHW:
+                            branch_out = ttnn.reshape(branch_out, (N, H_out, W_out, C_out))
+                            logger.debug(
+                                f"aspp.convs.0 reshaped output from [1, 1, {NHW}, {C_out}] to [{N}, {H_out}, {W_out}, {C_out}]"
+                            )
+                elif branch_out.shape[1] == 1 and branch_out.shape[2] == H * W:
                     branch_out = ttnn.reshape(branch_out, (N, H, W, branch_out.shape[3]))
 
                 if needs_manual_relu:
@@ -169,6 +183,19 @@ class TtASPP(LightweightModule):
         # Process pooled branch with conv
         logger.info(f"🔷 Executing conv: aspp.convs.4")
         pooled = self.pool_conv(pooled)
+        # Reshape logic for aspp.convs.4 that now outputs flattened format [1,1,NHW,C] -> [N,H,W,C]
+        if pooled.shape[1] == 1 and pooled.shape[2] > 1:
+            # Flattened format: [1, 1, NHW, C] -> [1, H, W, C]
+            NHW = pooled.shape[2]
+            C_pooled = pooled.shape[3]  # Use different variable name to avoid overwriting C
+            # W = 2*H, so NHW = N*H*W = 1*H*2*H = 2*H^2, therefore H = sqrt(NHW/2)
+            H_out = int((NHW // 2) ** 0.5)
+            W_out = 2 * H_out
+            if H_out * W_out == NHW:
+                pooled = ttnn.reshape(pooled, (N, H_out, W_out, C_pooled))
+                logger.debug(
+                    f"aspp.convs.4 reshaped output from [1, 1, {NHW}, {C_pooled}] to [{N}, {H_out}, {W_out}, {C_pooled}]"
+                )
 
         # Upsample pooled branch to match input spatial dimensions
         current_h, current_w = pooled.shape[1], pooled.shape[2]
@@ -206,6 +233,19 @@ class TtASPP(LightweightModule):
         # Project to final output
         logger.info(f"🔷 Executing conv: aspp.project")
         res = self.project_conv(res)
+        # Reshape logic for aspp.project that now outputs flattened format [1,1,NHW,C] -> [N,H,W,C]
+        if res.shape[1] == 1 and res.shape[2] > 1:
+            # Flattened format: [1, 1, NHW, C] -> [1, H, W, C]
+            NHW = res.shape[2]
+            C_project = res.shape[3]  # Use different variable name to avoid overwriting C
+            # W = 2*H, so NHW = N*H*W = 1*H*2*H = 2*H^2, therefore H = sqrt(NHW/2)
+            H_out = int((NHW // 2) ** 0.5)
+            W_out = 2 * H_out
+            if H_out * W_out == NHW:
+                res = ttnn.reshape(res, (N, H_out, W_out, C_project))
+                logger.debug(
+                    f"aspp.project reshaped output from [1, 1, {NHW}, {C_project}] to [{N}, {H_out}, {W_out}, {C_project}]"
+                )
         logger.debug(f"TtASPP forward pass complete - output shape: {res.shape}")
 
         return res

--- a/models/experimental/panoptic_deeplab/tt/tt_semseg.py
+++ b/models/experimental/panoptic_deeplab/tt/tt_semseg.py
@@ -269,6 +269,7 @@ class TtDeepLabV3PlusHead(LightweightModule):
             ttnn.deallocate(y_upsampled)
             # Use single conv versions - slicing handled by config, ReLU is fused
             logger.info(f"🔷 Executing conv: decoder.{f_key}.fuse_conv.0")
+            y = ttnn.to_layout(y, ttnn.ROW_MAJOR_LAYOUT)
             y_conv0 = stage["fuse_conv_0"](y)
             ttnn.deallocate(y)
 

--- a/models/experimental/panoptic_deeplab/tt/tt_semseg.py
+++ b/models/experimental/panoptic_deeplab/tt/tt_semseg.py
@@ -10,6 +10,7 @@ from models.experimental.panoptic_deeplab.tt.tt_upsample import BilinearUpsample
 from models.tt_cnn.tt.builder import TtConv2d
 from models.experimental.panoptic_deeplab.reference.pytorch_semseg import ShapeSpec
 from models.common.lightweightmodule import LightweightModule
+from models.experimental.panoptic_deeplab.tt.common import reshape_flattened_conv_output
 
 
 class TtDeepLabV3PlusHead(LightweightModule):
@@ -186,17 +187,7 @@ class TtDeepLabV3PlusHead(LightweightModule):
         y = stage["project_conv"](x)
         # Reshape logic for decoder.res5.project_conv (ASPP) - ASPP already handles its own reshape internally
         # But add safety check in case it's flattened
-        if y.shape[1] == 1 and y.shape[2] > 1:
-            NHW = y.shape[2]
-            C = y.shape[3]
-            # W = 2*H, so NHW = N*H*W = 1*H*2*H = 2*H^2, therefore H = sqrt(NHW/2)
-            H_out = int((NHW // 2) ** 0.5)
-            W_out = 2 * H_out
-            if H_out * W_out == NHW:
-                y = ttnn.reshape(y, (1, H_out, W_out, C))
-                logger.debug(
-                    f"decoder.{aspp_feature_key}.project_conv reshaped output from [1, 1, {NHW}, {C}] to [1, {H_out}, {W_out}, {C}]"
-                )
+        y = reshape_flattened_conv_output(y, batch_size=1, layer_name=f"decoder.{aspp_feature_key}.project_conv")
         y = ttnn.to_memory_config(y, ttnn.DRAM_MEMORY_CONFIG)
         logger.debug(f"TtDeepLabV3PlusHead ASPP stage complete, output shape: {y.shape}")
 
@@ -209,18 +200,7 @@ class TtDeepLabV3PlusHead(LightweightModule):
             logger.info(f"🔷 Executing conv: decoder.{f_key}.project_conv")
             proj_x = stage["project_conv"](x)
             # Reshape logic for decoder.{res2,res3,res4}.project_conv that now outputs flattened format [1,1,NHW,C] -> [N,H,W,C]
-            if proj_x.shape[1] == 1 and proj_x.shape[2] > 1:
-                # Flattened format: [1, 1, NHW, C] -> [1, H, W, C]
-                NHW = proj_x.shape[2]
-                C = proj_x.shape[3]
-                # W = 2*H, so NHW = N*H*W = 1*H*2*H = 2*H^2, therefore H = sqrt(NHW/2)
-                H_out = int((NHW // 2) ** 0.5)
-                W_out = 2 * H_out
-                if H_out * W_out == NHW:
-                    proj_x = ttnn.reshape(proj_x, (1, H_out, W_out, C))
-                    logger.debug(
-                        f"decoder.{f_key}.project_conv reshaped output from [1, 1, {NHW}, {C}] to [1, {H_out}, {W_out}, {C}]"
-                    )
+            proj_x = reshape_flattened_conv_output(proj_x, batch_size=1, layer_name=f"decoder.{f_key}.project_conv")
             proj_x = ttnn.to_memory_config(proj_x, ttnn.DRAM_MEMORY_CONFIG)
             logger.debug(f"TtDeepLabV3PlusHead fusion stage {i+1} projection complete, shape: {proj_x.shape}")
 

--- a/models/experimental/panoptic_deeplab/tt/tt_semseg.py
+++ b/models/experimental/panoptic_deeplab/tt/tt_semseg.py
@@ -484,7 +484,7 @@ class TtPanopticDeepLabSemSegHead(TtDeepLabV3PlusHead):
             logger.debug(f"Final upsample: input y is allocated (shape={y.shape}, dtype={y.dtype}, layout={y.layout})")
 
         # Matmul based upsample
-        print("y shape: ", y.shape)
+        logger.debug(f"y shape: {y.shape}")
         y = ttnn.reshape(y, (y.shape[0], 128, 256, y.shape[3]))
         y = self.final_upsample(y)
 

--- a/models/experimental/panoptic_deeplab/tt/tt_semseg.py
+++ b/models/experimental/panoptic_deeplab/tt/tt_semseg.py
@@ -477,6 +477,8 @@ class TtPanopticDeepLabSemSegHead(TtDeepLabV3PlusHead):
             logger.debug(f"Final upsample: input y is allocated (shape={y.shape}, dtype={y.dtype}, layout={y.layout})")
 
         # Matmul based upsample
+        print("y shape: ", y.shape)
+        y = ttnn.reshape(y, (y.shape[0], 128, 256, y.shape[3]))
         y = self.final_upsample(y)
 
         # Check allocation after final upsample


### PR DESCRIPTION
### Ticket
None

### Problem description
Optimizing performance for Deeplab V3 Plus (Panoptic Deeplab without instance embedding)

### What's changed
Some convolutions were optimized and no longer need to be DRAM sliced and can run in L1.
Added some reshapes to accommodate this.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (unrelated timeout) (passed on rerun)
- [x] [Blackhole Nightly](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-nightly-tests.yaml) CI passes
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes
- [x] New/Existing tests provide coverage for changes