### PR TITLE
Conv2d Block sharding activation mcast batches

### DIFF
--- a/models/demos/blackhole/resnet50/tests/test_perf_device_resnet50.py
+++ b/models/demos/blackhole/resnet50/tests/test_perf_device_resnet50.py
@@ -13,8 +13,8 @@ from models.demos.ttnn_resnet.tests.common.perf_device_resnet50 import run_perf_
 @pytest.mark.parametrize(
     "batch_size, test, expected_perf",
     [
-        [16, "True-act_dtype0-weight_dtype0-math_fidelity0-16-device_params0", 10601.0],
-        [32, "True-act_dtype0-weight_dtype0-math_fidelity0-32-device_params0", 14779.0],
+        [16, "True-act_dtype0-weight_dtype0-math_fidelity0-16-device_params0", 10610.0],
+        [32, "True-act_dtype0-weight_dtype0-math_fidelity0-32-device_params0", 14815.0],
     ],
 )
 def test_perf_device(batch_size, test, expected_perf):

--- a/models/demos/mobilenetv2/tests/perf/test_perf_mobilenetv2.py
+++ b/models/demos/mobilenetv2/tests/perf/test_perf_mobilenetv2.py
@@ -14,7 +14,7 @@ from models.perf.device_perf_utils import check_device_perf, prep_device_perf_re
 @pytest.mark.parametrize(
     "batch_size, expected_perf",
     [
-        [MOBILENETV2_BATCH_SIZE, 3677],
+        [MOBILENETV2_BATCH_SIZE, 3730],
     ],
 )
 def test_perf_device_mobilenetv2(batch_size, expected_perf):

--- a/models/demos/wormhole/resnet50/tests/test_perf_device_resnet50.py
+++ b/models/demos/wormhole/resnet50/tests/test_perf_device_resnet50.py
@@ -13,7 +13,7 @@ from models.demos.ttnn_resnet.tests.common.perf_device_resnet50 import run_perf_
 @pytest.mark.parametrize(
     "batch_size, test, expected_perf",
     [
-        [16, "True-16-act_dtype0-weight_dtype0-math_fidelity0-device_params0", 6090.0],
+        [16, "True-16-act_dtype0-weight_dtype0-math_fidelity0-device_params0", 6140.0],
     ],
 )
 def test_perf_device(batch_size, test, expected_perf):

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
@@ -801,7 +801,7 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_conv2d_sharded(
         (uint32_t)(transpose_mcast ? num_cores_y - 1 : num_cores_x - 1),  // act_mcast_num_cores
         (uint32_t)act_mcast_sender_semaphore_id,
         (uint32_t)act_mcast_receiver_semaphore_id,
-        (uint32_t)act_block_num_tiles * tilized_act_tile_size,  // act_mcast_sender_size_bytes
+        (uint32_t)tilized_act_tile_size,  // act_mcast_tile_size_bytes
         (uint32_t)(transpose_mcast ? 1 : 0),
         (uint32_t)needs_act_block_zero_out,  // zero_out_act_cb
         get_cb_info_by_name(cb_info, Conv2dCb::ACT).index,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_reader_common.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_reader_common.hpp
@@ -8,7 +8,6 @@
 #include <cstdint>
 #include <tt-metalium/constants.hpp>
 #include "dataflow_api.h"
-#include "tt-metalium/math.hpp"
 
 // Zero out all tiles for a given circular buffer.
 template <uint32_t cb_id>
@@ -474,92 +473,4 @@ FORCE_INLINE void signal_write_done(volatile tt_l1_ptr uint32_t* semaphore_addr_
 FORCE_INLINE void wait_write_done(volatile tt_l1_ptr uint32_t* semaphore_addr_ptr) {
     noc_semaphore_wait(semaphore_addr_ptr, VALID);
     noc_semaphore_set(semaphore_addr_ptr, INVALID);
-}
-// Multicast activation data from the local circular buffer to multiple destinations.
-// This function sends a block of data (the activation block) using NOC multicast commands.
-//
-// Template parameters:
-//   act_mcast_num_cores: Number of core destinations in the multicast group.
-template <uint32_t act_mcast_num_cores>
-void multicast_data(
-    bool is_receiver_core,        // Whether this core is also a receiver of its own multicast (for loopback).
-    uint32_t src_l1_addr,         // SRC address in L1
-    uint32_t dst_l1_addr,         // DST address in L1
-    uint64_t multicast_noc_addr,  // Multicast NOC address
-    uint32_t total_bytes)         // Total bytes to send
-{
-    uint64_t multicast_write_addr = multicast_noc_addr | dst_l1_addr;
-    if (is_receiver_core) {
-        if constexpr (act_mcast_num_cores) {
-            // num_dests will source, since we are copying to a different local CB as well
-            noc_async_write_multicast_loopback_src(
-                src_l1_addr, multicast_write_addr, total_bytes, act_mcast_num_cores + 1, true);
-        } else {
-            // In this case sender core is the only reciever in the grid,
-            // we can't use the multicast_loopback_src (hang)
-            noc_async_write(get_noc_addr(src_l1_addr), get_noc_addr(dst_l1_addr), total_bytes);
-        }
-    } else {
-        // If sender core is not the reciever core as well we can't use the loopback mcast. (hang)
-        noc_async_write_multicast(src_l1_addr, multicast_write_addr, total_bytes, act_mcast_num_cores + 1, true);
-    }
-}
-
-template <
-    uint32_t act_mcast_num_dest_cores,
-    uint32_t mcast_noc_burst_size,
-    uint32_t block_tile_count,
-    uint32_t tile_size>
-void mcast_block(bool is_receiver_core, uint32_t src_cb, uint32_t dst_cb, uint64_t multicast_noc_addr) {
-    // number of full bursts
-    constexpr uint32_t mcast_full_burst_cnt = block_tile_count * tile_size / mcast_noc_burst_size;
-    // size of the leftover burst, if 0 means we have no leftover burst
-    constexpr uint32_t mcast_leftover_burst_size = block_tile_count * tile_size % mcast_noc_burst_size;
-    // number of tiles that we need to wait for to cover the full burst size
-    constexpr uint32_t wait_tile_full_cnt = (mcast_noc_burst_size + tile_size - 1) / tile_size;
-
-    // In full burst iterations we wait for a bit more than the full burst size in case where the
-    // tile size does not divide the burst size evenly.
-    // we need to insure that we don't wait for more tiles than we have in the block
-    constexpr uint32_t wait_tile_full_done = std::min(mcast_full_burst_cnt * wait_tile_full_cnt, block_tile_count);
-
-    // optimization to avoid unnecessary branching in the loop
-    constexpr bool no_need_partial_wait_tile = mcast_full_burst_cnt * wait_tile_full_cnt <= block_tile_count;
-
-    // number of times we need to increase the wait_tile_curr for the full burst iterations
-    constexpr uint32_t wait_tile_full_iter_cnt = (wait_tile_full_done / wait_tile_full_cnt) - 1;
-
-    uint32_t src_l1_addr = get_read_ptr(src_cb);
-    uint32_t dst_l1_addr = get_write_ptr(dst_cb);
-
-    constexpr uint32_t wait_tile_start_cnt = std::min(block_tile_count, wait_tile_full_cnt);
-    uint32_t wait_tile_curr = wait_tile_start_cnt;
-    for (uint32_t i = 0; i < mcast_full_burst_cnt; i++) {
-        cb_wait_front(src_cb, wait_tile_curr);
-        multicast_data<act_mcast_num_dest_cores>(
-            is_receiver_core, src_l1_addr, dst_l1_addr, multicast_noc_addr, mcast_noc_burst_size);
-        src_l1_addr += mcast_noc_burst_size;
-        dst_l1_addr += mcast_noc_burst_size;
-
-        if constexpr (no_need_partial_wait_tile) {
-            wait_tile_curr += wait_tile_full_cnt;
-        } else {
-            // we shouldn't wait for more than the number of tiles in the block
-            if (i < wait_tile_full_iter_cnt) {
-                wait_tile_curr += wait_tile_full_cnt;
-            } else {
-                wait_tile_curr = block_tile_count;
-            }
-        }
-    }
-    if constexpr (mcast_leftover_burst_size > 0) {
-        cb_wait_front(src_cb, block_tile_count);
-        multicast_data<act_mcast_num_dest_cores>(
-            is_receiver_core, src_l1_addr, dst_l1_addr, multicast_noc_addr, mcast_leftover_burst_size);
-    }
-    if constexpr (act_mcast_num_dest_cores == 0) {
-        if (is_receiver_core) {
-            noc_async_write_barrier();
-        }
-    }
 }

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_reader_common.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_reader_common.hpp
@@ -4,8 +4,6 @@
 
 #pragma once
 
-#include <sys/param.h>
-#include <cstdint>
 #include <tt-metalium/constants.hpp>
 #include "dataflow_api.h"
 

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_reader_common.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_reader_common.hpp
@@ -4,8 +4,11 @@
 
 #pragma once
 
+#include <sys/param.h>
+#include <cstdint>
 #include <tt-metalium/constants.hpp>
 #include "dataflow_api.h"
+#include "tt-metalium/math.hpp"
 
 // Zero out all tiles for a given circular buffer.
 template <uint32_t cb_id>
@@ -478,13 +481,12 @@ FORCE_INLINE void wait_write_done(volatile tt_l1_ptr uint32_t* semaphore_addr_pt
 // Template parameters:
 //   act_mcast_num_cores: Number of core destinations in the multicast group.
 template <uint32_t act_mcast_num_cores>
-void multicast_act_data(
+void multicast_data(
     bool is_receiver_core,        // Whether this core is also a receiver of its own multicast (for loopback).
     uint32_t src_l1_addr,         // SRC address in L1
     uint32_t dst_l1_addr,         // DST address in L1
     uint64_t multicast_noc_addr,  // Multicast NOC address
-    uint32_t total_bytes,         // Total bytes to send
-    bool last_packet)             // Whether this is the last packet in the block
+    uint32_t total_bytes)         // Total bytes to send
 {
     uint64_t multicast_write_addr = multicast_noc_addr | dst_l1_addr;
     if (is_receiver_core) {
@@ -496,12 +498,68 @@ void multicast_act_data(
             // In this case sender core is the only reciever in the grid,
             // we can't use the multicast_loopback_src (hang)
             noc_async_write(get_noc_addr(src_l1_addr), get_noc_addr(dst_l1_addr), total_bytes);
-            if (last_packet) {
-                noc_async_write_barrier();
-            }
         }
     } else {
         // If sender core is not the reciever core as well we can't use the loopback mcast. (hang)
         noc_async_write_multicast(src_l1_addr, multicast_write_addr, total_bytes, act_mcast_num_cores + 1, true);
+    }
+}
+
+template <
+    uint32_t act_mcast_num_dest_cores,
+    uint32_t mcast_noc_burst_size,
+    uint32_t block_tile_count,
+    uint32_t tile_size>
+void mcast_block(bool is_receiver_core, uint32_t src_cb, uint32_t dst_cb, uint64_t multicast_noc_addr) {
+    // number of full bursts
+    constexpr uint32_t mcast_full_burst_cnt = block_tile_count * tile_size / mcast_noc_burst_size;
+    // size of the leftover burst, if 0 means we have no leftover burst
+    constexpr uint32_t mcast_leftover_burst_size = block_tile_count * tile_size % mcast_noc_burst_size;
+    // number of tiles that we need to wait for to cover the full burst size
+    constexpr uint32_t wait_tile_full_cnt = (mcast_noc_burst_size + tile_size - 1) / tile_size;
+
+    // In full burst iterations we wait for a bit more than the full burst size in case where the
+    // tile size does not divide the burst size evenly.
+    // we need to insure that we don't wait for more tiles than we have in the block
+    constexpr uint32_t wait_tile_full_done = std::min(mcast_full_burst_cnt * wait_tile_full_cnt, block_tile_count);
+
+    // optimization to avoid unnecessary branching in the loop
+    constexpr bool no_need_partial_wait_tile = mcast_full_burst_cnt * wait_tile_full_cnt <= block_tile_count;
+
+    // number of times we need to increase the wait_tile_curr for the full burst iterations
+    constexpr uint32_t wait_tile_full_iter_cnt = (wait_tile_full_done / wait_tile_full_cnt) - 1;
+
+    uint32_t src_l1_addr = get_read_ptr(src_cb);
+    uint32_t dst_l1_addr = get_write_ptr(dst_cb);
+
+    constexpr uint32_t wait_tile_start_cnt = std::min(block_tile_count, wait_tile_full_cnt);
+    uint32_t wait_tile_curr = wait_tile_start_cnt;
+    for (uint32_t i = 0; i < mcast_full_burst_cnt; i++) {
+        cb_wait_front(src_cb, wait_tile_curr);
+        multicast_data<act_mcast_num_dest_cores>(
+            is_receiver_core, src_l1_addr, dst_l1_addr, multicast_noc_addr, mcast_noc_burst_size);
+        src_l1_addr += mcast_noc_burst_size;
+        dst_l1_addr += mcast_noc_burst_size;
+
+        if constexpr (no_need_partial_wait_tile) {
+            wait_tile_curr += wait_tile_full_cnt;
+        } else {
+            // we shouldn't wait for more than the number of tiles in the block
+            if (i < wait_tile_full_iter_cnt) {
+                wait_tile_curr += wait_tile_full_cnt;
+            } else {
+                wait_tile_curr = block_tile_count;
+            }
+        }
+    }
+    if constexpr (mcast_leftover_burst_size > 0) {
+        cb_wait_front(src_cb, block_tile_count);
+        multicast_data<act_mcast_num_dest_cores>(
+            is_receiver_core, src_l1_addr, dst_l1_addr, multicast_noc_addr, mcast_leftover_burst_size);
+    }
+    if constexpr (act_mcast_num_dest_cores == 0) {
+        if (is_receiver_core) {
+            noc_async_write_barrier();
+        }
     }
 }

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_conv_activations_2d_mcast_padded_with_halo_3x3_weights_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_conv_activations_2d_mcast_padded_with_halo_3x3_weights_v2.cpp
@@ -13,6 +13,95 @@
 #include "debug/dprint_pages.h"
 #endif
 
+// Multicasts activation data from the local circular buffer to multiple destinations depending on the core role.
+template <uint32_t act_mcast_num_cores>
+void multicast_data(
+    bool is_receiver_core,        // Whether this core is also a receiver of its own multicast (for loopback).
+    uint32_t src_l1_addr,         // SRC address in L1
+    uint32_t dst_l1_addr,         // DST address in L1
+    uint64_t multicast_noc_addr,  // Multicast NOC address
+    uint32_t total_bytes)         // Total bytes to send
+{
+    uint64_t multicast_write_addr = multicast_noc_addr | dst_l1_addr;
+    if (is_receiver_core) {
+        if constexpr (act_mcast_num_cores) {
+            // num_dests will source, since we are copying to a different local CB as well
+            noc_async_write_multicast_loopback_src(
+                src_l1_addr, multicast_write_addr, total_bytes, act_mcast_num_cores + 1, true);
+        } else {
+            // In this case sender core is the only reciever in the grid,
+            // we can't use the multicast_loopback_src (hang)
+            noc_async_write(get_noc_addr(src_l1_addr), get_noc_addr(dst_l1_addr), total_bytes);
+        }
+    } else {
+        // If sender core is not the reciever core as well we can't use the loopback mcast. (hang)
+        noc_async_write_multicast(src_l1_addr, multicast_write_addr, total_bytes, act_mcast_num_cores + 1, true);
+    }
+}
+
+// Multicast activation data from the local circular buffer to multiple destinations (dst_cb in receiver cores).
+// This function sends a block of data (the activation block) using NOC multicast commands.
+template <
+    uint32_t act_mcast_num_dest_cores,
+    uint32_t mcast_noc_burst_size,
+    uint32_t block_tile_count,
+    uint32_t tile_size>
+void mcast_block(bool is_receiver_core, uint32_t src_cb, uint32_t dst_cb, uint64_t multicast_noc_addr) {
+    // number of full bursts
+    constexpr uint32_t mcast_full_burst_cnt = block_tile_count * tile_size / mcast_noc_burst_size;
+    // size of the leftover burst, if 0 means we have no leftover burst
+    constexpr uint32_t mcast_leftover_burst_size = block_tile_count * tile_size % mcast_noc_burst_size;
+    // number of tiles that we need to wait for to cover the full burst size
+    constexpr uint32_t wait_tile_full_cnt = (mcast_noc_burst_size + tile_size - 1) / tile_size;
+
+    // In full burst iterations we wait for a bit more than the full burst size in case where the
+    // tile size does not divide the burst size evenly.
+    // we need to insure that we don't wait for more tiles than we have in the block
+    constexpr uint32_t wait_tile_full_done = std::min(mcast_full_burst_cnt * wait_tile_full_cnt, block_tile_count);
+
+    // optimization to avoid unnecessary branching in the loop
+    constexpr bool no_need_partial_wait_tile = mcast_full_burst_cnt * wait_tile_full_cnt <= block_tile_count;
+
+    // number of times we need to increase the wait_tile_curr for the full burst iterations
+    constexpr uint32_t wait_tile_full_iter_cnt = (wait_tile_full_done / wait_tile_full_cnt) - 1;
+
+    uint32_t src_l1_addr = get_read_ptr(src_cb);
+    uint32_t dst_l1_addr = get_write_ptr(dst_cb);
+
+    constexpr uint32_t wait_tile_start_cnt = std::min(block_tile_count, wait_tile_full_cnt);
+    uint32_t wait_tile_curr = wait_tile_start_cnt;
+    for (uint32_t i = 0; i < mcast_full_burst_cnt; i++) {
+        cb_wait_front(src_cb, wait_tile_curr);
+        multicast_data<act_mcast_num_dest_cores>(
+            is_receiver_core, src_l1_addr, dst_l1_addr, multicast_noc_addr, mcast_noc_burst_size);
+        src_l1_addr += mcast_noc_burst_size;
+        dst_l1_addr += mcast_noc_burst_size;
+
+        if constexpr (no_need_partial_wait_tile) {
+            wait_tile_curr += wait_tile_full_cnt;
+        } else {
+            // we shouldn't wait for more than the number of tiles in the block
+            if (i < wait_tile_full_iter_cnt) {
+                wait_tile_curr += wait_tile_full_cnt;
+            } else {
+                wait_tile_curr = block_tile_count;
+            }
+        }
+    }
+    if constexpr (mcast_leftover_burst_size > 0) {
+        cb_wait_front(src_cb, block_tile_count);
+        multicast_data<act_mcast_num_dest_cores>(
+            is_receiver_core, src_l1_addr, dst_l1_addr, multicast_noc_addr, mcast_leftover_burst_size);
+    }
+
+    // In case we only do local l1 writes, we need to wait for the barrier to complete
+    if constexpr (act_mcast_num_dest_cores == 0) {
+        if (is_receiver_core) {
+            noc_async_write_barrier();
+        }
+    }
+}
+
 constexpr uint32_t DILATION_W = get_compile_time_arg_val(1);
 void kernel_main() {
     constexpr uint32_t dilation_h = get_compile_time_arg_val(0);

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_conv_activations_2d_mcast_padded_with_halo_3x3_weights_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_conv_activations_2d_mcast_padded_with_halo_3x3_weights_v2.cpp
@@ -40,7 +40,10 @@ void multicast_data(
 }
 
 // Multicast activation data from the local circular buffer to multiple destinations (dst_cb in receiver cores).
-// This function sends a block of data (the activation block) using NOC multicast commands.
+// This function sends a block of data (the activation block) using NOC multicast commands, it avoids waiting for the
+// whole block to be available in the source CB before starting the multicast, instead waits for enough tiles to do one
+// multicast of NOC_MAX_BURST_SIZE size. This is because under the hood, the multicast splits the data into chunks of
+// NOC_MAX_BURST_SIZE size
 template <
     uint32_t act_mcast_num_dest_cores,
     uint32_t mcast_noc_burst_size,


### PR DESCRIPTION
### Problem description
Currently reader kernel waits for whole block to be tilized before doing mcast. 
The mcast under the hood splits the transfer into multiple async calls.
The mcasting can be done with more granularity

### What's changed
- started waiting for smaller chunks of tilized activations before mcasting

### Checklist
- [X] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/19167430577)
- [X] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI [conv tests pass](https://github.com/tenstorrent/tt-metal/actions/runs/19167434810)
- [X] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/19170037692)
- [X] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI [same as main](https://github.com/tenstorrent/tt-metal/actions/runs/19231371785)
- [x] [Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) CI [in progress](https://github.com/tenstorrent/tt-metal/actions/runs/19231367659)