### PR TITLE
Remove Naif as owner from t3k frequent

### DIFF
--- a/.github/workflows/t3000-frequent-tests-impl.yaml
+++ b/.github/workflows/t3000-frequent-tests-impl.yaml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          { name: "t3k tteager tests", arch: wormhole_b0, cmd: run_t3000_tteager_tests, timeout: 30, owner_id: U05ACKAJTHS}, #Naif Tarafdar
+          { name: "t3k tteager tests", arch: wormhole_b0, cmd: run_t3000_tteager_tests, timeout: 30, owner_id: U084B1CES7M}, #Borys Bradel
           { name: "t3k ethernet tests", arch: wormhole_b0, cmd: run_t3000_ethernet_tests, timeout: 10, owner_id: ULMEPM2MA}, #Sean Nijjar
           { name: "t3k trace stress tests", arch: wormhole_b0, cmd: run_t3000_trace_stress_tests, timeout: 30, owner_id: U03NG0A5ND7}, #Aditya Saigal
           { name: "t3k falcon40b tests", arch: wormhole_b0, cmd: run_t3000_falcon40b_tests, timeout: 20, owner_id: U04S2UV6L8N}, #Sofija Jovic


### PR DESCRIPTION
There are now 0 CCLs in this pipeline, with the only test being a layernorm test from @bbradelTT's team. Switch owners for now.