### PR TITLE
Adding mcast support to dev api 2.0

### DIFF
--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_matmul_tile_layout_in0_receiver_in1_receiver.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_matmul_tile_layout_in0_receiver_in1_receiver.cpp
@@ -42,8 +42,8 @@ void kernel_main() {
     uint32_t in0_mcast_num_dests = get_arg_val<uint32_t>(21);
     uint32_t in0_mcast_sender_noc_x = get_arg_val<uint32_t>(22);
     uint32_t in0_mcast_sender_noc_y = get_arg_val<uint32_t>(23);
-    uint32_t in0_mcast_sender_semaphore_addr = get_semaphore(get_arg_val<uint32_t>(24));
-    uint32_t in0_mcast_receiver_semaphore_addr = get_semaphore(get_arg_val<uint32_t>(25));
+    uint32_t in0_mcast_sender_semaphore_id = get_arg_val<uint32_t>(24);
+    uint32_t in0_mcast_receiver_semaphore_id = get_arg_val<uint32_t>(25);
 
     // in1 mcast args
     uint32_t in1_mcast_dest_noc_start_x = get_arg_val<uint32_t>(26);
@@ -53,47 +53,47 @@ void kernel_main() {
     uint32_t in1_mcast_num_dests = get_arg_val<uint32_t>(30);
     uint32_t in1_mcast_sender_noc_x = get_arg_val<uint32_t>(31);
     uint32_t in1_mcast_sender_noc_y = get_arg_val<uint32_t>(32);
-    uint32_t in1_mcast_sender_semaphore_addr = get_semaphore(get_arg_val<uint32_t>(33));
-    uint32_t in1_mcast_receiver_semaphore_addr = get_semaphore(get_arg_val<uint32_t>(34));
+    uint32_t in1_mcast_sender_semaphore_id = get_arg_val<uint32_t>(33);
+    uint32_t in1_mcast_receiver_semaphore_id = get_arg_val<uint32_t>(34);
+
+    experimental::Noc noc;
 
     constexpr uint32_t cb_id_in0 = 0;
     constexpr uint32_t cb_id_in1 = 1;
+    experimental::CircularBuffer cb_in0(cb_id_in0);
+    experimental::CircularBuffer cb_in1(cb_id_in1);
 
-    volatile tt_l1_ptr uint32_t* in0_mcast_receiver_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(in0_mcast_receiver_semaphore_addr);
-    volatile tt_l1_ptr uint32_t* in1_mcast_receiver_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(in1_mcast_receiver_semaphore_addr);
+    experimental::Semaphore in0_mcast_sender_semaphore(in0_mcast_sender_semaphore_id);
+    experimental::Semaphore in0_mcast_receiver_semaphore(in0_mcast_receiver_semaphore_id);
+    experimental::Semaphore in1_mcast_sender_semaphore(in1_mcast_sender_semaphore_id);
+    experimental::Semaphore in1_mcast_receiver_semaphore(in1_mcast_receiver_semaphore_id);
 
     for (uint32_t b = 0; b < num_blocks; b++) {
         // Operand 0
-        cb_reserve_back(cb_id_in0, in0_block_num_tiles);
+        cb_in0.reserve_back(in0_block_num_tiles);
 
         // Set in0 semaphore value to INVALID
-        noc_semaphore_set(in0_mcast_receiver_semaphore_addr_ptr, INVALID);
+        in0_mcast_receiver_semaphore.set(INVALID);
 
         // Atomic increment source core counter
-        uint64_t in0_mcast_sender_semaphore_noc_addr =
-            get_noc_addr(in0_mcast_sender_noc_x, in0_mcast_sender_noc_y, in0_mcast_sender_semaphore_addr);
-        noc_semaphore_inc(in0_mcast_sender_semaphore_noc_addr, 1);
+        in0_mcast_sender_semaphore.up(noc, in0_mcast_sender_noc_x, in0_mcast_sender_noc_y, 1);
 
         // wait on in0 semaphore value to become VALID (set by mcast sender after it multicasts data)
-        noc_semaphore_wait(in0_mcast_receiver_semaphore_addr_ptr, VALID);
+        in0_mcast_receiver_semaphore.wait(VALID);
 
-        cb_push_back(cb_id_in0, in0_block_num_tiles);
+        cb_in0.push_back(in0_block_num_tiles);
 
         // Operand 1
-        cb_reserve_back(cb_id_in1, in1_block_num_tiles);
+        cb_in1.reserve_back(in1_block_num_tiles);
 
         // Set in1 semaphore value to INVALID
-        noc_semaphore_set(in1_mcast_receiver_semaphore_addr_ptr, INVALID);
+        in1_mcast_receiver_semaphore.set(INVALID);
 
-        uint64_t in1_mcast_sender_semaphore_noc_addr =
-            get_noc_addr(in1_mcast_sender_noc_x, in1_mcast_sender_noc_y, in1_mcast_sender_semaphore_addr);
-        noc_semaphore_inc(in1_mcast_sender_semaphore_noc_addr, 1);
+        in1_mcast_sender_semaphore.up(noc, in1_mcast_sender_noc_x, in1_mcast_sender_noc_y, 1);
 
         // wait on in1 semaphore value to become VALID (set by mcast sender after it multicasts data)
-        noc_semaphore_wait(in1_mcast_receiver_semaphore_addr_ptr, VALID);
+        in1_mcast_receiver_semaphore.wait(VALID);
 
-        cb_push_back(cb_id_in1, in1_block_num_tiles);
+        cb_in1.push_back(in1_block_num_tiles);
     }
 }

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_matmul_tile_layout_in0_receiver_in1_sender.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_matmul_tile_layout_in0_receiver_in1_sender.cpp
@@ -42,8 +42,8 @@ void kernel_main() {
     uint32_t in0_mcast_num_dests = get_arg_val<uint32_t>(21);
     uint32_t in0_mcast_sender_noc_x = get_arg_val<uint32_t>(22);
     uint32_t in0_mcast_sender_noc_y = get_arg_val<uint32_t>(23);
-    uint32_t in0_mcast_sender_semaphore_addr = get_semaphore(get_arg_val<uint32_t>(24));
-    uint32_t in0_mcast_receiver_semaphore_addr = get_semaphore(get_arg_val<uint32_t>(25));
+    uint32_t in0_mcast_sender_semaphore_id = get_arg_val<uint32_t>(24);
+    uint32_t in0_mcast_receiver_semaphore_id = get_arg_val<uint32_t>(25);
 
     // in1 mcast args
     uint32_t in1_mcast_dest_noc_start_x = get_arg_val<uint32_t>(26);
@@ -53,8 +53,8 @@ void kernel_main() {
     uint32_t in1_mcast_num_dests = get_arg_val<uint32_t>(30);
     uint32_t in1_mcast_sender_noc_x = get_arg_val<uint32_t>(31);
     uint32_t in1_mcast_sender_noc_y = get_arg_val<uint32_t>(32);
-    uint32_t in1_mcast_sender_semaphore_addr = get_semaphore(get_arg_val<uint32_t>(33));
-    uint32_t in1_mcast_receiver_semaphore_addr = get_semaphore(get_arg_val<uint32_t>(34));
+    uint32_t in1_mcast_sender_semaphore_id = get_arg_val<uint32_t>(33);
+    uint32_t in1_mcast_receiver_semaphore_id = get_arg_val<uint32_t>(34);
     // const args for tile-based bank-swizzled layout
     // could be added to the arg list in the future to test different
     // bank-swizzling configurations
@@ -62,26 +62,24 @@ void kernel_main() {
     constexpr uint32_t num_used_dram_ch_pow2_exponent = 3;
     constexpr uint32_t tile_size_pow2_exponent = 11;
 
+    experimental::Noc noc;
+
     constexpr uint32_t cb_id_in0 = 0;
     constexpr uint32_t cb_id_in1 = 1;
+    experimental::CircularBuffer cb_in0(cb_id_in0);
+    experimental::CircularBuffer cb_in1(cb_id_in1);
 
-    uint32_t single_tile_size_bytes = get_tile_size(cb_id_in0);
-
-    uint32_t l1_write_addr_in1;
+    uint32_t single_tile_size_bytes = cb_in0.get_tile_size();
 
     uint32_t in1_tensor_current_block_start_tile_id = in1_tensor_start_tile_id;
 
-    volatile tt_l1_ptr uint32_t* in0_mcast_receiver_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(in0_mcast_receiver_semaphore_addr);
+    experimental::Semaphore in0_mcast_sender_semaphore(in0_mcast_sender_semaphore_id);
+    experimental::Semaphore in0_mcast_receiver_semaphore(in0_mcast_receiver_semaphore_id);
+    experimental::Semaphore in1_mcast_sender_semaphore(in1_mcast_sender_semaphore_id);
+    experimental::Semaphore in1_mcast_receiver_semaphore(in1_mcast_receiver_semaphore_id);
 
     // Set ur local VALID value, to be mcasted to destinations flag address after the data has been mcasted
-    volatile tt_l1_ptr uint32_t* in1_mcast_receiver_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(in1_mcast_receiver_semaphore_addr);
-    *(in1_mcast_receiver_semaphore_addr_ptr) = VALID;
-    // local address that will be atomically incremented by mcast receivers, to know when all receivers are ready
-    // to receive the mcast
-    volatile tt_l1_ptr uint32_t* in1_mcast_sender_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(in1_mcast_sender_semaphore_addr);
+    in1_mcast_receiver_semaphore.set(VALID);
 
     constexpr auto in0_args = TensorAccessorArgs<0>();
     constexpr auto in1_args = TensorAccessorArgs<in0_args.next_compile_time_args_offset()>();
@@ -89,26 +87,22 @@ void kernel_main() {
 
     for (uint32_t b = 0; b < num_blocks; b++) {
         // Operand 0
-        cb_reserve_back(cb_id_in0, in0_block_num_tiles);
+        cb_in0.reserve_back(in0_block_num_tiles);
 
         // Set in0 semaphore value to INVALID
-        noc_semaphore_set(in0_mcast_receiver_semaphore_addr_ptr, INVALID);
+        in0_mcast_receiver_semaphore.set(INVALID);
 
         // Atomic increment source core counter
-        uint64_t in0_mcast_sender_semaphore_noc_addr =
-            get_noc_addr(in0_mcast_sender_noc_x, in0_mcast_sender_noc_y, in0_mcast_sender_semaphore_addr);
-        noc_semaphore_inc(in0_mcast_sender_semaphore_noc_addr, 1);
+        in0_mcast_sender_semaphore.up(noc, in0_mcast_sender_noc_x, in0_mcast_sender_noc_y, 1);
 
         // wait on in0 semaphore value to become VALID (set by mcast sender after it multicasts data)
-        noc_semaphore_wait(in0_mcast_receiver_semaphore_addr_ptr, VALID);
+        in0_mcast_receiver_semaphore.wait(VALID);
 
-        cb_push_back(cb_id_in0, in0_block_num_tiles);
+        cb_in0.push_back(in0_block_num_tiles);
 
         // Operand 1
-        cb_reserve_back(cb_id_in1, in1_block_num_tiles);
-        l1_write_addr_in1 = get_write_ptr(cb_id_in1);
+        cb_in1.reserve_back(in1_block_num_tiles);
 
-        uint32_t in1_start_address = l1_write_addr_in1;  // copy start address of block, to be used for mcasting
         uint32_t in1_block_size_bytes = 0;               // can be optimized later, pass it to kernel
 
         // Copy in1 block into CB, as the default kernel
@@ -116,9 +110,12 @@ void kernel_main() {
         for (uint32_t h = 0; h < in1_block_h; h++) {
             uint32_t in1_tensor_tile_id = in1_tensor_row_start_tile_id;
             for (uint32_t w = 0; w < in1_block_w; w++) {
-                uint64_t in1_tile_noc_address = get_noc_addr(in1_tensor_tile_id, s1);
-                noc_async_read(in1_tile_noc_address, l1_write_addr_in1, single_tile_size_bytes);
-                l1_write_addr_in1 += single_tile_size_bytes;
+                noc.async_read(
+                    s1,
+                    cb_in1,
+                    single_tile_size_bytes,
+                    {.page_id = in1_tensor_tile_id},
+                    {.offset_bytes = ((h * in1_block_w + w) * single_tile_size_bytes)});
                 in1_tensor_tile_id += in1_tensor_stride_w;
                 in1_block_size_bytes += single_tile_size_bytes;
             }
@@ -127,23 +124,24 @@ void kernel_main() {
         in1_tensor_current_block_start_tile_id += in1_tensor_next_block_stride;
 
         // Barrier! make sure the reads are done
-        noc_async_read_barrier();
+        noc.async_read_barrier();
 
         // wait until all in1 mcast destinations have atomically incremented the in1 semaphore_addr (i.e. its value
         // should be in0_mcast_num_dests), then reset the semaphore_addr value back to zero for the next block
-        noc_semaphore_wait(in1_mcast_sender_semaphore_addr_ptr, in1_mcast_num_dests);
-        noc_semaphore_set(in1_mcast_sender_semaphore_addr_ptr, 0);
+        in1_mcast_sender_semaphore.down(in1_mcast_num_dests);
 
         // Now we have the block in the CB address, we can mcast to dests!
-        uint64_t in1_multicast_data_addr = get_noc_multicast_addr(
-            in1_mcast_dest_noc_start_x,
-            in1_mcast_dest_noc_start_y,
-            in1_mcast_dest_noc_end_x,
-            in1_mcast_dest_noc_end_y,
-            in1_start_address);
         // num_dests must not include source, since we are NOT really doing a local copy!
-        noc_async_write_multicast(
-            in1_start_address, in1_multicast_data_addr, in1_block_size_bytes, in1_mcast_num_dests);
+        noc.async_write_multicast(
+            experimental::use<experimental::CircularBuffer::AddrSel::WRITE_PTR>(cb_in1),
+            experimental::use<experimental::CircularBuffer::AddrSel::WRITE_PTR>(cb_in1),
+            in1_block_size_bytes,
+            in1_mcast_num_dests,
+            {},
+            {.noc_x_start = in1_mcast_dest_noc_start_x,
+             .noc_y_start = in1_mcast_dest_noc_start_y,
+             .noc_x_end = in1_mcast_dest_noc_end_x,
+             .noc_y_end = in1_mcast_dest_noc_end_y});
 
         // Note: no need for write barrier, since these two multicasts are done on the same noc id and same vc even
         // though cmd bufs are different Also, this only works because we are setting VCs statically (using
@@ -151,20 +149,20 @@ void kernel_main() {
 #ifdef ARCH_BLACKHOLE
         // On Blackhole the flush is needed because the commands go into separate cmd buffer FIFOs and may not be sent
         // in order they are issued
-        noc_async_writes_flushed();
+        noc.async_writes_flushed();
 #endif
 
         // We should also multicast the flag to destinations
-        uint64_t in1_mcast_receiver_semaphore_noc_addr = get_noc_multicast_addr(
+        // num_dests must not include source, since we are NOT really doing a local copy!
+        in1_mcast_receiver_semaphore.set_multicast(
+            noc,
             in1_mcast_dest_noc_start_x,
             in1_mcast_dest_noc_start_y,
             in1_mcast_dest_noc_end_x,
             in1_mcast_dest_noc_end_y,
-            in1_mcast_receiver_semaphore_addr);
-        // num_dests must not include source, since we are NOT really doing a local copy!
-        noc_semaphore_set_multicast(
-            in1_mcast_receiver_semaphore_addr, in1_mcast_receiver_semaphore_noc_addr, in1_mcast_num_dests);
+            in1_mcast_num_dests
+        );
 
-        cb_push_back(cb_id_in1, in1_block_num_tiles);
+        cb_in1.push_back(in1_block_num_tiles);
     }
 }

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_matmul_tile_layout_in0_sender_in1_receiver.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_matmul_tile_layout_in0_sender_in1_receiver.cpp
@@ -42,8 +42,8 @@ void kernel_main() {
     uint32_t in0_mcast_num_dests = get_arg_val<uint32_t>(21);
     uint32_t in0_mcast_sender_noc_x = get_arg_val<uint32_t>(22);
     uint32_t in0_mcast_sender_noc_y = get_arg_val<uint32_t>(23);
-    uint32_t in0_mcast_sender_semaphore_addr = get_semaphore(get_arg_val<uint32_t>(24));
-    uint32_t in0_mcast_receiver_semaphore_addr = get_semaphore(get_arg_val<uint32_t>(25));
+    uint32_t in0_mcast_sender_semaphore_id = get_arg_val<uint32_t>(24);
+    uint32_t in0_mcast_receiver_semaphore_id = get_arg_val<uint32_t>(25);
 
     // in1 mcast args
     uint32_t in1_mcast_dest_noc_start_x = get_arg_val<uint32_t>(26);
@@ -53,8 +53,8 @@ void kernel_main() {
     uint32_t in1_mcast_num_dests = get_arg_val<uint32_t>(30);
     uint32_t in1_mcast_sender_noc_x = get_arg_val<uint32_t>(31);
     uint32_t in1_mcast_sender_noc_y = get_arg_val<uint32_t>(32);
-    uint32_t in1_mcast_sender_semaphore_addr = get_semaphore(get_arg_val<uint32_t>(33));
-    uint32_t in1_mcast_receiver_semaphore_addr = get_semaphore(get_arg_val<uint32_t>(34));
+    uint32_t in1_mcast_sender_semaphore_id = get_arg_val<uint32_t>(33);
+    uint32_t in1_mcast_receiver_semaphore_id = get_arg_val<uint32_t>(34);
 
     // const args for tile-based bank-swizzled layout
     // could be added to the arg list in the future to test different
@@ -63,36 +63,32 @@ void kernel_main() {
     constexpr uint32_t num_used_dram_ch_pow2_exponent = 3;
     constexpr uint32_t tile_size_pow2_exponent = 11;
 
+    experimental::Noc noc;
+
     constexpr uint32_t cb_id_in0 = 0;
     constexpr uint32_t cb_id_in1 = 1;
+    experimental::CircularBuffer cb_in0(cb_id_in0);
+    experimental::CircularBuffer cb_in1(cb_id_in1);
 
-    uint32_t single_tile_size_bytes = get_tile_size(cb_id_in0);
-
-    uint32_t l1_write_addr_in0;
+    uint32_t single_tile_size_bytes = cb_in0.get_tile_size();
 
     uint32_t in0_tensor_current_block_start_tile_id = in0_tensor_start_tile_id;
 
-    // Set ur local VALID value, to be mcasted to destinations flag address after the data has been mcasted
-    volatile tt_l1_ptr uint32_t* in0_mcast_receiver_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(in0_mcast_receiver_semaphore_addr);
-    *(in0_mcast_receiver_semaphore_addr_ptr) = VALID;
-    // local address that will be atomically incremented by mcast receivers, to know when all receivers are ready
-    // to receive the mcast
-    volatile tt_l1_ptr uint32_t* in0_mcast_sender_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(in0_mcast_sender_semaphore_addr);
+    experimental::Semaphore in0_mcast_sender_semaphore(in0_mcast_sender_semaphore_id);
+    experimental::Semaphore in0_mcast_receiver_semaphore(in0_mcast_receiver_semaphore_id);
+    experimental::Semaphore in1_mcast_sender_semaphore(in1_mcast_sender_semaphore_id);
+    experimental::Semaphore in1_mcast_receiver_semaphore(in1_mcast_receiver_semaphore_id);
 
-    volatile tt_l1_ptr uint32_t* in1_mcast_receiver_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(in1_mcast_receiver_semaphore_addr);
+    // Set ur local VALID value, to be mcasted to destinations flag address after the data has been mcasted
+    in0_mcast_receiver_semaphore.set(VALID);
 
     constexpr auto in0_args = TensorAccessorArgs<0>();
     constexpr auto in1_args = TensorAccessorArgs<in0_args.next_compile_time_args_offset()>();
     const auto s0 = TensorAccessor(in0_args, in0_tensor_addr, single_tile_size_bytes);
 
     for (uint32_t b = 0; b < num_blocks; b++) {
-        cb_reserve_back(cb_id_in0, in0_block_num_tiles);
-        l1_write_addr_in0 = get_write_ptr(cb_id_in0);
+        cb_in0.reserve_back(in0_block_num_tiles);
 
-        uint32_t in0_start_address = l1_write_addr_in0;  // copy start address of block, to be used for mcasting
         uint32_t in0_block_size_bytes = 0;               // can be optimized later, pass it to kernel
 
         // Copy in0 block into CB, as the default kernel
@@ -100,9 +96,15 @@ void kernel_main() {
         for (uint32_t h = 0; h < in0_block_h; h++) {
             uint32_t in0_tensor_tile_id = in0_tensor_row_start_tile_id;
             for (uint32_t w = 0; w < in0_block_w; w++) {
-                uint64_t in0_tile_noc_address = get_noc_addr(in0_tensor_tile_id, s0);
-                noc_async_read(in0_tile_noc_address, l1_write_addr_in0, single_tile_size_bytes);
-                l1_write_addr_in0 += single_tile_size_bytes;
+
+                noc.async_read(
+                    s0,
+                    cb_in0,
+                    single_tile_size_bytes,
+                    {.page_id = in0_tensor_tile_id},
+                    {.offset_bytes = ((h * in0_block_w + w) * single_tile_size_bytes)}
+                );
+
                 in0_tensor_tile_id += in0_tensor_stride_w;
                 in0_block_size_bytes += single_tile_size_bytes;
             }
@@ -111,22 +113,23 @@ void kernel_main() {
         in0_tensor_current_block_start_tile_id += in0_tensor_next_block_stride;
 
         // Barrier! make sure the reads are done
-        noc_async_read_barrier();
+        noc.async_read_barrier();
 
         // wait until all in0 mcast destinations have atomically incremented the in0 semaphore_addr (i.e. its value
         // should be in0_mcast_num_dests), then reset the semaphore_addr value back to zero for the next block
-        noc_semaphore_wait(in0_mcast_sender_semaphore_addr_ptr, in0_mcast_num_dests);
-        noc_semaphore_set(in0_mcast_sender_semaphore_addr_ptr, 0);
+        in0_mcast_sender_semaphore.down(in0_mcast_num_dests);
         // Now we have the block in the CB address, we can mcast to dests!
-        uint64_t in0_multicast_data_addr = get_noc_multicast_addr(
-            in0_mcast_dest_noc_end_x,
-            in0_mcast_dest_noc_end_y,
-            in0_mcast_dest_noc_start_x,
-            in0_mcast_dest_noc_start_y,
-            in0_start_address);
         // num_dests must not include source, since we are NOT really doing a local copy!
-        noc_async_write_multicast(
-            in0_start_address, in0_multicast_data_addr, in0_block_size_bytes, in0_mcast_num_dests);
+        noc.async_write_multicast(
+            experimental::use<experimental::CircularBuffer::AddrSel::WRITE_PTR>(cb_in0),
+            experimental::use<experimental::CircularBuffer::AddrSel::WRITE_PTR>(cb_in0),
+            in0_block_size_bytes,
+            in0_mcast_num_dests,
+            {},
+            {.noc_x_start = in0_mcast_dest_noc_end_x,
+             .noc_y_start = in0_mcast_dest_noc_end_y,
+             .noc_x_end = in0_mcast_dest_noc_start_x,
+             .noc_y_end = in0_mcast_dest_noc_start_y});
 
         // Note: no need for write barrier, since these two multicasts are done on the same noc id and same vc even
         // though cmd bufs are different Also, this only works because we are setting VCs statically (using
@@ -134,35 +137,33 @@ void kernel_main() {
 #ifdef ARCH_BLACKHOLE
         // On Blackhole the flush is needed because the commands go into separate cmd buffer FIFOs and may not be sent
         // in order they are issued
-        noc_async_writes_flushed();
+        noc.async_writes_flushed();
 #endif
 
         // We should also multicast the flag to destinations
-        uint64_t in0_mcast_receiver_semaphore_noc_addr = get_noc_multicast_addr(
+        // num_dests must not include source, since we are NOT really doing a local copy!
+        in0_mcast_receiver_semaphore.set_multicast(
+            noc,
             in0_mcast_dest_noc_end_x,
             in0_mcast_dest_noc_end_y,
             in0_mcast_dest_noc_start_x,
             in0_mcast_dest_noc_start_y,
-            in0_mcast_receiver_semaphore_addr);
-        // num_dests must not include source, since we are NOT really doing a local copy!
-        noc_semaphore_set_multicast(
-            in0_mcast_receiver_semaphore_addr, in0_mcast_receiver_semaphore_noc_addr, in0_mcast_num_dests);
+            in0_mcast_num_dests
+        );
 
-        cb_push_back(cb_id_in0, in0_block_num_tiles);
+        cb_in0.push_back(in0_block_num_tiles);
 
         // Operand 1
-        cb_reserve_back(cb_id_in1, in1_block_num_tiles);
+        cb_in1.reserve_back(in1_block_num_tiles);
 
         // Set in1 semaphore value to INVALID
-        noc_semaphore_set(in1_mcast_receiver_semaphore_addr_ptr, INVALID);
+        in1_mcast_receiver_semaphore.set(INVALID);
 
-        uint64_t in1_mcast_sender_semaphore_noc_addr =
-            get_noc_addr(in1_mcast_sender_noc_x, in1_mcast_sender_noc_y, in1_mcast_sender_semaphore_addr);
-        noc_semaphore_inc(in1_mcast_sender_semaphore_noc_addr, 1);
+        in1_mcast_sender_semaphore.up(noc, in1_mcast_sender_noc_x, in1_mcast_sender_noc_y, 1);
 
         // wait on in1 semaphore value to become VALID (set by mcast sender after it multicasts data)
-        noc_semaphore_wait(in1_mcast_receiver_semaphore_addr_ptr, VALID);
+        in1_mcast_receiver_semaphore.wait(VALID);
 
-        cb_push_back(cb_id_in1, in1_block_num_tiles);
+        cb_in1.push_back(in1_block_num_tiles);
     }
 }

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_matmul_tile_layout_in0_sender_in1_sender.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_matmul_tile_layout_in0_sender_in1_sender.cpp
@@ -42,8 +42,8 @@ void kernel_main() {
     uint32_t in0_mcast_num_dests = get_arg_val<uint32_t>(21);
     uint32_t in0_mcast_sender_noc_x = get_arg_val<uint32_t>(22);
     uint32_t in0_mcast_sender_noc_y = get_arg_val<uint32_t>(23);
-    uint32_t in0_mcast_sender_semaphore_addr = get_semaphore(get_arg_val<uint32_t>(24));
-    uint32_t in0_mcast_receiver_semaphore_addr = get_semaphore(get_arg_val<uint32_t>(25));
+    uint32_t in0_mcast_sender_semaphore_id = get_arg_val<uint32_t>(24);
+    uint32_t in0_mcast_receiver_semaphore_id = get_arg_val<uint32_t>(25);
 
     // in1 mcast args
     uint32_t in1_mcast_dest_noc_start_x = get_arg_val<uint32_t>(26);
@@ -53,8 +53,8 @@ void kernel_main() {
     uint32_t in1_mcast_num_dests = get_arg_val<uint32_t>(30);
     uint32_t in1_mcast_sender_noc_x = get_arg_val<uint32_t>(31);
     uint32_t in1_mcast_sender_noc_y = get_arg_val<uint32_t>(32);
-    uint32_t in1_mcast_sender_semaphore_addr = get_semaphore(get_arg_val<uint32_t>(33));
-    uint32_t in1_mcast_receiver_semaphore_addr = get_semaphore(get_arg_val<uint32_t>(34));
+    uint32_t in1_mcast_sender_semaphore_id = get_arg_val<uint32_t>(33);
+    uint32_t in1_mcast_receiver_semaphore_id = get_arg_val<uint32_t>(34);
 
     // const args for tile-based bank-swizzled layout
     // could be added to the arg list in the future to test different
@@ -66,32 +66,25 @@ void kernel_main() {
     constexpr uint32_t cb_id_in0 = 0;
     constexpr uint32_t cb_id_in1 = 1;
 
-    uint32_t single_tile_size_bytes = get_tile_size(cb_id_in0);
+    experimental::Noc noc;
+    experimental::CircularBuffer cb_in0(cb_id_in0);
+    experimental::CircularBuffer cb_in1(cb_id_in1);
 
-    uint32_t l1_write_addr_in0;
-    uint32_t l1_write_addr_in1;
+    uint32_t single_tile_size_bytes = cb_in0.get_tile_size();
 
     uint32_t in0_tensor_current_block_start_tile_id = in0_tensor_start_tile_id;
     uint32_t in1_tensor_current_block_start_tile_id = in1_tensor_start_tile_id;
 
-    // Set ur local VALID value, to be mcasted to destinations flag address after the data has been mcasted
-    volatile tt_l1_ptr uint32_t* in0_mcast_receiver_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(in0_mcast_receiver_semaphore_addr);
-    *(in0_mcast_receiver_semaphore_addr_ptr) = VALID;
+    experimental::Semaphore in0_mcast_sender_semaphore(in0_mcast_sender_semaphore_id);
+    experimental::Semaphore in0_mcast_receiver_semaphore(in0_mcast_receiver_semaphore_id);
+    experimental::Semaphore in1_mcast_sender_semaphore(in1_mcast_sender_semaphore_id);
+    experimental::Semaphore in1_mcast_receiver_semaphore(in1_mcast_receiver_semaphore_id);
 
     // Set ur local VALID value, to be mcasted to destinations flag address after the data has been mcasted
-    volatile tt_l1_ptr uint32_t* in1_mcast_receiver_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(in1_mcast_receiver_semaphore_addr);
-    *(in1_mcast_receiver_semaphore_addr_ptr) = VALID;
-    // local address that will be atomically incremented by mcast receivers, to know when all receivers are ready
-    // to receive the mcast
-    volatile tt_l1_ptr uint32_t* in0_mcast_sender_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(in0_mcast_sender_semaphore_addr);
+    in0_mcast_receiver_semaphore.set(VALID);
 
-    // local address that will be atomically incremented by mcast receivers, to know when all receivers are ready
-    // to receive the mcast
-    volatile tt_l1_ptr uint32_t* in1_mcast_sender_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(in1_mcast_sender_semaphore_addr);
+    // Set ur local VALID value, to be mcasted to destinations flag address after the data has been mcasted
+    in1_mcast_receiver_semaphore.set(VALID);
 
     constexpr auto in0_args = TensorAccessorArgs<0>();
     constexpr auto in1_args = TensorAccessorArgs<in0_args.next_compile_time_args_offset()>();
@@ -100,10 +93,8 @@ void kernel_main() {
     const auto s1 = TensorAccessor(in1_args, in1_tensor_addr, single_tile_size_bytes);
 
     for (uint32_t b = 0; b < num_blocks; b++) {
-        cb_reserve_back(cb_id_in0, in0_block_num_tiles);
-        l1_write_addr_in0 = get_write_ptr(cb_id_in0);
+        cb_in0.reserve_back(in0_block_num_tiles);
 
-        uint32_t in0_start_address = l1_write_addr_in0;  // copy start address of block, to be used for mcasting
         uint32_t in0_block_size_bytes = 0;               // can be optimized later, pass it to kernel
 
         // Copy in0 block into CB, as the default kernel
@@ -111,9 +102,13 @@ void kernel_main() {
         for (uint32_t h = 0; h < in0_block_h; h++) {
             uint32_t in0_tensor_tile_id = in0_tensor_row_start_tile_id;
             for (uint32_t w = 0; w < in0_block_w; w++) {
-                uint64_t in0_tile_noc_address = get_noc_addr(in0_tensor_tile_id, s0);
-                noc_async_read(in0_tile_noc_address, l1_write_addr_in0, single_tile_size_bytes);
-                l1_write_addr_in0 += single_tile_size_bytes;
+                noc.async_read(
+                    s0,
+                    cb_in0,
+                    single_tile_size_bytes,
+                    {.page_id = in0_tensor_tile_id},
+                    {.offset_bytes = ((h * in0_block_w + w) * single_tile_size_bytes)}
+                );
                 in0_tensor_tile_id += in0_tensor_stride_w;
                 in0_block_size_bytes += single_tile_size_bytes;
             }
@@ -122,23 +117,24 @@ void kernel_main() {
         in0_tensor_current_block_start_tile_id += in0_tensor_next_block_stride;
 
         // Barrier! make sure the reads are done
-        noc_async_read_barrier();
+        noc.async_read_barrier();
 
         // wait until all in0 mcast destinations have atomically incremented the in0 semaphore_addr (i.e. its value
         // should be in0_mcast_num_dests), then reset the semaphore_addr value back to zero for the next block
-        noc_semaphore_wait(in0_mcast_sender_semaphore_addr_ptr, in0_mcast_num_dests);
-        noc_semaphore_set(in0_mcast_sender_semaphore_addr_ptr, 0);
+        in0_mcast_sender_semaphore.down(in0_mcast_num_dests);
 
         // Now we have the block in the CB address, we can mcast to dests!
-        uint64_t in0_multicast_data_addr = get_noc_multicast_addr(
-            in0_mcast_dest_noc_end_x,
-            in0_mcast_dest_noc_end_y,
-            in0_mcast_dest_noc_start_x,
-            in0_mcast_dest_noc_start_y,
-            in0_start_address);
         // num_dests must not include source, since we are NOT really doing a local copy!
-        noc_async_write_multicast(
-            in0_start_address, in0_multicast_data_addr, in0_block_size_bytes, in0_mcast_num_dests);
+        noc.async_write_multicast(
+            experimental::use<experimental::CircularBuffer::AddrSel::WRITE_PTR>(cb_in0),
+            experimental::use<experimental::CircularBuffer::AddrSel::WRITE_PTR>(cb_in0),
+            in0_block_size_bytes,
+            in0_mcast_num_dests,
+            {},
+            {.noc_x_start = in0_mcast_dest_noc_end_x,
+             .noc_y_start = in0_mcast_dest_noc_end_y,
+             .noc_x_end = in0_mcast_dest_noc_start_x,
+             .noc_y_end = in0_mcast_dest_noc_start_y});
 
         // Note: no need for write barrier, since these two multicasts are done on the same noc id and same vc even
         // though cmd bufs are different Also, this only works because we are setting VCs statically (using
@@ -146,27 +142,25 @@ void kernel_main() {
 #ifdef ARCH_BLACKHOLE
         // On Blackhole the flush is needed because the commands go into separate cmd buffer FIFOs and may not be sent
         // in order they are issued
-        noc_async_writes_flushed();
+        noc.async_writes_flushed();
 #endif
 
         // We should also multicast the flag to destinations
-        uint64_t in0_mcast_receiver_semaphore_noc_addr = get_noc_multicast_addr(
+        // num_dests must not include source, since we are NOT really doing a local copy!
+        in0_mcast_receiver_semaphore.set_multicast(
+            noc,
             in0_mcast_dest_noc_end_x,
             in0_mcast_dest_noc_end_y,
             in0_mcast_dest_noc_start_x,
             in0_mcast_dest_noc_start_y,
-            in0_mcast_receiver_semaphore_addr);
-        // num_dests must not include source, since we are NOT really doing a local copy!
-        noc_semaphore_set_multicast(
-            in0_mcast_receiver_semaphore_addr, in0_mcast_receiver_semaphore_noc_addr, in0_mcast_num_dests);
+            in0_mcast_num_dests
+        );
 
-        cb_push_back(cb_id_in0, in0_block_num_tiles);
+        cb_in0.push_back(in0_block_num_tiles);
 
         // Operand 1
-        cb_reserve_back(cb_id_in1, in1_block_num_tiles);
-        l1_write_addr_in1 = get_write_ptr(cb_id_in1);
+        cb_in1.reserve_back(in1_block_num_tiles);
 
-        uint32_t in1_start_address = l1_write_addr_in1;  // copy start address of block, to be used for mcasting
         uint32_t in1_block_size_bytes = 0;               // can be optimized later, pass it to kernel
 
         // Copy in1 block into CB, as the default kernel
@@ -174,9 +168,13 @@ void kernel_main() {
         for (uint32_t h = 0; h < in1_block_h; h++) {
             uint32_t in1_tensor_tile_id = in1_tensor_row_start_tile_id;
             for (uint32_t w = 0; w < in1_block_w; w++) {
-                uint64_t in1_tile_noc_address = get_noc_addr(in1_tensor_tile_id, s1);
-                noc_async_read(in1_tile_noc_address, l1_write_addr_in1, single_tile_size_bytes);
-                l1_write_addr_in1 += single_tile_size_bytes;
+                noc.async_read(
+                    s1,
+                    cb_in1,
+                    single_tile_size_bytes,
+                    {.page_id = in1_tensor_tile_id},
+                    {.offset_bytes = ((h * in1_block_w + w) * single_tile_size_bytes)}
+                );
                 in1_tensor_tile_id += in1_tensor_stride_w;
                 in1_block_size_bytes += single_tile_size_bytes;
             }
@@ -185,39 +183,40 @@ void kernel_main() {
         in1_tensor_current_block_start_tile_id += in1_tensor_next_block_stride;
 
         // Barrier! make sure the reads are done
-        noc_async_read_barrier();
+        noc.async_read_barrier();
 
         // wait until all in1 mcast destinations have atomically incremented the in1 semaphore_addr (i.e. its value
         // should be in0_mcast_num_dests), then reset the semaphore_addr value back to zero for the next block
-        noc_semaphore_wait(in1_mcast_sender_semaphore_addr_ptr, in1_mcast_num_dests);
-        noc_semaphore_set(in1_mcast_sender_semaphore_addr_ptr, 0);
+        in1_mcast_sender_semaphore.down(in1_mcast_num_dests);
 
         // Now we have the block in the CB address, we can mcast to dests!
-        uint64_t in1_multicast_data_addr = get_noc_multicast_addr(
-            in1_mcast_dest_noc_end_x,
-            in1_mcast_dest_noc_end_y,
-            in1_mcast_dest_noc_start_x,
-            in1_mcast_dest_noc_start_y,
-            in1_start_address);
         // num_dests must not include source, since we are NOT really doing a local copy!
-        noc_async_write_multicast(
-            in1_start_address, in1_multicast_data_addr, in1_block_size_bytes, in1_mcast_num_dests);
+        noc.async_write_multicast(
+            experimental::use<experimental::CircularBuffer::AddrSel::WRITE_PTR>(cb_in1),
+            experimental::use<experimental::CircularBuffer::AddrSel::WRITE_PTR>(cb_in1),
+            in1_block_size_bytes,
+            in1_mcast_num_dests,
+            {},
+            {.noc_x_start = in1_mcast_dest_noc_end_x,
+             .noc_y_start = in1_mcast_dest_noc_end_y,
+             .noc_x_end = in1_mcast_dest_noc_start_x,
+             .noc_y_end = in1_mcast_dest_noc_start_y});
 
         // Note: no need for write barrier, since these two multicasts are done on the same noc id, same vc, same
         // cmd_buf Also, this only works because we are setting VCs statically (using NOC_CMD_STATIC_VC).
-        noc_async_writes_flushed();
+        noc.async_writes_flushed();
 
         // We should also multicast the flag to destinations
-        uint64_t in1_mcast_receiver_semaphore_noc_addr = get_noc_multicast_addr(
+        // num_dests must not include source, since we are NOT really doing a local copy!
+        in1_mcast_receiver_semaphore.set_multicast(
+            noc,
             in1_mcast_dest_noc_end_x,
             in1_mcast_dest_noc_end_y,
             in1_mcast_dest_noc_start_x,
             in1_mcast_dest_noc_start_y,
-            in1_mcast_receiver_semaphore_addr);
-        // num_dests must not include source, since we are NOT really doing a local copy!
-        noc_semaphore_set_multicast(
-            in1_mcast_receiver_semaphore_addr, in1_mcast_receiver_semaphore_noc_addr, in1_mcast_num_dests);
+            in1_mcast_num_dests
+        );
 
-        cb_push_back(cb_id_in1, in1_block_num_tiles);
+        cb_in1.push_back(in1_block_num_tiles);
     }
 }

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/writer_matmul_tile_layout.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/writer_matmul_tile_layout.cpp
@@ -27,10 +27,12 @@ void kernel_main() {
     constexpr uint32_t num_used_dram_ch_pow2_exponent = 3;
     constexpr uint32_t tile_size_pow2_exponent = 11;
 
+    experimental::Noc noc;
     constexpr uint32_t cb_id_out0 = 16;
+    experimental::CircularBuffer cb_out0(cb_id_out0);
 
     // single-tile
-    uint32_t single_tile_size_bytes = get_tile_size(cb_id_out0);
+    uint32_t single_tile_size_bytes = cb_out0.get_tile_size();
 
     constexpr auto out_args = TensorAccessorArgs<0>();
     const auto s = TensorAccessor(out_args, out_tensor_addr, single_tile_size_bytes);
@@ -42,24 +44,26 @@ void kernel_main() {
         for (uint32_t sbw = 0; sbw < out_num_subblocks_w; sbw++) {
             uint32_t out_tensor_sb_row_start_tile_id = out_tensor_sbw_start_tile_id;
 
-            cb_wait_front(cb_id_out0, out_subblock_tile_count);
-            uint32_t l1_read_addr = get_read_ptr(cb_id_out0);
+            cb_out0.wait_front(out_subblock_tile_count);
 
             for (uint32_t h = 0; h < out_subblock_h; h++) {
                 uint32_t out_tensor_tile_id = out_tensor_sb_row_start_tile_id;
                 for (uint32_t w = 0; w < out_subblock_w; w++) {
-                    uint64_t out_tensor_tile_noc_addr = get_noc_addr(out_tensor_tile_id, s);
-
-                    noc_async_write(l1_read_addr, out_tensor_tile_noc_addr, single_tile_size_bytes);
-                    l1_read_addr += single_tile_size_bytes;
+                    noc.async_write(
+                        cb_out0,
+                        s,
+                        single_tile_size_bytes,
+                        {.offset_bytes = ((h * out_subblock_w + w) * single_tile_size_bytes)},
+                        {.page_id = out_tensor_tile_id}
+                    );
 
                     out_tensor_tile_id += out_tensor_stride_w;
                 }
                 out_tensor_sb_row_start_tile_id += out_tensor_stride_h;
             }
 
-            noc_async_write_barrier();
-            cb_pop_front(cb_id_out0, out_subblock_tile_count);
+            noc.async_write_barrier();
+            cb_out0.pop_front(out_subblock_tile_count);
             out_tensor_sbw_start_tile_id += out_tensor_next_subblock_stride_w;
         }
         out_tensor_sbh_start_tile_id += out_tensor_next_subblock_stride_h;

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -2345,7 +2345,8 @@ void reset_noc_trid_barrier_counter(uint32_t id_mask = NOC_CLEAR_OUTSTANDING_REQ
 
 namespace experimental {
 
-struct MulticastEndpoint;  // Forward declaration can be removed when 2.0 objects are split into different headers
+// Forward declaration can be removed when 2.0 objects are split into different headers
+struct MulticastEndpoint;
 
 template <typename T>
 struct noc_traits_t {
@@ -2376,6 +2377,8 @@ private:
     using src_args_t = typename noc_traits_t<T>::src_args_type;
     template <typename T>
     using dst_args_t = typename noc_traits_t<T>::dst_args_type;
+    template <typename T>
+    using dst_args_mcast_t = typename noc_traits_t<T>::dst_args_mcast_type;
 
     template <AddressType address_type>
     using addr_underlying_t = std::conditional_t<address_type == AddressType::LOCAL_L1, uint32_t, uint64_t>;
@@ -2390,6 +2393,12 @@ private:
     auto get_dst_ptr(const Dst& dst, const dst_args_t<Dst>& dst_args) const {
         return addr_underlying_t<address_type>{
             noc_traits_t<Dst>::template dst_addr<address_type>(dst, *this, dst_args)};
+    }
+
+    template <AddressType address_type, typename Dst>
+    auto get_dst_ptr_mcast(const Dst& dst, const dst_args_mcast_t<Dst>& dst_args) const {
+        return addr_underlying_t<address_type>{
+            noc_traits_t<Dst>::template dst_addr_mcast<address_type>(dst, *this, dst_args)};
     }
 
 public:
@@ -2421,6 +2430,7 @@ public:
      * @param src_args Additional arguments for source address calculation
      * @param dst_args Additional arguments for destination address calculation
      * @param read_req_vc Virtual channel to use for the read request (default: NOC_UNICAST_WRITE_VC)
+     * @param trid Transaction ID to use when transaction id mode is enabled (default: INVALID_TXN_ID)
      * @tparam txn_id_mode Whether transaction id will be used for the noc transaction (default: DISABLED)
      * @tparam max_page_size Maximum page size for the transfer (default: NOC_MAX_BURST_SIZE + 1)
      * @tparam enable_noc_tracing Enable NoC tracing for debugging (default: true)
@@ -2459,10 +2469,11 @@ public:
      * @param src_args Additional arguments for source address calculation
      * @param dst_args Additional arguments for destination address calculation
      * @param vc Virtual channel to use for the write transaction (default: NOC_UNICAST_WRITE_VC)
+     * @param trid Transaction ID to use when transaction id mode is enabled (default: INVALID_TXN_ID)
      * @tparam txn_id_mode Whether transaction id will be used for the noc transaction (default: DISABLED)
-     * @tparam max_page_size Maximum page size for the transfer (default: NOC_MAX_BURST_SIZE + 1)
      * @tparam response_mode Posted noc transactions do not get ack from receiver, non-posted ones do (default:
      * NON_POSTED)
+     * @tparam max_page_size Maximum page size for the transfer (default: NOC_MAX_BURST_SIZE + 1)
      * @tparam enable_noc_tracing Enable NoC tracing for debugging (default: true)
      */
     template <
@@ -2512,6 +2523,56 @@ public:
                 size_bytes,
                 noc_id_,
                 vc);
+        }
+    }
+
+    /** @brief Initiates an asynchronous write from a source address in memory on the core executing this function call to a rectangular destination grid.
+     *
+     * The destination nodes must be a set of Tensix cores and must form a rectangular grid.
+     *
+     * @see async_write_barrier.
+     *
+     * @param src Source object (e.g., local L1 memory)
+     * @param dst Destination object (e.g., TensorAccessor)
+     * @param size_bytes Size of the data transfer in bytes
+     * @param num_dsts Number of destinations that the multicast source is targeting
+     * @param src_args Additional arguments for source address calculation
+     * @param dst_args Additional arguments for destination address calculation
+     * @param linked
+     * @param trid Transaction ID to use when transaction id mode is enabled (default: INVALID_TXN_ID)
+     * @tparam mcast_mode Indicates whether the sender is included in the multicast destinations
+     * @tparam txn_id_mode Whether transaction id will be used for the noc transaction (default: DISABLED)
+     * @tparam response_mode Posted noc transactions do not get ack from receiver, non-posted ones do (default:
+     * NON_POSTED)
+     * @tparam max_page_size Maximum page size for the transfer (default: NOC_MAX_BURST_SIZE + 1)
+     * @tparam enable_noc_tracing Enable NoC tracing for debugging (default: true)
+     */
+    template <
+        McastMode mcast_mode = McastMode::EXCLUDE_SRC,
+        TxnIdMode txn_id_mode = TxnIdMode::DISABLED,
+        ResponseMode response_mode = ResponseMode::NON_POSTED,
+        uint32_t max_page_size = NOC_MAX_BURST_SIZE + 1,
+        bool enable_noc_tracing = true,
+        typename Src,
+        typename Dst>
+    void async_write_multicast(
+        const Src& src,
+        const Dst& dst,
+        uint32_t size_bytes,
+        uint32_t num_dsts,
+        const src_args_t<Src>& src_args,
+        const dst_args_mcast_t<Dst>& dst_args,
+        bool linked = false,
+        uint32_t trid = INVALID_TXN_ID) const {
+        static_assert(txn_id_mode == TxnIdMode::DISABLED, "Mcasts with transaction id are not supported yet");
+        static_assert(response_mode == ResponseMode::NON_POSTED, "Mcasts with posted transactions are not supported"); // TODO: Make this an arch specific assertion
+
+        auto src_addr = get_src_ptr<AddressType::LOCAL_L1>(src, src_args);
+        auto dst_noc_addr = get_dst_ptr_mcast<AddressType::NOC>(dst, dst_args);
+        if constexpr (mcast_mode == McastMode::INCLUDE_SRC) {
+            noc_async_write_multicast_loopback_src(src_addr, dst_noc_addr, size_bytes, num_dsts, linked, noc_id_);
+        } else if constexpr (mcast_mode == McastMode::EXCLUDE_SRC) {
+            noc_async_write_multicast<max_page_size>(src_addr, dst_noc_addr, size_bytes, num_dsts, linked, noc_id_);
         }
     }
 
@@ -2617,13 +2678,13 @@ public:
      * issued on the current Tensix core to depart, but will not wait for them to complete.
      * Can wait on posted or non-posted transactions.
      *
-     * @tparam response_mode Indicates whether to wait for outstanding posted or non-posted transactions
      * @param trid Transaction ID to wait on for outstanding writes (default: INVALID_TXN_ID for full barrier)
+     * @tparam response_mode Indicates whether to wait for outstanding posted or non-posted transactions (default: NON_POSTED)
      * @tparam barrier_type Indicates whether to issue a full barrier or on a transaction id
      */
     // TODO (#31405): there is no variant of this for transaction ids. Use
     // ncrisc_noc_nonposted_write_with_transaction_id_sent but none for dynamic noc version exists atm.
-    template <ResponseMode response_mode, BarrierMode barrier_type = BarrierMode::FULL>
+    template <ResponseMode response_mode = ResponseMode::NON_POSTED, BarrierMode barrier_type = BarrierMode::FULL>
     void async_writes_flushed(uint32_t trid = INVALID_TXN_ID) const {
         if constexpr (response_mode == ResponseMode::POSTED) {
             static_assert(barrier_type == BarrierMode::FULL);
@@ -2663,6 +2724,8 @@ private:
 
 class CircularBuffer {
 public:
+    enum class AddrSelector { WRITE_PTR, READ_PTR };
+
     explicit CircularBuffer(uint32_t cb_id) : cb_id_(cb_id) {}
 
     uint32_t get_cb_id() const { return cb_id_; }
@@ -2702,17 +2765,92 @@ private:
 
 template <>
 struct noc_traits_t<CircularBuffer> {
-    struct src_args_type {};
-    struct dst_args_type {};
+    struct src_args_type {
+        uint32_t offset_bytes{};
+    };
+    struct dst_args_type {
+        uint32_t offset_bytes{};
+    };
+    struct dst_args_mcast_type {
+        uint32_t noc_x_start{};
+        uint32_t noc_y_start{};
+        uint32_t noc_x_end{};
+        uint32_t noc_y_end{};
+        uint32_t offset_bytes{};
+    };
     template <Noc::AddressType address_type>
-    static auto src_addr(const CircularBuffer& src, const Noc&, const src_args_type&) {
-        static_assert(address_type == Noc::AddressType::LOCAL_L1, "CircularBuffer can only be used as L1 source");
-        return src.get_read_ptr();
+    static auto src_addr(const CircularBuffer& src, const Noc&, const src_args_type& args) {
+        static_assert(address_type == Noc::AddressType::LOCAL_L1, "CircularBuffer without mcast range can only be used as L1 source");
+        return src.get_read_ptr() + args.offset_bytes;
     }
     template <Noc::AddressType address_type>
-    static auto dst_addr(const CircularBuffer& dst, const Noc&, const dst_args_type&) {
-        static_assert(address_type == Noc::AddressType::LOCAL_L1, "CircularBuffer can only be used as L1 destination");
-        return dst.get_write_ptr();
+    static auto dst_addr(const CircularBuffer& dst, const Noc& noc, const dst_args_type& args) {
+        static_assert(address_type == Noc::AddressType::LOCAL_L1, "CircularBuffer without mcast range can only be used as L1 source");
+        return dst.get_write_ptr() + args.offset_bytes;
+    }
+    template <Noc::AddressType address_type>
+    static auto dst_addr_mcast(const CircularBuffer& dst, const Noc& noc, const dst_args_mcast_type& args) {
+        static_assert(address_type == Noc::AddressType::NOC, "CircularBuffer with mcast range cannot be used as L1 source");
+        auto local_addr = dst.get_write_ptr() + args.offset_bytes;
+        return ::get_noc_multicast_addr(args.noc_x_start, args.noc_y_start, args.noc_x_end, args.noc_y_end, local_addr, noc.get_noc_id());
+    }
+};
+
+template <CircularBuffer::AddrSelector AddrSel>
+struct CircularBufferView {
+    const CircularBuffer& cb;
+    explicit constexpr CircularBufferView(const CircularBuffer& c) : cb(c) {}
+};
+
+// Convenience helper: use<CircularBuffer::AddrSelector::READ_PTR>(cb)
+// This allows user to indicate whether the read or write pointer should be used as the source or destination address
+// depending on whether the CircularBuffer is src or dst in the Noc apis
+template <CircularBuffer::AddrSelector AddrSel>
+constexpr auto use(const CircularBuffer& cb) {
+    return CircularBufferView<AddrSel>(cb);
+}
+
+template <CircularBuffer::AddrSelector AddrSel>
+class noc_traits_t<CircularBufferView<AddrSel>> {
+public:
+    struct src_args_type {
+        uint32_t offset_bytes{};
+    };
+    struct dst_args_type {
+        uint32_t offset_bytes{};
+    };
+    struct dst_args_mcast_type {
+        uint32_t noc_x_start{};
+        uint32_t noc_y_start{};
+        uint32_t noc_x_end{};
+        uint32_t noc_y_end{};
+        uint32_t offset_bytes{};
+    };
+    template <Noc::AddressType address_type>
+    static auto src_addr(const CircularBufferView<AddrSel>& view, const Noc&, const src_args_type& args) {
+        static_assert(address_type == Noc::AddressType::LOCAL_L1, "CircularBuffer without mcast range can only be used as L1 source");
+        return get_local_addr(view) + args.offset_bytes;
+    }
+    template <Noc::AddressType address_type>
+    static auto dst_addr(const CircularBufferView<AddrSel>& view, const Noc& noc, const dst_args_type& args) {
+        static_assert(address_type == Noc::AddressType::LOCAL_L1, "CircularBuffer without mcast rangecan only be used as L1 source");
+        return get_local_addr(view) + args.offset_bytes;
+    }
+    template <Noc::AddressType address_type>
+    static auto dst_addr_mcast(
+        const CircularBufferView<AddrSel>& view, const Noc& noc, const dst_args_mcast_type& args) {
+        static_assert(address_type == Noc::AddressType::NOC, "CircularBuffer with mcast range cannot be used as L1 source");
+        auto local_addr = get_local_addr(view) + args.offset_bytes;
+        return ::get_noc_multicast_addr(args.noc_x_start, args.noc_y_start, args.noc_x_end, args.noc_y_end, local_addr, noc.get_noc_id());
+    }
+
+private:
+    static constexpr auto get_local_addr(const CircularBufferView<AddrSel>& view) {
+        if constexpr (AddrSel == CircularBuffer::AddrSelector::READ_PTR) {
+            return view.cb.get_read_ptr();
+        } else {
+            return view.cb.get_write_ptr();
+        }
     }
 };
 
@@ -2761,13 +2899,13 @@ public:
     /**
      * @brief Atomically increment the semaphore by the specified value on a remote core.
      *
-     * @param value The value to increment the semaphore by.
+     * @param noc The Noc object representing the NoC to use for the transaction.
      * @param noc_x The X coordinate of the remote core in the NoC.
      * @param noc_y The Y coordinate of the remote core in the NoC.
-     * @param noc The Noc object representing the NoC to use for the transaction.
+     * @param value The value to increment the semaphore by.
      * @param vc The virtual channel to use for the transaction (default is NOC_UNICAST_WRITE_VC).
      */
-    void up(uint32_t value, uint32_t noc_x, uint32_t noc_y, const Noc& noc, uint8_t vc = NOC_UNICAST_WRITE_VC) {
+    void up(const Noc& noc, uint32_t noc_x, uint32_t noc_y, uint32_t value, uint8_t vc = NOC_UNICAST_WRITE_VC) {
         uint64_t dest_noc_addr = get_noc_addr(noc_x, noc_y, local_l1_addr_);
         noc_semaphore_inc(dest_noc_addr, value, noc.get_noc_id(), vc);
     }
@@ -2925,14 +3063,7 @@ struct noc_traits_t<UnicastEndpoint> {
 
 template <>
 struct noc_traits_t<MulticastEndpoint> {
-    struct src_args_type {
-        uint32_t noc_x_start{};
-        uint32_t noc_y_start{};
-        uint32_t noc_x_end{};
-        uint32_t noc_y_end{};
-        uint32_t addr{};
-    };
-    struct dst_args_type {
+    struct dst_args_mcast_type {
         uint32_t noc_x_start{};
         uint32_t noc_y_start{};
         uint32_t noc_x_end{};
@@ -2940,14 +3071,7 @@ struct noc_traits_t<MulticastEndpoint> {
         uint32_t addr{};
     };
     template <Noc::AddressType address_type>
-    static auto src_addr(const MulticastEndpoint& src, const Noc& noc, const src_args_type& args) {
-        static_assert(address_type == Noc::AddressType::NOC);
-        uint64_t noc_addr = src.get_noc_multicast_addr(
-            args.noc_x_start, args.noc_y_start, args.noc_x_end, args.noc_y_end, args.addr, noc.get_noc_id());
-        return noc_addr;
-    }
-    template <Noc::AddressType address_type>
-    static auto dst_addr(const MulticastEndpoint& dst, const Noc& noc, const dst_args_type& args) {
+    static auto dst_addr_mcast(const MulticastEndpoint& dst, const Noc& noc, const dst_args_mcast_type& args) {
         static_assert(address_type == Noc::AddressType::NOC);
         uint64_t noc_addr = dst.get_noc_multicast_addr(
             args.noc_x_start, args.noc_y_start, args.noc_x_end, args.noc_y_end, args.addr, noc.get_noc_id());


### PR DESCRIPTION
### Ticket
[29592](https://github.com/tenstorrent/tt-metal/issues/29592)

### What's changed

- Added `async_write_multicast` to NoC. Exposes but does not support mcasts with trids or posted mcasts 
- Added specialized noc_traits_t for CircularBuffer that allows user to specify whether rd or wr pointer should be used as the src or dst address
- When CircularBuffer is dst, allow user to specify mcast range
- consolidated `async_writes_flushed` and `async_posted_writes_flushed`

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/19383085717) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/19413953412) CI with demo tests passes (if applicable)
- [ ] Existing tests updated
