### PR TITLE
#31426: 64-bit vs 32-bit pointer confusion

### DIFF
--- a/tt_metal/hw/firmware/src/tt-2xx/quasar/noc.c
+++ b/tt_metal/hw/firmware/src/tt-2xx/quasar/noc.c
@@ -21,10 +21,10 @@
 
 #define NOC_WRITE_REG(addr, val)                                      \
     ((*((volatile uint32_t*)(noc_get_cmd_buf() * NOC_CMD_BUF_OFFSET + \
-                             noc_get_active_instance() * NOC_INSTANCE_OFFSET + (addr)))) = (val))
+                             noc_get_active_instance() * NOC_INSTANCE_OFFSET + ((uintptr_t)addr)))) = (val))
 #define NOC_READ_REG(addr)                                                                                             \
     (*((volatile uint32_t*)(noc_get_cmd_buf() * NOC_CMD_BUF_OFFSET + noc_get_active_instance() * NOC_INSTANCE_OFFSET + \
-                            (addr))))
+                            ((uintptr_t)addr))))
 
 #endif
 

--- a/tt_metal/hw/inc/accessor/dspec.h
+++ b/tt_metal/hw/inc/accessor/dspec.h
@@ -13,7 +13,7 @@
 
 #if defined(KERNEL_BUILD) || defined(FW_BUILD)
 // Forward declared from dataflow_api.h
-static uint32_t get_common_arg_addr(int arg_idx);
+static uintptr_t get_common_arg_addr(int arg_idx);
 #else
 // In non-kernel/non-firmware builds, get_common_arg_addr is a stub that always returns 0U.
 // This is safe because the function should not be called in these builds; if it is, 0U is an invalid address

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -100,7 +100,7 @@ bool is_l1_address(uint64_t addr) { return ((addr & 0xFFFFFFFF) < NOC_REG_SPACE_
  * | arg_idx        | Unique Runtime argument index                                           | uint32_t | 0 to 341    | True     |
  */
 // clang-format on
-static FORCE_INLINE uint32_t get_arg_addr(int arg_idx) { return (uint32_t)&rta_l1_base[arg_idx]; }
+static FORCE_INLINE uintptr_t get_arg_addr(int arg_idx) { return (uintptr_t)&rta_l1_base[arg_idx]; }
 
 // clang-format off
 /**
@@ -114,7 +114,7 @@ static FORCE_INLINE uint32_t get_arg_addr(int arg_idx) { return (uint32_t)&rta_l
  * | arg_idx        | Common Runtime argument index                                           | uint32_t | 0 to 341    | True     |
  */
 // clang-format on
-static FORCE_INLINE uint32_t get_common_arg_addr(int arg_idx) { return (uint32_t)&crta_l1_base[arg_idx]; }
+static FORCE_INLINE uintptr_t get_common_arg_addr(int arg_idx) { return (uintptr_t)&crta_l1_base[arg_idx]; }
 
 // clang-format off
 /**
@@ -314,7 +314,7 @@ uint32_t get_read_ptr(uint32_t operand) {
     return rd_ptr_bytes;
 }
 
-inline void wait_for_sync_register_value(uint32_t addr, int32_t val) {
+inline void wait_for_sync_register_value(uintptr_t addr, int32_t val) {
     volatile tt_reg_ptr uint32_t* reg_ptr = (volatile uint32_t*)addr;
     int32_t reg_value;
     WAYPOINT("SW");
@@ -341,7 +341,7 @@ inline void wait_for_sync_register_value(uint32_t addr, int32_t val) {
 // clang-format on
 FORCE_INLINE
 bool cb_pages_reservable_at_back(int32_t operand, int32_t num_pages) {
-    uint32_t pages_acked_ptr = (uint32_t)get_cb_tiles_acked_ptr(operand);
+    uintptr_t pages_acked_ptr = (uintptr_t)get_cb_tiles_acked_ptr(operand);
 
     // while the producer (write-side interface) is waiting for space to free up "tiles_pushed" is not changing
     // "tiles_pushed" is updated by the producer only when the tiles are pushed
@@ -371,7 +371,7 @@ bool cb_pages_reservable_at_back(int32_t operand, int32_t num_pages) {
 // clang-format on
 FORCE_INLINE
 void cb_reserve_back(int32_t operand, int32_t num_pages) {
-    uint32_t pages_acked_ptr = (uint32_t)get_cb_tiles_acked_ptr(operand);
+    uintptr_t pages_acked_ptr = (uintptr_t)get_cb_tiles_acked_ptr(operand);
 
     // while the producer (write-side interface) is waiting for space to free up "tiles_pushed" is not changing
     // "tiles_pushed" is updated by the producer only when the tiles are pushed
@@ -418,7 +418,7 @@ void cb_reserve_back(int32_t operand, int32_t num_pages) {
 FORCE_INLINE
 bool cb_pages_available_at_front(int32_t operand, int32_t num_pages) {
     uint32_t pages_acked = get_cb_tiles_acked_ptr(operand)[0];
-    uint32_t pages_received_ptr = (uint32_t)get_cb_tiles_received_ptr(operand);
+    uintptr_t pages_received_ptr = (uintptr_t)get_cb_tiles_received_ptr(operand);
 
     uint16_t pages_received = ((uint16_t)reg_read(pages_received_ptr)) - pages_acked;
     return num_pages <= pages_received;
@@ -451,7 +451,7 @@ bool cb_pages_available_at_front(int32_t operand, int32_t num_pages) {
 FORCE_INLINE
 void cb_wait_front(int32_t operand, int32_t num_pages) {
     uint32_t pages_acked = get_cb_tiles_acked_ptr(operand)[0];
-    uint32_t pages_received_ptr = (uint32_t)get_cb_tiles_received_ptr(operand);
+    uintptr_t pages_received_ptr = (uintptr_t)get_cb_tiles_received_ptr(operand);
 
     uint16_t pages_received;
 

--- a/tt_metal/hw/inc/firmware_common.h
+++ b/tt_metal/hw/inc/firmware_common.h
@@ -81,7 +81,7 @@ uint32_t firmware_config_init(
     extern uint32_t tt_l1_ptr* sem_l1_base[ProgrammableCoreType::COUNT];
 
     // TODO: check the asm for this loop to be sure loads are scheduled ok
-    uint32_t kernel_config_base[ProgrammableCoreType::COUNT];
+    uintptr_t kernel_config_base[ProgrammableCoreType::COUNT];
     launch_msg_t* launch_msg_address = &(mailboxes->launch[mailboxes->launch_msg_rd_ptr]);
 #pragma GCC unroll ProgrammableCoreType::COUNT
     for (uint32_t index = 0; index < ProgrammableCoreType::COUNT; index++) {

--- a/tt_metal/hw/inc/tensix_functions.h
+++ b/tt_metal/hw/inc/tensix_functions.h
@@ -748,4 +748,4 @@ inline void dbg_instrn_buf_clear_override_en() {
 }
 
 extern "C" void wzerorange(uint32_t* start, uint32_t* end);
-inline void wzeromem(uint32_t start, uint32_t len) { wzerorange((uint32_t*)start, (uint32_t*)(start + len)); }
+inline void wzeromem(uintptr_t start, uint32_t len) { wzerorange((uint32_t*)start, (uint32_t*)(start + len)); }

--- a/tt_metal/hw/inc/tt-2xx/quasar/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/tt-2xx/quasar/noc_nonblocking_api.h
@@ -115,25 +115,25 @@ inline __attribute__((always_inline)) void NOC_CMD_BUF_WRITE_REG(
         watcher_msg->noc_linked_status[noc] = (val & NOC_CMD_VC_LINKED) != 0;
     }
 #endif
-    uint32_t offset = (buf << NOC_CMD_BUF_OFFSET_BIT) + (noc << NOC_INSTANCE_OFFSET_BIT) + addr;
+    uintptr_t offset = (buf << NOC_CMD_BUF_OFFSET_BIT) + (noc << NOC_INSTANCE_OFFSET_BIT) + addr;
     volatile uint32_t* ptr = (volatile uint32_t*)offset;
     *ptr = val;
 }
 
 inline __attribute__((always_inline)) uint32_t NOC_CMD_BUF_READ_REG(uint32_t noc, uint32_t buf, uint32_t addr) {
-    uint32_t offset = (buf << NOC_CMD_BUF_OFFSET_BIT) + (noc << NOC_INSTANCE_OFFSET_BIT) + addr;
+    uintptr_t offset = (buf << NOC_CMD_BUF_OFFSET_BIT) + (noc << NOC_INSTANCE_OFFSET_BIT) + addr;
     volatile uint32_t* ptr = (volatile uint32_t*)offset;
     return *ptr;
 }
 
 inline __attribute__((always_inline)) uint32_t NOC_STATUS_READ_REG(uint32_t noc, uint32_t reg_id) {
-    uint32_t offset = (noc << NOC_INSTANCE_OFFSET_BIT) + NOC_STATUS(reg_id);
+    uintptr_t offset = (noc << NOC_INSTANCE_OFFSET_BIT) + NOC_STATUS(reg_id);
     volatile uint32_t* ptr = (volatile uint32_t*)offset;
     return *ptr;
 }
 
 inline __attribute__((always_inline)) uint32_t NOC_CFG_READ_REG(uint32_t noc, uint32_t reg_id) {
-    uint32_t offset = (noc << NOC_INSTANCE_OFFSET_BIT) + NOC_CFG(reg_id);
+    uintptr_t offset = (noc << NOC_INSTANCE_OFFSET_BIT) + NOC_CFG(reg_id);
     volatile uint32_t* ptr = (volatile uint32_t*)offset;
     return *ptr;
 }
@@ -143,7 +143,7 @@ inline __attribute__((always_inline)) bool noc_cmd_buf_ready(uint32_t noc, uint3
 }
 
 inline __attribute__((always_inline)) void noc_clear_outstanding_req_cnt(uint32_t noc, uint32_t id_mask) {
-    uint32_t offset = (noc << NOC_INSTANCE_OFFSET_BIT) + NOC_CLEAR_OUTSTANDING_REQ_CNT;
+    uintptr_t offset = (noc << NOC_INSTANCE_OFFSET_BIT) + NOC_CLEAR_OUTSTANDING_REQ_CNT;
     volatile uint32_t* ptr = (volatile uint32_t*)offset;
     *ptr = id_mask;
 }
@@ -160,11 +160,11 @@ inline __attribute__((always_inline)) uint32_t noc_get_interim_inline_value_addr
     uint32_t offset = dst_noc_addr & 0xF;
 
 #if defined(COMPILE_FOR_IDLE_ERISC)
-    uint32_t src_addr = MEM_IERISC_L1_INLINE_BASE + (2 * MEM_L1_INLINE_SIZE_PER_NOC) * proc_type;
+    uintptr_t src_addr = MEM_IERISC_L1_INLINE_BASE + (2 * MEM_L1_INLINE_SIZE_PER_NOC) * proc_type;
 #elif defined(COMPILE_FOR_ERISC)
-    uint32_t src_addr = MEM_AERISC_L1_INLINE_BASE + (2 * MEM_L1_INLINE_SIZE_PER_NOC) * proc_type;
+    uintptr_t src_addr = MEM_AERISC_L1_INLINE_BASE + (2 * MEM_L1_INLINE_SIZE_PER_NOC) * proc_type;
 #else
-    uint32_t src_addr = MEM_L1_INLINE_BASE + (2 * MEM_L1_INLINE_SIZE_PER_NOC) * proc_type;
+    uintptr_t src_addr = MEM_L1_INLINE_BASE + (2 * MEM_L1_INLINE_SIZE_PER_NOC) * proc_type;
 #endif
 
 #ifdef COMPILE_FOR_TRISC

--- a/tt_metal/hw/inc/tt-2xx/risc_common.h
+++ b/tt_metal/hw/inc/tt-2xx/risc_common.h
@@ -42,12 +42,12 @@ extern uint8_t my_x[NUM_NOCS];
 // Virtual Y coordinate
 extern uint8_t my_y[NUM_NOCS];
 
-inline void WRITE_REG(uint32_t addr, uint32_t val) {
+inline void WRITE_REG(uintptr_t addr, uint32_t val) {
     volatile tt_reg_ptr uint32_t* ptr = (volatile tt_reg_ptr uint32_t*)addr;
     ptr[0] = val;
 }
 
-inline uint32_t READ_REG(uint32_t addr) {
+inline uint32_t READ_REG(uintptr_t addr) {
     volatile tt_reg_ptr uint32_t* ptr = (volatile tt_reg_ptr uint32_t*)addr;
     return ptr[0];
 }
@@ -106,7 +106,7 @@ inline __attribute__((always_inline)) uint32_t buf_ptr_dec_wrap(uint32_t buf_ptr
 // tt_metal/third_party/tt_llk_wormhole_b0/common/inc/ckernel.h, which trisc
 // kernels bring into the global namespace using "using namespace ckernel".
 #if !defined(COMPILE_FOR_TRISC)  // BRISC, NCRISC, ERISC, IERISC
-inline __attribute__((always_inline)) uint32_t reg_read(uint32_t addr) {
+inline __attribute__((always_inline)) uint32_t reg_read(uintptr_t addr) {
     volatile tt_reg_ptr uint32_t* p_reg = reinterpret_cast<volatile tt_reg_ptr uint32_t*>(addr);
     return p_reg[0];
 }


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/31426

### Problem description
We use uint32_t where we should be using uintptr_t (or, heaven forfend, an actual pointer maybe?)

### What's changed
@arikTT added uintptr_t in a lot of places.

This is a precursor to updating the linker scripts for qsr64 support.

### Checklist
- [YES] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [YES] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes