### PR TITLE
#32279 Support keepdim=true for ttnn.prod when dim=nullopt

### DIFF
--- a/tests/ttnn/unit_tests/operations/reduce/test_reduction.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_reduction.py
@@ -62,14 +62,26 @@ def test_var(device, batch_size, h, w, dim, keepdim, correction):
 @pytest.mark.parametrize("c", [11])
 @pytest.mark.parametrize("h", [67])
 @pytest.mark.parametrize("w", [77])
-@pytest.mark.parametrize("dim", [0, 1, 2, 3])
+@pytest.mark.parametrize("dim", [None, 0, 1, 2, 3])
 @pytest.mark.parametrize("keepdim", [True, False])
-@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
+# prod supports only bfloat16, per ttnn/cpp/ttnn/operations/reduction/prod/prod_pybind.hpp
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16])
 def test_prod(device, batch_size, c, h, w, dim, keepdim, dtype):
     torch.manual_seed(0)
 
     torch_input_tensor = torch.randn((batch_size, c, h, w), dtype=torch.bfloat16)
-    torch_output_tensor = torch.prod(torch_input_tensor, dim=dim, keepdim=keepdim)
+    # tensor.size, which is called by torch.prod) doesn't accept dim=None,
+    # so we need to handle it separately.
+    # See https://github.com/pytorch/pytorch/issues/127882
+    if dim is None:
+        torch_output_tensor = torch.prod(torch_input_tensor)
+        if keepdim:
+            # torch.prod does not support keepdim=True for dim=None,
+            # so we need to reshape to match the input tensor.
+            new_shape = [1] * torch_input_tensor.dim()
+            torch_output_tensor = torch_output_tensor.reshape(new_shape)
+    else:
+        torch_output_tensor = torch.prod(torch_input_tensor, dim=dim, keepdim=keepdim)
 
     input_tensor = ttnn.from_torch(
         torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.L1_MEMORY_CONFIG, dtype=dtype
@@ -81,7 +93,7 @@ def test_prod(device, batch_size, c, h, w, dim, keepdim, dtype):
     output_tensor = ttnn.to_torch(output_tensor, dtype=torch.bfloat16)
     assert len(output_tensor.shape) == len(torch_output_tensor.shape)
     assert output_tensor.shape == torch_output_tensor.shape
-    # assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.99)
+    assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.99)
 
 
 @pytest.mark.parametrize("dim_1", [1])

--- a/tests/ttnn/unit_tests/operations/reduce/test_reduction.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_reduction.py
@@ -70,7 +70,7 @@ def test_prod(device, batch_size, c, h, w, dim, keepdim, dtype):
     torch.manual_seed(0)
 
     torch_input_tensor = torch.randn((batch_size, c, h, w), dtype=torch.bfloat16)
-    # tensor.size, which is called by torch.prod) doesn't accept dim=None,
+    # tensor.size, which is called by torch.prod, doesn't accept dim=None,
     # so we need to handle it separately.
     # See https://github.com/pytorch/pytorch/issues/127882
     if dim is None:

--- a/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.cpp
@@ -69,6 +69,8 @@ ttnn::SmallVector<int> generate_reduce_dim(
         for (int i = 0; i < rank; i++) {
             dim[i] = i;
         }
+        // It's already sorted and all are non-negative.
+        return dim;
     }
 
     for (int i = 0; i < dim.size(); i++) {

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_op.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_op.cpp
@@ -40,6 +40,12 @@ void Prod::validate(const std::vector<Tensor>& inputs) const {
             output_shape[i]);
         // TT_FATAL(input_shape_wo_padding[i] == output_shape_wo_padding[i], "Error");
     }
+
+    // prod supports only bfloat16, per ttnn/cpp/ttnn/operations/reduction/prod/prod_pybind.hpp
+    TT_FATAL(
+        input.dtype() == tt::tt_metal::DataType::BFLOAT16,
+        "Error - unsupported data type for prod, expected BFLOAT16 but got {}.",
+        input.dtype());
 }
 
 std::vector<Tensor> Prod::create_output_tensors(const std::vector<Tensor>& inputs) const {

--- a/ttnn/cpp/ttnn/operations/reduction/prod/prod.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/prod.cpp
@@ -82,8 +82,13 @@ Tensor ProdOperation::invoke(
 
     // If no dim is provided, compute the prod across all dimensions
     if (!dim.has_value()) {
-        TT_FATAL(!keepdim, "Not possible to keepdim with all dimensions enabled, as this returns a scalar");
-        return prod_all(input_a, output_mem_config);
+        Tensor result = prod_all(input_a, output_mem_config);
+        if (keepdim) {
+            // Reshape to have all dimensions (as many as the input rank) set to 1.
+            ttnn::SmallVector<uint32_t> output_shape(old_rank, 1);
+            result = ttnn::reshape(result, ttnn::Shape{output_shape});
+        }
+        return result;
     }
 
     TT_FATAL(size > 0, "Tensor has no dimensions");


### PR DESCRIPTION
### Ticket
Link to Github Issue #32279

### Problem description
ttnn.prod did not previously accept keepdim=true when reducing over all dimensions (dim=nullopt)
Added support for this option.

### What's changed
Added code to manually reshape the tensor after reduction when keepdim=true.
Updated unit tests to include this scenario. Also re-enabled assert_with_pcc in the unit test, which was previously disabled (this necessitated removal of bfloat8_b data type from the list of test parameters, which is not officially supported by prod anyways and pcc checks failed only on bfloat8_b). Added corresponding assert to fail with a reasonable message if any data type other than BFLOAT16 is provided.
Finally, minor refactor of generate_reduce_dim in ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.cpp to eliminate unnecessary sorting when a vector is already sorted. 


### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/19545009580
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes