### PR TITLE
enable fp32 support for ttnn.experimental.intimg

### DIFF
--- a/tests/ttnn/unit_tests/operations/reduce/test_intimg.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_intimg.py
@@ -38,7 +38,7 @@ def ttnn_integral_image_channel_last(features_nhwc):
 def test_cumsum_channel_last(device, input_shape_nhwc, dtype, memory_config):
     torch.manual_seed(0)
 
-    if dtype != ttnn.bfloat16 or dtype != ttnn.float32:
+    if dtype != ttnn.bfloat16 and dtype != ttnn.float32:
         pytest.skip("Unsupported dtype")
 
     torch_input_tensor = torch.relu(torch.rand(input_shape_nhwc, dtype=torch.bfloat16))

--- a/tests/ttnn/unit_tests/operations/reduce/test_intimg.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_intimg.py
@@ -33,12 +33,12 @@ def ttnn_integral_image_channel_last(features_nhwc):
     ],
     ids=["OFT32", "OFT16", "OFT8"],
 )
-@pytest.mark.parametrize("dtype", [ttnn.bfloat16], ids=["bfloat16"])
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32], ids=["bfloat16", "float32"])
 @pytest.mark.parametrize("memory_config", [ttnn.DRAM_MEMORY_CONFIG], ids=["DRAM"])
 def test_cumsum_channel_last(device, input_shape_nhwc, dtype, memory_config):
     torch.manual_seed(0)
 
-    if dtype != ttnn.bfloat16:
+    if dtype != ttnn.bfloat16 or dtype != ttnn.float32:
         pytest.skip("Unsupported dtype")
 
     torch_input_tensor = torch.relu(torch.rand(input_shape_nhwc, dtype=torch.bfloat16))

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/integral_image/device/intimg_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/integral_image/device/intimg_device_operation.cpp
@@ -23,7 +23,10 @@ void IntImgDeviceOperation::validate_on_program_cache_miss(
         input_shape.rank());
     TT_FATAL(input_shape[0] == 1, "intimg supports only one batch, found {} instead", input_shape[0]);
     TT_FATAL(input_layout == Layout::TILE, "only tile layout is supported, {} was provided instead", input_layout);
-    TT_FATAL(input_dtype == DataType::BFLOAT16, "only bf16 dtype is supported, {} was provided instead", input_dtype);
+    TT_FATAL(
+        input_dtype == DataType::BFLOAT16 || input_dtype == DataType::FLOAT32,
+        "only bf16 and fp32 dtypes are supported, {} was provided instead",
+        input_dtype);
 }
 
 void IntImgDeviceOperation::validate_on_program_cache_hit(

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/integral_image/device/intimg_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/integral_image/device/intimg_program_factory.cpp
@@ -94,18 +94,20 @@ IntImgProgramFactory::cached_program_t IntImgProgramFactory::create(
 
     const auto tile_spec = input_tensor.tensor_spec().tile();
 
-    const uint32_t TILES_NUM = (dst_cb_data_format == DataFormat::Float32) ? 32 : 48;
+    // if input dtype is 16bit, use 48 tiles per cb to preload tiles
+    // if 32bit, there's enough space for as may as 32 tiles per cb that the kernels expect as the minimum
+    const uint32_t tiles_num_per_cb = (dst_cb_data_format == DataFormat::Float32) ? 32 : 48;
     const auto core_range_set = CoreRangeSet{{{0, 0}, {CORES_X - 1, CORES_Y - 1}}};
-    create_cb(program, input_tensor.dtype(), IntImgCB::START, core_range_set, TILES_NUM);
-    create_cb(program, input_tensor.dtype(), IntImgCB::INPUT, core_range_set, TILES_NUM);
-    create_cb(program, input_tensor.dtype(), IntImgCB::ACC, core_range_set, TILES_NUM);
-    create_cb(program, input_tensor.dtype(), IntImgCB::CUMSUM_STAGE_0, core_range_set, TILES_NUM);
-    create_cb(program, input_tensor.dtype(), IntImgCB::CUMSUM_STAGE_1, core_range_set, TILES_NUM);
-    create_cb(program, input_tensor.dtype(), IntImgCB::CUMSUM_STAGE_2, core_range_set, TILES_NUM);
-    create_cb(program, input_tensor.dtype(), IntImgCB::OUTPUT, core_range_set, TILES_NUM);
-    create_cb(program, input_tensor.dtype(), IntImgCB::AXIS_2_BUFFER, core_range_set, TILES_NUM);
-    create_cb(program, input_tensor.dtype(), IntImgCB::AXIS_3_BUFFER_0, core_range_set, TILES_NUM);
-    create_cb(program, input_tensor.dtype(), IntImgCB::AXIS_3_BUFFER_1, core_range_set, TILES_NUM);
+    create_cb(program, input_tensor.dtype(), IntImgCB::START, core_range_set, tiles_num_per_cb);
+    create_cb(program, input_tensor.dtype(), IntImgCB::INPUT, core_range_set, tiles_num_per_cb);
+    create_cb(program, input_tensor.dtype(), IntImgCB::ACC, core_range_set, tiles_num_per_cb);
+    create_cb(program, input_tensor.dtype(), IntImgCB::CUMSUM_STAGE_0, core_range_set, tiles_num_per_cb);
+    create_cb(program, input_tensor.dtype(), IntImgCB::CUMSUM_STAGE_1, core_range_set, tiles_num_per_cb);
+    create_cb(program, input_tensor.dtype(), IntImgCB::CUMSUM_STAGE_2, core_range_set, tiles_num_per_cb);
+    create_cb(program, input_tensor.dtype(), IntImgCB::OUTPUT, core_range_set, tiles_num_per_cb);
+    create_cb(program, input_tensor.dtype(), IntImgCB::AXIS_2_BUFFER, core_range_set, tiles_num_per_cb);
+    create_cb(program, input_tensor.dtype(), IntImgCB::AXIS_3_BUFFER_0, core_range_set, tiles_num_per_cb);
+    create_cb(program, input_tensor.dtype(), IntImgCB::AXIS_3_BUFFER_1, core_range_set, tiles_num_per_cb);
 
     std::vector<uint32_t> compute_compile_time_args{
         static_cast<uint32_t>(IntImgCB::START),

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/integral_image/device/intimg_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/integral_image/device/intimg_program_factory.cpp
@@ -94,7 +94,7 @@ IntImgProgramFactory::cached_program_t IntImgProgramFactory::create(
 
     const auto tile_spec = input_tensor.tensor_spec().tile();
 
-    constexpr uint32_t TILES_NUM = 48;
+    const uint32_t TILES_NUM = (dst_cb_data_format == DataFormat::Float32) ? 32 : 48;
     const auto core_range_set = CoreRangeSet{{{0, 0}, {CORES_X - 1, CORES_Y - 1}}};
     create_cb(program, input_tensor.dtype(), IntImgCB::START, core_range_set, TILES_NUM);
     create_cb(program, input_tensor.dtype(), IntImgCB::INPUT, core_range_set, TILES_NUM);


### PR DESCRIPTION
### Ticket
#32910

### Problem description
intimg should support fp32

### What's changed
extended the assertion to support fp32 instead of only bf16 and provided a change in numbers of tiles used in cbs based on datatype

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes