### PR TITLE
Optimised mul_int32 with 40c/32 throughput (WH).

### DIFF
--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_mul_int32.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_mul_int32.h
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2025 Jason Davies <jason@jasondavies.com>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -14,151 +15,118 @@ template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void mul_int32(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
-        // size of each tile in Dest is 64 rows
         constexpr uint dst_tile_size = 64;
-        // operand A - int32
+
+        // Split the 32-bit input values into 11-bit chunks:
+        //
+        //   a = (a2 << 22) | (a1 << 11) | a0
+        //   b = (b2 << 22) | (b1 << 11) | b0
+        //
+        // This allows us to cast these values to fp32 without loss of
+        // precision, and furthermore, we can compute:
+        //
+        //   a * b = (top << 22) + (mid << 11) + low
+        //
+        // Where:
+        //
+        //   top = a0*b2 + a1*b1 + a2*b0 (maximum 24 bits)
+        //   mid = a0*b1 + a1*b0         (maximum 23 bits)
+        //   low = a0*b0                 (maximum 22 bits)
+        //
+        // For top and mid, we use FMA to sum values without loss of precision.
+        // We cannot use SFPSTOCHRND to convert FP32 to INT32, as the values
+        // are larger than 16 bits, so we extract the exponent and mantissa,
+        // and shift the mantissa by the appropriate amount.
+
+        // a0
         TT_SFPLOAD(p_sfpu::LREG0, INT32, ADDR_MOD_3, dst_index_in0 * dst_tile_size);
-        // operand B - int32
-        TT_SFPLOAD(p_sfpu::LREG1, INT32, ADDR_MOD_3, dst_index_in1 * dst_tile_size);
+        // a1
+        TTI_SFPSHFT2(p_sfpu::LREG0, p_sfpu::LREG13, p_sfpu::LREG2, 5);
+        // a2
+        TTI_SFPSHFT2(p_sfpu::LREG2, p_sfpu::LREG13, p_sfpu::LREG4, 5);
 
-        // INT32 split into 8-bit inputs
-        // mask
-        TTI_SFPLOADI(p_sfpu::LREG7, SFPLOADI_MOD0_USHORT, 0xFF);
-
-        // Copy A
-        TTI_SFPMOV(0, p_sfpu::LREG0, p_sfpu::LREG2, 0);
-        TTI_SFPMOV(0, p_sfpu::LREG0, p_sfpu::LREG3, 0);
-
-        // Extract A = [a3:a2:a1:a0] where each is 8-bit.
-        TTI_SFPAND(0, p_sfpu::LREG7, p_sfpu::LREG0, 0);               // LREG0 = a0 = A[7:0]
-        TTI_SFPSHFT((-8) & 0xfff, p_sfpu::LREG2, p_sfpu::LREG2, 1);   // LREG2 = a1 = A[15:8]
-        TTI_SFPAND(0, p_sfpu::LREG7, p_sfpu::LREG2, 0);               // clear other bits
-        TTI_SFPSHFT((-16) & 0xfff, p_sfpu::LREG3, p_sfpu::LREG3, 1);  // LREG3 = a2 = A[23:16]
-        TTI_SFPAND(0, p_sfpu::LREG7, p_sfpu::LREG3, 0);
-
-        // Copy B
-        TTI_SFPMOV(0, p_sfpu::LREG1, p_sfpu::LREG4, 0);
-        TTI_SFPMOV(0, p_sfpu::LREG1, p_sfpu::LREG5, 0);
-
-        // Extract B = [b3:b2:b1:b0] where each is 8-bit
-        TTI_SFPAND(0, p_sfpu::LREG7, p_sfpu::LREG1, 0);              // LREG1 = b0 = B[7:0]
-        TTI_SFPSHFT((-8) & 0xfff, p_sfpu::LREG4, p_sfpu::LREG4, 1);  // LREG5 = b1 = B[15:8]
-        TTI_SFPAND(0, p_sfpu::LREG7, p_sfpu::LREG4, 0);
-        TTI_SFPSHFT((-16) & 0xfff, p_sfpu::LREG5, p_sfpu::LREG5, 1);  // LREG6 = b2 = B[23:16]
-        TTI_SFPAND(0, p_sfpu::LREG7, p_sfpu::LREG5, 0);
-        // a3 and b3 will be extracted on the go due to limited registers.
-
-        // Cast all 8-bit values to FP32
-        TTI_SFPCAST(p_sfpu::LREG0, p_sfpu::LREG0, 0);
-        TTI_SFPCAST(p_sfpu::LREG1, p_sfpu::LREG1, 0);
+        // a1 = (a1 & 0x7ff) as fp32
+        TTI_SFPAND(0, p_sfpu::LREG12, p_sfpu::LREG2, 0);
         TTI_SFPCAST(p_sfpu::LREG2, p_sfpu::LREG2, 0);
-        TTI_SFPCAST(p_sfpu::LREG3, p_sfpu::LREG3, 0);
+
+        // a2 = a2 as fp32
         TTI_SFPCAST(p_sfpu::LREG4, p_sfpu::LREG4, 0);
+
+        // a0 = (a0 & 0x7ff) as fp32
+        TTI_SFPAND(0, p_sfpu::LREG12, p_sfpu::LREG0, 0);
+        TTI_SFPCAST(p_sfpu::LREG0, p_sfpu::LREG0, 0);
+
+        // b0
+        TT_SFPLOAD(p_sfpu::LREG1, INT32, ADDR_MOD_3, dst_index_in1 * dst_tile_size);
+        // b1
+        TTI_SFPSHFT2(p_sfpu::LREG1, p_sfpu::LREG13, p_sfpu::LREG3, 5);
+        // b2
+        TTI_SFPSHFT2(p_sfpu::LREG3, p_sfpu::LREG13, p_sfpu::LREG5, 5);
+
+        // b2 = b2 as fp32
         TTI_SFPCAST(p_sfpu::LREG5, p_sfpu::LREG5, 0);
 
-        // a0*b0 (bits 0-15)
-        TTI_SFPMUL(p_sfpu::LREG0, p_sfpu::LREG1, p_sfpu::LCONST_0, p_sfpu::LREG7, 0);
-        TTI_SFPNOP;
-        TTI_SFP_STOCH_RND(
-            SFPSTOCHRND_RND_EVEN,
-            0,
-            0,
-            p_sfpu::LREG7,
-            p_sfpu::LREG7,
-            SFPSTOCHRND_MOD1_FP32_TO_UINT16);  // fp32 -> uint16
+        // top = a0*b2
+        TTI_SFPMAD(p_sfpu::LREG0, p_sfpu::LREG5, p_sfpu::LCONST_0, p_sfpu::LREG5, 0);
 
-        // a0*b1 (bits 8-23)
-        TTI_SFPMUL(p_sfpu::LREG0, p_sfpu::LREG4, p_sfpu::LCONST_0, p_sfpu::LREG6, 0);
-        TTI_SFPNOP;
-        TTI_SFP_STOCH_RND(SFPSTOCHRND_RND_EVEN, 0, 0, p_sfpu::LREG6, p_sfpu::LREG6, SFPSTOCHRND_MOD1_FP32_TO_UINT16);
-        TTI_SFPSHFT(8, p_sfpu::LREG6, p_sfpu::LREG6, 1);                     // Shift left by 8
-        TTI_SFPIADD(0, p_sfpu::LREG6, p_sfpu::LREG7, SFPIADD_MOD1_CC_NONE);  // Accumulate in LREG7
-
-        // a0*b2 (bits 16-31)
-        TTI_SFPMUL(p_sfpu::LREG0, p_sfpu::LREG5, p_sfpu::LCONST_0, p_sfpu::LREG6, 0);
-        TTI_SFPNOP;
-        TTI_SFP_STOCH_RND(SFPSTOCHRND_RND_EVEN, 0, 0, p_sfpu::LREG6, p_sfpu::LREG6, SFPSTOCHRND_MOD1_FP32_TO_UINT16);
-        TTI_SFPSHFT(16, p_sfpu::LREG6, p_sfpu::LREG6, 1);  // Shift left by 16
-        TTI_SFPIADD(0, p_sfpu::LREG6, p_sfpu::LREG7, SFPIADD_MOD1_CC_NONE);
-
-        // a1*b0 (bits 8-23)
-        TTI_SFPMUL(p_sfpu::LREG2, p_sfpu::LREG1, p_sfpu::LCONST_0, p_sfpu::LREG6, 0);
-        TTI_SFPNOP;
-        TTI_SFP_STOCH_RND(SFPSTOCHRND_RND_EVEN, 0, 0, p_sfpu::LREG6, p_sfpu::LREG6, SFPSTOCHRND_MOD1_FP32_TO_UINT16);
-        TTI_SFPSHFT(8, p_sfpu::LREG6, p_sfpu::LREG6, 1);  // Shift left by 8
-        TTI_SFPIADD(0, p_sfpu::LREG6, p_sfpu::LREG7, SFPIADD_MOD1_CC_NONE);
-
-        // a1*b1 (bits 16-31)
-        TTI_SFPMUL(p_sfpu::LREG2, p_sfpu::LREG4, p_sfpu::LCONST_0, p_sfpu::LREG6, 0);
-        TTI_SFPNOP;
-        TTI_SFP_STOCH_RND(SFPSTOCHRND_RND_EVEN, 0, 0, p_sfpu::LREG6, p_sfpu::LREG6, SFPSTOCHRND_MOD1_FP32_TO_UINT16);
-        TTI_SFPSHFT(16, p_sfpu::LREG6, p_sfpu::LREG6, 1);  // Shift left by 16
-        TTI_SFPIADD(0, p_sfpu::LREG6, p_sfpu::LREG7, SFPIADD_MOD1_CC_NONE);
-
-        // a2*b0 (bits 16-31)
-        TTI_SFPMUL(p_sfpu::LREG3, p_sfpu::LREG1, p_sfpu::LCONST_0, p_sfpu::LREG6, 0);
-        TTI_SFPNOP;
-        TTI_SFP_STOCH_RND(SFPSTOCHRND_RND_EVEN, 0, 0, p_sfpu::LREG6, p_sfpu::LREG6, SFPSTOCHRND_MOD1_FP32_TO_UINT16);
-        TTI_SFPSHFT(16, p_sfpu::LREG6, p_sfpu::LREG6, 1);  // Shift left by 16
-        TTI_SFPIADD(0, p_sfpu::LREG6, p_sfpu::LREG7, SFPIADD_MOD1_CC_NONE);
-
-        TTI_SFPLOADI(p_sfpu::LREG6, SFPLOADI_MOD0_USHORT, 0x00FF);  // load 00FF to LREG6
-
-        // a1*b2 --> goes beyond 32-bits [24:39]. We need to extract the bits upto 32.
-        TTI_SFPMUL(p_sfpu::LREG2, p_sfpu::LREG5, p_sfpu::LCONST_0, p_sfpu::LREG5, 0);  // store result to LREG5
-        TTI_SFPNOP;
-        TTI_SFP_STOCH_RND(SFPSTOCHRND_RND_EVEN, 0, 0, p_sfpu::LREG5, p_sfpu::LREG5, SFPSTOCHRND_MOD1_FP32_TO_UINT16);
-        TTI_SFPAND(0, p_sfpu::LREG6, p_sfpu::LREG5, 0);    // zero out high overflow bits
-        TTI_SFPSHFT(24, p_sfpu::LREG5, p_sfpu::LREG5, 1);  // Shift left by 24
-        TTI_SFPIADD(0, p_sfpu::LREG5, p_sfpu::LREG7, SFPIADD_MOD1_CC_NONE);
-
-        // a2*b1 --> goes beyond 32-bits [24:39]. We need to extract the bits upto 32.
-        TTI_SFPMUL(p_sfpu::LREG3, p_sfpu::LREG4, p_sfpu::LCONST_0, p_sfpu::LREG5, 0);
-        TTI_SFPNOP;
-        TTI_SFP_STOCH_RND(SFPSTOCHRND_RND_EVEN, 0, 0, p_sfpu::LREG5, p_sfpu::LREG5, SFPSTOCHRND_MOD1_FP32_TO_UINT16);
-        TTI_SFPAND(0, p_sfpu::LREG6, p_sfpu::LREG5, 0);    // zero out high overflow bits
-        TTI_SFPSHFT(24, p_sfpu::LREG5, p_sfpu::LREG5, 1);  // Shift left by 24
-        TTI_SFPIADD(0, p_sfpu::LREG5, p_sfpu::LREG7, SFPIADD_MOD1_CC_NONE);
-
-        // Load operands again to extract a3 and b3
-        // operand A - int32
-        TT_SFPLOAD(p_sfpu::LREG2, INT32, ADDR_MOD_3, dst_index_in0 * dst_tile_size);
-        // operand B - int32
-        TT_SFPLOAD(p_sfpu::LREG3, INT32, ADDR_MOD_3, dst_index_in1 * dst_tile_size);
-        // mask
-        TTI_SFPLOADI(p_sfpu::LREG4, SFPLOADI_MOD0_USHORT, 0xFF);
-
-        // Extract A3
-        TTI_SFPSHFT((-24) & 0xfff, p_sfpu::LREG2, p_sfpu::LREG2, 1);  // LREG2 = a3 = A[31:24]
-        TTI_SFPAND(0, p_sfpu::LREG4, p_sfpu::LREG2, 0);
-
-        // Extract B3
-        TTI_SFPSHFT((-24) & 0xfff, p_sfpu::LREG3, p_sfpu::LREG3, 1);  // LREG3 = b3 = B[31:24]
-        TTI_SFPAND(0, p_sfpu::LREG4, p_sfpu::LREG3, 0);
-
-        // Cast to FP32
-        TTI_SFPCAST(p_sfpu::LREG2, p_sfpu::LREG2, 0);
+        // b1 = (b1 & 0x7ff) as fp32
+        TTI_SFPAND(0, p_sfpu::LREG12, p_sfpu::LREG3, 0);
         TTI_SFPCAST(p_sfpu::LREG3, p_sfpu::LREG3, 0);
 
-        // a0*b3 --> goes beyond 32-bits [24:39]. We need to extract the bits upto 32.
-        TTI_SFPMUL(p_sfpu::LREG0, p_sfpu::LREG3, p_sfpu::LCONST_0, p_sfpu::LREG5, 0);
-        TTI_SFPNOP;
-        TTI_SFP_STOCH_RND(SFPSTOCHRND_RND_EVEN, 0, 0, p_sfpu::LREG5, p_sfpu::LREG5, SFPSTOCHRND_MOD1_FP32_TO_UINT16);
-        TTI_SFPAND(0, p_sfpu::LREG6, p_sfpu::LREG5, 0);    // zero out high overflow bits
-        TTI_SFPSHFT(24, p_sfpu::LREG5, p_sfpu::LREG5, 1);  // Shift left by 24
+        // top += a1*b1
+        TTI_SFPMAD(p_sfpu::LREG2, p_sfpu::LREG3, p_sfpu::LREG5, p_sfpu::LREG5, 0);
+
+        // b0 = (b0 & 0x7ff) as fp32
+        TTI_SFPAND(0, p_sfpu::LREG12, p_sfpu::LREG1, 0);
+        TTI_SFPCAST(p_sfpu::LREG1, p_sfpu::LREG1, 0);
+
+        // top += a2*b0
+        TTI_SFPMAD(p_sfpu::LREG4, p_sfpu::LREG1, p_sfpu::LREG5, p_sfpu::LREG5, 0);
+
+        // mid = a0*b1
+        TTI_SFPMAD(p_sfpu::LREG0, p_sfpu::LREG3, p_sfpu::LCONST_0, p_sfpu::LREG6, 0);
+
+        // low = a0*b0
+        TTI_SFPMAD(p_sfpu::LREG0, p_sfpu::LREG1, p_sfpu::LCONST_0, p_sfpu::LREG7, 0);
+
+        // mid += a1*b0
+        TTI_SFPMAD(p_sfpu::LREG2, p_sfpu::LREG1, p_sfpu::LREG6, p_sfpu::LREG6, 0);
+
+        // convert low to integer, taking care with zero, since SFPEXMAN always sets the implicit bit.
+        TTI_SFPEXEXP(0, p_sfpu::LREG7, p_sfpu::LREG0, 2 | 8);
+        TTI_SFPEXMAN(0, p_sfpu::LREG7, p_sfpu::LREG7, 0);
+        TTI_SFPIADD(-23 & 0xfff, p_sfpu::LREG0, p_sfpu::LREG0, SFPIADD_MOD1_CC_NONE | SFPIADD_MOD1_ARG_IMM);
+        TTI_SFPSHFT2(p_sfpu::LREG7, p_sfpu::LREG0, p_sfpu::LREG7, 5);
+        TTI_SFPENCC(0, 0, 0, 0);
+
+        // convert mid to integer, taking care with zero, since SFPEXMAN always sets the implicit bit.
+        TTI_SFPEXEXP(0, p_sfpu::LREG6, p_sfpu::LREG0, 2 | 8);
+        TTI_SFPEXMAN(0, p_sfpu::LREG6, p_sfpu::LREG6, 0);
+        TTI_SFPIADD((11 - 23) & 0xfff, p_sfpu::LREG0, p_sfpu::LREG0, SFPIADD_MOD1_CC_NONE | SFPIADD_MOD1_ARG_IMM);
+        TTI_SFPSHFT2(p_sfpu::LREG6, p_sfpu::LREG0, p_sfpu::LREG6, 5);
+        TTI_SFPENCC(0, 0, 0, 0);
+
+        // convert top to integer, taking care with zero, since SFPEXMAN always sets the implicit bit.
+        TTI_SFPEXEXP(0, p_sfpu::LREG5, p_sfpu::LREG0, 2 | 8);
+        TTI_SFPEXMAN(0, p_sfpu::LREG5, p_sfpu::LREG5, 0);
+        TTI_SFPIADD((22 - 23) & 0xfff, p_sfpu::LREG0, p_sfpu::LREG0, SFPIADD_MOD1_CC_NONE | SFPIADD_MOD1_ARG_IMM);
+        TTI_SFPSHFT2(p_sfpu::LREG5, p_sfpu::LREG0, p_sfpu::LREG5, 5);
+        TTI_SFPENCC(0, 0, 0, 0);
+
+        // lo += mid
+        TTI_SFPIADD(0, p_sfpu::LREG6, p_sfpu::LREG7, SFPIADD_MOD1_CC_NONE);
+
+        // lo += top
         TTI_SFPIADD(0, p_sfpu::LREG5, p_sfpu::LREG7, SFPIADD_MOD1_CC_NONE);
 
-        // a3*b0 --> goes beyond 32-bits [24:39]. We need to extract the bits upto 32.
-        TTI_SFPMUL(p_sfpu::LREG2, p_sfpu::LREG1, p_sfpu::LCONST_0, p_sfpu::LREG5, 0);
-        TTI_SFPNOP;
-        TTI_SFP_STOCH_RND(SFPSTOCHRND_RND_EVEN, 0, 0, p_sfpu::LREG5, p_sfpu::LREG5, SFPSTOCHRND_MOD1_FP32_TO_UINT16);
-        TTI_SFPAND(0, p_sfpu::LREG6, p_sfpu::LREG5, 0);    // zero out high overflow bits
-        TTI_SFPSHFT(24, p_sfpu::LREG5, p_sfpu::LREG5, 1);  // Shift left by 24
-        TTI_SFPIADD(0, p_sfpu::LREG5, p_sfpu::LREG7, SFPIADD_MOD1_CC_NONE);
-
-        TT_SFPSTORE(p_sfpu::LREG7, INT32, ADDR_MOD_3, dst_index_out * dst_tile_size);
-        sfpi::dst_reg++;
+        TT_SFPSTORE(p_sfpu::LREG7, INT32, ADDR_MOD_2, dst_index_out * dst_tile_size);
     }
+}
+
+template <bool APPROXIMATION_MODE>
+inline void mul_int32_init() {
+    sfpi::vConstIntPrgm0 = 0x7ff;
+    sfpi::vConstIntPrgm1 = -11;
 }
 
 }  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_mul_int32.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_mul_int32.h
@@ -12,14 +12,14 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_mul_int32_init() {
-    llk_math_eltwise_binary_sfpu_init<SfpuType::unused, APPROXIMATE>();
+    llk_math_eltwise_binary_sfpu_init<SfpuType::mul_int32, APPROXIMATE>(sfpu::mul_int32_init<APPROXIMATE>);
 }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_mul_int32(
     uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::mul_int32<APPROXIMATE>, dst_index0, dst_index1, odst, vector_mode);
+        sfpu::mul_int32<APPROXIMATE>, dst_index0, dst_index1, odst, vector_mode);
 }
 
 }  // namespace ckernel


### PR DESCRIPTION
## This is a carbon copy of https://github.com/tenstorrent/tt-metal/pull/32645 since external developers can't run all the workflows.

### Ticket

Closes https://github.com/tenstorrent/tt-metal/issues/32479

### Problem description

`mul_int32` can be optimised.

### What's changed

- Rewrite kernel to use 11-bit chunks instead of 8-bit chunks.  This reduces the number of multiplications from 10 to 6, at the expense of more complex conversion from fp32 to int32 (because the products no longer fit into u16 and so a single `SFPSTOCHRND` can no longer be used).  However, overall this is ~2x faster (40 cycles instead of 87).
- Autoincrement is also used to save 1 cycle.
- A nice property of 11-bit chunks is that summing 3x 22-bit products can be done in fp32 without loss of precision, and so summation can be done for free with `SFPMAD`.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/19471430670) CI passes
- [x] [C++ Post commit tests (L2 Nightly)](https://github.com/tenstorrent/tt-metal/actions/runs/19471427132)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/runs/19479306783) CI fails the same way as on main
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/runs/19479310666) CI passes for Wormhole