### PR TITLE
fix page size for dram ubench

### DIFF
--- a/tests/scripts/test_moreh_microbenchmark.py
+++ b/tests/scripts/test_moreh_microbenchmark.py
@@ -767,9 +767,9 @@ def test_matmul_single_core_sharded(
         ("wormhole_b0", np.array([32768, 12 * 128]), 1, 8, 1, 12, 0),
         ("wormhole_b0", np.array([32768, 12 * 256]), 1, 8, 2, 12, 0),
         ("wormhole_b0", np.array([2048, 3840]), 1, 4, 1, 12, 0),  # Padded FF1 shapes for llama 70b on TG
-        ("blackhole", np.array([32768, 8 * 128]), 1, 8, 0, 8, 0),
-        ("blackhole", np.array([32768, 8 * 128]), 1, 8, 1, 8, 0),
-        ("blackhole", np.array([32768, 8 * 256]), 1, 8, 2, 8, 0),
+        ("blackhole", np.array([16 * 32768, 8 * 128]), 1, 16 * 8, 0, 8, 0),
+        ("blackhole", np.array([16 * 32768, 8 * 128]), 1, 16 * 8, 1, 8, 0),
+        ("blackhole", np.array([16 * 32768, 8 * 256]), 1, 16 * 8, 2, 8, 0),
         ("blackhole", np.array([2048, 3840]), 1, 4, 1, 8, 0),  # Padded FF1 shapes for llama 70b on TG
     ],
 )

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/8_dram_adjacent_core_read/kernels/reader_dram.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/8_dram_adjacent_core_read/kernels/reader_dram.cpp
@@ -15,6 +15,7 @@ void kernel_main() {
     constexpr uint32_t num_pages = get_compile_time_arg_val(3);
     constexpr uint32_t block_num_tiles = get_compile_time_arg_val(4);
     constexpr uint32_t page_size = get_compile_time_arg_val(5);
+    constexpr uint32_t last_page_size = get_compile_time_arg_val(6);
 
     const uint32_t bank_id = get_arg_val<uint32_t>(0);
     const uint32_t vc = get_arg_val<uint32_t>(1);
@@ -38,10 +39,19 @@ void kernel_main() {
         noc_async_read_tile_dram_sharded_set_trid(curr_block_trid);
 
         for (uint32_t h = 0; h < num_pages; ++h) {
+            uint32_t current_page_size = page_size;
+            if constexpr (last_page_size != page_size) {
+                if (h == num_pages - 1) {
+                    current_page_size = last_page_size;
+                }
+                // Set state for current page size
+                noc_async_read_one_packet_set_state<true>(src_base_addr, current_page_size, vc);
+            }
+
             noc_async_read_tile_dram_sharded_with_state_with_trid(
                 src_base_addr, l1_read_addr, l1_write_addr, curr_block_trid);
-            l1_read_addr += page_size;
-            l1_write_addr += page_size;
+            l1_read_addr += current_page_size;
+            l1_write_addr += current_page_size;
         }
 
         if (num_free_blocks_in_buffer == 2) {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/8_dram_adjacent_core_read/test_dram_read.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/8_dram_adjacent_core_read/test_dram_read.cpp
@@ -88,14 +88,35 @@ std::vector<T> slice_vec(std::vector<T> const& v, int m, int n) {
     return vec;
 }
 
-void get_max_page_size_and_num_pages(uint32_t num_tiles, uint32_t tile_size, uint32_t& page_size, uint32_t& num_pages) {
+// Returns max_page_size (for non-last pages), num_pages, and last_page_size
+std::tuple<uint32_t, uint32_t, uint32_t> get_max_page_size_and_num_pages(
+    uint32_t num_tiles, uint32_t tile_size, tt::ARCH arch) {
     uint64_t total_size = static_cast<uint64_t>(num_tiles) * tile_size;
 
-    page_size = (8192 / tile_size) * tile_size;
-    while (total_size % page_size != 0 && page_size >= tile_size) {
-        page_size -= tile_size;
+    // NOC_MAX_BURST_SIZE depends on architecture:
+    // - Wormhole B0: NOC_MAX_BURST_WORDS (256) * NOC_WORD_BYTES (256/8 = 32) = 8192 bytes
+    // - Blackhole: NOC_MAX_BURST_WORDS (256) * NOC_WORD_BYTES (512/8 = 64) = 16384 bytes
+    uint32_t max_noc_burst_size;
+    if (arch == tt::ARCH::WORMHOLE_B0) {
+        max_noc_burst_size = 8192;
+    } else if (arch == tt::ARCH::BLACKHOLE) {
+        max_noc_burst_size = 16384;
+    } else {
+        TT_THROW("unknown architecture: {}", arch);
     }
-    num_pages = total_size / page_size;
+
+    // Align max_noc_burst_size down to tile_size boundaries
+    uint32_t max_page_size = (max_noc_burst_size / tile_size) * tile_size;
+
+    if (total_size <= max_page_size) {
+        // If total size fits in one page, use it
+        return {total_size, 1, total_size};
+    } else {
+        // Use max_page_size for all pages except the last one
+        uint32_t num_pages = (total_size + max_page_size - 1) / max_page_size;
+        uint32_t last_page_size = total_size - (num_pages - 1) * max_page_size;
+        return {max_page_size, num_pages, last_page_size};
+    }
 }
 
 std::tuple<tt_metal::Program, tt_metal::KernelHandle, uint32_t> create_program(
@@ -123,8 +144,10 @@ std::tuple<tt_metal::Program, tt_metal::KernelHandle, uint32_t> create_program(
 
     uint32_t cb_index = 0;
     uint32_t cb_size = block_h * block_w * single_tile_size;
-    uint32_t page_size, num_pages;
-    get_max_page_size_and_num_pages(block_num_tiles, single_tile_size, page_size, num_pages);
+    auto [page_size, num_pages, last_page_size] =
+        get_max_page_size_and_num_pages(block_num_tiles, single_tile_size, device->arch());
+
+    log_info(tt::LogTest, "page_size: {}, num_pages: {}, last_page_size: {}", page_size, num_pages, last_page_size);
 
     uint32_t cb_addr = device->allocator()->get_base_allocator_addr(HalMemType::L1);
     tt_metal::CircularBufferConfig cb_config =
@@ -137,7 +160,8 @@ std::tuple<tt_metal::Program, tt_metal::KernelHandle, uint32_t> create_program(
         (std::uint32_t)num_blocks,
         (std::uint32_t)num_pages,
         (std::uint32_t)block_num_tiles,
-        (std::uint32_t)page_size};
+        (std::uint32_t)page_size,
+        (std::uint32_t)last_page_size};
 
     auto reader_kernel = tt_metal::CreateKernel(
         program,
@@ -402,6 +426,16 @@ int main(int argc, char** argv) {
         CoreRangeSet all_cores;
         std::vector<CoreCoord> all_cores_list;
         get_optimal_dram_bank_to_reader_assignment(device.get(), all_cores_list, all_cores, tt_metal::NOC::NOC_0);
+
+        // Slice all_cores_list to only use the first num_banks cores
+        all_cores_list = slice_vec(all_cores_list, bank_start_id, bank_start_id + num_banks - 1);
+
+        // Rebuild all_cores CoreRangeSet with only the selected cores
+        std::set<CoreRange> selected_cores_set;
+        for (const auto& core : all_cores_list) {
+            selected_cores_set.insert(CoreRange(core));
+        }
+        all_cores = CoreRangeSet(selected_cores_set);
 
         uint32_t num_tiles_per_core = num_tiles / num_cores;
         uint32_t num_tiles_cb = num_tiles_per_core / num_blocks;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/8_dram_adjacent_core_read/test_dram_read.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/8_dram_adjacent_core_read/test_dram_read.cpp
@@ -114,7 +114,7 @@ std::tuple<uint32_t, uint32_t, uint32_t> get_max_page_size_and_num_pages(
     } else {
         // Use max_page_size for all pages except the last one
         uint32_t num_pages = (total_size + max_page_size - 1) / max_page_size;
-        uint32_t last_page_size = total_size - (num_pages - 1) * max_page_size;
+        uint32_t last_page_size = total_size - ((num_pages - 1) * max_page_size);
         return {max_page_size, num_pages, last_page_size};
     }
 }


### PR DESCRIPTION
### Problem description
Discovered the wrong page size used for BH during testing, fix it.

### What's changed
calculate page size by non last and last page size
add more iterations to dram test, so we can saturate to ~512GB/s with syseng latest FW.

### Checklist
- [x] ubench https://github.com/tenstorrent/tt-metal/actions/runs/19376987464