### PR TITLE
Set blocking to true before reading back data

### DIFF
--- a/tests/tt_metal/tt_metal/eth/test_basic_eth.cpp
+++ b/tests/tt_metal/tt_metal/eth/test_basic_eth.cpp
@@ -304,7 +304,7 @@ bool noc_reader_and_writer_kernels(
     distributed::WriteShard(cq, writer_dram_buffer, all_zeros, zero_coord);
 
     workload.add_program(device_range, std::move(program));
-    distributed::EnqueueMeshWorkload(cq, workload, false);
+    distributed::EnqueueMeshWorkload(cq, workload, true);
 
     auto eth_readback_vec = tt::tt_metal::MetalContext::instance().get_cluster().read_core(
         device->id(), eth_noc_xy, eth_dst_l1_address, byte_size);

--- a/tests/tt_metal/tt_metal/eth/test_ring_gather_kernels.cpp
+++ b/tests/tt_metal/tt_metal/eth/test_ring_gather_kernels.cpp
@@ -348,7 +348,7 @@ bool eth_direct_ring_gather_sender_receiver_kernels(
             device_range, std::move(programs[device->get_devices()[0]->id()]));
         ths.emplace_back([&] {
             distributed::EnqueueMeshWorkload(
-                device->mesh_command_queue(), workloads[device->get_devices()[0]->id()], false);
+                device->mesh_command_queue(), workloads[device->get_devices()[0]->id()], true);
         });
     }
     for (auto& th : ths) {
@@ -505,7 +505,7 @@ bool eth_interleaved_ring_gather_sender_receiver_kernels(
             device_range, std::move(programs[device->get_devices()[0]->id()]));
         ths.emplace_back([&] {
             distributed::EnqueueMeshWorkload(
-                device->mesh_command_queue(), workloads[device->get_devices()[0]->id()], false);
+                device->mesh_command_queue(), workloads[device->get_devices()[0]->id()], true);
         });
     }
     for (auto& th : ths) {


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Reading back data without ensuring the test kernel has completed can result in ND test failures

### What's changed
Set blocking to True in EnqueueMeshWorkload

### Checklist
All Post Commit
https://github.com/tenstorrent/tt-metal/actions/runs/19520078563
Blackhole Multi Card
https://github.com/tenstorrent/tt-metal/actions/runs/19520076681