### PR TITLE
[skip ci] Remove Galaxy Deepseek tests from Galaxy Demo pipelines

### DIFF
--- a/.github/workflows/galaxy-demo-tests.yaml
+++ b/.github/workflows/galaxy-demo-tests.yaml
@@ -43,4 +43,3 @@ jobs:
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       model: ${{ inputs.model || 'all' }}
       topology: topology-6u
-      

--- a/.github/workflows/galaxy-demo-tests.yaml
+++ b/.github/workflows/galaxy-demo-tests.yaml
@@ -22,14 +22,8 @@ on:
           - gpt-oss
           - wan22
           - mochi
-      deepseek:
-        description: 'Run DeepSeek tests'
-        required: false
-        default: false
-        type: boolean
   schedule:
     - cron: "0 0 * * *" # This cron schedule runs demo tests every day at 12am UTC
-    - cron: "0 9 * * 6" # frequency of galaxy deepseek tests
 jobs:
   build-artifact:
     uses: ./.github/workflows/build-artifact.yaml
@@ -49,13 +43,4 @@ jobs:
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       model: ${{ inputs.model || 'all' }}
       topology: topology-6u
-  galaxy-deepseek-tests:
-    needs: build-artifact
-    secrets: inherit
-    uses: ./.github/workflows/galaxy-deepseek-tests-impl.yaml
-    if: ${{ (github.event_name == 'workflow_dispatch' && inputs.deepseek) || (github.event_name == 'schedule' && github.event.schedule == '0 9 * * 6') }}
-    with:
-      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-      topology: topology-6u
+      


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
As per discussion in meeting and in slack discussion, it was agreed that Deepseek tests will run on Galaxy Deepseek pipelines: https://tenstorrent.slack.com/archives/C05GRJC4J4A/p1763501155658589?thread_ts=1763500520.843319&cid=C05GRJC4J4A

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [x] https://github.com/tenstorrent/tt-metal/actions/runs/19482176332