### PR TITLE
Add log_check_device, log_check_location, and log_check_core to provi…

### DIFF
--- a/tools/triage/check_arc.py
+++ b/tools/triage/check_arc.py
@@ -40,7 +40,7 @@ class ArcCheckData:
 
 def check_wormhole_arc(arc: NocBlock, postcode: int) -> ArcCheckData:
     device = arc.location.device
-    device_id = device._id
+    device_id = device.device_id
     # Heartbeat must be increasing
     heartbeat_0 = read_arc_telemetry_entry(device_id, "TAG_ARC0_HEALTH")
     delay_seconds = 0.1
@@ -76,7 +76,7 @@ def check_wormhole_arc(arc: NocBlock, postcode: int) -> ArcCheckData:
 
 def check_blackhole_arc(arc: NocBlock, postcode: int) -> ArcCheckData:
     device = arc.location.device
-    device_id = device._id
+    device_id = device.device_id
     # Heartbeat must be increasing
     heartbeat_0 = read_arc_telemetry_entry(device_id, "TAG_TIMER_HEARTBEAT")
     delay_seconds = 0.2

--- a/tools/triage/check_arc.py
+++ b/tools/triage/check_arc.py
@@ -12,7 +12,7 @@ Description:
 """
 
 from dataclasses import dataclass
-from triage import ScriptConfig, triage_field, hex_serializer, log_check, run_script
+from triage import ScriptConfig, triage_field, hex_serializer, log_check_device, run_script
 from run_checks import run as get_run_checks
 from datetime import timedelta
 import time
@@ -39,13 +39,14 @@ class ArcCheckData:
 
 
 def check_wormhole_arc(arc: NocBlock, postcode: int) -> ArcCheckData:
-    device_id = arc.location._device._id
+    device = arc.location.device
+    device_id = device._id
     # Heartbeat must be increasing
     heartbeat_0 = read_arc_telemetry_entry(device_id, "TAG_ARC0_HEALTH")
     delay_seconds = 0.1
     time.sleep(delay_seconds)
     heartbeat_1 = read_arc_telemetry_entry(device_id, "TAG_ARC0_HEALTH")
-    log_check(heartbeat_1 > heartbeat_0, f"ARC heartbeat not increasing: {RED}{heartbeat_1}{RST}.")
+    log_check_device(device, heartbeat_1 > heartbeat_0, f"ARC heartbeat not increasing: {RED}{heartbeat_1}{RST}.")
 
     # Compute uptime
     arcclk_mhz = read_arc_telemetry_entry(device_id, "TAG_ARCCLK")
@@ -53,11 +54,13 @@ def check_wormhole_arc(arc: NocBlock, postcode: int) -> ArcCheckData:
     uptime_seconds = heartbeat_1 / heartbeats_per_second
 
     # Heartbeat must be between 500 and 20000 hb/s
-    log_check(
+    log_check_device(
+        device,
         heartbeats_per_second >= 500,
         f"ARC heartbeat is too low: {RED}{heartbeats_per_second}{RST}hb/s. Expected at least {BLUE}500{RST}hb/s",
     )
-    log_check(
+    log_check_device(
+        device,
         heartbeats_per_second <= 20000,
         f"ARC heartbeat is too high: {RED}{heartbeats_per_second}{RST}hb/s. Expected at most {BLUE}20000{RST}hb/s",
     )
@@ -72,13 +75,14 @@ def check_wormhole_arc(arc: NocBlock, postcode: int) -> ArcCheckData:
 
 
 def check_blackhole_arc(arc: NocBlock, postcode: int) -> ArcCheckData:
-    device_id = arc.location._device._id
+    device = arc.location.device
+    device_id = device._id
     # Heartbeat must be increasing
     heartbeat_0 = read_arc_telemetry_entry(device_id, "TAG_TIMER_HEARTBEAT")
     delay_seconds = 0.2
     time.sleep(delay_seconds)
     heartbeat_1 = read_arc_telemetry_entry(device_id, "TAG_TIMER_HEARTBEAT")
-    log_check(heartbeat_1 > heartbeat_0, f"ARC heartbeat not increasing: {RED}{heartbeat_1}{RST}.")
+    log_check_device(device, heartbeat_1 > heartbeat_0, f"ARC heartbeat not increasing: {RED}{heartbeat_1}{RST}.")
 
     # Compute uptime
     arcclk_mhz = read_arc_telemetry_entry(device_id, "TAG_ARCCLK")
@@ -86,11 +90,13 @@ def check_blackhole_arc(arc: NocBlock, postcode: int) -> ArcCheckData:
     uptime_seconds = heartbeat_1 / heartbeats_per_second
 
     # Heartbeat must be between 10 and 50
-    log_check(
+    log_check_device(
+        device,
         heartbeats_per_second >= 10,
         f"ARC heartbeat is too low: {RED}{heartbeats_per_second}{RST}hb/s. Expected at least {BLUE}10{RST}hb/s",
     )
-    log_check(
+    log_check_device(
+        device,
         heartbeats_per_second <= 50,
         f"ARC heartbeat is too high: {RED}{heartbeats_per_second}{RST}hb/s. Expected at most {BLUE}50{RST}hb/s",
     )
@@ -107,7 +113,8 @@ def check_blackhole_arc(arc: NocBlock, postcode: int) -> ArcCheckData:
 def check_arc(device: Device):
     arc = device.arc_block
     postcode = arc.get_register_store().read_register("ARC_RESET_SCRATCH0")
-    log_check(
+    log_check_device(
+        device,
         (postcode & 0xFFFF0000) == 0xC0DE0000,
         f"ARC postcode: {RED}0x{postcode:08x}{RST}. Expected {BLUE}0xc0de____{RST}",
     )

--- a/tools/triage/check_binary_integrity.py
+++ b/tools/triage/check_binary_integrity.py
@@ -18,7 +18,7 @@ import os
 from ttexalens.context import Context
 from ttexalens.coordinate import OnChipCoordinate
 from ttexalens.tt_exalens_lib import read_from_device
-from triage import ScriptConfig, log_check_core, run_script
+from triage import ScriptConfig, log_check_risc, run_script
 
 script_config = ScriptConfig(
     depends=["run_checks", "dispatcher_data", "elfs_cache"],
@@ -31,9 +31,9 @@ def check_binary_integrity(
     dispatcher_core_data = dispatcher_data.get_core_data(location, risc_name)
 
     # Check firmware ELF binary state on the device
-    log_check_core(
-        location,
+    log_check_risc(
         risc_name,
+        location,
         os.path.exists(dispatcher_core_data.firmware_path),
         f"Firmware ELF file {dispatcher_core_data.firmware_path} does not exist.",
     )
@@ -43,9 +43,9 @@ def check_binary_integrity(
         for section_name in sections_to_verify:
             section = elf_file.get_section_by_name(section_name)
             if section is None:
-                log_check_core(
-                    location,
+                log_check_risc(
                     risc_name,
+                    location,
                     False,
                     f"Section {section_name} not found in ELF file {dispatcher_core_data.firmware_path}.",
                 )
@@ -53,18 +53,18 @@ def check_binary_integrity(
                 address: int = section["sh_addr"]
                 data: bytes = section.data()
                 read_data = read_from_device(location, address, num_bytes=len(data))
-                log_check_core(
-                    location,
+                log_check_risc(
                     risc_name,
+                    location,
                     read_data == data,
                     f"Data mismatch in section {section_name} at address 0x{address:08x} in ELF file {dispatcher_core_data.firmware_path}.",
                 )
 
     # Check kernel ELF binary state on the device
     if dispatcher_core_data.kernel_xip_path is not None:
-        log_check_core(
-            location,
+        log_check_risc(
             risc_name,
+            location,
             os.path.exists(dispatcher_core_data.kernel_xip_path),
             f"Kernel ELF file {dispatcher_core_data.kernel_xip_path} does not exist.",
         )
@@ -75,9 +75,9 @@ def check_binary_integrity(
             for section_name in sections_to_verify:
                 section = elf_file.get_section_by_name(section_name)
                 if section is None:
-                    log_check_core(
-                        location,
+                    log_check_risc(
                         risc_name,
+                        location,
                         False,
                         f"Section {section_name} not found in ELF file {dispatcher_core_data.kernel_xip_path}.",
                     )
@@ -85,9 +85,9 @@ def check_binary_integrity(
                     data: bytes = section.data()
                     address: int = dispatcher_core_data.kernel_offset
                     read_data = read_from_device(location, address, num_bytes=len(data))
-                    log_check_core(
-                        location,
+                    log_check_risc(
                         risc_name,
+                        location,
                         read_data == data,
                         f"Data mismatch in section {section_name} at address 0x{address:08x} in ELF file {dispatcher_core_data.kernel_xip_path}.",
                     )

--- a/tools/triage/check_binary_integrity.py
+++ b/tools/triage/check_binary_integrity.py
@@ -18,7 +18,7 @@ import os
 from ttexalens.context import Context
 from ttexalens.coordinate import OnChipCoordinate
 from ttexalens.tt_exalens_lib import read_from_device
-from triage import ScriptConfig, log_check, run_script
+from triage import ScriptConfig, log_check_core, run_script
 
 script_config = ScriptConfig(
     depends=["run_checks", "dispatcher_data", "elfs_cache"],
@@ -31,7 +31,9 @@ def check_binary_integrity(
     dispatcher_core_data = dispatcher_data.get_core_data(location, risc_name)
 
     # Check firmware ELF binary state on the device
-    log_check(
+    log_check_core(
+        location,
+        risc_name,
         os.path.exists(dispatcher_core_data.firmware_path),
         f"Firmware ELF file {dispatcher_core_data.firmware_path} does not exist.",
     )
@@ -41,7 +43,9 @@ def check_binary_integrity(
         for section_name in sections_to_verify:
             section = elf_file.get_section_by_name(section_name)
             if section is None:
-                log_check(
+                log_check_core(
+                    location,
+                    risc_name,
                     False,
                     f"Section {section_name} not found in ELF file {dispatcher_core_data.firmware_path}.",
                 )
@@ -49,14 +53,18 @@ def check_binary_integrity(
                 address: int = section["sh_addr"]
                 data: bytes = section.data()
                 read_data = read_from_device(location, address, num_bytes=len(data))
-                log_check(
+                log_check_core(
+                    location,
+                    risc_name,
                     read_data == data,
-                    f"{location.to_user_str()}: Data mismatch in section {section_name} at address 0x{address:08x} in ELF file {dispatcher_core_data.firmware_path}.",
+                    f"Data mismatch in section {section_name} at address 0x{address:08x} in ELF file {dispatcher_core_data.firmware_path}.",
                 )
 
     # Check kernel ELF binary state on the device
     if dispatcher_core_data.kernel_xip_path is not None:
-        log_check(
+        log_check_core(
+            location,
+            risc_name,
             os.path.exists(dispatcher_core_data.kernel_xip_path),
             f"Kernel ELF file {dispatcher_core_data.kernel_xip_path} does not exist.",
         )
@@ -67,7 +75,9 @@ def check_binary_integrity(
             for section_name in sections_to_verify:
                 section = elf_file.get_section_by_name(section_name)
                 if section is None:
-                    log_check(
+                    log_check_core(
+                        location,
+                        risc_name,
                         False,
                         f"Section {section_name} not found in ELF file {dispatcher_core_data.kernel_xip_path}.",
                     )
@@ -75,9 +85,11 @@ def check_binary_integrity(
                     data: bytes = section.data()
                     address: int = dispatcher_core_data.kernel_offset
                     read_data = read_from_device(location, address, num_bytes=len(data))
-                    log_check(
+                    log_check_core(
+                        location,
+                        risc_name,
                         read_data == data,
-                        f"{location.to_user_str()}: Data mismatch in section {section_name} at address 0x{address:08x} in ELF file {dispatcher_core_data.kernel_xip_path}.",
+                        f"Data mismatch in section {section_name} at address 0x{address:08x} in ELF file {dispatcher_core_data.kernel_xip_path}.",
                     )
 
 

--- a/tools/triage/check_cb_inactive.py
+++ b/tools/triage/check_cb_inactive.py
@@ -41,7 +41,7 @@ def check_cb_idle(location: OnChipCoordinate, noc_id: int):
         log_check_location(
             location,
             value == 0,
-            f"at {location.to_str(noc_str)}: {noc_str} CB{cb_index} active (0x{value:08X}). NoC is likely hung.",
+            f"{noc_str} CB{cb_index} active (0x{value:08X}). NoC is likely hung.",
         )
 
 

--- a/tools/triage/check_cb_inactive.py
+++ b/tools/triage/check_cb_inactive.py
@@ -16,7 +16,7 @@ Description:
 from ttexalens.coordinate import OnChipCoordinate
 from run_checks import run as get_run_checks
 from ttexalens.context import Context
-from triage import ScriptConfig, log_check, run_script
+from triage import ScriptConfig, log_check_location, run_script
 
 script_config = ScriptConfig(
     depends=["run_checks"],
@@ -38,10 +38,10 @@ def check_cb_idle(location: OnChipCoordinate, noc_id: int):
     for cb_index in range(4):  # CB indices 0-3
         reg_name = generate_cb_reg_name(cb_index)
         value = register_store.read_register(reg_name)
-        log_check(
+        log_check_location(
+            location,
             value == 0,
-            f"Device {location._device._id} {location._device.get_block_type(location)} "
-            f"[{location.to_str('logical')}] at {location.to_str(noc_str)}: {noc_str} CB{cb_index} active (0x{value:08X}). NoC is likely hung.",
+            f"at {location.to_str(noc_str)}: {noc_str} CB{cb_index} active (0x{value:08X}). NoC is likely hung.",
         )
 
 

--- a/tools/triage/check_eth_status.py
+++ b/tools/triage/check_eth_status.py
@@ -80,7 +80,7 @@ class EthCore(ABC):
             if read_data != previous_data:
                 return True
             previous_data = read_data
-        log_check_location(self.location, False, f"No heartbeat detected for {self.location.to_user_str()}")
+        log_check_location(self.location, False, "No heartbeat detected")
         return False
 
     def get_results(self):
@@ -99,7 +99,7 @@ class EthCore(ABC):
                 output.port_status = "Unknown"
             else:
                 output.port_status = port_status_str
-            log_check_location(self.location, port_status_str != "Down", f"{self.location.to_user_str()} port is down")
+            log_check_location(self.location, port_status_str != "Down", "port is down")
 
         # RETRAIN COUNT
         output.retrain_count = int(
@@ -108,7 +108,7 @@ class EthCore(ABC):
         log_check_location(
             self.location,
             not output.retrain_count,
-            f"{self.location.to_user_str()} retrain count is {output.retrain_count}",
+            f"retrain count is {output.retrain_count}",
         )
 
         # RX LINK UP
@@ -120,7 +120,7 @@ class EthCore(ABC):
         log_check_location(
             self.location,
             output.rx_link_up == "Up",
-            f"{self.location.to_user_str()} rx link is not up: {output.rx_link_up}",
+            f"rx link is not up: {output.rx_link_up}",
         )
 
         # MAILBOX
@@ -138,7 +138,7 @@ class EthCore(ABC):
                 log_check_location(
                     self.location,
                     not any_pending_message,
-                    f"{self.location.to_user_str()} mailbox: {output.mailbox} (pending message)",
+                    f"mailbox: {output.mailbox} (pending message)",
                 )
         else:
             output.mailbox = ["None"]

--- a/tools/triage/check_eth_status.py
+++ b/tools/triage/check_eth_status.py
@@ -14,7 +14,7 @@ Description:
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from run_checks import run as get_run_checks
-from triage import ScriptConfig, triage_field, log_check, run_script
+from triage import ScriptConfig, triage_field, log_check_location, run_script
 from ttexalens.context import Context
 from ttexalens.device import Device, OnChipCoordinate
 from ttexalens.register_store import read_word_from_device
@@ -23,10 +23,6 @@ import utils
 script_config = ScriptConfig(
     depends=["run_checks"],
 )
-
-
-def log_check_with_loc(loc: OnChipCoordinate, ok: bool, message: str):
-    log_check(ok, f"{loc._device._id} {loc.to_user_str()}: {message}")
 
 
 @dataclass
@@ -84,7 +80,7 @@ class EthCore(ABC):
             if read_data != previous_data:
                 return True
             previous_data = read_data
-        log_check_with_loc(self.location, False, f"No heartbeat detected for {self.location.to_user_str()}")
+        log_check_location(self.location, False, f"No heartbeat detected for {self.location.to_user_str()}")
         return False
 
     def get_results(self):
@@ -103,13 +99,13 @@ class EthCore(ABC):
                 output.port_status = "Unknown"
             else:
                 output.port_status = port_status_str
-            log_check_with_loc(self.location, port_status_str != "Down", f"{self.location.to_user_str()} port is down")
+            log_check_location(self.location, port_status_str != "Down", f"{self.location.to_user_str()} port is down")
 
         # RETRAIN COUNT
         output.retrain_count = int(
             read_word_from_device(self.location, self.eth_core_definitions.retrain_count, context=self.context)
         )
-        log_check_with_loc(
+        log_check_location(
             self.location,
             not output.retrain_count,
             f"{self.location.to_user_str()} retrain count is {output.retrain_count}",
@@ -121,7 +117,7 @@ class EthCore(ABC):
             if read_word_from_device(self.location, self.eth_core_definitions.rx_link_up, context=self.context)
             else "Down"
         )
-        log_check_with_loc(
+        log_check_location(
             self.location,
             output.rx_link_up == "Up",
             f"{self.location.to_user_str()} rx link is not up: {output.rx_link_up}",
@@ -139,7 +135,7 @@ class EthCore(ABC):
                 output.mailbox.append(f"0x{mailbox_value:08X}")
                 if mailbox_value & 0xFFFF0000 == 0xCA110000:
                     any_pending_message = True
-                log_check_with_loc(
+                log_check_location(
                     self.location,
                     not any_pending_message,
                     f"{self.location.to_user_str()} mailbox: {output.mailbox} (pending message)",

--- a/tools/triage/check_noc_locations.py
+++ b/tools/triage/check_noc_locations.py
@@ -14,7 +14,7 @@ Description:
 from ttexalens.coordinate import OnChipCoordinate
 from run_checks import run as get_run_checks
 from ttexalens.context import Context
-from triage import ScriptConfig, log_check, run_script
+from triage import ScriptConfig, log_check_location, run_script
 
 script_config = ScriptConfig(
     depends=["run_checks"],
@@ -29,9 +29,10 @@ def check_noc_location(location: OnChipCoordinate, noc_id: int):
     n_x = data & 0x3F
     n_y = (data >> 6) & 0x3F
     loc_to_noc = location.to(noc_str)
-    log_check(
+    log_check_location(
+        location,
         loc_to_noc == (n_x, n_y),
-        f"Device {location._device._id} {location._device.get_block_type(location)} [{location.to_str('logical')}] block at {location.to_str(noc_str)} has wrong NOC location ({n_x}-{n_y})",
+        f"block at {location.to_str(noc_str)} has wrong NOC location ({n_x}-{n_y})",
     )
 
 

--- a/tools/triage/check_noc_status.py
+++ b/tools/triage/check_noc_status.py
@@ -42,7 +42,7 @@ def check_noc_status(
     fw_elf_path = dispatcher_data.get_core_data(location, risc_name).firmware_path
     fw_elf = elfs_cache[fw_elf_path]
 
-    message = f"Device {location._device._id} at {location.to_user_str()} on {risc_name} for NOC {noc_id}\n"
+    message = f"{risc_name} NOC{noc_id}: "
     passed = True
 
     loc_mem_access = MemoryAccess.get(location.noc_block.get_risc_debug(risc_name))

--- a/tools/triage/check_noc_status.py
+++ b/tools/triage/check_noc_status.py
@@ -19,7 +19,7 @@ from ttexalens.tt_exalens_lib import read_tensix_register
 from dispatcher_data import run as get_dispatcher_data, DispatcherData
 from elfs_cache import run as get_elfs_cache, ElfsCache
 from run_checks import run as get_run_checks
-from triage import ScriptConfig, log_check, run_script
+from triage import ScriptConfig, log_check_location, run_script
 
 script_config = ScriptConfig(
     depends=["run_checks", "dispatcher_data", "elfs_cache"],
@@ -64,7 +64,7 @@ def check_noc_status(
             message += f"    {reg} {var} {reg_val} {var_val}\n"
             passed = False
 
-    log_check(passed, message)
+    log_check_location(location, passed, message)
 
 
 def run(args, context: Context):

--- a/tools/triage/dispatcher_data.py
+++ b/tools/triage/dispatcher_data.py
@@ -17,7 +17,7 @@ import os
 
 from inspector_data import run as get_inspector_data, InspectorData
 from elfs_cache import run as get_elfs_cache, ElfsCache
-from triage import triage_singleton, ScriptConfig, run_script, log_check
+from triage import triage_singleton, ScriptConfig, run_script, log_check_location
 from ttexalens.coordinate import OnChipCoordinate
 from ttexalens.elf import MemoryAccess
 from ttexalens.context import Context
@@ -211,9 +211,10 @@ class DispatcherData:
         # Refer to tt_metal/api/tt-metalium/dev_msgs.h for struct kernel_config_msg_t
         launch_msg_rd_ptr = mailboxes.launch_msg_rd_ptr
 
-        log_check(
+        log_check_location(
+            location,
             launch_msg_rd_ptr < self._launch_msg_buffer_num_entries,
-            f"On device {location.device_id} at {location.to_user_str()}, launch message read pointer {launch_msg_rd_ptr} >= {self._launch_msg_buffer_num_entries}.",
+            f"launch message read pointer {launch_msg_rd_ptr} >= {self._launch_msg_buffer_num_entries}.",
         )
 
         previous_launch_msg_rd_ptr = (launch_msg_rd_ptr - 1) % self._launch_msg_buffer_num_entries

--- a/tools/triage/dump_callstacks.py
+++ b/tools/triage/dump_callstacks.py
@@ -24,7 +24,7 @@ Description:
 
 from dataclasses import dataclass
 
-from triage import ScriptConfig, TTTriageError, log_check_core, recurse_field, triage_field, hex_serializer, run_script
+from triage import ScriptConfig, TTTriageError, log_check_risc, recurse_field, triage_field, hex_serializer, run_script
 from ttexalens import util
 from ttexalens.hw.tensix.wormhole.wormhole import WormholeDevice
 from dispatcher_data import run as get_dispatcher_data, DispatcherData, DispatcherCoreData
@@ -270,9 +270,9 @@ def dump_callstacks(
         )
 
     except Exception as e:
-        log_check_core(
-            location,
+        log_check_risc(
             risc_name,
+            location,
             False,
             f"{ORANGE}Failed to dump callstacks: {e}{RST}",
         )

--- a/tools/triage/dump_callstacks.py
+++ b/tools/triage/dump_callstacks.py
@@ -24,7 +24,7 @@ Description:
 
 from dataclasses import dataclass
 
-from triage import ScriptConfig, TTTriageError, log_check, recurse_field, triage_field, hex_serializer, run_script
+from triage import ScriptConfig, TTTriageError, log_check_core, recurse_field, triage_field, hex_serializer, run_script
 from ttexalens import util
 from ttexalens.hw.tensix.wormhole.wormhole import WormholeDevice
 from dispatcher_data import run as get_dispatcher_data, DispatcherData, DispatcherCoreData
@@ -270,9 +270,11 @@ def dump_callstacks(
         )
 
     except Exception as e:
-        log_check(
+        log_check_core(
+            location,
+            risc_name,
             False,
-            f"{ORANGE}Failed to dump callstacks for {risc_name} at {location} on device {location._device._id}: {e}{RST}",
+            f"{ORANGE}Failed to dump callstacks: {e}{RST}",
         )
         return result
 

--- a/tools/triage/triage.py
+++ b/tools/triage/triage.py
@@ -423,7 +423,7 @@ def log_check_location(location: OnChipCoordinate, success: bool, message: str) 
     log_check_device(device, success, formatted_message)
 
 
-def log_check_core(location: OnChipCoordinate, risc_name: str, success: bool, message: str) -> None:
+def log_check_risc(risc_name: str, location: OnChipCoordinate, success: bool, message: str) -> None:
     formatted_message = f"{risc_name}: {message}"
     log_check_location(location, success, formatted_message)
 

--- a/tools/triage/triage.py
+++ b/tools/triage/triage.py
@@ -410,6 +410,24 @@ def log_check(success: bool, message: str) -> None:
         FAILURE_CHECKS.append(message)
 
 
+def log_check_device(device: Device, success: bool, message: str) -> None:
+    formatted_message = f"Device {device._id}: {message}"
+    log_check(success, formatted_message)
+
+
+def log_check_location(location: OnChipCoordinate, success: bool, message: str) -> None:
+    device = location.device
+    block_type = device.get_block_type(location)
+    location_str = location.to_user_str()
+    formatted_message = f"{block_type} [{location_str}]: {message}"
+    log_check_device(device, success, formatted_message)
+
+
+def log_check_core(location: OnChipCoordinate, risc_name: str, success: bool, message: str) -> None:
+    formatted_message = f"{risc_name}: {message}"
+    log_check_location(location, success, formatted_message)
+
+
 def serialize_result(script: TriageScript | None, result):
     from dataclasses import fields, is_dataclass
 


### PR DESCRIPTION
### Ticket
\

### Problem description
Refactor log_check into device/location/core-specific functions for better context in error messages

### What's changed
Added three logging functions that format device/location/core context.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes