### PR TITLE
Jmitrovic/vae encode problem

### DIFF
--- a/models/experimental/stable_diffusion_xl_base/tests/test_common.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/test_common.py
@@ -503,6 +503,8 @@ def prepare_image_latents(
     is_strength_max=True,
     add_noise=True,
     latents=None,  # passed in latents
+    start_latent_seed=None,
+    fixed_seed_for_batch=False,
 ):
     # 4, 5, 8
     assert image is not None, "Image is not provided"
@@ -518,12 +520,19 @@ def prepare_image_latents(
 
     cpu_device = torch.device("cpu")
     image = image.to(device=cpu_device, dtype=dtype)
+    saved_global_rng_state = None
 
     if image.shape[1] == 4:
         image_latents = image
     else:
         if tt_pipeline.pipeline_config.vae_on_device:
-            image_latents = [latent.sample() for latent in tt_pipeline.tt_vae.encode(image).latent_dist]
+            image_latents = []
+            for index, latent in enumerate(tt_pipeline.tt_vae.encode(image).latent_dist):
+                if start_latent_seed is not None:
+                    torch.manual_seed(start_latent_seed if fixed_seed_for_batch else start_latent_seed + index)
+                image_latents.append(latent.sample())
+                if index == 0 and batch_size > 1:
+                    saved_global_rng_state = torch.get_rng_state()
             image_latents = torch.cat(image_latents, dim=0)
         else:
             image_latents = [
@@ -535,6 +544,8 @@ def prepare_image_latents(
     image_latents = image_latents.repeat(batch_size // image_latents.shape[0], 1, 1, 1)
 
     if add_noise:
+        if saved_global_rng_state is not None:
+            torch.set_rng_state(saved_global_rng_state)
         torch_noise = torch.randn(shape, generator=None, device=cpu_device, dtype=dtype)
         torch_noise = torch_noise.repeat(batch_size // torch_noise.shape[0], 1, 1, 1)
         if is_strength_max:
@@ -579,6 +590,7 @@ def prepare_mask_latents_inpainting(
     dtype,
     cpu_device,
     masked_image_latents=None,
+    fixed_seed_for_batch=False,
 ):
     assert masked_image is not None, "Masked image must be provided at the moment"
     assert masked_image_latents is None, "Masked image latents are not supported for inpainting pipeline at the moment"
@@ -594,6 +606,8 @@ def prepare_mask_latents_inpainting(
         ),
     )
     mask = mask.to(device=cpu_device, dtype=dtype)
+    if fixed_seed_for_batch and batch_size > 1:
+        saved_global_rng_state = torch.get_rng_state()
 
     if masked_image is not None:
         if masked_image_latents is None:
@@ -603,9 +617,11 @@ def prepare_mask_latents_inpainting(
                     masked_image, generator=None
                 )
             else:
-                masked_image_latents = [
-                    mask.sample() for mask in tt_inpainting_pipeline.tt_vae.encode(masked_image).latent_dist
-                ]
+                masked_image_latents = []
+                for mask_dist in tt_inpainting_pipeline.tt_vae.encode(masked_image).latent_dist:
+                    if fixed_seed_for_batch and batch_size > 1:
+                        torch.set_rng_state(saved_global_rng_state)
+                    masked_image_latents.append(mask_dist.sample())
                 masked_image_latents = torch.cat(masked_image_latents, dim=0)
                 masked_image_latents = (
                     tt_inpainting_pipeline.torch_pipeline.vae.config.scaling_factor * masked_image_latents

--- a/models/experimental/stable_diffusion_xl_base/tests/test_common.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/test_common.py
@@ -531,7 +531,7 @@ def prepare_image_latents(
                 if start_latent_seed is not None:
                     torch.manual_seed(start_latent_seed if fixed_seed_for_batch else start_latent_seed + index)
                 image_latents.append(latent.sample())
-                if index == 0 and batch_size > 1:
+                if start_latent_seed is not None and index == 0 and batch_size > 1:
                     saved_global_rng_state = torch.get_rng_state()
             image_latents = torch.cat(image_latents, dim=0)
         else:

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_sdxl_inpainting_pipeline.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_sdxl_inpainting_pipeline.py
@@ -76,8 +76,6 @@ class TtSDXLInpaintingPipeline(TtSDXLImg2ImgPipeline):
             start_latent_seed, int
         ), "start_latent_seed must be an integer or None"
 
-        if start_latent_seed is not None:
-            torch.manual_seed(start_latent_seed if fixed_seed_for_batch else start_latent_seed)
         # the function returns img_latents, noise but we don't use noise at the moment, so discard it
         img_latents = prepare_image_latents(
             self.torch_pipeline,
@@ -92,6 +90,8 @@ class TtSDXLInpaintingPipeline(TtSDXLImg2ImgPipeline):
             self.pipeline_config.strength == 1,
             True,  # Make this configurable
             None,  # passed in latents
+            start_latent_seed,
+            fixed_seed_for_batch,
         )
         B, C, H, W = img_latents.shape  # 1, 4, 128, 128
         img_latents = torch.permute(img_latents, (0, 2, 3, 1))  # [1, H, W, C]
@@ -107,6 +107,7 @@ class TtSDXLInpaintingPipeline(TtSDXLImg2ImgPipeline):
             all_prompt_embeds_torch.dtype,
             self.cpu_device,
             None,
+            fixed_seed_for_batch,
         )
 
         B, C, H, W = mask.shape


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes