### PR TITLE
Telemetry: Remove TT_METAL_HOME dependency

### DIFF
--- a/tt_telemetry/CMakeLists.txt
+++ b/tt_telemetry/CMakeLists.txt
@@ -107,6 +107,16 @@ target_link_libraries(
         protobuf::libprotobuf # Add protobuf library for compatibility
 )
 
+# Copy frontend files to build directory so they're accessible relative to the executable
+add_custom_command(
+    TARGET tt_telemetry_server
+    POST_BUILD
+    COMMAND
+        ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/frontend/static
+        ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/frontend/static
+    COMMENT "Copying frontend files to build directory"
+)
+
 # Add tests subdirectory
 if(TT_METAL_BUILD_TESTS)
     add_subdirectory(tests)

--- a/tt_telemetry/CMakeLists.txt
+++ b/tt_telemetry/CMakeLists.txt
@@ -108,14 +108,28 @@ target_link_libraries(
 )
 
 # Copy frontend files to build directory so they're accessible relative to the executable
-add_custom_command(
-    TARGET tt_telemetry_server
-    POST_BUILD
+# Validate that frontend directory exists
+if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/frontend/static")
+    message(FATAL_ERROR "Frontend static directory not found at ${CMAKE_CURRENT_SOURCE_DIR}/frontend/static")
+endif()
+
+# Track frontend source files for dependency tracking
+file(GLOB_RECURSE FRONTEND_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/frontend/static/*")
+
+# Create a custom target to manage frontend asset copying with proper dependencies
+add_custom_target(
+    copy_frontend_assets
+    ALL
     COMMAND
         ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/frontend/static
         ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/frontend/static
+    DEPENDS
+        ${FRONTEND_SOURCES}
     COMMENT "Copying frontend files to build directory"
 )
+
+# Make the server target depend on frontend assets so they're always up-to-date
+add_dependencies(tt_telemetry_server copy_frontend_assets)
 
 # Add tests subdirectory
 if(TT_METAL_BUILD_TESTS)

--- a/tt_telemetry/README.md
+++ b/tt_telemetry/README.md
@@ -53,7 +53,7 @@ metal-wh-15 slots=1
 #
 # Run using:
 #
-# mpirun -x TT_METAL_HOME -hostfile hosts.txt ./run_telemetry.sh
+# mpirun -hostfile hosts.txt ./run_telemetry.sh
 #
 
 # Get MPI rank
@@ -76,10 +76,10 @@ else
 fi
 ```
 
-3. Use `mpirun` and make sure that TT_METAL_HOME is exported.
+3. Use `mpirun` to run the script across nodes. TT_METAL_HOME is no longer required.
 
 ```
-mpirun -x TT_METAL_HOME -hostfile hosts.txt /home/btrzynadlowski/tt-metal/run_telemetry.sh
+mpirun -hostfile hosts.txt /home/btrzynadlowski/tt-metal/run_telemetry.sh
 ```
 
 # Docker

--- a/tt_telemetry/docker/Dockerfile
+++ b/tt_telemetry/docker/Dockerfile
@@ -49,7 +49,7 @@ COPY build/tt_telemetry/ ./build/tt_telemetry/
 # Copy libs
 COPY build_Release/lib ./build_Release/lib
 
-# Copy the entire tt_telemetry directory (for backwards compatibility, if needed)
+# Copy the entire tt_telemetry directory (provides fallback path for frontend files and source tree access)
 COPY tt_telemetry/ ./tt_telemetry/
 
 # Set library search path to find the copied libraries

--- a/tt_telemetry/docker/Dockerfile
+++ b/tt_telemetry/docker/Dockerfile
@@ -10,19 +10,15 @@ FROM ghcr.io/tenstorrent/tt-metal/tt-metalium-ubuntu-22.04-release-amd64:latest 
 
 FROM base AS release
 
-# Set up TT_METAL_HOME
-# (PYTHON_ENV_DIR is already set in the base image)
-ENV TT_METAL_HOME=/tt-metal
-
-# Set TT_METAL_RUNTIME_ROOT, required by Metal run-time options to be set to tt_metal/ base
-ENV TT_METAL_RUNTIME_ROOT=/tt-metal
+# Set working directory
+WORKDIR /tt-metal
 
 # Clone tt-metal
 RUN /bin/bash -c "git clone --filter=blob:none --recurse-submodules --tags \
-    https://github.com/tenstorrent/tt-metal.git ${TT_METAL_HOME} \
-    && cd ${TT_METAL_HOME}"
+    https://github.com/tenstorrent/tt-metal.git /tt-metal"
 
-WORKDIR /tt-metal
+# Set TT_METAL_RUNTIME_ROOT, required by Metal run-time options to be set to tt_metal/ base
+ENV TT_METAL_RUNTIME_ROOT=/tt-metal
 
 # Build tt_telemetry then clear cache
 RUN /bin/bash -c "./build_metal.sh --build-telemetry \
@@ -41,22 +37,19 @@ ENTRYPOINT ["./build/tt_telemetry/tt_telemetry_server"]
 
 FROM base AS dev
 
-# Set up TT_METAL_HOME environment
-ENV TT_METAL_HOME=/tt-metal
+# Set working directory
+WORKDIR /tt-metal
 
 # Set TT_METAL_RUNTIME_ROOT, required by Metal run-time options to be set to tt_metal/ base
 ENV TT_METAL_RUNTIME_ROOT=/tt-metal
 
-# Set working directory to TT_METAL_HOME
-WORKDIR ${TT_METAL_HOME}
-
-# Copy the pre-built telemetry server binary
-COPY build/tt_telemetry/tt_telemetry_server ./build/tt_telemetry/tt_telemetry_server
+# Copy the pre-built telemetry server binary and frontend files
+COPY build/tt_telemetry/ ./build/tt_telemetry/
 
 # Copy libs
 COPY build_Release/lib ./build_Release/lib
 
-# Copy the entire tt_telemetry directory (contains frontend files, etc.)
+# Copy the entire tt_telemetry directory (for backwards compatibility, if needed)
 COPY tt_telemetry/ ./tt_telemetry/
 
 # Set library search path to find the copied libraries

--- a/tt_telemetry/docker/build.sh
+++ b/tt_telemetry/docker/build.sh
@@ -7,25 +7,20 @@
 
 set -e
 
-# Check if TT_METAL_HOME is set
-if [ -z "$TT_METAL_HOME" ]; then
-    echo "Error: TT_METAL_HOME environment variable is not set"
-    exit 1
-fi
+# Get the directory where this script is located
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Metal root is three levels up from tt_telemetry/docker/
+METAL_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
-# Check if TT_METAL_HOME directory exists
-if [ ! -d "$TT_METAL_HOME" ]; then
-    echo "Error: TT_METAL_HOME directory does not exist: $TT_METAL_HOME"
-    exit 1
-fi
+echo "Using Metal root: $METAL_ROOT"
 
 # Build telemetry server locally first
 echo "Building telemetry server locally..."
-cd $TT_METAL_HOME
+cd "$METAL_ROOT"
 ./build_metal.sh --build-telemetry --build-static-libs
 
 # Check if the binary was built successfully
-if [ ! -f "$TT_METAL_HOME/build/tt_telemetry/tt_telemetry_server" ]; then
+if [ ! -f "$METAL_ROOT/build/tt_telemetry/tt_telemetry_server" ]; then
     echo "Error: tt_telemetry_server binary not found after build"
     exit 1
 fi
@@ -35,4 +30,4 @@ echo "Local build successful. Creating minimal Docker image..."
 # Build minimal Docker image with just the binary
 docker build --target dev \
     -t ghcr.io/btrzynadlowski-tt/tt-telemetry-dev:latest \
-    -f $TT_METAL_HOME/tt_telemetry/docker/Dockerfile $TT_METAL_HOME
+    -f "$METAL_ROOT/tt_telemetry/docker/Dockerfile" "$METAL_ROOT"

--- a/tt_telemetry/docker/build.sh
+++ b/tt_telemetry/docker/build.sh
@@ -9,25 +9,43 @@ set -e
 
 # Get the directory where this script is located
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# Metal root is three levels up from tt_telemetry/docker/
+# Metal root is two levels up from tt_telemetry/docker/
 METAL_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
 echo "Using Metal root: $METAL_ROOT"
+
+# Validate paths exist
+DOCKERFILE="$METAL_ROOT/tt_telemetry/docker/Dockerfile"
+if [ ! -f "$DOCKERFILE" ]; then
+    echo "Error: Dockerfile not found at $DOCKERFILE"
+    exit 1
+fi
+
+if [ ! -d "$METAL_ROOT" ]; then
+    echo "Error: Metal root directory not found at $METAL_ROOT"
+    exit 1
+fi
 
 # Build telemetry server locally first
 echo "Building telemetry server locally..."
 cd "$METAL_ROOT"
 ./build_metal.sh --build-telemetry --build-static-libs
 
-# Check if the binary was built successfully
-if [ ! -f "$METAL_ROOT/build/tt_telemetry/tt_telemetry_server" ]; then
-    echo "Error: tt_telemetry_server binary not found after build"
+# Check if the binary was built successfully and is executable
+BINARY="$METAL_ROOT/build/tt_telemetry/tt_telemetry_server"
+if [ ! -x "$BINARY" ]; then
+    echo "Error: tt_telemetry_server binary not found or not executable at $BINARY"
     exit 1
 fi
 
 echo "Local build successful. Creating minimal Docker image..."
 
 # Build minimal Docker image with just the binary
-docker build --target dev \
+if ! docker build --target dev \
     -t ghcr.io/btrzynadlowski-tt/tt-telemetry-dev:latest \
-    -f "$METAL_ROOT/tt_telemetry/docker/Dockerfile" "$METAL_ROOT"
+    -f "$DOCKERFILE" "$METAL_ROOT"; then
+    echo "Error: docker build failed for Dockerfile $DOCKERFILE (exit code: $?)"
+    exit 1
+fi
+
+echo "Docker image built successfully"

--- a/tt_telemetry/docker/build_release.sh
+++ b/tt_telemetry/docker/build_release.sh
@@ -2,18 +2,12 @@
 
 set -e
 
-# Check if TT_METAL_HOME is set
-if [ -z "$TT_METAL_HOME" ]; then
-    echo "Error: TT_METAL_HOME environment variable is not set"
-    exit 1
-fi
+# Get the directory where this script is located
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Metal root is three levels up from tt_telemetry/docker/
+METAL_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
-# Check if TT_METAL_HOME directory exists
-if [ ! -d "$TT_METAL_HOME" ]; then
-    echo "Error: TT_METAL_HOME directory does not exist: $TT_METAL_HOME"
-    exit 1
-fi
+echo "Using Metal root: $METAL_ROOT"
 
-
-# Build release image (pulls from GitHub, uses TT_METAL_HOME only to locate Dockerfile)
-docker build --target release -t ghcr.io/btrzynadlowski-tt/tt-telemetry:latest -f $TT_METAL_HOME/tt_telemetry/docker/Dockerfile $TT_METAL_HOME
+# Build release image (pulls from GitHub, builds inside container)
+docker build --target release -t ghcr.io/btrzynadlowski-tt/tt-telemetry:latest -f "$METAL_ROOT/tt_telemetry/docker/Dockerfile" "$METAL_ROOT"

--- a/tt_telemetry/docker/build_release.sh
+++ b/tt_telemetry/docker/build_release.sh
@@ -4,10 +4,29 @@ set -e
 
 # Get the directory where this script is located
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# Metal root is three levels up from tt_telemetry/docker/
+# Metal root is two levels up from tt_telemetry/docker/
 METAL_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
 echo "Using Metal root: $METAL_ROOT"
 
+# Validate paths exist
+DOCKERFILE="$METAL_ROOT/tt_telemetry/docker/Dockerfile"
+if [ ! -f "$DOCKERFILE" ]; then
+    echo "Error: Dockerfile not found at $DOCKERFILE"
+    exit 1
+fi
+
+if [ ! -d "$METAL_ROOT" ]; then
+    echo "Error: Metal root directory not found at $METAL_ROOT"
+    exit 1
+fi
+
 # Build release image (pulls from GitHub, builds inside container)
-docker build --target release -t ghcr.io/btrzynadlowski-tt/tt-telemetry:latest -f "$METAL_ROOT/tt_telemetry/docker/Dockerfile" "$METAL_ROOT"
+if ! docker build --target release \
+    -t ghcr.io/btrzynadlowski-tt/tt-telemetry:latest \
+    -f "$DOCKERFILE" "$METAL_ROOT"; then
+    echo "Error: docker build failed for Dockerfile $DOCKERFILE (exit code: $?)"
+    exit 1
+fi
+
+echo "Docker image built successfully"

--- a/tt_telemetry/include/server/collection_endpoint.hpp
+++ b/tt_telemetry/include/server/collection_endpoint.hpp
@@ -16,5 +16,4 @@
  * Collection endpoint server for broadcasting telemetry data using websocketpp.
  */
 
-std::pair<std::future<bool>, std::shared_ptr<TelemetrySubscriber>> run_collection_endpoint(
-    uint16_t port, const std::string& metal_home = "");
+std::pair<std::future<bool>, std::shared_ptr<TelemetrySubscriber>> run_collection_endpoint(uint16_t port);

--- a/tt_telemetry/server/collection_endpoint.cpp
+++ b/tt_telemetry/server/collection_endpoint.cpp
@@ -212,8 +212,7 @@ static bool collection_endpoint_thread(std::shared_ptr<TelemetryCollectionEndpoi
     return true;
 }
 
-std::pair<std::future<bool>, std::shared_ptr<TelemetrySubscriber>> run_collection_endpoint(
-    uint16_t port, const std::string& metal_home) {
+std::pair<std::future<bool>, std::shared_ptr<TelemetrySubscriber>> run_collection_endpoint(uint16_t port) {
     auto server = std::make_shared<TelemetryCollectionEndpoint>(port);
     auto future = std::async(std::launch::async, collection_endpoint_thread, server);
     return std::make_pair(std::move(future), server);

--- a/tt_telemetry/server/main.cpp
+++ b/tt_telemetry/server/main.cpp
@@ -174,7 +174,7 @@ int main(int argc, char* argv[]) {
         "ws://server1:8081,ws://server2:8081). Enables aggregator mode, disabling the collection endpoint.",
         cxxopts::value<std::string>())(
         "metal-src-dir",
-        "Metal source directory (optional, defaults to TT_METAL_HOME env var)",
+        "Metal source directory (optional override, auto-detected by default)",
         cxxopts::value<std::string>())("h,help", "Print usage")(
         "disable-telemetry",
         "Disables collection of telemetry. Only permitted in aggregator mode, which by default also collects local "
@@ -271,7 +271,7 @@ int main(int argc, char* argv[]) {
     std::shared_ptr<TelemetrySubscriber> websocket_subscriber;
     if (!aggregator_mode) {
         log_info(tt::LogAlways, "Starting collection endpoint on port {}", collector_port);
-        std::tie(websocket_server, websocket_subscriber) = run_collection_endpoint(collector_port, metal_src_dir);
+        std::tie(websocket_server, websocket_subscriber) = run_collection_endpoint(collector_port);
         subscribers.push_back(websocket_subscriber);
     } else {
         std::promise<bool> promise;  // create promise that immediately resolves to true


### PR DESCRIPTION
### Ticket
Solves #32206

### Problem description
tt-metal no longer requires `TT_METAL_HOME` to build, but telemetry still required it to locate frontend static files (HTML/JS). This created an unnecessary dependency that complicated deployment and Docker workflows.

### What's changed
Removed `TT_METAL_HOME` dependency by implementing automatic frontend file discovery:

**Build-time:**
- `CMakeLists.txt`: Added post-build command to copy frontend files to `build/tt_telemetry/frontend/static/`

**Runtime:**
- `web_server.cpp`: Implemented multi-location search for frontend files:
  1. Relative to executable (`./frontend/static/`) - for deployed builds and Docker
  2. Source tree location (`../../tt_telemetry/frontend/static/`) - for dev builds
  3. Current directory fallbacks
- Made `--metal-src-dir` an optional override instead of required
- Removed `TT_METAL_HOME` environment variable fallback

**Docker:**
- Removed `TT_METAL_HOME` environment variables from `Dockerfile`
- Updated build scripts to use script-relative paths instead of `TT_METAL_HOME`
- Dev target copies entire `build/tt_telemetry/` including frontend files

**Impact:**
- Telemetry server now works without `TT_METAL_HOME`
- Frontend files are self-contained in build artifacts
- Developers can still edit frontend files in place and reload (searches source tree)
- `--metal-src-dir` available as override when needed

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [x] New/Existing tests provide coverage for changes