### PR TITLE
#32670: Resolve Issues with Galaxy Torus Tests being skipped

### DIFF
--- a/tools/tests/scaleout/cabling_descriptors/wh_galaxy_x_torus_superpod.textproto
+++ b/tools/tests/scaleout/cabling_descriptors/wh_galaxy_x_torus_superpod.textproto
@@ -5,8 +5,6 @@ graph_templates {
       name: "node1"
       node_ref { node_descriptor: "WH_GALAXY_X_TORUS" }
     }
-    internal_connections {
-    }
   }
 }
 

--- a/tools/tests/scaleout/cabling_descriptors/wh_galaxy_xy_torus_superpod.textproto
+++ b/tools/tests/scaleout/cabling_descriptors/wh_galaxy_xy_torus_superpod.textproto
@@ -5,8 +5,6 @@ graph_templates {
       name: "node1"
       node_ref { node_descriptor: "WH_GALAXY_XY_TORUS" }
     }
-    internal_connections {
-    }
   }
 }
 

--- a/tools/tests/scaleout/cabling_descriptors/wh_galaxy_y_torus_superpod.textproto
+++ b/tools/tests/scaleout/cabling_descriptors/wh_galaxy_y_torus_superpod.textproto
@@ -5,8 +5,6 @@ graph_templates {
       name: "node1"
       node_ref { node_descriptor: "WH_GALAXY_Y_TORUS" }
     }
-    internal_connections {
-    }
   }
 }
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/32670

### Problem description
Specifying empty internal_connections led to an error

### What's changed
Removed it

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes