### PR TITLE
update fabric microbenchmark pipeline to update bandwidth results to superset

### DIFF
--- a/.github/actions/upload-data-via-sftp/fabric_bandwidth_benchmark_data_batchfile.txt
+++ b/.github/actions/upload-data-via-sftp/fabric_bandwidth_benchmark_data_batchfile.txt
@@ -1,0 +1,2 @@
+put -r generated/fabric/bandwidth_summary_results_*_upload.csv
+ls -hal

--- a/.github/workflows/metal-run-microbenchmarks-impl.yaml
+++ b/.github/workflows/metal-run-microbenchmarks-impl.yaml
@@ -124,8 +124,8 @@ jobs:
         with:
           prefix: "test_reports_"
       - name: Upload benchmark data
-        if: ${{ !cancelled()}}
-        # if: ${{ !cancelled() && steps.save-environment-data.conclusion == 'success' && steps.save-environment-data.outputs.has_benchmark_data == 'true' }}
+        ## Only upload benchmark data for main branch
+        if: ${{ !cancelled() && github.ref_name == 'main' && contains(matrix.test-group.name, 'Fabric BW') }}
         uses: tenstorrent/tt-metal/.github/actions/upload-data-via-sftp@main
         with:
           ssh-private-key: ${{ secrets.SFTP_BENCHMARK_WRITER_KEY }}

--- a/.github/workflows/metal-run-microbenchmarks-impl.yaml
+++ b/.github/workflows/metal-run-microbenchmarks-impl.yaml
@@ -124,3 +124,12 @@ jobs:
         with:
           prefix: "test_reports_"
       - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
+      - name: Upload benchmark data
+        if: ${{ !cancelled() && steps.save-environment-data.conclusion == 'success' && steps.save-environment-data.outputs.has_benchmark_data == 'true' }}
+        uses: tenstorrent/tt-metal/.github/actions/upload-data-via-sftp@main
+        with:
+          ssh-private-key: ${{ secrets.SFTP_BENCHMARK_WRITER_KEY }}
+          sftp-batchfile: /work/.github/actions/upload-data-via-sftp/fabric_bandwidth_benchmark_data_batchfile.txt
+          username: ${{ secrets.SFTP_FABRIC_BENCHMARK_WRITER_USERNAME }}
+          hostname: ${{ secrets.SFTP_FABRIC_BENCHMARK_WRITER_HOSTNAME }}
+          path: /work

--- a/.github/workflows/metal-run-microbenchmarks-impl.yaml
+++ b/.github/workflows/metal-run-microbenchmarks-impl.yaml
@@ -123,9 +123,9 @@ jobs:
         if: ${{ !cancelled() }}
         with:
           prefix: "test_reports_"
-      - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
       - name: Upload benchmark data
-        if: ${{ !cancelled() && steps.save-environment-data.conclusion == 'success' && steps.save-environment-data.outputs.has_benchmark_data == 'true' }}
+        if: ${{ !cancelled()}}
+        # if: ${{ !cancelled() && steps.save-environment-data.conclusion == 'success' && steps.save-environment-data.outputs.has_benchmark_data == 'true' }}
         uses: tenstorrent/tt-metal/.github/actions/upload-data-via-sftp@main
         with:
           ssh-private-key: ${{ secrets.SFTP_BENCHMARK_WRITER_KEY }}
@@ -133,3 +133,4 @@ jobs:
           username: ${{ secrets.SFTP_FABRIC_BENCHMARK_WRITER_USERNAME }}
           hostname: ${{ secrets.SFTP_FABRIC_BENCHMARK_WRITER_HOSTNAME }}
           path: /work
+      - uses: tenstorrent/tt-metal/.github/actions/cleanup@main

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/golden/golden_bandwidth_summary_wormhole_b0_galaxy.csv
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/golden/golden_bandwidth_summary_wormhole_b0_galaxy.csv
@@ -1,4 +1,4 @@
-test_name,ftype,ntype,topology,num_devices,num_links,packet_size,iterations,Avg Cycles,Avg Packets/s,Avg Bandwidth (GB/s),BW Min (GB/s),BW Max (GB/s),BW Std Dev (GB/s),tolerance_percent
+test_name,ftype,ntype,topology,num_devices,num_links,packet_size,iterations,avg_cycles,avg_packets_per_s,avg_bandwidth_GB_per_s,bw_min_gb_per_s,bw_max_gb_per_s,bw_std_dev_gb_per_s,tolerance_percent
 LinearMulticast,CHIP_MULTICAST,NOC_UNICAST_WRITE,Linear,"[4,8]",1,2048,3,41854741.000000,3344902.294207,6.850360,6.847170,6.853376,0.002536,1.000000
 LinearMulticast,CHIP_MULTICAST,NOC_UNICAST_WRITE,Linear,"[4,8]",2,2048,3,41904743.666667,3340910.612711,6.842185,6.840947,6.843328,0.000974,1.000000
 LinearMulticast,CHIP_MULTICAST,NOC_UNICAST_WRITE,Linear,"[4,8]",3,2048,3,41914315.666667,3340148.018380,6.840623,6.838494,6.844103,0.002481,1.000000

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/golden/golden_bandwidth_summary_wormhole_b0_galaxy.csv
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/golden/golden_bandwidth_summary_wormhole_b0_galaxy.csv
@@ -1,4 +1,4 @@
-test_name,ftype,ntype,topology,num_devices,num_links,packet_size,iterations,avg_cycles,avg_packets_per_s,avg_bandwidth_GB_per_s,bw_min_gb_per_s,bw_max_gb_per_s,bw_std_dev_gb_per_s,tolerance_percent
+test_name,ftype,ntype,topology,num_devices,num_links,packet_size,iterations,avg_cycles,avg_packets_per_s,avg_bandwidth_GB_per_s,bw_min_GB_per_s,bw_max_GB_per_s,bw_std_dev_GB_per_s,tolerance_percent
 LinearMulticast,CHIP_MULTICAST,NOC_UNICAST_WRITE,Linear,"[4,8]",1,2048,3,41854741.000000,3344902.294207,6.850360,6.847170,6.853376,0.002536,1.000000
 LinearMulticast,CHIP_MULTICAST,NOC_UNICAST_WRITE,Linear,"[4,8]",2,2048,3,41904743.666667,3340910.612711,6.842185,6.840947,6.843328,0.000974,1.000000
 LinearMulticast,CHIP_MULTICAST,NOC_UNICAST_WRITE,Linear,"[4,8]",3,2048,3,41914315.666667,3340148.018380,6.840623,6.838494,6.844103,0.002481,1.000000

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/golden/golden_bandwidth_summary_wormhole_b0_t3k.csv
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/golden/golden_bandwidth_summary_wormhole_b0_t3k.csv
@@ -1,4 +1,4 @@
-test_name,ftype,ntype,topology,num_devices,num_links,packet_size,iterations,Avg Cycles,Avg Packets/s,Avg Bandwidth (GB/s),BW Min (GB/s),BW Max (GB/s),BW Std Dev (GB/s),tolerance_percent
+test_name,ftype,ntype,topology,num_devices,num_links,packet_size,iterations,avg_cycles,avg_packets_per_s,avg_bandwidth_gb_per_s,bw_min_gb_per_s,bw_max_gb_per_s,bw_std_dev_gb_per_s,tolerance_percent
 LinearMulticast,CHIP_MULTICAST,NOC_UNICAST_WRITE,Linear,"[2,4]",1,2048,3,15825794.333333,3791278.913595,7.764539,7.763792,7.765236,0.000590,1.000000
 LinearMulticast,CHIP_MULTICAST,NOC_FUSED_UNICAST_ATOMIC_INC,Linear,"[2,4]",1,2048,3,30169958.000000,1988733.372906,4.072926,4.071906,4.073869,0.000803,1.000000
 LinearMulticast,CHIP_MULTICAST,NOC_UNICAST_SCATTER_WRITE,Linear,"[2,4]",1,2048,3,19168398.333333,3130152.020734,6.410551,6.409587,6.411352,0.000730,1.000000

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/golden/golden_bandwidth_summary_wormhole_b0_t3k.csv
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/golden/golden_bandwidth_summary_wormhole_b0_t3k.csv
@@ -1,4 +1,4 @@
-test_name,ftype,ntype,topology,num_devices,num_links,packet_size,iterations,avg_cycles,avg_packets_per_s,avg_bandwidth_gb_per_s,bw_min_gb_per_s,bw_max_gb_per_s,bw_std_dev_gb_per_s,tolerance_percent
+test_name,ftype,ntype,topology,num_devices,num_links,packet_size,iterations,avg_cycles,avg_packets_per_s,avg_bandwidth_GB_per_s,bw_min_GB_per_s,bw_max_GB_per_s,bw_std_dev_GB_per_s,tolerance_percent
 LinearMulticast,CHIP_MULTICAST,NOC_UNICAST_WRITE,Linear,"[2,4]",1,2048,3,15825794.333333,3791278.913595,7.764539,7.763792,7.765236,0.000590,1.000000
 LinearMulticast,CHIP_MULTICAST,NOC_FUSED_UNICAST_ATOMIC_INC,Linear,"[2,4]",1,2048,3,30169958.000000,1988733.372906,4.072926,4.071906,4.073869,0.000803,1.000000
 LinearMulticast,CHIP_MULTICAST,NOC_UNICAST_SCATTER_WRITE,Linear,"[2,4]",1,2048,3,19168398.333333,3130152.020734,6.410551,6.409587,6.411352,0.000730,1.000000

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_context.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_context.cpp
@@ -221,7 +221,7 @@ void TestContext::report_code_profiling_results() {
     for (const auto& entry : code_profiling_entries_) {
         log_info(
             tt::LogTest,
-            "  Device {} Core {}: {} - Total Cycles: {}, Instances: {}, Avg Cycles/Instance: {:.2f}",
+            "  Device {} Core {}: {} - Total Cycles: {}, Instances: {}, avg_cycles/Instance: {:.2f}",
             entry.coord,
             entry.eth_channel,
             get_timer_type_name(entry.timer_type),

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_context.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_context.hpp
@@ -1349,12 +1349,8 @@ private:
             return;
         }
 
-        // Determine if we have upload columns by checking first result
-        bool has_upload_data = !bandwidth_results_summary_.empty() && 
-                               bandwidth_results_summary_[0].file_name.has_value();
-
         // Write header
-        if (include_upload_columns && has_upload_data) {
+        if (include_upload_columns) {
             csv_stream << "file_name,machine_type,test_ts,";
         }
         csv_stream << "test_name,ftype,ntype,topology,num_devices,num_links,packet_size,iterations";
@@ -1373,14 +1369,14 @@ private:
         for (const auto& result : bandwidth_results_summary_) {
             // Write upload columns if present
             if (include_upload_columns && has_upload_data) {
-                csv_stream << result.file_name.value() << "," 
-                          << result.machine_type.value() << "," 
+                csv_stream << result.file_name.value() << ","
+                          << result.machine_type.value() << ","
                           << result.test_ts.value() << ",";
             }
 
             // Convert vector of num_devices to a string representation
             std::string num_devices_str = convert_num_devices_to_string(result.num_devices);
-            
+
             // Write standard columns
             csv_stream << result.test_name << "," << result.ftype << "," << result.ntype << ","
                        << result.topology << ",\"" << num_devices_str << "\"," << result.num_links << ","
@@ -1388,7 +1384,7 @@ private:
             for (double stat : result.statistics_vector) {
                 csv_stream << "," << std::fixed << std::setprecision(6) << stat;
             }
-            
+
             // Find the corresponding golden entry for this test result
             auto golden_it = fetch_corresponding_golden_entry(result);
             if (golden_it == golden_csv_entries_.end()) {
@@ -1406,7 +1402,7 @@ private:
         auto arch_name = tt::tt_metal::hal::get_arch_name();
         std::ostringstream summary_oss;
         summary_oss << "bandwidth_summary_results_" << arch_name << ".csv";
-        
+
         std::filesystem::path output_path =
             std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) / output_dir;
         csv_summary_file_path_ = output_path / summary_oss.str();
@@ -1445,7 +1441,7 @@ private:
         auto arch_name = tt::tt_metal::hal::get_arch_name();
         std::ostringstream upload_oss;
         upload_oss << "bandwidth_summary_results_" << arch_name << "_upload.csv";
-        
+
         std::filesystem::path output_path =
             std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) / output_dir;
         csv_summary_upload_file_path_ = output_path / upload_oss.str();

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_context.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_context.hpp
@@ -1368,7 +1368,7 @@ private:
         // Write data rows
         for (const auto& result : bandwidth_results_summary_) {
             // Write upload columns if present
-            if (include_upload_columns && has_upload_data) {
+            if (include_upload_columns) {
                 csv_stream << result.file_name.value() << ","
                           << result.machine_type.value() << ","
                           << result.test_ts.value() << ",";

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_context.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_context.hpp
@@ -100,12 +100,12 @@ enum class BandwidthStatistics {
 };
 // The header of each statistic in the Bandwidth Summary CSV
 const std::unordered_map<BandwidthStatistics, std::string> BandwidthStatisticsHeader = {
-    {BandwidthStatistics::BandwidthMean, "Avg Bandwidth (GB/s)"},
-    {BandwidthStatistics::BandwidthMin, "BW Min (GB/s)"},
-    {BandwidthStatistics::BandwidthMax, "BW Max (GB/s)"},
-    {BandwidthStatistics::BandwidthStdDev, "BW Std Dev (GB/s)"},
-    {BandwidthStatistics::PacketsPerSecondMean, "Avg Packets/s"},
-    {BandwidthStatistics::CyclesMean, "Avg Cycles"},
+    {BandwidthStatistics::BandwidthMean, "avg_bandwidth_gb_per_s"},
+    {BandwidthStatistics::BandwidthMin, "bw_min_gb_per_s"},
+    {BandwidthStatistics::BandwidthMax, "bw_max_gb_per_s"},
+    {BandwidthStatistics::BandwidthStdDev, "bw_std_dev_gb_per_s"},
+    {BandwidthStatistics::PacketsPerSecondMean, "avg_packets_per_s"},
+    {BandwidthStatistics::CyclesMean, "avg_cycles"},
 };
 
 // Access to internal API: ProgramImpl::num_kernel
@@ -1360,7 +1360,11 @@ private:
         csv_stream << "test_name,ftype,ntype,topology,num_devices,num_links,packet_size,iterations";
         for (BandwidthStatistics stat : stat_order_) {
             const std::string& stat_name = BandwidthStatisticsHeader.at(stat);
-            csv_stream << "," << stat_name;
+            if (include_upload_columns) {
+                csv_stream << "," << to_lower(stat_name);
+            } else {
+                csv_stream << "," << stat_name;
+            }
         }
         csv_stream << ",tolerance_percent\n";
         log_info(tt::LogTest, "Initialized CSV file: {}", csv_path.string());

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_context.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_context.hpp
@@ -11,6 +11,7 @@
 #include <filesystem>
 #include <memory>
 #include <algorithm>
+#include <chrono>
 #include <fstream>
 #include <iomanip>
 #include <optional>
@@ -455,6 +456,9 @@ public:
         // Generate bandwidth summary CSV file
         generate_bandwidth_summary_csv();
 
+        // Generate bandwidth summary upload CSV file with metadata
+        generate_bandwidth_summary_upload_csv();
+
         // Compare summary results with golden CSV
         compare_summary_results_with_golden();
 
@@ -583,7 +587,7 @@ public:
 
         // Copy CSV files to CI artifacts directory
         for (const std::filesystem::path& csv_filepath :
-             {csv_file_path_, csv_summary_file_path_, diff_csv_file_path_, comparison_statistics_csv_file_path_}) {
+             {csv_file_path_, csv_summary_file_path_, csv_summary_upload_file_path_, diff_csv_file_path_, comparison_statistics_csv_file_path_}) {
             try {
                 std::filesystem::copy_file(
                     csv_filepath,
@@ -1337,59 +1341,116 @@ private:
 
     std::vector<GoldenCsvEntry>::iterator fetch_corresponding_golden_entry(const BandwidthResultSummary& test_result);
 
+    void write_bandwidth_summary_csv_to_file(const std::filesystem::path& csv_path, bool include_upload_columns) {
+        // Create CSV file with header
+        std::ofstream csv_stream(csv_path, std::ios::out | std::ios::trunc);
+        if (!csv_stream.is_open()) {
+            log_error(tt::LogTest, "Failed to create CSV file: {}", csv_path.string());
+            return;
+        }
+
+        // Determine if we have upload columns by checking first result
+        bool has_upload_data = !bandwidth_results_summary_.empty() && 
+                               bandwidth_results_summary_[0].file_name.has_value();
+
+        // Write header
+        if (include_upload_columns && has_upload_data) {
+            csv_stream << "file_name,machine_type,test_ts,";
+        }
+        csv_stream << "test_name,ftype,ntype,topology,num_devices,num_links,packet_size,iterations";
+        for (BandwidthStatistics stat : stat_order_) {
+            const std::string& stat_name = BandwidthStatisticsHeader.at(stat);
+            csv_stream << "," << stat_name;
+        }
+        csv_stream << ",tolerance_percent\n";
+        log_info(tt::LogTest, "Initialized CSV file: {}", csv_path.string());
+
+        // Write data rows
+        for (const auto& result : bandwidth_results_summary_) {
+            // Write upload columns if present
+            if (include_upload_columns && has_upload_data) {
+                csv_stream << result.file_name.value() << "," 
+                          << result.machine_type.value() << "," 
+                          << result.test_ts.value() << ",";
+            }
+
+            // Convert vector of num_devices to a string representation
+            std::string num_devices_str = convert_num_devices_to_string(result.num_devices);
+            
+            // Write standard columns
+            csv_stream << result.test_name << "," << result.ftype << "," << result.ntype << ","
+                       << result.topology << ",\"" << num_devices_str << "\"," << result.num_links << ","
+                       << result.packet_size << "," << result.num_iterations;
+            for (double stat : result.statistics_vector) {
+                csv_stream << "," << std::fixed << std::setprecision(6) << stat;
+            }
+            
+            // Find the corresponding golden entry for this test result
+            auto golden_it = fetch_corresponding_golden_entry(result);
+            if (golden_it == golden_csv_entries_.end()) {
+                csv_stream << "," << 1.0;
+            } else {
+                csv_stream << "," << golden_it->tolerance_percent;
+            }
+            csv_stream << "\n";
+        }
+        csv_stream.close();
+        log_info(tt::LogTest, "Bandwidth summary results written to CSV file: {}", csv_path.string());
+    }
+
     void generate_bandwidth_summary_csv() {
-        // Bandwidth summary CSV file is generated separately from Bandwidth CSV because we need to wait for all
-        // multirun tests to complete Generate detailed CSV filename
-        std::ostringstream summary_oss;
         auto arch_name = tt::tt_metal::hal::get_arch_name();
+        std::ostringstream summary_oss;
         summary_oss << "bandwidth_summary_results_" << arch_name << ".csv";
-        // Output directory already set in initialize_bandwidth_results_csv_file()
+        
         std::filesystem::path output_path =
             std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) / output_dir;
         csv_summary_file_path_ = output_path / summary_oss.str();
 
-        // Create detailed CSV file with header
-        std::ofstream summary_csv_stream(csv_summary_file_path_, std::ios::out | std::ios::trunc);  // Truncate file
-        if (!summary_csv_stream.is_open()) {
-            log_error(tt::LogTest, "Failed to create summary CSV file: {}", csv_summary_file_path_.string());
-            return;
-        }
+        write_bandwidth_summary_csv_to_file(csv_summary_file_path_, false);
+    }
 
-        // Write detailed header
-        summary_csv_stream << "test_name,ftype,ntype,topology,num_devices,num_links,packet_size,iterations";
-        for (BandwidthStatistics stat : stat_order_) {
-            const std::string& stat_name = BandwidthStatisticsHeader.at(stat);
-            summary_csv_stream << "," << stat_name;
-        }
-        summary_csv_stream << ",tolerance_percent";
-        summary_csv_stream << "\n";
-        log_info(tt::LogTest, "Initialized summary CSV file: {}", csv_summary_file_path_.string());
+    void populate_upload_metadata_fields() {
+        // Get arch name and cluster type
+        auto arch_name = tt::tt_metal::hal::get_arch_name();
+        auto cluster_type = tt::tt_metal::MetalContext::instance().get_cluster().get_cluster_type();
+        std::string machine_type = std::string(enchantum::to_string(cluster_type));
+        std::transform(machine_type.begin(), machine_type.end(), machine_type.begin(), ::tolower);
 
-        // Write data rows
-        for (const auto& result : bandwidth_results_summary_) {
-            // Convert vector of num_devices to a string representation
-            std::string num_devices_str = convert_num_devices_to_string(result.num_devices);
-            summary_csv_stream << result.test_name << "," << result.ftype << "," << result.ntype << ","
-                               << result.topology << ",\"" << num_devices_str << "\"," << result.num_links << ","
-                               << result.packet_size << "," << result.num_iterations;
-            for (double stat : result.statistics_vector) {
-                summary_csv_stream << "," << std::fixed << std::setprecision(6) << stat;
-            }
-            // Find the corresponding golden entry for this test result
-            auto golden_it = fetch_corresponding_golden_entry(result);
-            if (golden_it == golden_csv_entries_.end()) {
-                log_warning(
-                    tt::LogTest,
-                    "Golden CSV entry not found for test {}, putting tolerance of 1.0 in summary CSV",
-                    result.test_name);
-                summary_csv_stream << "," << 1.0;
-            } else {
-                summary_csv_stream << "," << golden_it->tolerance_percent;
-            }
-            summary_csv_stream << "\n";
+        // Generate file_name column value
+        std::string file_name = "bw_" + arch_name + "_" + machine_type;
+
+        // Capture current timestamp
+        auto now = std::chrono::system_clock::now();
+        auto time_t_now = std::chrono::system_clock::to_time_t(now);
+        std::tm timestamp_now{};
+        localtime_r(&time_t_now, &timestamp_now);
+        std::ostringstream timestamp_oss;
+        timestamp_oss << std::put_time(&timestamp_now, "%Y-%m-%d %H:%M:%S");
+        std::string test_ts = timestamp_oss.str();
+
+        // Populate optional fields in all result objects
+        for (auto& result : bandwidth_results_summary_) {
+            result.file_name = file_name;
+            result.machine_type = machine_type;
+            result.test_ts = test_ts;
         }
-        summary_csv_stream.close();
-        log_info(tt::LogTest, "Bandwidth summary results appended to CSV file: {}", csv_summary_file_path_.string());
+    }
+
+    void generate_bandwidth_summary_upload_csv() {
+        auto arch_name = tt::tt_metal::hal::get_arch_name();
+        std::ostringstream upload_oss;
+        upload_oss << "bandwidth_summary_results_" << arch_name << "_upload.csv";
+        
+        std::filesystem::path output_path =
+            std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) / output_dir;
+        csv_summary_upload_file_path_ = output_path / upload_oss.str();
+
+        // Populate upload metadata fields
+        populate_upload_metadata_fields();
+
+        // Write CSV with upload columns
+        write_bandwidth_summary_csv_to_file(csv_summary_upload_file_path_, true);
     }
 
     std::string get_golden_csv_filename() {
@@ -1659,6 +1720,7 @@ private:
     std::vector<BandwidthStatistics> stat_order_;
     std::filesystem::path csv_file_path_;
     std::filesystem::path csv_summary_file_path_;
+    std::filesystem::path csv_summary_upload_file_path_;
 
     // Golden CSV comparison data
     std::vector<GoldenCsvEntry> golden_csv_entries_;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_context.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_context.hpp
@@ -100,10 +100,10 @@ enum class BandwidthStatistics {
 };
 // The header of each statistic in the Bandwidth Summary CSV
 const std::unordered_map<BandwidthStatistics, std::string> BandwidthStatisticsHeader = {
-    {BandwidthStatistics::BandwidthMean, "avg_bandwidth_gb_per_s"},
-    {BandwidthStatistics::BandwidthMin, "bw_min_gb_per_s"},
-    {BandwidthStatistics::BandwidthMax, "bw_max_gb_per_s"},
-    {BandwidthStatistics::BandwidthStdDev, "bw_std_dev_gb_per_s"},
+    {BandwidthStatistics::BandwidthMean, "avg_bandwidth_GB_per_s"},
+    {BandwidthStatistics::BandwidthMin, "bw_min_GB_per_s"},
+    {BandwidthStatistics::BandwidthMax, "bw_max_GB_per_s"},
+    {BandwidthStatistics::BandwidthStdDev, "bw_std_dev_GB_per_s"},
     {BandwidthStatistics::PacketsPerSecondMean, "avg_packets_per_s"},
     {BandwidthStatistics::CyclesMean, "avg_cycles"},
 };
@@ -1356,11 +1356,7 @@ private:
         csv_stream << "test_name,ftype,ntype,topology,num_devices,num_links,packet_size,iterations";
         for (BandwidthStatistics stat : stat_order_) {
             const std::string& stat_name = BandwidthStatisticsHeader.at(stat);
-            if (include_upload_columns) {
-                csv_stream << "," << to_lower(stat_name);
-            } else {
-                csv_stream << "," << stat_name;
-            }
+            csv_stream << "," << stat_name;
         }
         csv_stream << ",tolerance_percent\n";
         log_info(tt::LogTest, "Initialized CSV file: {}", csv_path.string());

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_results.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_results.hpp
@@ -53,7 +53,7 @@ struct BandwidthResultSummary {
     std::vector<double> bandwidth_vector_GB_s;
     std::vector<double> packets_per_second_vector;
     std::vector<double> statistics_vector;  // Stores the calculated statistics for each test
-    
+
     // Optional fields for database upload CSV
     std::optional<std::string> file_name;
     std::optional<std::string> machine_type;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_results.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_results.hpp
@@ -53,6 +53,11 @@ struct BandwidthResultSummary {
     std::vector<double> bandwidth_vector_GB_s;
     std::vector<double> packets_per_second_vector;
     std::vector<double> statistics_vector;  // Stores the calculated statistics for each test
+    
+    // Optional fields for database upload CSV
+    std::optional<std::string> file_name;
+    std::optional<std::string> machine_type;
+    std::optional<std::string> test_ts;
 };
 
 // Golden CSV comparison structures


### PR DESCRIPTION
With this change, any bandwidth test runs from the metal microbenchmark pipeline that are run from main will upload their results to superset.

A snapshot of some uploaded data can be seen here: 
<img width="1081" height="569" alt="image" src="https://github.com/user-attachments/assets/f98cdb6b-3923-44e3-a500-647c33ee28e4" />


### Checklist
- [x] metal microbenchmark: https://github.com/tenstorrent/tt-metal/actions/runs/19515319023