### PR TITLE
Add test configuration for 5-galaxy Exabox inter-mesh routing validation

### DIFF
--- a/tests/tt_metal/distributed/config/5_galaxy_wh_exabox_rank_bindings.yaml
+++ b/tests/tt_metal/distributed/config/5_galaxy_wh_exabox_rank_bindings.yaml
@@ -14,4 +14,5 @@ rank_bindings:
   - rank: 4
     mesh_id: 4
     mesh_host_rank: 0
+
 mesh_graph_desc_path: "tests/tt_metal/tt_fabric/custom_mesh_descriptors/5_galaxy_wh_exabox_mgd.textproto"

--- a/tests/tt_metal/distributed/config/5_galaxy_wh_exabox_rank_bindings.yaml
+++ b/tests/tt_metal/distributed/config/5_galaxy_wh_exabox_rank_bindings.yaml
@@ -14,5 +14,4 @@ rank_bindings:
   - rank: 4
     mesh_id: 4
     mesh_host_rank: 0
-
 mesh_graph_desc_path: "tests/tt_metal/tt_fabric/custom_mesh_descriptors/5_galaxy_wh_exabox_mgd.textproto"

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_5_galaxy_multi_mesh.yaml
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_5_galaxy_multi_mesh.yaml
@@ -1,0 +1,204 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+
+allocation_policies:
+    receiver:
+      max_configs_per_core: 2
+
+Tests:
+  # ======================================================================================
+  # Single Sender to Single Receiver
+  # ======================================================================================
+  - name: "FiveGalaxyBasicUnicast"
+    fabric_setup:
+      topology: Mesh
+      routing_type: Dynamic
+      mesh_descriptor_path: "tests/tt_metal/tt_fabric/custom_mesh_descriptors/5_galaxy_wh_exabox_mgd.textproto"
+
+    top_level_iterations: 3
+
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      size: [32, 64, 128]
+      num_packets: [100]
+
+    defaults:
+      ftype: unicast
+
+    senders:
+      - device: [0, [0, 0]]
+        patterns:
+          - destination:
+              device: [1, [7, 3]]
+
+  # ======================================================================================
+  # Single Sender to Multiple Receivers
+  # ======================================================================================
+  - name: "FiveGalaxySingleSenderMultiReceiver"
+    fabric_setup:
+      topology: Mesh
+      routing_type: Dynamic
+      mesh_descriptor_path: "tests/tt_metal/tt_fabric/custom_mesh_descriptors/5_galaxy_wh_exabox_mgd.textproto"
+
+    top_level_iterations: 3
+
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc]
+      size: [64, 128]
+      num_packets: [100]
+
+    defaults:
+      ftype: unicast
+
+    senders:
+      - device: [0, [0, 0]]
+        patterns:
+          - destination:
+              device: [1, [7, 3]]
+          - destination:
+              device: [2, [4, 2]]
+          - destination:
+              device: [3, [3, 1]]
+          - destination:
+              device: [4, [6, 3]]
+
+  # ======================================================================================
+  # Multiple Senders to Single Receiver
+  # ======================================================================================
+  - name: "FiveGalaxyMultiSenderSingleReceiver"
+    fabric_setup:
+      topology: Mesh
+      routing_type: Dynamic
+      mesh_descriptor_path: "tests/tt_metal/tt_fabric/custom_mesh_descriptors/5_galaxy_wh_exabox_mgd.textproto"
+
+    top_level_iterations: 3
+
+    defaults:
+      ftype: unicast
+      ntype: unicast_write
+      size: 64
+      num_packets: 100
+
+    senders:
+      - device: [1, [0, 0]]
+        patterns:
+          - destination:
+              device: [0, [3, 1]]
+      - device: [2, [1, 1]]
+        patterns:
+          - destination:
+              device: [0, [3, 1]]
+      - device: [3, [2, 2]]
+        patterns:
+          - destination:
+              device: [0, [3, 1]]
+      - device: [4, [3, 3]]
+        patterns:
+          - destination:
+              device: [0, [3, 1]]
+
+  # ======================================================================================
+  # Training Pattern - Hub-based Forward Pass
+  # ======================================================================================
+  - name: "FiveGalaxyTrainingForward"
+    fabric_setup:
+      topology: Mesh
+      routing_type: Dynamic
+      mesh_descriptor_path: "tests/tt_metal/tt_fabric/custom_mesh_descriptors/5_galaxy_wh_exabox_mgd.textproto"
+
+    top_level_iterations: 3
+
+    parametrization_params:
+      size: [64, 128]
+      num_packets: [50]
+
+    defaults:
+      ftype: unicast
+      ntype: unicast_write
+
+    senders:
+      # Upstream meshes (0,1,2) → Hub (3)
+      - device: [0, [0, 0]]
+        patterns:
+          - destination:
+              device: [3, [0, 0]]
+      - device: [1, [3, 1]]
+        patterns:
+          - destination:
+              device: [3, [3, 1]]
+      - device: [2, [7, 3]]
+        patterns:
+          - destination:
+              device: [3, [7, 3]]
+
+      # Hub (3) → Downstream (4)
+      - device: [3, [0, 0]]
+        patterns:
+          - destination:
+              device: [4, [0, 0]]
+      - device: [3, [4, 2]]
+        patterns:
+          - destination:
+              device: [4, [4, 2]]
+
+  # ======================================================================================
+  # Training Pattern - Hub-based Backward Pass
+  # ======================================================================================
+  - name: "FiveGalaxyTrainingBackward"
+    fabric_setup:
+      topology: Mesh
+      routing_type: Dynamic
+      mesh_descriptor_path: "tests/tt_metal/tt_fabric/custom_mesh_descriptors/5_galaxy_wh_exabox_mgd.textproto"
+
+    top_level_iterations: 3
+
+    defaults:
+      ftype: unicast
+      ntype: unicast_write
+      size: 64
+      num_packets: 50
+
+    senders:
+      # Downstream (4) → Hub (3)
+      - device: [4, [0, 0]]
+        patterns:
+          - destination:
+              device: [3, [0, 0]]
+      - device: [4, [4, 2]]
+        patterns:
+          - destination:
+              device: [3, [4, 2]]
+
+      # Hub (3) → Upstream meshes (0,1,2)
+      - device: [3, [0, 0]]
+        patterns:
+          - destination:
+              device: [0, [0, 0]]
+      - device: [3, [3, 1]]
+        patterns:
+          - destination:
+              device: [1, [3, 1]]
+      - device: [3, [7, 3]]
+        patterns:
+          - destination:
+              device: [2, [7, 3]]
+
+  # ======================================================================================
+  # All-to-All Pattern (Sequential)
+  # ======================================================================================
+  - name: "FiveGalaxySequentialAllToAll"
+    enable_flow_control: true
+    fabric_setup:
+      topology: Mesh
+      routing_type: Dynamic
+      mesh_descriptor_path: "tests/tt_metal/tt_fabric/custom_mesh_descriptors/5_galaxy_wh_exabox_mgd.textproto"
+
+    parametrization_params:
+      ntype: [unicast_write]
+      size: [128]
+      num_packets: [250]
+
+    patterns:
+      - type: sequential_all_to_all

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_5_galaxy_multi_mesh.yaml
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_5_galaxy_multi_mesh.yaml
@@ -9,31 +9,6 @@ allocation_policies:
 
 Tests:
   # ======================================================================================
-  # Single Sender to Single Receiver
-  # ======================================================================================
-  - name: "FiveGalaxyBasicUnicast"
-    fabric_setup:
-      topology: Mesh
-      routing_type: Dynamic
-      mesh_descriptor_path: "tests/tt_metal/tt_fabric/custom_mesh_descriptors/5_galaxy_wh_exabox_mgd.textproto"
-
-    top_level_iterations: 3
-
-    parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
-      size: [32, 64, 128]
-      num_packets: [100]
-
-    defaults:
-      ftype: unicast
-
-    senders:
-      - device: [0, [0, 0]]
-        patterns:
-          - destination:
-              device: [1, [7, 3]]
-
-  # ======================================================================================
   # Single Sender to Multiple Receivers
   # ======================================================================================
   - name: "FiveGalaxySingleSenderMultiReceiver"
@@ -45,8 +20,8 @@ Tests:
     top_level_iterations: 3
 
     parametrization_params:
-      ntype: [unicast_write, atomic_inc]
-      size: [64, 128]
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+      size: [32, 64, 128]
       num_packets: [100]
 
     defaults:
@@ -100,9 +75,9 @@ Tests:
               device: [0, [3, 1]]
 
   # ======================================================================================
-  # Training Pattern - Hub-based Forward Pass
+  # Hub-and-Spoke Pattern: Tests centralized routing through a hub mesh
   # ======================================================================================
-  - name: "FiveGalaxyTrainingForward"
+  - name: "FiveGalaxyHubAndSpoke"
     fabric_setup:
       topology: Mesh
       routing_type: Dynamic
@@ -144,49 +119,8 @@ Tests:
               device: [4, [4, 2]]
 
   # ======================================================================================
-  # Training Pattern - Hub-based Backward Pass
-  # ======================================================================================
-  - name: "FiveGalaxyTrainingBackward"
-    fabric_setup:
-      topology: Mesh
-      routing_type: Dynamic
-      mesh_descriptor_path: "tests/tt_metal/tt_fabric/custom_mesh_descriptors/5_galaxy_wh_exabox_mgd.textproto"
-
-    top_level_iterations: 3
-
-    defaults:
-      ftype: unicast
-      ntype: unicast_write
-      size: 64
-      num_packets: 50
-
-    senders:
-      # Downstream (4) → Hub (3)
-      - device: [4, [0, 0]]
-        patterns:
-          - destination:
-              device: [3, [0, 0]]
-      - device: [4, [4, 2]]
-        patterns:
-          - destination:
-              device: [3, [4, 2]]
-
-      # Hub (3) → Upstream meshes (0,1,2)
-      - device: [3, [0, 0]]
-        patterns:
-          - destination:
-              device: [0, [0, 0]]
-      - device: [3, [3, 1]]
-        patterns:
-          - destination:
-              device: [1, [3, 1]]
-      - device: [3, [7, 3]]
-        patterns:
-          - destination:
-              device: [2, [7, 3]]
-
-  # ======================================================================================
-  # All-to-All Pattern (Sequential)
+  # All-to-All Pattern (Sequential): Fabric stress test, takes 21400 iterations to complete
+  # when ported to CI pipelines, should be marked as a stress test with appropriate timeout and resource allocation
   # ======================================================================================
   - name: "FiveGalaxySequentialAllToAll"
     enable_flow_control: true

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_5_galaxy_multi_mesh.yaml
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_5_galaxy_multi_mesh.yaml
@@ -86,8 +86,8 @@ Tests:
     top_level_iterations: 3
 
     parametrization_params:
-      size: [64, 128]
-      num_packets: [50]
+      size: [128, 512, 1024, 2048, 4096]
+      num_packets: [250]
 
     defaults:
       ftype: unicast


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/32278

### Problem description

- No existing test configuration for 5-galaxy setup with comprehensive traffic patterns

### What's changed

- Added test suite with traffic patterns ordered by complexity:
  - Basic unicast (single sender → single receiver)
  - Single sender → multiple receivers
  - Multiple senders → single receiver
  - Training patterns (hub-based forward/backward pass)
  - Sequential all-to-all (hardest, deadlock-safe pattern)

### Testing

On one of the 5 all to all hosts:
`ssh local-asaigal@wh-glx-a03u02`
Sync envs:
`./multihost_dev.sh --sync --run`
5 Galaxy Reset:
`mpirun-ulfm --host wh-glx-a03u02,wh-glx-a03u08,wh-glx-a03u14,wh-glx-a04u08,wh-glx-a04u14 --mca btl self,tcp --mca hwloc_base_binding_policy none --tag-output tt-smi -glx_reset > mpi_output.log`
Run newly created tests
`tt-run --rank-binding tests/tt_metal/distributed/config/5_galaxy_wh_exabox_rank_bindings.yaml --mpi-args "--host wh-glx-a03u02,wh-glx-a03u08,wh-glx-a03u14,wh-glx-a04u08,wh-glx-a04u14 --map-by rankfile:file=rankfile.txt --allow-run-as-root --mca btl self,tcp --mca btl_tcp_if_include ens5f0np0 --tag-output"  ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_5_galaxy_multi_mesh.yaml`


Outcome:
Successfully completes the test and closes user mode device drivers, test can be run repeatedly.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes