### PR TITLE
Fix Qwen2.5-VL demo for 3B and 7B variants

### DIFF
--- a/models/demos/qwen25_vl/PERF.md
+++ b/models/demos/qwen25_vl/PERF.md
@@ -6,10 +6,11 @@ Performance collected from [demo/demo.py](demo/demo.py) with the `batch-1` test 
 
 This configuration uses bfp4 MLP and bfp8 attention weights for all models.
 
-| Model             | Device      | Speed (t/s/u) | TTFT (ms) |
-|-------------------|-------------|---------------|-----------|
+| Model            | Device       | Speed (t/s/u) | TTFT (ms) |
+|------------------|--------------|---------------|-----------|
 | qwen25_vl-3b     | N150         | 31.85         | 752.11    |
 | qwen25_vl-3b     | N300         | 39.16         | 532.78    |
+| qwen25_vl-7b     | N300         | 33.16         | 910.55    |
 | qwen25_vl-32b    | T3K          | 21.91         | 1445.89   |
 | qwen25_vl-72b    | T3K          | 13.66         | 2723.91   |
 
@@ -17,9 +18,10 @@ This configuration uses bfp4 MLP and bfp8 attention weights for all models.
 
 Note: Vision performance is still undergoing optimization.
 
-| Model             | Device      | Speed (t/s/u) | TTFT (ms) |
-|-------------------|-------------|---------------|-----------|
-| qwen25_vl-3b     | N150         | 204.11        | 17520     |
-| qwen25_vl-3b     | N300         | 200.08        | 17880     |
-| qwen25_vl-32b    | T3K          | 205.84        | 17380     |
-| qwen25_vl-72b    | T3K          | 198.59        | 18010     |
+| Model            | Device       | Speed (t/s/u) | TTFT (ms) |
+|------------------|--------------|---------------|-----------|
+| qwen25_vl-3b     | N150         | 760.67        | 4700      |
+| qwen25_vl-3b     | N300         | 1151.94       | 3110      |
+| qwen25_vl-7b     | N300         | 1150.39       | 3110      |
+| qwen25_vl-32b    | T3K          | 1137.21       | 3150      |
+| qwen25_vl-72b    | T3K          | 818.57        | 4370      |

--- a/models/demos/qwen25_vl/demo/demo.py
+++ b/models/demos/qwen25_vl/demo/demo.py
@@ -481,10 +481,14 @@ def test_demo(
 
         # Start decoding
         iteration = 0
-        argmax_on_device = sampling_params["temperature"] == 0
+        argmax_on_device = model._supports_on_device_sampling
         if argmax_on_device:
+            logger.info(f"Using on-device sampling with temperature=0.0, top_k=-1, top_p=1.0")
             device_sampling_params = SamplingParams(temperature=0.0, top_k=-1, top_p=1.0)
         else:
+            logger.info(
+                f"Using host sampling with temperature={sampling_params['temperature']}, top_p={sampling_params['top_p']}"
+            )
             device_sampling_params = None
 
         users_decoding = True


### PR DESCRIPTION
### Problem description
Qwen2.5-VL demo test in CI is failing due to demo.py not caught up with https://github.com/tenstorrent/tt-metal/pull/31046.

### What's changed
- This PR updates demo.py to check if on-device sampling is enabled.
- Also updated models/demos/qwen_vl/PERF.md
  - Better performance from https://github.com/tenstorrent/tt-metal/pull/31400 optimizing the way we update cos/sin values for each user
  - Added 7B variant's performance numbers

### Checklist
- [x] [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes
  - https://github.com/tenstorrent/tt-metal/actions/runs/19514598687 