### PR TITLE
#31971: [skip ci] Reduce amount of run time for BH GLX upstream

### DIFF
--- a/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
+++ b/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
@@ -237,12 +237,22 @@ test_suite_bh_glx_metal_unit_tests() {
 
     # Dispatch
     build/test/tt_metal/unit_tests_eth --gtest_filter=UnitMeshCQMultiDeviceProgramFixture.ActiveEthKernelsSendInterleavedBufferAllConnectedChips
-    build/test/tt_metal/unit_tests_dispatch --gtest_filter=**RandomProgram**
-    build/test/tt_metal/unit_tests_dispatch --gtest_filter=UnitMeshCQSingleCardBufferFixture.ShardedBufferLargeL1ReadWrites
-    build/test/tt_metal/unit_tests_dispatch --gtest_filter=UnitMeshCQSingleCardBufferFixture.ShardedBufferLargeDRAMReadWrites
-    build/test/tt_metal/unit_tests_dispatch --gtest_filter=UnitMeshCQSingleCardFixture.TensixTestSubDeviceAllocations
-    build/test/tt_metal/unit_tests_dispatch --gtest_filter=UnitMeshMultiCQMultiDeviceEventFixture.*
-    build/test/tt_metal/unit_tests_device --gtest_filter=UnitMeshCQSingleCardFixture.TensixTestReadWriteMultipleCoresL1
+
+    build/test/tt_metal/unit_tests_dispatch --gtest_filter="\
+        UnitMeshCQProgramFixture.TensixTestRandomizedProgram:\
+        UnitMeshRandomProgramFixture.TensixActiveEthTestPrograms:\
+        UnitMeshRandomProgramFixture.TensixTestLargeProgramInBetweenFiveSmallPrograms:\
+        UnitMeshRandomProgramTraceFixture.TensixActiveEthTestProgramsTraceAndNoTrace:\
+        UnitMeshRandomProgramTraceFixture.TensixActiveEthTestProgramsTrace:\
+        UnitMeshRandomProgramTraceFixture.TensixTestLargeProgramInBetweenFiveSmallProgramsTrace:\
+        UnitMeshRandomProgramTraceFixture.TensixTestSimpleProgramsTrace:\
+        UnitMeshCQTraceFixture.TensixEnqueueMultiProgramTraceBenchmark:\
+        UnitMeshCQTraceFixture.TensixEnqueueTwoProgramTrace:\
+        UnitMeshCQSingleCardBufferFixture.ShardedBufferLargeL1ReadWrites:\
+        UnitMeshCQSingleCardBufferFixture.ShardedBufferLargeDRAMReadWrites:\
+        UnitMeshCQSingleCardFixture.TensixTestSubDeviceAllocations:\
+        UnitMeshMultiCQMultiDeviceEventFixture.*:\
+        UnitMeshCQSingleCardFixture.TensixTestReadWriteMultipleCoresL1"
 }
 
 test_suite_bh_glx_python_unit_tests() {

--- a/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
+++ b/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
@@ -239,20 +239,20 @@ test_suite_bh_glx_metal_unit_tests() {
     build/test/tt_metal/unit_tests_eth --gtest_filter=UnitMeshCQMultiDeviceProgramFixture.ActiveEthKernelsSendInterleavedBufferAllConnectedChips
 
     build/test/tt_metal/unit_tests_dispatch --gtest_filter="\
-        UnitMeshCQProgramFixture.TensixTestRandomizedProgram:\
-        UnitMeshRandomProgramFixture.TensixActiveEthTestPrograms:\
-        UnitMeshRandomProgramFixture.TensixTestLargeProgramInBetweenFiveSmallPrograms:\
-        UnitMeshRandomProgramTraceFixture.TensixActiveEthTestProgramsTraceAndNoTrace:\
-        UnitMeshRandomProgramTraceFixture.TensixActiveEthTestProgramsTrace:\
-        UnitMeshRandomProgramTraceFixture.TensixTestLargeProgramInBetweenFiveSmallProgramsTrace:\
-        UnitMeshRandomProgramTraceFixture.TensixTestSimpleProgramsTrace:\
-        UnitMeshCQTraceFixture.TensixEnqueueMultiProgramTraceBenchmark:\
-        UnitMeshCQTraceFixture.TensixEnqueueTwoProgramTrace:\
-        UnitMeshCQSingleCardBufferFixture.ShardedBufferLargeL1ReadWrites:\
-        UnitMeshCQSingleCardBufferFixture.ShardedBufferLargeDRAMReadWrites:\
-        UnitMeshCQSingleCardFixture.TensixTestSubDeviceAllocations:\
-        UnitMeshMultiCQMultiDeviceEventFixture.*:\
-        UnitMeshCQSingleCardFixture.TensixTestReadWriteMultipleCoresL1"
+UnitMeshCQProgramFixture.TensixTestRandomizedProgram:\
+UnitMeshRandomProgramFixture.TensixActiveEthTestPrograms:\
+UnitMeshRandomProgramFixture.TensixTestLargeProgramInBetweenFiveSmallPrograms:\
+UnitMeshRandomProgramTraceFixture.TensixActiveEthTestProgramsTraceAndNoTrace:\
+UnitMeshRandomProgramTraceFixture.TensixActiveEthTestProgramsTrace:\
+UnitMeshRandomProgramTraceFixture.TensixTestLargeProgramInBetweenFiveSmallProgramsTrace:\
+UnitMeshRandomProgramTraceFixture.TensixTestSimpleProgramsTrace:\
+UnitMeshCQTraceFixture.TensixEnqueueMultiProgramTraceBenchmark:\
+UnitMeshCQTraceFixture.TensixEnqueueTwoProgramTrace:\
+UnitMeshCQSingleCardBufferFixture.ShardedBufferLargeL1ReadWrites:\
+UnitMeshCQSingleCardBufferFixture.ShardedBufferLargeDRAMReadWrites:\
+UnitMeshCQSingleCardFixture.TensixTestSubDeviceAllocations:\
+UnitMeshMultiCQMultiDeviceEventFixture.*:\
+UnitMeshCQSingleCardFixture.TensixTestReadWriteMultipleCoresL1"
 }
 
 test_suite_bh_glx_python_unit_tests() {

--- a/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
+++ b/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
@@ -267,7 +267,6 @@ test_suite_bh_glx_llama_demo_tests() {
     verify_llama_dir_
 
     pytest models/tt_transformers/demo/simple_text_demo.py -k "performance and ci-32" --data_parallel 32
-    pytest models/tt_transformers/demo/simple_text_demo.py -k "performance-ci-stress-1" --data_parallel 32 --max_generated_tokens 220
 }
 
 # Define test suite mappings for different hardware topologies


### PR DESCRIPTION
### Ticket
[#31971](https://github.com/tenstorrent/tt-metal/issues/31971)

### What's changed
Update list of dispatch tests for BH galaxy upstream (identified by @nhuang-tt in https://tenstorrent.slack.com/archives/C09ETM7SLAE/p1762458726093879?thread_ts=1762383592.137649&cid=C09ETM7SLAE)
Remove llama8b stress test (identified by @alingTT as redundant test coverage)

### Checklist
- [x] Upstream tests https://github.com/tenstorrent/tt-metal/actions/runs/19302433189