### PR TITLE
Chain multiple 2D Ops with a single DRAM Read + Write

### DIFF
--- a/tests/ttnn/unit_tests/operations/conv/test_op_chaining.py
+++ b/tests/ttnn/unit_tests/operations/conv/test_op_chaining.py
@@ -131,7 +131,6 @@ def test_multi_conv(
                 (output_channels, current_input_channels, kernel[0], kernel[1]),
             )
         )
-
         torch_bias_tensors.append(
             randomize_torch_tensor(
                 torch_tensor_map,
@@ -190,16 +189,9 @@ def test_multi_conv(
         current_input_channels = output_channels
     print(current_torch_output.shape)
     ref = current_torch_output
-    [out_batch, out_channels, out_height, out_width] = current_torch_output.shape
-    tt_output_tensor = ttnn.zeros(
-        [out_batch, out_height, out_width, out_channels],
-        dtype=dtype,
-        layout=input_layout,
-        device=device,
-    )
-    ttnn.run_sliced_op(
+
+    tt_output_tensor = ttnn.run_sliced_op(
         input_tensor=tt_input_tensor,
-        output_tensor=tt_output_tensor,
         op_slice_attr=op_slicing_attrs,
         dram_slice_config=ttnn.Conv2dSliceConfig(slice_type=slice_type, num_slices=num_slices),
     )
@@ -208,6 +200,7 @@ def test_multi_conv(
 
     tt_output_tensor_host = ttnn.from_device(tt_output_tensor)
     out = ttnn.to_torch(tt_output_tensor_host)
+    out_height, out_width = ref.shape[1:3]
     out = out.reshape(batch_size, out_height, out_width, out.shape[-1])
     out = out[:, :, :, : ref.shape[-1]]
 

--- a/tests/ttnn/unit_tests/operations/conv/test_op_chaining.py
+++ b/tests/ttnn/unit_tests/operations/conv/test_op_chaining.py
@@ -182,7 +182,7 @@ def test_multi_conv(
         input_tensor=tt_input_tensor,
         output_tensor=tt_output_tensor,
         op_slice_attr=op_slicing_attrs,
-        dram_slice_config=ttnn.Conv2dSliceConfig(slice_type=ttnn.Conv2dDRAMSliceHeight, num_slices=8),
+        dram_slice_config=ttnn.Conv2dSliceConfig(slice_type=ttnn.Conv2dDRAMSliceWidth, num_slices=8),
     )
     threshold = 0.5
     tt_output_tensor_host = ttnn.from_device(tt_output_tensor)

--- a/tests/ttnn/unit_tests/operations/conv/test_op_chaining.py
+++ b/tests/ttnn/unit_tests/operations/conv/test_op_chaining.py
@@ -187,7 +187,6 @@ def test_multi_conv(
             )
         op_slicing_attrs.append(last_op_slice_attr)
         current_input_channels = output_channels
-    print(current_torch_output.shape)
     ref = current_torch_output
 
     tt_output_tensor = ttnn.run_sliced_op(
@@ -209,5 +208,4 @@ def test_multi_conv(
     logger.info(f"PCC = {pcc_msg}. Threshold = {threshold}")
     if not passing:
         torch.set_printoptions(sci_mode=False)
-        diff = torch.abs(out - ref) / ref.max()
         assert passing, f"Test failed with PCC = {pcc_msg}, below threshold {threshold}"

--- a/tests/ttnn/unit_tests/operations/conv/test_op_chaining.py
+++ b/tests/ttnn/unit_tests/operations/conv/test_op_chaining.py
@@ -1,0 +1,196 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+from tests.ttnn.nightly.unit_tests.operations.conv.test_conv2d import (
+    run_conv,
+    torch_tensor_map,
+    HS,
+    WS,
+    BS,
+    randomize_torch_tensor,
+)
+import ttnn
+import torch
+import math
+from loguru import logger
+
+
+SliceHeight = ttnn.Conv2dDRAMSliceHeight
+SliceWidth = ttnn.Conv2dDRAMSliceWidth
+
+
+@pytest.mark.parametrize(
+    "input_layout, dtype",
+    [[ttnn.TILE_LAYOUT, ttnn.bfloat8_b], [ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16]],
+)
+@pytest.mark.parametrize(
+    "batch_size, input_channels, input_height, input_width, math_fidelity, parameters",
+    # fmt: off
+    (
+        # ( 1,  400,    192,   192,     ttnn.MathFidelity.HiFi4,
+        #     [
+        #         (256, (1, 1), (1, 1), (0, 0), (1, 1)),
+        #         (512, (3, 3), (1, 1), (1, 1), (1, 1)),
+        #         (384, (5, 5), (1, 1), (1, 1), (1, 1))
+        #     ]
+        # ),
+        # ( 2,   13,    313,    71,     ttnn.MathFidelity.LoFi ,
+        #     [
+        #         (256, (5, 5), (1, 1), (2, 2), (2, 2)),
+        #         (256, (3, 3), (1, 1), (1, 1), (1, 1)),
+        #         (256, (5, 5), (1, 1), (1, 1), (1, 1))
+        #     ]
+        # ),
+        # ( 2,   63,    981,    39,     ttnn.MathFidelity.LoFi ,
+        #     [
+        #         (256, (3, 3), (2, 2), (2, 2), (1, 1)),
+        #         (256, (3, 3), (1, 1), (1, 1), (1, 1)),
+        #         (256, (5, 5), (1, 1), (1, 1), (1, 1))
+        #     ]
+        # ),
+        # ( 2,  512,    128,   128,     ttnn.MathFidelity.LoFi ,
+        #     [
+        #         (256, (3, 3), (1, 1), (1, 1), (1, 1)),
+        #         (256, (3, 3), (1, 1), (1, 1), (1, 1)),
+        #         (256, (5, 5), (1, 1), (1, 1), (1, 1))
+        #     ]
+        # ),
+        # ( 2,   64,    384,    64,     ttnn.MathFidelity.LoFi ,
+        #     [
+        #         (256, (4, 4), (2, 2), (1, 1), (1, 1)),
+        #         (256, (3, 3), (1, 1), (1, 1), (1, 1)),
+        #         (256, (5, 5), (1, 1), (1, 1), (1, 1))
+        #     ]
+        # ),
+        ( 1,    16,   1024,  1024,     ttnn.MathFidelity.LoFi ,
+            [
+                (32, (3, 3), (1, 1), (1, 1), (1, 1)),
+                (32, (3, 3), (1, 1), (1, 1), (1, 1)),
+                (32, (3, 3), (1, 1), (1, 1), (1, 1))
+            ]
+        ),
+        # ( 1, 2904,     48,    48,     ttnn.MathFidelity.HiFi4,
+        #     [
+        #         (256, (3, 3), (1, 1), (0, 0), (1, 1)),
+        #         (256, (3, 3), (1, 1), (1, 1), (1, 1)),
+        #         (256, (5, 5), (1, 1), (1, 1), (1, 1))
+        #     ]
+        # ),
+    )
+    # fmt: on
+)
+def test_multi_conv(
+    device,
+    torch_tensor_map,
+    batch_size,
+    input_channels,
+    input_height,
+    input_width,
+    input_layout,
+    dtype,
+    math_fidelity,
+    parameters,
+):
+    if device.core_grid.y == 7:
+        pytest.skip("Tests have been configured for N150.")
+
+    compute_config = ttnn.init_device_compute_kernel_config(
+        device.arch(),
+        math_fidelity=math_fidelity,
+    )
+    op_slicing_attrs = []
+    torch_weights_tensors = []
+    torch_bias_tensors = []
+    ttnn_weights_tensors = []
+    ttnn_bias_tensors = []
+    torch_input_tensor_nchw = randomize_torch_tensor(
+        torch_tensor_map, (batch_size, input_channels, input_height, input_width)
+    )
+    current_input_channels = input_channels
+    current_torch_output = torch_input_tensor_nchw
+    torch_input_tensor = torch.permute(torch_input_tensor_nchw, (0, 2, 3, 1))
+    tt_input_tensor = ttnn.from_torch(
+        torch_input_tensor,
+        dtype,
+        layout=input_layout,
+        device=device,
+    )
+    conv_config = ttnn.Conv2dConfig(
+        weights_dtype=dtype,
+        config_tensors_in_dram=True,
+        output_layout=input_layout,
+    )
+    for output_channels, kernel, stride, padding, dilation in parameters:
+        torch_weights_tensors.append(
+            randomize_torch_tensor(
+                torch_tensor_map,
+                (output_channels, current_input_channels, kernel[0], kernel[1]),
+            )
+        )
+
+        torch_bias_tensors.append(
+            randomize_torch_tensor(
+                torch_tensor_map,
+                (1, 1, 1, output_channels),
+            )
+        )
+        ttnn_weights_tensors.append(ttnn.from_torch(torch_weights_tensors[-1], ttnn.bfloat16))
+        ttnn_bias_tensors.append(ttnn.from_torch(torch_bias_tensors[-1], ttnn.bfloat16))
+        padding_n4 = (padding[0], padding[0], padding[1], padding[1])
+        current_torch_output = torch.nn.functional.conv2d(
+            current_torch_output,
+            torch_weights_tensors[-1],
+            bias=torch_bias_tensors[-1].reshape(-1),
+            stride=stride,
+            padding=padding,
+            dilation=dilation,
+        )
+        op_slicing_attrs.append(
+            ttnn.Conv2dSliceAttr(
+                batch_size=batch_size,
+                input_shape=[input_height, input_width],
+                input_channels=input_channels,
+                output_channels=output_channels,
+                kernel_size=tuple(kernel),
+                stride=tuple(stride),
+                padding_n4=tuple(padding_n4),
+                dilation=tuple(dilation),
+                groups=1,
+                input_layout=input_layout,
+                input_dtype=dtype,
+                output_dtype=dtype,
+                weight_tensor=ttnn_weights_tensors[-1],
+                device=device,
+                bias_tensor=ttnn_bias_tensors[-1],
+                conv_config=conv_config,
+                compute_config=compute_config,
+            )
+        )
+        current_input_channels = output_channels
+    print(current_torch_output.shape)
+    ref = current_torch_output
+    [out_batch, out_channels, out_height, out_width] = current_torch_output.shape
+    tt_output_tensor = ttnn.zeros(
+        [out_batch, out_height, out_width, out_channels],
+        dtype=dtype,
+        layout=input_layout,
+        device=device,
+    )
+    ttnn.run_sliced_op(
+        input_tensor=tt_input_tensor,
+        output_tensor=tt_output_tensor,
+        op_slice_attr=op_slicing_attrs,
+        dram_slice_config=ttnn.Conv2dSliceConfig(slice_type=ttnn.Conv2dDRAMSliceHeight, num_slices=8),
+    )
+    threshold = 0.5
+    tt_output_tensor_host = ttnn.from_device(tt_output_tensor)
+    out = ttnn.to_torch(tt_output_tensor_host)
+    out = out.reshape(batch_size, out_height, out_width, out.shape[-1])
+    out = out[:, :, :, : ref.shape[-1]]
+
+    ref = torch.permute(ref, (0, 2, 3, 1))
+    logger.info(f"Threshold: {threshold}")
+    diff = torch.abs(ref - out) / ref.abs().mean()
+    assert torch.all(diff < threshold), f"Max diff: {diff.max()}, Threshold: {threshold} "

--- a/tests/ttnn/unit_tests/operations/conv/test_op_chaining.py
+++ b/tests/ttnn/unit_tests/operations/conv/test_op_chaining.py
@@ -4,18 +4,13 @@
 
 import pytest
 from tests.ttnn.nightly.unit_tests.operations.conv.test_conv2d import (
-    run_conv,
     torch_tensor_map,
-    HS,
-    WS,
-    BS,
     randomize_torch_tensor,
 )
 import ttnn
 import torch
-import math
 from loguru import logger
-from tests.ttnn.utils_for_testing import assert_with_pcc, check_with_pcc_without_tensor_printout, assert_equal
+from tests.ttnn.utils_for_testing import check_with_pcc_without_tensor_printout
 
 
 SliceHeight = ttnn.Conv2dDRAMSliceHeight
@@ -27,52 +22,52 @@ SliceWidth = ttnn.Conv2dDRAMSliceWidth
     [[ttnn.TILE_LAYOUT, ttnn.bfloat8_b], [ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16]],
 )
 @pytest.mark.parametrize(
-    "batch_size, input_channels, input_height, input_width, math_fidelity, slice_type, parameters",
+    "batch_size, input_channels, input_height, input_width, math_fidelity, slice_type, num_slices, parameters",
     # fmt: off
     (
-        ( 1,  400,    192,   192,     ttnn.MathFidelity.HiFi4, SliceWidth,
+        ( 1,  400,    192,   192,     ttnn.MathFidelity.HiFi4, SliceWidth, 6,
             [
                 (512, (3, 3), (1, 1), (1, 1), (1, 1)),
                 (256, (3, 3), (1, 1), (1, 1), (1, 1)),
                 (128, (5, 5), (1, 1), (2, 2), (1, 1))
             ]
         ),
-        ( 2,   13,    313,    71,     ttnn.MathFidelity.LoFi, SliceWidth,
+        ( 2,   13,    313,    71,     ttnn.MathFidelity.LoFi, SliceHeight, 6,
             [
                 (256, (5, 5), (2, 2), (2, 2), (2, 2)),
                 (256, (3, 3), (1, 1), (1, 1), (1, 1)),
                 (256, (5, 5), (1, 1), (1, 1), (1, 1))
             ]
         ),
-        ( 2,   63,    981,    39,     ttnn.MathFidelity.LoFi, SliceHeight,
+        ( 2,   63,    981,    39,     ttnn.MathFidelity.LoFi, SliceHeight, 8,
             [
                 (256, (3, 3), (2, 2), (2, 2), (1, 1)),
                 (256, (3, 3), (1, 1), (1, 1), (1, 1)),
                 (256, (5, 5), (1, 1), (1, 1), (1, 1))
             ]
         ),
-        ( 2,  512,    128,   128,     ttnn.MathFidelity.LoFi, SliceWidth,
+        ( 2,  512,    128,   128,     ttnn.MathFidelity.LoFi, SliceWidth, 4,
             [
                 (256, (3, 3), (1, 1), (1, 1), (1, 1)),
                 (256, (3, 3), (1, 1), (1, 1), (1, 1)),
                 (256, (5, 5), (1, 1), (1, 1), (1, 1))
             ]
         ),
-        ( 2,   64,    384,    64,     ttnn.MathFidelity.LoFi, SliceWidth,
+        ( 2,   64,    384,    64,     ttnn.MathFidelity.LoFi, SliceHeight, 12,
             [
                 (256, (4, 4), (2, 2), (1, 1), (1, 1)),
                 (256, (3, 3), (1, 1), (1, 1), (1, 1)),
                 (256, (5, 5), (1, 1), (1, 1), (1, 1))
             ]
         ),
-        ( 1,    16,   1024,  1024,     ttnn.MathFidelity.LoFi, SliceWidth,
+        ( 1,    16,   1024,  1024,     ttnn.MathFidelity.LoFi, SliceWidth, 8,
             [
                 (32, (3, 3), (1, 1), (1, 1), (1, 1)),
                 (32, (3, 3), (1, 1), (1, 1), (1, 1)),
                 (32, (3, 3), (1, 1), (1, 1), (1, 1))
             ]
         ),
-        ( 1, 2904,     48,    48,     ttnn.MathFidelity.HiFi4, SliceWidth,
+        ( 1, 2904,     48,    48,     ttnn.MathFidelity.HiFi4, SliceWidth, 2,
             [
                 (256, (3, 3), (1, 1), (0, 0), (1, 1)),
                 (256, (3, 3), (1, 1), (1, 1), (1, 1)),
@@ -94,6 +89,7 @@ def test_multi_conv(
     math_fidelity,
     parameters,
     slice_type,
+    num_slices,
 ):
     if device.core_grid.y == 7:
         pytest.skip("Tests have been configured for N150.")
@@ -101,6 +97,8 @@ def test_multi_conv(
     compute_config = ttnn.init_device_compute_kernel_config(
         device.arch(),
         math_fidelity=math_fidelity,
+        fp32_dest_acc_en=True,
+        packer_l1_acc=True,
     )
     op_slicing_attrs = []
     torch_weights_tensors = []
@@ -123,6 +121,7 @@ def test_multi_conv(
         weights_dtype=dtype,
         config_tensors_in_dram=True,
         output_layout=input_layout,
+        activation=ttnn.UnaryWithParam(ttnn.UnaryOpType.RELU),
     )
     for output_channels, kernel, stride, padding, dilation in parameters:
         torch_weights_tensors.append(
@@ -141,13 +140,15 @@ def test_multi_conv(
         ttnn_weights_tensors.append(ttnn.from_torch(torch_weights_tensors[-1], ttnn.bfloat16))
         ttnn_bias_tensors.append(ttnn.from_torch(torch_bias_tensors[-1], ttnn.bfloat16))
         padding_n4 = (padding[0], padding[0], padding[1], padding[1])
-        current_torch_output = torch.nn.functional.conv2d(
-            current_torch_output,
-            torch_weights_tensors[-1],
-            bias=torch_bias_tensors[-1].reshape(-1),
-            stride=stride,
-            padding=padding,
-            dilation=dilation,
+        current_torch_output = torch.nn.functional.relu(
+            torch.nn.functional.conv2d(
+                current_torch_output,
+                torch_weights_tensors[-1],
+                bias=torch_bias_tensors[-1].reshape(-1),
+                stride=stride,
+                padding=padding,
+                dilation=dilation,
+            )
         )
         op_slicing_attrs.append(
             ttnn.Conv2dSliceAttr(
@@ -184,15 +185,20 @@ def test_multi_conv(
         input_tensor=tt_input_tensor,
         output_tensor=tt_output_tensor,
         op_slice_attr=op_slicing_attrs,
-        dram_slice_config=ttnn.Conv2dSliceConfig(slice_type=slice_type, num_slices=8),
+        dram_slice_config=ttnn.Conv2dSliceConfig(slice_type=slice_type, num_slices=num_slices),
     )
     threshold = 0.99
+    ref = torch.permute(ref, (0, 2, 3, 1))
+
     tt_output_tensor_host = ttnn.from_device(tt_output_tensor)
     out = ttnn.to_torch(tt_output_tensor_host)
     out = out.reshape(batch_size, out_height, out_width, out.shape[-1])
     out = out[:, :, :, : ref.shape[-1]]
 
-    ref = torch.permute(ref, (0, 2, 3, 1))
     logger.info(f"Threshold: {threshold}")
     passing, pcc_msg = check_with_pcc_without_tensor_printout(out, ref, pcc=threshold)
     logger.info(f"PCC = {pcc_msg}. Threshold = {threshold}")
+    if not passing:
+        torch.set_printoptions(sci_mode=False)
+        diff = torch.abs(out - ref) / ref.max()
+        assert passing, f"Test failed with PCC = {pcc_msg}, below threshold {threshold}"

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -313,6 +313,7 @@ set(TTNN_SRC_PYBIND
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/reduction/topk/topk_${PY_BINDING}.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/reduction/manual_seed/manual_seed_${PY_BINDING}.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/sliding_window/sliding_window_${PY_BINDING}.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/sliding_window/op_slicing/op_slicing_${PY_BINDING}.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/transformer/attention_softmax/attention_softmax_${PY_BINDING}.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/transformer/concatenate_heads/concatenate_heads_${PY_BINDING}.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/transformer/sdpa/sdpa_${PY_BINDING}.cpp

--- a/ttnn/cpp/ttnn-pybind/__init__.cpp
+++ b/ttnn/cpp/ttnn-pybind/__init__.cpp
@@ -69,6 +69,8 @@
 #include "ttnn/operations/prefetcher/prefetcher_pybind.hpp"
 #include "ttnn/operations/reduction/reduction_pybind.hpp"
 #include "ttnn/operations/sliding_window/sliding_window_pybind.hpp"
+#include "ttnn/operations/sliding_window/op_slicing/op_slicing_pybind.hpp"
+
 #include "ttnn/operations/transformer/transformer_pybind.hpp"
 #include "ttnn/operations/uniform/uniform_pybind.hpp"
 #include "ttnn/operations/rand/rand_pybind.hpp"
@@ -148,6 +150,8 @@ void py_module(py::module& module) {
 
     auto m_sliding_window = module.def_submodule("sliding_window", "sliding_window operations");
     sliding_window::py_bind_sliding_window(m_sliding_window);
+    auto m_op_slicing = module.def_submodule("op_slicing", "slicing for 2d operations");
+    op_slicing::py_bind_op_slicing(m_op_slicing);
 
     auto m_conv2d = module.def_submodule("conv", "Convolution operations");
     conv::py_module(m_conv2d);

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
@@ -975,7 +975,10 @@ tt::tt_metal::MemoryConfig Conv2dSliceAttr::get_input_memory_config(
 std::string Conv2dSliceAttr::name() { return "Conv2D"; }
 std::string Conv2dSliceAttr::str() { return fmt::format("Conv2D Slice Attr {}", *this); }
 ttnn::Tensor Conv2dSliceAttr::run_L1_op(
-    const ttnn::Tensor& sliced_input_tensor, IOShape output_slice_start, IOShape output_slice_end) {
+    const ttnn::Tensor& sliced_input_tensor,
+    IOShape output_slice_start,
+    IOShape output_slice_end,
+    bool pad_output_width) {
     auto [output_slice_height_start, output_slice_width_start] = output_slice_start;
     auto [output_slice_height_end, output_slice_width_end] = output_slice_end;
     int input_slice_height_start = (output_slice_height_start * stride[0]) - padding_n4[0];
@@ -1025,7 +1028,7 @@ ttnn::Tensor Conv2dSliceAttr::run_L1_op(
     uint32_t width_rounding_value =
         (conv_config.output_layout == tt::tt_metal::Layout::TILE) ? tt::constants::TILE_HEIGHT : 1;
 
-    if (output_slice_width % width_rounding_value != 0) {
+    if (pad_output_width && (output_slice_width % width_rounding_value != 0)) {
         uint32_t additional_padded_width = width_rounding_value - (output_slice_width % width_rounding_value);
         log_trace(
             LogOp, "Conv2d DRAM Slicing: Additional padding of {} added to the right side.", additional_padded_width);

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
@@ -413,9 +413,9 @@ Result conv2d_DRAM(
         conv_config,
         compute_config,
         device);
-
+    std::vector<op_slicing::OpSliceAttr*> slice_attr_vector = {&slice_attr};
     ttnn::operations::op_slicing::run_sliced_op(
-        input_tensor_on_device, dram_output_tensor, &slice_attr, dram_slice_config);
+        input_tensor_on_device, dram_output_tensor, slice_attr_vector, dram_slice_config);
 
     if (should_deallocate_act) {
         input_tensor_on_device.deallocate(true);

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
@@ -397,7 +397,7 @@ Result conv2d_DRAM(
     bias_tensor_on_device = bias_tensor;
     auto slice_attr = Conv2dSliceAttr(
         batch_size,
-        {input_height, input_width},
+        std::array<uint32_t, 2>{input_height, input_width},
         in_channels,
         out_channels,
         kernel_size,
@@ -838,6 +838,43 @@ Conv2dSliceAttr::Conv2dSliceAttr(
 
     };
 
+Conv2dSliceAttr::Conv2dSliceAttr(
+    uint32_t batch_size,
+    std::array<uint32_t, 2> input_shape,
+    uint32_t input_channels,
+    uint32_t output_channels,
+    std::array<uint32_t, 2> kernel_size,
+    std::array<uint32_t, 2> stride,
+    std::array<uint32_t, 4> padding_n4,
+    std::array<uint32_t, 2> dilation,
+    uint32_t groups,
+    Layout input_layout,
+    DataType input_dtype,
+    DataType output_dtype,
+    Tensor& weight_tensor,
+    OptionalRefTensor bias_tensor,
+    Conv2dConfig& conv_config,
+    DeviceComputeKernelConfig& compute_config,
+    MeshDevice* device) :
+    Conv2dSliceAttr(
+        batch_size,
+        IOShape{input_shape[0], input_shape[1]},
+        input_channels,
+        output_channels,
+        kernel_size,
+        stride,
+        padding_n4,
+        dilation,
+        groups,
+        input_layout,
+        input_dtype,
+        output_dtype,
+        weight_tensor,
+        bias_tensor,
+        conv_config,
+        compute_config,
+        device) {};
+
 std::tuple<Conv2dSliceAttr::IOShape, Conv2dSliceAttr::IOShape> Conv2dSliceAttr::get_input_slice(
     IOShape output_slice_start, IOShape output_slice_end) {
     auto [output_slice_height_start, output_slice_width_start] = output_slice_start;
@@ -936,7 +973,7 @@ tt::tt_metal::MemoryConfig Conv2dSliceAttr::get_input_memory_config(
 }
 
 std::string Conv2dSliceAttr::name() { return "Conv2D"; }
-
+std::string Conv2dSliceAttr::str() { return fmt::format("Conv2D Slice Attr {}", *this); }
 ttnn::Tensor Conv2dSliceAttr::run_L1_op(
     const ttnn::Tensor& sliced_input_tensor, IOShape output_slice_start, IOShape output_slice_end) {
     auto [output_slice_height_start, output_slice_width_start] = output_slice_start;

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.hpp
@@ -165,6 +165,21 @@ public:
         Conv2dConfig& conv_config,
         DeviceComputeKernelConfig& compute_config,
         MeshDevice* device);
+
+    Conv2dSliceAttr(
+        op_slicing::OpSliceAttr* previous_op,
+        uint32_t output_channels,
+        std::array<uint32_t, 2> kernel_size,
+        std::array<uint32_t, 2> stride,
+        std::array<uint32_t, 4> padding_n4,
+        std::array<uint32_t, 2> dilation,
+        uint32_t groups,
+        DataType output_dtype,
+        Tensor& weight_tensor,
+        OptionalRefTensor bias_tensor,
+        Conv2dConfig& conv_config,
+        DeviceComputeKernelConfig& compute_config);
+
     Conv2dSliceAttr(
         uint32_t batch_size,
         std::array<uint32_t, 2> input_shape,
@@ -193,6 +208,8 @@ public:
         bool pad_output_width = true) override;
     std::string name() override;
     std::string str() override;
+    std::tuple<TensorSpec, tt::tt_metal::distributed::MeshDevice*> get_output_tensor_spec_and_device() override;
+
     static constexpr auto attribute_names = std::make_tuple(
         "batch_size",
         "input_shape",

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.hpp
@@ -187,7 +187,10 @@ public:
     uint32_t get_L1_usage() override;
     tt::tt_metal::MemoryConfig get_input_memory_config(IOShape output_slice_start, IOShape output_slice_end) override;
     ttnn::Tensor run_L1_op(
-        const ttnn::Tensor& sliced_input_tensor, IOShape output_slice_start, IOShape output_slice_end) override;
+        const ttnn::Tensor& sliced_input_tensor,
+        IOShape output_slice_start,
+        IOShape output_slice_end,
+        bool pad_output_width = true) override;
     std::string name() override;
     std::string str() override;
     static constexpr auto attribute_names = std::make_tuple(

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.hpp
@@ -165,12 +165,59 @@ public:
         Conv2dConfig& conv_config,
         DeviceComputeKernelConfig& compute_config,
         MeshDevice* device);
+    Conv2dSliceAttr(
+        uint32_t batch_size,
+        std::array<uint32_t, 2> input_shape,
+        uint32_t input_channels,
+        uint32_t output_channels,
+        std::array<uint32_t, 2> kernel_size,
+        std::array<uint32_t, 2> stride,
+        std::array<uint32_t, 4> padding_n4,
+        std::array<uint32_t, 2> dilation,
+        uint32_t groups,
+        Layout input_layout,
+        DataType input_dtype,
+        DataType output_dtype,
+        Tensor& weight_tensor,
+        OptionalRefTensor bias_tensor,
+        Conv2dConfig& conv_config,
+        DeviceComputeKernelConfig& compute_config,
+        MeshDevice* device);
     std::tuple<IOShape, IOShape> get_input_slice(IOShape output_slice_start, IOShape output_slice_end) override;
     uint32_t get_L1_usage() override;
     tt::tt_metal::MemoryConfig get_input_memory_config(IOShape output_slice_start, IOShape output_slice_end) override;
     ttnn::Tensor run_L1_op(
         const ttnn::Tensor& sliced_input_tensor, IOShape output_slice_start, IOShape output_slice_end) override;
     std::string name() override;
+    std::string str() override;
+    static constexpr auto attribute_names = std::make_tuple(
+        "batch_size",
+        "input_shape",
+        "input_channels",
+        "output_channels",
+        "kernel_size",
+        "stride",
+        "padding_n4",
+        "dilation",
+        "groups",
+        "input_layout",
+        "input_dtype",
+        "output_dtype");
+    auto attribute_values() const {
+        return std::make_tuple(
+            std::cref(this->batch_size),
+            std::cref(this->input_shape),
+            std::cref(this->input_channels),
+            std::cref(this->output_channels),
+            std::cref(this->kernel_size),
+            std::cref(this->stride),
+            std::cref(this->padding_n4),
+            std::cref(this->dilation),
+            std::cref(this->groups),
+            std::cref(this->input_layout),
+            std::cref(this->input_dtype),
+            std::cref(this->output_dtype));
+    }
 };
 
 }  // namespace conv2d

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_pybind.cpp
@@ -526,6 +526,33 @@ void py_bind_conv2d(py::module& module) {
 
     py_conv_slice_attr.def(
         py::init<
+            op_slicing::OpSliceAttr*,
+            uint32_t,
+            std::array<uint32_t, 2>,
+            std::array<uint32_t, 2>,
+            std::array<uint32_t, 4>,
+            std::array<uint32_t, 2>,
+            uint32_t,
+            DataType,
+            Tensor&,
+            std::optional<std::reference_wrapper<ttnn::Tensor>>,
+            Conv2dConfig&,
+            DeviceComputeKernelConfig&>(),
+        py::kw_only(),
+        py::arg("previous_op"),
+        py::arg("output_channels"),
+        py::arg("kernel_size"),
+        py::arg("stride"),
+        py::arg("padding_n4"),
+        py::arg("dilation") = std::array<uint32_t, 2>{1, 1},
+        py::arg("groups") = 1,
+        py::arg("output_dtype") = DataType::BFLOAT16,
+        py::arg("weight_tensor"),
+        py::arg("bias_tensor") = std::nullopt,
+        py::arg("conv_config") = Conv2dConfig(),
+        py::arg("compute_config"));
+    py_conv_slice_attr.def(
+        py::init<
             uint32_t,
             std::array<uint32_t, 2>,
             uint32_t,
@@ -544,13 +571,13 @@ void py_bind_conv2d(py::module& module) {
             DeviceComputeKernelConfig&,
             MeshDevice*>(),
         py::kw_only(),
-        py::arg("batch_size") = 0,
-        py::arg("input_shape") = std::array<uint32_t, 2>({0, 0}),
-        py::arg("input_channels") = 0,
-        py::arg("output_channels") = 0,
-        py::arg("kernel_size") = std::array<uint32_t, 2>{0, 0},
-        py::arg("stride") = std::array<uint32_t, 2>{1, 1},
-        py::arg("padding_n4") = std::array<uint32_t, 4>{0, 0, 0, 0},
+        py::arg("batch_size"),
+        py::arg("input_shape"),
+        py::arg("input_channels"),
+        py::arg("output_channels"),
+        py::arg("kernel_size"),
+        py::arg("stride"),
+        py::arg("padding_n4"),
         py::arg("dilation") = std::array<uint32_t, 2>{1, 1},
         py::arg("groups") = 1,
         py::arg("input_layout") = Layout::TILE,
@@ -560,7 +587,7 @@ void py_bind_conv2d(py::module& module) {
         py::arg("bias_tensor") = std::nullopt,
         py::arg("conv_config") = Conv2dConfig(),
         py::arg("compute_config") = std::nullopt,
-        py::arg("device") = nullptr);
+        py::arg("device"));
     py_conv_slice_attr.def("__repr__", [](const Conv2dSliceAttr& slice_attr) { return fmt::format("{}", slice_attr); });
 }
 

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_pybind.cpp
@@ -20,6 +20,7 @@
 #include "ttnn/operations/conv/conv2d/device/conv2d_op.hpp"
 #include "ttnn/operations/conv/conv2d/prepare_conv2d_weights.hpp"
 #include "ttnn/operations/sliding_window/sliding_window_pybind.hpp"
+#include "ttnn/operations/sliding_window/op_slicing/op_slicing.hpp"
 #include "ttnn/types.hpp"
 #include "ttnn/operations/eltwise/unary/common/unary_op_types.hpp"
 
@@ -256,6 +257,51 @@ void py_bind_conv2d(py::module& module) {
         py::arg("tensor_shape"),
         py::arg("parallel_config"),
         py::arg("tile_size"));
+    auto py_conv_slice_attr = py::class_<Conv2dSliceAttr>(
+        module,
+        "Conv2dSliceAttr",
+        R"doc(
+        Conv2dSliceAttr is a class that implements the OpSliceAttr interface for Conv2D operations.
+        It is used to determine how the input tensor should be sliced based on the output slice.
+        )doc");
+
+    py_conv_slice_attr.def(
+        py::init<
+            uint32_t,
+            Conv2dSliceAttr::IOShape,
+            uint32_t,
+            uint32_t,
+            std::array<uint32_t, 2>,
+            std::array<uint32_t, 2>,
+            std::array<uint32_t, 4>,
+            std::array<uint32_t, 2>,
+            uint32_t,
+            Layout,
+            DataType,
+            DataType,
+            ttnn::Tensor&,
+            std::optional<std::reference_wrapper<ttnn::Tensor>>,
+            Conv2dConfig&,
+            DeviceComputeKernelConfig&,
+            MeshDevice*>(),
+        py::arg("batch_size"),
+        py::arg("input_shape"),
+        py::arg("input_channels"),
+        py::arg("output_channels"),
+        py::arg("kernel_size"),
+        py::arg("stride"),
+        py::arg("padding_n4"),
+        py::arg("dilation"),
+        py::arg("groups"),
+        py::arg("input_layout"),
+        py::arg("input_dtype"),
+        py::arg("output_dtype"),
+        py::arg("weight_tensor"),
+        py::arg("bias_tensor") = std::nullopt,
+        py::arg("conv_config") = Conv2dConfig(),
+        py::arg("compute_config") = std::nullopt,
+        py::arg("device"));
+    py_conv_slice_attr.def("__repr__", [](const Conv2dSliceConfig& config) { return fmt::format("{}", config); });
 
     auto py_conv_slice_config = py::class_<Conv2dSliceConfig>(
         module,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_pybind.cpp
@@ -257,51 +257,6 @@ void py_bind_conv2d(py::module& module) {
         py::arg("tensor_shape"),
         py::arg("parallel_config"),
         py::arg("tile_size"));
-    auto py_conv_slice_attr = py::class_<Conv2dSliceAttr>(
-        module,
-        "Conv2dSliceAttr",
-        R"doc(
-        Conv2dSliceAttr is a class that implements the OpSliceAttr interface for Conv2D operations.
-        It is used to determine how the input tensor should be sliced based on the output slice.
-        )doc");
-
-    py_conv_slice_attr.def(
-        py::init<
-            uint32_t,
-            Conv2dSliceAttr::IOShape,
-            uint32_t,
-            uint32_t,
-            std::array<uint32_t, 2>,
-            std::array<uint32_t, 2>,
-            std::array<uint32_t, 4>,
-            std::array<uint32_t, 2>,
-            uint32_t,
-            Layout,
-            DataType,
-            DataType,
-            ttnn::Tensor&,
-            std::optional<std::reference_wrapper<ttnn::Tensor>>,
-            Conv2dConfig&,
-            DeviceComputeKernelConfig&,
-            MeshDevice*>(),
-        py::arg("batch_size"),
-        py::arg("input_shape"),
-        py::arg("input_channels"),
-        py::arg("output_channels"),
-        py::arg("kernel_size"),
-        py::arg("stride"),
-        py::arg("padding_n4"),
-        py::arg("dilation"),
-        py::arg("groups"),
-        py::arg("input_layout"),
-        py::arg("input_dtype"),
-        py::arg("output_dtype"),
-        py::arg("weight_tensor"),
-        py::arg("bias_tensor") = std::nullopt,
-        py::arg("conv_config") = Conv2dConfig(),
-        py::arg("compute_config") = std::nullopt,
-        py::arg("device"));
-    py_conv_slice_attr.def("__repr__", [](const Conv2dSliceConfig& config) { return fmt::format("{}", config); });
 
     auto py_conv_slice_config = py::class_<Conv2dSliceConfig>(
         module,
@@ -560,6 +515,53 @@ void py_bind_conv2d(py::module& module) {
     )doc");
 
     py_conv_config.def("__repr__", [](const Conv2dConfig& config) { return fmt::format("{}", config); });
+
+    auto py_conv_slice_attr = py::class_<Conv2dSliceAttr, op_slicing::OpSliceAttr>(
+        module,
+        "Conv2dSliceAttr",
+        R"doc(
+        Conv2dSliceAttr is a class that implements the OpSliceAttr interface for Conv2D operations.
+        It is used to determine how the input tensor should be sliced based on the output slice.
+        )doc");
+
+    py_conv_slice_attr.def(
+        py::init<
+            uint32_t,
+            std::array<uint32_t, 2>,
+            uint32_t,
+            uint32_t,
+            std::array<uint32_t, 2>,
+            std::array<uint32_t, 2>,
+            std::array<uint32_t, 4>,
+            std::array<uint32_t, 2>,
+            uint32_t,
+            Layout,
+            DataType,
+            DataType,
+            ttnn::Tensor&,
+            std::optional<std::reference_wrapper<ttnn::Tensor>>,
+            Conv2dConfig&,
+            DeviceComputeKernelConfig&,
+            MeshDevice*>(),
+        py::kw_only(),
+        py::arg("batch_size") = 0,
+        py::arg("input_shape") = std::array<uint32_t, 2>({0, 0}),
+        py::arg("input_channels") = 0,
+        py::arg("output_channels") = 0,
+        py::arg("kernel_size") = std::array<uint32_t, 2>{0, 0},
+        py::arg("stride") = std::array<uint32_t, 2>{1, 1},
+        py::arg("padding_n4") = std::array<uint32_t, 4>{0, 0, 0, 0},
+        py::arg("dilation") = std::array<uint32_t, 2>{1, 1},
+        py::arg("groups") = 1,
+        py::arg("input_layout") = Layout::TILE,
+        py::arg("input_dtype") = DataType::BFLOAT16,
+        py::arg("output_dtype") = DataType::BFLOAT16,
+        py::arg("weight_tensor"),
+        py::arg("bias_tensor") = std::nullopt,
+        py::arg("conv_config") = Conv2dConfig(),
+        py::arg("compute_config") = std::nullopt,
+        py::arg("device") = nullptr);
+    py_conv_slice_attr.def("__repr__", [](const Conv2dSliceAttr& slice_attr) { return fmt::format("{}", slice_attr); });
 }
 
 }  // namespace ttnn::operations::conv::conv2d

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_pybind.cpp
@@ -586,7 +586,7 @@ void py_bind_conv2d(py::module& module) {
         py::arg("weight_tensor"),
         py::arg("bias_tensor") = std::nullopt,
         py::arg("conv_config") = Conv2dConfig(),
-        py::arg("compute_config") = std::nullopt,
+        py::arg("compute_config"),
         py::arg("device"));
     py_conv_slice_attr.def("__repr__", [](const Conv2dSliceAttr& slice_attr) { return fmt::format("{}", slice_attr); });
 }

--- a/ttnn/cpp/ttnn/operations/experimental/slice_write/device/kernels/dataflow/slice_write_writer_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/slice_write/device/kernels/dataflow/slice_write_writer_interleaved.cpp
@@ -5,7 +5,7 @@
 #include <stdint.h>
 #include <algorithm>
 #include "dataflow_api.h"
-
+#define DEBUG
 void kernel_main() {
     const uint32_t dst_addr = get_arg_val<uint32_t>(0);
     const uint32_t output_stick_size = get_arg_val<uint32_t>(1);

--- a/ttnn/cpp/ttnn/operations/experimental/slice_write/device/slice_write_rm_sharded_input_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/slice_write/device/slice_write_rm_sharded_input_program_factory.cpp
@@ -159,7 +159,7 @@ SliceWriteRuntimeArgs get_slice_write_runtime_args_rm_sharded_input(
         int max_num_sticks_this_core = 0;
         for (uint32_t j = 1; j < num_dims; j++) {
             id_per_dim[j] = unpadded_written % num_input_sticks_per_dim[j];
-            if (j == num_dims - 1 && unpadded_written == num_input_sticks_per_dim[j]) {
+            if (j == num_dims - 1 && unpadded_written >= num_input_sticks_per_dim[j]) {
                 // Handle edge case where last dimension is completely written
                 id_per_dim[j] = num_input_sticks_per_dim[j];
             }

--- a/ttnn/cpp/ttnn/operations/experimental/slice_write/device/slice_write_rm_sharded_input_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/slice_write/device/slice_write_rm_sharded_input_program_factory.cpp
@@ -59,7 +59,7 @@ SliceWriteRuntimeArgs get_slice_write_runtime_args_rm_sharded_input(
     std::vector<uint32_t> num_input_sticks_per_dim(num_dims);
     std::vector<uint32_t> num_output_sticks_per_dim(num_dims);
     std::vector<uint32_t> id_per_dim(num_dims);
-    std::vector<uint32_t> size_till_end(num_dims);
+    std::vector<int> size_till_end(num_dims);
 
     std::vector<uint32_t> accumulated_total_per_dim(num_dims);
     std::vector<uint32_t> accumulated_input_total_per_dim(num_dims);
@@ -156,9 +156,13 @@ SliceWriteRuntimeArgs get_slice_write_runtime_args_rm_sharded_input(
         id_per_dim[0] = num_sticks_read % num_input_sticks_per_dim[0];
         uint32_t unpadded_written = num_sticks_read / num_input_sticks_per_dim[0];
         uint32_t start_id = id_per_dim[0] + start_offset;
-        uint32_t max_num_sticks_this_core = 0;
+        int max_num_sticks_this_core = 0;
         for (uint32_t j = 1; j < num_dims; j++) {
             id_per_dim[j] = unpadded_written % num_input_sticks_per_dim[j];
+            if (j == num_dims - 1 && unpadded_written == num_input_sticks_per_dim[j]) {
+                // Handle edge case where last dimension is completely written
+                id_per_dim[j] = num_input_sticks_per_dim[j];
+            }
             unpadded_written = unpadded_written / num_input_sticks_per_dim[j];
             start_id += id_per_dim[j] * accumulated_total_per_dim[j - 1];
             size_till_end[j] = output_tensor_end[-1 - j] - output_tensor_start[-1 - j] - id_per_dim[j] - 1;
@@ -166,11 +170,12 @@ SliceWriteRuntimeArgs get_slice_write_runtime_args_rm_sharded_input(
         }
 
         uint32_t this_input_row_size_bytes = std::min(input_row_size_bytes, output_row_size_bytes - width_offset);
-        WriterKernelArgs writer_kernel_args = common_writer_kernel_args;
+        std::vector<uint32_t> writer_kernel_args = common_writer_kernel_args;
         writer_kernel_args[0] += width_offset;
         writer_kernel_args[2] = this_input_row_size_bytes;
 
-        uint32_t num_sticks_this_core = std::min(num_sticks_per_core, max_num_sticks_this_core + 1);
+        uint32_t num_sticks_this_core =
+            std::min<uint32_t>(num_sticks_per_core, std::max<int>(max_num_sticks_this_core + 1, 0));
 
         log_trace(
             tt::LogOp,

--- a/ttnn/cpp/ttnn/operations/experimental/slice_write/device/slice_write_tiled_sharded_input_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/slice_write/device/slice_write_tiled_sharded_input_program_factory.cpp
@@ -162,7 +162,7 @@ SliceWriteRuntimeArgs get_slice_write_runtime_args_tiled_sharded_input(
 
         for (uint32_t j = 1; j < num_dims; j++) {
             id_per_dim[j] = unpadded_written % num_input_tiles_per_dim[j];
-            if (j == num_dims - 1 && unpadded_written == num_input_tiles_per_dim[j]) {
+            if (j == num_dims - 1 && unpadded_written >= num_input_tiles_per_dim[j]) {
                 // Handle edge case where last dimension is completely written
                 id_per_dim[j] = num_input_tiles_per_dim[j];
             }

--- a/ttnn/cpp/ttnn/operations/experimental/slice_write/device/slice_write_tiled_sharded_input_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/slice_write/device/slice_write_tiled_sharded_input_program_factory.cpp
@@ -158,10 +158,14 @@ SliceWriteRuntimeArgs get_slice_write_runtime_args_tiled_sharded_input(
         id_per_dim[0] = 0;
         uint32_t unpadded_written = num_sticks_read;
         uint32_t start_id = id_per_dim[0] + start_offset + width_offset;
-        uint32_t max_num_tiles_this_core = 0;
+        int max_num_tiles_this_core = 0;
 
         for (uint32_t j = 1; j < num_dims; j++) {
             id_per_dim[j] = unpadded_written % num_input_tiles_per_dim[j];
+            if (j == num_dims - 1 && unpadded_written == num_input_tiles_per_dim[j]) {
+                // Handle edge case where last dimension is completely written
+                id_per_dim[j] = num_input_tiles_per_dim[j];
+            }
             unpadded_written = unpadded_written / num_input_tiles_per_dim[j];
             start_id += id_per_dim[j] * accumulated_total_tiles_per_dim[j - 1];
             size_till_end[j] = num_input_tiles_per_dim[j] - id_per_dim[j] - ((j == 1) ? 0 : 1);
@@ -169,8 +173,8 @@ SliceWriteRuntimeArgs get_slice_write_runtime_args_tiled_sharded_input(
         }
         WriterKernelArgs writer_kernel_args = common_writer_kernel_args;
 
-        uint32_t num_tiles_this_core =
-            std::min(num_tiles_nhw_per_core * num_tiles_per_channel, max_num_tiles_this_core);
+        uint32_t num_tiles_this_core = std::min<uint32_t>(
+            num_tiles_nhw_per_core * num_tiles_per_channel, std::max<int>(max_num_tiles_this_core, 0));
 
         log_trace(
             tt::LogOp,

--- a/ttnn/cpp/ttnn/operations/sliding_window/op_slicing/op_slicing.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/op_slicing/op_slicing.cpp
@@ -14,11 +14,20 @@
 #include "ttnn/operations/experimental/padded_slice/padded_slice.hpp"
 #include "ttnn/operations/conv/conv2d/conv2d.hpp"
 namespace ttnn::operations::op_slicing {
-
+ttnn::Tensor run_sliced_op(
+    const ttnn::Tensor& input_tensor,
+    const std::vector<OpSliceAttr*>& op_slice_attr,
+    Op2DSliceConfig dram_slice_config) {
+    auto last_op = op_slice_attr.back();
+    auto [output_tensor_spec, device] = last_op->get_output_tensor_spec_and_device();
+    auto output_tensor = tt::tt_metal::create_device_tensor(output_tensor_spec, device);
+    run_sliced_op(input_tensor, output_tensor, op_slice_attr, dram_slice_config);
+    return output_tensor;
+}
 void run_sliced_op(
     const ttnn::Tensor& input_tensor,
     ttnn::Tensor& output_tensor,
-    std::vector<OpSliceAttr*> op_slice_attr,
+    const std::vector<OpSliceAttr*>& op_slice_attr,
     Op2DSliceConfig dram_slice_config) {
     tt::tt_metal::Layout output_layout = output_tensor.layout();
     auto [batch_size, output_height, output_width, output_channels] = output_tensor.logical_shape().to_array_4D();

--- a/ttnn/cpp/ttnn/operations/sliding_window/op_slicing/op_slicing.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/op_slicing/op_slicing.cpp
@@ -68,7 +68,7 @@ void run_sliced_op(
                 output_slice_coords.push_back({input_slice_start, input_slice_end});
                 std::tie(input_slice_start, input_slice_end) =
                     (*op_attributes_iter)->get_input_slice(input_slice_start, input_slice_end);
-                log_info(
+                log_debug(
                     tt::LogOp,
                     "Input Slice Start: {}, End: {} for op {}",
                     input_slice_start,
@@ -101,7 +101,7 @@ void run_sliced_op(
                 output_slice_coords.push_back({input_slice_start, input_slice_end});
                 std::tie(input_slice_start, input_slice_end) =
                     (*op_attributes_iter)->get_input_slice(input_slice_start, input_slice_end);
-                log_info(
+                log_debug(
                     tt::LogOp,
                     "Input Slice Start: {}, End: {} for op {}",
                     input_slice_start,
@@ -123,25 +123,6 @@ void run_sliced_op(
             }
         }
         std::reverse(output_slice_coords.begin(), output_slice_coords.end());
-        // log_trace(
-        //     tt::LogOp,
-        //     "Op {} DRAM Slicing: Slice {}: Output Slice Start: ({}, {}), End: ({}, {})",
-        //     op_slice_attr->name(),
-        //     slice_index,
-        //     output_slice_height_start,
-        //     output_slice_width_start,
-        //     output_slice_height_end,
-        //     output_slice_width_end);
-        // log_trace(
-        //     tt::LogOp,
-        //     "Op {} DRAM Slicing: Slice {}: Input Slice Start: ({}, {}), End: ({}, {})",
-        //     op_slice_attr->name(),
-        //     slice_index,
-        //     input_slice_height_start,
-        //     input_slice_width_start,
-        //     input_slice_height_end,
-        //     input_slice_width_end);
-
         const uint32_t output_slice_height = output_slice_height_end - output_slice_height_start;
 
         const uint32_t output_slice_width = output_slice_width_end - output_slice_width_start;

--- a/ttnn/cpp/ttnn/operations/sliding_window/op_slicing/op_slicing.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/op_slicing/op_slicing.cpp
@@ -157,7 +157,7 @@ void run_sliced_op(
 
         ttnn::Tensor sliced_output_tensor = sliced_input_tensor;
 
-        for (int op_index = 0; op_index < op_slice_attr.size(); op_index++) {
+        for (size_t op_index = 0; op_index < op_slice_attr.size(); op_index++) {
             auto this_op_slice_attr = op_slice_attr[op_index];
             auto [output_slice_start, output_slice_end] = output_slice_coords[op_index];
             bool pad_output_width = (op_index == (op_slice_attr.size() - 1));

--- a/ttnn/cpp/ttnn/operations/sliding_window/op_slicing/op_slicing.hpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/op_slicing/op_slicing.hpp
@@ -40,10 +40,11 @@ public:
         const ttnn::Tensor& sliced_input_tensor, IOShape output_slice_start, IOShape output_slice_end) = 0;
     virtual std::string name() = 0;
 };
+
 void run_sliced_op(
     const ttnn::Tensor& input_tensor,
     ttnn::Tensor& output_tensor,
-    OpSliceAttr* op_slice_attr,
+    std::vector<OpSliceAttr*> op_slice_attr,
     Op2DSliceConfig dram_slice_config);
 
 }  // namespace ttnn::operations::op_slicing

--- a/ttnn/cpp/ttnn/operations/sliding_window/op_slicing/op_slicing.hpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/op_slicing/op_slicing.hpp
@@ -43,6 +43,7 @@ public:
         bool pad_output_width) = 0;
     virtual std::string name() = 0;
     virtual std::string str() = 0;
+    virtual std::tuple<TensorSpec, tt::tt_metal::distributed::MeshDevice*> get_output_tensor_spec_and_device() = 0;
 };
 
 void run_sliced_op(

--- a/ttnn/cpp/ttnn/operations/sliding_window/op_slicing/op_slicing.hpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/op_slicing/op_slicing.hpp
@@ -46,10 +46,15 @@ public:
     virtual std::tuple<TensorSpec, tt::tt_metal::distributed::MeshDevice*> get_output_tensor_spec_and_device() = 0;
 };
 
+ttnn::Tensor run_sliced_op(
+    const ttnn::Tensor& input_tensor,
+    const std::vector<OpSliceAttr*>& op_slice_attr,
+    Op2DSliceConfig dram_slice_config);
+
 void run_sliced_op(
     const ttnn::Tensor& input_tensor,
     ttnn::Tensor& output_tensor,
-    std::vector<OpSliceAttr*> op_slice_attr,
+    const std::vector<OpSliceAttr*>& op_slice_attr,
     Op2DSliceConfig dram_slice_config);
 
 }  // namespace ttnn::operations::op_slicing

--- a/ttnn/cpp/ttnn/operations/sliding_window/op_slicing/op_slicing.hpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/op_slicing/op_slicing.hpp
@@ -37,7 +37,10 @@ public:
     virtual tt::tt_metal::MemoryConfig get_input_memory_config(
         IOShape output_slice_start, IOShape output_slice_end) = 0;
     virtual ttnn::Tensor run_L1_op(
-        const ttnn::Tensor& sliced_input_tensor, IOShape output_slice_start, IOShape output_slice_end) = 0;
+        const ttnn::Tensor& sliced_input_tensor,
+        IOShape output_slice_start,
+        IOShape output_slice_end,
+        bool pad_output_width) = 0;
     virtual std::string name() = 0;
     virtual std::string str() = 0;
 };

--- a/ttnn/cpp/ttnn/operations/sliding_window/op_slicing/op_slicing.hpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/op_slicing/op_slicing.hpp
@@ -39,6 +39,7 @@ public:
     virtual ttnn::Tensor run_L1_op(
         const ttnn::Tensor& sliced_input_tensor, IOShape output_slice_start, IOShape output_slice_end) = 0;
     virtual std::string name() = 0;
+    virtual std::string str() = 0;
 };
 
 void run_sliced_op(

--- a/ttnn/cpp/ttnn/operations/sliding_window/op_slicing/op_slicing_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/op_slicing/op_slicing_pybind.cpp
@@ -5,6 +5,7 @@
 #include "op_slicing.hpp"
 #include "op_slicing_pybind.hpp"
 #include <pybind11/cast.h>
+#include <pybind11/detail/common.h>
 #include "ttnn-pybind/decorators.hpp"
 
 using namespace tt::tt_metal;
@@ -14,17 +15,43 @@ namespace ttnn::operations::op_slicing {
 void py_bind_op_slicing(py::module& module) {
     module.def(
         "run_sliced_op",
-        &run_sliced_op,
+        py::overload_cast<const ttnn::Tensor&, ttnn::Tensor&, const std::vector<OpSliceAttr*>&, Op2DSliceConfig>(
+            &run_sliced_op),
         py::kw_only(),
         py::arg("input_tensor"),
         py::arg("output_tensor"),
         py::arg("op_slice_attr"),
         py::arg("dram_slice_config"),
         R"doc(
-        Applies a 2D convolution over an input signal composed of several input planes.
+            This function is used as a performance optimization for sliced ops using DRAM Inputs & Outputs. This function allows for fusion of multiple OPs to execute on a single DRAM Input slice, and have only the output slice of the final op is written back to DRAM.
+            This reduces the impact of the relatively slow DRAM access by amortizing it across multiple operations.
 
-        For more information, refer to `this tech report. <https://github.com/tenstorrent/tt-metal/blob/main/tech_reports/CNNs/ttcnn.md>`
+        Keyword Args:
+            input_tensor (ttnn.Tensor):  The input to the first op. This tensor must be DRAM Interleaved, with it's a 4D Shape.
+            output_tensor (ttnn.Tensor):  The tensor to which the output of the final op is written to. This tensor must also be DRAM Interleaved, with a 4D Shape.
+            op_slice_attr (list[ttnn.OpSliceAttr]) : List describing the ops to be executed by passing objects of the operation's specific slicing attributes. For example, a list containing Conv2dSliceAttr and Pool2dSliceAttr.
+            dram_slice_config (ttnn.Op2DSliceConfig) : Object that describes how the slicing should take place, which includes the dimension being sliced (currently only Height & Width are supported) & the number of slices.
     )doc");
+    module.def(
+        "run_sliced_op",
+        py::overload_cast<const ttnn::Tensor&, const std::vector<OpSliceAttr*>&, Op2DSliceConfig>(&run_sliced_op),
+        py::kw_only(),
+        py::arg("input_tensor"),
+        py::arg("op_slice_attr"),
+        py::arg("dram_slice_config"),
+        R"doc(
+            This function is used as a performance optimization for sliced ops using DRAM Inputs & Outputs. This function allows for fusion of multiple OPs to execute on a single DRAM Input slice, and have only the output slice of the final op is written back to DRAM.
+            This reduces the impact of the relatively slow DRAM access by amortizing it across multiple operations.
+
+        Keyword Args:
+            input_tensor (ttnn.Tensor):  The input to the first op. This tensor must be DRAM Interleaved, with it's a 4D Shape.
+            op_slice_attr (list[ttnn.OpSliceAttr]) : List describing the ops to be executed by passing objects of the operation's specific slicing attributes. For example, a list containing Conv2dSliceAttr and Pool2dSliceAttr.
+            dram_slice_config (ttnn.Op2DSliceConfig) : Object that describes how the slicing should take place, which includes the dimension being sliced (currently only Height & Width are supported) & the number of slices.
+
+        Returns:
+            The output tensor of the final op
+            - ttnn.Tensor: The output tensor
+        )doc");
 
     py::class_<OpSliceAttr> py_op_slice_attr(
         module,

--- a/ttnn/cpp/ttnn/operations/sliding_window/op_slicing/op_slicing_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/op_slicing/op_slicing_pybind.cpp
@@ -2,22 +2,36 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
+#include "op_slicing.hpp"
+#include "op_slicing_pybind.hpp"
+#include <pybind11/cast.h>
+#include "ttnn-pybind/decorators.hpp"
 
 using namespace tt::tt_metal;
 
 namespace ttnn::operations::op_slicing {
 
-void py_bind_sliding_window(py::module& module) {
+void py_bind_op_slicing(py::module& module) {
     module.def(
         "run_sliced_op",
         &run_sliced_op,
+        py::kw_only(),
         py::arg("input_tensor"),
         py::arg("output_tensor"),
         py::arg("op_slice_attr"),
         py::arg("dram_slice_config"),
-        DOC("Runs a 2D operation in slices based on the provided slicing configuration and operation attributes."));
+        R"doc(
+        Applies a 2D convolution over an input signal composed of several input planes.
+
+        For more information, refer to `this tech report. <https://github.com/tenstorrent/tt-metal/blob/main/tech_reports/CNNs/ttcnn.md>`
+    )doc");
+
+    py::class_<OpSliceAttr> py_op_slice_attr(
+        module,
+        "OpSliceAttr",
+        R"doc(
+        OpSliceAttr is an interface that defines how to slice the input tensor based on the output slice.
+        )doc");
 }
 
 }  // namespace ttnn::operations::op_slicing

--- a/ttnn/cpp/ttnn/operations/sliding_window/op_slicing/op_slicing_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/op_slicing/op_slicing_pybind.cpp
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+using namespace tt::tt_metal;
+
+namespace ttnn::operations::op_slicing {
+
+void py_bind_sliding_window(py::module& module) {
+    module.def(
+        "run_sliced_op",
+        &run_sliced_op,
+        py::arg("input_tensor"),
+        py::arg("output_tensor"),
+        py::arg("op_slice_attr"),
+        py::arg("dram_slice_config"),
+        DOC("Runs a 2D operation in slices based on the provided slicing configuration and operation attributes."));
+}
+
+}  // namespace ttnn::operations::op_slicing

--- a/ttnn/cpp/ttnn/operations/sliding_window/op_slicing/op_slicing_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/op_slicing/op_slicing_pybind.hpp
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn-pybind/pybind_fwd.hpp"
+
+namespace ttnn::operations::op_slicing {
+namespace py = pybind11;
+void py_bind_op_slicing(py::module& module);
+}  // namespace ttnn::operations::op_slicing

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -383,6 +383,8 @@ from ttnn.operations.conv2d import (
     prepare_conv_transpose2d_weights,
     prepare_conv_transpose2d_bias,
     SlidingWindowParallelConfig,
+    Conv2dSliceAttr,
+    run_sliced_op,
 )
 from ttnn._ttnn.operations.conv import (
     convert_conv_weight_tensor_to_tiled_layout,

--- a/ttnn/ttnn/operations/conv2d.py
+++ b/ttnn/ttnn/operations/conv2d.py
@@ -18,6 +18,9 @@ Conv2dDRAMSliceWidth = ttnn._ttnn.operations.conv.Conv2dSliceConfig.SliceTypeEnu
 Conv2dL1Full = ttnn._ttnn.operations.conv.Conv2dSliceConfig.SliceTypeEnum.L1Full
 Conv2dL1FullSliceConfig = Conv2dSliceConfig(slice_type=Conv2dL1Full)
 
+Conv2dSliceAttr = ttnn._ttnn.operations.conv.Conv2dSliceAttr
+run_sliced_op = ttnn._ttnn.operations.op_slicing.run_sliced_op
+
 
 def get_conv_output_dim(input, window, stride=1, pad=0, dilation=1):
     """


### PR DESCRIPTION
### Problem description
DRAM Slicing reduces perf due to DRAM read & write.

### What's changed
- Reduce perf overhead of DRAM R/W by doing multiple layers in a single DRAM Read/Write cycle
- Implement tests for op chaining using Conv2d ops
- Fixed bugs in slice_write when certain cores have no valid output to write to DRAM.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI [passes] (https://github.com/tenstorrent/tt-metal/actions/runs/19633264716)
- [ ] Blackhole post commit passes
- [ ] New/Existing tests provide coverage for changes