### PR TITLE
[skip ci] Allow third-party licenses in SPDX check

### DIFF
--- a/check_copyright_config.yaml
+++ b/check_copyright_config.yaml
@@ -26,7 +26,7 @@ DEFAULT:
   # or
   # SPDX-FileContributor: year[-year] Espressif Systems
   # are replaced with this template prefixed with the correct comment notation (# or // or *) and SPDX- notation
-  # -- Jonathan Baker - Nov 18 2025 - the file must have an SPDX header, but may not have ours.  expressif_copyright will fail if ours is not found.  Commenting out
+  # -- Jonathan Baker - Nov 18 2025 - the file must have an SPDX header, but may not have ours.  espressif_copyright will fail if ours is not found.  Commenting out
   # espressif_copyright: '© {years} Tenstorrent AI ULC'
   # include:
   #   - "*.cpp"

--- a/check_copyright_config.yaml
+++ b/check_copyright_config.yaml
@@ -6,6 +6,12 @@ DEFAULT:
   allowed_licenses:
     - Apache-2.0
     - Apache-2.0 WITH LLVM-exception
+    - MIT
+    - BSD-2-Clause
+    - BSD-3-Clause
+    - ISC
+    - CC0-1.0
+    - Unlicense
   license_for_new_files: Apache-2.0  # license to be used when inserting a new copyright notice
   new_notice_c: |  # notice for new C, CPP, H, HPP and LD files
     // SPDX-FileCopyrightText: © {years} Tenstorrent AI ULC

--- a/check_copyright_config.yaml
+++ b/check_copyright_config.yaml
@@ -9,9 +9,6 @@ DEFAULT:
     - MIT
     - BSD-2-Clause
     - BSD-3-Clause
-    - ISC
-    - CC0-1.0
-    - Unlicense
   license_for_new_files: Apache-2.0  # license to be used when inserting a new copyright notice
   new_notice_c: |  # notice for new C, CPP, H, HPP and LD files
     // SPDX-FileCopyrightText: © {years} Tenstorrent AI ULC
@@ -29,11 +26,12 @@ DEFAULT:
   # or
   # SPDX-FileContributor: year[-year] Espressif Systems
   # are replaced with this template prefixed with the correct comment notation (# or // or *) and SPDX- notation
-  espressif_copyright: '© {years} Tenstorrent AI ULC'
-  include:
-    - "*.cpp"
-    - "*.cc"
-    - "*.h"
+  # -- Jonathan Baker - Nov 18 2025 - the file must have an SPDX header, but may not have ours.  expressif_copyright will fail if ours is not found.  Commenting out
+  # espressif_copyright: '© {years} Tenstorrent AI ULC'
+  # include:
+  #   - "*.cpp"
+  #   - "*.cc"
+  #   - "*.h"
 
 ignore:  # You can also select ignoring files here
   perform_check: no  # Don't check files from that block


### PR DESCRIPTION
This PR updates the copyright check configuration to allow common third-party open source licenses (MIT, BSD-2-Clause, BSD-3-Clause) in addition to our standard Apache-2.0 licenses.

Changes:
- Added MIT, BSD-2-Clause, and BSD-3-Clause to the allowed_licenses list
- Commented out espressif_copyright requirement to allow files with third-party copyright headers (as long as they have valid SPDX headers with allowed licenses)

This fixes the issue where the SPDX header check was rejecting valid third-party code that we've copied into our repository with proper licensing.