### PR TITLE
Revert "[skip ci] Reenable t3k tests on merge gate (#32040)"

### DIFF
--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -165,7 +165,7 @@ jobs:
       matrix:
         platform: [
           "N300-viommu",
-          "in-service-dedicated-merge-gate", # run t3k tests on CIv1 for now in order to have dedicated machine
+          # "N300-llmbox-viommu", # re-enable when we have more capacity
         ]
     uses: ./.github/workflows/smoke.yaml
     with:
@@ -188,7 +188,7 @@ jobs:
       matrix:
         platform: [
           "N300-viommu",
-          "in-service-dedicated-merge-gate", # run t3k tests on CIv1 for now in order to have dedicated machine
+          # "N300-llmbox-viommu", # re-enable when we have more capacity
         ]
     uses: ./.github/workflows/smoke.yaml
     with:

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -31,7 +31,7 @@ jobs:
         (format('tt-ubuntu-2204-{0}-stable', inputs.runner))
       }}
     container:
-      image: ${{ (inputs.docker-image && (contains(inputs.runner, 'dedicated-merge-gate') && inputs.docker-image || format('harbor.ci.tenstorrent.net/{0}', inputs.docker-image))) || 'docker-image-unresolved!' }}
+      image: ${{ (inputs.docker-image && format('harbor.ci.tenstorrent.net/{0}', inputs.docker-image)) || 'docker-image-unresolved!' }}
       env:
         ASAN_OPTIONS: "color=always"
         TSAN_OPTIONS: "color=always"


### PR DESCRIPTION
This reverts commit 6c6dff8b93fa8a52cccff941d283c32cd9d34861.

Something must've regressed since that PR tested vs. when it landed.  It's now failing.
