### PR TITLE
Avoid marking CQs as in-use if hooks throw away reads/writes.

### DIFF
--- a/tt_metal/api/tt-metalium/mesh_device.hpp
+++ b/tt_metal/api/tt-metalium/mesh_device.hpp
@@ -129,6 +129,11 @@ private:
     // Recursively quiesce all submeshes.
     void quiesce_internal();
 
+    // Check if the mesh device or any of its parents are in use.
+    bool are_parents_in_use(uint32_t cq_id) const;
+    // Check if the mesh device or any of its children are in use.
+    bool are_children_in_use(uint32_t cq_id) const;
+
     void mark_allocations_unsafe();
     void mark_allocations_safe();
 

--- a/tt_metal/api/tt-metalium/mesh_device.hpp
+++ b/tt_metal/api/tt-metalium/mesh_device.hpp
@@ -129,10 +129,10 @@ private:
     // Recursively quiesce all submeshes.
     void quiesce_internal();
 
-    // Check if the mesh device or any of its parents are in use.
-    bool are_parents_in_use(uint32_t cq_id) const;
-    // Check if the mesh device or any of its children are in use.
-    bool are_children_in_use(uint32_t cq_id) const;
+    // Check if the mesh device or any of its parents have a CQ in use, and returns one of the parent mesh IDs if found.
+    std::optional<int> get_parent_mesh_id_with_in_use_cq(uint32_t cq_id) const;
+    // Check if the mesh device or any of its children have a CQ in use, and returns one of the child mesh IDs if found.
+    std::optional<int> get_child_mesh_id_with_in_use_cq(uint32_t cq_id) const;
 
     void mark_allocations_unsafe();
     void mark_allocations_safe();

--- a/tt_metal/api/tt-metalium/mesh_device.hpp
+++ b/tt_metal/api/tt-metalium/mesh_device.hpp
@@ -63,6 +63,7 @@ namespace distributed {
 class MeshCommandQueue;
 class MeshDeviceView;
 struct MeshTraceBuffer;
+class MeshCommandQueueBase;
 
 using DeviceIds = std::vector<int>;
 
@@ -114,7 +115,7 @@ private:
     std::shared_ptr<MeshDevice> parent_mesh_;
     std::vector<std::weak_ptr<MeshDevice>> submeshes_;
 
-    tt::stl::SmallVector<std::unique_ptr<MeshCommandQueue>> mesh_command_queues_;
+    tt::stl::SmallVector<std::unique_ptr<MeshCommandQueueBase>> mesh_command_queues_;
 
     std::unique_ptr<SubDeviceManagerTracker> sub_device_manager_tracker_;
     uint32_t trace_buffers_size_ = 0;

--- a/tt_metal/distributed/fd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.cpp
@@ -534,12 +534,12 @@ void FDMeshCommandQueue::write_shard_to_device(
         return;
     }
 
-    in_use_ = true;
-    TT_FATAL(!trace_id_.has_value(), "Writes are not supported during trace capture. trace id: {}", trace_id_.value());
-
     if (tt::tt_metal::GraphTracker::instance().hook_write_to_device(&buffer)) {
         return;
     }
+
+    in_use_ = true;
+    TT_FATAL(!trace_id_.has_value(), "Writes are not supported during trace capture. trace id: {}", trace_id_.value());
 
     auto device_buffer = buffer.get_device_buffer(device_coord);
     auto shard_view = device_buffer->view(region.value_or(BufferRegion(0, device_buffer->size())));
@@ -560,12 +560,13 @@ void FDMeshCommandQueue::read_shard_from_device(
         return;
     }
 
-    in_use_ = true;
-    TT_FATAL(!trace_id_.has_value(), "Reads are not supported during trace capture.");
-
     if (tt::tt_metal::GraphTracker::instance().hook_read_from_device(&buffer)) {
         return;
     }
+
+    in_use_ = true;
+    TT_FATAL(!trace_id_.has_value(), "Reads are not supported during trace capture.");
+
 
     auto device_buffer = buffer.get_device_buffer(device_coord);
     auto shard_view = device_buffer->view(region.value_or(BufferRegion(0, device_buffer->size())));

--- a/tt_metal/distributed/fd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.cpp
@@ -567,7 +567,6 @@ void FDMeshCommandQueue::read_shard_from_device(
     in_use_ = true;
     TT_FATAL(!trace_id_.has_value(), "Reads are not supported during trace capture.");
 
-
     auto device_buffer = buffer.get_device_buffer(device_coord);
     auto shard_view = device_buffer->view(region.value_or(BufferRegion(0, device_buffer->size())));
 

--- a/tt_metal/distributed/fd_mesh_command_queue.hpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.hpp
@@ -274,6 +274,7 @@ public:
 
     void wait_for_completion(bool reset_launch_msg_state) override;
     void finish_and_reset_in_use() override;
+    bool in_use() override { return in_use_.load(); }
 };
 
 }  // namespace tt::tt_metal::distributed

--- a/tt_metal/distributed/mesh_command_queue_base.hpp
+++ b/tt_metal/distributed/mesh_command_queue_base.hpp
@@ -92,6 +92,7 @@ public:
         const std::optional<std::unordered_set<MeshCoordinate>>& shards,
         bool blocking) override;
 
+    // Returns true if the CQ is in use (has had commands enqueued).
     virtual bool in_use() { return false; }
 };
 

--- a/tt_metal/distributed/mesh_command_queue_base.hpp
+++ b/tt_metal/distributed/mesh_command_queue_base.hpp
@@ -91,6 +91,8 @@ public:
         DistributedHostBuffer& host_buffer,
         const std::optional<std::unordered_set<MeshCoordinate>>& shards,
         bool blocking) override;
+
+    virtual bool in_use() { return false; }
 };
 
 }  // namespace tt::tt_metal::distributed

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -659,8 +659,9 @@ std::optional<int> MeshDevice::get_child_mesh_id_with_in_use_cq(uint32_t cq_id) 
     }
     for (const auto& submesh : submeshes_) {
         if (auto submesh_ptr = submesh.lock()) {
-            if (submesh_ptr->get_child_mesh_id_with_in_use_cq(cq_id)) {
-                return submesh_ptr->id();
+            auto child_mesh_id = submesh_ptr->get_child_mesh_id_with_in_use_cq(cq_id);
+            if (child_mesh_id) {
+                return *child_mesh_id;
             }
         }
     }

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -605,7 +605,7 @@ bool MeshDevice::close() {
     // Only one mesh device can use a CQ on a physical device at a time, or else teardown or some other operation will
     // hang. Validate this.
     for (uint32_t cq_id = 0; cq_id < mesh_command_queues_.size(); cq_id++) {
-        if (dynamic_cast<FDMeshCommandQueue*>(mesh_command_queues_[cq_id].get())->in_use()) {
+        if (dynamic_cast<MeshCommandQueueBase*>(mesh_command_queues_[cq_id].get())->in_use()) {
             auto parent_mesh = get_parent_mesh();
             if (parent_mesh) {
                 auto parent_mesh_id = parent_mesh->get_parent_mesh_id_with_in_use_cq(cq_id);
@@ -643,7 +643,7 @@ bool MeshDevice::close() {
 
 std::optional<int> MeshDevice::get_parent_mesh_id_with_in_use_cq(uint32_t cq_id) const {
     if (cq_id < mesh_command_queues_.size() &&
-        dynamic_cast<FDMeshCommandQueue*>(mesh_command_queues_[cq_id].get())->in_use()) {
+        dynamic_cast<MeshCommandQueueBase*>(mesh_command_queues_[cq_id].get())->in_use()) {
         return id();
     }
     if (parent_mesh_) {
@@ -654,7 +654,7 @@ std::optional<int> MeshDevice::get_parent_mesh_id_with_in_use_cq(uint32_t cq_id)
 
 std::optional<int> MeshDevice::get_child_mesh_id_with_in_use_cq(uint32_t cq_id) const {
     if (cq_id < mesh_command_queues_.size() &&
-        dynamic_cast<FDMeshCommandQueue*>(mesh_command_queues_[cq_id].get())->in_use()) {
+        dynamic_cast<MeshCommandQueueBase*>(mesh_command_queues_[cq_id].get())->in_use()) {
         return id();
     }
     for (const auto& submesh : submeshes_) {

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -602,14 +602,19 @@ bool MeshDevice::close() {
         dynamic_cast<Device*>(device)->set_mesh_device(parent_mesh_);
     }
 
-    // Only one mesh device can use a CQ on a physical device at a time, or else teardown or some other operation will hang. Validate this.
+    // Only one mesh device can use a CQ on a physical device at a time, or else teardown or some other operation will
+    // hang. Validate this.
     for (uint32_t cq_id = 0; cq_id < mesh_command_queues_.size(); cq_id++) {
         if (dynamic_cast<FDMeshCommandQueue*>(mesh_command_queues_[cq_id].get())->in_use()) {
             auto parent_mesh = get_parent_mesh();
             if (parent_mesh) {
                 auto parent_mesh_id = parent_mesh->get_parent_mesh_id_with_in_use_cq(cq_id);
                 if (parent_mesh_id) {
-                    TT_THROW("MeshDevice cq ID {} is in use by parent mesh ID {} during close of mesh ID {}", cq_id, *parent_mesh_id, id());
+                    TT_THROW(
+                        "MeshDevice cq ID {} is in use by parent mesh ID {} during close of mesh ID {}",
+                        cq_id,
+                        *parent_mesh_id,
+                        id());
                 }
             }
 
@@ -617,7 +622,11 @@ bool MeshDevice::close() {
                 if (auto submesh_ptr = submesh.lock()) {
                     auto child_mesh_id = submesh_ptr->get_child_mesh_id_with_in_use_cq(cq_id);
                     if (child_mesh_id) {
-                        TT_THROW("MeshDevice cq ID {} is in use by child submesh ID {} during close of mesh ID {}", cq_id, *child_mesh_id, id());
+                        TT_THROW(
+                            "MeshDevice cq ID {} is in use by child submesh ID {} during close of mesh ID {}",
+                            cq_id,
+                            *child_mesh_id,
+                            id());
                     }
                 }
             }

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -605,7 +605,7 @@ bool MeshDevice::close() {
     // Only one mesh device can use a CQ on a physical device at a time, or else teardown or some other operation will
     // hang. Validate this.
     for (uint32_t cq_id = 0; cq_id < mesh_command_queues_.size(); cq_id++) {
-        if (dynamic_cast<MeshCommandQueueBase*>(mesh_command_queues_[cq_id].get())->in_use()) {
+        if (mesh_command_queues_[cq_id]->in_use()) {
             auto parent_mesh = get_parent_mesh();
             if (parent_mesh) {
                 auto parent_mesh_id = parent_mesh->get_parent_mesh_id_with_in_use_cq(cq_id);
@@ -642,8 +642,7 @@ bool MeshDevice::close() {
 }
 
 std::optional<int> MeshDevice::get_parent_mesh_id_with_in_use_cq(uint32_t cq_id) const {
-    if (cq_id < mesh_command_queues_.size() &&
-        dynamic_cast<MeshCommandQueueBase*>(mesh_command_queues_[cq_id].get())->in_use()) {
+    if (cq_id < mesh_command_queues_.size() && mesh_command_queues_[cq_id]->in_use()) {
         return id();
     }
     if (parent_mesh_) {
@@ -653,8 +652,7 @@ std::optional<int> MeshDevice::get_parent_mesh_id_with_in_use_cq(uint32_t cq_id)
 }
 
 std::optional<int> MeshDevice::get_child_mesh_id_with_in_use_cq(uint32_t cq_id) const {
-    if (cq_id < mesh_command_queues_.size() &&
-        dynamic_cast<MeshCommandQueueBase*>(mesh_command_queues_[cq_id].get())->in_use()) {
+    if (cq_id < mesh_command_queues_.size() && mesh_command_queues_[cq_id]->in_use()) {
         return id();
     }
     for (const auto& submesh : submeshes_) {

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -659,7 +659,7 @@ std::optional<int> MeshDevice::get_child_mesh_id_with_in_use_cq(uint32_t cq_id) 
         if (auto submesh_ptr = submesh.lock()) {
             auto child_mesh_id = submesh_ptr->get_child_mesh_id_with_in_use_cq(cq_id);
             if (child_mesh_id) {
-                return *child_mesh_id;
+                return child_mesh_id;
             }
         }
     }


### PR DESCRIPTION
### Problem description
FDMeshCommandQueue uses the in_use_ flag to determine whether it needs to clean up the dispatcher on closure. The flag is needed because single physical device may be contained inside an entire hierarchy of meshes, and those meshes almost certainly have conflicting state about the status of the dispatcher; if an incorrect version of the state is used to clean up the dispatcher, cleanup may hang forever.

This relies on only a single MeshDevice having ever used an actual physical device (otherwise the dispatch state on the device would be undefined and probably broken). In the case of forge, they use a submesh to do some calculations about the feasibility of executing commands. They set NO_DISPATCH on the submesh so the commands aren't actually executed there (they're later executed on the parent mesh). However, for reads and writes, this sets in_use_ on the submesh, so it attempts to clean up the dispatch and can hang (because it will wait for a certain number of workers to execute commands, but the number it's waiting for is incorrect).

### What's changed
Only set in_use_ if the hook doesn't throw away the read or write.

Also, add some checks on MeshDevice teardown to ensure no other MeshDevice is using an overlapping set of devices. This will make errors like this one easier to debug in the future.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes