### PR TITLE
Sliding window support when using tracing in prefill

### DIFF
--- a/models/demos/gemma3/tt/model_config.py
+++ b/models/demos/gemma3/tt/model_config.py
@@ -1268,8 +1268,7 @@ class ModelArgs:
 
         # TODO: If no specific sequence lengths are listed for a model and device, the default one will be used (from the default_supported_seq_lens dictionary)
         model_specific_supported_seq_lens = {
-            # EXAMPLE: #base_model_name : {device_name : [sequence_lengths]}
-            # "gemma-3-27b": {
+            # EXAMPLE: "gemma-3-4b": {
             #     "N150": [128, 256, 512, 1024, 2048],
             # }
         }

--- a/models/demos/gemma3/tt/model_config.py
+++ b/models/demos/gemma3/tt/model_config.py
@@ -1293,7 +1293,7 @@ class ModelArgs:
         """
         This function is used to determine if trace should be enabled for the prefill.
         Tracing is used only for certain sequence lengths, because for bigger sequence lengths, op2op gaps are already small, so we don't need tracing.
-        # TODO: Support chunked prefill with tracing
+        # TODO: Support chunked prefill with tracing - https://github.com/tenstorrent/tt-metal/issues/32056
         """
 
         allowed_seq_lens = self.trace_prefill_supported_seq_lens

--- a/models/demos/gemma3/tt/model_config.py
+++ b/models/demos/gemma3/tt/model_config.py
@@ -1259,15 +1259,17 @@ class ModelArgs:
 
     def get_trace_prefill_supported_seq_lens(self):
         default_supported_seq_lens = {
-            "N150": [128, 256, 512],
-            "N300": [128, 256, 512, 1024],
+            # for gemma we have different default supported seq lens than in tt_transformers
+            "N150": [128, 256],
+            "N300": [128, 256],
             "T3K": [128, 256, 512, 1024],
             "TG": [128, 256, 512, 1024],
         }
 
         # TODO: If no specific sequence lengths are listed for a model and device, the default one will be used (from the default_supported_seq_lens dictionary)
         model_specific_supported_seq_lens = {
-            # EXAMPLE: "gemma-3-4b": {
+            # EXAMPLE: #base_model_name : {device_name : [sequence_lengths]}
+            # "gemma-3-27b": {
             #     "N150": [128, 256, 512, 1024, 2048],
             # }
         }
@@ -1292,15 +1294,8 @@ class ModelArgs:
         """
         This function is used to determine if trace should be enabled for the prefill.
         Tracing is used only for certain sequence lengths, because for bigger sequence lengths, op2op gaps are already small, so we don't need tracing.
-        If we have chunked prefill, we disable tracing because there is no support to pass parameters such as chunk_start and chunk_end to trace.
-        There is no support to pass them as a tensor, and then inside the trace read it as a number.
-        # TODO: Support sliding window attention - This PR disabled tracing if a model uses sliding window attention, because this PR mainly covers models without sliding window attention. (for example,Llama-8B).
+        # TODO: Support chunked prefill with tracing
         """
-        # Trace in prefill is currently supported only for Llama-3.1-8B
-        # TODO: (https://github.com/tenstorrent/tt-metal/issues/25722) Support all other models that use tt_transformers
-
-        if hasattr(self, "sliding_window") and getattr(self, "sliding_window") != None:
-            return False
 
         allowed_seq_lens = self.trace_prefill_supported_seq_lens
 

--- a/models/demos/gpt_oss/tt/model.py
+++ b/models/demos/gpt_oss/tt/model.py
@@ -365,21 +365,41 @@ class Model:
 
         return tokens, current_pos_tt, rope_idxs, page_table
 
-    def prepare_inputs_prefill(self, tokens, start_pos=0, page_table=None, chunk_page_table=None):
+    def prepare_inputs_prefill_trace(self, tokens, start_pos=0, page_table=None, chunk_page_table=None):
+        """Prepare inputs on host so we later send them to device"""
+        host_inputs = self.prepare_inputs_prefill(
+            tokens, start_pos=start_pos, page_table=page_table, chunk_page_table=chunk_page_table, trace_enabled=True
+        )
+        return host_inputs
+
+    def transform_and_embed_prefill_inputs_device(self, tokens, tt_page_table, tt_chunk_page_table):
+        """Transform and embed tokens on device"""
+        tokens_embd = ttnn.embedding(tokens, self.embedding_weight, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat8_b)
+        tokens.deallocate(True)
+        if len(tokens_embd.shape) == 3:
+            tokens_embd = ttnn.unsqueeze_to_4D(tokens_embd)
+        return tokens_embd, tt_page_table, tt_chunk_page_table
+
+    def prepare_inputs_prefill(self, tokens, start_pos=0, page_table=None, chunk_page_table=None, trace_enabled=False):
         """Prepare inputs for prefill mode"""
         # Embed the tokens
         if tokens.dim() == 2:
             tokens = tokens.reshape(1, 1, 1, -1)
 
-        tokens = ttnn.from_torch(tokens, device=self.mesh_device, dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT)
-        tokens_embd = ttnn.embedding(tokens, self.embedding_weight, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat8_b)
-        tokens.deallocate(True)
-        # Ensure proper 4D shape
-        if len(tokens_embd.shape) == 3:
-            tokens_embd = ttnn.unsqueeze_to_4D(tokens_embd)
+        device = None if trace_enabled else self.mesh_device
+
+        tokens = ttnn.from_torch(tokens, device=device, dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT)
+
+        if not trace_enabled:
+            tokens_embd = ttnn.embedding(tokens, self.embedding_weight, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat8_b)
+            tokens.deallocate(True)
+
+            # Ensure proper 4D shape
+            if len(tokens_embd.shape) == 3:
+                tokens_embd = ttnn.unsqueeze_to_4D(tokens_embd)
 
         # Prepare rotation matrices (slice from rope_setup like tt-transformers model.py lines 156-159)
-        seq_len = tokens_embd.shape[-2] if len(tokens_embd.shape) == 4 else tokens_embd.shape[-2]
+        seq_len = self.args.max_seq_len if trace_enabled else tokens_embd.shape[-2]
         rot_mats_global = [
             self.rope_setup.cos_matrix[:, :, :seq_len, :],
             self.rope_setup.sin_matrix[:, :, :seq_len, :],
@@ -390,15 +410,19 @@ class Model:
         tt_page_table = None
         tt_chunk_page_table = None
         if page_table is not None:
-            tt_page_table = ttnn.from_torch(
-                page_table, device=self.mesh_device, dtype=ttnn.int32, layout=ttnn.ROW_MAJOR_LAYOUT
-            )
+            tt_page_table = ttnn.from_torch(page_table, device=device, dtype=ttnn.int32, layout=ttnn.ROW_MAJOR_LAYOUT)
         if chunk_page_table is not None:
             tt_chunk_page_table = ttnn.from_torch(
-                chunk_page_table, device=self.mesh_device, dtype=ttnn.int32, layout=ttnn.ROW_MAJOR_LAYOUT
+                chunk_page_table, device=device, dtype=ttnn.int32, layout=ttnn.ROW_MAJOR_LAYOUT
             )
 
-        return tokens_embd, rot_mats_global, rot_mats_local, tt_page_table, tt_chunk_page_table
+        return (
+            tokens if trace_enabled else tokens_embd,
+            rot_mats_global,
+            rot_mats_local,
+            tt_page_table,
+            tt_chunk_page_table,
+        )
 
     def process_output_decode(self, tt_out, B, S=1, is_tokens=False):
         """Process decode output and convert to torch tensors"""

--- a/models/demos/gpt_oss/tt/model_config.py
+++ b/models/demos/gpt_oss/tt/model_config.py
@@ -112,12 +112,9 @@ class ModelArgs:
         )
 
     def get_trace_prefill_supported_seq_lens(self):
-        default_supported_seq_lens = {
-            "N150": [128],
-            "N300": [128],
-            "T3K": [128],
-            "TG": [128],
-        }
+        # No supported sequence lengths for GPT-OSS model, see issue below
+        # TODO: https://github.com/tenstorrent/tt-metal/issues/32818
+        default_supported_seq_lens = {}
 
         # TODO: If no specific sequence lengths are listed for a model and device, the default one will be used (from the default_supported_seq_lens dictionary)
         model_specific_supported_seq_lens = {

--- a/models/demos/gpt_oss/tt/model_config.py
+++ b/models/demos/gpt_oss/tt/model_config.py
@@ -100,7 +100,7 @@ class ModelArgs:
         """
         This function is used to determine if trace should be enabled for the prefill.
         Tracing is used only for certain sequence lengths, because for bigger sequence lengths, op2op gaps are already small, so we don't need tracing.
-        # TODO: Support chunked prefill with tracing
+        # TODO: Support chunked prefill with tracing - https://github.com/tenstorrent/tt-metal/issues/32056
         """
 
         allowed_seq_lens = self.trace_prefill_supported_seq_lens

--- a/models/tt_transformers/demo/trace_region_config.py
+++ b/models/tt_transformers/demo/trace_region_config.py
@@ -108,6 +108,10 @@ def get_supported_trace_region_size(request, mesh_device):
             "T3K": 70000000,
             "TG": 70000000,
         },
+        "gemma-3-27b": {
+            "T3K": 70000000,
+            "TG": 70000000,
+        },
     }
 
     device_name_based_on_dp = device_name_based_on_data_parallel(request, mesh_device, os.getenv("MESH_DEVICE"))

--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -1876,15 +1876,8 @@ class ModelArgs:
         """
         This function is used to determine if trace should be enabled for the prefill.
         Tracing is used only for certain sequence lengths, because for bigger sequence lengths, op2op gaps are already small, so we don't need tracing.
-        If we have chunked prefill, we disable tracing because there is no support to pass parameters such as chunk_start and chunk_end to trace.
-        There is no support to pass them as a tensor, and then inside the trace read it as a number.
-        # TODO: Support sliding window attention - This PR disabled tracing if a model uses sliding window attention, because this PR mainly covers models without sliding window attention. (for example,Llama-8B).
+        # TODO: Support chunked prefill with tracing
         """
-        # Trace in prefill is currently supported only for Llama-3.1-8B, Llama-3.1-70B, Llama-3.3-70B
-        # TODO: (https://github.com/tenstorrent/tt-metal/issues/25722) Support all other models that use tt_transformers
-
-        if hasattr(self, "sliding_window") and getattr(self, "sliding_window") != None:
-            return False
 
         allowed_seq_lens = self.trace_prefill_supported_seq_lens
 

--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -1876,7 +1876,7 @@ class ModelArgs:
         """
         This function is used to determine if trace should be enabled for the prefill.
         Tracing is used only for certain sequence lengths, because for bigger sequence lengths, op2op gaps are already small, so we don't need tracing.
-        # TODO: Support chunked prefill with tracing
+        # TODO: Support chunked prefill with tracing - https://github.com/tenstorrent/tt-metal/issues/32056
         """
 
         allowed_seq_lens = self.trace_prefill_supported_seq_lens


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/30005)

Tracing in prefill is now supported for models that use sliding window attention.

### Checklist
- [x] [All post commit] https://github.com/tenstorrent/tt-metal/actions/runs/19500329865
- [x] (Single card demo tests) https://github.com/tenstorrent/tt-metal/actions/runs/19500343623
- [x] [Galaxy demo tests, for Llama] https://github.com/tenstorrent/tt-metal/actions/runs/19500312952
- [x] (For runtime and ops writers) [T3000 unit tests] https://github.com/tenstorrent/tt-metal/actions/runs/19500300769
- [x] (For models and ops writers) [T3000 demo tests] https://github.com/tenstorrent/tt-metal/actions/runs/19500290054

### note: GPT-OSS (Galaxy demo test) only run with fixes : https://github.com/tenstorrent/tt-metal/actions/runs/19507378696