### PR TITLE
Delete more internal uses of persistent kernel hash.

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_ring_distributed_sdpa.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_ring_distributed_sdpa.py
@@ -147,7 +147,6 @@ def test_ring_distributed_sdpa_main(device, q_chunk_size, k_chunk_size, s):
 
     if s / (2 * ring_size) < q_chunk_size:
         pytest.skip(f"Sequence length {s} not compatible with ring size {ring_size} and q_chunk_size {q_chunk_size}")
-    ttnn.device.DisablePersistentKernelCache()
     run_test_ring_distributed_sdpa(device, b, s, ring_size, q_chunk_size, k_chunk_size)
 
 

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_scaled_dot_product_attention.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_scaled_dot_product_attention.py
@@ -248,7 +248,6 @@ def test_sdpa_tt_padded(device, b, nh, nkv, s, d, q_chunk_size, k_chunk_size, dt
         pytest.skip("nkv must divide nh")
     if is_ci_env and (b == 1 or nh == 1 or s == 1 or q_chunk_size == 512 or k_chunk_size == 512):
         pytest.skip("Skipping to avoid CI timeout")
-    ttnn.device.DisablePersistentKernelCache()
     if is_causal:
         run_test_sdpa_tt(device, b, nh, nkv, s, d, q_chunk_size, k_chunk_size, dtype, rmse_threshold=0.033)
     else:
@@ -286,7 +285,6 @@ def test_sdpa_tt(device, b, nh, nkv, s, d, q_chunk_size, k_chunk_size, dtype, me
     if memory_config == ttnn.L1_MEMORY_CONFIG and k_chunk_size > 128 and q_chunk_size > 128:
         pytest.skip("L1 memory config with large chunk sizes can cause OOM.")
     rmse_threshold = 0.0092 if (dtype == ttnn.bfloat8_b or dtype == ttnn.bfloat4_b) else 0.0093
-    ttnn.device.DisablePersistentKernelCache()
     run_test_sdpa_tt(
         device,
         b,
@@ -316,7 +314,6 @@ def test_sdpa_tt_small_chunks(device, b, nh, nkv, s, d, q_chunk_size, k_chunk_si
         pytest.skip("s must be divisible by q_chunk_size and k_chunk_size")
     if nh == 8 and q_chunk_size == 128 and k_chunk_size == 128:
         pytest.skip("Can cause OOM if profiling is enabled.")
-    ttnn.device.DisablePersistentKernelCache()
     run_test_sdpa_tt(device, b, nh, nkv, s, d, q_chunk_size, k_chunk_size, dtype)
 
 
@@ -337,7 +334,6 @@ def test_sdpa_perf(device, b, nh, nkv, s, d, q_chunk_size, k_chunk_size, dtype):
         pytest.skip("s must be divisible by q_chunk_size and k_chunk_size")
     if nh == 8 and q_chunk_size == 128 and k_chunk_size == 128:
         pytest.skip("Can cause OOM if profiling is enabled.")
-    ttnn.device.DisablePersistentKernelCache()
     run_sdpa_noncausal(device, b, nh, nkv, s, d, q_chunk_size, k_chunk_size, dtype, use_mask=False)
 
 
@@ -355,7 +351,6 @@ def test_sdpa_tt_large_seq(device, b, nh, nkv, s, d, q_chunk_size, k_chunk_size,
         pytest.skip("s must be divisible by q_chunk_size and k_chunk_size")
     if nh == 8 and q_chunk_size == 128 and k_chunk_size == 128:
         pytest.skip("Can cause OOM if profiling is enabled.")
-    ttnn.device.DisablePersistentKernelCache()
     rmse_threshold = 0.0094
     run_test_sdpa_tt(
         device,
@@ -392,7 +387,6 @@ def test_sdpa_tt_perf(device, b, nh, nkv, s, d, q_chunk_size, k_chunk_size, dtyp
         pytest.skip("s must be divisible by q_chunk_size and k_chunk_size")
     if nh == 8 and q_chunk_size == 128 and k_chunk_size == 128:
         pytest.skip("Can cause OOM if profiling is enabled.")
-    ttnn.device.DisablePersistentKernelCache()
     run_test_sdpa_tt(device, b, nh, nkv, s, d, q_chunk_size, k_chunk_size, dtype)
 
 
@@ -439,7 +433,6 @@ def test_sdpa_noncausal(device, b, nh, nkv, s, d, q_chunk_size, k_chunk_size, dt
         pytest.skip("s must be divisible by q_chunk_size and k_chunk_size")
     if s > 2048 and (q_chunk_size == 128 or k_chunk_size == 128):
         pytest.skip("Bad PCC for small chunks")
-    ttnn.device.DisablePersistentKernelCache()
     rmse_threshold = 0.0069
     run_sdpa_noncausal(device, b, nh, nkv, s, d, q_chunk_size, k_chunk_size, dtype, rmse_threshold=rmse_threshold)
 
@@ -459,7 +452,6 @@ def test_sdpa_noncausal(device, b, nh, nkv, s, d, q_chunk_size, k_chunk_size, dt
 def test_sdpa_noncausal_unequal_seqlen(device, b, nh, nkv, sq, sk, d, q_chunk_size, k_chunk_size, dtype):
     if (sq % q_chunk_size != 0) or (sk % k_chunk_size != 0):
         pytest.skip("s must be divisible by q_chunk_size and k_chunk_size")
-    ttnn.device.DisablePersistentKernelCache()
     run_sdpa_noncausal(device, b, nh, nkv, sq, d, q_chunk_size, k_chunk_size, dtype, sk=sk)
 
 
@@ -802,7 +794,6 @@ def run_test_joint_sdpa(
 def test_joint_sdpa(device, b, nh, seq_len, joint_seq_len, d, q_chunk_size, k_chunk_size, dtype):
     if q_chunk_size == 512 and k_chunk_size == 512:
         pytest.skip("OOM config.")
-    ttnn.device.DisablePersistentKernelCache()
     rmse_threshold = 0.013
     run_test_joint_sdpa(
         device, b, nh, seq_len, joint_seq_len, d, q_chunk_size, k_chunk_size, dtype, rmse_threshold=rmse_threshold
@@ -1220,7 +1211,6 @@ def test_sdpa_sliding_window(device, b, nh, nkv, s, d, dtype, q_chunk_size, k_ch
     if sliding_window >= s:
         pytest.skip("sliding_window must be smaller than sequence length")
 
-    ttnn.device.DisablePersistentKernelCache()
     rmse_threshold = 0.01
     run_test_sdpa_sliding_window(
         device, b, nh, nkv, s, d, q_chunk_size, k_chunk_size, dtype, sliding_window, rmse_threshold=rmse_threshold
@@ -1601,7 +1591,6 @@ def test_sdpa_with_attention_sink(device, b, nh, nkv, s, d, dtype, q_chunk_size,
     if nh % nkv != 0:
         pytest.skip("nkv must divide nh")
 
-    ttnn.device.DisablePersistentKernelCache()
     rmse_threshold = 0.02
     run_test_sdpa_with_attention_sink(
         device, b, nh, nkv, s, d, q_chunk_size, k_chunk_size, dtype, rmse_threshold=rmse_threshold
@@ -1628,7 +1617,6 @@ def test_sdpa_with_attention_sink_sliding_window(
     if nh % nkv != 0:
         pytest.skip("nkv must divide nh")
 
-    ttnn.device.DisablePersistentKernelCache()
     rmse_threshold = 0.01
     run_test_sdpa_with_attention_sink_sliding_window(
         device,

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_scaled_dot_product_attention_decode.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_scaled_dot_product_attention_decode.py
@@ -569,7 +569,6 @@ def test_sdpa_decode(device, b, nh, nkv, s, d, dtype, grid_size, q_dtype, single
     if nkv > 1 and q_dtype != ttnn.bfloat16:
         pytest.skip("nkv > 1 requires q_dtype to be bfloat16")
 
-    ttnn.device.DisablePersistentKernelCache()
     if single_iter:
         run_test_sdpa_decode_single_iter(
             device, b, nh, nkv, s, d, dtype, grid_size, q_dtype, cur_pos_tensor, sharded_in=False, sharded_out=False
@@ -604,7 +603,6 @@ def test_sdpa_decode_non_causal(device, b, nh, nkv, s, d, dtype, grid_size, q_dt
     if nkv > 1 and q_dtype != ttnn.bfloat16:
         pytest.skip("nkv > 1 requires q_dtype to be bfloat16")
 
-    ttnn.device.DisablePersistentKernelCache()
     for _ in range(2):
         run_test_sdpa_decode_single_iter(
             device, b, nh, nkv, s, d, dtype, grid_size, q_dtype, sharded_in=False, sharded_out=False, causal=False
@@ -626,8 +624,6 @@ def test_sdpa_decode_non_causal(device, b, nh, nkv, s, d, dtype, grid_size, q_dt
     ([32, 8, 1, 32768, 128, (8, 6), True, True],),  # Llama2-70B
 )
 def test_sdpa_decode_ignore_users(device, b, nh, nkv, s, d, dtype, grid_size, q_dtype, single_iter, cur_pos_tensor):
-    ttnn.device.DisablePersistentKernelCache()
-
     # Set odd users to -1 to test skipping users
     start_indices = [100 if bb % 2 == 0 else -1 for bb in range(b)]
 
@@ -1141,7 +1137,6 @@ def test_sdpa_decode_paged_attention(
     if s == 128 * 1024 and block_size != 64:
         # 128k sequence, block_size 64 tests the sizing of the page table CB
         pytest.skip("Skipping test for seq_len=128k with block_size!=64")
-    ttnn.device.DisablePersistentKernelCache()
     run_test_sdpa_decode_paged_attention(
         device,
         b,
@@ -1181,7 +1176,6 @@ def test_sdpa_decode_paged_attention(
     ),  # Llama2-70B
 )
 def test_sdpa_decode_sharded(device, b, nh, nkv, s, d, dtype, grid_size, q_dtype):
-    ttnn.device.DisablePersistentKernelCache()
     run_test_sdpa_decode_single_iter(
         device, b, nh, nkv, s, d, dtype, grid_size, q_dtype, sharded_in=True, sharded_out=False
     )
@@ -1323,8 +1317,6 @@ def test_sdpa_decode_perf(device):
     ([16, 8, 1, 8192, 128],),  # Llama2-70B
 )
 def test_sdpa_decode_program_cache(device, b, nh, nkv, s, d, dtype):
-    ttnn.device.DisablePersistentKernelCache()
-
     dummy_tensors = []
     for i in range(2):
         # generate random start indices from 0 to s-1
@@ -1554,7 +1546,6 @@ def run_test_sdpa_decode_ndpcc(device, b, nh, nkv, s, d, dtype, grid_size, q_dty
     ),
 )
 def test_sdpa_decode_ndpcc(device, b, nh, nkv, s, d, dtype, grid_size, q_dtype):
-    ttnn.device.DisablePersistentKernelCache()
     run_test_sdpa_decode_ndpcc(device, b, nh, nkv, s, d, dtype, grid_size, q_dtype)
 
 
@@ -1595,8 +1586,6 @@ def test_sdpa_decode_sliding_window(
     # Ensure sliding window is smaller than sequence length
     if sliding_window_size >= s:
         pytest.skip(f"Sliding window {sliding_window_size} must be smaller than sequence length {s}")
-
-    ttnn.device.DisablePersistentKernelCache()
 
     # Test different window start positions to ensure all fill tile code paths are hit
     # when generating the sliding window


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/32208

### Problem description
Follow-up of https://github.com/tenstorrent/tt-metal/pull/32583.  There are more to be deleted.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/19600680631/job/56135980200) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/19599903144) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes