### PR TITLE
Remove all instances of ttnn.clone from Panoptic DeepLab

### DIFF
--- a/models/experimental/panoptic_deeplab/tests/test_device_perf_pdl.py
+++ b/models/experimental/panoptic_deeplab/tests/test_device_perf_pdl.py
@@ -12,7 +12,7 @@ from models.experimental.panoptic_deeplab.reference.pytorch_model import DEEPLAB
     [
         (
             "pytest models/experimental/panoptic_deeplab/tests/pcc/test_tt_model.py::test_model_panoptic_deeplab -k test_panoptic_deeplab",
-            32_661_399,
+            31_016_904,
             PANOPTIC_DEEPLAB,
             PANOPTIC_DEEPLAB,
             1,
@@ -22,7 +22,7 @@ from models.experimental.panoptic_deeplab.reference.pytorch_model import DEEPLAB
         ),
         (
             "pytest models/experimental/panoptic_deeplab/tests/pcc/test_tt_model.py::test_model_panoptic_deeplab -k test_deeplab_v3_plus",
-            23_648_515,
+            21_926_462,
             DEEPLAB_V3_PLUS,
             DEEPLAB_V3_PLUS,
             1,

--- a/models/experimental/panoptic_deeplab/tt/tt_model.py
+++ b/models/experimental/panoptic_deeplab/tt/tt_model.py
@@ -96,7 +96,10 @@ class TtPanopticDeepLab:
         backbone_dtype = resnet_layer_dtypes if resnet_layer_dtypes is not None else ttnn.bfloat8_b
 
         self.backbone = TtResNet(
-            parameters=backbone_params, device=device, dtype=backbone_dtype, model_configs=model_configs
+            parameters=backbone_params,
+            device=device,
+            dtype=backbone_dtype,
+            model_configs=model_configs,
         )
 
         logger.debug("ResNet backbone initialization complete")


### PR DESCRIPTION
### Ticket
None

### Problem description
There were unnecessary ttnn.clone operations in the model that added a few ms to execution time.

### What's changed
Removed ttnn.clone by making convolutions not deallocate input.
Perf improved to 21.9ms per iteration (down from 23)

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes
- [x] [Blackhole Nightly](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-nightly-tests.yaml) CI passes
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (pipeline in bad state but PDL tests pass)
- [x] New/Existing tests provide coverage for changes