### PR TITLE
Add Watcher functions to sanitize local L1 reads/writes

### DIFF
--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_noc_sanitize.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_noc_sanitize.cpp
@@ -592,3 +592,11 @@ TEST_F(MeshWatcherFixture, TensixTestWatcherSanitizeL1Overflow) {
         },
         this->devices_[0]);
 }
+
+TEST_F(MeshWatcherFixture, ActiveEthTestWatcherSanitizeL1Overflow) {
+    this->RunTestOnDevice(
+        [](MeshWatcherFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
+            RunTestEth(fixture, mesh_device, SanitizeL1Overflow);
+        },
+        this->devices_[0]);
+}

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_noc_sanitize.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_noc_sanitize.cpp
@@ -31,7 +31,6 @@
 #include <tt-metalium/hal.hpp>
 #include <tt-metalium/hal_types.hpp>
 #include <tt-metalium/kernel_types.hpp>
-#include "llrt.hpp"
 // Do we really want to expose Hal like this?
 // This looks like an API level test
 #include "impl/context/metal_context.hpp"
@@ -47,23 +46,24 @@ using namespace tt;
 using namespace tt::tt_metal;
 
 enum watcher_features_t {
-    SanitizeAddress,
-    SanitizeAlignmentL1Write,
-    SanitizeAlignmentL1Read,
-    SanitizeZeroL1Write,
-    SanitizeMailboxWrite,
-    SanitizeInlineWriteDram,
-    SanitizeLinkedTransaction,
+    SanitizeNOCAddress,
+    SanitizeNOCAlignmentL1Write,
+    SanitizeNOCAlignmentL1Read,
+    SanitizeNOCZeroL1Write,
+    SanitizeNOCMailboxWrite,
+    SanitizeNOCInlineWriteDram,
+    SanitizeNOCLinkedTransaction,
+    SanitizeL1Overflow,
 };
 
 tt::tt_metal::HalMemType get_buffer_mem_type_for_test(watcher_features_t feature) {
-    return feature == watcher_features_t::SanitizeInlineWriteDram ? tt_metal::HalMemType::DRAM
-                                                                  : tt_metal::HalMemType::L1;
+    return feature == watcher_features_t::SanitizeNOCInlineWriteDram ? tt_metal::HalMemType::DRAM
+                                                                     : tt_metal::HalMemType::L1;
 }
 
 tt::tt_metal::BufferType get_buffer_type_for_test(watcher_features_t feature) {
-    return feature == watcher_features_t::SanitizeInlineWriteDram ? tt_metal::BufferType::DRAM
-                                                                  : tt_metal::BufferType::L1;
+    return feature == watcher_features_t::SanitizeNOCInlineWriteDram ? tt_metal::BufferType::DRAM
+                                                                     : tt_metal::BufferType::L1;
 }
 
 uint32_t get_address_for_test(bool use_eth_core, tt::tt_metal::HalL1MemAddrType type, bool high_address = false) {
@@ -192,27 +192,29 @@ void RunTestOnCore(
     // depending on the flags passed in.
     bool use_inline_dw_write = false;
     bool bad_linked_transaction = false;
+    uint32_t l1_overflow_addr = 0;
     switch(feature) {
-        case SanitizeAddress:
+        case SanitizeNOCAddress:
             output_buf_noc_xy.x = 26;
             output_buf_noc_xy.y = 18;
             break;
-        case SanitizeAlignmentL1Write:
+        case SanitizeNOCAlignmentL1Write:
             output_buffer_addr++;  // This is illegal because reading DRAM->L1 needs DRAM alignment
                                    // requirements (32 byte aligned).
             buffer_size--;
             break;
-        case SanitizeAlignmentL1Read:
+        case SanitizeNOCAlignmentL1Read:
             input_buffer_addr++;
             buffer_size--;
             break;
-        case SanitizeZeroL1Write: output_buffer_addr = 0; break;
-        case SanitizeMailboxWrite:
+        case SanitizeNOCZeroL1Write: output_buffer_addr = 0; break;
+        case SanitizeNOCMailboxWrite:
             // This is illegal because we'd be writing to the mailbox memory
             buffer_addr = get_address_for_test(is_eth_core, HalL1MemAddrType::MAILBOX);
             break;
-        case SanitizeInlineWriteDram: use_inline_dw_write = true; break;
-        case SanitizeLinkedTransaction: bad_linked_transaction = true; break;
+        case SanitizeNOCInlineWriteDram: use_inline_dw_write = true; break;
+        case SanitizeNOCLinkedTransaction: bad_linked_transaction = true; break;
+        case SanitizeL1Overflow: l1_overflow_addr = 0xDDDDDDDD; break;
         default:
             log_warning(LogTest, "Unrecognized feature to test ({}), skipping...", feature);
             GTEST_SKIP();
@@ -232,7 +234,8 @@ void RunTestOnCore(
          output_buf_noc_xy.y,
          buffer_size,
          use_inline_dw_write,
-         bad_linked_transaction});
+         bad_linked_transaction,
+         l1_overflow_addr});
 
     // Run the kernel, expect an exception here
     try {
@@ -256,7 +259,7 @@ void RunTestOnCore(
         risc_name = "ncrisc";
     }
     switch(feature) {
-        case SanitizeAddress:
+        case SanitizeNOCAddress:
             expected = fmt::format(
                 "Device {} {} core(x={:2},y={:2}) virtual(x={:2},y={:2}): {} using noc0 tried to unicast write {} "
                 "bytes from local L1[{:#08x}] to Unknown core w/ virtual coords {} [addr=0x{:08x}] (NOC target "
@@ -273,7 +276,7 @@ void RunTestOnCore(
                 output_buf_noc_xy.str(),
                 output_buffer_addr);
             break;
-        case SanitizeAlignmentL1Write: {
+        case SanitizeNOCAlignmentL1Write: {
             expected = fmt::format(
                 "Device {} {} core(x={:2},y={:2}) virtual(x={:2},y={:2}): {} using noc{} tried to unicast write {} "
                 "bytes from local L1[{:#08x}] to Tensix core w/ virtual coords {} L1[addr=0x{:08x}] (invalid address "
@@ -292,7 +295,7 @@ void RunTestOnCore(
                 output_buffer_addr);
             break;
         }
-        case SanitizeAlignmentL1Read: {
+        case SanitizeNOCAlignmentL1Read: {
             expected = fmt::format(
                 "Device {} {} core(x={:2},y={:2}) virtual(x={:2},y={:2}): {} using noc{} tried to unicast read {} "
                 "bytes to local L1[{:#08x}] from Tensix core w/ virtual coords {} L1[addr=0x{:08x}] (invalid address "
@@ -310,7 +313,7 @@ void RunTestOnCore(
                 input_core_virtual_coords,
                 input_buffer_addr);
         } break;
-        case SanitizeZeroL1Write: {
+        case SanitizeNOCZeroL1Write: {
             expected = fmt::format(
                 "Device {} {} core(x={:2},y={:2}) virtual(x={:2},y={:2}): {} using noc{} tried to unicast write {} "
                 "bytes from local L1[{:#08x}] to Tensix core w/ virtual coords {} L1[addr=0x{:08x}] (NOC target "
@@ -328,7 +331,7 @@ void RunTestOnCore(
                 input_core_virtual_coords,
                 output_buffer_addr);
         } break;
-        case SanitizeMailboxWrite: {
+        case SanitizeNOCMailboxWrite: {
             expected = fmt::format(
                 "Device {} {} core(x={:2},y={:2}) virtual(x={:2},y={:2}): {} using noc0 tried to unicast read {} "
                 "bytes to local L1[{:#08x}] from Tensix core w/ virtual coords {} L1[addr=0x{:08x}] (Local L1 "
@@ -345,7 +348,7 @@ void RunTestOnCore(
                 input_buf_noc_xy.str(),
                 input_buffer_addr);
         } break;
-        case SanitizeInlineWriteDram: {
+        case SanitizeNOCInlineWriteDram: {
             expected = fmt::format(
                 "Device {} {} core(x={:2},y={:2}) virtual(x={:2},y={:2}): {} using noc0 tried to unicast write 4 bytes "
                 "from local L1[{:#08x}] to DRAM core w/ virtual coords {} DRAM[addr=0x{:08x}] (inline dw writes do not "
@@ -361,7 +364,7 @@ void RunTestOnCore(
                 output_core_virtual_coords.str(),
                 output_buffer_addr);
         } break;
-        case SanitizeLinkedTransaction: {
+        case SanitizeNOCLinkedTransaction: {
             expected = fmt::format(
                 "Device {} {} core(x={:2},y={:2}) virtual(x={:2},y={:2}): {} using noc0 tried to unicast write {} "
                 "bytes from local L1[{:#08x}] to Tensix core w/ virtual coords {} L1[addr=0x{:08x}] (submitting a "
@@ -377,6 +380,19 @@ void RunTestOnCore(
                 buffer_addr,
                 output_core_virtual_coords.str(),
                 output_buffer_addr);
+        } break;
+        case SanitizeL1Overflow: {
+            expected = fmt::format(
+                "Device {} {} core(x={:2},y={:2}) virtual(x={:2},y={:2}): {} core overflowed L1 with access to {:#x} "
+                "(read or write past the end of local memory).",
+                device->id(),
+                (is_eth_core) ? "acteth" : "worker",
+                core.x,
+                core.y,
+                virtual_core.x,
+                virtual_core.y,
+                risc_name,
+                l1_overflow_addr);
         } break;
         default:
             log_warning(LogTest, "Unrecognized feature to test ({}), skipping...", feature);
@@ -452,61 +468,61 @@ TEST_F(MeshWatcherFixture, TensixTestWatcherSanitize) {
     this->RunTestOnDevice(
         [](MeshWatcherFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
             CoreCoord core{0, 0};
-            RunTestOnCore(fixture, mesh_device, core, false, SanitizeAddress);
+            RunTestOnCore(fixture, mesh_device, core, false, SanitizeNOCAddress);
         },
         this->devices_[0]);
 }
 
-TEST_F(MeshWatcherFixture, TensixTestWatcherSanitizeAlignmentL1Write) {
+TEST_F(MeshWatcherFixture, TensixTestWatcherSanitizeNOCAlignmentL1Write) {
     this->RunTestOnDevice(
         [](MeshWatcherFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
             CoreCoord core{0, 0};
-            RunTestOnCore(fixture, mesh_device, core, false, SanitizeAlignmentL1Write);
+            RunTestOnCore(fixture, mesh_device, core, false, SanitizeNOCAlignmentL1Write);
         },
         this->devices_[0]);
 }
 
-TEST_F(MeshWatcherFixture, TensixTestWatcherSanitizeAlignmentL1Read) {
+TEST_F(MeshWatcherFixture, TensixTestWatcherSanitizeNOCAlignmentL1Read) {
     this->RunTestOnDevice(
         [](MeshWatcherFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
             CoreCoord core{0, 0};
-            RunTestOnCore(fixture, mesh_device, core, false, SanitizeAlignmentL1Read);
+            RunTestOnCore(fixture, mesh_device, core, false, SanitizeNOCAlignmentL1Read);
         },
         this->devices_[0]);
 }
 
-TEST_F(MeshWatcherFixture, TensixTestWatcherSanitizeAlignmentL1ReadNCrisc) {
+TEST_F(MeshWatcherFixture, TensixTestWatcherSanitizeNOCAlignmentL1ReadNCrisc) {
     this->RunTestOnDevice(
         [](MeshWatcherFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
             CoreCoord core{0, 0};
-            RunTestOnCore(fixture, mesh_device, core, false, SanitizeAlignmentL1Read, true);
+            RunTestOnCore(fixture, mesh_device, core, false, SanitizeNOCAlignmentL1Read, true);
         },
         this->devices_[0]);
 }
 
-TEST_F(MeshWatcherFixture, TensixTestWatcherSanitizeZeroL1Write) {
+TEST_F(MeshWatcherFixture, TensixTestWatcherSanitizeNOCZeroL1Write) {
     this->RunTestOnDevice(
         [](MeshWatcherFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
             CoreCoord core{0, 0};
-            RunTestOnCore(fixture, mesh_device, core, false, SanitizeZeroL1Write);
+            RunTestOnCore(fixture, mesh_device, core, false, SanitizeNOCZeroL1Write);
         },
         this->devices_[0]);
 }
 
-TEST_F(MeshWatcherFixture, TensixTestWatcherSanitizeMailboxWrite) {
+TEST_F(MeshWatcherFixture, TensixTestWatcherSanitizeNOCMailboxWrite) {
     this->RunTestOnDevice(
         [](MeshWatcherFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
             CoreCoord core{0, 0};
-            RunTestOnCore(fixture, mesh_device, core, false, SanitizeMailboxWrite);
+            RunTestOnCore(fixture, mesh_device, core, false, SanitizeNOCMailboxWrite);
         },
         this->devices_[0]);
 }
 
-TEST_F(MeshWatcherFixture, TensixTestWatcherSanitizeInlineWriteDram) {
+TEST_F(MeshWatcherFixture, TensixTestWatcherSanitizeNOCInlineWriteDram) {
     this->RunTestOnDevice(
         [](MeshWatcherFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
             CoreCoord core{0, 0};
-            RunTestOnCore(fixture, mesh_device, core, false, SanitizeInlineWriteDram);
+            RunTestOnCore(fixture, mesh_device, core, false, SanitizeNOCInlineWriteDram);
         },
         this->devices_[0]);
 }
@@ -514,23 +530,23 @@ TEST_F(MeshWatcherFixture, TensixTestWatcherSanitizeInlineWriteDram) {
 TEST_F(MeshWatcherFixture, ActiveEthTestWatcherSanitizeEth) {
     this->RunTestOnDevice(
         [](MeshWatcherFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
-            RunTestEth(fixture, mesh_device, SanitizeAddress);
+            RunTestEth(fixture, mesh_device, SanitizeNOCAddress);
         },
         this->devices_[0]);
 }
 
-TEST_F(MeshWatcherFixture, ActiveEthTestWatcherSanitizeMailboxWrite) {
+TEST_F(MeshWatcherFixture, ActiveEthTestWatcherSanitizeNOCMailboxWrite) {
     this->RunTestOnDevice(
         [](MeshWatcherFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
-            RunTestEth(fixture, mesh_device, SanitizeMailboxWrite);
+            RunTestEth(fixture, mesh_device, SanitizeNOCMailboxWrite);
         },
         this->devices_[0]);
 }
 
-TEST_F(MeshWatcherFixture, ActiveEthTestWatcherSanitizeInlineWriteDram) {
+TEST_F(MeshWatcherFixture, ActiveEthTestWatcherSanitizeNOCInlineWriteDram) {
     this->RunTestOnDevice(
         [](MeshWatcherFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
-            RunTestEth(fixture, mesh_device, SanitizeInlineWriteDram);
+            RunTestEth(fixture, mesh_device, SanitizeNOCInlineWriteDram);
         },
         this->devices_[0]);
 }
@@ -542,28 +558,37 @@ TEST_F(MeshWatcherFixture, IdleEthTestWatcherSanitizeIEth) {
     }
     this->RunTestOnDevice(
         [](MeshWatcherFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
-            RunTestIEth(fixture, mesh_device, SanitizeAddress);
+            RunTestIEth(fixture, mesh_device, SanitizeNOCAddress);
         },
         this->devices_[0]);
 }
 
-TEST_F(MeshWatcherFixture, IdleEthTestWatcherSanitizeInlineWriteDram) {
+TEST_F(MeshWatcherFixture, IdleEthTestWatcherSanitizeNOCInlineWriteDram) {
     if (!this->IsSlowDispatch()) {
         log_info(tt::LogTest, "FD-on-idle-eth not supported.");
         GTEST_SKIP();
     }
     this->RunTestOnDevice(
         [](MeshWatcherFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
-            RunTestIEth(fixture, mesh_device, SanitizeInlineWriteDram);
+            RunTestIEth(fixture, mesh_device, SanitizeNOCInlineWriteDram);
         },
         this->devices_[0]);
 }
 
-TEST_F(MeshWatcherFixture, DISABLED_SanitizeLinkedTransaction) {
+TEST_F(MeshWatcherFixture, DISABLED_SanitizeNOCLinkedTransaction) {
     this->RunTestOnDevice(
         [](MeshWatcherFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
             CoreCoord core{0, 0};
-            RunTestOnCore(fixture, mesh_device, core, false, SanitizeLinkedTransaction);
+            RunTestOnCore(fixture, mesh_device, core, false, SanitizeNOCLinkedTransaction);
+        },
+        this->devices_[0]);
+}
+
+TEST_F(MeshWatcherFixture, TensixTestWatcherSanitizeL1Overflow) {
+    this->RunTestOnDevice(
+        [](MeshWatcherFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
+            CoreCoord core{0, 0};
+            RunTestOnCore(fixture, mesh_device, core, false, SanitizeL1Overflow);
         },
         this->devices_[0]);
 }

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dram_copy_to_noc_coord.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dram_copy_to_noc_coord.cpp
@@ -5,6 +5,8 @@
 #include <cstdint>
 #include "dataflow_api.h"
 #include "debug/dprint.h"
+#include "dev_mem_map.h"
+#include "debug/sanitize.h"
 /**
  * NOC APIs are prefixed w/ "ncrisc" (legacy name) but there's nothing NCRISC specific, they can be used on BRISC or
  * other RISCs Any two RISC processors cannot use the same CMD_BUF non_blocking APIs shouldn't be mixed with slow noc.h
@@ -25,6 +27,7 @@ void kernel_main() {
 
     bool use_inline_dw_write = static_cast<bool>(get_arg_val<uint32_t>(8));
     bool bad_linked_transaction = static_cast<bool>(get_arg_val<uint32_t>(9));
+    std::uint32_t l1_overflow_addr = get_arg_val<uint32_t>(10);
 
 #if defined(SIGNAL_COMPLETION_TO_DISPATCHER)
     // We will assert later. This kernel will hang.
@@ -52,6 +55,10 @@ void kernel_main() {
         true    // posted
     );
 #endif
+
+    if (l1_overflow_addr) {
+        debug_sanitize_l1_access(l1_overflow_addr, 1);
+    }
 
     // NOC src address
     std::uint64_t buffer_src_noc_addr = get_noc_addr(src_noc_x, src_noc_y, buffer_src_addr);

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dram_copy_to_noc_coord.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dram_copy_to_noc_coord.cpp
@@ -5,7 +5,6 @@
 #include <cstdint>
 #include "dataflow_api.h"
 #include "debug/dprint.h"
-#include "dev_mem_map.h"
 #include "debug/sanitize.h"
 /**
  * NOC APIs are prefixed w/ "ncrisc" (legacy name) but there's nothing NCRISC specific, they can be used on BRISC or

--- a/tt_metal/hw/CMakeLists.txt
+++ b/tt_metal/hw/CMakeLists.txt
@@ -440,7 +440,7 @@ target_sources(
             inc/debug/fw_debug.h
             inc/debug/noc_logging.h
             inc/debug/ring_buffer.h
-            inc/debug/sanitize_noc.h
+            inc/debug/sanitize.h
             inc/debug/stack_usage.h
             inc/debug/watcher_common.h
             inc/debug/waypoint.h

--- a/tt_metal/hw/inc/dataflow_api_addrgen.h
+++ b/tt_metal/hw/inc/dataflow_api_addrgen.h
@@ -7,7 +7,7 @@
 #include "dataflow_api_common.h"
 #include "dataflow_cmd_bufs.h"
 #include "debug/assert.h"
-#include "debug/sanitize_noc.h"
+#include "debug/sanitize.h"
 #include "debug/waypoint.h"
 #include "utils/utils.h"
 

--- a/tt_metal/hw/inc/debug/sanitize.h
+++ b/tt_metal/hw/inc/debug/sanitize.h
@@ -486,11 +486,16 @@ void debug_throw_on_dram_addr(uint8_t noc_id, uint64_t addr, uint32_t len) {
 }
 
 void debug_sanitize_l1_access(uint64_t addr, uint32_t len) {
-    constexpr uint64_t l1_size = MEM_L1_SIZE;
-    if (addr + len > l1_size) {
+#if defined(COMPILE_FOR_ERISC)
+    constexpr uint64_t l1_overflow_addr = MEM_L1_SIZE + 1;
+#else
+    constexpr uint64_t l1_overflow_addr = MEM_ETH_SIZE + 1;
+#endif
+    if (addr + len <= addr || addr + len > l1_overflow_addr) {
         debug_sanitize_post_addr_and_hang(
+            0,  // unused (not a noc transaction)
+            0,  // unused (not a noc transaction)
             addr,
-            0,
             len,
             DEBUG_SANITIZE_NOC_UNICAST,
             DEBUG_SANITIZE_NOC_WRITE,

--- a/tt_metal/hw/inc/debug/sanitize.h
+++ b/tt_metal/hw/inc/debug/sanitize.h
@@ -487,9 +487,9 @@ void debug_throw_on_dram_addr(uint8_t noc_id, uint64_t addr, uint32_t len) {
 
 void debug_sanitize_l1_access(uint64_t addr, uint32_t len) {
 #if defined(COMPILE_FOR_ERISC)
-    constexpr uint64_t l1_overflow_addr = MEM_L1_SIZE + 1;
+    constexpr uint64_t l1_overflow_addr = MEM_L1_SIZE;
 #else
-    constexpr uint64_t l1_overflow_addr = MEM_ETH_SIZE + 1;
+    constexpr uint64_t l1_overflow_addr = MEM_ETH_SIZE;
 #endif
     if (addr + len <= addr || addr + len > l1_overflow_addr) {
         debug_sanitize_post_addr_and_hang(

--- a/tt_metal/hw/inc/debug/sanitize.h
+++ b/tt_metal/hw/inc/debug/sanitize.h
@@ -487,9 +487,9 @@ void debug_throw_on_dram_addr(uint8_t noc_id, uint64_t addr, uint32_t len) {
 
 void debug_sanitize_l1_access(uint64_t addr, uint32_t len) {
 #if defined(COMPILE_FOR_ERISC)
-    constexpr uint64_t l1_overflow_addr = MEM_L1_SIZE;
-#else
     constexpr uint64_t l1_overflow_addr = MEM_ETH_SIZE;
+#else
+    constexpr uint64_t l1_overflow_addr = MEM_L1_SIZE;
 #endif
     if (addr + len <= addr || addr + len > l1_overflow_addr) {
         debug_sanitize_post_addr_and_hang(

--- a/tt_metal/hw/inc/debug/sanitize_noc.h
+++ b/tt_metal/hw/inc/debug/sanitize_noc.h
@@ -170,7 +170,7 @@ inline uint16_t debug_valid_worker_addr(uint64_t addr, uint64_t len, bool write)
         return DebugSanitizeNocAddrMailbox;
     }
 #endif
-    return DebugSanitizeNocOK;
+    return DebugSanitizeOK;
 }
 
 inline uint16_t debug_valid_pcie_addr(uint64_t addr, uint64_t len) {
@@ -185,7 +185,7 @@ inline uint16_t debug_valid_pcie_addr(uint64_t addr, uint64_t len) {
     if (addr + len > core_info->noc_pcie_addr_end) {
         return DebugSanitizeNocAddrOverflow;
     }
-    return DebugSanitizeNocOK;
+    return DebugSanitizeOK;
 }
 inline uint16_t debug_valid_dram_addr(uint64_t addr, uint64_t len) {
     if (addr + len <= addr) {
@@ -199,7 +199,7 @@ inline uint16_t debug_valid_dram_addr(uint64_t addr, uint64_t len) {
     if (addr + len > core_info->noc_dram_addr_end) {
         return DebugSanitizeNocAddrOverflow;
     }
-    return DebugSanitizeNocOK;
+    return DebugSanitizeOK;
 }
 
 inline uint16_t debug_valid_eth_addr(uint64_t addr, uint64_t len, bool write) {
@@ -221,7 +221,7 @@ inline uint16_t debug_valid_eth_addr(uint64_t addr, uint64_t len, bool write) {
         return DebugSanitizeNocAddrMailbox;
     }
 #endif
-    return DebugSanitizeNocOK;
+    return DebugSanitizeOK;
 }
 
 // Note:
@@ -236,13 +236,13 @@ void __attribute__((noinline)) debug_sanitize_post_noc_addr_and_hang(
     debug_sanitize_noc_dir_t dir,
     debug_sanitize_noc_which_core_t which_core,
     uint16_t return_code) {
-    if (return_code == DebugSanitizeNocOK) {
+    if (return_code == DebugSanitizeOK) {
         return;
     }
 
-    debug_sanitize_noc_addr_msg_t tt_l1_ptr* v = *GET_MAILBOX_ADDRESS_DEV(watcher.sanitize_noc);
+    debug_sanitize_addr_msg_t tt_l1_ptr* v = *GET_MAILBOX_ADDRESS_DEV(watcher.sanitize);
 
-    if (v[noc_id].return_code == DebugSanitizeNocOK) {
+    if (v[noc_id].return_code == DebugSanitizeOK) {
         v[noc_id].noc_addr = noc_addr;
         v[noc_id].l1_addr = l1_addr;
         v[noc_id].len = len;
@@ -327,7 +327,7 @@ uint32_t debug_sanitize_noc_addr(
         uint8_t y_end = (uint8_t)NOC_MCAST_ADDR_END_Y(noc_addr);
         bool is_virtual_coord_end = false;
         AddressableCoreType end_core_type = get_core_type(noc_id, x_end, y_end, is_virtual_coord_end);
-        uint16_t return_code = DebugSanitizeNocOK;
+        uint16_t return_code = DebugSanitizeOK;
         if (core_type != AddressableCoreType::TENSIX || end_core_type != AddressableCoreType::TENSIX) {
             return_code = DebugSanitizeNocMulticastNonWorker;
         }

--- a/tt_metal/hw/inc/debug/watcher_common.h
+++ b/tt_metal/hw/inc/debug/watcher_common.h
@@ -10,7 +10,7 @@
 
 #if defined(COMPILE_FOR_ERISC)
 // Forward declare these functions to avoid including erisc.h -> circular dependency via noc_nonblocking_api.h,
-// sanitize_noc.h.
+// sanitize.h.
 namespace internal_ {
 void risc_context_switch();
 void disable_erisc_app();

--- a/tt_metal/hw/inc/dev_msgs.h
+++ b/tt_metal/hw/inc/dev_msgs.h
@@ -209,7 +209,7 @@ struct debug_waypoint_msg_t {
 };
 
 // This structure is populated by the device and read by the host
-struct debug_sanitize_noc_addr_msg_t {
+struct debug_sanitize_addr_msg_t {
     volatile uint64_t noc_addr;
     volatile uint32_t l1_addr;
     volatile uint32_t len;
@@ -220,7 +220,7 @@ struct debug_sanitize_noc_addr_msg_t {
     volatile uint8_t is_target;
     volatile uint8_t pad;  // CODEGEN:skip
 };
-static_assert(sizeof(debug_sanitize_noc_addr_msg_t) % sizeof(uint32_t) == 0);
+static_assert(sizeof(debug_sanitize_addr_msg_t) % sizeof(uint32_t) == 0);
 
 // Host -> device. Populated with the information on where we want to insert delays.
 struct debug_insert_delays_msg_t {
@@ -232,7 +232,7 @@ struct debug_insert_delays_msg_t {
 
 enum debug_sanitize_noc_return_code_enum {
     // 0 and 1 are a common stray values to write, so don't use those
-    DebugSanitizeNocOK = 2,
+    DebugSanitizeOK = 2,
     DebugSanitizeNocAddrUnderflow = 3,
     DebugSanitizeNocAddrOverflow = 4,
     DebugSanitizeNocAddrZeroLength = 5,
@@ -244,6 +244,7 @@ enum debug_sanitize_noc_return_code_enum {
     DebugSanitizeInlineWriteDramUnsupported = 11,
     DebugSanitizeNocAddrMailbox = 12,
     DebugSanitizeNocLinkedTransactionViolation = 13,
+    DebugSanitizeL1AddrOverflow = 14,
 };
 
 struct debug_assert_msg_t {
@@ -302,7 +303,7 @@ constexpr static std::uint32_t MAX_NUM_NOCS_PER_CORE = 2;
 struct watcher_msg_t {
     volatile uint32_t enable;
     struct debug_waypoint_msg_t debug_waypoint[MaxProcessorsPerCoreType];
-    struct debug_sanitize_noc_addr_msg_t sanitize_noc[MAX_NUM_NOCS_PER_CORE];
+    struct debug_sanitize_addr_msg_t sanitize[MAX_NUM_NOCS_PER_CORE];
     std::atomic<bool> noc_linked_status[MAX_NUM_NOCS_PER_CORE];
     struct debug_eth_link_t eth_status;
     uint8_t pad0;  // CODEGEN:skip

--- a/tt_metal/impl/debug/watcher_device_reader.cpp
+++ b/tt_metal/impl/debug/watcher_device_reader.cpp
@@ -147,7 +147,7 @@ string get_noc_target_str(
     tt::ChipId device_id,
     HalProgrammableCoreType programmable_core_type,
     int noc,
-    dev_msgs::debug_sanitize_noc_addr_msg_t::ConstView san) {
+    dev_msgs::debug_sanitize_addr_msg_t::ConstView san) {
     auto get_core_and_mem_type = [](tt::ChipId device_id, CoreCoord& noc_coord, int noc) -> std::pair<string, string> {
         // Get the virtual coord from the noc coord
         CoreCoord virtual_core = virtual_noc_coordinate(device_id, noc, noc_coord);
@@ -197,6 +197,21 @@ string get_noc_target_str(
     }
 
     out += fmt::format("[addr=0x{:08x}]", NOC_LOCAL_ADDR(san.noc_addr()));
+    return out;
+}
+
+string get_l1_target_str(
+    tt::ChipId device_id,
+    HalProgrammableCoreType programmable_core_type,
+    int noc,
+    dev_msgs::debug_sanitize_addr_msg_t::ConstView san) {
+    string out = fmt::format(
+        "{} core w/ virtual coords {} overflowed L1 {:#x}",
+        get_riscv_name(programmable_core_type, san.which_risc()),
+        virtual_noc_coordinate(device_id, noc, {NOC_UNICAST_ADDR_X(san.noc_addr()), NOC_UNICAST_ADDR_Y(san.noc_addr())})
+            .str(),
+        san.l1_addr(),
+        san.len());
     return out;
 }
 
@@ -629,18 +644,16 @@ void WatcherDeviceReader::Core::DumpL1Status() const {
 }
 
 void WatcherDeviceReader::Core::DumpNocSanitizeStatus(int noc) const {
-    auto san = mbox_data_.watcher().sanitize_noc()[noc];
+    auto san = mbox_data_.watcher().sanitize()[noc];
     string error_msg;
     string error_reason;
 
     switch (san.return_code()) {
-        case dev_msgs::DebugSanitizeNocOK:
-            if (san.noc_addr() != DEBUG_SANITIZE_NOC_SENTINEL_OK_64 ||
-                san.l1_addr() != DEBUG_SANITIZE_NOC_SENTINEL_OK_32 || san.len() != DEBUG_SANITIZE_NOC_SENTINEL_OK_32 ||
-                san.which_risc() != DEBUG_SANITIZE_NOC_SENTINEL_OK_16 ||
-                san.is_multicast() != DEBUG_SANITIZE_NOC_SENTINEL_OK_8 ||
-                san.is_write() != DEBUG_SANITIZE_NOC_SENTINEL_OK_8 ||
-                san.is_target() != DEBUG_SANITIZE_NOC_SENTINEL_OK_8) {
+        case dev_msgs::DebugSanitizeOK:
+            if (san.noc_addr() != DEBUG_SANITIZE_SENTINEL_OK_64 || san.l1_addr() != DEBUG_SANITIZE_SENTINEL_OK_32 ||
+                san.len() != DEBUG_SANITIZE_SENTINEL_OK_32 || san.which_risc() != DEBUG_SANITIZE_SENTINEL_OK_16 ||
+                san.is_multicast() != DEBUG_SANITIZE_SENTINEL_OK_8 || san.is_write() != DEBUG_SANITIZE_SENTINEL_OK_8 ||
+                san.is_target() != DEBUG_SANITIZE_SENTINEL_OK_8) {
                 error_msg = fmt::format(
                     "Watcher unexpected noc debug state on core {}, reported valid got noc{}{{0x{:08x}, {} }}",
                     virtual_coord_.str(),
@@ -694,6 +707,10 @@ void WatcherDeviceReader::Core::DumpNocSanitizeStatus(int noc) const {
             error_msg = get_noc_target_str(reader_.device_id, programmable_core_type_, noc, san);
             error_msg += fmt::format(" (submitting a non-mcast transaction when there's a linked transaction).");
             break;
+        case dev_msgs::DebugSanitizeL1AddrOverflow:
+            error_msg = get_l1_target_str(reader_.device_id, programmable_core_type_, noc, san);
+            error_msg += " (local L1 access overflow).";
+            break;
         default:
             error_msg = fmt::format(
                 "Watcher unexpected data corruption, noc debug state on core {}, unknown failure code: {}",
@@ -718,8 +735,8 @@ void WatcherDeviceReader::Core::DumpNocSanitizeStatus(int noc) const {
 void WatcherDeviceReader::Core::DumpAssertStatus() const {
     auto assert_status = mbox_data_.watcher().assert_status();
     if (assert_status.tripped() == dev_msgs::DebugAssertOK) {
-        if (assert_status.line_num() != DEBUG_SANITIZE_NOC_SENTINEL_OK_16 ||
-            assert_status.which() != DEBUG_SANITIZE_NOC_SENTINEL_OK_8) {
+        if (assert_status.line_num() != DEBUG_SANITIZE_SENTINEL_OK_16 ||
+            assert_status.which() != DEBUG_SANITIZE_SENTINEL_OK_8) {
             TT_THROW(
                 "Watcher unexpected assert state on core {}, reported OK but got processor {}, line {}.",
                 virtual_coord_.str(),

--- a/tt_metal/impl/debug/watcher_device_reader.cpp
+++ b/tt_metal/impl/debug/watcher_device_reader.cpp
@@ -203,7 +203,7 @@ string get_noc_target_str(
 string get_l1_target_str(
     HalProgrammableCoreType programmable_core_type, dev_msgs::debug_sanitize_addr_msg_t::ConstView san) {
     string out = fmt::format(
-        "{} core overflowed L1 with access to {:#x}",
+        "{} core overflowed L1 with access to {:#x} of length {}",
         get_riscv_name(programmable_core_type, san.which_risc()),
         san.l1_addr(),
         san.len());

--- a/tt_metal/impl/debug/watcher_device_reader.cpp
+++ b/tt_metal/impl/debug/watcher_device_reader.cpp
@@ -201,15 +201,10 @@ string get_noc_target_str(
 }
 
 string get_l1_target_str(
-    tt::ChipId device_id,
-    HalProgrammableCoreType programmable_core_type,
-    int noc,
-    dev_msgs::debug_sanitize_addr_msg_t::ConstView san) {
+    HalProgrammableCoreType programmable_core_type, dev_msgs::debug_sanitize_addr_msg_t::ConstView san) {
     string out = fmt::format(
-        "{} core w/ virtual coords {} overflowed L1 {:#x}",
+        "{} core overflowed L1 with access to {:#x}",
         get_riscv_name(programmable_core_type, san.which_risc()),
-        virtual_noc_coordinate(device_id, noc, {NOC_UNICAST_ADDR_X(san.noc_addr()), NOC_UNICAST_ADDR_Y(san.noc_addr())})
-            .str(),
         san.l1_addr(),
         san.len());
     return out;
@@ -708,8 +703,8 @@ void WatcherDeviceReader::Core::DumpNocSanitizeStatus(int noc) const {
             error_msg += fmt::format(" (submitting a non-mcast transaction when there's a linked transaction).");
             break;
         case dev_msgs::DebugSanitizeL1AddrOverflow:
-            error_msg = get_l1_target_str(reader_.device_id, programmable_core_type_, noc, san);
-            error_msg += " (local L1 access overflow).";
+            error_msg = get_l1_target_str(programmable_core_type_, san);
+            error_msg += " (read or write past the end of local memory).";
             break;
         default:
             error_msg = fmt::format(

--- a/tt_metal/impl/debug/watcher_device_reader.hpp
+++ b/tt_metal/impl/debug/watcher_device_reader.hpp
@@ -16,10 +16,10 @@
 
 namespace tt::tt_metal {
 
-constexpr uint64_t DEBUG_SANITIZE_NOC_SENTINEL_OK_64 = 0xbadabadabadabada;
-constexpr uint32_t DEBUG_SANITIZE_NOC_SENTINEL_OK_32 = 0xbadabada;
-constexpr uint16_t DEBUG_SANITIZE_NOC_SENTINEL_OK_16 = 0xbada;
-constexpr uint8_t DEBUG_SANITIZE_NOC_SENTINEL_OK_8 = 0xda;
+constexpr uint64_t DEBUG_SANITIZE_SENTINEL_OK_64 = 0xbadabadabadabada;
+constexpr uint32_t DEBUG_SANITIZE_SENTINEL_OK_32 = 0xbadabada;
+constexpr uint16_t DEBUG_SANITIZE_SENTINEL_OK_16 = 0xbada;
+constexpr uint8_t DEBUG_SANITIZE_SENTINEL_OK_8 = 0xda;
 
 class WatcherDeviceReader {
 public:

--- a/tt_metal/impl/debug/watcher_server.cpp
+++ b/tt_metal/impl/debug/watcher_server.cpp
@@ -360,21 +360,21 @@ void WatcherServer::Impl::init_device(ChipId device_id) {
         }
 
         // Initialize debug sanity L1/NOC addresses to sentinel "all ok"
-        for (auto sanitize_noc : data.sanitize_noc()) {
-            sanitize_noc.noc_addr() = DEBUG_SANITIZE_NOC_SENTINEL_OK_64;
-            sanitize_noc.l1_addr() = DEBUG_SANITIZE_NOC_SENTINEL_OK_32;
-            sanitize_noc.len() = DEBUG_SANITIZE_NOC_SENTINEL_OK_32;
-            sanitize_noc.which_risc() = DEBUG_SANITIZE_NOC_SENTINEL_OK_16;
-            sanitize_noc.return_code() = dev_msgs::DebugSanitizeNocOK;
-            sanitize_noc.is_multicast() = DEBUG_SANITIZE_NOC_SENTINEL_OK_8;
-            sanitize_noc.is_write() = DEBUG_SANITIZE_NOC_SENTINEL_OK_8;
-            sanitize_noc.is_target() = DEBUG_SANITIZE_NOC_SENTINEL_OK_8;
+        for (auto sanitize : data.sanitize()) {
+            sanitize.noc_addr() = DEBUG_SANITIZE_SENTINEL_OK_64;
+            sanitize.l1_addr() = DEBUG_SANITIZE_SENTINEL_OK_32;
+            sanitize.len() = DEBUG_SANITIZE_SENTINEL_OK_32;
+            sanitize.which_risc() = DEBUG_SANITIZE_SENTINEL_OK_16;
+            sanitize.return_code() = dev_msgs::DebugSanitizeOK;
+            sanitize.is_multicast() = DEBUG_SANITIZE_SENTINEL_OK_8;
+            sanitize.is_write() = DEBUG_SANITIZE_SENTINEL_OK_8;
+            sanitize.is_target() = DEBUG_SANITIZE_SENTINEL_OK_8;
         }
 
         // Initialize debug asserts to not tripped.
-        data.assert_status().line_num() = DEBUG_SANITIZE_NOC_SENTINEL_OK_16;
+        data.assert_status().line_num() = DEBUG_SANITIZE_SENTINEL_OK_16;
         data.assert_status().tripped() = dev_msgs::DebugAssertOK;
-        data.assert_status().which() = DEBUG_SANITIZE_NOC_SENTINEL_OK_8;
+        data.assert_status().which() = DEBUG_SANITIZE_SENTINEL_OK_8;
 
         // Initialize debug ring buffer to a known init val, we'll check against this to see if any
         // data has been written.

--- a/tt_metal/impl/dispatch/kernels/cq_common.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_common.hpp
@@ -9,7 +9,7 @@
 #include "dataflow_api.h"
 #include "cq_helpers.hpp"
 
-#include "debug/sanitize_noc.h"
+#include "debug/sanitize.h"
 #include <limits>
 
 // The command queue read interface controls reads from the issue region, host owns the issue region write interface


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/32949

### Problem description
Want to be able to sanitize L1 reads/writes through the new Device memory access APIs. Use Watcher to do safety checks until we have a new Debug State Tracker.

### What's changed
- Renamed existing Watcher statuses to differentiate if it's a NOC or L1 sanitization error
- Implemented a check for L1 overflow.
  - When the Device 2.0 APIs are merged then we can expand the check to also prevent overwriting mailboxes, base fw, etc.
- Added unit test for Tensix and Active Ethernet 

### Checklist
All Post Commit
https://github.com/tenstorrent/tt-metal/actions/runs/19555407506
Blackhole Post Commit
https://github.com/tenstorrent/tt-metal/actions/runs/19555409636
T3K Unit
https://github.com/tenstorrent/tt-metal/actions/runs/19555426574