### PR TITLE
[skip ci] add option to download build artifacts to skip building

### DIFF
--- a/.github/actions/download-artifacts-from-run/action.yml
+++ b/.github/actions/download-artifacts-from-run/action.yml
@@ -1,0 +1,183 @@
+name: "Download Artifacts from Workflow Run"
+description: "Download and extract build artifacts from a specific workflow run to skip building"
+
+inputs:
+  workflow_run_id:
+    required: true
+    description: "GitHub Actions workflow run ID to download artifacts from"
+  working-directory:
+    required: false
+    default: "/work"
+    description: "Directory to extract artifacts to"
+  tracy:
+    required: false
+    default: "false"
+    type: boolean
+    description: "Whether to look for profiler-enabled artifacts"
+
+outputs:
+  build-artifact-name:
+    description: "Name of the downloaded build artifact"
+    value: ${{ steps.download.outputs.build-artifact-name }}
+  wheel-artifact-name:
+    description: "Name of the downloaded wheel artifact"
+    value: ${{ steps.download.outputs.wheel-artifact-name }}
+  packages-artifact-name:
+    description: "Name of the downloaded packages artifact"
+    value: ${{ steps.download.outputs.packages-artifact-name }}
+
+runs:
+  using: composite
+  steps:
+    - name: Check required tools
+      shell: bash
+      run: |
+        if ! command -v gh >/dev/null 2>&1; then
+          echo "ERROR: GitHub CLI (gh) not found"
+          exit 1
+        fi
+        # Authenticate using GH_TOKEN if available (automatically used by gh CLI)
+        if [ -n "${GH_TOKEN:-}" ]; then
+          echo "GH_TOKEN found, GitHub CLI will use it automatically"
+        elif ! gh auth status >/dev/null 2>&1; then
+          echo "ERROR: GitHub CLI not authenticated and GH_TOKEN not set"
+          exit 1
+        fi
+
+    - name: Get workflow run info
+      id: run-info
+      shell: bash
+      run: |
+        WORKFLOW_RUN_ID="${{ inputs.workflow_run_id }}"
+        echo "Fetching artifacts from workflow run: $WORKFLOW_RUN_ID"
+
+        # Get workflow run details
+        RUN_INFO=$(gh run view "$WORKFLOW_RUN_ID" --repo "${{ github.repository }}" --json conclusion,workflowName 2>&1)
+        if [ $? -ne 0 ]; then
+          echo "ERROR: Failed to fetch workflow run $WORKFLOW_RUN_ID"
+          echo "$RUN_INFO"
+          exit 1
+        fi
+
+        CONCLUSION=$(echo "$RUN_INFO" | jq -r '.conclusion')
+        if [ "$CONCLUSION" != "success" ]; then
+          echo "WARNING: Workflow run $WORKFLOW_RUN_ID has conclusion: $CONCLUSION (expected: success)"
+        fi
+
+        echo "Workflow run conclusion: $CONCLUSION"
+
+    - name: List available artifacts
+      id: list-artifacts
+      shell: bash
+      run: |
+        WORKFLOW_RUN_ID="${{ inputs.workflow_run_id }}"
+        ARTIFACTS=$(gh api repos/${{ github.repository }}/actions/runs/"$WORKFLOW_RUN_ID"/artifacts --jq '.artifacts[].name' 2>&1)
+
+        if [ $? -ne 0 ]; then
+          echo "ERROR: Failed to list artifacts for run $WORKFLOW_RUN_ID"
+          echo "$ARTIFACTS"
+          exit 1
+        fi
+
+        echo "Available artifacts:"
+        echo "$ARTIFACTS"
+        echo "artifacts<<EOF" >> $GITHUB_OUTPUT
+        echo "$ARTIFACTS" >> $GITHUB_OUTPUT
+        echo "EOF" >> $GITHUB_OUTPUT
+
+    - name: Download artifacts
+      id: download
+      shell: bash
+      run: |
+        WORKFLOW_RUN_ID="${{ inputs.workflow_run_id }}"
+        WORK_DIR="${{ inputs.working-directory }}"
+        TRACY_ENABLED="${{ inputs.tracy }}"
+
+        mkdir -p "$WORK_DIR"
+        cd "$WORK_DIR"
+
+        # Parse artifact names from previous step
+        ARTIFACTS="${{ steps.list-artifacts.outputs.artifacts }}"
+
+        # Find build artifact (ttm_any.tar.zst)
+        BUILD_ARTIFACT=""
+        if [ "$TRACY_ENABLED" = "true" ]; then
+          BUILD_ARTIFACT=$(echo "$ARTIFACTS" | grep -E "TTMetal_build_any.*_profiler_" | head -1 || true)
+        else
+          BUILD_ARTIFACT=$(echo "$ARTIFACTS" | grep -E "TTMetal_build_any" | grep -v "_profiler_" | head -1 || true)
+        fi
+
+        # Find wheel artifact
+        WHEEL_ARTIFACT=$(echo "$ARTIFACTS" | grep -E "eager-dist|ttnn.*\.whl" | head -1 || true)
+
+        # Find packages artifact (optional)
+        PACKAGES_ARTIFACT=$(echo "$ARTIFACTS" | grep -E "packages-.*\.deb" | head -1 || true)
+
+        if [ -z "$BUILD_ARTIFACT" ]; then
+          echo "ERROR: Could not find build artifact matching pattern"
+          echo "Available artifacts:"
+          echo "$ARTIFACTS"
+          exit 1
+        fi
+
+        echo "Found build artifact: $BUILD_ARTIFACT"
+        echo "Found wheel artifact: ${WHEEL_ARTIFACT:-none}"
+        echo "Found packages artifact: ${PACKAGES_ARTIFACT:-none}"
+
+        # Download build artifact to a temp directory first
+        TEMP_DIR=$(mktemp -d)
+        echo "Downloading $BUILD_ARTIFACT to $TEMP_DIR..."
+        if ! gh run download "$WORKFLOW_RUN_ID" --repo "${{ github.repository }}" --name "$BUILD_ARTIFACT" --dir "$TEMP_DIR" 2>&1; then
+          echo "ERROR: Failed to download build artifact"
+          exit 1
+        fi
+
+        # Move ttm_any.tar.zst to work directory (keep it compressed for re-upload)
+        if [ -f "$TEMP_DIR/ttm_any.tar.zst" ]; then
+          mv "$TEMP_DIR/ttm_any.tar.zst" "$WORK_DIR/"
+          echo "Build artifact ready at $WORK_DIR/ttm_any.tar.zst"
+        elif [ -f "$TEMP_DIR/ttm_any.tar" ]; then
+          mv "$TEMP_DIR/ttm_any.tar" "$WORK_DIR/"
+          echo "Build artifact ready at $WORK_DIR/ttm_any.tar"
+        else
+          echo "ERROR: No ttm_any.tar.zst or ttm_any.tar found after download"
+          ls -la "$TEMP_DIR"
+          exit 1
+        fi
+        rm -rf "$TEMP_DIR"
+
+        # Download wheel artifact if found
+        if [ -n "$WHEEL_ARTIFACT" ]; then
+          TEMP_DIR=$(mktemp -d)
+          echo "Downloading $WHEEL_ARTIFACT to $TEMP_DIR..."
+          if gh run download "$WORKFLOW_RUN_ID" --repo "${{ github.repository }}" --name "$WHEEL_ARTIFACT" --dir "$TEMP_DIR" 2>&1; then
+            WHEEL_FILE=$(find "$TEMP_DIR" -name "*.whl" -type f | head -1)
+            if [ -n "$WHEEL_FILE" ]; then
+              mv "$WHEEL_FILE" "$WORK_DIR/"
+              echo "Wheel file ready at $WORK_DIR/$(basename "$WHEEL_FILE")"
+            fi
+          else
+            echo "WARNING: Failed to download wheel artifact (non-fatal)"
+          fi
+          rm -rf "$TEMP_DIR"
+        fi
+
+        # Download packages artifact if found
+        if [ -n "$PACKAGES_ARTIFACT" ]; then
+          TEMP_DIR=$(mktemp -d)
+          echo "Downloading $PACKAGES_ARTIFACT..."
+          if gh run download "$WORKFLOW_RUN_ID" --repo "${{ github.repository }}" --name "$PACKAGES_ARTIFACT" --dir "$TEMP_DIR" 2>&1; then
+            # Move any .deb files to work directory
+            find "$TEMP_DIR" -name "*.deb" -exec mv {} "$WORK_DIR/" \;
+          else
+            echo "WARNING: Failed to download packages artifact (non-fatal)"
+          fi
+          rm -rf "$TEMP_DIR"
+        fi
+
+        # Set outputs - use the original artifact names so downstream jobs can reference them
+        echo "build-artifact-name=$BUILD_ARTIFACT" >> $GITHUB_OUTPUT
+        echo "wheel-artifact-name=${WHEEL_ARTIFACT:-}" >> $GITHUB_OUTPUT
+        echo "packages-artifact-name=${PACKAGES_ARTIFACT:-}" >> $GITHUB_OUTPUT
+
+        echo "✓ Artifacts downloaded successfully to $WORK_DIR"

--- a/.github/actions/download-artifacts-from-run/action.yml
+++ b/.github/actions/download-artifacts-from-run/action.yml
@@ -11,7 +11,7 @@ inputs:
     description: "Directory to extract artifacts to"
   tracy:
     required: false
-    default: "false"
+    default: "true"
     description: "Whether to look for profiler-enabled artifacts"
 
 outputs:

--- a/.github/actions/download-artifacts-from-run/action.yml
+++ b/.github/actions/download-artifacts-from-run/action.yml
@@ -12,7 +12,6 @@ inputs:
   tracy:
     required: false
     default: "false"
-    type: boolean
     description: "Whether to look for profiler-enabled artifacts"
 
 outputs:
@@ -108,10 +107,10 @@ runs:
         fi
 
         # Find wheel artifact
-        WHEEL_ARTIFACT=$(echo "$ARTIFACTS" | grep -E "eager-dist|ttnn.*\.whl" | head -1 || true)
+        WHEEL_ARTIFACT=$(echo "$ARTIFACTS" | grep -E "eager-dist|ttnn" | head -1 || true)
 
         # Find packages artifact (optional)
-        PACKAGES_ARTIFACT=$(echo "$ARTIFACTS" | grep -E "packages-.*\.deb" | head -1 || true)
+        PACKAGES_ARTIFACT=$(echo "$ARTIFACTS" | grep -E "packages-" | head -1 || true)
 
         if [ -z "$BUILD_ARTIFACT" ]; then
           echo "ERROR: Could not find build artifact matching pattern"

--- a/.github/workflows/all-post-commit-workflows.yaml
+++ b/.github/workflows/all-post-commit-workflows.yaml
@@ -38,11 +38,6 @@ on:
         default: true
         type: boolean
         description: "Force test everything regardless of file changes"
-      use-artifacts-from-run:
-        required: false
-        type: string
-        description: "Workflow run ID to download artifacts from (skips build)"
-
   push:
     branches: ["main"]
 
@@ -61,8 +56,6 @@ jobs:
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
       packages: write
-      actions: read
-      contents: read
     secrets: inherit
     with:
       build-type: ${{ inputs.build-type || 'Release' }}
@@ -70,7 +63,6 @@ jobs:
       tracy: true
       version: ${{ inputs.version || '22.04' }}
       skip-tt-train: false
-      use-artifacts-from-run: ${{ inputs.use-artifacts-from-run || '' }}
 
   find-changed-files:
     runs-on: ubuntu-latest

--- a/.github/workflows/all-post-commit-workflows.yaml
+++ b/.github/workflows/all-post-commit-workflows.yaml
@@ -38,6 +38,11 @@ on:
         default: true
         type: boolean
         description: "Force test everything regardless of file changes"
+      use-artifacts-from-run:
+        required: false
+        type: string
+        description: "Workflow run ID to download artifacts from (skips build)"
+
   push:
     branches: ["main"]
 
@@ -56,6 +61,8 @@ jobs:
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
       packages: write
+      actions: read
+      contents: read
     secrets: inherit
     with:
       build-type: ${{ inputs.build-type || 'Release' }}
@@ -63,6 +70,7 @@ jobs:
       tracy: true
       version: ${{ inputs.version || '22.04' }}
       skip-tt-train: false
+      use-artifacts-from-run: ${{ inputs.use-artifacts-from-run || '' }}
 
   find-changed-files:
     runs-on: ubuntu-latest

--- a/.github/workflows/all-post-commit-workflows.yaml
+++ b/.github/workflows/all-post-commit-workflows.yaml
@@ -56,6 +56,8 @@ jobs:
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
       packages: write
+      contents: read # this line must be added
+      actions: read # this line must be added
     secrets: inherit
     with:
       build-type: ${{ inputs.build-type || 'Release' }}
@@ -63,6 +65,7 @@ jobs:
       tracy: true
       version: ${{ inputs.version || '22.04' }}
       skip-tt-train: false
+      use-artifacts-from-run: 19147788291
 
   find-changed-files:
     runs-on: ubuntu-latest

--- a/.github/workflows/all-post-commit-workflows.yaml
+++ b/.github/workflows/all-post-commit-workflows.yaml
@@ -56,8 +56,6 @@ jobs:
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
       packages: write
-      contents: read # this line must be added
-      actions: read # this line must be added
     secrets: inherit
     with:
       build-type: ${{ inputs.build-type || 'Release' }}
@@ -65,7 +63,6 @@ jobs:
       tracy: true
       version: ${{ inputs.version || '22.04' }}
       skip-tt-train: false
-      use-artifacts-from-run: 19147788291
 
   find-changed-files:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -73,6 +73,11 @@ on:
         type: string
         default: ""
         description: 'Commit SHA to test (default: HEAD)'
+      use-artifacts-from-run:
+        required: false
+        type: string
+        default: ""
+        description: "Workflow run ID to download artifacts from (skips build)"
     outputs:
       ci-build-docker-image:
         description: "Docker tag for the CI Build Docker image for building TT-Metalium et al"
@@ -91,13 +96,13 @@ on:
         value: ${{ jobs.build-docker-image.outputs.basic-ttnn-runtime-tag }}
       packages-artifact-name:
         description: "Name to give download-artifact to get the packages"
-        value: ${{ jobs.build-artifact.outputs.packages-artifact-name }}
+        value: ${{ jobs.build-artifact.result == 'success' && jobs.build-artifact.outputs.packages-artifact-name || (jobs.download-artifacts.result == 'success' && jobs.download-artifacts.outputs.packages-artifact-name || '') }}
       build-artifact-name:
         description: "Name of the published build artifact"
-        value: ${{ jobs.build-artifact.outputs.build_artifact_name }}
+        value: ${{ jobs.build-artifact.result == 'success' && jobs.build-artifact.outputs.build_artifact_name || (jobs.download-artifacts.result == 'success' && jobs.download-artifacts.outputs.build-artifact-name || '') }}
       wheel-artifact-name:
         description: "Name of the published wheel artifact"
-        value: ${{ jobs.build-wheel.outputs.wheel_artifact_name }}
+        value: ${{ jobs.build-wheel.result == 'success' && jobs.build-wheel.outputs.wheel_artifact_name || (jobs.download-artifacts.result == 'success' && jobs.download-artifacts.outputs.wheel-artifact-name || '') }}
 
   workflow_dispatch:
     inputs:
@@ -158,7 +163,58 @@ jobs:
       version: ${{ inputs.version }}
       architecture: ${{ inputs.architecture }}
 
+  download-artifacts:
+    if: ${{ inputs.use-artifacts-from-run != '' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+    outputs:
+      build-artifact-name: ${{ steps.download.outputs.build-artifact-name }}
+      wheel-artifact-name: ${{ steps.download.outputs.wheel-artifact-name }}
+      packages-artifact-name: ${{ steps.download.outputs.packages-artifact-name }}
+    steps:
+      - name: ⬇️ Checkout
+        uses: actions/checkout@v4
+
+      - name: Download artifacts from workflow run
+        id: download
+        env:
+          GH_TOKEN: ${{ github.token }}
+        uses: ./.github/actions/download-artifacts-from-run
+        with:
+          workflow_run_id: ${{ inputs.use-artifacts-from-run }}
+          working-directory: ${{ github.workspace }}/artifacts
+          tracy: ${{ inputs.tracy }}
+
+      - name: Upload build artifact for downstream jobs
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.download.outputs.build-artifact-name }}
+          path: ${{ github.workspace }}/artifacts/ttm_any.tar.zst
+          if-no-files-found: error
+          retention-days: 1
+
+      - name: Upload wheel artifact
+        if: ${{ steps.download.outputs.wheel-artifact-name != '' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.download.outputs.wheel-artifact-name }}
+          path: ${{ github.workspace }}/artifacts/*.whl
+          if-no-files-found: ignore
+          retention-days: 1
+
+      - name: Upload packages artifact
+        if: ${{ steps.download.outputs.packages-artifact-name != '' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.download.outputs.packages-artifact-name }}
+          path: ${{ github.workspace }}/artifacts/*.deb
+          if-no-files-found: ignore
+          retention-days: 1
+
   build-artifact:
+    if: ${{ inputs.use-artifacts-from-run == '' }}
     name: "🛠️ Build ${{ inputs.build-type }} ${{ inputs.distro }} ${{ inputs.version }}"
     needs: build-docker-image
     timeout-minutes: 100
@@ -329,7 +385,7 @@ jobs:
           compression-level: 0
 
   build-wheel:
-    if: ${{ inputs.build-wheel }}
+    if: ${{ inputs.build-wheel && inputs.use-artifacts-from-run == '' }}
     name: 🐍 Build wheel (Python ${{ inputs.version == '22.04' && '3.10' || '3.12' }})
     needs: build-docker-image
     timeout-minutes: 30

--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -99,10 +99,10 @@ on:
         value: ${{ jobs.build-artifact.result == 'success' && jobs.build-artifact.outputs.packages-artifact-name || (jobs.download-artifacts.result == 'success' && jobs.download-artifacts.outputs.packages-artifact-name || '') }}
       build-artifact-name:
         description: "Name of the published build artifact"
-        value: ${{ jobs.build-artifact.result == 'success' && jobs.build-artifact.outputs.build_artifact_name || (jobs.download-artifacts.result == 'success' && jobs.download-artifacts.outputs.build-artifact-name || '') }}
+        value: ${{ jobs.build-artifact.result == 'success' && jobs.build-artifact.outputs.build_artifact_name || (jobs.download-artifacts.result == 'success' && jobs.download-artifacts.outputs.build_artifact_name || '') }}
       wheel-artifact-name:
         description: "Name of the published wheel artifact"
-        value: ${{ jobs.build-wheel.result == 'success' && jobs.build-wheel.outputs.wheel_artifact_name || (jobs.download-artifacts.result == 'success' && jobs.download-artifacts.outputs.wheel-artifact-name || '') }}
+        value: ${{ jobs.build-wheel.result == 'success' && jobs.build-wheel.outputs.wheel_artifact_name || (jobs.download-artifacts.result == 'success' && jobs.download-artifacts.outputs.wheel_artifact_name || '') }}
 
   workflow_dispatch:
     inputs:
@@ -167,8 +167,8 @@ jobs:
     if: ${{ inputs.use-artifacts-from-run != '' }}
     runs-on: ubuntu-latest
     outputs:
-      build-artifact-name: ${{ steps.download.outputs.build-artifact-name }}
-      wheel-artifact-name: ${{ steps.download.outputs.wheel-artifact-name }}
+      build_artifact_name: ${{ steps.download.outputs.build-artifact-name }}
+      wheel_artifact_name: ${{ steps.download.outputs.wheel-artifact-name }}
       packages-artifact-name: ${{ steps.download.outputs.packages-artifact-name }}
     steps:
       - name: ⬇️ Checkout

--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -166,9 +166,6 @@ jobs:
   download-artifacts:
     if: ${{ inputs.use-artifacts-from-run != '' }}
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      actions: read
     outputs:
       build-artifact-name: ${{ steps.download.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ steps.download.outputs.wheel-artifact-name }}


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/31707)

### Problem description
Often times, when developers are testing on CI, they continuously build and rebuild metal and the python wheel for each CI run when they aren't actually changing any code that would cause metal or the wheel to have to be rebuilt. This wastes compute time on unnecessary rebuilds

### What's changed
Build-artifact has been modified to include the option to download build artifacts from previous runs, allowing users to skip the build step by following the instructions down below:

https://tenstorrent.atlassian.net/wiki/spaces/MI6/pages/1673953612/How+to+Skip+Build+Step+in+CI+Runs

### Checklist
- [x] [All post commit base](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/19147788291/job/54729821379
- [ ] [All post commit with reference artifact](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/19148722215