### PR TITLE
Disable yolov11 from Demo tests pipeline

### DIFF
--- a/.github/workflows/single-card-demo-tests-impl.yaml
+++ b/.github/workflows/single-card-demo-tests-impl.yaml
@@ -47,7 +47,7 @@ jobs:
             { name: "stable_diffusion", runner-label: "N150", performance: false, cmd: run_stable_diffusion_func, owner_id: U045U3DEKM4}, # Mohamed Bahnas
             { name: "segformer", runner-label: "N150", performance: false, cmd: run_segformer_func, owner_id: U045U3DEKM4, civ2-compatible: true}, # Mohamed Bahnas (vguduruTT)
             { name: "sentence_bert", runner-label: "N150", performance: false, cmd: run_sentencebert_func, owner_id: U045U3DEKM4, civ2-compatible: true}, # Mohamed Bahnas
-            { name: "yolov11", runner-label: "N150", performance: false, cmd: run_yolov11_func, owner_id: U045U3DEKM4, civ2-compatible: true}, # Mohamed Bahnas
+            # { name: "yolov11", runner-label: "N150", performance: false, cmd: run_yolov11_func, owner_id: U045U3DEKM4, civ2-compatible: true}, # Mohamed Bahnas - disable until issue #32151 is closed
             { name: "yolov11m", runner-label: "N150", performance: false, cmd: run_yolov11m_func, owner_id: U04B9QAMM4N, civ2-compatible: true}, # Dimitri Gnidash
             { name: "yolov9c", runner-label: "N150", performance: false, cmd: run_yolov9c_perf, owner_id: U056BK5U81E, civ2-compatible: true}, # Dalar Vartanians
             { name: "mobilenetv2", runner-label: "N150", performance: false, cmd: run_mobilenetv2_perf, owner_id: U056BK5U81E, civ2-compatible: true}, # Dalar Vartanians


### PR DESCRIPTION
### Ticket
#32151 

### Problem description / What's changed
Yolov11 on N150 has been failing for a while on main in the Demo tests pipeline (timed out).

https://github.com/tenstorrent/tt-metal/actions/runs/19212411517/job/54916844504

Disable test to make CI green, until issue is resolved.


### Checklist
- [x] [(Single-card) Demo tests (no perf)](https://github.com/tenstorrent/tt-metal/actions/runs/19227351706)