### PR TITLE
Initial implementation of L1 memory accessor

### DIFF
--- a/tests/tt_metal/tt_metal/api/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/api/CMakeLists.txt
@@ -49,6 +49,7 @@ target_sources(
         test_worker_config_buffer.cpp
         test_blockfloat_common.cpp
         test_duplicate_kernel.cpp
+        test_core_local_mem_api.cpp
 )
 
 target_include_directories(

--- a/tests/tt_metal/tt_metal/api/test_core_local_mem_api.cpp
+++ b/tests/tt_metal/tt_metal/api/test_core_local_mem_api.cpp
@@ -114,16 +114,14 @@ void RunTest(tt::tt_metal::distributed::MeshDevice* mesh_device) {
 
     // Verify data is the pattern
     std::vector<uint32_t> data(num_bytes / sizeof(uint32_t), 0);
+    std::vector<uint32_t> expected_data(num_bytes / sizeof(uint32_t));
+    std::iota(expected_data.begin(), expected_data.end(), pattern);
     mc.get_cluster().read_core(data.data(), num_bytes, tt_cxy_pair(device->id(), virtual_core), src_addr);
-    for (uint32_t i = 0; i < num_bytes / sizeof(uint32_t); i++) {
-        ASSERT_EQ(data[i], pattern);
-    }
+    ASSERT_EQ(data, expected_data);
 
     // Verify neighbor core received the data
     mc.get_cluster().read_core(data.data(), num_bytes, tt_cxy_pair(device->id(), neighbor_virtual_core), src_addr);
-    for (uint32_t i = 0; i < num_bytes / sizeof(uint32_t); i++) {
-        ASSERT_EQ(data[i], pattern);
-    }
+    ASSERT_EQ(data, expected_data);
 }
 
 }  // namespace

--- a/tests/tt_metal/tt_metal/api/test_core_local_mem_api.cpp
+++ b/tests/tt_metal/tt_metal/api/test_core_local_mem_api.cpp
@@ -1,0 +1,139 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <fmt/base.h>
+#include <tt-metalium/allocator.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/tt_metal.hpp>
+#include <vector>
+#include <random>
+
+#include <tt_stl/assert.hpp>
+#include <tt-metalium/buffer_types.hpp>
+#include <tt-metalium/circular_buffer_config.hpp>
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/data_types.hpp>
+#include <tt-metalium/device.hpp>
+#include "command_queue_fixture.hpp"
+#include "context/metal_context.hpp"
+#include <tt-metalium/distributed.hpp>
+#include "gtest/gtest.h"
+#include "mesh_device.hpp"
+#include <tt-metalium/kernel_types.hpp>
+#include <tt-logger/tt-logger.hpp>
+#include <tt-metalium/program.hpp>
+#include <tt_stl/span.hpp>
+#include <tt-metalium/tt_backend_api_types.hpp>
+
+namespace {
+
+void RunTest(tt::tt_metal::distributed::MeshDevice* mesh_device) {
+    const CoreCoord core = {0, 0};
+    tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
+    tt::tt_metal::distributed::MeshWorkload workload;
+
+    auto zero_coord = tt::tt_metal::distributed::MeshCoordinate(0, 0);
+    auto device_range = tt::tt_metal::distributed::MeshCoordinateRange(zero_coord, zero_coord);
+
+    auto& mc = tt::tt_metal::MetalContext::instance();
+
+    uint32_t unreserved_addr = mc.hal().get_dev_addr(
+        tt::tt_metal::HalProgrammableCoreType::TENSIX, tt::tt_metal::HalL1MemAddrType::DEFAULT_UNRESERVED);
+    uint32_t alignment = mc.hal().get_alignment(tt::tt_metal::HalMemType::L1);
+
+    // Ensure no regressions with the new API
+    uint32_t cycles_addr = unreserved_addr + 0;
+    uint32_t src_addr = std::max(
+        (uint32_t)(unreserved_addr + alignment),
+        (uint32_t)(unreserved_addr + (2 * sizeof(uint64_t))));  // two 64 bit cycle counters
+    uint32_t num_bytes = (128 * 1024 * sizeof(uint32_t));       // 512KB
+    uint32_t num_iterations = 1000;
+
+    // Try using the memory API with the NoC API to send random data to the neighbor core
+    CoreCoord neighbor_core{core.x + 1, core.y};
+    auto neighbor_virtual_core = mesh_device->worker_core_from_logical_core(neighbor_core);
+
+    std::random_device rd;
+    std::mt19937 gen(rd());
+    std::uniform_int_distribution<uint32_t> dist(0, UINT32_MAX);
+    uint32_t pattern = dist(gen);
+
+    std::vector<uint32_t> compile_args = {
+        cycles_addr,
+        src_addr,
+        num_bytes,
+        num_iterations,
+        neighbor_virtual_core.x,
+        neighbor_virtual_core.y,
+        pattern,
+    };
+
+    tt::tt_metal::CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/test_kernels/dataflow/core_local_mem_api.cpp",
+        core,
+        tt::tt_metal::DataMovementConfig{
+            .processor = tt::tt_metal::DataMovementProcessor::RISCV_0,
+            .noc = tt::tt_metal::NOC::NOC_0,
+            .compile_args = compile_args});
+    workload.add_program(device_range, std::move(program));
+
+    tt::tt_metal::distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(), workload, true);
+
+    uint64_t cycles_elapsed = 0;
+    auto device = mesh_device->get_devices()[0];
+    auto virtual_core = device->worker_core_from_logical_core(core);
+    mc.get_cluster().read_core(&cycles_elapsed, sizeof(uint64_t), tt_cxy_pair(device->id(), virtual_core), cycles_addr);
+
+    uint64_t cycles_elapsed_legacy_api = 0;
+    mc.get_cluster().read_core(
+        &cycles_elapsed_legacy_api,
+        sizeof(uint64_t),
+        tt_cxy_pair(device->id(), virtual_core),
+        cycles_addr + sizeof(uint64_t));
+
+    uint64_t total_bytes = (uint64_t)num_bytes * num_iterations;
+
+    double bytes_per_cycle = (double)total_bytes / (double)cycles_elapsed;
+    double bytes_per_cycle_legacy_api = (double)total_bytes / (double)cycles_elapsed_legacy_api;
+
+    double speedup = bytes_per_cycle_legacy_api / bytes_per_cycle;
+    // Ensure no differences greater than 0.05%
+    ASSERT_LT(std::abs(speedup - 1.0), 0.0005);
+
+    log_info(
+        tt::LogTest,
+        "Read Test: Num Bytes / Iteration: {}, Iterations: {}, Cycles: {}, Bytes/Cycle: {:.4f}, Bytes/Cycle (Legacy "
+        "API): {:.4f}",
+        num_bytes,
+        num_iterations,
+        cycles_elapsed,
+        bytes_per_cycle,
+        bytes_per_cycle_legacy_api);
+
+    // Verify data is the pattern
+    std::vector<uint32_t> data(num_bytes / sizeof(uint32_t), 0);
+    mc.get_cluster().read_core(data.data(), num_bytes, tt_cxy_pair(device->id(), virtual_core), src_addr);
+    for (uint32_t i = 0; i < num_bytes / sizeof(uint32_t); i++) {
+        ASSERT_EQ(data[i], pattern);
+    }
+
+    // Verify neighbor core received the data
+    mc.get_cluster().read_core(data.data(), num_bytes, tt_cxy_pair(device->id(), neighbor_virtual_core), src_addr);
+    for (uint32_t i = 0; i < num_bytes / sizeof(uint32_t); i++) {
+        ASSERT_EQ(data[i], pattern);
+    }
+}
+
+}  // namespace
+
+namespace tt::tt_metal {
+
+TEST_F(UnitMeshCQSingleCardProgramFixture, TestSimpleL1Read) {
+    for (auto& mesh_device : devices_) {
+        RunTest(mesh_device.get());
+    }
+}
+
+}  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/core_local_mem_api.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/core_local_mem_api.cpp
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "hw/inc/compile_time_args.h"
+#include "hw/inc/dataflow_api.h"
+#include "hw/inc/tt-1xx/risc_common.h"
+
+template <bool use_legacy_api>
+void access_memory(uint32_t src_addr, uint32_t end_addr, uint32_t num_iterations, volatile uint64_t* results) {
+    uint64_t start = c_tensix_core::read_wall_clock();
+    for (uint32_t i = 0; i < num_iterations; i++) {
+        if constexpr (use_legacy_api) {
+            volatile uint32_t* data = reinterpret_cast<volatile uint32_t*>(src_addr);
+            while (data < reinterpret_cast<volatile uint32_t*>(end_addr)) {
+                [[maybe_unused]] volatile uint32_t word = data[0];
+                data++;
+            }
+        } else {
+            experimental::CoreLocalMem<std::uint32_t> mem(src_addr);
+            while (mem.get_address() < end_addr) {
+                [[maybe_unused]] volatile uint32_t word = mem[0];
+                mem++;
+            }
+        }
+    }
+    uint64_t cycles_elapsed = c_tensix_core::read_wall_clock() - start;
+    results[0] = cycles_elapsed & 0xFFFFFFFF;
+    results[1] = (cycles_elapsed >> 32) & 0xFFFFFFFF;
+}
+
+void kernel_main() {
+    constexpr uint32_t cycles_addr = get_compile_time_arg_val(0);
+    constexpr uint32_t src_addr = get_compile_time_arg_val(1);
+    constexpr uint32_t num_bytes = get_compile_time_arg_val(2);
+    constexpr uint32_t num_iterations = get_compile_time_arg_val(3);
+    constexpr uint32_t neighbor_worker_core_x = get_compile_time_arg_val(4);
+    constexpr uint32_t neighbor_worker_core_y = get_compile_time_arg_val(5);
+    constexpr uint32_t pattern = get_compile_time_arg_val(6);
+
+    uint32_t end_addr = src_addr + num_bytes;
+
+    // Try reading
+    access_memory<false>(src_addr, end_addr, num_iterations, &((volatile uint64_t*)(cycles_addr))[0]);
+    access_memory<true>(src_addr, end_addr, num_iterations, &((volatile uint64_t*)(cycles_addr))[1]);
+
+    // Try writing with pattern
+    experimental::CoreLocalMem<std::uint32_t> mem(src_addr);
+    for (uint32_t i = 0; i < num_bytes / sizeof(uint32_t); i++) {
+        mem[i] = pattern;
+    }
+
+    // Try sending with NoC API
+    experimental::Noc noc;
+    experimental::UnicastEndpoint unicast_endpoint;
+    noc.async_write(
+        mem,
+        unicast_endpoint,
+        num_bytes,
+        {},
+        {
+            .noc_x = neighbor_worker_core_x,
+            .noc_y = neighbor_worker_core_y,
+            .addr = src_addr,
+        },
+        0);
+    noc.async_write_barrier();
+}

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/core_local_mem_api.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/core_local_mem_api.cpp
@@ -46,6 +46,20 @@ void kernel_main() {
     access_memory<false>(src_addr, end_addr, num_iterations, &((volatile uint64_t*)(cycles_addr))[0]);
     access_memory<true>(src_addr, end_addr, num_iterations, &((volatile uint64_t*)(cycles_addr))[1]);
 
+    // Try using a more complex type
+    struct TestStruct {
+        uint32_t foo;
+        uint64_t bar;
+    };
+
+    experimental::CoreLocalMem<TestStruct> struct_mem(src_addr);
+    struct_mem->foo = pattern;
+    struct_mem->bar = pattern + 1;
+    while (struct_mem->foo != pattern) {
+    }
+    while (struct_mem->bar != pattern + 1) {
+    }
+
     // Try writing and reading with operator[]
     experimental::CoreLocalMem<std::uint32_t> mem(src_addr);
     for (uint32_t i = 0; i < num_bytes / sizeof(uint32_t); i++) {

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/core_local_mem_api.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/core_local_mem_api.cpp
@@ -46,10 +46,14 @@ void kernel_main() {
     access_memory<false>(src_addr, end_addr, num_iterations, &((volatile uint64_t*)(cycles_addr))[0]);
     access_memory<true>(src_addr, end_addr, num_iterations, &((volatile uint64_t*)(cycles_addr))[1]);
 
-    // Try writing with pattern
+    // Try writing and reading with operator[]
     experimental::CoreLocalMem<std::uint32_t> mem(src_addr);
     for (uint32_t i = 0; i < num_bytes / sizeof(uint32_t); i++) {
-        mem[i] = pattern;
+        mem[i] = pattern + i;
+        if (mem[i] != pattern + i) {
+            while (true) {
+            }
+        }
     }
 
     // Try sending with NoC API
@@ -67,4 +71,105 @@ void kernel_main() {
         },
         0);
     noc.async_write_barrier();
+
+    // Pointer arithmetic (hangs if incorrect)
+    while (mem[0] != pattern) {
+    }
+    while (mem[4] != pattern + 4) {
+    }
+    while (mem[8] != pattern + 8) {
+    }
+
+    // Add offset to pointer
+    uint32_t mid_index = num_bytes / sizeof(uint32_t) / 2;
+    auto mid = mem + mid_index;
+
+    // get_address
+    auto mid_addr = mid.get_address();
+    if (mid_addr != src_addr + mid_index * sizeof(uint32_t)) {
+        while (true) {
+        }
+    }
+
+    // get_unsafe_ptr
+    auto unsafe_ptr = mid.get_unsafe_ptr();
+    if (reinterpret_cast<uintptr_t>(unsafe_ptr) != src_addr + mid_index * sizeof(uint32_t)) {
+        while (true) {
+        }
+    }
+
+    uint32_t middle_value = pattern + mid_index;
+    while (mid[0] != middle_value) {
+    }
+    while (mid[4] != middle_value + 4) {
+    }
+    while (mid[8] != middle_value + 8) {
+    }
+
+    // Subtract two pointers
+    auto diff = mid - mem;
+    if ((uint32_t)diff != mid_index) {
+        while (true) {
+        }
+    }
+
+    // Increment and decrement operators
+    auto inc_mem = mem;
+    inc_mem++;
+    while (inc_mem[0] != pattern + 1) {
+    }
+    while (inc_mem[4] != pattern + 5) {
+    }
+    while (inc_mem[8] != pattern + 9) {
+    }
+    auto dec_mem = mid;
+    dec_mem--;
+    while (dec_mem[0] != middle_value - 1) {
+    }
+    while (dec_mem[4] != middle_value + 3) {
+    }
+    while (dec_mem[8] != middle_value + 7) {
+    }
+
+    --inc_mem;
+    while (inc_mem[0] != pattern) {
+    }
+    while (inc_mem[4] != pattern + 4) {
+    }
+    while (inc_mem[8] != pattern + 8) {
+    }
+    ++dec_mem;
+    while (dec_mem[0] != middle_value) {
+    }
+    while (dec_mem[4] != middle_value + 4) {
+    }
+    while (dec_mem[8] != middle_value + 8) {
+    }
+
+    // Copy constructor
+    auto copy_mem = mem;
+    if (copy_mem != mem) {
+        while (true) {
+        }
+    }
+    while (copy_mem[0] != pattern) {
+    }
+    while (copy_mem[4] != pattern + 4) {
+    }
+    while (copy_mem[8] != pattern + 8) {
+    }
+
+    // Copy assignment operator
+    auto copy_assign_mem = mem;
+    copy_assign_mem = mem;
+    if (copy_assign_mem != mem) {
+        while (true) {
+        }
+    }
+    while (copy_assign_mem[0] != pattern) {
+    }
+    while (copy_assign_mem[4] != pattern + 4) {
+    }
+    while (copy_assign_mem[8] != pattern + 8) {
+    }
 }

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -3365,13 +3365,8 @@ public:
     difference_type operator-(const CoreLocalMem& other) const {
         difference_type byte_diff =
             static_cast<difference_type>(address_) - static_cast<difference_type>(other.address_);
-        if constexpr ((sizeof(T) & (sizeof(T) - 1)) == 0) {
-            // Optimized division for of sizeof(T) is a power of 2 for common cases like T = uint32_t
-            constexpr int shift = __builtin_ctz(sizeof(T));
-            return byte_diff >> shift;
-        } else {
-            return byte_diff / sizeof(T);
-        }
+        // Compiler automatically optimizes division to a shift if T is pow2
+        return byte_diff / sizeof(T);
     }
 
     bool operator==(const CoreLocalMem& other) const { return address_ == other.address_; }

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -3302,7 +3302,7 @@ public:
      */
     T& operator[](uint32_t index) const {
         // TODO: To be moved to a Watcher sanitize check
-        ASSERT((address_ + (index * sizeof(T)) < MEM_L1_SIZE));
+        ASSERT(address_ + (index + 1) * sizeof(T) <= MEM_L1_SIZE);
         return get_unsafe_ptr()[index];
     }
 
@@ -3312,7 +3312,7 @@ public:
      */
     T& operator*() const {
         // TODO: To be moved to a Watcher sanitize check
-        ASSERT(address_ < MEM_L1_SIZE);
+        ASSERT(address_ + sizeof(T) <= MEM_L1_SIZE);
         return get_unsafe_ptr()[0];
     }
 
@@ -3322,7 +3322,7 @@ public:
      */
     tt_l1_ptr T* operator->() const {
         // TODO: To be moved to a Watcher sanitize check
-        ASSERT(address_ < MEM_L1_SIZE);
+        ASSERT(address_ + sizeof(T) <= MEM_L1_SIZE);
         return get_unsafe_ptr();
     }
 

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -3306,6 +3306,16 @@ public:
         return get_unsafe_ptr()[0];
     }
 
+    /** @brief Dereference operator
+     *
+     * @return Pointer to the structure in the core's local memory
+     */
+    volatile T* operator->() const {
+        // TODO: To be moved to a Watcher sanitize check
+        ASSERT(address_ < MEM_L1_SIZE);
+        return get_unsafe_ptr();
+    }
+
     CoreLocalMem& operator+=(difference_type offset) {
         address_ += offset * sizeof(T);
         return *this;

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -3386,7 +3386,9 @@ struct noc_traits_t<CoreLocalMem<T, AddressType>> {
     struct src_args_type {
         AddressType offset_bytes = 0;
     };
-    struct dst_args_type {};
+    struct dst_args_type {
+        AddressType offset_bytes = 0;
+    };
     struct dst_args_mcast_type {};
 
     template <Noc::AddressType address_type>
@@ -3396,7 +3398,8 @@ struct noc_traits_t<CoreLocalMem<T, AddressType>> {
     }
     template <Noc::AddressType address_type>
     static auto dst_addr(const CoreLocalMem<T, AddressType>& dst, const Noc& noc, const dst_args_type& args) {
-        static_assert(false, "CoreLocalMem cannot be used as NoC destination");
+        static_assert(address_type == Noc::AddressType::LOCAL_L1, "CoreLocalMem can only be used as local L1 dest");
+        return dst.get_address() + args.offset_bytes;
     }
     template <Noc::AddressType address_type>
     static auto dst_addr_mcast(

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -3301,7 +3301,7 @@ public:
      * @return Reference to the element at the given index
      */
     T& operator[](uint32_t index) const {
-        // TODO: To be moved to a Watcher sanitize check
+        // TODO: To be moved to a Watcher sanitize check. Fix for eth cores.
         ASSERT(address_ + (index + 1) * sizeof(T) <= MEM_L1_SIZE);
         return get_unsafe_ptr()[index];
     }
@@ -3311,7 +3311,7 @@ public:
      * @return Reference to the value at the address
      */
     T& operator*() const {
-        // TODO: To be moved to a Watcher sanitize check
+        // TODO: To be moved to a Watcher sanitize check. Fix for eth cores.
         ASSERT(address_ + sizeof(T) <= MEM_L1_SIZE);
         return get_unsafe_ptr()[0];
     }
@@ -3321,7 +3321,7 @@ public:
      * @return Pointer to the structure in the core's local memory
      */
     tt_l1_ptr T* operator->() const {
-        // TODO: To be moved to a Watcher sanitize check
+        // TODO: To be moved to a Watcher sanitize check. Fix for eth cores.
         ASSERT(address_ + sizeof(T) <= MEM_L1_SIZE);
         return get_unsafe_ptr();
     }

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cstdint>
 #if __has_include("chlkc_unpack_data_format.h")
 #include "chlkc_pack_data_format.h"
 #include "chlkc_unpack_data_format.h"
@@ -3236,9 +3237,15 @@ struct noc_traits_t<tensor_accessor::Page> {
 /**
  * @brief Provides a safe pointer to a structure of type T in local L1 memory
  */
-template <typename T, typename AddressType = uint32_t>
+template <typename T, typename AddressType = uintptr_t>
 class L1Memory {
     using difference_type = std::ptrdiff_t;
+
+    static_assert(std::is_integral<AddressType>::value, "AddressType must be an integral type");
+    static_assert(std::is_unsigned<AddressType>::value, "AddressType must be unsigned for address representation");
+    static_assert(
+        sizeof(AddressType) >= sizeof(difference_type),
+        "AddressType must be large enough to hold difference_type for safe pointer arithmetic");
 
 public:
     /** @brief Construct a L1Memory instance from a raw address


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/29592

### Problem description
- Implement a safe L1 memory accessor

### What's changed
- Implement a CoreLocalMem class with Watcher assertions when the user tries to access data it's pointing to. Note, these Watcher asserts will be upgraded to a Watcher Sanitize check in a future PR for better error messages.
- User can still access to memory without the safety checks using `get_unsafe_ptr()`
- Add unit tests to verify CoreLocalMem read, write, pointer math, and it works as a source with the NoC 2.0 API, verify that there is no perf impact when using this wrapper class compared to using raw pointers

### Checklist
All Post Commit
https://github.com/tenstorrent/tt-metal/actions/runs/19583021822
Blackhole Post Commit
https://github.com/tenstorrent/tt-metal/actions/runs/19583023364