### PR TITLE
Flatten Kernel class

### DIFF
--- a/tests/tt_metal/tt_metal/api/test_kernel_compile_cache.cpp
+++ b/tests/tt_metal/tt_metal/api/test_kernel_compile_cache.cpp
@@ -25,7 +25,7 @@
 #include <tt-metalium/persistent_kernel_cache.hpp>
 #include <tt-metalium/program.hpp>
 #include <tt-metalium/tt_metal.hpp>
-#include "impl/kernels/kernel_impl.hpp"
+#include "impl/kernels/kernel.hpp"
 // Access to internal API: ProgramImpl::get_kernels
 #include "impl/program/program_impl.hpp"
 

--- a/tests/tt_metal/tt_metal/api/test_kernel_compile_cache.cpp
+++ b/tests/tt_metal/tt_metal/api/test_kernel_compile_cache.cpp
@@ -55,7 +55,7 @@ TEST_F(MeshDeviceFixture, TensixTestIncompleteKernelBinaryWithPersistentCache) {
             device->build_id(), tensix_core_type, dm_class_idx, riscv_id);
 
         const auto& kernels = program.impl().get_kernels(static_cast<uint32_t>(HalProgrammableCoreType::TENSIX));
-        const std::string full_kernel_name = KernelImpl::from(*kernels.at(kernel_handle)).get_full_kernel_name();
+        const std::string full_kernel_name = kernels.at(kernel_handle)->get_full_kernel_name();
 
         const std::string successful_marker_path =
             build_state.get_out_path() + full_kernel_name + SUCCESSFUL_JIT_BUILD_MARKER_FILE_NAME;
@@ -113,10 +113,8 @@ TEST_F(MeshDeviceFixture, TensixTestEquivalentDataMovementKernelsWithDifferentPr
             device->build_id(), tensix_core_type, dm_class_idx, riscv_1_id);
 
         const auto& kernels = program.impl().get_kernels(static_cast<uint32_t>(HalProgrammableCoreType::TENSIX));
-        const std::string full_kernel_name_riscv_0 =
-            KernelImpl::from(*kernels.at(kernel_handle_riscv_0)).get_full_kernel_name();
-        const std::string full_kernel_name_riscv_1 =
-            KernelImpl::from(*kernels.at(kernel_handle_riscv_1)).get_full_kernel_name();
+        const std::string full_kernel_name_riscv_0 = kernels.at(kernel_handle_riscv_0)->get_full_kernel_name();
+        const std::string full_kernel_name_riscv_1 = kernels.at(kernel_handle_riscv_1)->get_full_kernel_name();
 
         const std::string elf_file_path_riscv_0 = build_state_riscv_0.get_target_out_path(full_kernel_name_riscv_0);
         const std::string elf_file_path_riscv_1 = build_state_riscv_1.get_target_out_path(full_kernel_name_riscv_1);

--- a/tests/tt_metal/tt_metal/api/test_kernel_creation.cpp
+++ b/tests/tt_metal/tt_metal/api/test_kernel_creation.cpp
@@ -23,7 +23,7 @@
 #include <tt-metalium/kernel_types.hpp>
 #include <tt-metalium/program.hpp>
 #include <umd/device/types/core_coordinates.hpp>
-#include "impl/kernels/kernel_impl.hpp"
+#include "impl/kernels/kernel.hpp"
 #include "impl/program/program_impl.hpp"
 
 namespace tt::tt_metal {

--- a/tests/tt_metal/tt_metal/api/test_runtime_args.cpp
+++ b/tests/tt_metal/tt_metal/api/test_runtime_args.cpp
@@ -35,6 +35,7 @@
 
 // Access to internal API: ProgramImpl::num_kernel, get_kernel
 #include "impl/program/program_impl.hpp"
+#include "impl/context/metal_context.hpp"
 #include "impl/kernels/kernel.hpp"
 
 using namespace tt;

--- a/tests/tt_metal/tt_metal/api/test_runtime_args.cpp
+++ b/tests/tt_metal/tt_metal/api/test_runtime_args.cpp
@@ -35,8 +35,7 @@
 
 // Access to internal API: ProgramImpl::num_kernel, get_kernel
 #include "impl/program/program_impl.hpp"
-#include "impl/kernels/kernel_impl.hpp"
-#include "impl/context/metal_context.hpp"
+#include "impl/kernels/kernel.hpp"
 
 using namespace tt;
 using namespace tt::tt_metal;

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
@@ -57,7 +57,7 @@
 
 // Access to internal API: ProgramImpl::get_cb_base_addr, get_kernel
 #include "impl/program/program_impl.hpp"
-#include "impl/kernels/kernel_impl.hpp"
+#include "impl/kernels/kernel.hpp"
 
 namespace tt {
 namespace tt_metal {

--- a/tests/tt_metal/tt_metal/test_compile_program.cpp
+++ b/tests/tt_metal/tt_metal/test_compile_program.cpp
@@ -38,7 +38,7 @@
 
 // Access to internal API: ProgramImpl::num_kernel, get_kernel
 #include "impl/program/program_impl.hpp"
-#include "impl/kernels/kernel_impl.hpp"
+#include "impl/kernels/kernel.hpp"
 
 using std::vector;
 using namespace tt;

--- a/tests/tt_metal/tt_metal/test_compile_sets_kernel_binaries.cpp
+++ b/tests/tt_metal/tt_metal/test_compile_sets_kernel_binaries.cpp
@@ -190,11 +190,11 @@ int main(int argc, char** argv) {
             // Run iteration to get golden
             auto mask = tt_metal::BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key();
             tt_metal::detail::CompileProgram(device, program);
-            compute_binaries.insert({mask, tt_metal::KernelImpl::from(*compute_kernel).binaries(mask)});
+            compute_binaries.insert({mask, compute_kernel->binaries(mask)});
             TT_FATAL(compute_binaries.at(mask).size() == 3, "Expected 3 Compute binaries!");
-            brisc_binaries.insert({mask, tt_metal::KernelImpl::from(*riscv0_kernel).binaries(mask)});
+            brisc_binaries.insert({mask, riscv0_kernel->binaries(mask)});
             TT_FATAL(brisc_binaries.at(mask).size() == 1, "Expected 1 BRISC binary!");
-            ncrisc_binaries.insert({mask, tt_metal::KernelImpl::from(*riscv1_kernel).binaries(mask)});
+            ncrisc_binaries.insert({mask, riscv1_kernel->binaries(mask)});
             TT_FATAL(ncrisc_binaries.at(mask).size() == 1, "Expected 1 NCRISC binary!");
         }
 
@@ -256,15 +256,9 @@ int main(int argc, char** argv) {
                         }
                         TT_FATAL(
                             compute_kernel != nullptr && riscv0_kernel != nullptr && riscv1_kernel != nullptr, "Error");
-                        TT_FATAL(
-                            tt_metal::KernelImpl::from(*compute_kernel).binaries(mask) == compute_binaries.at(mask),
-                            "Error");
-                        TT_FATAL(
-                            tt_metal::KernelImpl::from(*riscv0_kernel).binaries(mask) == brisc_binaries.at(mask),
-                            "Error");
-                        TT_FATAL(
-                            tt_metal::KernelImpl::from(*riscv1_kernel).binaries(mask) == ncrisc_binaries.at(mask),
-                            "Error");
+                        TT_FATAL(compute_kernel->binaries(mask) == compute_binaries.at(mask), "Error");
+                        TT_FATAL(riscv0_kernel->binaries(mask) == brisc_binaries.at(mask), "Error");
+                        TT_FATAL(riscv1_kernel->binaries(mask) == ncrisc_binaries.at(mask), "Error");
 
                         std::string kernel_name = get_latest_kernel_binary_path(
                             tt_metal::BuildEnvManager::get_instance()

--- a/tests/tt_metal/tt_metal/test_compile_sets_kernel_binaries.cpp
+++ b/tests/tt_metal/tt_metal/test_compile_sets_kernel_binaries.cpp
@@ -35,7 +35,7 @@
 #include "llrt.hpp"
 #include "impl/context/metal_context.hpp"
 #include "impl/program/program_impl.hpp"
-#include "impl/kernels/kernel_impl.hpp"
+#include "impl/kernels/kernel.hpp"
 #include "tt_memory.h"
 #include <tt-logger/tt-logger.hpp>
 #include <tt-metalium/program.hpp>

--- a/tests/tt_metal/tt_metal/test_core_range_set.cpp
+++ b/tests/tt_metal/tt_metal/test_core_range_set.cpp
@@ -33,7 +33,7 @@
 #include "hostdevcommon/kernel_structs.h"
 #include <tt-metalium/kernel_types.hpp>
 #include "impl/context/metal_context.hpp"
-#include "impl/kernels/kernel_impl.hpp"
+#include "impl/kernels/kernel.hpp"
 #include <tt-logger/tt-logger.hpp>
 #include <tt-metalium/program.hpp>
 #include <tt_stl/span.hpp>

--- a/tt_metal/fabric/fabric.cpp
+++ b/tt_metal/fabric/fabric.cpp
@@ -22,7 +22,7 @@
 
 #include "impl/context/metal_context.hpp"
 #include "impl/program/program_impl.hpp"
-#include "impl/kernels/kernel_impl.hpp"
+#include "impl/kernels/kernel.hpp"
 #include <umd/device/types/xy_pair.hpp>
 
 #include "fabric_host_utils.hpp"

--- a/tt_metal/impl/debug/inspector/inspector.cpp
+++ b/tt_metal/impl/debug/inspector/inspector.cpp
@@ -13,7 +13,7 @@
 #include "program.hpp"
 #include <memory>
 #include <tt-logger/tt-logger.hpp>
-#include "impl/kernels/kernel_impl.hpp"
+#include "impl/kernels/kernel.hpp"
 
 namespace tt::tt_metal {
 

--- a/tt_metal/impl/dispatch/data_collection.cpp
+++ b/tt_metal/impl/dispatch/data_collection.cpp
@@ -6,7 +6,7 @@
 
 #include <cstdint>
 #include "impl/context/metal_context.hpp"
-#include "impl/kernels/kernel_impl.hpp"
+#include "impl/kernels/kernel.hpp"
 #include "tt-metalium/program.hpp"
 #include "data_collector.hpp"
 

--- a/tt_metal/impl/dispatch/data_collector.cpp
+++ b/tt_metal/impl/dispatch/data_collector.cpp
@@ -6,7 +6,7 @@
 #include <enchantum/enchantum.hpp>
 #include <enchantum/generators.hpp>
 #include <enchantum/iostream.hpp>
-#include "impl/kernels/kernel_impl.hpp"
+#include "impl/kernels/kernel.hpp"
 #include "tt-metalium/program.hpp"
 
 using tt::tt_metal::detail::ProgramImpl;

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -33,7 +33,7 @@
 #include "tt_metal/jit_build/genfiles.hpp"
 #include <umd/device/types/core_coordinates.hpp>
 #include <umd/device/types/arch.hpp>
-#include "kernel_impl.hpp"
+#include "kernel.hpp"
 
 namespace tt {
 

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -152,7 +152,7 @@ void Kernel::register_kernel_with_watcher() {
     }
 }
 
-void KernelImpl::register_kernel_elf_paths_with_watcher(IDevice& device) const {
+void Kernel::register_kernel_elf_paths_with_watcher(IDevice& device) const {
     TT_ASSERT(!this->kernel_full_name_.empty(), "Kernel full name not set!");
     auto paths = this->file_paths(device);
     MetalContext::instance().watcher_server()->register_kernel_elf_paths(this->watcher_kernel_id_, paths);
@@ -181,13 +181,13 @@ CoreType Kernel::get_kernel_core_type() const {
     TT_THROW("Unreachable");
 }
 
-const std::string& KernelImpl::get_full_kernel_name() const { return this->kernel_full_name_; }
+const std::string& Kernel::get_full_kernel_name() const { return this->kernel_full_name_; }
 
 void Kernel::add_defines(const std::map<std::string, std::string>& defines) {
     this->defines_.insert(defines.begin(), defines.end());
 }
 
-void KernelImpl::process_defines(
+void Kernel::process_defines(
     const std::function<void(const std::string& define, const std::string& value)> callback) const {
     for (const auto& [define, value] : this->defines_) {
         callback(define, value);
@@ -196,7 +196,7 @@ void KernelImpl::process_defines(
 
 void DataMovementKernel::process_defines(
     const std::function<void(const std::string& define, const std::string& value)> callback) const {
-    KernelImpl::process_defines(callback);
+    Kernel::process_defines(callback);
     callback("NOC_INDEX", std::to_string(this->config_.noc));
     callback("NOC_MODE", std::to_string(this->config_.noc_mode));
 }
@@ -212,7 +212,7 @@ void ComputeKernel::process_defines(
 
 void EthernetKernel::process_defines(
     const std::function<void(const std::string& define, const std::string& value)> callback) const {
-    KernelImpl::process_defines(callback);
+    Kernel::process_defines(callback);
     callback("NOC_INDEX", std::to_string(this->config_.noc));
     // pass default noc mode as eth does not need it, just for compile to pass
     callback("NOC_MODE", std::to_string(NOC_MODE::DM_DEDICATED_NOC));
@@ -236,17 +236,16 @@ std::string_view EthernetKernel::get_compiler_opt_level() const {
 
 std::string_view EthernetKernel::get_linker_opt_level() const { return this->get_compiler_opt_level(); }
 
-void KernelImpl::process_compile_time_args(
-    const std::function<void(const std::vector<uint32_t>& values)> callback) const {
+void Kernel::process_compile_time_args(const std::function<void(const std::vector<uint32_t>& values)> callback) const {
     callback(this->compile_time_args());
 }
 
-void KernelImpl::process_named_compile_time_args(
+void Kernel::process_named_compile_time_args(
     const std::function<void(const std::unordered_map<std::string, uint32_t>& named_args)> callback) const {
     callback(this->named_compile_time_args());
 }
 
-bool KernelImpl::binaries_exist_on_disk(const IDevice* device) const {
+bool Kernel::binaries_exist_on_disk(const IDevice* device) const {
     const uint32_t core_type =
         MetalContext::instance().hal().get_programmable_core_type_index(this->get_kernel_programmable_core_type());
     const uint32_t processor_class = enchantum::to_underlying(this->get_kernel_processor_class());
@@ -266,7 +265,7 @@ bool KernelImpl::binaries_exist_on_disk(const IDevice* device) const {
     return std::filesystem::exists(build_success_marker_path);
 }
 
-std::vector<std::string> KernelImpl::file_paths(IDevice& device) const {
+std::vector<std::string> Kernel::file_paths(IDevice& device) const {
     std::vector<std::string> file_paths;
     auto& hal = MetalContext::instance().hal();
     uint32_t core_type = hal.get_programmable_core_type_index(this->get_kernel_programmable_core_type());
@@ -288,7 +287,7 @@ uint8_t ComputeKernel::expected_num_binaries() const {
     return 3;
 }
 
-const std::vector<const ll_api::memory*>& KernelImpl::binaries(uint64_t build_key) const {
+const std::vector<const ll_api::memory*>& Kernel::binaries(uint64_t build_key) const {
     auto iter = binaries_.find(build_key);
     TT_FATAL(iter != binaries_.end(), "binary not found");
     if (iter->second.size() != expected_num_binaries()) {
@@ -526,13 +525,13 @@ detail::KernelMeta Kernel::meta(IDevice* device) const {
     return result;
 }
 
-uint32_t KernelImpl::get_binary_packed_size(IDevice* device, int index) const {
+uint32_t Kernel::get_binary_packed_size(IDevice* device, int index) const {
     // In testing situations we can query the size w/o a binary
     auto iter = binaries_.find(BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key());
     return iter != this->binaries_.end() ? iter->second[index]->get_packed_size() : 0;
 }
 
-uint32_t KernelImpl::get_binary_text_size(IDevice* device, int index) const {
+uint32_t Kernel::get_binary_text_size(IDevice* device, int index) const {
     // In testing situations we can query the size w/o a binary
     auto iter = binaries_.find(BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key());
     return iter != this->binaries_.end() ? iter->second[index]->get_text_size() : 0;
@@ -584,7 +583,7 @@ void ComputeKernel::generate_binaries(IDevice* device, JitBuildOptions& /*build_
     jit_build_subset(build_states, this);
 }
 
-void KernelImpl::set_binaries(uint64_t build_key, std::vector<const ll_api::memory*>&& binaries) {
+void Kernel::set_binaries(uint64_t build_key, std::vector<const ll_api::memory*>&& binaries) {
     // Try inserting an empty vector, as that is cheap to construct
     // and avoids an additional move.
     auto pair = binaries_.insert({build_key, {}});

--- a/tt_metal/impl/kernels/kernel.hpp
+++ b/tt_metal/impl/kernels/kernel.hpp
@@ -52,35 +52,36 @@ public:
 
     std::string name() const;
 
-    const KernelSource &kernel_source() const { return kernel_src_; }
+    const KernelSource& kernel_source() const { return kernel_src_; }
 
-    const CoreRangeSet &core_range_set() const { return core_range_set_; }
+    const CoreRangeSet& core_range_set() const { return core_range_set_; }
 
     const std::set<CoreCoord>& cores_with_runtime_args() const { return core_with_runtime_args_; }
 
     const std::map<std::string, std::string>& defines() const { return defines_; }
 
-    const std::set<CoreCoord> &logical_cores() const;
+    const std::set<CoreCoord>& logical_cores() const;
 
     std::vector<CoreRange> logical_coreranges() const;
 
-    bool is_on_logical_core(const CoreCoord &logical_core) const;
+    bool is_on_logical_core(const CoreCoord& logical_core) const;
 
     std::vector<uint32_t> compile_time_args() const { return compile_time_args_; }
     std::unordered_map<std::string, uint32_t> named_compile_time_args() const { return named_compile_time_args_; }
 
-    std::vector<uint32_t> & runtime_args(const CoreCoord &logical_core);
-    RuntimeArgsData & runtime_args_data(const CoreCoord &logical_core);
-    std::vector< std::vector< std::vector<uint32_t>> > & runtime_args();
-    std::vector< std::vector< RuntimeArgsData > > & runtime_args_data();
+    std::vector<uint32_t>& runtime_args(const CoreCoord& logical_core);
+    RuntimeArgsData& runtime_args_data(const CoreCoord& logical_core);
+    std::vector<std::vector<std::vector<uint32_t>>>& runtime_args();
+    std::vector<std::vector<RuntimeArgsData>>& runtime_args_data();
     void set_runtime_args_count(CoreRangeSet& core_ranges, uint32_t count);
-    std::vector<uint32_t> & common_runtime_args();
-    RuntimeArgsData & common_runtime_args_data();
+    std::vector<uint32_t>& common_runtime_args();
+    RuntimeArgsData& common_runtime_args_data();
     void set_common_runtime_args_count(uint32_t count);
     uint32_t get_common_runtime_args_count() const { return this->common_runtime_args_count_; }
     uint32_t dispatch_class() { return this->dispatch_class_; }
 
-    virtual bool configure(IDevice* device, const CoreCoord &logical_core, uint32_t base_address, const uint32_t offsets[]) const = 0;
+    virtual bool configure(
+        IDevice* device, const CoreCoord& logical_core, uint32_t base_address, const uint32_t offsets[]) const = 0;
 
     virtual Config config() const = 0;
 
@@ -92,8 +93,9 @@ public:
     void process_named_compile_time_args(
         std::function<void(const std::unordered_map<std::string, uint32_t>& named_args)>) const override;
 
-    void validate_runtime_args_size(size_t num_unique_rt_args, size_t num_common_rt_args, const CoreCoord& logical_core);
-    void set_runtime_args(const CoreCoord &logical_core, stl::Span<const uint32_t> runtime_args);
+    void validate_runtime_args_size(
+        size_t num_unique_rt_args, size_t num_common_rt_args, const CoreCoord& logical_core);
+    void set_runtime_args(const CoreCoord& logical_core, stl::Span<const uint32_t> runtime_args);
     void set_common_runtime_args(stl::Span<const uint32_t> runtime_args);
 
     int get_watcher_kernel_id() const { return watcher_kernel_id_; }
@@ -149,15 +151,16 @@ protected:
     uint8_t dispatch_class_{};
     std::vector<uint32_t> compile_time_args_;
     std::unordered_map<std::string, uint32_t> named_compile_time_args_;
-    std::vector< std::vector< std::vector<uint32_t>> > core_to_runtime_args_;
-    std::vector< std::vector< RuntimeArgsData> > core_to_runtime_args_data_;
+    std::vector<std::vector<std::vector<uint32_t>>> core_to_runtime_args_;
+    std::vector<std::vector<RuntimeArgsData>> core_to_runtime_args_data_;
     uint32_t common_runtime_args_count_;
     std::vector<uint32_t> common_runtime_args_;
     RuntimeArgsData common_runtime_args_data_{};
     std::set<CoreCoord> core_with_runtime_args_;
-    std::size_t max_runtime_args_per_core_;             // For validation
-    CoreCoord core_with_max_runtime_args_;              // For validation
-    std::map<std::string, std::string> defines_;        // preprocessor defines. this is to be able to generate generic instances.
+    std::size_t max_runtime_args_per_core_;  // For validation
+    CoreCoord core_with_max_runtime_args_;   // For validation
+    std::map<std::string, std::string>
+        defines_;  // preprocessor defines. this is to be able to generate generic instances.
     std::set<CoreCoord> logical_cores_;
 
     // Build key -> binaries (moved from KernelImpl)

--- a/tt_metal/impl/kernels/kernel.hpp
+++ b/tt_metal/impl/kernels/kernel.hpp
@@ -48,7 +48,7 @@ class Kernel : public JitBuildSettings {
 public:
     using Config = std::variant<DataMovementConfig, EthernetConfig, ComputeConfig>;
 
-    virtual ~Kernel() = default;
+    ~Kernel() override = default;
 
     std::string name() const;
 

--- a/tt_metal/impl/lightmetal/lightmetal_replay_impl.hpp
+++ b/tt_metal/impl/lightmetal/lightmetal_replay_impl.hpp
@@ -14,7 +14,7 @@
 #include <tt-metalium/device.hpp>
 #include <tt-metalium/circular_buffer.hpp>
 
-#include "impl/kernels/kernel_impl.hpp"
+#include "impl/kernels/kernel.hpp"
 
 namespace tt::tt_metal {
 struct TraceDescriptor;

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -61,7 +61,7 @@
 #include "vector_aligned.hpp"
 #include "dispatch/worker_config_buffer.hpp"
 #include "tt_metal/distributed/mesh_workload_impl.hpp"
-#include "kernels/kernel_impl.hpp"
+#include "kernels/kernel.hpp"
 #include "tt_metal/impl/dispatch/hardware_command_queue.hpp"
 
 namespace tt {

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -323,8 +323,8 @@ uint32_t finalize_kernel_bins(
         std::ranges::fill(kg->kernel_text_offsets, 0);
         for (auto kernel_id : kg->kernel_ids) {
             const auto& kernel = kernels.at(kernel_id);
-            const auto& binaries = KernelImpl::from(*kernel).binaries(
-                BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key());
+            const auto& binaries =
+                kernel->binaries(BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key());
             uint32_t num_binaries = kernel->expected_num_binaries();
             TT_ASSERT(kernel->get_kernel_programmable_core_type() == programmable_core_type);
             for (uint32_t i = 0; i < num_binaries; i++) {

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -1086,7 +1086,7 @@ void detail::ProgramImpl::populate_dispatch_data(IDevice* device) {
                         page_offsets[transfer_info_index] =
                             binaries_data.size() * sizeof(uint32_t) / HostMemDeviceCommand::PROGRAM_PAGE_SIZE;
                         lengths[transfer_info_index] = len * sizeof(uint32_t);
-                        processor_ids[transfer_info_index] = kernel_impl.get_kernel_processor_type(sub_kernel_index);
+                        processor_ids[transfer_info_index] = kernel->get_kernel_processor_type(sub_kernel_index);
 
                         binaries_data.insert(binaries_data.end(), mem_ptr, mem_ptr + len);
                         binaries_data.resize(

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -75,7 +75,7 @@
 #include <umd/device/types/core_coordinates.hpp>
 #include <umd/device/types/xy_pair.hpp>
 #include "host_api.hpp"
-#include "kernels/kernel_impl.hpp"
+#include "kernels/kernel.hpp"
 #include "tt_stl/reflection.hpp"
 
 namespace tt {

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -153,7 +153,7 @@ void GenerateBinaries(IDevice* device, JitBuildOptions& build_options, const std
     try {
         jit_build_genfiles_descriptors(
             BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_env, build_options);
-        KernelImpl::from(*kernel).generate_binaries(device, build_options);
+        kernel->generate_binaries(device, build_options);
     } catch (std::runtime_error& ex) {
         TT_THROW("Failed to generate binaries for {} {}", kernel->name(), ex.what());
     }
@@ -1060,9 +1060,8 @@ void detail::ProgramImpl::populate_dispatch_data(IDevice* device) {
     // This is generic for workers and eth cores
     for (const auto& kernels : this->kernels_) {
         for (const auto& [kernel_id, kernel] : kernels) {
-            auto& kernel_impl = KernelImpl::from(*kernel);
-            const auto& binaries = kernel_impl.binaries(
-                BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key());
+            const auto& binaries =
+                kernel->binaries(BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key());
             std::vector<uint32_t> dst_base_addrs;
             std::vector<uint32_t> page_offsets;
             std::vector<uint32_t> lengths;
@@ -1387,7 +1386,7 @@ void detail::ProgramImpl::compile(IDevice* device, bool force_slow_dispatch) {
             launch_build_step(
                 [kernel, device, this, &build_env] {
                     JitBuildOptions build_options(build_env.build_env);
-                    KernelImpl::from(*kernel).set_build_options(build_options);
+                    kernel->set_build_options(build_options);
                     if (this->compiled_.empty()) {
                         this->set_remote_circular_buffer_init(kernel);
                     }
@@ -1400,9 +1399,9 @@ void detail::ProgramImpl::compile(IDevice* device, bool force_slow_dispatch) {
                     kernel->set_full_name(kernel_path_suffix);
                     build_options.set_name(kernel_path_suffix);
 
-                    KernelImpl::from(*kernel).register_kernel_elf_paths_with_watcher(*device);
+                    kernel->register_kernel_elf_paths_with_watcher(*device);
 
-                    if (enable_persistent_kernel_cache && KernelImpl::from(*kernel).binaries_exist_on_disk(device)) {
+                    if (enable_persistent_kernel_cache && kernel->binaries_exist_on_disk(device)) {
                         if (not detail::HashLookup::inst().exists(kernel_hash)) {
                             detail::HashLookup::inst().add(kernel_hash);
                             detail::HashLookup::inst().add_generated_bin(kernel_hash);
@@ -1422,7 +1421,7 @@ void detail::ProgramImpl::compile(IDevice* device, bool force_slow_dispatch) {
 
     for (auto& kernels : kernels_) {
         for (auto& [id, kernel] : kernels) {
-            launch_build_step([kernel, device] { KernelImpl::from(*kernel).read_binaries(device); }, events);
+            launch_build_step([kernel, device] { kernel->read_binaries(device); }, events);
         }
     }
     sync_build_steps(events);

--- a/tt_metal/jit_build/genfiles.cpp
+++ b/tt_metal/jit_build/genfiles.cpp
@@ -29,7 +29,7 @@
 #include "jit_build_settings.hpp"
 #include <tt-logger/tt-logger.hpp>
 #include "impl/context/metal_context.hpp"
-#include "impl/kernels/kernel_impl.hpp"
+#include "impl/kernels/kernel.hpp"
 
 enum class UnpackToDestMode : uint8_t;
 

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -34,7 +34,7 @@
 #include <filesystem>
 #include "device.hpp"
 #include "impl/context/metal_context.hpp"
-#include "kernels/kernel_impl.hpp"
+#include "kernels/kernel.hpp"
 #include "dispatch/dispatch_settings.hpp"
 #include "device/device_impl.hpp"
 #include "hal_types.hpp"


### PR DESCRIPTION
### Ticket
No ticket

### Problem description
In #22783 , kernel class organization was split between internal KernelImpl and external (API) Kernel class using polymorphism.
In #28050 , this separation was further refactored so that Kernel class is no longer exposed at all via our public API.
The original Kernel vs KernelImpl is no longer needed.

### What's changed
Improves readability by flattening Kernel class structure.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes