### PR TITLE
Transitioning control plane to topology mapper

### DIFF
--- a/tests/scripts/run_cpp_fabric_tests.sh
+++ b/tests/scripts/run_cpp_fabric_tests.sh
@@ -84,6 +84,7 @@ tt-run --mock-cluster-rank-binding tests/tt_metal/tt_fabric/custom_mock_cluster_
 tt-run --mock-cluster-rank-binding tests/tt_metal/tt_fabric/custom_mock_cluster_descriptors/bh_qb_4x4_cluster_desc_mapping.yaml --rank-binding tests/tt_metal/distributed/config/bh_qb_4x4_rank_bindings.yaml --mpi-args "--mca btl self,tcp --mca btl_tcp_if_include eth0 --tag-output --allow-run-as-root" ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="MultiHost.TestBHQB4x4Fabric2DSanity"
 
 # Topology Mapper tests
+TT_METAL_MOCK_CLUSTER_DESC_PATH=tests/tt_metal/tt_fabric/custom_mock_cluster_descriptors/t3k_cluster_desc.yaml TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="T3kTopologyMapperCustomMapping/*"
 TT_METAL_MOCK_CLUSTER_DESC_PATH=tests/tt_metal/tt_fabric/custom_mock_cluster_descriptors/t3k_cluster_desc.yaml TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter=TopologyMapperTest.T3kMeshGraphTest
 TT_METAL_MOCK_CLUSTER_DESC_PATH=tests/tt_metal/tt_fabric/custom_mock_cluster_descriptors/n300_cluster_desc.yaml TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter=TopologyMapperTest.N300MeshGraphTest
 TT_METAL_MOCK_CLUSTER_DESC_PATH=tests/tt_metal/tt_fabric/custom_mock_cluster_descriptors/p100_cluster_desc.yaml TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter=TopologyMapperTest.P100MeshGraphTest

--- a/tests/tt_metal/tt_fabric/fabric_router/test_topology_mapper.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_topology_mapper.cpp
@@ -5,11 +5,15 @@
 #include <tt-metalium/mesh_graph.hpp>
 #include <tt-metalium/mesh_graph_descriptor.hpp>
 #include <tt-metalium/control_plane.hpp>
+#include <tt-metalium/fabric_types.hpp>
 #include "impl/context/metal_context.hpp"
 #include <memory>
+#include <unordered_set>
 
 #include "tt_metal/fabric/physical_system_descriptor.hpp"
 #include "tt_metal/fabric/topology_mapper.hpp"
+#include "t3k_mesh_descriptor_chip_mappings.hpp"
+#include "utils.hpp"
 
 namespace tt::tt_fabric {
 
@@ -456,5 +460,122 @@ TEST_F(TopologyMapperTest, PinningThrowsOnBadAsicPositionGalaxyMesh) {
     EXPECT_THROW(
         TopologyMapper(mesh_graph, *physical_system_descriptor_, local_mesh_binding, pins_missing), std::exception);
 }
+
+// Parameterized test fixture for testing TopologyMapper with custom mappings
+class T3kTopologyMapperWithCustomMappingFixture
+    : public TopologyMapperTest,
+      public testing::WithParamInterface<std::tuple<std::string, std::vector<std::vector<EthCoord>>>> {};
+
+TEST_P(T3kTopologyMapperWithCustomMappingFixture, T3kMeshGraphWithCustomMapping) {
+    auto [mesh_graph_desc_path, mesh_graph_eth_coords] = GetParam();
+    const std::filesystem::path t3k_mesh_graph_desc_path =
+        std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) / mesh_graph_desc_path;
+
+    auto mesh_graph = MeshGraph(t3k_mesh_graph_desc_path.string());
+
+    // Create logical to physical chip mapping from eth_coords
+    auto logical_mesh_chip_id_to_physical_chip_id_mapping =
+        fabric_router_tests::get_physical_chip_mapping_from_eth_coords_mapping(mesh_graph_eth_coords);
+
+    // Determine which meshes are in the mapping and create local mesh binding
+    std::unordered_set<MeshId> mesh_ids_in_mapping;
+    for (const auto& [fabric_node_id, _] : logical_mesh_chip_id_to_physical_chip_id_mapping) {
+        mesh_ids_in_mapping.insert(fabric_node_id.mesh_id);
+    }
+
+    // Create local mesh binding - use the first mesh ID found, or all meshes if multi-mesh
+    LocalMeshBinding local_mesh_binding;
+    if (mesh_ids_in_mapping.size() == 1) {
+        local_mesh_binding.mesh_ids = {*mesh_ids_in_mapping.begin()};
+    } else {
+        // For multi-mesh cases, bind to all meshes
+        local_mesh_binding.mesh_ids.assign(mesh_ids_in_mapping.begin(), mesh_ids_in_mapping.end());
+    }
+    local_mesh_binding.host_rank = MeshHostRankId{0};
+
+    // Create TopologyMapper using the new constructor that skips discovery
+    auto topology_mapper_with_mapping = TopologyMapper(
+        mesh_graph, *physical_system_descriptor_, local_mesh_binding, logical_mesh_chip_id_to_physical_chip_id_mapping);
+
+    // Verify that the mapper correctly uses the provided mapping for each mesh
+    for (const auto& mesh_id : mesh_ids_in_mapping) {
+        const auto mesh_shape = mesh_graph.get_mesh_shape(mesh_id);
+        const auto mesh_size = mesh_shape.mesh_size();
+
+        // Verify all fabric nodes in this mesh
+        for (ChipId chip_id = 0; chip_id < mesh_size; ++chip_id) {
+            FabricNodeId fabric_node_id(mesh_id, chip_id);
+
+            // Skip if this fabric node is not in the provided mapping (for multi-mesh cases)
+            if (logical_mesh_chip_id_to_physical_chip_id_mapping.find(fabric_node_id) ==
+                logical_mesh_chip_id_to_physical_chip_id_mapping.end()) {
+                continue;
+            }
+
+            // Verify that the physical chip ID matches what we provided
+            auto phys_chip_id_from_mapper =
+                topology_mapper_with_mapping.get_physical_chip_id_from_fabric_node_id(fabric_node_id);
+            auto expected_phys_chip_id = logical_mesh_chip_id_to_physical_chip_id_mapping.at(fabric_node_id);
+            EXPECT_EQ(phys_chip_id_from_mapper, expected_phys_chip_id)
+                << "Physical chip ID mismatch for fabric node " << fabric_node_id << " (mesh_id=" << mesh_id.get()
+                << ", chip_id=" << chip_id << ")";
+
+            // Verify bidirectional mappings work correctly
+            auto asic_id = topology_mapper_with_mapping.get_asic_id_from_fabric_node_id(fabric_node_id);
+            EXPECT_EQ(topology_mapper_with_mapping.get_fabric_node_id_from_asic_id(asic_id), fabric_node_id);
+            EXPECT_EQ(
+                topology_mapper_with_mapping.get_fabric_node_id_from_physical_chip_id(phys_chip_id_from_mapper),
+                fabric_node_id);
+
+            // Verify physical chip ID to ASIC ID conversion
+            auto phys_chip_id_from_asic = topology_mapper_with_mapping.get_physical_chip_id_from_asic_id(asic_id);
+            EXPECT_EQ(phys_chip_id_from_asic, expected_phys_chip_id);
+        }
+
+        // Verify host rank structures are built correctly
+        const auto& host_ranks = topology_mapper_with_mapping.get_host_ranks(mesh_id);
+        EXPECT_GT(host_ranks.size(), 0u) << "No host ranks found for mesh " << mesh_id.get();
+
+        // Verify mesh shape matches mesh graph
+        auto mapper_mesh_shape = topology_mapper_with_mapping.get_mesh_shape(mesh_id);
+        EXPECT_EQ(mapper_mesh_shape, mesh_shape) << "Mesh shape mismatch for mesh " << mesh_id.get();
+
+        // Verify coordinate range
+        auto coord_range = topology_mapper_with_mapping.get_coord_range(mesh_id);
+        auto expected_coord_range = mesh_graph.get_coord_range(mesh_id);
+        EXPECT_EQ(coord_range.start_coord(), expected_coord_range.start_coord())
+            << "Coordinate range start mismatch for mesh " << mesh_id.get();
+        EXPECT_EQ(coord_range.end_coord(), expected_coord_range.end_coord())
+            << "Coordinate range end mismatch for mesh " << mesh_id.get();
+
+        // Verify chip IDs
+        auto chip_ids = topology_mapper_with_mapping.get_chip_ids(mesh_id);
+        EXPECT_EQ(chip_ids.size(), mesh_size) << "Chip IDs size mismatch for mesh " << mesh_id.get();
+    }
+
+    // Verify local logical mesh chip id to physical chip id mapping
+    auto local_mapping = topology_mapper_with_mapping.get_local_logical_mesh_chip_id_to_physical_chip_id_mapping();
+    const auto& my_host = physical_system_descriptor_->my_host_name();
+
+    // Count how many chips from the provided mapping are on this host
+    size_t expected_local_mapping_size = 0;
+    for (const auto& [fabric_node_id, physical_chip_id] : logical_mesh_chip_id_to_physical_chip_id_mapping) {
+        auto asic_id = topology_mapper_with_mapping.get_asic_id_from_fabric_node_id(fabric_node_id);
+        if (physical_system_descriptor_->get_host_name_for_asic(asic_id) == my_host) {
+            expected_local_mapping_size++;
+            EXPECT_EQ(local_mapping.at(fabric_node_id), physical_chip_id)
+                << "Local mapping mismatch for fabric node " << fabric_node_id;
+        }
+    }
+    EXPECT_EQ(local_mapping.size(), expected_local_mapping_size)
+        << "Local mapping size mismatch. Expected " << expected_local_mapping_size << " but got "
+        << local_mapping.size();
+}
+
+// Instantiate the parameterized test with all t3k mesh descriptor chip mappings
+INSTANTIATE_TEST_SUITE_P(
+    T3kTopologyMapperCustomMapping,
+    T3kTopologyMapperWithCustomMappingFixture,
+    ::testing::ValuesIn(fabric_router_tests::t3k_mesh_descriptor_chip_mappings));
 
 }  // namespace tt::tt_fabric

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -461,8 +461,12 @@ void ControlPlane::init_control_plane(
     this->initialize_distributed_contexts();
 
     if (logical_mesh_chip_id_to_physical_chip_id_mapping.has_value()) {
-        // Do not initialize topology mapper if user provided physical chip mapping
-        this->topology_mapper_ = nullptr;
+        // Initialize topology mapper with provided mapping, skipping discovery
+        this->topology_mapper_ = std::make_unique<tt::tt_fabric::TopologyMapper>(
+            *this->routing_table_generator_->mesh_graph,
+            *this->physical_system_descriptor_,
+            this->local_mesh_binding_,
+            logical_mesh_chip_id_to_physical_chip_id_mapping->get());
         this->load_physical_chip_mapping(logical_mesh_chip_id_to_physical_chip_id_mapping->get());
     } else {
         std::vector<std::pair<AsicPosition, FabricNodeId>> fixed_asic_position_pinnings;
@@ -628,12 +632,8 @@ void ControlPlane::convert_fabric_routing_table_to_chip_routing_table() {
     for (std::uint32_t mesh_id_val = 0; mesh_id_val < router_intra_mesh_routing_table.size(); mesh_id_val++) {
         MeshId mesh_id{mesh_id_val};
         if (this->is_local_mesh(mesh_id)) {
-            // TODO: Remove this once Topology mapper works for multi-mesh systems
             // Get the number of ports per chip from any chip in the local mesh
-            auto local_mesh_chip_id_container =
-                (this->topology_mapper_ == nullptr)
-                    ? this->routing_table_generator_->mesh_graph->get_chip_ids(mesh_id, host_rank_id)
-                    : this->topology_mapper_->get_chip_ids(mesh_id, host_rank_id);
+            auto local_mesh_chip_id_container = this->topology_mapper_->get_chip_ids(mesh_id, host_rank_id);
 
             for (const auto& [_, src_fabric_chip_id] : local_mesh_chip_id_container) {
                 const auto src_fabric_node_id = FabricNodeId(mesh_id, src_fabric_chip_id);
@@ -865,11 +865,8 @@ void ControlPlane::configure_routing_tables_for_fabric_ethernet_channels(
         }
         const auto& local_mesh_coord_range = this->get_coord_range(mesh_id, MeshScope::LOCAL);
 
-        // TODO: Remove this once Topology mapper works for multi-mesh systems
         MeshContainer<ChipId> local_mesh_chip_id_container =
-            (this->topology_mapper_ == nullptr)
-                ? this->routing_table_generator_->mesh_graph->get_chip_ids(mesh_id, host_rank_id)
-                : this->topology_mapper_->get_chip_ids(mesh_id, host_rank_id);
+            this->topology_mapper_->get_chip_ids(mesh_id, host_rank_id);
 
         for (const auto& [_, fabric_chip_id] : local_mesh_chip_id_container) {
             const auto fabric_node_id = FabricNodeId(mesh_id, fabric_chip_id);
@@ -925,10 +922,7 @@ void ControlPlane::configure_routing_tables_for_fabric_ethernet_channels(
                     }
                 } else {
                     auto host_rank_for_chip =
-                        (this->topology_mapper_ == nullptr)
-                            ? this->routing_table_generator_->mesh_graph->get_host_rank_for_chip(
-                                  mesh_id, logical_connected_chip_id)
-                            : this->topology_mapper_->get_host_rank_for_chip(mesh_id, logical_connected_chip_id);
+                        this->topology_mapper_->get_host_rank_for_chip(mesh_id, logical_connected_chip_id);
                     TT_ASSERT(
                         host_rank_for_chip.has_value(),
                         "Mesh {} Chip {} does not have a host rank associated with it",
@@ -1512,10 +1506,7 @@ static void write_to_all_cores(
 void ControlPlane::compute_and_embed_1d_routing_path_table(
     MeshId mesh_id, tensix_routing_l1_info_t& tensix_routing_info) const {
     auto host_rank_id = this->get_local_host_rank_id_binding();
-    const auto& local_mesh_chip_id_container =
-        (this->topology_mapper_ == nullptr)
-            ? this->routing_table_generator_->mesh_graph->get_chip_ids(mesh_id, host_rank_id)
-            : this->topology_mapper_->get_chip_ids(mesh_id, host_rank_id);
+    const auto& local_mesh_chip_id_container = this->topology_mapper_->get_chip_ids(mesh_id, host_rank_id);
     uint16_t num_chips = MAX_CHIPS_LOWLAT_1D < local_mesh_chip_id_container.size()
                              ? MAX_CHIPS_LOWLAT_1D
                              : static_cast<uint16_t>(local_mesh_chip_id_container.size());
@@ -1530,10 +1521,7 @@ void ControlPlane::compute_and_embed_1d_routing_path_table(
 void ControlPlane::compute_and_embed_2d_routing_path_table(
     MeshId mesh_id, ChipId chip_id, tensix_routing_l1_info_t& tensix_routing_info) const {
     auto host_rank_id = this->get_local_host_rank_id_binding();
-    auto local_mesh_chip_id_container =
-        (this->topology_mapper_ == nullptr)
-            ? this->routing_table_generator_->mesh_graph->get_chip_ids(mesh_id, host_rank_id)
-            : this->topology_mapper_->get_chip_ids(mesh_id, host_rank_id);
+    auto local_mesh_chip_id_container = this->topology_mapper_->get_chip_ids(mesh_id, host_rank_id);
 
     bool chip_is_local_to_host = false;
     for (const auto& [_, local_chip_id] : local_mesh_chip_id_container) {
@@ -1820,11 +1808,6 @@ MeshShape ControlPlane::get_physical_mesh_shape(MeshId mesh_id, MeshScope scope)
     std::optional<MeshHostRankId> local_host_rank_id =
         MeshScope::LOCAL == scope ? std::make_optional(this->get_local_host_rank_id_binding()) : std::nullopt;
 
-    // TODO: Remove this once Topology mapper works for multi-mesh systems
-    if (this->topology_mapper_ == nullptr) {
-        return this->routing_table_generator_->mesh_graph->get_mesh_shape(mesh_id, local_host_rank_id);
-    }
-
     return this->topology_mapper_->get_mesh_shape(mesh_id, local_host_rank_id);
 }
 
@@ -2041,11 +2024,6 @@ MeshCoordinate ControlPlane::get_local_mesh_offset() const {
 MeshCoordinateRange ControlPlane::get_coord_range(MeshId mesh_id, MeshScope scope) const {
     std::optional<MeshHostRankId> local_host_rank_id =
         MeshScope::LOCAL == scope ? std::make_optional(this->get_local_host_rank_id_binding()) : std::nullopt;
-
-    // TODO: Remove this once Topology mapper works for multi-mesh systems
-    if (this->topology_mapper_ == nullptr) {
-        return this->routing_table_generator_->mesh_graph->get_coord_range(mesh_id, local_host_rank_id);
-    }
 
     return this->topology_mapper_->get_coord_range(mesh_id, local_host_rank_id);
 }

--- a/tt_metal/fabric/topology_mapper.hpp
+++ b/tt_metal/fabric/topology_mapper.hpp
@@ -63,6 +63,14 @@ public:
         const LocalMeshBinding& local_mesh_binding,
         const std::vector<std::pair<AsicPosition, FabricNodeId>>& fixed_asic_position_pinnings);
 
+    // Construct a TopologyMapper from a pre-provided logical mesh chip to physical chip mapping.
+    // Skips discovery and builds fabric node id to asic id mapping directly from the provided mapping.
+    TopologyMapper(
+        const MeshGraph& mesh_graph,
+        const tt::tt_metal::PhysicalSystemDescriptor& physical_system_descriptor,
+        const LocalMeshBinding& local_mesh_binding,
+        const std::map<FabricNodeId, ChipId>& logical_mesh_chip_id_to_physical_chip_id_mapping);
+
     /**
      * @brief Get logical mesh graph connectivity
      *


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/31527)

### Problem description
Current Control Plane data flow looks like this:
<img width="1786" height="748" alt="image" src="https://github.com/user-attachments/assets/fc2c91ae-9416-4f34-9c67-f404c4aac614" />

I would like to transition it to eventually be streamlined like this:
<img width="1582" height="422" alt="image" src="https://github.com/user-attachments/assets/e8e75660-5af8-4cb1-b2f9-b0047eb725b5" />

This means, that any Rank binding or physical to logical mapping APIs should use topology mapper, not mesh graph.

### What's changed
- [x] Changed control plane queries for rank bindings to use topology mapper instead of mesh graph
   - Topology mapper APIs are currently a duplicate of the mesh graph APIs and function exactly the same
   - There should be no functional difference, eventually any APIs relating to 
- [x] Added support for custom logical to physical mappings with topology mapper
- [x] Added tests for multi-mesh t3k tests

### Checklist
- [x] [APC](https://github.com/tenstorrent/tt-metal/actions/runs/19303562915)
- [x] [T3k Tests](https://github.com/tenstorrent/tt-metal/actions/runs/19303582909)