### PR TITLE
Initial implementation of RemoteCircularBuffer

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/10_dram_read_remote_cb_sync/kernels/receiver_l1.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/10_dram_read_remote_cb_sync/kernels/receiver_l1.cpp
@@ -43,7 +43,7 @@ void kernel_main() {
         uint32_t curr_block_num_tiles = block_num_tiles[l];
 
         uint32_t curr_block_size = curr_block_num_tiles * curr_page_size;
-        remote_cb.set_sender_page_size(curr_block_size);
+        remote_cb.set_receiver_page_size(curr_block_size);
 
         for (uint32_t block = 0; block < curr_num_blocks; ++block) {
             remote_cb.wait_front(1);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/10_dram_read_remote_cb_sync/kernels/receiver_l1.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/10_dram_read_remote_cb_sync/kernels/receiver_l1.cpp
@@ -35,18 +35,20 @@ void kernel_main() {
 
     start_page_size = page_size[0];
 
+    experimental::RemoteCircularBuffer remote_cb{remote_cb_id};
+
     for (uint32_t l = 0; l < num_layers; ++l) {
         uint32_t curr_page_size = page_size[l];
         uint32_t curr_num_blocks = num_blocks[l];
         uint32_t curr_block_num_tiles = block_num_tiles[l];
 
         uint32_t curr_block_size = curr_block_num_tiles * curr_page_size;
-        experimental::resize_remote_receiver_cb_interface(remote_cb_id, curr_block_size, noc_index);
+        remote_cb.set_sender_page_size(curr_block_size);
 
         for (uint32_t block = 0; block < curr_num_blocks; ++block) {
-            experimental::remote_cb_wait_front(remote_cb_id, 1);
-            experimental::remote_cb_pop_front(remote_cb_id, 1);
+            remote_cb.wait_front(1);
+            remote_cb.pop_front(1);
         }
     }
-    experimental::update_remote_cb_config_in_l1(remote_cb_id);
+    remote_cb.commit();
 }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/common/kernels/writer_l1.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/common/kernels/writer_l1.cpp
@@ -39,7 +39,11 @@ void kernel_main() {
 
     start_page_size = page_size[0];
 
-    constexpr uint32_t cb_id = 0;
+    experimental::Noc noc_if{noc};
+    experimental::RemoteCircularBuffer remote_cb{remote_cb_id, noc_if};
+
+    constexpr uint32_t local_cb_id = 0;
+    experimental::CircularBuffer local_cb{local_cb_id};
 
     for (uint32_t l = 0; l < num_layers; ++l) {
         uint32_t curr_coalesced_page_size = coalesced_page_size[l];
@@ -51,25 +55,17 @@ void kernel_main() {
         uint32_t curr_receiver_block_num_tiles = curr_block_num_tiles / num_receivers;
 
         uint32_t curr_block_size = curr_receiver_block_num_tiles * curr_page_size;
-        experimental::resize_remote_sender_cb_interface(remote_cb_id, curr_block_size, noc_index);
+        remote_cb.set_sender_page_size(curr_block_size);
 
         for (uint32_t block = 0; block < curr_num_blocks; ++block) {
-            cb_wait_front(cb_id, curr_block_num_tiles);
+            local_cb.wait_front(curr_block_num_tiles);
 
-            uint32_t local_cb_addr = get_read_ptr(cb_id);
-            experimental::remote_cb_reserve_back(remote_cb_id, 1);
-            experimental::remote_cb_push_back_and_write_pages(
-                remote_cb_id,
-                local_cb_addr,
-                1,
-                curr_num_tile_rows,
-                curr_coalesced_num_pages,
-                curr_coalesced_page_size,
-                noc);
+            remote_cb.reserve_back(1);
+            remote_cb.push_back(local_cb, 1, curr_num_tile_rows, curr_coalesced_num_pages, curr_coalesced_page_size);
 
-            cb_pop_front(cb_id, curr_block_num_tiles);
+            local_cb.pop_front(curr_block_num_tiles);
         }
         layer++;
     }
-    experimental::update_remote_cb_config_in_l1(remote_cb_id);
+    remote_cb.commit();
 }

--- a/tt_metal/hw/inc/remote_circular_buffer_api.h
+++ b/tt_metal/hw/inc/remote_circular_buffer_api.h
@@ -412,10 +412,31 @@ FORCE_INLINE void update_remote_cb_config_in_l1(uint32_t remote_cb_index) {
 class Noc;
 class CircularBuffer;
 
+/** @brief Remote circular buffer API
+ * Provides an interface for the Producer and Consumer cores of a Circular Buffer to be on different cores on the same
+ * chip.
+ */
 class RemoteCircularBuffer {
 public:
-    explicit RemoteCircularBuffer(uint32_t remote_cb_index) : remote_cb_index_(remote_cb_index), noc_(noc_index) {}
+    /** @brief Enum class for the type of remote pointer update
+     *
+     * SKIP: Skip updating the remote pointer
+     * UPDATE_OVER_NOC: Update the remote pointer over the NoC. This will cause a NoC transaction.
+     */
+    enum class RemotePointerUpdate { SKIP, UPDATE_OVER_NOC };
 
+    /** @brief Construct a RemoteCircularBuffer with the default NoC for the kernel
+     *
+     * @param remote_cb_index The index of the remote circular buffer
+     */
+    explicit RemoteCircularBuffer(uint32_t remote_cb_index) :
+        remote_cb_index_(remote_cb_index), noc_(experimental::Noc()) {}
+
+    /** @brief Construct a RemoteCircularBuffer with the specified NoC
+     *
+     * @param remote_cb_index The index of the remote circular buffer
+     * @param noc The NoC to use for the remote circular buffer
+     */
     explicit RemoteCircularBuffer(uint32_t remote_cb_index, experimental::Noc noc) :
         remote_cb_index_(remote_cb_index), noc_(noc) {}
 
@@ -424,6 +445,9 @@ public:
      * This will block until the specified number of pages are available on the remote circular buffer.
      *
      * This is intended to be called by the sender core.
+     *
+     * @param num_pages The number of pages to reserve
+     * @param noc The NoC to use for the remote circular buffer
      */
     void reserve_back(uint32_t num_pages) { remote_cb_reserve_back(remote_cb_index_, num_pages); }
 
@@ -432,15 +456,23 @@ public:
      * Must call reserve_back before calling this function.
      *
      * This is intended to be called by the sender core.
+     *
+     * @param src_local_cb The local circular buffer to push from
+     * @param num_pages The number of pages to push
+     * @param num_rows The number of rows to push
+     * @param coalesced_num_pages_per_row The number of coalesced pages per row
+     * @param coalesced_page_size The size of the coalesced page
+     * @param noc The NoC to use for the remote circular buffer
+     * @param update_remote_pointer The type of remote pointer update
      */
-    template <bool skip_ptr_update = true>
+    template <RemotePointerUpdate update_remote_pointer = RemotePointerUpdate::UPDATE_OVER_NOC>
     void push_back(
         experimental::CircularBuffer& src_local_cb,
         uint32_t num_pages,
         uint32_t num_rows,
         uint32_t coalesced_num_pages_per_row,
         uint32_t coalesced_page_size) {
-        remote_cb_push_back_and_write_pages<skip_ptr_update>(
+        remote_cb_push_back_and_write_pages<update_remote_pointer == RemotePointerUpdate::UPDATE_OVER_NOC>(
             remote_cb_index_,
             src_local_cb.get_read_ptr(),
             num_pages,
@@ -450,21 +482,27 @@ public:
             noc_.get_noc_id());
     }
 
-    /** @brief Resizes the remote circular buffer's page size
+    /** @brief Resizes the remote receiver circular buffer's page size
      *
      * Resizes the remote circular buffer's page size. This may result in noc transactions for synchronizing with the
      * receiver core.
      *
      * This is intended to be called by the sender core.
+     *
+     * @param page_size The new page size
+     * @param update_remote_pointer The type of remote pointer update
      */
-    template <bool skip_ptr_update = true>
+    template <RemotePointerUpdate update_remote_pointer = RemotePointerUpdate::UPDATE_OVER_NOC>
     void set_receiver_page_size(uint32_t page_size) {
-        resize_remote_receiver_cb_interface<skip_ptr_update>(remote_cb_index_, page_size, noc_.get_noc_id());
+        resize_remote_receiver_cb_interface<update_remote_pointer == RemotePointerUpdate::UPDATE_OVER_NOC>(
+            remote_cb_index_, page_size, noc_.get_noc_id());
     }
 
     /** @brief Waits for the specified number of pages to be available in the remote circular buffer
      *
      * This is intended to be called by the receiver core.
+     *
+     * @param num_pages The number of pages to wait for
      */
     void wait_front(uint32_t num_pages) { remote_cb_wait_front(remote_cb_index_, num_pages); }
 
@@ -475,20 +513,25 @@ public:
      * should be called before calling this function to ensure the data is available.
      *
      * This is intended to be called by the receiver core.
+     *
+     * @param num_pages The number of pages to pop
      */
     void pop_front(uint32_t num_pages) { remote_cb_pop_front(remote_cb_index_, num_pages, noc_.get_noc_id()); }
 
-    /** @brief Resizes the remote circular buffer's page size
+    /** @brief Resizes the sender remote circular buffer's page size
      *
      * Resizes the remote circular buffer's page size. This may result in noc transactions for synchronizing with the
      * sender core.
      *
      * This is intended to be called by the receiver core.
      *
+     * @param page_size The new page size
+     * @param update_remote_pointer The type of remote pointer update
      */
-    template <bool skip_ptr_update = true>
+    template <RemotePointerUpdate update_remote_pointer = RemotePointerUpdate::UPDATE_OVER_NOC>
     void set_sender_page_size(uint32_t page_size) {
-        resize_remote_sender_cb_interface<skip_ptr_update>(remote_cb_index_, page_size, noc_.get_noc_id());
+        resize_remote_sender_cb_interface<update_remote_pointer == RemotePointerUpdate::UPDATE_OVER_NOC>(
+            remote_cb_index_, page_size, noc_.get_noc_id());
     }
 
     /** @brief Waits for all pages to be consumed by the receiver core


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
- New device side APIs

### What's changed
- Implement RemoteCircularBuffer class and update the basic test to use this experimental API

### Checklist
All Post Commit
https://github.com/tenstorrent/tt-metal/actions/runs/19482886974
Blackhole Post Commit
https://github.com/tenstorrent/tt-metal/actions/runs/19482864701
Galaxy Unit Tests
https://github.com/tenstorrent/tt-metal/actions/runs/19482874553
Tested Locally
```
./build/test/tt_metal/perf_microbenchmark/10_dram_read_remote_cb_sync/test_dram_read_remote_cb   --k 1024   --n 256   --num-blocks 16   --cb-num-blocks 5   --num-receivers 1   --data-type 1
```