### PR TITLE
Add support for zones in noc traces + adjust timestamps based on device sync info

### DIFF
--- a/tt_metal/impl/profiler/profiler.hpp
+++ b/tt_metal/impl/profiler/profiler.hpp
@@ -108,13 +108,6 @@ private:
     // Storage for all core's L1 data buffers
     std::unordered_map<CoreCoord, std::vector<uint32_t>> core_l1_data_buffers;
 
-    // Storage for all noc trace data
-    std::vector<std::unordered_map<RuntimeID, nlohmann::json::array_t>> noc_trace_data;
-
-    // Storage for all noc trace markers that have been converted to json to ensure that the same marker isn't processed
-    // twice
-    std::unordered_set<tracy::TTDeviceMarker> noc_trace_markers_processed;
-
     // Output directory for noc trace data
     std::filesystem::path noc_trace_data_output_dir;
 

--- a/tt_metal/tools/profiler/event_metadata.hpp
+++ b/tt_metal/tools/profiler/event_metadata.hpp
@@ -141,6 +141,10 @@ struct alignas(uint64_t) KernelProfilerNocEventMetadata {
         std::memcpy(this, &raw_data, sizeof(KernelProfilerNocEventMetadata));
     }
 
+    static bool isValidEventType(NocEventType event_type) {
+        return event_type >= NocEventType::READ && event_type <= NocEventType::FABRIC_ROUTING_FIELDS_2D;
+    }
+
     static bool isFabricEventType(NocEventType event_type) {
         return event_type >= NocEventType::FABRIC_UNICAST_WRITE &&
                event_type <= NocEventType::FABRIC_UNICAST_SCATTER_WRITE;

--- a/tt_metal/tools/profiler/noc_event_profiler_utils.hpp
+++ b/tt_metal/tools/profiler/noc_event_profiler_utils.hpp
@@ -31,10 +31,7 @@ public:
     // both of these are keyed by physical chip id!
     using EthCoreToChannelMap = std::map<std::tuple<ChipId, CoreCoord>, tt::tt_fabric::chan_id_t>;
 
-    // Default constructor for cases where lookup is not built (e.g., non-1D fabric)
-    FabricRoutingLookup() = default;
-
-    FabricRoutingLookup(const IDevice* device) {
+    FabricRoutingLookup() {
         using namespace tt::tt_fabric;
 
         Cluster& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
@@ -45,11 +42,6 @@ public:
         std::sort(physical_chip_ids.begin(), physical_chip_ids.end());
 
         for (ChipId chip_id_src : physical_chip_ids) {
-            if (device->is_mmio_capable() && (cluster.get_cluster_type() == tt::tt_metal::ClusterType::TG)) {
-                // skip lauching on gateways for TG
-                continue;
-            }
-
             // NOTE: soc desc is for chip_id_src, not device->id()
             const auto& soc_desc = cluster.get_soc_desc(chip_id_src);
             // Build a mapping of (eth_core --> eth_chan)


### PR DESCRIPTION
### Ticket
Link to Github Issue: https://github.com/tenstorrent/tt-npe/issues/92

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes