### PR TITLE
[skip ci] adding more owners for the triage tool

### DIFF
--- a/.github/actions/analyze-workflow-data/owners.json
+++ b/.github/actions/analyze-workflow-data/owners.json
@@ -19,179 +19,124 @@
       { "id": "U08E1JCDVNX", "name": "Pavle Petrovic" },
       { "id": "U08BH66EXAL", "name": "Radoica Draskic" }
     ] },
-
     { "job-name-component": "t3000-demo-tests / t3k_mixtral_tests", "owner": { "id": "U03PUAKE719", "name": "Harry Zhou" } },
     { "job-name-component": "t3k_mixtral_tests", "owner": { "id": "U03PUAKE719", "name": "Harry Zhou" } },
-
     { "job-name-component": "t3000-demo-tests / t3k llama3_load_checkpoints tests", "owner": { "id": "U07RY6B5FLJ", "name": "Gongyu Wang" } },
     { "job-name-component": "t3k llama3_load_checkpoints tests", "owner": { "id": "U07RY6B5FLJ", "name": "Gongyu Wang" } },
-
     { "job-name-component": "t3000-demo-tests / t3k_falcon40b_tests", "owner": { "id": "U053W15B6JF", "name": "Djordje Ivanovic" } },
     { "job-name-component": "t3k_falcon40b_tests", "owner": { "id": "U053W15B6JF", "name": "Djordje Ivanovic" } },
-
     { "job-name-component": "t3000-demo-tests / t3k_llama3_tests", "owner": { "id": "U03PUAKE719", "name": "Miguel Tairum" } },
     { "job-name-component": "t3k_llama3_tests", "owner": { "id": "U03PUAKE719", "name": "Miguel Tairum" } },
-
     { "job-name-component": "t3000-demo-tests / t3k_qwen25_tests", "owner": { "id": "U03HY7MK4BT", "name": "Mark O'Connor" } },
     { "job-name-component": "t3k_qwen25_tests", "owner": { "id": "U03HY7MK4BT", "name": "Mark O'Connor" } },
-
     { "job-name-component": "t3000-demo-tests / t3k_llama3_vision_tests", "owner": { "id": "U06UEFWB4P9", "name": "Colman Glagovich" } },
     { "job-name-component": "t3k_llama3_vision_tests", "owner": { "id": "U06UEFWB4P9", "name": "Colman Glagovich" } },
-
     { "job-name-component": "t3000-demo-tests / t3k_llama3_90b_vision_tests", "owner": { "id": "U07RY6B5FLJ", "name": "Gongyu Wang" } },
     { "job-name-component": "t3k_llama3_90b_vision_tests", "owner": { "id": "U07RY6B5FLJ", "name": "Gongyu Wang" } },
-
     { "job-name-component": "t3000-demo-tests / t3k_llama3_70b_tests", "owner": { "id": "U06UEFWB4P9", "name": "Colman Glagovich" } },
     { "job-name-component": "t3k_llama3_70b_tests", "owner": { "id": "U06UEFWB4P9", "name": "Colman Glagovich" } },
-
     { "job-name-component": "t3000-demo-tests / t3k_falcon7b_tests", "owner": { "id": "U05RWH3QUPM", "name": "Salar Hosseini" } },
     { "job-name-component": "t3k_falcon7b_tests", "owner": { "id": "U05RWH3QUPM", "name": "Salar Hosseini" } },
-
     { "job-name-component": "t3000-demo-tests / t3k_resnet50_tests", "owner": { "id": "U0837MYG788", "name": "Marko Radosavljevic" } },
     { "job-name-component": "t3k_resnet50_tests", "owner": { "id": "U0837MYG788", "name": "Marko Radosavljevic" } },
-
     { "job-name-component": "t3000-demo-tests / t3k_sentence_bert_tests", "owner": { "id": "U045U3DEKM4", "name": "Mohamed Bahnas" } },
     { "job-name-component": "t3k_sentence_bert_tests", "owner": { "id": "U045U3DEKM4", "name": "Mohamed Bahnas" } },
-
     { "job-name-component": "t3000-demo-tests / t3k sd35_large tests", "owner": { "id": "U06UEFWB4P9", "name": "Colman Glagovich" } },
     { "job-name-component": "t3k sd35_large tests", "owner": { "id": "U06UEFWB4P9", "name": "Colman Glagovich" } },
-
     { "job-name-component": "t3000-demo-tests / t3k_mistral_tests", "owner": { "id": "U0896VBAKFC", "name": "Pratikkumar Prajapati" } },
     { "job-name-component": "t3k_mistral_tests", "owner": { "id": "U0896VBAKFC", "name": "Pratikkumar Prajapati" } },
-
     { "job-name-component": "t3000-demo-tests / t3k_qwen3_tests", "owner": { "id": "U03HY7MK4BT", "name": "Mark O'Connor" } },
     { "job-name-component": "t3k_qwen3_tests", "owner": { "id": "U03HY7MK4BT", "name": "Mark O'Connor" } },
-
     { "job-name-component": "t3000-demo-tests / t3k_qwen25_vl_tests", "owner": { "id": "U07RY6B5FLJ", "name": "Gongyu Wang" } },
     { "job-name-component": "t3k_qwen25_vl_tests", "owner": { "id": "U07RY6B5FLJ", "name": "Gongyu Wang" } },
-
     { "job-name-component": "t3000-demo-tests / t3k_gemma3_tests", "owner": { "id": "U08TJ70UFRT", "name": "Harry Andrews" } },
     { "job-name-component": "t3k_gemma3_tests", "owner": { "id": "U08TJ70UFRT", "name": "Harry Andrews" } },
-
     { "job-name-component": "t3000-unit-tests / t3k ttmetal tests", "owner": { "id": "ULMEPM2MA", "name": "Sean Nijjar" } },
     { "job-name-component": "t3k ttmetal tests", "owner": { "id": "ULMEPM2MA", "name": "Sean Nijjar" } },
-
     { "job-name-component": "t3000-unit-tests / t3k ttnn tests", "owner": { "id": "UBHPP2NDP", "name": "Joseph Chu" } },
     { "job-name-component": "t3k ttnn tests", "owner": { "id": "UBHPP2NDP", "name": "Joseph Chu" } },
-
     { "job-name-component": "t3000-unit-tests / t3k tt_metal multiprocess tests", "owner": { "id": "U03NG0A5ND7", "name": "Aditya Saigal" } },
     { "job-name-component": "t3k tt_metal multiprocess tests", "owner": { "id": "U03NG0A5ND7", "name": "Aditya Saigal" } },
-
     { "job-name-component": "t3000-unit-tests / t3k ttnn multiprocess tests", "owner": { "id": "U013121KDH9", "name": "Austin Ho" } },
     { "job-name-component": "t3k ttnn multiprocess tests", "owner": { "id": "U013121KDH9", "name": "Austin Ho" } },
-
     { "job-name-component": "t3000-unit-tests / t3k falcon7b tests", "owner": { "id": "UBHPP2NDP", "name": "Joseph Chu" } },
     { "job-name-component": "t3k falcon7b tests", "owner": { "id": "UBHPP2NDP", "name": "Joseph Chu" } },
-
     { "job-name-component": "t3000-unit-tests / t3k falcon40b tests", "owner": { "id": "U053W15B6JF", "name": "Djordje Ivanovic" } },
     { "job-name-component": "t3k falcon40b tests", "owner": { "id": "U053W15B6JF", "name": "Djordje Ivanovic" } },
-
     { "job-name-component": "t3000-unit-tests / t3k llama3-small tests", "owner": { "id": "U03PUAKE719", "name": "Miguel Tairum Cruz" } },
     { "job-name-component": "t3k llama3-small tests", "owner": { "id": "U03PUAKE719", "name": "Miguel Tairum Cruz" } },
-
     { "job-name-component": "t3000-unit-tests / t3k llama3.2-11b tests", "owner": { "id": "U03PUAKE719", "name": "Miguel Tairum Cruz" } },
     { "job-name-component": "t3k llama3.2-11b tests", "owner": { "id": "U03PUAKE719", "name": "Miguel Tairum Cruz" } },
-
     { "job-name-component": "t3000-unit-tests / t3k llama3.2-11b-vision tests", "owner": { "id": "U06UEFWB4P9", "name": "Colman Glagovich" } },
     { "job-name-component": "t3k llama3.2-11b-vision tests", "owner": { "id": "U06UEFWB4P9", "name": "Colman Glagovich" } },
-
     { "job-name-component": "t3000-unit-tests / t3k n300 mesh llama3.2-11b-vision tests", "owner": { "id": "U06UEFWB4P9", "name": "Colman Glagovich" } },
     { "job-name-component": "t3k n300 mesh llama3.2-11b-vision tests", "owner": { "id": "U06UEFWB4P9", "name": "Colman Glagovich" } },
-
     { "job-name-component": "t3000-unit-tests / t3k llama3.2-90b-vision tests", "owner": { "id": "U07RY6B5FLJ", "name": "Gongyu Wang" } },
     { "job-name-component": "t3k llama3.2-90b-vision tests", "owner": { "id": "U07RY6B5FLJ", "name": "Gongyu Wang" } },
-
     { "job-name-component": "t3000-unit-tests / t3k llama3.2-90b tests", "owner": { "id": "U07RY6B5FLJ", "name": "Gongyu Wang" } },
     { "job-name-component": "t3k llama3.2-90b tests", "owner": { "id": "U07RY6B5FLJ", "name": "Gongyu Wang" } },
-
     { "job-name-component": "t3000-unit-tests / t3k mixtral tests", "owner": { "id": "U03PUAKE719", "name": "Harry Zhou" } },
     { "job-name-component": "t3k mixtral tests", "owner": { "id": "U03PUAKE719", "name": "Harry Zhou" } },
-
     { "job-name-component": "t3000-unit-tests / t3k grok tests", "owner": { "id": "U03HY7MK4BT", "name": "Mark O'Connor" } },
     { "job-name-component": "t3k grok tests", "owner": { "id": "U03HY7MK4BT", "name": "Mark O'Connor" } },
-
     { "job-name-component": "t3000-unit-tests / t3k unet shallow tests", "owner": { "id": "U06ECNVR0EN", "name": "Evan Smal" } },
     { "job-name-component": "t3k unet shallow tests", "owner": { "id": "U06ECNVR0EN", "name": "Evan Smal" } },
-
     { "job-name-component": "t3000-unit-tests / t3k mistral tests", "owner": { "id": "U0896VBAKFC", "name": "Pratikkumar Prajapati" } },
     { "job-name-component": "t3k mistral tests", "owner": { "id": "U0896VBAKFC", "name": "Pratikkumar Prajapati" } },
-
     { "job-name-component": "t3000-unit-tests / t3k qwen25_vl tests", "owner": { "id": "U07RY6B5FLJ", "name": "Gongyu Wang" } },
     { "job-name-component": "t3k qwen25_vl tests", "owner": { "id": "U07RY6B5FLJ", "name": "Gongyu Wang" } },
-
     { "job-name-component": "t3000-unit-tests / t3k gemma3-small tests", "owner": { "id": "U08E1JCDVNX", "name": "Pavle Petrovic" } },
     { "job-name-component": "t3k gemma3-small tests", "owner": { "id": "U08E1JCDVNX", "name": "Pavle Petrovic" } },
-
     { "job-name-component": "galaxy-unit-tests / Galaxy Fabric tests", "owner": { "id": "UJ45FEC7M", "name": "Allan Liu" } },
     { "job-name-component": "Galaxy Fabric tests", "owner": { "id": "UJ45FEC7M", "name": "Allan Liu" } },
-
     { "job-name-component": "galaxy-unit-tests / Galaxy Llama3-70b unit tests", "owner": { "id": "U053W15B6JF", "name": "Djordje Ivanovic" } },
     { "job-name-component": "Galaxy Llama3-70b unit tests", "owner": { "id": "U053W15B6JF", "name": "Djordje Ivanovic" } },
-
     { "job-name-component": "galaxy-unit-tests / Galaxy DRAM Prefetcher unit tests", "owner": { "id": "U044T8U8DEF", "name": "Johanna Rock" } },
     { "job-name-component": "Galaxy DRAM Prefetcher unit tests", "owner": { "id": "U044T8U8DEF", "name": "Johanna Rock" } },
-
     { "job-name-component": "galaxy-unit-tests / Galaxy distributed ops tests", "owner": { "id": "U044T8U8DEF", "name": "Johanna Rock" } },
     { "job-name-component": "Galaxy distributed ops tests", "owner": { "id": "U044T8U8DEF", "name": "Johanna Rock" } },
-
     { "job-name-component": "galaxy-frequent-tests / Galaxy Llama3 frequent tests", "owner": { "id": "U053W15B6JF", "name": "Djordje Ivanovic" } },
     { "job-name-component": "Galaxy Llama3 frequent tests", "owner": { "id": "U053W15B6JF", "name": "Djordje Ivanovic" } },
-
     { "job-name-component": "galaxy-frequent-tests / Galaxy resnet50 frequent tests", "owner": { "id": "U052J2QDDKQ", "name": "Pavle Josipovic" } },
     { "job-name-component": "Galaxy resnet50 frequent tests", "owner": { "id": "U052J2QDDKQ", "name": "Pavle Josipovic" } },
-
     { "job-name-component": "galaxy-frequent-tests / Galaxy unit/distributed frequent tests", "owner": { "id": "UBHPP2NDP", "name": "Joseph Chu" } },
     { "job-name-component": "Galaxy unit/distributed frequent tests", "owner": { "id": "UBHPP2NDP", "name": "Joseph Chu" } },
-
     { "job-name-component": "galaxy-frequent-tests / Galaxy unit_distributed frequent tests", "owner": { "id": "UBHPP2NDP", "name": "Joseph Chu" } },
     { "job-name-component": "Galaxy unit_distributed frequent tests", "owner": { "id": "UBHPP2NDP", "name": "Joseph Chu" } },
-
     { "job-name-component": "galaxy-frequent-tests / Galaxy SD3.5 frequent tests", "owner": { "id": "U06UEFWB4P9", "name": "Colman Glagovich" } },
     { "job-name-component": "Galaxy SD3.5 frequent tests", "owner": { "id": "U06UEFWB4P9", "name": "Colman Glagovich" } },
-
     { "job-name-component": "profiler-tests / profiler tests", "owner": { "id": "U03BJ1L3LUQ", "name": "Mo Memarian" } },
     { "job-name-component": "profiler tests", "owner": { "id": "U03BJ1L3LUQ", "name": "Mo Memarian" } },
-
     { "job-name-component": "galaxy-model-perf-tests / Galaxy CNN model perf tests", "owner": { "id": "U052J2QDDKQ", "name": "Pavle Josipovic" } },
     { "job-name-component": "Galaxy CNN model perf tests", "owner": { "id": "U052J2QDDKQ", "name": "Pavle Josipovic" } },
-
     { "job-name-component": "galaxy-model-perf-tests / Galaxy Llama 70B model perf tests", "owner": { "id": "U053W15B6JF", "name": "Djordje Ivanovic" } },
     { "job-name-component": "Galaxy Llama 70B model perf tests", "owner": { "id": "U053W15B6JF", "name": "Djordje Ivanovic" } },
-
     { "job-name-component": "galaxy-model-perf-tests / Llama Galaxy Perf Unit Tests", "owner": { "id": "U053W15B6JF", "name": "Djordje Ivanovic" } },
     { "job-name-component": "Llama Galaxy Perf Unit Tests", "owner": { "id": "U053W15B6JF", "name": "Djordje Ivanovic" } },
-
     { "job-name-component": "galaxy-model-perf-tests / Galaxy Llama 70B prefill perf tests", "owner": { "id": "U03PUAKE719", "name": "Miguel Tairum" } },
     { "job-name-component": "Galaxy Llama 70B prefill perf tests", "owner": { "id": "U03PUAKE719", "name": "Miguel Tairum" } },
-
     { "job-name-component": "galaxy-model-perf-tests / Galaxy DiT SD3.5 model perf tests", "owner": { "id": "U06UEFWB4P9", "name": "Colman Glagovich" } },
     { "job-name-component": "Galaxy DiT SD3.5 model perf tests", "owner": { "id": "U06UEFWB4P9", "name": "Colman Glagovich" } },
-
     { "job-name-component": "galaxy-model-perf-tests / Galaxy DiT SD3", "owner": { "id": "U06UEFWB4P9", "name": "Colman Glagovich" } },
     { "job-name-component": "Galaxy DiT SD3", "owner": { "id": "U06UEFWB4P9", "name": "Colman Glagovich" } },
-
     { "job-name-component": "galaxy-model-perf-tests / Galaxy Sentence Bert tests", "owner": { "id": "U088413NP0Q", "name": "Ashai Reddy" } },
     { "job-name-component": "Galaxy Sentence Bert tests", "owner": { "id": "U088413NP0Q", "name": "Ashai Reddy" } },
-
     { "job-name-component": "galaxy-deepseek-tests / (Galaxy) DeepSeek tests", "owner": { "id": "U03HY7MK4BT", "name": "Mark O'Connor" } },
     { "job-name-component": "(Galaxy) DeepSeek tests", "owner": { "id": "U03HY7MK4BT", "name": "Mark O'Connor" } },
-
     { "job-name-component": "galaxy-nightly-tests / Galaxy CCL tests", "owner": { "id": "U05ACKAJTHS", "name": "Naif Tarafdar" } },
     { "job-name-component": "1_galaxy-nightly-tests _ Galaxy CCL tests", "owner": { "id": "U05ACKAJTHS", "name": "Naif Tarafdar" } },
-    { "job-name-component": "Galaxy CCL tests", "owner": [{ "id": "U05ACKAJTHS", "name": "Naif Tarafdar" }, { "id": "S09QQRK1CF8", "name": "ops-data-movement" }] },
-
+    { "job-name-component": "Galaxy CCL tests", "owner": [
+      { "id": "U05ACKAJTHS", "name": "Naif Tarafdar" },
+      { "id": "S09QQRK1CF8", "name": "ops-data-movement" }
+    ] },
     { "job-name-component": "galaxy-nightly-tests / Galaxy Fabric unit tests", "owner": { "id": "U08UBDUKH6Z", "name": "Neel Nyamagoudar" } },
     { "job-name-component": "Galaxy Fabric unit tests", "owner": { "id": "U08UBDUKH6Z", "name": "Neel Nyamagoudar" } },
-
     { "job-name-component": "galaxy-nightly-tests / Galaxy Fabric 2D Torus Nightly Tests", "owner": { "id": "U08UBDUKH6Z", "name": "Neel Nyamagoudar" } },
     { "job-name-component": "Galaxy Fabric 2D Torus Nightly Tests", "owner": { "id": "U08UBDUKH6Z", "name": "Neel Nyamagoudar" } },
-
     { "job-name-component": "galaxy-nightly-tests / Llama Galaxy Accuracy Test", "owner": { "id": "U053W15B6JF", "name": "Djordje Ivanovic" } },
     { "job-name-component": "Llama Galaxy Accuracy Test", "owner": { "id": "U053W15B6JF", "name": "Djordje Ivanovic" } },
-
     { "job-name-component": "galaxy-nightly-tests / Llama Galaxy Long Stress Test", "owner": { "id": "U053W15B6JF", "name": "Djordje Ivanovic" } },
-    { "job-name-component": "Llama Galaxy Long Stress Test", "owner": { "id": "U053W15B6JF", "name": "Djordje Ivanovic" } }
-  ,
+    { "job-name-component": "Llama Galaxy Long Stress Test", "owner": { "id": "U053W15B6JF", "name": "Djordje Ivanovic" } },
     { "job-name-component": "t3000-frequent-tests / t3k tteager tests", "owner": { "id": "U05ACKAJTHS", "name": "Naif Tarafdar" } },
     { "job-name-component": "t3k tteager tests", "owner": { "id": "U05ACKAJTHS", "name": "Naif Tarafdar" } },
     { "job-name-component": "t3000-frequent-tests / t3k ethernet tests", "owner": { "id": "ULMEPM2MA", "name": "Sean Nijjar" } },
@@ -199,13 +144,11 @@
     { "job-name-component": "t3000-frequent-tests / t3k trace stress tests", "owner": { "id": "U03NG0A5ND7", "name": "Aditya Saigal" } },
     { "job-name-component": "t3k trace stress tests", "owner": { "id": "U03NG0A5ND7", "name": "Aditya Saigal" } },
     { "job-name-component": "t3000-frequent-tests / t3k falcon40b tests", "owner": { "id": "U04S2UV6L8N", "name": "Sofija Jovic" } },
-    { "job-name-component": "t3k falcon40b tests", "owner": { "id": "U04S2UV6L8N", "name": "Sofija Jovic" } },
     { "job-name-component": "t3000-frequent-tests / t3k llama3.2-vision tests", "owner": { "id": "U06UEFWB4P9", "name": "Colman Glagovich" } },
     { "job-name-component": "t3k llama3.2-vision tests", "owner": { "id": "U06UEFWB4P9", "name": "Colman Glagovich" } },
     { "job-name-component": "t3000-frequent-tests / t3k n300 mesh llama3.2-vision tests", "owner": { "id": "U06UEFWB4P9", "name": "Colman Glagovich" } },
     { "job-name-component": "t3k n300 mesh llama3.2-vision tests", "owner": { "id": "U06UEFWB4P9", "name": "Colman Glagovich" } },
     { "job-name-component": "t3000-frequent-tests / t3k llama3.2-90b-vision tests", "owner": { "id": "U07RY6B5FLJ", "name": "Gongyu Wang" } },
-    { "job-name-component": "t3k llama3.2-90b-vision tests", "owner": { "id": "U07RY6B5FLJ", "name": "Gongyu Wang" } },
     { "job-name-component": "t3000-frequent-tests / t3k llama3 tests", "owner": { "id": "U03PUAKE719", "name": "Miguel Tairum" } },
     { "job-name-component": "t3k llama3 tests", "owner": { "id": "U03PUAKE719", "name": "Miguel Tairum" } },
     { "job-name-component": "t3000-frequent-tests / t3k llama3 accuracy tests", "owner": { "id": "U03PUAKE719", "name": "Miguel Tairum" } },
@@ -217,15 +160,12 @@
     { "job-name-component": "t3000-frequent-tests / t3k resnet tests", "owner": { "id": "U052J2QDDKQ", "name": "Pavle Josipovic" } },
     { "job-name-component": "t3k resnet tests", "owner": { "id": "U052J2QDDKQ", "name": "Pavle Josipovic" } },
     { "job-name-component": "t3000-frequent-tests / t3k sd35_large tests", "owner": { "id": "U06UEFWB4P9", "name": "Colman Glagovich" } },
-    { "job-name-component": "t3k sd35_large tests", "owner": { "id": "U06UEFWB4P9", "name": "Colman Glagovich" } },
     { "job-name-component": "t3000-frequent-tests / t3k mistral tests", "owner": { "id": "U0896VBAKFC", "name": "Pratikkumar Prajapati" } },
-    { "job-name-component": "t3k mistral tests", "owner": { "id": "U0896VBAKFC", "name": "Pratikkumar Prajapati" } },
     { "job-name-component": "blackhole-multi-card-demo-tests / llama3.3-70b", "owner": { "id": "U03PUAKE719", "name": "Miguel Tairum" } },
     { "job-name-component": "llama3.1-8b BH-LLMBox performance", "owner": { "id": "U08GELBB1AP", "name": "Ambrose Ling" } },
     { "job-name-component": "llama3.1-8b BH-LLMBox data-parallel", "owner": { "id": "U03PUAKE719", "name": "Miguel Tairum" } },
     { "job-name-component": "llama3.1-8b BH-LLMBox stress", "owner": { "id": "U03PUAKE719", "name": "Miguel Tairum" } },
     { "job-name-component": "llama3.3-70b BH-LLMBox batch-32 performance", "owner": { "id": "U03PUAKE719", "name": "Miguel Tairum" } },
-
     { "job-name-component": "galaxy-demo-tests / Galaxy Llama3 demo tests", "owner": { "id": "U053W15B6JF", "name": "Djordje Ivanovic" } },
     { "job-name-component": "Galaxy Llama3 demo tests", "owner": { "id": "U053W15B6JF", "name": "Djordje Ivanovic" } },
     { "job-name-component": "galaxy-demo-tests / Galaxy Llama3 long context demo tests", "owner": { "id": "U03PUAKE719", "name": "Miguel Tairum" } },
@@ -242,19 +182,24 @@
     { "job-name-component": "Galaxy SentenceBert demo tests", "owner": { "id": "U088413NP0Q", "name": "Ashai Reddy" } },
     { "job-name-component": "galaxy-demo-tests / Galaxy Stable Diffusion 3.5 Large demo tests", "owner": { "id": "U06UEFWB4P9", "name": "Colman Glagovich" } },
     { "job-name-component": "Galaxy Stable Diffusion 3.5 Large demo tests", "owner": { "id": "U06UEFWB4P9", "name": "Colman Glagovich" } },
-
-    { "job-name-component": "blackhole-multi-card-post-commit-tests / CCL APC test", "owner": [{ "id": "U0883RN6CRE", "name": "William Ly" }, { "id": "S09QQRK1CF8", "name": "ops-data-movement" }] },
+    { "job-name-component": "blackhole-multi-card-post-commit-tests / CCL APC test", "owner": [
+      { "id": "U0883RN6CRE", "name": "William Ly" },
+      { "id": "S09QQRK1CF8", "name": "ops-data-movement" }
+    ] },
     { "job-name-component": "CCL APC test", "owner": { "id": "S09QQRK1CF8", "name": "ops-data-movement" } },
-
     { "job-name-component": "t3000-fast-tests / t3k fabric tests", "owner": { "id": "UJ45FEC7M", "name": "Allan Liu" } },
-
-    { "job-name-component": "t3000-nightly-tests / t3k_ccl_tests", "owner": [{ "id": "U05ACKAJTHS", "name": "Naif Tarafdar" }, { "id": "S09QQRK1CF8", "name": "ops-data-movement" }] },
-    { "job-name-component": "t3000-nightly-tests / t3k_ccl_2d_tests", "owner": [{ "id": "U013121KDH9", "name": "Austin Ho" }, { "id": "S09QQRK1CF8", "name": "ops-data-movement" }] },
+    { "job-name-component": "t3000-nightly-tests / t3k_ccl_tests", "owner": [
+      { "id": "U05ACKAJTHS", "name": "Naif Tarafdar" },
+      { "id": "S09QQRK1CF8", "name": "ops-data-movement" }
+    ] },
+    { "job-name-component": "t3000-nightly-tests / t3k_ccl_2d_tests", "owner": [
+      { "id": "U013121KDH9", "name": "Austin Ho" },
+      { "id": "S09QQRK1CF8", "name": "ops-data-movement" }
+    ] },
     { "job-name-component": "t3k_ccl_tests", "owner": { "id": "S09QQRK1CF8", "name": "ops-data-movement" } },
     { "job-name-component": "t3k_ccl_2d_tests", "owner": { "id": "S09QQRK1CF8", "name": "ops-data-movement" } },
     { "job-name-component": "t3000-nightly-tests / t3k_fabric_unit_tests", "owner": { "id": "U08UBDUKH6Z", "name": "Neel Nyamagoudar" } },
     { "job-name-component": "t3000-nightly-tests / t3k_dispatch_unit_tests", "owner": { "id": "U07R05K4WGJ", "name": "John Bauman" } },
-
     { "job-name-component": "t3000-perplexity-tests / t3k_falcon7b_tests", "owner": { "id": "U05RWH3QUPM", "name": "Salar Hosseini" } },
     { "job-name-component": "t3000-perplexity-tests / t3k_falcon40b_tests", "owner": { "id": "U053W15B6JF", "name": "Djordje Ivanovic" } },
     { "job-name-component": "t3000-perplexity-tests / t3k_llama_70b_tests", "owner": { "id": "U06UEFWB4P9", "name": "Colman Glagovich" } },
@@ -265,7 +210,6 @@
     { "job-name-component": "t3000-perplexity-tests / t3k_qwen25_tests", "owner": { "id": "U03PUAKE719", "name": "Miguel Tairum" } },
     { "job-name-component": "t3000-perplexity-tests / t3k_qwen3_tests", "owner": { "id": "U03PUAKE719", "name": "Miguel Tairum" } },
     { "job-name-component": "t3000-perplexity-tests / t3k_gemma3_tests", "owner": { "id": "U08TJ70UFRT", "name": "Harry Andrews" } },
-
     { "job-name-component": "t3000-model-perf-tests / t3k LLM falcon7b model perf tests", "owner": { "id": "U05RWH3QUPM", "name": "Salar Hosseini" } },
     { "job-name-component": "t3k LLM falcon7b model perf tests", "owner": { "id": "U05RWH3QUPM", "name": "Salar Hosseini" } },
     { "job-name-component": "t3000-model-perf-tests / t3k LLM falcon40b model perf tests", "owner": { "id": "U053W15B6JF", "name": "Djordje Ivanovic" } },
@@ -276,13 +220,10 @@
     { "job-name-component": "t3k CNN sentence_bert model perf tests", "owner": { "id": "U045U3DEKM4", "name": "Mohamed Bahnas" } },
     { "job-name-component": "t3000-model-perf-tests / t3k DiT SD3.5 model perf tests", "owner": { "id": "U06UEFWB4P9", "name": "Colman Glagovich" } },
     { "job-name-component": "t3k DiT SD3.5 model perf tests", "owner": { "id": "U06UEFWB4P9", "name": "Colman Glagovich" } },
-
     { "job-name-component": "blackhole-nightly-tests / Nightly", "owner": { "id": "U03PUAKE719", "name": "Miguel Tairum" } },
     { "job-name-component": "blackhole-nightly-tests / whisper", "owner": { "id": "U05RWH3QUPM", "name": "Salar Hosseini" } },
     { "job-name-component": "blackhole-nightly-tests / llama3.1-8b", "owner": { "id": "U03PUAKE719", "name": "Miguel Tairum" } },
-
     { "job-name-component": "galaxy-stress-tests / galaxy-stress", "owner": { "id": "U053W15B6JF", "name": "Djordje Ivanovic" } },
-
     { "job-name-component": "single-card-demo-tests _ falcon7b-N150-func", "owner": { "id": "U05RWH3QUPM", "name": "Salar Hosseini" } },
     { "job-name-component": "single-card-demo-tests _ llama3-N150-func", "owner": { "id": "U03PUAKE719", "name": "Miguel Tairum" } },
     { "job-name-component": "single-card-demo-tests _ vgg-N150-func", "owner": { "id": "U084B1CES7M", "name": "Borys Bradel" } },
@@ -393,7 +334,6 @@
     { "job-name-component": "metal-run-microbenchmarks / WH Data Movement Regressions", "owner": { "id": "U084B109TED", "name": "Ata Tuzuner" } },
     { "job-name-component": "metal-run-microbenchmarks / BH Data Movement Regressions", "owner": { "id": "U084B109TED", "name": "Ata Tuzuner" } },
     { "job-name-component": "metal-run-microbenchmarks / BH P150 PCIe Performance", "owner": { "id": "U08276D910S", "name": "Nigel Huang" } },
-
     { "job-name-component": "ttnn eltwise group 1", "owner": { "id": "U08411R54Q2", "name": "Chris Maryan" } },
     { "job-name-component": "ttnn eltwise group 2", "owner": { "id": "U08411R54Q2", "name": "Chris Maryan" } },
     { "job-name-component": "ttnn eltwise group 3", "owner": { "id": "U08411R54Q2", "name": "Chris Maryan" } },
@@ -402,39 +342,39 @@
     { "job-name-component": "ttnn eltwise group 6", "owner": { "id": "U08411R54Q2", "name": "Chris Maryan" } },
     { "job-name-component": "ttnn eltwise group 7", "owner": { "id": "U08411R54Q2", "name": "Chris Maryan" } },
     { "job-name-component": "ttnn eltwise group 8", "owner": { "id": "U08411R54Q2", "name": "Chris Maryan" } },
-
-    { "job-name-component": "ttnn data_movement/ccl group 1", "owner": [{ "id": "U05ACKAJTHS", "name": "Naif Tarafdar" }, { "id": "S09QQRK1CF8", "name": "ops-data-movement" }] },
-    { "job-name-component": "ttnn data_movement/ccl group 2", "owner": [{ "id": "U05ACKAJTHS", "name": "Naif Tarafdar" }, { "id": "S09QQRK1CF8", "name": "ops-data-movement" }] },
-    { "job-name-component": "ttnn data_movement/ccl group 3", "owner": [{ "id": "U05ACKAJTHS", "name": "Naif Tarafdar" }, { "id": "S09QQRK1CF8", "name": "ops-data-movement" }] },
+    { "job-name-component": "ttnn data_movement/ccl group 1", "owner": [
+      { "id": "U05ACKAJTHS", "name": "Naif Tarafdar" },
+      { "id": "S09QQRK1CF8", "name": "ops-data-movement" }
+    ] },
+    { "job-name-component": "ttnn data_movement/ccl group 2", "owner": [
+      { "id": "U05ACKAJTHS", "name": "Naif Tarafdar" },
+      { "id": "S09QQRK1CF8", "name": "ops-data-movement" }
+    ] },
+    { "job-name-component": "ttnn data_movement/ccl group 3", "owner": [
+      { "id": "U05ACKAJTHS", "name": "Naif Tarafdar" },
+      { "id": "S09QQRK1CF8", "name": "ops-data-movement" }
+    ] },
     { "job-name-component": "ttnn-post-commit / ttnn data_movement/ccl group 1", "owner": { "id": "S09QQRK1CF8", "name": "ops-data-movement" } },
     { "job-name-component": "ttnn-post-commit / ttnn data_movement/ccl group 2", "owner": { "id": "S09QQRK1CF8", "name": "ops-data-movement" } },
     { "job-name-component": "ttnn-post-commit / ttnn data_movement/ccl group 3", "owner": { "id": "S09QQRK1CF8", "name": "ops-data-movement" } },
-
     { "job-name-component": "ttnn conv group", "owner": { "id": "U085GDCAZTN", "name": "Pavle Josipovic" } },
-
     { "job-name-component": "ttnn pool group", "owner": { "id": "U085GDCAZTN", "name": "Pavle Josipovic" } },
-
     { "job-name-component": "ttnn matmul group", "owner": { "id": "U084B1CES7M", "name": "Borys Bradel" } },
-
     { "job-name-component": "ttnn fused group", "owner": { "id": "U084B1CES7M", "name": "Borys Bradel" } },
-
     { "job-name-component": "ttnn moreh group", "owner": { "id": "U08411R54Q2", "name": "Chris Maryan" } },
-
     { "job-name-component": "ttnn transformers group", "owner": { "id": "U08411R54Q2", "name": "Chris Maryan" } },
-
     { "job-name-component": "ttnn reduce and misc ops group", "owner": { "id": "U084B1CES7M", "name": "Borys Bradel" } },
-
     { "job-name-component": "tt-metal-l2-nightly / ttnn nightly data_movement tests", "owner": { "id": "S09QQRK1CF8", "name": "ops-data-movement" } },
     { "job-name-component": "ttnn nightly data_movement tests", "owner": { "id": "S09QQRK1CF8", "name": "ops-data-movement" } },
-
     { "job-name-component": "cpp-post-commit / CCL", "owner": { "id": "S09QQRK1CF8", "name": "ops-data-movement" } },
     { "job-name-component": "CCL", "owner": { "id": "S09QQRK1CF8", "name": "ops-data-movement" } },
-
     { "job-name-component": "cpp-post-commit / data movement", "owner": { "id": "S09QQRK1CF8", "name": "ops-data-movement" } },
     { "job-name-component": "data movement", "owner": { "id": "S09QQRK1CF8", "name": "ops-data-movement" } },
-
     { "job-name-component": "ttnn-run-sweeps / ccl.generality.all_broadcast", "owner": { "id": "S09QQRK1CF8", "name": "ops-data-movement" } },
-    { "job-name-component": "Run sweeps in parallel", "owner": [{ "id": "S09QQRK1CF8", "name": "ops-data-movement" }, { "id": "U08T3JQEB36", "name": "Steven Lee" }] },
+    { "job-name-component": "Run sweeps in parallel", "owner": [
+      { "id": "S09QQRK1CF8", "name": "ops-data-movement" },
+      { "id": "U08T3JQEB36", "name": "Steven Lee" }
+    ] },
     { "job-name-component": "ccl.generality.all_broadcast", "owner": { "id": "S09QQRK1CF8", "name": "ops-data-movement" } },
     { "job-name-component": "ttnn-run-sweeps / ccl.generality.all_gather", "owner": { "id": "S09QQRK1CF8", "name": "ops-data-movement" } },
     { "job-name-component": "ccl.generality.all_gather", "owner": { "id": "S09QQRK1CF8", "name": "ops-data-movement" } },
@@ -450,7 +390,6 @@
     { "job-name-component": "ccl.generality.point_to_point", "owner": { "id": "S09QQRK1CF8", "name": "ops-data-movement" } },
     { "job-name-component": "ttnn-run-sweeps / ccl.generality.reduce_scatter", "owner": { "id": "S09QQRK1CF8", "name": "ops-data-movement" } },
     { "job-name-component": "ccl.generality.reduce_scatter", "owner": { "id": "S09QQRK1CF8", "name": "ops-data-movement" } },
-
     { "job-name-component": "ttnn-run-sweeps / data_movement.backward.concat_bw.concat_bw", "owner": { "id": "S09QQRK1CF8", "name": "ops-data-movement" } },
     { "job-name-component": "data_movement.backward.concat_bw.concat_bw", "owner": { "id": "S09QQRK1CF8", "name": "ops-data-movement" } },
     { "job-name-component": "ttnn-run-sweeps / data_movement.concat.concat_interleaved", "owner": { "id": "S09QQRK1CF8", "name": "ops-data-movement" } },
@@ -517,13 +456,11 @@
     { "job-name-component": "data_movement.view.view_pytorch2", "owner": { "id": "S09QQRK1CF8", "name": "ops-data-movement" } },
     { "job-name-component": "ttnn-run-sweeps / data_movement.view.view_tt_torch", "owner": { "id": "S09QQRK1CF8", "name": "ops-data-movement" } },
     { "job-name-component": "data_movement.view.view_tt_torch", "owner": { "id": "S09QQRK1CF8", "name": "ops-data-movement" } },
-
     { "job-name-component": "ttnn-run-sweeps / embedding.embedding", "owner": { "id": "S09QQRK1CF8", "name": "ops-data-movement" } },
     { "job-name-component": "embedding.embedding", "owner": { "id": "S09QQRK1CF8", "name": "ops-data-movement" } },
     { "job-name-component": "ttnn-run-sweeps / embedding_bw.embedding_bw", "owner": { "id": "S09QQRK1CF8", "name": "ops-data-movement" } },
     { "job-name-component": "embedding_bw.embedding_bw", "owner": { "id": "S09QQRK1CF8", "name": "ops-data-movement" } },
     { "job-name-component": "quick-6u-health", "owner": { "id": "U053W15B6JF", "name": "Djordje Ivanovic" } },
-
     { "job-name-component": "auto-retry", "owner": { "id": "U08BNDNLUCD", "name": "akirby-tt" } },
     { "job-name-component": "cpp-unit-tests", "owner": { "id": "U06CXU895AP", "name": "Michael Chiou" } },
     { "job-name-component": "cpp-unit-tests-slow-dispatch", "owner": { "id": "U06CXU895AP", "name": "Michael Chiou" } },
@@ -551,6 +488,32 @@
     { "job-name-component": "ttnn-sdpa-stress-tests", "owner": { "id": "U06UEFWB4P9", "name": "Colman Glagovich" } },
     { "job-name-component": "ttnn-sdxl-tests", "owner": { "id": "U07N3CUUN05", "name": "Iva Potkonjak" } },
     { "job-name-component": "ttnn-train-nightly-tests", "owner": { "id": "U082L4RSULT", "name": "Denys Makoviichuk" } },
-    { "job-name-component": "ttnn-transformers-tests", "owner": { "id": "U06UEFWB4P9", "name": "Colman Glagovich" } }
+    { "job-name-component": "ttnn-transformers-tests", "owner": { "id": "U06UEFWB4P9", "name": "Colman Glagovich" } },
+    { "job-name-component": "t3000-model-perf-tests-impl / t3k DiT SD3.5 model perf tests", "owner": { "id": "U03FJB5TM5Y", "name": "Owner U03FJB5TM5Y" } },
+    { "job-name-component": "t3k DiT Wan2.2 model perf tests", "owner": { "id": "U03FJB5TM5Y", "name": "Owner U03FJB5TM5Y" } },
+    { "job-name-component": "t3000-frequent-tests-impl / t3k llama3.2-vision tests", "owner": { "id": "U03FJB5TM5Y", "name": "Owner U03FJB5TM5Y" } },
+    { "job-name-component": "t3000-frequent-tests-impl / t3k n300 mesh llama3.2-vision tests", "owner": { "id": "U03FJB5TM5Y", "name": "Owner U03FJB5TM5Y" } },
+    { "job-name-component": "t3k llama3_70b tests", "owner": { "id": "U03FJB5TM5Y", "name": "Owner U03FJB5TM5Y" } },
+    { "job-name-component": "t3000-frequent-tests-impl / t3k sd35_large tests", "owner": { "id": "U03FJB5TM5Y", "name": "Owner U03FJB5TM5Y" } },
+    { "job-name-component": "t3k wan2.2 tests", "owner": { "id": "U03FJB5TM5Y", "name": "Owner U03FJB5TM5Y" } },
+    { "job-name-component": "t3k_llama_70b_tests", "owner": { "id": "U03FJB5TM5Y", "name": "Owner U03FJB5TM5Y" } },
+    { "job-name-component": "t3000-demo-tests-impl / t3k_llama3_vision_tests", "owner": { "id": "U03FJB5TM5Y", "name": "Owner U03FJB5TM5Y" } },
+    { "job-name-component": "t3000-demo-tests-impl / t3k_llama3_70b_tests", "owner": { "id": "U03FJB5TM5Y", "name": "Owner U03FJB5TM5Y" } },
+    { "job-name-component": "t3000-demo-tests-impl / t3k sd35_large tests", "owner": { "id": "U03FJB5TM5Y", "name": "Owner U03FJB5TM5Y" } },
+    { "job-name-component": "t3k_wan2.2_tests", "owner": { "id": "U03FJB5TM5Y", "name": "Owner U03FJB5TM5Y" } },
+    { "job-name-component": "t3000-unit-tests-impl / t3k llama3.2-11b-vision tests", "owner": { "id": "U03FJB5TM5Y", "name": "Owner U03FJB5TM5Y" } },
+    { "job-name-component": "t3000-unit-tests-impl / t3k n300 mesh llama3.2-11b-vision tests", "owner": { "id": "U03FJB5TM5Y", "name": "Owner U03FJB5TM5Y" } },
+    { "job-name-component": "Galaxy GPT-OSS unit tests", "owner": { "id": "U06F3ER8X9A", "name": "Owner U06F3ER8X9A" } },
+    { "job-name-component": "vgg", "owner": { "id": "U06Q7ESTFEV", "name": "Owner U06Q7ESTFEV" } },
+    { "job-name-component": "single-card-demo-tests-impl / vgg", "owner": { "id": "U06Q7ESTFEV", "name": "Owner U06Q7ESTFEV" } },
+    { "job-name-component": "panoptic_deeplab demo", "owner": { "id": "U08AWRT6U3E", "name": "Boris Janjic" } },
+    { "job-name-component": "t3k DiT Flux.1-dev model perf tests", "owner": { "id": "U08TED0JM9D", "name": "Owner U08TED0JM9D" } },
+    { "job-name-component": "t3k flux1 tests", "owner": { "id": "U08TED0JM9D", "name": "Owner U08TED0JM9D" } },
+    { "job-name-component": "t3k flux1-dev tests", "owner": { "id": "U08TED0JM9D", "name": "Owner U08TED0JM9D" } },
+    { "job-name-component": "t3k ViT Gemma3 perf tests", "owner": { "id": "U093901FR8U", "name": "Owner U093901FR8U" } },
+    { "job-name-component": "phi4", "owner": { "id": "U094PKWHNJ0", "name": "Owner U094PKWHNJ0" } },
+    { "job-name-component": "t3k DiT Mochi model perf tests", "owner": { "id": "U09ELB03XRU", "name": "Owner U09ELB03XRU" } },
+    { "job-name-component": "t3k mochi tests", "owner": { "id": "U09ELB03XRU", "name": "Owner U09ELB03XRU" } },
+    { "job-name-component": "t3k_mochi_tests", "owner": { "id": "U09ELB03XRU", "name": "Owner U09ELB03XRU" } }
   ]
 }


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/32371)

### Problem description
many jobs who had their owners encoded with the format "owner_id: ..." didn't have their owners ported to the owners.json.

### What's changed
ported those owners