### PR TITLE
Fix vadv2 OOM

### DIFF
--- a/models/experimental/vadv2/tt/tt_backbone.py
+++ b/models/experimental/vadv2/tt/tt_backbone.py
@@ -76,19 +76,61 @@ class TtResnet50:
 
         x = ttnn.sharded_to_interleaved(x)
 
-        x = ttnn.max_pool2d(
-            input_tensor=x,
-            batch_size=self.maxpool_args.batch_size,
-            input_h=self.maxpool_args.input_height,
-            input_w=self.maxpool_args.input_width,
-            channels=x.shape[3],
-            kernel_size=[3, 3],
-            stride=[2, 2],
-            padding=[1, 1],
-            dilation=[1, 1],
-            memory_config=ttnn.DRAM_MEMORY_CONFIG,
-            ceil_mode=False,
-        )
+        if self.maxpool_args.batch_size > 1:
+            current_batch_size = self.maxpool_args.batch_size
+            split_point = current_batch_size // 2
+            x0 = ttnn.slice(
+                x,
+                [0, 0, 0, 0],
+                [1, 1, split_point * self.maxpool_args.input_height * self.maxpool_args.input_width, x.shape[3]],
+            )
+            x1 = ttnn.slice(
+                x,
+                [0, 0, split_point * self.maxpool_args.input_height * self.maxpool_args.input_width, 0],
+                [1, 1, current_batch_size * self.maxpool_args.input_height * self.maxpool_args.input_width, x.shape[3]],
+            )
+            x0 = ttnn.max_pool2d(
+                input_tensor=x0,
+                batch_size=split_point,
+                input_h=self.maxpool_args.input_height,
+                input_w=self.maxpool_args.input_width,
+                channels=x.shape[3],
+                kernel_size=[3, 3],
+                stride=[2, 2],
+                padding=[1, 1],
+                dilation=[1, 1],
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                ceil_mode=False,
+            )
+            x1 = ttnn.max_pool2d(
+                input_tensor=x1,
+                batch_size=current_batch_size - split_point,
+                input_h=self.maxpool_args.input_height,
+                input_w=self.maxpool_args.input_width,
+                channels=x.shape[3],
+                kernel_size=[3, 3],
+                stride=[2, 2],
+                padding=[1, 1],
+                dilation=[1, 1],
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                ceil_mode=False,
+            )
+            x = ttnn.concat((x0, x1), dim=2, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        else:
+            x = ttnn.max_pool2d(
+                input_tensor=x,
+                batch_size=self.maxpool_args.batch_size,
+                input_h=self.maxpool_args.input_height,
+                input_w=self.maxpool_args.input_width,
+                channels=x.shape[3],
+                kernel_size=[3, 3],
+                stride=[2, 2],
+                padding=[1, 1],
+                dilation=[1, 1],
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                ceil_mode=False,
+            )
+        print("Maxpool done")
         outputs = []
         # Layer 1
         x = self.layer1_0(x)

--- a/models/experimental/vadv2/tt/tt_backbone.py
+++ b/models/experimental/vadv2/tt/tt_backbone.py
@@ -130,7 +130,6 @@ class TtResnet50:
                 memory_config=ttnn.DRAM_MEMORY_CONFIG,
                 ceil_mode=False,
             )
-        print("Maxpool done")
         outputs = []
         # Layer 1
         x = self.layer1_0(x)


### PR DESCRIPTION
### Problem description
Since the removal of in place halo in https://github.com/tenstorrent/tt-metal/commit/f5964193d6a777dd336703181ce18c5aa57a6c7e  vadv2 [fails on L2 nightly](https://github.com/tenstorrent/tt-metal/actions/runs/19249002546/job/55030451476#step:5:807) with OOM

### What's changed
- sliced the vadv2 maxpool batches in half to avoid the OOM caused by more memory usage

### Checklist
- [x] [(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/19335095872/job/55308875207)