### PR TITLE
Reorganize ttnn-post-commit workflow to run tests on merge-gate

### DIFF
--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -96,12 +96,12 @@ jobs:
         uses: tenstorrent/tt-metal/.github/actions/find-changed-files@v0.63.0
 
   build:
-    # if: ${{ github.ref_name == 'main' ||
-    #         needs.find-changes.outputs.cmake-changed == 'true' ||
-    #         needs.find-changes.outputs.any-code-changed == 'true' ||
-    #         needs.find-changes.outputs.docs-changed == 'true' ||
-    #         needs.find-changes.outputs.build-workflows-changed == 'true'
-    #     }}
+    if: ${{ github.ref_name == 'main' ||
+            needs.find-changes.outputs.cmake-changed == 'true' ||
+            needs.find-changes.outputs.any-code-changed == 'true' ||
+            needs.find-changes.outputs.docs-changed == 'true' ||
+            needs.find-changes.outputs.build-workflows-changed == 'true'
+        }}
     needs: find-changes
     uses: ./.github/workflows/build-artifact.yaml
     permissions:

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -96,12 +96,12 @@ jobs:
         uses: tenstorrent/tt-metal/.github/actions/find-changed-files@v0.63.0
 
   build:
-    if: ${{ github.ref_name == 'main' ||
-            needs.find-changes.outputs.cmake-changed == 'true' ||
-            needs.find-changes.outputs.any-code-changed == 'true' ||
-            needs.find-changes.outputs.docs-changed == 'true' ||
-            needs.find-changes.outputs.build-workflows-changed == 'true'
-        }}
+    # if: ${{ github.ref_name == 'main' ||
+    #         needs.find-changes.outputs.cmake-changed == 'true' ||
+    #         needs.find-changes.outputs.any-code-changed == 'true' ||
+    #         needs.find-changes.outputs.docs-changed == 'true' ||
+    #         needs.find-changes.outputs.build-workflows-changed == 'true'
+    #     }}
     needs: find-changes
     uses: ./.github/workflows/build-artifact.yaml
     permissions:

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -259,6 +259,24 @@ jobs:
       runner: ${{ matrix.platform }}
       product: tt-nn
 
+  ttnn-mgate-tests:
+    needs: [build, find-changes]
+    strategy:
+      fail-fast: false
+      matrix:
+        test-group: [
+          { arch: wormhole_b0, runner-label: N300 }
+        ]
+    uses: ./.github/workflows/ttnn-post-commit.yaml
+    secrets: inherit
+    with:
+      docker-image: ${{ needs.build.outputs.dev-docker-image }}
+      build-artifact-name: ${{ needs.build.outputs.build-artifact-name }}
+      wheel-artifact-name: ${{ needs.build.outputs.wheel-artifact-name }}
+      arch: ${{ matrix.test-group.arch }}
+      runner-label: ${{ matrix.test-group.runner-label }}
+      merge-gate-call: true
+
   ttsim-unit-tests:
     if: ${{ github.ref_name == 'main' ||
             needs.find-changes.outputs.any-code-changed == 'true'

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -259,7 +259,7 @@ jobs:
       runner: ${{ matrix.platform }}
       product: tt-nn
 
-  ttnn-mgate-tests:
+  ttnn-merge-gate-tests:
     needs: [build, find-changes]
     strategy:
       fail-fast: false

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -261,6 +261,12 @@ jobs:
 
   ttnn-merge-gate-tests:
     needs: [build, find-changes]
+    if: ${{ github.ref_name == 'main' ||
+            needs.find-changes.outputs.cmake-changed == 'true' ||
+            needs.find-changes.outputs.tt-metalium-changed == 'true' ||
+            needs.find-changes.outputs.tt-nn-changed == 'true' ||
+            needs.find-changes.outputs.tt-metalium-or-tt-nn-tests-changed == 'true'
+        }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ttnn-post-commit.yaml
+++ b/.github/workflows/ttnn-post-commit.yaml
@@ -107,7 +107,7 @@ jobs:
           echo $default_ttnn_tests
           echo $default_ttnn_tests | jq
           requested_ttnn_tests=$default_ttnn_tests
-          
+
           requested_ttnn_tests=$(jq --argjson merge_gate_call "${{ inputs.merge-gate-call }}" '[.[] | select(.merge_gate == $merge_gate_call)]' <<< "$requested_ttnn_tests")
           echo "[info] after filtering filtering out perf tests: $requested_ttnn_tests"
 

--- a/.github/workflows/ttnn-post-commit.yaml
+++ b/.github/workflows/ttnn-post-commit.yaml
@@ -85,7 +85,6 @@ jobs:
             { name: "ttnn data_movement/ccl group 1", cmd: 'pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/data_movement tests/ttnn/unit_tests/operations/ccl tests/ttnn/unit_tests/operations/point_to_point -xv --splits 3 --group 1 -m "not disable_fast_runtime_mode"', merge_gate: false },
             { name: "ttnn data_movement/ccl group 2", cmd: 'pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/data_movement tests/ttnn/unit_tests/operations/ccl tests/ttnn/unit_tests/operations/point_to_point -xv --splits 3 --group 2 -m "not disable_fast_runtime_mode"', merge_gate: false },
             { name: "ttnn data_movement/ccl group 3", cmd: 'pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/data_movement tests/ttnn/unit_tests/operations/ccl tests/ttnn/unit_tests/operations/point_to_point -xv --splits 3 --group 3 -m "not disable_fast_runtime_mode"', merge_gate: false },
-            { name: "ttnn data_movement/ccl group 1", cmd: 'pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/data_movement tests/ttnn/unit_tests/operations/ccl tests/ttnn/unit_tests/operations/point_to_point -xv --splits 3 --group 1 -m "not disable_fast_runtime_mode"', merge_gate: false },
             { name: "ttnn conv group", cmd: 'pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/conv -xv -m "not disable_fast_runtime_mode"', merge_gate: false },
             { name: "ttnn pool group", cmd: 'pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/pool -xv -m "not disable_fast_runtime_mode"', merge_gate: false },
             { name: "ttnn matmul group", cmd: 'pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/matmul -xv -m "not disable_fast_runtime_mode"', merge_gate: false },
@@ -109,7 +108,7 @@ jobs:
           requested_ttnn_tests=$default_ttnn_tests
 
           requested_ttnn_tests=$(jq --argjson merge_gate_call "${{ inputs.merge-gate-call }}" '[.[] | select(.merge_gate == $merge_gate_call)]' <<< "$requested_ttnn_tests")
-          echo "[info] after filtering filtering out perf tests: $requested_ttnn_tests"
+          echo "[info] after filtering for requested workflow tests: $requested_ttnn_tests"
 
           # Check that we have a valid test list that's not empty
           echo "$requested_ttnn_tests" | jq -e 'if type != "array" then error("Not a valid JSON array") elif length == 0 then error("Test list is empty") else . end' && echo "Valid test configs"

--- a/.github/workflows/ttnn-post-commit.yaml
+++ b/.github/workflows/ttnn-post-commit.yaml
@@ -26,6 +26,10 @@ on:
         required: false
         type: boolean
         default: false
+      merge-gate-call:
+        required: false
+        type: boolean
+        default: false
 
   workflow_dispatch:
     inputs:
@@ -55,59 +59,72 @@ on:
       wheel-artifact-name:
         required: true
         type: string
+      merge-gate-call:
+        required: false
+        type: boolean
+        default: false
 
 jobs:
+  define-ttnn-tests:
+    runs-on: ubuntu-latest
+    outputs:
+      ttnn-tests: ${{ steps.compute-tests.outputs.ttnn-tests }}
+    strategy:
+      matrix:
+        default-ttnn-tests:
+          [[
+            { name: "ttnn example tests", cmd: "./tests/scripts/run_ttnn_examples.sh", merge_gate: true },
+            { name: "ttnn eltwise group 1", cmd: 'pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/eltwise -xv --splits 8 --group 1 -m "not disable_fast_runtime_mode"', merge_gate: false },
+            { name: "ttnn eltwise group 2", cmd: 'pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/eltwise -xv --splits 8 --group 2 -m "not disable_fast_runtime_mode"', merge_gate: false },
+            { name: "ttnn eltwise group 3", cmd: 'pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/eltwise -xv --splits 8 --group 3 -m "not disable_fast_runtime_mode"', merge_gate: false },
+            { name: "ttnn eltwise group 4", cmd: 'pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/eltwise -xv --splits 8 --group 4 -m "not disable_fast_runtime_mode"', merge_gate: false },
+            { name: "ttnn eltwise group 5", cmd: 'pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/eltwise -xv --splits 8 --group 5 -m "not disable_fast_runtime_mode"', merge_gate: false },
+            { name: "ttnn eltwise group 6", cmd: 'pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/eltwise -xv --splits 8 --group 6 -m "not disable_fast_runtime_mode"', merge_gate: false },
+            { name: "ttnn eltwise group 7", cmd: 'pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/eltwise -xv --splits 8 --group 7 -m "not disable_fast_runtime_mode"', merge_gate: false },
+            { name: "ttnn eltwise group 8", cmd: 'pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/eltwise -xv --splits 8 --group 8 -m "not disable_fast_runtime_mode"', merge_gate: false },
+            { name: "ttnn data_movement/ccl group 1", cmd: 'pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/data_movement tests/ttnn/unit_tests/operations/ccl tests/ttnn/unit_tests/operations/point_to_point -xv --splits 3 --group 1 -m "not disable_fast_runtime_mode"', merge_gate: false },
+            { name: "ttnn data_movement/ccl group 2", cmd: 'pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/data_movement tests/ttnn/unit_tests/operations/ccl tests/ttnn/unit_tests/operations/point_to_point -xv --splits 3 --group 2 -m "not disable_fast_runtime_mode"', merge_gate: false },
+            { name: "ttnn data_movement/ccl group 3", cmd: 'pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/data_movement tests/ttnn/unit_tests/operations/ccl tests/ttnn/unit_tests/operations/point_to_point -xv --splits 3 --group 3 -m "not disable_fast_runtime_mode"', merge_gate: false },
+            { name: "ttnn data_movement/ccl group 1", cmd: 'pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/data_movement tests/ttnn/unit_tests/operations/ccl tests/ttnn/unit_tests/operations/point_to_point -xv --splits 3 --group 1 -m "not disable_fast_runtime_mode"', merge_gate: false },
+            { name: "ttnn conv group", cmd: 'pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/conv -xv -m "not disable_fast_runtime_mode"', merge_gate: false },
+            { name: "ttnn pool group", cmd: 'pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/pool -xv -m "not disable_fast_runtime_mode"', merge_gate: false },
+            { name: "ttnn matmul group", cmd: 'pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/matmul -xv -m "not disable_fast_runtime_mode"', merge_gate: false },
+            { name: "ttnn fused group", cmd: 'pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/fused -xv -m "not disable_fast_runtime_mode"', merge_gate: false },
+            { name: "ttnn transformers group", cmd: 'pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/transformers -xv -m "not disable_fast_runtime_mode"', merge_gate: false },
+            { name: "ttnn reduce and misc ops group", cmd: 'pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/reduce tests/ttnn/unit_tests/operations/rand tests/ttnn/unit_tests/operations/debug tests/ttnn/unit_tests/operations/ssm -xv -m "not disable_fast_runtime_mode"', merge_gate: false },
+            { name: "core ttnn unit test group", cmd: 'pytest -n auto --timeout 300 tests/ttnn/unit_tests/base_functionality tests/ttnn/unit_tests/benchmarks tests/ttnn/unit_tests/light_metal tests/ttnn/unit_tests/tensor -xv -m "not disable_fast_runtime_mode"', merge_gate: false },
+            { name: "ttnn notebook", cmd: 'TT_METAL_ENABLE_ERISC_IRAM=1 pytest -n auto --timeout 300 tests/ttnn/notebook_tests -xv -m "not disable_fast_runtime_mode"', merge_gate: false },
+            # { name: "ttnn fast runtime off", cmd: 'pytest -n auto --timeout 300 tests/ttnn/unit_tests -xv -m requires_fast_runtime_mode_off', merge_gate: false, fast_runtime_mode_off: true },
+          ]]
+    steps:
+      - name: Compute tests
+        shell: bash
+        id: compute-tests
+        run: |
+          set -euo pipefail
+          echo "[info] Outputing default values"
+          default_ttnn_tests='${{ toJSON(matrix.default-ttnn-tests) }}'
+          echo $default_ttnn_tests
+          echo $default_ttnn_tests | jq
+          requested_ttnn_tests=$default_ttnn_tests
+          
+          requested_ttnn_tests=$(jq --argjson merge_gate_call "${{ inputs.merge-gate-call }}" '[.[] | select(.merge_gate == $merge_gate_call)]' <<< "$requested_ttnn_tests")
+          echo "[info] after filtering filtering out perf tests: $requested_ttnn_tests"
+
+          # Check that we have a valid test list that's not empty
+          echo "$requested_ttnn_tests" | jq -e 'if type != "array" then error("Not a valid JSON array") elif length == 0 then error("Test list is empty") else . end' && echo "Valid test configs"
+          echo "ttnn-tests=$(echo $requested_ttnn_tests | tr -d '\n')" >> "$GITHUB_OUTPUT"
+          echo "[info] Showing GITHUB_OUTPUT"
+          cat "$GITHUB_OUTPUT"
   ttnn:
+    needs: define-ttnn-tests
     strategy:
       # Do not fail-fast because we need to ensure all tests go to completion
       # so we try not to get hanging machines
       fail-fast: false
       matrix:
         os: ["ubuntu-22.04"]
-        test-group:
-          - name: ttnn eltwise group 1
-            cmd: pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/eltwise -xv --splits 8 --group 1 -m "not disable_fast_runtime_mode"
-          - name: ttnn eltwise group 2
-            cmd: pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/eltwise -xv --splits 8 --group 2 -m "not disable_fast_runtime_mode"
-          - name: ttnn eltwise group 3
-            cmd: pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/eltwise -xv --splits 8 --group 3 -m "not disable_fast_runtime_mode"
-          - name: ttnn eltwise group 4
-            cmd: pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/eltwise -xv --splits 8 --group 4 -m "not disable_fast_runtime_mode"
-          - name: ttnn eltwise group 5
-            cmd: pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/eltwise -xv --splits 8 --group 5 -m "not disable_fast_runtime_mode"
-          - name: ttnn eltwise group 6
-            cmd: pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/eltwise -xv --splits 8 --group 6 -m "not disable_fast_runtime_mode"
-          - name: ttnn eltwise group 7
-            cmd: pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/eltwise -xv --splits 8 --group 7 -m "not disable_fast_runtime_mode"
-          - name: ttnn eltwise group 8
-            cmd: pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/eltwise -xv --splits 8 --group 8 -m "not disable_fast_runtime_mode"
-          - name: ttnn data_movement/ccl group 1
-            cmd: pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/data_movement tests/ttnn/unit_tests/operations/ccl tests/ttnn/unit_tests/operations/point_to_point -xv --splits 3 --group 1 -m "not disable_fast_runtime_mode"
-          - name: ttnn data_movement/ccl group 2
-            cmd: pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/data_movement tests/ttnn/unit_tests/operations/ccl tests/ttnn/unit_tests/operations/point_to_point -xv --splits 3 --group 2 -m "not disable_fast_runtime_mode"
-          - name: ttnn data_movement/ccl group 3
-            cmd: pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/data_movement tests/ttnn/unit_tests/operations/ccl tests/ttnn/unit_tests/operations/point_to_point -xv --splits 3 --group 3 -m "not disable_fast_runtime_mode"
-          - name: ttnn conv group
-            cmd: pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/conv -xv -m "not disable_fast_runtime_mode"
-          - name: ttnn pool group
-            cmd: pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/pool -xv -m "not disable_fast_runtime_mode"
-          - name: ttnn matmul group
-            cmd: pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/matmul -xv -m "not disable_fast_runtime_mode"
-          - name: ttnn fused group
-            cmd: pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/fused -xv -m "not disable_fast_runtime_mode"
-          - name: ttnn transformers group
-            cmd: pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/transformers -xv -m "not disable_fast_runtime_mode"
-          - name: ttnn reduce and misc ops group
-            cmd: pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/reduce tests/ttnn/unit_tests/operations/rand tests/ttnn/unit_tests/operations/debug tests/ttnn/unit_tests/operations/ssm -xv -m "not disable_fast_runtime_mode"
-          - name: core ttnn unit test group
-            cmd: pytest -n auto --timeout 300 tests/ttnn/unit_tests/base_functionality tests/ttnn/unit_tests/benchmarks tests/ttnn/unit_tests/light_metal tests/ttnn/unit_tests/tensor -xv -m "not disable_fast_runtime_mode"
-          - name: ttnn notebook
-            cmd: TT_METAL_ENABLE_ERISC_IRAM=1 pytest -n auto --timeout 300 tests/ttnn/notebook_tests -xv -m "not disable_fast_runtime_mode"
-          # - name: ttnn fast runtime off
-          #   cmd: pytest -n auto --timeout 300 tests/ttnn/unit_tests -xv -m requires_fast_runtime_mode_off
-          #   fast_runtime_mode_off: true
-          - name: ttnn example tests
-            cmd: ./tests/scripts/run_ttnn_examples.sh
+        test-group: ${{ fromJSON(needs.define-ttnn-tests.outputs.ttnn-tests) }}
     name: ${{ matrix.test-group.name }} ${{ inputs.arch }} ${{ inputs.runner-label }}
     runs-on: >-
       ${{


### PR DESCRIPTION
### What's changed
- Reorganize ttnn-post-commit workflow to run tests on merge-gate
- Run ttnn-example-tests on merge-gate

### Checklist
- [x] All post commit CI runs as expected: https://github.com/tenstorrent/tt-metal/actions/runs/19240774293
- [x] Merge-gate CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/19240737177