### PR TITLE
Disabling gemma3 prefill until issue is fixed

### DIFF
--- a/models/demos/gemma3/tt/model_config.py
+++ b/models/demos/gemma3/tt/model_config.py
@@ -1268,6 +1268,7 @@ class ModelArgs:
         }
 
         # TODO: If no specific sequence lengths are listed for a model and device, the default one will be used (from the default_supported_seq_lens dictionary)
+        # TODO: should be empty until https://github.com/tenstorrent/tt-metal/issues/33041 is fixed
         model_specific_supported_seq_lens = {
             # EXAMPLE: "gemma-3-4b": {
             #     "N150": [128, 256, 512, 1024, 2048],

--- a/models/demos/gemma3/tt/model_config.py
+++ b/models/demos/gemma3/tt/model_config.py
@@ -1260,10 +1260,11 @@ class ModelArgs:
     def get_trace_prefill_supported_seq_lens(self):
         default_supported_seq_lens = {
             # for gemma we have different default supported seq lens than in tt_transformers
-            "N150": [128, 256],
-            "N300": [128, 256],
-            "T3K": [128, 256, 512, 1024],
-            "TG": [128, 256, 512, 1024],
+            # TODO: should be empty until https://github.com/tenstorrent/tt-metal/issues/33041 is fixed
+            "N150": [],
+            "N300": [],
+            "T3K": [],
+            "TG": [],
         }
 
         # TODO: If no specific sequence lengths are listed for a model and device, the default one will be used (from the default_supported_seq_lens dictionary)


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/33041)

### Problem description
Gemma-3-27b-it uses different codepaths when tested through metal and when tested through vLLM v1. The different codepath that it takes through vLLM has no support for prefill tracing. Until that is supported, no sequence lengths will be covered by trace.

vLLM nightly - https://github.com/tenstorrent/tt-metal/actions/runs/19639513707