### PR TITLE
Add sample prompt file command to deepseek readme

### DIFF
--- a/models/demos/deepseek_v3/README.md
+++ b/models/demos/deepseek_v3/README.md
@@ -67,6 +67,12 @@ The CLI accepts JSON files in either of the following layouts:
 
 Use `--num-prompts` to truncate large prompt sets. For example, there are 256 total prompts in `models/demos/deepseek_v3/demo/test_prompts.json`, but you can limit it to a subset.
 
+### Sample usage with JSON file:
+
+```bash
+python models/demos/deepseek_v3/demo/demo.py  --prompts-file models/demos/deepseek_v3/demo/test_prompts.json --num-prompts 256 --output-path deepseek_tt_out.json  --max-new-tokens 128
+```
+
 ### Programmatic usage
 
 ```python

--- a/models/demos/deepseek_v3/README.md
+++ b/models/demos/deepseek_v3/README.md
@@ -70,7 +70,7 @@ Use `--num-prompts` to truncate large prompt sets. For example, there are 256 to
 ### Sample usage with JSON file:
 
 ```bash
-python models/demos/deepseek_v3/demo/demo.py  --prompts-file models/demos/deepseek_v3/demo/test_prompts.json --num-prompts 256 --output-path deepseek_tt_out.json  --max-new-tokens 128
+python models/demos/deepseek_v3/demo/demo.py --prompts-file models/demos/deepseek_v3/demo/test_prompts.json --num-prompts 256 --output-path deepseek_tt_out.json --max-new-tokens 128
 ```
 
 ### Programmatic usage


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
No sample prompt file command to deepseek readme

### What's changed
Add sample prompt file command to deepseek readme

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes