### PR TITLE
Add pointer validation to CBWriter

### DIFF
--- a/tt_metal/impl/debug/watcher_device_reader.cpp
+++ b/tt_metal/impl/debug/watcher_device_reader.cpp
@@ -776,7 +776,6 @@ void WatcherDeviceReader::Core::DumpAssertStatus() const {
     DumpWaypoints(true);
     DumpRingBuffer(true);
     LogRunningKernels();
-    sleep(10000);
     MetalContext::instance().watcher_server()->set_exception_message(error_msg);
     TT_THROW("Watcher detected tripped assert and stopped device.");
 }

--- a/tt_metal/impl/debug/watcher_device_reader.cpp
+++ b/tt_metal/impl/debug/watcher_device_reader.cpp
@@ -776,6 +776,7 @@ void WatcherDeviceReader::Core::DumpAssertStatus() const {
     DumpWaypoints(true);
     DumpRingBuffer(true);
     LogRunningKernels();
+    sleep(10000);
     MetalContext::instance().watcher_server()->set_exception_message(error_msg);
     TT_THROW("Watcher detected tripped assert and stopped device.");
 }

--- a/tt_metal/impl/debug/watcher_device_reader.cpp
+++ b/tt_metal/impl/debug/watcher_device_reader.cpp
@@ -775,10 +775,9 @@ void WatcherDeviceReader::Core::DumpAssertStatus() const {
     log_warning(tt::LogMetal, "{}", error_msg);
     DumpWaypoints(true);
     DumpRingBuffer(true);
-    sleep(100000);
     LogRunningKernels();
     MetalContext::instance().watcher_server()->set_exception_message(error_msg);
- //   TT_THROW("Watcher detected tripped assert and stopped device.");
+    TT_THROW("Watcher detected tripped assert and stopped device.");
 }
 
 void WatcherDeviceReader::Core::DumpPauseStatus() const {

--- a/tt_metal/impl/debug/watcher_device_reader.cpp
+++ b/tt_metal/impl/debug/watcher_device_reader.cpp
@@ -775,9 +775,10 @@ void WatcherDeviceReader::Core::DumpAssertStatus() const {
     log_warning(tt::LogMetal, "{}", error_msg);
     DumpWaypoints(true);
     DumpRingBuffer(true);
+    sleep(100000);
     LogRunningKernels();
     MetalContext::instance().watcher_server()->set_exception_message(error_msg);
-    TT_THROW("Watcher detected tripped assert and stopped device.");
+ //   TT_THROW("Watcher detected tripped assert and stopped device.");
 }
 
 void WatcherDeviceReader::Core::DumpPauseStatus() const {

--- a/tt_metal/impl/dispatch/kernels/cq_common.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_common.hpp
@@ -323,7 +323,7 @@ public:
                     }
                     // It's possible the writer_ptr wrapped and the expected pointer is at the very end of the buffer so
                     // it hasn't wrapped yet.
-                    ASSERT((adjusted_writer_ptr == expected) || (adjusted_writer_ptr == expected - buffer_size));
+                    ASSERT((adjusted_writer_ptr == expected) || ((expected == buffer_end) && (adjusted_writer_ptr == buffer_base)));
                     watch_released_ptr_ = expected;
                 }
             }
@@ -333,18 +333,12 @@ public:
             get_noc_addr_helper(downstream_noc_xy, get_semaphore<fd_core_type>(downstream_sem_id)), n, noc_idx);
     }
 
-    void initialize() {
-#if WATCHER_ASSERT_ENABLED
-        watch_released_ptr_ = buffer_base;
-#endif
-    }
-
     uint32_t additional_count{0};
 
 #if WATCHER_ASSERT_ENABLED
 private:
     // Pointer to the end of the last released page. Used for watcher assertions.
-    uint32_t watch_released_ptr_{0};
+    uint32_t watch_released_ptr_{buffer_base};
 #endif
 };
 

--- a/tt_metal/impl/dispatch/kernels/cq_common.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_common.hpp
@@ -312,7 +312,7 @@ public:
             constexpr uint32_t buffer_size = buffer_end - buffer_base;
             if constexpr (buffer_size != 0) {
                 if (n != 0) {
-                 //   uint32_t aligned_ptr = writer_ptr & ~(buffer_page_size - 1);
+                    //   uint32_t aligned_ptr = writer_ptr & ~(buffer_page_size - 1);
                     uint64_t bytes = n * buffer_page_size;
                     uint32_t expected = watch_released_ptr_ + bytes;
                     if (expected > buffer_end) {
@@ -329,9 +329,9 @@ public:
     }
 
     void initialize() {
-        #if defined(WATCHER_ENABLED)
+#if defined(WATCHER_ENABLED)
         watch_released_ptr_ = buffer_base;
-        #endif
+#endif
     }
 
     uint32_t additional_count{0};

--- a/tt_metal/impl/dispatch/kernels/cq_common.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_common.hpp
@@ -312,15 +312,14 @@ public:
             constexpr uint32_t buffer_size = buffer_end - buffer_base;
             if constexpr (buffer_size != 0) {
                 if (n != 0) {
-                    uint32_t aligned_ptr = writer_ptr & ~(buffer_page_size - 1);
+                 //   uint32_t aligned_ptr = writer_ptr & ~(buffer_page_size - 1);
                     uint64_t bytes = n * buffer_page_size;
-                    uint32_t advance_bytes = bytes % buffer_size;
-                    uint32_t expected = watch_released_ptr_ + advance_bytes;
-                    if (expected >= buffer_end) {
+                    uint32_t expected = watch_released_ptr_ + bytes;
+                    if (expected > buffer_end) {
                         expected -= buffer_size;
                     }
-                    ASSERT(aligned_ptr == expected);
-                    watch_released_ptr_ = aligned_ptr;
+                    ASSERT(writer_ptr == expected);
+                    watch_released_ptr_ = writer_ptr;
                 }
             }
         }

--- a/tt_metal/impl/dispatch/kernels/cq_common.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_common.hpp
@@ -312,7 +312,6 @@ public:
             constexpr uint32_t buffer_size = buffer_end - buffer_base;
             if constexpr (buffer_size != 0) {
                 if (n != 0) {
-                    //   uint32_t aligned_ptr = writer_ptr & ~(buffer_page_size - 1);
                     uint64_t bytes = n * buffer_page_size;
                     uint32_t expected = watch_released_ptr_ + bytes;
                     if (expected > buffer_end) {

--- a/tt_metal/impl/dispatch/kernels/cq_common.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_common.hpp
@@ -307,19 +307,22 @@ public:
 
     // Inform the consumer that n pages are available.
     FORCE_INLINE void release_pages(uint32_t n, uint32_t writer_ptr = 0, bool round_to_page_size = false) {
-#if defined(WATCHER_ENABLED)
+#if WATCHER_ASSERT_ENABLED
         if constexpr (buffer_page_size != 0) {
             constexpr uint32_t buffer_size = buffer_end - buffer_base;
             if constexpr (buffer_size != 0) {
                 if (n != 0) {
-                    // In the middle of writing a command, the writer pointer may not be aligned to the page size, but must always be past the number of pages released.
-                    uint32_t adjusted_writer_ptr = round_to_page_size ? (writer_ptr - (writer_ptr - buffer_base) % buffer_page_size) : writer_ptr;
+                    // In the middle of writing a command, the writer pointer may not be aligned to the page size, but
+                    // must always be past the number of pages released.
+                    uint32_t adjusted_writer_ptr =
+                        round_to_page_size ? (writer_ptr - (writer_ptr - buffer_base) % buffer_page_size) : writer_ptr;
                     uint64_t bytes = n * buffer_page_size;
                     uint32_t expected = watch_released_ptr_ + bytes;
                     if (expected > buffer_end) {
                         expected -= buffer_size;
                     }
-                    // It's possible the writer_ptr wrapped and the expected pointer is at the very end of the buffer so it hasn't wrapped yet.
+                    // It's possible the writer_ptr wrapped and the expected pointer is at the very end of the buffer so
+                    // it hasn't wrapped yet.
                     ASSERT((adjusted_writer_ptr == expected) || (adjusted_writer_ptr == expected - buffer_size));
                     watch_released_ptr_ = expected;
                 }
@@ -331,16 +334,17 @@ public:
     }
 
     void initialize() {
-#if defined(WATCHER_ENABLED)
+#if WATCHER_ASSERT_ENABLED
         watch_released_ptr_ = buffer_base;
 #endif
     }
 
     uint32_t additional_count{0};
 
-#if defined(WATCHER_ENABLED)
+#if WATCHER_ASSERT_ENABLED
 private:
-    static inline uint32_t watch_released_ptr_ = 0;
+    // Pointer to the end of the last released page. Used for watcher assertions.
+    uint32_t watch_released_ptr_{0};
 #endif
 };
 

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -650,7 +650,7 @@ uint32_t process_relay_paged_cmd_large(
 
         write_length -= amt_to_write;
         uint32_t npages = write_pages_to_dispatcher<0, false>(downstream_data_ptr, scratch_write_addr, amt_to_write);
-        DispatchRelayInlineState::cb_writer.release_pages(npages, downstream_data_ptr);
+        DispatchRelayInlineState::cb_writer.release_pages(npages, downstream_data_ptr, /*round_to_page_size*/ true);
 
         // TODO(pgk); we can do better on WH w/ tagging
         noc_async_read_barrier();
@@ -764,7 +764,7 @@ uint32_t process_relay_paged_cmd(uint32_t cmd_ptr, uint32_t& downstream__data_pt
             // Third step - write from DB
             uint32_t npages =
                 write_pages_to_dispatcher<0, false>(downstream_data_ptr, scratch_write_addr, amt_to_write);
-            DispatchRelayInlineState::cb_writer.release_pages(npages, downstream_data_ptr);
+            DispatchRelayInlineState::cb_writer.release_pages(npages, downstream_data_ptr, /*round_to_page_size*/ true);
 
             read_length -= amt_read;
 
@@ -884,7 +884,7 @@ void process_relay_paged_packed_sub_cmds(uint32_t total_length, uint32_t* l1_cac
 
         // Third step - write from DB
         uint32_t npages = write_pages_to_dispatcher<0, false>(downstream_data_ptr, scratch_write_addr, amt_to_write);
-        DispatchRelayInlineState::cb_writer.release_pages(npages, downstream_data_ptr);
+        DispatchRelayInlineState::cb_writer.release_pages(npages, downstream_data_ptr, /*round_to_page_size*/ true);
 
         total_length -= amt_read;
 
@@ -1017,7 +1017,7 @@ uint32_t process_relay_linear_cmd(uint32_t cmd_ptr, uint32_t& downstream_data_pt
             uint32_t npages =
                 write_pages_to_dispatcher<0, false>(downstream_data_ptr, scratch_write_addr, amt_to_write);
 
-            DispatchRelayInlineState::cb_writer.release_pages(npages, downstream_data_ptr);
+            DispatchRelayInlineState::cb_writer.release_pages(npages, downstream_data_ptr, /*round_to_page_size*/ true);
 
             read_length -= amt_to_read;
 
@@ -1371,7 +1371,7 @@ void process_relay_ringbuffer_sub_cmds(uint32_t count, uint32_t* l1_cache) {
 
         uint32_t npages = write_pages_to_dispatcher<0, false>(downstream_data_ptr, start, length);
 
-        DispatchRelayInlineState::cb_writer.release_pages(npages, downstream_data_ptr);
+        DispatchRelayInlineState::cb_writer.release_pages(npages, downstream_data_ptr, /*round_to_page_size*/ true);
         sub_cmd++;
     }
     uint32_t start = ringbuffer_start + sub_cmd->start;

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -1985,9 +1985,6 @@ void kernel_main() {
     DPRINT << "prefetcher_" << is_h_variant << is_d_variant << ": start" << ENDL();
 #endif
 
-    DispatchRelayInlineState::cb_writer.initialize();
-    DispatchSRelayInlineState::cb_writer.initialize();
-
     if (is_h_variant and is_d_variant) {
         kernel_main_hd();
     } else if (is_h_variant) {

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -662,7 +662,6 @@ uint32_t process_relay_paged_cmd_large(
         uint32_t amt_to_write = write_length;
         uint32_t npages = write_pages_to_dispatcher<1, true>(downstream_data_ptr, scratch_write_addr, amt_to_write);
 
-
         downstream_data_ptr = round_up_pow2(downstream_data_ptr, downstream_cb_page_size);
         // One page was acquired w/ the cmd in CMD_RELAY_INLINE_NOFLUSH with 16 bytes written
         DispatchRelayInlineState::cb_writer.release_pages(npages + 1, downstream_data_ptr);

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -187,7 +187,15 @@ struct DispatchRelayInlineState {
     static constexpr uint32_t downstream_cb_end_addr = downstream_cb_end;
     static constexpr uint32_t downstream_write_cmd_buf = BRISC_WR_CMD_BUF;
     static constexpr uint32_t downstream_noc_index = my_noc_index;
-    static inline CBWriter<my_downstream_cb_sem, my_noc_index, downstream_noc_xy, downstream_cb_sem> cb_writer{};
+    static inline CBWriter<
+        my_downstream_cb_sem,
+        my_noc_index,
+        downstream_noc_xy,
+        downstream_cb_sem,
+        downstream_cb_base,
+        downstream_cb_end,
+        downstream_cb_page_size>
+        cb_writer{};
 };
 
 struct DispatchSRelayInlineState {
@@ -200,7 +208,14 @@ struct DispatchSRelayInlineState {
     static constexpr uint32_t downstream_cb_end_addr = dispatch_s_buffer_end;
     static constexpr uint32_t downstream_write_cmd_buf = BRISC_WR_REG_CMD_BUF;
     static constexpr uint32_t downstream_noc_index = my_noc_index;
-    static inline CBWriter<my_dispatch_s_cb_sem_id, my_noc_index, dispatch_s_noc_xy, downstream_dispatch_s_cb_sem_id>
+    static inline CBWriter<
+        my_dispatch_s_cb_sem_id,
+        my_noc_index,
+        dispatch_s_noc_xy,
+        downstream_dispatch_s_cb_sem_id,
+        dispatch_s_buffer_base,
+        dispatch_s_buffer_end,
+        dispatch_s_cb_page_size>
         cb_writer{};
 };
 
@@ -477,7 +492,7 @@ static uint32_t process_relay_inline_cmd(uint32_t cmd_ptr, uint32_t& local_downs
 
     local_downstream_data_ptr = round_up_pow2(local_downstream_data_ptr, RelayInlineState::downstream_page_size);
     noc_async_writes_flushed();
-    RelayInlineState::cb_writer.release_pages(npages);
+    RelayInlineState::cb_writer.release_pages(npages, local_downstream_data_ptr);
     return cmd->relay_inline.stride;
 }
 
@@ -635,7 +650,7 @@ uint32_t process_relay_paged_cmd_large(
 
         write_length -= amt_to_write;
         uint32_t npages = write_pages_to_dispatcher<0, false>(downstream_data_ptr, scratch_write_addr, amt_to_write);
-        DispatchRelayInlineState::cb_writer.release_pages(npages);
+        DispatchRelayInlineState::cb_writer.release_pages(npages, downstream_data_ptr);
 
         // TODO(pgk); we can do better on WH w/ tagging
         noc_async_read_barrier();
@@ -648,9 +663,9 @@ uint32_t process_relay_paged_cmd_large(
         uint32_t npages = write_pages_to_dispatcher<1, true>(downstream_data_ptr, scratch_write_addr, amt_to_write);
 
         // One page was acquired w/ the cmd in CMD_RELAY_INLINE_NOFLUSH with 16 bytes written
-        DispatchRelayInlineState::cb_writer.release_pages(npages + 1);
+        DispatchRelayInlineState::cb_writer.release_pages(npages + 1, downstream_data_ptr);
     } else {
-        DispatchRelayInlineState::cb_writer.release_pages(1);
+        DispatchRelayInlineState::cb_writer.release_pages(1, downstream_data_ptr);
     }
 
     downstream_data_ptr = round_up_pow2(downstream_data_ptr, downstream_cb_page_size);
@@ -749,7 +764,7 @@ uint32_t process_relay_paged_cmd(uint32_t cmd_ptr, uint32_t& downstream__data_pt
             // Third step - write from DB
             uint32_t npages =
                 write_pages_to_dispatcher<0, false>(downstream_data_ptr, scratch_write_addr, amt_to_write);
-            DispatchRelayInlineState::cb_writer.release_pages(npages);
+        DispatchRelayInlineState::cb_writer.release_pages(npages, downstream_data_ptr);
 
             read_length -= amt_read;
 
@@ -769,7 +784,7 @@ uint32_t process_relay_paged_cmd(uint32_t cmd_ptr, uint32_t& downstream__data_pt
     downstream_data_ptr = round_up_pow2(downstream_data_ptr, downstream_cb_page_size);
 
     // One page was acquired w/ the cmd in CMD_RELAY_INLINE_NOFLUSH with 16 bytes written
-    DispatchRelayInlineState::cb_writer.release_pages(npages + 1);
+    DispatchRelayInlineState::cb_writer.release_pages(npages + 1, downstream_data_ptr);
 
     return CQ_PREFETCH_CMD_BARE_MIN_SIZE;
 }
@@ -869,7 +884,7 @@ void process_relay_paged_packed_sub_cmds(uint32_t total_length, uint32_t* l1_cac
 
         // Third step - write from DB
         uint32_t npages = write_pages_to_dispatcher<0, false>(downstream_data_ptr, scratch_write_addr, amt_to_write);
-        DispatchRelayInlineState::cb_writer.release_pages(npages);
+        DispatchRelayInlineState::cb_writer.release_pages(npages, downstream_data_ptr);
 
         total_length -= amt_read;
 
@@ -885,7 +900,7 @@ void process_relay_paged_packed_sub_cmds(uint32_t total_length, uint32_t* l1_cac
     downstream_data_ptr = round_up_pow2(downstream_data_ptr, downstream_cb_page_size);
 
     // One page was acquired w/ the cmd in CMD_RELAY_INLINE_NOFLUSH with 16 bytes written
-    DispatchRelayInlineState::cb_writer.release_pages(npages + 1);
+    DispatchRelayInlineState::cb_writer.release_pages(npages + 1, downstream_data_ptr);
 }
 
 template <bool cmddat_wrap_enable>
@@ -1002,7 +1017,7 @@ uint32_t process_relay_linear_cmd(uint32_t cmd_ptr, uint32_t& downstream_data_pt
             uint32_t npages =
                 write_pages_to_dispatcher<0, false>(downstream_data_ptr, scratch_write_addr, amt_to_write);
 
-            DispatchRelayInlineState::cb_writer.release_pages(npages);
+            DispatchRelayInlineState::cb_writer.release_pages(npages, downstream_data_ptr);
 
             read_length -= amt_to_read;
 
@@ -1019,7 +1034,7 @@ uint32_t process_relay_linear_cmd(uint32_t cmd_ptr, uint32_t& downstream_data_pt
     downstream_data_ptr = round_up_pow2(downstream_data_ptr, downstream_cb_page_size);
 
     // One page was acquired w/ the cmd in CMD_RELAY_INLINE_NOFLUSH
-    DispatchRelayInlineState::cb_writer.release_pages(npages + 1);
+    DispatchRelayInlineState::cb_writer.release_pages(npages + 1, downstream_data_ptr);
 
     return CQ_PREFETCH_CMD_BARE_MIN_SIZE;
 }
@@ -1125,7 +1140,7 @@ FORCE_INLINE static uint32_t process_exec_buf_relay_inline_cmd(
         RelayInlineState::downstream_noc_encoding);
     local_downstream_data_ptr = round_up_pow2(local_downstream_data_ptr, RelayInlineState::downstream_page_size);
     noc_async_writes_flushed(RelayInlineState::downstream_noc_index);
-    RelayInlineState::cb_writer.release_pages(npages);
+    RelayInlineState::cb_writer.release_pages(npages, local_downstream_data_ptr);
 
     return stride;
 }
@@ -1356,7 +1371,7 @@ void process_relay_ringbuffer_sub_cmds(uint32_t count, uint32_t* l1_cache) {
 
         uint32_t npages = write_pages_to_dispatcher<0, false>(downstream_data_ptr, start, length);
 
-        DispatchRelayInlineState::cb_writer.release_pages(npages);
+        DispatchRelayInlineState::cb_writer.release_pages(npages, downstream_data_ptr);
         sub_cmd++;
     }
     uint32_t start = ringbuffer_start + sub_cmd->start;
@@ -1364,7 +1379,7 @@ void process_relay_ringbuffer_sub_cmds(uint32_t count, uint32_t* l1_cache) {
     uint32_t npages = write_pages_to_dispatcher<1, false>(downstream_data_ptr, start, length);
 
     // One page was acquired w/ the cmd in CMD_RELAY_INLINE_NOFLUSH with 16 bytes written
-    DispatchRelayInlineState::cb_writer.release_pages(npages + 1);
+    DispatchRelayInlineState::cb_writer.release_pages(npages + 1, downstream_data_ptr);
     downstream_data_ptr = round_up_pow2(downstream_data_ptr, downstream_cb_page_size);
 }
 
@@ -1738,7 +1753,7 @@ inline void relay_raw_data_to_downstream(
             pages_to_release += extra_pages;
         }
         if (pages_to_release != 0) {
-            RelayInlineState::cb_writer.release_pages(pages_to_release);
+            RelayInlineState::cb_writer.release_pages(pages_to_release, local_downstream_data_ptr);
         }
 
         // Advance pointers and remaining


### PR DESCRIPTION
### Problem description
If there's a bug in the prefetcher code, it's possible for the downstream semaphore value to get out of sync with the data pointer that the prefetcher uses, which can cause the dispatcher not to receive all commands or for it to process garbage data.

### What's changed
Add some tracking in the CBWriter class. and an assert if the values get out of sync. This tracking is only enabled if WATCHER_ENABLED is set.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes