### PR TITLE
#27491: SDXL Transformer sharding

### DIFF
--- a/models/experimental/stable_diffusion_xl_base/refiner/tests/pcc/test_module_tt_attention.py
+++ b/models/experimental/stable_diffusion_xl_base/refiner/tests/pcc/test_module_tt_attention.py
@@ -82,7 +82,7 @@ def test_attention(
     torch_output_tensor = torch_attention(torch_input_tensor, torch_encoder_tensor).unsqueeze(0)
 
     ttnn_input_tensor = ttnn.from_torch(
-        torch_input_tensor,
+        torch_input_tensor.unsqueeze(0),
         dtype=ttnn.bfloat16,
         device=device,
         layout=ttnn.TILE_LAYOUT,

--- a/models/experimental/stable_diffusion_xl_base/refiner/tests/pcc/test_module_tt_transformerblock.py
+++ b/models/experimental/stable_diffusion_xl_base/refiner/tests/pcc/test_module_tt_transformerblock.py
@@ -81,7 +81,7 @@ def test_transformerblock(
         memory_config=ttnn.L1_MEMORY_CONFIG,
     )
     ttnn_input_tensor = ttnn.from_torch(
-        torch_input_tensor,
+        torch_input_tensor.unsqueeze(0),
         dtype=ttnn.bfloat16,
         device=device,
         layout=ttnn.TILE_LAYOUT,

--- a/models/experimental/stable_diffusion_xl_base/refiner/tests/pcc/test_module_tt_unet.py
+++ b/models/experimental/stable_diffusion_xl_base/refiner/tests/pcc/test_module_tt_unet.py
@@ -155,7 +155,7 @@ def run_refiner_unet_model(
 
     ttnn.ReadDeviceProfiler(device)
 
-    _, pcc_message = assert_with_pcc(torch_output_tensor, output_tensor, 0.996)
+    _, pcc_message = assert_with_pcc(torch_output_tensor, output_tensor, 0.997)
     logger.info(f"PCC of first iteration is: {pcc_message}")
 
     for _ in range(iterations - 1):

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_attention.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_attention.py
@@ -68,7 +68,7 @@ def test_attention(
     torch_output_tensor = torch_attention(torch_input_tensor, torch_encoder_tensor).unsqueeze(0)
 
     ttnn_input_tensor = ttnn.from_torch(
-        torch_input_tensor,
+        torch_input_tensor.unsqueeze(0),
         dtype=ttnn.bfloat16,
         device=device,
         layout=ttnn.TILE_LAYOUT,

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_crossattndownblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_crossattndownblock2d.py
@@ -18,8 +18,8 @@ from models.experimental.stable_diffusion_xl_base.tests.test_common import SDXL_
 @pytest.mark.parametrize(
     "input_shape, temb_shape, encoder_shape, query_dim, num_attn_heads, out_dim, down_block_id, pcc",
     [
-        ((1, 320, 64, 64), (1, 1280), (1, 77, 2048), 640, 10, 640, 1, 0.996),
-        ((1, 640, 32, 32), (1, 1280), (1, 77, 2048), 1280, 20, 1280, 2, 0.994),
+        ((1, 320, 64, 64), (1, 1280), (1, 77, 2048), 640, 10, 640, 1, 0.997),
+        ((1, 640, 32, 32), (1, 1280), (1, 77, 2048), 1280, 20, 1280, 2, 0.997),
     ],
 )
 @pytest.mark.parametrize("device_params", [{"l1_small_size": SDXL_L1_SMALL_SIZE}], indirect=True)

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_crossattnmidblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_crossattnmidblock2d.py
@@ -101,5 +101,5 @@ def test_crossattnmid(
     del unet, tt_crosattn
     gc.collect()
 
-    _, pcc_message = assert_with_pcc(torch_output_tensor, output_tensor, 0.995)
+    _, pcc_message = assert_with_pcc(torch_output_tensor, output_tensor, 0.997)
     logger.info(f"PCC is: {pcc_message}")

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_crossattnupblock.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_crossattnupblock.py
@@ -26,7 +26,7 @@ from models.experimental.stable_diffusion_xl_base.tests.test_common import SDXL_
             20,
             1280,
             0,
-            0.984,
+            0.977,
         ),
         (
             (1, 1280, 64, 64),
@@ -37,7 +37,7 @@ from models.experimental.stable_diffusion_xl_base.tests.test_common import SDXL_
             10,
             640,
             1,
-            0.993,
+            0.994,
         ),
     ],
 )

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_crossattnupblock.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_crossattnupblock.py
@@ -26,7 +26,7 @@ from models.experimental.stable_diffusion_xl_base.tests.test_common import SDXL_
             20,
             1280,
             0,
-            0.977,
+            0.975,
         ),
         (
             (1, 1280, 64, 64),

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_transformerblock.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_transformerblock.py
@@ -71,7 +71,7 @@ def test_transformerblock(
         memory_config=ttnn.L1_MEMORY_CONFIG,
     )
     ttnn_input_tensor = ttnn.from_torch(
-        torch_input_tensor,
+        torch_input_tensor.unsqueeze(0),
         dtype=ttnn.bfloat16,
         device=device,
         layout=ttnn.TILE_LAYOUT,

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_transformermodel.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_transformermodel.py
@@ -65,7 +65,7 @@ def test_transformermodel(
         dtype=ttnn.bfloat16,
         device=device,
         layout=ttnn.TILE_LAYOUT,
-        memory_config=ttnn.L1_MEMORY_CONFIG,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
     )
 
     ttnn_input_tensor = ttnn.from_torch(

--- a/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
@@ -52,7 +52,7 @@ def test_unet(
 
 @pytest.mark.models_device_performance_bare_metal
 def test_sdxl_unet_perf_device():
-    expected_device_perf_cycles_per_iteration = 184_754_238
+    expected_device_perf_cycles_per_iteration = 181_807_333
 
     command = f"pytest models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py::test_unet"
     cols = ["DEVICE FW", "DEVICE KERNEL", "DEVICE BRISC KERNEL"]

--- a/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
@@ -52,7 +52,7 @@ def test_unet(
 
 @pytest.mark.models_device_performance_bare_metal
 def test_sdxl_unet_perf_device():
-    expected_device_perf_cycles_per_iteration = 176_574_800
+    expected_device_perf_cycles_per_iteration = 176_075_797
 
     command = f"pytest models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py::test_unet"
     cols = ["DEVICE FW", "DEVICE KERNEL", "DEVICE BRISC KERNEL"]
@@ -117,7 +117,7 @@ def test_refiner_unet(
 
 @pytest.mark.models_device_performance_bare_metal
 def test_sdxl_refiner_unet_perf_device():
-    expected_device_perf_cycles_per_iteration = 547_857_240
+    expected_device_perf_cycles_per_iteration = 547_407_856
 
     command = f"pytest models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py::test_refiner_unet"
     cols = ["DEVICE FW", "DEVICE KERNEL", "DEVICE BRISC KERNEL"]

--- a/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
@@ -52,7 +52,7 @@ def test_unet(
 
 @pytest.mark.models_device_performance_bare_metal
 def test_sdxl_unet_perf_device():
-    expected_device_perf_cycles_per_iteration = 192_316_495
+    expected_device_perf_cycles_per_iteration = 184_754_238
 
     command = f"pytest models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py::test_unet"
     cols = ["DEVICE FW", "DEVICE KERNEL", "DEVICE BRISC KERNEL"]

--- a/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
@@ -52,7 +52,7 @@ def test_unet(
 
 @pytest.mark.models_device_performance_bare_metal
 def test_sdxl_unet_perf_device():
-    expected_device_perf_cycles_per_iteration = 194_350_275
+    expected_device_perf_cycles_per_iteration = 192_316_495
 
     command = f"pytest models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py::test_unet"
     cols = ["DEVICE FW", "DEVICE KERNEL", "DEVICE BRISC KERNEL"]

--- a/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
@@ -52,7 +52,7 @@ def test_unet(
 
 @pytest.mark.models_device_performance_bare_metal
 def test_sdxl_unet_perf_device():
-    expected_device_perf_cycles_per_iteration = 181_807_333
+    expected_device_perf_cycles_per_iteration = 176_574_800
 
     command = f"pytest models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py::test_unet"
     cols = ["DEVICE FW", "DEVICE KERNEL", "DEVICE BRISC KERNEL"]
@@ -117,7 +117,7 @@ def test_refiner_unet(
 
 @pytest.mark.models_device_performance_bare_metal
 def test_sdxl_refiner_unet_perf_device():
-    expected_device_perf_cycles_per_iteration = 551_173_379
+    expected_device_perf_cycles_per_iteration = 547_857_240
 
     command = f"pytest models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py::test_refiner_unet"
     cols = ["DEVICE FW", "DEVICE KERNEL", "DEVICE BRISC KERNEL"]

--- a/models/experimental/stable_diffusion_xl_base/tt/model_configs.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/model_configs.py
@@ -395,11 +395,11 @@ class ModelOptimisations:
 
         self.matmul_configs["2D_TM_LINEAR_640"] = ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
             compute_with_storage_grid_size=(8, 8),
-            in0_block_w=2,
+            in0_block_w=5,  # block sharded input cant use 2 for now, needs optimising
             per_core_M=16,
             per_core_N=3,
-            out_subblock_h=8,
-            out_subblock_w=1,
+            out_subblock_h=1,
+            out_subblock_w=3,  # block sharded output Error: out_subblock_w must be equal to per_core_N or out_subblock_h must be equal to 1.
             transpose_mcast=False,
             fused_activation=None,
         )
@@ -424,6 +424,7 @@ class ModelOptimisations:
             out_subblock_w=3,
             transpose_mcast=False,
             fused_activation=None,
+            fuse_batch=True,
         )
 
         self.matmul_configs["2D_RESNET_CONV_320_640"] = ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
@@ -447,6 +448,7 @@ class ModelOptimisations:
             out_subblock_w=5,
             transpose_mcast=False,
             fused_activation=None,
+            fuse_batch=True,
         )
 
         self.matmul_configs["2D_RESNET_CONV_640_1280"] = ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
@@ -509,14 +511,14 @@ class ModelOptimisations:
 
         self.matmul_configs["2D_ATTN_QKV_LINEAR_1280"] = ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
             compute_with_storage_grid_size=(8, 8),
-            in0_block_w=4,
+            in0_block_w=5,
             per_core_M=4,
             per_core_N=15,
             out_subblock_h=1,
             out_subblock_w=5,
             transpose_mcast=False,
             fused_activation=None,
-            fuse_batch=False,
+            fuse_batch=True,
         )
 
         self.matmul_configs["2D_RESNET_CONV_1920_1280"] = ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(

--- a/models/experimental/stable_diffusion_xl_base/tt/model_configs.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/model_configs.py
@@ -318,7 +318,7 @@ class ModelOptimisations:
 
         self.matmul_configs["2D_FF2_SEQ_LEN_4096"] = ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
             compute_with_storage_grid_size=(7, 8),
-            in0_block_w=10,  # max is 10
+            in0_block_w=5,  # max is 10
             out_subblock_h=1,
             out_subblock_w=3,
             per_core_M=16,

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_attention.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_attention.py
@@ -94,7 +94,7 @@ class TtAttention(LightweightModule):
     def forward(self, hidden_states, attention_mask, encoder_hidden_states=None):
         if encoder_hidden_states is None:
             encoder_hidden_states = hidden_states
-        B = list(hidden_states.shape)[0]
+        B, C, H, W = list(hidden_states.shape)
 
         if self.is_self_attention:
             if self.q_program_config is not None:
@@ -197,7 +197,7 @@ class TtAttention(LightweightModule):
             bias=self.tt_out_bias,
             program_config=self.dense_out_program_config,
             compute_kernel_config=self.default_compute_kernel_config,
-            memory_config=ttnn.L1_MEMORY_CONFIG,
+            memory_config=ttnn.L1_BLOCK_SHARDED_MEMORY_CONFIG if W == 1280 else ttnn.L1_MEMORY_CONFIG,
         )
 
         return hidden_states

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_feedforward.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_feedforward.py
@@ -43,8 +43,4 @@ class TtFeedForward(LightweightModule):
             compute_kernel_config=self.default_compute_kernel_config,
         )
 
-        if list(hidden_states.shape)[-1] == 640 or self.ff2_model_config is None:
-            # due to block sharded mm constraints, if we block shard the input tensor, we can only run it on 56 cores
-            # hence using DRAM memory config instead
-            hidden_states = ttnn.to_memory_config(hidden_states, ttnn.DRAM_MEMORY_CONFIG)
         return hidden_states

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_feedforward.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_feedforward.py
@@ -42,7 +42,7 @@ class TtFeedForward(LightweightModule):
             memory_config=ttnn.L1_BLOCK_SHARDED_MEMORY_CONFIG if self.ff2_model_config is not None else None,
             compute_kernel_config=self.default_compute_kernel_config,
         )
-        # print(f"after FF cfg: {hidden_states.memory_config()}, shape: {hidden_states.shape}")
+
         if list(hidden_states.shape)[-1] == 640:
             # due to block sharded mm constraints, if we block shard the input tensor, we can only run it on 56 cores
             # hence using DRAM memory config instead

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_feedforward.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_feedforward.py
@@ -42,6 +42,9 @@ class TtFeedForward(LightweightModule):
             memory_config=ttnn.L1_BLOCK_SHARDED_MEMORY_CONFIG if self.ff2_model_config is not None else None,
             compute_kernel_config=self.default_compute_kernel_config,
         )
-        hidden_states = ttnn.to_memory_config(hidden_states, ttnn.DRAM_MEMORY_CONFIG)
-
+        # print(f"after FF cfg: {hidden_states.memory_config()}, shape: {hidden_states.shape}")
+        if list(hidden_states.shape)[-1] == 640:
+            # due to block sharded mm constraints, if we block shard the input tensor, we can only run it on 56 cores
+            # hence using DRAM memory config instead
+            hidden_states = ttnn.to_memory_config(hidden_states, ttnn.DRAM_MEMORY_CONFIG)
         return hidden_states

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_feedforward.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_feedforward.py
@@ -43,7 +43,7 @@ class TtFeedForward(LightweightModule):
             compute_kernel_config=self.default_compute_kernel_config,
         )
 
-        if list(hidden_states.shape)[-1] == 640:
+        if list(hidden_states.shape)[-1] == 640 or self.ff2_model_config is None:
             # due to block sharded mm constraints, if we block shard the input tensor, we can only run it on 56 cores
             # hence using DRAM memory config instead
             hidden_states = ttnn.to_memory_config(hidden_states, ttnn.DRAM_MEMORY_CONFIG)

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_geglu.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_geglu.py
@@ -35,35 +35,6 @@ class TtGEGLU(LightweightModule):
                 # due to block sharded mm constraints, if we block shard the input tensor, we can only run it on 56 cores
                 # hence using L1 memory config instead
                 input_tensor = ttnn.to_memory_config(input_tensor, ttnn.L1_MEMORY_CONFIG)
-            # not needed if we shard everything
-            # else:
-            #     # here we can run the block sharded matmul on 64 cores
-            #     block_sharded_mem_config = ttnn.create_sharded_memory_config(
-            #         (input_tensor.shape[2] // 8, input_tensor.shape[3] // 8),
-            #         core_grid=ttnn.CoreGrid(y=8, x=8),
-            #         strategy=ttnn.ShardStrategy.BLOCK,
-            #         orientation=ttnn.ShardOrientation.ROW_MAJOR,
-            #         use_height_and_width_as_shard_shape=True,
-            #     )
-            #     input_tensor = ttnn.to_memory_config(input_tensor, block_sharded_mem_config)
-        
-        # from the sharding branch
-        # if input_tensor.shape[2] == 4096:
-        #     # due to block sharded mm constraints, if we block shard the input tensor, we can only run it on 56 cores
-        #     # hence using L1 memory config instead
-        #     input_tensor = ttnn.to_memory_config(input_tensor, ttnn.L1_MEMORY_CONFIG)
-        # else:
-        #     # here we can run the block sharded matmul on 64 cores
-        #     print(f"Input tensor cfg before GEGLU: {input_tensor.memory_config()}, shape: {input_tensor.shape}")
-        #     block_sharded_mem_config = ttnn.create_sharded_memory_config(
-        #         (input_tensor.shape[2] // 8, input_tensor.shape[3] // 8),
-        #         core_grid=ttnn.CoreGrid(y=8, x=8),
-        #         strategy=ttnn.ShardStrategy.BLOCK,
-        #         orientation=ttnn.ShardOrientation.ROW_MAJOR,
-        #         use_height_and_width_as_shard_shape=True,
-        #     )
-        #     input_tensor = ttnn.to_memory_config(input_tensor, block_sharded_mem_config)
-        #     print(f"Input tensor cfg after GEGLU: {input_tensor.memory_config()}, shape: {input_tensor.shape}")
 
         hidden_states = ttnn.linear(
             input_tensor,

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_geglu.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_geglu.py
@@ -35,16 +35,35 @@ class TtGEGLU(LightweightModule):
                 # due to block sharded mm constraints, if we block shard the input tensor, we can only run it on 56 cores
                 # hence using L1 memory config instead
                 input_tensor = ttnn.to_memory_config(input_tensor, ttnn.L1_MEMORY_CONFIG)
-            else:
-                # here we can run the block sharded matmul on 64 cores
-                block_sharded_mem_config = ttnn.create_sharded_memory_config(
-                    (input_tensor.shape[2] // 8, input_tensor.shape[3] // 8),
-                    core_grid=ttnn.CoreGrid(y=8, x=8),
-                    strategy=ttnn.ShardStrategy.BLOCK,
-                    orientation=ttnn.ShardOrientation.ROW_MAJOR,
-                    use_height_and_width_as_shard_shape=True,
-                )
-                input_tensor = ttnn.to_memory_config(input_tensor, block_sharded_mem_config)
+            # not needed if we shard everything
+            # else:
+            #     # here we can run the block sharded matmul on 64 cores
+            #     block_sharded_mem_config = ttnn.create_sharded_memory_config(
+            #         (input_tensor.shape[2] // 8, input_tensor.shape[3] // 8),
+            #         core_grid=ttnn.CoreGrid(y=8, x=8),
+            #         strategy=ttnn.ShardStrategy.BLOCK,
+            #         orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            #         use_height_and_width_as_shard_shape=True,
+            #     )
+            #     input_tensor = ttnn.to_memory_config(input_tensor, block_sharded_mem_config)
+        
+        # from the sharding branch
+        # if input_tensor.shape[2] == 4096:
+        #     # due to block sharded mm constraints, if we block shard the input tensor, we can only run it on 56 cores
+        #     # hence using L1 memory config instead
+        #     input_tensor = ttnn.to_memory_config(input_tensor, ttnn.L1_MEMORY_CONFIG)
+        # else:
+        #     # here we can run the block sharded matmul on 64 cores
+        #     print(f"Input tensor cfg before GEGLU: {input_tensor.memory_config()}, shape: {input_tensor.shape}")
+        #     block_sharded_mem_config = ttnn.create_sharded_memory_config(
+        #         (input_tensor.shape[2] // 8, input_tensor.shape[3] // 8),
+        #         core_grid=ttnn.CoreGrid(y=8, x=8),
+        #         strategy=ttnn.ShardStrategy.BLOCK,
+        #         orientation=ttnn.ShardOrientation.ROW_MAJOR,
+        #         use_height_and_width_as_shard_shape=True,
+        #     )
+        #     input_tensor = ttnn.to_memory_config(input_tensor, block_sharded_mem_config)
+        #     print(f"Input tensor cfg after GEGLU: {input_tensor.memory_config()}, shape: {input_tensor.shape}")
 
         hidden_states = ttnn.linear(
             input_tensor,

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_transformerblock.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_transformerblock.py
@@ -81,7 +81,7 @@ class TtBasicTransformerBlock(LightweightModule):
 
     def forward(self, input_tensor, attention_mask=None, encoder_hidden_states=None):
         N, C, H, W = list(input_tensor.shape)
-        if C == 640:
+        if W == 640:
             ln_program_config = ttnn.LayerNormShardedMultiCoreProgramConfig(
                 compute_with_storage_grid_size=ttnn.CoreCoord(5, 8),
                 subblock_w=4,
@@ -92,7 +92,7 @@ class TtBasicTransformerBlock(LightweightModule):
                 legacy_rsqrt=True,
             )
             is_base = True
-        elif C == 1280:
+        elif W == 1280:
             ln_program_config = ttnn.LayerNormShardedMultiCoreProgramConfig(
                 compute_with_storage_grid_size=ttnn.CoreCoord(8, 8),
                 subblock_w=5,

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_transformerblock.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_transformerblock.py
@@ -80,7 +80,6 @@ class TtBasicTransformerBlock(LightweightModule):
         )
 
     def forward(self, input_tensor, attention_mask=None, encoder_hidden_states=None):
-        # legacy_config = ttnn.LayerNormDefaultProgramConfig(legacy_reduction=True, legacy_rsqrt=True)
         N, C, H, W = list(input_tensor.shape)
         if C == 640:
             ln_program_config = ttnn.LayerNormShardedMultiCoreProgramConfig(
@@ -108,12 +107,10 @@ class TtBasicTransformerBlock(LightweightModule):
             bias=self.tt_norm1_bias,
             epsilon=self.ln_eps,
             compute_kernel_config=self.ln_compute_kernel_config,
-            # memory_config=ttnn.L1_MEMORY_CONFIG,
-            # program_config=legacy_config,
             memory_config=input_tensor.memory_config(),
             program_config=ln_program_config if input_tensor.is_sharded() else None,
         )
-        print(f"before attn1 cfg: {attn_hidden_states.memory_config()}, shape: {attn_hidden_states.shape}")
+
         attn_hidden_states = self.attn1(attn_hidden_states, attention_mask, None)
         hidden_states = ttnn.add(input_tensor, attn_hidden_states, use_legacy=False)
         ttnn.deallocate(input_tensor)
@@ -124,12 +121,10 @@ class TtBasicTransformerBlock(LightweightModule):
             bias=self.tt_norm2_bias,
             epsilon=self.ln_eps,
             compute_kernel_config=self.ln_compute_kernel_config,
-            # memory_config=ttnn.L1_MEMORY_CONFIG,
-            # program_config=legacy_config,
             memory_config=hidden_states.memory_config(),
             program_config=ln_program_config if hidden_states.is_sharded() else None,
         )
-        print(f"before attn2 cfg: {attn_hidden_states.memory_config()}, shape: {attn_hidden_states.shape}")
+
         attn_hidden_states = self.attn2(attn_hidden_states, attention_mask, encoder_hidden_states)
         hidden_states = ttnn.add(hidden_states, attn_hidden_states, use_legacy=False)
 
@@ -139,11 +134,10 @@ class TtBasicTransformerBlock(LightweightModule):
             bias=self.tt_norm3_bias,
             epsilon=self.ln_eps,
             compute_kernel_config=self.ln_compute_kernel_config,
-            # program_config=legacy_config,
             memory_config=hidden_states.memory_config(),
             program_config=ln_program_config if hidden_states.is_sharded() else None,
         )
-        print(f"before FF cfg: {attn_hidden_states.memory_config()}, shape: {attn_hidden_states.shape}")
+
         attn_hidden_states = self.ff(attn_hidden_states)
         hidden_states = ttnn.add(hidden_states, attn_hidden_states, use_legacy=False)
 

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_transformerblock.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_transformerblock.py
@@ -80,41 +80,92 @@ class TtBasicTransformerBlock(LightweightModule):
         )
 
     def forward(self, input_tensor, attention_mask=None, encoder_hidden_states=None):
-        legacy_config = ttnn.LayerNormDefaultProgramConfig(legacy_reduction=True, legacy_rsqrt=True)
+        # legacy_config = ttnn.LayerNormDefaultProgramConfig(legacy_reduction=True, legacy_rsqrt=True)
+        N, C, H, W = list(input_tensor.shape)
+        if C == 640:
+            ln_program_config = ttnn.LayerNormShardedMultiCoreProgramConfig(
+                compute_with_storage_grid_size=ttnn.CoreCoord(5, 8),
+                subblock_w=1,
+                block_h=16,
+                block_w=4,
+                inplace=False,
+                legacy_reduction=True,
+                legacy_rsqrt=True,
+            )
+        else:
+            ln_program_config = ttnn.LayerNormShardedMultiCoreProgramConfig(
+                compute_with_storage_grid_size=ttnn.CoreCoord(8, 8),
+                subblock_w=1,
+                block_h=4,
+                block_w=5,
+                inplace=False,
+                legacy_reduction=True,
+                legacy_rsqrt=True,
+            )
+        # mem_cfg = input_tensor.memory_config()
+        # print(f"Input tensor cfg at start of TtBasicTransformerBlock: {input_tensor.memory_config()}, shape: {input_tensor.shape}")
+        # input_tensor = ttnn.sharded_to_interleaved(input_tensor, memory_config=ttnn.L1_MEMORY_CONFIG)
         attn_hidden_states = ttnn.layer_norm(
             input_tensor,
             weight=self.tt_norm1_weights,
             bias=self.tt_norm1_bias,
             epsilon=self.ln_eps,
             compute_kernel_config=self.ln_compute_kernel_config,
-            memory_config=ttnn.L1_MEMORY_CONFIG,
-            program_config=legacy_config,
+            # memory_config=ttnn.L1_MEMORY_CONFIG,
+            # program_config=legacy_config,
+            memory_config=input_tensor.memory_config(),
+            program_config=ln_program_config if input_tensor.is_sharded() else None,
         )
+        # attn_hidden_states = ttnn.to_memory_config(attn_hidden_states, ttnn.L1_MEMORY_CONFIG)
         attn_hidden_states = self.attn1(attn_hidden_states, attention_mask, None)
         hidden_states = ttnn.add(input_tensor, attn_hidden_states, use_legacy=False)
         ttnn.deallocate(input_tensor)
+        # print(f"after attn1 cfg: {hidden_states.memory_config()}, shape: {hidden_states.shape}")
 
+        # hidden_states = ttnn.to_memory_config(hidden_states, ttnn.DRAM_MEMORY_CONFIG)
         attn_hidden_states = ttnn.layer_norm(
             hidden_states,
             weight=self.tt_norm2_weights,
             bias=self.tt_norm2_bias,
             epsilon=self.ln_eps,
             compute_kernel_config=self.ln_compute_kernel_config,
-            memory_config=ttnn.L1_MEMORY_CONFIG,
-            program_config=legacy_config,
+            # memory_config=ttnn.L1_MEMORY_CONFIG,
+            # program_config=legacy_config,
+            memory_config=hidden_states.memory_config(),
+            program_config=ln_program_config if hidden_states.is_sharded() else None,
+            # program_config=ttnn.LayerNormShardedMultiCoreProgramConfig(
+            #     compute_with_storage_grid_size=ttnn.CoreCoord(5, 8),
+            #     subblock_w=1,
+            #     block_h=16,
+            #     block_w=4,
+            #     inplace=True,
+            # )
         )
         attn_hidden_states = self.attn2(attn_hidden_states, attention_mask, encoder_hidden_states)
         hidden_states = ttnn.add(hidden_states, attn_hidden_states, use_legacy=False)
+        # print(f"after attn2 cfg: {hidden_states.memory_config()}, shape: {hidden_states.shape}")
 
+        # hidden_states = ttnn.to_memory_config(hidden_states, ttnn.L1_MEMORY_CONFIG)
         attn_hidden_states = ttnn.layer_norm(
             hidden_states,
             weight=self.tt_norm3_weights,
             bias=self.tt_norm3_bias,
             epsilon=self.ln_eps,
             compute_kernel_config=self.ln_compute_kernel_config,
-            program_config=legacy_config,
+            # program_config=legacy_config,
+            memory_config=hidden_states.memory_config(),
+            program_config=ln_program_config if hidden_states.is_sharded() else None,
+            # program_config=ttnn.LayerNormShardedMultiCoreProgramConfig(
+            #     compute_with_storage_grid_size=ttnn.CoreCoord(5, 8),
+            #     subblock_w=1,
+            #     block_h=16,
+            #     block_w=4,
+            #     inplace=True,
+            # )
         )
         attn_hidden_states = self.ff(attn_hidden_states)
         hidden_states = ttnn.add(hidden_states, attn_hidden_states, use_legacy=False)
+
+        # hidden_states = ttnn.interleaved_to_sharded(hidden_states, sharded_memory_config=mem_cfg)
 
         return hidden_states

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_transformermodel.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_transformermodel.py
@@ -93,8 +93,6 @@ class TtTransformer2DModel(LightweightModule):
             compute_kernel_config=self.compute_config_in,
             memory_config=ttnn.L1_BLOCK_SHARDED_MEMORY_CONFIG if C == 1280 else ttnn.L1_MEMORY_CONFIG,
         )
-        print(f"after proj_in cfg: {hidden_states.memory_config()}, shape: {hidden_states.shape}")
-        print(f"{B}, {C}, {H}, {W}")
 
         for i, transformer_block in enumerate(self.transformer_blocks):
             hidden_states = transformer_block(hidden_states, attention_mask, encoder_hidden_states)


### PR DESCRIPTION
### Ticket
#27491

### What's changed
As part of perf optimizations transformer part of SDXL UNet is sharded for 1280 number of channels. We avoid sharding 640 channels to maximize the core grid that is used.

Note: accuracy test passed in Shield CI

### Checklist
- [x] [(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/19301687527) CI passes
- [x] [Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/runs/19301644736) CI passes
- [x] [(Single-card) Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/runs/19301657709) CI passes 
- [x] [(Single-card) Demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/19301862098) CI passes