### PR TITLE
#32229: add bcast_llk for ROW bcast in ternary TTT

### DIFF
--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_addcmul_fpu_rowbcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_addcmul_fpu_rowbcast.cpp
@@ -1,0 +1,143 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Expects reader kernel to not perform per-tile fill (FILL_TILE_WITH_FIRST_ROW) controlled by BCAST_LLK flag
+
+#include <cstdint>
+
+#include "compute_kernel_api/eltwise_unary/eltwise_unary.h"
+#include "compute_kernel_api/eltwise_binary_sfpu.h"
+#include "compute_kernel_api/eltwise_binary.h"
+#include "compute_kernel_api/tile_move_copy.h"
+#include "compute_kernel_api/eltwise_unary/binop_with_scalar.h"
+#include "compute_kernel_api/bcast.h"
+
+namespace NAMESPACE {
+void MAIN {
+    uint32_t num_tiles = get_arg_val<uint32_t>(0);
+    uint32_t scalar_arg = get_arg_val<uint32_t>(3);
+
+    constexpr uint32_t num_tiles_per_cycle = get_compile_time_arg_val(0);  // set to 1
+    const bool scalar_is_not_1 = scalar_arg != 1u;
+
+    constexpr auto cb_in0 = tt::CBIndex::c_0;  // input_a
+    constexpr auto cb_in1 = tt::CBIndex::c_1;  // input_b
+    constexpr auto cb_in2 = tt::CBIndex::c_2;  // input_c
+    constexpr auto cb_out = tt::CBIndex::c_3;
+
+    // LLK broadcast destination CBs (dedicated per-input):
+    constexpr auto cb_llk_a = tt::CBIndex::c_4;  // broadcasted A (if used)
+    constexpr auto cb_llk_b = tt::CBIndex::c_5;  // broadcasted B (if used)
+    constexpr auto cb_llk_c = tt::CBIndex::c_6;  // broadcasted C (if used)
+
+// Effective CBs chosen at compile-time depending on broadcast flags
+#if BCAST_A
+    constexpr auto cb_eff_a = cb_llk_a;
+#else
+    constexpr auto cb_eff_a = cb_in0;
+#endif
+#if BCAST_B
+    constexpr auto cb_eff_b = cb_llk_b;
+#else
+    constexpr auto cb_eff_b = cb_in1;
+#endif
+#if BCAST_C
+    constexpr auto cb_eff_c = cb_llk_c;
+#else
+    constexpr auto cb_eff_c = cb_in2;
+#endif
+
+    // Initialize binary unit for B*C path; output packer initialized with cb_out
+    binary_op_init_common(cb_eff_b, cb_eff_c, cb_out);
+
+    for (uint32_t tile_id = 0; tile_id < num_tiles; ++tile_id) {
+// 1) Prepare B and C (broadcast if required), then compute mul(B, C) -> DST[0]
+// Perform LLK row broadcast for B if requested
+#if BCAST_B
+        cb_wait_front(cb_in1, num_tiles_per_cycle);
+        cb_reserve_back(cb_llk_b, num_tiles_per_cycle);
+        unary_bcast_init<BroadcastType::ROW>(cb_in1, cb_llk_b);
+        tile_regs_acquire();
+        unary_bcast<BroadcastType::ROW>(cb_in1, 0, 0);
+        tile_regs_commit();
+        tile_regs_wait();
+        pack_tile(0, cb_llk_b);
+        cb_push_back(cb_llk_b, num_tiles_per_cycle);
+        tile_regs_release();
+        cb_pop_front(cb_in1, num_tiles_per_cycle);
+#endif
+
+// Perform LLK row broadcast for C if requested
+#if BCAST_C
+        cb_wait_front(cb_in2, num_tiles_per_cycle);
+        cb_reserve_back(cb_llk_c, num_tiles_per_cycle);
+        unary_bcast_init<BroadcastType::ROW>(cb_in2, cb_llk_c);
+        tile_regs_acquire();
+        unary_bcast<BroadcastType::ROW>(cb_in2, 0, 0);
+        tile_regs_commit();
+        tile_regs_wait();
+        pack_tile(0, cb_llk_c);
+        cb_push_back(cb_llk_c, num_tiles_per_cycle);
+        tile_regs_release();
+        cb_pop_front(cb_in2, num_tiles_per_cycle);
+#endif
+
+// Perform LLK row broadcast for A if requested (do this before compute regs session)
+#if BCAST_A
+        cb_wait_front(cb_in0, num_tiles_per_cycle);
+        cb_reserve_back(cb_llk_a, num_tiles_per_cycle);
+        unary_bcast_init<BroadcastType::ROW>(cb_in0, cb_llk_a);
+        tile_regs_acquire();
+        unary_bcast<BroadcastType::ROW>(cb_in0, 0, 0);
+        tile_regs_commit();
+        tile_regs_wait();
+        pack_tile(0, cb_llk_a);
+        cb_push_back(cb_llk_a, num_tiles_per_cycle);
+        tile_regs_release();
+        cb_pop_front(cb_in0, num_tiles_per_cycle);
+#endif
+
+        // Ensure sources available
+        cb_wait_front(cb_eff_b, num_tiles_per_cycle);
+        cb_wait_front(cb_eff_c, num_tiles_per_cycle);
+
+        tile_regs_acquire();
+
+        // (input_b * input_c)
+        mul_tiles_init(cb_eff_b, cb_eff_c);
+        mul_tiles(cb_eff_b, cb_eff_c, 0, 0, 0);
+
+        // Done with cb_in1 and cb_in2, pop them early for pipeline efficiency
+        cb_pop_front(cb_eff_b, num_tiles_per_cycle);
+        cb_pop_front(cb_eff_c, num_tiles_per_cycle);
+
+        // Step 2: (input_b * input_c) * value -> DST[0]
+        if (scalar_is_not_1) {
+            binop_with_scalar_tile_init();
+            mul_unary_tile(0, scalar_arg);  // DST[0] * scalar -> DST[0]
+        }
+
+        // Wait for effective A
+        cb_wait_front(cb_eff_a, num_tiles_per_cycle);
+
+        // Step 3: Load A and add with result DST[0] + cb_post_a -> DST[0]
+        binary_dest_reuse_tiles_init<EltwiseBinaryType::ELWADD, EltwiseBinaryReuseDestType::DEST_TO_SRCA>(cb_eff_a);
+        binary_dest_reuse_tiles<EltwiseBinaryType::ELWADD, EltwiseBinaryReuseDestType::DEST_TO_SRCA>(cb_eff_a, 0, 0);
+
+        tile_regs_commit();
+        tile_regs_wait();
+
+        // Reserve output buffer only when ready to write
+        cb_reserve_back(cb_out, num_tiles_per_cycle);
+
+        // Pack the result from DST[0] to output
+        pack_tile(0, cb_out);
+
+        tile_regs_release();
+
+        cb_push_back(cb_out, num_tiles_per_cycle);
+        cb_pop_front(cb_eff_a, num_tiles_per_cycle);
+    }
+}
+}  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_sfpu_row_bcast_ttt.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_sfpu_row_bcast_ttt.cpp
@@ -1,0 +1,158 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Ternary SFPU compute kernel with optional ROW broadcast via LLK unary_bcast
+// Supports broadcasting 0, 1 or 2 inputs (A/B/C)
+// Expects reader kernel to not perform per-tile fill (FILL_TILE_WITH_FIRST_ROW) controlled by BCAST_LLK flag
+//
+// The actual ternary operation is provided via:
+//   TERNARY_SFPU_OP_INIT()
+//   TERNARY_SFPU_OP_FUNC(src_idx_a, src_idx_b, src_idx_c, dst_idx_out)
+// which are configured by the program factory for the desired op (e.g., where).
+
+#include <cstdint>
+
+#include "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_utils_common.hpp"
+#include "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_utils_sfpu.hpp"
+#include "compute_kernel_api/eltwise_unary/eltwise_unary.h"
+#include "compute_kernel_api/eltwise_unary/where.h"
+#include "compute_kernel_api/bcast.h"
+#include "compute_kernel_api/tile_move_copy.h"
+
+namespace NAMESPACE {
+void MAIN {
+    uint32_t num_tiles = get_arg_val<uint32_t>(0);
+
+    constexpr uint32_t num_tiles_per_cycle = get_compile_time_arg_val(0);  // typically 1
+
+    // Pre-CBs for inputs A, B, C and output CB
+    constexpr auto cb_pre_a = tt::CBIndex::c_0;
+    constexpr auto cb_pre_b = tt::CBIndex::c_1;
+    constexpr auto cb_pre_c = tt::CBIndex::c_2;
+    constexpr auto cb_out = tt::CBIndex::c_3;
+
+    // CBs to hold LLK broadcast results when enabled
+    constexpr auto cb_bcast_a = tt::CBIndex::c_4;
+    constexpr auto cb_bcast_b = tt::CBIndex::c_5;
+    constexpr auto cb_bcast_c = tt::CBIndex::c_6;
+
+// Compile-time effective CB selection
+#if BCAST_A
+    constexpr auto cb_eff_a = cb_bcast_a;
+#else
+    constexpr auto cb_eff_a = cb_pre_a;
+#endif
+#if BCAST_B
+    constexpr auto cb_eff_b = cb_bcast_b;
+#else
+    constexpr auto cb_eff_b = cb_pre_b;
+#endif
+#if BCAST_C
+    constexpr auto cb_eff_c = cb_bcast_c;
+#else
+    constexpr auto cb_eff_c = cb_pre_c;
+#endif
+
+    // Initialize pack/format for SFPU-style ternary kernels (matches existing ternary SFPU kernels)
+    unary_op_init_common(cb_eff_a, cb_out);
+
+    for (uint32_t tile_id = 0; tile_id < num_tiles; ++tile_id) {
+#if BCAST_A
+        {
+            cb_wait_front(cb_pre_a, num_tiles_per_cycle);
+            cb_reserve_back(cb_bcast_a, num_tiles_per_cycle);
+            unary_bcast_init<BroadcastType::ROW>(cb_pre_a, cb_bcast_a);
+
+            tile_regs_acquire();
+            unary_bcast<BroadcastType::ROW>(cb_pre_a, 0, 0);
+            tile_regs_commit();
+
+            tile_regs_wait();
+            pack_tile(0, cb_bcast_a);
+            cb_push_back(cb_bcast_a, num_tiles_per_cycle);
+            tile_regs_release();
+
+            cb_pop_front(cb_pre_a, num_tiles_per_cycle);
+        }
+#endif
+
+#if BCAST_B
+        {
+            cb_wait_front(cb_pre_b, num_tiles_per_cycle);
+            cb_reserve_back(cb_bcast_b, num_tiles_per_cycle);
+            unary_bcast_init<BroadcastType::ROW>(cb_pre_b, cb_bcast_b);
+
+            tile_regs_acquire();
+            unary_bcast<BroadcastType::ROW>(cb_pre_b, 0, 0);
+            tile_regs_commit();
+
+            tile_regs_wait();
+            pack_tile(0, cb_bcast_b);
+            cb_push_back(cb_bcast_b, num_tiles_per_cycle);
+            tile_regs_release();
+
+            cb_pop_front(cb_pre_b, num_tiles_per_cycle);
+        }
+#endif
+
+#if BCAST_C
+        {
+            cb_wait_front(cb_pre_c, num_tiles_per_cycle);
+            cb_reserve_back(cb_bcast_c, num_tiles_per_cycle);
+            unary_bcast_init<BroadcastType::ROW>(cb_pre_c, cb_bcast_c);
+
+            tile_regs_acquire();
+            unary_bcast<BroadcastType::ROW>(cb_pre_c, 0, 0);
+            tile_regs_commit();
+
+            tile_regs_wait();
+            pack_tile(0, cb_bcast_c);
+            cb_push_back(cb_bcast_c, num_tiles_per_cycle);
+            tile_regs_release();
+
+            cb_pop_front(cb_pre_c, num_tiles_per_cycle);
+        }
+#endif
+
+        // Now execute the ternary SFPU operation on the effective inputs.
+        // Reserve output when ready to write.
+        cb_reserve_back(cb_out, num_tiles_per_cycle);
+
+        // Ensure fronts are ready for whichever CBs we will read from
+        cb_wait_front(cb_eff_a, num_tiles_per_cycle);
+        cb_wait_front(cb_eff_b, num_tiles_per_cycle);
+        cb_wait_front(cb_eff_c, num_tiles_per_cycle);
+
+        tile_regs_acquire();
+
+        // Load A -> DST[0], B -> DST[1], C -> DST[2]
+        copy_tile_to_dst_init_short(cb_eff_a);
+        copy_tile(cb_eff_a, 0, 0);
+
+        copy_tile_to_dst_init_short(cb_eff_b);
+        copy_tile(cb_eff_b, 0, 1);
+
+        copy_tile_to_dst_init_short(cb_eff_c);
+        copy_tile(cb_eff_c, 0, 2);
+
+        // Execute configured ternary SFPU op
+        TERNARY_SFPU_OP_INIT();
+        TERNARY_SFPU_OP_FUNC(0, 1, 2, 0);
+
+        tile_regs_commit();
+        tile_regs_wait();
+
+        // Write out result
+        pack_tile(0, cb_out);
+        tile_regs_release();
+
+        cb_push_back(cb_out, num_tiles_per_cycle);
+
+        // Pop fronts for the consumed inputs.
+        cb_pop_front(cb_eff_a, num_tiles_per_cycle);
+        cb_pop_front(cb_eff_b, num_tiles_per_cycle);
+        cb_pop_front(cb_eff_c, num_tiles_per_cycle);
+    }
+}
+}  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_op_utils.cpp
@@ -171,6 +171,7 @@ std::string get_kernel_file_path(KernelName kernel_name, bool is_fpu) {
 
         case KernelName::ComputeNoBcastTTT: return fmt::format(compute, root, "ternary_sfpu_no_bcast_ttt.cpp");
         case KernelName::ComputeBcastTTT: return fmt::format(compute, root, "ternary_sfpu_col_scalar_bcast_ttt.cpp");
+        case KernelName::ComputeRowBcastTTT: return fmt::format(compute, root, "ternary_sfpu_row_bcast_ttt.cpp");
         case KernelName::ComputeBcastTTS_TST:
             return fmt::format(compute, root, "ternary_sfpu_col_scalar_bcast_tts_tst.cpp");
         case KernelName::ComputeNoBcastTTS_TST: return fmt::format(compute, root, "ternary_sfpu_no_bcast_tts_tst.cpp");
@@ -179,6 +180,8 @@ std::string get_kernel_file_path(KernelName kernel_name, bool is_fpu) {
         case KernelName::ComputeBcastAddcmul:
             return fmt::format(
                 compute, root, is_fpu ? "ternary_addcmul_fpu_bcast.cpp" : "ternary_addcmul_sfpu_bcast.cpp");
+        case KernelName::ComputeRowBcastAddcmul:
+            return fmt::format(compute, root, is_fpu ? "ternary_addcmul_fpu_rowbcast.cpp" : "ternary_addcmul_sfpu.cpp");
         default: __builtin_unreachable();
     }
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_op_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_op_utils.hpp
@@ -31,12 +31,14 @@ enum class KernelName {
     ReaderRowBcastTST,
     ReaderRowBcastTTS,
     WriterColBcastTTT,
-    ComputeNoBcastTTT,      // TTT: no bcast, outer dim and row bcast cases
-    ComputeBcastTTT,        // TTT : column and scalar bcast cases
-    ComputeBcastTTS_TST,    // TTS, TST: column and scalar bcast cases
-    ComputeNoBcastTTS_TST,  // TTS, TST: no bcast, outer dim and row bcast cases
-    ComputeNoBcastAddcmul,  // ADDCMUL: no bcast, uses existing add/mul operations
-    ComputeBcastAddcmul,    // ADDCMUL: column and scalar bcast cases
+    ComputeNoBcastTTT,       // TTT: no bcast, outer dim and row bcast cases
+    ComputeBcastTTT,         // TTT : column and scalar bcast cases
+    ComputeRowBcastTTT,      // TTT : row bcast cases : bfloat16 only
+    ComputeBcastTTS_TST,     // TTS, TST: column and scalar bcast cases
+    ComputeNoBcastTTS_TST,   // TTS, TST: no bcast, outer dim and row bcast cases
+    ComputeNoBcastAddcmul,   // ADDCMUL: no bcast, uses existing add/mul operations
+    ComputeBcastAddcmul,     // ADDCMUL: column and scalar bcast cases
+    ComputeRowBcastAddcmul,  // ADDCMUL: row bcast cases : bfloat16 only
 };
 
 struct TernaryKernelConfig {


### PR DESCRIPTION
### Ticket
Link to Github Issue #32229 #29836

### Problem description
- Legacy Where op is composite takes 2 Binary operation ADD, MUL
- Where Device operation with fill tile for broadcasting Row is much slower

### What's changed
- added bcast_llk for ROW bcast in ternary TTT 
- It is faster than both approaches mentioned above

**Perf profiled for WHERE:** 
A(1, 1, 1, 1024), B (1, 1, 1024, 1024), C (1, 1, 1, 1024)
Without bcast_llk for ROW bcast  for bfloat16
<img width="395" height="43" alt="image" src="https://github.com/user-attachments/assets/3d8e0ed1-2fdd-4abe-ac26-a10a5b277e3d" />

With bcast_llk for ROW bcast  for bfloat16
<img width="394" height="43" alt="image" src="https://github.com/user-attachments/assets/9223af84-a887-4c06-9b07-f4acc701fdfd" />

**Perf profiled for ADDCMUL :** 
Shape profiled A [75600, 5120 ] B [ 1, 5120 ]
[75600] -> w padding 75616

Legacy Addcmul op - ROW Bcast ( uses Binary MUL, ADD with bcast_llk for 1 ROW bcast )
<img width="919" height="162" alt="image" src="https://github.com/user-attachments/assets/41027b31-1d39-4935-a0f7-5f183129fd37" />
Row Bcast with fill_tile  for bfloat16
<img width="956" height="101" alt="image" src="https://github.com/user-attachments/assets/21973a89-0d65-45fb-be9a-dda145971172" />
Row Bcast with bcast_llk for bfloat16
<img width="886" height="103" alt="image" src="https://github.com/user-attachments/assets/8721fbab-6257-464d-b981-663949bb9b83" />


### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/19292439047
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/19292444147

- [x] Nightly L2 eltwise https://github.com/tenstorrent/tt-metal/actions/runs/19292451353

- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [x] New/Existing tests provide coverage for changes