### PR TITLE
Use typed activation function param for matmul inside conv2d

### DIFF
--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
@@ -276,10 +276,6 @@ Result conv2d_DRAM(
         // run conv as matmul
         std::optional<ttnn::operations::matmul::MatmulProgramConfig> program_config = std::nullopt;
         std::optional<MemoryConfig> mm_output_memory_config = std::nullopt;
-        std::optional<std::string> linear_activation = std::nullopt;
-        if (conv_config.activation.has_value()) {
-            linear_activation = unary::utils::unary_with_param_to_string(conv_config.activation.value());
-        }
         // Matmul expects inputs to be in Tile Layout
         tilize_with_optional_deallocation(input_tensor_on_device, conv_config.deallocate_activation);
         Tensor matmul_output = ttnn::linear(
@@ -291,7 +287,7 @@ Result conv2d_DRAM(
             mm_output_memory_config,
             output_dtype,
             program_config,
-            linear_activation,
+            conv_config.activation,
             compute_config);
         if (conv_config.deallocate_activation) {
             input_tensor_on_device.deallocate(true);
@@ -716,7 +712,6 @@ Result conv2d_L1(
         // run conv as matmul
         std::optional<ttnn::operations::matmul::MatmulProgramConfig> program_config = std::nullopt;
         std::optional<MemoryConfig> mm_output_memory_config = std::nullopt;
-        std::optional<std::string> linear_activation = std::nullopt;
 
         if (input_tensor_post_tm.is_sharded()) {
             uint32_t num_cores_c = get_num_cores_channels_from_parallel_config(parallel_config);
@@ -728,10 +723,6 @@ Result conv2d_L1(
                 parallel_config.shard_orientation == ShardOrientation::COL_MAJOR,
                 num_cores_c);
             mm_output_memory_config = conv_out_memory_config;
-        } else {
-            if (conv_config.activation.has_value()) {
-                linear_activation = unary::utils::unary_with_param_to_string(conv_config.activation.value());
-            }
         }
 
         Tensor matmul_output = ttnn::linear(
@@ -743,7 +734,8 @@ Result conv2d_L1(
             mm_output_memory_config,
             output_dtype,
             program_config,
-            linear_activation,
+            // for sharded input, activation is set on program config
+            input_tensor_post_tm.is_sharded() ? std::nullopt : conv_config.activation,
             compute_config);
 
         if (conv_config.deallocate_activation) {

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
@@ -902,48 +902,6 @@ UnaryWithParam string_to_unary_with_param(const std::string& name) {
     TT_THROW("Unknown unary op: {}", name);
 }
 
-std::string unary_with_param_to_string(const UnaryWithParam& unary_op) {
-    switch (unary_op.op_type) {
-        case UnaryOpType::RELU: return "relu";
-        case UnaryOpType::RELU6: return "relu6";
-        case UnaryOpType::GELU:
-            if (!unary_op.params.empty() && unary_op.params[0] == static_cast<float>(true)) {
-                return "gelu_approx";
-            }
-            return "gelu";
-        case UnaryOpType::SILU: return "silu";
-        case UnaryOpType::SIGMOID:
-            if (unary_op.params.size() >= 2 && unary_op.params[1] == static_cast<float>(true)) {
-                return "sigmoid_approx";
-            }
-            return "sigmoid";
-        case UnaryOpType::HARDSIGMOID: return "hardsigmoid";
-        case UnaryOpType::SQRT: return "sqrt";
-        case UnaryOpType::RSQRT: return "rsqrt";
-        case UnaryOpType::EXP: return "exp";
-        case UnaryOpType::RECIP: return "recip";
-        case UnaryOpType::LOG: return "log";
-        case UnaryOpType::LOG1P: return "log1p";
-        case UnaryOpType::TANH: return "tanh";
-        case UnaryOpType::LOG2: return "log2";
-        case UnaryOpType::LOG10: return "log10";
-        case UnaryOpType::SIN: return "sin";
-        case UnaryOpType::COS: return "cos";
-        case UnaryOpType::COSH: return "cosh";
-        case UnaryOpType::SINH: return "sinh";
-        case UnaryOpType::ABS: return "abs";
-        case UnaryOpType::ABS_INT32: return "abs_int32";
-        case UnaryOpType::SIGN: return "sign";
-        case UnaryOpType::SQUARE: return "square";
-        case UnaryOpType::SOFTPLUS: return "softplus";
-        case UnaryOpType::SELU: return "selu";
-        case UnaryOpType::ALT_COMPLEX_ROTATE90: return "alt_complex_rotate90";
-        case UnaryOpType::MISH: return "mish";
-        case UnaryOpType::HARDMISH: return "hardmish";
-        default: TT_THROW("Unsupported unary op type: {}", static_cast<int>(unary_op.op_type));
-    }
-}
-
 template <typename T>
 std::map<std::string, std::string> get_defines(
     UnaryOpType op_type,

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.hpp
@@ -14,8 +14,6 @@ namespace ttnn::operations::unary::utils {
 
 UnaryWithParam string_to_unary_with_param(const std::string& name);
 
-std::string unary_with_param_to_string(const UnaryWithParam& unary_op);
-
 bool get_op_approx_mode(UnaryOpType op_type);
 using DataType = tt::tt_metal::DataType;
 


### PR DESCRIPTION
This change updates the handling of activation functions for matmul operations inside conv2d by passing the typed UnaryOpWithParam directly, instead of converting it to a string and passing that string to ttnn::linear.

Recent updates to the matmul interfaces added native support for UnaryOpWithParam to specify activation functions. Leveraging this eliminates the need for the previous mapping from UnaryOpWithParam to string representations.

The only caveat is that when matmul is sharded, activations must be passed through the matmul program configuration. This approach is necessary to ensure the activation function fusion is correctly applied.

Note that in this scenario, activation functions need to be set to nullopt on the ttnn::linear interfaces, because even setting the same activation directly leads to a different code path where fusion might not occur.

Nightly tt-metal L2 tests
https://github.com/tenstorrent/tt-metal/actions/runs/19327013226
(Single-card) Frequent model and ttnn tests
https://github.com/tenstorrent/tt-metal/actions/runs/19326990874