### PR TITLE
Fixing Underflow in BufferCorePageMapping::Iterator::next_range

### DIFF
--- a/tt_metal/impl/buffers/buffer_page_mapping.cpp
+++ b/tt_metal/impl/buffers/buffer_page_mapping.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <tt-metalium/buffer_page_mapping.hpp>
+#include <iostream>
 
 namespace tt::tt_metal {
 
@@ -169,14 +170,47 @@ BufferCorePageMapping::Iterator::Range BufferCorePageMapping::Iterator::next_ran
         return result;
     }
     const auto& host_range = mapping_->host_ranges[range_index_];
+    // std::cout<<"range_index_: "<<range_index_<<std::endl;
+    // if (device_page_offset_ < host_range.device_page_offset) {  // we are in padding.
+    //     device_page_offset_ = host_range.device_page_offset;
+    //     // std::cout<<"AAAAAAAAAAAAAAA\n";
+    // }
+    std::cout << "device_page_offset_: " << device_page_offset_
+              << " host_range.host_page_start: " << host_range.host_page_start
+              << " host_range.device_page_offset: " << host_range.device_page_offset
+              << " host_range.num_pages: " << host_range.num_pages << std::endl;
     uint32_t num_pages_left = host_range.num_pages - (device_page_offset_ - host_range.device_page_offset);
     uint32_t num_pages = std::min(num_pages_left, end_device_page_offset - device_page_offset_);
+    // if (device_page_offset_ < host_range.device_page_offset) {  // we are in padding.
+    //     device_page_offset_ = host_range.device_page_offset;
+    //     // std::cout<<"AAAAAAAAAAAAAAA\n";
+    // }
+    // bool reached_padding = (device_page_offset_ < host_range.device_page_offset) ? true : false;
+
+    // fix not really
+    uint32_t computed_host_page_start = 0;
+    if (device_page_offset_ >= host_range.device_page_offset ||
+        host_range.device_page_offset - device_page_offset_ <= host_range.host_page_start) {
+        computed_host_page_start = host_range.host_page_start + device_page_offset_ - host_range.device_page_offset;
+    } else {
+        computed_host_page_start = host_range.host_page_start;
+        device_page_offset_ = host_range.device_page_offset;
+    }
     result = Range{
         .device_page_offset = device_page_offset_,
-        .host_page_start = host_range.host_page_start + device_page_offset_ - host_range.device_page_offset,
+        .host_page_start = computed_host_page_start,
         .num_pages = num_pages,
     };
+    std::cout << "num_pages_left: " << num_pages_left << std::endl;
+    std::cout << "result.host_page_start: " << result.host_page_start
+              << " result.device_page_offset: " << result.device_page_offset
+              << " result.num_pages: " << result.num_pages << std::endl;
     device_page_offset_ += num_pages;
+    // if(reached_padding) {
+    //     device_page_offset_ = host_range.device_page_offset + num_pages;
+    // } else {
+    //     device_page_offset_ += num_pages;
+    // }
     if (device_page_offset_ == host_range.device_page_offset + host_range.num_pages) {
         range_index_++;
     }

--- a/tt_metal/impl/buffers/buffer_page_mapping.cpp
+++ b/tt_metal/impl/buffers/buffer_page_mapping.cpp
@@ -4,6 +4,7 @@
 
 #include <tt-metalium/buffer_page_mapping.hpp>
 
+#include <iostream>
 namespace tt::tt_metal {
 
 namespace {
@@ -169,21 +170,47 @@ BufferCorePageMapping::Iterator::Range BufferCorePageMapping::Iterator::next_ran
         return result;
     }
     const auto& host_range = mapping_->host_ranges[range_index_];
-    uint32_t num_pages_left = host_range.device_page_offset + host_range.num_pages - device_page_offset_;
-    uint32_t num_pages = std::min(num_pages_left, end_device_page_offset - device_page_offset_);
-    uint32_t computed_host_page_start = 0;
-    if (device_page_offset_ >= host_range.device_page_offset ||
-        host_range.device_page_offset - device_page_offset_ <= host_range.host_page_start) {
-        computed_host_page_start = host_range.host_page_start + device_page_offset_ - host_range.device_page_offset;
-    } else {
-        computed_host_page_start = host_range.host_page_start;
+    bool excess_padding_ignored = (device_page_offset_ < host_range.device_page_offset) &&
+                                  (host_range.device_page_offset - device_page_offset_ > host_range.host_page_start);
+    if (excess_padding_ignored) {
         device_page_offset_ = host_range.device_page_offset;
     }
+
+    uint32_t num_pages_left = host_range.device_page_offset + host_range.num_pages - device_page_offset_;
+    // bool excess_padding_ignored = (device_page_offset_ < host_range.device_page_offset) &&
+    //     (host_range.device_page_offset - device_page_offset_ > host_range.host_page_start);
+    // if(excess_padding_ignored) {
+    //     num_pages_left = host_range.num_pages;
+    //
+    // }
+    uint32_t num_pages = std::min(num_pages_left, end_device_page_offset - device_page_offset_);
+    // uint32_t num_pages_to_write_to_device = num_pages;
+    // uint32_t computed_host_page_start = 0;
+    // if(excess_padding_ignored) {
+    //     computed_host_page_start = host_range.host_page_start;
+    //     device_page_offset_ = host_range.device_page_offset;
+    // } else {
+    //     computed_host_page_start = host_range.host_page_start + device_page_offset_ - host_range.device_page_offset;
+    // }
+    // if (device_page_offset_ >= host_range.device_page_offset ||
+    //     host_range.device_page_offset - device_page_offset_ <= host_range.host_page_start) {
+    //     computed_host_page_start = host_range.host_page_start + device_page_offset_ - host_range.device_page_offset;
+    // } else {
+    //     computed_host_page_start = 0;//= host_range.host_page_start;
+    //     // num_pages_to_write_to_device = host_range.host_page_start+num;
+    //     // device_page_offset_ = host_range.device_page_offset;
+    // }
     result = Range{
         .device_page_offset = device_page_offset_,
-        .host_page_start = computed_host_page_start,
+        .host_page_start = host_range.host_page_start + device_page_offset_ -
+                           host_range.device_page_offset,  // computed_host_page_start,
         .num_pages = num_pages,
     };
+    // if(more_padding_than_host_page_start) {
+    //     device_page_offset_ =host_range.device_page_offset + host_range.num_pages;
+    // } else {
+    //     device_page_offset_ += num_pages;// result.device_page_offset = device_page_offset_;
+    // }
     device_page_offset_ += num_pages;
     if (device_page_offset_ == host_range.device_page_offset + host_range.num_pages) {
         range_index_++;

--- a/tt_metal/impl/buffers/buffer_page_mapping.cpp
+++ b/tt_metal/impl/buffers/buffer_page_mapping.cpp
@@ -175,11 +175,13 @@ BufferCorePageMapping::Iterator::Range BufferCorePageMapping::Iterator::next_ran
     //     device_page_offset_ = host_range.device_page_offset;
     //     // std::cout<<"AAAAAAAAAAAAAAA\n";
     // }
-    std::cout << "device_page_offset_: " << device_page_offset_
-              << " host_range.host_page_start: " << host_range.host_page_start
-              << " host_range.device_page_offset: " << host_range.device_page_offset
-              << " host_range.num_pages: " << host_range.num_pages << std::endl;
-    uint32_t num_pages_left = host_range.num_pages - (device_page_offset_ - host_range.device_page_offset);
+    // std::cout << "device_page_offset_: " << device_page_offset_
+    //           << " host_range.host_page_start: " << host_range.host_page_start
+    //           << " host_range.device_page_offset: " << host_range.device_page_offset
+    //           << " host_range.num_pages: " << host_range.num_pages << std::endl;
+    uint32_t num_pages_left =
+        host_range.device_page_offset + host_range.num_pages -
+        device_page_offset_;  // host_range.num_pages - (device_page_offset_ - host_range.device_page_offset);
     uint32_t num_pages = std::min(num_pages_left, end_device_page_offset - device_page_offset_);
     // if (device_page_offset_ < host_range.device_page_offset) {  // we are in padding.
     //     device_page_offset_ = host_range.device_page_offset;
@@ -201,10 +203,10 @@ BufferCorePageMapping::Iterator::Range BufferCorePageMapping::Iterator::next_ran
         .host_page_start = computed_host_page_start,
         .num_pages = num_pages,
     };
-    std::cout << "num_pages_left: " << num_pages_left << std::endl;
-    std::cout << "result.host_page_start: " << result.host_page_start
-              << " result.device_page_offset: " << result.device_page_offset
-              << " result.num_pages: " << result.num_pages << std::endl;
+    // std::cout << "num_pages_left: " << num_pages_left << std::endl;
+    // std::cout << "result.host_page_start: " << result.host_page_start
+    //           << " result.device_page_offset: " << result.device_page_offset
+    //           << " result.num_pages: " << result.num_pages << std::endl;
     device_page_offset_ += num_pages;
     // if(reached_padding) {
     //     device_page_offset_ = host_range.device_page_offset + num_pages;

--- a/tt_metal/impl/buffers/buffer_page_mapping.cpp
+++ b/tt_metal/impl/buffers/buffer_page_mapping.cpp
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <tt-metalium/buffer_page_mapping.hpp>
-#include <iostream>
 
 namespace tt::tt_metal {
 
@@ -170,26 +169,8 @@ BufferCorePageMapping::Iterator::Range BufferCorePageMapping::Iterator::next_ran
         return result;
     }
     const auto& host_range = mapping_->host_ranges[range_index_];
-    // std::cout<<"range_index_: "<<range_index_<<std::endl;
-    // if (device_page_offset_ < host_range.device_page_offset) {  // we are in padding.
-    //     device_page_offset_ = host_range.device_page_offset;
-    //     // std::cout<<"AAAAAAAAAAAAAAA\n";
-    // }
-    // std::cout << "device_page_offset_: " << device_page_offset_
-    //           << " host_range.host_page_start: " << host_range.host_page_start
-    //           << " host_range.device_page_offset: " << host_range.device_page_offset
-    //           << " host_range.num_pages: " << host_range.num_pages << std::endl;
-    uint32_t num_pages_left =
-        host_range.device_page_offset + host_range.num_pages -
-        device_page_offset_;  // host_range.num_pages - (device_page_offset_ - host_range.device_page_offset);
+    uint32_t num_pages_left = host_range.device_page_offset + host_range.num_pages - device_page_offset_;
     uint32_t num_pages = std::min(num_pages_left, end_device_page_offset - device_page_offset_);
-    // if (device_page_offset_ < host_range.device_page_offset) {  // we are in padding.
-    //     device_page_offset_ = host_range.device_page_offset;
-    //     // std::cout<<"AAAAAAAAAAAAAAA\n";
-    // }
-    // bool reached_padding = (device_page_offset_ < host_range.device_page_offset) ? true : false;
-
-    // fix not really
     uint32_t computed_host_page_start = 0;
     if (device_page_offset_ >= host_range.device_page_offset ||
         host_range.device_page_offset - device_page_offset_ <= host_range.host_page_start) {
@@ -203,16 +184,7 @@ BufferCorePageMapping::Iterator::Range BufferCorePageMapping::Iterator::next_ran
         .host_page_start = computed_host_page_start,
         .num_pages = num_pages,
     };
-    // std::cout << "num_pages_left: " << num_pages_left << std::endl;
-    // std::cout << "result.host_page_start: " << result.host_page_start
-    //           << " result.device_page_offset: " << result.device_page_offset
-    //           << " result.num_pages: " << result.num_pages << std::endl;
     device_page_offset_ += num_pages;
-    // if(reached_padding) {
-    //     device_page_offset_ = host_range.device_page_offset + num_pages;
-    // } else {
-    //     device_page_offset_ += num_pages;
-    // }
     if (device_page_offset_ == host_range.device_page_offset + host_range.num_pages) {
         range_index_++;
     }

--- a/tt_metal/impl/buffers/buffer_page_mapping.cpp
+++ b/tt_metal/impl/buffers/buffer_page_mapping.cpp
@@ -177,40 +177,12 @@ BufferCorePageMapping::Iterator::Range BufferCorePageMapping::Iterator::next_ran
     }
 
     uint32_t num_pages_left = host_range.device_page_offset + host_range.num_pages - device_page_offset_;
-    // bool excess_padding_ignored = (device_page_offset_ < host_range.device_page_offset) &&
-    //     (host_range.device_page_offset - device_page_offset_ > host_range.host_page_start);
-    // if(excess_padding_ignored) {
-    //     num_pages_left = host_range.num_pages;
-    //
-    // }
     uint32_t num_pages = std::min(num_pages_left, end_device_page_offset - device_page_offset_);
-    // uint32_t num_pages_to_write_to_device = num_pages;
-    // uint32_t computed_host_page_start = 0;
-    // if(excess_padding_ignored) {
-    //     computed_host_page_start = host_range.host_page_start;
-    //     device_page_offset_ = host_range.device_page_offset;
-    // } else {
-    //     computed_host_page_start = host_range.host_page_start + device_page_offset_ - host_range.device_page_offset;
-    // }
-    // if (device_page_offset_ >= host_range.device_page_offset ||
-    //     host_range.device_page_offset - device_page_offset_ <= host_range.host_page_start) {
-    //     computed_host_page_start = host_range.host_page_start + device_page_offset_ - host_range.device_page_offset;
-    // } else {
-    //     computed_host_page_start = 0;//= host_range.host_page_start;
-    //     // num_pages_to_write_to_device = host_range.host_page_start+num;
-    //     // device_page_offset_ = host_range.device_page_offset;
-    // }
     result = Range{
         .device_page_offset = device_page_offset_,
-        .host_page_start = host_range.host_page_start + device_page_offset_ -
-                           host_range.device_page_offset,  // computed_host_page_start,
+        .host_page_start = host_range.host_page_start + device_page_offset_ - host_range.device_page_offset,
         .num_pages = num_pages,
     };
-    // if(more_padding_than_host_page_start) {
-    //     device_page_offset_ =host_range.device_page_offset + host_range.num_pages;
-    // } else {
-    //     device_page_offset_ += num_pages;// result.device_page_offset = device_page_offset_;
-    // }
     device_page_offset_ += num_pages;
     if (device_page_offset_ == host_range.device_page_offset + host_range.num_pages) {
         range_index_++;

--- a/tt_metal/impl/buffers/buffer_page_mapping.cpp
+++ b/tt_metal/impl/buffers/buffer_page_mapping.cpp
@@ -169,10 +169,10 @@ BufferCorePageMapping::Iterator::Range BufferCorePageMapping::Iterator::next_ran
         return result;
     }
     const auto& host_range = mapping_->host_ranges[range_index_];
-    bool excess_padding_ignored = (device_page_offset_ < host_range.device_page_offset) &&
-                                  (host_range.device_page_offset - device_page_offset_ > host_range.host_page_start);
-    if (excess_padding_ignored) {
-        device_page_offset_ = host_range.device_page_offset;
+    bool excess_padding = (device_page_offset_ < host_range.device_page_offset) &&
+                          (host_range.device_page_offset - device_page_offset_ > host_range.host_page_start);
+    if (excess_padding) {
+        device_page_offset_ = host_range.device_page_offset - host_range.host_page_start;
     }
 
     uint32_t num_pages_left = host_range.device_page_offset + host_range.num_pages - device_page_offset_;

--- a/tt_metal/impl/buffers/buffer_page_mapping.cpp
+++ b/tt_metal/impl/buffers/buffer_page_mapping.cpp
@@ -4,7 +4,6 @@
 
 #include <tt-metalium/buffer_page_mapping.hpp>
 
-#include <iostream>
 namespace tt::tt_metal {
 
 namespace {


### PR DESCRIPTION
### Ticket
[#30428
](https://github.com/tenstorrent/tt-metal/issues/30428)
### Problem description
There is an edge case not handled when iterating through the device pages and the number of `PADDING` pages preceding a contiguous range of pages exceeds the value of the page start id (i.e., the page number of the first page in the next contiguous range of pages). The call to `BufferCorePageMapping::Iterator::next_range` has an integer underflow when computing `host_range.host_page_start + device_page_offset_ - host_range.device_page_offset` in the current range. This caused a massive offset in the host page data address computation, leading to the segmentation faults seen in the sweep tests for the above ticket.

### What's changed
Added a condition to check if the current iterator reached the start of a sequence of `PADDING` pages and that the amount of `PADDING` pages is greater than the host page number of the next mapped page (i.e., the situation causing the underflow). If the overall `device_page_offset_` is less than the current range's `device_page_offset`  (i.e., the current iterator is pointing to a `PADDING` page) and the number of pages until `host_range.device_page_offset` is larger than `host_range.host_page_start` (i.e., the number of `PADDING` pages exceeds the page number of the first page in the next contiguous range of pages), then we must limit the amount of pages to include in the returned range to at most `host_range.host_page_start + host_range.num_pages` to avoid the `uint32_t` underflow in the computation `host_range.host_page_start + device_page_offset_ - host_range.device_page_offset`. That is, if there is more padding than page IDs, then we can include at most the number of page IDs in the returned range (there are no negative page IDs).

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/19396515926) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/19396521712) CI with demo tests passes (if applicable)
- [x] New/Existing tests provide coverage for changes