### PR TITLE
Fixing Underflow in BufferCorePageMapping::Iterator::next_range

### DIFF
--- a/tt_metal/impl/buffers/buffer_page_mapping.cpp
+++ b/tt_metal/impl/buffers/buffer_page_mapping.cpp
@@ -169,6 +169,13 @@ BufferCorePageMapping::Iterator::Range BufferCorePageMapping::Iterator::next_ran
         return result;
     }
     const auto& host_range = mapping_->host_ranges[range_index_];
+    if (device_page_offset_ < host_range.device_page_offset) {
+        if (host_range.device_page_offset >= end_device_page_offset) {
+            device_page_offset_ = end_device_page_offset;
+            return result;
+        }
+        device_page_offset_ = host_range.device_page_offset;
+    }
     uint32_t num_pages_left = host_range.num_pages - (device_page_offset_ - host_range.device_page_offset);
     uint32_t num_pages = std::min(num_pages_left, end_device_page_offset - device_page_offset_);
     result = Range{


### PR DESCRIPTION
### Ticket
[#30428
](https://github.com/tenstorrent/tt-metal/issues/30428)
### Problem description
There is an edge case not handled when iterating through the device pages and the number of `PADDING` pages preceding a contiguous range of pages exceeds the value of the page start id (i.e., the page number of the first page in the next contiguous range of pages). The call to `BufferCorePageMapping::Iterator::next_range` has an integer underflow when computing `host_range.host_page_start + device_page_offset_ - host_range.device_page_offset` in the current range. This caused a massive offset in the host page data address computation, leading to the segmentation faults seen in the sweep tests for the above ticket.

### What's changed
Added a condition to check if the current iterator is in a `PADDING` page. If so, check if the next non-padding index `host_range.device_page_offset >= end_device_page_offset`. If so, set the current iterator `device_page_offset_` to `end_device_page_offset` and exit the function to return a 0-range. If not, advance iterator `device_page_offset_` to the start of the next contiguous range of pages `host_range.device_page_offset`.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/19488979854) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/19488991125) CI with demo tests passes (if applicable)
- [x] New/Existing tests provide coverage for changes