### PR TITLE
#31426: Fix DebugPrintToId specializations

### DIFF
--- a/tt_metal/hw/inc/debug/dprint.h
+++ b/tt_metal/hw/inc/debug/dprint.h
@@ -193,13 +193,27 @@ template <>
 uint8_t DebugPrintTypeToId<uint16_t>() {
     return DPrintUINT16;
 }
+// We can't specialize on uint32_t or uint64_t because we don't know
+// whether on ILP32 unsigned or unsigned long is used for uint32_t and
+// on LP64 whether unsigned long or unsigned long long for uint64_t
 template <>
-uint8_t DebugPrintTypeToId<uint32_t>() {
+uint8_t DebugPrintTypeToId<unsigned>() {
+    static_assert(sizeof(unsigned) == sizeof(uint32_t));
     return DPrintUINT32;
 }
 template <>
-uint8_t DebugPrintTypeToId<uint64_t>() {
+uint8_t DebugPrintTypeToId<unsigned long long>() {
+    static_assert(sizeof(unsigned long long) == sizeof(uint64_t));
     return DPrintUINT64;
+}
+template <>
+uint8_t DebugPrintTypeToId<unsigned long>() {
+    if constexpr (sizeof(unsigned long) == sizeof(unsigned)) {
+        return DebugPrintTypeToId<unsigned>();
+    } else if constexpr (sizeof(unsigned long) == sizeof(unsigned long long)) {
+        return DebugPrintTypeToId<unsigned long long>();
+    } else
+        ;  // Fail to compile
 }
 template <>
 uint8_t DebugPrintTypeToId<int8_t>() {
@@ -210,17 +224,25 @@ uint8_t DebugPrintTypeToId<int16_t>() {
     return DPrintINT16;
 }
 template <>
-uint8_t DebugPrintTypeToId<int32_t>() {
+uint8_t DebugPrintTypeToId<int>() {
+    static_assert(sizeof(int) == sizeof(int32_t));
     return DPrintINT32;
 }
 template <>
-uint8_t DebugPrintTypeToId<int64_t>() {
+uint8_t DebugPrintTypeToId<long long>() {
+    static_assert(sizeof(long long) == sizeof(int64_t));
     return DPrintINT64;
 }
 template <>
-uint8_t DebugPrintTypeToId<int>() {
-    return DPrintINT32;
+uint8_t DebugPrintTypeToId<long>() {
+    if constexpr (sizeof(long) == sizeof(int)) {
+        return DebugPrintTypeToId<int>();
+    } else if constexpr (sizeof(long) == sizeof(long long)) {
+        return DebugPrintTypeToId<long long>();
+    } else
+        ;  // Fail to compile
 }
+
 template <>
 uint8_t DebugPrintTypeToId<float>() {
     return DPrintFLOAT32;


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/31426

### Problem description
Our dprint specializations fail on a 64-bit target.

### What's changed
Fixed to cope with however int, long and long long (and unsigned variants) are sized.

### Checklist
- [YES] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [YES] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes