### PR TITLE
Added to_device as lazy and made to_cpu to evaluate the tree

### DIFF
--- a/ttnn/core/tensor/tensor.cpp
+++ b/ttnn/core/tensor/tensor.cpp
@@ -141,6 +141,11 @@ Tensor Tensor::pad(
 }
 
 Tensor Tensor::cpu(bool blocking, std::optional<ttnn::QueueId> cq_id) const {
+    // To cpu will always materialize the tensors, always.
+    if (!lazy()->is_materialized()) {
+        ttnn::experimental::lazy::evaluate(lazy());
+    }
+
     return Tensor(get_materialized_tensor().cpu(blocking, cq_id));
 }
 
@@ -257,6 +262,10 @@ uint32_t Tensor::element_size() const { return tensor_impl::element_size_bytes(t
 
 // ttnn Tensor-only methods / constructors
 tt::tt_metal::metal_tensor::Tensor& Tensor::get_materialized_tensor() {
+    if (!lazy_tensor_->is_materialized()) {
+        printf("lazy_tensor_->is_materialized(): %d\n", lazy_tensor_->is_materialized());
+    }
+
     TT_FATAL(lazy_tensor_->is_materialized(), "Tensor is not materialized");
     return lazy_tensor_->materialized_tensor();
 }

--- a/ttnn/core/tensor/tensor_impl.cpp
+++ b/ttnn/core/tensor/tensor_impl.cpp
@@ -689,8 +689,9 @@ Tensor to_device(
     TT_FATAL(mesh_device != nullptr, "Need target device in order to move tensor to device!");
 
     std::optional<TensorSpec> tensor_spec_overriden_memory_config;
-    if (memory_config) {
-        tensor_spec_overriden_memory_config = tensor.tensor_spec().with_memory_config(*memory_config);
+    if (memory_config.has_value()) {
+        auto memory_config_value = memory_config.value();
+        tensor_spec_overriden_memory_config = tensor.tensor_spec().with_memory_config(memory_config_value);
     }
 
     const auto* tensor_spec = tensor_spec_overriden_memory_config.has_value()

--- a/ttnn/core/tensor/tensor_spec.cpp
+++ b/ttnn/core/tensor/tensor_spec.cpp
@@ -4,7 +4,6 @@
 
 #include "ttnn/tensor/tensor_spec.hpp"
 #include "ttnn/tensor/types.hpp"
-
 namespace tt::tt_metal {
 
 namespace {

--- a/ttnn/cpp/ttnn/operations/core/core.cpp
+++ b/ttnn/cpp/ttnn/operations/core/core.cpp
@@ -50,7 +50,7 @@ ttnn::Tensor to_device(
     std::optional<QueueId> queue_id) {
     auto mem_config = memory_config.value_or(ttnn::DRAM_MEMORY_CONFIG);
 
-    auto to_device_operation = std::make_shared<ToDeviceOperation>(mesh_device, mem_config, queue_id);
+    auto to_device_operation = std::make_shared<ToDeviceOperation>(mesh_device, std::move(mem_config), queue_id);
     auto lazy_inputs = ttnn::experimental::lazy::make_lazy_device_operation_inputs<ToDeviceOperation>(tensor);
     return tt::tt_metal::Tensor::make_lazy_tensor(lazy_inputs, to_device_operation, tensor.tensor_spec());
 }


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/32168)

### Problem description
to_device should be a lazy operation, since the tree might need or not to evaluate all its previous operations, depending on how we are using it. On the other hand, to cpu should evaluate all the dependencies

### What's changed
Added an operation to make to_device lazy and added some logic to evaluate the tree on to_cpu

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes