### PR TITLE
Mding/17803

### DIFF
--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_pause.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_pause.cpp
@@ -136,7 +136,7 @@ void RunTest(MeshWatcherFixture* fixture, const std::shared_ptr<distributed::Mes
     for (uint32_t x = xy_start.x; x <= xy_end.x; x++) {
         for (uint32_t y = xy_start.y; y <= xy_end.y; y++) {
             CoreCoord virtual_core = device->worker_core_from_logical_core({x, y});
-            for (auto &risc_str : {"brisc", "ncrisc", "trisc0", "trisc1", "trisc2"}) {
+            for (auto& risc_str : {" brisc", "ncrisc", "trisc0", "trisc1", "trisc2"}) {
                 std::string expected = fmt::format("{}:{}", virtual_core.str(), risc_str);
                 expected_strings.push_back(expected);
             }
@@ -156,8 +156,7 @@ void RunTest(MeshWatcherFixture* fixture, const std::shared_ptr<distributed::Mes
             expected_strings.push_back(expected);
         }
     }
-    // See #10527
-    // EXPECT_TRUE(FileContainsAllStrings(fixture->log_file_name, expected_strings));
+    EXPECT_TRUE(FileContainsAllStrings(fixture->log_file_name, expected_strings));
 }
 }
 }

--- a/tt_stl/tt_stl/assert.hpp
+++ b/tt_stl/tt_stl/assert.hpp
@@ -90,7 +90,7 @@ template <typename... Args>
     const char* file, int line, const char* assert_type, const char* condition_str, const Args&... args) {
     if (std::getenv("TT_ASSERT_ABORT")) {
         if constexpr (sizeof...(args) > 0) {
-            log_critical(tt::LogAlways, args...);
+            log_critical(tt::LogAlways, "{}: {}", assert_type, fmt::format(args...));
         }
         abort();
     }
@@ -100,7 +100,7 @@ template <typename... Args>
     if constexpr (sizeof...(args) > 0) {
         trace_message_ss << "info:" << std::endl;
         trace_message_ss << fmt::format(args...) << std::endl;
-        log_critical(tt::LogAlways, args...);
+        log_critical(tt::LogAlways, "{}: {}", assert_type, fmt::format(args...));
     }
     trace_message_ss << "backtrace:\n";
     trace_message_ss << tt::assert::backtrace_to_string(100, 3, " --- ");


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/17803

### Problem description
The output for assert says nothing about an assert being hit

### What's changed
There are two messaging from TT_THROW, TT_FATAL and TT_ASSERT.
1. The macro itself creates a log_critical message. In this message, the string doesn't show if it is throw, fatal or assert.
2. When you catch the exception, a string is passed from the throw/fatal/assert call. In this string, it clearly has TT_THROW/TT_FATAL/TT_ASSERT.

This feature enhancement adds TT_THROW/TT_FATAL/TT_ASSERT prefix string to the log_critical message when the exception is thrown.  This way, clear distinction of which type is thrown.

Ran these unit tests
A. unit_tests_debug_tools - pass
B. unit_tests_api - pass
C. unit_tests_device - pass

Also created positive test to make sure the prefix works in both normal compile (TT_THROW/TT_FATAL) and debug compile (TT_THROW/TT_FATAL/TT_ASSERT).

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes