### PR TITLE
#32110: Bump cpp-post-commit timeout to 40 min

### DIFF
--- a/.github/workflows/cpp-post-commit.yaml
+++ b/.github/workflows/cpp-post-commit.yaml
@@ -12,7 +12,7 @@ on:
       timeout:
         required: false
         type: number
-        default: 35
+        default: 40
       docker-image:
         required: true
         type: string


### PR DESCRIPTION
### Ticket
#32110

### Problem description
See attached issue