### PR TITLE
[skip ci] Remove --enable-profiler from docs.

### DIFF
--- a/docs/source/tt-metalium/tools/device_program_profiler.rst
+++ b/docs/source/tt-metalium/tools/device_program_profiler.rst
@@ -14,7 +14,7 @@ To use the device profiler, you must first build Metalium with profiling enabled
 
 .. code-block:: bash
 
-    ./build_metal.sh --enable-profiler
+    ./build_metal.sh
 
 This command enables both device-side profiling and Tracy for host-side profiling. For a general overview of profiling in Metalium and how to use the Tracy GUI, see :ref:`tracy_profiler`.
 
@@ -114,7 +114,7 @@ To build and run this example:
 .. code-block:: bash
 
     cd $TT_METAL_HOME
-    build_metal.sh --enable-profiler --build-programming-examples
+    build_metal.sh --build-programming-examples
     TT_METAL_DEVICE_PROFILER=1 ./build/programming_examples/profiler/test_full_buffer
 
 The results will be available in the Tracy GUI and in the ``profile_log_device.csv`` file.

--- a/docs/source/tt-metalium/tools/tracy_profiler.rst
+++ b/docs/source/tt-metalium/tools/tracy_profiler.rst
@@ -20,14 +20,14 @@ All host-side code, including python code in ``tt_metal`` can be profiled using 
 Enabling Tracy
 --------------
 
-To use Tracy for profiling, you need to build Metalium with profiler support enabled. This is done by setting the ``ENABLE_TRACY=ON`` option when configuring CMake. Or with the ``--enable-profiler`` flag in the build script. Profiling features are only available in builds where this option is set.
+To use Tracy for profiling, you need to build Metalium with profiler support (enabled by default).
 
 You can enable the profiler by running:
 
 ..  code-block:: bash
 
     # Via build script
-    ./build_metal.sh --enable-profiler
+    ./build_metal.sh
 
     # Via CMake flags
     cmake . -DENABLE_TRACY=ON


### PR DESCRIPTION
### Ticket

Closes https://github.com/tenstorrent/tt-metal/issues/32360

### Problem description

`build_metal.sh` has profiler enabled by default.

### What's changed

Remove `--enable-profiler` from docs.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes