### PR TITLE
changing from .yaml to .textproto extension

### DIFF
--- a/.github/scripts/utils/multi-user-create-files.py
+++ b/.github/scripts/utils/multi-user-create-files.py
@@ -38,7 +38,7 @@ def multi_user_containers(num_containers, image):
                 "TTNN_RUNTIME_ARTIFACTS": f"/app/tt-metal/.ttnn_runtime_artifacts_{i}",
                 "LD_LIBRARY_PATH": "/app/tt-metal/build/lib",
                 "PYTHONPATH": "/app/tt-metal",
-                "TT_MESH_GRAPH_DESC_PATH": "/app/tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.yaml",
+                "TT_MESH_GRAPH_DESC_PATH": "/app/tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto",
                 "TT_MULTI_USER_GALAXY": f"/app/tt-metal/.multi-user-galaxy-docker-files/tray-{i}.txt",
             },
             "devices": devices,


### PR DESCRIPTION
### Ticket
NA

### Problem description
This PR: 

https://github.com/tenstorrent/tt-metal/commit/596ef6eb32dcc9e578f6851b87b3a498c8dc071d 

Changed t3k_mesh_graph_descriptor.yaml into t3k_mesh_graph_descriptor.textproto, but not every use of the t3k_mesh_graph_descriptor.yaml was updated, which caused a failure in galaxy multi user isolation tests

### What's changed
One line update changing .yaml to .textproto

### Checklist
- [ ] [Galaxy Multi User Isolation Tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-multi-user-isolation-tests.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/19550037076
