### PR TITLE
Conv3d prepare weights and bias

### DIFF
--- a/tests/ttnn/unit_tests/operations/conv/test_conv3d.py
+++ b/tests/ttnn/unit_tests/operations/conv/test_conv3d.py
@@ -151,13 +151,11 @@ def run_conv3d_test(device, input_shape, out_channels, kernel_size, stride, padd
         in_channels=C,
         out_channels=out_channels,
         conv_config=config,
-        device=device,
         alignment=ALIGNMENT,
     )
     tt_bias = ttnn.prepare_conv3d_bias(
         bias_tensor=ttnn.from_torch(conv3d_module.bias.data, dtype=ttnn.bfloat16, device=device),
         out_channels=out_channels,
-        device=device,
     )
 
     tt_output = ttnn.experimental.conv3d(

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/CMakeLists.txt
@@ -26,6 +26,7 @@ target_sources(
         FILES ${kernels}
     PRIVATE
         conv3d.cpp
+        prepare_conv3d_weights.cpp
         device/conv3d_device_operation.cpp
         device/conv3d_program_factory.cpp
 )

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/conv3d_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/conv3d_pybind.cpp
@@ -11,6 +11,7 @@
 #include <pybind11/stl.h>
 
 #include "conv3d.hpp"
+#include "prepare_conv3d_weights.hpp"
 #include "ttnn-pybind/decorators.hpp"
 #include "ttnn/types.hpp"
 #include <tt-metalium/constants.hpp>
@@ -118,6 +119,57 @@ void py_bind_conv3d(py::module& module) {
     py_conv3d_config.def_readwrite("compute_with_storage_grid_size", &Conv3dConfig::compute_with_storage_grid_size, "");
 
     py_conv3d_config.def("__repr__", [](const Conv3dConfig& config) { return fmt::format("{}", config); });
+
+    // Bind prepare_conv3d_weights function
+    module.def(
+        "prepare_conv3d_weights",
+        prepare_conv3d_weights,
+        py::kw_only(),
+        py::arg("weight_tensor"),
+        py::arg("in_channels"),
+        py::arg("out_channels"),
+        py::arg("conv_config"),
+        py::arg("device"),
+        py::arg("alignment") = 16,
+        R"doc(
+        Prepares conv3d weight tensor for device execution.
+
+        Transforms PyTorch-style weight tensor [out_channels, in_channels, kD, kH, kW]
+        to the format expected by conv3d device operation.
+
+        Args:
+            weight_tensor (ttnn.Tensor): Weight tensor in PyTorch format [out_channels, in_channels, kD, kH, kW].
+            in_channels (int): Number of input channels.
+            out_channels (int): Number of output channels.
+            conv_config (ttnn.Conv3dConfig): Conv3d configuration containing C_in_block and other parameters.
+            device (ttnn.MeshDevice): Device to prepare weights for.
+            alignment (int, optional): Channel alignment boundary. Defaults to 16.
+
+        Returns:
+            ttnn.Tensor: Prepared weight tensor in tile layout, shape [-1, out_channels].
+        )doc");
+
+    // Bind prepare_conv3d_bias function
+    module.def(
+        "prepare_conv3d_bias",
+        prepare_conv3d_bias,
+        py::kw_only(),
+        py::arg("bias_tensor"),
+        py::arg("out_channels"),
+        py::arg("device"),
+        R"doc(
+        Prepares conv3d bias tensor for device execution.
+
+        Reshapes bias to [1, out_channels] format and converts to tile layout.
+
+        Args:
+            bias_tensor (ttnn.Tensor): Bias tensor.
+            out_channels (int): Number of output channels.
+            device (ttnn.MeshDevice): Device to prepare bias for.
+
+        Returns:
+            ttnn.Tensor: Prepared bias tensor in tile layout, shape [1, out_channels].
+        )doc");
 }
 
 }  // namespace ttnn::operations::experimental::conv3d::detail

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/conv3d_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/conv3d_pybind.cpp
@@ -129,7 +129,6 @@ void py_bind_conv3d(py::module& module) {
         py::arg("in_channels"),
         py::arg("out_channels"),
         py::arg("conv_config"),
-        py::arg("device"),
         py::arg("alignment") = 16,
         R"doc(
         Prepares conv3d weight tensor for device execution.
@@ -142,7 +141,6 @@ void py_bind_conv3d(py::module& module) {
             in_channels (int): Number of input channels.
             out_channels (int): Number of output channels.
             conv_config (ttnn.Conv3dConfig): Conv3d configuration containing C_in_block and other parameters.
-            device (ttnn.MeshDevice): Device to prepare weights for.
             alignment (int, optional): Channel alignment boundary. Defaults to 16.
 
         Returns:
@@ -156,7 +154,6 @@ void py_bind_conv3d(py::module& module) {
         py::kw_only(),
         py::arg("bias_tensor"),
         py::arg("out_channels"),
-        py::arg("device"),
         R"doc(
         Prepares conv3d bias tensor for device execution.
 
@@ -165,7 +162,6 @@ void py_bind_conv3d(py::module& module) {
         Args:
             bias_tensor (ttnn.Tensor): Bias tensor.
             out_channels (int): Number of output channels.
-            device (ttnn.MeshDevice): Device to prepare bias for.
 
         Returns:
             ttnn.Tensor: Prepared bias tensor in tile layout, shape [1, out_channels].

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/prepare_conv3d_weights.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/prepare_conv3d_weights.cpp
@@ -21,7 +21,6 @@ ttnn::Tensor prepare_conv3d_weights(
     uint32_t in_channels,
     uint32_t out_channels,
     const Conv3dConfig& conv_config,
-    MeshDevice* device,
     uint32_t alignment) {
     TT_FATAL(weight_tensor.layout() == Layout::ROW_MAJOR, "Weight tensor must be in ROW_MAJOR layout");
     TT_FATAL(
@@ -92,7 +91,7 @@ ttnn::Tensor prepare_conv3d_weights(
     return ttnn::to_layout(w, Layout::TILE);
 }
 
-ttnn::Tensor prepare_conv3d_bias(const ttnn::Tensor& bias_tensor, uint32_t out_channels, MeshDevice* device) {
+ttnn::Tensor prepare_conv3d_bias(const ttnn::Tensor& bias_tensor, uint32_t out_channels) {
     TT_FATAL(bias_tensor.layout() == Layout::ROW_MAJOR, "Bias tensor must be in ROW_MAJOR layout");
     TT_FATAL(
         bias_tensor.logical_volume() == out_channels,

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/prepare_conv3d_weights.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/prepare_conv3d_weights.cpp
@@ -1,0 +1,113 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "prepare_conv3d_weights.hpp"
+#include <cstdint>
+#include <tt-logger/tt-logger.hpp>
+#include "tt-metalium/shape.hpp"
+#include "ttnn/operations/data_movement/permute/permute.hpp"
+#include "ttnn/operations/data_movement/pad/pad.hpp"
+#include "ttnn/operations/data_movement/reshape_view/reshape.hpp"
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/operations/core/core.hpp"
+
+namespace ttnn {
+namespace operations::experimental::conv3d {
+namespace detail {
+
+ttnn::Tensor prepare_conv3d_weights(
+    const ttnn::Tensor& weight_tensor,
+    uint32_t in_channels,
+    uint32_t out_channels,
+    const Conv3dConfig& conv_config,
+    MeshDevice* device,
+    uint32_t alignment) {
+    TT_FATAL(weight_tensor.layout() == Layout::ROW_MAJOR, "Weight tensor must be in ROW_MAJOR layout");
+    TT_FATAL(
+        weight_tensor.logical_shape().rank() == 5, "Weight tensor must be 5D [out_channels, in_channels, kD, kH, kW]");
+
+    auto shape = weight_tensor.logical_shape();
+    uint32_t out_chan = shape[0];
+    uint32_t C = shape[1];
+    uint32_t kD = shape[2];
+    uint32_t kH = shape[3];
+    uint32_t kW = shape[4];
+
+    TT_FATAL(out_chan == out_channels, "Weight tensor out_channels dimension mismatch");
+    TT_FATAL(C == in_channels, "Weight tensor in_channels dimension mismatch");
+
+    // Step 1: Permute [out_chan, C, kD, kH, kW] -> [kD, kH, kW, C, out_chan]
+    // Permutation order: [2, 3, 4, 1, 0]
+    ttnn::SmallVector<int64_t> permute_order = {2, 3, 4, 1, 0};
+    auto w = ttnn::permute(weight_tensor, permute_order);
+
+    // Step 2: Pad input channels to alignment boundary
+    uint32_t ALIGN_PAD = (alignment - C % alignment) % alignment;
+    uint32_t C_in_aligned = C + ALIGN_PAD;
+
+    if (ALIGN_PAD > 0) {
+        // Shape after permute is [kD, kH, kW, C, out_chan]
+        // Need to pad dimension 3 (C dimension) from C to C_in_aligned
+        ttnn::SmallVector<std::array<uint32_t, 2>> padding = {
+            {0, 0},          // kD: no padding
+            {0, 0},          // kH: no padding
+            {0, 0},          // kW: no padding
+            {0, ALIGN_PAD},  // C: pad ALIGN_PAD elements at the end
+            {0, 0}           // out_chan: no padding
+        };
+        w = ttnn::pad(w, padding, 0.0f);
+    }
+
+    // Step 3: Reshape based on C_in_block configuration
+    uint32_t C_in_block = conv_config.C_in_block;
+    if (C_in_block == 0) {
+        C_in_block = C_in_aligned;
+    }
+
+    uint32_t num_C_in_blocks = C_in_aligned / C_in_block;
+    TT_FATAL(
+        num_C_in_blocks * C_in_block == C_in_aligned,
+        "num_C_in_blocks * C_in_block must equal C_in_aligned, got {} * {} != {}",
+        num_C_in_blocks,
+        C_in_block,
+        C_in_aligned);
+
+    // Reshape to [kD, kH, kW, num_C_in_blocks, C_in_block, out_chan]
+    ttnn::Shape reshaped_shape({kD, kH, kW, num_C_in_blocks, C_in_block, out_chan});
+    w = ttnn::reshape(w, reshaped_shape);
+
+    // Step 4: Permute [kD, kH, kW, num_C_in_blocks, C_in_block, out_chan] ->
+    //                 [num_C_in_blocks, kD, kH, kW, C_in_block, out_chan]
+    // Permutation order: [3, 0, 1, 2, 4, 5]
+    ttnn::SmallVector<int64_t> permute_order2 = {3, 0, 1, 2, 4, 5};
+    w = ttnn::permute(w, permute_order2);
+
+    // Step 5: Flatten to 2D [-1, out_chan]
+    uint32_t dim0 = num_C_in_blocks * kD * kH * kW * C_in_block;
+    ttnn::Shape final_shape({dim0, out_chan});
+    w = ttnn::reshape(w, final_shape);
+
+    // Step 6: Convert to tile layout
+    return ttnn::to_layout(w, Layout::TILE);
+}
+
+ttnn::Tensor prepare_conv3d_bias(const ttnn::Tensor& bias_tensor, uint32_t out_channels, MeshDevice* device) {
+    TT_FATAL(bias_tensor.layout() == Layout::ROW_MAJOR, "Bias tensor must be in ROW_MAJOR layout");
+    TT_FATAL(
+        bias_tensor.logical_volume() == out_channels,
+        "Bias tensor must have {} elements, got {}",
+        out_channels,
+        bias_tensor.logical_volume());
+
+    // Reshape to [1, out_channels]
+    ttnn::Shape bias_shape({1, out_channels});
+    auto bias = ttnn::reshape(bias_tensor, bias_shape);
+
+    // Convert to tile layout
+    return ttnn::to_layout(bias, Layout::TILE);
+}
+
+}  // namespace detail
+}  // namespace operations::experimental::conv3d
+}  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/prepare_conv3d_weights.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/prepare_conv3d_weights.hpp
@@ -27,13 +27,12 @@ ttnn::Tensor prepare_conv3d_weights(
     uint32_t in_channels,
     uint32_t out_channels,
     const Conv3dConfig& conv_config,
-    MeshDevice* device,
     uint32_t alignment = 16);
 
 // Prepares conv3d bias tensor for device
 // Reshapes bias to [1, -1] format and converts to tile layout
 // Returns a new tensor with layout=Tile
-ttnn::Tensor prepare_conv3d_bias(const ttnn::Tensor& bias_tensor, uint32_t out_channels, MeshDevice* device);
+ttnn::Tensor prepare_conv3d_bias(const ttnn::Tensor& bias_tensor, uint32_t out_channels);
 
 }  // namespace detail
 }  // namespace operations::experimental::conv3d

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/prepare_conv3d_weights.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/prepare_conv3d_weights.hpp
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+#include <optional>
+#include <string>
+#include <array>
+#include <cstdint>
+#include "ttnn/tensor/types.hpp"
+#include "ttnn/types.hpp"
+#include "ttnn/tensor/tensor.hpp"
+#include "device/conv3d_device_operation.hpp"
+
+namespace ttnn {
+
+namespace operations::experimental::conv3d {
+
+namespace detail {
+
+// Prepares conv3d weight tensor for device
+// Transforms PyTorch-style [out_channels, in_channels, kD, kH, kW] weight tensor
+// to the format expected by conv3d device operation
+// Returns a new tensor with layout=Tile
+ttnn::Tensor prepare_conv3d_weights(
+    const ttnn::Tensor& weight_tensor,
+    uint32_t in_channels,
+    uint32_t out_channels,
+    const Conv3dConfig& conv_config,
+    MeshDevice* device,
+    uint32_t alignment = 16);
+
+// Prepares conv3d bias tensor for device
+// Reshapes bias to [1, -1] format and converts to tile layout
+// Returns a new tensor with layout=Tile
+ttnn::Tensor prepare_conv3d_bias(const ttnn::Tensor& bias_tensor, uint32_t out_channels, MeshDevice* device);
+
+}  // namespace detail
+}  // namespace operations::experimental::conv3d
+}  // namespace ttnn

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -391,7 +391,7 @@ from ttnn.operations.pool import (
     prepare_grid_sample_grid,
 )
 
-from ttnn._ttnn.operations.experimental import Conv3dConfig
+from ttnn._ttnn.operations.experimental import Conv3dConfig, prepare_conv3d_weights, prepare_conv3d_bias
 from ttnn._ttnn.operations.experimental import MinimalMatmulConfig
 
 Conv1dConfig = ttnn._ttnn.operations.conv.Conv2dConfig


### PR DESCRIPTION
### Problem description
Conv3d doesn't have cpp support for preparing weights and bias
(only python utility function exists currently)

### What's changed
- added conv3d prepare weights
- added conv3d prepare bias 

### Checklist
- [X] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/19531736246)
- [X] [Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/19431685337)