### PR TITLE
Cluster validation improvements

### DIFF
--- a/tools/scaleout/validation/run_cluster_validation.cpp
+++ b/tools/scaleout/validation/run_cluster_validation.cpp
@@ -116,29 +116,6 @@ InputArgs parse_input_args(const std::vector<std::string>& args_vec) {
     return input_args;
 }
 
-std::string get_factory_system_descriptor_path(const InputArgs& input_args, const std::vector<std::string>& hostnames) {
-    std::string fsd_path;
-    if (input_args.cabling_descriptor_path.has_value()) {
-        const auto& distributed_context = tt::tt_metal::MetalContext::instance().global_distributed_context();
-        log_output_rank0("Creating Factory System Descriptor (Golden Representation)");
-        CablingGenerator cabling_generator;
-        std::string filename =
-                "generated_factory_system_descriptor_" + std::to_string(*distributed_context.rank()) + ".textproto";
-            fsd_path = input_args.output_path / filename;
-        if (not input_args.deployment_descriptor_path.has_value()) {
-            TT_FATAL(hostnames.size() == 1, "Expected exactly one host in the cluster when no deployment descriptor is provided");
-            cabling_generator = tt::scaleout_tools::CablingGenerator(input_args.cabling_descriptor_path.value(), hostnames);
-        } else {
-            cabling_generator = tt::scaleout_tools::CablingGenerator(
-                input_args.cabling_descriptor_path.value(), input_args.deployment_descriptor_path.value());
-        }
-        cabling_generator.emit_factory_system_descriptor(fsd_path);
-    } else {
-        fsd_path = input_args.fsd_path.value();
-    }
-    return fsd_path;
-}
-
 PhysicalSystemDescriptor generate_physical_system_descriptor(const InputArgs& input_args) {
     auto log_hostnames = [&](const std::vector<std::string>& hostnames) {
         std::stringstream ss;
@@ -181,29 +158,31 @@ void cleanup_metadata(const InputArgs& input_args, const std::string& gsd_file, 
     }
 }
 
-AsicTopology validate_connectivity(const InputArgs& input_args, PhysicalSystemDescriptor& physical_system_descriptor) {
+AsicTopology run_connectivity_validation(
+    const InputArgs& input_args, PhysicalSystemDescriptor& physical_system_descriptor) {
     if (!input_args.validate_connectivity) {
         return {};
     }
-    // Set output path for the YAML file
-    auto& distributed_context = tt::tt_metal::MetalContext::instance().global_distributed_context();
+    const auto& distributed_context = tt::tt_metal::MetalContext::instance().global_distributed_context();
     std::string gsd_yaml_filename = "global_system_descriptor_" + std::to_string(*distributed_context.rank()) + ".yaml";
     std::string gsd_yaml_path = input_args.output_path / gsd_yaml_filename;
-    // Dump the discovered system to YAML
     physical_system_descriptor.dump_to_yaml(gsd_yaml_path);
-    log_output_rank0("Validating Factory System Descriptor (Golden Representation) against Global System Descriptor");
-    bool log_output = *distributed_context.rank() == 0;
-    const auto fsd_path = get_factory_system_descriptor_path(input_args, physical_system_descriptor.get_all_hostnames());
-    auto missing_physical_connections = tt::scaleout_tools::validate_fsd_against_gsd(
-        fsd_path, gsd_yaml_path, true, input_args.fail_on_warning, log_output);
-    log_output_rank0("Factory System Descriptor (Golden Representation) Validation Complete");
+
+    const auto fsd_path = get_factory_system_descriptor_path(
+        input_args.cabling_descriptor_path,
+        input_args.deployment_descriptor_path,
+        input_args.fsd_path,
+        input_args.output_path.string());
+    auto missing_topology =
+        validate_connectivity(fsd_path, gsd_yaml_path, input_args.fail_on_warning, physical_system_descriptor);
+
     // TODO (AS): We shouldn't need to dump files to disk for validation, once validate_fsd_against_gsd can support
     // comparing string representations of the FSD and GSD. For now, each rank dumps a file to disk, which gets deleted
     // post validation (for all ranks except rank 0).
     if (*distributed_context.rank() != 0) {
         cleanup_metadata(input_args, gsd_yaml_path, fsd_path);
     }
-    return generate_asic_topology_from_connections(missing_physical_connections, physical_system_descriptor);
+    return missing_topology;
 }
 
 void print_usage_info() {
@@ -264,7 +243,7 @@ int main(int argc, char* argv[]) {
     // Create physical system descriptor and discover the system
     auto physical_system_descriptor = generate_physical_system_descriptor(input_args);
 
-    AsicTopology missing_asic_topology = validate_connectivity(input_args, physical_system_descriptor);
+    AsicTopology missing_asic_topology = run_connectivity_validation(input_args, physical_system_descriptor);
     bool links_reset = false;
     // Ethernet Link Retraining through SW is currently only supported for Wormhole
     bool link_retrain_supported = tt::tt_metal::MetalContext::instance().get_cluster().arch() == tt::ARCH::WORMHOLE_B0;
@@ -276,7 +255,7 @@ int main(int argc, char* argv[]) {
         links_reset = true;
         num_retrains++;
         physical_system_descriptor.run_discovery(true, true);
-        missing_asic_topology = validate_connectivity(input_args, physical_system_descriptor);
+        missing_asic_topology = run_connectivity_validation(input_args, physical_system_descriptor);
     }
 
     if (num_retrains == MAX_RETRAINS_BEFORE_FAILURE && !missing_asic_topology.empty()) {
@@ -288,6 +267,13 @@ int main(int argc, char* argv[]) {
         return 0;
     }
 
+    ConnectivityValidationConfig validation_config{
+        .output_path = input_args.output_path,
+        .cabling_descriptor_path = input_args.cabling_descriptor_path,
+        .deployment_descriptor_path = input_args.deployment_descriptor_path,
+        .fsd_path = input_args.fsd_path,
+        .fail_on_warning = input_args.fail_on_warning};
+
     eth_connections_healthy = generate_link_metrics(
         physical_system_descriptor,
         input_args.num_iterations,
@@ -296,7 +282,7 @@ int main(int argc, char* argv[]) {
         input_args.sweep_traffic_configs,
         input_args.packet_size_bytes,
         input_args.data_size,
-        input_args.output_path);
+        validation_config);
 
     if (*distributed_context.rank() == 0 && input_args.print_connectivity) {
         print_ethernet_connectivity(input_args.print_connectivity, physical_system_descriptor);

--- a/tools/scaleout/validation/schemas/ethernet_link_metrics.proto
+++ b/tools/scaleout/validation/schemas/ethernet_link_metrics.proto
@@ -26,6 +26,8 @@ message EthChannelIdentifier {
     uint64 tray_id = 3;
     uint64 asic_location = 4;
     uint32 channel = 5;
+    uint32 port_id = 6;
+    uint32 port_type = 7;
 }
 
 message EthernetLinkMetrics {

--- a/tools/scaleout/validation/utils/cluster_validation_utils.cpp
+++ b/tools/scaleout/validation/utils/cluster_validation_utils.cpp
@@ -486,8 +486,8 @@ LinkMetricsResult process_link_statuses(
 }
 
 struct PortInfo {
-    tt::scaleout_tools::PortType port_type;
-    tt::scaleout_tools::PortId port_id;
+    tt::scaleout_tools::PortType port_type = tt::scaleout_tools::PortType::TRACE;
+    tt::scaleout_tools::PortId port_id{0};
 };
 
 std::unordered_map<tt::tt_metal::AsicID, std::unordered_map<uint8_t, PortInfo>> generate_port_info(

--- a/tools/scaleout/validation/utils/cluster_validation_utils.cpp
+++ b/tools/scaleout/validation/utils/cluster_validation_utils.cpp
@@ -486,8 +486,8 @@ LinkMetricsResult process_link_statuses(
 }
 
 struct PortInfo {
-    tt::scaleout_tools::PortType port_type{};
-    tt::scaleout_tools::PortId port_id{};
+    tt::scaleout_tools::PortType port_type;
+    tt::scaleout_tools::PortId port_id;
 };
 
 std::unordered_map<tt::tt_metal::AsicID, std::unordered_map<uint8_t, PortInfo>> generate_port_info(

--- a/tools/scaleout/validation/utils/cluster_validation_utils.cpp
+++ b/tools/scaleout/validation/utils/cluster_validation_utils.cpp
@@ -1027,7 +1027,7 @@ LinkMetricsResult send_traffic_and_validate_links(
 
             // Check if any rank experienced a hang/timeout
             const auto& distributed_context = tt::tt_metal::MetalContext::instance().global_distributed_context();
-            bool any_rank_hung;
+            bool any_rank_hung = false;
             distributed_context.all_reduce(
                 tt::stl::Span<bool>(&did_hang_locally, 1),
                 tt::stl::Span<bool>(&any_rank_hung, 1),

--- a/tools/scaleout/validation/utils/cluster_validation_utils.cpp
+++ b/tools/scaleout/validation/utils/cluster_validation_utils.cpp
@@ -24,7 +24,7 @@
 
 namespace tt::scaleout_tools {
 
-// Timeout is based on the assumption that 30s should be enough for an iteration to run.
+// Timeout is based on the assumption that WORKLOAD_TIMEOUT_DURATION (30s) should be enough for an iteration to run.
 // Any longer and we assume that a hang has been encountered. We may need to tune this in future.
 static constexpr std::chrono::seconds WORKLOAD_TIMEOUT_DURATION{30};
 

--- a/tools/scaleout/validation/utils/cluster_validation_utils.cpp
+++ b/tools/scaleout/validation/utils/cluster_validation_utils.cpp
@@ -486,8 +486,8 @@ LinkMetricsResult process_link_statuses(
 }
 
 struct PortInfo {
-    tt::scaleout_tools::PortType port_type;
-    tt::scaleout_tools::PortId port_id;
+    tt::scaleout_tools::PortType port_type{};
+    tt::scaleout_tools::PortId port_id{};
 };
 
 std::unordered_map<tt::tt_metal::AsicID, std::unordered_map<uint8_t, PortInfo>> generate_port_info(

--- a/tools/scaleout/validation/utils/cluster_validation_utils.hpp
+++ b/tools/scaleout/validation/utils/cluster_validation_utils.hpp
@@ -23,6 +23,14 @@ using tt::CoordSystem;
 using tt::tt_metal::CoreCoord;
 using tt::tt_metal::PhysicalSystemDescriptor;
 
+struct ConnectivityValidationConfig {
+    std::filesystem::path output_path;
+    std::optional<std::string> cabling_descriptor_path = std::nullopt;
+    std::optional<std::string> deployment_descriptor_path = std::nullopt;
+    std::optional<std::string> fsd_path = std::nullopt;
+    bool fail_on_warning = false;
+};
+
 // ============================================================================
 // Utility Functions
 // ============================================================================
@@ -56,13 +64,25 @@ bool generate_link_metrics(
     bool sweep_traffic_configs,
     uint32_t packet_size_bytes,
     uint32_t data_size,
-    const std::filesystem::path& output_path);
+    const ConnectivityValidationConfig& validation_config);
 
 void reset_ethernet_links(
     const PhysicalSystemDescriptor& physical_system_descriptor, const tt_metal::AsicTopology& asic_topology);
 
 tt_metal::AsicTopology generate_asic_topology_from_connections(
     const std::set<PhysicalChannelConnection>& physical_connections,
+    PhysicalSystemDescriptor& physical_system_descriptor);
+
+std::string get_factory_system_descriptor_path(
+    const std::optional<std::string>& cabling_descriptor_path,
+    const std::optional<std::string>& deployment_descriptor_path,
+    const std::optional<std::string>& fsd_path,
+    const std::string& output_path);
+
+tt_metal::AsicTopology validate_connectivity(
+    const std::string& fsd_path,
+    const std::string& gsd_yaml_path,
+    bool fail_on_warning,
     PhysicalSystemDescriptor& physical_system_descriptor);
 
 }  // namespace tt::scaleout_tools

--- a/tools/scaleout/validation/utils/ethernet_link_metrics.hpp
+++ b/tools/scaleout/validation/utils/ethernet_link_metrics.hpp
@@ -32,11 +32,14 @@ struct EthChannelIdentifier {
     tt::tt_metal::TrayID tray_id;
     tt::tt_metal::ASICLocation asic_location;
     uint8_t channel = 0;
+    uint32_t port_id = 0;    // Physical port ID
+    uint32_t port_type = 0;  // Port type enum value
 };
 
 inline bool operator==(const EthChannelIdentifier& lhs, const EthChannelIdentifier& rhs) {
     return lhs.host == rhs.host && lhs.asic_id == rhs.asic_id && lhs.tray_id == rhs.tray_id &&
-           lhs.asic_location == rhs.asic_location && lhs.channel == rhs.channel;
+           lhs.asic_location == rhs.asic_location && lhs.channel == rhs.channel && lhs.port_id == rhs.port_id &&
+           lhs.port_type == rhs.port_type;
 }
 
 namespace std {
@@ -44,7 +47,13 @@ template <>
 struct hash<EthChannelIdentifier> {
     size_t operator()(const EthChannelIdentifier& identifier) const {
         return ttsl::hash::hash_objects_with_default_seed(
-            identifier.host, identifier.asic_id, identifier.tray_id, identifier.asic_location, identifier.channel);
+            identifier.host,
+            identifier.asic_id,
+            identifier.tray_id,
+            identifier.asic_location,
+            identifier.channel,
+            identifier.port_id,
+            identifier.port_type);
     }
 };
 }  // namespace std

--- a/tools/scaleout/validation/utils/ethernet_link_metrics_serialization.cpp
+++ b/tools/scaleout/validation/utils/ethernet_link_metrics_serialization.cpp
@@ -22,6 +22,8 @@ std::vector<uint8_t> serialize_link_metrics_to_bytes(const std::vector<::Etherne
         proto_channel_id->set_tray_id(*link_metric.channel_identifier.tray_id);
         proto_channel_id->set_asic_location(*link_metric.channel_identifier.asic_location);
         proto_channel_id->set_channel(link_metric.channel_identifier.channel);
+        proto_channel_id->set_port_id(link_metric.channel_identifier.port_id);
+        proto_channel_id->set_port_type(link_metric.channel_identifier.port_type);
 
         // Serialize LinkStatus
         auto* proto_link_status = proto_link_metrics->mutable_link_status();
@@ -73,6 +75,8 @@ std::vector<::EthernetLinkMetrics> deserialize_link_metrics_from_bytes(const std
         link_metric.channel_identifier.tray_id = tt::tt_metal::TrayID(proto_channel_id.tray_id());
         link_metric.channel_identifier.asic_location = tt::tt_metal::ASICLocation(proto_channel_id.asic_location());
         link_metric.channel_identifier.channel = static_cast<uint8_t>(proto_channel_id.channel());
+        link_metric.channel_identifier.port_id = proto_channel_id.port_id();
+        link_metric.channel_identifier.port_type = proto_channel_id.port_type();
 
         // Deserialize LinkStatus
         const auto& proto_link_status = proto_link_metric.link_status();
@@ -108,6 +112,8 @@ std::vector<uint8_t> serialize_eth_chan_identifiers_to_bytes(const std::vector<:
         proto_exit_node->set_tray_id(*exit_node.tray_id);
         proto_exit_node->set_asic_location(*exit_node.asic_location);
         proto_exit_node->set_channel(exit_node.channel);
+        proto_exit_node->set_port_id(exit_node.port_id);
+        proto_exit_node->set_port_type(exit_node.port_type);
     }
 
     // Serialize to bytes
@@ -138,6 +144,8 @@ std::vector<::EthChannelIdentifier> deserialize_eth_chan_identifiers_from_bytes(
         exit_node.tray_id = tt::tt_metal::TrayID(proto_exit_node.tray_id());
         exit_node.asic_location = tt::tt_metal::ASICLocation(proto_exit_node.asic_location());
         exit_node.channel = static_cast<uint8_t>(proto_exit_node.channel());
+        exit_node.port_id = proto_exit_node.port_id();
+        exit_node.port_type = proto_exit_node.port_type();
 
         exit_nodes.push_back(std::move(exit_node));
     }

--- a/tt_metal/fabric/physical_system_descriptor.cpp
+++ b/tt_metal/fabric/physical_system_descriptor.cpp
@@ -12,7 +12,6 @@
 #include <tt-metalium/control_plane.hpp>
 #include <tt-metalium/distributed_context.hpp>
 
-#include "tt_metal/llrt/tunnels_from_mmio_device.hpp"
 #include "tt_metal/llrt/hal.hpp"
 #include "tt_metal/llrt/rtoptions.hpp"
 #include "tt_metal/fabric/physical_system_descriptor.hpp"
@@ -81,7 +80,6 @@ std::pair<TrayID, ASICLocation> get_asic_position(
         tt::ARCH arch = cluster_desc->get_arch(chip_id);
         if (arch == tt::ARCH::WORMHOLE_B0) {
             // Query ASIC Location from the Cluster Descriptor for WH.
-            // This now relies on UMD instead of discover_tunnels_from_mmio_device.
             asic_location = ASICLocation{cluster_desc->get_asic_location(chip_id)};
         } else if (arch == tt::ARCH::BLACKHOLE) {
             // Query ASIC Location from the Cluster Descriptor for BH.

--- a/tt_metal/fabric/physical_system_descriptor.cpp
+++ b/tt_metal/fabric/physical_system_descriptor.cpp
@@ -80,19 +80,9 @@ std::pair<TrayID, ASICLocation> get_asic_position(
         ASICLocation asic_location;
         tt::ARCH arch = cluster_desc->get_arch(chip_id);
         if (arch == tt::ARCH::WORMHOLE_B0) {
-            // Derive ASIC Location based on the tunnel depth for Wormhole systems
-            // TODO: Remove this once UMD populates the ASIC Location for WH systems.
-            auto mmio_device = cluster_desc->get_closest_mmio_capable_chip(chip_id);
-            auto tunnels_from_mmio_device = llrt::discover_tunnels_from_mmio_device(cluster);
-            const auto& tunnels = tunnels_from_mmio_device.at(mmio_device);
-            for (auto tunnel = 0; tunnel < tunnels.size(); tunnel++) {
-                const auto& devices_on_tunnel = tunnels[tunnel];
-                auto device_it = std::find(devices_on_tunnel.begin(), devices_on_tunnel.end(), chip_id);
-                if (device_it != devices_on_tunnel.end()) {
-                    asic_location = ASICLocation{device_it - devices_on_tunnel.begin()};
-                    break;
-                }
-            }
+            // Query ASIC Location from the Cluster Descriptor for WH.
+            // This now relies on UMD instead of discover_tunnels_from_mmio_device.
+            asic_location = ASICLocation{cluster_desc->get_asic_location(chip_id)};
         } else if (arch == tt::ARCH::BLACKHOLE) {
             // Query ASIC Location from the Cluster Descriptor for BH.
             asic_location = ASICLocation{cluster_desc->get_asic_location(chip_id)};

--- a/tt_metal/fabric/physical_system_descriptor.cpp
+++ b/tt_metal/fabric/physical_system_descriptor.cpp
@@ -12,6 +12,7 @@
 #include <tt-metalium/control_plane.hpp>
 #include <tt-metalium/distributed_context.hpp>
 
+#include "tt_metal/llrt/tunnels_from_mmio_device.hpp"
 #include "tt_metal/llrt/hal.hpp"
 #include "tt_metal/llrt/rtoptions.hpp"
 #include "tt_metal/fabric/physical_system_descriptor.hpp"
@@ -79,8 +80,19 @@ std::pair<TrayID, ASICLocation> get_asic_position(
         ASICLocation asic_location;
         tt::ARCH arch = cluster_desc->get_arch(chip_id);
         if (arch == tt::ARCH::WORMHOLE_B0) {
-            // Query ASIC Location from the Cluster Descriptor for WH.
-            asic_location = ASICLocation{cluster_desc->get_asic_location(chip_id)};
+            // Derive ASIC Location based on the tunnel depth for Wormhole systems
+            // TODO: Remove this once UMD populates the ASIC Location for WH systems.
+            auto mmio_device = cluster_desc->get_closest_mmio_capable_chip(chip_id);
+            auto tunnels_from_mmio_device = llrt::discover_tunnels_from_mmio_device(cluster);
+            const auto& tunnels = tunnels_from_mmio_device.at(mmio_device);
+            for (auto tunnel = 0; tunnel < tunnels.size(); tunnel++) {
+                const auto& devices_on_tunnel = tunnels[tunnel];
+                auto device_it = std::find(devices_on_tunnel.begin(), devices_on_tunnel.end(), chip_id);
+                if (device_it != devices_on_tunnel.end()) {
+                    asic_location = ASICLocation{device_it - devices_on_tunnel.begin()};
+                    break;
+                }
+            }
         } else if (arch == tt::ARCH::BLACKHOLE) {
             // Query ASIC Location from the Cluster Descriptor for BH.
             asic_location = ASICLocation{cluster_desc->get_asic_location(chip_id)};


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/32256

### Problem description
- Cluster validation tool provided limited visibility into physical port configuration, only displaying logical ethernet channels without corresponding physical port IDs or types, making hardware-level debugging difficult
- Workload execution could hang indefinitely without user notification or timeout, leaving validation tool unresponsive and providing no actionable diagnostics
- Missing validation re-checks after detecting failures meant users couldn't determine if hangs were caused by link degradation during workload execution

### What's changed
- Physical port tracking: Extended EthChannelIdentifier with `port_id` and `port_type` fields, implemented `generate_port_info()` to map channels to physical ports via board descriptors, and updated `print_ethernet_connectivity()` and `log_link_metrics()` to display physical port information for hardware-level debugging
- Hang detection and timeout: Converted workload execution to async model with 30-second configurable timeout, using `std::async` with timeout monitoring and distributed all-reduce coordination to ensure all ranks exit together when hangs are detected
- Post-hang validation: Added `handle_workload_timeout()` that re-runs physical discovery and validates current system state against Factory System Descriptor after timeouts, generating timestamped GSD snapshots for post-mortem analysis of link failures during execution
- Code quality improvements: added documentation for ClusterContext and PortInfo structs

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes