### PR TITLE
Add multi-batch support to `ttnn.convert_to_hwc`

### DIFF
--- a/models/demos/vanilla_unet/tt/common.py
+++ b/models/demos/vanilla_unet/tt/common.py
@@ -10,7 +10,7 @@ import ttnn
 from models.demos.vanilla_unet.reference.model import UNet
 
 VANILLA_UNET_L1_SMALL_SIZE = 12 * 8192
-VANILLA_UNET_TRACE_SIZE = 218088
+VANILLA_UNET_TRACE_SIZE = 222208
 VANILLA_UNET_PCC_WH = 0.97700
 
 

--- a/tests/ttnn/unit_tests/gtests/CMakeLists.txt
+++ b/tests/ttnn/unit_tests/gtests/CMakeLists.txt
@@ -53,6 +53,7 @@ target_sources(
         test_add.cpp
         test_add_int.cpp
         test_broadcast_to.cpp
+        test_convert_to_hwc_gather.cpp
         test_generic_op.cpp
         test_graph_add.cpp
         test_graph_basic.cpp

--- a/tests/ttnn/unit_tests/gtests/test_convert_to_hwc_gather.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_convert_to_hwc_gather.cpp
@@ -175,6 +175,7 @@ std::vector<std::vector<float>> gather_with_blocked_transfers(
 
     // Flatten input shards for C-style access
     std::vector<std::vector<float>> input_shards_flat;
+    input_shards_flat.reserve(input_shards.size());
     for (const auto& shard : input_shards) {
         input_shards_flat.push_back(shard);  // Already flattened in this implementation
     }

--- a/tests/ttnn/unit_tests/gtests/test_convert_to_hwc_gather.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_convert_to_hwc_gather.cpp
@@ -1,0 +1,1035 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+#include <numeric>
+#include <set>
+#include <tt-metalium/core_coord.hpp>
+
+#include "ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/gather.hpp"
+
+namespace ttnn {
+namespace operations {
+namespace experimental {
+namespace cnn {
+namespace convert_to_hwc {
+namespace detail {
+namespace test {
+
+class GatherTransferTest : public ::testing::Test {
+protected:
+    void SetUp() override {}
+    void TearDown() override {}
+
+    // Helper to create core coordinate vectors
+    std::vector<CoreCoord> make_cores(uint32_t num_cores) {
+        std::vector<CoreCoord> cores;
+        cores.reserve(num_cores);
+        for (uint32_t i = 0; i < num_cores; i++) {
+            cores.emplace_back(i, 0);  // Simple linear arrangement
+        }
+        return cores;
+    }
+
+    // Verify transfer correctness by checking that all elements are accounted for
+    bool verify_transfers(const std::vector<GatherTransfer>& transfers, uint32_t B, uint32_t C, uint32_t HW) {
+        // Track which elements have been transferred
+        std::set<std::tuple<uint32_t, uint32_t, uint32_t>> transferred_elements;
+
+        // Calculate number of input cores
+        std::set<uint32_t> input_cores;
+        for (const auto& transfer : transfers) {
+            input_cores.insert(transfer.src_core_idx);
+        }
+        uint32_t num_input_cores = input_cores.size();
+        uint32_t hw_per_core = HW / num_input_cores;
+
+        for (const auto& transfer : transfers) {
+            // For each element in this transfer
+            for (uint32_t i = 0; i < transfer.length; i++) {
+                // Calculate the logical position this element came from
+                uint32_t hw = (transfer.src_core_idx * hw_per_core) + transfer.src_offset + i;
+                auto element = std::make_tuple(transfer.batch, transfer.channel, hw);
+
+                // Check for duplicates
+                if (transferred_elements.count(element) > 0) {
+                    return false;  // Duplicate transfer
+                }
+                transferred_elements.insert(element);
+            }
+        }
+
+        // Check that all elements were transferred
+        uint32_t expected_elements = B * C * HW;
+        return transferred_elements.size() == expected_elements;
+    }
+
+    // Check if transfers are properly coalesced
+    bool check_coalescing(const std::vector<GatherTransfer>& transfers) {
+        for (size_t i = 1; i < transfers.size(); i++) {
+            const auto& prev = transfers[i - 1];
+            const auto& curr = transfers[i];
+
+            // Check if these could have been coalesced but weren't
+            if (prev.src_core_idx == curr.src_core_idx && prev.dst_core_idx == curr.dst_core_idx &&
+                prev.channel == curr.channel && prev.batch == curr.batch &&
+                prev.src_offset + prev.length == curr.src_offset && prev.dst_offset + prev.length == curr.dst_offset) {
+                return false;  // Should have been coalesced
+            }
+        }
+        return true;
+    }
+
+    // Validate blocked transfer groups
+    bool verify_blocked_groups(
+        const std::vector<BlockedTransferGroup>& groups, uint32_t output_width, uint32_t block_size) {
+        // Check that groups are properly organized
+        std::set<std::pair<uint32_t, uint32_t>> seen_blocks;
+
+        for (const auto& group : groups) {
+            auto key = std::make_pair(group.dst_shard_idx, group.dst_block_idx);
+            if (seen_blocks.count(key) > 0) {
+                return false;  // Duplicate block
+            }
+            seen_blocks.insert(key);
+
+            // Verify block index is valid
+            uint32_t max_blocks = (output_width + block_size - 1) / block_size;
+            if (group.dst_block_idx >= max_blocks) {
+                return false;  // Invalid block index
+            }
+        }
+
+        return true;
+    }
+
+    // Helper to create test input shards
+    std::vector<std::vector<float>> create_test_input(uint32_t B, uint32_t C, uint32_t HW, uint32_t num_cores) {
+        std::vector<std::vector<float>> shards(num_cores);
+        uint32_t shard_width = HW / num_cores;
+        uint32_t shard_height = B * C;
+
+        float value = 0.0f;
+        for (uint32_t core = 0; core < num_cores; core++) {
+            shards[core].resize(shard_height * shard_width);
+            for (uint32_t row = 0; row < shard_height; row++) {
+                for (uint32_t col = 0; col < shard_width; col++) {
+                    // Fill with sequential values for easy verification
+                    shards[core][(row * shard_width) + col] = value++;
+                }
+            }
+        }
+
+        return shards;
+    }
+};
+
+// CPU execution functions moved from production code for testing purposes
+
+/**
+ * @brief Reference implementation of blocked gather operation
+ *
+ * This is a software reference implementation that demonstrates the blocked
+ * transfer approach. It's used for testing and validation, not for hardware execution.
+ *
+ * @param B Batch size
+ * @param C Number of channels
+ * @param HW Total spatial dimension
+ * @param input_cores Vector of input core coordinates
+ * @param output_cores Vector of output core coordinates
+ * @param input_shards Input data organized as shards (vector of flattened arrays)
+ * @param block_size Width of each column block (default 4)
+ * @return Output shards after gather operation
+ */
+std::vector<std::vector<float>> gather_with_blocked_transfers(
+    uint32_t B,
+    uint32_t C,
+    uint32_t HW,
+    const std::vector<CoreCoord>& input_cores,
+    const std::vector<CoreCoord>& output_cores,
+    const std::vector<std::vector<float>>& input_shards,
+    uint32_t block_size) {
+    uint32_t num_input_cores = input_cores.size();
+    uint32_t num_output_cores = output_cores.size();
+
+    // Input validation
+    TT_FATAL(HW % num_input_cores == 0, "HW={} must be divisible by num_input_cores={}", HW, num_input_cores);
+    TT_FATAL(
+        (B * HW) % num_output_cores == 0, "B*HW={} must be divisible by num_output_cores={}", B * HW, num_output_cores);
+
+    // First, precompute the high-level transfer list
+    auto transfers = precompute_gather_transfers(B, C, HW, input_cores, output_cores);
+
+    // Calculate output dimensions
+    uint32_t output_shard_height = C;
+    uint32_t output_shard_width = B * HW / num_output_cores;
+
+    // Group transfers by output column blocks
+    auto blocked_result = group_transfers_by_output_column_blocks(
+        transfers, B, C, HW, input_cores, num_output_cores, sizeof(float), block_size, output_shard_width);
+    const auto& blocked_groups = blocked_result.blocked_transfers;
+
+    // Flatten input shards for C-style access
+    std::vector<std::vector<float>> input_shards_flat;
+    for (const auto& shard : input_shards) {
+        input_shards_flat.push_back(shard);  // Already flattened in this implementation
+    }
+
+    // Initialize output shards
+    std::vector<std::vector<float>> output_shards(num_output_cores);
+    for (uint32_t i = 0; i < num_output_cores; i++) {
+        output_shards[i].resize(output_shard_height * output_shard_width, -1.0f);
+    }
+
+    // Process each column block
+    for (const auto& group : blocked_groups) {
+        // Calculate column range for this block
+        uint32_t col_start = group.dst_block_idx * block_size;
+        uint32_t col_end = std::min(col_start + block_size, output_shard_width);
+        uint32_t actual_block_width = col_end - col_start;
+
+        // Allocate temporary buffer for this column block (all rows, block_size columns)
+        // In real hardware, this could be in local memory
+        std::vector<float> block_buffer(output_shard_height * actual_block_width, 0.0f);
+
+        // Execute all transfers for this column block
+        for (const auto& transfer : group.transfers) {
+            // Get source data
+            const auto& src_flat = input_shards_flat[transfer.src_shard_idx];
+
+            // For each element in the transfer
+            for (uint32_t i = 0; i < transfer.length; i++) {
+                uint32_t src_idx = transfer.src_offset + i;
+                uint32_t dst_idx = transfer.dst_offset + i;
+
+                // Calculate 2D position in output shard
+                uint32_t dst_row = dst_idx / output_shard_width;
+                uint32_t dst_col = dst_idx % output_shard_width;
+
+                // Skip if this element is outside the current column block
+                if (dst_col < col_start || dst_col >= col_end) {
+                    continue;
+                }
+
+                // Calculate position within the column block
+                uint32_t block_col = dst_col - col_start;
+
+                // Write to block buffer
+                block_buffer[(dst_row * actual_block_width) + block_col] = src_flat[src_idx];
+            }
+        }
+
+        // Write the complete column block to the output shard
+        auto& output_shard = output_shards[group.dst_shard_idx];
+        for (uint32_t row = 0; row < output_shard_height; row++) {
+            std::memcpy(
+                &output_shard[(row * output_shard_width) + col_start],
+                &block_buffer[row * actual_block_width],
+                actual_block_width * sizeof(float));
+        }
+    }
+
+    return output_shards;
+}
+
+/**
+ * @brief Generic implementation of blocked gather operation for arbitrary element types
+ *
+ * This function performs the gather operation on any data type by working with
+ * raw bytes and element sizes, making it suitable for different precision formats.
+ *
+ * The implementation follows a blocked transfer approach where transfers are grouped
+ * by output column blocks to improve memory access patterns and enable efficient
+ * hardware implementation.
+ *
+ * This implementation keeps all offset calculations in elements and uses
+ * element_size only for memory operations. This design is more aligned
+ * with hardware DMA operations which work with byte counts.
+ *
+ * Memory efficiency:
+ * - Block buffer size = C × block_size × element_size bytes
+ * - For C=16, block_size=4:
+ *   - float32 (element_size=4): 16 × 4 × 4 = 256 bytes
+ *   - bfloat16 (element_size=2): 16 × 4 × 2 = 128 bytes
+ */
+void gather_with_blocked_transfers_generic(
+    const void* input_data,
+    void* output_data,
+    uint32_t element_size,
+    uint32_t B,
+    uint32_t C,
+    uint32_t HW,
+    const std::vector<CoreCoord>& input_cores,
+    const std::vector<CoreCoord>& output_cores,
+    uint32_t block_size) {
+    // First, precompute transfers (element-based, size-agnostic)
+    auto transfers = precompute_gather_transfers(B, C, HW, input_cores, output_cores);
+
+    // Group transfers by output column blocks
+    uint32_t output_shard_width = B * HW / output_cores.size();
+    auto blocked_result = group_transfers_by_output_column_blocks(
+        transfers, B, C, HW, input_cores, output_cores.size(), sizeof(float), block_size, output_shard_width);
+    const auto& blocked_groups = blocked_result.blocked_transfers;
+
+    uint32_t input_shard_width = HW / input_cores.size();
+    uint32_t output_shard_height = C;
+
+    // Cast to byte pointers for arithmetic
+    const uint8_t* input_bytes = static_cast<const uint8_t*>(input_data);
+    uint8_t* output_bytes = static_cast<uint8_t*>(output_data);
+
+    // Process each block group
+    for (const auto& group : blocked_groups) {
+        uint32_t col_start = group.dst_block_idx * block_size;
+        uint32_t col_end = std::min(col_start + block_size, output_shard_width);
+        uint32_t actual_block_width = col_end - col_start;
+
+        // Allocate block buffer in bytes
+        uint32_t block_buffer_elements = output_shard_height * actual_block_width;
+        std::vector<uint8_t> block_buffer(block_buffer_elements * element_size);
+
+        // Execute transfers into block buffer
+        for (const auto& transfer : group.transfers) {
+            // Calculate source pointer for this shard
+            const uint8_t* src_shard_base =
+                input_bytes + (transfer.src_shard_idx * B * C * input_shard_width * element_size);
+
+            const uint8_t* src_ptr = src_shard_base + (transfer.src_offset * element_size);
+
+            // Process the transfer - copy elements that belong to this block
+            for (uint32_t i = 0; i < transfer.length; i++) {
+                uint32_t dst_idx = transfer.dst_offset + i;
+                uint32_t dst_row = dst_idx / output_shard_width;
+                uint32_t dst_col = dst_idx % output_shard_width;
+
+                // Check if this element belongs in the current block
+                if (dst_col >= col_start && dst_col < col_end) {
+                    uint32_t block_col = dst_col - col_start;
+                    uint32_t block_idx = (dst_row * actual_block_width) + block_col;
+
+                    // Copy element_size bytes
+                    std::memcpy(&block_buffer[block_idx * element_size], &src_ptr[i * element_size], element_size);
+                }
+            }
+        }
+
+        // Copy block buffer to output shard
+        uint8_t* output_shard_base =
+            output_bytes + (group.dst_shard_idx * output_shard_height * output_shard_width * element_size);
+
+        for (uint32_t row = 0; row < output_shard_height; row++) {
+            // Copy entire row of the block
+            std::memcpy(
+                &output_shard_base[(row * output_shard_width + col_start) * element_size],
+                &block_buffer[row * actual_block_width * element_size],
+                actual_block_width * element_size);
+        }
+    }
+}
+
+TEST_F(GatherTransferTest, BasicTransferGeneration) {
+    // Test simple single core to single core case: B=1, C=2, HW=8
+    uint32_t B = 1, C = 2, HW = 8;
+    auto input_cores = make_cores(1);
+    auto output_cores = make_cores(1);
+
+    auto transfers = precompute_gather_transfers(B, C, HW, input_cores, output_cores);
+
+    // Should have exactly C transfers (one per channel) since everything is on same core
+    EXPECT_EQ(transfers.size(), C);
+
+    // Verify all transfers
+    EXPECT_TRUE(verify_transfers(transfers, B, C, HW));
+
+    // Check first transfer details
+    EXPECT_EQ(transfers[0].src_core_idx, 0u);
+    EXPECT_EQ(transfers[0].dst_core_idx, 0u);
+    EXPECT_EQ(transfers[0].channel, 0u);
+    EXPECT_EQ(transfers[0].batch, 0u);
+    EXPECT_EQ(transfers[0].length, HW);  // Should transfer entire row
+}
+
+TEST_F(GatherTransferTest, TransferCoalescing) {
+    // Test that adjacent transfers are properly coalesced
+    uint32_t B = 1, C = 2, HW = 16;
+    auto input_cores = make_cores(2);
+    auto output_cores = make_cores(2);
+
+    auto transfers = precompute_gather_transfers(B, C, HW, input_cores, output_cores);
+
+    // Verify coalescing worked properly
+    EXPECT_TRUE(check_coalescing(transfers));
+
+    // With 2 input cores and 2 output cores, we expect 4 transfers total
+    // (2 channels × 2 source cores = 4 transfers)
+    EXPECT_EQ(transfers.size(), 4u);
+}
+
+TEST_F(GatherTransferTest, MultiCoreTransfers) {
+    // Test various core configurations
+    struct TestCase {
+        uint32_t B, C, HW;
+        uint32_t num_input_cores, num_output_cores;
+        std::string description;
+    };
+
+    std::vector<TestCase> test_cases = {
+        {1, 2, 8, 1, 2, "1→2 cores"},
+        {2, 2, 8, 2, 2, "2→2 cores"},
+        {1, 4, 16, 2, 4, "2→4 cores"},
+        {2, 4, 16, 4, 2, "4→2 cores"},
+        {1, 3, 12, 3, 3, "3→3 cores (non-power-of-2)"},
+    };
+
+    for (const auto& tc : test_cases) {
+        auto input_cores = make_cores(tc.num_input_cores);
+        auto output_cores = make_cores(tc.num_output_cores);
+
+        auto transfers = precompute_gather_transfers(tc.B, tc.C, tc.HW, input_cores, output_cores);
+
+        // Verify correctness
+        EXPECT_TRUE(verify_transfers(transfers, tc.B, tc.C, tc.HW)) << "Failed for " << tc.description;
+        EXPECT_TRUE(check_coalescing(transfers)) << "Coalescing failed for " << tc.description;
+
+        // Verify we have transfers from/to all cores
+        std::set<uint32_t> src_cores, dst_cores;
+        for (const auto& t : transfers) {
+            src_cores.insert(t.src_core_idx);
+            dst_cores.insert(t.dst_core_idx);
+        }
+
+        EXPECT_EQ(src_cores.size(), tc.num_input_cores) << "Not all input cores used in " << tc.description;
+        EXPECT_EQ(dst_cores.size(), tc.num_output_cores) << "Not all output cores used in " << tc.description;
+    }
+}
+
+TEST_F(GatherTransferTest, BlockedTransferGrouping) {
+    // Test column block grouping
+    uint32_t B = 1, C = 2, HW = 16;
+    uint32_t block_size = 4;
+    auto input_cores = make_cores(2);
+    auto output_cores = make_cores(2);
+
+    auto transfers = precompute_gather_transfers(B, C, HW, input_cores, output_cores);
+    uint32_t output_shard_width = B * HW / output_cores.size();
+    auto blocked_result = group_transfers_by_output_column_blocks(
+        transfers, B, C, HW, input_cores, output_cores.size(), sizeof(float), block_size, output_shard_width);
+    const auto& blocked_groups = blocked_result.blocked_transfers;
+
+    // Calculate expected number of blocks
+    uint32_t blocks_per_shard = (output_shard_width + block_size - 1) / block_size;
+
+    // Verify blocked groups
+    EXPECT_TRUE(verify_blocked_groups(blocked_groups, output_shard_width, block_size));
+
+    // Check that all blocks are represented
+    std::set<std::pair<uint32_t, uint32_t>> block_keys;
+    for (const auto& group : blocked_groups) {
+        block_keys.insert(std::make_pair(group.dst_shard_idx, group.dst_block_idx));
+    }
+
+    // We should have blocks for each output shard
+    for (uint32_t shard = 0; shard < output_cores.size(); shard++) {
+        for (uint32_t block = 0; block < blocks_per_shard; block++) {
+            EXPECT_GT(block_keys.count(std::make_pair(shard, block)), 0u)
+                << "Missing block " << block << " for shard " << shard;
+        }
+    }
+}
+
+TEST_F(GatherTransferTest, EdgeCases) {
+    // Test edge cases
+
+    // Case 1: B=1, C=1, HW=4 (minimal case)
+    {
+        uint32_t B = 1, C = 1, HW = 4;
+        auto input_cores = make_cores(1);
+        auto output_cores = make_cores(1);
+
+        auto transfers = precompute_gather_transfers(B, C, HW, input_cores, output_cores);
+
+        // Should have exactly 1 transfer
+        EXPECT_EQ(transfers.size(), 1u);
+        EXPECT_EQ(transfers[0].length, 4u);
+        EXPECT_TRUE(verify_transfers(transfers, B, C, HW));
+    }
+
+    // Case 2: Single channel with multiple cores
+    {
+        uint32_t B = 1, C = 1, HW = 16;
+        auto input_cores = make_cores(4);
+        auto output_cores = make_cores(4);
+
+        auto transfers = precompute_gather_transfers(B, C, HW, input_cores, output_cores);
+
+        // Each input core should contribute to each output core
+        EXPECT_EQ(transfers.size(), 4u);  // 4 transfers for single channel
+        EXPECT_TRUE(verify_transfers(transfers, B, C, HW));
+    }
+
+    // Case 3: Large batch size
+    {
+        uint32_t B = 4, C = 2, HW = 8;
+        auto input_cores = make_cores(2);
+        auto output_cores = make_cores(2);
+
+        auto transfers = precompute_gather_transfers(B, C, HW, input_cores, output_cores);
+
+        EXPECT_TRUE(verify_transfers(transfers, B, C, HW));
+        EXPECT_TRUE(check_coalescing(transfers));
+    }
+}
+
+TEST_F(GatherTransferTest, LargeConfigurations) {
+    // Stress test with larger configuration
+    uint32_t B = 4, C = 16, HW = 64;
+    auto input_cores = make_cores(8);
+    auto output_cores = make_cores(8);
+
+    auto transfers = precompute_gather_transfers(B, C, HW, input_cores, output_cores);
+
+    // Verify basic properties
+    EXPECT_TRUE(verify_transfers(transfers, B, C, HW));
+    EXPECT_TRUE(check_coalescing(transfers));
+
+    // Test blocking with different block sizes
+    std::vector<uint32_t> block_sizes = {4, 8, 16};
+    for (auto block_size : block_sizes) {
+        uint32_t output_width = B * HW / output_cores.size();
+        auto blocked_result = group_transfers_by_output_column_blocks(
+            transfers, B, C, HW, input_cores, output_cores.size(), sizeof(float), block_size, output_width);
+        const auto& blocked = blocked_result.blocked_transfers;
+        EXPECT_TRUE(verify_blocked_groups(blocked, output_width, block_size)) << "Failed for block_size=" << block_size;
+    }
+}
+
+TEST_F(GatherTransferTest, UnevenSharding) {
+    // Test when HW is not evenly divisible by cores
+    // This should fail with TT_FATAL, so we test that it throws
+    uint32_t B = 1, C = 2, HW = 15;  // 15 not divisible by 2
+    auto input_cores = make_cores(2);
+    auto output_cores = make_cores(2);
+
+    // This should throw due to TT_FATAL
+    try {
+        precompute_gather_transfers(B, C, HW, input_cores, output_cores);
+        FAIL() << "Expected TT_FATAL exception";
+    } catch (const std::exception& e) {
+        std::string error_msg(e.what());
+        EXPECT_NE(error_msg.find("HW=15 must be divisible by num_input_cores=2"), std::string::npos)
+            << "Unexpected exception message: " << error_msg;
+    }
+}
+
+TEST_F(GatherTransferTest, TransferLowering) {
+    // Test high-level to low-level transfer conversion
+    uint32_t B = 2, C = 2, HW = 8;
+    auto input_cores = make_cores(2);
+    auto output_cores = make_cores(2);
+
+    auto transfers = precompute_gather_transfers(B, C, HW, input_cores, output_cores);
+    uint32_t derived_output_width = B * HW / output_cores.size();
+    auto low_level = lower_gather_transfers(
+        transfers, B, C, HW, input_cores, output_cores.size(), sizeof(float), derived_output_width);
+
+    // Should have same number of transfers
+    EXPECT_EQ(transfers.size(), low_level.size());
+
+    // Verify offsets are calculated correctly
+    uint32_t input_shard_width = HW / input_cores.size();
+    uint32_t output_shard_width = B * HW / output_cores.size();
+
+    for (size_t i = 0; i < transfers.size(); i++) {
+        const auto& hl = transfers[i];
+        const auto& ll = low_level[i];
+
+        // Verify source offset calculation
+        uint32_t expected_src_row = (hl.batch * C) + hl.channel;
+        uint32_t expected_src_offset = (expected_src_row * input_shard_width) + hl.src_offset;
+        EXPECT_EQ(ll.src_offset, expected_src_offset) << "Source offset mismatch for transfer " << i;
+
+        // Verify destination offset calculation
+        uint32_t expected_dst_row = hl.channel;
+        uint32_t expected_dst_offset = (expected_dst_row * output_shard_width) + hl.dst_offset;
+        EXPECT_EQ(ll.dst_offset, expected_dst_offset) << "Destination offset mismatch for transfer " << i;
+
+        // Length should be preserved
+        EXPECT_EQ(ll.length, hl.length);
+    }
+}
+
+TEST_F(GatherTransferTest, EndToEndGatherOperation) {
+    // Test the full gather operation with blocked transfers
+    uint32_t B = 2, C = 2, HW = 8;
+    uint32_t block_size = 2;
+    auto input_cores = make_cores(2);
+    auto output_cores = make_cores(2);
+
+    // Create test input
+    auto input_shards = create_test_input(B, C, HW, input_cores.size());
+
+    // Run gather operation
+    auto output_shards = gather_with_blocked_transfers(B, C, HW, input_cores, output_cores, input_shards, block_size);
+
+    // Verify output shape
+    EXPECT_EQ(output_shards.size(), output_cores.size());
+
+    uint32_t output_shard_height = C;
+    uint32_t output_shard_width = B * HW / output_cores.size();
+    for (const auto& shard : output_shards) {
+        EXPECT_EQ(shard.size(), output_shard_height * output_shard_width);
+    }
+
+    // Verify data correctness by checking a few specific values
+    // Input layout: [B*C, HW/cores] = [4, 4] per core
+    // Output layout: [C, B*HW/cores] = [2, 8] per core
+
+    // For example, element at (b=0, c=0, hw=0) should map correctly
+    // Input: core 0, row 0, col 0 -> value 0
+    // Output: core 0, row 0, col 0 -> should also be value 0
+    EXPECT_EQ(output_shards[0][0], 0.0f);
+
+    // Element at (b=0, c=1, hw=0)
+    // Input: core 0, row 1, col 0 -> value 4
+    // Output: core 0, row 1, col 0 -> should be value 4
+    EXPECT_EQ(output_shards[0][output_shard_width], 4.0f);
+}
+
+TEST_F(GatherTransferTest, VerifyTransferSorting) {
+    // Test that transfers are properly sorted for cache efficiency
+    uint32_t B = 2, C = 4, HW = 16;
+    auto input_cores = make_cores(4);
+    auto output_cores = make_cores(4);
+
+    auto transfers = precompute_gather_transfers(B, C, HW, input_cores, output_cores);
+
+    // Verify transfers are sorted by source core first
+    for (size_t i = 1; i < transfers.size(); i++) {
+        EXPECT_LE(transfers[i - 1].src_core_idx, transfers[i].src_core_idx) << "Transfers not sorted by source core";
+
+        // Within same source core, check row ordering
+        if (transfers[i - 1].src_core_idx == transfers[i].src_core_idx) {
+            uint32_t prev_row = (transfers[i - 1].batch * C) + transfers[i - 1].channel;
+            uint32_t curr_row = (transfers[i].batch * C) + transfers[i].channel;
+            EXPECT_LE(prev_row, curr_row) << "Transfers within core not sorted by row";
+
+            // Within same row, check column ordering
+            if (prev_row == curr_row) {
+                EXPECT_LE(transfers[i - 1].src_offset, transfers[i].src_offset)
+                    << "Transfers within row not sorted by offset";
+            }
+        }
+    }
+}
+
+TEST_F(GatherTransferTest, GenericElementTypes) {
+    // Test with different element types to verify generic implementation
+    uint32_t B = 2, C = 4, HW = 16;
+    auto input_cores = make_cores(2);
+    auto output_cores = make_cores(2);
+
+    // Test with float32 (host) - element_size = 4
+    {
+        // Create flat input data manually
+        std::vector<float> input_data(B * C * HW);
+        for (uint32_t i = 0; i < input_data.size(); i++) {
+            input_data[i] = static_cast<float>(i);
+        }
+        std::vector<float> output_data(B * C * HW, 0.0f);
+
+        gather_with_blocked_transfers_generic(
+            input_data.data(), output_data.data(), sizeof(float), B, C, HW, input_cores, output_cores, 4);
+
+        // Verify a few values
+        // Input is in [B, C, HW] layout flattened as: b0c0hw0, b0c0hw1, ..., b0c1hw0, b0c1hw1, ...
+        // Output should be in [C, B, HW] layout
+
+        // First element (c=0, b=0, hw=0) should map to output position 0
+        EXPECT_FLOAT_EQ(output_data[0], 0.0f);
+
+        // For c=1, b=0, hw=1:
+        // Input position: b*C*HW + c*HW + hw = 0*4*16 + 1*16 + 1 = 17
+        // Output position: c*B*HW + b*HW + hw = 1*2*16 + 0*16 + 1 = 33
+        uint32_t input_idx = 0 * C * HW + 1 * HW + 1;  // b=0, c=1, hw=1
+        EXPECT_FLOAT_EQ(output_data[1 * B * HW + 0 * HW + 1], static_cast<float>(input_idx));
+    }
+
+    // Test with uint16_t (simulating bfloat16 on device) - element_size = 2
+    {
+        std::vector<uint16_t> input_data(B * C * HW);
+        for (size_t i = 0; i < input_data.size(); i++) {
+            input_data[i] = static_cast<uint16_t>(i);
+        }
+        std::vector<uint16_t> output_data(B * C * HW, 0);
+
+        gather_with_blocked_transfers_generic(
+            input_data.data(), output_data.data(), sizeof(uint16_t), B, C, HW, input_cores, output_cores, 4);
+
+        // Verify transformation worked (same mapping as float test)
+        EXPECT_EQ(output_data[0], 0);  // First element
+        // For c=1, b=0, hw=1: input position = 0*4*16 + 1*16 + 1 = 17
+        uint32_t input_idx_u16 = 0 * C * HW + 1 * HW + 1;
+        EXPECT_EQ(output_data[1 * B * HW + 0 * HW + 1], static_cast<uint16_t>(input_idx_u16));
+    }
+
+    // Verify element size calculations
+    EXPECT_EQ(sizeof(float), 4u);
+    EXPECT_EQ(sizeof(uint16_t), 2u);
+    EXPECT_EQ(elements_to_bytes(100, 4), 400u);  // 100 elements * 4 bytes
+    EXPECT_EQ(elements_to_bytes(100, 2), 200u);  // 100 elements * 2 bytes
+}
+
+TEST_F(GatherTransferTest, VerifyInputAndOutputShards) {
+    // Test the gather operation with simple configuration to verify correctness
+    uint32_t B = 2, C = 3, HW = 4;
+    auto input_cores = make_cores(2);
+    auto output_cores = make_cores(2);
+
+    auto input_shards = create_test_input(B, C, HW, input_cores.size());
+
+    // Input is width-sharded: each core has [B*C, HW/num_cores] = [6, 2]
+    // Core 0: values 0-11 (sequential)
+    EXPECT_FLOAT_EQ(input_shards[0][0], 0.0f);    // row=0, col=0
+    EXPECT_FLOAT_EQ(input_shards[0][1], 1.0f);    // row=0, col=1
+    EXPECT_FLOAT_EQ(input_shards[0][2], 2.0f);    // row=1, col=0
+    EXPECT_FLOAT_EQ(input_shards[0][3], 3.0f);    // row=1, col=1
+    EXPECT_FLOAT_EQ(input_shards[0][4], 4.0f);    // row=2, col=0
+    EXPECT_FLOAT_EQ(input_shards[0][5], 5.0f);    // row=2, col=1
+    EXPECT_FLOAT_EQ(input_shards[0][6], 6.0f);    // row=3, col=0
+    EXPECT_FLOAT_EQ(input_shards[0][7], 7.0f);    // row=3, col=1
+    EXPECT_FLOAT_EQ(input_shards[0][8], 8.0f);    // row=4, col=0
+    EXPECT_FLOAT_EQ(input_shards[0][9], 9.0f);    // row=4, col=1
+    EXPECT_FLOAT_EQ(input_shards[0][10], 10.0f);  // row=5, col=0
+    EXPECT_FLOAT_EQ(input_shards[0][11], 11.0f);  // row=5, col=1
+
+    // Core 1: values 12-23 (sequential)
+    EXPECT_FLOAT_EQ(input_shards[1][0], 12.0f);   // row=0, col=0
+    EXPECT_FLOAT_EQ(input_shards[1][1], 13.0f);   // row=0, col=1
+    EXPECT_FLOAT_EQ(input_shards[1][2], 14.0f);   // row=1, col=0
+    EXPECT_FLOAT_EQ(input_shards[1][3], 15.0f);   // row=1, col=1
+    EXPECT_FLOAT_EQ(input_shards[1][4], 16.0f);   // row=2, col=0
+    EXPECT_FLOAT_EQ(input_shards[1][5], 17.0f);   // row=2, col=1
+    EXPECT_FLOAT_EQ(input_shards[1][6], 18.0f);   // row=3, col=0
+    EXPECT_FLOAT_EQ(input_shards[1][7], 19.0f);   // row=3, col=1
+    EXPECT_FLOAT_EQ(input_shards[1][8], 20.0f);   // row=4, col=0
+    EXPECT_FLOAT_EQ(input_shards[1][9], 21.0f);   // row=4, col=1
+    EXPECT_FLOAT_EQ(input_shards[1][10], 22.0f);  // row=5, col=0
+    EXPECT_FLOAT_EQ(input_shards[1][11], 23.0f);  // row=5, col=1
+
+    // Run gather operation to get output shards
+    // Output shard structure: [C, output_shard_width] where output_shard_width = B*HW/num_cores = 4
+    auto output_shards = gather_with_blocked_transfers(B, C, HW, input_cores, output_cores, input_shards, 2);
+
+    // Core 0 checks
+    EXPECT_FLOAT_EQ(output_shards[0][0], 0.0f);   // c=0, pos 0
+    EXPECT_FLOAT_EQ(output_shards[0][1], 1.0f);   // c=0, pos 1
+    EXPECT_FLOAT_EQ(output_shards[0][2], 12.0f);  // c=0, pos 2
+    EXPECT_FLOAT_EQ(output_shards[0][3], 13.0f);  // c=0, pos 3
+
+    EXPECT_FLOAT_EQ(output_shards[0][4], 2.0f);   // c=1, pos 0
+    EXPECT_FLOAT_EQ(output_shards[0][5], 3.0f);   // c=1, pos 1
+    EXPECT_FLOAT_EQ(output_shards[0][6], 14.0f);  // c=1, pos 2
+    EXPECT_FLOAT_EQ(output_shards[0][7], 15.0f);  // c=1, pos 3
+
+    EXPECT_FLOAT_EQ(output_shards[0][8], 4.0f);    // c=2, pos 0
+    EXPECT_FLOAT_EQ(output_shards[0][9], 5.0f);    // c=2, pos 1
+    EXPECT_FLOAT_EQ(output_shards[0][10], 16.0f);  // c=2, pos 2
+    EXPECT_FLOAT_EQ(output_shards[0][11], 17.0f);  // c=2, pos 3
+
+    // Core 1 checks
+    EXPECT_FLOAT_EQ(output_shards[1][0], 6.0f);   // c=0, pos 0
+    EXPECT_FLOAT_EQ(output_shards[1][1], 7.0f);   // c=0, pos 1
+    EXPECT_FLOAT_EQ(output_shards[1][2], 18.0f);  // c=0, pos 2
+    EXPECT_FLOAT_EQ(output_shards[1][3], 19.0f);  // c=0, pos 3
+
+    EXPECT_FLOAT_EQ(output_shards[1][4], 8.0f);   // c=1, pos 0
+    EXPECT_FLOAT_EQ(output_shards[1][5], 9.0f);   // c=1, pos 1
+    EXPECT_FLOAT_EQ(output_shards[1][6], 20.0f);  // c=1, pos 2
+    EXPECT_FLOAT_EQ(output_shards[1][7], 21.0f);  // c=1, pos 3
+
+    EXPECT_FLOAT_EQ(output_shards[1][8], 10.0f);   // c=2, pos 0
+    EXPECT_FLOAT_EQ(output_shards[1][9], 11.0f);   // c=2, pos 1
+    EXPECT_FLOAT_EQ(output_shards[1][10], 22.0f);  // c=2, pos 2
+    EXPECT_FLOAT_EQ(output_shards[1][11], 23.0f);  // c=2, pos 3
+
+    // Verify all elements were written (no -1 or uninitialized values)
+    for (const auto& shard : output_shards) {
+        for (float val : shard) {
+            EXPECT_NE(val, -1.0f) << "Found unwritten element";
+        }
+    }
+}
+
+TEST_F(GatherTransferTest, OneToManyCores) {
+    // Test 1 input core to 2 output cores
+    uint32_t B = 2, C = 2, HW = 4;
+    auto input_cores = make_cores(1);
+    auto output_cores = make_cores(2);
+
+    // Create input with 1 shard containing all data
+    std::vector<std::vector<float>> input_shards(1);
+    input_shards[0].resize(B * C * HW);
+    for (uint32_t i = 0; i < input_shards[0].size(); i++) {
+        input_shards[0][i] = static_cast<float>(i);
+    }
+
+    // Verify input values
+    EXPECT_FLOAT_EQ(input_shards[0][0], 0.0f);    // b=0,c=0,hw=0
+    EXPECT_FLOAT_EQ(input_shards[0][1], 1.0f);    // b=0,c=0,hw=1
+    EXPECT_FLOAT_EQ(input_shards[0][2], 2.0f);    // b=0,c=0,hw=2
+    EXPECT_FLOAT_EQ(input_shards[0][3], 3.0f);    // b=0,c=0,hw=3
+    EXPECT_FLOAT_EQ(input_shards[0][4], 4.0f);    // b=0,c=1,hw=0
+    EXPECT_FLOAT_EQ(input_shards[0][7], 7.0f);    // b=0,c=1,hw=3
+    EXPECT_FLOAT_EQ(input_shards[0][8], 8.0f);    // b=1,c=0,hw=0
+    EXPECT_FLOAT_EQ(input_shards[0][15], 15.0f);  // b=1,c=1,hw=3
+
+    // Run gather operation
+    auto output_shards = gather_with_blocked_transfers(B, C, HW, input_cores, output_cores, input_shards, 2);
+
+    // Output is height-sharded: each core gets B*HW/2 = 4 elements per channel
+    // Core 0 should get b=0 data, Core 1 should get b=1 data
+
+    // Core 0: c=0[0,1,2,3], c=1[4,5,6,7]
+    EXPECT_FLOAT_EQ(output_shards[0][0], 0.0f);  // c=0, b=0, hw=0
+    EXPECT_FLOAT_EQ(output_shards[0][1], 1.0f);  // c=0, b=0, hw=1
+    EXPECT_FLOAT_EQ(output_shards[0][2], 2.0f);  // c=0, b=0, hw=2
+    EXPECT_FLOAT_EQ(output_shards[0][3], 3.0f);  // c=0, b=0, hw=3
+    EXPECT_FLOAT_EQ(output_shards[0][4], 4.0f);  // c=1, b=0, hw=0
+    EXPECT_FLOAT_EQ(output_shards[0][5], 5.0f);  // c=1, b=0, hw=1
+    EXPECT_FLOAT_EQ(output_shards[0][6], 6.0f);  // c=1, b=0, hw=2
+    EXPECT_FLOAT_EQ(output_shards[0][7], 7.0f);  // c=1, b=0, hw=3
+
+    // Core 1: c=0[8,9,10,11], c=1[12,13,14,15]
+    EXPECT_FLOAT_EQ(output_shards[1][0], 8.0f);   // c=0, b=1, hw=0
+    EXPECT_FLOAT_EQ(output_shards[1][1], 9.0f);   // c=0, b=1, hw=1
+    EXPECT_FLOAT_EQ(output_shards[1][2], 10.0f);  // c=0, b=1, hw=2
+    EXPECT_FLOAT_EQ(output_shards[1][3], 11.0f);  // c=0, b=1, hw=3
+    EXPECT_FLOAT_EQ(output_shards[1][4], 12.0f);  // c=1, b=1, hw=0
+    EXPECT_FLOAT_EQ(output_shards[1][5], 13.0f);  // c=1, b=1, hw=1
+    EXPECT_FLOAT_EQ(output_shards[1][6], 14.0f);  // c=1, b=1, hw=2
+    EXPECT_FLOAT_EQ(output_shards[1][7], 15.0f);  // c=1, b=1, hw=3
+
+    // Verify all elements were written (no -1 or uninitialized values)
+    for (const auto& shard : output_shards) {
+        for (float val : shard) {
+            EXPECT_NE(val, -1.0f) << "Found unwritten element";
+        }
+    }
+}
+
+TEST_F(GatherTransferTest, ManyToOneCores) {
+    // Test 2 input cores to 1 output core
+    uint32_t B = 1, C = 2, HW = 8;
+    auto input_cores = make_cores(2);
+    auto output_cores = make_cores(1);
+
+    // Create input shards - width sharded across 2 cores
+    auto input_shards = create_test_input(B, C, HW, input_cores.size());
+
+    // Verify key input values
+    EXPECT_FLOAT_EQ(input_shards[0][0], 0.0f);   // c=0, hw=0
+    EXPECT_FLOAT_EQ(input_shards[0][3], 3.0f);   // c=0, hw=3
+    EXPECT_FLOAT_EQ(input_shards[0][4], 4.0f);   // c=1, hw=0
+    EXPECT_FLOAT_EQ(input_shards[1][0], 8.0f);   // c=0, hw=4
+    EXPECT_FLOAT_EQ(input_shards[1][3], 11.0f);  // c=0, hw=7
+    EXPECT_FLOAT_EQ(input_shards[1][4], 12.0f);  // c=1, hw=4
+
+    // Run gather operation
+    auto output_shards = gather_with_blocked_transfers(B, C, HW, input_cores, output_cores, input_shards, 4);
+
+    // All output on single core: [C, B*HW] = [2, 8]
+    // Logical output tensor is identical to input tensor
+    // Channel 0: interleaved from both cores [0,1,2,3,8,9,10,11]
+    EXPECT_FLOAT_EQ(output_shards[0][0], 0.0f);
+    EXPECT_FLOAT_EQ(output_shards[0][1], 1.0f);
+    EXPECT_FLOAT_EQ(output_shards[0][2], 2.0f);
+    EXPECT_FLOAT_EQ(output_shards[0][3], 3.0f);
+    EXPECT_FLOAT_EQ(output_shards[0][4], 8.0f);
+    EXPECT_FLOAT_EQ(output_shards[0][5], 9.0f);
+    EXPECT_FLOAT_EQ(output_shards[0][6], 10.0f);
+    EXPECT_FLOAT_EQ(output_shards[0][7], 11.0f);
+
+    // Channel 1: interleaved from both cores [4,5,6,7,12,13,14,15]
+    EXPECT_FLOAT_EQ(output_shards[0][8], 4.0f);
+    EXPECT_FLOAT_EQ(output_shards[0][9], 5.0f);
+    EXPECT_FLOAT_EQ(output_shards[0][10], 6.0f);
+    EXPECT_FLOAT_EQ(output_shards[0][11], 7.0f);
+    EXPECT_FLOAT_EQ(output_shards[0][12], 12.0f);
+    EXPECT_FLOAT_EQ(output_shards[0][13], 13.0f);
+    EXPECT_FLOAT_EQ(output_shards[0][14], 14.0f);
+    EXPECT_FLOAT_EQ(output_shards[0][15], 15.0f);
+
+    // Verify all elements were written (no -1 or uninitialized values)
+    for (const auto& shard : output_shards) {
+        for (float val : shard) {
+            EXPECT_NE(val, -1.0f) << "Found unwritten element";
+        }
+    }
+}
+
+TEST_F(GatherTransferTest, FourCoresToFourCores) {
+    // Test 4x4 core configuration with B=2, C=4, HW=8
+    uint32_t B = 2, C = 4, HW = 8;
+    auto input_cores = make_cores(4);
+    auto output_cores = make_cores(4);
+
+    // Create input shards
+    auto input_shards = create_test_input(B, C, HW, input_cores.size());
+
+    // Each input core has [B*C, HW/4] = [8, 2] elements
+    // Verify a sample from each input core
+    EXPECT_FLOAT_EQ(input_shards[0][0], 0.0f);    // core0: first element
+    EXPECT_FLOAT_EQ(input_shards[0][15], 15.0f);  // core0: last element
+    EXPECT_FLOAT_EQ(input_shards[1][0], 16.0f);   // core1: first element
+    EXPECT_FLOAT_EQ(input_shards[2][0], 32.0f);   // core2: first element
+    EXPECT_FLOAT_EQ(input_shards[3][0], 48.0f);   // core3: first element
+    EXPECT_FLOAT_EQ(input_shards[3][15], 63.0f);  // core3: last element
+
+    // Run gather operation
+    auto output_shards = gather_with_blocked_transfers(B, C, HW, input_cores, output_cores, input_shards, 2);
+
+    // Each output core has [C, B*HW/4] = [4, 4] elements
+    // Output distribution follows height sharding pattern
+
+    // Based on debug output, Core 0 has pattern: [0,1,16,17, 2,3,18,19, 4,5,20,21, 6,7,22,23]
+    EXPECT_FLOAT_EQ(output_shards[0][0], 0.0f);
+    EXPECT_FLOAT_EQ(output_shards[0][1], 1.0f);
+    EXPECT_FLOAT_EQ(output_shards[0][2], 16.0f);
+    EXPECT_FLOAT_EQ(output_shards[0][3], 17.0f);
+    EXPECT_FLOAT_EQ(output_shards[0][4], 2.0f);
+    EXPECT_FLOAT_EQ(output_shards[0][5], 3.0f);
+    EXPECT_FLOAT_EQ(output_shards[0][6], 18.0f);
+    EXPECT_FLOAT_EQ(output_shards[0][7], 19.0f);
+
+    // Core 3 has pattern: [40,41,56,57, 42,43,58,59, 44,45,60,61, 46,47,62,63]
+    EXPECT_FLOAT_EQ(output_shards[3][0], 40.0f);
+    EXPECT_FLOAT_EQ(output_shards[3][1], 41.0f);
+    EXPECT_FLOAT_EQ(output_shards[3][2], 56.0f);
+    EXPECT_FLOAT_EQ(output_shards[3][3], 57.0f);
+    EXPECT_FLOAT_EQ(output_shards[3][12], 46.0f);
+    EXPECT_FLOAT_EQ(output_shards[3][13], 47.0f);
+    EXPECT_FLOAT_EQ(output_shards[3][14], 62.0f);
+    EXPECT_FLOAT_EQ(output_shards[3][15], 63.0f);
+
+    // Verify all elements were written (no -1 or uninitialized values)
+    for (const auto& shard : output_shards) {
+        for (float val : shard) {
+            EXPECT_NE(val, -1.0f) << "Found unwritten element";
+        }
+    }
+}
+
+TEST_F(GatherTransferTest, SingleChannelManyBatches) {
+    // Test with C=1, B=4, HW=4 across 2 cores
+    uint32_t B = 4, C = 1, HW = 4;
+    auto input_cores = make_cores(2);
+    auto output_cores = make_cores(2);
+
+    // Create input shards
+    auto input_shards = create_test_input(B, C, HW, input_cores.size());
+
+    // Input layout: each core has [4, 2] = 8 elements
+    // Core 0: b0hw0-1, b1hw0-1, b2hw0-1, b3hw0-1
+    // Core 1: b0hw2-3, b1hw2-3, b2hw2-3, b3hw2-3
+    EXPECT_FLOAT_EQ(input_shards[0][0], 0.0f);   // b=0,hw=0
+    EXPECT_FLOAT_EQ(input_shards[0][2], 2.0f);   // b=1,hw=0
+    EXPECT_FLOAT_EQ(input_shards[0][4], 4.0f);   // b=2,hw=0
+    EXPECT_FLOAT_EQ(input_shards[0][6], 6.0f);   // b=3,hw=0
+    EXPECT_FLOAT_EQ(input_shards[1][0], 8.0f);   // b=0,hw=2
+    EXPECT_FLOAT_EQ(input_shards[1][7], 15.0f);  // b=3,hw=3
+
+    // Run gather operation
+    auto output_shards = gather_with_blocked_transfers(B, C, HW, input_cores, output_cores, input_shards, 4);
+
+    // Output layout: each core has [1, 8] = 8 elements
+    // Since C=1, output is just redistributed by B*HW
+    // Core 0: b0-1 data, Core 1: b2-3 data
+
+    // Core 0 should have b=0,1 all hw values
+    EXPECT_FLOAT_EQ(output_shards[0][0], 0.0f);   // b=0,hw=0
+    EXPECT_FLOAT_EQ(output_shards[0][1], 1.0f);   // b=0,hw=1
+    EXPECT_FLOAT_EQ(output_shards[0][2], 8.0f);   // b=0,hw=2
+    EXPECT_FLOAT_EQ(output_shards[0][3], 9.0f);   // b=0,hw=3
+    EXPECT_FLOAT_EQ(output_shards[0][4], 2.0f);   // b=1,hw=0
+    EXPECT_FLOAT_EQ(output_shards[0][5], 3.0f);   // b=1,hw=1
+    EXPECT_FLOAT_EQ(output_shards[0][6], 10.0f);  // b=1,hw=2
+    EXPECT_FLOAT_EQ(output_shards[0][7], 11.0f);  // b=1,hw=3
+
+    // Core 1 should have b=2,3 all hw values
+    EXPECT_FLOAT_EQ(output_shards[1][0], 4.0f);   // b=2,hw=0
+    EXPECT_FLOAT_EQ(output_shards[1][1], 5.0f);   // b=2,hw=1
+    EXPECT_FLOAT_EQ(output_shards[1][2], 12.0f);  // b=2,hw=2
+    EXPECT_FLOAT_EQ(output_shards[1][3], 13.0f);  // b=2,hw=3
+    EXPECT_FLOAT_EQ(output_shards[1][4], 6.0f);   // b=3,hw=0
+    EXPECT_FLOAT_EQ(output_shards[1][5], 7.0f);   // b=3,hw=1
+    EXPECT_FLOAT_EQ(output_shards[1][6], 14.0f);  // b=3,hw=2
+    EXPECT_FLOAT_EQ(output_shards[1][7], 15.0f);  // b=3,hw=3
+
+    // Verify all elements were written (no -1 or uninitialized values)
+    for (const auto& shard : output_shards) {
+        for (float val : shard) {
+            EXPECT_NE(val, -1.0f) << "Found unwritten element";
+        }
+    }
+}
+
+TEST_F(GatherTransferTest, BlockBoundaryCorrectness) {
+    // Test that values at block boundaries are handled correctly
+    // Use a simpler test with wrapper function to verify block boundaries
+    uint32_t B = 1, C = 2, HW = 8;
+    uint32_t block_size = 3;  // Non-power-of-2 to test edge cases
+    auto input_cores = make_cores(2);
+    auto output_cores = make_cores(2);
+
+    // Create input shards with clear pattern
+    std::vector<std::vector<float>> input_shards(2);
+    uint32_t input_shard_width = HW / 2;  // 4 elements per core
+
+    // Fill input shards with pattern: shard0 has 0-3, 8-11; shard1 has 4-7, 12-15
+    for (uint32_t core = 0; core < 2; core++) {
+        input_shards[core].resize(C * input_shard_width);
+        for (uint32_t c = 0; c < C; c++) {
+            for (uint32_t col = 0; col < input_shard_width; col++) {
+                uint32_t hw = core * input_shard_width + col;
+                input_shards[core][c * input_shard_width + col] = c * 100.0f + hw;
+            }
+        }
+    }
+
+    // Run gather with block_size=3
+    auto output_shards = gather_with_blocked_transfers(B, C, HW, input_cores, output_cores, input_shards, block_size);
+
+    // With block_size=3 and output_shard_width=4, we have:
+    // Block 0: columns 0-2
+    // Block 1: column 3
+    // The blocked algorithm should still produce correct results
+
+    // Verify output values match expected pattern
+    // For B=1, the gather should essentially preserve values but rearrange sharding
+    uint32_t output_shard_width = B * HW / 2;  // 4 elements per core
+
+    for (uint32_t core = 0; core < 2; core++) {
+        for (uint32_t c = 0; c < C; c++) {
+            for (uint32_t col = 0; col < output_shard_width; col++) {
+                uint32_t hw = core * output_shard_width + col;
+                float expected = c * 100.0f + hw;
+                float actual = output_shards[core][c * output_shard_width + col];
+
+                EXPECT_FLOAT_EQ(actual, expected) << "Block boundary error at core=" << core << ", c=" << c
+                                                  << ", col=" << col << " (hw=" << hw << ")";
+            }
+        }
+    }
+}
+
+}  // namespace test
+}  // namespace detail
+}  // namespace convert_to_hwc
+}  // namespace cnn
+}  // namespace experimental
+}  // namespace operations
+}  // namespace ttnn

--- a/tests/ttnn/unit_tests/operations/data_movement/test_convert_to_hwc.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_convert_to_hwc.py
@@ -9,9 +9,11 @@ import torch
 from tests.ttnn.utils_for_testing import assert_equal
 from tests.ttnn.unit_tests.operations.test_utils import round_up
 
-CHANNEL_TEST_CASES = [1, 3, 8, 12, 15, 32]
+CHANNEL_TEST_CASES = [1, 2, 3, 4]
+BATCH_TEST_CASES = [1, 2, 4, 8]
 
 
+@pytest.mark.parametrize("B", BATCH_TEST_CASES)
 @pytest.mark.parametrize("C", CHANNEL_TEST_CASES)
 @pytest.mark.parametrize("provide_memory_config", [True, False])
 @pytest.mark.parametrize(
@@ -30,33 +32,56 @@ CHANNEL_TEST_CASES = [1, 3, 8, 12, 15, 32]
             128,
             ttnn.CoreRangeSet(
                 {
+                    ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0)),
+                }
+            ),
+            128,
+        ),
+        (
+            128,
+            ttnn.CoreRangeSet(
+                {
                     ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 0)),
                 }
             ),
             64,
         ),
         (
-            168960,
+            256,
             ttnn.CoreRangeSet(
                 {
-                    ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 6)),
-                    ttnn.CoreRange(ttnn.CoreCoord(0, 7), ttnn.CoreCoord(6, 7)),
+                    ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 0)),
                 }
             ),
-            2688,
-        ),  # UNet Shallow
+            64,
+        ),
+        (
+            8192,
+            ttnn.CoreRangeSet(
+                {
+                    ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 7)),
+                }
+            ),
+            128,
+        ),
     ),
 )
-def test_convert_to_hwc(device, C, HW, core_grid, padded_sharded_dim, provide_memory_config):
+def test_convert_to_hwc_with_l1_input(device, B, C, HW, core_grid, padded_sharded_dim, provide_memory_config):
     device_num_cores = device.compute_with_storage_grid_size().x * device.compute_with_storage_grid_size().y
     requested_num_cores = core_grid.num_cores()
     if device_num_cores < requested_num_cores:
         pytest.skip(f"Not enough cores to run test case (need {requested_num_cores} but have {device_num_cores})")
 
-    input_tensor = torch.randn([1, 1, C, HW], dtype=torch.bfloat16)
-    expected = input_tensor.transpose(2, 3)
+    # Verify this is even sharding
+    assert (
+        padded_sharded_dim * core_grid.num_cores() == HW
+    ), f"Expected even sharding but got uneven: {padded_sharded_dim} * {core_grid.num_cores()} != {HW}"
 
-    input_shard_shape = (C, padded_sharded_dim)
+    input_tensor = torch.randn([1, B, C, HW], dtype=torch.bfloat16)
+
+    expected = input_tensor.transpose(2, 3).reshape(1, 1, B * HW, C)
+
+    input_shard_shape = (B * C, padded_sharded_dim)
     input_shard_spec = ttnn.ShardSpec(core_grid, input_shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
     input_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, input_shard_spec)
 
@@ -65,7 +90,7 @@ def test_convert_to_hwc(device, C, HW, core_grid, padded_sharded_dim, provide_me
     )
 
     if provide_memory_config:
-        output_shard_shape = (padded_sharded_dim, round_up(C, 8))
+        output_shard_shape = (B * padded_sharded_dim, round_up(C, 8))
         output_shard_spec = ttnn.ShardSpec(core_grid, output_shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
         output_mem_config = ttnn.MemoryConfig(
             ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, output_shard_spec
@@ -82,47 +107,226 @@ def test_convert_to_hwc(device, C, HW, core_grid, padded_sharded_dim, provide_me
     assert passed, message
 
 
+@pytest.mark.parametrize("B", [1])  # Only B=1 is currently supported for uneven sharding
+@pytest.mark.parametrize("C", CHANNEL_TEST_CASES)
+@pytest.mark.parametrize("provide_memory_config", [True, False])
+@pytest.mark.parametrize(
+    "HW, core_grid, padded_sharded_dim",
+    (
+        (
+            30,
+            ttnn.CoreRangeSet(
+                {
+                    ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0)),
+                }
+            ),
+            32,
+        ),
+        (
+            60,
+            ttnn.CoreRangeSet(
+                {
+                    ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 0)),
+                }
+            ),
+            32,
+        ),
+        (
+            168960,
+            ttnn.CoreRangeSet(
+                {
+                    ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 6)),
+                    ttnn.CoreRange(ttnn.CoreCoord(0, 7), ttnn.CoreCoord(6, 7)),
+                }
+            ),
+            2688,
+        ),  # UNet Shallow
+    ),
+)
+def test_convert_to_hwc_with_l1_input_uneven_sharding(
+    device, B, C, HW, core_grid, padded_sharded_dim, provide_memory_config
+):
+    device_num_cores = device.compute_with_storage_grid_size().x * device.compute_with_storage_grid_size().y
+    requested_num_cores = core_grid.num_cores()
+    if device_num_cores < requested_num_cores:
+        pytest.skip(f"Not enough cores to run test case (need {requested_num_cores} but have {device_num_cores})")
+
+    # Verify this is uneven sharding
+    assert (
+        padded_sharded_dim * core_grid.num_cores() > HW
+    ), f"Expected uneven sharding but got even: {padded_sharded_dim} * {core_grid.num_cores()} <= {HW}"
+
+    # Only B=1 is supported for uneven sharding
+    assert B == 1, f"Uneven sharding is only supported when B=1 (was {B})"
+
+    input_tensor = torch.randn([1, B, C, HW], dtype=torch.bfloat16)
+
+    expected = input_tensor.transpose(2, 3).reshape(1, 1, B * HW, C)
+
+    input_shard_shape = (B * C, padded_sharded_dim)
+    input_shard_spec = ttnn.ShardSpec(core_grid, input_shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
+    input_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, input_shard_spec)
+
+    input_tensor = ttnn.Tensor(
+        input_tensor, ttnn.bfloat16, device=device, layout=ttnn.ROW_MAJOR_LAYOUT, mem_config=input_mem_config
+    )
+
+    if provide_memory_config:
+        output_shard_shape = (B * padded_sharded_dim, round_up(C, 8))
+        output_shard_spec = ttnn.ShardSpec(core_grid, output_shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
+        output_mem_config = ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, output_shard_spec
+        )
+        actual = ttnn.experimental.convert_to_hwc(input_tensor, memory_config=output_mem_config, dtype=ttnn.bfloat16)
+    else:
+        actual = ttnn.experimental.convert_to_hwc(input_tensor, dtype=ttnn.bfloat16)
+
+    actual = ttnn.to_torch(actual)
+
+    passed, message = assert_equal(
+        expected, actual[:, :, :, : expected.shape[-1]]
+    )  # slice off padding that is applied when C % 8 != 0
+    assert passed, message
+
+
+@pytest.mark.parametrize("B", [1, 2, 4])
+@pytest.mark.parametrize("C", [1, 2, 3, 4])
+@pytest.mark.parametrize(
+    "HW, input_core_grid, output_core_grid, input_padded_sharded_dim, output_padded_sharded_dim",
+    (
+        (
+            32,
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))}),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))}),
+            32,
+            32,
+        ),
+        (
+            64,
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))}),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 0))}),
+            64,
+            32,
+        ),
+        (
+            128,
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))}),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 0))}),
+            128,
+            32,
+        ),
+    ),
+)
+def test_convert_to_hwc_with_l1_input_resharded(
+    device, B, C, HW, input_core_grid, output_core_grid, input_padded_sharded_dim, output_padded_sharded_dim
+):
+    device_num_cores = device.compute_with_storage_grid_size().x * device.compute_with_storage_grid_size().y
+    requested_num_cores = output_core_grid.num_cores()
+    if device_num_cores < requested_num_cores:
+        pytest.skip(f"Not enough cores to run test case (need {requested_num_cores} but have {device_num_cores})")
+
+    is_uneven = input_padded_sharded_dim * input_core_grid.num_cores() > HW
+    if is_uneven and B > 1:
+        pytest.skip(f"Uneven sharding is not supported when B > 1 (was {B})")
+
+    input_tensor = torch.randn([1, B, C, HW], dtype=torch.bfloat16)
+
+    expected = input_tensor.transpose(2, 3).reshape(1, 1, B * HW, C)
+
+    input_shard_shape = (B * C, input_padded_sharded_dim)
+    input_shard_spec = ttnn.ShardSpec(input_core_grid, input_shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
+    input_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, input_shard_spec)
+
+    input_tensor = ttnn.Tensor(
+        input_tensor, ttnn.bfloat16, device=device, layout=ttnn.ROW_MAJOR_LAYOUT, mem_config=input_mem_config
+    )
+
+    output_shard_shape = (B * output_padded_sharded_dim, round_up(C, 8))
+    output_shard_spec = ttnn.ShardSpec(output_core_grid, output_shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
+    output_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, output_shard_spec)
+
+    actual = ttnn.experimental.convert_to_hwc(input_tensor, memory_config=output_mem_config, dtype=ttnn.bfloat16)
+    actual = ttnn.to_torch(actual)
+    passed, message = assert_equal(
+        expected, actual[:, :, :, : expected.shape[-1]]
+    )  # slice off padding that is applied when C % 8 != 0
+    assert passed, message
+
+
+@pytest.mark.parametrize("B", [1, 2, 4])
 @pytest.mark.parametrize("C", CHANNEL_TEST_CASES)
 @pytest.mark.parametrize(
     "HW, input_core_grid, output_core_grid, input_padded_sharded_dim, output_padded_sharded_dim",
     (
         (
             32,
-            ttnn.CoreRangeSet(
-                {
-                    ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0)),
-                }
-            ),
-            ttnn.CoreRangeSet(
-                {
-                    ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0)),
-                }
-            ),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))}),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))}),
             32,
             32,
         ),
         (
-            84480,
-            ttnn.CoreRangeSet(
-                {
-                    ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(5, 0)),
-                }
-            ),
-            ttnn.CoreRangeSet(
-                {
-                    ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 3)),
-                }
-            ),
-            14080,
-            2656,
+            64,
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))}),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))}),
+            64,
+            64,
         ),
+        (
+            128,
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))}),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 0))}),
+            128,
+            64,
+        ),
+    ),
+)
+def test_convert_to_hwc_dram(
+    device, B, C, HW, input_core_grid, output_core_grid, input_padded_sharded_dim, output_padded_sharded_dim
+):
+    worker_num_cores = device.compute_with_storage_grid_size().x * device.compute_with_storage_grid_size().y
+    requested_num_cores = output_core_grid.num_cores()
+    if worker_num_cores < requested_num_cores:
+        pytest.skip(f"Not enough cores to run test case (need {requested_num_cores} but have {worker_num_cores})")
+
+    dram_num_cores = device.dram_grid_size().x * device.dram_grid_size().y
+    requested_num_dram_cores = input_core_grid.num_cores()
+    if dram_num_cores < requested_num_dram_cores:
+        pytest.skip(
+            f"Not enough DRAM cores to run test case (need {requested_num_dram_cores} but have {dram_num_cores})"
+        )
+
+    input_tensor = torch.randn([1, B, C, HW], dtype=torch.bfloat16)
+    expected = input_tensor.transpose(2, 3).reshape(1, 1, B * HW, C)
+
+    input_shard_shape = (B * C, input_padded_sharded_dim)
+    input_shard_spec = ttnn.ShardSpec(input_core_grid, input_shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
+    input_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.DRAM, input_shard_spec)
+
+    output_shard_shape = (B * output_padded_sharded_dim, round_up(C, 8))
+    output_shard_spec = ttnn.ShardSpec(output_core_grid, output_shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
+    output_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, output_shard_spec)
+
+    input_tensor = ttnn.Tensor(
+        input_tensor, ttnn.bfloat16, device=device, layout=ttnn.ROW_MAJOR_LAYOUT, mem_config=input_mem_config
+    )
+
+    actual = ttnn.experimental.convert_to_hwc(input_tensor, memory_config=output_mem_config, dtype=ttnn.bfloat16)
+    actual = ttnn.to_torch(actual)
+
+    passed, message = assert_equal(
+        expected, actual[:, :, :, : expected.shape[-1]]
+    )  # slice off padding that is applied when C % 8 != 0
+    assert passed, message
+
+
+@pytest.mark.parametrize("C", CHANNEL_TEST_CASES)
+@pytest.mark.parametrize(
+    "HW, input_core_grid, output_core_grid, input_padded_sharded_dim, output_padded_sharded_dim",
+    (
         (
             168960,
-            ttnn.CoreRangeSet(
-                {
-                    ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(11, 0)),
-                }
-            ),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(11, 0))}),
             ttnn.CoreRangeSet(
                 {
                     ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 6)),
@@ -131,10 +335,10 @@ def test_convert_to_hwc(device, C, HW, core_grid, padded_sharded_dim, provide_me
             ),
             14080,
             2688,
-        ),  # UNet Shallow
+        ),
     ),
 )
-def test_convert_to_hwc_dram(
+def test_convert_to_hwc_dram_uneven_sharding(
     device, C, HW, input_core_grid, output_core_grid, input_padded_sharded_dim, output_padded_sharded_dim
 ):
     worker_num_cores = device.compute_with_storage_grid_size().x * device.compute_with_storage_grid_size().y
@@ -148,6 +352,10 @@ def test_convert_to_hwc_dram(
         pytest.skip(
             f"Not enough DRAM cores to run test case (need {requested_num_dram_cores} but have {dram_num_cores})"
         )
+
+    # Uneven sharding along B*HW for output
+    assert input_padded_sharded_dim * input_core_grid.num_cores() == HW
+    assert output_padded_sharded_dim * output_core_grid.num_cores() > HW
 
     input_tensor = torch.randn([1, 1, C, HW], dtype=torch.bfloat16)
     expected = input_tensor.transpose(2, 3)

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/CMakeLists.txt
@@ -13,6 +13,7 @@ target_sources(
         convert_to_hwc/convert_to_hwc.cpp
         convert_to_hwc/device/convert_to_hwc_device_operation.cpp
         convert_to_hwc/device/convert_to_hwc_program_factory.cpp
+        convert_to_hwc/device/gather.cpp
 )
 
 target_include_directories(ttnn_op_experimental_cnn PRIVATE ${FixmeOpIncDirs})

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/convert_to_hwc.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/convert_to_hwc.cpp
@@ -15,14 +15,18 @@ static tt::tt_metal::MemoryConfig infer_hwc_output_memory_config(const ttnn::Ten
         input_memory_config.memory_layout() == tt::tt_metal::TensorMemoryLayout::WIDTH_SHARDED,
         "Input tensor must be width sharded");
 
+    const auto& logical_shape = input_tensor.logical_shape();
+    const int B = logical_shape[1];
+    const int C = logical_shape[2];
+
     const auto& input_shard_spec = input_memory_config.shard_spec().value();
-    const int input_shard_height = input_shard_spec.shape[0];
     const int input_shard_width = input_shard_spec.shape[1];
 
-    const int output_shard_height = input_shard_width;  // HW dimension per core stays the same
+    // Per-core output height is B times the per-core HW width (i.e., sticks)
+    const int output_shard_height = B * input_shard_width;
     const int alignment_elements = detail::compute_alignment_requirement_in_elements(input_tensor);
     TT_FATAL(alignment_elements != 0, "Number of alignment elements cannot be 0");
-    const int output_shard_width = tt::round_up(input_shard_height, alignment_elements);
+    const int output_shard_width = tt::round_up(C, alignment_elements);
 
     const std::array<uint32_t, 2> output_shard_shape = {output_shard_height, output_shard_width};
 

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/convert_to_hwc_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/convert_to_hwc_pybind.cpp
@@ -23,18 +23,21 @@ void bind_convert_to_hwc(py::module& module) {
     The input tensor is expected to be in row-major layout and width-sharded in L1 or DRAM.
     The output is a row-major height-sharded tensor.
 
+    Input tensor shape: [1, B, C, HW] where B is the batch size.
+    Output tensor shape: [1, 1, B * HW, C] - batches are flattened into the spatial dimension.
+
     When C is not a multiple of the device alignment requirement, the output shard width is automatically padded up
     to the next multiple of the alignment requirement to satisfy alignment constraints.
 
     Args:
-        input (ttnn.Tensor): Input tensor in CHW format, width-sharded in L1 or DRAM.
+        input (ttnn.Tensor): Input tensor in CHW format with shape [1, B, C, HW], width-sharded in L1 or DRAM.
         memory_config (Optional[ttnn.MemoryConfig]): Output memory configuration.
                                                      Required only for DRAM inputs. If omitted for L1 inputs, the output memory_config is automatically inferred.
                                                      The output shard width will be rounded up to the next multiple of the alignment requirement for proper memory alignment.
         dtype (Optional[ttnn.DataType]): Output data type (defaults to input dtype)
 
     Returns:
-        ttnn.Tensor: Output tensor in HWC format, height-sharded
+        ttnn.Tensor: Output tensor in HWC format with shape [1, 1, B * HW, C], height-sharded
 
     )doc";
 

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/convert_to_hwc_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/convert_to_hwc_device_operation.cpp
@@ -30,7 +30,7 @@ void ConvertToHWCDeviceOperation::validate_on_program_cache_miss(
     const auto& C = shape[-2];
 
     TT_FATAL(shape.size() == 4, "Input shape must be rank 4 (was rank {})", shape.size());
-    TT_FATAL(shape[0] == 1 && shape[1] == 1, "Expected input tensor to be shape [1, 1, C, HW] (shape was {})", shape);
+    TT_FATAL(shape[0] == 1, "Expected input tensor to be shape [1, B, C, HW] (shape was {})", shape);
     TT_FATAL(C <= TILE_HEIGHT, "C must be less than or equal to 32 (was {})", C);
 
     TT_FATAL(input.layout() == Layout::ROW_MAJOR, "Input tensor must be in row-major layout");
@@ -48,7 +48,7 @@ void ConvertToHWCDeviceOperation::validate_on_program_cache_miss(
 spec_return_value_t ConvertToHWCDeviceOperation::compute_output_specs(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     const auto& shape = tensor_args.input.logical_shape();
-    const int B = shape[0];
+    const int B = shape[1];
     const int C = shape[2];
     const int HW = shape[3];
 
@@ -57,7 +57,7 @@ spec_return_value_t ConvertToHWCDeviceOperation::compute_output_specs(
     const auto output_channels = tt::round_up(C, alignment_elements);
 
     return TensorSpec(
-        Shape({B, 1, HW, output_channels}),
+        Shape({1, 1, B * HW, output_channels}),
         TensorLayout(args.dtype, PageConfig(Layout::ROW_MAJOR), args.memory_config));
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/convert_to_hwc_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/convert_to_hwc_program_factory.cpp
@@ -10,9 +10,340 @@
 #include "ttnn/tensor/types.hpp"
 #include "ttnn/operations/data_movement/sharded/sharded_common.hpp"
 
-using namespace tt::constants;
+#include "gather.hpp"
 
 namespace ttnn::operations::experimental::cnn::detail {
+
+using namespace tt::constants;
+
+namespace {
+
+// Per-core tiling and addressing parameters used by the writers and compute kernels
+struct BlockTilingParams {
+    uint32_t total_tiles_per_block;
+    uint32_t total_tiles_per_core;
+    uint32_t tiles_per_block_writer0;
+    uint32_t tiles_per_block_writer1;
+    uint32_t output_addr_stride;
+    uint32_t block_size_bytes;
+};
+
+struct GroupingResult {
+    std::vector<std::vector<convert_to_hwc::detail::BlockedTransferGroup>> per_core_groups;
+    uint32_t num_blocks;
+};
+
+inline BlockTilingParams compute_block_tiling_params(
+    const ConvertToHwcConfig& config, uint32_t block_size_width, uint32_t num_blocks) {
+    const uint32_t total_tiles_per_block = tt::div_up(block_size_width, TILE_HEIGHT);
+    const uint32_t total_tiles_per_core = total_tiles_per_block * num_blocks;
+    const uint32_t tiles_per_block_writer0 = tt::div_up(total_tiles_per_block, 2);
+    const uint32_t tiles_per_block_writer1 = total_tiles_per_block - tiles_per_block_writer0;
+    const uint32_t output_stride_sticks = TILE_WIDTH;
+    // Inter-writer L1 output stride (bytes) between consecutive tiles written by a single writer.
+    // If a block is only one tile tall, only one writer is active, so no stride is needed.
+    const uint32_t output_addr_stride =
+        (block_size_width != TILE_HEIGHT) ? output_stride_sticks * config.output_shard_width * config.element_size_bytes
+                                          : 0;
+    const uint32_t block_size_bytes =
+        config.gather_l1_output_shard_height * block_size_width * config.element_size_bytes;
+    return {
+        total_tiles_per_block,
+        total_tiles_per_core,
+        tiles_per_block_writer0,
+        tiles_per_block_writer1,
+        output_addr_stride,
+        block_size_bytes};
+}
+
+inline std::vector<uint32_t> make_writer_compile_args(
+    bool is_reader,
+    uint32_t cb_in_transpose_index,
+    const ConvertToHwcConfig& config,
+    const BlockTilingParams& tiling,
+    uint32_t tiles_per_block_for_writer,
+    uint32_t initial_write_stick_offset,
+    uint32_t num_blocks) {
+    return {
+        CBIndex::CB_IN,
+        CBIndex::CB_IN_BATCH,
+        cb_in_transpose_index,
+        CBIndex::CB_OUT,
+        config.output_shard_width,
+        tiles_per_block_for_writer,
+        initial_write_stick_offset,
+        config.element_size_bytes,
+        static_cast<uint32_t>(config.is_input_in_dram),
+        static_cast<uint32_t>(is_reader),
+        is_reader ? config.gather_l1_output_shard_height : 0u,
+        num_blocks,
+        tiling.output_addr_stride,
+        tiling.block_size_bytes};
+}
+
+inline std::vector<uint32_t> make_compute_compile_args(
+    uint32_t total_tiles_per_block, uint32_t total_sticks_per_block, uint32_t num_blocks) {
+    return {
+        CBIndex::CB_IN_BATCH,
+        CBIndex::CB_IN_TILED,
+        CBIndex::CB_IN_TRANSPOSE_0,
+        CBIndex::CB_IN_TRANSPOSE_1,
+        total_tiles_per_block,
+        total_sticks_per_block,
+        num_blocks};
+}
+
+// Generate gather transfers, group them into output column blocks, and coalesce contiguous copies.
+GroupingResult group_and_coalesce_transfers(
+    const ConvertToHwcConfig& config,
+    const std::vector<CoreCoord>& in_cores,
+    uint32_t effective_hw_for_gather,
+    uint32_t block_size_width) {
+    const auto gather_transfers = convert_to_hwc::detail::precompute_gather_transfers(
+        config.batch_size,
+        config.input_channels,
+        effective_hw_for_gather,
+        in_cores,
+        config.output_cores,
+        block_size_width);
+
+    const auto blocked_result = convert_to_hwc::detail::group_transfers_by_output_column_blocks(
+        gather_transfers,
+        config.batch_size,
+        config.input_channels,
+        effective_hw_for_gather,
+        in_cores,
+        config.output_cores.size(),
+        /*element_size_bytes=*/config.element_size_bytes,
+        /*block_size=*/block_size_width,
+        /*output_shard_width=*/block_size_width);
+
+    auto blocked_gather_transfers = blocked_result.blocked_transfers;
+    auto per_core_blocked_gather_transfers =
+        convert_to_hwc::detail::split_by_destination_core(blocked_gather_transfers, config.output_cores.size());
+    for (auto& core_transfers : per_core_blocked_gather_transfers) {
+        core_transfers = convert_to_hwc::detail::coalesce_contiguous_transfers(core_transfers);
+    }
+    return {std::move(per_core_blocked_gather_transfers), blocked_result.num_logical_blocks};
+}
+
+// Serialize grouped transfers per destination core with the provided source-address mapping.
+inline std::vector<std::vector<uint32_t>> serialize_transfers_per_core(
+    const std::vector<std::vector<convert_to_hwc::detail::BlockedTransferGroup>>& per_core_groups,
+    const std::vector<CoreCoord>& in_cores,
+    const std::function<CoreCoord(const CoreCoord&)>& logical_to_addr_id) {
+    std::vector<std::vector<uint32_t>> per_core_serialized;
+    per_core_serialized.resize(per_core_groups.size());
+    for (size_t core_idx = 0; core_idx < per_core_groups.size(); core_idx++) {
+        per_core_serialized[core_idx] = convert_to_hwc::detail::serialize_blocked_transfer_groups(
+            per_core_groups[core_idx], in_cores, logical_to_addr_id);
+    }
+    return per_core_serialized;
+}
+
+}  // namespace
+
+// Effective HW used by gather: always the padded capacity per input core
+uint32_t calculate_effective_hw_for_sharding(
+    uint32_t hw_total, uint32_t batch_size, uint32_t padded_shard_width, uint32_t num_cores) {
+    // Covers both even sharding (exact fit) and uneven sharding (B=1; padded)
+    return num_cores * padded_shard_width;
+}
+
+struct CircularBufferHandles {
+    tt::tt_metal::CBHandle cb_in;
+    tt::tt_metal::CBHandle cb_out;
+};
+
+// Helper function to create a circular buffer
+tt::tt_metal::CBHandle create_circular_buffer(
+    tt::tt_metal::Program& program,
+    const CoreRangeSet& core_grid,
+    uint32_t index,
+    uint32_t total_size,
+    uint32_t page_size,
+    const tt::DataFormat& format,
+    tt::tt_metal::Buffer* buffer = nullptr);
+
+// Setup all circular buffers for the convert_to_hwc operation
+CircularBufferHandles setup_circular_buffers(
+    tt::tt_metal::Program& program,
+    const CoreRangeSet& core_grid,
+    const ConvertToHwcConfig& config,
+    const Tensor& input,
+    const Tensor& output,
+    uint32_t block_size_width);
+
+ConvertToHwcConfig ConvertToHwcConfig::create_from_tensors(const Tensor& input, const Tensor& output) {
+    ConvertToHwcConfig config;
+
+    // Input tensor properties
+    config.batch_size = input.logical_shape()[1];
+    config.input_channels = input.logical_shape()[2];
+    config.hw_total = input.logical_shape()[3];
+    config.input_format = tt::tt_metal::datatype_to_dataformat_converter(input.dtype());
+    config.element_size_bytes = tt::datum_size(config.input_format);
+
+    // DRAM/L1 configuration
+    config.is_input_in_dram = input.buffer()->core_type() == tt::CoreType::DRAM;
+    config.remote_address = input.buffer()->address();
+    config.remote_buffer_type = input.buffer()->buffer_type();
+    config.remote_core_type = input.buffer()->core_type();
+
+    // Shard specifications
+    config.output_shard_height = output.shard_spec()->shape[0];
+    config.output_shard_width = output.shard_spec()->shape[1];
+    config.l1_input_shard_height = config.is_input_in_dram ? input.logical_shape()[-2] : input.shard_spec()->shape[0];
+    // Use input's padded sharded width (WIDTH_SHARDED) for both DRAM and L1 inputs
+    config.l1_input_shard_width = input.shard_spec()->shape[1];
+
+    // Core information
+    // Kernels run on output cores; data sources are the input cores
+    config.output_core_grid = output.shard_spec()->grid;
+    config.output_cores = corerange_to_cores(
+        config.output_core_grid,
+        std::nullopt,
+        output.shard_spec()->orientation == tt::tt_metal::ShardOrientation::ROW_MAJOR);
+
+    // Always derive input core locations from the input tensor's shard grid
+    config.l1_input_core_grid = input.shard_spec()->grid;
+    config.l1_input_cores = corerange_to_cores(
+        config.l1_input_core_grid,
+        std::nullopt,
+        input.shard_spec()->orientation == tt::tt_metal::ShardOrientation::ROW_MAJOR);
+    config.dram_input_cores = corerange_to_cores(
+        input.shard_spec()->grid,
+        std::nullopt,
+        input.shard_spec()->orientation == tt::tt_metal::ShardOrientation::ROW_MAJOR);
+
+    // Gather output shard specifications (for the intermediate gather result)
+    // The gather operation transforms from [B, C, HW] to [C, B, HW] layout
+    // So the gather output has height=C and width=B*HW_effective/num_output_cores
+    config.gather_l1_output_shard_height = config.input_channels;
+
+    // Set per-destination-core gather width to the padded B*HW per output core (output shard height)
+    config.gather_l1_output_shard_width = config.output_shard_height;
+
+    // Alignment requirements
+    config.alignment_elements = compute_alignment_requirement_in_elements(output);
+
+    log_debug(
+        tt::LogType::LogOp,
+        "convert_to_hwc config: B={}, C={}, HW={}, input_in_dram={}, in_cores={}, out_cores={}, out_shard=[{}x{}], "
+        "gather_width={}",
+        config.batch_size,
+        config.input_channels,
+        config.hw_total,
+        config.is_input_in_dram,
+        config.l1_input_cores.size(),
+        config.output_cores.size(),
+        config.output_shard_height,
+        config.output_shard_width,
+        config.gather_l1_output_shard_width);
+
+    return config;
+}
+
+void ConvertToHwcConfig::validate() const {
+    TT_FATAL(alignment_elements != 0, "Number of alignment elements cannot be 0");
+    TT_FATAL(
+        output_shard_width % alignment_elements == 0,
+        "Output shard width {} must be multiple of {} to satisfy alignment constraints",
+        output_shard_width,
+        alignment_elements);
+    TT_FATAL(output_shard_height % 32 == 0, "Shard height {} must be multiple of tile width (32)", output_shard_height);
+    TT_FATAL(!output_cores.empty(), "No output cores available for processing");
+
+    // Check for uneven sharding and validate B=1 requirement
+    uint32_t input_num_cores = l1_input_cores.size();
+    // Uneven sharding occurs when the last core has fewer logical elements than the shard width
+    uint32_t total_padded_elements = input_num_cores * l1_input_shard_width;
+    bool is_uneven_sharding = hw_total < total_padded_elements;
+    if (is_uneven_sharding) {
+        TT_FATAL(
+            batch_size == 1,
+            "Uneven sharding (HW={} < total_padded_capacity={}) is only supported for batch_size=1, got batch_size={}",
+            hw_total,
+            total_padded_elements,
+            batch_size);
+    }
+}
+
+tt::tt_metal::CBHandle create_circular_buffer(
+    tt::tt_metal::Program& program,
+    const CoreRangeSet& core_grid,
+    uint32_t index,
+    uint32_t total_size,
+    uint32_t page_size,
+    const tt::DataFormat& format,
+    tt::tt_metal::Buffer* buffer) {
+    auto config = tt::tt_metal::CircularBufferConfig(total_size, {{index, format}}).set_page_size(index, page_size);
+    if (buffer != nullptr) {
+        config = config.set_globally_allocated_address(*buffer);
+    }
+    return tt::tt_metal::CreateCircularBuffer(program, core_grid, config);
+}
+
+CircularBufferHandles setup_circular_buffers(
+    tt::tt_metal::Program& program,
+    const CoreRangeSet& core_grid,
+    const ConvertToHwcConfig& config,
+    const Tensor& input,
+    const Tensor& output,
+    uint32_t block_size_width) {
+    const tt::DataFormat intermediary_format = tt::DataFormat::Float16_b;
+    const uint32_t intermediary_tile_size = tt::tile_size(intermediary_format);
+
+    // CB_IN: full input shard per core
+    const uint32_t cb_in_page_size = config.l1_input_shard_width * config.element_size_bytes;
+    const uint32_t cb_in_total_size = config.l1_input_shard_height * cb_in_page_size;
+    auto cb_in = create_circular_buffer(
+        program,
+        core_grid,
+        CBIndex::CB_IN,
+        cb_in_total_size,
+        cb_in_page_size,
+        config.input_format,
+        config.is_input_in_dram ? nullptr : input.buffer());
+
+    // CB_IN_BATCH: [C x block_size_width] staging for gathered sticks
+    const uint32_t cb_in_batch_page_size = block_size_width * config.element_size_bytes;
+    const uint32_t cb_in_batch_total_size = config.gather_l1_output_shard_height * cb_in_batch_page_size;
+    create_circular_buffer(
+        program, core_grid, CBIndex::CB_IN_BATCH, cb_in_batch_total_size, cb_in_batch_page_size, config.input_format);
+
+    // CB_IN_TILED: intermediate tiles
+    const uint32_t cb_in_tiled_page_size = intermediary_tile_size;
+    const uint32_t cb_in_tiled_total_size = tt::div_up(block_size_width, TILE_WIDTH) * intermediary_tile_size;
+    create_circular_buffer(
+        program, core_grid, CBIndex::CB_IN_TILED, cb_in_tiled_total_size, cb_in_tiled_page_size, intermediary_format);
+
+    // CB_IN_TRANSPOSE_[0/1]
+    const uint32_t cb_in_transpose_page_size = intermediary_tile_size;
+    const uint32_t cb_in_transpose_total_size = tt::div_up(block_size_width, TILE_WIDTH) * intermediary_tile_size;
+    create_circular_buffer(
+        program,
+        core_grid,
+        CBIndex::CB_IN_TRANSPOSE_0,
+        cb_in_transpose_total_size,
+        cb_in_transpose_page_size,
+        intermediary_format);
+    create_circular_buffer(
+        program,
+        core_grid,
+        CBIndex::CB_IN_TRANSPOSE_1,
+        cb_in_transpose_total_size,
+        cb_in_transpose_page_size,
+        intermediary_format);
+
+    // CB_OUT: output shard per core
+    const uint32_t cb_out_page_size = config.output_shard_width * config.element_size_bytes;
+    const uint32_t cb_out_total_size = cb_out_page_size * config.output_shard_height;  // same size as input
+    auto cb_out = create_circular_buffer(
+        program, core_grid, CBIndex::CB_OUT, cb_out_total_size, cb_out_page_size, config.input_format, output.buffer());
+
+    return {cb_in, cb_out};
+}
 
 uint32_t compute_alignment_requirement_in_elements(const Tensor& input_tensor) {
     const uint32_t element_size_bytes = input_tensor.element_size();
@@ -31,48 +362,28 @@ void set_runtime_arguments(
     const Tensor& input_tensor,
     const Tensor& output_tensor,
     bool is_input_in_dram,
-    const std::vector<tt::tt_metal::CoreCoord>& l1_input_cores,
-    const std::vector<std::vector<ttnn::operations::data_movement::detail::WidthShardingReshardSegment>>&
-        runtime_args_for_each_core,
+    const std::vector<tt::tt_metal::CoreCoord>& output_cores,
+    const std::vector<std::vector<uint32_t>>& per_core_serialized_transfers,
     tt::tt_metal::KernelHandle writer_kernel_id0,
     tt::tt_metal::KernelHandle writer_kernel_id1,
-    uint32_t total_num_sticks_kernel_0,
-    uint32_t dram_read_stride_bytes,
-    uint32_t dram_write_stride_bytes,
     uint32_t remote_address,
     tt::tt_metal::CBHandle cb_in,
     tt::tt_metal::CBHandle cb_out) {
-    if (is_input_in_dram) {
-        for (uint32_t core_idx = 0; core_idx < l1_input_cores.size(); core_idx++) {
-            const auto& args_for_all_segments = runtime_args_for_each_core[core_idx];
-            std::vector<uint32_t> runtime_args_0 = {remote_address, args_for_all_segments.size()};
-            std::vector<uint32_t> runtime_args_1 = {remote_address, args_for_all_segments.size()};
-            for (const auto& args : args_for_all_segments) {
-                const std::vector<uint32_t> segment_kernel_0 = {
-                    args.write_size, args.read_offset, args.bank_id, args.write_offset};
-                runtime_args_0.insert(runtime_args_0.end(), segment_kernel_0.begin(), segment_kernel_0.end());
-
-                // Adjust read and write offsets to the correct stick address because we are splitting work across 2
-                // kernels
-                const uint32_t adjusted_read_offset =
-                    args.read_offset + (total_num_sticks_kernel_0 * dram_write_stride_bytes);
-                const uint32_t adjusted_write_offset =
-                    args.write_offset + (total_num_sticks_kernel_0 * dram_read_stride_bytes);
-
-                const std::vector<uint32_t> segment_kernel_1 = {
-                    args.write_size, adjusted_read_offset, args.bank_id, adjusted_write_offset};
-                runtime_args_1.insert(runtime_args_1.end(), segment_kernel_1.begin(), segment_kernel_1.end());
-            }
-            SetRuntimeArgs(program, writer_kernel_id0, l1_input_cores[core_idx], runtime_args_0);
-            SetRuntimeArgs(program, writer_kernel_id1, l1_input_cores[core_idx], runtime_args_1);
-        }
-    } else {
-        tt::tt_metal::Buffer* input_buffer = input_tensor.buffer();
-        UpdateDynamicCircularBufferAddress(program, cb_in, *input_buffer);
+    // Set per-core runtime arguments for writer kernels
+    for (uint32_t core_idx = 0; core_idx < output_cores.size(); core_idx++) {
+        std::vector<uint32_t> runtime_args_0 = {remote_address};
+        std::vector<uint32_t> runtime_args_1 = {remote_address};
+        const auto& transfer_args = per_core_serialized_transfers.at(core_idx);
+        runtime_args_0.insert(runtime_args_0.end(), transfer_args.begin(), transfer_args.end());
+        runtime_args_1.insert(runtime_args_1.end(), transfer_args.begin(), transfer_args.end());
+        SetRuntimeArgs(program, writer_kernel_id0, output_cores[core_idx], runtime_args_0);
+        SetRuntimeArgs(program, writer_kernel_id1, output_cores[core_idx], runtime_args_1);
     }
-
-    tt::tt_metal::Buffer* output_buffer = output_tensor.buffer();
-    UpdateDynamicCircularBufferAddress(program, cb_out, *output_buffer);
+    // Only update input CB address for L1 input (DRAM input doesn't need CB update)
+    if (!is_input_in_dram) {
+        UpdateDynamicCircularBufferAddress(program, cb_in, *input_tensor.buffer());
+    }
+    UpdateDynamicCircularBufferAddress(program, cb_out, *output_tensor.buffer());
 }
 
 }  // namespace
@@ -86,161 +397,101 @@ ConvertToHWCProgramFactory::cached_program_t ConvertToHWCProgramFactory::create(
     const auto& a = tensor_args.input;
     auto& output = tensor_return_value;
 
-    // If we are pulling from DRAM we infer the shard shape by using the output shard spec
-    const bool is_input_in_dram = a.buffer()->core_type() == tt::CoreType::DRAM;
+    // Create configuration from input tensors
+    auto config = detail::ConvertToHwcConfig::create_from_tensors(a, output);
+    config.validate();
 
-    const uint32_t output_shard_height = output.shard_spec()->shape[0];
-    const uint32_t output_shard_width = output.shard_spec()->shape[1];
+    // Select input cores based on source memory (DRAM vs L1)
+    const auto& in_cores = config.is_input_in_dram ? config.dram_input_cores : config.l1_input_cores;
 
-    const uint32_t l1_input_shard_height = is_input_in_dram ? a.logical_shape()[-2] : a.shard_spec()->shape[0];
-    const uint32_t l1_input_shard_width = is_input_in_dram ? output_shard_height : a.shard_spec()->shape[1];
-    const CoreRangeSet l1_input_core_grid = is_input_in_dram ? output.shard_spec()->grid : a.shard_spec()->grid;
-    const std::vector<CoreCoord> l1_input_cores = corerange_to_cores(
-        l1_input_core_grid, std::nullopt, a.shard_spec()->orientation == tt::tt_metal::ShardOrientation::ROW_MAJOR);
+    // Effective HW for gather transfers (padded capacity per input core)
+    uint32_t effective_hw_for_gather = detail::calculate_effective_hw_for_sharding(
+        config.hw_total, config.batch_size, config.l1_input_shard_width, static_cast<uint32_t>(in_cores.size()));
 
-    TT_FATAL(
-        l1_input_shard_height <= TILE_HEIGHT, "Shard height must be 32 or smaller (was {})", l1_input_shard_height);
-    TT_FATAL(
-        l1_input_shard_width % TILE_WIDTH == 0,
-        "Shard width must be multiple of tile width (was {})",
-        l1_input_shard_width);
-    const auto alignment_elements = detail::compute_alignment_requirement_in_elements(output);
-    TT_FATAL(alignment_elements != 0, "Number of alignment elements cannot be 0");
-    TT_FATAL(
-        output_shard_width % alignment_elements == 0,
-        "Output shard width must be multiple of {} to satisfy alignment constraints (was {})",
-        alignment_elements,
-        output_shard_width);
+    const uint32_t block_size_width = config.gather_l1_output_shard_width;
+    const auto block_width = block_size_width;
 
-    const auto create_circular_buffer = [&program, &l1_input_core_grid](
-                                            uint32_t index,
-                                            uint32_t total_size,
-                                            uint32_t page_size,
-                                            const tt::DataFormat& format,
-                                            tt::tt_metal::Buffer* buffer = nullptr) -> tt::tt_metal::CBHandle {
-        auto config = tt::tt_metal::CircularBufferConfig(total_size, {{index, format}}).set_page_size(index, page_size);
-        if (buffer != nullptr) {
-            config = config.set_globally_allocated_address(*buffer);
+    // Setup circular buffers on the output cores (where the kernels execute)
+    auto cb_handles = detail::setup_circular_buffers(program, config.output_core_grid, config, a, output, block_width);
+    auto grouping = detail::group_and_coalesce_transfers(config, in_cores, effective_hw_for_gather, block_width);
+    const uint32_t num_blocks = grouping.num_blocks;
+
+    // Source-address mapping for serialization:
+    // - L1 input: logical core -> worker core (x,y)
+    // - DRAM input: x := bank_id, y := 0
+    std::function<CoreCoord(const CoreCoord&)> logical_to_addr_id;
+    if (config.is_input_in_dram) {
+        std::map<std::pair<int, int>, uint32_t> bank_id_by_core;
+        for (const auto& c : config.dram_input_cores) {
+            auto bank_ids = a.device()->allocator()->get_bank_ids_from_logical_core(config.remote_buffer_type, c);
+            uint32_t bank_id = bank_ids.empty() ? 0 : bank_ids[0];
+            bank_id_by_core[{c.x, c.y}] = bank_id;
         }
-        return tt::tt_metal::CreateCircularBuffer(program, l1_input_core_grid, config);
-    };
+        logical_to_addr_id = [bank_id_by_core = std::move(bank_id_by_core)](const CoreCoord& logical_core) {
+            auto it = bank_id_by_core.find({logical_core.x, logical_core.y});
+            uint32_t bank_id = (it == bank_id_by_core.end()) ? 0 : it->second;
+            return CoreCoord(bank_id, 0);
+        };
+    } else {
+        logical_to_addr_id = [&a](const CoreCoord& logical_core) {
+            return a.device()->worker_core_from_logical_core(logical_core);
+        };
+    }
 
-    const tt::DataFormat intermediary_format = tt::DataFormat::Float16_b;
-    const uint32_t intermediary_tile_size = tt::tile_size(intermediary_format);
+    // Serialize blocked transfer groups for each core
+    auto per_core_serialized_transfers =
+        detail::serialize_transfers_per_core(grouping.per_core_groups, in_cores, logical_to_addr_id);
 
-    const uint32_t cb_in_id = tt::CBIndex::c_0;
-    const tt::DataFormat input_format = tt::tt_metal::datatype_to_dataformat_converter(a.dtype());
-    const uint32_t input_element_size = tt::datum_size(input_format);
-    const uint32_t cb_in_page_size = l1_input_shard_width * input_element_size;
-    const uint32_t cb_in_total_size = l1_input_shard_height * cb_in_page_size;
-    const auto cb_in = create_circular_buffer(
-        cb_in_id, cb_in_total_size, cb_in_page_size, input_format, is_input_in_dram ? nullptr : a.buffer());
+    // Compute per-core tiling/state based on the chosen block width
+    const detail::BlockTilingParams tiling = detail::compute_block_tiling_params(config, block_width, num_blocks);
 
-    const uint32_t cb_in_tiled_id = tt::CBIndex::c_1;
-    const uint32_t cb_in_tiled_total_size = tt::div_up(l1_input_shard_width, TILE_WIDTH) * intermediary_tile_size;
-    const uint32_t cb_in_tiled_page_size = intermediary_tile_size;
-    create_circular_buffer(cb_in_tiled_id, cb_in_tiled_total_size, cb_in_tiled_page_size, intermediary_format);
+    // Split tiles within each block between the two writers
+    const uint32_t tiles_per_block_writer0 = tiling.tiles_per_block_writer0;
+    const uint32_t tiles_per_block_writer1 = tiling.tiles_per_block_writer1;
 
-    const uint32_t cb_in_transpose_total_size = tt::div_up(l1_input_shard_width, TILE_WIDTH) * intermediary_tile_size;
-    const uint32_t cb_in_transpose_page_size = intermediary_tile_size;
+    // Ensure tiles divide evenly across blocks
+    TT_FATAL(
+        tiling.total_tiles_per_core % num_blocks == 0,
+        "total_tiles_per_core={} must be divisible by num_blocks={}",
+        tiling.total_tiles_per_core,
+        num_blocks);
+    auto writer_compile_time_args0 = detail::make_writer_compile_args(
+        /*is_reader=*/true,
+        detail::CBIndex::CB_IN_TRANSPOSE_0,
+        config,
+        tiling,
+        tiles_per_block_writer0,
+        /*initial_write_stick_offset=*/0,
+        num_blocks);
 
-    const uint32_t cb_in_transpose_id0 = tt::CBIndex::c_2;
-    create_circular_buffer(
-        cb_in_transpose_id0, cb_in_transpose_total_size, cb_in_transpose_page_size, intermediary_format);
+    auto writer_compile_time_args1 = detail::make_writer_compile_args(
+        /*is_reader=*/false,
+        detail::CBIndex::CB_IN_TRANSPOSE_1,
+        config,
+        tiling,
+        tiles_per_block_writer1,
+        /*initial_write_stick_offset=*/tt::constants::TILE_WIDTH,
+        num_blocks);
 
-    const uint32_t cb_in_transpose_id1 = tt::CBIndex::c_3;
-    create_circular_buffer(
-        cb_in_transpose_id1, cb_in_transpose_total_size, cb_in_transpose_page_size, intermediary_format);
-
-    const uint32_t cb_out_id = tt::CBIndex::c_4;
-    const tt::DataFormat output_format = input_format;
-    const uint32_t cb_out_total_size = cb_in_total_size;  // same size as input
-    const uint32_t cb_out_page_size = l1_input_shard_height * input_element_size;
-    const auto cb_out =
-        create_circular_buffer(cb_out_id, cb_out_total_size, cb_out_page_size, output_format, output.buffer());
-
-    const uint32_t total_tiles_per_core = tt::div_up(l1_input_shard_width, TILE_HEIGHT);
-    const uint32_t total_tiles_writer0 = tt::div_up(total_tiles_per_core, 2);
-    const uint32_t total_tiles_writer1 = total_tiles_per_core - total_tiles_writer0;
-    uint32_t output_stride_sticks = TILE_WIDTH;  // needed to stride output address when doing split writers
-
-    const auto dram_input_cores = corerange_to_cores(
-        a.shard_spec()->grid, std::nullopt, a.shard_spec()->orientation == tt::tt_metal::ShardOrientation::ROW_MAJOR);
-    const auto remote_core_type = a.buffer()->core_type();
-    const auto remote_address = a.buffer()->address();
-    const auto remote_buffer_type = a.buffer()->buffer_type();
-    const auto [runtime_args_for_each_core, _, dram_write_stride_bytes, dram_read_stride_bytes] =
-        data_movement::detail::compute_width_sharding_reshard_segments(
-            {l1_input_shard_height, l1_input_shard_width},
-            a.shard_spec()->shape,  // dram shard shape
-            l1_input_cores,
-            dram_input_cores,
-            remote_buffer_type,
-            remote_core_type,
-            a.device(),
-            2);
-
-    // Split DRAM read across each kernel along tensor height since this is the best way to split work evenly
-    const uint32_t total_num_sticks_kernel_0 = l1_input_shard_height / 2;
-    const uint32_t total_num_sticks_kernel_1 = l1_input_shard_height - total_num_sticks_kernel_0;
-
-    std::vector<uint32_t> writer_compile_time_args0 = {
-        cb_in_id,
-        cb_in_transpose_id0,
-        cb_out_id,
-        output_shard_width,   // output channels
-        output_shard_height,  // output hw
-        total_tiles_writer0,
-        output_stride_sticks,
-        0,
-        input_element_size,
-        is_input_in_dram,
-        true,
-        dram_write_stride_bytes,
-        dram_read_stride_bytes,
-        total_num_sticks_kernel_0};
-
-    std::vector<uint32_t> writer_compile_time_args1 = {
-        cb_in_id,
-        cb_in_transpose_id1,
-        cb_out_id,
-        output_shard_width,   // output channels
-        output_shard_height,  // output hw
-        total_tiles_writer1,
-        output_stride_sticks,
-        output_stride_sticks,
-        input_element_size,
-        is_input_in_dram,
-        false,
-        dram_write_stride_bytes,
-        dram_read_stride_bytes,
-        total_num_sticks_kernel_1};
-
-    std::vector<uint32_t> compute_compile_time_args = {
-        cb_in_id,
-        cb_in_tiled_id,
-        cb_in_transpose_id0,
-        cb_in_transpose_id1,
-        total_tiles_per_core,
-        l1_input_shard_height,
-        is_input_in_dram};
+    auto compute_compile_time_args = detail::make_compute_compile_args(
+        tiling.total_tiles_per_block, config.gather_l1_output_shard_height, num_blocks);
 
     auto writer_kernel_id0 = tt::tt_metal::CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/kernels/writer_convert_to_hwc.cpp",
-        l1_input_core_grid,
+        config.output_core_grid,
         tt::tt_metal::ReaderDataMovementConfig(writer_compile_time_args0));
 
     auto writer_kernel_id1 = tt::tt_metal::CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/kernels/writer_convert_to_hwc.cpp",
-        l1_input_core_grid,
+        config.output_core_grid,
         tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args1));
 
     tt::tt_metal::CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/kernels/convert_to_hwc.cpp",
-        l1_input_core_grid,
+        config.output_core_grid,
         tt::tt_metal::ComputeConfig{
             .math_fidelity = MathFidelity::HiFi4,
             .fp32_dest_acc_en = false,
@@ -252,32 +503,25 @@ ConvertToHWCProgramFactory::cached_program_t ConvertToHWCProgramFactory::create(
         program,
         a,
         output,
-        is_input_in_dram,
-        l1_input_cores,
-        runtime_args_for_each_core,
+        config.is_input_in_dram,
+        config.output_cores,
+        per_core_serialized_transfers,
         writer_kernel_id0,
         writer_kernel_id1,
-        total_num_sticks_kernel_0,
-        dram_read_stride_bytes,
-        dram_write_stride_bytes,
-        remote_address,
-        cb_in,
-        cb_out);
+        config.remote_address,
+        cb_handles.cb_in,
+        cb_handles.cb_out);
 
-    // Store shared variables
+    // Store shared variables for override
     shared_variables_t shared_variables{
-        .cb_in = cb_in,
-        .cb_out = cb_out,
-        .is_input_in_dram = is_input_in_dram,
-        .l1_input_cores = l1_input_cores,
-        .runtime_args_for_each_core = runtime_args_for_each_core,
+        .cb_in = cb_handles.cb_in,
+        .cb_out = cb_handles.cb_out,
+        .is_input_in_dram = config.is_input_in_dram,
+        .output_cores = config.output_cores,
+        .per_core_serialized_transfers = per_core_serialized_transfers,
         .writer_kernel_id0 = writer_kernel_id0,
         .writer_kernel_id1 = writer_kernel_id1,
-        .total_num_sticks_kernel_0 = total_num_sticks_kernel_0,
-        .total_num_sticks_kernel_1 = total_num_sticks_kernel_1,
-        .dram_read_stride_bytes = dram_read_stride_bytes,
-        .dram_write_stride_bytes = dram_write_stride_bytes,
-        .remote_address = remote_address};
+        .remote_address = config.remote_address};
 
     return {std::move(program), std::move(shared_variables)};
 }
@@ -297,13 +541,10 @@ void ConvertToHWCProgramFactory::override_runtime_arguments(
         a,
         output,
         shared_vars.is_input_in_dram,
-        shared_vars.l1_input_cores,
-        shared_vars.runtime_args_for_each_core,
+        shared_vars.output_cores,
+        shared_vars.per_core_serialized_transfers,
         shared_vars.writer_kernel_id0,
         shared_vars.writer_kernel_id1,
-        shared_vars.total_num_sticks_kernel_0,
-        shared_vars.dram_read_stride_bytes,
-        shared_vars.dram_write_stride_bytes,
         shared_vars.remote_address,
         shared_vars.cb_in,
         shared_vars.cb_out);

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/convert_to_hwc_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/convert_to_hwc_program_factory.hpp
@@ -15,15 +15,12 @@ struct ConvertToHWCSharedVariables {
     tt::tt_metal::CBHandle cb_in{};
     tt::tt_metal::CBHandle cb_out{};
     bool is_input_in_dram = false;
-    std::vector<tt::tt_metal::CoreCoord> l1_input_cores;
-    std::vector<std::vector<ttnn::operations::data_movement::detail::WidthShardingReshardSegment>>
-        runtime_args_for_each_core;
+    // Destination/output cores where kernels execute
+    std::vector<tt::tt_metal::CoreCoord> output_cores;
+    // Serialized per-core runtime args for gather-based writer kernels
+    std::vector<std::vector<uint32_t>> per_core_serialized_transfers;
     tt::tt_metal::KernelHandle writer_kernel_id0{};
     tt::tt_metal::KernelHandle writer_kernel_id1{};
-    uint32_t total_num_sticks_kernel_0 = 0;
-    uint32_t total_num_sticks_kernel_1 = 0;
-    uint32_t dram_read_stride_bytes = 0;
-    uint32_t dram_write_stride_bytes = 0;
     uint32_t remote_address = 0;
 };
 
@@ -46,6 +43,67 @@ struct ConvertToHWCProgramFactory {
 }  // namespace ttnn::operations::experimental::cnn::program
 
 namespace ttnn::operations::experimental::cnn::detail {
+
+// Named constants for circular buffer indices
+namespace CBIndex {
+constexpr uint32_t CB_IN = tt::CBIndex::c_0;
+constexpr uint32_t CB_IN_BATCH = tt::CBIndex::c_1;
+constexpr uint32_t CB_IN_TILED = tt::CBIndex::c_2;
+constexpr uint32_t CB_IN_TRANSPOSE_0 = tt::CBIndex::c_3;
+constexpr uint32_t CB_IN_TRANSPOSE_1 = tt::CBIndex::c_4;
+constexpr uint32_t CB_OUT = tt::CBIndex::c_5;
+}  // namespace CBIndex
+
+// Configuration class to encapsulate operation parameters
+struct ConvertToHwcConfig {
+    // Input tensor properties
+    uint32_t batch_size;
+    uint32_t input_channels;
+    uint32_t hw_total;
+    uint32_t element_size_bytes;
+    tt::DataFormat input_format;
+
+    // Shard specifications
+    uint32_t l1_input_shard_height;
+    uint32_t l1_input_shard_width;
+    uint32_t output_shard_height;
+    uint32_t output_shard_width;
+
+    // Gather output shard specifications for CB_IN_BATCH and transfer calculations
+    uint32_t gather_l1_output_shard_height;
+    uint32_t gather_l1_output_shard_width;
+
+    // Core information
+    std::vector<CoreCoord> l1_input_cores;
+    std::vector<CoreCoord> dram_input_cores;
+    CoreRangeSet l1_input_core_grid;
+    std::vector<CoreCoord> output_cores;
+    CoreRangeSet output_core_grid;
+
+    // DRAM/L1 configuration
+    bool is_input_in_dram;
+    uint32_t remote_address;
+    tt::tt_metal::BufferType remote_buffer_type;
+    tt::CoreType remote_core_type;
+
+    // Alignment requirements
+    uint32_t alignment_elements;
+
+    static ConvertToHwcConfig create_from_tensors(const Tensor& input, const Tensor& output);
+    void validate() const;
+};
+
+struct BatchTransferInstruction {
+    uint32_t src_core_idx;
+    uint32_t dst_core_idx;
+    CoreCoord src_core_coord;
+    CoreCoord dst_core_coord;
+    uint32_t src_offset;
+    uint32_t dst_offset;
+    uint32_t transfer_size;
+    uint32_t bank_id;  // 0 for L1 transfers, actual bank_id for DRAM transfers
+};
+
 
 uint32_t compute_alignment_requirement_in_elements(const Tensor& input_tensor);
 

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/convert_to_hwc_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/convert_to_hwc_program_factory.hpp
@@ -57,21 +57,21 @@ constexpr uint32_t CB_OUT = tt::CBIndex::c_5;
 // Configuration class to encapsulate operation parameters
 struct ConvertToHwcConfig {
     // Input tensor properties
-    uint32_t batch_size;
-    uint32_t input_channels;
-    uint32_t hw_total;
-    uint32_t element_size_bytes;
-    tt::DataFormat input_format;
+    uint32_t batch_size{};
+    uint32_t input_channels{};
+    uint32_t hw_total{};
+    uint32_t element_size_bytes{};
+    tt::DataFormat input_format{};
 
     // Shard specifications
-    uint32_t l1_input_shard_height;
-    uint32_t l1_input_shard_width;
-    uint32_t output_shard_height;
-    uint32_t output_shard_width;
+    uint32_t l1_input_shard_height{};
+    uint32_t l1_input_shard_width{};
+    uint32_t output_shard_height{};
+    uint32_t output_shard_width{};
 
     // Gather output shard specifications for CB_IN_BATCH and transfer calculations
-    uint32_t gather_l1_output_shard_height;
-    uint32_t gather_l1_output_shard_width;
+    uint32_t gather_l1_output_shard_height{};
+    uint32_t gather_l1_output_shard_width{};
 
     // Core information
     std::vector<CoreCoord> l1_input_cores;
@@ -81,29 +81,17 @@ struct ConvertToHwcConfig {
     CoreRangeSet output_core_grid;
 
     // DRAM/L1 configuration
-    bool is_input_in_dram;
-    uint32_t remote_address;
-    tt::tt_metal::BufferType remote_buffer_type;
-    tt::CoreType remote_core_type;
+    bool is_input_in_dram{};
+    uint32_t remote_address{};
+    tt::tt_metal::BufferType remote_buffer_type{};
+    tt::CoreType remote_core_type{};
 
     // Alignment requirements
-    uint32_t alignment_elements;
+    uint32_t alignment_elements{};
 
     static ConvertToHwcConfig create_from_tensors(const Tensor& input, const Tensor& output);
     void validate() const;
 };
-
-struct BatchTransferInstruction {
-    uint32_t src_core_idx;
-    uint32_t dst_core_idx;
-    CoreCoord src_core_coord;
-    CoreCoord dst_core_coord;
-    uint32_t src_offset;
-    uint32_t dst_offset;
-    uint32_t transfer_size;
-    uint32_t bank_id;  // 0 for L1 transfers, actual bank_id for DRAM transfers
-};
-
 
 uint32_t compute_alignment_requirement_in_elements(const Tensor& input_tensor);
 

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/gather.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/gather.cpp
@@ -1,0 +1,512 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Gather planning utilities for converting [B, C, HW] -> [C, B, HW].
+ */
+
+#include "gather.hpp"
+#include <tt-metalium/host_api.hpp>
+#include <algorithm>
+#include <cstring>
+#include "ttnn/operations/data_movement/sharded/sharded_common.hpp"
+
+namespace ttnn::operations::experimental::cnn::convert_to_hwc::detail {
+
+namespace {
+
+// Try to extend the last transfer if it is adjacent and compatible; otherwise append a new one
+inline void append_or_extend_transfer(
+    std::vector<GatherTransfer>& transfers,
+    uint32_t input_core_idx,
+    uint32_t output_core_idx,
+    const std::vector<CoreCoord>& input_cores,
+    const std::vector<CoreCoord>& output_cores,
+    uint32_t input_offset_within_shard,
+    uint32_t output_offset_within_shard,
+    uint32_t channel,
+    uint32_t batch) {
+    if (!transfers.empty()) {
+        auto& last = transfers.back();
+        const bool compatible = last.src_core_idx == input_core_idx && last.dst_core_idx == output_core_idx &&
+                                last.channel == channel && last.batch == batch &&
+                                last.src_offset + last.length == input_offset_within_shard &&
+                                last.dst_offset + last.length == output_offset_within_shard;
+        if (compatible) {
+            last.length += 1;
+            return;
+        }
+    }
+
+    transfers.emplace_back(
+        input_core_idx,
+        output_core_idx,
+        input_cores[input_core_idx],
+        output_cores[output_core_idx],
+        input_offset_within_shard,
+        output_offset_within_shard,
+        1,
+        channel,
+        batch);
+}
+
+// Shared implementation for gather transfer generation.
+// If output_shard_width_override is provided, it is used verbatim; otherwise ceil(B*HW/num_output_cores).
+std::vector<GatherTransfer> generate_gather_transfers(
+    uint32_t B,
+    uint32_t C,
+    uint32_t HW,
+    const std::vector<CoreCoord>& input_cores,
+    const std::vector<CoreCoord>& output_cores,
+    std::optional<uint32_t> output_shard_width_override) {
+    std::vector<GatherTransfer> transfers;
+    const uint32_t num_input_cores = input_cores.size();
+    const uint32_t num_output_cores = output_cores.size();
+
+    TT_FATAL(HW % num_input_cores == 0, "HW={} must be divisible by num_input_cores={}", HW, num_input_cores);
+
+    const uint32_t input_shard_width = HW / num_input_cores;
+    const uint32_t output_shard_width = output_shard_width_override.has_value()
+                                            ? output_shard_width_override.value()
+                                            : (B * HW + num_output_cores - 1) / num_output_cores;
+    if (output_shard_width_override.has_value()) {
+        TT_FATAL(output_shard_width != 0, "output_shard_width_override must be non-zero");
+    }
+
+    // Iterate in destination order for better coalescing: rows=c, cols=b*HW + hw
+    for (uint32_t c = 0; c < C; c++) {
+        for (uint32_t b = 0; b < B; b++) {
+            for (uint32_t hw = 0; hw < HW; hw++) {
+                const uint32_t input_col = hw;
+                const uint32_t input_core_idx = input_col / input_shard_width;
+                const uint32_t input_offset_within_shard = input_col % input_shard_width;
+
+                const uint32_t output_col = (b * HW) + hw;
+                const uint32_t output_core_idx = output_col / output_shard_width;
+                const uint32_t output_offset_within_shard = output_col % output_shard_width;
+
+                append_or_extend_transfer(
+                    transfers,
+                    input_core_idx,
+                    output_core_idx,
+                    input_cores,
+                    output_cores,
+                    input_offset_within_shard,
+                    output_offset_within_shard,
+                    c,
+                    b);
+            }
+        }
+    }
+
+    // Sort by (src_core, src_row=b*C+c, src_offset)
+    std::sort(transfers.begin(), transfers.end(), [C](const GatherTransfer& a, const GatherTransfer& b) {
+        if (a.src_core_idx != b.src_core_idx) {
+            return a.src_core_idx < b.src_core_idx;
+        }
+        const uint32_t a_row = (a.batch * C) + a.channel;
+        const uint32_t b_row = (b.batch * C) + b.channel;
+        if (a_row != b_row) {
+            return a_row < b_row;
+        }
+        return a.src_offset < b.src_offset;
+    });
+
+    return transfers;
+}
+
+// Compute the inclusive block range touched by a segment [start_col, start_col+length)
+inline std::pair<uint32_t, uint32_t> compute_block_span(uint32_t start_col, uint32_t length, uint32_t block_size) {
+    const uint32_t end_col = start_col + length - 1;
+    const uint32_t start_block = start_col / block_size;
+    const uint32_t end_block = end_col / block_size;
+    return {start_block, end_block};
+}
+
+}  // namespace
+
+/**
+ * Precompute all transfers needed for the gather operation
+ *
+ * This function analyzes the data movement pattern and generates an explicit
+ * list of all transfers required.
+
+ * - Converts logical layout [B, C, HW] to [C, B, HW]
+ * - Input is width-sharded across the HW dimension: [B*C, HW/num_input_cores]
+ * - Output is height-sharded across the B*HW dimension: [C, B*HW/num_output_cores]
+ */
+std::vector<GatherTransfer> precompute_gather_transfers(
+    uint32_t B,
+    uint32_t C,
+    uint32_t HW,
+    const std::vector<CoreCoord>& input_cores,
+    const std::vector<CoreCoord>& output_cores) {
+    return generate_gather_transfers(B, C, HW, input_cores, output_cores, std::nullopt);
+}
+
+// Variant with explicit output shard width override
+std::vector<GatherTransfer> precompute_gather_transfers(
+    uint32_t B,
+    uint32_t C,
+    uint32_t HW,
+    const std::vector<CoreCoord>& input_cores,
+    const std::vector<CoreCoord>& output_cores,
+    uint32_t output_shard_width_override) {
+    return generate_gather_transfers(
+        B, C, HW, input_cores, output_cores, std::optional<uint32_t>(output_shard_width_override));
+}
+
+std::vector<LowLevelGatherTransfer> lower_gather_transfers(
+    const std::vector<GatherTransfer>& transfers,
+    uint32_t B,
+    uint32_t C,
+    uint32_t HW,
+    const std::vector<CoreCoord>& input_cores,
+    uint32_t num_output_cores,
+    uint32_t element_size_bytes,
+    uint32_t output_shard_width) {
+    std::vector<LowLevelGatherTransfer> low_level_transfers;
+
+    const uint32_t num_input_cores = input_cores.size();
+
+    // Calculate shard dimensions
+    const uint32_t input_shard_width = HW / num_input_cores;
+    // Always require explicit output shard width for consistent offsets
+    TT_FATAL(output_shard_width != 0, "Output shard width must be provided");
+
+    for (const auto& t : transfers) {
+        // Calculate absolute offset in source shard
+        // Input shard layout: [B*C, HW/num_input_cores] in row-major order
+        uint32_t src_row = (t.batch * C) + t.channel;
+        uint32_t src_absolute_offset = (src_row * input_shard_width) + t.src_offset;
+
+        // Calculate absolute offset in destination shard
+        // Output shard layout: [C, B*HW/num_output_cores] in row-major order
+        uint32_t dst_row = t.channel;
+        uint32_t dst_absolute_offset = (dst_row * output_shard_width) + t.dst_offset;
+
+        // Extract NOC coordinates from source core
+        uint32_t src_noc_x = input_cores[t.src_core_idx].x;
+        uint32_t src_noc_y = input_cores[t.src_core_idx].y;
+
+        // Convert element offsets to byte offsets
+        uint32_t src_offset_bytes = src_absolute_offset * element_size_bytes;
+        uint32_t dst_offset_bytes = dst_absolute_offset * element_size_bytes;
+        uint32_t transfer_size_bytes = t.length * element_size_bytes;
+
+        low_level_transfers.emplace_back(
+            t.src_core_idx,
+            src_absolute_offset,
+            t.dst_core_idx,
+            dst_absolute_offset,
+            t.length,
+            src_noc_x,
+            src_noc_y,
+            src_offset_bytes,
+            dst_offset_bytes,
+            transfer_size_bytes);
+    }
+
+    return low_level_transfers;
+}
+
+BlockedTransfersWithCount group_transfers_by_output_column_blocks(
+    const std::vector<GatherTransfer>& transfers,
+    uint32_t B,
+    uint32_t C,
+    uint32_t HW,
+    const std::vector<CoreCoord>& input_cores,
+    uint32_t num_output_cores,
+    uint32_t element_size_bytes,
+    uint32_t block_size,
+    uint32_t output_shard_width) {
+    // Dictionary to group transfers by (dst_shard_idx, column_block_idx)
+    std::map<std::pair<uint32_t, uint32_t>, std::vector<LowLevelGatherTransfer>> groups;
+
+    // Lower transfers to get flat offsets
+    auto low_level_transfers = lower_gather_transfers(
+        transfers, B, C, HW, input_cores, num_output_cores, element_size_bytes, output_shard_width);
+
+    // Group transfers by which column blocks they write to
+    for (size_t i = 0; i < transfers.size(); i++) {
+        const auto& transfer = transfers[i];
+        const auto& low_level = low_level_transfers[i];
+
+        const uint32_t start_col = transfer.dst_offset;
+        auto [start_block, end_block] = compute_block_span(start_col, transfer.length, block_size);
+
+        // Add this transfer to all column blocks it touches
+        for (uint32_t block_idx = start_block; block_idx <= end_block; block_idx++) {
+            auto key = std::make_pair(transfer.dst_core_idx, block_idx);
+            groups[key].push_back(low_level);
+        }
+    }
+
+    // Convert to vector of BlockedTransferGroup
+    std::vector<BlockedTransferGroup> blocked_groups;
+    for (const auto& [key, transfers_list] : groups) {
+        BlockedTransferGroup group(key.first, key.second, block_size);
+        group.transfers = transfers_list;
+        blocked_groups.push_back(std::move(group));
+    }
+
+    // Sort by destination shard and block index
+    std::sort(
+        blocked_groups.begin(), blocked_groups.end(), [](const BlockedTransferGroup& a, const BlockedTransferGroup& b) {
+            if (a.dst_shard_idx != b.dst_shard_idx) {
+                return a.dst_shard_idx < b.dst_shard_idx;
+            }
+            return a.dst_block_idx < b.dst_block_idx;
+        });
+
+    // Count unique column block indices to determine actual number of logical blocks
+    std::set<uint32_t> unique_block_indices;
+    for (const auto& group : blocked_groups) {
+        unique_block_indices.insert(group.dst_block_idx);
+    }
+
+    log_debug(
+        tt::LogType::LogOp,
+        "group_transfers_by_output_column_blocks: {} transfer groups, {} logical blocks",
+        blocked_groups.size(),
+        unique_block_indices.size());
+
+    return {std::move(blocked_groups), static_cast<uint32_t>(unique_block_indices.size())};
+}
+
+std::vector<BlockedTransferGroup> coalesce_contiguous_transfers(
+    const std::vector<BlockedTransferGroup>& blocked_groups) {
+    std::vector<BlockedTransferGroup> optimized_groups;
+    optimized_groups.reserve(blocked_groups.size());
+
+    for (const auto& group : blocked_groups) {
+        if (group.transfers.empty()) {
+            optimized_groups.push_back(group);
+            continue;
+        }
+
+        // Create a new group with the same metadata
+        BlockedTransferGroup optimized_group(group.dst_shard_idx, group.dst_block_idx, group.block_size);
+
+        // Sort transfers by (src_shard_idx, src_offset_bytes, dst_offset_bytes) for coalescing
+        auto sorted_transfers = group.transfers;
+        std::sort(
+            sorted_transfers.begin(),
+            sorted_transfers.end(),
+            [](const LowLevelGatherTransfer& a, const LowLevelGatherTransfer& b) {
+                if (a.src_shard_idx != b.src_shard_idx) {
+                    return a.src_shard_idx < b.src_shard_idx;
+                }
+                if (a.src_offset_bytes != b.src_offset_bytes) {
+                    return a.src_offset_bytes < b.src_offset_bytes;
+                }
+                return a.dst_offset_bytes < b.dst_offset_bytes;
+            });
+
+        // Coalesce contiguous transfers
+        for (size_t i = 0; i < sorted_transfers.size();) {
+            auto current_transfer = sorted_transfers[i];
+            size_t j = i + 1;
+
+            // Traditional contiguous coalescing only
+            while (j < sorted_transfers.size()) {
+                const auto& next_transfer = sorted_transfers[j];
+
+                bool same_core = (current_transfer.src_shard_idx == next_transfer.src_shard_idx) &&
+                                 (current_transfer.src_noc_x == next_transfer.src_noc_x) &&
+                                 (current_transfer.src_noc_y == next_transfer.src_noc_y);
+                bool src_contiguous =
+                    (current_transfer.src_offset_bytes + current_transfer.transfer_size_bytes ==
+                     next_transfer.src_offset_bytes);
+                bool dst_contiguous =
+                    (current_transfer.dst_offset_bytes + current_transfer.transfer_size_bytes ==
+                     next_transfer.dst_offset_bytes);
+
+                if (same_core && src_contiguous && dst_contiguous) {
+                    // Traditional contiguous coalescing
+                    current_transfer.transfer_size_bytes += next_transfer.transfer_size_bytes;
+                    current_transfer.length += next_transfer.length;
+                    j++;
+                } else {
+                    break;
+                }
+            }
+
+            // Add the (possibly coalesced) transfer
+            optimized_group.transfers.push_back(current_transfer);
+            i = j;
+        }
+
+        // Log the optimization results
+        if (optimized_group.transfers.size() != group.transfers.size()) {
+            log_debug(
+                tt::LogType::LogOp,
+                "Coalesced block[{}:{}]: {} transfers -> {} transfers (saved {} NOC ops)",
+                group.dst_shard_idx,
+                group.dst_block_idx,
+                group.transfers.size(),
+                optimized_group.transfers.size(),
+                group.transfers.size() - optimized_group.transfers.size());
+        }
+
+        optimized_groups.push_back(std::move(optimized_group));
+    }
+
+    return optimized_groups;
+}
+
+std::vector<GatherTransfer> precompute_gather_transfers(
+    const Tensor& input, const std::vector<CoreCoord>& output_cores) {
+    // Extract tensor properties
+    const auto& input_shape = input.logical_shape();
+    uint32_t B = input_shape[1];   // Batch size
+    uint32_t C = input_shape[2];   // Channels
+    uint32_t HW = input_shape[3];  // Spatial dimension
+
+    // Get input core coordinates from tensor's shard spec
+    TT_FATAL(input.is_sharded(), "Input tensor must be sharded for gather operation");
+
+    const auto& shard_spec = input.shard_spec().value();
+    const auto& core_grid = shard_spec.grid;
+    std::vector<CoreCoord> input_cores = corerange_to_cores(
+        core_grid, std::nullopt, shard_spec.orientation == tt::tt_metal::ShardOrientation::ROW_MAJOR);
+
+    // Call the original implementation
+    return precompute_gather_transfers(B, C, HW, input_cores, output_cores);
+}
+
+std::vector<BlockedTransferGroup> group_transfers_by_output_column_blocks(
+    const Tensor& input, const Tensor& output, const std::vector<GatherTransfer>& transfers, uint32_t block_size) {
+    // Extract tensor properties
+    const auto& input_shape = input.logical_shape();
+    uint32_t B = input_shape[1];
+    uint32_t C = input_shape[2];
+    uint32_t HW = input_shape[3];
+
+    // Ensure both tensors are sharded
+    TT_FATAL(input.is_sharded(), "Input tensor must be sharded for gather operation");
+    TT_FATAL(output.is_sharded(), "Output tensor must be sharded for gather operation");
+
+    // Get element size in bytes from tensor data type
+    uint32_t element_size_bytes = input.element_size();
+
+    // Get core coordinates from tensors
+    const auto& input_shard_spec = input.shard_spec().value();
+    const auto& input_core_grid = input_shard_spec.grid;
+    auto input_cores_vec = corerange_to_cores(
+        input_core_grid, std::nullopt, input_shard_spec.orientation == tt::tt_metal::ShardOrientation::ROW_MAJOR);
+
+    const auto& output_shard_spec = output.shard_spec().value();
+    const auto& output_core_grid = output_shard_spec.grid;
+    auto output_cores_vec = corerange_to_cores(
+        output_core_grid, std::nullopt, output_shard_spec.orientation == tt::tt_metal::ShardOrientation::ROW_MAJOR);
+    uint32_t num_output_cores = output_cores_vec.size();
+    // Compute per-core output row width (number of columns in each [C x (B*HW_per_core)] shard)
+    TT_FATAL(output.is_sharded(), "Output tensor must be sharded for gather operation");
+    const auto& output_shard_spec2 = output.shard_spec().value();
+    uint32_t output_shard_width =
+        static_cast<uint32_t>(output_shard_spec2.shape[0]);  // columns per output core = B*HW_per_core
+
+    // Call the unified implementation and return only the blocked transfers
+    auto result = group_transfers_by_output_column_blocks(
+        transfers, B, C, HW, input_cores_vec, num_output_cores, element_size_bytes, block_size, output_shard_width);
+    return result.blocked_transfers;
+}
+
+/**
+ * @brief Split blocked transfer groups by destination core for per-core processing
+ *
+ * This function reorganizes BlockedTransferGroup objects by their destination core index,
+ * creating a vector of vectors where each index corresponds to an output core and contains
+ * all the BlockedTransferGroup objects that write to that core.
+ */
+std::vector<std::vector<BlockedTransferGroup>> split_by_destination_core(
+    const std::vector<BlockedTransferGroup>& blocked_groups, uint32_t num_output_cores) {
+    // Initialize result with empty vectors for each output core
+    std::vector<std::vector<BlockedTransferGroup>> result(num_output_cores);
+
+    // Distribute each BlockedTransferGroup to the appropriate core's vector
+    for (const auto& group : blocked_groups) {
+        uint32_t dst_core_idx = group.dst_shard_idx;
+
+        // Validate core index bounds
+        TT_FATAL(
+            dst_core_idx < num_output_cores,
+            "Destination core index {} is out of bounds (num_output_cores={})",
+            dst_core_idx,
+            num_output_cores);
+
+        result[dst_core_idx].push_back(group);
+    }
+
+    return result;
+}
+
+}  // namespace ttnn::operations::experimental::cnn::convert_to_hwc::detail
+
+// fmt formatter implementations
+namespace fmt {
+
+auto formatter<ttnn::operations::experimental::cnn::convert_to_hwc::detail::GatherTransfer>::format(
+    const ttnn::operations::experimental::cnn::convert_to_hwc::detail::GatherTransfer& t, format_context& ctx) const
+    -> format_context::iterator {
+    std::string str = fmt::format(
+        "GatherTransfer(B={}, C={}: Core{}[{},{}][row={}·C+{}, cols={}:{}] → Core{}[{},{}][row={}, cols={}:{}], "
+        "len={})",
+        t.batch,
+        t.channel,
+        t.src_core_idx,
+        t.src_core_coord.x,
+        t.src_core_coord.y,
+        t.batch,
+        t.channel,
+        t.src_offset,
+        t.src_offset + t.length,
+        t.dst_core_idx,
+        t.dst_core_coord.x,
+        t.dst_core_coord.y,
+        t.channel,
+        t.dst_offset,
+        t.dst_offset + t.length,
+        t.length);
+    return fmt::format_to(ctx.out(), "{}", str);
+}
+
+auto formatter<ttnn::operations::experimental::cnn::convert_to_hwc::detail::LowLevelGatherTransfer>::format(
+    const ttnn::operations::experimental::cnn::convert_to_hwc::detail::LowLevelGatherTransfer& t,
+    format_context& ctx) const -> format_context::iterator {
+    std::string str = fmt::format(
+        "LowLevelGatherTransfer(src_shard{}[{}:{}] (offset={} B) @ NOC({},{}) => dst_shard{}[{}:{}] (offset={} B), "
+        "len={}, size={} B)",
+        t.src_shard_idx,
+        t.src_offset,
+        t.src_offset + t.length,
+        t.src_offset_bytes,
+        t.src_noc_x,
+        t.src_noc_y,
+        t.dst_shard_idx,
+        t.dst_offset,
+        t.dst_offset + t.length,
+        t.dst_offset_bytes,
+        t.length,
+        t.transfer_size_bytes);
+    return fmt::format_to(ctx.out(), "{}", str);
+}
+
+auto formatter<ttnn::operations::experimental::cnn::convert_to_hwc::detail::BlockedTransferGroup>::format(
+    const ttnn::operations::experimental::cnn::convert_to_hwc::detail::BlockedTransferGroup& t,
+    format_context& ctx) const -> format_context::iterator {
+    uint32_t col_start = t.dst_block_idx * t.block_size;
+    uint32_t col_end = col_start + t.block_size;
+
+    std::string str = fmt::format(
+        "BlockedTransferGroup(shard={}, cols=[{}:{}], {} transfers)",
+        t.dst_shard_idx,
+        col_start,
+        col_end,
+        t.transfers.size());
+    return fmt::format_to(ctx.out(), "{}", str);
+}
+
+}  // namespace fmt

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/gather.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/gather.hpp
@@ -8,6 +8,7 @@
 #include <functional>
 #include <tt-metalium/core_coord.hpp>
 #include "ttnn/tensor/types.hpp"
+#include "ttnn/tensor/tensor.hpp"
 
 namespace ttnn::operations::experimental::cnn::convert_to_hwc::detail {
 
@@ -290,11 +291,11 @@ inline uint32_t elements_to_bytes(uint32_t element_count, uint32_t element_size)
     return element_count * element_size;
 }
 
-void serialize_low_level_transfer(
+inline void serialize_low_level_transfer(
     const LowLevelGatherTransfer& transfer,
     std::vector<uint32_t>& output,
     const std::vector<CoreCoord>& input_cores,
-    std::function<CoreCoord(const CoreCoord&)> logical_to_worker_core) {
+    const std::function<CoreCoord(const CoreCoord&)>& logical_to_worker_core) {
     // Convert logical core coordinates to worker core coordinates
     CoreCoord logical_core = input_cores[transfer.src_shard_idx];
     auto worker_core = logical_to_worker_core(logical_core);
@@ -310,10 +311,10 @@ void serialize_low_level_transfer(
     output.push_back(worker_core.x);
 }
 
-std::vector<uint32_t> serialize_blocked_transfer_groups(
+inline std::vector<uint32_t> serialize_blocked_transfer_groups(
     const std::vector<BlockedTransferGroup>& groups,
     const std::vector<CoreCoord>& input_cores,
-    std::function<CoreCoord(const CoreCoord&)> logical_to_worker_core) {
+    const std::function<CoreCoord(const CoreCoord&)>& logical_to_worker_core) {
     std::vector<uint32_t> output;
     const uint32_t number_of_blocks = groups.size();
     output.push_back(number_of_blocks);

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/gather.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/gather.hpp
@@ -1,0 +1,355 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <fmt/core.h>
+#include <functional>
+#include <tt-metalium/core_coord.hpp>
+#include "ttnn/tensor/types.hpp"
+
+namespace ttnn::operations::experimental::cnn::convert_to_hwc::detail {
+
+/**
+ * @brief High-level transfer representation with semantic information
+ *
+ * Represents a data transfer from input core to output core with batch/channel context.
+ * Used during transfer precomputation phase to track data movement patterns.
+ *
+ * Note: All offsets and lengths are in elements, not bytes. The actual
+ * byte size depends on the data type (e.g., 2 bytes for bfloat16, 4 for float32).
+ */
+struct GatherTransfer {
+    uint32_t src_core_idx;
+    uint32_t dst_core_idx;
+    CoreCoord src_core_coord;
+    CoreCoord dst_core_coord;
+    uint32_t src_offset;  // Offset within source shard (in elements)
+    uint32_t dst_offset;  // Offset within destination shard (in elements)
+    uint32_t length;      // Number of elements to transfer
+    uint32_t channel;     // Channel index for this transfer
+    uint32_t batch;       // Batch index for this transfer
+
+    GatherTransfer(
+        uint32_t sc_idx,
+        uint32_t dc_idx,
+        const CoreCoord& sc_coord,
+        const CoreCoord& dc_coord,
+        uint32_t s_off,
+        uint32_t d_off,
+        uint32_t len,
+        uint32_t ch,
+        uint32_t b) :
+        src_core_idx(sc_idx),
+        dst_core_idx(dc_idx),
+        src_core_coord(sc_coord),
+        dst_core_coord(dc_coord),
+        src_offset(s_off),
+        dst_offset(d_off),
+        length(len),
+        channel(ch),
+        batch(b) {}
+};
+
+/**
+ * @brief Low-level transfer representation using absolute offsets
+ *
+ * Suitable for hardware implementation with raw memory addresses.
+ * All offsets are absolute within the flattened shard arrays.
+ */
+struct LowLevelGatherTransfer {
+    uint32_t src_shard_idx;        // Which input shard (0 to num_input_cores-1)
+    uint32_t src_offset;           // Absolute offset within the source shard (in elements)
+    uint32_t dst_shard_idx;        // Which output shard (0 to num_output_cores-1)
+    uint32_t dst_offset;           // Absolute offset within the destination shard (in elements)
+    uint32_t length;               // Number of elements to transfer
+    uint32_t src_noc_x;            // Source NOC X coordinate
+    uint32_t src_noc_y;            // Source NOC Y coordinate
+    uint32_t src_offset_bytes;     // Absolute offset within the source shard (in bytes)
+    uint32_t dst_offset_bytes;     // Absolute offset within the destination shard (in bytes)
+    uint32_t transfer_size_bytes;  // Number of bytes to transfer
+    uint32_t bank_id;              // DRAM bank id (0 for L1)
+
+    LowLevelGatherTransfer(uint32_t ssi, uint32_t so, uint32_t dsi, uint32_t doff, uint32_t len) :
+        src_shard_idx(ssi),
+        src_offset(so),
+        dst_shard_idx(dsi),
+        dst_offset(doff),
+        length(len),
+        src_noc_x(0),
+        src_noc_y(0),
+        src_offset_bytes(0),
+        dst_offset_bytes(0),
+        transfer_size_bytes(0),
+        bank_id(0) {}
+
+    LowLevelGatherTransfer(
+        uint32_t ssi,
+        uint32_t so,
+        uint32_t dsi,
+        uint32_t doff,
+        uint32_t len,
+        uint32_t snx,
+        uint32_t sny,
+        uint32_t sob,
+        uint32_t dob,
+        uint32_t tsb) :
+        src_shard_idx(ssi),
+        src_offset(so),
+        dst_shard_idx(dsi),
+        dst_offset(doff),
+        length(len),
+        src_noc_x(snx),
+        src_noc_y(sny),
+        src_offset_bytes(sob),
+        dst_offset_bytes(dob),
+        transfer_size_bytes(tsb),
+        bank_id(0) {}
+};
+
+/**
+ * @brief Group of transfers that write to the same column block of the output
+ *
+ * All transfers in this group write to columns [block_idx*block_size : (block_idx+1)*block_size].
+ * Used for memory-efficient blocked processing.
+ */
+struct BlockedTransferGroup {
+    uint32_t dst_shard_idx;                         // Which output shard
+    uint32_t dst_block_idx;                         // Which column block (0, 1, 2, ...)
+    uint32_t block_size;                            // Width of the column block
+    std::vector<LowLevelGatherTransfer> transfers;  // All transfers writing to this column block
+
+    BlockedTransferGroup(uint32_t dsi, uint32_t dbi, uint32_t bs) :
+        dst_shard_idx(dsi), dst_block_idx(dbi), block_size(bs) {}
+};
+
+/**
+ * @brief Precompute all transfers needed for the gather operation
+ *
+ * Analyzes the data layout transformation from [B, C, HW] to [C, B, HW] and generates
+ * an explicit list of all data movements required between distributed cores.
+ *
+ * @param B Batch size
+ * @param C Number of channels
+ * @param HW Total spatial dimension (height * width)
+ * @param input_cores Vector of input core coordinates
+ * @param output_cores Vector of output core coordinates
+ * @return Vector of GatherTransfer objects sorted by (src_core, batch*C + channel, src_offset)
+ */
+std::vector<GatherTransfer> precompute_gather_transfers(
+    uint32_t B,
+    uint32_t C,
+    uint32_t HW,
+    const std::vector<CoreCoord>& input_cores,
+    const std::vector<CoreCoord>& output_cores);
+
+// Variant that allows overriding the per-output-core width (useful for uneven output sharding)
+std::vector<GatherTransfer> precompute_gather_transfers(
+    uint32_t B,
+    uint32_t C,
+    uint32_t HW,
+    const std::vector<CoreCoord>& input_cores,
+    const std::vector<CoreCoord>& output_cores,
+    uint32_t output_shard_width_override);
+
+/**
+ * @brief Convert high-level transfers to low-level transfers with absolute offsets
+ *
+ * This function bridges the gap between semantic transfers and raw memory operations,
+ * converting logical coordinates into absolute memory offsets suitable for DMA.
+ *
+ * @param transfers High-level transfer list
+ * @param B Batch size
+ * @param C Number of channels
+ * @param HW Total spatial dimension
+ * @param input_cores Vector of input core coordinates
+ * @param num_output_cores Number of output cores
+ * @param element_size_bytes Size of each element in bytes
+ * @return Vector of LowLevelGatherTransfer objects
+ */
+std::vector<LowLevelGatherTransfer> lower_gather_transfers(
+    const std::vector<GatherTransfer>& transfers,
+    uint32_t B,
+    uint32_t C,
+    uint32_t HW,
+    const std::vector<CoreCoord>& input_cores,
+    uint32_t num_output_cores,
+    uint32_t element_size_bytes,
+    uint32_t output_shard_width);
+
+// Forward declaration for API that returns both groups and count
+struct BlockedTransfersWithCount;
+
+/**
+ * @brief Group transfers by output column blocks for memory-efficient processing
+ *
+ * Returns both the grouped transfers and the number of unique logical blocks.
+ *
+ * @param transfers High-level transfer list
+ * @param B Batch size
+ * @param C Number of channels
+ * @param HW Total spatial dimension
+ * @param input_cores Vector of input core coordinates
+ * @param num_output_cores Number of output cores
+ * @param element_size_bytes Size of each element in bytes
+ * @param block_size Width of each column block (default 4)
+ * @param output_shard_width Explicit width of each destination shard row
+ * @return BlockedTransfersWithCount {blocked_transfers, num_logical_blocks}
+ */
+BlockedTransfersWithCount group_transfers_by_output_column_blocks(
+    const std::vector<GatherTransfer>& transfers,
+    uint32_t B,
+    uint32_t C,
+    uint32_t HW,
+    const std::vector<CoreCoord>& input_cores,
+    uint32_t num_output_cores,
+    uint32_t element_size_bytes,
+    uint32_t block_size,
+    uint32_t output_shard_width);
+
+/**
+ * @brief Tensor-based interface for gather transfers precomputation
+ *
+ * This function analyzes the input tensor's sharding and generates transfers
+ * needed to reorganize data from [B, C, HW] to [C, B, HW] format.
+ *
+ * @param input Input tensor with [B*C, HW] sharding across cores
+ * @param output_cores Vector of output core coordinates
+ * @return Vector of GatherTransfer objects sorted by source for optimal cache access
+ */
+std::vector<GatherTransfer> precompute_gather_transfers(
+    const Tensor& input, const std::vector<CoreCoord>& output_cores);
+
+/**
+ * @brief Tensor-based interface for blocked transfer grouping
+ *
+ * Groups transfers by output column blocks for memory-efficient processing
+ * using the tensor's metadata to determine sharding information.
+ *
+ * @param input Input tensor with sharding information
+ * @param output Output tensor with sharding information
+ * @param transfers High-level transfer list
+ * @param block_size Width of each column block (default 4)
+ * @return Vector of BlockedTransferGroup objects
+ */
+std::vector<BlockedTransferGroup> group_transfers_by_output_column_blocks(
+    const Tensor& input,
+    const Tensor& output,
+    const std::vector<GatherTransfer>& transfers,
+    uint32_t block_size,
+    uint32_t output_shard_width);
+
+/**
+ * @brief Wrapper struct that returns both blocked transfers and the actual number of logical blocks
+ */
+struct BlockedTransfersWithCount {
+    std::vector<BlockedTransferGroup> blocked_transfers;
+    uint32_t num_logical_blocks;
+};
+
+// Note: group_transfers_by_output_column_blocks returns both groups and logical block count.
+
+/**
+ * @brief Coalesce contiguous transfers within blocked transfer groups to reduce NOC operations
+ *
+ * Analyzes transfers within each BlockedTransferGroup and merges contiguous transfers
+ * that read from the same source core and write to adjacent destination addresses.
+ * This optimization reduces the number of NOC operations and improves performance.
+ *
+ * @param blocked_groups Vector of BlockedTransferGroup objects to optimize
+ * @return Vector of optimized BlockedTransferGroup objects with coalesced transfers
+ */
+std::vector<BlockedTransferGroup> coalesce_contiguous_transfers(
+    const std::vector<BlockedTransferGroup>& blocked_groups);
+
+/**
+ * @brief Split blocked transfer groups by destination core for per-core processing
+ *
+ * This function reorganizes BlockedTransferGroup objects by their destination core index,
+ * creating a vector of vectors where each index corresponds to an output core and contains
+ * all the BlockedTransferGroup objects that write to that core.
+ *
+ * @param blocked_groups Vector of BlockedTransferGroup objects to split
+ * @param num_output_cores Total number of output cores (determines the size of outer vector)
+ * @return Vector of vectors where index i contains all BlockedTransferGroup objects
+ *         that write to output core i. Some inner vectors may be empty if a core
+ *         has no transfers assigned to it.
+ */
+std::vector<std::vector<BlockedTransferGroup>> split_by_destination_core(
+    const std::vector<BlockedTransferGroup>& blocked_groups, uint32_t num_output_cores);
+
+/**
+ * @brief Convert element count to byte count
+ *
+ * @param element_count Number of elements
+ * @param element_size Size of each element in bytes
+ * @return Number of bytes
+ */
+inline uint32_t elements_to_bytes(uint32_t element_count, uint32_t element_size) {
+    return element_count * element_size;
+}
+
+void serialize_low_level_transfer(
+    const LowLevelGatherTransfer& transfer,
+    std::vector<uint32_t>& output,
+    const std::vector<CoreCoord>& input_cores,
+    std::function<CoreCoord(const CoreCoord&)> logical_to_worker_core) {
+    // Convert logical core coordinates to worker core coordinates
+    CoreCoord logical_core = input_cores[transfer.src_shard_idx];
+    auto worker_core = logical_to_worker_core(logical_core);
+
+    // Kernel pulls data from input so only source core x/y is required
+    output.push_back(worker_core.x);
+    output.push_back(worker_core.y);
+    output.push_back(transfer.src_offset_bytes);
+    output.push_back(transfer.dst_offset_bytes);
+    output.push_back(transfer.transfer_size_bytes);
+    // Always serialize bank_id as the 6th value per transfer.
+    // For DRAM, logical_to_worker_core encodes the bank_id in x; for L1, this value is ignored by the kernel.
+    output.push_back(worker_core.x);
+}
+
+std::vector<uint32_t> serialize_blocked_transfer_groups(
+    const std::vector<BlockedTransferGroup>& groups,
+    const std::vector<CoreCoord>& input_cores,
+    std::function<CoreCoord(const CoreCoord&)> logical_to_worker_core) {
+    std::vector<uint32_t> output;
+    const uint32_t number_of_blocks = groups.size();
+    output.push_back(number_of_blocks);
+    for (const auto& group : groups) {
+        const uint32_t group_size = group.transfers.size();
+        output.push_back(group_size);
+        for (const auto& transfer : group.transfers) {
+            serialize_low_level_transfer(transfer, output, input_cores, logical_to_worker_core);
+        }
+    }
+    return output;
+}
+
+}  // namespace ttnn::operations::experimental::cnn::convert_to_hwc::detail
+
+// fmt formatter template specializations for pretty printing
+template <>
+struct fmt::formatter<ttnn::operations::experimental::cnn::convert_to_hwc::detail::GatherTransfer>
+    : formatter<string_view> {
+    auto format(
+        const ttnn::operations::experimental::cnn::convert_to_hwc::detail::GatherTransfer& t,
+        fmt::format_context& ctx) const -> format_context::iterator;
+};
+
+template <>
+struct fmt::formatter<ttnn::operations::experimental::cnn::convert_to_hwc::detail::LowLevelGatherTransfer>
+    : formatter<string_view> {
+    auto format(
+        const ttnn::operations::experimental::cnn::convert_to_hwc::detail::LowLevelGatherTransfer& t,
+        fmt::format_context& ctx) const -> format_context::iterator;
+};
+
+template <>
+struct fmt::formatter<ttnn::operations::experimental::cnn::convert_to_hwc::detail::BlockedTransferGroup>
+    : formatter<string_view> {
+    auto format(
+        const ttnn::operations::experimental::cnn::convert_to_hwc::detail::BlockedTransferGroup& t,
+        fmt::format_context& ctx) const -> format_context::iterator;
+};

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/kernels/convert_to_hwc.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/kernels/convert_to_hwc.cpp
@@ -8,6 +8,8 @@
 #include "compute_kernel_api/transpose_wh.h"
 #include "compute_kernel_api/tilize.h"
 
+
+
 template <uint32_t BatchSize = 1>
 FORCE_INLINE void transpose(uint32_t cb_in, uint32_t cb_out) {
     cb_wait_front(cb_in, BatchSize);
@@ -43,31 +45,30 @@ FORCE_INLINE void tilize(
 
 namespace NAMESPACE {
 void MAIN {
-    constexpr uint32_t cb_in = get_compile_time_arg_val(0);
+    constexpr uint32_t cb_in_batch = get_compile_time_arg_val(0);
     constexpr uint32_t cb_tiled_in = get_compile_time_arg_val(1);
     constexpr uint32_t cb_transpose_in0 = get_compile_time_arg_val(2);
     constexpr uint32_t cb_transpose_in1 = get_compile_time_arg_val(3);
-    constexpr uint32_t total_tiles = get_compile_time_arg_val(4);
+    constexpr uint32_t total_tiles_per_block = get_compile_time_arg_val(4);
     constexpr uint32_t total_sticks_per_block = get_compile_time_arg_val(5);
-    constexpr uint32_t is_input_in_dram = get_compile_time_arg_val(6);
+    constexpr uint32_t total_num_blocks = get_compile_time_arg_val(6);
 
-    compute_kernel_hw_startup(cb_in, cb_tiled_in);
-    if constexpr (!is_input_in_dram) {
-        cb_push_back(cb_in, total_sticks_per_block);
+    compute_kernel_hw_startup(cb_in_batch, cb_tiled_in);
+
+    for (uint32_t block_idx = 0; block_idx < total_num_blocks; block_idx++) {
+        tilize_init(cb_in_batch, total_tiles_per_block, cb_tiled_in);
+        tilize(cb_in_batch, total_tiles_per_block, total_sticks_per_block, cb_tiled_in);
+        tilize_uninit(cb_in_batch, cb_tiled_in);
+
+        pack_untilize_init(cb_in_batch, cb_transpose_in0);
+        transpose_wh_init(cb_in_batch, cb_transpose_in0);
+        pack_untilize_dest_init<1>(cb_in_batch);
+
+        for (uint32_t idx = 0; idx < total_tiles_per_block; idx++) {
+            const uint32_t cb_transpose_in = idx % 2 == 0 ? cb_transpose_in0 : cb_transpose_in1;
+            transpose<1>(cb_tiled_in, cb_transpose_in);
+        }
+        pack_untilize_uninit(cb_transpose_in0);
     }
-
-    tilize_init(cb_in, total_tiles, cb_tiled_in);
-    tilize(cb_in, total_tiles, total_sticks_per_block, cb_tiled_in);
-    tilize_uninit(cb_in, cb_tiled_in);
-
-    pack_untilize_init(cb_in, cb_transpose_in0);
-    transpose_wh_init(cb_in, cb_transpose_in0);
-    pack_untilize_dest_init<1>(cb_in);
-
-    for (uint32_t idx = 0; idx < total_tiles; idx++) {
-        const uint32_t cb_transpose_in = idx % 2 == 0 ? cb_transpose_in0 : cb_transpose_in1;
-        transpose<1>(cb_tiled_in, cb_transpose_in);
-    }
-    pack_untilize_uninit(cb_transpose_in0);
 }
 }  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/kernels/writer_convert_to_hwc.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/kernels/writer_convert_to_hwc.cpp
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "dataflow_api.h"
-#include "debug/dprint_pages.h"
 
 constexpr uint32_t TILE_SIZE = 32;
 
@@ -17,83 +16,80 @@ FORCE_INLINE void copy_padded_sticks(uint32_t l1_read_addr, uint32_t& l1_write_a
     }
 }
 
-template <uint32_t ReadStrideBytes, uint32_t WriteStrideBytes, uint32_t NumSticks>
-FORCE_INLINE void copy_segment_from_dram(
-    uint32_t copy_size,
-    uint32_t base_write_addr,
-    uint32_t write_offset,
-    uint32_t bank_id,
-    uint32_t base_read_addr,
-    uint32_t read_offset) {
-    uint32_t l1_write_addr = base_write_addr + write_offset;
-
-    uint32_t read_addr = base_read_addr + read_offset;
-    uint64_t noc_read_addr = get_noc_addr_from_bank_id<true>(bank_id, read_addr);
-
-    noc_async_read_one_packet_set_state(noc_read_addr, copy_size);
-    for (uint32_t j = 0; j < NumSticks; ++j) {
-        noc_async_read_one_packet_with_state<true>(noc_read_addr, l1_write_addr);
-        l1_write_addr += WriteStrideBytes;
-        noc_read_addr += ReadStrideBytes;
-    }
-}
 
 void kernel_main() {
     constexpr uint32_t cb_in = get_compile_time_arg_val(0);
-    constexpr uint32_t cb_in_transpose = get_compile_time_arg_val(1);
-    constexpr uint32_t cb_out = get_compile_time_arg_val(2);
-    constexpr uint32_t channels = get_compile_time_arg_val(3);  // stick size
-    constexpr uint32_t hw = get_compile_time_arg_val(4);        // total number of sticks to copy into output
+    constexpr uint32_t cb_in_batch = get_compile_time_arg_val(1);
+    constexpr uint32_t cb_in_transpose = get_compile_time_arg_val(2);
+    constexpr uint32_t cb_out = get_compile_time_arg_val(3);
+    constexpr uint32_t num_output_channels_padded = get_compile_time_arg_val(4);  // padded output channels (min 8)
     constexpr uint32_t num_full_tiles = get_compile_time_arg_val(5);
-    constexpr uint32_t output_stride_sticks = get_compile_time_arg_val(6);
-    constexpr uint32_t initial_l1_write_stick_offset = get_compile_time_arg_val(7);
-    constexpr uint32_t element_size_bytes = get_compile_time_arg_val(8);
+    constexpr uint32_t initial_l1_write_stick_offset = get_compile_time_arg_val(6);
+    constexpr uint32_t element_size_bytes = get_compile_time_arg_val(7);
+    constexpr bool is_input_in_dram = get_compile_time_arg_val(8);
+    constexpr bool is_reader = get_compile_time_arg_val(9);
+    constexpr uint32_t input_block_size_sticks_per_core = get_compile_time_arg_val(10);
+    constexpr uint32_t input_num_blocks = get_compile_time_arg_val(11);
+    constexpr uint32_t l1_write_output_addr_stride = get_compile_time_arg_val(12);
+    constexpr uint32_t block_size_bytes = get_compile_time_arg_val(13);
 
-    static_assert(hw % TILE_SIZE == 0, "Shard width must be multiple of tile width");
+    constexpr uint32_t channel_size = num_output_channels_padded * element_size_bytes;
 
-    constexpr bool is_input_in_dram = get_compile_time_arg_val(9);
-    constexpr bool should_wait = get_compile_time_arg_val(10);
-    constexpr uint32_t dram_write_stride_bytes = get_compile_time_arg_val(11);
-    constexpr uint32_t dram_read_stride_bytes = get_compile_time_arg_val(12);
-    constexpr uint32_t input_sticks_per_core = get_compile_time_arg_val(13);
+    const uint32_t dram_base_read_addr = is_input_in_dram ? get_arg_val<uint32_t>(0) : 0;
 
-    if constexpr (is_input_in_dram) {
-        const uint32_t dram_base_read_addr = get_arg_val<uint32_t>(0);
-        const uint32_t num_segments = get_arg_val<uint32_t>(1);
-        tt_l1_ptr uint32_t* args = (tt_l1_ptr uint32_t*)(get_arg_addr(2));
-        uint32_t args_idx = 0;
-        for (uint32_t i = 0; i < num_segments; ++i) {
-            uint32_t copy_size = args[args_idx++];
-            uint32_t write_offset = args[args_idx++];
-            uint32_t bank_id = args[args_idx++];
-            uint32_t read_offset = args[args_idx++];
-            copy_segment_from_dram<dram_read_stride_bytes, dram_write_stride_bytes, input_sticks_per_core>(
-                copy_size, get_write_ptr(cb_in), write_offset, bank_id, dram_base_read_addr, read_offset);
-        }
-        noc_async_read_barrier();
+    tt_l1_ptr uint32_t* args = (tt_l1_ptr uint32_t*)(get_arg_addr(1));
+    uint32_t args_idx = 0;
 
-        // One writer must wait until the other has pushed to avoid a race that will trigger a hang
-        if constexpr (should_wait) {
-            cb_wait_front(cb_in, input_sticks_per_core);
-        }
-        cb_push_back(cb_in, input_sticks_per_core);
-    }
+    const uint32_t num_blocks = args[args_idx++];
 
     constexpr uint32_t tile_size_stick_bytes = TILE_SIZE * element_size_bytes;
-    constexpr uint32_t channel_size = channels * element_size_bytes;
-
-    constexpr uint32_t l1_write_addr_stride = output_stride_sticks * channel_size;
     constexpr uint32_t initial_l1_write_addr_offset = initial_l1_write_stick_offset * channel_size;
 
     const uint32_t base_l1_write_addr = get_write_ptr(cb_out) + initial_l1_write_addr_offset;
+    uint32_t l1_output_write_addr = base_l1_write_addr;
 
-    uint32_t l1_write_addr = base_l1_write_addr;
-    for (uint32_t i = 0; i < num_full_tiles; i++) {
-        cb_wait_front(cb_in_transpose, 1);
-        const uint32_t l1_read_addr = get_read_ptr(cb_in_transpose);
-        copy_padded_sticks<channel_size, tile_size_stick_bytes, TILE_SIZE>(l1_read_addr, l1_write_addr);
-        noc_async_read_barrier();
-        cb_pop_front(cb_in_transpose, 1);
-        l1_write_addr += l1_write_addr_stride;  // skip some number of sticks if splitting writers across cores
+    // Process each blocked transfer group
+    for (uint32_t block_id = 0; block_id < num_blocks && block_id < input_num_blocks; block_id++) {
+        if constexpr (is_reader) {
+            cb_reserve_back(cb_in_batch, input_block_size_sticks_per_core);
+
+            // Process all transfers in this group
+            const uint32_t group_size = args[args_idx++];
+            for (uint32_t transfer_idx = 0; transfer_idx < group_size; transfer_idx++) {
+                uint32_t src_x = args[args_idx++];
+                uint32_t src_y = args[args_idx++];
+                uint32_t src_offset_bytes = args[args_idx++];
+                uint32_t dst_offset_bytes = args[args_idx++];
+                uint32_t transfer_size_bytes = args[args_idx++];
+                uint32_t bank_id = args[args_idx++];
+
+                uint64_t src_addr_base = 0;
+                if constexpr (is_input_in_dram) {
+                    // For DRAM, use bank_id to compute NOC address from bank_id
+                    src_addr_base = get_noc_addr_from_bank_id<true>(bank_id, dram_base_read_addr);
+                } else {
+                    src_addr_base = get_noc_addr(src_x, src_y, get_read_ptr(cb_in));
+                }
+
+                const uint32_t dst_addr = get_write_ptr(cb_in_batch) + (dst_offset_bytes % block_size_bytes);
+                noc_async_read(src_addr_base + src_offset_bytes, dst_addr, transfer_size_bytes);
+            }
+
+            noc_async_read_barrier();
+            cb_push_back(cb_in_batch, input_block_size_sticks_per_core);
+        }
+
+        for (uint32_t i = 0; i < num_full_tiles; i++) {
+            cb_wait_front(cb_in_transpose, 1);
+
+            const uint32_t l1_read_addr = get_read_ptr(cb_in_transpose);
+
+            copy_padded_sticks<channel_size, tile_size_stick_bytes, TILE_SIZE>(l1_read_addr, l1_output_write_addr);
+            noc_async_read_barrier();
+            cb_pop_front(cb_in_transpose, 1);
+
+            // Stride by a number of sticks when splitting writers across cores
+            l1_output_write_addr += l1_write_output_addr_stride;
+        }
     }
 }


### PR DESCRIPTION
### Summary

Enable multi-batch (B > 1) support for width-sharded row-major inputs in `ttnn.experimental.convert_to_hwc`.

This change also decouples the input tensor memory config from the output memory config to allow for resharding to any output shard grid. 

This change was achieved by adding an additional all-to-all gather on the input shard to transform it from [B, C, HW] to [C, B, HW] sharded over the width dimension, and then performing the existing local transpose to swap the shard dims while making the output height sharded.

Performance for B = 1 has not changed.

### Future Work

There are still a few limitation in this op which may need to be addressed a later date:
- #32431 
- #32430 
- Input must be sharded and WIDTH_SHARDED; output must be sharded and HEIGHT_SHARDED.
- Output shard width must be a multiple of alignment; output shard height must be a multiple of 32.
- We only support B=1 when using uneven sharding.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/19317242734
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable): https://github.com/tenstorrent/tt-metal/actions/runs/19316005445
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable): https://github.com/tenstorrent/tt-metal/actions/runs/19316950178
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable): https://github.com/tenstorrent/tt-metal/actions/runs/19317233570/job/55251579027
- [x] Frequent models: https://github.com/tenstorrent/tt-metal/actions/runs/19316940689
- [x] Single-card Demo Tests: https://github.com/tenstorrent/tt-metal/actions/runs/19837590039
