### PR TITLE
Initialize PRNG seed in trisc.cc

### DIFF
--- a/tt_metal/hw/firmware/src/tt-1xx/trisc.cc
+++ b/tt_metal/hw/firmware/src/tt-1xx/trisc.cc
@@ -105,6 +105,12 @@ int main(int argc, char* argv[]) {
 
     reset_cfg_state_id();
 
+    {
+        // #31901: initialize PRNG seed to 0 to avoid nondeterministic behavior
+        volatile uint tt_reg_ptr* cfg = get_cfg_pointer();
+        cfg[PRNG_SEED_Seed_Val_ADDR32] = 0;
+        riscv_wait(600);
+    }
     my_logical_x_ = mailboxes->core_info.absolute_logical_x;
     my_logical_y_ = mailboxes->core_info.absolute_logical_y;
     *trisc_run = RUN_SYNC_MSG_DONE;


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/31901

### Problem description
see ticket

### What's changed
Initialize PRNG seed to 0 in fw.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/19306347589) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes