### PR TITLE
[DM]: Porting DM tests to Device 2.0 APIs first pass

### DIFF
--- a/tests/tt_metal/tt_metal/data_movement/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/README.md
@@ -14,13 +14,26 @@ Some test suites use slow dispatch mode for reliable program execution. These te
 - **Conv Hardcoded** (IDs 21-23)
 - **Reshard Hardcoded** (IDs 17-20)
 
+## Device 2.0 API Support
+This test suite now includes tests using the new device 2.0 experimental NOC API alongside the original implementations. These tests provide validation and performance comparison for the updated API design:
+
+### Key Features of Device 2.0 API Tests:
+- **Experimental NOC API**: Uses `experimental::Noc`, `experimental::UnicastEndpoint`, and `experimental::noc_traits_t` for structured NOC operations
+- **Structured Arguments**: Source and destination arguments are defined using structured `noc_traits_t` types
+
+### Device 2.0 Test Suites:
+- **One to One** (ID: 158): Device 2.0 version of packet sizes tests using experimental write API
+- **One From One** (ID: 159): Device 2.0 version of packet sizes tests using experimental read API
+
+Both API versions run the same test cases but use different underlying implementations. The device 2.0 tests serve as validation and performance comparison for the new experimental API.
+
 ## Tests in the Test Suite
 
 | Name                        | ID(s)                | Description                                                                             |
 | ----------                  | -----                | ----------------------------------------------------                                    |
 | DRAM Unary                  | 0-3                  | Transactions between DRAM and a single Tensix core.                                     |
-| One to One                  | 4, 50, 150-151       | Write transactions between two Tensix cores.                                            |
-| One From One                | 5, 51, 152-153       | Read transactions between two Tensix cores.                                             |
+| One to One                  | 4, 50, 150-151, 158  | Write transactions between two Tensix cores.                                            |
+| One From One                | 5, 51, 152-153, 159  | Read transactions between two Tensix cores.                                             |
 | One to all                  | 6-8, 52, 154-155     | Writes transaction from one core to all cores.                                          |
 | One to all Multicast        | 9-14, 53-54, 100-102 | Writes transaction from one core to all cores using multicast.                          |
 | One From All                | 15, 30, 156-157      | Read transactions between one gatherer Tensix core and multiple sender Tensix cores.    |

--- a/tests/tt_metal/tt_metal/data_movement/one_from_one/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/one_from_one/README.md
@@ -37,6 +37,25 @@ The tests use the Mesh Device API with fast dispatch mode:
 Each test case uses bfloat16 as L1 data format and flit size (32B for WH, 64B for BH) as page size.
 Each test case has multiple runs, and each run has a unique runtime host id, assigned by a global counter.
 
-1. **One From One Packet Sizes**: Tests different number of transactions and transaction sizes by varying the num_of_transactions and transaction_size_pages parameters. The subordinate core sends data to the master core using various packet configurations.
+1. **TensixDataMovementOneFromOnePacketSizes** (Test ID: 5) - Tests different number of transactions and transaction sizes by varying the num_of_transactions and transaction_size_pages parameters. The master core reads data from the subordinate core using various packet configurations.
 
-2. **One From One Directed Ideal**: Tests the most optimal data movement setup from one subordinate core to one master core that maximizes the transaction size and performs enough transactions to amortize initialization overhead. This test uses neighboring cores to minimize latency.
+2. **TensixDataMovementOneFromOneDirectedIdeal** (Test ID: 51) - Tests the most optimal data movement setup from one subordinate core to one master core that maximizes the transaction size and performs enough transactions to amortize initialization overhead. Uses neighboring cores (0,0) ← (0,1) to minimize latency.
+
+3. **TensixDataMovementOneFromOneVirtualChannels** (Test ID: 152) - *[Currently Skipped]* Tests virtual channel functionality by cycling through multiple NOCs (NOC_0, NOC_1), transaction sizes, and virtual channels (1-4). Validates that different virtual channels can be used effectively for read operations.
+
+4. **TensixDataMovementOneFromOneCustom** (Test ID: 153) - *[Currently Skipped]* Custom test case with configurable parameters for specialized testing scenarios. Uses 256 transactions, 1 page per transaction, and 4 virtual channels for read operations.
+
+5. **TensixDataMovementOneFromOnePacketSizes2_0** (Test ID: 159) - Device 2.0 API version of the packet sizes test. Tests the same packet size variations as test ID 5 but uses the experimental NOC API with structured endpoints and virtual channel support for async read operations.
+
+## Device 2.0 API Tests
+This test suite now includes tests using the new device 2.0 experimental NOC API. These tests provide the same functionality as the original tests but use an updated API design:
+
+### Key Features of Device 2.0 API Tests:
+- **Experimental NOC API**: Uses `experimental::Noc`, `experimental::UnicastEndpoint`, and `experimental::noc_traits_t` for structured NOC operations
+- **Structured Arguments**: Source and destination arguments are defined using structured `noc_traits_t` types
+
+### Device 2.0 Kernels:
+- `requestor_2_0.cpp`: Implements the requestor (master/receiver) functionality using the experimental NOC API with async read operations
+- `requestor.cpp`: Original requestor kernel for comparison
+
+Both API versions run the same test cases but use different underlying implementations. The device 2.0 tests serve as a validation and performance comparison for the new experimental API.

--- a/tests/tt_metal/tt_metal/data_movement/one_from_one/kernels/requestor_2_0.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_from_one/kernels/requestor_2_0.cpp
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dataflow_api.h"
+#include "debug/dprint.h"
+
+// L1 to L1 request
+void kernel_main() {
+    constexpr uint32_t l1_local_addr = get_compile_time_arg_val(0);
+    constexpr uint32_t num_of_transactions = get_compile_time_arg_val(1);
+    constexpr uint32_t transaction_size_bytes = get_compile_time_arg_val(2);
+    constexpr uint32_t test_id = get_compile_time_arg_val(3);
+    constexpr uint32_t num_virtual_channels = get_compile_time_arg_val(4);
+
+    uint32_t responder_x_coord = get_arg_val<uint32_t>(0);
+    uint32_t responder_y_coord = get_arg_val<uint32_t>(1);
+
+    experimental::Noc noc(noc_index);
+    experimental::UnicastEndpoint unicast_endpoint;
+    experimental::noc_traits_t<experimental::UnicastEndpoint>::src_args_type src_args = {
+        .noc_x = responder_x_coord,
+        .noc_y = responder_y_coord,
+        .addr = l1_local_addr,
+    };
+    experimental::noc_traits_t<experimental::UnicastEndpoint>::dst_args_type dst_args = {
+        .noc_x = my_x[noc.get_noc_id()],
+        .noc_y = my_y[noc.get_noc_id()],
+        .addr = l1_local_addr,
+    };
+
+    {
+        DeviceZoneScopedN("RISCV1");
+        for (uint32_t i = 0; i < num_of_transactions; i++) {
+            // Cycle through virtual channels 0 to (num_virtual_channels - 1)
+            uint32_t current_virtual_channel = i % num_virtual_channels;
+            noc.async_read(
+                unicast_endpoint,
+                unicast_endpoint,
+                transaction_size_bytes,
+                src_args,
+                dst_args,
+                current_virtual_channel);
+        }
+        noc.async_read_barrier();
+    }
+
+    DeviceTimestampedData("Test id", test_id);
+
+    DeviceTimestampedData("Number of transactions", num_of_transactions);
+    DeviceTimestampedData("Transaction size in bytes", transaction_size_bytes);
+
+    DeviceTimestampedData("NoC Index", noc.get_noc_id());
+    DeviceTimestampedData("Number of Virtual Channels", num_virtual_channels);
+}

--- a/tests/tt_metal/tt_metal/data_movement/one_from_one/kernels/requestor_2_0.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_from_one/kernels/requestor_2_0.cpp
@@ -18,16 +18,6 @@ void kernel_main() {
 
     experimental::Noc noc(noc_index);
     experimental::UnicastEndpoint unicast_endpoint;
-    experimental::noc_traits_t<experimental::UnicastEndpoint>::src_args_type src_args = {
-        .noc_x = responder_x_coord,
-        .noc_y = responder_y_coord,
-        .addr = l1_local_addr,
-    };
-    experimental::noc_traits_t<experimental::UnicastEndpoint>::dst_args_type dst_args = {
-        .noc_x = my_x[noc.get_noc_id()],
-        .noc_y = my_y[noc.get_noc_id()],
-        .addr = l1_local_addr,
-    };
 
     {
         DeviceZoneScopedN("RISCV1");
@@ -38,8 +28,14 @@ void kernel_main() {
                 unicast_endpoint,
                 unicast_endpoint,
                 transaction_size_bytes,
-                src_args,
-                dst_args,
+                {
+                    .noc_x = responder_x_coord,
+                    .noc_y = responder_y_coord,
+                    .addr = l1_local_addr,
+                },
+                {
+                    .addr = l1_local_addr,
+                },
                 current_virtual_channel);
         }
         noc.async_read_barrier();

--- a/tests/tt_metal/tt_metal/data_movement/one_to_one/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/one_to_one/README.md
@@ -38,5 +38,25 @@ The tests use the Mesh Device API with fast dispatch mode:
 Each test case uses bfloat16 as L1 data format and flit size (32B for WH, 64B for BH) as page size.
 Each test case has multiple runs, and each run has a unique runtime host id, assigned by a global counter.
 
-1. One to One Packet Sizes: Tests different number of transactions and transaction sizes by varying the num_of_transactions and transaction_size_pages parameters.
-2. One to One Directed Ideal: Tests the most optimal data movement setup between two cores that maximizes the transaction size and performs enough transactions to amortize initialization overhead. This test is performed between neigbouring cores on a torus to minimize latency.
+1. **TensixDataMovementOneToOnePacketSizes** (Test ID: 4) - Tests different number of transactions and transaction sizes by varying the num_of_transactions and pages_per_transaction parameters. Sweeps through multiple combinations to test various packet configurations.
+
+2. **TensixDataMovementOneToOneDirectedIdeal** (Test ID: 50) - Tests the most optimal data movement setup between two cores that maximizes the transaction size and performs enough transactions to amortize initialization overhead. Uses neighboring cores (0,0) → (0,1) to minimize latency.
+
+3. **TensixDataMovementOneToOneVirtualChannels** (Test ID: 150) - *[Currently Skipped]* Tests virtual channel functionality by cycling through multiple NOCs (NOC_0, NOC_1), transaction sizes, and virtual channels (1-4). Validates that different virtual channels can be used effectively for data movement.
+
+4. **TensixDataMovementOneToOneCustom** (Test ID: 151) - *[Currently Skipped]* Custom test case with configurable parameters for specialized testing scenarios. Uses 256 transactions, 1 page per transaction, and 4 virtual channels.
+
+5. **TensixDataMovementOneToOnePacketSizes2_0** (Test ID: 158) - Device 2.0 API version of the packet sizes test. Tests the same packet size variations as test ID 4 but uses the experimental NOC API with structured endpoints and virtual channel support.
+
+## Device 2.0 API Tests
+This test suite now includes tests using the new device 2.0 experimental NOC API. These tests provide the same functionality as the original tests but use an updated API design:
+
+### Key Features of Device 2.0 API Tests:
+- **Experimental NOC API**: Uses `experimental::Noc`, `experimental::UnicastEndpoint`, and `experimental::noc_traits_t` for structured NOC operations
+- **Structured Arguments**: Source and destination arguments are defined using structured `noc_traits_t` types
+
+### Device 2.0 Kernels:
+- `sender_2_0.cpp`: Implements the sender functionality using the experimental NOC API
+- `sender.cpp`: Original sender kernel for comparison
+
+Both API versions run the same test cases but use different underlying implementations. The device 2.0 tests serve as a validation and performance comparison for the new experimental API.

--- a/tests/tt_metal/tt_metal/data_movement/one_to_one/kernels/sender_2_0.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_to_one/kernels/sender_2_0.cpp
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dataflow_api.h"
+#include "debug/dprint.h"
+
+// L1 to L1 send
+void kernel_main() {
+    // Compile-time arguments
+    constexpr uint32_t l1_local_addr = get_compile_time_arg_val(0);
+    constexpr uint32_t num_of_transactions = get_compile_time_arg_val(1);
+    constexpr uint32_t bytes_per_transaction = get_compile_time_arg_val(2);
+    constexpr uint32_t test_id = get_compile_time_arg_val(3);
+    constexpr uint32_t packed_subordinate_core_coordinates = get_compile_time_arg_val(4);
+    constexpr uint32_t num_virtual_channels = get_compile_time_arg_val(5);
+
+    // Runtime arguments
+    uint32_t receiver_x_coord = packed_subordinate_core_coordinates >> 16;
+    uint32_t receiver_y_coord = packed_subordinate_core_coordinates & 0xFFFF;
+
+    experimental::Noc noc(noc_index);
+    experimental::UnicastEndpoint unicast_endpoint;
+    experimental::noc_traits_t<experimental::UnicastEndpoint>::src_args_type src_args = {
+        .noc_x = my_x[noc.get_noc_id()],
+        .noc_y = my_y[noc.get_noc_id()],
+        .addr = l1_local_addr,
+    };
+    experimental::noc_traits_t<experimental::UnicastEndpoint>::dst_args_type dst_args = {
+        .noc_x = receiver_x_coord,
+        .noc_y = receiver_y_coord,
+        .addr = l1_local_addr,
+    };
+
+    {
+        DeviceZoneScopedN("RISCV0");
+        for (uint32_t i = 0; i < num_of_transactions; i++) {
+            // Cycle through virtual channels 0 to (num_virtual_channels - 1)
+            uint32_t current_virtual_channel = i % num_virtual_channels;
+            noc.async_write(
+                unicast_endpoint, unicast_endpoint, bytes_per_transaction, src_args, dst_args, current_virtual_channel);
+        }
+        noc.async_write_barrier();
+    }
+
+    DeviceTimestampedData("Test id", test_id);
+
+    DeviceTimestampedData("NoC Index", noc.get_noc_id());
+
+    DeviceTimestampedData("Number of transactions", num_of_transactions);
+    DeviceTimestampedData("Transaction size in bytes", bytes_per_transaction);
+
+    DeviceTimestampedData("Number of Virtual Channels", num_virtual_channels);
+}

--- a/tests/tt_metal/tt_metal/data_movement/one_to_one/test_one_to_one.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_to_one/test_one_to_one.cpp
@@ -29,9 +29,7 @@ struct OneToOneConfig {
     DataFormat l1_data_format = DataFormat::Invalid;
     uint32_t num_virtual_channels = 1;  // Number of virtual channels to cycle through (must be > 1 for cycling)
     NOC noc_id = NOC::NOC_0;
-
-    // TODO: Add the following parameters
-    //  1. Posted flag
+    bool use_2_0_api = false;  // Use Device 2.0 API
 };
 
 /// @brief Does L1 Sender Core --> L1 Receiver Core
@@ -98,8 +96,11 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const OneToO
 
     // Kernels
     std::string kernels_dir = "tests/tt_metal/tt_metal/data_movement/one_to_one/kernels/";
-    std::string sender_kernel_filename = "sender.cpp";
-    std::string sender_kernel_path = kernels_dir + sender_kernel_filename;
+    std::string sender_kernel_filename = "sender";
+    if (test_config.use_2_0_api) {
+        sender_kernel_filename += "_2_0";
+    }
+    std::string sender_kernel_path = kernels_dir + sender_kernel_filename + ".cpp";
 
     CreateKernel(
         program,
@@ -243,7 +244,8 @@ void packet_sizes_test(
     const shared_ptr<distributed::MeshDevice>& mesh_device,
     uint32_t test_id,
     CoreCoord master_core_coord = {0, 0},
-    CoreCoord subordinate_core_coord = {1, 1}) {
+    CoreCoord subordinate_core_coord = {1, 1},
+    bool use_2_0_api = false) {
     IDevice* device = mesh_device->get_device(0);
     // Physical Constraints
     auto [bytes_per_page, max_transmittable_bytes, max_transmittable_pages] =
@@ -271,6 +273,7 @@ void packet_sizes_test(
                 .pages_per_transaction = pages_per_transaction,
                 .bytes_per_page = bytes_per_page,
                 .l1_data_format = DataFormat::Float16_b,
+                .use_2_0_api = use_2_0_api,
             };
 
             // Run
@@ -368,4 +371,10 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToOneCustom) {
         num_virtual_channels);
 }
 
+TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToOnePacketSizes2_0) {
+    // Test ID
+    uint32_t test_id = 158;
+
+    unit_tests::dm::core_to_core::packet_sizes_test(get_mesh_device(), test_id, CoreCoord(0, 0), CoreCoord(1, 1), true);
+}
 }  // namespace tt::tt_metal

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -2910,15 +2910,25 @@ struct noc_traits_t<UnicastEndpoint> {
     };
     template <Noc::AddressType address_type>
     static auto src_addr(const UnicastEndpoint& src, const Noc& noc, const src_args_type& args) {
-        static_assert(address_type == Noc::AddressType::NOC);
-        uint64_t noc_addr = src.get_noc_unicast_addr(args.noc_x, args.noc_y, args.addr, noc.get_noc_id());
-        return noc_addr;
+        if constexpr (address_type == Noc::AddressType::LOCAL_L1) {
+            uint64_t noc_addr = src.get_noc_unicast_addr(args.noc_x, args.noc_y, args.addr, noc.get_noc_id());
+            ASSERT(noc.is_local_addr(noc_addr));
+            return static_cast<uint32_t>(noc_addr);
+        } else {
+            uint64_t noc_addr = src.get_noc_unicast_addr(args.noc_x, args.noc_y, args.addr, noc.get_noc_id());
+            return noc_addr;
+        }
     }
     template <Noc::AddressType address_type>
     static auto dst_addr(const UnicastEndpoint& dst, const Noc& noc, const dst_args_type& args) {
-        static_assert(address_type == Noc::AddressType::NOC);
-        uint64_t noc_addr = dst.get_noc_unicast_addr(args.noc_x, args.noc_y, args.addr, noc.get_noc_id());
-        return noc_addr;
+        if constexpr (address_type == Noc::AddressType::LOCAL_L1) {
+            uint64_t noc_addr = dst.get_noc_unicast_addr(args.noc_x, args.noc_y, args.addr, noc.get_noc_id());
+            ASSERT(noc.is_local_addr(noc_addr));
+            return static_cast<uint32_t>(noc_addr);
+        } else {
+            uint64_t noc_addr = dst.get_noc_unicast_addr(args.noc_x, args.noc_y, args.addr, noc.get_noc_id());
+            return noc_addr;
+        }
     }
 };
 

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -2911,10 +2911,7 @@ struct noc_traits_t<UnicastEndpoint> {
     template <Noc::AddressType address_type>
     static auto src_addr(const UnicastEndpoint& src, const Noc& noc, const src_args_type& args) {
         if constexpr (address_type == Noc::AddressType::LOCAL_L1) {
-            uint64_t noc_addr =
-                src.get_noc_unicast_addr(my_x[noc.get_noc_id()], my_y[noc.get_noc_id()], args.addr, noc.get_noc_id());
-            ASSERT(noc.is_local_addr(noc_addr));
-            return static_cast<uint32_t>(noc_addr);
+            return args.addr;
         } else {
             uint64_t noc_addr = src.get_noc_unicast_addr(args.noc_x, args.noc_y, args.addr, noc.get_noc_id());
             return noc_addr;
@@ -2923,10 +2920,7 @@ struct noc_traits_t<UnicastEndpoint> {
     template <Noc::AddressType address_type>
     static auto dst_addr(const UnicastEndpoint& dst, const Noc& noc, const dst_args_type& args) {
         if constexpr (address_type == Noc::AddressType::LOCAL_L1) {
-            uint64_t noc_addr =
-                dst.get_noc_unicast_addr(my_x[noc.get_noc_id()], my_y[noc.get_noc_id()], args.addr, noc.get_noc_id());
-            ASSERT(noc.is_local_addr(noc_addr));
-            return static_cast<uint32_t>(noc_addr);
+            return args.addr;
         } else {
             uint64_t noc_addr = dst.get_noc_unicast_addr(args.noc_x, args.noc_y, args.addr, noc.get_noc_id());
             return noc_addr;

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -2911,7 +2911,8 @@ struct noc_traits_t<UnicastEndpoint> {
     template <Noc::AddressType address_type>
     static auto src_addr(const UnicastEndpoint& src, const Noc& noc, const src_args_type& args) {
         if constexpr (address_type == Noc::AddressType::LOCAL_L1) {
-            uint64_t noc_addr = src.get_noc_unicast_addr(args.noc_x, args.noc_y, args.addr, noc.get_noc_id());
+            uint64_t noc_addr =
+                src.get_noc_unicast_addr(my_x[noc.get_noc_id()], my_y[noc.get_noc_id()], args.addr, noc.get_noc_id());
             ASSERT(noc.is_local_addr(noc_addr));
             return static_cast<uint32_t>(noc_addr);
         } else {
@@ -2922,7 +2923,8 @@ struct noc_traits_t<UnicastEndpoint> {
     template <Noc::AddressType address_type>
     static auto dst_addr(const UnicastEndpoint& dst, const Noc& noc, const dst_args_type& args) {
         if constexpr (address_type == Noc::AddressType::LOCAL_L1) {
-            uint64_t noc_addr = dst.get_noc_unicast_addr(args.noc_x, args.noc_y, args.addr, noc.get_noc_id());
+            uint64_t noc_addr =
+                dst.get_noc_unicast_addr(my_x[noc.get_noc_id()], my_y[noc.get_noc_id()], args.addr, noc.get_noc_id());
             ASSERT(noc.is_local_addr(noc_addr));
             return static_cast<uint32_t>(noc_addr);
         } else {


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/31236)

### Problem description
There are new Databuffer APIs for Metal 2.0 here: https://github.com/tenstorrent/tt-metal/blob/main/tt_metal/hw/inc/dataflow_api.h#L2360

We need to start porting DM tests to using these APIs before the APIs are ready for more wide scale usage. 

### What's changed
List of tests this PR ports to new APIs:
- One-to-One (covers the noc_write)
- One-from-One (covers the noc_read)

When writing these tests, the need for extracting local l1 addresses from the `UnicastEndpoint` arose. I've taken the liberty to add support for this in the APIs. @abhullar-tt @ruizhangTT let me know if there are any issues with this

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/19313301402) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/19313304218) CI tests passes