### PR TITLE
[skip ci] Remove YOLOv4 BH test from model tests script

### DIFF
--- a/tests/scripts/run_python_model_tests.sh
+++ b/tests/scripts/run_python_model_tests.sh
@@ -93,7 +93,6 @@ run_python_model_tests_blackhole() {
     done
 
     pytest models/demos/wormhole/resnet50/tests/test_resnet50_functional.py
-    pytest models/demos/yolov4/tests/pcc/test_ttnn_yolov4_bh.py
     pytest models/experimental/functional_unet/tests/test_unet_model.py
 }
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/pull/32443

### What's changed
Removed test for YOLOv4 from the run_python_model_tests script
BH post commit was failing after model removed in https://github.com/tenstorrent/tt-metal/pull/32443
https://github.com/tenstorrent/tt-metal/actions/runs/19500676987/job/55833262194#step:5:475
```
ERROR: file or directory not found: models/demos/yolov4/tests/pcc/test_ttnn_yolov4_bh.py
```