### PR TITLE
Blackhole assert after issue 25034 change

### DIFF
--- a/tt_metal/hw/inc/tt-1xx/blackhole/dev_mem_map.h
+++ b/tt_metal/hw/inc/tt-1xx/blackhole/dev_mem_map.h
@@ -179,7 +179,7 @@
 // This size must match the firmware noc_size_x & noc_size Y. Size is largest chip (X + Y) * sizeof uint8_t.
 // Chip sizes must round up to nearest multiple of 4 to deal with uint32_t alignment for L1 to local copies.
 #define MEM_LOGICAL_TO_VIRTUAL_SCRATCH (MEM_BANK_TO_NOC_SCRATCH + MEM_BANK_TO_NOC_SIZE)
-#define MEM_LOGICAL_TO_VIRTUAL_SIZE ((14 + 10) * sizeof(uint8_t))
+#define MEM_LOGICAL_TO_VIRTUAL_SIZE ((20 + 12) * sizeof(uint8_t))
 
 /////////////
 // Stack info


### PR DESCRIPTION
### Ticket
N/A

### Problem description
After the change for issue [25034](https://github.com/tenstorrent/tt-metal/issues/25034), when running Blackhole in a debug build the following assert is triggered:

`critical |          Always | Size of logical to virtual map is greater than available space (assert.hpp:103)`

### What's changed
Adjusted the size reserved for logical to virtual map to correctly work for Blackhole. Blackhole size is:
20 columns: 17 real columns rounded up to multiple of 4.
12 rows: 10 real rows rounded up to multiple of 4.

Properly tested with unit test & debug mode on both Blackhole & Wormhole

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [x] New/Existing tests provide coverage for changes