### PR TITLE
Profiler bug fix for mismatched start-end marker pairs

### DIFF
--- a/tools/tracy/device_post_proc_config.py
+++ b/tools/tracy/device_post_proc_config.py
@@ -208,6 +208,42 @@ class test_multi_op(default_setup):
     detectOps = False
 
 
+class test_multi_op_buffer_overflow(default_setup):
+    timerAnalysis = {
+        "BRISC KERNEL_START->KERNEL_END": {
+            "across": "core",
+            "type": "adjacent",
+            "start": {"core": "ANY", "risc": "BRISC", "zone_name": "BRISC-KERNEL"},
+            "end": {"core": "ANY", "risc": "BRISC", "zone_name": "BRISC-KERNEL"},
+        },
+        "NCRISC KERNEL_START->KERNEL_END": {
+            "across": "core",
+            "type": "adjacent",
+            "start": {"core": "ANY", "risc": "NCRISC", "zone_name": "NCRISC-KERNEL"},
+            "end": {"core": "ANY", "risc": "NCRISC", "zone_name": "NCRISC-KERNEL"},
+        },
+        "TRISC_0 KERNEL_START->KERNEL_END": {
+            "across": "core",
+            "type": "adjacent",
+            "start": {"core": "ANY", "risc": "TRISC_0", "zone_name": "TRISC-KERNEL"},
+            "end": {"core": "ANY", "risc": "TRISC_0", "zone_name": "TRISC-KERNEL"},
+        },
+        "TRISC_1 KERNEL_START->KERNEL_END": {
+            "across": "core",
+            "type": "adjacent",
+            "start": {"core": "ANY", "risc": "TRISC_1", "zone_name": "TRISC-KERNEL"},
+            "end": {"core": "ANY", "risc": "TRISC_1", "zone_name": "TRISC-KERNEL"},
+        },
+        "TRISC_2 KERNEL_START->KERNEL_END": {
+            "across": "core",
+            "type": "adjacent",
+            "start": {"core": "ANY", "risc": "TRISC_2", "zone_name": "TRISC-KERNEL"},
+            "end": {"core": "ANY", "risc": "TRISC_2", "zone_name": "TRISC-KERNEL"},
+        },
+    }
+    detectOps = False
+
+
 class test_custom_cycle_count(default_setup):
     timerAnalysis = {
         "BRISC KERNEL_START->KERNEL_END": {

--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -1629,19 +1629,17 @@ void DeviceProfiler::processDeviceMarkerData(std::set<tracy::TTDeviceMarker>& de
             } else if (marker.marker_type == tracy::TTDeviceMarkerType::ZONE_END) {
                 TT_FATAL(
                     !start_marker_stack.empty(),
-                    "End marker {} found without a corresponding start marker",
-                    marker.marker_id);
+                    "End marker found without a corresponding start marker.\nEnd marker: {}",
+                    marker.to_string());
 
                 const auto& start_marker_it = start_marker_stack.top();
 
                 if (!tt::tt_metal::MetalContext::instance().rtoptions().get_profiler_trace_only()) {
                     TT_FATAL(
                         start_marker_it->marker_id == marker.marker_id,
-                        "Start {} and end {} markers do not match. The Profiler DRAM buffers may be full, in which "
-                        "case "
-                        "either decrease the number of ops being profiled or run read device profiler more often.",
-                        start_marker_it->marker_id,
-                        marker.marker_id);
+                        "Start and end marker IDs do not match.\nStart marker: {}\nEnd marker: {}",
+                        start_marker_it->to_string(),
+                        marker.to_string());
 
                     if (start_marker_it->marker_name != marker.marker_name) {
                         marker.marker_name = start_marker_it->marker_name;
@@ -1652,9 +1650,9 @@ void DeviceProfiler::processDeviceMarkerData(std::set<tracy::TTDeviceMarker>& de
                 } else {
                     TT_FATAL(
                         start_marker_it->marker_name == marker.marker_name,
-                        "Start {} and end {} marker names do not match",
-                        start_marker_it->marker_name,
-                        marker.marker_name);
+                        "Start and end marker names do not match.\nStart marker: {}\nEnd marker: {}",
+                        start_marker_it->to_string(),
+                        marker.to_string());
                 }
                 start_marker_stack.pop();
             }

--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -1750,8 +1750,6 @@ DeviceProfiler::DeviceProfiler(const IDevice* device, const bool new_logs [[mayb
         return;
     }
 
-    // this->clearProfilerDramBuffer(device);
-
     this->device_logs_output_dir = std::filesystem::path(get_profiler_logs_dir());
     std::filesystem::create_directories(this->device_logs_output_dir);
 
@@ -2106,44 +2104,6 @@ void DeviceProfiler::updateTracyContexts(
     }
 #endif
 }
-
-// void DeviceProfiler::clearProfilerDramBuffer(const IDevice* device) {
-// #if defined(TRACY_ENABLE)
-//     ZoneScoped;
-//     if (!getDeviceProfilerState() || device == nullptr) {
-//         return;
-//     }
-
-//     const auto& hal = MetalContext::instance().hal();
-//     const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
-//     const auto& soc_desc = cluster.get_soc_desc(device_id);
-
-//     const uint32_t cores_per_dram_bank = soc_desc.profiler_ceiled_core_count_perf_dram_bank;
-//     if (cores_per_dram_bank == 0) {
-//         return;
-//     }
-
-//     const uint32_t bank_size_bytes =
-//         PROFILER_FULL_HOST_BUFFER_SIZE_PER_RISC * hal.get_max_processors_per_core() * cores_per_dram_bank;
-//     TT_ASSERT(bank_size_bytes <= hal.get_dev_size(HalDramMemAddrType::PROFILER));
-
-//     if (bank_size_bytes == 0) {
-//         return;
-//     }
-
-//     const DeviceAddr profiler_addr = hal.get_dev_addr(HalDramMemAddrType::PROFILER);
-//     const uint32_t num_dram_views = soc_desc.get_num_dram_views();
-
-//     std::vector<uint32_t> zero_buffer(bank_size_bytes / sizeof(uint32_t), 1);
-//     for (uint32_t view = 0; view < num_dram_views; ++view) {
-//         cluster.write_dram_vec(zero_buffer.data(), bank_size_bytes, device_id, view, profiler_addr);
-//     }
-
-//     if (!profile_buffer.empty()) {
-//         std::fill(profile_buffer.begin(), profile_buffer.end(), 1);
-//     }
-// #endif
-// }
 
 void DeviceProfiler::updateTracyContext(const std::pair<ChipId, CoreCoord>& device_core) {
 #if defined(TRACY_ENABLE)

--- a/tt_metal/impl/profiler/profiler.hpp
+++ b/tt_metal/impl/profiler/profiler.hpp
@@ -123,6 +123,9 @@ private:
     // Read all control buffers
     void readControlBuffers(IDevice* device, const std::vector<CoreCoord>& virtual_cores);
 
+    // Clear the device-side DRAM profiler buffer
+    // void clearProfilerDramBuffer(const IDevice* device);
+
     // Read control buffer for a single core
     void readControlBufferForCore(IDevice* device, const CoreCoord& virtual_core);
 

--- a/tt_metal/impl/profiler/profiler.hpp
+++ b/tt_metal/impl/profiler/profiler.hpp
@@ -123,9 +123,6 @@ private:
     // Read all control buffers
     void readControlBuffers(IDevice* device, const std::vector<CoreCoord>& virtual_cores);
 
-    // Clear the device-side DRAM profiler buffer
-    // void clearProfilerDramBuffer(const IDevice* device);
-
     // Read control buffer for a single core
     void readControlBufferForCore(IDevice* device, const CoreCoord& virtual_core);
 

--- a/tt_metal/programming_examples/profiler/CMakeLists.txt
+++ b/tt_metal/programming_examples/profiler/CMakeLists.txt
@@ -3,6 +3,7 @@ set(PROFILER_EXAMPLES_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/test_custom_cycle_count_slow_dispatch/test_custom_cycle_count_slow_dispatch.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_full_buffer/test_full_buffer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_multi_op/test_multi_op.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_multi_op_buffer_overflow/test_multi_op_buffer_overflow.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_dispatch_cores/test_dispatch_cores.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_timestamped_events/test_timestamped_events.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_noc_event_profiler/test_noc_event_profiler.cpp

--- a/tt_metal/programming_examples/profiler/test_multi_op_buffer_overflow/test_multi_op_buffer_overflow.cpp
+++ b/tt_metal/programming_examples/profiler/test_multi_op_buffer_overflow/test_multi_op_buffer_overflow.cpp
@@ -1,0 +1,85 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/device.hpp>
+#include <tt-metalium/distributed.hpp>
+
+using namespace tt;
+using namespace tt::tt_metal;
+
+constexpr uint32_t OP_COUNT = 1400;
+
+uint32_t program_runtime_id = 1;
+
+void RunCustomCycle(const std::shared_ptr<distributed::MeshDevice>& mesh_device, int num_ops) {
+    const CoreCoord compute_with_storage_size = mesh_device->compute_with_storage_grid_size();
+    const CoreCoord start_core = {0, 0};
+    const CoreCoord end_core = {compute_with_storage_size.x - 1, compute_with_storage_size.y - 1};
+    const CoreRange all_cores(start_core, end_core);
+
+    for (uint32_t i = 0; i < num_ops; ++i) {
+        // Mesh workload + device range span the mesh; program encapsulates kernels
+        distributed::MeshWorkload workload;
+        const distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(mesh_device->shape());
+        tt_metal::Program program = tt_metal::CreateProgram();
+
+        if (i % 5 == 0) {
+            tt_metal::CreateKernel(
+                program,
+                "tt_metal/programming_examples/profiler/test_multi_op/kernels/multi_op_compute.cpp",
+                all_cores,
+                tt_metal::ComputeConfig{.compile_args = {}});
+        }
+        tt_metal::CreateKernel(
+            program,
+            "tt_metal/programming_examples/profiler/test_multi_op/kernels/multi_op.cpp",
+            all_cores,
+            tt_metal::DataMovementConfig{
+                .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default});
+
+        tt_metal::CreateKernel(
+            program,
+            "tt_metal/programming_examples/profiler/test_multi_op/kernels/multi_op.cpp",
+            all_cores,
+            tt_metal::DataMovementConfig{
+                .processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = tt_metal::NOC::RISCV_1_default});
+
+        program.set_runtime_id(program_runtime_id++);
+        workload.add_program(device_range, std::move(program));
+        distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(), workload, false);
+    }
+}
+
+int main() {
+    bool pass = true;
+
+    try {
+        ////////////////////////////////////////////////////////////////////////////
+        //                      Device Setup
+        ////////////////////////////////////////////////////////////////////////////
+        constexpr ChipId device_id = 0;
+        std::shared_ptr<distributed::MeshDevice> mesh_device = distributed::MeshDevice::create_unit_mesh(device_id);
+
+        RunCustomCycle(mesh_device, OP_COUNT);
+        ReadMeshDeviceProfilerResults(*mesh_device);
+
+        pass &= mesh_device->close();
+
+    } catch (const std::exception& e) {
+        pass = false;
+        // Capture the exception error message
+        fmt::print(stderr, "{}\n", e.what());
+        // Capture system call errors that may have returned from driver/kernel
+        fmt::print(stderr, "System error message: {}\n", std::strerror(errno));
+    }
+
+    if (pass) {
+        fmt::print("Test Passed\n");
+    } else {
+        TT_THROW("Test Failed");
+    }
+
+    return 0;
+}

--- a/tt_metal/tools/profiler/kernel_profiler.hpp
+++ b/tt_metal/tools/profiler/kernel_profiler.hpp
@@ -280,18 +280,19 @@ __attribute__((noinline)) void finish_profiler() {
     if (profiler_control_buffer[PROFILER_DONE] == 1) {
         return;
     }
-    bool do_noc = true;
-    if (!profiler_control_buffer[DRAM_PROFILER_ADDRESS]) {
-        do_noc = false;
-    }
     uint32_t core_flat_id = profiler_control_buffer[FLAT_ID];
     uint32_t profiler_core_count_per_dram = profiler_control_buffer[CORE_COUNT_PER_DRAM];
+    bool is_dram_set = profiler_control_buffer[DRAM_PROFILER_ADDRESS] != 0;
 
     uint32_t pageSize =
         PROFILER_FULL_HOST_BUFFER_SIZE_PER_RISC * MaxProcessorsPerCoreType * profiler_core_count_per_dram;
 
     NocRegisterStateSave noc_state;
     for (uint32_t riscID = 0; riscID < PROCESSOR_COUNT; riscID++) {
+        bool do_noc = true;
+        if (!is_dram_set) {
+            do_noc = false;
+        }
 #if defined(COMPILE_FOR_IDLE_ERISC)
         profiler_data_buffer[riscID].data[ID_LH] = ((core_flat_id & 0xFF) << 3) | riscID;
 #else


### PR DESCRIPTION
#30393 

This PR fixes a bug with the profiler where mismatches were being detected with start-end marker pairs. 

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/19437164837)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (https://github.com/tenstorrent/tt-metal/actions/runs/19437173235)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/19378092825)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/19378048627)
- [x] [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/19378057923)
- [x] [T3K Profiler] (https://github.com/tenstorrent/tt-metal/actions/runs/19437183389)
- [x] [Galaxy Profiler] (https://github.com/tenstorrent/tt-metal/actions/runs/19350807280)
- [x] [Metal Microbenchmarks] (https://github.com/tenstorrent/tt-metal/actions/runs/19378065596)
- [x] New/Existing tests provide coverage for changes