### PR TITLE
MM - Require Sharded Matmuls to Use Program Config Activation

### DIFF
--- a/ttnn/cpp/ttnn/operations/matmul/matmul.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul.cpp
@@ -149,6 +149,14 @@ ttnn::Tensor bound_matmul(
             input_tensor_b.logical_shape());
     }
 
+    if (input_tensor_a.is_sharded() || input_tensor_b.is_sharded()) {
+        TT_FATAL(
+            !parameters.user_fused_activation.has_value(),
+            "Sharded matmul run with {} activation: this should be placed in the program config's fused_activation "
+            "field",
+            parameters.user_fused_activation.value().op_type);
+    }
+
     // Check for zero volume tensors
     if (input_tensor_a.logical_volume() == 0 || input_tensor_b.logical_volume() == 0) [[unlikely]] {
         return detail::handle_zero_volume_matmul(
@@ -210,11 +218,20 @@ ttnn::Tensor bound_matmul(
             optional_output_tensor);
     }
 
-    if (parameters.user_fused_activation.has_value() && !parameters.user_core_coord.has_value()) {
-        const UnaryWithParam& activation = parameters.user_fused_activation.value();
+    log_debug(tt::LogOp, "Performing the unfused activation: {}", parameters.user_fused_activation.value().op_type);
 
+    if (parameters.user_fused_activation.has_value() && !parameters.user_core_coord.has_value()) {
+        // const UnaryWithParam& activation = parameters.user_fused_activation.value();
+        const UnaryWithParam activation = UnaryWithParam(UnaryOpType::GELU, static_cast<float>(false));
+        log_debug(tt::LogOp, "invoking");
+        log_debug(tt::LogOp, "output_tensor: {}", output_tensor.logical_shape());
+        log_debug(tt::LogOp, "Optional output tensor has_value: {}", optional_output_tensor.has_value());
+        log_debug(tt::LogOp, "Activation is: {}", activation.op_type);
+        log_debug(tt::LogOp, "Activation params: {}", activation.params);
+        log_debug(tt::LogOp, "Output Memory Config: {}", parameters.output_mem_config);
         output_tensor = ttnn::operations::unary::Unary_chain::invoke(
-            output_tensor, {activation}, parameters.output_mem_config, optional_output_tensor);
+            output_tensor, {activation}, parameters.output_mem_config);  //, optional_output_tensor);
+        log_debug(tt::LogOp, "done");
     }
 
     return output_tensor;

--- a/ttnn/cpp/ttnn/operations/matmul/matmul.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul.cpp
@@ -219,12 +219,10 @@ ttnn::Tensor bound_matmul(
     }
 
     if (parameters.user_fused_activation.has_value() && !parameters.user_core_coord.has_value()) {
-        // const UnaryWithParam& activation = parameters.user_fused_activation.value();
-        const UnaryWithParam activation = UnaryWithParam(UnaryOpType::GELU, static_cast<float>(false));
+        const UnaryWithParam& activation = parameters.user_fused_activation.value();
 
         output_tensor = ttnn::operations::unary::Unary_chain::invoke(
-            output_tensor, {activation}, parameters.output_mem_config);  //, optional_output_tensor);
-        log_debug(tt::LogOp, "done");
+            output_tensor, {activation}, parameters.output_mem_config, optional_output_tensor);
     }
 
     return output_tensor;

--- a/ttnn/cpp/ttnn/operations/matmul/matmul.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul.cpp
@@ -218,17 +218,10 @@ ttnn::Tensor bound_matmul(
             optional_output_tensor);
     }
 
-    log_debug(tt::LogOp, "Performing the unfused activation: {}", parameters.user_fused_activation.value().op_type);
-
     if (parameters.user_fused_activation.has_value() && !parameters.user_core_coord.has_value()) {
         // const UnaryWithParam& activation = parameters.user_fused_activation.value();
         const UnaryWithParam activation = UnaryWithParam(UnaryOpType::GELU, static_cast<float>(false));
-        log_debug(tt::LogOp, "invoking");
-        log_debug(tt::LogOp, "output_tensor: {}", output_tensor.logical_shape());
-        log_debug(tt::LogOp, "Optional output tensor has_value: {}", optional_output_tensor.has_value());
-        log_debug(tt::LogOp, "Activation is: {}", activation.op_type);
-        log_debug(tt::LogOp, "Activation params: {}", activation.params);
-        log_debug(tt::LogOp, "Output Memory Config: {}", parameters.output_mem_config);
+
         output_tensor = ttnn::operations::unary::Unary_chain::invoke(
             output_tensor, {activation}, parameters.output_mem_config);  //, optional_output_tensor);
         log_debug(tt::LogOp, "done");

--- a/ttnn/cpp/ttnn/operations/matmul/matmul_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul_pybind.cpp
@@ -669,7 +669,7 @@ void py_module(py::module& module) {
             memory_config (ttnn.MemoryConfig, optional): the memory configuration of the output tensor. Defaults to `None`, which will result in using `ttnn.DRAM_MEMORY_CONFIG`.
             dtype (ttnn.DataType, optional): the data type of the output tensor. Defaults to `None`.
             program_config (MatmulProgramConfig, optional): the program configuration for the matmul operation. Defaults to `None`.
-            activation (str or ttnn.UnaryWithParam, optional): the activation function to be applied. Defaults to `None`.
+            activation (str or ttnn.UnaryWithParam, optional): the activation function to be applied. When using sharded tensors, the :attr:`fused_activation` parameter of the :attr:`program_config` should be used instead. Defaults to `None`.
             compute_kernel_config (ttnn.DeviceComputeKernelConfig, optional): the compute kernel configuration for the matmul operation. Defaults to `None`.
             core_grid (ttnn.CoreGrid, optional): the grid on which to distribute the sharded tensor on (writes to the cores L1s). Defaults to `None`.
             output_tile (List of [int], optional): Specifies the output tile configuration. Defaults to `None`.
@@ -766,7 +766,7 @@ void py_module(py::module& module) {
             memory_config (ttnn.MemoryConfig, optional): the memory configuration of the output tensor. Defaults to `None`, which will result in using `ttnn.DRAM_MEMORY_CONFIG`.
             dtype (ttnn.DataType, optional): the data type of the output tensor. Defaults to `None`.
             program_config (MatmulProgramConfig, optional): the program configuration for the matmul operation. Defaults to `None`.
-            activation (str or ttnn.UnaryWithParam, optional): the activation function to be applied. Defaults to `None`.
+            activation (str or ttnn.UnaryWithParam, optional): the activation function to be applied. When using sharded tensors, the :attr:`fused_activation` parameter of the :attr:`program_config` should be used instead. Defaults to `None`.
             compute_kernel_config (ttnn.DeviceComputeKernelConfig, optional): the compute kernel configuration for the matmul operation. Defaults to `None`.
             core_grid (ttnn.CoreGrid, optional): the grid on which to distribute the sharded tensor on (writes to the cores L1s). Defaults to `None`.
             output_tile (List of [int], optional): Specifies the output tile configuration. Defaults to `None`.

--- a/ttnn/cpp/ttnn/operations/matmul/matmul_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul_pybind.cpp
@@ -516,7 +516,7 @@ void py_module(py::module& module) {
             memory_config(ttnn.MemoryConfig, optional): the memory configuration of the output tensor. Defaults to `None`, which will result in using ttnn.DRAM_MEMORY_CONFIG.
             dtype (ttnn.DataType): the data type of the output tensor. Defaults to `None`.
             program_config (ttnn.MatmulProgramConfig): the program configuration for the matmul operation. Defaults to `None`.
-            activation (str or ttnn.UnaryWithParam, optional): the activation function to be applied. Defaults to `None`.
+            activation (str or ttnn.UnaryWithParam, optional): the activation function to be applied. When using sharded tensors, the :attr:`fused_activation` parameter of the :attr:`program_config` should be used instead. Defaults to `None`.
             compute_kernel_config (ttnn.DeviceComputeKernelConfig): the compute kernel configuration for the matmul operation. Defaults to `None`.
             core_grid (ttnn.CoreGrid): the grid on which to distribute the sharded tensor on (writes to the cores L1s). Defaults to `None`.
             output_tile (List of [int], optional): Specifies the output tile configuration. Defaults to `None`.


### PR DESCRIPTION
### Ticket
[#32399](https://github.com/tenstorrent/tt-metal/issues/32399)

### Problem description
Matmul has two ways of specifying activation. The "activation" parameter for convenience, and the "fused_activation" parameter in the program config. 

Unexpected results were seen when supplying activations to matmul - sometimes the activation isn't fused when it's expected to be, and this results in a change in the L1 requirements of the matmul. The common denominator to these issues is using "activation" for sharded matmuls instead of the "fused_activation" of the sharded program config.

### What's changed
Add validation to prevent this situation from occurring. 

Eliminating the diverging code paths so that the activation occurs the same way is either case is another possibility, but will be more involved as this will impact other non-sharded cases that rely on having this distinction.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/19437556466)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests [passes](https://github.com/tenstorrent/tt-metal/actions/runs/19437564714)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/19543591574)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/19549213788) 
- [ ] [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/19543605436) 
- [x] Frequent Model & TTNN [passes](https://github.com/tenstorrent/tt-metal/actions/runs/19437572977) 
- [x] Night L2 [passes](https://github.com/tenstorrent/tt-metal/actions/runs/19510944075)