### PR TITLE
[skip ci] Increase timeout for RelWithDebInfo build

### DIFF
--- a/.github/workflows/all-post-commit-workflows.yaml
+++ b/.github/workflows/all-post-commit-workflows.yaml
@@ -185,6 +185,7 @@ jobs:
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       gtest_filter: "*-*NIGHTLY_*"
+      timeout: ${{ (inputs.build-type == 'RelWithDebInfo') && 60 || 35 }}
   tt-train-cpp-unit-tests:
     needs: [build-artifact, find-changed-files]
     secrets: inherit


### PR DESCRIPTION
### Problem description
Cpp unit tests are failing with timeout when we are testing RelWithDebInfo builds
https://github.com/tenstorrent/tt-metal/actions/runs/19414481374/job/55544571506

### What's changed
Add specific timeout for RelWithDebInfo builds