### PR TITLE
[TT_Train] Fix SwiGLU test crash due to xtensor lazy evaluation

### DIFF
--- a/tt-train/tests/ops/swiglu_op_test.cpp
+++ b/tt-train/tests/ops/swiglu_op_test.cpp
@@ -59,7 +59,8 @@ xt::xarray<float> swiglu_forward_reference(
     auto xw3 = xt::linalg::tensordot(x, w3_mat, {3}, {0});
 
     // SiLU activation: z * sigmoid(z)
-    auto silu = [](const xt::xarray<float>& t) {
+    // Note: Must return xt::xarray to force evaluation, not a lazy expression
+    auto silu = [](const xt::xarray<float>& t) -> xt::xarray<float> {
         auto sigmoid = 1.0f / (1.0f + xt::exp(-t));
         return t * sigmoid;
     };


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/32974

### Problem description
The `SwiGLUOpTest.SwiGLU_Basic_1x1x32x32` test crashes with segmentation faults or `std::bad_alloc` errors. The root cause is that the `silu` lambda in `swiglu_forward_reference` returns an unevaluated xtensor lazy expression that holds references to local variables. When the lambda returns, these references become dangling, causing crashes when the expression is later evaluated.

### What's changed
Added explicit return type `-> xt::xarray<float>` to the silu lambda to force immediate evaluation of the expression before returning. This ensures the computed values are returned rather than a lazy expression with dangling references to local variables.

All 7 SwiGLU tests now pass successfully.


### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [x] New/Existing tests provide coverage for changes