### PR TITLE
Fix Sliding Window Attention PCC Accuracy Issues

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_scaled_dot_product_attention_decode.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_scaled_dot_product_attention_decode.py
@@ -1598,15 +1598,23 @@ def test_sdpa_decode_sliding_window(
 
     ttnn.device.DisablePersistentKernelCache()
 
-    # Test different positions to ensure sliding window works correctly
-    test_positions = [
-        sliding_window_size * 2,  # Window fully slides
-        sliding_window_size // 2,  # Window partially filled
-        sliding_window_size - 1,  # Window almost full
-        s // 2,  # Middle of sequence
-        s - 10,  # Near end of sequence
-    ]
+    # Test different window start positions to ensure all fill tile code paths are hit
+    # when generating the sliding window
+    k_values = [5, 10, 20, 30]
 
+    test_positions = [
+        *[
+            (sliding_window_size + offset - 1) + 32 * k
+            for k in k_values
+            for offset in (15, 16, 17)
+            # in first face, in second face (1st face completely filled), in second face (1st face completely filled + 2nd face partially filled)
+        ],
+        sliding_window_size * 2,
+        sliding_window_size // 2,
+        sliding_window_size - 1,
+        s // 2,
+        s - 10,
+    ]
     for cur_pos in test_positions:
         if cur_pos >= s:
             continue

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/dataflow_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/dataflow_common.hpp
@@ -159,7 +159,7 @@ void fill_tile_partial_sliding_window(uint32_t cb_id, uint32_t tile_id, uint32_t
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_id) + tile_id * tile_bytes);
 
     // Determine which faces to fill completely (before the window_start_pos_in_tile)
-    int face_start = (window_start_pos_in_tile < 15) ? 0 : 1;  // Last face to fill completely
+    int face_start = (window_start_pos_in_tile < 16) ? 0 : 1;  // Last face to fill completely
 
     // Fill complete faces (faces 0, 2, 4, 6... for faces before face_start)
     if (face_start == 1) {


### PR DESCRIPTION
### Ticket
#30362 

### Problem description
sliding window attention has bad PCC for cur pos iterations that are `(cur_pos + 1 - sliding_window_size) % 32 == 15` because we are filling full first face when we should only be filling the first face partially

### What's changed
- change to check for < 16 not 15
- updated unit tests to sweep those code paths

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [L2 nightly stress for SDPA](https://github.com/tenstorrent/tt-metal/actions/runs/19238421488)