### PR TITLE
feat: use loadmacro to optimize where op

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_ternary_sfpu_where.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_ternary_sfpu_where.h
@@ -23,5 +23,6 @@ inline void llk_math_eltwise_ternary_sfpu_where(
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_ternary_sfpu_where_init() {
     _llk_math_eltwise_ternary_sfpu_init_<SfpuType::where>();
+    ckernel::sfpu::_init_where_<APPROXIMATE>();
 }
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_ternary_sfpu_where.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_ternary_sfpu_where.h
@@ -23,5 +23,6 @@ inline void llk_math_eltwise_ternary_sfpu_where(
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_ternary_sfpu_where_init() {
     _llk_math_eltwise_ternary_sfpu_init_<SfpuType::where>();
+    ckernel::sfpu::_init_where_<APPROXIMATE>();
 }
 }  // namespace ckernel


### PR DESCRIPTION
This is a copy of https://github.com/tenstorrent/tt-metal/pull/32122 by @jasondavies. Previous PR couldn't pass ttsim checks due to the fact that it's coming from a fork with insufficient permissions to run these tests.

### Ticket
https://github.com/tenstorrent/tt-metal/issues/31802

### Problem description
where can be optimised via SFPLOADMACRO.

### What's changed
See https://github.com/tenstorrent/tt-llk/pull/822 for more details. A new _init_where_ function needs to be called to configure the macros.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/19270054122) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/19270066736) CI with demo tests passes
- [x] [APC + BH PC C++ tests](https://github.com/tenstorrent/tt-metal/actions/runs/19270803149) CI passes