### PR TITLE
Increase MEM_LOGICAL_TO_VIRTUAL_SIZE on Blackhole

### DIFF
--- a/tt_metal/hw/inc/tt-1xx/blackhole/dev_mem_map.h
+++ b/tt_metal/hw/inc/tt-1xx/blackhole/dev_mem_map.h
@@ -179,7 +179,7 @@
 // This size must match the firmware noc_size_x & noc_size Y. Size is largest chip (X + Y) * sizeof uint8_t.
 // Chip sizes must round up to nearest multiple of 4 to deal with uint32_t alignment for L1 to local copies.
 #define MEM_LOGICAL_TO_VIRTUAL_SCRATCH (MEM_BANK_TO_NOC_SCRATCH + MEM_BANK_TO_NOC_SIZE)
-#define MEM_LOGICAL_TO_VIRTUAL_SIZE ((14 + 10) * sizeof(uint8_t))
+#define MEM_LOGICAL_TO_VIRTUAL_SIZE ((20 + 10) * sizeof(uint8_t))
 
 /////////////
 // Stack info


### PR DESCRIPTION
### Ticket
N/A

### Problem description
`Size of logical to virtual map is greater than available space` on Blackhole Galaxy because the grid size X is rounded up to 20

### What's changed
Update the MEM_LOGICAL_TO_VIRTUAL_SIZE in blackhole dev_mem_map.h

### Checklist
Trivial change tested locally