### PR TITLE
[POOL] Removal of is_avg_pool flag from sliding_window 

### DIFF
--- a/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.cpp
@@ -88,7 +88,6 @@ static std::vector<Tensor> pool2d_invoke(
         .padding = {padding_4d.at(0), padding_4d.at(1), padding_4d.at(2), padding_4d.at(3)},
         .dilation_hw = {dilation_h, dilation_w},
         .ceil_mode = ceil_mode,
-        .is_avg_pool = pool_type == Pool2DType::AVG_POOL2D,
     };
     auto output_shape = sliding_window_config.get_output_shape();
     const bool is_input_tensor_in_dram = input_tensor.memory_config().is_dram();
@@ -246,7 +245,6 @@ static std::vector<Tensor> pool2d_invoke(
         .core_range_set = parallel_config.grid,
         .snap_to_tile = is_out_tiled,
         .ceil_mode = ceil_mode,
-        .is_avg_pool = pool_type == Pool2DType::AVG_POOL2D,
     };
 
     // call the halo uop

--- a/ttnn/cpp/ttnn/operations/sliding_window/sliding_window.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/sliding_window.cpp
@@ -1324,7 +1324,7 @@ std::string SlidingWindowConfig::to_string() const {
            "_dil_h=" + std::to_string(std::get<0>(dilation_hw)) + "_dil_w=" + std::to_string(std::get<1>(dilation_hw)) +
            "_cores_nhw=" + std::to_string(num_cores_nhw) + "_cores_c=" + std::to_string(num_cores_c) +
            "_grid=" + core_range_set.str() + (snap_to_tile ? "_snap_to_tile" : "") + (is_bilinear ? "_bilinear" : "") +
-           (is_transpose ? "_transpose" : "") + (ceil_mode ? "_ceil_mode" : "") + (is_avg_pool ? "_avg_pool" : "");
+           (is_transpose ? "_transpose" : "") + (ceil_mode ? "_ceil_mode" : "");
 }
 
 }  // namespace ttnn::operations::sliding_window

--- a/ttnn/cpp/ttnn/operations/sliding_window/sliding_window.hpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/sliding_window.hpp
@@ -56,7 +56,6 @@ struct SlidingWindowConfig {
     bool is_bilinear = false;
     bool is_transpose = false;
     bool ceil_mode = false;
-    bool is_avg_pool = false;
 
     std::string to_string() const;
     bool has_parallel_config() const;


### PR DESCRIPTION
### Problem description
The flag added to sliding window config is_avg_pool is set but never used. 

### What's changed
Removed the is_avg_pool flag from the pools and sliding window op. Nothing to add is needed since the hash functions already takes into consideration enum pool type to check for the cache hit.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/19300446402)
- [x] [Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/runs/19300471431)