### PR TITLE
Pjosipovic/mm fuse bias height

### DIFF
--- a/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
@@ -2458,3 +2458,42 @@ def test_matmul_padding(
 
     # Verify values match with high precision
     assert torch.allclose(golden_output, output, atol=1e-6)
+
+
+@pytest.mark.parametrize("input_shape", [(1576, 768)])
+@pytest.mark.parametrize("weight_shape", [(768, 768)])
+def test_linear_with_non_tile_aligned_bias(device, input_shape, weight_shape):
+    """
+    Regression test for issue #32441.
+    Tests ttnn.linear with bias that has non-tile-aligned padded dimensions.
+    The bias shape [1576, 768] pads to [1600, 768] where 1600 != tile_height (32),
+    which previously caused a validation error during bias fusion.
+    """
+    torch.manual_seed(0)
+
+    # Create tensors matching the issue repro
+    torch_input = torch.randn(input_shape, dtype=torch.bfloat16)
+    torch_weight = torch.randn(weight_shape, dtype=torch.bfloat16)
+    torch_bias = torch.randn(input_shape, dtype=torch.bfloat16)
+
+    # Compute expected output using PyTorch
+    # linear(input, weight, bias) with transpose_b=True means: input @ weight.T + bias
+    torch_output = torch.nn.functional.linear(torch_input, torch_weight, bias=None) + torch_bias
+
+    # Convert to ttnn tensors with DRAM memory config as in the original issue
+    input_tensor = ttnn.from_torch(
+        torch_input, layout=ttnn.TILE_LAYOUT, device=device, dtype=ttnn.bfloat16, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+    weight_tensor = ttnn.from_torch(
+        torch_weight, layout=ttnn.TILE_LAYOUT, device=device, dtype=ttnn.bfloat16, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+    bias_tensor = ttnn.from_torch(
+        torch_bias, layout=ttnn.TILE_LAYOUT, device=device, dtype=ttnn.bfloat16, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+
+    # This should not crash with "Unsupported bias shape" error
+    output_tensor = ttnn.linear(input_tensor, weight_tensor, bias=bias_tensor, transpose_b=True)
+    output = ttnn.to_torch(output_tensor)
+
+    # Verify correctness
+    assert_with_pcc(torch_output, output, pcc=0.99)

--- a/ttnn/cpp/ttnn/operations/matmul/matmul.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul.cpp
@@ -97,7 +97,17 @@ static bool get_post_process_bias(
     // MatmulMultiCoreProgramConfig doesn't support bias fusion, so we need to apply it as a post-process
     bool post_process_bias = false;
     if (bias.has_value()) {
-        if (program_config.has_value()) {
+        // Check if bias shape is compatible with kernel fusion
+        // Bias fusion requires bias_shape_aligned[-2] == tile_height
+        const auto& bias_tensor = bias.value();
+        const auto& bias_padded_shape = bias_tensor.padded_shape();
+        const auto& tile_shape = input_tensor_a_adjusted.tensor_spec().tile().get_tile_shape();
+        uint32_t tile_height = tile_shape[0];
+
+        // If bias second-to-last dimension doesn't match tile height, must post-process
+        if (bias_padded_shape[-2] != tile_height) {
+            post_process_bias = true;
+        } else if (program_config.has_value()) {
             // Check if the provided program config is MatmulMultiCoreProgramConfig
             post_process_bias = std::holds_alternative<MatmulMultiCoreProgramConfig>(program_config.value());
         } else if (!user_core_coord.has_value()) {


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/32441)

### Problem description
Commit #f9dc6d2 introduced a regression that was unnoticed by tt-metal CI but tripped up by tt-forge.
In ttnn::linear bias can be fused only if height of the tensor is equal to the tile height.

### What's changed
Added another condition for bias fusing in ttnn::linear.
Added a regression test, based on the one from issue logged by forge team.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/19388746996)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/19388753742) 
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/runs/19388762409)
- [x] [Frequent model and ttnn tests ](https://github.com/tenstorrent/tt-metal/actions/runs/19388757405)
- [x] [Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/runs/19388750588)