### PR TITLE
[skip ci] Change t3k unit test pipeline to run every 2 hours to reduce queues

### DIFF
--- a/.github/workflows/t3000-unit-tests.yaml
+++ b/.github/workflows/t3000-unit-tests.yaml
@@ -2,8 +2,8 @@ name: "(T3K) T3000 unit tests"
 
 on:
   workflow_dispatch:
-  push:
-    branches: ["main"]
+  schedule:
+    - cron: "0 */2 * * *" # This cron schedule runs the workflow every 2 hours
 
 permissions:
   packages: write


### PR DESCRIPTION
Recently t3k queues have been long, affecting time to merge. T3k tests were subsequently taken out of merge gate in https://github.com/tenstorrent/tt-metal/commit/606e6aa5e5ec5ba35fe8a613c8102eb594b13319.

In order to have t3k coverage in merge gate again, t3k unit tests will have to be run less frequently to keep up with demand.

Reference:
https://tenstorrent.slack.com/archives/C05GRJC4J4A/p1762377391653399