### PR TITLE
[TT-Train] Fix MatmulsTest device lifecycle leak by using TEST_F macro

### DIFF
--- a/tt-train/tests/ttnn_fixed/matmuls_test.cpp
+++ b/tt-train/tests/ttnn_fixed/matmuls_test.cpp
@@ -76,7 +76,7 @@ namespace {
 
 namespace ttml::ttnn_fixed::tests {
 
-TEST(MatmulsTest, MatMulNoTranspose) {
+TEST_F(MatmulsTest, MatMulNoTranspose) {
     // Create simple matrices.
     xt::xarray<float> a = {{1, 2}, {3, 4}};
     xt::xarray<float> b = {{5, 6}, {7, 8}};
@@ -94,7 +94,7 @@ TEST(MatmulsTest, MatMulNoTranspose) {
     EXPECT_TRUE(xt::allclose(y, expected));
 }
 
-TEST(MatmulsTest, MatMulTransposeA) {
+TEST_F(MatmulsTest, MatMulTransposeA) {
     xt::xarray<float> a = {{1, 2}, {3, 4}};
     xt::xarray<float> b = {{5, 6}, {7, 8}};
 
@@ -110,7 +110,7 @@ TEST(MatmulsTest, MatMulTransposeA) {
     EXPECT_TRUE(xt::allclose(y, expected));
 }
 
-TEST(MatmulsTest, MatMulTransposeB) {
+TEST_F(MatmulsTest, MatMulTransposeB) {
     xt::xarray<float> a = {{1, 2}, {3, 4}};
     xt::xarray<float> b = {{5, 6}, {7, 8}};
 
@@ -126,7 +126,7 @@ TEST(MatmulsTest, MatMulTransposeB) {
     EXPECT_TRUE(xt::allclose(y, expected));
 }
 
-TEST(MatmulsTest, MatMulTransposeBoth) {
+TEST_F(MatmulsTest, MatMulTransposeBoth) {
     xt::xarray<float> a = {{1, 2}, {3, 4}};
     xt::xarray<float> b = {{5, 6}, {7, 8}};
 
@@ -142,7 +142,7 @@ TEST(MatmulsTest, MatMulTransposeBoth) {
     EXPECT_TRUE(xt::allclose(y, expected));
 }
 
-TEST(MatmulsTest, MatMulBackwardNoTranspose) {
+TEST_F(MatmulsTest, MatMulBackwardNoTranspose) {
     // Create matrices and an output gradient.
     xt::xarray<float> a = {{1, 2}, {3, 4}};
     xt::xarray<float> b = {{5, 6}, {7, 8}};
@@ -167,7 +167,7 @@ TEST(MatmulsTest, MatMulBackwardNoTranspose) {
     EXPECT_TRUE(xt::allclose(grad_b, expected_grad_b));
 }
 
-TEST(MatmulsTest, MatMulBackwardTransposeA) {
+TEST_F(MatmulsTest, MatMulBackwardTransposeA) {
     // Test backward with transpose_a = true.
     xt::xarray<float> a = {{1, 2}, {3, 4}};
     xt::xarray<float> b = {{5, 6}, {7, 8}};
@@ -191,7 +191,7 @@ TEST(MatmulsTest, MatMulBackwardTransposeA) {
     EXPECT_TRUE(xt::allclose(grad_b, expected_grad_b));
 }
 
-TEST(MatmulsTest, MatMulBackwardTransposeB) {
+TEST_F(MatmulsTest, MatMulBackwardTransposeB) {
     // Test backward with transpose_b = true.
     xt::xarray<float> a = {{1, 2}, {3, 4}};
     xt::xarray<float> b = {{5, 6}, {7, 8}};
@@ -215,7 +215,7 @@ TEST(MatmulsTest, MatMulBackwardTransposeB) {
     EXPECT_TRUE(xt::allclose(grad_b, expected_grad_b));
 }
 
-TEST(MatmulsTest, MatMulBackwardTransposeBoth) {
+TEST_F(MatmulsTest, MatMulBackwardTransposeBoth) {
     // Test backward with both transpose flags true.
     xt::xarray<float> a = {{1, 2}, {3, 4}};
     xt::xarray<float> b = {{5, 6}, {7, 8}};


### PR DESCRIPTION
### Ticket
Fixes #32252

### Problem description

**Test-interaction bug:** `ReduceOpTest.TestMeanDim0` passes when run individually but fails after `MatmulsTest` with error:
```
"open_device was called after the device was created."
```

**Root Cause:**
`MatmulsTest` defined a GoogleTest fixture with `SetUp()` and `TearDown()` methods for proper device lifecycle management, but all 8 test functions incorrectly used the `TEST()` macro instead of `TEST_F()`.

This is a classic GoogleTest mistake - the fixture class exists but is never used because the tests don't inherit from it. As a result:
- Fixture `SetUp()` and `TearDown()` methods are never executed
- Device opens implicitly on first `ctx().get_device()` call
- Device never closes (TearDown not called)
- Subsequent tests expecting a closed device fail

This bug only manifests when tests run sequentially (in the full test suite), not when run individually, making it a true test-interaction issue as described by the branch name `ttml-test-fails-in-bunch-runs-alone-bug`.

### What's changed

**Fix:** Changed `TEST()` to `TEST_F()` for all 8 MatmulsTest functions to properly activate the fixture.

**Files Modified:**
- `tt-train/tests/ttnn_fixed/matmuls_test.cpp` (lines 79, 97, 113, 129, 145, 170, 194, 218)
- 8 insertions, 8 deletions (one character addition per line: `_F`)

**Impact:**
- ✅ Device lifecycle now managed correctly (opens in SetUp(), closes in TearDown())
- ✅ Resolves test-interaction failure of `ReduceOpTest.TestMeanDim0`
- ✅ All MatmulsTest tests properly initialize and cleanup device resources
- ✅ Test suite can run without device lifecycle conflicts

**Testing:**
- Verified all 8 MatmulsTest tests pass with proper device lifecycle
- Verified ReduceOpTest.TestMeanDim0 now passes after MatmulsTest
- Tested 3 consecutive test groups (TrivialTnnFixedTest + MatmulsTest + ReduceOpTest = 24 tests)
- Result: 100% pass rate, no side effects on preceding or subsequent tests


### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [x] New/Existing tests provide coverage for changes