### PR TITLE
Change to correct API for generating CoreCoords in non-rectangular grids in untilize_with_unpadding_multi_core_sharded

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_program_factory.cpp
@@ -899,7 +899,6 @@ operation::ProgramWithCallbacks untilize_with_unpadding_multi_core_sharded(
     auto out_shard_spec = output.shard_spec().has_value() ? output.shard_spec().value() : shard_spec;
 
     bool row_major = shard_spec.orientation == ShardOrientation::ROW_MAJOR;
-
     auto all_cores = shard_spec.grid;
     uint32_t ntiles_per_block = shard_spec.shape[1] / TILE_WIDTH;
     uint32_t nblocks_per_core = shard_spec.shape[0] / TILE_HEIGHT;

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_program_factory.cpp
@@ -899,11 +899,8 @@ operation::ProgramWithCallbacks untilize_with_unpadding_multi_core_sharded(
     auto out_shard_spec = output.shard_spec().has_value() ? output.shard_spec().value() : shard_spec;
 
     bool row_major = shard_spec.orientation == ShardOrientation::ROW_MAJOR;
-    auto grid = *shard_spec.grid.ranges().begin();
-    uint32_t ncores_x = grid.end_coord.x + 1;
-    uint32_t ncores_y = grid.end_coord.y + 1;
+
     auto all_cores = shard_spec.grid;
-    uint32_t ncores = all_cores.num_cores();
     uint32_t ntiles_per_block = shard_spec.shape[1] / TILE_WIDTH;
     uint32_t nblocks_per_core = shard_spec.shape[0] / TILE_HEIGHT;
     uint32_t batch = a.physical_volume() / (a.padded_shape()[-2] * a.padded_shape()[-1]);
@@ -1055,7 +1052,7 @@ operation::ProgramWithCallbacks untilize_with_unpadding_multi_core_sharded(
         }
         tt::tt_metal::SetRuntimeArgs(program, unary_writer_kernel_id, all_cores, writer_rt_args);
     } else {
-        cores = grid_to_cores(ncores, ncores_x, ncores_y, row_major);
+        cores = corerange_to_cores(all_cores, std::nullopt, row_major);
         for (uint32_t i = 0; i < cores.size(); ++i) {
             CoreCoord& core = cores[i];
 


### PR DESCRIPTION

### Ticket
[#32470
](https://github.com/tenstorrent/tt-metal/issues/32470)
### Problem description
The `untilize_with_unpadding_multi_core_sharded`kernel program factory in `ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_program_factory.cpp` was using the wrong API which assumed a rectangular grid of cores. This was causing the error in the ticket.
### What's changed
Changed the program factory to use the API `corerange_to_cores` instead of `grid_to_cores` to generate the vector of CoreCoords. This API does not assume a rectangular core grid and generates the vector of CoreCoords based on the ranges of core coordinates specified by the user.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/19448356911) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/19448368913) CI with demo tests passes (if applicable)
- [x] [apc nightly debug run](https://github.com/tenstorrent/tt-metal/actions/runs/19448323169)
- [x] New/Existing tests provide coverage for changes