### PR TITLE
Fplavec 32279 keepdim ttnn.prod

### DIFF
--- a/.cursor/commands/git/commit.md
+++ b/.cursor/commands/git/commit.md
@@ -1,0 +1,34 @@
+# Commit
+
+## Overview
+Create a git commit with an appropriate commit message following conventional commit format.
+
+## Steps
+1. **Prepare changes**
+   - Check what stages you got with `git status`
+   - Stage proper changes with `git add`
+
+2. **Write commit message**
+   - Follow conventional commit format: `<type>(<scope>): <subject>`
+   - Use imperative, present tense for subject
+   - Include body if explanation needed
+   - Reference issues in footer if applicable
+
+3. **Address any issues surfaced by a precommit hook**
+
+
+**Commit types**
+   - `feat`: New feature
+   - `fix`: Bug fix
+   - `docs`: Documentation changes
+   - `refactor`: Code refactoring
+   - `test`: Adding or updating tests
+   - `chore`: Maintenance tasks
+
+**Common scopes**
+   - `ttnn`, `tt_metal`, `model`
+
+## Commit Template
+- [ ] Changes are staged
+- [ ] Commit message follows conventional format
+- [ ] No sensitive data in changes

--- a/.cursor/commands/git/create-pr.md
+++ b/.cursor/commands/git/create-pr.md
@@ -1,0 +1,22 @@
+# Create PR
+
+## Overview
+Create a well-structured pull request with proper description, labels, and reviewers.
+
+## Steps
+1. **Prepare branch**
+   - Ensure all changes are committed
+   - Push branch to remote
+   - Verify branch is up to date with main
+
+2. **Write PR description**
+   - Summarize changes clearly according to the template in .github/pull_request_template.md
+   - Include context and motivation
+   - List any breaking changes
+   - Add screenshots if UI changes
+
+3. **Set up PR**
+   - Create PR with descriptive title
+   - Add appropriate labels
+   - Assign reviewers
+   - Link related issues

--- a/.cursor/commands/ttnn/migrate-device-operation.md
+++ b/.cursor/commands/ttnn/migrate-device-operation.md
@@ -1,0 +1,39 @@
+# Migrate Device Operation to TMP Pattern
+
+Migrate a device operation from the old vector-based structure to the new TMP (Template Metaprogramming) device operation pattern that eliminates unnecessary heap allocations.
+
+## Usage
+
+When you need to migrate a device operation, use this command and provide:
+- The operation name you're migrating (e.g., 'Embedding', 'Unary', 'Dropout')
+- The location of the old device operation code
+
+## Comprehensive Guide
+
+**Follow the detailed migration guide at:** `ttnn/cursor/DEVICE_OPERATION_MIGRATION_GUIDE.md`
+
+The comprehensive guide includes:
+- Detailed comparison of old vs new operation structures
+- Step-by-step migration process with code examples
+- Complete 15-step checklist for verification
+- File structure guidance
+- Building and testing instructions
+- Reference examples (Dropout operation)
+
+See the comprehensive guide for detailed examples and the complete 15-step checklist.
+
+## Common Pitfalls
+
+1. **Forgetting to register the prim**: Always register in `ttnn::prim` namespace and use it instead of direct calls
+2. **Including runtime-only values in hash**: Only hash compile-time constants that affect program structure
+3. **Not including values that affect the program structure in hash**: Every parameter that affects program structure must be in the hash
+4. **Redundant tensors in tensor_args_t**: Do not add redundant arguments like `preallocated_output`, if legacy operation did not handle that explicitly in `create_output_tensors`
+5. **tensor_args_t must NOT contain references** - no `const &` or `&`
+
+## Example Reference
+
+See the Dropout operation migration for a complete example:
+- Location: `ttnn/cpp/ttnn/operations/experimental/dropout`
+- PRs: https://github.com/tenstorrent/tt-metal/pull/11793, https://github.com/tenstorrent/tt-metal/pull/11956
+
+For detailed file structure, building, and testing instructions, see the comprehensive guide.

--- a/.cursor/commands/ttnn/verify-device-operation-hash.md
+++ b/.cursor/commands/ttnn/verify-device-operation-hash.md
@@ -1,0 +1,453 @@
+# Verify Device Operation Hash
+
+Verify that a device operation's `compute_program_hash` correctly includes all values that affect program structure and excludes runtime-only values.
+
+## Usage
+
+When you need to verify a device operation's hash implementation, use this command and provide:
+- The operation name you're verifying (e.g., 'Dropout', 'Conv3d', 'Binary')
+- The location of the device operation code
+
+## Overview
+
+The program hash is used by the program cache to determine if a cached program can be reused. The hash must include:
+- **All values that affect selection of a program factory**
+- **All values that affect program structure** (kernels, kernel groups, compile-time args, defines, CB configs, semaphores)
+- **Program factory variant index** (when multiple factories exist)
+
+The hash must exclude:
+- **Values that don't affect program structure** (buffer address, offsets, number of tiles to process, etc)
+
+## Quick Decision: Do You Need a Custom Hash?
+
+**Default Implementation Available:**
+The infrastructure provides a default `compute_program_hash` that automatically hashes:
+- The device operation type
+- All of `operation_attributes_t`
+- All of `tensor_args_t`
+
+**You can skip implementing `compute_program_hash` if:**
+- ✅ All members of `operation_attributes_t` affect program structure (or program factory selection)
+- ✅ All relevant properties of `tensor_args_t` affect program structure
+- ✅ Single program factory (no factory variant index needed)
+- ✅ No runtime-only values in `operation_attributes_t` that don't affect program structure
+
+**You must implement custom `compute_program_hash` if:**
+- ❌ You have runtime-only values in `operation_attributes_t` (e.g., `seed` that only affects runtime args)
+- ❌ You have multiple program factories (need to include `program_factory.index()`)
+- ❌ You need to exclude specific tensor properties that don't affect program structure
+- ❌ You need to include derived values not directly in `operation_attributes_t` or `tensor_args_t`
+
+## Analysis Process
+
+### Step 1: Identify Program Factory(ies)
+
+1. Check `select_program_factory` in the device operation to see if there are multiple factories
+2. If single factory: analyze that one factory
+3. If multiple factories: analyze each factory variant separately
+
+**Example (Dropout):**
+```cpp
+program_factory_t select_program_factory(const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    if (args.use_per_device_seed) {
+        return program::DropoutMeshWorkloadFactory{};
+    } else {
+        return program::DropoutProgramFactory{};
+    }
+}
+```
+This has 2 factories, so analyze both.
+
+### Step 2: Analyze Program Factory `create` Method
+
+For each program factory, examine the `create` method and identify what affects program structure:
+
+#### 2.1 Kernels
+
+**What to look for:**
+- Kernel paths (different kernels = different program structure)
+- Kernel types (Reader, Writer, Compute)
+- Kernel configurations (MathFidelity, fp32_dest_acc_en, math_approx_mode)
+
+**What affects hash:**
+- Kernel source file path
+- Kernel type (ReaderDataMovementConfig, WriterDataMovementConfig, ComputeConfig)
+- Math fidelity settings
+- Any compile-time kernel configuration
+
+**Example:**
+```cpp
+kernels.reader = create_reader_kernel(program, all_cores, reader_compile_args, kReaderKernelPath);
+kernels.writer = create_writer_kernel(program, all_cores, writer_compile_args, kWriterKernelPath);
+kernels.compute_group_1 = create_compute_kernel(program, core_group_1, compute_group_1_args, kComputeKernelPath, math_approx_mode);
+```
+- `kReaderKernelPath`, `kWriterKernelPath`, `kComputeKernelPath` → affects hash
+- `math_approx_mode` → affects hash (part of ComputeConfig)
+
+#### 2.2 Kernel Groups / Core Ranges
+
+**What to look for:**
+- CoreRangeSet assignments to different kernel groups
+- Different core ranges for different kernels
+
+**What affects hash:**
+- CoreRangeSet structure (which cores run which kernels)
+- Number of core groups
+- Core group assignments
+
+**Example:**
+```cpp
+auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
+    split_work_to_cores(compute_with_storage_grid_size, num_tiles);
+```
+- `core_group_1`, `core_group_2` structure → affects hash
+- `num_cores`, `num_cores_y` → may affect hash if they change core assignments
+
+#### 2.3 Compile-Time Arguments
+
+**What to look for:**
+- Values passed to `CreateKernel` as compile-time args
+- Values in `compile_time_args` vectors
+- Values from `TensorAccessorArgs` (these are compile-time)
+
+**What affects hash:**
+- All compile-time arguments passed to kernels
+- Tensor accessor args (buffer layout, strides, etc.)
+
+**Example:**
+```cpp
+std::vector<uint32_t> compute_group_1_args = {
+    num_tiles_per_core_group_1,  // per_core_block_cnt
+    1,                           // per_core_block_size
+    prob_int,                    // prob
+    uscale                       // scale
+};
+```
+- All values in `compute_group_1_args` → affect hash
+- These come from `operation_attributes_t` (prob, scale) or `tensor_args_t` (num_tiles derived from input shape)
+
+**Important:** If a value is used in compile-time args, it MUST be in the hash, even if it's also used in runtime args.
+
+#### 2.4 Defines (Preprocessor Defines)
+
+**What to look for:**
+- `std::map<std::string, std::string> defines` passed to kernel creation
+- Any preprocessor defines that change kernel compilation
+
+**What affects hash:**
+- All define keys and values
+
+**Example:**
+```cpp
+std::map<std::string, std::string> defines;
+defines["STATS_GRANULARITY"] = std::to_string(stats_granularity);
+defines["LOG2_STATS_GRANULARITY"] = std::to_string(log2_stats_granularity);
+defines["EXP_APPROX_MODE"] = std::to_string(exp_approx_mode);
+
+auto reader_kernels_id = CreateKernel(
+    program,
+    kernel_path,
+    core_grid,
+    tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args, defines));
+```
+- All define values → affect hash
+- These typically come from `operation_attributes_t` or derived from `tensor_args_t`
+
+#### 2.5 Circular Buffer (CB) Configs
+
+**What to look for:**
+- `CircularBufferConfig` creation
+- CB indices, data formats, page sizes, number of tiles
+
+**What affects hash:**
+- CB index
+- Data format
+- Page size
+- Number of tiles
+- Core ranges for each CB
+
+**Example:**
+```cpp
+CircularBufferConfig cb_config = CircularBufferConfig(num_tiles * single_tile_size, {{cb_index, data_format}})
+                                     .set_page_size(cb_index, single_tile_size);
+auto cb_handle = CreateCircularBuffer(program, core_ranges, cb_config);
+```
+- `cb_index`, `data_format`, `single_tile_size`, `num_tiles` → affect hash
+- These come from tensor dtypes (affects data_format) and shapes (affects num_tiles)
+
+#### 2.6 Semaphores
+
+**What to look for:**
+- `CreateSemaphore` calls
+- Semaphore initialization values
+
+**What affects hash:**
+- Semaphore indices
+- Initial values (if compile-time)
+- Core ranges
+
+**Note:** Most semaphores use runtime values, but if initialization is compile-time, it affects hash.
+
+### Step 3: Trace Values Back to Source
+
+For each value identified above, trace it back to:
+- `operation_attributes_t` members
+- `tensor_args_t` members (or properties derived from tensors like shape, dtype, memory_config)
+
+**Example (Dropout):**
+- `prob_int` (compile-time arg) → comes from `args.prob` (operation_attributes_t)
+- `uscale` (compile-time arg) → comes from `args.scale` (operation_attributes_t)
+- `num_tiles` (CB config) → derived from `input.physical_volume()` (tensor_args_t)
+- `data_fmt_in` (CB config) → derived from `input.dtype()` (tensor_args_t)
+- `core_group_1`, `core_group_2` → derived from `num_tiles` and `compute_with_storage_grid_size` (tensor_args_t)
+
+### Step 4: Decide if Custom `compute_program_hash` is Needed
+
+**Default Implementation:**
+The infrastructure provides a default `compute_program_hash` that hashes:
+- The device operation type
+- All of `operation_attributes_t`
+- All of `tensor_args_t`
+
+**When to Use Default (No Custom Implementation Needed):**
+✅ Use the default if:
+- All members of `operation_attributes_t` affect program structure (or program factory selection)
+- All relevant properties of `tensor_args_t` affect program structure
+- No runtime-only values in `operation_attributes_t` that don't affect program structure
+- Single program factory (no factory variant index needed)
+
+**When to Implement Custom `compute_program_hash`:**
+❌ Implement custom hash if:
+- You have runtime-only values in `operation_attributes_t` that don't affect program structure (e.g., `seed` in Dropout)
+- You have multiple program factories and need to include `program_factory.index()`
+- You need to exclude specific tensor properties that don't affect program structure
+- You need to include derived values not directly in `operation_attributes_t` or `tensor_args_t`
+
+### Step 5: Check Custom `compute_program_hash` Implementation (If Needed)
+
+If you need a custom implementation, verify that it includes:
+1. ✅ Program factory variant index (if multiple factories)
+2. ✅ All `operation_attributes_t` members that affect program structure
+3. ✅ All `tensor_args_t` properties that affect program structure
+4. ✅ Any derived values that affect program structure
+
+Verify that it excludes:
+1. ❌ Runtime-only values (buffer addresses, offsets)
+2. ❌ Values only used in `override_runtime_arguments` (unless also used in compile-time args)
+3. ❌ Values that don't affect program structure
+
+**Example 1: Dropout (Custom Hash Needed)**
+
+Dropout needs a custom hash because:
+- `seed` in `operation_attributes_t` is runtime-only (only affects runtime args)
+- Multiple program factories (needs `program_factory.index()`)
+
+```cpp
+tt::stl::hash::hash_t DropoutDeviceOperation::compute_program_hash(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    const auto& input_tensor = tensor_args.input;
+    const auto& input_shape = input_tensor.padded_shape();
+    auto args_without_seed = args;
+    args_without_seed.seed = 0;  // ✅ Correct: seed only affects runtime args
+    auto program_factory = select_program_factory(args, tensor_args);
+    operation::Hash hash = operation::hash_operation<DropoutDeviceOperation>(
+        args_without_seed,           // ✅ Includes prob, scale, output_dtype, output_memory_config
+        program_factory.index(),     // ✅ Includes factory variant index
+        input_tensor.dtype(),        // ✅ Affects CB data format
+        input_tensor.memory_config(), // ✅ Affects program structure
+        input_shape.volume());       // ✅ Affects num_tiles, core groups
+    return hash;
+}
+```
+
+**Analysis:**
+- ✅ `program_factory.index()` - correct (2 factories)
+- ✅ `args_without_seed` - includes prob, scale, output_dtype, output_memory_config (all affect program structure)
+- ✅ `input_tensor.dtype()` - affects CB data format
+- ✅ `input_tensor.memory_config()` - affects program structure
+- ✅ `input_shape.volume()` - affects num_tiles and core group assignments
+- ✅ `seed` excluded - correct (only used in runtime args)
+
+**Example 2: Operation with Default Hash (No Custom Implementation)**
+
+If an operation has:
+- All `operation_attributes_t` members affect program structure
+- All relevant `tensor_args_t` properties affect program structure
+- Single program factory
+- No runtime-only values in attributes
+
+Then you can **omit** `compute_program_hash` entirely. The default implementation will hash all of `operation_attributes_t` and `tensor_args_t`, which is correct.
+
+## Testing Your Hash Implementation
+
+### Test Pattern 1: Cache Hit Test (Same Structure, Different Addresses)
+
+Test that programs with the same structure but different buffer addresses reuse the cache:
+
+```python
+def test_operation_cache_address(device, ...):
+    # Test that program cache updates the addresses of the inputs
+    grid_size = device.compute_with_storage_grid_size()
+    dummy = []
+    for _ in range(3):
+        # Create new tensors with different addresses but same structure
+        dummy.append(ttnn.from_torch(torch.randn(input_shape), device=device, layout=ttnn.TILE_LAYOUT))
+        run_operation_test(device, ...)
+
+    # Should have only 1 cache entry (same program structure)
+    assert device.num_program_cache_entries() == 1
+```
+
+### Test Pattern 2: Cache Miss Test (Different Structure)
+
+Test that programs with different structure create separate cache entries:
+
+```python
+def test_operation_cache_hash(device, ...):
+    # Test that program cache does not re-use the same program for different inputs
+    grid_size = device.compute_with_storage_grid_size()
+    dummy = []
+    for i in range(2):
+        # Change something that affects program structure
+        new_shape = (input_shape[0], input_shape[1] * (i + 1), ...)
+        dummy.append(ttnn.from_torch(torch.randn(new_shape), device=device, layout=ttnn.TILE_LAYOUT))
+        run_operation_test(device, new_shape, ...)
+
+    # Should have 2 cache entries (different program structures)
+    assert device.num_program_cache_entries() == 2
+```
+
+### Test Pattern 3: Runtime-Only Changes (Cache Hit)
+
+Test that changing runtime-only values (like seed) doesn't create new cache entries:
+
+```python
+def test_operation_cache_runtime_only(device, ...):
+    # Test that changing runtime-only values doesn't create new cache entries
+    for seed in [42, 123, 456]:
+        run_operation_test(device, ..., seed=seed)
+
+    # Should have only 1 cache entry (seed doesn't affect program structure)
+    assert device.num_program_cache_entries() == 1
+```
+
+### Test Pattern 4: Compile-Time Changes (Cache Miss)
+
+Test that changing compile-time values creates new cache entries:
+
+```python
+def test_operation_cache_compile_time(device, ...):
+    # Test that changing compile-time values creates new cache entries
+    for prob in [0.1, 0.5, 0.9]:
+        run_operation_test(device, ..., prob=prob)
+
+    # Should have 3 cache entries (prob affects compile-time args)
+    assert device.num_program_cache_entries() == 3
+```
+
+## Checklist
+
+Use this checklist to verify your hash implementation:
+
+### For Single Program Factory:
+- [ ] Identified all kernels and their configurations
+- [ ] Identified all kernel groups/core ranges
+- [ ] Identified all compile-time arguments
+- [ ] Identified all defines
+- [ ] Identified all CB configurations
+- [ ] Identified all semaphores (if any)
+- [ ] Traced all values back to `operation_attributes_t` or `tensor_args_t`
+- [ ] **Decided if custom `compute_program_hash` is needed:**
+  - [ ] All `operation_attributes_t` members affect program structure? → Can use default
+  - [ ] All relevant `tensor_args_t` properties affect program structure? → Can use default
+  - [ ] Any runtime-only values in `operation_attributes_t`? → Need custom hash
+- [ ] If custom hash needed: Verified it includes all identified values
+- [ ] If custom hash needed: Verified it excludes runtime-only values
+- [ ] Written cache hit test (same structure, different addresses)
+- [ ] Written cache miss test (different structure)
+- [ ] Written runtime-only change test (should hit cache)
+- [ ] Written compile-time change test (should miss cache)
+
+### For Multiple Program Factories:
+- [ ] Analyzed each program factory variant separately
+- [ ] Verified `compute_program_hash` includes `program_factory.index()`
+- [ ] Verified each factory's hash includes all its structure-affecting values
+- [ ] Written tests for each factory variant
+- [ ] Written test that verifies different factories create different cache entries
+
+## Common Issues
+
+### Issue 1: Missing Program Factory Index
+
+**Problem:** When multiple factories exist, forgetting to include `program_factory.index()` in hash.
+
+**Solution:** Always include `select_program_factory(...).index()` in the hash.
+
+### Issue 2: Including Runtime-Only Values
+
+**Problem:** Including values that only affect runtime arguments (like seed, buffer addresses).
+
+**Solution:** Only include values used in compile-time args, kernel configs, CB configs, or defines.
+
+### Issue 3: Excluding Compile-Time Values
+
+**Problem:** Forgetting to include values that affect compile-time args but are also used in runtime args.
+
+**Solution:** If a value is used in compile-time args, it MUST be in the hash, even if also used in runtime args.
+
+### Issue 4: Missing Derived Values
+
+**Problem:** Forgetting to include values derived from tensors that affect program structure (like num_tiles from shape).
+
+**Solution:** Include all tensor properties that affect program structure: dtype, memory_config, shape (for num_tiles, core groups).
+
+### Issue 5: Including Values That Don't Affect Structure
+
+**Problem:** Including values that don't actually affect kernels, CBs, or program structure.
+
+**Solution:** Only include values that directly affect: kernel paths/configs, compile-time args, defines, CB configs, core ranges, semaphores.
+
+### Issue 6: Unnecessary Custom Hash Implementation
+
+**Problem:** Implementing a custom `compute_program_hash` when the default would work.
+
+**Solution:** If all `operation_attributes_t` members and all relevant `tensor_args_t` properties affect program structure, and you have a single program factory, you can omit `compute_program_hash` entirely. The default implementation will hash all attributes and tensor args, which is correct.
+
+## Example Reference
+
+**Operations with Custom Hash (Needed):**
+- Dropout: Location `ttnn/cpp/ttnn/operations/experimental/dropout`
+  - Hash implementation: `dropout_device_operation.cpp` (lines 115-130)
+  - Why custom: Has `seed` (runtime-only) and multiple program factories
+  - Program factory: `dropout_program_factory.cpp`
+  - Tests: `tests/ttnn/unit_tests/operations/dropout/`
+
+- PlusOne: Location `ttnn/cpp/ttnn/operations/experimental/plusone`
+  - Hash implementation: `plusone_device_operation.cpp` (lines 35-56)
+  - Why custom: Hashes specific tensor properties (dtype, memory_config, shape) rather than whole tensor
+
+**Operations Using Default Hash:**
+- Look for operations that don't declare `compute_program_hash` - they use the default implementation
+
+**Test Examples:**
+- Conv3d operation tests: Location `tests/ttnn/unit_tests/operations/conv/test_conv3d.py`
+  - Cache address test: `test_conv3d_cache_address` (lines 199-208)
+  - Cache hash test: `test_conv3d_cache_hash` (lines 216-228)
+
+## Building and Testing
+
+**Build:**
+```bash
+./build_metal.sh -c -e --debug --without-python-bindings
+```
+
+**Test:**
+```bash
+source python_env/bin/activate
+pytest tests/ttnn/unit_tests/operations/<operation_name>/ -v
+```
+
+**Reset device if needed:**
+```bash
+tt-smi -r
+```

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -53,7 +53,7 @@ tt_metal/hostdevcommon/ @abhullar-tt @jbaumanTT @kstevensTT @tenstorrent/codeown
 tt_metal/hw @abhullar-tt @jbaumanTT @nathan-TT @kstevensTT @tenstorrent/codeowner-bypass
 tt_metal/hw/ckernels/ @rtawfik01 @rdjogoTT @nvelickovicTT @amahmudTT @lpremovicTT @ncvetkovicTT @fvranicTT @tenstorrent/codeowner-bypass
 tt_metal/hw/firmware/src/tt-1xx/*erisc* @aliuTT @ubcheema @tenstorrent/codeowner-bypass
-tt_metal/hw/inc/ @abhullar-tt @jbaumanTT @kstevensTT @nathan-TT @vvukomanovicTT @atatuzunerTT @tenstorrent/codeowner-bypass
+tt_metal/hw/inc/ @abhullar-tt @jbaumanTT @kstevensTT @nathan-TT @vvukomanovicTT @atatuzunerTT @ruizhangTT @tenstorrent/codeowner-bypass
 tt_metal/hw/inc/ethernet/ @aliuTT @ubcheema @tenstorrent/codeowner-bypass
 tt_metal/hw/inc/tt-1xx/wormhole/eth_l1_address_map.h @aliuTT @ubcheema @tenstorrent/codeowner-bypass
 tt_metal/hw/inc/accessor @tenstorrent/metalium-developers-ttnn-core @tenstorrent/codeowner-bypass

--- a/.github/workflows/all-static-checks.yaml
+++ b/.github/workflows/all-static-checks.yaml
@@ -35,10 +35,13 @@ jobs:
 
       - name: Run Pre-commit
         uses: pre-commit/action@v3.0.1
+        env:
+          PRE_COMMIT_FROM_REF: ${{ github.event_name == 'pull_request' && format('refs/remotes/origin/{0}', github.event.pull_request.base.ref) || 'HEAD^' }}
+          PRE_COMMIT_TO_REF: HEAD
         with:
           extra_args: |
-            --from-ref ${{ github.event_name == 'pull_request' && format('refs/remotes/origin/{0}', github.event.pull_request.base.ref) || 'HEAD^' }} \
-            --to-ref HEAD
+            --from-ref ${{ env.PRE_COMMIT_FROM_REF }} \
+            --to-ref ${{ env.PRE_COMMIT_TO_REF }}
         continue-on-error: false
   check-black:
     runs-on: ubuntu-latest

--- a/.github/workflows/blackhole-20-cores-tests.yaml
+++ b/.github/workflows/blackhole-20-cores-tests.yaml
@@ -71,6 +71,3 @@ jobs:
         if: ${{ !cancelled() }}
         with:
           prefix: "test_reports_"
-
-      - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
-        if: always()

--- a/.github/workflows/blackhole-nightly-tests-20-cores-impl.yaml
+++ b/.github/workflows/blackhole-nightly-tests-20-cores-impl.yaml
@@ -76,6 +76,3 @@ jobs:
         with:
           slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
           owner: ${{ matrix.test-group.owner_id }}
-
-      - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
-        if: always()

--- a/.github/workflows/galaxy-nightly-tests-impl.yaml
+++ b/.github/workflows/galaxy-nightly-tests-impl.yaml
@@ -27,30 +27,16 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          { name: "Galaxy CCL tests", arch: wormhole_b0, cmd: "pytest tests/nightly/tg/ccl", timeout: 120, owner_id: U05ACKAJTHS}, # Naif Tarafdar
-          { name: "Galaxy Fabric unit tests", arch: wormhole_b0, cmd: build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="NightlyFabric*Fixture.*", timeout: 60, owner_id: U08UBDUKH6Z}, # Neel Nyamagoudar
-          { name: "Galaxy Fabric 2D Torus Nightly Tests", arch: wormhole_b0, cmd: ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_2d_torus_nightly.yaml, timeout: 60, owner_id: U08UBDUKH6Z}, # Neel Nyamagoudar
-          {
-            name: "Galaxy Fabric Stability Tests",
-            arch: wormhole_b0,
-            cmd: TT_METAL_CLEAR_L1=1 build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_stability_6U_galaxy.yaml,
-            timeout: 150,
-            owner_id: U08FXFFH7L0
-          }, # Abhishek Agarwal
+          { name: "Galaxy CCL tests", arch: wormhole_b0, cmd: "pytest tests/nightly/tg/ccl", timeout: 40, owner_id: U05ACKAJTHS}, # Naif Tarafdar
+          { name: "Galaxy Fabric unit tests", arch: wormhole_b0, cmd: build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="NightlyFabric*Fixture.*", timeout: 25, owner_id: U08UBDUKH6Z}, # Neel Nyamagoudar
+          { name: "Galaxy Fabric 2D Torus Nightly Tests", arch: wormhole_b0, cmd: ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_2d_torus_nightly.yaml, timeout: 45, owner_id: U08UBDUKH6Z}, # Neel Nyamagoudar
           {
             name: "Llama Galaxy Accuracy Test",
             arch: wormhole_b0,
             cmd: "LLAMA_DIR=/mnt/MLPerf/tt_dnn-models/llama/Llama3.3-70B-Instruct/ FAKE_DEVICE=TG pytest models/demos/llama3_70b_galaxy/tests/test_llama_accuracy.py",
-            timeout: 30,
+            timeout: 15,
             owner_id: U053W15B6JF
-          }, # Djordje Ivanovic
-          {
-            name: "Llama Galaxy Long Stress Test",
-            arch: wormhole_b0,
-            cmd: "LLAMA_DIR=/mnt/MLPerf/tt_dnn-models/llama/Llama3.3-70B-Instruct/ FAKE_DEVICE=TG pytest models/demos/llama3_70b_galaxy/demo/demo_decode.py  -k 'stress-test and not mini-stress-test'",
-            timeout: 240,
-            owner_id: U053W15B6JF
-          }, # Djordje Ivanovic
+          } # Djordje Ivanovic
         ]
     name: ${{ matrix.test-group.name }}
     runs-on:

--- a/.github/workflows/galaxy-nightly-tests.yaml
+++ b/.github/workflows/galaxy-nightly-tests.yaml
@@ -3,7 +3,7 @@ name: "(Galaxy) nightly tests"
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 0 * * 6" # Runs every Saturday at 12am UTC
+    - cron: "0 0 * * *" # Runs every day at 12am UTC
 
 jobs:
   build-artifact:

--- a/.github/workflows/galaxy-stress-tests-impl.yaml
+++ b/.github/workflows/galaxy-stress-tests-impl.yaml
@@ -68,3 +68,70 @@ jobs:
           owner: U053W15B6JF # Djordje Ivanovic
       - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
         if: always()
+
+  galaxy-long-tests:
+    strategy:
+      fail-fast: false
+      matrix:
+        test-group: [
+          {
+            name: "Galaxy Fabric Stability Tests",
+            arch: wormhole_b0,
+            cmd: TT_METAL_CLEAR_L1=1 build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_stability_6U_galaxy.yaml,
+            timeout: 100,
+            owner_id: U08FXFFH7L0
+          }, # Abhishek Agarwal
+          {
+            name: "Llama Galaxy Long Stress Test",
+            arch: wormhole_b0,
+            cmd: "LLAMA_DIR=/mnt/MLPerf/tt_dnn-models/llama/Llama3.3-70B-Instruct/ FAKE_DEVICE=TG pytest models/demos/llama3_70b_galaxy/demo/demo_decode.py  -k 'stress-test and not mini-stress-test'",
+            timeout: 140,
+            owner_id: U053W15B6JF
+          } # Djordje Ivanovic
+        ]
+    name: ${{ matrix.test-group.name }}
+    runs-on:
+      - ${{ inputs.extra-tag }}
+      - topology-6u
+      - arch-wormhole_b0
+      - pipeline-functional
+    container:
+      image: ${{ inputs.docker-image || 'docker-image-unresolved!' }}
+      env:
+        TT_METAL_HOME: /work
+        PYTHONPATH: /work
+        LD_LIBRARY_PATH: /work/build/lib
+        LOGURU_LEVEL: INFO
+        ARCH_NAME: ${{ matrix.test-group.arch }}
+      volumes:
+        - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
+        - /dev/hugepages-1G:/dev/hugepages-1G
+        - /mnt/MLPerf:/mnt/MLPerf:ro
+      options: "--device /dev/tenstorrent"
+    defaults:
+      run:
+        shell: bash
+        working-directory: /work # https://github.com/actions/runner/issues/878
+    steps:
+      - name: ⬇️  Setup Job
+        uses: tenstorrent/tt-metal/.github/actions/setup-job@5b5c6ff5b54025e165d189371cda93d2b9ef6115
+        timeout-minutes: 10
+        with:
+          build-artifact-name: ${{ inputs.build-artifact-name }}
+          wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
+      - name: Run tests
+        timeout-minutes: ${{ matrix.test-group.timeout }}
+        run: |
+          ${{ matrix.test-group.cmd }}
+      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
+        if: ${{ failure() }}
+        with:
+          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
+          owner: ${{ matrix.test-group.owner_id }}
+      - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
+        timeout-minutes: 10
+        if: ${{ !cancelled() }}
+        with:
+          prefix: "test_reports_"
+      - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
+        if: always()

--- a/.github/workflows/run-profiler-regression.yaml
+++ b/.github/workflows/run-profiler-regression.yaml
@@ -115,5 +115,3 @@ jobs:
         if: ${{ !cancelled() }}
         with:
           prefix: "test_reports_"
-      - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
-        if: always()

--- a/.github/workflows/t3000-fast-tests-impl.yaml
+++ b/.github/workflows/t3000-fast-tests-impl.yaml
@@ -113,5 +113,3 @@ jobs:
       - name: Generate gtest annotations on failure
         uses: tenstorrent/tt-metal/.github/actions/generate-gtest-failure-message@main
         if: ${{ failure() }}
-      - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
-        if: always()

--- a/.github/workflows/temp-ccache-test.yaml
+++ b/.github/workflows/temp-ccache-test.yaml
@@ -110,6 +110,3 @@ jobs:
         with:
           path: /work/build/tt-train/generated/test_reports/
           prefix: "test_reports_"
-
-      - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
-        if: always()

--- a/.github/workflows/tt-metal-l2-nightly-impl.yaml
+++ b/.github/workflows/tt-metal-l2-nightly-impl.yaml
@@ -222,8 +222,6 @@ jobs:
         with:
           slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
           owner: U08DCK9MA1E # Miłosz Gajewski
-      - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
-        if: always()
 
   ttnn-fused-tests:
     if: ${{ inputs.run_fused_tests }}
@@ -575,8 +573,6 @@ jobs:
         with:
           slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
           owner: ${{ matrix.owner }}
-      - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
-        if: always()
 
   ttnn-eltwise-tests:
     if: ${{ inputs.run_eltwise_tests }}

--- a/.github/workflows/ttnn-run-sweeps.yaml
+++ b/.github/workflows/ttnn-run-sweeps.yaml
@@ -621,9 +621,9 @@ jobs:
           echo "├─────────────────────────────────────────────────────────────┤"
           echo "│ Sweep Name:           ${{ github.event.inputs.sweep_name || 'ALL SWEEPS (Nightly)' }}"
           echo "│ Suite Name:           ${{ github.event.inputs.suite_name || 'Not specified' }}"
-          echo "│ Skip on Timeout:      ${{ github.event.inputs.skip_on_timeout == true && 'true' || 'false' }}"
-          echo "│ Upload Results:       ${{ github.event.inputs.upload_results == true && 'true' || 'false' }}"
-          echo "│ Measure Device Perf:  ${{ github.event.inputs.measure_device_perf == true && 'true' || 'false' }}"
+          echo "│ Skip on Timeout:      ${{ github.event.inputs.skip_on_timeout == 'true' && 'true' || 'false' }}"
+          echo "│ Upload Results:       ${{ github.event.inputs.upload_results == 'true' && 'true' || 'false' }}"
+          echo "│ Measure Device Perf:  ${{ github.event.inputs.measure_device_perf == 'true' && 'true' || 'false' }}"
           echo "│ Architecture:         ${{ github.event.inputs.arch || 'wormhole_b0' }}"
           echo "│ Runner Label:         ${{ github.event.inputs['runner-label'] || 'N150' }}"
           echo "│ Log Level:            ${{ github.event.inputs['log-level'] || 'INFO' }}"
@@ -651,10 +651,21 @@ jobs:
     name: Generate Sweep Vectors ${{ matrix.arch }} ${{ matrix.runner_label }}
     needs: build-artifact
     strategy:
+      fail-fast: false
       matrix:
         include:
+          # Entry 1: Manual dispatch with single sweep only
           - arch: ${{ github.event.inputs.arch || 'wormhole_b0' }}
             runner_label: ${{ github.event.inputs['runner-label'] || 'N150' }}
+            generate_mode: all
+          # Entry 2: Scheduled/comprehensive OR manual dispatch with "ALL SWEEPS" - N150 for non-CCL modules
+          - arch: ${{ github.event.inputs.arch || 'wormhole_b0' }}
+            runner_label: N150
+            generate_mode: non_ccl
+          # Entry 3: Scheduled/comprehensive OR manual dispatch with "ALL SWEEPS" - n300-llmbox for CCL modules only
+          - arch: ${{ github.event.inputs.arch || 'wormhole_b0' }}
+            runner_label: n300-llmbox
+            generate_mode: ccl_only
     container:
       image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       env:
@@ -706,15 +717,43 @@ jobs:
           echo "└─────────────────────────────────────────────────────────────┘"
           echo "::endgroup::"
       - name: Run ttnn sweeps generation (single sweep)
-        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.sweep_name != 'ALL SWEEPS (Nightly)' && github.event.inputs.sweep_name != 'ALL SWEEPS (Comprehensive)' }}
+        if: |
+          github.event_name == 'workflow_dispatch' &&
+          github.event.inputs.sweep_name != 'ALL SWEEPS (Nightly)' &&
+          github.event.inputs.sweep_name != 'ALL SWEEPS (Comprehensive)' &&
+          matrix.generate_mode == 'all'
         run: python3 tests/sweep_framework/sweeps_parameter_generator.py --module-name ${{ github.event.inputs.sweep_name }} --dump-file --tag ci-main --explicit
       - name: Run ttnn sweeps generation (all sweeps)
-        if: ${{ github.event_name == 'schedule' || github.event.inputs.sweep_name == 'ALL SWEEPS (Nightly)' || github.event.inputs.sweep_name == 'ALL SWEEPS (Comprehensive)' }}
-        run: python3 tests/sweep_framework/sweeps_parameter_generator.py --dump-file --tag ci-main --explicit
+        if: |
+          (github.event_name == 'schedule' ||
+           github.event.inputs.sweep_name == 'ALL SWEEPS (Nightly)' ||
+           github.event.inputs.sweep_name == 'ALL SWEEPS (Comprehensive)') &&
+          (matrix.generate_mode == 'non_ccl' || matrix.generate_mode == 'ccl_only')
+        run: |
+          # Determine which modules to skip based on generate_mode
+          SKIP_MODULES_FLAG=""
+          if [[ "${{ matrix.generate_mode }}" == "non_ccl" ]]; then
+            # Skip all CCL modules when generating on N150
+            SKIP_MODULES_FLAG="--skip-modules ccl.generality.all_broadcast,ccl.generality.all_gather,ccl.generality.all_reduce,ccl.generality.all_to_all_combine,ccl.generality.all_to_all_dispatch,ccl.generality.all_to_all,ccl.generality.point_to_point,ccl.generality.reduce_scatter"
+          elif [[ "${{ matrix.generate_mode }}" == "ccl_only" ]]; then
+            # Generate only CCL modules on n300-llmbox by skipping all non-CCL modules
+            # Use single-line Python command to avoid YAML parsing issues with multiline strings
+            NON_CCL_MODULES=$(python3 -c "import pathlib; sweeps_dir = pathlib.Path('tests/sweep_framework/sweeps'); all_modules = [str(py_file.relative_to(sweeps_dir))[:-3].replace('/', '.') for py_file in sorted(sweeps_dir.glob('**/*.py')) if '__init__' not in str(py_file.relative_to(sweeps_dir))[:-3].replace('/', '.') and not str(py_file.relative_to(sweeps_dir))[:-3].replace('/', '.').startswith('ccl.')]; print(','.join(all_modules))") || {
+              echo "Error: Failed to compute non-CCL modules"
+              exit 1
+            }
+            if [[ -z "$NON_CCL_MODULES" ]]; then
+              echo "Error: No non-CCL modules found - this would skip all modules"
+              exit 1
+            fi
+            SKIP_MODULES_FLAG="--skip-modules $NON_CCL_MODULES"
+          fi
+
+          python3 tests/sweep_framework/sweeps_parameter_generator.py --dump-file --tag ci-main --explicit $SKIP_MODULES_FLAG
       - name: Upload sweep vectors
         uses: actions/upload-artifact@v4
         with:
-          name: sweeps-vectors
+          name: sweeps-vectors-${{ matrix.generate_mode }}
           path: /work/tests/sweep_framework/vectors_export/
           retention-days: 1
   ttnn-compute-module-matrix:
@@ -732,55 +771,105 @@ jobs:
           echo "Run Attempt: ${{ github.run_attempt }}"
       - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0
         with:
-          name: sweeps-vectors
-          path: /tmp/vectors
+          pattern: sweeps-vectors-*
+          path: /tmp/vectors-download
+          merge-multiple: true
+      - name: Merge vector artifacts
+        shell: bash
+        run: |
+          # Create final vectors directory
+          mkdir -p /tmp/vectors
+          # Move all JSON files from subdirectories to /tmp/vectors
+          find /tmp/vectors-download -name "*.json" -exec mv {} /tmp/vectors/ \;
       - id: set-matrix
         shell: bash
         run: |
           python - <<'PY' > /tmp/matrix.json
-          import os, json, math, sys
+          import os, json, sys
           d = '/tmp/vectors'
           modules = sorted([f[:-5] for f in os.listdir(d) if f.endswith('.json')])
 
-          # Modules that need to be split by suite due to long execution times
-          suite_split_modules = {
-              'conv2d.full.conv2d_sliding_window': [
-                  'sliding_window_suite_0',
-                  'sliding_window_suite_1',
-                  'sliding_window_suite_2',
-                  'sliding_window_suite_3',
-                  'sliding_window_suite_4',
-                  'sliding_window_suite_5',
-                  'sliding_window_suite_6'
-              ]
-          }
+          # Helper for chunking modules into batches
+          def chunk_modules(items, size):
+              return [",".join(items[i:i+size]) for i in range(0, len(items), size)] if items else []
 
-          # Remove suite-split modules from regular processing
-          regular_modules = [m for m in modules if m not in suite_split_modules.keys()]
+          ccl_modules = [m for m in modules if m.startswith('ccl.')]
+
+          schedule_expr = "${{ github.event.schedule }}"
+          event_name = "${{ github.event_name }}"
+          sweep_name = "${{ github.event.inputs.sweep_name }}"
+          measure_device_perf = "${{ github.event.inputs.measure_device_perf }}"
 
           # Use smaller batch size for comprehensive runs (Wed/Sat schedule or manual comprehensive dispatch)
           # Also use smaller batch size when device performance measurement is enabled to avoid timeouts
           # Use larger batch size for nightly runs (Mon/Tue/Thu/Fri schedule or manual nightly dispatch)
-          device_perf_enabled = "${{ github.event_name }}" == "schedule" or "${{ github.event.inputs.measure_device_perf }}" == "true"
-          if "${{ github.event.schedule }}" == "0 4 * * 3" or "${{ github.event.schedule }}" == "0 5 * * 6" or "${{ github.event.inputs.sweep_name }}" == "ALL SWEEPS (Comprehensive)" or device_perf_enabled:
+          device_perf_enabled = event_name == "schedule" or measure_device_perf == "true"
+          if schedule_expr == "0 4 * * 3" or schedule_expr == "0 5 * * 6" or sweep_name == "ALL SWEEPS (Comprehensive)" or device_perf_enabled:
               BATCH_SIZE = 3  # Smaller batches for comprehensive runs or when device performance measurement is enabled (must stay under 256 total batches due to GitHub Actions limit)
           else:
               BATCH_SIZE = 10  # Larger batches for nightly runs
 
-          # Create batches for regular modules
-          batches = [",".join(regular_modules[i:i+BATCH_SIZE]) for i in range(0, len(regular_modules), BATCH_SIZE)]
+          # Create batches for all modules
+          regular_batches = chunk_modules(modules, BATCH_SIZE)
 
-          # Add suite-split modules as individual suite batches
-          for module_name, suites in suite_split_modules.items():
-              if module_name in modules:  # Only add if the module exists
-                  for suite in suites:
-                      batches.append(f"{module_name}:{suite}")
+          # Maintain backwards-compatible batch list output
+          batches = list(regular_batches)
+
+          # Generate CCL-only batches for dedicated runners
+          ccl_batches = chunk_modules(ccl_modules, BATCH_SIZE)
+
+          is_comprehensive = schedule_expr == "0 4 * * 3" or schedule_expr == "0 5 * * 6" or sweep_name == "ALL SWEEPS (Comprehensive)"
+          wormhole_suite_name = "nightly" if not is_comprehensive else None
+
+          include_entries = []
+
+          wormhole_template = {
+              "test_group_name": "wormhole-n150-sweeps",
+              "arch": "wormhole_b0",
+              "runs_on": "tt-ubuntu-2204-n150-stable",
+              "tt_smi_cmd": "tt-smi -r",
+          }
+
+          for batch in regular_batches:
+              include_entries.append({
+                  **wormhole_template,
+                  "module_selector": batch,
+                  "batch_display": batch,
+                  "suite_name": wormhole_suite_name,
+              })
+
+          if ccl_batches:
+              n300_template = {
+                  "test_group_name": "n300-llmbox-ccl",
+                  "arch": "wormhole_b0",
+                  "runs_on": "tt-ubuntu-2204-n300-llmbox-viommu-stable",
+                  "tt_smi_cmd": "tt-smi -r",
+              }
+              for batch in ccl_batches:
+                  include_entries.append({
+                      **n300_template,
+                      "module_selector": batch,
+                      "batch_display": f"ccl:{batch}",
+                      "suite_name": "generality_suite_fabric_1d",
+                  })
 
           total_batches = len(batches)
           if total_batches > 256:
               print(f"Total batch count ({total_batches}) exceeds GitHub Actions matrix limit of 256. Please adjust BATCH_SIZE or reduce the number of modules.", file=sys.stderr)
               sys.exit(1)
-          print(json.dumps({"module": modules, "batches": batches}))
+
+          total_matrix_entries = len(include_entries)
+          if total_matrix_entries > 256:
+              print(f"Total matrix entry count ({total_matrix_entries}) exceeds GitHub Actions matrix limit of 256. Please adjust batching logic or reduce modules.", file=sys.stderr)
+              sys.exit(1)
+
+          result = {
+              "module": modules,
+              "batches": batches,
+              "ccl_batches": ccl_batches,
+              "include": include_entries,
+          }
+          print(json.dumps(result))
           PY
           echo "matrix=$(cat /tmp/matrix.json)" >> "$GITHUB_OUTPUT"
   ttnn-run-single-sweep:
@@ -856,8 +945,9 @@ jobs:
       - name: Download sweep vectors
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0
         with:
-          name: sweeps-vectors
-          path: /work/tests/sweep_framework/vectors_export/
+          pattern: sweeps-vectors-*
+          path: /work/tests/sweep_framework/vectors_export
+          merge-multiple: true
       - name: Run ttnn sweeps (single sweep) ${{ github.event.inputs.runner_label }} ${{ github.event.inputs.sweep_name }} ${{ github.event.inputs.suite_name }}
         run: |
           SKIP_ON_TIMEOUT_FLAG=""
@@ -885,7 +975,7 @@ jobs:
           path: /work/tests/sweep_framework/results_export/
           retention-days: 1
   ttnn-run-sweeps-parallel:
-    name: Run sweeps in parallel (${{ matrix.test-group.name }}, ${{ matrix.batch }})
+    name: Run sweeps in parallel (${{ matrix.test_group_name }}, ${{ matrix.batch_display }})
     needs:
       - ttnn-generate-sweeps
       - build-artifact
@@ -897,34 +987,19 @@ jobs:
       fail-fast: false
       max-parallel: 20
       matrix:
-        test-group:
-          [
-            {
-              name: "wormhole-n150-sweeps",
-              arch: wormhole_b0,
-              runs-on: tt-ubuntu-2204-n150-stable,
-              tt-smi-cmd: "tt-smi -r"
-            },
-            # {
-            #   name: "Wormhole N300 Sweeps",
-            #   arch: wormhole_b0,
-            #   runs-on: tt-ubuntu-2204-n300-stable,
-            #   tt-smi-cmd: "tt-smi-metal -r 0"
-            # }
-          ]
-        batch: ${{ fromJSON(needs.ttnn-compute-module-matrix.outputs.matrix).batches }}
+        include: ${{ fromJSON(needs.ttnn-compute-module-matrix.outputs.matrix).include }}
     container:
       image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       env:
         TT_METAL_HOME: /work
         PYTHONPATH: /work
         LD_LIBRARY_PATH: /work/build/lib
-        ARCH_NAME: ${{ matrix.test-group.arch }}
+        ARCH_NAME: ${{ matrix.arch }}
         LOGURU_LEVEL: INFO
         GITHUB_ACTIONS: true
         ELASTIC_USERNAME: ${{ secrets.SWEEPS_ELASTIC_USERNAME }}
         ELASTIC_PASSWORD: ${{ secrets.SWEEPS_ELASTIC_PASSWORD }}
-        TT_SMI_RESET_COMMAND: ${{ matrix.test-group.tt-smi-cmd }}
+        TT_SMI_RESET_COMMAND: ${{ matrix.tt_smi_cmd }}
         TRACY_NO_INVARIANT_CHECK: 1
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
@@ -936,7 +1011,7 @@ jobs:
         shell: bash
         working-directory: /work # https://github.com/actions/runner/issues/878
     timeout-minutes: 720
-    runs-on: ${{ matrix.test-group.runs-on }}
+    runs-on: ${{ matrix.runs_on }}
     steps:
       - name: ⬇️  Setup Job
         uses: tenstorrent/tt-metal/.github/actions/setup-job@5b5c6ff5b54025e165d189371cda93d2b9ef6115
@@ -950,23 +1025,27 @@ jobs:
           echo "┌─────────────────────────────────────────────────────────────┐"
           echo "│              Parallel Sweeps Configuration                  │"
           echo "├─────────────────────────────────────────────────────────────┤"
-          echo "│ Run Mode:             Parallel Execution (${{ matrix.test-group.name }})"
-          echo "│ Batch:                ${{ matrix.batch }}"
-          echo "│ Architecture:         ${{ matrix.test-group.arch }}"
-          echo "│ Runner:               ${{ matrix.test-group.runs-on }}"
-          echo "│ Skip on Timeout:      ${{ github.event_name == 'schedule' && 'true' || (github.event.inputs.skip_on_timeout == true && 'true' || 'false') }}"
-          echo "│ Measure Device Perf:  ${{ github.event_name == 'schedule' && 'true' || (github.event.inputs.measure_device_perf == true && 'true' || 'false') }}"
-          echo "│ Upload Results:       ${{ github.event_name == 'schedule' && 'true' || (github.event.inputs.upload_results == true && 'true' || 'false') }}"
+          echo "│ Run Mode:             Parallel Execution (${{ matrix.test_group_name }})"
+          echo "│ Batch:                ${{ matrix.batch_display }}"
+          echo "│ Module Selector:      ${{ matrix.module_selector }}"
+          echo "│ Suite Override:       ${{ matrix.suite_name || 'none' }}"
+          echo "│ Architecture:         ${{ matrix.arch }}"
+          echo "│ Runner:               ${{ matrix.runs_on }}"
+          echo "│ Skip on Timeout:      ${{ github.event_name == 'schedule' && 'true' || (github.event.inputs.skip_on_timeout == 'true' && 'true' || 'false') }}"
+          echo "│ Measure Device Perf:  ${{ github.event_name == 'schedule' && 'true' || (github.event.inputs.measure_device_perf == 'true' && 'true' || 'false') }}"
+          echo "│ Upload Results:       ${{ github.event_name == 'schedule' && 'true' || (github.event.inputs.upload_results == 'true' && 'true' || 'false') }}"
           echo "└─────────────────────────────────────────────────────────────┘"
           echo "::endgroup::"
       - name: Download sweep vectors
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0
         with:
-          name: sweeps-vectors
-          path: /work/tests/sweep_framework/vectors_export/
+          pattern: sweeps-vectors-*
+          path: /work/tests/sweep_framework/vectors_export
+          merge-multiple: true
       - name: Run ttnn sweeps (batch)
         run: |
-          BATCH="${{ matrix.batch }}"
+          MODULE_SELECTOR="${{ matrix.module_selector }}"
+          SUITE_NAME="${{ matrix.suite_name }}"
 
           # Set skip-on-timeout flag based on input (default to true for all scheduled runs)
           SKIP_ON_TIMEOUT_FLAG=""
@@ -986,29 +1065,44 @@ jobs:
             DEVICE_PERF_FLAG="--device-perf"
           fi
 
-          # Check if batch contains colon (suite-specific execution)
-          if [[ "$BATCH" == *":"* ]]; then
-            MODULE_NAME="${BATCH%:*}"
-            SUITE_NAME="${BATCH#*:}"
-            # Suite-specific execution doesn't need nightly restriction
-            python3 tests/sweep_framework/sweeps_runner.py --module-name "$MODULE_NAME" --suite-name "$SUITE_NAME" --vector-source vectors_export --result-dest results_export --tag ci-main --summary $SKIP_ON_TIMEOUT_FLAG $DEVICE_PERF_FLAG
-          else
-            # Regular batch execution
-            if [[ "${{ github.event.schedule }}" == "0 4 * * 3" ]] || [[ "${{ github.event.schedule }}" == "0 5 * * 6" ]] || [[ "${{ github.event.inputs.sweep_name }}" == "ALL SWEEPS (Comprehensive)" ]]; then
-              python3 tests/sweep_framework/sweeps_runner.py --module-name "$BATCH" --vector-source vectors_export --result-dest results_export --tag ci-main --summary $SKIP_ON_TIMEOUT_FLAG $DEVICE_PERF_FLAG
-            else
-              python3 tests/sweep_framework/sweeps_runner.py --module-name "$BATCH" --vector-source vectors_export --result-dest results_export --tag ci-main --suite-name nightly --summary $SKIP_ON_TIMEOUT_FLAG $DEVICE_PERF_FLAG
-            fi
+          CMD=(
+            python3 tests/sweep_framework/sweeps_runner.py
+            --module-name "$MODULE_SELECTOR"
+            --vector-source vectors_export
+            --result-dest results_export
+            --tag ci-main
+            --summary
+          )
+
+          if [[ -n "$SKIP_ON_TIMEOUT_FLAG" ]]; then
+            CMD+=("$SKIP_ON_TIMEOUT_FLAG")
           fi
+
+          if [[ -n "$DEVICE_PERF_FLAG" ]]; then
+            CMD+=("$DEVICE_PERF_FLAG")
+          fi
+
+          if [[ -n "$SUITE_NAME" ]]; then
+            CMD+=(--suite-name "$SUITE_NAME")
+          fi
+
+          "${CMD[@]}"
       - name: Compute artifact suffix
         shell: bash
         run: |
-          echo "BATCH_SUFFIX=$(echo -n '${{ matrix.batch }}' | sha256sum | cut -d' ' -f1 | cut -c1-12)" >> $GITHUB_ENV
+          DISPLAY_LABEL="${{ matrix.batch_display }}"
+          SUITE_LABEL="${{ matrix.suite_name }}"
+          GROUP_LABEL="${{ matrix.test_group_name }}"
+          FINGERPRINT="$GROUP_LABEL|$DISPLAY_LABEL"
+          if [[ -n "$SUITE_LABEL" ]]; then
+            FINGERPRINT="$FINGERPRINT|$SUITE_LABEL"
+          fi
+          echo "BATCH_SUFFIX=$(echo -n "$FINGERPRINT" | sha256sum | cut -d' ' -f1 | cut -c1-12)" >> $GITHUB_ENV
       - name: Upload sweep results
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
-          name: sweeps-results-${{ matrix.test-group.name }}-batch-${{ env.BATCH_SUFFIX }}
+          name: sweeps-results-${{ matrix.test_group_name }}-batch-${{ env.BATCH_SUFFIX }}
           path: /work/tests/sweep_framework/results_export/
           retention-days: 1
   ttnn-homogenize-run-result:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,3 +63,13 @@ repos:
       name: Convert .ipynb to .py for ttnn basic examples
       entry: python3 scripts/convert_notebooks_to_python.py
       language: system
+- repo: local
+  hooks:
+    - id: detect-legacy-device-op
+      name: Detect legacy device operation classes in newly added files
+      entry: python3 scripts/detect_legacy_device_op.py --check-new-only
+      language: system
+      types: [file]
+      files: ^ttnn/.*\.hpp$
+      pass_filenames: true
+      require_serial: true

--- a/releases/README.md
+++ b/releases/README.md
@@ -14,8 +14,8 @@ TT-Metal Releases
 
 | Release | Release Date |
 |---------|--------------|
-| 0.65.0  | ETA Nov 19, 2025 |
-| [0.64.0](https://github.com/tenstorrent/tt-metal/releases/tag/v0.64.0) | Oct 29, 2025 |
+| 0.65.0  | ETA Dec, 2025 |
+| [0.64.3](https://github.com/tenstorrent/tt-metal/releases/tag/v0.64.3) | Oct 29, 2025 |
 | [0.63.0](https://github.com/tenstorrent/tt-metal/releases/tag/v0.63.0) | Sep 22, 2025 |
 | [0.62.2](https://github.com/tenstorrent/tt-metal/releases/tag/v0.62.2) | Aug 20, 2025 |
 | 0.61.0  | Skipped |
@@ -35,6 +35,7 @@ Visit the [Releases](https://github.com/tenstorrent/tt-metal/releases) section f
 
 ## Release Notes
 
+- [v0.64.3](https://github.com/tenstorrent/tt-metal/releases/tag/v0.64.3)
 - [v0.63.0](https://github.com/tenstorrent/tt-metal/releases/tag/v0.63.0)
 - [v0.62.2](https://github.com/tenstorrent/tt-metal/releases/tag/v0.62.2)
 - [v0.60.1](https://github.com/tenstorrent/tt-metal/releases/tag/v0.60.1)

--- a/scripts/detect_legacy_device_op.py
+++ b/scripts/detect_legacy_device_op.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+"""
+Detect classes that implement the legacy concept OldDeviceOperation.
+
+Uses simple pattern matching (no clang) to find classes with all three non-static methods:
+    - validate
+    - compute_output_specs
+    - create_program
+
+Checks specified .hpp files. Used by pre-commit hooks to detect legacy patterns in newly added files.
+"""
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+
+# Compile regex patterns once at module level for the three methods we check
+_METHOD_NAMES = ["validate", "compute_output_specs", "create_program"]
+_METHOD_PATTERNS = {name: re.compile(rf"\b{re.escape(name)}\s*[<(]") for name in _METHOD_NAMES}
+
+
+def check_has_non_static_method(filepath, method_name):
+    """
+    Check if a method exists and is non-static.
+    Returns True if a non-static declaration is found.
+    """
+    try:
+        with open(filepath, "r") as f:
+            content = f.read()
+    except FileNotFoundError:
+        return False
+
+    # Get pre-compiled pattern for the known method
+    method_pattern = _METHOD_PATTERNS[method_name]
+
+    # Find all positions where the method appears
+    for match in method_pattern.finditer(content):
+        match_pos = match.start()
+
+        # Look backwards for "static" keyword (within reasonable distance, ~200 chars)
+        lookback_start = max(0, match_pos - 200)
+        context = content[lookback_start:match_pos]
+
+        # Check if "static" appears before the method name
+        if re.search(r"\bstatic\s+", context):
+            continue  # This is a static method, skip it
+
+        # Found a non-static method
+        return True
+
+    return False
+
+
+def check_file_for_legacy_class(filepath):
+    """
+    Check if a file contains a legacy device operation class.
+    Returns True if all three methods are found as non-static.
+    """
+    for method_name in _METHOD_NAMES:
+        if not check_has_non_static_method(filepath, method_name):
+            return False
+    return True
+
+
+def _file_exists_in_git(filepath, ref):
+    """Check if a file exists in a git ref."""
+    try:
+        subprocess.check_output(
+            ["git", "cat-file", "-e", f"{ref}:{filepath}"],
+            stderr=subprocess.DEVNULL,
+        )
+        return True
+    except subprocess.CalledProcessError:
+        return False
+
+
+def _auto_detect_from_ref(to_ref):
+    """Auto-detect from_ref by finding merge base with common branches."""
+    for base_branch in ["origin/main", "main", "origin/master", "master"]:
+        try:
+            subprocess.check_output(
+                ["git", "rev-parse", "--verify", base_branch],
+                stderr=subprocess.DEVNULL,
+            )
+            merge_base = subprocess.check_output(
+                ["git", "merge-base", to_ref, base_branch],
+                stderr=subprocess.DEVNULL,
+                encoding="utf-8",
+            ).strip()
+            if merge_base:
+                return merge_base
+        except (subprocess.CalledProcessError, FileNotFoundError):
+            continue
+
+    # Fallback: try HEAD^ for local pre-commit (before commit)
+    try:
+        subprocess.check_output(
+            ["git", "cat-file", "-e", "HEAD^"],
+            stderr=subprocess.DEVNULL,
+        )
+        return "HEAD^"
+    except subprocess.CalledProcessError:
+        pass
+
+    # Last resort: use HEAD (but this won't work correctly in CI)
+    return "HEAD"
+
+
+def get_base_ref_for_precommit(from_ref=None, to_ref=None):
+    """
+    Determine base refs when running in pre-commit context.
+    In CI, pre-commit uses --from-ref and --to-ref, which we accept as arguments.
+    Falls back to auto-detection if not provided.
+
+    Returns tuple (from_ref, to_ref).
+    """
+    # Check environment variables first (could be set by CI)
+    from_ref = from_ref or os.environ.get("PRE_COMMIT_FROM_REF")
+    to_ref = to_ref or os.environ.get("PRE_COMMIT_TO_REF") or "HEAD"
+
+    # Auto-detect from_ref if not provided
+    if not from_ref:
+        from_ref = _auto_detect_from_ref(to_ref)
+
+    return from_ref, to_ref
+
+
+def is_file_newly_added(filepath, from_ref=None, to_ref=None):
+    """
+    Check if a file is newly added (doesn't exist in from_ref but exists in to_ref).
+    Returns True if file is new, False if it exists in from_ref (modified).
+    If refs are None, tries to auto-detect them.
+    """
+    from_ref, to_ref = get_base_ref_for_precommit(from_ref, to_ref)
+
+    # File is newly added if it doesn't exist in from_ref but exists in to_ref
+    exists_in_from = _file_exists_in_git(filepath, from_ref)
+    exists_in_to = _file_exists_in_git(filepath, to_ref) or os.path.exists(filepath)
+
+    return not exists_in_from and exists_in_to
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Detect legacy device operation classes")
+    parser.add_argument("files", nargs="+", help="Path(s) to .hpp file(s) to check")
+    parser.add_argument(
+        "--check-new-only",
+        action="store_true",
+        help="Only check files that are newly added (not in base_ref). Used by pre-commit.",
+    )
+    parser.add_argument(
+        "--from-ref",
+        help="Base ref to compare against (from-ref in pre-commit context). Auto-detected if not provided.",
+    )
+    parser.add_argument(
+        "--to-ref",
+        help="Target ref to compare to (to-ref in pre-commit context). Defaults to HEAD.",
+        default="HEAD",
+    )
+    args = parser.parse_args()
+
+    legacy_files = []
+    for filepath in args.files:
+        # If check-new-only is set, skip files that exist in from_ref (modified files)
+        if args.check_new_only:
+            # Use provided from-ref and to-ref, or auto-detect
+            if not is_file_newly_added(filepath, args.from_ref, args.to_ref):
+                continue  # Skip modified files, only check newly added ones
+
+        if check_file_for_legacy_class(filepath):
+            legacy_files.append(filepath)
+
+    if not legacy_files:
+        return 0
+
+    print("❌ ERROR: Detected new classes following legacy concept OldDeviceOperation", file=sys.stderr)
+    print(
+        "   (class implements non-static member functions: validate, compute_output_specs, create_program)",
+        file=sys.stderr,
+    )
+    print("", file=sys.stderr)
+    print("Files with legacy classes:", file=sys.stderr)
+    for filepath in legacy_files:
+        print(f"  - {filepath}", file=sys.stderr)
+    print("", file=sys.stderr)
+    print("Please follow the modern device operation pattern instead:", file=sys.stderr)
+    print(
+        "  - See documentation: https://docs.tenstorrent.com/tt-metal/latest/ttnn/ttnn/adding_new_ttnn_operation.html",
+        file=sys.stderr,
+    )
+
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/scripts/run_python_model_tests.sh
+++ b/tests/scripts/run_python_model_tests.sh
@@ -93,7 +93,6 @@ run_python_model_tests_blackhole() {
     done
 
     pytest models/demos/wormhole/resnet50/tests/test_resnet50_functional.py
-    pytest models/demos/yolov4/tests/pcc/test_ttnn_yolov4_bh.py
     pytest models/experimental/functional_unet/tests/test_unet_model.py
 }
 

--- a/tests/ttnn/unit_tests/gtests/test_graph_query_op_constraints.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_graph_query_op_constraints.cpp
@@ -794,14 +794,19 @@ INSTANTIATE_TEST_SUITE_P(
                 .transpose_mcast = false,
                 .fused_activation = std::nullopt})));
 
-class Conv2dOpIfTest : public ttnn::TTNNFixtureWithDevice {};
-TEST_F(Conv2dOpIfTest, Conv2d) {
+class Conv2dOpIfTest
+    : public ttnn::TTNNFixtureWithDevice,
+      public ::testing::WithParamInterface<std::optional<ttnn::operations::conv::conv2d::Conv2dConfig>> {};
+
+TEST_P(Conv2dOpIfTest, Conv2d) {
+    const auto& conv2d_config = GetParam();
+
     const auto input_spec = ttnn::TensorSpec(
         ttnn::Shape{1, 1, 50176, 3},
         tt::tt_metal::TensorLayout(
             tt::tt_metal::DataType::BFLOAT16,
             tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),
-            ttnn::DRAM_MEMORY_CONFIG));
+            ttnn::L1_MEMORY_CONFIG));
     const auto weight_spec = ttnn::TensorSpec(
         ttnn::Shape{1, 1, 1568, 64},
         tt::tt_metal::TensorLayout(
@@ -846,19 +851,26 @@ TEST_F(Conv2dOpIfTest, Conv2d) {
             groups,
             std::nullopt,
             std::nullopt,
-            std::nullopt,
+            conv2d_config,
             std::nullopt,
             output_spec.tensor_layout().get_memory_config());
 
         EXPECT_EQ(query.status, ttnn::graph::ExecutionStatus::Success);
         // Ensure some real usage is reported
         EXPECT_GT(query.resource_usage.cb_peak_size_per_core, 10000);
-        EXPECT_GT(query.resource_usage.l1_buffers_peak_per_core, 10000);
-        EXPECT_GT(query.resource_usage.peak_memory_usage_per_core, 10000);
+        const uint32_t l1_peak_threshold = (conv2d_config == std::nullopt) ? 200000 : 150000;
+        EXPECT_GT(query.resource_usage.l1_buffers_peak_per_core, l1_peak_threshold);
+        const uint32_t total_peak_threshold = (conv2d_config == std::nullopt) ? 400000 : 350000;
+        EXPECT_GT(query.resource_usage.peak_memory_usage_per_core, total_peak_threshold);
         ASSERT_TRUE(query.output_tensor_spec.has_value());
         EXPECT_EQ(query.output_tensor_spec.value(), output_spec);
     }
 }
+
+INSTANTIATE_TEST_SUITE_P(
+    Conv2dConfigVariations,
+    Conv2dOpIfTest,
+    ::testing::Values(std::nullopt, ttnn::operations::conv::conv2d::Conv2dConfig{.deallocate_activation = true}));
 
 }  // namespace test
 }  // namespace binary

--- a/tests/ttnn/unit_tests/operations/reduce/test_reduction.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_reduction.py
@@ -62,14 +62,26 @@ def test_var(device, batch_size, h, w, dim, keepdim, correction):
 @pytest.mark.parametrize("c", [11])
 @pytest.mark.parametrize("h", [67])
 @pytest.mark.parametrize("w", [77])
-@pytest.mark.parametrize("dim", [0, 1, 2, 3])
+@pytest.mark.parametrize("dim", [None, 0, 1, 2, 3])
 @pytest.mark.parametrize("keepdim", [True, False])
-@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
+# prod supports only bfloat16, per ttnn/cpp/ttnn/operations/reduction/prod/prod_pybind.hpp
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16])
 def test_prod(device, batch_size, c, h, w, dim, keepdim, dtype):
     torch.manual_seed(0)
 
     torch_input_tensor = torch.randn((batch_size, c, h, w), dtype=torch.bfloat16)
-    torch_output_tensor = torch.prod(torch_input_tensor, dim=dim, keepdim=keepdim)
+    # tensor.size, which is called by torch.prod) doesn't accept dim=None,
+    # so we need to handle it separately.
+    # See https://github.com/pytorch/pytorch/issues/127882
+    if dim is None:
+        torch_output_tensor = torch.prod(torch_input_tensor)
+        if keepdim:
+            # torch.prod does not support keepdim=True for dim=None,
+            # so we need to reshape to match the input tensor.
+            new_shape = [1] * torch_input_tensor.dim()
+            torch_output_tensor = torch_output_tensor.reshape(new_shape)
+    else:
+        torch_output_tensor = torch.prod(torch_input_tensor, dim=dim, keepdim=keepdim)
 
     input_tensor = ttnn.from_torch(
         torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.L1_MEMORY_CONFIG, dtype=dtype
@@ -81,7 +93,7 @@ def test_prod(device, batch_size, c, h, w, dim, keepdim, dtype):
     output_tensor = ttnn.to_torch(output_tensor, dtype=torch.bfloat16)
     assert len(output_tensor.shape) == len(torch_output_tensor.shape)
     assert output_tensor.shape == torch_output_tensor.shape
-    # assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.99)
+    assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.99)
 
 
 @pytest.mark.parametrize("dim_1", [1])

--- a/tests/ttnn/unit_tests/operations/reduce/test_reduction.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_reduction.py
@@ -70,7 +70,7 @@ def test_prod(device, batch_size, c, h, w, dim, keepdim, dtype):
     torch.manual_seed(0)
 
     torch_input_tensor = torch.randn((batch_size, c, h, w), dtype=torch.bfloat16)
-    # tensor.size, which is called by torch.prod) doesn't accept dim=None,
+    # tensor.size, which is called by torch.prod, doesn't accept dim=None,
     # so we need to handle it separately.
     # See https://github.com/pytorch/pytorch/issues/127882
     if dim is None:

--- a/tt_metal/hw/firmware/src/tt-2xx/quasar/noc.c
+++ b/tt_metal/hw/firmware/src/tt-2xx/quasar/noc.c
@@ -21,10 +21,10 @@
 
 #define NOC_WRITE_REG(addr, val)                                      \
     ((*((volatile uint32_t*)(noc_get_cmd_buf() * NOC_CMD_BUF_OFFSET + \
-                             noc_get_active_instance() * NOC_INSTANCE_OFFSET + (addr)))) = (val))
+                             noc_get_active_instance() * NOC_INSTANCE_OFFSET + ((uintptr_t)addr)))) = (val))
 #define NOC_READ_REG(addr)                                                                                             \
     (*((volatile uint32_t*)(noc_get_cmd_buf() * NOC_CMD_BUF_OFFSET + noc_get_active_instance() * NOC_INSTANCE_OFFSET + \
-                            (addr))))
+                            ((uintptr_t)addr))))
 
 #endif
 

--- a/tt_metal/hw/inc/accessor/dspec.h
+++ b/tt_metal/hw/inc/accessor/dspec.h
@@ -13,7 +13,7 @@
 
 #if defined(KERNEL_BUILD) || defined(FW_BUILD)
 // Forward declared from dataflow_api.h
-static uint32_t get_common_arg_addr(int arg_idx);
+static uintptr_t get_common_arg_addr(int arg_idx);
 #else
 // In non-kernel/non-firmware builds, get_common_arg_addr is a stub that always returns 0U.
 // This is safe because the function should not be called in these builds; if it is, 0U is an invalid address

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -100,7 +100,7 @@ bool is_l1_address(uint64_t addr) { return ((addr & 0xFFFFFFFF) < NOC_REG_SPACE_
  * | arg_idx        | Unique Runtime argument index                                           | uint32_t | 0 to 341    | True     |
  */
 // clang-format on
-static FORCE_INLINE uint32_t get_arg_addr(int arg_idx) { return (uint32_t)&rta_l1_base[arg_idx]; }
+static FORCE_INLINE uintptr_t get_arg_addr(int arg_idx) { return (uintptr_t)&rta_l1_base[arg_idx]; }
 
 // clang-format off
 /**
@@ -114,7 +114,7 @@ static FORCE_INLINE uint32_t get_arg_addr(int arg_idx) { return (uint32_t)&rta_l
  * | arg_idx        | Common Runtime argument index                                           | uint32_t | 0 to 341    | True     |
  */
 // clang-format on
-static FORCE_INLINE uint32_t get_common_arg_addr(int arg_idx) { return (uint32_t)&crta_l1_base[arg_idx]; }
+static FORCE_INLINE uintptr_t get_common_arg_addr(int arg_idx) { return (uintptr_t)&crta_l1_base[arg_idx]; }
 
 // clang-format off
 /**
@@ -314,7 +314,7 @@ uint32_t get_read_ptr(uint32_t operand) {
     return rd_ptr_bytes;
 }
 
-inline void wait_for_sync_register_value(uint32_t addr, int32_t val) {
+inline void wait_for_sync_register_value(uintptr_t addr, int32_t val) {
     volatile tt_reg_ptr uint32_t* reg_ptr = (volatile uint32_t*)addr;
     int32_t reg_value;
     WAYPOINT("SW");
@@ -341,7 +341,7 @@ inline void wait_for_sync_register_value(uint32_t addr, int32_t val) {
 // clang-format on
 FORCE_INLINE
 bool cb_pages_reservable_at_back(int32_t operand, int32_t num_pages) {
-    uint32_t pages_acked_ptr = (uint32_t)get_cb_tiles_acked_ptr(operand);
+    uintptr_t pages_acked_ptr = (uintptr_t)get_cb_tiles_acked_ptr(operand);
 
     // while the producer (write-side interface) is waiting for space to free up "tiles_pushed" is not changing
     // "tiles_pushed" is updated by the producer only when the tiles are pushed
@@ -371,7 +371,7 @@ bool cb_pages_reservable_at_back(int32_t operand, int32_t num_pages) {
 // clang-format on
 FORCE_INLINE
 void cb_reserve_back(int32_t operand, int32_t num_pages) {
-    uint32_t pages_acked_ptr = (uint32_t)get_cb_tiles_acked_ptr(operand);
+    uintptr_t pages_acked_ptr = (uintptr_t)get_cb_tiles_acked_ptr(operand);
 
     // while the producer (write-side interface) is waiting for space to free up "tiles_pushed" is not changing
     // "tiles_pushed" is updated by the producer only when the tiles are pushed
@@ -418,7 +418,7 @@ void cb_reserve_back(int32_t operand, int32_t num_pages) {
 FORCE_INLINE
 bool cb_pages_available_at_front(int32_t operand, int32_t num_pages) {
     uint32_t pages_acked = get_cb_tiles_acked_ptr(operand)[0];
-    uint32_t pages_received_ptr = (uint32_t)get_cb_tiles_received_ptr(operand);
+    uintptr_t pages_received_ptr = (uintptr_t)get_cb_tiles_received_ptr(operand);
 
     uint16_t pages_received = ((uint16_t)reg_read(pages_received_ptr)) - pages_acked;
     return num_pages <= pages_received;
@@ -451,7 +451,7 @@ bool cb_pages_available_at_front(int32_t operand, int32_t num_pages) {
 FORCE_INLINE
 void cb_wait_front(int32_t operand, int32_t num_pages) {
     uint32_t pages_acked = get_cb_tiles_acked_ptr(operand)[0];
-    uint32_t pages_received_ptr = (uint32_t)get_cb_tiles_received_ptr(operand);
+    uintptr_t pages_received_ptr = (uintptr_t)get_cb_tiles_received_ptr(operand);
 
     uint16_t pages_received;
 

--- a/tt_metal/hw/inc/debug/dprint.h
+++ b/tt_metal/hw/inc/debug/dprint.h
@@ -193,13 +193,27 @@ template <>
 uint8_t DebugPrintTypeToId<uint16_t>() {
     return DPrintUINT16;
 }
+// We can't specialize on uint32_t or uint64_t because we don't know
+// whether on ILP32 unsigned or unsigned long is used for uint32_t and
+// on LP64 whether unsigned long or unsigned long long for uint64_t
 template <>
-uint8_t DebugPrintTypeToId<uint32_t>() {
+uint8_t DebugPrintTypeToId<unsigned>() {
+    static_assert(sizeof(unsigned) == sizeof(uint32_t));
     return DPrintUINT32;
 }
 template <>
-uint8_t DebugPrintTypeToId<uint64_t>() {
+uint8_t DebugPrintTypeToId<unsigned long long>() {
+    static_assert(sizeof(unsigned long long) == sizeof(uint64_t));
     return DPrintUINT64;
+}
+template <>
+uint8_t DebugPrintTypeToId<unsigned long>() {
+    if constexpr (sizeof(unsigned long) == sizeof(unsigned)) {
+        return DebugPrintTypeToId<unsigned>();
+    } else if constexpr (sizeof(unsigned long) == sizeof(unsigned long long)) {
+        return DebugPrintTypeToId<unsigned long long>();
+    } else
+        ;  // Fail to compile
 }
 template <>
 uint8_t DebugPrintTypeToId<int8_t>() {
@@ -210,17 +224,25 @@ uint8_t DebugPrintTypeToId<int16_t>() {
     return DPrintINT16;
 }
 template <>
-uint8_t DebugPrintTypeToId<int32_t>() {
+uint8_t DebugPrintTypeToId<int>() {
+    static_assert(sizeof(int) == sizeof(int32_t));
     return DPrintINT32;
 }
 template <>
-uint8_t DebugPrintTypeToId<int64_t>() {
+uint8_t DebugPrintTypeToId<long long>() {
+    static_assert(sizeof(long long) == sizeof(int64_t));
     return DPrintINT64;
 }
 template <>
-uint8_t DebugPrintTypeToId<int>() {
-    return DPrintINT32;
+uint8_t DebugPrintTypeToId<long>() {
+    if constexpr (sizeof(long) == sizeof(int)) {
+        return DebugPrintTypeToId<int>();
+    } else if constexpr (sizeof(long) == sizeof(long long)) {
+        return DebugPrintTypeToId<long long>();
+    } else
+        ;  // Fail to compile
 }
+
 template <>
 uint8_t DebugPrintTypeToId<float>() {
     return DPrintFLOAT32;

--- a/tt_metal/hw/inc/firmware_common.h
+++ b/tt_metal/hw/inc/firmware_common.h
@@ -81,7 +81,7 @@ uint32_t firmware_config_init(
     extern uint32_t tt_l1_ptr* sem_l1_base[ProgrammableCoreType::COUNT];
 
     // TODO: check the asm for this loop to be sure loads are scheduled ok
-    uint32_t kernel_config_base[ProgrammableCoreType::COUNT];
+    uintptr_t kernel_config_base[ProgrammableCoreType::COUNT];
     launch_msg_t* launch_msg_address = &(mailboxes->launch[mailboxes->launch_msg_rd_ptr]);
 #pragma GCC unroll ProgrammableCoreType::COUNT
     for (uint32_t index = 0; index < ProgrammableCoreType::COUNT; index++) {

--- a/tt_metal/hw/inc/tensix_functions.h
+++ b/tt_metal/hw/inc/tensix_functions.h
@@ -748,4 +748,4 @@ inline void dbg_instrn_buf_clear_override_en() {
 }
 
 extern "C" void wzerorange(uint32_t* start, uint32_t* end);
-inline void wzeromem(uint32_t start, uint32_t len) { wzerorange((uint32_t*)start, (uint32_t*)(start + len)); }
+inline void wzeromem(uintptr_t start, uint32_t len) { wzerorange((uint32_t*)start, (uint32_t*)(start + len)); }

--- a/tt_metal/hw/inc/tt-2xx/quasar/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/tt-2xx/quasar/noc_nonblocking_api.h
@@ -115,25 +115,25 @@ inline __attribute__((always_inline)) void NOC_CMD_BUF_WRITE_REG(
         watcher_msg->noc_linked_status[noc] = (val & NOC_CMD_VC_LINKED) != 0;
     }
 #endif
-    uint32_t offset = (buf << NOC_CMD_BUF_OFFSET_BIT) + (noc << NOC_INSTANCE_OFFSET_BIT) + addr;
+    uintptr_t offset = (buf << NOC_CMD_BUF_OFFSET_BIT) + (noc << NOC_INSTANCE_OFFSET_BIT) + addr;
     volatile uint32_t* ptr = (volatile uint32_t*)offset;
     *ptr = val;
 }
 
 inline __attribute__((always_inline)) uint32_t NOC_CMD_BUF_READ_REG(uint32_t noc, uint32_t buf, uint32_t addr) {
-    uint32_t offset = (buf << NOC_CMD_BUF_OFFSET_BIT) + (noc << NOC_INSTANCE_OFFSET_BIT) + addr;
+    uintptr_t offset = (buf << NOC_CMD_BUF_OFFSET_BIT) + (noc << NOC_INSTANCE_OFFSET_BIT) + addr;
     volatile uint32_t* ptr = (volatile uint32_t*)offset;
     return *ptr;
 }
 
 inline __attribute__((always_inline)) uint32_t NOC_STATUS_READ_REG(uint32_t noc, uint32_t reg_id) {
-    uint32_t offset = (noc << NOC_INSTANCE_OFFSET_BIT) + NOC_STATUS(reg_id);
+    uintptr_t offset = (noc << NOC_INSTANCE_OFFSET_BIT) + NOC_STATUS(reg_id);
     volatile uint32_t* ptr = (volatile uint32_t*)offset;
     return *ptr;
 }
 
 inline __attribute__((always_inline)) uint32_t NOC_CFG_READ_REG(uint32_t noc, uint32_t reg_id) {
-    uint32_t offset = (noc << NOC_INSTANCE_OFFSET_BIT) + NOC_CFG(reg_id);
+    uintptr_t offset = (noc << NOC_INSTANCE_OFFSET_BIT) + NOC_CFG(reg_id);
     volatile uint32_t* ptr = (volatile uint32_t*)offset;
     return *ptr;
 }
@@ -143,7 +143,7 @@ inline __attribute__((always_inline)) bool noc_cmd_buf_ready(uint32_t noc, uint3
 }
 
 inline __attribute__((always_inline)) void noc_clear_outstanding_req_cnt(uint32_t noc, uint32_t id_mask) {
-    uint32_t offset = (noc << NOC_INSTANCE_OFFSET_BIT) + NOC_CLEAR_OUTSTANDING_REQ_CNT;
+    uintptr_t offset = (noc << NOC_INSTANCE_OFFSET_BIT) + NOC_CLEAR_OUTSTANDING_REQ_CNT;
     volatile uint32_t* ptr = (volatile uint32_t*)offset;
     *ptr = id_mask;
 }
@@ -160,11 +160,11 @@ inline __attribute__((always_inline)) uint32_t noc_get_interim_inline_value_addr
     uint32_t offset = dst_noc_addr & 0xF;
 
 #if defined(COMPILE_FOR_IDLE_ERISC)
-    uint32_t src_addr = MEM_IERISC_L1_INLINE_BASE + (2 * MEM_L1_INLINE_SIZE_PER_NOC) * proc_type;
+    uintptr_t src_addr = MEM_IERISC_L1_INLINE_BASE + (2 * MEM_L1_INLINE_SIZE_PER_NOC) * proc_type;
 #elif defined(COMPILE_FOR_ERISC)
-    uint32_t src_addr = MEM_AERISC_L1_INLINE_BASE + (2 * MEM_L1_INLINE_SIZE_PER_NOC) * proc_type;
+    uintptr_t src_addr = MEM_AERISC_L1_INLINE_BASE + (2 * MEM_L1_INLINE_SIZE_PER_NOC) * proc_type;
 #else
-    uint32_t src_addr = MEM_L1_INLINE_BASE + (2 * MEM_L1_INLINE_SIZE_PER_NOC) * proc_type;
+    uintptr_t src_addr = MEM_L1_INLINE_BASE + (2 * MEM_L1_INLINE_SIZE_PER_NOC) * proc_type;
 #endif
 
 #ifdef COMPILE_FOR_TRISC

--- a/tt_metal/hw/inc/tt-2xx/risc_common.h
+++ b/tt_metal/hw/inc/tt-2xx/risc_common.h
@@ -42,12 +42,12 @@ extern uint8_t my_x[NUM_NOCS];
 // Virtual Y coordinate
 extern uint8_t my_y[NUM_NOCS];
 
-inline void WRITE_REG(uint32_t addr, uint32_t val) {
+inline void WRITE_REG(uintptr_t addr, uint32_t val) {
     volatile tt_reg_ptr uint32_t* ptr = (volatile tt_reg_ptr uint32_t*)addr;
     ptr[0] = val;
 }
 
-inline uint32_t READ_REG(uint32_t addr) {
+inline uint32_t READ_REG(uintptr_t addr) {
     volatile tt_reg_ptr uint32_t* ptr = (volatile tt_reg_ptr uint32_t*)addr;
     return ptr[0];
 }
@@ -106,7 +106,7 @@ inline __attribute__((always_inline)) uint32_t buf_ptr_dec_wrap(uint32_t buf_ptr
 // tt_metal/third_party/tt_llk_wormhole_b0/common/inc/ckernel.h, which trisc
 // kernels bring into the global namespace using "using namespace ckernel".
 #if !defined(COMPILE_FOR_TRISC)  // BRISC, NCRISC, ERISC, IERISC
-inline __attribute__((always_inline)) uint32_t reg_read(uint32_t addr) {
+inline __attribute__((always_inline)) uint32_t reg_read(uintptr_t addr) {
     volatile tt_reg_ptr uint32_t* p_reg = reinterpret_cast<volatile tt_reg_ptr uint32_t*>(addr);
     return p_reg[0];
 }

--- a/tt_metal/impl/buffers/buffer_page_mapping.cpp
+++ b/tt_metal/impl/buffers/buffer_page_mapping.cpp
@@ -169,6 +169,13 @@ BufferCorePageMapping::Iterator::Range BufferCorePageMapping::Iterator::next_ran
         return result;
     }
     const auto& host_range = mapping_->host_ranges[range_index_];
+    if (device_page_offset_ < host_range.device_page_offset) {
+        if (host_range.device_page_offset >= end_device_page_offset) {
+            device_page_offset_ = end_device_page_offset;
+            return result;
+        }
+        device_page_offset_ = host_range.device_page_offset;
+    }
     uint32_t num_pages_left = host_range.num_pages - (device_page_offset_ - host_range.device_page_offset);
     uint32_t num_pages = std::min(num_pages_left, end_device_page_offset - device_page_offset_);
     result = Range{

--- a/ttnn/api/ttnn/graph/graph_query_op_constraints.hpp
+++ b/ttnn/api/ttnn/graph/graph_query_op_constraints.hpp
@@ -122,14 +122,19 @@ auto query_op_constraints(Op op, tt::tt_metal::distributed::MeshDevice* device, 
         try {
             auto capture_inner = ScopedGraphCapture(GraphProcessor::RunMode::NO_DISPATCH);
             output = detail::extract_output_tensor(std::apply(op, transformed_args));
-            op_trace = capture_inner.end_graph_capture();
         }  // end of inner graph capture
         catch (const std::exception& e) {
             log_debug(tt::LogOp, "Error during graph capture: {}", e.what());
             return ConstraintQueryResponse{
-                ExecutionStatus::Error, {0, 0, 0}, /* output_tensor_spec= */ std::nullopt, e.what()};
+                ExecutionStatus::Error,
+                {.cb_peak_size_per_core = 0,
+                 .l1_buffers_peak_per_core = 0,
+                 .peak_memory_usage_per_core = 0,
+                 .l1_output_buffer_per_core = 0},
+                /* output_tensor_spec= */ std::nullopt,
+                e.what()};
         }
-
+        op_trace = capture_outer.end_graph_capture();
     }  // end of outer graph capture
 
     // extract memory footprint from the trace

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
@@ -250,6 +250,12 @@ public:
     }
 };
 
+std::uint32_t* copy_common_runtime_args(const tt::tt_metal::Buffer& buffer, std::uint32_t* dst) {
+    const auto src = tt::tt_metal::TensorAccessorArgs(buffer, tensor_accessor::ArgConfig::RuntimeTensorShape)
+                         .get_common_runtime_args();
+    return std::copy(src.begin(), src.end(), dst);
+}
+
 template <typename F>
 void set_or_update_runtime_arguments(
     Program& program,
@@ -764,13 +770,16 @@ BinaryNgDeviceOperation::ProgramFactory::cached_program_t BinaryNgDeviceOperatio
         writer_kernel = KernelName::WriterNoBcastNg;
     }
     std::vector<uint32_t> writer_compile_time_args;
-    tt::tt_metal::TensorAccessorArgs(*c_buffer).append_to(writer_compile_time_args);
+    std::vector<uint32_t> writer_common_runtime_args;
+    tt::tt_metal::TensorAccessorArgs(*c_buffer, tensor_accessor::ArgConfig::RuntimeTensorShape)
+        .append_to(writer_compile_time_args, writer_common_runtime_args);
     writer_compile_time_args.push_back(static_cast<uint32_t>(has_sharding));
     tt::tt_metal::KernelHandle writer_kernel_id = tt_metal::CreateKernel(
         program,
         get_kernel_file_path(writer_kernel, is_sfpu_op, is_where_op),
         all_device_cores,
         tt_metal::WriterDataMovementConfig(writer_compile_time_args, std::move(writer_defines)));
+    tt_metal::SetCommonRuntimeArgs(program, writer_kernel_id, writer_common_runtime_args);
 
     // COMPUTE KERNEL
     bool fp32_dest_acc_en = c_data_format == tt::DataFormat::UInt32 || c_data_format == tt::DataFormat::Int32 ||
@@ -836,14 +845,19 @@ BinaryNgDeviceOperation::ProgramFactory::cached_program_t BinaryNgDeviceOperatio
 
     // READER KERNEL
     std::vector<uint32_t> reader_compile_time_args;
-    tt::tt_metal::TensorAccessorArgs(*a_buffer).append_to(reader_compile_time_args);
-    tt::tt_metal::TensorAccessorArgs(b_buffer != nullptr ? *b_buffer : *a_buffer).append_to(reader_compile_time_args);
+    std::vector<uint32_t> reader_common_runtime_args;
+    tt::tt_metal::TensorAccessorArgs(*a_buffer, tensor_accessor::ArgConfig::RuntimeTensorShape)
+        .append_to(reader_compile_time_args, reader_common_runtime_args);
+    tt::tt_metal::TensorAccessorArgs(
+        b_buffer != nullptr ? *b_buffer : *a_buffer, tensor_accessor::ArgConfig::RuntimeTensorShape)
+        .append_to(reader_compile_time_args, reader_common_runtime_args);
     reader_compile_time_args.push_back(static_cast<uint32_t>(has_sharding));
     tt::tt_metal::KernelHandle reader_kernel_id = tt_metal::CreateKernel(
         program,
         get_kernel_file_path(kernel_config.reader_kernel, is_sfpu_op, is_where_op),
         all_device_cores,
         tt_metal::ReaderDataMovementConfig(reader_compile_time_args, std::move(reader_defines)));
+    tt_metal::SetCommonRuntimeArgs(program, reader_kernel_id, reader_common_runtime_args);
 
     auto set_runtime_args = [](Program& program, KernelHandle kernel_id, CoreCoord core, auto&& args) {
         tt_metal::SetRuntimeArgs(program, kernel_id, core, args);
@@ -872,6 +886,21 @@ void BinaryNgDeviceOperation::ProgramFactory::override_runtime_arguments(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
     tensor_return_value_t& c) {
+    auto& program = cached_program.program;
+    auto reader_kernel_id = cached_program.shared_variables.reader_kernel_id;
+    auto writer_kernel_id = cached_program.shared_variables.writer_kernel_id;
+
+    {
+        auto a_buffer = tensor_args.input_tensor_a.buffer();
+        auto b_buffer = tensor_args.input_tensor_b ? tensor_args.input_tensor_b->buffer() : a_buffer;
+        auto c_buffer = c.buffer();
+        auto args = GetCommonRuntimeArgs(program, reader_kernel_id).data();
+        args = CMAKE_UNIQUE_NAMESPACE::copy_common_runtime_args(*a_buffer, args);
+        CMAKE_UNIQUE_NAMESPACE::copy_common_runtime_args(*b_buffer, args);
+        args = GetCommonRuntimeArgs(program, writer_kernel_id).data();
+        CMAKE_UNIQUE_NAMESPACE::copy_common_runtime_args(*c_buffer, args);
+    }
+
     auto update_args = [](Program& program, KernelHandle kernel_id, CoreCoord core, auto&& args) {
         auto& all_args = GetRuntimeArgs(program, kernel_id);
         auto& core_args = all_args.at(core.x).at(core.y);
@@ -879,9 +908,9 @@ void BinaryNgDeviceOperation::ProgramFactory::override_runtime_arguments(
     };
 
     CMAKE_UNIQUE_NAMESPACE::set_or_update_runtime_arguments(
-        cached_program.program,
-        cached_program.shared_variables.reader_kernel_id,
-        cached_program.shared_variables.writer_kernel_id,
+        program,
+        reader_kernel_id,
+        writer_kernel_id,
         cached_program.shared_variables.compute_kernel_id,
         cached_program.shared_variables.cb_src_a,
         cached_program.shared_variables.cb_src_b,

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
@@ -250,12 +250,6 @@ public:
     }
 };
 
-std::uint32_t* copy_common_runtime_args(const tt::tt_metal::Buffer& buffer, std::uint32_t* dst) {
-    const auto src = tt::tt_metal::TensorAccessorArgs(buffer, tensor_accessor::ArgConfig::RuntimeTensorShape)
-                         .get_common_runtime_args();
-    return std::copy(src.begin(), src.end(), dst);
-}
-
 template <typename F>
 void set_or_update_runtime_arguments(
     Program& program,
@@ -770,16 +764,13 @@ BinaryNgDeviceOperation::ProgramFactory::cached_program_t BinaryNgDeviceOperatio
         writer_kernel = KernelName::WriterNoBcastNg;
     }
     std::vector<uint32_t> writer_compile_time_args;
-    std::vector<uint32_t> writer_common_runtime_args;
-    tt::tt_metal::TensorAccessorArgs(*c_buffer, tensor_accessor::ArgConfig::RuntimeTensorShape)
-        .append_to(writer_compile_time_args, writer_common_runtime_args);
+    tt::tt_metal::TensorAccessorArgs(*c_buffer).append_to(writer_compile_time_args);
     writer_compile_time_args.push_back(static_cast<uint32_t>(has_sharding));
     tt::tt_metal::KernelHandle writer_kernel_id = tt_metal::CreateKernel(
         program,
         get_kernel_file_path(writer_kernel, is_sfpu_op, is_where_op),
         all_device_cores,
         tt_metal::WriterDataMovementConfig(writer_compile_time_args, std::move(writer_defines)));
-    tt_metal::SetCommonRuntimeArgs(program, writer_kernel_id, writer_common_runtime_args);
 
     // COMPUTE KERNEL
     bool fp32_dest_acc_en = c_data_format == tt::DataFormat::UInt32 || c_data_format == tt::DataFormat::Int32 ||
@@ -845,19 +836,14 @@ BinaryNgDeviceOperation::ProgramFactory::cached_program_t BinaryNgDeviceOperatio
 
     // READER KERNEL
     std::vector<uint32_t> reader_compile_time_args;
-    std::vector<uint32_t> reader_common_runtime_args;
-    tt::tt_metal::TensorAccessorArgs(*a_buffer, tensor_accessor::ArgConfig::RuntimeTensorShape)
-        .append_to(reader_compile_time_args, reader_common_runtime_args);
-    tt::tt_metal::TensorAccessorArgs(
-        b_buffer != nullptr ? *b_buffer : *a_buffer, tensor_accessor::ArgConfig::RuntimeTensorShape)
-        .append_to(reader_compile_time_args, reader_common_runtime_args);
+    tt::tt_metal::TensorAccessorArgs(*a_buffer).append_to(reader_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(b_buffer != nullptr ? *b_buffer : *a_buffer).append_to(reader_compile_time_args);
     reader_compile_time_args.push_back(static_cast<uint32_t>(has_sharding));
     tt::tt_metal::KernelHandle reader_kernel_id = tt_metal::CreateKernel(
         program,
         get_kernel_file_path(kernel_config.reader_kernel, is_sfpu_op, is_where_op),
         all_device_cores,
         tt_metal::ReaderDataMovementConfig(reader_compile_time_args, std::move(reader_defines)));
-    tt_metal::SetCommonRuntimeArgs(program, reader_kernel_id, reader_common_runtime_args);
 
     auto set_runtime_args = [](Program& program, KernelHandle kernel_id, CoreCoord core, auto&& args) {
         tt_metal::SetRuntimeArgs(program, kernel_id, core, args);
@@ -886,21 +872,6 @@ void BinaryNgDeviceOperation::ProgramFactory::override_runtime_arguments(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
     tensor_return_value_t& c) {
-    auto& program = cached_program.program;
-    auto reader_kernel_id = cached_program.shared_variables.reader_kernel_id;
-    auto writer_kernel_id = cached_program.shared_variables.writer_kernel_id;
-
-    {
-        auto a_buffer = tensor_args.input_tensor_a.buffer();
-        auto b_buffer = tensor_args.input_tensor_b ? tensor_args.input_tensor_b->buffer() : a_buffer;
-        auto c_buffer = c.buffer();
-        auto args = GetCommonRuntimeArgs(program, reader_kernel_id).data();
-        args = CMAKE_UNIQUE_NAMESPACE::copy_common_runtime_args(*a_buffer, args);
-        CMAKE_UNIQUE_NAMESPACE::copy_common_runtime_args(*b_buffer, args);
-        args = GetCommonRuntimeArgs(program, writer_kernel_id).data();
-        CMAKE_UNIQUE_NAMESPACE::copy_common_runtime_args(*c_buffer, args);
-    }
-
     auto update_args = [](Program& program, KernelHandle kernel_id, CoreCoord core, auto&& args) {
         auto& all_args = GetRuntimeArgs(program, kernel_id);
         auto& core_args = all_args.at(core.x).at(core.y);
@@ -908,9 +879,9 @@ void BinaryNgDeviceOperation::ProgramFactory::override_runtime_arguments(
     };
 
     CMAKE_UNIQUE_NAMESPACE::set_or_update_runtime_arguments(
-        program,
-        reader_kernel_id,
-        writer_kernel_id,
+        cached_program.program,
+        cached_program.shared_variables.reader_kernel_id,
+        cached_program.shared_variables.writer_kernel_id,
         cached_program.shared_variables.compute_kernel_id,
         cached_program.shared_variables.cb_src_a,
         cached_program.shared_variables.cb_src_b,

--- a/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.cpp
@@ -69,6 +69,8 @@ ttnn::SmallVector<int> generate_reduce_dim(
         for (int i = 0; i < rank; i++) {
             dim[i] = i;
         }
+        // It's already sorted and all are non-negative.
+        return dim;
     }
 
     for (int i = 0; i < dim.size(); i++) {

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_op.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_op.cpp
@@ -40,6 +40,12 @@ void Prod::validate(const std::vector<Tensor>& inputs) const {
             output_shape[i]);
         // TT_FATAL(input_shape_wo_padding[i] == output_shape_wo_padding[i], "Error");
     }
+
+    // prod supports only bfloat16, per ttnn/cpp/ttnn/operations/reduction/prod/prod_pybind.hpp
+    TT_FATAL(
+        input.dtype() == tt::tt_metal::DataType::BFLOAT16,
+        "Error - unsupported data type for prod, expected BFLOAT16 but got {}.",
+        input.dtype());
 }
 
 std::vector<Tensor> Prod::create_output_tensors(const std::vector<Tensor>& inputs) const {

--- a/ttnn/cpp/ttnn/operations/reduction/prod/prod.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/prod.cpp
@@ -82,8 +82,13 @@ Tensor ProdOperation::invoke(
 
     // If no dim is provided, compute the prod across all dimensions
     if (!dim.has_value()) {
-        TT_FATAL(!keepdim, "Not possible to keepdim with all dimensions enabled, as this returns a scalar");
-        return prod_all(input_a, output_mem_config);
+        Tensor result = prod_all(input_a, output_mem_config);
+        if (keepdim) {
+            // Reshape to have all dimensions (as many as the input rank) set to 1.
+            ttnn::SmallVector<uint32_t> output_shape(old_rank, 1);
+            result = ttnn::reshape(result, ttnn::Shape{output_shape});
+        }
+        return result;
     }
 
     TT_FATAL(size > 0, "Tensor has no dimensions");

--- a/ttnn/cursor/DEVICE_OPERATION_MIGRATION_GUIDE.md
+++ b/ttnn/cursor/DEVICE_OPERATION_MIGRATION_GUIDE.md
@@ -1,0 +1,543 @@
+# Migrate Device Operation to TMP (Template Metaprogramming) Pattern
+
+**Task**: Migrate a device operation from the old vector-based structure to the new TMP device operation pattern that eliminates unnecessary heap allocations.
+
+**Instructions**:
+1. Replace `<PROVIDED DEVICE OPERATION>` with the actual operation name you're migrating (e.g., 'Embedding', 'Unary', 'Dropout', etc.)
+2. Locate the old device operation structure in the codebase
+3. Follow each section below systematically to create the new TMP structure
+4. Update all call sites to use the new prim registration
+5. Run tests to verify the migration
+
+---
+
+## Old Device Operation vs TMP Device Operation
+
+### Old Operation Structure
+
+The old operation is represented by a fairly simple structure. The main issue is that inputs and outputs are processed as vectors, so even for unary operations we do heap allocations for inputs and outputs.
+
+**Example - Old Unary Operation:**
+
+```cpp
+struct Unary {
+    const std::vector<UnaryWithParam> op_chain;
+    const MemoryConfig output_mem_config;
+    bool fp32_dest_acc_en;
+    bool preserve_fp32_precision;
+    DataType output_dtype;
+
+    void validate_with_output_tensors(
+        const std::vector<Tensor> &input_tensors,
+        const std::vector<std::optional<Tensor>> &optional_output_tensors) const;
+
+    std::vector<tt::tt_metal::Shape> compute_output_shapes(
+        const std::vector<Tensor>& input_tensors) const;
+
+    std::vector<Tensor> create_output_tensors(
+        const std::vector<Tensor>& input_tensors,
+        const std::vector<std::optional<Tensor>>& output_tensors) const;
+
+    operation::ProgramWithCallbacks create_program(
+        const std::vector<Tensor>& input_tensors,
+        std::vector<Tensor>& output_tensors) const;
+
+    UnaryOpParallelizationStrategy get_parallelization_strategy(
+        const std::vector<Tensor>& input_tensors) const;
+
+    const operation::Hash compute_program_hash(
+        const std::vector<Tensor>& input_tensors) const;
+};
+```
+
+### New TMP Device Operation Structure
+
+The new TMP Device Operation is more verbose but allows precise input/output types, which eliminates unnecessary heap allocations.
+
+**Example - New Unary Operation:**
+
+```cpp
+struct operation_attributes_t {
+    const std::vector<UnaryWithParam> op_chain;
+    const DataType output_dtype = DataType::INVALID;
+    const MemoryConfig output_memory_config;
+    const bool fp32_dest_acc_en = false;
+    const bool preserve_fp32_precision = false;
+};
+
+struct tensor_args_t {
+    const Tensor& input;
+    std::optional<Tensor> preallocated_output;
+};
+
+using tensor_return_value_t = Tensor;
+using shape_return_value_t = ttnn::Shape;
+
+struct UnaryDeviceOperation {
+    using operation_attributes_t = unary::operation_attributes_t;
+    using tensor_args_t = unary::tensor_args_t;
+    using shape_return_value_t = unary::shape_return_value_t;
+    using tensor_return_value_t = unary::tensor_return_value_t;
+    using program_factory_t = std::variant<
+        program::UnaryProgramFactory,
+        program::UnaryShardedProgramFactory
+    >;
+
+    static program_factory_t select_program_factory(
+        const operation_attributes_t&,
+        const tensor_args_t&);
+
+    static void validate_on_program_cache_hit(
+        const operation_attributes_t&,
+        const tensor_args_t&);
+
+    static void validate_on_program_cache_miss(
+        const operation_attributes_t&,
+        const tensor_args_t&);
+
+    static shape_return_value_t compute_output_shapes(
+        const operation_attributes_t&,
+        const tensor_args_t&);
+
+    static tensor_return_value_t create_output_tensors(
+        const operation_attributes_t& operation_attributes,
+        const tensor_args_t&);
+
+    static tt::stl::hash::hash_t compute_program_hash(
+        const operation_attributes_t&,
+        const tensor_args_t&);
+
+    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
+        const Tensor& input,
+        const std::vector<UnaryWithParam>& op_chain,
+        DataType output_dtype,
+        const MemoryConfig& output_memory_config,
+        bool fp32_dest_acc_en,
+        bool preserve_fp32_precision,
+        const std::optional<Tensor>& preallocated_output);
+};
+```
+
+---
+
+## Migration Process
+
+### Step 1: Create `operation_attributes_t`
+
+Use the old Device Operation structure to find members for `operation_attributes_t`. Extract all const member variables that represent operation configuration (not tensor arguments).
+
+**Example - Old Embeddings Operation:**
+
+```cpp
+struct Embeddings {
+    const MemoryConfig output_mem_config;       // ← Include
+    const bool tilized;                         // ← Include
+    const EmbeddingsType embeddings_type;       // ← Include
+    const std::optional<uint32_t> pad_token;    // ← Include
+    const DataType output_dtype;                // ← Include
+
+    void validate(const std::vector<Tensor> &input_tensors) const;
+    std::vector<tt::tt_metal::Shape> compute_output_shapes(
+        const std::vector<Tensor> &input_tensors) const;
+    std::vector<Tensor> create_output_tensors(
+        const std::vector<Tensor> &input_tensors) const;
+    operation::ProgramWithCallbacks create_program(
+        const std::vector<Tensor> &input_tensors,
+        std::vector<Tensor> &output_tensors) const;
+};
+```
+
+**Resulting `operation_attributes_t`:**
+
+```cpp
+struct operation_attributes_t {
+    const MemoryConfig output_mem_config;
+    const bool tilized;
+    const EmbeddingsType embeddings_type;
+    const std::optional<uint32_t> pad_token;
+    const DataType output_dtype;
+};
+```
+
+### Step 2: Create `tensor_args_t`
+
+Use the Operation's `invoke` method signature to determine `tensor_args_t`. Include all Tensor parameters (both required and optional).
+
+**Example - Embedding invoke signature:**
+
+```cpp
+struct Embedding {
+    static inline Tensor invoke(
+        uint8_t queue_id,
+        const Tensor& input_tensor_arg,              // ← Include
+        const Tensor& weight_arg,                    // ← Include
+        const std::optional<int>& pad_token = std::nullopt,
+        const Layout& layout = ttnn::ROW_MAJOR_LAYOUT,
+        EmbeddingsType embeddings_type = EmbeddingsType::GENERIC,
+        const std::optional<const DataType> dtype = std::nullopt,
+        const std::optional<MemoryConfig>& memory_config = std::nullopt,
+        std::optional<Tensor> optional_output_tensor = std::nullopt)  // ← Include
+```
+
+**Resulting `tensor_args_t`:**
+
+```cpp
+struct tensor_args_t {
+    const Tensor& input_tensor_arg;
+    const Tensor& weight_arg;
+    const std::optional<Tensor>& optional_output_tensor;
+};
+```
+
+### Step 3: Define Return Types
+
+#### For operations with a single return value:
+
+```cpp
+using shape_return_value_t = ttnn::Shape;
+using tensor_return_value_t = Tensor;
+```
+
+**OR** (for newer operations using TensorSpec):
+
+```cpp
+using spec_return_value_t = TensorSpec;
+using tensor_return_value_t = Tensor;
+```
+
+#### For operations returning multiple tensors:
+
+```cpp
+using shape_return_value_t = std::vector<ttnn::Shape>;
+using tensor_return_value_t = std::vector<Tensor>;
+```
+
+**OR** (using tuple):
+
+```cpp
+using shape_return_value_t = std::tuple<ttnn::Shape, ttnn::Shape>;
+using tensor_return_value_t = std::tuple<Tensor, Tensor>;
+```
+
+**Note**: Prefer `spec_return_value_t` (TensorSpec) for newer operations as it provides more complete tensor metadata. Use `shape_return_value_t` only if maintaining compatibility with older patterns.
+
+### Step 4: Implement `select_program_factory`
+
+This method returns a `std::variant` listing all possible program factory types. The selection logic is usually straightforward based on tensor properties or operation attributes.
+
+**Example:**
+
+```cpp
+UnaryDeviceOperation::program_factory_t UnaryDeviceOperation::select_program_factory(
+    const operation_attributes_t& args,
+    const tensor_args_t& tensor_args) {
+    if (tensor_args.input.is_sharded()) {
+        return program::UnaryShardedProgramFactory{};
+    } else {
+        return program::UnaryProgramFactory{};
+    }
+}
+```
+
+### Step 5: Implement Validation
+
+Unless the old device operation provides a separate `validate_on_cache_hit`, implement `validate_on_cache_miss` and call it from `validate_on_cache_hit`.
+
+**Example:**
+
+```cpp
+void DropoutDeviceOperation::validate_on_program_cache_hit(
+    const operation_attributes_t& args,
+    const tensor_args_t& tensor_args) {
+    validate_on_program_cache_miss(args, tensor_args);
+}
+
+void DropoutDeviceOperation::validate_on_program_cache_miss(
+    const operation_attributes_t& args,
+    const tensor_args_t& tensor_args) {
+    // Copy validation logic from old operation's validate method
+    // Adapt to use args and tensor_args instead of input_tensors vector
+}
+```
+
+### Step 6: Register Prim
+
+Register and call the device operation prim. **Do not call its `invoke` directly** - always use the registered prim.
+
+**Registration (typically in the device operation header file):**
+
+```cpp
+namespace ttnn::prim {
+constexpr auto dropout =
+    ttnn::register_operation<
+        "ttnn::prim::dropout",
+        ttnn::operations::experimental::dropout::DropoutDeviceOperation
+    >();
+}  // namespace ttnn::prim
+```
+
+**Usage (replace old operation::run calls):**
+
+```cpp
+// OLD:
+return operation::run(Embeddings{...}, input_tensors);
+
+// NEW:
+return ttnn::prim::embedding(input_tensor, weight, ...);
+```
+
+### Step 7: Create Program Factory
+
+To define `shared_params_t` and `override_runtime_arguments`, find the lambda that updates runtime arguments in the old program factory. It's usually called `override_runtime_args_callback`.
+
+**Example - Old program factory lambda:**
+
+```cpp
+auto override_runtime_args_callback = [
+    num_cores_x,
+    num_cores_y,
+    reader_kernel_id,
+    writer_kernel_id,
+    cores,
+    device
+](
+    const Program &program,
+    const std::vector<Buffer *> &input_buffers,
+    const std::vector<Buffer *> &output_buffers) {
+
+    auto output_dram_buffer = output_buffers.at(0);
+    auto input_dram_buffer = input_buffers.at(0);
+    auto weights_dram_buffer = input_buffers.at(1);
+
+    for (const auto &core : cores) {
+        {
+            auto &runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
+            runtime_args[0] = input_dram_buffer->address();
+            runtime_args[1] = weights_dram_buffer->address();
+        }
+        {
+            auto &runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
+            runtime_args[0] = output_dram_buffer->address();
+        }
+    }
+};
+```
+
+**Lambda capture → `shared_params_t`:**
+
+The lambda's capture list becomes `shared_params_t`:
+
+```cpp
+struct shared_params_t {
+    uint32_t num_cores_x;
+    uint32_t num_cores_y;
+    KernelHandle reader_kernel_id;
+    KernelHandle writer_kernel_id;
+    std::vector<CoreCoord> cores;
+    // Note: 'device' is typically not needed in shared_params_t
+};
+```
+
+**Lambda body → `override_runtime_arguments`:**
+
+```cpp
+void EmbeddingProgramFactory::override_runtime_arguments(
+    cached_program_t& cached_program,
+    const operation_attributes_t& operation_attributes,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& output) {
+
+    // Buffers are not provided, so we take them from output/input tensors
+    auto output_dram_buffer = output.buffer();
+    auto input_dram_buffer = tensor_args.input_tensor_arg.buffer();
+    auto weights_dram_buffer = tensor_args.weight_arg.buffer();
+
+    auto& program = cached_program.program;
+    const auto& cores = cached_program.shared_variables.cores;
+    const auto& reader_kernel_id = cached_program.shared_variables.reader_kernel_id;
+    const auto& writer_kernel_id = cached_program.shared_variables.writer_kernel_id;
+
+    for (const auto &core : cores) {
+        {
+            auto &runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
+            runtime_args[0] = input_dram_buffer->address();
+            runtime_args[1] = weights_dram_buffer->address();
+        }
+        {
+            auto &runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
+            runtime_args[0] = output_dram_buffer->address();
+        }
+    }
+}
+```
+
+**Note**: If variables like `num_cores_x` and `num_cores_y` are not used in the override method, remove them from `shared_variables_t`.
+
+### Step 8: Implement `compute_program_hash`
+
+Hash is based on operation attributes and input arguments and helps reuse already compiled programs.
+
+**What to include in hash:**
+- Setup of Circular Buffers
+- Kernels and cores used
+- Compile-time arguments/defines
+- Operation attributes that affect program structure
+
+**What to exclude from hash:**
+- Buffer addresses
+- Offsets
+- Number of tiles to process (runtime arguments)
+
+**If the legacy operation does not implement `compute_program_hash`**, the default behavior is to hash both attributes and input tensors. The new operation works the same, so no need to implement this function if it wasn't implemented before.
+
+**Example migration:**
+
+**Old:**
+
+```cpp
+const tt::tt_metal::operation::Hash Unary::compute_program_hash(
+    const std::vector<Tensor>& input_tensors) const {
+
+    const auto& input_tensor = input_tensors.at(0);
+    const auto& input_shape = input_tensor.legacy_shape();
+
+    tt::tt_metal::operation::Hash hash = operation::hash_operation<Unary>(
+        compute_volume(input_shape),
+        input_tensor.dtype(),
+        std::get<DeviceStorage>(input_tensor.storage()).memory_config(),
+        this->output_mem_config);
+
+    for (const auto& unary_with_param_op : this->op_chain) {
+        hash = tt::stl::hash::hash_objects(hash, unary_with_param_op.op_type);
+        if (unary_with_param_op.has_parameter()) {
+            hash = tt::stl::hash::hash_objects(hash, unary_with_param_op.params);
+        }
+    }
+
+    return hash;
+}
+```
+
+**New:**
+
+```cpp
+tt::stl::hash::hash_t UnaryDeviceOperation::compute_program_hash(
+    const operation_attributes_t& args,
+    const tensor_args_t& tensor_args) {
+
+    const auto& input_tensor = tensor_args.input;
+    const auto& input_shape = input_tensor.legacy_shape();
+
+    auto program_factory = select_program_factory(args, tensor_args);
+
+    operation::Hash hash = operation::hash_operation<UnaryDeviceOperation>(
+        args,
+        program_factory.index(),  // Include program factory variant index
+        input_tensor.dtype(),     // impacts program in program factory
+        std::get<DeviceStorage>(input_tensor.storage()).memory_config(),
+        compute_volume(input_shape)); // core groups depend on volume
+
+    for (const auto& unary_with_param_op : args.op_chain) {
+        hash = tt::stl::hash::hash_objects(hash, unary_with_param_op.op_type);
+        if (unary_with_param_op.has_parameter()) {
+            hash = tt::stl::hash::hash_objects(hash, unary_with_param_op.params); // impacts defines
+        }
+    }
+
+    return hash;
+}
+```
+
+---
+
+## Examples
+
+Great examples of operations migrated to TMP:
+
+Dropout operation: `ttnn/cpp/ttnn/operations/experimental/dropout`
+PRs:
+  - https://github.com/tenstorrent/tt-metal/pull/11793
+  - https://github.com/tenstorrent/tt-metal/pull/11956
+
+---
+
+## Building and Testing
+
+### Building the Project
+
+To build the project with debug symbols (without Python bindings for faster builds during development):
+
+```bash
+./build_metal.sh -c -e --debug --without-python-bindings
+```
+
+### Running Tests
+
+After building, activate the Python environment and run the specific test file:
+
+```bash
+source python_env/bin/activate
+pytest tests/ttnn/unit_tests/operations/<operation_name>/
+```
+
+### Resetting Device After Failure
+
+If a test fails and leaves the device in a bad state, reset it:
+
+```bash
+tt-smi -r
+```
+
+---
+
+## Migration Checklist
+
+Use this checklist to ensure all steps are completed:
+
+- [ ] **Step 1**: Created `operation_attributes_t` struct with all const configuration members
+- [ ] **Step 2**: Created `tensor_args_t` struct with all Tensor parameters from invoke signature
+- [ ] **Step 3**: Defined `tensor_return_value_t` and `spec_return_value_t` appropriately
+- [ ] **Step 4**: Implemented `compute_output_specs`
+- [ ] **Step 5**: [Optional] Implemented `create_output_tensors` (if legacy had it)
+- [ ] **Step 6**: Implemented `select_program_factory` returning correct variant type
+- [ ] **Step 7**: Implemented `validate_on_program_cache_miss`
+- [ ] **Step 8**: [Optional] Implemented `validate_on_program_cache_hit` (if legacy had it)
+- [ ] **Step 9**: Registered prim in `ttnn::prim` namespace
+- [ ] **Step 10**: Updated all call sites to use prim instead of direct invoke or `operation::run`
+- [ ] **Step 11**: Created program factory with:
+  - [ ] `shared_variables_t` struct (from lambda captures)
+  - [ ] `create` method (from old `create_program`)
+  - [ ] `override_runtime_arguments` method (from lambda body)
+- [ ] **Step 12**: [Optional] Implemented `compute_program_hash` (if legacy had it)
+- [ ] **Step 13**: Removed old device operation code (after verification)
+- [ ] **Step 14**: Relevant test pass
+- [ ] **Step 15**: Code compiles without warnings
+
+---
+
+## Common Pitfalls
+
+1. **Forgetting to register the prim**: Always register in `ttnn::prim` namespace and use it instead of direct calls
+2. **Including runtime-only values in hash**: Only hash compile-time constants that affect program structure
+3. **Not including values that affect the program structure in hash**: Every parameter that has an effect on program structure must be taken into account in the hash
+4. **Redundant tensors in tensor_args_t**: Do not add redundant arguments like `preallocated_output`, if legacy operation did not handle that explicitly in `create_output_tensors`
+
+---
+
+## File Structure
+
+After migration, your operation should have this structure:
+
+```
+ttnn/cpp/ttnn/operations/<operation>/
+├── device/
+│   ├── <operation>_device_operation.hpp      # Main device operation struct
+│   ├── <operation>_device_operation.cpp      # Implementation
+│   ├── <operation>_device_operation_types.hpp # operation_attributes_t, tensor_args_t, return types
+│   ├── <operation>_program_factory.hpp       # Program factory structs
+│   ├── <operation>_program_factory.cpp       # Program factory implementation
+│   └── kernels/                              # Kernel files (if any)
+├── <operation>.hpp                           # Public API wrapper
+├── <operation>.cpp                           # Public API implementation
+└── <operation>_pybind.cpp                    # Python bindings (if any)
+```


### PR DESCRIPTION
### Ticket
Link to Github Issue #32279

### Problem description
ttnn.prod did not previously accept keepdim=true when reducing over all dimensions (dim= nullopt)
Added support for this option.

### What's changed
Added code to manually reshape the tensor after reduction when keepdim=true.
Updated unit tests to include this scenario. Also re-enabled assert_with_pcc in the unit test, which was previously disabled (this necessitated removal of bfloat8_b from the list of test parameters, which is not officially supported by prod anyways and pcc checks failed only on bfloat8_b).
Finally, minor refactor of generate_reduce_dim in ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.cpp to eliminate unnecessary sorting when a vector is already sorted. 


### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/19488742623
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes