### PR TITLE
CI for tt-triage: Add hang app with auto timeout detection

### DIFF
--- a/tools/tests/triage/hang_apps/add_2_integers_hang/add_2_integers_hang.cpp
+++ b/tools/tests/triage/hang_apps/add_2_integers_hang/add_2_integers_hang.cpp
@@ -148,7 +148,16 @@ int main() {
     // Add the program to the workload and execute it.
     workload.add_program(device_range, std::move(program));
     distributed::EnqueueMeshWorkload(cq, workload, false);
-    distributed::Finish(cq);
+    try {
+        distributed::Finish(cq);
+    } catch (std::runtime_error& e) {
+        if (std::string(e.what()).find("device timeout") != std::string::npos) {
+            printf("Device timeout detected as expected.\n");
+            exit(0);
+        } else {
+            throw;
+        }
+    }
 
     // Data can be read from a MeshBuffer using the ReadShard function. This function is used to read data from a
     // specific shard of a MeshBuffer. The shard is specified by the MeshCoordinate. The last argument indicates if the

--- a/tools/tests/triage/hang_apps/add_2_integers_hang/add_2_integers_hang.cpp
+++ b/tools/tests/triage/hang_apps/add_2_integers_hang/add_2_integers_hang.cpp
@@ -153,7 +153,7 @@ int main() {
     } catch (std::runtime_error& e) {
         if (std::string(e.what()).find("device timeout") != std::string::npos) {
             printf("Device timeout detected as expected.\n");
-            exit(0);
+            std::_Exit(0);
         } else {
             throw;
         }

--- a/tools/tests/triage/hang_apps/add_2_integers_hang/kernels/dataflow/reader_binary_1_tile.cpp
+++ b/tools/tests/triage/hang_apps/add_2_integers_hang/kernels/dataflow/reader_binary_1_tile.cpp
@@ -23,11 +23,11 @@ void kernel_main() {
     // Setting the page size to be tile_size_bytes works because we set it up
     // explicitly in host code. This is usually a good idea as it makes coding
     // easy.
-    constexpr auto args_in0 = TensorAccessorArgs<0>();
-    const auto in0 = TensorAccessor(args_in0, in0_addr, tile_size_bytes);
+    constexpr auto in0_args = TensorAccessorArgs<0>();
+    const auto in0 = TensorAccessor(in0_args, in0_addr, tile_size_bytes);
 
-    constexpr auto args_in1 = TensorAccessorArgs<args_in0.next_compile_time_args_offset()>();
-    const auto in1 = TensorAccessor(args_in1, in1_addr, tile_size_bytes);
+    constexpr auto in1_args = TensorAccessorArgs<in0_args.next_compile_time_args_offset()>();
+    const auto in1 = TensorAccessor(in1_args, in1_addr, tile_size_bytes);
 
     // read the tiles from DRAM into the circular buffers
     cb_reserve_back(cb_in0, 1);

--- a/tools/tests/triage/hang_apps/add_2_integers_hang/kernels/dataflow/writer_1_tile.cpp
+++ b/tools/tests/triage/hang_apps/add_2_integers_hang/kernels/dataflow/writer_1_tile.cpp
@@ -12,8 +12,8 @@ void kernel_main() {
     const uint32_t tile_size_bytes = get_tile_size(cb_out0);
 
     // Address of the output buffer
-    constexpr auto args_a = TensorAccessorArgs<0>();
-    const auto dst = TensorAccessor(args_a, dst_addr, tile_size_bytes);
+    constexpr auto out0_args = TensorAccessorArgs<0>();
+    const auto dst = TensorAccessor(out0_args, dst_addr, tile_size_bytes);
 
     // Make sure there is a tile in the circular buffer
     cb_wait_front(cb_out0, 1);

--- a/tools/tests/triage/test_triage.py
+++ b/tools/tests/triage/test_triage.py
@@ -36,7 +36,7 @@ def cause_hang_with_app(request):
             pass
 
         # Check if the process has exited
-        if proc.returncode is None:
+        if proc.returncode != 0:
             raise RuntimeError("The application did not hang as expected.")
     else:
         time.sleep(timeout)


### PR DESCRIPTION
Fixing sample hang app. It started having data movement kernel compilation problems.
Adding configuration code that will cause it to auto timeout.
Running all tt-triage tests on top of that auto closed app as well.