### PR TITLE
#0: [skip ci] Add mock cluster descriptors for P300, BH QB, BH LB, BH Quad Galaxy

### DIFF
--- a/tests/tt_metal/tt_fabric/custom_mock_cluster_descriptors/6u_quad_host_cluster_desc_mapping.yaml
+++ b/tests/tt_metal/tt_fabric/custom_mock_cluster_descriptors/6u_quad_host_cluster_desc_mapping.yaml
@@ -1,0 +1,5 @@
+rank_to_cluster_mock_cluster_desc:
+  0: "tests/tt_metal/tt_fabric/custom_mock_cluster_descriptors/6u_quad_host_cluster_desc_rank_0.yaml"
+  1: "tests/tt_metal/tt_fabric/custom_mock_cluster_descriptors/6u_quad_host_cluster_desc_rank_1.yaml"
+  2: "tests/tt_metal/tt_fabric/custom_mock_cluster_descriptors/6u_quad_host_cluster_desc_rank_2.yaml"
+  3: "tests/tt_metal/tt_fabric/custom_mock_cluster_descriptors/6u_quad_host_cluster_desc_rank_3.yaml"

--- a/tests/tt_metal/tt_fabric/custom_mock_cluster_descriptors/6u_quad_host_cluster_desc_rank_0.yaml
+++ b/tests/tt_metal/tt_fabric/custom_mock_cluster_descriptors/6u_quad_host_cluster_desc_rank_0.yaml
@@ -1,0 +1,1905 @@
+arch:
+  0: wormhole_b0
+  1: wormhole_b0
+  2: wormhole_b0
+  3: wormhole_b0
+  4: wormhole_b0
+  5: wormhole_b0
+  6: wormhole_b0
+  7: wormhole_b0
+  8: wormhole_b0
+  9: wormhole_b0
+  10: wormhole_b0
+  11: wormhole_b0
+  12: wormhole_b0
+  13: wormhole_b0
+  14: wormhole_b0
+  15: wormhole_b0
+  16: wormhole_b0
+  17: wormhole_b0
+  18: wormhole_b0
+  19: wormhole_b0
+  20: wormhole_b0
+  21: wormhole_b0
+  22: wormhole_b0
+  23: wormhole_b0
+  24: wormhole_b0
+  25: wormhole_b0
+  26: wormhole_b0
+  27: wormhole_b0
+  28: wormhole_b0
+  29: wormhole_b0
+  30: wormhole_b0
+  31: wormhole_b0
+chips:
+  {}
+chip_unique_ids:
+  31: 591431948248821840
+  30: 591431935363919950
+  29: 591431935363919944
+  12: 303201559212208180
+  11: 231143978059182160
+  10: 231143965174280270
+  9: 231143965174280264
+  8: 231143965174280244
+  7: 159086384021254224
+  6: 159086371136352334
+  5: 159086371136352328
+  4: 159086371136352308
+  3: 87028789983326288
+  2: 87028777098424398
+  1: 87028777098424392
+  0: 87028777098424372
+  13: 303201559212208200
+  14: 303201559212208206
+  15: 303201572097110096
+  16: 375259153250136116
+  17: 375259153250136136
+  18: 375259153250136142
+  19: 375259166135038032
+  20: 447316747288064052
+  21: 447316747288064072
+  22: 447316747288064078
+  23: 447316760172965968
+  24: 519374341325991988
+  25: 519374341325992008
+  26: 519374341325992014
+  27: 519374354210893904
+  28: 591431935363919924
+ethernet_connections:
+  -
+    - chip: 0
+      chan: 4
+    - chip: 1
+      chan: 4
+  -
+    - chip: 0
+      chan: 5
+    - chip: 1
+      chan: 5
+  -
+    - chip: 0
+      chan: 6
+    - chip: 1
+      chan: 6
+  -
+    - chip: 0
+      chan: 7
+    - chip: 1
+      chan: 7
+  -
+    - chip: 0
+      chan: 8
+    - chip: 4
+      chan: 4
+  -
+    - chip: 0
+      chan: 9
+    - chip: 4
+      chan: 5
+  -
+    - chip: 0
+      chan: 10
+    - chip: 4
+      chan: 6
+  -
+    - chip: 0
+      chan: 11
+    - chip: 4
+      chan: 7
+  -
+    - chip: 0
+      chan: 12
+    - chip: 16
+      chan: 0
+  -
+    - chip: 0
+      chan: 13
+    - chip: 16
+      chan: 1
+  -
+    - chip: 0
+      chan: 14
+    - chip: 16
+      chan: 2
+  -
+    - chip: 0
+      chan: 15
+    - chip: 16
+      chan: 3
+  -
+    - chip: 1
+      chan: 8
+    - chip: 5
+      chan: 4
+  -
+    - chip: 1
+      chan: 9
+    - chip: 5
+      chan: 5
+  -
+    - chip: 1
+      chan: 10
+    - chip: 5
+      chan: 6
+  -
+    - chip: 1
+      chan: 11
+    - chip: 5
+      chan: 7
+  -
+    - chip: 1
+      chan: 12
+    - chip: 17
+      chan: 0
+  -
+    - chip: 1
+      chan: 13
+    - chip: 17
+      chan: 1
+  -
+    - chip: 1
+      chan: 14
+    - chip: 17
+      chan: 2
+  -
+    - chip: 1
+      chan: 15
+    - chip: 17
+      chan: 3
+  -
+    - chip: 2
+      chan: 4
+    - chip: 3
+      chan: 4
+  -
+    - chip: 2
+      chan: 5
+    - chip: 3
+      chan: 5
+  -
+    - chip: 2
+      chan: 6
+    - chip: 3
+      chan: 6
+  -
+    - chip: 2
+      chan: 7
+    - chip: 3
+      chan: 7
+  -
+    - chip: 2
+      chan: 8
+    - chip: 6
+      chan: 4
+  -
+    - chip: 2
+      chan: 9
+    - chip: 6
+      chan: 5
+  -
+    - chip: 2
+      chan: 10
+    - chip: 6
+      chan: 6
+  -
+    - chip: 2
+      chan: 11
+    - chip: 6
+      chan: 7
+  -
+    - chip: 2
+      chan: 12
+    - chip: 18
+      chan: 0
+  -
+    - chip: 2
+      chan: 13
+    - chip: 18
+      chan: 1
+  -
+    - chip: 2
+      chan: 14
+    - chip: 18
+      chan: 2
+  -
+    - chip: 2
+      chan: 15
+    - chip: 18
+      chan: 3
+  -
+    - chip: 3
+      chan: 8
+    - chip: 7
+      chan: 4
+  -
+    - chip: 3
+      chan: 9
+    - chip: 7
+      chan: 5
+  -
+    - chip: 3
+      chan: 10
+    - chip: 7
+      chan: 6
+  -
+    - chip: 3
+      chan: 11
+    - chip: 7
+      chan: 7
+  -
+    - chip: 3
+      chan: 12
+    - chip: 19
+      chan: 0
+  -
+    - chip: 3
+      chan: 13
+    - chip: 19
+      chan: 1
+  -
+    - chip: 3
+      chan: 14
+    - chip: 19
+      chan: 2
+  -
+    - chip: 3
+      chan: 15
+    - chip: 19
+      chan: 3
+  -
+    - chip: 4
+      chan: 8
+    - chip: 8
+      chan: 4
+  -
+    - chip: 4
+      chan: 9
+    - chip: 8
+      chan: 5
+  -
+    - chip: 4
+      chan: 10
+    - chip: 8
+      chan: 6
+  -
+    - chip: 4
+      chan: 11
+    - chip: 8
+      chan: 7
+  -
+    - chip: 4
+      chan: 12
+    - chip: 20
+      chan: 0
+  -
+    - chip: 4
+      chan: 13
+    - chip: 20
+      chan: 1
+  -
+    - chip: 4
+      chan: 14
+    - chip: 20
+      chan: 2
+  -
+    - chip: 4
+      chan: 15
+    - chip: 20
+      chan: 3
+  -
+    - chip: 5
+      chan: 8
+    - chip: 9
+      chan: 4
+  -
+    - chip: 5
+      chan: 9
+    - chip: 9
+      chan: 5
+  -
+    - chip: 5
+      chan: 10
+    - chip: 9
+      chan: 6
+  -
+    - chip: 5
+      chan: 11
+    - chip: 9
+      chan: 7
+  -
+    - chip: 5
+      chan: 12
+    - chip: 21
+      chan: 0
+  -
+    - chip: 5
+      chan: 13
+    - chip: 21
+      chan: 1
+  -
+    - chip: 5
+      chan: 14
+    - chip: 21
+      chan: 2
+  -
+    - chip: 5
+      chan: 15
+    - chip: 21
+      chan: 3
+  -
+    - chip: 6
+      chan: 8
+    - chip: 10
+      chan: 4
+  -
+    - chip: 6
+      chan: 9
+    - chip: 10
+      chan: 5
+  -
+    - chip: 6
+      chan: 10
+    - chip: 10
+      chan: 6
+  -
+    - chip: 6
+      chan: 11
+    - chip: 10
+      chan: 7
+  -
+    - chip: 6
+      chan: 12
+    - chip: 22
+      chan: 0
+  -
+    - chip: 6
+      chan: 13
+    - chip: 22
+      chan: 1
+  -
+    - chip: 6
+      chan: 14
+    - chip: 22
+      chan: 2
+  -
+    - chip: 6
+      chan: 15
+    - chip: 22
+      chan: 3
+  -
+    - chip: 7
+      chan: 8
+    - chip: 11
+      chan: 4
+  -
+    - chip: 7
+      chan: 9
+    - chip: 11
+      chan: 5
+  -
+    - chip: 7
+      chan: 10
+    - chip: 11
+      chan: 6
+  -
+    - chip: 7
+      chan: 11
+    - chip: 11
+      chan: 7
+  -
+    - chip: 7
+      chan: 12
+    - chip: 23
+      chan: 0
+  -
+    - chip: 7
+      chan: 13
+    - chip: 23
+      chan: 1
+  -
+    - chip: 7
+      chan: 14
+    - chip: 23
+      chan: 2
+  -
+    - chip: 7
+      chan: 15
+    - chip: 23
+      chan: 3
+  -
+    - chip: 8
+      chan: 8
+    - chip: 12
+      chan: 4
+  -
+    - chip: 8
+      chan: 9
+    - chip: 12
+      chan: 5
+  -
+    - chip: 8
+      chan: 10
+    - chip: 12
+      chan: 6
+  -
+    - chip: 8
+      chan: 11
+    - chip: 12
+      chan: 7
+  -
+    - chip: 8
+      chan: 12
+    - chip: 24
+      chan: 0
+  -
+    - chip: 8
+      chan: 13
+    - chip: 24
+      chan: 1
+  -
+    - chip: 8
+      chan: 14
+    - chip: 24
+      chan: 2
+  -
+    - chip: 8
+      chan: 15
+    - chip: 24
+      chan: 3
+  -
+    - chip: 9
+      chan: 8
+    - chip: 13
+      chan: 4
+  -
+    - chip: 9
+      chan: 9
+    - chip: 13
+      chan: 5
+  -
+    - chip: 9
+      chan: 10
+    - chip: 13
+      chan: 6
+  -
+    - chip: 9
+      chan: 11
+    - chip: 13
+      chan: 7
+  -
+    - chip: 9
+      chan: 12
+    - chip: 25
+      chan: 0
+  -
+    - chip: 9
+      chan: 13
+    - chip: 25
+      chan: 1
+  -
+    - chip: 9
+      chan: 14
+    - chip: 25
+      chan: 2
+  -
+    - chip: 9
+      chan: 15
+    - chip: 25
+      chan: 3
+  -
+    - chip: 10
+      chan: 8
+    - chip: 14
+      chan: 4
+  -
+    - chip: 10
+      chan: 9
+    - chip: 14
+      chan: 5
+  -
+    - chip: 10
+      chan: 10
+    - chip: 14
+      chan: 6
+  -
+    - chip: 10
+      chan: 11
+    - chip: 14
+      chan: 7
+  -
+    - chip: 10
+      chan: 12
+    - chip: 26
+      chan: 0
+  -
+    - chip: 10
+      chan: 13
+    - chip: 26
+      chan: 1
+  -
+    - chip: 10
+      chan: 14
+    - chip: 26
+      chan: 2
+  -
+    - chip: 10
+      chan: 15
+    - chip: 26
+      chan: 3
+  -
+    - chip: 11
+      chan: 8
+    - chip: 15
+      chan: 4
+  -
+    - chip: 11
+      chan: 9
+    - chip: 15
+      chan: 5
+  -
+    - chip: 11
+      chan: 10
+    - chip: 15
+      chan: 6
+  -
+    - chip: 11
+      chan: 11
+    - chip: 15
+      chan: 7
+  -
+    - chip: 11
+      chan: 12
+    - chip: 27
+      chan: 0
+  -
+    - chip: 11
+      chan: 13
+    - chip: 27
+      chan: 1
+  -
+    - chip: 11
+      chan: 14
+    - chip: 27
+      chan: 2
+  -
+    - chip: 11
+      chan: 15
+    - chip: 27
+      chan: 3
+  -
+    - chip: 12
+      chan: 8
+    - chip: 13
+      chan: 8
+  -
+    - chip: 12
+      chan: 9
+    - chip: 13
+      chan: 9
+  -
+    - chip: 12
+      chan: 10
+    - chip: 13
+      chan: 10
+  -
+    - chip: 12
+      chan: 11
+    - chip: 13
+      chan: 11
+  -
+    - chip: 12
+      chan: 12
+    - chip: 28
+      chan: 0
+  -
+    - chip: 12
+      chan: 13
+    - chip: 28
+      chan: 1
+  -
+    - chip: 12
+      chan: 14
+    - chip: 28
+      chan: 2
+  -
+    - chip: 12
+      chan: 15
+    - chip: 28
+      chan: 3
+  -
+    - chip: 13
+      chan: 12
+    - chip: 29
+      chan: 0
+  -
+    - chip: 13
+      chan: 13
+    - chip: 29
+      chan: 1
+  -
+    - chip: 13
+      chan: 14
+    - chip: 29
+      chan: 2
+  -
+    - chip: 13
+      chan: 15
+    - chip: 29
+      chan: 3
+  -
+    - chip: 14
+      chan: 8
+    - chip: 15
+      chan: 8
+  -
+    - chip: 14
+      chan: 9
+    - chip: 15
+      chan: 9
+  -
+    - chip: 14
+      chan: 10
+    - chip: 15
+      chan: 10
+  -
+    - chip: 14
+      chan: 11
+    - chip: 15
+      chan: 11
+  -
+    - chip: 14
+      chan: 12
+    - chip: 30
+      chan: 0
+  -
+    - chip: 14
+      chan: 13
+    - chip: 30
+      chan: 1
+  -
+    - chip: 14
+      chan: 14
+    - chip: 30
+      chan: 2
+  -
+    - chip: 14
+      chan: 15
+    - chip: 30
+      chan: 3
+  -
+    - chip: 15
+      chan: 12
+    - chip: 31
+      chan: 0
+  -
+    - chip: 15
+      chan: 13
+    - chip: 31
+      chan: 1
+  -
+    - chip: 15
+      chan: 14
+    - chip: 31
+      chan: 2
+  -
+    - chip: 15
+      chan: 15
+    - chip: 31
+      chan: 3
+  -
+    - chip: 16
+      chan: 4
+    - chip: 17
+      chan: 4
+  -
+    - chip: 16
+      chan: 5
+    - chip: 17
+      chan: 5
+  -
+    - chip: 16
+      chan: 6
+    - chip: 17
+      chan: 6
+  -
+    - chip: 16
+      chan: 7
+    - chip: 17
+      chan: 7
+  -
+    - chip: 16
+      chan: 8
+    - chip: 20
+      chan: 4
+  -
+    - chip: 16
+      chan: 9
+    - chip: 20
+      chan: 5
+  -
+    - chip: 16
+      chan: 10
+    - chip: 20
+      chan: 6
+  -
+    - chip: 16
+      chan: 11
+    - chip: 20
+      chan: 7
+  -
+    - chip: 16
+      chan: 12
+    - chip: 19
+      chan: 12
+  -
+    - chip: 16
+      chan: 13
+    - chip: 19
+      chan: 13
+  -
+    - chip: 16
+      chan: 14
+    - chip: 19
+      chan: 14
+  -
+    - chip: 16
+      chan: 15
+    - chip: 19
+      chan: 15
+  -
+    - chip: 17
+      chan: 8
+    - chip: 21
+      chan: 4
+  -
+    - chip: 17
+      chan: 9
+    - chip: 21
+      chan: 5
+  -
+    - chip: 17
+      chan: 10
+    - chip: 21
+      chan: 6
+  -
+    - chip: 17
+      chan: 11
+    - chip: 21
+      chan: 7
+  -
+    - chip: 17
+      chan: 12
+    - chip: 18
+      chan: 12
+  -
+    - chip: 17
+      chan: 13
+    - chip: 18
+      chan: 13
+  -
+    - chip: 17
+      chan: 14
+    - chip: 18
+      chan: 14
+  -
+    - chip: 17
+      chan: 15
+    - chip: 18
+      chan: 15
+  -
+    - chip: 18
+      chan: 4
+    - chip: 19
+      chan: 4
+  -
+    - chip: 18
+      chan: 5
+    - chip: 19
+      chan: 5
+  -
+    - chip: 18
+      chan: 6
+    - chip: 19
+      chan: 6
+  -
+    - chip: 18
+      chan: 7
+    - chip: 19
+      chan: 7
+  -
+    - chip: 18
+      chan: 8
+    - chip: 22
+      chan: 4
+  -
+    - chip: 18
+      chan: 9
+    - chip: 22
+      chan: 5
+  -
+    - chip: 18
+      chan: 10
+    - chip: 22
+      chan: 6
+  -
+    - chip: 18
+      chan: 11
+    - chip: 22
+      chan: 7
+  -
+    - chip: 19
+      chan: 8
+    - chip: 23
+      chan: 4
+  -
+    - chip: 19
+      chan: 9
+    - chip: 23
+      chan: 5
+  -
+    - chip: 19
+      chan: 10
+    - chip: 23
+      chan: 6
+  -
+    - chip: 19
+      chan: 11
+    - chip: 23
+      chan: 7
+  -
+    - chip: 20
+      chan: 8
+    - chip: 24
+      chan: 4
+  -
+    - chip: 20
+      chan: 9
+    - chip: 24
+      chan: 5
+  -
+    - chip: 20
+      chan: 10
+    - chip: 24
+      chan: 6
+  -
+    - chip: 20
+      chan: 11
+    - chip: 24
+      chan: 7
+  -
+    - chip: 20
+      chan: 12
+    - chip: 23
+      chan: 12
+  -
+    - chip: 20
+      chan: 13
+    - chip: 23
+      chan: 13
+  -
+    - chip: 20
+      chan: 14
+    - chip: 23
+      chan: 14
+  -
+    - chip: 20
+      chan: 15
+    - chip: 23
+      chan: 15
+  -
+    - chip: 21
+      chan: 8
+    - chip: 25
+      chan: 4
+  -
+    - chip: 21
+      chan: 9
+    - chip: 25
+      chan: 5
+  -
+    - chip: 21
+      chan: 10
+    - chip: 25
+      chan: 6
+  -
+    - chip: 21
+      chan: 11
+    - chip: 25
+      chan: 7
+  -
+    - chip: 21
+      chan: 12
+    - chip: 22
+      chan: 12
+  -
+    - chip: 21
+      chan: 13
+    - chip: 22
+      chan: 13
+  -
+    - chip: 21
+      chan: 14
+    - chip: 22
+      chan: 14
+  -
+    - chip: 21
+      chan: 15
+    - chip: 22
+      chan: 15
+  -
+    - chip: 22
+      chan: 8
+    - chip: 26
+      chan: 4
+  -
+    - chip: 22
+      chan: 9
+    - chip: 26
+      chan: 5
+  -
+    - chip: 22
+      chan: 10
+    - chip: 26
+      chan: 6
+  -
+    - chip: 22
+      chan: 11
+    - chip: 26
+      chan: 7
+  -
+    - chip: 23
+      chan: 8
+    - chip: 27
+      chan: 4
+  -
+    - chip: 23
+      chan: 9
+    - chip: 27
+      chan: 5
+  -
+    - chip: 23
+      chan: 10
+    - chip: 27
+      chan: 6
+  -
+    - chip: 23
+      chan: 11
+    - chip: 27
+      chan: 7
+  -
+    - chip: 24
+      chan: 8
+    - chip: 28
+      chan: 4
+  -
+    - chip: 24
+      chan: 9
+    - chip: 28
+      chan: 5
+  -
+    - chip: 24
+      chan: 10
+    - chip: 28
+      chan: 6
+  -
+    - chip: 24
+      chan: 11
+    - chip: 28
+      chan: 7
+  -
+    - chip: 24
+      chan: 12
+    - chip: 27
+      chan: 12
+  -
+    - chip: 24
+      chan: 13
+    - chip: 27
+      chan: 13
+  -
+    - chip: 24
+      chan: 14
+    - chip: 27
+      chan: 14
+  -
+    - chip: 24
+      chan: 15
+    - chip: 27
+      chan: 15
+  -
+    - chip: 25
+      chan: 8
+    - chip: 29
+      chan: 4
+  -
+    - chip: 25
+      chan: 9
+    - chip: 29
+      chan: 5
+  -
+    - chip: 25
+      chan: 10
+    - chip: 29
+      chan: 6
+  -
+    - chip: 25
+      chan: 11
+    - chip: 29
+      chan: 7
+  -
+    - chip: 25
+      chan: 12
+    - chip: 26
+      chan: 12
+  -
+    - chip: 25
+      chan: 13
+    - chip: 26
+      chan: 13
+  -
+    - chip: 25
+      chan: 14
+    - chip: 26
+      chan: 14
+  -
+    - chip: 25
+      chan: 15
+    - chip: 26
+      chan: 15
+  -
+    - chip: 26
+      chan: 8
+    - chip: 30
+      chan: 4
+  -
+    - chip: 26
+      chan: 9
+    - chip: 30
+      chan: 5
+  -
+    - chip: 26
+      chan: 10
+    - chip: 30
+      chan: 6
+  -
+    - chip: 26
+      chan: 11
+    - chip: 30
+      chan: 7
+  -
+    - chip: 27
+      chan: 8
+    - chip: 31
+      chan: 4
+  -
+    - chip: 27
+      chan: 9
+    - chip: 31
+      chan: 5
+  -
+    - chip: 27
+      chan: 10
+    - chip: 31
+      chan: 6
+  -
+    - chip: 27
+      chan: 11
+    - chip: 31
+      chan: 7
+  -
+    - chip: 28
+      chan: 8
+    - chip: 29
+      chan: 8
+  -
+    - chip: 28
+      chan: 9
+    - chip: 29
+      chan: 9
+  -
+    - chip: 28
+      chan: 10
+    - chip: 29
+      chan: 10
+  -
+    - chip: 28
+      chan: 11
+    - chip: 29
+      chan: 11
+  -
+    - chip: 28
+      chan: 12
+    - chip: 31
+      chan: 12
+  -
+    - chip: 28
+      chan: 13
+    - chip: 31
+      chan: 13
+  -
+    - chip: 28
+      chan: 14
+    - chip: 31
+      chan: 14
+  -
+    - chip: 28
+      chan: 15
+    - chip: 31
+      chan: 15
+  -
+    - chip: 29
+      chan: 12
+    - chip: 30
+      chan: 12
+  -
+    - chip: 29
+      chan: 13
+    - chip: 30
+      chan: 13
+  -
+    - chip: 29
+      chan: 14
+    - chip: 30
+      chan: 14
+  -
+    - chip: 29
+      chan: 15
+    - chip: 30
+      chan: 15
+  -
+    - chip: 30
+      chan: 8
+    - chip: 31
+      chan: 8
+  -
+    - chip: 30
+      chan: 9
+    - chip: 31
+      chan: 9
+  -
+    - chip: 30
+      chan: 10
+    - chip: 31
+      chan: 10
+  -
+    - chip: 30
+      chan: 11
+    - chip: 31
+      chan: 11
+ethernet_connections_to_remote_devices:
+  -
+    - chip: 15
+      chan: 3
+    - remote_chip_id: 303201550622273589
+      chan: 3
+  -
+    - chip: 15
+      chan: 2
+    - remote_chip_id: 303201550622273589
+      chan: 2
+  -
+    - chip: 15
+      chan: 1
+    - remote_chip_id: 303201550622273589
+      chan: 1
+  -
+    - chip: 15
+      chan: 0
+    - remote_chip_id: 303201550622273589
+      chan: 0
+  -
+    - chip: 14
+      chan: 3
+    - remote_chip_id: 303201550622273602
+      chan: 3
+  -
+    - chip: 14
+      chan: 2
+    - remote_chip_id: 303201550622273602
+      chan: 2
+  -
+    - chip: 14
+      chan: 1
+    - remote_chip_id: 303201550622273602
+      chan: 1
+  -
+    - chip: 14
+      chan: 0
+    - remote_chip_id: 303201550622273602
+      chan: 0
+  -
+    - chip: 13
+      chan: 3
+    - remote_chip_id: 303201572097110071
+      chan: 3
+  -
+    - chip: 13
+      chan: 2
+    - remote_chip_id: 303201572097110071
+      chan: 2
+  -
+    - chip: 13
+      chan: 1
+    - remote_chip_id: 303201572097110071
+      chan: 1
+  -
+    - chip: 13
+      chan: 0
+    - remote_chip_id: 303201572097110071
+      chan: 0
+  -
+    - chip: 0
+      chan: 3
+    - remote_chip_id: 87028789983326521
+      chan: 3
+  -
+    - chip: 0
+      chan: 2
+    - remote_chip_id: 87028789983326521
+      chan: 2
+  -
+    - chip: 0
+      chan: 1
+    - remote_chip_id: 87028789983326521
+      chan: 1
+  -
+    - chip: 0
+      chan: 0
+    - remote_chip_id: 87028789983326521
+      chan: 0
+  -
+    - chip: 1
+      chan: 3
+    - remote_chip_id: 87028789983326263
+      chan: 3
+  -
+    - chip: 1
+      chan: 2
+    - remote_chip_id: 87028789983326263
+      chan: 2
+  -
+    - chip: 1
+      chan: 1
+    - remote_chip_id: 87028789983326263
+      chan: 1
+  -
+    - chip: 1
+      chan: 0
+    - remote_chip_id: 87028789983326263
+      chan: 0
+  -
+    - chip: 2
+      chan: 3
+    - remote_chip_id: 87028768508489794
+      chan: 3
+  -
+    - chip: 2
+      chan: 2
+    - remote_chip_id: 87028768508489794
+      chan: 2
+  -
+    - chip: 2
+      chan: 1
+    - remote_chip_id: 87028768508489794
+      chan: 1
+  -
+    - chip: 2
+      chan: 0
+    - remote_chip_id: 87028768508489794
+      chan: 0
+  -
+    - chip: 3
+      chan: 3
+    - remote_chip_id: 87028768508489781
+      chan: 3
+  -
+    - chip: 3
+      chan: 2
+    - remote_chip_id: 87028768508489781
+      chan: 2
+  -
+    - chip: 3
+      chan: 1
+    - remote_chip_id: 87028768508489781
+      chan: 1
+  -
+    - chip: 3
+      chan: 0
+    - remote_chip_id: 87028768508489781
+      chan: 0
+  -
+    - chip: 4
+      chan: 3
+    - remote_chip_id: 159086384021254457
+      chan: 3
+  -
+    - chip: 4
+      chan: 2
+    - remote_chip_id: 159086384021254457
+      chan: 2
+  -
+    - chip: 4
+      chan: 1
+    - remote_chip_id: 159086384021254457
+      chan: 1
+  -
+    - chip: 4
+      chan: 0
+    - remote_chip_id: 159086384021254457
+      chan: 0
+  -
+    - chip: 5
+      chan: 3
+    - remote_chip_id: 159086384021254199
+      chan: 3
+  -
+    - chip: 5
+      chan: 2
+    - remote_chip_id: 159086384021254199
+      chan: 2
+  -
+    - chip: 5
+      chan: 1
+    - remote_chip_id: 159086384021254199
+      chan: 1
+  -
+    - chip: 5
+      chan: 0
+    - remote_chip_id: 159086384021254199
+      chan: 0
+  -
+    - chip: 6
+      chan: 3
+    - remote_chip_id: 159086362546417730
+      chan: 3
+  -
+    - chip: 6
+      chan: 2
+    - remote_chip_id: 159086362546417730
+      chan: 2
+  -
+    - chip: 6
+      chan: 1
+    - remote_chip_id: 159086362546417730
+      chan: 1
+  -
+    - chip: 6
+      chan: 0
+    - remote_chip_id: 159086362546417730
+      chan: 0
+  -
+    - chip: 7
+      chan: 3
+    - remote_chip_id: 159086362546417717
+      chan: 3
+  -
+    - chip: 7
+      chan: 2
+    - remote_chip_id: 159086362546417717
+      chan: 2
+  -
+    - chip: 7
+      chan: 1
+    - remote_chip_id: 159086362546417717
+      chan: 1
+  -
+    - chip: 7
+      chan: 0
+    - remote_chip_id: 159086362546417717
+      chan: 0
+  -
+    - chip: 8
+      chan: 3
+    - remote_chip_id: 231143978059182393
+      chan: 3
+  -
+    - chip: 8
+      chan: 2
+    - remote_chip_id: 231143978059182393
+      chan: 2
+  -
+    - chip: 8
+      chan: 1
+    - remote_chip_id: 231143978059182393
+      chan: 1
+  -
+    - chip: 8
+      chan: 0
+    - remote_chip_id: 231143978059182393
+      chan: 0
+  -
+    - chip: 9
+      chan: 3
+    - remote_chip_id: 231143978059182135
+      chan: 3
+  -
+    - chip: 9
+      chan: 2
+    - remote_chip_id: 231143978059182135
+      chan: 2
+  -
+    - chip: 9
+      chan: 1
+    - remote_chip_id: 231143978059182135
+      chan: 1
+  -
+    - chip: 9
+      chan: 0
+    - remote_chip_id: 231143978059182135
+      chan: 0
+  -
+    - chip: 10
+      chan: 3
+    - remote_chip_id: 231143956584345666
+      chan: 3
+  -
+    - chip: 10
+      chan: 2
+    - remote_chip_id: 231143956584345666
+      chan: 2
+  -
+    - chip: 10
+      chan: 1
+    - remote_chip_id: 231143956584345666
+      chan: 1
+  -
+    - chip: 10
+      chan: 0
+    - remote_chip_id: 231143956584345666
+      chan: 0
+  -
+    - chip: 11
+      chan: 3
+    - remote_chip_id: 231143956584345653
+      chan: 3
+  -
+    - chip: 11
+      chan: 2
+    - remote_chip_id: 231143956584345653
+      chan: 2
+  -
+    - chip: 11
+      chan: 1
+    - remote_chip_id: 231143956584345653
+      chan: 1
+  -
+    - chip: 11
+      chan: 0
+    - remote_chip_id: 231143956584345653
+      chan: 0
+  -
+    - chip: 12
+      chan: 3
+    - remote_chip_id: 303201572097110329
+      chan: 3
+  -
+    - chip: 12
+      chan: 2
+    - remote_chip_id: 303201572097110329
+      chan: 2
+  -
+    - chip: 12
+      chan: 1
+    - remote_chip_id: 303201572097110329
+      chan: 1
+  -
+    - chip: 12
+      chan: 0
+    - remote_chip_id: 303201572097110329
+      chan: 0
+chips_with_mmio:
+  - 0: 17
+  - 1: 2
+  - 2: 14
+  - 3: 24
+  - 4: 20
+  - 5: 5
+  - 6: 10
+  - 7: 30
+  - 8: 18
+  - 9: 6
+  - 10: 13
+  - 11: 27
+  - 12: 19
+  - 13: 0
+  - 14: 11
+  - 15: 25
+  - 16: 21
+  - 17: 1
+  - 18: 12
+  - 19: 26
+  - 20: 23
+  - 21: 7
+  - 22: 15
+  - 23: 31
+  - 24: 22
+  - 25: 3
+  - 26: 8
+  - 27: 29
+  - 28: 16
+  - 29: 4
+  - 30: 9
+  - 31: 28
+io_device_type: PCIe
+harvesting:
+  0:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  1:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  2:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  3:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  4:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  5:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  6:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  7:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  8:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  9:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  10:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  11:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  12:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  13:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  14:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  15:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  16:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  17:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  18:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  19:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  20:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  21:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  22:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  23:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  24:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  25:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  26:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  27:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  28:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  29:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  30:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  31:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+chip_to_boardtype:
+  0: ubb
+  1: ubb
+  2: ubb
+  3: ubb
+  4: ubb
+  5: ubb
+  6: ubb
+  7: ubb
+  8: ubb
+  9: ubb
+  10: ubb
+  11: ubb
+  12: ubb
+  13: ubb
+  14: ubb
+  15: ubb
+  16: ubb
+  17: ubb
+  18: ubb
+  19: ubb
+  20: ubb
+  21: ubb
+  22: ubb
+  23: ubb
+  24: ubb
+  25: ubb
+  26: ubb
+  27: ubb
+  28: ubb
+  29: ubb
+  30: ubb
+  31: ubb
+chip_to_bus_id:
+  0: 0x0001
+  1: 0x00c1
+  2: 0x0081
+  3: 0x0041
+  4: 0x0002
+  5: 0x00c2
+  6: 0x0082
+  7: 0x0042
+  8: 0x0003
+  9: 0x00c3
+  10: 0x0083
+  11: 0x0043
+  12: 0x0004
+  13: 0x00c4
+  14: 0x0084
+  15: 0x0044
+  16: 0x0005
+  17: 0x00c5
+  18: 0x0085
+  19: 0x0045
+  20: 0x0006
+  21: 0x00c6
+  22: 0x0086
+  23: 0x0046
+  24: 0x0007
+  25: 0x00c7
+  26: 0x0087
+  27: 0x0047
+  28: 0x0008
+  29: 0x00c8
+  30: 0x0088
+  31: 0x0048
+boards:
+  -
+    - board_id: 72061240465162240
+    - board_type: ubb
+    - chips:
+        - 31
+        - 30
+        - 29
+        - 12
+        - 11
+        - 10
+        - 9
+        - 8
+        - 7
+        - 6
+        - 5
+        - 4
+        - 3
+        - 2
+        - 1
+        - 0
+        - 13
+        - 14
+        - 15
+        - 16
+        - 17
+        - 18
+        - 19
+        - 20
+        - 21
+        - 22
+        - 23
+        - 24
+        - 25
+        - 26
+        - 27
+        - 28
+asic_locations:
+  0: 1
+  1: 1
+  2: 1
+  3: 1
+  4: 2
+  5: 2
+  6: 2
+  7: 2
+  8: 3
+  9: 3
+  10: 3
+  11: 3
+  12: 4
+  13: 4
+  14: 4
+  15: 4
+  16: 5
+  17: 5
+  18: 5
+  19: 5
+  20: 6
+  21: 6
+  22: 6
+  23: 6
+  24: 7
+  25: 7
+  26: 7
+  27: 7
+  28: 8
+  29: 8
+  30: 8
+  31: 8

--- a/tests/tt_metal/tt_fabric/custom_mock_cluster_descriptors/6u_quad_host_cluster_desc_rank_1.yaml
+++ b/tests/tt_metal/tt_fabric/custom_mock_cluster_descriptors/6u_quad_host_cluster_desc_rank_1.yaml
@@ -1,0 +1,1909 @@
+arch:
+  0: wormhole_b0
+  1: wormhole_b0
+  2: wormhole_b0
+  3: wormhole_b0
+  4: wormhole_b0
+  5: wormhole_b0
+  6: wormhole_b0
+  7: wormhole_b0
+  8: wormhole_b0
+  9: wormhole_b0
+  10: wormhole_b0
+  11: wormhole_b0
+  12: wormhole_b0
+  13: wormhole_b0
+  14: wormhole_b0
+  15: wormhole_b0
+  16: wormhole_b0
+  17: wormhole_b0
+  18: wormhole_b0
+  19: wormhole_b0
+  20: wormhole_b0
+  21: wormhole_b0
+  22: wormhole_b0
+  23: wormhole_b0
+  24: wormhole_b0
+  25: wormhole_b0
+  26: wormhole_b0
+  27: wormhole_b0
+  28: wormhole_b0
+  29: wormhole_b0
+  30: wormhole_b0
+  31: wormhole_b0
+chips:
+  {}
+chip_unique_ids:
+  31: 591431948248821817
+  30: 591431926773985346
+  29: 591431926773985333
+  12: 303201537737371701
+  11: 231143978059182137
+  10: 231143956584345666
+  9: 231143956584345653
+  8: 231143943699443765
+  7: 159086384021254201
+  6: 159086362546417730
+  5: 159086362546417717
+  4: 159086349661515829
+  3: 87028789983326265
+  2: 87028768508489794
+  1: 87028768508489781
+  0: 87028755623587893
+  13: 303201550622273589
+  14: 303201550622273602
+  15: 303201572097110073
+  16: 375259131775299637
+  17: 375259144660201525
+  18: 375259144660201538
+  19: 375259166135038009
+  20: 447316725813227573
+  21: 447316738698129461
+  22: 447316738698129474
+  23: 447316760172965945
+  24: 519374319851155509
+  25: 519374332736057397
+  26: 519374332736057410
+  27: 519374354210893881
+  28: 591431913889083445
+ethernet_connections:
+  -
+    - chip: 0
+      chan: 4
+    - chip: 3
+      chan: 4
+  -
+    - chip: 0
+      chan: 5
+    - chip: 3
+      chan: 5
+  -
+    - chip: 0
+      chan: 6
+    - chip: 3
+      chan: 6
+  -
+    - chip: 0
+      chan: 7
+    - chip: 3
+      chan: 7
+  -
+    - chip: 0
+      chan: 8
+    - chip: 4
+      chan: 4
+  -
+    - chip: 0
+      chan: 9
+    - chip: 4
+      chan: 5
+  -
+    - chip: 0
+      chan: 10
+    - chip: 4
+      chan: 6
+  -
+    - chip: 0
+      chan: 11
+    - chip: 4
+      chan: 7
+  -
+    - chip: 0
+      chan: 12
+    - chip: 16
+      chan: 0
+  -
+    - chip: 0
+      chan: 13
+    - chip: 16
+      chan: 1
+  -
+    - chip: 0
+      chan: 14
+    - chip: 16
+      chan: 2
+  -
+    - chip: 0
+      chan: 15
+    - chip: 16
+      chan: 3
+  -
+    - chip: 1
+      chan: 4
+    - chip: 2
+      chan: 4
+  -
+    - chip: 1
+      chan: 5
+    - chip: 2
+      chan: 5
+  -
+    - chip: 1
+      chan: 6
+    - chip: 2
+      chan: 6
+  -
+    - chip: 1
+      chan: 7
+    - chip: 2
+      chan: 7
+  -
+    - chip: 1
+      chan: 8
+    - chip: 5
+      chan: 4
+  -
+    - chip: 1
+      chan: 9
+    - chip: 5
+      chan: 5
+  -
+    - chip: 1
+      chan: 10
+    - chip: 5
+      chan: 6
+  -
+    - chip: 1
+      chan: 11
+    - chip: 5
+      chan: 7
+  -
+    - chip: 1
+      chan: 12
+    - chip: 17
+      chan: 0
+  -
+    - chip: 1
+      chan: 13
+    - chip: 17
+      chan: 1
+  -
+    - chip: 1
+      chan: 14
+    - chip: 17
+      chan: 2
+  -
+    - chip: 1
+      chan: 15
+    - chip: 17
+      chan: 3
+  -
+    - chip: 2
+      chan: 8
+    - chip: 6
+      chan: 4
+  -
+    - chip: 2
+      chan: 9
+    - chip: 6
+      chan: 5
+  -
+    - chip: 2
+      chan: 10
+    - chip: 6
+      chan: 6
+  -
+    - chip: 2
+      chan: 11
+    - chip: 6
+      chan: 7
+  -
+    - chip: 2
+      chan: 12
+    - chip: 18
+      chan: 0
+  -
+    - chip: 2
+      chan: 13
+    - chip: 18
+      chan: 1
+  -
+    - chip: 2
+      chan: 14
+    - chip: 18
+      chan: 2
+  -
+    - chip: 2
+      chan: 15
+    - chip: 18
+      chan: 3
+  -
+    - chip: 3
+      chan: 8
+    - chip: 7
+      chan: 4
+  -
+    - chip: 3
+      chan: 9
+    - chip: 7
+      chan: 5
+  -
+    - chip: 3
+      chan: 10
+    - chip: 7
+      chan: 6
+  -
+    - chip: 3
+      chan: 11
+    - chip: 7
+      chan: 7
+  -
+    - chip: 3
+      chan: 12
+    - chip: 19
+      chan: 0
+  -
+    - chip: 3
+      chan: 13
+    - chip: 19
+      chan: 1
+  -
+    - chip: 3
+      chan: 14
+    - chip: 19
+      chan: 2
+  -
+    - chip: 3
+      chan: 15
+    - chip: 19
+      chan: 3
+  -
+    - chip: 4
+      chan: 8
+    - chip: 8
+      chan: 4
+  -
+    - chip: 4
+      chan: 9
+    - chip: 8
+      chan: 5
+  -
+    - chip: 4
+      chan: 10
+    - chip: 8
+      chan: 6
+  -
+    - chip: 4
+      chan: 11
+    - chip: 8
+      chan: 7
+  -
+    - chip: 4
+      chan: 12
+    - chip: 20
+      chan: 0
+  -
+    - chip: 4
+      chan: 13
+    - chip: 20
+      chan: 1
+  -
+    - chip: 4
+      chan: 14
+    - chip: 20
+      chan: 2
+  -
+    - chip: 4
+      chan: 15
+    - chip: 20
+      chan: 3
+  -
+    - chip: 5
+      chan: 8
+    - chip: 9
+      chan: 4
+  -
+    - chip: 5
+      chan: 9
+    - chip: 9
+      chan: 5
+  -
+    - chip: 5
+      chan: 10
+    - chip: 9
+      chan: 6
+  -
+    - chip: 5
+      chan: 11
+    - chip: 9
+      chan: 7
+  -
+    - chip: 5
+      chan: 12
+    - chip: 21
+      chan: 0
+  -
+    - chip: 5
+      chan: 13
+    - chip: 21
+      chan: 1
+  -
+    - chip: 5
+      chan: 14
+    - chip: 21
+      chan: 2
+  -
+    - chip: 5
+      chan: 15
+    - chip: 21
+      chan: 3
+  -
+    - chip: 6
+      chan: 8
+    - chip: 10
+      chan: 4
+  -
+    - chip: 6
+      chan: 9
+    - chip: 10
+      chan: 5
+  -
+    - chip: 6
+      chan: 10
+    - chip: 10
+      chan: 6
+  -
+    - chip: 6
+      chan: 11
+    - chip: 10
+      chan: 7
+  -
+    - chip: 6
+      chan: 12
+    - chip: 22
+      chan: 0
+  -
+    - chip: 6
+      chan: 13
+    - chip: 22
+      chan: 1
+  -
+    - chip: 6
+      chan: 14
+    - chip: 22
+      chan: 2
+  -
+    - chip: 6
+      chan: 15
+    - chip: 22
+      chan: 3
+  -
+    - chip: 7
+      chan: 8
+    - chip: 11
+      chan: 4
+  -
+    - chip: 7
+      chan: 9
+    - chip: 11
+      chan: 5
+  -
+    - chip: 7
+      chan: 10
+    - chip: 11
+      chan: 6
+  -
+    - chip: 7
+      chan: 11
+    - chip: 11
+      chan: 7
+  -
+    - chip: 7
+      chan: 12
+    - chip: 23
+      chan: 0
+  -
+    - chip: 7
+      chan: 13
+    - chip: 23
+      chan: 1
+  -
+    - chip: 7
+      chan: 14
+    - chip: 23
+      chan: 2
+  -
+    - chip: 7
+      chan: 15
+    - chip: 23
+      chan: 3
+  -
+    - chip: 8
+      chan: 8
+    - chip: 12
+      chan: 4
+  -
+    - chip: 8
+      chan: 9
+    - chip: 12
+      chan: 5
+  -
+    - chip: 8
+      chan: 10
+    - chip: 12
+      chan: 6
+  -
+    - chip: 8
+      chan: 11
+    - chip: 12
+      chan: 7
+  -
+    - chip: 8
+      chan: 12
+    - chip: 24
+      chan: 0
+  -
+    - chip: 8
+      chan: 13
+    - chip: 24
+      chan: 1
+  -
+    - chip: 8
+      chan: 14
+    - chip: 24
+      chan: 2
+  -
+    - chip: 8
+      chan: 15
+    - chip: 24
+      chan: 3
+  -
+    - chip: 9
+      chan: 8
+    - chip: 13
+      chan: 4
+  -
+    - chip: 9
+      chan: 9
+    - chip: 13
+      chan: 5
+  -
+    - chip: 9
+      chan: 10
+    - chip: 13
+      chan: 6
+  -
+    - chip: 9
+      chan: 11
+    - chip: 13
+      chan: 7
+  -
+    - chip: 9
+      chan: 12
+    - chip: 25
+      chan: 0
+  -
+    - chip: 9
+      chan: 13
+    - chip: 25
+      chan: 1
+  -
+    - chip: 9
+      chan: 14
+    - chip: 25
+      chan: 2
+  -
+    - chip: 9
+      chan: 15
+    - chip: 25
+      chan: 3
+  -
+    - chip: 10
+      chan: 8
+    - chip: 14
+      chan: 4
+  -
+    - chip: 10
+      chan: 9
+    - chip: 14
+      chan: 5
+  -
+    - chip: 10
+      chan: 10
+    - chip: 14
+      chan: 6
+  -
+    - chip: 10
+      chan: 11
+    - chip: 14
+      chan: 7
+  -
+    - chip: 10
+      chan: 12
+    - chip: 26
+      chan: 0
+  -
+    - chip: 10
+      chan: 13
+    - chip: 26
+      chan: 1
+  -
+    - chip: 10
+      chan: 14
+    - chip: 26
+      chan: 2
+  -
+    - chip: 10
+      chan: 15
+    - chip: 26
+      chan: 3
+  -
+    - chip: 11
+      chan: 8
+    - chip: 15
+      chan: 4
+  -
+    - chip: 11
+      chan: 9
+    - chip: 15
+      chan: 5
+  -
+    - chip: 11
+      chan: 10
+    - chip: 15
+      chan: 6
+  -
+    - chip: 11
+      chan: 11
+    - chip: 15
+      chan: 7
+  -
+    - chip: 11
+      chan: 12
+    - chip: 27
+      chan: 0
+  -
+    - chip: 11
+      chan: 13
+    - chip: 27
+      chan: 1
+  -
+    - chip: 11
+      chan: 14
+    - chip: 27
+      chan: 2
+  -
+    - chip: 11
+      chan: 15
+    - chip: 27
+      chan: 3
+  -
+    - chip: 12
+      chan: 8
+    - chip: 15
+      chan: 8
+  -
+    - chip: 12
+      chan: 9
+    - chip: 15
+      chan: 9
+  -
+    - chip: 12
+      chan: 10
+    - chip: 15
+      chan: 10
+  -
+    - chip: 12
+      chan: 11
+    - chip: 15
+      chan: 11
+  -
+    - chip: 12
+      chan: 12
+    - chip: 28
+      chan: 0
+  -
+    - chip: 12
+      chan: 13
+    - chip: 28
+      chan: 1
+  -
+    - chip: 12
+      chan: 14
+    - chip: 28
+      chan: 2
+  -
+    - chip: 12
+      chan: 15
+    - chip: 28
+      chan: 3
+  -
+    - chip: 13
+      chan: 8
+    - chip: 14
+      chan: 8
+  -
+    - chip: 13
+      chan: 9
+    - chip: 14
+      chan: 9
+  -
+    - chip: 13
+      chan: 10
+    - chip: 14
+      chan: 10
+  -
+    - chip: 13
+      chan: 11
+    - chip: 14
+      chan: 11
+  -
+    - chip: 13
+      chan: 12
+    - chip: 29
+      chan: 0
+  -
+    - chip: 13
+      chan: 13
+    - chip: 29
+      chan: 1
+  -
+    - chip: 13
+      chan: 14
+    - chip: 29
+      chan: 2
+  -
+    - chip: 13
+      chan: 15
+    - chip: 29
+      chan: 3
+  -
+    - chip: 14
+      chan: 12
+    - chip: 30
+      chan: 0
+  -
+    - chip: 14
+      chan: 13
+    - chip: 30
+      chan: 1
+  -
+    - chip: 14
+      chan: 14
+    - chip: 30
+      chan: 2
+  -
+    - chip: 14
+      chan: 15
+    - chip: 30
+      chan: 3
+  -
+    - chip: 15
+      chan: 12
+    - chip: 31
+      chan: 0
+  -
+    - chip: 15
+      chan: 13
+    - chip: 31
+      chan: 1
+  -
+    - chip: 15
+      chan: 14
+    - chip: 31
+      chan: 2
+  -
+    - chip: 15
+      chan: 15
+    - chip: 31
+      chan: 3
+  -
+    - chip: 16
+      chan: 4
+    - chip: 19
+      chan: 4
+  -
+    - chip: 16
+      chan: 5
+    - chip: 19
+      chan: 5
+  -
+    - chip: 16
+      chan: 6
+    - chip: 19
+      chan: 6
+  -
+    - chip: 16
+      chan: 7
+    - chip: 19
+      chan: 7
+  -
+    - chip: 16
+      chan: 8
+    - chip: 20
+      chan: 4
+  -
+    - chip: 16
+      chan: 9
+    - chip: 20
+      chan: 5
+  -
+    - chip: 16
+      chan: 10
+    - chip: 20
+      chan: 6
+  -
+    - chip: 16
+      chan: 11
+    - chip: 20
+      chan: 7
+  -
+    - chip: 16
+      chan: 12
+    - chip: 18
+      chan: 12
+  -
+    - chip: 16
+      chan: 13
+    - chip: 18
+      chan: 13
+  -
+    - chip: 16
+      chan: 14
+    - chip: 18
+      chan: 14
+  -
+    - chip: 16
+      chan: 15
+    - chip: 18
+      chan: 15
+  -
+    - chip: 17
+      chan: 4
+    - chip: 18
+      chan: 4
+  -
+    - chip: 17
+      chan: 5
+    - chip: 18
+      chan: 5
+  -
+    - chip: 17
+      chan: 6
+    - chip: 18
+      chan: 6
+  -
+    - chip: 17
+      chan: 7
+    - chip: 18
+      chan: 7
+  -
+    - chip: 17
+      chan: 8
+    - chip: 21
+      chan: 4
+  -
+    - chip: 17
+      chan: 9
+    - chip: 21
+      chan: 5
+  -
+    - chip: 17
+      chan: 10
+    - chip: 21
+      chan: 6
+  -
+    - chip: 17
+      chan: 11
+    - chip: 21
+      chan: 7
+  -
+    - chip: 17
+      chan: 12
+    - chip: 19
+      chan: 12
+  -
+    - chip: 17
+      chan: 13
+    - chip: 19
+      chan: 13
+  -
+    - chip: 17
+      chan: 14
+    - chip: 19
+      chan: 14
+  -
+    - chip: 17
+      chan: 15
+    - chip: 19
+      chan: 15
+  -
+    - chip: 18
+      chan: 8
+    - chip: 22
+      chan: 4
+  -
+    - chip: 18
+      chan: 9
+    - chip: 22
+      chan: 5
+  -
+    - chip: 18
+      chan: 10
+    - chip: 22
+      chan: 6
+  -
+    - chip: 18
+      chan: 11
+    - chip: 22
+      chan: 7
+  -
+    - chip: 19
+      chan: 8
+    - chip: 23
+      chan: 4
+  -
+    - chip: 19
+      chan: 9
+    - chip: 23
+      chan: 5
+  -
+    - chip: 19
+      chan: 10
+    - chip: 23
+      chan: 6
+  -
+    - chip: 19
+      chan: 11
+    - chip: 23
+      chan: 7
+  -
+    - chip: 20
+      chan: 8
+    - chip: 24
+      chan: 4
+  -
+    - chip: 20
+      chan: 9
+    - chip: 24
+      chan: 5
+  -
+    - chip: 20
+      chan: 10
+    - chip: 24
+      chan: 6
+  -
+    - chip: 20
+      chan: 11
+    - chip: 24
+      chan: 7
+  -
+    - chip: 20
+      chan: 12
+    - chip: 22
+      chan: 12
+  -
+    - chip: 20
+      chan: 13
+    - chip: 22
+      chan: 13
+  -
+    - chip: 20
+      chan: 14
+    - chip: 22
+      chan: 14
+  -
+    - chip: 20
+      chan: 15
+    - chip: 22
+      chan: 15
+  -
+    - chip: 21
+      chan: 8
+    - chip: 25
+      chan: 4
+  -
+    - chip: 21
+      chan: 9
+    - chip: 25
+      chan: 5
+  -
+    - chip: 21
+      chan: 10
+    - chip: 25
+      chan: 6
+  -
+    - chip: 21
+      chan: 11
+    - chip: 25
+      chan: 7
+  -
+    - chip: 21
+      chan: 12
+    - chip: 23
+      chan: 12
+  -
+    - chip: 21
+      chan: 13
+    - chip: 23
+      chan: 13
+  -
+    - chip: 21
+      chan: 14
+    - chip: 23
+      chan: 14
+  -
+    - chip: 21
+      chan: 15
+    - chip: 23
+      chan: 15
+  -
+    - chip: 22
+      chan: 8
+    - chip: 26
+      chan: 4
+  -
+    - chip: 22
+      chan: 9
+    - chip: 26
+      chan: 5
+  -
+    - chip: 22
+      chan: 10
+    - chip: 26
+      chan: 6
+  -
+    - chip: 22
+      chan: 11
+    - chip: 26
+      chan: 7
+  -
+    - chip: 23
+      chan: 8
+    - chip: 27
+      chan: 4
+  -
+    - chip: 23
+      chan: 9
+    - chip: 27
+      chan: 5
+  -
+    - chip: 23
+      chan: 10
+    - chip: 27
+      chan: 6
+  -
+    - chip: 23
+      chan: 11
+    - chip: 27
+      chan: 7
+  -
+    - chip: 24
+      chan: 8
+    - chip: 28
+      chan: 4
+  -
+    - chip: 24
+      chan: 9
+    - chip: 28
+      chan: 5
+  -
+    - chip: 24
+      chan: 10
+    - chip: 28
+      chan: 6
+  -
+    - chip: 24
+      chan: 11
+    - chip: 28
+      chan: 7
+  -
+    - chip: 24
+      chan: 12
+    - chip: 26
+      chan: 12
+  -
+    - chip: 24
+      chan: 13
+    - chip: 26
+      chan: 13
+  -
+    - chip: 24
+      chan: 14
+    - chip: 26
+      chan: 14
+  -
+    - chip: 24
+      chan: 15
+    - chip: 26
+      chan: 15
+  -
+    - chip: 25
+      chan: 8
+    - chip: 29
+      chan: 4
+  -
+    - chip: 25
+      chan: 9
+    - chip: 29
+      chan: 5
+  -
+    - chip: 25
+      chan: 10
+    - chip: 29
+      chan: 6
+  -
+    - chip: 25
+      chan: 11
+    - chip: 29
+      chan: 7
+  -
+    - chip: 25
+      chan: 12
+    - chip: 27
+      chan: 12
+  -
+    - chip: 25
+      chan: 13
+    - chip: 27
+      chan: 13
+  -
+    - chip: 25
+      chan: 14
+    - chip: 27
+      chan: 14
+  -
+    - chip: 25
+      chan: 15
+    - chip: 27
+      chan: 15
+  -
+    - chip: 26
+      chan: 8
+    - chip: 30
+      chan: 4
+  -
+    - chip: 26
+      chan: 9
+    - chip: 30
+      chan: 5
+  -
+    - chip: 26
+      chan: 10
+    - chip: 30
+      chan: 6
+  -
+    - chip: 26
+      chan: 11
+    - chip: 30
+      chan: 7
+  -
+    - chip: 27
+      chan: 8
+    - chip: 31
+      chan: 4
+  -
+    - chip: 27
+      chan: 9
+    - chip: 31
+      chan: 5
+  -
+    - chip: 27
+      chan: 10
+    - chip: 31
+      chan: 6
+  -
+    - chip: 27
+      chan: 11
+    - chip: 31
+      chan: 7
+  -
+    - chip: 28
+      chan: 8
+    - chip: 31
+      chan: 8
+  -
+    - chip: 28
+      chan: 9
+    - chip: 31
+      chan: 9
+  -
+    - chip: 28
+      chan: 10
+    - chip: 31
+      chan: 10
+  -
+    - chip: 28
+      chan: 11
+    - chip: 31
+      chan: 11
+  -
+    - chip: 28
+      chan: 12
+    - chip: 30
+      chan: 12
+  -
+    - chip: 28
+      chan: 13
+    - chip: 30
+      chan: 13
+  -
+    - chip: 28
+      chan: 14
+    - chip: 30
+      chan: 14
+  -
+    - chip: 28
+      chan: 15
+    - chip: 30
+      chan: 15
+  -
+    - chip: 29
+      chan: 8
+    - chip: 30
+      chan: 8
+  -
+    - chip: 29
+      chan: 9
+    - chip: 30
+      chan: 9
+  -
+    - chip: 29
+      chan: 10
+    - chip: 30
+      chan: 10
+  -
+    - chip: 29
+      chan: 11
+    - chip: 30
+      chan: 11
+  -
+    - chip: 29
+      chan: 12
+    - chip: 31
+      chan: 12
+  -
+    - chip: 29
+      chan: 13
+    - chip: 31
+      chan: 13
+  -
+    - chip: 29
+      chan: 14
+    - chip: 31
+      chan: 14
+  -
+    - chip: 29
+      chan: 15
+    - chip: 31
+      chan: 15
+ethernet_connections_to_remote_devices:
+  -
+    - chip: 15
+      chan: 3
+    - remote_chip_id: 303201572097110337
+      chan: 3
+  -
+    - chip: 15
+      chan: 2
+    - remote_chip_id: 303201572097110337
+      chan: 2
+  -
+    - chip: 15
+      chan: 1
+    - remote_chip_id: 303201572097110337
+      chan: 1
+  -
+    - chip: 15
+      chan: 0
+    - remote_chip_id: 303201572097110337
+      chan: 0
+  -
+    - chip: 14
+      chan: 3
+    - remote_chip_id: 303201559212208206
+      chan: 3
+  -
+    - chip: 14
+      chan: 2
+    - remote_chip_id: 303201559212208206
+      chan: 2
+  -
+    - chip: 14
+      chan: 1
+    - remote_chip_id: 303201559212208206
+      chan: 1
+  -
+    - chip: 14
+      chan: 0
+    - remote_chip_id: 303201559212208206
+      chan: 0
+  -
+    - chip: 13
+      chan: 3
+    - remote_chip_id: 303201572097110096
+      chan: 3
+  -
+    - chip: 13
+      chan: 2
+    - remote_chip_id: 303201572097110096
+      chan: 2
+  -
+    - chip: 13
+      chan: 1
+    - remote_chip_id: 303201572097110096
+      chan: 1
+  -
+    - chip: 13
+      chan: 0
+    - remote_chip_id: 303201572097110096
+      chan: 0
+  -
+    - chip: 0
+      chan: 3
+    - remote_chip_id: 87028789983326547
+      chan: 3
+  -
+    - chip: 0
+      chan: 2
+    - remote_chip_id: 87028789983326547
+      chan: 2
+  -
+    - chip: 0
+      chan: 1
+    - remote_chip_id: 87028789983326547
+      chan: 1
+  -
+    - chip: 0
+      chan: 0
+    - remote_chip_id: 87028789983326547
+      chan: 0
+  -
+    - chip: 1
+      chan: 3
+    - remote_chip_id: 87028789983326288
+      chan: 3
+  -
+    - chip: 1
+      chan: 2
+    - remote_chip_id: 87028789983326288
+      chan: 2
+  -
+    - chip: 1
+      chan: 1
+    - remote_chip_id: 87028789983326288
+      chan: 1
+  -
+    - chip: 1
+      chan: 0
+    - remote_chip_id: 87028789983326288
+      chan: 0
+  -
+    - chip: 2
+      chan: 3
+    - remote_chip_id: 87028777098424398
+      chan: 3
+  -
+    - chip: 2
+      chan: 2
+    - remote_chip_id: 87028777098424398
+      chan: 2
+  -
+    - chip: 2
+      chan: 1
+    - remote_chip_id: 87028777098424398
+      chan: 1
+  -
+    - chip: 2
+      chan: 0
+    - remote_chip_id: 87028777098424398
+      chan: 0
+  -
+    - chip: 3
+      chan: 3
+    - remote_chip_id: 87028789983326529
+      chan: 3
+  -
+    - chip: 3
+      chan: 2
+    - remote_chip_id: 87028789983326529
+      chan: 2
+  -
+    - chip: 3
+      chan: 1
+    - remote_chip_id: 87028789983326529
+      chan: 1
+  -
+    - chip: 3
+      chan: 0
+    - remote_chip_id: 87028789983326529
+      chan: 0
+  -
+    - chip: 4
+      chan: 3
+    - remote_chip_id: 159086384021254483
+      chan: 3
+  -
+    - chip: 4
+      chan: 2
+    - remote_chip_id: 159086384021254483
+      chan: 2
+  -
+    - chip: 4
+      chan: 1
+    - remote_chip_id: 159086384021254483
+      chan: 1
+  -
+    - chip: 4
+      chan: 0
+    - remote_chip_id: 159086384021254483
+      chan: 0
+  -
+    - chip: 5
+      chan: 3
+    - remote_chip_id: 159086384021254224
+      chan: 3
+  -
+    - chip: 5
+      chan: 2
+    - remote_chip_id: 159086384021254224
+      chan: 2
+  -
+    - chip: 5
+      chan: 1
+    - remote_chip_id: 159086384021254224
+      chan: 1
+  -
+    - chip: 5
+      chan: 0
+    - remote_chip_id: 159086384021254224
+      chan: 0
+  -
+    - chip: 6
+      chan: 3
+    - remote_chip_id: 159086371136352334
+      chan: 3
+  -
+    - chip: 6
+      chan: 2
+    - remote_chip_id: 159086371136352334
+      chan: 2
+  -
+    - chip: 6
+      chan: 1
+    - remote_chip_id: 159086371136352334
+      chan: 1
+  -
+    - chip: 6
+      chan: 0
+    - remote_chip_id: 159086371136352334
+      chan: 0
+  -
+    - chip: 7
+      chan: 3
+    - remote_chip_id: 159086384021254465
+      chan: 3
+  -
+    - chip: 7
+      chan: 2
+    - remote_chip_id: 159086384021254465
+      chan: 2
+  -
+    - chip: 7
+      chan: 1
+    - remote_chip_id: 159086384021254465
+      chan: 1
+  -
+    - chip: 7
+      chan: 0
+    - remote_chip_id: 159086384021254465
+      chan: 0
+  -
+    - chip: 8
+      chan: 3
+    - remote_chip_id: 231143978059182419
+      chan: 3
+  -
+    - chip: 8
+      chan: 2
+    - remote_chip_id: 231143978059182419
+      chan: 2
+  -
+    - chip: 8
+      chan: 1
+    - remote_chip_id: 231143978059182419
+      chan: 1
+  -
+    - chip: 8
+      chan: 0
+    - remote_chip_id: 231143978059182419
+      chan: 0
+  -
+    - chip: 9
+      chan: 3
+    - remote_chip_id: 231143978059182160
+      chan: 3
+  -
+    - chip: 9
+      chan: 2
+    - remote_chip_id: 231143978059182160
+      chan: 2
+  -
+    - chip: 9
+      chan: 1
+    - remote_chip_id: 231143978059182160
+      chan: 1
+  -
+    - chip: 9
+      chan: 0
+    - remote_chip_id: 231143978059182160
+      chan: 0
+  -
+    - chip: 10
+      chan: 3
+    - remote_chip_id: 231143965174280270
+      chan: 3
+  -
+    - chip: 10
+      chan: 2
+    - remote_chip_id: 231143965174280270
+      chan: 2
+  -
+    - chip: 10
+      chan: 1
+    - remote_chip_id: 231143965174280270
+      chan: 1
+  -
+    - chip: 10
+      chan: 0
+    - remote_chip_id: 231143965174280270
+      chan: 0
+  -
+    - chip: 11
+      chan: 3
+    - remote_chip_id: 231143978059182401
+      chan: 3
+  -
+    - chip: 11
+      chan: 2
+    - remote_chip_id: 231143978059182401
+      chan: 2
+  -
+    - chip: 11
+      chan: 1
+    - remote_chip_id: 231143978059182401
+      chan: 1
+  -
+    - chip: 11
+      chan: 0
+    - remote_chip_id: 231143978059182401
+      chan: 0
+  -
+    - chip: 12
+      chan: 3
+    - remote_chip_id: 303201572097110355
+      chan: 3
+  -
+    - chip: 12
+      chan: 2
+    - remote_chip_id: 303201572097110355
+      chan: 2
+  -
+    - chip: 12
+      chan: 1
+    - remote_chip_id: 303201572097110355
+      chan: 1
+  -
+    - chip: 12
+      chan: 0
+    - remote_chip_id: 303201572097110355
+      chan: 0
+chips_with_mmio:
+  - 0: 8
+  - 1: 17
+  - 2: 3
+  - 3: 27
+  - 4: 14
+  - 5: 18
+  - 6: 2
+  - 7: 26
+  - 8: 11
+  - 9: 19
+  - 10: 1
+  - 11: 29
+  - 12: 7
+  - 13: 22
+  - 14: 0
+  - 15: 28
+  - 16: 10
+  - 17: 15
+  - 18: 6
+  - 19: 23
+  - 20: 16
+  - 21: 25
+  - 22: 9
+  - 23: 30
+  - 24: 13
+  - 25: 21
+  - 26: 4
+  - 27: 24
+  - 28: 12
+  - 29: 20
+  - 30: 5
+  - 31: 31
+io_device_type: PCIe
+harvesting:
+  0:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  1:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  2:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  3:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  4:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  5:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  6:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  7:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  8:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  9:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  10:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  11:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  12:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  13:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  14:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  15:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  16:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  17:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  18:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  19:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  20:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  21:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  22:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  23:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  24:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  25:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  26:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  27:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  28:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  29:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  30:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  31:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+chip_to_boardtype:
+  0: ubb
+  1: ubb
+  2: ubb
+  3: ubb
+  4: ubb
+  5: ubb
+  6: ubb
+  7: ubb
+  8: ubb
+  9: ubb
+  10: ubb
+  11: ubb
+  12: ubb
+  13: ubb
+  14: ubb
+  15: ubb
+  16: ubb
+  17: ubb
+  18: ubb
+  19: ubb
+  20: ubb
+  21: ubb
+  22: ubb
+  23: ubb
+  24: ubb
+  25: ubb
+  26: ubb
+  27: ubb
+  28: ubb
+  29: ubb
+  30: ubb
+  31: ubb
+chip_to_bus_id:
+  0: 0x0081
+  1: 0x0001
+  2: 0x00c1
+  3: 0x0041
+  4: 0x0082
+  5: 0x0002
+  6: 0x00c2
+  7: 0x0042
+  8: 0x0083
+  9: 0x0003
+  10: 0x00c3
+  11: 0x0043
+  12: 0x0084
+  13: 0x0004
+  14: 0x00c4
+  15: 0x0044
+  16: 0x0085
+  17: 0x0005
+  18: 0x00c5
+  19: 0x0045
+  20: 0x0086
+  21: 0x0006
+  22: 0x00c6
+  23: 0x0046
+  24: 0x0087
+  25: 0x0007
+  26: 0x00c7
+  27: 0x0047
+  28: 0x0088
+  29: 0x0008
+  30: 0x00c8
+  31: 0x0048
+boards:
+  -
+    - board_id: 72061240465162240
+    - board_type: ubb
+    - chips:
+        - 31
+        - 27
+        - 23
+        - 19
+        - 15
+        - 11
+        - 7
+        - 3
+  -
+    - board_id: 72061241270468608
+    - board_type: ubb
+    - chips:
+        - 28
+        - 26
+        - 25
+        - 24
+        - 22
+        - 21
+        - 20
+        - 18
+        - 17
+        - 29
+        - 0
+        - 13
+        - 30
+        - 1
+        - 14
+        - 2
+        - 4
+        - 5
+        - 6
+        - 8
+        - 9
+        - 10
+        - 12
+        - 16
+asic_locations:
+  0: 1
+  1: 1
+  2: 1
+  3: 1
+  4: 2
+  5: 2
+  6: 2
+  7: 2
+  8: 3
+  9: 3
+  10: 3
+  11: 3
+  12: 4
+  13: 4
+  14: 4
+  15: 4
+  16: 5
+  17: 5
+  18: 5
+  19: 5
+  20: 6
+  21: 6
+  22: 6
+  23: 6
+  24: 7
+  25: 7
+  26: 7
+  27: 7
+  28: 8
+  29: 8
+  30: 8
+  31: 8

--- a/tests/tt_metal/tt_fabric/custom_mock_cluster_descriptors/6u_quad_host_cluster_desc_rank_2.yaml
+++ b/tests/tt_metal/tt_fabric/custom_mock_cluster_descriptors/6u_quad_host_cluster_desc_rank_2.yaml
@@ -1,0 +1,1905 @@
+arch:
+  0: wormhole_b0
+  1: wormhole_b0
+  2: wormhole_b0
+  3: wormhole_b0
+  4: wormhole_b0
+  5: wormhole_b0
+  6: wormhole_b0
+  7: wormhole_b0
+  8: wormhole_b0
+  9: wormhole_b0
+  10: wormhole_b0
+  11: wormhole_b0
+  12: wormhole_b0
+  13: wormhole_b0
+  14: wormhole_b0
+  15: wormhole_b0
+  16: wormhole_b0
+  17: wormhole_b0
+  18: wormhole_b0
+  19: wormhole_b0
+  20: wormhole_b0
+  21: wormhole_b0
+  22: wormhole_b0
+  23: wormhole_b0
+  24: wormhole_b0
+  25: wormhole_b0
+  26: wormhole_b0
+  27: wormhole_b0
+  28: wormhole_b0
+  29: wormhole_b0
+  30: wormhole_b0
+  31: wormhole_b0
+chips:
+  {}
+chip_unique_ids:
+  31: 591431948248822102
+  30: 591431948248822099
+  29: 591431948248822081
+  12: 303201572097110327
+  11: 231143978059182422
+  10: 231143978059182419
+  9: 231143978059182401
+  8: 231143978059182391
+  7: 159086384021254486
+  6: 159086384021254483
+  5: 159086384021254465
+  4: 159086384021254455
+  3: 87028789983326550
+  2: 87028789983326547
+  1: 87028789983326529
+  0: 87028789983326519
+  13: 303201572097110337
+  14: 303201572097110355
+  15: 303201572097110358
+  16: 375259166135038263
+  17: 375259166135038273
+  18: 375259166135038291
+  19: 375259166135038294
+  20: 447316760172966199
+  21: 447316760172966209
+  22: 447316760172966227
+  23: 447316760172966230
+  24: 519374354210894135
+  25: 519374354210894145
+  26: 519374354210894163
+  27: 519374354210894166
+  28: 591431948248822071
+ethernet_connections:
+  -
+    - chip: 0
+      chan: 4
+    - chip: 3
+      chan: 4
+  -
+    - chip: 0
+      chan: 5
+    - chip: 3
+      chan: 5
+  -
+    - chip: 0
+      chan: 6
+    - chip: 3
+      chan: 6
+  -
+    - chip: 0
+      chan: 7
+    - chip: 3
+      chan: 7
+  -
+    - chip: 0
+      chan: 8
+    - chip: 4
+      chan: 4
+  -
+    - chip: 0
+      chan: 9
+    - chip: 4
+      chan: 5
+  -
+    - chip: 0
+      chan: 10
+    - chip: 4
+      chan: 6
+  -
+    - chip: 0
+      chan: 11
+    - chip: 4
+      chan: 7
+  -
+    - chip: 0
+      chan: 12
+    - chip: 16
+      chan: 0
+  -
+    - chip: 0
+      chan: 13
+    - chip: 16
+      chan: 1
+  -
+    - chip: 0
+      chan: 14
+    - chip: 16
+      chan: 2
+  -
+    - chip: 0
+      chan: 15
+    - chip: 16
+      chan: 3
+  -
+    - chip: 1
+      chan: 4
+    - chip: 2
+      chan: 4
+  -
+    - chip: 1
+      chan: 5
+    - chip: 2
+      chan: 5
+  -
+    - chip: 1
+      chan: 6
+    - chip: 2
+      chan: 6
+  -
+    - chip: 1
+      chan: 7
+    - chip: 2
+      chan: 7
+  -
+    - chip: 1
+      chan: 8
+    - chip: 5
+      chan: 4
+  -
+    - chip: 1
+      chan: 9
+    - chip: 5
+      chan: 5
+  -
+    - chip: 1
+      chan: 10
+    - chip: 5
+      chan: 6
+  -
+    - chip: 1
+      chan: 11
+    - chip: 5
+      chan: 7
+  -
+    - chip: 1
+      chan: 12
+    - chip: 17
+      chan: 0
+  -
+    - chip: 1
+      chan: 13
+    - chip: 17
+      chan: 1
+  -
+    - chip: 1
+      chan: 14
+    - chip: 17
+      chan: 2
+  -
+    - chip: 1
+      chan: 15
+    - chip: 17
+      chan: 3
+  -
+    - chip: 2
+      chan: 8
+    - chip: 6
+      chan: 4
+  -
+    - chip: 2
+      chan: 9
+    - chip: 6
+      chan: 5
+  -
+    - chip: 2
+      chan: 10
+    - chip: 6
+      chan: 6
+  -
+    - chip: 2
+      chan: 11
+    - chip: 6
+      chan: 7
+  -
+    - chip: 2
+      chan: 12
+    - chip: 18
+      chan: 0
+  -
+    - chip: 2
+      chan: 13
+    - chip: 18
+      chan: 1
+  -
+    - chip: 2
+      chan: 14
+    - chip: 18
+      chan: 2
+  -
+    - chip: 2
+      chan: 15
+    - chip: 18
+      chan: 3
+  -
+    - chip: 3
+      chan: 8
+    - chip: 7
+      chan: 4
+  -
+    - chip: 3
+      chan: 9
+    - chip: 7
+      chan: 5
+  -
+    - chip: 3
+      chan: 10
+    - chip: 7
+      chan: 6
+  -
+    - chip: 3
+      chan: 11
+    - chip: 7
+      chan: 7
+  -
+    - chip: 3
+      chan: 12
+    - chip: 19
+      chan: 0
+  -
+    - chip: 3
+      chan: 13
+    - chip: 19
+      chan: 1
+  -
+    - chip: 3
+      chan: 14
+    - chip: 19
+      chan: 2
+  -
+    - chip: 3
+      chan: 15
+    - chip: 19
+      chan: 3
+  -
+    - chip: 4
+      chan: 8
+    - chip: 8
+      chan: 4
+  -
+    - chip: 4
+      chan: 9
+    - chip: 8
+      chan: 5
+  -
+    - chip: 4
+      chan: 10
+    - chip: 8
+      chan: 6
+  -
+    - chip: 4
+      chan: 11
+    - chip: 8
+      chan: 7
+  -
+    - chip: 4
+      chan: 12
+    - chip: 20
+      chan: 0
+  -
+    - chip: 4
+      chan: 13
+    - chip: 20
+      chan: 1
+  -
+    - chip: 4
+      chan: 14
+    - chip: 20
+      chan: 2
+  -
+    - chip: 4
+      chan: 15
+    - chip: 20
+      chan: 3
+  -
+    - chip: 5
+      chan: 8
+    - chip: 9
+      chan: 4
+  -
+    - chip: 5
+      chan: 9
+    - chip: 9
+      chan: 5
+  -
+    - chip: 5
+      chan: 10
+    - chip: 9
+      chan: 6
+  -
+    - chip: 5
+      chan: 11
+    - chip: 9
+      chan: 7
+  -
+    - chip: 5
+      chan: 12
+    - chip: 21
+      chan: 0
+  -
+    - chip: 5
+      chan: 13
+    - chip: 21
+      chan: 1
+  -
+    - chip: 5
+      chan: 14
+    - chip: 21
+      chan: 2
+  -
+    - chip: 5
+      chan: 15
+    - chip: 21
+      chan: 3
+  -
+    - chip: 6
+      chan: 8
+    - chip: 10
+      chan: 4
+  -
+    - chip: 6
+      chan: 9
+    - chip: 10
+      chan: 5
+  -
+    - chip: 6
+      chan: 10
+    - chip: 10
+      chan: 6
+  -
+    - chip: 6
+      chan: 11
+    - chip: 10
+      chan: 7
+  -
+    - chip: 6
+      chan: 12
+    - chip: 22
+      chan: 0
+  -
+    - chip: 6
+      chan: 13
+    - chip: 22
+      chan: 1
+  -
+    - chip: 6
+      chan: 14
+    - chip: 22
+      chan: 2
+  -
+    - chip: 6
+      chan: 15
+    - chip: 22
+      chan: 3
+  -
+    - chip: 7
+      chan: 8
+    - chip: 11
+      chan: 4
+  -
+    - chip: 7
+      chan: 9
+    - chip: 11
+      chan: 5
+  -
+    - chip: 7
+      chan: 10
+    - chip: 11
+      chan: 6
+  -
+    - chip: 7
+      chan: 11
+    - chip: 11
+      chan: 7
+  -
+    - chip: 7
+      chan: 12
+    - chip: 23
+      chan: 0
+  -
+    - chip: 7
+      chan: 13
+    - chip: 23
+      chan: 1
+  -
+    - chip: 7
+      chan: 14
+    - chip: 23
+      chan: 2
+  -
+    - chip: 7
+      chan: 15
+    - chip: 23
+      chan: 3
+  -
+    - chip: 8
+      chan: 8
+    - chip: 12
+      chan: 4
+  -
+    - chip: 8
+      chan: 9
+    - chip: 12
+      chan: 5
+  -
+    - chip: 8
+      chan: 10
+    - chip: 12
+      chan: 6
+  -
+    - chip: 8
+      chan: 11
+    - chip: 12
+      chan: 7
+  -
+    - chip: 8
+      chan: 12
+    - chip: 24
+      chan: 0
+  -
+    - chip: 8
+      chan: 13
+    - chip: 24
+      chan: 1
+  -
+    - chip: 8
+      chan: 14
+    - chip: 24
+      chan: 2
+  -
+    - chip: 8
+      chan: 15
+    - chip: 24
+      chan: 3
+  -
+    - chip: 9
+      chan: 8
+    - chip: 13
+      chan: 4
+  -
+    - chip: 9
+      chan: 9
+    - chip: 13
+      chan: 5
+  -
+    - chip: 9
+      chan: 10
+    - chip: 13
+      chan: 6
+  -
+    - chip: 9
+      chan: 11
+    - chip: 13
+      chan: 7
+  -
+    - chip: 9
+      chan: 12
+    - chip: 25
+      chan: 0
+  -
+    - chip: 9
+      chan: 13
+    - chip: 25
+      chan: 1
+  -
+    - chip: 9
+      chan: 14
+    - chip: 25
+      chan: 2
+  -
+    - chip: 9
+      chan: 15
+    - chip: 25
+      chan: 3
+  -
+    - chip: 10
+      chan: 8
+    - chip: 14
+      chan: 4
+  -
+    - chip: 10
+      chan: 9
+    - chip: 14
+      chan: 5
+  -
+    - chip: 10
+      chan: 10
+    - chip: 14
+      chan: 6
+  -
+    - chip: 10
+      chan: 11
+    - chip: 14
+      chan: 7
+  -
+    - chip: 10
+      chan: 12
+    - chip: 26
+      chan: 0
+  -
+    - chip: 10
+      chan: 13
+    - chip: 26
+      chan: 1
+  -
+    - chip: 10
+      chan: 14
+    - chip: 26
+      chan: 2
+  -
+    - chip: 10
+      chan: 15
+    - chip: 26
+      chan: 3
+  -
+    - chip: 11
+      chan: 8
+    - chip: 15
+      chan: 4
+  -
+    - chip: 11
+      chan: 9
+    - chip: 15
+      chan: 5
+  -
+    - chip: 11
+      chan: 10
+    - chip: 15
+      chan: 6
+  -
+    - chip: 11
+      chan: 11
+    - chip: 15
+      chan: 7
+  -
+    - chip: 11
+      chan: 12
+    - chip: 27
+      chan: 0
+  -
+    - chip: 11
+      chan: 13
+    - chip: 27
+      chan: 1
+  -
+    - chip: 11
+      chan: 14
+    - chip: 27
+      chan: 2
+  -
+    - chip: 11
+      chan: 15
+    - chip: 27
+      chan: 3
+  -
+    - chip: 12
+      chan: 8
+    - chip: 15
+      chan: 8
+  -
+    - chip: 12
+      chan: 9
+    - chip: 15
+      chan: 9
+  -
+    - chip: 12
+      chan: 10
+    - chip: 15
+      chan: 10
+  -
+    - chip: 12
+      chan: 11
+    - chip: 15
+      chan: 11
+  -
+    - chip: 12
+      chan: 12
+    - chip: 28
+      chan: 0
+  -
+    - chip: 12
+      chan: 13
+    - chip: 28
+      chan: 1
+  -
+    - chip: 12
+      chan: 14
+    - chip: 28
+      chan: 2
+  -
+    - chip: 12
+      chan: 15
+    - chip: 28
+      chan: 3
+  -
+    - chip: 13
+      chan: 8
+    - chip: 14
+      chan: 8
+  -
+    - chip: 13
+      chan: 9
+    - chip: 14
+      chan: 9
+  -
+    - chip: 13
+      chan: 10
+    - chip: 14
+      chan: 10
+  -
+    - chip: 13
+      chan: 11
+    - chip: 14
+      chan: 11
+  -
+    - chip: 13
+      chan: 12
+    - chip: 29
+      chan: 0
+  -
+    - chip: 13
+      chan: 13
+    - chip: 29
+      chan: 1
+  -
+    - chip: 13
+      chan: 14
+    - chip: 29
+      chan: 2
+  -
+    - chip: 13
+      chan: 15
+    - chip: 29
+      chan: 3
+  -
+    - chip: 14
+      chan: 12
+    - chip: 30
+      chan: 0
+  -
+    - chip: 14
+      chan: 13
+    - chip: 30
+      chan: 1
+  -
+    - chip: 14
+      chan: 14
+    - chip: 30
+      chan: 2
+  -
+    - chip: 14
+      chan: 15
+    - chip: 30
+      chan: 3
+  -
+    - chip: 15
+      chan: 12
+    - chip: 31
+      chan: 0
+  -
+    - chip: 15
+      chan: 13
+    - chip: 31
+      chan: 1
+  -
+    - chip: 15
+      chan: 14
+    - chip: 31
+      chan: 2
+  -
+    - chip: 15
+      chan: 15
+    - chip: 31
+      chan: 3
+  -
+    - chip: 16
+      chan: 4
+    - chip: 19
+      chan: 4
+  -
+    - chip: 16
+      chan: 5
+    - chip: 19
+      chan: 5
+  -
+    - chip: 16
+      chan: 6
+    - chip: 19
+      chan: 6
+  -
+    - chip: 16
+      chan: 7
+    - chip: 19
+      chan: 7
+  -
+    - chip: 16
+      chan: 8
+    - chip: 20
+      chan: 4
+  -
+    - chip: 16
+      chan: 9
+    - chip: 20
+      chan: 5
+  -
+    - chip: 16
+      chan: 10
+    - chip: 20
+      chan: 6
+  -
+    - chip: 16
+      chan: 11
+    - chip: 20
+      chan: 7
+  -
+    - chip: 16
+      chan: 12
+    - chip: 17
+      chan: 12
+  -
+    - chip: 16
+      chan: 13
+    - chip: 17
+      chan: 13
+  -
+    - chip: 16
+      chan: 14
+    - chip: 17
+      chan: 14
+  -
+    - chip: 16
+      chan: 15
+    - chip: 17
+      chan: 15
+  -
+    - chip: 17
+      chan: 4
+    - chip: 18
+      chan: 4
+  -
+    - chip: 17
+      chan: 5
+    - chip: 18
+      chan: 5
+  -
+    - chip: 17
+      chan: 6
+    - chip: 18
+      chan: 6
+  -
+    - chip: 17
+      chan: 7
+    - chip: 18
+      chan: 7
+  -
+    - chip: 17
+      chan: 8
+    - chip: 21
+      chan: 4
+  -
+    - chip: 17
+      chan: 9
+    - chip: 21
+      chan: 5
+  -
+    - chip: 17
+      chan: 10
+    - chip: 21
+      chan: 6
+  -
+    - chip: 17
+      chan: 11
+    - chip: 21
+      chan: 7
+  -
+    - chip: 18
+      chan: 8
+    - chip: 22
+      chan: 4
+  -
+    - chip: 18
+      chan: 9
+    - chip: 22
+      chan: 5
+  -
+    - chip: 18
+      chan: 10
+    - chip: 22
+      chan: 6
+  -
+    - chip: 18
+      chan: 11
+    - chip: 22
+      chan: 7
+  -
+    - chip: 18
+      chan: 12
+    - chip: 19
+      chan: 12
+  -
+    - chip: 18
+      chan: 13
+    - chip: 19
+      chan: 13
+  -
+    - chip: 18
+      chan: 14
+    - chip: 19
+      chan: 14
+  -
+    - chip: 18
+      chan: 15
+    - chip: 19
+      chan: 15
+  -
+    - chip: 19
+      chan: 8
+    - chip: 23
+      chan: 4
+  -
+    - chip: 19
+      chan: 9
+    - chip: 23
+      chan: 5
+  -
+    - chip: 19
+      chan: 10
+    - chip: 23
+      chan: 6
+  -
+    - chip: 19
+      chan: 11
+    - chip: 23
+      chan: 7
+  -
+    - chip: 20
+      chan: 8
+    - chip: 24
+      chan: 4
+  -
+    - chip: 20
+      chan: 9
+    - chip: 24
+      chan: 5
+  -
+    - chip: 20
+      chan: 10
+    - chip: 24
+      chan: 6
+  -
+    - chip: 20
+      chan: 11
+    - chip: 24
+      chan: 7
+  -
+    - chip: 20
+      chan: 12
+    - chip: 21
+      chan: 12
+  -
+    - chip: 20
+      chan: 13
+    - chip: 21
+      chan: 13
+  -
+    - chip: 20
+      chan: 14
+    - chip: 21
+      chan: 14
+  -
+    - chip: 20
+      chan: 15
+    - chip: 21
+      chan: 15
+  -
+    - chip: 21
+      chan: 8
+    - chip: 25
+      chan: 4
+  -
+    - chip: 21
+      chan: 9
+    - chip: 25
+      chan: 5
+  -
+    - chip: 21
+      chan: 10
+    - chip: 25
+      chan: 6
+  -
+    - chip: 21
+      chan: 11
+    - chip: 25
+      chan: 7
+  -
+    - chip: 22
+      chan: 8
+    - chip: 26
+      chan: 4
+  -
+    - chip: 22
+      chan: 9
+    - chip: 26
+      chan: 5
+  -
+    - chip: 22
+      chan: 10
+    - chip: 26
+      chan: 6
+  -
+    - chip: 22
+      chan: 11
+    - chip: 26
+      chan: 7
+  -
+    - chip: 22
+      chan: 12
+    - chip: 23
+      chan: 12
+  -
+    - chip: 22
+      chan: 13
+    - chip: 23
+      chan: 13
+  -
+    - chip: 22
+      chan: 14
+    - chip: 23
+      chan: 14
+  -
+    - chip: 22
+      chan: 15
+    - chip: 23
+      chan: 15
+  -
+    - chip: 23
+      chan: 8
+    - chip: 27
+      chan: 4
+  -
+    - chip: 23
+      chan: 9
+    - chip: 27
+      chan: 5
+  -
+    - chip: 23
+      chan: 10
+    - chip: 27
+      chan: 6
+  -
+    - chip: 23
+      chan: 11
+    - chip: 27
+      chan: 7
+  -
+    - chip: 24
+      chan: 8
+    - chip: 28
+      chan: 4
+  -
+    - chip: 24
+      chan: 9
+    - chip: 28
+      chan: 5
+  -
+    - chip: 24
+      chan: 10
+    - chip: 28
+      chan: 6
+  -
+    - chip: 24
+      chan: 11
+    - chip: 28
+      chan: 7
+  -
+    - chip: 24
+      chan: 12
+    - chip: 25
+      chan: 12
+  -
+    - chip: 24
+      chan: 13
+    - chip: 25
+      chan: 13
+  -
+    - chip: 24
+      chan: 14
+    - chip: 25
+      chan: 14
+  -
+    - chip: 24
+      chan: 15
+    - chip: 25
+      chan: 15
+  -
+    - chip: 25
+      chan: 8
+    - chip: 29
+      chan: 4
+  -
+    - chip: 25
+      chan: 9
+    - chip: 29
+      chan: 5
+  -
+    - chip: 25
+      chan: 10
+    - chip: 29
+      chan: 6
+  -
+    - chip: 25
+      chan: 11
+    - chip: 29
+      chan: 7
+  -
+    - chip: 26
+      chan: 8
+    - chip: 30
+      chan: 4
+  -
+    - chip: 26
+      chan: 9
+    - chip: 30
+      chan: 5
+  -
+    - chip: 26
+      chan: 10
+    - chip: 30
+      chan: 6
+  -
+    - chip: 26
+      chan: 11
+    - chip: 30
+      chan: 7
+  -
+    - chip: 26
+      chan: 12
+    - chip: 27
+      chan: 12
+  -
+    - chip: 26
+      chan: 13
+    - chip: 27
+      chan: 13
+  -
+    - chip: 26
+      chan: 14
+    - chip: 27
+      chan: 14
+  -
+    - chip: 26
+      chan: 15
+    - chip: 27
+      chan: 15
+  -
+    - chip: 27
+      chan: 8
+    - chip: 31
+      chan: 4
+  -
+    - chip: 27
+      chan: 9
+    - chip: 31
+      chan: 5
+  -
+    - chip: 27
+      chan: 10
+    - chip: 31
+      chan: 6
+  -
+    - chip: 27
+      chan: 11
+    - chip: 31
+      chan: 7
+  -
+    - chip: 28
+      chan: 8
+    - chip: 31
+      chan: 8
+  -
+    - chip: 28
+      chan: 9
+    - chip: 31
+      chan: 9
+  -
+    - chip: 28
+      chan: 10
+    - chip: 31
+      chan: 10
+  -
+    - chip: 28
+      chan: 11
+    - chip: 31
+      chan: 11
+  -
+    - chip: 28
+      chan: 12
+    - chip: 29
+      chan: 12
+  -
+    - chip: 28
+      chan: 13
+    - chip: 29
+      chan: 13
+  -
+    - chip: 28
+      chan: 14
+    - chip: 29
+      chan: 14
+  -
+    - chip: 28
+      chan: 15
+    - chip: 29
+      chan: 15
+  -
+    - chip: 29
+      chan: 8
+    - chip: 30
+      chan: 8
+  -
+    - chip: 29
+      chan: 9
+    - chip: 30
+      chan: 9
+  -
+    - chip: 29
+      chan: 10
+    - chip: 30
+      chan: 10
+  -
+    - chip: 29
+      chan: 11
+    - chip: 30
+      chan: 11
+  -
+    - chip: 30
+      chan: 12
+    - chip: 31
+      chan: 12
+  -
+    - chip: 30
+      chan: 13
+    - chip: 31
+      chan: 13
+  -
+    - chip: 30
+      chan: 14
+    - chip: 31
+      chan: 14
+  -
+    - chip: 30
+      chan: 15
+    - chip: 31
+      chan: 15
+ethernet_connections_to_remote_devices:
+  -
+    - chip: 15
+      chan: 3
+    - remote_chip_id: 303201572097110100
+      chan: 3
+  -
+    - chip: 15
+      chan: 2
+    - remote_chip_id: 303201572097110100
+      chan: 2
+  -
+    - chip: 15
+      chan: 1
+    - remote_chip_id: 303201572097110100
+      chan: 1
+  -
+    - chip: 15
+      chan: 0
+    - remote_chip_id: 303201572097110100
+      chan: 0
+  -
+    - chip: 14
+      chan: 3
+    - remote_chip_id: 303201537737371701
+      chan: 3
+  -
+    - chip: 14
+      chan: 2
+    - remote_chip_id: 303201537737371701
+      chan: 2
+  -
+    - chip: 14
+      chan: 1
+    - remote_chip_id: 303201537737371701
+      chan: 1
+  -
+    - chip: 14
+      chan: 0
+    - remote_chip_id: 303201537737371701
+      chan: 0
+  -
+    - chip: 13
+      chan: 3
+    - remote_chip_id: 303201572097110073
+      chan: 3
+  -
+    - chip: 13
+      chan: 2
+    - remote_chip_id: 303201572097110073
+      chan: 2
+  -
+    - chip: 13
+      chan: 1
+    - remote_chip_id: 303201572097110073
+      chan: 1
+  -
+    - chip: 13
+      chan: 0
+    - remote_chip_id: 303201572097110073
+      chan: 0
+  -
+    - chip: 0
+      chan: 3
+    - remote_chip_id: 87028789983326768
+      chan: 3
+  -
+    - chip: 0
+      chan: 2
+    - remote_chip_id: 87028789983326768
+      chan: 2
+  -
+    - chip: 0
+      chan: 1
+    - remote_chip_id: 87028789983326768
+      chan: 1
+  -
+    - chip: 0
+      chan: 0
+    - remote_chip_id: 87028789983326768
+      chan: 0
+  -
+    - chip: 1
+      chan: 3
+    - remote_chip_id: 87028789983326265
+      chan: 3
+  -
+    - chip: 1
+      chan: 2
+    - remote_chip_id: 87028789983326265
+      chan: 2
+  -
+    - chip: 1
+      chan: 1
+    - remote_chip_id: 87028789983326265
+      chan: 1
+  -
+    - chip: 1
+      chan: 0
+    - remote_chip_id: 87028789983326265
+      chan: 0
+  -
+    - chip: 2
+      chan: 3
+    - remote_chip_id: 87028755623587893
+      chan: 3
+  -
+    - chip: 2
+      chan: 2
+    - remote_chip_id: 87028755623587893
+      chan: 2
+  -
+    - chip: 2
+      chan: 1
+    - remote_chip_id: 87028755623587893
+      chan: 1
+  -
+    - chip: 2
+      chan: 0
+    - remote_chip_id: 87028755623587893
+      chan: 0
+  -
+    - chip: 3
+      chan: 3
+    - remote_chip_id: 87028789983326292
+      chan: 3
+  -
+    - chip: 3
+      chan: 2
+    - remote_chip_id: 87028789983326292
+      chan: 2
+  -
+    - chip: 3
+      chan: 1
+    - remote_chip_id: 87028789983326292
+      chan: 1
+  -
+    - chip: 3
+      chan: 0
+    - remote_chip_id: 87028789983326292
+      chan: 0
+  -
+    - chip: 4
+      chan: 3
+    - remote_chip_id: 159086384021254704
+      chan: 3
+  -
+    - chip: 4
+      chan: 2
+    - remote_chip_id: 159086384021254704
+      chan: 2
+  -
+    - chip: 4
+      chan: 1
+    - remote_chip_id: 159086384021254704
+      chan: 1
+  -
+    - chip: 4
+      chan: 0
+    - remote_chip_id: 159086384021254704
+      chan: 0
+  -
+    - chip: 5
+      chan: 3
+    - remote_chip_id: 159086384021254201
+      chan: 3
+  -
+    - chip: 5
+      chan: 2
+    - remote_chip_id: 159086384021254201
+      chan: 2
+  -
+    - chip: 5
+      chan: 1
+    - remote_chip_id: 159086384021254201
+      chan: 1
+  -
+    - chip: 5
+      chan: 0
+    - remote_chip_id: 159086384021254201
+      chan: 0
+  -
+    - chip: 6
+      chan: 3
+    - remote_chip_id: 159086349661515829
+      chan: 3
+  -
+    - chip: 6
+      chan: 2
+    - remote_chip_id: 159086349661515829
+      chan: 2
+  -
+    - chip: 6
+      chan: 1
+    - remote_chip_id: 159086349661515829
+      chan: 1
+  -
+    - chip: 6
+      chan: 0
+    - remote_chip_id: 159086349661515829
+      chan: 0
+  -
+    - chip: 7
+      chan: 3
+    - remote_chip_id: 159086384021254228
+      chan: 3
+  -
+    - chip: 7
+      chan: 2
+    - remote_chip_id: 159086384021254228
+      chan: 2
+  -
+    - chip: 7
+      chan: 1
+    - remote_chip_id: 159086384021254228
+      chan: 1
+  -
+    - chip: 7
+      chan: 0
+    - remote_chip_id: 159086384021254228
+      chan: 0
+  -
+    - chip: 8
+      chan: 3
+    - remote_chip_id: 231143978059182640
+      chan: 3
+  -
+    - chip: 8
+      chan: 2
+    - remote_chip_id: 231143978059182640
+      chan: 2
+  -
+    - chip: 8
+      chan: 1
+    - remote_chip_id: 231143978059182640
+      chan: 1
+  -
+    - chip: 8
+      chan: 0
+    - remote_chip_id: 231143978059182640
+      chan: 0
+  -
+    - chip: 9
+      chan: 3
+    - remote_chip_id: 231143978059182137
+      chan: 3
+  -
+    - chip: 9
+      chan: 2
+    - remote_chip_id: 231143978059182137
+      chan: 2
+  -
+    - chip: 9
+      chan: 1
+    - remote_chip_id: 231143978059182137
+      chan: 1
+  -
+    - chip: 9
+      chan: 0
+    - remote_chip_id: 231143978059182137
+      chan: 0
+  -
+    - chip: 10
+      chan: 3
+    - remote_chip_id: 231143943699443765
+      chan: 3
+  -
+    - chip: 10
+      chan: 2
+    - remote_chip_id: 231143943699443765
+      chan: 2
+  -
+    - chip: 10
+      chan: 1
+    - remote_chip_id: 231143943699443765
+      chan: 1
+  -
+    - chip: 10
+      chan: 0
+    - remote_chip_id: 231143943699443765
+      chan: 0
+  -
+    - chip: 11
+      chan: 3
+    - remote_chip_id: 231143978059182164
+      chan: 3
+  -
+    - chip: 11
+      chan: 2
+    - remote_chip_id: 231143978059182164
+      chan: 2
+  -
+    - chip: 11
+      chan: 1
+    - remote_chip_id: 231143978059182164
+      chan: 1
+  -
+    - chip: 11
+      chan: 0
+    - remote_chip_id: 231143978059182164
+      chan: 0
+  -
+    - chip: 12
+      chan: 3
+    - remote_chip_id: 303201572097110576
+      chan: 3
+  -
+    - chip: 12
+      chan: 2
+    - remote_chip_id: 303201572097110576
+      chan: 2
+  -
+    - chip: 12
+      chan: 1
+    - remote_chip_id: 303201572097110576
+      chan: 1
+  -
+    - chip: 12
+      chan: 0
+    - remote_chip_id: 303201572097110576
+      chan: 0
+chips_with_mmio:
+  - 0: 27
+  - 1: 21
+  - 2: 3
+  - 3: 8
+  - 4: 25
+  - 5: 17
+  - 6: 5
+  - 7: 10
+  - 8: 30
+  - 9: 19
+  - 10: 6
+  - 11: 13
+  - 12: 29
+  - 13: 22
+  - 14: 1
+  - 15: 11
+  - 16: 24
+  - 17: 18
+  - 18: 0
+  - 19: 14
+  - 20: 31
+  - 21: 23
+  - 22: 7
+  - 23: 15
+  - 24: 26
+  - 25: 16
+  - 26: 2
+  - 27: 9
+  - 28: 28
+  - 29: 20
+  - 30: 4
+  - 31: 12
+io_device_type: PCIe
+harvesting:
+  0:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  1:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  2:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  3:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  4:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  5:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  6:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  7:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  8:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  9:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  10:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  11:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  12:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  13:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  14:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  15:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  16:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  17:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  18:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  19:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  20:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  21:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  22:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  23:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  24:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  25:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  26:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  27:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  28:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  29:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  30:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  31:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+chip_to_boardtype:
+  0: ubb
+  1: ubb
+  2: ubb
+  3: ubb
+  4: ubb
+  5: ubb
+  6: ubb
+  7: ubb
+  8: ubb
+  9: ubb
+  10: ubb
+  11: ubb
+  12: ubb
+  13: ubb
+  14: ubb
+  15: ubb
+  16: ubb
+  17: ubb
+  18: ubb
+  19: ubb
+  20: ubb
+  21: ubb
+  22: ubb
+  23: ubb
+  24: ubb
+  25: ubb
+  26: ubb
+  27: ubb
+  28: ubb
+  29: ubb
+  30: ubb
+  31: ubb
+chip_to_bus_id:
+  0: 0x0041
+  1: 0x0001
+  2: 0x00c1
+  3: 0x0081
+  4: 0x0042
+  5: 0x0002
+  6: 0x00c2
+  7: 0x0082
+  8: 0x0043
+  9: 0x0003
+  10: 0x00c3
+  11: 0x0083
+  12: 0x0044
+  13: 0x0004
+  14: 0x00c4
+  15: 0x0084
+  16: 0x0045
+  17: 0x0005
+  18: 0x00c5
+  19: 0x0085
+  20: 0x0046
+  21: 0x0006
+  22: 0x00c6
+  23: 0x0086
+  24: 0x0047
+  25: 0x0007
+  26: 0x00c7
+  27: 0x0087
+  28: 0x0048
+  29: 0x0008
+  30: 0x00c8
+  31: 0x0088
+boards:
+  -
+    - board_id: 72061240465162240
+    - board_type: ubb
+    - chips:
+        - 31
+        - 30
+        - 29
+        - 12
+        - 11
+        - 10
+        - 9
+        - 8
+        - 7
+        - 6
+        - 5
+        - 4
+        - 3
+        - 2
+        - 1
+        - 0
+        - 13
+        - 14
+        - 15
+        - 16
+        - 17
+        - 18
+        - 19
+        - 20
+        - 21
+        - 22
+        - 23
+        - 24
+        - 25
+        - 26
+        - 27
+        - 28
+asic_locations:
+  0: 1
+  1: 1
+  2: 1
+  3: 1
+  4: 2
+  5: 2
+  6: 2
+  7: 2
+  8: 3
+  9: 3
+  10: 3
+  11: 3
+  12: 4
+  13: 4
+  14: 4
+  15: 4
+  16: 5
+  17: 5
+  18: 5
+  19: 5
+  20: 6
+  21: 6
+  22: 6
+  23: 6
+  24: 7
+  25: 7
+  26: 7
+  27: 7
+  28: 8
+  29: 8
+  30: 8
+  31: 8

--- a/tests/tt_metal/tt_fabric/custom_mock_cluster_descriptors/6u_quad_host_cluster_desc_rank_3.yaml
+++ b/tests/tt_metal/tt_fabric/custom_mock_cluster_descriptors/6u_quad_host_cluster_desc_rank_3.yaml
@@ -1,0 +1,1905 @@
+arch:
+  0: wormhole_b0
+  1: wormhole_b0
+  2: wormhole_b0
+  3: wormhole_b0
+  4: wormhole_b0
+  5: wormhole_b0
+  6: wormhole_b0
+  7: wormhole_b0
+  8: wormhole_b0
+  9: wormhole_b0
+  10: wormhole_b0
+  11: wormhole_b0
+  12: wormhole_b0
+  13: wormhole_b0
+  14: wormhole_b0
+  15: wormhole_b0
+  16: wormhole_b0
+  17: wormhole_b0
+  18: wormhole_b0
+  19: wormhole_b0
+  20: wormhole_b0
+  21: wormhole_b0
+  22: wormhole_b0
+  23: wormhole_b0
+  24: wormhole_b0
+  25: wormhole_b0
+  26: wormhole_b0
+  27: wormhole_b0
+  28: wormhole_b0
+  29: wormhole_b0
+  30: wormhole_b0
+  31: wormhole_b0
+chips:
+  {}
+chip_unique_ids:
+  31: 591431948248822320
+  30: 591431948248822073
+  29: 591431948248821844
+  12: 303201572097110071
+  11: 231143978059182640
+  10: 231143978059182393
+  9: 231143978059182164
+  8: 231143978059182135
+  7: 159086384021254704
+  6: 159086384021254457
+  5: 159086384021254228
+  4: 159086384021254199
+  3: 87028789983326768
+  2: 87028789983326521
+  1: 87028789983326292
+  0: 87028789983326263
+  13: 303201572097110100
+  14: 303201572097110329
+  15: 303201572097110576
+  16: 375259166135038007
+  17: 375259166135038036
+  18: 375259166135038265
+  19: 375259166135038512
+  20: 447316760172965943
+  21: 447316760172965972
+  22: 447316760172966201
+  23: 447316760172966448
+  24: 519374354210893879
+  25: 519374354210893908
+  26: 519374354210894137
+  27: 519374354210894384
+  28: 591431948248821815
+ethernet_connections:
+  -
+    - chip: 0
+      chan: 4
+    - chip: 2
+      chan: 4
+  -
+    - chip: 0
+      chan: 5
+    - chip: 2
+      chan: 5
+  -
+    - chip: 0
+      chan: 6
+    - chip: 2
+      chan: 6
+  -
+    - chip: 0
+      chan: 7
+    - chip: 2
+      chan: 7
+  -
+    - chip: 0
+      chan: 8
+    - chip: 4
+      chan: 4
+  -
+    - chip: 0
+      chan: 9
+    - chip: 4
+      chan: 5
+  -
+    - chip: 0
+      chan: 10
+    - chip: 4
+      chan: 6
+  -
+    - chip: 0
+      chan: 11
+    - chip: 4
+      chan: 7
+  -
+    - chip: 0
+      chan: 12
+    - chip: 16
+      chan: 0
+  -
+    - chip: 0
+      chan: 13
+    - chip: 16
+      chan: 1
+  -
+    - chip: 0
+      chan: 14
+    - chip: 16
+      chan: 2
+  -
+    - chip: 0
+      chan: 15
+    - chip: 16
+      chan: 3
+  -
+    - chip: 1
+      chan: 4
+    - chip: 3
+      chan: 4
+  -
+    - chip: 1
+      chan: 5
+    - chip: 3
+      chan: 5
+  -
+    - chip: 1
+      chan: 6
+    - chip: 3
+      chan: 6
+  -
+    - chip: 1
+      chan: 7
+    - chip: 3
+      chan: 7
+  -
+    - chip: 1
+      chan: 8
+    - chip: 5
+      chan: 4
+  -
+    - chip: 1
+      chan: 9
+    - chip: 5
+      chan: 5
+  -
+    - chip: 1
+      chan: 10
+    - chip: 5
+      chan: 6
+  -
+    - chip: 1
+      chan: 11
+    - chip: 5
+      chan: 7
+  -
+    - chip: 1
+      chan: 12
+    - chip: 17
+      chan: 0
+  -
+    - chip: 1
+      chan: 13
+    - chip: 17
+      chan: 1
+  -
+    - chip: 1
+      chan: 14
+    - chip: 17
+      chan: 2
+  -
+    - chip: 1
+      chan: 15
+    - chip: 17
+      chan: 3
+  -
+    - chip: 2
+      chan: 8
+    - chip: 6
+      chan: 4
+  -
+    - chip: 2
+      chan: 9
+    - chip: 6
+      chan: 5
+  -
+    - chip: 2
+      chan: 10
+    - chip: 6
+      chan: 6
+  -
+    - chip: 2
+      chan: 11
+    - chip: 6
+      chan: 7
+  -
+    - chip: 2
+      chan: 12
+    - chip: 18
+      chan: 0
+  -
+    - chip: 2
+      chan: 13
+    - chip: 18
+      chan: 1
+  -
+    - chip: 2
+      chan: 14
+    - chip: 18
+      chan: 2
+  -
+    - chip: 2
+      chan: 15
+    - chip: 18
+      chan: 3
+  -
+    - chip: 3
+      chan: 8
+    - chip: 7
+      chan: 4
+  -
+    - chip: 3
+      chan: 9
+    - chip: 7
+      chan: 5
+  -
+    - chip: 3
+      chan: 10
+    - chip: 7
+      chan: 6
+  -
+    - chip: 3
+      chan: 11
+    - chip: 7
+      chan: 7
+  -
+    - chip: 3
+      chan: 12
+    - chip: 19
+      chan: 0
+  -
+    - chip: 3
+      chan: 13
+    - chip: 19
+      chan: 1
+  -
+    - chip: 3
+      chan: 14
+    - chip: 19
+      chan: 2
+  -
+    - chip: 3
+      chan: 15
+    - chip: 19
+      chan: 3
+  -
+    - chip: 4
+      chan: 8
+    - chip: 8
+      chan: 4
+  -
+    - chip: 4
+      chan: 9
+    - chip: 8
+      chan: 5
+  -
+    - chip: 4
+      chan: 10
+    - chip: 8
+      chan: 6
+  -
+    - chip: 4
+      chan: 11
+    - chip: 8
+      chan: 7
+  -
+    - chip: 4
+      chan: 12
+    - chip: 20
+      chan: 0
+  -
+    - chip: 4
+      chan: 13
+    - chip: 20
+      chan: 1
+  -
+    - chip: 4
+      chan: 14
+    - chip: 20
+      chan: 2
+  -
+    - chip: 4
+      chan: 15
+    - chip: 20
+      chan: 3
+  -
+    - chip: 5
+      chan: 8
+    - chip: 9
+      chan: 4
+  -
+    - chip: 5
+      chan: 9
+    - chip: 9
+      chan: 5
+  -
+    - chip: 5
+      chan: 10
+    - chip: 9
+      chan: 6
+  -
+    - chip: 5
+      chan: 11
+    - chip: 9
+      chan: 7
+  -
+    - chip: 5
+      chan: 12
+    - chip: 21
+      chan: 0
+  -
+    - chip: 5
+      chan: 13
+    - chip: 21
+      chan: 1
+  -
+    - chip: 5
+      chan: 14
+    - chip: 21
+      chan: 2
+  -
+    - chip: 5
+      chan: 15
+    - chip: 21
+      chan: 3
+  -
+    - chip: 6
+      chan: 8
+    - chip: 10
+      chan: 4
+  -
+    - chip: 6
+      chan: 9
+    - chip: 10
+      chan: 5
+  -
+    - chip: 6
+      chan: 10
+    - chip: 10
+      chan: 6
+  -
+    - chip: 6
+      chan: 11
+    - chip: 10
+      chan: 7
+  -
+    - chip: 6
+      chan: 12
+    - chip: 22
+      chan: 0
+  -
+    - chip: 6
+      chan: 13
+    - chip: 22
+      chan: 1
+  -
+    - chip: 6
+      chan: 14
+    - chip: 22
+      chan: 2
+  -
+    - chip: 6
+      chan: 15
+    - chip: 22
+      chan: 3
+  -
+    - chip: 7
+      chan: 8
+    - chip: 11
+      chan: 4
+  -
+    - chip: 7
+      chan: 9
+    - chip: 11
+      chan: 5
+  -
+    - chip: 7
+      chan: 10
+    - chip: 11
+      chan: 6
+  -
+    - chip: 7
+      chan: 11
+    - chip: 11
+      chan: 7
+  -
+    - chip: 7
+      chan: 12
+    - chip: 23
+      chan: 0
+  -
+    - chip: 7
+      chan: 13
+    - chip: 23
+      chan: 1
+  -
+    - chip: 7
+      chan: 14
+    - chip: 23
+      chan: 2
+  -
+    - chip: 7
+      chan: 15
+    - chip: 23
+      chan: 3
+  -
+    - chip: 8
+      chan: 8
+    - chip: 12
+      chan: 4
+  -
+    - chip: 8
+      chan: 9
+    - chip: 12
+      chan: 5
+  -
+    - chip: 8
+      chan: 10
+    - chip: 12
+      chan: 6
+  -
+    - chip: 8
+      chan: 11
+    - chip: 12
+      chan: 7
+  -
+    - chip: 8
+      chan: 12
+    - chip: 24
+      chan: 0
+  -
+    - chip: 8
+      chan: 13
+    - chip: 24
+      chan: 1
+  -
+    - chip: 8
+      chan: 14
+    - chip: 24
+      chan: 2
+  -
+    - chip: 8
+      chan: 15
+    - chip: 24
+      chan: 3
+  -
+    - chip: 9
+      chan: 8
+    - chip: 13
+      chan: 4
+  -
+    - chip: 9
+      chan: 9
+    - chip: 13
+      chan: 5
+  -
+    - chip: 9
+      chan: 10
+    - chip: 13
+      chan: 6
+  -
+    - chip: 9
+      chan: 11
+    - chip: 13
+      chan: 7
+  -
+    - chip: 9
+      chan: 12
+    - chip: 25
+      chan: 0
+  -
+    - chip: 9
+      chan: 13
+    - chip: 25
+      chan: 1
+  -
+    - chip: 9
+      chan: 14
+    - chip: 25
+      chan: 2
+  -
+    - chip: 9
+      chan: 15
+    - chip: 25
+      chan: 3
+  -
+    - chip: 10
+      chan: 8
+    - chip: 14
+      chan: 4
+  -
+    - chip: 10
+      chan: 9
+    - chip: 14
+      chan: 5
+  -
+    - chip: 10
+      chan: 10
+    - chip: 14
+      chan: 6
+  -
+    - chip: 10
+      chan: 11
+    - chip: 14
+      chan: 7
+  -
+    - chip: 10
+      chan: 12
+    - chip: 26
+      chan: 0
+  -
+    - chip: 10
+      chan: 13
+    - chip: 26
+      chan: 1
+  -
+    - chip: 10
+      chan: 14
+    - chip: 26
+      chan: 2
+  -
+    - chip: 10
+      chan: 15
+    - chip: 26
+      chan: 3
+  -
+    - chip: 11
+      chan: 8
+    - chip: 15
+      chan: 4
+  -
+    - chip: 11
+      chan: 9
+    - chip: 15
+      chan: 5
+  -
+    - chip: 11
+      chan: 10
+    - chip: 15
+      chan: 6
+  -
+    - chip: 11
+      chan: 11
+    - chip: 15
+      chan: 7
+  -
+    - chip: 11
+      chan: 12
+    - chip: 27
+      chan: 0
+  -
+    - chip: 11
+      chan: 13
+    - chip: 27
+      chan: 1
+  -
+    - chip: 11
+      chan: 14
+    - chip: 27
+      chan: 2
+  -
+    - chip: 11
+      chan: 15
+    - chip: 27
+      chan: 3
+  -
+    - chip: 12
+      chan: 8
+    - chip: 14
+      chan: 8
+  -
+    - chip: 12
+      chan: 9
+    - chip: 14
+      chan: 9
+  -
+    - chip: 12
+      chan: 10
+    - chip: 14
+      chan: 10
+  -
+    - chip: 12
+      chan: 11
+    - chip: 14
+      chan: 11
+  -
+    - chip: 12
+      chan: 12
+    - chip: 28
+      chan: 0
+  -
+    - chip: 12
+      chan: 13
+    - chip: 28
+      chan: 1
+  -
+    - chip: 12
+      chan: 14
+    - chip: 28
+      chan: 2
+  -
+    - chip: 12
+      chan: 15
+    - chip: 28
+      chan: 3
+  -
+    - chip: 13
+      chan: 8
+    - chip: 15
+      chan: 8
+  -
+    - chip: 13
+      chan: 9
+    - chip: 15
+      chan: 9
+  -
+    - chip: 13
+      chan: 10
+    - chip: 15
+      chan: 10
+  -
+    - chip: 13
+      chan: 11
+    - chip: 15
+      chan: 11
+  -
+    - chip: 13
+      chan: 12
+    - chip: 29
+      chan: 0
+  -
+    - chip: 13
+      chan: 13
+    - chip: 29
+      chan: 1
+  -
+    - chip: 13
+      chan: 14
+    - chip: 29
+      chan: 2
+  -
+    - chip: 13
+      chan: 15
+    - chip: 29
+      chan: 3
+  -
+    - chip: 14
+      chan: 12
+    - chip: 30
+      chan: 0
+  -
+    - chip: 14
+      chan: 13
+    - chip: 30
+      chan: 1
+  -
+    - chip: 14
+      chan: 14
+    - chip: 30
+      chan: 2
+  -
+    - chip: 14
+      chan: 15
+    - chip: 30
+      chan: 3
+  -
+    - chip: 15
+      chan: 12
+    - chip: 31
+      chan: 0
+  -
+    - chip: 15
+      chan: 13
+    - chip: 31
+      chan: 1
+  -
+    - chip: 15
+      chan: 14
+    - chip: 31
+      chan: 2
+  -
+    - chip: 15
+      chan: 15
+    - chip: 31
+      chan: 3
+  -
+    - chip: 16
+      chan: 4
+    - chip: 18
+      chan: 4
+  -
+    - chip: 16
+      chan: 5
+    - chip: 18
+      chan: 5
+  -
+    - chip: 16
+      chan: 6
+    - chip: 18
+      chan: 6
+  -
+    - chip: 16
+      chan: 7
+    - chip: 18
+      chan: 7
+  -
+    - chip: 16
+      chan: 8
+    - chip: 20
+      chan: 4
+  -
+    - chip: 16
+      chan: 9
+    - chip: 20
+      chan: 5
+  -
+    - chip: 16
+      chan: 10
+    - chip: 20
+      chan: 6
+  -
+    - chip: 16
+      chan: 11
+    - chip: 20
+      chan: 7
+  -
+    - chip: 16
+      chan: 12
+    - chip: 17
+      chan: 12
+  -
+    - chip: 16
+      chan: 13
+    - chip: 17
+      chan: 13
+  -
+    - chip: 16
+      chan: 14
+    - chip: 17
+      chan: 14
+  -
+    - chip: 16
+      chan: 15
+    - chip: 17
+      chan: 15
+  -
+    - chip: 17
+      chan: 4
+    - chip: 19
+      chan: 4
+  -
+    - chip: 17
+      chan: 5
+    - chip: 19
+      chan: 5
+  -
+    - chip: 17
+      chan: 6
+    - chip: 19
+      chan: 6
+  -
+    - chip: 17
+      chan: 7
+    - chip: 19
+      chan: 7
+  -
+    - chip: 17
+      chan: 8
+    - chip: 21
+      chan: 4
+  -
+    - chip: 17
+      chan: 9
+    - chip: 21
+      chan: 5
+  -
+    - chip: 17
+      chan: 10
+    - chip: 21
+      chan: 6
+  -
+    - chip: 17
+      chan: 11
+    - chip: 21
+      chan: 7
+  -
+    - chip: 18
+      chan: 8
+    - chip: 22
+      chan: 4
+  -
+    - chip: 18
+      chan: 9
+    - chip: 22
+      chan: 5
+  -
+    - chip: 18
+      chan: 10
+    - chip: 22
+      chan: 6
+  -
+    - chip: 18
+      chan: 11
+    - chip: 22
+      chan: 7
+  -
+    - chip: 18
+      chan: 12
+    - chip: 19
+      chan: 12
+  -
+    - chip: 18
+      chan: 13
+    - chip: 19
+      chan: 13
+  -
+    - chip: 18
+      chan: 14
+    - chip: 19
+      chan: 14
+  -
+    - chip: 18
+      chan: 15
+    - chip: 19
+      chan: 15
+  -
+    - chip: 19
+      chan: 8
+    - chip: 23
+      chan: 4
+  -
+    - chip: 19
+      chan: 9
+    - chip: 23
+      chan: 5
+  -
+    - chip: 19
+      chan: 10
+    - chip: 23
+      chan: 6
+  -
+    - chip: 19
+      chan: 11
+    - chip: 23
+      chan: 7
+  -
+    - chip: 20
+      chan: 8
+    - chip: 24
+      chan: 4
+  -
+    - chip: 20
+      chan: 9
+    - chip: 24
+      chan: 5
+  -
+    - chip: 20
+      chan: 10
+    - chip: 24
+      chan: 6
+  -
+    - chip: 20
+      chan: 11
+    - chip: 24
+      chan: 7
+  -
+    - chip: 20
+      chan: 12
+    - chip: 21
+      chan: 12
+  -
+    - chip: 20
+      chan: 13
+    - chip: 21
+      chan: 13
+  -
+    - chip: 20
+      chan: 14
+    - chip: 21
+      chan: 14
+  -
+    - chip: 20
+      chan: 15
+    - chip: 21
+      chan: 15
+  -
+    - chip: 21
+      chan: 8
+    - chip: 25
+      chan: 4
+  -
+    - chip: 21
+      chan: 9
+    - chip: 25
+      chan: 5
+  -
+    - chip: 21
+      chan: 10
+    - chip: 25
+      chan: 6
+  -
+    - chip: 21
+      chan: 11
+    - chip: 25
+      chan: 7
+  -
+    - chip: 22
+      chan: 8
+    - chip: 26
+      chan: 4
+  -
+    - chip: 22
+      chan: 9
+    - chip: 26
+      chan: 5
+  -
+    - chip: 22
+      chan: 10
+    - chip: 26
+      chan: 6
+  -
+    - chip: 22
+      chan: 11
+    - chip: 26
+      chan: 7
+  -
+    - chip: 22
+      chan: 12
+    - chip: 23
+      chan: 12
+  -
+    - chip: 22
+      chan: 13
+    - chip: 23
+      chan: 13
+  -
+    - chip: 22
+      chan: 14
+    - chip: 23
+      chan: 14
+  -
+    - chip: 22
+      chan: 15
+    - chip: 23
+      chan: 15
+  -
+    - chip: 23
+      chan: 8
+    - chip: 27
+      chan: 4
+  -
+    - chip: 23
+      chan: 9
+    - chip: 27
+      chan: 5
+  -
+    - chip: 23
+      chan: 10
+    - chip: 27
+      chan: 6
+  -
+    - chip: 23
+      chan: 11
+    - chip: 27
+      chan: 7
+  -
+    - chip: 24
+      chan: 8
+    - chip: 28
+      chan: 4
+  -
+    - chip: 24
+      chan: 9
+    - chip: 28
+      chan: 5
+  -
+    - chip: 24
+      chan: 10
+    - chip: 28
+      chan: 6
+  -
+    - chip: 24
+      chan: 11
+    - chip: 28
+      chan: 7
+  -
+    - chip: 24
+      chan: 12
+    - chip: 25
+      chan: 12
+  -
+    - chip: 24
+      chan: 13
+    - chip: 25
+      chan: 13
+  -
+    - chip: 24
+      chan: 14
+    - chip: 25
+      chan: 14
+  -
+    - chip: 24
+      chan: 15
+    - chip: 25
+      chan: 15
+  -
+    - chip: 25
+      chan: 8
+    - chip: 29
+      chan: 4
+  -
+    - chip: 25
+      chan: 9
+    - chip: 29
+      chan: 5
+  -
+    - chip: 25
+      chan: 10
+    - chip: 29
+      chan: 6
+  -
+    - chip: 25
+      chan: 11
+    - chip: 29
+      chan: 7
+  -
+    - chip: 26
+      chan: 8
+    - chip: 30
+      chan: 4
+  -
+    - chip: 26
+      chan: 9
+    - chip: 30
+      chan: 5
+  -
+    - chip: 26
+      chan: 10
+    - chip: 30
+      chan: 6
+  -
+    - chip: 26
+      chan: 11
+    - chip: 30
+      chan: 7
+  -
+    - chip: 26
+      chan: 12
+    - chip: 27
+      chan: 12
+  -
+    - chip: 26
+      chan: 13
+    - chip: 27
+      chan: 13
+  -
+    - chip: 26
+      chan: 14
+    - chip: 27
+      chan: 14
+  -
+    - chip: 26
+      chan: 15
+    - chip: 27
+      chan: 15
+  -
+    - chip: 27
+      chan: 8
+    - chip: 31
+      chan: 4
+  -
+    - chip: 27
+      chan: 9
+    - chip: 31
+      chan: 5
+  -
+    - chip: 27
+      chan: 10
+    - chip: 31
+      chan: 6
+  -
+    - chip: 27
+      chan: 11
+    - chip: 31
+      chan: 7
+  -
+    - chip: 28
+      chan: 8
+    - chip: 30
+      chan: 8
+  -
+    - chip: 28
+      chan: 9
+    - chip: 30
+      chan: 9
+  -
+    - chip: 28
+      chan: 10
+    - chip: 30
+      chan: 10
+  -
+    - chip: 28
+      chan: 11
+    - chip: 30
+      chan: 11
+  -
+    - chip: 28
+      chan: 12
+    - chip: 29
+      chan: 12
+  -
+    - chip: 28
+      chan: 13
+    - chip: 29
+      chan: 13
+  -
+    - chip: 28
+      chan: 14
+    - chip: 29
+      chan: 14
+  -
+    - chip: 28
+      chan: 15
+    - chip: 29
+      chan: 15
+  -
+    - chip: 29
+      chan: 8
+    - chip: 31
+      chan: 8
+  -
+    - chip: 29
+      chan: 9
+    - chip: 31
+      chan: 9
+  -
+    - chip: 29
+      chan: 10
+    - chip: 31
+      chan: 10
+  -
+    - chip: 29
+      chan: 11
+    - chip: 31
+      chan: 11
+  -
+    - chip: 30
+      chan: 12
+    - chip: 31
+      chan: 12
+  -
+    - chip: 30
+      chan: 13
+    - chip: 31
+      chan: 13
+  -
+    - chip: 30
+      chan: 14
+    - chip: 31
+      chan: 14
+  -
+    - chip: 30
+      chan: 15
+    - chip: 31
+      chan: 15
+ethernet_connections_to_remote_devices:
+  -
+    - chip: 15
+      chan: 3
+    - remote_chip_id: 303201572097110327
+      chan: 3
+  -
+    - chip: 15
+      chan: 2
+    - remote_chip_id: 303201572097110327
+      chan: 2
+  -
+    - chip: 15
+      chan: 1
+    - remote_chip_id: 303201572097110327
+      chan: 1
+  -
+    - chip: 15
+      chan: 0
+    - remote_chip_id: 303201572097110327
+      chan: 0
+  -
+    - chip: 14
+      chan: 3
+    - remote_chip_id: 303201559212208180
+      chan: 3
+  -
+    - chip: 14
+      chan: 2
+    - remote_chip_id: 303201559212208180
+      chan: 2
+  -
+    - chip: 14
+      chan: 1
+    - remote_chip_id: 303201559212208180
+      chan: 1
+  -
+    - chip: 14
+      chan: 0
+    - remote_chip_id: 303201559212208180
+      chan: 0
+  -
+    - chip: 13
+      chan: 3
+    - remote_chip_id: 303201572097110358
+      chan: 3
+  -
+    - chip: 13
+      chan: 2
+    - remote_chip_id: 303201572097110358
+      chan: 2
+  -
+    - chip: 13
+      chan: 1
+    - remote_chip_id: 303201572097110358
+      chan: 1
+  -
+    - chip: 13
+      chan: 0
+    - remote_chip_id: 303201572097110358
+      chan: 0
+  -
+    - chip: 0
+      chan: 3
+    - remote_chip_id: 87028777098424392
+      chan: 3
+  -
+    - chip: 0
+      chan: 2
+    - remote_chip_id: 87028777098424392
+      chan: 2
+  -
+    - chip: 0
+      chan: 1
+    - remote_chip_id: 87028777098424392
+      chan: 1
+  -
+    - chip: 0
+      chan: 0
+    - remote_chip_id: 87028777098424392
+      chan: 0
+  -
+    - chip: 1
+      chan: 3
+    - remote_chip_id: 87028789983326550
+      chan: 3
+  -
+    - chip: 1
+      chan: 2
+    - remote_chip_id: 87028789983326550
+      chan: 2
+  -
+    - chip: 1
+      chan: 1
+    - remote_chip_id: 87028789983326550
+      chan: 1
+  -
+    - chip: 1
+      chan: 0
+    - remote_chip_id: 87028789983326550
+      chan: 0
+  -
+    - chip: 2
+      chan: 3
+    - remote_chip_id: 87028777098424372
+      chan: 3
+  -
+    - chip: 2
+      chan: 2
+    - remote_chip_id: 87028777098424372
+      chan: 2
+  -
+    - chip: 2
+      chan: 1
+    - remote_chip_id: 87028777098424372
+      chan: 1
+  -
+    - chip: 2
+      chan: 0
+    - remote_chip_id: 87028777098424372
+      chan: 0
+  -
+    - chip: 3
+      chan: 3
+    - remote_chip_id: 87028789983326519
+      chan: 3
+  -
+    - chip: 3
+      chan: 2
+    - remote_chip_id: 87028789983326519
+      chan: 2
+  -
+    - chip: 3
+      chan: 1
+    - remote_chip_id: 87028789983326519
+      chan: 1
+  -
+    - chip: 3
+      chan: 0
+    - remote_chip_id: 87028789983326519
+      chan: 0
+  -
+    - chip: 4
+      chan: 3
+    - remote_chip_id: 159086371136352328
+      chan: 3
+  -
+    - chip: 4
+      chan: 2
+    - remote_chip_id: 159086371136352328
+      chan: 2
+  -
+    - chip: 4
+      chan: 1
+    - remote_chip_id: 159086371136352328
+      chan: 1
+  -
+    - chip: 4
+      chan: 0
+    - remote_chip_id: 159086371136352328
+      chan: 0
+  -
+    - chip: 5
+      chan: 3
+    - remote_chip_id: 159086384021254486
+      chan: 3
+  -
+    - chip: 5
+      chan: 2
+    - remote_chip_id: 159086384021254486
+      chan: 2
+  -
+    - chip: 5
+      chan: 1
+    - remote_chip_id: 159086384021254486
+      chan: 1
+  -
+    - chip: 5
+      chan: 0
+    - remote_chip_id: 159086384021254486
+      chan: 0
+  -
+    - chip: 6
+      chan: 3
+    - remote_chip_id: 159086371136352308
+      chan: 3
+  -
+    - chip: 6
+      chan: 2
+    - remote_chip_id: 159086371136352308
+      chan: 2
+  -
+    - chip: 6
+      chan: 1
+    - remote_chip_id: 159086371136352308
+      chan: 1
+  -
+    - chip: 6
+      chan: 0
+    - remote_chip_id: 159086371136352308
+      chan: 0
+  -
+    - chip: 7
+      chan: 3
+    - remote_chip_id: 159086384021254455
+      chan: 3
+  -
+    - chip: 7
+      chan: 2
+    - remote_chip_id: 159086384021254455
+      chan: 2
+  -
+    - chip: 7
+      chan: 1
+    - remote_chip_id: 159086384021254455
+      chan: 1
+  -
+    - chip: 7
+      chan: 0
+    - remote_chip_id: 159086384021254455
+      chan: 0
+  -
+    - chip: 8
+      chan: 3
+    - remote_chip_id: 231143965174280264
+      chan: 3
+  -
+    - chip: 8
+      chan: 2
+    - remote_chip_id: 231143965174280264
+      chan: 2
+  -
+    - chip: 8
+      chan: 1
+    - remote_chip_id: 231143965174280264
+      chan: 1
+  -
+    - chip: 8
+      chan: 0
+    - remote_chip_id: 231143965174280264
+      chan: 0
+  -
+    - chip: 9
+      chan: 3
+    - remote_chip_id: 231143978059182422
+      chan: 3
+  -
+    - chip: 9
+      chan: 2
+    - remote_chip_id: 231143978059182422
+      chan: 2
+  -
+    - chip: 9
+      chan: 1
+    - remote_chip_id: 231143978059182422
+      chan: 1
+  -
+    - chip: 9
+      chan: 0
+    - remote_chip_id: 231143978059182422
+      chan: 0
+  -
+    - chip: 10
+      chan: 3
+    - remote_chip_id: 231143965174280244
+      chan: 3
+  -
+    - chip: 10
+      chan: 2
+    - remote_chip_id: 231143965174280244
+      chan: 2
+  -
+    - chip: 10
+      chan: 1
+    - remote_chip_id: 231143965174280244
+      chan: 1
+  -
+    - chip: 10
+      chan: 0
+    - remote_chip_id: 231143965174280244
+      chan: 0
+  -
+    - chip: 11
+      chan: 3
+    - remote_chip_id: 231143978059182391
+      chan: 3
+  -
+    - chip: 11
+      chan: 2
+    - remote_chip_id: 231143978059182391
+      chan: 2
+  -
+    - chip: 11
+      chan: 1
+    - remote_chip_id: 231143978059182391
+      chan: 1
+  -
+    - chip: 11
+      chan: 0
+    - remote_chip_id: 231143978059182391
+      chan: 0
+  -
+    - chip: 12
+      chan: 3
+    - remote_chip_id: 303201559212208200
+      chan: 3
+  -
+    - chip: 12
+      chan: 2
+    - remote_chip_id: 303201559212208200
+      chan: 2
+  -
+    - chip: 12
+      chan: 1
+    - remote_chip_id: 303201559212208200
+      chan: 1
+  -
+    - chip: 12
+      chan: 0
+    - remote_chip_id: 303201559212208200
+      chan: 0
+chips_with_mmio:
+  - 0: 13
+  - 1: 0
+  - 2: 30
+  - 3: 22
+  - 4: 12
+  - 5: 5
+  - 6: 26
+  - 7: 16
+  - 8: 14
+  - 9: 1
+  - 10: 27
+  - 11: 20
+  - 12: 10
+  - 13: 2
+  - 14: 29
+  - 15: 18
+  - 16: 8
+  - 17: 3
+  - 18: 25
+  - 19: 19
+  - 20: 15
+  - 21: 7
+  - 22: 31
+  - 23: 24
+  - 24: 9
+  - 25: 4
+  - 26: 23
+  - 27: 21
+  - 28: 11
+  - 29: 6
+  - 30: 28
+  - 31: 17
+io_device_type: PCIe
+harvesting:
+  0:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  1:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  2:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  3:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  4:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  5:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  6:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  7:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  8:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  9:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  10:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  11:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  12:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  13:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  14:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  15:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  16:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  17:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  18:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  19:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  20:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  21:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  22:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  23:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  24:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  25:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  26:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  27:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  28:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  29:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  30:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+  31:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 0
+    pcie_harvesting_mask: 0
+    l2cpu_harvesting_mask: 0
+chip_to_boardtype:
+  0: ubb
+  1: ubb
+  2: ubb
+  3: ubb
+  4: ubb
+  5: ubb
+  6: ubb
+  7: ubb
+  8: ubb
+  9: ubb
+  10: ubb
+  11: ubb
+  12: ubb
+  13: ubb
+  14: ubb
+  15: ubb
+  16: ubb
+  17: ubb
+  18: ubb
+  19: ubb
+  20: ubb
+  21: ubb
+  22: ubb
+  23: ubb
+  24: ubb
+  25: ubb
+  26: ubb
+  27: ubb
+  28: ubb
+  29: ubb
+  30: ubb
+  31: ubb
+chip_to_bus_id:
+  0: 0x0081
+  1: 0x00c1
+  2: 0x0041
+  3: 0x0001
+  4: 0x0082
+  5: 0x00c2
+  6: 0x0042
+  7: 0x0002
+  8: 0x0083
+  9: 0x00c3
+  10: 0x0043
+  11: 0x0003
+  12: 0x0084
+  13: 0x00c4
+  14: 0x0044
+  15: 0x0004
+  16: 0x0085
+  17: 0x00c5
+  18: 0x0045
+  19: 0x0005
+  20: 0x0086
+  21: 0x00c6
+  22: 0x0046
+  23: 0x0006
+  24: 0x0087
+  25: 0x00c7
+  26: 0x0047
+  27: 0x0007
+  28: 0x0088
+  29: 0x00c8
+  30: 0x0048
+  31: 0x0008
+boards:
+  -
+    - board_id: 72061240465162240
+    - board_type: ubb
+    - chips:
+        - 31
+        - 30
+        - 29
+        - 12
+        - 11
+        - 10
+        - 9
+        - 8
+        - 7
+        - 6
+        - 5
+        - 4
+        - 3
+        - 2
+        - 1
+        - 0
+        - 13
+        - 14
+        - 15
+        - 16
+        - 17
+        - 18
+        - 19
+        - 20
+        - 21
+        - 22
+        - 23
+        - 24
+        - 25
+        - 26
+        - 27
+        - 28
+asic_locations:
+  0: 1
+  1: 1
+  2: 1
+  3: 1
+  4: 2
+  5: 2
+  6: 2
+  7: 2
+  8: 3
+  9: 3
+  10: 3
+  11: 3
+  12: 4
+  13: 4
+  14: 4
+  15: 4
+  16: 5
+  17: 5
+  18: 5
+  19: 5
+  20: 6
+  21: 6
+  22: 6
+  23: 6
+  24: 7
+  25: 7
+  26: 7
+  27: 7
+  28: 8
+  29: 8
+  30: 8
+  31: 8

--- a/tests/tt_metal/tt_fabric/custom_mock_cluster_descriptors/bh_lb_2x4_cluster_desc.yaml
+++ b/tests/tt_metal/tt_fabric/custom_mock_cluster_descriptors/bh_lb_2x4_cluster_desc.yaml
@@ -1,0 +1,258 @@
+arch:
+  0: blackhole
+  1: blackhole
+  2: blackhole
+  3: blackhole
+  4: blackhole
+  5: blackhole
+  6: blackhole
+  7: blackhole
+chips:
+  {}
+chip_unique_ids:
+  7: 143238000935680
+  6: 143238000935392
+  5: 143238000935200
+  4: 143238000935104
+  3: 143238000934976
+  2: 143238000808160
+  1: 143238000807040
+  0: 143238000805344
+ethernet_connections:
+  -
+    - chip: 0
+      chan: 4
+    - chip: 2
+      chan: 9
+  -
+    - chip: 0
+      chan: 6
+    - chip: 2
+      chan: 11
+  -
+    - chip: 0
+      chan: 9
+    - chip: 6
+      chan: 9
+  -
+    - chip: 0
+      chan: 11
+    - chip: 6
+      chan: 11
+  -
+    - chip: 1
+      chan: 4
+    - chip: 4
+      chan: 9
+  -
+    - chip: 1
+      chan: 5
+    - chip: 7
+      chan: 5
+  -
+    - chip: 1
+      chan: 6
+    - chip: 4
+      chan: 11
+  -
+    - chip: 1
+      chan: 7
+    - chip: 7
+      chan: 7
+  -
+    - chip: 1
+      chan: 9
+    - chip: 2
+      chan: 4
+  -
+    - chip: 1
+      chan: 11
+    - chip: 2
+      chan: 6
+  -
+    - chip: 2
+      chan: 8
+    - chip: 5
+      chan: 8
+  -
+    - chip: 2
+      chan: 10
+    - chip: 5
+      chan: 10
+  -
+    - chip: 3
+      chan: 4
+    - chip: 4
+      chan: 4
+  -
+    - chip: 3
+      chan: 6
+    - chip: 4
+      chan: 6
+  -
+    - chip: 3
+      chan: 9
+    - chip: 7
+      chan: 4
+  -
+    - chip: 3
+      chan: 11
+    - chip: 7
+      chan: 6
+  -
+    - chip: 5
+      chan: 4
+    - chip: 7
+      chan: 9
+  -
+    - chip: 5
+      chan: 6
+    - chip: 7
+      chan: 11
+  -
+    - chip: 5
+      chan: 9
+    - chip: 6
+      chan: 4
+  -
+    - chip: 5
+      chan: 11
+    - chip: 6
+      chan: 6
+ethernet_connections_to_remote_devices:
+  []
+chips_with_mmio:
+  - 0: 4
+  - 1: 6
+  - 2: 5
+  - 3: 3
+  - 4: 7
+  - 5: 1
+  - 6: 0
+  - 7: 2
+io_device_type: PCIe
+harvesting:
+  0:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 288
+    pcie_harvesting_mask: 2
+    l2cpu_harvesting_mask: 0
+  1:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 288
+    pcie_harvesting_mask: 2
+    l2cpu_harvesting_mask: 0
+  2:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 288
+    pcie_harvesting_mask: 2
+    l2cpu_harvesting_mask: 0
+  3:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 288
+    pcie_harvesting_mask: 2
+    l2cpu_harvesting_mask: 0
+  4:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 288
+    pcie_harvesting_mask: 2
+    l2cpu_harvesting_mask: 0
+  5:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 288
+    pcie_harvesting_mask: 2
+    l2cpu_harvesting_mask: 0
+  6:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 288
+    pcie_harvesting_mask: 2
+    l2cpu_harvesting_mask: 0
+  7:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 288
+    pcie_harvesting_mask: 2
+    l2cpu_harvesting_mask: 0
+chip_to_boardtype:
+  0: p150
+  1: p150
+  2: p150
+  3: p150
+  4: p150
+  5: p150
+  6: p150
+  7: p150
+chip_to_bus_id:
+  0: 0x00e1
+  1: 0x0081
+  2: 0x00c1
+  3: 0x0021
+  4: 0x00a1
+  5: 0x0041
+  6: 0x0061
+  7: 0x0001
+boards:
+  -
+    - board_id: 4476187525167
+    - board_type: p150
+    - chips:
+        - 0
+  -
+    - board_id: 4476187525220
+    - board_type: p150
+    - chips:
+        - 1
+  -
+    - board_id: 4476187525255
+    - board_type: p150
+    - chips:
+        - 2
+  -
+    - board_id: 4476187529218
+    - board_type: p150
+    - chips:
+        - 3
+  -
+    - board_id: 4476187529222
+    - board_type: p150
+    - chips:
+        - 4
+  -
+    - board_id: 4476187529225
+    - board_type: p150
+    - chips:
+        - 5
+  -
+    - board_id: 4476187529231
+    - board_type: p150
+    - chips:
+        - 6
+  -
+    - board_id: 4476187529240
+    - board_type: p150
+    - chips:
+        - 7
+asic_locations:
+  0: 0
+  1: 0
+  2: 0
+  3: 0
+  4: 0
+  5: 0
+  6: 0
+  7: 0

--- a/tests/tt_metal/tt_fabric/custom_mock_cluster_descriptors/bh_qb_2x2_cluster_desc.yaml
+++ b/tests/tt_metal/tt_fabric/custom_mock_cluster_descriptors/bh_qb_2x2_cluster_desc.yaml
@@ -1,0 +1,166 @@
+arch:
+  0: blackhole
+  1: blackhole
+  2: blackhole
+  3: blackhole
+chips:
+  {}
+chip_unique_ids:
+  3: 143238001592768
+  2: 143238001592352
+  1: 143238001591648
+  0: 143238001591456
+ethernet_connections:
+  -
+    - chip: 0
+      chan: 4
+    - chip: 3
+      chan: 4
+  -
+    - chip: 0
+      chan: 5
+    - chip: 3
+      chan: 5
+  -
+    - chip: 0
+      chan: 6
+    - chip: 3
+      chan: 6
+  -
+    - chip: 0
+      chan: 7
+    - chip: 3
+      chan: 7
+  -
+    - chip: 0
+      chan: 8
+    - chip: 2
+      chan: 8
+  -
+    - chip: 0
+      chan: 9
+    - chip: 2
+      chan: 9
+  -
+    - chip: 0
+      chan: 10
+    - chip: 2
+      chan: 10
+  -
+    - chip: 0
+      chan: 11
+    - chip: 2
+      chan: 11
+  -
+    - chip: 1
+      chan: 4
+    - chip: 2
+      chan: 4
+  -
+    - chip: 1
+      chan: 5
+    - chip: 2
+      chan: 5
+  -
+    - chip: 1
+      chan: 6
+    - chip: 2
+      chan: 6
+  -
+    - chip: 1
+      chan: 7
+    - chip: 2
+      chan: 7
+  -
+    - chip: 1
+      chan: 8
+    - chip: 3
+      chan: 8
+  -
+    - chip: 1
+      chan: 9
+    - chip: 3
+      chan: 9
+  -
+    - chip: 1
+      chan: 10
+    - chip: 3
+      chan: 10
+  -
+    - chip: 1
+      chan: 11
+    - chip: 3
+      chan: 11
+ethernet_connections_to_remote_devices:
+  []
+chips_with_mmio:
+  - 0: 0
+  - 1: 2
+  - 2: 1
+  - 3: 3
+io_device_type: PCIe
+harvesting:
+  0:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 288
+    pcie_harvesting_mask: 2
+    l2cpu_harvesting_mask: 0
+  1:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 288
+    pcie_harvesting_mask: 2
+    l2cpu_harvesting_mask: 0
+  2:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 288
+    pcie_harvesting_mask: 2
+    l2cpu_harvesting_mask: 0
+  3:
+    noc_translation: true
+    harvest_mask: 0
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 288
+    pcie_harvesting_mask: 2
+    l2cpu_harvesting_mask: 0
+chip_to_boardtype:
+  0: p150
+  1: p150
+  2: p150
+  3: p150
+chip_to_bus_id:
+  0: 0x0061
+  1: 0x00c1
+  2: 0x0041
+  3: 0x00a1
+boards:
+  -
+    - board_id: 4476187549733
+    - board_type: p150
+    - chips:
+        - 0
+  -
+    - board_id: 4476187549739
+    - board_type: p150
+    - chips:
+        - 1
+  -
+    - board_id: 4476187549761
+    - board_type: p150
+    - chips:
+        - 2
+  -
+    - board_id: 4476187549774
+    - board_type: p150
+    - chips:
+        - 3
+asic_locations:
+  0: 0
+  1: 0
+  2: 0
+  3: 0

--- a/tests/tt_metal/tt_fabric/custom_mock_cluster_descriptors/p300_cluster_desc.yaml
+++ b/tests/tt_metal/tt_fabric/custom_mock_cluster_descriptors/p300_cluster_desc.yaml
@@ -1,0 +1,56 @@
+arch:
+  0: blackhole
+  1: blackhole
+chips:
+  {}
+chip_unique_ids:
+  1: 151896654217409
+  0: 151896654217408
+ethernet_connections:
+  -
+    - chip: 0
+      chan: 2
+    - chip: 1
+      chan: 9
+  -
+    - chip: 0
+      chan: 3
+    - chip: 1
+      chan: 8
+ethernet_connections_to_remote_devices:
+  []
+chips_with_mmio:
+  - 0: 1
+  - 1: 0
+io_device_type: PCIe
+harvesting:
+  0:
+    noc_translation: true
+    harvest_mask: 5
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 288
+    pcie_harvesting_mask: 2
+    l2cpu_harvesting_mask: 0
+  1:
+    noc_translation: true
+    harvest_mask: 260
+    dram_harvesting_mask: 0
+    eth_harvesting_mask: 288
+    pcie_harvesting_mask: 1
+    l2cpu_harvesting_mask: 0
+chip_to_boardtype:
+  0: p300
+  1: p300
+chip_to_bus_id:
+  0: 0x0003
+  1: 0x0001
+boards:
+  -
+    - board_id: 4746770444294
+    - board_type: p300
+    - chips:
+        - 1
+        - 0
+asic_locations:
+  0: 0
+  1: 1


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Need mock descriptors for various system types for testing simulation.
Ideally these can eventually be generated on the fly based off of a FSD for example.

### What's changed
Add mock cluster descriptors for various BH system types.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes
