### PR TITLE
prefer _ttml .so from build artifacts over an installed version from pip

### DIFF
--- a/tt-train/sources/ttml/ttml/__init__.py
+++ b/tt-train/sources/ttml/ttml/__init__.py
@@ -106,6 +106,7 @@ def _initialize():
     sys.path.append(str(ttml_dir))
 
     import importlib
+    import importlib.util
 
     ttml_module = importlib.util.find_spec("_ttml", package=None)
 


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Python module packaging of ttml via pip implementation is causing some headaches when trying to import a build artifact version of _ttml (as opposed to the pip installed version).

### What's changed
Search for and import the build artifact _ttml .so file before trying to import from the pip install location.
This effectively makes the ttml module's __init__.py prefer the _ttml .so artifact from tt-metal's build dir over the pip installed _ttml .so artifact.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes