### PR TITLE
Revert "#32518: Exclude tensor shape from compile-time args for binary_ng"

### DIFF
--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
@@ -250,12 +250,6 @@ public:
     }
 };
 
-std::uint32_t* copy_common_runtime_args(const tt::tt_metal::Buffer& buffer, std::uint32_t* dst) {
-    const auto src = tt::tt_metal::TensorAccessorArgs(buffer, tensor_accessor::ArgConfig::RuntimeTensorShape)
-                         .get_common_runtime_args();
-    return std::copy(src.begin(), src.end(), dst);
-}
-
 template <typename F>
 void set_or_update_runtime_arguments(
     Program& program,
@@ -770,16 +764,13 @@ BinaryNgDeviceOperation::ProgramFactory::cached_program_t BinaryNgDeviceOperatio
         writer_kernel = KernelName::WriterNoBcastNg;
     }
     std::vector<uint32_t> writer_compile_time_args;
-    std::vector<uint32_t> writer_common_runtime_args;
-    tt::tt_metal::TensorAccessorArgs(*c_buffer, tensor_accessor::ArgConfig::RuntimeTensorShape)
-        .append_to(writer_compile_time_args, writer_common_runtime_args);
+    tt::tt_metal::TensorAccessorArgs(*c_buffer).append_to(writer_compile_time_args);
     writer_compile_time_args.push_back(static_cast<uint32_t>(has_sharding));
     tt::tt_metal::KernelHandle writer_kernel_id = tt_metal::CreateKernel(
         program,
         get_kernel_file_path(writer_kernel, is_sfpu_op, is_where_op),
         all_device_cores,
         tt_metal::WriterDataMovementConfig(writer_compile_time_args, std::move(writer_defines)));
-    tt_metal::SetCommonRuntimeArgs(program, writer_kernel_id, writer_common_runtime_args);
 
     // COMPUTE KERNEL
     bool fp32_dest_acc_en = c_data_format == tt::DataFormat::UInt32 || c_data_format == tt::DataFormat::Int32 ||
@@ -845,19 +836,14 @@ BinaryNgDeviceOperation::ProgramFactory::cached_program_t BinaryNgDeviceOperatio
 
     // READER KERNEL
     std::vector<uint32_t> reader_compile_time_args;
-    std::vector<uint32_t> reader_common_runtime_args;
-    tt::tt_metal::TensorAccessorArgs(*a_buffer, tensor_accessor::ArgConfig::RuntimeTensorShape)
-        .append_to(reader_compile_time_args, reader_common_runtime_args);
-    tt::tt_metal::TensorAccessorArgs(
-        b_buffer != nullptr ? *b_buffer : *a_buffer, tensor_accessor::ArgConfig::RuntimeTensorShape)
-        .append_to(reader_compile_time_args, reader_common_runtime_args);
+    tt::tt_metal::TensorAccessorArgs(*a_buffer).append_to(reader_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(b_buffer != nullptr ? *b_buffer : *a_buffer).append_to(reader_compile_time_args);
     reader_compile_time_args.push_back(static_cast<uint32_t>(has_sharding));
     tt::tt_metal::KernelHandle reader_kernel_id = tt_metal::CreateKernel(
         program,
         get_kernel_file_path(kernel_config.reader_kernel, is_sfpu_op, is_where_op),
         all_device_cores,
         tt_metal::ReaderDataMovementConfig(reader_compile_time_args, std::move(reader_defines)));
-    tt_metal::SetCommonRuntimeArgs(program, reader_kernel_id, reader_common_runtime_args);
 
     auto set_runtime_args = [](Program& program, KernelHandle kernel_id, CoreCoord core, auto&& args) {
         tt_metal::SetRuntimeArgs(program, kernel_id, core, args);
@@ -886,21 +872,6 @@ void BinaryNgDeviceOperation::ProgramFactory::override_runtime_arguments(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
     tensor_return_value_t& c) {
-    auto& program = cached_program.program;
-    auto reader_kernel_id = cached_program.shared_variables.reader_kernel_id;
-    auto writer_kernel_id = cached_program.shared_variables.writer_kernel_id;
-
-    {
-        auto a_buffer = tensor_args.input_tensor_a.buffer();
-        auto b_buffer = tensor_args.input_tensor_b ? tensor_args.input_tensor_b->buffer() : a_buffer;
-        auto c_buffer = c.buffer();
-        auto args = GetCommonRuntimeArgs(program, reader_kernel_id).data();
-        args = CMAKE_UNIQUE_NAMESPACE::copy_common_runtime_args(*a_buffer, args);
-        CMAKE_UNIQUE_NAMESPACE::copy_common_runtime_args(*b_buffer, args);
-        args = GetCommonRuntimeArgs(program, writer_kernel_id).data();
-        CMAKE_UNIQUE_NAMESPACE::copy_common_runtime_args(*c_buffer, args);
-    }
-
     auto update_args = [](Program& program, KernelHandle kernel_id, CoreCoord core, auto&& args) {
         auto& all_args = GetRuntimeArgs(program, kernel_id);
         auto& core_args = all_args.at(core.x).at(core.y);
@@ -908,9 +879,9 @@ void BinaryNgDeviceOperation::ProgramFactory::override_runtime_arguments(
     };
 
     CMAKE_UNIQUE_NAMESPACE::set_or_update_runtime_arguments(
-        program,
-        reader_kernel_id,
-        writer_kernel_id,
+        cached_program.program,
+        cached_program.shared_variables.reader_kernel_id,
+        cached_program.shared_variables.writer_kernel_id,
         cached_program.shared_variables.compute_kernel_id,
         cached_program.shared_variables.cb_src_a,
         cached_program.shared_variables.cb_src_b,


### PR DESCRIPTION
Reverts tenstorrent/tt-metal#32677

Failing APC eltwise tests https://github.com/tenstorrent/tt-metal/actions/runs/19509273923/job/55854738777#step:6:5447