### PR TITLE
Native Kernels for Row Major Tensors on Eltwise Binary Operations

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast.py
@@ -1694,142 +1694,103 @@ class TestBinaryRowMajor:
         pytest.param((2, 3, 33, 64), id="multi_nc_multi_row"),
         pytest.param((1, 1, 3, 1025), id="wide_over_1024"),
         pytest.param((1, 1, 1025, 32), id="tall_over_1024"),
-        pytest.param((1, 1, 1, 4096), id="extreme_row_width"),
         pytest.param((1, 1, 1, 1), id="tiny"),
+        pytest.param((1, 1, 1, 1024), id="width_eq_stride"),
+        pytest.param((1, 1, 1, 1025), id="width_gt_stride_remainder"),
+        pytest.param((1, 1, 1, 2048), id="two_full_chunks"),
+        pytest.param((1, 1, 1, 2049), id="two_full_chunks_remainder"),
+        pytest.param((1, 1, 1, 4096), id="extreme_row_width"),
         pytest.param((1, 1, 2, 1, 1, 3, 1025), id="rank7_weird_wide"),
+    ]
+
+    DTYPE_CASES = [
+        pytest.param(torch.bfloat16, ttnn.bfloat16, id="bfloat16"),
+        pytest.param(torch.float32, ttnn.float32, id="float32"),
+        pytest.param(torch.int32, ttnn.int32, id="int32"),
+        pytest.param(torch.uint32, ttnn.uint32, id="uint32"),
     ]
 
     BROADCAST_CASES = [
         pytest.param("native", "b", id="native"),
-        pytest.param("scalar", "b", id="scalar"),
-        pytest.param("row", "b", id="row_b"),
+        pytest.param("scalar", "b", id="scalar_b"),
         pytest.param("row", "a", id="row_a"),
-        pytest.param("col", "b", id="col_b"),
+        pytest.param("row", "b", id="row_b"),
         pytest.param("col", "a", id="col_a"),
+        pytest.param("col", "b", id="col_b"),
+        pytest.param("mixed", "a", id="mixed_row_a_col_b"),
+        pytest.param("mixed", "b", id="mixed_col_a_row_b"),
     ]
 
     MEMORY_CONFIG_CASES = [
+        pytest.param(ttnn.DRAM_MEMORY_CONFIG, ttnn.DRAM_MEMORY_CONFIG, None, id="default"),
         pytest.param(ttnn.DRAM_MEMORY_CONFIG, ttnn.DRAM_MEMORY_CONFIG, ttnn.DRAM_MEMORY_CONFIG, id="dram_dram_dram"),
         pytest.param(ttnn.L1_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG, id="l1_l1_l1"),
         pytest.param(ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG, ttnn.DRAM_MEMORY_CONFIG, id="dram_l1_dram"),
         pytest.param(ttnn.L1_MEMORY_CONFIG, ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG, id="l1_dram_l1"),
     ]
 
-    @pytest.fixture(autouse=True)
-    def _fixed_seed(self):
-        torch.manual_seed(0)
-
-    # Helpers to map strings to types and create tensors
-    def _get_dtypes(self, s):
-        if s == "bfloat16":
-            return (torch.bfloat16, ttnn.bfloat16)
-        if s == "float32":
-            return (torch.float32, ttnn.float32)
-        if s == "int32":
-            return (torch.int32, ttnn.int32)
-        if s == "uint32":
-            return (torch.uint32, ttnn.uint32)
-        raise ValueError(f"Unsupported dtype_str: {s}")
-
-    def _broadcast_shape(self, shape, mode):
-        if mode == "native":
-            return tuple(shape)
-        if mode == "scalar":
-            return (1,) * len(shape)
-        if mode == "row":
-            return tuple(shape[:-2]) + (1, shape[-1])
-        if mode == "col":
-            return tuple(shape[:-2]) + (shape[-2], 1)
-        raise ValueError(f"Unsupported mode: {mode}")
-
-    def _make_tensor(self, device, shape, dt_pt, dt_tt, memory_config):
-        if dt_pt in (torch.bfloat16, torch.float32):
-            host = torch.randn(shape, dtype=dt_pt)
-        elif dt_pt == torch.int32:
-            host = torch.randint(-1000, 1000, shape, dtype=dt_pt)
-        elif dt_pt == torch.uint32:
-            host = torch.randint(0, 1000, shape, dtype=torch.int64).to(torch.uint32)
-        else:
-            raise ValueError(f"Unsupported torch dtype: {dt_pt}")
-        tt = ttnn.from_torch(
-            host,
-            dtype=dt_tt,
-            layout=ttnn.ROW_MAJOR_LAYOUT,
-            device=device,
-            memory_config=memory_config,
-        )
-        return host, tt
-
-    def _assert_binary_add(self, out_tt_torch, pt_a, pt_b, dtype_str):
-        if dtype_str == "uint32":
-            ref = torch.add(pt_a.to(torch.int64), pt_b.to(torch.int64)).to(out_tt_torch.dtype)
-            assert torch.equal(out_tt_torch, ref)
-        elif dtype_str == "int32":
-            assert torch.equal(out_tt_torch, torch.add(pt_a, pt_b))
-        else:
-            assert_with_pcc(out_tt_torch, torch.add(pt_a, pt_b))
-
-    def _input_shapes(self, shape, mode, bcast_on):
-        bcast_shape = self._broadcast_shape(shape, mode)
-        if bcast_on == "a":
-            return bcast_shape, tuple(shape)
-        if bcast_on == "b":
-            return tuple(shape), bcast_shape
-        raise ValueError(f"Unsupported bcast_on: {bcast_on}")
-
     @pytest.mark.parametrize("shape", SHAPES)
-    @pytest.mark.parametrize("dtype_str", ["bfloat16", "float32", "int32", "uint32"])
-    @pytest.mark.parametrize("mode,bcast_on", BROADCAST_CASES)
-    def test_binary_row_major_broadcasts(self, device, shape, dtype_str, mode, bcast_on):
-        dt_pt, dt_tt = self._get_dtypes(dtype_str)
-        a_shape, b_shape = self._input_shapes(shape, mode, bcast_on)
-
-        pt_a, tt_a = self._make_tensor(device, a_shape, dt_pt, dt_tt, ttnn.DRAM_MEMORY_CONFIG)
-        pt_b, tt_b = self._make_tensor(device, b_shape, dt_pt, dt_tt, ttnn.DRAM_MEMORY_CONFIG)
-
-        with ttnn.manage_config("throw_exception_on_fallback", True):
-            tt_out = ttnn.add(tt_a, tt_b, use_legacy=None)
-        tt_out = ttnn.to_torch(tt_out)
-        self._assert_binary_add(tt_out, pt_a, pt_b, dtype_str)
-
-    @pytest.mark.parametrize("shape", SHAPES)
-    @pytest.mark.parametrize("dtype_str", ["bfloat16", "int32"])
+    @pytest.mark.parametrize("dtype_pt,dtype_tt", DTYPE_CASES)
     @pytest.mark.parametrize("mode,bcast_on", BROADCAST_CASES)
     @pytest.mark.parametrize("a_config,b_config,out_config", MEMORY_CONFIG_CASES)
-    def test_binary_row_major_broadcasts_memory_configs(
-        self, device, shape, dtype_str, mode, bcast_on, a_config, b_config, out_config
-    ):
-        dt_pt, dt_tt = self._get_dtypes(dtype_str)
-        a_shape, b_shape = self._input_shapes(shape, mode, bcast_on)
+    def test_binary_row_major(self, device, shape, dtype_pt, dtype_tt, mode, bcast_on, a_config, b_config, out_config):
+        torch.manual_seed(0)
 
-        pt_a, tt_a = self._make_tensor(device, a_shape, dt_pt, dt_tt, a_config)
-        pt_b, tt_b = self._make_tensor(device, b_shape, dt_pt, dt_tt, b_config)
+        if mode == "mixed":
+            row_shape = tuple(shape[:-2]) + (1, shape[-1])
+            col_shape = tuple(shape[:-2]) + (shape[-2], 1)
+            a_shape, b_shape = (row_shape, col_shape) if bcast_on == "a" else (col_shape, row_shape)
+        else:
+            if mode == "native":
+                bcast_shape = tuple(shape)
+            elif mode == "scalar":
+                bcast_shape = (1,) * len(shape)
+            elif mode == "row":
+                bcast_shape = tuple(shape[:-2]) + (1, shape[-1])
+            else:
+                bcast_shape = tuple(shape[:-2]) + (shape[-2], 1)
+            a_shape, b_shape = (bcast_shape, tuple(shape)) if bcast_on == "a" else (tuple(shape), bcast_shape)
+
+        if dtype_pt in (torch.bfloat16, torch.float32):
+            pt_a = torch.randn(a_shape, dtype=dtype_pt)
+            pt_b = torch.randn(b_shape, dtype=dtype_pt)
+        elif dtype_pt == torch.int32:
+            pt_a = torch.randint(-1000, 1000, a_shape, dtype=dtype_pt)
+            pt_b = torch.randint(-1000, 1000, b_shape, dtype=dtype_pt)
+        else:
+            pt_a = torch.randint(0, 1000, a_shape, dtype=torch.int64).to(torch.uint32)
+            pt_b = torch.randint(0, 1000, b_shape, dtype=torch.int64).to(torch.uint32)
+
+        tt_a = ttnn.from_torch(
+            pt_a,
+            dtype=dtype_tt,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            device=device,
+            memory_config=a_config,
+        )
+        tt_b = ttnn.from_torch(
+            pt_b,
+            dtype=dtype_tt,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            device=device,
+            memory_config=b_config,
+        )
+
+        add_kwargs = {"use_legacy": None}
+        if out_config is not None:
+            add_kwargs["memory_config"] = out_config
 
         with ttnn.manage_config("throw_exception_on_fallback", True):
-            tt_out = ttnn.add(tt_a, tt_b, memory_config=out_config, use_legacy=None)
-        tt_out = ttnn.to_torch(tt_out)
-        self._assert_binary_add(tt_out, pt_a, pt_b, dtype_str)
+            tt_out = ttnn.add(tt_a, tt_b, **add_kwargs)
 
-    @pytest.mark.parametrize("shape", SHAPES)
-    @pytest.mark.parametrize("dtype_str", ["bfloat16", "int32"])
-    def test_binary_row_major_mixed_row_col_bcast(self, device, shape, dtype_str):
-        dt_pt, dt_tt = self._get_dtypes(dtype_str)
-        row_shape = tuple(shape[:-2]) + (1, shape[-1])
-        col_shape = tuple(shape[:-2]) + (shape[-2], 1)
-
-        pt_a, tt_a = self._make_tensor(device, row_shape, dt_pt, dt_tt, ttnn.DRAM_MEMORY_CONFIG)
-        pt_b, tt_b = self._make_tensor(device, col_shape, dt_pt, dt_tt, ttnn.DRAM_MEMORY_CONFIG)
-        with ttnn.manage_config("throw_exception_on_fallback", True):
-            tt_out = ttnn.add(tt_a, tt_b, use_legacy=None)
         tt_out = ttnn.to_torch(tt_out)
-        self._assert_binary_add(tt_out, pt_a, pt_b, dtype_str)
-
-        pt_a, tt_a = self._make_tensor(device, col_shape, dt_pt, dt_tt, ttnn.DRAM_MEMORY_CONFIG)
-        pt_b, tt_b = self._make_tensor(device, row_shape, dt_pt, dt_tt, ttnn.DRAM_MEMORY_CONFIG)
-        with ttnn.manage_config("throw_exception_on_fallback", True):
-            tt_out = ttnn.add(tt_a, tt_b, use_legacy=None)
-        tt_out = ttnn.to_torch(tt_out)
-        self._assert_binary_add(tt_out, pt_a, pt_b, dtype_str)
+        if dtype_pt == torch.uint32:
+            reference = torch.add(pt_a.to(torch.int64), pt_b.to(torch.int64)).to(tt_out.dtype)
+            assert torch.equal(tt_out, reference)
+        elif dtype_pt == torch.int32:
+            assert torch.equal(tt_out, torch.add(pt_a, pt_b))
+        else:
+            assert_with_pcc(tt_out, torch.add(pt_a, pt_b))
 
 
 @pytest.mark.parametrize(

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast.py
@@ -1686,6 +1686,152 @@ def test_binary_sharded_scalar_row_major(scalar, a_shape, shard_type, shard_size
     assert_with_pcc(tt_out, torch.add(a_pt, scalar))
 
 
+class TestBinaryRowMajor:
+    SHAPES = [
+        pytest.param((1, 1, 32, 32), id="tile_aligned"),
+        pytest.param((1, 1, 35, 35), id="non_tile_aligned"),
+        pytest.param((4, 2, 17, 19), id="weird_nc_hw"),
+        pytest.param((2, 3, 33, 64), id="multi_nc_multi_row"),
+        pytest.param((1, 1, 3, 1025), id="wide_over_1024"),
+        pytest.param((1, 1, 1025, 32), id="tall_over_1024"),
+        pytest.param((1, 1, 1, 4096), id="extreme_row_width"),
+        pytest.param((1, 1, 1, 1), id="tiny"),
+        pytest.param((1, 1, 2, 1, 1, 3, 1025), id="rank7_weird_wide"),
+    ]
+
+    BROADCAST_CASES = [
+        pytest.param("native", "b", id="native"),
+        pytest.param("scalar", "b", id="scalar"),
+        pytest.param("row", "b", id="row_b"),
+        pytest.param("row", "a", id="row_a"),
+        pytest.param("col", "b", id="col_b"),
+        pytest.param("col", "a", id="col_a"),
+    ]
+
+    MEMORY_CONFIG_CASES = [
+        pytest.param(ttnn.DRAM_MEMORY_CONFIG, ttnn.DRAM_MEMORY_CONFIG, ttnn.DRAM_MEMORY_CONFIG, id="dram_dram_dram"),
+        pytest.param(ttnn.L1_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG, id="l1_l1_l1"),
+        pytest.param(ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG, ttnn.DRAM_MEMORY_CONFIG, id="dram_l1_dram"),
+        pytest.param(ttnn.L1_MEMORY_CONFIG, ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG, id="l1_dram_l1"),
+    ]
+
+    @pytest.fixture(autouse=True)
+    def _fixed_seed(self):
+        torch.manual_seed(0)
+
+    # Helpers to map strings to types and create tensors
+    def _get_dtypes(self, s):
+        if s == "bfloat16":
+            return (torch.bfloat16, ttnn.bfloat16)
+        if s == "float32":
+            return (torch.float32, ttnn.float32)
+        if s == "int32":
+            return (torch.int32, ttnn.int32)
+        if s == "uint32":
+            return (torch.uint32, ttnn.uint32)
+        raise ValueError(f"Unsupported dtype_str: {s}")
+
+    def _broadcast_shape(self, shape, mode):
+        if mode == "native":
+            return tuple(shape)
+        if mode == "scalar":
+            return (1,) * len(shape)
+        if mode == "row":
+            return tuple(shape[:-2]) + (1, shape[-1])
+        if mode == "col":
+            return tuple(shape[:-2]) + (shape[-2], 1)
+        raise ValueError(f"Unsupported mode: {mode}")
+
+    def _make_tensor(self, device, shape, dt_pt, dt_tt, memory_config):
+        if dt_pt in (torch.bfloat16, torch.float32):
+            host = torch.randn(shape, dtype=dt_pt)
+        elif dt_pt == torch.int32:
+            host = torch.randint(-1000, 1000, shape, dtype=dt_pt)
+        elif dt_pt == torch.uint32:
+            host = torch.randint(0, 1000, shape, dtype=torch.int64).to(torch.uint32)
+        else:
+            raise ValueError(f"Unsupported torch dtype: {dt_pt}")
+        tt = ttnn.from_torch(
+            host,
+            dtype=dt_tt,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            device=device,
+            memory_config=memory_config,
+        )
+        return host, tt
+
+    def _assert_binary_add(self, out_tt_torch, pt_a, pt_b, dtype_str):
+        if dtype_str == "uint32":
+            ref = torch.add(pt_a.to(torch.int64), pt_b.to(torch.int64)).to(out_tt_torch.dtype)
+            assert torch.equal(out_tt_torch, ref)
+        elif dtype_str == "int32":
+            assert torch.equal(out_tt_torch, torch.add(pt_a, pt_b))
+        else:
+            assert_with_pcc(out_tt_torch, torch.add(pt_a, pt_b))
+
+    def _input_shapes(self, shape, mode, bcast_on):
+        bcast_shape = self._broadcast_shape(shape, mode)
+        if bcast_on == "a":
+            return bcast_shape, tuple(shape)
+        if bcast_on == "b":
+            return tuple(shape), bcast_shape
+        raise ValueError(f"Unsupported bcast_on: {bcast_on}")
+
+    @pytest.mark.parametrize("shape", SHAPES)
+    @pytest.mark.parametrize("dtype_str", ["bfloat16", "float32", "int32", "uint32"])
+    @pytest.mark.parametrize("mode,bcast_on", BROADCAST_CASES)
+    def test_binary_row_major_broadcasts(self, device, shape, dtype_str, mode, bcast_on):
+        dt_pt, dt_tt = self._get_dtypes(dtype_str)
+        a_shape, b_shape = self._input_shapes(shape, mode, bcast_on)
+
+        pt_a, tt_a = self._make_tensor(device, a_shape, dt_pt, dt_tt, ttnn.DRAM_MEMORY_CONFIG)
+        pt_b, tt_b = self._make_tensor(device, b_shape, dt_pt, dt_tt, ttnn.DRAM_MEMORY_CONFIG)
+
+        with ttnn.manage_config("throw_exception_on_fallback", True):
+            tt_out = ttnn.add(tt_a, tt_b, use_legacy=None)
+        tt_out = ttnn.to_torch(tt_out)
+        self._assert_binary_add(tt_out, pt_a, pt_b, dtype_str)
+
+    @pytest.mark.parametrize("shape", SHAPES)
+    @pytest.mark.parametrize("dtype_str", ["bfloat16", "int32"])
+    @pytest.mark.parametrize("mode,bcast_on", BROADCAST_CASES)
+    @pytest.mark.parametrize("a_config,b_config,out_config", MEMORY_CONFIG_CASES)
+    def test_binary_row_major_broadcasts_memory_configs(
+        self, device, shape, dtype_str, mode, bcast_on, a_config, b_config, out_config
+    ):
+        dt_pt, dt_tt = self._get_dtypes(dtype_str)
+        a_shape, b_shape = self._input_shapes(shape, mode, bcast_on)
+
+        pt_a, tt_a = self._make_tensor(device, a_shape, dt_pt, dt_tt, a_config)
+        pt_b, tt_b = self._make_tensor(device, b_shape, dt_pt, dt_tt, b_config)
+
+        with ttnn.manage_config("throw_exception_on_fallback", True):
+            tt_out = ttnn.add(tt_a, tt_b, memory_config=out_config, use_legacy=None)
+        tt_out = ttnn.to_torch(tt_out)
+        self._assert_binary_add(tt_out, pt_a, pt_b, dtype_str)
+
+    @pytest.mark.parametrize("shape", SHAPES)
+    @pytest.mark.parametrize("dtype_str", ["bfloat16", "int32"])
+    def test_binary_row_major_mixed_row_col_bcast(self, device, shape, dtype_str):
+        dt_pt, dt_tt = self._get_dtypes(dtype_str)
+        row_shape = tuple(shape[:-2]) + (1, shape[-1])
+        col_shape = tuple(shape[:-2]) + (shape[-2], 1)
+
+        pt_a, tt_a = self._make_tensor(device, row_shape, dt_pt, dt_tt, ttnn.DRAM_MEMORY_CONFIG)
+        pt_b, tt_b = self._make_tensor(device, col_shape, dt_pt, dt_tt, ttnn.DRAM_MEMORY_CONFIG)
+        with ttnn.manage_config("throw_exception_on_fallback", True):
+            tt_out = ttnn.add(tt_a, tt_b, use_legacy=None)
+        tt_out = ttnn.to_torch(tt_out)
+        self._assert_binary_add(tt_out, pt_a, pt_b, dtype_str)
+
+        pt_a, tt_a = self._make_tensor(device, col_shape, dt_pt, dt_tt, ttnn.DRAM_MEMORY_CONFIG)
+        pt_b, tt_b = self._make_tensor(device, row_shape, dt_pt, dt_tt, ttnn.DRAM_MEMORY_CONFIG)
+        with ttnn.manage_config("throw_exception_on_fallback", True):
+            tt_out = ttnn.add(tt_a, tt_b, use_legacy=None)
+        tt_out = ttnn.to_torch(tt_out)
+        self._assert_binary_add(tt_out, pt_a, pt_b, dtype_str)
+
+
 @pytest.mark.parametrize(
     "a_shape, b_shape, a_shard_size, b_shard_size, core_range",
     (

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
@@ -526,39 +526,61 @@ inline auto invoke_binary_ng_impl(
     if (not typecast_a and not typecast_b) {
         const auto input_a_rm = operations::binary::detail::is_layout_or_scalar(lhs, Layout::ROW_MAJOR);
         const auto input_b_rm = operations::binary::detail::is_layout_or_scalar(rhs, Layout::ROW_MAJOR);
-        const auto input_a = operations::binary::detail::to_layout(lhs, Layout::TILE);
-        const auto input_b = operations::binary::detail::to_layout(rhs, Layout::TILE);
+        const auto input_a_sharded = lhs.memory_config().is_sharded();
+        const auto input_b_sharded = [&]() {
+            if constexpr (requires { rhs.memory_config(); }) {
+                return rhs.memory_config().is_sharded();
+            } else {
+                return false;
+            }
+        }();
+        // we don't support to_layout with optional output tensor
+        TT_FATAL(
+            !(output_preallocated && input_a_rm && input_b_rm),
+            "Optional output tensor with Row Major input is not supported right now for Elementwise operations");
+        if (input_a_rm and input_b_rm and not input_a_sharded and not input_b_sharded) {
+            auto result = ttnn::prim::binary_ng(
+                lhs,
+                rhs,
+                binary_op_type,
+                out_dtype,
+                mem_config,
+                output,
+                fast_and_approximate_mode,
+                lhs_activations,
+                rhs_activations,
+                post_activations,
+                std::nullopt,
+                sub_core_grids);
 
-        if (input_a_rm and input_b_rm) {
-            // we don't support to_layout with optional output tensor
-            TT_FATAL(
-                !output_preallocated,
-                "Optional output tensor with Row Major input is not supported right now for Elementwise "
-                "operations");
+            return result;
+        } else {
+            // Either one or both are tiles
+            const auto input_a = operations::binary::detail::to_layout(lhs, Layout::TILE);
+            const auto input_b = operations::binary::detail::to_layout(rhs, Layout::TILE);
+
+            auto result = ttnn::prim::binary_ng(
+                input_a,
+                input_b,
+                binary_op_type,
+                out_dtype,
+                memory_config,
+                output,
+                fast_and_approximate_mode,
+                lhs_activations,
+                rhs_activations,
+                post_activations,
+                std::nullopt,
+                sub_core_grids);
+
+            // if both inputs are in row major, convert the output to row major
+            // since there's no consensus here, avoiding the conversion if we have an excuse to is likely the best option
+            // since it leads to better perf
+            if (input_a_rm and input_b_rm) {
+                return operations::binary::detail::to_layout(result, Layout::ROW_MAJOR);
+            }
+            return result;
         }
-
-        auto result = ttnn::prim::binary_ng(
-            input_a,
-            input_b,
-            binary_op_type,
-            out_dtype,
-            memory_config,
-            output,
-            fast_and_approximate_mode,
-            lhs_activations,
-            rhs_activations,
-            post_activations,
-            std::nullopt,
-            sub_core_grids);
-
-        // if both inputs are in row major, convert the output to row major
-        // since there's no consensus here, avoiding the conversion if we have an excuse to is likely the best option
-        // since it leads to better perf
-        if (input_a_rm and input_b_rm) {
-            return operations::binary::detail::to_layout(result, Layout::ROW_MAJOR);
-        }
-
-        return result;
     }
     const auto input_a = operations::binary::detail::to_dtype(lhs, DataType::BFLOAT16);
     const auto input_b = operations::binary::detail::to_dtype(rhs, DataType::BFLOAT16);

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
@@ -573,14 +573,13 @@ inline auto invoke_binary_ng_impl(
                 std::nullopt,
                 sub_core_grids);
 
-            // if both inputs are in row major, convert the output to row major
-            // since there's no consensus here, avoiding the conversion if we have an excuse to is likely the best option
-            // since it leads to better perf
-            if (input_a_rm and input_b_rm) {
-                return operations::binary::detail::to_layout(result, Layout::ROW_MAJOR);
-            }
-            return result;
+        // if both inputs are in row major, convert the output to row major
+        // since there's no consensus here, avoiding the conversion if we have an excuse to is likely the best option
+        // since it leads to better perf
+        if (input_a_rm and input_b_rm) {
+            return operations::binary::detail::to_layout(result, Layout::ROW_MAJOR);
         }
+        return result;
     }
     const auto input_a = operations::binary::detail::to_dtype(lhs, DataType::BFLOAT16);
     const auto input_b = operations::binary::detail::to_dtype(rhs, DataType::BFLOAT16);

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
@@ -554,12 +554,12 @@ inline auto invoke_binary_ng_impl(
                 sub_core_grids);
 
             return result;
-        } else {
-            // Either one or both are tiles
-            const auto input_a = operations::binary::detail::to_layout(lhs, Layout::TILE);
-            const auto input_b = operations::binary::detail::to_layout(rhs, Layout::TILE);
+        }
+        // Either one or both are tiles
+        const auto input_a = operations::binary::detail::to_layout(lhs, Layout::TILE);
+        const auto input_b = operations::binary::detail::to_layout(rhs, Layout::TILE);
 
-            auto result = ttnn::prim::binary_ng(
+        auto result = ttnn::prim::binary_ng(
                 input_a,
                 input_b,
                 binary_op_type,

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
@@ -238,7 +238,10 @@ ttsl::hash::hash_t BinaryNgDeviceOperation::operation_attributes_t::to_hash() co
         subtile_broadcast_type,
         is_sfpu,
         is_quant_op,
-        is_where_op);
+        is_where_op,
+        input_layout_a,
+        input_layout_b,
+        output_layout);
 }
 
 DataType BinaryNgDeviceOperation::operation_attributes_t::get_dtype() const {
@@ -280,7 +283,10 @@ void BinaryNgDeviceOperation::validate_on_program_cache_miss(
             "If both output dtype and output tensor provided dtype should match");
     }
 
-    TT_FATAL(input_tensor_a.layout() == Layout::TILE, "First operand to eltwise binary must be tilized");
+    TT_FATAL(
+        input_tensor_a.layout() == Layout::TILE || input_tensor_a.layout() == Layout::ROW_MAJOR,
+        "First operand to eltwise binary must have TILE or ROW_MAJOR layout, got {}",
+        input_tensor_a.layout());
 
     bool tensor_a_sharded = input_tensor_a.memory_config().is_sharded();
     if (not tensor_a_sharded) {
@@ -303,7 +309,10 @@ void BinaryNgDeviceOperation::validate_on_program_cache_miss(
         TT_FATAL(
             input_tensor_a.device() == input_tensor_b->device(),
             "Operands to eltwise binary need to be on the same device!");
-        TT_FATAL(input_tensor_b->layout() == Layout::TILE, "Second operand to eltwise binary must be tilized");
+        TT_FATAL(
+            input_tensor_b->layout() == Layout::TILE || input_tensor_b->layout() == Layout::ROW_MAJOR,
+            "Second operand to eltwise binary must have TILE or ROW_MAJOR layout, got {}",
+            input_tensor_b->layout());
 
         if (not tensor_b_sharded) {
             TT_FATAL(
@@ -436,11 +445,15 @@ BinaryNgDeviceOperation::spec_return_value_t BinaryNgDeviceOperation::compute_ou
         return TensorSpec(
             output_shape,
             TensorLayout(
-                output_dtype, PageConfig(Layout::TILE), MemoryConfig(memory_layout, buffer_type, shard_spec_opt)));
+                output_dtype,
+                PageConfig(attributes.output_layout),
+                MemoryConfig(memory_layout, buffer_type, shard_spec_opt)));
     }
 
     // If not sharded, use the memory config from input a that is interleaved
-    return TensorSpec(output_shape, TensorLayout(output_dtype, PageConfig(Layout::TILE), attributes.memory_config));
+    return TensorSpec(
+        output_shape,
+        TensorLayout(output_dtype, PageConfig(attributes.output_layout), attributes.memory_config));
 }
 
 BinaryNgDeviceOperation::tensor_return_value_t BinaryNgDeviceOperation::create_output_tensors(
@@ -531,6 +544,12 @@ ttnn::operations::binary_ng::BinaryNgDeviceOperation::tensor_return_value_t bina
         (binary_op_type == ttnn::operations::binary_ng::BinaryOpType::WHERE_TTS ||
          binary_op_type == ttnn::operations::binary_ng::BinaryOpType::WHERE_TST);
 
+    auto output_layout = output_tensor ? output_tensor->layout() : Layout::TILE;
+    if (!output_tensor.has_value() && input_tensor_a.layout() == Layout::ROW_MAJOR &&
+        input_tensor_b.layout() == Layout::ROW_MAJOR) {
+        output_layout = Layout::ROW_MAJOR;
+    }
+
     MemoryConfig mem_config_actual = input_tensor_a.memory_config();
     if (input_tensor_a.is_sharded()) {
         mem_config_actual =
@@ -605,7 +624,10 @@ ttnn::operations::binary_ng::BinaryNgDeviceOperation::tensor_return_value_t bina
         subtile_broadcast_type,
         is_sfpu_op,
         is_quant_op,
-        is_where_op};
+        is_where_op,
+        input_tensor_a.layout(),
+        input_tensor_b.layout(),
+        output_layout};
 
     auto tensor_args = OperationType::tensor_args_t{input_tensor_a, input_tensor_b, output_tensor};
     return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
@@ -632,6 +654,11 @@ ttnn::operations::binary_ng::BinaryNgDeviceOperation::tensor_return_value_t bina
     MemoryConfig mem_config_actual = memory_config.value_or(
         output_tensor.has_value() ? output_tensor->memory_config() : input_tensor_a.memory_config());
 
+    auto output_layout = output_tensor ? output_tensor->layout() : Layout::TILE;
+    if (!output_tensor.has_value() && input_tensor_a.layout() == Layout::ROW_MAJOR) {
+        output_layout = Layout::ROW_MAJOR;
+    }
+
     auto operation_attributes = OperationType::operation_attributes_t{
         binary_op_type,
         {lhs_activations.begin(), lhs_activations.end()},
@@ -648,7 +675,11 @@ ttnn::operations::binary_ng::BinaryNgDeviceOperation::tensor_return_value_t bina
         ttnn::operations::binary_ng::SubtileBroadcastType::NONE,
         is_sfpu_op,
         is_quant_op,
-        false};
+        false,
+        input_tensor_a.layout(),
+        Layout::INVALID,
+        output_layout};
+
     auto tensor_args = OperationType::tensor_args_t{input_tensor_a, std::nullopt, output_tensor};
     return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.hpp
@@ -45,6 +45,9 @@ struct BinaryNgDeviceOperation {
         bool is_sfpu = false;
         bool is_quant_op = false;
         bool is_where_op = false;
+        Layout input_layout_a = Layout::TILE;
+        Layout input_layout_b = Layout::TILE;
+        Layout output_layout = Layout::TILE;
 
         ttsl::hash::hash_t to_hash() const;
         DataType get_dtype() const;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
@@ -110,7 +110,7 @@ std::optional<AllShardSpecs> get_shard_specs(
 bool should_use_row_major_path(
     const BinaryNgDeviceOperation::operation_attributes_t& operation_attributes,
     const std::optional<Tensor>& b,
-    bool has_sharding) {
+    const bool has_sharding) {
     if (operation_attributes.input_layout_a != Layout::ROW_MAJOR ||
         operation_attributes.output_layout != Layout::ROW_MAJOR || has_sharding) {
         return false;
@@ -294,13 +294,13 @@ void set_or_update_runtime_arguments(
     uint32_t writer_stride_size_bytes = 0;
 
     if (row_major_inputs) {
-        uint32_t c_aligned_page_size = c.buffer()->aligned_page_size();
-        uint32_t a_aligned_page_size = a.buffer()->aligned_page_size();
-        uint32_t b_aligned_page_size = b.has_value() ? b->buffer()->aligned_page_size() : a_aligned_page_size;
+        const uint32_t c_aligned_page_size = c.buffer()->aligned_page_size();
+        const uint32_t a_aligned_page_size = a.buffer()->aligned_page_size();
+        const uint32_t b_aligned_page_size = b.has_value() ? b->buffer()->aligned_page_size() : a_aligned_page_size;
 
-        uint32_t c_row_width_elements_aligned = c_aligned_page_size / c.element_size();
-        uint32_t a_row_width_elements_aligned = a_aligned_page_size / a.element_size();
-        uint32_t b_row_width_elements_aligned =
+        const uint32_t c_row_width_elements_aligned = c_aligned_page_size / c.element_size();
+        const uint32_t a_row_width_elements_aligned = a_aligned_page_size / a.element_size();
+        const uint32_t b_row_width_elements_aligned =
             b.has_value() ? (b_aligned_page_size / b->element_size()) : a_row_width_elements_aligned;
 
         // Use the smallest aligned row width among non-broadcast inputs to avoid over-read.
@@ -314,18 +314,18 @@ void set_or_update_runtime_arguments(
         common_row_width_elements = std::max<uint32_t>(1u, common_row_width_elements);
 
         num_rows_per_tile = std::max<uint32_t>(1u, tile_hw / common_row_width_elements);
-        bool aligned_for_a =
+        const bool aligned_for_a =
             (aWt_r == cWt_r) ? ((common_row_width_elements * a.element_size()) == a_aligned_page_size) : true;
-        bool aligned_for_b = (b.has_value() && bWt_r == cWt_r)
-                                 ? ((common_row_width_elements * b->element_size()) == b_aligned_page_size)
-                                 : true;
-        bool aligned_for_c = (common_row_width_elements * c.element_size()) == c_aligned_page_size;
+        const bool aligned_for_b = (b.has_value() && bWt_r == cWt_r)
+                                       ? ((common_row_width_elements * b->element_size()) == b_aligned_page_size)
+                                       : true;
+        const bool aligned_for_c = (common_row_width_elements * c.element_size()) == c_aligned_page_size;
         if (!aligned_for_a || !aligned_for_b || !aligned_for_c) {
             num_rows_per_tile = 1;
         }
 
         row_blocks_per_channel = tt::div_up(cHt_r, num_rows_per_tile);
-        uint32_t total_row_blocks = cND * cD * cN * cC * row_blocks_per_channel;
+        const uint32_t total_row_blocks = cND * cD * cN * cC * row_blocks_per_channel;
         tiles_per_row_width = tt::div_up(common_row_width_elements, tile_hw);
         const uint32_t a_tile_bytes = tile_hw * a.element_size();
         const uint32_t a_row_width_bytes = common_row_width_elements * a.element_size();

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
@@ -393,8 +393,18 @@ void set_or_update_runtime_arguments(
         } else if (core_group_2.contains(core)) {
             c_num_tiles = num_tiles_per_core_group_2;
         } else {
-            handle_args(program, reader_kernel_id, core, std::array<uint32_t, 24>{0});
-            handle_args(program, writer_kernel_id, core, std::array<uint32_t, 16>{0});
+            // Keep dummy runtime-arg sizes aligned with the active kernel variant so unused cores do not
+            // inflate the per-kernel max runtime-arg allocation.
+            if (row_major_inputs) {
+                handle_args(program, reader_kernel_id, core, std::array<uint32_t, 26>{0});
+                handle_args(program, writer_kernel_id, core, std::array<uint32_t, 14>{0});
+            } else if (b.has_value()) {
+                handle_args(program, reader_kernel_id, core, std::array<uint32_t, 21>{0});
+                handle_args(program, writer_kernel_id, core, std::array<uint32_t, 11>{0});
+            } else {
+                handle_args(program, reader_kernel_id, core, std::array<uint32_t, 21>{0});
+                handle_args(program, writer_kernel_id, core, std::array<uint32_t, 12>{0});
+            }
             handle_args(program, compute_kernel_id, core, std::array<uint32_t, 4>{0});
             continue;
         }

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
@@ -37,8 +37,8 @@ std::tuple<uint32_t, uint32_t, uint32_t, uint32_t, uint32_t> get_shape_dims(cons
         shape.rank() >= 5 ? shape[-5] : 1,
         shape[-4],
         shape[-3],
-        shape[-2] / tile.get_height(),
-        shape[-1] / tile.get_width()};
+        tt::div_up(shape[-2], tile.get_height()),
+        tt::div_up(shape[-1], tile.get_width())};
 }
 
 std::tuple<uint32_t, uint32_t> calculate_compute_kernel_args(
@@ -105,6 +105,20 @@ std::optional<AllShardSpecs> get_shard_specs(
         a_sharded ? *get_shard_spec(a) : adjust_to_shape(*get_shard_spec(c), c_shape, a_shape),
         b_sharded ? *get_shard_spec(*b) : adjust_to_shape(*get_shard_spec(c), c_shape, b_shape),
         *get_shard_spec(c)};
+}
+
+bool should_use_row_major_path(
+    const BinaryNgDeviceOperation::operation_attributes_t& operation_attributes,
+    const std::optional<Tensor>& b,
+    bool has_sharding) {
+    if (operation_attributes.input_layout_a != Layout::ROW_MAJOR ||
+        operation_attributes.output_layout != Layout::ROW_MAJOR || has_sharding) {
+        return false;
+    }
+    if (b.has_value()) {
+        return operation_attributes.input_layout_b == Layout::ROW_MAJOR;
+    }
+    return true;
 }
 
 uint32_t get_shards_per_width(const ShardSpec& shard_spec, TensorMemoryLayout memory_layout) {
@@ -214,6 +228,12 @@ void set_or_update_runtime_arguments(
     auto aND = extract_nD_dims(a, out_rank);
     auto bND = b.has_value() ? extract_nD_dims(*b, out_rank) : 1;
     auto cND = extract_nD_dims(c, out_rank);
+    const auto aHt_r = a.padded_shape()[-2];
+    const auto aWt_r = a.padded_shape()[-1];
+    const auto bHt_r = b.has_value() ? b->padded_shape()[-2] : 0;
+    const auto bWt_r = b.has_value() ? b->padded_shape()[-1] : 0;
+    const auto cHt_r = c.padded_shape()[-2];
+    const auto cWt_r = c.padded_shape()[-1];
 
     const auto [aD, aN, aC, aHt, aWt] = get_shape_dims(a);
     const auto [bD, bN, bC, bHt, bWt] = b.has_value() ? get_shape_dims(*b) : std::tuple{1u, 1u, 1u, 1u, 1u};
@@ -256,10 +276,71 @@ void set_or_update_runtime_arguments(
     uint32_t num_cores;
     std::vector<CoreCoord> cores;
 
+    const bool row_major_inputs = should_use_row_major_path(operation_attributes, b, has_sharding);
+    const uint32_t a_alignment = a.buffer()->alignment();
+    const uint32_t b_alignment = b.has_value() ? b->buffer()->alignment() : a_alignment;
+    const uint32_t c_alignment = c.buffer()->alignment();
+
     const uint32_t tile_height = c.tensor_spec().tile().get_height();
     const uint32_t tile_width = c.tensor_spec().tile().get_width();
     const uint32_t tile_hw = tile_height * tile_width;
-    const uint32_t c_num_tiles = c.physical_volume() / tile_hw;
+
+    uint32_t c_num_tiles;
+    uint32_t num_rows_per_tile = 0;
+    uint32_t row_blocks_per_channel = 1;
+    uint32_t tiles_per_row_width = 1;
+    uint32_t common_row_width_elements = 0;
+    uint32_t reader_stride_size_bytes = 0;
+    uint32_t writer_stride_size_bytes = 0;
+
+    if (row_major_inputs) {
+        uint32_t c_aligned_page_size = c.buffer()->aligned_page_size();
+        uint32_t a_aligned_page_size = a.buffer()->aligned_page_size();
+        uint32_t b_aligned_page_size = b.has_value() ? b->buffer()->aligned_page_size() : a_aligned_page_size;
+
+        uint32_t c_row_width_elements_aligned = c_aligned_page_size / c.element_size();
+        uint32_t a_row_width_elements_aligned = a_aligned_page_size / a.element_size();
+        uint32_t b_row_width_elements_aligned =
+            b.has_value() ? (b_aligned_page_size / b->element_size()) : a_row_width_elements_aligned;
+
+        // Use the smallest aligned row width among non-broadcast inputs to avoid over-read.
+        common_row_width_elements = c_row_width_elements_aligned;
+        if (aWt_r == cWt_r) {
+            common_row_width_elements = std::min(common_row_width_elements, a_row_width_elements_aligned);
+        }
+        if (b.has_value() && bWt_r == cWt_r) {
+            common_row_width_elements = std::min(common_row_width_elements, b_row_width_elements_aligned);
+        }
+        common_row_width_elements = std::max<uint32_t>(1u, common_row_width_elements);
+
+        num_rows_per_tile = std::max<uint32_t>(1u, tile_hw / common_row_width_elements);
+        bool aligned_for_a =
+            (aWt_r == cWt_r) ? ((common_row_width_elements * a.element_size()) == a_aligned_page_size) : true;
+        bool aligned_for_b = (b.has_value() && bWt_r == cWt_r)
+                                 ? ((common_row_width_elements * b->element_size()) == b_aligned_page_size)
+                                 : true;
+        bool aligned_for_c = (common_row_width_elements * c.element_size()) == c_aligned_page_size;
+        if (!aligned_for_a || !aligned_for_b || !aligned_for_c) {
+            num_rows_per_tile = 1;
+        }
+
+        row_blocks_per_channel = tt::div_up(cHt_r, num_rows_per_tile);
+        uint32_t total_row_blocks = cND * cD * cN * cC * row_blocks_per_channel;
+        tiles_per_row_width = tt::div_up(common_row_width_elements, tile_hw);
+        const uint32_t a_tile_bytes = tile_hw * a.element_size();
+        const uint32_t a_row_width_bytes = common_row_width_elements * a.element_size();
+        reader_stride_size_bytes =
+            (a_row_width_bytes > a_tile_bytes) ? a_tile_bytes : tt::round_up(a_row_width_bytes, a_alignment);
+        const uint32_t c_tile_bytes = tile_hw * c.element_size();
+        const uint32_t c_row_width_bytes = common_row_width_elements * c.element_size();
+        writer_stride_size_bytes =
+            (c_row_width_bytes > c_tile_bytes) ? c_tile_bytes : tt::round_up(c_row_width_bytes, c_alignment);
+        // Row-major kernels process one (ND,D,N,C,th-block) at a time.
+        c_num_tiles = total_row_blocks;
+    } else {
+        c_num_tiles = c.physical_volume() / tile_hw;
+    }
+
     uint32_t c_shard_height{}, c_shard_width{}, num_shards_per_width{};
 
     ShardShapeGenerator a_shard_shape_generator;
@@ -300,6 +381,7 @@ void set_or_update_runtime_arguments(
         cores = corerange_to_cores(all_device_cores, {}, row_major);
     }
 
+    uint32_t current_block = 0;
     for (uint32_t i = 0, start_tile_id = 0; i < num_cores_total; i++) {
         const auto& core = cores[i];
 
@@ -311,8 +393,8 @@ void set_or_update_runtime_arguments(
         } else if (core_group_2.contains(core)) {
             c_num_tiles = num_tiles_per_core_group_2;
         } else {
-            handle_args(program, reader_kernel_id, core, std::array<uint32_t, 21>{0});
-            handle_args(program, writer_kernel_id, core, std::array<uint32_t, 11>{0});
+            handle_args(program, reader_kernel_id, core, std::array<uint32_t, 24>{0});
+            handle_args(program, writer_kernel_id, core, std::array<uint32_t, 16>{0});
             handle_args(program, compute_kernel_id, core, std::array<uint32_t, 4>{0});
             continue;
         }
@@ -343,13 +425,48 @@ void set_or_update_runtime_arguments(
                         : 0u;
         uint32_t compute_scalar_value = quantization_zero_point;
 
+        // Calculate actual physical tiles for compute kernel
+        // If Wide Row: 1 unit = 'tiles_per_row_width' physical tiles
+        // If Narrow Row: 1 unit = 1 physical tile (but logical row count logic applies inside)
+        uint32_t compute_tiles = row_major_inputs ? (c_num_tiles * tiles_per_row_width) : c_num_tiles;
+
+        uint32_t packed_scalar_for_reader = 0u;
         if (b.has_value()) {
             if (has_sharding) {
                 auto b_shard_shape = b_shard_shape_generator(core);
                 b_num_tiles = b_shard_shape[0] * b_shard_shape[1];  // actual
             }
-            std::array writer_runtime_args = {
-                c.buffer()->address(), c_start_id, c_num_tiles, c_current_shard_width, cD, cN, cC, cHt, cWt, cND, 0u};
+            std::vector<uint32_t> writer_runtime_args;
+            if (row_major_inputs) {
+                writer_runtime_args = {
+                    c.buffer()->address(),
+                    common_row_width_elements,
+                    c_num_tiles,
+                    cD,
+                    cN,
+                    cC,
+                    cHt_r,
+                    cND,
+                    current_block,
+                    num_rows_per_tile,
+                    static_cast<uint32_t>(c.buffer()->aligned_page_size()),
+                    c_alignment,
+                    tiles_per_row_width,
+                    writer_stride_size_bytes};
+            } else {
+                writer_runtime_args = {
+                    c.buffer()->address(),
+                    c_start_id,
+                    c_num_tiles,
+                    c_current_shard_width,
+                    cD,
+                    cN,
+                    cC,
+                    cHt,
+                    cWt,
+                    cND,
+                    0u};
+            }
             handle_args(program, writer_kernel_id, core, writer_runtime_args);
 
             auto [freq, counter] =
@@ -359,7 +476,11 @@ void set_or_update_runtime_arguments(
                 compute_scalar_value = pack_scalar_runtime_arg(
                     operation_attributes.scalar.value(), b.has_value() ? b->dtype() : a.dtype(), false);
             }
-            std::array compute_runtime_args = {c_num_tiles, freq, counter, compute_scalar_value};
+            if (row_major_inputs) {
+                freq = 1;
+                counter = 0;
+            }
+            std::array compute_runtime_args = {compute_tiles, freq, counter, compute_scalar_value};
             handle_args(program, compute_kernel_id, core, compute_runtime_args);
         } else {
             const auto scalar = *operation_attributes.scalar;
@@ -367,50 +488,113 @@ void set_or_update_runtime_arguments(
             // only quant ops have different dtypes for a & b and we want to force f32 for better accuracy when
             // scale is passed as a scalar, so we'll leave this here
             const auto packed_scalar = pack_scalar_runtime_arg(scalar, a.dtype(), is_quant_op);
-            std::array writer_runtime_args = {
-                packed_scalar,
-                c.buffer()->address(),
+            packed_scalar_for_reader = packed_scalar;
+            std::vector<uint32_t> writer_runtime_args;
+            if (row_major_inputs) {
+                writer_runtime_args = {
+                    c.buffer()->address(),
+                    common_row_width_elements,
+                    c_num_tiles,
+                    cD,
+                    cN,
+                    cC,
+                    cHt_r,
+                    cND,
+                    current_block,
+                    num_rows_per_tile,
+                    static_cast<uint32_t>(c.buffer()->aligned_page_size()),
+                    c_alignment,
+                    tiles_per_row_width,
+                    writer_stride_size_bytes};
+            } else {
+                writer_runtime_args = {
+                    packed_scalar,
+                    c.buffer()->address(),
+                    c_start_id,
+                    c_num_tiles,
+                    c_current_shard_width,
+                    cD,
+                    cN,
+                    cC,
+                    cHt,
+                    cWt,
+                    cND,
+                    0u};
+            }
+            handle_args(program, writer_kernel_id, core, writer_runtime_args);
+
+            std::array compute_runtime_args = {compute_tiles, 0u, 0u, compute_scalar_value};
+            handle_args(program, compute_kernel_id, core, compute_runtime_args);
+        }
+        std::vector<uint32_t> reader_runtime_args;
+
+        if (row_major_inputs) {
+            const uint32_t b_addr = b.has_value() ? b->buffer()->address() : 0u;
+            const uint32_t b_page_size = b.has_value() ? static_cast<uint32_t>(b->buffer()->aligned_page_size())
+                                                       : static_cast<uint32_t>(a.buffer()->aligned_page_size());
+            const uint32_t bD_arg = b.has_value() ? bD : 1u;
+            const uint32_t bN_arg = b.has_value() ? bN : 1u;
+            const uint32_t bC_arg = b.has_value() ? bC : 1u;
+            const uint32_t bHt_r_arg = b.has_value() ? bHt_r : 1u;
+            reader_runtime_args = {
+                a.buffer()->address(),
+                c_num_tiles,
+                aD,
+                aN,
+                aC,
+                aHt_r,
+                aND,
+                b_addr,
+                bD_arg,
+                bN_arg,
+                bC_arg,
+                bHt_r_arg,
+                bND,
+                cHt_r,
+                cC,
+                cND,
+                current_block,
+                num_rows_per_tile,
+                common_row_width_elements,
+                static_cast<uint32_t>(a.buffer()->aligned_page_size()),
+                b_page_size,
+                a_alignment,
+                b_alignment,
+                tiles_per_row_width,
+                reader_stride_size_bytes,
+                packed_scalar_for_reader};
+        } else {
+            reader_runtime_args = {
+                a.buffer()->address(),
                 c_start_id,
+                a_num_tiles,
                 c_num_tiles,
                 c_current_shard_width,
+                aHt * aWt * aC * aN * aD * (aND > 1),
+                aHt * aWt * aC * aN * (aD > 1),
+                aHt * aWt * aC * (aN > 1),
+                aHt * aWt * (aC > 1),
                 cD,
                 cN,
                 cC,
                 cHt,
                 cWt,
-                cND};
-            handle_args(program, writer_kernel_id, core, writer_runtime_args);
-
-            std::array compute_runtime_args = {c_num_tiles, 0u, 0u, compute_scalar_value};
-            handle_args(program, compute_kernel_id, core, compute_runtime_args);
+                cND,
+                b.has_value() ? b->buffer()->address() : 0u,
+                bHt * bWt * bC * bN * bD * (bND > 1),
+                bHt * bWt * bC * bN * (bD > 1),
+                bHt * bWt * bC * (bN > 1),
+                bHt * bWt * (bC > 1),
+                b_num_tiles,
+            };
         }
 
-        std::array reader_runtime_args = {
-            a.buffer()->address(),
-            c_start_id,
-            a_num_tiles,
-            c_num_tiles,
-            c_current_shard_width,
-            aHt * aWt * aC * aN * aD * (aND > 1),
-            aHt * aWt * aC * aN * (aD > 1),
-            aHt * aWt * aC * (aN > 1),
-            aHt * aWt * (aC > 1),
-            cD,
-            cN,
-            cC,
-            cHt,
-            cWt,
-            cND,
-            b.has_value() ? b->buffer()->address() : 0u,
-            bHt * bWt * bC * bN * bD * (bND > 1),
-            bHt * bWt * bC * bN * (bD > 1),
-            bHt * bWt * bC * (bN > 1),
-            bHt * bWt * (bC > 1),
-            b_num_tiles,
-        };
         handle_args(program, reader_kernel_id, core, reader_runtime_args);
 
         start_tile_id += c_num_tiles;
+        if (row_major_inputs) {
+            current_block += c_num_tiles;
+        }
     }
     if (has_sharding) {
         if (a.is_sharded()) {
@@ -455,6 +639,42 @@ KernelName get_reader_kernel_name_and_defines(
         return KernelName::ReaderScalarBcastNg;
     }
     TT_FATAL(false, "Unsupported subtile broadcast type {}", static_cast<int>(subtile_broadcast_type));
+}
+
+KernelName get_reader_rm_kernel_name_and_defines(
+    const SubtileBroadcastType subtile_broadcast_type,
+    const bool has_rhs_tensor,
+    std::map<std::string, std::string>& reader_defines) {
+    if (!has_rhs_tensor) {
+        return KernelName::ReaderRmScalarOpNg;
+    }
+    if (subtile_broadcast_type == SubtileBroadcastType::NONE) {
+        return KernelName::ReaderRmNoBcastNg;
+    }
+    if (subtile_broadcast_type == SubtileBroadcastType::ROW_A ||
+        subtile_broadcast_type == SubtileBroadcastType::ROW_B) {
+        reader_defines["SRC_BCAST"] = subtile_broadcast_type == SubtileBroadcastType::ROW_A ? "1" : "0";
+        reader_defines["SRC_BCAST_B"] = subtile_broadcast_type == SubtileBroadcastType::ROW_B ? "1" : "0";
+        return KernelName::ReaderRmRowBcastNg;
+    }
+    if (subtile_broadcast_type == SubtileBroadcastType::COL_A ||
+        subtile_broadcast_type == SubtileBroadcastType::COL_B) {
+        reader_defines["SRC_BCAST"] = subtile_broadcast_type == SubtileBroadcastType::COL_A ? "1" : "0";
+        reader_defines["SRC_BCAST_B"] = subtile_broadcast_type == SubtileBroadcastType::COL_B ? "1" : "0";
+        return KernelName::ReaderRmColBcastNg;
+    }
+    if (subtile_broadcast_type == SubtileBroadcastType::ROW_B_COL_A ||
+        subtile_broadcast_type == SubtileBroadcastType::ROW_A_COL_B) {
+        reader_defines["SRC_BCAST_ROW_B"] = subtile_broadcast_type == SubtileBroadcastType::ROW_B_COL_A ? "1" : "0";
+        return KernelName::ReaderRmRowBColABcastNg;
+    }
+    if (subtile_broadcast_type == SubtileBroadcastType::SCALAR_A ||
+        subtile_broadcast_type == SubtileBroadcastType::SCALAR_B) {
+        reader_defines["SRC_BCAST"] = subtile_broadcast_type == SubtileBroadcastType::SCALAR_A ? "1" : "0";
+        reader_defines["SRC_BCAST_B"] = subtile_broadcast_type == SubtileBroadcastType::SCALAR_B ? "1" : "0";
+        return KernelName::ReaderRmScalarBcastNg;
+    }
+    TT_FATAL(false, "Unsupported row-major subtile broadcast type {}", static_cast<int>(subtile_broadcast_type));
 }
 
 void overwrite_compute_kernel_name_and_defines(
@@ -630,6 +850,8 @@ BinaryNgDeviceOperation::ProgramFactory::cached_program_t BinaryNgDeviceOperatio
 
     bool op_has_exp =
         op_type == BinaryOpType::LOGADDEXP || op_type == BinaryOpType::LDEXP || op_type == BinaryOpType::LOGADDEXP2;
+    const bool inputs_row_major =
+        CMAKE_UNIQUE_NAMESPACE::should_use_row_major_path(operation_attributes, b, has_sharding);
 
     // How many tiles to store per input CB (double buffer)
     auto [a_cb, a_cb_handle] = create_cb(
@@ -687,6 +909,12 @@ BinaryNgDeviceOperation::ProgramFactory::cached_program_t BinaryNgDeviceOperatio
         c_data_format,
         c_sharded ? c_buffer : nullptr);
 
+    const bool outputs_row_major = inputs_row_major && operation_attributes.output_layout == Layout::ROW_MAJOR;
+    if (inputs_row_major) {
+        TT_FATAL(!has_sharding, "Row-major binary_ng path does not support sharded tensors yet");
+        TT_FATAL(outputs_row_major, "Row-major binary_ng path requires row-major output layout");
+    }
+
     auto kernel_config = CMAKE_UNIQUE_NAMESPACE::BinaryNgKernelConfig(operation_attributes.subtile_broadcast_type);
     // WRITER KERNEL
     auto writer_kernel = CMAKE_UNIQUE_NAMESPACE::KernelName::WriterScalar;
@@ -703,10 +931,11 @@ BinaryNgDeviceOperation::ProgramFactory::cached_program_t BinaryNgDeviceOperatio
     auto reader_defines = make_dataflow_defines(a_dtype, b_dtype);
     reader_defines["SRC_SHARDED"] = a_sharded ? "1" : "0";
     reader_defines["SRC_SHARDED_B"] = b_sharded ? "1" : "0";
-
-    // overwrite reader and write kernel names so that reader reads both and b and
-    // writer does not read b.
-    if (b.has_value()) {
+    if (inputs_row_major) {
+        kernel_config.reader_kernel = CMAKE_UNIQUE_NAMESPACE::get_reader_rm_kernel_name_and_defines(
+            operation_attributes.subtile_broadcast_type, b.has_value(), reader_defines);
+        writer_kernel = KernelName::WriterRmNoBcastNg;
+    } else if (b.has_value()) {
         kernel_config.reader_kernel = CMAKE_UNIQUE_NAMESPACE::get_reader_kernel_name_and_defines(
             operation_attributes.subtile_broadcast_type, reader_defines);
         writer_kernel = KernelName::WriterNoBcastNg;
@@ -758,7 +987,10 @@ BinaryNgDeviceOperation::ProgramFactory::cached_program_t BinaryNgDeviceOperatio
     compute_kernel_defines["BCAST_INPUT"] = kernel_config.bcast_input_str();
 
     const uint32_t num_tiles_per_cycle = 1;  // we produce 1 output tile per read-compute-write cycle
-    if (CMAKE_UNIQUE_NAMESPACE::is_llk_bcast(operation_attributes.subtile_broadcast_type, a_dtype, b_dtype, c_dtype)) {
+    const bool use_llk_bcast =
+        !inputs_row_major &&
+        CMAKE_UNIQUE_NAMESPACE::is_llk_bcast(operation_attributes.subtile_broadcast_type, a_dtype, b_dtype, c_dtype);
+    if (use_llk_bcast) {
         CMAKE_UNIQUE_NAMESPACE::overwrite_compute_kernel_name_and_defines(
             compute_kernel, operation_attributes.subtile_broadcast_type, compute_kernel_defines);
         reader_defines["BCAST_LLK"] = "1";

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
@@ -92,6 +92,18 @@ std::string get_kernel_file_path(KernelName kernel_name, bool is_sfpu, bool is_w
             return fmt::format(dataflow, root_ng, "reader_interleaved_row_col_mixed_bcast.cpp");
         case KernelName::ReaderScalarBcastNg:
             return fmt::format(dataflow, root_ng, "reader_interleaved_scalar_bcast.cpp");
+        case KernelName::ReaderRmNoBcastNg: return fmt::format(dataflow, root_ng, "reader_interleaved_rm_no_bcast.cpp");
+        case KernelName::ReaderRmRowBcastNg:
+            return fmt::format(dataflow, root_ng, "reader_interleaved_rm_row_bcast.cpp");
+        case KernelName::ReaderRmColBcastNg:
+            return fmt::format(dataflow, root_ng, "reader_interleaved_rm_col_bcast.cpp");
+        case KernelName::ReaderRmRowBColABcastNg:
+            return fmt::format(dataflow, root_ng, "reader_interleaved_rm_row_col_mixed_bcast.cpp");
+        case KernelName::ReaderRmScalarBcastNg:
+            return fmt::format(dataflow, root_ng, "reader_interleaved_rm_scalar_bcast.cpp");
+        case KernelName::ReaderRmScalarOpNg:
+            return fmt::format(dataflow, root_ng, "reader_interleaved_rm_scalar_op.cpp");
+        case KernelName::WriterRmNoBcastNg: return fmt::format(dataflow, root_ng, "writer_interleaved_rm_no_bcast.cpp");
         case KernelName::WriterNoBcastNg: return fmt::format(dataflow, root_ng, "writer_interleaved_no_bcast.cpp");
         case KernelName::ReaderNoBcast: return fmt::format(dataflow, root, "reader_interleaved_no_bcast.cpp");
         case KernelName::WriterScalar: return fmt::format(dataflow, root, "writer_interleaved_scalar.cpp");
@@ -519,20 +531,28 @@ std::map<std::string, std::string> make_dataflow_defines(
     // to maintain backward compatibility, we need to support both dtype and b_dtype
     if (dtype == DataType::FLOAT32) {
         defines["FILL_TILE_WITH_FIRST_COLUMN"] = "fill_tile_with_first_column";
+        defines["FILL_TILE_WITH_FIRST_COLUMN_RM"] = "fill_tile_with_first_column_rm";
+        defines["FILL_TILE_WITH_FIRST_ROW_RM"] = "fill_tile_with_first_row_rm";
         defines["FILL_TILE_WITH_FIRST_ROW"] = "fill_tile_with_first_row";
         defines["FILL_TILE_WITH_FIRST_ELEMENT"] = "fill_tile_with_first_element<float>";
         defines["FILL_WITH_VALUE_FLOAT"] = "fill_with_val<1024, float>";
     } else if (dtype == DataType::INT32) {
+        defines["FILL_TILE_WITH_FIRST_COLUMN_RM"] = "fill_tile_with_first_column_rm";
+        defines["FILL_TILE_WITH_FIRST_ROW_RM"] = "fill_tile_with_first_row_rm";
         defines["FILL_TILE_WITH_FIRST_COLUMN"] = "fill_tile_with_first_column";
         defines["FILL_TILE_WITH_FIRST_ROW"] = "fill_tile_with_first_row";
         defines["FILL_TILE_WITH_FIRST_ELEMENT"] = "fill_tile_with_first_element<int32_t>";
         defines["FILL_WITH_VALUE"] = "fill_with_val<1024, int32_t>";
     } else if (dtype == DataType::UINT32) {
+        defines["FILL_TILE_WITH_FIRST_COLUMN_RM"] = "fill_tile_with_first_column_rm";
+        defines["FILL_TILE_WITH_FIRST_ROW_RM"] = "fill_tile_with_first_row_rm";
         defines["FILL_TILE_WITH_FIRST_COLUMN"] = "fill_tile_with_first_column";
         defines["FILL_TILE_WITH_FIRST_ROW"] = "fill_tile_with_first_row";
         defines["FILL_TILE_WITH_FIRST_ELEMENT"] = "fill_tile_with_first_element<uint32_t>";
         defines["FILL_WITH_VALUE"] = "fill_with_val<1024, uint32_t>";
     } else {
+        defines["FILL_TILE_WITH_FIRST_COLUMN_RM"] = "fill_tile_with_first_column_rm_bfloat16";
+        defines["FILL_TILE_WITH_FIRST_ROW_RM"] = "fill_tile_with_first_row_rm_bfloat16";
         defines["FILL_TILE_WITH_FIRST_COLUMN"] = "fill_tile_with_first_column_bfloat16";
         defines["FILL_TILE_WITH_FIRST_ROW"] = "fill_tile_with_first_row_bfloat16";
         defines["FILL_TILE_WITH_FIRST_ELEMENT"] = "fill_tile_with_first_element_bfloat16";

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.hpp
@@ -25,6 +25,13 @@ enum class KernelName {
     ReaderColBcastNg,
     ReaderRowBColABcastNg,
     ReaderScalarBcastNg,
+    ReaderRmNoBcastNg,
+    ReaderRmRowBcastNg,
+    ReaderRmColBcastNg,
+    ReaderRmRowBColABcastNg,
+    ReaderRmScalarBcastNg,
+    ReaderRmScalarOpNg,
+    WriterRmNoBcastNg,
     ComputeRowBcastNg,
     ComputeRowColBcastNg,
 };

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu.cpp
@@ -113,7 +113,7 @@ void kernel_main() {
     PACK((llk_pack_relu_config(ReluType::ZERO_RELU)));
 #endif
 
-#if not(HAS_ACTIVATIONS(LHS) or HAS_ACTIVATIONS(RHS)) and not(HAS_ACTIVATIONS(POST))
+#if not(HAS_ACTIVATIONS(LHS) or HAS_ACTIVATIONS(RHS))
     BINARY_SFPU_INIT
 #endif
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu.cpp
@@ -113,7 +113,7 @@ void kernel_main() {
     PACK((llk_pack_relu_config(ReluType::ZERO_RELU)));
 #endif
 
-#if not(HAS_ACTIVATIONS(LHS) or HAS_ACTIVATIONS(RHS))
+#if not(HAS_ACTIVATIONS(LHS) or HAS_ACTIVATIONS(RHS)) and not(HAS_ACTIVATIONS(POST))
     BINARY_SFPU_INIT
 #endif
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_col_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_col_bcast.cpp
@@ -1,0 +1,228 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+
+#include "api/dataflow/dataflow_api.h"
+#include "ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/fill_tile_utils.hpp"
+
+#define ALIGN_TO(len, align) (((len) + (align) - 1) / (align)) * (align)
+
+namespace {
+inline void copy_one_element(uint32_t dst_l1_addr, uint32_t src_l1_addr, uint32_t element_size) {
+    if (element_size == 1) {
+        auto* src_ptr = reinterpret_cast<volatile tt_l1_ptr uint8_t*>(src_l1_addr);
+        auto* dst_ptr = reinterpret_cast<volatile tt_l1_ptr uint8_t*>(dst_l1_addr);
+        dst_ptr[0] = src_ptr[0];
+    } else if (element_size == 2) {
+        auto* src_ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(src_l1_addr);
+        auto* dst_ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(dst_l1_addr);
+        dst_ptr[0] = src_ptr[0];
+    } else {
+        auto* src_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(src_l1_addr);
+        auto* dst_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(dst_l1_addr);
+        dst_ptr[0] = src_ptr[0];
+    }
+}
+}  // namespace
+
+void kernel_main() {
+    uint32_t index = 0;
+    const uint32_t src_addr = get_arg_val<uint32_t>(index++);
+    const uint32_t dst_num_tiles = get_arg_val<uint32_t>(index++);
+
+    const uint32_t aD = get_arg_val<uint32_t>(index++);
+    const uint32_t aN = get_arg_val<uint32_t>(index++);
+    const uint32_t aC = get_arg_val<uint32_t>(index++);
+    const uint32_t aHt = get_arg_val<uint32_t>(index++);
+    const uint32_t aND = get_arg_val<uint32_t>(index++);
+
+    const uint32_t src_addr_b = get_arg_val<uint32_t>(index++);
+    const uint32_t bD = get_arg_val<uint32_t>(index++);
+    const uint32_t bN = get_arg_val<uint32_t>(index++);
+    const uint32_t bC = get_arg_val<uint32_t>(index++);
+    const uint32_t bHt = get_arg_val<uint32_t>(index++);
+    const uint32_t bND = get_arg_val<uint32_t>(index++);
+
+    const uint32_t cHt = get_arg_val<uint32_t>(index++);
+    const uint32_t cC = get_arg_val<uint32_t>(index++);
+    const uint32_t cND = get_arg_val<uint32_t>(index++);
+    const uint32_t current_block_start = get_arg_val<uint32_t>(index++);
+    const uint32_t rows_per_tile = get_arg_val<uint32_t>(index++);
+    const uint32_t row_width_elements = get_arg_val<uint32_t>(index++);
+    const uint32_t page_size_a_arg = get_arg_val<uint32_t>(index++);
+    const uint32_t page_size_b_arg = get_arg_val<uint32_t>(index++);
+    const uint32_t alignment_a = get_arg_val<uint32_t>(index++);
+    const uint32_t alignment_b = get_arg_val<uint32_t>(index++);
+    const uint32_t tiles_per_row = get_arg_val<uint32_t>(index++);
+    const uint32_t stride_size_bytes = get_arg_val<uint32_t>(index++);
+    const uint32_t packed_scalar = get_arg_val<uint32_t>(index++);
+
+    (void)packed_scalar;
+
+    constexpr auto cb_id_src = tt::CBIndex::c_0;
+    constexpr auto cb_id_src_b = tt::CBIndex::c_1;
+    constexpr auto src_args = TensorAccessorArgs<0>();
+    constexpr auto src_b_args = TensorAccessorArgs<src_args.next_compile_time_args_offset()>();
+
+    constexpr uint32_t src_tile_bytes = get_tile_size(cb_id_src);
+    const uint32_t tile_hw = get_tile_hw(cb_id_src);
+    constexpr uint32_t element_size = src_tile_bytes / tile_hw;
+    const uint32_t element_size_aligned_a = ALIGN_TO(element_size, alignment_a);
+    const uint32_t element_size_aligned_b = ALIGN_TO(element_size, alignment_b);
+    const uint32_t row_width_bytes = row_width_elements * element_size;
+
+    const uint32_t outHt = cHt;
+    const uint32_t outC = cC;
+    const uint32_t outN = (aN > bN) ? aN : bN;
+    const uint32_t outD = (aD > bD) ? aD : bD;
+    const uint32_t outND = cND;
+
+#if SRC_BCAST
+    const uint32_t page_size_a = element_size;
+    const uint32_t page_size_b = ALIGN_TO(page_size_b_arg, alignment_b);
+#else
+    const uint32_t page_size_a = ALIGN_TO(page_size_a_arg, alignment_a);
+    const uint32_t page_size_b = element_size;
+#endif
+
+    const auto src = TensorAccessor(src_args, src_addr, page_size_a);
+    const auto src_b = TensorAccessor(src_b_args, src_addr_b, page_size_b);
+
+    const uint32_t s_h_a = (aHt == 1) ? 0 : 1;
+    const uint32_t s_c_a = (aC == 1) ? 0 : aHt;
+    const uint32_t s_n_a = (aN == 1) ? 0 : aC * aHt;
+    const uint32_t s_d_a = (aD == 1) ? 0 : aN * aC * aHt;
+    const uint32_t s_nd_a = (aND == 1) ? 0 : aD * aN * aC * aHt;
+
+    const uint32_t s_h_b = (bHt == 1) ? 0 : 1;
+    const uint32_t s_c_b = (bC == 1) ? 0 : bHt;
+    const uint32_t s_n_b = (bN == 1) ? 0 : bC * bHt;
+    const uint32_t s_d_b = (bD == 1) ? 0 : bN * bC * bHt;
+    const uint32_t s_nd_b = (bND == 1) ? 0 : bD * bN * bC * bHt;
+
+    const uint32_t row_blocks_per_channel = (outHt + rows_per_tile - 1) / rows_per_tile;
+
+    uint32_t tmp = current_block_start;
+    uint32_t start_th = (tmp % row_blocks_per_channel) * rows_per_tile;
+    tmp /= row_blocks_per_channel;
+    uint32_t start_c = tmp % outC;
+    tmp /= outC;
+    uint32_t start_n = tmp % outN;
+    tmp /= outN;
+    uint32_t start_d = tmp % outD;
+    tmp /= outD;
+    uint32_t start_nd = tmp;
+
+    uint32_t row_blocks_pushed = 0;
+
+    for (uint32_t nd = start_nd; nd < outND && row_blocks_pushed < dst_num_tiles; ++nd, start_d = 0) {
+        uint32_t ptr_nd_a = nd * s_nd_a;
+        uint32_t ptr_nd_b = nd * s_nd_b;
+
+        for (uint32_t d = start_d; d < outD && row_blocks_pushed < dst_num_tiles; ++d, start_n = 0) {
+            uint32_t ptr_d_a = ptr_nd_a + d * s_d_a;
+            uint32_t ptr_d_b = ptr_nd_b + d * s_d_b;
+
+            for (uint32_t n = start_n; n < outN && row_blocks_pushed < dst_num_tiles; ++n, start_c = 0) {
+                uint32_t ptr_n_a = ptr_d_a + n * s_n_a;
+                uint32_t ptr_n_b = ptr_d_b + n * s_n_b;
+
+                for (uint32_t c = start_c; c < outC && row_blocks_pushed < dst_num_tiles; ++c, start_th = 0) {
+                    uint32_t ptr_c_a = ptr_n_a + c * s_c_a;
+                    uint32_t ptr_c_b = ptr_n_b + c * s_c_b;
+
+                    for (uint32_t th = start_th; th < outHt && row_blocks_pushed < dst_num_tiles; th += rows_per_tile) {
+                        uint32_t rows_remaining_in_block = outHt - th;
+                        uint32_t limit =
+                            (rows_remaining_in_block < rows_per_tile) ? rows_remaining_in_block : rows_per_tile;
+
+                        uint32_t row_block_a = ptr_c_a + th * s_h_a;
+                        uint32_t row_block_b = ptr_c_b + th * s_h_b;
+
+                        for (uint32_t t_i = 0; t_i < tiles_per_row; ++t_i) {
+                            uint32_t t_offset = t_i * stride_size_bytes;
+                            uint32_t bytes_left_in_row = row_width_bytes - t_offset;
+                            if (bytes_left_in_row > row_width_bytes) {
+                                bytes_left_in_row = 0;
+                            }
+
+                            uint32_t current_chunk_bytes =
+                                (stride_size_bytes < bytes_left_in_row) ? stride_size_bytes : bytes_left_in_row;
+                            uint32_t current_chunk_elements = current_chunk_bytes / element_size;
+
+#if SRC_BCAST
+                            uint32_t read_len_a = element_size_aligned_a;
+                            uint32_t read_len_b = ALIGN_TO(current_chunk_bytes, alignment_b);
+#else
+                            uint32_t read_len_a = ALIGN_TO(current_chunk_bytes, alignment_a);
+                            uint32_t read_len_b = element_size_aligned_b;
+#endif
+
+                            cb_reserve_back(cb_id_src, 1);
+                            uint32_t l1_write_addr_src = get_write_ptr(cb_id_src);
+
+                            cb_reserve_back(cb_id_src_b, 1);
+                            uint32_t l1_write_addr_src_b = get_write_ptr(cb_id_src_b);
+
+#if SRC_BCAST
+                            for (int32_t k = static_cast<int32_t>(limit) - 1; k >= 0; --k) {
+                                uint32_t row_idx_a = row_block_a + static_cast<uint32_t>(k) * s_h_a;
+                                uint64_t addr_a = get_noc_addr(row_idx_a, src);
+                                uint32_t src_low_bits = static_cast<uint32_t>(addr_a & 0xF);
+                                uint32_t scratch_l1_addr = l1_write_addr_src + src_low_bits;
+                                uint32_t row_l1_addr =
+                                    l1_write_addr_src + static_cast<uint32_t>(k) * current_chunk_bytes;
+
+                                noc_async_read(addr_a, scratch_l1_addr, read_len_a);
+                                noc_async_read_barrier();
+
+                                copy_one_element(row_l1_addr, scratch_l1_addr, element_size);
+                                FILL_TILE_WITH_FIRST_COLUMN_RM(row_l1_addr, current_chunk_elements);
+                            }
+
+                            uint32_t curr_l1_b = l1_write_addr_src_b;
+                            for (uint32_t k = 0; k < limit; ++k) {
+                                uint32_t row_idx_b = row_block_b + k * s_h_b;
+                                uint64_t addr_b = get_noc_addr(row_idx_b, src_b) + t_offset;
+                                noc_async_read(addr_b, curr_l1_b, read_len_b);
+                                curr_l1_b += current_chunk_bytes;
+                            }
+                            noc_async_read_barrier();
+#else
+                            uint32_t curr_l1_a = l1_write_addr_src;
+                            for (uint32_t k = 0; k < limit; ++k) {
+                                uint32_t row_idx_a = row_block_a + k * s_h_a;
+                                uint64_t addr_a = get_noc_addr(row_idx_a, src) + t_offset;
+                                noc_async_read(addr_a, curr_l1_a, read_len_a);
+                                curr_l1_a += current_chunk_bytes;
+                            }
+                            noc_async_read_barrier();
+
+                            for (int32_t k = static_cast<int32_t>(limit) - 1; k >= 0; --k) {
+                                uint32_t row_idx_b = row_block_b + static_cast<uint32_t>(k) * s_h_b;
+                                uint64_t addr_b = get_noc_addr(row_idx_b, src_b);
+                                uint32_t src_low_bits = static_cast<uint32_t>(addr_b & 0xF);
+                                uint32_t scratch_l1_addr = l1_write_addr_src_b + src_low_bits;
+                                uint32_t row_l1_addr =
+                                    l1_write_addr_src_b + static_cast<uint32_t>(k) * current_chunk_bytes;
+
+                                noc_async_read(addr_b, scratch_l1_addr, read_len_b);
+                                noc_async_read_barrier();
+
+                                copy_one_element(row_l1_addr, scratch_l1_addr, element_size);
+                                FILL_TILE_WITH_FIRST_COLUMN_RM(row_l1_addr, current_chunk_elements);
+                            }
+#endif
+
+                            cb_push_back(cb_id_src, 1);
+                            cb_push_back(cb_id_src_b, 1);
+                        }
+
+                        row_blocks_pushed++;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_col_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_col_bcast.cpp
@@ -9,12 +9,15 @@
 
 namespace {
 // Broadcast reads land in a scratch slot offset by source low bits; normalize the seed value to row start before fill.
-FORCE_INLINE void copy_one_element(uint32_t dst_l1_addr, uint32_t src_l1_addr, uint32_t element_size) {
-    if (element_size == 1) {
+template <uint32_t element_size>
+FORCE_INLINE void copy_one_element(uint32_t dst_l1_addr, uint32_t src_l1_addr) {
+    static_assert(element_size == 1 || element_size == 2 || element_size == 4);
+
+    if constexpr (element_size == 1) {
         auto* src_ptr = reinterpret_cast<volatile tt_l1_ptr uint8_t*>(src_l1_addr);
         auto* dst_ptr = reinterpret_cast<volatile tt_l1_ptr uint8_t*>(dst_l1_addr);
         dst_ptr[0] = src_ptr[0];
-    } else if (element_size == 2) {
+    } else if constexpr (element_size == 2) {
         auto* src_ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(src_l1_addr);
         auto* dst_ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(dst_l1_addr);
         dst_ptr[0] = src_ptr[0];
@@ -164,7 +167,7 @@ void kernel_main() {
                                 noc_async_read(addr_a, scratch_l1_addr, element_size_aligned_a);
                                 noc_async_read_barrier();
 
-                                copy_one_element(row_l1_addr, scratch_l1_addr, element_size);
+                                copy_one_element<element_size>(row_l1_addr, scratch_l1_addr);
                                 FILL_TILE_WITH_FIRST_COLUMN_RM(row_l1_addr, current_chunk_elements);
                             }
 
@@ -199,7 +202,7 @@ void kernel_main() {
                                 noc_async_read(addr_b, scratch_l1_addr, element_size_aligned_b);
                                 noc_async_read_barrier();
 
-                                copy_one_element(row_l1_addr, scratch_l1_addr, element_size);
+                                copy_one_element<element_size>(row_l1_addr, scratch_l1_addr);
                                 FILL_TILE_WITH_FIRST_COLUMN_RM(row_l1_addr, current_chunk_elements);
                             }
 #endif

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_col_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_col_bcast.cpp
@@ -1,15 +1,15 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 // SPDX-License-Identifier: Apache-2.0
 
 #include <stdint.h>
 
+#include "api/alignment.h"
 #include "api/dataflow/dataflow_api.h"
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/fill_tile_utils.hpp"
 
-#define ALIGN_TO(len, align) (((len) + (align) - 1) / (align)) * (align)
-
 namespace {
-inline void copy_one_element(uint32_t dst_l1_addr, uint32_t src_l1_addr, uint32_t element_size) {
+// Broadcast reads land in a scratch slot offset by source low bits; normalize the seed value to row start before fill.
+FORCE_INLINE void copy_one_element(uint32_t dst_l1_addr, uint32_t src_l1_addr, uint32_t element_size) {
     if (element_size == 1) {
         auto* src_ptr = reinterpret_cast<volatile tt_l1_ptr uint8_t*>(src_l1_addr);
         auto* dst_ptr = reinterpret_cast<volatile tt_l1_ptr uint8_t*>(dst_l1_addr);
@@ -56,9 +56,6 @@ void kernel_main() {
     const uint32_t alignment_b = get_arg_val<uint32_t>(index++);
     const uint32_t tiles_per_row = get_arg_val<uint32_t>(index++);
     const uint32_t stride_size_bytes = get_arg_val<uint32_t>(index++);
-    const uint32_t packed_scalar = get_arg_val<uint32_t>(index++);
-
-    (void)packed_scalar;
 
     constexpr auto cb_id_src = tt::CBIndex::c_0;
     constexpr auto cb_id_src_b = tt::CBIndex::c_1;
@@ -66,10 +63,10 @@ void kernel_main() {
     constexpr auto src_b_args = TensorAccessorArgs<src_args.next_compile_time_args_offset()>();
 
     constexpr uint32_t src_tile_bytes = get_tile_size(cb_id_src);
-    const uint32_t tile_hw = get_tile_hw(cb_id_src);
+    constexpr uint32_t tile_hw = get_tile_hw(cb_id_src);
     constexpr uint32_t element_size = src_tile_bytes / tile_hw;
-    const uint32_t element_size_aligned_a = ALIGN_TO(element_size, alignment_a);
-    const uint32_t element_size_aligned_b = ALIGN_TO(element_size, alignment_b);
+    const uint32_t element_size_aligned_a = align(element_size, alignment_a);
+    const uint32_t element_size_aligned_b = align(element_size, alignment_b);
     const uint32_t row_width_bytes = row_width_elements * element_size;
 
     const uint32_t outHt = cHt;
@@ -79,11 +76,11 @@ void kernel_main() {
     const uint32_t outND = cND;
 
 #if SRC_BCAST
-    const uint32_t page_size_a = element_size;
-    const uint32_t page_size_b = ALIGN_TO(page_size_b_arg, alignment_b);
+    const uint32_t page_size_a = element_size_aligned_a;
+    const uint32_t page_size_b = align(page_size_b_arg, alignment_b);
 #else
-    const uint32_t page_size_a = ALIGN_TO(page_size_a_arg, alignment_a);
-    const uint32_t page_size_b = element_size;
+    const uint32_t page_size_a = align(page_size_a_arg, alignment_a);
+    const uint32_t page_size_b = element_size_aligned_b;
 #endif
 
     const auto src = TensorAccessor(src_args, src_addr, page_size_a);
@@ -117,64 +114,54 @@ void kernel_main() {
     uint32_t row_blocks_pushed = 0;
 
     for (uint32_t nd = start_nd; nd < outND && row_blocks_pushed < dst_num_tiles; ++nd, start_d = 0) {
-        uint32_t ptr_nd_a = nd * s_nd_a;
-        uint32_t ptr_nd_b = nd * s_nd_b;
+        const uint32_t ptr_nd_a = nd * s_nd_a;
+        const uint32_t ptr_nd_b = nd * s_nd_b;
 
         for (uint32_t d = start_d; d < outD && row_blocks_pushed < dst_num_tiles; ++d, start_n = 0) {
-            uint32_t ptr_d_a = ptr_nd_a + d * s_d_a;
-            uint32_t ptr_d_b = ptr_nd_b + d * s_d_b;
+            const uint32_t ptr_d_a = ptr_nd_a + d * s_d_a;
+            const uint32_t ptr_d_b = ptr_nd_b + d * s_d_b;
 
             for (uint32_t n = start_n; n < outN && row_blocks_pushed < dst_num_tiles; ++n, start_c = 0) {
-                uint32_t ptr_n_a = ptr_d_a + n * s_n_a;
-                uint32_t ptr_n_b = ptr_d_b + n * s_n_b;
+                const uint32_t ptr_n_a = ptr_d_a + n * s_n_a;
+                const uint32_t ptr_n_b = ptr_d_b + n * s_n_b;
 
                 for (uint32_t c = start_c; c < outC && row_blocks_pushed < dst_num_tiles; ++c, start_th = 0) {
-                    uint32_t ptr_c_a = ptr_n_a + c * s_c_a;
-                    uint32_t ptr_c_b = ptr_n_b + c * s_c_b;
+                    const uint32_t ptr_c_a = ptr_n_a + c * s_c_a;
+                    const uint32_t ptr_c_b = ptr_n_b + c * s_c_b;
 
                     for (uint32_t th = start_th; th < outHt && row_blocks_pushed < dst_num_tiles; th += rows_per_tile) {
-                        uint32_t rows_remaining_in_block = outHt - th;
-                        uint32_t limit =
+                        const uint32_t rows_remaining_in_block = outHt - th;
+                        const uint32_t limit =
                             (rows_remaining_in_block < rows_per_tile) ? rows_remaining_in_block : rows_per_tile;
 
-                        uint32_t row_block_a = ptr_c_a + th * s_h_a;
-                        uint32_t row_block_b = ptr_c_b + th * s_h_b;
+                        const uint32_t row_block_a = ptr_c_a + th * s_h_a;
+                        const uint32_t row_block_b = ptr_c_b + th * s_h_b;
 
                         for (uint32_t t_i = 0; t_i < tiles_per_row; ++t_i) {
-                            uint32_t t_offset = t_i * stride_size_bytes;
-                            uint32_t bytes_left_in_row = row_width_bytes - t_offset;
-                            if (bytes_left_in_row > row_width_bytes) {
-                                bytes_left_in_row = 0;
-                            }
-
-                            uint32_t current_chunk_bytes =
+                            const uint32_t current_chunk_offset = t_i * stride_size_bytes;
+                            const uint32_t bytes_left_in_row = row_width_bytes - current_chunk_offset;
+                            const uint32_t current_chunk_bytes =
                                 (stride_size_bytes < bytes_left_in_row) ? stride_size_bytes : bytes_left_in_row;
-                            uint32_t current_chunk_elements = current_chunk_bytes / element_size;
-
-#if SRC_BCAST
-                            uint32_t read_len_a = element_size_aligned_a;
-                            uint32_t read_len_b = ALIGN_TO(current_chunk_bytes, alignment_b);
-#else
-                            uint32_t read_len_a = ALIGN_TO(current_chunk_bytes, alignment_a);
-                            uint32_t read_len_b = element_size_aligned_b;
-#endif
+                            const uint32_t current_chunk_elements = current_chunk_bytes / element_size;
 
                             cb_reserve_back(cb_id_src, 1);
-                            uint32_t l1_write_addr_src = get_write_ptr(cb_id_src);
+                            const uint32_t l1_write_addr_src = get_write_ptr(cb_id_src);
 
                             cb_reserve_back(cb_id_src_b, 1);
-                            uint32_t l1_write_addr_src_b = get_write_ptr(cb_id_src_b);
+                            const uint32_t l1_write_addr_src_b = get_write_ptr(cb_id_src_b);
 
 #if SRC_BCAST
+                            const uint32_t current_read_len_b = align(current_chunk_bytes, alignment_b);
+
                             for (int32_t k = static_cast<int32_t>(limit) - 1; k >= 0; --k) {
-                                uint32_t row_idx_a = row_block_a + static_cast<uint32_t>(k) * s_h_a;
-                                uint64_t addr_a = get_noc_addr(row_idx_a, src);
-                                uint32_t src_low_bits = static_cast<uint32_t>(addr_a & 0xF);
-                                uint32_t scratch_l1_addr = l1_write_addr_src + src_low_bits;
-                                uint32_t row_l1_addr =
+                                const uint32_t row_idx_a = row_block_a + static_cast<uint32_t>(k) * s_h_a;
+                                const uint64_t addr_a = get_noc_addr(row_idx_a, src);
+                                const uint32_t src_low_bits = static_cast<uint32_t>(addr_a & 0xF);
+                                const uint32_t scratch_l1_addr = l1_write_addr_src + src_low_bits;
+                                const uint32_t row_l1_addr =
                                     l1_write_addr_src + static_cast<uint32_t>(k) * current_chunk_bytes;
 
-                                noc_async_read(addr_a, scratch_l1_addr, read_len_a);
+                                noc_async_read(addr_a, scratch_l1_addr, element_size_aligned_a);
                                 noc_async_read_barrier();
 
                                 copy_one_element(row_l1_addr, scratch_l1_addr, element_size);
@@ -183,31 +170,33 @@ void kernel_main() {
 
                             uint32_t curr_l1_b = l1_write_addr_src_b;
                             for (uint32_t k = 0; k < limit; ++k) {
-                                uint32_t row_idx_b = row_block_b + k * s_h_b;
-                                uint64_t addr_b = get_noc_addr(row_idx_b, src_b) + t_offset;
-                                noc_async_read(addr_b, curr_l1_b, read_len_b);
+                                const uint32_t row_idx_b = row_block_b + k * s_h_b;
+                                const uint64_t addr_b = get_noc_addr(row_idx_b, src_b) + current_chunk_offset;
+                                noc_async_read(addr_b, curr_l1_b, current_read_len_b);
                                 curr_l1_b += current_chunk_bytes;
                             }
                             noc_async_read_barrier();
 #else
+                            const uint32_t current_read_len_a = align(current_chunk_bytes, alignment_a);
+
                             uint32_t curr_l1_a = l1_write_addr_src;
                             for (uint32_t k = 0; k < limit; ++k) {
-                                uint32_t row_idx_a = row_block_a + k * s_h_a;
-                                uint64_t addr_a = get_noc_addr(row_idx_a, src) + t_offset;
-                                noc_async_read(addr_a, curr_l1_a, read_len_a);
+                                const uint32_t row_idx_a = row_block_a + k * s_h_a;
+                                const uint64_t addr_a = get_noc_addr(row_idx_a, src) + current_chunk_offset;
+                                noc_async_read(addr_a, curr_l1_a, current_read_len_a);
                                 curr_l1_a += current_chunk_bytes;
                             }
                             noc_async_read_barrier();
 
                             for (int32_t k = static_cast<int32_t>(limit) - 1; k >= 0; --k) {
-                                uint32_t row_idx_b = row_block_b + static_cast<uint32_t>(k) * s_h_b;
-                                uint64_t addr_b = get_noc_addr(row_idx_b, src_b);
-                                uint32_t src_low_bits = static_cast<uint32_t>(addr_b & 0xF);
-                                uint32_t scratch_l1_addr = l1_write_addr_src_b + src_low_bits;
-                                uint32_t row_l1_addr =
+                                const uint32_t row_idx_b = row_block_b + static_cast<uint32_t>(k) * s_h_b;
+                                const uint64_t addr_b = get_noc_addr(row_idx_b, src_b);
+                                const uint32_t src_low_bits = static_cast<uint32_t>(addr_b & 0xF);
+                                const uint32_t scratch_l1_addr = l1_write_addr_src_b + src_low_bits;
+                                const uint32_t row_l1_addr =
                                     l1_write_addr_src_b + static_cast<uint32_t>(k) * current_chunk_bytes;
 
-                                noc_async_read(addr_b, scratch_l1_addr, read_len_b);
+                                noc_async_read(addr_b, scratch_l1_addr, element_size_aligned_b);
                                 noc_async_read_barrier();
 
                                 copy_one_element(row_l1_addr, scratch_l1_addr, element_size);

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_no_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_no_bcast.cpp
@@ -1,11 +1,10 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 // SPDX-License-Identifier: Apache-2.0
 
 #include <stdint.h>
 
+#include "api/alignment.h"
 #include "api/dataflow/dataflow_api.h"
-
-#define ALIGN_TO(len, align) (((len) + (align) - 1) / (align)) * (align)
 
 void kernel_main() {
     uint32_t index = 0;
@@ -37,9 +36,6 @@ void kernel_main() {
     const uint32_t alignment_b = get_arg_val<uint32_t>(index++);
     const uint32_t tiles_per_row = get_arg_val<uint32_t>(index++);
     const uint32_t stride_size_bytes = get_arg_val<uint32_t>(index++);
-    const uint32_t packed_scalar = get_arg_val<uint32_t>(index++);
-
-    (void)packed_scalar;
 
     constexpr auto cb_id_src = tt::CBIndex::c_0;
     constexpr auto cb_id_src_b = tt::CBIndex::c_1;
@@ -47,7 +43,7 @@ void kernel_main() {
     constexpr auto src_b_args = TensorAccessorArgs<src_args.next_compile_time_args_offset()>();
 
     constexpr uint32_t src_tile_bytes = get_tile_size(cb_id_src);
-    const uint32_t tile_hw = get_tile_hw(cb_id_src);
+    constexpr uint32_t tile_hw = get_tile_hw(cb_id_src);
     constexpr uint32_t element_size = src_tile_bytes / tile_hw;
     const uint32_t row_width_bytes = row_width_elements * element_size;
 
@@ -57,8 +53,8 @@ void kernel_main() {
     const uint32_t outD = (aD > bD) ? aD : bD;
     const uint32_t outND = cND;
 
-    const uint32_t page_size_a = ALIGN_TO(page_size_a_arg, alignment_a);
-    const uint32_t page_size_b = ALIGN_TO(page_size_b_arg, alignment_b);
+    const uint32_t page_size_a = align(page_size_a_arg, alignment_a);
+    const uint32_t page_size_b = align(page_size_b_arg, alignment_b);
 
     const auto src = TensorAccessor(src_args, src_addr, page_size_a);
     const auto src_b = TensorAccessor(src_b_args, src_addr_b, page_size_b);
@@ -91,63 +87,57 @@ void kernel_main() {
     uint32_t row_blocks_pushed = 0;
 
     for (uint32_t nd = start_nd; nd < outND && row_blocks_pushed < dst_num_tiles; ++nd, start_d = 0) {
-        uint32_t ptr_nd_a = nd * s_nd_a;
-        uint32_t ptr_nd_b = nd * s_nd_b;
+        const uint32_t ptr_nd_a = nd * s_nd_a;
+        const uint32_t ptr_nd_b = nd * s_nd_b;
 
         for (uint32_t d = start_d; d < outD && row_blocks_pushed < dst_num_tiles; ++d, start_n = 0) {
-            uint32_t ptr_d_a = ptr_nd_a + d * s_d_a;
-            uint32_t ptr_d_b = ptr_nd_b + d * s_d_b;
+            const uint32_t ptr_d_a = ptr_nd_a + d * s_d_a;
+            const uint32_t ptr_d_b = ptr_nd_b + d * s_d_b;
 
             for (uint32_t n = start_n; n < outN && row_blocks_pushed < dst_num_tiles; ++n, start_c = 0) {
-                uint32_t ptr_n_a = ptr_d_a + n * s_n_a;
-                uint32_t ptr_n_b = ptr_d_b + n * s_n_b;
+                const uint32_t ptr_n_a = ptr_d_a + n * s_n_a;
+                const uint32_t ptr_n_b = ptr_d_b + n * s_n_b;
 
                 for (uint32_t c = start_c; c < outC && row_blocks_pushed < dst_num_tiles; ++c, start_th = 0) {
-                    uint32_t ptr_c_a = ptr_n_a + c * s_c_a;
-                    uint32_t ptr_c_b = ptr_n_b + c * s_c_b;
+                    const uint32_t ptr_c_a = ptr_n_a + c * s_c_a;
+                    const uint32_t ptr_c_b = ptr_n_b + c * s_c_b;
 
                     for (uint32_t th = start_th; th < outHt && row_blocks_pushed < dst_num_tiles; th += rows_per_tile) {
-                        uint32_t rows_remaining_in_block = outHt - th;
-                        uint32_t limit =
+                        const uint32_t rows_remaining_in_block = outHt - th;
+                        const uint32_t limit =
                             (rows_remaining_in_block < rows_per_tile) ? rows_remaining_in_block : rows_per_tile;
 
-                        uint32_t row_block_a = ptr_c_a + th * s_h_a;
-                        uint32_t row_block_b = ptr_c_b + th * s_h_b;
+                        const uint32_t row_block_a = ptr_c_a + th * s_h_a;
+                        const uint32_t row_block_b = ptr_c_b + th * s_h_b;
 
                         for (uint32_t t_i = 0; t_i < tiles_per_row; ++t_i) {
-                            uint32_t t_offset = t_i * stride_size_bytes;
-
-                            uint32_t bytes_left_in_row = row_width_bytes - t_offset;
-                            if (bytes_left_in_row > row_width_bytes) {
-                                bytes_left_in_row = 0;
-                            }
-
-                            uint32_t current_chunk_bytes =
+                            const uint32_t current_chunk_offset = t_i * stride_size_bytes;
+                            const uint32_t bytes_left_in_row = row_width_bytes - current_chunk_offset;
+                            const uint32_t current_chunk_bytes =
                                 (stride_size_bytes < bytes_left_in_row) ? stride_size_bytes : bytes_left_in_row;
-
-                            uint32_t read_len_a = ALIGN_TO(current_chunk_bytes, alignment_a);
-                            uint32_t read_len_b = ALIGN_TO(current_chunk_bytes, alignment_b);
+                            const uint32_t current_read_len_a = align(current_chunk_bytes, alignment_a);
+                            const uint32_t current_read_len_b = align(current_chunk_bytes, alignment_b);
 
                             cb_reserve_back(cb_id_src, 1);
-                            uint32_t l1_write_addr_src = get_write_ptr(cb_id_src);
+                            const uint32_t l1_write_addr_src = get_write_ptr(cb_id_src);
 
                             cb_reserve_back(cb_id_src_b, 1);
-                            uint32_t l1_write_addr_src_b = get_write_ptr(cb_id_src_b);
+                            const uint32_t l1_write_addr_src_b = get_write_ptr(cb_id_src_b);
 
                             uint32_t curr_l1_a = l1_write_addr_src;
                             for (uint32_t k = 0; k < limit; ++k) {
-                                uint32_t row_idx_a = row_block_a + k * s_h_a;
-                                uint64_t addr_a = get_noc_addr(row_idx_a, src) + t_offset;
-                                noc_async_read(addr_a, curr_l1_a, read_len_a);
+                                const uint32_t row_idx_a = row_block_a + k * s_h_a;
+                                const uint64_t addr_a = get_noc_addr(row_idx_a, src) + current_chunk_offset;
+                                noc_async_read(addr_a, curr_l1_a, current_read_len_a);
                                 curr_l1_a += current_chunk_bytes;
                             }
                             noc_async_read_barrier();
 
                             uint32_t curr_l1_b = l1_write_addr_src_b;
                             for (uint32_t k = 0; k < limit; ++k) {
-                                uint32_t row_idx_b = row_block_b + k * s_h_b;
-                                uint64_t addr_b = get_noc_addr(row_idx_b, src_b) + t_offset;
-                                noc_async_read(addr_b, curr_l1_b, read_len_b);
+                                const uint32_t row_idx_b = row_block_b + k * s_h_b;
+                                const uint64_t addr_b = get_noc_addr(row_idx_b, src_b) + current_chunk_offset;
+                                noc_async_read(addr_b, curr_l1_b, current_read_len_b);
                                 curr_l1_b += current_chunk_bytes;
                             }
                             noc_async_read_barrier();

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_no_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_no_bcast.cpp
@@ -1,0 +1,165 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+
+#include "api/dataflow/dataflow_api.h"
+
+#define ALIGN_TO(len, align) (((len) + (align) - 1) / (align)) * (align)
+
+void kernel_main() {
+    uint32_t index = 0;
+    const uint32_t src_addr = get_arg_val<uint32_t>(index++);
+    const uint32_t dst_num_tiles = get_arg_val<uint32_t>(index++);
+
+    const uint32_t aD = get_arg_val<uint32_t>(index++);
+    const uint32_t aN = get_arg_val<uint32_t>(index++);
+    const uint32_t aC = get_arg_val<uint32_t>(index++);
+    const uint32_t aHt = get_arg_val<uint32_t>(index++);
+    const uint32_t aND = get_arg_val<uint32_t>(index++);
+
+    const uint32_t src_addr_b = get_arg_val<uint32_t>(index++);
+    const uint32_t bD = get_arg_val<uint32_t>(index++);
+    const uint32_t bN = get_arg_val<uint32_t>(index++);
+    const uint32_t bC = get_arg_val<uint32_t>(index++);
+    const uint32_t bHt = get_arg_val<uint32_t>(index++);
+    const uint32_t bND = get_arg_val<uint32_t>(index++);
+
+    const uint32_t cHt = get_arg_val<uint32_t>(index++);
+    const uint32_t cC = get_arg_val<uint32_t>(index++);
+    const uint32_t cND = get_arg_val<uint32_t>(index++);
+    const uint32_t current_block_start = get_arg_val<uint32_t>(index++);
+    const uint32_t rows_per_tile = get_arg_val<uint32_t>(index++);
+    const uint32_t row_width_elements = get_arg_val<uint32_t>(index++);
+    const uint32_t page_size_a_arg = get_arg_val<uint32_t>(index++);
+    const uint32_t page_size_b_arg = get_arg_val<uint32_t>(index++);
+    const uint32_t alignment_a = get_arg_val<uint32_t>(index++);
+    const uint32_t alignment_b = get_arg_val<uint32_t>(index++);
+    const uint32_t tiles_per_row = get_arg_val<uint32_t>(index++);
+    const uint32_t stride_size_bytes = get_arg_val<uint32_t>(index++);
+    const uint32_t packed_scalar = get_arg_val<uint32_t>(index++);
+
+    (void)packed_scalar;
+
+    constexpr auto cb_id_src = tt::CBIndex::c_0;
+    constexpr auto cb_id_src_b = tt::CBIndex::c_1;
+    constexpr auto src_args = TensorAccessorArgs<0>();
+    constexpr auto src_b_args = TensorAccessorArgs<src_args.next_compile_time_args_offset()>();
+
+    constexpr uint32_t src_tile_bytes = get_tile_size(cb_id_src);
+    const uint32_t tile_hw = get_tile_hw(cb_id_src);
+    constexpr uint32_t element_size = src_tile_bytes / tile_hw;
+    const uint32_t row_width_bytes = row_width_elements * element_size;
+
+    const uint32_t outHt = cHt;
+    const uint32_t outC = cC;
+    const uint32_t outN = (aN > bN) ? aN : bN;
+    const uint32_t outD = (aD > bD) ? aD : bD;
+    const uint32_t outND = cND;
+
+    const uint32_t page_size_a = ALIGN_TO(page_size_a_arg, alignment_a);
+    const uint32_t page_size_b = ALIGN_TO(page_size_b_arg, alignment_b);
+
+    const auto src = TensorAccessor(src_args, src_addr, page_size_a);
+    const auto src_b = TensorAccessor(src_b_args, src_addr_b, page_size_b);
+
+    const uint32_t s_h_a = (aHt == 1) ? 0 : 1;
+    const uint32_t s_c_a = (aC == 1) ? 0 : aHt;
+    const uint32_t s_n_a = (aN == 1) ? 0 : aC * aHt;
+    const uint32_t s_d_a = (aD == 1) ? 0 : aN * aC * aHt;
+    const uint32_t s_nd_a = (aND == 1) ? 0 : aD * aN * aC * aHt;
+
+    const uint32_t s_h_b = (bHt == 1) ? 0 : 1;
+    const uint32_t s_c_b = (bC == 1) ? 0 : bHt;
+    const uint32_t s_n_b = (bN == 1) ? 0 : bC * bHt;
+    const uint32_t s_d_b = (bD == 1) ? 0 : bN * bC * bHt;
+    const uint32_t s_nd_b = (bND == 1) ? 0 : bD * bN * bC * bHt;
+
+    const uint32_t row_blocks_per_channel = (outHt + rows_per_tile - 1) / rows_per_tile;
+
+    uint32_t tmp = current_block_start;
+    uint32_t start_th = (tmp % row_blocks_per_channel) * rows_per_tile;
+    tmp /= row_blocks_per_channel;
+    uint32_t start_c = tmp % outC;
+    tmp /= outC;
+    uint32_t start_n = tmp % outN;
+    tmp /= outN;
+    uint32_t start_d = tmp % outD;
+    tmp /= outD;
+    uint32_t start_nd = tmp;
+
+    uint32_t row_blocks_pushed = 0;
+
+    for (uint32_t nd = start_nd; nd < outND && row_blocks_pushed < dst_num_tiles; ++nd, start_d = 0) {
+        uint32_t ptr_nd_a = nd * s_nd_a;
+        uint32_t ptr_nd_b = nd * s_nd_b;
+
+        for (uint32_t d = start_d; d < outD && row_blocks_pushed < dst_num_tiles; ++d, start_n = 0) {
+            uint32_t ptr_d_a = ptr_nd_a + d * s_d_a;
+            uint32_t ptr_d_b = ptr_nd_b + d * s_d_b;
+
+            for (uint32_t n = start_n; n < outN && row_blocks_pushed < dst_num_tiles; ++n, start_c = 0) {
+                uint32_t ptr_n_a = ptr_d_a + n * s_n_a;
+                uint32_t ptr_n_b = ptr_d_b + n * s_n_b;
+
+                for (uint32_t c = start_c; c < outC && row_blocks_pushed < dst_num_tiles; ++c, start_th = 0) {
+                    uint32_t ptr_c_a = ptr_n_a + c * s_c_a;
+                    uint32_t ptr_c_b = ptr_n_b + c * s_c_b;
+
+                    for (uint32_t th = start_th; th < outHt && row_blocks_pushed < dst_num_tiles; th += rows_per_tile) {
+                        uint32_t rows_remaining_in_block = outHt - th;
+                        uint32_t limit =
+                            (rows_remaining_in_block < rows_per_tile) ? rows_remaining_in_block : rows_per_tile;
+
+                        uint32_t row_block_a = ptr_c_a + th * s_h_a;
+                        uint32_t row_block_b = ptr_c_b + th * s_h_b;
+
+                        for (uint32_t t_i = 0; t_i < tiles_per_row; ++t_i) {
+                            uint32_t t_offset = t_i * stride_size_bytes;
+
+                            uint32_t bytes_left_in_row = row_width_bytes - t_offset;
+                            if (bytes_left_in_row > row_width_bytes) {
+                                bytes_left_in_row = 0;
+                            }
+
+                            uint32_t current_chunk_bytes =
+                                (stride_size_bytes < bytes_left_in_row) ? stride_size_bytes : bytes_left_in_row;
+
+                            uint32_t read_len_a = ALIGN_TO(current_chunk_bytes, alignment_a);
+                            uint32_t read_len_b = ALIGN_TO(current_chunk_bytes, alignment_b);
+
+                            cb_reserve_back(cb_id_src, 1);
+                            uint32_t l1_write_addr_src = get_write_ptr(cb_id_src);
+
+                            cb_reserve_back(cb_id_src_b, 1);
+                            uint32_t l1_write_addr_src_b = get_write_ptr(cb_id_src_b);
+
+                            uint32_t curr_l1_a = l1_write_addr_src;
+                            for (uint32_t k = 0; k < limit; ++k) {
+                                uint32_t row_idx_a = row_block_a + k * s_h_a;
+                                uint64_t addr_a = get_noc_addr(row_idx_a, src) + t_offset;
+                                noc_async_read(addr_a, curr_l1_a, read_len_a);
+                                curr_l1_a += current_chunk_bytes;
+                            }
+                            noc_async_read_barrier();
+
+                            uint32_t curr_l1_b = l1_write_addr_src_b;
+                            for (uint32_t k = 0; k < limit; ++k) {
+                                uint32_t row_idx_b = row_block_b + k * s_h_b;
+                                uint64_t addr_b = get_noc_addr(row_idx_b, src_b) + t_offset;
+                                noc_async_read(addr_b, curr_l1_b, read_len_b);
+                                curr_l1_b += current_chunk_bytes;
+                            }
+                            noc_async_read_barrier();
+
+                            cb_push_back(cb_id_src, 1);
+                            cb_push_back(cb_id_src_b, 1);
+                        }
+
+                        row_blocks_pushed++;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_row_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_row_bcast.cpp
@@ -1,0 +1,180 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+
+#include "api/dataflow/dataflow_api.h"
+#include "ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/fill_tile_utils.hpp"
+
+#define ALIGN_TO(len, align) (((len) + (align) - 1) / (align)) * (align)
+
+void kernel_main() {
+    uint32_t index = 0;
+    const uint32_t src_addr = get_arg_val<uint32_t>(index++);
+    const uint32_t dst_num_tiles = get_arg_val<uint32_t>(index++);
+
+    const uint32_t aD = get_arg_val<uint32_t>(index++);
+    const uint32_t aN = get_arg_val<uint32_t>(index++);
+    const uint32_t aC = get_arg_val<uint32_t>(index++);
+    const uint32_t aHt = get_arg_val<uint32_t>(index++);
+    const uint32_t aND = get_arg_val<uint32_t>(index++);
+
+    const uint32_t src_addr_b = get_arg_val<uint32_t>(index++);
+    const uint32_t bD = get_arg_val<uint32_t>(index++);
+    const uint32_t bN = get_arg_val<uint32_t>(index++);
+    const uint32_t bC = get_arg_val<uint32_t>(index++);
+    const uint32_t bHt = get_arg_val<uint32_t>(index++);
+    const uint32_t bND = get_arg_val<uint32_t>(index++);
+
+    const uint32_t cHt = get_arg_val<uint32_t>(index++);
+    const uint32_t cC = get_arg_val<uint32_t>(index++);
+    const uint32_t cND = get_arg_val<uint32_t>(index++);
+    const uint32_t current_block_start = get_arg_val<uint32_t>(index++);
+    const uint32_t rows_per_tile = get_arg_val<uint32_t>(index++);
+    const uint32_t row_width_elements = get_arg_val<uint32_t>(index++);
+    const uint32_t page_size_a_arg = get_arg_val<uint32_t>(index++);
+    const uint32_t page_size_b_arg = get_arg_val<uint32_t>(index++);
+    const uint32_t alignment_a = get_arg_val<uint32_t>(index++);
+    const uint32_t alignment_b = get_arg_val<uint32_t>(index++);
+    const uint32_t tiles_per_row = get_arg_val<uint32_t>(index++);
+    const uint32_t stride_size_bytes = get_arg_val<uint32_t>(index++);
+    const uint32_t packed_scalar = get_arg_val<uint32_t>(index++);
+
+    (void)packed_scalar;
+
+    constexpr auto cb_id_src = tt::CBIndex::c_0;
+    constexpr auto cb_id_src_b = tt::CBIndex::c_1;
+    constexpr auto src_args = TensorAccessorArgs<0>();
+    constexpr auto src_b_args = TensorAccessorArgs<src_args.next_compile_time_args_offset()>();
+
+    constexpr uint32_t src_tile_bytes = get_tile_size(cb_id_src);
+    const uint32_t tile_hw = get_tile_hw(cb_id_src);
+    constexpr uint32_t element_size = src_tile_bytes / tile_hw;
+    const uint32_t row_width_bytes = row_width_elements * element_size;
+
+    const uint32_t outHt = cHt;
+    const uint32_t outC = cC;
+    const uint32_t outN = (aN > bN) ? aN : bN;
+    const uint32_t outD = (aD > bD) ? aD : bD;
+    const uint32_t outND = cND;
+
+    const uint32_t page_size_a = ALIGN_TO(page_size_a_arg, alignment_a);
+    const uint32_t page_size_b = ALIGN_TO(page_size_b_arg, alignment_b);
+
+    const auto src = TensorAccessor(src_args, src_addr, page_size_a);
+    const auto src_b = TensorAccessor(src_b_args, src_addr_b, page_size_b);
+
+    const uint32_t s_h_a = (aHt == 1) ? 0 : 1;
+    const uint32_t s_c_a = (aC == 1) ? 0 : aHt;
+    const uint32_t s_n_a = (aN == 1) ? 0 : aC * aHt;
+    const uint32_t s_d_a = (aD == 1) ? 0 : aN * aC * aHt;
+    const uint32_t s_nd_a = (aND == 1) ? 0 : aD * aN * aC * aHt;
+
+    const uint32_t s_h_b = (bHt == 1) ? 0 : 1;
+    const uint32_t s_c_b = (bC == 1) ? 0 : bHt;
+    const uint32_t s_n_b = (bN == 1) ? 0 : bC * bHt;
+    const uint32_t s_d_b = (bD == 1) ? 0 : bN * bC * bHt;
+    const uint32_t s_nd_b = (bND == 1) ? 0 : bD * bN * bC * bHt;
+
+    const uint32_t row_blocks_per_channel = (outHt + rows_per_tile - 1) / rows_per_tile;
+
+    uint32_t tmp = current_block_start;
+    uint32_t start_th = (tmp % row_blocks_per_channel) * rows_per_tile;
+    tmp /= row_blocks_per_channel;
+    uint32_t start_c = tmp % outC;
+    tmp /= outC;
+    uint32_t start_n = tmp % outN;
+    tmp /= outN;
+    uint32_t start_d = tmp % outD;
+    tmp /= outD;
+    uint32_t start_nd = tmp;
+
+    uint32_t row_blocks_pushed = 0;
+
+    for (uint32_t nd = start_nd; nd < outND && row_blocks_pushed < dst_num_tiles; ++nd, start_d = 0) {
+        uint32_t ptr_nd_a = nd * s_nd_a;
+        uint32_t ptr_nd_b = nd * s_nd_b;
+
+        for (uint32_t d = start_d; d < outD && row_blocks_pushed < dst_num_tiles; ++d, start_n = 0) {
+            uint32_t ptr_d_a = ptr_nd_a + d * s_d_a;
+            uint32_t ptr_d_b = ptr_nd_b + d * s_d_b;
+
+            for (uint32_t n = start_n; n < outN && row_blocks_pushed < dst_num_tiles; ++n, start_c = 0) {
+                uint32_t ptr_n_a = ptr_d_a + n * s_n_a;
+                uint32_t ptr_n_b = ptr_d_b + n * s_n_b;
+
+                for (uint32_t c = start_c; c < outC && row_blocks_pushed < dst_num_tiles; ++c, start_th = 0) {
+                    uint32_t ptr_c_a = ptr_n_a + c * s_c_a;
+                    uint32_t ptr_c_b = ptr_n_b + c * s_c_b;
+
+                    for (uint32_t th = start_th; th < outHt && row_blocks_pushed < dst_num_tiles; th += rows_per_tile) {
+                        uint32_t rows_remaining_in_block = outHt - th;
+                        uint32_t limit =
+                            (rows_remaining_in_block < rows_per_tile) ? rows_remaining_in_block : rows_per_tile;
+
+                        uint32_t row_block_a = ptr_c_a + th * s_h_a;
+                        uint32_t row_block_b = ptr_c_b + th * s_h_b;
+
+                        for (uint32_t t_i = 0; t_i < tiles_per_row; ++t_i) {
+                            uint32_t t_offset = t_i * stride_size_bytes;
+                            uint32_t bytes_left_in_row = row_width_bytes - t_offset;
+                            if (bytes_left_in_row > row_width_bytes) {
+                                bytes_left_in_row = 0;
+                            }
+
+                            uint32_t current_chunk_bytes =
+                                (stride_size_bytes < bytes_left_in_row) ? stride_size_bytes : bytes_left_in_row;
+                            uint32_t current_chunk_elements = current_chunk_bytes / element_size;
+
+                            uint32_t read_len_a = ALIGN_TO(current_chunk_bytes, alignment_a);
+                            uint32_t read_len_b = ALIGN_TO(current_chunk_bytes, alignment_b);
+
+                            cb_reserve_back(cb_id_src, 1);
+                            uint32_t l1_write_addr_src = get_write_ptr(cb_id_src);
+
+                            cb_reserve_back(cb_id_src_b, 1);
+                            uint32_t l1_write_addr_src_b = get_write_ptr(cb_id_src_b);
+
+#if SRC_BCAST
+                            uint64_t addr_a = get_noc_addr(row_block_a, src) + t_offset;
+                            noc_async_read(addr_a, l1_write_addr_src, read_len_a);
+
+                            uint32_t curr_l1_b = l1_write_addr_src_b;
+                            for (uint32_t k = 0; k < limit; ++k) {
+                                uint32_t row_idx_b = row_block_b + k * s_h_b;
+                                uint64_t addr_b = get_noc_addr(row_idx_b, src_b) + t_offset;
+                                noc_async_read(addr_b, curr_l1_b, read_len_b);
+                                curr_l1_b += current_chunk_bytes;
+                            }
+#else
+                            uint32_t curr_l1_a = l1_write_addr_src;
+                            for (uint32_t k = 0; k < limit; ++k) {
+                                uint32_t row_idx_a = row_block_a + k * s_h_a;
+                                uint64_t addr_a = get_noc_addr(row_idx_a, src) + t_offset;
+                                noc_async_read(addr_a, curr_l1_a, read_len_a);
+                                curr_l1_a += current_chunk_bytes;
+                            }
+
+                            uint64_t addr_b = get_noc_addr(row_block_b, src_b) + t_offset;
+                            noc_async_read(addr_b, l1_write_addr_src_b, read_len_b);
+#endif
+
+                            noc_async_read_barrier();
+
+#if SRC_BCAST
+                            FILL_TILE_WITH_FIRST_ROW_RM(l1_write_addr_src, current_chunk_elements, limit);
+#else
+                            FILL_TILE_WITH_FIRST_ROW_RM(l1_write_addr_src_b, current_chunk_elements, limit);
+#endif
+
+                            cb_push_back(cb_id_src, 1);
+                            cb_push_back(cb_id_src_b, 1);
+                        }
+
+                        row_blocks_pushed++;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_row_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_row_bcast.cpp
@@ -1,12 +1,11 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 // SPDX-License-Identifier: Apache-2.0
 
 #include <stdint.h>
 
+#include "api/alignment.h"
 #include "api/dataflow/dataflow_api.h"
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/fill_tile_utils.hpp"
-
-#define ALIGN_TO(len, align) (((len) + (align) - 1) / (align)) * (align)
 
 void kernel_main() {
     uint32_t index = 0;
@@ -38,9 +37,6 @@ void kernel_main() {
     const uint32_t alignment_b = get_arg_val<uint32_t>(index++);
     const uint32_t tiles_per_row = get_arg_val<uint32_t>(index++);
     const uint32_t stride_size_bytes = get_arg_val<uint32_t>(index++);
-    const uint32_t packed_scalar = get_arg_val<uint32_t>(index++);
-
-    (void)packed_scalar;
 
     constexpr auto cb_id_src = tt::CBIndex::c_0;
     constexpr auto cb_id_src_b = tt::CBIndex::c_1;
@@ -48,7 +44,7 @@ void kernel_main() {
     constexpr auto src_b_args = TensorAccessorArgs<src_args.next_compile_time_args_offset()>();
 
     constexpr uint32_t src_tile_bytes = get_tile_size(cb_id_src);
-    const uint32_t tile_hw = get_tile_hw(cb_id_src);
+    constexpr uint32_t tile_hw = get_tile_hw(cb_id_src);
     constexpr uint32_t element_size = src_tile_bytes / tile_hw;
     const uint32_t row_width_bytes = row_width_elements * element_size;
 
@@ -58,8 +54,13 @@ void kernel_main() {
     const uint32_t outD = (aD > bD) ? aD : bD;
     const uint32_t outND = cND;
 
-    const uint32_t page_size_a = ALIGN_TO(page_size_a_arg, alignment_a);
-    const uint32_t page_size_b = ALIGN_TO(page_size_b_arg, alignment_b);
+#if SRC_BCAST
+    const uint32_t page_size_a = align(page_size_a_arg, alignment_a);
+    const uint32_t page_size_b = align(page_size_b_arg, alignment_b);
+#else
+    const uint32_t page_size_a = align(page_size_a_arg, alignment_a);
+    const uint32_t page_size_b = align(page_size_b_arg, alignment_b);
+#endif
 
     const auto src = TensorAccessor(src_args, src_addr, page_size_a);
     const auto src_b = TensorAccessor(src_b_args, src_addr_b, page_size_b);
@@ -92,78 +93,70 @@ void kernel_main() {
     uint32_t row_blocks_pushed = 0;
 
     for (uint32_t nd = start_nd; nd < outND && row_blocks_pushed < dst_num_tiles; ++nd, start_d = 0) {
-        uint32_t ptr_nd_a = nd * s_nd_a;
-        uint32_t ptr_nd_b = nd * s_nd_b;
+        const uint32_t ptr_nd_a = nd * s_nd_a;
+        const uint32_t ptr_nd_b = nd * s_nd_b;
 
         for (uint32_t d = start_d; d < outD && row_blocks_pushed < dst_num_tiles; ++d, start_n = 0) {
-            uint32_t ptr_d_a = ptr_nd_a + d * s_d_a;
-            uint32_t ptr_d_b = ptr_nd_b + d * s_d_b;
+            const uint32_t ptr_d_a = ptr_nd_a + d * s_d_a;
+            const uint32_t ptr_d_b = ptr_nd_b + d * s_d_b;
 
             for (uint32_t n = start_n; n < outN && row_blocks_pushed < dst_num_tiles; ++n, start_c = 0) {
-                uint32_t ptr_n_a = ptr_d_a + n * s_n_a;
-                uint32_t ptr_n_b = ptr_d_b + n * s_n_b;
+                const uint32_t ptr_n_a = ptr_d_a + n * s_n_a;
+                const uint32_t ptr_n_b = ptr_d_b + n * s_n_b;
 
                 for (uint32_t c = start_c; c < outC && row_blocks_pushed < dst_num_tiles; ++c, start_th = 0) {
-                    uint32_t ptr_c_a = ptr_n_a + c * s_c_a;
-                    uint32_t ptr_c_b = ptr_n_b + c * s_c_b;
+                    const uint32_t ptr_c_a = ptr_n_a + c * s_c_a;
+                    const uint32_t ptr_c_b = ptr_n_b + c * s_c_b;
 
                     for (uint32_t th = start_th; th < outHt && row_blocks_pushed < dst_num_tiles; th += rows_per_tile) {
-                        uint32_t rows_remaining_in_block = outHt - th;
-                        uint32_t limit =
+                        const uint32_t rows_remaining_in_block = outHt - th;
+                        const uint32_t limit =
                             (rows_remaining_in_block < rows_per_tile) ? rows_remaining_in_block : rows_per_tile;
 
-                        uint32_t row_block_a = ptr_c_a + th * s_h_a;
-                        uint32_t row_block_b = ptr_c_b + th * s_h_b;
+                        const uint32_t row_block_a = ptr_c_a + th * s_h_a;
+                        const uint32_t row_block_b = ptr_c_b + th * s_h_b;
 
                         for (uint32_t t_i = 0; t_i < tiles_per_row; ++t_i) {
-                            uint32_t t_offset = t_i * stride_size_bytes;
-                            uint32_t bytes_left_in_row = row_width_bytes - t_offset;
-                            if (bytes_left_in_row > row_width_bytes) {
-                                bytes_left_in_row = 0;
-                            }
-
-                            uint32_t current_chunk_bytes =
+                            const uint32_t current_chunk_offset = t_i * stride_size_bytes;
+                            const uint32_t bytes_left_in_row = row_width_bytes - current_chunk_offset;
+                            const uint32_t current_chunk_bytes =
                                 (stride_size_bytes < bytes_left_in_row) ? stride_size_bytes : bytes_left_in_row;
-                            uint32_t current_chunk_elements = current_chunk_bytes / element_size;
-
-                            uint32_t read_len_a = ALIGN_TO(current_chunk_bytes, alignment_a);
-                            uint32_t read_len_b = ALIGN_TO(current_chunk_bytes, alignment_b);
+                            const uint32_t current_chunk_elements = current_chunk_bytes / element_size;
+                            const uint32_t current_read_len_a = align(current_chunk_bytes, alignment_a);
+                            const uint32_t current_read_len_b = align(current_chunk_bytes, alignment_b);
 
                             cb_reserve_back(cb_id_src, 1);
-                            uint32_t l1_write_addr_src = get_write_ptr(cb_id_src);
+                            const uint32_t l1_write_addr_src = get_write_ptr(cb_id_src);
 
                             cb_reserve_back(cb_id_src_b, 1);
-                            uint32_t l1_write_addr_src_b = get_write_ptr(cb_id_src_b);
+                            const uint32_t l1_write_addr_src_b = get_write_ptr(cb_id_src_b);
 
 #if SRC_BCAST
-                            uint64_t addr_a = get_noc_addr(row_block_a, src) + t_offset;
-                            noc_async_read(addr_a, l1_write_addr_src, read_len_a);
+                            const uint64_t addr_a = get_noc_addr(row_block_a, src) + current_chunk_offset;
+                            noc_async_read(addr_a, l1_write_addr_src, current_read_len_a);
 
                             uint32_t curr_l1_b = l1_write_addr_src_b;
                             for (uint32_t k = 0; k < limit; ++k) {
-                                uint32_t row_idx_b = row_block_b + k * s_h_b;
-                                uint64_t addr_b = get_noc_addr(row_idx_b, src_b) + t_offset;
-                                noc_async_read(addr_b, curr_l1_b, read_len_b);
+                                const uint32_t row_idx_b = row_block_b + k * s_h_b;
+                                const uint64_t addr_b = get_noc_addr(row_idx_b, src_b) + current_chunk_offset;
+                                noc_async_read(addr_b, curr_l1_b, current_read_len_b);
                                 curr_l1_b += current_chunk_bytes;
                             }
+                            noc_async_read_barrier();
+                            FILL_TILE_WITH_FIRST_ROW_RM(l1_write_addr_src, current_chunk_elements, limit);
 #else
                             uint32_t curr_l1_a = l1_write_addr_src;
                             for (uint32_t k = 0; k < limit; ++k) {
-                                uint32_t row_idx_a = row_block_a + k * s_h_a;
-                                uint64_t addr_a = get_noc_addr(row_idx_a, src) + t_offset;
-                                noc_async_read(addr_a, curr_l1_a, read_len_a);
+                                const uint32_t row_idx_a = row_block_a + k * s_h_a;
+                                const uint64_t addr_a = get_noc_addr(row_idx_a, src) + current_chunk_offset;
+                                noc_async_read(addr_a, curr_l1_a, current_read_len_a);
                                 curr_l1_a += current_chunk_bytes;
                             }
 
-                            uint64_t addr_b = get_noc_addr(row_block_b, src_b) + t_offset;
-                            noc_async_read(addr_b, l1_write_addr_src_b, read_len_b);
-#endif
+                            const uint64_t addr_b = get_noc_addr(row_block_b, src_b) + current_chunk_offset;
+                            noc_async_read(addr_b, l1_write_addr_src_b, current_read_len_b);
 
                             noc_async_read_barrier();
-
-#if SRC_BCAST
-                            FILL_TILE_WITH_FIRST_ROW_RM(l1_write_addr_src, current_chunk_elements, limit);
-#else
                             FILL_TILE_WITH_FIRST_ROW_RM(l1_write_addr_src_b, current_chunk_elements, limit);
 #endif
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_row_col_mixed_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_row_col_mixed_bcast.cpp
@@ -1,0 +1,220 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+
+#include "api/dataflow/dataflow_api.h"
+#include "ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/fill_tile_utils.hpp"
+
+#define ALIGN_TO(len, align) (((len) + (align) - 1) / (align)) * (align)
+
+namespace {
+inline void copy_one_element(uint32_t dst_l1_addr, uint32_t src_l1_addr, uint32_t element_size) {
+    if (element_size == 1) {
+        auto* src_ptr = reinterpret_cast<volatile tt_l1_ptr uint8_t*>(src_l1_addr);
+        auto* dst_ptr = reinterpret_cast<volatile tt_l1_ptr uint8_t*>(dst_l1_addr);
+        dst_ptr[0] = src_ptr[0];
+    } else if (element_size == 2) {
+        auto* src_ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(src_l1_addr);
+        auto* dst_ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(dst_l1_addr);
+        dst_ptr[0] = src_ptr[0];
+    } else {
+        auto* src_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(src_l1_addr);
+        auto* dst_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(dst_l1_addr);
+        dst_ptr[0] = src_ptr[0];
+    }
+}
+}  // namespace
+
+void kernel_main() {
+    uint32_t index = 0;
+    const uint32_t src_addr = get_arg_val<uint32_t>(index++);
+    const uint32_t dst_num_tiles = get_arg_val<uint32_t>(index++);
+
+    const uint32_t aD = get_arg_val<uint32_t>(index++);
+    const uint32_t aN = get_arg_val<uint32_t>(index++);
+    const uint32_t aC = get_arg_val<uint32_t>(index++);
+    const uint32_t aHt = get_arg_val<uint32_t>(index++);
+    const uint32_t aND = get_arg_val<uint32_t>(index++);
+
+    const uint32_t src_addr_b = get_arg_val<uint32_t>(index++);
+    const uint32_t bD = get_arg_val<uint32_t>(index++);
+    const uint32_t bN = get_arg_val<uint32_t>(index++);
+    const uint32_t bC = get_arg_val<uint32_t>(index++);
+    const uint32_t bHt = get_arg_val<uint32_t>(index++);
+    const uint32_t bND = get_arg_val<uint32_t>(index++);
+
+    const uint32_t cHt = get_arg_val<uint32_t>(index++);
+    const uint32_t cC = get_arg_val<uint32_t>(index++);
+    const uint32_t cND = get_arg_val<uint32_t>(index++);
+    const uint32_t current_block_start = get_arg_val<uint32_t>(index++);
+    const uint32_t rows_per_tile = get_arg_val<uint32_t>(index++);
+    const uint32_t row_width_elements = get_arg_val<uint32_t>(index++);
+    const uint32_t page_size_a_arg = get_arg_val<uint32_t>(index++);
+    const uint32_t page_size_b_arg = get_arg_val<uint32_t>(index++);
+    const uint32_t alignment_a = get_arg_val<uint32_t>(index++);
+    const uint32_t alignment_b = get_arg_val<uint32_t>(index++);
+    const uint32_t tiles_per_row = get_arg_val<uint32_t>(index++);
+    const uint32_t stride_size_bytes = get_arg_val<uint32_t>(index++);
+    const uint32_t packed_scalar = get_arg_val<uint32_t>(index++);
+
+    (void)packed_scalar;
+
+    constexpr auto cb_id_src = tt::CBIndex::c_0;
+    constexpr auto cb_id_src_b = tt::CBIndex::c_1;
+    constexpr auto src_args = TensorAccessorArgs<0>();
+    constexpr auto src_b_args = TensorAccessorArgs<src_args.next_compile_time_args_offset()>();
+
+    constexpr uint32_t src_tile_bytes = get_tile_size(cb_id_src);
+    const uint32_t tile_hw = get_tile_hw(cb_id_src);
+    constexpr uint32_t element_size = src_tile_bytes / tile_hw;
+    const uint32_t element_size_aligned_a = ALIGN_TO(element_size, alignment_a);
+    const uint32_t element_size_aligned_b = ALIGN_TO(element_size, alignment_b);
+    const uint32_t row_width_bytes = row_width_elements * element_size;
+
+    const uint32_t outHt = cHt;
+    const uint32_t outC = cC;
+    const uint32_t outN = (aN > bN) ? aN : bN;
+    const uint32_t outD = (aD > bD) ? aD : bD;
+    const uint32_t outND = cND;
+
+#if SRC_BCAST_ROW_B
+    const uint32_t page_size_a = element_size;
+    const uint32_t page_size_b = ALIGN_TO(page_size_b_arg, alignment_b);
+#else
+    const uint32_t page_size_a = ALIGN_TO(page_size_a_arg, alignment_a);
+    const uint32_t page_size_b = element_size;
+#endif
+
+    const auto src = TensorAccessor(src_args, src_addr, page_size_a);
+    const auto src_b = TensorAccessor(src_b_args, src_addr_b, page_size_b);
+
+    const uint32_t s_h_a = (aHt == 1) ? 0 : 1;
+    const uint32_t s_c_a = (aC == 1) ? 0 : aHt;
+    const uint32_t s_n_a = (aN == 1) ? 0 : aC * aHt;
+    const uint32_t s_d_a = (aD == 1) ? 0 : aN * aC * aHt;
+    const uint32_t s_nd_a = (aND == 1) ? 0 : aD * aN * aC * aHt;
+
+    const uint32_t s_h_b = (bHt == 1) ? 0 : 1;
+    const uint32_t s_c_b = (bC == 1) ? 0 : bHt;
+    const uint32_t s_n_b = (bN == 1) ? 0 : bC * bHt;
+    const uint32_t s_d_b = (bD == 1) ? 0 : bN * bC * bHt;
+    const uint32_t s_nd_b = (bND == 1) ? 0 : bD * bN * bC * bHt;
+
+    const uint32_t row_blocks_per_channel = (outHt + rows_per_tile - 1) / rows_per_tile;
+
+    uint32_t tmp = current_block_start;
+    uint32_t start_th = (tmp % row_blocks_per_channel) * rows_per_tile;
+    tmp /= row_blocks_per_channel;
+    uint32_t start_c = tmp % outC;
+    tmp /= outC;
+    uint32_t start_n = tmp % outN;
+    tmp /= outN;
+    uint32_t start_d = tmp % outD;
+    tmp /= outD;
+    uint32_t start_nd = tmp;
+
+    uint32_t row_blocks_pushed = 0;
+
+    for (uint32_t nd = start_nd; nd < outND && row_blocks_pushed < dst_num_tiles; ++nd, start_d = 0) {
+        uint32_t ptr_nd_a = nd * s_nd_a;
+        uint32_t ptr_nd_b = nd * s_nd_b;
+
+        for (uint32_t d = start_d; d < outD && row_blocks_pushed < dst_num_tiles; ++d, start_n = 0) {
+            uint32_t ptr_d_a = ptr_nd_a + d * s_d_a;
+            uint32_t ptr_d_b = ptr_nd_b + d * s_d_b;
+
+            for (uint32_t n = start_n; n < outN && row_blocks_pushed < dst_num_tiles; ++n, start_c = 0) {
+                uint32_t ptr_n_a = ptr_d_a + n * s_n_a;
+                uint32_t ptr_n_b = ptr_d_b + n * s_n_b;
+
+                for (uint32_t c = start_c; c < outC && row_blocks_pushed < dst_num_tiles; ++c, start_th = 0) {
+                    uint32_t ptr_c_a = ptr_n_a + c * s_c_a;
+                    uint32_t ptr_c_b = ptr_n_b + c * s_c_b;
+
+                    for (uint32_t th = start_th; th < outHt && row_blocks_pushed < dst_num_tiles; th += rows_per_tile) {
+                        uint32_t rows_remaining_in_block = outHt - th;
+                        uint32_t limit =
+                            (rows_remaining_in_block < rows_per_tile) ? rows_remaining_in_block : rows_per_tile;
+
+                        uint32_t row_block_a = ptr_c_a + th * s_h_a;
+                        uint32_t row_block_b = ptr_c_b + th * s_h_b;
+
+                        for (uint32_t t_i = 0; t_i < tiles_per_row; ++t_i) {
+                            uint32_t t_offset = t_i * stride_size_bytes;
+                            uint32_t bytes_left_in_row = row_width_bytes - t_offset;
+                            if (bytes_left_in_row > row_width_bytes) {
+                                bytes_left_in_row = 0;
+                            }
+
+                            uint32_t current_chunk_bytes =
+                                (stride_size_bytes < bytes_left_in_row) ? stride_size_bytes : bytes_left_in_row;
+                            uint32_t current_chunk_elements = current_chunk_bytes / element_size;
+
+#if SRC_BCAST_ROW_B
+                            uint32_t read_len_a = element_size_aligned_a;
+                            uint32_t read_len_b = ALIGN_TO(current_chunk_bytes, alignment_b);
+#else
+                            uint32_t read_len_a = ALIGN_TO(current_chunk_bytes, alignment_a);
+                            uint32_t read_len_b = element_size_aligned_b;
+#endif
+
+                            cb_reserve_back(cb_id_src, 1);
+                            uint32_t l1_write_addr_src = get_write_ptr(cb_id_src);
+
+                            cb_reserve_back(cb_id_src_b, 1);
+                            uint32_t l1_write_addr_src_b = get_write_ptr(cb_id_src_b);
+
+#if SRC_BCAST_ROW_B
+                            for (int32_t k = static_cast<int32_t>(limit) - 1; k >= 0; --k) {
+                                uint32_t row_idx_a = row_block_a + static_cast<uint32_t>(k) * s_h_a;
+                                uint64_t addr_a = get_noc_addr(row_idx_a, src);
+                                uint32_t src_low_bits = static_cast<uint32_t>(addr_a & 0xF);
+                                uint32_t scratch_l1_addr = l1_write_addr_src + src_low_bits;
+                                uint32_t row_l1_addr =
+                                    l1_write_addr_src + static_cast<uint32_t>(k) * current_chunk_bytes;
+
+                                noc_async_read(addr_a, scratch_l1_addr, read_len_a);
+                                noc_async_read_barrier();
+
+                                copy_one_element(row_l1_addr, scratch_l1_addr, element_size);
+                                FILL_TILE_WITH_FIRST_COLUMN_RM(row_l1_addr, current_chunk_elements);
+                            }
+
+                            uint64_t addr_b = get_noc_addr(row_block_b, src_b) + t_offset;
+                            noc_async_read(addr_b, l1_write_addr_src_b, read_len_b);
+                            noc_async_read_barrier();
+                            FILL_TILE_WITH_FIRST_ROW_RM(l1_write_addr_src_b, current_chunk_elements, limit);
+#else
+                            for (int32_t k = static_cast<int32_t>(limit) - 1; k >= 0; --k) {
+                                uint32_t row_idx_b = row_block_b + static_cast<uint32_t>(k) * s_h_b;
+                                uint64_t addr_b = get_noc_addr(row_idx_b, src_b);
+                                uint32_t src_low_bits = static_cast<uint32_t>(addr_b & 0xF);
+                                uint32_t scratch_l1_addr = l1_write_addr_src_b + src_low_bits;
+                                uint32_t row_l1_addr =
+                                    l1_write_addr_src_b + static_cast<uint32_t>(k) * current_chunk_bytes;
+
+                                noc_async_read(addr_b, scratch_l1_addr, read_len_b);
+                                noc_async_read_barrier();
+
+                                copy_one_element(row_l1_addr, scratch_l1_addr, element_size);
+                                FILL_TILE_WITH_FIRST_COLUMN_RM(row_l1_addr, current_chunk_elements);
+                            }
+
+                            uint64_t addr_a = get_noc_addr(row_block_a, src) + t_offset;
+                            noc_async_read(addr_a, l1_write_addr_src, read_len_a);
+                            noc_async_read_barrier();
+                            FILL_TILE_WITH_FIRST_ROW_RM(l1_write_addr_src, current_chunk_elements, limit);
+#endif
+
+                            cb_push_back(cb_id_src, 1);
+                            cb_push_back(cb_id_src_b, 1);
+                        }
+
+                        row_blocks_pushed++;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_row_col_mixed_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_row_col_mixed_bcast.cpp
@@ -1,15 +1,15 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 // SPDX-License-Identifier: Apache-2.0
 
 #include <stdint.h>
 
+#include "api/alignment.h"
 #include "api/dataflow/dataflow_api.h"
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/fill_tile_utils.hpp"
 
-#define ALIGN_TO(len, align) (((len) + (align) - 1) / (align)) * (align)
-
 namespace {
-inline void copy_one_element(uint32_t dst_l1_addr, uint32_t src_l1_addr, uint32_t element_size) {
+// Broadcast reads land in a scratch slot offset by source low bits; normalize the seed value to row start before fill.
+FORCE_INLINE void copy_one_element(uint32_t dst_l1_addr, uint32_t src_l1_addr, uint32_t element_size) {
     if (element_size == 1) {
         auto* src_ptr = reinterpret_cast<volatile tt_l1_ptr uint8_t*>(src_l1_addr);
         auto* dst_ptr = reinterpret_cast<volatile tt_l1_ptr uint8_t*>(dst_l1_addr);
@@ -56,9 +56,6 @@ void kernel_main() {
     const uint32_t alignment_b = get_arg_val<uint32_t>(index++);
     const uint32_t tiles_per_row = get_arg_val<uint32_t>(index++);
     const uint32_t stride_size_bytes = get_arg_val<uint32_t>(index++);
-    const uint32_t packed_scalar = get_arg_val<uint32_t>(index++);
-
-    (void)packed_scalar;
 
     constexpr auto cb_id_src = tt::CBIndex::c_0;
     constexpr auto cb_id_src_b = tt::CBIndex::c_1;
@@ -66,10 +63,10 @@ void kernel_main() {
     constexpr auto src_b_args = TensorAccessorArgs<src_args.next_compile_time_args_offset()>();
 
     constexpr uint32_t src_tile_bytes = get_tile_size(cb_id_src);
-    const uint32_t tile_hw = get_tile_hw(cb_id_src);
+    constexpr uint32_t tile_hw = get_tile_hw(cb_id_src);
     constexpr uint32_t element_size = src_tile_bytes / tile_hw;
-    const uint32_t element_size_aligned_a = ALIGN_TO(element_size, alignment_a);
-    const uint32_t element_size_aligned_b = ALIGN_TO(element_size, alignment_b);
+    const uint32_t element_size_aligned_a = align(element_size, alignment_a);
+    const uint32_t element_size_aligned_b = align(element_size, alignment_b);
     const uint32_t row_width_bytes = row_width_elements * element_size;
 
     const uint32_t outHt = cHt;
@@ -79,11 +76,11 @@ void kernel_main() {
     const uint32_t outND = cND;
 
 #if SRC_BCAST_ROW_B
-    const uint32_t page_size_a = element_size;
-    const uint32_t page_size_b = ALIGN_TO(page_size_b_arg, alignment_b);
+    const uint32_t page_size_a = element_size_aligned_a;
+    const uint32_t page_size_b = align(page_size_b_arg, alignment_b);
 #else
-    const uint32_t page_size_a = ALIGN_TO(page_size_a_arg, alignment_a);
-    const uint32_t page_size_b = element_size;
+    const uint32_t page_size_a = align(page_size_a_arg, alignment_a);
+    const uint32_t page_size_b = element_size_aligned_b;
 #endif
 
     const auto src = TensorAccessor(src_args, src_addr, page_size_a);
@@ -117,92 +114,84 @@ void kernel_main() {
     uint32_t row_blocks_pushed = 0;
 
     for (uint32_t nd = start_nd; nd < outND && row_blocks_pushed < dst_num_tiles; ++nd, start_d = 0) {
-        uint32_t ptr_nd_a = nd * s_nd_a;
-        uint32_t ptr_nd_b = nd * s_nd_b;
+        const uint32_t ptr_nd_a = nd * s_nd_a;
+        const uint32_t ptr_nd_b = nd * s_nd_b;
 
         for (uint32_t d = start_d; d < outD && row_blocks_pushed < dst_num_tiles; ++d, start_n = 0) {
-            uint32_t ptr_d_a = ptr_nd_a + d * s_d_a;
-            uint32_t ptr_d_b = ptr_nd_b + d * s_d_b;
+            const uint32_t ptr_d_a = ptr_nd_a + d * s_d_a;
+            const uint32_t ptr_d_b = ptr_nd_b + d * s_d_b;
 
             for (uint32_t n = start_n; n < outN && row_blocks_pushed < dst_num_tiles; ++n, start_c = 0) {
-                uint32_t ptr_n_a = ptr_d_a + n * s_n_a;
-                uint32_t ptr_n_b = ptr_d_b + n * s_n_b;
+                const uint32_t ptr_n_a = ptr_d_a + n * s_n_a;
+                const uint32_t ptr_n_b = ptr_d_b + n * s_n_b;
 
                 for (uint32_t c = start_c; c < outC && row_blocks_pushed < dst_num_tiles; ++c, start_th = 0) {
-                    uint32_t ptr_c_a = ptr_n_a + c * s_c_a;
-                    uint32_t ptr_c_b = ptr_n_b + c * s_c_b;
+                    const uint32_t ptr_c_a = ptr_n_a + c * s_c_a;
+                    const uint32_t ptr_c_b = ptr_n_b + c * s_c_b;
 
                     for (uint32_t th = start_th; th < outHt && row_blocks_pushed < dst_num_tiles; th += rows_per_tile) {
-                        uint32_t rows_remaining_in_block = outHt - th;
-                        uint32_t limit =
+                        const uint32_t rows_remaining_in_block = outHt - th;
+                        const uint32_t limit =
                             (rows_remaining_in_block < rows_per_tile) ? rows_remaining_in_block : rows_per_tile;
 
-                        uint32_t row_block_a = ptr_c_a + th * s_h_a;
-                        uint32_t row_block_b = ptr_c_b + th * s_h_b;
+                        const uint32_t row_block_a = ptr_c_a + th * s_h_a;
+                        const uint32_t row_block_b = ptr_c_b + th * s_h_b;
 
                         for (uint32_t t_i = 0; t_i < tiles_per_row; ++t_i) {
-                            uint32_t t_offset = t_i * stride_size_bytes;
-                            uint32_t bytes_left_in_row = row_width_bytes - t_offset;
-                            if (bytes_left_in_row > row_width_bytes) {
-                                bytes_left_in_row = 0;
-                            }
-
-                            uint32_t current_chunk_bytes =
+                            const uint32_t current_chunk_offset = t_i * stride_size_bytes;
+                            const uint32_t bytes_left_in_row = row_width_bytes - current_chunk_offset;
+                            const uint32_t current_chunk_bytes =
                                 (stride_size_bytes < bytes_left_in_row) ? stride_size_bytes : bytes_left_in_row;
-                            uint32_t current_chunk_elements = current_chunk_bytes / element_size;
-
-#if SRC_BCAST_ROW_B
-                            uint32_t read_len_a = element_size_aligned_a;
-                            uint32_t read_len_b = ALIGN_TO(current_chunk_bytes, alignment_b);
-#else
-                            uint32_t read_len_a = ALIGN_TO(current_chunk_bytes, alignment_a);
-                            uint32_t read_len_b = element_size_aligned_b;
-#endif
+                            const uint32_t current_chunk_elements = current_chunk_bytes / element_size;
 
                             cb_reserve_back(cb_id_src, 1);
-                            uint32_t l1_write_addr_src = get_write_ptr(cb_id_src);
+                            const uint32_t l1_write_addr_src = get_write_ptr(cb_id_src);
 
                             cb_reserve_back(cb_id_src_b, 1);
-                            uint32_t l1_write_addr_src_b = get_write_ptr(cb_id_src_b);
+                            const uint32_t l1_write_addr_src_b = get_write_ptr(cb_id_src_b);
 
 #if SRC_BCAST_ROW_B
+                            const uint32_t current_read_len_b = align(current_chunk_bytes, alignment_b);
+
                             for (int32_t k = static_cast<int32_t>(limit) - 1; k >= 0; --k) {
-                                uint32_t row_idx_a = row_block_a + static_cast<uint32_t>(k) * s_h_a;
-                                uint64_t addr_a = get_noc_addr(row_idx_a, src);
-                                uint32_t src_low_bits = static_cast<uint32_t>(addr_a & 0xF);
-                                uint32_t scratch_l1_addr = l1_write_addr_src + src_low_bits;
-                                uint32_t row_l1_addr =
+                                const uint32_t row_idx_a = row_block_a + static_cast<uint32_t>(k) * s_h_a;
+                                const uint64_t addr_a = get_noc_addr(row_idx_a, src);
+                                const uint32_t src_low_bits = static_cast<uint32_t>(addr_a & 0xF);
+                                const uint32_t scratch_l1_addr = l1_write_addr_src + src_low_bits;
+                                const uint32_t row_l1_addr =
                                     l1_write_addr_src + static_cast<uint32_t>(k) * current_chunk_bytes;
 
-                                noc_async_read(addr_a, scratch_l1_addr, read_len_a);
+                                noc_async_read(addr_a, scratch_l1_addr, element_size_aligned_a);
                                 noc_async_read_barrier();
 
                                 copy_one_element(row_l1_addr, scratch_l1_addr, element_size);
                                 FILL_TILE_WITH_FIRST_COLUMN_RM(row_l1_addr, current_chunk_elements);
                             }
 
-                            uint64_t addr_b = get_noc_addr(row_block_b, src_b) + t_offset;
-                            noc_async_read(addr_b, l1_write_addr_src_b, read_len_b);
+                            const uint64_t addr_b = get_noc_addr(row_block_b, src_b) + current_chunk_offset;
+                            noc_async_read(addr_b, l1_write_addr_src_b, current_read_len_b);
                             noc_async_read_barrier();
                             FILL_TILE_WITH_FIRST_ROW_RM(l1_write_addr_src_b, current_chunk_elements, limit);
 #else
+                            const uint32_t current_read_len_a = align(current_chunk_bytes, alignment_a);
+
                             for (int32_t k = static_cast<int32_t>(limit) - 1; k >= 0; --k) {
-                                uint32_t row_idx_b = row_block_b + static_cast<uint32_t>(k) * s_h_b;
-                                uint64_t addr_b = get_noc_addr(row_idx_b, src_b);
-                                uint32_t src_low_bits = static_cast<uint32_t>(addr_b & 0xF);
-                                uint32_t scratch_l1_addr = l1_write_addr_src_b + src_low_bits;
-                                uint32_t row_l1_addr =
+                                const uint32_t row_idx_b = row_block_b + static_cast<uint32_t>(k) * s_h_b;
+                                const uint64_t addr_b = get_noc_addr(row_idx_b, src_b);
+                                const uint32_t src_low_bits = static_cast<uint32_t>(addr_b & 0xF);
+                                const uint32_t scratch_l1_addr = l1_write_addr_src_b + src_low_bits;
+                                const uint32_t row_l1_addr =
                                     l1_write_addr_src_b + static_cast<uint32_t>(k) * current_chunk_bytes;
 
-                                noc_async_read(addr_b, scratch_l1_addr, read_len_b);
+                                noc_async_read(addr_b, scratch_l1_addr, element_size_aligned_b);
                                 noc_async_read_barrier();
 
                                 copy_one_element(row_l1_addr, scratch_l1_addr, element_size);
                                 FILL_TILE_WITH_FIRST_COLUMN_RM(row_l1_addr, current_chunk_elements);
                             }
 
-                            uint64_t addr_a = get_noc_addr(row_block_a, src) + t_offset;
-                            noc_async_read(addr_a, l1_write_addr_src, read_len_a);
+                            const uint64_t addr_a = get_noc_addr(row_block_a, src) + current_chunk_offset;
+                            noc_async_read(addr_a, l1_write_addr_src, current_read_len_a);
                             noc_async_read_barrier();
                             FILL_TILE_WITH_FIRST_ROW_RM(l1_write_addr_src, current_chunk_elements, limit);
 #endif

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_row_col_mixed_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_row_col_mixed_bcast.cpp
@@ -9,12 +9,15 @@
 
 namespace {
 // Broadcast reads land in a scratch slot offset by source low bits; normalize the seed value to row start before fill.
-FORCE_INLINE void copy_one_element(uint32_t dst_l1_addr, uint32_t src_l1_addr, uint32_t element_size) {
-    if (element_size == 1) {
+template <uint32_t element_size>
+FORCE_INLINE void copy_one_element(uint32_t dst_l1_addr, uint32_t src_l1_addr) {
+    static_assert(element_size == 1 || element_size == 2 || element_size == 4);
+
+    if constexpr (element_size == 1) {
         auto* src_ptr = reinterpret_cast<volatile tt_l1_ptr uint8_t*>(src_l1_addr);
         auto* dst_ptr = reinterpret_cast<volatile tt_l1_ptr uint8_t*>(dst_l1_addr);
         dst_ptr[0] = src_ptr[0];
-    } else if (element_size == 2) {
+    } else if constexpr (element_size == 2) {
         auto* src_ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(src_l1_addr);
         auto* dst_ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(dst_l1_addr);
         dst_ptr[0] = src_ptr[0];
@@ -164,7 +167,7 @@ void kernel_main() {
                                 noc_async_read(addr_a, scratch_l1_addr, element_size_aligned_a);
                                 noc_async_read_barrier();
 
-                                copy_one_element(row_l1_addr, scratch_l1_addr, element_size);
+                                copy_one_element<element_size>(row_l1_addr, scratch_l1_addr);
                                 FILL_TILE_WITH_FIRST_COLUMN_RM(row_l1_addr, current_chunk_elements);
                             }
 
@@ -186,7 +189,7 @@ void kernel_main() {
                                 noc_async_read(addr_b, scratch_l1_addr, element_size_aligned_b);
                                 noc_async_read_barrier();
 
-                                copy_one_element(row_l1_addr, scratch_l1_addr, element_size);
+                                copy_one_element<element_size>(row_l1_addr, scratch_l1_addr);
                                 FILL_TILE_WITH_FIRST_COLUMN_RM(row_l1_addr, current_chunk_elements);
                             }
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_scalar_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_scalar_bcast.cpp
@@ -1,0 +1,221 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+
+#include "api/dataflow/dataflow_api.h"
+#include "ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/fill_tile_utils.hpp"
+
+#define ALIGN_TO(len, align) (((len) + (align) - 1) / (align)) * (align)
+
+namespace {
+inline void copy_one_element(uint32_t dst_l1_addr, uint32_t src_l1_addr, uint32_t element_size) {
+    if (element_size == 1) {
+        auto* src_ptr = reinterpret_cast<volatile tt_l1_ptr uint8_t*>(src_l1_addr);
+        auto* dst_ptr = reinterpret_cast<volatile tt_l1_ptr uint8_t*>(dst_l1_addr);
+        dst_ptr[0] = src_ptr[0];
+    } else if (element_size == 2) {
+        auto* src_ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(src_l1_addr);
+        auto* dst_ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(dst_l1_addr);
+        dst_ptr[0] = src_ptr[0];
+    } else {
+        auto* src_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(src_l1_addr);
+        auto* dst_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(dst_l1_addr);
+        dst_ptr[0] = src_ptr[0];
+    }
+}
+}  // namespace
+
+void kernel_main() {
+    uint32_t index = 0;
+    const uint32_t src_addr = get_arg_val<uint32_t>(index++);
+    const uint32_t dst_num_tiles = get_arg_val<uint32_t>(index++);
+
+    const uint32_t aD = get_arg_val<uint32_t>(index++);
+    const uint32_t aN = get_arg_val<uint32_t>(index++);
+    const uint32_t aC = get_arg_val<uint32_t>(index++);
+    const uint32_t aHt = get_arg_val<uint32_t>(index++);
+    const uint32_t aND = get_arg_val<uint32_t>(index++);
+
+    const uint32_t src_addr_b = get_arg_val<uint32_t>(index++);
+    const uint32_t bD = get_arg_val<uint32_t>(index++);
+    const uint32_t bN = get_arg_val<uint32_t>(index++);
+    const uint32_t bC = get_arg_val<uint32_t>(index++);
+    const uint32_t bHt = get_arg_val<uint32_t>(index++);
+    const uint32_t bND = get_arg_val<uint32_t>(index++);
+
+    const uint32_t cHt = get_arg_val<uint32_t>(index++);
+    const uint32_t cC = get_arg_val<uint32_t>(index++);
+    const uint32_t cND = get_arg_val<uint32_t>(index++);
+    const uint32_t current_block_start = get_arg_val<uint32_t>(index++);
+    const uint32_t rows_per_tile = get_arg_val<uint32_t>(index++);
+    const uint32_t row_width_elements = get_arg_val<uint32_t>(index++);
+    const uint32_t page_size_a_arg = get_arg_val<uint32_t>(index++);
+    const uint32_t page_size_b_arg = get_arg_val<uint32_t>(index++);
+    const uint32_t alignment_a = get_arg_val<uint32_t>(index++);
+    const uint32_t alignment_b = get_arg_val<uint32_t>(index++);
+    const uint32_t tiles_per_row = get_arg_val<uint32_t>(index++);
+    const uint32_t stride_size_bytes = get_arg_val<uint32_t>(index++);
+    const uint32_t packed_scalar = get_arg_val<uint32_t>(index++);
+
+    (void)packed_scalar;
+
+    constexpr auto cb_id_src = tt::CBIndex::c_0;
+    constexpr auto cb_id_src_b = tt::CBIndex::c_1;
+    constexpr auto src_args = TensorAccessorArgs<0>();
+    constexpr auto src_b_args = TensorAccessorArgs<src_args.next_compile_time_args_offset()>();
+
+    constexpr uint32_t src_tile_bytes = get_tile_size(cb_id_src);
+    const uint32_t tile_hw = get_tile_hw(cb_id_src);
+    constexpr uint32_t element_size = src_tile_bytes / tile_hw;
+    const uint32_t element_size_aligned_a = ALIGN_TO(element_size, alignment_a);
+    const uint32_t element_size_aligned_b = ALIGN_TO(element_size, alignment_b);
+    const uint32_t row_width_bytes = row_width_elements * element_size;
+
+    const uint32_t outHt = cHt;
+    const uint32_t outC = cC;
+    const uint32_t outN = (aN > bN) ? aN : bN;
+    const uint32_t outD = (aD > bD) ? aD : bD;
+    const uint32_t outND = cND;
+
+#if SRC_BCAST
+    const uint32_t page_size_a = element_size;
+    const uint32_t page_size_b = ALIGN_TO(page_size_b_arg, alignment_b);
+#else
+    const uint32_t page_size_a = ALIGN_TO(page_size_a_arg, alignment_a);
+    const uint32_t page_size_b = element_size;
+#endif
+
+    const auto src = TensorAccessor(src_args, src_addr, page_size_a);
+    const auto src_b = TensorAccessor(src_b_args, src_addr_b, page_size_b);
+
+    const uint32_t s_h_a = (aHt == 1) ? 0 : 1;
+    const uint32_t s_c_a = (aC == 1) ? 0 : aHt;
+    const uint32_t s_n_a = (aN == 1) ? 0 : aC * aHt;
+    const uint32_t s_d_a = (aD == 1) ? 0 : aN * aC * aHt;
+    const uint32_t s_nd_a = (aND == 1) ? 0 : aD * aN * aC * aHt;
+
+    const uint32_t s_h_b = (bHt == 1) ? 0 : 1;
+    const uint32_t s_c_b = (bC == 1) ? 0 : bHt;
+    const uint32_t s_n_b = (bN == 1) ? 0 : bC * bHt;
+    const uint32_t s_d_b = (bD == 1) ? 0 : bN * bC * bHt;
+    const uint32_t s_nd_b = (bND == 1) ? 0 : bD * bN * bC * bHt;
+
+    const uint32_t row_blocks_per_channel = (outHt + rows_per_tile - 1) / rows_per_tile;
+
+    uint32_t tmp = current_block_start;
+    uint32_t start_th = (tmp % row_blocks_per_channel) * rows_per_tile;
+    tmp /= row_blocks_per_channel;
+    uint32_t start_c = tmp % outC;
+    tmp /= outC;
+    uint32_t start_n = tmp % outN;
+    tmp /= outN;
+    uint32_t start_d = tmp % outD;
+    tmp /= outD;
+    uint32_t start_nd = tmp;
+
+    uint32_t row_blocks_pushed = 0;
+
+    for (uint32_t nd = start_nd; nd < outND && row_blocks_pushed < dst_num_tiles; ++nd, start_d = 0) {
+        uint32_t ptr_nd_a = nd * s_nd_a;
+        uint32_t ptr_nd_b = nd * s_nd_b;
+
+        for (uint32_t d = start_d; d < outD && row_blocks_pushed < dst_num_tiles; ++d, start_n = 0) {
+            uint32_t ptr_d_a = ptr_nd_a + d * s_d_a;
+            uint32_t ptr_d_b = ptr_nd_b + d * s_d_b;
+
+            for (uint32_t n = start_n; n < outN && row_blocks_pushed < dst_num_tiles; ++n, start_c = 0) {
+                uint32_t ptr_n_a = ptr_d_a + n * s_n_a;
+                uint32_t ptr_n_b = ptr_d_b + n * s_n_b;
+
+                for (uint32_t c = start_c; c < outC && row_blocks_pushed < dst_num_tiles; ++c, start_th = 0) {
+                    uint32_t ptr_c_a = ptr_n_a + c * s_c_a;
+                    uint32_t ptr_c_b = ptr_n_b + c * s_c_b;
+
+                    for (uint32_t th = start_th; th < outHt && row_blocks_pushed < dst_num_tiles; th += rows_per_tile) {
+                        uint32_t rows_remaining_in_block = outHt - th;
+                        uint32_t limit =
+                            (rows_remaining_in_block < rows_per_tile) ? rows_remaining_in_block : rows_per_tile;
+
+                        uint32_t row_block_a = ptr_c_a + th * s_h_a;
+                        uint32_t row_block_b = ptr_c_b + th * s_h_b;
+
+                        for (uint32_t t_i = 0; t_i < tiles_per_row; ++t_i) {
+                            uint32_t t_offset = t_i * stride_size_bytes;
+                            uint32_t bytes_left_in_row = row_width_bytes - t_offset;
+                            if (bytes_left_in_row > row_width_bytes) {
+                                bytes_left_in_row = 0;
+                            }
+
+                            uint32_t current_chunk_bytes =
+                                (stride_size_bytes < bytes_left_in_row) ? stride_size_bytes : bytes_left_in_row;
+                            uint32_t current_chunk_elements = current_chunk_bytes / element_size;
+
+#if SRC_BCAST
+                            uint32_t read_len_a = element_size_aligned_a;
+                            uint32_t read_len_b = ALIGN_TO(current_chunk_bytes, alignment_b);
+#else
+                            uint32_t read_len_a = ALIGN_TO(current_chunk_bytes, alignment_a);
+                            uint32_t read_len_b = element_size_aligned_b;
+#endif
+
+                            cb_reserve_back(cb_id_src, 1);
+                            uint32_t l1_write_addr_src = get_write_ptr(cb_id_src);
+
+                            cb_reserve_back(cb_id_src_b, 1);
+                            uint32_t l1_write_addr_src_b = get_write_ptr(cb_id_src_b);
+
+#if SRC_BCAST
+                            uint64_t addr_a = get_noc_addr(row_block_a, src);
+                            uint32_t src_low_bits = static_cast<uint32_t>(addr_a & 0xF);
+                            uint32_t scratch_l1_addr = l1_write_addr_src + src_low_bits;
+
+                            noc_async_read(addr_a, scratch_l1_addr, read_len_a);
+                            noc_async_read_barrier();
+
+                            copy_one_element(l1_write_addr_src, scratch_l1_addr, element_size);
+                            FILL_TILE_WITH_FIRST_COLUMN_RM(l1_write_addr_src, current_chunk_elements);
+
+                            uint32_t curr_l1_b = l1_write_addr_src_b;
+                            for (uint32_t k = 0; k < limit; ++k) {
+                                uint32_t row_idx_b = row_block_b + k * s_h_b;
+                                uint64_t addr_b = get_noc_addr(row_idx_b, src_b) + t_offset;
+                                noc_async_read(addr_b, curr_l1_b, read_len_b);
+                                curr_l1_b += current_chunk_bytes;
+                            }
+                            noc_async_read_barrier();
+
+                            FILL_TILE_WITH_FIRST_ROW_RM(l1_write_addr_src, current_chunk_elements, limit);
+#else
+                            uint32_t curr_l1_a = l1_write_addr_src;
+                            for (uint32_t k = 0; k < limit; ++k) {
+                                uint32_t row_idx_a = row_block_a + k * s_h_a;
+                                uint64_t addr_a = get_noc_addr(row_idx_a, src) + t_offset;
+                                noc_async_read(addr_a, curr_l1_a, read_len_a);
+                                curr_l1_a += current_chunk_bytes;
+                            }
+                            noc_async_read_barrier();
+
+                            uint64_t addr_b = get_noc_addr(row_block_b, src_b);
+                            uint32_t src_low_bits = static_cast<uint32_t>(addr_b & 0xF);
+                            uint32_t scratch_l1_addr = l1_write_addr_src_b + src_low_bits;
+
+                            noc_async_read(addr_b, scratch_l1_addr, read_len_b);
+                            noc_async_read_barrier();
+
+                            copy_one_element(l1_write_addr_src_b, scratch_l1_addr, element_size);
+                            FILL_TILE_WITH_FIRST_COLUMN_RM(l1_write_addr_src_b, current_chunk_elements);
+                            FILL_TILE_WITH_FIRST_ROW_RM(l1_write_addr_src_b, current_chunk_elements, limit);
+#endif
+
+                            cb_push_back(cb_id_src, 1);
+                            cb_push_back(cb_id_src_b, 1);
+                        }
+
+                        row_blocks_pushed++;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_scalar_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_scalar_bcast.cpp
@@ -9,12 +9,15 @@
 
 namespace {
 // Broadcast reads land in a scratch slot offset by source low bits; normalize the seed value to row start before fill.
-FORCE_INLINE void copy_one_element(uint32_t dst_l1_addr, uint32_t src_l1_addr, uint32_t element_size) {
-    if (element_size == 1) {
+template <uint32_t element_size>
+FORCE_INLINE void copy_one_element(uint32_t dst_l1_addr, uint32_t src_l1_addr) {
+    static_assert(element_size == 1 || element_size == 2 || element_size == 4);
+
+    if constexpr (element_size == 1) {
         auto* src_ptr = reinterpret_cast<volatile tt_l1_ptr uint8_t*>(src_l1_addr);
         auto* dst_ptr = reinterpret_cast<volatile tt_l1_ptr uint8_t*>(dst_l1_addr);
         dst_ptr[0] = src_ptr[0];
-    } else if (element_size == 2) {
+    } else if constexpr (element_size == 2) {
         auto* src_ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(src_l1_addr);
         auto* dst_ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(dst_l1_addr);
         dst_ptr[0] = src_ptr[0];
@@ -159,7 +162,7 @@ void kernel_main() {
                             noc_async_read(addr_a, scratch_l1_addr, element_size_aligned_a);
                             noc_async_read_barrier();
 
-                            copy_one_element(l1_write_addr_src, scratch_l1_addr, element_size);
+                            copy_one_element<element_size>(l1_write_addr_src, scratch_l1_addr);
                             FILL_TILE_WITH_FIRST_COLUMN_RM(l1_write_addr_src, current_chunk_elements);
 
                             uint32_t curr_l1_b = l1_write_addr_src_b;
@@ -190,7 +193,7 @@ void kernel_main() {
                             noc_async_read(addr_b, scratch_l1_addr, element_size_aligned_b);
                             noc_async_read_barrier();
 
-                            copy_one_element(l1_write_addr_src_b, scratch_l1_addr, element_size);
+                            copy_one_element<element_size>(l1_write_addr_src_b, scratch_l1_addr);
                             FILL_TILE_WITH_FIRST_COLUMN_RM(l1_write_addr_src_b, current_chunk_elements);
                             FILL_TILE_WITH_FIRST_ROW_RM(l1_write_addr_src_b, current_chunk_elements, limit);
 #endif

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_scalar_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_scalar_bcast.cpp
@@ -1,15 +1,15 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 // SPDX-License-Identifier: Apache-2.0
 
 #include <stdint.h>
 
+#include "api/alignment.h"
 #include "api/dataflow/dataflow_api.h"
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/fill_tile_utils.hpp"
 
-#define ALIGN_TO(len, align) (((len) + (align) - 1) / (align)) * (align)
-
 namespace {
-inline void copy_one_element(uint32_t dst_l1_addr, uint32_t src_l1_addr, uint32_t element_size) {
+// Broadcast reads land in a scratch slot offset by source low bits; normalize the seed value to row start before fill.
+FORCE_INLINE void copy_one_element(uint32_t dst_l1_addr, uint32_t src_l1_addr, uint32_t element_size) {
     if (element_size == 1) {
         auto* src_ptr = reinterpret_cast<volatile tt_l1_ptr uint8_t*>(src_l1_addr);
         auto* dst_ptr = reinterpret_cast<volatile tt_l1_ptr uint8_t*>(dst_l1_addr);
@@ -56,9 +56,6 @@ void kernel_main() {
     const uint32_t alignment_b = get_arg_val<uint32_t>(index++);
     const uint32_t tiles_per_row = get_arg_val<uint32_t>(index++);
     const uint32_t stride_size_bytes = get_arg_val<uint32_t>(index++);
-    const uint32_t packed_scalar = get_arg_val<uint32_t>(index++);
-
-    (void)packed_scalar;
 
     constexpr auto cb_id_src = tt::CBIndex::c_0;
     constexpr auto cb_id_src_b = tt::CBIndex::c_1;
@@ -66,10 +63,10 @@ void kernel_main() {
     constexpr auto src_b_args = TensorAccessorArgs<src_args.next_compile_time_args_offset()>();
 
     constexpr uint32_t src_tile_bytes = get_tile_size(cb_id_src);
-    const uint32_t tile_hw = get_tile_hw(cb_id_src);
+    constexpr uint32_t tile_hw = get_tile_hw(cb_id_src);
     constexpr uint32_t element_size = src_tile_bytes / tile_hw;
-    const uint32_t element_size_aligned_a = ALIGN_TO(element_size, alignment_a);
-    const uint32_t element_size_aligned_b = ALIGN_TO(element_size, alignment_b);
+    const uint32_t element_size_aligned_a = align(element_size, alignment_a);
+    const uint32_t element_size_aligned_b = align(element_size, alignment_b);
     const uint32_t row_width_bytes = row_width_elements * element_size;
 
     const uint32_t outHt = cHt;
@@ -79,11 +76,11 @@ void kernel_main() {
     const uint32_t outND = cND;
 
 #if SRC_BCAST
-    const uint32_t page_size_a = element_size;
-    const uint32_t page_size_b = ALIGN_TO(page_size_b_arg, alignment_b);
+    const uint32_t page_size_a = element_size_aligned_a;
+    const uint32_t page_size_b = align(page_size_b_arg, alignment_b);
 #else
-    const uint32_t page_size_a = ALIGN_TO(page_size_a_arg, alignment_a);
-    const uint32_t page_size_b = element_size;
+    const uint32_t page_size_a = align(page_size_a_arg, alignment_a);
+    const uint32_t page_size_b = element_size_aligned_b;
 #endif
 
     const auto src = TensorAccessor(src_args, src_addr, page_size_a);
@@ -117,60 +114,49 @@ void kernel_main() {
     uint32_t row_blocks_pushed = 0;
 
     for (uint32_t nd = start_nd; nd < outND && row_blocks_pushed < dst_num_tiles; ++nd, start_d = 0) {
-        uint32_t ptr_nd_a = nd * s_nd_a;
-        uint32_t ptr_nd_b = nd * s_nd_b;
+        const uint32_t ptr_nd_a = nd * s_nd_a;
+        const uint32_t ptr_nd_b = nd * s_nd_b;
 
         for (uint32_t d = start_d; d < outD && row_blocks_pushed < dst_num_tiles; ++d, start_n = 0) {
-            uint32_t ptr_d_a = ptr_nd_a + d * s_d_a;
-            uint32_t ptr_d_b = ptr_nd_b + d * s_d_b;
+            const uint32_t ptr_d_a = ptr_nd_a + d * s_d_a;
+            const uint32_t ptr_d_b = ptr_nd_b + d * s_d_b;
 
             for (uint32_t n = start_n; n < outN && row_blocks_pushed < dst_num_tiles; ++n, start_c = 0) {
-                uint32_t ptr_n_a = ptr_d_a + n * s_n_a;
-                uint32_t ptr_n_b = ptr_d_b + n * s_n_b;
+                const uint32_t ptr_n_a = ptr_d_a + n * s_n_a;
+                const uint32_t ptr_n_b = ptr_d_b + n * s_n_b;
 
                 for (uint32_t c = start_c; c < outC && row_blocks_pushed < dst_num_tiles; ++c, start_th = 0) {
-                    uint32_t ptr_c_a = ptr_n_a + c * s_c_a;
-                    uint32_t ptr_c_b = ptr_n_b + c * s_c_b;
+                    const uint32_t ptr_c_a = ptr_n_a + c * s_c_a;
+                    const uint32_t ptr_c_b = ptr_n_b + c * s_c_b;
 
                     for (uint32_t th = start_th; th < outHt && row_blocks_pushed < dst_num_tiles; th += rows_per_tile) {
-                        uint32_t rows_remaining_in_block = outHt - th;
-                        uint32_t limit =
+                        const uint32_t rows_remaining_in_block = outHt - th;
+                        const uint32_t limit =
                             (rows_remaining_in_block < rows_per_tile) ? rows_remaining_in_block : rows_per_tile;
 
-                        uint32_t row_block_a = ptr_c_a + th * s_h_a;
-                        uint32_t row_block_b = ptr_c_b + th * s_h_b;
+                        const uint32_t row_block_a = ptr_c_a + th * s_h_a;
+                        const uint32_t row_block_b = ptr_c_b + th * s_h_b;
 
                         for (uint32_t t_i = 0; t_i < tiles_per_row; ++t_i) {
-                            uint32_t t_offset = t_i * stride_size_bytes;
-                            uint32_t bytes_left_in_row = row_width_bytes - t_offset;
-                            if (bytes_left_in_row > row_width_bytes) {
-                                bytes_left_in_row = 0;
-                            }
-
-                            uint32_t current_chunk_bytes =
+                            const uint32_t current_chunk_offset = t_i * stride_size_bytes;
+                            const uint32_t bytes_left_in_row = row_width_bytes - current_chunk_offset;
+                            const uint32_t current_chunk_bytes =
                                 (stride_size_bytes < bytes_left_in_row) ? stride_size_bytes : bytes_left_in_row;
-                            uint32_t current_chunk_elements = current_chunk_bytes / element_size;
-
-#if SRC_BCAST
-                            uint32_t read_len_a = element_size_aligned_a;
-                            uint32_t read_len_b = ALIGN_TO(current_chunk_bytes, alignment_b);
-#else
-                            uint32_t read_len_a = ALIGN_TO(current_chunk_bytes, alignment_a);
-                            uint32_t read_len_b = element_size_aligned_b;
-#endif
+                            const uint32_t current_chunk_elements = current_chunk_bytes / element_size;
 
                             cb_reserve_back(cb_id_src, 1);
-                            uint32_t l1_write_addr_src = get_write_ptr(cb_id_src);
+                            const uint32_t l1_write_addr_src = get_write_ptr(cb_id_src);
 
                             cb_reserve_back(cb_id_src_b, 1);
-                            uint32_t l1_write_addr_src_b = get_write_ptr(cb_id_src_b);
+                            const uint32_t l1_write_addr_src_b = get_write_ptr(cb_id_src_b);
 
 #if SRC_BCAST
-                            uint64_t addr_a = get_noc_addr(row_block_a, src);
-                            uint32_t src_low_bits = static_cast<uint32_t>(addr_a & 0xF);
-                            uint32_t scratch_l1_addr = l1_write_addr_src + src_low_bits;
+                            const uint32_t current_read_len_b = align(current_chunk_bytes, alignment_b);
+                            const uint64_t addr_a = get_noc_addr(row_block_a, src);
+                            const uint32_t src_low_bits = static_cast<uint32_t>(addr_a & 0xF);
+                            const uint32_t scratch_l1_addr = l1_write_addr_src + src_low_bits;
 
-                            noc_async_read(addr_a, scratch_l1_addr, read_len_a);
+                            noc_async_read(addr_a, scratch_l1_addr, element_size_aligned_a);
                             noc_async_read_barrier();
 
                             copy_one_element(l1_write_addr_src, scratch_l1_addr, element_size);
@@ -178,29 +164,30 @@ void kernel_main() {
 
                             uint32_t curr_l1_b = l1_write_addr_src_b;
                             for (uint32_t k = 0; k < limit; ++k) {
-                                uint32_t row_idx_b = row_block_b + k * s_h_b;
-                                uint64_t addr_b = get_noc_addr(row_idx_b, src_b) + t_offset;
-                                noc_async_read(addr_b, curr_l1_b, read_len_b);
+                                const uint32_t row_idx_b = row_block_b + k * s_h_b;
+                                const uint64_t addr_b = get_noc_addr(row_idx_b, src_b) + current_chunk_offset;
+                                noc_async_read(addr_b, curr_l1_b, current_read_len_b);
                                 curr_l1_b += current_chunk_bytes;
                             }
                             noc_async_read_barrier();
 
                             FILL_TILE_WITH_FIRST_ROW_RM(l1_write_addr_src, current_chunk_elements, limit);
 #else
+                            const uint32_t current_read_len_a = align(current_chunk_bytes, alignment_a);
                             uint32_t curr_l1_a = l1_write_addr_src;
                             for (uint32_t k = 0; k < limit; ++k) {
-                                uint32_t row_idx_a = row_block_a + k * s_h_a;
-                                uint64_t addr_a = get_noc_addr(row_idx_a, src) + t_offset;
-                                noc_async_read(addr_a, curr_l1_a, read_len_a);
+                                const uint32_t row_idx_a = row_block_a + k * s_h_a;
+                                const uint64_t addr_a = get_noc_addr(row_idx_a, src) + current_chunk_offset;
+                                noc_async_read(addr_a, curr_l1_a, current_read_len_a);
                                 curr_l1_a += current_chunk_bytes;
                             }
                             noc_async_read_barrier();
 
-                            uint64_t addr_b = get_noc_addr(row_block_b, src_b);
-                            uint32_t src_low_bits = static_cast<uint32_t>(addr_b & 0xF);
-                            uint32_t scratch_l1_addr = l1_write_addr_src_b + src_low_bits;
+                            const uint64_t addr_b = get_noc_addr(row_block_b, src_b);
+                            const uint32_t src_low_bits = static_cast<uint32_t>(addr_b & 0xF);
+                            const uint32_t scratch_l1_addr = l1_write_addr_src_b + src_low_bits;
 
-                            noc_async_read(addr_b, scratch_l1_addr, read_len_b);
+                            noc_async_read(addr_b, scratch_l1_addr, element_size_aligned_b);
                             noc_async_read_barrier();
 
                             copy_one_element(l1_write_addr_src_b, scratch_l1_addr, element_size);

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_scalar_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_scalar_op.cpp
@@ -1,0 +1,153 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+
+#include "api/dataflow/dataflow_api.h"
+#include "ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/fill_tile_utils.hpp"
+
+#define ALIGN_TO(len, align) (((len) + (align) - 1) / (align)) * (align)
+
+void kernel_main() {
+    uint32_t index = 0;
+    const uint32_t src_addr = get_arg_val<uint32_t>(index++);
+    const uint32_t dst_num_tiles = get_arg_val<uint32_t>(index++);
+
+    const uint32_t aD = get_arg_val<uint32_t>(index++);
+    const uint32_t aN = get_arg_val<uint32_t>(index++);
+    const uint32_t aC = get_arg_val<uint32_t>(index++);
+    const uint32_t aHt = get_arg_val<uint32_t>(index++);
+    const uint32_t aND = get_arg_val<uint32_t>(index++);
+
+    const uint32_t src_addr_b = get_arg_val<uint32_t>(index++);
+    const uint32_t bD = get_arg_val<uint32_t>(index++);
+    const uint32_t bN = get_arg_val<uint32_t>(index++);
+    const uint32_t bC = get_arg_val<uint32_t>(index++);
+    const uint32_t bHt = get_arg_val<uint32_t>(index++);
+    const uint32_t bND = get_arg_val<uint32_t>(index++);
+
+    const uint32_t cHt = get_arg_val<uint32_t>(index++);
+    const uint32_t cC = get_arg_val<uint32_t>(index++);
+    const uint32_t cND = get_arg_val<uint32_t>(index++);
+    const uint32_t current_block_start = get_arg_val<uint32_t>(index++);
+    const uint32_t rows_per_tile = get_arg_val<uint32_t>(index++);
+    const uint32_t row_width_elements = get_arg_val<uint32_t>(index++);
+    const uint32_t page_size_a_arg = get_arg_val<uint32_t>(index++);
+    const uint32_t page_size_b_arg = get_arg_val<uint32_t>(index++);
+    const uint32_t alignment_a = get_arg_val<uint32_t>(index++);
+    const uint32_t alignment_b = get_arg_val<uint32_t>(index++);
+    const uint32_t tiles_per_row = get_arg_val<uint32_t>(index++);
+    const uint32_t stride_size_bytes = get_arg_val<uint32_t>(index++);
+    const uint32_t packed_scalar = get_arg_val<uint32_t>(index++);
+
+    (void)src_addr_b;
+    (void)bD;
+    (void)bN;
+    (void)bC;
+    (void)bHt;
+    (void)bND;
+    (void)page_size_b_arg;
+    (void)alignment_b;
+
+    constexpr auto cb_id_src = tt::CBIndex::c_0;
+    constexpr auto cb_id_src_b = tt::CBIndex::c_1;
+    constexpr auto src_args = TensorAccessorArgs<0>();
+
+    constexpr uint32_t src_tile_bytes = get_tile_size(cb_id_src);
+    const uint32_t tile_hw = get_tile_hw(cb_id_src);
+    constexpr uint32_t element_size = src_tile_bytes / tile_hw;
+    const uint32_t row_width_bytes = row_width_elements * element_size;
+
+    const uint32_t outHt = cHt;
+    const uint32_t outC = cC;
+    const uint32_t outN = aN;
+    const uint32_t outD = aD;
+    const uint32_t outND = cND;
+
+    const uint32_t page_size_a = ALIGN_TO(page_size_a_arg, alignment_a);
+    const auto src = TensorAccessor(src_args, src_addr, page_size_a);
+
+    cb_reserve_back(cb_id_src_b, 1);
+#ifdef FILL_WITH_VALUE_FLOAT_B
+    const auto float_ptr_b = reinterpret_cast<const float*>(&packed_scalar);
+    FILL_WITH_VALUE_FLOAT_B(cb_id_src_b, *float_ptr_b);
+#endif
+#ifdef FILL_WITH_VALUE_B
+    FILL_WITH_VALUE_B(cb_id_src_b, packed_scalar);
+#endif
+    cb_push_back(cb_id_src_b, 1);
+
+    const uint32_t s_h_a = (aHt == 1) ? 0 : 1;
+    const uint32_t s_c_a = (aC == 1) ? 0 : aHt;
+    const uint32_t s_n_a = (aN == 1) ? 0 : aC * aHt;
+    const uint32_t s_d_a = (aD == 1) ? 0 : aN * aC * aHt;
+    const uint32_t s_nd_a = (aND == 1) ? 0 : aD * aN * aC * aHt;
+
+    const uint32_t row_blocks_per_channel = (outHt + rows_per_tile - 1) / rows_per_tile;
+
+    uint32_t tmp = current_block_start;
+    uint32_t start_th = (tmp % row_blocks_per_channel) * rows_per_tile;
+    tmp /= row_blocks_per_channel;
+    uint32_t start_c = tmp % outC;
+    tmp /= outC;
+    uint32_t start_n = tmp % outN;
+    tmp /= outN;
+    uint32_t start_d = tmp % outD;
+    tmp /= outD;
+    uint32_t start_nd = tmp;
+
+    uint32_t row_blocks_pushed = 0;
+
+    for (uint32_t nd = start_nd; nd < outND && row_blocks_pushed < dst_num_tiles; ++nd, start_d = 0) {
+        uint32_t ptr_nd_a = nd * s_nd_a;
+
+        for (uint32_t d = start_d; d < outD && row_blocks_pushed < dst_num_tiles; ++d, start_n = 0) {
+            uint32_t ptr_d_a = ptr_nd_a + d * s_d_a;
+
+            for (uint32_t n = start_n; n < outN && row_blocks_pushed < dst_num_tiles; ++n, start_c = 0) {
+                uint32_t ptr_n_a = ptr_d_a + n * s_n_a;
+
+                for (uint32_t c = start_c; c < outC && row_blocks_pushed < dst_num_tiles; ++c, start_th = 0) {
+                    uint32_t ptr_c_a = ptr_n_a + c * s_c_a;
+
+                    for (uint32_t th = start_th; th < outHt && row_blocks_pushed < dst_num_tiles; th += rows_per_tile) {
+                        uint32_t rows_remaining_in_block = outHt - th;
+                        uint32_t limit =
+                            (rows_remaining_in_block < rows_per_tile) ? rows_remaining_in_block : rows_per_tile;
+
+                        uint32_t row_block_a = ptr_c_a + th * s_h_a;
+
+                        for (uint32_t t_i = 0; t_i < tiles_per_row; ++t_i) {
+                            uint32_t t_offset = t_i * stride_size_bytes;
+
+                            uint32_t bytes_left_in_row = row_width_bytes - t_offset;
+                            if (bytes_left_in_row > row_width_bytes) {
+                                bytes_left_in_row = 0;
+                            }
+
+                            uint32_t current_chunk_bytes =
+                                (stride_size_bytes < bytes_left_in_row) ? stride_size_bytes : bytes_left_in_row;
+                            uint32_t read_len_a = ALIGN_TO(current_chunk_bytes, alignment_a);
+
+                            cb_reserve_back(cb_id_src, 1);
+                            uint32_t l1_write_addr_src = get_write_ptr(cb_id_src);
+
+                            uint32_t curr_l1_a = l1_write_addr_src;
+                            for (uint32_t k = 0; k < limit; ++k) {
+                                uint32_t row_idx_a = row_block_a + k * s_h_a;
+                                uint64_t addr_a = get_noc_addr(row_idx_a, src) + t_offset;
+                                noc_async_read(addr_a, curr_l1_a, read_len_a);
+                                curr_l1_a += current_chunk_bytes;
+                            }
+                            noc_async_read_barrier();
+
+                            cb_push_back(cb_id_src, 1);
+                        }
+
+                        row_blocks_pushed++;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_scalar_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_scalar_op.cpp
@@ -1,12 +1,11 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 // SPDX-License-Identifier: Apache-2.0
 
 #include <stdint.h>
 
+#include "api/alignment.h"
 #include "api/dataflow/dataflow_api.h"
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/fill_tile_utils.hpp"
-
-#define ALIGN_TO(len, align) (((len) + (align) - 1) / (align)) * (align)
 
 void kernel_main() {
     uint32_t index = 0;
@@ -19,12 +18,7 @@ void kernel_main() {
     const uint32_t aHt = get_arg_val<uint32_t>(index++);
     const uint32_t aND = get_arg_val<uint32_t>(index++);
 
-    const uint32_t src_addr_b = get_arg_val<uint32_t>(index++);
-    const uint32_t bD = get_arg_val<uint32_t>(index++);
-    const uint32_t bN = get_arg_val<uint32_t>(index++);
-    const uint32_t bC = get_arg_val<uint32_t>(index++);
-    const uint32_t bHt = get_arg_val<uint32_t>(index++);
-    const uint32_t bND = get_arg_val<uint32_t>(index++);
+    index += 6;  // Scalar-op reader shares the RM reader ABI but does not consume tensor-B shape/address args.
 
     const uint32_t cHt = get_arg_val<uint32_t>(index++);
     const uint32_t cC = get_arg_val<uint32_t>(index++);
@@ -33,28 +27,19 @@ void kernel_main() {
     const uint32_t rows_per_tile = get_arg_val<uint32_t>(index++);
     const uint32_t row_width_elements = get_arg_val<uint32_t>(index++);
     const uint32_t page_size_a_arg = get_arg_val<uint32_t>(index++);
-    const uint32_t page_size_b_arg = get_arg_val<uint32_t>(index++);
+    index++;  // Skip tensor-B page size.
     const uint32_t alignment_a = get_arg_val<uint32_t>(index++);
-    const uint32_t alignment_b = get_arg_val<uint32_t>(index++);
+    index++;  // Skip tensor-B alignment.
     const uint32_t tiles_per_row = get_arg_val<uint32_t>(index++);
     const uint32_t stride_size_bytes = get_arg_val<uint32_t>(index++);
     const uint32_t packed_scalar = get_arg_val<uint32_t>(index++);
-
-    (void)src_addr_b;
-    (void)bD;
-    (void)bN;
-    (void)bC;
-    (void)bHt;
-    (void)bND;
-    (void)page_size_b_arg;
-    (void)alignment_b;
 
     constexpr auto cb_id_src = tt::CBIndex::c_0;
     constexpr auto cb_id_src_b = tt::CBIndex::c_1;
     constexpr auto src_args = TensorAccessorArgs<0>();
 
     constexpr uint32_t src_tile_bytes = get_tile_size(cb_id_src);
-    const uint32_t tile_hw = get_tile_hw(cb_id_src);
+    constexpr uint32_t tile_hw = get_tile_hw(cb_id_src);
     constexpr uint32_t element_size = src_tile_bytes / tile_hw;
     const uint32_t row_width_bytes = row_width_elements * element_size;
 
@@ -64,7 +49,7 @@ void kernel_main() {
     const uint32_t outD = aD;
     const uint32_t outND = cND;
 
-    const uint32_t page_size_a = ALIGN_TO(page_size_a_arg, alignment_a);
+    const uint32_t page_size_a = align(page_size_a_arg, alignment_a);
     const auto src = TensorAccessor(src_args, src_addr, page_size_a);
 
     cb_reserve_back(cb_id_src_b, 1);
@@ -99,44 +84,39 @@ void kernel_main() {
     uint32_t row_blocks_pushed = 0;
 
     for (uint32_t nd = start_nd; nd < outND && row_blocks_pushed < dst_num_tiles; ++nd, start_d = 0) {
-        uint32_t ptr_nd_a = nd * s_nd_a;
+        const uint32_t ptr_nd_a = nd * s_nd_a;
 
         for (uint32_t d = start_d; d < outD && row_blocks_pushed < dst_num_tiles; ++d, start_n = 0) {
-            uint32_t ptr_d_a = ptr_nd_a + d * s_d_a;
+            const uint32_t ptr_d_a = ptr_nd_a + d * s_d_a;
 
             for (uint32_t n = start_n; n < outN && row_blocks_pushed < dst_num_tiles; ++n, start_c = 0) {
-                uint32_t ptr_n_a = ptr_d_a + n * s_n_a;
+                const uint32_t ptr_n_a = ptr_d_a + n * s_n_a;
 
                 for (uint32_t c = start_c; c < outC && row_blocks_pushed < dst_num_tiles; ++c, start_th = 0) {
-                    uint32_t ptr_c_a = ptr_n_a + c * s_c_a;
+                    const uint32_t ptr_c_a = ptr_n_a + c * s_c_a;
 
                     for (uint32_t th = start_th; th < outHt && row_blocks_pushed < dst_num_tiles; th += rows_per_tile) {
-                        uint32_t rows_remaining_in_block = outHt - th;
-                        uint32_t limit =
+                        const uint32_t rows_remaining_in_block = outHt - th;
+                        const uint32_t limit =
                             (rows_remaining_in_block < rows_per_tile) ? rows_remaining_in_block : rows_per_tile;
 
-                        uint32_t row_block_a = ptr_c_a + th * s_h_a;
+                        const uint32_t row_block_a = ptr_c_a + th * s_h_a;
 
                         for (uint32_t t_i = 0; t_i < tiles_per_row; ++t_i) {
-                            uint32_t t_offset = t_i * stride_size_bytes;
-
-                            uint32_t bytes_left_in_row = row_width_bytes - t_offset;
-                            if (bytes_left_in_row > row_width_bytes) {
-                                bytes_left_in_row = 0;
-                            }
-
-                            uint32_t current_chunk_bytes =
+                            const uint32_t current_chunk_offset = t_i * stride_size_bytes;
+                            const uint32_t bytes_left_in_row = row_width_bytes - current_chunk_offset;
+                            const uint32_t current_chunk_bytes =
                                 (stride_size_bytes < bytes_left_in_row) ? stride_size_bytes : bytes_left_in_row;
-                            uint32_t read_len_a = ALIGN_TO(current_chunk_bytes, alignment_a);
+                            const uint32_t current_read_len = align(current_chunk_bytes, alignment_a);
 
                             cb_reserve_back(cb_id_src, 1);
-                            uint32_t l1_write_addr_src = get_write_ptr(cb_id_src);
+                            const uint32_t l1_write_addr_src = get_write_ptr(cb_id_src);
 
                             uint32_t curr_l1_a = l1_write_addr_src;
                             for (uint32_t k = 0; k < limit; ++k) {
-                                uint32_t row_idx_a = row_block_a + k * s_h_a;
-                                uint64_t addr_a = get_noc_addr(row_idx_a, src) + t_offset;
-                                noc_async_read(addr_a, curr_l1_a, read_len_a);
+                                const uint32_t row_idx_a = row_block_a + k * s_h_a;
+                                const uint64_t addr_a = get_noc_addr(row_idx_a, src) + current_chunk_offset;
+                                noc_async_read(addr_a, curr_l1_a, current_read_len);
                                 curr_l1_a += current_chunk_bytes;
                             }
                             noc_async_read_barrier();

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/writer_interleaved_rm_no_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/writer_interleaved_rm_no_bcast.cpp
@@ -1,0 +1,96 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+
+#include "api/dataflow/dataflow_api.h"
+
+#define ALIGN_TO(len, align) (((len) + (align) - 1) / (align)) * (align)
+
+void kernel_main() {
+    uint32_t index = 0;
+    const uint32_t dst_addr = get_arg_val<uint32_t>(index++);
+    const uint32_t row_width_elements = get_arg_val<uint32_t>(index++);
+    const uint32_t dst_num_tiles = get_arg_val<uint32_t>(index++);
+
+    const uint32_t outD = get_arg_val<uint32_t>(index++);
+    const uint32_t outN = get_arg_val<uint32_t>(index++);
+    const uint32_t outC = get_arg_val<uint32_t>(index++);
+    const uint32_t outHt = get_arg_val<uint32_t>(index++);
+    const uint32_t outND = get_arg_val<uint32_t>(index++);
+
+    const uint32_t current_block_start = get_arg_val<uint32_t>(index++);
+    const uint32_t rows_per_tile = get_arg_val<uint32_t>(index++);
+    const uint32_t page_size_arg = get_arg_val<uint32_t>(index++);
+    const uint32_t alignment = get_arg_val<uint32_t>(index++);
+    const uint32_t tiles_per_row = get_arg_val<uint32_t>(index++);
+    const uint32_t stride_size_bytes = get_arg_val<uint32_t>(index++);
+
+    constexpr auto cb_id_out = tt::CBIndex::c_2;
+    constexpr auto dst_args = TensorAccessorArgs<0>();
+
+    constexpr uint32_t tile_bytes = get_tile_size(cb_id_out);
+    const uint32_t tile_hw = get_tile_hw(cb_id_out);
+    constexpr uint32_t element_size = tile_bytes / tile_hw;
+    const uint32_t full_page_size = ALIGN_TO(page_size_arg, alignment);
+    const uint32_t row_width_bytes = row_width_elements * element_size;
+
+    const auto dst = TensorAccessor(dst_args, dst_addr, full_page_size);
+
+    const uint32_t row_blocks_per_channel = (outHt + rows_per_tile - 1) / rows_per_tile;
+
+    uint32_t tmp = current_block_start;
+    uint32_t start_th = (tmp % row_blocks_per_channel) * rows_per_tile;
+    tmp /= row_blocks_per_channel;
+    uint32_t start_c = tmp % outC;
+    tmp /= outC;
+    uint32_t start_n = tmp % outN;
+    tmp /= outN;
+    uint32_t start_d = tmp % outD;
+    tmp /= outD;
+    uint32_t start_nd = tmp;
+
+    uint32_t row_blocks_written = 0;
+
+    for (uint32_t nd = start_nd; nd < outND && row_blocks_written < dst_num_tiles; ++nd, start_d = 0) {
+        for (uint32_t d = start_d; d < outD && row_blocks_written < dst_num_tiles; ++d, start_n = 0) {
+            for (uint32_t n = start_n; n < outN && row_blocks_written < dst_num_tiles; ++n, start_c = 0) {
+                for (uint32_t c = start_c; c < outC && row_blocks_written < dst_num_tiles; ++c, start_th = 0) {
+                    for (uint32_t th = start_th; th < outHt && row_blocks_written < dst_num_tiles;
+                         th += rows_per_tile) {
+                        uint32_t rows_remaining = outHt - th;
+                        uint32_t limit = (rows_remaining < rows_per_tile) ? rows_remaining : rows_per_tile;
+
+                        for (uint32_t t_i = 0; t_i < tiles_per_row; ++t_i) {
+                            cb_wait_front(cb_id_out, 1);
+
+                            uint32_t l1_read_addr = get_read_ptr(cb_id_out);
+                            uint32_t bytes_left_in_row = row_width_bytes - (t_i * stride_size_bytes);
+                            if (bytes_left_in_row > row_width_bytes) {
+                                bytes_left_in_row = 0;
+                            }
+
+                            uint32_t current_chunk_bytes =
+                                (stride_size_bytes < bytes_left_in_row) ? stride_size_bytes : bytes_left_in_row;
+                            uint32_t chunk_noc_offset = t_i * stride_size_bytes;
+                            uint32_t write_len = ALIGN_TO(current_chunk_bytes, alignment);
+                            uint32_t row_block_base_row = (((((nd * outD) + d) * outN + n) * outC + c) * outHt) + th;
+
+                            for (uint32_t row = 0; row < limit; ++row) {
+                                uint32_t row_abs_idx = row_block_base_row + row;
+                                uint64_t dst_noc_addr = get_noc_addr(row_abs_idx, dst) + chunk_noc_offset;
+                                noc_async_write(l1_read_addr, dst_noc_addr, write_len);
+                                l1_read_addr += current_chunk_bytes;
+                            }
+
+                            noc_async_write_barrier();
+                            cb_pop_front(cb_id_out, 1);
+                        }
+
+                        row_blocks_written++;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/writer_interleaved_rm_no_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/writer_interleaved_rm_no_bcast.cpp
@@ -1,11 +1,10 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 // SPDX-License-Identifier: Apache-2.0
 
 #include <stdint.h>
 
+#include "api/alignment.h"
 #include "api/dataflow/dataflow_api.h"
-
-#define ALIGN_TO(len, align) (((len) + (align) - 1) / (align)) * (align)
 
 void kernel_main() {
     uint32_t index = 0;
@@ -30,9 +29,9 @@ void kernel_main() {
     constexpr auto dst_args = TensorAccessorArgs<0>();
 
     constexpr uint32_t tile_bytes = get_tile_size(cb_id_out);
-    const uint32_t tile_hw = get_tile_hw(cb_id_out);
+    constexpr uint32_t tile_hw = get_tile_hw(cb_id_out);
     constexpr uint32_t element_size = tile_bytes / tile_hw;
-    const uint32_t full_page_size = ALIGN_TO(page_size_arg, alignment);
+    const uint32_t full_page_size = align(page_size_arg, alignment);
     const uint32_t row_width_bytes = row_width_elements * element_size;
 
     const auto dst = TensorAccessor(dst_args, dst_addr, full_page_size);
@@ -58,28 +57,24 @@ void kernel_main() {
                 for (uint32_t c = start_c; c < outC && row_blocks_written < dst_num_tiles; ++c, start_th = 0) {
                     for (uint32_t th = start_th; th < outHt && row_blocks_written < dst_num_tiles;
                          th += rows_per_tile) {
-                        uint32_t rows_remaining = outHt - th;
-                        uint32_t limit = (rows_remaining < rows_per_tile) ? rows_remaining : rows_per_tile;
+                        const uint32_t rows_remaining = outHt - th;
+                        const uint32_t limit = (rows_remaining < rows_per_tile) ? rows_remaining : rows_per_tile;
+                        const uint32_t row_block_base_row = (((((nd * outD) + d) * outN + n) * outC + c) * outHt) + th;
 
                         for (uint32_t t_i = 0; t_i < tiles_per_row; ++t_i) {
+                            const uint32_t current_chunk_offset = t_i * stride_size_bytes;
+                            const uint32_t bytes_left_in_row = row_width_bytes - current_chunk_offset;
+                            const uint32_t current_chunk_bytes =
+                                (stride_size_bytes < bytes_left_in_row) ? stride_size_bytes : bytes_left_in_row;
+                            const uint32_t current_write_len = align(current_chunk_bytes, alignment);
+
                             cb_wait_front(cb_id_out, 1);
 
                             uint32_t l1_read_addr = get_read_ptr(cb_id_out);
-                            uint32_t bytes_left_in_row = row_width_bytes - (t_i * stride_size_bytes);
-                            if (bytes_left_in_row > row_width_bytes) {
-                                bytes_left_in_row = 0;
-                            }
-
-                            uint32_t current_chunk_bytes =
-                                (stride_size_bytes < bytes_left_in_row) ? stride_size_bytes : bytes_left_in_row;
-                            uint32_t chunk_noc_offset = t_i * stride_size_bytes;
-                            uint32_t write_len = ALIGN_TO(current_chunk_bytes, alignment);
-                            uint32_t row_block_base_row = (((((nd * outD) + d) * outN + n) * outC + c) * outHt) + th;
-
                             for (uint32_t row = 0; row < limit; ++row) {
-                                uint32_t row_abs_idx = row_block_base_row + row;
-                                uint64_t dst_noc_addr = get_noc_addr(row_abs_idx, dst) + chunk_noc_offset;
-                                noc_async_write(l1_read_addr, dst_noc_addr, write_len);
+                                const uint32_t row_abs_idx = row_block_base_row + row;
+                                const uint64_t dst_noc_addr = get_noc_addr(row_abs_idx, dst) + current_chunk_offset;
+                                noc_async_write(l1_read_addr, dst_noc_addr, current_write_len);
                                 l1_read_addr += current_chunk_bytes;
                             }
 


### PR DESCRIPTION
### Ticket
[Link to Github Issue ](https://github.com/tenstorrent/tt-metal/issues/28645#issuecomment-3490393158)

### Problem description
Currently the row major version of eltwise is performed by converting to tiled, performing the eltwise and then converting back to row major. This approach introduces costly conversions and dependencies on other operations that could be avoided.

### What's changed
Instead of tilizing the entire tensor, we stream row-major data directly from DRAM into tile-sized slices inside circular buffers. These slices are fed into the existing Binary NG SFPU compute kernel with no intermediate layout transforms.

This improves compute throughput for RM tensors

#### **No-broadcast Case**

* Each row is split into tile-sized chunks (up to 32×32 values).
* These chunks are streamed directly into circular buffers (`cb_a`, `cb_b`).
* Compute kernel consumes tiles as usual, but the data originates directly from RM layout.
* Rows are partitioned across Tensix cores.
* Large rows (width > tile_width) are handled by issuing sequential reads per tile chunk.

#### **Row Broadcast**

* Broadcasted row is expanded once into a full tile and stored in CB.
* All tiles in that row reuse this CB entry.

#### **Column Broadcast**
* Column vector is stretched to match tile dimensions by repeating each element across the row


### Performance Improvments 


#### Per-Case Summary (Main vs Native Row-Major)

```
 Case    Dtype Broadcast       Shape  Main Row Host (us)  Feature Row Host (us)  Host Speedup vs Main Row  Main Row Dev (us)  Feature Row Dev (us)  Dev Speedup vs Main Row
    1 BFLOAT16      NONE   1x1x32x32           1124.0500               267.8310                    4.1969            12.7310                8.1900                   1.5545
    2 BFLOAT16      NONE   4x2x32x32            690.9900                26.2290                   26.3445            13.8500                8.2320                   1.6825
    3 BFLOAT16      NONE 1x1x32x1056            349.8800                 2.8600                  122.3357            44.7180                4.4410                  10.0694
    4 BFLOAT16      NONE 2x2x32x1024            485.5100                 3.4400                  141.1366            67.9020                8.0620                   8.4225
    5 BFLOAT16  SCALAR_B   1x1x32x32            561.1790               336.7290                    1.6666            16.5130               14.0350                   1.1766
    6 BFLOAT16  SCALAR_B   4x2x32x32             12.3200                 3.2000                    3.8500            17.7970               14.1280                   1.2597
    7 BFLOAT16  SCALAR_B 1x1x32x1056             50.2100                 2.6900                   18.6654            40.0300                6.9030                   5.7989
    8 BFLOAT16  SCALAR_B 2x2x32x1024             27.2300                 3.1800                    8.5629            58.5320               14.4700                   4.0451
    9 BFLOAT16     ROW_B   1x1x32x32            471.9700               346.4100                    1.3625            14.0910               13.9370                   1.0110
   10 BFLOAT16     ROW_B   4x2x32x32            628.7800                 3.2600                  192.8773            15.1500               13.7930                   1.0984
   11 BFLOAT16     ROW_B 1x1x32x1056            232.9610                 2.7100                   85.9635            35.6470                6.5180                   5.4690
   12 BFLOAT16     ROW_B 2x2x32x1024            165.8600                 2.9500                   56.2237           139.6700                8.3910                  16.6452
   13 BFLOAT16     COL_B   1x1x32x32            399.6500               152.4310                    2.6218            33.5490               21.8040                   1.5387
   14 BFLOAT16     COL_B   4x2x32x32            106.2600                 3.1400                   33.8408            34.8550               21.6230                   1.6119
   15 BFLOAT16     COL_B 1x1x32x1056              7.9100                 2.7800                    2.8453            57.0130                6.9930                   8.1529
   16 BFLOAT16     COL_B 2x2x1024x32            490.2010                 6.5100                   75.2997            96.0430               57.7970                   1.6617
   17  FLOAT32      NONE   1x1x32x32           1036.4300               238.1800                    4.3515            13.7790                8.8660                   1.5541
   18  FLOAT32      NONE   4x2x32x32           1041.4310                 3.9700                  262.3252            15.9270                8.7240                   1.8257
   19  FLOAT32      NONE 1x1x32x1056           1135.1110                 2.5910                  438.0976            48.4420                5.6890                   8.5150
   20  FLOAT32      NONE 2x2x32x1024            636.3800                 2.8710                  221.6580           113.8520               14.0710                   8.0913
   21  FLOAT32  SCALAR_B   1x1x32x32            869.2210               306.3700                    2.8372            22.6300               22.0690                   1.0254
   22  FLOAT32  SCALAR_B   4x2x32x32             57.6590                 3.3600                   17.1604            25.2520               22.2010                   1.1374
   23  FLOAT32  SCALAR_B 1x1x32x1056              6.8500                 2.6300                    2.6046            50.0730               10.5950                   4.7261
   24  FLOAT32  SCALAR_B 2x2x32x1024             33.0890                 2.7200                   12.1651            90.6130               24.6960                   3.6691
   25  FLOAT32     ROW_B   1x1x32x32            566.7720               277.3700                    2.0434            30.3340               21.4510                   1.4141
   26  FLOAT32     ROW_B   4x2x32x32            179.0300                 8.4690                   21.1394            32.1420               21.4540                   1.4982
   27  FLOAT32     ROW_B 1x1x32x1056            219.6100                23.3900                    9.3891            54.2530               10.4850                   5.1743
   28  FLOAT32     ROW_B 2x2x32x1024            174.8700                 2.7100                   64.5277           294.3180               14.9310                  19.7119
   29  FLOAT32     COL_B   1x1x32x32            315.8710               237.1310                    1.3321            29.7160               23.7760                   1.2498
   30  FLOAT32     COL_B   4x2x32x32            114.0700                25.1910                    4.5282            31.2620               23.9200                   1.3069
   31  FLOAT32     COL_B 1x1x32x1056              8.5400                 3.2000                    2.6688            57.6160               10.4470                   5.5151
   32  FLOAT32     COL_B 2x2x1024x32            527.1820                 3.0410                  173.3581            88.8160               64.1850                   1.3838
```


- Host mean speedup: **63.0619x**
- Host median speedup: **14.6627x**
- Host geometric mean speedup: **16.2778x**
- Host total-time speedup (sum main / sum feature): **5.5106x**
- Device mean speedup: **4.3436x**
- Device median speedup: **1.6721x**
- Device geometric mean speedup: **2.8276x**
- Device total-time speedup (sum main / sum feature): **3.1611x**


### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1212832436210943