### PR TITLE
Reshape 2d input tensor before fold to 4d

### DIFF
--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
@@ -222,6 +222,7 @@ Result conv2d_DRAM(
     ttnn::Tensor input_tensor_on_device = fold_input_tensor_if_required(
         input_tensor,
         device,
+        batch_size,
         input_height,
         input_width,
         in_channels,
@@ -458,6 +459,7 @@ Result conv2d_L1(
     auto input_tensor = fold_input_tensor_if_required(
         input_tensor_,
         device,
+        batch_size,
         input_height,
         input_width,
         in_channels,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
@@ -1585,6 +1585,7 @@ bool auto_enable_kernel_folding(
 Tensor fold_input_tensor_if_required(
     const ttnn::Tensor& input_tensor,
     MeshDevice* device,
+    uint32_t& batch_size,
     uint32_t& input_height,
     uint32_t& input_width,
     uint32_t& in_channels,
@@ -1611,8 +1612,8 @@ Tensor fold_input_tensor_if_required(
     if (conv_config.enable_kernel_stride_folding.value() && (stride[0] > 1 || stride[1] > 1)) {
         auto folding_result = compute_kernel_stride_folding_params(
             input_height, input_width, in_channels, kernel_size, stride, padding_n4, conv_config);
-        auto folded_input_tensor =
-            fold_tensor(input_tensor, device, stride, kernel_size, padding_n4, input_height, input_width, in_channels);
+        auto folded_input_tensor = fold_tensor(
+            input_tensor, device, stride, kernel_size, padding_n4, batch_size, input_height, input_width, in_channels);
         if (conv_config.deallocate_activation && !input_tensor.memory_config().is_dram()) {
             auto tensor_to_deallocate = input_tensor;
             tensor_to_deallocate.deallocate(true);
@@ -1638,6 +1639,7 @@ ttnn::Tensor fold_tensor(
     std::array<uint32_t, 2> stride,
     std::array<uint32_t, 2> kernel_size,
     std::array<uint32_t, 4> padding_n4,
+    uint32_t batch_size,
     uint32_t input_height,
     uint32_t input_width,
     uint32_t in_channels) {
@@ -1652,9 +1654,9 @@ ttnn::Tensor fold_tensor(
         tensor_on_device = ttnn::to_device(tensor_on_device, device, ttnn::DRAM_MEMORY_CONFIG);
     }
 
-    // Reshape tensor if needed before folding
+    // Reshape tensor from flattened 4D shape (e.g., [1, 1, N*H*W, C]) back to original 4D shape [N, H, W, C] before
+    // folding
     const auto& current_shape = tensor_on_device.logical_shape();
-    uint32_t batch_size = current_shape[0];
     bool needs_reshape =
         (current_shape.rank() == 4 && (current_shape[1] != input_height || current_shape[2] != input_width));
     if (needs_reshape) {

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.hpp
@@ -207,6 +207,7 @@ bool auto_enable_kernel_folding(
 Tensor fold_input_tensor_if_required(
     const ttnn::Tensor& input_tensor,
     MeshDevice* device,
+    uint32_t& batch_size,
     uint32_t& input_height,
     uint32_t& input_width,
     uint32_t& in_channels,
@@ -223,6 +224,7 @@ ttnn::Tensor fold_tensor(
     std::array<uint32_t, 2> stride,
     std::array<uint32_t, 2> kernel_size,
     std::array<uint32_t, 4> padding_n4,
+    uint32_t batch_size,
     uint32_t input_height,
     uint32_t input_width,
     uint32_t in_channels);

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.hpp
@@ -222,7 +222,10 @@ ttnn::Tensor fold_tensor(
     MeshDevice* device,
     std::array<uint32_t, 2> stride,
     std::array<uint32_t, 2> kernel_size,
-    std::array<uint32_t, 4> padding_n4);
+    std::array<uint32_t, 4> padding_n4,
+    uint32_t input_height,
+    uint32_t input_width,
+    uint32_t in_channels);
 
 struct KernelStrideFoldingResult {
     uint32_t input_height;

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/fold.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/fold.cpp
@@ -410,6 +410,7 @@ Tensor FoldOperation::invoke(
     const bool has_c_padding = (pad_c_front | pad_c_back) != 0;
 
     const Tensor& input_tensor = input_tensor_;
+    TT_ASSERT(input_tensor.logical_shape().rank() == 4, "Fold op only supports 4D tensors");
 
     // Legacy transpose-based fold (TODO: remove when #29514 is solved)
     if (use_transpose_as_fold) {


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/32885

### Problem description
2D tensor errors out with input height not divisible by stride_h.

### What's changed
Reshape input tensor if shape is 2D.

### Checklist
- [X] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI [Running](https://github.com/tenstorrent/tt-metal/actions/runs/19542257157)
- [X] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI [running](https://github.com/tenstorrent/tt-metal/actions/runs/19542623830)
- [X] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI [passing](https://github.com/tenstorrent/tt-metal/actions/runs/19538508707)
- [X] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI [Passing](https://github.com/tenstorrent/tt-metal/actions/runs/19565548845)
- [X] [(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml) CI [passing](https://github.com/tenstorrent/tt-metal/actions/runs/19565553139)
- [X] [Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) CI [passing](https://github.com/tenstorrent/tt-metal/actions/runs/19565557234)