### PR TITLE
Reenable Galaxy model perf CNN tests

### DIFF
--- a/.github/workflows/galaxy-model-perf-tests-impl.yaml
+++ b/.github/workflows/galaxy-model-perf-tests-impl.yaml
@@ -37,15 +37,6 @@ jobs:
           # Create matrix in two parts: disabled and active models
           DISABLED_MODELS=$(jq -n '[
             {
-              "name": "Galaxy CNN model perf tests",
-              "model-type": "CNN",
-              "model-name": "cnn",
-              "arch": "wormhole_b0",
-              "save-perf-data": false,
-              "timeout": 60,
-              "cmd": "TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE=\"7,7\" ./tests/scripts/run_tests.sh --tt-arch wormhole_b0 --pipeline-type cnn_model_perf_tg_device --dispatch-mode \"\""
-            },
-            {
               "name": "Galaxy Llama 70B model perf tests",
               "model-type": "Llama-70B",
               "model-name": "llama70b",
@@ -98,6 +89,15 @@ jobs:
           ]' --compact-output)
 
           ACTIVE_MODELS=$(jq -n '[
+            {
+              "name": "Galaxy CNN model perf tests",
+              "model-type": "CNN",
+              "model-name": "cnn",
+              "arch": "wormhole_b0",
+              "save-perf-data": false,
+              "timeout": 60,
+              "cmd": "TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE=\"7,7\" ./tests/scripts/run_tests.sh --tt-arch wormhole_b0 --pipeline-type cnn_model_perf_tg_device --dispatch-mode \"\""
+            },
             {
               "name": "Galaxy DiT SD3.5 model perf tests",
               "model-type": "SD3.5",

--- a/.github/workflows/galaxy-model-perf-tests.yaml
+++ b/.github/workflows/galaxy-model-perf-tests.yaml
@@ -10,10 +10,10 @@ on:
         type: choice
         options:
           - all
-#          - cnn
 #          - llama70b
 #          - llama_unit_tests
 #          - llama70b_prefill
+          - cnn
           - sd35
           - flux1-dev
           - sentence_bert


### PR DESCRIPTION
### Problem description
Galaxy model perf CNN tests were disabled in https://github.com/tenstorrent/tt-metal/pull/31818

### What's changed
Reenabled Galaxy model perf CNN tests

### Checklist
- [X] [(Galaxy) model perf tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/19129265697)