### PR TITLE
[TTT] Fix undefined variable

### DIFF
--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -50,7 +50,7 @@ def split_list(lst, n):
     start = 0
     for i in range(n):
         chunks.append(list(lst[start : start + chunk_size]))  # Convert to list explicitly
-        start = end
+        start += chunk_size
     return chunks
 
 


### PR DESCRIPTION
split_list references end variable and before assignment, causing an error.