### PR TITLE
[skip ci] Fix build with old CMake

### DIFF
--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -72,6 +72,18 @@ CPMAddPackage(
         protobuf_noreturn.patch
 )
 
+if(CMAKE_VERSION VERSION_LESS 3.25)
+    # CMake 3.24 didn't yet have add_subdirectory(... SYSTEM), libprotobuf doesn't publish its interface dirs as SYSTEM
+    # and headers in it run afoul certain compiler warnings.  That all combines to failed builds.  Work around it here.
+    get_target_property(PROTOBUF_INCLUDES protobuf::libprotobuf INTERFACE_INCLUDE_DIRECTORIES)
+    set_target_properties(
+        libprotobuf
+        PROPERTIES
+            INTERFACE_SYSTEM_INCLUDE_DIRECTORIES
+                "${PROTOBUF_INCLUDES}"
+    )
+endif()
+
 # Setting visibility to hidden to avoid symbol conflicts with other protobuf libraries when tt-metal package is used
 set_target_properties(
     libprotobuf


### PR DESCRIPTION
### Ticket
#29192

### Problem description
CMake v2.24 does not support `add_subdirectory( ... SYSTEM)`, and protobuf does not publish its interface as SYSTEM, and protobuf's headers run afoul certain compiler warnings.  When those three combine, we get a build failure.
We still want to support CMake v2.24 until we move past Ubuntu 22.04 as that is the default version shipped by Canonical on that platform.

### What's changed
Patch the protobuf target to ensure its headers are treated as SYSTEM by all consumers.