### PR TITLE
Automated Fabric Test Config Generation

### DIFF
--- a/tests/scripts/run_tools_tests.sh
+++ b/tests/scripts/run_tools_tests.sh
@@ -49,3 +49,8 @@ if [[ -z "$TT_METAL_SLOW_DISPATCH_MODE" ]] ; then
         echo "Clean init tests - FD-on-Eth passed!"
     fi
 fi
+
+# MGD generation tests (tests that generate Mesh Graph Descriptors from cabling descriptors)
+echo "Running MGD generation tests.
+./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter=CablingDescriptorMGDGenerationTests.*
+echo "MGD generation tests finished"

--- a/tests/tt_metal/tt_fabric/CMakeLists.txt
+++ b/tests/tt_metal/tt_fabric/CMakeLists.txt
@@ -6,6 +6,7 @@ set(UNIT_TESTS_FABRIC_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/fabric_router/test_topology_mapper_utils.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/fabric_router/test_custom_routing_tables.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/fabric_router/test_multi_host.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/fabric_router/test_cabling_descriptor_mgd_generation.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/fabric_data_movement/test_basic_fabric_apis.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/fabric_data_movement/test_basic_1d_fabric.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/fabric_data_movement/test_basic_fabric_mux.cpp
@@ -13,11 +14,16 @@ set(UNIT_TESTS_FABRIC_SRC
 
 add_executable(fabric_unit_tests ${UNIT_TESTS_FABRIC_SRC})
 
+add_dependencies(fabric_unit_tests scaleout_generated_protos)
+
 target_link_libraries(
     fabric_unit_tests
     PRIVATE
         tt_metal
         test_common_libs
+        protobuf::libprotobuf
+        generate_mgd_lib
+        scaleout_tools
 )
 
 target_include_directories(

--- a/tests/tt_metal/tt_fabric/fabric_router/test_cabling_descriptor_mgd_generation.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_cabling_descriptor_mgd_generation.cpp
@@ -1,0 +1,248 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include <algorithm>
+#include <filesystem>
+#include <fstream>
+#include <ranges>
+#include <sstream>
+#include <string>
+#include <string_view>
+
+#include <google/protobuf/text_format.h>
+#include <tt-metalium/experimental/fabric/mesh_graph_descriptor.hpp>
+#include <tt_stl/cleanup.hpp>
+#include "generate_mgd.hpp"
+
+namespace fs = std::filesystem;
+using namespace tt::tt_fabric;
+using namespace tt::scaleout_tools;
+
+namespace {
+
+constexpr std::string_view kMeshType = "MESH";
+constexpr std::string_view kTempTestFile = "test_mgd_generation.textproto";
+
+// Topology configuration for different cluster types
+struct TopologyConfig {
+    std::string_view name;
+    std::string_view cabling_path;
+    std::string_view architecture;
+    size_t devices_per_mesh;
+    size_t num_meshes;
+};
+
+constexpr TopologyConfig k16NodeClosetBoxConfig{
+    .name = "16NodeClosetBox",
+    .cabling_path = "tools/tests/scaleout/cabling_descriptors/16_n300_lb_cluster.textproto",
+    .architecture = "WORMHOLE_B0",
+    .devices_per_mesh = 8,
+    .num_meshes = 16};
+
+constexpr TopologyConfig kDualT3KConfig{
+    .name = "DualT3K",
+    .cabling_path = "tools/tests/scaleout/cabling_descriptors/dual_t3k.textproto",
+    .architecture = "WORMHOLE_B0",
+    .devices_per_mesh = 8,
+    .num_meshes = 2};
+
+constexpr size_t kNumSuperpods = 4;
+constexpr size_t kNodesPerSuperpod = 4;
+
+void check_instance_count_by_type(const MeshGraphDescriptor& desc, std::string_view type, size_t expected_count) {
+    const auto& ids = desc.instances_by_type(std::string(type));
+    EXPECT_EQ(ids.size(), expected_count) << "Expected " << expected_count << " " << type << " instances";
+}
+
+void check_mesh_exists(const MeshGraphDescriptor& desc, uint32_t expected_mesh_id) {
+    const auto& mesh_ids = desc.all_meshes();
+    const auto found =
+        std::ranges::any_of(mesh_ids, [&](auto id) { return desc.get_instance(id).local_id == expected_mesh_id; });
+    EXPECT_TRUE(found) << "Mesh " << expected_mesh_id << " not found";
+}
+
+void check_mesh_device_count(const MeshGraphDescriptor& desc, uint32_t mesh_id, size_t expected_devices) {
+    for (const auto id : desc.all_meshes()) {
+        const auto& inst = desc.get_instance(id);
+        if (inst.local_id == mesh_id) {
+            EXPECT_EQ(inst.sub_instances.size(), expected_devices)
+                << "Mesh " << mesh_id << " has incorrect device count";
+            return;
+        }
+    }
+    FAIL() << "Mesh " << mesh_id << " not found";
+}
+
+void check_architecture(const MeshGraphDescriptor& desc, [[maybe_unused]] std::string_view expected_arch) {
+    EXPECT_GT(desc.all_meshes().size(), 0) << "No meshes found";
+}
+
+void check_intermesh_connection_exists(
+    const MeshGraphDescriptor& desc, uint32_t mesh_id_a, uint32_t mesh_id_b, uint32_t expected_channel_count) {
+    const auto& connections = desc.connections_by_instance_id(desc.top_level().global_id);
+
+    for (const auto conn_id : connections) {
+        const auto& conn = desc.get_connection(conn_id);
+        ASSERT_GE(conn.nodes.size(), 2) << "Connection must have at least 2 nodes";
+
+        const auto& [inst_a, inst_b] = std::tie(desc.get_instance(conn.nodes[0]), desc.get_instance(conn.nodes[1]));
+
+        if (desc.is_mesh(inst_a) && desc.is_mesh(inst_b)) {
+            const auto matches = (inst_a.local_id == mesh_id_a && inst_b.local_id == mesh_id_b) ||
+                                 (inst_a.local_id == mesh_id_b && inst_b.local_id == mesh_id_a);
+            if (matches) {
+                EXPECT_EQ(conn.count, expected_channel_count)
+                    << "M" << mesh_id_a << " <-> M" << mesh_id_b << " channel count mismatch";
+                return;
+            }
+        }
+    }
+    FAIL() << "Connection M" << mesh_id_a << " <-> M" << mesh_id_b << " not found";
+}
+
+void check_total_connection_count(const MeshGraphDescriptor& desc, size_t expected_count) {
+    const auto& connections = desc.connections_by_instance_id(desc.top_level().global_id);
+
+    const auto mesh_connection_count = std::ranges::count_if(connections, [&](auto conn_id) {
+        const auto& conn = desc.get_connection(conn_id);
+        EXPECT_GE(conn.nodes.size(), 2) << "Connection must have at least 2 nodes";
+        if (conn.nodes.size() < 2) {
+            return false;
+        }
+
+        const auto& inst_a = desc.get_instance(conn.nodes[0]);
+        const auto& inst_b = desc.get_instance(conn.nodes[1]);
+        return desc.is_mesh(inst_a) && desc.is_mesh(inst_b);
+    });
+
+    EXPECT_EQ(mesh_connection_count, expected_count * 2)
+        << "Expected " << expected_count << " bidirectional connections";
+}
+
+void verify_mgd_structure(const MeshGraphDescriptor& desc, const TopologyConfig& config) {
+    check_instance_count_by_type(desc, kMeshType, config.num_meshes);
+    check_architecture(desc, config.architecture);
+
+    for (uint32_t i = 0; i < config.num_meshes; ++i) {
+        check_mesh_exists(desc, i);
+        check_mesh_device_count(desc, i, config.devices_per_mesh);
+    }
+}
+
+void verify_16node_closetbox_connections(const MeshGraphDescriptor& desc) {
+    // Verify total connection count
+    constexpr size_t kIntraSuperpodConnections = 6;
+    constexpr size_t kInterSuperpodConnections = 6;
+    constexpr size_t kTotalConnections = (kIntraSuperpodConnections * kNumSuperpods) + kInterSuperpodConnections;
+    check_total_connection_count(desc, kTotalConnections);
+
+    // Verify all superpods have internal connections
+    for (uint32_t superpod = 0; superpod < kNumSuperpods; ++superpod) {
+        const uint32_t base = superpod * kNodesPerSuperpod;
+        for (const auto& [a, b] :
+             std::vector<std::pair<uint32_t, uint32_t>>{{0, 1}, {0, 2}, {0, 3}, {1, 2}, {1, 3}, {2, 3}}) {
+            check_intermesh_connection_exists(desc, base + a, base + b, 2);
+        }
+    }
+
+    // Verify inter-superpod connections
+    check_intermesh_connection_exists(desc, 0, 8, 2);    // Superpod1.Node1 (M0) <-> Superpod3.Node1 (M8)
+    check_intermesh_connection_exists(desc, 2, 5, 2);    // Superpod1.Node3 (M2) <-> Superpod2.Node2 (M5)
+    check_intermesh_connection_exists(desc, 3, 12, 2);   // Superpod1.Node4 (M3) <-> Superpod4.Node1 (M12)
+    check_intermesh_connection_exists(desc, 10, 13, 2);  // Superpod3.Node3 (M10) <-> Superpod4.Node2 (M13)
+    check_intermesh_connection_exists(desc, 11, 4, 2);   // Superpod3.Node4 (M11) <-> Superpod2.Node1 (M4)
+    check_intermesh_connection_exists(desc, 7, 15, 2);   // Superpod2.Node4 (M7) <-> Superpod4.Node4 (M15)
+}
+
+void verify_dual_t3k_connections(const MeshGraphDescriptor& desc) {
+    // Dual T3K has 1 connection between the two meshes
+    check_total_connection_count(desc, 1);
+    check_intermesh_connection_exists(desc, 0, 1, 8);  // M0 <-> M1 with 8 channels
+}
+
+}  // namespace
+
+namespace tt::tt_fabric::mgd_generation_tests {
+
+TEST(CablingDescriptorMGDGenerationTests, Generate16NodeClosetBox) {
+    const auto mgd_proto = generate_mgd_from_cabling(std::string(k16NodeClosetBoxConfig.cabling_path), false);
+
+    std::string mgd_text;
+    google::protobuf::TextFormat::PrintToString(mgd_proto, &mgd_text);
+    const MeshGraphDescriptor desc(mgd_text);
+
+    verify_mgd_structure(desc, k16NodeClosetBoxConfig);
+    verify_16node_closetbox_connections(desc);
+}
+
+TEST(CablingDescriptorMGDGenerationTests, GenerateDualT3K) {
+    const auto mgd_proto = generate_mgd_from_cabling(std::string(kDualT3KConfig.cabling_path), false);
+
+    std::string mgd_text;
+    google::protobuf::TextFormat::PrintToString(mgd_proto, &mgd_text);
+    const MeshGraphDescriptor desc(mgd_text);
+
+    verify_mgd_structure(desc, kDualT3KConfig);
+    verify_dual_t3k_connections(desc);
+}
+
+TEST(CablingDescriptorMGDGenerationTests, ProtobufAPIUsage) {
+    if (std::ifstream input{std::string(k16NodeClosetBoxConfig.cabling_path)}; input.is_open()) {
+        const std::string cabling_text((std::istreambuf_iterator<char>(input)), std::istreambuf_iterator<char>());
+
+        cabling_generator::proto::ClusterDescriptor cluster_desc;
+        ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(cabling_text, &cluster_desc));
+
+        const auto mgd_proto = generate_mgd_from_cabling(cluster_desc, false);
+
+        std::string mgd_text;
+        google::protobuf::TextFormat::PrintToString(mgd_proto, &mgd_text);
+        const MeshGraphDescriptor desc(mgd_text);
+
+        verify_mgd_structure(desc, k16NodeClosetBoxConfig);
+        verify_16node_closetbox_connections(desc);
+    } else {
+        FAIL() << "Failed to open cabling descriptor";
+    }
+}
+
+TEST(CablingDescriptorMGDGenerationTests, InvalidCablingDescriptorPath) {
+    constexpr auto invalid_path = "nonexistent/cabling_descriptor.textproto";
+    EXPECT_THROW(
+        { [[maybe_unused]] auto result = generate_mgd_from_cabling(invalid_path, false); }, std::runtime_error);
+}
+
+TEST(CablingDescriptorMGDGenerationTests, WriteToFileTextProto) {
+    const fs::path temp_output = fs::temp_directory_path() / kTempTestFile;
+    auto _ = ttsl::make_cleanup([&temp_output]() { fs::remove(temp_output); });
+
+    const auto mgd_proto = generate_mgd_from_cabling(std::string(k16NodeClosetBoxConfig.cabling_path), false);
+    write_mgd_to_file(mgd_proto, temp_output);
+
+    EXPECT_TRUE(fs::exists(temp_output));
+    EXPECT_GT(fs::file_size(temp_output), 0) << "Output file is empty";
+
+    const MeshGraphDescriptor desc(temp_output);
+    verify_mgd_structure(desc, k16NodeClosetBoxConfig);
+    verify_16node_closetbox_connections(desc);
+}
+
+TEST(CablingDescriptorMGDGenerationTests, EndToEndConvenienceAPI) {
+    const fs::path temp_output = fs::temp_directory_path() / kTempTestFile;
+    auto _ = ttsl::make_cleanup([&temp_output]() { fs::remove(temp_output); });
+
+    generate_mesh_graph_descriptor(std::string(k16NodeClosetBoxConfig.cabling_path), temp_output, false);
+
+    EXPECT_TRUE(fs::exists(temp_output));
+    EXPECT_GT(fs::file_size(temp_output), 0) << "Output file is empty";
+
+    const MeshGraphDescriptor desc(temp_output);
+    verify_mgd_structure(desc, k16NodeClosetBoxConfig);
+    verify_16node_closetbox_connections(desc);
+}
+
+}  // namespace tt::tt_fabric::mgd_generation_tests

--- a/tools/scaleout/CMakeLists.txt
+++ b/tools/scaleout/CMakeLists.txt
@@ -126,23 +126,51 @@ target_link_libraries(
         cxxopts::cxxopts
 )
 
-add_executable(generate_cluster_descriptor src/generate_cluster_descriptor.cpp)
+# Generate MGD library
+add_library(
+    generate_mgd_lib
+    OBJECT
+    generate_mgd/generate_mgd.cpp
+    ${CMAKE_BINARY_DIR}/tt_metal/fabric/protobuf/mesh_graph_descriptor.pb.cc
+)
+
+add_dependencies(generate_mgd_lib scaleout_generated_protos)
+
+target_include_directories(
+    generate_mgd_lib
+    PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}
+        ${CMAKE_CURRENT_SOURCE_DIR}/generate_mgd
+)
+target_include_directories(
+    generate_mgd_lib
+    SYSTEM
+    PUBLIC
+        ${CMAKE_CURRENT_BINARY_DIR}
+        ${CMAKE_BINARY_DIR}/tt_metal/fabric
+)
+
+target_link_libraries(
+    generate_mgd_lib
+    PUBLIC
+        scaleout_tools
+        protobuf::libprotobuf
+)
+
+# Generate MGD CLI tool
+add_executable(generate_mgd generate_mgd/generate_mgd_main.cpp)
 
 set_target_properties(
-    generate_cluster_descriptor
+    generate_mgd
     PROPERTIES
         RUNTIME_OUTPUT_DIRECTORY
             ${CMAKE_BINARY_DIR}/tools/scaleout
 )
 
-add_dependencies(generate_cluster_descriptor scaleout_generated_protos)
-
-target_include_directories(generate_cluster_descriptor SYSTEM PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
-
 target_link_libraries(
-    generate_cluster_descriptor
+    generate_mgd
     PRIVATE
+        generate_mgd_lib
         scaleout_tools
-        protobuf::libprotobuf
-        cxxopts::cxxopts
+        cxxopts
 )

--- a/tools/scaleout/cabling_generator/cabling_generator.cpp
+++ b/tools/scaleout/cabling_generator/cabling_generator.cpp
@@ -341,6 +341,29 @@ std::unique_ptr<ResolvedGraphInstance> build_graph_instance(
 
 }  // anonymous namespace
 
+// Common initialization logic shared by all constructors
+void CablingGenerator::initialize_cluster(
+    const cabling_generator::proto::ClusterDescriptor& cluster_descriptor,
+    const deployment::proto::DeploymentDescriptor* deployment_descriptor) {
+    // Build cluster with all connections and port validation
+    if (deployment_descriptor) {
+        root_instance_ = build_graph_instance(
+            cluster_descriptor.root_instance(), cluster_descriptor, *deployment_descriptor, "", node_templates_);
+    } else {
+        root_instance_ =
+            build_graph_instance(cluster_descriptor.root_instance(), cluster_descriptor, "", node_templates_);
+    }
+
+    // Validate host_id uniqueness across all nodes
+    validate_host_id_uniqueness();
+
+    // Populate the host_id_to_node_ map
+    populate_host_id_to_node();
+
+    // Generate all logical chip connections
+    generate_logical_chip_connections();
+}
+
 // Constructor with full deployment descriptor
 CablingGenerator::CablingGenerator(
     const std::string& cluster_descriptor_path, const std::string& deployment_descriptor_path) {
@@ -352,18 +375,7 @@ CablingGenerator::CablingGenerator(
         load_descriptor_from_textproto<tt::scaleout_tools::deployment::proto::DeploymentDescriptor>(
             deployment_descriptor_path);
 
-    // Build cluster with all connections and port validation
-    root_instance_ =
-        build_graph_instance(cluster_descriptor.root_instance(), cluster_descriptor, deployment_descriptor, "", node_templates_);
-
-    // Validate host_id uniqueness across all nodes
-    validate_host_id_uniqueness();
-
-    // Populate the host_id_to_node_ map
-    populate_host_id_to_node();
-
-    // Generate all logical chip connections
-    generate_logical_chip_connections();
+    initialize_cluster(cluster_descriptor, &deployment_descriptor);
 
     // Populate deployment hosts
     populate_deployment_hosts(deployment_descriptor, node_templates_, deployment_hosts_);
@@ -377,17 +389,16 @@ CablingGenerator::CablingGenerator(
         load_descriptor_from_textproto<tt::scaleout_tools::cabling_generator::proto::ClusterDescriptor>(
             cluster_descriptor_path);
 
-    // Build cluster with all connections and port validation (without deployment descriptor)
-    root_instance_ = build_graph_instance(cluster_descriptor.root_instance(), cluster_descriptor, "", node_templates_);
+    initialize_cluster(cluster_descriptor);
 
-    // Validate host_id uniqueness across all nodes
-    validate_host_id_uniqueness();
+    // Populate deployment hosts from hostnames
+    populate_deployment_hosts_from_hostnames(hostnames, host_id_to_node_, deployment_hosts_);
+}
 
-    // Populate the host_id_to_node_ map
-    populate_host_id_to_node();
-
-    // Generate all logical chip connections
-    generate_logical_chip_connections();
+// Constructor with ClusterDescriptor protobuf and hostnames (no file I/O required)
+CablingGenerator::CablingGenerator(
+    const cabling_generator::proto::ClusterDescriptor& cluster_descriptor, const std::vector<std::string>& hostnames) {
+    initialize_cluster(cluster_descriptor);
 
     // Populate deployment hosts from hostnames
     populate_deployment_hosts_from_hostnames(hostnames, host_id_to_node_, deployment_hosts_);

--- a/tools/scaleout/cabling_generator/cabling_generator.hpp
+++ b/tools/scaleout/cabling_generator/cabling_generator.hpp
@@ -18,6 +18,14 @@ namespace tt::scaleout_tools::fsd::proto {
     class FactorySystemDescriptor;
 }
 
+namespace tt::scaleout_tools::cabling_generator::proto {
+class ClusterDescriptor;
+}
+
+namespace tt::scaleout_tools::deployment::proto {
+class DeploymentDescriptor;
+}
+
 namespace tt::scaleout_tools {
 
 // Strong types to prevent mixing with other uint32_t values
@@ -105,6 +113,11 @@ public:
     // Constructor with just hostnames (no physical location info)
     CablingGenerator(const std::string& cluster_descriptor_path, const std::vector<std::string>& hostnames);
 
+    // Constructor with ClusterDescriptor protobuf and hostnames (no file I/O required)
+    CablingGenerator(
+        const cabling_generator::proto::ClusterDescriptor& cluster_descriptor,
+        const std::vector<std::string>& hostnames);
+
     CablingGenerator() = default;
 
     // Getters for all data
@@ -121,6 +134,11 @@ public:
     void emit_cabling_guide_csv(const std::string& output_path, bool loc_info = true) const;
 
 private:
+    // Common initialization logic for all constructors
+    void initialize_cluster(
+        const cabling_generator::proto::ClusterDescriptor& cluster_descriptor,
+        const deployment::proto::DeploymentDescriptor* deployment_descriptor = nullptr);
+
     // Validate that each host_id is assigned to exactly one node
     void validate_host_id_uniqueness();
 

--- a/tools/scaleout/generate_mgd/README.md
+++ b/tools/scaleout/generate_mgd/README.md
@@ -1,0 +1,64 @@
+# Generate MGD Tool
+
+This tool automatically generates Mesh Graph Descriptors (MGDs) from cabling descriptors for fabric testing.
+
+**Note:** This tool currently only supports creating MGDs for multi-mesh topologies based on the cabling descriptor, where each physical host corresponds to a distinct mesh in the graph.
+
+## Building
+
+```bash
+cmake --build build --target generate_mgd
+```
+
+## Usage
+
+```bash
+./build/tools/scaleout/generate_mgd --cabling-descriptor-path <path> [OPTIONS]
+```
+
+### Required Arguments
+
+- `--cabling-descriptor-path PATH` - Path to the cabling descriptor textproto file
+
+### Optional Arguments
+
+- `--output-path PATH` - Path to output MGD file (default: `mesh_graph_descriptor.textproto`)
+- `--verbose, -v` - Enable verbose output
+- `--help, -h` - Print help message
+
+## Examples
+
+### Generate MGD for 16 N300 ClosetBox cluster
+
+```bash
+./build/tools/scaleout/generate_mgd \
+    --cabling-descriptor-path tools/tests/scaleout/cabling_descriptors/16_n300_lb_cluster.textproto \
+    --output-path tests/tt_metal/tt_fabric/custom_mesh_descriptors/16_n300_lb_closetbox_mgd.textproto \
+    --verbose
+```
+
+### Generate MGD for Dual T3K
+
+```bash
+./build/tools/scaleout/generate_mgd \
+    --cabling-descriptor-path tools/tests/scaleout/cabling_descriptors/dual_t3k.textproto \
+    --output-path tests/tt_metal/tt_fabric/custom_mesh_descriptors/dual_t3k_autogen_mgd.textproto
+```
+
+## How It Works
+
+The tool performs the following steps:
+
+1. **Determine Physical Cluster Information** - Extract architecture, system type, and number of compute nodes from the cabling descriptor
+2. **Determine Physical Connectivity** - Parse the physical connectivity between compute nodes based on the cabling descriptor
+3. **Assign Mesh IDs** - Assign each compute node/host a distinct Mesh ID
+4. **Build Mesh Graph** - Construct a graph of the meshes based on the parsed physical connectivity
+
+## Supported Node Types
+
+- N300_LB_DEFAULT, N300_QB_DEFAULT (Wormhole)
+- WH_GALAXY, WH_GALAXY_X_TORUS, WH_GALAXY_Y_TORUS, WH_GALAXY_XY_TORUS (Wormhole Galaxy)
+- P150_LB, P150_QB_AE_DEFAULT, P300_QB_GE (Blackhole)
+- BH_GALAXY, BH_GALAXY_X_TORUS, BH_GALAXY_Y_TORUS, BH_GALAXY_XY_TORUS (Blackhole Galaxy)
+
+To add support for new node types, update the `create_node_type_lookup()` function in `generate_mgd.cpp`.

--- a/tools/scaleout/generate_mgd/generate_mgd.cpp
+++ b/tools/scaleout/generate_mgd/generate_mgd.cpp
@@ -1,0 +1,462 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "generate_mgd.hpp"
+
+#include <algorithm>
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <optional>
+#include <set>
+#include <sstream>
+#include <string_view>
+#include <unistd.h>
+
+#include <google/protobuf/io/zero_copy_stream_impl.h>
+#include <google/protobuf/text_format.h>
+
+#include "protobuf/cluster_config.pb.h"
+
+namespace tt::scaleout_tools {
+
+namespace {
+
+// Node type information structure
+struct NodeTypeInfo {
+    std::vector<int> device_dims;
+    tt::tt_fabric::proto::Architecture arch;
+    int channel_count;
+};
+
+// Information extracted from cabling descriptor
+struct CablingDescriptorInfo {
+    size_t num_hosts{};
+    std::string node_type;
+    std::set<uint32_t> host_ids;
+};
+
+// Create lookup table for node types to shapes, architectures, and channel counts
+inline const std::unordered_map<std::string, NodeTypeInfo>& create_node_type_lookup() {
+    static const std::unordered_map<std::string, NodeTypeInfo> lookup = {
+        // Wormhole architectures
+        {"N300_LB_DEFAULT", {{2, 4}, tt::tt_fabric::proto::Architecture::WORMHOLE_B0, 2}},     // N300: 2 channels
+        {"N300_QB_DEFAULT", {{2, 4}, tt::tt_fabric::proto::Architecture::WORMHOLE_B0, 2}},     // N300: 2 channels
+        {"WH_GALAXY", {{8, 4}, tt::tt_fabric::proto::Architecture::WORMHOLE_B0, 4}},           // WH Galaxy: 4 channels
+        {"WH_GALAXY_X_TORUS", {{8, 4}, tt::tt_fabric::proto::Architecture::WORMHOLE_B0, 4}},   // WH Galaxy: 4 channels
+        {"WH_GALAXY_Y_TORUS", {{8, 4}, tt::tt_fabric::proto::Architecture::WORMHOLE_B0, 4}},   // WH Galaxy: 4 channels
+        {"WH_GALAXY_XY_TORUS", {{8, 4}, tt::tt_fabric::proto::Architecture::WORMHOLE_B0, 4}},  // WH Galaxy: 4 channels
+
+        // Blackhole architectures
+        {"P150_LB", {{2, 4}, tt::tt_fabric::proto::Architecture::BLACKHOLE, 4}},             // P150: 4 channels
+        {"P150_QB_AE_DEFAULT", {{2, 2}, tt::tt_fabric::proto::Architecture::BLACKHOLE, 4}},  // P150: 4 channels
+        {"P300_QB_GE", {{2, 2}, tt::tt_fabric::proto::Architecture::BLACKHOLE, 2}},          // P300: 2 channels
+        {"BH_GALAXY", {{8, 4}, tt::tt_fabric::proto::Architecture::BLACKHOLE, 2}},           // BH Galaxy: 2 channels
+        {"BH_GALAXY_X_TORUS", {{8, 4}, tt::tt_fabric::proto::Architecture::BLACKHOLE, 2}},   // BH Galaxy: 2 channels
+        {"BH_GALAXY_Y_TORUS", {{8, 4}, tt::tt_fabric::proto::Architecture::BLACKHOLE, 2}},   // BH Galaxy: 2 channels
+        {"BH_GALAXY_XY_TORUS", {{8, 4}, tt::tt_fabric::proto::Architecture::BLACKHOLE, 2}},  // BH Galaxy: 2 channels
+    };
+    return lookup;
+}
+
+// Helper function to recursively collect all host_ids from a GraphInstance
+void collect_host_ids(const proto::GraphInstance& instance, std::set<uint32_t>& host_ids) {
+    for (const auto& [child_name, child_mapping] : instance.child_mappings()) {
+        if (child_mapping.has_host_id()) {
+            // This is a leaf node with a host_id
+            host_ids.insert(child_mapping.host_id());
+        } else if (child_mapping.has_sub_instance()) {
+            // This is a nested graph, recurse into it
+            collect_host_ids(child_mapping.sub_instance(), host_ids);
+        }
+    }
+}
+
+// Helper function to find node type by traversing the graph template hierarchy
+std::string find_node_type_from_template(
+    const std::string& template_name, const proto::ClusterDescriptor& cluster_desc) {
+    auto it = cluster_desc.graph_templates().find(template_name);
+    if (it == cluster_desc.graph_templates().end()) {
+        throw std::runtime_error("Graph template '" + template_name + "' not found in cabling descriptor");
+    }
+
+    const auto& graph_template = it->second;
+
+    // Traverse children to find a node reference
+    for (const auto& child : graph_template.children()) {
+        if (child.has_node_ref()) {
+            // Found a node reference - this is the node type
+            return child.node_ref().node_descriptor();
+        } else if (child.has_graph_ref()) {
+            // Recurse into nested graph to find node type
+            return find_node_type_from_template(child.graph_ref().graph_template(), cluster_desc);
+        }
+    }
+
+    throw std::runtime_error("No node references found in graph template '" + template_name + "'");
+}
+
+std::vector<std::string> generate_hostnames(const size_t num_hosts) {
+    std::vector<std::string> hostnames;
+    hostnames.reserve(num_hosts);
+    for (size_t i = 0; i < num_hosts; ++i) {
+        hostnames.push_back("M" + std::to_string(i));
+    }
+    return hostnames;
+}
+
+std::unordered_map<std::string, std::unordered_map<std::string, uint32_t>> compute_intermesh_connections(
+    const std::vector<std::string>& hostnames, const std::vector<LogicalChannelConnection>& chip_connections) {
+    std::unordered_map<std::string, std::unordered_map<std::string, uint32_t>> intermesh_connections;
+
+    for (const auto& connection : chip_connections) {
+        if (connection.first.host_id == connection.second.host_id) {
+            continue;
+        }
+        intermesh_connections[hostnames[*connection.first.host_id]][hostnames[*connection.second.host_id]]++;
+    }
+
+    return intermesh_connections;
+}
+
+// Helper to extract cabling info from ClusterDescriptor protobuf
+CablingDescriptorInfo get_cabling_info_from_proto(const proto::ClusterDescriptor& cluster_desc) {
+    CablingDescriptorInfo info;
+
+    // Collect all host_ids from the root instance
+    if (cluster_desc.has_root_instance()) {
+        collect_host_ids(cluster_desc.root_instance(), info.host_ids);
+    }
+
+    if (info.host_ids.empty()) {
+        throw std::runtime_error("No host_ids found in cabling descriptor");
+    }
+
+    // Validate host IDs are contiguous and start from 0
+    uint32_t expected_max = info.host_ids.size() - 1;
+    uint32_t actual_max = *info.host_ids.rbegin();
+    if (actual_max != expected_max) {
+        throw std::runtime_error(
+            "Host IDs must be contiguous starting from 0. Found " + std::to_string(info.host_ids.size()) +
+            " hosts but max host_id is " + std::to_string(actual_max) + " (expected " + std::to_string(expected_max) +
+            ")");
+    }
+
+    info.num_hosts = info.host_ids.size();
+
+    // Extract node type from the root instance's template
+    if (cluster_desc.has_root_instance()) {
+        info.node_type = find_node_type_from_template(cluster_desc.root_instance().template_name(), cluster_desc);
+    }
+
+    return info;
+}
+
+}  // anonymous namespace
+
+// Internal helper that generates MGD, accepting an optional file path to avoid temp file creation
+static tt::tt_fabric::proto::MeshGraphDescriptor generate_mgd_impl(
+    const proto::ClusterDescriptor& cluster_desc, const std::optional<std::string>& cabling_file_path, bool verbose) {
+    // Extract cluster information from protobuf
+    auto cabling_info = get_cabling_info_from_proto(cluster_desc);
+
+    if (verbose) {
+        std::cout << "Found " << cabling_info.num_hosts << " host(s) with node type: " << cabling_info.node_type
+                  << '\n';
+        std::cout << "Host IDs: ";
+        for (const auto id : cabling_info.host_ids) {
+            std::cout << id << ' ';
+        }
+        std::cout << '\n';
+    }
+
+    // Generate hostnames based on the number of hosts
+    std::vector<std::string> hostnames = generate_hostnames(cabling_info.num_hosts);
+
+    // Create the cabling generator to get chip connections
+    auto cabling_descriptor = cabling_file_path.has_value()
+                                  ? CablingGenerator(*cabling_file_path, hostnames)  // Use file path directly
+                                  : CablingGenerator(cluster_desc, hostnames);  // Use protobuf directly (no file I/O)
+    auto chip_connections = cabling_descriptor.get_chip_connections();
+
+    if (verbose) {
+        std::cout << "Node type: " << cabling_info.node_type << '\n';
+    }
+
+    const auto intermesh_connections = compute_intermesh_connections(hostnames, chip_connections);
+
+    const size_t total_connections = [&intermesh_connections]() {
+        size_t count = 0;
+        for (const auto& [_, conn] : intermesh_connections) {
+            count += conn.size();
+        }
+        return count;
+    }();
+
+    if (verbose) {
+        std::cout << "Computed " << total_connections << " inter-mesh connection(s)\n";
+        for (const auto& [src_host, conn] : intermesh_connections) {
+            for (const auto& [dst_host, count] : conn) {
+                std::cout << "  " << src_host << " <-> " << dst_host << ": " << count << " channel(s)\n";
+            }
+        }
+    }
+
+    const auto& node_type_lookup = create_node_type_lookup();
+    tt::tt_fabric::proto::MeshGraphDescriptor mgd;
+
+    const auto it = node_type_lookup.find(cabling_info.node_type);
+    if (it == node_type_lookup.end()) {
+        // Build list of supported types from the actual map keys
+        std::string supported_types;
+        for (const auto& [type_name, _] : node_type_lookup) {
+            if (!supported_types.empty()) {
+                supported_types += ", ";
+            }
+            supported_types += type_name;
+        }
+        throw std::runtime_error(
+            "Unknown node type '" + cabling_info.node_type + "'. " + "Supported types: " + supported_types);
+    }
+
+    const auto& [device_dims, arch, channel_count] = it->second;
+
+    if (verbose) {
+        std::cout << "Architecture: " << tt::tt_fabric::proto::Architecture_Name(arch) << '\n';
+        std::cout << "Device topology: " << device_dims[0] << "x" << device_dims[1] << '\n';
+        std::cout << "Channels per connection: " << channel_count << '\n';
+    }
+
+    // Create a single mesh descriptor that will be reused for all instances
+    auto* mesh_desc = mgd.add_mesh_descriptors();
+    mesh_desc->set_name("Mesh");
+    mesh_desc->set_arch(arch);
+
+    // Set device topology
+    auto* device_topo = mesh_desc->mutable_device_topology();
+    for (int dim : device_dims) {
+        device_topo->add_dims(dim);
+    }
+
+    // Set host topology
+    auto* host_topo = mesh_desc->mutable_host_topology();
+    host_topo->add_dims(1);
+    host_topo->add_dims(1);
+
+    // Set channels using the value from the lookup table
+    auto* channels = mesh_desc->mutable_channels();
+    channels->set_count(channel_count);
+    channels->set_policy(tt::tt_fabric::proto::Policy::STRICT);
+
+    // Create graph descriptor
+    auto* graph_desc = mgd.add_graph_descriptors();
+    graph_desc->set_name("G0");
+    graph_desc->set_type("FABRIC");
+
+    // Add mesh instances (all using the same mesh descriptor)
+    for (size_t i = 0; i < cabling_info.num_hosts; ++i) {
+        auto* instance = graph_desc->add_instances();
+        auto* mesh_ref = instance->mutable_mesh();
+        mesh_ref->set_mesh_descriptor("Mesh");
+        mesh_ref->set_mesh_id(i);
+    }
+
+    // Add connections between meshes
+    for (const auto& [src_host, conn] : intermesh_connections) {
+        for (const auto& [dst_host, count] : conn) {
+            // Parse mesh ID from hostname (format: "M{id}")
+            // Since hostnames are generated as "M0", "M1", etc., we can extract the ID
+            int src_idx = std::stoi(src_host.substr(1));
+            int dst_idx = std::stoi(dst_host.substr(1));
+
+            auto* connection = graph_desc->add_connections();
+
+            // Add source node
+            auto* src_node = connection->add_nodes();
+            auto* src_mesh_ref = src_node->mutable_mesh();
+            src_mesh_ref->set_mesh_descriptor("Mesh");
+            src_mesh_ref->set_mesh_id(src_idx);
+
+            // Add destination node
+            auto* dst_node = connection->add_nodes();
+            auto* dst_mesh_ref = dst_node->mutable_mesh();
+            dst_mesh_ref->set_mesh_descriptor("Mesh");
+            dst_mesh_ref->set_mesh_id(dst_idx);
+
+            // Set channels (no policy for cleaner output)
+            auto* conn_channels = connection->mutable_channels();
+            conn_channels->set_count(count);
+        }
+    }
+
+    // Set top-level instance
+    auto* top_level = mgd.mutable_top_level_instance();
+    auto* graph_ref = top_level->mutable_graph();
+    graph_ref->set_graph_descriptor("G0");
+    graph_ref->set_graph_id(0);
+
+    if (verbose) {
+        std::cout << "Mesh Graph Descriptor successfully generated\n";
+        std::cout << "  Meshes: " << cabling_info.num_hosts << '\n';
+        std::cout << "  Connections: " << total_connections << '\n';
+    }
+
+    return mgd;
+}
+
+tt::tt_fabric::proto::MeshGraphDescriptor generate_mgd_from_cabling(
+    const proto::ClusterDescriptor& cluster_desc, bool verbose) {
+    // Call internal helper without file path (will use temp file)
+    return generate_mgd_impl(cluster_desc, std::nullopt, verbose);
+}
+
+tt::tt_fabric::proto::MeshGraphDescriptor generate_mgd_from_cabling(
+    const std::filesystem::path& cabling_descriptor_path, const bool verbose) {
+    if (std::ifstream file(cabling_descriptor_path); !file.is_open()) {
+        throw std::runtime_error("Cannot open cabling descriptor file: " + cabling_descriptor_path.string());
+    }
+
+    const std::string file_content = [&cabling_descriptor_path]() {
+        std::ifstream file(cabling_descriptor_path);
+        return std::string(std::istreambuf_iterator<char>(file), std::istreambuf_iterator<char>());
+    }();
+
+    proto::ClusterDescriptor cluster_desc;
+    if (!google::protobuf::TextFormat::ParseFromString(file_content, &cluster_desc)) {
+        throw std::runtime_error("Failed to parse cabling descriptor protobuf: " + cabling_descriptor_path.string());
+    }
+
+    if (verbose) {
+        std::cout << "Reading cabling descriptor: " << cabling_descriptor_path << '\n';
+    }
+
+    // Call internal helper with file path (avoids temp file creation)
+    return generate_mgd_impl(cluster_desc, cabling_descriptor_path.string(), verbose);
+}
+
+void write_mgd_to_file(const tt::tt_fabric::proto::MeshGraphDescriptor& mgd, const std::filesystem::path& output_path) {
+    if (mgd.mesh_descriptors_size() == 0 || mgd.graph_descriptors_size() == 0) {
+        throw std::runtime_error("Invalid MGD: missing mesh or graph descriptors");
+    }
+
+    const auto& mesh_desc = mgd.mesh_descriptors(0);
+    const auto& device_topo = mesh_desc.device_topology();
+    const auto& host_topo = mesh_desc.host_topology();
+    const auto& channels = mesh_desc.channels();
+    const auto& graph_desc = mgd.graph_descriptors(0);
+    const auto& top_level = mgd.top_level_instance();
+
+    std::ofstream mgd_file(output_path);
+    if (!mgd_file.is_open()) {
+        throw std::runtime_error("Failed to open file for writing: " + output_path.string());
+    }
+
+    // Write Meshes section
+    mgd_file << "# --- Meshes ---------------------------------------------------------------\n\n";
+    mgd_file << "mesh_descriptors {\n";
+    mgd_file << "  name: \"" << mesh_desc.name() << "\"\n";
+    mgd_file << "  arch: " << tt::tt_fabric::proto::Architecture_Name(mesh_desc.arch()) << "\n";
+    mgd_file << "  device_topology { dims: [ ";
+    for (int i = 0; i < device_topo.dims_size(); ++i) {
+        if (i > 0) {
+            mgd_file << ", ";
+        }
+        mgd_file << device_topo.dims(i);
+    }
+    mgd_file << " ] }\n";
+    mgd_file << "  host_topology   { dims: [ ";
+    for (int i = 0; i < host_topo.dims_size(); ++i) {
+        if (i > 0) {
+            mgd_file << ", ";
+        }
+        mgd_file << host_topo.dims(i);
+    }
+    mgd_file << " ] }\n";
+    mgd_file << "  channels {\n";
+    mgd_file << "    count: " << channels.count() << "\n";
+    mgd_file << "    policy: " << tt::tt_fabric::proto::Policy_Name(channels.policy()) << "\n";
+    mgd_file << "  }\n";
+    mgd_file << "}\n\n";
+
+    // Write Graphs section
+    mgd_file << "# --- Graphs ---------------------------------------------------------------\n\n";
+    mgd_file << "graph_descriptors {\n";
+    mgd_file << "  name: \"" << graph_desc.name() << "\"\n";
+    mgd_file << "  type: \"" << graph_desc.type() << "\"\n";
+
+    // Write instances comment
+    size_t num_instances = graph_desc.instances_size();
+    mgd_file << "  # Instances: mesh ids 0";
+    for (size_t i = 1; i < num_instances; ++i) {
+        mgd_file << "," << i;
+    }
+    mgd_file << " (all " << device_topo.dims(0) << "x" << device_topo.dims(1) << ")\n";
+
+    // Write instances
+    for (int i = 0; i < graph_desc.instances_size(); ++i) {
+        const auto& instance = graph_desc.instances(i);
+        mgd_file << "  instances { mesh { mesh_descriptor: \"" << instance.mesh().mesh_descriptor()
+                 << "\" mesh_id: " << instance.mesh().mesh_id() << " } }\n";
+    }
+
+    // Collect and sort connections for ordered output
+    struct ConnectionInfo {
+        int src_id;
+        int dst_id;
+        int channel_count;
+    };
+    std::vector<ConnectionInfo> sorted_connections;
+
+    for (int i = 0; i < graph_desc.connections_size(); ++i) {
+        const auto& connection = graph_desc.connections(i);
+        if (connection.nodes_size() == 2) {
+            int id1 = connection.nodes(0).mesh().mesh_id();
+            int id2 = connection.nodes(1).mesh().mesh_id();
+            sorted_connections.push_back({std::min(id1, id2), std::max(id1, id2), connection.channels().count()});
+        }
+    }
+
+    // Sort connections by source id first, then by destination id
+    std::sort(
+        sorted_connections.begin(), sorted_connections.end(), [](const ConnectionInfo& a, const ConnectionInfo& b) {
+            return (a.src_id != b.src_id) ? (a.src_id < b.src_id) : (a.dst_id < b.dst_id);
+        });
+
+    // Write sorted connections
+    mgd_file << "\n";
+    for (const auto& conn : sorted_connections) {
+        mgd_file << "  # M" << conn.src_id << " <-> M" << conn.dst_id << "\n";
+        mgd_file << "  connections {\n";
+        mgd_file << "    nodes { mesh { mesh_descriptor: \"" << mesh_desc.name() << "\" mesh_id: " << conn.src_id
+                 << " } }\n";
+        mgd_file << "    nodes { mesh { mesh_descriptor: \"" << mesh_desc.name() << "\" mesh_id: " << conn.dst_id
+                 << " } }\n";
+        mgd_file << "    channels { count: " << conn.channel_count << " }\n";
+        mgd_file << "  }\n";
+    }
+
+    mgd_file << "}\n\n";
+
+    // Write Instantiation section
+    mgd_file << "# --- Instantiation ----------------------------------------------------------\n";
+    mgd_file << "top_level_instance { graph { graph_descriptor: \"" << top_level.graph().graph_descriptor()
+             << "\" graph_id: " << top_level.graph().graph_id() << " } }\n";
+
+    mgd_file.close();
+}
+
+void generate_mesh_graph_descriptor(
+    const std::filesystem::path& cabling_descriptor_path,
+    const std::filesystem::path& output_path,
+    const bool verbose) {
+    const auto mgd = generate_mgd_from_cabling(cabling_descriptor_path, verbose);
+    write_mgd_to_file(mgd, output_path);
+
+    if (verbose) {
+        std::cout << "MGD written to: " << output_path << '\n';
+    }
+}
+
+}  // namespace tt::scaleout_tools

--- a/tools/scaleout/generate_mgd/generate_mgd.hpp
+++ b/tools/scaleout/generate_mgd/generate_mgd.hpp
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include <filesystem>
+#include <set>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <vector>
+
+#include <cabling_generator/cabling_generator.hpp>
+#include "protobuf/cluster_config.pb.h"
+#include "protobuf/mesh_graph_descriptor.pb.h"
+
+namespace tt::scaleout_tools {
+
+namespace proto = cabling_generator::proto;
+
+// Generate MGD from cabling descriptor protobuf object
+[[nodiscard]] tt::tt_fabric::proto::MeshGraphDescriptor generate_mgd_from_cabling(
+    const proto::ClusterDescriptor& cluster_desc, bool verbose = false);
+
+// Generate MGD from cabling descriptor file
+[[nodiscard]] tt::tt_fabric::proto::MeshGraphDescriptor generate_mgd_from_cabling(
+    const std::filesystem::path& cabling_descriptor_path, bool verbose = false);
+
+// Write MGD protobuf to file in textproto format
+void write_mgd_to_file(const tt::tt_fabric::proto::MeshGraphDescriptor& mgd, const std::filesystem::path& output_path);
+
+// Convenience function: generate and write MGD in one call
+void generate_mesh_graph_descriptor(
+    const std::filesystem::path& cabling_descriptor_path,
+    const std::filesystem::path& output_path,
+    bool verbose = false);
+
+}  // namespace tt::scaleout_tools

--- a/tools/scaleout/generate_mgd/generate_mgd_main.cpp
+++ b/tools/scaleout/generate_mgd/generate_mgd_main.cpp
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <filesystem>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+
+#include <cxxopts.hpp>
+
+#include "generate_mgd.hpp"
+
+int main(int argc, char* argv[]) {
+    cxxopts::Options options(
+        "generate_mgd", "Generate Mesh Graph Descriptors from cabling descriptors for fabric testing");
+
+    options.add_options()(
+        "c,cabling-descriptor-path", "Path to the cabling descriptor textproto file", cxxopts::value<std::string>())(
+        "o,output-path",
+        "Path to output MGD textproto file",
+        cxxopts::value<std::string>()->default_value("mesh_graph_descriptor.textproto"))(
+        "v,verbose", "Enable verbose output", cxxopts::value<bool>()->default_value("false")->implicit_value("true"))(
+        "h,help", "Print usage information");
+
+    try {
+        const auto result = options.parse(argc, argv);
+
+        if (result.count("help") || argc == 1) {
+            std::cout << options.help() << '\n';
+            return 0;
+        }
+
+        if (!result.count("cabling-descriptor-path")) {
+            throw std::invalid_argument("--cabling-descriptor-path is required");
+        }
+
+        const std::filesystem::path cabling_descriptor_path = result["cabling-descriptor-path"].as<std::string>();
+        const std::filesystem::path output_path = result["output-path"].as<std::string>();
+        const bool verbose = result["verbose"].as<bool>();
+
+        tt::scaleout_tools::generate_mesh_graph_descriptor(cabling_descriptor_path, output_path, verbose);
+        return 0;
+
+    } catch (const cxxopts::exceptions::exception& e) {
+        std::cerr << "Error parsing arguments: " << e.what() << '\n';
+        std::cerr << "Use --help for usage information\n";
+        return 1;
+    } catch (const std::exception& e) {
+        std::cerr << "Error: " << e.what() << '\n';
+        return 1;
+    }
+}

--- a/tools/tests/scaleout/cabling_descriptors/dual_t3k.textproto
+++ b/tools/tests/scaleout/cabling_descriptors/dual_t3k.textproto
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Dual T3K Configuration
+# 2 T3K nodes (each 2x4 Wormhole chips) connected together
+
+graph_templates {
+  key: "dual_t3k"
+  value {
+    children {
+      name: "t3k1"
+      node_ref { node_descriptor: "N300_LB_DEFAULT" }
+    }
+    children {
+      name: "t3k2"
+      node_ref { node_descriptor: "N300_LB_DEFAULT" }
+    }
+    internal_connections {
+      key: "QSFP_DD"
+      value {
+        # T3K1 to T3K2 connections (8 channels total, 2 per chip pair)
+        # N300 LB: tray 1/4 use port 2, tray 2/3 use port 1
+        connections {
+          port_a { path: ["t3k1"] tray_id: 1 port_id: 2 }
+          port_b { path: ["t3k2"] tray_id: 1 port_id: 2 }
+        }
+        connections {
+          port_a { path: ["t3k1"] tray_id: 2 port_id: 1 }
+          port_b { path: ["t3k2"] tray_id: 2 port_id: 1 }
+        }
+        connections {
+          port_a { path: ["t3k1"] tray_id: 3 port_id: 1 }
+          port_b { path: ["t3k2"] tray_id: 3 port_id: 1 }
+        }
+        connections {
+          port_a { path: ["t3k1"] tray_id: 4 port_id: 2 }
+          port_b { path: ["t3k2"] tray_id: 4 port_id: 2 }
+        }
+      }
+    }
+  }
+}
+
+# Root instance
+root_instance {
+  template_name: "dual_t3k"
+  child_mappings {
+    key: "t3k1"
+    value { host_id: 0 }
+  }
+  child_mappings {
+    key: "t3k2"
+    value { host_id: 1 }
+  }
+}


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/32258

### Problem description
- Mesh Graph Descriptors (MGDs) for multi-chip fabric topologies were manually written and maintained, making them error-prone and difficult to keep in sync with physical cabling configurations
- No automated way to generate MGDs from cabling descriptors, leading to potential inconsistencies between hardware setup and software configuration
- Lack of comprehensive testing to validate that generated MGDs correctly reflect the physical topology
- Manual MGD creation doesn't scale for complex topologies (e.g., 16-node ClosetBox with multiple superpods and inter-superpod connections)

### What's changed
Added generate_mgd tool:
- CLI tool that converts cabling descriptors to Mesh Graph Descriptors
- Automatically computes mesh instances, connections, and channel counts from physical topology
- Supports multiple node types (N300, P150, Galaxy, etc.)
- Provides file output and programmatic API

Added GTest validation suite:
- Tests MGD generation for 16-node ClosetBox topology and dual t3k, easily extendable to future topologies
- Validates mesh counts, architecture, and connection topology
- Verifies intra-superpod and inter-superpod connections

CMake and documentation:
- Added README with usage examples

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes