### PR TITLE
Fix perf degradation in tilize_with_val_padding

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/kernels/dataflow/reader_unary_pad_dims_split_rows_multicore.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/kernels/dataflow/reader_unary_pad_dims_split_rows_multicore.cpp
@@ -37,20 +37,22 @@ FORCE_INLINE void fill_with_val(uint32_t start_addr, uint32_t n_bytes, uint32_t 
 
     // For data-types smaller than 4Bytes, handle unaligned address
     if constexpr (val_size < 4) {
-        auto* start_ptr = reinterpret_cast<volatile tt_l1_ptr IntType*>(start_addr);
-        auto* end_ptr = reinterpret_cast<volatile tt_l1_ptr IntType*>(end_addr);
-        auto* start_ptr_4B = reinterpret_cast<volatile tt_l1_ptr IntType*>(start_addr_4B);
-        auto* end_ptr_4B = reinterpret_cast<volatile tt_l1_ptr IntType*>(start_addr_4B);
-        IntType val_ = static_cast<IntType>(val);
+        if (start_addr != start_addr_4B || end_addr != end_addr_4B) {
+            auto* start_ptr = reinterpret_cast<volatile tt_l1_ptr IntType*>(start_addr);
+            auto* end_ptr = reinterpret_cast<volatile tt_l1_ptr IntType*>(end_addr);
+            auto* start_ptr_4B = reinterpret_cast<volatile tt_l1_ptr IntType*>(start_addr_4B);
+            auto* end_ptr_4B = reinterpret_cast<volatile tt_l1_ptr IntType*>(start_addr_4B);
+            IntType val_ = static_cast<IntType>(val);
 
-        // Write from start_addr to start_addr_4B, if start_addr is unaligned to 4Bytes
-        for (auto* ptr = start_ptr; ptr < start_ptr_4B; ++ptr) {
-            *ptr = val_;
-        }
+            // Write from start_addr to start_addr_4B, if start_addr is unaligned to 4Bytes
+            for (auto* ptr = start_ptr; ptr < start_ptr_4B; ++ptr) {
+                *ptr = val_;
+            }
 
-        // Write from end_addr_4B to end_addr, if end_addr is unaligned to 4Bytes
-        for (auto* ptr = end_ptr_4B; ptr < end_ptr; ++ptr) {
-            *ptr = val_;
+            // Write from end_addr_4B to end_addr, if end_addr is unaligned to 4Bytes
+            for (auto* ptr = end_ptr_4B; ptr < end_ptr; ++ptr) {
+                *ptr = val_;
+            }
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/kernels/dataflow/reader_unary_pad_dims_split_rows_multicore.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/kernels/dataflow/reader_unary_pad_dims_split_rows_multicore.cpp
@@ -37,23 +37,23 @@ FORCE_INLINE void fill_with_val(uint32_t start_addr, uint32_t n_bytes, uint32_t 
 
     // For data-types smaller than 4Bytes, handle unaligned address
     if constexpr (val_size < 4) {
-        if (start_addr != start_addr_4B || end_addr != end_addr_4B) {
-            auto* start_ptr = reinterpret_cast<volatile tt_l1_ptr IntType*>(start_addr);
-            auto* end_ptr = reinterpret_cast<volatile tt_l1_ptr IntType*>(end_addr);
-            auto* start_ptr_4B = reinterpret_cast<volatile tt_l1_ptr IntType*>(start_addr_4B);
-            auto* end_ptr_4B = reinterpret_cast<volatile tt_l1_ptr IntType*>(start_addr_4B);
-            IntType val_ = static_cast<IntType>(val);
+        // if (start_addr != start_addr_4B || end_addr != end_addr_4B) {
+        auto* start_ptr = reinterpret_cast<volatile tt_l1_ptr IntType*>(start_addr);
+        auto* end_ptr = reinterpret_cast<volatile tt_l1_ptr IntType*>(end_addr);
+        auto* start_ptr_4B = reinterpret_cast<volatile tt_l1_ptr IntType*>(start_addr_4B);
+        auto* end_ptr_4B = reinterpret_cast<volatile tt_l1_ptr IntType*>(end_addr_4B);
+        IntType val_ = static_cast<IntType>(val);
 
-            // Write from start_addr to start_addr_4B, if start_addr is unaligned to 4Bytes
-            for (auto* ptr = start_ptr; ptr < start_ptr_4B; ++ptr) {
-                *ptr = val_;
-            }
-
-            // Write from end_addr_4B to end_addr, if end_addr is unaligned to 4Bytes
-            for (auto* ptr = end_ptr_4B; ptr < end_ptr; ++ptr) {
-                *ptr = val_;
-            }
+        // Write from start_addr to start_addr_4B, if start_addr is unaligned to 4Bytes
+        for (auto* ptr = start_ptr; ptr < start_ptr_4B; ++ptr) {
+            *ptr = val_;
         }
+
+        // Write from end_addr_4B to end_addr, if end_addr is unaligned to 4Bytes
+        for (auto* ptr = end_ptr_4B; ptr < end_ptr; ++ptr) {
+            *ptr = val_;
+        }
+        // }
     }
 }
 


### PR DESCRIPTION
### Ticket
Link to Github Issue - N/A
Failing pipeline: https://github.com/tenstorrent/tt-metal/actions/runs/19293751512/job/55171139366

### Problem description
PR https://github.com/tenstorrent/tt-metal/pull/31609 fixes a functional issue when L1 address is unaligned to 4bytes ... and there was a typo in this code which introduced extra unnecessary loop iterations.

### What's changed
Fixed typo.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/19375350120)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/19375364597)
- [x] [T3K demo](https://github.com/tenstorrent/tt-metal/actions/runs/19378532026)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/runs/19377886786)

Reference run of [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/runs/19371269385) with my previous PR reverted.