### PR TITLE
Revert "Add Watcher functions to sanitize local L1 reads/writes (#329…

### DIFF
--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dram_copy_to_noc_coord.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dram_copy_to_noc_coord.cpp
@@ -5,7 +5,6 @@
 #include <cstdint>
 #include "dataflow_api.h"
 #include "debug/dprint.h"
-#include "debug/sanitize.h"
 /**
  * NOC APIs are prefixed w/ "ncrisc" (legacy name) but there's nothing NCRISC specific, they can be used on BRISC or
  * other RISCs Any two RISC processors cannot use the same CMD_BUF non_blocking APIs shouldn't be mixed with slow noc.h
@@ -26,7 +25,6 @@ void kernel_main() {
 
     bool use_inline_dw_write = static_cast<bool>(get_arg_val<uint32_t>(8));
     bool bad_linked_transaction = static_cast<bool>(get_arg_val<uint32_t>(9));
-    std::uint32_t l1_overflow_addr = get_arg_val<uint32_t>(10);
 
 #if defined(SIGNAL_COMPLETION_TO_DISPATCHER)
     // We will assert later. This kernel will hang.
@@ -54,10 +52,6 @@ void kernel_main() {
         true    // posted
     );
 #endif
-
-    if (l1_overflow_addr) {
-        debug_sanitize_l1_access(l1_overflow_addr, 1);
-    }
 
     // NOC src address
     std::uint64_t buffer_src_noc_addr = get_noc_addr(src_noc_x, src_noc_y, buffer_src_addr);

--- a/tt_metal/hw/CMakeLists.txt
+++ b/tt_metal/hw/CMakeLists.txt
@@ -440,7 +440,7 @@ target_sources(
             inc/debug/fw_debug.h
             inc/debug/noc_logging.h
             inc/debug/ring_buffer.h
-            inc/debug/sanitize.h
+            inc/debug/sanitize_noc.h
             inc/debug/stack_usage.h
             inc/debug/watcher_common.h
             inc/debug/waypoint.h

--- a/tt_metal/hw/inc/dataflow_api_addrgen.h
+++ b/tt_metal/hw/inc/dataflow_api_addrgen.h
@@ -7,7 +7,7 @@
 #include "dataflow_api_common.h"
 #include "dataflow_cmd_bufs.h"
 #include "debug/assert.h"
-#include "debug/sanitize.h"
+#include "debug/sanitize_noc.h"
 #include "debug/waypoint.h"
 #include "utils/utils.h"
 

--- a/tt_metal/hw/inc/debug/sanitize_noc.h
+++ b/tt_metal/hw/inc/debug/sanitize_noc.h
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //
-// debug/sanitize.h
+// debug/sanitize_noc.h
 //
 // This file implements a method sanitize noc addresses.
 // Malformed addresses (out of range offsets, bad XY, etc) are stored in L1
@@ -170,7 +170,7 @@ inline uint16_t debug_valid_worker_addr(uint64_t addr, uint64_t len, bool write)
         return DebugSanitizeNocAddrMailbox;
     }
 #endif
-    return DebugSanitizeOK;
+    return DebugSanitizeNocOK;
 }
 
 inline uint16_t debug_valid_pcie_addr(uint64_t addr, uint64_t len) {
@@ -185,7 +185,7 @@ inline uint16_t debug_valid_pcie_addr(uint64_t addr, uint64_t len) {
     if (addr + len > core_info->noc_pcie_addr_end) {
         return DebugSanitizeNocAddrOverflow;
     }
-    return DebugSanitizeOK;
+    return DebugSanitizeNocOK;
 }
 inline uint16_t debug_valid_dram_addr(uint64_t addr, uint64_t len) {
     if (addr + len <= addr) {
@@ -199,7 +199,7 @@ inline uint16_t debug_valid_dram_addr(uint64_t addr, uint64_t len) {
     if (addr + len > core_info->noc_dram_addr_end) {
         return DebugSanitizeNocAddrOverflow;
     }
-    return DebugSanitizeOK;
+    return DebugSanitizeNocOK;
 }
 
 inline uint16_t debug_valid_eth_addr(uint64_t addr, uint64_t len, bool write) {
@@ -221,13 +221,13 @@ inline uint16_t debug_valid_eth_addr(uint64_t addr, uint64_t len, bool write) {
         return DebugSanitizeNocAddrMailbox;
     }
 #endif
-    return DebugSanitizeOK;
+    return DebugSanitizeNocOK;
 }
 
 // Note:
 //  - this isn't racy w/ the host so long as invalid is written last
 //  - this isn't racy between riscvs so long as each gets their own noc_index
-void __attribute__((noinline)) debug_sanitize_post_addr_and_hang(
+void __attribute__((noinline)) debug_sanitize_post_noc_addr_and_hang(
     uint8_t noc_id,
     uint64_t noc_addr,
     uint32_t l1_addr,
@@ -236,13 +236,13 @@ void __attribute__((noinline)) debug_sanitize_post_addr_and_hang(
     debug_sanitize_noc_dir_t dir,
     debug_sanitize_noc_which_core_t which_core,
     uint16_t return_code) {
-    if (return_code == DebugSanitizeOK) {
+    if (return_code == DebugSanitizeNocOK) {
         return;
     }
 
-    debug_sanitize_addr_msg_t tt_l1_ptr* v = *GET_MAILBOX_ADDRESS_DEV(watcher.sanitize);
+    debug_sanitize_noc_addr_msg_t tt_l1_ptr* v = *GET_MAILBOX_ADDRESS_DEV(watcher.sanitize_noc);
 
-    if (v[noc_id].return_code == DebugSanitizeOK) {
+    if (v[noc_id].return_code == DebugSanitizeNocOK) {
         v[noc_id].noc_addr = noc_addr;
         v[noc_id].l1_addr = l1_addr;
         v[noc_id].len = len;
@@ -284,7 +284,7 @@ inline void debug_sanitize_check_linked_transactions(
         // Submitting a non-mcast transaction if there's a linked transaction on any cmd_buf will cause a deadlock.
         auto* watcher_msg = GET_MAILBOX_ADDRESS_DEV(watcher);
         if (watcher_msg->noc_linked_status[noc_id]) {
-            debug_sanitize_post_addr_and_hang(
+            debug_sanitize_post_noc_addr_and_hang(
                 noc_id,
                 noc_addr,
                 l1_addr,
@@ -327,7 +327,7 @@ uint32_t debug_sanitize_noc_addr(
         uint8_t y_end = (uint8_t)NOC_MCAST_ADDR_END_Y(noc_addr);
         bool is_virtual_coord_end = false;
         AddressableCoreType end_core_type = get_core_type(noc_id, x_end, y_end, is_virtual_coord_end);
-        uint16_t return_code = DebugSanitizeOK;
+        uint16_t return_code = DebugSanitizeNocOK;
         if (core_type != AddressableCoreType::TENSIX || end_core_type != AddressableCoreType::TENSIX) {
             return_code = DebugSanitizeNocMulticastNonWorker;
         }
@@ -352,7 +352,7 @@ uint32_t debug_sanitize_noc_addr(
                 return_code = DebugSanitizeNocMulticastInvalidRange;
             }
         }
-        debug_sanitize_post_addr_and_hang(
+        debug_sanitize_post_noc_addr_and_hang(
             noc_id, noc_addr, l1_addr, noc_len, multicast, dir, DEBUG_SANITIZE_NOC_TARGET, return_code);
     }
 #if defined(WATCHER_ENABLE_NOC_SANITIZE_LINKED_TRANSACTION)
@@ -370,7 +370,7 @@ uint32_t debug_sanitize_noc_addr(
     if (core_type == AddressableCoreType::PCIE) {
         alignment_mask =
             (dir == DEBUG_SANITIZE_NOC_READ ? NOC_PCIE_READ_ALIGNMENT_BYTES : NOC_PCIE_WRITE_ALIGNMENT_BYTES) - 1;
-        debug_sanitize_post_addr_and_hang(
+        debug_sanitize_post_noc_addr_and_hang(
             noc_id,
             noc_addr,
             l1_addr,
@@ -382,7 +382,7 @@ uint32_t debug_sanitize_noc_addr(
     } else if (core_type == AddressableCoreType::DRAM) {
         alignment_mask =
             (dir == DEBUG_SANITIZE_NOC_READ ? NOC_DRAM_READ_ALIGNMENT_BYTES : NOC_DRAM_WRITE_ALIGNMENT_BYTES) - 1;
-        debug_sanitize_post_addr_and_hang(
+        debug_sanitize_post_noc_addr_and_hang(
             noc_id,
             noc_addr,
             l1_addr,
@@ -393,7 +393,7 @@ uint32_t debug_sanitize_noc_addr(
             debug_valid_dram_addr(noc_local_addr, noc_len));
     } else if (core_type == AddressableCoreType::ETH) {
         if (!debug_valid_reg_addr(noc_local_addr, noc_len)) {
-            debug_sanitize_post_addr_and_hang(
+            debug_sanitize_post_noc_addr_and_hang(
                 noc_id,
                 noc_addr,
                 l1_addr,
@@ -405,7 +405,7 @@ uint32_t debug_sanitize_noc_addr(
         }
     } else if (core_type == AddressableCoreType::TENSIX) {
         if (!debug_valid_reg_addr(noc_local_addr, noc_len)) {
-            debug_sanitize_post_addr_and_hang(
+            debug_sanitize_post_noc_addr_and_hang(
                 noc_id,
                 noc_addr,
                 l1_addr,
@@ -417,7 +417,7 @@ uint32_t debug_sanitize_noc_addr(
         }
     } else {
         // Bad XY
-        debug_sanitize_post_addr_and_hang(
+        debug_sanitize_post_noc_addr_and_hang(
             noc_id,
             noc_addr,
             l1_addr,
@@ -450,11 +450,11 @@ void debug_sanitize_noc_and_worker_addr(
 #else
         uint16_t return_code = debug_valid_worker_addr(worker_addr, len, dir == DEBUG_SANITIZE_NOC_READ);
 #endif
-        debug_sanitize_post_addr_and_hang(
+        debug_sanitize_post_noc_addr_and_hang(
             noc_id, noc_addr, worker_addr, len, multicast, dir, DEBUG_SANITIZE_NOC_LOCAL, return_code);
 
         if ((worker_addr & alignment_mask) != (noc_addr & alignment_mask)) {
-            debug_sanitize_post_addr_and_hang(
+            debug_sanitize_post_noc_addr_and_hang(
                 noc_id,
                 noc_addr,
                 worker_addr,
@@ -473,7 +473,7 @@ void debug_throw_on_dram_addr(uint8_t noc_id, uint64_t addr, uint32_t len) {
     bool is_virtual_coord = true;
     AddressableCoreType core_type = get_core_type(noc_id, x, y, is_virtual_coord);
     if (core_type == AddressableCoreType::DRAM) {
-        debug_sanitize_post_addr_and_hang(
+        debug_sanitize_post_noc_addr_and_hang(
             noc_id,
             addr,
             0,
@@ -482,25 +482,6 @@ void debug_throw_on_dram_addr(uint8_t noc_id, uint64_t addr, uint32_t len) {
             DEBUG_SANITIZE_NOC_WRITE,
             DEBUG_SANITIZE_NOC_TARGET,
             DebugSanitizeInlineWriteDramUnsupported);
-    }
-}
-
-void debug_sanitize_l1_access(uint64_t addr, uint32_t len) {
-#if defined(COMPILE_FOR_ERISC)
-    constexpr uint64_t l1_overflow_addr = MEM_ETH_SIZE;
-#else
-    constexpr uint64_t l1_overflow_addr = MEM_L1_SIZE;
-#endif
-    if (addr + len <= addr || addr + len > l1_overflow_addr) {
-        debug_sanitize_post_addr_and_hang(
-            0,  // unused (not a noc transaction)
-            0,  // unused (not a noc transaction)
-            addr,
-            len,
-            DEBUG_SANITIZE_NOC_UNICAST,
-            DEBUG_SANITIZE_NOC_WRITE,
-            DEBUG_SANITIZE_NOC_TARGET,
-            DebugSanitizeL1AddrOverflow);
     }
 }
 
@@ -598,7 +579,6 @@ void debug_sanitize_l1_access(uint64_t addr, uint32_t len) {
 #define DEBUG_SANITIZE_NO_DRAM_ADDR(noc_id, addr, l) debug_throw_on_dram_addr(noc_id, addr, l)
 #define DEBUG_SANITIZE_NO_LINKED_TRANSACTION(noc_id, multicast) \
     debug_sanitize_check_linked_transactions(noc_id, 0, 0, 0, multicast, DEBUG_SANITIZE_NOC_WRITE);
-#define DEBUG_SANITIZE_L1_ADDR(addr, l) debug_sanitize_l1_addr(addr, l) debug_sanitize_l1_access(addr, l);
 
 // Delay for debugging purposes
 inline void debug_insert_delay(uint8_t transaction_type) {
@@ -640,7 +620,5 @@ inline void debug_insert_delay(uint8_t transaction_type) {
 #define DEBUG_INSERT_DELAY(transaction_type)
 #define DEBUG_SANITIZE_NO_DRAM_ADDR(noc_id, addr, l) LOG_LEN(l)
 #define DEBUG_SANITIZE_NO_LINKED_TRANSACTION(noc_id, multicast)
-
-#define DEBUG_SANITIZE_L1_ADDR(addr, l)
 
 #endif  // WATCHER_ENABLED

--- a/tt_metal/hw/inc/debug/watcher_common.h
+++ b/tt_metal/hw/inc/debug/watcher_common.h
@@ -10,7 +10,7 @@
 
 #if defined(COMPILE_FOR_ERISC)
 // Forward declare these functions to avoid including erisc.h -> circular dependency via noc_nonblocking_api.h,
-// sanitize.h.
+// sanitize_noc.h.
 namespace internal_ {
 void risc_context_switch();
 void disable_erisc_app();

--- a/tt_metal/hw/inc/dev_msgs.h
+++ b/tt_metal/hw/inc/dev_msgs.h
@@ -209,7 +209,7 @@ struct debug_waypoint_msg_t {
 };
 
 // This structure is populated by the device and read by the host
-struct debug_sanitize_addr_msg_t {
+struct debug_sanitize_noc_addr_msg_t {
     volatile uint64_t noc_addr;
     volatile uint32_t l1_addr;
     volatile uint32_t len;
@@ -220,7 +220,7 @@ struct debug_sanitize_addr_msg_t {
     volatile uint8_t is_target;
     volatile uint8_t pad;  // CODEGEN:skip
 };
-static_assert(sizeof(debug_sanitize_addr_msg_t) % sizeof(uint32_t) == 0);
+static_assert(sizeof(debug_sanitize_noc_addr_msg_t) % sizeof(uint32_t) == 0);
 
 // Host -> device. Populated with the information on where we want to insert delays.
 struct debug_insert_delays_msg_t {
@@ -232,7 +232,7 @@ struct debug_insert_delays_msg_t {
 
 enum debug_sanitize_noc_return_code_enum {
     // 0 and 1 are a common stray values to write, so don't use those
-    DebugSanitizeOK = 2,
+    DebugSanitizeNocOK = 2,
     DebugSanitizeNocAddrUnderflow = 3,
     DebugSanitizeNocAddrOverflow = 4,
     DebugSanitizeNocAddrZeroLength = 5,
@@ -244,7 +244,6 @@ enum debug_sanitize_noc_return_code_enum {
     DebugSanitizeInlineWriteDramUnsupported = 11,
     DebugSanitizeNocAddrMailbox = 12,
     DebugSanitizeNocLinkedTransactionViolation = 13,
-    DebugSanitizeL1AddrOverflow = 14,
 };
 
 struct debug_assert_msg_t {
@@ -303,7 +302,7 @@ constexpr static std::uint32_t MAX_NUM_NOCS_PER_CORE = 2;
 struct watcher_msg_t {
     volatile uint32_t enable;
     struct debug_waypoint_msg_t debug_waypoint[MaxProcessorsPerCoreType];
-    struct debug_sanitize_addr_msg_t sanitize[MAX_NUM_NOCS_PER_CORE];
+    struct debug_sanitize_noc_addr_msg_t sanitize_noc[MAX_NUM_NOCS_PER_CORE];
     std::atomic<bool> noc_linked_status[MAX_NUM_NOCS_PER_CORE];
     struct debug_eth_link_t eth_status;
     uint8_t pad0;  // CODEGEN:skip

--- a/tt_metal/impl/debug/watcher_device_reader.cpp
+++ b/tt_metal/impl/debug/watcher_device_reader.cpp
@@ -147,7 +147,7 @@ string get_noc_target_str(
     tt::ChipId device_id,
     HalProgrammableCoreType programmable_core_type,
     int noc,
-    dev_msgs::debug_sanitize_addr_msg_t::ConstView san) {
+    dev_msgs::debug_sanitize_noc_addr_msg_t::ConstView san) {
     auto get_core_and_mem_type = [](tt::ChipId device_id, CoreCoord& noc_coord, int noc) -> std::pair<string, string> {
         // Get the virtual coord from the noc coord
         CoreCoord virtual_core = virtual_noc_coordinate(device_id, noc, noc_coord);
@@ -197,16 +197,6 @@ string get_noc_target_str(
     }
 
     out += fmt::format("[addr=0x{:08x}]", NOC_LOCAL_ADDR(san.noc_addr()));
-    return out;
-}
-
-string get_l1_target_str(
-    HalProgrammableCoreType programmable_core_type, dev_msgs::debug_sanitize_addr_msg_t::ConstView san) {
-    string out = fmt::format(
-        "{} core overflowed L1 with access to {:#x} of length {}",
-        get_riscv_name(programmable_core_type, san.which_risc()),
-        san.l1_addr(),
-        san.len());
     return out;
 }
 
@@ -639,16 +629,18 @@ void WatcherDeviceReader::Core::DumpL1Status() const {
 }
 
 void WatcherDeviceReader::Core::DumpNocSanitizeStatus(int noc) const {
-    auto san = mbox_data_.watcher().sanitize()[noc];
+    auto san = mbox_data_.watcher().sanitize_noc()[noc];
     string error_msg;
     string error_reason;
 
     switch (san.return_code()) {
-        case dev_msgs::DebugSanitizeOK:
-            if (san.noc_addr() != DEBUG_SANITIZE_SENTINEL_OK_64 || san.l1_addr() != DEBUG_SANITIZE_SENTINEL_OK_32 ||
-                san.len() != DEBUG_SANITIZE_SENTINEL_OK_32 || san.which_risc() != DEBUG_SANITIZE_SENTINEL_OK_16 ||
-                san.is_multicast() != DEBUG_SANITIZE_SENTINEL_OK_8 || san.is_write() != DEBUG_SANITIZE_SENTINEL_OK_8 ||
-                san.is_target() != DEBUG_SANITIZE_SENTINEL_OK_8) {
+        case dev_msgs::DebugSanitizeNocOK:
+            if (san.noc_addr() != DEBUG_SANITIZE_NOC_SENTINEL_OK_64 ||
+                san.l1_addr() != DEBUG_SANITIZE_NOC_SENTINEL_OK_32 || san.len() != DEBUG_SANITIZE_NOC_SENTINEL_OK_32 ||
+                san.which_risc() != DEBUG_SANITIZE_NOC_SENTINEL_OK_16 ||
+                san.is_multicast() != DEBUG_SANITIZE_NOC_SENTINEL_OK_8 ||
+                san.is_write() != DEBUG_SANITIZE_NOC_SENTINEL_OK_8 ||
+                san.is_target() != DEBUG_SANITIZE_NOC_SENTINEL_OK_8) {
                 error_msg = fmt::format(
                     "Watcher unexpected noc debug state on core {}, reported valid got noc{}{{0x{:08x}, {} }}",
                     virtual_coord_.str(),
@@ -702,10 +694,6 @@ void WatcherDeviceReader::Core::DumpNocSanitizeStatus(int noc) const {
             error_msg = get_noc_target_str(reader_.device_id, programmable_core_type_, noc, san);
             error_msg += fmt::format(" (submitting a non-mcast transaction when there's a linked transaction).");
             break;
-        case dev_msgs::DebugSanitizeL1AddrOverflow:
-            error_msg = get_l1_target_str(programmable_core_type_, san);
-            error_msg += " (read or write past the end of local memory).";
-            break;
         default:
             error_msg = fmt::format(
                 "Watcher unexpected data corruption, noc debug state on core {}, unknown failure code: {}",
@@ -730,8 +718,8 @@ void WatcherDeviceReader::Core::DumpNocSanitizeStatus(int noc) const {
 void WatcherDeviceReader::Core::DumpAssertStatus() const {
     auto assert_status = mbox_data_.watcher().assert_status();
     if (assert_status.tripped() == dev_msgs::DebugAssertOK) {
-        if (assert_status.line_num() != DEBUG_SANITIZE_SENTINEL_OK_16 ||
-            assert_status.which() != DEBUG_SANITIZE_SENTINEL_OK_8) {
+        if (assert_status.line_num() != DEBUG_SANITIZE_NOC_SENTINEL_OK_16 ||
+            assert_status.which() != DEBUG_SANITIZE_NOC_SENTINEL_OK_8) {
             TT_THROW(
                 "Watcher unexpected assert state on core {}, reported OK but got processor {}, line {}.",
                 virtual_coord_.str(),

--- a/tt_metal/impl/debug/watcher_device_reader.hpp
+++ b/tt_metal/impl/debug/watcher_device_reader.hpp
@@ -16,10 +16,10 @@
 
 namespace tt::tt_metal {
 
-constexpr uint64_t DEBUG_SANITIZE_SENTINEL_OK_64 = 0xbadabadabadabada;
-constexpr uint32_t DEBUG_SANITIZE_SENTINEL_OK_32 = 0xbadabada;
-constexpr uint16_t DEBUG_SANITIZE_SENTINEL_OK_16 = 0xbada;
-constexpr uint8_t DEBUG_SANITIZE_SENTINEL_OK_8 = 0xda;
+constexpr uint64_t DEBUG_SANITIZE_NOC_SENTINEL_OK_64 = 0xbadabadabadabada;
+constexpr uint32_t DEBUG_SANITIZE_NOC_SENTINEL_OK_32 = 0xbadabada;
+constexpr uint16_t DEBUG_SANITIZE_NOC_SENTINEL_OK_16 = 0xbada;
+constexpr uint8_t DEBUG_SANITIZE_NOC_SENTINEL_OK_8 = 0xda;
 
 class WatcherDeviceReader {
 public:

--- a/tt_metal/impl/debug/watcher_server.cpp
+++ b/tt_metal/impl/debug/watcher_server.cpp
@@ -360,21 +360,21 @@ void WatcherServer::Impl::init_device(ChipId device_id) {
         }
 
         // Initialize debug sanity L1/NOC addresses to sentinel "all ok"
-        for (auto sanitize : data.sanitize()) {
-            sanitize.noc_addr() = DEBUG_SANITIZE_SENTINEL_OK_64;
-            sanitize.l1_addr() = DEBUG_SANITIZE_SENTINEL_OK_32;
-            sanitize.len() = DEBUG_SANITIZE_SENTINEL_OK_32;
-            sanitize.which_risc() = DEBUG_SANITIZE_SENTINEL_OK_16;
-            sanitize.return_code() = dev_msgs::DebugSanitizeOK;
-            sanitize.is_multicast() = DEBUG_SANITIZE_SENTINEL_OK_8;
-            sanitize.is_write() = DEBUG_SANITIZE_SENTINEL_OK_8;
-            sanitize.is_target() = DEBUG_SANITIZE_SENTINEL_OK_8;
+        for (auto sanitize_noc : data.sanitize_noc()) {
+            sanitize_noc.noc_addr() = DEBUG_SANITIZE_NOC_SENTINEL_OK_64;
+            sanitize_noc.l1_addr() = DEBUG_SANITIZE_NOC_SENTINEL_OK_32;
+            sanitize_noc.len() = DEBUG_SANITIZE_NOC_SENTINEL_OK_32;
+            sanitize_noc.which_risc() = DEBUG_SANITIZE_NOC_SENTINEL_OK_16;
+            sanitize_noc.return_code() = dev_msgs::DebugSanitizeNocOK;
+            sanitize_noc.is_multicast() = DEBUG_SANITIZE_NOC_SENTINEL_OK_8;
+            sanitize_noc.is_write() = DEBUG_SANITIZE_NOC_SENTINEL_OK_8;
+            sanitize_noc.is_target() = DEBUG_SANITIZE_NOC_SENTINEL_OK_8;
         }
 
         // Initialize debug asserts to not tripped.
-        data.assert_status().line_num() = DEBUG_SANITIZE_SENTINEL_OK_16;
+        data.assert_status().line_num() = DEBUG_SANITIZE_NOC_SENTINEL_OK_16;
         data.assert_status().tripped() = dev_msgs::DebugAssertOK;
-        data.assert_status().which() = DEBUG_SANITIZE_SENTINEL_OK_8;
+        data.assert_status().which() = DEBUG_SANITIZE_NOC_SENTINEL_OK_8;
 
         // Initialize debug ring buffer to a known init val, we'll check against this to see if any
         // data has been written.

--- a/tt_metal/impl/dispatch/kernels/cq_common.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_common.hpp
@@ -9,7 +9,7 @@
 #include "dataflow_api.h"
 #include "cq_helpers.hpp"
 
-#include "debug/sanitize.h"
+#include "debug/sanitize_noc.h"
 #include <limits>
 
 // The command queue read interface controls reads from the issue region, host owns the issue region write interface


### PR DESCRIPTION
…50)"

This reverts commit e39a0157ef7828c6bba9aff5a47e25ea97690daa.

This commit broke APC https://github.com/tenstorrent/tt-metal/actions/runs/19604745969/job/56148146972

### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes
