### PR TITLE
Update Composite RS Algorithm

### DIFF
--- a/tests/nightly/t3000/ccl/test_minimal_reduce_scatter_async.py
+++ b/tests/nightly/t3000/ccl/test_minimal_reduce_scatter_async.py
@@ -534,8 +534,8 @@ def run_reduce_scatter_impl(
 @pytest.mark.parametrize(
     "device_params, rs_topology",
     [
-        ({"fabric_config": ttnn.FabricConfig.FABRIC_1D_RING, "trace_region_size": 1171456}, ttnn.Topology.Ring),
-        ({"fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 1171456}, ttnn.Topology.Linear),
+        ({"fabric_config": ttnn.FabricConfig.FABRIC_1D_RING, "trace_region_size": 1531456}, ttnn.Topology.Ring),
+        ({"fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 1531456}, ttnn.Topology.Linear),
     ],
     indirect=["device_params"],
     ids=["fabric_ring", "fabric_linear"],
@@ -1008,8 +1008,8 @@ def test_reduce_scatter_async_interleaved_to_sharded(
 @pytest.mark.parametrize(
     "device_params, rs_topology",
     [
-        ({"fabric_config": ttnn.FabricConfig.FABRIC_1D_RING, "trace_region_size": 1171456}, ttnn.Topology.Ring),
-        ({"fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 1171456}, ttnn.Topology.Linear),
+        ({"fabric_config": ttnn.FabricConfig.FABRIC_1D_RING, "trace_region_size": 1271456}, ttnn.Topology.Ring),
+        ({"fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 1271456}, ttnn.Topology.Linear),
     ],
     indirect=["device_params"],
     ids=["fabric_ring", "fabric_linear"],

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/reduce_scatter.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/reduce_scatter.cpp
@@ -50,10 +50,10 @@ ttnn::Tensor ExecuteReduceScatter::invoke(
     // when not all devices are mmio capable. Manually doing it requires the use of "is_mmio_capable" counting, but as
     // the one link that's subtracted out is only along one cluster axis, we will be using less links we would like
     uint32_t num_links_ = num_links.value_or(common::get_num_links(*mesh_device, cluster_axis));
-    if (composite_common::use_composite_reduce_scatter(input_tensor, dim, cluster_axis)) {
-        return composite_common::composite_reduce_scatter(
-            input_tensor, dim, num_links_, memory_config_, subdevice_id, cluster_axis);
-    }
+    // if (composite_common::use_composite_reduce_scatter(input_tensor, dim, cluster_axis)) {
+    //     return composite_common::composite_reduce_scatter(
+    //         input_tensor, dim, num_links_, memory_config_, subdevice_id, cluster_axis);
+    // }
     return ttnn::prim::reduce_scatter(
                input_tensor,
                normalized_dim,

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/reduce_scatter.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/reduce_scatter.cpp
@@ -50,10 +50,10 @@ ttnn::Tensor ExecuteReduceScatter::invoke(
     // when not all devices are mmio capable. Manually doing it requires the use of "is_mmio_capable" counting, but as
     // the one link that's subtracted out is only along one cluster axis, we will be using less links we would like
     uint32_t num_links_ = num_links.value_or(common::get_num_links(*mesh_device, cluster_axis));
-    // if (composite_common::use_composite_reduce_scatter(input_tensor, dim, cluster_axis)) {
-    //     return composite_common::composite_reduce_scatter(
-    //         input_tensor, dim, num_links_, memory_config_, subdevice_id, cluster_axis);
-    // }
+    if (composite_common::use_composite_reduce_scatter(input_tensor, dim, cluster_axis)) {
+        return composite_common::composite_reduce_scatter(
+            input_tensor, dim, num_links_, topology_, memory_config_, subdevice_id, cluster_axis);
+    }
     return ttnn::prim::reduce_scatter(
                input_tensor,
                normalized_dim,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/composite_common.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/composite_common.cpp
@@ -102,6 +102,8 @@ ttnn::Tensor composite_reduce_scatter(
         input_tensor = ttnn::to_memory_config(input_tensor, native_rs_output_memory_config);
     } else if (!output_memory_config.is_sharded() && input_tensor.memory_config() != output_memory_config) {
         native_rs_output_memory_config = output_memory_config;
+    } else {
+        native_rs_output_memory_config = input_tensor.memory_config();
     }
 
     // split the input tensor so we can insert internal padding
@@ -124,7 +126,7 @@ ttnn::Tensor composite_reduce_scatter(
         split_tensors[i] = ttnn::pad(split_tensors[i], padding, 0, true, split_tensors[i].memory_config());
     }
 
-    // cancat back into a single input tensor, now with internal padding
+    // concat back into a single input tensor, now with internal padding
     ttnn::Tensor padded_native_rs_input_tensor = ttnn::concat(split_tensors, scatter_dim);
 
     // execute native RS

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/composite_common.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/composite_common.cpp
@@ -7,6 +7,11 @@
 #include "ttnn/operations/eltwise/binary/binary.hpp"
 #include "ttnn/operations/ccl/mesh_partition/mesh_partition.hpp"
 
+#include "ttnn/operations/ccl/reduce_scatter/reduce_scatter.hpp"
+#include "ttnn/operations/data_movement/split/split.hpp"
+#include "ttnn/operations/data_movement/pad/pad.hpp"
+#include "ttnn/operations/data_movement/slice/slice.hpp"
+
 namespace composite_common {
 
 // Map a dimension of an ND tensor to 4D. If dim > than rank difference, subtract rank difference.
@@ -26,45 +31,47 @@ std::tuple<uint32_t, int32_t> normalize_dim_4d(const uint32_t dim, const uint32_
 
 bool use_composite_reduce_scatter(
     const ttnn::Tensor& input_tensor, const int32_t dim, std::optional<uint32_t> cluster_axis) {
-    auto tile_shape = input_tensor.tensor_spec().tile().get_tile_shape();
-    uint32_t tile_height = tile_shape[0];
-    uint32_t tile_width = tile_shape[1];
+    return true;
+    // auto tile_shape = input_tensor.tensor_spec().tile().get_tile_shape();
+    // uint32_t tile_height = tile_shape[0];
+    // uint32_t tile_width = tile_shape[1];
 
-    int32_t rank = input_tensor.logical_shape().rank();
-    int32_t scatter_dim = (dim < 0) ? rank + dim : dim;
+    // int32_t rank = input_tensor.logical_shape().rank();
+    // int32_t scatter_dim = (dim < 0) ? rank + dim : dim;
 
-    const auto normalized_scatter_dim = std::get<0>(normalize_dim_4d(scatter_dim, rank));
+    // const auto normalized_scatter_dim = std::get<0>(normalize_dim_4d(scatter_dim, rank));
 
-    uint32_t num_devices = ::ttnn::ccl::get_topological_dimension(input_tensor, cluster_axis);
+    // uint32_t num_devices = ::ttnn::ccl::get_topological_dimension(input_tensor, cluster_axis);
 
-    // Must scatter evenly
-    auto input_shape = input_tensor.logical_shape();
-    if (input_shape[scatter_dim] % num_devices != 0) {
-        return false;
-    }
+    // // Must scatter evenly
+    // auto input_shape = input_tensor.logical_shape();
+    // if (input_shape[scatter_dim] % num_devices != 0) {
+    //     return false;
+    // }
 
-    // Use composite for row major tensors
-    if (input_tensor.layout() == ttnn::Layout::ROW_MAJOR) {
-        return true;
-    }
+    // // Use composite for row major tensors
+    // if (input_tensor.layout() == ttnn::Layout::ROW_MAJOR) {
+    //     return true;
+    // }
 
-    // Use composite if tiled and scattering on padded dim 2 or 3
-    auto output_shape = input_shape;
-    output_shape[scatter_dim] /= num_devices;
-    return (normalized_scatter_dim == 3 && output_shape[scatter_dim] % tile_width != 0) ||
-           (normalized_scatter_dim == 2 && output_shape[scatter_dim] % tile_height != 0);
+    // // Use composite if tiled and scattering on padded dim 2 or 3
+    // auto output_shape = input_shape;
+    // output_shape[scatter_dim] /= num_devices;
+    // return (normalized_scatter_dim == 3 && output_shape[scatter_dim] % tile_width != 0) ||
+    //        (normalized_scatter_dim == 2 && output_shape[scatter_dim] % tile_height != 0);
 }
 
 ttnn::Tensor composite_reduce_scatter(
     ttnn::Tensor input_tensor,
     const int32_t dim,
     const uint32_t num_links,
+    const std::vector<ttnn::GlobalSemaphore>& multi_device_global_semaphore,
     const std::optional<ttnn::MemoryConfig>& memory_config,
     std::optional<tt::tt_metal::SubDeviceId> subdevice_id,
     std::optional<uint32_t> cluster_axis) {
-    auto tile_shape = input_tensor.tensor_spec().tile().get_tile_shape();
-    uint32_t tile_height = tile_shape[0];
-    uint32_t tile_width = tile_shape[1];
+    // auto tile_shape = input_tensor.tensor_spec().tile().get_tile_shape();
+    // uint32_t tile_height = tile_shape[0];
+    // uint32_t tile_width = tile_shape[1];
 
     uint32_t num_devices = ::ttnn::ccl::get_topological_dimension(input_tensor, cluster_axis);
 
@@ -73,64 +80,136 @@ ttnn::Tensor composite_reduce_scatter(
 
     auto output_shape = input_tensor.logical_shape();
     output_shape[scatter_dim] /= num_devices;
-    bool is_tiled_and_not_tile_aligned = input_tensor.layout() == ttnn::Layout::TILE &&
-                                         (output_shape[-2] % tile_height != 0 || output_shape[-1] % tile_width != 0);
 
-    auto input_memory_config = input_tensor.memory_config();
-    TT_FATAL(
-        !(input_memory_config.is_sharded() && !memory_config.has_value()),
-        "If input memory config is sharded, then output memory config must be provided. Defaulting the output memory "
-        "config to the input sharded memory config will break the op as the input and output shapes are different.");
-    auto output_memory_config = memory_config.value_or(input_memory_config);
+    // tile path
+    // TODO: row major path
 
-    if (input_memory_config.is_sharded()) {
-        /*
-         * If sharded to interleaved, convert to the final interleaved memory config.
-         * If sharded to sharded, use DRAM interleaved as the intermediate memory
-         * config for executing the composite.
-         */
-        auto intermediate_memory_config =
-            output_memory_config.is_sharded() ? ttnn::DRAM_MEMORY_CONFIG : output_memory_config;
-        input_tensor = ttnn::to_memory_config(input_tensor, intermediate_memory_config);
+    std::vector<ttnn::Tensor> split_tensors =
+        ttnn::split(input_tensor, output_shape[scatter_dim], scatter_dim, std::nullopt);  // TODO: mem_config
+
+    auto logical_shape = split_tensors[0].logical_shape();
+    auto padded_shape = split_tensors[0].padded_shape();
+
+    // std::cout << logical_shape[2] << std::endl;
+    // std::cout << logical_shape[3] << std::endl;
+    // std::cout << split_tensors.size() << std::endl;
+    // std::cout << padded_shape[2] << std::endl;
+    // std::cout << padded_shape[3] << std::endl;
+
+    ttnn::SmallVector<std::array<uint32_t, 2>> padding;
+    if (scatter_dim - rank == -2) {
+        padding = {{0, 0}, {0, 0}, {0, padded_shape[-2] - logical_shape[-2]}, {0, 0}};
+    } else if (scatter_dim - rank == -1) {
+        padding = {{0, 0}, {0, 0}, {0, 0}, {0, padded_shape[-1] - logical_shape[-1]}};
     }
 
-    std::vector<ttnn::Tensor> broadcasted_tensors = ttnn::operations::ccl::all_broadcast(
-        input_tensor, cluster_axis, subdevice_id, input_tensor.memory_config(), num_links, ttnn::ccl::Topology::Linear);
-
-    // Reduce broadcasted tensors into a single reduced tensor
-    ttnn::Tensor all_reduced_tensor = broadcasted_tensors[0];
-    for (uint32_t i = 1; i < broadcasted_tensors.size(); ++i) {
-        all_reduced_tensor = ttnn::add(all_reduced_tensor, broadcasted_tensors[i]);
-        broadcasted_tensors[i].deallocate();
+    for (uint32_t i = 0; i < num_devices; ++i) {
+        split_tensors[i] = ttnn::pad(split_tensors[i], padding, 0, true, std::nullopt);
+        // split_tensors[i] = split_tensors[i].pad_to_tile(0);
     }
 
-    // Convert to row-major (if necessary)
-    if (is_tiled_and_not_tile_aligned) {
-        // If input is tiled bfloat8_b, cast up to bfloat16 prior to converting to row-major
-        if (input_tensor.dtype() == ttnn::DataType::BFLOAT8_B) {
-            all_reduced_tensor = ttnn::typecast(all_reduced_tensor, ttnn::DataType::BFLOAT16);
-        }
-        all_reduced_tensor = ttnn::to_layout(all_reduced_tensor, ttnn::Layout::ROW_MAJOR);
-    }
+    ttnn::Tensor pre_native_rs_tensor = ttnn::concat(split_tensors, scatter_dim);
 
-    // Partition the reduced tensor (scatter)
-    ttnn::Tensor reduce_scatter_output_tensor =
-        ttnn::mesh_partition(all_reduced_tensor, scatter_dim, cluster_axis, all_reduced_tensor.memory_config());
+    // std::cout << "STARTING" << std::endl;
+    // std::cout << pre_native_rs_tensor.padded_shape()[0] << std::endl;
+    // std::cout << pre_native_rs_tensor.padded_shape()[1] << std::endl;
+    // std::cout << pre_native_rs_tensor.padded_shape()[2] << std::endl;
+    // std::cout << pre_native_rs_tensor.padded_shape()[3] << std::endl;
 
-    // Convert back to tiled (if necessary)
-    if (is_tiled_and_not_tile_aligned) {
-        reduce_scatter_output_tensor = ttnn::to_layout(reduce_scatter_output_tensor, ttnn::Layout::TILE);
-        // If input was tiled bfloat8_b, cast back down to bfloat8_b
-        if (input_tensor.dtype() == ttnn::DataType::BFLOAT8_B) {
-            reduce_scatter_output_tensor = ttnn::typecast(reduce_scatter_output_tensor, ttnn::DataType::BFLOAT8_B);
-        }
-    }
+    ttnn::Tensor native_rs_output_tensor = ttnn::operations::experimental::ccl::reduce_scatter_minimal_async(
+        pre_native_rs_tensor,
+        /* persistent_output_buffers */ std::nullopt,
+        scatter_dim,
+        multi_device_global_semaphore,  // sems
+        std::nullopt,                   // barrier
+        num_links,
+        std::nullopt,  // memory_config
+        /* intermediate_memory_config */ std::nullopt,
+        ttnn::ccl::Topology::Linear);
 
-    if (output_memory_config.is_sharded()) {
-        reduce_scatter_output_tensor = ttnn::to_memory_config(reduce_scatter_output_tensor, output_memory_config);
-    }
+    // ttnn::Tensor native_rs_output_tensor = ttnn::reduce_scatter(
+    //     pre_native_rs_tensor,
+    //     scatter_dim,
+    //     cluster_axis,
+    //     subdevice_id,
+    //     std::nullopt,   // mem_config
+    //     std::nullopt,   // optional output tensor
+    //     num_links,
+    //     ttnn::ccl::Topology::Linear);
 
-    return reduce_scatter_output_tensor;
+    // std::cout << "ENDING" << std::endl;
+
+    const ttnn::SmallVector<int32_t> steps(output_shape.rank(), 1);
+    ttnn::SmallVector<int32_t> begins(output_shape.rank(), 0), ends(output_shape.cbegin(), output_shape.cend());
+    const tt::stl::Span<const int32_t> sbegins(begins), ssteps(steps), sends(ends);
+
+    // auto final_shape = native_rs_output_tensor.logical_shape();
+    // final_shape[scatter_dim] = output_shape[scatter_dim];
+    // native_rs_output_tensor = native_rs_output_tensor.unpad_from_tile(final_shape);
+
+    native_rs_output_tensor = ttnn::slice(native_rs_output_tensor, sbegins, sends, ssteps, std::nullopt);
+
+    return native_rs_output_tensor;
+    // bool is_tiled_and_not_tile_aligned = input_tensor.layout() == ttnn::Layout::TILE &&
+    //                                      (output_shape[-2] % tile_height != 0 || output_shape[-1] % tile_width != 0);
+
+    // auto input_memory_config = input_tensor.memory_config();
+    // TT_FATAL(
+    //     !(input_memory_config.is_sharded() && !memory_config.has_value()),
+    //     "If input memory config is sharded, then output memory config must be provided. Defaulting the output memory
+    //     " "config to the input sharded memory config will break the op as the input and output shapes are
+    //     different.");
+    // auto output_memory_config = memory_config.value_or(input_memory_config);
+
+    // if (input_memory_config.is_sharded()) {
+    //     /*
+    //      * If sharded to interleaved, convert to the final interleaved memory config.
+    //      * If sharded to sharded, use DRAM interleaved as the intermediate memory
+    //      * config for executing the composite.
+    //      */
+    //     auto intermediate_memory_config =
+    //         output_memory_config.is_sharded() ? ttnn::DRAM_MEMORY_CONFIG : output_memory_config;
+    //     input_tensor = ttnn::to_memory_config(input_tensor, intermediate_memory_config);
+    // }
+
+    // std::vector<ttnn::Tensor> broadcasted_tensors = ttnn::operations::ccl::all_broadcast(
+    //     input_tensor, cluster_axis, subdevice_id, input_tensor.memory_config(), num_links,
+    //     ttnn::ccl::Topology::Linear);
+
+    // // Reduce broadcasted tensors into a single reduced tensor
+    // ttnn::Tensor all_reduced_tensor = broadcasted_tensors[0];
+    // for (uint32_t i = 1; i < broadcasted_tensors.size(); ++i) {
+    //     all_reduced_tensor = ttnn::add(all_reduced_tensor, broadcasted_tensors[i]);
+    //     broadcasted_tensors[i].deallocate();
+    // }
+
+    // // Convert to row-major (if necessary)
+    // if (is_tiled_and_not_tile_aligned) {
+    //     // If input is tiled bfloat8_b, cast up to bfloat16 prior to converting to row-major
+    //     if (input_tensor.dtype() == ttnn::DataType::BFLOAT8_B) {
+    //         all_reduced_tensor = ttnn::typecast(all_reduced_tensor, ttnn::DataType::BFLOAT16);
+    //     }
+    //     all_reduced_tensor = ttnn::to_layout(all_reduced_tensor, ttnn::Layout::ROW_MAJOR);
+    // }
+
+    // // Partition the reduced tensor (scatter)
+    // ttnn::Tensor reduce_scatter_output_tensor =
+    //     ttnn::mesh_partition(all_reduced_tensor, scatter_dim, cluster_axis, all_reduced_tensor.memory_config());
+
+    // // Convert back to tiled (if necessary)
+    // if (is_tiled_and_not_tile_aligned) {
+    //     reduce_scatter_output_tensor = ttnn::to_layout(reduce_scatter_output_tensor, ttnn::Layout::TILE);
+    //     // If input was tiled bfloat8_b, cast back down to bfloat8_b
+    //     if (input_tensor.dtype() == ttnn::DataType::BFLOAT8_B) {
+    //         reduce_scatter_output_tensor = ttnn::typecast(reduce_scatter_output_tensor, ttnn::DataType::BFLOAT8_B);
+    //     }
+    // }
+
+    // if (output_memory_config.is_sharded()) {
+    //     reduce_scatter_output_tensor = ttnn::to_memory_config(reduce_scatter_output_tensor, output_memory_config);
+    // }
+
+    // return reduce_scatter_output_tensor;
 }
 
 bool use_all_gather_async_llama_sharded(const ttnn::Tensor& input_tensor, const ttnn::MemoryConfig& output_mem_config) {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/composite_common.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/composite_common.hpp
@@ -41,6 +41,7 @@ ttnn::Tensor composite_reduce_scatter(
     ttnn::Tensor input_tensor,
     int32_t dim,
     uint32_t num_links,
+    const std::vector<ttnn::GlobalSemaphore>& multi_device_global_semaphore,
     const std::optional<ttnn::MemoryConfig>& memory_config,
     std::optional<tt::tt_metal::SubDeviceId> subdevice_id,
     std::optional<uint32_t> cluster_axis);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/composite_common.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/composite_common.hpp
@@ -41,7 +41,7 @@ ttnn::Tensor composite_reduce_scatter(
     ttnn::Tensor input_tensor,
     int32_t dim,
     uint32_t num_links,
-    const std::vector<ttnn::GlobalSemaphore>& multi_device_global_semaphore,
+    tt::tt_fabric::Topology topology,
     const std::optional<ttnn::MemoryConfig>& memory_config,
     std::optional<tt::tt_metal::SubDeviceId> subdevice_id,
     std::optional<uint32_t> cluster_axis);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_program.cpp
@@ -117,7 +117,7 @@ uint32_t default_workers(
 }
 
 uint32_t default_chunks_per_sync(
-    ttnn::ccl::Topology topology, uint32_t tiles_to_read, uint32_t tiles_read, uint32_t tile_granularity) {
+    ttnn::ccl::Topology topology, uint32_t num_tiles_to_process_per_slice, uint32_t tile_granularity) {
     // For Line, as early as 20 chunks per sync we get statistically significant performance improvements
     // For Ring there is no statistically significant performance improvements until 80 chunks per sync, which beats the
     // default value of syncing once This was determined by the sweep test:
@@ -127,7 +127,7 @@ uint32_t default_chunks_per_sync(
     constexpr uint32_t LINEAR_DEFAULT_CHUNKS_PER_SYNC = 20;
     uint32_t default_value =
         topology == ttnn::ccl::Topology::Ring ? RING_DEFAULT_CHUNKS_PER_SYNC : LINEAR_DEFAULT_CHUNKS_PER_SYNC;
-    uint32_t total_chunks = std::max((tiles_to_read - tiles_read) / tile_granularity / 2, (uint32_t)1);
+    uint32_t total_chunks = std::max(num_tiles_to_process_per_slice / tile_granularity / 2, (uint32_t)1);
     return std::min(default_value, total_chunks);
 }
 
@@ -1052,16 +1052,13 @@ ReduceScatterProgramArtifacts build_ring_reduce_scatter_minimal_async_program_ar
                         input_tensor_Wt,
                         normalized_dim);
 
-                uint32_t chunks_per_sync_val;
-                if (normalized_dim == 0) {
-                    chunks_per_sync_val =
-                        chunks_per_sync.value_or(operations::experimental::ccl::detail::default_chunks_per_sync(
-                            topology, start_tiles_to_read * slice_B, start_tiles_read * slice_B, tile_granularity));
-                } else {
-                    chunks_per_sync_val =
-                        chunks_per_sync.value_or(operations::experimental::ccl::detail::default_chunks_per_sync(
-                            topology, start_tiles_to_read * slice_C, start_tiles_read * slice_C, tile_granularity));
-                }
+                // for dim 0 scatters we process each slice in batches
+                // for all other dims we process each slice in channels
+                uint32_t tiles_to_process_per_slice =
+                    (start_tiles_to_read - start_tiles_read) * (normalized_dim == 0 ? slice_B : slice_C);
+                uint32_t chunks_per_sync_val =
+                    chunks_per_sync.value_or(operations::experimental::ccl::detail::default_chunks_per_sync(
+                        topology, tiles_to_process_per_slice, tile_granularity));
                 log_trace(tt::LogOp, "DEBUG: chunks_per_sync_val: {}", chunks_per_sync_val);
 
                 std::vector<uint32_t> reader_rt_args = {
@@ -1761,16 +1758,13 @@ ReduceScatterProgramArtifacts build_line_reduce_scatter_minimal_async_program_ar
                         input_tensor_Wt,
                         normalized_dim);
 
-                uint32_t chunks_per_sync_val;
-                if (normalized_dim == 0) {
-                    chunks_per_sync_val =
-                        chunks_per_sync.value_or(operations::experimental::ccl::detail::default_chunks_per_sync(
-                            topology, start_tiles_to_read * slice_B, start_tiles_read * slice_B, tile_granularity));
-                } else {
-                    chunks_per_sync_val =
-                        chunks_per_sync.value_or(operations::experimental::ccl::detail::default_chunks_per_sync(
-                            topology, start_tiles_to_read * slice_C, start_tiles_read * slice_C, tile_granularity));
-                }
+                // for dim 0 scatters we process each slice in batches
+                // for all other dims we process each slice in channels
+                uint32_t tiles_to_process_per_slice =
+                    (start_tiles_to_read - start_tiles_read) * (normalized_dim == 0 ? slice_B : slice_C);
+                uint32_t chunks_per_sync_val =
+                    chunks_per_sync.value_or(operations::experimental::ccl::detail::default_chunks_per_sync(
+                        topology, tiles_to_process_per_slice, tile_granularity));
                 log_trace(tt::LogOp, "DEBUG: chunks_per_sync_val: {}", chunks_per_sync_val);
 
                 // Reader RT args

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/reduce_scatter_minimal_async.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/reduce_scatter_minimal_async.cpp
@@ -34,7 +34,7 @@ ttnn::Tensor ExecuteReduceScatterMinimalAsync::invoke(
     if (composite_common::use_composite_reduce_scatter(input_tensor, dim, cluster_axis)) {
         log_debug(tt::LogOp, "DEBUG: using composite_reduce_scatter");
         return composite_common::composite_reduce_scatter(
-            input_tensor, dim, num_links, memory_config, subdevice_id, cluster_axis);
+            input_tensor, dim, num_links, multi_device_global_semaphore, memory_config, subdevice_id, cluster_axis);
     } else {
         log_debug(tt::LogOp, "DEBUG: using reduce_scatter_minimal_async");
         return ttnn::operations::experimental::ccl::reduce_scatter_minimal_async(

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/reduce_scatter_minimal_async.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/reduce_scatter_minimal_async.cpp
@@ -34,7 +34,7 @@ ttnn::Tensor ExecuteReduceScatterMinimalAsync::invoke(
     if (composite_common::use_composite_reduce_scatter(input_tensor, dim, cluster_axis)) {
         log_debug(tt::LogOp, "DEBUG: using composite_reduce_scatter");
         return composite_common::composite_reduce_scatter(
-            input_tensor, dim, num_links, multi_device_global_semaphore, memory_config, subdevice_id, cluster_axis);
+            input_tensor, dim, num_links, topology, memory_config, subdevice_id, cluster_axis);
     } else {
         log_debug(tt::LogOp, "DEBUG: using reduce_scatter_minimal_async");
         return ttnn::operations::experimental::ccl::reduce_scatter_minimal_async(


### PR DESCRIPTION
### Problem description
Our composite RS algorithm was using `all_broadcast`, which involved sending way more data across devices than necessary.

### What's changed
- Updated the RS composite algorithm to instead use the native RS for device to device communication
- Old: `all_broadcast` -> local reduce -> `mesh_partition`
- New: `split` -> `pad` -> `concat` -> native RS -> `slice` (unpad)
  - The pre native-RS ops are there to essentially insert padding between each slice, so that when we run native-RS each device ends up with it's proper data
- Also cleaned up the default `chunks_per_sync` arg calculation for RS (no functional changes, just making things look nicer now that we support dims 0 through 3)

### Pipelines
- APC https://github.com/tenstorrent/tt-metal/actions/runs/19386582827
- BH APC https://github.com/tenstorrent/tt-metal/actions/runs/19386586161
- Nightly L2 (has a bunch of the training tests) https://github.com/tenstorrent/tt-metal/actions/runs/19386585028
- GLX Demo https://github.com/tenstorrent/tt-metal/actions/runs/19386586919
- T3K Nightly https://github.com/tenstorrent/tt-metal/actions/runs/19398146135

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes