### PR TITLE
Add non zero size asserts to system_memory_manager.cpp

### DIFF
--- a/tt_metal/impl/dispatch/system_memory_manager.cpp
+++ b/tt_metal/impl/dispatch/system_memory_manager.cpp
@@ -282,6 +282,7 @@ ChipId SystemMemoryManager::get_device_id() const { return this->device_id; }
 std::vector<SystemMemoryCQInterface>& SystemMemoryManager::get_cq_interfaces() { return this->cq_interfaces; }
 
 void* SystemMemoryManager::issue_queue_reserve(uint32_t cmd_size_B, const uint8_t cq_id) {
+    TT_ASSERT(cmd_size_B > 0, "Command size must be greater than 0");
     if (this->bypass_enable) {
         uint32_t curr_size = this->bypass_buffer.size();
         uint32_t new_size = curr_size + (cmd_size_B / sizeof(uint32_t));
@@ -336,6 +337,7 @@ void SystemMemoryManager::cq_write(const void* data, uint32_t size_in_bytes, uin
 
 // TODO: RENAME issue_queue_stride ?
 void SystemMemoryManager::issue_queue_push_back(uint32_t push_size_B, const uint8_t cq_id) {
+    TT_ASSERT(push_size_B > 0, "Push size must be greater than 0");
     if (this->bypass_enable) {
         this->bypass_buffer_write_offset += push_size_B;
         return;
@@ -525,6 +527,7 @@ void SystemMemoryManager::fetch_queue_write(uint32_t command_size_B, const uint8
         max_command_size_B);
     TT_ASSERT(
         (command_size_B >> DispatchSettings::PREFETCH_Q_LOG_MINSIZE) < 0xFFFF, "FetchQ command too large to represent");
+    TT_ASSERT(command_size_B > 0, "Command size must be greater than 0");
     if (this->bypass_enable) {
         return;
     }


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/21030

### Problem description
- Using size 0 by mistake will cause a prefetcher hang

### What's changed
- Add TT_ASSERT to check for non zero input size

### Checklist
APC
https://github.com/tenstorrent/tt-metal/actions/runs/19153497673
Blackhole Post Commit
https://github.com/tenstorrent/tt-metal/actions/runs/19153498473