### PR TITLE
#30286: Add num_command_queues to ttnn.open_device api similar to ttnn.open_mesh_device api

### DIFF
--- a/tests/ttnn/unit_tests/base_functionality/test_device.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_device.py
@@ -10,7 +10,7 @@ import torch
 
 def test_open_device():
     """Simple unit test to test device open/close APIs"""
-    device = ttnn.open_device(device_id=0)
+    device = ttnn.open_device(device_id=0, num_command_queues=1)
     ttnn.close_device(device)
 
 

--- a/ttnn/api/ttnn/device.hpp
+++ b/ttnn/api/ttnn/device.hpp
@@ -17,6 +17,7 @@ std::shared_ptr<MeshDevice> open_mesh_device(
     int device_id,
     size_t l1_small_size = DEFAULT_L1_SMALL_SIZE,
     size_t trace_region_size = DEFAULT_TRACE_REGION_SIZE,
+    size_t num_command_queues = 1,
     const tt::tt_metal::DispatchCoreConfig& dispatch_core_config = tt::tt_metal::DispatchCoreConfig{},
     size_t worker_l1_size = DEFAULT_WORKER_L1_SIZE);
 void close_device(IDevice& device);

--- a/ttnn/core/device.cpp
+++ b/ttnn/core/device.cpp
@@ -13,10 +13,11 @@ std::shared_ptr<MeshDevice> open_mesh_device(
     int device_id,
     size_t l1_small_size,
     size_t trace_region_size,
+    size_t num_command_queues,
     const tt::tt_metal::DispatchCoreConfig& dispatch_core_config,
     size_t worker_l1_size) {
     return MeshDevice::create_unit_mesh(
-        device_id, l1_small_size, trace_region_size, 1, dispatch_core_config, {}, worker_l1_size);
+        device_id, l1_small_size, trace_region_size, num_command_queues, dispatch_core_config, {}, worker_l1_size);
 }
 
 void enable_program_cache(IDevice& device) { device.enable_program_cache(); }

--- a/ttnn/cpp/ttnn-pybind/device.cpp
+++ b/ttnn/cpp/ttnn-pybind/device.cpp
@@ -43,6 +43,7 @@ void ttnn_device(py::module& module) {
         py::arg("device_id"),
         py::arg("l1_small_size") = DEFAULT_L1_SMALL_SIZE,
         py::arg("trace_region_size") = DEFAULT_TRACE_REGION_SIZE,
+        py::arg("num_command_queues") = 1,
         py::arg("dispatch_core_config") = tt::tt_metal::DispatchCoreConfig{},
         py::arg("worker_l1_size") = DEFAULT_WORKER_L1_SIZE,
         py::return_value_policy::reference,
@@ -53,8 +54,9 @@ void ttnn_device(py::module& module) {
                 device_id (int): The device ID to open.
                 l1_small_size (int, optional): The size of the L1 small buffer. Defaults to `ttnn.device.DEFAULT_L1_SMALL_SIZE`.
                 trace_region_size (int, optional): The size of the trace region. Defaults to `ttnn.device.DEFAULT_TRACE_REGION_SIZE`.
+                num_command_queues (int, optional): The number of command queues to open. Defaults to 1.
+                dispatch_core_config (ttnn.device.DispatchCoreConfig, optional): The dispatch core config to use. Defaults to a hardware-specific value.
                 worker_l1_size (int, optional): The size of the user-allocatable L1 buffer. Defaults to a hardware-specific value.
-                dispatch_core_type (ttnn.device.DispatchCoreType, optional): The type of dispatch core to use. Defaults to `ttnn.device.DispatchCoreType.WORKER`.
 
             Returns:
                 ttnn.Device: The device with the given device_id.


### PR DESCRIPTION
### Ticket
#30286

### Problem description
`ttnn.open_mesh_device` has a `num_command_queues` parameter, yet `ttnn.open_device` does not (it is internally hardcoded to 1). This makes our apis non-uniform.

### What's changed
Add `num_command_queues` parameter to `ttnn.open_device`.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [x] New/Existing tests provide coverage for changes