### PR TITLE
Unremove `model_location_generator` flag in simple text demo TTT

### DIFF
--- a/models/tt_transformers/demo/simple_text_demo.py
+++ b/models/tt_transformers/demo/simple_text_demo.py
@@ -739,6 +739,7 @@ def test_demo_text(
     token_accuracy,
     stress_test,
     enable_trace,
+    model_location_generator,
     num_layers,
     mode,
 ):


### PR DESCRIPTION
### Problem description
Accidental removal of this flag causing CIv2 failures https://github.com/tenstorrent/tt-metal/actions/runs/19212411517

### What's changed
Add back the flag

### Checklist
- [ ] [Single Card Demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/19232816225)