### PR TITLE
Make from_torch return None instead of throwing when passed None as the tensor argument

### DIFF
--- a/tests/ttnn/unit_tests/base_functionality/test_to_and_from_torch.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_to_and_from_torch.py
@@ -10,6 +10,10 @@ import ttnn
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
 
+def test_from_torch_none():
+    assert ttnn.from_torch(None) is None
+
+
 @pytest.mark.parametrize(
     "shape",
     [


### PR DESCRIPTION
### Ticket
[Github Issue](https://github.com/tenstorrent/tt-metal/issues/14458)

### Problem description
From the original issue:
> Currently, passing a `None` torch tensor to `ttnn.from_torch` triggers a FATAL error. This behavior is not ideal since ttnn operations allow optional tensors as param. When the param is `None`, it would be more convenient if `from_torch` could accept it and return a `None` ttnn tensor, avoiding the need for additional if-else handling.

### What's changed
- Added an early return to the `ttnn.from_torch` function. Now `ttnn.from_torch` returns `None` when the `tensor` argument is `None`.
- Updated type annotations and the docstring.
- Added a test case covering the new change.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/19502004593) CI passes
- [x] New tests provide coverage for changes