### PR TITLE
Restore Llama model perf pipelines

### DIFF
--- a/.github/workflows/galaxy-model-perf-tests-impl.yaml
+++ b/.github/workflows/galaxy-model-perf-tests-impl.yaml
@@ -46,16 +46,6 @@ jobs:
               "cmd": "TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE=\"7,7\" pytest -n auto models/demos/vision/classification/resnet50/ttnn_resnet/tests/test_perf_e2e_resnet50.py -m \"model_perf_tg\" && python3 models/perf/merge_perf_results.py --upper-threshold 1.10"
             }, # Pavle Josipovic
             {
-              "name": "Galaxy Llama 70B model perf tests",
-              "model-type": "Llama-70B",
-              "model-name": "llama70b",
-              "arch": "wormhole_b0",
-              "save-perf-data": true,
-              "timeout": 60,
-              "cmd": "TT_METAL_KERNELS_EARLY_RETURN=1 TT_METAL_ENABLE_ERISC_IRAM=1 FAKE_DEVICE=TG LLAMA_DIR=/mnt/MLPerf/tt_dnn-models/llama/Llama3.3-70B-Instruct/ pytest -n auto models/demos/llama3_70b_galaxy/tests/test_decoder_device_perf.py::test_llama_TG_perf_device_non_overlapped_dispatch --timeout=600 && TT_METAL_ENABLE_ERISC_IRAM=1 FAKE_DEVICE=TG LLAMA_DIR=/mnt/MLPerf/tt_dnn-models/llama/Llama3.3-70B-Instruct/ pytest -n auto models/demos/llama3_70b_galaxy/tests/test_decoder_device_perf.py::test_llama_TG_perf_device --timeout=600",
-              "owner_id": "U053W15B6JF"
-            }, # Djordje Ivanovic
-            {
               "name": "Llama Galaxy Perf Unit Tests",
               "model-name": "llama_unit_tests",
               "arch": "wormhole_b0",
@@ -88,6 +78,16 @@ jobs:
           ]' --compact-output)
 
           ACTIVE_MODELS=$(jq -n '[
+            {
+              "name": "Galaxy Llama 70B model perf tests",
+              "model-type": "Llama-70B",
+              "model-name": "llama70b",
+              "arch": "wormhole_b0",
+              "save-perf-data": true,
+              "timeout": 60,
+              "cmd": "TT_METAL_KERNELS_EARLY_RETURN=1 TT_METAL_ENABLE_ERISC_IRAM=1 FAKE_DEVICE=TG LLAMA_DIR=/mnt/MLPerf/tt_dnn-models/llama/Llama3.3-70B-Instruct/ pytest -n auto models/demos/llama3_70b_galaxy/tests/test_decoder_device_perf.py::test_llama_TG_perf_device_non_overlapped_dispatch --timeout=600 && TT_METAL_ENABLE_ERISC_IRAM=1 FAKE_DEVICE=TG LLAMA_DIR=/mnt/MLPerf/tt_dnn-models/llama/Llama3.3-70B-Instruct/ pytest -n auto models/demos/llama3_70b_galaxy/tests/test_decoder_device_perf.py::test_llama_TG_perf_device --timeout=600",
+              "owner_id": "U053W15B6JF"
+            }, # Djordje Ivanovic
             {
               "name": "Galaxy DiT SD3.5 model perf tests",
               "model-type": "SD3.5",

--- a/.github/workflows/galaxy-model-perf-tests.yaml
+++ b/.github/workflows/galaxy-model-perf-tests.yaml
@@ -11,9 +11,9 @@ on:
         options:
           - all
 #          - cnn
-#          - llama70b
 #          - llama_unit_tests
 #          - llama70b_prefill
+          - llama70b
           - sd35
           - flux1-dev
           - motif

--- a/conftest.py
+++ b/conftest.py
@@ -731,8 +731,11 @@ def bh_2d_mesh_device(request, silicon_arch_name, silicon_arch_blackhole, device
 
 
 @pytest.fixture()
-def ensure_devices_tg():
+def ensure_devices_tg(request):
     import ttnn
+
+    if "no_ensure_devices_tg" in request.keywords:
+        return
 
     device_ids = ttnn.get_device_ids()
     assert len(device_ids) == 32, f"Expected 32 devices, got {len(device_ids)}"

--- a/models/demos/llama3_70b_galaxy/conftest.py
+++ b/models/demos/llama3_70b_galaxy/conftest.py
@@ -11,19 +11,12 @@ def ensure_gc():
     gc.collect()
 
 
-@pytest.fixture(autouse=True)
-def ensure_devices(ensure_devices_tg):
-    pass
-
-
 @pytest.fixture
-def device_params(request, galaxy_type):
+def device_params(request):
     # Get param dict passed in from test parametrize (or default to empty dict)
     params = getattr(request, "param", {}).copy()
 
     if "fabric_config" in params and params["fabric_config"] == True:
-        params["fabric_config"] = (
-            ttnn.FabricConfig.FABRIC_1D_RING if galaxy_type == "6U" else ttnn.FabricConfig.FABRIC_1D
-        )
+        params["fabric_config"] = ttnn.FabricConfig.FABRIC_1D_RING
 
     return params

--- a/models/demos/llama3_70b_galaxy/tests/decoder_perf_targets_6u.json
+++ b/models/demos/llama3_70b_galaxy/tests/decoder_perf_targets_6u.json
@@ -1,110 +1,110 @@
 {
   "decoder": {
-    "RMSAllGather_0": {
+    "RMSAllGatherDeviceOperation_0": {
       "op_name": "RMS_0",
       "kernel_duration": 16719.618287037036,
       "op_to_op": 770.5111111111111,
       "first_to_last_start": 2178.4296296296297,
-      "non-overlapped-dispatch-time": 8567.31746031746,
+      "non-overlapped-dispatch-time": 774.2222222222222,
       "kernel_duration_relative_margin": 0.05,
       "op_to_op_duration_relative_margin": 0.2,
       "first_to_last_start_relative_margin": 0.2,
       "dispatch_duration_relative_margin": 0.2
     },
-    "RMSAllGather_1": {
+    "RMSAllGatherDeviceOperation_1": {
       "op_name": "RMS_1",
-      "kernel_duration": 16346.488888888889,
+      "kernel_duration": 17300.604166666668,
       "op_to_op": 740.4962962962964,
       "first_to_last_start": 2197.888888888889,
-      "non-overlapped-dispatch-time": 7375.0952380952385,
+      "non-overlapped-dispatch-time": 770.8888888888889,
       "kernel_duration_relative_margin": 0.05,
       "op_to_op_duration_relative_margin": 0.2,
       "first_to_last_start_relative_margin": 0.2,
       "dispatch_duration_relative_margin": 0.2
     },
-    "AllGatherConcat_0": {
+    "AllGatherConcatDeviceOperation_0": {
       "op_name": "AllGatherConcat",
       "kernel_duration": 8411.797916666666,
       "op_to_op": 602.2222222222222,
       "first_to_last_start": 119.33333333333333,
-      "non-overlapped-dispatch-time": 11377.785714285712,
+      "non-overlapped-dispatch-time": 620.3333333333334,
       "kernel_duration_relative_margin": 0.05,
       "op_to_op_duration_relative_margin": 0.5,
       "first_to_last_start_relative_margin": 0.5,
-      "dispatch_duration_relative_margin": 0.5
+      "dispatch_duration_relative_margin": 0.2
     },
-    "AllGatherAsync_0": {
+    "AllGatherAsyncDeviceOperation_0": {
       "op_name": "AllGatherAsync_Binary_Mult",
       "kernel_duration": 7083.920833333334,
       "op_to_op": 646.3333333333334,
       "first_to_last_start": 205.22222222222223,
-      "non-overlapped-dispatch-time": 4531.650793650794,
+      "non-overlapped-dispatch-time": 642.8888888888889,
       "kernel_duration_relative_margin": 0.05,
       "op_to_op_duration_relative_margin": 0.5,
       "first_to_last_start_relative_margin": 1.5,
       "dispatch_duration_relative_margin": 0.2
     },
-    "Matmul_0": {
+    "MatmulDeviceOperation_0": {
       "op_name": "QKV_MM",
-      "kernel_duration": 7082.489583333333,
+      "kernel_duration": 8161.475694444444,
       "op_to_op": 758.6296296296297,
       "first_to_last_start": 1855.8074074074075,
-      "non-overlapped-dispatch-time": 5367.539682539683,
+      "non-overlapped-dispatch-time": 759.8888888888889,
       "kernel_duration_relative_margin": 0.05,
       "op_to_op_duration_relative_margin": 0.2,
       "first_to_last_start_relative_margin": 0.2,
-      "dispatch_duration_relative_margin": 0.1
+      "dispatch_duration_relative_margin": 0.2
     },
-    "Matmul_1": {
+    "MatmulDeviceOperation_1": {
       "op_name": "DO_MM",
-      "kernel_duration": 7701.098148148148,
+      "kernel_duration": 8721.927083333334,
       "op_to_op": 598.9481481481482,
       "first_to_last_start": 1994.0888888888887,
-      "non-overlapped-dispatch-time": 5825.539682539683,
+      "non-overlapped-dispatch-time": 663.5555555555555,
       "kernel_duration_relative_margin": 0.05,
       "op_to_op_duration_relative_margin": 0.2,
       "first_to_last_start_relative_margin": 0.2,
-      "dispatch_duration_relative_margin": 0.1
+      "dispatch_duration_relative_margin": 0.2
     },
-    "Matmul_2": {
+    "MatmulDeviceOperation_2": {
       "op_name": "FF2_MM",
       "kernel_duration": 13973.23125,
       "op_to_op": 652.1777777777777,
       "first_to_last_start": 1941.1703703703704,
-      "non-overlapped-dispatch-time": 5811.801587301586,
+      "non-overlapped-dispatch-time": 631.6666666666666,
       "kernel_duration_relative_margin": 0.05,
       "op_to_op_duration_relative_margin": 0.2,
       "first_to_last_start_relative_margin": 0.2,
-      "dispatch_duration_relative_margin": 0.1
+      "dispatch_duration_relative_margin": 0.2
     },
     "LlamaReduceScatterCreateHeadsDeviceOperation_0": {
       "op_name": "LlamaReduceScatterCreateHeads",
       "kernel_duration": 8010.601157407407,
       "op_to_op": 867.8740740740741,
-      "first_to_last_start": 1734.2666666666667,
-      "non-overlapped-dispatch-time": 8437.777777777777,
+      "first_to_last_start": 2131.8888888888887,
+      "non-overlapped-dispatch-time": 708.5555555555555,
       "kernel_duration_relative_margin": 0.1,
       "op_to_op_duration_relative_margin": 0.4,
       "first_to_last_start_relative_margin": 0.2,
-      "dispatch_duration_relative_margin": 0.4
+      "dispatch_duration_relative_margin": 0.2
     },
-    "AllReduceAsync_0": {
+    "AllReduceAsyncDeviceOperation_0": {
       "op_name": "AllReduceAsync_DO",
       "kernel_duration": 13299.603472222221,
       "op_to_op": 706.1111111111111,
       "first_to_last_start": 1511.5407407407406,
-      "non-overlapped-dispatch-time": 6555.587301587301,
+      "non-overlapped-dispatch-time": 581.1111111111111,
       "kernel_duration_relative_margin": 0.05,
       "op_to_op_duration_relative_margin": 0.2,
       "first_to_last_start_relative_margin": 0.2,
-      "dispatch_duration_relative_margin": 0.3
+      "dispatch_duration_relative_margin": 0.2
     },
-    "AllReduceAsync_1": {
+    "AllReduceAsyncDeviceOperation_1": {
       "op_name": "AllReduceAsync_FF2",
       "kernel_duration": 13440.619212962962,
       "op_to_op": 728.6148148148148,
       "first_to_last_start": 1533.1851851851852,
-      "non-overlapped-dispatch-time": 6639.5952380952385,
+      "non-overlapped-dispatch-time": 739.2222222222222,
       "kernel_duration_relative_margin": 0.05,
       "op_to_op_duration_relative_margin": 0.2,
       "first_to_last_start_relative_margin": 0.2,
@@ -115,62 +115,62 @@
       "kernel_duration": 17497.70138888889,
       "op_to_op": 723.4444444444445,
       "first_to_last_start": 2007.5555555555557,
-      "non-overlapped-dispatch-time": 23457.444444444445,
+      "non-overlapped-dispatch-time": 691.1111111111111,
       "kernel_duration_relative_margin": 0.05,
       "op_to_op_duration_relative_margin": 0.2,
       "first_to_last_start_relative_margin": 0.2,
-      "dispatch_duration_relative_margin": 0.3
+      "dispatch_duration_relative_margin": 0.2
     },
     "LlamaReduceScatterDeviceOperation_0": {
       "op_name": "ReduceScatter_FF3",
-      "kernel_duration": 7218.590972222222,
+      "kernel_duration": 7100.527777777777,
       "op_to_op": 698.4148148148148,
       "first_to_last_start": 1688.2222222222222,
-      "non-overlapped-dispatch-time": 7398.333333333333,
+      "non-overlapped-dispatch-time": 690.2222222222222,
       "kernel_duration_relative_margin": 0.05,
       "op_to_op_duration_relative_margin": 0.2,
       "first_to_last_start_relative_margin": 0.4,
-      "dispatch_duration_relative_margin": 0.3
+      "dispatch_duration_relative_margin": 0.2
     },
-    "RotaryEmbeddingLlamaFusedQK_0": {
+    "RotaryEmbeddingLlamaFusedQKDeviceOperation_0": {
       "op_name": "RotaryEmbeddingLlamaFusedQK",
-      "kernel_duration": 2234.1837962962964,
+      "kernel_duration": 2600.9479166666665,
       "op_to_op": 1002.4444444444445,
       "first_to_last_start": 1551.888888888889,
-      "non-overlapped-dispatch-time": 3411.5079365079364,
+      "non-overlapped-dispatch-time": 767.6666666666666,
       "kernel_duration_relative_margin": 0.1,
       "op_to_op_duration_relative_margin": 0.5,
       "first_to_last_start_relative_margin": 0.5,
-      "dispatch_duration_relative_margin": 0.35
+      "dispatch_duration_relative_margin": 0.2
     },
-    "PagedUpdateCacheDeviceOperation_0": {
+    "PagedFusedUpdateCacheDeviceOperation_0": {
       "op_name": "PagedUpdateCache",
       "kernel_duration": 4451.882870370371,
       "op_to_op": 737.1037037037038,
       "first_to_last_start": 206.22222222222223,
-      "non-overlapped-dispatch-time": 4170.3650793650795,
+      "non-overlapped-dispatch-time": 760.5555555555555,
       "kernel_duration_relative_margin": 0.2,
       "op_to_op_duration_relative_margin": 0.2,
       "first_to_last_start_relative_margin": 1.0,
       "dispatch_duration_relative_margin": 0.2
     },
-    "ScaledDotProductAttentionDecode_0": {
+    "SdpaDecodeDeviceOperation_0": {
       "op_name": "SDPA",
       "kernel_duration": 8062.635416666667,
       "op_to_op": 625.3407407407408,
       "first_to_last_start": 2315.9037037037037,
-      "non-overlapped-dispatch-time": 8528.468253968254,
+      "non-overlapped-dispatch-time": 623.7777777777778,
       "kernel_duration_relative_margin": 0.07,
       "op_to_op_duration_relative_margin": 0.2,
       "first_to_last_start_relative_margin": 0.2,
-      "dispatch_duration_relative_margin": 0.3
+      "dispatch_duration_relative_margin": 0.2
     },
     "BinaryDeviceOperation_0": {
       "op_name": "Binary_Mult_Silu",
       "kernel_duration": 2374.3958333333335,
       "op_to_op": 717.0592592592592,
       "first_to_last_start": 1613.674074074074,
-      "non-overlapped-dispatch-time": 5580.150793650793,
+      "non-overlapped-dispatch-time": 658.5555555555555,
       "kernel_duration_relative_margin": 0.1,
       "op_to_op_duration_relative_margin": 0.2,
       "first_to_last_start_relative_margin": 0.2,
@@ -183,190 +183,226 @@
       "op_name": "InterleavedToSharded_0",
       "kernel_duration": 21786.4125,
       "op_to_op": 627.7333333333333,
-      "non-overlapped-dispatch-time": 5159.928571428572,
+      "non-overlapped-dispatch-time": 615.0,
       "kernel_duration_relative_margin": 0.2,
       "op_to_op_duration_relative_margin": 0.2,
-      "dispatch_duration_relative_margin": 0.5
+      "dispatch_duration_relative_margin": 0.2
     },
     "InterleavedToShardedDeviceOperation_1": {
       "op_name": "InterleavedToSharded_1",
       "kernel_duration": 879.2395833333334,
       "op_to_op": 691.2,
-      "non-overlapped-dispatch-time": 2257.0,
+      "non-overlapped-dispatch-time": 683.0,
       "kernel_duration_relative_margin": 0.2,
       "op_to_op_duration_relative_margin": 0.2,
-      "dispatch_duration_relative_margin": 0.5
+      "dispatch_duration_relative_margin": 0.2
     },
     "InterleavedToShardedDeviceOperation_2": {
       "op_name": "InterleavedToSharded_2",
       "kernel_duration": 1298.8395833333334,
       "op_to_op": 703.7333333333333,
-      "non-overlapped-dispatch-time": 2656.3571428571427,
+      "non-overlapped-dispatch-time": 677.0,
       "kernel_duration_relative_margin": 0.2,
       "op_to_op_duration_relative_margin": 0.2,
-      "dispatch_duration_relative_margin": 0.5
+      "dispatch_duration_relative_margin": 0.2
     },
-    "RMSAllGather_0": {
+    "RMSAllGatherDeviceOperation_0": {
       "op_name": "RMSAllGather_0",
       "kernel_duration": 14480.010416666666,
       "op_to_op": 694.8666666666667,
-      "non-overlapped-dispatch-time": 7116.071428571428,
+      "non-overlapped-dispatch-time": 691.0,
       "kernel_duration_relative_margin": 0.2,
       "op_to_op_duration_relative_margin": 0.2,
-      "dispatch_duration_relative_margin": 0.5
+      "dispatch_duration_relative_margin": 0.2
     },
     "ReshardDeviceOperation_0": {
       "op_name": "Reshard_0",
       "kernel_duration": 1118.5125,
       "op_to_op": 762.7333333333333,
-      "non-overlapped-dispatch-time": 9687.357142857143,
+      "non-overlapped-dispatch-time": 726.0,
       "kernel_duration_relative_margin": 0.2,
       "op_to_op_duration_relative_margin": 0.2,
-      "dispatch_duration_relative_margin": 0.5
+      "dispatch_duration_relative_margin": 0.2
     },
     "ReshardDeviceOperation_1": {
       "op_name": "Reshard_1",
       "kernel_duration": 3915.485416666667,
       "op_to_op": 625.0,
-      "non-overlapped-dispatch-time": 4517.285714285715,
+      "non-overlapped-dispatch-time": 700.0,
       "kernel_duration_relative_margin": 0.2,
       "op_to_op_duration_relative_margin": 0.2,
-      "dispatch_duration_relative_margin": 0.5
+      "dispatch_duration_relative_margin": 0.2
     },
-    "Matmul_0": {
+    "MatmulDeviceOperation_0": {
       "op_name": "Matmul_0",
       "kernel_duration": 142716.93958333333,
       "op_to_op": 610.6666666666666,
-      "non-overlapped-dispatch-time": 5595.785714285715,
+      "non-overlapped-dispatch-time": 598.0,
       "kernel_duration_relative_margin": 0.2,
       "op_to_op_duration_relative_margin": 0.2,
-      "dispatch_duration_relative_margin": 0.5
+      "dispatch_duration_relative_margin": 0.2
     },
-    "AllReduceAsync_0": {
+    "AllReduceAsyncDeviceOperation_0": {
       "op_name": "AllReduceAsync_0",
       "kernel_duration": 30319.389583333334,
       "op_to_op": 647.7333333333333,
-      "non-overlapped-dispatch-time": 9394.285714285714,
+      "non-overlapped-dispatch-time": 614.0,
       "kernel_duration_relative_margin": 0.2,
       "op_to_op_duration_relative_margin": 0.2,
-      "dispatch_duration_relative_margin": 0.5
+      "dispatch_duration_relative_margin": 0.2
     },
     "ShardedToInterleavedDeviceOperation_0": {
       "op_name": "ShardedToInterleavedDeviceOperation_0",
       "kernel_duration": 8355.870833333332,
       "op_to_op": 789.2,
-      "non-overlapped-dispatch-time": 4592.0,
+      "non-overlapped-dispatch-time": 704.0,
       "kernel_duration_relative_margin": 0.3,
       "op_to_op_duration_relative_margin": 1.0,
-      "dispatch_duration_relative_margin": 0.5
+      "dispatch_duration_relative_margin": 0.2
     },
     "ShardedToInterleavedDeviceOperation_1": {
       "op_name": "ShardedToInterleavedDeviceOperation_1",
       "kernel_duration": 1002.19375,
       "op_to_op": 1849.0,
-      "non-overlapped-dispatch-time": 2205.4285714285716,
+      "non-overlapped-dispatch-time": 728.0,
       "kernel_duration_relative_margin": 0.2,
       "op_to_op_duration_relative_margin": 1.0,
+      "dispatch_duration_relative_margin": 0.7
+    },
+    "ShardedToInterleavedDeviceOperation_2": {
+      "op_name": "ShardedToInterleavedDeviceOperation_2",
+      "kernel_duration": 1442.96875,
+      "op_to_op": 635.0,
+      "non-overlapped-dispatch-time": 725.0,
+      "kernel_duration_relative_margin": 0.3,
+      "op_to_op_duration_relative_margin": 0.3,
+      "dispatch_duration_relative_margin": 0.2
+    },
+    "ShardedToInterleavedDeviceOperation_3": {
+      "op_name": "ShardedToInterleavedDeviceOperation_3",
+      "kernel_duration": 2623.3125,
+      "op_to_op": 700.0,
+      "non-overlapped-dispatch-time": 6000.0,
+      "kernel_duration_relative_margin": 0.3,
+      "op_to_op_duration_relative_margin": 0.3,
       "dispatch_duration_relative_margin": 0.5
     },
-    "TopK_0": {
+    "ManualSeedDeviceOperation_0": {
+      "op_name": "ManualSeed_0",
+      "kernel_duration": 2623.3125,
+      "op_to_op": 700.0,
+      "non-overlapped-dispatch-time": 6000.0,
+      "kernel_duration_relative_margin": 0.3,
+      "op_to_op_duration_relative_margin": 0.3,
+      "dispatch_duration_relative_margin": 0.5
+    },
+    "TopKDeviceOperation_0": {
       "op_name": "TopK_0",
       "kernel_duration": 179979.625,
       "op_to_op": 671.0,
-      "non-overlapped-dispatch-time": 4614.0,
+      "non-overlapped-dispatch-time": 654.0,
       "kernel_duration_relative_margin": 0.2,
       "op_to_op_duration_relative_margin": 0.7,
-      "dispatch_duration_relative_margin": 0.5
+      "dispatch_duration_relative_margin": 0.2
     },
-    "AllGatherAsync_0": {
+    "AllGatherAsyncDeviceOperation_0": {
       "op_name": "AllGatherAsync_0",
       "kernel_duration": 10840.89375,
       "op_to_op": 655.7333333333333,
-      "non-overlapped-dispatch-time": 6158.0,
+      "non-overlapped-dispatch-time": 635.0,
       "kernel_duration_relative_margin": 0.35,
       "op_to_op_duration_relative_margin": 0.2,
-      "dispatch_duration_relative_margin": 0.5
+      "dispatch_duration_relative_margin": 0.2
     },
-    "AllGatherAsync_1": {
+    "AllGatherAsyncDeviceOperation_1": {
       "op_name": "AllGatherAsync_1",
       "kernel_duration": 12112.06875,
       "op_to_op": 674.6,
-      "non-overlapped-dispatch-time": 6675.0,
+      "non-overlapped-dispatch-time": 652.0,
       "kernel_duration_relative_margin": 0.33,
       "op_to_op_duration_relative_margin": 0.2,
-      "dispatch_duration_relative_margin": 0.5
+      "dispatch_duration_relative_margin": 0.2
     },
     "TypecastDeviceOperation_0": {
       "op_name": "TypecastDeviceOperation_input_bf16",
       "kernel_duration": 20326.516666666666,
       "op_to_op": 639.3333333333334,
-      "non-overlapped-dispatch-time": 5311.142857142857,
+      "non-overlapped-dispatch-time": 636.0,
       "kernel_duration_relative_margin": 0.2,
       "op_to_op_duration_relative_margin": 0.2,
-      "dispatch_duration_relative_margin": 0.5
+      "dispatch_duration_relative_margin": 0.2
     },
     "TypecastDeviceOperation_1": {
       "op_name": "TypecastDeviceOperation_0",
       "kernel_duration": 1887.1354166666667,
       "op_to_op": 662.2666666666667,
-      "non-overlapped-dispatch-time": 2810.3571428571427,
+      "non-overlapped-dispatch-time": 613.0,
       "kernel_duration_relative_margin": 0.2,
       "op_to_op_duration_relative_margin": 0.2,
-      "dispatch_duration_relative_margin": 0.5
+      "dispatch_duration_relative_margin": 0.6
     },
     "BinaryDeviceOperation_0": {
       "op_name": "BinaryDeviceOperation_Last_Residual",
       "kernel_duration": 849.73125,
       "op_to_op": 696.3333333333334,
-      "non-overlapped-dispatch-time": 5750.214285714285,
+      "non-overlapped-dispatch-time": 675.0,
       "kernel_duration_relative_margin": 0.2,
       "op_to_op_duration_relative_margin": 0.2,
-      "dispatch_duration_relative_margin": 0.5
+      "dispatch_duration_relative_margin": 0.2
     },
     "BinaryNgDeviceOperation_0": {
       "op_name": "BinaryDeviceOperation_Indices_Correction",
       "kernel_duration": 3139.0291666666667,
       "op_to_op": 665.4,
-      "non-overlapped-dispatch-time": 6386.571428571428,
+      "non-overlapped-dispatch-time": 640.0,
       "kernel_duration_relative_margin": 0.2,
       "op_to_op_duration_relative_margin": 0.2,
+      "dispatch_duration_relative_margin": 0.2
+    },
+    "BinaryNgDeviceOperation_1": {
+      "op_name": "BinaryNgDeviceOperation_1",
+      "kernel_duration": 2623.3125,
+      "op_to_op": 700.0,
+      "non-overlapped-dispatch-time": 6000.0,
+      "kernel_duration_relative_margin": 0.3,
+      "op_to_op_duration_relative_margin": 0.3,
       "dispatch_duration_relative_margin": 0.5
     },
-    "Untilize_0": {
+    "UntilizeDeviceOperation_0": {
       "op_name": "Untilize_0",
       "kernel_duration": 2918.804166666667,
       "op_to_op": 644.8666666666667,
-      "non-overlapped-dispatch-time": 3867.8571428571427,
+      "non-overlapped-dispatch-time": 655.0,
       "kernel_duration_relative_margin": 0.2,
       "op_to_op_duration_relative_margin": 0.4,
-      "dispatch_duration_relative_margin": 0.5
+      "dispatch_duration_relative_margin": 0.2
     },
-    "Sampling_0": {
+    "SamplingDeviceOperation_0": {
       "op_name": "Sampling_0",
       "kernel_duration": 67650.89791666667,
       "op_to_op": 54836.46666666667,
-      "non-overlapped-dispatch-time": 80988.14285714286,
+      "non-overlapped-dispatch-time": 49290.0,
       "kernel_duration_relative_margin": 0.2,
       "op_to_op_duration_relative_margin": 0.2,
-      "dispatch_duration_relative_margin": 0.5
+      "dispatch_duration_relative_margin": 0.2
     },
-    "PlusOne_0": {
+    "PlusOneDeviceOperation_0": {
       "op_name": "PlusOne_0",
       "kernel_duration": 442.40625,
       "op_to_op": 650.0,
-      "non-overlapped-dispatch-time": 1862.2142857142858,
+      "non-overlapped-dispatch-time": 713.0,
       "kernel_duration_relative_margin": 0.2,
       "op_to_op_duration_relative_margin": 0.4,
-      "dispatch_duration_relative_margin": 1.64
+      "dispatch_duration_relative_margin": 0.2
     },
-    "PlusOne_1": {
+    "PlusOneDeviceOperation_1": {
       "op_name": "PlusOne_1",
       "kernel_duration": 12576.729166666666,
       "op_to_op": 2232.9333333333334,
-      "non-overlapped-dispatch-time": 2225.3571428571427,
+      "non-overlapped-dispatch-time": 1598.0,
       "kernel_duration_relative_margin": 0.2,
       "op_to_op_duration_relative_margin": 0.4,
-      "dispatch_duration_relative_margin": 0.5
+      "dispatch_duration_relative_margin": 0.7
     }
   }
 }

--- a/models/demos/llama3_70b_galaxy/tests/decoder_perf_targets_6u.json
+++ b/models/demos/llama3_70b_galaxy/tests/decoder_perf_targets_6u.json
@@ -5,7 +5,7 @@
       "kernel_duration": 16719.618287037036,
       "op_to_op": 770.5111111111111,
       "first_to_last_start": 2178.4296296296297,
-      "non-overlapped-dispatch-time": 774.2222222222222,
+      "non-overlapped-dispatch-time": 8328.333333333334,
       "kernel_duration_relative_margin": 0.05,
       "op_to_op_duration_relative_margin": 0.2,
       "first_to_last_start_relative_margin": 0.2,
@@ -183,7 +183,7 @@
       "op_name": "InterleavedToSharded_0",
       "kernel_duration": 21786.4125,
       "op_to_op": 627.7333333333333,
-      "non-overlapped-dispatch-time": 615.0,
+      "non-overlapped-dispatch-time": 5138.0,
       "kernel_duration_relative_margin": 0.2,
       "op_to_op_duration_relative_margin": 0.2,
       "dispatch_duration_relative_margin": 0.2
@@ -192,7 +192,7 @@
       "op_name": "InterleavedToSharded_1",
       "kernel_duration": 879.2395833333334,
       "op_to_op": 691.2,
-      "non-overlapped-dispatch-time": 683.0,
+      "non-overlapped-dispatch-time": 2433.0,
       "kernel_duration_relative_margin": 0.2,
       "op_to_op_duration_relative_margin": 0.2,
       "dispatch_duration_relative_margin": 0.2
@@ -201,7 +201,7 @@
       "op_name": "InterleavedToSharded_2",
       "kernel_duration": 1298.8395833333334,
       "op_to_op": 703.7333333333333,
-      "non-overlapped-dispatch-time": 677.0,
+      "non-overlapped-dispatch-time": 2495.0,
       "kernel_duration_relative_margin": 0.2,
       "op_to_op_duration_relative_margin": 0.2,
       "dispatch_duration_relative_margin": 0.2
@@ -210,7 +210,7 @@
       "op_name": "RMSAllGather_0",
       "kernel_duration": 14480.010416666666,
       "op_to_op": 694.8666666666667,
-      "non-overlapped-dispatch-time": 691.0,
+      "non-overlapped-dispatch-time": 6911.0,
       "kernel_duration_relative_margin": 0.2,
       "op_to_op_duration_relative_margin": 0.2,
       "dispatch_duration_relative_margin": 0.2
@@ -219,7 +219,7 @@
       "op_name": "Reshard_0",
       "kernel_duration": 1118.5125,
       "op_to_op": 762.7333333333333,
-      "non-overlapped-dispatch-time": 726.0,
+      "non-overlapped-dispatch-time": 9920.0,
       "kernel_duration_relative_margin": 0.2,
       "op_to_op_duration_relative_margin": 0.2,
       "dispatch_duration_relative_margin": 0.2
@@ -228,7 +228,7 @@
       "op_name": "Reshard_1",
       "kernel_duration": 3915.485416666667,
       "op_to_op": 625.0,
-      "non-overlapped-dispatch-time": 700.0,
+      "non-overlapped-dispatch-time": 4330.0,
       "kernel_duration_relative_margin": 0.2,
       "op_to_op_duration_relative_margin": 0.2,
       "dispatch_duration_relative_margin": 0.2
@@ -237,7 +237,7 @@
       "op_name": "Matmul_0",
       "kernel_duration": 142716.93958333333,
       "op_to_op": 610.6666666666666,
-      "non-overlapped-dispatch-time": 598.0,
+      "non-overlapped-dispatch-time": 5490.0,
       "kernel_duration_relative_margin": 0.2,
       "op_to_op_duration_relative_margin": 0.2,
       "dispatch_duration_relative_margin": 0.2
@@ -246,7 +246,7 @@
       "op_name": "AllReduceAsync_0",
       "kernel_duration": 30319.389583333334,
       "op_to_op": 647.7333333333333,
-      "non-overlapped-dispatch-time": 614.0,
+      "non-overlapped-dispatch-time": 9795.0,
       "kernel_duration_relative_margin": 0.2,
       "op_to_op_duration_relative_margin": 0.2,
       "dispatch_duration_relative_margin": 0.2
@@ -255,7 +255,7 @@
       "op_name": "ShardedToInterleavedDeviceOperation_0",
       "kernel_duration": 8355.870833333332,
       "op_to_op": 789.2,
-      "non-overlapped-dispatch-time": 704.0,
+      "non-overlapped-dispatch-time": 4304.0,
       "kernel_duration_relative_margin": 0.3,
       "op_to_op_duration_relative_margin": 1.0,
       "dispatch_duration_relative_margin": 0.2
@@ -264,7 +264,7 @@
       "op_name": "ShardedToInterleavedDeviceOperation_1",
       "kernel_duration": 1002.19375,
       "op_to_op": 1849.0,
-      "non-overlapped-dispatch-time": 728.0,
+      "non-overlapped-dispatch-time": 2316.0,
       "kernel_duration_relative_margin": 0.2,
       "op_to_op_duration_relative_margin": 1.0,
       "dispatch_duration_relative_margin": 0.7
@@ -273,7 +273,7 @@
       "op_name": "ShardedToInterleavedDeviceOperation_2",
       "kernel_duration": 1442.96875,
       "op_to_op": 635.0,
-      "non-overlapped-dispatch-time": 725.0,
+      "non-overlapped-dispatch-time": 2230.0,
       "kernel_duration_relative_margin": 0.3,
       "op_to_op_duration_relative_margin": 0.3,
       "dispatch_duration_relative_margin": 0.2
@@ -300,7 +300,7 @@
       "op_name": "TopK_0",
       "kernel_duration": 179979.625,
       "op_to_op": 671.0,
-      "non-overlapped-dispatch-time": 654.0,
+      "non-overlapped-dispatch-time": 5476.0,
       "kernel_duration_relative_margin": 0.2,
       "op_to_op_duration_relative_margin": 0.7,
       "dispatch_duration_relative_margin": 0.2
@@ -309,7 +309,7 @@
       "op_name": "AllGatherAsync_0",
       "kernel_duration": 10840.89375,
       "op_to_op": 655.7333333333333,
-      "non-overlapped-dispatch-time": 635.0,
+      "non-overlapped-dispatch-time": 5497.0,
       "kernel_duration_relative_margin": 0.35,
       "op_to_op_duration_relative_margin": 0.2,
       "dispatch_duration_relative_margin": 0.2
@@ -318,7 +318,7 @@
       "op_name": "AllGatherAsync_1",
       "kernel_duration": 12112.06875,
       "op_to_op": 674.6,
-      "non-overlapped-dispatch-time": 652.0,
+      "non-overlapped-dispatch-time": 5789.0,
       "kernel_duration_relative_margin": 0.33,
       "op_to_op_duration_relative_margin": 0.2,
       "dispatch_duration_relative_margin": 0.2
@@ -327,7 +327,7 @@
       "op_name": "TypecastDeviceOperation_input_bf16",
       "kernel_duration": 20326.516666666666,
       "op_to_op": 639.3333333333334,
-      "non-overlapped-dispatch-time": 636.0,
+      "non-overlapped-dispatch-time": 4865.0,
       "kernel_duration_relative_margin": 0.2,
       "op_to_op_duration_relative_margin": 0.2,
       "dispatch_duration_relative_margin": 0.2
@@ -336,7 +336,7 @@
       "op_name": "TypecastDeviceOperation_0",
       "kernel_duration": 1887.1354166666667,
       "op_to_op": 662.2666666666667,
-      "non-overlapped-dispatch-time": 613.0,
+      "non-overlapped-dispatch-time": 3649.0,
       "kernel_duration_relative_margin": 0.2,
       "op_to_op_duration_relative_margin": 0.2,
       "dispatch_duration_relative_margin": 0.6
@@ -345,7 +345,7 @@
       "op_name": "BinaryDeviceOperation_Last_Residual",
       "kernel_duration": 849.73125,
       "op_to_op": 696.3333333333334,
-      "non-overlapped-dispatch-time": 675.0,
+      "non-overlapped-dispatch-time": 5230.0,
       "kernel_duration_relative_margin": 0.2,
       "op_to_op_duration_relative_margin": 0.2,
       "dispatch_duration_relative_margin": 0.2
@@ -354,7 +354,7 @@
       "op_name": "BinaryDeviceOperation_Indices_Correction",
       "kernel_duration": 3139.0291666666667,
       "op_to_op": 665.4,
-      "non-overlapped-dispatch-time": 640.0,
+      "non-overlapped-dispatch-time": 6259.0,
       "kernel_duration_relative_margin": 0.2,
       "op_to_op_duration_relative_margin": 0.2,
       "dispatch_duration_relative_margin": 0.2
@@ -372,7 +372,7 @@
       "op_name": "Untilize_0",
       "kernel_duration": 2918.804166666667,
       "op_to_op": 644.8666666666667,
-      "non-overlapped-dispatch-time": 655.0,
+      "non-overlapped-dispatch-time": 3793.0,
       "kernel_duration_relative_margin": 0.2,
       "op_to_op_duration_relative_margin": 0.4,
       "dispatch_duration_relative_margin": 0.2
@@ -381,7 +381,7 @@
       "op_name": "Sampling_0",
       "kernel_duration": 67650.89791666667,
       "op_to_op": 54836.46666666667,
-      "non-overlapped-dispatch-time": 49290.0,
+      "non-overlapped-dispatch-time": 84648.0,
       "kernel_duration_relative_margin": 0.2,
       "op_to_op_duration_relative_margin": 0.2,
       "dispatch_duration_relative_margin": 0.2
@@ -390,7 +390,7 @@
       "op_name": "PlusOne_0",
       "kernel_duration": 442.40625,
       "op_to_op": 650.0,
-      "non-overlapped-dispatch-time": 713.0,
+      "non-overlapped-dispatch-time": 4491.0,
       "kernel_duration_relative_margin": 0.2,
       "op_to_op_duration_relative_margin": 0.4,
       "dispatch_duration_relative_margin": 0.2
@@ -399,7 +399,7 @@
       "op_name": "PlusOne_1",
       "kernel_duration": 12576.729166666666,
       "op_to_op": 2232.9333333333334,
-      "non-overlapped-dispatch-time": 1598.0,
+      "non-overlapped-dispatch-time": 2203.0,
       "kernel_duration_relative_margin": 0.2,
       "op_to_op_duration_relative_margin": 0.4,
       "dispatch_duration_relative_margin": 0.7


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/31202

### Problem description
Model perf pipelines were failing due to various reasons previously
- UMD changes leading to device lock such that you cant open device in subprocess
- misc fabric issues that have been resolved

### What's changed
- disable any fixtures that open the device in the main process for model perf tests
- modify `test_decoder_device_perf.py` to fix op index issues when trying to parse op csv
- restore llama model perf test pipelines in yaml

### Checklist
- [ ] [Galaxy Model Perf Pipelines](https://github.com/tenstorrent/tt-metal/actions/runs/21498985293)