### PR TITLE
Cleanup Tile class

### DIFF
--- a/tt_metal/api/tt-metalium/tile.hpp
+++ b/tt_metal/api/tt-metalium/tile.hpp
@@ -20,35 +20,7 @@ enum class DataFormat : uint8_t;
 
 namespace tt::tt_metal {
 
-constexpr std::array<std::array<std::array<uint32_t, 2>, 2>, 12> TILE_FACE_HW_CHOICES = {{
-    // TODO: add other tile shapes once llk supported it
-    {{ {32, 32}, {16, 16} }},
-    {{ {16, 32}, {16, 16} }},
-    {{ {32, 16}, {16, 16} }},
-    {{ {16, 16}, {16, 16} }},
-    // this shapes are not supported yet on llk, just for host loopback
-    {{ {8, 32}, {8, 16} }},
-    {{ {4, 32}, {4, 16} }},
-    {{ {2, 32}, {2, 16} }},
-    {{ {1, 32}, {1, 16} }},
-    // this shapes are not supported yet on llk, just for host loopback
-    {{ {8, 16}, {8, 16} }},
-    {{ {4, 16}, {4, 16} }},
-    {{ {2, 16}, {2, 16} }},
-    {{ {1, 16}, {1, 16} }}
-}};
-
 struct Tile {
-    std::array<uint32_t, 2> tile_shape = {constants::TILE_HEIGHT, constants::TILE_WIDTH};
-    std::array<uint32_t, 2> face_shape = {constants::FACE_HEIGHT, constants::FACE_WIDTH};
-    uint32_t tile_hw = constants::TILE_HW;
-    uint32_t face_hw = constants::FACE_HW;
-    uint32_t num_faces = constants::TILE_HW / constants::FACE_HW;
-    uint32_t partial_face = 0;
-    uint32_t narrow_tile = 0;
-    bool transpose_within_face = false; // tranpose datums within each face
-    bool transpose_of_faces = false; // transpose the face order
-
     Tile(
         std::array<uint32_t, 2> tile_shape = {constants::TILE_HEIGHT, constants::TILE_WIDTH},
         bool transpose_tile = false);
@@ -73,6 +45,17 @@ struct Tile {
 
     static constexpr auto attribute_names = std::forward_as_tuple("tile_shape", "face_shape", "num_faces");
     auto attribute_values() const { return std::forward_as_tuple(tile_shape, face_shape, num_faces); }
+
+private:
+    std::array<uint32_t, 2> tile_shape = {constants::TILE_HEIGHT, constants::TILE_WIDTH};
+    std::array<uint32_t, 2> face_shape = {constants::FACE_HEIGHT, constants::FACE_WIDTH};
+    uint32_t tile_hw = constants::TILE_HW;
+    uint32_t face_hw = constants::FACE_HW;
+    uint32_t num_faces = constants::TILE_HW / constants::FACE_HW;
+    uint32_t partial_face = 0;
+    uint32_t narrow_tile = 0;
+    bool transpose_within_face = false;  // tranpose datums within each face
+    bool transpose_of_faces = false;     // transpose the face order
 };
 
 }  // namespace tt::tt_metal

--- a/tt_metal/api/tt-metalium/tile.hpp
+++ b/tt_metal/api/tt-metalium/tile.hpp
@@ -54,7 +54,7 @@ private:
     uint32_t num_faces = constants::TILE_HW / constants::FACE_HW;
     uint32_t partial_face = 0;
     uint32_t narrow_tile = 0;
-    bool transpose_within_face = false;  // tranpose datums within each face
+    bool transpose_within_face = false;  // transpose datums within each face
     bool transpose_of_faces = false;     // transpose the face order
 };
 

--- a/tt_metal/impl/data_format/tile.cpp
+++ b/tt_metal/impl/data_format/tile.cpp
@@ -14,6 +14,23 @@
 
 namespace tt::tt_metal {
 
+constexpr std::array<std::array<std::array<uint32_t, 2>, 2>, 12> TILE_FACE_HW_CHOICES = {
+    {// TODO: add other tile shapes once llk supported it
+     {{{32, 32}, {16, 16}}},
+     {{{16, 32}, {16, 16}}},
+     {{{32, 16}, {16, 16}}},
+     {{{16, 16}, {16, 16}}},
+     // this shapes are not supported yet on llk, just for host loopback
+     {{{8, 32}, {8, 16}}},
+     {{{4, 32}, {4, 16}}},
+     {{{2, 32}, {2, 16}}},
+     {{{1, 32}, {1, 16}}},
+     // this shapes are not supported yet on llk, just for host loopback
+     {{{8, 16}, {8, 16}}},
+     {{{4, 16}, {4, 16}}},
+     {{{2, 16}, {2, 16}}},
+     {{{1, 16}, {1, 16}}}}};
+
 Tile::Tile(std::array<uint32_t, 2> tile_shape, bool transpose_tile) : tile_shape(tile_shape) {
     auto it = std::find_if(TILE_FACE_HW_CHOICES.begin(), TILE_FACE_HW_CHOICES.end(), [this](const auto& pair) {
         if (pair[0] == this->tile_shape) {

--- a/tt_metal/impl/data_format/tile.cpp
+++ b/tt_metal/impl/data_format/tile.cpp
@@ -20,12 +20,12 @@ constexpr std::array<std::array<std::array<uint32_t, 2>, 2>, 12> TILE_FACE_HW_CH
      {{{16, 32}, {16, 16}}},
      {{{32, 16}, {16, 16}}},
      {{{16, 16}, {16, 16}}},
-     // this shapes are not supported yet on llk, just for host loopback
+     // these shapes are not supported yet on llk, just for host loopback
      {{{8, 32}, {8, 16}}},
      {{{4, 32}, {4, 16}}},
      {{{2, 32}, {2, 16}}},
      {{{1, 32}, {1, 16}}},
-     // this shapes are not supported yet on llk, just for host loopback
+     // these shapes are not supported yet on llk, just for host loopback
      {{{8, 16}, {8, 16}}},
      {{{4, 16}, {4, 16}}},
      {{{2, 16}, {2, 16}}},

--- a/ttnn/cpp/ttnn-pybind/tensor.cpp
+++ b/ttnn/cpp/ttnn-pybind/tensor.cpp
@@ -153,13 +153,13 @@ void tensor_mem_config_module(py::module& m_tensor) {
             [](const Tile& self) {
                 return fmt::format("Tile with shape: [{}, {}]", self.get_tile_shape()[0], self.get_tile_shape()[1]);
             })
-        .def_readonly("tile_shape", &Tile::tile_shape)
-        .def_readonly("face_shape", &Tile::face_shape)
-        .def_readonly("num_faces", &Tile::num_faces)
-        .def_readonly("partial_face", &Tile::partial_face)
-        .def_readonly("narrow_tile", &Tile::narrow_tile)
-        .def_readonly("transpose_within_face", &Tile::transpose_within_face)
-        .def_readonly("transpose_of_faces", &Tile::transpose_of_faces);
+        .def_property_readonly("tile_shape", &Tile::get_tile_shape)
+        .def_property_readonly("face_shape", &Tile::get_face_shape)
+        .def_property_readonly("num_faces", &Tile::get_num_faces)
+        .def_property_readonly("partial_face", &Tile::get_partial_face)
+        .def_property_readonly("narrow_tile", &Tile::get_narrow_tile)
+        .def_property_readonly("transpose_within_face", &Tile::get_transpose_within_face)
+        .def_property_readonly("transpose_of_faces", &Tile::get_transpose_of_faces);
 
     auto pyTensorSpec = static_cast<py::class_<TensorSpec>>(m_tensor.attr("TensorSpec"));
     pyTensorSpec

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_program_factory.cpp
@@ -1759,10 +1759,10 @@ operation::ProgramWithCallbacks transpose_wh_multi_core_sharded(const Tensor& a,
     uint32_t H = padded_shape[2];
     uint32_t Hs = shard_shape[0], Ws = shard_shape[1];
 
-    uint32_t Hts = Hs / tile.tile_shape[0];
-    uint32_t Wts = Ws / tile.tile_shape[1];
+    uint32_t Hts = Hs / tile.get_height();
+    uint32_t Wts = Ws / tile.get_width();
 
-    uint32_t Ht = H / tile.tile_shape[0];
+    uint32_t Ht = H / tile.get_height();
     uint32_t Ht_per_shard = std::min(Ht, Hts);
 
     uint32_t num_hw_blocks_per_shard = Hts > Ht ? Hts / Ht : 1;
@@ -1840,10 +1840,10 @@ operation::ProgramWithCallbacks transpose_wh_multi_core_sharded(const Tensor& a,
         uint32_t H = padded_shape[2];
         uint32_t Hs = shard_shape[0], Ws = shard_shape[1];
 
-        uint32_t Hts = Hs / tile.tile_shape[0];
-        uint32_t Wts = Ws / tile.tile_shape[1];
+        uint32_t Hts = Hs / tile.get_height();
+        uint32_t Wts = Ws / tile.get_width();
 
-        uint32_t Ht = H / tile.tile_shape[0];
+        uint32_t Ht = H / tile.get_height();
         uint32_t Ht_per_shard = std::min(Ht, Hts);
 
         uint32_t num_hw_blocks_per_shard = Hts > Ht ? Hts / Ht : 1;


### PR DESCRIPTION
### Ticket
Close #31867

### Problem description
Runtime is cleaning up our public facing API.
In `tile.hpp`, implementation details (TILE_FACE_HW_CHOICES) is exported publicly,
and the `Tile` class expose member variables directory despite the presence of getters.

### What's changed
Moved implementation details behind the impl.
Redirect member elements access to use getters, and set members to private.

### Checklist
- [x] [All post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/19242142885) (Data movement test seem to be broken)