### PR TITLE
Stable diffusion fix pcc error

### DIFF
--- a/models/demos/wormhole/stable_diffusion/common.py
+++ b/models/demos/wormhole/stable_diffusion/common.py
@@ -5,6 +5,6 @@
 from models.common.utility_functions import is_blackhole
 
 # L1 Small Size Constants
-SD_L1_SMALL_SIZE = 21184 if is_blackhole() else 20928
+SD_L1_SMALL_SIZE = 21760 if is_blackhole() else 20928
 # Trace Region Size Constants
 SD_TRACE_REGION_SIZE = 820000000 if is_blackhole() else 789835776

--- a/models/demos/wormhole/stable_diffusion/tt/vae/ttnn_vae_utils.py
+++ b/models/demos/wormhole/stable_diffusion/tt/vae/ttnn_vae_utils.py
@@ -120,7 +120,6 @@ def split_conv_and_run(
                 return_weights_and_bias=return_weights_and_bias,
                 dtype=conv_output_dtype,
             )
-            hidden_states_slice.deallocate(True)
 
             if return_weights_and_bias:
                 # First time we call this function, weights and biases are passed in on host;


### PR DESCRIPTION
### Problem description
Stable diffusion was red on P100 blackhole nightly due to PCC error
https://github.com/tenstorrent/tt-metal/actions/runs/19528588513/job/55955597221#step:5:256
This happened due to stopping of [DRAM activations deallocation](https://github.com/tenstorrent/tt-metal/pull/31903)


### What's changed
- removed unnecessary deallocation which caused PCC issues
- increased l1_small size for WH (to make demo test green)

### Checklist
- [X] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/19634379493)
- [X] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI [models tests pass](https://github.com/tenstorrent/tt-metal/actions/runs/19634369537)
- [X] [(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/19634389988)