### PR TITLE
[skip ci] Fix setup-job to correctly check inputs.use-evaluation-image 

### DIFF
--- a/.github/actions/setup-job/action.yml
+++ b/.github/actions/setup-job/action.yml
@@ -29,7 +29,7 @@ runs:
   using: "composite"
   steps:
     - name: 🧬 Checkout Repository
-      if: ${{ inputs.use-evaluation-image == false }}
+      if: ${{ inputs.use-evaluation-image == 'false' }}
       uses: actions/checkout@v4
       with:
         fetch-depth: ${{ inputs.fetch-depth }}
@@ -44,27 +44,27 @@ runs:
       shell: bash
 
     - name: 📦 Download Build Artifact
-      if: ${{ inputs.build-artifact-name != '' && inputs.use-evaluation-image == false }}
+      if: ${{ inputs.build-artifact-name != '' && inputs.use-evaluation-image == 'false' }}
       uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0
       with:
         name: ${{ inputs.build-artifact-name }}
         path: ${{ inputs.path }}
 
     - name: 📂 Extract Build Files
-      if: ${{ inputs.build-artifact-name != '' && inputs.use-evaluation-image == false }}
+      if: ${{ inputs.build-artifact-name != '' && inputs.use-evaluation-image == 'false' }}
       working-directory: ${{ inputs.path }}
       run: tar --zstd -xf ttm_any.tar.zst
       shell: bash
 
     - name: 🧪 Download Python Wheel
-      if: ${{ inputs.wheel-artifact-name != '' && inputs.use-evaluation-image == false }}
+      if: ${{ inputs.wheel-artifact-name != '' && inputs.use-evaluation-image == 'false' }}
       uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0
       with:
         name: ${{ inputs.wheel-artifact-name }}
         path: ${{ inputs.path }}
 
     - name: 💿 Install Wheel
-      if: ${{ inputs.wheel-artifact-name != '' && inputs.use-evaluation-image == false }}
+      if: ${{ inputs.wheel-artifact-name != '' && inputs.use-evaluation-image == 'false' }}
       working-directory: ${{ inputs.path }}
       run: |
         echo "📂 In directory: $(pwd)"


### PR DESCRIPTION
### Ticket
None

### Problem description
Broke after https://github.com/tenstorrent/tt-metal/pull/32427
Github composite action inputs are always strings (why github... https://github.com/actions/runner/issues/2238)

### What's changed
Correct the condition so that steps are not skipped by accident
E.g. https://github.com/tenstorrent/tt-metal/actions/runs/19439696545/job/55620500469 the test fails because the checkout repo step is skipped due to the incorrect condition