### PR TITLE
[skip ci] Skip TT-Sim for Forks

### DIFF
--- a/.github/workflows/ai-tools.yaml
+++ b/.github/workflows/ai-tools.yaml
@@ -12,6 +12,8 @@ on:
 
 jobs:
   call-ai-assistant:
+    # Do not run on Forks, they won't have the req'd secrets.
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false }}
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/pr-gate.yaml
+++ b/.github/workflows/pr-gate.yaml
@@ -272,6 +272,7 @@ jobs:
 
   ttsim-integration-tests:
     needs: [ build ]
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false }}
     strategy:
       fail-fast: false
     uses: ./.github/workflows/ttsim.yaml


### PR DESCRIPTION
### Ticket
Fixes #32255

### Problem description
TT-Sim cannot (currently) run on Forks.

### What's changed
Don't try that which is guaranteed to fail.

BONUS: Skp AI Assistant job, too, which has the same problem and produces noise on Fork PRs.

Demo: https://github.com/tenstorrent/tt-metal/pull/32996