### PR TITLE
Update BH Galaxy XY Torus Expected QSFP Cabling

### DIFF
--- a/tools/scaleout/node/node.cpp
+++ b/tools/scaleout/node/node.cpp
@@ -283,17 +283,17 @@ private:
         add_connection(qsfp_connections, 1, 4, 3, 4);
         add_connection(qsfp_connections, 1, 5, 3, 5);
         add_connection(qsfp_connections, 1, 6, 3, 6);
-        add_connection(qsfp_connections, 2, 3, 4, 3);
-        add_connection(qsfp_connections, 2, 4, 4, 4);
-        add_connection(qsfp_connections, 2, 5, 4, 5);
         add_connection(qsfp_connections, 2, 6, 4, 6);
+        add_connection(qsfp_connections, 2, 5, 4, 5);
+        add_connection(qsfp_connections, 2, 4, 4, 4);
+        add_connection(qsfp_connections, 2, 3, 4, 3);
     }
 
     // Add Y-torus QSFP connections
     static void add_y_torus_connections(tt::scaleout_tools::cabling_generator::proto::NodeDescriptor* node) {
         auto* const qsfp_connections = get_port_connections(node, "QSFP_DD");
-        add_connection(qsfp_connections, 1, 1, 2, 1);
         add_connection(qsfp_connections, 1, 2, 2, 2);
+        add_connection(qsfp_connections, 1, 1, 2, 1);
         add_connection(qsfp_connections, 3, 1, 4, 1);
         add_connection(qsfp_connections, 3, 2, 4, 2);
     }

--- a/tools/scaleout/node/node.cpp
+++ b/tools/scaleout/node/node.cpp
@@ -279,23 +279,23 @@ private:
     // Add X-torus QSFP connections
     static void add_x_torus_connections(tt::scaleout_tools::cabling_generator::proto::NodeDescriptor* node) {
         auto* const qsfp_connections = get_port_connections(node, "QSFP_DD");
-        add_connection(qsfp_connections, 1, 3, 2, 3);
-        add_connection(qsfp_connections, 1, 4, 2, 4);
-        add_connection(qsfp_connections, 1, 5, 2, 5);
-        add_connection(qsfp_connections, 1, 6, 2, 6);
-        add_connection(qsfp_connections, 3, 6, 4, 6);
-        add_connection(qsfp_connections, 3, 5, 4, 5);
-        add_connection(qsfp_connections, 3, 4, 4, 4);
-        add_connection(qsfp_connections, 3, 3, 4, 3);
+        add_connection(qsfp_connections, 1, 3, 3, 3);
+        add_connection(qsfp_connections, 1, 4, 3, 4);
+        add_connection(qsfp_connections, 1, 5, 3, 5);
+        add_connection(qsfp_connections, 1, 6, 3, 6);
+        add_connection(qsfp_connections, 2, 3, 4, 3);
+        add_connection(qsfp_connections, 2, 4, 4, 4);
+        add_connection(qsfp_connections, 2, 5, 4, 5);
+        add_connection(qsfp_connections, 2, 6, 4, 6);
     }
 
     // Add Y-torus QSFP connections
     static void add_y_torus_connections(tt::scaleout_tools::cabling_generator::proto::NodeDescriptor* node) {
         auto* const qsfp_connections = get_port_connections(node, "QSFP_DD");
-        add_connection(qsfp_connections, 1, 2, 3, 2);
-        add_connection(qsfp_connections, 1, 1, 3, 1);
-        add_connection(qsfp_connections, 2, 1, 4, 1);
-        add_connection(qsfp_connections, 2, 2, 4, 2);
+        add_connection(qsfp_connections, 1, 1, 2, 1);
+        add_connection(qsfp_connections, 1, 2, 2, 2);
+        add_connection(qsfp_connections, 3, 1, 4, 1);
+        add_connection(qsfp_connections, 3, 2, 4, 2);
     }
 
 public:


### PR DESCRIPTION
### Ticket
No Ticket.

### Problem description
- External Cabling for BH Galaxy in `tools/scaleout/node/node.cpp` was incorrectly modelled, since it did not account for Trays 2 and 3 being swapped with respect to WH Galaxy
 
### What's changed
- Update cabling to match POR.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes