### PR TITLE
Add array registration to GraphArgumentSerializer

### DIFF
--- a/ttnn/api/ttnn/graph/graph_argument_serializer.hpp
+++ b/ttnn/api/ttnn/graph/graph_argument_serializer.hpp
@@ -15,14 +15,14 @@ std::string graph_demangle(std::string_view name);
 
 class GraphArgumentSerializer {
 public:
-    using ConvertionFunction = std::function<std::string(const std::any&)>;
+    using ConversionFunction = std::function<std::string(const std::any&)>;
     std::vector<std::string> to_list(const std::span<std::any>& span);
 
     static GraphArgumentSerializer& instance();
 
 private:
     GraphArgumentSerializer();
-    std::unordered_map<std::type_index, ConvertionFunction>& registry();
+    std::unordered_map<std::type_index, ConversionFunction>& registry();
 
     template <typename T, std::size_t N>
     void register_small_vector();
@@ -38,6 +38,6 @@ private:
 
     void initialize();
 
-    std::unordered_map<std::type_index, GraphArgumentSerializer::ConvertionFunction> map;
+    std::unordered_map<std::type_index, GraphArgumentSerializer::ConversionFunction> map;
 };
 }  // namespace ttnn::graph

--- a/ttnn/api/ttnn/graph/graph_argument_serializer.hpp
+++ b/ttnn/api/ttnn/graph/graph_argument_serializer.hpp
@@ -27,6 +27,9 @@ private:
     template <typename T, std::size_t N>
     void register_small_vector();
 
+    template <typename T, std::size_t N>
+    void register_array();
+
     template <typename T>
     void register_type();
 

--- a/ttnn/core/graph/graph_argument_serializer.cpp
+++ b/ttnn/core/graph/graph_argument_serializer.cpp
@@ -271,11 +271,13 @@ void GraphArgumentSerializer::initialize() {
     // Register SmallVector types for various operations using generic serialize_container
     // Note: std::array<unsigned int, N> is already registered via register_type<uint>() above
     register_reference_wrapper_pair<ttsl::SmallVector<std::array<unsigned int, 2>, 8>>(
-        registry(), serialize_container<unsigned int, 2, 8>);
+        registry(), [](const ttsl::SmallVector<std::array<unsigned int, 2>, 8>& vec) -> std::string {
+            return serialize_container(vec);
+        });
     register_reference_wrapper_pair<ttsl::SmallVector<long, 8>>(
-        registry(), serialize_container<ttsl::SmallVector<long, 8>>);
+        registry(), [](const ttsl::SmallVector<long, 8>& vec) -> std::string { return serialize_container(vec); });
     register_reference_wrapper_pair<ttsl::SmallVector<int, 8>>(
-        registry(), serialize_container<ttsl::SmallVector<int, 8>>);
+        registry(), [](const ttsl::SmallVector<int, 8>& vec) -> std::string { return serialize_container(vec); });
 
     // Register std::variant<std::array<uint, 2>, std::array<uint, 4>> for conv2d stride/dilation
     register_reference_wrapper_pair<std::variant<std::array<unsigned int, 2>, std::array<unsigned int, 4>>>(

--- a/ttnn/core/graph/graph_argument_serializer.cpp
+++ b/ttnn/core/graph/graph_argument_serializer.cpp
@@ -90,6 +90,39 @@ void GraphArgumentSerializer::register_small_vector() {
     };
 }
 
+template <typename T, std::size_t N>
+void GraphArgumentSerializer::register_array() {
+    registry()[typeid(std::reference_wrapper<std::array<T, N>>)] = [](const std::any& value) -> std::string {
+        std::ostringstream oss;
+        auto referenced_value = std::any_cast<std::reference_wrapper<std::array<T, N>>>(value);
+        const auto& arr = referenced_value.get();
+        oss << "[";
+        for (size_t i = 0; i < N; ++i) {
+            if (i > 0) {
+                oss << ", ";
+            }
+            oss << arr[i];
+        }
+        oss << "]";
+        return oss.str();
+    };
+
+    registry()[typeid(std::reference_wrapper<const std::array<T, N>>)] = [](const std::any& value) -> std::string {
+        std::ostringstream oss;
+        auto referenced_value = std::any_cast<std::reference_wrapper<const std::array<T, N>>>(value);
+        const auto& arr = referenced_value.get();
+        oss << "[";
+        for (size_t i = 0; i < N; ++i) {
+            if (i > 0) {
+                oss << ", ";
+            }
+            oss << arr[i];
+        }
+        oss << "]";
+        return oss.str();
+    };
+}
+
 template <typename OptionalT>
 void GraphArgumentSerializer::register_optional_type() {
     registry()[typeid(std::reference_wrapper<OptionalT>)] = [](const std::any& value) -> std::string {
@@ -139,6 +172,11 @@ void GraphArgumentSerializer::register_type() {
     register_small_vector<T, 4>();
     register_small_vector<T, 8>();
     register_small_vector<T, 16>();
+    // std::array
+    register_array<T, 2>();
+    register_array<T, 4>();
+    register_array<T, 8>();
+    register_array<T, 16>();
 }
 
 std::vector<std::string> GraphArgumentSerializer::to_list(const std::span<std::any>& span) {
@@ -199,5 +237,195 @@ void GraphArgumentSerializer::initialize() {
     GraphArgumentSerializer::register_type<std::variant<int, float>>();
     GraphArgumentSerializer::register_type<std::variant<unsigned int, float>>();
     GraphArgumentSerializer::register_type<std::variant<float, unsigned int>>();
+
+    // Register std::array types commonly used for pad operations
+    // We register these directly without going through register_type to avoid recursive template expansion
+    registry()[typeid(std::reference_wrapper<std::array<unsigned int, 2>>)] = [](const std::any& value) -> std::string {
+        std::ostringstream oss;
+        auto referenced_value = std::any_cast<std::reference_wrapper<std::array<unsigned int, 2>>>(value);
+        const auto& arr = referenced_value.get();
+        oss << "[";
+        for (size_t i = 0; i < 2; ++i) {
+            if (i > 0) {
+                oss << ", ";
+            }
+            oss << arr[i];
+        }
+        oss << "]";
+        return oss.str();
+    };
+
+    registry()[typeid(std::reference_wrapper<const std::array<unsigned int, 2>>)] =
+        [](const std::any& value) -> std::string {
+        std::ostringstream oss;
+        auto referenced_value = std::any_cast<std::reference_wrapper<const std::array<unsigned int, 2>>>(value);
+        const auto& arr = referenced_value.get();
+        oss << "[";
+        for (size_t i = 0; i < 2; ++i) {
+            if (i > 0) {
+                oss << ", ";
+            }
+            oss << arr[i];
+        }
+        oss << "]";
+        return oss.str();
+    };
+
+    registry()[typeid(std::reference_wrapper<std::array<unsigned int, 4>>)] = [](const std::any& value) -> std::string {
+        std::ostringstream oss;
+        auto referenced_value = std::any_cast<std::reference_wrapper<std::array<unsigned int, 4>>>(value);
+        const auto& arr = referenced_value.get();
+        oss << "[";
+        for (size_t i = 0; i < 4; ++i) {
+            if (i > 0) {
+                oss << ", ";
+            }
+            oss << arr[i];
+        }
+        oss << "]";
+        return oss.str();
+    };
+
+    registry()[typeid(std::reference_wrapper<const std::array<unsigned int, 4>>)] =
+        [](const std::any& value) -> std::string {
+        std::ostringstream oss;
+        auto referenced_value = std::any_cast<std::reference_wrapper<const std::array<unsigned int, 4>>>(value);
+        const auto& arr = referenced_value.get();
+        oss << "[";
+        for (size_t i = 0; i < 4; ++i) {
+            if (i > 0) {
+                oss << ", ";
+            }
+            oss << arr[i];
+        }
+        oss << "]";
+        return oss.str();
+    };
+
+    // Register SmallVector<std::array<unsigned int, 2>, 8> for pad operations
+    registry()[typeid(std::reference_wrapper<ttsl::SmallVector<std::array<unsigned int, 2>, 8>>)] =
+        [](const std::any& value) -> std::string {
+        std::ostringstream oss;
+        auto referenced_value =
+            std::any_cast<std::reference_wrapper<ttsl::SmallVector<std::array<unsigned int, 2>, 8>>>(value);
+        const auto& vec = referenced_value.get();
+        oss << "[";
+        for (size_t i = 0; i < vec.size(); ++i) {
+            if (i > 0) {
+                oss << ", ";
+            }
+            oss << "[" << vec[i][0] << ", " << vec[i][1] << "]";
+        }
+        oss << "]";
+        return oss.str();
+    };
+
+    registry()[typeid(std::reference_wrapper<const ttsl::SmallVector<std::array<unsigned int, 2>, 8>>)] =
+        [](const std::any& value) -> std::string {
+        std::ostringstream oss;
+        auto referenced_value =
+            std::any_cast<std::reference_wrapper<const ttsl::SmallVector<std::array<unsigned int, 2>, 8>>>(value);
+        const auto& vec = referenced_value.get();
+        oss << "[";
+        for (size_t i = 0; i < vec.size(); ++i) {
+            if (i > 0) {
+                oss << ", ";
+            }
+            oss << "[" << vec[i][0] << ", " << vec[i][1] << "]";
+        }
+        oss << "]";
+        return oss.str();
+    };
+
+    // Register SmallVector<long, 8> for permute operations (dims parameter)
+    registry()[typeid(std::reference_wrapper<ttsl::SmallVector<long, 8>>)] = [](const std::any& value) -> std::string {
+        std::ostringstream oss;
+        auto referenced_value = std::any_cast<std::reference_wrapper<ttsl::SmallVector<long, 8>>>(value);
+        const auto& vec = referenced_value.get();
+        oss << "[";
+        for (size_t i = 0; i < vec.size(); ++i) {
+            if (i > 0) {
+                oss << ", ";
+            }
+            oss << vec[i];
+        }
+        oss << "]";
+        return oss.str();
+    };
+
+    registry()[typeid(std::reference_wrapper<const ttsl::SmallVector<long, 8>>)] =
+        [](const std::any& value) -> std::string {
+        std::ostringstream oss;
+        auto referenced_value = std::any_cast<std::reference_wrapper<const ttsl::SmallVector<long, 8>>>(value);
+        const auto& vec = referenced_value.get();
+        oss << "[";
+        for (size_t i = 0; i < vec.size(); ++i) {
+            if (i > 0) {
+                oss << ", ";
+            }
+            oss << vec[i];
+        }
+        oss << "]";
+        return oss.str();
+    };
+
+    // Register SmallVector<int, 8> for reshape operations (shape parameter)
+    registry()[typeid(std::reference_wrapper<ttsl::SmallVector<int, 8>>)] = [](const std::any& value) -> std::string {
+        std::ostringstream oss;
+        auto referenced_value = std::any_cast<std::reference_wrapper<ttsl::SmallVector<int, 8>>>(value);
+        const auto& vec = referenced_value.get();
+        oss << "[";
+        for (size_t i = 0; i < vec.size(); ++i) {
+            if (i > 0) {
+                oss << ", ";
+            }
+            oss << vec[i];
+        }
+        oss << "]";
+        return oss.str();
+    };
+
+    registry()[typeid(std::reference_wrapper<const ttsl::SmallVector<int, 8>>)] =
+        [](const std::any& value) -> std::string {
+        std::ostringstream oss;
+        auto referenced_value = std::any_cast<std::reference_wrapper<const ttsl::SmallVector<int, 8>>>(value);
+        const auto& vec = referenced_value.get();
+        oss << "[";
+        for (size_t i = 0; i < vec.size(); ++i) {
+            if (i > 0) {
+                oss << ", ";
+            }
+            oss << vec[i];
+        }
+        oss << "]";
+        return oss.str();
+    };
+
+    // Register std::variant<std::array<uint, 2>, std::array<uint, 4>> for conv2d stride/dilation
+    registry()[typeid(std::reference_wrapper<std::variant<std::array<unsigned int, 2>, std::array<unsigned int, 4>>>)] =
+        [](const std::any& value) -> std::string {
+        std::ostringstream oss;
+        auto referenced_value = std::any_cast<
+            std::reference_wrapper<std::variant<std::array<unsigned int, 2>, std::array<unsigned int, 4>>>>(value);
+        const auto& var = referenced_value.get();
+
+        if (std::holds_alternative<std::array<unsigned int, 2>>(var)) {
+            const auto& arr = std::get<std::array<unsigned int, 2>>(var);
+            oss << "[" << arr[0] << ", " << arr[1] << "]";
+        } else {
+            const auto& arr = std::get<std::array<unsigned int, 4>>(var);
+            oss << "[" << arr[0] << ", " << arr[1] << ", " << arr[2] << ", " << arr[3] << "]";
+        }
+        return oss.str();
+    };
+
+    // Register std::nullopt_t for optional parameters
+    registry()[typeid(std::reference_wrapper<std::nullopt_t>)] = [](const std::any&) -> std::string {
+        return "nullopt";
+    };
+
+    registry()[typeid(std::reference_wrapper<const std::nullopt_t>)] = [](const std::any&) -> std::string {
+        return "nullopt";
+    };
 }
 }  // namespace ttnn::graph


### PR DESCRIPTION
### Ticket
NA

### Problem description
graph tracing is not working properly

### What's changed
- Introduced `register_array` method to handle serialization of `std::array` types.
- Registered common `std::array` types directly in the `initialize` method for better handling in pad operations.
- Enhanced the serialization logic for both mutable and immutable references of `std::array`.

**Before fix:**
```
"arguments": [
      "Tensor(storage=HostStorage(),tensor_spec=TensorSpec(logical_shape=Shape([32, 3, 3, 3]),tensor_layout=TensorLayout(dtype=DataType::FLOAT32,page_config=PageConfig(config=RowMajorPageConfig(tile=Tile(tile_shape={32, 32},face_shape={16, 16},num_faces=4))),memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0),alignment=Alignment([1]))))",
      "[ unsupported type , std::reference_wrapper<std::array<unsigned int, 4ul> >]",
      "[ unsupported type , std::reference_wrapper<std::array<unsigned int, 4ul> >]",
      "0"
    ],
```

**After fix:**
```
"arguments": [
      "Tensor(storage=HostStorage(),tensor_spec=TensorSpec(logical_shape=Shape([32, 3, 3, 3]),tensor_layout=TensorLayout(dtype=DataType::FLOAT32,page_config=PageConfig(config=RowMajorPageConfig(tile=Tile(tile_shape={32, 32},face_shape={16, 16},num_faces=4))),memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0),alignment=Alignment([1]))))",
      "[32, 16, 3, 3]",
      "[0, 0, 0, 0]",
      "0"
    ],
```

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes