### PR TITLE
enable 2-erisc fabric by default on BH

### DIFF
--- a/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
@@ -73,7 +73,6 @@ jobs:
               TT_METAL_CLEAR_L1=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ${TT_METAL_HOME}/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_sanity_common.yaml
               TT_METAL_CLEAR_L1=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ${TT_METAL_HOME}/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_sanity_at_least_2x2_mesh.yaml
               TT_FABRIC_PROFILE_RX_CH_FWD=1 TT_METAL_CLEAR_L1=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ${TT_METAL_HOME}/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_code_profiling.yaml
-              TT_METAL_FABRIC_BLACKHOLE_TWO_ERISC=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ${TT_METAL_HOME}/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_2erisc_quick.yaml
             timeout: 15
           # - name: t3000 fast fabric tests
           #   cmd: "source tests/scripts/t3000/run_t3000_unit_tests.sh && run_t3000_ttfabric_tests"

--- a/tt_metal/fabric/erisc_datamover_builder.cpp
+++ b/tt_metal/fabric/erisc_datamover_builder.cpp
@@ -73,8 +73,8 @@ namespace tt::tt_fabric {
  */
 namespace {
 // Returns true when fabric 2-ERISC should be considered enabled for builders.
-// Effective if either the explicit env override is present, or when running on
-// Blackhole with 2 ERISCs available and Fabric Tensix MUX config is enabled.
+// This is disabled for Wormhole and enabled for Blackhole when 2-eriscs can be dispatched to
+// and if we are not building with the tensix mux extension (due to stack size issue).
 bool is_fabric_two_erisc_enabled() {
     auto &mc = tt::tt_metal::MetalContext::instance();
     // Force-disable if the override is present
@@ -85,7 +85,7 @@ bool is_fabric_two_erisc_enabled() {
     if (hal.get_arch() != tt::ARCH::BLACKHOLE) {
         return false;
     }
-    if (mc.get_fabric_tensix_config() != tt::tt_fabric::FabricTensixConfig::MUX) {
+    if (mc.get_fabric_tensix_config() == tt::tt_fabric::FabricTensixConfig::MUX) {
         return false;
     }
     return hal.get_num_risc_processors(tt::tt_metal::HalProgrammableCoreType::ACTIVE_ETH) >= 2;
@@ -179,9 +179,6 @@ size_t get_num_riscv_cores() {
     if (is_fabric_two_erisc_enabled()) {
         size_t nriscs = tt::tt_metal::MetalContext::instance().hal().get_num_risc_processors(
             tt::tt_metal::HalProgrammableCoreType::ACTIVE_ETH);
-        if (nriscs > 1) {
-            log_warning(tt::LogFabric, "Launching fabric in experimental 2-erisc mode.");
-        }
         return nriscs;
     }
     return 1;

--- a/tt_metal/fabric/erisc_datamover_builder.cpp
+++ b/tt_metal/fabric/erisc_datamover_builder.cpp
@@ -85,7 +85,7 @@ bool is_fabric_two_erisc_enabled() {
     }
 
     const auto &hal = mc.hal();
-    // only blackhole supports 2-erisc
+    // by default, enable only single erisc mode for future architectures as well to simplify bringup
     bool arch_bh = hal.get_arch() == tt::ARCH::BLACKHOLE;
 
     // out of stack size issue on the erisc, to be investigated

--- a/tt_metal/fabric/erisc_datamover_builder.cpp
+++ b/tt_metal/fabric/erisc_datamover_builder.cpp
@@ -95,6 +95,7 @@ bool is_fabric_two_erisc_enabled() {
 
     // 2d dynamic fabric doesn't properly support 2-erisc yet but is being deprecated anyways so we
     // simply disable 2-erisc on it for now.
+    // Issue [#32419](https://github.com/tenstorrent/tt-metal/issues/32419)
     bool is_2d_dynamic = mc.get_fabric_config() == tt::tt_fabric::FabricConfig::FABRIC_2D_DYNAMIC ||
                          mc.get_fabric_config() == tt::tt_fabric::FabricConfig::FABRIC_2D_DYNAMIC_TORUS_X ||
                          mc.get_fabric_config() == tt::tt_fabric::FabricConfig::FABRIC_2D_DYNAMIC_TORUS_Y ||

--- a/tt_metal/fabric/erisc_datamover_builder.hpp
+++ b/tt_metal/fabric/erisc_datamover_builder.hpp
@@ -436,6 +436,11 @@ size_t log_worker_to_fabric_edm_sender_rt_args(const std::vector<uint32_t>& args
 /*
  * The `FabricEriscDatamoverBuilder` is a general class that is used to build fabric router erisc kernels.
  * It is instantiated per fabric (erisc) router. It works closely with the `FabricEriscDatamoverConfig` class.
+ *
+ * Note on 2-ERISC enablement (Blackhole):
+ *   Builder logic may enable an effective "fabric 2-ERISC" mode by default when the platform exposes
+ *   two ERISCs on the Ethernet core and Fabric Tensix MUX is enabled. Decisions such as ERISC count and
+ *   TXQ selection are derived from this effective mode. A presence-based disable env exists to force-disable.
  */
 class FabricEriscDatamoverBuilder {
 public:

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -82,7 +82,7 @@ enum class EnvVarID {
     TT_METAL_FABRIC_TELEMETRY,              // Enable fabric telemetry
     TT_FABRIC_PROFILE_RX_CH_FWD,            // Enable fabric RX channel forwarding profiling
     TT_METAL_FORCE_REINIT,                  // Force context reinitialization
-    TT_METAL_FABRIC_BLACKHOLE_TWO_ERISC,    // Enable 2-ERISC mode with fabric
+    TT_METAL_DISABLE_FABRIC_TWO_ERISC,      // Disable fabric 2-ERISC mode
     TT_METAL_LOG_KERNELS_COMPILE_COMMANDS,  // Log kernel compilation commands
     TT_METAL_SLOW_DISPATCH_MODE,            // Use slow dispatch mode
     TT_METAL_SKIP_ETH_CORES_WITH_RETRAIN,   // Skip Ethernet cores during retrain
@@ -232,7 +232,6 @@ RunTimeOptions::RunTimeOptions() :
 
     InitializeFromEnvVars();
 
-    // Disable 2-erisc mode for non-Silicon devices (simulator/mock)
     if (this->runtime_target_device_ != tt::TargetDevice::Silicon) {
         log_info(tt::LogMetal, "Disabling multi-erisc mode with simulator/mock target device");
         this->enable_2_erisc_mode = false;
@@ -485,6 +484,15 @@ void RunTimeOptions::HandleEnvVar(EnvVarID id, const char* value) {
             break;
         }
 
+        // TT_METAL_DISABLE_FABRIC_TWO_ERISC
+        // Presence-based override to force-disable fabric 2-ERISC mode, even if defaults would enable
+        // Default: false (2-ERISC mode enabled)
+        // Usage: export TT_METAL_DISABLE_FABRIC_TWO_ERISC=1
+        case EnvVarID::TT_METAL_DISABLE_FABRIC_TWO_ERISC:
+            log_info(tt::LogMetal, "Disabling two-erisc fabric mode with TT_METAL_DISABLE_FABRIC_TWO_ERISC");
+            this->disable_fabric_2_erisc_mode = true;
+            break;
+
         // TT_METAL_DISABLE_MULTI_AERISC
         // Disable multi-ERISC mode (2-ERISC mode is enabled by default on Blackhole).
         // Use this to fallback to single ERISC mode.
@@ -515,12 +523,6 @@ void RunTimeOptions::HandleEnvVar(EnvVarID id, const char* value) {
         // Default: false (normal initialization)
         // Usage: export TT_METAL_FORCE_REINIT=1
         case EnvVarID::TT_METAL_FORCE_REINIT: this->force_context_reinit = true; break;
-
-        // TT_METAL_FABRIC_BLACKHOLE_TWO_ERISC
-        // Enable two ERISC mode with fabric on Blackhole architecture.
-        // Default: false (single ERISC mode)
-        // Usage: export TT_METAL_FABRIC_BLACKHOLE_TWO_ERISC=1
-        case EnvVarID::TT_METAL_FABRIC_BLACKHOLE_TWO_ERISC: this->enable_2_erisc_mode_with_fabric = true; break;
 
         // TT_METAL_LOG_KERNELS_COMPILE_COMMANDS
         // Log kernel compilation commands for debugging.

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -204,8 +204,9 @@ class RunTimeOptions {
 
     // Forces Tracy profiler pushes during execution for real-time profiling
     bool tracy_mid_run_push = false;
-    // feature flag to enable 2-erisc mode with fabric on Blackhole, until it is enabled by default
-    bool enable_2_erisc_mode_with_fabric = false;
+
+    // presence-based override to force-disable fabric 2-ERISC regardless of defaults
+    bool disable_fabric_2_erisc_mode = false;
 
     // feature flag to enable 2-erisc mode on Blackhole (general, not fabric-specific)
     bool enable_2_erisc_mode = true;
@@ -408,7 +409,7 @@ public:
             get_kernels_early_return(),
             get_erisc_iram_enabled(),
             get_enable_2_erisc_mode(),
-            get_is_fabric_2_erisc_mode_enabled());
+            get_disable_fabric_2_erisc_mode());
         for (int i = 0; i < RunTimeDebugFeatureCount; i++) {
             compile_hash_str += "_";
             compile_hash_str += get_feature_hash_string((llrt::RunTimeDebugFeatures)i);
@@ -506,9 +507,8 @@ public:
 
     bool get_force_context_reinit() const { return force_context_reinit; }
 
-    // Feature flag to specify if fabric is enabled in 2-erisc mode or not.
-    // if true, then the fabric router is parallelized across two eriscs in the Ethernet core
-    bool get_is_fabric_2_erisc_mode_enabled() const { return enable_2_erisc_mode_with_fabric; }
+    // Presence-based override to force-disable fabric 2-ERISC
+    bool get_disable_fabric_2_erisc_mode() const { return disable_fabric_2_erisc_mode; }
 
     // Feature flag to enable 2-erisc mode on Blackhole
     bool get_enable_2_erisc_mode() const { return enable_2_erisc_mode; }


### PR DESCRIPTION
This changes improves fabric performance on Blackhole by work sharing across both erisc cores inside each Ethernet core. For example, neighbour exchange patterns on Line fabric double from around 16 GB/s/dir to roughly 30 GB/s/dir @ 4k packet size.

To disable, specify environment variable `TT_METAL_DISABLE_FABRIC_TWO_ERISC`

### Ticket
Closes [#20669](https://github.com/tenstorrent/tt-metal/issues/20669)

### Checklist
- [x] All post commit - T3K Quick: https://github.com/tenstorrent/tt-metal/actions/runs/19310938480
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable): https://github.com/tenstorrent/tt-metal/actions/runs/19335619871
- [x] BH Multi-card Unit Tests: https://github.com/tenstorrent/tt-metal/actions/runs/19335626348
- [x] BH Multi-card Demo Tests: https://github.com/tenstorrent/tt-metal/actions/runs/19335640166
- [x] BH Nightly: https://github.com/tenstorrent/tt-metal/actions/runs/19343214216
There is no proper BH GLX pipeline yet but I did run fabric tests, extended g08blx03 for many hours and iterations and saw no issues. 