### PR TITLE
[not for review] Support all outputs in lazy mode + track graph in eager mode

### DIFF
--- a/tests/ttnn/unit_tests/gtests/test_lazy_mode.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_lazy_mode.cpp
@@ -482,7 +482,7 @@ TEST_F(LazyModeFixture, MatmulWithElementwiseLazy) {
     auto eager_result = final_eager.cpu();
 
     log_info(tt::LogTest, "Printing eager graph...");
-    lazy::print_graph(final_eager.lazy());
+    lazy::print_graph(final_eager);
 
     // ========== Now run LAZY mode and compare ==========
     log_info(tt::LogTest, "Running same operations in LAZY mode...");

--- a/tests/ttnn/unit_tests/gtests/test_lazy_mode.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_lazy_mode.cpp
@@ -481,8 +481,8 @@ TEST_F(LazyModeFixture, MatmulWithElementwiseLazy) {
     auto final_eager = ttnn::multiply(exp_result_eager, matmul_result_eager);
     auto eager_result = final_eager.cpu();
 
-    // Clean up eager tensors to free device memory before running lazy mode
-    log_info(tt::LogTest, "Cleaning up eager tensors...");
+    log_info(tt::LogTest, "Printing eager graph...");
+    lazy::print_graph(final_eager.lazy());
 
     // ========== Now run LAZY mode and compare ==========
     log_info(tt::LogTest, "Running same operations in LAZY mode...");

--- a/ttnn/api/ttnn/decorators.hpp
+++ b/ttnn/api/ttnn/decorators.hpp
@@ -198,15 +198,15 @@ private:
 
         auto lazy_inputs = ttnn::experimental::lazy::make_lazy_device_operation_inputs<operation_t>(tensor_args);
 
-        // Call compute_output_specs and flatten to vector<TensorSpec>
+        // Call compute_output_specs and flatten to vector<optional<TensorSpec>>
         auto output_specs = operation_t::compute_output_specs(operation_attributes, tensor_args);
-        auto [flat_specs, is_optional] = ttnn::experimental::lazy::flatten_specs(output_specs);
+        auto flat_specs = ttnn::experimental::lazy::flatten_specs(output_specs);
 
         // Create lazy tensors using the flat vector
         auto lazy_tensors = Tensor::make_lazy_tensors(lazy_inputs, lazy_op, flat_specs);
 
         // Reconstruct the correct return type
-        return ttnn::experimental::lazy::reconstruct_return_value<tensor_return_value_t>(lazy_tensors, is_optional);
+        return ttnn::experimental::lazy::reconstruct_return_value<tensor_return_value_t>(lazy_tensors, flat_specs);
     }
 };
 

--- a/ttnn/api/ttnn/experimental/lazy/evaluation_manager.hpp
+++ b/ttnn/api/ttnn/experimental/lazy/evaluation_manager.hpp
@@ -11,4 +11,5 @@ class LazyTensor;
 
 void evaluate(const std::shared_ptr<LazyTensor>& lazy_tensor);
 
+void print_graph(const std::shared_ptr<LazyTensor>& lazy_tensor);
 }  // namespace ttnn::experimental::lazy

--- a/ttnn/api/ttnn/experimental/lazy/evaluation_manager.hpp
+++ b/ttnn/api/ttnn/experimental/lazy/evaluation_manager.hpp
@@ -7,9 +7,8 @@ class Tensor;
 }
 
 namespace ttnn::experimental::lazy {
-class LazyTensor;
 
-void evaluate(const std::shared_ptr<LazyTensor>& lazy_tensor);
+void evaluate(const tt::tt_metal::Tensor& tensor);
 
-void print_graph(const std::shared_ptr<LazyTensor>& lazy_tensor);
+void print_graph(const tt::tt_metal::Tensor& tensor);
 }  // namespace ttnn::experimental::lazy

--- a/ttnn/api/ttnn/experimental/lazy/lazy_device_operation.hpp
+++ b/ttnn/api/ttnn/experimental/lazy/lazy_device_operation.hpp
@@ -57,6 +57,11 @@ public:
 
     tt::stl::hash::hash_t operation_type_id() const override { return tt::stl::hash::type_hash<operation_t>; }
 
+    std::vector<std::optional<TensorSpec>> compute_output_specs(const tensor_args_t& tensor_args) const {
+        auto specs = operation_t::compute_output_specs(attributes_, tensor_args);
+        return flatten_specs(specs);
+    }
+
     // Required for hashing support
     tt::stl::hash::hash_t to_hash() const {
         // Hash based on the operation type and attributes

--- a/ttnn/api/ttnn/experimental/lazy/lazy_tensor.hpp
+++ b/ttnn/api/ttnn/experimental/lazy/lazy_tensor.hpp
@@ -30,8 +30,8 @@ enum class LazyTensorState {
 };
 
 class LazyTensor {
-    using LazyOperationPtr = std::shared_ptr<ttnn::experimental::lazy::LazyOperation>;
-    using LazyOperationInputsPtr = std::shared_ptr<ttnn::experimental::lazy::LazyOperationInputs>;
+    using LazyOperationPtr = std::shared_ptr<LazyOperation>;
+    using LazyOperationInputsPtr = std::shared_ptr<LazyOperationInputs>;
     using TensorSpec = tt::tt_metal::TensorSpec;
     using MaterializedTensor = tt::tt_metal::metal_tensor::Tensor;
 
@@ -107,7 +107,7 @@ public:
     static std::vector<std::shared_ptr<LazyTensor>> make_lazy_tensors(
         const LazyOperationInputsPtr& op_inputs,
         const LazyOperationPtr& op,
-        const std::vector<TensorSpec>& tensor_specs);
+        const std::vector<std::optional<TensorSpec>>& tensor_specs);
 
     static std::shared_ptr<LazyTensor> make_materialized_tensor(const MaterializedTensor& metal_tensor);
 

--- a/ttnn/api/ttnn/experimental/lazy/lazy_utils.hpp
+++ b/ttnn/api/ttnn/experimental/lazy/lazy_utils.hpp
@@ -5,11 +5,140 @@
 #pragma once
 
 #include "ttnn/tensor/tensor.hpp"
-#include <optional>
-#include <functional>
+#include <array>
 #include <tuple>
-#include <utility>
 
 namespace ttnn::experimental::lazy {
+
+// Check if type is std::array<Tensor, N>
+template <typename T>
+struct is_tensor_array : std::false_type {};
+
+template <std::size_t N>
+struct is_tensor_array<std::array<Tensor, N>> : std::true_type {};
+
+template <typename T>
+inline constexpr bool is_tensor_array_v = is_tensor_array<T>::value;
+
+// Check if type is std::tuple of all Tensors
+template <typename T>
+struct is_all_tensor_tuple : std::false_type {};
+
+template <typename... Types>
+struct is_all_tensor_tuple<std::tuple<Types...>> : std::bool_constant<(std::same_as<Types, Tensor> && ...)> {};
+
+template <typename T>
+inline constexpr bool is_all_tensor_tuple_v = is_all_tensor_tuple<T>::value;
+
+// Helper to flatten spec_return_value_t to vector<TensorSpec> and track nullopt positions
+struct SpecConversionResult {
+    std::vector<TensorSpec> specs;
+    std::vector<bool> is_optional;  // true if position was nullopt in original spec
+};
+
+// Flatten any spec type to vector<TensorSpec>
+template <typename SpecType>
+SpecConversionResult flatten_specs(const SpecType& specs) {
+    using spec_t = std::decay_t<SpecType>;
+
+    if constexpr (std::same_as<spec_t, TensorSpec>) {
+        // Single spec
+        return {std::vector<TensorSpec>{specs}, std::vector<bool>{false}};
+    } else if constexpr (std::same_as<spec_t, std::vector<TensorSpec>>) {
+        // Vector of specs (all non-optional)
+        return {specs, std::vector<bool>(specs.size(), false)};
+    } else if constexpr (std::same_as<spec_t, std::vector<std::optional<TensorSpec>>>) {
+        // Vector of optional specs
+        SpecConversionResult result;
+        result.specs.reserve(specs.size());
+        result.is_optional.reserve(specs.size());
+        for (const auto& spec_opt : specs) {
+            if (spec_opt.has_value()) {
+                result.specs.push_back(spec_opt.value());
+                result.is_optional.push_back(false);
+            } else {
+                result.is_optional.push_back(true);
+            }
+        }
+        return result;
+    } else if constexpr (requires { std::tuple_size<spec_t>::value; }) {
+        // Tuple (array or tuple) - convert to vector
+        constexpr auto N = std::tuple_size_v<spec_t>;
+        SpecConversionResult result;
+        result.specs.reserve(N);
+        result.is_optional.reserve(N);
+
+        [&]<std::size_t... Is>(std::index_sequence<Is...>) {
+            (
+                (void)[&] {
+                    const auto& elem = std::get<Is>(specs);
+                    using elem_t = std::decay_t<decltype(elem)>;
+                    if constexpr (std::same_as<elem_t, TensorSpec>) {
+                        result.specs.push_back(elem);
+                        result.is_optional.push_back(false);
+                    } else if constexpr (std::same_as<elem_t, std::optional<TensorSpec>>) {
+                        if (elem.has_value()) {
+                            result.specs.push_back(elem.value());
+                            result.is_optional.push_back(false);
+                        } else {
+                            result.is_optional.push_back(true);
+                        }
+                    }
+                }(),
+                ...);
+        }(std::make_index_sequence<N>{});
+
+        return result;
+    } else {
+        static_assert(std::same_as<spec_t, void>, "Unsupported spec type");
+        return {};
+    }
+}
+
+// Reconstruct tensor_return_value_t from vector<Tensor>
+template <typename ReturnType>
+ReturnType reconstruct_return_value(const std::vector<Tensor>& tensors, const std::vector<bool>& is_optional) {
+    using return_t = std::decay_t<ReturnType>;
+
+    if constexpr (std::same_as<return_t, Tensor>) {
+        // Single tensor
+        TT_FATAL(tensors.size() == 1, "Expected 1 tensor");
+        return tensors[0];
+    } else if constexpr (std::same_as<return_t, std::vector<Tensor>>) {
+        // Vector of tensors
+        return tensors;
+    } else if constexpr (std::same_as<return_t, std::vector<std::optional<Tensor>>>) {
+        // Vector of optional tensors - reconstruct with nullopts
+        std::vector<std::optional<Tensor>> result;
+        result.reserve(is_optional.size());
+        size_t tensor_idx = 0;
+        for (bool is_null : is_optional) {
+            if (is_null) {
+                result.push_back(std::nullopt);
+            } else {
+                result.push_back(tensors[tensor_idx++]);
+            }
+        }
+        return result;
+    } else if constexpr (is_tensor_array_v<return_t>) {
+        // std::array<Tensor, N>
+        constexpr auto N = std::tuple_size_v<return_t>;
+        TT_FATAL(tensors.size() == N, "Expected {} tensors", N);
+        return_t result;
+        for (size_t i = 0; i < N; i++) {
+            result[i] = tensors[i];
+        }
+        return result;
+    } else if constexpr (is_all_tensor_tuple_v<return_t>) {
+        // std::tuple<Tensor, ...>
+        constexpr auto N = std::tuple_size_v<return_t>;
+        TT_FATAL(tensors.size() == N, "Expected {} tensors", N);
+        return [&]<std::size_t... Is>(std::index_sequence<Is...>) {
+            return return_t{tensors[Is]...};
+        }(std::make_index_sequence<N>{});
+    } else {
+        static_assert(std::same_as<return_t, void>, "Unsupported return type");
+    }
+}
 
 }  // namespace ttnn::experimental::lazy

--- a/ttnn/api/ttnn/experimental/lazy/lazy_utils.hpp
+++ b/ttnn/api/ttnn/experimental/lazy/lazy_utils.hpp
@@ -162,7 +162,10 @@ ReturnType reconstruct_return_value(
             return tensors;
         }
     } else {
-        static_assert(std::same_as<return_t, void>, "Unsupported return type");
+        static_assert(
+            std::same_as<return_t, void>,
+            "Unsupported return type. Supported return types are Tensor, optional<Tensor>, tuple<Tensor, ...>, "
+            "array<Tensor, ...>, vector<Tensor> and vector<optional<Tensor>>.");
     }
 }
 

--- a/ttnn/api/ttnn/tensor/tensor.hpp
+++ b/ttnn/api/ttnn/tensor/tensor.hpp
@@ -212,7 +212,7 @@ public:
     static std::vector<Tensor> make_lazy_tensors(
         const std::shared_ptr<ttnn::experimental::lazy::LazyOperationInputs>& op_inputs,
         const std::shared_ptr<ttnn::experimental::lazy::LazyOperation>& op,
-        const std::vector<TensorSpec>& tensor_specs);
+        const std::vector<std::optional<TensorSpec>>& tensor_specs);
 
     void evaluate();
 

--- a/ttnn/api/ttnn/tensor/tensor.hpp
+++ b/ttnn/api/ttnn/tensor/tensor.hpp
@@ -208,7 +208,7 @@ public:
     static Tensor make_lazy_tensor(
         const std::shared_ptr<ttnn::experimental::lazy::LazyOperationInputs>& op_inputs,
         const std::shared_ptr<ttnn::experimental::lazy::LazyOperation>& op,
-        TensorSpec tensor_spec);
+        const TensorSpec& tensor_spec);
     static std::vector<Tensor> make_lazy_tensors(
         const std::shared_ptr<ttnn::experimental::lazy::LazyOperationInputs>& op_inputs,
         const std::shared_ptr<ttnn::experimental::lazy::LazyOperation>& op,

--- a/ttnn/core/tensor/experimental/lazy/compile/passes/unary_operation_fusion.cpp
+++ b/ttnn/core/tensor/experimental/lazy/compile/passes/unary_operation_fusion.cpp
@@ -113,9 +113,6 @@ void UnaryOperationsFusionPass::run(const ttnn::Tensor& tensor) {
             auto* last_unary_op = chain.back();
             auto old_attributes = last_unary_op->attributes();
 
-            // Get the output specs from the last operation (since that's what our fused op will output)
-            auto output_specs = last_unary_op->compute_output_specs();
-
             // Get the input of the first operation in the chain (for graph dependency update)
             auto first_op_inputs = chain_tensors[0]->op_inputs();
             auto first_op_tensor_args =

--- a/ttnn/core/tensor/experimental/lazy/evaluation_manager.cpp
+++ b/ttnn/core/tensor/experimental/lazy/evaluation_manager.cpp
@@ -30,69 +30,84 @@ std::string get_input_ids(const std::shared_ptr<LazyTensor>& tensor) {
 }
 
 // This is an example of how we're going to traverse nodes in graph later
-void log_unary_operation(const std::shared_ptr<LazyTensor>& tensor) {
+void log_unary_operation(const std::shared_ptr<LazyTensor>& tensor, const std::string& prefix) {
     auto op = tensor->op();
     auto* unary_op = dynamic_cast<LazyDeviceOperation<UnaryDeviceOperation>*>(op.get());
     auto attributes = unary_op->attributes();
     log_info(
         tt::LogTest,
-        "[Evaluate] [lazy_id={}] Unary Operation[type={}, input_ids={}]",
+        "[{}] [lazy_id={}] Unary Operation[type={}, input_ids={}]",
+        prefix,
         tensor->id(),
         enchantum::to_string(attributes.op_chain.at(0).type()),
         get_input_ids(tensor));
 }
-void log_binary_ng_operation(const std::shared_ptr<LazyTensor>& tensor) {
+void log_binary_ng_operation(const std::shared_ptr<LazyTensor>& tensor, const std::string& prefix) {
     auto op = tensor->op();
     auto* binary_ng_op = dynamic_cast<LazyDeviceOperation<BinaryNgDeviceOperation>*>(op.get());
     auto attributes = binary_ng_op->attributes();
     log_info(
         tt::LogTest,
-        "[Evaluate] [lazy_id={}] Binary Operation[type={}, input_ids={}]",
+        "[{}] [lazy_id={}] Binary Operation[type={}, input_ids={}]",
+        prefix,
         tensor->id(),
         enchantum::to_string(attributes.binary_op_type),
         get_input_ids(tensor));
 }
 
-void log_old_infra_operation(const std::shared_ptr<LazyTensor>& tensor) {
+void log_old_infra_operation(const std::shared_ptr<LazyTensor>& tensor, const std::string& prefix) {
     auto op = tensor->op();
     // TODO: We should probably capture old infra operation differently to skip casting it to OldInfraDeviceOperation
     auto* old_infra_op = dynamic_cast<LazyDeviceOperation<OldInfraDeviceOperation<Tensors>>*>(op.get());
     auto attributes = old_infra_op->attributes();
     log_info(
         tt::LogTest,
-        "[Evaluate] [lazy_id={}] {} Operation[input_ids={}] (Old Infra)",
+        "[{}] [lazy_id={}] {} Operation[input_ids={}] (Old Infra)",
+        prefix,
         tensor->id(),
         attributes.get_type_name(),
         get_input_ids(tensor));
 }
 
-std::unordered_map<tt::stl::hash::hash_t, std::function<void(const std::shared_ptr<LazyTensor>&)>> operation_log_map = {
-    {tt::stl::hash::type_hash<UnaryDeviceOperation>, log_unary_operation},
-    {tt::stl::hash::type_hash<BinaryNgDeviceOperation>, log_binary_ng_operation},
-    {tt::stl::hash::type_hash<OldInfraDeviceOperation<Tensors>>, log_old_infra_operation},
+std::unordered_map<tt::stl::hash::hash_t, std::function<void(const std::shared_ptr<LazyTensor>&, const std::string&)>>
+    operation_log_map = {
+        {tt::stl::hash::type_hash<UnaryDeviceOperation>, log_unary_operation},
+        {tt::stl::hash::type_hash<BinaryNgDeviceOperation>, log_binary_ng_operation},
+        {tt::stl::hash::type_hash<OldInfraDeviceOperation<Tensors>>, log_old_infra_operation},
 };
+
+void print_lazy_tensor(const std::shared_ptr<LazyTensor>& tensor, const std::string& prefix) {
+    if (tensor->op()) {
+        if (operation_log_map.find(tensor->op()->operation_type_id()) != operation_log_map.end()) {
+            operation_log_map[tensor->op()->operation_type_id()](tensor, prefix);
+        } else {
+            log_info(
+                tt::LogTest,
+                "[{}] [lazy_id={}] {} Operation[input_ids={}, type_id={}]",
+                prefix,
+                tensor->id(),
+                tensor->op()->name(),
+                get_input_ids(tensor),
+                tensor->op()->operation_type_id());
+        }
+    } else {
+        log_info(tt::LogTest, "[{}] [lazy_id={}] Unknown Operation[type_id=???]", prefix, tensor->id());
+    }
+}
 }  // namespace
 
 void evaluate(const std::shared_ptr<LazyTensor>& lazy_tensor) {
     auto sorted_tensors = GraphUtils::topological_sort(lazy_tensor);
     for (auto& tensor : sorted_tensors) {
-        if (tensor->op()) {
-            if (operation_log_map.find(tensor->op()->operation_type_id()) != operation_log_map.end()) {
-                operation_log_map[tensor->op()->operation_type_id()](tensor);
-            } else {
-                log_info(
-                    tt::LogTest,
-                    "[Evaluate] [lazy_id={}] {} Operation[input_ids={}, type_id={}]",
-                    tensor->id(),
-                    tensor->op()->name(),
-                    get_input_ids(tensor),
-                    tensor->op()->operation_type_id());
-            }
-        } else {
-            log_info(tt::LogTest, "[Evaluate] [lazy_id={}] Unknown Operation[type_id=???]", tensor->id());
-        }
-
+        print_lazy_tensor(tensor, "Evaluate");
         tensor->evaluate();
+    }
+}
+
+void print_graph(const std::shared_ptr<LazyTensor>& lazy_tensor) {
+    auto sorted_tensors = GraphUtils::topological_sort(lazy_tensor);
+    for (auto& tensor : sorted_tensors) {
+        print_lazy_tensor(tensor, "Print Graph");
     }
 }
 

--- a/ttnn/core/tensor/experimental/lazy/evaluation_manager.cpp
+++ b/ttnn/core/tensor/experimental/lazy/evaluation_manager.cpp
@@ -96,18 +96,18 @@ void print_lazy_tensor(const std::shared_ptr<LazyTensor>& tensor, const std::str
 }
 }  // namespace
 
-void evaluate(const std::shared_ptr<LazyTensor>& lazy_tensor) {
-    auto sorted_tensors = GraphUtils::topological_sort(lazy_tensor);
-    for (auto& tensor : sorted_tensors) {
-        print_lazy_tensor(tensor, "Evaluate");
-        tensor->evaluate();
+void evaluate(const tt::tt_metal::Tensor& tensor) {
+    auto sorted_tensors = GraphUtils::topological_sort(tensor.lazy());
+    for (auto& lazy_tensor : sorted_tensors) {
+        print_lazy_tensor(lazy_tensor, "Evaluate");
+        lazy_tensor->evaluate();
     }
 }
 
-void print_graph(const std::shared_ptr<LazyTensor>& lazy_tensor) {
-    auto sorted_tensors = GraphUtils::topological_sort(lazy_tensor);
-    for (auto& tensor : sorted_tensors) {
-        print_lazy_tensor(tensor, "Print Graph");
+void print_graph(const tt::tt_metal::Tensor& tensor) {
+    auto sorted_tensors = GraphUtils::topological_sort(tensor.lazy());
+    for (auto& lazy_tensor : sorted_tensors) {
+        print_lazy_tensor(lazy_tensor, "Print Graph");
     }
 }
 

--- a/ttnn/core/tensor/experimental/lazy/lazy_tensor.cpp
+++ b/ttnn/core/tensor/experimental/lazy/lazy_tensor.cpp
@@ -46,11 +46,15 @@ std::shared_ptr<LazyTensor> LazyTensor::make_materialized_tensor(
 }
 
 std::vector<std::shared_ptr<LazyTensor>> LazyTensor::make_lazy_tensors(
-    const LazyOperationInputsPtr& op_inputs, const LazyOperationPtr& op, const std::vector<TensorSpec>& tensor_specs) {
+    const LazyOperationInputsPtr& op_inputs,
+    const LazyOperationPtr& op,
+    const std::vector<std::optional<TensorSpec>>& tensor_specs) {
     std::vector<std::shared_ptr<LazyTensor>> lazy_tensors;
     lazy_tensors.reserve(tensor_specs.size());
-    for (const auto& tensor_spec : tensor_specs) {
-        lazy_tensors.push_back(make_lazy_tensor(op_inputs, op, tensor_spec));
+    for (const auto& tensor_spec_opt : tensor_specs) {
+        if (tensor_spec_opt.has_value()) {
+            lazy_tensors.push_back(make_lazy_tensor(op_inputs, op, tensor_spec_opt.value()));
+        }
     }
     for (size_t i = 0; i < lazy_tensors.size(); i++) {
         std::vector<std::shared_ptr<LazyTensor>> siblings;

--- a/ttnn/core/tensor/tensor.cpp
+++ b/ttnn/core/tensor/tensor.cpp
@@ -282,8 +282,8 @@ std::shared_ptr<TensorAttributes> Tensor::tensor_attributes() const {
 Tensor Tensor::make_lazy_tensor(
     const std::shared_ptr<ttnn::experimental::lazy::LazyOperationInputs>& op_inputs,
     const std::shared_ptr<ttnn::experimental::lazy::LazyOperation>& op,
-    TensorSpec tensor_spec) {
-    return Tensor(LazyTensor::make_lazy_tensor(op_inputs, op, std::move(tensor_spec)));
+    const TensorSpec& tensor_spec) {
+    return Tensor(LazyTensor::make_lazy_tensor(op_inputs, op, tensor_spec));
 }
 
 std::vector<Tensor> Tensor::make_lazy_tensors(

--- a/ttnn/core/tensor/tensor.cpp
+++ b/ttnn/core/tensor/tensor.cpp
@@ -143,7 +143,7 @@ Tensor Tensor::pad(
 Tensor Tensor::cpu(bool blocking, std::optional<ttnn::QueueId> cq_id) const {
     // To cpu will always materialize the tensors, always.
     if (!lazy()->is_materialized()) {
-        ttnn::experimental::lazy::evaluate(lazy());
+        ttnn::experimental::lazy::evaluate(*this);
     }
 
     return Tensor(get_materialized_tensor().cpu(blocking, cq_id));

--- a/ttnn/core/tensor/tensor.cpp
+++ b/ttnn/core/tensor/tensor.cpp
@@ -289,7 +289,7 @@ Tensor Tensor::make_lazy_tensor(
 std::vector<Tensor> Tensor::make_lazy_tensors(
     const std::shared_ptr<ttnn::experimental::lazy::LazyOperationInputs>& op_inputs,
     const std::shared_ptr<ttnn::experimental::lazy::LazyOperation>& op,
-    const std::vector<TensorSpec>& tensor_specs) {
+    const std::vector<std::optional<TensorSpec>>& tensor_specs) {
     auto lazy_tensors = LazyTensor::make_lazy_tensors(op_inputs, op, tensor_specs);
     std::vector<Tensor> tensors;
     tensors.reserve(lazy_tensors.size());

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/nlp_create_qkv_heads_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/nlp_create_qkv_heads_device_operation.hpp
@@ -25,8 +25,8 @@ struct NlpCreateHeadsDeviceOperation {
     };
 
     struct tensor_args_t {
-        const Tensor& input_tensor_q;
-        const std::optional<Tensor>& input_tensor_kv;
+        const Tensor input_tensor_q;
+        const std::optional<Tensor> input_tensor_kv;
         std::vector<std::optional<Tensor>> optional_output_tensors;
     };
 

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/pool_op.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/pool_op.hpp
@@ -36,7 +36,7 @@ struct Pool2D {
     };
 
     struct tensor_args_t {
-        const std::vector<Tensor>& input_tensors_;
+        const std::vector<Tensor> input_tensors_;
     };
 
     using spec_return_value_t = TensorSpec;


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/31760)

### Problem description
We currently support only Tensor and vector<Tensor> outputs. 

Also, we don't track graph in eager mode.

### What's changed
Add support for the following types (which covers all ops, and allows to have CanBeMadeLazy == PrimitiveOperationConcept:
- [x] Tensor
- [x] optional<Tensor>
- [x] vector<Tensor>
- [x] vector<optional<Tensor>>
- [x] tuple<Tensor, ...>
- [x] tuple<optional<Tensor>, ...>
- [x] array<Tensor, ...>
- [x] array<optional<Tensor>, ...>

Update lazy tensors with inputs and op in eager mode. Skip siblings for now.