### PR TITLE
readability-braces-around-statements

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -154,7 +154,6 @@ Checks: >
   -portability-template-virtual-member-function,
   -readability-avoid-nested-conditional-operator,
   -readability-avoid-unconditional-preprocessor-if,
-  -readability-braces-around-statements,
   -readability-container-contains,
   -readability-container-data-pointer,
   -readability-convert-member-functions-to-static,

--- a/tests/tt_metal/tt_fabric/fabric_router/test_mesh_graph_descriptor.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_mesh_graph_descriptor.cpp
@@ -474,9 +474,15 @@ TEST(MeshGraphDescriptorTests, TestInstanceCreation) {
     auto pod_ids = desc.instances_by_type("POD");
     auto mesh_ids = desc.instances_by_type("MESH");
 
-    for (uint32_t id : cluster_ids) check_instance_type(desc, id, true);   // CLUSTER should be graph
-    for (uint32_t id : pod_ids) check_instance_type(desc, id, true);       // POD should be graph
-    for (uint32_t id : mesh_ids) check_instance_type(desc, id, false);     // mesh should be mesh
+    for (uint32_t id : cluster_ids) {
+        check_instance_type(desc, id, true);  // CLUSTER should be graph
+    }
+    for (uint32_t id : pod_ids) {
+        check_instance_type(desc, id, true);  // POD should be graph
+    }
+    for (uint32_t id : mesh_ids) {
+        check_instance_type(desc, id, false);  // mesh should be mesh
+    }
 
     // Check hierarchy relationships
     check_instance_exists_by_name(desc, "G0");

--- a/tests/tt_metal/tt_metal/debug_tools/debug_tools_test_utils.hpp
+++ b/tests/tt_metal/tt_metal/debug_tools/debug_tools_test_utils.hpp
@@ -94,8 +94,9 @@ inline std::string_view::size_type FloatingGlobEndsAt(const std::string_view hay
         if (result != haystack.npos) {
             return result + idx;
         }
-        if (!idx)
+        if (!idx) {
             break;
+        }
     }
 
     return haystack.npos;
@@ -104,8 +105,9 @@ inline std::string_view::size_type FloatingGlobEndsAt(const std::string_view hay
 // Count the number of '*' characters.
 inline unsigned GlobCount(const std::string_view glob) {
     unsigned count = 0;
-    for (std::string_view::size_type idx = 0; (idx = glob.find('*', idx)) != glob.npos; idx++)
+    for (std::string_view::size_type idx = 0; (idx = glob.find('*', idx)) != glob.npos; idx++) {
         count++;
+    }
     return count;
 }
 // str matches pattern, allowing '?' and '*' globbing.
@@ -122,8 +124,9 @@ inline bool StringContainsGlob(const std::string_view haystack, const std::strin
 // strings between lines in the file.
 inline bool FileContainsAllStrings(const std::string& file_name, const std::vector<std::string> &must_contain) {
     std::fstream log_file;
-    if (!OpenFile(file_name, log_file, std::fstream::in))
+    if (!OpenFile(file_name, log_file, std::fstream::in)) {
         return false;
+    }
 
     // Construct a set of required strings, we'll remove each one when it's found.
     std::set<std::string_view> must_contain_set;
@@ -151,8 +154,9 @@ inline bool FileContainsAllStrings(const std::string& file_name, const std::vect
         }
 
         // Remove all strings found on this line from the set to continue searching for
-        for (const auto &s : found_on_current_line)
+        for (const auto& s : found_on_current_line) {
             must_contain_set.erase(s);
+        }
     }
 
     // Reached EOF with strings yet to find.
@@ -173,8 +177,9 @@ inline bool FileContainsAllStrings(const std::string& file_name, const std::vect
 // between lines in a file.
 inline bool FileContainsAllStringsInOrder(const std::string& file_name, const std::vector<std::string> &must_contain) {
     std::fstream log_file;
-    if (!OpenFile(file_name, log_file, std::fstream::in))
+    if (!OpenFile(file_name, log_file, std::fstream::in)) {
         return false;
+    }
 
     // Construct a deque of required strings, we'll remove each one when it's found.
     std::deque<std::string_view> must_contain_queue;

--- a/tests/tt_metal/tt_metal/debug_tools/inspector/test_rpc_startup.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/inspector/test_rpc_startup.cpp
@@ -16,7 +16,9 @@ class InspectorFixture : public ::testing::Test {
     // Helper to find a free port
     int find_free_port() {
         int sock = socket(AF_INET, SOCK_STREAM, 0);
-        if (sock < 0) return 0;
+        if (sock < 0) {
+            return 0;
+        }
         sockaddr_in addr{};
         addr.sin_family = AF_INET;
         addr.sin_addr.s_addr = INADDR_ANY;
@@ -37,7 +39,9 @@ class InspectorFixture : public ::testing::Test {
 
     std::string find_free_port_address() {
         int port = find_free_port();
-        if (port == 0) return "";
+        if (port == 0) {
+            return "";
+        }
         return "localhost:" + std::to_string(port);
     }
 

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_noc_sanitize_delays.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_noc_sanitize_delays.cpp
@@ -178,8 +178,9 @@ void RunDelayTestOnCore(
 }
 
 TEST_F(MeshWatcherDelayFixture, TensixTestWatcherSanitizeInsertDelays) {
-    if (this->slow_dispatch_)
+    if (this->slow_dispatch_) {
         GTEST_SKIP();
+    }
 
     this->RunTestOnDevice(
         [](MeshWatcherFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_pause.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_pause.cpp
@@ -84,8 +84,9 @@ void RunTest(MeshWatcherFixture* fixture, const std::shared_ptr<distributed::Mes
     bool has_ieth_cores = !device->get_inactive_ethernet_cores().empty();
 
     // TODO: Enable this when FD-on-idle-eth is supported.
-    if (!fixture->IsSlowDispatch())
+    if (!fixture->IsSlowDispatch()) {
         has_ieth_cores = false;
+    }
 
     if (has_eth_cores) {
         KernelHandle erisc_kid;

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_waypoint.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_waypoint.cpp
@@ -94,8 +94,9 @@ void RunTest(MeshWatcherFixture* fixture, const std::shared_ptr<distributed::Mes
     bool has_idle_eth_cores = !device->get_inactive_ethernet_cores().empty();
 
     // TODO: Enable this when FD-on-idle-eth is supported.
-    if (!fixture->IsSlowDispatch())
+    if (!fixture->IsSlowDispatch()) {
         has_idle_eth_cores = false;
+    }
 
     if (has_eth_cores) {
         KernelHandle erisc_kid;
@@ -164,8 +165,9 @@ void RunTest(MeshWatcherFixture* fixture, const std::shared_ptr<distributed::Mes
                     // blank | prefetch, dispatch | tensix kernels
                     int k_id = 1 + 2 + 3;
                     std::string k_id_s = fmt::format("{:3}", k_id);
-                    if (device->arch() == ARCH::BLACKHOLE)
+                    if (device->arch() == ARCH::BLACKHOLE) {
                         k_id_s += fmt::format("|{:3}", k_id + 1);
+                    }
                 } else {
                     k_id_s = "";
                 }

--- a/tt_metal/common/thread_pool.cpp
+++ b/tt_metal/common/thread_pool.cpp
@@ -125,7 +125,9 @@ public:
         // has progressed (data has been read).
         // A stall is only required when the ring_buffer_ backing the queue
         // is full. Realistically, this should never happen, given the size
-        while (tail_.load()->next == head_.load());
+        while (tail_.load()->next == head_.load()) {
+            ;
+        }
         tail_.load()->data = std::move(task);
         tail_.store(tail_.load()->next);
     }

--- a/tt_metal/distributed/distributed.cpp
+++ b/tt_metal/distributed/distributed.cpp
@@ -29,7 +29,9 @@ void EventSynchronize(const MeshEvent& event) {
     }
     for (const auto& coord : event.device_range()) {
         auto physical_device = event.device()->get_device(coord);
-        while (physical_device->sysmem_manager().get_last_completed_event(event.mesh_cq_id()) < event.id());
+        while (physical_device->sysmem_manager().get_last_completed_event(event.mesh_cq_id()) < event.id()) {
+            ;
+        }
     }
 }
 

--- a/tt_metal/fabric/builder/fabric_core_placement.cpp
+++ b/tt_metal/fabric/builder/fabric_core_placement.cpp
@@ -15,7 +15,9 @@ void run_default_galaxy_optimizer(
     const CorePlacementContext& ctx,
     tt::tt_fabric::FabricEriscDatamoverBuilder& edm_builder1,
     tt::tt_fabric::FabricEriscDatamoverBuilder& edm_builder2) {
-    if (!ctx.is_galaxy) return;
+    if (!ctx.is_galaxy) {
+        return;
+    }
 
     constexpr uint32_t ring_noc_selection_link_threshold = 3;
     constexpr uint32_t line_noc_selection_link_threshold = 2;

--- a/tt_metal/fabric/mesh_graph_descriptor.cpp
+++ b/tt_metal/fabric/mesh_graph_descriptor.cpp
@@ -217,14 +217,18 @@ std::vector<std::string> MeshGraphDescriptor::static_validate(const proto::MeshG
     // Run validation groups with early exit checkpoints
     {
         validate_basic_structure(proto, all_errors);
-        if (!all_errors.empty()) return all_errors;
+        if (!all_errors.empty()) {
+            return all_errors;
+        }
     }
 
     {
         validate_names(proto, all_errors);
         validate_channels(proto, all_errors);
         validate_architecture_consistency(proto, all_errors);
-        if (!all_errors.empty()) return all_errors;
+        if (!all_errors.empty()) {
+            return all_errors;
+        }
     }
 
     {
@@ -232,14 +236,18 @@ std::vector<std::string> MeshGraphDescriptor::static_validate(const proto::MeshG
         validate_express_connections(proto, all_errors);
         validate_graph_descriptors(proto, all_errors);
         validate_graph_topology_and_connections(proto, all_errors);
-        if (!all_errors.empty()) return all_errors;
+        if (!all_errors.empty()) {
+            return all_errors;
+        }
     }
 
     {
         if (backwards_compatible) {
             validate_legacy_requirements(proto, all_errors);
         }
-        if (!all_errors.empty()) return all_errors;
+        if (!all_errors.empty()) {
+            return all_errors;
+        }
     }
 
     return all_errors;
@@ -1150,13 +1158,17 @@ void MeshGraphDescriptor::print_node(GlobalNodeId id, int indent_level) {
         const auto* mesh_desc = std::get<const proto::MeshDescriptor*>(inst.desc);
         ss << indent << "Device Topology Dimensions: [";
         for (int i = 0; i < mesh_desc->device_topology().dims_size(); ++i) {
-            if (i > 0) ss << ", ";
+            if (i > 0) {
+                ss << ", ";
+            }
             ss << mesh_desc->device_topology().dims(i);
         }
         ss << "]" << std::endl;
         ss << indent << "Host Topology Dimensions: [";
         for (int i = 0; i < mesh_desc->host_topology().dims_size(); ++i) {
-            if (i > 0) ss << ", ";
+            if (i > 0) {
+                ss << ", ";
+            }
             ss << mesh_desc->host_topology().dims(i);
         }
         ss << "]" << std::endl;

--- a/tt_metal/jit_build/genfiles.cpp
+++ b/tt_metal/jit_build/genfiles.cpp
@@ -41,7 +41,9 @@ namespace {
 
 void gen_kernel_cpp(const string& src, const string& dst_name, const vector<string>& prolog) {
     std::ofstream out(dst_name);
-    for (const string& s : prolog) out << s;
+    for (const string& s : prolog) {
+        out << s;
+    }
     out << src;
 }
 

--- a/tt_metal/llrt/llrt.cpp
+++ b/tt_metal/llrt/llrt.cpp
@@ -281,7 +281,9 @@ void wait_until_cores_done(
     auto start = std::chrono::high_resolution_clock::now();
     const auto& rtoptions = tt_metal::MetalContext::instance().rtoptions();
     bool is_simulator = rtoptions.get_simulator_enabled();
-    if (is_simulator) timeout_ms = 0;
+    if (is_simulator) {
+        timeout_ms = 0;
+    }
     while (!not_done_phys_cores.empty()) {
         if (timeout_ms > 0) {
             auto now = std::chrono::high_resolution_clock::now();

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -336,7 +336,9 @@ void Cluster::assign_mem_channels_to_devices(
             continue;
         }
         this->device_to_host_mem_channel_[device_id] = channel++;
-        if ((channel + 1) % 4 == 0) channel++;
+        if ((channel + 1) % 4 == 0) {
+            channel++;
+        }
     }
 }
 

--- a/tt_metal/llrt/tt_elffile.cpp
+++ b/tt_metal/llrt/tt_elffile.cpp
@@ -439,8 +439,9 @@ void ElfFile::Impl::Elf<Is64>::LoadImage() {
             auto bytes = GetContents(section);
             auto words = std::span(reinterpret_cast<uint32_t const *>(bytes.data()), bytes.size() / sizeof(uint32_t));
             for (unsigned ix = 0; ix != words.size(); ix++) {
-                if (ix >= GetSegments().size())
+                if (ix >= GetSegments().size()) {
                     continue;
+                }
                 uint32_t limit = words[ix];
                 auto const &seg = GetSegments()[ix];
                 if (seg.membytes > limit) {

--- a/ttnn/api/ttnn/config.hpp
+++ b/ttnn/api/ttnn/config.hpp
@@ -73,7 +73,9 @@ public:
                 }
 
                 std::transform(name_str.begin(), name_str.end(), name_str.begin(), [](unsigned char c) {
-                    if (std::isalnum(c)) return static_cast<char>(std::tolower(c));
+                    if (std::isalnum(c)) {
+                        return static_cast<char>(std::tolower(c));
+                    }
                     return '_';
                 });
 
@@ -81,8 +83,12 @@ public:
                     return a == '_' && b == '_';
                 }), name_str.end());
 
-                if (!name_str.empty() && name_str.front() == '_') name_str.erase(0, 1);
-                if (!name_str.empty() && name_str.back() == '_') name_str.pop_back();
+                if (!name_str.empty() && name_str.front() == '_') {
+                    name_str.erase(0, 1);
+                }
+                if (!name_str.empty() && name_str.back() == '_') {
+                    name_str.pop_back();
+                }
 
                 // Get current date and time
                 auto now = std::chrono::system_clock::now();

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/sharded_to_interleaved/device/sharded_to_interleaved_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/sharded_to_interleaved/device/sharded_to_interleaved_program_factory.cpp
@@ -231,8 +231,9 @@ operation::ProgramWithCallbacks sharded_to_interleaved_multi_core(
             uint32_t l1_alignment = hal::get_l1_alignment();
             uint32_t padded_shard_width = align(output_unit_size, dst_buffer->alignment());
             if(is_blackhole or is_l1_aligned) {
-                if(!dst_is_dram or is_l1_aligned)
+                if (!dst_is_dram or is_l1_aligned) {
                     padded_shard_width = align(output_unit_size, l1_alignment);
+                }
             }
             tt_metal::SetRuntimeArgs(
                 program,


### PR DESCRIPTION
### Ticket
#22758 
Closes #32061 

### Problem description
We have this check disabled.
https://clang.llvm.org/extra/clang-tidy/checks/readability/braces-around-statements.html

Putting braces around control flow statements is usually best for readability, and its best to be consistent.

Its actually strange that this check fails, because we tried to enable this in clang-format.

### What's changed
- Enable check
- Apply automatic FIXITs

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/19152744179) CI passes
- [x] New/Existing tests provide coverage for changes