### PR TITLE
Matmul - Relax DRAM Requirement for Tall/Wide Tensors

### DIFF
--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
@@ -39,9 +39,21 @@ constexpr std::array<std::tuple<uint32_t, uint32_t>, 20> SUBBLOCK_HW_CHOICES = {
 
 constexpr uint32_t NARROW_SHAPE_RATIO_THRESHOLD = 8;
 
-bool is_narrow_shape(uint32_t height, uint32_t width) {
+// This function helps determine if an optimised 1D MM config will provide perf benefits for a matmul
+bool is_narrow_shape(uint32_t height, uint32_t width, bool all_dram) {
     uint32_t height_width_ratio = (height > width) ? height / width : width / height;
-    return height_width_ratio > NARROW_SHAPE_RATIO_THRESHOLD || height <= ttnn::TILE_SIZE || width <= ttnn::TILE_SIZE;
+
+    // Check if tensor is actually narrow and will benefit from 1D config
+    if (height_width_ratio > NARROW_SHAPE_RATIO_THRESHOLD) {
+        return true;
+    }
+
+    // MMs that are entirely in DRAM but with a dimension smaller than the tile size will benefit from 1D config
+    if (all_dram) {
+        return height <= ttnn::TILE_SIZE || width <= ttnn::TILE_SIZE;
+    }
+
+    return false;
 }
 
 inline bool get_fp32_dest_acc_en(const std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config) {
@@ -521,14 +533,15 @@ inline MatmulProgramConfig create_simple_matmul_program_config(
                                  mem_config.memory_layout() == TensorMemoryLayout::INTERLEAVED &&
                                  input_tensor_b.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED;
 
-    const bool all_dram_interleaved = all_interleaved &&
-                                      input_tensor_a.memory_config().buffer_type() == BufferType::DRAM &&
-                                      input_tensor_b.memory_config().buffer_type() == BufferType::DRAM &&
-                                      mem_config.buffer_type() == BufferType::DRAM;
+    const bool all_dram = input_tensor_a.memory_config().buffer_type() == BufferType::DRAM &&
+                          input_tensor_b.memory_config().buffer_type() == BufferType::DRAM &&
+                          mem_config.buffer_type() == BufferType::DRAM;
+
+    const bool all_dram_interleaved = all_dram && all_interleaved;
 
     uint32_t height = ashape[-2];
     uint32_t width = bshape[-1];
-    bool is_narrow = is_narrow_shape(height, width);
+    const bool is_narrow = is_narrow_shape(height, width, all_dram);
     bool is_wide = false;
     bool is_tall = false;
     if (all_interleaved && is_narrow) {
@@ -752,7 +765,7 @@ MatmulProgramConfig create_matmul_program_config(
     auto height = batch_size_a * m_size;
     auto width = n_size;
     bool a_is_block_sharded = a_layout == TensorMemoryLayout::BLOCK_SHARDED;
-    if (is_narrow_shape(height, width) || any_size_within_tile) {
+    if (is_narrow_shape(height, width, false) || any_size_within_tile) {
         if (!a_is_block_sharded) {
             return create_matmul_1d_systolic_array_program_config(
                 input_tensor_a,

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
@@ -517,19 +517,21 @@ inline MatmulProgramConfig create_simple_matmul_program_config(
     uint32_t per_core_M, per_core_N, out_subblock_h, out_subblock_w;
     uint32_t num_blocks_x, num_blocks_y;
 
-    bool all_dram_interleaved = input_tensor_a.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED &&
-                                mem_config.memory_layout() == TensorMemoryLayout::INTERLEAVED &&
-                                input_tensor_b.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED &&
-                                input_tensor_a.memory_config().buffer_type() == BufferType::DRAM &&
-                                input_tensor_b.memory_config().buffer_type() == BufferType::DRAM &&
-                                mem_config.buffer_type() == BufferType::DRAM;
+    const bool all_interleaved = input_tensor_a.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED &&
+                                 mem_config.memory_layout() == TensorMemoryLayout::INTERLEAVED &&
+                                 input_tensor_b.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED;
+
+    const bool all_dram_interleaved = all_interleaved &&
+                                      input_tensor_a.memory_config().buffer_type() == BufferType::DRAM &&
+                                      input_tensor_b.memory_config().buffer_type() == BufferType::DRAM &&
+                                      mem_config.buffer_type() == BufferType::DRAM;
 
     uint32_t height = ashape[-2];
     uint32_t width = bshape[-1];
     bool is_narrow = is_narrow_shape(height, width);
     bool is_wide = false;
     bool is_tall = false;
-    if (is_narrow) {
+    if (all_interleaved && is_narrow) {
         is_wide = width > height;
         is_tall = !is_wide;
     }

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
@@ -529,7 +529,7 @@ inline MatmulProgramConfig create_simple_matmul_program_config(
     bool is_narrow = is_narrow_shape(height, width);
     bool is_wide = false;
     bool is_tall = false;
-    if (all_dram_interleaved && is_narrow) {
+    if (is_narrow) {
         is_wide = width > height;
         is_tall = !is_wide;
     }


### PR DESCRIPTION
### Ticket
#31743

### Problem description
Currently, matmul's program config auto-selection deploys the optimised mcast 1D configs when a DRAM matmul has narrow (i.e. wide or tall) tensors. It also enables them when one of the dimensions of interest fits within one tile. 

The restriction to only use it for DRAM matmuls results in narrow L1 matmuls not receiving the optimised program config, and therefore having unexpectedly poor performance.

### What's changed
Relaxed the DRAM requirement for narrow tensors. 

Matmuls that have a dimension within one tile must still be in DRAM, as this can degrade performance for L1 matmuls.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/19106590820) [rebase](https://github.com/tenstorrent/tt-metal/actions/runs/19238408122)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests [passes](https://github.com/tenstorrent/tt-metal/actions/runs/19238473001) 
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/19238438871)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/19180588598) 
- [ ] [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/19238506019)  matches [main](https://github.com/tenstorrent/tt-metal/actions/runs/19221288878/job/54940126873)
- [x] Galaxy model perf test [passes](https://github.com/tenstorrent/tt-metal/actions/runs/19170912840)

