### PR TITLE
#32539: implement ttnn.manual_seed op scaffolding

### DIFF
--- a/docs/source/ttnn/ttnn/api.rst
+++ b/docs/source/ttnn/ttnn/api.rst
@@ -426,6 +426,7 @@ Reduction
    ttnn.prod
    ttnn.topk
    ttnn.cumsum
+   ttnn.manual_seed
 
 Data Movement
 =============

--- a/tests/ttnn/unit_tests/operations/data_movement/test_manual_seed.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_manual_seed.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
+import torch
 import ttnn
 
 
@@ -28,13 +29,13 @@ def test_manual_short_with_user_id(device):
 
 def test_manual_tensors(device):
     """Test manual_seed with tensor inputs for both seeds and user_ids, verifying tensor-based API."""
-    seed_tensor = ttnn.rand([42], dtype=ttnn.uint32, layout=ttnn.Layout.ROW_MAJOR, device=device)
-    user_id_tensor = ttnn.rand([7], dtype=ttnn.uint32, layout=ttnn.Layout.ROW_MAJOR, device=device)
+    seed_tensor = ttnn.from_torch(torch.Tensor([42]), dtype=ttnn.uint32, layout=ttnn.Layout.ROW_MAJOR, device=device)
+    user_id_tensor = ttnn.from_torch(torch.Tensor([7]), dtype=ttnn.uint32, layout=ttnn.Layout.ROW_MAJOR, device=device)
     ttnn.manual_seed(device=device, seeds=seed_tensor, user_ids=user_id_tensor)
 
 
 def test_manual_tensors_wrong_config(device):
     """Test that manual_seed raises ValueError when mixing tensor seeds with scalar user_ids (invalid configuration)."""
-    seed_tensor = ttnn.rand([42], dtype=ttnn.uint32, layout=ttnn.Layout.ROW_MAJOR, device=device)
+    seed_tensor = ttnn.from_torch(torch.Tensor([42]), dtype=ttnn.uint32, layout=ttnn.Layout.ROW_MAJOR, device=device)
     with pytest.raises(Exception):
         ttnn.manual_seed(device=device, seeds=seed_tensor, user_ids=7)

--- a/tests/ttnn/unit_tests/operations/data_movement/test_manual_seed.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_manual_seed.py
@@ -3,14 +3,38 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
-import torch
 import ttnn
-from tests.ttnn.utils_for_testing import assert_with_pcc
-
-TILE_WIDTH = 32
 
 
 def test_manual_seed(device):
-    torch.manual_seed(0)
-
+    """Test manual_seed with explicit keyword arguments for device and seeds (integer scalar)."""
     ttnn.manual_seed(device=device, seeds=42)
+
+
+def test_manual_seed_with_user_id(device):
+    """Test manual_seed with both seed and user_id as integer scalars using keyword arguments."""
+    ttnn.manual_seed(device=device, seeds=42, user_ids=7)
+
+
+def test_manual_short(device):
+    """Test manual_seed using positional arguments with only seed (shorthand syntax)."""
+    ttnn.manual_seed(device, 42)
+
+
+def test_manual_short_with_user_id(device):
+    """Test manual_seed using positional arguments for device and seed, with user_id as keyword argument."""
+    ttnn.manual_seed(device, 42, user_ids=7)
+
+
+def test_manual_tensors(device):
+    """Test manual_seed with tensor inputs for both seeds and user_ids, verifying tensor-based API."""
+    seed_tensor = ttnn.rand([42], dtype=ttnn.uint32, layout=ttnn.Layout.ROW_MAJOR, device=device)
+    user_id_tensor = ttnn.rand([7], dtype=ttnn.uint32, layout=ttnn.Layout.ROW_MAJOR, device=device)
+    ttnn.manual_seed(device=device, seeds=seed_tensor, user_ids=user_id_tensor)
+
+
+def test_manual_tensors_wrong_config(device):
+    """Test that manual_seed raises ValueError when mixing tensor seeds with scalar user_ids (invalid configuration)."""
+    seed_tensor = ttnn.rand([42], dtype=ttnn.uint32, layout=ttnn.Layout.ROW_MAJOR, device=device)
+    with pytest.raises(Exception):
+        ttnn.manual_seed(device=device, seeds=seed_tensor, user_ids=7)

--- a/tests/ttnn/unit_tests/operations/data_movement/test_manual_seed.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_manual_seed.py
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+import ttnn
+from tests.ttnn.utils_for_testing import assert_with_pcc
+
+TILE_WIDTH = 32
+
+
+def test_manual_seed(device):
+    torch.manual_seed(0)
+
+    ttnn.manual_seed(device, 42)

--- a/tests/ttnn/unit_tests/operations/data_movement/test_manual_seed.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_manual_seed.py
@@ -13,4 +13,4 @@ TILE_WIDTH = 32
 def test_manual_seed(device):
     torch.manual_seed(0)
 
-    ttnn.manual_seed(device, 42)
+    ttnn.manual_seed(device=device, seeds=42)

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -311,6 +311,7 @@ set(TTNN_SRC_PYBIND
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/reduction/moe/moe_${PY_BINDING}.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/reduction/sampling/sampling_${PY_BINDING}.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/reduction/topk/topk_${PY_BINDING}.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/reduction/manual_seed/manual_seed_${PY_BINDING}.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/sliding_window/sliding_window_${PY_BINDING}.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/transformer/attention_softmax/attention_softmax_${PY_BINDING}.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/transformer/concatenate_heads/concatenate_heads_${PY_BINDING}.cpp

--- a/ttnn/cpp/ttnn/operations/reduction/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/reduction/CMakeLists.txt
@@ -20,6 +20,7 @@ file(
     prod/device/kernels/*
     sampling/device/kernels/*
     topk/device/kernels/*
+    manual_seed/device/kernels/*
 )
 target_sources(
     ttnn_op_reduction
@@ -65,6 +66,9 @@ target_sources(
         topk/topk.cpp
         topk/device/topk_program_factory.cpp
         reduction_common/reduction_common.cpp
+        manual_seed/manual_seed.cpp
+        manual_seed/device/manual_seed_operation.cpp
+        manual_seed/device/manual_seed_program_factory.cpp
 )
 
 target_include_directories(ttnn_op_reduction PRIVATE ${FixmeOpIncDirs})

--- a/ttnn/cpp/ttnn/operations/reduction/manual_seed/device/manual_seed_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/manual_seed/device/manual_seed_device_operation_types.hpp
@@ -16,6 +16,8 @@ struct operation_attributes_t {
 };
 
 struct tensor_args_t {
+    Tensor
+        output{};  // TODO: To be removed when API will be fixed with https://github.com/tenstorrent/tt-metal/pull/32260
     std::optional<Tensor> seeds = std::nullopt;
     std::optional<Tensor> user_ids = std::nullopt;
 };

--- a/ttnn/cpp/ttnn/operations/reduction/manual_seed/device/manual_seed_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/manual_seed/device/manual_seed_device_operation_types.hpp
@@ -17,7 +17,7 @@ struct operation_attributes_t {
 
 struct tensor_args_t {
     Tensor
-        output{};  // TODO: To be removed when API will be fixed with https://github.com/tenstorrent/tt-metal/pull/32260
+        output;  // TODO: To be removed when API will be fixed with https://github.com/tenstorrent/tt-metal/pull/32260
     std::optional<Tensor> seeds = std::nullopt;
     std::optional<Tensor> user_ids = std::nullopt;
 };

--- a/ttnn/cpp/ttnn/operations/reduction/manual_seed/device/manual_seed_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/manual_seed/device/manual_seed_device_operation_types.hpp
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/tensor/tensor.hpp"
+
+#include <optional>
+
+namespace ttnn::operations::reduction::manual_seed {
+struct operation_attributes_t {
+    tt::tt_metal::distributed::MeshDevice* device = nullptr;
+    std::optional<uint32_t> seeds = std::nullopt;
+    std::optional<uint32_t> user_ids = std::nullopt;
+};
+
+struct tensor_args_t {
+    std::optional<Tensor> seeds = std::nullopt;
+    std::optional<Tensor> user_ids = std::nullopt;
+};
+
+using spec_return_value_t = ttnn::TensorSpec;
+using tensor_return_value_t = Tensor;
+
+}  // namespace ttnn::operations::reduction::manual_seed

--- a/ttnn/cpp/ttnn/operations/reduction/manual_seed/device/manual_seed_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/manual_seed/device/manual_seed_operation.cpp
@@ -89,15 +89,14 @@ ManualSeedDeviceOperation::invoke(
         operation_attributes.user_ids = std::get<uint32_t>(user_ids.value());
     }
     // Prepare tensor arguments
-    tensor_args_t tensor_args{};
-
     // TODO: To be removed when API will be fixed with https://github.com/tenstorrent/tt-metal/pull/32260
     auto output_tensor = create_device_tensor(
         ttnn::TensorSpec(
             ttnn::Shape{1},
             tt::tt_metal::TensorLayout(DataType::UINT32, tt::tt_metal::PageConfig(Layout::ROW_MAJOR), MemoryConfig())),
         std::addressof(device));
-    tensor_args.output = output_tensor;
+
+    tensor_args_t tensor_args{output_tensor};
 
     if (std::holds_alternative<Tensor>(seeds)) {
         tensor_args.seeds = std::get<Tensor>(seeds);

--- a/ttnn/cpp/ttnn/operations/reduction/manual_seed/device/manual_seed_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/manual_seed/device/manual_seed_operation.hpp
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "manual_seed_device_operation_types.hpp"
+#include "manual_seed_program_factory.hpp"
+
+#include "ttnn/decorators.hpp"
+
+#include <optional>
+
+namespace ttnn::operations::reduction::manual_seed {
+
+struct ManualSeedDeviceOperation {
+    using operation_attributes_t = manual_seed::operation_attributes_t;
+    using tensor_args_t = manual_seed::tensor_args_t;
+    using spec_return_value_t = manual_seed::spec_return_value_t;
+    using tensor_return_value_t = manual_seed::tensor_return_value_t;
+    using program_factory_t = std::variant<program::ManualSeedProgramFactory>;
+
+    static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
+
+    static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
+    static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
+
+    static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
+    static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
+
+    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
+        MeshDevice& device,
+        std::variant<uint32_t, Tensor> seeds,
+        std::optional<std::variant<uint32_t, Tensor>> user_ids);
+};
+
+}  // namespace ttnn::operations::reduction::manual_seed
+
+namespace ttnn::prim {
+
+constexpr auto manual_seed = ttnn::register_operation<
+    "ttnn::prim::manual_seed",
+    ttnn::operations::reduction::manual_seed::ManualSeedDeviceOperation>();
+
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/reduction/manual_seed/device/manual_seed_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/manual_seed/device/manual_seed_program_factory.cpp
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "manual_seed_program_factory.hpp"
+
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+
+namespace ttnn::operations::reduction::manual_seed::program {
+using namespace tt::tt_metal;
+
+ManualSeedProgramFactory::cached_program_t ManualSeedProgramFactory::create(
+    const operation_attributes_t& /*operation_attributes*/,
+    const tensor_args_t& /*tensor_args*/,
+    tensor_return_value_t& /*output_tensor*/) {
+    tt::tt_metal::Program program{};
+
+    return cached_program_t{std::move(program), {}};
+}
+
+void ManualSeedProgramFactory::override_runtime_arguments(
+    cached_program_t& /*cached_program*/,
+    const operation_attributes_t& /*operation_attributes*/,
+    const tensor_args_t& /*tensor_args*/,
+    tensor_return_value_t& /*output_tensor*/) {
+    // TODO: Fill
+}
+}  // namespace ttnn::operations::reduction::manual_seed::program

--- a/ttnn/cpp/ttnn/operations/reduction/manual_seed/device/manual_seed_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/manual_seed/device/manual_seed_program_factory.hpp
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "manual_seed_device_operation_types.hpp"
+
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/work_split.hpp>
+#include "ttnn/device_operation.hpp"
+
+namespace ttnn::operations::reduction::manual_seed::program {
+using namespace tt::tt_metal;
+
+struct ManualSeedProgramFactory {
+    struct shared_variables_t {};
+
+    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
+
+    static cached_program_t create(const operation_attributes_t&, const tensor_args_t&, tensor_return_value_t&);
+    static void override_runtime_arguments(
+        cached_program_t&, const operation_attributes_t&, const tensor_args_t&, tensor_return_value_t&);
+};
+
+}  // namespace ttnn::operations::reduction::manual_seed::program

--- a/ttnn/cpp/ttnn/operations/reduction/manual_seed/manual_seed.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/manual_seed/manual_seed.cpp
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "manual_seed.hpp"
+
+namespace ttnn::operations::reduction {
+
+uint32_t ExecuteManualSeed::invoke(
+    MeshDevice& device, std::variant<uint32_t, Tensor> seeds, std::optional<std::variant<uint32_t, Tensor>> user_ids) {
+    return 0;
+    // TODO: Implementation
+}
+
+}  // namespace ttnn::operations::reduction

--- a/ttnn/cpp/ttnn/operations/reduction/manual_seed/manual_seed.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/manual_seed/manual_seed.cpp
@@ -4,12 +4,13 @@
 
 #include "manual_seed.hpp"
 
+#include "device/manual_seed_operation.hpp"
+
 namespace ttnn::operations::reduction {
 
-uint32_t ExecuteManualSeed::invoke(
+Tensor ExecuteManualSeed::invoke(
     MeshDevice& device, std::variant<uint32_t, Tensor> seeds, std::optional<std::variant<uint32_t, Tensor>> user_ids) {
-    return 0;
-    // TODO: Implementation
+    return ttnn::prim::manual_seed(device, seeds, user_ids);
 }
 
 }  // namespace ttnn::operations::reduction

--- a/ttnn/cpp/ttnn/operations/reduction/manual_seed/manual_seed.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/manual_seed/manual_seed.hpp
@@ -9,9 +9,10 @@
 #include "ttnn/decorators.hpp"
 
 namespace ttnn::operations::reduction {
+
 // NOTE: This OP does not return anything, but register_operation currently does not handle void return types.
 struct ExecuteManualSeed {
-    static uint32_t invoke(
+    static Tensor invoke(
         MeshDevice& device,
         std::variant<uint32_t, Tensor> seeds,
         std::optional<std::variant<uint32_t, Tensor>> user_ids = std::nullopt);

--- a/ttnn/cpp/ttnn/operations/reduction/manual_seed/manual_seed.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/manual_seed/manual_seed.hpp
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <optional>
+
+#include "ttnn/decorators.hpp"
+
+namespace ttnn::operations::reduction {
+// NOTE: This OP does not return anything, but register_operation currently does not handle void return types.
+struct ExecuteManualSeed {
+    static uint32_t invoke(
+        MeshDevice& device,
+        std::variant<uint32_t, Tensor> seeds,
+        std::optional<std::variant<uint32_t, Tensor>> user_ids = std::nullopt);
+};
+
+}  // namespace ttnn::operations::reduction
+
+namespace ttnn {
+
+constexpr auto manual_seed =
+    ttnn::register_operation<"ttnn::manual_seed", ttnn::operations::reduction::ExecuteManualSeed>();
+
+}  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/reduction/manual_seed/manual_seed_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/manual_seed/manual_seed_pybind.cpp
@@ -27,7 +27,32 @@ void bind_manual_seed_operation(py::module& module) {
 
             Returns:
                 Tensor: An empty tensor, as this operation does not produce a meaningful output. To be changed in the future.
+
+            Note:
+
+                Supported dtypes and layout for seeds tensor values:
+
+                .. list-table::
+                    :header-rows: 1
+
+                    * - Dtypes
+                      - Layouts
+                    * - X
+                      - X
+                    * - X
+                      - X
+
+                Supported dtypes and layout for user_ids tensor values:
+
+                .. list-table::
+                    :header-rows: 1
+
+                    * - Dtypes
+                      - Layouts
+                    * - X, X
+                      - X
         )doc";
+    // TODO: To be filled when implementing device logic
     using OperationType = decltype(ttnn::manual_seed);
     bind_registered_operation(
         module,

--- a/ttnn/cpp/ttnn/operations/reduction/manual_seed/manual_seed_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/manual_seed/manual_seed_pybind.cpp
@@ -15,8 +15,7 @@ void bind_manual_seed_operation(py::module& module) {
     auto doc = R"doc(
             Sets a seed to pseudo random number generators (PRNGs) on the specified device.
 
-            This operation allows users to set a specific seed or a tensor of seeds for random number generation,
-            ensuring reproducibility in operations that rely on randomness.
+            This operation allows users to either set a single seed value to all PRNGs in the device, or to specify potentially different seed values to PRNGs at the cores assigned to the provided user IDs.
 
             Args:
                 device (ttnn.MeshDevice): The device on which to set the manual seed.

--- a/ttnn/cpp/ttnn/operations/reduction/manual_seed/manual_seed_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/manual_seed/manual_seed_pybind.cpp
@@ -26,7 +26,7 @@ void bind_manual_seed_operation(py::module& module) {
                 user_ids (int or ttnn.Tensor, optional): An optional user ID or tensor of user IDs associated with the seeds.
 
             Returns:
-                None
+                Tensor: An empty tensor, as this operation does not produce a meaningful output. To be changed in the future.
         )doc";
     using OperationType = decltype(ttnn::manual_seed);
     bind_registered_operation(
@@ -37,10 +37,10 @@ void bind_manual_seed_operation(py::module& module) {
             [](const OperationType& self,
                MeshDevice& device,
                std::variant<uint32_t, ttnn::Tensor> seeds,
-               std::optional<std::variant<uint32_t, ttnn::Tensor>> user_ids) -> uint32_t {
+               std::optional<std::variant<uint32_t, ttnn::Tensor>> user_ids) -> Tensor {
                 return self(device, seeds, user_ids);
             },
-            py::arg("device").noconvert(),
+            py::arg("device"),
             py::arg("seeds"),
             py::kw_only(),
             py::arg("user_ids") = std::nullopt});

--- a/ttnn/cpp/ttnn/operations/reduction/manual_seed/manual_seed_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/manual_seed/manual_seed_pybind.cpp
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "manual_seed_pybind.hpp"
+
+#include "manual_seed.hpp"
+
+#include "ttnn-pybind/decorators.hpp"
+
+namespace ttnn::operations::reduction::detail {
+namespace py = pybind11;
+
+void bind_manual_seed_operation(py::module& module) {
+    auto doc = R"doc(
+            Sets the manual seed for random number generation on the specified device.
+
+            This operation allows users to set a specific seed or a tensor of seeds for random number generation,
+            ensuring reproducibility in operations that rely on randomness.
+
+            Args:
+                device (ttnn.MeshDevice): The device on which to set the manual seed.
+                seeds (int or ttnn.Tensor): A single integer seed or a tensor of seeds to initialize the random number generator.
+
+            Keyword Args:
+                user_ids (int or ttnn.Tensor, optional): An optional user ID or tensor of user IDs associated with the seeds.
+
+            Returns:
+                None
+        )doc";
+    using OperationType = decltype(ttnn::manual_seed);
+    bind_registered_operation(
+        module,
+        ttnn::manual_seed,
+        doc,
+        ttnn::pybind_overload_t{
+            [](const OperationType& self,
+               MeshDevice& device,
+               std::variant<uint32_t, ttnn::Tensor> seeds,
+               std::optional<std::variant<uint32_t, ttnn::Tensor>> user_ids) -> uint32_t {
+                return self(device, seeds, user_ids);
+            },
+            py::arg("device").noconvert(),
+            py::arg("seeds"),
+            py::kw_only(),
+            py::arg("user_ids") = std::nullopt});
+}
+
+}  // namespace ttnn::operations::reduction::detail

--- a/ttnn/cpp/ttnn/operations/reduction/manual_seed/manual_seed_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/manual_seed/manual_seed_pybind.cpp
@@ -13,7 +13,7 @@ namespace py = pybind11;
 
 void bind_manual_seed_operation(py::module& module) {
     auto doc = R"doc(
-            Sets the manual seed for random number generation on the specified device.
+            Sets a seed to pseudo random number generators (PRNGs) on the specified device.
 
             This operation allows users to set a specific seed or a tensor of seeds for random number generation,
             ensuring reproducibility in operations that rely on randomness.

--- a/ttnn/cpp/ttnn/operations/reduction/manual_seed/manual_seed_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/manual_seed/manual_seed_pybind.hpp
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn-pybind/pybind_fwd.hpp"
+
+namespace ttnn::operations::reduction::detail {
+namespace py = pybind11;
+
+void bind_manual_seed_operation(py::module& module);
+
+}  // namespace ttnn::operations::reduction::detail

--- a/ttnn/cpp/ttnn/operations/reduction/reduction_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/reduction_pybind.cpp
@@ -19,6 +19,7 @@
 #include "ttnn/operations/reduction/prod/prod_pybind.hpp"
 #include "ttnn/operations/reduction/sampling/sampling_pybind.hpp"
 #include "ttnn/operations/reduction/topk/topk_pybind.hpp"
+#include "ttnn/operations/reduction/manual_seed/manual_seed_pybind.hpp"
 
 namespace ttnn::operations::reduction {
 
@@ -42,6 +43,7 @@ void py_module(py::module& module) {
     detail::bind_reduction_prod_operation(module, ttnn::prod);
     detail::bind_reduction_sampling_operation(module);
     detail::bind_reduction_topk_operation(module);
+    detail::bind_manual_seed_operation(module);
 }
 
 }  // namespace ttnn::operations::reduction


### PR DESCRIPTION
### Ticket
This PR implements scaffolding (OP placeholder) for `ttnn.manual_seed` described in #32539 

### What's changed
- Added scaffolding of the OP based on ticked description,
- Added base test for passing input params,
- Added docs binding,

### Next steps
- Implement device logic,
- Add example code snippet to OP docs,
- Add more tests for device logic.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/19493435242 https://github.com/tenstorrent/tt-metal/actions/runs/19494712725
 