### PR TITLE
#0: [skip ci] Add missing timeouts to BHPC

### DIFF
--- a/.github/workflows/blackhole-20-cores-tests.yaml
+++ b/.github/workflows/blackhole-20-cores-tests.yaml
@@ -54,10 +54,12 @@ jobs:
     steps:
       - name: Setup Job
         uses: tenstorrent/tt-metal/.github/actions/setup-job@5b5c6ff5b54025e165d189371cda93d2b9ef6115
+        timeout-minutes: 10
         with:
           build-artifact-name: ${{ inputs.build-artifact-name }}
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
       - name: Run ${{ matrix.test-group.name }}
+        timeout-minutes: 10
         env:
           ARCH_NAME: ${{ inputs.arch }}
           TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE: "4, 3"

--- a/.github/workflows/blackhole-multi-card-demo-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-demo-tests-impl.yaml
@@ -90,6 +90,7 @@ jobs:
           build-artifact-name: ${{ inputs.build-artifact-name }}
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
       - uses: tenstorrent/tt-metal/.github/actions/ensure-bh-links-online@main
+        timeout-minutes: 10
         with:
           runner-label: ${{ inputs.runner-label }}
       - name: Download Llama model weights from LFC
@@ -197,6 +198,7 @@ jobs:
           build-artifact-name: ${{ inputs.build-artifact-name }}
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
       - uses: tenstorrent/tt-metal/.github/actions/ensure-bh-links-online@main
+        timeout-minutes: 10
         with:
           runner-label: ${{ inputs.runner-label }}
       - name: Run demo regression tests

--- a/.github/workflows/blackhole-multi-card-post-commit-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-post-commit-tests-impl.yaml
@@ -64,6 +64,7 @@ jobs:
           build-artifact-name: ${{ inputs.build-artifact-name }}
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
       - uses: tenstorrent/tt-metal/.github/actions/ensure-bh-links-online@main
+        timeout-minutes: 10
         with:
           runner-label: ${{ inputs.runner-label }}
       - name: ${{ matrix.test-group.name }} tests

--- a/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
@@ -105,6 +105,7 @@ jobs:
           build-artifact-name: ${{ inputs.build-artifact-name }}
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
       - uses: tenstorrent/tt-metal/.github/actions/ensure-bh-links-online@main
+        timeout-minutes: 10
         with:
           runner-label: ${{ matrix.runner-group.runner-label }}
       - name: ${{ matrix.test-group.name }} tests

--- a/.github/workflows/ttnn-stress-tests-impl.yaml
+++ b/.github/workflows/ttnn-stress-tests-impl.yaml
@@ -59,6 +59,7 @@ jobs:
       - name: Ensure BH Eth links online
         if: ${{ contains(inputs.runner-label, 'BH-') }}
         uses: tenstorrent/tt-metal/.github/actions/ensure-bh-links-online@main
+        timeout-minutes: 10
         with:
           runner-label: ${{ inputs.runner-label }}
 

--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -239,6 +239,7 @@ jobs:
       - name: Ensure BH Eth links online
         if: ${{ contains(matrix.test-group.mesh-device, 'P150') }}
         uses: tenstorrent/tt-metal/.github/actions/ensure-bh-links-online@main
+        timeout-minutes: 10
         with:
           runner-label: ${{ matrix.test-group.runner-label }}
 


### PR DESCRIPTION
### Ticket
None

### What's changed

- BHPC 20 cores test is missing timeouts, takes <1min to run but setting 10 minutes to be safe.
- Set a 10 minute timeout for ensure-bh-links-online action