### PR TITLE
Update Caching strategy

### DIFF
--- a/models/demos/deepseek_v3/tests/test_lm_head.py
+++ b/models/demos/deepseek_v3/tests/test_lm_head.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
+import os
 from pathlib import Path
 from typing import Any
 
@@ -13,7 +14,7 @@ from loguru import logger
 import ttnn
 from models.demos.deepseek_v3.tt.ccl import CCL
 from models.demos.deepseek_v3.tt.lm_head import LMHead
-from models.demos.deepseek_v3.utils.config_helpers import sub_state_dict
+from models.demos.deepseek_v3.utils.config_helpers import _check_weights_exist_and_convert, sub_state_dict
 from models.demos.deepseek_v3.utils.run_config import create_run_config
 from models.demos.deepseek_v3.utils.test_utils import (
     assert_hidden_dim_pcc,
@@ -71,8 +72,17 @@ def test_forward_pass(
     # Pad input to SEQ_LEN_CHUNK_SIZE if necessary
     torch_input = pad_or_trim_seq_len(torch_input, mode, seq_len)
 
+    weight_cache_path = (
+        cache_path
+        / "tests_cache"
+        / os.environ.get("PYTEST_CURRENT_TEST")
+        / f"{hf_config.num_hidden_layers}_layers"
+        / f"mesh_{mesh_device.shape[0]}x{mesh_device.shape[1]}"
+    )
+
     # Setup: Convert weights and get weight_config
-    weight_config = LMHead.convert_weights(hf_config, (state_dict,), cache_path, mesh_device)
+    weight_config = LMHead.convert_weights(hf_config, (state_dict,), weight_cache_path, mesh_device)
+    _check_weights_exist_and_convert(weight_cache_path, weight_config)
     model_config = get_model_config(LMHead, mode, hf_config, mesh_device, 3)
     model_state = LMHead.create_state(hf_config, mesh_device, ccl)
     run_config = create_run_config(model_config, weight_config, model_state)

--- a/models/demos/deepseek_v3/tests/test_lm_head.py
+++ b/models/demos/deepseek_v3/tests/test_lm_head.py
@@ -73,7 +73,11 @@ def test_forward_pass(
     torch_input = pad_or_trim_seq_len(torch_input, mode, seq_len)
 
     weight_cache_path = (
-        cache_path / "tests_cache" / os.environ.get("PYTEST_CURRENT_TEST") / f"{hf_config.num_hidden_layers}_layers"
+        cache_path
+        / "tests_cache"
+        / os.environ.get("PYTEST_CURRENT_TEST")
+        / f"{hf_config.num_hidden_layers}_layers"
+        / f"mesh_{mesh_device.shape[0]}x{mesh_device.shape[1]}"
     )
 
     # Setup: Convert weights and get weight_config

--- a/models/demos/deepseek_v3/tests/test_lm_head.py
+++ b/models/demos/deepseek_v3/tests/test_lm_head.py
@@ -73,11 +73,7 @@ def test_forward_pass(
     torch_input = pad_or_trim_seq_len(torch_input, mode, seq_len)
 
     weight_cache_path = (
-        cache_path
-        / "tests_cache"
-        / os.environ.get("PYTEST_CURRENT_TEST")
-        / f"{hf_config.num_hidden_layers}_layers"
-        / f"mesh_{mesh_device.shape[0]}x{mesh_device.shape[1]}"
+        cache_path / "tests_cache" / os.environ.get("PYTEST_CURRENT_TEST") / f"{hf_config.num_hidden_layers}_layers"
     )
 
     # Setup: Convert weights and get weight_config

--- a/models/demos/deepseek_v3/tests/test_lm_head1d.py
+++ b/models/demos/deepseek_v3/tests/test_lm_head1d.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
+import os
 from pathlib import Path
 from typing import Any
 
@@ -13,7 +14,7 @@ from loguru import logger
 import ttnn
 from models.demos.deepseek_v3.tt.ccl import CCL
 from models.demos.deepseek_v3.tt.lm_head1d import LMHead1D
-from models.demos.deepseek_v3.utils.config_helpers import sub_state_dict
+from models.demos.deepseek_v3.utils.config_helpers import _check_weights_exist_and_convert, sub_state_dict
 from models.demos.deepseek_v3.utils.run_config import create_run_config
 from models.demos.deepseek_v3.utils.test_utils import assert_hidden_dim_pcc, get_model_config, run_module_forward
 
@@ -62,7 +63,16 @@ def test_forward_pass(
     reference_output = reference_model(torch_input)
 
     # Setup: Convert weights and get weight_config
-    weight_config = LMHead1D.convert_weights(hf_config, (state_dict,), cache_path, mesh_device)
+    weight_cache_path = (
+        cache_path
+        / "tests_cache"
+        / os.environ.get("PYTEST_CURRENT_TEST")
+        / f"{hf_config.num_hidden_layers}_layers"
+        / f"mesh_{mesh_device.shape[0]}x{mesh_device.shape[1]}"
+    )
+
+    weight_config = LMHead1D.convert_weights(hf_config, (state_dict,), weight_cache_path, mesh_device)
+    _check_weights_exist_and_convert(weight_cache_path, weight_config)
     model_config = get_model_config(LMHead1D, mode, mesh_device)
     model_state = LMHead1D.create_state(mesh_device, ccl)
     run_config = create_run_config(model_config, weight_config, model_state)

--- a/models/demos/deepseek_v3/tests/test_lm_head1d.py
+++ b/models/demos/deepseek_v3/tests/test_lm_head1d.py
@@ -64,11 +64,7 @@ def test_forward_pass(
 
     # Setup: Convert weights and get weight_config
     weight_cache_path = (
-        cache_path
-        / "tests_cache"
-        / os.environ.get("PYTEST_CURRENT_TEST")
-        / f"{hf_config.num_hidden_layers}_layers"
-        / f"mesh_{mesh_device.shape[0]}x{mesh_device.shape[1]}"
+        cache_path / "tests_cache" / os.environ.get("PYTEST_CURRENT_TEST") / f"{hf_config.num_hidden_layers}_layers"
     )
 
     weight_config = LMHead1D.convert_weights(hf_config, (state_dict,), weight_cache_path, mesh_device)

--- a/models/demos/deepseek_v3/tests/test_lm_head1d.py
+++ b/models/demos/deepseek_v3/tests/test_lm_head1d.py
@@ -64,7 +64,11 @@ def test_forward_pass(
 
     # Setup: Convert weights and get weight_config
     weight_cache_path = (
-        cache_path / "tests_cache" / os.environ.get("PYTEST_CURRENT_TEST") / f"{hf_config.num_hidden_layers}_layers"
+        cache_path
+        / "tests_cache"
+        / os.environ.get("PYTEST_CURRENT_TEST")
+        / f"{hf_config.num_hidden_layers}_layers"
+        / f"mesh_{mesh_device.shape[0]}x{mesh_device.shape[1]}"
     )
 
     weight_config = LMHead1D.convert_weights(hf_config, (state_dict,), weight_cache_path, mesh_device)

--- a/models/demos/deepseek_v3/tests/test_moe.py
+++ b/models/demos/deepseek_v3/tests/test_moe.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
+import os
+
 import pytest
 import torch
 from loguru import logger
@@ -11,6 +13,7 @@ import ttnn
 # Import from local reference files instead of HuggingFace
 from models.demos.deepseek_v3.reference.modeling_deepseek import DeepseekV3MoE
 from models.demos.deepseek_v3.tt.moe import MoE
+from models.demos.deepseek_v3.utils.config_helpers import _check_weights_exist_and_convert
 from models.demos.deepseek_v3.utils.run_config import create_run_config
 from models.demos.deepseek_v3.utils.test_utils import (
     add_inv_scale_to_state_dict,
@@ -78,8 +81,16 @@ def test_forward_pass(
     with torch.no_grad():
         reference_output = reference_model(torch_input)
 
+    weight_cache_path = (
+        cache_path
+        / "tests_cache"
+        / os.environ.get("PYTEST_CURRENT_TEST")
+        / f"{hf_config.num_hidden_layers}_layers"
+        / f"mesh_{mesh_device.shape[0]}x{mesh_device.shape[1]}"
+    )
     # Setup: Convert weights and get weight_config
-    weight_config = MoE.convert_weights(hf_config, (state_dict,), cache_path, mesh_device)
+    weight_config = MoE.convert_weights(hf_config, (state_dict,), weight_cache_path, mesh_device)
+    _check_weights_exist_and_convert(weight_cache_path, weight_config)
 
     # Generate appropriate config using utility function
     model_config = get_model_config(MoE, mode, hf_config, mesh_device, topk_fallback=topk_fallback)

--- a/models/demos/deepseek_v3/tests/test_moe.py
+++ b/models/demos/deepseek_v3/tests/test_moe.py
@@ -82,11 +82,7 @@ def test_forward_pass(
         reference_output = reference_model(torch_input)
 
     weight_cache_path = (
-        cache_path
-        / "tests_cache"
-        / os.environ.get("PYTEST_CURRENT_TEST")
-        / f"{hf_config.num_hidden_layers}_layers"
-        / f"mesh_{mesh_device.shape[0]}x{mesh_device.shape[1]}"
+        cache_path / "tests_cache" / os.environ.get("PYTEST_CURRENT_TEST") / f"{hf_config.num_hidden_layers}_layers"
     )
     # Setup: Convert weights and get weight_config
     weight_config = MoE.convert_weights(hf_config, (state_dict,), weight_cache_path, mesh_device)

--- a/models/demos/deepseek_v3/tests/test_moe.py
+++ b/models/demos/deepseek_v3/tests/test_moe.py
@@ -82,7 +82,11 @@ def test_forward_pass(
         reference_output = reference_model(torch_input)
 
     weight_cache_path = (
-        cache_path / "tests_cache" / os.environ.get("PYTEST_CURRENT_TEST") / f"{hf_config.num_hidden_layers}_layers"
+        cache_path
+        / "tests_cache"
+        / os.environ.get("PYTEST_CURRENT_TEST")
+        / f"{hf_config.num_hidden_layers}_layers"
+        / f"mesh_{mesh_device.shape[0]}x{mesh_device.shape[1]}"
     )
     # Setup: Convert weights and get weight_config
     weight_config = MoE.convert_weights(hf_config, (state_dict,), weight_cache_path, mesh_device)

--- a/models/demos/deepseek_v3/tests/test_moe_gate.py
+++ b/models/demos/deepseek_v3/tests/test_moe_gate.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
+import os
+
 import pytest
 import torch
 from loguru import logger
@@ -11,6 +13,7 @@ import ttnn
 # Import from local reference files instead of HuggingFace
 from models.demos.deepseek_v3.reference.modeling_deepseek import MoEGate as ReferenceMoEGate
 from models.demos.deepseek_v3.tt.moe_gate import MoEGate
+from models.demos.deepseek_v3.utils.config_helpers import _check_weights_exist_and_convert
 from models.demos.deepseek_v3.utils.run_config import create_run_config
 from models.demos.deepseek_v3.utils.test_utils import get_model_config, run_module_forward
 from tests.ttnn.utils_for_testing import comp_pcc
@@ -48,7 +51,16 @@ def test_forward_pass(
     hf_state_dict = reference_model.state_dict()
 
     # Setup: Convert weights and get weight_config
-    weight_config = MoEGate.convert_weights(hf_config, (hf_state_dict,), cache_path, mesh_device)
+    weight_cache_path = (
+        cache_path
+        / "tests_cache"
+        / os.environ.get("PYTEST_CURRENT_TEST")
+        / f"{hf_config.num_hidden_layers}_layers"
+        / f"mesh_{mesh_device.shape[0]}x{mesh_device.shape[1]}"
+    )
+
+    weight_config = MoEGate.convert_weights(hf_config, (hf_state_dict,), weight_cache_path, mesh_device)
+    _check_weights_exist_and_convert(weight_cache_path, weight_config)
 
     # Generate appropriate config using utility function
     model_config = get_model_config(

--- a/models/demos/deepseek_v3/tests/test_moe_gate.py
+++ b/models/demos/deepseek_v3/tests/test_moe_gate.py
@@ -52,11 +52,7 @@ def test_forward_pass(
 
     # Setup: Convert weights and get weight_config
     weight_cache_path = (
-        cache_path
-        / "tests_cache"
-        / os.environ.get("PYTEST_CURRENT_TEST")
-        / f"{hf_config.num_hidden_layers}_layers"
-        / f"mesh_{mesh_device.shape[0]}x{mesh_device.shape[1]}"
+        cache_path / "tests_cache" / os.environ.get("PYTEST_CURRENT_TEST") / f"{hf_config.num_hidden_layers}_layers"
     )
 
     weight_config = MoEGate.convert_weights(hf_config, (hf_state_dict,), weight_cache_path, mesh_device)

--- a/models/demos/deepseek_v3/tests/test_moe_gate.py
+++ b/models/demos/deepseek_v3/tests/test_moe_gate.py
@@ -52,7 +52,11 @@ def test_forward_pass(
 
     # Setup: Convert weights and get weight_config
     weight_cache_path = (
-        cache_path / "tests_cache" / os.environ.get("PYTEST_CURRENT_TEST") / f"{hf_config.num_hidden_layers}_layers"
+        cache_path
+        / "tests_cache"
+        / os.environ.get("PYTEST_CURRENT_TEST")
+        / f"{hf_config.num_hidden_layers}_layers"
+        / f"mesh_{mesh_device.shape[0]}x{mesh_device.shape[1]}"
     )
 
     weight_config = MoEGate.convert_weights(hf_config, (hf_state_dict,), weight_cache_path, mesh_device)

--- a/models/demos/deepseek_v3/tt/mlp/mlp.py
+++ b/models/demos/deepseek_v3/tt/mlp/mlp.py
@@ -142,6 +142,7 @@ class MLP(AbstractModule):
                 per_device_out_features,
                 mesh_device.dram_grid_size(),
             ),
+            convert_meta=True,
         )
 
     @final

--- a/models/demos/deepseek_v3/tt/mlp/mlp.py
+++ b/models/demos/deepseek_v3/tt/mlp/mlp.py
@@ -142,7 +142,6 @@ class MLP(AbstractModule):
                 per_device_out_features,
                 mesh_device.dram_grid_size(),
             ),
-            convert_meta=True,
         )
 
     @final

--- a/models/demos/deepseek_v3/utils/config_helpers.py
+++ b/models/demos/deepseek_v3/utils/config_helpers.py
@@ -677,7 +677,6 @@ def shard_and_save(
     if path.exists():
         logger.warning(f"Overwriting existing cache file: {path}")
     ttnn.dump_tensor(path, ttnn_tensor)
-    # relative_path = Path(str(path).split("mesh_")[1].split("/", 1)[1])
     path_str = str(path)
     mesh_idx = path_str.find("mesh_")
     if mesh_idx == -1:

--- a/models/demos/deepseek_v3/utils/config_helpers.py
+++ b/models/demos/deepseek_v3/utils/config_helpers.py
@@ -607,8 +607,8 @@ def shard_and_save(
     dtype: ttnn.DataType | None = None,
     layout: ttnn.Layout | None = None,
     memory_config: ttnn.MemoryConfig | None = None,
-    append_mesh_dir: bool = False,
     _torch_impl: bool = False,
+    convert_meta=False,
 ) -> SavedWeight:
     """Shard a tensor and save it to a file."""
     assert all(isinstance(shard_dim, (int, NoneType)) for shard_dim in shard_dims)
@@ -669,9 +669,7 @@ def shard_and_save(
             memory_config=memory_config,
         )
 
-    # Ensure the path has an appropriate extension and optional mesh-specific directory
-    if append_mesh_dir:
-        path = path.parent / f"mesh_{mesh_device.shape[0]}x{mesh_device.shape[1]}" / path.name
+    # Ensure the path has an appropriate extension
     if not path.name.endswith(TENSOR_CACHE_EXTENSION):
         path = path.with_name(f"{path.name}{TENSOR_CACHE_EXTENSION}")
 
@@ -680,6 +678,17 @@ def shard_and_save(
     if path.exists():
         logger.warning(f"Overwriting existing cache file: {path}")
     ttnn.dump_tensor(path, ttnn_tensor)
+
+    if not convert_meta:
+        path_str = str(path)
+        mesh_idx = path_str.find("mesh_")
+        if mesh_idx == -1:
+            raise ValueError(f"Expected 'mesh_' in path: {path}")
+        # Skip past "mesh_<rows>x<cols>/" to get relative path
+        parts = path_str[mesh_idx:].split("/", 1)
+        if len(parts) < 2:
+            raise ValueError(f"Invalid path structure after 'mesh_': {path}")
+        path = Path(parts[1])
 
     return SavedWeight(path, memory_config)
 
@@ -875,11 +884,20 @@ def _check_weights_exist_and_convert(root_path: Path, weight_config: WeightConfi
         if entry is None:
             continue
         if isinstance(entry, SavedWeight):
-            target_path = entry.path if entry.path.is_absolute() else root_path / entry.path
-            if entry.path.suffix != TENSOR_CACHE_EXTENSION or not target_path.exists():
+            if (
+                not (entry.path.is_absolute())
+                and not (root_path / entry.path).exists()
+                or entry.path.suffix != TENSOR_CACHE_EXTENSION
+            ):
                 return False
-            if not entry.path.is_absolute():
-                entry.path = target_path
+            elif (
+                not (entry.path.is_absolute())
+                and (root_path / entry.path).exists()
+                and entry.path.suffix == TENSOR_CACHE_EXTENSION
+            ):
+                entry.path = root_path / entry.path
+            elif entry.path.is_absolute() and (not entry.path.exists() or entry.path.suffix != TENSOR_CACHE_EXTENSION):
+                return False
         elif not _check_weights_exist_and_convert(root_path, entry):
             return False
     return True


### PR DESCRIPTION
### Ticket


### Problem description
Current deepseek weight saving strategy only handles global path when saving

### What's changed
Modify the save strategy to handle relative path and load from relative path.

### Checklist

[![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=hzhou%2F1118)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml)
[![(Galaxy) DeepSeek tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-tests.yaml/badge.svg?branch=hzhou%2F1118)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-tests.yaml)