### PR TITLE
Add TTT Qwen 3 32b to BH demo CI pipelines

### DIFF
--- a/.github/workflows/blackhole-multi-card-demo-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-demo-tests-impl.yaml
@@ -154,27 +154,27 @@ jobs:
       fail-fast: false
       matrix:
         test-group:
-          - name: "llama3.3-70b batch-32 performance"
+          - name: "llama3.3-70b ${{ inputs.runner-label }} batch-32 performance"
             arch: blackhole
             cmd: HF_MODEL=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.3-70B-Instruct TT_CACHE_PATH=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.3-70B-Instruct pytest models/tt_transformers/demo/simple_text_demo.py -k "performance and ci-32"
             owner_id: U03PUAKE719 # Miguel Tairum
-          - name: "llama3.3-70b batch-1 TP device perf prefill"
+          - name: "llama3.3-70b ${{ inputs.runner-label }} batch-1 TP device perf prefill"
             arch: blackhole
             cmd: HF_MODEL=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.3-70B-Instruct pytest models/tt_transformers/tests/test_device_perf.py -k "prefill-llama3_70b-2-1024-2-10-1-1-False"
             owner_id: U08GELBB1AP # Ambrose Ling
-          - name: "llama3.3-70b batch-1 TP device perf decode"
+          - name: "llama3.3-70b ${{ inputs.runner-label }} batch-1 TP device perf decode"
             arch: blackhole
             cmd: HF_MODEL=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.3-70B-Instruct pytest models/tt_transformers/tests/test_device_perf.py -k "decode-llama3_70b-2-1024-2-10-1-1-False"
             owner_id: U08GELBB1AP # Ambrose Ling
-          - name: "qwen3-32b batch-32 TP device perf prefill"
+          - name: "qwen3-32b ${{ inputs.runner-label }} batch-32 TP device perf prefill"
             arch: blackhole
             cmd: HF_MODEL=/localdev/blackhole_demos/huggingface_data/Qwen/Qwen3-32B TT_CACHE_PATH=/localdev/blackhole_demos/huggingface_data/Qwen/Qwen3-32B pytest models/tt_transformers/demo/simple_text_demo.py -k "performance and ci-32"
             owner_id: U08GELBB1AP # Ambrose Ling
-          - name: "qwen3-32b batch-1 TP device perf prefill"
+          - name: "qwen3-32b ${{ inputs.runner-label }} batch-1 TP device perf prefill"
             arch: blackhole
             cmd: HF_MODEL=/localdev/blackhole_demos/huggingface_data/Qwen/Qwen3-32B pytest models/tt_transformers/tests/test_device_perf.py -k "prefill-llama3_70b-2-1024-2-10-1-1-False"
             owner_id: U08GELBB1AP # Ambrose Ling
-          - name: "qwen3-32b batch-1 TP device perf decode"
+          - name: "qwen3-32b ${{ inputs.runner-label }} batch-1 TP device perf decode"
             arch: blackhole
             cmd: HF_MODEL=/localdev/blackhole_demos/huggingface_data/Qwen/Qwen3-32B pytest models/tt_transformers/tests/test_device_perf.py -k "decode-llama3_70b-2-1024-2-10-1-1-False"
             owner_id: U08GELBB1AP # Ambrose Ling

--- a/.github/workflows/blackhole-multi-card-demo-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-demo-tests-impl.yaml
@@ -172,11 +172,11 @@ jobs:
             owner_id: U08GELBB1AP # Ambrose Ling
           - name: "qwen3-32b ${{ inputs.runner-label }} batch-1 TP device perf prefill"
             arch: blackhole
-            cmd: HF_MODEL=/localdev/blackhole_demos/huggingface_data/Qwen/Qwen3-32B pytest models/tt_transformers/tests/test_device_perf.py -k "prefill-llama3_70b-2-1024-2-10-1-1-False"
+            cmd: HF_MODEL=/localdev/blackhole_demos/huggingface_data/Qwen/Qwen3-32B pytest models/tt_transformers/tests/test_device_perf.py -k "prefill-qwen3_32b-2-1024-2-10-1-1-False"
             owner_id: U08GELBB1AP # Ambrose Ling
           - name: "qwen3-32b ${{ inputs.runner-label }} batch-1 TP device perf decode"
             arch: blackhole
-            cmd: HF_MODEL=/localdev/blackhole_demos/huggingface_data/Qwen/Qwen3-32B pytest models/tt_transformers/tests/test_device_perf.py -k "decode-llama3_70b-2-1024-2-10-1-1-False"
+            cmd: HF_MODEL=/localdev/blackhole_demos/huggingface_data/Qwen/Qwen3-32B pytest models/tt_transformers/tests/test_device_perf.py -k "decode-qwen3_32b-2-1024-2-10-1-1-False"
             owner_id: U08GELBB1AP # Ambrose Ling
     name: ${{ matrix.test-group.name }}
     runs-on:

--- a/.github/workflows/blackhole-multi-card-demo-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-demo-tests-impl.yaml
@@ -166,7 +166,7 @@ jobs:
             arch: blackhole
             cmd: HF_MODEL=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.3-70B-Instruct pytest models/tt_transformers/tests/test_device_perf.py -k "decode-llama3_70b-2-1024-2-10-1-1-False"
             owner_id: U08GELBB1AP # Ambrose Ling
-          - name: "qwen3-32b ${{ inputs.runner-label }} batch-32 TP device perf prefill"
+          - name: "qwen3-32b ${{ inputs.runner-label }} batch-32 performance"
             arch: blackhole
             cmd: HF_MODEL=/localdev/blackhole_demos/huggingface_data/Qwen/Qwen3-32B TT_CACHE_PATH=/localdev/blackhole_demos/huggingface_data/Qwen/Qwen3-32B pytest models/tt_transformers/demo/simple_text_demo.py -k "performance and ci-32"
             owner_id: U08GELBB1AP # Ambrose Ling

--- a/.github/workflows/blackhole-multi-card-demo-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-demo-tests-impl.yaml
@@ -154,17 +154,29 @@ jobs:
       fail-fast: false
       matrix:
         test-group:
-          - name: "llama3.3-70b ${{ inputs.runner-label }} batch-32 performance"
+          # - name: "llama3.3-70b batch-32 performance"
+          #   arch: blackhole
+          #   cmd: HF_MODEL=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.3-70B-Instruct TT_CACHE_PATH=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.3-70B-Instruct pytest models/tt_transformers/demo/simple_text_demo.py -k "performance and ci-32"
+          #   owner_id: U03PUAKE719 # Miguel Tairum
+          # - name: "llama3.3-70b batch-1 TP device perf prefill"
+          #   arch: blackhole
+          #   cmd: HF_MODEL=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.3-70B-Instruct pytest models/tt_transformers/tests/test_device_perf.py -k "prefill-llama3_70b-2-1024-2-10-1-1-False"
+          #   owner_id: U08GELBB1AP # Ambrose Ling
+          # - name: "llama3.3-70b batch-1 TP device perf decode"
+          #   arch: blackhole
+          #   cmd: HF_MODEL=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.3-70B-Instruct pytest models/tt_transformers/tests/test_device_perf.py -k "decode-llama3_70b-2-1024-2-10-1-1-False"
+          #   owner_id: U08GELBB1AP # Ambrose Ling
+          - name: "qwen3-32b batch-32 TP device perf prefill"
             arch: blackhole
-            cmd: HF_MODEL=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.3-70B-Instruct TT_CACHE_PATH=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.3-70B-Instruct pytest models/tt_transformers/demo/simple_text_demo.py -k "performance and ci-32"
-            owner_id: U03PUAKE719 # Miguel Tairum
-          - name: "llama3.3-70b ${{ inputs.runner-label }} batch-1 TP device perf prefill (layers=2)"
-            arch: blackhole
-            cmd: HF_MODEL=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.3-70B-Instruct pytest models/tt_transformers/tests/test_device_perf.py -k "prefill-llama3_70b-2-1024-2-2-1-1-False"
+            cmd: HF_MODEL=/localdev/blackhole_demos/huggingface_data/Qwen/Qwen3-32B TT_CACHE_PATH=/localdev/blackhole_demos/huggingface_data/Qwen/Qwen3-32B pytest models/tt_transformers/demo/simple_text_demo.py -k "performance and ci-32"
             owner_id: U08GELBB1AP # Ambrose Ling
-          - name: "llama3.3-70b ${{ inputs.runner-label }} batch-1 TP device perf decode (layers=10)"
+          - name: "qwen3-32b batch-1 TP device perf prefill"
             arch: blackhole
-            cmd: HF_MODEL=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.3-70B-Instruct pytest models/tt_transformers/tests/test_device_perf.py -k "decode-llama3_70b-2-1024-2-10-1-1-False"
+            cmd: HF_MODEL=/localdev/blackhole_demos/huggingface_data/Qwen/Qwen3-32B pytest models/tt_transformers/tests/test_device_perf.py -k "prefill-llama3_70b-2-1024-2-10-1-1-False"
+            owner_id: U08GELBB1AP # Ambrose Ling
+          - name: "qwen3-32b batch-1 TP device perf decode"
+            arch: blackhole
+            cmd: HF_MODEL=/localdev/blackhole_demos/huggingface_data/Qwen/Qwen3-32B pytest models/tt_transformers/tests/test_device_perf.py -k "decode-llama3_70b-2-1024-2-10-1-1-False"
             owner_id: U08GELBB1AP # Ambrose Ling
     name: ${{ matrix.test-group.name }}
     runs-on:

--- a/.github/workflows/blackhole-multi-card-demo-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-demo-tests-impl.yaml
@@ -158,11 +158,11 @@ jobs:
             arch: blackhole
             cmd: HF_MODEL=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.3-70B-Instruct TT_CACHE_PATH=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.3-70B-Instruct pytest models/tt_transformers/demo/simple_text_demo.py -k "performance and ci-32"
             owner_id: U03PUAKE719 # Miguel Tairum
-          - name: "llama3.3-70b ${{ inputs.runner-label }} batch-1 TP device perf prefill"
+          - name: "llama3.3-70b ${{ inputs.runner-label }} batch-1 TP device perf prefill (layers=2)"
             arch: blackhole
             cmd: HF_MODEL=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.3-70B-Instruct pytest models/tt_transformers/tests/test_device_perf.py -k "prefill-llama3_70b-2-1024-2-10-1-1-False"
             owner_id: U08GELBB1AP # Ambrose Ling
-          - name: "llama3.3-70b ${{ inputs.runner-label }} batch-1 TP device perf decode"
+          - name: "llama3.3-70b ${{ inputs.runner-label }} batch-1 TP device perf decode (layers=10)"
             arch: blackhole
             cmd: HF_MODEL=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.3-70B-Instruct pytest models/tt_transformers/tests/test_device_perf.py -k "decode-llama3_70b-2-1024-2-10-1-1-False"
             owner_id: U08GELBB1AP # Ambrose Ling

--- a/.github/workflows/blackhole-multi-card-demo-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-demo-tests-impl.yaml
@@ -154,18 +154,18 @@ jobs:
       fail-fast: false
       matrix:
         test-group:
-          # - name: "llama3.3-70b batch-32 performance"
-          #   arch: blackhole
-          #   cmd: HF_MODEL=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.3-70B-Instruct TT_CACHE_PATH=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.3-70B-Instruct pytest models/tt_transformers/demo/simple_text_demo.py -k "performance and ci-32"
-          #   owner_id: U03PUAKE719 # Miguel Tairum
-          # - name: "llama3.3-70b batch-1 TP device perf prefill"
-          #   arch: blackhole
-          #   cmd: HF_MODEL=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.3-70B-Instruct pytest models/tt_transformers/tests/test_device_perf.py -k "prefill-llama3_70b-2-1024-2-10-1-1-False"
-          #   owner_id: U08GELBB1AP # Ambrose Ling
-          # - name: "llama3.3-70b batch-1 TP device perf decode"
-          #   arch: blackhole
-          #   cmd: HF_MODEL=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.3-70B-Instruct pytest models/tt_transformers/tests/test_device_perf.py -k "decode-llama3_70b-2-1024-2-10-1-1-False"
-          #   owner_id: U08GELBB1AP # Ambrose Ling
+          - name: "llama3.3-70b batch-32 performance"
+            arch: blackhole
+            cmd: HF_MODEL=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.3-70B-Instruct TT_CACHE_PATH=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.3-70B-Instruct pytest models/tt_transformers/demo/simple_text_demo.py -k "performance and ci-32"
+            owner_id: U03PUAKE719 # Miguel Tairum
+          - name: "llama3.3-70b batch-1 TP device perf prefill"
+            arch: blackhole
+            cmd: HF_MODEL=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.3-70B-Instruct pytest models/tt_transformers/tests/test_device_perf.py -k "prefill-llama3_70b-2-1024-2-10-1-1-False"
+            owner_id: U08GELBB1AP # Ambrose Ling
+          - name: "llama3.3-70b batch-1 TP device perf decode"
+            arch: blackhole
+            cmd: HF_MODEL=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.3-70B-Instruct pytest models/tt_transformers/tests/test_device_perf.py -k "decode-llama3_70b-2-1024-2-10-1-1-False"
+            owner_id: U08GELBB1AP # Ambrose Ling
           - name: "qwen3-32b batch-32 TP device perf prefill"
             arch: blackhole
             cmd: HF_MODEL=/localdev/blackhole_demos/huggingface_data/Qwen/Qwen3-32B TT_CACHE_PATH=/localdev/blackhole_demos/huggingface_data/Qwen/Qwen3-32B pytest models/tt_transformers/demo/simple_text_demo.py -k "performance and ci-32"

--- a/models/tt_transformers/tests/test_device_perf.py
+++ b/models/tt_transformers/tests/test_device_perf.py
@@ -31,7 +31,7 @@ from tools.tracy.process_model_log import get_latest_ops_log_filename
 @pytest.mark.parametrize("num_runs", [2])
 @pytest.mark.parametrize("max_seq_len", [1024])
 @pytest.mark.parametrize("max_generated_tokens", [2])
-@pytest.mark.parametrize("model_name", ["llama3_70b", "llama3_8b"])  # Add more models here as needed
+@pytest.mark.parametrize("model_name", ["llama3_70b", "llama3_8b", "qwen3_32b"])  # Add more models here as needed
 @pytest.mark.parametrize("mode", ["prefill", "decode"])
 def test_device_perf_one_iter(
     num_layers,


### PR DESCRIPTION
### Ticket
Part of https://github.com/tenstorrent/tt-metal/issues/25016

### Problem description
To complete model qualification for Qwen and consistently keep track of perf measurements for Qwen we add it to BH demo ci

### What's changed
- updated yaml file to add qwen batch 32 perf test and device perf tests

### Checklist
- [ ] [BH demo CI](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-multi-card-demo-tests.yaml) all passing, only failure is a machine failure irrelevant to these changes