### PR TITLE
Fix BH demo device perf with sampling 

### DIFF
--- a/.github/workflows/blackhole-multi-card-demo-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-demo-tests-impl.yaml
@@ -49,11 +49,11 @@ jobs:
             owner_id: U03PUAKE719 # Miguel Tairum
           - name: "llama3.1-8b ${{ inputs.runner-label }} batch-1 TP device perf decode"
             arch: blackhole
-            cmd: HF_MODEL=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.1-8B-Instruct pytest models/tt_transformers/tests/test_device_perf.py -k "decode-llama3_8b-2-1024-10-1-1-False"
+            cmd: HF_MODEL=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.1-8B-Instruct pytest models/tt_transformers/tests/test_device_perf.py -k "decode-llama3_8b-2-1024-2-10-1-1-False"
             owner_id: U08GELBB1AP # Ambrose Ling
           - name: "llama3.1-8b ${{ inputs.runner-label }} batch-1 TP device perf prefill"
             arch: blackhole
-            cmd: HF_MODEL=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.1-8B-Instruct pytest models/tt_transformers/tests/test_device_perf.py -k "prefill-llama3_8b-2-1024-10-1-1-False"
+            cmd: HF_MODEL=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.1-8B-Instruct pytest models/tt_transformers/tests/test_device_perf.py -k "prefill-llama3_8b-2-1024-2-10-1-1-False"
             owner_id: U08GELBB1AP # Ambrose Ling
     name: ${{ matrix.test-group.name }}
     runs-on:
@@ -159,11 +159,11 @@ jobs:
             owner_id: U03PUAKE719 # Miguel Tairum
           - name: "llama3.3-70b ${{ inputs.runner-label }} batch-1 TP device perf prefill"
             arch: blackhole
-            cmd: HF_MODEL=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.3-70B-Instruct pytest models/tt_transformers/tests/test_device_perf.py -k "prefill-llama3_70b-2-1024-10-1-1-False"
+            cmd: HF_MODEL=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.3-70B-Instruct pytest models/tt_transformers/tests/test_device_perf.py -k "prefill-llama3_70b-2-1024-2-10-1-1-False"
             owner_id: U08GELBB1AP # Ambrose Ling
           - name: "llama3.3-70b ${{ inputs.runner-label }} batch-1 TP device perf decode"
             arch: blackhole
-            cmd: HF_MODEL=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.3-70B-Instruct pytest models/tt_transformers/tests/test_device_perf.py -k "decode-llama3_70b-2-1024-10-1-1-False"
+            cmd: HF_MODEL=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.3-70B-Instruct pytest models/tt_transformers/tests/test_device_perf.py -k "decode-llama3_70b-2-1024-2-10-1-1-False"
             owner_id: U08GELBB1AP # Ambrose Ling
     name: ${{ matrix.test-group.name }}
     runs-on:

--- a/models/tt_transformers/tests/test_device_perf.py
+++ b/models/tt_transformers/tests/test_device_perf.py
@@ -28,17 +28,11 @@ from tools.tracy.process_model_log import get_latest_ops_log_filename
 @pytest.mark.parametrize("batch_size", [1, 32])
 @pytest.mark.parametrize("data_parallel", [1, 2, 4, 8])
 @pytest.mark.parametrize("num_layers", [10])
+@pytest.mark.parametrize("num_runs", [2])
 @pytest.mark.parametrize("max_seq_len", [1024])
 @pytest.mark.parametrize("max_generated_tokens", [2])
 @pytest.mark.parametrize("model_name", ["llama3_70b", "llama3_8b"])  # Add more models here as needed
-@pytest.mark.parametrize(
-    "mode, num_runs",
-    [
-        ("prefill", 2),
-        ("decode", 4),
-    ],
-    ids=["prefill", "decode"],
-)
+@pytest.mark.parametrize("mode", ["prefill", "decode"])
 def test_device_perf_one_iter(
     num_layers,
     model_name,

--- a/models/tt_transformers/tests/test_utils.py
+++ b/models/tt_transformers/tests/test_utils.py
@@ -321,10 +321,10 @@ def find_repeated_block(ops, min_repeat=2):
                 }
     # No repetition found
     return {
-        "head": ops,
-        "layer_block": [],
+        "num_head_ops": len(ops),
+        "num_layer_block_ops": 0,
         "num_layers": 0,
-        "tail": [],
+        "num_tail_ops": len(ops),
     }
 
 
@@ -358,6 +358,7 @@ def split_compile_and_trace(
         )
         Any of the additional outputs may be None if slicing arguments are not provided.
     """
+
     # Finds the first index such that ops[left:] contains num_runs of identical blocks of ops
     first_run_start = find_repeated_runs(df["OP CODE"].tolist(), num_runs)
     adjusted_len = (len(df) - first_run_start) // num_runs  # The number of ops in each run


### PR DESCRIPTION
### Problem description
Failing pipelines: https://github.com/tenstorrent/tt-metal/actions/runs/19128937363/job/54695391379

BH demo pipelines were failing when sampling on device was added to TT transformers, causing changes in the op list that was unanticipated. Previously we were parsing 4 runs of ops but we should only need to parse the last 2 runs with decode.

1st run: 12 head ops + 25 x 10 mid layer ops + 29 tail ops 
2nd run:  12 head ops + 25 x 10 mid layer ops + 21 tail ops 
3rd run:  12 head ops + 25 x 10 mid layer ops + 21 tail ops 
4th run:  12 head ops + 25 x 10 mid layer ops + 21 tail ops 

When it cant evenly divide into 4 runs such that ops in all 4 runs match, it couldn't detect repetition in the op codes so it caused a key error 

### What's changed
- parse only the last 2 runs instead of 4 (the compile and trace run of decode) 

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Multi Card demo](https://github.com/tenstorrent/tt-metal/actions/runs/19149425635)