### PR TITLE
#28352 / #28343: [skip ci] Re-enable fabric2d tests on QBGE upstream container

### DIFF
--- a/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
+++ b/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
@@ -116,11 +116,7 @@ test_suite_bh_multi_pcie_metal_unit_tests() {
         sleep 5
     done
     ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric1D*Fixture.*"
-
-    # Remove this once https://github.com/tenstorrent/tt-metal/issues/28352 is fixed
-    if [[ "$hw_topology" != "blackhole_qb_ge" ]]; then
-        ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2D*Fixture.*"
-    fi
+    ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2D*Fixture.*"
 
     ./build/test/tt_metal/unit_tests_eth
     if [[ "$hw_topology" == "blackhole_llmbox" ]]; then


### PR DESCRIPTION
### Ticket
#28352 eth instability issue (still not resolved, issue still seen on 2/3 QBGEs)
#28343 container delivery top-level issue

### What's changed
Fabric2D tests work on the QBGE runner in CI, re-enable them on upstream testing

### Checklist
- [x] Upstream tests: https://github.com/tenstorrent/tt-metal/actions/runs/19338724170/job/55323767047