### PR TITLE
Fix handling of scalar value shard_to_full

### DIFF
--- a/ttnn/core/distributed/distributed_tensor.cpp
+++ b/ttnn/core/distributed/distributed_tensor.cpp
@@ -366,16 +366,20 @@ public:
         });
 
         tt::stl::SmallVector<int> num_chunks;
-        if (config_.dims.size() == 1) {
-            num_chunks.push_back(xtensor_views.size());
-        } else {
-            TT_FATAL(
-                xtensor_views.size() == distribution_shape_.mesh_size(),
-                "ND composition requires the number of tensors {} to match the mesh shape {}",
-                xtensor_views.size(),
-                distribution_shape_);
-            for (size_t i = 0; i < distribution_shape_.dims(); ++i) {
-                num_chunks.push_back(distribution_shape_[i]);
+        // Scalar (0-dim tensor)
+        bool is_single_views = xtensor_views.size() == 1;
+        if (!is_single_views) {
+            if (config_.dims.size() == 1) {
+                num_chunks.push_back(xtensor_views.size());
+            } else {
+                TT_FATAL(
+                    xtensor_views.size() == distribution_shape_.mesh_size(),
+                    "ND composition requires the number of tensors {} to match the mesh shape {}",
+                    xtensor_views.size(),
+                    distribution_shape_);
+                for (size_t i = 0; i < distribution_shape_.dims(); ++i) {
+                    num_chunks.push_back(distribution_shape_[i]);
+                }
             }
         }
 

--- a/ttnn/core/tensor/xtensor/partition.cpp
+++ b/ttnn/core/tensor/xtensor/partition.cpp
@@ -124,8 +124,6 @@ XtensorAdapter<typename Expression::value_type> concat_ndim(
     const ttsl::SmallVector<int>& dims) {
     using DataType = typename Expression::value_type;
 
-    TT_FATAL(num_chunks.size() == dims.size(), "num_chunks and dims must have the same size");
-
     if (expressions.empty()) {
         return XtensorAdapter<DataType>(std::vector<DataType>(), {0});
     }
@@ -136,6 +134,8 @@ XtensorAdapter<typename Expression::value_type> concat_ndim(
         std::vector<size_t> shape_vec(expressions.front().shape().cbegin(), expressions.front().shape().cend());
         return XtensorAdapter<DataType>(std::move(data), std::move(shape_vec));
     }
+
+    TT_FATAL(num_chunks.size() == dims.size(), "num_chunks and dims must have the same size");
 
     const auto& first_expr = expressions.front();
     const auto& expected_shape = first_expr.shape();


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-xla/issues/1993)

### Problem description
Scalars have rank 0 and can still carry a sharding attribute (replicated). 

### What's changed
This change ensures proper handling of such cases, by early returning without further process to avoid errors such as `Invalid dimension index; got dims: SmallVector([0]), tensor dimension: 0`

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes