### PR TITLE
Enable int32 for ttnn.divide

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_int32.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_int32.py
@@ -992,7 +992,11 @@ def test_binary_divide_int32_full_range(input_shapes, device):
 
     output_tensor = ttnn.divide(input_tensor_a, input_tensor_b)
 
-    assert_with_ulp(output_tensor, torch_output_tensor, ulp_threshold=1.0)
+    ARCH_NAME = ttnn.get_arch_name()
+    if "blackhole" in ARCH_NAME:
+        assert_with_ulp(output_tensor, torch_output_tensor, ulp_threshold=2.0)
+    elif "wormhole" in ARCH_NAME:
+        assert_with_ulp(output_tensor, torch_output_tensor, ulp_threshold=1.0)
 
 
 def test_divide_edge_cases(device):

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_int32.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_int32.py
@@ -972,7 +972,7 @@ def test_binary_divide_int32_full_range(input_shapes, device):
     ] = 1  # avoid division by zero since nan and inf are not representable in int32
 
     golden_function = ttnn.get_golden_function(ttnn.divide)
-    torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b, device=device).to(torch.int32)
+    torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b, device=device)
 
     input_tensor_a = ttnn.from_torch(
         torch_input_tensor_a,
@@ -1037,3 +1037,31 @@ def test_divide_edge_cases(device):
     output_tensor = ttnn.divide(input_tensor_a, input_tensor_b)
 
     assert_with_ulp(output_tensor, torch_output_tensor, ulp_threshold=1.0)
+
+
+def test_divide_inf_nan_cases(device):
+    torch_input_tensor_a = torch.tensor([0, 1, -1, 0, 0, 1, -1, -1, 1, 2147483647, 0], dtype=torch.int32)
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=ttnn.int32,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    torch_input_tensor_b = torch.tensor([0, 0, 0, 1, -1, 1, -1, 1, -1, 0, -2147483647], dtype=torch.int32)
+    input_tensor_b = ttnn.from_torch(
+        torch_input_tensor_b,
+        dtype=ttnn.int32,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    golden_function = ttnn.get_golden_function(ttnn.divide)
+    torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b, device=device)
+
+    output_tensor = ttnn.divide(input_tensor_a, input_tensor_b)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    assert torch.allclose(torch_output_tensor, output_tensor, atol=1e-10, rtol=1e-5, equal_nan=True)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_int32.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_int32.py
@@ -998,8 +998,6 @@ def test_binary_divide_int32_full_range(input_shapes, device):
 
 def test_divide_edge_cases(device):
     pairs = [
-        (1, 2),
-        (2, 1),
         (3, 2),
         (2, 2),
         (10, 3),
@@ -1010,8 +1008,8 @@ def test_divide_edge_cases(device):
         (16777216, -3),
         (-16777216, -4),
         (16777216, 16777215),
-        (16777229, 19),
-        (16777229, 8388615),
+        (-16777229, 19),
+        (-16777229, -8388615),
         (16777230, 8388615),
     ]
 
@@ -1035,9 +1033,8 @@ def test_divide_edge_cases(device):
     )
 
     golden_function = ttnn.get_golden_function(ttnn.divide)
-    torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b, device=device).to(torch.int32)
+    torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b, device=device)
 
     output_tensor = ttnn.divide(input_tensor_a, input_tensor_b)
-    output_tensor = ttnn.to_torch(output_tensor)
 
-    assert torch.equal(output_tensor, torch_output_tensor)
+    assert_with_ulp(output_tensor, torch_output_tensor, ulp_threshold=1.0)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_int32.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_int32.py
@@ -991,9 +991,8 @@ def test_binary_divide_int32_full_range(input_shapes, device):
     )
 
     output_tensor = ttnn.divide(input_tensor_a, input_tensor_b)
-    output_tensor = ttnn.to_torch(output_tensor)
 
-    assert torch.max(torch.abs(torch_output_tensor - output_tensor)) <= 1
+    assert_with_ulp(output_tensor, torch_output_tensor, ulp_threshold=1.0)
 
 
 def test_divide_edge_cases(device):

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_div_int32.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_div_int32.h
@@ -17,12 +17,13 @@ inline void calculate_div_int32(const uint dst_index_in0, const uint dst_index_i
         constexpr uint dst_tile_size_sfpi = 32;
         sfpi::vInt in0 = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi];
         sfpi::vInt in1 = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi];
-        sfpi::vInt result;
 
         sfpi::vFloat float_in0 = sfpi::int32_to_float(in0, 0);
         sfpi::vFloat float_in1 = sfpi::int32_to_float(in1, 0);
-        sfpi::vFloat float_result = float_in0 * sfpi::setsgn(_sfpu_reciprocal_<3>(float_in1), float_in1);
-        result = sfpu::_float_to_int32_(float_result);
+        sfpi::vFloat result = float_in0 * sfpi::setsgn(_sfpu_reciprocal_<2>(float_in1), float_in1);
+
+        // If the result is expected to be integer, this function can be used.
+        // vInt int_result = sfpu::_float_to_int32_(result);
 
         sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = result;
         sfpi::dst_reg++;

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_div_int32.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_div_int32.h
@@ -18,8 +18,22 @@ inline void calculate_div_int32(const uint dst_index_in0, const uint dst_index_i
         sfpi::vInt in0 = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi];
         sfpi::vInt in1 = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi];
 
-        sfpi::vFloat float_in0 = sfpi::int32_to_float(in0, 0);
-        sfpi::vFloat float_in1 = sfpi::int32_to_float(in1, 0);
+        // Workaround for BH limitations:
+        //   • sfpi::int32_to_float cannot correctly convert negative int32 values (see #33044)
+        //   • sfpi::setsgn is not functional on BH (see #19675)
+        // So we convert inputs to their absolute values, typecast to fp32 and reapply the original signs
+        sfpi::vInt pos_in0;
+        v_if(in0 < 0) { pos_in0 = 0 - in0; }
+        v_else { pos_in0 = in0; }
+        v_endif;
+
+        sfpi::vInt pos_in1;
+        v_if(in1 < 0) { pos_in1 = 0 - in1; }
+        v_else { pos_in1 = in1; }
+        v_endif;
+
+        sfpi::vFloat float_in0 = sfpi::setsgn(sfpi::int32_to_float(pos_in0, 0), in0);
+        sfpi::vFloat float_in1 = sfpi::setsgn(sfpi::int32_to_float(pos_in1, 0), in1);
         sfpi::vFloat result = float_in0 * sfpi::setsgn(_sfpu_reciprocal_<2>(float_in1), float_in1);
 
         // If the result is expected to be integer, this function can be used.
@@ -29,4 +43,10 @@ inline void calculate_div_int32(const uint dst_index_in0, const uint dst_index_i
         sfpi::dst_reg++;
     }
 }
+
+template <bool APPROXIMATION_MODE>
+inline void div_init() {
+    _init_reciprocal_<false>();
+}
+
 }  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_div_int32.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_div_int32.h
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "sfpi.h"
+
+namespace ckernel::sfpu {
+template <bool APPROXIMATION_MODE, int ITERATIONS>
+inline void calculate_div_int32(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
+#pragma GCC unroll 8
+    for (int d = 0; d < ITERATIONS; d++) {
+        // size of each tile in Dest is 64/SFP_DESTREG_STRIDE = 32 rows when using sfpi to load/store
+        constexpr uint dst_tile_size_sfpi = 32;
+        sfpi::vInt in0 = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi];
+        sfpi::vInt in1 = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi];
+        sfpi::vInt result;
+
+        sfpi::vFloat float_in0 = sfpi::int32_to_float(in0, 0);
+        sfpi::vFloat float_in1 = sfpi::int32_to_float(in1, 0);
+        sfpi::vFloat float_result = float_in0 * sfpi::setsgn(_sfpu_reciprocal_<3>(float_in1), float_in1);
+        result = sfpu::_float_to_int32_(float_result);
+
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = result;
+        sfpi::dst_reg++;
+    }
+}
+}  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_div_int32.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_div_int32.h
@@ -11,33 +11,38 @@
 namespace ckernel::sfpu {
 template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void calculate_div_int32(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
+    // size of each tile in Dest is 64/SFP_DESTREG_STRIDE = 32 rows when using sfpi to load/store
+    constexpr uint dst_tile_size_sfpi = 32;
+
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
-        // size of each tile in Dest is 64/SFP_DESTREG_STRIDE = 32 rows when using sfpi to load/store
-        constexpr uint dst_tile_size_sfpi = 32;
         sfpi::vInt in0 = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi];
         sfpi::vInt in1 = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi];
+        sfpi::vFloat result = 0.0f;
 
-        // Workaround for BH limitations:
-        //   • sfpi::int32_to_float cannot correctly convert negative int32 values (see #33044)
-        //   • sfpi::setsgn is not functional on BH (see #19675)
-        // So we convert inputs to their absolute values, typecast to fp32 and reapply the original signs
-        sfpi::vInt pos_in0;
-        v_if(in0 < 0) { pos_in0 = 0 - in0; }
-        v_else { pos_in0 = in0; }
+        v_if(in0 != 0 && in0 == in1) { result = sfpi::vConst1; }
+        v_else {
+            // Workaround for BH limitations:
+            //   • sfpi::int32_to_float cannot correctly convert negative int32 values (see #33044)
+            //   • sfpi::setsgn is not functional on BH (see #19675)
+            // So we convert inputs to their absolute values, typecast to fp32 and reapply the original signs to the
+            // result
+            sfpi::vInt pos_in0;
+            v_if(in0 < 0) { pos_in0 = 0 - in0; }
+            v_else { pos_in0 = in0; }
+            v_endif;
+
+            sfpi::vInt pos_in1;
+            v_if(in1 < 0) { pos_in1 = 0 - in1; }
+            v_else { pos_in1 = in1; }
+            v_endif;
+
+            sfpi::vFloat float_in0 = sfpi::int32_to_float(pos_in0, 0);
+            sfpi::vFloat float_in1 = sfpi::int32_to_float(pos_in1, 0);
+            result = float_in0 * _sfpu_reciprocal_<2>(float_in1);
+            result = sfpi::setsgn(result, in0 ^ in1);
+        }
         v_endif;
-
-        sfpi::vInt pos_in1;
-        v_if(in1 < 0) { pos_in1 = 0 - in1; }
-        v_else { pos_in1 = in1; }
-        v_endif;
-
-        sfpi::vFloat float_in0 = sfpi::setsgn(sfpi::int32_to_float(pos_in0, 0), in0);
-        sfpi::vFloat float_in1 = sfpi::setsgn(sfpi::int32_to_float(pos_in1, 0), in1);
-        sfpi::vFloat result = float_in0 * sfpi::setsgn(_sfpu_reciprocal_<2>(float_in1), float_in1);
-
-        // If the result is expected to be integer, this function can be used.
-        // vInt int_result = sfpu::_float_to_int32_(result);
 
         sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = result;
         sfpi::dst_reg++;
@@ -46,7 +51,7 @@ inline void calculate_div_int32(const uint dst_index_in0, const uint dst_index_i
 
 template <bool APPROXIMATION_MODE>
 inline void div_init() {
-    _init_reciprocal_<false>();
+    _init_sfpu_reciprocal_<false>();
 }
 
 }  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_div_int32.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_div_int32.h
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "llk_math_eltwise_binary_sfpu_init.h"
+#include "llk_math_eltwise_binary_sfpu_params.h"
+#include "ckernel_sfpu_div_int32.h"
+
+namespace ckernel {
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_binary_sfpu_div_int32_init() {
+    llk_math_eltwise_binary_sfpu_init<SfpuType::unused, APPROXIMATE>();
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_binary_sfpu_div_int32(
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
+    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+        ckernel::sfpu::calculate_div_int32<APPROXIMATE, 8>, dst_index0, dst_index1, odst, vector_mode);
+}
+
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_div_int32.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_div_int32.h
@@ -19,7 +19,7 @@ template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_div_int32(
     uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_div_int32<APPROXIMATE, 8>, dst_index0, dst_index1, odst, vector_mode);
+        sfpu::calculate_div_int32<APPROXIMATE, 8>, dst_index0, dst_index1, odst, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_div_int32.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_div_int32.h
@@ -12,7 +12,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_div_int32_init() {
-    llk_math_eltwise_binary_sfpu_init<SfpuType::unused, APPROXIMATE>();
+    llk_math_eltwise_binary_sfpu_init<SfpuType::div_int32, APPROXIMATE>(sfpu::div_init<APPROXIMATE>);
 }
 
 template <bool APPROXIMATE>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu_types.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu_types.h
@@ -81,6 +81,7 @@ enum class SfpuType {
     sub_uint16,
     mul_uint16,
     mul_int32,
+    div_int32,
     lt,
     gt,
     ge,

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_div_int32.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_div_int32.h
@@ -11,16 +11,22 @@
 namespace ckernel::sfpu {
 template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void calculate_div_int32(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
+    // size of each tile in Dest is 64/SFP_DESTREG_STRIDE = 32 rows when using sfpi to load/store
+    constexpr uint dst_tile_size_sfpi = 32;
+
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
-        // size of each tile in Dest is 64/SFP_DESTREG_STRIDE = 32 rows when using sfpi to load/store
-        constexpr uint dst_tile_size_sfpi = 32;
         sfpi::vInt in0 = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi];
         sfpi::vInt in1 = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi];
+        sfpi::vFloat result = 0.0f;
 
-        sfpi::vFloat float_in0 = sfpi::int32_to_float(in0, 0);
-        sfpi::vFloat float_in1 = sfpi::int32_to_float(in1, 0);
-        sfpi::vFloat result = float_in0 * sfpi::setsgn(_sfpu_reciprocal_<2>(float_in1), float_in1);
+        v_if(in0 != 0 && in0 == in1) { result = sfpi::vConst1; }
+        v_else {
+            sfpi::vFloat float_in0 = sfpi::int32_to_float(in0, 0);
+            sfpi::vFloat float_in1 = sfpi::int32_to_float(in1, 0);
+            result = float_in0 * _sfpu_reciprocal_<2>(float_in1);
+        }
+        v_endif;
 
         // If the result is expected to be integer, this function can be used.
         // vInt int_result = sfpu::_float_to_int32_(result);
@@ -32,7 +38,7 @@ inline void calculate_div_int32(const uint dst_index_in0, const uint dst_index_i
 
 template <bool APPROXIMATION_MODE>
 inline void div_init() {
-    _init_reciprocal_<false>();
+    _init_sfpu_reciprocal_<false>();
 }
 
 }  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_div_int32.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_div_int32.h
@@ -29,4 +29,10 @@ inline void calculate_div_int32(const uint dst_index_in0, const uint dst_index_i
         sfpi::dst_reg++;
     }
 }
+
+template <bool APPROXIMATION_MODE>
+inline void div_init() {
+    _init_reciprocal_<false>();
+}
+
 }  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_div_int32.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_div_int32.h
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "sfpi.h"
+
+namespace ckernel::sfpu {
+template <bool APPROXIMATION_MODE, int ITERATIONS>
+inline void calculate_div_int32(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
+#pragma GCC unroll 8
+    for (int d = 0; d < ITERATIONS; d++) {
+        // size of each tile in Dest is 64/SFP_DESTREG_STRIDE = 32 rows when using sfpi to load/store
+        constexpr uint dst_tile_size_sfpi = 32;
+        sfpi::vInt in0 = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi];
+        sfpi::vInt in1 = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi];
+        sfpi::vInt result;
+
+        sfpi::vFloat float_in0 = sfpi::int32_to_float(in0, 0);
+        sfpi::vFloat float_in1 = sfpi::int32_to_float(in1, 0);
+        sfpi::vFloat float_result = float_in0 * sfpi::setsgn(_sfpu_reciprocal_<3>(float_in1), float_in1);
+        result = sfpu::_float_to_int32_(float_result);
+
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = result;
+        sfpi::dst_reg++;
+    }
+}
+}  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_div_int32.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_div_int32.h
@@ -20,7 +20,7 @@ inline void calculate_div_int32(const uint dst_index_in0, const uint dst_index_i
 
         sfpi::vFloat float_in0 = sfpi::int32_to_float(in0, 0);
         sfpi::vFloat float_in1 = sfpi::int32_to_float(in1, 0);
-        sfpi::vFloat result = float_in0 * sfpi::setsgn(_sfpu_reciprocal_<3>(float_in1), float_in1);
+        sfpi::vFloat result = float_in0 * sfpi::setsgn(_sfpu_reciprocal_<2>(float_in1), float_in1);
 
         // If the result is expected to be integer, this function can be used.
         // vInt int_result = sfpu::_float_to_int32_(result);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_div_int32.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_div_int32.h
@@ -17,12 +17,13 @@ inline void calculate_div_int32(const uint dst_index_in0, const uint dst_index_i
         constexpr uint dst_tile_size_sfpi = 32;
         sfpi::vInt in0 = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi];
         sfpi::vInt in1 = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi];
-        sfpi::vInt result;
 
         sfpi::vFloat float_in0 = sfpi::int32_to_float(in0, 0);
         sfpi::vFloat float_in1 = sfpi::int32_to_float(in1, 0);
-        sfpi::vFloat float_result = float_in0 * sfpi::setsgn(_sfpu_reciprocal_<3>(float_in1), float_in1);
-        result = sfpu::_float_to_int32_(float_result);
+        sfpi::vFloat result = float_in0 * sfpi::setsgn(_sfpu_reciprocal_<3>(float_in1), float_in1);
+
+        // If the result is expected to be integer, this function can be used.
+        // vInt int_result = sfpu::_float_to_int32_(result);
 
         sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = result;
         sfpi::dst_reg++;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_div_int32.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_div_int32.h
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "llk_math_eltwise_binary_sfpu_init.h"
+#include "llk_math_eltwise_binary_sfpu_params.h"
+#include "ckernel_sfpu_div_int32.h"
+
+namespace ckernel {
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_binary_sfpu_div_int32_init() {
+    llk_math_eltwise_binary_sfpu_init<SfpuType::unused, APPROXIMATE>();
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_binary_sfpu_div_int32(
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
+    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+        ckernel::sfpu::calculate_div_int32<APPROXIMATE, 8>, dst_index0, dst_index1, odst, vector_mode);
+}
+
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_div_int32.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_div_int32.h
@@ -19,7 +19,7 @@ template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_div_int32(
     uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_div_int32<APPROXIMATE, 8>, dst_index0, dst_index1, odst, vector_mode);
+        sfpu::calculate_div_int32<APPROXIMATE, 8>, dst_index0, dst_index1, odst, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_div_int32.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_div_int32.h
@@ -12,7 +12,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_div_int32_init() {
-    llk_math_eltwise_binary_sfpu_init<SfpuType::unused, APPROXIMATE>();
+    llk_math_eltwise_binary_sfpu_init<SfpuType::div_int32, APPROXIMATE>(sfpu::div_init<APPROXIMATE>);
 }
 
 template <bool APPROXIMATE>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu_types.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu_types.h
@@ -82,6 +82,7 @@ enum class SfpuType {
     sub_uint16,
     mul_uint16,
     mul_int32,
+    div_int32,
     lt,
     gt,
     ge,

--- a/tt_metal/include/compute_kernel_api/div_int32_sfpu.h
+++ b/tt_metal/include/compute_kernel_api/div_int32_sfpu.h
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "compute_kernel_api/common_globals.h"
+#ifdef TRISC_MATH
+#include "llk_math_eltwise_binary_sfpu_div_int32.h"
+#endif
+
+namespace ckernel {
+
+// clang-format off
+/**
+ * Performs an elementwise division operation with the two 32-bit integer inputs: y = divide(x0,x1)
+ * Output overwrites odst in DST.
+ *
+ * The DST register buffer must be in acquired state via *acquire_dst* call. This call is blocking and is only available
+ * on the compute engine.
+ * A maximum of 4 tiles from each operand can be loaded into DST at once, for a total of 8 tiles,
+ * when using 16 bit formats. This gets reduced to 2 tiles from each operand for 32 bit formats.
+ *
+ * Return value: None
+ *
+ * | Argument              | Description                                                           | Type     | Valid Range                                           | Required |
+ * |-----------------------|-----------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
+ * | idst0                 | The index of the tile in DST register buffer to use as first operand  | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | idst1                 | The index of the tile in DST register buffer to use as second operand | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | odst                  | The index of the tile in DST register buffer to use as output         | uint32_t | Must be less than the size of the DST register buffer | True     |
+ */
+// clang-format on
+ALWI void div_int32_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
+    MATH((llk_math_eltwise_binary_sfpu_div_int32<APPROX>(idst0, idst1, odst)));
+}
+
+/**
+ * Please refer to documentation for div_int32_tile_init.
+ */
+ALWI void div_int32_tile_init() { MATH((llk_math_eltwise_binary_sfpu_div_int32_init<APPROX>())); }
+
+}  // namespace ckernel

--- a/tt_metal/include/compute_kernel_api/div_int32_sfpu.h
+++ b/tt_metal/include/compute_kernel_api/div_int32_sfpu.h
@@ -35,7 +35,7 @@ ALWI void div_int32_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
 }
 
 /**
- * Please refer to documentation for div_int32_tile_init.
+ * Please refer to documentation for div_int32_tile.
  */
 ALWI void div_int32_tile_init() { MATH((llk_math_eltwise_binary_sfpu_div_int32_init<APPROX>())); }
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
@@ -357,7 +357,23 @@ inline auto invoke_binary_ng(
     }
 
     const auto a_dtype = lhs.dtype();
+    const DataType b_dtype = [&] {
+        if constexpr (requires { rhs.dtype(); }) {
+            return rhs.dtype();
+        } else {
+            return a_dtype;
+        }
+    }();
     const auto output_preallocated = output.has_value();
+    const auto is_integer_division =
+        (binary_op_type == BinaryOpType::DIV) && (a_dtype == DataType::INT32) && (b_dtype == DataType::INT32);
+    if (is_integer_division) {
+        // For integer division, output dtype should be float32
+        if (dtype.has_value() || output_preallocated) {
+            auto temp_dtype = output_preallocated ? output->dtype() : *dtype;
+            TT_FATAL(temp_dtype == DataType::FLOAT32, "For integer division, supported output dtype is FLOAT32");
+        }
+    }
     const auto out_dtype = output_preallocated ? output->dtype() : dtype.value_or(a_dtype);
 
     const auto mem_config = output_preallocated ? output->memory_config() : memory_config.value_or(lhs.memory_config());

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_pybind.cpp
@@ -1196,7 +1196,12 @@ void bind_prelu(
 
 template <typename binary_operation_t>
 void bind_div(
-    py::module& module, const binary_operation_t& operation, const std::string& description, const std::string& math) {
+    py::module& module,
+    const binary_operation_t& operation,
+    const std::string& description,
+    const std::string& math,
+    const std::string& supported_dtype = "BFLOAT16",
+    const std::string& note = " ") {
     auto doc = fmt::format(
         R"doc(
         {2}
@@ -1218,7 +1223,7 @@ void bind_div(
         Returns:
             ttnn.Tensor: the output tensor.
 
-        {4}
+        {6}
 
         Note:
             Supported dtypes, layouts, and ranks:
@@ -1229,7 +1234,7 @@ void bind_div(
                * - Dtypes
                  - Layouts
                  - Ranks
-               * - BFLOAT16
+               * - {4}
                  - TILE
                  - 2, 3, 4
 
@@ -1239,6 +1244,8 @@ void bind_div(
         operation.python_fully_qualified_name(),
         description,
         math,
+        supported_dtype,
+        note,
         BINARY_BROADCAST_DOC);
 
     bind_registered_operation(
@@ -2332,6 +2339,7 @@ void py_module(py::module& module) {
         R"doc(
         When :attr:`fast_and_approximate_mode` is `True`, operation assumes that :attr:`input_tensor_b` is not zero.
         When :attr:`fast_and_approximate_mode` is `False` (default), operation properly handle division by zero.
+        When the inputs are INT32, the outputs are also returned as INT32.
         )doc");
 
     detail::bind_binary_operation(
@@ -2521,8 +2529,13 @@ void py_module(py::module& module) {
     detail::bind_div(
         module,
         ttnn::div,
-        R"doc(Computes div for :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`)doc",
+        R"doc(Divides :attr:`input_tensor_a` by :attr:`input_tensor_b` and returns a tensor with the same layout as :attr:`input_tensor_a`)doc",
         R"doc(\mathrm{output}_i = \begin{cases} \mathrm{\left(\frac{\mathrm{input\_tensor\_a}_i}{\mathrm{input\_tensor\_b}_i}\right)}, & \text{if } \mathrm{round\_mode} = \mathrm{None} \\ \mathrm{\text{floor}\left(\frac{\mathrm{input\_tensor\_a}_i}{\mathrm{input\_tensor\_b}_i}\right)}, & \text{if } \mathrm{round\_mode} = \mathrm{floor} \\ \mathrm{\text{trunc}\left(\frac{\mathrm{input\_tensor\_a}_i}{\mathrm{input\_tensor\_b}_i}\right)}, & \text{if } \mathrm{round\_mode} = \mathrm{trunc} \end{cases}
+        )doc",
+        R"doc(BFLOAT16, FLOAT32, INT32)doc",
+        R"doc(
+        When the inputs are INT32, the outputs are also returned as INT32.
+        With INT32 inputs, round_mode `None` produces a FLOAT32 output, while `floor` and `trunc` produce an INT32 output.
         )doc");
 
     detail::bind_binary_composite_overload(
@@ -2662,6 +2675,7 @@ void py_module(py::module& module) {
         R"doc(
         When :attr:`fast_and_approximate_mode` is `True`, the operation uses FPU+SFPU implementation for better performance.
         When :attr:`fast_and_approximate_mode` is `False` (default), the operation uses SFPU implementation for better accuracy.
+        When the inputs are INT32, the outputs are also returned as INT32.
         )doc");
 
     detail::bind_inplace_operation(

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_pybind.cpp
@@ -2534,7 +2534,6 @@ void py_module(py::module& module) {
         )doc",
         R"doc(BFLOAT16, FLOAT32, INT32)doc",
         R"doc(
-        When the inputs are INT32, the outputs are also returned as INT32.
         With INT32 inputs, round_mode `None` produces a FLOAT32 output, while `floor` and `trunc` produce an INT32 output.
         )doc");
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_pybind.cpp
@@ -2339,7 +2339,7 @@ void py_module(py::module& module) {
         R"doc(
         When :attr:`fast_and_approximate_mode` is `True`, operation assumes that :attr:`input_tensor_b` is not zero.
         When :attr:`fast_and_approximate_mode` is `False` (default), operation properly handle division by zero.
-        When the inputs are INT32, the outputs are also returned as INT32.
+        When the inputs are INT32, the outputs are FLOAT32 and output datatype conversion is not supported.
         )doc");
 
     detail::bind_binary_operation(
@@ -2671,11 +2671,11 @@ void py_module(py::module& module) {
         ttnn::divide_,
         R"doc(Performs division in-place operation on :attr:`input_a` and :attr:`input_b` and returns the tensor with the same layout as :attr:`input_tensor`)doc",
         R"doc(\verb|divide|(\mathrm{{input\_tensor\_a,input\_tensor\_b}}))doc",
-        R"doc(BFLOAT16, FLOAT32, INT32, UINT16)doc",
+        R"doc(BFLOAT16, FLOAT32, UINT16)doc",
         R"doc(
         When :attr:`fast_and_approximate_mode` is `True`, the operation uses FPU+SFPU implementation for better performance.
         When :attr:`fast_and_approximate_mode` is `False` (default), the operation uses SFPU implementation for better accuracy.
-        When the inputs are INT32, the outputs are also returned as INT32.
+        The operation is not supported for INT32 inputs since the outputs are returned as FLOAT32.
         )doc");
 
     detail::bind_inplace_operation(

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/common/binary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/common/binary_op_utils.cpp
@@ -253,8 +253,13 @@ std::map<std::string, std::string> get_defines_fp32(
             op_name = "power_binary_tile";
             break;
         case BinaryOpType::DIV:
-            new_defines.insert({"BINOP_INIT", fmt::format("div_binary_tile_init();")});
-            op_name = "div_binary_tile";
+            if (input_a_dtype == DataType::INT32 && input_b_dtype == DataType::INT32) {
+                new_defines.insert({"BINOP_INIT", fmt::format("div_int32_tile_init();")});
+                op_name = "div_int32_tile";
+            } else {
+                new_defines.insert({"BINOP_INIT", fmt::format("div_binary_tile_init();")});
+                op_name = "div_binary_tile";
+            }
             break;
         case BinaryOpType::BITWISE_AND:
             if (input_a_dtype == DataType::UINT16 && input_b_dtype == DataType::UINT16) {

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/kernels/compute/eltwise_binary_sfpu_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/kernels/compute/eltwise_binary_sfpu_kernel.cpp
@@ -16,6 +16,7 @@
 #include "compute_kernel_api/sub_int_sfpu.h"
 #include "compute_kernel_api/mul_int_sfpu.h"
 #include "compute_kernel_api/mul_int32_sfpu.h"
+#include "compute_kernel_api/div_int32_sfpu.h"
 #include "compute_kernel_api/binary_max_min.h"
 #include "compute_kernel_api/xlogy.h"
 #include "compute_kernel_api/gcd.h"

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
@@ -278,8 +278,9 @@ BinaryNgDeviceOperation::spec_return_value_t BinaryNgDeviceOperation::compute_ou
     if (attributes.binary_op_type == BinaryOpType::DIV && input_tensor_a.dtype() == DataType::INT32) {
         if (tensor_b.has_value() && tensor_b->dtype() == DataType::INT32) {
             output_dtype = DataType::FLOAT32;
+        } else if (!tensor_b.has_value()) {
+            output_dtype = DataType::FLOAT32;
         }
-        output_dtype = DataType::FLOAT32;
     }
 
     // Broadcasting Rules Overview:

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
@@ -272,6 +272,15 @@ BinaryNgDeviceOperation::spec_return_value_t BinaryNgDeviceOperation::compute_ou
     const int rank_a = input_shape_a.rank();
     const int rank_b = input_shape_b.rank();
     const int larger_rank = std::max(rank_a, rank_b);
+    auto output_dtype = attributes.get_dtype();
+
+    // Integer division results in FP32 outputs.
+    if (attributes.binary_op_type == BinaryOpType::DIV && input_tensor_a.dtype() == DataType::INT32) {
+        if (tensor_b.has_value() && tensor_b->dtype() == DataType::INT32) {
+            output_dtype = DataType::FLOAT32;
+        }
+        output_dtype = DataType::FLOAT32;
+    }
 
     // Broadcasting Rules Overview:
     // - If the two tensors have different ranks, we virtually pad the smaller-rank tensor's shape
@@ -358,14 +367,11 @@ BinaryNgDeviceOperation::spec_return_value_t BinaryNgDeviceOperation::compute_ou
         return TensorSpec(
             output_shape,
             TensorLayout(
-                attributes.get_dtype(),
-                PageConfig(Layout::TILE),
-                MemoryConfig(memory_layout, buffer_type, output_shard_spec)));
+                output_dtype, PageConfig(Layout::TILE), MemoryConfig(memory_layout, buffer_type, output_shard_spec)));
     }
 
     // If not sharded, use the memory config from input a that is interleaved
-    return TensorSpec(
-        output_shape, TensorLayout(attributes.get_dtype(), PageConfig(Layout::TILE), attributes.memory_config));
+    return TensorSpec(output_shape, TensorLayout(output_dtype, PageConfig(Layout::TILE), attributes.memory_config));
 }
 
 BinaryNgDeviceOperation::program_factory_t BinaryNgDeviceOperation::select_program_factory(

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
@@ -276,9 +276,7 @@ BinaryNgDeviceOperation::spec_return_value_t BinaryNgDeviceOperation::compute_ou
 
     // Integer division results in FP32 outputs.
     if (attributes.binary_op_type == BinaryOpType::DIV && input_tensor_a.dtype() == DataType::INT32) {
-        if (tensor_b.has_value() && tensor_b->dtype() == DataType::INT32) {
-            output_dtype = DataType::FLOAT32;
-        } else if (!tensor_b.has_value()) {
+        if (!tensor_b.has_value() || tensor_b->dtype() == DataType::INT32) {
             output_dtype = DataType::FLOAT32;
         }
     }

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
@@ -659,7 +659,11 @@ BinaryNgDeviceOperation::ProgramFactory::cached_program_t BinaryNgDeviceOperatio
             post_activations.insert(post_activations.begin(), *op_config.postprocess);
         }
 
-        if (binary::utils::is_typecast(a_dtype, c_dtype) and !is_quant_op) {
+        bool is_integer_division =
+            (operation_attributes.binary_op_type == BinaryOpType::DIV && a_dtype == DataType::INT32 &&
+             b_dtype == DataType::INT32);
+
+        if (binary::utils::is_typecast(a_dtype, c_dtype) and !is_quant_op and !is_integer_division) {
             post_activations.push_back({
                 unary::UnaryOpType::TYPECAST,
                 {static_cast<int>(a_dtype), static_cast<int>(c_dtype)},

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
@@ -401,7 +401,12 @@ std::pair<std::string, std::string> get_sfpu_init_fn(OpConfig::SfpuBinaryOp sfpu
             } else {
                 return {"mul_binary_tile_init();", "mul_binary_tile"};
             }
-        case DIV: return {"div_binary_tile_init();", "div_binary_tile"};
+        case DIV:
+            if (dtype == DataType::INT32) {
+                return {"div_int32_tile_init();", "div_int32_tile"};
+            } else {
+                return {"div_binary_tile_init();", "div_binary_tile"};
+            }
         case POWER: return {"power_binary_tile_init();", "power_binary_tile"};
         case RSUB:
             if (dtype == DataType::INT32) {

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu.cpp
@@ -14,6 +14,7 @@
 #include "compute_kernel_api/sub_int_sfpu.h"
 #include "compute_kernel_api/mul_int_sfpu.h"
 #include "compute_kernel_api/mul_int32_sfpu.h"
+#include "compute_kernel_api/div_int32_sfpu.h"
 #include "compute_kernel_api/quantization.h"
 #include "compute_kernel_api/binary_max_min.h"
 #include "compute_kernel_api/gcd.h"

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu_no_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu_no_bcast.cpp
@@ -14,6 +14,7 @@
 #include "compute_kernel_api/sub_int_sfpu.h"
 #include "compute_kernel_api/mul_int_sfpu.h"
 #include "compute_kernel_api/mul_int32_sfpu.h"
+#include "compute_kernel_api/div_int32_sfpu.h"
 #include "compute_kernel_api/quantization.h"
 #include "compute_kernel_api/binary_max_min.h"
 #include "compute_kernel_api/gcd.h"

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu_scalar.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu_scalar.cpp
@@ -14,6 +14,7 @@
 #include "compute_kernel_api/sub_int_sfpu.h"
 #include "compute_kernel_api/mul_int_sfpu.h"
 #include "compute_kernel_api/mul_int32_sfpu.h"
+#include "compute_kernel_api/div_int32_sfpu.h"
 #include "compute_kernel_api/quantization.h"
 #include "compute_kernel_api/xlogy.h"
 #include "compute_kernel_api/binary_comp.h"

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_row_col_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_row_col_bcast.cpp
@@ -14,6 +14,7 @@
 #include "compute_kernel_api/sub_int_sfpu.h"
 #include "compute_kernel_api/mul_int_sfpu.h"
 #include "compute_kernel_api/mul_int32_sfpu.h"
+#include "compute_kernel_api/div_int32_sfpu.h"
 #include "compute_kernel_api/quantization.h"
 #include "compute_kernel_api/binary_max_min.h"
 #include "compute_kernel_api/gcd.h"


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/18589

### Problem description
ttnn.divide does not support INT32 division

### What's changed
Kernel implementation for ttnn.divide which supports integer inputs upto 2**24.

**Special-Value Handling:**
| A  | B  | PyTorch Result (round_mode=None) | TT Result |
|----|----|----------------------------------|-----------|
| -1 | -1 | 1.0                              | 1.0       |
| -1 |  0 | -inf                             | -inf      |
| -1 |  1 | -1.0                             | -1.0      |
|  0 | -1 | -0.0                              | 0.0       |
|  0 |  0 | nan                              | nan       |
|  0 |  1 | 0.0                              | 0.0       |
|  1 | -1 | -1.0                             | -1.0      |
|  1 |  0 | inf                              | inf       |
|  1 |  1 | 1.0                              | 1.0       |
|  0 |  -0 | nan                              | nan       |
|  -0 |  0 | nan                              | nan       |
|  -0 | -0 | nan                              | nan       |

**Workaround for BH:**
- Typecasting using `sfpi::int32_to_float` does not work correctly in BH (see https://github.com/tenstorrent/tt-metal/issues/33044)
- As an alternative, I tried using `_calculate_typecast_int32_to_fp32_`, but this function expects a destination tile size of `64` for SFPU, whereas SFPI uses `32`. Because of this mismatch, the typecasted output for tensor B contained interleaved values from tensors A and B.
- To work around this, I used if-conditions to convert inputs to their absolute values, applied sfpi::int32_to_float and reapplied their original signs to the result.
<img width="448" height="255" alt="Screenshot 2025-11-26 at 18 04 56" src="https://github.com/user-attachments/assets/9f5319ac-7cbc-4a8b-afd9-83a0f4366927" />


### Checklist
- [x] All post commit - https://github.com/tenstorrent/tt-metal/actions/runs/19637928784
Latest Run: https://github.com/tenstorrent/tt-metal/actions/runs/19703645119
- [x] Blackhole Post commit - https://github.com/tenstorrent/tt-metal/actions/runs/19640110577
Latest Run: https://github.com/tenstorrent/tt-metal/actions/runs/19703666073
- [x] Nightly tt-metal L2 tests - https://github.com/tenstorrent/tt-metal/actions/runs/19660848513
- [x] New/Existing tests provide coverage for changes