### PR TITLE
feat: improve sfpu int32 multiplication on bh

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_mul_int32.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_mul_int32.h
@@ -70,7 +70,7 @@ inline void mul_int32(const uint dst_index_in0, const uint dst_index_in1, const 
         // b2
         TT_SFPLOADMACRO((2 << 2) | (b2 & 3), INT32, ADDR_MOD_7, offset1 | (b2 >> 2));
         // c = mul24_hi(a0, b2)
-        TTI_SFPMUL24(a0, b2, p_sfpu::LCONST_0, c, 1);
+        TTI_SFPMUL24(a0, b2, p_sfpu::LCONST_0, c, SFPMUL24_MOD1_UPPER);
         // b1 = b1 + a1
         TTI_SFPIADD(0, a1, b1, SFPIADD_MOD1_CC_NONE);
         // c
@@ -89,9 +89,9 @@ inline void mul_int32_init() {
     // Load instruction templates.  This is more efficient than using
     // SFPCONFIG, but requires DISABLE_BACKDOOR_LOAD=false (the default).
 
-    TTI_SFPSHFT2(-23 & 0xfff, 0, 12, 6);
-    TTI_SFPMUL24(0, 0, p_sfpu::LCONST_0, 13, 0);
-    TTI_SFPSHFT(23, b1, 14, 1 | 4);
+    TTI_SFPSHFT2(-23 & 0xfff, 0, 12, SFPSHFT2_MOD1_SHFT_IMM);
+    TTI_SFPMUL24(0, 0, p_sfpu::LCONST_0, 13, SFPMUL24_MOD1_LOWER);
+    TTI_SFPSHFT(23, b1, 14, 1 | 4);  // SFPSHFT_MOD1_ARG_IMM | SFPSHFT_MOD1_ARG_IMM_USE_VC
     TTI_SFPIADD(0, c, 15, SFPIADD_MOD1_CC_NONE);
 
     // Configure macros.
@@ -147,6 +147,11 @@ inline void mul_int32_init() {
 
         TTI_SFPCONFIG(0, 7, 0);
     }
+    // Misc: {
+    //   StoreMod0: MOD0_FMT_SRCB,
+    //   UsesLoadMod0ForStore: {1,1,1,1},
+    //   UnitDelayKind: {1,1,1,1}, (WaitForElapsedInstructions=1)
+    // }
     TTI_SFPCONFIG(0xff0, 8, 1);
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_mul_int32.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_mul_int32.h
@@ -20,7 +20,8 @@ inline void mul_int32(const uint dst_index_in0, const uint dst_index_in1, const 
     uint offset1 = dst_index_in1 * dst_tile_size;
     uint offset2 = dst_index_out * dst_tile_size;
 
-    constexpr uint z = 0;
+    constexpr uint a0 = 0;
+    constexpr uint b0 = 0;
     constexpr uint a1 = 1;
     constexpr uint b1 = 2;
     constexpr uint b2 = 3;
@@ -29,17 +30,17 @@ inline void mul_int32(const uint dst_index_in0, const uint dst_index_in1, const 
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
         // b0
-        TT_SFPLOAD(z, INT32, ADDR_MOD_7, offset1);
+        TT_SFPLOAD(b0, INT32, ADDR_MOD_7, offset1);
         // a1
         TT_SFPLOADMACRO((0 << 2) | (a1 & 3), INT32, ADDR_MOD_7, offset0 | (a1 >> 2));
         // b1
         TT_SFPLOADMACRO((1 << 2) | (b1 & 3), INT32, ADDR_MOD_7, offset1 | (b1 >> 2));
         // a0
-        TT_SFPLOAD(z, INT32, ADDR_MOD_7, offset0);
+        TT_SFPLOAD(a0, INT32, ADDR_MOD_7, offset0);
         // b2
         TT_SFPLOADMACRO((2 << 2) | (b2 & 3), INT32, ADDR_MOD_7, offset1 | (b2 >> 2));
         // c = mul24_hi(a0, b2)
-        TTI_SFPMUL24(z, b2, p_sfpu::LCONST_0, c, 1);
+        TTI_SFPMUL24(a0, b2, p_sfpu::LCONST_0, c, 1);
         // b1 = b1 + a1
         TTI_SFPIADD(0, a1, b1, SFPIADD_MOD1_CC_NONE);
         // c
@@ -52,13 +53,11 @@ inline void mul_int32(const uint dst_index_in0, const uint dst_index_in1, const 
 
 template <bool APPROXIMATION_MODE>
 inline void mul_int32_init() {
-
-    constexpr uint z = 0;
     constexpr uint b1 = 2;
     constexpr uint c = 4;
 
     TTI_SFPSHFT2(-23 & 0xfff, 0, 12, 6);
-    TTI_SFPMUL24(z, 0, p_sfpu::LCONST_0, 13, 0);
+    TTI_SFPMUL24(0, 0, p_sfpu::LCONST_0, 13, 0);
     TTI_SFPSHFT(23, b1, 14, 1 | 4);
     TTI_SFPIADD(0, c, 15, SFPIADD_MOD1_CC_NONE);
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_mul_int32.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_mul_int32.h
@@ -12,14 +12,14 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_mul_int32_init() {
-    llk_math_eltwise_binary_sfpu_init<SfpuType::mul_int32, APPROXIMATE>(ckernel::sfpu::mul_int32_init<APPROXIMATE>);
+    llk_math_eltwise_binary_sfpu_init<SfpuType::mul_int32, APPROXIMATE>(sfpu::mul_int32_init<APPROXIMATE>);
 }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_mul_int32(
     uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
     _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::mul_int32<APPROXIMATE>, dst_index0, dst_index1, odst, vector_mode);
+        sfpu::mul_int32<APPROXIMATE>, dst_index0, dst_index1, odst, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_mul_int32.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_mul_int32.h
@@ -12,7 +12,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_mul_int32_init() {
-    llk_math_eltwise_binary_sfpu_init<SfpuType::unused, APPROXIMATE>();
+    llk_math_eltwise_binary_sfpu_init<SfpuType::mul_int32, APPROXIMATE>(ckernel::sfpu::mul_int32_init<APPROXIMATE>);
 }
 
 template <bool APPROXIMATE>

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/common/binary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/common/binary_op_utils.cpp
@@ -401,12 +401,16 @@ std::map<std::string, std::string> get_defines_fp32(
             new_defines.merge(get_defines(UnaryOpType::NEZ, std::nullopt, "PRE_IN0_0", "0", input_a_dtype));
             new_defines.merge(get_defines(UnaryOpType::NEZ, std::nullopt, "PRE_IN1_0", "0", input_b_dtype));
             if (input_a_dtype == DataType::INT32 && input_b_dtype == DataType::INT32) {
+                new_defines.insert({"MUL_INT32_INIT", fmt::format("mul_int32_tile_init();")});
                 op_name = "mul_int32_tile";
             } else if (input_a_dtype == DataType::UINT32 && input_b_dtype == DataType::UINT32) {
+                new_defines.insert({"MUL_INT32_INIT", fmt::format("mul_int32_tile_init();")});
                 op_name = "mul_uint32_tile";
             } else if (input_a_dtype == DataType::UINT16 && input_b_dtype == DataType::UINT16) {
+                new_defines.insert({"MUL_INT_INIT", fmt::format("mul_int_tile_init();")});
                 op_name = "mul_uint16_tile";
             } else {
+                new_defines.insert({"BINOP_INIT", fmt::format("mul_binary_tile_init();")});
                 op_name = "mul_binary_tile";
             }
             new_defines.merge(get_defines(UnaryOpType::NEZ, std::nullopt, "0", idst1, input_a_dtype));


### PR DESCRIPTION
## This is a carbon copy of #32634 by @jasondavies 

### Ticket
#32494

### Problem description

Optimise int32 multiplication (~11x faster).

### What's changed

- Use SFPLOADMACRO.
- Requires tt-llk initialisation of `ADDR_MOD_6`.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/19538459023) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/19548673502) CI with demo tests passes (if applicable)
- [x] [C++ APC tests](https://github.com/tenstorrent/tt-metal/actions/runs/19549047928) CI passes