### PR TITLE
#32704: Migrate op to new infra: concatenate_heads

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/transformer/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/CMakeLists.txt
@@ -54,6 +54,7 @@ target_sources(
         all_reduce_create_qkv_heads/device/all_reduce_create_qkv_heads_op.cpp
         all_reduce_create_qkv_heads/device/all_reduce_create_qkv_heads_program_factory.cpp
         concatenate_heads/device/concatenate_heads_device_operation.cpp
+        concatenate_heads/device/concatenate_heads_program_factory.cpp
         create_qkv_heads/create_qkv_heads.cpp
         create_qkv_heads/device/create_qkv_heads_device_operation.cpp
         create_qkv_heads/device/create_qkv_heads_program_factory.cpp

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/concatenate_heads/concatenate_heads.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/concatenate_heads/concatenate_heads.hpp
@@ -7,7 +7,7 @@
 #include <utility>
 
 #include "device/concatenate_heads_device_operation.hpp"
-#include "ttnn/run_operation.hpp"
+#include "ttnn/device_operation.hpp"
 #include "ttnn/operations/core/core.hpp"
 
 namespace ttnn {
@@ -19,13 +19,8 @@ struct ConcatenateHeadsOperation {
         const CoreCoord& compute_with_storage_grid_size,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         std::optional<Tensor> optional_output_tensor = std::nullopt) {
-        return tt::tt_metal::operation::run(
-                   ConcatenateHeadsDeviceOperation{
-                       compute_with_storage_grid_size, memory_config.value_or(input_tensor.memory_config())},
-                   {input_tensor},
-                   {},
-                   {std::move(optional_output_tensor)})
-            .at(0);
+        return ttnn::prim::concatenate_heads(
+            input_tensor, compute_with_storage_grid_size, memory_config, optional_output_tensor);
     }
 };
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/concatenate_heads/device/concatenate_heads_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/concatenate_heads/device/concatenate_heads_device_operation.cpp
@@ -84,8 +84,6 @@ tt::stl::hash::hash_t ConcatenateHeadsDeviceOperation::compute_program_hash(
     const auto& input_tensor = tensor_args.input;
     const auto& input_shape = input_tensor.padded_shape();
     auto program_factory = select_program_factory(args, tensor_args);
-    // Note: compute_with_storage_grid_size is excluded from hash as it's validation-only
-    // and doesn't affect program structure. Only output_mem_config affects the program.
     operation::Hash hash = operation::hash_operation<ConcatenateHeadsDeviceOperation>(
         args.output_mem_config,
         program_factory.index(),

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/concatenate_heads/device/concatenate_heads_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/concatenate_heads/device/concatenate_heads_device_operation.cpp
@@ -5,12 +5,27 @@
 #include "concatenate_heads_device_operation.hpp"
 
 #include "concatenate_heads_program_factory.hpp"
+#include <tt-metalium/constants.hpp>
+
+using namespace tt::tt_metal;
 
 namespace ttnn::operations::experimental::transformer {
 
-void ConcatenateHeadsDeviceOperation::validate_with_output_tensors(
-    const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const {
-    const auto& input_tensor = input_tensors.at(0);
+ConcatenateHeadsDeviceOperation::program_factory_t ConcatenateHeadsDeviceOperation::select_program_factory(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    return program::ConcatenateHeadsProgramFactory{};
+}
+
+void ConcatenateHeadsDeviceOperation::validate_on_program_cache_hit(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    validate_on_program_cache_miss(args, tensor_args);
+}
+
+void ConcatenateHeadsDeviceOperation::validate_on_program_cache_miss(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    const auto& input_tensor = tensor_args.input;
+    const auto& preallocated_output = tensor_args.preallocated_output;
+
     const auto batch_size = input_tensor.padded_shape()[0];
     // TODO: See issue #1744
     TT_FATAL(batch_size >= 7 && batch_size <= 9, "Input batch size must be between 7 to 9 for bert large TM ops!");
@@ -24,54 +39,75 @@ void ConcatenateHeadsDeviceOperation::validate_with_output_tensors(
 
     TT_FATAL((input_tensor.padded_shape() == ttnn::Shape({batch_size, 16, 384, 64})), "Unsupported input shape");
 
-    TT_FATAL(output_tensors.size() == 1, "Must have 1 output tensors");
-    const auto& optional_output_tensor = output_tensors.at(0);
-    if (optional_output_tensor.has_value()) {
+    if (preallocated_output.has_value()) {
         TT_FATAL(
-            optional_output_tensor.value().dtype() == input_tensor.dtype(),
-            "Output dtype must be same as input dtype!");
+            preallocated_output.value().dtype() == input_tensor.dtype(), "Output dtype must be same as input dtype!");
 
         TT_FATAL(
-            optional_output_tensor.value().padded_shape() == ttnn::Shape({batch_size, 1, 384, 1024}),
+            preallocated_output.value().padded_shape() == ttnn::Shape({batch_size, 1, 384, 1024}),
             "Output shape must be (batch_size, 1, 384, 1024)!");
     }
-}
-
-std::vector<ttnn::TensorSpec> ConcatenateHeadsDeviceOperation::compute_output_specs(
-    const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const {
-    if (output_tensors.at(0).has_value()) {
-        return {output_tensors.at(0)->tensor_spec()};
-    }
-    const auto& input_tensor = input_tensors.at(0);
-    const auto batch_size = input_tensor.padded_shape()[0];
-    ttnn::Shape output_shape({batch_size, 1, 384, 1024});
-    return {TensorSpec(
-        output_shape,
-        tt::tt_metal::TensorLayout(
-            input_tensor.dtype(), tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE), output_mem_config))};
-}
-
-std::vector<Tensor> ConcatenateHeadsDeviceOperation::create_output_tensors(
-    const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const {
-    if (output_tensors.at(0).has_value()) {
-        return {output_tensors.at(0).value()};
-    }
-
-    return {create_device_tensor(compute_output_specs(input_tensors, output_tensors)[0], input_tensors.at(0).device())};
-}
-
-tt::tt_metal::operation::ProgramWithCallbacks ConcatenateHeadsDeviceOperation::create_program(
-    const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const {
-    const auto& input_tensor = input_tensors.at(0);
-    auto& output_tensor = output_tensors.at(0);
 
     auto device_compute_with_storage_grid_size = input_tensor.device()->compute_with_storage_grid_size();
     TT_FATAL(
-        (this->compute_with_storage_grid_size.x <= device_compute_with_storage_grid_size.x &&
-         this->compute_with_storage_grid_size.y <= device_compute_with_storage_grid_size.y),
+        (args.compute_with_storage_grid_size.x <= device_compute_with_storage_grid_size.x &&
+         args.compute_with_storage_grid_size.y <= device_compute_with_storage_grid_size.y),
         "Unsupported grid shape");
+}
 
-    return detail::concatenate_heads_multi_core(input_tensor, output_tensor, this->compute_with_storage_grid_size);
+spec_return_value_t ConcatenateHeadsDeviceOperation::compute_output_specs(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    if (tensor_args.preallocated_output.has_value()) {
+        return tensor_args.preallocated_output->tensor_spec();
+    }
+
+    const auto& input_tensor = tensor_args.input;
+    const auto batch_size = input_tensor.padded_shape()[0];
+    ttnn::Shape output_shape({batch_size, 1, 384, 1024});
+    return TensorSpec(
+        output_shape,
+        tt::tt_metal::TensorLayout(
+            input_tensor.dtype(), tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE), args.output_mem_config));
+}
+
+tensor_return_value_t ConcatenateHeadsDeviceOperation::create_output_tensors(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    if (tensor_args.preallocated_output.has_value()) {
+        return *tensor_args.preallocated_output;
+    }
+
+    return create_device_tensor(compute_output_specs(args, tensor_args), tensor_args.input.device());
+}
+
+tt::stl::hash::hash_t ConcatenateHeadsDeviceOperation::compute_program_hash(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    const auto& input_tensor = tensor_args.input;
+    const auto& input_shape = input_tensor.padded_shape();
+    auto program_factory = select_program_factory(args, tensor_args);
+    // Note: compute_with_storage_grid_size is excluded from hash as it's validation-only
+    // and doesn't affect program structure. Only output_mem_config affects the program.
+    operation::Hash hash = operation::hash_operation<ConcatenateHeadsDeviceOperation>(
+        args.output_mem_config,
+        program_factory.index(),
+        input_tensor.dtype(),
+        input_tensor.memory_config(),
+        input_shape.volume());
+
+    return hash;
+}
+
+std::tuple<ConcatenateHeadsDeviceOperation::operation_attributes_t, ConcatenateHeadsDeviceOperation::tensor_args_t>
+ConcatenateHeadsDeviceOperation::invoke(
+    const Tensor& input_tensor,
+    const CoreCoord& compute_with_storage_grid_size,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<Tensor>& preallocated_output) {
+    return {
+        operation_attributes_t{
+            .compute_with_storage_grid_size = compute_with_storage_grid_size,
+            .output_mem_config = memory_config.value_or(input_tensor.memory_config()),
+        },
+        tensor_args_t{.input = input_tensor, .preallocated_output = preallocated_output}};
 }
 
 }  // namespace ttnn::operations::experimental::transformer

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/concatenate_heads/device/concatenate_heads_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/concatenate_heads/device/concatenate_heads_device_operation.hpp
@@ -4,25 +4,49 @@
 
 #pragma once
 
+#include <functional>
 #include <optional>
 
 #include "ttnn/tensor/tensor.hpp"
-#include "ttnn/run_operation.hpp"
+#include "concatenate_heads_program_factory.hpp"
+
+#include "ttnn/device_operation.hpp"
+#include "ttnn/decorators.hpp"
+
+#include "concatenate_heads_device_operation_types.hpp"
 
 namespace ttnn::operations::experimental::transformer {
 
 struct ConcatenateHeadsDeviceOperation {
-    CoreCoord compute_with_storage_grid_size;
-    tt::tt_metal::MemoryConfig output_mem_config;
+    using operation_attributes_t = transformer::operation_attributes_t;
+    using tensor_args_t = transformer::tensor_args_t;
+    using spec_return_value_t = transformer::spec_return_value_t;
+    using tensor_return_value_t = transformer::tensor_return_value_t;
+    using program_factory_t = std::variant<program::ConcatenateHeadsProgramFactory>;
 
-    void validate_with_output_tensors(
-        const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const;
-    std::vector<ttnn::TensorSpec> compute_output_specs(
-        const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const;
-    std::vector<Tensor> create_output_tensors(
-        const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const;
-    tt::tt_metal::operation::ProgramWithCallbacks create_program(
-        const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const;
+    static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
+
+    static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
+    static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
+
+    static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
+
+    static tensor_return_value_t create_output_tensors(
+        const operation_attributes_t& operation_attributes, const tensor_args_t&);
+
+    static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+
+    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
+        const Tensor& input_tensor,
+        const CoreCoord& compute_with_storage_grid_size,
+        const std::optional<MemoryConfig>& memory_config,
+        const std::optional<Tensor>& preallocated_output);
 };
 
 }  // namespace ttnn::operations::experimental::transformer
+
+namespace ttnn::prim {
+constexpr auto concatenate_heads = ttnn::register_operation<
+    "ttnn::prim::concatenate_heads",
+    ttnn::operations::experimental::transformer::ConcatenateHeadsDeviceOperation>();
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/concatenate_heads/device/concatenate_heads_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/concatenate_heads/device/concatenate_heads_device_operation_types.hpp
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/core.hpp"
+
+namespace ttnn::operations::experimental::transformer {
+
+struct operation_attributes_t {
+    const CoreCoord compute_with_storage_grid_size;
+    const tt::tt_metal::MemoryConfig output_mem_config;
+};
+
+struct tensor_args_t {
+    const Tensor& input;
+    const std::optional<Tensor>& preallocated_output;
+};
+
+using tensor_return_value_t = Tensor;
+
+using spec_return_value_t = TensorSpec;
+
+}  // namespace ttnn::operations::experimental::transformer

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/concatenate_heads/device/concatenate_heads_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/concatenate_heads/device/concatenate_heads_device_operation_types.hpp
@@ -15,8 +15,8 @@ struct operation_attributes_t {
 };
 
 struct tensor_args_t {
-    const Tensor& input;
-    const std::optional<Tensor>& preallocated_output;
+    const Tensor input;
+    const std::optional<Tensor> preallocated_output;
 };
 
 using tensor_return_value_t = Tensor;

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/concatenate_heads/device/concatenate_heads_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/concatenate_heads/device/concatenate_heads_program_factory.cpp
@@ -1,0 +1,168 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "concatenate_heads_program_factory.hpp"
+
+#include "concatenate_heads_device_operation_types.hpp"
+#include "ttnn/tensor/tensor.hpp"
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+
+namespace ttnn::operations::experimental::transformer::program {
+
+using namespace tt::constants;
+using namespace tt::tt_metal;
+using namespace tt;
+
+ConcatenateHeadsProgramFactory::cached_program_t ConcatenateHeadsProgramFactory::create(
+    const operation_attributes_t& operation_attributes,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& output) {
+    const auto& a = tensor_args.input;
+    const auto& ashape = a.padded_shape();
+    const auto& compute_with_storage_grid_size = operation_attributes.compute_with_storage_grid_size;
+
+    tt::DataFormat cb_data_format = tt_metal::datatype_to_dataformat_converter(a.dtype());
+
+    uint32_t single_tile_size = tt::tile_size(cb_data_format);
+    tt_metal::Buffer* in0_buffer = a.buffer();
+    TT_ASSERT(in0_buffer->size() % single_tile_size == 0);
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      TM Parameters Setup
+    ////////////////////////////////////////////////////////////////////////////
+    // Output shape is: [B, 1, 384, 1024]
+    uint32_t per_core_tiles = (ashape[1] * ashape[3]) / TILE_WIDTH;
+    uint32_t in0_h_tiles = ashape[2] / TILE_HEIGHT;
+
+    // These parameters are identical to out_* in multi_core_create_qkv_heads
+    uint32_t in0_w = 64;
+    uint32_t in0_w_tiles = in0_w / TILE_WIDTH;
+    uint32_t in0_c = per_core_tiles / in0_w_tiles;
+    uint32_t in0_HtWt = in0_h_tiles * in0_w_tiles;
+    uint32_t in0_CHtWt = in0_c * in0_HtWt;
+
+    // Parallelize ashape[2] (384 / 32 = 12 tiles) across columns
+    // Parallelize ashape[0] (B) across rows
+    uint32_t num_cores_x = ashape[2] / TILE_HEIGHT;
+    uint32_t num_cores_y = ashape[0];
+    TT_ASSERT(num_cores_x <= compute_with_storage_grid_size.x);
+    TT_ASSERT(num_cores_y <= compute_with_storage_grid_size.y);
+    CoreCoord core_range = {num_cores_x, num_cores_y};
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Grayskull Device Setup
+    ////////////////////////////////////////////////////////////////////////////
+    tt_metal::Buffer* out_buffer = output.buffer();
+    TT_ASSERT(out_buffer != nullptr, "Output buffer should be allocated on device!");
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Application Setup
+    ////////////////////////////////////////////////////////////////////////////
+    tt_metal::Program program = tt_metal::CreateProgram();
+
+    uint32_t start_core_x = 0;
+    uint32_t start_core_y = 0;
+    uint32_t num_cores_c = core_range.x;
+    uint32_t num_cores_r = core_range.y;
+
+    CoreRange all_cores(
+        {(std::size_t)start_core_x, (std::size_t)start_core_y},
+        {(std::size_t)start_core_x + num_cores_c - 1, (std::size_t)start_core_y + num_cores_r - 1});
+
+    std::vector<uint32_t> reader_compile_time_args = {
+        // READER COMPILE TIME ARGS
+        (std::uint32_t)in0_w_tiles,  // in0_w_tiles
+        (std::uint32_t)in0_c,        // in0_c
+        (std::uint32_t)in0_HtWt,     // in0_HtWt
+    };
+    tt::tt_metal::TensorAccessorArgs(in0_buffer).append_to(reader_compile_time_args);
+    std::vector<uint32_t> writer_compile_time_args = {
+        // WRITER COMPILE TIME ARGS
+        (std::uint32_t)in0_w_tiles,  // in0_w_tiles
+        (std::uint32_t)in0_c,        // in0_c
+    };
+    tt::tt_metal::TensorAccessorArgs(out_buffer).append_to(writer_compile_time_args);
+
+    auto reader_kernel_id = tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/experimental/transformer/concatenate_heads/device/kernels/dataflow/"
+        "reader_tm_tile_layout_concat_heads.cpp",
+        all_cores,
+        tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
+    auto writer_kernel_id = tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/experimental/transformer/concatenate_heads/device/kernels/dataflow/"
+        "writer_tm_tile_layout_concat_heads.cpp",
+        all_cores,
+        tt_metal::WriterDataMovementConfig(writer_compile_time_args));
+
+    // Create circular buffers
+    uint32_t src0_cb_index = 0;
+    uint32_t cb0_tiles = per_core_tiles * 2;  // double buffer
+    tt_metal::CircularBufferConfig cb_src0_config =
+        tt_metal::CircularBufferConfig(cb0_tiles * single_tile_size, {{src0_cb_index, cb_data_format}})
+            .set_page_size(src0_cb_index, single_tile_size);
+    tt_metal::CreateCircularBuffer(program, all_cores, cb_src0_config);
+
+    for (int core_idx_y = 0; core_idx_y < num_cores_r; core_idx_y++) {
+        for (int core_idx_x = 0; core_idx_x < num_cores_c; core_idx_x++) {
+            CoreCoord core = {(std::size_t)start_core_x + core_idx_x, (std::size_t)start_core_y + core_idx_y};
+            uint32_t in0_tensor_tile_id = (core_idx_x * in0_w_tiles) + (core_idx_y * in0_CHtWt);
+
+            std::vector<uint32_t> reader_runtime_args = {
+                (std::uint32_t)in0_buffer->address(),  // in0_tensor_addr
+                in0_tensor_tile_id,                    // in0_tensor_tile_id
+            };
+            std::vector<uint32_t> writer_runtime_args = {
+                (std::uint32_t)out_buffer->address(),                      // out_tensor_addr
+                (core_idx_x + core_idx_y * num_cores_c) * per_core_tiles,  // out_tensor_tile_id
+            };
+
+            tt_metal::SetRuntimeArgs(program, reader_kernel_id, core, reader_runtime_args);
+            tt_metal::SetRuntimeArgs(program, writer_kernel_id, core, writer_runtime_args);
+        }
+    }
+
+    return cached_program_t{
+        std::move(program),
+        {/* reader_kernel_id = */ reader_kernel_id,
+         /* writer_kernel_id = */ writer_kernel_id,
+         /* num_cores_r      = */ num_cores_r,
+         /* num_cores_c      = */ num_cores_c}};
+}
+
+void ConcatenateHeadsProgramFactory::override_runtime_arguments(
+    cached_program_t& cached_program,
+    const operation_attributes_t& operation_attributes,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& output) {
+    auto& shared_vars = cached_program.shared_variables;
+    auto& program = cached_program.program;
+
+    auto src_dram_buffer = tensor_args.input.buffer();
+    auto dst_dram_buffer = output.buffer();
+
+    uint32_t start_core_x = 0;
+    uint32_t start_core_y = 0;
+
+    for (int core_idx_y = 0; core_idx_y < shared_vars.num_cores_r; core_idx_y++) {
+        for (int core_idx_x = 0; core_idx_x < shared_vars.num_cores_c; core_idx_x++) {
+            CoreCoord core = {(std::size_t)start_core_x + core_idx_x, (std::size_t)start_core_y + core_idx_y};
+
+            {
+                auto& runtime_args = GetRuntimeArgs(program, shared_vars.reader_kernel_id, core);
+                runtime_args[0] = src_dram_buffer->address();
+            }
+
+            {
+                auto& runtime_args = GetRuntimeArgs(program, shared_vars.writer_kernel_id, core);
+                runtime_args[0] = dst_dram_buffer->address();
+            }
+        }
+    }
+}
+
+}  // namespace ttnn::operations::experimental::transformer::program

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/concatenate_heads/device/concatenate_heads_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/concatenate_heads/device/concatenate_heads_program_factory.hpp
@@ -2,152 +2,34 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt-metalium/host_api.hpp>
-#include <tt-metalium/constants.hpp>
-#include <tt-metalium/tensor_accessor_args.hpp>
-#include "ttnn/tensor/tensor.hpp"
+#pragma once
 
-namespace ttnn::operations::experimental::transformer::detail {
+#include "concatenate_heads_device_operation_types.hpp"
+#include "ttnn/device_operation.hpp"
 
-using namespace tt::constants;
-using namespace tt::tt_metal;
-using namespace tt;
+namespace ttnn::operations::experimental::transformer::program {
 
-inline tt::tt_metal::operation::ProgramWithCallbacks concatenate_heads_multi_core(
-    const Tensor& a, Tensor& output, CoreCoord compute_with_storage_grid_size) {
-    const auto& ashape = a.padded_shape();
+struct ConcatenateHeadsSharedVariables {
+    tt::tt_metal::KernelHandle reader_kernel_id = 0;
+    tt::tt_metal::KernelHandle writer_kernel_id = 0;
+    uint32_t num_cores_r = 0;
+    uint32_t num_cores_c = 0;
+};
 
-    tt::DataFormat cb_data_format = tt_metal::datatype_to_dataformat_converter(a.dtype());
+struct ConcatenateHeadsProgramFactory {
+    using shared_variables_t = ConcatenateHeadsSharedVariables;
+    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
 
-    uint32_t single_tile_size = tt::tile_size(cb_data_format);
-    tt_metal::Buffer* in0_buffer = a.buffer();
-    TT_ASSERT(in0_buffer->size() % single_tile_size == 0);
+    static cached_program_t create(
+        const operation_attributes_t& operation_attributes,
+        const tensor_args_t& tensor_args,
+        tensor_return_value_t& tensor_return_value);
 
-    ////////////////////////////////////////////////////////////////////////////
-    //                      TM Parameters Setup
-    ////////////////////////////////////////////////////////////////////////////
-    // Output shape is: [B, 1, 384, 1024]
-    uint32_t per_core_tiles = (ashape[1] * ashape[3]) / TILE_WIDTH;
-    uint32_t in0_h_tiles = ashape[2] / TILE_HEIGHT;
+    static void override_runtime_arguments(
+        cached_program_t& cached_program,
+        const operation_attributes_t& operation_attributes,
+        const tensor_args_t& tensor_args,
+        tensor_return_value_t& tensor_return_value);
+};
 
-    // These parameters are identical to out_* in multi_core_create_qkv_heads
-    uint32_t in0_w = 64;
-    uint32_t in0_w_tiles = in0_w / TILE_WIDTH;
-    uint32_t in0_c = per_core_tiles / in0_w_tiles;
-    uint32_t in0_HtWt = in0_h_tiles * in0_w_tiles;
-    uint32_t in0_CHtWt = in0_c * in0_HtWt;
-
-    // Parallelize ashape[2] (384 / 32 = 12 tiles) across columns
-    // Parallelize ashape[0] (B) across rows
-    uint32_t num_cores_x = ashape[2] / TILE_HEIGHT;
-    uint32_t num_cores_y = ashape[0];
-    TT_ASSERT(num_cores_x <= compute_with_storage_grid_size.x);
-    TT_ASSERT(num_cores_y <= compute_with_storage_grid_size.y);
-    CoreCoord core_range = {num_cores_x, num_cores_y};
-
-    ////////////////////////////////////////////////////////////////////////////
-    //                      Grayskull Device Setup
-    ////////////////////////////////////////////////////////////////////////////
-    tt_metal::Buffer* out_buffer = output.buffer();
-    TT_ASSERT(out_buffer != nullptr, "Output buffer should be allocated on device!");
-
-    ////////////////////////////////////////////////////////////////////////////
-    //                      Application Setup
-    ////////////////////////////////////////////////////////////////////////////
-    tt_metal::Program program = tt_metal::CreateProgram();
-
-    uint32_t start_core_x = 0;
-    uint32_t start_core_y = 0;
-    uint32_t num_cores_c = core_range.x;
-    uint32_t num_cores_r = core_range.y;
-
-    CoreRange all_cores(
-        {(std::size_t)start_core_x, (std::size_t)start_core_y},
-        {(std::size_t)start_core_x + num_cores_c - 1, (std::size_t)start_core_y + num_cores_r - 1});
-
-    std::vector<uint32_t> reader_compile_time_args = {
-        // READER COMPILE TIME ARGS
-        (std::uint32_t)in0_w_tiles,  // in0_w_tiles
-        (std::uint32_t)in0_c,        // in0_c
-        (std::uint32_t)in0_HtWt,     // in0_HtWt
-    };
-    tt::tt_metal::TensorAccessorArgs(in0_buffer).append_to(reader_compile_time_args);
-    std::vector<uint32_t> writer_compile_time_args = {
-        // WRITER COMPILE TIME ARGS
-        (std::uint32_t)in0_w_tiles,  // in0_w_tiles
-        (std::uint32_t)in0_c,        // in0_c
-    };
-    tt::tt_metal::TensorAccessorArgs(out_buffer).append_to(writer_compile_time_args);
-
-    auto reader_kernel_id = tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/experimental/transformer/concatenate_heads/device/kernels/dataflow/"
-        "reader_tm_tile_layout_concat_heads.cpp",
-        all_cores,
-        tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
-    auto writer_kernel_id = tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/experimental/transformer/concatenate_heads/device/kernels/dataflow/"
-        "writer_tm_tile_layout_concat_heads.cpp",
-        all_cores,
-        tt_metal::WriterDataMovementConfig(writer_compile_time_args));
-
-    // Create circular buffers
-    uint32_t src0_cb_index = 0;
-    uint32_t cb0_tiles = per_core_tiles * 2;  // double buffer
-    tt_metal::CircularBufferConfig cb_src0_config =
-        tt_metal::CircularBufferConfig(cb0_tiles * single_tile_size, {{src0_cb_index, cb_data_format}})
-            .set_page_size(src0_cb_index, single_tile_size);
-    tt_metal::CreateCircularBuffer(program, all_cores, cb_src0_config);
-
-    for (int core_idx_y = 0; core_idx_y < num_cores_r; core_idx_y++) {
-        for (int core_idx_x = 0; core_idx_x < num_cores_c; core_idx_x++) {
-            CoreCoord core = {(std::size_t)start_core_x + core_idx_x, (std::size_t)start_core_y + core_idx_y};
-            uint32_t in0_tensor_tile_id = (core_idx_x * in0_w_tiles) + (core_idx_y * in0_CHtWt);
-
-            std::vector<uint32_t> reader_runtime_args = {
-                (std::uint32_t)in0_buffer->address(),  // in0_tensor_addr
-                in0_tensor_tile_id,                    // in0_tensor_tile_id
-            };
-            std::vector<uint32_t> writer_runtime_args = {
-                (std::uint32_t)out_buffer->address(),                      // out_tensor_addr
-                (core_idx_x + core_idx_y * num_cores_c) * per_core_tiles,  // out_tensor_tile_id
-            };
-
-            tt_metal::SetRuntimeArgs(program, reader_kernel_id, core, reader_runtime_args);
-            tt_metal::SetRuntimeArgs(program, writer_kernel_id, core, writer_runtime_args);
-        }
-    }
-
-    auto override_runtime_args_callback =
-        [reader_kernel_id, writer_kernel_id, num_cores_r, num_cores_c, start_core_x, start_core_y](
-            const void* operation,
-            Program& program,
-            const std::vector<Tensor>& input_tensors,
-            const std::vector<std::optional<const Tensor>>& optional_tensors,
-            const std::vector<Tensor>& output_tensors) {
-            auto src_dram_buffer = input_tensors.at(0).buffer();
-
-            auto dst_dram_buffer = output_tensors.at(0).buffer();
-
-            for (int core_idx_y = 0; core_idx_y < num_cores_r; core_idx_y++) {
-                for (int core_idx_x = 0; core_idx_x < num_cores_c; core_idx_x++) {
-                    CoreCoord core = {(std::size_t)start_core_x + core_idx_x, (std::size_t)start_core_y + core_idx_y};
-
-                    {
-                        auto& runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
-                        runtime_args[0] = src_dram_buffer->address();
-                    }
-
-                    {
-                        auto& runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
-                        runtime_args[0] = dst_dram_buffer->address();
-                    }
-                }
-            }
-        };
-
-    return {std::move(program), override_runtime_args_callback};
-}
-
-}  // namespace ttnn::operations::experimental::transformer::detail
+}  // namespace ttnn::operations::experimental::transformer::program


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/32704)

### Problem description
The concatenate_heads operation used the old vector-based device operation structure, which causes unnecessary heap allocations even for operations with a single input/output tensor.

### What's changed
Migrated the concatenate_heads operation to the new TMP (Template Metaprogramming) device operation pattern following the migration guide. This eliminates unnecessary heap allocations while maintaining full backward compatibility.

**Changes made:**
- Created `concatenate_heads_device_operation_types.hpp` with `operation_attributes_t` and `tensor_args_t` structures
- Updated device operation header to TMP structure with static methods
- Implemented program factory with `create()` and `override_runtime_arguments()` methods
- Registered operation in `ttnn::prim` namespace
- Updated public API to use prim instead of `device_operation::run`
- Removed old inline program factory implementation

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes ([link to run](https://github.com/tenstorrent/tt-metal/actions/runs/19550391495))
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [x] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models). ([link to run](https://github.com/tenstorrent/tt-metal/actions/runs/19550403625))
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [x] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main) ([link to run](https://github.com/tenstorrent/tt-metal/actions/runs/19550398392))
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes