### PR TITLE
SDXL fix accuracy tests json

### DIFF
--- a/models/experimental/stable_diffusion_xl_base/utils/clip_fid_ranges.py
+++ b/models/experimental/stable_diffusion_xl_base/utils/clip_fid_ranges.py
@@ -13,7 +13,7 @@ def get_model_targets(model_name):
     with open(TARGET_JSON_PATH) as f:
         model_targets_json = json.load(f)
 
-    model_targets = model_targets_json[model_name]
+    model_targets = model_targets_json[model_name.removesuffix("-tp")]
     if model_name.endswith("-tp"):
         model_targets["perf"] = model_targets.pop("perf-tp")
 


### PR DESCRIPTION
### Problem description
We have red❌ sdxl_accuracy_test runs in Sheild CI:
- [on-Nightly run example](https://github.com/tenstorrent/tt-shield/actions/runs/19517850162/job/55875693837)
- [On-Twice-a-week run example](https://github.com/tenstorrent/tt-shield/actions/runs/19513084097/job/55861158965)
```
>       model_targets = model_targets_json[model_name]
E       KeyError: 'sdxl-tp'
```
Basicaly problem is #32328 - there is error when accessing targets.json, and json report can't be generated, accuracy with use_cfg_parallel wasn't tested with PR😅

### What's changed
- models/experimental/stable_diffusion_xl_base/utils/clip_fid_ranges.py - accessing targets.json is fixed

### Checklist
- [x] [sdxl_accuracy with and without use_cfg_parallel](https://github.com/tenstorrent/tt-shield/actions/runs/19570287403) passes
- [x] [sdxl_inpaint_accuracy with and without use_cfg_parallel](https://github.com/tenstorrent/tt-shield/actions/runs/19570362273) passes