### PR TITLE
SDPA L1 interleaved

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_scaled_dot_product_attention.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_scaled_dot_product_attention.py
@@ -79,7 +79,18 @@ def create_sliding_window_mask_prefill(b, nh, seq_len, sliding_window=0, is_caus
 
 
 def run_test_sdpa_tt(
-    device, b, nh, nkv, s, d, q_chunk_size, k_chunk_size, dtype, use_high_precision_compute=False, rmse_threshold=None
+    device,
+    b,
+    nh,
+    nkv,
+    s,
+    d,
+    q_chunk_size,
+    k_chunk_size,
+    dtype,
+    use_high_precision_compute=False,
+    rmse_threshold=None,
+    memory_config=ttnn.DRAM_MEMORY_CONFIG,
 ):
     torch.manual_seed(1234)
 
@@ -109,9 +120,15 @@ def run_test_sdpa_tt(
     K = fa_rand(b, nkv, s, d)
     V = fa_rand(b, nkv, s, d)
 
-    tt_Q = ttnn.from_torch(Q, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device, pad_value=0.0)
-    tt_K = ttnn.from_torch(K, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device, pad_value=0.0)
-    tt_V = ttnn.from_torch(V, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device, pad_value=0.0)
+    tt_Q = ttnn.from_torch(
+        Q, dtype=dtype, layout=ttnn.TILE_LAYOUT, memory_config=memory_config, device=device, pad_value=0.0
+    )
+    tt_K = ttnn.from_torch(
+        K, dtype=dtype, layout=ttnn.TILE_LAYOUT, memory_config=memory_config, device=device, pad_value=0.0
+    )
+    tt_V = ttnn.from_torch(
+        V, dtype=dtype, layout=ttnn.TILE_LAYOUT, memory_config=memory_config, device=device, pad_value=0.0
+    )
     tt_back = ttnn.transformer.scaled_dot_product_attention(
         tt_Q, tt_K, tt_V, is_causal=True, program_config=program_config, compute_kernel_config=compute_kernel_config
     )
@@ -242,6 +259,9 @@ def test_sdpa_tt_padded(device, b, nh, nkv, s, d, q_chunk_size, k_chunk_size, dt
 
 @pytest.mark.skipif(is_watcher_enabled(), reason="Kernel OOM with watcher enabled")
 @pytest.mark.parametrize("dtype", [ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat16], ids=["bfp4", "bfp8", "bf16"])
+@pytest.mark.parametrize(
+    "memory_config", [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG], ids=["dram_interleaved", "l1_interleaved"]
+)
 @pytest.mark.parametrize("q_chunk_size", [128, 256], ids=["q128", "q256"])
 @pytest.mark.parametrize("k_chunk_size", [128, 256], ids=["k128", "k256"])
 @pytest.mark.parametrize(
@@ -254,7 +274,7 @@ def test_sdpa_tt_padded(device, b, nh, nkv, s, d, q_chunk_size, k_chunk_size, dt
         [1, 8, 1, 8192, 128],  # Llama2-70B large sequence
     ),
 )
-def test_sdpa_tt(device, b, nh, nkv, s, d, q_chunk_size, k_chunk_size, dtype):
+def test_sdpa_tt(device, b, nh, nkv, s, d, q_chunk_size, k_chunk_size, dtype, memory_config):
     if dtype == ttnn.bfloat4_b and (
         q_chunk_size > 128 or k_chunk_size > 128 or [b, nh, nkv, s, d] != [1, 8, 1, 2048, 128]
     ):
@@ -263,9 +283,23 @@ def test_sdpa_tt(device, b, nh, nkv, s, d, q_chunk_size, k_chunk_size, dtype):
         pytest.skip("s must be divisible by q_chunk_size and k_chunk_size")
     if nh == 8 and q_chunk_size == 128 and k_chunk_size == 128:
         pytest.skip("Can cause OOM if profiling is enabled.")
+    if memory_config == ttnn.L1_MEMORY_CONFIG and k_chunk_size > 128 and q_chunk_size > 128:
+        pytest.skip("L1 memory config with large chunk sizes can cause OOM.")
     rmse_threshold = 0.0092 if (dtype == ttnn.bfloat8_b or dtype == ttnn.bfloat4_b) else 0.0093
     ttnn.device.DisablePersistentKernelCache()
-    run_test_sdpa_tt(device, b, nh, nkv, s, d, q_chunk_size, k_chunk_size, dtype, rmse_threshold=rmse_threshold)
+    run_test_sdpa_tt(
+        device,
+        b,
+        nh,
+        nkv,
+        s,
+        d,
+        q_chunk_size,
+        k_chunk_size,
+        dtype,
+        rmse_threshold=rmse_threshold,
+        memory_config=memory_config,
+    )
 
 
 @pytest.mark.skipif(is_watcher_enabled(), reason="Kernel OOM with watcher enabled")

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_op.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_op.cpp
@@ -37,9 +37,7 @@ void ScaledDotProductAttention::validate(
                 input_tensor.dtype() == DataType::BFLOAT4_B,
             "Data type of input tensor must be BFLOAT16, BFLOAT8_B, or BFLOAT4_B and is {}",
             input_tensor.dtype());
-        TT_FATAL(
-            input_tensor.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM,
-            "Operands to SDPA need to be in DRAM");
+        TT_FATAL(!input_tensor.is_sharded(), "Operands to SDPA need to be DRAM/L1 interleaved");
     }
 
     auto validate_padding = [&](const Tensor& tensor) {


### PR DESCRIPTION
### Problem description
SDPA supports only DRAM interleaved inputs.

### What's changed
Op code does not assume tensor location for the interleaved tensors, this is hidden away with `TensorAccessor`. Due to this changing the assert in validate function to fail only when input is sharded.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/19361692147) CI passes
- [x] [Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/runs/19366868577) CI passes