### PR TITLE
[tt-train] Fix deprecated CoreRangeSet and CoreCoord usage in tt-train

### DIFF
--- a/tt-train/sources/ttml/metal/ops/cross_entropy_bw/device/cross_entropy_bw_program_factory.cpp
+++ b/tt-train/sources/ttml/metal/ops/cross_entropy_bw/device/cross_entropy_bw_program_factory.cpp
@@ -88,7 +88,7 @@ void assign_per_core_runtime_args(
     const tt::tt_metal::CoreRangeSet& core_group_1,
     const tt::tt_metal::CoreRangeSet& core_group_2) {
     for (uint32_t i = 0, num_rows_written = 0; i < num_cores; i++) {
-        CoreCoord core = {i / num_cores_y, i % num_cores_y};
+        tt::tt_metal::CoreCoord core = {i / num_cores_y, i % num_cores_y};
 
         // Determine how many rows this core will process
         uint32_t num_rows_per_core = 0;
@@ -397,7 +397,7 @@ void CrossEntropyBackwardProgramFactory::override_runtime_arguments(
                                                       : GetRuntimeArgs(program, cross_entropy_bw_kernel_group_2_id);
 
     for (uint32_t i = 0; i < num_cores; i++) {
-        CoreCoord core = {i / num_cores_y, i % num_cores_y};
+        tt::tt_metal::CoreCoord core = {i / num_cores_y, i % num_cores_y};
 
         // Update input buffers for the reader kernel
         {

--- a/tt-train/sources/ttml/metal/ops/cross_entropy_bw/device/cross_entropy_bw_program_factory.hpp
+++ b/tt-train/sources/ttml/metal/ops/cross_entropy_bw/device/cross_entropy_bw_program_factory.hpp
@@ -15,8 +15,8 @@ struct CrossEntropyBackwardProgramFactory {
         tt::tt_metal::KernelHandle writer_kernel_id;
         tt::tt_metal::KernelHandle compute_kernel_group_1_id;
         tt::tt_metal::KernelHandle compute_kernel_group_2_id;
-        CoreRangeSet core_group_1;
-        CoreRangeSet core_group_2;
+        tt::tt_metal::CoreRangeSet core_group_1;
+        tt::tt_metal::CoreRangeSet core_group_2;
         uint32_t num_cores{};
         uint32_t num_cores_y{};
     };

--- a/tt-train/sources/ttml/metal/ops/cross_entropy_fw/device/cross_entropy_fw_program_factory.cpp
+++ b/tt-train/sources/ttml/metal/ops/cross_entropy_fw/device/cross_entropy_fw_program_factory.cpp
@@ -94,7 +94,7 @@ void assign_per_core_runtime_args(
     const tt::tt_metal::CoreRangeSet& core_group_1,
     const tt::tt_metal::CoreRangeSet& core_group_2) {
     for (uint32_t i = 0, num_rows_written = 0; i < num_cores; i++) {
-        CoreCoord core = {i / num_cores_y, i % num_cores_y};
+        tt::tt_metal::CoreCoord core = {i / num_cores_y, i % num_cores_y};
 
         // Determine how many rows this core will process
         uint32_t num_rows_per_core = 0;
@@ -407,7 +407,7 @@ void CrossEntropyForwardProgramFactory::override_runtime_arguments(
                                                       : GetRuntimeArgs(program, cross_entropy_fw_kernel_group_2_id);
 
     for (uint32_t i = 0; i < num_cores; i++) {
-        CoreCoord core = {i / num_cores_y, i % num_cores_y};
+        tt::tt_metal::CoreCoord core = {i / num_cores_y, i % num_cores_y};
 
         // Update input buffers for the reader kernel
         {

--- a/tt-train/sources/ttml/metal/ops/cross_entropy_fw/device/cross_entropy_fw_program_factory.hpp
+++ b/tt-train/sources/ttml/metal/ops/cross_entropy_fw/device/cross_entropy_fw_program_factory.hpp
@@ -15,8 +15,8 @@ struct CrossEntropyForwardProgramFactory {
         tt::tt_metal::KernelHandle writer_kernel_id;
         tt::tt_metal::KernelHandle compute_kernel_group_1_id;
         tt::tt_metal::KernelHandle compute_kernel_group_2_id;
-        CoreRangeSet core_group_1;
-        CoreRangeSet core_group_2;
+        tt::tt_metal::CoreRangeSet core_group_1;
+        tt::tt_metal::CoreRangeSet core_group_2;
         uint32_t num_cores{};
         uint32_t num_cores_y{};
     };

--- a/tt-train/sources/ttml/metal/ops/profiler_no_op/device/profiler_no_op_program_factory.cpp
+++ b/tt-train/sources/ttml/metal/ops/profiler_no_op/device/profiler_no_op_program_factory.cpp
@@ -57,7 +57,7 @@ void assign_per_core_runtime_args(
     const tt::tt_metal::CoreRangeSet& core_group_1,
     const tt::tt_metal::CoreRangeSet& core_group_2) {
     for (uint32_t i = 0, num_rows_written = 0; i < num_cores; i++) {
-        CoreCoord core = {i / num_cores_y, i % num_cores_y};
+        tt::tt_metal::CoreCoord core = {i / num_cores_y, i % num_cores_y};
 
         // Determine how many rows this core will process
         uint32_t num_rows_per_core = 0;
@@ -215,7 +215,7 @@ void ProfilerNoopProgramFactory::override_runtime_arguments(
     auto& writer_runtime_args = GetRuntimeArgs(program, profiler_no_op_writer_kernel_id);
 
     for (uint32_t i = 0; i < num_cores; i++) {
-        CoreCoord core = {i / num_cores_y, i % num_cores_y};
+        tt::tt_metal::CoreCoord core = {i / num_cores_y, i % num_cores_y};
 
         // Update input buffers for the reader kernel
         {

--- a/tt-train/sources/ttml/metal/ops/profiler_no_op/device/profiler_no_op_program_factory.hpp
+++ b/tt-train/sources/ttml/metal/ops/profiler_no_op/device/profiler_no_op_program_factory.hpp
@@ -13,8 +13,8 @@ struct ProfilerNoopProgramFactory {
     struct shared_variables_t {
         tt::tt_metal::KernelHandle reader_kernel_id;
         tt::tt_metal::KernelHandle writer_kernel_id;
-        CoreRangeSet core_group_1;
-        CoreRangeSet core_group_2;
+        tt::tt_metal::CoreRangeSet core_group_1;
+        tt::tt_metal::CoreRangeSet core_group_2;
         uint32_t num_cores{};
         uint32_t num_cores_y{};
     };

--- a/tt-train/sources/ttml/metal/ops/rmsnorm_bw/device/rmsnorm_bw_program_factory.cpp
+++ b/tt-train/sources/ttml/metal/ops/rmsnorm_bw/device/rmsnorm_bw_program_factory.cpp
@@ -86,7 +86,7 @@ void assign_per_core_runtime_args(
     const tt::tt_metal::CoreRangeSet& core_group_1,
     const tt::tt_metal::CoreRangeSet& core_group_2) {
     for (uint32_t i = 0, num_rows_written = 0; i < num_cores; i++) {
-        CoreCoord core = {i / num_cores_y, i % num_cores_y};
+        tt::tt_metal::CoreCoord core = {i / num_cores_y, i % num_cores_y};
 
         // Determine how many rows this core will process
         uint32_t num_rows_per_core = 0;
@@ -410,7 +410,7 @@ void RMSNormBackwardProgramFactory::override_runtime_arguments(
     auto& writer_runtime_args = GetRuntimeArgs(program, rmsnorm_bw_writer_kernel_id);
 
     for (uint32_t i = 0; i < num_cores; i++) {
-        CoreCoord core = {i / num_cores_y, i % num_cores_y};
+        tt::tt_metal::CoreCoord core = {i / num_cores_y, i % num_cores_y};
 
         // Update input buffers for the reader kernel
         {

--- a/tt-train/sources/ttml/metal/ops/rmsnorm_bw/device/rmsnorm_bw_program_factory.hpp
+++ b/tt-train/sources/ttml/metal/ops/rmsnorm_bw/device/rmsnorm_bw_program_factory.hpp
@@ -15,8 +15,8 @@ struct RMSNormBackwardProgramFactory {
         tt::tt_metal::KernelHandle rmsnorm_bw_writer_kernel_id;
         tt::tt_metal::KernelHandle rmsnorm_bw_kernel_group_1_id;
         tt::tt_metal::KernelHandle rmsnorm_bw_kernel_group_2_id;
-        CoreRangeSet core_group_1;
-        CoreRangeSet core_group_2;
+        tt::tt_metal::CoreRangeSet core_group_1;
+        tt::tt_metal::CoreRangeSet core_group_2;
         uint32_t num_cores{};
         uint32_t num_cores_y{};
     };

--- a/tt-train/sources/ttml/metal/ops/rmsnorm_fw/device/rmsnorm_fw_program_factory.cpp
+++ b/tt-train/sources/ttml/metal/ops/rmsnorm_fw/device/rmsnorm_fw_program_factory.cpp
@@ -90,7 +90,7 @@ void assign_per_core_runtime_args(
     const tt::tt_metal::CoreRangeSet& core_group_1,
     const tt::tt_metal::CoreRangeSet& core_group_2) {
     for (uint32_t i = 0, num_rows_written = 0; i < num_cores; i++) {
-        CoreCoord core = {i / num_cores_y, i % num_cores_y};
+        tt::tt_metal::CoreCoord core = {i / num_cores_y, i % num_cores_y};
 
         // Determine how many rows this core will process
         uint32_t num_rows_per_core = 0;
@@ -400,7 +400,7 @@ void RMSNormForwardProgramFactory::override_runtime_arguments(
         core_group_2.ranges().empty() ? group_1_runtime_args : GetRuntimeArgs(program, rmsnorm_fw_group_2_kernel);
 
     for (uint32_t i = 0; i < num_cores; i++) {
-        CoreCoord core = {i / num_cores_y, i % num_cores_y};
+        tt::tt_metal::CoreCoord core = {i / num_cores_y, i % num_cores_y};
 
         // Update input buffers for the reader kernel
         {

--- a/tt-train/sources/ttml/metal/ops/rmsnorm_fw/device/rmsnorm_fw_program_factory.hpp
+++ b/tt-train/sources/ttml/metal/ops/rmsnorm_fw/device/rmsnorm_fw_program_factory.hpp
@@ -15,8 +15,8 @@ struct RMSNormForwardProgramFactory {
         tt::tt_metal::KernelHandle rmsnorm_fw_writer_kernel_id;
         tt::tt_metal::KernelHandle rmsnorm_fw_kernel_group_1_id;
         tt::tt_metal::KernelHandle rmsnorm_fw_kernel_group_2_id;
-        CoreRangeSet core_group_1;
-        CoreRangeSet core_group_2;
+        tt::tt_metal::CoreRangeSet core_group_1;
+        tt::tt_metal::CoreRangeSet core_group_2;
         uint32_t num_cores{};
         uint32_t num_cores_y{};
     };

--- a/tt-train/sources/ttml/metal/ops/sdpa_fw/device/sdpa_fw_program_factory.cpp
+++ b/tt-train/sources/ttml/metal/ops/sdpa_fw/device/sdpa_fw_program_factory.cpp
@@ -484,7 +484,7 @@ void SDPAForwardProgramFactory::override_runtime_arguments(
     auto& writer_runtime_args = GetRuntimeArgs(program, sdpa_fw_writer_kernel);
 
     for (uint32_t i = 0; i < num_cores; ++i) {
-        CoreCoord core = {i / num_cores_y, i % num_cores_y};
+        tt::tt_metal::CoreCoord core = {i / num_cores_y, i % num_cores_y};
 
         // Update input buffers for the reader kernel
         {

--- a/tt-train/sources/ttml/metal/ops/sdpa_fw/device/sdpa_fw_program_factory.hpp
+++ b/tt-train/sources/ttml/metal/ops/sdpa_fw/device/sdpa_fw_program_factory.hpp
@@ -15,8 +15,8 @@ struct SDPAForwardProgramFactory {
         tt::tt_metal::KernelHandle sdpa_fw_writer_kernel;
         tt::tt_metal::KernelHandle sdpa_fw_kernel_group_1;
         tt::tt_metal::KernelHandle sdpa_fw_kernel_group_2;
-        CoreRangeSet core_group_1;
-        CoreRangeSet core_group_2;
+        tt::tt_metal::CoreRangeSet core_group_1;
+        tt::tt_metal::CoreRangeSet core_group_2;
         uint32_t num_cores{};
         uint32_t num_cores_y{};
     };

--- a/tt-train/sources/ttml/metal/ops/silu_bw/device/silu_bw_program_factory.cpp
+++ b/tt-train/sources/ttml/metal/ops/silu_bw/device/silu_bw_program_factory.cpp
@@ -62,7 +62,7 @@ void assign_per_core_runtime_args(
     const tt::tt_metal::CoreRangeSet& core_group_1,
     const tt::tt_metal::CoreRangeSet& core_group_2) {
     for (uint32_t i = 0, num_rows_written = 0; i < num_cores; i++) {
-        CoreCoord core = {i / num_cores_y, i % num_cores_y};
+        tt::tt_metal::CoreCoord core = {i / num_cores_y, i % num_cores_y};
 
         // Determine how many rows this core will process
         uint32_t num_rows_per_core = 0;
@@ -256,7 +256,7 @@ void SiLUBackwardProgramFactory::override_runtime_arguments(
     auto& writer_runtime_args = GetRuntimeArgs(program, silu_bw_writer_kernel_id);
 
     for (uint32_t i = 0; i < num_cores; i++) {
-        CoreCoord core = {i / num_cores_y, i % num_cores_y};
+        tt::tt_metal::CoreCoord core = {i / num_cores_y, i % num_cores_y};
 
         // Update input buffers for the reader kernel
         {

--- a/tt-train/sources/ttml/metal/ops/silu_bw/device/silu_bw_program_factory.hpp
+++ b/tt-train/sources/ttml/metal/ops/silu_bw/device/silu_bw_program_factory.hpp
@@ -15,8 +15,8 @@ struct SiLUBackwardProgramFactory {
         tt::tt_metal::KernelHandle silu_bw_writer_kernel_id;
         tt::tt_metal::KernelHandle silu_bw_kernel_group_1_id;
         tt::tt_metal::KernelHandle silu_bw_kernel_group_2_id;
-        CoreRangeSet core_group_1;
-        CoreRangeSet core_group_2;
+        tt::tt_metal::CoreRangeSet core_group_1;
+        tt::tt_metal::CoreRangeSet core_group_2;
         uint32_t num_cores{};
         uint32_t num_cores_y{};
     };

--- a/tt-train/sources/ttml/metal/ops/softmax/device/softmax_program_factory.cpp
+++ b/tt-train/sources/ttml/metal/ops/softmax/device/softmax_program_factory.cpp
@@ -83,7 +83,7 @@ void assign_per_core_runtime_args(
     const tt::tt_metal::CoreRangeSet& core_group_1,
     const tt::tt_metal::CoreRangeSet& core_group_2) {
     for (uint32_t i = 0, num_rows_written = 0; i < num_cores; i++) {
-        CoreCoord core = {i / num_cores_y, i % num_cores_y};
+        tt::tt_metal::CoreCoord core = {i / num_cores_y, i % num_cores_y};
 
         // Determine how many rows this core will process
         uint32_t num_rows_per_core = 0;
@@ -354,7 +354,7 @@ void SoftmaxProgramFactory::override_runtime_arguments(
     auto& writer_runtime_args = GetRuntimeArgs(program, softmax_writer_kernel_id);
 
     for (uint32_t i = 0; i < num_cores; i++) {
-        CoreCoord core = {i / num_cores_y, i % num_cores_y};
+        tt::tt_metal::CoreCoord core = {i / num_cores_y, i % num_cores_y};
 
         // Update input buffers for the reader kernel
         {

--- a/tt-train/sources/ttml/metal/ops/softmax/device/softmax_program_factory.hpp
+++ b/tt-train/sources/ttml/metal/ops/softmax/device/softmax_program_factory.hpp
@@ -15,8 +15,8 @@ struct SoftmaxProgramFactory {
         tt::tt_metal::KernelHandle writer_kernel_id;
         tt::tt_metal::KernelHandle compute_kernel_group_1_id;
         tt::tt_metal::KernelHandle compute_kernel_group_2_id;
-        CoreRangeSet core_group_1;
-        CoreRangeSet core_group_2;
+        tt::tt_metal::CoreRangeSet core_group_1;
+        tt::tt_metal::CoreRangeSet core_group_2;
         uint32_t num_cores{};
         uint32_t num_cores_y{};
     };

--- a/tt-train/sources/ttml/metal/optimizers/sgd_fused/device/sgd_fused_program_factory.cpp
+++ b/tt-train/sources/ttml/metal/optimizers/sgd_fused/device/sgd_fused_program_factory.cpp
@@ -119,7 +119,7 @@ void assign_per_core_runtime_args(
     const bool use_dampening = !(bfloat_one_minus_dampening == bfloat16(1.0F));
 
     for (uint32_t i = 0, num_tiles_written = 0; i < num_cores; i++) {
-        CoreCoord core = {i / num_cores_y, i % num_cores_y};
+        tt::tt_metal::CoreCoord core = {i / num_cores_y, i % num_cores_y};
 
         // Determine how many tiles this core will process
         uint32_t num_tiles_per_core = 0;
@@ -436,7 +436,7 @@ void SGDFusedProgramFactory::override_runtime_arguments(
     const bool use_dampening = !(bfloat_one_minus_dampening == bfloat16(1.0F));
 
     for (uint32_t i = 0; i < num_cores; i++) {
-        CoreCoord core = {i / num_cores_y, i % num_cores_y};
+        tt::tt_metal::CoreCoord core = {i / num_cores_y, i % num_cores_y};
 
         // Update input buffers for the reader kernel
         {

--- a/tt-train/sources/ttml/metal/optimizers/sgd_fused/device/sgd_fused_program_factory.hpp
+++ b/tt-train/sources/ttml/metal/optimizers/sgd_fused/device/sgd_fused_program_factory.hpp
@@ -15,8 +15,8 @@ struct SGDFusedProgramFactory {
         tt::tt_metal::KernelHandle writer_kernel_id;
         tt::tt_metal::KernelHandle compute_kernel_group_1_id;
         tt::tt_metal::KernelHandle compute_kernel_group_2_id;
-        CoreRangeSet core_group_1;
-        CoreRangeSet core_group_2;
+        tt::tt_metal::CoreRangeSet core_group_1;
+        tt::tt_metal::CoreRangeSet core_group_2;
         uint32_t num_cores{};
         uint32_t num_cores_y{};
     };


### PR DESCRIPTION
### Summary
Fixes compilation warnings by adding the `tt::tt_metal::` namespace prefix to deprecated `CoreRangeSet` and `CoreCoord` usage in tt-train.

### Changes
- Replace `CoreRangeSet` with `tt::tt_metal::CoreRangeSet` in program factory header files
- Replace `CoreCoord` with `tt::tt_metal::CoreCoord` in program factory source files
- Resolves deprecation warnings:
  - "CoreRangeSet is deprecated: Use tt::tt_metal::CoreRangeSet"
  - "CoreCoord is deprecated: Use tt::tt_metal::CoreCoord"

### Files Modified
- Header files: `sources/ttml/metal/ops/*/device/*_program_factory.hpp` (8 files)
- Source files: `sources/ttml/metal/ops/*/device/*_program_factory.cpp` (multiple files)
- Optimizer: `sources/ttml/metal/optimizers/sgd_fused/device/sgd_fused_program_factory.*`

No functional changes, only namespace prefix additions for type compliance.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)