### PR TITLE
[skip ci] Fix vit path for test_demo_vit_ttnn_inference_perf_e2e_2cq_trace.py

### DIFF
--- a/tests/scripts/single_card/run_single_card_demo_tests.sh
+++ b/tests/scripts/single_card/run_single_card_demo_tests.sh
@@ -388,7 +388,7 @@ run_vovnet_demo(){
 
 run_vit_demo(){
 
- pytest models/demos/wormhole/vit/demo/test_demo_vit_ttnn_inference_perf_e2e_2cq_trace.py
+ pytest models/demos/wormhole/vit/tests/test_demo_vit_ttnn_inference_perf_e2e_2cq_trace.py
 
 }
 


### PR DESCRIPTION
### What's changed
File seems to have been reorganized but the path was not updated causing this failure: https://github.com/tenstorrent/tt-metal/actions/runs/19298721577/job/55187828026#step:8:17