### PR TITLE
[skip ci] [Reduce APC] Run fabric-unit-tests on merge gate

### DIFF
--- a/.github/workflows/all-post-commit-workflows.yaml
+++ b/.github/workflows/all-post-commit-workflows.yaml
@@ -111,24 +111,6 @@ jobs:
                                   (github.event_name == 'workflow_dispatch' && inputs.force-test-everything) ||
                                   steps.find-changes.outputs['any-code-changed'] == 'true' }}" >> "$GITHUB_OUTPUT"
 
-  # Fabric Unit Tests
-  fabric-unit-tests:
-    needs: [build-artifact, find-changed-files]
-    secrets: inherit
-    strategy:
-      fail-fast: false
-      matrix:
-        test-group: [
-          { arch: wormhole_b0, runner-label: N300 },
-        ]
-    if: ${{ needs.find-changed-files.outputs.test-metalium == 'true' }}
-    uses: ./.github/workflows/fabric-build-and-unit-tests.yaml
-    with:
-      arch: ${{ matrix.test-group.arch }}
-      runner-label: ${{ matrix.test-group.runner-label }}
-      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
   # TTNN FD Unit tests
   ttnn-unit-tests:
     needs: [build-artifact, find-changed-files]

--- a/.github/workflows/fabric-build-and-unit-tests.yaml
+++ b/.github/workflows/fabric-build-and-unit-tests.yaml
@@ -19,9 +19,9 @@ on:
       docker-image:
         required: true
         type: string
-      wheel-artifact-name:
-        required: true
-        type: string
+      # wheel-artifact-name:
+      #   required: true
+      #   type: string
       enable-watcher:
         required: false
         type: boolean
@@ -66,7 +66,7 @@ jobs:
         timeout-minutes: 10
         with:
           build-artifact-name: ${{ inputs.build-artifact-name }}
-          wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
+          #wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
           enable-watcher: ${{ inputs.enable-watcher || false }}
       - name: ${{ matrix.test-group.name }} tests
         timeout-minutes: ${{ inputs.timeout }}

--- a/.github/workflows/fabric-build-and-unit-tests.yaml
+++ b/.github/workflows/fabric-build-and-unit-tests.yaml
@@ -13,9 +13,9 @@ on:
         required: false
         type: number
         default: 10
-      build-artifact-name:
-        required: true
-        type: string
+      # build-artifact-name:
+      #   required: true
+      #   type: string
       docker-image:
         required: true
         type: string
@@ -62,22 +62,13 @@ jobs:
         working-directory: /work # https://github.com/actions/runner/issues/878
     steps:
       - name: ⬇️  Setup Job
-        # uses: tenstorrent/tt-metal/.github/actions/setup-job@5b5c6ff5b54025e165d189371cda93d2b9ef6115
-        # timeout-minutes: 10
-        # with:
-        #   build-artifact-name: ${{ inputs.build-artifact-name }}
-        #   #wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
-        #   enable-watcher: ${{ inputs.enable-watcher || false }}
-        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0
+        uses: tenstorrent/tt-metal/.github/actions/setup-job@5b5c6ff5b54025e165d189371cda93d2b9ef6115
         timeout-minutes: 10
         with:
-          name: ${{ inputs.build-artifact-name || 'packages artifact unresolved!' }}
-          path: /work/pkgs/
+          #build-artifact-name: ${{ inputs.build-artifact-name }}
+          #wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
+          enable-watcher: ${{ inputs.enable-watcher || false }}
 
-      - name: Install packages
-        run: |
-          # Ideally only tt-metalium-validation, but APT doesn't resolve dependencies from files on disk without being told about them.
-          apt install -y ./pkgs/tt-metalium_*.deb ./pkgs/tt-metalium-jit_*.deb ./pkgs/tt-metalium_*.deb ./pkgs/tt-metalium-validation_*.deb
       - name: ${{ matrix.test-group.name }} tests
         timeout-minutes: ${{ inputs.timeout }}
         run: |

--- a/.github/workflows/fabric-build-and-unit-tests.yaml
+++ b/.github/workflows/fabric-build-and-unit-tests.yaml
@@ -62,12 +62,22 @@ jobs:
         working-directory: /work # https://github.com/actions/runner/issues/878
     steps:
       - name: ⬇️  Setup Job
-        uses: tenstorrent/tt-metal/.github/actions/setup-job@5b5c6ff5b54025e165d189371cda93d2b9ef6115
+        # uses: tenstorrent/tt-metal/.github/actions/setup-job@5b5c6ff5b54025e165d189371cda93d2b9ef6115
+        # timeout-minutes: 10
+        # with:
+        #   build-artifact-name: ${{ inputs.build-artifact-name }}
+        #   #wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
+        #   enable-watcher: ${{ inputs.enable-watcher || false }}
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0
         timeout-minutes: 10
         with:
-          build-artifact-name: ${{ inputs.build-artifact-name }}
-          #wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
-          enable-watcher: ${{ inputs.enable-watcher || false }}
+          name: ${{ inputs.build-artifact-name || 'packages artifact unresolved!' }}
+          path: /work/pkgs/
+
+      - name: Install packages
+        run: |
+          # Ideally only tt-metalium-validation, but APT doesn't resolve dependencies from files on disk without being told about them.
+          apt install -y ./pkgs/tt-metalium_*.deb ./pkgs/tt-metalium-jit_*.deb ./pkgs/tt-metalium_*.deb ./pkgs/tt-metalium-validation_*.deb
       - name: ${{ matrix.test-group.name }} tests
         timeout-minutes: ${{ inputs.timeout }}
         run: |

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -96,12 +96,12 @@ jobs:
         uses: tenstorrent/tt-metal/.github/actions/find-changed-files@v0.63.0
 
   build:
-    # if: ${{ github.ref_name == 'main' ||
-    #         needs.find-changes.outputs.cmake-changed == 'true' ||
-    #         needs.find-changes.outputs.any-code-changed == 'true' ||
-    #         needs.find-changes.outputs.docs-changed == 'true' ||
-    #         needs.find-changes.outputs.build-workflows-changed == 'true'
-    #     }}
+    if: ${{ github.ref_name == 'main' ||
+            needs.find-changes.outputs.cmake-changed == 'true' ||
+            needs.find-changes.outputs.any-code-changed == 'true' ||
+            needs.find-changes.outputs.docs-changed == 'true' ||
+            needs.find-changes.outputs.build-workflows-changed == 'true'
+        }}
     needs: find-changes
     uses: ./.github/workflows/build-artifact.yaml
     permissions:

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -274,8 +274,7 @@ jobs:
     needs: [build, find-changes]
     if: ${{ github.ref_name == 'main' ||
             needs.find-changes.outputs.cmake-changed == 'true' ||
-            needs.find-changes.outputs.tt-metalium-changed == 'true' ||
-            needs.find-changes.outputs.test-metalium == 'true'
+            needs.find-changes.outputs.tt-metalium-changed == 'true'
         }}
     secrets: inherit
     strategy:

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -272,11 +272,11 @@ jobs:
 
   fabric-unit-tests:
     needs: [build, find-changes]
-    # if: ${{ github.ref_name == 'main' ||
-    #         needs.find-changes.outputs.cmake-changed == 'true' ||
-    #         needs.find-changes.outputs.tt-metalium-changed == 'true' ||
-    #         needs.find-changes.outputs.test-metalium == 'true'
-    #     }}
+    if: ${{ github.ref_name == 'main' ||
+            needs.find-changes.outputs.cmake-changed == 'true' ||
+            needs.find-changes.outputs.tt-metalium-changed == 'true' ||
+            needs.find-changes.outputs.test-metalium == 'true'
+        }}
     secrets: inherit
     strategy:
       fail-fast: false

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -96,12 +96,12 @@ jobs:
         uses: tenstorrent/tt-metal/.github/actions/find-changed-files@v0.63.0
 
   build:
-    if: ${{ github.ref_name == 'main' ||
-            needs.find-changes.outputs.cmake-changed == 'true' ||
-            needs.find-changes.outputs.any-code-changed == 'true' ||
-            needs.find-changes.outputs.docs-changed == 'true' ||
-            needs.find-changes.outputs.build-workflows-changed == 'true'
-        }}
+    # if: ${{ github.ref_name == 'main' ||
+    #         needs.find-changes.outputs.cmake-changed == 'true' ||
+    #         needs.find-changes.outputs.any-code-changed == 'true' ||
+    #         needs.find-changes.outputs.docs-changed == 'true' ||
+    #         needs.find-changes.outputs.build-workflows-changed == 'true'
+    #     }}
     needs: find-changes
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
@@ -269,6 +269,28 @@ jobs:
       arch: ${{ matrix.test-group.arch }}
       runner-label: ${{ matrix.test-group.runner-label }}
       merge-gate-call: true
+
+  fabric-unit-tests:
+    needs: [build, find-changes]
+    if: ${{ github.ref_name == 'main' ||
+            needs.find-changes.outputs.cmake-changed == 'true' ||
+            needs.find-changes.outputs.tt-metalium-changed == 'true' ||
+            needs.find-changes.outputs.test-metalium == 'true'
+        }}
+    secrets: inherit
+    strategy:
+      fail-fast: false
+      matrix:
+        test-group: [
+          { arch: wormhole_b0, runner-label: N300 },
+        ]
+    uses: ./.github/workflows/fabric-build-and-unit-tests.yaml
+    with:
+      arch: ${{ matrix.test-group.arch }}
+      runner-label: ${{ matrix.test-group.runner-label }}
+      docker-image: ${{ needs.build.outputs.dev-docker-image }}
+      build-artifact-name: ${{ needs.build.outputs.build-artifact-name }}
+      wheel-artifact-name: ${{ needs.build.outputs.wheel-artifact-name }}
 
   ttsim-unit-tests:
     if: ${{ github.ref_name == 'main' ||

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -288,7 +288,6 @@ jobs:
       arch: ${{ matrix.test-group.arch }}
       runner-label: ${{ matrix.test-group.runner-label }}
       docker-image: ${{ needs.build-asan.outputs.dev-docker-image }}
-      build-artifact-name: ${{ needs.build-asan.outputs.packages-artifact-name }}
 
   ttsim-unit-tests:
     if: ${{ github.ref_name == 'main' ||

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -288,7 +288,7 @@ jobs:
       arch: ${{ matrix.test-group.arch }}
       runner-label: ${{ matrix.test-group.runner-label }}
       docker-image: ${{ needs.build-asan.outputs.dev-docker-image }}
-      build-artifact-name: ${{ needs.build-asan.outputs.build-artifact-name }}
+      build-artifact-name: ${{ needs.build-asan.outputs.packages-artifact-name }}
 
   ttsim-unit-tests:
     if: ${{ github.ref_name == 'main' ||

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -288,8 +288,7 @@ jobs:
       arch: ${{ matrix.test-group.arch }}
       runner-label: ${{ matrix.test-group.runner-label }}
       docker-image: ${{ needs.build-asan.outputs.dev-docker-image }}
-      build-artifact-name: ${{ needs.build-asan.outputs.build-artifact-name }}
-      wheel-artifact-name: ${{ needs.build-asan.outputs.wheel-artifact-name }}
+      build-artifact-name: ${{ needs.build-asan.outputs.packages-artifact-name }}
 
   ttsim-unit-tests:
     if: ${{ github.ref_name == 'main' ||

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -288,7 +288,7 @@ jobs:
       arch: ${{ matrix.test-group.arch }}
       runner-label: ${{ matrix.test-group.runner-label }}
       docker-image: ${{ needs.build-asan.outputs.dev-docker-image }}
-      build-artifact-name: ${{ needs.build-asan.outputs.packages-artifact-name }}
+      build-artifact-name: ${{ needs.build-asan.outputs.build-artifact-name }}
 
   ttsim-unit-tests:
     if: ${{ github.ref_name == 'main' ||

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -287,9 +287,9 @@ jobs:
     with:
       arch: ${{ matrix.test-group.arch }}
       runner-label: ${{ matrix.test-group.runner-label }}
-      docker-image: ${{ needs.build.outputs.dev-docker-image }}
-      build-artifact-name: ${{ needs.build.outputs.build-artifact-name }}
-      wheel-artifact-name: ${{ needs.build.outputs.wheel-artifact-name }}
+      docker-image: ${{ needs.build-asan.outputs.dev-docker-image }}
+      build-artifact-name: ${{ needs.build-asan.outputs.build-artifact-name }}
+      wheel-artifact-name: ${{ needs.build-asan.outputs.wheel-artifact-name }}
 
   ttsim-unit-tests:
     if: ${{ github.ref_name == 'main' ||

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -187,11 +187,11 @@ jobs:
       product: tt-nn
 
   build-asan:
-    if: ${{ github.ref_name == 'main' ||
-            needs.find-changes.outputs.cmake-changed == 'true' ||
-            needs.find-changes.outputs.any-code-changed == 'true' ||
-            needs.find-changes.outputs.build-workflows-changed == 'true'
-        }}
+    # if: ${{ github.ref_name == 'main' ||
+    #         needs.find-changes.outputs.cmake-changed == 'true' ||
+    #         needs.find-changes.outputs.any-code-changed == 'true' ||
+    #         needs.find-changes.outputs.build-workflows-changed == 'true'
+    #     }}
     needs: find-changes
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
@@ -271,11 +271,11 @@ jobs:
       merge-gate-call: true
 
   fabric-unit-tests:
-    needs: [build, find-changes]
-    if: ${{ github.ref_name == 'main' ||
-            needs.find-changes.outputs.cmake-changed == 'true' ||
-            needs.find-changes.outputs.tt-metalium-changed == 'true'
-        }}
+    needs: [build-asan, find-changes]
+    # if: ${{ github.ref_name == 'main' ||
+    #         needs.find-changes.outputs.cmake-changed == 'true' ||
+    #         needs.find-changes.outputs.tt-metalium-changed == 'true'
+    #     }}
     secrets: inherit
     strategy:
       fail-fast: false

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -272,11 +272,11 @@ jobs:
 
   fabric-unit-tests:
     needs: [build, find-changes]
-    if: ${{ github.ref_name == 'main' ||
-            needs.find-changes.outputs.cmake-changed == 'true' ||
-            needs.find-changes.outputs.tt-metalium-changed == 'true' ||
-            needs.find-changes.outputs.test-metalium == 'true'
-        }}
+    # if: ${{ github.ref_name == 'main' ||
+    #         needs.find-changes.outputs.cmake-changed == 'true' ||
+    #         needs.find-changes.outputs.tt-metalium-changed == 'true' ||
+    #         needs.find-changes.outputs.test-metalium == 'true'
+    #     }}
     secrets: inherit
     strategy:
       fail-fast: false


### PR DESCRIPTION
### What's changed
Remove fabric-unit-tests from APC and add it into merge gate

As discussed in this slack conversation here: https://tenstorrent.slack.com/archives/C05GRJC4J4A/p1763752448122639

### Checklist
- [x] All post commit CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/19643731667
- [x] Merge Gate passes: https://github.com/tenstorrent/tt-metal/actions/runs/19584663525
- [ ] Merge Gate with `build-asan` : https://github.com/tenstorrent/tt-metal/actions/runs/19651321333

It has less than 2% failure rate in the last 7 days
<img width="996" height="865" alt="Screenshot 2025-11-24 at 12 05 37 PM" src="https://github.com/user-attachments/assets/871a9dcf-a49d-457f-8cf1-26acc0b61eaa" />