### PR TITLE
Fixing CI for triage non determistic failures

### DIFF
--- a/.github/workflows/triage.yaml
+++ b/.github/workflows/triage.yaml
@@ -57,7 +57,7 @@ jobs:
         run: |
             mkdir -p generated/test_reports
             pip install -r tools/triage/requirements.txt
-            pytest ./tools/tests/triage/
+            TT_METAL_RESET_DEVICE_AFTER_HANG=1 pytest ./tools/tests/triage/
       - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
         if: ${{ failure() }}
         with:


### PR DESCRIPTION
Calling `tt-smi -r` after running hang apps.
Printing hang app process output if auto hang doesn't work for further debugging info.