### PR TITLE
Eliminate Duplicate Copy Tile in MPWI

### DIFF
--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_pool_2d.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_pool_2d.cpp
@@ -74,7 +74,6 @@ void MAIN {
     constexpr uint32_t data_dst_idx = 0;
     constexpr uint32_t index_dst_idx = 2;
     constexpr uint32_t inc_dst_idx = 4;
-    constexpr uint32_t index_scratch_in_dst_idx = 5;
     constexpr uint32_t index_scratch_out_dst_idx = 6;
 
     constexpr uint32_t face_r_dim = window_size_hw < FACE_HEIGHT && !return_indices ? window_size_hw : FACE_HEIGHT;
@@ -114,6 +113,7 @@ void MAIN {
     } else {
         unary_op_init_common(in_cb_id_0, in_cb_id_0);
         copy_tile_to_dst_init_short(in_cb_id_0);
+        max_reduce_with_indices_init<ckernel::DataLayout::ROW_MAJOR>();
     }
 
     constexpr uint32_t remaining_elems = window_size_hw % max_sticks_for_reduction;
@@ -183,25 +183,10 @@ void MAIN {
                     }
                     reconfig_data_format_srca(in_idx_cb_id);
                     copy_tile(in_idx_cb_id, mpwi_cb_tile_idx, index_dst_idx);
-                    copy_tile(in_idx_cb_id, mpwi_cb_tile_idx, index_scratch_in_dst_idx);
                     if (last_c_block) {
                         cb_pop_front(in_idx_cb_id, 1);
-                    }
 
-                    if (first_c_block) {
-                        max_reduce_with_indices_init<ckernel::DataLayout::ROW_MAJOR>();
-                    }
-                    // the max_reduce_with_indices LLK function only supports kernel_size=9, pending
-                    // https://github.com/tenstorrent/tt-metal/issues/28141 but, since for return_indices the in_cb is
-                    // oversized (equal to 1 tile), and since this CB is filled with padding values in the beginning of
-                    // the data movement kernel, it is possible to still use max_reduce_with_indices with kernel sizes
-                    // smaller than 9 as the excess sticks are just filled with padding values
-                    constexpr uint32_t max_mpwi_kernel_size = 9;
-                    max_reduce_with_indices<max_mpwi_kernel_size, ckernel::DataLayout::ROW_MAJOR>(
-                        data_dst_idx, index_dst_idx);
-
-                    // update the current index column
-                    if (last_c_block) {
+                        // update the current index column
                         if (current_idx_col + stride_w + eff_kernel_w > in_w_padded) {
                             // we reached the right edge, wrap down and to the left
                             current_idx_col = 0;
@@ -221,8 +206,19 @@ void MAIN {
 
                         // we allow overflow here for negative values as this only occurs in padding regions
                         add_int_tile_init();
-                        add_uint16_tile(index_scratch_in_dst_idx, inc_dst_idx, index_scratch_out_dst_idx);
+                        add_uint16_tile(index_dst_idx, inc_dst_idx, index_scratch_out_dst_idx);
+
+                        max_reduce_with_indices_init<ckernel::DataLayout::ROW_MAJOR>();
                     }
+
+                    // the max_reduce_with_indices LLK function only supports kernel_size=9, pending
+                    // https://github.com/tenstorrent/tt-metal/issues/28141 but, since for return_indices the in_cb is
+                    // oversized (equal to 1 tile), and since this CB is filled with padding values in the beginning of
+                    // the data movement kernel, it is possible to still use max_reduce_with_indices with kernel sizes
+                    // smaller than 9 as the excess sticks are just filled with padding values
+                    constexpr uint32_t max_mpwi_kernel_size = 9;
+                    max_reduce_with_indices<max_mpwi_kernel_size, ckernel::DataLayout::ROW_MAJOR>(
+                        data_dst_idx, index_dst_idx);
                 } else {
                     unpack_tilizeA_B_block<neginf_srca_maxpool, true, false, zero_srca_avgpool>(
                         curr_in_cb_id,


### PR DESCRIPTION
### Ticket
N/A

### Problem description
On main MPWI copies the indexes to 2 DST registers since one copy will be reduced, and the other copy needs to be incremented.

### What's changed
The increment operation has been moved in front of the reduction.  The increment operation outputs to a different DST index than the input, thus the input can be reused for the reduction, freeing one DST register (now 4 are used instead of 5) and eliminating the duplicate copy.

Negligible performance difference, total Pool2D kernel time over the MPWI unit test is reduced by 0.5%, more benefit may be realized when other bottlenecks are removed.  Additionally since we now only use 4 DST registers we could potentially process 2 positions at once.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/19346652745
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/19346655370
- [x] [Nightly L2](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/19346659593
- [x] [Nightly Blackhole](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-nightly-tests.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/19346663702
- [x] New/Existing tests provide coverage for changes