### PR TITLE
[tt-train] Removed Wormhole arch restriction from SwiGLU FW

### DIFF
--- a/tt-train/sources/ttml/metal/ops/swiglu_fw/device/swiglu_fw_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/ops/swiglu_fw/device/swiglu_fw_device_operation.cpp
@@ -20,12 +20,6 @@ void SwiGLUForwardDeviceOperation::validate_on_program_cache_miss(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     auto check_tensor = [](const ttnn::Tensor& tensor, const std::string& name) {
         TT_FATAL(
-            tensor.device()->arch() == tt::ARCH::WORMHOLE_B0,
-            "SwiGLUForward operation is only supported on Wormhole. Device arch: {}. Tensor name {}",
-            enchantum::to_string(tensor.device()->arch()),
-            name);
-
-        TT_FATAL(
             tensor.storage_type() == tt::tt_metal::StorageType::DEVICE,
             "SwiGLUForward operation requires {} to be on Device. Input storage type: {}",
             name,


### PR DESCRIPTION


### Problem description
[L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/runs/19491520776/job/55794074008) was failing on main due to freshly added SwiGLUOpTest tests

### What's changed
TT-Train now supports Blackhole in addition to Wormhole, so removed the arch restriction. 

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)