### PR TITLE
[skip ci] Run cpp from l2-nightly on p150b-viommu

### DIFF
--- a/.github/workflows/tt-metal-l2-nightly.yaml
+++ b/.github/workflows/tt-metal-l2-nightly.yaml
@@ -134,7 +134,7 @@ jobs:
         test-group: [
           { arch: wormhole_b0, runner-label: N150 },
           { arch: wormhole_b0, runner-label: N300 },
-          { arch: blackhole, runner-label: P150 },
+          { arch: blackhole, runner-label: P150b },
         ]
     uses: ./.github/workflows/cpp-post-commit.yaml
     with:


### PR DESCRIPTION
### What's changed
Run cpp tests from l2-nightly on p150b-viommu