### PR TITLE
Changing of DevicePool in preparation for MetalContext integration

### DIFF
--- a/tt_metal/api/tt-metalium/device_pool.hpp
+++ b/tt_metal/api/tt-metalium/device_pool.hpp
@@ -82,7 +82,6 @@ private:
     // It is set to true when dispatch firmware is launched, and reset
     // after the terimnate command is sent.
     bool dispatch_firmware_active_ = false;
-    bool use_numa_node_based_thread_binding = false;
 
     mutable std::mutex lock;
     std::vector<std::unique_ptr<tt_metal::IDevice>> devices;

--- a/tt_metal/api/tt-metalium/device_pool.hpp
+++ b/tt_metal/api/tt-metalium/device_pool.hpp
@@ -82,6 +82,7 @@ private:
     // It is set to true when dispatch firmware is launched, and reset
     // after the terimnate command is sent.
     bool dispatch_firmware_active_ = false;
+    bool use_numa_node_based_thread_binding = false;
 
     mutable std::mutex lock;
     std::vector<std::unique_ptr<tt_metal::IDevice>> devices;

--- a/tt_metal/impl/device/device_pool.cpp
+++ b/tt_metal/impl/device/device_pool.cpp
@@ -125,12 +125,33 @@ std::pair<int, int> get_cpu_cores_for_dispatch_threads(
     return std::make_pair(core_assigned_to_device_worker_thread, core_assigned_to_device_completion_queue_reader);
 }
 
+void bind_current_thread_to_free_cores(const std::unordered_set<uint32_t>& free_cores) {
+    cpu_set_t cpuset;
+    pthread_t current_thread = pthread_self();
+    CPU_ZERO(&cpuset);
+
+    for (const auto& free_core : free_cores) {
+        CPU_SET(free_core, &cpuset);
+    }
+    int rc = pthread_setaffinity_np(current_thread, sizeof(cpu_set_t), &cpuset);
+    if (rc) {
+        log_warning(
+            tt::LogMetal,
+            "Unable to bind main thread to free CPU cores. May see performance degradation. Error Code: {}",
+            rc);
+    }
+}
+
 std::unordered_map<uint32_t, uint32_t> get_device_id_to_core_map(
-    const std::vector<ChipId>& device_ids,
-    std::unordered_set<uint32_t>& free_cores,
     bool use_numa_node_based_thread_binding,
     const uint8_t num_hw_cqs,
     std::unordered_map<uint32_t, uint32_t>& completion_queue_reader_to_cpu_core_map) {
+    std::vector<ChipId> device_ids;
+    for (ChipId device_id : tt::tt_metal::MetalContext::instance().get_cluster().all_chip_ids()) {
+        device_ids.emplace_back(device_id);
+    }
+
+    std::unordered_set<uint32_t> free_cores = {};
     uint32_t num_online_processors = sysconf(_SC_NPROCESSORS_ONLN);
     constexpr uint32_t max_num_procs_per_device = 2;
     // When using multiple command queues, assign separate CPU cores to worker and completion queue reader threads,
@@ -164,26 +185,14 @@ std::unordered_map<uint32_t, uint32_t> get_device_id_to_core_map(
             }
         }
     }
+
+    if (use_numa_node_based_thread_binding) {
+        // Bind main thread to cores not being used by workers
+        bind_current_thread_to_free_cores(free_cores);
+    }
+
     return worker_thread_to_cpu_core_map;
 }
-
-void bind_current_thread_to_free_cores(const std::unordered_set<uint32_t>& free_cores) {
-    cpu_set_t cpuset;
-    pthread_t current_thread = pthread_self();
-    CPU_ZERO(&cpuset);
-
-    for (const auto& free_core : free_cores) {
-        CPU_SET(free_core, &cpuset);
-    }
-    int rc = pthread_setaffinity_np(current_thread, sizeof(cpu_set_t), &cpuset);
-    if (rc) {
-        log_warning(
-            tt::LogMetal,
-            "Unable to bind main thread to free CPU cores. May see performance degradation. Error Code: {}",
-            rc);
-    }
-}
-
 }  // namespace device_cpu_allocator
 
 DevicePool* DevicePool::_inst = nullptr;
@@ -242,6 +251,10 @@ void DevicePool::initialize(
         static DevicePool device_pool{};
         _inst = &device_pool;
     }
+
+    _inst->worker_thread_to_cpu_core_map = device_cpu_allocator::get_device_id_to_core_map(
+        _inst->use_numa_node_based_thread_binding, num_hw_cqs, _inst->completion_queue_reader_to_cpu_core_map);
+
     _inst->l1_small_size = l1_small_size;
     _inst->trace_region_size = trace_region_size;
     _inst->worker_l1_size = worker_l1_size;
@@ -727,22 +740,7 @@ void DevicePool::init_firmware_on_active_devices() const {
 DevicePool::DevicePool() {
     ZoneScoped;
     log_debug(tt::LogMetal, "DevicePool constructor");
-    bool use_numa_node_based_thread_binding = parse_env("TT_METAL_NUMA_BASED_AFFINITY", false);
-    std::vector<ChipId> all_device_ids;
-    for (ChipId device_id : tt::tt_metal::MetalContext::instance().get_cluster().all_chip_ids()) {
-        all_device_ids.emplace_back(device_id);
-    }
-    std::unordered_set<uint32_t> free_cores = {};
-    this->worker_thread_to_cpu_core_map = device_cpu_allocator::get_device_id_to_core_map(
-        all_device_ids,
-        free_cores,
-        use_numa_node_based_thread_binding,
-        num_hw_cqs,
-        this->completion_queue_reader_to_cpu_core_map);
-    if (use_numa_node_based_thread_binding) {
-        // Bind main thread to cores not being used by workers
-        device_cpu_allocator::bind_current_thread_to_free_cores(free_cores);
-    }
+    use_numa_node_based_thread_binding = parse_env("TT_METAL_NUMA_BASED_AFFINITY", false);
 }
 
 IDevice* DevicePool::get_active_device(ChipId device_id) const {


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/25036)

### Problem description
Shifting DevicePool away from being a singleton

### What's changed
Moved Things from creation to init part

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes