### PR TITLE
split_work_to_cores pybind in ttnn module

### DIFF
--- a/docs/source/ttnn/ttnn/api.rst
+++ b/docs/source/ttnn/ttnn/api.rst
@@ -52,6 +52,7 @@ Core
    ttnn.deallocate
    ttnn.reallocate
    ttnn.to_memory_config
+   ttnn.split_work_to_cores
 
 
 Tensor Creation

--- a/tests/ttnn/unit_tests/operations/debug/test_generic_op.py
+++ b/tests/ttnn/unit_tests/operations/debug/test_generic_op.py
@@ -13,9 +13,7 @@ from models.common.utility_functions import skip_for_blackhole
 
 @skip_for_blackhole("Not tested / built for Blackhole")
 def test_eltwise_exp(device):
-    num_tiles = 4
-    src_bank_id = 0
-    dst_bank_id = 0
+    num_tiles = 16
 
     shape = [1, num_tiles, 32, 32]
     data = torch.rand(shape).to(torch.bfloat16)
@@ -39,8 +37,10 @@ def test_eltwise_exp(device):
     )
     io_tensors = [input_tensor, output_tensor]
 
-    core = ttnn.CoreCoord(0, 0)
-    core_grid = ttnn.CoreRangeSet([ttnn.CoreRange(core, core)])
+    max_core = ttnn.CoreCoord(7, 7)
+    all_cores = ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 0), max_core)])
+    (_, core_grid, core_group_1, core_group_2, work_per_core1, _) = ttnn.split_work_to_cores(all_cores, num_tiles)
+    assert core_group_2 is None, "tt_metal/kernels/compute/eltwise_sfpu.cpp kernel has number of tiles to compile as compile time arg, does not support 2 core groups"
 
     input_cb_data_format = ttnn.bfloat16  # this will be mapped tt::DataFormat::Float16_b
     cb_total_size = 2 * 2 * 1024  # tt::DataFormat::Float16_b hard coded to have size 2 * 1024
@@ -73,8 +73,18 @@ def test_eltwise_exp(device):
     writer_compile_time_args = [out_cb]
     writer_compile_time_args.extend(ttnn.TensorAccessorArgs(output_tensor).get_compile_time_args())
     compute_compile_time_args = [num_tiles, 1]
-    reader_rt_args = [input_tensor.buffer_address(), num_tiles, 0]
-    writer_rt_args = [output_tensor.buffer_address(), num_tiles, 0]
+
+    num_x_cores = max_core.x + 1
+    num_y_cores = max_core.y + 1
+    reader_rt_args = [[[] for _ in range(num_y_cores)] for _ in range(num_x_cores)]
+    writer_rt_args = [[[] for _ in range(num_y_cores)] for _ in range(num_x_cores)]
+    current_tile = 0
+    for core_range in core_group_1.ranges():
+        for x in range(core_range.start.x, core_range.end.x+1):
+            for y in range(core_range.start.y, core_range.end.y+1):
+                reader_rt_args[x][y] = [input_tensor.buffer_address(), work_per_core1, current_tile]
+                writer_rt_args[x][y] = [output_tensor.buffer_address(), work_per_core1, current_tile]
+                current_tile += work_per_core1
 
     reader_kernel_descriptor = ttnn.KernelDescriptor(
         kernel_source="ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_interleaved_start_id.cpp",

--- a/tests/ttnn/unit_tests/operations/debug/test_generic_op.py
+++ b/tests/ttnn/unit_tests/operations/debug/test_generic_op.py
@@ -14,8 +14,6 @@ from models.common.utility_functions import skip_for_blackhole
 @skip_for_blackhole("Not tested / built for Blackhole")
 @pytest.mark.parametrize("num_tiles", [1, 12, 64, 128])
 def test_eltwise_exp(device, num_tiles):
-    num_tiles = 16
-
     shape = [1, num_tiles, 32, 32]
     data = torch.rand(shape).to(torch.bfloat16)
 

--- a/tests/ttnn/unit_tests/operations/debug/test_generic_op.py
+++ b/tests/ttnn/unit_tests/operations/debug/test_generic_op.py
@@ -39,7 +39,9 @@ def test_eltwise_exp(device, num_tiles):
     max_core = ttnn.CoreCoord(7, 7)
     all_cores = ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 0), max_core)])
     (_, core_grid, core_group_1, core_group_2, work_per_core1, _) = ttnn.split_work_to_cores(all_cores, num_tiles)
-    # assert core_group_2 is {}, "tt_metal/kernels/compute/eltwise_sfpu.cpp kernel has number of tiles to compile as compile time arg, does not support 2 core groups"
+    assert (
+        len(core_group_2.ranges()) == 0
+    ), "tt_metal/kernels/compute/eltwise_sfpu.cpp kernel has number of tiles to compile as compile time arg, does not support 2 core groups"
 
     input_cb_data_format = ttnn.bfloat16  # this will be mapped tt::DataFormat::Float16_b
     cb_total_size = 2 * 2 * 1024  # tt::DataFormat::Float16_b hard coded to have size 2 * 1024

--- a/ttnn/cpp/ttnn-pybind/operations/core.cpp
+++ b/ttnn/cpp/ttnn-pybind/operations/core.cpp
@@ -344,7 +344,7 @@ void py_module(py::module& module) {
         Args:
             grid_size (ttnn.CoreCoord): The size of the core grid (x, y dimensions).
             units_to_divide (int): The total number of work units to distribute.
-            row_wise (bool, optional): Whether to distribute row-wise. Defaults to False.
+            row_wise (bool, optional): Whether to distribute work by iterating row-wise. Defaults to False.
 
         Returns:
             tuple: A tuple containing:
@@ -378,7 +378,7 @@ void py_module(py::module& module) {
         Args:
             core_grid (ttnn.CoreRangeSet): The set of core ranges to distribute work across.
             units_to_divide (int): The total number of work units to distribute.
-            row_wise (bool, optional): Whether to distribute row-wise. Defaults to False.
+            row_wise (bool, optional): Whether to distribute work by iterating row-wise. Defaults to False.
 
         Returns:
             tuple: A tuple containing:

--- a/ttnn/cpp/ttnn-pybind/operations/core.cpp
+++ b/ttnn/cpp/ttnn-pybind/operations/core.cpp
@@ -354,6 +354,7 @@ void py_module(py::module& module) {
                 - core_group_2 (CoreRangeSet): Cores doing less work (empty if evenly divisible)
                 - units_per_core_group_1 (int): Work units per core in group 1
                 - units_per_core_group_2 (int): Work units per core in group 2
+
         )doc");
 
     module.def(
@@ -382,6 +383,7 @@ void py_module(py::module& module) {
                 - core_group_2 (CoreRangeSet): Cores doing less work (empty if evenly divisible)
                 - units_per_core_group_1 (int): Work units per core in group 1
                 - units_per_core_group_2 (int): Work units per core in group 2
+
         )doc");
 }
 

--- a/ttnn/cpp/ttnn-pybind/operations/core.cpp
+++ b/ttnn/cpp/ttnn-pybind/operations/core.cpp
@@ -327,6 +327,62 @@ void py_module(py::module& module) {
         py::overload_cast<const CoreCoord, const uint32_t, const CoreRangeSet&, const bool>(
             &tt::tt_metal::num_cores_to_corerangeset_in_subcoregrids),
         R"doc(Create a CoreRangeSet containing the specified number of cores starting from start_core in given subcoregrids)doc");
+
+    module.def(
+        "split_work_to_cores",
+        py::overload_cast<const CoreCoord, const uint32_t, const bool>(&tt::tt_metal::split_work_to_cores),
+        py::arg("grid_size"),
+        py::arg("units_to_divide"),
+        py::arg("row_wise") = false,
+        R"doc(
+        Split work units across cores in a grid.
+
+        This function divides a specified number of work units across cores in a grid.
+        It returns information about how the work is distributed, including core ranges
+        for different groups if work cannot be evenly divided.
+
+        Args:
+            grid_size (ttnn.CoreCoord): The size of the core grid (x, y dimensions).
+            units_to_divide (int): The total number of work units to distribute.
+            row_wise (bool, optional): Whether to distribute row-wise. Defaults to False.
+
+        Returns:
+            tuple: A tuple containing:
+                - num_cores (int): Number of cores being used
+                - all_cores (CoreRangeSet): All cores involved
+                - core_group_1 (CoreRangeSet): Cores doing more work
+                - core_group_2 (CoreRangeSet): Cores doing less work (empty if evenly divisible)
+                - units_per_core_group_1 (int): Work units per core in group 1
+                - units_per_core_group_2 (int): Work units per core in group 2
+        )doc");
+
+    module.def(
+        "split_work_to_cores",
+        py::overload_cast<const CoreRangeSet&, const uint32_t, const bool>(&tt::tt_metal::split_work_to_cores),
+        py::arg("core_grid"),
+        py::arg("units_to_divide"),
+        py::arg("row_wise") = false,
+        R"doc(
+        Split work units across cores in a CoreRangeSet.
+
+        This function divides a specified number of work units across cores in a CoreRangeSet.
+        It returns information about how the work is distributed, including core ranges
+        for different groups if work cannot be evenly divided.
+
+        Args:
+            core_grid (ttnn.CoreRangeSet): The set of core ranges to distribute work across.
+            units_to_divide (int): The total number of work units to distribute.
+            row_wise (bool, optional): Whether to distribute row-wise. Defaults to False.
+
+        Returns:
+            tuple: A tuple containing:
+                - num_cores (int): Number of cores being used
+                - all_cores (CoreRangeSet): All cores involved
+                - core_group_1 (CoreRangeSet): Cores doing more work
+                - core_group_2 (CoreRangeSet): Cores doing less work (empty if evenly divisible)
+                - units_per_core_group_1 (int): Work units per core in group 1
+                - units_per_core_group_2 (int): Work units per core in group 2
+        )doc");
 }
 
 }  // namespace ttnn::operations::core

--- a/ttnn/cpp/ttnn-pybind/operations/core.cpp
+++ b/ttnn/cpp/ttnn-pybind/operations/core.cpp
@@ -354,6 +354,12 @@ void py_module(py::module& module) {
                 - core_group_2 (CoreRangeSet): Cores doing less work (empty if evenly divisible)
                 - units_per_core_group_1 (int): Work units per core in group 1
                 - units_per_core_group_2 (int): Work units per core in group 2
+
+        Example:
+        >>> # Split 100 tiles across an 8x8 core grid
+        >>> num_cores, all_cores, core_group_1, core_group_2, units_1, units_2 = \\
+        ...     ttnn.split_work_to_cores(ttnn.CoreCoord(8, 8), 100)
+        >>> print(f"Using {num_cores} cores, {units_1} units per core in group 1, {units_2} in group 2")
         )doc");
 
     module.def(
@@ -382,6 +388,12 @@ void py_module(py::module& module) {
                 - core_group_2 (CoreRangeSet): Cores doing less work (empty if evenly divisible)
                 - units_per_core_group_1 (int): Work units per core in group 1
                 - units_per_core_group_2 (int): Work units per core in group 2
+        Example:
+        >>> # Split 100 tiles across an 8x8 core grid
+        >>> core_rangeset = ttnn.CoreRangeSet(ttnn.CoreRange(ttnn.CoreCoord(0,0), ttnn.CoreCoord(7,7)))
+        >>> num_cores, all_cores, core_group_1, core_group_2, units_1, units_2 = \\
+        ...     ttnn.split_work_to_cores(core_rangeset, 100)
+        >>> print(f"Using {num_cores} cores, {units_1} units per core in group 1, {units_2} in group 2")
         )doc");
 }
 

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -270,6 +270,7 @@ from ttnn.core import (
     dump_stack_trace_on_segfault,
     num_cores_to_corerangeset,
     num_cores_to_corerangeset_in_subcoregrids,
+    split_work_to_cores,
     get_current_command_queue_id_for_thread,
 )
 

--- a/ttnn/ttnn/core.py
+++ b/ttnn/ttnn/core.py
@@ -16,7 +16,7 @@ from ttnn.types import (
     BufferType,
 )
 
-from ttnn._ttnn.operations.core import split_work_to_cores
+split_work_to_cores = ttnn._ttnn.operations.core.split_work_to_cores
 
 set_printoptions = ttnn._ttnn.core.set_printoptions
 

--- a/ttnn/ttnn/core.py
+++ b/ttnn/ttnn/core.py
@@ -80,6 +80,46 @@ def num_cores_to_corerangeset_in_subcoregrids(
     )
 
 
+def split_work_to_cores(
+    grid_size: Union[ttnn.CoreCoord, ttnn.CoreRangeSet],
+    units_to_divide: int,
+    row_wise: bool = False,
+) -> Tuple[int, ttnn.CoreRangeSet, ttnn.CoreRangeSet, ttnn.CoreRangeSet, int, int]:
+    """
+    Split work units across cores in a grid.
+
+    This function divides a specified number of work units across cores in a grid or CoreRangeSet.
+    It returns information about how the work is distributed, including core ranges for different
+    groups if work cannot be evenly divided.
+
+    Args:
+        grid_size (ttnn.CoreCoord | ttnn.CoreRangeSet): The size of the core grid (x, y dimensions)
+            or a CoreRangeSet specifying the cores to use.
+        units_to_divide (int): The total number of work units to distribute.
+        row_wise (bool, optional): Whether to distribute row-wise. Defaults to False.
+
+    Returns:
+        tuple: A tuple containing:
+            - num_cores (int): Number of cores being used
+            - all_cores (ttnn.CoreRangeSet): All cores involved
+            - core_group_1 (ttnn.CoreRangeSet): Cores doing more work
+            - core_group_2 (ttnn.CoreRangeSet): Cores doing less work (empty if evenly divisible)
+            - units_per_core_group_1 (int): Work units per core in group 1
+            - units_per_core_group_2 (int): Work units per core in group 2
+
+    Example:
+        >>> # Split 100 tiles across an 8x8 core grid
+        >>> num_cores, all_cores, core_group_1, core_group_2, units_1, units_2 = \\
+        ...     ttnn.split_work_to_cores(ttnn.CoreCoord(8, 8), 100)
+        >>> print(f"Using {num_cores} cores, {units_1} units per core in group 1, {units_2} in group 2")
+    """
+    return ttnn._ttnn.operations.core.split_work_to_cores(
+        grid_size,
+        units_to_divide,
+        row_wise,
+    )
+
+
 def has_tile_padding(tensor, *, dim=None):
     if dim is not None:
         rank = tensor.shape.rank

--- a/ttnn/ttnn/core.py
+++ b/ttnn/ttnn/core.py
@@ -16,6 +16,8 @@ from ttnn.types import (
     BufferType,
 )
 
+from ttnn._ttnn.operations.core import split_work_to_cores
+
 set_printoptions = ttnn._ttnn.core.set_printoptions
 
 
@@ -76,46 +78,6 @@ def num_cores_to_corerangeset_in_subcoregrids(
         start_core,
         target_num_cores,
         sub_core_grids,
-        row_wise,
-    )
-
-
-def split_work_to_cores(
-    grid_size: Union[ttnn.CoreCoord, ttnn.CoreRangeSet],
-    units_to_divide: int,
-    row_wise: bool = False,
-) -> Tuple[int, ttnn.CoreRangeSet, ttnn.CoreRangeSet, ttnn.CoreRangeSet, int, int]:
-    """
-    Split work units across cores in a grid.
-
-    This function divides a specified number of work units across cores in a grid or CoreRangeSet.
-    It returns information about how the work is distributed, including core ranges for different
-    groups if work cannot be evenly divided.
-
-    Args:
-        grid_size (ttnn.CoreCoord | ttnn.CoreRangeSet): The size of the core grid (x, y dimensions)
-            or a CoreRangeSet specifying the cores to use.
-        units_to_divide (int): The total number of work units to distribute.
-        row_wise (bool, optional): Whether to distribute row-wise. Defaults to False.
-
-    Returns:
-        tuple: A tuple containing:
-            - num_cores (int): Number of cores being used
-            - all_cores (ttnn.CoreRangeSet): All cores involved
-            - core_group_1 (ttnn.CoreRangeSet): Cores doing more work
-            - core_group_2 (ttnn.CoreRangeSet): Cores doing less work (empty if evenly divisible)
-            - units_per_core_group_1 (int): Work units per core in group 1
-            - units_per_core_group_2 (int): Work units per core in group 2
-
-    Example:
-        >>> # Split 100 tiles across an 8x8 core grid
-        >>> num_cores, all_cores, core_group_1, core_group_2, units_1, units_2 = \\
-        ...     ttnn.split_work_to_cores(ttnn.CoreCoord(8, 8), 100)
-        >>> print(f"Using {num_cores} cores, {units_1} units per core in group 1, {units_2} in group 2")
-    """
-    return ttnn._ttnn.operations.core.split_work_to_cores(
-        grid_size,
-        units_to_divide,
         row_wise,
     )
 


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
when utilizing ttnn generic_op for multicore kernels, there is not a python function in ttnn to split the work amongst the cores, but there is a metal function that does this.  See tt-metal/tests/ttnn/unit_tests/gtests/test_generic_op.cpp vs single core python twin at tt-metal/tests/ttnn/unit_tests/operations/debug/test_generic_op.py 

### What's changed
added pybind in ttnn to tt::tt_metal::split_work_to_cores at tt-metal/tt_metal/common/work_split.cpp
utilizing pybind in test_generic_op.py

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes