### PR TITLE
Update multi-tensor CCL tests to use device quiescing

### DIFF
--- a/tests/ttnn/unit_tests/gtests/ccl/test_multi_tensor_ccl.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_multi_tensor_ccl.cpp
@@ -4,28 +4,19 @@
 
 #include "gtest/gtest.h"
 
-#include "ttnn/operations/experimental/ccl/all_gather_async/all_gather_async.hpp"
-#include "ttnn/operations/experimental/ccl/all_reduce_async/all_reduce_async.hpp"
-#include "ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/reduce_scatter_minimal_async.hpp"
+#include "ttnn/tensor/unit_mesh/unit_mesh_utils.hpp"
+#include "ttnn/operations/ccl/all_gather/all_gather.hpp"
+#include "ttnn/operations/ccl/reduce_scatter/reduce_scatter.hpp"
+#include "ttnn/operations/ccl/all_reduce/all_reduce.hpp"
 
 #include "tt_metal/tt_metal/common/multi_device_fixture.hpp"
 #include "test_fabric_edm_common.hpp"
 
 #include <vector>
-
 namespace tt::tt_metal {
 
 namespace {
 namespace CMAKE_UNIQUE_NAMESPACE {
-
-ttnn::global_semaphore::MultiDeviceGlobalSemaphore create_global_semaphore(const std::vector<IDevice*>& devices) {
-    return ttnn::global_semaphore::create_global_semaphore_with_same_address(
-        devices,
-        devices.at(0)->worker_cores(HalProgrammableCoreType::TENSIX, SubDeviceId{0}),
-        0,
-        tt::tt_metal::BufferType::L1,
-        10);
-}
 
 std::vector<std::shared_ptr<distributed::MeshDevice>> get_line_devices(distributed::MeshDevice* mesh_device) {
     return {
@@ -36,17 +27,19 @@ std::vector<std::shared_ptr<distributed::MeshDevice>> get_line_devices(distribut
     };
 }
 
-std::vector<IDevice*> get_line_devices_as_idevice(
-    const std::vector<std::shared_ptr<distributed::MeshDevice>>& mesh_devices) {
-    std::vector<IDevice*> devices;
-    devices.reserve(mesh_devices.size());
-    for (auto& mesh_device : mesh_devices) {
-        devices.push_back(mesh_device.get());
-    }
-    return devices;
-}
 }  // namespace CMAKE_UNIQUE_NAMESPACE
 }  // namespace
+
+class MeshDevice1x4Fixture : public MeshDeviceFixtureBase {
+protected:
+    MeshDevice1x4Fixture() : MeshDeviceFixtureBase(Config{.mesh_shape = MeshShape{1, 4}}) {
+        tt::tt_fabric::SetFabricConfig(tt::tt_fabric::FabricConfig::FABRIC_1D);
+    }
+    void TearDown() override {
+        MeshDeviceFixtureBase::TearDown();
+        tt::tt_fabric::SetFabricConfig(tt::tt_fabric::FabricConfig::DISABLED);
+    }
+};
 
 class MultiCQFabricMeshDevice2x4Fixture : public MultiCQMeshDevice2x4Fixture {
 protected:
@@ -57,9 +50,8 @@ protected:
     }
 };
 
-TEST_F(MultiCQFabricMeshDevice2x4Fixture, DISABLED_AllGatherCommandProcessorAsync) {
+TEST_F(MeshDevice1x4Fixture, AllGatherReturnedTensor) {
     auto mesh_devices = CMAKE_UNIQUE_NAMESPACE::get_line_devices(mesh_device_.get());
-    auto devices = CMAKE_UNIQUE_NAMESPACE::get_line_devices_as_idevice(mesh_devices);
 
     std::vector<ttnn::Tensor> tensors;
     TensorSpec tensor_spec(
@@ -68,65 +60,64 @@ TEST_F(MultiCQFabricMeshDevice2x4Fixture, DISABLED_AllGatherCommandProcessorAsyn
         std::vector<bfloat16> data(tensor_spec.logical_shape().volume(), bfloat16(static_cast<float>(dev_idx)));
         tensors.push_back(Tensor::from_vector(std::move(data), tensor_spec).to_device(mesh_devices[dev_idx].get()));
     }
-    auto semaphore = CMAKE_UNIQUE_NAMESPACE::create_global_semaphore(devices);
-    std::vector<ttnn::global_semaphore::MultiDeviceGlobalSemaphore> multi_dev_semaphore = {semaphore};
-    tt::tt_metal::distributed::Synchronize(mesh_device_.get(), std::nullopt, std::vector<SubDeviceId>());
 
-    // TODO (#30692): Use the new all gather flow with aggregate and disaggregate once this issue is fixed.
-    // auto all_gathered = ttnn::experimental::all_gather_command_processor_async(
-    //     tensors,
-    //     /* dim */ 0,
-    //     multi_dev_semaphore,
-    //     /* persistent_output_buffer */ std::nullopt,
-    //     /* num_links */ 1,
-    //     /* memory_config */ std::nullopt,
-    //     ttnn::ccl::Topology::Linear,
-    //     /* cluster_axis */ std::nullopt,
-    //     SubDeviceId(0));
-    // for (int dev_idx = 0; dev_idx < mesh_devices.size(); dev_idx++) {
-    //     auto data = all_gathered[dev_idx].to_vector<bfloat16>();
-    //     for (int i = 0; i < data.size(); i++) {
-    //         float expected = static_cast<float>(i / tensor_spec.logical_shape().volume());
-    //         EXPECT_EQ(static_cast<float>(data[i]), expected);
-    //     }
-    // }
+    auto aggregated_tensor = tt::tt_metal::experimental::unit_mesh::aggregate(tensors);
+
+    // Quiesce parent mesh before all gather
+    mesh_device_->quiesce_submeshes();
+
+    auto all_gathered_tensor = ttnn::all_gather(
+        aggregated_tensor,
+        /* dim */ 0);
+
+    // Quiesce parent mesh after all gather
+    mesh_device_->quiesce_submeshes();
+
+    auto disaggregated_output_tensors = tt::tt_metal::experimental::unit_mesh::disaggregate(all_gathered_tensor);
+    for (int dev_idx = 0; dev_idx < mesh_devices.size(); dev_idx++) {
+        auto data = disaggregated_output_tensors[dev_idx].to_vector<bfloat16>();
+        for (int i = 0; i < data.size(); i++) {
+            float expected = static_cast<float>(i / tensor_spec.logical_shape().volume());
+            EXPECT_EQ(static_cast<float>(data[i]), expected);
+        }
+    }
 }
 
-// TODO: uncomment this once the composite implementation is completed (#28556)
-TEST_F(MultiCQFabricMeshDevice2x4Fixture, DISABLED_AllGatherMinimalAsyncComposite) {
+TEST_F(MeshDevice1x4Fixture, AllGatherPersistentOutput) {
     auto mesh_devices = CMAKE_UNIQUE_NAMESPACE::get_line_devices(mesh_device_.get());
-    auto devices = CMAKE_UNIQUE_NAMESPACE::get_line_devices_as_idevice(mesh_devices);
 
-    std::vector<ttnn::Tensor> tensors;
+    std::vector<ttnn::Tensor> tensors, output_tensors;
     TensorSpec tensor_spec(
         ttnn::Shape({1, 8, 1024, 768}), TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE), MemoryConfig{}));
+    TensorSpec output_tensor_spec(
+        ttnn::Shape({4, 8, 1024, 768}), TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE), MemoryConfig{}));
     for (int dev_idx = 0; dev_idx < mesh_devices.size(); dev_idx++) {
         std::vector<bfloat16> data(tensor_spec.logical_shape().volume(), bfloat16(static_cast<float>(dev_idx)));
         tensors.push_back(Tensor::from_vector(std::move(data), tensor_spec).to_device(mesh_devices[dev_idx].get()));
+        std::vector<bfloat16> output_data(output_tensor_spec.logical_shape().volume(), bfloat16(0));
+        output_tensors.push_back(
+            Tensor::from_vector(std::move(output_data), output_tensor_spec).to_device(mesh_devices[dev_idx].get()));
     }
-    auto forward_semaphore = CMAKE_UNIQUE_NAMESPACE::create_global_semaphore(devices);
-    auto backward_semaphore = CMAKE_UNIQUE_NAMESPACE::create_global_semaphore(devices);
-    std::vector<ttnn::global_semaphore::MultiDeviceGlobalSemaphore> multi_dev_semaphore = {
-        forward_semaphore, backward_semaphore};
-    tt::tt_metal::distributed::Synchronize(mesh_device_.get(), std::nullopt, std::vector<SubDeviceId>());
 
-    auto all_gathered = ttnn::experimental::all_gather_async(
-        /* input_tensors */ tensors,
-        /* persistent_output_buffer */ std::nullopt,
+    auto aggregated_tensor = tt::tt_metal::experimental::unit_mesh::aggregate(tensors);
+    auto aggregated_output_tensor = tt::tt_metal::experimental::unit_mesh::aggregate(output_tensors);
+
+    // Quiesce parent mesh before all gather
+    mesh_device_->quiesce_submeshes();
+
+    auto all_gathered_tensor = ttnn::all_gather(
+        aggregated_tensor,
         /* dim */ 0,
-        /* multi_device_global_semaphore */ multi_dev_semaphore,
-        /* num_links */ 1,
-        /* memory_config */ std::nullopt,
-        /* topology */ ttnn::ccl::Topology::Linear,
-        /* subdevice_id */ SubDeviceId(0),
-        /* cluster_axis */ std::nullopt,
-        /* use_optimal_ccl_for_llama */ false,
-        /* barrier_semaphore */ std::nullopt,
-        /* chunks_per_sync */ std::nullopt,
-        /* num_workers_per_link */ std::nullopt,
-        /* num_buffers_per_channel */ std::nullopt);
+        std::nullopt,
+        std::nullopt,
+        std::nullopt,
+        aggregated_output_tensor);
+
+    // Quiesce parent mesh after all gather
+    mesh_device_->quiesce_submeshes();
+
     for (int dev_idx = 0; dev_idx < mesh_devices.size(); dev_idx++) {
-        auto data = all_gathered[dev_idx].to_vector<bfloat16>();
+        auto data = output_tensors[dev_idx].to_vector<bfloat16>();
         for (int i = 0; i < data.size(); i++) {
             float expected = static_cast<float>(i / tensor_spec.logical_shape().volume());
             EXPECT_EQ(static_cast<float>(data[i]), expected);
@@ -134,55 +125,47 @@ TEST_F(MultiCQFabricMeshDevice2x4Fixture, DISABLED_AllGatherMinimalAsyncComposit
     }
 }
 
-// same as above but with a different tensor shape which triggers the native implementation
-TEST_F(MultiCQFabricMeshDevice2x4Fixture, AllGatherMinimalAsyncNative) {
-    // Issue #29828: This has some assertion error, issue assigned to CCL team
-    GTEST_SKIP();
+TEST_F(MeshDevice1x4Fixture, ReduceScatter) {
     auto mesh_devices = CMAKE_UNIQUE_NAMESPACE::get_line_devices(mesh_device_.get());
-    auto devices = CMAKE_UNIQUE_NAMESPACE::get_line_devices_as_idevice(mesh_devices);
 
-    std::vector<ttnn::Tensor> tensors;
+    std::vector<ttnn::Tensor> tensors, output_tensors;
     TensorSpec tensor_spec(
-        ttnn::Shape({1, 1, 1024, 768}), TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE), MemoryConfig{}));
+        ttnn::Shape({1, 8, 1024, 768}), TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE), MemoryConfig{}));
+    TensorSpec output_tensor_spec(
+        ttnn::Shape({1, 8, 1024, 192}), TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE), MemoryConfig{}));
     for (int dev_idx = 0; dev_idx < mesh_devices.size(); dev_idx++) {
-        std::vector<bfloat16> data(tensor_spec.logical_shape().volume(), bfloat16(static_cast<float>(dev_idx)));
+        std::vector<bfloat16> data(tensor_spec.logical_shape().volume(), bfloat16(static_cast<float>(1)));
         tensors.push_back(Tensor::from_vector(std::move(data), tensor_spec).to_device(mesh_devices[dev_idx].get()));
+        std::vector<bfloat16> output_data(output_tensor_spec.logical_shape().volume(), bfloat16(0));
+        output_tensors.push_back(
+            Tensor::from_vector(std::move(output_data), output_tensor_spec).to_device(mesh_devices[dev_idx].get()));
     }
-    auto forward_semaphore = CMAKE_UNIQUE_NAMESPACE::create_global_semaphore(devices);
-    auto backward_semaphore = CMAKE_UNIQUE_NAMESPACE::create_global_semaphore(devices);
-    std::vector<ttnn::global_semaphore::MultiDeviceGlobalSemaphore> multi_dev_semaphore = {
-        forward_semaphore, backward_semaphore};
-    tt::tt_metal::distributed::Synchronize(mesh_device_.get(), std::nullopt, std::vector<SubDeviceId>());
+    auto aggregated_tensor = tt::tt_metal::experimental::unit_mesh::aggregate(tensors);
+    auto aggregated_output_tensor = tt::tt_metal::experimental::unit_mesh::aggregate(output_tensors);
 
-    auto all_gathered = ttnn::experimental::all_gather_async(
-        /* input_tensors */ tensors,
-        /* persistent_output_buffer */ std::nullopt,
-        /* dim */ 0,
-        /* multi_device_global_semaphore */ multi_dev_semaphore,
-        /* num_links */ 1,
-        /* memory_config */ std::nullopt,
-        /* topology */ ttnn::ccl::Topology::Linear,
-        /* subdevice_id */ SubDeviceId(0),
-        /* cluster_axis */ std::nullopt,
-        /* use_optimal_ccl_for_llama */ false,
-        /* barrier_semaphore */ std::nullopt,
-        /* chunks_per_sync */ std::nullopt,
-        /* num_workers_per_link */ std::nullopt,
-        /* num_buffers_per_channel */ std::nullopt);
+    // Quiesce parent mesh before reduce scatter
+    mesh_device_->quiesce_submeshes();
+    auto reduced = ttnn::reduce_scatter(
+        aggregated_tensor,
+        /* dim */ 3,
+        std::nullopt,
+        std::nullopt,
+        std::nullopt,
+        aggregated_output_tensor);
+    // Quiesce parent mesh after reduce scatter
+    mesh_device_->quiesce_submeshes();
+
     for (int dev_idx = 0; dev_idx < mesh_devices.size(); dev_idx++) {
-        auto data = all_gathered[dev_idx].to_vector<bfloat16>();
+        auto data = output_tensors[dev_idx].to_vector<bfloat16>();
         for (int i = 0; i < data.size(); i++) {
-            float expected = static_cast<float>(i / tensor_spec.logical_shape().volume());
+            float expected = static_cast<float>(mesh_devices.size());
             EXPECT_EQ(static_cast<float>(data[i]), expected);
         }
     }
 }
 
-// TODO: This test is failing in the CI pipeline "(T3K) T3000 unit tests" but cannot be reproduced locally.
-// Temporarily disabling this test as we plan to deprecate this API soon (#29340).
-TEST_F(MultiCQFabricMeshDevice2x4Fixture, DISABLED_ReduceScatterAsync) {
+TEST_F(MeshDevice1x4Fixture, AllReduce) {
     auto mesh_devices = CMAKE_UNIQUE_NAMESPACE::get_line_devices(mesh_device_.get());
-    auto devices = CMAKE_UNIQUE_NAMESPACE::get_line_devices_as_idevice(mesh_devices);
 
     std::vector<ttnn::Tensor> tensors;
     TensorSpec tensor_spec(
@@ -191,28 +174,25 @@ TEST_F(MultiCQFabricMeshDevice2x4Fixture, DISABLED_ReduceScatterAsync) {
         std::vector<bfloat16> data(tensor_spec.logical_shape().volume(), bfloat16(static_cast<float>(1)));
         tensors.push_back(Tensor::from_vector(std::move(data), tensor_spec).to_device(mesh_devices[dev_idx].get()));
     }
-    auto from_remote_multi_device_global_semaphore = CMAKE_UNIQUE_NAMESPACE::create_global_semaphore(devices);
-    auto to_remote_multi_device_global_semaphore = CMAKE_UNIQUE_NAMESPACE::create_global_semaphore(devices);
 
-    tt::tt_metal::distributed::Synchronize(mesh_device_.get(), std::nullopt, std::vector<SubDeviceId>());
-    // auto reduced = ttnn::experimental::reduce_scatter_async(
-    //     tensors,
-    //     3,
-    //     from_remote_multi_device_global_semaphore,
-    //     to_remote_multi_device_global_semaphore,
-    //     ttnn::operations::reduction::ReduceType::Sum,
-    //     std::nullopt,
-    //     ttnn::ccl::Topology::Linear,
-    //     1,
-    //     SubDeviceId(0));
+    auto aggregated_tensor = tt::tt_metal::experimental::unit_mesh::aggregate(tensors);
 
-    // for (int dev_idx = 0; dev_idx < mesh_devices.size(); dev_idx++) {
-    //     auto data = reduced[dev_idx].to_vector<bfloat16>();
-    //     for (int i = 0; i < data.size(); i++) {
-    //         float expected = static_cast<float>(mesh_devices.size());
-    //         EXPECT_EQ(static_cast<float>(data[i]), expected);
-    //     }
-    // }
+    // Quiesce parent mesh before all reduce
+    mesh_device_->quiesce_submeshes();
+    auto all_reduced_tensor = ttnn::all_reduce(
+        aggregated_tensor,
+        /* cluster_axis */ 1);
+    // Quiesce parent mesh after all reduce
+    mesh_device_->quiesce_submeshes();
+
+    auto disaggregated_output_tensors = tt::tt_metal::experimental::unit_mesh::disaggregate(all_reduced_tensor);
+    for (int dev_idx = 0; dev_idx < mesh_devices.size(); dev_idx++) {
+        auto data = disaggregated_output_tensors[dev_idx].to_vector<bfloat16>();
+        for (int i = 0; i < data.size(); i++) {
+            float expected = static_cast<float>(mesh_devices.size());
+            EXPECT_EQ(static_cast<float>(data[i]), expected);
+        }
+    }
 }
 
 }  // namespace tt::tt_metal

--- a/tests/ttnn/unit_tests/gtests/ccl/test_multi_tensor_ccl.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_multi_tensor_ccl.cpp
@@ -64,14 +64,14 @@ TEST_F(MeshDevice1x4Fixture, AllGatherReturnedTensor) {
     auto aggregated_tensor = tt::tt_metal::experimental::unit_mesh::aggregate(tensors);
 
     // Quiesce parent mesh before all gather
-    mesh_device_->quiesce_submeshes();
+    mesh_device_->quiesce_devices();
 
     auto all_gathered_tensor = ttnn::all_gather(
         aggregated_tensor,
         /* dim */ 0);
 
     // Quiesce parent mesh after all gather
-    mesh_device_->quiesce_submeshes();
+    mesh_device_->quiesce_devices();
 
     auto disaggregated_output_tensors = tt::tt_metal::experimental::unit_mesh::disaggregate(all_gathered_tensor);
     for (int dev_idx = 0; dev_idx < mesh_devices.size(); dev_idx++) {
@@ -103,7 +103,7 @@ TEST_F(MeshDevice1x4Fixture, AllGatherPersistentOutput) {
     auto aggregated_output_tensor = tt::tt_metal::experimental::unit_mesh::aggregate(output_tensors);
 
     // Quiesce parent mesh before all gather
-    mesh_device_->quiesce_submeshes();
+    mesh_device_->quiesce_devices();
 
     auto all_gathered_tensor = ttnn::all_gather(
         aggregated_tensor,
@@ -114,7 +114,7 @@ TEST_F(MeshDevice1x4Fixture, AllGatherPersistentOutput) {
         aggregated_output_tensor);
 
     // Quiesce parent mesh after all gather
-    mesh_device_->quiesce_submeshes();
+    mesh_device_->quiesce_devices();
 
     for (int dev_idx = 0; dev_idx < mesh_devices.size(); dev_idx++) {
         auto data = output_tensors[dev_idx].to_vector<bfloat16>();
@@ -144,7 +144,7 @@ TEST_F(MeshDevice1x4Fixture, ReduceScatter) {
     auto aggregated_output_tensor = tt::tt_metal::experimental::unit_mesh::aggregate(output_tensors);
 
     // Quiesce parent mesh before reduce scatter
-    mesh_device_->quiesce_submeshes();
+    mesh_device_->quiesce_devices();
     auto reduced = ttnn::reduce_scatter(
         aggregated_tensor,
         /* dim */ 3,
@@ -153,7 +153,7 @@ TEST_F(MeshDevice1x4Fixture, ReduceScatter) {
         std::nullopt,
         aggregated_output_tensor);
     // Quiesce parent mesh after reduce scatter
-    mesh_device_->quiesce_submeshes();
+    mesh_device_->quiesce_devices();
 
     for (int dev_idx = 0; dev_idx < mesh_devices.size(); dev_idx++) {
         auto data = output_tensors[dev_idx].to_vector<bfloat16>();
@@ -178,12 +178,12 @@ TEST_F(MeshDevice1x4Fixture, AllReduce) {
     auto aggregated_tensor = tt::tt_metal::experimental::unit_mesh::aggregate(tensors);
 
     // Quiesce parent mesh before all reduce
-    mesh_device_->quiesce_submeshes();
+    mesh_device_->quiesce_devices();
     auto all_reduced_tensor = ttnn::all_reduce(
         aggregated_tensor,
         /* cluster_axis */ 1);
     // Quiesce parent mesh after all reduce
-    mesh_device_->quiesce_submeshes();
+    mesh_device_->quiesce_devices();
 
     auto disaggregated_output_tensors = tt::tt_metal::experimental::unit_mesh::disaggregate(all_reduced_tensor);
     for (int dev_idx = 0; dev_idx < mesh_devices.size(); dev_idx++) {

--- a/tests/ttnn/unit_tests/gtests/multi_thread/test_ccl_multi_cq_multi_device.cpp
+++ b/tests/ttnn/unit_tests/gtests/multi_thread/test_ccl_multi_cq_multi_device.cpp
@@ -409,7 +409,7 @@ TEST_F(MultiCQFabricMeshDevice2x4Fixture, AsyncExecutionWorksCQ0CQ1) {
         for (size_t i = 0; i < devices.size(); ++i) {
             auto device = devices[i];
             auto device_tensor = gathered_tensors[i];
-            boost::asio::post(pool, [&, num_elems, device_tensor]() mutable {
+            boost::asio::post(pool, [&, device, num_elems, device_tensor]() mutable {
                 auto output_data = std::shared_ptr<bfloat16[]>(new bfloat16[device_tensor.physical_volume()]);
                 ttnn::read_buffer(op_cq_id, device_tensor, {output_data});
 
@@ -613,7 +613,7 @@ TEST_F(MultiCQFabricMeshDevice2x4Fixture, AsyncExecutionWorksMultithreadCQ0) {
             auto device = devices[i];
             auto device_tensor = gathered_tensors[i];
 
-            boost::asio::post(pool, [&, num_elems, device_tensor]() mutable {
+            boost::asio::post(pool, [&, device, num_elems, device_tensor]() mutable {
                 auto output_data = std::shared_ptr<bfloat16[]>(new bfloat16[device_tensor.physical_volume()]);
                 ttnn::read_buffer(mem_cq_id, device_tensor, {output_data});
 

--- a/tests/ttnn/unit_tests/gtests/multi_thread/test_ccl_multi_cq_multi_device.cpp
+++ b/tests/ttnn/unit_tests/gtests/multi_thread/test_ccl_multi_cq_multi_device.cpp
@@ -23,10 +23,11 @@
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/tensor/layout/tensor_layout.hpp"
 #include "ttnn/operations/functions.hpp"
-#include "ttnn/operations/experimental/ccl/all_reduce_async/all_reduce_async.hpp"
 #include "ttnn/operations/ccl/shared_with_host/hetergeneous_data_structs.hpp"
 #include "ttnn/operations/ccl/ccl_host_types.hpp"
+#include "ttnn/operations/ccl/all_gather/all_gather.hpp"
 #include "ttnn/tensor/tensor_impl.hpp"
+#include "ttnn/tensor/unit_mesh/unit_mesh_utils.hpp"
 #include "ttnn/distributed/types.hpp"
 #include "tt_metal/test_utils/env_vars.hpp"
 #include "tt_metal/tt_metal/common/multi_device_fixture.hpp"
@@ -50,7 +51,7 @@ using tt::tt_metal::distributed::MeshShape;
 // Custom Fixture using 1D Fabric on a Multi-CQ MeshDevice
 class MultiCQFabricMeshDevice2x4Fixture : public MeshDeviceFixtureBase {
 protected:
-    MultiCQFabricMeshDevice2x4Fixture() : MeshDeviceFixtureBase(Config{.mesh_shape = MeshShape{2, 4}, .num_cqs = 2}) {
+    MultiCQFabricMeshDevice2x4Fixture() : MeshDeviceFixtureBase(Config{.mesh_shape = MeshShape{1, 4}, .num_cqs = 2}) {
         tt::tt_fabric::SetFabricConfig(tt::tt_fabric::FabricConfig::FABRIC_1D);
     }
     void TearDown() override {
@@ -60,7 +61,7 @@ protected:
 };
 
 // TODO(#30692): Re-enable after migrating to aggregated tensor + semaphore-free all-gather APIs.
-TEST_F(MultiCQFabricMeshDevice2x4Fixture, DISABLED_AsyncExecutionWorksCQ0) {
+TEST_F(MultiCQFabricMeshDevice2x4Fixture, AsyncExecutionWorksCQ0) {
     constexpr size_t test_expected_num_devices = 4;
 
     MeshDevice* mesh_device = this->mesh_device_.get();
@@ -86,20 +87,14 @@ TEST_F(MultiCQFabricMeshDevice2x4Fixture, DISABLED_AsyncExecutionWorksCQ0) {
         test_expected_num_devices,
         num_devices);
 
-    log_info(LogTest, "Creating Global Semaphore for Ccl Ops");
-    auto multi_device_global_semaphore = ttnn::global_semaphore::create_global_semaphore_with_same_address(
-        devices,
-        devices[0]->worker_cores(HalProgrammableCoreType::TENSIX, SubDeviceId{0}),
-        0,                             // initial value
-        tt::tt_metal::BufferType::L1,  // buffer type
-        10                             // attempts
-    );
-
     const int batch_size = 8;
     const int sequence_length = 1024;
     const int embedding_dim = 768;
 
+    uint32_t dim = 0;
     const ttnn::Shape input_shape = ttnn::Shape{1, batch_size, sequence_length, embedding_dim};
+    ttnn::Shape output_shape = ttnn::Shape{1, batch_size, sequence_length, embedding_dim};
+    output_shape[dim] *= devices.size();
     const MemoryConfig in_memory_config = MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM);
     const auto num_elems = input_shape.volume();
 
@@ -107,10 +102,13 @@ TEST_F(MultiCQFabricMeshDevice2x4Fixture, DISABLED_AsyncExecutionWorksCQ0) {
     boost::asio::thread_pool pool(devices.size());
 
     TensorSpec tensor_spec(input_shape, TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE), in_memory_config));
+    TensorSpec output_tensor_spec(
+        output_shape, TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE), in_memory_config));
 
     for (int outer_loop = 0; outer_loop < 1; outer_loop++) {
         log_info(LogTest, "Running outer loop {}", outer_loop);
         std::vector<Tensor> device_tensors(devices.size());
+        std::vector<Tensor> output_tensors(devices.size());
 
         log_info(LogTest, "Enqueue Operations before AllGather");
         std::vector<std::future<void>> futures;
@@ -131,12 +129,18 @@ TEST_F(MultiCQFabricMeshDevice2x4Fixture, DISABLED_AsyncExecutionWorksCQ0) {
                 auto input_storage = tt::tt_metal::DeviceStorage{input_buffer, {MeshCoordinate(0, 0)}};
                 Tensor input_tensor = Tensor(input_storage, tensor_spec, TensorTopology{});
 
+                auto output_buffer =
+                    tt::tt_metal::tensor_impl::allocate_device_buffer(single_mesh.get(), output_tensor_spec);
+                auto output_storage = tt::tt_metal::DeviceStorage{output_buffer, {MeshCoordinate(0, 0)}};
+                Tensor output_tensor = Tensor(output_storage, output_tensor_spec, TensorTopology{});
+
                 // Enqueue write_buffer to the read/write command queue and record the event
                 ttnn::write_buffer(QueueId(op_cq_id), input_tensor, {host_data});
 
                 // Enqueue multiple operations to the operation command queue
                 // Set output_tensor into device_tensor for allreduce
                 device_tensors[dev_idx] = ttnn::test_utils::dispatch_ops_to_device(input_tensor, QueueId(op_cq_id));
+                output_tensors[dev_idx] = output_tensor;
 
                 promise->set_value();
             });
@@ -150,21 +154,23 @@ TEST_F(MultiCQFabricMeshDevice2x4Fixture, DISABLED_AsyncExecutionWorksCQ0) {
 
         log_info(LogTest, "Enqueue AllGather");
 
-        // Enqueue the all_gather_command_processor_async operation on each device.
-        // It does not support command queue ID as a parameter and internally uses command queue 0.
-        std::vector<ttnn::global_semaphore::MultiDeviceGlobalSemaphore> multi_dev_semaphore = {
-            multi_device_global_semaphore};
-        // TODO (#30692): Use the new all gather flow with aggregate and disaggregate once this issue is fixed.
-        // const std::vector<Tensor> gathered_tensors = ttnn::experimental::all_gather_command_processor_async(
-        //     device_tensors,
-        //     /* dim */ 0,
-        //     multi_dev_semaphore,
-        //     /* persistent_output_buffer */ std::nullopt,
-        //     /* num_links */ 1,
-        //     operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
-        //     ttnn::ccl::Topology::Linear,
-        //     /* cluster_axis */ std::nullopt,
-        //     SubDeviceId(0));
+        auto aggregated_tensor = tt::tt_metal::experimental::unit_mesh::aggregate(device_tensors);
+        auto aggregated_output_tensor = tt::tt_metal::experimental::unit_mesh::aggregate(output_tensors);
+        // Quiesce parent mesh before all gather
+        mesh_device_->quiesce_submeshes();
+
+        auto all_gathered_tensor = ttnn::all_gather(
+            aggregated_tensor,
+            /* dim */ 0,
+            std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            aggregated_output_tensor);
+
+        // Quiesce parent mesh after all gather
+        mesh_device_->quiesce_submeshes();
+
+        auto gathered_tensors = output_tensors;
 
         log_info(LogTest, "Enqueue dummy ops");
         for (int dev_idx = 0; dev_idx < devices.size(); dev_idx++) {
@@ -193,22 +199,22 @@ TEST_F(MultiCQFabricMeshDevice2x4Fixture, DISABLED_AsyncExecutionWorksCQ0) {
         }
         futures.clear();
 
-        // log_info(LogTest, "read_buffer");
-        // // Read the values from each device and compare them with the results calculated on the host
-        // for (size_t i = 0; i < devices.size(); ++i) {
-        //     auto device = devices[i];
-        //     auto device_tensor = gathered_tensors[i];
-        //     boost::asio::post(pool, [&, device, num_elems, device_tensor]() mutable {
-        //         auto output_data = std::shared_ptr<bfloat16[]>(new bfloat16[device_tensor.physical_volume()]);
-        //         ttnn::read_buffer(QueueId(op_cq_id), device_tensor, {output_data});
+        log_info(LogTest, "read_buffer");
+        // Read the values from each device and compare them with the results calculated on the host
+        for (size_t i = 0; i < devices.size(); ++i) {
+            auto device = devices[i];
+            auto device_tensor = gathered_tensors[i];
+            boost::asio::post(pool, [&, i, device, num_elems, device_tensor]() mutable {
+                auto output_data = std::shared_ptr<bfloat16[]>(new bfloat16[device_tensor.physical_volume()]);
+                ttnn::read_buffer(QueueId(op_cq_id), device_tensor, {output_data});
 
-        //         for (int j = 0; j < device_tensor.physical_volume(); j++) {
-        //             int base = j / num_elems;  // dev_idx
-        //             ASSERT_EQ(static_cast<float>(output_data[j]), (-1.0 * base * 32.0 + 128));
-        //         }
-        //         log_info(LogTest, "Device{} Compare Success", device->id());
-        //     });
-        // }
+                for (int j = 0; j < device_tensor.physical_volume(); j++) {
+                    int base = j / num_elems;  // dev_idx
+                    ASSERT_EQ(static_cast<float>(output_data[j]), (-1.0 * base * 32.0 + 128));
+                }
+                log_info(LogTest, "Device{} Compare Success", device->id());
+            });
+        }
     }
 
     pool.join();
@@ -221,7 +227,7 @@ TEST_F(MultiCQFabricMeshDevice2x4Fixture, DISABLED_AsyncExecutionWorksCQ0) {
     log_info(tt::LogTest, "Finished");
 }
 
-TEST_F(MultiCQFabricMeshDevice2x4Fixture, DISABLED_AsyncExecutionWorksCQ0CQ1) {
+TEST_F(MultiCQFabricMeshDevice2x4Fixture, AsyncExecutionWorksCQ0CQ1) {
     constexpr size_t test_expected_num_devices = 4;
 
     MeshDevice* mesh_device = this->mesh_device_.get();
@@ -252,21 +258,14 @@ TEST_F(MultiCQFabricMeshDevice2x4Fixture, DISABLED_AsyncExecutionWorksCQ0CQ1) {
         test_expected_num_devices,
         num_devices);
 
-    log_info(LogTest, "Creating Global Semaphore for Ccl Ops");
-
-    auto multi_device_global_semaphore = ttnn::global_semaphore::create_global_semaphore_with_same_address(
-        devices,
-        devices[0]->worker_cores(HalProgrammableCoreType::TENSIX, SubDeviceId{0}),
-        0,                             // initial value
-        tt::tt_metal::BufferType::L1,  // buffer type
-        10                             // attempts
-    );
-
     const int batch_size = 8;
     const int sequence_length = 1024;
     const int embedding_dim = 768;
 
+    uint32_t dim = 0;
     const ttnn::Shape input_shape = ttnn::Shape{1, batch_size, sequence_length, embedding_dim};
+    ttnn::Shape output_shape = ttnn::Shape{1, batch_size, sequence_length, embedding_dim};
+    output_shape[dim] *= devices.size();
     const MemoryConfig in_memory_config = MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM);
     const auto num_elems = input_shape.volume();
 
@@ -275,12 +274,14 @@ TEST_F(MultiCQFabricMeshDevice2x4Fixture, DISABLED_AsyncExecutionWorksCQ0CQ1) {
 
     boost::asio::thread_pool pool(devices.size());
 
+    TensorSpec tensor_spec(input_shape, TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE), in_memory_config));
+    TensorSpec output_tensor_spec(
+        output_shape, TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE), in_memory_config));
+
     for (int outer_loop = 0; outer_loop < 1; outer_loop++) {
         log_info(LogTest, "Running outer loop {}", outer_loop);
         std::vector<Tensor> device_tensors(devices.size());
-
-        TensorSpec tensor_spec(
-            input_shape, TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE), in_memory_config));
+        std::vector<Tensor> output_tensors(devices.size());
 
         log_info(LogTest, "Enqueue Operations before AllGather");
         std::vector<std::future<void>> futures;
@@ -302,12 +303,18 @@ TEST_F(MultiCQFabricMeshDevice2x4Fixture, DISABLED_AsyncExecutionWorksCQ0CQ1) {
                 // create_device_tensor)
                 Tensor input_tensor = Tensor(input_storage, tensor_spec, TensorTopology{});
 
+                auto output_buffer =
+                    tt::tt_metal::tensor_impl::allocate_device_buffer(single_mesh.get(), output_tensor_spec);
+                auto output_storage = tt::tt_metal::DeviceStorage{output_buffer, {MeshCoordinate(0, 0)}};
+                Tensor output_tensor = Tensor(output_storage, output_tensor_spec, TensorTopology{});
+
                 // Enqueue write_buffer to the operation`s command queue and record the event
                 ttnn::write_buffer(op_cq_id, input_tensor, {host_data});
 
                 // Enqueue multiple operations to the operation command queue
                 // Set output_tensor into device_tensor for allgather
                 device_tensors[dev_idx] = ttnn::test_utils::dispatch_ops_to_device(input_tensor, op_cq_id);
+                output_tensors[dev_idx] = output_tensor;
 
                 auto& op_cq_2 = single_mesh->mesh_command_queue(op_cq_id.get());
                 auto operation_event = ttnn::record_event(op_cq_2);
@@ -327,21 +334,24 @@ TEST_F(MultiCQFabricMeshDevice2x4Fixture, DISABLED_AsyncExecutionWorksCQ0CQ1) {
 
         log_info(LogTest, "Enqueue AllGather");
 
-        // Enqueue the all_gather_command_processor_async operation on each device.
-        // It does not support command queue ID as a parameter and internally uses command queue 0.
-        std::vector<ttnn::global_semaphore::MultiDeviceGlobalSemaphore> multi_dev_semaphore = {
-            multi_device_global_semaphore};
-        // TODO (#30692): Use the new all gather flow with aggregate and disaggregate once this issue is fixed.
-        // const std::vector<Tensor> gathered_tensors = ttnn::experimental::all_gather_command_processor_async(
-        //     device_tensors,
-        //     /* dim */ 0,
-        //     multi_dev_semaphore,
-        //     /* persistent_output_buffer */ std::nullopt,
-        //     /* num_links */ 1,
-        //     operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
-        //     ttnn::ccl::Topology::Linear,
-        //     /* cluster_axis */ std::nullopt,
-        //     SubDeviceId(0));
+        auto aggregated_tensor = tt::tt_metal::experimental::unit_mesh::aggregate(device_tensors);
+        auto aggregated_output_tensor = tt::tt_metal::experimental::unit_mesh::aggregate(output_tensors);
+
+        // Quiesce parent mesh before all gather
+        mesh_device_->quiesce_submeshes();
+
+        auto all_gathered_tensor = ttnn::all_gather(
+            aggregated_tensor,
+            /* dim */ dim,
+            std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            aggregated_output_tensor);
+
+        // Quiesce parent mesh after all gather
+        mesh_device_->quiesce_submeshes();
+
+        auto gathered_tensors = output_tensors;
 
         log_info(LogTest, "Enqueue dummy ops");
         for (size_t dev_idx = 0; dev_idx < devices.size(); dev_idx++) {
@@ -376,9 +386,10 @@ TEST_F(MultiCQFabricMeshDevice2x4Fixture, DISABLED_AsyncExecutionWorksCQ0CQ1) {
         futures.clear();
 
         for (size_t dev_idx = 0; dev_idx < devices.size(); ++dev_idx) {
+            auto device = devices[dev_idx];
             auto promise = std::make_shared<std::promise<void>>();
             futures.push_back(promise->get_future());
-            boost::asio::post(pool, [&, dev_idx, promise]() mutable {
+            boost::asio::post(pool, [&, dev_idx, device, promise]() mutable {
                 auto& single_mesh = single_meshes[dev_idx];
                 auto ccl_event = ttnn::record_event(single_mesh->mesh_command_queue(ccl_cq_id.get()));
                 // Enqueue the task waiting for the operation_event to the ccl`s command queue
@@ -394,23 +405,22 @@ TEST_F(MultiCQFabricMeshDevice2x4Fixture, DISABLED_AsyncExecutionWorksCQ0CQ1) {
         }
         futures.clear();
 
-        // log_info(LogTest, "read_buffer");
-        // // Read the values from each device and compare them with the results calculated on the host
-        // for (size_t i = 0; i < devices.size(); ++i) {
-        //     auto device = devices[i];
-        //     auto device_tensor = gathered_tensors[i];
+        log_info(LogTest, "read_buffer");
+        // Read the values from each device and compare them with the results calculated on the host
+        for (size_t i = 0; i < devices.size(); ++i) {
+            auto device = devices[i];
+            auto device_tensor = gathered_tensors[i];
+            boost::asio::post(pool, [&, i, device, num_elems, device_tensor]() mutable {
+                auto output_data = std::shared_ptr<bfloat16[]>(new bfloat16[device_tensor.physical_volume()]);
+                ttnn::read_buffer(op_cq_id, device_tensor, {output_data});
 
-        //     boost::asio::post(pool, [&, device, num_elems, device_tensor]() mutable {
-        //         auto output_data = std::shared_ptr<bfloat16[]>(new bfloat16[device_tensor.physical_volume()]);
-        //         ttnn::read_buffer(op_cq_id, device_tensor, {output_data});
-
-        //         for (int j = 0; j < device_tensor.physical_volume(); j++) {
-        //             int base = j / num_elems;  // dev_idx
-        //             ASSERT_EQ(static_cast<float>(output_data[j]), (-1.0 * base * 32.0 + 128));
-        //         }
-        //         log_info(LogTest, "Device{} Compare Success", device->id());
-        //     });
-        // }
+                for (int j = 0; j < device_tensor.physical_volume(); j++) {
+                    int base = j / num_elems;  // dev_idx
+                    ASSERT_EQ(static_cast<float>(output_data[j]), (-1.0 * base * 32.0 + 128));
+                }
+                log_info(LogTest, "Device{} Compare Success", device->id());
+            });
+        }
     }
 
     pool.join();
@@ -423,7 +433,7 @@ TEST_F(MultiCQFabricMeshDevice2x4Fixture, DISABLED_AsyncExecutionWorksCQ0CQ1) {
     log_info(tt::LogTest, "Finished");
 }
 
-TEST_F(MultiCQFabricMeshDevice2x4Fixture, DISABLED_AsyncExecutionWorksMultithreadCQ0) {
+TEST_F(MultiCQFabricMeshDevice2x4Fixture, AsyncExecutionWorksMultithreadCQ0) {
     constexpr size_t test_expected_num_devices = 4;
 
     MeshDevice* mesh_device = this->mesh_device_.get();
@@ -455,21 +465,14 @@ TEST_F(MultiCQFabricMeshDevice2x4Fixture, DISABLED_AsyncExecutionWorksMultithrea
         test_expected_num_devices,
         num_devices);
 
-    log_info(LogTest, "Creating Global Semaphore for Ccl Ops");
-
-    auto multi_device_global_semaphore = ttnn::global_semaphore::create_global_semaphore_with_same_address(
-        devices,
-        devices[0]->worker_cores(HalProgrammableCoreType::TENSIX, SubDeviceId{0}),
-        0,                             // initial value
-        tt::tt_metal::BufferType::L1,  // buffer type
-        10                             // attempts
-    );
-
     const int batch_size = 8;
     const int sequence_length = 1024;
     const int embedding_dim = 768;
 
+    uint32_t dim = 0;
     const ttnn::Shape input_shape = ttnn::Shape{1, batch_size, sequence_length, embedding_dim};
+    ttnn::Shape output_shape = ttnn::Shape{1, batch_size, sequence_length, embedding_dim};
+    output_shape[dim] *= devices.size();
     const MemoryConfig in_memory_config = MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM);
     const auto num_elems = input_shape.volume();
 
@@ -478,12 +481,14 @@ TEST_F(MultiCQFabricMeshDevice2x4Fixture, DISABLED_AsyncExecutionWorksMultithrea
 
     boost::asio::thread_pool pool(devices.size());
 
+    TensorSpec tensor_spec(input_shape, TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE), in_memory_config));
+    TensorSpec output_tensor_spec(
+        output_shape, TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE), in_memory_config));
+
     for (int outer_loop = 0; outer_loop < 1; outer_loop++) {
         log_info(LogTest, "Running outer loop {}", outer_loop);
         std::vector<Tensor> device_tensors(devices.size());
-
-        TensorSpec tensor_spec(
-            input_shape, TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE), in_memory_config));
+        std::vector<Tensor> output_tensors(devices.size());
 
         log_info(LogTest, "Enqueue Operations before AllGather");
         std::vector<std::future<void>> futures;
@@ -505,6 +510,11 @@ TEST_F(MultiCQFabricMeshDevice2x4Fixture, DISABLED_AsyncExecutionWorksMultithrea
                 // create_device_tensor)
                 Tensor input_tensor = Tensor(input_storage, tensor_spec, TensorTopology{});
 
+                auto output_buffer =
+                    tt::tt_metal::tensor_impl::allocate_device_buffer(single_mesh.get(), output_tensor_spec);
+                auto output_storage = tt::tt_metal::DeviceStorage{output_buffer, {MeshCoordinate(0, 0)}};
+                Tensor output_tensor = Tensor(output_storage, output_tensor_spec, TensorTopology{});
+
                 // Enqueue write_buffer to the operation`s command queue and record the event
                 ttnn::write_buffer(mem_cq_id, input_tensor, {host_data});
 
@@ -517,6 +527,7 @@ TEST_F(MultiCQFabricMeshDevice2x4Fixture, DISABLED_AsyncExecutionWorksMultithrea
                 // Enqueue multiple operations to the operation command queue
                 // Set output_tensor into device_tensor for allgather
                 device_tensors[dev_idx] = ttnn::test_utils::dispatch_ops_to_device(input_tensor, op_ccl_cq_id);
+                output_tensors[dev_idx] = output_tensor;
 
                 promise->set_value();
             });
@@ -530,21 +541,24 @@ TEST_F(MultiCQFabricMeshDevice2x4Fixture, DISABLED_AsyncExecutionWorksMultithrea
 
         log_info(LogTest, "Enqueue AllGather");
 
-        // Enqueue the all_gather_command_processor_async operation on each device.
-        // It does not support command queue ID as a parameter and internally uses command queue 0.
-        std::vector<ttnn::global_semaphore::MultiDeviceGlobalSemaphore> multi_dev_semaphore = {
-            multi_device_global_semaphore};
-        // TODO (#30692): Use the new all gather flow with aggregate and disaggregate once this issue is fixed.
-        // const std::vector<Tensor> gathered_tensors = ttnn::experimental::all_gather_command_processor_async(
-        //     device_tensors,
-        //     /* dim */ 0,
-        //     multi_dev_semaphore,
-        //     /* persistent_output_buffer */ std::nullopt,
-        //     /* num_links */ 1,
-        //     operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
-        //     ttnn::ccl::Topology::Linear,
-        //     /* cluster_axis */ std::nullopt,
-        //     SubDeviceId(0));
+        auto aggregated_tensor = tt::tt_metal::experimental::unit_mesh::aggregate(device_tensors);
+        auto aggregated_output_tensor = tt::tt_metal::experimental::unit_mesh::aggregate(output_tensors);
+
+        // Quiesce parent mesh before all gather
+        mesh_device_->quiesce_submeshes();
+
+        auto all_gathered_tensor = ttnn::all_gather(
+            aggregated_tensor,
+            /* dim */ dim,
+            std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            aggregated_output_tensor);
+
+        // Quiesce parent mesh after all gather
+        mesh_device_->quiesce_submeshes();
+
+        auto gathered_tensors = output_tensors;
 
         log_info(LogTest, "Enqueue dummy ops");
         for (size_t dev_idx = 0; dev_idx < devices.size(); dev_idx++) {
@@ -576,9 +590,10 @@ TEST_F(MultiCQFabricMeshDevice2x4Fixture, DISABLED_AsyncExecutionWorksMultithrea
         futures.clear();
 
         for (size_t dev_idx = 0; dev_idx < devices.size(); ++dev_idx) {
+            auto device = devices[dev_idx];
             auto promise = std::make_shared<std::promise<void>>();
             futures.push_back(promise->get_future());
-            boost::asio::post(pool, [&, dev_idx, promise]() mutable {
+            boost::asio::post(pool, [&, dev_idx, device, promise]() mutable {
                 auto& single_mesh = single_meshes[dev_idx];
                 auto ccl_event = ttnn::record_event(single_mesh->mesh_command_queue(op_ccl_cq_id.get()));
                 // Enqueue the task waiting for the operation_event to the ccl`s command queue
@@ -596,21 +611,21 @@ TEST_F(MultiCQFabricMeshDevice2x4Fixture, DISABLED_AsyncExecutionWorksMultithrea
 
         log_info(LogTest, "read_buffer");
         // Read the values from each device and compare them with the results calculated on the host
-        // for (size_t i = 0; i < devices.size(); ++i) {
-        //     auto device = devices[i];
-        //     auto device_tensor = gathered_tensors[i];
+        for (size_t i = 0; i < devices.size(); ++i) {
+            auto device = devices[i];
+            auto device_tensor = gathered_tensors[i];
 
-        //     boost::asio::post(pool, [&, device, num_elems, device_tensor]() mutable {
-        //         auto output_data = std::shared_ptr<bfloat16[]>(new bfloat16[device_tensor.physical_volume()]);
-        //         ttnn::read_buffer(mem_cq_id, device_tensor, {output_data});
+            boost::asio::post(pool, [&, i, device, num_elems, device_tensor]() mutable {
+                auto output_data = std::shared_ptr<bfloat16[]>(new bfloat16[device_tensor.physical_volume()]);
+                ttnn::read_buffer(mem_cq_id, device_tensor, {output_data});
 
-        //         for (int j = 0; j < device_tensor.physical_volume(); j++) {
-        //             int base = j / num_elems;  // dev_idx
-        //             ASSERT_EQ(static_cast<float>(output_data[j]), (-1.0 * base * 32.0 + 128));
-        //         }
-        //         log_info(LogTest, "Device{} Compare Success", device->id());
-        //     });
-        // }
+                for (int j = 0; j < device_tensor.physical_volume(); j++) {
+                    int base = j / num_elems;  // dev_idx
+                    ASSERT_EQ(static_cast<float>(output_data[j]), (-1.0 * base * 32.0 + 128));
+                }
+                log_info(LogTest, "Device{} Compare Success", device->id());
+            });
+        }
     }
 
     pool.join();


### PR DESCRIPTION
### Ticket
#30692

### Problem description
@jbaumanTT merged in his device quiescing API. We need to update the CCL tests to show an example of how to run CCLs with this flow.

### What's changed
Change tests to aggregate tensors, quiesce, run the CCLs, quiesce and then verify.

### Checklist
- [ ] T3K fast: https://github.com/tenstorrent/tt-metal/actions/runs/19311545948
- [ ] T3K unit: https://github.com/tenstorrent/tt-metal/actions/runs/19311516691