### PR TITLE
[Fabric] Fix 1D Ring handling

### DIFF
--- a/tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_1x8_mesh_graph_descriptor.textproto
+++ b/tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_1x8_mesh_graph_descriptor.textproto
@@ -3,7 +3,7 @@
 mesh_descriptors {
   name: "M0"
   arch: WORMHOLE_B0
-  device_topology { dims: [ 1, 8 ] dim_types: [ RING, RING ] }
+  device_topology { dims: [ 1, 8 ] }
   host_topology   { dims: [ 1, 1 ] }
   channels {
     count: 2

--- a/tests/tt_metal/tt_fabric/fabric_router/test_multi_host.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_multi_host.cpp
@@ -601,7 +601,7 @@ TEST(MultiHost, TestBHQB4x4Fabric1DSanity) {
 
     // Intra-mesh adjacency count is determined by the MGD, independent of fabric config
     const auto& intramesh_connections = get_all_intramesh_connections(control_plane);
-    EXPECT_EQ(intramesh_connections.size(), 96);  // MESH. Convert to 128 for TORUS_XY
+    EXPECT_EQ(intramesh_connections.size(), 128);
 
     for (const auto& [src_node_id, dst_node_id] : intramesh_connections) {
         const auto& direction = control_plane.get_forwarding_direction(src_node_id, dst_node_id);

--- a/tests/tt_metal/tt_fabric/fabric_router/test_routing_tables.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_routing_tables.cpp
@@ -42,16 +42,6 @@ std::unique_ptr<tt::tt_fabric::ControlPlane> make_control_plane(
     return control_plane;
 }
 
-constexpr auto kFabricConfig1D = tt::tt_fabric::FabricConfig::FABRIC_1D_RING;
-
-std::unique_ptr<tt::tt_fabric::ControlPlane> make_control_plane_1d(const std::filesystem::path& graph_desc) {
-    auto control_plane = std::make_unique<tt::tt_fabric::ControlPlane>(graph_desc.string());
-    control_plane->initialize_fabric_context(kFabricConfig1D);
-    control_plane->configure_routing_tables_for_fabric_ethernet_channels(kFabricConfig1D, kReliabilityMode);
-
-    return control_plane;
-}
-
 }  // namespace
 
 namespace tt::tt_fabric::fabric_router_tests {
@@ -125,46 +115,18 @@ TEST_F(ControlPlaneFixture, TestT3kFabricRoutes) {
     }
 }
 
-TEST_F(ControlPlaneFixture, TestT3k1x8FabricRoutes) {
-    const std::filesystem::path t3k_mesh_graph_desc_path =
-        std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
-        "tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_1x8_mesh_graph_descriptor.textproto";
-    auto control_plane = make_control_plane_1d(t3k_mesh_graph_desc_path);
-
-    auto valid_chans = control_plane->get_valid_eth_chans_on_routing_plane(FabricNodeId(MeshId{0}, 0), 0);
-    EXPECT_GT(valid_chans.size(), 0);
-    for (auto chan : valid_chans) {
-        auto path = control_plane->get_fabric_route(FabricNodeId(MeshId{0}, 0), FabricNodeId(MeshId{0}, 7), chan);
-        EXPECT_EQ(!path.empty(), true);
-    }
-    valid_chans = control_plane->get_valid_eth_chans_on_routing_plane(FabricNodeId(MeshId{0}, 0), 1);
-    EXPECT_GT(valid_chans.size(), 0);
-    for (auto chan : valid_chans) {
-        auto path = control_plane->get_fabric_route(FabricNodeId(MeshId{0}, 0), FabricNodeId(MeshId{0}, 7), chan);
-        EXPECT_EQ(!path.empty(), true);
-    }
-
-    // Test that all forwarding directions are valid
-    auto src_fabric_node_id = FabricNodeId(MeshId{0}, 0);
-    for (unsigned int x = 1; x < 8; ++x) {
-        auto dst_fabric_node_id = FabricNodeId(MeshId{0}, x);
-        auto forwarding_direction = control_plane->get_forwarding_direction(src_fabric_node_id, dst_fabric_node_id);
-        EXPECT_EQ(forwarding_direction.has_value(), true);
-    }
-}
-
 TEST_F(ControlPlaneFixture, TestSingleGalaxy1x32ControlPlaneInit) {
     const std::filesystem::path galaxy_6u_mesh_graph_desc_path =
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
         "tests/tt_metal/tt_fabric/custom_mesh_descriptors/galaxy_1x32_mesh_graph_descriptor.textproto";
-    auto control_plane = make_control_plane_1d(galaxy_6u_mesh_graph_desc_path);
+    auto control_plane = make_control_plane(galaxy_6u_mesh_graph_desc_path);
 }
 
 TEST_F(ControlPlaneFixture, TestSingleGalaxy1x32FabricRoutes) {
     const std::filesystem::path galaxy_6u_mesh_graph_desc_path =
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
         "tests/tt_metal/tt_fabric/custom_mesh_descriptors/galaxy_1x32_mesh_graph_descriptor.textproto";
-    auto control_plane = make_control_plane_1d(galaxy_6u_mesh_graph_desc_path);
+    auto control_plane = make_control_plane(galaxy_6u_mesh_graph_desc_path);
 
     // Test routing from first chip (0) to last chip (31) in the 1x32 topology
     auto valid_chans = control_plane->get_valid_eth_chans_on_routing_plane(FabricNodeId(MeshId{0}, 0), 0);
@@ -180,14 +142,6 @@ TEST_F(ControlPlaneFixture, TestSingleGalaxy1x32FabricRoutes) {
     for (auto chan : valid_chans) {
         auto path = control_plane->get_fabric_route(FabricNodeId(MeshId{0}, 0), FabricNodeId(MeshId{0}, 31), chan);
         EXPECT_EQ(!path.empty(), true);
-    }
-
-    // Test that all forwarding directions are valid
-    auto src_fabric_node_id = FabricNodeId(MeshId{0}, 0);
-    for (unsigned int x = 1; x < 32; ++x) {
-        auto dst_fabric_node_id = FabricNodeId(MeshId{0}, x);
-        auto forwarding_direction = control_plane->get_forwarding_direction(src_fabric_node_id, dst_fabric_node_id);
-        EXPECT_EQ(forwarding_direction.has_value(), true);
     }
 }
 

--- a/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/Sys_eng_smoke_tests/test_ccl_smoke_test_qb.py
+++ b/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/Sys_eng_smoke_tests/test_ccl_smoke_test_qb.py
@@ -166,7 +166,7 @@ def test_ccl_ddr_smoke_test(
 @pytest.mark.parametrize("num_workers_per_link", [2])
 @pytest.mark.parametrize("num_buffers_per_channel", [2])
 def test_ccl_other_smoke_test(
-    bh_1d_mesh_device,
+    bh_2d_mesh_device,
     num_devices,
     ag_output_shape,
     dim,
@@ -182,8 +182,8 @@ def test_ccl_other_smoke_test(
     num_workers_per_link,
     num_buffers_per_channel,
 ):
-    validate_test(num_devices, all_gather_topology, bh_1d_mesh_device.shape, 0)
-    submesh_device = bh_1d_mesh_device.create_submesh(ttnn.MeshShape((num_devices, 1)))
+    validate_test(num_devices, all_gather_topology, bh_2d_mesh_device.shape, 0)
+    submesh_device = bh_2d_mesh_device.create_submesh(ttnn.MeshShape((num_devices, 1)))
     run_all_gather_impl(
         submesh_device,
         num_devices,

--- a/tt_metal/fabric/fabric_host_utils.cpp
+++ b/tt_metal/fabric/fabric_host_utils.cpp
@@ -29,17 +29,8 @@ bool is_tt_fabric_config(tt::tt_fabric::FabricConfig fabric_config) {
 }
 
 FabricType get_fabric_type(tt::tt_fabric::FabricConfig fabric_config) {
-    auto cluster_type = tt::tt_metal::MetalContext::instance().get_cluster().get_cluster_type();
     switch (fabric_config) {
-        // Issue: 32146, Special case for T3k WH devices to use Mesh fabric type instead of Torus_XY
-        // WH T3K currently do not support Torus_XY fabric type, because they do not have wrapping connections.
-        // If you want to use 1D Ring on t3k please use 1x8 MGD.
-        case tt::tt_fabric::FabricConfig::FABRIC_1D_RING: {
-            if (cluster_type == tt::tt_metal::ClusterType::GALAXY) {
-                return FabricType::TORUS_XY;
-            }
-            return FabricType::MESH;
-        }
+        case tt::tt_fabric::FabricConfig::FABRIC_1D_RING: return FabricType::TORUS_XY;
         case tt::tt_fabric::FabricConfig::FABRIC_2D_TORUS_X: return FabricType::TORUS_X;
         case tt::tt_fabric::FabricConfig::FABRIC_2D_TORUS_Y: return FabricType::TORUS_Y;
         case tt::tt_fabric::FabricConfig::FABRIC_2D_TORUS_XY: return FabricType::TORUS_XY;

--- a/tt_metal/fabric/mesh_graph.cpp
+++ b/tt_metal/fabric/mesh_graph.cpp
@@ -338,6 +338,14 @@ void MeshGraph::initialize_from_mgd(const MeshGraphDescriptor& mgd, std::optiona
 
         if (fabric_config.has_value()) {
             FabricType requested_fabric_type = get_fabric_type(*fabric_config);
+
+            // 1D Ring is a special case where it can utilize torus links if present, else fallback
+            // to using folded connections on corner chips
+            if (*fabric_config == FabricConfig::FABRIC_1D_RING && mgd_fabric_type == FabricType::MESH) {
+                // override requested_fabric_type to MESH as fallback
+                requested_fabric_type = FabricType::MESH;
+            }
+
             // Validate that FabricConfig doesn't try to create connections that don't exist
             if (requires_more_connectivity(requested_fabric_type, mgd_fabric_type, mesh_shape)) {
                 TT_THROW(
@@ -472,6 +480,14 @@ void MeshGraph::initialize_from_mgd(const MeshGraphDescriptor& mgd, std::optiona
 
         if (fabric_config.has_value()) {
             FabricType requested_fabric_type = get_fabric_type(*fabric_config);
+
+            // 1D Ring is a special case where it can utilize torus links if present, else fallback
+            // to using folded connections on corner chips
+            if (*fabric_config == FabricConfig::FABRIC_1D_RING && mgd_fabric_type == FabricType::MESH) {
+                // override requested_fabric_type to MESH as fallback
+                requested_fabric_type = FabricType::MESH;
+            }
+
             // Validate that FabricConfig doesn't try to create connections that don't exist
             if (requires_more_connectivity(requested_fabric_type, mgd_fabric_type, switch_shape)) {
                 TT_THROW(


### PR DESCRIPTION
### Ticket
N/A

### Problem description
https://github.com/tenstorrent/tt-metal/pull/30864 introduced bugs with 1D Ring handling which were patched by https://github.com/tenstorrent/tt-metal/pull/32144 and https://github.com/tenstorrent/tt-metal/pull/32181. The patch handled the T3K ring by mapping it to a 1X8 Torus XY MGD. However this is not sufficient/accurate because:
1. `FabricType::TORUS_XY` is only set for galaxy clusters. This would miss cases where non-galaxy clusters could be setup in a torus XY fashion such as 4x4 BH QB. It also adds some maintenance overhead as we would need to add/verify the handling for every new cluster that is brought up.
2. Setting up the T3K 1X8 MGD as Torus XY also might be a bit misleading/confusing as there are no actual physical torus connections.
3. In the current fabric init flow, setting up as 1XN Torus MGD doesnt directly translate to (or guarantee) a ring setup because
    1. The mesh device 'concept' isnt tied to the fabric init flow yet, that is when setting up fabric the shape of the mesh device has no role.
    2. To setup the 1D ring, we might need to fold the fabric connections on a chip. Currently this folding happens only for corner chips on the mesh and not for any other chips.

### What's changed
Currently 1D Ring setup on T3K works because we fold the fabric connections on the corner chips. The following diagram shows how the fabric is setup for 1D ring case.

<img width="720" height="351" alt="image" src="https://github.com/user-attachments/assets/7cb940b3-f80b-4854-83f5-715408e1c0ef" />


The fix in this PR handles 1D ring as a special case:
1. If the cluster has torus links the ring topology will leverage those links
2. Otherwise, we can leverage the folded connections to mimic the ring setup

Also, some of the changes that were introduced in the prior patches are being reverted in this PR to be inline with the current fix.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/19566239853)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (https://github.com/tenstorrent/tt-metal/actions/runs/19565022395)
- [x] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/19565038592)
- [x] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/19565083324)
- [x] [BH Multi-card] (https://github.com/tenstorrent/tt-metal/actions/runs/19565008509)
- [x] [vLLM Nightly] (https://github.com/tenstorrent/tt-metal/actions/runs/19565165235) (same failure as main)
- [x] [T3K Nightly] (https://github.com/tenstorrent/tt-metal/actions/runs/19566796537)
- [x] New/Existing tests provide coverage for changes