### PR TITLE
[skip ci] [Reduce APC] Move dispatch multicmd queue in cpp from apc to l2nightly

### DIFF
--- a/.github/workflows/cpp-l2nightly.yaml
+++ b/.github/workflows/cpp-l2nightly.yaml
@@ -49,6 +49,9 @@ jobs:
           - name: dispatch
             cmd: |
               TT_METAL_ENABLE_ERISC_IRAM=1 ./build/test/tt_metal/unit_tests_dispatch --gtest_filter=$GTEST_FILTER
+          - name: dispatch multicmd queue
+            cmd: |
+              TT_METAL_ENABLE_ERISC_IRAM=1 TT_METAL_GTEST_NUM_HW_CQS=2 ./build/test/tt_metal/unit_tests_dispatch --gtest_filter=UnitMeshMultiCQ*Fixture.${GTEST_FILTER}
           - name: distributed
             cmd: |
               ./build/test/tt_metal/distributed/distributed_unit_tests --gtest_filter=$GTEST_FILTER

--- a/.github/workflows/tt-metal-l2-nightly.yaml
+++ b/.github/workflows/tt-metal-l2-nightly.yaml
@@ -136,7 +136,7 @@ jobs:
           { arch: wormhole_b0, runner-label: N300 },
           { arch: blackhole, runner-label: P150b },
         ]
-    uses: ./.github/workflows/cpp-post-commit.yaml
+    uses: ./.github/workflows/cpp-l2nightly.yaml
     with:
       arch: ${{ matrix.test-group.arch }}
       runner-label: ${{ matrix.test-group.runner-label }}


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [x] All post commit CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/19440921331
- [x] L2-nightly runs and passes `dispatch` and `dispatch multicmd queue`: https://github.com/tenstorrent/tt-metal/actions/runs/19440906270/job/55624452672