### PR TITLE
Int8 Matmul test

### DIFF
--- a/tests/tt_metal/tt_metal/llk/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/llk/CMakeLists.txt
@@ -9,6 +9,7 @@ set(UNIT_TESTS_LLK_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/test_sfpu_compute.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_single_core_binary_compute.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_single_core_matmul_compute.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_single_core_matmul_int8.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_transpose.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_unary_broadcast.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_untilize_tilize.cpp

--- a/tests/tt_metal/tt_metal/llk/test_single_core_matmul_int8.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_single_core_matmul_int8.cpp
@@ -1,0 +1,230 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <chrono>
+#include <fmt/base.h>
+#include <gtest/gtest.h>
+#include <stdint.h>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/tt_metal.hpp>
+#include <unistd.h>
+#include <functional>
+#include <random>
+#include <map>
+#include <memory>
+#include <ostream>
+#include <utility>
+#include <variant>
+#include <vector>
+
+#include <tt-metalium/bfloat16.hpp>
+#include <tt-metalium/buffer.hpp>
+#include <tt-metalium/buffer_types.hpp>
+#include <tt-metalium/circular_buffer_config.hpp>
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/data_types.hpp>
+#include "device_fixture.hpp"
+#include <tt-metalium/kernel_types.hpp>
+#include <tt-logger/tt-logger.hpp>
+#include <tt-metalium/program.hpp>
+#include <tt_stl/span.hpp>
+#include <tt-metalium/tt_backend_api_types.hpp>
+#include "tt_metal/test_utils/comparison.hpp"
+#include "tt_metal/test_utils/df/float32.hpp"
+#include "tt_metal/test_utils/packing.hpp"
+#include "tt_metal/test_utils/print_helpers.hpp"
+#include "tt_metal/test_utils/stimulus.hpp"
+
+namespace tt::tt_metal {
+
+using namespace tt;
+using namespace tt::test_utils;
+using namespace tt::test_utils::df;
+
+namespace unit_tests::compute::matmul {
+
+std::vector<int8_t> generate_uniform_int8(size_t num_elements, int8_t min, int8_t max, uint32_t seed = 0) {
+    std::vector<int8_t> random_array(num_elements);
+
+    std::mt19937 gen(seed);
+    std::uniform_int_distribution<int16_t> distrib(min, max);
+
+    for (int i = 0; i < num_elements; i++) {
+        random_array[i] = static_cast<int8_t>(distrib(gen));
+    }
+
+    return random_array;
+}
+
+void convert_to_sign_mag(std::vector<int8_t>& vec) {
+    for (int i = 0; i < vec.size(); i++) {
+        int8_t temp = vec[i];
+        if (temp < 0) {
+            if (temp == -128) {
+                temp = -127;
+            }
+            temp = (~temp) + 1;
+            temp = temp | 0x80;
+            vec[i] = temp;
+        }
+    }
+}
+
+int get_output_coordinate(int x, int y) {
+    int offset = ((x < 16) ? 0 : 256) + ((y < 16) ? 0 : 512);
+    return offset + (y % 16) * 16 + (x % 16);
+}
+
+bool single_tile_matmul_int8(tt_metal::IDevice* device) {
+    bool pass = true;
+
+    CoreCoord core(0, 0);
+    const uint32_t in0_cb_index = 0;
+    const uint32_t in1_cb_index = 1;
+    const uint32_t out_cb_index = 16;
+    const size_t tile_size = 1 * 1 * 32 * 32;
+    const size_t byte_size = 1 * tile_size;
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Application Setup
+    ////////////////////////////////////////////////////////////////////////////
+    tt::tt_metal::InterleavedBufferConfig dram_config{
+        .device = device, .size = byte_size, .page_size = byte_size, .buffer_type = tt::tt_metal::BufferType::DRAM};
+
+    tt_metal::Program program = tt_metal::CreateProgram();
+    auto input0_dram_buffer = CreateBuffer(dram_config);
+    const uint32_t in0_dram_addr = input0_dram_buffer->address();
+    auto input1_dram_buffer = CreateBuffer(dram_config);
+    const uint32_t in1_dram_addr = input1_dram_buffer->address();
+    auto output_dram_buffer = CreateBuffer(dram_config);
+    const uint32_t out_dram_addr = output_dram_buffer->address();
+
+    tt_metal::CircularBufferConfig l1_input0_cb_config =
+        tt_metal::CircularBufferConfig(byte_size, {{in0_cb_index, tt::DataFormat::Int8}})
+            .set_page_size(in0_cb_index, byte_size);
+    auto l1_input0_cb = tt_metal::CreateCircularBuffer(program, core, l1_input0_cb_config);
+
+    tt_metal::CircularBufferConfig l1_input1_cb_config =
+        tt_metal::CircularBufferConfig(byte_size, {{in1_cb_index, tt::DataFormat::Int8}})
+            .set_page_size(in1_cb_index, byte_size);
+    auto l1_input1_cb = tt_metal::CreateCircularBuffer(program, core, l1_input1_cb_config);
+
+    tt_metal::CircularBufferConfig l1_output_cb_config =
+        tt_metal::CircularBufferConfig(byte_size, {{out_cb_index, tt::DataFormat::Int8}})
+            .set_page_size(out_cb_index, byte_size);
+    auto l1_output_cb = tt_metal::CreateCircularBuffer(program, core, l1_output_cb_config);
+
+    auto reader_kernel = tt_metal::CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/test_kernels/compute/unit_tests/matmul/reader_binary.cpp",
+        core,
+        tt_metal::DataMovementConfig{
+            .processor = tt_metal::DataMovementProcessor::RISCV_1,
+            .noc = tt_metal::NOC::RISCV_1_default,
+            .compile_args = {in0_cb_index, in1_cb_index}});
+
+    auto writer_kernel = tt_metal::CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/test_kernels/compute/unit_tests/matmul/writer_unary.cpp",
+        core,
+        tt_metal::DataMovementConfig{
+            .processor = tt_metal::DataMovementProcessor::RISCV_0,
+            .noc = tt_metal::NOC::RISCV_0_default,
+            .compile_args = {out_cb_index}});
+
+    auto simple_matmul_kernel = tt_metal::CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/test_kernels/compute/unit_tests/matmul/single_tile_compute.cpp",
+        core,
+        tt_metal::ComputeConfig{.fp32_dest_acc_en = true, .compile_args = {in0_cb_index, in1_cb_index, out_cb_index}});
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Stimulus Generation
+    ////////////////////////////////////////////////////////////////////////////
+    int8_t min = -5, max = 5;
+    std::vector<int8_t> input_0 = generate_uniform_int8(tile_size, min, max, 0 /*seed*/);
+    std::vector<int8_t> input_1 = generate_uniform_int8(tile_size, min, max, 1 /*different seed*/);
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Golden Generation
+    ////////////////////////////////////////////////////////////////////////////
+    std::vector<int32_t> golden_output_int32(tile_size, 0);
+    std::vector<int8_t> golden_output(tile_size, 0);
+    // matmul
+    for (int x = 0; x < 32; x++) {
+        for (int y = 0; y < 32; y++) {
+            for (int z = 0; z < 32; z++) {
+                golden_output_int32[get_output_coordinate(x, y)] +=
+                    (int32_t)input_0[get_output_coordinate(z, y)] * (int32_t)input_1[get_output_coordinate(x, z)];
+            }
+        }
+    }
+    // clamping to int8
+    for (int i = 0; i < 1024; i++) {
+        if (golden_output_int32[i] > 127) {
+            golden_output_int32[i] = 127;
+        } else if (golden_output_int32[i] < -127) {
+            golden_output_int32[i] = -127;
+        }
+        golden_output[i] = static_cast<int8_t>(golden_output_int32[i]);
+    }
+    convert_to_sign_mag(golden_output);
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Compile and Execute Application
+    ////////////////////////////////////////////////////////////////////////////
+
+    convert_to_sign_mag(input_0);
+    tt_metal::detail::WriteToBuffer(input0_dram_buffer, input_0);
+    convert_to_sign_mag(input_1);
+    tt_metal::detail::WriteToBuffer(input1_dram_buffer, input_1);
+
+    tt_metal::SetRuntimeArgs(
+        program,
+        reader_kernel,
+        core,
+        {
+            (uint32_t)in0_dram_addr,
+            (uint32_t)0,  // in_0 dram bank id
+            (uint32_t)in1_dram_addr,
+            (uint32_t)0,
+            (uint32_t)1,  // num_tiles
+        });
+    tt_metal::SetRuntimeArgs(
+        program,
+        writer_kernel,
+        core,
+        {
+            (uint32_t)out_dram_addr,
+            (uint32_t)0,
+            (uint32_t)1,  // num_tiles
+        });
+
+    tt_metal::detail::LaunchProgram(device, program);
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Comparison Checking
+    ////////////////////////////////////////////////////////////////////////////
+    std::vector<int8_t> dest_buffer_data;
+    tt_metal::detail::ReadFromBuffer(output_dram_buffer, dest_buffer_data);
+    pass = dest_buffer_data == golden_output;
+
+    for (int i = 0; i < 1024; i++) {
+        if (dest_buffer_data[i] != golden_output[i]) {
+            std::cout << "element " << i << ": " << (uint32_t)dest_buffer_data[i] << " vs. "
+                      << (uint32_t)golden_output[i] << " \n";
+        }
+    }
+
+    return pass;
+}
+
+}  // namespace unit_tests::compute::matmul
+
+TEST_F(DeviceFixture, TensixTestSingleCoreSingleTileComputeMatmulInt8) {
+    for (unsigned int id = 0; id < num_devices_; id++) {
+        ASSERT_TRUE(unit_tests::compute::matmul::single_tile_matmul_int8(this->devices_.at(id)));
+    }
+}
+
+}  // namespace tt::tt_metal

--- a/tt_metal/jit_build/data_format.cpp
+++ b/tt_metal/jit_build/data_format.cpp
@@ -235,6 +235,8 @@ DataFormat get_single_pack_src_format(
             pack_src_format = DataFormat::UInt16;
         } else if (data_format == DataFormat::UInt8) {
             pack_src_format = DataFormat::UInt8;
+        } else if (data_format == DataFormat::Int8) {
+            pack_src_format = DataFormat::Int8;
         } else {
             TT_THROW("No valid conversion from fp32 dest to output format = {}", data_format);
         }


### PR DESCRIPTION
### Ticket
-

### Problem description
Wanted to test int8 matmul

### What's changed
Added test for int8 matmul !!! It doesn't work any more since this branch was old and I just dug it back up !!!!!

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes