### PR TITLE
#32471: Remove experimental from namespace for xtensor and unit_mesh_utils

### DIFF
--- a/tests/ttnn/unit_tests/gtests/ccl/test_multi_tensor_ccl.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_multi_tensor_ccl.cpp
@@ -61,7 +61,7 @@ TEST_F(MeshDevice1x4Fixture, AllGatherReturnedTensor) {
         tensors.push_back(Tensor::from_vector(std::move(data), tensor_spec).to_device(mesh_devices[dev_idx].get()));
     }
 
-    auto aggregated_tensor = tt::tt_metal::experimental::unit_mesh::aggregate(tensors);
+    auto aggregated_tensor = tt::tt_metal::unit_mesh::aggregate(tensors);
 
     // Quiesce parent mesh before all gather
     mesh_device_->quiesce_devices();
@@ -73,7 +73,7 @@ TEST_F(MeshDevice1x4Fixture, AllGatherReturnedTensor) {
     // Quiesce parent mesh after all gather
     mesh_device_->quiesce_devices();
 
-    auto disaggregated_output_tensors = tt::tt_metal::experimental::unit_mesh::disaggregate(all_gathered_tensor);
+    auto disaggregated_output_tensors = tt::tt_metal::unit_mesh::disaggregate(all_gathered_tensor);
     for (int dev_idx = 0; dev_idx < mesh_devices.size(); dev_idx++) {
         auto data = disaggregated_output_tensors[dev_idx].to_vector<bfloat16>();
         for (int i = 0; i < data.size(); i++) {
@@ -99,8 +99,8 @@ TEST_F(MeshDevice1x4Fixture, AllGatherPersistentOutput) {
             Tensor::from_vector(std::move(output_data), output_tensor_spec).to_device(mesh_devices[dev_idx].get()));
     }
 
-    auto aggregated_tensor = tt::tt_metal::experimental::unit_mesh::aggregate(tensors);
-    auto aggregated_output_tensor = tt::tt_metal::experimental::unit_mesh::aggregate(output_tensors);
+    auto aggregated_tensor = tt::tt_metal::unit_mesh::aggregate(tensors);
+    auto aggregated_output_tensor = tt::tt_metal::unit_mesh::aggregate(output_tensors);
 
     // Quiesce parent mesh before all gather
     mesh_device_->quiesce_devices();
@@ -140,8 +140,8 @@ TEST_F(MeshDevice1x4Fixture, ReduceScatter) {
         output_tensors.push_back(
             Tensor::from_vector(std::move(output_data), output_tensor_spec).to_device(mesh_devices[dev_idx].get()));
     }
-    auto aggregated_tensor = tt::tt_metal::experimental::unit_mesh::aggregate(tensors);
-    auto aggregated_output_tensor = tt::tt_metal::experimental::unit_mesh::aggregate(output_tensors);
+    auto aggregated_tensor = tt::tt_metal::unit_mesh::aggregate(tensors);
+    auto aggregated_output_tensor = tt::tt_metal::unit_mesh::aggregate(output_tensors);
 
     // Quiesce parent mesh before reduce scatter
     mesh_device_->quiesce_devices();
@@ -175,7 +175,7 @@ TEST_F(MeshDevice1x4Fixture, AllReduce) {
         tensors.push_back(Tensor::from_vector(std::move(data), tensor_spec).to_device(mesh_devices[dev_idx].get()));
     }
 
-    auto aggregated_tensor = tt::tt_metal::experimental::unit_mesh::aggregate(tensors);
+    auto aggregated_tensor = tt::tt_metal::unit_mesh::aggregate(tensors);
 
     // Quiesce parent mesh before all reduce
     mesh_device_->quiesce_devices();
@@ -185,7 +185,7 @@ TEST_F(MeshDevice1x4Fixture, AllReduce) {
     // Quiesce parent mesh after all reduce
     mesh_device_->quiesce_devices();
 
-    auto disaggregated_output_tensors = tt::tt_metal::experimental::unit_mesh::disaggregate(all_reduced_tensor);
+    auto disaggregated_output_tensors = tt::tt_metal::unit_mesh::disaggregate(all_reduced_tensor);
     for (int dev_idx = 0; dev_idx < mesh_devices.size(); dev_idx++) {
         auto data = disaggregated_output_tensors[dev_idx].to_vector<bfloat16>();
         for (int i = 0; i < data.size(); i++) {

--- a/tests/ttnn/unit_tests/gtests/multi_thread/test_ccl_multi_cq_multi_device.cpp
+++ b/tests/ttnn/unit_tests/gtests/multi_thread/test_ccl_multi_cq_multi_device.cpp
@@ -154,8 +154,8 @@ TEST_F(MultiCQFabricMeshDevice2x4Fixture, AsyncExecutionWorksCQ0) {
 
         log_info(LogTest, "Enqueue AllGather");
 
-        auto aggregated_tensor = tt::tt_metal::experimental::unit_mesh::aggregate(device_tensors);
-        auto aggregated_output_tensor = tt::tt_metal::experimental::unit_mesh::aggregate(output_tensors);
+        auto aggregated_tensor = tt::tt_metal::unit_mesh::aggregate(device_tensors);
+        auto aggregated_output_tensor = tt::tt_metal::unit_mesh::aggregate(output_tensors);
         // Quiesce parent mesh before all gather
         mesh_device_->quiesce_devices();
 
@@ -334,8 +334,8 @@ TEST_F(MultiCQFabricMeshDevice2x4Fixture, AsyncExecutionWorksCQ0CQ1) {
 
         log_info(LogTest, "Enqueue AllGather");
 
-        auto aggregated_tensor = tt::tt_metal::experimental::unit_mesh::aggregate(device_tensors);
-        auto aggregated_output_tensor = tt::tt_metal::experimental::unit_mesh::aggregate(output_tensors);
+        auto aggregated_tensor = tt::tt_metal::unit_mesh::aggregate(device_tensors);
+        auto aggregated_output_tensor = tt::tt_metal::unit_mesh::aggregate(output_tensors);
 
         // Quiesce parent mesh before all gather
         mesh_device_->quiesce_devices();
@@ -540,8 +540,8 @@ TEST_F(MultiCQFabricMeshDevice2x4Fixture, AsyncExecutionWorksMultithreadCQ0) {
 
         log_info(LogTest, "Enqueue AllGather");
 
-        auto aggregated_tensor = tt::tt_metal::experimental::unit_mesh::aggregate(device_tensors);
-        auto aggregated_output_tensor = tt::tt_metal::experimental::unit_mesh::aggregate(output_tensors);
+        auto aggregated_tensor = tt::tt_metal::unit_mesh::aggregate(device_tensors);
+        auto aggregated_output_tensor = tt::tt_metal::unit_mesh::aggregate(output_tensors);
 
         // Quiesce parent mesh before all gather
         mesh_device_->quiesce_devices();

--- a/tests/ttnn/unit_tests/gtests/tensor/test_partition.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_partition.cpp
@@ -31,10 +31,10 @@ namespace ttnn {
 namespace {
 
 using ::testing::SizeIs;
-using ::tt::tt_metal::experimental::xtensor::chunk;
-using ::tt::tt_metal::experimental::xtensor::chunk_ndim;
-using ::tt::tt_metal::experimental::xtensor::concat;
-using ::tt::tt_metal::experimental::xtensor::concat_ndim;
+using ::tt::tt_metal::xtensor::chunk;
+using ::tt::tt_metal::xtensor::chunk_ndim;
+using ::tt::tt_metal::xtensor::concat;
+using ::tt::tt_metal::xtensor::concat_ndim;
 
 TEST(PartitionTest, ChunkBasicNonDivisible3) {
     // Create a 1D tensor: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
@@ -261,8 +261,7 @@ TEST(PartitionTest, ChunkDoesNotAccessData) {
         for (const auto& chunked_xexpr : chunks) {
             EXPECT_THAT(chunked_xexpr, SizeIs(kDim0Size * page_size));
             EXPECT_EQ(
-                tt::tt_metal::experimental::xtensor::get_shape_from_xarray(chunked_xexpr),
-                ttnn::Shape({kDim0Size, 1, page_size}));
+                tt::tt_metal::xtensor::get_shape_from_xarray(chunked_xexpr), ttnn::Shape({kDim0Size, 1, page_size}));
         }
     } else {
         FAIL() << "segfault occurred when calling `chunk`";

--- a/tests/ttnn/unit_tests/gtests/tensor/test_unit_mesh_utils.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_unit_mesh_utils.cpp
@@ -17,7 +17,7 @@
 #include "ttnn/tensor/unit_mesh/unit_mesh_utils.hpp"
 #include "tests/tt_metal/tt_metal/common/multi_device_fixture.hpp"
 
-namespace tt::tt_metal::experimental::unit_mesh {
+namespace tt::tt_metal::unit_mesh {
 namespace {
 
 using ::testing::HasSubstr;
@@ -233,4 +233,4 @@ TEST_F(UnitMeshUtils2x4Test, DisaggregateWithoutSubmeshes) {
 }
 
 }  // namespace
-}  // namespace tt::tt_metal::experimental::unit_mesh
+}  // namespace tt::tt_metal::unit_mesh

--- a/tests/ttnn/unit_tests/gtests/tensor/test_xtensor_adapter.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_xtensor_adapter.cpp
@@ -17,7 +17,7 @@ namespace ttnn {
 namespace {
 
 using ::testing::ElementsAre;
-using ::tt::tt_metal::experimental::xtensor::XtensorAdapter;
+using ::tt::tt_metal::xtensor::XtensorAdapter;
 
 TEST(XtensorAdapterTest, BasicConstruction) {
     std::vector<float> data = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f};

--- a/tests/ttnn/unit_tests/gtests/tensor/test_xtensor_conversion.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_xtensor_conversion.cpp
@@ -32,11 +32,11 @@ namespace {
 
 using ::testing::ElementsAre;
 using ::testing::Eq;
-using ::tt::tt_metal::experimental::xtensor::from_xtensor;
-using ::tt::tt_metal::experimental::xtensor::get_shape_from_xarray;
-using ::tt::tt_metal::experimental::xtensor::span_to_xtensor_view;
-using ::tt::tt_metal::experimental::xtensor::to_xtensor;
-using ::tt::tt_metal::experimental::xtensor::xtensor_to_span;
+using ::tt::tt_metal::xtensor::from_xtensor;
+using ::tt::tt_metal::xtensor::get_shape_from_xarray;
+using ::tt::tt_metal::xtensor::span_to_xtensor_view;
+using ::tt::tt_metal::xtensor::to_xtensor;
+using ::tt::tt_metal::xtensor::xtensor_to_span;
 
 TensorSpec get_tensor_spec(const ttnn::Shape& shape) {
     return TensorSpec(

--- a/tt-train/sources/ttml/core/tt_tensor_utils.hpp
+++ b/tt-train/sources/ttml/core/tt_tensor_utils.hpp
@@ -51,7 +51,7 @@ template <class T = float, ttnn::DataType TensorType = ttnn::DataType::BFLOAT16>
     ttnn::distributed::MeshDevice* device,
     ttnn::Layout layout = ttnn::Layout::TILE,
     const ttnn::distributed::TensorToMesh* mesh_mapper = nullptr) {
-    auto shape = tt::tt_metal::experimental::xtensor::get_shape_from_xarray(buffer);
+    auto shape = tt::tt_metal::xtensor::get_shape_from_xarray(buffer);
     auto buffer_view = xtensor_to_span(buffer);
     return from_vector<T, TensorType>(
         std::vector<T>(buffer_view.begin(), buffer_view.end()), shape, device, layout, mesh_mapper);

--- a/tt-train/sources/ttml/core/xtensor_utils.hpp
+++ b/tt-train/sources/ttml/core/xtensor_utils.hpp
@@ -58,16 +58,16 @@ set to N at compile time. xtensor_fixed<T, xshape<I, J, K> : tensor whose shape 
 namespace ttml::core {
 template <class T>
 xt::xarray<T> span_to_xtensor_view(std::span<T> vec, const ttnn::Shape& shape) {
-    return tt::tt_metal::experimental::xtensor::span_to_xtensor_view(vec, shape);
+    return tt::tt_metal::xtensor::span_to_xtensor_view(vec, shape);
 }
 template <class T>
 auto xtensor_to_span(const xt::xarray<T>& xtensor) {
-    return tt::tt_metal::experimental::xtensor::xtensor_to_span(xtensor);
+    return tt::tt_metal::xtensor::xtensor_to_span(xtensor);
 }
 
 template <typename T>
 xt::xarray<T> concat(const std::vector<xt::xarray<T>>& v, size_t axis = 0) {
-    return tt::tt_metal::experimental::xtensor::concat(v, axis).expr();
+    return tt::tt_metal::xtensor::concat(v, axis).expr();
 }
 
 }  // namespace ttml::core

--- a/ttnn/api/ttnn/tensor/unit_mesh/unit_mesh_utils.hpp
+++ b/ttnn/api/ttnn/tensor/unit_mesh/unit_mesh_utils.hpp
@@ -8,7 +8,7 @@
 
 #include "ttnn/tensor/tensor.hpp"
 
-namespace tt::tt_metal::experimental::unit_mesh {
+namespace tt::tt_metal::unit_mesh {
 
 // Aggregates tensors from unit meshes (1x1 submeshes) into a single tensor on the parent mesh.
 //
@@ -27,4 +27,4 @@ Tensor aggregate(const std::vector<tt::tt_metal::Tensor>& tensors);
 // Returns a vector of tensors, one per submesh, all sharing the same buffer address.
 std::vector<tt::tt_metal::Tensor> disaggregate(const tt::tt_metal::Tensor& tensor);
 
-}  // namespace tt::tt_metal::experimental::unit_mesh
+}  // namespace tt::tt_metal::unit_mesh

--- a/ttnn/api/ttnn/tensor/xtensor/conversion_utils.hpp
+++ b/ttnn/api/ttnn/tensor/xtensor/conversion_utils.hpp
@@ -10,7 +10,7 @@
 #include "ttnn/tensor/tensor.hpp"
 #include <ttnn/tensor/xtensor/xtensor_all_includes.hpp>
 
-namespace tt::tt_metal::experimental::xtensor {
+namespace tt::tt_metal::xtensor {
 
 // Returns the shape of the xtensor as `tt::tt_metal::Shape`.
 template <typename E>
@@ -122,4 +122,4 @@ xt::xarray<T> to_xtensor(const tt::tt_metal::Tensor& tensor) {
     return xt::xarray<T>(span_to_xtensor_view(tt::stl::Span<T>(vec.data(), vec.size()), shape));
 }
 
-}  // namespace tt::tt_metal::experimental::xtensor
+}  // namespace tt::tt_metal::xtensor

--- a/ttnn/api/ttnn/tensor/xtensor/partition.hpp
+++ b/ttnn/api/ttnn/tensor/xtensor/partition.hpp
@@ -10,7 +10,7 @@
 #include <xtensor/views/xstrided_view.hpp>
 #include "ttnn/tensor/tensor.hpp"
 
-namespace tt::tt_metal::experimental::xtensor {
+namespace tt::tt_metal::xtensor {
 namespace detail {
 
 // Helper to compute the type of an unowned strided view over an `xt::xexpression`.
@@ -59,4 +59,4 @@ XtensorAdapter<typename Expression::value_type> concat_ndim(
 // Deprecated: Use high-level APIs defined in distributed_tensor.hpp
 tt::tt_metal::Tensor concat(const std::vector<tt::tt_metal::Tensor>& tensors, int dim = 0);
 
-}  // namespace tt::tt_metal::experimental::xtensor
+}  // namespace tt::tt_metal::xtensor

--- a/ttnn/core/distributed/distributed_tensor.cpp
+++ b/ttnn/core/distributed/distributed_tensor.cpp
@@ -65,7 +65,7 @@ TensorSpec compute_tensor_spec_for_shards(
         if (!xtensor_view.has_value()) {
             continue;
         }
-        auto xtensor_shard_shape = tt::tt_metal::experimental::xtensor::get_shape_from_xarray(xtensor_view->get());
+        auto xtensor_shard_shape = tt::tt_metal::xtensor::get_shape_from_xarray(xtensor_view->get());
         if (shard_shape.has_value()) {
             TT_FATAL(
                 shard_shape.value() == xtensor_shard_shape,
@@ -194,10 +194,9 @@ public:
         }
 
         // Otherwise, use xtensor to chunk the data into shards.
-        auto input_xtensor =
-            tt::tt_metal::experimental::xtensor::adapt(span, std::vector<size_t>(shape.cbegin(), shape.cend()));
+        auto input_xtensor = tt::tt_metal::xtensor::adapt(span, std::vector<size_t>(shape.cbegin(), shape.cend()));
 
-        auto chunks = tt::tt_metal::experimental::xtensor::chunk_ndim(input_xtensor, num_chunks_per_dim, tensor_dims);
+        auto chunks = tt::tt_metal::xtensor::chunk_ndim(input_xtensor, num_chunks_per_dim, tensor_dims);
         TT_FATAL(chunks.size() >= 1, "No chunks were produced");
         TT_FATAL(
             distribution_shape_.dims() == 1 || chunks.size() == sharded_mesh_size,
@@ -205,8 +204,7 @@ public:
             chunks.size(),
             sharded_mesh_size);
 
-        using StridedViewRef =
-            std::reference_wrapper<tt::tt_metal::experimental::xtensor::StridedView<decltype(input_xtensor)>>;
+        using StridedViewRef = std::reference_wrapper<tt::tt_metal::xtensor::StridedView<decltype(input_xtensor)>>;
         tt::tt_metal::distributed::MeshContainer<std::optional<StridedViewRef>> sharded_xtensor_views(
             distribution_shape_, std::nullopt);
 
@@ -358,11 +356,11 @@ public:
         }
 
         // Convert shards into a linear buffer of xtensor views.
-        std::vector<tt::tt_metal::experimental::xtensor::AdaptedView<const T>> xtensor_views;
+        std::vector<tt::tt_metal::xtensor::AdaptedView<const T>> xtensor_views;
         xtensor_views.reserve(distribution_shape_.mesh_size());
         std::vector<size_t> shard_shape(tensor.logical_shape().cbegin(), tensor.logical_shape().cend());
         dst_buffer.apply([&xtensor_views, &shard_shape](const tt::tt_metal::HostBuffer& shard) {
-            xtensor_views.push_back(tt::tt_metal::experimental::xtensor::adapt(shard.view_as<const T>(), shard_shape));
+            xtensor_views.push_back(tt::tt_metal::xtensor::adapt(shard.view_as<const T>(), shard_shape));
         });
 
         tt::stl::SmallVector<int> num_chunks;
@@ -379,9 +377,8 @@ public:
             }
         }
 
-        auto xtensor_adapter =
-            tt::tt_metal::experimental::xtensor::concat_ndim(xtensor_views, num_chunks, config_.dims);
-        auto&& shape = tt::tt_metal::experimental::xtensor::get_shape_from_xarray(xtensor_adapter.expr());
+        auto xtensor_adapter = tt::tt_metal::xtensor::concat_ndim(xtensor_views, num_chunks, config_.dims);
+        auto&& shape = tt::tt_metal::xtensor::get_shape_from_xarray(xtensor_adapter.expr());
         return {std::move(xtensor_adapter).data(), std::move(shape)};
     }
 

--- a/ttnn/core/tensor/unit_mesh/unit_mesh_utils.cpp
+++ b/ttnn/core/tensor/unit_mesh/unit_mesh_utils.cpp
@@ -12,7 +12,7 @@
 #include <tt-metalium/allocator.hpp>
 #include <tt_stl/assert.hpp>
 
-namespace tt::tt_metal::experimental::unit_mesh {
+namespace tt::tt_metal::unit_mesh {
 
 namespace {
 
@@ -133,4 +133,4 @@ std::vector<tt::tt_metal::Tensor> disaggregate(const tt::tt_metal::Tensor& tenso
     return result;
 }
 
-}  // namespace tt::tt_metal::experimental::unit_mesh
+}  // namespace tt::tt_metal::unit_mesh

--- a/ttnn/core/tensor/xtensor/partition.cpp
+++ b/ttnn/core/tensor/xtensor/partition.cpp
@@ -19,7 +19,7 @@
 #include <xtensor/core/xtensor_forward.hpp>
 #include <xtensor/views/xview.hpp>
 
-namespace tt::tt_metal::experimental::xtensor {
+namespace tt::tt_metal::xtensor {
 namespace {
 
 ttsl::SmallVector<int> normalize_dims(const ttsl::SmallVector<int>& dims, size_t tensor_dims) {
@@ -303,4 +303,4 @@ EXPLICIT_INSTANTIATIONS_FOR_TYPE(uint32_t)
 
 #undef EXPLICIT_INSTANTIATIONS_FOR_TYPE
 
-}  // namespace tt::tt_metal::experimental::xtensor
+}  // namespace tt::tt_metal::xtensor


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/32471)

### Problem description
`unit_mesh_utils` and `xtensor` are no longer considered experimental, so the namespace and references should be updated.

### What's changed

- Removed `experimental` from `unit_mesh_utils` and `xtensor` namespaces
- Updated references accordingly

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes ([link to run](https://github.com/tenstorrent/tt-metal/actions/runs/19437893743))
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes