### PR TITLE
[skip ci] Replace codeowner-bypass team reference in codeowners analysis

### DIFF
--- a/.github/workflows/codeowners-group-analysis.yaml
+++ b/.github/workflows/codeowners-group-analysis.yaml
@@ -1872,7 +1872,7 @@ jobs:
               [ -z "$team" ] && continue
 
               if [ "$team" = "@tenstorrent/codeowner-bypass" ]; then
-                echo "DEBUG: Skipping large-changes team"
+                echo "DEBUG: Skipping codeowner-bypass team"
                 continue
               fi
 

--- a/.github/workflows/codeowners-group-analysis.yaml
+++ b/.github/workflows/codeowners-group-analysis.yaml
@@ -777,7 +777,7 @@ jobs:
               [ -z "$team_entry" ] && continue
               team=$(echo "$team_entry" | cut -d':' -f1)
               [ -z "$team" ] && continue
-              [ "$team" = "@tenstorrent/metalium-codeowners-large-changes" ] && continue
+              [ "$team" = "@tenstorrent/codeowner-bypass" ] && continue
               team_files=$(echo "$team_entry" | cut -d':' -f2-)
               clean_team=$(echo "$team" | sed 's/^@//')
               sorted_files=$(echo "$team_files" | tr ',' '\n' | sort | tr '\n' ',' | sed 's/,$//')
@@ -1767,7 +1767,7 @@ jobs:
               team=$(echo "$team_entry" | cut -d':' -f1)
               [ -z "$team" ] && continue
 
-              if [ "$team" = "@tenstorrent/metalium-codeowners-large-changes" ]; then
+              if [ "$team" = "@tenstorrent/codeowner-bypass" ]; then
                 continue
               fi
 
@@ -1871,7 +1871,7 @@ jobs:
               echo "DEBUG: Extracted team='$team'"
               [ -z "$team" ] && continue
 
-              if [ "$team" = "@tenstorrent/metalium-codeowners-large-changes" ]; then
+              if [ "$team" = "@tenstorrent/codeowner-bypass" ]; then
                 echo "DEBUG: Skipping large-changes team"
                 continue
               fi


### PR DESCRIPTION
### Ticket
NA

### Problem description
team name recently changed

### What's changed
rename

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes