### PR TITLE
#0: Add support for posted multicast transactions

### DIFF
--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dedicated_noc_writer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dedicated_noc_writer.cpp
@@ -83,14 +83,19 @@ void kernel_main() {
 
         // Test mcast
         if (mcast) {
-            // write mcast
-            noc_async_write_multicast_one_packet(
-                l1_read_addr, mcast_addr_self_noc, page_size, num_dests - 1, false, noc);
-            noc_async_write_multicast(l1_read_addr, mcast_addr_self_noc, page_size, num_dests - 1, false, noc);
-            noc_async_write_multicast_loopback_src(l1_read_addr, mcast_addr_self_noc, page_size, num_dests, false, noc);
-            // semaphore mcast
-            noc_semaphore_set_multicast(l1_read_addr, mcast_addr_self_noc, num_dests - 1, false, noc);
-            noc_semaphore_set_multicast_loopback_src(l1_read_addr, mcast_addr_self_noc, num_dests, false, noc);
+            for (auto posted : {true, false}) {
+                // write mcast
+                noc_async_write_multicast_one_packet(
+                    l1_read_addr, mcast_addr_self_noc, page_size, num_dests - 1, false, posted, noc);
+                noc_async_write_multicast(
+                    l1_read_addr, mcast_addr_self_noc, page_size, num_dests - 1, false, posted, noc);
+                noc_async_write_multicast_loopback_src(
+                    l1_read_addr, mcast_addr_self_noc, page_size, num_dests, false, posted, noc);
+                // semaphore mcast
+                noc_semaphore_set_multicast(l1_read_addr, mcast_addr_self_noc, num_dests - 1, false, posted, noc);
+                noc_semaphore_set_multicast_loopback_src(
+                    l1_read_addr, mcast_addr_self_noc, num_dests, false, posted, noc);
+            }
         }
 
 // dw_write skip BH since there's HW issue

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dynamic_noc_writer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dynamic_noc_writer.cpp
@@ -103,33 +103,48 @@ void kernel_main() {
 
         // Test mcast
         if (mcast) {
-            // write mcast
-            noc_async_write_multicast_one_packet(
-                l1_read_addr,
-                noc == noc_index ? mcast_addr_self_noc : mcast_addr_other_noc,
-                page_size,
-                num_dests - 1,
-                false,
-                noc);
-            noc_async_write_multicast(
-                l1_read_addr,
-                noc == noc_index ? mcast_addr_self_noc : mcast_addr_other_noc,
-                page_size,
-                num_dests - 1,
-                false,
-                noc);
-            noc_async_write_multicast_loopback_src(
-                l1_read_addr,
-                noc == noc_index ? mcast_addr_self_noc : mcast_addr_other_noc,
-                page_size,
-                num_dests,
-                false,
-                noc);
-            // semaphore mcast
-            noc_semaphore_set_multicast(
-                l1_read_addr, noc == noc_index ? mcast_addr_self_noc : mcast_addr_other_noc, num_dests - 1, false, noc);
-            noc_semaphore_set_multicast_loopback_src(
-                l1_read_addr, noc == noc_index ? mcast_addr_self_noc : mcast_addr_other_noc, num_dests, false, noc);
+            for (auto posted : {true, false}) {
+                // write mcast
+                noc_async_write_multicast_one_packet(
+                    l1_read_addr,
+                    noc == noc_index ? mcast_addr_self_noc : mcast_addr_other_noc,
+                    page_size,
+                    num_dests - 1,
+                    false,
+                    posted,
+                    noc);
+                noc_async_write_multicast(
+                    l1_read_addr,
+                    noc == noc_index ? mcast_addr_self_noc : mcast_addr_other_noc,
+                    page_size,
+                    num_dests - 1,
+                    false,
+                    posted,
+                    noc);
+                noc_async_write_multicast_loopback_src(
+                    l1_read_addr,
+                    noc == noc_index ? mcast_addr_self_noc : mcast_addr_other_noc,
+                    page_size,
+                    num_dests,
+                    false,
+                    posted,
+                    noc);
+                // semaphore mcast
+                noc_semaphore_set_multicast(
+                    l1_read_addr,
+                    noc == noc_index ? mcast_addr_self_noc : mcast_addr_other_noc,
+                    num_dests - 1,
+                    false,
+                    posted,
+                    noc);
+                noc_semaphore_set_multicast_loopback_src(
+                    l1_read_addr,
+                    noc == noc_index ? mcast_addr_self_noc : mcast_addr_other_noc,
+                    num_dests,
+                    false,
+                    posted,
+                    noc);
+            }
         }
 
 // dw_write skip BH since there's HW issue

--- a/tt_metal/hw/inc/dataflow_api_addrgen.h
+++ b/tt_metal/hw/inc/dataflow_api_addrgen.h
@@ -149,6 +149,7 @@ inline constexpr bool has_required_addrgen_traits_v =
 // clang-format off
 /**
  * Get an encoding for a noc address which contains Tensix core grid and L1 address.
+ * This API expects the start and end coordinates to be appropriately ordered for the specific NOC.
  *
  * Return value: uint64_t
  *
@@ -176,6 +177,43 @@ uint64_t get_noc_multicast_addr(
         DYNAMIC_NOC_X(noc, noc_x_end),
         DYNAMIC_NOC_Y(noc, noc_y_end),
         addr);
+}
+
+// clang-format off
+/**
+ * Get an encoding for a noc address which contains Tensix core grid and L1 address.
+ * This API expects the start coordinate to be the top-right core and the end coordinate to be the bottom-left core.
+ *
+ * Return value: uint64_t
+ *
+ * | Argument    | Description                             | Data type | Valid range        | required |
+ * |-------------|-----------------------------------------|-----------|--------------------|----------|
+ * | noc_x_start | Physical x coordinate of the start core | uint32_t  | WH: 0-9, BH: 0-16  | True     |
+ * | noc_y_start | Physical y coordinate of the start core | uint32_t  | WH: 0-11, BH: 0-11 | True     |
+ * | noc_x_end   | Physical x coordinate of the end core   | uint32_t  | WH: 0-9, BH: 0-16  | True     |
+ * | noc_y_end   | Physical y coordinate of the end core   | uint32_t  | WH: 0-11, BH: 0-11 | True     |
+ * | addr        | Address in local L1 memory              | uint32_t  | 0..1MB             | True     |
+ * | noc         | Which NOC to use for the transaction    | uint8_t   | 0 or 1             | False    |
+ */
+// clang-format on
+template <uint8_t noc>
+FORCE_INLINE uint64_t get_noc_multicast_addr(
+    uint32_t noc_x_start, uint32_t noc_y_start, uint32_t noc_x_end, uint32_t noc_y_end, uint32_t addr) {
+    if constexpr (noc == 0) {
+        return NOC_MULTICAST_ADDR(
+            DYNAMIC_NOC_X(noc, noc_x_start),
+            DYNAMIC_NOC_Y(noc, noc_y_start),
+            DYNAMIC_NOC_X(noc, noc_x_end),
+            DYNAMIC_NOC_Y(noc, noc_y_end),
+            addr);
+    } else {
+        return NOC_MULTICAST_ADDR(
+            DYNAMIC_NOC_X(noc, noc_x_end),
+            DYNAMIC_NOC_Y(noc, noc_y_end),
+            DYNAMIC_NOC_X(noc, noc_x_start),
+            DYNAMIC_NOC_Y(noc, noc_y_start),
+            addr);
+    }
 }
 
 // clang-format off

--- a/tt_metal/hw/inc/tt-1xx/wormhole/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/tt-1xx/wormhole/noc_nonblocking_api.h
@@ -241,15 +241,20 @@ inline __attribute__((always_inline)) void ncrisc_noc_fast_write_loopback_src(
     bool mcast,
     bool linked,
     uint32_t num_dests,
-    bool multicast_path_reserve) {
+    bool multicast_path_reserve,
+    bool posted = false) {
     if constexpr (noc_mode == DM_DYNAMIC_NOC) {
-        inc_noc_counter_val<proc_type, NocBarrierType::NONPOSTED_WRITES_NUM_ISSUED>(noc, 1);
-        inc_noc_counter_val<proc_type, NocBarrierType::NONPOSTED_WRITES_ACKED>(noc, num_dests);
+        if (posted) {
+            inc_noc_counter_val<proc_type, NocBarrierType::POSTED_WRITES_NUM_ISSUED>(noc, 1);
+        } else {
+            inc_noc_counter_val<proc_type, NocBarrierType::NONPOSTED_WRITES_NUM_ISSUED>(noc, 1);
+            inc_noc_counter_val<proc_type, NocBarrierType::NONPOSTED_WRITES_ACKED>(noc, num_dests);
+        }
     }
     uint32_t noc_cmd_field =
         NOC_CMD_CPY | NOC_CMD_WR | NOC_CMD_VC_STATIC | NOC_CMD_STATIC_VC(vc) | (linked ? NOC_CMD_VC_LINKED : 0x0) |
         (mcast ? ((multicast_path_reserve ? NOC_CMD_PATH_RESERVE : 0) | NOC_CMD_BRCST_PACKET) : 0x0) |
-        NOC_CMD_BRCST_SRC_INCLUDE | NOC_CMD_RESP_MARKED;
+        NOC_CMD_BRCST_SRC_INCLUDE | (posted ? 0 : NOC_CMD_RESP_MARKED);
 
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_CTRL, noc_cmd_field);
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_LO, src_addr);
@@ -258,8 +263,12 @@ inline __attribute__((always_inline)) void ncrisc_noc_fast_write_loopback_src(
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_AT_LEN_BE, len_bytes);
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_CMD_CTRL, NOC_CTRL_SEND_REQ);
     if constexpr (noc_mode == DM_DEDICATED_NOC) {
-        noc_nonposted_writes_num_issued[noc] += 1;
-        noc_nonposted_writes_acked[noc] += num_dests;
+        if (posted) {
+            noc_posted_writes_num_issued[noc] += 1;
+        } else {
+            noc_nonposted_writes_num_issued[noc] += 1;
+            noc_nonposted_writes_acked[noc] += num_dests;
+        }
     }
 }
 
@@ -553,7 +562,7 @@ inline __attribute__((always_inline)) void ncrisc_noc_fast_write_any_len(
         trid);
 }
 
-template <uint8_t noc_mode = DM_DEDICATED_NOC>
+template <uint8_t noc_mode = DM_DEDICATED_NOC, bool one_packet = false>
 inline __attribute__((always_inline)) void ncrisc_noc_fast_write_any_len_loopback_src(
     uint32_t noc,
     uint32_t cmd_buf,
@@ -564,27 +573,31 @@ inline __attribute__((always_inline)) void ncrisc_noc_fast_write_any_len_loopbac
     bool mcast,
     bool linked,
     uint32_t num_dests,
-    bool multicast_path_reserve) {
-    while (len_bytes > NOC_MAX_BURST_SIZE) {
-        while (!noc_cmd_buf_ready(noc, cmd_buf));
-        ncrisc_noc_fast_write_loopback_src<noc_mode>(
-            noc,
-            cmd_buf,
-            src_addr,
-            dest_addr,
-            NOC_MAX_BURST_SIZE,
-            vc,
-            mcast,
-            linked,
-            num_dests,
-            multicast_path_reserve);
-        src_addr += NOC_MAX_BURST_SIZE;
-        dest_addr += NOC_MAX_BURST_SIZE;
-        len_bytes -= NOC_MAX_BURST_SIZE;
+    bool multicast_path_reserve,
+    bool posted = false) {
+    if constexpr (!one_packet) {
+        while (len_bytes > NOC_MAX_BURST_SIZE) {
+            while (!noc_cmd_buf_ready(noc, cmd_buf));
+            ncrisc_noc_fast_write_loopback_src<noc_mode>(
+                noc,
+                cmd_buf,
+                src_addr,
+                dest_addr,
+                NOC_MAX_BURST_SIZE,
+                vc,
+                mcast,
+                linked,
+                num_dests,
+                multicast_path_reserve,
+                posted);
+            src_addr += NOC_MAX_BURST_SIZE;
+            dest_addr += NOC_MAX_BURST_SIZE;
+            len_bytes -= NOC_MAX_BURST_SIZE;
+        }
     }
     while (!noc_cmd_buf_ready(noc, cmd_buf));
     ncrisc_noc_fast_write_loopback_src<noc_mode>(
-        noc, cmd_buf, src_addr, dest_addr, len_bytes, vc, mcast, linked, num_dests, multicast_path_reserve);
+        noc, cmd_buf, src_addr, dest_addr, len_bytes, vc, mcast, linked, num_dests, multicast_path_reserve, posted);
 }
 
 // `dst_type` is "Don't care" on Wormhole, it's required on Blackhole to workaround bug that manifests with noc

--- a/tt_metal/hw/inc/tt-2xx/quasar/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/tt-2xx/quasar/noc_nonblocking_api.h
@@ -280,15 +280,20 @@ inline __attribute__((always_inline)) void ncrisc_noc_fast_write_loopback_src(
     bool mcast,
     bool linked,
     uint32_t num_dests,
-    bool multicast_path_reserve) {
+    bool multicast_path_reserve,
+    bool posted = false) {
     if constexpr (noc_mode == DM_DYNAMIC_NOC) {
-        inc_noc_counter_val<proc_type, NocBarrierType::NONPOSTED_WRITES_NUM_ISSUED>(noc, 1);
-        inc_noc_counter_val<proc_type, NocBarrierType::NONPOSTED_WRITES_ACKED>(noc, num_dests);
+        if (posted) {
+            inc_noc_counter_val<proc_type, NocBarrierType::POSTED_WRITES_NUM_ISSUED>(noc, 1);
+        } else {
+            inc_noc_counter_val<proc_type, NocBarrierType::NONPOSTED_WRITES_NUM_ISSUED>(noc, 1);
+            inc_noc_counter_val<proc_type, NocBarrierType::NONPOSTED_WRITES_ACKED>(noc, num_dests);
+        }
     }
     uint32_t noc_cmd_field =
         NOC_CMD_CPY | NOC_CMD_WR | NOC_CMD_VC_STATIC | NOC_CMD_STATIC_VC(vc) | (linked ? NOC_CMD_VC_LINKED : 0x0) |
         (mcast ? ((multicast_path_reserve ? NOC_CMD_PATH_RESERVE : 0) | NOC_CMD_BRCST_PACKET) : 0x0) |
-        NOC_BRCST_SRC_INCLUDE | NOC_CMD_RESP_MARKED;
+        NOC_BRCST_SRC_INCLUDE | (posted ? 0 : NOC_CMD_RESP_MARKED);
 
     // NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_CTRL, noc_cmd_field);
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_LO, src_addr);
@@ -300,8 +305,12 @@ inline __attribute__((always_inline)) void ncrisc_noc_fast_write_loopback_src(
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_AT_LEN, len_bytes);
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_CMD_CTRL, NOC_CTRL_SEND_REQ);
     if constexpr (noc_mode == DM_DEDICATED_NOC) {
-        noc_nonposted_writes_num_issued[noc] += 1;
-        noc_nonposted_writes_acked[noc] += num_dests;
+        if (posted) {
+            noc_posted_writes_num_issued[noc] += 1;
+        } else {
+            noc_nonposted_writes_num_issued[noc] += 1;
+            noc_nonposted_writes_acked[noc] += num_dests;
+        }
     }
 }
 
@@ -649,7 +658,7 @@ inline __attribute__((always_inline)) void ncrisc_noc_fast_write_any_len(
         trid);
 }
 
-template <uint8_t noc_mode = DM_DEDICATED_NOC>
+template <uint8_t noc_mode = DM_DEDICATED_NOC, bool one_packet = false>
 inline __attribute__((always_inline)) void ncrisc_noc_fast_write_any_len_loopback_src(
     uint32_t noc,
     uint32_t cmd_buf,
@@ -660,27 +669,31 @@ inline __attribute__((always_inline)) void ncrisc_noc_fast_write_any_len_loopbac
     bool mcast,
     bool linked,
     uint32_t num_dests,
-    bool multicast_path_reserve) {
-    while (len_bytes > NOC_MAX_BURST_SIZE) {
-        while (!noc_cmd_buf_ready(noc, cmd_buf));
-        ncrisc_noc_fast_write_loopback_src<noc_mode>(
-            noc,
-            cmd_buf,
-            src_addr,
-            dest_addr,
-            NOC_MAX_BURST_SIZE,
-            vc,
-            mcast,
-            linked,
-            num_dests,
-            multicast_path_reserve);
-        src_addr += NOC_MAX_BURST_SIZE;
-        dest_addr += NOC_MAX_BURST_SIZE;
-        len_bytes -= NOC_MAX_BURST_SIZE;
+    bool multicast_path_reserve,
+    bool posted = false) {
+    if constexpr (!one_packet) {
+        while (len_bytes > NOC_MAX_BURST_SIZE) {
+            while (!noc_cmd_buf_ready(noc, cmd_buf));
+            ncrisc_noc_fast_write_loopback_src<noc_mode>(
+                noc,
+                cmd_buf,
+                src_addr,
+                dest_addr,
+                NOC_MAX_BURST_SIZE,
+                vc,
+                mcast,
+                linked,
+                num_dests,
+                multicast_path_reserve,
+                posted);
+            src_addr += NOC_MAX_BURST_SIZE;
+            dest_addr += NOC_MAX_BURST_SIZE;
+            len_bytes -= NOC_MAX_BURST_SIZE;
+        }
     }
     while (!noc_cmd_buf_ready(noc, cmd_buf));
     ncrisc_noc_fast_write_loopback_src<noc_mode>(
-        noc, cmd_buf, src_addr, dest_addr, len_bytes, vc, mcast, linked, num_dests, multicast_path_reserve);
+        noc, cmd_buf, src_addr, dest_addr, len_bytes, vc, mcast, linked, num_dests, multicast_path_reserve, posted);
 }
 
 template <uint8_t noc_mode = DM_DEDICATED_NOC, InlineWriteDst dst_type = InlineWriteDst::DEFAULT, bool flush = true>


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
We did not expose posted flag for noc multicast transactions.
`noc_async_write_multicast` did not pass the `noc` argument to `noc_async_write_multicast_one_packet`, so a different noc might have been used then what the user set.
`noc_async_write_multicast_loopback_src` did not support skipping the while loop when it is known to only be a single packet.

### What's changed
Add posted flag for noc multicast transactions.
Pass `noc` arg to downstream fn.
Add one packet support to `noc_async_write_multicast_loopback_src` fns.
Add a templated `get_noc_multicast_addr` templated on noc, which will reorder the mcast noc coords appropriately for the target noc. This removes the burden on the user on determining what the ordering of coords should be, and should always pass top right as the start coord. Keep the existing API the same for backwards compatibility.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes