### PR TITLE
fix transpose bug

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_transpose.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_transpose.py
@@ -1347,9 +1347,7 @@ def test_transpose_hc_mem_config(device, n, c, h, w):
     sharded_mem_config = ttnn.MemoryConfig(
         ttnn.types.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.types.BufferType.L1, shard_spec
     )
-    print("input memory config:", tt_input_tensor.memory_config())
     tt_output_tensor = ttnn.transpose(tt_input_tensor, 1, 2, memory_config=sharded_mem_config)
-    print("output memory config:", tt_output_tensor.memory_config())
     tt_output_tensor = ttnn.to_memory_config(tt_output_tensor, ttnn.L1_MEMORY_CONFIG)
     tt_output_tensor = ttnn.from_device(tt_output_tensor)
     tt_output_tensor = ttnn.to_torch(tt_output_tensor)

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_transpose.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_transpose.py
@@ -1324,3 +1324,34 @@ def test_transpose_29126(device):
     ttnn_output = ttnn.to_torch(ttnn_output.cpu())
 
     assert_with_pcc(torch_output, ttnn_output, 0.9999)
+
+
+@pytest.mark.parametrize("n", [16])
+@pytest.mark.parametrize("c", [128])
+@pytest.mark.parametrize("h", [256])
+@pytest.mark.parametrize("w", [16])
+def test_transpose_hc_mem_config(device, n, c, h, w):
+    torch.manual_seed(2005)
+    torch_input_tensor = torch.rand((n, c, h, w), dtype=torch.bfloat16)
+    torch_output_tensor = torch_input_tensor.transpose(1, 2)
+    tt_input_tensor = ttnn.from_torch(
+        torch_input_tensor,
+        dtype=ttnn.DataType.BFLOAT16,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=device,
+        memory_config=ttnn.L1_MEMORY_CONFIG,
+    )
+    # shard config
+    shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 7))})
+    shard_spec = ttnn.ShardSpec(shard_grid, (8192, 16), ttnn.ShardOrientation.ROW_MAJOR)
+    sharded_mem_config = ttnn.MemoryConfig(
+        ttnn.types.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.types.BufferType.L1, shard_spec
+    )
+    print("input memory config:", tt_input_tensor.memory_config())
+    tt_output_tensor = ttnn.transpose(tt_input_tensor, 1, 2, memory_config=sharded_mem_config)
+    print("output memory config:", tt_output_tensor.memory_config())
+    tt_output_tensor = ttnn.to_memory_config(tt_output_tensor, ttnn.L1_MEMORY_CONFIG)
+    tt_output_tensor = ttnn.from_device(tt_output_tensor)
+    tt_output_tensor = ttnn.to_torch(tt_output_tensor)
+
+    assert_with_pcc(torch_output_tensor, tt_output_tensor, 0.9999)

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/writer_permute_interleaved_rm_row_invariant.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/writer_permute_interleaved_rm_row_invariant.cpp
@@ -51,7 +51,7 @@ void kernel_main() {
         }
         cb_wait_front(tt::CBIndex::c_0, 1);
         uint32_t l1_read_addr = get_read_ptr(tt::CBIndex::c_0);
-        uint64_t dst_noc_addr = get_noc_addr(dest_linear_idx, s0);
+        uint64_t dst_noc_addr = s0.get_noc_addr(dest_linear_idx);
         noc_async_write(l1_read_addr, dst_noc_addr, page_size);
         noc_async_write_barrier();
         cb_pop_front(tt::CBIndex::c_0, 1);

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/permute.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/permute.cpp
@@ -54,7 +54,11 @@ ttnn::Tensor permute_impl(
     };
 
     auto transpose_hc = [&](const ttnn::Tensor& input) -> ttnn::Tensor {
-        return ttnn::transpose(input, 1, -2, output_mem_config, pad_value);
+        auto mem_config = output_mem_config;
+        if (input.memory_config().is_sharded() && output_mem_config.is_sharded()) {
+            mem_config = input.memory_config();
+        }
+        return ttnn::transpose(input, 1, -2, mem_config, pad_value);
     };
 
     auto transpose_cn = [&](const ttnn::Tensor& input) -> ttnn::Tensor {

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/permute.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/permute.cpp
@@ -54,6 +54,8 @@ ttnn::Tensor permute_impl(
     };
 
     auto transpose_hc = [&](const ttnn::Tensor& input) -> ttnn::Tensor {
+        // some permute tests assume transpose hc uses the input shard spec
+        // avoid the intermediate memory configuration mismatch
         auto mem_config = output_mem_config;
         if (input.memory_config().is_sharded() && output_mem_config.is_sharded()) {
             mem_config = input.memory_config();

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/transpose.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/transpose.cpp
@@ -10,6 +10,8 @@
 #include "ttnn/operations/data_movement/permute/device/permute_device_operation.hpp"
 #include "ttnn/operations/data_movement/transpose/transpose.hpp"
 #include "ttnn/operations/copy/typecast/typecast.hpp"
+#include "ttnn/operations/data_movement/common/common.hpp"
+#include "ttnn/operations/experimental/auto_format/auto_format.hpp"
 
 #include <tt-metalium/hal.hpp>
 
@@ -79,7 +81,82 @@ ttnn::Tensor transpose_nd(
 
 }  // namespace detail
 
-ttnn::Tensor ExecuteTranspose::invoke(
+using OwnedTransposeArgs =
+    std::tuple<ttnn::Tensor, int64_t, int64_t, std::optional<MemoryConfig>, std::optional<float>>;
+using BaseTransposeType = std::function<ttnn::Tensor(
+    const ttnn::Tensor&, int64_t, int64_t, const std::optional<MemoryConfig>&, const std::optional<float>&)>;
+
+using MassagedTranspose = MassagedOperation<
+    ttnn::Tensor,
+    const ttnn::Tensor&,
+    int64_t,
+    int64_t,
+    const std::optional<MemoryConfig>&,
+    const std::optional<float>&>;
+using MassagedTransposeParams = MassagedOperationParams<
+    ttnn::Tensor,
+    const ttnn::Tensor&,
+    int64_t,
+    int64_t,
+    const std::optional<MemoryConfig>&,
+    const std::optional<float>&>;
+
+bool shard_not_supported(const ttnn::Tensor& input_tensor, int64_t dim1, int64_t dim2) {
+    const auto& input_shape = input_tensor.logical_shape();
+    uint32_t normalized_dim1 = input_shape.get_normalized_index(dim1);
+    uint32_t normalized_dim2 = input_shape.get_normalized_index(dim2);
+
+    uint32_t initial_rank = input_shape.rank();
+    if (initial_rank < 4) {
+        uint32_t rank_diff = 4 - initial_rank;
+        normalized_dim1 += rank_diff;
+        normalized_dim2 += rank_diff;
+    }
+
+    if (normalized_dim1 > normalized_dim2) {
+        std::swap(normalized_dim1, normalized_dim2);
+    }
+
+    // diff output shard spec is not supported for HC transpose
+    bool not_supported = normalized_dim2 == 2 && normalized_dim1 == 1;
+    return not_supported;
+}
+
+MassagedTranspose build_memory_config_transpose(BaseTransposeType base_transpose) {
+    auto target_memory_config = std::make_shared<std::optional<MemoryConfig>>();
+    return MassagedTranspose(MassagedTransposeParams{
+        .predicate = [target_memory_config](
+                         const ttnn::Tensor& input_tensor,
+                         int64_t dim1,
+                         int64_t dim2,
+                         const std::optional<MemoryConfig>& memory_config,
+                         const std::optional<float>& pad_value) -> bool {
+            *target_memory_config = memory_config;
+            if (!memory_config.has_value()) {
+                return false;
+            }
+            auto output_mem_config_sharded = memory_config.value().is_sharded();
+            bool massage_op = input_tensor.memory_config() != memory_config.value() && output_mem_config_sharded;
+            massage_op = massage_op && shard_not_supported(input_tensor, dim1, dim2);
+            return massage_op;
+        },
+        .pre_transform = [](const ttnn::Tensor& input_tensor,
+                            int64_t dim1,
+                            int64_t dim2,
+                            const std::optional<MemoryConfig>& memory_config,
+                            const std::optional<float>& pad_value) -> OwnedTransposeArgs {
+            return std::make_tuple(input_tensor, dim1, dim2, input_tensor.memory_config(), pad_value);
+        },
+        .post_transform = [target_memory_config](const ttnn::Tensor& output) -> ttnn::Tensor {
+            if (target_memory_config->has_value() && output.memory_config() != target_memory_config->value()) {
+                return ttnn::to_memory_config(output, target_memory_config->value());
+            }
+            return output;
+        },
+        .operation = std::move(base_transpose)});
+}
+
+ttnn::Tensor transpose_impl(
     const ttnn::Tensor& input_tensor,
     const int64_t& dim1,
     const int64_t& dim2,
@@ -143,6 +220,23 @@ ttnn::Tensor ExecuteTranspose::invoke(
     }
     output = initial_rank < 4u ? ttnn::squeeze_from_4D(output, initial_rank) : output;
     return typecast ? ttnn::typecast(output, DataType::BFLOAT8_B) : output;
+}
+
+ttnn::Tensor ExecuteTranspose::invoke(
+    const ttnn::Tensor& input_tensor,
+    const int64_t& dim1,
+    const int64_t& dim2,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<float>& pad_value) {
+    auto base_transpose = [](const ttnn::Tensor& input_tensor,
+                             int64_t dim1,
+                             int64_t dim2,
+                             const std::optional<MemoryConfig>& memory_config,
+                             const std::optional<float>& pad_value) {
+        return transpose_impl(input_tensor, dim1, dim2, memory_config, pad_value);
+    };
+
+    return build_memory_config_transpose(base_transpose)(input_tensor, dim1, dim2, memory_config, pad_value);
 }
 
 ttnn::Tensor ExecuteTranspose::invoke(


### PR DESCRIPTION
### Ticket
Link to Github Issue https://github.com/tenstorrent/tt-metal/issues/20504

### Problem description
Transpose op keeps the input sharded configuration in transpose::HC case even when output memory configuration is being passed by the user


### What's changed
Massage the op to change the configuration to the output memory configuration if needed

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/19240886655
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes