### PR TITLE
9974: test_transpose_hc misalignment test fix

### DIFF
--- a/tests/scripts/run_tt_metal.py
+++ b/tests/scripts/run_tt_metal.py
@@ -84,7 +84,7 @@ TT_METAL_SLOW_DISPATCH_TEST_ENTRIES = (
         "tt_metal/tests/test_generic_binary_reader_matmul_large_block",
         "test_generic_binary_reader_matmul_large_block",
     ),
-    void_for_bh(TestEntry("tt_metal/tests/test_transpose_hc", "test_transpose_hc")),
+    TestEntry("tt_metal/tests/test_transpose_hc", "test_transpose_hc"),
     TestEntry("tt_metal/tests/test_bmm", "test_bmm"),
     # TestEntry("tt_metal/tests/test_flatten", "test_flatten"),
     TestEntry("tt_metal/tests/test_multiple_programs", "test_multiple_programs"),

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/transpose_hc.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/transpose_hc.cpp
@@ -2,60 +2,68 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <stdint.h>
 #include "dataflow_api.h"
-
 #include "debug/dprint.h"
 
-using uint32_t = std::uint32_t;
+#include <cstdint>
+#include <cstring>
 
 // tile index to address
 inline uint32_t TADDR(uint32_t ti) { return ti << 11; }
 
 void kernel_main() {
-    uint32_t src_addr = get_arg_val<uint32_t>(0);
-    uint32_t src_bank_id = get_arg_val<uint32_t>(1);
-    uint32_t W = get_arg_val<uint32_t>(2);
-    uint32_t H = get_arg_val<uint32_t>(3);
-    uint32_t C = get_arg_val<uint32_t>(4);
-    uint32_t HW = get_arg_val<uint32_t>(5);
-    uint32_t N = get_arg_val<uint32_t>(6);
-    uint32_t CHW = get_arg_val<uint32_t>(7);
+    const uint32_t src_addr = get_arg_val<uint32_t>(0U);
+    const uint32_t src_bank_id = get_arg_val<uint32_t>(1U);
+    const uint32_t W = get_arg_val<uint32_t>(2U);
+    const uint32_t H = get_arg_val<uint32_t>(3U);
+    const uint32_t C = {get_arg_val<uint32_t>(4U)};
+    const uint32_t HW = get_arg_val<uint32_t>(5U);
+    const uint32_t N = get_arg_val<uint32_t>(6U);
+    const uint32_t CHW = get_arg_val<uint32_t>(7U);
 
-    auto WT = (W >> 5);      // number of tiles in W
-    auto HT = (H >> 5);      // number of tiles in H
-    auto CT = (C >> 5);      // number of tiles in C
-    auto HTWT = (HW >> 10);  // product of HT*WT
-    auto HW2 = (HW << 1);    // HW stride in bytes
-    auto CHW2 = (CHW << 1);  // batch stride in bytes
-    constexpr uint32_t SUBTILE_LINE_BYTES = (16 << 1);
-    constexpr uint32_t onetile = 1;
-    constexpr uint32_t operand0 = 0;
+    constexpr uint32_t tile_elements = 32U;
+    const uint32_t WT = W / tile_elements;                       // number of tiles in W
+    const uint32_t HT = H / tile_elements;                       // number of tiles in H
+    const uint32_t CT = C / tile_elements;                       // number of tiles in C
+    const uint32_t HTWT = HW / (tile_elements * tile_elements);  // product of HT*WT
+    const uint32_t HW2 = HW * 2U;                                // HW stride in bytes, * 2U since FP16
+    const uint32_t CHW2 = CHW * 2U;                              // batch stride in bytes, *2U since FP16
 
-    // The basic idea here is to iterate over output tiles (that will be over CT,WT) and H
-    // this will generate a linearly incremented output address in the inner loop
-    // we then reverse map this linear dest address to src address
+    constexpr uint32_t subtile_elements = 16U;
+    constexpr uint32_t SUBTILE_LINE_BYTES = subtile_elements * 2U;  // FP16 is 2 bytes
+    constexpr uint32_t subtile_size_bytes = subtile_elements * SUBTILE_LINE_BYTES;
+    constexpr uint32_t tile_size_bytes = tile_elements * tile_elements * 2U;  // * 2U since FP16 is 2 bytes
+
+    constexpr uint32_t ALIGNMENT = get_compile_time_arg_val(0U);
+    constexpr uint32_t ALIGNMENT_MASK = ALIGNMENT - 1U;
+    constexpr bool MISALIGNED = ALIGNMENT > SUBTILE_LINE_BYTES;
+
+    const uint32_t intermed_l1_scratch = MISALIGNED ? get_write_ptr(1U) : 0U;
+    uint8_t* intermed_l1_scratch_ptr = reinterpret_cast<uint8_t*>(intermed_l1_scratch);
+
+    constexpr uint32_t onetile = 1U;
+    constexpr uint32_t operand0 = 0U;
+
+    // The original tensor shape is [N, C, H, W]
+    // It is laid out in memory as addr = W + ShapeW * H + ShapeW * ShapeH * C + ShapeW * ShapeH * ShapeC * N
+
+    // This will be converted to a tensor shape of [N, H, C, W]
+    // With memory laid out as addr = W + ShapeW * C + ShapeW * ShapeC * H + ShapeW * ShapeC * ShapeH * N
+    // Thus we loop over N, H, C, W to produce a linear incremeneted output address
     uint64_t batch_addr = get_noc_addr_from_bank_id<true>(src_bank_id, src_addr);
-    for (uint32_t n = 0; n < N; n++) {
-        uint32_t htWT = 0;
-        for (uint32_t h = 0; h < H; h++) {
-            uint32_t ctoffs = 0;
-            for (uint32_t ct = 0; ct < CT; ct++) {
-                for (uint32_t wt = 0; wt < WT; wt++) {
-                    // what is the source address for the current tile?
-                    // c32 = intra-C-tile loop
-                    // every 32 C's acquire a new output tile address
-                    //        DPRINT << "h=" << h << " ct=" << ct << " wt=" << wt << " W=" << W << " HW2=" << HW2 <<
-                    //        ENDL();
-
+    for (uint32_t n = 0U; n < N; ++n) {
+        uint32_t htWT = 0U;
+        for (uint32_t h = 0U; h < H; ++h) {
+            uint32_t ctoffs = 0U;
+            for (uint32_t ct = 0U; ct < CT; ++ct) {
+                for (uint32_t wt = 0U; wt < WT; ++wt) {
                     cb_reserve_back(operand0, onetile);
 
                     uint32_t dest_tr0_l1 = get_write_ptr(operand0);
-                    uint32_t save_dest = dest_tr0_l1;
-                    uint32_t cSubtileOffs = 0;
-                    for (uint32_t sub = 0; sub < 4; sub++) {
+                    uint32_t cSubtileOffs = 0U;
+                    for (uint32_t sub = 0U; sub < 4U; ++sub) {
                         uint32_t c16offs = cSubtileOffs;
-                        for (uint32_t c16 = 0; c16 < 16; c16++) {
+                        for (uint32_t c16 = 0U; c16 < 16; ++c16) {
                             // In this loop sub, c16 are source subtile, c16
                             // dest in this loop is varying h implicitly via dest address increment
 
@@ -63,34 +71,49 @@ void kernel_main() {
                             // We are iterating over it as H Ct Wt-tiles
                             // intra-tile FC16 for F going over 4-subtiles
                             // the source address is (bytes):
-                            // src_addr = c*HW2 + (ht*Wt + wt)*1024*2 + f*256*2 + (h16*16 + w16)*2
-                            // we have 512 bytes per subtile and 32 bytes per subtile row of 16 elems
-                            // here sub<<9 is multiply by 512 which offset in bytes of a subtile
-                            // note that dest h is decomposed as h = ht+h32 and htWT is incremented by WT in the outer H
-                            // loop
-                            auto h32 = (h & 31);
-                            // TODO(AP): not really trivial need better comments here
-                            auto sub_src_offs = (sub & 1) << 9;  // if dest subtile w==16, add 512 to src subtile offset
-                            sub_src_offs +=
-                                (((h32 >> 4) << 1)
-                                 << 9);  // if intra-tile source h is > 16, add 2*512 to subtile offset
+                            // src_addr = c*HW2 + (ht*Wt + wt)*tile_size_bytes + sub*subtile_size_bytes + (h16*16 +
+                            // w16)*2 we have 512 bytes per subtile and 32 bytes per subtile row of 16 elems note that
+                            // dest h is decomposed as h = ht+h32 and htWT is incremented by WT in the outer H loop
+                            const uint32_t h32 = static_cast<uint32_t>(h & (tile_elements - 1U));
+
+                            // subtiles are ordered like this:
+                            // 0 1
+                            // 2 3
+                            // So this will offset the address by a sub tile size for tiles 1 and 3
+                            // if intra-tile source h is >= 16, add 2*512 to subtile offset
+                            const uint32_t sub_src_offs =
+                                (sub & 0x1U) * subtile_size_bytes + (h32 / subtile_elements) * 2U * subtile_size_bytes;
+
                             // below we only use the lower 4 bits out of 5-bit range for h, shift by 5 because 2 bytes
                             // per element
-                            auto src_offs =
-                                ctoffs + c16offs + TADDR(htWT + wt) + sub_src_offs + ((h32 & 15) << 5);  // bytes offset
-                            auto src_addr = batch_addr + src_offs;
+                            const uint32_t src_offs = ctoffs + c16offs + TADDR(htWT + wt) + sub_src_offs +
+                                                      ((h32 & (subtile_elements - 1U)) * tile_elements);
+                            const uint64_t src_addr = batch_addr + src_offs;
 
-                            // if (h == 0 && ct == 0 && wt == 0) {
-                            //     DPRINT << "  Sub=" << sub << " c16=" << c16 << ENDL();
-                            //     DPRINT << "    Reading from src_offs=" << src_offs << ENDL();
-                            //     DPRINT << "    Writing to   dst_offs=" << dest_tr0_l1-save_dest << ENDL();
-                            // }
-
-                            // this starts async NOC dma from DRAM to TR0_L1 buffer
-                            noc_async_read(src_addr, dest_tr0_l1, SUBTILE_LINE_BYTES);
-
-                            // if (h == 0 && ct == 0 && wt == 0)
-                            //     DPRINT << uint32_t( reinterpret_cast<uint16_t*>( dest_tr0_l1 )[0] ) << ENDL();
+                            if (MISALIGNED) {
+                                // if source addr and dest addr don't share alignment then we need to read to the
+                                // intermediate buffer and then copy it to the correct location
+                                const uint32_t src_alignment =
+                                    static_cast<uint32_t>(src_addr & static_cast<uint64_t>(ALIGNMENT_MASK));
+                                if ((dest_tr0_l1 & ALIGNMENT_MASK) != src_alignment) {
+                                    // we write to the top of the intermediate buffer as that's aligned, and we write
+                                    // from the closest align source address if source is not aligned to ALIGNMENT then
+                                    // we go to the nearest address that is aligned and copy from there
+                                    noc_async_read(src_addr - src_alignment, intermed_l1_scratch, ALIGNMENT);
+                                    uint8_t* dest_tr0_l1_ptr = reinterpret_cast<uint8_t*>(dest_tr0_l1);
+                                    // need the barrier to ensure that we can copy from the intermediate buffer
+                                    noc_async_read_barrier();
+                                    // if source is not aligned to ALIGNMENT then we need to skip forward by the amount
+                                    // needed to align to get to the correct data
+                                    ::memcpy(
+                                        dest_tr0_l1_ptr, intermed_l1_scratch_ptr + src_alignment, SUBTILE_LINE_BYTES);
+                                } else {
+                                    // this starts async NOC dma from DRAM to TR0_L1 buffer
+                                    noc_async_read(src_addr, dest_tr0_l1, SUBTILE_LINE_BYTES);
+                                }
+                            } else {
+                                noc_async_read(src_addr, dest_tr0_l1, SUBTILE_LINE_BYTES);
+                            }
 
                             // the output address is just linearly incremented
                             dest_tr0_l1 += SUBTILE_LINE_BYTES;
@@ -100,8 +123,8 @@ void kernel_main() {
                         // 0 1
                         // 2 3
                         // Here we offset C by 16 starting with subtile=2
-                        if (sub == 1) {                  // after we are done with subtile 1, increment for sub=2
-                            cSubtileOffs += (HW2 << 4);  // 16*HWbytes, which is subtile vertical size
+                        if (sub == 1U) {  // after we are done with subtile 1, increment for sub=2
+                            cSubtileOffs += (HW2 * subtile_elements);  // 16*HWbytes, which is subtile vertical size
                         }
                     }  // sub<4
 
@@ -111,10 +134,13 @@ void kernel_main() {
                     // notifies the unpacker that the buffer is populated
                     cb_push_back(operand0, onetile);
                 }
-                ctoffs += (HW2 << 5);  // since we increment ct, we need to mlutiply by 32
+                // since src_addr for c term is ShapeW * ShapeH * C,
+                // We increment C Offset by HW2 * tile_elements
+                ctoffs += HW2 * tile_elements;
             }  // ct loop
             // multiplication-free computation of ht*WT, since ht = h/32
-            if ((h & 31) == 31) {
+            // since last h of tile increment source address W size
+            if ((h & (tile_elements - 1U)) == tile_elements - 1U) {
                 htWT += WT;
             }
         }  // h < H loop

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/transpose_hc_8bank.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/transpose_hc_8bank.cpp
@@ -2,50 +2,63 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <stdint.h>
 #include "dataflow_api.h"
-
 #include "debug/dprint.h"
 
-using uint32_t = std::uint32_t;
+#include <cstdint>
+#include <cstring>
 
 // tile index to address
 inline uint32_t TADDR(uint32_t ti) { return ti << 11; }
 
 void kernel_main() {
-    uint32_t src0_addr = get_arg_val<uint32_t>(0);
-    uint32_t src_bank_id = get_arg_val<uint32_t>(1);
-    uint32_t W = get_arg_val<uint32_t>(2);
-    uint32_t H = get_arg_val<uint32_t>(3);
-    uint32_t C = get_arg_val<uint32_t>(4);
-    uint32_t HW = get_arg_val<uint32_t>(5);
-    uint32_t N = get_arg_val<uint32_t>(6);
-    uint32_t CHW = get_arg_val<uint32_t>(7);
+    const uint32_t src0_addr = get_arg_val<uint32_t>(0U);
+    const uint32_t src_bank_id = get_arg_val<uint32_t>(1U);
+    const uint32_t W = get_arg_val<uint32_t>(2U);
+    const uint32_t H = get_arg_val<uint32_t>(3U);
+    const uint32_t C = get_arg_val<uint32_t>(4U);
+    const uint32_t HW = get_arg_val<uint32_t>(5U);
+    const uint32_t N = get_arg_val<uint32_t>(6U);
+    const uint32_t CHW = get_arg_val<uint32_t>(7U);
 
-    auto WT = (W >> 5);      // number of tiles in W
-    auto HT = (H >> 5);      // number of tiles in H
-    auto CT = (C >> 5);      // number of tiles in C
-    auto HTWT = (HW >> 10);  // product of HT*WT
-    auto HW2 = (HW << 1);    // HW stride in bytes
-    auto CHW2 = (CHW << 1);  // batch stride in bytes
-    constexpr uint32_t SUBTILE_LINE_BYTES = (16 << 1);
-    constexpr uint32_t onetile = 1;
-    constexpr uint32_t operand0 = 0;
+    constexpr uint32_t tile_elements = 32U;
+    const uint32_t WT = W / tile_elements;                       // number of tiles in W
+    const uint32_t HT = H / tile_elements;                       // number of tiles in H
+    const uint32_t CT = C / tile_elements;                       // number of tiles in C
+    const uint32_t HTWT = HW / (tile_elements * tile_elements);  // product of HT*WT
+    const uint32_t HW2 = HW * 2U;                                // HW stride in bytes, * 2U since FP16
+    const uint32_t CHW2 = CHW * 2U;                              // batch stride in bytes, *2U since FP16
 
-    // The basic idea here is to iterate over output tiles (that will be over CT,WT) and H
-    // this will generate a linearly incremented output address in the inner loop
-    // we then reverse map this linear dest address to src address
+    constexpr uint32_t subtile_elements = 16U;
+    constexpr uint32_t SUBTILE_LINE_BYTES = subtile_elements * 2U;  // FP16 is 2 bytes
+    constexpr uint32_t subtile_size_bytes = subtile_elements * SUBTILE_LINE_BYTES;
+    constexpr uint32_t tile_size_bytes = tile_elements * tile_elements * 2U;  // * 2U since FP16 is 2 bytes
 
-    constexpr auto src_args = TensorAccessorArgs<0>();
-    const auto s0 = TensorAccessor(src_args, src0_addr, 2048);
+    constexpr uint32_t ALIGNMENT = get_compile_time_arg_val(0U);
+    constexpr uint32_t ALIGNMENT_MASK = ALIGNMENT - 1U;
+    constexpr bool MISALIGNED = ALIGNMENT > SUBTILE_LINE_BYTES;
 
+    const uint32_t intermed_l1_scratch = MISALIGNED ? get_write_ptr(1U) : 0U;
+    uint8_t* intermed_l1_scratch_ptr = reinterpret_cast<uint8_t*>(intermed_l1_scratch);
+
+    constexpr uint32_t onetile = 1U;
+    constexpr uint32_t operand0 = 0U;
+    constexpr auto src_args = TensorAccessorArgs<1U>();
+    const auto s0 = TensorAccessor(src_args, src0_addr, tile_size_bytes);
+
+    // The original tensor shape is [N, C, H, W]
+    // It is laid out in memory as addr = W + ShapeW * H + ShapeW * ShapeH * C + ShapeW * ShapeH * ShapeC * N
+
+    // This will be converted to a tensor shape of [N, H, C, W]
+    // With memory laid out as addr = W + ShapeW * C + ShapeW * ShapeC * H + ShapeW * ShapeC * ShapeH * N
+    // Thus we loop over N, H, C, W to produce a linear incremented output address
     uint64_t batch_addr = src0_addr;
-    for (uint32_t n = 0; n < N; n++) {
-        uint32_t htWT = 0;
-        for (uint32_t h = 0; h < H; h++) {
-            uint32_t ctoffs = 0;
-            for (uint32_t ct = 0; ct < CT; ct++) {
-                for (uint32_t wt = 0; wt < WT; wt++) {
+    for (uint32_t n = 0U; n < N; ++n) {
+        uint32_t htWT = 0U;
+        for (uint32_t h = 0U; h < H; ++h) {
+            uint32_t ctoffs = 0U;
+            for (uint32_t ct = 0U; ct < CT; ++ct) {
+                for (uint32_t wt = 0U; wt < WT; ++wt) {
                     // what is the source address for the current tile?
                     // c32 = intra-C-tile loop
                     // every 32 C's acquire a new output tile address
@@ -55,11 +68,12 @@ void kernel_main() {
                     cb_reserve_back(operand0, onetile);
 
                     uint32_t dest_tr0_l1 = get_write_ptr(operand0);
-                    uint32_t save_dest = dest_tr0_l1;
-                    uint32_t cSubtileOffs = 0;
-                    for (uint32_t sub = 0; sub < 4; sub++) {
+                    uint32_t cSubtileOffs = 0U;
+
+                    // loop over the 4 sub tiles of each tile
+                    for (uint32_t sub = 0U; sub < 4U; ++sub) {
                         uint32_t c16offs = cSubtileOffs;
-                        for (uint32_t c16 = 0; c16 < 16; c16++) {
+                        for (uint32_t c16 = 0U; c16 < 16U; ++c16) {
                             // In this loop sub, c16 are source subtile, c16
                             // dest in this loop is varying h implicitly via dest address increment
 
@@ -67,39 +81,55 @@ void kernel_main() {
                             // We are iterating over it as H Ct Wt-tiles
                             // intra-tile FC16 for F going over 4-subtiles
                             // the source address is (bytes):
-                            // src_addr = c*HW2 + (ht*Wt + wt)*1024*2 + f*256*2 + (h16*16 + w16)*2
-                            // we have 512 bytes per subtile and 32 bytes per subtile row of 16 elems
-                            // here sub<<9 is multiply by 512 which offset in bytes of a subtile
-                            // note that dest h is decomposed as h = ht+h32 and htWT is incremented by WT in the outer H
-                            // loop
-                            auto h32 = (h & 31);
-                            // TODO(AP): not really trivial need better comments here
-                            auto sub_src_offs = (sub & 1) << 9;  // if dest subtile w==16, add 512 to src subtile offset
-                            sub_src_offs +=
-                                (((h32 >> 4) << 1)
-                                 << 9);  // if intra-tile source h is > 16, add 2*512 to subtile offset
+                            // src_addr = c*HW2 + (ht*Wt + wt)*tile_size_bytes + sub*subtile_size_bytes + (h16*16 +
+                            // w16)*2 we have 512 bytes per subtile and 32 bytes per subtile row of 16 elems note that
+                            // dest h is decomposed as h = ht+h32 and htWT is incremented by WT in the outer H loop
+                            const uint32_t h32 = static_cast<uint32_t>(h & (tile_elements - 1U));
+
+                            // subtiles are ordered like this:
+                            // 0 1
+                            // 2 3
+                            // So this will offset the address by a sub tile size for tiles 1 and 3
+                            // if intra-tile source h is >= 16, add 2*512 to subtile offset
+                            const uint32_t sub_src_offs =
+                                (sub & 0x1U) * subtile_size_bytes + (h32 / subtile_elements) * 2U * subtile_size_bytes;
+
                             // below we only use the lower 4 bits out of 5-bit range for h, shift by 5 because 2 bytes
                             // per element
-                            auto src_offs =
-                                ctoffs + c16offs + TADDR(htWT + wt) + sub_src_offs + ((h32 & 15) << 5);  // bytes offset
-                            auto bsrc_offs = (batch_addr + src_offs) - src0_addr;
-                            uint32_t batch_itile = (bsrc_offs >> 11);
-                            uint32_t rem = (bsrc_offs & 2047);
+                            const uint32_t src_offs = ctoffs + c16offs + TADDR(htWT + wt) + sub_src_offs +
+                                                      ((h32 & (subtile_elements - 1U)) * tile_elements);
+                            const uint64_t bsrc_offs = (batch_addr + src_offs) - src0_addr;
+                            const uint32_t batch_itile = static_cast<uint32_t>(bsrc_offs / tile_size_bytes);
+                            const uint32_t rem = static_cast<uint32_t>(bsrc_offs & (tile_size_bytes - 1U));
 
-                            // if (h == 0 && ct == 0 && wt == 0) {
-                            //     DPRINT << "  Sub=" << sub << " c16=" << c16 << ENDL();
-                            //     DPRINT << "    Reading from src_offs=" << src_offs << ENDL();
-                            //     DPRINT << "    Writing to   dst_offs=" << dest_tr0_l1-save_dest << ENDL();
-                            // }
+                            const uint64_t banked_addr = get_noc_addr(batch_itile, s0) + rem;
 
-                            uint64_t banked_addr = get_noc_addr(batch_itile, s0);
-                            banked_addr += rem;
-
-                            // this starts async NOC dma from DRAM to TR0_L1 buffer
-                            noc_async_read(banked_addr, dest_tr0_l1, SUBTILE_LINE_BYTES);
-
-                            // if (h == 0 && ct == 0 && wt == 0)
-                            //     DPRINT << uint32_t( reinterpret_cast<uint16_t*>( dest_tr0_l1 )[0] ) << ENDL();
+                            if (MISALIGNED) {
+                                // if banked addr and dest addr don't share alignment then we need to read to the
+                                // intermediate buffer and then copy it to the correct location
+                                const uint32_t banked_alignment =
+                                    static_cast<uint32_t>(banked_addr & static_cast<uint64_t>(ALIGNMENT_MASK));
+                                if ((dest_tr0_l1 & ALIGNMENT_MASK) != banked_alignment) {
+                                    // we write to the top of the intermediate buffer as that's aligned, and we write
+                                    // from the closest align source address if source is not aligned to ALIGNMENT then
+                                    // we go to the nearest address that is aligned and copy from there
+                                    noc_async_read(banked_addr - banked_alignment, intermed_l1_scratch, ALIGNMENT);
+                                    uint8_t* dest_tr0_l1_ptr = reinterpret_cast<uint8_t*>(dest_tr0_l1);
+                                    // need the barrier to ensure that we can copy from the intermediate buffer
+                                    noc_async_read_barrier();
+                                    // if source is not aligned to ALIGNMENT then we need to skip forward by the amount
+                                    // needed to align to get to the correct data
+                                    ::memcpy(
+                                        dest_tr0_l1_ptr,
+                                        intermed_l1_scratch_ptr + banked_alignment,
+                                        SUBTILE_LINE_BYTES);
+                                } else {
+                                    // this starts async NOC dma from DRAM to TR0_L1 buffer
+                                    noc_async_read(banked_addr, dest_tr0_l1, SUBTILE_LINE_BYTES);
+                                }
+                            } else {
+                                noc_async_read(banked_addr, dest_tr0_l1, SUBTILE_LINE_BYTES);
+                            }
 
                             // the output address is just linearly incremented
                             dest_tr0_l1 += SUBTILE_LINE_BYTES;
@@ -109,8 +139,8 @@ void kernel_main() {
                         // 0 1
                         // 2 3
                         // Here we offset C by 16 starting with subtile=2
-                        if (sub == 1) {                  // after we are done with subtile 1, increment for sub=2
-                            cSubtileOffs += (HW2 << 4);  // 16*HWbytes, which is subtile vertical size
+                        if (sub == 1U) {  // after we are done with subtile 1, increment for sub=2
+                            cSubtileOffs += (HW2 * subtile_elements);  // 16*HWbytes, which is subtile vertical size
                         }
                     }  // sub<4
 
@@ -120,13 +150,16 @@ void kernel_main() {
                     // notifies the unpacker that the buffer is populated
                     cb_push_back(operand0, onetile);
                 }
-                ctoffs += (HW2 << 5);  // since we increment ct, we need to mlutiply by 32
+                // since src_addr for c term is ShapeW * ShapeH * C,
+                // We increment C Offset by HW2 * tile_elements
+                ctoffs += HW2 * tile_elements;
             }  // ct loop
             // multiplication-free computation of ht*WT, since ht = h/32
-            if ((h & 31) == 31) {
+            // since last h of tile increment source address W size
+            if ((h & (tile_elements - 1U)) == tile_elements - 1U) {
                 htWT += WT;
             }
         }  // h < H loop
-        batch_addr += CHW2;
+        batch_addr += CHW2;  // increment for N which is the same for the source and destination address
     }  // n<N loop
 }

--- a/tests/tt_metal/tt_metal/test_transpose_hc.cpp
+++ b/tests/tt_metal/tt_metal/test_transpose_hc.cpp
@@ -2,40 +2,32 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <errno.h>
-#include <fmt/base.h>
-#include <math.h>
-#include <stdint.h>
-#include <stdlib.h>
-#include <sys/types.h>
-#include <tt-metalium/bfloat16.hpp>
-#include <tt-metalium/host_api.hpp>
-#include <tt-metalium/tilize_utils.hpp>
-#include <tt-metalium/tt_metal.hpp>
-#include <algorithm>
-#include <cstring>
-#include <exception>
-#include <functional>
-#include <map>
-#include <memory>
-#include <utility>
-#include <variant>
-#include <vector>
+#include "hostdevcommon/kernel_structs.h"
+#include "test_gold_impls.hpp"
 
-#include <tt_stl/assert.hpp>
+#include <tt-logger/tt-logger.hpp>
+#include <tt-metalium/bfloat16.hpp>
 #include <tt-metalium/buffer.hpp>
 #include <tt-metalium/buffer_types.hpp>
 #include <tt-metalium/circular_buffer_config.hpp>
 #include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/host_api.hpp>
 #include <tt-metalium/data_types.hpp>
-#include "hostdevcommon/kernel_structs.h"
 #include <tt-metalium/kernel_types.hpp>
-#include <tt-logger/tt-logger.hpp>
 #include <tt-metalium/program.hpp>
-#include <tt_stl/span.hpp>
-#include "test_gold_impls.hpp"
-#include <tt-metalium/tt_backend_api_types.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/tilize_utils.hpp>
+#include <tt-metalium/tt_backend_api_types.hpp>
+#include <tt-metalium/tt_metal.hpp>
+#include <tt_stl/assert.hpp>
+#include <tt_stl/span.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <cstdlib>
+#include <iterator>
+#include <vector>
 
 namespace tt {
 namespace tt_metal {
@@ -43,11 +35,7 @@ class IDevice;
 }  // namespace tt_metal
 }  // namespace tt
 
-using std::vector;
 using namespace tt;
-
-using std::uint16_t;
-using std::uint32_t;
 
 //////////////////////////////////////////////////////////////////////////////////////////
 // Reference CPU implementation of transpose_HC
@@ -58,9 +46,9 @@ using std::uint32_t;
 //////////////////////////////////////////////////////////////////////////////////////////
 int main(int argc, char** argv) {
     bool pass = true;
-    bool multibank = true;
+    constexpr bool multibank = true;
 
-    auto* slow_dispatch_mode = getenv("TT_METAL_SLOW_DISPATCH_MODE");
+    const auto* const slow_dispatch_mode = ::getenv("TT_METAL_SLOW_DISPATCH_MODE");
     TT_FATAL(slow_dispatch_mode, "This test only supports TT_METAL_SLOW_DISPATCH_MODE");
 
     try {
@@ -77,52 +65,70 @@ int main(int argc, char** argv) {
 
         CoreCoord core = {0, 0};
 
-        // vector<uint32_t> shape = {1, 96, 32*4, 32*5};
-        vector<uint32_t> shape = {2, 32 * 3, 32 * 5, 32 * 2};
-        uint32_t num_tensor_tiles = shape.at(0) * shape.at(1) * shape.at(2) * shape.at(3) / (32 * 32);
+        constexpr uint32_t subtile_elements = 16U;
+        constexpr uint32_t subtile_line_bytes = subtile_elements * 2U;  // FP16 is 2 bytes
+        constexpr uint32_t tile_elements = 32U;
+        constexpr uint32_t tile_size = tile_elements * tile_elements;
 
-        uint32_t single_tile_bytes = 2 * 1024;
-        uint32_t dram_buffer_bytes =
+        // shape of this vector is [N, C, H, W]
+        // It is laid out in memory as addr = W + ShapeW * H + ShapeW * ShapeH * C + ShapeW * SHapeH * ShapeC * N
+        const std::vector<uint32_t> shape = {2U, tile_elements * 3U, tile_elements * 5U, tile_elements * 2U};
+        const uint32_t num_elements =
+            std::accumulate(std::cbegin(shape), std::cend(shape), 1U, [](const uint32_t left, const uint32_t right) {
+                return left * right;
+            });
+        const uint32_t num_tensor_tiles = num_elements / tile_size;
+
+        const uint32_t single_tile_bytes = 2U * tile_size;  // FP16_B is 2 bytes
+        const uint32_t dram_buffer_bytes =
             single_tile_bytes * num_tensor_tiles;  // num_tiles of FP16_B, hard-coded in the reader/writer kernels
+        const uint32_t page_size = (!multibank) ? dram_buffer_bytes : single_tile_bytes;
 
-        uint32_t page_size = single_tile_bytes;
-        if (not multibank) {
-            page_size = dram_buffer_bytes;
-        }
-
-        tt_metal::InterleavedBufferConfig dram_config{
+        const tt_metal::InterleavedBufferConfig dram_config = {
             .device = device,
             .size = dram_buffer_bytes,
             .page_size = page_size,
             .buffer_type = tt_metal::BufferType::DRAM};
 
         auto src0_dram_buffer = CreateBuffer(dram_config);
-        uint32_t dram_buffer_src0_addr = src0_dram_buffer->address();
+        const uint32_t dram_buffer_src0_addr = src0_dram_buffer->address();
         auto dst_dram_buffer = CreateBuffer(dram_config);
-        uint32_t dram_buffer_dst_addr = dst_dram_buffer->address();
+        const uint32_t dram_buffer_dst_addr = dst_dram_buffer->address();
+        const uint32_t alignment = dst_dram_buffer->alignment();
+        const bool misaligned = alignment > subtile_line_bytes;
 
-        uint32_t src0_cb_index = 0;
-        uint32_t num_buffer_tiles = 2;
+        const uint32_t src0_cb_index = 0U;
+        const uint32_t num_buffer_tiles = 2U;
         // this buffer is used in transpose_hc.cpp NCRISC kernel
-        tt_metal::CircularBufferConfig cb_src0_config =
+        const tt_metal::CircularBufferConfig cb_src0_config =
             tt_metal::CircularBufferConfig(
                 num_buffer_tiles * single_tile_bytes, {{src0_cb_index, tt::DataFormat::Float16_b}})
                 .set_page_size(src0_cb_index, single_tile_bytes);
         tt_metal::CreateCircularBuffer(program, core, cb_src0_config);
 
-        uint32_t ouput_cb_index = tt::CBIndex::c_16;
+        const uint32_t output_cb_index = tt::CBIndex::c_16;
         // this buffer is used in writer_unary.cpp BRISC kernel
-        tt_metal::CircularBufferConfig cb_output_config =
+        const tt_metal::CircularBufferConfig cb_output_config =
             tt_metal::CircularBufferConfig(
-                num_buffer_tiles * single_tile_bytes, {{ouput_cb_index, tt::DataFormat::Float16_b}})
-                .set_page_size(ouput_cb_index, single_tile_bytes);
+                num_buffer_tiles * single_tile_bytes, {{output_cb_index, tt::DataFormat::Float16_b}})
+                .set_page_size(output_cb_index, single_tile_bytes);
         tt_metal::CreateCircularBuffer(program, core, cb_output_config);
 
-        uint32_t W = shape[3], H = shape[2], C = shape[1], N = shape[0];
-        uint32_t HW = H * W;
-        uint32_t CHW = C * H * W;
+        // need some scratch memory here - if we need data from a misaligned address then we need to read from the
+        // nearest aligned address and then copy the data to the correct location
+        if (misaligned) {
+            const uint32_t src1_cb_index = 1U;
+            tt::tt_metal::CircularBufferConfig cb_src1_config =
+                tt::tt_metal::CircularBufferConfig(alignment, {{src1_cb_index, tt::DataFormat::Float16_b}})
+                    .set_page_size(src1_cb_index, alignment);
+            tt::tt_metal::CreateCircularBuffer(program, core, cb_src1_config);
+        }
 
+        const uint32_t W = shape[3U], H = shape[2U], C = shape[1U], N = shape[0U];
+        const uint32_t HW = H * W;
+        const uint32_t CHW = C * H * W;
         std::vector<uint32_t> reader_compile_time_args;
+        reader_compile_time_args.emplace_back(alignment);
         tt::tt_metal::TensorAccessorArgs(src0_dram_buffer).append_to(reader_compile_time_args);
         auto reader_kernel = tt_metal::CreateKernel(
             program,
@@ -146,7 +152,7 @@ int main(int argc, char** argv) {
                 .noc = tt_metal::NOC::RISCV_0_default,
                 .compile_args = writer_compile_time_args});
 
-        vector<uint32_t> compute_kernel_args = {uint(num_tensor_tiles)};
+        std::vector<uint32_t> compute_kernel_args = {num_tensor_tiles};
 
         tt_metal::CreateKernel(
             program,
@@ -161,15 +167,13 @@ int main(int argc, char** argv) {
         ////////////////////////////////////////////////////////////////////////////
         //                      Execute Application
         ////////////////////////////////////////////////////////////////////////////
-        std::vector<uint32_t> src0_vec = create_random_vector_of_bfloat16(dram_buffer_bytes, 100, 0x1234);
+        std::vector<uint32_t> src0_vec = create_random_vector_of_bfloat16(dram_buffer_bytes, 100U, 0x1234);
         auto src_4f_16 = u16_from_u32_vector(src0_vec);
         tt_metal::detail::WriteToBuffer(src0_dram_buffer, src0_vec);
 
-        tt_metal::SetRuntimeArgs(
-            program, reader_kernel, core, {dram_buffer_src0_addr, (uint32_t)0, W, H, C, HW, N, CHW});
+        tt_metal::SetRuntimeArgs(program, reader_kernel, core, {dram_buffer_src0_addr, 0U, W, H, C, HW, N, CHW});
 
-        tt_metal::SetRuntimeArgs(
-            program, unary_writer_kernel, core, {dram_buffer_dst_addr, (uint32_t)0, num_tensor_tiles});
+        tt_metal::SetRuntimeArgs(program, unary_writer_kernel, core, {dram_buffer_dst_addr, 0U, num_tensor_tiles});
 
         tt_metal::detail::LaunchProgram(device, program);
 
@@ -181,11 +185,11 @@ int main(int argc, char** argv) {
         ////////////////////////////////////////////////////////////////////////////
         int argfail = -1;
         auto comparison_function = [](float a, float b) {
-            const float rtol = 0.001f;
-            const float atol = 1e-3f;
-            float maxabs = fmaxf(fabsf(a), fabsf(b));
-            float absdiff = fabsf(a - b);
-            auto result = (absdiff <= atol) || absdiff < rtol * maxabs;
+            const float rtol{0.001f};
+            const float atol{1e-3f};
+            const float maxabs{std::fmaxf(std::abs(a), std::abs(b))};
+            float absdiff{std::abs(a - b)};
+            const auto result{(absdiff <= atol) || (absdiff < rtol * maxabs)};
             if (!result) {
                 absdiff *= 1.0f;  // breakpoint spot
             }
@@ -193,16 +197,16 @@ int main(int argc, char** argv) {
         };
 
         // recover a linear view of input vector for consumption by gold_ function
-        vector<uint16_t> src_linear =
+        std::vector<uint16_t> src_linear =
             convert_layout<uint16_t>(src_4f_16, shape, TensorLayoutType::TILED_NFACES, TensorLayoutType::LIN_ROW_MAJOR);
-        vector<uint16_t> gold_reduced = gold_transpose_hc(src_linear, shape);  // result is uint16_t untilized
+        std::vector<uint16_t> gold_reduced = gold_transpose_hc(src_linear, shape);  // result is uint16_t untilized
 
         // Tilize from row major and convert to pairs (uint32_t)
-        vector<uint32_t> shapeR{shape[0], shape[2], shape[1], shape[3]};
-        auto gold_16_4f = convert_layout<uint16_t>(
+        std::vector<uint32_t> shapeR = {shape[0U], shape[2U], shape[1U], shape[3U]};
+        const auto gold_16_4f = convert_layout<uint16_t>(
             gold_reduced, shapeR, TensorLayoutType::LIN_ROW_MAJOR, TensorLayoutType::TILED_NFACES);
-        auto gold_4f_u32 = u32_from_u16_vector(gold_16_4f);
-        auto u16_result = u16_from_u32_vector(result_vec);
+        const auto gold_4f_u32 = u32_from_u16_vector(gold_16_4f);
+        const auto u16_result = u16_from_u32_vector(result_vec);
 
         pass &= packed_uint32_t_vector_comparison(result_vec, gold_4f_u32, comparison_function, &argfail);
         if (!pass) {
@@ -227,5 +231,5 @@ int main(int argc, char** argv) {
 
     TT_FATAL(pass, "Error");
 
-    return 0;
+    return EXIT_SUCCESS;
 }


### PR DESCRIPTION
This PR fixes the inability of BlackHole to run this unit tests due to the fact that BlackHole requires modulo 64 NOC address transfers. 

### Ticket
[Github Issue 9974](https://github.com/tenstorrent/tt-metal/issues/9974)

### Problem description
 
The test_transpose_hc test references two data movement kernels `transpose_hc.cpp` and `transponse_hc_8bank.cpp` which worked on WhiteHole but not BlackHole.  Data is transferred a subtile line at a time, which is (16 X 2 bytes for FP16) = 32 bytes.  Because BlackHole requires modulo 64 addresses instead of modulo 32 addresses this resulted in a hang/termination.

### What's changed
The kernels were modified to pass in the alignment as a compile time argument and if a misaligned transfer is detected then the data was copied aligned to an intermediate scratch buffer on the destination and that memory was copied to the correct location. 

The updated code was tested on both BlackHole and WhiteHole for both multibank and non multibank test cases.

### Checklist
- [X] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [X] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [X] New/Existing tests provide coverage for changes