### PR TITLE
#0: Subdevice assertions for aggregate/disaggregate

### DIFF
--- a/ttnn/core/tensor/unit_mesh/unit_mesh_utils.cpp
+++ b/ttnn/core/tensor/unit_mesh/unit_mesh_utils.cpp
@@ -41,6 +41,9 @@ Tensor aggregate(const std::vector<tt::tt_metal::Tensor>& tensors) {
     for (const auto& tensor : tensors) {
         auto* device = tensor.device();
         TT_FATAL(device != nullptr, "All tensors must be on device");
+        TT_FATAL(
+            device->get_active_sub_device_manager_id() == device->get_default_sub_device_manager_id(),
+            "Cannot aggregate tensors when non-default sub-device manager is active");
 
         const auto& shape = device->shape();
         TT_FATAL(shape.mesh_size() == 1, "Expected unit mesh (1x1), but got mesh of size {}", shape.mesh_size());
@@ -99,6 +102,9 @@ std::vector<tt::tt_metal::Tensor> disaggregate(const tt::tt_metal::Tensor& tenso
     // Validate the tensor is allocated on mesh device, that is parent mesh of unit meshes.
     auto* mesh_device = tensor.device();
     TT_FATAL(mesh_device != nullptr, "Tensor must be allocated on a mesh device");
+    TT_FATAL(
+        mesh_device->get_active_sub_device_manager_id() == mesh_device->get_default_sub_device_manager_id(),
+        "Cannot disaggregate tensor when non-default sub-device manager is active");
     const auto submeshes = mesh_device->get_submeshes();
     TT_FATAL(
         submeshes.size() == mesh_device->shape().mesh_size(),

--- a/ttnn/core/tensor/unit_mesh/unit_mesh_utils.cpp
+++ b/ttnn/core/tensor/unit_mesh/unit_mesh_utils.cpp
@@ -43,7 +43,7 @@ Tensor aggregate(const std::vector<tt::tt_metal::Tensor>& tensors) {
         TT_FATAL(device != nullptr, "All tensors must be on device");
         TT_FATAL(
             device->get_active_sub_device_manager_id() == device->get_default_sub_device_manager_id(),
-            "Cannot aggregate tensors when non-default sub-device manager is active");
+            "Cannot aggregate tensors when unit mesh has non-default sub-device manager");
 
         const auto& shape = device->shape();
         TT_FATAL(shape.mesh_size() == 1, "Expected unit mesh (1x1), but got mesh of size {}", shape.mesh_size());
@@ -55,6 +55,9 @@ Tensor aggregate(const std::vector<tt::tt_metal::Tensor>& tensors) {
     std::shared_ptr<tt::tt_metal::distributed::MeshDevice> parent_mesh = tensors[0].device()->get_parent_mesh();
     TT_FATAL(parent_mesh != nullptr, "First device must have a parent mesh");
     TT_FATAL(parent_mesh->shape().mesh_size() == tensors.size(), "Input tensors must span the entire parent mesh");
+    TT_FATAL(
+        parent_mesh->get_active_sub_device_manager_id() == parent_mesh->get_default_sub_device_manager_id(),
+        "Cannot aggregate tensors when parent mesh has non-default sub-device manager");
 
     for (size_t i = 1; i < devices.size(); i++) {
         TT_FATAL(
@@ -104,7 +107,7 @@ std::vector<tt::tt_metal::Tensor> disaggregate(const tt::tt_metal::Tensor& tenso
     TT_FATAL(mesh_device != nullptr, "Tensor must be allocated on a mesh device");
     TT_FATAL(
         mesh_device->get_active_sub_device_manager_id() == mesh_device->get_default_sub_device_manager_id(),
-        "Cannot disaggregate tensor when non-default sub-device manager is active");
+        "Cannot disaggregate tensor when parent mesh has non-default sub-device manager");
     const auto submeshes = mesh_device->get_submeshes();
     TT_FATAL(
         submeshes.size() == mesh_device->shape().mesh_size(),
@@ -127,6 +130,9 @@ std::vector<tt::tt_metal::Tensor> disaggregate(const tt::tt_metal::Tensor& tenso
     std::vector<Tensor> result;
     result.reserve(submeshes.size());
     for (const auto& submesh : submeshes) {
+        TT_FATAL(
+            submesh->get_active_sub_device_manager_id() == submesh->get_default_sub_device_manager_id(),
+            "Cannot disaggregate tensor when submesh has non-default sub-device manager");
         auto mesh_buffer = tt::tt_metal::distributed::MeshBuffer::create(
             input_mesh_buffer->global_config(), input_mesh_buffer->device_local_config(), submesh.get(), input_address);
 


### PR DESCRIPTION
### Ticket
Link to Github Issue: N/A

### Problem description
`agreggate/disaggregate` make the same assumptions about subdevices as `MeshDevice::quiesce_internal`, but don't enforce them with assertions.

### What's changed

- Added assertions for verifying subdevice allocator in `aggregate` and `disaggregate`

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes ([link to run](https://github.com/tenstorrent/tt-metal/actions/runs/19445400024))
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes