### PR TITLE
Add native L1 sharding to binary_ng program hash

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/eltwise/test_binary_bcast_ext.py
+++ b/tests/ttnn/nightly/unit_tests/operations/eltwise/test_binary_bcast_ext.py
@@ -1083,3 +1083,70 @@ def test_binary_sharded_bcast_no_profile(a_shape, b_shape, a_config, b_config, o
     out_pt = torch.add(a_pt, b_pt)
     out_tt = ttnn.add(a_tt, b_tt, memory_config=out_config, use_legacy=None)
     assert_with_pcc(ttnn.to_torch(out_tt), out_pt)
+
+
+@pytest.mark.parametrize(
+    "test_shapes",
+    ([[1, 1, 2304, 1792], [1, 1, 2112, 1792]],),
+)
+# HEIGHT SHARDING test - tests program cache with different shapes
+def test_inplace_sub_height_sharded_different_shapes(test_shapes, device):
+    grid_size = device.compute_with_storage_grid_size()
+
+    if grid_size.x < 5 or grid_size.y < 4:
+        pytest.skip(
+            f"This test is intended to run on devices with at least 5x4 core grid. Core grid: {grid_size.x}x{grid_size.y}"
+        )
+
+    import math
+
+    for iteration, shape in enumerate(test_shapes):
+        # Generate random tensors
+        torch_input_tensor_a = torch.rand(shape, dtype=torch.bfloat16)
+        torch_input_tensor_b = torch.rand(shape, dtype=torch.bfloat16)
+
+        # Calculate shard dimensions
+        total_rows = math.prod(shape[:-1])  # 2304 or 2112
+        total_cols = shape[-1]  # 1792
+
+        num_cores = 20
+
+        shard_height = math.ceil(total_rows / num_cores / 32) * 32
+        shard_width = math.ceil(total_cols / 32) * 32
+
+        # Create HEIGHT_SHARDED memory config
+        sharded_memory_config = ttnn.create_sharded_memory_config(
+            shape=(shard_height, shard_width),
+            core_grid=ttnn.CoreGrid(y=4, x=5),
+            strategy=ttnn.ShardStrategy.HEIGHT,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+
+        # Create tensors on device as HEIGHT_SHARDED
+        input_tensor_a = ttnn.from_torch(
+            torch_input_tensor_a,
+            dtype=ttnn.bfloat16,
+            device=device,
+            layout=ttnn.TILE_LAYOUT,
+            memory_config=sharded_memory_config,
+        )
+        input_tensor_b = ttnn.from_torch(
+            torch_input_tensor_b,
+            dtype=ttnn.bfloat16,
+            device=device,
+            layout=ttnn.TILE_LAYOUT,
+            memory_config=sharded_memory_config,
+        )
+
+        ttnn.sub_(input_tensor_a, input_tensor_b)
+        output_tensor = ttnn.to_torch(input_tensor_a)
+
+        # Validate results
+        golden_fn = ttnn.get_golden_function(ttnn.sub_)
+        torch_output_tensor = golden_fn(torch_input_tensor_a, torch_input_tensor_b)
+        assert_allclose(torch_output_tensor, output_tensor)
+
+        # Cleanup before next iteration
+        ttnn.deallocate(input_tensor_a)
+        ttnn.deallocate(input_tensor_b)

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
@@ -384,12 +384,16 @@ tt::stl::hash::hash_t BinaryNgDeviceOperation::compute_program_hash(
             "Unexpected type {}",
             tt::stl::get_active_type_name_in_variant(input_tensor_b->storage()));
 
+        const auto shard_volumes = get_shard_volumes(
+            input_tensor_a.tensor_spec(), input_tensor_b->tensor_spec(), compute_output_specs(attributes, tensor_args));
+
         return operation::hash_operation<BinaryNgDeviceOperation>(
             attributes,
             input_tensor_a.dtype(),
             input_tensor_a.memory_config(),
             input_tensor_b->dtype(),
-            input_tensor_b->memory_config());
+            input_tensor_b->memory_config(),
+            shard_volumes);
     }
 
     return operation::hash_operation<BinaryNgDeviceOperation>(

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.hpp
@@ -104,4 +104,13 @@ struct AllShardSpecs {
 tt::tt_metal::ShardSpec adjust_to_shape(
     const tt::tt_metal::ShardSpec& shard_spec, const ttnn::Shape& from_shape, const ttnn::Shape& to_shape);
 
+struct AllShardVolumes {
+    std::optional<std::uint32_t> a_shard_volume;
+    std::optional<std::uint32_t> b_shard_volume;
+    std::optional<std::uint32_t> c_shard_volume;
+};
+
+std::optional<AllShardVolumes> get_shard_volumes(
+    const TensorSpec& a, const std::optional<TensorSpec>& b, const TensorSpec& c);
+
 }  // namespace ttnn::operations::binary_ng


### PR DESCRIPTION
### Ticket
#31122

### Problem description
A reproduction of consecutive binary_ng invocations with program cache enabled caused a hang in OftNet.

### What's changed
binary_ng now hashes whether the kernel uses "native L1 sharding", as well as what the shard volumes of each tensor are for initializing the circular buffers. We do not want to reuse programs when the circular buffers should alias different sized shards or when the decision to use "native L1 sharding" changes.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/19184044815) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/19184772664) CI with demo tests passes (if applicable)
- [x] [Nightly tt-metal L2 eltwise](https://github.com/tenstorrent/tt-metal/actions/runs/19184782433) CI passes
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes