### PR TITLE
#32524 Add sub core grids support to binary ops

### DIFF
--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
@@ -338,7 +338,7 @@ inline auto invoke_binary_ng(
     tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
     const std::optional<bool>& use_legacy,
     const std::optional<bool>& fast_and_approximate_mode,
-    const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt) {
+    const std::optional<CoreRangeSet>& sub_core_grids) {
     if (use_legacy ? *use_legacy
                    : binary::is_legacy_only(lhs, rhs, memory_config, output, lhs_activations, rhs_activations) and
                          (not detail::is_binary_ng_only(lhs, rhs, binary_op_type))) {
@@ -740,7 +740,8 @@ Tensor BinaryOperationSfpu<binary_op_type>::invoke(
         lhs_activations,
         rhs_activations,
         use_legacy,
-        /*fast_and_approximate_mode*/ false);
+        /*fast_and_approximate_mode*/ false,
+        /*sub_core_grids*/ std::nullopt);
 }
 
 template <BinaryOpType binary_op_type>
@@ -780,11 +781,12 @@ Tensor BinaryOperationHypot<binary_op_type>::invoke(
         std::nullopt,
         memory_config,
         optional_output_tensor,
-        {},      // no post_activations
-        {},      // no lhs_activations
-        {},      // no rhs_activations
-        false,   // legacy_flag
-        false);  // fast_and_approximate_mode
+        {},             // no post_activations
+        {},             // no lhs_activations
+        {},             // no rhs_activations
+        false,          // legacy_flag
+        false,          // fast_and_approximate_mode
+        std::nullopt);  // sub_core_grids
 }
 
 template <BinaryOpType binary_op_type>

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
@@ -337,7 +337,8 @@ inline auto invoke_binary_ng(
     tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
     tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
     const std::optional<bool>& use_legacy,
-    const std::optional<bool>& fast_and_approximate_mode) {
+    const std::optional<bool>& fast_and_approximate_mode,
+    const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt) {
     if (use_legacy ? *use_legacy
                    : binary::is_legacy_only(lhs, rhs, memory_config, output, lhs_activations, rhs_activations) and
                          (not detail::is_binary_ng_only(lhs, rhs, binary_op_type))) {
@@ -395,7 +396,8 @@ inline auto invoke_binary_ng(
             lhs_activations,
             rhs_activations,
             post_activations,
-            std::nullopt);
+            std::nullopt,
+            sub_core_grids);
 
         // if both inputs are in row major, convert the output to row major
         // since there's no consensus here, avoiding the conversion if we have an excuse to is likely the best option
@@ -422,8 +424,8 @@ inline auto invoke_binary_ng(
             lhs_activations,
             rhs_activations,
             post_activations,
-            std::nullopt);
-
+            std::nullopt,
+            sub_core_grids);
         return typecast_out ? ttnn::typecast(result, out_dtype, mem_config, output) : result;
     }
 }
@@ -440,7 +442,8 @@ Tensor BinaryOperation<binary_op_type>::invoke(
     tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
     tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
     tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
-    const std::optional<bool>& use_legacy) {
+    const std::optional<bool>& use_legacy,
+    const std::optional<CoreRangeSet>& sub_core_grids) {
     return detail::invoke_binary_ng(
         lhs,
         rhs,
@@ -452,7 +455,8 @@ Tensor BinaryOperation<binary_op_type>::invoke(
         lhs_activations,
         rhs_activations,
         use_legacy,
-        /*fast_and_approximate_mode*/ false);
+        /*fast_and_approximate_mode*/ false,
+        sub_core_grids);
 }
 
 template <BinaryOpType binary_op_type>
@@ -465,7 +469,8 @@ Tensor BinaryOperation<binary_op_type>::invoke(
     tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
     tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
     tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
-    const std::optional<bool>& use_legacy) {
+    const std::optional<bool>& use_legacy,
+    const std::optional<CoreRangeSet>& sub_core_grids) {
     return detail::invoke_binary_ng(
         lhs,
         rhs,
@@ -477,7 +482,8 @@ Tensor BinaryOperation<binary_op_type>::invoke(
         lhs_activations,
         rhs_activations,
         use_legacy,
-        /*fast_and_approximate_mode*/ false);
+        /*fast_and_approximate_mode*/ false,
+        sub_core_grids);
 }
 
 template <BinaryOpType binary_op_type>
@@ -491,7 +497,8 @@ Tensor BinaryOperationWithFastApprox<binary_op_type>::invoke(
     tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
     tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
     const std::optional<bool>& use_legacy,
-    const std::optional<bool>& fast_and_approximate_mode) {
+    const std::optional<bool>& fast_and_approximate_mode,
+    const std::optional<CoreRangeSet>& sub_core_grids) {
     return detail::invoke_binary_ng(
         lhs,
         rhs,
@@ -503,7 +510,8 @@ Tensor BinaryOperationWithFastApprox<binary_op_type>::invoke(
         lhs_activations,
         rhs_activations,
         use_legacy,
-        fast_and_approximate_mode);
+        fast_and_approximate_mode,
+        sub_core_grids);
 }
 
 template <BinaryOpType binary_op_type>
@@ -517,7 +525,8 @@ Tensor BinaryOperationWithFastApprox<binary_op_type>::invoke(
     tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
     tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
     const std::optional<bool>& use_legacy,
-    const std::optional<bool>& fast_and_approximate_mode) {
+    const std::optional<bool>& fast_and_approximate_mode,
+    const std::optional<CoreRangeSet>& sub_core_grids) {
     return detail::invoke_binary_ng(
         lhs,
         rhs,
@@ -529,7 +538,8 @@ Tensor BinaryOperationWithFastApprox<binary_op_type>::invoke(
         lhs_activations,
         rhs_activations,
         use_legacy,
-        fast_and_approximate_mode);
+        fast_and_approximate_mode,
+        sub_core_grids);
 }
 
 template <BinaryOpType binary_op_type>
@@ -542,7 +552,8 @@ Tensor RelationalBinary<binary_op_type>::invoke(
     tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
     tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
     tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
-    const std::optional<bool>& use_legacy) {
+    const std::optional<bool>& use_legacy,
+    const std::optional<CoreRangeSet>& sub_core_grids) {
     return detail::invoke_binary_ng(
         lhs,
         rhs,
@@ -554,7 +565,8 @@ Tensor RelationalBinary<binary_op_type>::invoke(
         lhs_activations,
         rhs_activations,
         use_legacy,
-        /*fast_and_approximate_mode*/ false);
+        /*fast_and_approximate_mode*/ false,
+        sub_core_grids);
 }
 
 template <BinaryOpType binary_op_type>
@@ -567,7 +579,8 @@ Tensor RelationalBinary<binary_op_type>::invoke(
     tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
     tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
     tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
-    const std::optional<bool>& use_legacy) {
+    const std::optional<bool>& use_legacy,
+    const std::optional<CoreRangeSet>& sub_core_grids) {
     if (use_legacy ? *use_legacy
                    : binary::is_legacy_only(lhs, rhs, memory_config, output, lhs_activations, rhs_activations) and
                          (not detail::is_binary_ng_only(lhs, rhs, binary_op_type))) {
@@ -587,7 +600,8 @@ Tensor RelationalBinary<binary_op_type>::invoke(
         lhs_activations,
         rhs_activations,
         use_legacy,
-        /*fast_and_approximate_mode*/ false);
+        /*fast_and_approximate_mode*/ false,
+        sub_core_grids);
 }
 // scalar - tensor combination not available on Pytorch for this op
 template <BinaryOpType binary_op_type>

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary.hpp
@@ -31,7 +31,8 @@ struct BinaryOperation {
         tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations = {},
         tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
         tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations = {},
-        const std::optional<bool>& use_legacy = std::nullopt);
+        const std::optional<bool>& use_legacy = std::nullopt,
+        const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
 
     static Tensor invoke(
         const ttnn::Tensor& lhs,
@@ -42,7 +43,8 @@ struct BinaryOperation {
         tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations = {},
         tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
         tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations = {},
-        const std::optional<bool>& use_legacy = std::nullopt);
+        const std::optional<bool>& use_legacy = std::nullopt,
+        const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
 };
 
 template <BinaryOpType binary_op_type>
@@ -57,7 +59,8 @@ struct BinaryOperationWithFastApprox {
         tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
         tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations = {},
         const std::optional<bool>& use_legacy = std::nullopt,
-        const std::optional<bool>& fast_and_approximate_mode = std::nullopt);
+        const std::optional<bool>& fast_and_approximate_mode = std::nullopt,
+        const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
 
     static Tensor invoke(
         const ttnn::Tensor& lhs,
@@ -69,7 +72,8 @@ struct BinaryOperationWithFastApprox {
         tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
         tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations = {},
         const std::optional<bool>& use_legacy = std::nullopt,
-        const std::optional<bool>& fast_and_approximate_mode = std::nullopt);
+        const std::optional<bool>& fast_and_approximate_mode = std::nullopt,
+        const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
 };
 
 template <BinaryOpType binary_op_type>
@@ -83,7 +87,8 @@ struct RelationalBinary {
         tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations = {},
         tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
         tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations = {},
-        const std::optional<bool>& use_legacy = std::nullopt);
+        const std::optional<bool>& use_legacy = std::nullopt,
+        const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
 
     static Tensor invoke(
         const ttnn::Tensor& lhs,
@@ -94,7 +99,8 @@ struct RelationalBinary {
         tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations = {},
         tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
         tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations = {},
-        const std::optional<bool>& use_legacy = std::nullopt);
+        const std::optional<bool>& use_legacy = std::nullopt,
+        const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
 
     // rhs - tensor combination not available on Pytorch for this op
     static Tensor invoke(

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_composite.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_composite.hpp
@@ -112,7 +112,8 @@ struct ExecuteDiv {
         tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations = {},
         tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
         tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations = {},
-        const std::optional<bool>& use_legacy = std::nullopt);
+        const std::optional<bool>& use_legacy = std::nullopt,
+        const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
 
     static Tensor invoke(
         const Tensor& lhs,
@@ -125,7 +126,8 @@ struct ExecuteDiv {
         tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations = {},
         tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
         tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations = {},
-        const std::optional<bool>& use_legacy = std::nullopt);
+        const std::optional<bool>& use_legacy = std::nullopt,
+        const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
 };
 
 template <BinaryOpType binary_op_type>

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_composite.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_composite.hpp
@@ -139,7 +139,8 @@ struct ExecuteBiasGelu {
         tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations = {},
         tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations = {},
         tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations = {},
-        std::optional<bool> use_legacy = std::nullopt) {
+        std::optional<bool> use_legacy = std::nullopt,
+        const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt) {
         return BinaryOperation<binary_op_type>::invoke(
             input_tensor_a_arg,
             input_tensor_b_arg,
@@ -149,7 +150,8 @@ struct ExecuteBiasGelu {
             post_activations,
             lhs_activations,
             rhs_activations,
-            use_legacy);
+            use_legacy,
+            sub_core_grids);
     }
 
     static Tensor invoke(
@@ -161,7 +163,8 @@ struct ExecuteBiasGelu {
         tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations = {},
         tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations = {},
         tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations = {},
-        std::optional<bool> use_legacy = std::nullopt) {
+        std::optional<bool> use_legacy = std::nullopt,
+        const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt) {
         return ttnn::gelu(
             ttnn::add(input_tensor_a, bias, std::nullopt, memory_config, optional_output_tensor),
             true,
@@ -177,7 +180,8 @@ struct ExecuteBiasGelu {
         const std::optional<Tensor>& output = std::nullopt,
         tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations = {},
         tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations = {},
-        tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations = {}) {
+        tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations = {},
+        const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt) {
         return BinaryOperation<binary_op_type>::invoke(
             input_tensor_a,
             input_tensor_b,
@@ -186,7 +190,8 @@ struct ExecuteBiasGelu {
             output,
             lhs_activations,
             rhs_activations,
-            post_activations);
+            post_activations,
+            sub_core_grids);
     }
 
     static Tensor invoke(

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_pybind.cpp
@@ -1257,7 +1257,8 @@ void bind_div(
                const ttnn::SmallVector<unary::EltwiseUnaryWithParam>& activations,
                const ttnn::SmallVector<unary::EltwiseUnaryWithParam>& input_tensor_a_activations,
                const ttnn::SmallVector<unary::EltwiseUnaryWithParam>& input_tensor_b_activations,
-               const std::optional<bool>& use_legacy) -> ttnn::Tensor {
+               const std::optional<bool>& use_legacy,
+               const std::optional<CoreRangeSet>& sub_core_grids) -> ttnn::Tensor {
                 return self(
                     input_tensor_a,
                     input_tensor_b,
@@ -1269,7 +1270,8 @@ void bind_div(
                     activations,
                     input_tensor_a_activations,
                     input_tensor_b_activations,
-                    use_legacy);
+                    use_legacy,
+                    sub_core_grids);
             },
             py::arg("input_tensor_a"),
             py::arg("input_tensor_b"),
@@ -1283,6 +1285,7 @@ void bind_div(
             py::arg("input_tensor_a_activations") = ttnn::SmallVector<unary::EltwiseUnaryWithParam>(),
             py::arg("input_tensor_b_activations") = ttnn::SmallVector<unary::EltwiseUnaryWithParam>(),
             py::arg("use_legacy") = std::nullopt,
+            py::arg("sub_core_grids") = std::nullopt,
         },
 
         ttnn::pybind_overload_t{
@@ -1297,7 +1300,8 @@ void bind_div(
                const ttnn::SmallVector<unary::EltwiseUnaryWithParam>& activations,
                const ttnn::SmallVector<unary::EltwiseUnaryWithParam>& input_tensor_a_activations,
                const ttnn::SmallVector<unary::EltwiseUnaryWithParam>& input_tensor_b_activations,
-               const std::optional<bool>& use_legacy) -> ttnn::Tensor {
+               const std::optional<bool>& use_legacy,
+               const std::optional<CoreRangeSet>& sub_core_grids) -> ttnn::Tensor {
                 return self(
                     input_tensor_a,
                     value,
@@ -1309,7 +1313,8 @@ void bind_div(
                     activations,
                     input_tensor_a_activations,
                     input_tensor_b_activations,
-                    use_legacy);
+                    use_legacy,
+                    sub_core_grids);
             },
             py::arg("input_tensor_a"),
             py::arg("value"),
@@ -1323,6 +1328,7 @@ void bind_div(
             py::arg("input_tensor_a_activations") = ttnn::SmallVector<unary::EltwiseUnaryWithParam>(),
             py::arg("input_tensor_b_activations") = ttnn::SmallVector<unary::EltwiseUnaryWithParam>(),
             py::arg("use_legacy") = std::nullopt,
+            py::arg("sub_core_grids") = std::nullopt,
         });
 }
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_pybind.cpp
@@ -165,7 +165,8 @@ void bind_binary_operation(
                const ttnn::SmallVector<unary::EltwiseUnaryWithParam>& activations,
                const ttnn::SmallVector<unary::EltwiseUnaryWithParam>& input_tensor_a_activations,
                const ttnn::SmallVector<unary::EltwiseUnaryWithParam>& input_tensor_b_activations,
-               const std::optional<bool>& use_legacy) -> ttnn::Tensor {
+               const std::optional<bool>& use_legacy,
+               const std::optional<CoreRangeSet>& sub_core_grids) -> ttnn::Tensor {
                 return self(
                     input_tensor_a,
                     scalar,
@@ -175,7 +176,8 @@ void bind_binary_operation(
                     activations,
                     input_tensor_a_activations,
                     input_tensor_b_activations,
-                    use_legacy);
+                    use_legacy,
+                    sub_core_grids);
             },
             py::arg("input_tensor_a"),
             py::arg("input_tensor_b"),
@@ -186,7 +188,8 @@ void bind_binary_operation(
             py::arg("activations") = ttnn::SmallVector<unary::EltwiseUnaryWithParam>(),
             py::arg("input_tensor_a_activations") = ttnn::SmallVector<unary::EltwiseUnaryWithParam>(),
             py::arg("input_tensor_b_activations") = ttnn::SmallVector<unary::EltwiseUnaryWithParam>(),
-            py::arg("use_legacy") = std::nullopt},
+            py::arg("use_legacy") = std::nullopt,
+            py::arg("sub_core_grids") = std::nullopt},
 
         // tensor and tensor
         ttnn::pybind_overload_t{
@@ -199,7 +202,8 @@ void bind_binary_operation(
                const ttnn::SmallVector<unary::EltwiseUnaryWithParam>& activations,
                const ttnn::SmallVector<unary::EltwiseUnaryWithParam>& input_tensor_a_activations,
                const ttnn::SmallVector<unary::EltwiseUnaryWithParam>& input_tensor_b_activations,
-               const std::optional<bool>& use_legacy) -> ttnn::Tensor {
+               const std::optional<bool>& use_legacy,
+               const std::optional<CoreRangeSet>& sub_core_grids) -> ttnn::Tensor {
                 return self(
                     input_tensor_a,
                     input_tensor_b,
@@ -209,7 +213,8 @@ void bind_binary_operation(
                     activations,
                     input_tensor_a_activations,
                     input_tensor_b_activations,
-                    use_legacy);
+                    use_legacy,
+                    sub_core_grids);
             },
             py::arg("input_tensor_a"),
             py::arg("input_tensor_b"),
@@ -221,6 +226,7 @@ void bind_binary_operation(
             py::arg("input_tensor_a_activations") = ttnn::SmallVector<unary::EltwiseUnaryWithParam>(),
             py::arg("input_tensor_b_activations") = ttnn::SmallVector<unary::EltwiseUnaryWithParam>(),
             py::arg("use_legacy") = std::nullopt,
+            py::arg("sub_core_grids") = std::nullopt,
         });
 }
 
@@ -1387,7 +1393,8 @@ void bind_binary_operation_with_fast_approx(
                const ttnn::SmallVector<unary::EltwiseUnaryWithParam>& activations,
                const ttnn::SmallVector<unary::EltwiseUnaryWithParam>& input_tensor_a_activations,
                const ttnn::SmallVector<unary::EltwiseUnaryWithParam>& input_tensor_b_activations,
-               const std::optional<bool>& use_legacy) -> ttnn::Tensor {
+               const std::optional<bool>& use_legacy,
+               const std::optional<CoreRangeSet>& sub_core_grids) -> ttnn::Tensor {
                 return self(
                     input_tensor_a,
                     input_tensor_b,
@@ -1398,7 +1405,8 @@ void bind_binary_operation_with_fast_approx(
                     input_tensor_a_activations,
                     input_tensor_b_activations,
                     use_legacy,
-                    fast_and_approximate_mode);
+                    fast_and_approximate_mode,
+                    sub_core_grids);
             },
             py::arg("input_tensor_a"),
             py::arg("input_tensor_b"),
@@ -1410,7 +1418,8 @@ void bind_binary_operation_with_fast_approx(
             py::arg("activations") = ttnn::SmallVector<unary::EltwiseUnaryWithParam>(),
             py::arg("input_tensor_a_activations") = ttnn::SmallVector<unary::EltwiseUnaryWithParam>(),
             py::arg("input_tensor_b_activations") = ttnn::SmallVector<unary::EltwiseUnaryWithParam>(),
-            py::arg("use_legacy") = std::nullopt},
+            py::arg("use_legacy") = std::nullopt,
+            py::arg("sub_core_grids") = std::nullopt},
 
         ttnn::pybind_overload_t{
             [](const binary_operation_t& self,
@@ -1423,7 +1432,8 @@ void bind_binary_operation_with_fast_approx(
                const ttnn::SmallVector<unary::EltwiseUnaryWithParam>& activations,
                const ttnn::SmallVector<unary::EltwiseUnaryWithParam>& input_tensor_a_activations,
                const ttnn::SmallVector<unary::EltwiseUnaryWithParam>& input_tensor_b_activations,
-               const std::optional<bool>& use_legacy) -> ttnn::Tensor {
+               const std::optional<bool>& use_legacy,
+               const std::optional<CoreRangeSet>& sub_core_grids) -> ttnn::Tensor {
                 return self(
                     input_tensor_a,
                     value,
@@ -1434,7 +1444,8 @@ void bind_binary_operation_with_fast_approx(
                     input_tensor_a_activations,
                     input_tensor_b_activations,
                     use_legacy,
-                    fast_and_approximate_mode);
+                    fast_and_approximate_mode,
+                    sub_core_grids);
             },
             py::arg("input_tensor_a"),
             py::arg("value"),
@@ -1446,7 +1457,8 @@ void bind_binary_operation_with_fast_approx(
             py::arg("activations") = ttnn::SmallVector<unary::EltwiseUnaryWithParam>(),
             py::arg("input_tensor_a_activations") = ttnn::SmallVector<unary::EltwiseUnaryWithParam>(),
             py::arg("input_tensor_b_activations") = ttnn::SmallVector<unary::EltwiseUnaryWithParam>(),
-            py::arg("use_legacy") = std::nullopt});
+            py::arg("use_legacy") = std::nullopt,
+            py::arg("sub_core_grids") = std::nullopt});
 }
 
 template <typename binary_operation_t>

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
@@ -198,7 +198,8 @@ Tensor ExecuteDiv::invoke(
     tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
     tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
     tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
-    const std::optional<bool>& use_legacy) {
+    const std::optional<bool>& use_legacy,
+    const std::optional<CoreRangeSet>& sub_core_grids) {
     const auto has_legacy_only_args = round_mode.has_value() or accurate_mode;
     if (not(use_legacy ? *use_legacy
                        : has_legacy_only_args or
@@ -216,7 +217,8 @@ Tensor ExecuteDiv::invoke(
             post_activations,
             lhs_activations,
             rhs_activations,
-            use_legacy);
+            use_legacy,
+            sub_core_grids);
     }
 
     TT_FATAL(
@@ -243,7 +245,8 @@ Tensor ExecuteDiv::invoke(
     tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
     tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
     tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
-    const std::optional<bool>& use_legacy) {
+    const std::optional<bool>& use_legacy,
+    const std::optional<CoreRangeSet>& sub_core_grids) {
     const auto has_legacy_only_args = round_mode.has_value() or output_dtype.has_value() or accurate_mode;
 
     DataType input_dtype = input_a.dtype();
@@ -269,7 +272,8 @@ Tensor ExecuteDiv::invoke(
             post_activations,
             lhs_activations,
             rhs_activations,
-            use_legacy);
+            use_legacy,
+            sub_core_grids);
     }
 
     TT_FATAL(

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
@@ -62,7 +62,15 @@ bool is_quant_op(const BinaryOpType val) {
 }  // namespace utils
 
 CoreRangeSet get_worker_grid(
-    const Tensor& input_tensor_a, const Tensor* input_tensor_b, const std::optional<Tensor>& output_tensor) {
+    const Tensor& input_tensor_a,
+    const Tensor* input_tensor_b,
+    const std::optional<Tensor>& output_tensor,
+    const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt) {
+    // If sub_core_grids is provided, use it directly
+    if (sub_core_grids.has_value()) {
+        return sub_core_grids.value();
+    }
+
     auto get_tensor_grid = [](const Tensor& tensor) -> CoreRangeSet {
         const auto& grid = tensor.shard_spec()->grid;
         auto device = tensor.device();
@@ -130,6 +138,7 @@ tt::stl::hash::hash_t BinaryNgDeviceOperation::operation_attributes_t::to_hash()
         memory_config,
         get_dtype(),
         compute_kernel_config,
+        sub_core_grids,
         subtile_broadcast_type,
         is_sfpu,
         is_quant_op,
@@ -426,7 +435,8 @@ BinaryNgDeviceOperation::invoke(
     tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
     tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
     tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
-    std::optional<unary::ScalarVariant> scalar_value) {
+    std::optional<unary::ScalarVariant> scalar_value,
+    const std::optional<CoreRangeSet>& sub_core_grids) {
     // Validate storage type for input tensors
     TT_FATAL(
         input_tensor_a.storage_type() == StorageType::DEVICE,
@@ -464,8 +474,9 @@ BinaryNgDeviceOperation::invoke(
             is_where_op ? dtype_b : dtype_a,  // TODO: For mixed dtypes we need to set this value to the appropriate
                                               // dtype depending on which LLK is meant to be used.
             output_dtype,
-            get_worker_grid(input_tensor_a, &input_tensor_b, output_tensor),
+            get_worker_grid(input_tensor_a, &input_tensor_b, output_tensor, sub_core_grids),
             std::nullopt,
+            sub_core_grids,
             subtile_broadcast_type,
             is_sfpu_op,
             is_quant_op,
@@ -485,7 +496,8 @@ BinaryNgDeviceOperation::invoke(
     tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations,
     tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations,
     tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations,
-    std::optional<unary::ScalarVariant> scalar_value) {
+    std::optional<unary::ScalarVariant> scalar_value,
+    const std::optional<CoreRangeSet>& sub_core_grids) {
     DataType dtype_a = input_tensor_a.dtype();
     bool is_sfpu_op =
         (utils::is_binary_sfpu_op(binary_op_type, dtype_a, dtype_a, fast_and_approximate_mode.value_or(false)));
@@ -501,8 +513,9 @@ BinaryNgDeviceOperation::invoke(
                 output_tensor.has_value() ? output_tensor->memory_config() : input_tensor_a.memory_config()),
             input_tensor_a.dtype(),
             output_dtype,
-            get_worker_grid(input_tensor_a, nullptr, output_tensor),
+            get_worker_grid(input_tensor_a, nullptr, output_tensor, sub_core_grids),
             std::nullopt,
+            sub_core_grids,
             SubtileBroadcastType::NONE,
             is_sfpu_op,
             is_quant_op,

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
@@ -65,7 +65,7 @@ CoreRangeSet get_worker_grid(
     const Tensor& input_tensor_a,
     const Tensor* input_tensor_b,
     const std::optional<Tensor>& output_tensor,
-    const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt) {
+    const std::optional<CoreRangeSet>& sub_core_grids) {
     // If sub_core_grids is provided, use it directly
     if (sub_core_grids.has_value()) {
         return sub_core_grids.value();

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.hpp
@@ -40,6 +40,7 @@ struct BinaryNgDeviceOperation {
         std::optional<DataType> dtype;
         const CoreRangeSet worker_grid;
         std::optional<DeviceComputeKernelConfig> compute_kernel_config;
+        std::optional<CoreRangeSet> sub_core_grids;
         SubtileBroadcastType subtile_broadcast_type = SubtileBroadcastType::NONE;
         bool is_sfpu = false;
         bool is_quant_op = false;
@@ -101,7 +102,8 @@ struct BinaryNgDeviceOperation {
         tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations,
         tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations,
         tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations,
-        std::optional<unary::ScalarVariant> scalar_value);
+        std::optional<unary::ScalarVariant> scalar_value,
+        const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
 
     // tensor-scalar invocation
     static std::tuple<operation_attributes_t, tensor_args_t> invoke(
@@ -115,7 +117,8 @@ struct BinaryNgDeviceOperation {
         tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations,
         tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations,
         tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations,
-        std::optional<unary::ScalarVariant> scalar_value);
+        std::optional<unary::ScalarVariant> scalar_value,
+        const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
 };
 
 }  // namespace ttnn::operations::binary_ng


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/32524)

### Problem description
Feature to add sub_core_grids parameter to binary ops

### What's changed
Add the optional parameter.
Worked for both interleaved and sharded tensors.
Note not all binary ops such composite ops have been supported in this PR. But common one such as add, mul, div, gt etc have been supported.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes