### PR TITLE
Enabling expanded codepath profiling

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/CMakeLists.txt
@@ -73,6 +73,7 @@ foreach(TEST_SRC ${PERF_MICROBENCH_TESTS_SRCS})
                 routing/tt_fabric_test_device_setup.cpp
                 routing/tt_fabric_test_progress_monitor.cpp
                 routing/tt_fabric_test_eth_readback.cpp
+                ${PROJECT_SOURCE_DIR}/tt_metal/fabric/fabric_edm_profiler_helper.cpp
                 routing/tt_fabric_test_code_profiler.cpp
                 routing/tt_fabric_telemetry_manager.cpp
         )

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric.cpp
@@ -109,7 +109,7 @@ int main(int argc, char** argv) {
     if (has_latency_tests) {
         test_context.initialize_latency_results_csv_file();
     }
-    
+
     // Set code profiling enabled based on rtoptions
     auto& rtoptions = tt::tt_metal::MetalContext::instance().rtoptions();
     bool code_profiling_enabled = rtoptions.fabric_code_profiling_enabled();
@@ -215,7 +215,7 @@ int main(int argc, char** argv) {
             test_context.set_skip_packet_validation(test_config.skip_packet_validation);
 
             // TODO: Check to see if code profiling can be enabled even without benchmark mode (Issue #32036)
-            if (!test_config.benchmark_mode) {
+            if (test_config.performance_test_mode == PerformanceTestMode::NONE) {
                 if (code_profiling_enabled) {
                     log_warning(
                         tt::LogTest,

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_code_profiler.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_code_profiler.cpp
@@ -39,7 +39,7 @@ void CodeProfiler::clear_code_profiling_buffers() {
 
     // Check if any code profiling is enabled
     auto& rtoptions = ctx.rtoptions();
-    if (!rtoptions.get_enable_fabric_code_profiling_rx_ch_fwd()) {
+    if (!rtoptions.fabric_code_profiling_enabled()) {
         return;  // No profiling enabled, nothing to clear
     }
 
@@ -57,7 +57,7 @@ void CodeProfiler::read_code_profiling_results() {
 
     // Check if any code profiling is enabled
     auto& rtoptions = ctx.rtoptions();
-    if (!rtoptions.get_enable_fabric_code_profiling_rx_ch_fwd()) {
+    if (!rtoptions.fabric_code_profiling_enabled()) {
         return;  // No profiling enabled, nothing to read
     }
 
@@ -71,8 +71,14 @@ void CodeProfiler::read_code_profiling_results() {
 
     // Process results for each enabled timer type
     std::vector<CodeProfilingTimerType> enabled_timers;
-    if (rtoptions.get_enable_fabric_code_profiling_rx_ch_fwd()) {
-        enabled_timers.push_back(CodeProfilingTimerType::RECEIVER_CHANNEL_FORWARD);
+    if (rtoptions.fabric_code_profiling_enabled()) {
+        CodeProfilingTimerType code_profiling_timer_type =
+            convert_to_code_profiling_timer_type(rtoptions.get_fabric_code_profiling_timer_str());
+        TT_FATAL(
+            code_profiling_timer_type != CodeProfilingTimerType::NONE,
+            "Invalid code profiling timer string: {}",
+            rtoptions.get_fabric_code_profiling_timer_str());
+        enabled_timers.push_back(code_profiling_timer_type);
     }
 
     for (const auto& location : results) {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_code_profiler.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_code_profiler.hpp
@@ -11,6 +11,10 @@
 #include "tt_fabric_telemetry.hpp"
 #include "tt_fabric_test_eth_readback.hpp"
 
+// Helper functions for code profiling
+using tt::tt_fabric::convert_code_profiling_timer_type_to_str;
+using tt::tt_fabric::convert_to_code_profiling_timer_type;
+
 // Manages fabric code profiling lifecycle (readback, clearing, reporting).
 class CodeProfiler {
 public:

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_code_profiler.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_code_profiler.hpp
@@ -6,14 +6,31 @@
 
 #include <memory>
 #include <vector>
+#include <fstream>
 
 #include <tt-logger/tt-logger.hpp>
+#include <tt-metalium/mesh_coord.hpp>
 #include "tt_fabric_telemetry.hpp"
 #include "tt_fabric_test_eth_readback.hpp"
+#include "tt_fabric_test_constants.hpp"
+#include "tt_fabric_test_common_types.hpp"
+
+using tt::tt_fabric::fabric_tests::OUTPUT_DIR;
+
+using TestConfig = tt::tt_fabric::fabric_tests::TestConfig;
+using TrafficPatternConfig = tt::tt_fabric::fabric_tests::TrafficPatternConfig;
+
+using MeshCoordinate = tt::tt_metal::distributed::MeshCoordinate;
 
 // Helper functions for code profiling
 using tt::tt_fabric::convert_code_profiling_timer_type_to_str;
 using tt::tt_fabric::convert_to_code_profiling_timer_type;
+
+// Helper functions for parsing traffic pattern parameters
+using tt::tt_fabric::fabric_tests::fetch_first_traffic_pattern;
+using tt::tt_fabric::fabric_tests::fetch_pattern_ftype;
+using tt::tt_fabric::fabric_tests::fetch_pattern_ntype;
+using tt::tt_fabric::fabric_tests::fetch_pattern_packet_size;
 
 // Manages fabric code profiling lifecycle (readback, clearing, reporting).
 class CodeProfiler {
@@ -26,6 +43,9 @@ public:
     void clear_code_profiling_buffers();
     void read_code_profiling_results();
     void report_code_profiling_results() const;
+    void initialize_code_profiling_results_csv_file();
+    std::string convert_coord_to_string(const MeshCoordinate& coord);
+    void dump_code_profiling_results_to_csv(const TestConfig& config);
     void reset();  // Clears entries and device buffers when profiling is enabled
 
     const std::vector<CodeProfilingEntry>& get_entries() const;
@@ -34,4 +54,5 @@ private:
     EthCoreBufferReadback& eth_readback_;
     std::vector<CodeProfilingEntry> entries_;
     bool enabled_ = false;
+    std::filesystem::path code_profiling_csv_file_path_;
 };

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_context.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_context.cpp
@@ -120,71 +120,11 @@ void TestContext::read_code_profiling_results() { get_code_profiler().read_code_
 void TestContext::report_code_profiling_results() { get_code_profiler().report_code_profiling_results(); }
 
 void TestContext::initialize_code_profiling_results_csv_file() {
-    std::ostringstream code_profiling_results_oss;
-    auto arch_name = tt::tt_metal::hal::get_arch_name();
-    code_profiling_results_oss << "code_profiling_results_" << arch_name << ".csv";
-
-    // Output directory already set in initialize_bandwidth_results_csv_file()
-    std::filesystem::path output_path =
-        std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) / std::string(OUTPUT_DIR);
-    code_profiling_csv_file_path_ = output_path / code_profiling_results_oss.str();
-
-    // Create detailed CSV file with header
-    std::ofstream code_profiling_csv_stream(
-        code_profiling_csv_file_path_, std::ios::out | std::ios::trunc);  // Truncate file
-    if (!code_profiling_csv_stream.is_open()) {
-        log_error(tt::LogTest, "Failed to create code profiling CSV file: {}", code_profiling_csv_file_path_.string());
-        return;
-    }
-
-    // Write detailed header
-    code_profiling_csv_stream << "test_name,ftype,ntype,topology,num_links,packet_size,iteration_number,";
-    code_profiling_csv_stream
-        << "device_coord,core,code_profiling_timer_type,total_cycles,num_instances,avg_cycles_per_instance";
-    code_profiling_csv_stream << "\n";
-
-    log_info(tt::LogTest, "Initialized code profiling CSV file: {}", code_profiling_csv_file_path_.string());
-
-    code_profiling_csv_stream.close();
-}
-
-std::string TestContext::convert_coord_to_string(const ::tt::tt_metal::distributed::MeshCoordinate& coord) {
-    return "[" + std::to_string(coord[0]) + "," + std::to_string(coord[1]) + "]";
+    get_code_profiler().initialize_code_profiling_results_csv_file();
 }
 
 void TestContext::dump_code_profiling_results_to_csv(const TestConfig& config) {
-    // Extract representative ftype, ntype, packet_size from first sender's first pattern
-    const TrafficPatternConfig& first_pattern = fetch_first_traffic_pattern(config);
-    std::string ftype_str = fetch_pattern_ftype(first_pattern);
-    std::string ntype_str = fetch_pattern_ntype(first_pattern);
-    // uint32_t packet_size = fetch_pattern_packet_size(first_pattern);
-
-    // Open CSV file in append mode
-    std::ofstream code_profiling_csv_stream(code_profiling_csv_file_path_, std::ios::out | std::ios::app);
-    if (!code_profiling_csv_stream.is_open()) {
-        log_error(
-            tt::LogTest,
-            "Failed to open Code Profiling CSV file for appending: {}",
-            code_profiling_csv_file_path_.string());
-        return;
-    }
-
-    // // Write data rows (header already written in initialize_code_profiling_results_csv_file)
-    // for (const auto& entry : code_profiling_entries_) {
-    //     std::string coord_str = convert_coord_to_string(entry.coord);
-    //     code_profiling_csv_stream << config.name << "," << ftype_str << "," << ntype_str << ","
-    //                               << enchantum::to_string(config.fabric_setup.topology) << ","
-    //                               << config.fabric_setup.num_links << "," << packet_size << ","
-    //                               << config.iteration_number << ",";
-    //     code_profiling_csv_stream << "\"" << coord_str << "\"," << entry.eth_channel << ","
-    //                               << convert_code_profiling_timer_type_to_str(entry.timer_type) << ","
-    //                               << entry.total_cycles << "," << entry.num_instances << "," << std::fixed
-    //                               << std::setprecision(6) << entry.avg_cycles_per_instance << "\n";
-    // }
-
-    // code_profiling_csv_stream.close();
-
-    // log_info(tt::LogTest, "Code Profiling results appended to CSV file: {}", code_profiling_csv_file_path_.string());
+    get_code_profiler().dump_code_profiling_results_to_csv(config);
 }
 
 void TestContext::process_telemetry_for_golden() {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_context.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_context.cpp
@@ -126,7 +126,7 @@ void TestContext::initialize_code_profiling_results_csv_file() {
 
     // Output directory already set in initialize_bandwidth_results_csv_file()
     std::filesystem::path output_path =
-        std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) / output_dir;
+        std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) / std::string(OUTPUT_DIR);
     code_profiling_csv_file_path_ = output_path / code_profiling_results_oss.str();
 
     // Create detailed CSV file with header
@@ -157,7 +157,7 @@ void TestContext::dump_code_profiling_results_to_csv(const TestConfig& config) {
     const TrafficPatternConfig& first_pattern = fetch_first_traffic_pattern(config);
     std::string ftype_str = fetch_pattern_ftype(first_pattern);
     std::string ntype_str = fetch_pattern_ntype(first_pattern);
-    uint32_t packet_size = fetch_pattern_packet_size(first_pattern);
+    // uint32_t packet_size = fetch_pattern_packet_size(first_pattern);
 
     // Open CSV file in append mode
     std::ofstream code_profiling_csv_stream(code_profiling_csv_file_path_, std::ios::out | std::ios::app);
@@ -169,22 +169,22 @@ void TestContext::dump_code_profiling_results_to_csv(const TestConfig& config) {
         return;
     }
 
-    // Write data rows (header already written in initialize_code_profiling_results_csv_file)
-    for (const auto& entry : code_profiling_entries_) {
-        std::string coord_str = convert_coord_to_string(entry.coord);
-        code_profiling_csv_stream << config.name << "," << ftype_str << "," << ntype_str << ","
-                                  << enchantum::to_string(config.fabric_setup.topology) << ","
-                                  << config.fabric_setup.num_links << "," << packet_size << ","
-                                  << config.iteration_number << ",";
-        code_profiling_csv_stream << "\"" << coord_str << "\"," << entry.eth_channel << ","
-                                  << convert_code_profiling_timer_type_to_str(entry.timer_type) << ","
-                                  << entry.total_cycles << "," << entry.num_instances << "," << std::fixed
-                                  << std::setprecision(6) << entry.avg_cycles_per_instance << "\n";
-    }
+    // // Write data rows (header already written in initialize_code_profiling_results_csv_file)
+    // for (const auto& entry : code_profiling_entries_) {
+    //     std::string coord_str = convert_coord_to_string(entry.coord);
+    //     code_profiling_csv_stream << config.name << "," << ftype_str << "," << ntype_str << ","
+    //                               << enchantum::to_string(config.fabric_setup.topology) << ","
+    //                               << config.fabric_setup.num_links << "," << packet_size << ","
+    //                               << config.iteration_number << ",";
+    //     code_profiling_csv_stream << "\"" << coord_str << "\"," << entry.eth_channel << ","
+    //                               << convert_code_profiling_timer_type_to_str(entry.timer_type) << ","
+    //                               << entry.total_cycles << "," << entry.num_instances << "," << std::fixed
+    //                               << std::setprecision(6) << entry.avg_cycles_per_instance << "\n";
+    // }
 
-    code_profiling_csv_stream.close();
+    // code_profiling_csv_stream.close();
 
-    log_info(tt::LogTest, "Code Profiling results appended to CSV file: {}", code_profiling_csv_file_path_.string());
+    // log_info(tt::LogTest, "Code Profiling results appended to CSV file: {}", code_profiling_csv_file_path_.string());
 }
 
 void TestContext::process_telemetry_for_golden() {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_context.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_context.cpp
@@ -119,6 +119,74 @@ void TestContext::read_code_profiling_results() { get_code_profiler().read_code_
 
 void TestContext::report_code_profiling_results() { get_code_profiler().report_code_profiling_results(); }
 
+void TestContext::initialize_code_profiling_results_csv_file() {
+    std::ostringstream code_profiling_results_oss;
+    auto arch_name = tt::tt_metal::hal::get_arch_name();
+    code_profiling_results_oss << "code_profiling_results_" << arch_name << ".csv";
+
+    // Output directory already set in initialize_bandwidth_results_csv_file()
+    std::filesystem::path output_path =
+        std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) / output_dir;
+    code_profiling_csv_file_path_ = output_path / code_profiling_results_oss.str();
+
+    // Create detailed CSV file with header
+    std::ofstream code_profiling_csv_stream(
+        code_profiling_csv_file_path_, std::ios::out | std::ios::trunc);  // Truncate file
+    if (!code_profiling_csv_stream.is_open()) {
+        log_error(tt::LogTest, "Failed to create code profiling CSV file: {}", code_profiling_csv_file_path_.string());
+        return;
+    }
+
+    // Write detailed header
+    code_profiling_csv_stream << "test_name,ftype,ntype,topology,num_links,packet_size,iteration_number,";
+    code_profiling_csv_stream
+        << "device_coord,core,code_profiling_timer_type,total_cycles,num_instances,avg_cycles_per_instance";
+    code_profiling_csv_stream << "\n";
+
+    log_info(tt::LogTest, "Initialized code profiling CSV file: {}", code_profiling_csv_file_path_.string());
+
+    code_profiling_csv_stream.close();
+}
+
+std::string TestContext::convert_coord_to_string(const ::tt::tt_metal::distributed::MeshCoordinate& coord) {
+    return "[" + std::to_string(coord[0]) + "," + std::to_string(coord[1]) + "]";
+}
+
+void TestContext::dump_code_profiling_results_to_csv(const TestConfig& config) {
+    // Extract representative ftype, ntype, packet_size from first sender's first pattern
+    const TrafficPatternConfig& first_pattern = fetch_first_traffic_pattern(config);
+    std::string ftype_str = fetch_pattern_ftype(first_pattern);
+    std::string ntype_str = fetch_pattern_ntype(first_pattern);
+    uint32_t packet_size = fetch_pattern_packet_size(first_pattern);
+
+    // Open CSV file in append mode
+    std::ofstream code_profiling_csv_stream(code_profiling_csv_file_path_, std::ios::out | std::ios::app);
+    if (!code_profiling_csv_stream.is_open()) {
+        log_error(
+            tt::LogTest,
+            "Failed to open Code Profiling CSV file for appending: {}",
+            code_profiling_csv_file_path_.string());
+        return;
+    }
+
+    // Write data rows (header already written in initialize_code_profiling_results_csv_file)
+    for (const auto& entry : code_profiling_entries_) {
+        std::string coord_str = convert_coord_to_string(entry.coord);
+        code_profiling_csv_stream << config.name << "," << ftype_str << "," << ntype_str << ","
+                                  << enchantum::to_string(config.fabric_setup.topology) << ","
+                                  << config.fabric_setup.num_links << "," << packet_size << ","
+                                  << config.iteration_number << ",";
+        code_profiling_csv_stream << "\"" << coord_str << "\"," << entry.eth_channel << ","
+                                  << convert_code_profiling_timer_type_to_str(entry.timer_type) << ","
+                                  << entry.total_cycles << "," << entry.num_instances << "," << std::fixed
+                                  << std::setprecision(6) << entry.avg_cycles_per_instance << "\n";
+    }
+
+    code_profiling_csv_stream.close();
+
+    log_info(tt::LogTest, "Code Profiling results appended to CSV file: {}", code_profiling_csv_file_path_.string());
+}
+
 void TestContext::process_telemetry_for_golden() {
     auto& telemetry_manager = get_telemetry_manager();
     telemetry_manager.process_telemetry_for_golden();

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_context.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_context.hpp
@@ -35,7 +35,6 @@
 #include "tt_fabric_test_constants.hpp"
 #include <tt-logger/tt-logger.hpp>
 #include <tt-metalium/hal.hpp>
-#include <tt-metalium/mesh_coord.hpp>
 
 using tt::tt_fabric::fabric_tests::CI_ARTIFACTS_DIR;
 using tt::tt_fabric::fabric_tests::DEFAULT_BUILT_TESTS_DUMP_FILE;
@@ -59,7 +58,6 @@ using ProgressMonitorConfig = tt::tt_fabric::fabric_tests::ProgressMonitorConfig
 using TestProgressMonitor = tt::tt_fabric::fabric_tests::TestProgressMonitor;
 using SenderMemoryMap = tt::tt_fabric::fabric_tests::SenderMemoryMap;
 using IDeviceInfoProvider = tt::tt_fabric::fabric_tests::IDeviceInfoProvider;
-using TrafficPatternConfig = tt::tt_fabric::fabric_tests::TrafficPatternConfig;
 
 using ChipSendType = tt::tt_fabric::ChipSendType;
 using NocSendType = tt::tt_fabric::NocSendType;
@@ -91,17 +89,6 @@ using BandwidthStatistics = tt::tt_fabric::fabric_tests::BandwidthStatistics;
 using BandwidthProfiler = ::BandwidthProfiler;
 using BandwidthResultsManager = tt::tt_fabric::fabric_tests::BandwidthResultsManager;
 using LatencyTestManager = ::LatencyTestManager;
-
-// Helper functions for parsing traffic pattern parameters
-using tt::tt_fabric::fabric_tests::fetch_first_traffic_pattern;
-using tt::tt_fabric::fabric_tests::fetch_pattern_ftype;
-using tt::tt_fabric::fabric_tests::fetch_pattern_ntype;
-using tt::tt_fabric::fabric_tests::fetch_pattern_num_packets;
-using tt::tt_fabric::fabric_tests::fetch_pattern_packet_size;
-
-// Helper functions for code profiling
-using tt::tt_fabric::convert_code_profiling_timer_type_to_str;
-using tt::tt_fabric::convert_to_code_profiling_timer_type;
 
 // Access to internal API: ProgramImpl::num_kernel
 #include "impl/program/program_impl.hpp"
@@ -214,10 +201,8 @@ public:
 
     // Configures latency test mode by extracting and storing parameters from the test config
     void setup_latency_test_mode(const TestConfig& config);
-    
-    void initialize_code_profiling_results_csv_file();
 
-    std::string convert_coord_to_string(const ::tt::tt_metal::distributed::MeshCoordinate& coord);
+    void initialize_code_profiling_results_csv_file();
 
     void dump_code_profiling_results_to_csv(const TestConfig& config);
 
@@ -276,9 +261,6 @@ private:
 
     std::vector<std::string> all_failed_bandwidth_tests_;  // Accumulates failed bandwidth tests
     bool has_test_failures_ = false;  // Track if any tests failed validation
-
-    // Code profiling results CSV file path (TODO: Move to tt_fabric_test_Results)
-    std::filesystem::path code_profiling_csv_file_path_;
 
     // Ethernet core buffer readback helper
     std::unique_ptr<EthCoreBufferReadback> eth_readback_;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_context.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_context.hpp
@@ -99,6 +99,10 @@ using tt::tt_fabric::fabric_tests::fetch_pattern_ntype;
 using tt::tt_fabric::fabric_tests::fetch_pattern_num_packets;
 using tt::tt_fabric::fabric_tests::fetch_pattern_packet_size;
 
+// Helper functions for code profiling
+using tt::tt_fabric::convert_code_profiling_timer_type_to_str;
+using tt::tt_fabric::convert_to_code_profiling_timer_type;
+
 // Access to internal API: ProgramImpl::num_kernel
 #include "impl/program/program_impl.hpp"
 
@@ -210,6 +214,12 @@ public:
 
     // Configures latency test mode by extracting and storing parameters from the test config
     void setup_latency_test_mode(const TestConfig& config);
+    
+    void initialize_code_profiling_results_csv_file();
+
+    std::string convert_coord_to_string(const ::tt::tt_metal::distributed::MeshCoordinate& coord);
+
+    void dump_code_profiling_results_to_csv(const TestConfig& config);
 
 private:
     void reset_local_variables();
@@ -266,6 +276,9 @@ private:
 
     std::vector<std::string> all_failed_bandwidth_tests_;  // Accumulates failed bandwidth tests
     bool has_test_failures_ = false;  // Track if any tests failed validation
+
+    // Code profiling results CSV file path (TODO: Move to tt_fabric_test_Results)
+    std::filesystem::path code_profiling_csv_file_path_;
 
     // Ethernet core buffer readback helper
     std::unique_ptr<EthCoreBufferReadback> eth_readback_;

--- a/tt_metal/fabric/CMakeLists.txt
+++ b/tt_metal/fabric/CMakeLists.txt
@@ -59,6 +59,7 @@ target_sources(
         fabric_init.cpp
         fabric_host_utils.cpp
         fabric_telemetry_reader.cpp
+        fabric_edm_profiler_helper.cpp
         fabric_context.cpp
         fabric_builder_context.cpp
         fabric_mux_config.cpp

--- a/tt_metal/fabric/erisc_datamover_builder.hpp
+++ b/tt_metal/fabric/erisc_datamover_builder.hpp
@@ -13,6 +13,7 @@
 #include <umd/device/types/cluster_descriptor_types.hpp>
 #include <tt-metalium/experimental/fabric/fabric_edm_types.hpp>
 #include "fabric/fabric_edm_packet_header.hpp"
+#include "fabric_edm_profiler_helper.hpp"
 #include <tt-metalium/experimental/fabric/edm_fabric_counters.hpp>
 #include <tt-metalium/experimental/fabric/routing_table_generator.hpp>  // for FabricNodeId
 #include <hostdevcommon/fabric_common.h>

--- a/tt_metal/fabric/fabric_edm_profiler_helper.cpp
+++ b/tt_metal/fabric/fabric_edm_profiler_helper.cpp
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "fabric_edm_profiler_helper.hpp"
+
+namespace tt::tt_fabric {
+
+CodeProfilingTimerType convert_to_code_profiling_timer_type(const std::string& timer_str) {
+    TT_FATAL(!timer_str.empty(), "Empty code profiling timer string provided");
+
+    TT_FATAL(
+        CodeProfilingTimerTypeMap.contains(timer_str), "Invalid code profiling timer string provided: {}", timer_str);
+
+    return CodeProfilingTimerTypeMap.at(timer_str);
+}
+
+std::string convert_code_profiling_timer_type_to_str(const CodeProfilingTimerType& timer_type) {
+    auto it = std::find_if(
+        CodeProfilingTimerTypeMap.begin(), CodeProfilingTimerTypeMap.end(), [&timer_type](const auto& entry) {
+            return entry.second == timer_type;
+        });
+    TT_FATAL(
+        it != CodeProfilingTimerTypeMap.end(), "Code Profiling Timer Type not found in map, cannot convert to string");
+    return it->first;
+}
+
+}  // namespace tt::tt_fabric

--- a/tt_metal/fabric/fabric_edm_profiler_helper.hpp
+++ b/tt_metal/fabric/fabric_edm_profiler_helper.hpp
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <string>
+#include <unordered_map>
+
+#include "tt_metal/fabric/hw/inc/edm_fabric/telemetry/code_profiling_types.hpp"
+#include <tt_stl/assert.hpp>
+
+namespace tt::tt_fabric {
+
+// Code Profiling Timer Type Enum is declared in code_profiling_types.hpp
+const std::unordered_map<std::string, CodeProfilingTimerType> CodeProfilingTimerTypeMap = {
+    {"RECEIVER_CHANNEL_FORWARD", CodeProfilingTimerType::RECEIVER_CHANNEL_FORWARD},
+    {"SENDER_CHANNEL_FORWARD", CodeProfilingTimerType::SENDER_CHANNEL_FORWARD},
+};
+
+CodeProfilingTimerType convert_to_code_profiling_timer_type(const std::string& timer_str);
+
+std::string convert_code_profiling_timer_type_to_str(const CodeProfilingTimerType& timer_type);
+
+}  // namespace tt::tt_fabric

--- a/tt_metal/fabric/fabric_edm_profiler_helper.hpp
+++ b/tt_metal/fabric/fabric_edm_profiler_helper.hpp
@@ -16,6 +16,8 @@ namespace tt::tt_fabric {
 const std::unordered_map<std::string, CodeProfilingTimerType> CodeProfilingTimerTypeMap = {
     {"RECEIVER_CHANNEL_FORWARD", CodeProfilingTimerType::RECEIVER_CHANNEL_FORWARD},
     {"SENDER_CHANNEL_FORWARD", CodeProfilingTimerType::SENDER_CHANNEL_FORWARD},
+    {"RECEIVER_CHANNEL_SEND_ACKS", CodeProfilingTimerType::RECEIVER_CHANNEL_SEND_ACKS},
+    {"RECEIVER_CHANNEL_SEND_COMPLETION_ACK", CodeProfilingTimerType::RECEIVER_CHANNEL_SEND_COMPLETION_ACK},
 };
 
 CodeProfilingTimerType convert_to_code_profiling_timer_type(const std::string& timer_str);

--- a/tt_metal/fabric/hw/inc/edm_fabric/telemetry/code_profiling_types.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/telemetry/code_profiling_types.hpp
@@ -13,11 +13,12 @@
 enum class CodeProfilingTimerType : uint32_t {
     NONE = 0,
     RECEIVER_CHANNEL_FORWARD = 1 << 0,
+    SENDER_CHANNEL_FORWARD = 1 << 1,
     // Future timers can be added here:
     // SENDER_CHANNEL_PROCESS = 1 << 1,
     // PACKET_ROUTING = 1 << 2,
     // etc.
-    LAST = RECEIVER_CHANNEL_FORWARD << 1  // Sentinel for size calculation
+    LAST = SENDER_CHANNEL_FORWARD << 1  // Sentinel for size calculation
 };
 
 /**
@@ -35,7 +36,7 @@ struct CodeProfilingTimerResult {
 constexpr uint32_t get_num_code_profiling_timer_types() {
     // Count the number of timer types defined
     // Currently only RECEIVER_CHANNEL_FORWARD is defined
-    return 1;
+    return 2;
 }
 
 /**

--- a/tt_metal/fabric/hw/inc/edm_fabric/telemetry/code_profiling_types.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/telemetry/code_profiling_types.hpp
@@ -14,11 +14,13 @@ enum class CodeProfilingTimerType : uint32_t {
     NONE = 0,
     RECEIVER_CHANNEL_FORWARD = 1 << 0,
     SENDER_CHANNEL_FORWARD = 1 << 1,
+    RECEIVER_CHANNEL_SEND_ACKS = 1 << 2,
+    RECEIVER_CHANNEL_SEND_COMPLETION_ACK = 1 << 3,
     // Future timers can be added here:
     // SENDER_CHANNEL_PROCESS = 1 << 1,
     // PACKET_ROUTING = 1 << 2,
     // etc.
-    LAST = SENDER_CHANNEL_FORWARD << 1  // Sentinel for size calculation
+    LAST = RECEIVER_CHANNEL_SEND_COMPLETION_ACK << 1  // Sentinel for size calculation
 };
 
 /**

--- a/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
+++ b/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
@@ -1439,6 +1439,16 @@ FORCE_INLINE
     if constexpr (!ETH_TXQ_SPIN_WAIT_SEND_NEXT_DATA) {
         can_send = can_send && !internal_::eth_txq_is_busy(sender_txq_id);
     }
+
+    // Code profiling timer for sender channel forward
+    NamedProfiler<
+        CodeProfilingTimerType::SENDER_CHANNEL_FORWARD,
+        code_profiling_enabled_timers_bitfield,
+        code_profiling_buffer_base_addr>
+        sender_send_data_timer;
+    sender_send_data_timer.set_should_dump(can_send);
+    sender_send_data_timer.open();
+
     if (can_send) {
         did_something = true;
         progress = true;
@@ -1460,6 +1470,9 @@ FORCE_INLINE
         }
         increment_local_update_ptr_val(sender_channel_free_slots_stream_id, 1);
     }
+
+    // Close the code profiling timer
+    sender_send_data_timer.close();
 
     // Process COMPLETIONs from receiver
     int32_t completions_since_last_check =

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -82,7 +82,7 @@ enum class EnvVarID {
     TT_METAL_ENABLE_GATHERING,              // Enable instruction gathering
     TT_METAL_FABRIC_BW_TELEMETRY,           // Enable fabric bandwidth telemetry
     TT_METAL_FABRIC_TELEMETRY,              // Enable fabric telemetry
-    TT_FABRIC_PROFILE_RX_CH_FWD,            // Enable fabric RX channel forwarding profiling
+    TT_FABRIC_PROFILER,                     // Enable fabric codepath profiling
     TT_METAL_FORCE_REINIT,                  // Force context reinitialization
     TT_METAL_DISABLE_FABRIC_TWO_ERISC,      // Disable fabric 2-ERISC mode
     TT_METAL_LOG_KERNELS_COMPILE_COMMANDS,  // Log kernel compilation commands
@@ -522,11 +522,11 @@ void RunTimeOptions::HandleEnvVar(EnvVarID id, const char* value) {
         //        export TT_METAL_FABRIC_TELEMETRY="chips=all;eth=0,2,7;erisc=all;stats=ROUTER_STATE|BANDWIDTH"
         case EnvVarID::TT_METAL_FABRIC_TELEMETRY: this->ParseFabricTelemetryEnv(value); break;
 
-        // TT_FABRIC_PROFILE_RX_CH_FWD
-        // Enables fabric RX channel forwarding profiling.
-        // Default: false
-        // Usage: export TT_FABRIC_PROFILE_RX_CH_FWD=1
-        case EnvVarID::TT_FABRIC_PROFILE_RX_CH_FWD: this->fabric_profiling_settings.enable_rx_ch_fwd = true; break;
+        // TT_FABRIC_PROFILER
+        // Enables fabric codepath profiling and allows the user to select the specific profiler.
+        // Default: blank
+        // Usage: export TT_FABRIC_PROFILER=RECEIVER_CHANNEL_FORWARD
+        case EnvVarID::TT_FABRIC_PROFILER: this->set_fabric_code_profiling_timer_str(std::string(value)); break;
 
         // RELIABILITY_MODE
         // Sets the fabric reliability mode (STRICT, RELAXED, or DYNAMIC).

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -82,7 +82,7 @@ enum class EnvVarID {
     TT_METAL_ENABLE_GATHERING,              // Enable instruction gathering
     TT_METAL_FABRIC_BW_TELEMETRY,           // Enable fabric bandwidth telemetry
     TT_METAL_FABRIC_TELEMETRY,              // Enable fabric telemetry
-    TT_FABRIC_PROFILER,                     // Enable fabric codepath profiling
+    TT_FABRIC_PROFILER,                     // Enable fabric codepath profiling, details in code_profiling_types.hpp
     TT_METAL_FORCE_REINIT,                  // Force context reinitialization
     TT_METAL_DISABLE_FABRIC_TWO_ERISC,      // Disable fabric 2-ERISC mode
     TT_METAL_LOG_KERNELS_COMPILE_COMMANDS,  // Log kernel compilation commands

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -156,7 +156,8 @@ class RunTimeOptions {
 
     // Fabric profiling settings
     struct FabricProfilingSettings {
-        bool enable_rx_ch_fwd = false;
+        // Check CodeProfilingTimerType in code_profiling_types.hpp for a map of timer types to bitfield positions
+        std::string enabled_timer_str{};
     } fabric_profiling_settings;
 
     TargetSelection feature_targets[RunTimeDebugFeatureCount];
@@ -606,9 +607,10 @@ public:
     const FabricTelemetrySettings& get_fabric_telemetry_settings() const { return fabric_telemetry_settings; }
 
     // If true, enables code profiling for receiver channel forward operations
-    bool get_enable_fabric_code_profiling_rx_ch_fwd() const { return fabric_profiling_settings.enable_rx_ch_fwd; }
-    void set_enable_fabric_code_profiling_rx_ch_fwd(bool enable) {
-        fabric_profiling_settings.enable_rx_ch_fwd = enable;
+    bool fabric_code_profiling_enabled() const { return !fabric_profiling_settings.enabled_timer_str.empty(); }
+    std::string get_fabric_code_profiling_timer_str() const { return fabric_profiling_settings.enabled_timer_str; }
+    void set_fabric_code_profiling_timer_str(const std::string& timer_str) {
+        fabric_profiling_settings.enabled_timer_str = timer_str;
     }
 
     // Reliability mode override accessor


### PR DESCRIPTION
### Ticket

### Problem description
PR https://github.com/tenstorrent/tt-metal/pull/30423 added codepath profilers to fabric, enabling us to record the number of cycles spent in various sections of the fabric router at runtime. However, this implementation was basic, with a single codepath profiler enabled.

### What's changed
- Modified how we enable codepath profilers at test time. Now, we run codepath profiling by running the following:

```
TT_METAL_CLEAR_L1=1 TT_FABRIC_PROFILER=<profiler> $(TT_METAL_HOME)/build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ${TT_METAL_HOME}/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_ubench_at_least_2x2_mesh.yaml
```

`<profiler>` should be replaced with the name of the profiler we want to enable. A full list of currently-available profilers is found in `tt_metal/fabric/hw/inc/edm_fabric/telemetry/code_profiling_types.hpp`, in the `CodeProfilingTimerType` enum.
```
enum class CodeProfilingTimerType : uint32_t {
    NONE = 0,
    RECEIVER_CHANNEL_FORWARD = 1 << 0,
    SENDER_CHANNEL_FORWARD = 1 << 1,
    // Future timers can be added here:
    // SENDER_CHANNEL_PROCESS = 1 << 1,
    // PACKET_ROUTING = 1 << 2,
    // etc.
    LAST = SENDER_CHANNEL_FORWARD << 1  // Sentinel for size calculation
};
```
For instance, to run the `RECEIVER_CHANNEL_FORWARD` profiler, specify `TT_FABRIC_PROFILER=RECEIVER_CHANNEL_FORWARD` when running the test.

The runtime arg is converted to a `CodeProfilingTimerType` using the `CodeProfilingTimerTypeMap` in `tt_metal/fabric/fabric_edm_profiler_helper.hpp`, as shown below:

```
// Code Profiling Timer Type Enum is declared in code_profiling_types.hpp
const std::unordered_map<std::string, CodeProfilingTimerType> CodeProfilingTimerTypeMap = {
    {"RECEIVER_CHANNEL_FORWARD", CodeProfilingTimerType::RECEIVER_CHANNEL_FORWARD},
    {"SENDER_CHANNEL_FORWARD", CodeProfilingTimerType::SENDER_CHANNEL_FORWARD},
};
```

If you want to add a new Codepath profiler to fabric:
1. Specify your CodeProfilingTimerType in the two data structures mentioned above. Make sure that you specify a unique bit for the timer in the CodeProfilingTimerType.
3. Add your Timer to the fabric code. 

Other changes:
- Added a new timer (`SENDER_CHANNEL_FORWARD`), which measures the number of cycles used by the sender channel in a fabric router to send outgoing messages. 
- Added helper functions in `fabric_edm_profiler_helper.cpp` and `.hpp`, which allows us to convert runtime profiler specifications into CodeProfilingTimerType Enums.

NOTE: Although this is working, there are still a few things that should be investigated. I've made an issue logging the edge cases here: https://github.com/tenstorrent/tt-metal/issues/32036

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/19151181094
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/19151186034
- [ ] [Blackhole Nightly](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-nightly-tests.yaml) 
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)