### PR TITLE
Edit model perf in CI

### DIFF
--- a/models/demos/yolov4/tests/perf/test_perf.py
+++ b/models/demos/yolov4/tests/perf/test_perf.py
@@ -10,7 +10,7 @@ from models.perf.device_perf_utils import check_device_perf, prep_device_perf_re
 @pytest.mark.parametrize(
     "batch_size, model_name, expected_perf",
     [
-        (1, "yolov4", 114),
+        (1, "yolov4", 102.1),
     ],
 )
 @pytest.mark.models_device_performance_bare_metal

--- a/models/demos/yolov6l/tests/perf/test_perf_yolov6l.py
+++ b/models/demos/yolov6l/tests/perf/test_perf_yolov6l.py
@@ -14,7 +14,7 @@ from models.perf.device_perf_utils import check_device_perf, prep_device_perf_re
 @pytest.mark.parametrize(
     "batch_size, expected_perf",
     [
-        [1, 110.3],
+        [1, 103.25],
     ],
 )
 @pytest.mark.models_device_performance_bare_metal

--- a/models/demos/yolov7/tests/perf/test_perf.py
+++ b/models/demos/yolov7/tests/perf/test_perf.py
@@ -19,7 +19,7 @@ sys.modules["models.yolo"] = yolov7_model
 @pytest.mark.parametrize(
     "batch_size, expected_perf",
     [
-        [1, 135.17],
+        [1, 128.34],
     ],
 )
 @pytest.mark.models_device_performance_bare_metal

--- a/models/demos/yolov8s/tests/perf/test_perf_yolov8s.py
+++ b/models/demos/yolov8s/tests/perf/test_perf_yolov8s.py
@@ -12,7 +12,7 @@ from models.perf.device_perf_utils import check_device_perf, prep_device_perf_re
 @pytest.mark.parametrize(
     "batch_size, expected_perf",
     [
-        [1, 236.95],
+        [1, 224.33],
     ],
 )
 @pytest.mark.models_device_performance_bare_metal

--- a/models/experimental/efficientnetb0/tests/perf/test_perf.py
+++ b/models/experimental/efficientnetb0/tests/perf/test_perf.py
@@ -15,7 +15,7 @@ from models.common.utility_functions import (
 @pytest.mark.parametrize(
     "batch_size, expected_perf",
     [
-        [1, 174.0],
+        [1, 136.49],
     ],
 )
 @pytest.mark.models_device_performance_bare_metal

--- a/models/experimental/swin_s/tests/perf/test_perf.py
+++ b/models/experimental/swin_s/tests/perf/test_perf.py
@@ -10,7 +10,7 @@ from models.perf.device_perf_utils import check_device_perf, prep_device_perf_re
 @pytest.mark.parametrize(
     "batch_size, model_name, expected_perf",
     [
-        (1, "Swin_s", 11.5),
+        (1, "Swin_s", 10.07),
     ],
 )
 @pytest.mark.models_device_performance_bare_metal

--- a/models/experimental/vovnet/tests/perf/test_perf.py
+++ b/models/experimental/vovnet/tests/perf/test_perf.py
@@ -10,7 +10,7 @@ from models.perf.device_perf_utils import run_device_perf, check_device_perf, pr
 @pytest.mark.parametrize(
     "batch_size, expected_perf",
     [
-        [1, 159.00],
+        [1, 149.43],
     ],
 )
 @pytest.mark.models_device_performance_bare_metal


### PR DESCRIPTION
### Ticket
Link to Github Issue - N/A
Failing run: https://github.com/tenstorrent/tt-metal/actions/runs/19293751512/job/55171139366

### Problem description
Some models have lower perf due to https://github.com/tenstorrent/tt-metal/pull/31609, which fixes a functional issue at the expense of higher loop iterations when L1 address is unaligned to 4bytes.

### What's changed
Lowering the expected perf for:
- yolov8s
- yolov7
- yolov6I
- efficientnetb0

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/19371150043)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/runs/19371154810)