### PR TITLE
Make create_output_tensors and validate_on_cache_hit optional

### DIFF
--- a/ttnn/api/ttnn/decorators.hpp
+++ b/ttnn/api/ttnn/decorators.hpp
@@ -157,8 +157,7 @@ consteval void assert_operation_in_correct_namespace() {
             static_assert(
                 not tt::stl::reflection::fixed_string_equals(namespace_substring, prim_namespace),
                 "Composite operations must not be in the `ttnn::prim` namespace. You may have forgotten to implement "
-                "one of: validate_on_program_cache_hit, validate_on_program_cache_miss, create_output_tensors, or "
-                "select_program_factory.");
+                "one of: validate_on_program_cache_miss, compute_output_specs, or select_program_factory.");
         }
     }
 }

--- a/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
@@ -66,7 +66,12 @@ struct MeshDeviceOperationAdapter {
     }
 
     static void validate_on_program_cache_hit(const operation_attributes_t& attrs, const tensor_args_t& tensor_args) {
-        DeviceOperation::validate_on_program_cache_hit(attrs, tensor_args);
+        if constexpr (requires { DeviceOperation::validate_on_program_cache_hit(attrs, tensor_args); }) {
+            DeviceOperation::validate_on_program_cache_hit(attrs, tensor_args);
+        } else {
+            // Default implementation: call validate_on_program_cache_miss
+            DeviceOperation::validate_on_program_cache_miss(attrs, tensor_args);
+        }
     }
 
     static void validate_on_program_cache_miss(const operation_attributes_t& attrs, const tensor_args_t& tensor_args) {


### PR DESCRIPTION
### Ticket
None

### Problem description
New Device Operation is very verbose. Some of it is trivial to address

### What's changed
It should be enough to declare compute_output_spec and validate_on_cache_miss by default.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes