### PR TITLE
adding option for DeviceManager

### DIFF
--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -155,6 +155,10 @@ enum class EnvVarID {
     TT_METAL_DPRINT_ONE_FILE_PER_RISC,         // Separate file per RISC-V processor
     TT_METAL_DPRINT_PREPEND_DEVICE_CORE_RISC,  // Prepend device/core/RISC info
 
+    // ========================================
+    // DEVICE MANAGER
+    // ========================================
+    TT_METAL_NUMA_BASED_AFFINITY,
 };
 
 // Environment variable name for TT-Metal root directory
@@ -1018,6 +1022,18 @@ void RunTimeOptions::HandleEnvVar(EnvVarID id, const char* value) {
         case EnvVarID::TT_METAL_DPRINT_PREPEND_DEVICE_CORE_RISC:
             // Handled by ParseFeatureEnv() - this is for documentation
             break;
+
+        // ========================================
+        // NUMA THREAD BINDING
+        // ========================================
+        // TT_METAL_NUMA_BASED_AFFINITY
+        // Specifies thread binding in DeviceManager
+        // Default: disabled
+        // Usage: export TT_METAL_NUMA_BASED_AFFINITY 1
+        case EnvVarID::TT_METAL_NUMA_BASED_AFFINITY: {
+            this->numa_based_affinity = true;
+            break;
+        }
     }
 }
 

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -1024,14 +1024,14 @@ void RunTimeOptions::HandleEnvVar(EnvVarID id, const char* value) {
             break;
 
         // ========================================
-        // NUMA THREAD BINDING
+        // DEVICE MANAGER
         // ========================================
         // TT_METAL_NUMA_BASED_AFFINITY
         // Specifies thread binding in DeviceManager
         // Default: disabled
-        // Usage: export TT_METAL_NUMA_BASED_AFFINITY 1
+        // Usage: export TT_METAL_NUMA_BASED_AFFINITY=1
         case EnvVarID::TT_METAL_NUMA_BASED_AFFINITY: {
-            this->numa_based_affinity = true;
+            this->numa_based_affinity = is_env_enabled(value);
             break;
         }
     }

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -233,6 +233,9 @@ class RunTimeOptions {
     // Force JIT compile even if dependencies are up to date
     bool force_jit_compile = false;
 
+    // To be used for NUMA node based thread binding
+    bool numa_based_affinity = false;
+
 public:
     RunTimeOptions();
     RunTimeOptions(const RunTimeOptions&) = delete;
@@ -550,6 +553,8 @@ public:
 
     bool get_force_jit_compile() const { return force_jit_compile; }
     void set_force_jit_compile(bool enable) { force_jit_compile = enable; }
+
+    bool get_numa_based_affinity() const { return numa_based_affinity; }
 
     // Parse all feature-specific environment variables, after hal is initialized.
     // (Needed because syntax of some env vars is arch-dependent.)


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/32130)

### Problem description
As a part of moving DevicePool, moving env read into RtOptions

### What's changed
now all the reading of ENV variables will happen in one place, and will be just queried in DeviceManager

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes