### PR TITLE
[CONV3D] Relaxing timeout for triage triggering

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/conv/test_conv3d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/conv/test_conv3d.py
@@ -54,7 +54,7 @@ def test_conv3d_sweep_shapes(device, B, C_in, C_out, T, H, W, kernel_size, strid
         [(1, 128, 16, 16, 16), 128, (3, 3, 3), (1, 1, 1), (0, 1, 1), "replicate"],
     ],
 )
-@pytest.mark.timeout(500)
+@pytest.mark.timeout(1000)
 def test_conv3d_sweep_blocks(device, input_shape, out_channels, kernel_size, stride, padding, padding_mode):
     """
     For a specific shape, sweep through different block sizes.


### PR DESCRIPTION
### Problem description
Sweeps block testing conv 3d functionality last longer than the dedicated hang detection timeout.

### What's changed
Relaxing the timeout due to the duration of the conv3d sweep blocks test