### PR TITLE
[skip ci] Reenable t3k tests on merge gate

### DIFF
--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -165,7 +165,7 @@ jobs:
       matrix:
         platform: [
           "N300-viommu",
-          # "N300-llmbox-viommu", # re-enable when we have more capacity
+          "in-service-dedicated-merge-gate", # run t3k tests on CIv1 for now in order to have dedicated machine
         ]
     uses: ./.github/workflows/smoke.yaml
     with:
@@ -188,7 +188,7 @@ jobs:
       matrix:
         platform: [
           "N300-viommu",
-          # "N300-llmbox-viommu", # re-enable when we have more capacity
+          "in-service-dedicated-merge-gate", # run t3k tests on CIv1 for now in order to have dedicated machine
         ]
     uses: ./.github/workflows/smoke.yaml
     with:

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -31,7 +31,7 @@ jobs:
         (format('tt-ubuntu-2204-{0}-stable', inputs.runner))
       }}
     container:
-      image: ${{ (inputs.docker-image && format('harbor.ci.tenstorrent.net/{0}', inputs.docker-image)) || 'docker-image-unresolved!' }}
+      image: ${{ (inputs.docker-image && (contains(inputs.runner, 'dedicated-merge-gate') && inputs.docker-image || format('harbor.ci.tenstorrent.net/{0}', inputs.docker-image))) || 'docker-image-unresolved!' }}
       env:
         ASAN_OPTIONS: "color=always"
         TSAN_OPTIONS: "color=always"

--- a/ttnn/test/CMakeLists.txt
+++ b/ttnn/test/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Spell out the RPATH so that shlibdeps can find deps across package components.
+# force a full run of merge gate
 set(CMAKE_INSTALL_RPATH "$ORIGIN/../lib")
 
 # Smoke

--- a/ttnn/test/CMakeLists.txt
+++ b/ttnn/test/CMakeLists.txt
@@ -1,5 +1,4 @@
 # Spell out the RPATH so that shlibdeps can find deps across package components.
-# force a full run of merge gate
 set(CMAKE_INSTALL_RPATH "$ORIGIN/../lib")
 
 # Smoke


### PR DESCRIPTION
A CIv1 runner has been relabeled to provide dedicated service to merge gate WH llmbox tests. The label is `tt-ubuntu-2204-in-service-dedicated-merge-gate-stable` due to smoke.yaml formatting the runner label:
```format('tt-ubuntu-2204-{0}-stable', inputs.runner)```

This was done to reenable llmbox coverage in merge gate. 

Reference:
https://github.com/tenstorrent/tt-metal/pull/32033

- [x] Testing https://github.com/tenstorrent/tt-metal/actions/runs/19178116671