### PR TITLE
[skip ci] Add Pavle to CODEOWNERS list of tt_transformers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -271,9 +271,9 @@ models/demos/ttnn_falcon7b @cfjchu @uaydonat @tenstorrent/codeowner-bypass
 models/*/vgg/ @bbradelTT @uaydonat @mbahnasTT @tenstorrent/codeowner-bypass
 models/demos/wormhole @uaydonat @yieldthought @cglagovichTT @tenstorrent/codeowner-bypass
 models/demos/t3000 @uaydonat @yieldthought @cglagovichTT @tenstorrent/codeowner-bypass
-models/tt_transformers @cglagovichTT @yieldthought @mtairum @uaydonat @gwangTT @tenstorrent/codeowner-bypass
+models/tt_transformers @cglagovichTT @yieldthought @mtairum @uaydonat @gwangTT @ppetrovicTT @tenstorrent/codeowner-bypass
 models/demos/llama3_70b_galaxy @johanna-rock-tt @kpaigwar @sraizada-tt @djordje-tt @mtairum @yalrawwashTT @alingTT @tenstorrent/codeowner-bypass
-models/tt_transformers/tt/generator*.py @cglagovichTT @yieldthought @mtairum @skhorasganiTT @uaydonat @tenstorrent/codeowner-bypass
+models/tt_transformers/tt/generator*.py @cglagovichTT @yieldthought @mtairum @skhorasganiTT @ppetrovicTT @uaydonat @tenstorrent/codeowner-bypass
 models/demos/qwen25_vl @gwangTT @yieldthought @uaydonat @tenstorrent/codeowner-bypass
 models/demos/falcon7b_common @skhorasganiTT @djordje-tt @uaydonat @tenstorrent/codeowner-bypass
 models/demos/wormhole/mamba @esmalTT @uaydonat @kpaigwar @tenstorrent/codeowner-bypass


### PR DESCRIPTION

### Problem description
Copied from [Slack conversation](https://tenstorrent.slack.com/archives/C092FVC8DFY/p1763740689333969):
> Earlier this week [@Radomir Jakovljevic](https://tenstorrent.enterprise.slack.com/team/U08AZKUDVFX) requested for you to be made co-owner of TT-Transformers, given the increasing number of contributions from the shield team.
[@Gongyu Wang](https://tenstorrent.enterprise.slack.com/team/U08JFM3CFA4) is our resident maintainer of the library. Can you add [@Pavle Petrovic](https://tenstorrent.enterprise.slack.com/team/U08E1JCDVNX) to the CODEOWNERS list?

### What's changed
Made changes to CODEOWNERS.  Welcome, @ppetrovicTT!