### PR TITLE
Remove Filler Loop In Pool Reader

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/pool/test_maxpool2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/pool/test_maxpool2d.py
@@ -29,7 +29,7 @@ def randomize_torch_tensor(tensor_map, tensor_shape):
     if tensor_shape in tensor_map.keys():
         torch_tensor = tensor_map[tensor_shape]
     else:
-        torch_tensor = torch.randn(tensor_shape, dtype=torch.bfloat16)
+        torch_tensor = torch.ones(tensor_shape, dtype=torch.bfloat16)
         tensor_map[tensor_shape] = torch_tensor
 
     return torch_tensor
@@ -177,6 +177,13 @@ def run_max_pool2d(
     ttnn_output = ttnn_output.reshape(out_n, out_h, out_w, out_c)  # N, H, W, C
     ttnn_output = torch.permute(ttnn_output, (0, 3, 1, 2))  # N, C, H, W
 
+    # Set torch print options to show all elements without abbreviation
+    torch.set_printoptions(threshold=float("inf"), linewidth=200, sci_mode=False)
+    print("TTNN output: ", ttnn_output[0][0].flatten())
+    print("Torch output: ", torch_output[0][0].flatten())
+    # Reset to default torch print options
+    torch.set_printoptions(profile="default")
+
     # test for equivalance
     atol, rtol = torch.testing._comparison.default_tolerances(torch.bfloat16)
     if in_dtype == ttnn.bfloat8_b or out_dtype == ttnn.bfloat8_b:
@@ -194,400 +201,396 @@ def run_max_pool2d(
         assert allclose
 
 
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
-@pytest.mark.parametrize(
-    "input_shape",  ## NCHW
-    (
-        (  # resnet shapes
-            [1, 64, 112, 112],
-            [16, 64, 112, 112],
-            # hpr shapes
-            [8, 32, 132, 20],
-            [32, 32, 264, 40],
-            [4, 16, 1056, 160],
-            [16, 16, 528, 80],
-            # wide for vgg
-            [1, 256, 56, 56],
-            [1, 512, 28, 28],
-            # wide yolo kernel
-            [1, 512, 10, 10],
-            [1, 96, 112, 112],
-            [1, 192, 132, 20],
-            # wide non-8 multiple tests
-            [1, 800, 32, 32],
-            [1, 640, 32, 32],
-            [1, 576, 32, 32],
-            [1, 384, 32, 32],
-            # C partial tile test
-            [1, 16, 12, 12],
-            [1, 1, 56, 56],
-            [2, 290, 10, 10],
-            [1, 280, 10, 10],
-            # partial grid tests
-            [1, 32, 10, 10],  # BH
-            [1, 32, 6, 6],  # WH
-        )
-    ),
-)
-@pytest.mark.parametrize(
-    "kernel_size",
-    (
-        (3, 3),  # 1 face 1 chunk
-        (5, 5),  # 2 faces 1 chunk
-        (7, 7),  # 2 chunks
-        (9, 9),  # 3 chunks
-    ),
-)
-@pytest.mark.parametrize(
-    "padding",
-    (
-        (0, 0),
-        (1, 1),
-        (1, 4, 3, 2),
-    ),
-)
-@pytest.mark.parametrize(
-    "stride",
-    (
-        (1, 1),
-        (2, 2),
-    ),
-)
-@pytest.mark.parametrize(
-    "dilation",
-    (
-        (1, 1),
-        (2, 2),
-    ),
-)
-@pytest.mark.parametrize(
-    "in_dtype",
-    [
-        ttnn.bfloat16,
-        ttnn.bfloat8_b,
-    ],
-)
-@pytest.mark.parametrize(
-    "ceil_mode",
-    [
-        False,
-        True,
-    ],
-)
-def test_run_max_pool_height_shard(
-    input_shape, kernel_size, padding, stride, dilation, device, tensor_map, in_dtype, ceil_mode
-):
-    run_max_pool2d(
-        input_shape,
-        kernel_size,
-        padding,
-        stride,
-        dilation,
-        device,
-        tensor_map,
-        in_dtype,
-        shard_scheme=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
-        ceil_mode=ceil_mode,
-    )
+# @pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
+# @pytest.mark.parametrize(
+#     "input_shape",  ## NCHW
+#     (
+#         (  # resnet shapes
+#             [1, 64, 112, 112],
+#             [16, 64, 112, 112],
+#             # hpr shapes
+#             [8, 32, 132, 20],
+#             [32, 32, 264, 40],
+#             [4, 16, 1056, 160],
+#             [16, 16, 528, 80],
+#             # wide for vgg
+#             [1, 256, 56, 56],
+#             [1, 512, 28, 28],
+#             # wide yolo kernel
+#             [1, 512, 10, 10],
+#             [1, 96, 112, 112],
+#             [1, 192, 132, 20],
+#             # wide non-8 multiple tests
+#             [1, 800, 32, 32],
+#             [1, 640, 32, 32],
+#             [1, 576, 32, 32],
+#             [1, 384, 32, 32],
+#             # C partial tile test
+#             [1, 16, 12, 12],
+#             [1, 1, 56, 56],
+#             [2, 290, 10, 10],
+#             [1, 280, 10, 10],
+#             # partial grid tests
+#             [1, 32, 10, 10],  # BH
+#             [1, 32, 6, 6],  # WH
+#         )
+#     ),
+# )
+# @pytest.mark.parametrize(
+#     "kernel_size",
+#     (
+#         (3, 3),  # 1 face 1 chunk
+#         (5, 5),  # 2 faces 1 chunk
+#         (7, 7),  # 2 chunks
+#         (9, 9),  # 3 chunks
+#     ),
+# )
+# @pytest.mark.parametrize(
+#     "padding",
+#     (
+#         (0, 0),
+#         (1, 1),
+#         (1, 4, 3, 2),
+#     ),
+# )
+# @pytest.mark.parametrize(
+#     "stride",
+#     (
+#         (1, 1),
+#         (2, 2),
+#     ),
+# )
+# @pytest.mark.parametrize(
+#     "dilation",
+#     (
+#         (1, 1),
+#         (2, 2),
+#     ),
+# )
+# @pytest.mark.parametrize(
+#     "in_dtype",
+#     [
+#         ttnn.bfloat16,
+#         ttnn.bfloat8_b,
+#     ],
+# )
+# @pytest.mark.parametrize(
+#     "ceil_mode",
+#     [
+#         False,
+#         True,
+#     ],
+# )
+# def test_run_max_pool_height_shard(
+#     input_shape, kernel_size, padding, stride, dilation, device, tensor_map, in_dtype, ceil_mode
+# ):
+#     run_max_pool2d(
+#         input_shape,
+#         kernel_size,
+#         padding,
+#         stride,
+#         dilation,
+#         device,
+#         tensor_map,
+#         in_dtype,
+#         shard_scheme=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+#         ceil_mode=ceil_mode,
+#     )
+
+
+# @pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
+# @pytest.mark.parametrize(
+#     "input_shape",  ## NCHW
+#     (
+#         (
+#             [1, 2048, 28, 28],
+#             [1, 1024, 6, 6],
+#             [1, 2048, 132, 20],
+#             [2, 4096, 10, 16],
+#             [1, 32768, 10, 10],
+#         )
+#     ),
+# )
+# @pytest.mark.parametrize(
+#     "kernel_size",
+#     (
+#         (5, 5),
+#         (9, 9),
+#     ),
+# )
+# @pytest.mark.parametrize(
+#     "padding",
+#     (
+#         (1, 2),
+#         (4, 2),
+#     ),
+# )
+# @pytest.mark.parametrize(
+#     "stride",
+#     ((1, 1),),
+# )
+# @pytest.mark.parametrize(
+#     "dilation",
+#     (
+#         (1, 1),
+#         (3, 1),
+#     ),
+# )
+# @pytest.mark.parametrize(
+#     "in_dtype",
+#     [
+#         ttnn.bfloat16,
+#     ],
+# )
+# @pytest.mark.parametrize(
+#     "ceil_mode",
+#     [
+#         False,
+#     ],
+# )
+# def test_run_max_pool_width_shard(
+#     input_shape,
+#     kernel_size,
+#     padding,
+#     stride,
+#     dilation,
+#     device,
+#     tensor_map,
+#     in_dtype,
+#     ceil_mode,
+# ):
+#     run_max_pool2d(
+#         input_shape,
+#         kernel_size,
+#         padding,
+#         stride,
+#         dilation,
+#         device,
+#         tensor_map,
+#         in_dtype,
+#         shard_scheme=ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+#         ceil_mode=ceil_mode,
+#     )
+
+
+# @pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
+# @pytest.mark.parametrize(
+#     "input_shape",  ## NCHW
+#     (
+#         (
+#             [1, 256, 56, 56],
+#             [1, 128, 10, 14],
+#             [1, 512, 8, 6],
+#             [1, 256, 132, 20],
+#             [1, 4096, 10, 10],
+#         )
+#     ),
+# )
+# @pytest.mark.parametrize(
+#     "kernel_size",
+#     (
+#         (6, 6),
+#         (10, 10),
+#     ),
+# )
+# @pytest.mark.parametrize(
+#     "padding",
+#     (
+#         (3, 2),
+#         (4, 5),
+#     ),
+# )
+# @pytest.mark.parametrize(
+#     "stride",
+#     ((1, 1),),
+# )
+# @pytest.mark.parametrize(
+#     "dilation",
+#     (
+#         (1, 1),
+#         (4, 3),
+#     ),
+# )
+# @pytest.mark.parametrize(
+#     "in_dtype",
+#     [
+#         ttnn.bfloat16,
+#     ],
+# )
+# @pytest.mark.parametrize(
+#     "ceil_mode",
+#     [
+#         False,
+#     ],
+# )
+# def test_run_max_pool_block_shard(
+#     input_shape,
+#     kernel_size,
+#     padding,
+#     stride,
+#     dilation,
+#     device,
+#     tensor_map,
+#     in_dtype,
+#     ceil_mode,
+# ):
+#     run_max_pool2d(
+#         input_shape,
+#         kernel_size,
+#         padding,
+#         stride,
+#         dilation,
+#         device,
+#         tensor_map,
+#         in_dtype,
+#         shard_scheme=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+#         ceil_mode=ceil_mode,
+#     )
+
+
+# @pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
+# @pytest.mark.parametrize(
+#     "input_shape",  ## NCHW
+#     (
+#         (
+#             [8, 64, 112, 112],
+#             [1, 512, 10, 10],
+#         )
+#     ),
+# )
+# @pytest.mark.parametrize("memory_config", [ttnn.L1_MEMORY_CONFIG, ttnn.DRAM_MEMORY_CONFIG])
+# def test_run_max_pool_mem_config(
+#     input_shape,
+#     device,
+#     tensor_map,
+#     memory_config,
+# ):
+#     run_max_pool2d(
+#         input_shape,
+#         (3, 3),
+#         (1, 1),
+#         (2, 2),
+#         (1, 1),
+#         device,
+#         tensor_map,
+#         ttnn.bfloat16,
+#         memory_config=memory_config,
+#     )
+
+
+# @pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
+# @pytest.mark.parametrize(
+#     "input_shape",  ## NCHW
+#     (([1, 512, 10, 10],)),  ## yolov4 shapes
+# )
+# @pytest.mark.parametrize(
+#     "kernel_size",
+#     (
+#         (5, 5),
+#         (9, 9),
+#         (13, 13),
+#     ),
+# )
+# @pytest.mark.parametrize(
+#     "padding",
+#     (
+#         (2, 2),
+#         (4, 4),
+#         (6, 6),
+#     ),
+# )
+# @pytest.mark.parametrize(
+#     "stride",
+#     ((1, 1),),
+# )
+# @pytest.mark.parametrize(
+#     "dilation",
+#     ((1, 1),),
+# )
+# @pytest.mark.parametrize("in_dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
+# def test_run_max_pool_yolov4(
+#     input_shape,
+#     kernel_size,
+#     padding,
+#     stride,
+#     dilation,
+#     device,
+#     tensor_map,
+#     in_dtype,
+# ):
+#     run_max_pool2d(input_shape, kernel_size, padding, stride, dilation, device, tensor_map, in_dtype)
+
+
+# @pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
+# @pytest.mark.parametrize(
+#     "input_shape",
+#     (([1, 256, 54, 54],)),
+# )
+# @pytest.mark.parametrize(
+#     "kernel_size",
+#     ((3, 3),),
+# )
+# @pytest.mark.parametrize(
+#     "padding",
+#     ((0, 0),),
+# )
+# @pytest.mark.parametrize("stride", ((2, 2),))
+# @pytest.mark.parametrize(
+#     "dilation",
+#     ((1, 1),),
+# )
+# @pytest.mark.parametrize("in_dtype", [ttnn.bfloat16])
+# @pytest.mark.parametrize("ceil_mode", [False, True])
+# def test_run_max_pool_squeeze_net_model(
+#     input_shape,
+#     kernel_size,
+#     padding,
+#     stride,
+#     dilation,
+#     device,
+#     tensor_map,
+#     in_dtype,
+#     ceil_mode,
+# ):
+#     run_max_pool2d(
+#         input_shape,
+#         kernel_size,
+#         padding,
+#         stride,
+#         dilation,
+#         device,
+#         tensor_map,
+#         in_dtype,
+#         ceil_mode=ceil_mode,
+#     )
 
 
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
+@pytest.mark.parametrize("out_dtype", [ttnn.bfloat16])
+@pytest.mark.parametrize("output_layout", [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT])
 @pytest.mark.parametrize(
-    "input_shape",  ## NCHW
-    (
-        (
-            [1, 2048, 28, 28],
-            [1, 1024, 6, 6],
-            [1, 2048, 132, 20],
-            [2, 4096, 10, 16],
-            [1, 32768, 10, 10],
-        )
-    ),
-)
-@pytest.mark.parametrize(
-    "kernel_size",
-    (
-        (5, 5),
-        (9, 9),
-    ),
-)
-@pytest.mark.parametrize(
-    "padding",
-    (
-        (1, 2),
-        (4, 2),
-    ),
-)
-@pytest.mark.parametrize(
-    "stride",
-    ((1, 1),),
-)
-@pytest.mark.parametrize(
-    "dilation",
-    (
-        (1, 1),
-        (3, 1),
-    ),
-)
-@pytest.mark.parametrize(
-    "in_dtype",
-    [
-        ttnn.bfloat16,
-    ],
-)
-@pytest.mark.parametrize(
-    "ceil_mode",
-    [
-        False,
-    ],
-)
-def test_run_max_pool_width_shard(
-    input_shape,
-    kernel_size,
-    padding,
-    stride,
-    dilation,
-    device,
-    tensor_map,
-    in_dtype,
-    ceil_mode,
-):
-    run_max_pool2d(
-        input_shape,
-        kernel_size,
-        padding,
-        stride,
-        dilation,
-        device,
-        tensor_map,
-        in_dtype,
-        shard_scheme=ttnn.TensorMemoryLayout.WIDTH_SHARDED,
-        ceil_mode=ceil_mode,
-    )
-
-
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
-@pytest.mark.parametrize(
-    "input_shape",  ## NCHW
-    (
-        (
-            [1, 256, 56, 56],
-            [1, 128, 10, 14],
-            [1, 512, 8, 6],
-            [1, 256, 132, 20],
-            [1, 4096, 10, 10],
-        )
-    ),
-)
-@pytest.mark.parametrize(
-    "kernel_size",
-    (
-        (6, 6),
-        (10, 10),
-    ),
-)
-@pytest.mark.parametrize(
-    "padding",
-    (
-        (3, 2),
-        (4, 5),
-    ),
-)
-@pytest.mark.parametrize(
-    "stride",
-    ((1, 1),),
-)
-@pytest.mark.parametrize(
-    "dilation",
-    (
-        (1, 1),
-        (4, 3),
-    ),
-)
-@pytest.mark.parametrize(
-    "in_dtype",
-    [
-        ttnn.bfloat16,
-    ],
-)
-@pytest.mark.parametrize(
-    "ceil_mode",
-    [
-        False,
-    ],
-)
-def test_run_max_pool_block_shard(
-    input_shape,
-    kernel_size,
-    padding,
-    stride,
-    dilation,
-    device,
-    tensor_map,
-    in_dtype,
-    ceil_mode,
-):
-    run_max_pool2d(
-        input_shape,
-        kernel_size,
-        padding,
-        stride,
-        dilation,
-        device,
-        tensor_map,
-        in_dtype,
-        shard_scheme=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
-        ceil_mode=ceil_mode,
-    )
-
-
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
-@pytest.mark.parametrize(
-    "input_shape",  ## NCHW
-    (
-        (
-            [8, 64, 112, 112],
-            [1, 512, 10, 10],
-        )
-    ),
-)
-@pytest.mark.parametrize("memory_config", [ttnn.L1_MEMORY_CONFIG, ttnn.DRAM_MEMORY_CONFIG])
-def test_run_max_pool_mem_config(
-    input_shape,
-    device,
-    tensor_map,
-    memory_config,
-):
-    run_max_pool2d(
-        input_shape,
-        (3, 3),
-        (1, 1),
-        (2, 2),
-        (1, 1),
-        device,
-        tensor_map,
-        ttnn.bfloat16,
-        memory_config=memory_config,
-    )
-
-
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
-@pytest.mark.parametrize(
-    "input_shape",  ## NCHW
-    (([1, 512, 10, 10],)),  ## yolov4 shapes
-)
-@pytest.mark.parametrize(
-    "kernel_size",
-    (
-        (5, 5),
-        (9, 9),
-        (13, 13),
-    ),
-)
-@pytest.mark.parametrize(
-    "padding",
-    (
-        (2, 2),
-        (4, 4),
-        (6, 6),
-    ),
-)
-@pytest.mark.parametrize(
-    "stride",
-    ((1, 1),),
-)
-@pytest.mark.parametrize(
-    "dilation",
-    ((1, 1),),
-)
-@pytest.mark.parametrize("in_dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
-def test_run_max_pool_yolov4(
-    input_shape,
-    kernel_size,
-    padding,
-    stride,
-    dilation,
-    device,
-    tensor_map,
-    in_dtype,
-):
-    run_max_pool2d(input_shape, kernel_size, padding, stride, dilation, device, tensor_map, in_dtype)
-
-
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
-@pytest.mark.parametrize(
-    "input_shape",
-    (([1, 256, 54, 54],)),
+    "input_shape, shard_startegy",
+    # (
+    #     (
+    #         ([1, 64, 112, 112], HS),
+    #         ([1, 280, 10, 10], HS),
+    #         ([1, 384, 32, 32], HS),
+    #         ([1, 256, 132, 20], BS),
+    #         ([1, 512, 8, 6], BS),
+    #         ([2, 4096, 10, 16], WS),
+    #         ([1, 32768, 10, 10], WS),
+    #     )
+    # ),
+    ((([1, 32, 60, 60], HS),)),
 )
 @pytest.mark.parametrize(
     "kernel_size",
     ((3, 3),),
 )
 @pytest.mark.parametrize(
-    "padding",
-    ((0, 0),),
-)
-@pytest.mark.parametrize("stride", ((2, 2),))
-@pytest.mark.parametrize(
-    "dilation",
-    ((1, 1),),
-)
-@pytest.mark.parametrize("in_dtype", [ttnn.bfloat16])
-@pytest.mark.parametrize("ceil_mode", [False, True])
-def test_run_max_pool_squeeze_net_model(
-    input_shape,
-    kernel_size,
-    padding,
-    stride,
-    dilation,
-    device,
-    tensor_map,
-    in_dtype,
-    ceil_mode,
-):
-    run_max_pool2d(
-        input_shape,
-        kernel_size,
-        padding,
-        stride,
-        dilation,
-        device,
-        tensor_map,
-        in_dtype,
-        ceil_mode=ceil_mode,
-    )
-
-
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
-@pytest.mark.parametrize("out_dtype", [ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat4_b])
-@pytest.mark.parametrize("output_layout", [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT])
-@pytest.mark.parametrize(
-    "input_shape, shard_startegy",
-    (
-        (
-            ([1, 64, 112, 112], HS),
-            ([1, 280, 10, 10], HS),
-            ([1, 384, 32, 32], HS),
-            ([1, 256, 132, 20], BS),
-            ([1, 512, 8, 6], BS),
-            ([2, 4096, 10, 16], WS),
-            ([1, 32768, 10, 10], WS),
-        )
-    ),
-)
-@pytest.mark.parametrize(
-    "kernel_size",
-    (
-        (3, 3),
-        (5, 5),
-        (9, 9),
-    ),
-)
-@pytest.mark.parametrize(
     "in_dtype",
     [
         ttnn.bfloat16,
-        ttnn.bfloat8_b,
     ],
 )
 def test_max_pool2d_output_formats_and_layouts(
@@ -613,165 +616,165 @@ def test_max_pool2d_output_formats_and_layouts(
     )
 
 
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 37888}], indirect=True)
-@pytest.mark.parametrize(
-    "input_shape_nchw",
-    (([1, 128, 256, 512],)),
-)
-@pytest.mark.parametrize(
-    "kernel_size",
-    ((3, 3),),
-)
-@pytest.mark.parametrize(
-    "padding",
-    ((1, 1),),
-)
-@pytest.mark.parametrize(
-    "dilation",
-    ((1, 1),),
-)
-@pytest.mark.parametrize(
-    "stride",
-    ((2, 2),),
-)
-@pytest.mark.parametrize("dtype", [ttnn.bfloat8_b])
-def test_panoptic_maxpool_sliced(device, input_shape_nchw, kernel_size, padding, dilation, stride, dtype, tensor_map):
-    num_slices = 2
+# @pytest.mark.parametrize("device_params", [{"l1_small_size": 37888}], indirect=True)
+# @pytest.mark.parametrize(
+#     "input_shape_nchw",
+#     (([1, 128, 256, 512],)),
+# )
+# @pytest.mark.parametrize(
+#     "kernel_size",
+#     ((3, 3),),
+# )
+# @pytest.mark.parametrize(
+#     "padding",
+#     ((1, 1),),
+# )
+# @pytest.mark.parametrize(
+#     "dilation",
+#     ((1, 1),),
+# )
+# @pytest.mark.parametrize(
+#     "stride",
+#     ((2, 2),),
+# )
+# @pytest.mark.parametrize("dtype", [ttnn.bfloat8_b])
+# def test_panoptic_maxpool_sliced(device, input_shape_nchw, kernel_size, padding, dilation, stride, dtype, tensor_map):
+#     num_slices = 2
 
-    batch_size, channels, input_h, input_w = input_shape_nchw
-    assert channels % num_slices == 0, "Channels must be divisible by num_slices"
-    slice_channels = channels // num_slices
+#     batch_size, channels, input_h, input_w = input_shape_nchw
+#     assert channels % num_slices == 0, "Channels must be divisible by num_slices"
+#     slice_channels = channels // num_slices
 
-    logger.info(f"Running Panoptic MaxPool2D with Channel Slicing (slices={num_slices})")
+#     logger.info(f"Running Panoptic MaxPool2D with Channel Slicing (slices={num_slices})")
 
-    torch.manual_seed(0)
-    torch_input_nchw = randomize_torch_tensor(tensor_map, input_shape_nchw)
+#     torch.manual_seed(0)
+#     torch_input_nchw = randomize_torch_tensor(tensor_map, input_shape_nchw)
 
-    torch_output = torch.nn.MaxPool2d(
-        kernel_size=kernel_size,
-        stride=stride,
-        padding=padding,
-        dilation=dilation,
-        return_indices=False,
-        ceil_mode=False,
-    )(torch_input_nchw)
+#     torch_output = torch.nn.MaxPool2d(
+#         kernel_size=kernel_size,
+#         stride=stride,
+#         padding=padding,
+#         dilation=dilation,
+#         return_indices=False,
+#         ceil_mode=False,
+#     )(torch_input_nchw)
 
-    out_h, out_w = torch_output.shape[2], torch_output.shape[3]
+#     out_h, out_w = torch_output.shape[2], torch_output.shape[3]
 
-    ttnn_input_nhwc = ttnn.from_torch(
-        torch_input_nchw.permute(0, 2, 3, 1), device=device, layout=ttnn.TILE_LAYOUT, dtype=dtype
-    )
-    output_slices = []
-    for i in range(num_slices):
-        start_idx = i * slice_channels
-        end_idx = (i + 1) * slice_channels
+#     ttnn_input_nhwc = ttnn.from_torch(
+#         torch_input_nchw.permute(0, 2, 3, 1), device=device, layout=ttnn.TILE_LAYOUT, dtype=dtype
+#     )
+#     output_slices = []
+#     for i in range(num_slices):
+#         start_idx = i * slice_channels
+#         end_idx = (i + 1) * slice_channels
 
-        x_slice = ttnn.slice(ttnn_input_nhwc, [0, 0, 0, start_idx], [batch_size, input_h, input_w, end_idx])
+#         x_slice = ttnn.slice(ttnn_input_nhwc, [0, 0, 0, start_idx], [batch_size, input_h, input_w, end_idx])
 
-        x_slice_reshaped = ttnn.reshape(x_slice, (1, 1, batch_size * input_h * input_w, slice_channels))
-        ttnn.deallocate(x_slice)
+#         x_slice_reshaped = ttnn.reshape(x_slice, (1, 1, batch_size * input_h * input_w, slice_channels))
+#         ttnn.deallocate(x_slice)
 
-        x_slice_pooled = ttnn.max_pool2d(
-            x_slice_reshaped,
-            batch_size=batch_size,
-            input_h=input_h,
-            input_w=input_w,
-            channels=slice_channels,
-            kernel_size=list(kernel_size),
-            stride=list(stride),
-            padding=list(padding),
-            dilation=list(dilation),
-            ceil_mode=False,
-            dtype=ttnn.bfloat8_b,
-            output_layout=ttnn.TILE_LAYOUT,
-        )
-        ttnn.deallocate(x_slice_reshaped)
+#         x_slice_pooled = ttnn.max_pool2d(
+#             x_slice_reshaped,
+#             batch_size=batch_size,
+#             input_h=input_h,
+#             input_w=input_w,
+#             channels=slice_channels,
+#             kernel_size=list(kernel_size),
+#             stride=list(stride),
+#             padding=list(padding),
+#             dilation=list(dilation),
+#             ceil_mode=False,
+#             dtype=ttnn.bfloat8_b,
+#             output_layout=ttnn.TILE_LAYOUT,
+#         )
+#         ttnn.deallocate(x_slice_reshaped)
 
-        x_slice_output_nhwc = ttnn.reshape(x_slice_pooled, (batch_size, out_h, out_w, slice_channels))
-        ttnn.deallocate(x_slice_pooled)
-        x_slice_output_nhwc = ttnn.to_memory_config(x_slice_output_nhwc, ttnn.DRAM_MEMORY_CONFIG)
-        output_slices.append(x_slice_output_nhwc)
+#         x_slice_output_nhwc = ttnn.reshape(x_slice_pooled, (batch_size, out_h, out_w, slice_channels))
+#         ttnn.deallocate(x_slice_pooled)
+#         x_slice_output_nhwc = ttnn.to_memory_config(x_slice_output_nhwc, ttnn.DRAM_MEMORY_CONFIG)
+#         output_slices.append(x_slice_output_nhwc)
 
-    ttnn.deallocate(ttnn_input_nhwc)
-    ttnn_output_nhwc = ttnn.concat(output_slices, dim=3)
-    for s in output_slices:
-        ttnn.deallocate(s)
+#     ttnn.deallocate(ttnn_input_nhwc)
+#     ttnn_output_nhwc = ttnn.concat(output_slices, dim=3)
+#     for s in output_slices:
+#         ttnn.deallocate(s)
 
-    ttnn_output_torch = ttnn.to_torch(ttnn_output_nhwc)
-    ttnn_output_torch_nchw = torch.permute(ttnn_output_torch, (0, 3, 1, 2))
-    ttnn_output_torch_nchw = ttnn_output_torch_nchw.to(torch.bfloat16)
+#     ttnn_output_torch = ttnn.to_torch(ttnn_output_nhwc)
+#     ttnn_output_torch_nchw = torch.permute(ttnn_output_torch, (0, 3, 1, 2))
+#     ttnn_output_torch_nchw = ttnn_output_torch_nchw.to(torch.bfloat16)
 
-    atol = 0.35
-    allclose = torch.allclose(ttnn_output_torch_nchw, torch_output, atol=atol)
-    assert allclose
+#     atol = 0.35
+#     allclose = torch.allclose(ttnn_output_torch_nchw, torch_output, atol=atol)
+#     assert allclose
 
 
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
-@pytest.mark.parametrize("padding", [(0, 0), [0, 0, 0, 0]])
-def test_golden_maxpool2d_with_vovnet_params(device, padding):
-    """
-    Test that golden_maxpool2d function correctly handles VoVNet parameters,
-    specifically the 4D padding format that caused issue #27576.
+# @pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
+# @pytest.mark.parametrize("padding", [(0, 0), [0, 0, 0, 0]])
+# def test_golden_maxpool2d_with_vovnet_params(device, padding):
+#     """
+#     Test that golden_maxpool2d function correctly handles VoVNet parameters,
+#     specifically the 4D padding format that caused issue #27576.
 
-    This test directly compares the golden function output with torch reference
-    to ensure the golden implementation is correct.
-    """
-    from ttnn.operations.pool import golden_maxpool2d
+#     This test directly compares the golden function output with torch reference
+#     to ensure the golden implementation is correct.
+#     """
+#     from ttnn.operations.pool import golden_maxpool2d
 
-    # VoVNet test parameters from the original issue
-    batch_size, in_h, in_w, in_c = 1, 56, 56, 256
-    kernel_size = (3, 3)
-    stride = (2, 2)
-    dilation = (1, 1)
-    ceil_mode = True
+#     # VoVNet test parameters from the original issue
+#     batch_size, in_h, in_w, in_c = 1, 56, 56, 256
+#     kernel_size = (3, 3)
+#     stride = (2, 2)
+#     dilation = (1, 1)
+#     ceil_mode = True
 
-    # Create input tensor
-    torch.manual_seed(0)
-    torch_input = torch.randn(batch_size, in_c, in_h, in_w, dtype=torch.bfloat16)
+#     # Create input tensor
+#     torch.manual_seed(0)
+#     torch_input = torch.randn(batch_size, in_c, in_h, in_w, dtype=torch.bfloat16)
 
-    # Convert to ttnn format for golden function (1, 1, NHW, C)
-    ttnn_format_input = torch_input.permute(0, 2, 3, 1).reshape(1, 1, batch_size * in_h * in_w, in_c)
-    ttnn_input = ttnn.from_torch(ttnn_format_input, device=device)
+#     # Convert to ttnn format for golden function (1, 1, NHW, C)
+#     ttnn_format_input = torch_input.permute(0, 2, 3, 1).reshape(1, 1, batch_size * in_h * in_w, in_c)
+#     ttnn_input = ttnn.from_torch(ttnn_format_input, device=device)
 
-    # Golden function expects a torch tensor that will be converted internally
-    torch_input_for_golden = ttnn.to_torch(ttnn_input)
+#     # Golden function expects a torch tensor that will be converted internally
+#     torch_input_for_golden = ttnn.to_torch(ttnn_input)
 
-    # Test golden function with the given padding format
-    golden_output = golden_maxpool2d(
-        input_tensor=torch_input_for_golden,
-        batch_size=batch_size,
-        input_h=in_h,
-        input_w=in_w,
-        channels=in_c,
-        kernel_size=kernel_size,
-        stride=stride,
-        padding=padding,
-        dilation=dilation,
-        ceil_mode=ceil_mode,
-    )
+#     # Test golden function with the given padding format
+#     golden_output = golden_maxpool2d(
+#         input_tensor=torch_input_for_golden,
+#         batch_size=batch_size,
+#         input_h=in_h,
+#         input_w=in_w,
+#         channels=in_c,
+#         kernel_size=kernel_size,
+#         stride=stride,
+#         padding=padding,
+#         dilation=dilation,
+#         ceil_mode=ceil_mode,
+#     )
 
-    # Run torch reference
-    torch_output = torch.nn.functional.max_pool2d(
-        torch_input,
-        kernel_size=kernel_size,
-        stride=stride,
-        padding=(0, 0),  # torch expects 2D
-        dilation=dilation,
-        ceil_mode=ceil_mode,
-    )
+#     # Run torch reference
+#     torch_output = torch.nn.functional.max_pool2d(
+#         torch_input,
+#         kernel_size=kernel_size,
+#         stride=stride,
+#         padding=(0, 0),  # torch expects 2D
+#         dilation=dilation,
+#         ceil_mode=ceil_mode,
+#     )
 
-    # Convert golden output back to NCHW for comparison
-    # First get the expected output shape
-    expected_out_h = torch_output.shape[2]
-    expected_out_w = torch_output.shape[3]
+#     # Convert golden output back to NCHW for comparison
+#     # First get the expected output shape
+#     expected_out_h = torch_output.shape[2]
+#     expected_out_w = torch_output.shape[3]
 
-    # Reshape golden output from (1, 1, N*H*W, C) to (N, C, H, W)
-    # Golden function returns a torch tensor already
-    golden_torch = golden_output.reshape(batch_size, expected_out_h, expected_out_w, in_c)
-    golden_torch = golden_torch.permute(0, 3, 1, 2)  # NHWC to NCHW
+#     # Reshape golden output from (1, 1, N*H*W, C) to (N, C, H, W)
+#     # Golden function returns a torch tensor already
+#     golden_torch = golden_output.reshape(batch_size, expected_out_h, expected_out_w, in_c)
+#     golden_torch = golden_torch.permute(0, 3, 1, 2)  # NHWC to NCHW
 
-    # Verify golden function produces correct results
-    # For bfloat16 maxpool tests we use torch.equal since we don't expect any loss
-    assert torch.equal(
-        golden_torch, torch_output
-    ), f"Golden function produces incorrect output. Expected shape: {torch_output.shape}, got: {golden_torch.shape}"
+#     # Verify golden function produces correct results
+#     # For bfloat16 maxpool tests we use torch.equal since we don't expect any loss
+#     assert torch.equal(
+#         golden_torch, torch_output
+#     ), f"Golden function produces incorrect output. Expected shape: {torch_output.shape}, got: {golden_torch.shape}"

--- a/tests/ttnn/nightly/unit_tests/operations/pool/test_maxpool2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/pool/test_maxpool2d.py
@@ -29,7 +29,7 @@ def randomize_torch_tensor(tensor_map, tensor_shape):
     if tensor_shape in tensor_map.keys():
         torch_tensor = tensor_map[tensor_shape]
     else:
-        torch_tensor = torch.ones(tensor_shape, dtype=torch.bfloat16)
+        torch_tensor = torch.randn(tensor_shape, dtype=torch.bfloat16)
         tensor_map[tensor_shape] = torch_tensor
 
     return torch_tensor
@@ -567,21 +567,20 @@ def run_max_pool2d(
 
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
 @pytest.mark.parametrize("out_dtype", [ttnn.bfloat16])
-@pytest.mark.parametrize("output_layout", [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT])
+@pytest.mark.parametrize("output_layout", [ttnn.TILE_LAYOUT])
 @pytest.mark.parametrize(
     "input_shape, shard_startegy",
-    # (
-    #     (
-    #         ([1, 64, 112, 112], HS),
-    #         ([1, 280, 10, 10], HS),
-    #         ([1, 384, 32, 32], HS),
-    #         ([1, 256, 132, 20], BS),
-    #         ([1, 512, 8, 6], BS),
-    #         ([2, 4096, 10, 16], WS),
-    #         ([1, 32768, 10, 10], WS),
-    #     )
-    # ),
-    ((([1, 32, 60, 60], HS),)),
+    (
+        (
+            ([1, 64, 112, 112], HS),
+            ([1, 280, 10, 10], HS),
+            ([1, 384, 32, 32], HS),
+            ([1, 256, 132, 20], BS),
+            ([1, 512, 8, 6], BS),
+            ([2, 4096, 10, 16], WS),
+            ([1, 32768, 10, 10], WS),
+        )
+    ),
 )
 @pytest.mark.parametrize(
     "kernel_size",

--- a/tests/ttnn/nightly/unit_tests/operations/pool/test_maxpool2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/pool/test_maxpool2d.py
@@ -29,13 +29,6 @@ def randomize_torch_tensor(tensor_map, tensor_shape):
     if tensor_shape in tensor_map.keys():
         torch_tensor = tensor_map[tensor_shape]
     else:
-        # torch_tensor = torch.zeros(tensor_shape, dtype=torch.bfloat16)
-        # in_n, in_c, in_h, in_w = tensor_shape
-        # for n in range(in_n):
-        #     for c in range(in_c):
-        #         for h in range(in_h):
-        #             for w in range(in_w):
-        #                 torch_tensor[n, c, h, w] = ((h * in_w + w) // 32) * 32
         torch_tensor = torch.randn(tensor_shape, dtype=torch.bfloat16)
         tensor_map[tensor_shape] = torch_tensor
 
@@ -201,373 +194,373 @@ def run_max_pool2d(
         assert allclose
 
 
-# @pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
-# @pytest.mark.parametrize(
-#     "input_shape",  ## NCHW
-#     (
-#         (  # resnet shapes
-#             [1, 64, 112, 112],
-#             [16, 64, 112, 112],
-#             # hpr shapes
-#             [8, 32, 132, 20],
-#             [32, 32, 264, 40],
-#             [4, 16, 1056, 160],
-#             [16, 16, 528, 80],
-#             # wide for vgg
-#             [1, 256, 56, 56],
-#             [1, 512, 28, 28],
-#             # wide yolo kernel
-#             [1, 512, 10, 10],
-#             [1, 96, 112, 112],
-#             [1, 192, 132, 20],
-#             # wide non-8 multiple tests
-#             [1, 800, 32, 32],
-#             [1, 640, 32, 32],
-#             [1, 576, 32, 32],
-#             [1, 384, 32, 32],
-#             # C partial tile test
-#             [1, 16, 12, 12],
-#             [1, 1, 56, 56],
-#             [2, 290, 10, 10],
-#             [1, 280, 10, 10],
-#             # partial grid tests
-#             [1, 32, 10, 10],  # BH
-#             [1, 32, 6, 6],  # WH
-#         )
-#     ),
-# )
-# @pytest.mark.parametrize(
-#     "kernel_size",
-#     (
-#         (3, 3),  # 1 face 1 chunk
-#         (5, 5),  # 2 faces 1 chunk
-#         (7, 7),  # 2 chunks
-#         (9, 9),  # 3 chunks
-#     ),
-# )
-# @pytest.mark.parametrize(
-#     "padding",
-#     (
-#         (0, 0),
-#         (1, 1),
-#         (1, 4, 3, 2),
-#     ),
-# )
-# @pytest.mark.parametrize(
-#     "stride",
-#     (
-#         (1, 1),
-#         (2, 2),
-#     ),
-# )
-# @pytest.mark.parametrize(
-#     "dilation",
-#     (
-#         (1, 1),
-#         (2, 2),
-#     ),
-# )
-# @pytest.mark.parametrize(
-#     "in_dtype",
-#     [
-#         ttnn.bfloat16,
-#         ttnn.bfloat8_b,
-#     ],
-# )
-# @pytest.mark.parametrize(
-#     "ceil_mode",
-#     [
-#         False,
-#         True,
-#     ],
-# )
-# def test_run_max_pool_height_shard(
-#     input_shape, kernel_size, padding, stride, dilation, device, tensor_map, in_dtype, ceil_mode
-# ):
-#     run_max_pool2d(
-#         input_shape,
-#         kernel_size,
-#         padding,
-#         stride,
-#         dilation,
-#         device,
-#         tensor_map,
-#         in_dtype,
-#         shard_scheme=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
-#         ceil_mode=ceil_mode,
-#     )
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
+@pytest.mark.parametrize(
+    "input_shape",  ## NCHW
+    (
+        (  # resnet shapes
+            [1, 64, 112, 112],
+            [16, 64, 112, 112],
+            # hpr shapes
+            [8, 32, 132, 20],
+            [32, 32, 264, 40],
+            [4, 16, 1056, 160],
+            [16, 16, 528, 80],
+            # wide for vgg
+            [1, 256, 56, 56],
+            [1, 512, 28, 28],
+            # wide yolo kernel
+            [1, 512, 10, 10],
+            [1, 96, 112, 112],
+            [1, 192, 132, 20],
+            # wide non-8 multiple tests
+            [1, 800, 32, 32],
+            [1, 640, 32, 32],
+            [1, 576, 32, 32],
+            [1, 384, 32, 32],
+            # C partial tile test
+            [1, 16, 12, 12],
+            [1, 1, 56, 56],
+            [2, 290, 10, 10],
+            [1, 280, 10, 10],
+            # partial grid tests
+            [1, 32, 10, 10],  # BH
+            [1, 32, 6, 6],  # WH
+        )
+    ),
+)
+@pytest.mark.parametrize(
+    "kernel_size",
+    (
+        (3, 3),  # 1 face 1 chunk
+        (5, 5),  # 2 faces 1 chunk
+        (7, 7),  # 2 chunks
+        (9, 9),  # 3 chunks
+    ),
+)
+@pytest.mark.parametrize(
+    "padding",
+    (
+        (0, 0),
+        (1, 1),
+        (1, 4, 3, 2),
+    ),
+)
+@pytest.mark.parametrize(
+    "stride",
+    (
+        (1, 1),
+        (2, 2),
+    ),
+)
+@pytest.mark.parametrize(
+    "dilation",
+    (
+        (1, 1),
+        (2, 2),
+    ),
+)
+@pytest.mark.parametrize(
+    "in_dtype",
+    [
+        ttnn.bfloat16,
+        ttnn.bfloat8_b,
+    ],
+)
+@pytest.mark.parametrize(
+    "ceil_mode",
+    [
+        False,
+        True,
+    ],
+)
+def test_run_max_pool_height_shard(
+    input_shape, kernel_size, padding, stride, dilation, device, tensor_map, in_dtype, ceil_mode
+):
+    run_max_pool2d(
+        input_shape,
+        kernel_size,
+        padding,
+        stride,
+        dilation,
+        device,
+        tensor_map,
+        in_dtype,
+        shard_scheme=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        ceil_mode=ceil_mode,
+    )
 
 
-# @pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
-# @pytest.mark.parametrize(
-#     "input_shape",  ## NCHW
-#     (
-#         (
-#             [1, 2048, 28, 28],
-#             [1, 1024, 6, 6],
-#             [1, 2048, 132, 20],
-#             [2, 4096, 10, 16],
-#             [1, 32768, 10, 10],
-#         )
-#     ),
-# )
-# @pytest.mark.parametrize(
-#     "kernel_size",
-#     (
-#         (5, 5),
-#         (9, 9),
-#     ),
-# )
-# @pytest.mark.parametrize(
-#     "padding",
-#     (
-#         (1, 2),
-#         (4, 2),
-#     ),
-# )
-# @pytest.mark.parametrize(
-#     "stride",
-#     ((1, 1),),
-# )
-# @pytest.mark.parametrize(
-#     "dilation",
-#     (
-#         (1, 1),
-#         (3, 1),
-#     ),
-# )
-# @pytest.mark.parametrize(
-#     "in_dtype",
-#     [
-#         ttnn.bfloat16,
-#     ],
-# )
-# @pytest.mark.parametrize(
-#     "ceil_mode",
-#     [
-#         False,
-#     ],
-# )
-# def test_run_max_pool_width_shard(
-#     input_shape,
-#     kernel_size,
-#     padding,
-#     stride,
-#     dilation,
-#     device,
-#     tensor_map,
-#     in_dtype,
-#     ceil_mode,
-# ):
-#     run_max_pool2d(
-#         input_shape,
-#         kernel_size,
-#         padding,
-#         stride,
-#         dilation,
-#         device,
-#         tensor_map,
-#         in_dtype,
-#         shard_scheme=ttnn.TensorMemoryLayout.WIDTH_SHARDED,
-#         ceil_mode=ceil_mode,
-#     )
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
+@pytest.mark.parametrize(
+    "input_shape",  ## NCHW
+    (
+        (
+            [1, 2048, 28, 28],
+            [1, 1024, 6, 6],
+            [1, 2048, 132, 20],
+            [2, 4096, 10, 16],
+            [1, 32768, 10, 10],
+        )
+    ),
+)
+@pytest.mark.parametrize(
+    "kernel_size",
+    (
+        (5, 5),
+        (9, 9),
+    ),
+)
+@pytest.mark.parametrize(
+    "padding",
+    (
+        (1, 2),
+        (4, 2),
+    ),
+)
+@pytest.mark.parametrize(
+    "stride",
+    ((1, 1),),
+)
+@pytest.mark.parametrize(
+    "dilation",
+    (
+        (1, 1),
+        (3, 1),
+    ),
+)
+@pytest.mark.parametrize(
+    "in_dtype",
+    [
+        ttnn.bfloat16,
+    ],
+)
+@pytest.mark.parametrize(
+    "ceil_mode",
+    [
+        False,
+    ],
+)
+def test_run_max_pool_width_shard(
+    input_shape,
+    kernel_size,
+    padding,
+    stride,
+    dilation,
+    device,
+    tensor_map,
+    in_dtype,
+    ceil_mode,
+):
+    run_max_pool2d(
+        input_shape,
+        kernel_size,
+        padding,
+        stride,
+        dilation,
+        device,
+        tensor_map,
+        in_dtype,
+        shard_scheme=ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ceil_mode=ceil_mode,
+    )
 
 
-# @pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
-# @pytest.mark.parametrize(
-#     "input_shape",  ## NCHW
-#     (
-#         (
-#             [1, 256, 56, 56],
-#             [1, 128, 10, 14],
-#             [1, 512, 8, 6],
-#             [1, 256, 132, 20],
-#             [1, 4096, 10, 10],
-#         )
-#     ),
-# )
-# @pytest.mark.parametrize(
-#     "kernel_size",
-#     (
-#         (6, 6),
-#         (10, 10),
-#     ),
-# )
-# @pytest.mark.parametrize(
-#     "padding",
-#     (
-#         (3, 2),
-#         (4, 5),
-#     ),
-# )
-# @pytest.mark.parametrize(
-#     "stride",
-#     ((1, 1),),
-# )
-# @pytest.mark.parametrize(
-#     "dilation",
-#     (
-#         (1, 1),
-#         (4, 3),
-#     ),
-# )
-# @pytest.mark.parametrize(
-#     "in_dtype",
-#     [
-#         ttnn.bfloat16,
-#     ],
-# )
-# @pytest.mark.parametrize(
-#     "ceil_mode",
-#     [
-#         False,
-#     ],
-# )
-# def test_run_max_pool_block_shard(
-#     input_shape,
-#     kernel_size,
-#     padding,
-#     stride,
-#     dilation,
-#     device,
-#     tensor_map,
-#     in_dtype,
-#     ceil_mode,
-# ):
-#     run_max_pool2d(
-#         input_shape,
-#         kernel_size,
-#         padding,
-#         stride,
-#         dilation,
-#         device,
-#         tensor_map,
-#         in_dtype,
-#         shard_scheme=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
-#         ceil_mode=ceil_mode,
-#     )
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
+@pytest.mark.parametrize(
+    "input_shape",  ## NCHW
+    (
+        (
+            [1, 256, 56, 56],
+            [1, 128, 10, 14],
+            [1, 512, 8, 6],
+            [1, 256, 132, 20],
+            [1, 4096, 10, 10],
+        )
+    ),
+)
+@pytest.mark.parametrize(
+    "kernel_size",
+    (
+        (6, 6),
+        (10, 10),
+    ),
+)
+@pytest.mark.parametrize(
+    "padding",
+    (
+        (3, 2),
+        (4, 5),
+    ),
+)
+@pytest.mark.parametrize(
+    "stride",
+    ((1, 1),),
+)
+@pytest.mark.parametrize(
+    "dilation",
+    (
+        (1, 1),
+        (4, 3),
+    ),
+)
+@pytest.mark.parametrize(
+    "in_dtype",
+    [
+        ttnn.bfloat16,
+    ],
+)
+@pytest.mark.parametrize(
+    "ceil_mode",
+    [
+        False,
+    ],
+)
+def test_run_max_pool_block_shard(
+    input_shape,
+    kernel_size,
+    padding,
+    stride,
+    dilation,
+    device,
+    tensor_map,
+    in_dtype,
+    ceil_mode,
+):
+    run_max_pool2d(
+        input_shape,
+        kernel_size,
+        padding,
+        stride,
+        dilation,
+        device,
+        tensor_map,
+        in_dtype,
+        shard_scheme=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+        ceil_mode=ceil_mode,
+    )
 
 
-# @pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
-# @pytest.mark.parametrize(
-#     "input_shape",  ## NCHW
-#     (
-#         (
-#             [8, 64, 112, 112],
-#             [1, 512, 10, 10],
-#         )
-#     ),
-# )
-# @pytest.mark.parametrize("memory_config", [ttnn.L1_MEMORY_CONFIG, ttnn.DRAM_MEMORY_CONFIG])
-# def test_run_max_pool_mem_config(
-#     input_shape,
-#     device,
-#     tensor_map,
-#     memory_config,
-# ):
-#     run_max_pool2d(
-#         input_shape,
-#         (3, 3),
-#         (1, 1),
-#         (2, 2),
-#         (1, 1),
-#         device,
-#         tensor_map,
-#         ttnn.bfloat16,
-#         memory_config=memory_config,
-#     )
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
+@pytest.mark.parametrize(
+    "input_shape",  ## NCHW
+    (
+        (
+            [8, 64, 112, 112],
+            [1, 512, 10, 10],
+        )
+    ),
+)
+@pytest.mark.parametrize("memory_config", [ttnn.L1_MEMORY_CONFIG, ttnn.DRAM_MEMORY_CONFIG])
+def test_run_max_pool_mem_config(
+    input_shape,
+    device,
+    tensor_map,
+    memory_config,
+):
+    run_max_pool2d(
+        input_shape,
+        (3, 3),
+        (1, 1),
+        (2, 2),
+        (1, 1),
+        device,
+        tensor_map,
+        ttnn.bfloat16,
+        memory_config=memory_config,
+    )
 
 
-# @pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
-# @pytest.mark.parametrize(
-#     "input_shape",  ## NCHW
-#     (([1, 512, 10, 10],)),  ## yolov4 shapes
-# )
-# @pytest.mark.parametrize(
-#     "kernel_size",
-#     (
-#         (5, 5),
-#         (9, 9),
-#         (13, 13),
-#     ),
-# )
-# @pytest.mark.parametrize(
-#     "padding",
-#     (
-#         (2, 2),
-#         (4, 4),
-#         (6, 6),
-#     ),
-# )
-# @pytest.mark.parametrize(
-#     "stride",
-#     ((1, 1),),
-# )
-# @pytest.mark.parametrize(
-#     "dilation",
-#     ((1, 1),),
-# )
-# @pytest.mark.parametrize("in_dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
-# def test_run_max_pool_yolov4(
-#     input_shape,
-#     kernel_size,
-#     padding,
-#     stride,
-#     dilation,
-#     device,
-#     tensor_map,
-#     in_dtype,
-# ):
-#     run_max_pool2d(input_shape, kernel_size, padding, stride, dilation, device, tensor_map, in_dtype)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
+@pytest.mark.parametrize(
+    "input_shape",  ## NCHW
+    (([1, 512, 10, 10],)),  ## yolov4 shapes
+)
+@pytest.mark.parametrize(
+    "kernel_size",
+    (
+        (5, 5),
+        (9, 9),
+        (13, 13),
+    ),
+)
+@pytest.mark.parametrize(
+    "padding",
+    (
+        (2, 2),
+        (4, 4),
+        (6, 6),
+    ),
+)
+@pytest.mark.parametrize(
+    "stride",
+    ((1, 1),),
+)
+@pytest.mark.parametrize(
+    "dilation",
+    ((1, 1),),
+)
+@pytest.mark.parametrize("in_dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
+def test_run_max_pool_yolov4(
+    input_shape,
+    kernel_size,
+    padding,
+    stride,
+    dilation,
+    device,
+    tensor_map,
+    in_dtype,
+):
+    run_max_pool2d(input_shape, kernel_size, padding, stride, dilation, device, tensor_map, in_dtype)
 
 
-# @pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
-# @pytest.mark.parametrize(
-#     "input_shape",
-#     (([1, 256, 54, 54],)),
-# )
-# @pytest.mark.parametrize(
-#     "kernel_size",
-#     ((3, 3),),
-# )
-# @pytest.mark.parametrize(
-#     "padding",
-#     ((0, 0),),
-# )
-# @pytest.mark.parametrize("stride", ((2, 2),))
-# @pytest.mark.parametrize(
-#     "dilation",
-#     ((1, 1),),
-# )
-# @pytest.mark.parametrize("in_dtype", [ttnn.bfloat16])
-# @pytest.mark.parametrize("ceil_mode", [False, True])
-# def test_run_max_pool_squeeze_net_model(
-#     input_shape,
-#     kernel_size,
-#     padding,
-#     stride,
-#     dilation,
-#     device,
-#     tensor_map,
-#     in_dtype,
-#     ceil_mode,
-# ):
-#     run_max_pool2d(
-#         input_shape,
-#         kernel_size,
-#         padding,
-#         stride,
-#         dilation,
-#         device,
-#         tensor_map,
-#         in_dtype,
-#         ceil_mode=ceil_mode,
-#     )
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
+@pytest.mark.parametrize(
+    "input_shape",
+    (([1, 256, 54, 54],)),
+)
+@pytest.mark.parametrize(
+    "kernel_size",
+    ((3, 3),),
+)
+@pytest.mark.parametrize(
+    "padding",
+    ((0, 0),),
+)
+@pytest.mark.parametrize("stride", ((2, 2),))
+@pytest.mark.parametrize(
+    "dilation",
+    ((1, 1),),
+)
+@pytest.mark.parametrize("in_dtype", [ttnn.bfloat16])
+@pytest.mark.parametrize("ceil_mode", [False, True])
+def test_run_max_pool_squeeze_net_model(
+    input_shape,
+    kernel_size,
+    padding,
+    stride,
+    dilation,
+    device,
+    tensor_map,
+    in_dtype,
+    ceil_mode,
+):
+    run_max_pool2d(
+        input_shape,
+        kernel_size,
+        padding,
+        stride,
+        dilation,
+        device,
+        tensor_map,
+        in_dtype,
+        ceil_mode=ceil_mode,
+    )
 
 
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
 @pytest.mark.parametrize("out_dtype", [ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat4_b])
-@pytest.mark.parametrize("output_layout", [ttnn.TILE_LAYOUT])
+@pytest.mark.parametrize("output_layout", [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT])
 @pytest.mark.parametrize(
     "input_shape, shard_startegy",
     (
@@ -620,165 +613,165 @@ def test_max_pool2d_output_formats_and_layouts(
     )
 
 
-# @pytest.mark.parametrize("device_params", [{"l1_small_size": 37888}], indirect=True)
-# @pytest.mark.parametrize(
-#     "input_shape_nchw",
-#     (([1, 128, 256, 512],)),
-# )
-# @pytest.mark.parametrize(
-#     "kernel_size",
-#     ((3, 3),),
-# )
-# @pytest.mark.parametrize(
-#     "padding",
-#     ((1, 1),),
-# )
-# @pytest.mark.parametrize(
-#     "dilation",
-#     ((1, 1),),
-# )
-# @pytest.mark.parametrize(
-#     "stride",
-#     ((2, 2),),
-# )
-# @pytest.mark.parametrize("dtype", [ttnn.bfloat8_b])
-# def test_panoptic_maxpool_sliced(device, input_shape_nchw, kernel_size, padding, dilation, stride, dtype, tensor_map):
-#     num_slices = 2
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 37888}], indirect=True)
+@pytest.mark.parametrize(
+    "input_shape_nchw",
+    (([1, 128, 256, 512],)),
+)
+@pytest.mark.parametrize(
+    "kernel_size",
+    ((3, 3),),
+)
+@pytest.mark.parametrize(
+    "padding",
+    ((1, 1),),
+)
+@pytest.mark.parametrize(
+    "dilation",
+    ((1, 1),),
+)
+@pytest.mark.parametrize(
+    "stride",
+    ((2, 2),),
+)
+@pytest.mark.parametrize("dtype", [ttnn.bfloat8_b])
+def test_panoptic_maxpool_sliced(device, input_shape_nchw, kernel_size, padding, dilation, stride, dtype, tensor_map):
+    num_slices = 2
 
-#     batch_size, channels, input_h, input_w = input_shape_nchw
-#     assert channels % num_slices == 0, "Channels must be divisible by num_slices"
-#     slice_channels = channels // num_slices
+    batch_size, channels, input_h, input_w = input_shape_nchw
+    assert channels % num_slices == 0, "Channels must be divisible by num_slices"
+    slice_channels = channels // num_slices
 
-#     logger.info(f"Running Panoptic MaxPool2D with Channel Slicing (slices={num_slices})")
+    logger.info(f"Running Panoptic MaxPool2D with Channel Slicing (slices={num_slices})")
 
-#     torch.manual_seed(0)
-#     torch_input_nchw = randomize_torch_tensor(tensor_map, input_shape_nchw)
+    torch.manual_seed(0)
+    torch_input_nchw = randomize_torch_tensor(tensor_map, input_shape_nchw)
 
-#     torch_output = torch.nn.MaxPool2d(
-#         kernel_size=kernel_size,
-#         stride=stride,
-#         padding=padding,
-#         dilation=dilation,
-#         return_indices=False,
-#         ceil_mode=False,
-#     )(torch_input_nchw)
+    torch_output = torch.nn.MaxPool2d(
+        kernel_size=kernel_size,
+        stride=stride,
+        padding=padding,
+        dilation=dilation,
+        return_indices=False,
+        ceil_mode=False,
+    )(torch_input_nchw)
 
-#     out_h, out_w = torch_output.shape[2], torch_output.shape[3]
+    out_h, out_w = torch_output.shape[2], torch_output.shape[3]
 
-#     ttnn_input_nhwc = ttnn.from_torch(
-#         torch_input_nchw.permute(0, 2, 3, 1), device=device, layout=ttnn.TILE_LAYOUT, dtype=dtype
-#     )
-#     output_slices = []
-#     for i in range(num_slices):
-#         start_idx = i * slice_channels
-#         end_idx = (i + 1) * slice_channels
+    ttnn_input_nhwc = ttnn.from_torch(
+        torch_input_nchw.permute(0, 2, 3, 1), device=device, layout=ttnn.TILE_LAYOUT, dtype=dtype
+    )
+    output_slices = []
+    for i in range(num_slices):
+        start_idx = i * slice_channels
+        end_idx = (i + 1) * slice_channels
 
-#         x_slice = ttnn.slice(ttnn_input_nhwc, [0, 0, 0, start_idx], [batch_size, input_h, input_w, end_idx])
+        x_slice = ttnn.slice(ttnn_input_nhwc, [0, 0, 0, start_idx], [batch_size, input_h, input_w, end_idx])
 
-#         x_slice_reshaped = ttnn.reshape(x_slice, (1, 1, batch_size * input_h * input_w, slice_channels))
-#         ttnn.deallocate(x_slice)
+        x_slice_reshaped = ttnn.reshape(x_slice, (1, 1, batch_size * input_h * input_w, slice_channels))
+        ttnn.deallocate(x_slice)
 
-#         x_slice_pooled = ttnn.max_pool2d(
-#             x_slice_reshaped,
-#             batch_size=batch_size,
-#             input_h=input_h,
-#             input_w=input_w,
-#             channels=slice_channels,
-#             kernel_size=list(kernel_size),
-#             stride=list(stride),
-#             padding=list(padding),
-#             dilation=list(dilation),
-#             ceil_mode=False,
-#             dtype=ttnn.bfloat8_b,
-#             output_layout=ttnn.TILE_LAYOUT,
-#         )
-#         ttnn.deallocate(x_slice_reshaped)
+        x_slice_pooled = ttnn.max_pool2d(
+            x_slice_reshaped,
+            batch_size=batch_size,
+            input_h=input_h,
+            input_w=input_w,
+            channels=slice_channels,
+            kernel_size=list(kernel_size),
+            stride=list(stride),
+            padding=list(padding),
+            dilation=list(dilation),
+            ceil_mode=False,
+            dtype=ttnn.bfloat8_b,
+            output_layout=ttnn.TILE_LAYOUT,
+        )
+        ttnn.deallocate(x_slice_reshaped)
 
-#         x_slice_output_nhwc = ttnn.reshape(x_slice_pooled, (batch_size, out_h, out_w, slice_channels))
-#         ttnn.deallocate(x_slice_pooled)
-#         x_slice_output_nhwc = ttnn.to_memory_config(x_slice_output_nhwc, ttnn.DRAM_MEMORY_CONFIG)
-#         output_slices.append(x_slice_output_nhwc)
+        x_slice_output_nhwc = ttnn.reshape(x_slice_pooled, (batch_size, out_h, out_w, slice_channels))
+        ttnn.deallocate(x_slice_pooled)
+        x_slice_output_nhwc = ttnn.to_memory_config(x_slice_output_nhwc, ttnn.DRAM_MEMORY_CONFIG)
+        output_slices.append(x_slice_output_nhwc)
 
-#     ttnn.deallocate(ttnn_input_nhwc)
-#     ttnn_output_nhwc = ttnn.concat(output_slices, dim=3)
-#     for s in output_slices:
-#         ttnn.deallocate(s)
+    ttnn.deallocate(ttnn_input_nhwc)
+    ttnn_output_nhwc = ttnn.concat(output_slices, dim=3)
+    for s in output_slices:
+        ttnn.deallocate(s)
 
-#     ttnn_output_torch = ttnn.to_torch(ttnn_output_nhwc)
-#     ttnn_output_torch_nchw = torch.permute(ttnn_output_torch, (0, 3, 1, 2))
-#     ttnn_output_torch_nchw = ttnn_output_torch_nchw.to(torch.bfloat16)
+    ttnn_output_torch = ttnn.to_torch(ttnn_output_nhwc)
+    ttnn_output_torch_nchw = torch.permute(ttnn_output_torch, (0, 3, 1, 2))
+    ttnn_output_torch_nchw = ttnn_output_torch_nchw.to(torch.bfloat16)
 
-#     atol = 0.35
-#     allclose = torch.allclose(ttnn_output_torch_nchw, torch_output, atol=atol)
-#     assert allclose
+    atol = 0.35
+    allclose = torch.allclose(ttnn_output_torch_nchw, torch_output, atol=atol)
+    assert allclose
 
 
-# @pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
-# @pytest.mark.parametrize("padding", [(0, 0), [0, 0, 0, 0]])
-# def test_golden_maxpool2d_with_vovnet_params(device, padding):
-#     """
-#     Test that golden_maxpool2d function correctly handles VoVNet parameters,
-#     specifically the 4D padding format that caused issue #27576.
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
+@pytest.mark.parametrize("padding", [(0, 0), [0, 0, 0, 0]])
+def test_golden_maxpool2d_with_vovnet_params(device, padding):
+    """
+    Test that golden_maxpool2d function correctly handles VoVNet parameters,
+    specifically the 4D padding format that caused issue #27576.
 
-#     This test directly compares the golden function output with torch reference
-#     to ensure the golden implementation is correct.
-#     """
-#     from ttnn.operations.pool import golden_maxpool2d
+    This test directly compares the golden function output with torch reference
+    to ensure the golden implementation is correct.
+    """
+    from ttnn.operations.pool import golden_maxpool2d
 
-#     # VoVNet test parameters from the original issue
-#     batch_size, in_h, in_w, in_c = 1, 56, 56, 256
-#     kernel_size = (3, 3)
-#     stride = (2, 2)
-#     dilation = (1, 1)
-#     ceil_mode = True
+    # VoVNet test parameters from the original issue
+    batch_size, in_h, in_w, in_c = 1, 56, 56, 256
+    kernel_size = (3, 3)
+    stride = (2, 2)
+    dilation = (1, 1)
+    ceil_mode = True
 
-#     # Create input tensor
-#     torch.manual_seed(0)
-#     torch_input = torch.randn(batch_size, in_c, in_h, in_w, dtype=torch.bfloat16)
+    # Create input tensor
+    torch.manual_seed(0)
+    torch_input = torch.randn(batch_size, in_c, in_h, in_w, dtype=torch.bfloat16)
 
-#     # Convert to ttnn format for golden function (1, 1, NHW, C)
-#     ttnn_format_input = torch_input.permute(0, 2, 3, 1).reshape(1, 1, batch_size * in_h * in_w, in_c)
-#     ttnn_input = ttnn.from_torch(ttnn_format_input, device=device)
+    # Convert to ttnn format for golden function (1, 1, NHW, C)
+    ttnn_format_input = torch_input.permute(0, 2, 3, 1).reshape(1, 1, batch_size * in_h * in_w, in_c)
+    ttnn_input = ttnn.from_torch(ttnn_format_input, device=device)
 
-#     # Golden function expects a torch tensor that will be converted internally
-#     torch_input_for_golden = ttnn.to_torch(ttnn_input)
+    # Golden function expects a torch tensor that will be converted internally
+    torch_input_for_golden = ttnn.to_torch(ttnn_input)
 
-#     # Test golden function with the given padding format
-#     golden_output = golden_maxpool2d(
-#         input_tensor=torch_input_for_golden,
-#         batch_size=batch_size,
-#         input_h=in_h,
-#         input_w=in_w,
-#         channels=in_c,
-#         kernel_size=kernel_size,
-#         stride=stride,
-#         padding=padding,
-#         dilation=dilation,
-#         ceil_mode=ceil_mode,
-#     )
+    # Test golden function with the given padding format
+    golden_output = golden_maxpool2d(
+        input_tensor=torch_input_for_golden,
+        batch_size=batch_size,
+        input_h=in_h,
+        input_w=in_w,
+        channels=in_c,
+        kernel_size=kernel_size,
+        stride=stride,
+        padding=padding,
+        dilation=dilation,
+        ceil_mode=ceil_mode,
+    )
 
-#     # Run torch reference
-#     torch_output = torch.nn.functional.max_pool2d(
-#         torch_input,
-#         kernel_size=kernel_size,
-#         stride=stride,
-#         padding=(0, 0),  # torch expects 2D
-#         dilation=dilation,
-#         ceil_mode=ceil_mode,
-#     )
+    # Run torch reference
+    torch_output = torch.nn.functional.max_pool2d(
+        torch_input,
+        kernel_size=kernel_size,
+        stride=stride,
+        padding=(0, 0),  # torch expects 2D
+        dilation=dilation,
+        ceil_mode=ceil_mode,
+    )
 
-#     # Convert golden output back to NCHW for comparison
-#     # First get the expected output shape
-#     expected_out_h = torch_output.shape[2]
-#     expected_out_w = torch_output.shape[3]
+    # Convert golden output back to NCHW for comparison
+    # First get the expected output shape
+    expected_out_h = torch_output.shape[2]
+    expected_out_w = torch_output.shape[3]
 
-#     # Reshape golden output from (1, 1, N*H*W, C) to (N, C, H, W)
-#     # Golden function returns a torch tensor already
-#     golden_torch = golden_output.reshape(batch_size, expected_out_h, expected_out_w, in_c)
-#     golden_torch = golden_torch.permute(0, 3, 1, 2)  # NHWC to NCHW
+    # Reshape golden output from (1, 1, N*H*W, C) to (N, C, H, W)
+    # Golden function returns a torch tensor already
+    golden_torch = golden_output.reshape(batch_size, expected_out_h, expected_out_w, in_c)
+    golden_torch = golden_torch.permute(0, 3, 1, 2)  # NHWC to NCHW
 
-#     # Verify golden function produces correct results
-#     # For bfloat16 maxpool tests we use torch.equal since we don't expect any loss
-#     assert torch.equal(
-#         golden_torch, torch_output
-#     ), f"Golden function produces incorrect output. Expected shape: {torch_output.shape}, got: {golden_torch.shape}"
+    # Verify golden function produces correct results
+    # For bfloat16 maxpool tests we use torch.equal since we don't expect any loss
+    assert torch.equal(
+        golden_torch, torch_output
+    ), f"Golden function produces incorrect output. Expected shape: {torch_output.shape}, got: {golden_torch.shape}"

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_pool_2d.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_pool_2d.cpp
@@ -290,15 +290,13 @@ void MAIN {
                         tensix_sync();
                         pack_reconfig_data_format(out_cb_id);
 
-                        PACK(tt::compute::common::print_full_tile(pre_tilize_cb_id));
-
                         tilize_init(pre_tilize_cb_id, in_ntiles_c, out_cb_id);
                         tilize_block(pre_tilize_cb_id, in_ntiles_c, out_cb_id);
                         tilize_uninit(pre_tilize_cb_id, out_cb_id);
 
-                        PACK(tt::compute::common::print_full_tile(out_cb_id));
-
                         cb_push_back(out_cb_id, in_ntiles_c);
+                        cb_pop_front(pre_tilize_cb_id, TILE_HEIGHT * in_ntiles_c);
+                        cb_reserve_back(pre_tilize_cb_id, in_ntiles_c * TILE_HEIGHT);
 
                         if constexpr (is_output_block_format) {
                             pack_reconfig_data_format(pre_tilize_cb_id);

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_pool_2d.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_pool_2d.cpp
@@ -266,6 +266,7 @@ void MAIN {
                     if (tilize_stick_counter == TILE_HEIGHT ||
                         (last_tile && tilize_stick_counter == last_tile_height)) {
                         if (last_tile && last_tile_height != TILE_HEIGHT) {
+                            cb_wait_front(pre_tilize_cb_id, last_tile_height * in_ntiles_c);
                             // if the last tile is not whole we won't have pushed enough sticks, so we need to
                             // push some filler sticks to reach TILE_HEIGHT to make sure the CB pointers are correct
                             // before calling tilize
@@ -275,6 +276,7 @@ void MAIN {
                             cb_push_back(pre_tilize_cb_id, filler_stick_tiles);
                             PACK(DPRINT << "Pushing filler sticks: " << filler_stick_tiles << "\n");
                         }
+                        cb_wait_front(pre_tilize_cb_id, TILE_HEIGHT * in_ntiles_c);
                         PACK(DPRINT << "PACKING TILE\n");
                         PACK((pack_untilize_uninit(pre_tilize_cb_id)));
 
@@ -290,9 +292,9 @@ void MAIN {
 
                         PACK(tt::compute::common::print_full_tile(pre_tilize_cb_id));
 
-                        fast_tilize_init(pre_tilize_cb_id, in_ntiles_c, out_cb_id);
-                        fast_tilize_block(pre_tilize_cb_id, in_ntiles_c, out_cb_id);
-                        fast_tilize_uninit(pre_tilize_cb_id, out_cb_id);
+                        tilize_init(pre_tilize_cb_id, in_ntiles_c, out_cb_id);
+                        tilize_block(pre_tilize_cb_id, in_ntiles_c, out_cb_id);
+                        tilize_uninit(pre_tilize_cb_id, out_cb_id);
 
                         PACK(tt::compute::common::print_full_tile(out_cb_id));
 

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/dataflow/reader_pool_2d.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/dataflow/reader_pool_2d.cpp
@@ -111,8 +111,8 @@ ALWI void initialize_return_indices_data() {
     // Calculate initial index based on padding conditions
     uint16_t init_index = 0;
     constexpr uint32_t eff_kernel_w = (kernel_w - 1) * dilation_w + 1;
-    const uint16_t start_row = (uint16_t)get_arg_val<uint32_t>(0);
-    const uint16_t start_col = (uint16_t)get_arg_val<uint32_t>(1);
+    const uint16_t start_row = (uint16_t)get_arg_val<uint32_t>(1);
+    const uint16_t start_col = (uint16_t)get_arg_val<uint32_t>(2);
 
     if (start_row <= pad_t) {
         // top left is in top padding, we increment from the padding index in the top left
@@ -517,7 +517,7 @@ void kernel_main() {
     }
 
     uint16_t num_segments = reader_indices_ptr[0] & 0xffff;
-    bool first_row_value = reader_id == 0;
+    bool first_row_value = reader_id == 0 || !use_split_reader;
 
     uint32_t reader_indices_on_core = 0;
 
@@ -583,43 +583,5 @@ void kernel_main() {
                 first_row_value = false;
             }
         }
-    }
-
-    while (reader_indices_on_core--) {
-        if constexpr (!one_scalar_per_core) {
-            fill_scalar<
-                one_scalar_per_core,
-                in_scalar_cb_id,
-                reader_nindices,
-                use_split_reader,
-                multi_buffering_factor>(scalar_start, scalar_end, scalar_value, scalar_index, counter, config_ptr);
-        }
-        read_kernel_with_top_left_index<
-            in_nblocks_c,
-            in_cb_id,
-            kernel_h,
-            kernel_w,
-            in_w_padded,
-            in_nbytes_leftover,
-            in_c,
-            max_sticks_for_reduction,
-            total_elems_to_reduce,
-            is_avg_pool,
-            wide_reduction,
-            clear_value_cb_id,
-            in_cb_ntiles,
-            in_nbytes_c,
-            shard_width_bytes,
-            is_large_kernel,
-            last_tile_is_partial,
-            dilation_h,
-            dilation_w,
-            return_indices,
-            zero_pages,
-            out_cb_id,
-            out_idx_cb_id,
-            reader_id,
-            pack_tmp_cb_id,
-            pack_idx_tmp_cb_id>(0, in_l1_read_base_addr);
     }
 }  // kernel_main()

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/pool_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/pool_multi_core_program_factory.cpp
@@ -724,7 +724,7 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
         }
         uint32_t out_nhw_this_core = std::min(out_nhw_per_core, total_out_nhw - total_out_nhw_processed);
         std::vector<uint32_t> args = {out_nhw_this_core};
-        printf("core (%d, %d) will process %d out_nhw\n", core_x_i, core_y_i, out_nhw_this_core);
+
         if (return_indices) {
             TT_FATAL(core_starting_indices.size() == ncores, "core starting indices size should match number of cores");
             const uint32_t start_index = core_starting_indices[core_i];

--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/device/grid_sample_bilinear_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/device/grid_sample_bilinear_program_factory.cpp
@@ -227,31 +227,16 @@ GridSampleBilinearProgramFactory::cached_program_t GridSampleBilinearProgramFact
             input_cb_index_1,                  // ct_arg[8]: input_cb_index_1
             scalar_cb_index_0,                 // ct_arg[9]: scalar_cb_index_0
             scalar_cb_index_1,                 // ct_arg[10]: scalar_cb_index_1
-            DUMMY_CB_ID,                       // ct_arg[11]: unused
-            DUMMY_CB_ID,                       // ct_arg[12]: unused
-            DUMMY_CB_ID,                       // ct_arg[13]: unused
-            DUMMY_CB_ID,                       // ct_arg[14]: unused
-            DUMMY_CB_ID,                       // ct_arg[15]: unused
-            DUMMY_CB_ID,                       // ct_arg[16]: unused
-            output_cb_index,                   // ct_arg[17]: output_cb_index
-            DUMMY_CB_ID,                       // ct_arg[18]: unused
-            ONE_SCALAR_PER_CORE,               // ct_arg[19]: ONE_SCALAR_PER_CORE
-            pre_tilize_cb_id,                  // ct_arg[20]: pre_tilize_cb_id
-            is_output_tiled ? 1U : 0U,         // ct_arg[21]: is_output_tiled
-            is_output_block_format ? 1U : 0U,  // ct_arg[22]: is_output_block_format
-            false,                             // ct_arg[23]: return_indices (unused)
-            1,                                 // ct_arg[24]: stride_h (unused)
-            1,                                 // ct_arg[25]: stride_w (unused)
-            1,                                 // ct_arg[26]: in_h_padded (unused)
-            1,                                 // ct_arg[27]: in_w_padded (unused)
-            1,                                 // ct_arg[28]: eff_kernel_h (unused)
-            1,                                 // ct_arg[29]: eff_kernel_w (unused)
-            1,                                 // ct_arg[30]: pad_l (unused)
+            output_cb_index,                   // ct_arg[11]: output_cb_index
+            ONE_SCALAR_PER_CORE,               // ct_arg[12]: ONE_SCALAR_PER_CORE
+            pre_tilize_cb_id,                  // ct_arg[13]: pre_tilize_cb_id
+            is_output_tiled ? 1U : 0U,         // ct_arg[14]: is_output_tiled
+            is_output_block_format ? 1U : 0U,  // ct_arg[15]: is_output_block_format
         };
 
         return tt::tt_metal::CreateKernel(
             program,
-            "ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_pool_2d.cpp",
+            "ttnn/cpp/ttnn/operations/pool/grid_sample/device/kernels/compute/compute_grid_sample.cpp",
             cores,
             tt::tt_metal::ComputeConfig{
                 .math_fidelity = MathFidelity::HiFi4,

--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/device/kernels/compute/compute_grid_sample.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/device/kernels/compute/compute_grid_sample.cpp
@@ -1,0 +1,215 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "compute_kernel_api/pack_untilize.h"
+#include "compute_kernel_api/reduce.h"
+#include "compute_kernel_api/tilize.h"
+#include "compute_kernel_api.h"
+#include "compute_kernel_api/pack.h"
+#include "compute_kernel_api/eltwise_unary/eltwise_unary.h"
+#include "compute_kernel_api/tile_move_copy.h"
+#include "compute_kernel_api/add_int_sfpu.h"
+
+#define DEBUG_PRINT 0
+
+#if DEBUG_PRINT == 1
+#include "debug/dprint.h"
+#include "debug/dprint_pages.h"
+#include "debug/dprint_tensix.h"
+#include "tools/profiler/kernel_profiler.hpp"
+#endif
+
+#define ALWI inline __attribute__((always_inline))
+
+#define FACE_HEIGHT 16
+#define FACE_WIDTH 16
+#define TILE_HEIGHT 32
+#define TILE_WIDTH 32
+
+namespace NAMESPACE {
+
+void MAIN {
+    // NOTE: here it is assumed that in_ntiles_hw == 1. General cases not handled yet. When ntiles_hw > 1 the large
+    // kernel is called
+    constexpr uint32_t in_ntiles_c = get_compile_time_arg_val(0);
+    constexpr uint32_t window_size_hw = get_compile_time_arg_val(1);
+
+    constexpr uint32_t split_reader = get_compile_time_arg_val(2);
+
+    constexpr uint32_t nsticks_per_core_by_nblocks = get_compile_time_arg_val(3);
+    constexpr uint32_t in_c = get_compile_time_arg_val(4);
+    constexpr uint32_t in_nblocks_c = get_compile_time_arg_val(5);
+    constexpr uint32_t max_sticks_for_reduction = get_compile_time_arg_val(6);
+
+    constexpr uint32_t in_cb_id_0 = get_compile_time_arg_val(7);
+    constexpr uint32_t in_cb_id_1 = get_compile_time_arg_val(8);  // for split reader
+    constexpr uint32_t in_scalar_cb_id_0 = get_compile_time_arg_val(9);
+    constexpr uint32_t in_scalar_cb_id_1 = get_compile_time_arg_val(10);
+    constexpr uint32_t out_cb_id = get_compile_time_arg_val(11);
+    constexpr bool one_scalar_per_core = get_compile_time_arg_val(12);
+    constexpr uint32_t pre_tilize_cb_id = get_compile_time_arg_val(13);
+    constexpr bool is_output_tiled = get_compile_time_arg_val(14);  // 1 = TILED, 0 = ROW_MAJOR
+    constexpr bool is_output_block_format = (bool)get_compile_time_arg_val(15);
+
+    constexpr uint32_t face_r_dim = window_size_hw < FACE_HEIGHT ? window_size_hw : FACE_HEIGHT;
+    constexpr bool last_tile_is_partial = in_c % TILE_WIDTH != 0;
+    constexpr uint32_t num_faces_in_input_tile =
+        (max_sticks_for_reduction < TILE_HEIGHT || window_size_hw <= FACE_HEIGHT) ? 2 : 4;
+    constexpr uint32_t num_faces_in_output_tile = 2;
+    constexpr uint32_t num_faces_in_last_output_tile = last_tile_is_partial && in_c % TILE_WIDTH <= FACE_WIDTH ? 1 : 2;
+    constexpr uint32_t num_out_sticks = 1;
+
+    // average pool with large kernels requires fp32 accumulation so we can only reduce 4 tiles at a time,
+    // otherwise we can reduce 8 tiles at a time.
+    constexpr bool is_large_kernel = window_size_hw > max_sticks_for_reduction;
+    constexpr uint32_t MAX_TILES_PER_REDUCTION = is_large_kernel ? 4 : 8;
+    constexpr uint32_t max_tiles_per_iter =
+        in_ntiles_c < MAX_TILES_PER_REDUCTION ? in_ntiles_c : MAX_TILES_PER_REDUCTION;
+    constexpr uint32_t partial_iter_output_tiles =
+        in_ntiles_c % MAX_TILES_PER_REDUCTION == 0 ? max_tiles_per_iter : in_ntiles_c % MAX_TILES_PER_REDUCTION;
+
+    static_assert(REDUCE_OP == PoolType::SUM, "Grid sample only uses REDUCE_OP = SUM");
+    constexpr bool neginf_srca_maxpool = false;
+    constexpr bool zero_srca_avgpool = true;
+
+    // tilize reconfiguration can be beneficial when we have a wide tensor with a non MAX_TILES_PER_REDUCTION number of
+    // C tiles, but we only use it when the window size fits within a face such that the tilize can be done only on the
+    // rows populated with data, otherwise we need to call clear_out_tiles between reconfigs to avoid untilizing junk
+    // data which is much slower than just untilizing the entire MAX_TILES_PER_REDUCTION
+    constexpr bool tilize_reconfig = in_nblocks_c > 1 && in_ntiles_c % MAX_TILES_PER_REDUCTION != 0 &&
+                                     window_size_hw <= FACE_HEIGHT && !last_tile_is_partial;
+
+    constexpr uint32_t tilize_untilize_cb = is_output_tiled ? pre_tilize_cb_id : out_cb_id;
+    tilizeA_B_reduce_init<neginf_srca_maxpool, zero_srca_avgpool>(
+        in_cb_id_0, in_scalar_cb_id_0, max_tiles_per_iter, tilize_untilize_cb, num_faces_in_input_tile, face_r_dim);
+    pack_untilize_dest_init<max_tiles_per_iter>(tilize_untilize_cb, num_out_sticks, num_faces_in_output_tile);
+
+    constexpr uint32_t remaining_elems = window_size_hw % max_sticks_for_reduction;
+    constexpr uint32_t interm_reduction_chunks =
+        remaining_elems ? window_size_hw / max_sticks_for_reduction + 1 : window_size_hw / max_sticks_for_reduction;
+
+    // wait for initialization to complete
+    if constexpr (one_scalar_per_core) {
+        cb_wait_front(in_scalar_cb_id_0, 1);
+    }
+    uint32_t current_idx_col;
+    uint32_t current_idx_row;
+
+    uint32_t tilize_stick_counter = 0;
+    for (uint32_t n = 0; n < nsticks_per_core_by_nblocks; ++n) {
+        const bool reader0 = !(split_reader && (n & 0x1));
+        const uint32_t curr_scalar_cb_id = (!reader0 && !one_scalar_per_core) ? in_scalar_cb_id_1 : in_scalar_cb_id_0;
+        const uint32_t curr_in_cb_id = !reader0 ? in_cb_id_1 : in_cb_id_0;
+        if constexpr (!one_scalar_per_core) {
+            cb_wait_front(curr_scalar_cb_id, 1);
+        }
+        if (is_output_tiled && !tilize_stick_counter) {
+            cb_reserve_back(out_cb_id, in_ntiles_c);
+        }
+        for (uint32_t c_i = 0; c_i < in_nblocks_c; c_i++) {
+            const bool last_c_block = c_i == in_nblocks_c - 1;
+            const bool first_c_block = c_i == 0;
+            const uint32_t tiles_to_reduce =
+                tilize_reconfig ? (last_c_block ? partial_iter_output_tiles : max_tiles_per_iter) : max_tiles_per_iter;
+            const uint32_t number_of_tiles = last_c_block ? partial_iter_output_tiles : max_tiles_per_iter;
+            const uint32_t output_faces =
+                (last_tile_is_partial && last_c_block)
+                    ? (number_of_tiles - 1) * num_faces_in_output_tile + num_faces_in_last_output_tile
+                    : number_of_tiles * num_faces_in_output_tile;
+            if constexpr (!is_output_tiled) {
+                cb_reserve_back(out_cb_id, output_faces);
+            }
+            if constexpr (tilize_reconfig) {
+                if (first_c_block || last_c_block) {
+                    UNPACK((llk_unpack_tilizeA_B_init<neginf_srca_maxpool, true, false, zero_srca_avgpool>(
+                        in_cb_id_0, in_scalar_cb_id_0, tiles_to_reduce, num_faces_in_input_tile, face_r_dim, 1)));
+                }
+            }
+            tile_regs_acquire();
+            for (uint32_t chunk = 0; chunk < interm_reduction_chunks; chunk++) {
+                cb_wait_front(curr_in_cb_id, 1);
+                unpack_tilizeA_B_block<neginf_srca_maxpool, true, false, zero_srca_avgpool>(
+                    curr_in_cb_id,
+                    curr_scalar_cb_id,
+                    tiles_to_reduce,
+                    0 /*tile idx for Src b is 0 because only 1 tile of constants is loaded*/,
+                    num_faces_in_input_tile,
+                    face_r_dim);
+                for (uint32_t math_tile_idx = 0; math_tile_idx < tiles_to_reduce; ++math_tile_idx) {
+                    reduce_tile_math(math_tile_idx, num_faces_in_input_tile);
+                }
+                cb_pop_front(curr_in_cb_id, 1);
+            }
+            tile_regs_commit();
+            tile_regs_wait();
+            if constexpr (is_output_tiled) {
+                // TILED output: accumulate sticks and perform tilization when needed
+                if (last_c_block) {
+                    pack_untilize_dest<partial_iter_output_tiles>(
+                        pre_tilize_cb_id, 1, 0, num_out_sticks, num_faces_in_output_tile);
+                    cb_push_back(pre_tilize_cb_id, partial_iter_output_tiles);
+                    tilize_stick_counter++;
+                } else {
+                    pack_untilize_dest<max_tiles_per_iter>(
+                        pre_tilize_cb_id, 1, 0, num_out_sticks, num_faces_in_output_tile);
+                    cb_push_back(pre_tilize_cb_id, max_tiles_per_iter);
+                }
+                tile_regs_release();
+
+                if (tilize_stick_counter == TILE_HEIGHT) {
+                    PACK((pack_untilize_uninit(pre_tilize_cb_id)));
+
+                    // Workaround until #27504 is not closed
+                    // We should be calling tilizeA_B_uninit and for BFP4 output may be a reconfig_data_format
+                    // and also remove the tensix_syncs. Currently they are incomplete and hence the full call
+                    // to unpack_A_hw_configure.
+                    tensix_sync();
+                    UNPACK((llk_unpack_A_hw_configure_disaggregated<DST_ACCUM_MODE, StochRndType::None, false>(
+                        pre_tilize_cb_id)));
+                    tensix_sync();
+                    pack_reconfig_data_format(out_cb_id);
+
+                    fast_tilize_init(pre_tilize_cb_id, in_ntiles_c, out_cb_id);
+                    fast_tilize_block(pre_tilize_cb_id, in_ntiles_c, out_cb_id);
+                    fast_tilize_uninit(pre_tilize_cb_id, out_cb_id);
+
+                    cb_push_back(out_cb_id, in_ntiles_c);
+
+                    if constexpr (is_output_block_format) {
+                        pack_reconfig_data_format(pre_tilize_cb_id);
+                    }
+
+                    tilize_stick_counter = 0;
+
+                    UNPACK((llk_unpack_tilizeA_B_init<neginf_srca_maxpool, true, false, zero_srca_avgpool>(
+                        in_cb_id_0, in_scalar_cb_id_0, tiles_to_reduce, num_faces_in_input_tile, face_r_dim, 1)));
+                    // init math for reduction again since FPU gets reprogrammed by tilize
+                    MATH((llk_math_reduce_init<REDUCE_OP, REDUCE_DIM, DST_ACCUM_MODE, MATH_FIDELITY>()));
+#ifdef ARCH_BLACKHOLE
+                    // need this on BH to set swizzle bit before pack untilize dest
+                    MATH((llk_math_hw_configure_disaggregated<true, true>(0, 0)));
+#endif
+                    PACK((llk_pack_untilize_init<max_tiles_per_iter, max_tiles_per_iter, false, false, TILE_C_DIM>(
+                        pre_tilize_cb_id, 1, num_faces_in_output_tile)));
+                }
+            } else {
+                // ROW_MAJOR output: pack directly to output CB
+                if (last_c_block) {
+                    pack_untilize_dest<partial_iter_output_tiles>(
+                        out_cb_id, 1, 0, num_out_sticks, num_faces_in_output_tile);
+                } else {
+                    pack_untilize_dest<max_tiles_per_iter>(out_cb_id, 1, 0, num_out_sticks, num_faces_in_output_tile);
+                }
+                cb_push_back(out_cb_id, output_faces);
+                tile_regs_release();
+            }
+        }
+        if constexpr (!one_scalar_per_core) {
+            cb_pop_front(curr_scalar_cb_id, 1);
+        }
+    }
+}
+
+}  // namespace NAMESPACE


### PR DESCRIPTION
### Ticket
N/A

### Problem description
The Pool2D reader kernel has an extra loop which processes dummy data to prevent deadlocking the compute kernel when some cores process less data than others since the compute kernel expects each core to process the same number of kernel positions.  This is unnecessary and could even cause the compute kernel to pack extra positions of junk data at the back of the output tensor causing out of bounds writes.

I believe there is also a race condition in the Pool2D compute kernel where the pre_tilize_cb is pushed without reserving potentially causing conflicts between UNPACK/PACK.

### What's changed
The number of positions processed by each core is now passed as a runtime argument to compute, and the extra loop has been removed from the reader such that each core processes only it's intended data.

In compute the logic is largely unchanged except for reading the new runtime arguments. Additionality it was necessary to add a new check to push the full TILE_HEIGHT * c_tiles number of pages to the pre_tilize_cb to ensure pointers are in the correct place in the event of a non-full last tile. Finally CB sync logic was added to compute to eliminate the race condition.

A MPWI bug has also been fixed to update the `first_row_val` condition based on `use_split_reader`, this previously had no impact as the dummy loop cancelled out the error.

A new grid sample compute kernel has also been implemented to remove the dependency between grid sample an the pool kernel.

### Checklist
In progress