### PR TITLE
#26985: Removing skip from test_tosa_gather after research

### DIFF
--- a/.github/workflows/ttsim.yaml
+++ b/.github/workflows/ttsim.yaml
@@ -282,8 +282,7 @@ jobs:
             tests/ttnn/unit_tests/operations/transformers/test_paged_cache_mask.py \
             tests/ttnn/unit_tests/operations/eltwise/test_polyval.py \
             tests/ttnn/unit_tests/operations/transformers/test_prefetcher_TG.py \
-            tests/ttnn/unit_tests/operations/data_movement/test_reallocate.py \
-            tests/ttnn/unit_tests/operations/data_movement/test_tosa_gather.py
+            tests/ttnn/unit_tests/operations/data_movement/test_reallocate.py
   ttsim-cpp-unit-tests:
     if: ${{ inputs.run-metal-cpp-unit-tests }}
     runs-on: tt-ubuntu-2204-small-stable

--- a/tests/ttnn/unit_tests/operations/data_movement/test_tosa_gather.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_tosa_gather.py
@@ -8,7 +8,6 @@ import ttnn
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
 
-@pytest.mark.skip("#26985: ND PCC failure, seems slight but APC must be stable")
 @pytest.mark.parametrize(
     "N, K, C, W",
     [


### PR DESCRIPTION
### Ticket

#26985

### Connected tickets

https://github.com/tenstorrent/tt-metal/issues/27071

### Problem description

`ttnn.tosa_gather` was causing nondeterministic failures in APC runs. Earlier investigation pointed to the non-deterministic behavior of `ttnn.expand`, which is used internally by `ttnn.tosa_gather`. Ticket #27071 was created to track this.

Several months have passed since then, and after a recent discussion with @itarabanTT, it appears that the issue with `ttnn.expand` no longer occurs. `tosa_gather` was also tested across two APC runs without any signs of failure.

This PR removes the skip from the test accordingly.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/19496520986