### PR TITLE
Fix 16-bit integer multiplication

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_mul_int.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_mul_int.h
@@ -11,14 +11,14 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_mul_int_init() {
-    llk_math_eltwise_binary_sfpu_init<SfpuType::unused, APPROXIMATE>();
+    llk_math_eltwise_binary_sfpu_init<SfpuType::mul_uint16, APPROXIMATE>(sfpu::_init_mul_int_<APPROXIMATE>);
 }
 
 template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_binary_sfpu_mul_int(
     uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::_mul_int_<APPROXIMATE, ITERATIONS>, dst_index0, dst_index1, odst, vector_mode);
+        sfpu::_mul_int_<APPROXIMATE, ITERATIONS>, dst_index0, dst_index1, odst, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_mul_int.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_mul_int.h
@@ -11,7 +11,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_mul_int_init() {
-    llk_math_eltwise_binary_sfpu_init<SfpuType::unused, APPROXIMATE>();
+    llk_math_eltwise_binary_sfpu_init<SfpuType::mul_uint16, APPROXIMATE>(sfpu::_init_mul_int_<APPROXIMATE>);
 }
 
 template <bool APPROXIMATE, int ITERATIONS = 8>


### PR DESCRIPTION
## This is a carbon copy of https://github.com/tenstorrent/tt-metal/pull/32519 since external contributors can't run all the pipelines.

### Ticket

https://github.com/tenstorrent/tt-metal/issues/32495

### Problem description
The current implementation doesn't work for all uint16 inputs; the result is shifted and truncated if it is greater than 24 bits.

### What's changed

- See https://github.com/tenstorrent/tt-llk/pull/843 for details of fix in tt-llk.
- This PR calls the new init function that has been added.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/19432882954) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/19432885785) CI with demo tests passes (if applicable)
- [x] [Post-commit C++ and eager tests](https://github.com/tenstorrent/tt-metal/actions/runs/19432890312) CI passes (if applicable)