### PR TITLE
optionally disable AVX in tt-metal build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,14 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_POSITION_INDEPENDENT_CODE TRUE)
 
+option(TT_METAL_ENABLE_AVX "Enable AVX/AVX2 optimized host code paths" ON)
+if(TT_METAL_ENABLE_AVX)
+    set(TT_METAL_X86_MARCH "x86-64-v3")
+else()
+    set(TT_METAL_X86_MARCH "x86-64-v2")
+endif()
+add_compile_definitions(TT_METAL_ENABLE_AVX=$<IF:$<BOOL:${TT_METAL_ENABLE_AVX}>,1,0>)
+
 # CMake 3.19: "smartly dropping dependencies of static and object libraries"
 set(CMAKE_OPTIMIZE_DEPENDENCIES TRUE)
 
@@ -124,6 +132,8 @@ message(STATUS "Build with LTO: ${TT_LTO_ENABLED}")
 message(STATUS "Build with Shared TTNN Sublibraries: ${ENABLE_TTNN_SHARED_SUBLIBS}")
 message(STATUS "Build with LightMetal Trace Enabled: ${TT_ENABLE_LIGHT_METAL_TRACE}")
 message(STATUS "Build with Multihost Distributed Compute: ${ENABLE_DISTRIBUTED}")
+message(STATUS "Enable AVX optimizations: ${TT_METAL_ENABLE_AVX}")
+message(STATUS "Target x86 baseline: ${TT_METAL_X86_MARCH}")
 
 ############################################################################################################################
 
@@ -166,7 +176,7 @@ target_link_libraries(
 )
 
 add_compile_options(
-    "$<$<STREQUAL:${CMAKE_SYSTEM_PROCESSOR},x86_64>:-march=x86-64-v3>"
+    "$<$<STREQUAL:${CMAKE_SYSTEM_PROCESSOR},x86_64>:-march=${TT_METAL_X86_MARCH}>"
     -fPIC
     -fvisibility-inlines-hidden
     -Wall

--- a/build_metal.sh
+++ b/build_metal.sh
@@ -51,6 +51,7 @@ show_help() {
     echo "  --without-distributed            Disable distributed compute support (OpenMPI dependency). Enabled by default."
     echo "  --without-python-bindings        Disable Python bindings (ttnncpp will be available as standalone library, otherwise ttnn will include the cpp backend and the python bindings), Enabled by default"
     echo "  --enable-fake-kernels-target     Enable fake kernels target, to enable generation of compile_commands.json for the kernels to enable IDE support."
+    echo "  --no-avx                         Build without AVX optimizations (targets x86-64-v2 baseline)."
 }
 
 clean() {
@@ -97,6 +98,7 @@ configure_only="OFF"
 enable_distributed="ON"
 with_python_bindings="ON"
 enable_fake_kernels_target="OFF"
+enable_avx="ON"
 
 declare -a cmake_args
 
@@ -136,6 +138,7 @@ configure-only
 without-distributed
 without-python-bindings
 enable-fake-kernels-target
+no-avx
 "
 
 # Flatten LONGOPTIONS into a comma-separated string for getopt
@@ -199,6 +202,8 @@ while true; do
             with_python_bindings="OFF";;
         --enable-fake-kernels-target)
             enable_fake_kernels_target="ON";;
+        --no-avx)
+            enable_avx="OFF";;
         --disable-unity-builds)
 	    unity_builds="OFF";;
         --disable-light-metal-trace)
@@ -277,12 +282,14 @@ echo "INFO: Enable Light Metal Trace: $light_metal_trace"
 echo "INFO: Enable Distributed: $enable_distributed"
 echo "INFO: With python bindings: $with_python_bindings"
 echo "INFO: Enable Tracy: $tracy_enabled"
+echo "INFO: Enable AVX Optimizations: $enable_avx"
 
 # Prepare cmake arguments
 cmake_args+=("-B" "$build_dir")
 cmake_args+=("-G" "Ninja")
 cmake_args+=("-DCMAKE_BUILD_TYPE=$build_type")
 cmake_args+=("-DCMAKE_INSTALL_PREFIX=$cmake_install_prefix")
+cmake_args+=("-DTT_METAL_ENABLE_AVX=$enable_avx")
 
 if [ "$cxx_compiler_path" != "" ]; then
     echo "INFO: C++ compiler: $cxx_compiler_path"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "tt-metal",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {}
+}

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/3_pcie_transfer/test_pull_from_pcie.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/3_pcie_transfer/test_pull_from_pcie.cpp
@@ -6,7 +6,9 @@
 #include <emmintrin.h>
 #include <errno.h>
 #include <fmt/base.h>
+#if TT_METAL_ENABLE_AVX
 #include <immintrin.h>
+#endif
 #include <smmintrin.h>
 #include <stdlib.h>
 #include <tt-metalium/allocator.hpp>
@@ -74,6 +76,18 @@ void* align(void* ptr, std::size_t max_alignment) {
 
 #define INNER_LOOP 8
 
+constexpr uint32_t kSseAlignmentBytes = sizeof(__m128);
+constexpr uint32_t kSseBlockBytes = INNER_LOOP * sizeof(__m128);
+#if TT_METAL_ENABLE_AVX
+constexpr uint32_t kMemcpyAlignmentBytes = sizeof(__m256i);
+constexpr uint32_t kStreamingAlignmentBytes = sizeof(__m256);
+constexpr uint32_t kStreamingBlockBytes = INNER_LOOP * sizeof(__m256);
+#else
+constexpr uint32_t kMemcpyAlignmentBytes = sizeof(__m128i);
+constexpr uint32_t kStreamingAlignmentBytes = kSseAlignmentBytes;
+constexpr uint32_t kStreamingBlockBytes = kSseBlockBytes;
+#endif
+
 template <bool stream_load, bool aligned_load>
 void nt_memcpy_128b(uint8_t* __restrict dst, const uint8_t* __restrict src, size_t n) {
     size_t num_lines = n / (INNER_LOOP * sizeof(__m128i));
@@ -108,6 +122,9 @@ void nt_memcpy_128b(uint8_t* __restrict dst, const uint8_t* __restrict src, size
 
 template <bool stream_load, bool aligned_load>
 void nt_memcpy_256b(uint8_t* __restrict dst, const uint8_t* __restrict src, size_t n) {
+#if !TT_METAL_ENABLE_AVX
+    nt_memcpy_128b<stream_load, aligned_load>(dst, src, n);
+#else
     size_t num_lines = n / (INNER_LOOP * sizeof(__m256i));
     constexpr size_t inner_blk_size = INNER_LOOP * sizeof(__m256i);
     size_t i;
@@ -137,6 +154,7 @@ void nt_memcpy_256b(uint8_t* __restrict dst, const uint8_t* __restrict src, size
     if (num_lines > 0) {
         tt_driver_atomics::sfence();
     }
+#endif
 }
 
 int main(int argc, char** argv) {
@@ -149,7 +167,7 @@ int main(int argc, char** argv) {
     bool simulate_write_ptr_update = false;
     uint32_t write_ptr_readback_interval = 0;
     uint32_t copy_mode = 0;
-    constexpr uint32_t memcpy_alignment = sizeof(__m256i);
+    constexpr uint32_t memcpy_alignment = kMemcpyAlignmentBytes;
     std::size_t addr_align = memcpy_alignment;
 
     try {
@@ -222,20 +240,19 @@ int main(int argc, char** argv) {
         if (copy_mode >= 2 && copy_mode <= 7) {
             if (copy_mode == 2 || copy_mode == 3) {
                 TT_ASSERT(
-                    addr_align % sizeof(__m128) == 0,
+                    addr_align % kSseAlignmentBytes == 0,
                     "Address alignment must be a multiple of 16 when using nt_memcpy");
             } else if (copy_mode == 5 || copy_mode == 6) {
                 TT_ASSERT(
-                    addr_align % sizeof(__m256) == 0,
+                    addr_align % kStreamingAlignmentBytes == 0,
                     "Address alignment must be a multiple of 32 when using nt_memcpy");
             }
             if (copy_mode >= 2 && copy_mode <= 4) {
                 TT_ASSERT(
-                    transfer_size % (INNER_LOOP * sizeof(__m128)) == 0,
-                    "Each copy to hugepage must be mod32==0 when using nt_memcpy");
+                    transfer_size % kSseBlockBytes == 0, "Each copy to hugepage must be mod32==0 when using nt_memcpy");
             } else if (copy_mode >= 5 && copy_mode <= 7) {
                 TT_ASSERT(
-                    transfer_size % (INNER_LOOP * sizeof(__m256)) == 0,
+                    transfer_size % kStreamingBlockBytes == 0,
                     "Each copy to hugepage must be mod64==0 when using nt_memcpy");
             }
         }

--- a/tt_metal/impl/data_format/bfloat4.cpp
+++ b/tt_metal/impl/data_format/bfloat4.cpp
@@ -6,10 +6,13 @@
 #include <tt-metalium/bfloat4.hpp>
 #include <tt_stl/span.hpp>
 #include <array>
+#include <bit>
 #include <functional>
 #include <random>
 #include <vector>
+#if TT_METAL_ENABLE_AVX
 #include <simde/x86/avx2.h>
+#endif
 
 #include <tt_stl/assert.hpp>
 #include "blockfloat_common.hpp"
@@ -93,7 +96,6 @@ std::vector<float> unpack_bfp4_tiles_into_float_vec(
     int data_dwords_per_exp_dword_log2 = log2(data_dwords_per_exp * num_exps_in_dword);
     int data_dwords_per_exp_log2 = log2(data_dwords_per_exp);
 
-    // the exponent index will always be 0 when tile_HW == 16, between 0-1 when tile_HW == 32, and between 0-3 otherwise
     uint32_t exp_bit_mask = (tile_HW == 16) ? 0x0 : (tile_HW == 32) ? 0x1 : 0x3;
 
     uint32_t size_bytes = bfp_tiles.size() * 4;
@@ -105,19 +107,6 @@ std::vector<float> unpack_bfp4_tiles_into_float_vec(
     int data_index;
     int subtile_r;
     int subtile_c;
-    const std::vector<uint32_t> mask_vec0 = {0xf, 0xf0, 0xf00, 0xf000};
-    const std::vector<uint32_t> mask_vec1 = {0xf0000, 0xf00000, 0xf000000, 0xf0000000};
-    const std::vector<uint32_t> shift_vec0 = {0, 4, 8, 12};
-    const std::vector<uint32_t> shift_vec1 = {16, 20, 24, 28};
-    const simde__m128i mask0 = simde_mm_loadu_si128(reinterpret_cast<const simde__m128i*>(mask_vec0.data()));
-    const simde__m128i mask1 = simde_mm_loadu_si128(reinterpret_cast<const simde__m128i*>(mask_vec1.data()));
-    const simde__m128i shift0 = simde_mm_loadu_si128(reinterpret_cast<const simde__m128i*>(shift_vec0.data()));
-    const simde__m128i shift1 = simde_mm_loadu_si128(reinterpret_cast<const simde__m128i*>(shift_vec1.data()));
-    simde__m256i rebias_offset = simde_mm256_setzero_si256();
-    if (is_exp_a) {
-        rebias_offset =
-            simde_mm256_set1_epi32(-112);  // This rebias offset must be added if we are working with BFP8 format.
-    }
     uint32_t exp_word, sub_word_index;
 
     uint32_t num_float_in_tile = subtiles_in_tile_row * subtiles_in_tile_col * subtile_rows * subtile_cols;
@@ -130,6 +119,21 @@ std::vector<float> unpack_bfp4_tiles_into_float_vec(
 
     std::vector<float> float_vec;
     float_vec.resize(num_tiles * num_float_in_tile);
+
+#if TT_METAL_ENABLE_AVX
+    const std::vector<uint32_t> mask_vec0 = {0xf, 0xf0, 0xf00, 0xf000};
+    const std::vector<uint32_t> mask_vec1 = {0xf0000, 0xf00000, 0xf000000, 0xf0000000};
+    const std::vector<uint32_t> shift_vec0 = {0, 4, 8, 12};
+    const std::vector<uint32_t> shift_vec1 = {16, 20, 24, 28};
+    const simde__m128i mask0 = simde_mm_loadu_si128(reinterpret_cast<const simde__m128i*>(mask_vec0.data()));
+    const simde__m128i mask1 = simde_mm_loadu_si128(reinterpret_cast<const simde__m128i*>(mask_vec1.data()));
+    const simde__m128i shift0 = simde_mm_loadu_si128(reinterpret_cast<const simde__m128i*>(shift_vec0.data()));
+    const simde__m128i shift1 = simde_mm_loadu_si128(reinterpret_cast<const simde__m128i*>(shift_vec1.data()));
+    simde__m256i rebias_offset = simde_mm256_setzero_si256();
+    if (is_exp_a) {
+        rebias_offset = simde_mm256_set1_epi32(-112);
+    }
+
     for (int tile_index = 0; tile_index < num_tiles; ++tile_index) {
         for (int tr = 0; tr < subtiles_in_tile_row; ++tr) {
             for (int tc = 0; tc < subtiles_in_tile_col; ++tc) {
@@ -142,26 +146,19 @@ std::vector<float> unpack_bfp4_tiles_into_float_vec(
                         data_index =
                             (tr * (subtiles_in_tile_col * face_HW / num_elements_in_dword) +
                              tc * (face_HW / num_elements_in_dword) + i * num_dwords_per_row +
-                             j / num_elements_in_dword);  // Each uint32_t contains 8 BFP4 values. Divide data index by
-                                                          // 8
+                             j / num_elements_in_dword);
                         int tile_and_data_index = data_index + (num_bfp_dwords_in_tile * tile_index);
 
                         int exponent_index =
                             (data_index >> data_dwords_per_exp_dword_log2) + (num_bfp_dwords_in_tile * tile_index);
-                        // Extract the uint32_t value that stores the shared exponent for this set
-                        // of data. Each 32 bit word is shared amongst 64 datums
                         exp_word = bfp_tiles[exponent_index];
 
                         int num_exponent_words_skip = tile_index * num_exp_words;
                         sub_word_index = ((tile_and_data_index - num_exponent_words_skip) >> data_dwords_per_exp_log2) &
-                                         exp_bit_mask;  // Extract the byte in which the shared exponent is stored. Each
-                                                        // byte is shared amongst 16 datums.
-                        simde__m256i exp_vector0 = simde_mm256_set1_epi32(
-                            get_byte(exp_word, sub_word_index));  // Replicate exp scalar in a vector
+                                         exp_bit_mask;
+                        simde__m256i exp_vector0 = simde_mm256_set1_epi32(get_byte(exp_word, sub_word_index));
                         simde__m256i exp_vector1 = exp_vector0;
 
-                        // Take 2 uint32_t values. These are 16 BFP4 values
-                        // Replicate each uint32 value 8 times - one for each bfp4 value
                         uint32_t first_val = bfp_tiles[num_exp_words + tile_and_data_index];
                         simde__m128i first0 = simde_mm_set1_epi32(first_val);
                         simde__m128i first1 = simde_mm_set1_epi32(first_val);
@@ -169,42 +166,26 @@ std::vector<float> unpack_bfp4_tiles_into_float_vec(
                         simde__m128i second0 = simde_mm_set1_epi32(second_val);
                         simde__m128i second1 = simde_mm_set1_epi32(second_val);
 
-                        first0 = simde_mm_srlv_epi32(
-                            simde_mm_and_si128(first0, mask0), shift0);  // Extract each BFP4 from the first0 uint32_t
-                        first1 = simde_mm_srlv_epi32(
-                            simde_mm_and_si128(first1, mask1), shift1);  // Extract each BFP4 from the first1 uint32_t
-                        second0 = simde_mm_srlv_epi32(
-                            simde_mm_and_si128(second0, mask0), shift0);  // Extract each BFP4 from the first0 uint32_t
-                        second1 = simde_mm_srlv_epi32(
-                            simde_mm_and_si128(second1, mask1), shift1);  // Extract each BFP4 from the first1 uint32_t
-                        simde__m256i combined0 =
-                            simde_mm256_set_m128i(first1, first0);  // Concatenate 2 128 vectors to 1 256
-                        simde__m256i combined1 =
-                            simde_mm256_set_m128i(second1, second0);  // Concatenate 2 128 vectors to 1 256
+                        first0 = simde_mm_srlv_epi32(simde_mm_and_si128(first0, mask0), shift0);
+                        first1 = simde_mm_srlv_epi32(simde_mm_and_si128(first1, mask1), shift1);
+                        second0 = simde_mm_srlv_epi32(simde_mm_and_si128(second0, mask0), shift0);
+                        second1 = simde_mm_srlv_epi32(simde_mm_and_si128(second1, mask1), shift1);
+                        simde__m256i combined0 = simde_mm256_set_m128i(first1, first0);
+                        simde__m256i combined1 = simde_mm256_set_m128i(second1, second0);
 
-                        // Extract sign and mantissa (expo extracted above)
                         simde__m256i sign0 = simde_mm256_srl_epi32(combined0, simde_mm_set_epi64x(0, 3));
                         simde__m256i man0 = simde_mm256_and_si256(combined0, simde_mm256_set1_epi32(0x7));
                         simde__m256i sign1 = simde_mm256_srl_epi32(combined1, simde_mm_set_epi64x(0, 3));
                         simde__m256i man1 = simde_mm256_and_si256(combined1, simde_mm256_set1_epi32(0x7));
 
-                        for (int i = 0; i < 2; i++) {
-                            simde__m256i shift_cnt = simde_mm256_setzero_si256();  // Initialize shift amount per datum
-                                                                                   // to 0. This is incremented below.
-                            simde__m256i man_shifted = i == 0 ? man0 : man1;       // Initialize updated mantissa
-                            simde__m256i select_mask = simde_mm256_cmpeq_epi32(
-                                man_shifted,
-                                shift_cnt);  // This mask is used to set mantissa values to 0, if they start at 0.
+                        for (int idx = 0; idx < 2; idx++) {
+                            simde__m256i shift_cnt = simde_mm256_setzero_si256();
+                            simde__m256i man_shifted = idx == 0 ? man0 : man1;
+                            simde__m256i select_mask = simde_mm256_cmpeq_epi32(man_shifted, shift_cnt);
                             for (int shift_val = 0; shift_val < 3; shift_val++) {
-                                // Shift each mantissa and update the corresponding shift_cnt until the 3rd bit of the 8
-                                // bit data is set.
                                 simde__m256i shift_mask = simde_mm256_or_si256(
                                     simde_mm256_cmpgt_epi32(man_shifted, simde_mm256_set1_epi32(0x4)),
-                                    simde_mm256_cmpeq_epi32(
-                                        man_shifted,
-                                        simde_mm256_set1_epi32(
-                                            0x4)));  // If the 6th bit is set, propagate the current
-                                                     // mantissa value. Else take the left shifted value
+                                    simde_mm256_cmpeq_epi32(man_shifted, simde_mm256_set1_epi32(0x4)));
                                 man_shifted = simde_mm256_blendv_epi8(
                                     simde_mm256_sll_epi32(man_shifted, simde_mm_set_epi64x(0, 1)),
                                     man_shifted,
@@ -214,72 +195,118 @@ std::vector<float> unpack_bfp4_tiles_into_float_vec(
                             }
                             man_shifted = simde_mm256_and_si256(
                                 simde_mm256_sll_epi32(man_shifted, simde_mm_set_epi64x(0, 1)),
-                                simde_mm256_set1_epi32(
-                                    0x7));  // One more shift to clear 3rd bit; Mask with 3bits for mantissa
-                            if (i == 0) {
-                                man0 = simde_mm256_blendv_epi8(
-                                    man_shifted, man0, select_mask);  // Choose new mantissa or keep old mantissa based
-                                                                      // on 0 initial condition.
-                                // Flush denormals to zero
-                                // Check if shift > exp and mantissa is not zero
-                                simde__m256i mask_shift_gt_exp = simde_mm256_cmpgt_epi32(shift_cnt, exp_vector0);
-                                simde__m256i mask_nonzero_mantissa = simde_mm256_xor_si256(select_mask, simde_mm256_set1_epi32(-1));
-                                mask_denormal0 = simde_mm256_and_si256(mask_shift_gt_exp, mask_nonzero_mantissa);
+                                simde_mm256_set1_epi32(0x7));
+                            if (idx == 0) {
+                                man0 = simde_mm256_blendv_epi8(man_shifted, man0, select_mask);
+                            } else {
+                                man1 = simde_mm256_blendv_epi8(man_shifted, man1, select_mask);
+                            }
 
+                            simde__m256i mask_shift_gt_exp =
+                                simde_mm256_cmpgt_epi32(shift_cnt, idx == 0 ? exp_vector0 : exp_vector1);
+                            simde__m256i mask_nonzero_mantissa =
+                                simde_mm256_xor_si256(select_mask, simde_mm256_set1_epi32(-1));
+                            simde__m256i mask_denormal =
+                                simde_mm256_and_si256(mask_shift_gt_exp, mask_nonzero_mantissa);
+                            if (idx == 0) {
+                                mask_denormal0 = mask_denormal;
+                            } else {
+                                mask_denormal1 = mask_denormal;
+                            }
+
+                            if (idx == 0) {
                                 exp_vector0 = simde_mm256_blendv_epi8(
                                     simde_mm256_sub_epi32(exp_vector0, simde_mm256_add_epi32(rebias_offset, shift_cnt)),
                                     simde_mm256_setzero_si256(),
-                                    select_mask);  // Choose new (rebiased exponent) or keep previous exponent based on
-                                                   // mantissa intiial condition
+                                    select_mask);
                             } else {
-                                man1 = simde_mm256_blendv_epi8(
-                                    man_shifted, man1, select_mask);  // Choose new mantissa or keep old mantissa based
-                                                                      // on 0 initial condition.
-                                // Flush denormals to zero
-                                // Check if shift > exp and mantissa is not zero
-                                simde__m256i mask_shift_gt_exp = simde_mm256_cmpgt_epi32(shift_cnt, exp_vector1);
-                                simde__m256i mask_nonzero_mantissa = simde_mm256_xor_si256(select_mask, simde_mm256_set1_epi32(-1));
-                                mask_denormal1 = simde_mm256_and_si256(mask_shift_gt_exp, mask_nonzero_mantissa);
                                 exp_vector1 = simde_mm256_blendv_epi8(
                                     simde_mm256_sub_epi32(exp_vector1, simde_mm256_add_epi32(rebias_offset, shift_cnt)),
                                     simde_mm256_setzero_si256(),
-                                    select_mask);  // Choose new (rebiased exponent) or keep previous exponent based on
-                                                   // mantissa intiial condition
+                                    select_mask);
                             }
                         }
 
-                        sign0 = simde_mm256_sll_epi32(sign0, simde_mm_set_epi64x(0, 31));              // Shift sign
-                        sign1 = simde_mm256_sll_epi32(sign1, simde_mm_set_epi64x(0, 31));              // Shift sign
-                        exp_vector0 = simde_mm256_sll_epi32(exp_vector0, simde_mm_set_epi64x(0, 23));  // Shift exp
-                        exp_vector1 = simde_mm256_sll_epi32(exp_vector1, simde_mm_set_epi64x(0, 23));  // Shift exp
-                        man0 = simde_mm256_sll_epi32(man0, simde_mm_set_epi64x(0, 20));                // Shift mantissa
-                        man0 = simde_mm256_or_si256(
-                            sign0,
-                            simde_mm256_or_si256(
-                                exp_vector0, man0));  // Store final value in mantissa register and save
-                        man1 = simde_mm256_sll_epi32(man1, simde_mm_set_epi64x(0, 20));  // Shift mantissa
-                        man1 = simde_mm256_or_si256(
-                            sign1,
-                            simde_mm256_or_si256(
-                                exp_vector1, man1));  // Store final value in mantissa register and save
+                        sign0 = simde_mm256_sll_epi32(sign0, simde_mm_set_epi64x(0, 31));
+                        exp_vector0 = simde_mm256_sll_epi32(exp_vector0, simde_mm_set_epi64x(0, 23));
+                        man0 = simde_mm256_sll_epi32(man0, simde_mm_set_epi64x(0, 19));
+                        sign1 = simde_mm256_sll_epi32(sign1, simde_mm_set_epi64x(0, 31));
+                        exp_vector1 = simde_mm256_sll_epi32(exp_vector1, simde_mm_set_epi64x(0, 23));
+                        man1 = simde_mm256_sll_epi32(man1, simde_mm_set_epi64x(0, 19));
 
-                        // Zero out lanes where mask_denormal is true
-                        man0 = simde_mm256_blendv_epi8(man0, simde_mm256_setzero_si256(), mask_denormal0);
-                        man1 = simde_mm256_blendv_epi8(man1, simde_mm256_setzero_si256(), mask_denormal1);
+                        simde__m256i man0_with_sign =
+                            simde_mm256_or_si256(sign0, simde_mm256_or_si256(exp_vector0, man0));
+                        simde__m256i man1_with_sign =
+                            simde_mm256_or_si256(sign1, simde_mm256_or_si256(exp_vector1, man1));
+
+                        man0_with_sign =
+                            simde_mm256_blendv_epi8(man0_with_sign, simde_mm256_setzero_si256(), mask_denormal0);
+                        man1_with_sign =
+                            simde_mm256_blendv_epi8(man1_with_sign, simde_mm256_setzero_si256(), mask_denormal1);
+
                         uint32_t float_data_index;
                         if (row_major_output) {
                             float_data_index = subtile_c + (tile_W * subtile_r) + (tile_index * num_float_in_tile);
+                            simde_mm256_storeu_ps(
+                                &float_vec[float_data_index], simde_mm256_castsi256_ps(man0_with_sign));
+                            simde_mm256_storeu_ps(
+                                &float_vec[float_data_index + 8], simde_mm256_castsi256_ps(man1_with_sign));
                         } else {
                             float_data_index = fp32_element_index;
-                            fp32_element_index += 2 * num_elements_in_dword;
+                            fp32_element_index += 16;
+                            simde_mm256_storeu_ps(
+                                &float_vec[float_data_index], simde_mm256_castsi256_ps(man0_with_sign));
+                            simde_mm256_storeu_ps(
+                                &float_vec[float_data_index + 8], simde_mm256_castsi256_ps(man1_with_sign));
                         }
-                        simde_mm256_storeu_ps(&float_vec[float_data_index], simde_mm256_castsi256_ps(man0));
-                        simde_mm256_storeu_ps(
-                            &float_vec[float_data_index + num_elements_in_dword], simde_mm256_castsi256_ps(man1));
                     }
                 }
             }
         }
     }
+#else
+    for (int tile_index = 0; tile_index < num_tiles; ++tile_index) {
+        for (int tr = 0; tr < subtiles_in_tile_row; ++tr) {
+            for (int tc = 0; tc < subtiles_in_tile_col; ++tc) {
+                for (int i = 0; i < subtile_rows; ++i) {
+                    subtile_r = tr * subtile_rows + i;
+                    for (int j = 0; j < subtile_cols; j += 2 * num_elements_in_dword) {
+                        subtile_c = tc * subtile_cols + j;
+                        data_index =
+                            (tr * (subtiles_in_tile_col * face_HW / num_elements_in_dword) +
+                             tc * (face_HW / num_elements_in_dword) + i * num_dwords_per_row +
+                             j / num_elements_in_dword);
+                        int tile_and_data_index = data_index + (num_bfp_dwords_in_tile * tile_index);
+                        int exponent_index =
+                            (data_index >> data_dwords_per_exp_dword_log2) + (num_bfp_dwords_in_tile * tile_index);
+                        exp_word = bfp_tiles[exponent_index];
+                        int num_exponent_words_skip = tile_index * num_exp_words;
+                        sub_word_index = ((tile_and_data_index - num_exponent_words_skip) >> data_dwords_per_exp_log2) &
+                                         exp_bit_mask;
+                        uint8_t shared_exp = get_byte(exp_word, sub_word_index);
+
+                        uint32_t word0 = bfp_tiles[num_exp_words + tile_and_data_index];
+                        uint32_t word1 = bfp_tiles[num_exp_words + tile_and_data_index + 1];
+                        uint32_t float_data_index =
+                            row_major_output ? (subtile_c + (tile_W * subtile_r) + (tile_index * num_float_in_tile))
+                                             : fp32_element_index;
+
+                        for (int lane = 0; lane < 16; ++lane) {
+                            uint32_t word = (lane < 8) ? word0 : word1;
+                            uint8_t datum = static_cast<uint8_t>((word >> ((lane % 8) * 4)) & 0xF);
+                            uint32_t bit_val = convert_bfp_to_u32(tt::DataFormat::Bfp4_b, datum, shared_exp, is_exp_a);
+                            float value = std::bit_cast<float>(bit_val);
+                            float_vec[float_data_index + lane] = value;
+                        }
+
+                        if (!row_major_output) {
+                            fp32_element_index += 16;
+                        }
+                    }
+                }
+            }
+        }
+    }
+#endif
     return float_vec;
 }


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/32672)

### Problem description
Older systems that do not have AVX will have an illegal instruction error when trying to use built metal

### What's changed
This PR adds a flag for gating out usage of AVX in building metal

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes