### PR TITLE
Reduce layer count for BH op perf tests

### DIFF
--- a/.github/workflows/blackhole-multi-card-demo-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-demo-tests-impl.yaml
@@ -47,13 +47,13 @@ jobs:
             arch: blackhole
             cmd: HF_MODEL=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.1-8B-Instruct TT_CACHE_PATH=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.1-8B-Instruct pytest models/tt_transformers/demo/simple_text_demo.py -k "performance-ci-stress-1" --data_parallel ${{ inputs.num_devices }} --max_generated_tokens 22000
             owner_id: U03PUAKE719 # Miguel Tairum
-          - name: "llama3.1-8b ${{ inputs.runner-label }} batch-1 TP device perf decode"
+          - name: "llama3.1-8b ${{ inputs.runner-label }} batch-1 TP device perf decode (layers=10)"
             arch: blackhole
             cmd: HF_MODEL=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.1-8B-Instruct pytest models/tt_transformers/tests/test_device_perf.py -k "decode-llama3_8b-2-1024-2-10-1-1-False"
             owner_id: U08GELBB1AP # Ambrose Ling
-          - name: "llama3.1-8b ${{ inputs.runner-label }} batch-1 TP device perf prefill"
+          - name: "llama3.1-8b ${{ inputs.runner-label }} batch-1 TP device perf prefill (layers=2)"
             arch: blackhole
-            cmd: HF_MODEL=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.1-8B-Instruct pytest models/tt_transformers/tests/test_device_perf.py -k "prefill-llama3_8b-2-1024-2-10-1-1-False"
+            cmd: HF_MODEL=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.1-8B-Instruct pytest models/tt_transformers/tests/test_device_perf.py -k "prefill-llama3_8b-2-1024-2-2-1-1-False"
             owner_id: U08GELBB1AP # Ambrose Ling
     name: ${{ matrix.test-group.name }}
     runs-on:
@@ -158,11 +158,11 @@ jobs:
             arch: blackhole
             cmd: HF_MODEL=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.3-70B-Instruct TT_CACHE_PATH=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.3-70B-Instruct pytest models/tt_transformers/demo/simple_text_demo.py -k "performance and ci-32"
             owner_id: U03PUAKE719 # Miguel Tairum
-          - name: "llama3.3-70b ${{ inputs.runner-label }} batch-1 TP device perf prefill"
+          - name: "llama3.3-70b ${{ inputs.runner-label }} batch-1 TP device perf prefill (layers=2)"
             arch: blackhole
-            cmd: HF_MODEL=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.3-70B-Instruct pytest models/tt_transformers/tests/test_device_perf.py -k "prefill-llama3_70b-2-1024-2-10-1-1-False"
+            cmd: HF_MODEL=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.3-70B-Instruct pytest models/tt_transformers/tests/test_device_perf.py -k "prefill-llama3_70b-2-1024-2-2-1-1-False"
             owner_id: U08GELBB1AP # Ambrose Ling
-          - name: "llama3.3-70b ${{ inputs.runner-label }} batch-1 TP device perf decode"
+          - name: "llama3.3-70b ${{ inputs.runner-label }} batch-1 TP device perf decode (layers=10)"
             arch: blackhole
             cmd: HF_MODEL=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.3-70B-Instruct pytest models/tt_transformers/tests/test_device_perf.py -k "decode-llama3_70b-2-1024-2-10-1-1-False"
             owner_id: U08GELBB1AP # Ambrose Ling

--- a/models/tt_transformers/demo/simple_text_demo.py
+++ b/models/tt_transformers/demo/simple_text_demo.py
@@ -965,11 +965,16 @@ def test_demo_text(
             logger.info("Starting prefill warmup...")
             profiler.start(f"compile_prefill", iteration=batch_idx)
 
+            from tracy import Profiler
+
+            tracy_profiler = Profiler()
+
             logits = generator.prefill_forward_text(
                 input_tokens_prefill_pt,  # Prefill warmup for all users, in case some users have different seqlens than others
                 page_table=page_table,
                 kv_cache=tt_kv_cache,
                 prompt_lens=decoding_pos,
+                profiler=tracy_profiler,  # profiler,
             )
             profiler.end(f"compile_prefill", iteration=batch_idx)
             logger.info("Finished prefill warmup")

--- a/models/tt_transformers/demo/simple_text_demo.py
+++ b/models/tt_transformers/demo/simple_text_demo.py
@@ -964,17 +964,11 @@ def test_demo_text(
         if mode == "prefill" or mode == "full":
             logger.info("Starting prefill warmup...")
             profiler.start(f"compile_prefill", iteration=batch_idx)
-
-            from tracy import Profiler
-
-            tracy_profiler = Profiler()
-
             logits = generator.prefill_forward_text(
                 input_tokens_prefill_pt,  # Prefill warmup for all users, in case some users have different seqlens than others
                 page_table=page_table,
                 kv_cache=tt_kv_cache,
                 prompt_lens=decoding_pos,
-                profiler=tracy_profiler,  # profiler,
             )
             profiler.end(f"compile_prefill", iteration=batch_idx)
             logger.info("Finished prefill warmup")

--- a/models/tt_transformers/tests/test_device_perf.py
+++ b/models/tt_transformers/tests/test_device_perf.py
@@ -27,7 +27,7 @@ from tools.tracy.process_model_log import get_latest_ops_log_filename
 @pytest.mark.parametrize("export_measurements", [True, False])
 @pytest.mark.parametrize("batch_size", [1, 32])
 @pytest.mark.parametrize("data_parallel", [1, 2, 4, 8])
-@pytest.mark.parametrize("num_layers", [10])
+@pytest.mark.parametrize("num_layers", [2, 10])
 @pytest.mark.parametrize("num_runs", [2])
 @pytest.mark.parametrize("max_seq_len", [1024])
 @pytest.mark.parametrize("max_generated_tokens", [2])

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -229,11 +229,19 @@ class Generator:
             # Only paged attention is supported for prefill
             enable_trace = False
 
+        tracy_profiler = kwargs.get("profiler", None)
+        if tracy_profiler is not None:
+            tracy_profiler.enable()
+            logger.info("Disabling Tracy Profiler")
+            tracy_profiler.disable()
         self.warmup_prefill_traces(
             page_table,
             kv_cache,
             enable_trace,
         )
+        if tracy_profiler is not None:
+            logger.info("Enabling Tracy Profiler")
+            tracy_profiler.enable()
 
         batch_size, batch_seq_len = tokens.shape
         max_batch_size_per_model = self.model_args[0].max_batch_size
@@ -339,6 +347,7 @@ class Generator:
                 )
 
         logger.info(f"Finished prefill for all users up to {batch_seq_len} tokens, Starting decode...")
+
         return output_logits
 
     def prefill_forward_single_user_text(

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -339,7 +339,6 @@ class Generator:
                 )
 
         logger.info(f"Finished prefill for all users up to {batch_seq_len} tokens, Starting decode...")
-
         return output_logits
 
     def prefill_forward_single_user_text(

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -229,19 +229,11 @@ class Generator:
             # Only paged attention is supported for prefill
             enable_trace = False
 
-        tracy_profiler = kwargs.get("profiler", None)
-        if tracy_profiler is not None:
-            tracy_profiler.enable()
-            logger.info("Disabling Tracy Profiler")
-            tracy_profiler.disable()
         self.warmup_prefill_traces(
             page_table,
             kv_cache,
             enable_trace,
         )
-        if tracy_profiler is not None:
-            logger.info("Enabling Tracy Profiler")
-            tracy_profiler.enable()
 
         batch_size, batch_seq_len = tokens.shape
         max_batch_size_per_model = self.model_args[0].max_batch_size


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/32288

### Problem description
Profiler buffers OOM because we are now compiling prefill traces for all sequence lengths, to avoid those errors we reduce the number of layers we profile to 2 for these tests. 

@mtairum suggested to skip profiling warm up traces which I tried in the first commit (creating tracy profiler inside generator and intentionally disabling before warm up traces and re-enabling it after it is complete inside `generator.py`. However there was no effect and the error persisted, unsure if it is an issue with the profiler apis themselves but reducing layer count fixed the issue). Still looking to see if I used api incorrectly to avoid profiling warm up traces but simpler fix with only profiling 2 layers works for now.

### Checklist
- [ ] [BH multi card demo](https://github.com/tenstorrent/tt-metal/actions/runs/19309763098/job/55229287676)