### PR TITLE
Removing Device_pool reference from ttnn

### DIFF
--- a/ttnn/api/ttnn/device.hpp
+++ b/ttnn/api/ttnn/device.hpp
@@ -20,7 +20,7 @@ std::shared_ptr<MeshDevice> open_mesh_device(
     size_t num_command_queues = 1,
     const tt::tt_metal::DispatchCoreConfig& dispatch_core_config = tt::tt_metal::DispatchCoreConfig{},
     size_t worker_l1_size = DEFAULT_WORKER_L1_SIZE);
-void close_device(IDevice& device);
+void close_device(MeshDevice& device);
 void enable_program_cache(IDevice& device);
 void disable_and_clear_program_cache(IDevice& device);
 bool is_wormhole_or_blackhole(tt::ARCH arch);

--- a/ttnn/core/device.cpp
+++ b/ttnn/core/device.cpp
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttnn/device.hpp"
-#include <tt-metalium/device_pool.hpp>
 
 namespace ttnn {
 
@@ -24,14 +23,7 @@ void enable_program_cache(IDevice& device) { device.enable_program_cache(); }
 
 void disable_and_clear_program_cache(IDevice& device) { device.disable_and_clear_program_cache(); }
 
-void close_device(IDevice& device) {
-    // TODO #20966: Remove single device support and branches + dynamic_cast
-    if (auto mesh_device = dynamic_cast<MeshDevice*>(&device)) {
-        mesh_device->close();
-    } else {
-        tt::DevicePool::instance().close_device(device.id());
-    }
-}
+void close_device(MeshDevice& device) { device.close(); }
 
 bool is_wormhole_or_blackhole(tt::ARCH arch) { return arch == tt::ARCH::WORMHOLE_B0 or arch == tt::ARCH::BLACKHOLE; }
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/25036

### Problem description
Removing device_pool from public API

### What's changed
Removed a redundant call to the device_pool

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes