### PR TITLE
Improve performance of accurate exponential

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
@@ -17,20 +17,20 @@ namespace sfpu {
 sfpi_inline sfpi::vFloat sfpu_exp(sfpi::vFloat val) { return _sfpu_exp_(val); }
 
 /*
- * Convert an float value to a 32-bit integer value (specialized function for exp21f and exp61f)
-
- * exp21f and exp61f rely on a float -> int conversion to compute the exponent of the integer part of the input.
- * Two functions are available: _float_to_int32_ and _float_to_int32_positive_, which use branch to handle special cases
- * With exp21f/exp61f function, some of these cases never happen (e.g. negative exponent, overflow)
+ * Both _float_to_int32_ and _float_to_int32_positive_ use branch to handle special cases
+ * With exp21f function, some of these cases never happen (e.g. negative exponent, overflow)
  * This allow for a branch free (and much smaller algorithm) to compute integer value
  *
  * The constraint on `val` is: 0 <= val < 128.0f
+ * Note: Unlike _float_to_int32_ and _float_to_int32_positive, this function assumes that
+ * value has been been divide by 2^23
+ * If that was not the case, we would have had to shift by `exp - 23` instead of `exp`
+ * This saves 1 SFPADDI instruction.
  */
 sfpi_inline sfpi::vInt _float_to_int32_for_exp21f_(sfpi::vFloat val) {
     sfpi::vInt exp = exexp(val);
     sfpi::vInt man = exman8(val);  // get mantissa with implicit bit (man in [1; 2])
-    sfpi::vInt shift = exp - 23;
-    man = sfpi::reinterpret<sfpi::vInt>(shft(sfpi::reinterpret<sfpi::vUInt>(man), shift));
+    man = sfpi::reinterpret<sfpi::vInt>(sfpi::shft(sfpi::reinterpret<sfpi::vUInt>(man), exp));
     return man;
 }
 
@@ -49,52 +49,47 @@ sfpi_inline sfpi::vInt _float_to_int32_for_exp21f_(sfpi::vFloat val) {
  */
 template <bool is_fp32_dest_acc_en = false>
 sfpi_inline sfpi::vFloat _sfpu_exp_21f_(sfpi::vFloat val) {
-    // Intermediary values can overflow if abs(val) is above 88.5f, which leads to output increasing again instead
-    // of staying at 0 (or becoming finite on large inputs). This overflow happens when `| log2(e) * val | > 127.0f`,
-    // which correspond to `|val| > 88.5f`
-    // Intermediary values can overflow if values exceeds 88.72283935546875 or -88.72283172607421875
-    // To prevent this, we clamp -88.5 < x < 89
-    // (thresholds values are rounded to bf16, as it does not change result but only requires one SFPLOADI vs. two)
-    sfpi::vFloat threshold_high = sfpi::vFloat(89);
-    sfpi::vFloat threshold_low = sfpi::vFloat(-88.5);
-    vec_min_max(threshold_low, val);
-    vec_min_max(val, threshold_high);
-
-    // The paper relies on the following formula (c.f. Section 2 and 3 of paper):
-    // z = (bias + x * factor * N_m); where:
-    // factor = 0x00b8aa3b (computed through log(e))
-    // bias = 0x3f800000
-    //
-    // Fundamentally, this computes exp(x) = 2**(x / ln2) = 2**(x_i) * 2**(x_f) where
+    // This function computes exp(x) by leverage mathematic properties of exp(x):
+    // That is, exp(x) = 2**(x / ln2) = 2**(x_i) * 2**(x_f) where
     // - z_i = trunc(x / ln2) (integer part)
     // - z_f = x/ln2 - trunc(x/ln2) (fractional part)
-    sfpi::vInt z = _float_to_int32_for_exp21f_(val * sfpi::vFloat(0x00b8aa3b) + sfpi::vFloat(0x3f800000));
+    //
+    // The paper relies on the following formula (c.f. Section 2 and 3 of paper):
+    // z = (bias + x * factor * N_m); where:
+    // factor = log(2) * 2^23
+    // bias = 127 * 2^23
+    // Fundamentally, the formula in the paper computes
+    // z = val * log(2) * 2^23 + 127 * 2^23
+    // This formula prepares for the computation of exp(x) = 2^(x/log(2))
+    //
+    // In our case, we will let the multiplication by 2^23 be done implicitly in _float_to_int32_exp21f_ function
+    constexpr float ONE_LN2 = 1.4426950216293334961f;
+    sfpi::vFloat xlog2 = (val * ONE_LN2 + 127.f);
+
+    // Intermedirary values can overflow in xlog2 is outside of [0, 256[ which leads to invalid resutls instead of 0
+    // (when input < -88.5) and +inf (when input > 88.5)
+    // To avoid this, we clamp xlog2 to [0, 255]
+    // (thresholds values are rounded to bf16, as it does not change result but only requires one SFPLOADI vs. two)
+    sfpi::vFloat threshold_low = 0.f;
+    sfpi::vFloat threshold_high = sfpi::vFloat(255.f);
+    vec_min_max(threshold_low, xlog2);
+    vec_min_max(xlog2, threshold_high);
+
+    sfpi::vInt z = _float_to_int32_for_exp21f_(xlog2);
+
     sfpi::vInt exponential_part =
         exexp_nodebias(sfpi::reinterpret<sfpi::vFloat>(z));  // Extract exponent ( = 2**(integer part of val/ln2))
     sfpi::vInt fractional_part =
         sfpi::exman9(sfpi::reinterpret<sfpi::vFloat>(z));  // Extract mantissa ( = leftover part, in [0; 1])
 
-    // To refine approximation of 2**(x_f), we use an approximation of 2**x on [0; 1]
+    sfpi::vFloat frac = sfpi::int32_to_float(fractional_part, 0);
+
+    // To refine approximation of 2**(x_f), we use an approximation of 2**x on [0; 2^23]
     // This uses a 2nd degree polynomial adjustment of the fractional part
-    constexpr float POLY_D1 = 0.40196114e-7f;
-    constexpr int POLY_D2 = 0xf94ee7;
-    constexpr int POLY_D3 = 0x560e;
-    constexpr float POLY_D1_MUL_POLY_D2 = POLY_D1 * static_cast<float>(POLY_D2);
-
-    // Compute polynomial through Horner's method
-    // Unrolled d1(d2 + f)(d3 + f) to (d1*d2 + d1*f)(d3 + f) to use MAD
-    sfpi::vFloat p1 =
-        sfpi::vFloat(POLY_D1) * sfpi::int32_to_float(fractional_part, 0) + sfpi::vFloat(POLY_D1_MUL_POLY_D2);
-    sfpi::vFloat p2 = sfpi::int32_to_float(sfpi::vInt(POLY_D3) + fractional_part, 0);
-
-    // Compute 2**(adjusted fractional part) through float -> int conversion
-    fractional_part = _float_to_int32_for_exp21f_(p1 * p2);
+    frac = PolynomialEvaluator::eval(frac, 1.0017248f, 7.839635491371155e-08f, 4.791750143340323e-15f);
 
     // Recombined exponent and mantissa: this is equivalent to 2**(x_i) * 2**(x_f)
-    exponential_part = sfpi::reinterpret<sfpi::vInt>(
-        sfpi::setexp(sfpi::reinterpret<sfpi::vFloat>(fractional_part), exponential_part));  // restore exponent
-
-    sfpi::vFloat y = sfpi::reinterpret<sfpi::vFloat>(exponential_part);
+    sfpi::vFloat y = sfpi::setexp(frac, exponential_part);
 
     if constexpr (!is_fp32_dest_acc_en) {
         // LRegs work on float32 data. If DST is bfloat16 then SFPSTORE will truncate it.
@@ -107,34 +102,66 @@ sfpi_inline sfpi::vFloat _sfpu_exp_21f_(sfpi::vFloat val) {
     return y;
 }
 
+/*
+ * This function implements the exponential function using a polynomial approximation algorithm
+ * based on "Simple Multiple Precision Algorithms for Exponential Functions [Tips & Tricks]"
+ * by Moroz et al. 2022 (https://doi.org/10.1109/MSP.2022.3157460).
+ * More specifically, it is the implementation of the `exp_61f` algorithm described in Section 5
+ *
+ * @param val The input value (sfpi::vFloat vector), can be any floating point number
+ *
+ * @return sfpi::vFloat Result of exp(val)
+ *
+ * @see Moroz et al. 2022 - "Simple Multiple Precision Algorithms for Exponential Functions"
+ *      ( https://doi.org/10.1109/MSP.2022.3157460 )
+ */
 sfpi_inline sfpi::vFloat _sfpu_exp_61f_(sfpi::vFloat val) {
-    sfpi::vFloat y = sfpi::vConst0;
-    v_if(val > -87.3f) {
-        // The paper relies on the following formula (c.f. Section 2 and 3 of paper):
-        // z = (bias + x * factor * N_m; where:
-        // factor = 0x00b8aa3b (computed through log(e))
-        // bias = 0x3f800000
-        sfpi::vInt z = _float_to_int32_for_exp21f_(val * sfpi::vFloat(0x00b8aa3b) + sfpi::vFloat(0x3f800000));
-        sfpi::vInt zii = sfpi::exexp(sfpi::reinterpret<sfpi::vFloat>(z));   // Extract exponent
-        sfpi::vInt zif = sfpi::exman9(sfpi::reinterpret<sfpi::vFloat>(z));  // Extract mantissa
+    // This function computes exp(x) by leverage mathematic properties of exp(x):
+    // That is, exp(x) = 2**(x / ln2) = 2**(x_i) * 2**(x_f) where
+    // - z_i = trunc(x / ln2) (integer part)
+    // - z_f = x/ln2 - trunc(x/ln2) (fractional part)
+    //
+    // The paper relies on the following formula (c.f. Section 2 and 3 of paper):
+    // z = (bias + x * factor * N_m); where:
+    // factor = log(2) * 2^23
+    // bias = 127 * 2^23
+    // Fundamentally, the formula in the paper computes
+    // z = val * log(2) * 2^23 + 127 * 2^23
+    // This formula prepares for the computation of exp(x) = 2^(x/log(2))
+    //
+    // In our case, we will let the multiplication by 2^23 be done implicitly in _float_to_int32_exp21f_ function
+    constexpr float ONE_LN2 = 1.4426950216293334961f;
+    sfpi::vFloat xlog2 = val * ONE_LN2 + 127.f;
 
-        // Normalize mantissa field into a fractional value in [0,1)
-        sfpi::vFloat frac = sfpi::int32_to_float(zif, 0) * sfpi::vFloat(1.1920929e-7f);
+    // Intermedirary values can overflow in xlog2 is outside of [0, 256[ which leads to invalid resutls instead of 0
+    // (when input < -88.5) and +inf (when input > 88.5)
+    // To avoid this, we clamp xlog2 to [0, 255]
+    // (thresholds values are rounded to bf16, as it does not change result but only requires one SFPLOADI vs. two)
+    sfpi::vFloat threshold_low = 0.f;
+    sfpi::vFloat threshold_high = sfpi::vFloat(255.f);
+    vec_min_max(threshold_low, xlog2);
+    vec_min_max(xlog2, threshold_high);
 
-        // Evaluate degree-6 polynomial coefficients using Horner’s rule
-        // Note: Unlike exp_21f, in exp_61f all polynomial coefficients are floating-point values.
-        // In exp_21f, the paper mixes integer and float constants to perform bit-level manipulation of the exponent and
-        // mantissa fields (using bit manipulation techniques - BMT) for exactness. In exp_61f, all coefficients are
-        // floating-point values derived from the Chebyshev polynomial approach, making the implementation simpler and
-        // purely mathematical without integer-based operations.
-        sfpi::vFloat poly = POLYVAL7<sfpi::vFloat>(
-            0.0002170391f, 0.001243946f, 0.0096788315f, 0.055483369f, 0.24022982f, 0.69314699f, 1.0000000018f, frac);
+    sfpi::vInt z = _float_to_int32_for_exp21f_(xlog2);
 
-        // Restore exponent
-        zii = sfpi::reinterpret<sfpi::vInt>(sfpi::setexp(poly, 127U + zii));
-        y = sfpi::reinterpret<sfpi::vFloat>(zii);
-    }
-    v_endif;
+    sfpi::vInt exponential_part =
+        exexp_nodebias(sfpi::reinterpret<sfpi::vFloat>(z));  // Extract exponent ( = 2**(integer part of val/ln2))
+    sfpi::vInt fractional_part =
+        sfpi::exman9(sfpi::reinterpret<sfpi::vFloat>(z));  // Extract mantissa ( = leftover part, in [0; 1])
+
+    sfpi::vFloat frac = sfpi::int32_to_float(fractional_part, 0);
+    // Multiply by 2^-23
+    // We could have scaled polynomial coefficients, but the last one would have been near the subnormal range (i.e.
+    // truncation risk)
+    frac = sfpi::addexp(frac, -23);
+
+    // To refine approximation of 2**(x_f), we use an approximation of 2**x on [0; 1]
+    // This uses a 2nd degree polynomial adjustment of the fractional part
+    frac = PolynomialEvaluator::eval(
+        frac, sfpi::vConst1, 0.69314699f, 0.24022982f, 0.055483369f, 0.0096788315f, 0.001243946f, 0.0002170391f);
+
+    // Recombined exponent and mantissa: this is equivalent to 2**(x_i) * 2**(x_f)
+    sfpi::vFloat y = sfpi::setexp(frac, exponential_part);
 
     return y;
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
@@ -47,7 +47,7 @@ sfpi_inline sfpi::vInt _float_to_int32_for_exp21f_(sfpi::vFloat val) {
  * @see Moroz et al. 2022 - "Simple Multiple Precision Algorithms for Exponential Functions"
  *      ( https://doi.org/10.1109/MSP.2022.3157460 )
  */
-template <bool is_fp32_dest_acc_en = false>
+template <bool is_fp32_dest_acc_en>
 sfpi_inline sfpi::vFloat _sfpu_exp_21f_(sfpi::vFloat val) {
     // This function computes exp(x) by leverage mathematic properties of exp(x):
     // That is, exp(x) = 2**(x / ln2) = 2**(x_i) * 2**(x_f) where

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
@@ -28,8 +28,8 @@ sfpi_inline sfpi::vFloat sfpu_exp(sfpi::vFloat val) { return _sfpu_exp_(val); }
  * This saves 1 SFPADDI instruction.
  */
 sfpi_inline sfpi::vInt _float_to_int32_for_exp21f_(sfpi::vFloat val) {
-    sfpi::vInt exp = exexp(val);
-    sfpi::vInt man = exman8(val);  // get mantissa with implicit bit (man in [1; 2])
+    sfpi::vInt exp = sfpi::exexp(val);
+    sfpi::vInt man = sfpi::exman8(val);  // get mantissa with implicit bit (man in [1; 2])
     man = sfpi::reinterpret<sfpi::vInt>(sfpi::shft(sfpi::reinterpret<sfpi::vUInt>(man), exp));
     return man;
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
@@ -72,8 +72,8 @@ sfpi_inline sfpi::vFloat _sfpu_exp_21f_(sfpi::vFloat val) {
     // (thresholds values are rounded to bf16, as it does not change result but only requires one SFPLOADI vs. two)
     sfpi::vFloat threshold_low = 0.f;
     sfpi::vFloat threshold_high = sfpi::vFloat(255.f);
-    vec_min_max(threshold_low, xlog2);
-    vec_min_max(xlog2, threshold_high);
+    sfpi::vec_min_max(threshold_low, xlog2);
+    sfpi::vec_min_max(xlog2, threshold_high);
 
     sfpi::vInt z = _float_to_int32_for_exp21f_(xlog2);
 
@@ -139,8 +139,8 @@ sfpi_inline sfpi::vFloat _sfpu_exp_61f_(sfpi::vFloat val) {
     // (thresholds values are rounded to bf16, as it does not change result but only requires one SFPLOADI vs. two)
     sfpi::vFloat threshold_low = 0.f;
     sfpi::vFloat threshold_high = sfpi::vFloat(255.f);
-    vec_min_max(threshold_low, xlog2);
-    vec_min_max(xlog2, threshold_high);
+    sfpi::vec_min_max(threshold_low, xlog2);
+    sfpi::vec_min_max(xlog2, threshold_high);
 
     sfpi::vInt z = _float_to_int32_for_exp21f_(xlog2);
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
@@ -23,7 +23,7 @@ sfpi_inline sfpi::vFloat sfpu_exp(sfpi::vFloat val) { return _sfpu_exp_(val); }
  *
  * The constraint on `val` is: 0 <= val < 128.0f
  * Note: Unlike _float_to_int32_ and _float_to_int32_positive, this function assumes that
- * value has been been divide by 2^23
+ * value has been been divided by 2^23
  * If that was not the case, we would have had to shift by `exp - 23` instead of `exp`
  * This saves 1 SFPADDI instruction.
  */
@@ -49,7 +49,7 @@ sfpi_inline sfpi::vInt _float_to_int32_for_exp21f_(sfpi::vFloat val) {
  */
 template <bool is_fp32_dest_acc_en>
 sfpi_inline sfpi::vFloat _sfpu_exp_21f_(sfpi::vFloat val) {
-    // This function computes exp(x) by leverage mathematic properties of exp(x):
+    // This function computes exp(x) by leveraging mathematic properties of exp(x):
     // That is, exp(x) = 2**(x / ln2) = 2**(x_i) * 2**(x_f) where
     // - z_i = trunc(x / ln2) (integer part)
     // - z_f = x/ln2 - trunc(x/ln2) (fractional part)
@@ -66,7 +66,7 @@ sfpi_inline sfpi::vFloat _sfpu_exp_21f_(sfpi::vFloat val) {
     constexpr float ONE_LN2 = 1.4426950216293334961f;
     sfpi::vFloat xlog2 = (val * ONE_LN2 + 127.f);
 
-    // Intermedirary values can overflow in xlog2 is outside of [0, 256[ which leads to invalid resutls instead of 0
+    // Intermediary values can overflow in xlog2 is outside of [0, 256[ which leads to invalid results instead of 0
     // (when input < -88.5) and +inf (when input > 88.5)
     // To avoid this, we clamp xlog2 to [0, 255]
     // (thresholds values are rounded to bf16, as it does not change result but only requires one SFPLOADI vs. two)
@@ -116,7 +116,7 @@ sfpi_inline sfpi::vFloat _sfpu_exp_21f_(sfpi::vFloat val) {
  *      ( https://doi.org/10.1109/MSP.2022.3157460 )
  */
 sfpi_inline sfpi::vFloat _sfpu_exp_61f_(sfpi::vFloat val) {
-    // This function computes exp(x) by leverage mathematic properties of exp(x):
+    // This function computes exp(x) by leveraging mathematic properties of exp(x):
     // That is, exp(x) = 2**(x / ln2) = 2**(x_i) * 2**(x_f) where
     // - z_i = trunc(x / ln2) (integer part)
     // - z_f = x/ln2 - trunc(x/ln2) (fractional part)
@@ -133,7 +133,7 @@ sfpi_inline sfpi::vFloat _sfpu_exp_61f_(sfpi::vFloat val) {
     constexpr float ONE_LN2 = 1.4426950216293334961f;
     sfpi::vFloat xlog2 = val * ONE_LN2 + 127.f;
 
-    // Intermedirary values can overflow in xlog2 is outside of [0, 256[ which leads to invalid resutls instead of 0
+    // Intermediary values can overflow in xlog2 is outside of [0, 256[ which leads to invalid results instead of 0
     // (when input < -88.5) and +inf (when input > 88.5)
     // To avoid this, we clamp xlog2 to [0, 255]
     // (thresholds values are rounded to bf16, as it does not change result but only requires one SFPLOADI vs. two)

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
@@ -23,7 +23,7 @@ sfpi_inline sfpi::vFloat sfpu_exp(sfpi::vFloat val) { return _sfpu_exp_(val); }
  *
  * The constraint on `val` is: 0 <= val < 128.0f
  * Note: Unlike _float_to_int32_ and _float_to_int32_positive, this function assumes that
- * value has been been divided by 2^23
+ * value has been been divided by 2^23. Output value will be scaled by 2^23 compared to 'val'.
  * If that was not the case, we would have had to shift by `exp - 23` instead of `exp`
  * This saves 1 SFPADDI instruction.
  */

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp2.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp2.h
@@ -8,54 +8,30 @@
 
 namespace ckernel::sfpu {
 
-/**
- * This function implements binary exponentiation using a polynomial approximation algorithm
- * based on "Simple Multiple Precision Algorithms for Exponential Functions [Tips & Tricks]"
- * by Moroz et al. 2022 (https://doi.org/10.1109/MSP.2022.3157460).
- * More specifically, it is the implementation of the `exp_21f` algorithm described in Section 5
- **/
-
-template <bool is_fp32_dest_acc_en = false>
-sfpi_inline sfpi::vFloat _sfpu_exp2_21f_(sfpi::vFloat val) {
-    sfpi::vFloat y = 0.0f;
-    v_if(val > -127.f) {
-        sfpi::vInt z = _float_to_int32_for_exp21f_(val * sfpi::vFloat(0x00800000) + sfpi::vFloat(0x3f800000));
-        sfpi::vInt zii = exexp(sfpi::reinterpret<sfpi::vFloat>(z));         // Extract exponent
-        sfpi::vInt zif = sfpi::exman9(sfpi::reinterpret<sfpi::vFloat>(z));  // Extract mantissa
-
-        sfpi::vFloat d1 = sfpi::vFloat(sfpi::vConstFloatPrgm0);
-        sfpi::vFloat d2 = sfpi::int32_to_float(sfpi::vConstIntPrgm1 + zif, 0);
-        sfpi::vFloat d3 = sfpi::int32_to_float(sfpi::vConstIntPrgm2 + zif, 0);
-        d2 = d1 * d2;
-        zif = _float_to_int32_for_exp21f_(d2 * d3);
-
-        zii = sfpi::reinterpret<sfpi::vInt>(
-            sfpi::setexp(sfpi::reinterpret<sfpi::vFloat>(zif), 127U + zii));  // restore exponent
-
-        y = sfpi::reinterpret<sfpi::vFloat>(zii);
-        if constexpr (!is_fp32_dest_acc_en) {
-            y = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(y, 0));
-        }
-    }
-    v_endif;
-    return y;
-}
-
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>
 inline void calculate_exp2() {
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat v = sfpi::dst_reg[0];
-        sfpi::dst_reg[0] = _sfpu_exp2_21f_<is_fp32_dest_acc_en>(v);
+
+        v = v * sfpi::vConstFloatPrgm0;
+        sfpi::vFloat result;
+
+        if constexpr (is_fp32_dest_acc_en) {
+            result = _sfpu_exp_f32_accurate_(v);
+        } else {
+            result = _sfpu_exp_21f_<true>(v);
+            result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
+        }
+
+        sfpi::dst_reg[0] = result;
         sfpi::dst_reg++;
     }
 }
 
 template <bool APPROXIMATION_MODE>
 inline void exp2_init() {
-    sfpi::vConstFloatPrgm0 = 0.40196114e-7f;
-    sfpi::vConstIntPrgm1 = 0xf94ee7;
-    sfpi::vConstIntPrgm2 = 0x560e;
+    sfpi::vConstFloatPrgm0 = 0.6931471805f;
 }
 
 }  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_expm1.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_expm1.h
@@ -10,10 +10,17 @@
 namespace ckernel::sfpu {
 
 /*
- * This function implements expm1(x) = exp(x) - 1 using a polynomial approximation algorithm
- * based on "Simple Multiple Precision Algorithms for Exponential Functions [Tips & Tricks]"
- * by Moroz et al. 2022 (https://doi.org/10.1109/MSP.2022.3157460).
- * More specifically, it is the implementation of the `exp_21f` algorithm described in Section 5
+ * This function implements expm1(x) = exp(x) - 1 using a hybrid approach to avoid
+ * catastrophic cancellation when x is close to 0.
+ *
+ * Implementation strategy:
+ * - For |x| < 0.4: Uses a 3rd-order Taylor series expansion
+ *   expm1(x) ≈ x + x²/2 + x³/6, evaluated in Horner form
+ * - For |x| >= 0.4: Calls _sfpu_exp_21f_ (based on the exp_21f algorithm from
+ *   Moroz et al. 2022) and subtracts 1
+ *
+ * The Taylor series avoids the loss of precision that would occur when subtracting
+ * two nearly equal numbers (exp(x) - 1) for small x.
  *
  * @param val The input value (sfpi::vFloat vector), can be any floating point number
  *
@@ -31,29 +38,9 @@ sfpi_inline sfpi::vFloat _sfpu_expm1_(sfpi::vFloat val) {
         // In Horner form, on reducing further : y = (val * (val * (val * 0.166f + 0.5f )+ 1)
         y = val * (sfpi::vConst1 + val * (sfpi::vFloat(0.5f) + val * sfpi::vFloat(0.166f)));
     }
-    v_elseif(val > sfpi::vFloat(-88.0f)) {
-        // Clamp to prevent overflow if x > 89
-        sfpi::vFloat threshold_high = sfpi::vFloat(89.f);
-        sfpi::vec_min_max(val, threshold_high);
-
-        // The paper relies on the following formula (c.f. Section 2 and 3 of paper):
-        // z = (bias + x * factor * N_m; where:
-        // factor = 0x00b8aa3b (computed through log(e))
-        // bias = 0x3f800000
-        sfpi::vInt z = _float_to_int32_for_exp21f_(val * sfpi::vFloat(0x00b8aa3b) + sfpi::vFloat(0x3f800000));
-        sfpi::vInt zii = exexp(sfpi::reinterpret<sfpi::vFloat>(z));
-        sfpi::vInt zif = sfpi::exman9(sfpi::reinterpret<sfpi::vFloat>(z));
-
-        sfpi::vFloat d1 = sfpi::vFloat(sfpi::vConstFloatPrgm0);
-        sfpi::vFloat d2 = sfpi::int32_to_float(sfpi::vConstIntPrgm1 + zif, 0);
-        sfpi::vFloat d3 = sfpi::int32_to_float(sfpi::vConstIntPrgm2 + zif, 0);
-        d2 = d1 * d2;
-        zif = _float_to_int32_for_exp21f_(d2 * d3);
-
-        // Restore exponent
-        zii = sfpi::reinterpret<sfpi::vInt>(sfpi::setexp(sfpi::reinterpret<sfpi::vFloat>(zif), 127U + zii));
-
-        y = sfpi::reinterpret<sfpi::vFloat>(zii) - sfpi::vConst1;
+    v_else {
+        sfpi::vFloat exp_result = _sfpu_exp_21f_<true>(val);
+        y = exp_result - sfpi::vConst1;
     }
     v_endif;
     if constexpr (!is_fp32_dest_acc_en) {

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
@@ -17,20 +17,20 @@ namespace sfpu {
 sfpi_inline sfpi::vFloat sfpu_exp(sfpi::vFloat val) { return _sfpu_exp_(val); }
 
 /*
- * Convert an float value to a 32-bit integer value (specialized function for exp21f and exp61f)
-
- * exp21f and exp61f rely on a float -> int conversion to compute the exponent of the integer part of the input.
- * Two functions are available: _float_to_int32_ and _float_to_int32_positive_, which use branch to handle special cases
- * With exp21f/exp61f function, some of these cases never happen (e.g. negative exponent, overflow)
+ * Both _float_to_int32_ and _float_to_int32_positive_ use branch to handle special cases
+ * With exp21f function, some of these cases never happen (e.g. negative exponent, overflow)
  * This allow for a branch free (and much smaller algorithm) to compute integer value
  *
  * The constraint on `val` is: 0 <= val < 128.0f
+ * Note: Unlike _float_to_int32_ and _float_to_int32_positive, this function assumes that
+ * value has been been divide by 2^23
+ * If that was not the case, we would have had to shift by `exp - 23` instead of `exp`
+ * This saves 1 SFPADDI instruction.
  */
 sfpi_inline sfpi::vInt _float_to_int32_for_exp21f_(sfpi::vFloat val) {
     sfpi::vInt exp = exexp(val);
     sfpi::vInt man = exman8(val);  // get mantissa with implicit bit (man in [1; 2])
-    sfpi::vInt shift = exp - 23;
-    man = sfpi::reinterpret<sfpi::vInt>(shft(sfpi::reinterpret<sfpi::vUInt>(man), shift));
+    man = sfpi::reinterpret<sfpi::vInt>(sfpi::shft(sfpi::reinterpret<sfpi::vUInt>(man), exp));
     return man;
 }
 
@@ -49,52 +49,47 @@ sfpi_inline sfpi::vInt _float_to_int32_for_exp21f_(sfpi::vFloat val) {
  */
 template <bool is_fp32_dest_acc_en = false>
 sfpi_inline sfpi::vFloat _sfpu_exp_21f_(sfpi::vFloat val) {
-    // Intermediary values can overflow if abs(val) is above 88.5f, which leads to output increasing again instead
-    // of staying at 0 (or becoming finite on large inputs). This overflow happens when `| log2(e) * val | > 127.0f`,
-    // which correspond to `|val| > 88.5f`
-    // Intermediary values can overflow if values exceeds 88.72283935546875 or -88.72283172607421875
-    // To prevent this, we clamp -88.5 < x < 89
-    // (thresholds values are rounded to bf16, as it does not change result but only requires one SFPLOADI vs. two)
-    sfpi::vFloat threshold_high = sfpi::vFloat(89);
-    sfpi::vFloat threshold_low = sfpi::vFloat(-88.5);
-    vec_min_max(threshold_low, val);
-    vec_min_max(val, threshold_high);
-
-    // The paper relies on the following formula (c.f. Section 2 and 3 of paper):
-    // z = (bias + x * factor * N_m; where:
-    // factor = 0x00b8aa3b (computed through log(e))
-    // bias = 0x3f800000
-    //
-    // Fundamentally, this computes exp(x) = 2**(x / ln2) = 2**(x_i) * 2**(x_f) where
+    // This function computes exp(x) by leverage mathematic properties of exp(x):
+    // That is, exp(x) = 2**(x / ln2) = 2**(x_i) * 2**(x_f) where
     // - z_i = trunc(x / ln2) (integer part)
     // - z_f = x/ln2 - trunc(x/ln2) (fractional part)
-    sfpi::vInt z = _float_to_int32_for_exp21f_(val * sfpi::vFloat(0x00b8aa3b) + sfpi::vFloat(0x3f800000));
+    //
+    // The paper relies on the following formula (c.f. Section 2 and 3 of paper):
+    // z = (bias + x * factor * N_m); where:
+    // factor = log(2) * 2^23
+    // bias = 127 * 2^23
+    // Fundamentally, the formula in the paper computes
+    // z = val * log(2) * 2^23 + 127 * 2^23
+    // This formula prepares for the computation of exp(x) = 2^(x/log(2))
+    //
+    // In our case, we will let the multiplication by 2^23 be done implicitly in _float_to_int32_exp21f_ function
+    constexpr float ONE_LN2 = 1.4426950216293334961f;
+    sfpi::vFloat xlog2 = (val * ONE_LN2 + 127.f);
+
+    // Intermedirary values can overflow in xlog2 is outside of [0, 256[ which leads to invalid resutls instead of 0
+    // (when input < -88.5) and +inf (when input > 88.5)
+    // To avoid this, we clamp xlog2 to [0, 255]
+    // (thresholds values are rounded to bf16, as it does not change result but only requires one SFPLOADI vs. two)
+    sfpi::vFloat threshold_low = 0.f;
+    sfpi::vFloat threshold_high = sfpi::vFloat(255.f);
+    vec_min_max(threshold_low, xlog2);
+    vec_min_max(xlog2, threshold_high);
+
+    sfpi::vInt z = _float_to_int32_for_exp21f_(xlog2);
+
     sfpi::vInt exponential_part =
         exexp_nodebias(sfpi::reinterpret<sfpi::vFloat>(z));  // Extract exponent ( = 2**(integer part of val/ln2))
     sfpi::vInt fractional_part =
         sfpi::exman9(sfpi::reinterpret<sfpi::vFloat>(z));  // Extract mantissa ( = leftover part, in [0; 1])
 
-    // To refine approximation of 2**(x_f), we use an approximation of 2**x on [0; 1]
+    sfpi::vFloat frac = sfpi::int32_to_float(fractional_part, 0);
+
+    // To refine approximation of 2**(x_f), we use an approximation of 2**x on [0; 2^23]
     // This uses a 2nd degree polynomial adjustment of the fractional part
-    constexpr float POLY_D1 = 0.40196114e-7f;
-    constexpr int POLY_D2 = 0xf94ee7;
-    constexpr int POLY_D3 = 0x560e;
-    constexpr float POLY_D1_MUL_POLY_D2 = POLY_D1 * static_cast<float>(POLY_D2);
-
-    // Compute polynomial through Horner's method
-    // Unrolled d1(d2 + f)(d3 + f) to (d1*d2 + d1*f)(d3 + f) to use MAD
-    sfpi::vFloat p1 =
-        sfpi::vFloat(POLY_D1) * sfpi::int32_to_float(fractional_part, 0) + sfpi::vFloat(POLY_D1_MUL_POLY_D2);
-    sfpi::vFloat p2 = sfpi::int32_to_float(sfpi::vInt(POLY_D3) + fractional_part, 0);
-
-    // Compute 2**(adjusted fractional part) through float -> int conversion
-    fractional_part = _float_to_int32_for_exp21f_(p1 * p2);
+    frac = PolynomialEvaluator::eval(frac, 1.0017248f, 7.839635491371155e-08f, 4.791750143340323e-15f);
 
     // Recombined exponent and mantissa: this is equivalent to 2**(x_i) * 2**(x_f)
-    exponential_part = sfpi::reinterpret<sfpi::vInt>(
-        sfpi::setexp(sfpi::reinterpret<sfpi::vFloat>(fractional_part), exponential_part));  // restore exponent
-
-    sfpi::vFloat y = sfpi::reinterpret<sfpi::vFloat>(exponential_part);
+    sfpi::vFloat y = sfpi::setexp(frac, exponential_part);
 
     if constexpr (!is_fp32_dest_acc_en) {
         // LRegs work on float32 data. If DST is bfloat16 then SFPSTORE will truncate it.
@@ -107,34 +102,66 @@ sfpi_inline sfpi::vFloat _sfpu_exp_21f_(sfpi::vFloat val) {
     return y;
 }
 
+/*
+ * This function implements the exponential function using a polynomial approximation algorithm
+ * based on "Simple Multiple Precision Algorithms for Exponential Functions [Tips & Tricks]"
+ * by Moroz et al. 2022 (https://doi.org/10.1109/MSP.2022.3157460).
+ * More specifically, it is the implementation of the `exp_61f` algorithm described in Section 5
+ *
+ * @param val The input value (sfpi::vFloat vector), can be any floating point number
+ *
+ * @return sfpi::vFloat Result of exp(val)
+ *
+ * @see Moroz et al. 2022 - "Simple Multiple Precision Algorithms for Exponential Functions"
+ *      ( https://doi.org/10.1109/MSP.2022.3157460 )
+ */
 sfpi_inline sfpi::vFloat _sfpu_exp_61f_(sfpi::vFloat val) {
-    sfpi::vFloat y = sfpi::vConst0;
-    v_if(val > -87.3f) {
-        // The paper relies on the following formula (c.f. Section 2 and 3 of paper):
-        // z = (bias + x * factor * N_m); where:
-        // factor = 0x00b8aa3b (computed through log(e))
-        // bias = 0x3f800000
-        sfpi::vInt z = _float_to_int32_for_exp21f_(val * sfpi::vFloat(0x00b8aa3b) + sfpi::vFloat(0x3f800000));
-        sfpi::vInt zii = sfpi::exexp(sfpi::reinterpret<sfpi::vFloat>(z));   // Extract exponent
-        sfpi::vInt zif = sfpi::exman9(sfpi::reinterpret<sfpi::vFloat>(z));  // Extract mantissa
+    // This function computes exp(x) by leverage mathematic properties of exp(x):
+    // That is, exp(x) = 2**(x / ln2) = 2**(x_i) * 2**(x_f) where
+    // - z_i = trunc(x / ln2) (integer part)
+    // - z_f = x/ln2 - trunc(x/ln2) (fractional part)
+    //
+    // The paper relies on the following formula (c.f. Section 2 and 3 of paper):
+    // z = (bias + x * factor * N_m); where:
+    // factor = log(2) * 2^23
+    // bias = 127 * 2^23
+    // Fundamentally, the formula in the paper computes
+    // z = val * log(2) * 2^23 + 127 * 2^23
+    // This formula prepares for the computation of exp(x) = 2^(x/log(2))
+    //
+    // In our case, we will let the multiplication by 2^23 be done implicitly in _float_to_int32_exp21f_ function
+    constexpr float ONE_LN2 = 1.4426950216293334961f;
+    sfpi::vFloat xlog2 = val * ONE_LN2 + 127.f;
 
-        // Normalize mantissa field into a fractional value in [0,1)
-        sfpi::vFloat frac = sfpi::int32_to_float(zif, 0) * sfpi::vFloat(1.1920929e-7f);
+    // Intermedirary values can overflow in xlog2 is outside of [0, 256[ which leads to invalid resutls instead of 0
+    // (when input < -88.5) and +inf (when input > 88.5)
+    // To avoid this, we clamp xlog2 to [0, 255]
+    // (thresholds values are rounded to bf16, as it does not change result but only requires one SFPLOADI vs. two)
+    sfpi::vFloat threshold_low = 0.f;
+    sfpi::vFloat threshold_high = sfpi::vFloat(255.f);
+    vec_min_max(threshold_low, xlog2);
+    vec_min_max(xlog2, threshold_high);
 
-        // Evaluate degree-6 polynomial coefficients using Horner’s rule
-        // Note: Unlike exp_21f, in exp_61f all polynomial coefficients are floating-point values.
-        // In exp_21f, the paper mixes integer and float constants to perform bit-level manipulation of the exponent and
-        // mantissa fields (using bit manipulation techniques - BMT) for exactness. In exp_61f, all coefficients are
-        // floating-point values derived from the Chebyshev polynomial approach, making the implementation simpler and
-        // purely mathematical without integer-based operations.
-        sfpi::vFloat poly = POLYVAL7<sfpi::vFloat>(
-            0.0002170391f, 0.001243946f, 0.0096788315f, 0.055483369f, 0.24022982f, 0.69314699f, 1.0000000018f, frac);
+    sfpi::vInt z = _float_to_int32_for_exp21f_(xlog2);
 
-        // Restore exponent
-        zii = sfpi::reinterpret<sfpi::vInt>(sfpi::setexp(poly, 127U + zii));
-        y = sfpi::reinterpret<sfpi::vFloat>(zii);
-    }
-    v_endif;
+    sfpi::vInt exponential_part =
+        exexp_nodebias(sfpi::reinterpret<sfpi::vFloat>(z));  // Extract exponent ( = 2**(integer part of val/ln2))
+    sfpi::vInt fractional_part =
+        sfpi::exman9(sfpi::reinterpret<sfpi::vFloat>(z));  // Extract mantissa ( = leftover part, in [0; 1])
+
+    sfpi::vFloat frac = sfpi::int32_to_float(fractional_part, 0);
+    // Multiply by 2^-23
+    // We could have scaled polynomial coefficients, but the last one would have been near the subnormal range (i.e.
+    // truncation risk)
+    frac = sfpi::addexp(frac, -23);
+
+    // To refine approximation of 2**(x_f), we use an approximation of 2**x on [0; 1]
+    // This uses a 2nd degree polynomial adjustment of the fractional part
+    frac = PolynomialEvaluator::eval(
+        frac, sfpi::vConst1, 0.69314699f, 0.24022982f, 0.055483369f, 0.0096788315f, 0.001243946f, 0.0002170391f);
+
+    // Recombined exponent and mantissa: this is equivalent to 2**(x_i) * 2**(x_f)
+    sfpi::vFloat y = sfpi::setexp(frac, exponential_part);
 
     return y;
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
@@ -47,7 +47,7 @@ sfpi_inline sfpi::vInt _float_to_int32_for_exp21f_(sfpi::vFloat val) {
  * @see Moroz et al. 2022 - "Simple Multiple Precision Algorithms for Exponential Functions"
  *      ( https://doi.org/10.1109/MSP.2022.3157460 )
  */
-template <bool is_fp32_dest_acc_en = false>
+template <bool is_fp32_dest_acc_en>
 sfpi_inline sfpi::vFloat _sfpu_exp_21f_(sfpi::vFloat val) {
     // This function computes exp(x) by leverage mathematic properties of exp(x):
     // That is, exp(x) = 2**(x / ln2) = 2**(x_i) * 2**(x_f) where

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
@@ -28,8 +28,8 @@ sfpi_inline sfpi::vFloat sfpu_exp(sfpi::vFloat val) { return _sfpu_exp_(val); }
  * This saves 1 SFPADDI instruction.
  */
 sfpi_inline sfpi::vInt _float_to_int32_for_exp21f_(sfpi::vFloat val) {
-    sfpi::vInt exp = exexp(val);
-    sfpi::vInt man = exman8(val);  // get mantissa with implicit bit (man in [1; 2])
+    sfpi::vInt exp = sfpi::exexp(val);
+    sfpi::vInt man = sfpi::exman8(val);  // get mantissa with implicit bit (man in [1; 2])
     man = sfpi::reinterpret<sfpi::vInt>(sfpi::shft(sfpi::reinterpret<sfpi::vUInt>(man), exp));
     return man;
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
@@ -72,8 +72,8 @@ sfpi_inline sfpi::vFloat _sfpu_exp_21f_(sfpi::vFloat val) {
     // (thresholds values are rounded to bf16, as it does not change result but only requires one SFPLOADI vs. two)
     sfpi::vFloat threshold_low = 0.f;
     sfpi::vFloat threshold_high = sfpi::vFloat(255.f);
-    vec_min_max(threshold_low, xlog2);
-    vec_min_max(xlog2, threshold_high);
+    sfpi::vec_min_max(threshold_low, xlog2);
+    sfpi::vec_min_max(xlog2, threshold_high);
 
     sfpi::vInt z = _float_to_int32_for_exp21f_(xlog2);
 
@@ -139,8 +139,8 @@ sfpi_inline sfpi::vFloat _sfpu_exp_61f_(sfpi::vFloat val) {
     // (thresholds values are rounded to bf16, as it does not change result but only requires one SFPLOADI vs. two)
     sfpi::vFloat threshold_low = 0.f;
     sfpi::vFloat threshold_high = sfpi::vFloat(255.f);
-    vec_min_max(threshold_low, xlog2);
-    vec_min_max(xlog2, threshold_high);
+    sfpi::vec_min_max(threshold_low, xlog2);
+    sfpi::vec_min_max(xlog2, threshold_high);
 
     sfpi::vInt z = _float_to_int32_for_exp21f_(xlog2);
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
@@ -23,7 +23,7 @@ sfpi_inline sfpi::vFloat sfpu_exp(sfpi::vFloat val) { return _sfpu_exp_(val); }
  *
  * The constraint on `val` is: 0 <= val < 128.0f
  * Note: Unlike _float_to_int32_ and _float_to_int32_positive, this function assumes that
- * value has been been divide by 2^23
+ * value has been been divided by 2^23
  * If that was not the case, we would have had to shift by `exp - 23` instead of `exp`
  * This saves 1 SFPADDI instruction.
  */
@@ -49,7 +49,7 @@ sfpi_inline sfpi::vInt _float_to_int32_for_exp21f_(sfpi::vFloat val) {
  */
 template <bool is_fp32_dest_acc_en>
 sfpi_inline sfpi::vFloat _sfpu_exp_21f_(sfpi::vFloat val) {
-    // This function computes exp(x) by leverage mathematic properties of exp(x):
+    // This function computes exp(x) by leveraging mathematic properties of exp(x):
     // That is, exp(x) = 2**(x / ln2) = 2**(x_i) * 2**(x_f) where
     // - z_i = trunc(x / ln2) (integer part)
     // - z_f = x/ln2 - trunc(x/ln2) (fractional part)
@@ -66,7 +66,7 @@ sfpi_inline sfpi::vFloat _sfpu_exp_21f_(sfpi::vFloat val) {
     constexpr float ONE_LN2 = 1.4426950216293334961f;
     sfpi::vFloat xlog2 = (val * ONE_LN2 + 127.f);
 
-    // Intermedirary values can overflow in xlog2 is outside of [0, 256[ which leads to invalid resutls instead of 0
+    // Intermediary values can overflow in xlog2 is outside of [0, 256[ which leads to invalid results instead of 0
     // (when input < -88.5) and +inf (when input > 88.5)
     // To avoid this, we clamp xlog2 to [0, 255]
     // (thresholds values are rounded to bf16, as it does not change result but only requires one SFPLOADI vs. two)
@@ -116,7 +116,7 @@ sfpi_inline sfpi::vFloat _sfpu_exp_21f_(sfpi::vFloat val) {
  *      ( https://doi.org/10.1109/MSP.2022.3157460 )
  */
 sfpi_inline sfpi::vFloat _sfpu_exp_61f_(sfpi::vFloat val) {
-    // This function computes exp(x) by leverage mathematic properties of exp(x):
+    // This function computes exp(x) by leveraging mathematic properties of exp(x):
     // That is, exp(x) = 2**(x / ln2) = 2**(x_i) * 2**(x_f) where
     // - z_i = trunc(x / ln2) (integer part)
     // - z_f = x/ln2 - trunc(x/ln2) (fractional part)
@@ -133,7 +133,7 @@ sfpi_inline sfpi::vFloat _sfpu_exp_61f_(sfpi::vFloat val) {
     constexpr float ONE_LN2 = 1.4426950216293334961f;
     sfpi::vFloat xlog2 = val * ONE_LN2 + 127.f;
 
-    // Intermedirary values can overflow in xlog2 is outside of [0, 256[ which leads to invalid resutls instead of 0
+    // Intermediary values can overflow in xlog2 is outside of [0, 256[ which leads to invalid results instead of 0
     // (when input < -88.5) and +inf (when input > 88.5)
     // To avoid this, we clamp xlog2 to [0, 255]
     // (thresholds values are rounded to bf16, as it does not change result but only requires one SFPLOADI vs. two)

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
@@ -23,7 +23,7 @@ sfpi_inline sfpi::vFloat sfpu_exp(sfpi::vFloat val) { return _sfpu_exp_(val); }
  *
  * The constraint on `val` is: 0 <= val < 128.0f
  * Note: Unlike _float_to_int32_ and _float_to_int32_positive, this function assumes that
- * value has been been divided by 2^23
+ * value has been been divided by 2^23. Output value will be scaled by 2^23 compared to 'val'.
  * If that was not the case, we would have had to shift by `exp - 23` instead of `exp`
  * This saves 1 SFPADDI instruction.
  */

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp2.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp2.h
@@ -8,54 +8,30 @@
 
 namespace ckernel::sfpu {
 
-/**
- * This function implements binary exponentiation using a polynomial approximation algorithm
- * based on "Simple Multiple Precision Algorithms for Exponential Functions [Tips & Tricks]"
- * by Moroz et al. 2022 (https://doi.org/10.1109/MSP.2022.3157460).
- * More specifically, it is the implementation of the `exp_21f` algorithm described in Section 5
- **/
-
-template <bool is_fp32_dest_acc_en = false>
-sfpi_inline sfpi::vFloat _sfpu_exp2_21f_(sfpi::vFloat val) {
-    sfpi::vFloat y = 0.0f;
-    v_if(val > -127.f) {
-        sfpi::vInt z = _float_to_int32_for_exp21f_(val * sfpi::vFloat(0x00800000) + sfpi::vFloat(0x3f800000));
-        sfpi::vInt zii = exexp(sfpi::reinterpret<sfpi::vFloat>(z));         // Extract exponent
-        sfpi::vInt zif = sfpi::exman9(sfpi::reinterpret<sfpi::vFloat>(z));  // Extract mantissa
-
-        sfpi::vFloat d1 = sfpi::vFloat(sfpi::vConstFloatPrgm0);
-        sfpi::vFloat d2 = sfpi::int32_to_float(sfpi::vConstIntPrgm1 + zif, 0);
-        sfpi::vFloat d3 = sfpi::int32_to_float(sfpi::vConstIntPrgm2 + zif, 0);
-        d2 = d1 * d2;
-        zif = _float_to_int32_for_exp21f_(d2 * d3);
-
-        zii = sfpi::reinterpret<sfpi::vInt>(
-            sfpi::setexp(sfpi::reinterpret<sfpi::vFloat>(zif), 127U + zii));  // restore exponent
-
-        y = sfpi::reinterpret<sfpi::vFloat>(zii);
-        if constexpr (!is_fp32_dest_acc_en) {
-            y = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(y, 0));
-        }
-    }
-    v_endif;
-    return y;
-}
-
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>
 inline void calculate_exp2() {
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat v = sfpi::dst_reg[0];
-        sfpi::dst_reg[0] = _sfpu_exp2_21f_<is_fp32_dest_acc_en>(v);
+
+        v = v * sfpi::vConstFloatPrgm0;
+        sfpi::vFloat result;
+
+        if constexpr (is_fp32_dest_acc_en) {
+            result = _sfpu_exp_f32_accurate_(v);
+        } else {
+            result = _sfpu_exp_21f_<true>(v);
+            result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
+        }
+
+        sfpi::dst_reg[0] = result;
         sfpi::dst_reg++;
     }
 }
 
 template <bool APPROXIMATION_MODE>
 inline void exp2_init() {
-    sfpi::vConstFloatPrgm0 = 0.40196114e-7f;
-    sfpi::vConstIntPrgm1 = 0xf94ee7;
-    sfpi::vConstIntPrgm2 = 0x560e;
+    sfpi::vConstFloatPrgm0 = 0.6931471805f;
 }
 
 }  // namespace ckernel::sfpu


### PR DESCRIPTION
### Ticket
#32805

### Problem description
Accurate exponential functions have room for improvement on the performance front. 

### What's changed
- Improve the execution speed of `exp_21f` and `exp_61f` SFPU Kernels. 
- Change exp2 and expm1 to have them call exp_21f or accurate fp32 exp instead of duplicating exp implementation.

### Accuracy analysis

For exp, outputs are the same as before (no accuracy change). 
For exp2, float32 accuracy improves from 20'000 ULP to ~20 ULP of error.

### Performance improvement

Note: exp+fast+approx is unchanged, and is only used as reference point.

#### Wormhole

**bfloat16**: (accurate exp defaults to exp_21f)

Name | Cycles/Datum | Cycles/Tile | Speed-up vs main
-- | -- | -- | --
exp+fast+approx | 0.18 | 189.4 | x 7.66
exp_21f (main) | 1.45 | 1417 | x 1
exp_21f (new) | 1.07 | 1161 | x 1.22


While exp_61f is unused, this PR also speeds it up by the following on float32:

Name | Cycles/Datum | Cycles/Tile | Speed-up vs main
-- | -- | -- | --
exp+fast+approx | 0.30 | 311.5 | x 8.41
exp_61 (main) | 2.56 | 2619.0 | x 1
exp_61f (new) | 1.52 | 1559.3 | x 1.68


For exp2: 

Type | Branch | Cycles/Datum | Cycles/Tile
-- | -- | -- | --
bfloat16 | main | 1.29 | 1320
bfloat16 | new | 1.15 | 1177
float32 | main | 1.38 | 1417
float32 | new | 2.49 | 2551


### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=nmaurice/faster-accurate-exp)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:nmaurice/faster-accurate-exp)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nmaurice/faster-accurate-exp)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nmaurice/faster-accurate-exp) (failures in main)
- [x] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nmaurice/faster-accurate-exp)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nmaurice/faster-accurate-exp) (unrelated failures)
- [x] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [x] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nmaurice/faster-accurate-exp)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nmaurice/faster-accurate-exp) (failures in main/unrelated)
  - [x] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))  [OK](https://github.com/tenstorrent/tt-metal/actions/runs/20828840270) and [OK](https://github.com/tenstorrent/tt-metal/actions/runs/20828842896)
  - [x] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [x] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nmaurice/faster-accurate-exp)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nmaurice/faster-accurate-exp) (failures in main/unrelated)
  - [x] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [x] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nmaurice/faster-accurate-exp)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nmaurice/faster-accurate-exp)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml)) (fails on main)
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
