### PR TITLE
Deprecate public API variants of MeshDevice::[get_device|is_local] and replace them with internal calls where possible

### DIFF
--- a/tests/tt_metal/distributed/multiprocess/test_sanity.cpp
+++ b/tests/tt_metal/distributed/multiprocess/test_sanity.cpp
@@ -17,6 +17,7 @@
 #include <tt-metalium/mesh_buffer.hpp>
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/tt_metal.hpp>
+#include "tt_metal/distributed/mesh_device_impl.hpp"
 
 #include "tests/tt_metal/tt_metal/common/multi_device_fixture.hpp"
 
@@ -203,7 +204,7 @@ TEST_F(BigMeshDualRankTest2x4, SimpleShardedBufferTest) {
         auto shard_col = i % global_buffer_shape.width();
         auto device_row = shard_row / shard_shape.height();
         auto device_col = shard_col / shard_shape.width();
-        if (mesh_device_->is_local(MeshCoordinate(device_row, device_col))) {
+        if (mesh_device_->impl().is_local(MeshCoordinate(device_row, device_col))) {
             EXPECT_EQ(dst_vec[i], src_vec[i]) << "Mismatch at index: " << i;
         }
     }

--- a/tests/tt_metal/distributed/test_mesh_buffer.cpp
+++ b/tests/tt_metal/distributed/test_mesh_buffer.cpp
@@ -39,6 +39,7 @@
 #include "tests/tt_metal/tt_metal/common/multi_device_fixture.hpp"
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include "impl/context/metal_context.hpp"
+#include "tt_metal/distributed/mesh_device_impl.hpp"
 
 namespace tt::tt_metal::distributed::test {
 namespace {
@@ -357,7 +358,7 @@ TEST_F(MeshBufferTestSuite, InterleavedShardsReadWrite) {
 
             for (std::size_t logical_x = 0; logical_x < buf->device()->num_cols(); logical_x++) {
                 for (std::size_t logical_y = 0; logical_y < buf->device()->num_rows(); logical_y++) {
-                    if (!mesh_device_->is_local(MeshCoordinate(logical_y, logical_x))) {
+                    if (!mesh_device_->impl().is_local(MeshCoordinate(logical_y, logical_x))) {
                         continue;
                     }
                     std::vector<uint32_t> dst_vec = {};

--- a/tests/tt_metal/distributed/test_mesh_device.cpp
+++ b/tests/tt_metal/distributed/test_mesh_device.cpp
@@ -24,6 +24,8 @@
 #include "tests/tt_metal/tt_metal/common/multi_device_fixture.hpp"
 #include <tt-metalium/experimental/fabric/control_plane.hpp>
 #include <tt-metalium/experimental/device.hpp>
+#include <distributed/mesh_device_impl.hpp>
+#include <distributed/mesh_device_view_impl.hpp>
 
 namespace tt::tt_metal::distributed {
 namespace {
@@ -65,7 +67,7 @@ TEST_F(MeshDevice2x4Test, ViewIs2D) {
     std::vector<IDevice*> devices;
     std::vector<tt::tt_fabric::FabricNodeId> fabric_node_ids;
     for (const auto& coord : MeshCoordinateRange(mesh_device_->shape())) {
-        devices.push_back(mesh_device_->get_view().get_device(coord));
+        devices.push_back(mesh_device_->get_view().impl().get_device(coord));
         fabric_node_ids.push_back(mesh_device_->get_view().get_fabric_node_id(coord));
     }
 
@@ -102,9 +104,13 @@ TEST_F(MeshDevice2x4Test, CreateSubmesh) {
     EXPECT_THAT(submesh->get_submeshes(), IsEmpty());
 
     // Verify coordinates are correct.
-    EXPECT_EQ(mesh_device_->get_device(MeshCoordinate{1, 1})->id(), submesh->get_device(MeshCoordinate{0, 0})->id());
-    EXPECT_EQ(mesh_device_->get_device(MeshCoordinate{1, 2})->id(), submesh->get_device(MeshCoordinate{0, 1})->id());
-    EXPECT_EQ(submesh->get_device(MeshCoordinate{1, 1}), nullptr);
+    EXPECT_EQ(
+        mesh_device_->impl().get_device(MeshCoordinate{1, 1})->id(),
+        submesh->impl().get_device(MeshCoordinate{0, 0})->id());
+    EXPECT_EQ(
+        mesh_device_->impl().get_device(MeshCoordinate{1, 2})->id(),
+        submesh->impl().get_device(MeshCoordinate{0, 1})->id());
+    EXPECT_EQ(submesh->impl().get_device(MeshCoordinate{1, 1}), nullptr);
 }
 
 TEST_F(MeshDevice2x4Test, CreateSubmeshesNonDivisibleSubshape) {
@@ -196,7 +202,7 @@ TEST_F(MeshDeviceTest, CheckFabricNodeIds) {
     for (const auto& coord : MeshCoordinateRange(mesh_device_->shape())) {
         tt_fabric::FabricNodeId fabric_node_id = mesh_device_->get_fabric_node_id(coord);
         EXPECT_EQ(
-            control_plane.get_fabric_node_id_from_physical_chip_id(mesh_device_->get_device(coord)->id()),
+            control_plane.get_fabric_node_id_from_physical_chip_id(mesh_device_->impl().get_device(coord)->id()),
             fabric_node_id);
     }
 }

--- a/tests/tt_metal/distributed/test_mesh_device_view.cpp
+++ b/tests/tt_metal/distributed/test_mesh_device_view.cpp
@@ -12,6 +12,7 @@
 #include <tt-metalium/mesh_coord.hpp>
 #include <tt-metalium/shape2d.hpp>
 #include <tt-metalium/mesh_device_view.hpp>
+#include <distributed/mesh_device_view_impl.hpp>
 
 #include "tests/tt_metal/tt_metal/common/multi_device_fixture.hpp"
 
@@ -209,15 +210,15 @@ TEST_F(MeshDeviceView2x4Test, ViewContains) {
 TEST_F(MeshDeviceView2x4Test, ViewGetDevice) {
     const auto& view = mesh_device_->get_view();
 
-    auto* device_00 = view.get_device(MeshCoordinate{0, 0});
-    auto* device_13 = view.get_device(MeshCoordinate{1, 3});
+    auto* device_00 = view.impl().get_device(MeshCoordinate{0, 0});
+    auto* device_13 = view.impl().get_device(MeshCoordinate{1, 3});
 
     EXPECT_NE(device_00, nullptr);
     EXPECT_NE(device_13, nullptr);
     EXPECT_NE(device_00->id(), device_13->id());
 
     // Out of bounds returns nullptr
-    EXPECT_EQ(view.get_device(MeshCoordinate{2, 0}), nullptr);
+    EXPECT_EQ(view.impl().get_device(MeshCoordinate{2, 0}), nullptr);
 }
 
 TEST_F(MeshDeviceView2x4Test, ViewGetFabricNodeId) {
@@ -337,7 +338,7 @@ TEST_F(MeshDeviceView2x4Test, ViewGetFabricNodeIdsOnColumn) {
 TEST_F(MeshDeviceView2x4Test, ViewFindDevice) {
     const auto& view = mesh_device_->get_view();
 
-    auto* device = view.get_device(MeshCoordinate{1, 2});
+    auto* device = view.impl().get_device(MeshCoordinate{1, 2});
     ASSERT_NE(device, nullptr);
 
     auto coord = view.find_device(device->id());
@@ -385,11 +386,11 @@ TEST_F(MeshDeviceView2x4Test, ViewIsLocal) {
     const auto& view = mesh_device_->get_view();
 
     // All devices should be local in single-host tests
-    EXPECT_TRUE(view.is_local(MeshCoordinate{0, 0}));
-    EXPECT_TRUE(view.is_local(MeshCoordinate{1, 3}));
+    EXPECT_TRUE(view.impl().is_local(MeshCoordinate{0, 0}));
+    EXPECT_TRUE(view.impl().is_local(MeshCoordinate{1, 3}));
 
     // Out of bounds throws
-    EXPECT_ANY_THROW((void)view.is_local(MeshCoordinate{2, 0}));
+    EXPECT_ANY_THROW((void)view.impl().is_local(MeshCoordinate{2, 0}));
 }
 
 TEST_F(MeshDeviceView2x4Test, ViewIterator) {
@@ -422,7 +423,7 @@ TEST_F(MeshDeviceView2x4Test, View2DMethodsThrowOnNon2DMesh) {
     std::vector<IDevice*> devices;
     std::vector<tt::tt_fabric::FabricNodeId> fabric_node_ids;
     for (const auto& coord : MeshCoordinateRange(mesh_device_->shape())) {
-        devices.push_back(mesh_device_->get_view().get_device(coord));
+        devices.push_back(mesh_device_->get_view().impl().get_device(coord));
         fabric_node_ids.push_back(mesh_device_->get_view().get_fabric_node_id(coord));
     }
 

--- a/tests/tt_metal/distributed/test_mesh_socket.cpp
+++ b/tests/tt_metal/distributed/test_mesh_socket.cpp
@@ -22,6 +22,7 @@
 #include <tt-metalium/system_mesh.hpp>
 #include <cstring>
 #include <tt-metalium/tt_align.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal::distributed {
 
@@ -589,8 +590,8 @@ void test_single_connection_multi_device_socket(
     auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
 
     // Used to setup fabric connections
-    const uint32_t sender_physical_device_id = md0->get_device(MeshCoordinate(0, 0))->id();
-    const uint32_t recv_physical_device_id = md1->get_device(MeshCoordinate(0, 0))->id();
+    const uint32_t sender_physical_device_id = md0->impl().get_device(MeshCoordinate(0, 0))->id();
+    const uint32_t recv_physical_device_id = md1->impl().get_device(MeshCoordinate(0, 0))->id();
     const auto sender_fabric_node_id =
         control_plane.get_fabric_node_id_from_physical_chip_id(sender_physical_device_id);
     const auto recv_fabric_node_id = control_plane.get_fabric_node_id_from_physical_chip_id(recv_physical_device_id);
@@ -760,8 +761,8 @@ void test_single_connection_multi_device_socket_with_workers(
     auto fabric_max_packet_size = tt_fabric::get_tt_fabric_max_payload_size_bytes();
 
     // Used to setup fabric connections
-    const uint32_t sender_physical_device_id = md0->get_device(MeshCoordinate(0, 0))->id();
-    const uint32_t recv_physical_device_id = md1->get_device(MeshCoordinate(0, 0))->id();
+    const uint32_t sender_physical_device_id = md0->impl().get_device(MeshCoordinate(0, 0))->id();
+    const uint32_t recv_physical_device_id = md1->impl().get_device(MeshCoordinate(0, 0))->id();
     const auto sender_fabric_node_id =
         control_plane.get_fabric_node_id_from_physical_chip_id(sender_physical_device_id);
     const auto recv_fabric_node_id = control_plane.get_fabric_node_id_from_physical_chip_id(recv_physical_device_id);
@@ -1254,10 +1255,10 @@ void test_multi_sender_single_recv(
     bool split_reducer) {
     TT_FATAL(link_indices.size() == 3, "Link indices must be of size 3");
     // Used to setup fabric connections
-    const uint32_t sender_0_physical_device_id = sender_0->get_device(MeshCoordinate(0, 0))->id();
-    const uint32_t sender_1_physical_device_id = sender_1->get_device(MeshCoordinate(0, 0))->id();
-    const uint32_t reducer_physical_device_id = reducer->get_device(MeshCoordinate(0, 0))->id();
-    const uint32_t receiver_physical_device_id = receiver->get_device(MeshCoordinate(0, 0))->id();
+    const uint32_t sender_0_physical_device_id = sender_0->impl().get_device(MeshCoordinate(0, 0))->id();
+    const uint32_t sender_1_physical_device_id = sender_1->impl().get_device(MeshCoordinate(0, 0))->id();
+    const uint32_t reducer_physical_device_id = reducer->impl().get_device(MeshCoordinate(0, 0))->id();
+    const uint32_t receiver_physical_device_id = receiver->impl().get_device(MeshCoordinate(0, 0))->id();
 
     auto sender_logical_coord = CoreCoord(0, 0);
     auto recv0_logical_coord = CoreCoord(0, 0);
@@ -1512,8 +1513,8 @@ void test_multi_connection_multi_device_data_copy(
     auto recv_mesh_workload = MeshWorkload();
 
     for (const auto& connection : socket_connections) {
-        auto sender_physical_id = sender_mesh->get_device(connection.sender_core.device_coord)->id();
-        auto recv_physical_id = recv_mesh->get_device(connection.receiver_core.device_coord)->id();
+        auto sender_physical_id = sender_mesh->impl().get_device(connection.sender_core.device_coord)->id();
+        auto recv_physical_id = recv_mesh->impl().get_device(connection.receiver_core.device_coord)->id();
 
         auto sender_program = create_sender_program(
             send_socket,
@@ -1622,10 +1623,10 @@ void run_multi_sender_single_recv(FixtureT* fixture, bool split_reducer) {
         while (true) {
             link_indices.clear();
             std::shuffle(coordinates.begin(), coordinates.end(), std::mt19937(std::random_device()()));
-            auto sender_0_physical_chip_id = mesh_device->get_device(coordinates[0])->id();
-            auto sender_1_physical_chip_id = mesh_device->get_device(coordinates[1])->id();
-            auto reducer_physical_chip_id = mesh_device->get_device(coordinates[2])->id();
-            auto receiver_physical_chip_id = mesh_device->get_device(coordinates[3])->id();
+            auto sender_0_physical_chip_id = mesh_device->impl().get_device(coordinates[0])->id();
+            auto sender_1_physical_chip_id = mesh_device->impl().get_device(coordinates[1])->id();
+            auto reducer_physical_chip_id = mesh_device->impl().get_device(coordinates[2])->id();
+            auto receiver_physical_chip_id = mesh_device->impl().get_device(coordinates[3])->id();
             auto reducer_fabric_node_id =
                 control_plane.get_fabric_node_id_from_physical_chip_id(reducer_physical_chip_id);
 
@@ -1667,10 +1668,10 @@ void run_multi_sender_single_recv(FixtureT* fixture, bool split_reducer) {
     auto reducer = fixture->get_mesh_device()->create_submesh(MeshShape(1, 1), coordinates[2]);
     auto receiver = fixture->get_mesh_device()->create_submesh(MeshShape(1, 1), coordinates[3]);
 
-    log_info(LogTest, "Sender 0 ID: {}", sender_0->get_device(MeshCoordinate(0, 0))->id());
-    log_info(LogTest, "Sender 1 ID: {}", sender_1->get_device(MeshCoordinate(0, 0))->id());
-    log_info(LogTest, "Reduce ID: {}", reducer->get_device(MeshCoordinate(0, 0))->id());
-    log_info(LogTest, "Receiver ID: {}", receiver->get_device(MeshCoordinate(0, 0))->id());
+    log_info(LogTest, "Sender 0 ID: {}", sender_0->impl().get_device(MeshCoordinate(0, 0))->id());
+    log_info(LogTest, "Sender 1 ID: {}", sender_1->impl().get_device(MeshCoordinate(0, 0))->id());
+    log_info(LogTest, "Reduce ID: {}", reducer->impl().get_device(MeshCoordinate(0, 0))->id());
+    log_info(LogTest, "Receiver ID: {}", receiver->impl().get_device(MeshCoordinate(0, 0))->id());
 
     uint32_t num_interations = 10;
     test_multi_sender_single_recv(
@@ -1699,7 +1700,7 @@ void run_multi_connection_multi_device_data_copy(FixtureT* fixture) {
 TEST_F(MeshSocketTest, SingleConnectionSingleDeviceConfig) {
     auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
     auto md0 = mesh_device_->create_submesh(MeshShape(1, 1), MeshCoordinate(0, 0));
-    auto current_device_id = md0->get_device(MeshCoordinate(0, 0))->id();
+    auto current_device_id = md0->impl().get_device(MeshCoordinate(0, 0))->id();
     auto current_fabric_node_id = control_plane.get_fabric_node_id_from_physical_chip_id(current_device_id);
     auto sender_logical_coord = CoreCoord(0, 0);
     auto recv_logical_coord = CoreCoord(0, 1);
@@ -1750,7 +1751,7 @@ TEST_F(MeshSocketTest, SingleConnectionSingleDeviceConfig) {
 TEST_F(MeshSocketTest, MultiConnectionSingleDeviceConfig) {
     auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
     auto md0 = mesh_device_->create_submesh(MeshShape(1, 1), MeshCoordinate(0, 0));
-    auto current_device_id = md0->get_device(MeshCoordinate(0, 0))->id();
+    auto current_device_id = md0->impl().get_device(MeshCoordinate(0, 0))->id();
     auto current_fabric_node_id = control_plane.get_fabric_node_id_from_physical_chip_id(current_device_id);
     std::size_t socket_fifo_size = 1024;
     const auto& worker_grid = md0->compute_with_storage_grid_size();
@@ -1834,11 +1835,11 @@ TEST_F(MeshSocketTest2DFabric, MultiConnectionMultiDeviceTest) {
     std::unordered_map<MeshCoordinate, ChipId> receiver_device_coord_to_id;
 
     for (const auto& coord : MeshCoordinateRange(md0->shape())) {
-        sender_device_coord_to_id[coord] = md0->get_device(coord)->id();
+        sender_device_coord_to_id[coord] = md0->impl().get_device(coord)->id();
     }
 
     for (const auto& coord : MeshCoordinateRange(md1->shape())) {
-        receiver_device_coord_to_id[coord] = md1->get_device(coord)->id();
+        receiver_device_coord_to_id[coord] = md1->impl().get_device(coord)->id();
     }
     std::size_t socket_fifo_size = 1024;
     const auto& worker_grid = md0->compute_with_storage_grid_size();

--- a/tests/tt_metal/distributed/test_mesh_workload.cpp
+++ b/tests/tt_metal/distributed/test_mesh_workload.cpp
@@ -51,6 +51,7 @@
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include <umd/device/types/core_coordinates.hpp>
 #include <umd/device/types/cluster_descriptor_types.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal::distributed::test {
 namespace {
@@ -125,10 +126,10 @@ void verify_cb_config(
 
     for (const auto& [device_range, _] : workload.get_programs()) {
         for (const auto& coord : device_range) {
-            if (!mesh_device->is_local(coord)) {
+            if (!mesh_device->impl().is_local(coord)) {
                 continue;
             }
-            auto* device = mesh_device->get_device(coord);
+            auto* device = mesh_device->impl().get_device(coord);
             uint32_t l1_unreserved_base = device->allocator()->get_base_allocator_addr(HalMemType::L1);
             for (const auto& core_range : crs.ranges()) {
                 for (const auto& core_coord : core_range) {
@@ -256,8 +257,8 @@ TEST_F(MeshWorkloadTestSuite, TestMeshWorkloadOnActiveEth) {
     for (int i = 0; i < num_workloads; i++) {
         std::shared_ptr<MeshWorkload> workload = std::make_shared<MeshWorkload>();
         for (const auto& device_coord : MeshCoordinateRange(mesh_device_->shape())) {
-            if (mesh_device_->is_local(device_coord)) {
-                IDevice* device = mesh_device_->get_device(device_coord);
+            if (mesh_device_->impl().is_local(device_coord)) {
+                IDevice* device = mesh_device_->impl().get_device(device_coord);
                 auto programs = utils::create_random_programs(
                     1, mesh_device_->compute_with_storage_grid_size(), seed, device->get_active_ethernet_cores(true));
                 workload->add_program(MeshCoordinateRange(device_coord, device_coord), std::move(*programs[0]));
@@ -767,18 +768,18 @@ TEST_F(MeshWorkloadTestSuite, MeshWorkloadSemaphoreDifferentPrograms) {
     Finish(mesh_device_->mesh_command_queue());
 
     for (const auto& device_coord : devices_0) {
-        if (!mesh_device_->is_local(device_coord)) {
+        if (!mesh_device_->impl().is_local(device_coord)) {
             continue;
         }
-        auto* device = mesh_device_->get_device(device_coord);
+        auto* device = mesh_device_->impl().get_device(device_coord);
         validate_sems(mesh_device_, device, full_grid, mesh_workload, expected_semaphore_values_0);
     }
 
     for (const auto& device_coord : devices_1) {
-        if (!mesh_device_->is_local(device_coord)) {
+        if (!mesh_device_->impl().is_local(device_coord)) {
             continue;
         }
-        auto* device = mesh_device_->get_device(device_coord);
+        auto* device = mesh_device_->impl().get_device(device_coord);
         validate_sems(mesh_device_, device, full_grid, mesh_workload, expected_semaphore_values_1);
     }
 }

--- a/tests/tt_metal/tt_fabric/benchmark/collectives/unicast/run_unicast_once.cpp
+++ b/tests/tt_metal/tt_fabric/benchmark/collectives/unicast/run_unicast_once.cpp
@@ -20,6 +20,7 @@
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/mesh_device.hpp>
 #include <tt-metalium/mesh_device_view.hpp>
+#include <distributed/mesh_device_view_impl.hpp>
 
 namespace tt::tt_fabric::bench {
 
@@ -122,7 +123,7 @@ PerfPoint run_unicast_once(HelpersFixture* fixture, const PerfParams& p) {
     auto view = mesh->get_view();
     auto coord_of_phys = [&](ChipId phys) -> Dist::MeshCoordinate {
         for (const auto& c : Dist::MeshCoordinateRange(view.shape())) {
-            if (view.get_device(c)->id() == phys) {
+            if (view.impl().get_device(c)->id() == phys) {
                 return c;
             }
         }

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/addrgen_write/multicast_runner.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/addrgen_write/multicast_runner.cpp
@@ -22,6 +22,7 @@
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/mesh_device.hpp>
 #include <tt-metalium/mesh_device_view.hpp>
+#include <distributed/mesh_device_view_impl.hpp>
 
 namespace tt::tt_fabric::test {
 
@@ -105,7 +106,7 @@ void run_multicast_write_test(tt::tt_metal::MeshDeviceFixtureBase* fixture, cons
     auto view = mesh->get_view();
     auto coord_of_phys = [&](ChipId phys) -> Dist::MeshCoordinate {
         for (const auto& c : Dist::MeshCoordinateRange(view.shape())) {
-            if (view.get_device(c)->id() == phys) {
+            if (view.impl().get_device(c)->id() == phys) {
                 return c;
             }
         }
@@ -143,7 +144,7 @@ void run_multicast_write_test(tt::tt_metal::MeshDeviceFixtureBase* fixture, cons
     for (uint32_t r = 0; r < M; ++r) {
         for (uint32_t c = 0; c < N; ++c) {
             Dist::MeshCoordinate mc{(int)r, (int)c};
-            auto* dev = view.get_device(mc);
+            auto* dev = view.impl().get_device(mc);
             if (!dev) {
                 continue;
             }
@@ -231,7 +232,7 @@ void run_multicast_write_test(tt::tt_metal::MeshDeviceFixtureBase* fixture, cons
 
     // Ensure the same logical worker maps to the same physical XY across all receiver chips
     for (const auto& mc : dst_coords) {
-        auto* dev_i = view.get_device(mc);
+        auto* dev_i = view.impl().get_device(mc);
         auto xy_i = dev_i->worker_core_from_logical_core(p.receiver_core);
         if (xy_i != rx_xy) {
             ADD_FAILURE() << "Receiver worker XY mismatch across chips";
@@ -317,7 +318,7 @@ void run_multicast_write_test(tt::tt_metal::MeshDeviceFixtureBase* fixture, cons
 
     // === Per-direction fabric connections (W,E,N,S) ===
     auto coord_to_fabric_id = [&](Dist::MeshCoordinate mc) -> tt::tt_fabric::FabricNodeId {
-        auto* dev = view.get_device(mc);
+        auto* dev = view.impl().get_device(mc);
         TT_FATAL(dev != nullptr, "No device at mesh coord ({}, {})", (int)mc[0], (int)mc[1]);
         ChipId phys = dev->id();
         return cp.get_fabric_node_id_from_physical_chip_id(phys);

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/addrgen_write/unicast_runner.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/addrgen_write/unicast_runner.cpp
@@ -22,6 +22,7 @@
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/mesh_device.hpp>
 #include <tt-metalium/mesh_device_view.hpp>
+#include <distributed/mesh_device_view_impl.hpp>
 
 namespace tt::tt_fabric::test {
 
@@ -137,7 +138,7 @@ void run_unicast_write_test(HelpersFixture* fixture, const AddrgenTestParams& p)
     auto view = mesh->get_view();
     auto coord_of_phys = [&](ChipId phys) -> Dist::MeshCoordinate {
         for (const auto& c : Dist::MeshCoordinateRange(view.shape())) {
-            if (view.get_device(c)->id() == phys) {
+            if (view.impl().get_device(c)->id() == phys) {
                 return c;
             }
         }

--- a/tests/tt_metal/tt_metal/data_movement/all_from_all/test_all_from_all.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/all_from_all/test_all_from_all.cpp
@@ -9,6 +9,7 @@
 #include "dm_common.hpp"
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/mesh_coord.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 
@@ -52,7 +53,7 @@ struct AllFromAllConfig {
 /// @return Status of the test execution (e.g., success or failure).
 bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const AllFromAllConfig& test_config) {
     // Get the actual device for this single-device test
-    IDevice* device = mesh_device->get_device(0);
+    IDevice* device = mesh_device->impl().get_device(0);
     /* ================ SETUP ================ */
 
     // Program
@@ -252,8 +253,9 @@ void packet_sizes_test(
     /* Running the Test */
 
     uint32_t max_transactions_per_subordinate = 256;
-    uint32_t max_reservable_pages_per_transaction =
-        mesh_device->get_device(0)->arch() == ARCH::BLACKHOLE ? 1024 : 2048;  // Max total transaction size == 64 KB
+    uint32_t max_reservable_pages_per_transaction = mesh_device->impl().get_device(0)->arch() == ARCH::BLACKHOLE
+                                                        ? 1024
+                                                        : 2048;  // Max total transaction size == 64 KB
 
     for (uint32_t num_of_transactions_per_subordinate = 1;
          num_of_transactions_per_subordinate <= max_transactions_per_subordinate;
@@ -291,7 +293,7 @@ void packet_sizes_test(
 }
 
 void virtual_channels_test(const shared_ptr<distributed::MeshDevice>& mesh_device, uint32_t test_case_id) {
-    IDevice* device = mesh_device->get_device(0);
+    IDevice* device = mesh_device->impl().get_device(0);
     // Physical Constraints
     auto [bytes_per_page, max_bytes_reservable, max_pages_reservable] =
         unit_tests::dm::compute_physical_constraints(mesh_device);
@@ -394,7 +396,7 @@ TO-DO:
 
 TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllFromAllDirectedIdeal) {
     auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->get_device(0);
+    auto* device = mesh_device->impl().get_device(0);
     uint32_t test_case_id = 310;
 
     /* Parameters */
@@ -413,7 +415,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllFromAllDirectedIdeal) {
 
 TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllFromAllPacketSizes) {
     auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->get_device(0);
+    auto* device = mesh_device->impl().get_device(0);
 
     uint32_t test_case_id = 311;
 
@@ -517,7 +519,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllFromAllCustom) {
     uint32_t test_case_id = 318;
 
     auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->get_device(0);
+    auto* device = mesh_device->impl().get_device(0);
 
     // Parameters
     CoreCoord mst_start_coord = {0, 0};

--- a/tests/tt_metal/tt_metal/data_movement/all_to_all/test_all_to_all.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/all_to_all/test_all_to_all.cpp
@@ -9,6 +9,8 @@
 #include "dm_common.hpp"
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/mesh_coord.hpp>
+#include <distributed/mesh_device_impl.hpp>
+
 namespace tt::tt_metal {
 
 using namespace std;
@@ -50,7 +52,7 @@ struct AllToAllConfig {
 /// @return Status of the test execution (e.g., success or failure).
 bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const AllToAllConfig& test_config) {
     // Get the actual device for this single-device test
-    IDevice* device = mesh_device->get_device(0);
+    IDevice* device = mesh_device->impl().get_device(0);
     /* ================ SETUP ================ */
 
     // Program
@@ -262,8 +264,9 @@ void packet_sizes_test(
     /* Running the Test */
 
     uint32_t max_transactions_per_master = 256;
-    uint32_t max_reservable_pages_per_transaction =
-        mesh_device->get_device(0)->arch() == ARCH::BLACKHOLE ? 1024 : 2048;  // Max total transaction size == 64 KB
+    uint32_t max_reservable_pages_per_transaction = mesh_device->impl().get_device(0)->arch() == ARCH::BLACKHOLE
+                                                        ? 1024
+                                                        : 2048;  // Max total transaction size == 64 KB
 
     for (uint32_t num_of_transactions_per_master = 1; num_of_transactions_per_master <= max_transactions_per_master;
          num_of_transactions_per_master *= 4) {
@@ -300,7 +303,7 @@ void packet_sizes_test(
 }
 
 void virtual_channels_test(const shared_ptr<distributed::MeshDevice>& mesh_device, uint32_t test_case_id) {
-    auto* device = mesh_device->get_device(0);
+    auto* device = mesh_device->impl().get_device(0);
     // Physical Constraints
     auto [bytes_per_page, max_bytes_reservable, max_pages_reservable] =
         unit_tests::dm::compute_physical_constraints(mesh_device);
@@ -357,7 +360,7 @@ void custom_test(
     uint32_t num_of_transactions,
     uint32_t pages_per_transaction,
     uint32_t num_virtual_channels) {
-    auto* device = mesh_device->get_device(0);
+    auto* device = mesh_device->impl().get_device(0);
 
     // Physical Constraints
     auto [bytes_per_page, max_bytes_reservable, max_pages_reservable] =
@@ -404,7 +407,7 @@ TO-DO:
 /* ======== All to All ======== */
 TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllToAllDirectedIdeal) {
     auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->get_device(0);
+    auto* device = mesh_device->impl().get_device(0);
 
     uint32_t test_case_id = 300;
 
@@ -423,7 +426,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllToAllDirectedIdeal) {
 
 TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllToAllPacketSizes) {
     auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->get_device(0);
+    auto* device = mesh_device->impl().get_device(0);
 
     uint32_t test_case_id = 301;
 

--- a/tests/tt_metal/tt_metal/data_movement/core_bidirectional/test_core_bidirectional.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/core_bidirectional/test_core_bidirectional.cpp
@@ -9,6 +9,7 @@
 #include "dm_common.hpp"
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/mesh_coord.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 
@@ -41,7 +42,7 @@ struct CoreBidirectionalConfig {
 /// @return
 bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const CoreBidirectionalConfig& test_config) {
     // Get the actual device for this single-device test
-    IDevice* device = mesh_device->get_device(0);
+    IDevice* device = mesh_device->impl().get_device(0);
     /* ================ SETUP ================ */
 
     // Program
@@ -252,7 +253,7 @@ void packet_sizes_test(
         tt::tt_metal::unit_tests::dm::compute_physical_constraints(mesh_device);
 
     // Parameters
-    IDevice* device = mesh_device->get_device(0);
+    IDevice* device = mesh_device->impl().get_device(0);
     uint32_t max_transactions = 256;
     uint32_t max_pages_per_transaction =
         device->arch() == tt::ARCH::BLACKHOLE ? 1024 : 2048;  // Max total transaction size == 64 KB

--- a/tests/tt_metal/tt_metal/data_movement/direct_write/test_direct_write.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/direct_write/test_direct_write.cpp
@@ -7,6 +7,7 @@
 #include "dm_common.hpp"
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/mesh_coord.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 
@@ -38,7 +39,7 @@ struct DirectWriteConfig {
 bool run_dm(
     const std::shared_ptr<tt::tt_metal::distributed::MeshDevice>& mesh_device, const DirectWriteConfig& test_config) {
     // Get the actual device for this single-device test
-    IDevice* device = mesh_device->get_device(0);
+    IDevice* device = mesh_device->impl().get_device(0);
 
     // Program
     Program program = CreateProgram();

--- a/tests/tt_metal/tt_metal/data_movement/dm_common.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/dm_common.cpp
@@ -6,6 +6,7 @@
 #include "device_fixture.hpp"
 #include <tt-metalium/mesh_device.hpp>
 #include <tuple>
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal::unit_tests::dm {
 
@@ -21,7 +22,7 @@ static uint32_t obtain_page_size_bytes(ARCH arch) { return (arch == ARCH::BLACKH
 L1AddressInfo get_l1_address_and_size(
     const std::shared_ptr<distributed::MeshDevice>& mesh_device, const CoreCoord& core_coord) {
     // Obtaining L1 address and size for a specific core //
-    const IDevice* device = mesh_device->get_device(0);
+    const IDevice* device = mesh_device->impl().get_device(0);
 
     CoreCoord physical_core = device->worker_core_from_logical_core(core_coord);
 
@@ -46,7 +47,7 @@ DramAddressInfo get_dram_address_and_size() {
 
 std::tuple<uint32_t, uint32_t, uint32_t> compute_physical_constraints(
     const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
-    const IDevice* device = mesh_device->get_device(0);
+    const IDevice* device = mesh_device->impl().get_device(0);
     ARCH arch = device->arch();
 
     // Use core {0,0} as representative core for computing physical constraints

--- a/tests/tt_metal/tt_metal/data_movement/dram_sharded/test_dram_sharded.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/dram_sharded/test_dram_sharded.cpp
@@ -11,6 +11,7 @@
 #include <tt-metalium/mesh_coord.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-metalium/mesh_buffer.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 
@@ -38,7 +39,7 @@ struct DramShardedConfig {
 /// @return
 bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const DramShardedConfig& test_config) {
     // Get the actual device for this single-device test
-    IDevice* device = mesh_device->get_device(0);
+    IDevice* device = mesh_device->impl().get_device(0);
 
     // Program
     Program program = CreateProgram();

--- a/tests/tt_metal/tt_metal/data_movement/dram_unary/test_unary_dram.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/dram_unary/test_unary_dram.cpp
@@ -9,6 +9,7 @@
 #include "tt_metal/test_utils/stimulus.hpp"
 #include "tt_metal/test_utils/print_helpers.hpp"
 #include "dm_common.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 
@@ -36,7 +37,7 @@ struct DramConfig {
 /// @param fixture - DispatchFixture pointer for dispatch-aware operations
 /// @return
 bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const DramConfig& test_config) {
-    IDevice* device = mesh_device->get_device(0);
+    IDevice* device = mesh_device->impl().get_device(0);
     // SETUP
 
     // Program
@@ -246,7 +247,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementDRAMCoreLocations) {
     uint32_t test_case_id = 1;
 
     auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->get_device(0);
+    auto* device = mesh_device->impl().get_device(0);
 
     CoreCoord core_coord;
     uint32_t dram_channel = 0;
@@ -271,7 +272,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementDRAMChannels) {
     uint32_t test_case_id = 2;
 
     auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->get_device(0);
+    auto* device = mesh_device->impl().get_device(0);
 
     CoreCoord core_coord = {0, 0};
 

--- a/tests/tt_metal/tt_metal/data_movement/interleaved/test_interleaved.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/interleaved/test_interleaved.cpp
@@ -10,6 +10,7 @@
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/mesh_coord.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 
@@ -38,7 +39,7 @@ struct InterleavedConfig {
 /// @return
 bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const InterleavedConfig& test_config) {
     // Get the actual device for this single-device test
-    IDevice* device = mesh_device->get_device(0);
+    IDevice* device = mesh_device->impl().get_device(0);
 
     // Program
     Program program = CreateProgram();
@@ -251,7 +252,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementDRAMInterleavedPageCoreLocati
 
     // Cores
     auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->get_device(0);
+    auto* device = mesh_device->impl().get_device(0);
     auto grid_size = device->compute_with_storage_grid_size();
     log_info(tt::LogTest, "Grid size x: {}, y: {}", grid_size.x, grid_size.y);
     for (unsigned int x = 0; x < grid_size.x; x++) {
@@ -532,7 +533,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementL1InterleavedPageCoreLocation
 
     // Cores
     auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->get_device(0);
+    auto* device = mesh_device->impl().get_device(0);
     auto grid_size = device->compute_with_storage_grid_size();
     log_info(tt::LogTest, "Grid size x: {}, y: {}", grid_size.x, grid_size.y);
     for (unsigned int x = 0; x < grid_size.x; x++) {

--- a/tests/tt_metal/tt_metal/data_movement/loopback/test_loopback.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/loopback/test_loopback.cpp
@@ -9,6 +9,7 @@
 #include "tt_metal/test_utils/stimulus.hpp"
 #include "tt_metal/test_utils/print_helpers.hpp"
 #include "dm_common.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 
@@ -42,7 +43,7 @@ struct LoopbackConfig {
 /// @param fixture - DispatchFixture pointer for dispatch-aware operations
 /// @return
 bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const LoopbackConfig& test_config) {
-    IDevice* device = mesh_device->get_device(0);
+    IDevice* device = mesh_device->impl().get_device(0);
     // Program
     Program program = CreateProgram();
 
@@ -145,7 +146,7 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const Loopba
 /* ========== Test case for loopback data movement; ========== */
 TEST_F(GenericMeshDeviceFixture, TensixDataMovementLoopbackPacketSizes) {
     auto mesh_device = get_mesh_device();
-    auto arch_ = mesh_device->get_device(0)->arch();
+    auto arch_ = mesh_device->impl().get_device(0)->arch();
 
     // Parameters
     uint32_t max_transactions = 256;

--- a/tests/tt_metal/tt_metal/data_movement/multi_interleaved/test_multi_interleaved.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/multi_interleaved/test_multi_interleaved.cpp
@@ -10,6 +10,7 @@
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/mesh_coord.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 
@@ -43,7 +44,7 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const MultiI
         test_config.page_size_bytes);
 
     // Get the actual device for this single-device test
-    IDevice* device = mesh_device->get_device(0);
+    IDevice* device = mesh_device->impl().get_device(0);
 
     // Program
     Program program = CreateProgram();
@@ -290,7 +291,7 @@ void packet_sizes_test(
 /* ========== Full grid directed ideal ========== */
 TEST_F(GenericMeshDeviceFixture, TensixDataMovementMultiInterleavedDirectedIdeal) {
     auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->get_device(0);
+    auto* device = mesh_device->impl().get_device(0);
 
     uint32_t test_case_id = 110;
     CoreCoord mst_start_coord = {0, 0};
@@ -302,7 +303,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementMultiInterleavedDirectedIdeal
 /* ========== Full grid packet sizes sweep ========== */
 TEST_F(GenericMeshDeviceFixture, TensixDataMovementMultiInterleavedSizes) {
     auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->get_device(0);
+    auto* device = mesh_device->impl().get_device(0);
 
     uint32_t test_case_id = 111;
     CoreCoord mst_start_coord = {0, 0};
@@ -314,7 +315,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementMultiInterleavedSizes) {
 /* ========== Full grid read kernel directed ideal ========== */
 TEST_F(GenericMeshDeviceFixture, TensixDataMovementMultiInterleavedReadDirectedIdeal) {
     auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->get_device(0);
+    auto* device = mesh_device->impl().get_device(0);
 
     uint32_t test_case_id = 112;
     CoreCoord mst_start_coord = {0, 0};
@@ -326,7 +327,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementMultiInterleavedReadDirectedI
 /* ========== Full grid read kernel packet sizes sweep ========== */
 TEST_F(GenericMeshDeviceFixture, TensixDataMovementMultiInterleavedReadSizes) {
     auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->get_device(0);
+    auto* device = mesh_device->impl().get_device(0);
 
     uint32_t test_case_id = 113;
     CoreCoord mst_start_coord = {0, 0};
@@ -338,7 +339,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementMultiInterleavedReadSizes) {
 /* ========== Full grid write kernel directed ideal ========== */
 TEST_F(GenericMeshDeviceFixture, TensixDataMovementMultiInterleavedWriteDirectedIdeal) {
     auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->get_device(0);
+    auto* device = mesh_device->impl().get_device(0);
 
     uint32_t test_case_id = 114;
     CoreCoord mst_start_coord = {0, 0};
@@ -350,7 +351,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementMultiInterleavedWriteDirected
 /* ========== Full grid write kernel packet sizes sweep ========== */
 TEST_F(GenericMeshDeviceFixture, TensixDataMovementMultiInterleavedWriteSizes) {
     auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->get_device(0);
+    auto* device = mesh_device->impl().get_device(0);
 
     uint32_t test_case_id = 115;
     CoreCoord mst_start_coord = {0, 0};

--- a/tests/tt_metal/tt_metal/data_movement/one_from_all/test_one_from_all.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_from_all/test_one_from_all.cpp
@@ -9,6 +9,7 @@
 #include "tt_metal/test_utils/stimulus.hpp"
 #include "tt_metal/test_utils/print_helpers.hpp"
 #include "dm_common.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 
@@ -43,7 +44,7 @@ struct OneFromAllConfig {
 /// @param fixture - DispatchFixture pointer for dispatch-aware operations
 /// @return
 bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const OneFromAllConfig& test_config) {
-    IDevice* device = mesh_device->get_device(0);
+    IDevice* device = mesh_device->impl().get_device(0);
     // Program
     Program program = CreateProgram();
 
@@ -210,8 +211,9 @@ void packet_sizes_test(
 
     // Parameters
     uint32_t max_transactions = 256;
-    uint32_t max_transaction_size_pages =
-        mesh_device->get_device(0)->arch() == tt::ARCH::BLACKHOLE ? 1024 : 2048;  // Max total transaction size == 64 KB
+    uint32_t max_transaction_size_pages = mesh_device->impl().get_device(0)->arch() == tt::ARCH::BLACKHOLE
+                                              ? 1024
+                                              : 2048;  // Max total transaction size == 64 KB
 
     for (uint32_t num_of_transactions = 1; num_of_transactions <= max_transactions; num_of_transactions *= 4) {
         for (uint32_t transaction_size_pages = 1; transaction_size_pages <= max_transaction_size_pages;
@@ -331,7 +333,7 @@ void custom_test(
 TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneFromAllPacketSizes) {
     uint32_t test_id = 15;
     auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->get_device(0);
+    auto* device = mesh_device->impl().get_device(0);
     CoreCoord master_core_coord = {0, 0};
     CoreCoord subordinate_start_coord = {0, 0};
     CoreCoord subordinate_grid_size = {
@@ -345,7 +347,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneFromAllPacketSizes) {
 TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneFromAllDirectedIdeal) {
     uint32_t test_id = 30;
     auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->get_device(0);
+    auto* device = mesh_device->impl().get_device(0);
     CoreCoord master_core_coord = {0, 0};
     CoreCoord subordinate_start_coord = {0, 0};
     CoreCoord subordinate_grid_size = {
@@ -361,7 +363,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneFromAllVirtualChannels) {
     // Test ID (Arbitrary)
     uint32_t test_id = 156;
     auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->get_device(0);
+    auto* device = mesh_device->impl().get_device(0);
 
     CoreCoord master_core_coord = {0, 0};
     CoreCoord subordinate_start_coord = {0, 0};
@@ -377,7 +379,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneFromAllCustom) {
 
     uint32_t test_id = 157;
     auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->get_device(0);
+    auto* device = mesh_device->impl().get_device(0);
 
     CoreCoord master_core_coord = {0, 0};
     CoreCoord subordinate_start_coord = {0, 0};

--- a/tests/tt_metal/tt_metal/data_movement/one_from_one/test_one_from_one.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_from_one/test_one_from_one.cpp
@@ -9,6 +9,7 @@
 #include "tt_metal/test_utils/stimulus.hpp"
 #include "tt_metal/test_utils/print_helpers.hpp"
 #include "dm_common.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 
@@ -37,7 +38,7 @@ struct OneFromOneConfig {
 /// @param fixture - DispatchFixture pointer for dispatch-aware operations
 /// @return
 bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const OneFromOneConfig& test_config) {
-    IDevice* device = mesh_device->get_device(0);
+    IDevice* device = mesh_device->impl().get_device(0);
     // Program
     Program program = CreateProgram();
 
@@ -178,7 +179,7 @@ void packet_sizes_test(
     CoreCoord subordinate_core_coord,
     bool use_2_0_api = false,
     NOC noc_id = NOC::RISCV_1_default) {
-    IDevice* device = mesh_device->get_device(0);
+    IDevice* device = mesh_device->impl().get_device(0);
     // Physical Constraints
     auto [page_size_bytes, max_transmittable_bytes, max_transmittable_pages] =
         unit_tests::dm::compute_physical_constraints(mesh_device);

--- a/tests/tt_metal/tt_metal/data_movement/one_packet/test_one_packet.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_packet/test_one_packet.cpp
@@ -9,6 +9,7 @@
 #include "dm_common.hpp"
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/mesh_coord.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 
@@ -33,7 +34,7 @@ struct OnePacketConfig {
 /// @return
 bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const OnePacketConfig& test_config) {
     // Get the actual device for this single-device test
-    IDevice* device = mesh_device->get_device(0);
+    IDevice* device = mesh_device->impl().get_device(0);
     // Program
     Program program = CreateProgram();
 
@@ -168,7 +169,7 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const OnePac
 /* ========== Test case for reading varying number of packets and packet sizes; Test id = 80 ========== */
 TEST_F(GenericMeshDeviceFixture, TensixDataMovementOnePacketReadSizes) {
     auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->get_device(0);
+    auto* device = mesh_device->impl().get_device(0);
     // Physical Constraints
     auto [page_size_bytes, max_transmittable_bytes, max_transmittable_pages] =
         tt::tt_metal::unit_tests::dm::compute_physical_constraints(mesh_device);
@@ -204,7 +205,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOnePacketReadSizes) {
 /* ========== Test case for writing varying number of packets and packet sizes; Test id = 81 ========== */
 TEST_F(GenericMeshDeviceFixture, TensixDataMovementOnePacketWriteSizes) {
     auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->get_device(0);
+    auto* device = mesh_device->impl().get_device(0);
 
     // Physical Constraints
     auto [page_size_bytes, max_transmittable_bytes, max_transmittable_pages] =

--- a/tests/tt_metal/tt_metal/data_movement/one_to_all/test_multicast_schemes.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_to_all/test_multicast_schemes.cpp
@@ -8,6 +8,7 @@
 #include "tt_metal/test_utils/print_helpers.hpp"
 #include "dm_common.hpp"
 #include "test_one_to_all.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 
@@ -19,8 +20,8 @@ namespace unit_tests::dm::core_to_all::multicast_schemes {
 
 uint32_t determine_max_grid_dimension(const shared_ptr<distributed::MeshDevice>& mesh_device) {
     uint32_t smaller_dimension =
-        min(mesh_device->get_device(0)->compute_with_storage_grid_size().x,
-            mesh_device->get_device(0)->compute_with_storage_grid_size().y);
+        min(mesh_device->impl().get_device(0)->compute_with_storage_grid_size().x,
+            mesh_device->impl().get_device(0)->compute_with_storage_grid_size().y);
     return (smaller_dimension - 1);
 }
 
@@ -222,7 +223,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToAllMulticastSchemeSingle
     bool loopback = false;
     NOC noc_id = NOC::NOC_0;
     uint32_t sub_grid_dimension_size =
-        mesh_device->get_device(0)->arch() == ARCH::WORMHOLE_B0 ? 7 : 9;  // Adjust based on architecture
+        mesh_device->impl().get_device(0)->arch() == ARCH::WORMHOLE_B0 ? 7 : 9;  // Adjust based on architecture
     unit_tests::dm::core_to_all::multicast_schemes::MulticastSchemeType multicast_scheme =
         unit_tests::dm::core_to_all::multicast_schemes::MulticastSchemeType::SenderInGridTopRight;
 

--- a/tests/tt_metal/tt_metal/data_movement/one_to_all/test_one_to_all.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_to_all/test_one_to_all.cpp
@@ -13,6 +13,7 @@
 #include "tt_metal/test_utils/print_helpers.hpp"
 #include "dm_common.hpp"
 #include "test_one_to_all.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 
@@ -51,7 +52,7 @@ struct OneToAllConfig {
 };
 
 bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const OneToAllConfig& test_config) {
-    IDevice* device = mesh_device->get_device(0);
+    IDevice* device = mesh_device->impl().get_device(0);
     /* ================ SETUP ================ */
 
     // Program
@@ -302,8 +303,9 @@ void packet_sizes_test(
     /* Running the Test */
 
     uint32_t max_transactions = 256;
-    uint32_t max_pages_reservable_per_transaction =
-        mesh_device->get_device(0)->arch() == ARCH::BLACKHOLE ? 1024 : 2048;  // Max total transaction size == 64 KB
+    uint32_t max_pages_reservable_per_transaction = mesh_device->impl().get_device(0)->arch() == ARCH::BLACKHOLE
+                                                        ? 1024
+                                                        : 2048;  // Max total transaction size == 64 KB
 
     for (bool loopback : {true, false}) {
         if (loopback) {
@@ -502,7 +504,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToAllUnicastPacketSizes) {
     uint32_t test_case_id = unit_tests::dm::core_to_all::START_ID + 2;
 
     auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->get_device(0);
+    auto* device = mesh_device->impl().get_device(0);
 
     bool is_multicast = false;
     bool is_linked = false;
@@ -559,7 +561,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToAllMulticastPacketSizes)
     uint32_t test_case_id = unit_tests::dm::core_to_all::START_ID + 5;
 
     auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->get_device(0);
+    auto* device = mesh_device->impl().get_device(0);
 
     bool is_multicast = true;
     bool is_linked = false;
@@ -616,7 +618,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToAllMulticastLinkedPacket
     uint32_t test_case_id = unit_tests::dm::core_to_all::START_ID + 8;
 
     auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->get_device(0);
+    auto* device = mesh_device->impl().get_device(0);
 
     bool is_multicast = true;
     bool is_linked = true;
@@ -637,7 +639,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToAllUnicastDirectedIdeal)
     uint32_t test_case_id = 52;  // Arbitrary test id
 
     auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->get_device(0);
+    auto* device = mesh_device->impl().get_device(0);
 
     bool loopback = true;
     NOC noc_id = NOC::NOC_0;
@@ -668,7 +670,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToAllMulticastDirectedIdea
     uint32_t test_case_id = 53;  // Arbitrary test id
 
     auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->get_device(0);
+    auto* device = mesh_device->impl().get_device(0);
 
     bool loopback = true;
     NOC noc_id = NOC::NOC_0;
@@ -699,7 +701,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToAllMulticastLinkedDirect
     uint32_t test_case_id = 54;  // Arbitrary test id
 
     auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->get_device(0);
+    auto* device = mesh_device->impl().get_device(0);
 
     bool loopback = true;
     NOC noc_id = NOC::NOC_0;
@@ -732,7 +734,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToAllUnicastVirtualChannel
     uint32_t test_case_id = 154;
 
     auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->get_device(0);
+    auto* device = mesh_device->impl().get_device(0);
 
     // These should always be false
     bool is_multicast = false;
@@ -764,7 +766,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToAllUnicastCustom) {
     uint32_t test_case_id = 155;
 
     auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->get_device(0);
+    auto* device = mesh_device->impl().get_device(0);
 
     // These should always be false
     bool is_multicast = false;
@@ -837,7 +839,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToAllUnicastPacketSizes2_0
     uint32_t test_case_id = unit_tests::dm::core_to_all::START_ID_2_0 + 2;
 
     auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->get_device(0);
+    auto* device = mesh_device->impl().get_device(0);
 
     bool is_multicast = false;
     bool is_linked = false;
@@ -894,7 +896,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToAllMulticastPacketSizes2
     uint32_t test_case_id = unit_tests::dm::core_to_all::START_ID_2_0 + 5;
 
     auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->get_device(0);
+    auto* device = mesh_device->impl().get_device(0);
 
     bool is_multicast = true;
     bool is_linked = false;
@@ -951,7 +953,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToAllMulticastLinkedPacket
     uint32_t test_case_id = unit_tests::dm::core_to_all::START_ID_2_0 + 8;
 
     auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->get_device(0);
+    auto* device = mesh_device->impl().get_device(0);
 
     bool is_multicast = true;
     bool is_linked = true;
@@ -970,7 +972,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToAllMulticastLinkedDirect
     uint32_t test_case_id = unit_tests::dm::core_to_all::START_ID_2_0 + 9;
 
     auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->get_device(0);
+    auto* device = mesh_device->impl().get_device(0);
 
     bool loopback = true;
     NOC noc_id = NOC::NOC_0;

--- a/tests/tt_metal/tt_metal/data_movement/one_to_one/test_one_to_one.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_to_one/test_one_to_one.cpp
@@ -9,6 +9,7 @@
 #include "dm_common.hpp"
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/mesh_coord.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 
@@ -38,7 +39,7 @@ struct OneToOneConfig {
 /// @return
 bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const OneToOneConfig& test_config) {
     // Get the actual device for this single-device test
-    IDevice* device = mesh_device->get_device(0);
+    IDevice* device = mesh_device->impl().get_device(0);
 
     /* ================ SETUP ================ */
 
@@ -245,7 +246,7 @@ void packet_sizes_test(
     CoreCoord master_core_coord = {0, 0},
     CoreCoord subordinate_core_coord = {1, 1},
     bool use_2_0_api = false) {
-    IDevice* device = mesh_device->get_device(0);
+    IDevice* device = mesh_device->impl().get_device(0);
     // Physical Constraints
     auto [bytes_per_page, max_transmittable_bytes, max_transmittable_pages] =
         unit_tests::dm::compute_physical_constraints(mesh_device);

--- a/tests/tt_metal/tt_metal/data_movement/pcie_read_bw/test_pcie_read_bw.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/pcie_read_bw/test_pcie_read_bw.cpp
@@ -9,6 +9,7 @@
 #include <tt-metalium/kernel_types.hpp>
 #include <tt-metalium/program.hpp>
 #include "dm_common.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 
@@ -35,7 +36,7 @@ struct PCIeReadBwConfig {
 /// @return true if test passes, false otherwise
 bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const PCIeReadBwConfig& test_config) {
     // Get the actual device for this single-device test
-    IDevice* device = mesh_device->get_device(0);
+    IDevice* device = mesh_device->impl().get_device(0);
     auto device_id = device->id();
 
     // Program

--- a/tests/tt_metal/tt_metal/data_movement/transaction_id/test_transaction_id.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/transaction_id/test_transaction_id.cpp
@@ -9,6 +9,7 @@
 #include "dm_common.hpp"
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/mesh_coord.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 
@@ -43,7 +44,7 @@ struct TransactionIdConfig {
 /// @return
 bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const TransactionIdConfig& test_config) {
     // Get the actual device for this single-device test
-    IDevice* device = mesh_device->get_device(0);
+    IDevice* device = mesh_device->impl().get_device(0);
 
     /* ================ SETUP ================ */
 
@@ -194,7 +195,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementTransactionIdReadAfterWrite) 
     uint32_t test_id = 600;
 
     auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->get_device(0);
+    auto* device = mesh_device->impl().get_device(0);
 
     // Physical Constraints
     auto [bytes_per_page, max_transmittable_bytes, max_transmittable_pages] =
@@ -208,8 +209,9 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementTransactionIdReadAfterWrite) 
     CoreCoord sub1_core_coord = {device->compute_with_storage_grid_size().x - 1, 0};
 
     // Parameters
-    uint32_t max_pages_per_transaction =
-        mesh_device->get_device(0)->arch() == ARCH::BLACKHOLE ? 1024 : 2048;  // Max total transaction size == 64 KB
+    uint32_t max_pages_per_transaction = mesh_device->impl().get_device(0)->arch() == ARCH::BLACKHOLE
+                                             ? 1024
+                                             : 2048;  // Max total transaction size == 64 KB
 
     for (uint32_t num_of_trids = 1; num_of_trids <= 16; num_of_trids *= 2) {  // Up to 0xF (16) transaction ids
         for (uint32_t pages_per_transaction = 1; pages_per_transaction <= max_pages_per_transaction;
@@ -241,7 +243,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementTransactionIdReadAfterWriteOn
     uint32_t test_id = 601;
 
     auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->get_device(0);
+    auto* device = mesh_device->impl().get_device(0);
 
     // Physical Constraints
     auto [bytes_per_page, max_transmittable_bytes, max_transmittable_pages] =
@@ -288,7 +290,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementTransactionIdReadAfterWriteOn
     uint32_t test_id = 602;
 
     auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->get_device(0);
+    auto* device = mesh_device->impl().get_device(0);
 
     // Physical Constraints
     auto [bytes_per_page, max_transmittable_bytes, max_transmittable_pages] =
@@ -336,7 +338,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementTransactionIdWriteAfterRead) 
     uint32_t test_id = 610;
 
     auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->get_device(0);
+    auto* device = mesh_device->impl().get_device(0);
 
     // Physical Constraints
     auto [bytes_per_page, max_transmittable_bytes, max_transmittable_pages] =
@@ -350,8 +352,9 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementTransactionIdWriteAfterRead) 
     CoreCoord sub1_core_coord = {device->compute_with_storage_grid_size().x - 1, 0};
 
     // Parameters
-    uint32_t max_pages_per_transaction =
-        mesh_device->get_device(0)->arch() == ARCH::BLACKHOLE ? 1024 : 2048;  // Max total transaction size == 64 KB
+    uint32_t max_pages_per_transaction = mesh_device->impl().get_device(0)->arch() == ARCH::BLACKHOLE
+                                             ? 1024
+                                             : 2048;  // Max total transaction size == 64 KB
 
     for (uint32_t num_of_trids = 1; num_of_trids <= 16; num_of_trids *= 2) {  // Up to 0xF (16) transaction ids
         for (uint32_t pages_per_transaction = 1; pages_per_transaction <= max_pages_per_transaction;
@@ -384,7 +387,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementTransactionIdWriteAfterReadOn
     uint32_t test_id = 611;
 
     auto mesh_device = get_mesh_device();
-    auto* device = mesh_device->get_device(0);
+    auto* device = mesh_device->impl().get_device(0);
 
     // Physical Constraints
     auto [bytes_per_page, max_transmittable_bytes, max_transmittable_pages] =

--- a/tests/tt_metal/tt_metal/device/test_device.cpp
+++ b/tests/tt_metal/tt_metal/device/test_device.cpp
@@ -41,6 +41,7 @@
 #include <tt-metalium/vector_aligned.hpp>
 #include "math.hpp"
 #include <impl/dispatch/dispatch_mem_map.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal {
 
@@ -490,7 +491,7 @@ TEST_F(MeshDeviceFixture, MeshL1ToPinnedMemoryAt16BAlignedAddress) {
 
     // Use first device from the mesh for this test
     MeshCoordinate target_coord(0, 0);
-    IDevice* device = mesh_device->get_device(target_coord);
+    IDevice* device = mesh_device->impl().get_device(target_coord);
     EXPECT_TRUE(device->is_mmio_capable());
 
     CoreCoord logical_core(0, 0);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_pgm_dispatch.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_pgm_dispatch.cpp
@@ -45,6 +45,7 @@
 #include "tt_metal/impl/dispatch/device_command.hpp"
 #include <tt-metalium/sub_device.hpp>
 #include <impl/dispatch/dispatch_mem_map.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 constexpr uint32_t DEFAULT_ITERATIONS = 10000;
 constexpr uint32_t DEFAULT_WARMUP_ITERATIONS = 100;
@@ -371,7 +372,7 @@ bool initialize_program(
     }
 
     if (info.erisc_enabled) {
-        auto erisc_cores = mesh_device->get_device(0, 0)->get_active_ethernet_cores(true);
+        auto erisc_cores = mesh_device->impl().get_device(0, 0)->get_active_ethernet_cores(true);
         if (info.erisc_count > erisc_cores.size()) {
             log_fatal(
                 tt::LogTest,
@@ -731,7 +732,7 @@ static int pgm_dispatch(T& state, TestInfo info) {
         }
 
         // Set benchmark counters before timing (all values are known at this point)
-        set_benchmark_counters(state, info, mesh_device->get_device(0, 0), executor.total_program_iterations);
+        set_benchmark_counters(state, info, mesh_device->impl().get_device(0, 0), executor.total_program_iterations);
 
         // Run warmup
         executor.warmup_programs();

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common.hpp
@@ -32,6 +32,7 @@
 #include "tt_fabric_test_common_types.hpp"
 #include "tt_metal/distributed/fd_mesh_command_queue.hpp"
 #include "tt_metal/impl/dispatch/hardware_command_queue.hpp"
+#include "tt_metal/distributed/mesh_device_impl.hpp"
 
 using MeshDevice = tt::tt_metal::distributed::MeshDevice;
 using MeshCoordinate = tt::tt_metal::distributed::MeshCoordinate;
@@ -527,7 +528,7 @@ public:
         uint32_t size_bytes,
         bool blocking,
         std::unordered_map<CoreCoord, std::vector<uint32_t>>& results_out) const {
-        auto* device = mesh_device_->get_device(device_coord);
+        auto* device = mesh_device_->impl().get_device(device_coord);
         auto num_elements = tt::align(size_bytes, sizeof(uint32_t));
         for (const auto& logical_core : cores) {
             auto virtual_core = device->ethernet_core_from_logical_core(logical_core);
@@ -557,7 +558,7 @@ public:
         const std::vector<CoreCoord>& cores,
         uint32_t address,
         const std::vector<uint8_t>& data) const {
-        auto* device = mesh_device_->get_device(device_coord);
+        auto* device = mesh_device_->impl().get_device(device_coord);
         for (const auto& logical_core : cores) {
             auto virtual_core = device->ethernet_core_from_logical_core(logical_core);
 

--- a/tt_metal/api/tt-metalium/mesh_device.hpp
+++ b/tt_metal/api/tt-metalium/mesh_device.hpp
@@ -276,7 +276,9 @@ public:
 
     // Returns the devices in the mesh in row-major order.
     std::vector<IDevice*> get_devices() const;
+    [[deprecated("Deprecated, retrieving physical devices can fail in distributed contexts.")]]
     IDevice* get_device(ChipId physical_device_id) const;
+    [[deprecated("Deprecated, retrieving physical devices can fail in distributed contexts.")]]
     IDevice* get_device(const MeshCoordinate& coord) const;
     tt_fabric::FabricNodeId get_fabric_node_id(const MeshCoordinate& coord) const;
 
@@ -292,6 +294,7 @@ public:
 
     // Returns true if the coordinate is local to this mesh device.
     // Throws if the coordinate is out of bounds of this mesh device.
+    [[deprecated("Deprecated, is_local should be avoided as it is likely to cause issues in distributed contexts.")]]
     bool is_local(const MeshCoordinate& coord) const;
 
     const MeshShape& shape() const;

--- a/tt_metal/api/tt-metalium/mesh_device.hpp
+++ b/tt_metal/api/tt-metalium/mesh_device.hpp
@@ -293,6 +293,7 @@ public:
         tt::stl::Span<const std::uint32_t> l1_bank_remap = {},
         size_t worker_l1_size = DEFAULT_WORKER_L1_SIZE);
 
+    // Only for internal and testing purposes
     const MeshDeviceImpl& impl() const { return *pimpl_; }
     MeshDeviceImpl& impl() { return *pimpl_; }
 };

--- a/tt_metal/api/tt-metalium/mesh_device.hpp
+++ b/tt_metal/api/tt-metalium/mesh_device.hpp
@@ -197,9 +197,13 @@ public:
 
     // Returns the devices in the mesh in row-major order.
     std::vector<IDevice*> get_devices() const;
-    [[deprecated("Deprecated, retrieving physical devices can fail in distributed contexts.")]]
+    [[deprecated(
+        "Deprecated, retrieving physical devices can fail in distributed contexts. This will be removed after "
+        "28-02-2026.")]]
     IDevice* get_device(ChipId physical_device_id) const;
-    [[deprecated("Deprecated, retrieving physical devices can fail in distributed contexts.")]]
+    [[deprecated(
+        "Deprecated, retrieving physical devices can fail in distributed contexts. This will be removed after "
+        "28-02-2026.")]]
     IDevice* get_device(const MeshCoordinate& coord) const;
     tt_fabric::FabricNodeId get_fabric_node_id(const MeshCoordinate& coord) const;
 
@@ -215,7 +219,9 @@ public:
 
     // Returns true if the coordinate is local to this mesh device.
     // Throws if the coordinate is out of bounds of this mesh device.
-    [[deprecated("Deprecated, is_local should be avoided as it is likely to cause issues in distributed contexts.")]]
+    [[deprecated(
+        "Deprecated, is_local should be avoided as it is likely to cause issues in distributed contexts. This will be "
+        "removed after 28-02-2026.")]]
     bool is_local(const MeshCoordinate& coord) const;
 
     const MeshShape& shape() const;

--- a/tt_metal/api/tt-metalium/mesh_device.hpp
+++ b/tt_metal/api/tt-metalium/mesh_device.hpp
@@ -76,45 +76,6 @@ class MeshDevice : public IDevice, public std::enable_shared_from_this<MeshDevic
 private:
     MeshDevice() = default;
 
-    // TODO(#31961): Moved to MeshDeviceImpl, need to wait for deprecation period expiry of local_root_devices, before
-    // this can be removed. My bad.
-    class ScopedDevices {
-    private:
-        std::vector<MaybeRemote<IDevice*>> devices_;
-        std::map<ChipId, IDevice*> opened_local_devices_;
-
-    public:
-        // Constructor acquires physical resources
-        ScopedDevices(
-            size_t l1_small_size,
-            size_t trace_region_size,
-            size_t num_command_queues,
-            size_t worker_l1_size,
-            const DispatchCoreConfig& dispatch_core_config,
-            const MeshDeviceConfig& config);
-        ScopedDevices(
-            const std::vector<MaybeRemote<int>>& all_device_ids,
-            const std::vector<MaybeRemote<int>>& active_device_ids,
-            size_t l1_small_size,
-            size_t trace_region_size,
-            size_t num_command_queues,
-            size_t worker_l1_size,
-            const DispatchCoreConfig& dispatch_core_config);
-
-        // Destructor releases physical resources
-        ~ScopedDevices();
-        ScopedDevices(const ScopedDevices&) = delete;
-        ScopedDevices& operator=(const ScopedDevices&) = delete;
-
-        // Returns the list of devices opened by the root mesh device (i.e. not submeshes).
-        [[deprecated("This function is deprecated. Use opened_local_devices() instead.")]]
-        const std::vector<IDevice*>& local_root_devices() const;
-
-        const std::map<ChipId, IDevice*>& opened_local_devices() const;
-
-        const std::vector<MaybeRemote<IDevice*>>& root_devices() const;
-    };
-
     std::unique_ptr<MeshDeviceImpl> pimpl_;
 
 public:

--- a/tt_metal/api/tt-metalium/mesh_device_view.hpp
+++ b/tt_metal/api/tt-metalium/mesh_device_view.hpp
@@ -67,7 +67,8 @@ public:
 
     // Returns `IDevice*` instance for `coord`.
     // In multi-host context, throws if `coord` is querying a remote device.
-    [[nodiscard]] IDevice* get_device(const MeshCoordinate& coord) const;
+    [[deprecated("Deprecated, retrieving physical devices can fail in distributed contexts.")]] [[nodiscard]] IDevice*
+    get_device(const MeshCoordinate& coord) const;
 
     // Returns `tt::tt_fabric::FabricNodeId` for `coord`.
     // In multi-host context, fabric node IDs are always available, even for remote devices.
@@ -111,6 +112,7 @@ public:
 
     // Returns true if the view is fully local, i.e. all devices in the view are local.
     // Throws if the coordinate is out of bounds of this view.
+    [[deprecated("Deprecated, is_local should be avoided as it is likely to cause issues in distributed contexts.")]]
     bool is_local(const MeshCoordinate& coord) const;
 
     // Returns the coordinate range of all local devices in this view.

--- a/tt_metal/api/tt-metalium/mesh_device_view.hpp
+++ b/tt_metal/api/tt-metalium/mesh_device_view.hpp
@@ -68,7 +68,9 @@ public:
 
     // Returns `IDevice*` instance for `coord`.
     // In multi-host context, throws if `coord` is querying a remote device.
-    [[deprecated("Deprecated, retrieving physical devices can fail in distributed contexts.")]] [[nodiscard]] IDevice*
+    [[deprecated(
+        "Deprecated, retrieving physical devices can fail in distributed contexts. This will be removed after "
+        "28-02-2026.")]] [[nodiscard]] IDevice*
     get_device(const MeshCoordinate& coord) const;
 
     // Returns `tt::tt_fabric::FabricNodeId` for `coord`.
@@ -113,7 +115,9 @@ public:
 
     // Returns true if the view is fully local, i.e. all devices in the view are local.
     // Throws if the coordinate is out of bounds of this view.
-    [[deprecated("Deprecated, is_local should be avoided as it is likely to cause issues in distributed contexts.")]]
+    [[deprecated(
+        "Deprecated, is_local should be avoided as it is likely to cause issues in distributed contexts. This will be "
+        "removed after 28-02-2026.")]]
     bool is_local(const MeshCoordinate& coord) const;
 
     // Returns the coordinate range of all local devices in this view.

--- a/tt_metal/distributed/distributed.cpp
+++ b/tt_metal/distributed/distributed.cpp
@@ -7,6 +7,7 @@
 
 #include "device.hpp"
 #include "mesh_device.hpp"
+#include "mesh_device_impl.hpp"
 #include "mesh_trace.hpp"
 #include "mesh_workload_impl.hpp"
 #include "tt-metalium/program.hpp"
@@ -28,7 +29,7 @@ void EventSynchronize(const MeshEvent& event) {
         return;
     }
     for (const auto& coord : event.device_range()) {
-        auto* physical_device = event.device()->get_device(coord);
+        auto* physical_device = event.device()->impl().get_device(coord);
         while (physical_device->sysmem_manager().get_last_completed_event(event.mesh_cq_id()) < event.id()) {
             ;
         }
@@ -41,7 +42,7 @@ bool EventQuery(const MeshEvent& event) {
     }
     bool event_completed = true;
     for (const auto& coord : event.device_range()) {
-        auto* physical_device = event.device()->get_device(coord);
+        auto* physical_device = event.device()->impl().get_device(coord);
         event_completed &= physical_device->sysmem_manager().get_last_completed_event(event.mesh_cq_id()) >= event.id();
     }
     return event_completed;

--- a/tt_metal/distributed/mesh_buffer.cpp
+++ b/tt_metal/distributed/mesh_buffer.cpp
@@ -11,6 +11,7 @@
 
 #include <tt_stl/assert.hpp>
 #include "device.hpp"
+#include "mesh_device_impl.hpp"
 
 namespace tt::tt_metal::distributed {
 namespace {
@@ -117,7 +118,7 @@ std::shared_ptr<MeshBuffer> MeshBuffer::create(
 void MeshBuffer::initialize_device_buffers() {
     auto init_device_buffer_at_address = [this](const MeshCoordinate& coord) {
         std::shared_ptr<Buffer> buffer = Buffer::create(
-            device()->get_device(coord),
+            device()->impl().get_device(coord),
             address_,
             device_local_size_,
             device_local_config_.page_size,
@@ -130,7 +131,7 @@ void MeshBuffer::initialize_device_buffers() {
 
     for (auto& [coord, device_buffer] : buffers_) {
         if (auto mesh_device = mesh_device_.lock(); mesh_device != nullptr) {
-            if (mesh_device->is_local(coord)) {
+            if (mesh_device->impl().is_local(coord)) {
                 device_buffer = MaybeRemote<std::shared_ptr<Buffer>>::local(init_device_buffer_at_address(coord));
             }
         }

--- a/tt_metal/distributed/mesh_command_queue_base.cpp
+++ b/tt_metal/distributed/mesh_command_queue_base.cpp
@@ -19,6 +19,7 @@
 #include "tt_metal/common/thread_pool.hpp"
 #include "tt_cluster.hpp"
 #include "dispatch/dispatch_settings.hpp"
+#include "tt_metal/distributed/mesh_device_impl.hpp"
 
 namespace tt::tt_metal::distributed {
 
@@ -179,9 +180,10 @@ void MeshCommandQueueBase::enqueue_write_shard_to_sub_grid(
             this->write_shard_to_device(buffer, coord, host_data, region);
         };
         for (const auto& coord : device_range) {
-            if (mesh_device_->is_local(coord)) {
+            if (mesh_device_->impl().is_local(coord)) {
                 dispatch_thread_pool_->enqueue(
-                    [&dispatch_lambda, coord]() { dispatch_lambda(coord); }, mesh_device_->get_device(coord)->id());
+                    [&dispatch_lambda, coord]() { dispatch_lambda(coord); },
+                    mesh_device_->impl().get_device(coord)->id());
             }
         }
         dispatch_thread_pool_->wait();
@@ -232,10 +234,10 @@ void MeshCommandQueueBase::enqueue_write_shards_nolock(
 
     for (std::size_t shard_idx = 0; shard_idx < shard_data_transfers.size(); shard_idx++) {
         auto shard_coord = shard_data_transfers[shard_idx].shard_coord();
-        if (mesh_device_->is_local(shard_coord)) {
+        if (mesh_device_->impl().is_local(shard_coord)) {
             dispatch_thread_pool_->enqueue(
                 [&dispatch_lambda, shard_idx]() { dispatch_lambda(shard_idx); },
-                mesh_device_->get_device(shard_coord)->id());
+                mesh_device_->impl().get_device(shard_coord)->id());
         }
     }
     dispatch_thread_pool_->wait();
@@ -279,7 +281,7 @@ void MeshCommandQueueBase::enqueue_read_shards_nolock(
     std::unordered_map<IDevice*, uint32_t> num_txns_per_device = {};
     bool has_pinned_memory = false;
     for (const auto& shard_data_transfer : shard_data_transfers) {
-        if (mesh_device_->is_local(shard_data_transfer.shard_coord())) {
+        if (mesh_device_->impl().is_local(shard_data_transfer.shard_coord())) {
             auto pinned_memory = experimental::ShardDataTransferGetPinnedMemory(shard_data_transfer);
             has_pinned_memory = has_pinned_memory || pinned_memory != nullptr;
             this->read_shard_from_device(

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -8,6 +8,7 @@
 #include <mesh_coord.hpp>
 #include <mesh_device.hpp>
 #include <mesh_device_view.hpp>
+#include "distributed/mesh_device_impl.hpp"
 #include <tt_stl/small_vector.hpp>
 #include <sub_device.hpp>
 #include "impl/sub_device/sub_device_impl.hpp"
@@ -129,7 +130,7 @@ MeshCoordinate compute_system_mesh_offset(const MeshDeviceView& view) {
 
 }  // namespace
 
-MeshDevice::ScopedDevices::ScopedDevices(
+MeshDeviceImpl::ScopedDevices::ScopedDevices(
     const std::vector<MaybeRemote<int>>& all_device_ids,
     const std::vector<MaybeRemote<int>>& active_device_ids,
     size_t l1_small_size,
@@ -160,7 +161,7 @@ MeshDevice::ScopedDevices::ScopedDevices(
     }
 }
 
-MeshDevice::ScopedDevices::~ScopedDevices() {
+MeshDeviceImpl::ScopedDevices::~ScopedDevices() {
     if (!opened_local_devices_.empty()) {
         std::vector<IDevice*> devices_to_close;
         devices_to_close.reserve(opened_local_devices_.size());
@@ -171,18 +172,18 @@ MeshDevice::ScopedDevices::~ScopedDevices() {
     }
 }
 
-const std::map<ChipId, IDevice*>& MeshDevice::ScopedDevices::opened_local_devices() const {
+const std::map<ChipId, IDevice*>& MeshDeviceImpl::ScopedDevices::opened_local_devices() const {
     return opened_local_devices_;
 }
 
-const std::vector<MaybeRemote<IDevice*>>& MeshDevice::ScopedDevices::root_devices() const { return devices_; }
+const std::vector<MaybeRemote<IDevice*>>& MeshDeviceImpl::ScopedDevices::root_devices() const { return devices_; }
 
-uint8_t MeshDevice::num_hw_cqs() const {
+uint8_t MeshDeviceImpl::num_hw_cqs() const {
     return validate_and_get_reference_value(
         this->get_devices(), [](const auto* device) { return device->num_hw_cqs(); });
 }
 
-bool MeshDevice::is_initialized() const {
+bool MeshDeviceImpl::is_initialized() const {
     // TODO: Revisit whether we can simplify this when `MeshDevice` initialization isn't so coupled
     // with individual device initialization.
     if (!is_internal_state_initialized) {
@@ -195,25 +196,26 @@ bool MeshDevice::is_initialized() const {
         this->get_devices(), [](const auto* device) { return device->is_initialized(); });
 }
 
-uint32_t MeshDevice::l1_size_per_core() const {
+uint32_t MeshDeviceImpl::l1_size_per_core() const {
     return validate_and_get_reference_value(
         this->get_devices(), [](const auto* device) { return device->l1_size_per_core(); });
 }
 
-uint32_t MeshDevice::dram_size_per_channel() const {
+uint32_t MeshDeviceImpl::dram_size_per_channel() const {
     return validate_and_get_reference_value(
         this->get_devices(), [](const auto* device) { return device->dram_size_per_channel(); });
 }
 
-IDevice* MeshDevice::reference_device() const { return this->get_devices().at(0); }
+IDevice* MeshDeviceImpl::reference_device() const { return this->get_devices().at(0); }
 
 // NOLINTNEXTLINE(readability-make-member-function-const)
-void MeshDevice::mark_allocations_unsafe() { this->allocator_impl()->mark_allocations_unsafe(); }
+void MeshDeviceImpl::mark_allocations_unsafe() { this->allocator_impl()->mark_allocations_unsafe(); }
 
 // NOLINTNEXTLINE(readability-make-member-function-const)
-void MeshDevice::mark_allocations_safe() { this->allocator_impl()->mark_allocations_safe(); }
+void MeshDeviceImpl::mark_allocations_safe() { this->allocator_impl()->mark_allocations_safe(); }
 
-MeshDevice::MeshDevice(
+MeshDeviceImpl::MeshDeviceImpl(
+    MeshDevice* pimpl_wrapper,
     std::shared_ptr<ScopedDevices> mesh_handle,
     std::unique_ptr<MeshDeviceView> mesh_device_view,
     std::shared_ptr<MeshDevice> parent_mesh) :
@@ -223,14 +225,35 @@ MeshDevice::MeshDevice(
     parent_mesh_(std::move(parent_mesh)),
     dispatch_thread_pool_(create_default_thread_pool(extract_locals(scoped_devices_->root_devices()))),
     reader_thread_pool_(create_default_thread_pool(extract_locals(scoped_devices_->root_devices()))),
-    program_cache_(std::make_unique<program_cache::detail::ProgramCache>()) {
-    Inspector::mesh_device_created(this, parent_mesh_ ? std::make_optional(parent_mesh_->mesh_id_) : std::nullopt);
+    program_cache_(std::make_unique<program_cache::detail::ProgramCache>()),
+    pimpl_wrapper_(pimpl_wrapper) {
+    pimpl_wrapper_->pimpl_ = std::unique_ptr<MeshDeviceImpl>(this);
+    Inspector::mesh_device_created(
+        pimpl_wrapper_, parent_mesh_ ? std::make_optional(parent_mesh_->id()) : std::nullopt);
     const auto& mpi_context = MetalContext::instance().global_distributed_context();
     distributed_context_ =
         mpi_context.split(distributed::multihost::Color(id()), distributed::multihost::Key(*mpi_context.rank()));
 }
 
 std::shared_ptr<MeshDevice> MeshDevice::create(
+    const MeshDeviceConfig& config,
+    size_t l1_small_size,
+    size_t trace_region_size,
+    size_t num_command_queues,
+    const DispatchCoreConfig& dispatch_core_config,
+    tt::stl::Span<const std::uint32_t> l1_bank_remap,
+    size_t worker_l1_size) {
+    return MeshDeviceImpl::create(
+        config,
+        l1_small_size,
+        trace_region_size,
+        num_command_queues,
+        dispatch_core_config,
+        l1_bank_remap,
+        worker_l1_size);
+}
+
+std::shared_ptr<MeshDevice> MeshDeviceImpl::create(
     const MeshDeviceConfig& config,
     size_t l1_small_size,
     size_t trace_region_size,
@@ -257,7 +280,7 @@ std::shared_ptr<MeshDevice> MeshDevice::create(
                     ? SystemMesh::instance().get_mapped_devices(std::nullopt).device_ids
                     : mapped_devices.device_ids;
             return std::make_tuple(
-                std::make_shared<ScopedDevices>(
+                std::make_shared<MeshDeviceImpl::ScopedDevices>(
                     mapped_devices_full_system_device_ids,
                     mapped_devices.device_ids,
                     l1_small_size,
@@ -300,15 +323,17 @@ std::shared_ptr<MeshDevice> MeshDevice::create(
             config.mesh_shape().value());
     }();
 
-    // Make a copy because we std::move the scoped_devices when creating MeshDevice
+    // Make a copy because we std::move the scoped_devices when creating MeshDeviceImpl
     const auto root_devices = scoped_devices->root_devices();
 
-    auto mesh_device = std::make_shared<MeshDevice>(
+    auto mesh_device = std::shared_ptr<MeshDevice>(new MeshDevice());
+    auto mesh_device_impl = new MeshDeviceImpl(
+        mesh_device.get(),
         std::move(scoped_devices),
         std::make_unique<MeshDeviceView>(mesh_shape, root_devices, fabric_node_ids),
         std::shared_ptr<MeshDevice>());
 
-    mesh_device->initialize(num_command_queues, l1_small_size, trace_region_size, worker_l1_size, l1_bank_remap);
+    mesh_device_impl->initialize(num_command_queues, l1_small_size, trace_region_size, worker_l1_size, l1_bank_remap);
 
     // TODO #20966: Remove these calls
     for (auto* device : extract_locals(root_devices)) {
@@ -316,7 +341,7 @@ std::shared_ptr<MeshDevice> MeshDevice::create(
     }
 
     // Wait for all ranks to finish initializing the mesh device before proceeding.
-    mesh_device->distributed_context_->barrier();
+    mesh_device_impl->distributed_context_->barrier();
 
     // The Device Profiler must be initialized before Fabric is loaded on the Cluster
     tt_metal::MetalContext::instance().device_manager()->init_profiler();
@@ -324,11 +349,29 @@ std::shared_ptr<MeshDevice> MeshDevice::create(
     return mesh_device;
 }
 
-void MeshDevice::enqueue_to_thread_pool(std::function<void()>&& f) { dispatch_thread_pool_->enqueue(std::move(f)); }
+void MeshDeviceImpl::enqueue_to_thread_pool(std::function<void()>&& f) { dispatch_thread_pool_->enqueue(std::move(f)); }
 
-void MeshDevice::wait_for_thread_pool() { dispatch_thread_pool_->wait(); }
+void MeshDeviceImpl::wait_for_thread_pool() { dispatch_thread_pool_->wait(); }
 
 std::map<int, std::shared_ptr<MeshDevice>> MeshDevice::create_unit_meshes(
+    const std::vector<int>& device_ids,
+    size_t l1_small_size,
+    size_t trace_region_size,
+    size_t num_command_queues,
+    const DispatchCoreConfig& dispatch_core_config,
+    tt::stl::Span<const std::uint32_t> l1_bank_remap,
+    size_t worker_l1_size) {
+    return MeshDeviceImpl::create_unit_meshes(
+        device_ids,
+        l1_small_size,
+        trace_region_size,
+        num_command_queues,
+        dispatch_core_config,
+        l1_bank_remap,
+        worker_l1_size);
+}
+
+std::map<int, std::shared_ptr<MeshDevice>> MeshDeviceImpl::create_unit_meshes(
     const std::vector<int>& device_ids,
     size_t l1_small_size,
     size_t trace_region_size,
@@ -357,7 +400,7 @@ std::map<int, std::shared_ptr<MeshDevice>> MeshDevice::create_unit_meshes(
         (*MetalContext::instance().global_distributed_context().size() > 1)
             ? SystemMesh::instance().get_mapped_devices(std::nullopt).device_ids
             : wrap_to_maybe_remote(device_ids);
-    auto scoped_devices = std::make_shared<ScopedDevices>(
+    auto scoped_devices = std::make_shared<MeshDeviceImpl::ScopedDevices>(
         mapped_devices_full_system_device_ids,
         wrap_to_maybe_remote(device_ids),
         l1_small_size,
@@ -366,14 +409,17 @@ std::map<int, std::shared_ptr<MeshDevice>> MeshDevice::create_unit_meshes(
         worker_l1_size,
         dispatch_core_config);
 
-    // Make a copy because we std::move the scoped_devices when creating MeshDevice
+    // Make a copy because we std::move the scoped_devices when creating MeshDeviceImpl
     const auto root_devices = scoped_devices->root_devices();
-    auto mesh_device = std::make_shared<MeshDevice>(
+
+    auto mesh_device = std::shared_ptr<MeshDevice>(new MeshDevice());
+    auto mesh_device_impl = new MeshDeviceImpl(
+        mesh_device.get(),
         std::move(scoped_devices),
         std::make_unique<MeshDeviceView>(MeshShape(1, device_ids.size()), root_devices, fabric_node_ids),
         std::shared_ptr<MeshDevice>());
 
-    auto submeshes = mesh_device->create_submeshes(MeshShape(1, 1));
+    auto submeshes = mesh_device_impl->create_submeshes(mesh_device, MeshShape(1, 1));
     TT_FATAL(
         device_ids.size() == submeshes.size(),
         "Created an unexpected number of submeshes: {} instead of {}",
@@ -385,7 +431,7 @@ std::map<int, std::shared_ptr<MeshDevice>> MeshDevice::create_unit_meshes(
     }
 
     // Wait for all ranks to finish initializing the mesh device before proceeding.
-    mesh_device->distributed_context_->barrier();
+    mesh_device_impl->distributed_context_->barrier();
 
     // The Device Profiler must be initialized before Fabric is loaded on the Cluster
     tt_metal::MetalContext::instance().device_manager()->init_profiler();
@@ -394,6 +440,24 @@ std::map<int, std::shared_ptr<MeshDevice>> MeshDevice::create_unit_meshes(
 }
 
 std::shared_ptr<MeshDevice> MeshDevice::create_unit_mesh(
+    int device_id,
+    size_t l1_small_size,
+    size_t trace_region_size,
+    size_t num_command_queues,
+    const DispatchCoreConfig& dispatch_core_config,
+    tt::stl::Span<const std::uint32_t> l1_bank_remap,
+    size_t worker_l1_size) {
+    return MeshDeviceImpl::create_unit_mesh(
+        device_id,
+        l1_small_size,
+        trace_region_size,
+        num_command_queues,
+        dispatch_core_config,
+        l1_bank_remap,
+        worker_l1_size);
+}
+
+std::shared_ptr<MeshDevice> MeshDeviceImpl::create_unit_mesh(
     int device_id,
     size_t l1_small_size,
     size_t trace_region_size,
@@ -412,8 +476,10 @@ std::shared_ptr<MeshDevice> MeshDevice::create_unit_mesh(
         .at(device_id);
 }
 
-std::shared_ptr<MeshDevice> MeshDevice::create_submesh(
-    const MeshShape& submesh_shape, const std::optional<MeshCoordinate>& offset) {
+std::shared_ptr<MeshDevice> MeshDeviceImpl::create_submesh(
+    const std::shared_ptr<MeshDevice>& parent_mesh,
+    const MeshShape& submesh_shape,
+    const std::optional<MeshCoordinate>& offset) {
     auto lock_api = this->lock_api();
     TT_FATAL(
         std::all_of(submesh_shape.cbegin(), submesh_shape.cend(), [](size_t dim) { return dim > 0; }),
@@ -461,36 +527,45 @@ std::shared_ptr<MeshDevice> MeshDevice::create_submesh(
         }
         submesh_fabric_node_ids.push_back(view_->get_fabric_node_id(coord));
     }
-    auto submesh = std::make_shared<MeshDevice>(
+
+    auto submesh = std::shared_ptr<MeshDevice>(new MeshDevice());
+    auto submesh_impl = new MeshDeviceImpl(
+        submesh.get(),
         scoped_devices_,
         std::make_unique<MeshDeviceView>(submesh_shape, submesh_devices, submesh_fabric_node_ids),
-        shared_from_this());
+        parent_mesh);
 
     const auto& allocator_config = reference_device()->allocator_impl()->get_config();
-    submesh->initialize(
+    submesh_impl->initialize(
         num_hw_cqs(),
         allocator_config.l1_small_size,
         allocator_config.trace_region_size,
         allocator_config.worker_l1_size,
         allocator_config.l1_bank_remap);
+
     // TODO #20966: Remove these calls
-    if (!submesh->get_view().get_devices().empty()) {
-        for (auto* device : submesh->get_devices()) {
+    if (!submesh_impl->get_view().get_devices().empty()) {
+        for (auto* device : submesh_impl->get_devices()) {
             dynamic_cast<Device*>(device)->set_mesh_device(submesh);
         }
     }
 
     submeshes_.push_back(submesh);
-    log_trace(LogMetal, "Instantiating submesh {}: {} with offset: {}", submesh->id(), submesh_shape, offset);
-    if (!submesh->get_view().get_devices().empty()) {
-        log_trace(LogMetal, "Submesh {} instantiated with {} devices", submesh->id(), submesh->get_devices().size());
+    log_trace(LogMetal, "Instantiating submesh {}: {} with offset: {}", submesh_impl->id(), submesh_shape, offset);
+    if (!submesh_impl->get_view().get_devices().empty()) {
+        log_trace(
+            LogMetal,
+            "Submesh {} instantiated with {} devices",
+            submesh_impl->id(),
+            submesh_impl->get_devices().size());
     } else {
-        log_trace(LogMetal, "Submesh {} instantiated with only remote devices", submesh->id());
+        log_trace(LogMetal, "Submesh {} instantiated with only remote devices", submesh_impl->id());
     }
     return submesh;
 }
 
-std::vector<std::shared_ptr<MeshDevice>> MeshDevice::create_submeshes(const MeshShape& submesh_shape) {
+std::vector<std::shared_ptr<MeshDevice>> MeshDeviceImpl::create_submeshes(
+    const std::shared_ptr<MeshDevice>& parent_mesh, const MeshShape& submesh_shape) {
     // Calculate how many submeshes fit in each dimension.
     tt::stl::SmallVector<uint32_t> steps;
     for (size_t dim = 0; dim < shape().dims(); dim++) {
@@ -511,18 +586,18 @@ std::vector<std::shared_ptr<MeshDevice>> MeshDevice::create_submeshes(const Mesh
         for (size_t dim = 0; dim < submesh_shape.dims(); dim++) {
             offset_coords.push_back(step_position[dim] * submesh_shape[dim]);
         }
-        submeshes.push_back(create_submesh(submesh_shape, MeshCoordinate(offset_coords)));
+        submeshes.push_back(create_submesh(parent_mesh, submesh_shape, MeshCoordinate(offset_coords)));
     }
 
     return submeshes;
 }
 
-MeshDevice::~MeshDevice() {
-    Inspector::mesh_device_destroyed(this);
+MeshDeviceImpl::~MeshDeviceImpl() {
+    Inspector::mesh_device_destroyed(this->pimpl_wrapper_);
     close();
 }
 
-IDevice* MeshDevice::get_device(ChipId physical_device_id) const {
+IDevice* MeshDeviceImpl::get_device(ChipId physical_device_id) const {
     for (auto* device : this->get_devices()) {
         if (device->id() == physical_device_id) {
             return device;
@@ -531,24 +606,24 @@ IDevice* MeshDevice::get_device(ChipId physical_device_id) const {
     TT_THROW("Physical Device ID: {} not found in assigned devices", physical_device_id);
 }
 
-std::vector<IDevice*> MeshDevice::get_devices() const {
+std::vector<IDevice*> MeshDeviceImpl::get_devices() const {
     auto devices = view_->get_devices();
     TT_ASSERT(!devices.empty(), "Mesh Device should have at least 1 IDevice");
     return devices;
 }
 
 // TODO: Remove this function once we have a proper view interface
-IDevice* MeshDevice::get_device(size_t row_idx, size_t col_idx) const {
+IDevice* MeshDeviceImpl::get_device(size_t row_idx, size_t col_idx) const {
     return get_device(MeshCoordinate{static_cast<uint32_t>(row_idx), static_cast<uint32_t>(col_idx)});
 }
 
-IDevice* MeshDevice::get_device(const MeshCoordinate& coord) const { return view_->get_device(coord); }
+IDevice* MeshDeviceImpl::get_device(const MeshCoordinate& coord) const { return view_->get_device(coord); }
 
-tt_fabric::FabricNodeId MeshDevice::get_fabric_node_id(const MeshCoordinate& coord) const {
+tt_fabric::FabricNodeId MeshDeviceImpl::get_fabric_node_id(const MeshCoordinate& coord) const {
     return view_->get_fabric_node_id(coord);
 }
 
-MeshCommandQueue& MeshDevice::mesh_command_queue(std::optional<uint8_t> cq_id) const {
+MeshCommandQueue& MeshDeviceImpl::mesh_command_queue(std::optional<uint8_t> cq_id) const {
     auto id = cq_id.value_or(GetCurrentCommandQueueIdForThread());
 
     TT_FATAL(id < mesh_command_queues_.size(), "cq_id {} is out of range", id);
@@ -557,7 +632,7 @@ MeshCommandQueue& MeshDevice::mesh_command_queue(std::optional<uint8_t> cq_id) c
     return *command_queue;
 }
 
-DeviceIds MeshDevice::get_device_ids() const {
+DeviceIds MeshDeviceImpl::get_device_ids() const {
     DeviceIds device_ids;
     for (auto* device : this->get_devices()) {
         device_ids.push_back(device->id());
@@ -565,24 +640,24 @@ DeviceIds MeshDevice::get_device_ids() const {
     return device_ids;
 }
 
-size_t MeshDevice::num_devices() const { return view_->num_devices(); }
+size_t MeshDeviceImpl::num_devices() const { return view_->num_devices(); }
 
-CoreCoord MeshDevice::compute_with_storage_grid_size() const {
+CoreCoord MeshDeviceImpl::compute_with_storage_grid_size() const {
     return validate_and_get_reference_value(
         this->get_devices(), [](const auto* device) { return device->compute_with_storage_grid_size(); });
 }
 
-tt::ARCH MeshDevice::arch() const { return tt_metal::MetalContext::instance().get_cluster().arch(); }
+tt::ARCH MeshDeviceImpl::arch() const { return tt_metal::MetalContext::instance().get_cluster().arch(); }
 
-size_t MeshDevice::num_rows() const { return view_->num_rows(); }
+size_t MeshDeviceImpl::num_rows() const { return view_->num_rows(); }
 
-size_t MeshDevice::num_cols() const { return view_->num_cols(); }
+size_t MeshDeviceImpl::num_cols() const { return view_->num_cols(); }
 
-const MeshShape& MeshDevice::shape() const { return view_->shape(); }
+const MeshShape& MeshDeviceImpl::shape() const { return view_->shape(); }
 
-bool MeshDevice::is_local(const MeshCoordinate& coord) const { return view_->is_local(coord); }
+bool MeshDeviceImpl::is_local(const MeshCoordinate& coord) const { return view_->is_local(coord); }
 
-void MeshDevice::reshape(const MeshShape& new_shape) {
+void MeshDeviceImpl::reshape(const MeshShape& new_shape) {
     const auto num_devices = view_->shape().mesh_size();
     TT_FATAL(new_shape.mesh_size() == num_devices, "New shape must have the same number of devices as current shape");
 
@@ -644,13 +719,14 @@ void MeshDevice::reshape(const MeshShape& new_shape) {
     view_ = std::move(new_view);
 }
 
-bool MeshDevice::close() {
+bool MeshDeviceImpl::close() {
     ZoneScoped;
 
     log_trace(tt::LogMetal, "Closing mesh device {}", this->id());
 
     if (this->is_initialized()) {
-        ReadMeshDeviceProfilerResults(*this, ProfilerReadState::LAST_FD_READ);
+        // TODO(p1-0tr): Figure out a way of doing this without the pimpl_wrapper_
+        ReadMeshDeviceProfilerResults(*this->pimpl_wrapper_, ProfilerReadState::LAST_FD_READ);
     }
 
     if (distributed_context_) {
@@ -669,7 +745,7 @@ bool MeshDevice::close() {
         if (mesh_command_queues_[cq_id]->in_use()) {
             auto parent_mesh = get_parent_mesh();
             if (parent_mesh) {
-                auto parent_mesh_id = parent_mesh->get_parent_mesh_id_with_in_use_cq(cq_id);
+                auto parent_mesh_id = parent_mesh->impl().get_parent_mesh_id_with_in_use_cq(cq_id);
                 if (parent_mesh_id) {
                     TT_THROW(
                         "MeshDevice cq ID {} is in use by parent mesh ID {} during close of mesh ID {}",
@@ -681,7 +757,7 @@ bool MeshDevice::close() {
 
             for (const auto& submesh : submeshes_) {
                 if (auto submesh_ptr = submesh.lock()) {
-                    auto child_mesh_id = submesh_ptr->get_child_mesh_id_with_in_use_cq(cq_id);
+                    auto child_mesh_id = submesh_ptr->impl().get_child_mesh_id_with_in_use_cq(cq_id);
                     if (child_mesh_id) {
                         TT_THROW(
                             "MeshDevice cq ID {} is in use by child submesh ID {} during close of mesh ID {}",
@@ -706,23 +782,23 @@ bool MeshDevice::close() {
     return true;
 }
 
-std::optional<int> MeshDevice::get_parent_mesh_id_with_in_use_cq(uint32_t cq_id) const {
+std::optional<int> MeshDeviceImpl::get_parent_mesh_id_with_in_use_cq(uint32_t cq_id) const {
     if (cq_id < mesh_command_queues_.size() && mesh_command_queues_[cq_id]->in_use()) {
         return id();
     }
     if (parent_mesh_) {
-        return parent_mesh_->get_parent_mesh_id_with_in_use_cq(cq_id);
+        return parent_mesh_->impl().get_parent_mesh_id_with_in_use_cq(cq_id);
     }
     return std::nullopt;
 }
 
-std::optional<int> MeshDevice::get_child_mesh_id_with_in_use_cq(uint32_t cq_id) const {
+std::optional<int> MeshDeviceImpl::get_child_mesh_id_with_in_use_cq(uint32_t cq_id) const {
     if (cq_id < mesh_command_queues_.size() && mesh_command_queues_[cq_id]->in_use()) {
         return id();
     }
     for (const auto& submesh : submeshes_) {
         if (auto submesh_ptr = submesh.lock()) {
-            auto child_mesh_id = submesh_ptr->get_child_mesh_id_with_in_use_cq(cq_id);
+            auto child_mesh_id = submesh_ptr->impl().get_child_mesh_id_with_in_use_cq(cq_id);
             if (child_mesh_id) {
                 return child_mesh_id;
             }
@@ -731,23 +807,23 @@ std::optional<int> MeshDevice::get_child_mesh_id_with_in_use_cq(uint32_t cq_id) 
     return std::nullopt;
 }
 
-std::string MeshDevice::to_string() const {
+std::string MeshDeviceImpl::to_string() const {
     return fmt::format("MeshDevice({}x{} grid, {} devices)", this->num_rows(), this->num_cols(), this->num_devices());
 }
 
-const MeshDeviceView& MeshDevice::get_view() const {
+const MeshDeviceView& MeshDeviceImpl::get_view() const {
     TT_FATAL(view_, "MeshDeviceView is not initialized");
     return *view_;
 }
 
-int MeshDevice::id() const { return mesh_id_; }
+int MeshDeviceImpl::id() const { return mesh_id_; }
 // For a mesh, build id is the same as the device id for the reference device
-ChipId MeshDevice::build_id() const { return reference_device()->id(); }
+ChipId MeshDeviceImpl::build_id() const { return reference_device()->id(); }
 
-bool MeshDevice::is_parent_mesh() const { return parent_mesh_ == nullptr; }
+bool MeshDeviceImpl::is_parent_mesh() const { return parent_mesh_ == nullptr; }
 
-const std::shared_ptr<MeshDevice>& MeshDevice::get_parent_mesh() const { return parent_mesh_; }
-std::vector<std::shared_ptr<MeshDevice>> MeshDevice::get_submeshes() const {
+const std::shared_ptr<MeshDevice>& MeshDeviceImpl::get_parent_mesh() const { return parent_mesh_; }
+std::vector<std::shared_ptr<MeshDevice>> MeshDeviceImpl::get_submeshes() const {
     std::vector<std::shared_ptr<MeshDevice>> result;
     result.reserve(submeshes_.size());
     for (const auto& weak_submesh : submeshes_) {
@@ -758,19 +834,17 @@ std::vector<std::shared_ptr<MeshDevice>> MeshDevice::get_submeshes() const {
     return result;
 }
 
-std::ostream& operator<<(std::ostream& os, const MeshDevice& mesh_device) { return os << mesh_device.to_string(); }
-
-void MeshDevice::enable_program_cache() {
+void MeshDeviceImpl::enable_program_cache() {
     log_info(tt::LogMetal, "Enabling program cache on MeshDevice {}", this->id());
     program_cache_->enable();
 }
 
-void MeshDevice::clear_program_cache() {
+void MeshDeviceImpl::clear_program_cache() {
     log_info(tt::LogMetal, "Clearing program cache on MeshDevice {}", this->id());
     program_cache_->clear();
 }
 
-void MeshDevice::disable_and_clear_program_cache() {
+void MeshDeviceImpl::disable_and_clear_program_cache() {
     log_info(tt::LogMetal, "Disabling and clearing program cache on MeshDevice {}", this->id());
     if (program_cache_->is_enabled()) {
         program_cache_->disable();
@@ -778,118 +852,123 @@ void MeshDevice::disable_and_clear_program_cache() {
     program_cache_->clear();
 }
 
-size_t MeshDevice::num_program_cache_entries() { return program_cache_->num_entries(); }
+size_t MeshDeviceImpl::num_program_cache_entries() { return program_cache_->num_entries(); }
 
-SubDeviceManagerId MeshDevice::create_sub_device_manager(
+SubDeviceManagerId MeshDeviceImpl::create_sub_device_manager(
     std::initializer_list<SubDevice> sub_devices, DeviceAddr local_l1_size) {
     auto lock = lock_api();
     return sub_device_manager_tracker_->create_sub_device_manager(sub_devices, local_l1_size);
 }
 
-SubDeviceManagerId MeshDevice::create_sub_device_manager(
+SubDeviceManagerId MeshDeviceImpl::create_sub_device_manager(
     tt::stl::Span<const SubDevice> sub_devices, DeviceAddr local_l1_size) {
     auto lock = lock_api();
     return sub_device_manager_tracker_->create_sub_device_manager(sub_devices, local_l1_size);
 }
-void MeshDevice::remove_sub_device_manager(SubDeviceManagerId sub_device_manager_id) {
+void MeshDeviceImpl::remove_sub_device_manager(SubDeviceManagerId sub_device_manager_id) {
     auto lock = lock_api();
     sub_device_manager_tracker_->remove_sub_device_manager(sub_device_manager_id);
 }
-void MeshDevice::load_sub_device_manager(SubDeviceManagerId sub_device_manager_id) {
+void MeshDeviceImpl::load_sub_device_manager(SubDeviceManagerId sub_device_manager_id) {
     auto lock = lock_api();
     sub_device_manager_tracker_->load_sub_device_manager(sub_device_manager_id);
 }
-void MeshDevice::clear_loaded_sub_device_manager() { sub_device_manager_tracker_->clear_loaded_sub_device_manager(); }
+void MeshDeviceImpl::clear_loaded_sub_device_manager() {
+    sub_device_manager_tracker_->clear_loaded_sub_device_manager();
+}
 
-CoreCoord MeshDevice::dram_grid_size() const {
+CoreCoord MeshDeviceImpl::dram_grid_size() const {
     return validate_and_get_reference_value(
         this->get_devices(), [](const auto* device) { return device->dram_grid_size(); });
 }
 
 // Device property methods that can be delegated to reference device
-CoreCoord MeshDevice::grid_size() const {
+CoreCoord MeshDeviceImpl::grid_size() const {
     return validate_and_get_reference_value(
         this->get_devices(), [](const auto* device) { return device->grid_size(); });
 }
-CoreCoord MeshDevice::logical_grid_size() const {
+CoreCoord MeshDeviceImpl::logical_grid_size() const {
     return validate_and_get_reference_value(
         this->get_devices(), [](const auto* device) { return device->logical_grid_size(); });
 }
-CoreCoord MeshDevice::virtual_noc0_coordinate(uint8_t noc_index, CoreCoord coord) const {
+CoreCoord MeshDeviceImpl::virtual_noc0_coordinate(uint8_t noc_index, CoreCoord coord) const {
     TT_FATAL(num_devices() == 1, "virtual_noc0_coordinate() is only supported on unit MeshDevice.");
     return get_devices().front()->virtual_noc0_coordinate(noc_index, coord);
 }
-std::vector<CoreCoord> MeshDevice::worker_cores_from_logical_cores(const std::vector<CoreCoord>& logical_cores) const {
+std::vector<CoreCoord> MeshDeviceImpl::worker_cores_from_logical_cores(
+    const std::vector<CoreCoord>& logical_cores) const {
     return validate_and_get_reference_value(this->get_devices(), [logical_cores](const auto* device) {
         return device->worker_cores_from_logical_cores(logical_cores);
     });
 }
-std::vector<CoreCoord> MeshDevice::get_optimal_dram_bank_to_logical_worker_assignment(NOC noc) {
+std::vector<CoreCoord> MeshDeviceImpl::get_optimal_dram_bank_to_logical_worker_assignment(NOC noc) {
     return get_devices().front()->get_optimal_dram_bank_to_logical_worker_assignment(noc);
 }
-CoreCoord MeshDevice::virtual_core_from_logical_core(const CoreCoord& logical_coord, const CoreType& core_type) const {
+CoreCoord MeshDeviceImpl::virtual_core_from_logical_core(
+    const CoreCoord& logical_coord, const CoreType& core_type) const {
     return validate_and_get_reference_value(this->get_devices(), [logical_coord, core_type](const auto* device) {
         return device->virtual_core_from_logical_core(logical_coord, core_type);
     });
 }
-CoreCoord MeshDevice::worker_core_from_logical_core(const CoreCoord& logical_core) const {
+CoreCoord MeshDeviceImpl::worker_core_from_logical_core(const CoreCoord& logical_core) const {
     return validate_and_get_reference_value(this->get_devices(), [logical_core](const auto* device) {
         return device->worker_core_from_logical_core(logical_core);
     });
 }
-CoreCoord MeshDevice::logical_core_from_ethernet_core(const CoreCoord& ethernet_core) const {
+CoreCoord MeshDeviceImpl::logical_core_from_ethernet_core(const CoreCoord& ethernet_core) const {
     return validate_and_get_reference_value(this->get_devices(), [ethernet_core](const auto* device) {
         return device->logical_core_from_ethernet_core(ethernet_core);
     });
 }
 
 // These methods require some change / or assert out for now
-std::vector<CoreCoord> MeshDevice::ethernet_cores_from_logical_cores(
+std::vector<CoreCoord> MeshDeviceImpl::ethernet_cores_from_logical_cores(
     const std::vector<CoreCoord>& logical_cores) const {
     return validate_and_get_reference_value(this->get_devices(), [logical_cores](const auto* device) {
         return device->ethernet_cores_from_logical_cores(logical_cores);
     });
 }
-CoreCoord MeshDevice::ethernet_core_from_logical_core(const CoreCoord& logical_core) const {
+CoreCoord MeshDeviceImpl::ethernet_core_from_logical_core(const CoreCoord& logical_core) const {
     return validate_and_get_reference_value(this->get_devices(), [logical_core](const auto* device) {
         return device->ethernet_core_from_logical_core(logical_core);
     });
 }
-std::unordered_set<CoreCoord> MeshDevice::get_active_ethernet_cores(bool /*skip_reserved_tunnel_cores*/) const {
+std::unordered_set<CoreCoord> MeshDeviceImpl::get_active_ethernet_cores(bool /*skip_reserved_tunnel_cores*/) const {
     TT_THROW("get_active_ethernet_cores() is not supported on MeshDevice - use individual devices instead");
 }
 
-std::unordered_set<CoreCoord> MeshDevice::get_inactive_ethernet_cores() const {
+std::unordered_set<CoreCoord> MeshDeviceImpl::get_inactive_ethernet_cores() const {
     TT_THROW("get_inactive_ethernet_cores() is not supported on MeshDevice - use individual devices instead");
 }
 
-bool MeshDevice::is_inactive_ethernet_core(CoreCoord /*logical_core*/) const {
+bool MeshDeviceImpl::is_inactive_ethernet_core(CoreCoord /*logical_core*/) const {
     TT_THROW("is_inactive_ethernet_core() is not supported on MeshDevice - use individual devices instead");
 }
 
-std::tuple<ChipId, CoreCoord> MeshDevice::get_connected_ethernet_core(CoreCoord /*eth_core*/) const {
+std::tuple<ChipId, CoreCoord> MeshDeviceImpl::get_connected_ethernet_core(CoreCoord /*eth_core*/) const {
     TT_THROW("get_connected_ethernet_core() is not supported on MeshDevice - use individual devices instead");
 }
 
-bool MeshDevice::is_active_ethernet_core(CoreCoord /*logical_core*/, bool /*skip_reserved_tunnel_cores*/) const {
+bool MeshDeviceImpl::is_active_ethernet_core(CoreCoord /*logical_core*/, bool /*skip_reserved_tunnel_cores*/) const {
     TT_THROW("is_active_ethernet_core() is not supported on MeshDevice - use individual devices instead");
 }
 
-std::vector<CoreCoord> MeshDevice::get_ethernet_sockets(ChipId /*connected_chip_id*/) const {
+std::vector<CoreCoord> MeshDeviceImpl::get_ethernet_sockets(ChipId /*connected_chip_id*/) const {
     TT_THROW("get_ethernet_sockets() is not supported on MeshDevice - use individual devices instead");
 }
 
-uint32_t MeshDevice::num_virtual_eth_cores(SubDeviceId sub_device_id) {
+uint32_t MeshDeviceImpl::num_virtual_eth_cores(SubDeviceId sub_device_id) {
     // Issue #19729: Return the maximum number of active ethernet cores across physical devices in the Mesh.
     TT_FATAL(*sub_device_id == 0, "Cannot query virtual ethernet cores per sub-device when using MeshDevice");
     return num_virtual_eth_cores_;
 }
 
 // Core and worker management methods (These are OK)
-CoreRangeSet MeshDevice::worker_cores(HalProgrammableCoreType core_type, SubDeviceId sub_device_id) const {
+CoreRangeSet MeshDeviceImpl::worker_cores(HalProgrammableCoreType core_type, SubDeviceId sub_device_id) const {
     return sub_device_manager_tracker_->get_active_sub_device_manager()->sub_device(sub_device_id).cores(core_type);
 }
-uint32_t MeshDevice::num_worker_cores(HalProgrammableCoreType core_type, SubDeviceId sub_device_id) const {
+
+uint32_t MeshDeviceImpl::num_worker_cores(HalProgrammableCoreType core_type, SubDeviceId sub_device_id) const {
     return sub_device_manager_tracker_->get_active_sub_device_manager()
         ->sub_device(sub_device_id)
         .impl()
@@ -897,57 +976,57 @@ uint32_t MeshDevice::num_worker_cores(HalProgrammableCoreType core_type, SubDevi
 }
 
 // Bank and memory management methods
-int MeshDevice::num_dram_channels() const { return reference_device()->num_dram_channels(); }
+int MeshDeviceImpl::num_dram_channels() const { return reference_device()->num_dram_channels(); }
 
-CoreCoord MeshDevice::logical_core_from_dram_channel(uint32_t dram_channel) const {
+CoreCoord MeshDeviceImpl::logical_core_from_dram_channel(uint32_t dram_channel) const {
     return validate_and_get_reference_value(this->get_devices(), [dram_channel](const auto* device) {
         return device->logical_core_from_dram_channel(dram_channel);
     });
 }
-uint32_t MeshDevice::dram_channel_from_logical_core(const CoreCoord& logical_core) const {
+uint32_t MeshDeviceImpl::dram_channel_from_logical_core(const CoreCoord& logical_core) const {
     return validate_and_get_reference_value(this->get_devices(), [logical_core](const auto* device) {
         return device->dram_channel_from_logical_core(logical_core);
     });
 }
-uint32_t MeshDevice::dram_channel_from_virtual_core(const CoreCoord& virtual_core) const {
+uint32_t MeshDeviceImpl::dram_channel_from_virtual_core(const CoreCoord& virtual_core) const {
     return validate_and_get_reference_value(this->get_devices(), [virtual_core](const auto* device) {
         return device->dram_channel_from_virtual_core(virtual_core);
     });
 }
 
 // Core management and network operations
-const std::set<CoreCoord>& MeshDevice::ethernet_cores() const {
+const std::set<CoreCoord>& MeshDeviceImpl::ethernet_cores() const {
     return validate_and_get_reference_value(
         this->get_devices(), [](const auto* device) -> const std::set<CoreCoord>& { return device->ethernet_cores(); });
 }
-const std::set<CoreCoord>& MeshDevice::storage_only_cores() const {
+const std::set<CoreCoord>& MeshDeviceImpl::storage_only_cores() const {
     return validate_and_get_reference_value(this->get_devices(), [](const auto* device) -> const std::set<CoreCoord>& {
         return device->storage_only_cores();
     });
 }
-uint32_t MeshDevice::get_noc_unicast_encoding(uint8_t noc_index, const CoreCoord& core) const {
+uint32_t MeshDeviceImpl::get_noc_unicast_encoding(uint8_t noc_index, const CoreCoord& core) const {
     return validate_and_get_reference_value(this->get_devices(), [noc_index, core](const auto* device) {
         return device->get_noc_unicast_encoding(noc_index, core);
     });
 }
-uint32_t MeshDevice::get_noc_multicast_encoding(uint8_t noc_index, const CoreRange& cores) const {
+uint32_t MeshDeviceImpl::get_noc_multicast_encoding(uint8_t noc_index, const CoreRange& cores) const {
     return validate_and_get_reference_value(this->get_devices(), [noc_index, cores](const auto* device) {
         return device->get_noc_multicast_encoding(noc_index, cores);
     });
 }
 
 // System memory and command queue management
-SystemMemoryManager& MeshDevice::sysmem_manager() {
+SystemMemoryManager& MeshDeviceImpl::sysmem_manager() {
     TT_THROW("sysmem_manager() is not supported on MeshDevice - use individual devices instead");
     return reference_device()->sysmem_manager();
 }
 
-CommandQueue& MeshDevice::command_queue(std::optional<uint8_t> cq_id) {
+CommandQueue& MeshDeviceImpl::command_queue(std::optional<uint8_t> cq_id) {
     TT_THROW("command_queue() is not supported on MeshDevice - use individual devices instead");
     return reference_device()->command_queue(cq_id);
 }
 
-void MeshDevice::release_mesh_trace(const MeshTraceId& trace_id) {
+void MeshDeviceImpl::release_mesh_trace(const MeshTraceId& trace_id) {
     TracyTTMetalReleaseMeshTrace(this->get_device_ids(), *trace_id);
 
     sub_device_manager_tracker_->get_active_sub_device_manager()->release_trace(trace_id);
@@ -958,17 +1037,17 @@ void MeshDevice::release_mesh_trace(const MeshTraceId& trace_id) {
     }
 }
 
-std::shared_ptr<MeshTraceBuffer> MeshDevice::get_mesh_trace(const MeshTraceId& trace_id) {
+std::shared_ptr<MeshTraceBuffer> MeshDeviceImpl::get_mesh_trace(const MeshTraceId& trace_id) {
     return sub_device_manager_tracker_->get_active_sub_device_manager()->get_trace(trace_id);
 }
 
-MeshTraceId MeshDevice::begin_mesh_trace(uint8_t cq_id) {
+MeshTraceId MeshDeviceImpl::begin_mesh_trace(uint8_t cq_id) {
     auto trace_id = MeshTrace::next_id();
     this->begin_mesh_trace(cq_id, trace_id);
     return trace_id;
 }
 
-void MeshDevice::begin_mesh_trace(uint8_t cq_id, const MeshTraceId& trace_id) {
+void MeshDeviceImpl::begin_mesh_trace(uint8_t cq_id, const MeshTraceId& trace_id) {
     TracyTTMetalBeginMeshTrace(this->get_device_ids(), *trace_id);
     TT_FATAL(
         !this->mesh_command_queues_[cq_id]->trace_id().has_value(),
@@ -988,7 +1067,7 @@ void MeshDevice::begin_mesh_trace(uint8_t cq_id, const MeshTraceId& trace_id) {
     this->mesh_command_queues_[cq_id]->record_begin(trace_id, trace_buffer->desc);
 }
 
-void MeshDevice::end_mesh_trace(uint8_t cq_id, const MeshTraceId& trace_id) {
+void MeshDeviceImpl::end_mesh_trace(uint8_t cq_id, const MeshTraceId& trace_id) {
     TracyTTMetalEndMeshTrace(this->get_device_ids(), *trace_id);
     TT_FATAL(
         this->mesh_command_queues_[cq_id]->trace_id() == trace_id,
@@ -1009,7 +1088,7 @@ void MeshDevice::end_mesh_trace(uint8_t cq_id, const MeshTraceId& trace_id) {
     this->mark_allocations_unsafe();
 }
 
-void MeshDevice::replay_mesh_trace(uint8_t cq_id, const MeshTraceId& trace_id, bool blocking) {
+void MeshDeviceImpl::replay_mesh_trace(uint8_t cq_id, const MeshTraceId& trace_id, bool blocking) {
     ZoneScoped;
     TracyTTMetalReplayMeshTrace(this->get_device_ids(), *trace_id);
     auto* active_sub_device_manager = sub_device_manager_tracker_->get_active_sub_device_manager();
@@ -1023,11 +1102,11 @@ void MeshDevice::replay_mesh_trace(uint8_t cq_id, const MeshTraceId& trace_id, b
     mesh_command_queues_[cq_id]->enqueue_trace(trace_id, blocking);
 }
 
-uint32_t MeshDevice::get_trace_buffers_size() const { return trace_buffers_size_; }
-void MeshDevice::set_trace_buffers_size(uint32_t size) { trace_buffers_size_ = size; }
+uint32_t MeshDeviceImpl::get_trace_buffers_size() const { return trace_buffers_size_; }
+void MeshDeviceImpl::set_trace_buffers_size(uint32_t size) { trace_buffers_size_ = size; }
 
 // Dispatch and initialization
-bool MeshDevice::initialize(
+bool MeshDeviceImpl::initialize(
     const uint8_t /*num_hw_cqs*/,
     size_t /*l1_small_size*/,
     size_t /*trace_region_size*/,
@@ -1051,8 +1130,9 @@ bool MeshDevice::initialize(
     cq_shared_state->sub_device_cq_owner.resize(1);
 
     const auto& allocator = reference_device()->allocator_impl();
+    // SubDeviceManagerTracker needs a MeshDevice pointer.
     sub_device_manager_tracker_ = std::make_unique<SubDeviceManagerTracker>(
-        this, std::make_unique<L1BankingAllocator>(allocator->get_config()), sub_devices);
+        this->pimpl_wrapper_, std::make_unique<L1BankingAllocator>(allocator->get_config()), sub_devices);
     // Issue #19729: Store the maximum number of active ethernet cores across opened physical devices in the Mesh
     // as the number of virtual ethernet cores seen by the MeshDevice
     num_virtual_eth_cores_ =
@@ -1061,101 +1141,103 @@ bool MeshDevice::initialize(
     if (MetalContext::instance().rtoptions().get_fast_dispatch()) {
         for (std::size_t cq_id = 0; cq_id < this->num_hw_cqs(); cq_id++) {
             mesh_command_queues_.push_back(std::make_unique<FDMeshCommandQueue>(
-                this,
+                this->pimpl_wrapper_,  // TODO(p1-0tr): should pass impl?
                 cq_id,
                 dispatch_thread_pool_,
                 reader_thread_pool_,
                 cq_shared_state,
-                std::bind(&MeshDevice::lock_api, this)));
+                std::bind(&MeshDeviceImpl::lock_api, this)));
         }
     } else {
         for (std::size_t cq_id = 0; cq_id < this->num_hw_cqs(); cq_id++) {
-            mesh_command_queues_.push_back(
-                std::make_unique<SDMeshCommandQueue>(this, cq_id, std::bind(&MeshDevice::lock_api, this)));
+            mesh_command_queues_.push_back(std::make_unique<SDMeshCommandQueue>(
+                this->pimpl_wrapper_ /* TODO(p1-0tr): should pass impl? */,
+                cq_id,
+                std::bind(&MeshDeviceImpl::lock_api, this)));
         }
     }
-    Inspector::mesh_device_initialized(this);
+    Inspector::mesh_device_initialized(this->pimpl_wrapper_);
     is_internal_state_initialized = true;
     return true;
 }
 
-void MeshDevice::init_command_queue_host() {
+void MeshDeviceImpl::init_command_queue_host() {
     TT_THROW("init_command_queue_host() is not supported on MeshDevice - use individual devices instead");
     reference_device()->init_command_queue_host();
 }
-void MeshDevice::init_command_queue_device() {
+void MeshDeviceImpl::init_command_queue_device() {
     TT_THROW("init_command_queue_device() is not supported on MeshDevice - use individual devices instead");
     reference_device()->init_command_queue_device();
 }
-bool MeshDevice::compile_fabric() {
+bool MeshDeviceImpl::compile_fabric() {
     TT_THROW("compile_fabric() is not supported on MeshDevice - use individual devices instead");
     return reference_device()->compile_fabric();
 }
-void MeshDevice::configure_fabric() {
+void MeshDeviceImpl::configure_fabric() {
     TT_THROW("configure_fabric() is not supported on MeshDevice - use individual devices instead");
     reference_device()->configure_fabric();
 }
-void MeshDevice::init_fabric() {
+void MeshDeviceImpl::init_fabric() {
     TT_THROW("init_fabric_program() is not supported on MeshDevice - use individual devices instead");
     reference_device()->init_fabric();
 }
 
-program_cache::detail::ProgramCache& MeshDevice::get_program_cache() { return *program_cache_; }
-HalProgrammableCoreType MeshDevice::get_programmable_core_type(CoreCoord virtual_core) const {
+program_cache::detail::ProgramCache& MeshDeviceImpl::get_program_cache() { return *program_cache_; }
+HalProgrammableCoreType MeshDeviceImpl::get_programmable_core_type(CoreCoord virtual_core) const {
     return reference_device()->get_programmable_core_type(virtual_core);
 }
 
-HalMemType MeshDevice::get_mem_type_of_core(CoreCoord virtual_core) const {
+HalMemType MeshDeviceImpl::get_mem_type_of_core(CoreCoord virtual_core) const {
     return reference_device()->get_mem_type_of_core(virtual_core);
 }
 
 // Methods for SubDevice Management
-bool MeshDevice::has_noc_mcast_txns(SubDeviceId sub_device_id) const {
+bool MeshDeviceImpl::has_noc_mcast_txns(SubDeviceId sub_device_id) const {
     return sub_device_manager_tracker_->get_active_sub_device_manager()->has_noc_mcast_txns(sub_device_id);
 }
-uint8_t MeshDevice::num_noc_unicast_txns(SubDeviceId sub_device_id) const {
+uint8_t MeshDeviceImpl::num_noc_unicast_txns(SubDeviceId sub_device_id) const {
     return sub_device_manager_tracker_->get_active_sub_device_manager()->num_noc_unicast_txns(sub_device_id);
 }
-uint8_t MeshDevice::noc_data_start_index(SubDeviceId sub_device_id, bool unicast_data) const {
+uint8_t MeshDeviceImpl::noc_data_start_index(SubDeviceId sub_device_id, bool unicast_data) const {
     if (unicast_data) {
         return sub_device_manager_tracker_->get_active_sub_device_manager()->noc_unicast_data_start_index(
             sub_device_id);
     }
     return 0;
 }
-SubDeviceManagerId MeshDevice::get_active_sub_device_manager_id() const {
+SubDeviceManagerId MeshDeviceImpl::get_active_sub_device_manager_id() const {
     return sub_device_manager_tracker_->get_active_sub_device_manager()->id();
 }
-SubDeviceManagerId MeshDevice::get_default_sub_device_manager_id() const {
+SubDeviceManagerId MeshDeviceImpl::get_default_sub_device_manager_id() const {
     return sub_device_manager_tracker_->get_default_sub_device_manager()->id();
 }
-CoreCoord MeshDevice::virtual_program_dispatch_core(uint8_t cq_id) const {
+CoreCoord MeshDeviceImpl::virtual_program_dispatch_core(uint8_t cq_id) const {
     return validate_and_get_reference_value(
         this->get_devices(), [cq_id](const auto* device) { return device->virtual_program_dispatch_core(cq_id); });
 }
-const std::vector<SubDeviceId>& MeshDevice::get_sub_device_ids() const {
+const std::vector<SubDeviceId>& MeshDeviceImpl::get_sub_device_ids() const {
     return sub_device_manager_tracker_->get_active_sub_device_manager()->get_sub_device_ids();
 }
-const std::vector<SubDeviceId>& MeshDevice::get_sub_device_stall_group() const {
+const std::vector<SubDeviceId>& MeshDeviceImpl::get_sub_device_stall_group() const {
     return sub_device_manager_tracker_->get_active_sub_device_manager()->get_sub_device_stall_group();
 }
-void MeshDevice::set_sub_device_stall_group(tt::stl::Span<const SubDeviceId> sub_device_ids) {
+void MeshDeviceImpl::set_sub_device_stall_group(tt::stl::Span<const SubDeviceId> sub_device_ids) {
     sub_device_manager_tracker_->get_active_sub_device_manager()->set_sub_device_stall_group(sub_device_ids);
 }
-void MeshDevice::reset_sub_device_stall_group() {
+void MeshDeviceImpl::reset_sub_device_stall_group() {
     sub_device_manager_tracker_->get_active_sub_device_manager()->reset_sub_device_stall_group();
 }
 
-uint32_t MeshDevice::num_sub_devices() const {
+uint32_t MeshDeviceImpl::num_sub_devices() const {
     return sub_device_manager_tracker_->get_active_sub_device_manager()->num_sub_devices();
 }
 
-bool MeshDevice::is_mmio_capable() const {
+bool MeshDeviceImpl::is_mmio_capable() const {
     TT_THROW("is_mmio_capable() is not supported on MeshDevice - use individual devices instead");
     return reference_device()->is_mmio_capable();
 }
 
-void MeshDevice::quiesce_internal() {
+void MeshDeviceImpl::quiesce_internal() {
     TT_FATAL(
         get_active_sub_device_manager_id() == get_default_sub_device_manager_id(),
         "Cannot quiesce when non-default sub-device manager is active");
@@ -1174,7 +1256,7 @@ void MeshDevice::quiesce_internal() {
     }
 }
 
-void MeshDevice::quiesce_devices() {
+void MeshDeviceImpl::quiesce_devices() {
     quiesce_internal();
     for (auto& command_queue : mesh_command_queues_) {
         for (auto& device : get_devices()) {
@@ -1187,29 +1269,253 @@ void MeshDevice::quiesce_devices() {
 }
 
 // Allocator methods
-std::optional<DeviceAddr> MeshDevice::lowest_occupied_compute_l1_address() const {
+std::optional<DeviceAddr> MeshDeviceImpl::lowest_occupied_compute_l1_address() const {
     return sub_device_manager_tracker_->lowest_occupied_compute_l1_address();
 }
 
-std::optional<DeviceAddr> MeshDevice::lowest_occupied_compute_l1_address(
+std::optional<DeviceAddr> MeshDeviceImpl::lowest_occupied_compute_l1_address(
     tt::stl::Span<const SubDeviceId> sub_device_ids) const {
     return sub_device_manager_tracker_->lowest_occupied_compute_l1_address(sub_device_ids);
 }
 
-const std::unique_ptr<AllocatorImpl>& MeshDevice::allocator_impl() const {
+const std::unique_ptr<AllocatorImpl>& MeshDeviceImpl::allocator_impl() const {
     return sub_device_manager_tracker_->get_default_sub_device_manager()->allocator(SubDeviceId{0});
 }
 
-const std::unique_ptr<Allocator>& MeshDevice::allocator() const { return this->allocator_impl()->view(); }
+const std::unique_ptr<Allocator>& MeshDeviceImpl::allocator() const { return this->allocator_impl()->view(); }
 
-const std::unique_ptr<AllocatorImpl>& MeshDevice::allocator_impl(SubDeviceId sub_device_id) const {
+const std::unique_ptr<AllocatorImpl>& MeshDeviceImpl::allocator_impl(SubDeviceId sub_device_id) const {
     return sub_device_manager_tracker_->get_active_sub_device_manager()->allocator(sub_device_id);
 }
 
-const std::unique_ptr<Allocator>& MeshDevice::allocator(SubDeviceId sub_device_id) const {
+const std::unique_ptr<Allocator>& MeshDeviceImpl::allocator(SubDeviceId sub_device_id) const {
     return this->allocator_impl(sub_device_id)->view();
 }
 
+std::shared_ptr<distributed::MeshDevice> MeshDeviceImpl::get_mesh_device() {
+    // This should be called from MeshDevice, not MeshDeviceImpl
+    TT_THROW("get_mesh_device() should not be called on MeshDeviceImpl directly");
+    return nullptr;
+}
+
+MeshDevice::~MeshDevice() {}
+
+// MeshDevice PIMPL forwarding methods
+tt::ARCH MeshDevice::arch() const { return pimpl_->arch(); }
+int MeshDevice::id() const { return pimpl_->id(); }
+ChipId MeshDevice::build_id() const { return pimpl_->build_id(); }
+uint8_t MeshDevice::num_hw_cqs() const { return pimpl_->num_hw_cqs(); }
+bool MeshDevice::is_initialized() const { return pimpl_->is_initialized(); }
+int MeshDevice::num_dram_channels() const { return pimpl_->num_dram_channels(); }
+uint32_t MeshDevice::l1_size_per_core() const { return pimpl_->l1_size_per_core(); }
+uint32_t MeshDevice::dram_size_per_channel() const { return pimpl_->dram_size_per_channel(); }
+CoreCoord MeshDevice::grid_size() const { return pimpl_->grid_size(); }
+CoreCoord MeshDevice::logical_grid_size() const { return pimpl_->logical_grid_size(); }
+CoreCoord MeshDevice::dram_grid_size() const { return pimpl_->dram_grid_size(); }
+CoreCoord MeshDevice::virtual_noc0_coordinate(uint8_t noc_index, CoreCoord coord) const {
+    return pimpl_->virtual_noc0_coordinate(noc_index, coord);
+}
+std::vector<CoreCoord> MeshDevice::worker_cores_from_logical_cores(const std::vector<CoreCoord>& logical_cores) const {
+    return pimpl_->worker_cores_from_logical_cores(logical_cores);
+}
+std::vector<CoreCoord> MeshDevice::ethernet_cores_from_logical_cores(
+    const std::vector<CoreCoord>& logical_cores) const {
+    return pimpl_->ethernet_cores_from_logical_cores(logical_cores);
+}
+std::vector<CoreCoord> MeshDevice::get_optimal_dram_bank_to_logical_worker_assignment(NOC noc) {
+    return pimpl_->get_optimal_dram_bank_to_logical_worker_assignment(noc);
+}
+CoreCoord MeshDevice::virtual_core_from_logical_core(const CoreCoord& logical_coord, const CoreType& core_type) const {
+    return pimpl_->virtual_core_from_logical_core(logical_coord, core_type);
+}
+CoreCoord MeshDevice::worker_core_from_logical_core(const CoreCoord& logical_core) const {
+    return pimpl_->worker_core_from_logical_core(logical_core);
+}
+CoreCoord MeshDevice::ethernet_core_from_logical_core(const CoreCoord& logical_core) const {
+    return pimpl_->ethernet_core_from_logical_core(logical_core);
+}
+CoreCoord MeshDevice::logical_core_from_ethernet_core(const CoreCoord& ethernet_core) const {
+    return pimpl_->logical_core_from_ethernet_core(ethernet_core);
+}
+std::unordered_set<CoreCoord> MeshDevice::get_active_ethernet_cores(bool skip_reserved_tunnel_cores) const {
+    return pimpl_->get_active_ethernet_cores(skip_reserved_tunnel_cores);
+}
+std::unordered_set<CoreCoord> MeshDevice::get_inactive_ethernet_cores() const {
+    return pimpl_->get_inactive_ethernet_cores();
+}
+bool MeshDevice::is_active_ethernet_core(CoreCoord logical_core, bool skip_reserved_tunnel_cores) const {
+    return pimpl_->is_active_ethernet_core(logical_core, skip_reserved_tunnel_cores);
+}
+std::tuple<ChipId, CoreCoord> MeshDevice::get_connected_ethernet_core(CoreCoord eth_core) const {
+    return pimpl_->get_connected_ethernet_core(eth_core);
+}
+std::vector<CoreCoord> MeshDevice::get_ethernet_sockets(ChipId connected_chip_id) const {
+    return pimpl_->get_ethernet_sockets(connected_chip_id);
+}
+bool MeshDevice::is_inactive_ethernet_core(CoreCoord logical_core) const {
+    return pimpl_->is_inactive_ethernet_core(logical_core);
+}
+uint32_t MeshDevice::num_virtual_eth_cores(SubDeviceId sub_device_id) {
+    return pimpl_->num_virtual_eth_cores(sub_device_id);
+}
+CoreCoord MeshDevice::compute_with_storage_grid_size() const { return pimpl_->compute_with_storage_grid_size(); }
+CoreRangeSet MeshDevice::worker_cores(HalProgrammableCoreType core_type, SubDeviceId sub_device_id) const {
+    return pimpl_->worker_cores(core_type, sub_device_id);
+}
+uint32_t MeshDevice::num_worker_cores(HalProgrammableCoreType core_type, SubDeviceId sub_device_id) const {
+    return pimpl_->num_worker_cores(core_type, sub_device_id);
+}
+const std::unique_ptr<Allocator>& MeshDevice::allocator() const { return pimpl_->allocator(); }
+const std::unique_ptr<Allocator>& MeshDevice::allocator(SubDeviceId sub_device_id) const {
+    return pimpl_->allocator(sub_device_id);
+}
+const std::unique_ptr<AllocatorImpl>& MeshDevice::allocator_impl() const { return pimpl_->allocator_impl(); }
+const std::unique_ptr<AllocatorImpl>& MeshDevice::allocator_impl(SubDeviceId sub_device_id) const {
+    return pimpl_->allocator_impl(sub_device_id);
+}
+CoreCoord MeshDevice::logical_core_from_dram_channel(uint32_t dram_channel) const {
+    return pimpl_->logical_core_from_dram_channel(dram_channel);
+}
+uint32_t MeshDevice::dram_channel_from_logical_core(const CoreCoord& logical_core) const {
+    return pimpl_->dram_channel_from_logical_core(logical_core);
+}
+uint32_t MeshDevice::dram_channel_from_virtual_core(const CoreCoord& virtual_core) const {
+    return pimpl_->dram_channel_from_virtual_core(virtual_core);
+}
+std::optional<DeviceAddr> MeshDevice::lowest_occupied_compute_l1_address() const {
+    return pimpl_->lowest_occupied_compute_l1_address();
+}
+std::optional<DeviceAddr> MeshDevice::lowest_occupied_compute_l1_address(
+    tt::stl::Span<const SubDeviceId> sub_device_ids) const {
+    return pimpl_->lowest_occupied_compute_l1_address(sub_device_ids);
+}
+const std::set<CoreCoord>& MeshDevice::ethernet_cores() const { return pimpl_->ethernet_cores(); }
+const std::set<CoreCoord>& MeshDevice::storage_only_cores() const { return pimpl_->storage_only_cores(); }
+uint32_t MeshDevice::get_noc_unicast_encoding(uint8_t noc_index, const CoreCoord& core) const {
+    return pimpl_->get_noc_unicast_encoding(noc_index, core);
+}
+uint32_t MeshDevice::get_noc_multicast_encoding(uint8_t noc_index, const CoreRange& cores) const {
+    return pimpl_->get_noc_multicast_encoding(noc_index, cores);
+}
+SystemMemoryManager& MeshDevice::sysmem_manager() { return pimpl_->sysmem_manager(); }
+CommandQueue& MeshDevice::command_queue(std::optional<uint8_t> cq_id) { return pimpl_->command_queue(cq_id); }
+MeshTraceId MeshDevice::begin_mesh_trace(uint8_t cq_id) { return pimpl_->begin_mesh_trace(cq_id); }
+void MeshDevice::begin_mesh_trace(uint8_t cq_id, const MeshTraceId& trace_id) {
+    pimpl_->begin_mesh_trace(cq_id, trace_id);
+}
+void MeshDevice::end_mesh_trace(uint8_t cq_id, const MeshTraceId& trace_id) { pimpl_->end_mesh_trace(cq_id, trace_id); }
+void MeshDevice::replay_mesh_trace(uint8_t cq_id, const MeshTraceId& trace_id, bool blocking) {
+    pimpl_->replay_mesh_trace(cq_id, trace_id, blocking);
+}
+void MeshDevice::release_mesh_trace(const MeshTraceId& trace_id) { pimpl_->release_mesh_trace(trace_id); }
+std::shared_ptr<MeshTraceBuffer> MeshDevice::get_mesh_trace(const MeshTraceId& trace_id) {
+    return pimpl_->get_mesh_trace(trace_id);
+}
+uint32_t MeshDevice::get_trace_buffers_size() const { return pimpl_->get_trace_buffers_size(); }
+void MeshDevice::set_trace_buffers_size(uint32_t size) { pimpl_->set_trace_buffers_size(size); }
+bool MeshDevice::initialize(
+    uint8_t num_hw_cqs,
+    size_t l1_small_size,
+    size_t trace_region_size,
+    size_t worker_l1_size,
+    tt::stl::Span<const std::uint32_t> l1_bank_remap,
+    bool minimal) {
+    return pimpl_->initialize(num_hw_cqs, l1_small_size, trace_region_size, worker_l1_size, l1_bank_remap, minimal);
+}
+void MeshDevice::init_command_queue_host() { pimpl_->init_command_queue_host(); }
+void MeshDevice::init_command_queue_device() { pimpl_->init_command_queue_device(); }
+bool MeshDevice::compile_fabric() { return pimpl_->compile_fabric(); }
+void MeshDevice::configure_fabric() { pimpl_->configure_fabric(); }
+void MeshDevice::init_fabric() { pimpl_->init_fabric(); }
+bool MeshDevice::close() { return pimpl_->close(); }
+void MeshDevice::enable_program_cache() { pimpl_->enable_program_cache(); }
+void MeshDevice::clear_program_cache() { pimpl_->clear_program_cache(); }
+void MeshDevice::disable_and_clear_program_cache() { pimpl_->disable_and_clear_program_cache(); }
+program_cache::detail::ProgramCache& MeshDevice::get_program_cache() { return pimpl_->get_program_cache(); }
+std::size_t MeshDevice::num_program_cache_entries() { return pimpl_->num_program_cache_entries(); }
+HalProgrammableCoreType MeshDevice::get_programmable_core_type(CoreCoord virtual_core) const {
+    return pimpl_->get_programmable_core_type(virtual_core);
+}
+HalMemType MeshDevice::get_mem_type_of_core(CoreCoord virtual_core) const {
+    return pimpl_->get_mem_type_of_core(virtual_core);
+}
+bool MeshDevice::has_noc_mcast_txns(SubDeviceId sub_device_id) const {
+    return pimpl_->has_noc_mcast_txns(sub_device_id);
+}
+uint8_t MeshDevice::num_noc_unicast_txns(SubDeviceId sub_device_id) const {
+    return pimpl_->num_noc_unicast_txns(sub_device_id);
+}
+uint8_t MeshDevice::noc_data_start_index(SubDeviceId sub_device_id, bool unicast_data) const {
+    return pimpl_->noc_data_start_index(sub_device_id, unicast_data);
+}
+SubDeviceManagerId MeshDevice::get_active_sub_device_manager_id() const {
+    return pimpl_->get_active_sub_device_manager_id();
+}
+SubDeviceManagerId MeshDevice::get_default_sub_device_manager_id() const {
+    return pimpl_->get_default_sub_device_manager_id();
+}
+SubDeviceManagerId MeshDevice::create_sub_device_manager(
+    std::initializer_list<SubDevice> sub_devices, DeviceAddr local_l1_size) {
+    return pimpl_->create_sub_device_manager(sub_devices, local_l1_size);
+}
+SubDeviceManagerId MeshDevice::create_sub_device_manager(
+    tt::stl::Span<const SubDevice> sub_devices, DeviceAddr local_l1_size) {
+    return pimpl_->create_sub_device_manager(sub_devices, local_l1_size);
+}
+void MeshDevice::remove_sub_device_manager(SubDeviceManagerId sub_device_manager_id) {
+    pimpl_->remove_sub_device_manager(sub_device_manager_id);
+}
+void MeshDevice::load_sub_device_manager(SubDeviceManagerId sub_device_manager_id) {
+    pimpl_->load_sub_device_manager(sub_device_manager_id);
+}
+void MeshDevice::clear_loaded_sub_device_manager() { pimpl_->clear_loaded_sub_device_manager(); }
+CoreCoord MeshDevice::virtual_program_dispatch_core(uint8_t cq_id) const {
+    return pimpl_->virtual_program_dispatch_core(cq_id);
+}
+const std::vector<SubDeviceId>& MeshDevice::get_sub_device_ids() const { return pimpl_->get_sub_device_ids(); }
+const std::vector<SubDeviceId>& MeshDevice::get_sub_device_stall_group() const {
+    return pimpl_->get_sub_device_stall_group();
+}
+void MeshDevice::set_sub_device_stall_group(tt::stl::Span<const SubDeviceId> sub_device_ids) {
+    pimpl_->set_sub_device_stall_group(sub_device_ids);
+}
+void MeshDevice::reset_sub_device_stall_group() { pimpl_->reset_sub_device_stall_group(); }
+uint32_t MeshDevice::num_sub_devices() const { return pimpl_->num_sub_devices(); }
+bool MeshDevice::is_mmio_capable() const { return pimpl_->is_mmio_capable(); }
 std::shared_ptr<distributed::MeshDevice> MeshDevice::get_mesh_device() { return shared_from_this(); }
+std::vector<IDevice*> MeshDevice::get_devices() const { return pimpl_->get_devices(); }
+IDevice* MeshDevice::get_device(ChipId physical_device_id) const { return pimpl_->get_device(physical_device_id); }
+IDevice* MeshDevice::get_device(const MeshCoordinate& coord) const { return pimpl_->get_device(coord); }
+tt_fabric::FabricNodeId MeshDevice::get_fabric_node_id(const MeshCoordinate& coord) const {
+    return pimpl_->get_fabric_node_id(coord);
+}
+DeviceIds MeshDevice::get_device_ids() const { return pimpl_->get_device_ids(); }
+size_t MeshDevice::num_devices() const { return pimpl_->num_devices(); }
+size_t MeshDevice::num_rows() const { return pimpl_->num_rows(); }
+size_t MeshDevice::num_cols() const { return pimpl_->num_cols(); }
+IDevice* MeshDevice::get_device(size_t row_idx, size_t col_idx) const { return pimpl_->get_device(row_idx, col_idx); }
+bool MeshDevice::is_local(const MeshCoordinate& coord) const { return pimpl_->is_local(coord); }
+const MeshShape& MeshDevice::shape() const { return pimpl_->shape(); }
+void MeshDevice::reshape(const MeshShape& new_shape) { pimpl_->reshape(new_shape); }
+const MeshDeviceView& MeshDevice::get_view() const { return pimpl_->get_view(); }
+std::string MeshDevice::to_string() const { return pimpl_->to_string(); }
+bool MeshDevice::is_parent_mesh() const { return pimpl_->is_parent_mesh(); }
+const std::shared_ptr<MeshDevice>& MeshDevice::get_parent_mesh() const { return pimpl_->get_parent_mesh(); }
+std::vector<std::shared_ptr<MeshDevice>> MeshDevice::get_submeshes() const { return pimpl_->get_submeshes(); }
+void MeshDevice::quiesce_devices() { pimpl_->quiesce_devices(); }
+std::shared_ptr<MeshDevice> MeshDevice::create_submesh(
+    const MeshShape& submesh_shape, const std::optional<MeshCoordinate>& offset) {
+    return pimpl_->create_submesh(shared_from_this(), submesh_shape, offset);
+}
+std::vector<std::shared_ptr<MeshDevice>> MeshDevice::create_submeshes(const MeshShape& submesh_shape) {
+    return pimpl_->create_submeshes(shared_from_this(), submesh_shape);
+}
+MeshCommandQueue& MeshDevice::mesh_command_queue(std::optional<uint8_t> cq_id) const {
+    return pimpl_->mesh_command_queue(cq_id);
+}
+void MeshDevice::enqueue_to_thread_pool(std::function<void()>&& f) { pimpl_->enqueue_to_thread_pool(std::move(f)); }
+void MeshDevice::wait_for_thread_pool() { pimpl_->wait_for_thread_pool(); }
+
+std::ostream& operator<<(std::ostream& os, const MeshDevice& mesh_device) { return os << mesh_device.to_string(); }
 
 }  // namespace tt::tt_metal::distributed

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -57,6 +57,7 @@
 #include "dispatch/system_memory_manager.hpp"
 #include <llrt/tt_cluster.hpp>
 #include <umd/device/types/core_coordinates.hpp>
+#include "mesh_device_view_impl.hpp"
 
 namespace tt::tt_metal {
 class CommandQueue;
@@ -520,8 +521,8 @@ std::shared_ptr<MeshDevice> MeshDeviceImpl::create_submesh(
     std::vector<tt::tt_fabric::FabricNodeId> submesh_fabric_node_ids;
     const MeshCoordinateRange submesh_range(offset_coord, end_coordinate);
     for (const auto& coord : submesh_range) {
-        if (view_->is_local(coord)) {
-            submesh_devices.push_back(MaybeRemote<IDevice*>::local(view_->get_device(coord)));
+        if (view_->impl().is_local(coord)) {
+            submesh_devices.push_back(MaybeRemote<IDevice*>::local(view_->impl().get_device(coord)));
         } else {
             submesh_devices.push_back(MaybeRemote<IDevice*>::remote());
         }
@@ -617,7 +618,7 @@ IDevice* MeshDeviceImpl::get_device(size_t row_idx, size_t col_idx) const {
     return get_device(MeshCoordinate{static_cast<uint32_t>(row_idx), static_cast<uint32_t>(col_idx)});
 }
 
-IDevice* MeshDeviceImpl::get_device(const MeshCoordinate& coord) const { return view_->get_device(coord); }
+IDevice* MeshDeviceImpl::get_device(const MeshCoordinate& coord) const { return view_->impl().get_device(coord); }
 
 tt_fabric::FabricNodeId MeshDeviceImpl::get_fabric_node_id(const MeshCoordinate& coord) const {
     return view_->get_fabric_node_id(coord);
@@ -655,7 +656,7 @@ size_t MeshDeviceImpl::num_cols() const { return view_->num_cols(); }
 
 const MeshShape& MeshDeviceImpl::shape() const { return view_->shape(); }
 
-bool MeshDeviceImpl::is_local(const MeshCoordinate& coord) const { return view_->is_local(coord); }
+bool MeshDeviceImpl::is_local(const MeshCoordinate& coord) const { return view_->impl().is_local(coord); }
 
 void MeshDeviceImpl::reshape(const MeshShape& new_shape) {
     const auto num_devices = view_->shape().mesh_size();
@@ -692,8 +693,8 @@ void MeshDeviceImpl::reshape(const MeshShape& new_shape) {
         auto line_coords = view_->get_line_coordinates();
         for (const auto& coord : line_coords) {
             new_device_order.push_back(
-                view_->is_local(coord) ? MaybeRemote<IDevice*>::local(this->get_device(coord))
-                                       : MaybeRemote<IDevice*>::remote());
+                view_->impl().is_local(coord) ? MaybeRemote<IDevice*>::local(this->get_device(coord))
+                                              : MaybeRemote<IDevice*>::remote());
             new_fabric_node_ids.push_back(view_->get_fabric_node_id(coord));
         }
     } else {

--- a/tt_metal/distributed/mesh_device_impl.hpp
+++ b/tt_metal/distributed/mesh_device_impl.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -62,7 +62,7 @@ class MeshCommandQueue;
 class MeshDeviceView;
 struct MeshTraceBuffer;
 class MeshCommandQueueBase;
-class MeshDeviceImpl;
+class MeshDevice;
 
 namespace multihost {
 class DistributedContext;
@@ -70,14 +70,9 @@ class DistributedContext;
 
 using DeviceIds = std::vector<int>;
 
-class MeshDevice : public IDevice, public std::enable_shared_from_this<MeshDevice> {
-    friend class MeshDeviceImpl;
-
+class MeshDeviceImpl : public IDevice {
 private:
-    MeshDevice() = default;
-
-    // TODO(#31961): Moved to MeshDeviceImpl, need to wait for deprecation period expiry of local_root_devices, before
-    // this can be removed. My bad.
+    // Resource management class / RAII wrapper for *physical devices* of the mesh
     class ScopedDevices {
     private:
         std::vector<MaybeRemote<IDevice*>> devices_;
@@ -115,16 +110,65 @@ private:
         const std::vector<MaybeRemote<IDevice*>>& root_devices() const;
     };
 
-    std::unique_ptr<MeshDeviceImpl> pimpl_;
+    // THREAD SAFETY: Enqueueing work on the device should be thread safe. Operations that modify state should be
+    // protected by api_mutex_. Operations that reconfigure global state (e.g. setting subdevices or enabling tracing)
+    // on the device may not be thread safe.
+    std::mutex api_mutex_;
+    bool is_internal_state_initialized = false;
+    std::shared_ptr<ScopedDevices> scoped_devices_;
+    int mesh_id_;
+    std::unique_ptr<MeshDeviceView> view_;
+    // Submesh keeps the parent mesh alive. Parent_mesh_ is null if the current mesh is the parent mesh.
+    std::shared_ptr<MeshDevice> parent_mesh_;
+    std::vector<std::weak_ptr<MeshDevice>> submeshes_;
+
+    tt::stl::SmallVector<std::unique_ptr<MeshCommandQueueBase>> mesh_command_queues_;
+
+    std::unique_ptr<SubDeviceManagerTracker> sub_device_manager_tracker_;
+    uint32_t trace_buffers_size_ = 0;
+    uint32_t max_num_eth_cores_ = 0;
+    std::shared_ptr<ThreadPool> dispatch_thread_pool_;
+    std::shared_ptr<ThreadPool> reader_thread_pool_;
+    // Num Virtual Eth Cores == Max Number of Eth Cores across all opened devices (Issue #19729)
+    std::size_t num_virtual_eth_cores_ = 0;
+    std::unique_ptr<program_cache::detail::ProgramCache> program_cache_;
+    // This is a reference device used to query properties that are the same for all devices in the mesh.
+    IDevice* reference_device() const;
+    // Recursively quiesce all submeshes.
+    void quiesce_internal();
+
+    // Check if the mesh device or any of its parents have a CQ in use, and returns one of the parent mesh IDs if found.
+    std::optional<int> get_parent_mesh_id_with_in_use_cq(uint32_t cq_id) const;
+    // Check if the mesh device or any of its children have a CQ in use, and returns one of the child mesh IDs if found.
+    std::optional<int> get_child_mesh_id_with_in_use_cq(uint32_t cq_id) const;
+
+    // NOLINTNEXTLINE(readability-make-member-function-const)
+    void mark_allocations_unsafe();
+    // NOLINTNEXTLINE(readability-make-member-function-const)
+    void mark_allocations_safe();
+
+    std::shared_ptr<MeshTraceBuffer>& create_mesh_trace(const MeshTraceId& trace_id);
+
+    std::lock_guard<std::mutex> lock_api() { return std::lock_guard<std::mutex>(api_mutex_); }
+
+    // Distributed context used to synchronize operations done by all ranks on the given mesh device.
+    std::shared_ptr<distributed::multihost::DistributedContext> distributed_context_;
+
+    MeshDevice* pimpl_wrapper_;
 
 public:
-    ~MeshDevice() override;
+    MeshDeviceImpl(
+        MeshDevice* pimpl_wrapper,
+        std::shared_ptr<ScopedDevices> mesh_handle,
+        std::unique_ptr<MeshDeviceView> mesh_device_view,
+        std::shared_ptr<MeshDevice> parent_mesh = {});
+    ~MeshDeviceImpl() override;
 
-    MeshDevice(const MeshDevice&) = delete;
-    MeshDevice& operator=(const MeshDevice&) = delete;
+    MeshDeviceImpl(const MeshDeviceImpl&) = delete;
+    MeshDeviceImpl& operator=(const MeshDeviceImpl&) = delete;
 
-    MeshDevice(MeshDevice&&) = delete;
-    MeshDevice& operator=(MeshDevice&&) = delete;
+    MeshDeviceImpl(MeshDeviceImpl&&) = delete;
+    MeshDeviceImpl& operator=(MeshDeviceImpl&&) = delete;
 
     // IDevice interface implementation
     tt::ARCH arch() const override;
@@ -146,7 +190,6 @@ public:
     std::vector<CoreCoord> ethernet_cores_from_logical_cores(
         const std::vector<CoreCoord>& logical_cores) const override;
     std::vector<CoreCoord> get_optimal_dram_bank_to_logical_worker_assignment(NOC noc) override;
-
     CoreCoord virtual_core_from_logical_core(const CoreCoord& logical_coord, const CoreType& core_type) const override;
     CoreCoord worker_core_from_logical_core(const CoreCoord& logical_core) const override;
     CoreCoord ethernet_core_from_logical_core(const CoreCoord& logical_core) const override;
@@ -236,9 +279,7 @@ public:
 
     // Returns the devices in the mesh in row-major order.
     std::vector<IDevice*> get_devices() const;
-    [[deprecated("Deprecated, retrieving physical devices can fail in distributed contexts.")]]
     IDevice* get_device(ChipId physical_device_id) const;
-    [[deprecated("Deprecated, retrieving physical devices can fail in distributed contexts.")]]
     IDevice* get_device(const MeshCoordinate& coord) const;
     tt_fabric::FabricNodeId get_fabric_node_id(const MeshCoordinate& coord) const;
 
@@ -254,7 +295,6 @@ public:
 
     // Returns true if the coordinate is local to this mesh device.
     // Throws if the coordinate is out of bounds of this mesh device.
-    [[deprecated("Deprecated, is_local should be avoided as it is likely to cause issues in distributed contexts.")]]
     bool is_local(const MeshCoordinate& coord) const;
 
     const MeshShape& shape() const;
@@ -295,9 +335,12 @@ public:
     void quiesce_devices();
 
     std::shared_ptr<MeshDevice> create_submesh(
-        const MeshShape& submesh_shape, const std::optional<MeshCoordinate>& offset = std::nullopt);
+        const std::shared_ptr<MeshDevice>& parent_mesh,
+        const MeshShape& submesh_shape,
+        const std::optional<MeshCoordinate>& offset = std::nullopt);
 
-    std::vector<std::shared_ptr<MeshDevice>> create_submeshes(const MeshShape& submesh_shape);
+    std::vector<std::shared_ptr<MeshDevice>> create_submeshes(
+        const std::shared_ptr<MeshDevice>& parent_mesh, const MeshShape& submesh_shape);
 
     // This method will get removed once in favour of the ones in IDevice* and TT-Mesh bringup
     // These are prefixed with "mesh_" to avoid conflicts with the IDevice* methods
@@ -331,12 +374,9 @@ public:
         const DispatchCoreConfig& dispatch_core_config = DispatchCoreConfig{},
         tt::stl::Span<const std::uint32_t> l1_bank_remap = {},
         size_t worker_l1_size = DEFAULT_WORKER_L1_SIZE);
-
-    const MeshDeviceImpl& impl() const { return *pimpl_; }
-    MeshDeviceImpl& impl() { return *pimpl_; }
 };
 
-std::ostream& operator<<(std::ostream& os, const MeshDevice& mesh_device);
+std::ostream& operator<<(std::ostream& os, const MeshDeviceImpl& mesh_device);
 
 }  // namespace distributed
 

--- a/tt_metal/distributed/mesh_device_impl.hpp
+++ b/tt_metal/distributed/mesh_device_impl.hpp
@@ -154,11 +154,8 @@ private:
     // Distributed context used to synchronize operations done by all ranks on the given mesh device.
     std::shared_ptr<distributed::multihost::DistributedContext> distributed_context_;
 
-    MeshDevice* pimpl_wrapper_;
-
 public:
     MeshDeviceImpl(
-        MeshDevice* pimpl_wrapper,
         std::shared_ptr<ScopedDevices> mesh_handle,
         std::unique_ptr<MeshDeviceView> mesh_device_view,
         std::shared_ptr<MeshDevice> parent_mesh = {});
@@ -240,12 +237,21 @@ public:
         size_t worker_l1_size,
         tt::stl::Span<const std::uint32_t> l1_bank_remap = {},
         bool minimal = false) override;
+    bool initialize_impl(
+        MeshDevice* pimpl_wrapper,
+        uint8_t num_hw_cqs,
+        size_t l1_small_size,
+        size_t trace_region_size,
+        size_t worker_l1_size,
+        tt::stl::Span<const std::uint32_t> l1_bank_remap = {},
+        bool minimal = false);
     void init_command_queue_host() override;
     void init_command_queue_device() override;
     bool compile_fabric() override;
     void configure_fabric() override;
     void init_fabric() override;
     bool close() override;
+    bool close_impl(MeshDevice* pimpl_wrapper);
     void enable_program_cache() override;
     void clear_program_cache() override;
     void disable_and_clear_program_cache() override;

--- a/tt_metal/distributed/mesh_device_view.cpp
+++ b/tt_metal/distributed/mesh_device_view.cpp
@@ -4,6 +4,7 @@
 
 #include <mesh_device.hpp>
 #include <mesh_device_view.hpp>
+#include "mesh_device_view_impl.hpp"
 #include <cstddef>
 #include <functional>
 #include <optional>
@@ -11,6 +12,7 @@
 #include <unordered_set>
 #include <stack>
 #include <vector>
+#include <algorithm>
 
 #include <tt_stl/assert.hpp>
 #include <tt_stl/small_vector.hpp>
@@ -27,7 +29,7 @@ namespace tt::tt_metal::distributed {
 namespace {
 
 std::vector<IDevice*> get_devices_from_coordinates(
-    const MeshDeviceView& mesh, const std::vector<MeshCoordinate>& coords) {
+    const MeshDeviceViewImpl& mesh, const std::vector<MeshCoordinate>& coords) {
     std::vector<IDevice*> devices;
     for (const auto& coord : coords) {
         if (auto* device = mesh.get_device(coord)) {
@@ -38,7 +40,7 @@ std::vector<IDevice*> get_devices_from_coordinates(
 }
 
 std::vector<tt::tt_fabric::FabricNodeId> get_fabric_node_ids_from_coordinates(
-    const MeshDeviceView& mesh, const std::vector<MeshCoordinate>& coords) {
+    const MeshDeviceViewImpl& mesh, const std::vector<MeshCoordinate>& coords) {
     std::vector<tt::tt_fabric::FabricNodeId> fabric_node_ids;
     fabric_node_ids.reserve(coords.size());
     for (const auto& coord : coords) {
@@ -49,13 +51,15 @@ std::vector<tt::tt_fabric::FabricNodeId> get_fabric_node_ids_from_coordinates(
 
 }  // namespace
 
-MeshDeviceView::MeshDeviceView(
+// MeshDeviceViewImpl implementations
+
+MeshDeviceViewImpl::MeshDeviceViewImpl(
     const MeshShape& shape,
     const std::vector<IDevice*>& devices,
     const std::vector<tt::tt_fabric::FabricNodeId>& fabric_node_ids) :
-    MeshDeviceView(shape, wrap_to_maybe_remote(devices), fabric_node_ids) {}
+    MeshDeviceViewImpl(shape, wrap_to_maybe_remote(devices), fabric_node_ids) {}
 
-MeshDeviceView::MeshDeviceView(
+MeshDeviceViewImpl::MeshDeviceViewImpl(
     const MeshShape& shape,
     const std::vector<MaybeRemote<IDevice*>>& devices,
     const std::vector<tt::tt_fabric::FabricNodeId>& fabric_node_ids) :
@@ -69,7 +73,7 @@ MeshDeviceView::MeshDeviceView(
             fabric_node_ids.begin(),
             fabric_node_ids.end(),
             [this](const auto& fabric_node_id) { return fabric_node_id.mesh_id == mesh_id_; }),
-        "All fabric node ids in MeshDeviceView must have the same mesh id: {}",
+        "All fabric node ids in MeshDeviceViewImpl must have the same mesh id: {}",
         *mesh_id_);
 
     // Build coordinate map.
@@ -78,7 +82,7 @@ MeshDeviceView::MeshDeviceView(
     }
 }
 
-std::vector<IDevice*> MeshDeviceView::get_devices(const MeshCoordinateRange& range) const {
+std::vector<IDevice*> MeshDeviceViewImpl::get_devices(const MeshCoordinateRange& range) const {
     std::vector<IDevice*> devices_in_region;
     for (const auto& coord : range) {
         devices_.at(coord).if_local([&devices_in_region](const auto& device) { devices_in_region.push_back(device); });
@@ -86,9 +90,10 @@ std::vector<IDevice*> MeshDeviceView::get_devices(const MeshCoordinateRange& ran
     return devices_in_region;
 }
 
-std::vector<IDevice*> MeshDeviceView::get_devices() const { return extract_locals(devices_.values()); }
+std::vector<IDevice*> MeshDeviceViewImpl::get_devices() const { return extract_locals(devices_.values()); }
 
-std::vector<tt::tt_fabric::FabricNodeId> MeshDeviceView::get_fabric_node_ids(const MeshCoordinateRange& range) const {
+std::vector<tt::tt_fabric::FabricNodeId> MeshDeviceViewImpl::get_fabric_node_ids(
+    const MeshCoordinateRange& range) const {
     std::vector<tt::tt_fabric::FabricNodeId> fabric_node_ids_in_region;
     fabric_node_ids_in_region.reserve(range.shape().mesh_size());
     for (const auto& coord : range) {
@@ -97,12 +102,12 @@ std::vector<tt::tt_fabric::FabricNodeId> MeshDeviceView::get_fabric_node_ids(con
     return fabric_node_ids_in_region;
 }
 
-std::vector<tt::tt_fabric::FabricNodeId> MeshDeviceView::get_fabric_node_ids() const {
+std::vector<tt::tt_fabric::FabricNodeId> MeshDeviceViewImpl::get_fabric_node_ids() const {
     return fabric_node_ids_.values();
 }
 
-std::vector<IDevice*> MeshDeviceView::get_devices_on_row(size_t row) const {
-    TT_FATAL(shape_2d_.has_value(), "MeshDeviceView is not 2D!");
+std::vector<IDevice*> MeshDeviceViewImpl::get_devices_on_row(size_t row) const {
+    TT_FATAL(shape_2d_.has_value(), "MeshDeviceViewImpl is not 2D!");
     TT_FATAL(row < shape_2d_->height(), "Row index out of bounds: {}", row);
     std::vector<IDevice*> row_devices;
     row_devices.reserve(shape_2d_->width());
@@ -113,8 +118,8 @@ std::vector<IDevice*> MeshDeviceView::get_devices_on_row(size_t row) const {
     return row_devices;
 }
 
-std::vector<IDevice*> MeshDeviceView::get_devices_on_column(size_t col) const {
-    TT_FATAL(shape_2d_.has_value(), "MeshDeviceView is not 2D!");
+std::vector<IDevice*> MeshDeviceViewImpl::get_devices_on_column(size_t col) const {
+    TT_FATAL(shape_2d_.has_value(), "MeshDeviceViewImpl is not 2D!");
     TT_FATAL(col < shape_2d_->width(), "Column index out of bounds: {}", col);
     std::vector<IDevice*> col_devices;
     col_devices.reserve(shape_2d_->height());
@@ -125,8 +130,8 @@ std::vector<IDevice*> MeshDeviceView::get_devices_on_column(size_t col) const {
     return col_devices;
 }
 
-std::vector<tt::tt_fabric::FabricNodeId> MeshDeviceView::get_fabric_node_ids_on_row(size_t row) const {
-    TT_FATAL(shape_2d_.has_value(), "MeshDeviceView is not 2D!");
+std::vector<tt::tt_fabric::FabricNodeId> MeshDeviceViewImpl::get_fabric_node_ids_on_row(size_t row) const {
+    TT_FATAL(shape_2d_.has_value(), "MeshDeviceViewImpl is not 2D!");
     TT_FATAL(row < shape_2d_->height(), "Row index out of bounds: {}", row);
     std::vector<tt::tt_fabric::FabricNodeId> row_fabric_node_ids;
     row_fabric_node_ids.reserve(shape_2d_->width());
@@ -136,8 +141,8 @@ std::vector<tt::tt_fabric::FabricNodeId> MeshDeviceView::get_fabric_node_ids_on_
     return row_fabric_node_ids;
 }
 
-std::vector<tt::tt_fabric::FabricNodeId> MeshDeviceView::get_fabric_node_ids_on_column(size_t col) const {
-    TT_FATAL(shape_2d_.has_value(), "MeshDeviceView is not 2D!");
+std::vector<tt::tt_fabric::FabricNodeId> MeshDeviceViewImpl::get_fabric_node_ids_on_column(size_t col) const {
+    TT_FATAL(shape_2d_.has_value(), "MeshDeviceViewImpl is not 2D!");
     TT_FATAL(col < shape_2d_->width(), "Column index out of bounds: {}", col);
     std::vector<tt::tt_fabric::FabricNodeId> col_fabric_node_ids;
     col_fabric_node_ids.reserve(shape_2d_->height());
@@ -147,16 +152,16 @@ std::vector<tt::tt_fabric::FabricNodeId> MeshDeviceView::get_fabric_node_ids_on_
     return col_fabric_node_ids;
 }
 
-bool MeshDeviceView::empty() const noexcept { return devices_.shape().mesh_size() == 0; }
-size_t MeshDeviceView::size() const noexcept { return devices_.shape().mesh_size(); }
-const MeshShape& MeshDeviceView::shape() const noexcept { return devices_.shape(); }
-tt::tt_fabric::MeshId MeshDeviceView::mesh_id() const noexcept { return mesh_id_; }
+bool MeshDeviceViewImpl::empty() const noexcept { return devices_.shape().mesh_size() == 0; }
+size_t MeshDeviceViewImpl::size() const noexcept { return devices_.shape().mesh_size(); }
+const MeshShape& MeshDeviceViewImpl::shape() const noexcept { return devices_.shape(); }
+tt::tt_fabric::MeshId MeshDeviceViewImpl::mesh_id() const noexcept { return mesh_id_; }
 
-bool MeshDeviceView::contains(const MeshCoordinate& coord) const noexcept {
+bool MeshDeviceViewImpl::contains(const MeshCoordinate& coord) const noexcept {
     return devices_.coord_range().contains(coord);
 }
 
-IDevice* MeshDeviceView::get_device(const MeshCoordinate& coord) const {
+IDevice* MeshDeviceViewImpl::get_device(const MeshCoordinate& coord) const {
     if (!contains(coord)) {
         return nullptr;
     }
@@ -165,30 +170,30 @@ IDevice* MeshDeviceView::get_device(const MeshCoordinate& coord) const {
     return *maybe_device;
 }
 
-tt::tt_fabric::FabricNodeId MeshDeviceView::get_fabric_node_id(const MeshCoordinate& coord) const {
+tt::tt_fabric::FabricNodeId MeshDeviceViewImpl::get_fabric_node_id(const MeshCoordinate& coord) const {
     TT_FATAL(contains(coord), "Coordinate {} not found in mesh {}", coord, devices_.shape());
     return fabric_node_ids_.at(coord);
 }
 
-size_t MeshDeviceView::num_rows() const {
-    TT_FATAL(shape_2d_.has_value(), "MeshDeviceView is not 2D!");
+size_t MeshDeviceViewImpl::num_rows() const {
+    TT_FATAL(shape_2d_.has_value(), "MeshDeviceViewImpl is not 2D!");
     return shape_2d_->height();
 }
-size_t MeshDeviceView::num_cols() const {
-    TT_FATAL(shape_2d_.has_value(), "MeshDeviceView is not 2D!");
+size_t MeshDeviceViewImpl::num_cols() const {
+    TT_FATAL(shape_2d_.has_value(), "MeshDeviceViewImpl is not 2D!");
     return shape_2d_->width();
 }
-size_t MeshDeviceView::num_devices() const { return devices_.shape().mesh_size(); }
+size_t MeshDeviceViewImpl::num_devices() const { return devices_.shape().mesh_size(); }
 
-MeshCoordinate MeshDeviceView::find_device(ChipId device_id) const {
+MeshCoordinate MeshDeviceViewImpl::find_device(ChipId device_id) const {
     auto it = device_coordinates_.find(device_id);
     TT_FATAL(it != device_coordinates_.end(), "Device not found in mesh: {}", device_id);
     return it->second;
 }
 
-bool MeshDeviceView::is_mesh_2d() const { return shape_2d_.has_value(); }
+bool MeshDeviceViewImpl::is_mesh_2d() const { return shape_2d_.has_value(); }
 
-std::vector<MeshCoordinate> MeshDeviceView::get_line_coordinates(
+std::vector<MeshCoordinate> MeshDeviceViewImpl::get_line_coordinates(
     size_t length, const Shape2D& mesh_shape, const Shape2D& mesh_offset) {
     const auto [num_rows, num_cols] = mesh_shape;
     auto [start_row, start_col] = mesh_offset;
@@ -329,7 +334,8 @@ std::vector<MeshCoordinate> MeshDeviceView::get_line_coordinates(
     return line_coords;
 }
 
-std::vector<MeshCoordinate> MeshDeviceView::get_ring_coordinates(const Shape2D& ring_shape, const Shape2D& mesh_shape) {
+std::vector<MeshCoordinate> MeshDeviceViewImpl::get_ring_coordinates(
+    const Shape2D& ring_shape, const Shape2D& mesh_shape) {
     const auto [ring_rows, ring_cols] = ring_shape;
     TT_FATAL(ring_rows > 0 && ring_cols > 0, "Ring shape must not be empty along either dimension. Got {}", ring_shape);
     TT_FATAL(
@@ -369,38 +375,38 @@ std::vector<MeshCoordinate> MeshDeviceView::get_ring_coordinates(const Shape2D& 
     return boundary_coords;
 }
 
-std::vector<MeshCoordinate> MeshDeviceView::get_line_coordinates() const {
-    TT_FATAL(shape_2d_.has_value(), "MeshDeviceView is not 2D!");
+std::vector<MeshCoordinate> MeshDeviceViewImpl::get_line_coordinates() const {
+    TT_FATAL(shape_2d_.has_value(), "MeshDeviceViewImpl is not 2D!");
     return get_line_coordinates(devices_.shape().mesh_size(), *shape_2d_, /*mesh_offset=*/Shape2D(0, 0));
 }
 
-std::vector<MeshCoordinate> MeshDeviceView::get_ring_coordinates() const {
-    TT_FATAL(shape_2d_.has_value(), "MeshDeviceView is not 2D!");
+std::vector<MeshCoordinate> MeshDeviceViewImpl::get_ring_coordinates() const {
+    TT_FATAL(shape_2d_.has_value(), "MeshDeviceViewImpl is not 2D!");
     return get_ring_coordinates(*shape_2d_, *shape_2d_);
 }
 
-std::vector<IDevice*> MeshDeviceView::get_line_devices() const {
+std::vector<IDevice*> MeshDeviceViewImpl::get_line_devices() const {
     return get_devices_from_coordinates(*this, get_line_coordinates());
 }
 
-std::vector<IDevice*> MeshDeviceView::get_ring_devices() const {
+std::vector<IDevice*> MeshDeviceViewImpl::get_ring_devices() const {
     return get_devices_from_coordinates(*this, get_ring_coordinates());
 }
 
-std::vector<tt::tt_fabric::FabricNodeId> MeshDeviceView::get_line_fabric_node_ids() const {
+std::vector<tt::tt_fabric::FabricNodeId> MeshDeviceViewImpl::get_line_fabric_node_ids() const {
     return get_fabric_node_ids_from_coordinates(*this, get_line_coordinates());
 }
 
-std::vector<tt::tt_fabric::FabricNodeId> MeshDeviceView::get_ring_fabric_node_ids() const {
+std::vector<tt::tt_fabric::FabricNodeId> MeshDeviceViewImpl::get_ring_fabric_node_ids() const {
     return get_fabric_node_ids_from_coordinates(*this, get_ring_coordinates());
 }
 
-bool MeshDeviceView::is_local(const MeshCoordinate& coord) const {
+bool MeshDeviceViewImpl::is_local(const MeshCoordinate& coord) const {
     TT_FATAL(contains(coord), "Coordinate {} not found in mesh {}", coord, devices_.shape());
     return devices_.at(coord).is_local();
 }
 
-MeshCoordinateRange MeshDeviceView::get_local_mesh_coord_range() const {
+MeshCoordinateRange MeshDeviceViewImpl::get_local_mesh_coord_range() const {
     const MeshShape& mesh_shape = shape();
     const size_t num_dims = mesh_shape.dims();
 
@@ -427,5 +433,121 @@ MeshCoordinateRange MeshDeviceView::get_local_mesh_coord_range() const {
 
     return MeshCoordinateRange(start_coord, end_coord);
 }
+
+// MeshDeviceView implementations
+
+MeshDeviceView::MeshDeviceView(
+    const MeshShape& shape,
+    const std::vector<IDevice*>& devices,
+    const std::vector<tt::tt_fabric::FabricNodeId>& fabric_node_ids) :
+    pimpl_(std::make_unique<MeshDeviceViewImpl>(shape, devices, fabric_node_ids)) {}
+
+MeshDeviceView::MeshDeviceView(
+    const MeshShape& shape,
+    const std::vector<MaybeRemote<IDevice*>>& devices,
+    const std::vector<tt::tt_fabric::FabricNodeId>& fabric_node_ids) :
+    pimpl_(std::make_unique<MeshDeviceViewImpl>(shape, devices, fabric_node_ids)) {}
+
+MeshDeviceView::~MeshDeviceView() = default;
+
+MeshDeviceView::MeshDeviceView(const MeshDeviceView& other) :
+    pimpl_(std::make_unique<MeshDeviceViewImpl>(*other.pimpl_)) {}
+
+MeshDeviceView& MeshDeviceView::operator=(const MeshDeviceView& other) {
+    if (this != &other) {
+        pimpl_ = std::make_unique<MeshDeviceViewImpl>(*other.pimpl_);
+    }
+    return *this;
+}
+
+MeshDeviceView::MeshDeviceView(MeshDeviceView&&) noexcept = default;
+MeshDeviceView& MeshDeviceView::operator=(MeshDeviceView&&) noexcept = default;
+
+std::vector<IDevice*> MeshDeviceView::get_devices(const MeshCoordinateRange& range) const {
+    return pimpl_->get_devices(range);
+}
+
+std::vector<IDevice*> MeshDeviceView::get_devices() const { return pimpl_->get_devices(); }
+
+std::vector<tt::tt_fabric::FabricNodeId> MeshDeviceView::get_fabric_node_ids(const MeshCoordinateRange& range) const {
+    return pimpl_->get_fabric_node_ids(range);
+}
+
+std::vector<tt::tt_fabric::FabricNodeId> MeshDeviceView::get_fabric_node_ids() const {
+    return pimpl_->get_fabric_node_ids();
+}
+
+std::vector<IDevice*> MeshDeviceView::get_devices_on_row(size_t row) const { return pimpl_->get_devices_on_row(row); }
+
+std::vector<IDevice*> MeshDeviceView::get_devices_on_column(size_t col) const {
+    return pimpl_->get_devices_on_column(col);
+}
+
+std::vector<tt::tt_fabric::FabricNodeId> MeshDeviceView::get_fabric_node_ids_on_row(size_t row) const {
+    return pimpl_->get_fabric_node_ids_on_row(row);
+}
+
+std::vector<tt::tt_fabric::FabricNodeId> MeshDeviceView::get_fabric_node_ids_on_column(size_t col) const {
+    return pimpl_->get_fabric_node_ids_on_column(col);
+}
+
+bool MeshDeviceView::empty() const noexcept { return pimpl_->empty(); }
+
+size_t MeshDeviceView::size() const noexcept { return pimpl_->size(); }
+
+const MeshShape& MeshDeviceView::shape() const noexcept { return pimpl_->shape(); }
+
+tt::tt_fabric::MeshId MeshDeviceView::mesh_id() const noexcept { return pimpl_->mesh_id(); }
+
+bool MeshDeviceView::contains(const MeshCoordinate& coord) const noexcept { return pimpl_->contains(coord); }
+
+IDevice* MeshDeviceView::get_device(const MeshCoordinate& coord) const { return pimpl_->get_device(coord); }
+
+tt::tt_fabric::FabricNodeId MeshDeviceView::get_fabric_node_id(const MeshCoordinate& coord) const {
+    return pimpl_->get_fabric_node_id(coord);
+}
+
+size_t MeshDeviceView::num_rows() const { return pimpl_->num_rows(); }
+
+size_t MeshDeviceView::num_cols() const { return pimpl_->num_cols(); }
+
+size_t MeshDeviceView::num_devices() const { return pimpl_->num_devices(); }
+
+MeshCoordinate MeshDeviceView::find_device(ChipId device_id) const { return pimpl_->find_device(device_id); }
+
+bool MeshDeviceView::is_mesh_2d() const { return pimpl_->is_mesh_2d(); }
+
+std::vector<MeshCoordinate> MeshDeviceView::get_line_coordinates(
+    size_t length, const Shape2D& mesh_shape, const Shape2D& mesh_offset) {
+    return MeshDeviceViewImpl::get_line_coordinates(length, mesh_shape, mesh_offset);
+}
+
+std::vector<MeshCoordinate> MeshDeviceView::get_line_coordinates() const { return pimpl_->get_line_coordinates(); }
+
+std::vector<MeshCoordinate> MeshDeviceView::get_ring_coordinates(const Shape2D& ring_shape, const Shape2D& mesh_shape) {
+    return MeshDeviceViewImpl::get_ring_coordinates(ring_shape, mesh_shape);
+}
+
+std::vector<MeshCoordinate> MeshDeviceView::get_ring_coordinates() const { return pimpl_->get_ring_coordinates(); }
+
+std::vector<IDevice*> MeshDeviceView::get_line_devices() const { return pimpl_->get_line_devices(); }
+
+std::vector<IDevice*> MeshDeviceView::get_ring_devices() const { return pimpl_->get_ring_devices(); }
+
+std::vector<tt::tt_fabric::FabricNodeId> MeshDeviceView::get_line_fabric_node_ids() const {
+    return pimpl_->get_line_fabric_node_ids();
+}
+
+std::vector<tt::tt_fabric::FabricNodeId> MeshDeviceView::get_ring_fabric_node_ids() const {
+    return pimpl_->get_ring_fabric_node_ids();
+}
+
+bool MeshDeviceView::is_local(const MeshCoordinate& coord) const { return pimpl_->is_local(coord); }
+
+MeshCoordinateRange MeshDeviceView::get_local_mesh_coord_range() const { return pimpl_->get_local_mesh_coord_range(); }
+
+std::vector<MaybeRemote<IDevice*>>::const_iterator MeshDeviceView::begin() const { return pimpl_->begin(); }
+
+std::vector<MaybeRemote<IDevice*>>::const_iterator MeshDeviceView::end() const { return pimpl_->end(); }
 
 }  // namespace tt::tt_metal::distributed

--- a/tt_metal/distributed/mesh_device_view_impl.hpp
+++ b/tt_metal/distributed/mesh_device_view_impl.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -20,35 +20,24 @@
 
 namespace tt::tt_metal::distributed {
 
-// Forward declarations
+// Forward declaration of MeshDevice
 class MeshDevice;
-class MeshDeviceViewImpl;
 
 /**
- * @brief The MeshDeviceView class provides a view of a specific sub-region within the MeshDevice.
+ * @brief The MeshDeviceViewImpl class provides the implementation for MeshDeviceView.
  *
- * Once a MeshDevice is initialized, MeshDeviceView allows the creation of multiple "views" on the
- * MeshDevice, enabling more granular control over a cluster of initialized devices. This approach
- * differs from simply creating a new MeshDevice on a subset of devices.
- *
- * MeshDeviceView serves two primary purposes:
- *
- * 1. It facilitates the creation of abstractions that define parallelization strategies, such as
- *    tensor-parallel or pipeline-parallel, by assigning views of the MeshDevice.
- *
- * 2. It acts as a query interface for the MeshDevice, allowing the retrieval of devices based on
- *    specific sub-regions. This is particularly useful for collective communication operations
- *    (CCL-ops), such as line all-gather, which require column or row views of the device mesh.
+ * This class replicates the full interface of MeshDeviceView and will be used
+ * as the implementation class in the PIMPL pattern.
  */
 
-class MeshDeviceView {
+class MeshDeviceViewImpl {
 public:
-    // Constructors for MeshDeviceView for fully and partially local meshes.
-    explicit MeshDeviceView(
+    // Constructors for MeshDeviceViewImpl for fully and partially local meshes.
+    explicit MeshDeviceViewImpl(
         const MeshShape& shape,
         const std::vector<IDevice*>& devices,
         const std::vector<tt::tt_fabric::FabricNodeId>& fabric_node_ids);
-    explicit MeshDeviceView(
+    explicit MeshDeviceViewImpl(
         const MeshShape& shape,
         const std::vector<MaybeRemote<IDevice*>>& devices,
         const std::vector<tt::tt_fabric::FabricNodeId>& fabric_node_ids);
@@ -68,15 +57,14 @@ public:
 
     // Returns `IDevice*` instance for `coord`.
     // In multi-host context, throws if `coord` is querying a remote device.
-    [[deprecated("Deprecated, retrieving physical devices can fail in distributed contexts.")]] [[nodiscard]] IDevice*
-    get_device(const MeshCoordinate& coord) const;
+    [[nodiscard]] IDevice* get_device(const MeshCoordinate& coord) const;
 
     // Returns `tt::tt_fabric::FabricNodeId` for `coord`.
     // In multi-host context, fabric node IDs are always available, even for remote devices.
     [[nodiscard]] tt::tt_fabric::FabricNodeId get_fabric_node_id(const MeshCoordinate& coord) const;
 
-    std::vector<MaybeRemote<IDevice*>>::const_iterator begin() const;
-    std::vector<MaybeRemote<IDevice*>>::const_iterator end() const;
+    auto begin() const { return devices_.values().begin(); }
+    auto end() const { return devices_.values().end(); }
 
     // Throws if no device corresponds to `device_id`.
     [[nodiscard]] MeshCoordinate find_device(ChipId device_id) const;
@@ -113,29 +101,22 @@ public:
 
     // Returns true if the view is fully local, i.e. all devices in the view are local.
     // Throws if the coordinate is out of bounds of this view.
-    [[deprecated("Deprecated, is_local should be avoided as it is likely to cause issues in distributed contexts.")]]
     bool is_local(const MeshCoordinate& coord) const;
 
     // Returns the coordinate range of all local devices in this view.
     // The range is a bounding box that encompasses all local coordinates.
     MeshCoordinateRange get_local_mesh_coord_range() const;
 
-    // Destructor
-    ~MeshDeviceView();
-
-    // Copy constructor and assignment
-    MeshDeviceView(const MeshDeviceView&);
-    MeshDeviceView& operator=(const MeshDeviceView&);
-
-    // Move constructor and assignment
-    MeshDeviceView(MeshDeviceView&&) noexcept;
-    MeshDeviceView& operator=(MeshDeviceView&&) noexcept;
-
-    const MeshDeviceViewImpl& impl() const { return *pimpl_; }
-    MeshDeviceViewImpl& impl() { return *pimpl_; }
-
 private:
-    std::unique_ptr<MeshDeviceViewImpl> pimpl_;
+    DistributedMeshContainer<IDevice*> devices_;
+    MeshContainer<tt::tt_fabric::FabricNodeId> fabric_node_ids_;
+    tt::tt_fabric::MeshId mesh_id_;
+
+    std::unordered_map<ChipId, MeshCoordinate> device_coordinates_;
+
+    // Set if the view is 2D to enable row/col APIs, otherwise nullopt.
+    // TODO: #17477 - Remove this?
+    std::optional<Shape2D> shape_2d_;
 };
 
 }  // namespace tt::tt_metal::distributed

--- a/tt_metal/distributed/mesh_trace.cpp
+++ b/tt_metal/distributed/mesh_trace.cpp
@@ -34,6 +34,7 @@
 #include "tt_metal/impl/dispatch/device_command.hpp"
 #include "tt_metal/impl/trace/dispatch.hpp"
 #include "impl/allocator/allocator.hpp"
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal::distributed {
 
@@ -52,7 +53,7 @@ void MeshTraceDescriptor::assemble_dispatch_commands(
 
     for (const auto& trace_md : mesh_trace_md) {
         const auto& sysmem_mgr_coord = trace_md.sysmem_manager_coord;
-        auto& sysmem_manager = mesh_device->get_device(sysmem_mgr_coord)->sysmem_manager();
+        auto& sysmem_manager = mesh_device->impl().get_device(sysmem_mgr_coord)->sysmem_manager();
         auto trace_data_word_offset = trace_md.offset / sizeof(uint32_t);
         auto trace_data_size_words = trace_md.size / sizeof(uint32_t);
         auto& bypass_data = sysmem_manager.get_bypass_data();

--- a/tt_metal/distributed/pinned_memory.cpp
+++ b/tt_metal/distributed/pinned_memory.cpp
@@ -21,6 +21,8 @@
 #include <umd/device/chip_helpers/sysmem_buffer.hpp>
 #include "impl/dispatch/system_memory_manager.hpp"
 #include "llrt/tt_cluster.hpp"
+#include <distributed/mesh_device_impl.hpp>
+#include <distributed/mesh_device_view_impl.hpp>
 
 namespace tt::tt_metal::experimental {
 
@@ -248,7 +250,7 @@ void PinnedMemoryImpl::add_barrier_event(const distributed::MeshEvent& event) {
         }
         bool all_devices_completed = true;
         for (const auto& coord : event.device_range()) {
-            auto* physical_device = event.device()->get_device(coord);
+            auto* physical_device = event.device()->impl().get_device(coord);
             if (physical_device->sysmem_manager().get_last_completed_event(event.mesh_cq_id()) < event.id()) {
                 all_devices_completed = false;
                 break;
@@ -325,7 +327,7 @@ std::unique_ptr<PinnedMemory> PinnedMemory::Create(
     devices.reserve(coordinates.size());
     for (const auto& coord : coordinates) {
         if (view.contains(coord)) {
-            if (auto* device = view.get_device(coord)) {
+            if (auto* device = view.impl().get_device(coord)) {
                 devices.push_back(device);
             }
         }

--- a/tt_metal/distributed/sd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/sd_mesh_command_queue.cpp
@@ -12,6 +12,7 @@
 #include <tt-metalium/graph_tracking.hpp>
 #include <utility>
 #include <llrt/tt_cluster.hpp>
+#include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal::distributed {
 
@@ -77,16 +78,16 @@ void SDMeshCommandQueue::enqueue_mesh_workload(MeshWorkload& mesh_workload, bool
     }
     for (auto& [coord_range, program] : mesh_workload.get_programs()) {
         for (const auto& coord : coord_range) {
-            if (mesh_device_->is_local(coord)) {
-                auto* device = mesh_device_->get_device(coord);
+            if (mesh_device_->impl().is_local(coord)) {
+                auto* device = mesh_device_->impl().get_device(coord);
                 tt_metal::detail::LaunchProgram(device, program, false);
             }
         }
     }
     for (auto& [coord_range, program] : mesh_workload.get_programs()) {
         for (const auto& coord : coord_range) {
-            if (mesh_device_->is_local(coord)) {
-                auto* device = mesh_device_->get_device(coord);
+            if (mesh_device_->impl().is_local(coord)) {
+                auto* device = mesh_device_->impl().get_device(coord);
                 tt_metal::detail::WaitProgramDone(device, program);
             }
         }

--- a/tt_metal/fabric/fabric.cpp
+++ b/tt_metal/fabric/fabric.cpp
@@ -22,6 +22,7 @@
 #include "impl/program/program_impl.hpp"
 #include "impl/kernels/kernel.hpp"
 #include <umd/device/types/xy_pair.hpp>
+#include "distributed/mesh_device_impl.hpp"
 
 #include "fabric_host_utils.hpp"
 #include "fabric_context.hpp"
@@ -442,7 +443,7 @@ size_t get_number_of_available_routing_planes(
 
     size_t row_idx = cluster_axis == 0 ? 0 : row_or_col;
     size_t col_idx = cluster_axis == 0 ? row_or_col : 0;
-    auto* first_chip = mesh_device.get_device(row_idx, col_idx);
+    auto* first_chip = mesh_device.impl().get_device(row_idx, col_idx);
     ChipId first_chip_id = first_chip->id();
     auto fabric_node_in_row_or_col = control_plane.get_fabric_node_id_from_physical_chip_id(first_chip_id);
 

--- a/tt_metal/impl/debug/inspector/data.cpp
+++ b/tt_metal/impl/debug/inspector/data.cpp
@@ -7,6 +7,7 @@
 #include "rpc_server_controller.hpp"
 #include "logger.hpp"
 #include "context/metal_context.hpp"
+#include "distributed/mesh_device_impl.hpp"
 #include "distributed/mesh_workload_impl.hpp"
 #include "jit_build/build_env_manager.hpp"
 #include "device/device_manager.hpp"

--- a/tt_metal/impl/debug/inspector/inspector.cpp
+++ b/tt_metal/impl/debug/inspector/inspector.cpp
@@ -8,7 +8,7 @@
 #include "impl/debug/inspector/rpc_server_generated.hpp"
 #include "impl/program/program_impl.hpp"
 #include "jit_build/jit_build_options.hpp"
-#include "mesh_device.hpp"
+#include "distributed/mesh_device_impl.hpp"
 #include "distributed/mesh_workload_impl.hpp"
 #include "program.hpp"
 #include <memory>
@@ -205,7 +205,7 @@ void Inspector::program_set_binary_status(
 }
 
 void Inspector::mesh_device_created(
-    const distributed::MeshDevice* mesh_device, std::optional<int> parent_mesh_id) noexcept {
+    const distributed::MeshDeviceImpl* mesh_device, std::optional<int> parent_mesh_id) noexcept {
     if (!is_enabled()) {
         return;
     }
@@ -226,7 +226,7 @@ void Inspector::mesh_device_created(
     }
 }
 
-void Inspector::mesh_device_destroyed(const distributed::MeshDevice* mesh_device) noexcept {
+void Inspector::mesh_device_destroyed(const distributed::MeshDeviceImpl* mesh_device) noexcept {
     if (!is_enabled()) {
         return;
     }
@@ -245,7 +245,7 @@ void Inspector::mesh_device_destroyed(const distributed::MeshDevice* mesh_device
     }
 }
 
-void Inspector::mesh_device_initialized(const distributed::MeshDevice* mesh_device) noexcept {
+void Inspector::mesh_device_initialized(const distributed::MeshDeviceImpl* mesh_device) noexcept {
     if (!is_enabled()) {
         return;
     }

--- a/tt_metal/impl/debug/inspector/inspector.hpp
+++ b/tt_metal/impl/debug/inspector/inspector.hpp
@@ -12,7 +12,7 @@
 namespace tt::tt_metal {
 
 namespace distributed {
-class MeshDevice;
+class MeshDeviceImpl;
 class MeshWorkloadImpl;
 }  // namespace distributed
 
@@ -45,9 +45,9 @@ public:
         const detail::ProgramImpl* program, const IDevice* device, uint64_t build_key) noexcept;
 
     static void mesh_device_created(
-        const distributed::MeshDevice* mesh_device, std::optional<int> parent_mesh_id) noexcept;
-    static void mesh_device_destroyed(const distributed::MeshDevice* mesh_device) noexcept;
-    static void mesh_device_initialized(const distributed::MeshDevice* mesh_device) noexcept;
+        const distributed::MeshDeviceImpl* mesh_device, std::optional<int> parent_mesh_id) noexcept;
+    static void mesh_device_destroyed(const distributed::MeshDeviceImpl* mesh_device) noexcept;
+    static void mesh_device_initialized(const distributed::MeshDeviceImpl* mesh_device) noexcept;
 
     static void mesh_workload_created(const distributed::MeshWorkloadImpl* mesh_workload) noexcept;
     static void mesh_workload_destroyed(const distributed::MeshWorkloadImpl* mesh_workload) noexcept;

--- a/tt_metal/impl/debug/inspector/logger.cpp
+++ b/tt_metal/impl/debug/inspector/logger.cpp
@@ -5,6 +5,7 @@
 #include "impl/debug/inspector/logger.hpp"
 #include "impl/debug/inspector/types.hpp"
 #include "impl/context/metal_context.hpp"
+#include "distributed/mesh_device_impl.hpp"
 #include <iomanip>
 #include <chrono>
 

--- a/tt_metal/impl/debug/inspector/types.hpp
+++ b/tt_metal/impl/debug/inspector/types.hpp
@@ -16,8 +16,8 @@ namespace tt::tt_metal {
     class MetalContext;
 
     namespace distributed {
-        class MeshDevice;
-        class MeshWorkloadImpl;
+    class MeshDeviceImpl;
+    class MeshWorkloadImpl;
     }
 }
 
@@ -43,7 +43,7 @@ struct ProgramData {
 };
 
 struct MeshDeviceData {
-    const distributed::MeshDevice* mesh_device = nullptr;
+    const distributed::MeshDeviceImpl* mesh_device = nullptr;
     int mesh_id{};
     std::optional<int> parent_mesh_id;
     bool initialized = false;

--- a/tt_metal/tools/profiler/tt_metal_tracy.hpp
+++ b/tt_metal/tools/profiler/tt_metal_tracy.hpp
@@ -5,6 +5,7 @@
 
 #include <tt_metal_profiler.hpp>
 #include "impl/context/metal_context.hpp"
+#include "distributed/mesh_device_impl.hpp"
 #include <tt_metal/impl/profiler/profiler_state.hpp>
 #include <tt_metal/impl/profiler/profiler_state_manager.hpp>
 
@@ -59,7 +60,7 @@
         for (auto& [device_range, program] : (mesh_workload).get_programs()) {                                \
             if ((trace_id).has_value()) {                                                                     \
                 for_each_local((mesh_device), device_range, [&](const auto& coord) {                          \
-                    auto device = (mesh_device)->get_device(coord);                                           \
+                    auto device = (mesh_device)->impl().get_device(coord);                                    \
                     tt::tt_metal::MetalContext::instance().profiler_state_manager()->add_runtime_id_to_trace( \
                         device->id(), *((trace_id).value()), program.get_runtime_id());                       \
                     if (TracyTTMetalTraceTrackingEnabled()) {                                                 \


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/31961

### Problem description
Part of the `MeshDevice` API surface breaks on multi-host set-ups.

### What's changed
Make the public `MeshDevice` API fully multi-host friendly. The `MeshDevice::[get_device|is_local]` and `MeshDeviceView::[get_device|is_local]` methods are deprecated in the public API. `MeshDevice` and `MeshDeviceView` have been refactored to use PIMPL. Internal usage of `[get_device|is_local]` is now done through the `*Impl` types.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [x] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes