### PR TITLE
#32320: use new CB and Noc for generic reduce

### DIFF
--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_h.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_h.cpp
@@ -5,6 +5,7 @@
 #include <cstdint>
 
 #include "compute_kernel_api/reduce.h"
+#include "tt_metal/api/tt-metalium/circular_buffer.hpp"
 
 namespace NAMESPACE {
 void MAIN {
@@ -13,10 +14,14 @@ void MAIN {
     uint32_t NC = get_compile_time_arg_val(2);
     uint32_t row_chunk = get_compile_time_arg_val(3);
 
+    tt::tt_metal::experimental::CircularBuffer cb_in0(tt::CBIndex::c_0);
+    tt::tt_metal::experimental::CircularBuffer cb_in2(tt::CBIndex::c_2);
+    tt::tt_metal::experimental::CircularBuffer cb_out(tt::CBIndex::c_3);
+
     compute_kernel_hw_startup(tt::CBIndex::c_0, tt::CBIndex::c_2, tt::CBIndex::c_3);
     reduce_init(tt::CBIndex::c_0, tt::CBIndex::c_2, tt::CBIndex::c_3);
 
-    cb_wait_front(tt::CBIndex::c_2, 1);  // scaler tile from the reader
+    cb_in2.wait_front(1);  // scaler tile from the reader
 
     constexpr int onetile = 1;
 
@@ -40,16 +45,16 @@ void MAIN {
             for (uint32_t ht = 0; ht < Ht; ++ht) {
                 reduce_dst_idx = 0;
                 for (uint32_t i = wt; i < chunk_end; ++i) {
-                    cb_wait_front(tt::CB::c_in0, onetile);
+                    cb_in0.wait_front(onetile);
                     reduce_tile(tt::CB::c_in0, tt::CB::c_in2, 0, 0, reduce_dst_idx);
-                    cb_pop_front(tt::CB::c_in0, onetile);
+                    cb_in0.pop_front(onetile);
                     ++reduce_dst_idx;
                 }
             }
             for (uint32_t i = wt; i < chunk_end; ++i) {
-                cb_reserve_back(tt::CBIndex::c_3, onetile);
+                cb_out.reserve_back(onetile);
                 pack_tile((i - wt), tt::CBIndex::c_3);
-                cb_push_back(tt::CBIndex::c_3, onetile);
+                cb_out.push_back(onetile);
             }
             release_dst();
         }

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_hw.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_hw.cpp
@@ -12,10 +12,14 @@ void MAIN {
     uint32_t Wt = get_compile_time_arg_val(1);
     uint32_t NC = get_compile_time_arg_val(2);
 
+    experimental::CircularBuffer cb_in0(tt::CBIndex::c_0);
+    experimental::CircularBuffer cb_in2(tt::CBIndex::c_2);
+    experimental::CircularBuffer cb_out(tt::CBIndex::c_3);
+
     compute_kernel_hw_startup(tt::CBIndex::c_0, tt::CBIndex::c_2, tt::CBIndex::c_3);
     reduce_init(tt::CBIndex::c_0, tt::CBIndex::c_2, tt::CBIndex::c_3);
 
-    cb_wait_front(tt::CBIndex::c_2, 1);  // scaler tile from the reader
+    cb_in2.wait_front(1);  // scaler tile from the reader
     for (uint32_t nc = 0; nc < NC; nc++) {
         constexpr int onetile = 1;
         int reduce_dst_idx = 0;
@@ -25,15 +29,15 @@ void MAIN {
             // reducing in W means out[h][0] = sum(w=0..W-1, in[h][w])
             // in this case we just sequentially add to accumulator all the W-tiles in a row
             for (uint32_t wt = 0; wt < Wt; ++wt) {
-                cb_wait_front(tt::CBIndex::c_0, onetile);
+                cb_in0.wait_front(onetile);
                 // REDUCE_OP/DIM is expected to come from add_define
                 reduce_tile(tt::CBIndex::c_0, tt::CBIndex::c_2, 0, 0, reduce_dst_idx);
-                cb_pop_front(tt::CBIndex::c_0, onetile);
+                cb_in0.pop_front(onetile);
             }
         }
-        cb_reserve_back(tt::CBIndex::c_3, onetile);
+        cb_out.reserve_back(onetile);
         pack_tile(reduce_dst_idx, tt::CBIndex::c_3);
-        cb_push_back(tt::CBIndex::c_3, onetile);
+        cb_out.push_back(onetile);
         release_dst();
     }
 }

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_w.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_w.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <cstdint>
+#include "tt_metal/api/tt-metalium/circular_buffer.hpp"
 
 #ifndef REDUCE_ROW_SUM_VIA_MM
 #include "compute_kernel_api/reduce.h"
@@ -17,6 +18,10 @@ void MAIN {
     uint32_t Wt = get_compile_time_arg_val(1);
     uint32_t NC = get_compile_time_arg_val(2);
 
+    tt::tt_metal::experimental::CircularBuffer cb_in0(tt::CBIndex::c_0);
+    tt::tt_metal::experimental::CircularBuffer cb_in2(tt::CBIndex::c_2);
+    tt::tt_metal::experimental::CircularBuffer cb_out(tt::CBIndex::c_3);
+
 #ifndef REDUCE_ROW_SUM_VIA_MM
     compute_kernel_hw_startup(tt::CBIndex::c_0, tt::CBIndex::c_2, tt::CBIndex::c_3);
     reduce_init(tt::CBIndex::c_0, tt::CBIndex::c_2, tt::CBIndex::c_3);
@@ -24,7 +29,7 @@ void MAIN {
     mm_init(tt::CBIndex::c_0, tt::CBIndex::c_2, tt::CBIndex::c_3);
 #endif
 
-    cb_wait_front(tt::CBIndex::c_2, 1);  // scaler tile from the reader
+    cb_in2.wait_front(1);  // scaler tile from the reader
     for (uint32_t nc = 0; nc < NC; nc++) {
         constexpr int onetile = 1;
         int reduce_dst_idx = 0;
@@ -34,19 +39,19 @@ void MAIN {
             // in this case we just sequentially add to accumulator all the W-tiles in a row
             acquire_dst();
             for (uint32_t wt = 0; wt < Wt; ++wt) {
-                cb_wait_front(tt::CBIndex::c_0, onetile);
+                cb_in0.wait_front(onetile);
                 // REDUCE_OP is expected to come from add_define
 #ifndef REDUCE_ROW_SUM_VIA_MM
                 reduce_tile(tt::CBIndex::c_0, tt::CBIndex::c_2, 0, 0, reduce_dst_idx);
 #else
                 matmul_tiles(tt::CBIndex::c_0, tt::CBIndex::c_2, 0, 0, 0, false);
 #endif
-                cb_pop_front(tt::CBIndex::c_0, onetile);
+                cb_in0.pop_front(onetile);
             }
 
-            cb_reserve_back(tt::CBIndex::c_3, onetile);
+            cb_out.reserve_back(onetile);
             pack_tile(reduce_dst_idx, tt::CBIndex::c_3);
-            cb_push_back(tt::CBIndex::c_3, onetile);
+            cb_out.push_back(onetile);
             release_dst();
         }
     }


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes