### PR TITLE
Improve Out of Memory Error Message

### DIFF
--- a/tt_metal/impl/allocator/bank_manager.cpp
+++ b/tt_metal/impl/allocator/bank_manager.cpp
@@ -420,15 +420,21 @@ uint64_t BankManager::allocate_buffer(
     // vs. top-down allocation
     if (dependent_allocators.empty()) {
         auto address = alloc->allocate(size_per_bank, bottom_up, address_limit);
-        TT_FATAL(
-            address.has_value(),
-            "Out of Memory: Not enough space to allocate {} B {} buffer across {} banks, where each bank needs to "
-            "store {} B, but bank size is only {} B",
-            size,
-            enchantum::to_string(buffer_type_),
-            num_banks,
-            size_per_bank,
-            bank_size());
+        if (!address.has_value()) {
+            auto mem_stats = alloc->get_statistics();
+            TT_FATAL(
+                false,
+                "Out of Memory: Not enough space to allocate {} B {} buffer across {} banks, where each bank needs to "
+                "store {} B, but bank size is {} B (allocated: {} B, free: {} B, largest free block: {} B)",
+                size,
+                enchantum::to_string(buffer_type_),
+                num_banks,
+                size_per_bank,
+                bank_size(),
+                mem_stats.total_allocated_bytes,
+                mem_stats.total_free_bytes,
+                mem_stats.largest_free_block_bytes);
+        }
         allocated_buffers_[allocator_id.get()].insert(address.value());
         // No neighbors, nothing to invalidate
         return address.value();
@@ -461,14 +467,21 @@ uint64_t BankManager::allocate_buffer(
         }
     }
 
-    TT_FATAL(
-        chosen.has_value(),
-        "Out of Memory: Not enough space after considering dependencies to allocate {} B {} across {} banks ({} B "
-        "per bank)",
-        size,
-        enchantum::to_string(buffer_type_),
-        num_banks,
-        size_per_bank);
+    if (!chosen.has_value()) {
+        auto mem_stats = alloc->get_statistics();
+        TT_FATAL(
+            false,
+            "Out of Memory: Not enough space after considering dependencies to allocate {} B {} across {} banks ({} B "
+            "per bank), bank size is {} B (allocated: {} B, free: {} B, largest free block: {} B)",
+            size,
+            enchantum::to_string(buffer_type_),
+            num_banks,
+            size_per_bank,
+            bank_size(),
+            mem_stats.total_allocated_bytes,
+            mem_stats.total_free_bytes,
+            mem_stats.largest_free_block_bytes);
+    }
     TT_FATAL(
         chosen.value() % alignment_bytes_ == 0,
         "Chosen address {} is not aligned to {} B",


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/32149

### Problem description
Without knowing the allocator’s current memory status, it is difficult to determine if the allocation failed due to fragmentation or actual memory exhaustion.

### What's changed
tt-metal already provides a `get_statistics` method that reports memory usage, including:

- `total_allocated_bytes`
- `total_free_bytes`
- `largest_free_block_bytes`

I suggest modifying the allocation failure handling logic as follows:
When allocation fails, call get_statistics before throwing an exception.
So that we can include the output of these statistics in the error message.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes