### PR TITLE
[skip ci] For dev tag always bump minor

### DIFF
--- a/.github/actions/calculate-version/action.yml
+++ b/.github/actions/calculate-version/action.yml
@@ -128,8 +128,18 @@ runs:
         tag_type="${{ inputs.tag-type }}"
 
         if [ "$tag_type" = "dev" ]; then
-          echo "Dev tag type - ignoring version bump, using latest version"
-          echo "new_version=$latest_tag" >> "$GITHUB_OUTPUT"
+          echo "Dev tag type - forcing minor version bump"
+          # Extract version numbers (remove 'v' prefix) for dev minor bump
+          version_no_v=${latest_tag#v}
+          IFS='.' read -r major minor patch <<< "$version_no_v"
+
+          # Always increment minor version for dev tags
+          minor=$((minor + 1))
+          patch=0
+
+          new_version="v$major.$minor.$patch"
+          echo "Dev version calculated: $new_version"
+          echo "new_version=$new_version" >> "$GITHUB_OUTPUT"
           exit 0
         fi
 

--- a/.github/workflows/test-action-calculate-version.yml
+++ b/.github/workflows/test-action-calculate-version.yml
@@ -242,6 +242,155 @@ jobs:
           fi
           echo "PASS: PATCH bump test passed"
 
+  test-dev-tag-versioning:
+    name: Test Dev Tag Minor Version Bumping
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup git
+        run: |
+          git config user.name "Test User"
+          git config user.email "test@example.com"
+
+      # Test dev tag with different base versions
+      - name: Test dev tag from v1.5.3
+        run: |
+          git tag v1.5.3
+          echo "Created base tag v1.5.3"
+
+      - name: Test dev tag minor increment from v1.5.3
+        id: test-dev-v1-5-3
+        uses: ./.github/actions/calculate-version
+        with:
+          tag-type: "dev"
+
+      - name: Verify dev tag increments minor from v1.5.3
+        run: |
+          echo "Dev tag from v1.5.3 results:"
+          echo "  Latest semver: ${{ steps.test-dev-v1-5-3.outputs.latest_semver }}"
+          echo "  New version: ${{ steps.test-dev-v1-5-3.outputs.new_version }}"
+          echo "  Final version: ${{ steps.test-dev-v1-5-3.outputs.final_version }}"
+
+          if [ "${{ steps.test-dev-v1-5-3.outputs.latest_semver }}" != "v1.5.3" ]; then
+            echo "FAIL: Expected latest_semver to be v1.5.3"
+            exit 1
+          fi
+
+          if [ "${{ steps.test-dev-v1-5-3.outputs.new_version }}" != "v1.6.0" ]; then
+            echo "FAIL: Expected dev tag to increment minor version to v1.6.0, got ${{ steps.test-dev-v1-5-3.outputs.new_version }}"
+            exit 1
+          fi
+
+          # Check final version has correct format with date
+          current_date=$(date +%Y%m%d)
+          expected_final="v1.6.0-dev$current_date"
+          if [ "${{ steps.test-dev-v1-5-3.outputs.final_version }}" != "$expected_final" ]; then
+            echo "FAIL: Expected final version to be $expected_final, got ${{ steps.test-dev-v1-5-3.outputs.final_version }}"
+            exit 1
+          fi
+
+          echo "PASS: Dev tag minor increment from v1.5.3 test passed"
+
+      # Test dev tag from major version
+      - name: Test dev tag from v3.0.0
+        run: |
+          git tag v3.0.0
+          echo "Created base tag v3.0.0"
+
+      - name: Test dev tag minor increment from v3.0.0
+        id: test-dev-v3-0-0
+        uses: ./.github/actions/calculate-version
+        with:
+          tag-type: "dev"
+
+      - name: Verify dev tag increments minor from v3.0.0
+        run: |
+          echo "Dev tag from v3.0.0 results:"
+          echo "  Latest semver: ${{ steps.test-dev-v3-0-0.outputs.latest_semver }}"
+          echo "  New version: ${{ steps.test-dev-v3-0-0.outputs.new_version }}"
+          echo "  Final version: ${{ steps.test-dev-v3-0-0.outputs.final_version }}"
+
+          if [ "${{ steps.test-dev-v3-0-0.outputs.latest_semver }}" != "v3.0.0" ]; then
+            echo "FAIL: Expected latest_semver to be v3.0.0"
+            exit 1
+          fi
+
+          if [ "${{ steps.test-dev-v3-0-0.outputs.new_version }}" != "v3.1.0" ]; then
+            echo "FAIL: Expected dev tag to increment minor version to v3.1.0, got ${{ steps.test-dev-v3-0-0.outputs.new_version }}"
+            exit 1
+          fi
+
+          echo "PASS: Dev tag minor increment from v3.0.0 test passed"
+
+      # Test dev tag ignores commit indicators
+      - name: Test dev tag ignores commit version indicators
+        run: |
+          git reset --hard v3.0.0
+          echo "major change" > major-change.txt
+          git add major-change.txt
+          git commit -m "Breaking API change (MAJOR)"
+
+          echo "patch fix" > patch-fix.txt
+          git add patch-fix.txt
+          git commit -m "Bug fix (PATCH)"
+
+      - name: Test dev tag ignores MAJOR/PATCH commits
+        id: test-dev-ignores-commits
+        uses: ./.github/actions/calculate-version
+        with:
+          tag-type: "dev"
+
+      - name: Verify dev tag ignores commit indicators
+        run: |
+          echo "Dev tag ignores commits results:"
+          echo "  Latest semver: ${{ steps.test-dev-ignores-commits.outputs.latest_semver }}"
+          echo "  New version: ${{ steps.test-dev-ignores-commits.outputs.new_version }}"
+          echo "  Final version: ${{ steps.test-dev-ignores-commits.outputs.final_version }}"
+
+          # Should still be v3.1.0 regardless of MAJOR/PATCH commits
+          if [ "${{ steps.test-dev-ignores-commits.outputs.new_version }}" != "v3.1.0" ]; then
+            echo "FAIL: Expected dev tag to always increment minor to v3.1.0 regardless of commit indicators, got ${{ steps.test-dev-ignores-commits.outputs.new_version }}"
+            exit 1
+          fi
+
+          echo "PASS: Dev tag ignores commit indicators test passed"
+
+      # Test dev tag from v0.0.0 (no previous tags)
+      - name: Test dev tag from no previous tags
+        run: |
+          # Remove all tags to test v0.0.0 scenario
+          git tag -d $(git tag -l) || echo "No tags to delete"
+
+      - name: Test dev tag minor increment from v0.0.0
+        id: test-dev-v0-0-0
+        uses: ./.github/actions/calculate-version
+        with:
+          tag-type: "dev"
+
+      - name: Verify dev tag increments minor from v0.0.0
+        run: |
+          echo "Dev tag from v0.0.0 results:"
+          echo "  Latest semver: ${{ steps.test-dev-v0-0-0.outputs.latest_semver }}"
+          echo "  New version: ${{ steps.test-dev-v0-0-0.outputs.new_version }}"
+          echo "  Final version: ${{ steps.test-dev-v0-0-0.outputs.final_version }}"
+
+          if [ "${{ steps.test-dev-v0-0-0.outputs.latest_semver }}" != "v0.0.0" ]; then
+            echo "FAIL: Expected latest_semver to be v0.0.0 when no tags exist"
+            exit 1
+          fi
+
+          if [ "${{ steps.test-dev-v0-0-0.outputs.new_version }}" != "v0.1.0" ]; then
+            echo "FAIL: Expected dev tag to increment minor version to v0.1.0 from v0.0.0, got ${{ steps.test-dev-v0-0-0.outputs.new_version }}"
+            exit 1
+          fi
+
+          echo "PASS: Dev tag minor increment from v0.0.0 test passed"
+
   test-edge-cases:
     name: Test Edge Cases
     runs-on: ubuntu-latest
@@ -602,7 +751,7 @@ jobs:
   final-test-summary:
     name: Final Test Summary
     runs-on: ubuntu-latest
-    needs: [test-calculate-version, test-version-bumping, test-edge-cases, integration-test, test-force-bump-and-ignore-commits]
+    needs: [test-calculate-version, test-version-bumping, test-dev-tag-versioning, test-edge-cases, integration-test, test-force-bump-and-ignore-commits]
     steps:
       - name: Test summary
         run: |
@@ -621,6 +770,12 @@ jobs:
           echo "  ✅ MINOR version bumping"
           echo "  ✅ PATCH version bumping"
           echo "  ✅ No bump scenario"
+          echo ""
+          echo "Dev Tag Versioning:"
+          echo "  ✅ Dev tag minor increment from v1.5.3"
+          echo "  ✅ Dev tag minor increment from v3.0.0"
+          echo "  ✅ Dev tag minor increment from v0.0.0"
+          echo "  ✅ Dev tag ignores commit indicators"
           echo ""
           echo "Advanced Features:"
           echo "  ✅ RC increment logic"

--- a/.github/workflows/test-action-calculate-version.yml
+++ b/.github/workflows/test-action-calculate-version.yml
@@ -116,6 +116,8 @@ jobs:
       - name: Verify Test 4 Results
         run: |
           echo "Test 4 Results:"
+          echo "  Latest semver: ${{ steps.test-dev.outputs.latest_semver }}"
+          echo "  New version: ${{ steps.test-dev.outputs.new_version }}"
           echo "  Final version: ${{ steps.test-dev.outputs.final_version }}"
 
           # Dev version should have -dev suffix with date
@@ -123,6 +125,13 @@ jobs:
             echo "FAIL: Expected final_version to contain -dev suffix"
             exit 1
           fi
+
+          # Dev tag should always increment minor version from latest (v2.1.0 -> v2.2.0)
+          if [ "${{ steps.test-dev.outputs.new_version }}" != "v2.2.0" ]; then
+            echo "FAIL: Expected dev tag to increment minor version to v2.2.0, got ${{ steps.test-dev.outputs.new_version }}"
+            exit 1
+          fi
+
           echo "PASS: Test 4 passed"
 
   test-version-bumping:

--- a/.github/workflows/test-action-calculate-version.yml
+++ b/.github/workflows/test-action-calculate-version.yml
@@ -391,6 +391,160 @@ jobs:
 
           echo "PASS: Dev tag minor increment from v0.0.0 test passed"
 
+  test-dev-tag-consistency:
+    name: Test Dev Tag Consistency
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup git
+        run: |
+          git config user.name "Test User"
+          git config user.email "test@example.com"
+
+      # Test that dev tags are consistent when called multiple times without base version change
+      - name: Setup base version for consistency test
+        run: |
+          git tag v2.3.5
+          echo "Created base tag v2.3.5 for consistency testing"
+
+      - name: First dev tag generation
+        id: first-dev-call
+        uses: ./.github/actions/calculate-version
+        with:
+          tag-type: "dev"
+
+      - name: Second dev tag generation (same conditions)
+        id: second-dev-call
+        uses: ./.github/actions/calculate-version
+        with:
+          tag-type: "dev"
+
+      - name: Verify dev tag consistency
+        run: |
+          echo "First dev call results:"
+          echo "  Latest semver: ${{ steps.first-dev-call.outputs.latest_semver }}"
+          echo "  New version: ${{ steps.first-dev-call.outputs.new_version }}"
+          echo "  Final version: ${{ steps.first-dev-call.outputs.final_version }}"
+          echo ""
+          echo "Second dev call results:"
+          echo "  Latest semver: ${{ steps.second-dev-call.outputs.latest_semver }}"
+          echo "  New version: ${{ steps.second-dev-call.outputs.new_version }}"
+          echo "  Final version: ${{ steps.second-dev-call.outputs.final_version }}"
+
+          # Both calls should have same latest_semver
+          if [ "${{ steps.first-dev-call.outputs.latest_semver }}" != "${{ steps.second-dev-call.outputs.latest_semver }}" ]; then
+            echo "FAIL: Expected latest_semver to be the same in both calls"
+            echo "  First: ${{ steps.first-dev-call.outputs.latest_semver }}"
+            echo "  Second: ${{ steps.second-dev-call.outputs.latest_semver }}"
+            exit 1
+          fi
+
+          # Both calls should have same new_version (base increment)
+          if [ "${{ steps.first-dev-call.outputs.new_version }}" != "${{ steps.second-dev-call.outputs.new_version }}" ]; then
+            echo "FAIL: Expected new_version to be the same in both calls"
+            echo "  First: ${{ steps.first-dev-call.outputs.new_version }}"
+            echo "  Second: ${{ steps.second-dev-call.outputs.new_version }}"
+            exit 1
+          fi
+
+          # Both calls should have same final_version (since same date)
+          if [ "${{ steps.first-dev-call.outputs.final_version }}" != "${{ steps.second-dev-call.outputs.final_version }}" ]; then
+            echo "FAIL: Expected final_version to be the same in both calls (same date)"
+            echo "  First: ${{ steps.first-dev-call.outputs.final_version }}"
+            echo "  Second: ${{ steps.second-dev-call.outputs.final_version }}"
+            exit 1
+          fi
+
+          # Verify the expected version pattern
+          if [ "${{ steps.first-dev-call.outputs.new_version }}" != "v2.4.0" ]; then
+            echo "FAIL: Expected new_version to be v2.4.0 (minor increment from v2.3.5)"
+            exit 1
+          fi
+
+          # Verify final version has correct date format
+          current_date=$(date +%Y%m%d)
+          expected_final="v2.4.0-dev$current_date"
+          if [ "${{ steps.first-dev-call.outputs.final_version }}" != "$expected_final" ]; then
+            echo "FAIL: Expected final version to be $expected_final"
+            exit 1
+          fi
+
+          echo "PASS: Dev tag consistency test passed - multiple calls produce identical results"
+
+      # Test consistency even with additional commits (but no new release tags)
+      - name: Add commits without new release tags
+        run: |
+          echo "additional change 1" > change1.txt
+          git add change1.txt
+          git commit -m "Some development work (MINOR)"
+
+          echo "additional change 2" > change2.txt
+          git add change2.txt
+          git commit -m "Bug fix (PATCH)"
+
+          echo "additional change 3" > change3.txt
+          git add change3.txt
+          git commit -m "Breaking change (MAJOR)"
+
+      - name: Third dev tag generation (with additional commits)
+        id: third-dev-call
+        uses: ./.github/actions/calculate-version
+        with:
+          tag-type: "dev"
+
+      - name: Fourth dev tag generation (with additional commits)
+        id: fourth-dev-call
+        uses: ./.github/actions/calculate-version
+        with:
+          tag-type: "dev"
+
+      - name: Verify dev tag consistency with commits
+        run: |
+          echo "Third dev call results (with commits):"
+          echo "  Latest semver: ${{ steps.third-dev-call.outputs.latest_semver }}"
+          echo "  New version: ${{ steps.third-dev-call.outputs.new_version }}"
+          echo "  Final version: ${{ steps.third-dev-call.outputs.final_version }}"
+          echo ""
+          echo "Fourth dev call results (with commits):"
+          echo "  Latest semver: ${{ steps.fourth-dev-call.outputs.latest_semver }}"
+          echo "  New version: ${{ steps.fourth-dev-call.outputs.new_version }}"
+          echo "  Final version: ${{ steps.fourth-dev-call.outputs.final_version }}"
+
+          # Latest semver should still be the same (v2.3.5 - no new release tags)
+          if [ "${{ steps.third-dev-call.outputs.latest_semver }}" != "v2.3.5" ]; then
+            echo "FAIL: Expected latest_semver to still be v2.3.5 (no new release tags)"
+            exit 1
+          fi
+
+          if [ "${{ steps.fourth-dev-call.outputs.latest_semver }}" != "v2.3.5" ]; then
+            echo "FAIL: Expected latest_semver to still be v2.3.5 (no new release tags)"
+            exit 1
+          fi
+
+          # New version should still be v2.4.0 (dev always increments minor from latest release)
+          if [ "${{ steps.third-dev-call.outputs.new_version }}" != "v2.4.0" ]; then
+            echo "FAIL: Expected new_version to still be v2.4.0 (dev ignores commit indicators)"
+            exit 1
+          fi
+
+          if [ "${{ steps.fourth-dev-call.outputs.new_version }}" != "v2.4.0" ]; then
+            echo "FAIL: Expected new_version to still be v2.4.0 (dev ignores commit indicators)"
+            exit 1
+          fi
+
+          # Final versions should be identical (same date)
+          if [ "${{ steps.third-dev-call.outputs.final_version }}" != "${{ steps.fourth-dev-call.outputs.final_version }}" ]; then
+            echo "FAIL: Expected final_version to be identical in both calls with commits"
+            exit 1
+          fi
+
+          echo "PASS: Dev tag consistency with commits test passed - dev tags ignore commit content and remain consistent"
+
   test-edge-cases:
     name: Test Edge Cases
     runs-on: ubuntu-latest
@@ -751,7 +905,7 @@ jobs:
   final-test-summary:
     name: Final Test Summary
     runs-on: ubuntu-latest
-    needs: [test-calculate-version, test-version-bumping, test-dev-tag-versioning, test-edge-cases, integration-test, test-force-bump-and-ignore-commits]
+    needs: [test-calculate-version, test-version-bumping, test-dev-tag-versioning, test-dev-tag-consistency, test-edge-cases, integration-test, test-force-bump-and-ignore-commits]
     steps:
       - name: Test summary
         run: |
@@ -776,6 +930,8 @@ jobs:
           echo "  ✅ Dev tag minor increment from v3.0.0"
           echo "  ✅ Dev tag minor increment from v0.0.0"
           echo "  ✅ Dev tag ignores commit indicators"
+          echo "  ✅ Dev tag consistency across multiple calls"
+          echo "  ✅ Dev tag consistency with additional commits"
           echo ""
           echo "Advanced Features:"
           echo "  ✅ RC increment logic"


### PR DESCRIPTION
### Problem description
For daily dev tags we want them to always be one minor version up from released one

### What's changed
Added always bumping of minor version in dev tag