### PR TITLE
fix: duplicate haloize mode reset code from tt-metal

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_A_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_A_api.h
@@ -64,7 +64,6 @@ inline void llk_unpack_A_init(
     const std::uint32_t transpose_of_faces = 0,
     const std::uint32_t within_face_16x16_transpose = 0,
     const std::uint32_t operand = 0) {
-    cfg_reg_rmw_tensix<THCON_SEC0_REG2_Haloize_mode_RMW>(within_face_16x16_transpose);
 
     const std::uint32_t operand_id = get_operand_id(operand);
     const std::uint32_t face_r_dim = get_operand_face_r_dim(operand_id);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_A_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_A_api.h
@@ -64,7 +64,6 @@ inline void llk_unpack_A_init(
     const std::uint32_t transpose_of_faces = 0,
     const std::uint32_t within_face_16x16_transpose = 0,
     const std::uint32_t operand = 0) {
-    cfg_reg_rmw_tensix<THCON_SEC0_REG2_Haloize_mode_RMW>(within_face_16x16_transpose);
 
     const std::uint32_t operand_id = get_operand_id(operand);
     const std::uint32_t face_r_dim = get_operand_face_r_dim(operand_id);


### PR DESCRIPTION
### Ticket
None

### Problem description

This PR removes duplicate haloize mode reset code from TT-metal that [has been moved](https://github.com/tenstorrent/tt-llk/pull/825) to the llk library. The change addresses test failures that occurred after randomizing test execution order, which revealed that the haloize mode reset needed to exist in the llk library. Now that the functionality exists there, this duplicate code in TT-metal can be safely removed.

### What's changed

Resetting the haloize mode has been moved into the LLK method. We discovered it was missing when some tests began failing after we randomized the test execution order. After adding the fix to our LLK code, we noticed that TT-Metal already contained a similar patch. Since this logic now lives in the LLK library, we’d like to remove the duplicate from TT-Metal.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/19388022015) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/19388015600) CI with demo tests passes (if applicable)
- [x] [C++ tests](https://github.com/tenstorrent/tt-metal/actions/runs/19389593957/job/55482979839) pass