### PR TITLE
Append mesh shape in weights cache path

### DIFF
--- a/models/demos/deepseek_v3/utils/config_helpers.py
+++ b/models/demos/deepseek_v3/utils/config_helpers.py
@@ -838,7 +838,11 @@ def get_weight_config(
     mesh_device: ttnn.Device,
     force_recalculate: bool,
 ):
-    weight_cache_path = weight_cache_path / f"{hf_config.num_hidden_layers}_layers"
+    weight_cache_path = (
+        weight_cache_path
+        / f"{hf_config.num_hidden_layers}_layers"
+        / str("mesh_" + str(mesh_device.shape[0]) + "x" + str(mesh_device.shape[1]))
+    )
     config_path = weight_cache_path / "config.json"
     weight_path = weight_cache_path / "weights"
     for _ in range(1):

--- a/models/demos/deepseek_v3/utils/config_helpers.py
+++ b/models/demos/deepseek_v3/utils/config_helpers.py
@@ -841,7 +841,7 @@ def get_weight_config(
     weight_cache_path = (
         weight_cache_path
         / f"{hf_config.num_hidden_layers}_layers"
-        / str("mesh_" + str(mesh_device.shape[0]) + "x" + str(mesh_device.shape[1]))
+        / f"mesh_{mesh_device.shape[0]}x{mesh_device.shape[1]}"
     )
     config_path = weight_cache_path / "config.json"
     weight_path = weight_cache_path / "weights"


### PR DESCRIPTION

### Problem description
Weights sharding are related to mesh shape as well.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes