### PR TITLE
SDXL CI fix

### DIFF
--- a/models/experimental/stable_diffusion_xl_base/refiner/tests/pcc/test_module_tt_transformerblock.py
+++ b/models/experimental/stable_diffusion_xl_base/refiner/tests/pcc/test_module_tt_transformerblock.py
@@ -21,8 +21,8 @@ from models.experimental.stable_diffusion_xl_base.tests.test_common import SDXL_
         ((1, 4096, 768), (1, 77, 1280), 1, 1, 768, 12, 768, 0.999, "down_blocks"),
         ((1, 1024, 1536), (1, 77, 1280), 2, 0, 1536, 24, 1536, 0.999, "down_blocks"),
         ((1, 1024, 1536), (1, 77, 1280), 2, 1, 1536, 24, 1536, 0.998, "down_blocks"),
-        ((1, 256, 1536), (1, 77, 1280), -1, 0, 1536, 24, 1536, 0.999, "mid_block"),
-        ((1, 256, 1536), (1, 77, 1280), -1, 1, 1536, 24, 1536, 0.998, "mid_block"),
+        ((1, 256, 1536), (1, 77, 1280), -1, 0, 1536, 24, 1536, 0.998, "mid_block"),
+        ((1, 256, 1536), (1, 77, 1280), -1, 1, 1536, 24, 1536, 0.999, "mid_block"),
     ],
 )
 @pytest.mark.parametrize("device_params", [{"l1_small_size": SDXL_L1_SMALL_SIZE}], indirect=True)


### PR DESCRIPTION
### What's changed
Logic for determining default matmul program config changed, refiner tests are affected. We should define program configs for refiner, in the meantime thresholds will be adapted

### Checklist
- [x] [(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/19329280198) CI passes