### PR TITLE
Metal updates to support active erisc through sim

### DIFF
--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -223,6 +223,22 @@ void MetalContext::teardown() {
     }
     initialized_ = false;
 
+    auto all_devices = cluster_->all_chip_ids();
+    // If simulator is enabled, force a teardown of active ethernet cores for WH
+    if (rtoptions_.get_simulator_enabled()) {
+        if (hal_->get_eth_fw_is_cooperative()) {
+            for (ChipId device_id : all_devices) {
+                for (const auto& logical_core : this->get_control_plane().get_active_ethernet_cores(device_id)) {
+                    CoreCoord virtual_core = cluster_->get_virtual_coordinate_from_logical_coordinates(
+                        device_id, logical_core, CoreType::ETH);
+                    erisc_send_exit_signal(device_id, virtual_core, false);
+                    while (erisc_app_still_running(device_id, virtual_core)) {
+                    }
+                }
+            }
+        }
+    }
+
     // Set internal routing to false to exit active ethernet FW & go back to base FW
     cluster_->set_internal_routing_info_for_ethernet_cores(false);
 
@@ -237,7 +253,6 @@ void MetalContext::teardown() {
         rtoptions_.set_disable_dma_ops(false);
     }
 
-    auto all_devices = cluster_->all_chip_ids();
     watcher_server_->detach_devices();
     watcher_server_.reset();
     for (ChipId device_id : all_devices) {

--- a/tt_metal/impl/device/device_pool.cpp
+++ b/tt_metal/impl/device/device_pool.cpp
@@ -356,7 +356,9 @@ void DevicePool::initialize_fabric_and_dispatch_fw() const {
             tt::LogMetal, "Initializing Fabric and Dispatch Firmware for Galaxy cluster (this may take a few minutes)");
     }
     this->initialize_active_devices();
-    this->wait_for_fabric_router_sync();
+
+    this->wait_for_fabric_router_sync(
+        tt::tt_metal::MetalContext::instance().rtoptions().get_simulator_enabled() ? 15000 : 5000);
     log_trace(tt::LogMetal, "Fabric and Dispatch Firmware initialized");
 }
 


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Updates required to support active erisc through sim
- We do not simulate base FW, so a direct return from metal fw to base fw is not currently supported
- Fabric timeout is too strict when running through simulation, and needs a larger amount of time to finish initializing

### What's changed
- Write the erisc exit signal to allow sim to detect/stop the core. Another note is that due to how sim can be clocked (ex today in UMD it is only clocked on reads), there was an issue where starting the next test might report erisc still running because no clocking of the sim was done between disabling internal routing and the start of the next test. This is because we don't normally wait for eriscs to return to base fw before starting the next test #30373
- Increase fabric sync timeout when running through sim

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [x] New/Existing tests provide coverage for changes