### PR TITLE
lower gemma kv cache precision

### DIFF
--- a/models/demos/gemma3/tt/model_config.py
+++ b/models/demos/gemma3/tt/model_config.py
@@ -88,7 +88,7 @@ class ModelOptimizations:
                     {
                         "TensorPrecision": {
                             TensorGroup.WQKV: PrecisionSetting.BF16,
-                            TensorGroup.KV_CACHE: PrecisionSetting.BF16,
+                            TensorGroup.KV_CACHE: PrecisionSetting.BF8,
                             TensorGroup.WO: PrecisionSetting.BF16,
                         },
                         "OpFidelity": {
@@ -118,7 +118,7 @@ class ModelOptimizations:
                 {
                     "TensorPrecision": {
                         TensorGroup.WQKV: PrecisionSetting.BF16,
-                        TensorGroup.KV_CACHE: PrecisionSetting.BF16,
+                        TensorGroup.KV_CACHE: PrecisionSetting.BF8,
                         TensorGroup.WO: PrecisionSetting.BF16,
                     },
                     "OpFidelity": {

--- a/models/demos/gemma3/tt/model_config.py
+++ b/models/demos/gemma3/tt/model_config.py
@@ -88,7 +88,7 @@ class ModelOptimizations:
                     {
                         "TensorPrecision": {
                             TensorGroup.WQKV: PrecisionSetting.BF16,
-                            TensorGroup.KV_CACHE: PrecisionSetting.BF8,
+                            TensorGroup.KV_CACHE: PrecisionSetting.BF16,
                             TensorGroup.WO: PrecisionSetting.BF16,
                         },
                         "OpFidelity": {
@@ -118,7 +118,7 @@ class ModelOptimizations:
                 {
                     "TensorPrecision": {
                         TensorGroup.WQKV: PrecisionSetting.BF16,
-                        TensorGroup.KV_CACHE: PrecisionSetting.BF8,
+                        TensorGroup.KV_CACHE: PrecisionSetting.BF16,
                         TensorGroup.WO: PrecisionSetting.BF16,
                     },
                     "OpFidelity": {

--- a/models/tt_transformers/model_params/gemma-3-27b-it/accuracy_decoder_config.json
+++ b/models/tt_transformers/model_params/gemma-3-27b-it/accuracy_decoder_config.json
@@ -1,0 +1,134 @@
+{
+    "decoders": {
+        "0": {
+            "precision_cfg": {
+                "KV_CACHE": "BFP8"
+            }
+        },
+        "1": {
+            "precision_cfg": {
+                "KV_CACHE": "BFP8"
+            }
+        },
+        "2": {
+            "precision_cfg": {
+                "KV_CACHE": "BFP8"
+            }
+        },
+        "3": {
+            "precision_cfg": {
+                "KV_CACHE": "BFP8"
+            }
+        },
+        "4": {
+            "precision_cfg": {
+                "KV_CACHE": "BFP8"
+            }
+        },
+        "5": {
+            "precision_cfg": {
+                "KV_CACHE": "BFP8"
+            }
+        },
+        "6": {
+            "precision_cfg": {
+                "KV_CACHE": "BFP8"
+            }
+        },
+        "7": {
+            "precision_cfg": {
+                "KV_CACHE": "BFP8"
+            }
+        },
+        "8": {
+            "precision_cfg": {
+                "KV_CACHE": "BFP8"
+            }
+        },
+        "9": {
+            "precision_cfg": {
+                "KV_CACHE": "BFP8"
+            }
+        },
+        "10": {
+            "precision_cfg": {
+                "KV_CACHE": "BFP8"
+            }
+        },
+        "11": {
+            "precision_cfg": {
+                "KV_CACHE": "BFP8"
+            }
+        },
+        "12": {
+            "precision_cfg": {
+                "KV_CACHE": "BFP8"
+            }
+        },
+        "13": {
+            "precision_cfg": {
+                "KV_CACHE": "BFP8"
+            }
+        },
+        "14": {
+            "precision_cfg": {
+                "KV_CACHE": "BFP8"
+            }
+        },
+        "15": {
+            "precision_cfg": {
+                "KV_CACHE": "BFP8"
+            }
+        },
+        "16": {
+            "precision_cfg": {
+                "KV_CACHE": "BFP8"
+            }
+        },
+        "17": {
+            "precision_cfg": {
+                "KV_CACHE": "BFP8"
+            }
+        },
+        "18": {
+            "precision_cfg": {
+                "KV_CACHE": "BFP8"
+            }
+        },
+        "19": {
+            "precision_cfg": {
+                "KV_CACHE": "BFP8"
+            }
+        },
+        "20": {
+            "precision_cfg": {
+                "KV_CACHE": "BFP8"
+            }
+        },
+        "21": {
+            "precision_cfg": {
+                "KV_CACHE": "BFP8"
+            }
+        },
+        "22": {
+            "precision_cfg": {
+                "KV_CACHE": "BFP8"
+            }
+        },
+        "23": {
+            "precision_cfg": {
+                "KV_CACHE": "BFP8"
+            }
+        },
+        "24": {
+            "precision_cfg": {
+                "KV_CACHE": "BFP8"
+            }
+        },
+        "25": {
+            "precision_cfg": {
+                "KV_CACHE": "BFP8"
+            }
+        }
+    }
+}

--- a/models/tt_transformers/model_params/gemma-3-27b-it/accuracy_decoder_config.json
+++ b/models/tt_transformers/model_params/gemma-3-27b-it/accuracy_decoder_config.json
@@ -129,6 +129,186 @@
             "precision_cfg": {
                 "KV_CACHE": "BFP8"
             }
+        },
+        "26": {
+            "precision_cfg": {
+                "KV_CACHE": "BFP8"
+            }
+        },
+        "27": {
+            "precision_cfg": {
+                "KV_CACHE": "BFP8"
+            }
+        },
+        "28": {
+            "precision_cfg": {
+                "KV_CACHE": "BFP8"
+            }
+        },
+        "29": {
+            "precision_cfg": {
+                "KV_CACHE": "BFP8"
+            }
+        },
+        "30": {
+            "precision_cfg": {
+                "KV_CACHE": "BFP8"
+            }
+        },
+        "31": {
+            "precision_cfg": {
+                "KV_CACHE": "BFP8"
+            }
+        },
+        "32": {
+            "precision_cfg": {
+                "KV_CACHE": "BFP8"
+            }
+        },
+        "33": {
+            "precision_cfg": {
+                "KV_CACHE": "BFP8"
+            }
+        },
+        "34": {
+            "precision_cfg": {
+                "KV_CACHE": "BFP8"
+            }
+        },
+        "35": {
+            "precision_cfg": {
+                "KV_CACHE": "BFP8"
+            }
+        },
+        "36": {
+            "precision_cfg": {
+                "KV_CACHE": "BFP8"
+            }
+        },
+        "37": {
+            "precision_cfg": {
+                "KV_CACHE": "BFP8"
+            }
+        },
+        "38": {
+            "precision_cfg": {
+                "KV_CACHE": "BFP8"
+            }
+        },
+        "39": {
+            "precision_cfg": {
+                "KV_CACHE": "BFP8"
+            }
+        },
+        "40": {
+            "precision_cfg": {
+                "KV_CACHE": "BFP8"
+            }
+        },
+        "41": {
+            "precision_cfg": {
+                "KV_CACHE": "BFP8"
+            }
+        },
+        "42": {
+            "precision_cfg": {
+                "KV_CACHE": "BFP8"
+            }
+        },
+        "43": {
+            "precision_cfg": {
+                "KV_CACHE": "BFP8"
+            }
+        },
+        "44": {
+            "precision_cfg": {
+                "KV_CACHE": "BFP8"
+            }
+        },
+        "45": {
+            "precision_cfg": {
+                "KV_CACHE": "BFP8"
+            }
+        },
+        "46": {
+            "precision_cfg": {
+                "KV_CACHE": "BFP8"
+            }
+        },
+        "47": {
+            "precision_cfg": {
+                "KV_CACHE": "BFP8"
+            }
+        },
+        "48": {
+            "precision_cfg": {
+                "KV_CACHE": "BFP8"
+            }
+        },
+        "49": {
+            "precision_cfg": {
+                "KV_CACHE": "BFP8"
+            }
+        },
+        "50": {
+            "precision_cfg": {
+                "KV_CACHE": "BFP8"
+            }
+        },
+        "51": {
+            "precision_cfg": {
+                "KV_CACHE": "BFP8"
+            }
+        },
+        "52": {
+            "precision_cfg": {
+                "KV_CACHE": "BFP8"
+            }
+        },
+        "53": {
+            "precision_cfg": {
+                "KV_CACHE": "BFP8"
+            }
+        },
+        "54": {
+            "precision_cfg": {
+                "KV_CACHE": "BFP8"
+            }
+        },
+        "55": {
+            "precision_cfg": {
+                "KV_CACHE": "BFP8"
+            }
+        },
+        "56": {
+            "precision_cfg": {
+                "KV_CACHE": "BFP8"
+            }
+        },
+        "57": {
+            "precision_cfg": {
+                "KV_CACHE": "BFP8"
+            }
+        },
+        "58": {
+            "precision_cfg": {
+                "KV_CACHE": "BFP8"
+            }
+        },
+        "59": {
+            "precision_cfg": {
+                "KV_CACHE": "BFP8"
+            }
+        },
+        "60": {
+            "precision_cfg": {
+                "KV_CACHE": "BFP8"
+            }
+        },
+        "61": {
+            "precision_cfg": {
+                "KV_CACHE": "BFP8"
+            }
         }
     }
 }


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes