### PR TITLE
Migrate op to new infra: group_attn_matmul

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/device/group_attn_matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/device/group_attn_matmul_device_operation.cpp
@@ -262,8 +262,8 @@ GroupAttnMatmulDeviceOperation::invoke(
     std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config,
     std::optional<const uint32_t> num_tokens,
     std::optional<const bool> transpose_hw,
-    const uint32_t out_subblock_w,
-    const bool row_major,
+    uint32_t out_subblock_w,
+    bool row_major,
     std::optional<Tensor> preallocated_output) {
     return std::make_tuple(
         operation_attributes_t{
@@ -279,7 +279,7 @@ GroupAttnMatmulDeviceOperation::invoke(
         tensor_args_t{
             .input_tensor_a = input_tensor_a,
             .input_tensor_b = input_tensor_b,
-            .preallocated_output = preallocated_output,
+            .preallocated_output = std::move(preallocated_output),
         });
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/device/group_attn_matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/device/group_attn_matmul_device_operation.cpp
@@ -5,20 +5,33 @@
 #include "group_attn_matmul_device_operation.hpp"
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/constants.hpp>
+#include "ttnn/tensor/tensor_utils.hpp"
 
 using namespace tt::tt_metal;
 
 namespace ttnn::operations::experimental::matmul {
 
-void GroupAttnMatmulDeviceOperation::validate(const std::vector<Tensor>& input_tensors) const {
+using namespace group_attn_matmul;
+
+GroupAttnMatmulDeviceOperation::program_factory_t GroupAttnMatmulDeviceOperation::select_program_factory(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    return program::GroupAttnMatmulProgramFactory{};
+}
+
+void GroupAttnMatmulDeviceOperation::validate_on_program_cache_hit(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    validate_on_program_cache_miss(operation_attributes, tensor_args);
+}
+
+void GroupAttnMatmulDeviceOperation::validate_on_program_cache_miss(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     // input_a: [q_len, q_heads, batch, head_dim]
     // input_b: [batch, kv_heads, head_dim, kv_len]
     // intermediate: [q_heads, batch, batch, kv_len]
     // output: [q_len, q_heads, batch, kv_len]
 
-    TT_FATAL(input_tensors.size() == 2, "Expected 2 input tensors but got {}", input_tensors.size());
-    const auto& input_tensor_a = input_tensors.at(0);
-    const auto& input_tensor_b = input_tensors.at(1);
+    const auto& input_tensor_a = tensor_args.input_tensor_a;
+    const auto& input_tensor_b = tensor_args.input_tensor_b;
     TT_FATAL(
         (input_tensor_a.layout() == Layout::TILE && input_tensor_b.layout() == Layout::TILE),
         "Inputs to matmul must be tilized");
@@ -42,11 +55,13 @@ void GroupAttnMatmulDeviceOperation::validate(const std::vector<Tensor>& input_t
     const auto num_cores_used =
         std::max(ashape[1], tt::constants::TILE_HEIGHT);  // Need at least 32 cores for mcasting KV heads
     TT_FATAL(
-        (num_cores_used <= this->compute_with_storage_grid_size.x * this->compute_with_storage_grid_size.y),
+        (num_cores_used <=
+         operation_attributes.compute_with_storage_grid_size.x * operation_attributes.compute_with_storage_grid_size.y),
         "Compute grid size is too small for group attention matmul! For now, we require at most 1 q_heads per core.");
 
     // Any sharded memory configs must be HEIGHT_SHARDED and have the same orientation
-    ShardOrientation shard_orientation = this->row_major ? ShardOrientation::ROW_MAJOR : ShardOrientation::COL_MAJOR;
+    ShardOrientation shard_orientation =
+        operation_attributes.row_major ? ShardOrientation::ROW_MAJOR : ShardOrientation::COL_MAJOR;
     if (input_tensor_a.is_sharded()) {
         TT_FATAL(
             input_tensor_a.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED,
@@ -92,27 +107,27 @@ void GroupAttnMatmulDeviceOperation::validate(const std::vector<Tensor>& input_t
             shard_shape[1],
             bshape[3]);
     }
-    if (this->output_mem_config.is_sharded()) {
+    if (operation_attributes.output_mem_config.is_sharded()) {
         TT_FATAL(
-            this->output_mem_config.memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED,
+            operation_attributes.output_mem_config.memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED,
             "Output memory config layout must be HEIGHT_SHARDED but got {}",
-            this->output_mem_config.memory_layout());
+            operation_attributes.output_mem_config.memory_layout());
 
         // If user passes in output_mem_config with shard_spec, assert that it is the same as the one calculated in
         // GroupAttnMatmulDeviceOperation::create_output_tensors
-        if (this->output_mem_config.shard_spec().has_value()) {
-            const ttnn::Shape output_shape = this->compute_output_specs(input_tensors).at(0).padded_shape();
+        if (operation_attributes.output_mem_config.shard_spec().has_value()) {
+            const ttnn::Shape output_shape = compute_output_specs(operation_attributes, tensor_args).padded_shape();
             const uint32_t num_cores = output_shape[1];
-            CoreRangeSet all_cores =
-                num_cores_to_corerangeset(num_cores, this->compute_with_storage_grid_size, this->row_major);
+            CoreRangeSet all_cores = num_cores_to_corerangeset(
+                num_cores, operation_attributes.compute_with_storage_grid_size, operation_attributes.row_major);
 
-            auto shard_shape = this->output_mem_config.shard_spec().value().shape;
+            auto shard_shape = operation_attributes.output_mem_config.shard_spec().value().shape;
             TT_FATAL(
-                this->output_mem_config.shard_spec().value().grid == all_cores,
+                operation_attributes.output_mem_config.shard_spec().value().grid == all_cores,
                 "Shard spec in output mem config must match shard spec calculated in "
                 "GroupAttnMatmulDeviceOperation::create_output_tensors!");
             TT_FATAL(
-                this->output_mem_config.shard_spec().value().orientation == shard_orientation,
+                operation_attributes.output_mem_config.shard_spec().value().orientation == shard_orientation,
                 "Any sharded memory configs must have the same shard orientation as one another!");
             TT_FATAL(
                 shard_shape[0] == output_shape[2],
@@ -128,22 +143,22 @@ void GroupAttnMatmulDeviceOperation::validate(const std::vector<Tensor>& input_t
     }
 
     bool read_from_kv_cache = false;
-    if (this->num_tokens.has_value() or this->transpose_hw.has_value()) {
+    if (operation_attributes.num_tokens.has_value() or operation_attributes.transpose_hw.has_value()) {
         TT_FATAL(
-            (this->num_tokens.has_value() and this->transpose_hw.has_value()),
+            (operation_attributes.num_tokens.has_value() and operation_attributes.transpose_hw.has_value()),
             "Must provide num_tokens and transpose_hw flag if we are reading from cache for in1!");
-        TT_FATAL(this->num_tokens.value() % 32 == 0, "Number of tokens must be divisble by 32!");
+        TT_FATAL(operation_attributes.num_tokens.value() % 32 == 0, "Number of tokens must be divisble by 32!");
         read_from_kv_cache = true;
     }
 
     if (read_from_kv_cache) {
-        if (this->transpose_hw.value()) {
+        if (operation_attributes.transpose_hw.value()) {
             TT_FATAL(
                 ashape[3] == bshape[3],
                 "For pre-attention matmul, dimension K for B is in B.shape[3], so A.shape[3] must match B.shape[3]");  // A.K == B.K
         } else {
             TT_FATAL(
-                ashape[3] == this->num_tokens,
+                ashape[3] == operation_attributes.num_tokens,
                 "For post-attention matmul, dimension K (A.shape[3]) is the kv_seq_len in this case and must match the "
                 "length of the cache we read");  // A.K == B.K
         }
@@ -154,67 +169,57 @@ void GroupAttnMatmulDeviceOperation::validate(const std::vector<Tensor>& input_t
     }
 }
 
-std::vector<ttnn::TensorSpec> GroupAttnMatmulDeviceOperation::compute_output_specs(
-    const std::vector<Tensor>& input_tensors) const {
+GroupAttnMatmulDeviceOperation::spec_return_value_t GroupAttnMatmulDeviceOperation::compute_output_specs(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     // input_a: [q_len, q_heads, batch, head_dim]
     // input_b: [batch, kv_heads, head_dim, kv_len]
     // intermediate: [q_heads, batch, batch, kv_len]
     // output: [q_len, q_heads, batch, kv_len]
-    const auto& input_tensor_a = input_tensors.at(0);
-    const auto& input_tensor_b = input_tensors.at(1);
+    const auto& input_tensor_a = tensor_args.input_tensor_a;
+    const auto& input_tensor_b = tensor_args.input_tensor_b;
     const auto& ashape = input_tensor_a.padded_shape();
     const auto& bshape = input_tensor_b.padded_shape();
 
     uint32_t N = bshape[3];
-    if (this->transpose_hw.value_or(false)) {
-        N = this->num_tokens.value();
+    if (operation_attributes.transpose_hw.value_or(false)) {
+        N = operation_attributes.num_tokens.value();
     }
     Shape output_shape({1, ashape[1], ashape[2], N});
 
-    if (this->output_mem_config.is_sharded()) {
-        auto output_mem_config = this->output_mem_config;
-        if (!this->output_mem_config.shard_spec().has_value()) {
+    if (operation_attributes.output_mem_config.is_sharded()) {
+        auto output_mem_config = operation_attributes.output_mem_config;
+        if (!operation_attributes.output_mem_config.shard_spec().has_value()) {
             const uint32_t num_cores = output_shape[1];
-            CoreRangeSet all_cores =
-                num_cores_to_corerangeset(num_cores, this->compute_with_storage_grid_size, this->row_major);
+            CoreRangeSet all_cores = num_cores_to_corerangeset(
+                num_cores, operation_attributes.compute_with_storage_grid_size, operation_attributes.row_major);
 
             ShardOrientation shard_orientation =
-                this->row_major ? ShardOrientation::ROW_MAJOR : ShardOrientation::COL_MAJOR;
+                operation_attributes.row_major ? ShardOrientation::ROW_MAJOR : ShardOrientation::COL_MAJOR;
             ShardSpec shard_spec = ShardSpec{all_cores, {output_shape[2], output_shape[3]}, shard_orientation};
             output_mem_config = output_mem_config.with_shard_spec(shard_spec);
         }
-        return {TensorSpec(output_shape, TensorLayout(output_dtype, PageConfig(Layout::TILE), output_mem_config))};
+        return TensorSpec(
+            output_shape, TensorLayout(operation_attributes.output_dtype, PageConfig(Layout::TILE), output_mem_config));
     }
-    return {TensorSpec(output_shape, TensorLayout(output_dtype, PageConfig(Layout::TILE), output_mem_config))};
+    return TensorSpec(
+        output_shape,
+        TensorLayout(
+            operation_attributes.output_dtype, PageConfig(Layout::TILE), operation_attributes.output_mem_config));
 }
 
-operation::ProgramWithCallbacks GroupAttnMatmulDeviceOperation::create_program(
-    const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const {
-    const auto& input_tensor_a = input_tensors.at(0);
-    const auto& input_tensor_b = input_tensors.at(1);
-    auto& output_tensor = output_tensors.at(0);
-
-    auto device_compute_with_storage_grid_size = input_tensor_a.device()->compute_with_storage_grid_size();
-    TT_ASSERT(
-        (this->compute_with_storage_grid_size.x <= device_compute_with_storage_grid_size.x &&
-         this->compute_with_storage_grid_size.y <= device_compute_with_storage_grid_size.y),
-        "Unsupported grid shape");
-
-    return multi_core_group_attn_matmul(
-        input_tensor_a,
-        input_tensor_b,
-        output_tensor,
-        this->num_tokens,
-        this->transpose_hw,
-        this->out_subblock_w,
-        this->compute_with_storage_grid_size,
-        this->row_major,
-        this->compute_kernel_config);
+GroupAttnMatmulDeviceOperation::tensor_return_value_t GroupAttnMatmulDeviceOperation::create_output_tensors(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    if (tensor_args.preallocated_output.has_value()) {
+        return *tensor_args.preallocated_output;
+    }
+    return create_device_tensor(
+        compute_output_specs(operation_attributes, tensor_args), tensor_args.input_tensor_a.device());
 }
 
-operation::Hash GroupAttnMatmulDeviceOperation::compute_program_hash(const std::vector<Tensor>& input_tensors) const {
-    const auto& input_tensor_a = input_tensors.at(0);
-    const auto& input_tensor_b = input_tensors.at(1);
+tt::stl::hash::hash_t GroupAttnMatmulDeviceOperation::compute_program_hash(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    const auto& input_tensor_a = tensor_args.input_tensor_a;
+    const auto& input_tensor_b = tensor_args.input_tensor_b;
 
     TT_ASSERT(
         std::holds_alternative<DeviceStorage>(input_tensor_a.storage()),
@@ -225,14 +230,18 @@ operation::Hash GroupAttnMatmulDeviceOperation::compute_program_hash(const std::
         "Unexpected type {}",
         tt::stl::get_active_type_name_in_variant(input_tensor_b.storage()));
 
+    auto program_factory = select_program_factory(operation_attributes, tensor_args);
+
     return operation::hash_operation<GroupAttnMatmulDeviceOperation>(
-        this->transpose_hw,
-        this->out_subblock_w,
-        this->compute_with_storage_grid_size.str(),
-        this->output_mem_config.memory_layout(),
-        this->output_mem_config.buffer_type(),
-        this->output_dtype,
-        this->row_major,
+        program_factory.index(),
+        operation_attributes.transpose_hw,
+        operation_attributes.out_subblock_w,
+        operation_attributes.compute_with_storage_grid_size.str(),
+        operation_attributes.output_mem_config.memory_layout(),
+        operation_attributes.output_mem_config.buffer_type(),
+        operation_attributes.output_dtype,
+        operation_attributes.row_major,
+        operation_attributes.compute_kernel_config,  // Affects math_fidelity and fp32_dest_acc_en in ComputeConfig
         input_tensor_a.memory_config().memory_layout(),
         input_tensor_a.memory_config().buffer_type(),
         input_tensor_a.dtype(),
@@ -241,6 +250,37 @@ operation::Hash GroupAttnMatmulDeviceOperation::compute_program_hash(const std::
         input_tensor_b.memory_config().buffer_type(),
         input_tensor_b.dtype(),
         input_tensor_b.device()->id());
+}
+
+std::tuple<GroupAttnMatmulDeviceOperation::operation_attributes_t, GroupAttnMatmulDeviceOperation::tensor_args_t>
+GroupAttnMatmulDeviceOperation::invoke(
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
+    const CoreCoord& compute_with_storage_grid_size,
+    const std::optional<MemoryConfig>& memory_config,
+    std::optional<const DataType> output_dtype,
+    std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config,
+    std::optional<const uint32_t> num_tokens,
+    std::optional<const bool> transpose_hw,
+    const uint32_t out_subblock_w,
+    const bool row_major,
+    std::optional<Tensor> preallocated_output) {
+    return std::make_tuple(
+        operation_attributes_t{
+            .num_tokens = num_tokens,
+            .transpose_hw = transpose_hw,
+            .out_subblock_w = out_subblock_w,
+            .compute_with_storage_grid_size = compute_with_storage_grid_size,
+            .output_mem_config = memory_config.value_or(input_tensor_a.memory_config()),
+            .output_dtype = output_dtype.value_or(input_tensor_a.dtype()),
+            .row_major = row_major,
+            .compute_kernel_config = compute_kernel_config.value_or(ttnn::DeviceComputeKernelConfig{}),
+        },
+        tensor_args_t{
+            .input_tensor_a = input_tensor_a,
+            .input_tensor_b = input_tensor_b,
+            .preallocated_output = preallocated_output,
+        });
 }
 
 }  // namespace ttnn::operations::experimental::matmul

--- a/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/device/group_attn_matmul_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/device/group_attn_matmul_device_operation.hpp
@@ -5,41 +5,61 @@
 #pragma once
 
 #include <optional>
+#include <variant>
 
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
-#include "ttnn/operation.hpp"
+#include "ttnn/device_operation.hpp"
+#include "ttnn/decorators.hpp"
+
+#include "group_attn_matmul_device_operation_types.hpp"
+#include "group_attn_matmul_program_factory.hpp"
 
 namespace ttnn::operations::experimental::matmul {
 
-// TODO: Group attention matmul will support sharding, mcasting, and should be faster; we should make attn_matmul (ie.
-// KV heads = 1) a special case of group_attn_matmul and run the same op
-tt::tt_metal::operation::ProgramWithCallbacks multi_core_group_attn_matmul(
-    const Tensor& a,
-    const Tensor& b,
-    Tensor& output,
-    std::optional<const uint32_t> num_tokens,
-    std::optional<const bool> transpose_hw,
-    uint32_t out_subblock_w,
-    CoreCoord compute_with_storage_grid_size,
-    bool row_major,
-    ttnn::DeviceComputeKernelConfig compute_kernel_config);
-
 struct GroupAttnMatmulDeviceOperation {
-    std::optional<const uint32_t> num_tokens;
-    std::optional<const bool> transpose_hw;
-    const uint32_t out_subblock_w;
-    CoreCoord compute_with_storage_grid_size;
-    tt::tt_metal::MemoryConfig output_mem_config;
-    tt::tt_metal::DataType output_dtype;
-    const bool row_major;  // Specifies how work is distributed across cores
-    const ttnn::DeviceComputeKernelConfig compute_kernel_config;
+    using operation_attributes_t = group_attn_matmul::operation_attributes_t;
+    using tensor_args_t = group_attn_matmul::tensor_args_t;
+    using spec_return_value_t = group_attn_matmul::spec_return_value_t;
+    using tensor_return_value_t = group_attn_matmul::tensor_return_value_t;
+    using program_factory_t = std::variant<program::GroupAttnMatmulProgramFactory>;
 
-    void validate(const std::vector<Tensor>& input_tensors) const;
-    std::vector<ttnn::TensorSpec> compute_output_specs(const std::vector<Tensor>& input_tensors) const;
-    tt::tt_metal::operation::ProgramWithCallbacks create_program(
-        const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const;
-    tt::tt_metal::operation::Hash compute_program_hash(const std::vector<Tensor>& input_tensors) const;
+    static program_factory_t select_program_factory(
+        const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
+
+    static void validate_on_program_cache_hit(
+        const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
+
+    static void validate_on_program_cache_miss(
+        const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
+
+    static spec_return_value_t compute_output_specs(
+        const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
+
+    static tensor_return_value_t create_output_tensors(
+        const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
+
+    static tt::stl::hash::hash_t compute_program_hash(
+        const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
+
+    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
+        const Tensor& input_tensor_a,
+        const Tensor& input_tensor_b,
+        const CoreCoord& compute_with_storage_grid_size,
+        const std::optional<MemoryConfig>& memory_config,
+        std::optional<const DataType> output_dtype,
+        std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config,
+        std::optional<const uint32_t> num_tokens,
+        std::optional<const bool> transpose_hw,
+        const uint32_t out_subblock_w,
+        const bool row_major,
+        std::optional<Tensor> preallocated_output);
 };
 
 }  // namespace ttnn::operations::experimental::matmul
+
+namespace ttnn::prim {
+constexpr auto group_attn_matmul = ttnn::register_operation<
+    "ttnn::prim::group_attn_matmul",
+    ttnn::operations::experimental::matmul::GroupAttnMatmulDeviceOperation>();
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/device/group_attn_matmul_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/device/group_attn_matmul_device_operation.hpp
@@ -51,8 +51,8 @@ struct GroupAttnMatmulDeviceOperation {
         std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config,
         std::optional<const uint32_t> num_tokens,
         std::optional<const bool> transpose_hw,
-        const uint32_t out_subblock_w,
-        const bool row_major,
+        uint32_t out_subblock_w,
+        bool row_major,
         std::optional<Tensor> preallocated_output);
 };
 

--- a/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/device/group_attn_matmul_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/device/group_attn_matmul_device_operation_types.hpp
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
+
+namespace ttnn::operations::experimental::matmul::group_attn_matmul {
+
+struct operation_attributes_t {
+    std::optional<const uint32_t> num_tokens;
+    std::optional<const bool> transpose_hw;
+    const uint32_t out_subblock_w;
+    CoreCoord compute_with_storage_grid_size;
+    tt::tt_metal::MemoryConfig output_mem_config;
+    tt::tt_metal::DataType output_dtype;
+    const bool row_major;  // Specifies how work is distributed across cores
+    const ttnn::DeviceComputeKernelConfig compute_kernel_config;
+};
+
+struct tensor_args_t {
+    const Tensor& input_tensor_a;
+    const Tensor& input_tensor_b;
+    std::optional<Tensor> preallocated_output;
+};
+
+using tensor_return_value_t = Tensor;
+using spec_return_value_t = TensorSpec;
+
+}  // namespace ttnn::operations::experimental::matmul::group_attn_matmul

--- a/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/device/group_attn_matmul_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/device/group_attn_matmul_program_factory.cpp
@@ -2,30 +2,331 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "group_attn_matmul_device_operation.hpp"
+#include "group_attn_matmul_program_factory.hpp"
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
 
-namespace ttnn::operations::experimental::matmul {
+namespace ttnn::operations::experimental::matmul::program {
 
 using namespace tt;
 using namespace tt::constants;
 using namespace tt::tt_metal;
+using namespace ttnn::operations::experimental::matmul::group_attn_matmul;
 
-operation::ProgramWithCallbacks multi_core_group_attn_matmul(
+namespace {
+
+void set_runtime_args(
+    Program& program,
     const Tensor& a,
     const Tensor& b,
-    Tensor& output,
-    std::optional<const uint32_t> num_tokens,
-    std::optional<const bool> transpose_hw,
-    const uint32_t out_subblock_w,
-    CoreCoord compute_with_storage_grid_size,
-    const bool row_major,
-    ttnn::DeviceComputeKernelConfig compute_kernel_config) {
+    const Tensor& output,
+    const operation_attributes_t& operation_attributes,
+    const GroupAttnMatmulProgramFactory::shared_variables_t& shared_vars) {
+    tt::tt_metal::Buffer* src0_buffer = a.buffer();
+    tt::tt_metal::Buffer* src1_buffer = b.buffer();
+    tt::tt_metal::Buffer* dst_buffer = output.buffer();
+
+    const auto& ashape = a.padded_shape();
+    const auto& bshape = b.padded_shape();
+
+    tt::tt_metal::IDevice* device = a.device();
+
+    // A block of work is one MtNt
+    uint32_t Q_HEADS =
+        ashape[1];  // ashape[0] is q_len (always 1) and ashape[1] is Q num_heads; only parallelize on this
+    // Must always have at least 32 cores active since there are always 32 mcast cores for KV_HEADS
+    // TODO: Currently, we always mcast to at least 32 cores even when Q_HEADS < 32; we can optimize if we pass in
+    // proper mcast receiver grid based on Q_HEADS
+    // TODO: If batch > 32 (ie. 64), each core handles all batches; only supported for interleaved KV_heads
+    // TODO: For sharded KV_heads, user batch must be 32 due to how we shard
+    // TODO: To generalize to allow parallelizing/sharding across generic batch for KV_heads, we need to track
+    // sender cores across batch-number of rows instead of 32
+    // TODO: Only support one block of work (ie. 1 Q head per core) because each core assumes only one KV_heads to
+    // use
+    uint32_t num_active_cores = std::max(Q_HEADS, TILE_HEIGHT);
+    auto
+        [num_cores,
+         all_cores,
+         core_group_1,
+         core_group_2,
+         num_output_blocks_per_core_group_1,
+         num_output_blocks_per_core_group_2] =
+            tt::tt_metal::split_work_to_cores(
+                operation_attributes.compute_with_storage_grid_size, num_active_cores, operation_attributes.row_major);
+    // num_cores should be same as num_active_cores
+    TT_FATAL(
+        num_output_blocks_per_core_group_1 == 1 and num_output_blocks_per_core_group_2 == 0,
+        "Group attention matmul only supports one q_heads per core. Increase compute grid size to at least have as "
+        "many cores as q_heads!");
+
+    // C = torch.matmul(A.transpose(0, 2) * B).transpose(0, 2)
+    // MN = MK*KN
+    // Note, in1 K may not be the same as in0 K. We will read up to in0 K from in1 K for matmul.
+    const bool transpose_hw_bool = operation_attributes.transpose_hw.value_or(false);
+    const uint32_t num_tokens_val =
+        operation_attributes.num_tokens.value_or(0);  // should not be nullopt if transpose_hw=true
+
+    uint32_t KV_HEADS = bshape[1];  // bshape[0] is user batch
+    uint32_t Mt = ashape[2] / TILE_HEIGHT;
+    uint32_t Kt = ashape[3] / TILE_WIDTH;
+    // For transpose_hw=true, in1_Kt is same as in0_Kt but on bshape[3]
+    // For transpose_hw=false, in1_Kt is on bshape[2] but represents the max cache length to read from (ie. may not
+    // equal in0_Kt)
+    uint32_t in1_Kt = transpose_hw_bool ? Kt : bshape[2] / TILE_HEIGHT;
+    uint32_t Nt = transpose_hw_bool ? num_tokens_val / TILE_HEIGHT : bshape[3] / TILE_WIDTH;
+    uint32_t MtKt = Mt * Kt;
+    uint32_t MtNt = Mt * Nt;
+    // For transpose_hw=true, in1_Kt is max cache length
+    // For transpose_hw=false, bshape[2] is max cache length
+    uint32_t in1_KtNt = transpose_hw_bool ? bshape[2] / TILE_HEIGHT * in1_Kt : in1_Kt * Nt;
+    uint32_t in1_CKtNt = KV_HEADS * in1_KtNt;
+
+    // Matmul params that is runtime dependent
+    uint32_t in0_block_w = Kt;
+    uint32_t in0_subblock_num_tiles = in0_block_w * shared_vars.out_subblock_h;
+    uint32_t in0_block_num_tiles = in0_subblock_num_tiles;
+    uint32_t in1_block_num_tiles_per_kv_heads = in0_block_w * shared_vars.out_subblock_w;
+    uint32_t in1_block_num_tiles = KV_HEADS * in1_block_num_tiles_per_kv_heads;
+    uint32_t in1_num_blocks = ((Nt - 1) / shared_vars.out_block_w) +
+                              1;  // Rounds up to include nearest out_block_w; "padding" is handled internally
+
+    uint32_t Nt_bytes = Nt * shared_vars.in1_single_tile_size;
+    uint32_t out_last_subblock_w =
+        Nt % shared_vars.out_block_w == 0 ? shared_vars.out_block_w : Nt % shared_vars.out_block_w;
+    uint32_t in1_last_block_w_tile_read_bytes = out_last_subblock_w * shared_vars.in1_single_tile_size;
+    uint32_t in1_last_block_addr_skip =
+        (shared_vars.out_subblock_w - out_last_subblock_w) * shared_vars.in1_single_tile_size;
+
+    uint32_t bfloat16_Nt_bytes = shared_vars.ONE_ROW_BFLOAT16_BYTES * Nt;
+    uint32_t bfloat16_last_row_bytes_read = shared_vars.ONE_ROW_BFLOAT16_BYTES * out_last_subblock_w;
+
+    // Mcast receiver args
+    // NOTE: If Q_HEADS < 32, have all cores in mcast grid participate in semaphore syncing because we mcast
+    // KV_HEADS from/to the same CB Otherwise, data corruption if sender is in mcast grid and it starts populating
+    // its mcast CB as other senders are sending
+    CoreRangeSet mcast_receiver_cores = num_cores_to_corerangeset(
+        Q_HEADS, operation_attributes.compute_with_storage_grid_size, operation_attributes.row_major);
+    CoreRange mcast_receiver_cores_bounding_box = mcast_receiver_cores.bounding_box();
+    uint32_t mcast_num_dests =
+        mcast_receiver_cores.num_cores();  // same as num_active_cores if Q_HEADS >= 32; also, always same as Q_HEADS
+    uint32_t mcast_num_cores = mcast_receiver_cores_bounding_box.size();
+    CoreCoord top_left_core = mcast_receiver_cores_bounding_box.start_coord;
+    CoreCoord bottom_right_core = mcast_receiver_cores_bounding_box.end_coord;
+    CoreCoord top_left_core_physical = device->worker_core_from_logical_core(top_left_core);
+    CoreCoord bottom_right_core_physical = device->worker_core_from_logical_core(bottom_right_core);
+
+    // Default reader runtime args
+    std::vector<uint32_t> reader_runtime_args = {
+        0,  // 0: has_work_for_mcast_kv_heads
+        0,  // 1: has_work_for_q_heads
+        src1_buffer->address(),
+        Mt,
+        Nt,
+        KV_HEADS,
+        in1_CKtNt,
+        in1_CKtNt * TILE_HEIGHT,  // in1 stride; skips 32 * KtNt in bshape[0] for one block of MtNt
+        0,                        // 8: blocks of work
+        0,  // in1_start_id; always start at 0 for each block of work and let kernels handle id tracking; for
+            // sharded, this isn't used
+
+        in0_block_w,
+        shared_vars.out_block_w,
+        shared_vars.in1_num_subblocks,
+        in1_num_blocks,
+        in1_block_num_tiles,
+
+        Nt_bytes,
+        shared_vars.in1_block_w_tile_bytes,
+        out_last_subblock_w,
+        in1_last_block_w_tile_read_bytes,
+        in1_last_block_addr_skip,
+
+        // mcast args
+        (uint32_t)(shared_vars.reader_noc_is_NOC_0 ? top_left_core_physical.x
+                                                   : bottom_right_core_physical.x),  // in1_mcast_dest_noc_start_x
+        (uint32_t)(shared_vars.reader_noc_is_NOC_0 ? top_left_core_physical.y
+                                                   : bottom_right_core_physical.y),  // in1_mcast_dest_noc_start_y
+        (uint32_t)(shared_vars.reader_noc_is_NOC_0 ? bottom_right_core_physical.x
+                                                   : top_left_core_physical.x),  // in1_mcast_dest_noc_end_x
+        (uint32_t)(shared_vars.reader_noc_is_NOC_0 ? bottom_right_core_physical.y
+                                                   : top_left_core_physical.y),  // in1_mcast_dest_noc_end_y
+        0,                                                                       // 24: in1_mcast_num_dests
+        0,                                                                       // 25: in1_mcast_num_cores
+        mcast_num_cores,  // mcast grid size; in1_mcast_num_cores may change depending on if sender is part of the
+                          // receiver grid or not
+        shared_vars.in1_mcast_sender_semaphore_id,
+        shared_vars.in1_mcast_receiver_semaphore_id,
+        in1_block_num_tiles * shared_vars.in1_single_tile_size,  // in1_mcast_sender_size_bytes
+        0,                                                       // 30: in1_mcast_sender_id
+        (uint32_t)shared_vars.in1_mcast_sender_noc_x.size(),     // in1_mcast_sender_num_x
+        (uint32_t)shared_vars.in1_mcast_sender_noc_y.size(),     // in1_mcast_sender_num_y
+    };
+    // TODO: Length of these variables should be static in length since we hard-code 32 mcast sender cores and cache
+    // on compute_with_storage_grid_size
+    reader_runtime_args.insert(
+        reader_runtime_args.end(),
+        shared_vars.in1_mcast_sender_noc_x.begin(),
+        shared_vars.in1_mcast_sender_noc_x.end());
+    reader_runtime_args.insert(
+        reader_runtime_args.end(),
+        shared_vars.in1_mcast_sender_noc_y.begin(),
+        shared_vars.in1_mcast_sender_noc_y.end());
+
+    // Default writer runtime args
+    std::vector<uint32_t> writer_runtime_args = {
+        0,  // 0: has_work_for_q_heads
+        src0_buffer->address(),
+        dst_buffer->address(),
+        Mt,
+        Kt,
+        Nt,
+        MtKt,
+        0,  // 7: blocks of work
+        0,  // 8: in0_start_id
+        0,  // 9: out_start_id
+
+        in0_block_w,
+        shared_vars.in1_num_subblocks,
+        in1_num_blocks,
+        MtNt,  // out_num_tiles
+
+        shared_vars.bfloat16_row_bytes,
+        bfloat16_Nt_bytes,
+        bfloat16_last_row_bytes_read,
+    };
+
+    // Default compute runtime args
+    std::vector<uint32_t> compute_runtime_args = {
+        0,  // 0: has_work_for_q_heads
+        0,  // 1: batch,
+        Mt,
+        0,  // 3: num_kv_heads_skip
+        0,  // 4: num_kv_heads_remaining
+
+        in0_block_w,
+        shared_vars.out_subblock_h,
+        shared_vars.in1_num_subblocks,
+        in1_num_blocks,
+        in0_block_num_tiles,
+        in1_block_num_tiles,
+        MtNt,  // out_num_tiles
+
+        in0_subblock_num_tiles,
+        shared_vars.in1_per_core_w,
+    };
+
+    CoreRange all_cores_bounding_box = all_cores.bounding_box();
+    std::vector<CoreCoord> cores = grid_to_cores_with_noop(
+        all_cores_bounding_box.end_coord.x,
+        all_cores_bounding_box.end_coord.y,
+        shared_vars.device_compute_with_storage_grid.x,
+        shared_vars.device_compute_with_storage_grid.y,
+        operation_attributes.row_major);
+    uint32_t g1_numcores = core_group_1.num_cores();
+
+    std::vector<std::vector<uint32_t>> all_reader_runtime_args = {cores.size(), reader_runtime_args};
+    std::vector<std::vector<uint32_t>> all_writer_runtime_args = {cores.size(), writer_runtime_args};
+    std::vector<std::vector<uint32_t>> all_compute_runtime_args = {cores.size(), compute_runtime_args};
+
+    // Set runtime args
+    uint32_t num_output_blocks_per_core;
+    for (uint32_t i = 0, num_blocks_written = 0; i < num_cores; i++) {
+        if (i < g1_numcores) {
+            num_output_blocks_per_core = num_output_blocks_per_core_group_1;
+        } else {
+            num_output_blocks_per_core = num_output_blocks_per_core_group_2;
+        }
+
+        uint32_t kv_heads_id = i / (Q_HEADS / KV_HEADS);
+        // Runtime method of turning off kernels/code blocks
+        // Needed because some cores only have partial readers for reading/mcasting kv_heads
+        uint32_t has_work_for_q_heads = i < Q_HEADS;  // compute and writer only does work if this is true; reader
+                                                      // will only receive kv_heads if this is true
+        uint32_t has_work_for_mcast_kv_heads = i < num_active_cores;  // reader only does any work if this is true
+        uint32_t mcast_num_cores_for_core =
+            mcast_num_cores -
+            (uint32_t)(i < mcast_num_cores);  // if sender is not part of mcast grid, send to full grid
+
+        // Update core dependent runtime args
+        all_reader_runtime_args[i][0] = has_work_for_mcast_kv_heads;
+        all_reader_runtime_args[i][1] = has_work_for_q_heads;
+        all_reader_runtime_args[i][8] = num_output_blocks_per_core;
+        // If Q_HEADS < 32, have all cores participate in receiving; std::min is needed for cases where mcast grid
+        // is > num_active_cores and non-active cores are turned off and don't receive
+        all_reader_runtime_args[i][24] =
+            Q_HEADS < TILE_HEIGHT ? std::min(mcast_num_cores_for_core, num_active_cores - 1) : mcast_num_dests - 1;
+        all_reader_runtime_args[i][25] = mcast_num_cores_for_core;
+        all_reader_runtime_args[i][30] = i;
+
+        all_writer_runtime_args[i][0] = has_work_for_q_heads;
+        all_writer_runtime_args[i][7] = num_output_blocks_per_core;
+        all_writer_runtime_args[i][8] = num_blocks_written * MtKt;
+        all_writer_runtime_args[i][9] = num_blocks_written * MtNt;
+
+        all_compute_runtime_args[i][0] = has_work_for_q_heads;
+        all_compute_runtime_args[i][1] = num_output_blocks_per_core;
+        all_compute_runtime_args[i][3] = kv_heads_id * in1_block_num_tiles_per_kv_heads;
+        all_compute_runtime_args[i][4] = (KV_HEADS - kv_heads_id) * in1_block_num_tiles_per_kv_heads;
+
+        num_blocks_written += num_output_blocks_per_core;
+    }
+
+    SetRuntimeArgs(program, shared_vars.reader_id, cores, all_reader_runtime_args);
+    SetRuntimeArgs(program, shared_vars.writer_id, cores, all_writer_runtime_args);
+    SetRuntimeArgs(program, shared_vars.compute_kernel_id, cores, all_compute_runtime_args);
+
+    // Update dynamic CBs (which is most of them)
+    if (shared_vars.in0_is_sharded) {
+        uint32_t cb0_num_input_tiles =
+            a.shard_spec().value().numel() / TILE_HW;  // Should be full MtKt and C should be 1
+        UpdateDynamicCircularBufferAddressAndTotalSize(
+            program, shared_vars.cb_src0, *src0_buffer, cb0_num_input_tiles * shared_vars.in0_single_tile_size);
+    } else {
+        uint32_t cb0_num_input_tiles =
+            in0_block_w;  // TODO: Generalize; double buffer and add blocking along ineer dim if we have Mt > 1
+        UpdateCircularBufferTotalSize(
+            program, shared_vars.cb_src0, cb0_num_input_tiles * shared_vars.in0_single_tile_size);
+    }
+
+    uint32_t cb1_num_input_tiles = 2 * in1_block_num_tiles;
+    UpdateCircularBufferTotalSize(program, shared_vars.cb_src1, cb1_num_input_tiles * shared_vars.in1_single_tile_size);
+
+    if (shared_vars.in1_is_sharded) {
+        uint32_t cb2_num_input_tiles =
+            b.shard_spec().value().numel() / TILE_HW;  // Should be full CKtNt and batch must be 32
+        UpdateDynamicCircularBufferAddressAndTotalSize(
+            program, shared_vars.cb_src2, *src1_buffer, cb2_num_input_tiles * shared_vars.in1_single_tile_size);
+    }
+
+    UpdateCircularBufferTotalSize(program, shared_vars.cb_interm1, MtNt * shared_vars.interm_single_tile_size);
+
+    if (shared_vars.output_is_sharded) {
+        uint32_t num_output_tiles =
+            output.shard_spec().value().numel() / TILE_HW;  // Should be full MtNt and C should be 1
+        UpdateDynamicCircularBufferAddressAndTotalSize(
+            program, shared_vars.cb_output, *dst_buffer, num_output_tiles * shared_vars.output_single_tile_size);
+    } else {
+        uint32_t num_output_tiles =
+            MtNt;  // TODO: Should be MtNt if Mt > 1? Or, produce one Nt at a time and double buffer?
+        UpdateCircularBufferTotalSize(
+            program, shared_vars.cb_output, num_output_tiles * shared_vars.output_single_tile_size);
+    }
+}
+
+}  // namespace
+
+GroupAttnMatmulProgramFactory::cached_program_t GroupAttnMatmulProgramFactory::create(
+    const operation_attributes_t& operation_attributes,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& tensor_return_value) {
     tt::tt_metal::Program program{};
+
+    const auto& a = tensor_args.input_tensor_a;
+    const auto& b = tensor_args.input_tensor_b;
+    const auto& output = tensor_return_value;
 
     const auto& ashape = a.padded_shape();
     const auto& bshape = b.padded_shape();
@@ -34,7 +335,7 @@ operation::ProgramWithCallbacks multi_core_group_attn_matmul(
     tt::tt_metal::IDevice* device = a.device();
 
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
-        get_compute_kernel_config_args(device->arch(), compute_kernel_config);
+        get_compute_kernel_config_args(device->arch(), operation_attributes.compute_kernel_config);
 
     tt::DataFormat in0_data_format = tt::tt_metal::datatype_to_dataformat_converter(a.dtype());
     tt::DataFormat in1_data_format = tt::tt_metal::datatype_to_dataformat_converter(b.dtype());
@@ -63,8 +364,9 @@ operation::ProgramWithCallbacks multi_core_group_attn_matmul(
         CoreRange({0, 0}, {device_compute_with_storage_grid.x - 1, device_compute_with_storage_grid.y - 1});
 
     // See set_runtime_args for how input shapes are used; these are the variables needed for setting up kernels and CBs
-    const bool transpose_hw_bool = transpose_hw.value_or(false);
-    const uint32_t num_tokens_val = num_tokens.value_or(0);  // should not be nullopt if transpose_hw=true
+    const bool transpose_hw_bool = operation_attributes.transpose_hw.value_or(false);
+    const uint32_t num_tokens_val =
+        operation_attributes.num_tokens.value_or(0);         // should not be nullopt if transpose_hw=true
     uint32_t KV_HEADS = bshape[1];                           // bshape[0] is user batch
     uint32_t Mt = ashape[2] / TILE_HEIGHT;
     uint32_t Kt = ashape[3] / TILE_WIDTH;
@@ -73,9 +375,9 @@ operation::ProgramWithCallbacks multi_core_group_attn_matmul(
 
     // Matmul blocking parameters; these determine how large CBs are; actual value doesn't matter here since CBs are
     // resized in callback...
-    const uint32_t out_block_w = out_subblock_w;
+    const uint32_t out_block_w = operation_attributes.out_subblock_w;
     const uint32_t in0_block_w = Kt;
-    const uint32_t in1_block_num_tiles = KV_HEADS * in0_block_w * out_subblock_w;
+    const uint32_t in1_block_num_tiles = KV_HEADS * in0_block_w * operation_attributes.out_subblock_w;
 
     // out_subblock_w and other hardcoded params are known at compile time
     constexpr uint32_t out_subblock_h =
@@ -84,13 +386,13 @@ operation::ProgramWithCallbacks multi_core_group_attn_matmul(
     const uint32_t out_subblock_num_tiles = out_subblock_h * out_block_w;
     const uint32_t intermediate_num_tiles = out_subblock_num_tiles;
     const uint32_t in1_per_core_w = in1_num_subblocks * out_block_w;
-    const uint32_t in1_block_w_tile_bytes = out_subblock_w * in1_single_tile_size;
+    const uint32_t in1_block_w_tile_bytes = operation_attributes.out_subblock_w * in1_single_tile_size;
     uint32_t ONE_ROW_BFLOAT16_BYTES = fp32_dest_acc_en and in0_data_format == tt::DataFormat::Float32 ? 128 : 64;
     const uint32_t bfloat16_row_bytes = ONE_ROW_BFLOAT16_BYTES * out_block_w;  // TODO: Generalize
 
     log_debug(tt::LogOp, "in0_block_w: {}", in0_block_w);
     log_debug(tt::LogOp, "out_subblock_h: {}", out_subblock_h);
-    log_debug(tt::LogOp, "out_subblock_w: {}", out_subblock_w);
+    log_debug(tt::LogOp, "out_subblock_w: {}", operation_attributes.out_subblock_w);
     log_debug(tt::LogOp, "math_fidelity: {}", math_fidelity);
     log_debug(tt::LogOp, "math_approx_mode: {}", math_approx_mode);
     log_debug(tt::LogOp, "fp32_dest_acc_en: {}", fp32_dest_acc_en);
@@ -109,7 +411,8 @@ operation::ProgramWithCallbacks multi_core_group_attn_matmul(
     // TODO: If this is not the case, then we should set reader_runtime_args to max possible size and update sender noc
     // coordinates based on input
     CoreCoord mcast_sender_grid =
-        ((CoreRangeSet)num_cores_to_corerangeset(TILE_HEIGHT, compute_with_storage_grid_size, row_major))
+        ((CoreRangeSet)num_cores_to_corerangeset(
+             TILE_HEIGHT, operation_attributes.compute_with_storage_grid_size, operation_attributes.row_major))
             .bounding_box()
             .grid_size();
     std::vector<uint32_t> in1_mcast_sender_noc_x(mcast_sender_grid.x);
@@ -212,14 +515,14 @@ operation::ProgramWithCallbacks multi_core_group_attn_matmul(
 
     std::vector<uint32_t> reader_compile_time_args = {
         (uint32_t)transpose_hw_bool,
-        (uint32_t)row_major,
-        out_subblock_w,
+        (uint32_t)operation_attributes.row_major,
+        operation_attributes.out_subblock_w,
     };
     tt::tt_metal::TensorAccessorArgs(*src1_buffer).append_to(reader_compile_time_args);
 
     std::vector<uint32_t> writer_compile_time_args = {
         (uint32_t)output_cb_index,
-        out_subblock_w,
+        operation_attributes.out_subblock_w,
         intermediate_num_tiles,
     };
     tt::tt_metal::TensorAccessorArgs(*src0_buffer).append_to(writer_compile_time_args);
@@ -267,7 +570,7 @@ operation::ProgramWithCallbacks multi_core_group_attn_matmul(
 
     std::vector<uint32_t> compute_args = {
         (uint32_t)transpose_hw_bool,  // transpose_hw for matmul_init
-        out_subblock_w,
+        operation_attributes.out_subblock_w,
         out_subblock_num_tiles,
         intermediate_num_tiles,
     };  // bmm compute kernel the B, Mt, Nt are just 3 for loops that technically act as 1 large loop, so only set Nt
@@ -281,338 +584,57 @@ operation::ProgramWithCallbacks multi_core_group_attn_matmul(
         tt::tt_metal::ComputeConfig{
             .math_fidelity = math_fidelity, .fp32_dest_acc_en = fp32_dest_acc_en, .compile_args = compute_args});
 
-    auto set_runtime_args = [num_tokens,
-                             transpose_hw,
-                             row_major,
-                             compute_with_storage_grid_size,
-                             device_compute_with_storage_grid,
-                             reader_id,
-                             writer_id,
-                             compute_kernel_id,
-                             cb_src0,
-                             cb_src1,
-                             cb_src2,
-                             cb_interm1,
-                             cb_output,
-                             in0_single_tile_size,
-                             in1_single_tile_size,
-                             interm_single_tile_size,
-                             output_single_tile_size,
-                             in0_is_sharded,
-                             in1_is_sharded,
-                             output_is_sharded,
-                             reader_noc_is_NOC_0,
-                             in1_mcast_sender_semaphore_id,
-                             in1_mcast_receiver_semaphore_id,
-                             in1_mcast_sender_noc_x,
-                             in1_mcast_sender_noc_y,
-
-                             // Params determined by out_subblock_w
-                             out_subblock_w,
-                             out_subblock_h,
-                             in1_num_subblocks,
-                             out_block_w,
-                             in1_per_core_w,
-                             in1_block_w_tile_bytes,
-                             ONE_ROW_BFLOAT16_BYTES,
-                             bfloat16_row_bytes](
-                                Program& program, const Tensor& a, const Tensor& b, const Tensor& output) {
-        tt::tt_metal::Buffer* src0_buffer = a.buffer();
-        tt::tt_metal::Buffer* src1_buffer = b.buffer();
-        tt::tt_metal::Buffer* dst_buffer = output.buffer();
-
-        const auto& ashape = a.padded_shape();
-        const auto& bshape = b.padded_shape();
-
-        tt::tt_metal::IDevice* device = a.device();
-
-        // A block of work is one MtNt
-        uint32_t Q_HEADS =
-            ashape[1];  // ashape[0] is q_len (always 1) and ashape[1] is Q num_heads; only parallelize on this
-        // Must always have at least 32 cores active since there are always 32 mcast cores for KV_HEADS
-        // TODO: Currently, we always mcast to at least 32 cores even when Q_HEADS < 32; we can optimize if we pass in
-        // proper mcast receiver grid based on Q_HEADS
-        // TODO: If batch > 32 (ie. 64), each core handles all batches; only supported for interleaved KV_heads
-        // TODO: For sharded KV_heads, user batch must be 32 due to how we shard
-        // TODO: To generalize to allow parallelizing/sharding across generic batch for KV_heads, we need to track
-        // sender cores across batch-number of rows instead of 32
-        // TODO: Only support one block of work (ie. 1 Q head per core) because each core assumes only one KV_heads to
-        // use
-        uint32_t num_active_cores = std::max(Q_HEADS, TILE_HEIGHT);
-        auto
-            [num_cores,
-             all_cores,
-             core_group_1,
-             core_group_2,
-             num_output_blocks_per_core_group_1,
-             num_output_blocks_per_core_group_2] =
-                tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_active_cores, row_major);
-        // num_cores should be same as num_active_cores
-        TT_FATAL(
-            num_output_blocks_per_core_group_1 == 1 and num_output_blocks_per_core_group_2 == 0,
-            "Group attention matmul only supports one q_heads per core. Increase compute grid size to at least have as "
-            "many cores as q_heads!");
-
-        // C = torch.matmul(A.transpose(0, 2) * B).transpose(0, 2)
-        // MN = MK*KN
-        // Note, in1 K may not be the same as in0 K. We will read up to in0 K from in1 K for matmul.
-        const bool transpose_hw_bool = transpose_hw.value_or(false);
-        const uint32_t num_tokens_val = num_tokens.value_or(0);  // should not be nullopt if transpose_hw=true
-
-        uint32_t KV_HEADS = bshape[1];  // bshape[0] is user batch
-        uint32_t Mt = ashape[2] / TILE_HEIGHT;
-        uint32_t Kt = ashape[3] / TILE_WIDTH;
-        // For transpose_hw=true, in1_Kt is same as in0_Kt but on bshape[3]
-        // For transpose_hw=false, in1_Kt is on bshape[2] but represents the max cache length to read from (ie. may not
-        // equal in0_Kt)
-        uint32_t in1_Kt = transpose_hw_bool ? Kt : bshape[2] / TILE_HEIGHT;
-        uint32_t Nt = transpose_hw_bool ? num_tokens_val / TILE_HEIGHT : bshape[3] / TILE_WIDTH;
-        uint32_t MtKt = Mt * Kt;
-        uint32_t MtNt = Mt * Nt;
-        // For transpose_hw=true, in1_Kt is max cache length
-        // For transpose_hw=false, bshape[2] is max cache length
-        uint32_t in1_KtNt = transpose_hw_bool ? bshape[2] / TILE_HEIGHT * in1_Kt : in1_Kt * Nt;
-        uint32_t in1_CKtNt = KV_HEADS * in1_KtNt;
-
-        // Matmul params that is runtime dependent
-        uint32_t in0_block_w = Kt;
-        uint32_t in0_subblock_num_tiles = in0_block_w * out_subblock_h;
-        uint32_t in0_block_num_tiles = in0_subblock_num_tiles;
-        uint32_t in1_block_num_tiles_per_kv_heads = in0_block_w * out_subblock_w;
-        uint32_t in1_block_num_tiles = KV_HEADS * in1_block_num_tiles_per_kv_heads;
-        uint32_t in1_num_blocks =
-            ((Nt - 1) / out_block_w) + 1;  // Rounds up to include nearest out_block_w; "padding" is handled internally
-
-        uint32_t Nt_bytes = Nt * in1_single_tile_size;
-        uint32_t out_last_subblock_w = Nt % out_block_w == 0 ? out_block_w : Nt % out_block_w;
-        uint32_t in1_last_block_w_tile_read_bytes = out_last_subblock_w * in1_single_tile_size;
-        uint32_t in1_last_block_addr_skip = (out_subblock_w - out_last_subblock_w) * in1_single_tile_size;
-
-        uint32_t bfloat16_Nt_bytes = ONE_ROW_BFLOAT16_BYTES * Nt;
-        uint32_t bfloat16_last_row_bytes_read = ONE_ROW_BFLOAT16_BYTES * out_last_subblock_w;
-
-        // Mcast receiver args
-        // NOTE: If Q_HEADS < 32, have all cores in mcast grid participate in semaphore syncing because we mcast
-        // KV_HEADS from/to the same CB Otherwise, data corruption if sender is in mcast grid and it starts populating
-        // its mcast CB as other senders are sending
-        CoreRangeSet mcast_receiver_cores =
-            num_cores_to_corerangeset(Q_HEADS, compute_with_storage_grid_size, row_major);
-        CoreRange mcast_receiver_cores_bounding_box = mcast_receiver_cores.bounding_box();
-        uint32_t mcast_num_dests =
-            mcast_receiver_cores
-                .num_cores();  // same as num_active_cores if Q_HEADS >= 32; also, always same as Q_HEADS
-        uint32_t mcast_num_cores = mcast_receiver_cores_bounding_box.size();
-        CoreCoord top_left_core = mcast_receiver_cores_bounding_box.start_coord;
-        CoreCoord bottom_right_core = mcast_receiver_cores_bounding_box.end_coord;
-        CoreCoord top_left_core_physical = device->worker_core_from_logical_core(top_left_core);
-        CoreCoord bottom_right_core_physical = device->worker_core_from_logical_core(bottom_right_core);
-
-        // Default reader runtime args
-        std::vector<uint32_t> reader_runtime_args = {
-            0,  // 0: has_work_for_mcast_kv_heads
-            0,  // 1: has_work_for_q_heads
-            src1_buffer->address(),
-            Mt,
-            Nt,
-            KV_HEADS,
-            in1_CKtNt,
-            in1_CKtNt * TILE_HEIGHT,  // in1 stride; skips 32 * KtNt in bshape[0] for one block of MtNt
-            0,                        // 8: blocks of work
-            0,  // in1_start_id; always start at 0 for each block of work and let kernels handle id tracking; for
-                // sharded, this isn't used
-
-            in0_block_w,
-            out_block_w,
-            in1_num_subblocks,
-            in1_num_blocks,
-            in1_block_num_tiles,
-
-            Nt_bytes,
-            in1_block_w_tile_bytes,
-            out_last_subblock_w,
-            in1_last_block_w_tile_read_bytes,
-            in1_last_block_addr_skip,
-
-            // mcast args
-            (uint32_t)(reader_noc_is_NOC_0 ? top_left_core_physical.x
-                                           : bottom_right_core_physical.x),  // in1_mcast_dest_noc_start_x
-            (uint32_t)(reader_noc_is_NOC_0 ? top_left_core_physical.y
-                                           : bottom_right_core_physical.y),  // in1_mcast_dest_noc_start_y
-            (uint32_t)(reader_noc_is_NOC_0 ? bottom_right_core_physical.x
-                                           : top_left_core_physical.x),  // in1_mcast_dest_noc_end_x
-            (uint32_t)(reader_noc_is_NOC_0 ? bottom_right_core_physical.y
-                                           : top_left_core_physical.y),  // in1_mcast_dest_noc_end_y
-            0,                                                           // 24: in1_mcast_num_dests
-            0,                                                           // 25: in1_mcast_num_cores
-            mcast_num_cores,  // mcast grid size; in1_mcast_num_cores may change depending on if sender is part of the
-                              // receiver grid or not
-            in1_mcast_sender_semaphore_id,
-            in1_mcast_receiver_semaphore_id,
-            in1_block_num_tiles * in1_single_tile_size,  // in1_mcast_sender_size_bytes
-            0,                                           // 30: in1_mcast_sender_id
-            (uint32_t)in1_mcast_sender_noc_x.size(),     // in1_mcast_sender_num_x
-            (uint32_t)in1_mcast_sender_noc_y.size(),     // in1_mcast_sender_num_y
-        };
-        // TODO: Length of these variables should be static in length since we hard-code 32 mcast sender cores and cache
-        // on compute_with_storage_grid_size
-        reader_runtime_args.insert(
-            reader_runtime_args.end(), in1_mcast_sender_noc_x.begin(), in1_mcast_sender_noc_x.end());
-        reader_runtime_args.insert(
-            reader_runtime_args.end(), in1_mcast_sender_noc_y.begin(), in1_mcast_sender_noc_y.end());
-
-        // Default writer runtime args
-        std::vector<uint32_t> writer_runtime_args = {
-            0,  // 0: has_work_for_q_heads
-            src0_buffer->address(),
-            dst_buffer->address(),
-            Mt,
-            Kt,
-            Nt,
-            MtKt,
-            0,  // 7: blocks of work
-            0,  // 8: in0_start_id
-            0,  // 9: out_start_id
-
-            in0_block_w,
-            in1_num_subblocks,
-            in1_num_blocks,
-            MtNt,  // out_num_tiles
-
-            bfloat16_row_bytes,
-            bfloat16_Nt_bytes,
-            bfloat16_last_row_bytes_read,
-        };
-
-        // Default compute runtime args
-        std::vector<uint32_t> compute_runtime_args = {
-            0,  // 0: has_work_for_q_heads
-            0,  // 1: batch,
-            Mt,
-            0,  // 3: num_kv_heads_skip
-            0,  // 4: num_kv_heads_remaining
-
-            in0_block_w,
-            out_subblock_h,
-            in1_num_subblocks,
-            in1_num_blocks,
-            in0_block_num_tiles,
-            in1_block_num_tiles,
-            MtNt,  // out_num_tiles
-
-            in0_subblock_num_tiles,
-            in1_per_core_w,
-        };
-
-        CoreRange all_cores_bounding_box = all_cores.bounding_box();
-        std::vector<CoreCoord> cores = grid_to_cores_with_noop(
-            all_cores_bounding_box.end_coord.x,
-            all_cores_bounding_box.end_coord.y,
-            device_compute_with_storage_grid.x,
-            device_compute_with_storage_grid.y,
-            row_major);
-        uint32_t g1_numcores = core_group_1.num_cores();
-
-        std::vector<std::vector<uint32_t>> all_reader_runtime_args = {cores.size(), reader_runtime_args};
-        std::vector<std::vector<uint32_t>> all_writer_runtime_args = {cores.size(), writer_runtime_args};
-        std::vector<std::vector<uint32_t>> all_compute_runtime_args = {cores.size(), compute_runtime_args};
-
-        // Set runtime args
-        uint32_t num_output_blocks_per_core;
-        for (uint32_t i = 0, num_blocks_written = 0; i < num_cores; i++) {
-            if (i < g1_numcores) {
-                num_output_blocks_per_core = num_output_blocks_per_core_group_1;
-            } else {
-                num_output_blocks_per_core = num_output_blocks_per_core_group_2;
-            }
-
-            uint32_t kv_heads_id = i / (Q_HEADS / KV_HEADS);
-            // Runtime method of turning off kernels/code blocks
-            // Needed because some cores only have partial readers for reading/mcasting kv_heads
-            uint32_t has_work_for_q_heads = i < Q_HEADS;  // compute and writer only does work if this is true; reader
-                                                          // will only receive kv_heads if this is true
-            uint32_t has_work_for_mcast_kv_heads = i < num_active_cores;  // reader only does any work if this is true
-            uint32_t mcast_num_cores_for_core =
-                mcast_num_cores -
-                (uint32_t)(i < mcast_num_cores);  // if sender is not part of mcast grid, send to full grid
-
-            // Update core dependent runtime args
-            all_reader_runtime_args[i][0] = has_work_for_mcast_kv_heads;
-            all_reader_runtime_args[i][1] = has_work_for_q_heads;
-            all_reader_runtime_args[i][8] = num_output_blocks_per_core;
-            // If Q_HEADS < 32, have all cores participate in receiving; std::min is needed for cases where mcast grid
-            // is > num_active_cores and non-active cores are turned off and don't receive
-            all_reader_runtime_args[i][24] =
-                Q_HEADS < TILE_HEIGHT ? std::min(mcast_num_cores_for_core, num_active_cores - 1) : mcast_num_dests - 1;
-            all_reader_runtime_args[i][25] = mcast_num_cores_for_core;
-            all_reader_runtime_args[i][30] = i;
-
-            all_writer_runtime_args[i][0] = has_work_for_q_heads;
-            all_writer_runtime_args[i][7] = num_output_blocks_per_core;
-            all_writer_runtime_args[i][8] = num_blocks_written * MtKt;
-            all_writer_runtime_args[i][9] = num_blocks_written * MtNt;
-
-            all_compute_runtime_args[i][0] = has_work_for_q_heads;
-            all_compute_runtime_args[i][1] = num_output_blocks_per_core;
-            all_compute_runtime_args[i][3] = kv_heads_id * in1_block_num_tiles_per_kv_heads;
-            all_compute_runtime_args[i][4] = (KV_HEADS - kv_heads_id) * in1_block_num_tiles_per_kv_heads;
-
-            num_blocks_written += num_output_blocks_per_core;
-        }
-
-        SetRuntimeArgs(program, reader_id, cores, all_reader_runtime_args);
-        SetRuntimeArgs(program, writer_id, cores, all_writer_runtime_args);
-        SetRuntimeArgs(program, compute_kernel_id, cores, all_compute_runtime_args);
-
-        // Update dynamic CBs (which is most of them)
-        if (in0_is_sharded) {
-            uint32_t cb0_num_input_tiles =
-                a.shard_spec().value().numel() / TILE_HW;  // Should be full MtKt and C should be 1
-            UpdateDynamicCircularBufferAddressAndTotalSize(
-                program, cb_src0, *src0_buffer, cb0_num_input_tiles * in0_single_tile_size);
-        } else {
-            uint32_t cb0_num_input_tiles =
-                in0_block_w;  // TODO: Generalize; double buffer and add blocking along ineer dim if we have Mt > 1
-            UpdateCircularBufferTotalSize(program, cb_src0, cb0_num_input_tiles * in0_single_tile_size);
-        }
-
-        uint32_t cb1_num_input_tiles = 2 * in1_block_num_tiles;
-        UpdateCircularBufferTotalSize(program, cb_src1, cb1_num_input_tiles * in1_single_tile_size);
-
-        if (in1_is_sharded) {
-            uint32_t cb2_num_input_tiles =
-                b.shard_spec().value().numel() / TILE_HW;  // Should be full CKtNt and batch must be 32
-            UpdateDynamicCircularBufferAddressAndTotalSize(
-                program, cb_src2, *src1_buffer, cb2_num_input_tiles * in1_single_tile_size);
-        }
-
-        UpdateCircularBufferTotalSize(program, cb_interm1, MtNt * interm_single_tile_size);
-
-        if (output_is_sharded) {
-            uint32_t num_output_tiles =
-                output.shard_spec().value().numel() / TILE_HW;  // Should be full MtNt and C should be 1
-            UpdateDynamicCircularBufferAddressAndTotalSize(
-                program, cb_output, *dst_buffer, num_output_tiles * output_single_tile_size);
-        } else {
-            uint32_t num_output_tiles =
-                MtNt;  // TODO: Should be MtNt if Mt > 1? Or, produce one Nt at a time and double buffer?
-            UpdateCircularBufferTotalSize(program, cb_output, num_output_tiles * output_single_tile_size);
-        }
+    // Store shared variables
+    shared_variables_t shared_vars{
+        .reader_id = reader_id,
+        .writer_id = writer_id,
+        .compute_kernel_id = compute_kernel_id,
+        .cb_src0 = cb_src0,
+        .cb_src1 = cb_src1,
+        .cb_src2 = cb_src2,
+        .cb_interm1 = cb_interm1,
+        .cb_output = cb_output,
+        .in1_mcast_sender_semaphore_id = in1_mcast_sender_semaphore_id,
+        .in1_mcast_receiver_semaphore_id = in1_mcast_receiver_semaphore_id,
+        .in1_mcast_sender_noc_x = in1_mcast_sender_noc_x,
+        .in1_mcast_sender_noc_y = in1_mcast_sender_noc_y,
+        .in0_single_tile_size = in0_single_tile_size,
+        .in1_single_tile_size = in1_single_tile_size,
+        .interm_single_tile_size = interm_single_tile_size,
+        .output_single_tile_size = output_single_tile_size,
+        .in0_is_sharded = in0_is_sharded,
+        .in1_is_sharded = in1_is_sharded,
+        .output_is_sharded = output_is_sharded,
+        .reader_noc_is_NOC_0 = reader_noc_is_NOC_0,
+        .out_subblock_w = operation_attributes.out_subblock_w,
+        .out_subblock_h = out_subblock_h,
+        .in1_num_subblocks = in1_num_subblocks,
+        .out_block_w = out_block_w,
+        .in1_per_core_w = in1_per_core_w,
+        .in1_block_w_tile_bytes = in1_block_w_tile_bytes,
+        .ONE_ROW_BFLOAT16_BYTES = ONE_ROW_BFLOAT16_BYTES,
+        .bfloat16_row_bytes = bfloat16_row_bytes,
+        .device_compute_with_storage_grid = device_compute_with_storage_grid,
     };
 
-    set_runtime_args(program, a, b, output);
+    // Set initial runtime args
+    set_runtime_args(program, a, b, output, operation_attributes, shared_vars);
 
-    auto override_runtime_arguments_callback = [set_runtime_args](
-                                                   const void* operation,
-                                                   Program& program,
-                                                   const std::vector<Tensor>& input_tensors,
-                                                   const std::vector<std::optional<const Tensor>>&,
-                                                   const std::vector<Tensor>& output_tensors) {
-        const auto& output_tensor = output_tensors.at(0);
-
-        set_runtime_args(program, input_tensors.at(0), input_tensors.at(1), output_tensor);
-    };
-
-    return {.program = std::move(program), .override_runtime_arguments_callback = override_runtime_arguments_callback};
+    return cached_program_t{std::move(program), std::move(shared_vars)};
 }
 
-}  // namespace ttnn::operations::experimental::matmul
+void GroupAttnMatmulProgramFactory::override_runtime_arguments(
+    cached_program_t& cached_program,
+    const operation_attributes_t& operation_attributes,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& tensor_return_value) {
+    set_runtime_args(
+        cached_program.program,
+        tensor_args.input_tensor_a,
+        tensor_args.input_tensor_b,
+        tensor_return_value,
+        operation_attributes,
+        cached_program.shared_variables);
+}
+
+}  // namespace ttnn::operations::experimental::matmul::program

--- a/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/device/group_attn_matmul_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/device/group_attn_matmul_program_factory.hpp
@@ -15,34 +15,34 @@ namespace ttnn::operations::experimental::matmul::program {
 using namespace ttnn::operations::experimental::matmul::group_attn_matmul;
 
 struct GroupAttnMatmulSharedVariables {
-    tt::tt_metal::KernelHandle reader_id;
-    tt::tt_metal::KernelHandle writer_id;
-    tt::tt_metal::KernelHandle compute_kernel_id;
-    tt::tt_metal::CBHandle cb_src0;
-    tt::tt_metal::CBHandle cb_src1;
-    tt::tt_metal::CBHandle cb_src2;  // 0 if unused
-    tt::tt_metal::CBHandle cb_interm1;
-    tt::tt_metal::CBHandle cb_output;
-    uint32_t in1_mcast_sender_semaphore_id;
-    uint32_t in1_mcast_receiver_semaphore_id;
+    tt::tt_metal::KernelHandle reader_id = 0;
+    tt::tt_metal::KernelHandle writer_id = 0;
+    tt::tt_metal::KernelHandle compute_kernel_id = 0;
+    tt::tt_metal::CBHandle cb_src0 = 0;
+    tt::tt_metal::CBHandle cb_src1 = 0;
+    tt::tt_metal::CBHandle cb_src2 = 0;  // 0 if unused
+    tt::tt_metal::CBHandle cb_interm1 = 0;
+    tt::tt_metal::CBHandle cb_output = 0;
+    uint32_t in1_mcast_sender_semaphore_id = 0;
+    uint32_t in1_mcast_receiver_semaphore_id = 0;
     std::vector<uint32_t> in1_mcast_sender_noc_x;
     std::vector<uint32_t> in1_mcast_sender_noc_y;
-    uint32_t in0_single_tile_size;
-    uint32_t in1_single_tile_size;
-    uint32_t interm_single_tile_size;
-    uint32_t output_single_tile_size;
-    bool in0_is_sharded;
-    bool in1_is_sharded;
-    bool output_is_sharded;
-    bool reader_noc_is_NOC_0;
-    uint32_t out_subblock_w;
-    uint32_t out_subblock_h;
-    uint32_t in1_num_subblocks;
-    uint32_t out_block_w;
-    uint32_t in1_per_core_w;
-    uint32_t in1_block_w_tile_bytes;
-    uint32_t ONE_ROW_BFLOAT16_BYTES;
-    uint32_t bfloat16_row_bytes;
+    uint32_t in0_single_tile_size = 0;
+    uint32_t in1_single_tile_size = 0;
+    uint32_t interm_single_tile_size = 0;
+    uint32_t output_single_tile_size = 0;
+    bool in0_is_sharded = false;
+    bool in1_is_sharded = false;
+    bool output_is_sharded = false;
+    bool reader_noc_is_NOC_0 = false;
+    uint32_t out_subblock_w = 0;
+    uint32_t out_subblock_h = 0;
+    uint32_t in1_num_subblocks = 0;
+    uint32_t out_block_w = 0;
+    uint32_t in1_per_core_w = 0;
+    uint32_t in1_block_w_tile_bytes = 0;
+    uint32_t ONE_ROW_BFLOAT16_BYTES = 0;
+    uint32_t bfloat16_row_bytes = 0;
     CoreCoord device_compute_with_storage_grid;
 };
 

--- a/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/device/group_attn_matmul_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/device/group_attn_matmul_program_factory.hpp
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <vector>
+
+#include "group_attn_matmul_device_operation_types.hpp"
+#include "ttnn/device_operation.hpp"
+#include "ttnn/tensor/tensor.hpp"
+
+namespace ttnn::operations::experimental::matmul::program {
+
+using namespace ttnn::operations::experimental::matmul::group_attn_matmul;
+
+struct GroupAttnMatmulSharedVariables {
+    tt::tt_metal::KernelHandle reader_id;
+    tt::tt_metal::KernelHandle writer_id;
+    tt::tt_metal::KernelHandle compute_kernel_id;
+    tt::tt_metal::CBHandle cb_src0;
+    tt::tt_metal::CBHandle cb_src1;
+    tt::tt_metal::CBHandle cb_src2;  // 0 if unused
+    tt::tt_metal::CBHandle cb_interm1;
+    tt::tt_metal::CBHandle cb_output;
+    uint32_t in1_mcast_sender_semaphore_id;
+    uint32_t in1_mcast_receiver_semaphore_id;
+    std::vector<uint32_t> in1_mcast_sender_noc_x;
+    std::vector<uint32_t> in1_mcast_sender_noc_y;
+    uint32_t in0_single_tile_size;
+    uint32_t in1_single_tile_size;
+    uint32_t interm_single_tile_size;
+    uint32_t output_single_tile_size;
+    bool in0_is_sharded;
+    bool in1_is_sharded;
+    bool output_is_sharded;
+    bool reader_noc_is_NOC_0;
+    uint32_t out_subblock_w;
+    uint32_t out_subblock_h;
+    uint32_t in1_num_subblocks;
+    uint32_t out_block_w;
+    uint32_t in1_per_core_w;
+    uint32_t in1_block_w_tile_bytes;
+    uint32_t ONE_ROW_BFLOAT16_BYTES;
+    uint32_t bfloat16_row_bytes;
+    CoreCoord device_compute_with_storage_grid;
+};
+
+struct GroupAttnMatmulProgramFactory {
+    using shared_variables_t = GroupAttnMatmulSharedVariables;
+    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
+
+    static cached_program_t create(
+        const operation_attributes_t& operation_attributes,
+        const tensor_args_t& tensor_args,
+        tensor_return_value_t& tensor_return_value);
+
+    static void override_runtime_arguments(
+        cached_program_t& cached_program,
+        const operation_attributes_t& operation_attributes,
+        const tensor_args_t& tensor_args,
+        tensor_return_value_t& tensor_return_value);
+};
+
+}  // namespace ttnn::operations::experimental::matmul::program

--- a/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/group_attn_matmul.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/group_attn_matmul.cpp
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "device/group_attn_matmul_device_operation.hpp"
-#include "ttnn/run_operation.hpp"
 #include "ttnn/operations/core/core.hpp"
 #include "group_attn_matmul.hpp"
 
@@ -56,20 +55,18 @@ ttnn::Tensor GroupAttnMatmulOperation::invoke(
         },
         kernel_config_val);
 
-    return tt::tt_metal::operation::run(
-               GroupAttnMatmulDeviceOperation{
-                   std::nullopt,
-                   std::nullopt,
-                   out_subblock_w,
-                   compute_with_storage_grid_size,
-                   mem_config,
-                   output_dtype.value_or(input_tensor_a.dtype()),
-                   row_major,
-                   kernel_config_val},
-               {input_tensor_a, input_tensor_b},
-               {},
-               {std::move(optional_output_tensor)})
-        .at(0);
+    return ttnn::prim::group_attn_matmul(
+        input_tensor_a,
+        input_tensor_b,
+        compute_with_storage_grid_size,
+        mem_config,
+        output_dtype,
+        std::make_optional(kernel_config_val),
+        std::nullopt,  // num_tokens
+        std::nullopt,  // transpose_hw
+        out_subblock_w,
+        row_major,
+        std::move(optional_output_tensor));
 }
 
 }  // namespace ttnn::operations::experimental::matmul


### PR DESCRIPTION
## Summary
This PR migrates the operation to the new device operation infrastructure.

## Changes
Migrated from legacy to new structure
Updated program factory to use new device operation interface
Removed old and files
Added new device operation files following the new infrastructure pattern

## Testing
Pre-commit hooks passed
All formatting checks passed

- [x] [(T3K) T3000 model perf tests](https://github.com/tenstorrent/tt-metal/actions/runs/19546883075)