### PR TITLE
Initial implementation of RemoteCircularBuffer

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/10_dram_read_remote_cb_sync/kernels/receiver_l1.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/10_dram_read_remote_cb_sync/kernels/receiver_l1.cpp
@@ -44,7 +44,7 @@ void kernel_main() {
         uint32_t curr_block_num_tiles = block_num_tiles[l];
 
         uint32_t curr_block_size = curr_block_num_tiles * curr_page_size;
-        remote_cb.set_receiver_page_size(curr_block_size, noc);
+        remote_cb.set_sender_page_size(curr_block_size, noc);
 
         for (uint32_t block = 0; block < curr_num_blocks; ++block) {
             remote_cb.wait_front(1);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/10_dram_read_remote_cb_sync/kernels/receiver_l1.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/10_dram_read_remote_cb_sync/kernels/receiver_l1.cpp
@@ -43,7 +43,7 @@ void kernel_main() {
         uint32_t curr_block_num_tiles = block_num_tiles[l];
 
         uint32_t curr_block_size = curr_block_num_tiles * curr_page_size;
-        remote_cb.set_sender_page_size(curr_block_size);
+        remote_cb.set_receiver_page_size(curr_block_size);
 
         for (uint32_t block = 0; block < curr_num_blocks; ++block) {
             remote_cb.wait_front(1);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/10_dram_read_remote_cb_sync/kernels/receiver_l1.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/10_dram_read_remote_cb_sync/kernels/receiver_l1.cpp
@@ -44,11 +44,11 @@ void kernel_main() {
         uint32_t curr_block_num_tiles = block_num_tiles[l];
 
         uint32_t curr_block_size = curr_block_num_tiles * curr_page_size;
-        remote_cb.set_sender_page_size(curr_block_size, noc);
+        remote_cb.set_sender_page_size(noc, curr_block_size);
 
         for (uint32_t block = 0; block < curr_num_blocks; ++block) {
             remote_cb.wait_front(1);
-            remote_cb.pop_front(1, noc);
+            remote_cb.pop_front(noc, 1);
         }
     }
     remote_cb.commit();

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/10_dram_read_remote_cb_sync/kernels/receiver_l1.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/10_dram_read_remote_cb_sync/kernels/receiver_l1.cpp
@@ -35,18 +35,20 @@ void kernel_main() {
 
     start_page_size = page_size[0];
 
+    experimental::RemoteCircularBuffer remote_cb{remote_cb_id};
+
     for (uint32_t l = 0; l < num_layers; ++l) {
         uint32_t curr_page_size = page_size[l];
         uint32_t curr_num_blocks = num_blocks[l];
         uint32_t curr_block_num_tiles = block_num_tiles[l];
 
         uint32_t curr_block_size = curr_block_num_tiles * curr_page_size;
-        experimental::resize_remote_receiver_cb_interface(remote_cb_id, curr_block_size, noc_index);
+        remote_cb.set_sender_page_size(curr_block_size);
 
         for (uint32_t block = 0; block < curr_num_blocks; ++block) {
-            experimental::remote_cb_wait_front(remote_cb_id, 1);
-            experimental::remote_cb_pop_front(remote_cb_id, 1);
+            remote_cb.wait_front(1);
+            remote_cb.pop_front(1);
         }
     }
-    experimental::update_remote_cb_config_in_l1(remote_cb_id);
+    remote_cb.commit();
 }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/10_dram_read_remote_cb_sync/kernels/receiver_l1.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/10_dram_read_remote_cb_sync/kernels/receiver_l1.cpp
@@ -36,6 +36,7 @@ void kernel_main() {
     start_page_size = page_size[0];
 
     experimental::RemoteCircularBuffer remote_cb{remote_cb_id};
+    experimental::Noc noc;
 
     for (uint32_t l = 0; l < num_layers; ++l) {
         uint32_t curr_page_size = page_size[l];
@@ -43,7 +44,7 @@ void kernel_main() {
         uint32_t curr_block_num_tiles = block_num_tiles[l];
 
         uint32_t curr_block_size = curr_block_num_tiles * curr_page_size;
-        remote_cb.set_receiver_page_size(curr_block_size);
+        remote_cb.set_receiver_page_size(curr_block_size, noc);
 
         for (uint32_t block = 0; block < curr_num_blocks; ++block) {
             remote_cb.wait_front(1);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/10_dram_read_remote_cb_sync/kernels/receiver_l1.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/10_dram_read_remote_cb_sync/kernels/receiver_l1.cpp
@@ -48,7 +48,7 @@ void kernel_main() {
 
         for (uint32_t block = 0; block < curr_num_blocks; ++block) {
             remote_cb.wait_front(1);
-            remote_cb.pop_front(1);
+            remote_cb.pop_front(1, noc);
         }
     }
     remote_cb.commit();

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/11_remote_cb_sync_matmul_single_core/kernels/receiver_l1.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/11_remote_cb_sync_matmul_single_core/kernels/receiver_l1.cpp
@@ -50,7 +50,7 @@ void kernel_main() {
         uint32_t curr_block_num_tiles = block_num_tiles[l];
 
         uint32_t curr_block_size = curr_block_num_tiles * curr_page_size;
-        remote_cb.set_receiver_page_size(curr_block_size, noc);
+        remote_cb.set_sender_page_size(curr_block_size, noc);
         experimental::align_local_cbs_to_remote_cb<1>(remote_cb_id, {cb_id_in1});
 
         for (uint32_t block = 0; block < curr_num_blocks; ++block) {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/11_remote_cb_sync_matmul_single_core/kernels/receiver_l1.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/11_remote_cb_sync_matmul_single_core/kernels/receiver_l1.cpp
@@ -36,6 +36,7 @@ void kernel_main() {
     start_page_size = page_size[0];
 
     experimental::RemoteCircularBuffer remote_cb{remote_cb_id};
+    experimental::Noc noc;
 
     constexpr uint32_t cb_id_in1 = 1;
     experimental::CircularBuffer local_cb{cb_id_in1};
@@ -49,7 +50,7 @@ void kernel_main() {
         uint32_t curr_block_num_tiles = block_num_tiles[l];
 
         uint32_t curr_block_size = curr_block_num_tiles * curr_page_size;
-        remote_cb.set_receiver_page_size(curr_block_size);
+        remote_cb.set_receiver_page_size(curr_block_size, noc);
         experimental::align_local_cbs_to_remote_cb<1>(remote_cb_id, {cb_id_in1});
 
         for (uint32_t block = 0; block < curr_num_blocks; ++block) {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/11_remote_cb_sync_matmul_single_core/kernels/receiver_l1.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/11_remote_cb_sync_matmul_single_core/kernels/receiver_l1.cpp
@@ -50,7 +50,7 @@ void kernel_main() {
         uint32_t curr_block_num_tiles = block_num_tiles[l];
 
         uint32_t curr_block_size = curr_block_num_tiles * curr_page_size;
-        remote_cb.set_sender_page_size(curr_block_size, noc);
+        remote_cb.set_sender_page_size(noc, curr_block_size);
         experimental::align_local_cbs_to_remote_cb<1>(remote_cb_id, {cb_id_in1});
 
         for (uint32_t block = 0; block < curr_num_blocks; ++block) {
@@ -59,7 +59,7 @@ void kernel_main() {
             local_cb.push_back(curr_block_num_tiles);
             // wait for compute done
             sync_cb.wait_front(1);
-            remote_cb.pop_front(1);
+            remote_cb.pop_front(noc, 1);
             sync_cb.pop_front(1);
         }
     }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/common/kernels/writer_l1.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/common/kernels/writer_l1.cpp
@@ -55,13 +55,14 @@ void kernel_main() {
         uint32_t curr_receiver_block_num_tiles = curr_block_num_tiles / num_receivers;
 
         uint32_t curr_block_size = curr_receiver_block_num_tiles * curr_page_size;
-        remote_cb.set_receiver_page_size(curr_block_size, noc_if);
+        remote_cb.set_receiver_page_size(noc_if, curr_block_size);
 
         for (uint32_t block = 0; block < curr_num_blocks; ++block) {
             local_cb.wait_front(curr_block_num_tiles);
 
             remote_cb.reserve_back(1);
-            remote_cb.push_back(local_cb, 1, curr_num_tile_rows, curr_coalesced_num_pages, curr_coalesced_page_size, noc_if);
+            remote_cb.push_back(
+                noc_if, local_cb, 1, curr_num_tile_rows, curr_coalesced_num_pages, curr_coalesced_page_size);
 
             local_cb.pop_front(curr_block_num_tiles);
         }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/common/kernels/writer_l1.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/common/kernels/writer_l1.cpp
@@ -39,7 +39,11 @@ void kernel_main() {
 
     start_page_size = page_size[0];
 
-    constexpr uint32_t cb_id = 0;
+    experimental::Noc noc_if{noc};
+    experimental::RemoteCircularBuffer remote_cb{remote_cb_id, noc_if};
+
+    constexpr uint32_t local_cb_id = 0;
+    experimental::CircularBuffer local_cb{local_cb_id};
 
     for (uint32_t l = 0; l < num_layers; ++l) {
         uint32_t curr_coalesced_page_size = coalesced_page_size[l];
@@ -51,25 +55,17 @@ void kernel_main() {
         uint32_t curr_receiver_block_num_tiles = curr_block_num_tiles / num_receivers;
 
         uint32_t curr_block_size = curr_receiver_block_num_tiles * curr_page_size;
-        experimental::resize_remote_sender_cb_interface(remote_cb_id, curr_block_size, noc_index);
+        remote_cb.set_sender_page_size(curr_block_size);
 
         for (uint32_t block = 0; block < curr_num_blocks; ++block) {
-            cb_wait_front(cb_id, curr_block_num_tiles);
+            local_cb.wait_front(curr_block_num_tiles);
 
-            uint32_t local_cb_addr = get_read_ptr(cb_id);
-            experimental::remote_cb_reserve_back(remote_cb_id, 1);
-            experimental::remote_cb_push_back_and_write_pages(
-                remote_cb_id,
-                local_cb_addr,
-                1,
-                curr_num_tile_rows,
-                curr_coalesced_num_pages,
-                curr_coalesced_page_size,
-                noc);
+            remote_cb.reserve_back(1);
+            remote_cb.push_back(local_cb, 1, curr_num_tile_rows, curr_coalesced_num_pages, curr_coalesced_page_size);
 
-            cb_pop_front(cb_id, curr_block_num_tiles);
+            local_cb.pop_front(curr_block_num_tiles);
         }
         layer++;
     }
-    experimental::update_remote_cb_config_in_l1(remote_cb_id);
+    remote_cb.commit();
 }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/common/kernels/writer_l1.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/common/kernels/writer_l1.cpp
@@ -40,7 +40,7 @@ void kernel_main() {
     start_page_size = page_size[0];
 
     experimental::Noc noc_if{noc};
-    experimental::RemoteCircularBuffer remote_cb{remote_cb_id, noc_if};
+    experimental::RemoteCircularBuffer remote_cb{remote_cb_id};
 
     constexpr uint32_t local_cb_id = 0;
     experimental::CircularBuffer local_cb{local_cb_id};
@@ -55,7 +55,7 @@ void kernel_main() {
         uint32_t curr_receiver_block_num_tiles = curr_block_num_tiles / num_receivers;
 
         uint32_t curr_block_size = curr_receiver_block_num_tiles * curr_page_size;
-        remote_cb.set_sender_page_size(curr_block_size);
+        remote_cb.set_sender_page_size(curr_block_size, noc_if);
 
         for (uint32_t block = 0; block < curr_num_blocks; ++block) {
             local_cb.wait_front(curr_block_num_tiles);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/common/kernels/writer_l1.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/common/kernels/writer_l1.cpp
@@ -61,7 +61,7 @@ void kernel_main() {
             local_cb.wait_front(curr_block_num_tiles);
 
             remote_cb.reserve_back(1);
-            remote_cb.push_back(local_cb, 1, curr_num_tile_rows, curr_coalesced_num_pages, curr_coalesced_page_size);
+            remote_cb.push_back(local_cb, 1, curr_num_tile_rows, curr_coalesced_num_pages, curr_coalesced_page_size, noc_if);
 
             local_cb.pop_front(curr_block_num_tiles);
         }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/common/kernels/writer_l1.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/common/kernels/writer_l1.cpp
@@ -55,7 +55,7 @@ void kernel_main() {
         uint32_t curr_receiver_block_num_tiles = curr_block_num_tiles / num_receivers;
 
         uint32_t curr_block_size = curr_receiver_block_num_tiles * curr_page_size;
-        remote_cb.set_sender_page_size(curr_block_size, noc_if);
+        remote_cb.set_receiver_page_size(curr_block_size, noc_if);
 
         for (uint32_t block = 0; block < curr_num_blocks; ++block) {
             local_cb.wait_front(curr_block_num_tiles);

--- a/tt_metal/hw/inc/remote_circular_buffer_api.h
+++ b/tt_metal/hw/inc/remote_circular_buffer_api.h
@@ -463,7 +463,7 @@ public:
         uint32_t num_rows,
         uint32_t coalesced_num_pages_per_row,
         uint32_t coalesced_page_size,
-        experimental::Noc noc = experimental::Noc()) {
+        experimental::Noc& noc) {
         remote_cb_push_back_and_write_pages<update_remote_pointer == RemotePointerUpdate::UPDATE_OVER_NOC>(
             remote_cb_index_,
             src_local_cb.get_read_ptr(),
@@ -492,7 +492,7 @@ public:
     template <RemotePointerUpdate update_remote_pointer = RemotePointerUpdate::UPDATE_OVER_NOC>
     void set_receiver_page_size(
         uint32_t page_size,
-        experimental::Noc noc = experimental::Noc(),
+        experimental::Noc& noc,
         uint8_t noc_mode = detail::default_noc_mode,
         bool posted = true,
         uint8_t cmd_buf = detail::default_cmd_buf) {
@@ -519,7 +519,7 @@ public:
      * @param num_pages The number of pages to pop
      * @param noc The NoC to use for the remote pointer update
      */
-    void pop_front(uint32_t num_pages, experimental::Noc noc = experimental::Noc()) {
+    void pop_front(uint32_t num_pages, experimental::Noc& noc) {
         remote_cb_pop_front(remote_cb_index_, num_pages, noc.get_noc_id());
     }
 
@@ -541,7 +541,7 @@ public:
     template <RemotePointerUpdate update_remote_pointer = RemotePointerUpdate::UPDATE_OVER_NOC>
     void set_sender_page_size(
         uint32_t page_size,
-        experimental::Noc noc = experimental::Noc(),
+        experimental::Noc& noc,
         uint8_t noc_mode = detail::default_noc_mode,
         bool posted = true,
         uint8_t cmd_buf = detail::default_cmd_buf) {
@@ -569,7 +569,6 @@ public:
 
 private:
     uint32_t remote_cb_index_;
-    experimental::Noc noc_;
 };
 
 #endif

--- a/tt_metal/hw/inc/remote_circular_buffer_api.h
+++ b/tt_metal/hw/inc/remote_circular_buffer_api.h
@@ -449,21 +449,21 @@ public:
      *
      * @tparam update_remote_pointer The type of remote pointer update
      *
+     * @param noc The NoC to use for the remote pointer update
      * @param src The source to push from. Must be local.
      * @param num_pages The number of pages to push
      * @param num_rows The number of rows to push
      * @param coalesced_num_pages_per_row The number of coalesced pages per row
      * @param coalesced_page_size The size of the coalesced page
-     * @param noc The NoC to use for the remote pointer update
      */
     template <typename Src, RemotePointerUpdate update_remote_pointer = RemotePointerUpdate::UPDATE_OVER_NOC>
     void push_back(
+        experimental::Noc& noc,
         const Src& src,
         uint32_t num_pages,
         uint32_t num_rows,
         uint32_t coalesced_num_pages_per_row,
         uint32_t coalesced_page_size,
-        experimental::Noc& noc,
         const typename experimental::noc_traits_t<Src>::src_args_type& src_args =
             typename experimental::noc_traits_t<Src>::src_args_type{}) {
         auto src_addr = experimental::noc_traits_t<Src>::template src_addr<experimental::Noc::AddressType::LOCAL_L1>(
@@ -487,16 +487,16 @@ public:
      *
      * @tparam update_remote_pointer The type of remote pointer update
      *
-     * @param page_size The new page size
      * @param noc The NoC to use for the remote pointer update
+     * @param page_size The new page size
      * @param noc_mode The NoC mode to use for the remote pointer update
      * @param posted Whether to use posted semaphore inc
      * @param cmd_buf The command buffer to use for the remote pointer update
      */
     template <RemotePointerUpdate update_remote_pointer = RemotePointerUpdate::UPDATE_OVER_NOC>
     void set_sender_page_size(
-        uint32_t page_size,
         experimental::Noc& noc,
+        uint32_t page_size,
         uint8_t noc_mode = detail::default_noc_mode,
         bool posted = true,
         uint8_t cmd_buf = detail::default_cmd_buf) {
@@ -520,10 +520,10 @@ public:
      *
      * This is intended to be called by the receiver core.
      *
-     * @param num_pages The number of pages to pop
      * @param noc The NoC to use for the remote pointer update
+     * @param num_pages The number of pages to pop
      */
-    void pop_front(uint32_t num_pages, experimental::Noc& noc) {
+    void pop_front(experimental::Noc& noc, uint32_t num_pages) {
         remote_cb_pop_front(remote_cb_index_, num_pages, noc.get_noc_id());
     }
 
@@ -536,21 +536,26 @@ public:
      *
      * @tparam update_remote_pointer The type of remote pointer update
      *
-     * @param page_size The new page size
      * @param noc The NoC to use for the remote pointer update
+     * @param page_size The new page size
      * @param noc_mode The NoC mode to use for the remote pointer update
      * @param posted Whether to use posted semaphore inc
      * @param cmd_buf The command buffer to use for the remote pointer update
      */
     template <RemotePointerUpdate update_remote_pointer = RemotePointerUpdate::UPDATE_OVER_NOC>
     void set_receiver_page_size(
-        uint32_t page_size,
         experimental::Noc& noc,
+        uint32_t page_size,
         uint8_t noc_mode = detail::default_noc_mode,
-        bool posted = true,
+        Noc::ResponseMode response_mode = Noc::ResponseMode::POSTED,
         uint8_t cmd_buf = detail::default_cmd_buf) {
         resize_remote_sender_cb_interface<update_remote_pointer == RemotePointerUpdate::UPDATE_OVER_NOC>(
-            remote_cb_index_, page_size, noc.get_noc_id(), noc_mode, posted, cmd_buf);
+            remote_cb_index_,
+            page_size,
+            noc.get_noc_id(),
+            noc_mode,
+            response_mode == Noc::ResponseMode::POSTED,
+            cmd_buf);
     }
 
     /** @brief Waits for all pages to be consumed by the receiver core

--- a/tt_metal/hw/inc/remote_circular_buffer_api.h
+++ b/tt_metal/hw/inc/remote_circular_buffer_api.h
@@ -447,7 +447,6 @@ public:
      * This is intended to be called by the sender core.
      *
      * @param num_pages The number of pages to reserve
-     * @param noc The NoC to use for the remote circular buffer
      */
     void reserve_back(uint32_t num_pages) { remote_cb_reserve_back(remote_cb_index_, num_pages); }
 
@@ -462,8 +461,7 @@ public:
      * @param num_rows The number of rows to push
      * @param coalesced_num_pages_per_row The number of coalesced pages per row
      * @param coalesced_page_size The size of the coalesced page
-     * @param noc The NoC to use for the remote circular buffer
-     * @param update_remote_pointer The type of remote pointer update
+     * @tparam update_remote_pointer The type of remote pointer update
      */
     template <RemotePointerUpdate update_remote_pointer = RemotePointerUpdate::UPDATE_OVER_NOC>
     void push_back(
@@ -490,7 +488,7 @@ public:
      * This is intended to be called by the sender core.
      *
      * @param page_size The new page size
-     * @param update_remote_pointer The type of remote pointer update
+     * @tparam update_remote_pointer The type of remote pointer update
      */
     template <RemotePointerUpdate update_remote_pointer = RemotePointerUpdate::UPDATE_OVER_NOC>
     void set_receiver_page_size(uint32_t page_size) {
@@ -526,7 +524,7 @@ public:
      * This is intended to be called by the receiver core.
      *
      * @param page_size The new page size
-     * @param update_remote_pointer The type of remote pointer update
+     * @tparam update_remote_pointer The type of remote pointer update
      */
     template <RemotePointerUpdate update_remote_pointer = RemotePointerUpdate::UPDATE_OVER_NOC>
     void set_sender_page_size(uint32_t page_size) {
@@ -543,7 +541,7 @@ public:
      *
      * The read/write pointers of the remote circular buffers are stored in L1, so that subsequent programs can resume
      * where the previous pointers were. During execution, this pointer is cached in a struct for optimal perf to avoid
-     * repeated L1 reads/writes. This requires the user to call this program at the end of their kernel execution in
+     * repeated L1 reads/writes. This requires the user to call this function at the end of their kernel execution in
      * order to write the final value back to L1. This should only be called by one RISC per core which has the final
      * updated value.
      *

--- a/tt_metal/hw/inc/remote_circular_buffer_api.h
+++ b/tt_metal/hw/inc/remote_circular_buffer_api.h
@@ -474,10 +474,10 @@ public:
             noc.get_noc_id());
     }
 
-    /** @brief Resizes the remote receiver's circular buffer page size
+    /** @brief Resizes the sender's circular buffer page size
      *
-     * Resizes the remote circular buffer's page size. This may result in noc transactions for synchronizing with the
-     * receiver core.
+     * Resizes the sender circular buffer's page size. This may result in noc transactions for synchronizing with the
+     * remote receiver core.
      *
      * This is intended to be called by the sender core.
      *
@@ -490,7 +490,7 @@ public:
      * @param cmd_buf The command buffer to use for the remote pointer update
      */
     template <RemotePointerUpdate update_remote_pointer = RemotePointerUpdate::UPDATE_OVER_NOC>
-    void set_receiver_page_size(
+    void set_sender_page_size(
         uint32_t page_size,
         experimental::Noc& noc,
         uint8_t noc_mode = detail::default_noc_mode,
@@ -523,10 +523,10 @@ public:
         remote_cb_pop_front(remote_cb_index_, num_pages, noc.get_noc_id());
     }
 
-    /** @brief Resizes the remote sender's circular buffer page size
+    /** @brief Resizes the receiver's circular buffer page size
      *
-     * Resizes the remote circular buffer's page size. This may result in noc transactions for synchronizing with the
-     * sender core.
+     * Resizes the receiver's circular buffer page size. This may result in noc transactions for synchronizing with the
+     * remote sender core.
      *
      * This is intended to be called by the receiver core.
      *
@@ -539,7 +539,7 @@ public:
      * @param cmd_buf The command buffer to use for the remote pointer update
      */
     template <RemotePointerUpdate update_remote_pointer = RemotePointerUpdate::UPDATE_OVER_NOC>
-    void set_sender_page_size(
+    void set_receiver_page_size(
         uint32_t page_size,
         experimental::Noc& noc,
         uint8_t noc_mode = detail::default_noc_mode,


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/29592

### Problem description
- New device side APIs

### What's changed
- Implement RemoteCircularBuffer class and update the basic test to use this experimental API

### Checklist
All Post Commit
https://github.com/tenstorrent/tt-metal/actions/runs/19482886974
Blackhole Post Commit
https://github.com/tenstorrent/tt-metal/actions/runs/19482864701
Galaxy Unit Tests
https://github.com/tenstorrent/tt-metal/actions/runs/19482874553
Nightly Metal L2
https://github.com/tenstorrent/tt-metal/actions/runs/19484923126
Tested Locally
```
./build/test/tt_metal/perf_microbenchmark/10_dram_read_remote_cb_sync/test_dram_read_remote_cb   --k 1024   --n 256   --num-blocks 16   --cb-num-blocks 5   --num-receivers 1   --data-type 1
```