### PR TITLE
Moving DataCollector singleton to MetalContext

### DIFF
--- a/tt_metal/impl/CMakeLists.txt
+++ b/tt_metal/impl/CMakeLists.txt
@@ -52,6 +52,7 @@ set(IMPL_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/dispatch/launch_message_ring_buffer_state.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dispatch/worker_config_buffer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dispatch/data_collection.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/dispatch/data_collector.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dispatch/ringbuffer_cache.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dispatch/topology.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dispatch/kernel_config/fd_kernel.cpp

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -135,6 +135,8 @@ void MetalContext::initialize(
         profiler_state_manager_ = std::make_unique<ProfilerStateManager>();
     }
 
+    data_collector_ = std::make_unique<DataCollector>();
+
     // Minimal setup, don't initialize FW/Dispatch/etc.
     if (minimal) {
         return;
@@ -287,7 +289,6 @@ MetalContext::MetalContext() {
     rtoptions_.ParseAllFeatureEnv(*hal_);
     cluster_ = std::make_unique<Cluster>(rtoptions_, *hal_);
     distributed_context_ = distributed::multihost::DistributedContext::get_current_world();
-    data_collector_ = std::make_unique<DataCollector>();
 
     // We do need to call Cluster teardown at the end of the program, use atexit temporarily until we have clarity on
     // how MetalContext lifetime will work through the API.

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -32,6 +32,7 @@
 #include <tt-metalium/hal.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include <umd/device/types/cluster_descriptor_types.hpp>
+#include "tt_metal/impl/dispatch/data_collector.hpp"
 
 namespace tt::tt_metal {
 
@@ -225,6 +226,7 @@ void MetalContext::teardown() {
 
     // Set internal routing to false to exit active ethernet FW & go back to base FW
     cluster_->set_internal_routing_info_for_ethernet_cores(false);
+    data_collector_->DumpData();
 
     if (dprint_server_) {
         dprint_server_->detach_devices();
@@ -250,6 +252,9 @@ void MetalContext::teardown() {
             mem_map.reset();
         }
     }
+
+    data_collector_.reset();
+
     dispatch_query_manager_.reset();
     dispatch_core_manager_.reset();
     tt::tt_metal::reset_topology_state();
@@ -280,6 +285,7 @@ MetalContext::MetalContext() {
     rtoptions_.ParseAllFeatureEnv(*hal_);
     cluster_ = std::make_unique<Cluster>(rtoptions_, *hal_);
     distributed_context_ = distributed::multihost::DistributedContext::get_current_world();
+    data_collector_ = std::make_unique<DataCollector>();
 
     // We do need to call Cluster teardown at the end of the program, use atexit temporarily until we have clarity on
     // how MetalContext lifetime will work through the API.

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -226,7 +226,11 @@ void MetalContext::teardown() {
 
     // Set internal routing to false to exit active ethernet FW & go back to base FW
     cluster_->set_internal_routing_info_for_ethernet_cores(false);
-    data_collector_->DumpData();
+
+    if (data_collector_) {
+        data_collector_->DumpData();
+        data_collector_.reset();
+    }
 
     if (dprint_server_) {
         dprint_server_->detach_devices();
@@ -252,8 +256,6 @@ void MetalContext::teardown() {
             mem_map.reset();
         }
     }
-
-    data_collector_.reset();
 
     dispatch_query_manager_.reset();
     dispatch_core_manager_.reset();

--- a/tt_metal/impl/context/metal_context.hpp
+++ b/tt_metal/impl/context/metal_context.hpp
@@ -36,6 +36,7 @@ namespace inspector {
 class Data;
 }
 
+class DataCollector;
 // A class to manage one-time initialization and teardown (FW, dispatch, fabric, cluster) and access to related state.
 // Dispatch-independent state (Cluster) is initialized with the creation of MetalContext and accessible right after.
 // Dispatch-dependent state (FW, dispatch, fabric) is initialized explicitly with a MetalContext::initialize() call, and
@@ -64,6 +65,7 @@ public:
     std::unique_ptr<WatcherServer>& watcher_server() { return watcher_server_; }
 
     std::unique_ptr<ProfilerStateManager>& profiler_state_manager() { return profiler_state_manager_; }
+    std::unique_ptr<DataCollector>& data_collector() { return data_collector_; }
 
     void initialize(
         const DispatchCoreConfig& dispatch_core_config,
@@ -176,6 +178,8 @@ private:
     std::unique_ptr<DPrintServer> dprint_server_;
     std::unique_ptr<WatcherServer> watcher_server_;
     std::unique_ptr<ProfilerStateManager> profiler_state_manager_;
+    std::unique_ptr<DataCollector> data_collector_;
+
     std::array<std::unique_ptr<DispatchMemMap>, static_cast<size_t>(CoreType::COUNT)> dispatch_mem_map_;
     std::unique_ptr<tt::tt_fabric::ControlPlane> control_plane_;
     tt_fabric::FabricConfig fabric_config_ = tt_fabric::FabricConfig::DISABLED;

--- a/tt_metal/impl/dispatch/data_collection.cpp
+++ b/tt_metal/impl/dispatch/data_collection.cpp
@@ -5,14 +5,8 @@
 #include "data_collection.hpp"
 
 #include <cstdint>
-#include <core_coord.hpp>
-#include "impl/program/program_impl.hpp"
-#include <umd/device/types/core_coordinates.hpp>
-#include "hal_types.hpp"
-
 #include "impl/context/metal_context.hpp"
 #include "impl/kernels/kernel_impl.hpp"
-#include "program/program_impl.hpp"
 #include "tt-metalium/program.hpp"
 #include "data_collector.hpp"
 

--- a/tt_metal/impl/dispatch/data_collection.cpp
+++ b/tt_metal/impl/dispatch/data_collection.cpp
@@ -4,258 +4,22 @@
 
 #include "data_collection.hpp"
 
-#include <algorithm>
-#include <array>
 #include <cstdint>
-#include <cstdlib>
-#include <map>
-#include <optional>
-#include <ostream>
-#include <utility>
-
 #include <core_coord.hpp>
-#include <enchantum/enchantum.hpp>
-#include <enchantum/generators.hpp>
-#include <enchantum/iostream.hpp>
 #include "impl/program/program_impl.hpp"
 #include <umd/device/types/core_coordinates.hpp>
-
-#include <tt_stl/assert.hpp>
 #include "hal_types.hpp"
+
 #include "impl/context/metal_context.hpp"
 #include "impl/kernels/kernel_impl.hpp"
 #include "program/program_impl.hpp"
 #include "tt-metalium/program.hpp"
+#include "data_collector.hpp"
 
 using namespace tt;
 using namespace tt::tt_metal;
 
 using tt::tt_metal::detail::ProgramImpl;
-namespace {
-
-// Class to track stats for DispatchData
-class DispatchStats {
-public:
-    uint32_t max_transaction_size = 0;
-    uint32_t min_transaction_size = UINT32_MAX;
-    uint32_t num_writes = 0;
-    uint64_t total_write_size = 0;
-
-    void Update(
-        uint32_t max_transaction_size, uint32_t min_transaction_size, uint32_t num_writes, uint64_t total_write_size) {
-        this->max_transaction_size = std::max(this->max_transaction_size, max_transaction_size);
-        this->min_transaction_size = std::min(this->min_transaction_size, min_transaction_size);
-        this->num_writes += num_writes;
-        this->total_write_size += total_write_size;
-    }
-    void Update(uint32_t transaction_size, uint32_t transaction_count) {
-        Update(transaction_size, transaction_size, transaction_count, transaction_count * transaction_size);
-    }
-    void Update(DispatchStats& other) {
-        Update(other.max_transaction_size, other.min_transaction_size, other.num_writes, other.total_write_size);
-    }
-
-    void Dump(std::ofstream& outfile, const std::map<uint32_t, uint32_t>& raw_data) const {
-        outfile << fmt::format("\t\tmax_transaction_size = {}\n", max_transaction_size);
-        outfile << fmt::format("\t\tmin_transaction_size = {}\n", min_transaction_size);
-        outfile << fmt::format("\t\tnum_writes           = {}\n", num_writes);
-        outfile << fmt::format("\t\ttotal_write_size     = {}\n", total_write_size);
-        outfile << "\t\ttransaction_counts   = [";
-        for (auto& size_and_count : raw_data) {
-            outfile << size_and_count.first << ":" << size_and_count.second << " ";
-        }
-        outfile << "]\n";
-    }
-};
-
-// Class to hold dispatch write data for the DataCollector
-class DispatchData {
-public:
-    DispatchData(data_collector_t type) : type(type) {}
-
-    void Update(uint32_t transaction_size, std::optional<HalProcessorIdentifier> processor) {
-        data[processor][transaction_size]++;
-    }
-
-    void Merge(const DispatchData& other) {
-        for (auto& [processor, processor_data] : other.data) {
-            for (auto& [size, count] : processor_data) {
-                this->data[processor][size] += count;
-            }
-        }
-    }
-
-    void DumpStats(std::ofstream& outfile) const {
-        // Only dump if this has data
-        if (data.empty()) {
-            return;
-        }
-        outfile << fmt::format("\t{} stats:\n", type);
-
-        // Track stats for all RISCS, as well as per RISC
-        DispatchStats total_stats;
-        std::map<uint32_t, uint32_t> total_data;
-        for (auto& [processor, processor_data] : data) {
-            // Go through all data and update stats
-            DispatchStats processor_stats;
-            for (auto& [size, count] : processor_data) {
-                processor_stats.Update(size, count);
-                total_data[size] += count;
-            }
-            total_stats.Update(processor_stats);
-
-            // Only for binaries, print for each RISC type
-            if (type == DISPATCH_DATA_BINARY) {
-                TT_ASSERT(processor != std::nullopt);
-                outfile << "\t  " << *processor << " binary data:\n";
-                processor_stats.Dump(outfile, processor_data);
-            }
-        }
-
-        // For types other than binaries, just print once
-        if (type == DISPATCH_DATA_BINARY) {
-            outfile << "\t  Overall binaries data:\n";
-        }
-        total_stats.Dump(outfile, total_data);
-    }
-
-private:
-    // processor -> transaction size -> count
-    std::map<std::optional<HalProcessorIdentifier>, std::map<uint32_t, uint32_t>> data;
-    data_collector_t type;
-};
-
-// Class to manage & dump dispatch data for each program
-class DataCollector {
-public:
-    // Single instance of the data collector
-    static DataCollector* inst;
-
-    DataCollector() {
-        TT_ASSERT(inst == nullptr);
-        inst = this;
-    };
-    ~DataCollector() { inst = nullptr; };
-
-    void RecordData(
-        uint64_t program_id,
-        data_collector_t type,
-        uint32_t transaction_size,
-        std::optional<HalProcessorIdentifier> processor);
-    void RecordKernelGroup(ProgramImpl& program, HalProgrammableCoreType core_type, const KernelGroup& kernel_group);
-    void RecordProgramRun(uint64_t program_id);
-    void DumpData();
-
-private:
-    struct KernelData {
-        int watcher_kernel_id;
-        HalProcessorClassType processor_class;
-    };
-    struct KernelGroupData {
-        std::vector<KernelData> kernels;
-        CoreRangeSet core_ranges;
-    };
-    std::map<uint64_t, std::vector<DispatchData>> program_id_to_dispatch_data;
-    std::map<uint64_t, std::map<HalProgrammableCoreType, std::vector<KernelGroupData>>> program_id_to_kernel_groups;
-    std::map<uint64_t, int> program_id_to_call_count;
-};
-
-void DataCollector::RecordData(
-    uint64_t program_id,
-    data_collector_t type,
-    uint32_t transaction_size,
-    std::optional<HalProcessorIdentifier> processor) {
-    auto& dispatch_data = program_id_to_dispatch_data[program_id];
-    if (dispatch_data.empty()) {
-        // If no existing data for this program, initialize starting values.
-        dispatch_data.reserve(enchantum::count<data_collector_t>);
-        for (auto idx : enchantum::values_generator<data_collector_t>) {
-            dispatch_data.emplace_back(idx);
-        }
-    }
-    dispatch_data.at(type).Update(transaction_size, processor);
-}
-
-void DataCollector::RecordKernelGroup(
-    ProgramImpl& program, HalProgrammableCoreType core_type, const KernelGroup& kernel_group) {
-    uint64_t program_id = program.get_id();
-    // Make a copy of relevant info, since user may destroy program before we dump.
-    std::vector<KernelData> kernel_data;
-    kernel_data.reserve(kernel_group.kernel_ids.size());
-    for (auto kernel_id : kernel_group.kernel_ids) {
-        auto kernel = program.get_kernel(kernel_id);
-        kernel_data.push_back({kernel->get_watcher_kernel_id(), kernel->get_kernel_processor_class()});
-    }
-    program_id_to_kernel_groups[program_id][core_type].push_back({std::move(kernel_data), kernel_group.core_ranges});
-}
-
-void DataCollector::RecordProgramRun(uint64_t program_id) {
-    program_id_to_call_count[program_id]++;
-}
-
-void DataCollector::DumpData() {
-    std::ofstream outfile = std::ofstream("dispatch_data.txt");
-
-    // Extra DispatchData objects to collect data across programs
-    std::vector<DispatchData> cross_program_data;
-    cross_program_data.reserve(enchantum::count<data_collector_t>);
-    for (auto idx : enchantum::values_generator<data_collector_t>) {
-        cross_program_data.emplace_back(idx);
-    }
-
-    // Go through all programs, and dump relevant data
-    for (const auto& [program_id, data] : program_id_to_dispatch_data) {
-        outfile << fmt::format("Program {}: Ran {} time(s).\n", program_id, program_id_to_call_count[program_id]);
-
-        // Dump kernel ids for each kernel group in this program
-        for (const auto& [core_type, kernel_groups] : program_id_to_kernel_groups[program_id]) {
-            outfile << fmt::format("\t{} Kernel Groups: {}\n", core_type, kernel_groups.size());
-            for (const auto& [kernels, ranges] : kernel_groups) {
-                // Dump kernel ids in this group
-                outfile << "\t\t{";
-                for (const auto& kernel : kernels) {
-                    using enchantum::iostream_operators::operator<<;
-                    outfile << core_type << "_" << kernel.processor_class << ":" << kernel.watcher_kernel_id << " ";
-                }
-                outfile << "} on cores ";
-
-                // Dump the cores this kernel group contains
-                outfile << ranges.str() << "\n";
-            }
-        }
-
-        // Dump dispatch write stats
-        for (auto type : enchantum::values_generator<data_collector_t>) {
-            const DispatchData& type_data = data.at(type);
-            cross_program_data[type].Merge(type_data);
-            type_data.DumpStats(outfile);
-        }
-    }
-
-    // Dump cross-program stats
-    outfile << "Cross-Program Data:\n";
-    for (const auto& type_data : cross_program_data) {
-        type_data.DumpStats(outfile);
-    }
-    outfile.close();
-}
-
-DataCollector* DataCollector::inst = nullptr;
-
-void DumpDispatchDataAndClose() {
-    DataCollector::inst->DumpData();
-    delete DataCollector::inst;
-}
-
-// Helper function to init the data collector if it isn't already up.
-void InitDataCollector() {
-    if (DataCollector::inst == nullptr) {
-        new DataCollector();
-        std::atexit(DumpDispatchDataAndClose);
-    }
-}
-
-}  // namespace
 
 namespace tt {
 
@@ -268,9 +32,7 @@ void RecordDispatchData(
     if (!tt::tt_metal::MetalContext::instance().rtoptions().get_dispatch_data_collection_enabled()) {
         return;
     }
-
-    InitDataCollector();
-    DataCollector::inst->RecordData(program_id, type, transaction_size, processor);
+    tt::tt_metal::MetalContext::instance().data_collector()->RecordData(program_id, type, transaction_size, processor);
 }
 
 void RecordKernelGroup(ProgramImpl& program, HalProgrammableCoreType core_type, const KernelGroup& kernel_group) {
@@ -279,8 +41,7 @@ void RecordKernelGroup(ProgramImpl& program, HalProgrammableCoreType core_type, 
         return;
     }
 
-    InitDataCollector();
-    DataCollector::inst->RecordKernelGroup(program, core_type, kernel_group);
+    tt::tt_metal::MetalContext::instance().data_collector()->RecordKernelGroup(program, core_type, kernel_group);
 }
 
 void RecordProgramRun(uint64_t program_id) {
@@ -289,8 +50,7 @@ void RecordProgramRun(uint64_t program_id) {
         return;
     }
 
-    InitDataCollector();
-    DataCollector::inst->RecordProgramRun(program_id);
+    tt::tt_metal::MetalContext::instance().data_collector()->RecordProgramRun(program_id);
 }
 
 }  // namespace tt

--- a/tt_metal/impl/dispatch/data_collection.hpp
+++ b/tt_metal/impl/dispatch/data_collection.hpp
@@ -6,11 +6,8 @@
 #include <host_api.hpp>
 #include <stdint.h>
 #include <optional>
-
-#include "hal_types.hpp"
 #include "program/program_impl.hpp"
 
-#include <umd/device/types/core_coordinates.hpp>
 #pragma once
 
 namespace tt {

--- a/tt_metal/impl/dispatch/data_collection.hpp
+++ b/tt_metal/impl/dispatch/data_collection.hpp
@@ -11,6 +11,7 @@
 #include "program/program_impl.hpp"
 
 #include <umd/device/types/core_coordinates.hpp>
+#pragma once
 
 namespace tt {
 namespace tt_metal {

--- a/tt_metal/impl/dispatch/data_collection.hpp
+++ b/tt_metal/impl/dispatch/data_collection.hpp
@@ -2,13 +2,13 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#pragma once
+
 #include <device.hpp>
 #include <host_api.hpp>
 #include <stdint.h>
 #include <optional>
 #include "program/program_impl.hpp"
-
-#pragma once
 
 namespace tt {
 namespace tt_metal {

--- a/tt_metal/impl/dispatch/data_collector.cpp
+++ b/tt_metal/impl/dispatch/data_collector.cpp
@@ -3,22 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "data_collector.hpp"
-
-#include <algorithm>
-#include <array>
-#include <cstdint>
-#include <map>
-#include <utility>
-
 #include <enchantum/enchantum.hpp>
 #include <enchantum/generators.hpp>
 #include <enchantum/iostream.hpp>
-#include "impl/program/program_impl.hpp"
-#include <umd/device/types/core_coordinates.hpp>
-
-#include "hal_types.hpp"
 #include "impl/kernels/kernel_impl.hpp"
-#include "program/program_impl.hpp"
 #include "tt-metalium/program.hpp"
 
 using tt::tt_metal::detail::ProgramImpl;

--- a/tt_metal/impl/dispatch/data_collector.cpp
+++ b/tt_metal/impl/dispatch/data_collector.cpp
@@ -1,0 +1,186 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "data_collector.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <map>
+#include <utility>
+
+#include <enchantum/enchantum.hpp>
+#include <enchantum/generators.hpp>
+#include <enchantum/iostream.hpp>
+#include "impl/program/program_impl.hpp"
+#include <umd/device/types/core_coordinates.hpp>
+
+#include "hal_types.hpp"
+#include "impl/kernels/kernel_impl.hpp"
+#include "program/program_impl.hpp"
+#include "tt-metalium/program.hpp"
+
+using tt::tt_metal::detail::ProgramImpl;
+namespace tt::tt_metal {
+
+// Class to track stats for DispatchData
+class DispatchStats {
+public:
+    uint32_t max_transaction_size = 0;
+    uint32_t min_transaction_size = UINT32_MAX;
+    uint32_t num_writes = 0;
+    uint64_t total_write_size = 0;
+
+    void Update(
+        uint32_t max_transaction_size, uint32_t min_transaction_size, uint32_t num_writes, uint64_t total_write_size) {
+        this->max_transaction_size = std::max(this->max_transaction_size, max_transaction_size);
+        this->min_transaction_size = std::min(this->min_transaction_size, min_transaction_size);
+        this->num_writes += num_writes;
+        this->total_write_size += total_write_size;
+    }
+    void Update(uint32_t transaction_size, uint32_t transaction_count) {
+        Update(transaction_size, transaction_size, transaction_count, transaction_count * transaction_size);
+    }
+    void Update(DispatchStats& other) {
+        Update(other.max_transaction_size, other.min_transaction_size, other.num_writes, other.total_write_size);
+    }
+
+    void Dump(std::ofstream& outfile, const std::map<uint32_t, uint32_t>& raw_data) const {
+        outfile << fmt::format("\t\tmax_transaction_size = {}\n", max_transaction_size);
+        outfile << fmt::format("\t\tmin_transaction_size = {}\n", min_transaction_size);
+        outfile << fmt::format("\t\tnum_writes           = {}\n", num_writes);
+        outfile << fmt::format("\t\ttotal_write_size     = {}\n", total_write_size);
+        outfile << "\t\ttransaction_counts   = [";
+        for (auto& size_and_count : raw_data) {
+            outfile << size_and_count.first << ":" << size_and_count.second << " ";
+        }
+        outfile << "]\n";
+    }
+};
+
+void DispatchData::Update(uint32_t transaction_size, std::optional<HalProcessorIdentifier> processor) {
+    data[processor][transaction_size]++;
+}
+void DispatchData::Merge(const DispatchData& other) {
+    for (auto& [processor, processor_data] : other.data) {
+        for (auto& [size, count] : processor_data) {
+            this->data[processor][size] += count;
+        }
+    }
+}
+
+void DispatchData::DumpStats(std::ofstream& outfile) const {
+    // Only dump if this has data
+    if (data.empty()) {
+        return;
+    }
+    outfile << fmt::format("\t{} stats:\n", type);
+
+    // Track stats for all RISCS, as well as per RISC
+    DispatchStats total_stats;
+    std::map<uint32_t, uint32_t> total_data;
+    for (auto& [processor, processor_data] : data) {
+        // Go through all data and update stats
+        DispatchStats processor_stats;
+        for (auto& [size, count] : processor_data) {
+            processor_stats.Update(size, count);
+            total_data[size] += count;
+        }
+        total_stats.Update(processor_stats);
+
+        // Only for binaries, print for each RISC type
+        if (type == DISPATCH_DATA_BINARY) {
+            TT_ASSERT(processor != std::nullopt);
+            outfile << "\t  " << *processor << " binary data:\n";
+            processor_stats.Dump(outfile, processor_data);
+        }
+    }
+
+    // For types other than binaries, just print once
+    if (type == DISPATCH_DATA_BINARY) {
+        outfile << "\t  Overall binaries data:\n";
+    }
+    total_stats.Dump(outfile, total_data);
+}
+
+// Class to hold dispatch write data for the DataCollector
+void DataCollector::RecordData(
+    uint64_t program_id,
+    data_collector_t type,
+    uint32_t transaction_size,
+    std::optional<HalProcessorIdentifier> processor) {
+    auto& dispatch_data = program_id_to_dispatch_data[program_id];
+    if (dispatch_data.empty()) {
+        // If no existing data for this program, initialize starting values.
+        dispatch_data.reserve(enchantum::count<data_collector_t>);
+        for (auto idx : enchantum::values_generator<data_collector_t>) {
+            dispatch_data.emplace_back(idx);
+        }
+    }
+    dispatch_data.at(type).Update(transaction_size, processor);
+}
+
+void DataCollector::RecordKernelGroup(
+    ProgramImpl& program, HalProgrammableCoreType core_type, const KernelGroup& kernel_group) {
+    uint64_t program_id = program.get_id();
+    // Make a copy of relevant info, since user may destroy program before we dump.
+    std::vector<KernelData> kernel_data;
+    kernel_data.reserve(kernel_group.kernel_ids.size());
+    for (auto kernel_id : kernel_group.kernel_ids) {
+        auto kernel = program.get_kernel(kernel_id);
+        kernel_data.push_back({kernel->get_watcher_kernel_id(), kernel->get_kernel_processor_class()});
+    }
+    program_id_to_kernel_groups[program_id][core_type].push_back({std::move(kernel_data), kernel_group.core_ranges});
+}
+
+void DataCollector::RecordProgramRun(uint64_t program_id) { program_id_to_call_count[program_id]++; }
+
+void DataCollector::DumpData() {
+    std::ofstream outfile = std::ofstream("dispatch_data.txt");
+
+    // Extra DispatchData objects to collect data across programs
+    std::vector<DispatchData> cross_program_data;
+    cross_program_data.reserve(enchantum::count<data_collector_t>);
+    for (auto idx : enchantum::values_generator<data_collector_t>) {
+        cross_program_data.emplace_back(idx);
+    }
+
+    // Go through all programs, and dump relevant data
+    for (const auto& [program_id, data] : program_id_to_dispatch_data) {
+        outfile << fmt::format("Program {}: Ran {} time(s).\n", program_id, program_id_to_call_count[program_id]);
+
+        // Dump kernel ids for each kernel group in this program
+        for (const auto& [core_type, kernel_groups] : program_id_to_kernel_groups[program_id]) {
+            outfile << fmt::format("\t{} Kernel Groups: {}\n", core_type, kernel_groups.size());
+            for (const auto& [kernels, ranges] : kernel_groups) {
+                // Dump kernel ids in this group
+                outfile << "\t\t{";
+                for (const auto& kernel : kernels) {
+                    using enchantum::iostream_operators::operator<<;
+                    outfile << core_type << "_" << kernel.processor_class << ":" << kernel.watcher_kernel_id << " ";
+                }
+                outfile << "} on cores ";
+
+                // Dump the cores this kernel group contains
+                outfile << ranges.str() << "\n";
+            }
+        }
+
+        // Dump dispatch write stats
+        for (auto type : enchantum::values_generator<data_collector_t>) {
+            const DispatchData& type_data = data.at(type);
+            cross_program_data[type].Merge(type_data);
+            type_data.DumpStats(outfile);
+        }
+    }
+
+    // Dump cross-program stats
+    outfile << "Cross-Program Data:\n";
+    for (const auto& type_data : cross_program_data) {
+        type_data.DumpStats(outfile);
+    }
+    outfile.close();
+}
+
+}  // namespace tt::tt_metal

--- a/tt_metal/impl/dispatch/data_collector.hpp
+++ b/tt_metal/impl/dispatch/data_collector.hpp
@@ -2,11 +2,14 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#pragma once
+
 #include <cstdint>
 #include <map>
+#include <vector>
+#include <optional>
+#include <fstream>
 #include "data_collection.hpp"
-
-#pragma once
 
 namespace tt::tt_metal {
 
@@ -30,8 +33,8 @@ private:
 // Class to manage & dump dispatch data for each program
 class DataCollector {
 public:
-    DataCollector() {};
-    ~DataCollector() {};
+    DataCollector() = default;
+    ~DataCollector() = default;
 
     void RecordData(
         uint64_t program_id,

--- a/tt_metal/impl/dispatch/data_collector.hpp
+++ b/tt_metal/impl/dispatch/data_collector.hpp
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include <map>
+
+#include "data_collection.hpp"
+#include <umd/device/types/core_coordinates.hpp>
+#include "hal_types.hpp"
+
+namespace tt::tt_metal {
+
+// Class to hold dispatch write data for the DataCollector
+class DispatchData {
+public:
+    DispatchData(data_collector_t type) : type(type) {}
+
+    void Update(uint32_t transaction_size, std::optional<HalProcessorIdentifier> processor);
+
+    void Merge(const DispatchData& other);
+
+    void DumpStats(std::ofstream& outfile) const;
+
+private:
+    // processor -> transaction size -> count
+    std::map<std::optional<HalProcessorIdentifier>, std::map<uint32_t, uint32_t>> data;
+    data_collector_t type;
+};
+
+// Class to manage & dump dispatch data for each program
+class DataCollector {
+public:
+    DataCollector() {};
+    ~DataCollector() {};
+
+    void RecordData(
+        uint64_t program_id,
+        data_collector_t type,
+        uint32_t transaction_size,
+        std::optional<tt_metal::HalProcessorIdentifier> processor);
+    void RecordKernelGroup(
+        tt_metal::detail::ProgramImpl& program,
+        tt_metal::HalProgrammableCoreType core_type,
+        const tt_metal::KernelGroup& kernel_group);
+    void RecordProgramRun(uint64_t program_id);
+    void DumpData();
+
+private:
+    struct KernelData {
+        int watcher_kernel_id;
+        HalProcessorClassType processor_class;
+    };
+    struct KernelGroupData {
+        std::vector<KernelData> kernels;
+        CoreRangeSet core_ranges;
+    };
+    std::map<uint64_t, std::vector<DispatchData>> program_id_to_dispatch_data;
+    std::map<uint64_t, std::map<HalProgrammableCoreType, std::vector<KernelGroupData>>> program_id_to_kernel_groups;
+    std::map<uint64_t, int> program_id_to_call_count;
+};
+
+}  // namespace tt::tt_metal

--- a/tt_metal/impl/dispatch/data_collector.hpp
+++ b/tt_metal/impl/dispatch/data_collector.hpp
@@ -4,10 +4,9 @@
 
 #include <cstdint>
 #include <map>
-
 #include "data_collection.hpp"
-#include <umd/device/types/core_coordinates.hpp>
-#include "hal_types.hpp"
+
+#pragma once
 
 namespace tt::tt_metal {
 


### PR DESCRIPTION
### Ticket
[#32130](https://github.com/tenstorrent/tt-metal/issues/32130)

### Problem description
Moving DataCollector singleton to MetalContext

### What's changed
DataCollector was changed to a non-singleton class and moved to be a unique instance in MetalContext

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] New/Existing tests provide coverage for changes