### PR TITLE
[Llama-3.3-70B galaxy] Apply minimal_matmul to attn

### DIFF
--- a/models/demos/llama3_70b_galaxy/tt/llama_attention.py
+++ b/models/demos/llama3_70b_galaxy/tt/llama_attention.py
@@ -646,26 +646,29 @@ class TtLlamaAttention(LightweightModule):
             attn_output_11SH = ttnn.reshape(attn_output_11SH, [1, 1, seq_len, -1])
 
         # reshaping long sequence to matmul fit on device
-        if seq_len > 1024:
-            attn_output_11SH = ttnn.reshape(attn_output_11SH, [1, seq_len // 1024, 1024, -1])
+        if seq_len > 2048:
+            attn_output_11SH = ttnn.reshape(attn_output_11SH, [1, seq_len // 2048, 2048, -1])
 
-        output_11SH = ttnn.experimental.minimal_matmul(
-            input_tensor=attn_output_11SH,
-            weight_tensor=self.wo_interleaved,
-            config=self.model_config["WO_PREFILL_MINIMAL_PROGCFG"](seq_len),
-            compute_kernel_config=self.compute_kernel_config_hifi2_fp16,
-            memory_config=ttnn.DRAM_MEMORY_CONFIG,
-        )
-        # output_11SH = ttnn.linear(
-        #     attn_output_11SH,
-        #     self.wo_interleaved,
-        #     compute_kernel_config=self.compute_kernel_config_hifi2_fp16,
-        #     dtype=ttnn.bfloat8_b,
-        #     memory_config=ttnn.DRAM_MEMORY_CONFIG,
-        #     program_config=self.model_config["WO_PREFILL_PROGCFG"](seq_len),
-        # )
+        ## For shorter sequence lengths use the original matmul since it performs better than the minimal matmul
+        if seq_len < 4096:
+            output_11SH = ttnn.linear(
+                attn_output_11SH,
+                self.wo_interleaved,
+                compute_kernel_config=self.compute_kernel_config_hifi2_fp16,
+                dtype=ttnn.bfloat8_b,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                program_config=self.model_config["WO_PREFILL_PROGCFG"](seq_len),
+            )
+        else:
+            output_11SH = ttnn.experimental.minimal_matmul(
+                input_tensor=attn_output_11SH,
+                weight_tensor=self.wo_interleaved,
+                config=self.model_config["WO_PREFILL_MINIMAL_PROGCFG"](seq_len),
+                compute_kernel_config=self.compute_kernel_config_hifi2_fp16,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            )
 
-        if seq_len > 1024:
+        if seq_len > 2048:
             output_11SH = ttnn.reshape(output_11SH, [1, 1, seq_len, -1])
         ttnn.deallocate(attn_output_11SH)
 

--- a/models/demos/llama3_70b_galaxy/tt/llama_attention.py
+++ b/models/demos/llama3_70b_galaxy/tt/llama_attention.py
@@ -646,8 +646,8 @@ class TtLlamaAttention(LightweightModule):
             attn_output_11SH = ttnn.reshape(attn_output_11SH, [1, 1, seq_len, -1])
 
         # reshaping long sequence to matmul fit on device
-        if seq_len > 2048:
-            attn_output_11SH = ttnn.reshape(attn_output_11SH, [1, seq_len // 2048, 2048, -1])
+        if seq_len > 1024:
+            attn_output_11SH = ttnn.reshape(attn_output_11SH, [1, seq_len // 1024, 1024, -1])
 
         ## For shorter sequence lengths use the original matmul since it performs better than the minimal matmul
         if seq_len < 4096:
@@ -668,7 +668,7 @@ class TtLlamaAttention(LightweightModule):
                 memory_config=ttnn.DRAM_MEMORY_CONFIG,
             )
 
-        if seq_len > 2048:
+        if seq_len > 1024:
             output_11SH = ttnn.reshape(output_11SH, [1, 1, seq_len, -1])
         ttnn.deallocate(attn_output_11SH)
 

--- a/models/demos/llama3_70b_galaxy/tt/llama_ccl.py
+++ b/models/demos/llama3_70b_galaxy/tt/llama_ccl.py
@@ -102,7 +102,7 @@ class TT_CCL:
             self.rs_create_heads_buffers = self.get_decode_rs_create_heads_buffers()
         if mode == "prefill":
             # For some prefill seqlens we always allocate CCL buffers. Otherwise they will require barrier syncing
-            self.support_seqlens = [128]  # [4096, 2048, 1024, 128]
+            self.support_seqlens = [4096, 2048, 1024, 128]
             if allocate_prefill_buffers:
                 self.persistent_buffers = (
                     self.get_ring_prefill_reduce_scatter_buffers()

--- a/models/demos/llama3_70b_galaxy/tt/llama_ccl.py
+++ b/models/demos/llama3_70b_galaxy/tt/llama_ccl.py
@@ -102,7 +102,7 @@ class TT_CCL:
             self.rs_create_heads_buffers = self.get_decode_rs_create_heads_buffers()
         if mode == "prefill":
             # For some prefill seqlens we always allocate CCL buffers. Otherwise they will require barrier syncing
-            self.support_seqlens = [4096, 2048, 1024, 128]
+            self.support_seqlens = [128]  # [4096, 2048, 1024, 128]
             if allocate_prefill_buffers:
                 self.persistent_buffers = (
                     self.get_ring_prefill_reduce_scatter_buffers()

--- a/models/demos/llama3_70b_galaxy/tt/lm_head.py
+++ b/models/demos/llama3_70b_galaxy/tt/lm_head.py
@@ -205,14 +205,23 @@ class LMHead(LightweightModule):
                 outputs.append(output)
         else:
             for weight, pc in zip(self.output_weights_prefill, self.program_configs):
-                output = ttnn.linear(
-                    x,
-                    weight,
+                # x = ttnn.typecast(x, ttnn.bfloat8_b)
+                output = ttnn.experimental.minimal_matmul(
+                    input_tensor=x,
+                    weight_tensor=weight,
+                    config=self.prefill_pc,
+                    dtype=ttnn.bfloat8_b,
                     compute_kernel_config=self.compute_kernel_config,
                     memory_config=ttnn.DRAM_MEMORY_CONFIG,
-                    program_config=self.prefill_pc,
-                    dtype=ttnn.bfloat8_b,
                 )
+                # output = ttnn.linear(
+                #     x,
+                #     weight,
+                #     compute_kernel_config=self.compute_kernel_config,
+                #     memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                #     program_config=self.prefill_pc,
+                #     dtype=ttnn.bfloat8_b,
+                # )
                 x.deallocate(True)
                 outputs.append(output)
 

--- a/models/demos/llama3_70b_galaxy/tt/lm_head.py
+++ b/models/demos/llama3_70b_galaxy/tt/lm_head.py
@@ -205,22 +205,22 @@ class LMHead(LightweightModule):
                 outputs.append(output)
         else:
             for weight, pc in zip(self.output_weights_prefill, self.program_configs):
-                # x = ttnn.typecast(x, ttnn.bfloat8_b)
-                output = ttnn.experimental.minimal_matmul(
-                    input_tensor=x,
-                    weight_tensor=weight,
-                    config=self.prefill_pc,
-                    dtype=ttnn.bfloat8_b,
+                output = ttnn.linear(
+                    x,
+                    weight,
                     compute_kernel_config=self.compute_kernel_config,
                     memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                    program_config=self.prefill_pc,
+                    dtype=ttnn.bfloat8_b,
                 )
-                # output = ttnn.linear(
-                #     x,
-                #     weight,
+                # Minimal matmul is not giving any performance improvement over linear
+                # output = ttnn.experimental.minimal_matmul(
+                #     input_tensor=x,
+                #     weight_tensor=weight,
+                #     config=self.prefill_pc,
+                #     dtype=ttnn.bfloat8_b,
                 #     compute_kernel_config=self.compute_kernel_config,
                 #     memory_config=ttnn.DRAM_MEMORY_CONFIG,
-                #     program_config=self.prefill_pc,
-                #     dtype=ttnn.bfloat8_b,
                 # )
                 x.deallocate(True)
                 outputs.append(output)

--- a/models/demos/llama3_70b_galaxy/tt/model_config.py
+++ b/models/demos/llama3_70b_galaxy/tt/model_config.py
@@ -1149,7 +1149,7 @@ class TtModelArgs:
                         subblock_w=2,
                         compute_with_storage_grid_size=ttnn.CoreCoord(7, 8),
                     )
-                else:  # seqlen <= 2048
+                else:  # seqlen > 1024
                     return ttnn.MinimalMatmulConfig(
                         M_block_size=8,
                         K_block_size=8,
@@ -1568,23 +1568,23 @@ class TtModelArgs:
                 prefetch=False,
             )
 
-            # self.model_config["LM_HEAD_PREFILL_PROGCFG"] = self.matmul_1d_config_from_tensor_shapes(
-            #     in0_shape=(1, 1, 32, 2048),
-            #     in1_shape=(1, 1, 2048, 16384),
-            #     grid=ttnn.CoreGrid(x=7, y=7),  # (7,10) leads to hangs
-            #     act=None,
-            #     is_fp32_accumulate=False,
-            #     # overwrite_subblock_w=1,
-            #     # overwrite_subblock_h=1,
-            # )
-            self.model_config["LM_HEAD_PREFILL_PROGCFG"] = ttnn.MinimalMatmulConfig(
-                M_block_size=8,
-                K_block_size=8,
-                N_block_size=8,
-                subblock_h=1,
-                subblock_w=1,
-                compute_with_storage_grid_size=ttnn.CoreCoord(7, 7),
+            self.model_config["LM_HEAD_PREFILL_PROGCFG"] = self.matmul_1d_config_from_tensor_shapes(
+                in0_shape=(1, 1, 32, 2048),
+                in1_shape=(1, 1, 2048, 16384),
+                grid=ttnn.CoreGrid(x=7, y=7),  # (7,10) leads to hangs
+                act=None,
+                is_fp32_accumulate=False,
+                # overwrite_subblock_w=1,
+                # overwrite_subblock_h=1,
             )
+            # self.model_config["LM_HEAD_PREFILL_PROGCFG"] = ttnn.MinimalMatmulConfig(
+            #     M_block_size=8,
+            #     K_block_size=8,
+            #     N_block_size=8,
+            #     subblock_h=1,
+            #     subblock_w=1,
+            #     compute_with_storage_grid_size=ttnn.CoreCoord(7, 10),
+            # )
 
             attn_input_grid = self.dram_shard_core_grid_for_k(self.dim)
             attn_input_sub_core_grid = ttnn.num_cores_to_corerangeset_in_subcoregrids(

--- a/models/demos/llama3_70b_galaxy/tt/model_config.py
+++ b/models/demos/llama3_70b_galaxy/tt/model_config.py
@@ -1069,7 +1069,7 @@ class TtModelArgs:
                         subblock_w=8,
                         compute_with_storage_grid_size=ttnn.CoreCoord(7, 7),
                     )
-                else:  # seq_len <= 1024:
+                else:
                     return ttnn.MinimalMatmulConfig(
                         M_block_size=8,
                         K_block_size=8,

--- a/models/demos/llama3_70b_galaxy/tt/model_config.py
+++ b/models/demos/llama3_70b_galaxy/tt/model_config.py
@@ -1059,6 +1059,28 @@ class TtModelArgs:
                 )
             )
 
+            def prefill_wo_minimal_matmul_config(seq_len):
+                if seq_len <= 128:
+                    return ttnn.MinimalMatmulConfig(
+                        M_block_size=8,
+                        K_block_size=8,
+                        N_block_size=8,
+                        subblock_h=1,
+                        subblock_w=8,
+                        compute_with_storage_grid_size=ttnn.CoreCoord(7, 7),
+                    )
+                else:  # seq_len <= 1024:
+                    return ttnn.MinimalMatmulConfig(
+                        M_block_size=8,
+                        K_block_size=8,
+                        N_block_size=8,
+                        subblock_h=4,
+                        subblock_w=2,
+                        compute_with_storage_grid_size=ttnn.CoreCoord(7, 8),
+                    )
+
+            self.model_config["WO_PREFILL_MINIMAL_PROGCFG"] = prefill_wo_minimal_matmul_config
+
             # Calculate largest number of lm_head_num_rows such that self.dim % (lm_head_num_rows * 8) == 0
             if self.num_devices == 32:
                 lm_head_num_rows = 4
@@ -1106,6 +1128,38 @@ class TtModelArgs:
                     )
                 )
             )
+
+            # Configs determined by manual sweep the optimal configs for the different seqlen ranges
+            def prefill_xqkv_minimal_matmul_config(seq_len):
+                if seq_len <= 128:
+                    return ttnn.MinimalMatmulConfig(
+                        M_block_size=8,
+                        K_block_size=8,
+                        N_block_size=8,
+                        subblock_h=4,
+                        subblock_w=2,
+                        compute_with_storage_grid_size=ttnn.CoreCoord(7, 7),
+                    )
+                elif seq_len <= 1024:
+                    return ttnn.MinimalMatmulConfig(
+                        M_block_size=8,
+                        K_block_size=8,
+                        N_block_size=8,
+                        subblock_h=4,
+                        subblock_w=2,
+                        compute_with_storage_grid_size=ttnn.CoreCoord(7, 8),
+                    )
+                else:  # seqlen <= 2048
+                    return ttnn.MinimalMatmulConfig(
+                        M_block_size=8,
+                        K_block_size=8,
+                        N_block_size=8,
+                        subblock_h=1,
+                        subblock_w=8,
+                        compute_with_storage_grid_size=ttnn.CoreCoord(7, 8),
+                    )
+
+            self.model_config["XQKV_PREFILL_MINIMAL_PROGCFG"] = prefill_xqkv_minimal_matmul_config
 
             assert self.n_kv_heads % self.cluster_shape[1] == 0, "n_kv_heads must be divisible by num_devices"
             self.model_config["KV_PREFILL_MEM_CFG"] = lambda seq_len: ttnn.create_sharded_memory_config(
@@ -1514,14 +1568,22 @@ class TtModelArgs:
                 prefetch=False,
             )
 
-            self.model_config["LM_HEAD_PREFILL_PROGCFG"] = self.matmul_1d_config_from_tensor_shapes(
-                in0_shape=(1, 1, 32, 2048),
-                in1_shape=(1, 1, 2048, 16384),
-                grid=ttnn.CoreGrid(x=7, y=7),  # (7,10) leads to hangs
-                act=None,
-                is_fp32_accumulate=False,
-                # overwrite_subblock_w=1,
-                # overwrite_subblock_h=1,
+            # self.model_config["LM_HEAD_PREFILL_PROGCFG"] = self.matmul_1d_config_from_tensor_shapes(
+            #     in0_shape=(1, 1, 32, 2048),
+            #     in1_shape=(1, 1, 2048, 16384),
+            #     grid=ttnn.CoreGrid(x=7, y=7),  # (7,10) leads to hangs
+            #     act=None,
+            #     is_fp32_accumulate=False,
+            #     # overwrite_subblock_w=1,
+            #     # overwrite_subblock_h=1,
+            # )
+            self.model_config["LM_HEAD_PREFILL_PROGCFG"] = ttnn.MinimalMatmulConfig(
+                M_block_size=8,
+                K_block_size=8,
+                N_block_size=8,
+                subblock_h=1,
+                subblock_w=1,
+                compute_with_storage_grid_size=ttnn.CoreCoord(7, 7),
             )
 
             attn_input_grid = self.dram_shard_core_grid_for_k(self.dim)

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/minimal_matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/minimal_matmul_device_operation.cpp
@@ -155,7 +155,7 @@ std::vector<TensorSpec> MinimalMatmulOp::compute_output_specs(const std::vector<
     output_shape[-1] = N;
 
     const auto& memory_config = this->output_mem_config.value_or(in0_input_tensor.memory_config());
-    auto dtype = in0_input_tensor.dtype();
+    auto dtype = this->output_dtype.value_or(in0_input_tensor.dtype());
 
     return {TensorSpec(output_shape, TensorLayout(dtype, PageConfig(Layout::TILE), memory_config))};
 }

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/minimal_matmul_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/minimal_matmul_device_operation.hpp
@@ -57,6 +57,7 @@ struct MinimalMatmulOp {
     std::optional<const MinimalMatmulConfig> config;
     std::optional<unary::UnaryWithParam> fused_activation;
     std::optional<tt::tt_metal::MemoryConfig> output_mem_config;
+    std::optional<tt::tt_metal::DataType> output_dtype;
     DeviceComputeKernelConfig compute_kernel_config;
 
     void validate(

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/minimal_matmul.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/minimal_matmul.cpp
@@ -20,6 +20,7 @@ ttnn::Tensor ExecuteMinimalMatmul::invoke(
     std::optional<unary::UnaryWithParam> fused_activation,
     const std::optional<const MinimalMatmulConfig>& config,
     const std::optional<MemoryConfig>& memory_config,
+    std::optional<const DataType> dtype,
     std::optional<DeviceComputeKernelConfig> compute_kernel_config) {
     auto kernel_config_val = init_device_compute_kernel_config(
         input_tensor.device()->arch(),
@@ -34,6 +35,7 @@ ttnn::Tensor ExecuteMinimalMatmul::invoke(
                    .config = config,
                    .fused_activation = std::move(fused_activation),
                    .output_mem_config = memory_config,
+                   .output_dtype = dtype,
                    .compute_kernel_config = kernel_config_val},
                {input_tensor, weight_tensor},
                {bias_tensor},

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/minimal_matmul.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/minimal_matmul.hpp
@@ -24,6 +24,7 @@ struct ExecuteMinimalMatmul {
         std::optional<unary::UnaryWithParam> fused_activation,
         const std::optional<const MinimalMatmulConfig>& config,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
+        std::optional<const DataType> dtype = std::nullopt,
         std::optional<DeviceComputeKernelConfig> compute_kernel_config = std::nullopt);
 };
 

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/minimal_matmul_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/minimal_matmul_pybind.cpp
@@ -20,7 +20,7 @@ void py_bind_minimal_matmul(py::module& module) {
         module,
         ttnn::experimental::minimal_matmul,
         R"doc(
-        minimal_matmul(input_tensor, weight_tensor, bias_tensor=None, *, fused_activation=None, config=None, memory_config=None, compute_kernel_config=None)
+        minimal_matmul(input_tensor, weight_tensor, bias_tensor=None, *, fused_activation=None, config=None, memory_config=None, dtype=None, compute_kernel_config=None)
 
         Experimental, high-performance matrix multiply (A @ B [+ bias]) with optional fused activation.
         This op expects TILE layout tensors on device and operates in tile units internally. It is designed
@@ -81,6 +81,10 @@ void py_bind_minimal_matmul(py::module& module) {
             Memory configuration for the output tensor. If not provided, the output inherits the memory configuration
             of `input_tensor`. The output is produced in TILE layout.
 
+        dtype : Optional[ttnn.DataType], default: None
+            Data type of the output tensor. If not provided, the output inherits the data type
+            of `input_tensor`.
+
         compute_kernel_config : Optional[ttnn.operations.core.compute_kernel.DeviceComputeKernelConfig], default: None
             Compute kernel configuration. If omitted, defaults are selected via `init_device_compute_kernel_config`
             (e.g., MathFidelity::HiFi2, fp32 accumulation enabled, packer accumulation enabled).
@@ -88,7 +92,8 @@ void py_bind_minimal_matmul(py::module& module) {
         Returns
         -------
         ttnn.Tensor
-            Output tensor with shape [..., M, N], TILE layout, and the same dtype as `input_tensor`.
+            Output tensor with shape [..., M, N], TILE layout, and dtype specified by `dtype` parameter
+            (or same dtype as `input_tensor` if `dtype` is not provided).
 
         Shape Semantics
         ----------------
@@ -105,7 +110,8 @@ void py_bind_minimal_matmul(py::module& module) {
         - All tensors must be on the same device and allocated in device buffers.
         - All tensors must be in TILE layout (sharded tensors must be tile-aligned at shard boundaries).
         - Supported dtypes for inputs: BF16, BF8_B, BF4_B, FLOAT32. Bias (if present)
-          must be one of the supported dtypes. The dtype of the output is the same as the dtype of the inputs.
+          must be one of the supported dtypes. The dtype of the output can be specified via the `dtype` parameter,
+          otherwise it defaults to the dtype of `input_tensor`.
         - No implicit transpose flags are supported; provide `weight_tensor` with logical shape [..., K, N].
         - Weight and bias must have 1 in all leading dimensions (dims < -2). Activation may have arbitrary
           upper dimensions; these are broadcast across rows (internally folded into M for execution).
@@ -149,6 +155,7 @@ void py_bind_minimal_matmul(py::module& module) {
             py::arg("fused_activation") = std::nullopt,
             py::arg("config") = std::nullopt,
             py::arg("memory_config") = std::nullopt,
+            py::arg("dtype") = std::nullopt,
             py::arg("compute_kernel_config") = std::nullopt});
 
     auto py_minimal_matmul_config = py::class_<MinimalMatmulConfig>(


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/32522

### Problem description
Small perf increment by moving to `minimal_matmul` implementation

### What's changed
- Add `minimal_matmul` to `dense_out` in Llama-3.3-70B attention
  - Also tested on LM-Head but saw no benefits
  - on QKV matmuls the configs was leading to bad tokens
- Add optional argument to `miminal_matmul` OP to support output dtype. 

### TODO
- Quick investigate why QKV MMs were generating bad tokens

### Checklist
- [x] [Galaxy CI](https://github.com/tenstorrent/tt-metal/actions/runs/19635342736)
- [x] [Galaxy APC Fast](https://github.com/tenstorrent/tt-metal/actions/runs/19635351781)
- [x] [APC](https://github.com/tenstorrent/tt-metal/actions/runs/19579173856)
- [x] [L2 Nightly, experimental](https://github.com/tenstorrent/tt-metal/actions/runs/19635842753)