### PR TITLE
conditional page table set

### DIFF
--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -579,7 +579,8 @@ class Generator:
         ):
             # If the page table has changed, it means that the inputs have shuffled, so we need to copy them from host again
             reset_inputs = True
-            self.prev_page_table = tuple(pt.clone() for pt in page_table)
+            if page_table is not None:
+                self.prev_page_table = tuple(pt.clone() for pt in page_table)
 
         if reset_inputs:
             for i in range(self.data_parallel):


### PR DESCRIPTION
### Problem description
CI failing with changes to generator when not using page attention https://github.com/tenstorrent/tt-metal/actions/runs/19216817181/job/54927804521#step:6:4951

### What's changed
Set the member `self.prev_page_table` only when page table is not `None`.

### Checklist
APC: https://github.com/tenstorrent/tt-metal/actions/runs/19233422100
T3K demo: https://github.com/tenstorrent/tt-metal/actions/runs/19233435614