### PR TITLE
Fix GQA for split_query_key_value_and_split_heads

### DIFF
--- a/tests/ttnn/unit_tests/operations/transformers/test_transformer.py
+++ b/tests/ttnn/unit_tests/operations/transformers/test_transformer.py
@@ -191,13 +191,64 @@ def test_transformer_split_query_key_value_and_split_heads(
 
 @pytest.mark.parametrize("batch_size", [1])
 @pytest.mark.parametrize("sequence_size", [1024])
+@pytest.mark.parametrize("num_heads", [4, 16])
+@pytest.mark.parametrize("head_size", [64, 128])
+@pytest.mark.parametrize("num_kv_heads", [None])
+@pytest.mark.parametrize("input_dtype", [ttnn.bfloat16])
+@pytest.mark.parametrize("input_memory_config", [ttnn.DRAM_MEMORY_CONFIG])
+def test_transformer_split_query_key_value_and_split_heads_with_kv_input_tensor(
+    batch_size, num_heads, sequence_size, head_size, num_kv_heads, input_dtype, input_memory_config, *, device
+):
+    torch.manual_seed(0)
+
+    input_shape = (batch_size, sequence_size, num_heads * head_size)
+    kv_input_shape = (batch_size, sequence_size, num_heads * 2 * head_size)
+    torch_input_tensor = torch_random(input_shape, -0.1, 0.1, dtype=torch.bfloat16)
+    torch_kv_input_tensor = torch_random(kv_input_shape, -0.1, 0.1, dtype=torch.bfloat16)
+    golden_function = ttnn.get_golden_function(ttnn.transformer.split_query_key_value_and_split_heads)
+
+    (
+        torch_query_tensor,
+        torch_key_tensor,
+        torch_value_tensor,
+    ) = golden_function(torch_input_tensor, torch_kv_input_tensor, num_heads=num_heads, num_kv_heads=num_kv_heads)
+
+    input_tensor = ttnn.from_torch(
+        torch_input_tensor,
+        device=device,
+        dtype=input_dtype,
+        memory_config=input_memory_config,
+        layout=ttnn.TILE_LAYOUT,
+    )
+    kv_input_tensor = ttnn.from_torch(
+        torch_kv_input_tensor,
+        device=device,
+        dtype=input_dtype,
+        memory_config=input_memory_config,
+        layout=ttnn.TILE_LAYOUT,
+    )
+
+    query_tensor, key_tensor, value_tensor = ttnn.transformer.split_query_key_value_and_split_heads(
+        input_tensor, kv_input_tensor, num_heads=num_heads, num_kv_heads=num_kv_heads
+    )
+    query_tensor = ttnn.to_torch(query_tensor)
+    key_tensor = ttnn.to_torch(key_tensor)
+    value_tensor = ttnn.to_torch(value_tensor)
+
+    assert_with_pcc(torch_query_tensor, query_tensor, 0.999)
+    assert_with_pcc(torch_key_tensor, key_tensor, 0.999)
+    assert_with_pcc(torch_value_tensor, value_tensor, 0.999)
+
+
+@pytest.mark.parametrize("batch_size", [1])
+@pytest.mark.parametrize("sequence_size", [1024])
 @pytest.mark.parametrize("num_heads", [24])
 @pytest.mark.parametrize("head_size", [128])
 @pytest.mark.parametrize("num_kv_heads", [8])
 @pytest.mark.parametrize("transpose_key", [True, False])
 @pytest.mark.parametrize("input_dtype", [ttnn.bfloat16])
 @pytest.mark.parametrize("input_memory_config", [ttnn.DRAM_MEMORY_CONFIG])
-def test_transformer_split_query_key_value_and_split_heads_with_kv_input_tensor(
+def test_transformer_split_query_key_value_and_split_heads_with_kv_input_tensor_and_num_kv_heads(
     batch_size,
     num_heads,
     sequence_size,

--- a/tests/ttnn/unit_tests/operations/transformers/test_transformer.py
+++ b/tests/ttnn/unit_tests/operations/transformers/test_transformer.py
@@ -194,10 +194,20 @@ def test_transformer_split_query_key_value_and_split_heads(
 @pytest.mark.parametrize("num_heads", [24])
 @pytest.mark.parametrize("head_size", [128])
 @pytest.mark.parametrize("num_kv_heads", [8])
+@pytest.mark.parametrize("transpose_key", [True, False])
 @pytest.mark.parametrize("input_dtype", [ttnn.bfloat16])
 @pytest.mark.parametrize("input_memory_config", [ttnn.DRAM_MEMORY_CONFIG])
 def test_transformer_split_query_key_value_and_split_heads_with_kv_input_tensor(
-    batch_size, num_heads, sequence_size, head_size, num_kv_heads, input_dtype, input_memory_config, *, device
+    batch_size,
+    num_heads,
+    sequence_size,
+    head_size,
+    num_kv_heads,
+    transpose_key,
+    input_dtype,
+    input_memory_config,
+    *,
+    device,
 ):
     torch.manual_seed(0)
 
@@ -212,7 +222,11 @@ def test_transformer_split_query_key_value_and_split_heads_with_kv_input_tensor(
         torch_key_tensor,
         torch_value_tensor,
     ) = golden_function(
-        torch_input_tensor, torch_kv_input_tensor, num_heads=num_heads, num_kv_heads=num_kv_heads, transpose_key=False
+        torch_input_tensor,
+        torch_kv_input_tensor,
+        num_heads=num_heads,
+        num_kv_heads=num_kv_heads,
+        transpose_key=transpose_key,
     )
 
     input_tensor = ttnn.from_torch(
@@ -231,7 +245,7 @@ def test_transformer_split_query_key_value_and_split_heads_with_kv_input_tensor(
     )
 
     query_tensor, key_tensor, value_tensor = ttnn.transformer.split_query_key_value_and_split_heads(
-        input_tensor, kv_input_tensor, num_heads=num_heads, num_kv_heads=num_kv_heads, transpose_key=False
+        input_tensor, kv_input_tensor, num_heads=num_heads, num_kv_heads=num_kv_heads, transpose_key=transpose_key
     )
     query_tensor = ttnn.to_torch(query_tensor)
     key_tensor = ttnn.to_torch(key_tensor)

--- a/tests/ttnn/unit_tests/operations/transformers/test_transformer.py
+++ b/tests/ttnn/unit_tests/operations/transformers/test_transformer.py
@@ -191,9 +191,9 @@ def test_transformer_split_query_key_value_and_split_heads(
 
 @pytest.mark.parametrize("batch_size", [1])
 @pytest.mark.parametrize("sequence_size", [1024])
-@pytest.mark.parametrize("num_heads", [4, 16])
-@pytest.mark.parametrize("head_size", [64, 128])
-@pytest.mark.parametrize("num_kv_heads", [None])
+@pytest.mark.parametrize("num_heads", [24])
+@pytest.mark.parametrize("head_size", [128])
+@pytest.mark.parametrize("num_kv_heads", [8])
 @pytest.mark.parametrize("input_dtype", [ttnn.bfloat16])
 @pytest.mark.parametrize("input_memory_config", [ttnn.DRAM_MEMORY_CONFIG])
 def test_transformer_split_query_key_value_and_split_heads_with_kv_input_tensor(
@@ -202,7 +202,7 @@ def test_transformer_split_query_key_value_and_split_heads_with_kv_input_tensor(
     torch.manual_seed(0)
 
     input_shape = (batch_size, sequence_size, num_heads * head_size)
-    kv_input_shape = (batch_size, sequence_size, num_heads * 2 * head_size)
+    kv_input_shape = (batch_size, sequence_size, num_kv_heads * 2 * head_size)
     torch_input_tensor = torch_random(input_shape, -0.1, 0.1, dtype=torch.bfloat16)
     torch_kv_input_tensor = torch_random(kv_input_shape, -0.1, 0.1, dtype=torch.bfloat16)
     golden_function = ttnn.get_golden_function(ttnn.transformer.split_query_key_value_and_split_heads)
@@ -211,7 +211,9 @@ def test_transformer_split_query_key_value_and_split_heads_with_kv_input_tensor(
         torch_query_tensor,
         torch_key_tensor,
         torch_value_tensor,
-    ) = golden_function(torch_input_tensor, torch_kv_input_tensor, num_heads=num_heads, num_kv_heads=num_kv_heads)
+    ) = golden_function(
+        torch_input_tensor, torch_kv_input_tensor, num_heads=num_heads, num_kv_heads=num_kv_heads, transpose_key=False
+    )
 
     input_tensor = ttnn.from_torch(
         torch_input_tensor,
@@ -229,7 +231,7 @@ def test_transformer_split_query_key_value_and_split_heads_with_kv_input_tensor(
     )
 
     query_tensor, key_tensor, value_tensor = ttnn.transformer.split_query_key_value_and_split_heads(
-        input_tensor, kv_input_tensor, num_heads=num_heads, num_kv_heads=num_kv_heads
+        input_tensor, kv_input_tensor, num_heads=num_heads, num_kv_heads=num_kv_heads, transpose_key=False
     )
     query_tensor = ttnn.to_torch(query_tensor)
     key_tensor = ttnn.to_torch(key_tensor)

--- a/ttnn/cpp/ttnn/operations/transformer/split_query_key_value_and_split_heads/split_query_key_value_and_split_heads.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/split_query_key_value_and_split_heads/split_query_key_value_and_split_heads.cpp
@@ -78,7 +78,7 @@ std::tuple<Tensor, Tensor, Tensor> SplitQueryKeyValueAndSplitHeadsOperation::inv
     const uint32_t sequence_size = input_shape[1];
     const uint32_t sequence_size_padded = padded_input_shape[1];
 
-    if (num_kv_heads.has_value()) {
+    if (num_kv_heads.has_value() && !input_tensor_kv.has_value()) {
         TT_FATAL(
             !transpose_key,
             "Invalid configuration: Transpose is set to true, but this is not supported when separate num_kv_heads is "
@@ -130,10 +130,10 @@ std::tuple<Tensor, Tensor, Tensor> SplitQueryKeyValueAndSplitHeadsOperation::inv
             input_shape[1]);
 
         TT_FATAL(
-            input_shape_kv[2] == 2 * input_shape[2],
-            "Dimension mismatch: KV tensor hidden size ({}) must be twice the Q tensor hidden size ({}).",
-            input_shape_kv[2],
-            2 * input_shape[2]);
+            (input_shape_kv[2] / (2 * num_kv_heads.value())) == (input_shape[2] / num_heads),
+            "Dimension mismatch: KV head size ({}) must be equal to query head size ({}).",
+            (input_shape_kv[2] / (2 * num_kv_heads.value())),
+            (input_shape[2] / num_heads));
 
         hidden_dim = input_shape[2];
         hidden_dim_padded = padded_input_shape[2];

--- a/ttnn/cpp/ttnn/operations/transformer/split_query_key_value_and_split_heads/split_query_key_value_and_split_heads.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/split_query_key_value_and_split_heads/split_query_key_value_and_split_heads.cpp
@@ -136,15 +136,15 @@ std::tuple<Tensor, Tensor, Tensor> SplitQueryKeyValueAndSplitHeadsOperation::inv
             num_heads);
 
         TT_FATAL(
-            (input_shape_kv[2] % (2 * num_kv_heads.value())) == 0,
+            (input_shape_kv[2] % (2 * num_kv_heads.value_or(num_heads))) == 0,
             "KV dimension ({}) must be divisible by 2 * num_kv_heads ({}).",
             input_shape_kv[2],
-            (2 * num_kv_heads.value()));
+            (2 * num_kv_heads.value_or(num_heads)));
 
         TT_FATAL(
-            (input_shape_kv[2] / (2 * num_kv_heads.value())) == (input_shape[2] / num_heads),
+            (input_shape_kv[2] / (2 * num_kv_heads.value_or(num_heads))) == (input_shape[2] / num_heads),
             "Dimension mismatch: KV head size ({}) must be equal to query head size ({}).",
-            (input_shape_kv[2] / (2 * num_kv_heads.value())),
+            (input_shape_kv[2] / (2 * num_kv_heads.value_or(num_heads))),
             (input_shape[2] / num_heads));
 
         hidden_dim = input_shape[2];

--- a/ttnn/cpp/ttnn/operations/transformer/split_query_key_value_and_split_heads/split_query_key_value_and_split_heads.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/split_query_key_value_and_split_heads/split_query_key_value_and_split_heads.cpp
@@ -130,6 +130,18 @@ std::tuple<Tensor, Tensor, Tensor> SplitQueryKeyValueAndSplitHeadsOperation::inv
             input_shape[1]);
 
         TT_FATAL(
+            (input_shape[2] % num_heads) == 0,
+            "Query dimension ({}) must be divisible by num_heads ({}).",
+            input_shape[2],
+            num_heads);
+
+        TT_FATAL(
+            (input_shape_kv[2] % (2 * num_kv_heads.value())) == 0,
+            "KV dimension ({}) must be divisible by 2 * num_kv_heads ({}).",
+            input_shape_kv[2],
+            (2 * num_kv_heads.value()));
+
+        TT_FATAL(
             (input_shape_kv[2] / (2 * num_kv_heads.value())) == (input_shape[2] / num_heads),
             "Dimension mismatch: KV head size ({}) must be equal to query head size ({}).",
             (input_shape_kv[2] / (2 * num_kv_heads.value())),


### PR DESCRIPTION
### Ticket
#32407 

### Problem description
`ttnn/cpp/ttnn/operations/transformer/split_query_key_value_and_split_heads/split_query_key_value_and_split_heads.cpp` has an incorrect if statement. This if statement checks for `num_kv_heads.has_value()` but not for `input_tensor_kv`. However, grouped query attention does not correspond to this if statement. Furthermore, head size assert is using an incorrect calculation. In addition, the golden function of `split_query_key_value_and_split_heads` does not capture grouped query attention completely.

### What's changed
- `if num_kv_heads.has_value()` is changed into `if (num_kv_heads.has_value() && !input_tensor_kv.has_value())`
- head size assert is changed to use input_kv_tensor / (2 * num_kv_heads) 
- head size assert is changed to use input_tensor / num_heads
- golden function is changed to slice query, key, value appropriately for both grouped query attention and multi-head attention

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [x] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [x] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes