### PR TITLE
Removing Fabric 2d Dynamic References in codebase

### DIFF
--- a/tests/nightly/tg/ccl/test_minimal_all_gather_async.py
+++ b/tests/nightly/tg/ccl/test_minimal_all_gather_async.py
@@ -376,7 +376,7 @@ def test_all_gather_async_quad_host_mesh(
     [
         (
             {
-                "fabric_config": ttnn.FabricConfig.FABRIC_2D_DYNAMIC,
+                "fabric_config": ttnn.FabricConfig.FABRIC_2D,
                 "reliability_mode": ttnn.FabricReliabilityMode.RELAXED_INIT,
                 "trace_region_size": 190112,
             },
@@ -392,7 +392,7 @@ def test_all_gather_async_quad_host_mesh(
         ),
     ],
     indirect=["device_params"],
-    ids=["fabric_2d_dynamic_linear", "fabric_linear"],
+    ids=["fabric_2d_linear", "fabric_linear"],
 )
 @pytest.mark.parametrize("mesh_device", [(4, 32)], indirect=True)
 def test_all_gather_4x32_sanity(

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_common.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_common.cpp
@@ -1733,19 +1733,6 @@ std::vector<Shape4D<uint32_t>> GenericWrappedTensorSlicerV2::create_worker_slice
     return worker_slice_shapes;
 }
 
-void validate_fabric_2d_dynamic_config(Topology topology) {
-    TT_FATAL(topology != Topology::Ring, "Fabric 2D dynamic is not supported for ring topology");
-    auto physical_mesh_shapes = tt::tt_fabric::get_physical_mesh_shapes();
-    TT_FATAL(
-        physical_mesh_shapes.size() == 1,
-        "Fabric 2D dynamic CCLs expected a single Physical Mesh to be instantiated, but got {} meshes",
-        physical_mesh_shapes.size());
-    const auto& physical_mesh_shape = physical_mesh_shapes.begin()->second;
-    TT_FATAL(
-        physical_mesh_shape.dims() == 2,
-        "Fabric 2D dynamic CCLs are not supported for mesh shape with more than 2 dimensions");
-}
-
 std::tuple<size_t, size_t, bool> get_forward_backward_configuration(
     size_t ring_size, size_t ring_index, Topology topology) {
     // Used for experimentation for optimal perf
@@ -1787,7 +1774,6 @@ std::tuple<std::array<uint32_t, 2>, std::array<uint32_t, 2>> get_forward_backwar
 
     auto fabric_config = tt::tt_fabric::GetFabricConfig();
     if (fabric_config == tt::tt_fabric::FabricConfig::FABRIC_2D) {
-        validate_fabric_2d_dynamic_config(topology);
         if (forward_device_coord) {
             auto forward_device_fabric_node_id = mesh_device->get_fabric_node_id(forward_device_coord.value());
             forward_args[0] = *forward_device_fabric_node_id.mesh_id;
@@ -1849,7 +1835,6 @@ std::tuple<std::array<uint32_t, 6>, std::array<uint32_t, 6>> get_forward_backwar
     auto fabric_config = tt::tt_fabric::GetFabricConfig();
 
     if (fabric_config == tt::tt_fabric::FabricConfig::FABRIC_2D) {
-        validate_fabric_2d_dynamic_config(topology);
         auto src_fabric_node_id = mesh_device->get_fabric_node_id(src_device_coord);
         auto set_mcast_args = [&src_fabric_node_id](
                                   std::array<uint32_t, 6>& args,


### PR DESCRIPTION
### Ticket
Fabric 2D Dynamic was removed from the codebase by the fabric team but not all instances of it were updated to fabric 2D causing pipelines to break.

https://github.com/tenstorrent/tt-metal/actions/runs/19545101131

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes