### PR TITLE
[skip ci] Bump model expected device perf

### DIFF
--- a/models/demos/blackhole/vit/tests/test_vit_device_perf.py
+++ b/models/demos/blackhole/vit/tests/test_vit_device_perf.py
@@ -46,7 +46,7 @@ def test_vit_device_ops(
 @pytest.mark.parametrize(
     "expected_kernel_samples_per_sec",
     [
-        4120,
+        4300,
     ],
 )
 @pytest.mark.models_device_performance_bare_metal

--- a/models/demos/wormhole/vgg_unet/tests/perf/test_perf_vgg_unet.py
+++ b/models/demos/wormhole/vgg_unet/tests/perf/test_perf_vgg_unet.py
@@ -11,7 +11,7 @@ from models.perf.device_perf_utils import check_device_perf, prep_device_perf_re
 @pytest.mark.parametrize(
     "batch_size, expected_perf",
     [
-        [1, 281],
+        [1, 290],
     ],
 )
 @pytest.mark.models_device_performance_bare_metal

--- a/models/demos/wormhole/vit/tests/test_vit_device_perf.py
+++ b/models/demos/wormhole/vit/tests/test_vit_device_perf.py
@@ -46,7 +46,7 @@ def test_vit_device_ops(
 @pytest.mark.parametrize(
     "expected_kernel_samples_per_sec",
     [
-        1509,
+        1560,
     ],
 )
 @pytest.mark.models_device_performance_bare_metal

--- a/models/demos/yolov8x/tests/perf/test_perf_yolov8x.py
+++ b/models/demos/yolov8x/tests/perf/test_perf_yolov8x.py
@@ -11,7 +11,7 @@ from models.perf.device_perf_utils import check_device_perf, prep_device_perf_re
 @pytest.mark.parametrize(
     "batch_size, expected_perf",
     [
-        [1, 68],
+        [1, 70],
     ],
 )
 @pytest.mark.models_device_performance_bare_metal

--- a/models/experimental/panoptic_deeplab/tests/test_device_perf_pdl.py
+++ b/models/experimental/panoptic_deeplab/tests/test_device_perf_pdl.py
@@ -12,7 +12,7 @@ from models.experimental.panoptic_deeplab.reference.pytorch_model import DEEPLAB
     [
         (
             "pytest models/experimental/panoptic_deeplab/tests/pcc/test_tt_model.py::test_model_panoptic_deeplab -k test_panoptic_deeplab",
-            31_016_904,
+            30_539_964,
             PANOPTIC_DEEPLAB,
             PANOPTIC_DEEPLAB,
             1,


### PR DESCRIPTION
### Problem description
Some models are faster than expected on device perf ci 
causing ci to be [red](https://github.com/tenstorrent/tt-metal/actions/runs/19432419284/job/55595232233)

### What's changed
- bumped vit expected perf on bh and wh
- bumped vgg expected perf on wh
- bumped yolov8x expected perf
- bumped panoptic expected perf