### PR TITLE
[skip ci] [Reduce APC] Remove ttnn notebook test from APC

### DIFF
--- a/.github/workflows/ttnn-post-commit.yaml
+++ b/.github/workflows/ttnn-post-commit.yaml
@@ -92,7 +92,6 @@ jobs:
             { name: "ttnn transformers group", cmd: 'pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/transformers -xv -m "not disable_fast_runtime_mode"', merge_gate: false },
             { name: "ttnn reduce and misc ops group", cmd: 'pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/reduce tests/ttnn/unit_tests/operations/rand tests/ttnn/unit_tests/operations/debug tests/ttnn/unit_tests/operations/ssm -xv -m "not disable_fast_runtime_mode"', merge_gate: false },
             { name: "core ttnn unit test group", cmd: 'pytest -n auto --timeout 300 tests/ttnn/unit_tests/base_functionality tests/ttnn/unit_tests/benchmarks tests/ttnn/unit_tests/light_metal tests/ttnn/unit_tests/tensor -xv -m "not disable_fast_runtime_mode"', merge_gate: false },
-            { name: "ttnn notebook", cmd: 'TT_METAL_ENABLE_ERISC_IRAM=1 pytest -n auto --timeout 300 tests/ttnn/notebook_tests -xv -m "not disable_fast_runtime_mode"', merge_gate: false },
             # { name: "ttnn fast runtime off", cmd: 'pytest -n auto --timeout 300 tests/ttnn/unit_tests -xv -m requires_fast_runtime_mode_off', merge_gate: false, fast_runtime_mode_off: true },
           ]]
     steps:


### PR DESCRIPTION
### What's changed
Remove ttnn notebook tests from APC because it is already running and monitored from L2-nightly pipeline here: https://github.com/tenstorrent/tt-metal/actions/runs/19355878797/job/55400520882

https://github.com/tenstorrent/tt-metal/blob/main/.github/workflows/ttnn-tutorials-post-commit.yaml#L108