### PR TITLE
Pjosipovic/fix issue /32944

### DIFF
--- a/tests/ttnn/unit_tests/gtests/test_conv2d.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_conv2d.cpp
@@ -15,6 +15,7 @@
 #include "ttnn/device.hpp"
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/operations/conv/conv2d/conv2d.hpp"
+#include "ttnn/operations/conv/conv_types.hpp"
 #include "ttnn/operations/data_movement/permute/permute.hpp"
 #include "ttnn/operations/data_movement/reshape_view/reshape.hpp"
 #include "ttnn/operations/data_movement/untilize/untilize.hpp"
@@ -159,28 +160,29 @@ TEST_P(Conv2DFixture, Conv2DCalculateCorrectly) {
         input_tensor = ttnn::permute(input_tensor, SmallVector<int64_t>{0, 2, 3, 1});
 
         // Run Conv2D
-        auto [output_tensor, output_dimensions] = std::get<static_cast<int>(ResultType::OUTPUT_DIM)>(ttnn::conv2d(
-            input_tensor,
-            weight_tensor,
-            device.get(),
-            param.input_channels,
-            param.output_channels,
-            param.batch_size,
-            param.input_height,
-            param.input_width,
-            param.kernel_size,
-            param.stride,
-            param.padding,
-            std::array<uint32_t, 2>{1, 1},  // dilation
-            1,                              // groups
-            std::nullopt,                   // dtype
-            std::nullopt,                   // bias tensor
-            std::nullopt,                   // conv config
-            std::nullopt,                   // compute config
-            std::nullopt,                   // memory config
-            std::nullopt,                   // slice config
-            true                            // return_output_dim
-            ));
+        auto [output_tensor, output_dimensions] =
+            std::get<static_cast<int>(ttnn::operations::conv::ResultType::OUTPUT_DIM)>(ttnn::conv2d(
+                input_tensor,
+                weight_tensor,
+                device.get(),
+                param.input_channels,
+                param.output_channels,
+                param.batch_size,
+                param.input_height,
+                param.input_width,
+                param.kernel_size,
+                param.stride,
+                param.padding,
+                std::array<uint32_t, 2>{1, 1},  // dilation
+                1,                              // groups
+                std::nullopt,                   // dtype
+                std::nullopt,                   // bias tensor
+                std::nullopt,                   // conv config
+                std::nullopt,                   // compute config
+                std::nullopt,                   // memory config
+                std::nullopt,                   // slice config
+                true                            // return_output_dim
+                ));
 
         // move output tensor to dram
         output_tensor = ttnn::to_memory_config(output_tensor, dram_mem_config);

--- a/ttnn/cpp/ttnn/operations/conv/conv1d/conv1d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv1d/conv1d.cpp
@@ -2,38 +2,18 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include "ttnn/operations/conv/conv1d/conv1d.hpp"
+
 #include <array>
-#include <cstdint>
-#include <iostream>
-#include <optional>
-#include <string>
-#include <tuple>
-#include <utility>
 #include <variant>
 
-#include <tt-metalium/buffer_types.hpp>
-
-#include <tt-logger/tt-logger.hpp>
+#include "ttnn/operations/conv/conv_types.hpp"
 #include "ttnn/operations/conv/conv2d/conv2d.hpp"
-#include "ttnn/tensor/tensor.hpp"
-#include "ttnn/tensor/types.hpp"
-
-#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
-#include "ttnn/operations/conv/conv1d/conv1d.hpp"
-#include "ttnn/operations/conv/conv2d/device/conv2d_op.hpp"
-#include "ttnn/operations/matmul/matmul.hpp"
-#include "ttnn/operations/sliding_window/halo/halo.hpp"
-#include "ttnn/operations/sliding_window/sliding_window.hpp"
 #include "ttnn/operations/core/core.hpp"
-#include "ttnn/operations/data_movement/move/move.hpp"
 
-namespace ttnn {
-namespace operations::conv {
-using namespace tt;
+namespace ttnn::operations::conv::conv1d {
 
-namespace conv1d {
-
-Result conv1d(
+Result Conv1dOperation::invoke(
     const ttnn::Tensor& input_tensor,
     const ttnn::Tensor& weight_tensor,
     MeshDevice* device,
@@ -94,8 +74,9 @@ Result conv1d(
             conv_config,
             compute_config,
             memory_config,
-            Conv2dSliceConfig{
-                .slice_type = Conv2dSliceConfig::SliceType::L1_FULL},  // Conv1D doesn't support DRAM Slicing. Only L1
+            conv2d::Conv2dSliceConfig{
+                .slice_type =
+                    conv2d::Conv2dSliceConfig::SliceType::L1_FULL},  // Conv1D doesn't support DRAM Slicing. Only L1
             true,
             true));
 
@@ -109,48 +90,5 @@ Result conv1d(
         return Result(output_tensor);
     };
 }
-Result Conv1dOperation::invoke(
-    const ttnn::Tensor& input_tensor,
-    const ttnn::Tensor& weight_tensor,
-    MeshDevice* device,
-    uint32_t in_channels,
-    uint32_t out_channels,
-    uint32_t batch_size,
-    uint32_t input_length,
-    uint32_t kernel_size,
-    uint32_t stride,
-    std::variant<std::array<uint32_t, 2>, uint32_t> padding,
-    uint32_t dilation,
-    uint32_t groups,
-    const std::optional<const DataType>& dtype,
-    const std::optional<const ttnn::Tensor>& bias_tensor,
-    const std::optional<const Conv1dConfig>& conv_config,
-    const std::optional<const DeviceComputeKernelConfig>& compute_config,
-    const std::optional<const MemoryConfig>& memory_config,
-    bool return_output_dim,
-    bool return_weights_and_bias) {
-    return conv1d(
-        input_tensor,
-        weight_tensor,
-        device,
-        in_channels,
-        out_channels,
-        batch_size,
-        input_length,
-        kernel_size,
-        stride,
-        padding,
-        dilation,
-        groups,
-        dtype,
-        bias_tensor,
-        conv_config,
-        compute_config,
-        memory_config,
-        return_output_dim,
-        return_weights_and_bias);
-}
 
-}  // namespace conv1d
-}  // namespace operations::conv
-}  // namespace ttnn
+}  // namespace ttnn::operations::conv::conv1d

--- a/ttnn/cpp/ttnn/operations/conv/conv1d/conv1d.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv1d/conv1d.hpp
@@ -8,16 +8,12 @@
 #include <optional>
 #include <tuple>
 
-#include "ttnn/types.hpp"
-#include "ttnn/tensor/tensor.hpp"
 #include "ttnn/decorators.hpp"
-#include "ttnn/operations/conv/conv_types.hpp"
-#include "ttnn/operations/conv/conv2d/conv2d_utils.hpp"
+#include "ttnn/operations/conv/conv2d/device/conv2d_op.hpp"
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/types.hpp"
 
-namespace ttnn {
-
-namespace operations::conv {
-namespace conv1d {
+namespace ttnn::operations::conv::conv1d {
 
 using OutputLength = uint32_t;
 using Result = std::variant<
@@ -27,27 +23,6 @@ using Result = std::variant<
     std::tuple<ttnn::Tensor, OutputLength, std::tuple<ttnn::Tensor, std::optional<ttnn::Tensor>>>>;
 
 using Conv1dConfig = ttnn::operations::conv::conv2d::Conv2dConfig;
-
-Result conv1d(
-    const ttnn::Tensor& input_tensor,
-    const ttnn::Tensor& weight_tensor,
-    MeshDevice* device,
-    uint32_t in_channels,
-    uint32_t out_channels,
-    uint32_t batch_size,
-    uint32_t input_length,
-    uint32_t kernel_size,
-    uint32_t stride = 1,
-    std::variant<std::array<uint32_t, 2>, uint32_t> padding = uint32_t{0},
-    uint32_t dilation = 1,
-    uint32_t groups = 1,
-    const std::optional<const DataType>& dtype = std::nullopt,
-    const std::optional<const ttnn::Tensor>& bias_tensor = std::nullopt,
-    const std::optional<const Conv1dConfig>& conv_config = std::nullopt,
-    const std::optional<const DeviceComputeKernelConfig>& compute_config = std::nullopt,
-    const std::optional<const MemoryConfig>& memory_config = std::nullopt,
-    bool return_output_dim = true,
-    bool return_weights_and_bias = true);
 
 // Conv1dOperation is a wrapper around Conv2dOperation to handle 1D convolutions.
 // It uses the same logic as Conv2dOperation but with 1D-specific parameters.
@@ -74,9 +49,8 @@ struct Conv1dOperation {
         bool return_output_dim = true,
         bool return_weights_and_bias = true);
 };
-}  // namespace conv1d
-}  // namespace operations::conv
-}  // namespace ttnn
+
+}  // namespace ttnn::operations::conv::conv1d
 
 namespace ttnn {
 constexpr auto conv1d = ttnn::register_operation<"ttnn::conv1d", operations::conv::conv1d::Conv1dOperation>();

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
@@ -9,424 +9,26 @@
 #include <utility>
 
 #include <tt-metalium/buffer_types.hpp>
-
 #include <tt_stl/assert.hpp>
 #include <tt-logger/tt-logger.hpp>
+
 #include "tt-metalium/math.hpp"
-#include <tt_stl/small_vector.hpp>
-#include "ttnn/operations/data_movement/slice/slice.hpp"
-#include "ttnn/operations/data_movement/untilize/untilize.hpp"
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/tensor/types.hpp"
+#include "ttnn/types.hpp"
 
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
-#include "ttnn/operations/eltwise/unary/common/unary_op_types.hpp"
-#include "ttnn/operations/eltwise/unary/common/unary_op_utils.hpp"
+#include "ttnn/operations/core/core.hpp"
 #include "ttnn/operations/conv/conv2d/conv2d.hpp"
 #include "ttnn/operations/conv/conv2d/conv2d_utils.hpp"
-#include "ttnn/operations/conv/conv2d/prepare_conv2d_weights.hpp"
 #include "ttnn/operations/conv/conv2d/device/conv2d_op.hpp"
+#include "ttnn/operations/conv/conv2d/prepare_conv2d_weights.hpp"
+#include "ttnn/operations/data_movement/move/move.hpp"
 #include "ttnn/operations/matmul/matmul.hpp"
 #include "ttnn/operations/sliding_window/halo/halo.hpp"
 #include "ttnn/operations/sliding_window/sliding_window.hpp"
-#include "ttnn/operations/data_movement/fold/fold.hpp"
-#include "ttnn/operations/core/core.hpp"
-#include "ttnn/operations/data_movement/move/move.hpp"
-#include "ttnn/operations/experimental/slice_write/slice_write.hpp"
-#include "ttnn/operations/experimental/padded_slice/padded_slice.hpp"
-#include "ttnn/operations/creation.hpp"
-#include "ttnn/types.hpp"
-namespace ttnn {
-namespace operations::conv {
-using namespace tt;
-using sliding_window::SlidingWindowConfig;
-namespace conv2d {
 
-ResultWithOptions result_to_result_with_options(
-    const Result& result, const bool return_output_dim, const bool return_weights_and_bias) {
-    if (return_output_dim && return_weights_and_bias) {
-        return std::make_tuple(
-            std::get<0>(result),
-            std::make_tuple(std::get<1>(result), std::get<2>(result)),
-            std::make_tuple(std::get<3>(result), std::get<4>(result)));
-    } else if (return_output_dim) {
-        return std::make_tuple(std::get<0>(result), std::make_tuple(std::get<1>(result), std::get<2>(result)));
-    } else if (return_weights_and_bias) {
-        return std::make_tuple(std::get<0>(result), std::make_tuple(std::get<3>(result), std::get<4>(result)));
-    }
-    return std::get<0>(result);
-}
-
-ResultWithOptions conv2d(
-    const ttnn::Tensor& input_tensor,
-    const ttnn::Tensor& weight_tensor,
-    MeshDevice* device,
-    uint32_t in_channels,
-    uint32_t out_channels,
-    uint32_t batch_size,
-    uint32_t input_height,
-    uint32_t input_width,
-    std::array<uint32_t, 2> kernel_size,
-    std::array<uint32_t, 2> stride,
-    std::variant<std::array<uint32_t, 2>, std::array<uint32_t, 4>> padding,
-    std::array<uint32_t, 2> dilation,
-    uint32_t groups,
-    const std::optional<const DataType>& dtype,
-    const std::optional<const ttnn::Tensor>& bias_tensor,
-    const std::optional<const Conv2dConfig>& conv_config_,
-    const std::optional<const DeviceComputeKernelConfig>& compute_config_,
-    const std::optional<const MemoryConfig>& memory_config_,
-    const std::optional<const Conv2dSliceConfig>& dram_slice_config_,
-    bool return_output_dim,
-    bool return_weights_and_bias) {
-    if (dram_slice_config_.has_value()) {
-        if (dram_slice_config_.value().slice_type == Conv2dSliceConfig::SliceType::L1_FULL) {
-            log_trace(tt::LogOp, "Conv2d L1 with slice config {}", dram_slice_config_);
-            return result_to_result_with_options(
-                conv2d_L1(
-                    input_tensor,
-                    weight_tensor,
-                    device,
-                    in_channels,
-                    out_channels,
-                    batch_size,
-                    input_height,
-                    input_width,
-                    kernel_size,
-                    stride,
-                    padding,
-                    dilation,
-                    groups,
-                    dtype,
-                    bias_tensor,
-                    conv_config_,
-                    compute_config_,
-                    memory_config_),
-                return_output_dim,
-                return_weights_and_bias);
-        } else {
-            log_trace(tt::LogOp, "Conv2d DRAM with slice config {}", dram_slice_config_);
-            return result_to_result_with_options(
-                conv2d_DRAM(
-                    input_tensor,
-                    weight_tensor,
-                    device,
-                    in_channels,
-                    out_channels,
-                    batch_size,
-                    input_height,
-                    input_width,
-                    kernel_size,
-                    stride,
-                    padding,
-                    dilation,
-                    groups,
-                    dtype,
-                    bias_tensor,
-                    conv_config_,
-                    compute_config_,
-                    memory_config_,
-                    dram_slice_config_),
-                return_output_dim,
-                return_weights_and_bias);
-        }
-    } else {
-        bool input_is_on_device = tt::tt_metal::is_device_tensor(input_tensor);
-        if (input_is_on_device && input_tensor.memory_config().is_l1()) {
-            log_trace(tt::LogOp, "Conv2d L1 without slice config");
-            return result_to_result_with_options(
-                conv2d_L1(
-                    input_tensor,
-                    weight_tensor,
-                    device,
-                    in_channels,
-                    out_channels,
-                    batch_size,
-                    input_height,
-                    input_width,
-                    kernel_size,
-                    stride,
-                    padding,
-                    dilation,
-                    groups,
-                    dtype,
-                    bias_tensor,
-                    conv_config_,
-                    compute_config_,
-                    memory_config_),
-                return_output_dim,
-                return_weights_and_bias);
-        }
-        log_trace(tt::LogOp, "Conv2d DRAM without slice config");
-        return result_to_result_with_options(
-            conv2d_DRAM(
-                input_tensor,
-                weight_tensor,
-                device,
-                in_channels,
-                out_channels,
-                batch_size,
-                input_height,
-                input_width,
-                kernel_size,
-                stride,
-                padding,
-                dilation,
-                groups,
-                dtype,
-                bias_tensor,
-                conv_config_,
-                compute_config_,
-                memory_config_,
-                std::nullopt),
-            return_output_dim,
-            return_weights_and_bias);
-    }
-}
-
-// This function is used for DRAM Slicing
-// It divides the output tensor into slices, and calculates the corresponding input slices.
-// Uses ttnn::slice to slice the input tensor and bring it to L1.
-// Calls conv2d_L1 to perform the convolution on the sliced input tensor.
-// Finally, it uses ttnn::experimental::slice_write to write the output tensor back to DRAM.
-// The function is called in a loop for each slice of the output tensor.
-// The Conv2dSliceConfig is used to determine the slicing configuration. The dimension along which it is sliced, and the
-// number of such slices.
-// Conv2dConfig does not control the final output, but rather the conv2d_L1 function that is called internally.
-Result conv2d_DRAM(
-    const ttnn::Tensor& input_tensor,
-    const ttnn::Tensor& weight_tensor,
-    MeshDevice* device,
-    uint32_t in_channels,
-    uint32_t out_channels,
-    uint32_t batch_size,
-    uint32_t input_height,
-    uint32_t input_width,
-    std::array<uint32_t, 2> kernel_size,
-    std::array<uint32_t, 2> stride,
-    std::variant<std::array<uint32_t, 2>, std::array<uint32_t, 4>> padding,
-    std::array<uint32_t, 2> dilation,
-    uint32_t groups,
-    const std::optional<const DataType>& dtype,
-    const std::optional<const ttnn::Tensor>& bias_tensor,
-    const std::optional<const Conv2dConfig>& conv_config_,
-    const std::optional<const DeviceComputeKernelConfig>& compute_config_,
-    const std::optional<const MemoryConfig>& memory_config_,
-    const std::optional<const Conv2dSliceConfig>& dram_slice_config_) {
-    Conv2dConfig conv_config = conv_config_.value_or(Conv2dConfig());
-    const DataType output_dtype = dtype.value_or(input_tensor.dtype());
-    std::array<uint32_t, 4> padding_n4 = sliding_window::get_pair_n4_padding(padding);
-    bool mm_conv = use_matmul_for_1x1_conv(kernel_size, stride, padding_n4, dilation, groups, conv_config);
-    DeviceComputeKernelConfig compute_config = compute_config_.value_or(get_conv_default_compute_kernel_config(device));
-    const auto compute_grid_size = device->compute_with_storage_grid_size();
-    ttnn::Tensor input_tensor_on_device = fold_input_tensor_if_required(
-        input_tensor,
-        device,
-        batch_size,
-        input_height,
-        input_width,
-        in_channels,
-        kernel_size,
-        stride,
-        dilation,
-        padding_n4,
-        mm_conv,
-        conv_config);
-    if (!is_device_tensor(input_tensor_on_device)) {
-        input_tensor_on_device =
-            ttnn::operations::core::to_device(input_tensor_on_device, device, ttnn::DRAM_MEMORY_CONFIG);
-    }
-    const bool should_deallocate_act = conv_config.deallocate_activation && !input_tensor.memory_config().is_dram();
-    ttnn::Tensor weight_tensor_on_device;
-    std::optional<ttnn::Tensor> bias_tensor_on_device;
-    if (mm_conv) {
-        const uint32_t input_channels_alignment = get_input_channels_alignment(
-            tt::tt_metal::TensorMemoryLayout::INTERLEAVED, input_tensor.layout(), true, mm_conv, std::nullopt);
-        // Configure weight and bias preparation parameters
-        Conv2dWeightsBiasPrepConfig params(
-            input_channels_alignment,
-            conv_config.weights_dtype,
-            1,  // Set to 1 as it doesn't matter in Interleaved MM.
-            1,  // Set to 1 as it doesn't matter in Interleaved MM.
-            std::nullopt,
-            std::nullopt,
-            groups,
-            1,  // Set to 1 as it doesn't matter in Interleaved MM.
-            input_width,
-            true,  // DRAM MM Convs are always interleaved
-            bias_tensor.has_value(),
-            true,  // parameters_on_device
-            conv_config.enable_kernel_stride_folding.value(),
-            conv_config.full_inner_dim,
-            conv_config.enable_activation_reuse,
-            kernel_size,
-            stride,
-            padding_n4);
-
-        // Prepare weights and move to device if necessary
-        if (!is_device_tensor(weight_tensor)) {
-            log_debug(tt::LogOp, "conv2d: Preprocessing weights for MM DRAM Interleaved.");
-            std::tie(weight_tensor_on_device, bias_tensor_on_device) =
-                prepare_conv_weights_biases_and_move_to_device(weight_tensor, bias_tensor, params, device);
-        } else {
-            weight_tensor_on_device = weight_tensor;
-            if (bias_tensor.has_value()) {
-                bias_tensor_on_device = bias_tensor.value();
-            }
-        }
-        // run conv as matmul
-        std::optional<ttnn::operations::matmul::MatmulProgramConfig> program_config = std::nullopt;
-        std::optional<MemoryConfig> mm_output_memory_config = std::nullopt;
-        // Matmul expects inputs to be in Tile Layout
-        tilize_with_optional_deallocation(input_tensor_on_device, should_deallocate_act);
-        Tensor matmul_output = ttnn::linear(
-            input_tensor_on_device,
-            weight_tensor_on_device,
-            bias_tensor_on_device,
-            false,
-            false,
-            mm_output_memory_config,
-            output_dtype,
-            program_config,
-            conv_config.activation,
-            compute_config);
-        if (should_deallocate_act) {
-            input_tensor_on_device.deallocate(true);
-        }
-        return {matmul_output, input_height, input_width, weight_tensor_on_device, bias_tensor_on_device};
-    }
-    if (memory_config_.has_value()) {
-        log_warning(
-            tt::LogOp,
-            "Conv2D DRAM doesn't support specifying memory config, as the output will always be DRAM Interleaved");
-    }
-
-    TT_FATAL(
-        !(conv_config.output_layout == Layout::ROW_MAJOR && output_dtype == DataType::BFLOAT8_B),
-        "Conv output can't be in Row Major if output dtype is BFloat8_B.");
-
-    auto [output_height, output_width] =
-        calculate_output_image_size({input_height, input_width}, kernel_size, stride, padding_n4, dilation);
-
-    if (!conv_config.weights_dtype.has_value()) {
-        conv_config.weights_dtype = weight_tensor.dtype();
-    }
-    Conv2dSliceConfig dram_slice_config;
-    std::tie(dram_slice_config, conv_config) = determine_conv2d_slice_config(
-        dram_slice_config_,
-        ConvDRAMParamters{
-            .in_channels = in_channels,
-            .out_channels = out_channels,
-            .batch_size = batch_size,
-            .input_height = input_height,
-            .input_width = input_width,
-            .output_height = output_height,
-            .output_width = output_width,
-            .kernel_size = kernel_size,
-            .stride = stride,
-            .padding_n4 = padding_n4,
-            .dilation = dilation,
-            .groups = groups,
-            .conv_config = conv_config,
-            .compute_kernel_config = compute_config,
-            .compute_grid = compute_grid_size,
-            .weights_datatype = conv_config.weights_dtype.value_or(weight_tensor.dtype()),
-            .input_datatype = input_tensor.dtype(),
-            .output_datatype = output_dtype,
-            .input_layout = input_tensor.layout(),
-            .enable_bias = bias_tensor.has_value(),
-            .mm_conv = mm_conv,
-        },
-        device);
-    log_debug(tt::LogOp, "Conv2D DRAM with Slice Config {}", dram_slice_config);
-    TT_FATAL(dram_slice_config.num_slices > 0, " Number of slices should be greater than 0 for Conv2D DRAM Slicing");
-
-    const uint32_t output_sliced_dim =
-        dram_slice_config.slice_type == Conv2dSliceConfig::SliceType::DRAM_HEIGHT ? output_height : output_width;
-
-    if (output_sliced_dim == 1) {
-        dram_slice_config.num_slices = 1;
-    } else {
-        TT_ASSERT(
-            dram_slice_config.num_slices < output_sliced_dim,
-            " Number of slices {} should be less than the dimension {} being sliced in Conv2D DRAM Slicing",
-            dram_slice_config.num_slices,
-            output_sliced_dim);
-    }
-    if (dram_slice_config.num_slices == 1) {
-        return conv2d_L1(
-            input_tensor_on_device,
-            weight_tensor,
-            device,
-            in_channels,
-            out_channels,
-            batch_size,
-            input_height,
-            input_width,
-            kernel_size,
-            stride,
-            padding_n4,
-            dilation,
-            groups,
-            output_dtype,
-            bias_tensor,
-            conv_config,
-            compute_config_,
-            DRAM_MEMORY_CONFIG);
-    }
-    const auto unflattened_input_shape = ttnn::Shape{batch_size, input_height, input_width, in_channels};
-    input_tensor_on_device = ttnn::reshape(input_tensor_on_device, unflattened_input_shape, unflattened_input_shape);
-    TT_FATAL(input_tensor_on_device.memory_config().is_dram(), "Conv DRAM expects the input tensor to be in DRAM.");
-    TT_FATAL(
-        input_tensor_on_device.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED,
-        "Input Tensor to Conv DRAM should be in Interleaved Memory Layout");
-
-    Tensor dram_output_tensor = tt_metal::create_device_tensor(
-        TensorSpec(
-            ttnn::Shape({batch_size, output_height, output_width, out_channels}),
-            tt_metal::TensorLayout(
-                output_dtype,
-                tt_metal::PageConfig(conv_config.output_layout),
-                MemoryConfig{
-                    TensorMemoryLayout::INTERLEAVED,
-                    BufferType::DRAM,
-                })),
-        device);
-
-    weight_tensor_on_device = weight_tensor;
-    bias_tensor_on_device = bias_tensor;
-    auto slice_attr = Conv2dSliceAttr(
-        batch_size,
-        {input_height, input_width},
-        in_channels,
-        out_channels,
-        kernel_size,
-        stride,
-        padding_n4,
-        dilation,
-        groups,
-        input_tensor.layout(),
-        input_tensor.dtype(),
-        output_dtype,
-        std::ref(weight_tensor_on_device),
-        bias_tensor_on_device.has_value() ? std::make_optional(std::ref(bias_tensor_on_device.value())) : std::nullopt,
-        conv_config,
-        compute_config,
-        device);
-
-    ttnn::operations::op_slicing::run_sliced_op(
-        input_tensor_on_device, dram_output_tensor, &slice_attr, dram_slice_config);
-
-    if (should_deallocate_act) {
-        input_tensor_on_device.deallocate(true);
-    }
-    const auto flattened_output_shape = flatten_4d_shape(dram_output_tensor.logical_shape());
-    const auto flattened_padded_output_shape = flatten_4d_shape(dram_output_tensor.padded_shape());
-
-    dram_output_tensor = ttnn::reshape(dram_output_tensor, flattened_output_shape, flattened_padded_output_shape);
-
-    return {dram_output_tensor, output_height, output_width, weight_tensor_on_device, bias_tensor_on_device};
-}
+namespace ttnn::operations::conv::conv2d {
 
 Result conv2d_L1(
     const ttnn::Tensor& input_tensor_,
@@ -638,7 +240,7 @@ Result conv2d_L1(
 
     if (!mm_conv) {
         // call halo op
-        SlidingWindowConfig sliding_window_config = SlidingWindowConfig{
+        sliding_window::SlidingWindowConfig sliding_window_config = sliding_window::SlidingWindowConfig{
             .batch_size = batch_size,
             .input_hw = {input_height, input_width},
             .window_hw = {kernel_size[0], kernel_size[1]},
@@ -659,7 +261,7 @@ Result conv2d_L1(
                 input_tensor_post_tm = ttnn::to_layout(input_tensor_post_tm, Layout::ROW_MAJOR);
             }
         } else {
-            Tensor halo_output = ttnn::halo(
+            ttnn::Tensor halo_output = ttnn::halo(
                 input_tensor_post_tm,
                 sliding_window_config,
                 0,
@@ -730,7 +332,7 @@ Result conv2d_L1(
             mm_output_memory_config = conv_out_memory_config;
         }
 
-        Tensor matmul_output = ttnn::linear(
+        ttnn::Tensor matmul_output = ttnn::linear(
             input_tensor_post_tm,
             weight_tensor_on_device,
             bias_tensor_on_device,
@@ -752,6 +354,312 @@ Result conv2d_L1(
 
         return {matmul_output, output_height, output_width, weight_tensor_on_device, bias_tensor_on_device};
     }
+}
+
+// Internal class for DRAM slicing operations
+class Conv2dSliceAttr : public ttnn::operations::op_slicing::OpSliceAttr {
+    using OptionalRefTensor = std::optional<std::reference_wrapper<ttnn::Tensor>>;
+    using RefTensor = std::reference_wrapper<ttnn::Tensor>;
+
+    uint32_t batch_size;
+    IOShape input_shape;
+    uint32_t input_channels;
+    uint32_t output_channels;
+    std::array<uint32_t, 2> kernel_size;
+    std::array<uint32_t, 2> stride;
+    std::array<uint32_t, 4> padding_n4;
+    std::array<uint32_t, 2> dilation;
+    uint32_t groups;
+    Layout input_layout;
+    DataType input_dtype;
+    DataType output_dtype;
+    Tensor& weight_tensor;
+    OptionalRefTensor bias_tensor;
+    Conv2dConfig conv_config;
+    DeviceComputeKernelConfig compute_config;
+    MeshDevice* device;
+
+public:
+    Conv2dSliceAttr(
+        uint32_t batch_size,
+        IOShape input_shape,
+        uint32_t input_channels,
+        uint32_t output_channels,
+        std::array<uint32_t, 2> kernel_size,
+        std::array<uint32_t, 2> stride,
+        std::array<uint32_t, 4> padding_n4,
+        std::array<uint32_t, 2> dilation,
+        uint32_t groups,
+        Layout input_layout,
+        DataType input_dtype,
+        DataType output_dtype,
+        Tensor& weight_tensor,
+        OptionalRefTensor bias_tensor,
+        Conv2dConfig& conv_config,
+        DeviceComputeKernelConfig& compute_config,
+        MeshDevice* device);
+    std::tuple<IOShape, IOShape> get_input_slice(IOShape output_slice_start, IOShape output_slice_end) override;
+    uint32_t get_L1_usage() override;
+    tt::tt_metal::MemoryConfig get_input_memory_config(IOShape output_slice_start, IOShape output_slice_end) override;
+    ttnn::Tensor run_L1_op(
+        const ttnn::Tensor& sliced_input_tensor, IOShape output_slice_start, IOShape output_slice_end) override;
+    std::string name() override;
+};
+
+ResultWithOptions result_to_result_with_options(
+    const Result& result, const bool return_output_dim, const bool return_weights_and_bias) {
+    if (return_output_dim && return_weights_and_bias) {
+        return std::make_tuple(
+            std::get<0>(result),
+            std::make_tuple(std::get<1>(result), std::get<2>(result)),
+            std::make_tuple(std::get<3>(result), std::get<4>(result)));
+    } else if (return_output_dim) {
+        return std::make_tuple(std::get<0>(result), std::make_tuple(std::get<1>(result), std::get<2>(result)));
+    } else if (return_weights_and_bias) {
+        return std::make_tuple(std::get<0>(result), std::make_tuple(std::get<3>(result), std::get<4>(result)));
+    }
+    return std::get<0>(result);
+}
+
+// Enum to represent the execution path for conv2d operations
+enum class Conv2dExecutionPath {
+    L1,   // Execute conv2d using L1 memory
+    DRAM  // Execute conv2d using DRAM slicing
+};
+
+// Helper function to determine which conv2d execution path to take based on
+// slice configuration and input tensor properties
+Conv2dExecutionPath determine_conv2d_execution_path(
+    const ttnn::Tensor& input_tensor, const std::optional<const Conv2dSliceConfig>& slice_config) {
+    // If slice config explicitly specifies L1_FULL, use L1 path
+    if (slice_config.has_value() && slice_config->slice_type == Conv2dSliceConfig::SliceType::L1_FULL) {
+        return Conv2dExecutionPath::L1;
+    }
+
+    // If no slice config and input is already on device in L1, use L1 path
+    if (!slice_config.has_value() && tt::tt_metal::is_device_tensor(input_tensor) &&
+        input_tensor.memory_config().is_l1()) {
+        return Conv2dExecutionPath::L1;
+    }
+
+    // Otherwise, use DRAM path
+    return Conv2dExecutionPath::DRAM;
+}
+
+// This function is used for DRAM Slicing
+// It divides the output tensor into slices, and calculates the corresponding input slices.
+// Uses ttnn::slice to slice the input tensor and bring it to L1.
+// Calls conv2d_L1 to perform the convolution on the sliced input tensor.
+// Finally, it uses ttnn::experimental::slice_write to write the output tensor back to DRAM.
+// The function is called in a loop for each slice of the output tensor.
+// The Conv2dSliceConfig is used to determine the slicing configuration. The dimension along which it is sliced, and the
+// number of such slices.
+// Conv2dConfig does not control the final output, but rather the conv2d_L1 function that is called internally.
+Result conv2d_DRAM(
+    const ttnn::Tensor& input_tensor,
+    const ttnn::Tensor& weight_tensor,
+    MeshDevice* device,
+    uint32_t in_channels,
+    uint32_t out_channels,
+    uint32_t batch_size,
+    uint32_t input_height,
+    uint32_t input_width,
+    std::array<uint32_t, 2> kernel_size,
+    std::array<uint32_t, 2> stride,
+    std::variant<std::array<uint32_t, 2>, std::array<uint32_t, 4>> padding,
+    std::array<uint32_t, 2> dilation,
+    uint32_t groups,
+    const std::optional<const DataType>& dtype,
+    const std::optional<const ttnn::Tensor>& bias_tensor,
+    const std::optional<const Conv2dConfig>& conv_config_,
+    const std::optional<const DeviceComputeKernelConfig>& compute_config_,
+    const std::optional<const MemoryConfig>& memory_config_,
+    const std::optional<const Conv2dSliceConfig>& dram_slice_config_) {
+    Conv2dConfig conv_config = conv_config_.value_or(Conv2dConfig());
+    const DataType output_dtype = dtype.value_or(input_tensor.dtype());
+    std::array<uint32_t, 4> padding_n4 = sliding_window::get_pair_n4_padding(padding);
+    bool mm_conv = use_matmul_for_1x1_conv(kernel_size, stride, padding_n4, dilation, groups, conv_config);
+    DeviceComputeKernelConfig compute_config = compute_config_.value_or(get_conv_default_compute_kernel_config(device));
+    const auto compute_grid_size = device->compute_with_storage_grid_size();
+
+    // Fold the input tensor if required - this may update mm_conv after folding
+    ttnn::Tensor input_tensor_on_device = fold_input_tensor_if_required(
+        input_tensor,
+        device,
+        batch_size,
+        input_height,
+        input_width,
+        in_channels,
+        kernel_size,
+        stride,
+        dilation,
+        padding_n4,
+        mm_conv,
+        conv_config);
+    if (!is_device_tensor(input_tensor_on_device)) {
+        input_tensor_on_device =
+            ttnn::operations::core::to_device(input_tensor_on_device, device, ttnn::DRAM_MEMORY_CONFIG);
+    }
+
+    // After folding, check if this can be implemented as matmul and delegate to conv2d_L1
+    // Note: mm_conv may have been updated by fold_input_tensor_if_required
+    if (mm_conv) {
+        return conv2d_L1(
+            input_tensor_on_device,
+            weight_tensor,
+            device,
+            in_channels,
+            out_channels,
+            batch_size,
+            input_height,
+            input_width,
+            kernel_size,
+            stride,
+            padding_n4,
+            dilation,
+            groups,
+            output_dtype,
+            bias_tensor,
+            conv_config,
+            compute_config_,
+            memory_config_);
+    }
+
+    // DRAM slicing path - only executed when mm_conv is false
+    const bool should_deallocate_act = conv_config.deallocate_activation && !input_tensor.memory_config().is_dram();
+    ttnn::Tensor weight_tensor_on_device;
+    std::optional<ttnn::Tensor> bias_tensor_on_device;
+    if (memory_config_.has_value()) {
+        log_warning(
+            tt::LogOp,
+            "Conv2D DRAM doesn't support specifying memory config, as the output will always be DRAM Interleaved");
+    }
+
+    TT_FATAL(
+        !(conv_config.output_layout == Layout::ROW_MAJOR && output_dtype == DataType::BFLOAT8_B),
+        "Conv output can't be in Row Major if output dtype is BFloat8_B.");
+
+    auto [output_height, output_width] =
+        calculate_output_image_size({input_height, input_width}, kernel_size, stride, padding_n4, dilation);
+
+    if (!conv_config.weights_dtype.has_value()) {
+        conv_config.weights_dtype = weight_tensor.dtype();
+    }
+    Conv2dSliceConfig dram_slice_config;
+    std::tie(dram_slice_config, conv_config) = determine_conv2d_slice_config(
+        dram_slice_config_,
+        ConvDRAMParamters{
+            .in_channels = in_channels,
+            .out_channels = out_channels,
+            .batch_size = batch_size,
+            .input_height = input_height,
+            .input_width = input_width,
+            .output_height = output_height,
+            .output_width = output_width,
+            .kernel_size = kernel_size,
+            .stride = stride,
+            .padding_n4 = padding_n4,
+            .dilation = dilation,
+            .groups = groups,
+            .conv_config = conv_config,
+            .compute_kernel_config = compute_config,
+            .compute_grid = compute_grid_size,
+            .weights_datatype = conv_config.weights_dtype.value_or(weight_tensor.dtype()),
+            .input_datatype = input_tensor.dtype(),
+            .output_datatype = output_dtype,
+            .input_layout = input_tensor.layout(),
+            .enable_bias = bias_tensor.has_value(),
+            .mm_conv = mm_conv,
+        },
+        device);
+    log_debug(tt::LogOp, "Conv2D DRAM with Slice Config {}", dram_slice_config);
+    TT_FATAL(dram_slice_config.num_slices > 0, " Number of slices should be greater than 0 for Conv2D DRAM Slicing");
+
+    const uint32_t output_sliced_dim =
+        dram_slice_config.slice_type == Conv2dSliceConfig::SliceType::DRAM_HEIGHT ? output_height : output_width;
+
+    if (output_sliced_dim == 1) {
+        dram_slice_config.num_slices = 1;
+    } else {
+        TT_ASSERT(
+            dram_slice_config.num_slices < output_sliced_dim,
+            " Number of slices {} should be less than the dimension {} being sliced in Conv2D DRAM Slicing",
+            dram_slice_config.num_slices,
+            output_sliced_dim);
+    }
+    if (dram_slice_config.num_slices == 1) {
+        return conv2d_L1(
+            input_tensor_on_device,
+            weight_tensor,
+            device,
+            in_channels,
+            out_channels,
+            batch_size,
+            input_height,
+            input_width,
+            kernel_size,
+            stride,
+            padding_n4,
+            dilation,
+            groups,
+            output_dtype,
+            bias_tensor,
+            conv_config,
+            compute_config_,
+            DRAM_MEMORY_CONFIG);
+    }
+    const auto unflattened_input_shape = ttnn::Shape{batch_size, input_height, input_width, in_channels};
+    input_tensor_on_device = ttnn::reshape(input_tensor_on_device, unflattened_input_shape, unflattened_input_shape);
+    TT_FATAL(input_tensor_on_device.memory_config().is_dram(), "Conv DRAM expects the input tensor to be in DRAM.");
+    TT_FATAL(
+        input_tensor_on_device.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED,
+        "Input Tensor to Conv DRAM should be in Interleaved Memory Layout");
+
+    ttnn::Tensor dram_output_tensor = tt::tt_metal::create_device_tensor(
+        tt::tt_metal::TensorSpec(
+            ttnn::Shape({batch_size, output_height, output_width, out_channels}),
+            tt::tt_metal::TensorLayout(
+                output_dtype,
+                tt::tt_metal::PageConfig(conv_config.output_layout),
+                MemoryConfig{
+                    TensorMemoryLayout::INTERLEAVED,
+                    BufferType::DRAM,
+                })),
+        device);
+
+    weight_tensor_on_device = weight_tensor;
+    bias_tensor_on_device = bias_tensor;
+    auto slice_attr = Conv2dSliceAttr(
+        batch_size,
+        {input_height, input_width},
+        in_channels,
+        out_channels,
+        kernel_size,
+        stride,
+        padding_n4,
+        dilation,
+        groups,
+        input_tensor.layout(),
+        input_tensor.dtype(),
+        output_dtype,
+        std::ref(weight_tensor_on_device),
+        bias_tensor_on_device.has_value() ? std::make_optional(std::ref(bias_tensor_on_device.value())) : std::nullopt,
+        conv_config,
+        compute_config,
+        device);
+
+    ttnn::operations::op_slicing::run_sliced_op(
+        input_tensor_on_device, dram_output_tensor, &slice_attr, dram_slice_config);
+
+    if (should_deallocate_act) {
+        input_tensor_on_device.deallocate(true);
+    }
+    const auto flattened_output_shape = flatten_4d_shape(dram_output_tensor.logical_shape());
+    const auto flattened_padded_output_shape = flatten_4d_shape(dram_output_tensor.padded_shape());
+
+    dram_output_tensor = ttnn::reshape(dram_output_tensor, flattened_output_shape, flattened_padded_output_shape);
+
+    return {dram_output_tensor, output_height, output_width, weight_tensor_on_device, bias_tensor_on_device};
 }
 
 ResultWithOptions Conv2dOperation::invoke(
@@ -776,28 +684,146 @@ ResultWithOptions Conv2dOperation::invoke(
     const std::optional<const Conv2dSliceConfig>& slice_config_,
     bool return_output_dim,
     bool return_weights_and_bias) {
-    return conv2d(
-        input_tensor,
-        weight_tensor,
-        device,
-        in_channels,
-        out_channels,
-        batch_size,
-        input_height,
-        input_width,
-        kernel_size,
-        stride,
-        padding,
-        dilation,
-        groups,
-        dtype,
-        bias_tensor,
-        conv_config_,
-        compute_config_,
-        memory_config,
-        slice_config_,
+    // Determine execution path based on configuration and input properties
+    Conv2dExecutionPath path = determine_conv2d_execution_path(input_tensor, slice_config_);
+
+    // Execute L1 path
+    if (path == Conv2dExecutionPath::L1) {
+        log_trace(tt::LogOp, "Conv2d L1 {}", slice_config_.has_value() ? "with slice config" : "without slice config");
+        return result_to_result_with_options(
+            conv2d_L1(
+                input_tensor,
+                weight_tensor,
+                device,
+                in_channels,
+                out_channels,
+                batch_size,
+                input_height,
+                input_width,
+                kernel_size,
+                stride,
+                padding,
+                dilation,
+                groups,
+                dtype,
+                bias_tensor,
+                conv_config_,
+                compute_config_,
+                memory_config),
+            return_output_dim,
+            return_weights_and_bias);
+    }
+
+    // Execute DRAM path
+    log_trace(tt::LogOp, "Conv2d DRAM {}", slice_config_.has_value() ? "with slice config" : "without slice config");
+    return result_to_result_with_options(
+        conv2d_DRAM(
+            input_tensor,
+            weight_tensor,
+            device,
+            in_channels,
+            out_channels,
+            batch_size,
+            input_height,
+            input_width,
+            kernel_size,
+            stride,
+            padding,
+            dilation,
+            groups,
+            dtype,
+            bias_tensor,
+            conv_config_,
+            compute_config_,
+            memory_config,
+            slice_config_),
         return_output_dim,
         return_weights_and_bias);
+}
+
+// Helper struct to represent bounds for a single dimension (height or width)
+struct SliceBounds {
+    int start;            // Start index in input tensor
+    int end;              // End index in input tensor
+    uint32_t pad_before;  // Padding before (top for height, left for width)
+    uint32_t pad_after;   // Padding after (bottom for height, right for width)
+};
+
+// Helper struct to hold slice bounds and padding for both dimensions
+struct SlicePaddingResult {
+    SliceBounds height;
+    SliceBounds width;
+    uint32_t output_height;  // Total output height
+    uint32_t output_width;   // Total output width
+};
+
+// Calculate slice bounds and padding for conv2d slicing operations
+// This function encapsulates the logic for determining:
+// 1. Input slice boundaries based on output slice
+// 2. Padding needed at boundaries
+// 3. Special handling for edges of the full output tensor
+SlicePaddingResult calculate_slice_padding_and_bounds(
+    const std::tuple<uint32_t, uint32_t>& output_slice_start,
+    const std::tuple<uint32_t, uint32_t>& output_slice_end,
+    const std::tuple<uint32_t, uint32_t>& input_shape,
+    const std::array<uint32_t, 2>& kernel_size,
+    const std::array<uint32_t, 2>& stride,
+    const std::array<uint32_t, 4>& padding_n4,
+    const std::array<uint32_t, 2>& dilation) {
+    auto [output_slice_height_start, output_slice_width_start] = output_slice_start;
+    auto [output_slice_height_end, output_slice_width_end] = output_slice_end;
+    auto [input_height, input_width] = input_shape;
+
+    // Calculate required input slice range based on output slice
+    // Formula: input_start = (output_start * stride) - padding
+    // Formula: input_end = ((output_end - 1) * stride) - padding + dilated_kernel_size
+    int input_slice_height_start = (output_slice_height_start * stride[0]) - padding_n4[0];
+    int input_slice_height_end = ((output_slice_height_end - 1) * stride[0]) - padding_n4[0] +
+                                 ((kernel_size[0] - 1) * (dilation[0] - 1)) + kernel_size[0];
+    int input_slice_width_start = (output_slice_width_start * stride[1]) - padding_n4[2];
+    int input_slice_width_end = ((output_slice_width_end - 1) * stride[1]) - padding_n4[2] +
+                                ((kernel_size[1] - 1) * (dilation[1] - 1)) + kernel_size[1];
+
+    // Calculate padding needed if input slice extends beyond input tensor
+    uint32_t pad_top = std::max<int>(0, -input_slice_height_start);
+    uint32_t pad_bottom = std::max<int>(0, input_slice_height_end - input_height);
+    uint32_t pad_left = std::max<int>(0, -input_slice_width_start);
+    uint32_t pad_right = std::max<int>(0, input_slice_width_end - input_width);
+
+    // Clamp input slice to valid input tensor bounds
+    input_slice_height_start = std::max<int>(0, input_slice_height_start);
+    input_slice_height_end = std::min<int>(input_height, input_slice_height_end);
+    input_slice_width_start = std::max<int>(0, input_slice_width_start);
+    input_slice_width_end = std::min<int>(input_width, input_slice_width_end);
+
+    // Calculate full output dimensions
+    auto [output_height, output_width] = calculate_output_image_size(
+        std::array<uint32_t, 2>{input_height, input_width}, kernel_size, stride, padding_n4, dilation);
+
+    // Special handling for edges: if output slice starts/ends at tensor boundary,
+    // use the full original padding and reset input slice to tensor boundary
+    if (output_slice_height_start == 0) {
+        pad_top = padding_n4[0];
+        input_slice_height_start = 0;
+    }
+    if (output_slice_height_end == output_height) {
+        pad_bottom = padding_n4[1];
+        input_slice_height_end = input_height;
+    }
+    if (output_slice_width_start == 0) {
+        pad_left = padding_n4[2];
+        input_slice_width_start = 0;
+    }
+    if (output_slice_width_end == output_width) {
+        pad_right = padding_n4[3];
+        input_slice_width_end = input_width;
+    }
+
+    return SlicePaddingResult{
+        .height = {input_slice_height_start, input_slice_height_end, pad_top, pad_bottom},
+        .width = {input_slice_width_start, input_slice_width_end, pad_left, pad_right},
+        .output_height = output_height,
+        .output_width = output_width};
 }
 
 Conv2dSliceAttr::Conv2dSliceAttr(
@@ -834,43 +860,16 @@ Conv2dSliceAttr::Conv2dSliceAttr(
     bias_tensor(bias_tensor),
     conv_config(conv_config),
     compute_config(compute_config),
-    device(device) {
-
-    };
+    device(device) {}
 
 std::tuple<Conv2dSliceAttr::IOShape, Conv2dSliceAttr::IOShape> Conv2dSliceAttr::get_input_slice(
     IOShape output_slice_start, IOShape output_slice_end) {
-    auto [output_slice_height_start, output_slice_width_start] = output_slice_start;
-    auto [output_slice_height_end, output_slice_width_end] = output_slice_end;
-    int input_slice_height_start = (output_slice_height_start * stride[0]) - padding_n4[0];
-    int input_slice_height_end = ((output_slice_height_end - 1) * stride[0]) - padding_n4[0] +
-                                 ((kernel_size[0] - 1) * (dilation[0] - 1)) + kernel_size[0];
-    int input_slice_width_start = (output_slice_width_start * stride[1]) - padding_n4[2];
-    int input_slice_width_end = ((output_slice_width_end - 1) * stride[1]) - padding_n4[2] +
-                                ((kernel_size[1] - 1) * (dilation[1] - 1)) + kernel_size[1];
-    input_slice_height_start = std::max<int>(0, input_slice_height_start);
-    input_slice_height_end = std::min<int>(std::get<0>(input_shape), input_slice_height_end);
-    input_slice_width_start = std::max<int>(0, input_slice_width_start);
-    input_slice_width_end = std::min<int>(std::get<1>(input_shape), input_slice_width_end);
-    auto [output_height, output_width] = calculate_output_image_size(
-        std::array<uint32_t, 2>{std::get<0>(input_shape), std::get<1>(input_shape)},
-        kernel_size,
-        stride,
-        padding_n4,
-        dilation);
-    if (output_slice_height_start == 0) {
-        input_slice_height_start = 0;
-    }
-    if (output_slice_height_end == output_height) {
-        input_slice_height_end = std::get<0>(input_shape);
-    }
-    if (output_slice_width_start == 0) {
-        input_slice_width_start = 0;
-    }
-    if (output_slice_width_end == output_width) {
-        input_slice_width_end = std::get<1>(input_shape);
-    }
-    return {{input_slice_height_start, input_slice_width_start}, {input_slice_height_end, input_slice_width_end}};
+    // Use helper function to calculate slice bounds and padding
+    auto result = calculate_slice_padding_and_bounds(
+        output_slice_start, output_slice_end, input_shape, kernel_size, stride, padding_n4, dilation);
+
+    // Return start and end positions (padding info not needed for this function)
+    return {{result.height.start, result.width.start}, {result.height.end, result.width.end}};
 }
 uint32_t Conv2dSliceAttr::get_L1_usage() { return 0; }
 
@@ -939,63 +938,34 @@ std::string Conv2dSliceAttr::name() { return "Conv2D"; }
 
 ttnn::Tensor Conv2dSliceAttr::run_L1_op(
     const ttnn::Tensor& sliced_input_tensor, IOShape output_slice_start, IOShape output_slice_end) {
+    // Use helper function to calculate slice bounds and padding
+    auto result = calculate_slice_padding_and_bounds(
+        output_slice_start, output_slice_end, input_shape, kernel_size, stride, padding_n4, dilation);
+
+    // Calculate dimensions directly from result
+    int input_slice_height = result.height.end - result.height.start;
+    int input_slice_width = result.width.end - result.width.start;
+
     auto [output_slice_height_start, output_slice_width_start] = output_slice_start;
     auto [output_slice_height_end, output_slice_width_end] = output_slice_end;
-    int input_slice_height_start = (output_slice_height_start * stride[0]) - padding_n4[0];
-    int input_slice_height_end = ((output_slice_height_end - 1) * stride[0]) - padding_n4[0] +
-                                 ((kernel_size[0] - 1) * (dilation[0] - 1)) + kernel_size[0];
-    int input_slice_width_start = (output_slice_width_start * stride[1]) - padding_n4[2];
-    int input_slice_width_end = ((output_slice_width_end - 1) * stride[1]) - padding_n4[2] +
-                                ((kernel_size[1] - 1) * (dilation[1] - 1)) + kernel_size[1];
-
-    int pad_top = std::max<int>(0, -input_slice_height_start);
-    int pad_bottom = std::max<int>(0, input_slice_height_end - std::get<0>(input_shape));
-    int pad_left = std::max<int>(0, -input_slice_width_start);
-    int pad_right = std::max<int>(0, input_slice_width_end - std::get<1>(input_shape));
-
-    input_slice_height_start = std::max<int>(0, input_slice_height_start);
-    input_slice_height_end = std::min<int>(std::get<0>(input_shape), input_slice_height_end);
-    input_slice_width_start = std::max<int>(0, input_slice_width_start);
-    input_slice_width_end = std::min<int>(std::get<1>(input_shape), input_slice_width_end);
-
-    auto [output_height, output_width] = calculate_output_image_size(
-        std::array<uint32_t, 2>{std::get<0>(input_shape), std::get<1>(input_shape)},
-        kernel_size,
-        stride,
-        padding_n4,
-        dilation);
-    if (output_slice_height_start == 0) {
-        pad_top = padding_n4[0];
-        input_slice_height_start = 0;
-    }
-    if (output_slice_height_end == output_height) {
-        pad_bottom = padding_n4[1];
-        input_slice_height_end = std::get<0>(input_shape);
-    }
-    if (output_slice_width_start == 0) {
-        pad_left = padding_n4[2];
-        input_slice_width_start = 0;
-    }
-    if (output_slice_width_end == output_width) {
-        pad_right = padding_n4[3];
-        input_slice_width_end = std::get<1>(input_shape);
-    }
-
-    int input_slice_height = input_slice_height_end - input_slice_height_start;
-    int input_slice_width = input_slice_width_end - input_slice_width_start;
-
     uint32_t output_slice_width = output_slice_width_end - output_slice_width_start;
+
+    // Create padding array from result
+    auto this_op_padding = std::array<uint32_t, 4>(
+        {result.height.pad_before, result.height.pad_after, result.width.pad_before, result.width.pad_after});
+
+    // Apply width rounding and adjust right padding if necessary
     uint32_t width_rounding_value =
         (conv_config.output_layout == tt::tt_metal::Layout::TILE) ? tt::constants::TILE_HEIGHT : 1;
-
     if (output_slice_width % width_rounding_value != 0) {
         uint32_t additional_padded_width = width_rounding_value - (output_slice_width % width_rounding_value);
         log_trace(
-            LogOp, "Conv2d DRAM Slicing: Additional padding of {} added to the right side.", additional_padded_width);
-        pad_right += additional_padded_width * stride[1];
+            tt::LogOp,
+            "Conv2d DRAM Slicing: Additional padding of {} added to the right side.",
+            additional_padded_width);
+        this_op_padding[3] += additional_padded_width * stride[1];  // Adjust right padding
         output_slice_width += additional_padded_width;
     }
-    auto this_op_padding = std::array<uint32_t, 4>({pad_top, pad_bottom, pad_left, pad_right});
     log_debug(
         tt::LogOp,
         "Conv input {}, padding {}, dilation {}, kernel {}, stride {}, output slice {}x{}",
@@ -1017,7 +987,7 @@ ttnn::Tensor Conv2dSliceAttr::run_L1_op(
 
     auto conv2d_result = conv2d_L1(
         sliced_input_tensor,
-       weight_tensor,
+        weight_tensor,
         device,
         input_channels,
         output_channels,
@@ -1032,13 +1002,13 @@ ttnn::Tensor Conv2dSliceAttr::run_L1_op(
         output_dtype,
         bias_tensor,
         conv_config_l1,
-        compute_config);
+        compute_config,
+        std::nullopt);
     weight_tensor = std::get<3>(conv2d_result);
     if (bias_tensor.has_value()) {
         bias_tensor->get() = std::get<4>(conv2d_result).value();
     }
     return std::get<0>(conv2d_result);
 }
-}  // namespace conv2d
-}  // namespace operations::conv
-}  // namespace ttnn
+
+}  // namespace ttnn::operations::conv::conv2d

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.hpp
@@ -3,25 +3,19 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
+
 #include <optional>
-#include <stdexcept>
 #include <tuple>
 #include <variant>
 
+#include "ttnn/decorators.hpp"
 #include "ttnn/distributed/types.hpp"
 #include "ttnn/operations/conv/conv2d/device/conv2d_op.hpp"
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
-#include "ttnn/tensor/layout/layout.hpp"
-#include "ttnn/tensor/types.hpp"
-#include "ttnn/types.hpp"
 #include "ttnn/tensor/tensor.hpp"
-#include "ttnn/decorators.hpp"
-#include "ttnn/operations/conv/conv_types.hpp"
-#include "ttnn/operations/conv/conv2d/conv2d_utils.hpp"
-namespace ttnn {
+#include "ttnn/types.hpp"
 
-namespace operations::conv {
-namespace conv2d {
+namespace ttnn::operations::conv::conv2d {
 
 using OutputHeight = uint32_t;
 using OutputWidth = uint32_t;
@@ -35,70 +29,7 @@ using ResultWithOptions = std::variant<
         std::tuple<OutputHeight, OutputWidth>,
         std::tuple<ttnn::Tensor, std::optional<ttnn::Tensor>>>>;
 
-Result conv2d_L1(
-    const ttnn::Tensor& input_tensor,
-    const ttnn::Tensor& weight_tensor,
-    MeshDevice* device,
-    uint32_t in_channels,
-    uint32_t out_channels,
-    uint32_t batch_size,
-    uint32_t input_height,
-    uint32_t input_width,
-    std::array<uint32_t, 2> kernel_size,
-    std::array<uint32_t, 2> stride,
-    std::variant<std::array<uint32_t, 2>, std::array<uint32_t, 4>> padding,
-    std::array<uint32_t, 2> dilation,
-    uint32_t groups,
-    const std::optional<const DataType>& dtype = std::nullopt,
-    const std::optional<const ttnn::Tensor>& bias_tensor = std::nullopt,
-    const std::optional<const Conv2dConfig>& conv_config_ = std::nullopt,
-    const std::optional<const DeviceComputeKernelConfig>& compute_config_ = std::nullopt,
-    const std::optional<const MemoryConfig>& memory_config = std::nullopt);
-
-Result conv2d_DRAM(
-    const ttnn::Tensor& input_tensor,
-    const ttnn::Tensor& weight_tensor,
-    MeshDevice* device,
-    uint32_t in_channels,
-    uint32_t out_channels,
-    uint32_t batch_size,
-    uint32_t input_height,
-    uint32_t input_width,
-    std::array<uint32_t, 2> kernel_size,
-    std::array<uint32_t, 2> stride,
-    std::variant<std::array<uint32_t, 2>, std::array<uint32_t, 4>> padding,
-    std::array<uint32_t, 2> dilation,
-    uint32_t groups,
-    const std::optional<const DataType>& dtype = std::nullopt,
-    const std::optional<const ttnn::Tensor>& bias_tensor = std::nullopt,
-    const std::optional<const Conv2dConfig>& conv_config_ = std::nullopt,
-    const std::optional<const DeviceComputeKernelConfig>& compute_config_ = std::nullopt,
-    const std::optional<const MemoryConfig>& memory_config_ = std::nullopt,
-    const std::optional<const Conv2dSliceConfig>& dram_slice_config_ = std::nullopt);
-
-ResultWithOptions conv2d(
-    const ttnn::Tensor& input_tensor,
-    const ttnn::Tensor& weight_tensor,
-    MeshDevice* device,
-    uint32_t in_channels,
-    uint32_t out_channels,
-    uint32_t batch_size,
-    uint32_t input_height,
-    uint32_t input_width,
-    std::array<uint32_t, 2> kernel_size,
-    std::array<uint32_t, 2> stride,
-    std::variant<std::array<uint32_t, 2>, std::array<uint32_t, 4>> padding,
-    std::array<uint32_t, 2> dilation,
-    uint32_t groups,
-    const std::optional<const DataType>& dtype = std::nullopt,
-    const std::optional<const ttnn::Tensor>& bias_tensor = std::nullopt,
-    const std::optional<const Conv2dConfig>& conv_config_ = std::nullopt,
-    const std::optional<const DeviceComputeKernelConfig>& compute_config_ = std::nullopt,
-    const std::optional<const MemoryConfig>& memory_config_ = std::nullopt,
-    const std::optional<const Conv2dSliceConfig>& dram_slice_config_ = std::nullopt,
-    bool return_output_dim = false,
-    bool return_weights_and_bias = false);
-
+// Public operation interface
 struct Conv2dOperation {
     static ResultWithOptions invoke(
         const ttnn::Tensor& input_tensor,
@@ -124,58 +55,7 @@ struct Conv2dOperation {
         bool return_weights_and_bias = false);
 };
 
-class Conv2dSliceAttr : public ttnn::operations::op_slicing::OpSliceAttr {
-    using OptionalRefTensor = std::optional<std::reference_wrapper<ttnn::Tensor>>;
-    using RefTensor = std::reference_wrapper<ttnn::Tensor>;
-
-    uint32_t batch_size;
-    IOShape input_shape;
-    uint32_t input_channels;
-    uint32_t output_channels;
-    std::array<uint32_t, 2> kernel_size;
-    std::array<uint32_t, 2> stride;
-    std::array<uint32_t, 4> padding_n4;
-    std::array<uint32_t, 2> dilation;
-    uint32_t groups;
-    Layout input_layout;
-    DataType input_dtype;
-    DataType output_dtype;
-    Tensor& weight_tensor;
-    OptionalRefTensor bias_tensor;
-    Conv2dConfig conv_config;
-    DeviceComputeKernelConfig compute_config;
-    MeshDevice* device;
-
-public:
-    Conv2dSliceAttr(
-        uint32_t batch_size,
-        IOShape input_shape,
-        uint32_t input_channels,
-        uint32_t output_channels,
-        std::array<uint32_t, 2> kernel_size,
-        std::array<uint32_t, 2> stride,
-        std::array<uint32_t, 4> padding_n4,
-        std::array<uint32_t, 2> dilation,
-        uint32_t groups,
-        Layout input_layout,
-        DataType input_dtype,
-        DataType output_dtype,
-        Tensor& weight_tensor,
-        OptionalRefTensor bias_tensor,
-        Conv2dConfig& conv_config,
-        DeviceComputeKernelConfig& compute_config,
-        MeshDevice* device);
-    std::tuple<IOShape, IOShape> get_input_slice(IOShape output_slice_start, IOShape output_slice_end) override;
-    uint32_t get_L1_usage() override;
-    tt::tt_metal::MemoryConfig get_input_memory_config(IOShape output_slice_start, IOShape output_slice_end) override;
-    ttnn::Tensor run_L1_op(
-        const ttnn::Tensor& sliced_input_tensor, IOShape output_slice_start, IOShape output_slice_end) override;
-    std::string name() override;
-};
-
-}  // namespace conv2d
-}  // namespace operations::conv
-}  // namespace ttnn
+}  // namespace ttnn::operations::conv::conv2d
 
 namespace ttnn {
 constexpr auto conv2d = ttnn::register_operation<"ttnn::conv2d", operations::conv::conv2d::Conv2dOperation>();

--- a/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/conv_transpose2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/conv_transpose2d.cpp
@@ -2,28 +2,22 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <cstdint>
-#include <optional>
+#include "ttnn/operations/conv/conv_transpose2d/conv_transpose2d.hpp"
+
+#include <array>
 #include <utility>
 
+#include "ttnn/operations/conv/conv2d/conv2d_utils.hpp"
+#include "ttnn/operations/conv/conv2d/device/conv2d_op.hpp"
+#include "ttnn/operations/conv/conv_transpose2d/prepare_conv_transpose2d_weights.hpp"
 #include "ttnn/operations/core/core.hpp"
 #include "ttnn/operations/data_movement/move/move.hpp"
 #include "ttnn/operations/matmul/matmul.hpp"
-#include "ttnn/operations/conv/conv_transpose2d/conv_transpose2d.hpp"
-#include "ttnn/operations/conv/conv2d/conv2d_utils.hpp"
-#include "ttnn/operations/conv/conv_transpose2d/prepare_conv_transpose2d_weights.hpp"
 #include "ttnn/operations/sliding_window/halo/halo.hpp"
-#include "ttnn/tensor/types.hpp"
 
-namespace ttnn {
-namespace operations::conv {
+namespace ttnn::operations::conv::conv_transpose2d {
 
-using namespace tt;
-using sliding_window::SlidingWindowConfig;
-
-namespace conv_transpose2d {
-
-Result conv_transpose2d(
+Result ConvTranpose2dOperation::invoke(
     const ttnn::Tensor& input_tensor,
     const ttnn::Tensor& weight_tensor,
     MeshDevice* device,
@@ -51,7 +45,7 @@ Result conv_transpose2d(
     DeviceComputeKernelConfig compute_config = compute_config_.value_or(get_conv_default_compute_kernel_config(device));
 
     // Inverse of sliding_window.get_output_shape()
-    SlidingWindowConfig sliding_window_config = SlidingWindowConfig{
+    sliding_window::SlidingWindowConfig sliding_window_config = sliding_window::SlidingWindowConfig{
         .batch_size = batch_size,
         .input_hw = {input_height, input_width},
         .window_hw = {kernel_size[0], kernel_size[1]},
@@ -86,13 +80,13 @@ Result conv_transpose2d(
     uint32_t input_pad_left = (full_input_width - strided_input_width) / 2;
     uint32_t input_pad_right = full_input_width - strided_input_width - input_pad_left;
 
-    log_debug(LogOp, "Input : {}x{}", input_height, input_width);
-    log_debug(LogOp, "Output : {}x{}", output_height, output_width);
+    log_debug(tt::LogOp, "Input : {}x{}", input_height, input_width);
+    log_debug(tt::LogOp, "Output : {}x{}", output_height, output_width);
 
-    log_debug(LogOp, "Conv Op Input : {}x{}", full_input_height, full_input_width);
-    log_debug(LogOp, "Strided Input : {}x{}", strided_input_height, strided_input_width);
+    log_debug(tt::LogOp, "Conv Op Input : {}x{}", full_input_height, full_input_width);
+    log_debug(tt::LogOp, "Strided Input : {}x{}", strided_input_height, strided_input_width);
 
-    log_debug(LogOp, "Padding : ({},{}) ({},{})", input_pad_top, input_pad_bottom, input_pad_left, input_pad_right);
+    log_debug(tt::LogOp, "Padding : ({},{}) ({},{})", input_pad_top, input_pad_bottom, input_pad_left, input_pad_right);
 
     const bool mm_conv = use_matmul_for_1x1_conv(
         kernel_size,
@@ -312,54 +306,4 @@ Result conv_transpose2d(
     return conv_output;
 }
 
-Result ConvTranpose2dOperation::invoke(
-    const ttnn::Tensor& input_tensor,
-    const ttnn::Tensor& weight_tensor,
-    MeshDevice* device,
-    uint32_t in_channels,
-    uint32_t out_channels,
-    uint32_t batch_size,
-    uint32_t input_height,
-    uint32_t input_width,
-    std::array<uint32_t, 2> kernel_size,
-    std::array<uint32_t, 2> stride,
-    std::array<uint32_t, 2> padding,
-    std::array<uint32_t, 2> output_padding,
-    std::array<uint32_t, 2> dilation,
-    uint32_t groups,
-    const std::optional<const DataType>& dtype,
-    const std::optional<const ttnn::Tensor>& bias_tensor,
-    const std::optional<const Conv2dConfig>& conv_config_,
-    const std::optional<const DeviceComputeKernelConfig>& compute_config_,
-    const std::optional<const MemoryConfig>& memory_config,
-    bool mirror_kernel,
-    bool return_output_dim,
-    bool return_weights_and_bias) {
-    return conv_transpose2d(
-        input_tensor,
-        weight_tensor,
-        device,
-        in_channels,
-        out_channels,
-        batch_size,
-        input_height,
-        input_width,
-        kernel_size,
-        stride,
-        padding,
-        output_padding,
-        dilation,
-        groups,
-        dtype,
-        bias_tensor,
-        conv_config_,
-        compute_config_,
-        memory_config,
-        mirror_kernel,
-        return_output_dim,
-        return_weights_and_bias);
-}
-
-}  // namespace conv_transpose2d
-}  // namespace operations::conv
-}  // namespace ttnn
+}  // namespace ttnn::operations::conv::conv_transpose2d

--- a/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/conv_transpose2d.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/conv_transpose2d.hpp
@@ -3,15 +3,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
+
 #include <cstdint>
-#include "ttnn/operations/conv/conv_types.hpp"
-#include "ttnn/operations/conv/conv2d/conv2d_utils.hpp"
+#include <optional>
+#include <tuple>
+#include <variant>
+
 #include "ttnn/decorators.hpp"
+#include "ttnn/operations/conv/conv2d/device/conv2d_op.hpp"
 
-namespace ttnn {
-
-namespace operations::conv {
-namespace conv_transpose2d {
+namespace ttnn::operations::conv::conv_transpose2d {
 
 using OutputHeight = uint32_t;
 using OutputWidth = uint32_t;
@@ -25,30 +26,6 @@ using Result = std::variant<
         std::tuple<ttnn::Tensor, std::optional<ttnn::Tensor>>>>;
 
 struct ConvTranpose2dOperation {
-    static Result invoke(
-        const ttnn::Tensor& input_tensor,
-        const ttnn::Tensor& weight_tensor,
-        IDevice* device,
-        uint32_t in_channels,
-        uint32_t out_channels,
-        uint32_t batch_size,
-        uint32_t input_height,
-        uint32_t input_width,
-        std::array<uint32_t, 2> kernel_size,
-        std::array<uint32_t, 2> stride = std::array<uint32_t, 2>{1, 1},
-        std::array<uint32_t, 2> padding = std::array<uint32_t, 2>{0, 0},
-        std::array<uint32_t, 2> output_padding = std::array<uint32_t, 2>{0, 0},
-        std::array<uint32_t, 2> dilation = std::array<uint32_t, 2>{1, 1},
-        uint32_t groups = 1,
-        const std::optional<const DataType>& dtype = std::nullopt,
-        std::optional<const ttnn::Tensor> bias_tensor = std::nullopt,
-        const std::optional<const Conv2dConfig>& conv_config_ = std::nullopt,
-        const std::optional<const DeviceComputeKernelConfig>& compute_config_ = std::nullopt,
-        const std::optional<const MemoryConfig>& memory_config = std::nullopt,
-        bool mirror_kernel = true,
-        bool return_output_dim = false,
-        bool return_weights_and_bias = false);
-
     static Result invoke(
         const ttnn::Tensor& input_tensor,
         const ttnn::Tensor& weight_tensor,
@@ -66,7 +43,7 @@ struct ConvTranpose2dOperation {
         uint32_t groups = 1,
         const std::optional<const DataType>& dtype = std::nullopt,
         const std::optional<const ttnn::Tensor>& bias_tensor = std::nullopt,
-        const std::optional<const Conv2dConfig>& conv_config_ = std::nullopt,
+        const std::optional<const conv2d::Conv2dConfig>& conv_config_ = std::nullopt,
         const std::optional<const DeviceComputeKernelConfig>& compute_config_ = std::nullopt,
         const std::optional<const MemoryConfig>& memory_config = std::nullopt,
         bool mirror_kernel = true,
@@ -74,9 +51,7 @@ struct ConvTranpose2dOperation {
         bool return_weights_and_bias = false);
 };
 
-}  // namespace conv_transpose2d
-}  // namespace operations::conv
-}  // namespace ttnn
+}  // namespace ttnn::operations::conv::conv_transpose2d
 
 namespace ttnn {
 constexpr auto conv_transpose2d =

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/pool_op.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/pool_op.hpp
@@ -12,7 +12,6 @@
 #include "ttnn/core.hpp"
 #include "ttnn/decorators.hpp"
 #include "ttnn/device_operation.hpp"
-#include "ttnn/operations/conv/conv2d/conv2d.hpp"
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
 #include "ttnn/operations/sliding_window/sliding_window.hpp"
 #include "ttnn/operations/pool/pool_utils.hpp"

--- a/ttnn/cpp/ttnn/operations/sliding_window/op_slicing/op_slicing.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/op_slicing/op_slicing.cpp
@@ -11,7 +11,6 @@
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/operations/experimental/slice_write/slice_write.hpp"
 #include "ttnn/operations/experimental/padded_slice/padded_slice.hpp"
-#include "ttnn/operations/conv/conv2d/conv2d.hpp"
 namespace ttnn::operations::op_slicing {
 
 void run_sliced_op(


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/32944)

### Problem description
DRAM sliced codepath for conv2d replicated logic for running convs through ttnn::linear.
We need tensors that are passed in to ttnn::linear to be flattened (2d) in order for all cases to work.
Instead of fixing the new codepath code is refactored so that logic for this is not duplicated, and now tensors is always flattened.

In addition small cleanup was done on conv2d, conv1 and transposed_conv2d top level files.

### Checklist
  - [x] [(Single-card) Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/runs/19634676336) CI passes
  - [x] [(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/19617937492) CI passes
  - [x] [(Single-card) Model perf tests](https://github.com/tenstorrent/tt-metal/actions/runs/19617937161) CI passes
  - [x] [All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/runs/19617935798) CI passes
  - [x] [Blackhole post-commit tests](https://github.com/tenstorrent/tt-metal/actions/runs/19617936181) CI passes
  - [x] [Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/runs/19617935148) CI passes