### PR TITLE
#0: Fix Noc hop distance test to only check consistent distances based on harvesting

### DIFF
--- a/tests/tt_metal/distributed/test_mesh_device.cpp
+++ b/tests/tt_metal/distributed/test_mesh_device.cpp
@@ -139,31 +139,36 @@ TEST(GetWorkerNocHopDistanceAPI, UnitMeshes) {
     auto device_ids_set = tt::tt_metal::MetalContext::instance().get_cluster().user_exposed_chip_ids();
     std::vector<int> device_ids(device_ids_set.begin(), device_ids_set.end());
     auto devs = tt::tt_metal::distributed::MeshDevice::create_unit_meshes(device_ids);
-    for (auto& [_, dev] : devs) {
-        auto noc_0_hop_distance = tt::tt_metal::experimental::Device::get_worker_noc_hop_distance(
-            dev.get(), CoreCoord(0, 0), CoreCoord(0, 1), NOC::NOC_0);
-        auto noc_1_hop_distance = tt::tt_metal::experimental::Device::get_worker_noc_hop_distance(
-            dev.get(), CoreCoord(0, 0), CoreCoord(0, 1), NOC::NOC_1);
-        EXPECT_EQ(noc_0_hop_distance, 1);
-        EXPECT_EQ(noc_1_hop_distance, dev->grid_size().y - 1);
-        noc_0_hop_distance = tt::tt_metal::experimental::Device::get_worker_noc_hop_distance(
-            dev.get(), CoreCoord(0, 1), CoreCoord(0, 0), NOC::NOC_0);
-        noc_1_hop_distance = tt::tt_metal::experimental::Device::get_worker_noc_hop_distance(
-            dev.get(), CoreCoord(0, 1), CoreCoord(0, 0), NOC::NOC_1);
-        EXPECT_EQ(noc_0_hop_distance, dev->grid_size().y - 1);
-        EXPECT_EQ(noc_1_hop_distance, 1);
-        noc_0_hop_distance = tt::tt_metal::experimental::Device::get_worker_noc_hop_distance(
-            dev.get(), CoreCoord(0, 0), CoreCoord(1, 0), NOC::NOC_0);
-        noc_1_hop_distance = tt::tt_metal::experimental::Device::get_worker_noc_hop_distance(
-            dev.get(), CoreCoord(0, 0), CoreCoord(1, 0), NOC::NOC_1);
-        EXPECT_EQ(noc_0_hop_distance, 1);
-        EXPECT_EQ(noc_1_hop_distance, dev->grid_size().x - 1);
-        noc_0_hop_distance = tt::tt_metal::experimental::Device::get_worker_noc_hop_distance(
-            dev.get(), CoreCoord(1, 0), CoreCoord(0, 0), NOC::NOC_0);
-        noc_1_hop_distance = tt::tt_metal::experimental::Device::get_worker_noc_hop_distance(
-            dev.get(), CoreCoord(1, 0), CoreCoord(0, 0), NOC::NOC_1);
-        EXPECT_EQ(noc_0_hop_distance, dev->grid_size().x - 1);
-        EXPECT_EQ(noc_1_hop_distance, 1);
+    auto harvest_axis = tt::tt_metal::MetalContext::instance().hal().get_tensix_harvest_axis();
+    for (auto& [device_id, dev] : devs) {
+        bool unharvested = tt::tt_metal::MetalContext::instance().get_cluster().get_harvesting_mask(device_id) == 0;
+        if (unharvested || harvest_axis == HalTensixHarvestAxis::COL) {  // Only Y hop distance is consistent
+            auto noc_0_hop_distance = tt::tt_metal::experimental::Device::get_worker_noc_hop_distance(
+                dev.get(), CoreCoord(0, 0), CoreCoord(0, 1), NOC::NOC_0);
+            auto noc_1_hop_distance = tt::tt_metal::experimental::Device::get_worker_noc_hop_distance(
+                dev.get(), CoreCoord(0, 0), CoreCoord(0, 1), NOC::NOC_1);
+            EXPECT_EQ(noc_0_hop_distance, 1);
+            EXPECT_EQ(noc_1_hop_distance, dev->grid_size().y - 1);
+            noc_0_hop_distance = tt::tt_metal::experimental::Device::get_worker_noc_hop_distance(
+                dev.get(), CoreCoord(0, 1), CoreCoord(0, 0), NOC::NOC_0);
+            noc_1_hop_distance = tt::tt_metal::experimental::Device::get_worker_noc_hop_distance(
+                dev.get(), CoreCoord(0, 1), CoreCoord(0, 0), NOC::NOC_1);
+            EXPECT_EQ(noc_0_hop_distance, dev->grid_size().y - 1);
+            EXPECT_EQ(noc_1_hop_distance, 1);
+        } else if (unharvested || harvest_axis == HalTensixHarvestAxis::ROW) {  // Only X hop distance is consistent
+            auto noc_0_hop_distance = tt::tt_metal::experimental::Device::get_worker_noc_hop_distance(
+                dev.get(), CoreCoord(0, 0), CoreCoord(1, 0), NOC::NOC_0);
+            auto noc_1_hop_distance = tt::tt_metal::experimental::Device::get_worker_noc_hop_distance(
+                dev.get(), CoreCoord(0, 0), CoreCoord(1, 0), NOC::NOC_1);
+            EXPECT_EQ(noc_0_hop_distance, 1);
+            EXPECT_EQ(noc_1_hop_distance, dev->grid_size().x - 1);
+            noc_0_hop_distance = tt::tt_metal::experimental::Device::get_worker_noc_hop_distance(
+                dev.get(), CoreCoord(1, 0), CoreCoord(0, 0), NOC::NOC_0);
+            noc_1_hop_distance = tt::tt_metal::experimental::Device::get_worker_noc_hop_distance(
+                dev.get(), CoreCoord(1, 0), CoreCoord(0, 0), NOC::NOC_1);
+            EXPECT_EQ(noc_0_hop_distance, dev->grid_size().x - 1);
+            EXPECT_EQ(noc_1_hop_distance, 1);
+        }
     }
 }
 


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Test is failing on random machines. This is because the original test assumed unharvested distances, and checks both X and Y unconditionally.

### What's changed
Check only the X or Y distance based on whether or not that axis is unharvested.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [x] New/Existing tests provide coverage for changes