### PR TITLE
Issue 1=17803: Enhance TT_ASSERT/FATAL/THROW to have the assert_type …

### DIFF
--- a/tt_stl/tt_stl/assert.hpp
+++ b/tt_stl/tt_stl/assert.hpp
@@ -90,7 +90,7 @@ template <typename... Args>
     const char* file, int line, const char* assert_type, const char* condition_str, const Args&... args) {
     if (std::getenv("TT_ASSERT_ABORT")) {
         if constexpr (sizeof...(args) > 0) {
-            log_critical(tt::LogAlways, args...);
+            log_critical(tt::LogAlways, "{}: {}", assert_type, fmt::format(args...));
         }
         abort();
     }
@@ -100,7 +100,7 @@ template <typename... Args>
     if constexpr (sizeof...(args) > 0) {
         trace_message_ss << "info:" << std::endl;
         trace_message_ss << fmt::format(args...) << std::endl;
-        log_critical(tt::LogAlways, args...);
+        log_critical(tt::LogAlways, "{}: {}", assert_type, fmt::format(args...));
     }
     trace_message_ss << "backtrace:\n";
     trace_message_ss << tt::assert::backtrace_to_string(100, 3, " --- ");


### PR DESCRIPTION
…prefix to the log during exception event

### Ticket
https://github.com/tenstorrent/tt-metal/issues/17803

### Problem description
TT_ASSERT calls TT_THROW
The output for an assert says nothing about an assert being hit
This can be misleading as asserts look like errors
This could be fixed by printing "assert" instead of "fatal", or by adding some other output about the assert

### What's changed
Update the macro such that the assert_type is prefix into the log_critical message.  This will clearly distinguish the different type (TT_ASSERT or TT_FATAL or TT_THROW)

Positive testing
1. Normal compile, test TT_FATAL/TT_THROW - pass
2. Debug compile, test TT_FATAL/TT_THROW and TT_ASSERT - pass

Random Sample Regression unit test testing
1. unit_tests_api - pass (some test uses TT_FATAL and this feature enhancement cause no negative impact)
2. unit_tests_device - pass
3. unit_tests_debug_tools - pass

### Checklist
- [X] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes