### PR TITLE
wrap fabric kernel builders in a common interface

### DIFF
--- a/tt_metal/fabric/CMakeLists.txt
+++ b/tt_metal/fabric/CMakeLists.txt
@@ -36,6 +36,8 @@ target_sources(
         routing_table_generator.cpp
         mesh_graph.cpp
         erisc_datamover_builder.cpp
+        fabric_router_channel_mapping.cpp
+        fabric_router_builder.cpp
         builder/fabric_core_placement.cpp
         builder/fabric_channel_allocator.cpp
         builder/fabric_static_sized_channels_allocator.cpp

--- a/tt_metal/fabric/builder/fabric_builder_helpers.hpp
+++ b/tt_metal/fabric/builder/fabric_builder_helpers.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "hostdevcommon/fabric_common.h"
 #include "tt_metal/fabric/builder/fabric_builder_config.hpp"
 #include "tt_metal/fabric/fabric_context.hpp"
 
@@ -79,7 +80,7 @@ inline uint32_t get_downstream_edm_sender_channel(
     //         NORTH → channel 3
 
     size_t downstream_compact_index_for_upstream;
-    if (downstream_direction == 0) {
+    if (downstream_direction == eth_chan_directions::EAST) {
         // EAST downstream: WEST(1)→0, NORTH(2)→1, SOUTH(3)→2
         downstream_compact_index_for_upstream = receiver_direction - 1;
     } else {

--- a/tt_metal/fabric/builder/fabric_core_placement.cpp
+++ b/tt_metal/fabric/builder/fabric_core_placement.cpp
@@ -24,24 +24,24 @@ void run_default_galaxy_optimizer(
     bool enable_noc_selection_opt = false;
     if (ctx.topology == Topology::Ring) {
         enable_noc_selection_opt =
-            (ctx.num_links > ring_noc_selection_link_threshold) && (edm_builder1.my_noc_y != edm_builder2.my_noc_y);
+            (ctx.num_links > ring_noc_selection_link_threshold) && (edm_builder1.get_noc_y() != edm_builder2.get_noc_y());
     } else {
         enable_noc_selection_opt =
-            (ctx.num_links > line_noc_selection_link_threshold) && (edm_builder1.my_noc_y != edm_builder2.my_noc_y);
+            (ctx.num_links > line_noc_selection_link_threshold) && (edm_builder1.get_noc_y() != edm_builder2.get_noc_y());
     }
     log_debug(
         tt::LogTest,
         "Fabric MeshId {} ChipId {} edm_builder1 {} {} is connecting to edm_builder2 {} {} num links {}",
         *(edm_builder1.local_fabric_node_id.mesh_id),
         edm_builder1.local_fabric_node_id.chip_id,
-        edm_builder1.my_noc_x,
-        edm_builder1.my_noc_y,
-        edm_builder2.my_noc_x,
-        edm_builder2.my_noc_y,
+        edm_builder1.get_noc_x(),
+        edm_builder1.get_noc_y(),
+        edm_builder2.get_noc_x(),
+        edm_builder2.get_noc_y(),
         ctx.num_links);
 
     if (enable_noc_selection_opt) {
-        if (edm_builder1.my_noc_x < edm_builder2.my_noc_x) {
+        if (edm_builder1.get_noc_x() < edm_builder2.get_noc_x()) {
             for (uint32_t i = 0; i < builder_config::num_receiver_channels; i++) {
                 edm_builder1.config.receiver_channel_forwarding_noc_ids[i] = 0;
                 edm_builder2.config.receiver_channel_forwarding_noc_ids[i] = 1;
@@ -54,7 +54,7 @@ void run_default_galaxy_optimizer(
                 edm_builder1.config.sender_channel_ack_noc_ids[i] = 1;
                 edm_builder2.config.sender_channel_ack_noc_ids[i] = 0;
             }
-        } else if (edm_builder1.my_noc_x > edm_builder2.my_noc_x) {
+        } else if (edm_builder1.get_noc_x() > edm_builder2.get_noc_x()) {
             for (uint32_t i = 0; i < builder_config::num_receiver_channels; i++) {
                 edm_builder1.config.receiver_channel_forwarding_noc_ids[i] = 1;
                 edm_builder2.config.receiver_channel_forwarding_noc_ids[i] = 0;
@@ -85,9 +85,9 @@ void apply_core_placement_optimizations(
     // perf degradation, potentially caused by sw overhead of checking two nocs.
     if (ctx.is_galaxy) {
         if (ctx.topology == Topology::Ring) {
-            enable_core_placement_opt = (ctx.num_links > 3) && (edm_fwd.my_noc_y != edm_bwd.my_noc_y);
+            enable_core_placement_opt = (ctx.num_links > 3) && (edm_fwd.get_noc_y() != edm_bwd.get_noc_y());
         } else {
-            enable_core_placement_opt = (ctx.num_links > 2) && (edm_fwd.my_noc_y != edm_bwd.my_noc_y);
+            enable_core_placement_opt = (ctx.num_links > 2) && (edm_fwd.get_noc_y() != edm_bwd.get_noc_y());
         }
     }
 

--- a/tt_metal/fabric/erisc_datamover_builder.cpp
+++ b/tt_metal/fabric/erisc_datamover_builder.cpp
@@ -1404,9 +1404,9 @@ void FabricEriscDatamoverBuilder::connect_to_downstream_edm_impl(
         tt::LogTest,
         "EDM at x={}, y={}, Direction={}, FabricNodeId={} :: Connecting to downstream EDM at x={}, y={}, "
         "Direction={}",
-        my_noc_x,
-        my_noc_y,
-        direction,
+        this->get_noc_x(),
+        this->get_noc_y(),
+        this->get_direction(),
         local_fabric_node_id,
         downstream_builder->get_noc_x(),
         downstream_builder->get_noc_y(),

--- a/tt_metal/fabric/erisc_datamover_builder.cpp
+++ b/tt_metal/fabric/erisc_datamover_builder.cpp
@@ -1441,7 +1441,7 @@ void FabricEriscDatamoverBuilder::connect_to_downstream_edm_impl(
     // Setup VC1 connection if needed
     constexpr uint32_t ds_index = 1;
     auto vc1_send_chan = builder_config::get_sender_channel_count(is_2D_routing) - 1;
-    
+
     this->setup_downstream_vc_connection(vc1_edm_builder, ds_index, vc1_send_chan, true);
 }
 

--- a/tt_metal/fabric/erisc_datamover_builder.cpp
+++ b/tt_metal/fabric/erisc_datamover_builder.cpp
@@ -22,7 +22,6 @@
 #include <numeric>
 #include <optional>
 #include <unordered_set>
-#include <variant>
 #include <vector>
 
 #include "tt_metal/fabric/builder/fabric_static_sized_channels_allocator.hpp"
@@ -722,10 +721,9 @@ FabricEriscDatamoverBuilder::FabricEriscDatamoverBuilder(
     bool build_in_worker_connection_mode,
     FabricEriscDatamoverType fabric_edm_type,
     bool has_tensix_extension) :
+    FabricDatamoverBuilderBase(my_noc_x, my_noc_y, direction),
     my_eth_core_logical(my_eth_core_logical),
     my_eth_channel(my_eth_core_logical.y),
-    my_noc_x(my_noc_x),
-    my_noc_y(my_noc_y),
     config(config),
     local_fabric_node_id(local_fabric_node_id),
     peer_fabric_node_id(peer_fabric_node_id),
@@ -737,7 +735,6 @@ FabricEriscDatamoverBuilder::FabricEriscDatamoverBuilder(
     edm_local_sync_ptr(config.edm_local_sync_address),
     edm_local_tensix_sync_ptr(config.edm_local_tensix_sync_address),
     edm_status_ptr(config.edm_status_address),
-    direction(direction),
 
     // this is the receiver channel's local sem for flow controlling with downstream fabric sender
     receiver_channels_downstream_flow_control_semaphore_id(receiver_channels_downstream_flow_control_semaphore_id),
@@ -927,7 +924,7 @@ std::vector<uint32_t> FabricEriscDatamoverBuilder::get_compile_time_args(uint32_
     // when have dateline vc (vc1) and with tensix exntension enabled, need to send vc1 to downstream fabric router
     // instead of downstream tensix exntension.
     bool vc1_has_different_downstream_dest =
-        fabric_context.need_deadlock_avoidance_support(this->direction) && this->has_tensix_extension;
+        fabric_context.need_deadlock_avoidance_support(this->direction_) && this->has_tensix_extension;
 
     // Compute edge-facing flags for this ethernet core/channel
     const auto [is_intermesh_router_on_edge, is_intramesh_router_on_edge] =
@@ -945,7 +942,7 @@ std::vector<uint32_t> FabricEriscDatamoverBuilder::get_compile_time_args(uint32_
 
         this->firmware_context_switch_interval,
         this->fuse_receiver_flush_and_completion_ptr,
-        fabric_context.need_deadlock_avoidance_support(this->direction),
+        fabric_context.need_deadlock_avoidance_support(this->direction_),
         this->dateline_connection,
         control_plane.is_cross_host_eth_link(local_physical_chip_id, this->my_eth_channel),
         is_handshake_master,
@@ -1014,7 +1011,7 @@ std::vector<uint32_t> FabricEriscDatamoverBuilder::get_compile_time_args(uint32_
         config.receiver_txq_id,
         config.risc_configs[risc_id].iterations_between_ctx_switch_and_teardown_checks(),
         fabric_context.is_2D_routing_enabled(),
-        this->direction,
+        this->direction_,
         soc_desc.get_num_eth_channels(),
 
         eth_txq_spin_wait_send_next_data,
@@ -1342,7 +1339,7 @@ FabricEriscDatamoverBuilder FabricEriscDatamoverBuilder::build(
 //         this->direction};
 // }
 
-SenderWorkerAdapterSpec FabricEriscDatamoverBuilder::build_connection_to_fabric_channel(uint32_t ds_edm) {
+SenderWorkerAdapterSpec FabricEriscDatamoverBuilder::build_connection_to_fabric_channel(uint32_t ds_edm) const {
     const bool is_2D_routing =
         tt::tt_metal::MetalContext::instance().get_control_plane().get_fabric_context().is_2D_routing_enabled();
     auto max_ds_edm_count = builder_config::get_sender_channel_count(is_2D_routing);
@@ -1381,8 +1378,8 @@ SenderWorkerAdapterSpec FabricEriscDatamoverBuilder::build_connection_to_fabric_
 
     this->sender_channel_connection_liveness_check_disable_array[ds_edm] = true;
     return SenderWorkerAdapterSpec{
-        this->my_noc_x,
-        this->my_noc_y,
+        this->noc_x_,
+        this->noc_y_,
         static_channel_allocator->get_sender_channel_base_address(ds_edm),
         sender_channels_num_buffer,
         this->sender_channels_flow_control_semaphore_id[ds_edm],
@@ -1393,77 +1390,67 @@ SenderWorkerAdapterSpec FabricEriscDatamoverBuilder::build_connection_to_fabric_
         eth_chan_directions::EAST};
 }
 
+
 // Internal implementation for connect_to_downstream_edm
+// Note: this can be deleted after fabric latency tests are ported to new test infrastructure
 void FabricEriscDatamoverBuilder::connect_to_downstream_edm_impl(
-    FabricDatamoverBuilder downstream_builder, FabricDatamoverBuilder vc1_edm_builder) {
+    FabricDatamoverBuilderBase *downstream_builder, FabricDatamoverBuilderBase *vc1_edm_builder) {
     TT_FATAL(
         !this->build_in_worker_connection_mode, "Tried to connect EDM to downstream builder in worker connection mode");
 
-    std::visit(
-        [this, &vc1_edm_builder](auto&& builder_ref) {
-            auto& builder = builder_ref.get();
+    eth_chan_directions ds_dir = downstream_builder->get_direction();
 
-            [[maybe_unused]] const auto ds_noc_x = builder.get_noc_x();
-            [[maybe_unused]] const auto ds_noc_y = builder.get_noc_y();
-            eth_chan_directions ds_dir = builder.get_direction();
+    log_debug(
+        tt::LogTest,
+        "EDM at x={}, y={}, Direction={}, FabricNodeId={} :: Connecting to downstream EDM at x={}, y={}, "
+        "Direction={}",
+        my_noc_x,
+        my_noc_y,
+        direction,
+        local_fabric_node_id,
+        downstream_builder->get_noc_x(),
+        downstream_builder->get_noc_y(),
+        ds_dir);
 
-            log_debug(
-                tt::LogTest,
-                "EDM at x={}, y={}, Direction={}, FabricNodeId={} :: Connecting to downstream EDM at x={}, y={}, "
-                "Direction={}",
-                my_noc_x,
-                my_noc_y,
-                direction,
-                local_fabric_node_id,
-                ds_noc_x,
-                ds_noc_y,
-                ds_dir);
+    const auto& fabric_context =
+        tt::tt_metal::MetalContext::instance().get_control_plane().get_fabric_context();
+    const bool is_2D_routing = fabric_context.is_2D_routing_enabled();
 
-            const auto& fabric_context =
-                tt::tt_metal::MetalContext::instance().get_control_plane().get_fabric_context();
-            const bool is_2D_routing = fabric_context.is_2D_routing_enabled();
+    // Setup VC0 connection
+    constexpr uint32_t ds_vc0_index = 0;
+    auto ds_vc0_send_chan = get_downstream_edm_sender_channel(is_2D_routing, this->get_direction(), ds_dir);
+    setup_downstream_vc_connection(downstream_builder, ds_vc0_index, ds_vc0_send_chan, false);
 
-            // Setup VC0 connection
-            constexpr uint32_t ds_vc0_index = 0;
-            auto ds_vc0_send_chan = get_downstream_edm_sender_channel(is_2D_routing, this->direction, ds_dir);
-            setup_downstream_vc_connection(builder, ds_vc0_index, ds_vc0_send_chan, false);
+    if (!fabric_context.need_deadlock_avoidance_support(this->get_direction())) {
+        return;
+    }
 
-            if (!fabric_context.need_deadlock_avoidance_support(this->direction)) {
-                return;
-            }
+    // for vc1, need to connect using the edm builder not tensix builder.
+    if (is_2D_routing) {
+        // for 2D routing we can only connect VC1 if the downstream is on the same axis
+        bool connect_vc1 =
+            (this->get_direction() == eth_chan_directions::EAST && ds_dir == eth_chan_directions::WEST) ||
+            (this->get_direction() == eth_chan_directions::WEST && ds_dir == eth_chan_directions::EAST) ||
+            (this->get_direction() == eth_chan_directions::NORTH && ds_dir == eth_chan_directions::SOUTH) ||
+            (this->get_direction() == eth_chan_directions::SOUTH && ds_dir == eth_chan_directions::NORTH);
+        if (!connect_vc1) {
+            return;
+        }
+    }
 
-            // for vc1, need to connect using the edm builder not tensix builder.
-            if (is_2D_routing) {
-                // for 2D routing we can only connect VC1 if the downstream is on the same axis
-                bool connect_vc1 =
-                    (this->direction == eth_chan_directions::EAST && ds_dir == eth_chan_directions::WEST) ||
-                    (this->direction == eth_chan_directions::WEST && ds_dir == eth_chan_directions::EAST) ||
-                    (this->direction == eth_chan_directions::NORTH && ds_dir == eth_chan_directions::SOUTH) ||
-                    (this->direction == eth_chan_directions::SOUTH && ds_dir == eth_chan_directions::NORTH);
-                if (!connect_vc1) {
-                    return;
-                }
-            }
-
-            // Setup VC1 connection if needed
-            constexpr uint32_t ds_index = 1;
-            auto vc1_send_chan = builder_config::get_sender_channel_count(is_2D_routing) - 1;
-            std::visit(
-                [this, ds_index, vc1_send_chan](auto&& vc1_builder_ref) {
-                    auto& vc1_builder = vc1_builder_ref.get();
-                    this->setup_downstream_vc_connection(vc1_builder, ds_index, vc1_send_chan, true);
-                },
-                vc1_edm_builder);
-        },
-        downstream_builder);
+    // Setup VC1 connection if needed
+    constexpr uint32_t ds_index = 1;
+    auto vc1_send_chan = builder_config::get_sender_channel_count(is_2D_routing) - 1;
+    
+    this->setup_downstream_vc_connection(vc1_edm_builder, ds_index, vc1_send_chan, true);
 }
 
-void FabricEriscDatamoverBuilder::connect_to_downstream_edm(FabricDatamoverBuilder downstream_builder) {
+void FabricEriscDatamoverBuilder::connect_to_downstream_edm(FabricDatamoverBuilderBase *downstream_builder) {
     connect_to_downstream_edm_impl(downstream_builder, downstream_builder);
 }
 
 void FabricEriscDatamoverBuilder::connect_to_downstream_edm(
-    FabricDatamoverBuilder downstream_builder, FabricDatamoverBuilder vc1_edm_builder) {
+    FabricDatamoverBuilderBase *downstream_builder, FabricDatamoverBuilderBase *vc1_edm_builder) {
     connect_to_downstream_edm_impl(downstream_builder, vc1_edm_builder);
 }
 
@@ -1472,20 +1459,19 @@ void FabricEriscDatamoverBuilder::connect_to_downstream_edm(
 // sender channel it is connecting to.
 //   downstream == static? => instantiate static_sender_channel_adapter
 //   downstream == elastic? => instantiate elastic_sender_channel_adapter
-template <typename BuilderType>
 void FabricEriscDatamoverBuilder::setup_downstream_vc_connection(
-    BuilderType& downstream_builder, uint32_t vc_idx, uint32_t channel_id, bool is_vc1) {
+    FabricDatamoverBuilderBase* downstream_builder, uint32_t vc_idx, uint32_t channel_id, bool is_vc1) {
     const auto& fabric_context = tt::tt_metal::MetalContext::instance().get_control_plane().get_fabric_context();
     const bool is_2D_routing = fabric_context.is_2D_routing_enabled();
-    const auto ds_noc_x = downstream_builder.get_noc_x();
-    const auto ds_noc_y = downstream_builder.get_noc_y();
-    eth_chan_directions ds_dir = downstream_builder.get_direction();
+    const auto ds_noc_x = downstream_builder->get_noc_x();
+    const auto ds_noc_y = downstream_builder->get_noc_y();
+    eth_chan_directions ds_dir = downstream_builder->get_direction();
 
-    auto adapter_spec = downstream_builder.build_connection_to_fabric_channel(channel_id);
+    auto adapter_spec = downstream_builder->build_connection_to_fabric_channel(channel_id);
 
-    if constexpr (std::is_same_v<BuilderType, FabricTensixDatamoverBuilder>) {
+    if (auto* downstream_tensix_builder = dynamic_cast<FabricTensixDatamoverBuilder*>(downstream_builder)) {
         this->num_downstream_tensix_connections++;
-        downstream_builder.append_upstream_routers_noc_xy(this->my_noc_x, this->my_noc_y);
+        downstream_tensix_builder->append_upstream_routers_noc_xy(this->noc_x_, this->noc_y_);
     }
 
     auto channel_allocator = config.channel_allocator.get();
@@ -1497,20 +1483,14 @@ void FabricEriscDatamoverBuilder::setup_downstream_vc_connection(
     adapter_ptr->add_downstream_connection(adapter_spec, vc_idx, ds_dir, CoreCoord(ds_noc_x, ds_noc_y), is_2D_routing, is_vc1);
 }
 
-eth_chan_directions FabricEriscDatamoverBuilder::get_direction() const { return this->direction; }
-
 size_t FabricEriscDatamoverBuilder::get_configured_risc_count() const { return this->config.risc_configs.size(); }
-
-size_t FabricEriscDatamoverBuilder::get_noc_x() const { return this->my_noc_x; }
-
-size_t FabricEriscDatamoverBuilder::get_noc_y() const { return this->my_noc_y; }
 
 void FabricEriscDatamoverBuilder::teardown_from_host(
     tt::tt_metal::IDevice* d, tt::tt_fabric::TerminationSignal termination_signal) const {
     std::vector<uint32_t> val(1, termination_signal);
     tt::tt_metal::detail::WriteToDeviceL1(
         d,
-        d->logical_core_from_ethernet_core(CoreCoord(this->my_noc_x, this->my_noc_y)),
+        d->logical_core_from_ethernet_core(CoreCoord(this->noc_x_, this->noc_y_)),
         config.termination_signal_address,
         val,
         CoreType::ETH);
@@ -1527,5 +1507,4 @@ void FabricEriscDatamoverBuilder::set_wait_for_host_signal(bool wait_for_host_si
 void FabricEriscDatamoverBuilder::set_firmware_context_switch_type(FabricEriscDatamoverContextSwitchType type) {
     this->firmware_context_switch_type = type;
 }
-
 }  // namespace tt::tt_fabric

--- a/tt_metal/fabric/erisc_datamover_builder.hpp
+++ b/tt_metal/fabric/erisc_datamover_builder.hpp
@@ -21,24 +21,22 @@
 #include <vector>
 #include <array>
 #include <cstddef>
-#include <variant>
 #include <memory>
 #include "builder/fabric_channel_allocator.hpp"
 #include "tt_metal/fabric/builder/fabric_builder_config.hpp"
 #include "tt_metal/fabric/builder/connection_writer_adapter.hpp"
+#include "tt_metal/fabric/fabric_datamover_builder_base.hpp"
 
 namespace tt::tt_fabric {
 
 struct FabricRiscConfig;
-class FabricEriscDatamoverBuilder;
-class FabricTensixDatamoverBuilder;
+class FabricRouterBuilder;
 class MultiPoolChannelAllocator;
 class ChannelToPoolMapping;
 class FabricRemoteChannelsAllocator;
 
-// Type alias for any fabric datamover builder
-using FabricDatamoverBuilder = std::
-    variant<std::reference_wrapper<FabricEriscDatamoverBuilder>, std::reference_wrapper<FabricTensixDatamoverBuilder>>;
+class FabricEriscDatamoverBuilder;
+class FabricTensixDatamoverBuilder;
 
 /**
  * Specify the EDM types—Default, Dateline, DatelineUpstream, and DatelineUpstreamAdjacentDevice—used to configure
@@ -439,7 +437,9 @@ size_t log_worker_to_fabric_edm_sender_rt_args(const std::vector<uint32_t>& args
  *   two ERISCs on the Ethernet core and Fabric Tensix MUX is enabled. Decisions such as ERISC count and
  *   TXQ selection are derived from this effective mode. A presence-based disable env exists to force-disable.
  */
-class FabricEriscDatamoverBuilder {
+class FabricEriscDatamoverBuilder : public FabricDatamoverBuilderBase {
+    friend class FabricRouterBuilder;
+
 public:
     static constexpr size_t default_firmware_context_switch_interval = 10000;
     static constexpr auto default_firmware_context_switch_type = FabricEriscDatamoverContextSwitchType::WAIT_FOR_IDLE;
@@ -496,7 +496,7 @@ public:
         bool has_tensix_extension = false);
 
     [[nodiscard]] SenderWorkerAdapterSpec build_connection_to_worker_channel() const;
-    [[nodiscard]] SenderWorkerAdapterSpec build_connection_to_fabric_channel(uint32_t vc);
+    [[nodiscard]] SenderWorkerAdapterSpec build_connection_to_fabric_channel(uint32_t vc) const override;
 
     [[nodiscard]] std::vector<uint32_t> get_compile_time_args(uint32_t risc_id) const;
 
@@ -505,13 +505,10 @@ public:
 
     [[nodiscard]] std::vector<uint32_t> get_runtime_args() const;
 
-    void connect_to_downstream_edm(FabricDatamoverBuilder downstream_builder);
-    void connect_to_downstream_edm(FabricDatamoverBuilder downstream_builder, FabricDatamoverBuilder vc1_edm_builder);
+    void connect_to_downstream_edm(FabricDatamoverBuilderBase* downstream_builder);
+    void connect_to_downstream_edm(FabricDatamoverBuilderBase* downstream_builder, FabricDatamoverBuilderBase* vc1_edm_builder);
 
-    eth_chan_directions get_direction() const;
     size_t get_configured_risc_count() const;
-    size_t get_noc_x() const;
-    size_t get_noc_y() const;
 
     void dump_to_log() const {
         // TODO
@@ -530,8 +527,6 @@ public:
     friend class EdmLineFabricOpInterface;
     CoreCoord my_eth_core_logical;
     chan_id_t my_eth_channel;
-    size_t my_noc_x = 0;
-    size_t my_noc_y = 0;
 
     FabricEriscDatamoverConfig config;
 
@@ -554,7 +549,6 @@ public:
     size_t edm_local_sync_ptr = 0;
     size_t edm_local_tensix_sync_ptr = 0;
     size_t edm_status_ptr = 0;
-    eth_chan_directions direction = eth_chan_directions::EAST;
     size_t downstream_edms_connected = 0;
 
     // Semaphore IDs
@@ -570,7 +564,7 @@ public:
     std::array<size_t, builder_config::num_sender_channels> downstream_vcs_sender_channel_buffer_index_semaphore_id =
         {};
 
-    std::array<bool, builder_config::num_sender_channels> sender_channel_connection_liveness_check_disable_array = {};
+    mutable std::array<bool, builder_config::num_sender_channels> sender_channel_connection_liveness_check_disable_array = {};
 
     bool build_in_worker_connection_mode = false;
     size_t firmware_context_switch_interval = default_firmware_context_switch_interval;
@@ -584,13 +578,12 @@ public:
 
 private:
     // Shared helper for setting up VC connections
-    template <typename BuilderType>
     void setup_downstream_vc_connection(
-        BuilderType& downstream_builder, uint32_t vc_idx, uint32_t channel_id, bool is_vc1);
+        FabricDatamoverBuilderBase* downstream_builder, uint32_t vc_idx, uint32_t channel_id, bool is_vc1);
 
     // Internal implementation for connect_to_downstream_edm
     void connect_to_downstream_edm_impl(
-        FabricDatamoverBuilder downstream_builder, FabricDatamoverBuilder vc1_edm_builder);
+        FabricDatamoverBuilderBase *downstream_builder, FabricDatamoverBuilderBase *vc1_edm_builder);
 };
 
 }  // namespace tt::tt_fabric

--- a/tt_metal/fabric/erisc_datamover_builder_helper.cpp
+++ b/tt_metal/fabric/erisc_datamover_builder_helper.cpp
@@ -299,8 +299,8 @@ EdmLineFabricOpInterface::EdmLineFabricOpInterface(
             auto& backward_direction_edm = edm_builders_backward_direction.at(device_sequence[i]->id());
 
             for (size_t l = 0; l < num_links; l++) {
-                forward_direction_edm.at(l).connect_to_downstream_edm(backward_direction_edm.at(l));
-                backward_direction_edm.at(l).connect_to_downstream_edm(forward_direction_edm.at(l));
+                forward_direction_edm.at(l).connect_to_downstream_edm(&backward_direction_edm.at(l));
+                backward_direction_edm.at(l).connect_to_downstream_edm(&forward_direction_edm.at(l));
             }
         }
     }
@@ -407,8 +407,8 @@ EdmLineFabricOpInterface::EdmLineFabricOpInterface(
             auto& backward_direction_edm = edm_builders_backward_direction.at(local_device->id());
 
             for (size_t l = 0; l < this->num_links; l++) {
-                forward_direction_edm.at(l).connect_to_downstream_edm(backward_direction_edm.at(l));
-                backward_direction_edm.at(l).connect_to_downstream_edm(forward_direction_edm.at(l));
+                forward_direction_edm.at(l).connect_to_downstream_edm(&backward_direction_edm.at(l));
+                backward_direction_edm.at(l).connect_to_downstream_edm(&forward_direction_edm.at(l));
             }
         }
     }
@@ -489,7 +489,7 @@ EdmLineFabricOpInterface::generate_local_chip_fabric_termination_infos(tt::tt_me
     auto generate_termination_info =
         [](const tt::tt_fabric::FabricEriscDatamoverBuilder& edm_builder) -> tt::tt_fabric::edm_termination_info_t {
         return tt::tt_fabric::edm_termination_info_t{
-            0, edm_builder.my_noc_x, edm_builder.my_noc_y, edm_builder.config.termination_signal_address};
+            0, edm_builder.get_noc_x(), edm_builder.get_noc_y(), edm_builder.config.termination_signal_address};
     };
     std::vector<tt::tt_fabric::edm_termination_info_t> edm_termination_infos;
     edm_termination_infos.reserve(this->num_links * 2);
@@ -542,13 +542,13 @@ EdmLineFabricOpInterface::generate_ordered_termination_info_farthest_to_nearest(
             auto& farther_edm = farther_edms.at(l);
             const std::size_t distance_receiver = i + 1;
             edm_termination_infos.push_back(
-                {distance_receiver, farther_edm.my_noc_x, farther_edm.my_noc_y, config.termination_signal_address});
+                {distance_receiver, farther_edm.get_noc_x(), farther_edm.get_noc_y(), config.termination_signal_address});
         }
         for (size_t l = 0; l < this->num_links; l++) {
             auto& nearer_edm = nearer_edms.at(l);
             const std::size_t distance_sender = i;
             edm_termination_infos.push_back(
-                {distance_sender, nearer_edm.my_noc_x, nearer_edm.my_noc_y, config.termination_signal_address});
+                {distance_sender, nearer_edm.get_noc_x(), nearer_edm.get_noc_y(), config.termination_signal_address});
         }
     }
     log_trace(tt::LogFabric, "Done Generating termination infos");

--- a/tt_metal/fabric/fabric_datamover_builder_base.hpp
+++ b/tt_metal/fabric/fabric_datamover_builder_base.hpp
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <hostdevcommon/fabric_common.h>
+
+namespace tt::tt_fabric {
+
+struct SenderWorkerAdapterSpec;
+
+// Base class for all fabric datamover builders
+class FabricDatamoverBuilderBase {
+public:
+    virtual ~FabricDatamoverBuilderBase() = default;
+
+    size_t get_noc_x() const { return noc_x_; }
+    size_t get_noc_y() const { return noc_y_; }
+    eth_chan_directions get_direction() const { return direction_; }
+    virtual SenderWorkerAdapterSpec build_connection_to_fabric_channel(uint32_t channel_id) const = 0;
+
+protected:
+    FabricDatamoverBuilderBase(size_t noc_x, size_t noc_y, eth_chan_directions direction)
+        : noc_x_(noc_x), noc_y_(noc_y), direction_(direction) {}
+
+    size_t noc_x_;
+    size_t noc_y_;
+    eth_chan_directions direction_;
+};
+
+}  // namespace tt::tt_fabric

--- a/tt_metal/fabric/fabric_init.cpp
+++ b/tt_metal/fabric/fabric_init.cpp
@@ -311,11 +311,11 @@ void build_tt_fabric_program(
         auto& router_builder1 = router_builders.at(eth_chan_dir1);
         auto& router_builder2 = router_builders.at(eth_chan_dir2);
 
-        uint32_t vc0_sender_channel_1 = is_2D_routing ? static_cast<uint32_t>(router_builder1->get_direction()) : 1;
-        router_builder1->connect_to_downstream_router_over_noc(*router_builder2, 0, vc0_sender_channel_1);
+        router_builder1->connect_to_downstream_router_over_noc(*router_builder2, 0);
+        router_builder2->connect_to_downstream_router_over_noc(*router_builder1, 0);
 
-        uint32_t vc0_sender_channel_2 = is_2D_routing ? static_cast<uint32_t>(router_builder2->get_direction()) : 1;
-        router_builder2->connect_to_downstream_router_over_noc(*router_builder1, 0, vc0_sender_channel_2);
+        router_builder1->connect_to_downstream_router_over_noc(*router_builder2, 1);
+        router_builder2->connect_to_downstream_router_over_noc(*router_builder1, 1);
     };
 
     auto connect_downstream_builders = [&](RoutingDirection dir1, RoutingDirection dir2) {

--- a/tt_metal/fabric/fabric_init.cpp
+++ b/tt_metal/fabric/fabric_init.cpp
@@ -11,6 +11,8 @@
 #include "tt_metal.hpp"
 #include "tt_metal/fabric/fabric_context.hpp"
 #include "tt_metal/fabric/fabric_tensix_builder.hpp"
+#include "tt_metal/fabric/fabric_router_builder.hpp"
+#include "tt_metal/fabric/fabric_router_channel_mapping.hpp"
 #include "tt_metal/fabric/builder/fabric_core_placement.hpp"
 #include "tt_metal/fabric/fabric_host_utils.hpp"
 #include "device.hpp"
@@ -147,8 +149,7 @@ std::pair<tt::tt_fabric::FabricEriscDatamoverType, tt::tt_fabric::FabricEriscDat
 void build_tt_fabric_program(
     tt::tt_metal::IDevice* device,
     tt::tt_metal::Program* fabric_program_ptr,
-    std::unordered_map<tt::tt_fabric::chan_id_t, tt::tt_fabric::FabricEriscDatamoverBuilder>& edm_builders,
-    std::unordered_map<tt::tt_fabric::chan_id_t, tt::tt_fabric::FabricTensixDatamoverBuilder>& tensix_builders) {
+    std::unordered_map<tt::tt_fabric::chan_id_t, std::unique_ptr<tt::tt_fabric::FabricRouterBuilder>>& router_builders) {
     using namespace tt_fabric;
     const auto& control_plane= tt::tt_metal::MetalContext::instance().get_control_plane();
     auto fabric_node_id = control_plane.get_fabric_node_id_from_physical_chip_id(device->id());
@@ -165,39 +166,6 @@ void build_tt_fabric_program(
         edm_builder.set_firmware_context_switch_interval(k_DispatchFabricRouterContextSwitchInterval);
         edm_builder.set_firmware_context_switch_type(FabricEriscDatamoverContextSwitchType::INTERVAL);
     };
-
-    if (is_TG && device->is_mmio_capable()) {
-        const auto& edm_config = fabric_context.get_fabric_router_config();
-
-        auto router_chans_and_direction = control_plane.get_active_fabric_eth_channels(fabric_node_id);
-        for (const auto& [eth_chan, eth_direction] : router_chans_and_direction) {
-            log_debug(
-                tt::LogFabric,
-                "FabricEriscDatamoverConfig for device {}: eth_chan={}, direction={}",
-                device->id(),
-                eth_chan,
-                eth_direction);
-            // remote_fabric_node_id is only used to determine the handshake master, no functional impact
-            // for now treat the mmio chips as the handshake master
-            auto eth_logical_core = soc_desc.get_eth_core_for_channel(eth_chan, CoordSystem::LOGICAL);
-            auto edm_builder = tt::tt_fabric::FabricEriscDatamoverBuilder::build(
-                device,
-                *fabric_program_ptr,
-                eth_logical_core,
-                fabric_node_id,
-                FabricNodeId{fabric_node_id.mesh_id, fabric_node_id.chip_id + 1},
-                edm_config,
-                false,                                            /* build_in_worker_connection_mode */
-                tt::tt_fabric::FabricEriscDatamoverType::Default, /* fabric_edm_type */
-                eth_direction);
-            // Both links used by dispatch on TG Gateway (mmio device)
-            // TODO: https://github.com/tenstorrent/tt-metal/issues/24413
-            configure_edm_builder_for_dispatch(edm_builder);
-            edm_builders.insert({eth_chan, edm_builder});
-        }
-
-        return;
-    }
 
     std::unordered_map<RoutingDirection, std::vector<chan_id_t>> active_fabric_eth_channels;
     std::unordered_map<RoutingDirection, FabricNodeId> chip_neighbors;
@@ -310,47 +278,28 @@ void build_tt_fabric_program(
             const auto& curr_edm_config =
                 get_fabric_router_config(fabric_tensix_extension_enabled, dispatch_link, eth_direction);
 
-            bool has_tensix_extension = false;
-            if (fabric_tensix_extension_enabled && !dispatch_link) {
-                has_tensix_extension = true;
-            }
-
-            auto edm_builder = tt::tt_fabric::FabricEriscDatamoverBuilder::build(
+            const auto topology = fabric_context.get_fabric_topology();
+            auto router_builder = tt::tt_fabric::FabricRouterBuilder::build(
                 device,
                 *fabric_program_ptr,
                 eth_logical_core,
                 fabric_node_id,
                 remote_fabric_node_id,
                 curr_edm_config,
-                false, /* build_in_worker_connection_mode */
                 fabric_edm_type,
                 eth_direction,
-                has_tensix_extension);
-            edm_builders.insert({eth_chan, edm_builder});
-
-            if (tt::tt_metal::MetalContext::instance().get_cluster().arch() == tt::ARCH::BLACKHOLE &&
-                tt::tt_metal::MetalContext::instance().rtoptions().get_enable_2_erisc_mode()) {
-                // Enable updates at a fixed interval for link stability and link status updates
-                constexpr uint32_t k_BlackholeFabricRouterContextSwitchInterval = 32;
-                edm_builder.set_firmware_context_switch_interval(k_BlackholeFabricRouterContextSwitchInterval);
-                edm_builder.set_firmware_context_switch_type(FabricEriscDatamoverContextSwitchType::INTERVAL);
-            }
-
-            if (fabric_tensix_extension_enabled) {
-                // Only create tensix builder if this channel is not used by dispatch
-                if (!dispatch_link) {
-                    auto tensix_builder = tt::tt_fabric::FabricTensixDatamoverBuilder::build(
-                        device, *fabric_program_ptr, fabric_node_id, remote_fabric_node_id, eth_chan, eth_direction);
-                    tensix_builders.insert({eth_chan, tensix_builder});
-                }
-            }
+                fabric_tensix_extension_enabled,
+                dispatch_link,
+                eth_chan,
+                topology);
+            router_builders.insert({eth_chan, std::move(router_builder)});
         }
 
         // Last link may be used by dispatch if there is tunneling
         // TODO: https://github.com/tenstorrent/tt-metal/issues/24413
         if (!active_fabric_eth_channels[direction].empty() && device_has_dispatch_tunnel) {
             const auto dispatch_eth_chan = active_fabric_eth_channels[direction].back();
-            configure_edm_builder_for_dispatch(edm_builders.at(dispatch_eth_chan));
+            configure_edm_builder_for_dispatch(router_builders.at(dispatch_eth_chan)->get_erisc_builder());
         }
     }
 
@@ -359,28 +308,14 @@ void build_tt_fabric_program(
 
     auto build_downstream_connections = [&](tt::tt_fabric::chan_id_t eth_chan_dir1,
                                             tt::tt_fabric::chan_id_t eth_chan_dir2) {
-        auto& edm_builder1 = edm_builders.at(eth_chan_dir1);
-        auto& edm_builder2 = edm_builders.at(eth_chan_dir2);
+        auto& router_builder1 = router_builders.at(eth_chan_dir1);
+        auto& router_builder2 = router_builders.at(eth_chan_dir2);
 
-        if (fabric_tensix_extension_enabled) {
-            if (tensix_builders.find(eth_chan_dir1) != tensix_builders.end() &&
-                tensix_builders.find(eth_chan_dir2) != tensix_builders.end()) {
-                auto& tensix_builder1 = tensix_builders.at(eth_chan_dir1);
-                auto& tensix_builder2 = tensix_builders.at(eth_chan_dir2);
+        uint32_t vc0_sender_channel_1 = is_2D_routing ? static_cast<uint32_t>(router_builder1->get_direction()) : 1;
+        router_builder1->connect_to_downstream_router_over_noc(*router_builder2, 0, vc0_sender_channel_1);
 
-                // need to also pass in edm_builder because it is used to build vc1 connection
-                edm_builder1.connect_to_downstream_edm(tensix_builder2, edm_builder2);
-                edm_builder2.connect_to_downstream_edm(tensix_builder1, edm_builder1);
-            } else {
-                // build the downstream connection for the eth channels without tensix extension (dispatch routing
-                // plane)
-                edm_builder1.connect_to_downstream_edm(edm_builder2);
-                edm_builder2.connect_to_downstream_edm(edm_builder1);
-            }
-        } else {
-            edm_builder1.connect_to_downstream_edm(edm_builder2);
-            edm_builder2.connect_to_downstream_edm(edm_builder1);
-        }
+        uint32_t vc0_sender_channel_2 = is_2D_routing ? static_cast<uint32_t>(router_builder2->get_direction()) : 1;
+        router_builder2->connect_to_downstream_router_over_noc(*router_builder1, 0, vc0_sender_channel_2);
     };
 
     auto connect_downstream_builders = [&](RoutingDirection dir1, RoutingDirection dir2) {
@@ -405,12 +340,14 @@ void build_tt_fabric_program(
                 auto eth_chan_dir1 = eth_chans_dir1[link];
                 auto eth_chan_dir2 = eth_chans_dir2[link];
 
-                auto& edm_builder1 = edm_builders.at(eth_chan_dir1);
-                auto& edm_builder2 = edm_builders.at(eth_chan_dir2);
+                auto& router_builder1 = router_builders.at(eth_chan_dir1);
+                auto& router_builder2 = router_builders.at(eth_chan_dir2);
 
                 build_downstream_connections(eth_chan_dir1, eth_chan_dir2);
 
                 // select VC based on the current link
+                auto& edm_builder1 = router_builder1->get_erisc_builder();
+                auto& edm_builder2 = router_builder2->get_erisc_builder();
                 auto edm_noc_vc = edm_builder1.config.DEFAULT_NOC_VC + (link % edm_builder1.config.NUM_EDM_NOC_VCS);
                 edm_builder1.config.edm_noc_vc = edm_noc_vc;
                 edm_builder2.config.edm_noc_vc = edm_noc_vc;
@@ -450,32 +387,33 @@ void build_tt_fabric_program(
 
 std::unique_ptr<tt::tt_metal::Program> create_and_compile_tt_fabric_program(tt::tt_metal::IDevice* device) {
     std::unique_ptr<tt::tt_metal::Program> fabric_program_ptr = std::make_unique<tt::tt_metal::Program>();
-    std::unordered_map<tt::tt_fabric::chan_id_t, tt::tt_fabric::FabricEriscDatamoverBuilder> edm_builders;
-    std::unordered_map<tt::tt_fabric::chan_id_t, tt::tt_fabric::FabricTensixDatamoverBuilder> tensix_builders;
+    std::unordered_map<tt::tt_fabric::chan_id_t, std::unique_ptr<tt::tt_fabric::FabricRouterBuilder>> router_builders;
 
     const auto& control_plane= tt::tt_metal::MetalContext::instance().get_control_plane();
     auto& fabric_context = control_plane.get_fabric_context();
 
-    build_tt_fabric_program(device, fabric_program_ptr.get(), edm_builders, tensix_builders);
-    fabric_context.set_num_fabric_initialized_routers(device->id(), edm_builders.size());
-    if (edm_builders.empty()) {
+    build_tt_fabric_program(device, fabric_program_ptr.get(), router_builders);
+    fabric_context.set_num_fabric_initialized_routers(device->id(), router_builders.size());
+    if (router_builders.empty()) {
         return nullptr;
     }
 
-    // Compile all fabric tensix builders
+    // Compile all fabric tensix builders through router builders
     if (tt::tt_metal::MetalContext::instance().get_fabric_tensix_config() !=
         tt::tt_fabric::FabricTensixConfig::DISABLED) {
-        for (auto& [eth_chan, tensix_builder] : tensix_builders) {
-            tensix_builder.create_and_compile(device, *fabric_program_ptr);
+        for (auto& [eth_chan, router_builder] : router_builders) {
+            if (router_builder->has_tensix_builder()) {
+                router_builder->get_tensix_builder().create_and_compile(device, *fabric_program_ptr);
+            }
         }
     }
 
     // for now it doesnt matter which channel is the master, so just pick the 1st in the map
-    auto master_router_chan = edm_builders.begin()->first;
+    auto master_router_chan = router_builders.begin()->first;
     fabric_context.set_fabric_master_router_chan(device->id(), master_router_chan);
 
     uint32_t router_channels_mask = 0;
-    for (const auto& [router_chan, _] : edm_builders) {
+    for (const auto& [router_chan, _] : router_builders) {
         router_channels_mask += 0x1 << (uint32_t)router_chan;
     }
 
@@ -485,11 +423,12 @@ std::unique_ptr<tt::tt_metal::Program> create_and_compile_tt_fabric_program(tt::
     }
 
     auto soc_desc = tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(device->id());
-    const auto num_enabled_eth_cores = edm_builders.size();
+    const auto num_enabled_eth_cores = router_builders.size();
     const auto num_enabled_risc_cores =
-        edm_builders.begin()->second.get_configured_risc_count();  // same across all eth cores
+        router_builders.begin()->second->get_configured_risc_count();  // same across all eth cores
     size_t num_local_fabric_routers = num_enabled_eth_cores;
-    for (auto& [eth_chan, edm_builder] : edm_builders) {
+    for (auto& [eth_chan, router_builder] : router_builders) {
+        auto& edm_builder = router_builder->get_erisc_builder();
         edm_builder.set_wait_for_host_signal(true);
         const std::vector<uint32_t> rt_args = edm_builder.get_runtime_args();
         for (uint32_t risc_id = 0; risc_id < num_enabled_risc_cores; risc_id++) {

--- a/tt_metal/fabric/fabric_router_builder.cpp
+++ b/tt_metal/fabric/fabric_router_builder.cpp
@@ -1,0 +1,205 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "fabric_router_builder.hpp"
+#include "tt_metal/fabric/erisc_datamover_builder.hpp"
+#include "tt_metal/fabric/fabric_tensix_builder.hpp"
+#include "tt_metal/fabric/fabric_context.hpp"
+#include "tt_metal/fabric/builder/fabric_builder_helpers.hpp"
+#include "impl/context/metal_context.hpp"
+#include "tt_metal/third_party/umd/device/api/umd/device/types/core_coordinates.hpp"
+#include <tt_stl/assert.hpp>
+
+namespace tt::tt_fabric {
+
+FabricRouterBuilder::FabricRouterBuilder(
+    std::unique_ptr<FabricEriscDatamoverBuilder> erisc_builder,
+    std::optional<FabricTensixDatamoverBuilder> tensix_builder,
+    FabricRouterChannelMapping channel_mapping) :
+    erisc_builder_(std::move(erisc_builder)),
+    tensix_builder_(std::move(tensix_builder)),
+    channel_mapping_(std::move(channel_mapping)) {
+    TT_FATAL(erisc_builder_ != nullptr, "Erisc builder cannot be null");
+}
+
+std::unique_ptr<FabricRouterBuilder> FabricRouterBuilder::build(
+    tt::tt_metal::IDevice* device,
+    tt::tt_metal::Program& fabric_program,
+    umd::CoreCoord eth_logical_core,
+    FabricNodeId fabric_node_id,
+    FabricNodeId remote_fabric_node_id,
+    const tt::tt_fabric::FabricEriscDatamoverConfig& edm_config,
+    tt::tt_fabric::FabricEriscDatamoverType fabric_edm_type,
+    tt::tt_fabric::eth_chan_directions eth_direction,
+    bool fabric_tensix_extension_enabled,
+    bool dispatch_link,
+    tt::tt_fabric::chan_id_t eth_chan,
+    tt::tt_fabric::Topology topology) {
+
+    bool has_tensix_extension = false;
+    if (fabric_tensix_extension_enabled && !dispatch_link) {
+        has_tensix_extension = true;
+    }
+
+    auto edm_builder = std::make_unique<tt::tt_fabric::FabricEriscDatamoverBuilder>(
+        tt::tt_fabric::FabricEriscDatamoverBuilder::build(
+            device,
+            fabric_program,
+            eth_logical_core,
+            fabric_node_id,
+            remote_fabric_node_id,
+            edm_config,
+            false, /* build_in_worker_connection_mode */
+            fabric_edm_type,
+            eth_direction,
+            has_tensix_extension));
+
+    if (tt::tt_metal::MetalContext::instance().get_cluster().arch() == tt::ARCH::BLACKHOLE &&
+        tt::tt_metal::MetalContext::instance().rtoptions().get_enable_2_erisc_mode()) {
+        // Enable updates at a fixed interval for link stability and link status updates
+        constexpr uint32_t k_BlackholeFabricRouterContextSwitchInterval = 32;
+        edm_builder->set_firmware_context_switch_interval(k_BlackholeFabricRouterContextSwitchInterval);
+        edm_builder->set_firmware_context_switch_type(FabricEriscDatamoverContextSwitchType::INTERVAL);
+    }
+
+    // Create tensix builder if needed
+    std::optional<tt::tt_fabric::FabricTensixDatamoverBuilder> tensix_builder_opt;
+    if (fabric_tensix_extension_enabled) {
+        // Only create tensix builder if this channel is not used by dispatch
+        if (!dispatch_link) {
+            auto tensix_builder = tt::tt_fabric::FabricTensixDatamoverBuilder::build(
+                device, fabric_program, fabric_node_id, remote_fabric_node_id, eth_chan, eth_direction);
+            tensix_builder_opt = tensix_builder;
+        }
+    }
+
+    // Create channel mapping
+    auto channel_mapping = tt::tt_fabric::FabricRouterChannelMapping(topology, eth_direction);
+
+    return std::make_unique<tt::tt_fabric::FabricRouterBuilder>(
+        std::move(edm_builder), tensix_builder_opt, std::move(channel_mapping));
+}
+
+
+void FabricRouterBuilder::connect_to_downstream_router_over_noc(
+    FabricRouterBuilder& other,
+    [[maybe_unused]] uint32_t vc,
+    uint32_t sender_channel_idx) {
+
+    TT_FATAL(
+        !erisc_builder_->build_in_worker_connection_mode,
+        "Tried to connect router to downstream in worker connection mode");
+
+    const auto& fabric_context =
+        tt::tt_metal::MetalContext::instance().get_control_plane().get_fabric_context();
+    const bool is_2D_routing = fabric_context.is_2D_routing_enabled();
+
+    // Helper to get the downstream builder for a specific VC based on channel mapping
+    auto get_downstream_builder_for_vc = [&](uint32_t vc_index, uint32_t sender_channel_idx) -> FabricDatamoverBuilderBase* {
+        auto mapping = other.channel_mapping_.get_sender_mapping(vc_index, sender_channel_idx);
+
+        if (mapping.builder_type == BuilderType::TENSIX) {
+            return &other.tensix_builder_.value();
+        } else {
+            return other.erisc_builder_.get();
+        }
+    };
+
+    // Lambda to connect a VC to a downstream builder
+    auto connect_vc = [&](uint32_t vc_index, FabricDatamoverBuilderBase* downstream_builder, uint32_t logical_sender_channel_idx) {
+        log_debug(
+            tt::LogTest,
+            "Router at x={}, y={}, Direction={}, FabricNodeId={} :: Connecting VC{} to downstream router at x={}, y={}, Direction={}",
+            erisc_builder_->get_noc_x(),
+            erisc_builder_->get_noc_y(),
+            erisc_builder_->get_direction(),
+            erisc_builder_->local_fabric_node_id,
+            vc_index,
+            downstream_builder->get_noc_x(),
+            downstream_builder->get_noc_y(),
+            downstream_builder->get_direction());
+
+        // auto send_chan = get_sender_channel(is_2D_routing, this->get_direction(), vc_index);
+        auto downstream_mapping = other.channel_mapping_.get_sender_mapping(vc_index, logical_sender_channel_idx);
+        uint32_t internal_channel_id = downstream_mapping.internal_sender_channel_id;
+
+        // Need to call the templated method with the correct derived type
+        // NOTE: erisc_builder_ is hardcoded here because there is currently no scenario where tensix forwards to tensix
+        //       however when that is enabled, this code should be updated to point to the src builder dynamically
+        if (auto* downstream_erisc_builder = dynamic_cast<FabricEriscDatamoverBuilder*>(downstream_builder)) {
+            erisc_builder_->setup_downstream_vc_connection(downstream_erisc_builder, vc_index, internal_channel_id, vc_index == 1);
+        } else if (auto* downstream_tensix_builder = dynamic_cast<FabricTensixDatamoverBuilder*>(downstream_builder)) {
+            erisc_builder_->setup_downstream_vc_connection(downstream_tensix_builder, vc_index, internal_channel_id, vc_index == 1);
+        }
+    };
+
+    // Connect VC0
+    connect_vc(0, get_downstream_builder_for_vc(0, sender_channel_idx), sender_channel_idx);
+
+    // Check if we should connect VC1 for deadlock avoidance
+    if (!fabric_context.need_deadlock_avoidance_support(this->get_direction())) {
+        return;
+    }
+
+    // For 2D routing we can only connect VC1 if the downstream is on the same axis
+    bool connect_vc1 = true;
+    if (is_2D_routing) {
+        auto ds_dir = other.get_direction();
+
+        connect_vc1 =
+            (this->get_direction() == eth_chan_directions::EAST && ds_dir == eth_chan_directions::WEST) ||
+            (this->get_direction() == eth_chan_directions::WEST && ds_dir == eth_chan_directions::EAST) ||
+            (this->get_direction() == eth_chan_directions::NORTH && ds_dir == eth_chan_directions::SOUTH) ||
+            (this->get_direction() == eth_chan_directions::SOUTH && ds_dir == eth_chan_directions::NORTH);
+    }
+
+    if (connect_vc1) {
+        // Get the downstream builder for VC1 based on channel mapping
+        // Note: VC1 only ever has one sender channel, so we index with offset 0 into VC1
+        constexpr uint32_t sender_channel_index_into_vc1 = 0;
+        connect_vc(1, get_downstream_builder_for_vc(1, sender_channel_index_into_vc1), sender_channel_index_into_vc1);
+    }
+}
+
+SenderWorkerAdapterSpec FabricRouterBuilder::build_connection_to_fabric_channel(
+    uint32_t vc, uint32_t sender_channel_idx) {
+    // This method returns connection info for a sender channel, which can be used by
+    // downstream routers to connect to this sender channel
+    auto sender_mapping = channel_mapping_.get_sender_mapping(vc, sender_channel_idx);
+
+    if (sender_mapping.builder_type == BuilderType::ERISC) {
+        return erisc_builder_->build_connection_to_fabric_channel(sender_mapping.internal_sender_channel_id);
+    } else if (sender_mapping.builder_type == BuilderType::TENSIX) {
+        TT_FATAL(tensix_builder_.has_value(), "Tensix builder not available but mapping requires it");
+        return tensix_builder_->build_connection_to_fabric_channel(sender_mapping.internal_sender_channel_id);
+    } else {
+        TT_FATAL(false, "Unknown builder type");
+    }
+}
+
+eth_chan_directions FabricRouterBuilder::get_direction() const {
+    return erisc_builder_->get_direction();
+}
+
+size_t FabricRouterBuilder::get_noc_x() const {
+    return erisc_builder_->get_noc_x();
+}
+
+size_t FabricRouterBuilder::get_noc_y() const {
+    return erisc_builder_->get_noc_y();
+}
+
+size_t FabricRouterBuilder::get_configured_risc_count() const {
+    return erisc_builder_->get_configured_risc_count();
+}
+
+FabricNodeId FabricRouterBuilder::get_local_fabric_node_id() const {
+    return erisc_builder_->local_fabric_node_id;
+}
+
+FabricNodeId FabricRouterBuilder::get_peer_fabric_node_id() const {
+    return erisc_builder_->peer_fabric_node_id;
+}
+
+}  // namespace tt::tt_fabric

--- a/tt_metal/fabric/fabric_router_builder.cpp
+++ b/tt_metal/fabric/fabric_router_builder.cpp
@@ -115,9 +115,9 @@ void FabricRouterBuilder::connect_to_downstream_router_over_noc(
 
     auto get_downstream_builder_for_vc = [&](uint32_t vc_index, uint32_t sender_channel_idx) -> FabricDatamoverBuilderBase* {
         auto mapping = other.channel_mapping_.get_sender_mapping(vc_index, sender_channel_idx);
-        
+
         if (mapping.builder_type == BuilderType::TENSIX) {
-            TT_FATAL(other.tensix_builder_.has_value(), 
+            TT_FATAL(other.tensix_builder_.has_value(),
                      "Channel mapping requires TENSIX builder for VC{} channel {}, but tensix builder not present",
                      vc_index, sender_channel_idx);
             return &other.tensix_builder_.value();
@@ -133,9 +133,9 @@ void FabricRouterBuilder::connect_to_downstream_router_over_noc(
         TT_FATAL(
             !erisc_builder_->build_in_worker_connection_mode,
             "Tried to connect router to downstream in worker connection mode");
-            
+
         // Helper to get the downstream builder for a specific VC based on channel mapping
-        
+
         uint32_t sender_channel_idx = get_downstream_sender_channel(is_2D_routing, other.get_direction());
         // Connect VC0
         connect_vc(0, get_downstream_builder_for_vc(0, sender_channel_idx), sender_channel_idx);

--- a/tt_metal/fabric/fabric_router_builder.cpp
+++ b/tt_metal/fabric/fabric_router_builder.cpp
@@ -6,7 +6,6 @@
 #include "tt_metal/fabric/erisc_datamover_builder.hpp"
 #include "tt_metal/fabric/fabric_tensix_builder.hpp"
 #include "tt_metal/fabric/fabric_context.hpp"
-#include "tt_metal/fabric/builder/fabric_builder_helpers.hpp"
 #include "impl/context/metal_context.hpp"
 #include "tt_metal/third_party/umd/device/api/umd/device/types/core_coordinates.hpp"
 #include <tt_stl/assert.hpp>
@@ -75,7 +74,10 @@ std::unique_ptr<FabricRouterBuilder> FabricRouterBuilder::build(
     }
 
     // Create channel mapping
-    auto channel_mapping = tt::tt_fabric::FabricRouterChannelMapping(topology, eth_direction);
+    // Only enable tensix extension in mapping if we actually created a tensix builder
+    bool has_tensix_builder = tensix_builder_opt.has_value();
+    auto channel_mapping = tt::tt_fabric::FabricRouterChannelMapping(
+        topology, eth_direction, has_tensix_builder);
 
     return std::make_unique<tt::tt_fabric::FabricRouterBuilder>(
         std::move(edm_builder), tensix_builder_opt, std::move(channel_mapping));
@@ -83,30 +85,7 @@ std::unique_ptr<FabricRouterBuilder> FabricRouterBuilder::build(
 
 
 void FabricRouterBuilder::connect_to_downstream_router_over_noc(
-    FabricRouterBuilder& other,
-    [[maybe_unused]] uint32_t vc,
-    uint32_t sender_channel_idx) {
-
-    TT_FATAL(
-        !erisc_builder_->build_in_worker_connection_mode,
-        "Tried to connect router to downstream in worker connection mode");
-
-    const auto& fabric_context =
-        tt::tt_metal::MetalContext::instance().get_control_plane().get_fabric_context();
-    const bool is_2D_routing = fabric_context.is_2D_routing_enabled();
-
-    // Helper to get the downstream builder for a specific VC based on channel mapping
-    auto get_downstream_builder_for_vc = [&](uint32_t vc_index, uint32_t sender_channel_idx) -> FabricDatamoverBuilderBase* {
-        auto mapping = other.channel_mapping_.get_sender_mapping(vc_index, sender_channel_idx);
-
-        if (mapping.builder_type == BuilderType::TENSIX) {
-            return &other.tensix_builder_.value();
-        } else {
-            return other.erisc_builder_.get();
-        }
-    };
-
-    // Lambda to connect a VC to a downstream builder
+    FabricRouterBuilder& other, uint32_t vc) {
     auto connect_vc = [&](uint32_t vc_index, FabricDatamoverBuilderBase* downstream_builder, uint32_t logical_sender_channel_idx) {
         log_debug(
             tt::LogTest,
@@ -134,31 +113,57 @@ void FabricRouterBuilder::connect_to_downstream_router_over_noc(
         }
     };
 
-    // Connect VC0
-    connect_vc(0, get_downstream_builder_for_vc(0, sender_channel_idx), sender_channel_idx);
+    auto get_downstream_builder_for_vc = [&](uint32_t vc_index, uint32_t sender_channel_idx) -> FabricDatamoverBuilderBase* {
+        auto mapping = other.channel_mapping_.get_sender_mapping(vc_index, sender_channel_idx);
+        
+        if (mapping.builder_type == BuilderType::TENSIX) {
+            TT_FATAL(other.tensix_builder_.has_value(), 
+                     "Channel mapping requires TENSIX builder for VC{} channel {}, but tensix builder not present",
+                     vc_index, sender_channel_idx);
+            return &other.tensix_builder_.value();
+        } else {
+            return other.erisc_builder_.get();
+        }
+    };
 
-    // Check if we should connect VC1 for deadlock avoidance
-    if (!fabric_context.need_deadlock_avoidance_support(this->get_direction())) {
-        return;
-    }
+    const auto& fabric_context =
+        tt::tt_metal::MetalContext::instance().get_control_plane().get_fabric_context();
+    const bool is_2D_routing = fabric_context.is_2D_routing_enabled();
+    if (vc == 0) {
+        TT_FATAL(
+            !erisc_builder_->build_in_worker_connection_mode,
+            "Tried to connect router to downstream in worker connection mode");
+            
+        // Helper to get the downstream builder for a specific VC based on channel mapping
+        
+        uint32_t sender_channel_idx = get_downstream_sender_channel(is_2D_routing, other.get_direction());
+        // Connect VC0
+        connect_vc(0, get_downstream_builder_for_vc(0, sender_channel_idx), sender_channel_idx);
+    } else if (vc == 1) {
 
-    // For 2D routing we can only connect VC1 if the downstream is on the same axis
-    bool connect_vc1 = true;
-    if (is_2D_routing) {
-        auto ds_dir = other.get_direction();
+        // Check if we should connect VC1 for deadlock avoidance
+        if (!fabric_context.need_deadlock_avoidance_support(this->get_direction())) {
+            return;
+        }
 
-        connect_vc1 =
-            (this->get_direction() == eth_chan_directions::EAST && ds_dir == eth_chan_directions::WEST) ||
-            (this->get_direction() == eth_chan_directions::WEST && ds_dir == eth_chan_directions::EAST) ||
-            (this->get_direction() == eth_chan_directions::NORTH && ds_dir == eth_chan_directions::SOUTH) ||
-            (this->get_direction() == eth_chan_directions::SOUTH && ds_dir == eth_chan_directions::NORTH);
-    }
+        // For 2D routing we can only connect VC1 if the downstream is on the same axis
+        bool connect_vc1 = true;
+        if (is_2D_routing) {
+            auto ds_dir = other.get_direction();
 
-    if (connect_vc1) {
-        // Get the downstream builder for VC1 based on channel mapping
-        // Note: VC1 only ever has one sender channel, so we index with offset 0 into VC1
-        constexpr uint32_t sender_channel_index_into_vc1 = 0;
-        connect_vc(1, get_downstream_builder_for_vc(1, sender_channel_index_into_vc1), sender_channel_index_into_vc1);
+            connect_vc1 =
+                (this->get_direction() == eth_chan_directions::EAST && ds_dir == eth_chan_directions::WEST) ||
+                (this->get_direction() == eth_chan_directions::WEST && ds_dir == eth_chan_directions::EAST) ||
+                (this->get_direction() == eth_chan_directions::NORTH && ds_dir == eth_chan_directions::SOUTH) ||
+                (this->get_direction() == eth_chan_directions::SOUTH && ds_dir == eth_chan_directions::NORTH);
+        }
+
+        if (connect_vc1) {
+            // Get the downstream builder for VC1 based on channel mapping
+            // Note: VC1 only ever has one sender channel, so we index with offset 0 into VC1
+            constexpr uint32_t sender_channel_index_into_vc1 = 0;
+            connect_vc(1, get_downstream_builder_for_vc(1, sender_channel_index_into_vc1), sender_channel_index_into_vc1);
+        }
     }
 }
 
@@ -176,6 +181,54 @@ SenderWorkerAdapterSpec FabricRouterBuilder::build_connection_to_fabric_channel(
     } else {
         TT_FATAL(false, "Unknown builder type");
     }
+}
+
+uint32_t FabricRouterBuilder::get_downstream_sender_channel(const bool is_2D_routing, const eth_chan_directions downstream_direction) const {
+
+    if (!is_2D_routing) {
+        return 1;  // 1D: sender channel 1 for forwarding
+    }
+
+    // Sender channel 0 is always reserved for the local worker.
+    //
+    // Sender channels 1–3 correspond to the three upstream neighbors relative
+    // to the downstream router’s direction.
+    //
+    // The mapping from receiver direction → sender channel depends on the
+    // downstream forwarding direction:
+    //
+    //   • Downstream = EAST:
+    //         WEST  → channel 1
+    //         NORTH → channel 2
+    //         SOUTH → channel 3
+    //
+    //   • Downstream = WEST:
+    //         EAST  → channel 1
+    //         NORTH → channel 2
+    //         SOUTH → channel 3
+    //
+    //   • Downstream = NORTH:
+    //         EAST  → channel 1
+    //         WEST  → channel 2
+    //         SOUTH → channel 3
+    //
+    //   • Downstream = SOUTH:
+    //         EAST  → channel 1
+    //         WEST  → channel 2
+    //         NORTH → channel 3
+
+    size_t downstream_compact_index_for_upstream;
+    if (downstream_direction == eth_chan_directions::EAST) {
+        // EAST downstream: WEST(1)→0, NORTH(2)→1, SOUTH(3)→2
+        downstream_compact_index_for_upstream = this->get_direction() - 1;
+    } else {
+        // For other downstream directions: if upstream < downstream, use as-is; else subtract 1
+        downstream_compact_index_for_upstream =
+            (this->get_direction() < downstream_direction) ? this->get_direction() : (this->get_direction() - 1);
+    }
+
+    // Sender channel = 1 + compact index (since channel 0 is for local worker)
+    return 1 + downstream_compact_index_for_upstream;
 }
 
 eth_chan_directions FabricRouterBuilder::get_direction() const {

--- a/tt_metal/fabric/fabric_router_builder.hpp
+++ b/tt_metal/fabric/fabric_router_builder.hpp
@@ -1,0 +1,119 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <memory>
+#include <optional>
+#include "tt_metal/fabric/erisc_datamover_builder.hpp"
+#include "tt_metal/fabric/fabric_tensix_builder.hpp"
+#include "tt_metal/fabric/fabric_router_channel_mapping.hpp"
+
+namespace tt::tt_fabric {
+
+/**
+ * FabricRouterBuilder
+ *
+ * Wrapper class that wraps FabricEriscDatamoverBuilder (always present) and optionally
+ * FabricTensixDatamoverBuilder (0 or 1). This wrapper acts as the external interface for
+ * router connections, translating between logical channels (VC + sender/receiver indices)
+ * and internal builder channels.
+ */
+class FabricRouterBuilder {
+public:
+    /**
+     * Constructor
+     *
+     * @param erisc_builder The erisc datamover builder (always required)
+     * @param tensix_builder Optional tensix datamover builder
+     * @param channel_mapping The channel mapping object that defines logical to internal channel mappings
+     */
+    FabricRouterBuilder(
+        std::unique_ptr<FabricEriscDatamoverBuilder> erisc_builder,
+        std::optional<FabricTensixDatamoverBuilder> tensix_builder,
+        FabricRouterChannelMapping channel_mapping);
+
+    /**
+     * Build a FabricRouterBuilder with all necessary components
+     *
+     * @param device The device to build on
+     * @param fabric_program The fabric program
+     * @param eth_logical_core The ethernet logical core
+     * @param fabric_node_id The local fabric node ID
+     * @param remote_fabric_node_id The remote fabric node ID
+     * @param edm_config The EDM configuration
+     * @param fabric_edm_type The fabric EDM type
+     * @param eth_direction The ethernet direction
+     * @param fabric_tensix_extension_enabled Whether fabric tensix extension is enabled
+     * @param dispatch_link Whether this is a dispatch link
+     * @param eth_chan The ethernet channel (for tensix builder)
+     * @param topology The fabric topology
+     * @return A unique_ptr to the constructed FabricRouterBuilder
+     */
+    static std::unique_ptr<FabricRouterBuilder> build(
+        tt::tt_metal::IDevice* device,
+        tt::tt_metal::Program& fabric_program,
+        umd::CoreCoord eth_logical_core,
+        FabricNodeId fabric_node_id,
+        FabricNodeId remote_fabric_node_id,
+        const tt::tt_fabric::FabricEriscDatamoverConfig& edm_config,
+        tt::tt_fabric::FabricEriscDatamoverType fabric_edm_type,
+        tt::tt_fabric::eth_chan_directions eth_direction,
+        bool fabric_tensix_extension_enabled,
+        bool dispatch_link,
+        tt::tt_fabric::chan_id_t eth_chan,
+        tt::tt_fabric::Topology topology);
+
+    /**
+     * Connect the downstream router over noc or Ethernet. Iterates through all VCs and channels
+     * between the routers and connects them.
+     *
+     * Establishes one-way connection
+     *
+     * @param other The other router builder to connect to
+     * @param vc Virtual channel ID
+     * @param receiver_channel_idx Logical receiver channel index within the VC on the other router
+     */
+    void connect_to_downstream_router_over_noc(
+        FabricRouterBuilder& other,
+        uint32_t vc,
+        uint32_t receiver_channel_idx);
+
+    /**
+     * Build connection to fabric channel (for sender channels)
+     *
+     * @param vc Virtual channel ID
+     * @param sender_channel_idx Logical sender channel index within the VC
+     * @return SenderWorkerAdapterSpec for external connections
+     */
+    SenderWorkerAdapterSpec build_connection_to_fabric_channel(uint32_t vc, uint32_t sender_channel_idx);
+
+    // Getters/delegators for wrapped builder properties
+    eth_chan_directions get_direction() const;
+    size_t get_noc_x() const;
+    size_t get_noc_y() const;
+    size_t get_configured_risc_count() const;
+    FabricNodeId get_local_fabric_node_id() const;
+    FabricNodeId get_peer_fabric_node_id() const;
+
+    // Access to wrapped builders (if needed for advanced use cases)
+    FabricEriscDatamoverBuilder& get_erisc_builder() { return *erisc_builder_; }
+    const FabricEriscDatamoverBuilder& get_erisc_builder() const { return *erisc_builder_; }
+    bool has_tensix_builder() const { return tensix_builder_.has_value(); }
+    FabricTensixDatamoverBuilder& get_tensix_builder() {
+        TT_FATAL(tensix_builder_.has_value(), "Tensix builder not available");
+        return tensix_builder_.value();
+    }
+    const FabricTensixDatamoverBuilder& get_tensix_builder() const {
+        TT_FATAL(tensix_builder_.has_value(), "Tensix builder not available");
+        return tensix_builder_.value();
+    }
+
+private:
+    std::unique_ptr<FabricEriscDatamoverBuilder> erisc_builder_;
+    std::optional<FabricTensixDatamoverBuilder> tensix_builder_;
+    FabricRouterChannelMapping channel_mapping_;
+};
+
+}  // namespace tt::tt_fabric

--- a/tt_metal/fabric/fabric_router_builder.hpp
+++ b/tt_metal/fabric/fabric_router_builder.hpp
@@ -73,12 +73,8 @@ public:
      *
      * @param other The other router builder to connect to
      * @param vc Virtual channel ID
-     * @param receiver_channel_idx Logical receiver channel index within the VC on the other router
      */
-    void connect_to_downstream_router_over_noc(
-        FabricRouterBuilder& other,
-        uint32_t vc,
-        uint32_t receiver_channel_idx);
+    void connect_to_downstream_router_over_noc(FabricRouterBuilder& other, uint32_t vc);
 
     /**
      * Build connection to fabric channel (for sender channels)
@@ -88,6 +84,9 @@ public:
      * @return SenderWorkerAdapterSpec for external connections
      */
     SenderWorkerAdapterSpec build_connection_to_fabric_channel(uint32_t vc, uint32_t sender_channel_idx);
+
+
+    uint32_t get_downstream_sender_channel(bool is_2D_routing, eth_chan_directions downstream_direction) const;
 
     // Getters/delegators for wrapped builder properties
     eth_chan_directions get_direction() const;

--- a/tt_metal/fabric/fabric_router_channel_mapping.cpp
+++ b/tt_metal/fabric/fabric_router_channel_mapping.cpp
@@ -1,0 +1,123 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "fabric_router_channel_mapping.hpp"
+#include "tt_metal/fabric/builder/fabric_builder_config.hpp"
+#include "tt_metal/fabric/fabric_context.hpp"
+#include <tt_stl/assert.hpp>
+
+namespace tt::tt_fabric {
+
+FabricRouterChannelMapping::FabricRouterChannelMapping(
+    Topology topology, eth_chan_directions direction) :
+    topology_(topology), direction_(direction) {
+    initialize_mappings();
+}
+
+void FabricRouterChannelMapping::initialize_mappings() {
+    initialize_vc0_mappings();
+    initialize_vc1_mappings();
+    initialize_vc2_mappings();
+}
+
+void FabricRouterChannelMapping::initialize_vc0_mappings() {
+    const bool is_2d = is_2d_topology();
+
+    if (!is_2d) {
+        // 1D topology: [0] = worker, [1] = vc0 forward channels
+        // Sender channels
+        sender_channel_map_[LogicalSenderChannelKey{0, 0}] =
+            InternalSenderChannelMapping{BuilderType::ERISC, 0};  // worker channel
+        sender_channel_map_[LogicalSenderChannelKey{0, 1}] =
+            InternalSenderChannelMapping{BuilderType::ERISC, 1};  // forward channel
+
+        // Receiver channel (typically single receiver channel per VC)
+        receiver_channel_map_[LogicalReceiverChannelKey{0, 0}] =
+            InternalReceiverChannelMapping{BuilderType::ERISC, 0};
+    } else {
+        // 2D topology: [0-3] = N/E/S/W/Worker
+        // Map based on direction: 0=EAST, 1=WEST, 2=NORTH, 3=SOUTH
+        // For 2D, sender channels map to erisc builder channels 0-3
+        constexpr size_t max_2d_vc0_channels = 4;
+        for (uint32_t i = 0; i < max_2d_vc0_channels; ++i) {
+            sender_channel_map_[LogicalSenderChannelKey{0, i}] =
+                InternalSenderChannelMapping{BuilderType::ERISC, i};
+        }
+
+        // Receiver channel
+        receiver_channel_map_[LogicalReceiverChannelKey{0, 0}] =
+            InternalReceiverChannelMapping{BuilderType::ERISC, 0};
+    }
+}
+
+void FabricRouterChannelMapping::initialize_vc1_mappings() {
+    const bool has_ring_or_torus = is_ring_or_torus();
+    if (!has_ring_or_torus) {
+        // VC1 only exists for Ring/Torus topologies
+        return;
+    }
+
+    const bool is_2d = is_2d_topology();
+    // VC1: [0] = vc1 forward channel
+    // Maps to erisc builder's last sender channel
+    uint32_t vc1_sender_channel = is_2d ? builder_config::num_sender_channels_2d_torus - 1
+                                         : builder_config::num_sender_channels_1d_ring - 1;
+
+    sender_channel_map_[LogicalSenderChannelKey{1, 0}] =
+        InternalSenderChannelMapping{BuilderType::ERISC, vc1_sender_channel};
+
+    // Receiver channel for VC1
+    receiver_channel_map_[LogicalReceiverChannelKey{1, 0}] =
+        InternalReceiverChannelMapping{BuilderType::ERISC, 1};  // VC1 uses receiver channel 1
+}
+
+void FabricRouterChannelMapping::initialize_vc2_mappings() {
+    const bool is_2d = is_2d_topology();
+    if (!is_2d) {
+        // VC2 (intermesh) only exists for 2D topologies
+        return;
+    }
+
+    // VC2: [0-2] for 2D, [0-3] for 2D+Z
+    // For now, we'll map to erisc/tensix builder channels
+    // The exact mapping depends on intermesh implementation details
+    // This is a placeholder - actual implementation may vary
+    uint32_t num_vc2_channels = 3;  // Default for 2D, could be 4 for 2D+Z
+
+    for (uint32_t i = 0; i < num_vc2_channels; ++i) {
+        // Map to erisc builder for now - tensix mapping would be added if needed
+        sender_channel_map_[LogicalSenderChannelKey{2, i}] =
+            InternalSenderChannelMapping{BuilderType::ERISC, i};
+
+        receiver_channel_map_[LogicalReceiverChannelKey{2, i}] =
+            InternalReceiverChannelMapping{BuilderType::ERISC, i};
+    }
+}
+
+bool FabricRouterChannelMapping::is_2d_topology() const {
+    return topology_ == Topology::Mesh || topology_ == Topology::Torus;
+}
+
+bool FabricRouterChannelMapping::is_ring_or_torus() const {
+    return topology_ == Topology::Ring || topology_ == Topology::Torus;
+}
+
+InternalSenderChannelMapping FabricRouterChannelMapping::get_sender_mapping(
+    uint32_t vc, uint32_t sender_channel_idx) const {
+    LogicalSenderChannelKey key{vc, sender_channel_idx};
+    auto it = sender_channel_map_.find(key);
+    TT_FATAL(it != sender_channel_map_.end(), "No mapping found for VC{} sender channel {}", vc, sender_channel_idx);
+    return it->second;
+}
+
+InternalReceiverChannelMapping FabricRouterChannelMapping::get_receiver_mapping(
+    uint32_t vc, uint32_t receiver_channel_idx) const {
+    LogicalReceiverChannelKey key{vc, receiver_channel_idx};
+    auto it = receiver_channel_map_.find(key);
+    TT_FATAL(
+        it != receiver_channel_map_.end(), "No mapping found for VC{} receiver channel {}", vc, receiver_channel_idx);
+    return it->second;
+}
+
+}  // namespace tt::tt_fabric

--- a/tt_metal/fabric/fabric_router_channel_mapping.hpp
+++ b/tt_metal/fabric/fabric_router_channel_mapping.hpp
@@ -53,19 +53,21 @@ struct InternalReceiverChannelMapping {
 /**
  * FabricRouterChannelMapping
  *
- * Defines the mapping from logical channels (VC + channel index) to internal builder channels.
+ * Defines the mapping from logical channels (VC + relative channel index within VC) to internal builder channels.
  * This mapping is computed based on topology, direction, and tensix extension mode.
  *
- * The mapping follows the design doc table:
- * - VC0: [0] = worker, [1] = vc0 forward channels (1D) or [0-3] = N/E/S/W/Worker (2D)
- * - VC1: [0] = vc1 forward channel (ring/torus only)
+ * Channel indices are relative to each VC:
+ * - VC0 (1D): [0] = local worker, [1] = forwarding from upstream
+ * - VC0 (2D): [0] = local worker, [1-3] = forwarding from upstream routers
+ * - VC1: [0] = vc1 forward channel (ring/torus only, for deadlock avoidance)
  * - VC2: [0-2] or [0-3] = intermesh channels (2D/2D+Z only)
  */
 class FabricRouterChannelMapping {
 public:
     FabricRouterChannelMapping(
         Topology topology,
-        eth_chan_directions direction);
+        eth_chan_directions direction,
+        bool has_tensix_extension = false);
 
     /**
      * Get the internal sender channel mapping for a logical sender channel
@@ -81,6 +83,7 @@ private:
     Topology topology_;
     // will become used when Z-link support is added
     [[maybe_unused]] eth_chan_directions direction_;
+    bool has_tensix_extension_;
 
     std::map<LogicalSenderChannelKey, InternalSenderChannelMapping> sender_channel_map_;
     std::map<LogicalReceiverChannelKey, InternalReceiverChannelMapping> receiver_channel_map_;

--- a/tt_metal/fabric/fabric_router_channel_mapping.hpp
+++ b/tt_metal/fabric/fabric_router_channel_mapping.hpp
@@ -1,0 +1,96 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include <map>
+#include "tt_metal/api/tt-metalium/fabric_edm_types.hpp"
+#include "tt_metal/hostdevcommon/api/hostdevcommon/fabric_common.h"
+
+namespace tt::tt_fabric {
+
+enum class BuilderType : uint8_t {
+    ERISC = 0,
+    TENSIX = 1,
+};
+
+struct LogicalSenderChannelKey {
+    uint32_t vc;
+    uint32_t sender_channel_idx;
+
+    bool operator<(const LogicalSenderChannelKey& other) const {
+        if (vc != other.vc) {
+            return vc < other.vc;
+        }
+        return sender_channel_idx < other.sender_channel_idx;
+    }
+};
+
+struct LogicalReceiverChannelKey {
+    uint32_t vc;
+    uint32_t receiver_channel_idx;
+
+    bool operator<(const LogicalReceiverChannelKey& other) const {
+        if (vc != other.vc) {
+            return vc < other.vc;
+        }
+        return receiver_channel_idx < other.receiver_channel_idx;
+    }
+};
+
+struct InternalSenderChannelMapping {
+    BuilderType builder_type;
+    uint32_t internal_sender_channel_id;
+};
+
+struct InternalReceiverChannelMapping {
+    BuilderType builder_type;
+    uint32_t internal_receiver_channel_id;
+};
+
+/**
+ * FabricRouterChannelMapping
+ *
+ * Defines the mapping from logical channels (VC + channel index) to internal builder channels.
+ * This mapping is computed based on topology, direction, and tensix extension mode.
+ *
+ * The mapping follows the design doc table:
+ * - VC0: [0] = worker, [1] = vc0 forward channels (1D) or [0-3] = N/E/S/W/Worker (2D)
+ * - VC1: [0] = vc1 forward channel (ring/torus only)
+ * - VC2: [0-2] or [0-3] = intermesh channels (2D/2D+Z only)
+ */
+class FabricRouterChannelMapping {
+public:
+    FabricRouterChannelMapping(
+        Topology topology,
+        eth_chan_directions direction);
+
+    /**
+     * Get the internal sender channel mapping for a logical sender channel
+     */
+    InternalSenderChannelMapping get_sender_mapping(uint32_t vc, uint32_t sender_channel_idx) const;
+
+    /**
+     * Get the internal receiver channel mapping for a logical receiver channel
+     */
+    InternalReceiverChannelMapping get_receiver_mapping(uint32_t vc, uint32_t receiver_channel_idx) const;
+
+private:
+    Topology topology_;
+    // will become used when Z-link support is added
+    [[maybe_unused]] eth_chan_directions direction_;
+
+    std::map<LogicalSenderChannelKey, InternalSenderChannelMapping> sender_channel_map_;
+    std::map<LogicalReceiverChannelKey, InternalReceiverChannelMapping> receiver_channel_map_;
+
+    void initialize_mappings();
+    void initialize_vc0_mappings();
+    void initialize_vc1_mappings();
+    void initialize_vc2_mappings();
+    bool is_2d_topology() const;
+    bool is_ring_or_torus() const;
+};
+
+}  // namespace tt::tt_fabric

--- a/tt_metal/fabric/fabric_tensix_builder.cpp
+++ b/tt_metal/fabric/fabric_tensix_builder.cpp
@@ -369,16 +369,14 @@ FabricTensixDatamoverBuilder::FabricTensixDatamoverBuilder(
     uint32_t noc_y,
     std::shared_ptr<tt::tt_fabric::FabricMuxConfig> fabric_mux_config,
     eth_chan_directions direction) :
+    FabricDatamoverBuilderBase(noc_x, noc_y, direction),
     my_core_logical_(my_core_logical),
     local_fabric_node_id_(local_fabric_node_id),
     remote_fabric_node_id_(remote_fabric_node_id),
     ethernet_channel_id_(ethernet_channel_id),
     link_idx_(link_idx),
     risc_id_(risc_id),
-    noc_x_(noc_x),
-    noc_y_(noc_y),
-    fabric_mux_config_(std::move(fabric_mux_config)),
-    direction_(direction) {
+    fabric_mux_config_(std::move(fabric_mux_config)) {
     channel_connection_liveness_check_disable_array_.fill(false);
     TT_FATAL(fabric_mux_config_ != nullptr, "FabricMuxConfig cannot be null");
 }

--- a/tt_metal/fabric/fabric_tensix_builder.hpp
+++ b/tt_metal/fabric/fabric_tensix_builder.hpp
@@ -111,7 +111,7 @@ private:
  * - Builds mux kernels on fabric tensix cores for worker → mux → fabric router routing.
  * - Build the connections between Fabric routers, fabric router -> mux -> downstream fabric router.
  */
-class FabricTensixDatamoverBuilder {
+class FabricTensixDatamoverBuilder : public FabricDatamoverBuilderBase {
 public:
     // Constructor for fabric tensix datamover builder
     FabricTensixDatamoverBuilder(
@@ -139,7 +139,7 @@ public:
     void create_and_compile(tt::tt_metal::IDevice* device, tt::tt_metal::Program& program);
 
     // Build connection to fabric channel - returns connection specs for EDMs to connect to this mux
-    tt::tt_fabric::SenderWorkerAdapterSpec build_connection_to_fabric_channel(uint32_t channel_id) const;
+    tt::tt_fabric::SenderWorkerAdapterSpec build_connection_to_fabric_channel(uint32_t channel_id) const override;
 
     // Getters
     const CoreCoord& get_logical_core() const { return my_core_logical_; }
@@ -147,9 +147,6 @@ public:
     tt::tt_fabric::FabricNodeId get_remote_fabric_node_id() const { return remote_fabric_node_id_; }
     uint32_t get_ethernet_channel_id() const { return ethernet_channel_id_; }
     size_t get_risc_id() const { return risc_id_; }
-    uint32_t get_noc_x() const { return noc_x_; }
-    uint32_t get_noc_y() const { return noc_y_; }
-    eth_chan_directions get_direction() const { return direction_; }
 
     void append_upstream_routers_noc_xy(uint32_t noc_x, uint32_t noc_y);
 
@@ -163,14 +160,9 @@ private:
 
     // RISC and NOC configuration
     size_t risc_id_;
-    uint32_t noc_x_;
-    uint32_t noc_y_;
 
     // Mux configuration
     std::shared_ptr<tt::tt_fabric::FabricMuxConfig> fabric_mux_config_;
-
-    // Direction for routing
-    eth_chan_directions direction_;
 
     // Channel connection liveness check disable array
     mutable std::array<bool, builder_config::num_sender_channels> channel_connection_liveness_check_disable_array_{};


### PR DESCRIPTION
General cleanup and will make implementing Z and supporting the various topologies/configs simpler.

Create a new `FabricRouterBuilder` which wraps `FabricEriscDatamoverBuilder` and the option `FabricTensixDatamoverBuilder`.

The `FabricRouterBuilder` is now used to creating routers (as a whole) and connecting them to each other. Connections are now done with a {VC_idx, relative_ch_offset_in_VC} pair. These connection IDs are used to lookup into an external to internal channel map. This map resides in the `FabricRouterBuilder` and gives us flexibility to move channel locations around (e.g. a sender channel can be placed in either the `FabricEriscDatamoverBuilder` or the `FabricTensixDatamoverBuilder` without changes to the connection logic. This way we can start decoupling the logical fabric config from the actual implementation of channels.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/19479655321
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable): https://github.com/tenstorrent/tt-metal/actions/runs/19479638292
- [x] BH Nightly: https://github.com/tenstorrent/tt-metal/actions/runs/19479642476
- [x] T3000 Unit Tests: https://github.com/tenstorrent/tt-metal/actions/runs/19479652538
- [x] T3000 Nightly: https://github.com/tenstorrent/tt-metal/actions/runs/19479657095
- [x] Galaxy Quick: https://github.com/tenstorrent/tt-metal/actions/runs/19479635596
- [x] Galaxy Unit Test: https://github.com/tenstorrent/tt-metal/actions/runs/19479729772
- [x] BH Multi-card: https://github.com/tenstorrent/tt-metal/actions/runs/19479725172