### PR TITLE
#18966: [skip ci] Don't run cleanup on jobs that only run on CIv2

### DIFF
--- a/.github/workflows/blackhole-20-cores-tests.yaml
+++ b/.github/workflows/blackhole-20-cores-tests.yaml
@@ -71,6 +71,3 @@ jobs:
         if: ${{ !cancelled() }}
         with:
           prefix: "test_reports_"
-
-      - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
-        if: always()

--- a/.github/workflows/blackhole-nightly-tests-20-cores-impl.yaml
+++ b/.github/workflows/blackhole-nightly-tests-20-cores-impl.yaml
@@ -76,6 +76,3 @@ jobs:
         with:
           slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
           owner: ${{ matrix.test-group.owner_id }}
-
-      - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
-        if: always()

--- a/.github/workflows/run-profiler-regression.yaml
+++ b/.github/workflows/run-profiler-regression.yaml
@@ -115,5 +115,3 @@ jobs:
         if: ${{ !cancelled() }}
         with:
           prefix: "test_reports_"
-      - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
-        if: always()

--- a/.github/workflows/t3000-fast-tests-impl.yaml
+++ b/.github/workflows/t3000-fast-tests-impl.yaml
@@ -113,5 +113,3 @@ jobs:
       - name: Generate gtest annotations on failure
         uses: tenstorrent/tt-metal/.github/actions/generate-gtest-failure-message@main
         if: ${{ failure() }}
-      - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
-        if: always()

--- a/.github/workflows/temp-ccache-test.yaml
+++ b/.github/workflows/temp-ccache-test.yaml
@@ -110,6 +110,3 @@ jobs:
         with:
           path: /work/build/tt-train/generated/test_reports/
           prefix: "test_reports_"
-
-      - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
-        if: always()

--- a/.github/workflows/tt-metal-l2-nightly-impl.yaml
+++ b/.github/workflows/tt-metal-l2-nightly-impl.yaml
@@ -222,8 +222,6 @@ jobs:
         with:
           slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
           owner: U08DCK9MA1E # Miłosz Gajewski
-      - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
-        if: always()
 
   ttnn-fused-tests:
     if: ${{ inputs.run_fused_tests }}
@@ -575,8 +573,6 @@ jobs:
         with:
           slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
           owner: ${{ matrix.owner }}
-      - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
-        if: always()
 
   ttnn-eltwise-tests:
     if: ${{ inputs.run_eltwise_tests }}


### PR DESCRIPTION
### Ticket
#18966

### Problem description
CIv2 runners are ephemeral (start up and tear itself down before/after each job) so there's no need to spend extra time cleaning up after itself when the runner gets deleted after each job.

### What's changed
Don't run cleanup step on jobs that only run on CIv2