### PR TITLE
Pjosipovic/conv2d ws prefered noc

### DIFF
--- a/models/demos/vgg/tests/test_perf_vgg.py
+++ b/models/demos/vgg/tests/test_perf_vgg.py
@@ -119,7 +119,7 @@ def test_perf_device_bare_metal_vgg(batch_size, model_name):
     margin = 0.03
 
     if model_name == "ttnn_vgg11":
-        expected_perf = 435
+        expected_perf = 448
         command = f"pytest tests/ttnn/integration_tests/vgg/test_ttnn_vgg11.py"
     else:
         expected_perf = 355

--- a/models/experimental/efficientnetb0/tests/perf/test_perf.py
+++ b/models/experimental/efficientnetb0/tests/perf/test_perf.py
@@ -15,7 +15,7 @@ from models.common.utility_functions import (
 @pytest.mark.parametrize(
     "batch_size, expected_perf",
     [
-        [1, 174.0],
+        [1, 213.0],
     ],
 )
 @pytest.mark.models_device_performance_bare_metal

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
@@ -312,6 +312,21 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_conv2d_width_sharded(
 
     bool tilize_in0 = false;
 
+    // Select preferred NoCs for DRAM operations based on architecture
+    // Must be done early to use in multicast coordinate setup
+    // weights_kernel (RISCV_1) reads weights/bias from DRAM -> use preferred read NoC
+    // act_kernel (RISCV_0) primarily does L1 reads and multicasts -> use preferred write NoC
+    // This optimizes NoC bandwidth by separating DRAM reads from L1/multicast operations
+    tt::tt_metal::NOC weights_noc = tt::tt_metal::detail::preferred_noc_for_dram_read(device->arch());
+    tt::tt_metal::NOC act_noc = tt::tt_metal::detail::preferred_noc_for_dram_write(device->arch());
+
+    log_debug(
+        tt::LogOp,
+        "Conv2D NoC selection: act_noc={}, weights_noc={} for arch={}",
+        (uint32_t)act_noc,
+        (uint32_t)weights_noc,
+        (uint32_t)device->arch());
+
     uint32_t act_mcast_sender_semaphore = tt::tt_metal::CreateSemaphore(program, all_cores, 0);    // 0==INVALID
     uint32_t act_mcast_receiver_semaphore = tt::tt_metal::CreateSemaphore(program, all_cores, 0);  // 0==INVALID.
 
@@ -319,6 +334,20 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_conv2d_width_sharded(
     CoreCoord act_mcast_end_core_logical(all_cores.bounding_box().end_coord.x, all_cores.bounding_box().end_coord.y);
     auto act_mcast_start = device->worker_core_from_logical_core(act_mcast_start_core_logical);
     auto act_mcast_end = device->worker_core_from_logical_core(act_mcast_end_core_logical);
+
+    // Swap multicast coordinates if using NOC_1 for proper addressing
+    // NOC_0 and NOC_1 have inverted coordinate systems on some architectures
+    if (act_noc == tt::tt_metal::NOC::NOC_1) {
+        std::swap(act_mcast_start, act_mcast_end);
+        log_debug(
+            tt::LogOp,
+            "Conv2D: Swapped mcast coords for NOC_1: start=({},{}), end=({},{})",
+            act_mcast_start.x,
+            act_mcast_start.y,
+            act_mcast_end.x,
+            act_mcast_end.y);
+    }
+
     TT_FATAL(act_block_h_datums % 2 == 0, "2 Indices are packed in one uint32_t word.");
 
     std::map<std::string, std::string> writer_defines;
@@ -522,7 +551,7 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_conv2d_width_sharded(
         all_reader_cores,
         tt::tt_metal::DataMovementConfig{
             .processor = tt::tt_metal::DataMovementProcessor::RISCV_0,
-            .noc = tt::tt_metal::NOC::RISCV_0_default,
+            .noc = act_noc,
             .compile_args = activation_kernel_compile_args,
             .defines = reader_defines});
 
@@ -532,7 +561,7 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_conv2d_width_sharded(
         all_cores,
         tt::tt_metal::DataMovementConfig{
             .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
-            .noc = tt::tt_metal::NOC::RISCV_1_default,
+            .noc = weights_noc,
             .compile_args = weights_kernel_compile_args,
             .defines = writer_defines});
 

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/activation_reader_width_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/activation_reader_width_sharded.cpp
@@ -204,11 +204,6 @@ void kernel_main() {
             // Round robin self-mcast and receive tilized act matrix in cb_id_act
             // Compute should function like regular mm
 #ifndef SKIP_MCAST
-            uint32_t act_w_outer_i = 0;
-
-            uint32_t sender_noc_x = 0;
-            uint32_t sender_noc_y = 0;
-
             for (uint32_t act_w_outer_i = 0; act_w_outer_i < num_input_cores; act_w_outer_i++) {
                 cb_reserve_back(cb_id_act, act_block_num_tiles);
                 if (act_w_outer_i == this_core_id) {
@@ -259,8 +254,13 @@ void kernel_main() {
                     // Set act semaphore value to INVALID
                     noc_semaphore_set(act_mcast_receiver_semaphore_addr_ptr, INVALID);
 
-                    uint32_t sender_x = act_mcast_x_lookup[sender_noc_x];
-                    uint32_t sender_y = act_mcast_y_lookup[sender_noc_y];
+                    // Compute sender's logical coordinates from iteration index
+                    uint32_t sender_logical_x = act_w_outer_i % num_cores_x;
+                    uint32_t sender_logical_y = act_w_outer_i / num_cores_x;
+
+                    // Lookup physical coordinates
+                    uint32_t sender_x = act_mcast_x_lookup[sender_logical_x];
+                    uint32_t sender_y = act_mcast_y_lookup[sender_logical_y];
 
                     // Atomic increment source core counter
                     uint64_t act_mcast_sender_semaphore_noc_addr =
@@ -272,12 +272,6 @@ void kernel_main() {
                 }
 
                 cb_push_back(cb_id_act, act_block_num_tiles);
-
-                sender_noc_x++;
-                if (sender_noc_x >= num_cores_x) {
-                    sender_noc_x = 0;
-                    sender_noc_y++;
-                }
 
             }  // num_input_cores
             cb_pop_front(tilized_in0_cb_id, act_block_num_tiles);


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/21428)

### Problem description
WIDTH_SHARDED conv2d wasn't using proper NoC selection for activation/weights kernels.
This lead to bad DRAM bw utilisation on reading weights.

### What's changed
3x perf improvement on most WS conv2d.

### Checklist
  - [x] (Single-card) Device perf regressions https://github.com/tenstorrent/tt-metal/actions/runs/19616864733 CI passes
  - [x] (Single-card) Frequent model and ttnn tests https://github.com/tenstorrent/tt-metal/actions/runs/19616865274 CI passes
  - [x] (Single-card) Model perf tests https://github.com/tenstorrent/tt-metal/actions/runs/19616864709 CI passes
  - [x] Blackhole post-commit tests https://github.com/tenstorrent/tt-metal/actions/runs/19616865171 CI passes
  - [x] Nightly tt-metal L2 tests https://github.com/tenstorrent/tt-metal/actions/runs/19616860962 CI passes
  - [ ] All post-commit tests https://github.com/tenstorrent/tt-metal/actions/runs/19635544398 in progress