### PR TITLE
SDXL added inpainting accuracy

### DIFF
--- a/models/experimental/stable_diffusion_xl_base/targets/targets.json
+++ b/models/experimental/stable_diffusion_xl_base/targets/targets.json
@@ -1,14 +1,38 @@
 {
-  "perf": {
-    "functional": 125,
-    "complete":   25,
-    "target":     12.5
+  "sdxl": {
+    "perf": {
+      "functional": 125,
+      "complete":   25,
+      "target":     12.5
+    },
+    "perf-tp": {
+      "functional": 62.5,
+      "complete":   12.5,
+      "target":     6.25
+    },
+    "accuracy": {
+      "fid_valid_range_full_dataset": [23.01085758, 23.95007626],
+      "clip_valid_range_full_dataset": [31.68631873, 31.81331801],
+      "clip_valid_range_100": [31.70502465208177, 32.094664207879916],
+      "fid_valid_range_100": [182.78657778059338, 183.9511842650918]
+    }
   },
-
-  "accuracy": {
-    "fid_valid_range_5000": [23.01085758, 23.95007626],
-    "clip_valid_range_5000": [31.68631873, 31.81331801],
-    "clip_valid_range_100": [31.70502465208177, 32.094664207879916],
-    "fid_valid_range_100": [182.78657778059338, 183.9511842650918]
+  "sdxl-inpaint": {
+    "perf": {
+      "functional": 125,
+      "complete":   25,
+      "target":     12.5
+    },
+    "perf-tp": {
+      "functional": 62.5,
+      "complete":   12.5,
+      "target":     6.25
+    },
+    "accuracy": {
+      "fid_valid_range_full_dataset": [39.93630404436355, 41.04755341596031],
+      "clip_valid_range_full_dataset": [31.208422499810794, 31.53588599031795],
+      "clip_valid_range_100": [31.133804321593956, 31.523443877392097],
+      "fid_valid_range_100": [185.03820965247064, 186.2028161369691]
+    }
   }
 }

--- a/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_inpaint_accuracy.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_inpaint_accuracy.py
@@ -247,7 +247,7 @@ def test_accuracy_sdxl_inpaint(
 
 
 def get_dataset_for_inpainting_accuracy(n_prompts: int):
-    logger.info(f"Reqested {n_prompts} prompts for inpainting accuracy evaluation...")
+    logger.info(f"Requested {n_prompts} prompts for inpainting accuracy evaluation...")
     if n_prompts > MAX_N_SAMPLES or n_prompts < MIN_N_SAMPLES:
         logger.warning(f"Requested number of prompts {n_prompts} is out of bounds [{MIN_N_SAMPLES}, {MAX_N_SAMPLES}]")
         if n_prompts > MAX_N_SAMPLES:

--- a/models/experimental/stable_diffusion_xl_base/utils/clip_fid_ranges.py
+++ b/models/experimental/stable_diffusion_xl_base/utils/clip_fid_ranges.py
@@ -5,8 +5,8 @@
 import json
 
 TARGET_JSON_PATH = "models/experimental/stable_diffusion_xl_base/targets/targets.json"
-STANDARD_DATASET_SIZES = {100, 1260, 5000}
-SDXL_DATASET_SIZE, SDXL_INPAINT_DATASET_SIZE = 5000, 1260
+SDXL_DATASET_SIZE, SDXL_INPAINT_DATASET_SIZE, QUICK_TEST_DATASET_SIZE = 5000, 1260, 100
+STANDARD_DATASET_SIZES = {SDXL_DATASET_SIZE, SDXL_INPAINT_DATASET_SIZE, QUICK_TEST_DATASET_SIZE}
 
 
 def get_model_targets(model_name):
@@ -25,9 +25,10 @@ get_approx = lambda range_tuple: (range_tuple[0] * 0.97, range_tuple[1] * 1.03)
 
 def using_full_dataset(model_name, num_prompts):
     if model_name in {"sdxl", "sdxl-tp"}:
-        return num_prompts == 5000
+        return num_prompts == SDXL_DATASET_SIZE
     elif model_name in {"sdxl-inpaint", "sdxl-inpaint-tp"}:
-        return num_prompts == 1260
+        return num_prompts == SDXL_INPAINT_DATASET_SIZE
+    assert False, f"Unknown model name {model_name}"
 
 
 def accuracy_check_fid(model_name, score, num_prompts, mode):

--- a/models/experimental/stable_diffusion_xl_base/utils/clip_fid_ranges.py
+++ b/models/experimental/stable_diffusion_xl_base/utils/clip_fid_ranges.py
@@ -14,7 +14,7 @@ def get_model_targets(model_name):
         model_targets_json = json.load(f)
 
     model_targets = model_targets_json[model_name]
-    if model_name[-3:] == "-tp":
+    if model_name.endswith("-tp"):
         model_targets["perf"] = model_targets.pop("perf-tp")
 
     return model_targets

--- a/models/experimental/stable_diffusion_xl_base/utils/clip_fid_ranges.py
+++ b/models/experimental/stable_diffusion_xl_base/utils/clip_fid_ranges.py
@@ -5,64 +5,86 @@
 import json
 
 TARGET_JSON_PATH = "models/experimental/stable_diffusion_xl_base/targets/targets.json"
+STANDARD_DATASET_SIZES = {100, 1260, 5000}
+SDXL_DATASET_SIZE, SDXL_INPAINT_DATASET_SIZE = 5000, 1260
 
-with open(TARGET_JSON_PATH) as f:
-    targets = json.load(f)
+
+def get_model_targets(model_name):
+    with open(TARGET_JSON_PATH) as f:
+        model_targets_json = json.load(f)
+
+    model_targets = model_targets_json[model_name]
+    if model_name[-3:] == "-tp":
+        model_targets["perf"] = model_targets.pop("perf-tp")
+
+    return model_targets
+
 
 get_approx = lambda range_tuple: (range_tuple[0] * 0.97, range_tuple[1] * 1.03)
 
 
-def accuracy_check_fid(score, num_prompts, mode):
+def using_full_dataset(model_name, num_prompts):
+    if model_name in {"sdxl", "sdxl-tp"}:
+        return num_prompts == 5000
+    elif model_name in {"sdxl-inpaint", "sdxl-inpaint-tp"}:
+        return num_prompts == 1260
+
+
+def accuracy_check_fid(model_name, score, num_prompts, mode):
     # code 0 - invalid input, code 3 - out of range, code 2 - within range, this is for CI dashboard compatibility
     assert mode in {"valid", "approx", "delta"}, "mode should be either valid, approx, or delta"
-    if num_prompts not in {100, 5000} or score == -1:
+    if num_prompts not in STANDARD_DATASET_SIZES or score == -1:
         return 0
 
+    using_full_dataset_flag = using_full_dataset(model_name, num_prompts)
+    targets = get_model_targets(model_name)
     if mode == "valid":
         range_tuple = (
-            targets["accuracy"]["fid_valid_range_5000"]
-            if num_prompts == 5000
+            targets["accuracy"]["fid_valid_range_full_dataset"]
+            if using_full_dataset_flag
             else targets["accuracy"]["fid_valid_range_100"]
         )
     elif mode == "approx":
         range_tuple = (
-            get_approx(targets["accuracy"]["fid_valid_range_5000"])
-            if num_prompts == 5000
+            get_approx(targets["accuracy"]["fid_valid_range_full_dataset"])
+            if using_full_dataset_flag
             else get_approx(targets["accuracy"]["fid_valid_range_100"])
         )
     elif mode == "delta":
-        delta_score = get_appr_delta_metric(score, num_prompts, "fid")
+        delta_score = get_appr_delta_metric(model_name, score, num_prompts, "fid")
         return 2 if delta_score <= 0.5 else 3
 
     return 2 if score >= range_tuple[0] and score <= range_tuple[1] else 3
 
 
-def accuracy_check_clip(score, num_prompts, mode):
+def accuracy_check_clip(model_name, score, num_prompts, mode):
     # code 0 - invalid input, code 3 - out of range, code 2 - within range, this is for CI dashboard compatibility
     assert mode in {"valid", "approx", "delta"}, "mode should be either valid, approx, or delta"
-    if num_prompts not in {100, 5000} or score == -1:
+    if num_prompts not in STANDARD_DATASET_SIZES or score == -1:
         return 0
 
+    using_full_dataset_flag = using_full_dataset(model_name, num_prompts)
+    targets = get_model_targets(model_name)
     if mode == "valid":
         range_tuple = (
-            targets["accuracy"]["clip_valid_range_5000"]
-            if num_prompts == 5000
+            targets["accuracy"]["clip_valid_range_full_dataset"]
+            if using_full_dataset_flag
             else targets["accuracy"]["clip_valid_range_100"]
         )
     elif mode == "approx":
         range_tuple = (
-            get_approx(targets["accuracy"]["clip_valid_range_5000"])
-            if num_prompts == 5000
+            get_approx(targets["accuracy"]["clip_valid_range_full_dataset"])
+            if using_full_dataset_flag
             else get_approx(targets["accuracy"]["clip_valid_range_100"])
         )
     elif mode == "delta":
-        delta_score = get_appr_delta_metric(score, num_prompts, "clip")
+        delta_score = get_appr_delta_metric(model_name, score, num_prompts, "clip")
         return 2 if delta_score <= 0.5 else 3
 
     return 2 if score >= range_tuple[0] and score <= range_tuple[1] else 3
 
 
-def get_appr_delta_metric(score, num_prompts, score_type):
+def get_appr_delta_metric(model_name, score, num_prompts, score_type):
     """
     Intuition:
         Delta metric quantifies how far (as a percentage of the true metric interval)
@@ -73,19 +95,21 @@ def get_appr_delta_metric(score, num_prompts, score_type):
         1.06 is used to adjust the range to the approximate range (+/- 3%)
     """
     assert score_type in {"fid", "clip"}, "score_type should be either fid or clip"
-    if num_prompts not in {100, 5000}:
+    if num_prompts not in STANDARD_DATASET_SIZES:
         return -1
 
+    using_full_dataset_flag = using_full_dataset(model_name, num_prompts)
+    targets = get_model_targets(model_name)
     if score_type == "fid":
         valid_range_tuple = (
-            targets["accuracy"]["fid_valid_range_5000"]
-            if num_prompts == 5000
+            targets["accuracy"]["fid_valid_range_full_dataset"]
+            if using_full_dataset_flag
             else targets["accuracy"]["fid_valid_range_100"]
         )
     else:
         valid_range_tuple = (
-            targets["accuracy"]["clip_valid_range_5000"]
-            if num_prompts == 5000
+            targets["accuracy"]["clip_valid_range_full_dataset"]
+            if using_full_dataset_flag
             else targets["accuracy"]["clip_valid_range_100"]
         )
 


### PR DESCRIPTION
## Ticket
(SDXL Inpainting needs accuracy test) #32254

## Problem description
SDXL Inpainting needs accuracy test

### What's changed
Added SDXL Inpainting accuracy test:

- `models/experimental/stable_diffusion_xl_base/demo/demo_inpainting.py`:  `input_masks` and `input_images` are new arguments, the default behavior remains unchanged (when calling the demo)
- `models/experimental/stable_diffusion_xl_base/targets/targets.json`:  added perf and accuracy targets for sdxl-inpainting
- `models/experimental/stable_diffusion_xl_base/tests/test_sdxl_accuracy.py`:  model_name is now a variable when calling get_appr_delta_metric, accuracy_check_fid, accuracy_check_fid, targets depend on model_name also
- `models/experimental/stable_diffusion_xl_base/tests/test_sdxl_inpaint_accuracy.py`:  almost equivalent to `models/experimental/stable_diffusion_xl_base/tests/test_sdxl_accuracy.py`, dataset is 'InpaintCOCO'
- `models/experimental/stable_diffusion_xl_base/utils/clip_fid_ranges.py`:  model_name is now a parametar for every function

### Checklist 
- [x] [demo inpainting](https://github.com/tenstorrent/tt-shield/actions/runs/19314227378/job/55243903332)
- [x] [sdxl_accuracy](https://github.com/tenstorrent/tt-shield/actions/runs/19314180663/job/55244002171)
- [x] [sdxl_inpainting_accuracy](https://github.com/tenstorrent/tt-shield/actions/runs/19314198407/job/55243632373)

## Notes
1) **Dataset**:
There are 3 promising datasets we know about:
paint-by-inpaint ([images link](https://huggingface.co/datasets/paint-by-inpaint/PIPE), [masks link](https://huggingface.co/datasets/paint-by-inpaint/PIPE_Masks))  is missing prompts - prompts can be found through COCO2014 with coco_image_id but that will take so long
COCO2014 [coco link](https://cocodataset.org/#download) is missing masks, but it has multiple sets of polygons of points for every image - which can be processed into masks
InpaintCOCO [InpaintCOCO link](https://huggingface.co/datasets/phiyodr/InpaintCOCO) has everything but only 1260 rows...
I'm currently using InpaintCOCO - I can try changing it If 1260 prompts is a big problem?

2) **FID calculation reference statistics**:
(FID reference statistics means reference `mi` and `cov` calculated from reference dataset)
For SDXL accuracy test we have FID reference statistics (downloaded from mlcommons [link](https://github.com/mlcommons/inference/blob/master/text_to_image/tools/val2014.npz)).  <br>
I believe we don't need to calculate new reference statistics because InpaintCOCO dataset is just different subset from COCO2014 just like mlcommons reference dataset, also in the end we are looking for difference between our FID and nvidia results FID score <br> Also calculating it in runtime will add 5-10 minuts per run, or it can be uploaded somewhere and downloaded in test (it has 32MB so saving it in tt-metal repo is no no)

3) Also I saw **different metrics when using TP=2 vs TP=1** - but that's the known issue: [SDXL Img2Img encoder seed](https://github.com/tenstorrent/tt-metal/issues/30975)

4) CLIP score check is missing but I would like to first take helper functions from `models/experimental/stable_diffusion_xl_base/tests/test_sdxl_accuracy.py` and put it in some utils modul for reusability (separate PR in my opinion)

## NVIDIA results - same experiment with reference sdlx-inpainting pipeline:
```
nvidia_res_1260 = {'FID_SCORE': 40.49192873016193, 'CLIP_SCORE': 31.372154245064372}
nvidia_res_100 = {'FID_SCORE': 185.62051289471987, 'CLIP_SCORE': 31.328624099493027}
```

based on these results I determined targets for our hardware:
```
"fid_valid_range_full_dataset": [39.93630404436355, 41.04755341596031],
"clip_valid_range_full_dataset": [31.208422499810794, 31.53588599031795],
"clip_valid_range_100": [31.133804321593956, 31.523443877392097],
"fid_valid_range_100": [185.03820965247064, 186.2028161369691]
```