### PR TITLE
Fix fabric test infra skip logic

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric.cpp
@@ -148,8 +148,8 @@ int main(int argc, char** argv) {
         if (!cmdline_parser.check_filter(test_config, true)) {
             log_info(tt::LogTest, "Skipping Test Group: {} due to filter policy", test_config.name);
             continue;
-        } else if (builder.should_skip_test(test_config)) {
-            log_info(tt::LogTest, "Skipping Test Group: {} due to skip policy", test_config.name);
+        } else if (builder.should_skip_test_on_platform(test_config)) {
+            log_info(tt::LogTest, "Skipping Test Group: {} due to platform skip policy", test_config.name);
             continue;
         }
         log_info(tt::LogTest, "Running Test Group: {}", test_config.name);
@@ -172,6 +172,13 @@ int main(int argc, char** argv) {
         if (!open_devices_success) {
             log_warning(
                 tt::LogTest, "Skipping Test Group: {} due to unsupported fabric configuration", test_config.name);
+            continue;
+        }
+
+        // Check topology-based skip conditions after devices are opened
+        if (builder.should_skip_test_on_topology(test_config)) {
+            log_info(tt::LogTest, "Skipping Test Group: {} due to topology skip policy", test_config.name);
+            test_context.close_devices();
             continue;
         }
         tests_ran++;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_config.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_config.hpp
@@ -409,10 +409,8 @@ public:
 
         return built_tests;
     }
-    // Helper function to check if a test should be skipped based on:
-    // 1. topology and device count
-    // 2. architecture or cluster type
-    bool should_skip_test(const ParsedTestConfig& test_config) const {
+    // Helper function to check if a test should be skipped based on architecture or cluster type.
+    bool should_skip_test_on_platform(const ParsedTestConfig& test_config) const {
         // Skip if the test declares platforms to skip and this platform matches
         if (test_config.skip.has_value()) {
             // Determine current platform identifiers
@@ -426,6 +424,11 @@ public:
                 }
             }
         }
+        return false;
+    }
+
+    // Helper function to check if a test should be skipped based on topology incompatibilities.
+    bool should_skip_test_on_topology(const ParsedTestConfig& test_config) const {
         if (test_config.fabric_setup.topology == Topology::Ring) {
             uint32_t num_devices = device_info_provider_.get_local_node_ids().size();
             if (num_devices < MIN_RING_TOPOLOGY_DEVICES) {


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
We are currently skipping tests in the fabric test infra due to comparing based on the local node ids, but before any devices have been initialized, as can be seen here in test_fabric_deadlock_stability_6U_galaxy.yaml where the ring topology tests get skipped despite running on a 6u.

### What's changed
Separated the skip function into two separate parts to preserve functionality, one for yaml based skips and one for the ring topology skip.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/19378485977
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [x] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes