### PR TITLE
SDXL refiner fix

### DIFF
--- a/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
@@ -52,7 +52,7 @@ def test_unet(
 
 @pytest.mark.models_device_performance_bare_metal
 def test_sdxl_unet_perf_device():
-    expected_device_perf_cycles_per_iteration = 164_837_382
+    expected_device_perf_cycles_per_iteration = 163_890_516
 
     command = f"pytest models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py::test_unet"
     cols = ["DEVICE FW", "DEVICE KERNEL", "DEVICE BRISC KERNEL"]
@@ -117,7 +117,7 @@ def test_refiner_unet(
 
 @pytest.mark.models_device_performance_bare_metal
 def test_sdxl_refiner_unet_perf_device():
-    expected_device_perf_cycles_per_iteration = 530_025_393
+    expected_device_perf_cycles_per_iteration = 529_581_745
 
     command = f"pytest models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py::test_refiner_unet"
     cols = ["DEVICE FW", "DEVICE KERNEL", "DEVICE BRISC KERNEL"]

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_attention.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_attention.py
@@ -61,7 +61,7 @@ class TtAttention(LightweightModule):
 
         if self.is_self_attention == True:
             self.sdpa_program_config.q_chunk_size = 128
-            self.sdpa_program_config.k_chunk_size = 512 if out_dim == 640 else 1024
+            self.sdpa_program_config.k_chunk_size = 1024 if self.heads == 20 else 512
             fused_qkv_weights = torch.cat(
                 [
                     torch.transpose(q_weights, -2, -1),


### PR DESCRIPTION
### What's changed
Changed the k chunk size in refiner to avoid OOM.

### Checklist
- [x] [(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/19461071242) CI passes
- [x] [(Single-card) Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/runs/19461089222) CI passes