### PR TITLE
add_top_row compute kernel

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_binary_sfpu_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_binary_sfpu_api.h
@@ -7,3 +7,4 @@
 #include "llk_math_eltwise_binary_sfpu_init.h"
 #include "llk_math_eltwise_binary_sfpu_binop.h"
 #include "llk_math_eltwise_binary_sfpu_max_pool_indices.h"
+#include "llk_math_eltwise_binary_sfpu_add_top_row.h"

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_binary_sfpu_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_binary_sfpu_api.h
@@ -5,6 +5,6 @@
 #pragma once
 #include "llk_math_common_api.h"
 #include "llk_math_eltwise_binary_sfpu_init.h"
+#include "llk_math_eltwise_binary_sfpu_add_top_row.h"
 #include "llk_math_eltwise_binary_sfpu_binop.h"
 #include "llk_math_eltwise_binary_sfpu_max_pool_indices.h"
-#include "llk_math_eltwise_binary_sfpu_add_top_row.h"

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_add_top_row.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_add_top_row.h
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "sfpu/ckernel_sfpu_add_top_row.h"
+#include "ckernel_instr_params.h"
+
+namespace ckernel::sfpu {
+
+template <DataFormat format>
+inline void calculate_add_top_row(const uint tile_idx_0 = 0, const uint tile_idx_1 = 0, const uint tile_idx_dst = 0) {
+    // Use the specified format and tile indices for the add_top_row operation
+    _calculate_add_top_row_<format>(tile_idx_0, tile_idx_1, tile_idx_dst);
+}
+
+inline void init_add_top_row() {
+    // Initialize add_top_row operation
+    _init_add_top_row_();
+}
+
+}  // namespace ckernel::sfpu
+

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_add_top_row.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_add_top_row.h
@@ -23,4 +23,3 @@ inline void init_add_top_row() {
 }
 
 }  // namespace ckernel::sfpu
-

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_add_top_row.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_add_top_row.h
@@ -5,9 +5,7 @@
 #pragma once
 
 #include "ckernel.h"
-#include "ckernel_defs.h"
 #include "sfpu/ckernel_sfpu_add_top_row.h"
-#include "ckernel_instr_params.h"
 
 namespace ckernel::sfpu {
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_add_top_row.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_add_top_row.h
@@ -12,7 +12,7 @@
 namespace ckernel::sfpu {
 
 template <DataFormat format>
-inline void calculate_add_top_row(const uint tile_idx_0 = 0, const uint tile_idx_1 = 0, const uint tile_idx_dst = 0) {
+inline void calculate_add_top_row(const uint tile_idx_0, const uint tile_idx_1, const uint tile_idx_dst) {
     // Use the specified format and tile indices for the add_top_row operation
     _calculate_add_top_row_<format>(tile_idx_0, tile_idx_1, tile_idx_dst);
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_add_top_row.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_add_top_row.h
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "llk_math_eltwise_binary_sfpu_init.h"
+#include "llk_math_eltwise_binary_sfpu_params.h"
+#include "ckernel_sfpu_add_top_row.h"
+
+namespace ckernel {
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_binary_sfpu_add_top_row_init() {
+    llk_math_eltwise_binary_sfpu_init<SfpuType::add_top_row, APPROXIMATE>(
+        sfpu::init_add_top_row);
+}
+
+template <bool APPROXIMATE, DataFormat format>
+inline void llk_math_eltwise_binary_sfpu_add_top_row(
+    uint dst_index_in_0, uint dst_index_in_1, uint dst_index_out) {
+    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+        sfpu::calculate_add_top_row<format>,
+        dst_index_in_0,
+        dst_index_in_1,
+        dst_index_out,
+        (int)VectorMode::RC_custom);
+}
+
+}  // namespace ckernel
+

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_add_top_row.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_add_top_row.h
@@ -28,4 +28,3 @@ inline void llk_math_eltwise_binary_sfpu_add_top_row(
 }
 
 }  // namespace ckernel
-

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_add_top_row.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_add_top_row.h
@@ -24,7 +24,7 @@ inline void llk_math_eltwise_binary_sfpu_add_top_row(
         dst_index_in_0,
         dst_index_in_1,
         dst_index_out,
-        (int)VectorMode::RC_custom);
+        static_cast<int>(VectorMode::RC_custom));
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_add_top_row.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_add_top_row.h
@@ -10,16 +10,13 @@
 
 namespace ckernel {
 
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_add_top_row_init() {
-    llk_math_eltwise_binary_sfpu_init<SfpuType::add_top_row, APPROXIMATE>(
-        sfpu::init_add_top_row);
+    llk_math_eltwise_binary_sfpu_init<SfpuType::add_top_row, true>(sfpu::init_add_top_row);
 }
 
-template <bool APPROXIMATE, DataFormat format>
-inline void llk_math_eltwise_binary_sfpu_add_top_row(
-    uint dst_index_in_0, uint dst_index_in_1, uint dst_index_out) {
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+template <DataFormat format>
+inline void llk_math_eltwise_binary_sfpu_add_top_row(uint dst_index_in_0, uint dst_index_in_1, uint dst_index_out) {
+    _llk_math_eltwise_binary_sfpu_params_<true>(
         sfpu::calculate_add_top_row<format>,
         dst_index_in_0,
         dst_index_in_1,

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu_types.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu_types.h
@@ -132,4 +132,5 @@ enum class SfpuType {
     cbrt,  // cube root
     hardmish,
     reduce,
+    add_top_row,
 };

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_binary_sfpu_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_binary_sfpu_api.h
@@ -7,3 +7,4 @@
 #include "llk_math_eltwise_binary_sfpu_init.h"
 #include "llk_math_eltwise_binary_sfpu_binop.h"
 #include "llk_math_eltwise_binary_sfpu_max_pool_indices.h"
+#include "llk_math_eltwise_binary_sfpu_add_top_row.h"

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_binary_sfpu_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_binary_sfpu_api.h
@@ -5,6 +5,6 @@
 #pragma once
 #include "llk_math_common_api.h"
 #include "llk_math_eltwise_binary_sfpu_init.h"
+#include "llk_math_eltwise_binary_sfpu_add_top_row.h"
 #include "llk_math_eltwise_binary_sfpu_binop.h"
 #include "llk_math_eltwise_binary_sfpu_max_pool_indices.h"
-#include "llk_math_eltwise_binary_sfpu_add_top_row.h"

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_add_top_row.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_add_top_row.h
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "sfpu/ckernel_sfpu_add_top_row.h"
+#include "ckernel_instr_params.h"
+
+namespace ckernel::sfpu {
+
+template <DataFormat format>
+inline void calculate_add_top_row(const uint tile_idx_0 = 0, const uint tile_idx_1 = 0, const uint tile_idx_dst = 0) {
+    // Use the specified format and tile indices for the add_top_row operation
+    _calculate_add_top_row_<format>(tile_idx_0, tile_idx_1, tile_idx_dst);
+}
+
+inline void init_add_top_row() {
+    // Initialize add_top_row operation
+    _init_add_top_row_();
+}
+
+}  // namespace ckernel::sfpu
+

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_add_top_row.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_add_top_row.h
@@ -23,4 +23,3 @@ inline void init_add_top_row() {
 }
 
 }  // namespace ckernel::sfpu
-

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_add_top_row.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_add_top_row.h
@@ -5,9 +5,7 @@
 #pragma once
 
 #include "ckernel.h"
-#include "ckernel_defs.h"
 #include "sfpu/ckernel_sfpu_add_top_row.h"
-#include "ckernel_instr_params.h"
 
 namespace ckernel::sfpu {
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_add_top_row.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_add_top_row.h
@@ -12,7 +12,7 @@
 namespace ckernel::sfpu {
 
 template <DataFormat format>
-inline void calculate_add_top_row(const uint tile_idx_0 = 0, const uint tile_idx_1 = 0, const uint tile_idx_dst = 0) {
+inline void calculate_add_top_row(const uint tile_idx_0, const uint tile_idx_1, const uint tile_idx_dst) {
     // Use the specified format and tile indices for the add_top_row operation
     _calculate_add_top_row_<format>(tile_idx_0, tile_idx_1, tile_idx_dst);
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_add_top_row.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_add_top_row.h
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "llk_math_eltwise_binary_sfpu_init.h"
+#include "llk_math_eltwise_binary_sfpu_params.h"
+#include "ckernel_sfpu_add_top_row.h"
+
+namespace ckernel {
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_binary_sfpu_add_top_row_init() {
+    llk_math_eltwise_binary_sfpu_init<SfpuType::add_top_row, APPROXIMATE>(
+        sfpu::init_add_top_row);
+}
+
+template <bool APPROXIMATE, DataFormat format>
+inline void llk_math_eltwise_binary_sfpu_add_top_row(
+    uint dst_index_in_0, uint dst_index_in_1, uint dst_index_out) {
+    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+        sfpu::calculate_add_top_row<format>,
+        dst_index_in_0,
+        dst_index_in_1,
+        dst_index_out,
+        (int)VectorMode::RC_custom);
+}
+
+}  // namespace ckernel
+

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_add_top_row.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_add_top_row.h
@@ -28,4 +28,3 @@ inline void llk_math_eltwise_binary_sfpu_add_top_row(
 }
 
 }  // namespace ckernel
-

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_add_top_row.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_add_top_row.h
@@ -24,7 +24,7 @@ inline void llk_math_eltwise_binary_sfpu_add_top_row(
         dst_index_in_0,
         dst_index_in_1,
         dst_index_out,
-        (int)VectorMode::RC_custom);
+        static_cast<int>(VectorMode::RC_custom));
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_add_top_row.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_add_top_row.h
@@ -10,16 +10,13 @@
 
 namespace ckernel {
 
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_add_top_row_init() {
-    llk_math_eltwise_binary_sfpu_init<SfpuType::add_top_row, APPROXIMATE>(
-        sfpu::init_add_top_row);
+    llk_math_eltwise_binary_sfpu_init<SfpuType::add_top_row, true>(sfpu::init_add_top_row);
 }
 
-template <bool APPROXIMATE, DataFormat format>
-inline void llk_math_eltwise_binary_sfpu_add_top_row(
-    uint dst_index_in_0, uint dst_index_in_1, uint dst_index_out) {
-    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+template <DataFormat format>
+inline void llk_math_eltwise_binary_sfpu_add_top_row(uint dst_index_in_0, uint dst_index_in_1, uint dst_index_out) {
+    _llk_math_eltwise_binary_sfpu_params_<true>(
         sfpu::calculate_add_top_row<format>,
         dst_index_in_0,
         dst_index_in_1,

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu_types.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu_types.h
@@ -132,4 +132,5 @@ enum class SfpuType {
     cbrt,  // cube root
     hardmish,
     reduce,
+    add_top_row,
 };

--- a/tt_metal/include/compute_kernel_api.h
+++ b/tt_metal/include/compute_kernel_api.h
@@ -636,6 +636,42 @@ ALWI void sfpu_reduce_init() {
     MATH((llk_math_eltwise_unary_sfpu_reduce_init<true, format>()));
 }
 
+// clang-format off
+/**
+ * Performs element-wise add_top_row operation between the top rows of two tiles in DST register.
+ * Takes the top row of tile at dst_tile_a and adds it with the top row of tile at dst_tile_b,
+ * storing the result in the top row of tile at dst_tile_c.
+ * The DST register buffer must be in acquired state via *acquire_dst* call. This call is blocking and is only
+ * available on the compute engine.
+ *
+ * Only 32x32 tile dimensions are supported.
+ * - This kernel is optimized for 32x32 tile dimensions and uses VectorMode::RC_custom for customized addition
+ * Only dst tiles within the destination register are supported.
+ *
+ * | Argument        | Description                                                              | Type      | Valid Range                                           | Required |
+ * |-----------------|--------------------------------------------------------------------------|-----------|-------------------------------------------------------|----------|
+ * | dst_tile_a      | The index of the first tile in DST register                              | uint32_t  | Must be less than the size of the DST register buffer | True     |
+ * | dst_tile_b      | The index of the second tile in DST register                             | uint32_t  | Must be less than the size of the DST register buffer | True     |
+ * | dst_tile_c      | The index of the third tile in DST register                              | uint32_t  | Must be less than the size of the DST register buffer | True     |
+ * | format          | The data format for the add_top_row operation                            | DataFormat| Float32, Int32, UInt32                                | True     |
+ */
+// clang-format on
+template <DataFormat format>
+ALWI void sfpu_add_top_row(uint32_t dst_tile_a, uint32_t dst_tile_b, uint32_t dst_tile_c) {
+    static_assert(
+        format == DataFormat::Float32 || format == DataFormat::Int32 || format == DataFormat::UInt32,
+        "Unsupported data format. Supported formats: Float32, Int32, UInt32");
+
+    MATH((llk_math_eltwise_binary_sfpu_add_top_row<true, format>(dst_tile_a, dst_tile_b, dst_tile_c)));
+}
+
+/**
+ * Please refer to documentation for any_init.
+ */
+ALWI void sfpu_add_top_row_init() {        
+    MATH((llk_math_eltwise_binary_sfpu_add_top_row_init<true>()));
+}
+
 /**
  * Pauses the cores so that the debug interface can be used to inspect the value of the registers.
  *

--- a/tt_metal/include/compute_kernel_api.h
+++ b/tt_metal/include/compute_kernel_api.h
@@ -645,8 +645,7 @@ ALWI void sfpu_reduce_init() {
  * available on the compute engine.
  *
  * Only 32x32 tile dimensions are supported.
- * - This kernel is optimized for 32x32 tile dimensions and uses VectorMode::RC_custom for customized addition
- * Only dst tiles within the destination register are supported.
+ * All three tile indices must refer to tiles in the DST register
  *
  * | Argument        | Description                                                              | Type      | Valid Range                                           | Required |
  * |-----------------|--------------------------------------------------------------------------|-----------|-------------------------------------------------------|----------|
@@ -668,7 +667,7 @@ ALWI void sfpu_add_top_row(uint32_t dst_tile_a, uint32_t dst_tile_b, uint32_t ds
 /**
  * Please refer to documentation for any_init.
  */
-ALWI void sfpu_add_top_row_init() {        
+ALWI void sfpu_add_top_row_init() {
     MATH((llk_math_eltwise_binary_sfpu_add_top_row_init<true>()));
 }
 

--- a/tt_metal/include/compute_kernel_api.h
+++ b/tt_metal/include/compute_kernel_api.h
@@ -661,15 +661,13 @@ ALWI void sfpu_add_top_row(uint32_t dst_tile_0, uint32_t dst_tile_1, uint32_t ds
         format == DataFormat::Float32 || format == DataFormat::Int32 || format == DataFormat::UInt32,
         "Unsupported data format. Supported formats: Float32, Int32, UInt32");
 
-    MATH((llk_math_eltwise_binary_sfpu_add_top_row<true, format>(dst_tile_0, dst_tile_1, dst_tile_out)));
+    MATH((llk_math_eltwise_binary_sfpu_add_top_row<format>(dst_tile_0, dst_tile_1, dst_tile_out)));
 }
 
 /**
  * Please refer to documentation for any_init.
  */
-ALWI void sfpu_add_top_row_init() {
-    MATH((llk_math_eltwise_binary_sfpu_add_top_row_init<true>()));
-}
+ALWI void sfpu_add_top_row_init() { MATH((llk_math_eltwise_binary_sfpu_add_top_row_init())); }
 
 /**
  * Pauses the cores so that the debug interface can be used to inspect the value of the registers.

--- a/tt_metal/include/compute_kernel_api.h
+++ b/tt_metal/include/compute_kernel_api.h
@@ -639,29 +639,29 @@ ALWI void sfpu_reduce_init() {
 // clang-format off
 /**
  * Performs element-wise add_top_row operation between the top rows of two tiles in DST register.
- * Takes the top row of tile at dst_tile_a and adds it with the top row of tile at dst_tile_b,
- * storing the result in the top row of tile at dst_tile_c.
+ * Takes the top row of tile at dst_tile_0 and adds it with the top row of tile at dst_tile_1,
+ * storing the result in the top row of tile at dst_tile_out.
  * The DST register buffer must be in acquired state via *acquire_dst* call. This call is blocking and is only
  * available on the compute engine.
  *
  * Only 32x32 tile dimensions are supported.
- * All three tile indices must refer to tiles in the DST register
+ * All tile indices must reference valid tiles within the DST register.
  *
  * | Argument        | Description                                                              | Type      | Valid Range                                           | Required |
  * |-----------------|--------------------------------------------------------------------------|-----------|-------------------------------------------------------|----------|
- * | dst_tile_a      | The index of the first tile in DST register                              | uint32_t  | Must be less than the size of the DST register buffer | True     |
- * | dst_tile_b      | The index of the second tile in DST register                             | uint32_t  | Must be less than the size of the DST register buffer | True     |
- * | dst_tile_c      | The index of the third tile in DST register                              | uint32_t  | Must be less than the size of the DST register buffer | True     |
+ * | dst_tile_0      | The index of the first tile in DST register                              | uint32_t  | Must be less than the size of the DST register buffer | True     |
+ * | dst_tile_1      | The index of the second tile in DST register                             | uint32_t  | Must be less than the size of the DST register buffer | True     |
+ * | dst_tile_out    | The index of the output tile in DST register                             | uint32_t  | Must be less than the size of the DST register buffer | True     |
  * | format          | The data format for the add_top_row operation                            | DataFormat| Float32, Int32, UInt32                                | True     |
  */
 // clang-format on
 template <DataFormat format>
-ALWI void sfpu_add_top_row(uint32_t dst_tile_a, uint32_t dst_tile_b, uint32_t dst_tile_c) {
+ALWI void sfpu_add_top_row(uint32_t dst_tile_0, uint32_t dst_tile_1, uint32_t dst_tile_out) {
     static_assert(
         format == DataFormat::Float32 || format == DataFormat::Int32 || format == DataFormat::UInt32,
         "Unsupported data format. Supported formats: Float32, Int32, UInt32");
 
-    MATH((llk_math_eltwise_binary_sfpu_add_top_row<true, format>(dst_tile_a, dst_tile_b, dst_tile_c)));
+    MATH((llk_math_eltwise_binary_sfpu_add_top_row<true, format>(dst_tile_0, dst_tile_1, dst_tile_out)));
 }
 
 /**


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/29535#issuecomment-3479884917
### Problem description
The column reduction kernels store their results in the top row of each tile. Adding two reduced tiles together would sum all the data in the tiles, even though only the top row is relevant. This approach is computationally intensive and inefficient.

### What's changed
Once the desired tiles have been reduced, if you want to accumulate their sums, this kernel computes the sum using only the first row of each tile. This approach reduces the number of operations and cycles required, optimizing summation and accumulation after reduction ops. 

Performance analytics from LLK Perf Infra show that this approach is more efficient (requiring fewer cycles) than performing a regular Add SFPU followed by a reduction on the resulting tile.