### PR TITLE
[skip ci] Fix mesh graph descriptor extension

### DIFF
--- a/.github/workflows/t3000-nightly-tests-impl.yaml
+++ b/.github/workflows/t3000-nightly-tests-impl.yaml
@@ -25,7 +25,7 @@ jobs:
         test-group: [
           { name: "t3k_ccl_tests", arch: wormhole_b0, cmd: pytest -n auto tests/nightly/t3000/ccl, timeout: 90, owner_id: U05ACKAJTHS}, # Naif Tarafdar
           # TODO: Separated from the suite above due to issues switching between fabric configs and needing to use a custom mesh descriptor
-          { name: "t3k_ccl_2d_tests", arch: wormhole_b0, cmd: TT_MESH_GRAPH_DESC_PATH=tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_1x8_mesh_graph_descriptor.yaml pytest -n auto tests/nightly/t3000/2d_ccl, timeout: 10, owner_id: U013121KDH9}, # Austin Ho
+          { name: "t3k_ccl_2d_tests", arch: wormhole_b0, cmd: TT_MESH_GRAPH_DESC_PATH=tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_1x8_mesh_graph_descriptor.textproto pytest -n auto tests/nightly/t3000/2d_ccl, timeout: 10, owner_id: U013121KDH9}, # Austin Ho
           { name: "t3k_fabric_unit_tests", arch: wormhole_b0, cmd: build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="NightlyFabric*Fixture.*", timeout: 30, owner_id: U08UBDUKH6Z}, # Neel Nyamagoudar
           { name: "t3k_dispatch_unit_tests", arch: wormhole_b0, cmd: build/test/tt_metal/unit_tests_dispatch --gtest_filter="Large*.NIGHTLY_DRAMReadback/*", timeout: 15, owner_id: U07R05K4WGJ}, # John Bauman
           {


### PR DESCRIPTION
Mesh graph descriptor yaml file was deprecated which resulted in ccl_2d tests to fail. Change filename in t3k nightly pipeline.