### PR TITLE
Remove any redundancy in the sys eng testing

### DIFF
--- a/tests/ttnn/stress_tests/test_ccl.py
+++ b/tests/ttnn/stress_tests/test_ccl.py
@@ -16,21 +16,15 @@ from models.common.utility_functions import skip_for_blackhole, skip_for_wormhol
     "num_devices, ag_output_shape, dim, layout, all_gather_topology",
     [
         (4, [1, 1, 10000, 32768], 3, ttnn.TILE_LAYOUT, ttnn.Topology.Linear),
-        (4, [1, 1, 10000, 32768], 3, ttnn.TILE_LAYOUT, ttnn.Topology.Ring),
-        (2, [1, 1, 10000, 32768], 3, ttnn.TILE_LAYOUT, ttnn.Topology.Linear),
     ],
 )
 @pytest.mark.parametrize(
     "ag_input_dtype",
     [
-        ttnn.bfloat16,
         ttnn.uint32,
-        ttnn.bfloat8_b,
     ],
     ids=[
-        "float_16",
         "uint_32",
-        "bfloat_8",
     ],
 )
 @pytest.mark.parametrize(
@@ -64,9 +58,8 @@ from models.common.utility_functions import skip_for_blackhole, skip_for_wormhol
     "cluster_axis",
     [
         0,
-        1,
     ],
-    ids=["row", "column"],
+    ids=["row"],
 )
 @pytest.mark.parametrize("chunks_per_sync", [20])
 @pytest.mark.parametrize("num_workers_per_link", [2])

--- a/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/Sys_eng_smoke_tests/test_ccl_smoke_test_galaxy_mesh.py
+++ b/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/Sys_eng_smoke_tests/test_ccl_smoke_test_galaxy_mesh.py
@@ -27,14 +27,10 @@ from tests.ttnn.unit_tests.operations.ccl.blackhole_CI.box.nightly.test_all_gath
 @pytest.mark.parametrize(
     "ag_input_dtype",
     [
-        ttnn.bfloat16,
         ttnn.uint32,
-        ttnn.bfloat8_b,
     ],
     ids=[
-        "float_16",
         "uint_32",
-        "bfloat_8",
     ],
 )
 @pytest.mark.parametrize(
@@ -113,29 +109,19 @@ def test_ccl_ddr_smoke_test(
     ttnn.ReadDeviceProfiler(submesh_device)
 
 
-# P300 with 2 harvested columns so 110 cores are available.
-# Test utilizes 1'478'492.16 bytes per core to nearly maximize 1.5MB size
 @skip_for_wormhole_b0()
 @pytest.mark.parametrize("num_links", [2])
 @pytest.mark.parametrize(
-    "num_devices, ag_output_shape, dim, layout, all_gather_topology, cluster_axis",
+    "num_devices, ag_output_shape, dim, layout, all_gather_topology, cluster_axis, ag_input_dtype",
     [
-        (4, [1, 1, 6016, 8192], 3, ttnn.TILE_LAYOUT, ttnn.Topology.Linear, 0),
-        (8, [1, 1, 6016, 4096], 3, ttnn.TILE_LAYOUT, ttnn.Topology.Linear, 1),
-    ],
-    ids=["horizontal_test", "vertical_test"],
-)
-@pytest.mark.parametrize(
-    "ag_input_dtype",
-    [
-        ttnn.bfloat16,
-        ttnn.uint32,
-        ttnn.bfloat8_b,
+        (4, [1, 1, 6016, 8192], 3, ttnn.TILE_LAYOUT, ttnn.Topology.Linear, 0, ttnn.bfloat16),
+        (8, [1, 1, 6016, 4096], 3, ttnn.TILE_LAYOUT, ttnn.Topology.Linear, 1, ttnn.uint32),
+        (8, [1, 1, 6016, 4096], 3, ttnn.TILE_LAYOUT, ttnn.Topology.Linear, 1, ttnn.bfloat8_b),
     ],
     ids=[
-        "float_16",
-        "uint_32",
-        "bfloat_8",
+        "horizontal_test_bfloat16",
+        "vertical_test_uint32",
+        "vertical_test_bfloat8",
     ],
 )
 @pytest.mark.parametrize(

--- a/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/Sys_eng_smoke_tests/test_ccl_smoke_test_galaxy_torus.py
+++ b/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/Sys_eng_smoke_tests/test_ccl_smoke_test_galaxy_torus.py
@@ -27,14 +27,10 @@ from tests.ttnn.unit_tests.operations.ccl.blackhole_CI.box.nightly.test_all_gath
 @pytest.mark.parametrize(
     "ag_input_dtype",
     [
-        ttnn.bfloat16,
         ttnn.uint32,
-        ttnn.bfloat8_b,
     ],
     ids=[
-        "float_16",
         "uint_32",
-        "bfloat_8",
     ],
 )
 @pytest.mark.parametrize(
@@ -118,25 +114,13 @@ def test_ccl_ddr_smoke_test(
 @skip_for_wormhole_b0()
 @pytest.mark.parametrize("num_links", [2])
 @pytest.mark.parametrize(
-    "num_devices, ag_output_shape, dim, layout, all_gather_topology, cluster_axis",
+    "num_devices, ag_output_shape, dim, layout, all_gather_topology, cluster_axis, ag_input_dtype",
     [
-        (4, [1, 1, 6016, 8192], 3, ttnn.TILE_LAYOUT, ttnn.Topology.Ring, 0),
-        (8, [1, 1, 6016, 4096], 3, ttnn.TILE_LAYOUT, ttnn.Topology.Ring, 1),
+        (4, [1, 1, 6016, 8192], 3, ttnn.TILE_LAYOUT, ttnn.Topology.Ring, 0, ttnn.bfloat16),
+        (8, [1, 1, 6016, 4096], 3, ttnn.TILE_LAYOUT, ttnn.Topology.Ring, 1, ttnn.uint32),
+        (8, [1, 1, 6016, 4096], 3, ttnn.TILE_LAYOUT, ttnn.Topology.Ring, 1, ttnn.bfloat8_b),
     ],
-    ids=["horizontal_test", "vertical_test"],
-)
-@pytest.mark.parametrize(
-    "ag_input_dtype",
-    [
-        ttnn.bfloat16,
-        ttnn.uint32,
-        ttnn.bfloat8_b,
-    ],
-    ids=[
-        "float_16",
-        "uint_32",
-        "bfloat_8",
-    ],
+    ids=["horizontal_test_bf16", "vertical_test_u32", "vertical_test_bf8"],
 )
 @pytest.mark.parametrize(
     "mem_config_input, mem_config_ag",

--- a/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/Sys_eng_smoke_tests/test_ccl_smoke_test_lb.py
+++ b/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/Sys_eng_smoke_tests/test_ccl_smoke_test_lb.py
@@ -27,14 +27,10 @@ from tests.ttnn.unit_tests.operations.ccl.blackhole_CI.box.nightly.test_all_gath
 @pytest.mark.parametrize(
     "ag_input_dtype",
     [
-        ttnn.bfloat16,
         ttnn.uint32,
-        ttnn.bfloat8_b,
     ],
     ids=[
-        "float_16",
         "uint_32",
-        "bfloat_8",
     ],
 )
 @pytest.mark.parametrize(
@@ -118,25 +114,13 @@ def test_ccl_ddr_smoke_test(
 @skip_for_wormhole_b0()
 @pytest.mark.parametrize("num_links", [2])
 @pytest.mark.parametrize(
-    "num_devices, ag_output_shape, dim, layout, all_gather_topology, cluster_axis",
+    "num_devices, ag_output_shape, dim, layout, all_gather_topology, cluster_axis, ag_input_dtype",
     [
-        (4, [1, 1, 6016, 8192], 3, ttnn.TILE_LAYOUT, ttnn.Topology.Linear, 0),
-        (2, [1, 1, 6016, 4096], 3, ttnn.TILE_LAYOUT, ttnn.Topology.Linear, 1),
+        (4, [1, 1, 6016, 8192], 3, ttnn.TILE_LAYOUT, ttnn.Topology.Linear, 0, ttnn.bfloat16),
+        (2, [1, 1, 6016, 4096], 3, ttnn.TILE_LAYOUT, ttnn.Topology.Linear, 1, ttnn.uint32),
+        (2, [1, 1, 6016, 4096], 3, ttnn.TILE_LAYOUT, ttnn.Topology.Linear, 1, ttnn.bfloat8_b),
     ],
-    ids=["horizontal_test", "vertical_test"],
-)
-@pytest.mark.parametrize(
-    "ag_input_dtype",
-    [
-        ttnn.bfloat16,
-        ttnn.uint32,
-        ttnn.bfloat8_b,
-    ],
-    ids=[
-        "float_16",
-        "uint_32",
-        "bfloat_8",
-    ],
+    ids=["horizontal_test_bf16", "vertical_test_u32", "vertical_test_bf8"],
 )
 @pytest.mark.parametrize(
     "mem_config_input, mem_config_ag",

--- a/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/Sys_eng_smoke_tests/test_ccl_smoke_test_p300.py
+++ b/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/Sys_eng_smoke_tests/test_ccl_smoke_test_p300.py
@@ -22,14 +22,10 @@ from tests.ttnn.unit_tests.operations.ccl.blackhole_CI.box.nightly.test_all_gath
 @pytest.mark.parametrize(
     "ag_input_dtype",
     [
-        ttnn.bfloat16,
         ttnn.uint32,
-        # ttnn.bfloat8_b, #issue #30353
     ],
     ids=[
-        "float_16",
         "uint_32",
-        # "bfloat_8",
     ],
 )
 @pytest.mark.parametrize(

--- a/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/Sys_eng_smoke_tests/test_ccl_smoke_test_qb.py
+++ b/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/Sys_eng_smoke_tests/test_ccl_smoke_test_qb.py
@@ -22,14 +22,10 @@ from tests.ttnn.unit_tests.operations.ccl.blackhole_CI.box.nightly.test_all_gath
 @pytest.mark.parametrize(
     "ag_input_dtype",
     [
-        ttnn.bfloat16,
         ttnn.uint32,
-        ttnn.bfloat8_b,
     ],
     ids=[
-        "float_16",
         "uint_32",
-        "bfloat_8",
     ],
 )
 @pytest.mark.parametrize(

--- a/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/Sys_eng_smoke_tests/test_ccl_smoke_test_qb_ge.py
+++ b/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/Sys_eng_smoke_tests/test_ccl_smoke_test_qb_ge.py
@@ -22,14 +22,10 @@ from tests.ttnn.unit_tests.operations.ccl.blackhole_CI.box.nightly.test_all_gath
 @pytest.mark.parametrize(
     "ag_input_dtype",
     [
-        ttnn.bfloat16,
         ttnn.uint32,
-        ttnn.bfloat8_b,
     ],
     ids=[
-        "bfloat_16",
         "uint_32",
-        "bfloat_8",
     ],
 )
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Ticket
Sys eng smoke tests are taking too long, in this PR I remove as much redundancy as possible in the tests while minimizing coverage loss.

https://github.com/tenstorrent/tt-metal/actions/runs/19142625825

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes