### PR TITLE
SDXL - Adjust PCC Thresholds for MM Change

### DIFF
--- a/models/experimental/stable_diffusion_xl_base/refiner/tests/pcc/test_module_tt_transformerblock.py
+++ b/models/experimental/stable_diffusion_xl_base/refiner/tests/pcc/test_module_tt_transformerblock.py
@@ -21,8 +21,8 @@ from models.experimental.stable_diffusion_xl_base.tests.test_common import SDXL_
         ((1, 4096, 768), (1, 77, 1280), 1, 1, 768, 12, 768, 0.999, "down_blocks"),
         ((1, 1024, 1536), (1, 77, 1280), 2, 0, 1536, 24, 1536, 0.999, "down_blocks"),
         ((1, 1024, 1536), (1, 77, 1280), 2, 1, 1536, 24, 1536, 0.998, "down_blocks"),
-        ((1, 256, 1536), (1, 77, 1280), -1, 0, 1536, 24, 1536, 0.999, "mid_block"),
-        ((1, 256, 1536), (1, 77, 1280), -1, 1, 1536, 24, 1536, 0.998, "mid_block"),
+        ((1, 256, 1536), (1, 77, 1280), -1, 0, 1536, 24, 1536, 0.998, "mid_block"),
+        ((1, 256, 1536), (1, 77, 1280), -1, 1, 1536, 24, 1536, 0.999, "mid_block"),
     ],
 )
 @pytest.mark.parametrize("device_params", [{"l1_small_size": SDXL_L1_SMALL_SIZE}], indirect=True)


### PR DESCRIPTION
### Problem description
https://github.com/tenstorrent/tt-metal/commit/56bf9224fc2a08264bb5eac6ae90d62a9a2c400f changed the way Matmul autoselected program configs, allowing 1D configs to be used for narrow interleaved matmuls in L1 that should get a performance benefit.

In the SDXL mid_block testcases, the changed matmul program config had the unexpected side effect of changing one PCC from 0.999 -> 0.998, and the other from 0.998 -> 0.999. No significant accuracy issue is noticed on the individual matmul being performed.

### What's changed
Swapped the 0.998 and 0.999 PCC thresholds on the mid_block tests.

### Checklist
- [x] Frequent Model & TTNN Tests [SDXL passes](https://github.com/tenstorrent/tt-metal/actions/runs/19307225438)