### PR TITLE
Implement in-memory GSD/FSD validation to avoid disk I/O

### DIFF
--- a/tools/scaleout/CMakeLists.txt
+++ b/tools/scaleout/CMakeLists.txt
@@ -77,6 +77,8 @@ target_link_libraries(
     PRIVATE
         enchantum::enchantum
         protobuf::libprotobuf
+        yaml-cpp::yaml-cpp
+        scaleout_tools
         tt_metal
 )
 target_compile_features(scaleout_tools PUBLIC cxx_std_20)

--- a/tools/scaleout/factory_system_descriptor/utils.cpp
+++ b/tools/scaleout/factory_system_descriptor/utils.cpp
@@ -518,6 +518,16 @@ std::set<PhysicalChannelConnection> validate_fsd_against_gsd(
     return validate_fsd_against_gsd_impl(generated_fsd, discovered_gsd, strict_validation, assert_on_connection_mismatch, log_output);
 }
 
+std::set<PhysicalChannelConnection> validate_fsd_against_gsd(
+    const fsd::proto::FactorySystemDescriptor& fsd_proto,
+    const YAML::Node& gsd_yaml_node,
+    bool strict_validation,
+    bool assert_on_connection_mismatch,
+    bool log_output) {
+    return validate_fsd_against_gsd_impl(
+        fsd_proto, gsd_yaml_node, strict_validation, assert_on_connection_mismatch, log_output);
+}
+
 std::set<PhysicalChannelConnection> validate_cabling_descriptor_against_gsd(
     const std::string& cabling_descriptor_path,
     const std::vector<std::string>& hostnames,

--- a/tools/scaleout/factory_system_descriptor/utils.hpp
+++ b/tools/scaleout/factory_system_descriptor/utils.hpp
@@ -31,6 +31,25 @@ std::set<PhysicalChannelConnection> validate_fsd_against_gsd(
     bool assert_on_connection_mismatch = true,
     bool log_output = true);
 
+// In-memory overload for validating FSD against GSD without disk I/O
+// Validates that the Factory System Descriptor (FSD) protobuf matches the Global System Descriptor (GSD) YAML node
+// This overload operates on in-memory data structures, avoiding file I/O operations
+// Parameters:
+//   - fsd_proto: The FSD protobuf object (in-memory)
+//   - gsd_yaml_node: The GSD YAML node (in-memory)
+//   - strict_validation: If true, checks that all connections match bidirectionally
+//                        If false, only checks that GSD connections exist in FSD
+//   - assert_on_connection_mismatch: If true, throws an error if there are connection mismatches
+//                                    If false, missing connections are logged without an error being thrown
+//   - log_output: If true, logs validation results
+// Returns: Set of physical channel connections that are missing or mismatched
+std::set<PhysicalChannelConnection> validate_fsd_against_gsd(
+    const fsd::proto::FactorySystemDescriptor& fsd_proto,
+    const YAML::Node& gsd_yaml_node,
+    bool strict_validation = true,
+    bool assert_on_connection_mismatch = true,
+    bool log_output = true);
+
 // Validate cabling descriptor against discovered system topology
 std::set<PhysicalChannelConnection> validate_cabling_descriptor_against_gsd(
     const std::string& cabling_descriptor_path,

--- a/tools/scaleout/validation/run_cluster_validation.cpp
+++ b/tools/scaleout/validation/run_cluster_validation.cpp
@@ -18,6 +18,8 @@
 #include <cabling_generator/cabling_generator.hpp>
 #include <tt-metalium/hal.hpp>
 #include "tools/scaleout/validation/utils/cluster_validation_utils.hpp"
+#include <yaml-cpp/yaml.h>
+#include "protobuf/factory_system_descriptor.pb.h"
 #include <llrt/tt_cluster.hpp>
 
 namespace tt::scaleout_tools {
@@ -240,42 +242,17 @@ PhysicalSystemDescriptor generate_physical_system_descriptor(const InputArgs& in
     }
 }
 
-void cleanup_metadata(const InputArgs& input_args, const std::string& gsd_file, const std::string& fsd_file) {
-    // Remove GSD file
-    std::filesystem::remove(gsd_file);
-    if (!input_args.fsd_path.has_value()) {
-        // Remove FSD file
-        std::filesystem::remove(fsd_file);
-    } else {
-        TT_FATAL(fsd_file == input_args.fsd_path.value(), "Internal error: Expected FSD File Paths to match");
-    }
-}
-
 AsicTopology run_connectivity_validation(
     const InputArgs& input_args, PhysicalSystemDescriptor& physical_system_descriptor) {
     if (!input_args.validate_connectivity) {
         return {};
     }
-    const auto& distributed_context = tt::tt_metal::MetalContext::instance().global_distributed_context();
-    std::string gsd_yaml_filename = "global_system_descriptor_" + std::to_string(*distributed_context.rank()) + ".yaml";
-    std::string gsd_yaml_path = input_args.output_path / gsd_yaml_filename;
-    physical_system_descriptor.dump_to_yaml(gsd_yaml_path);
-
-    const auto fsd_path = get_factory_system_descriptor_path(
-        input_args.cabling_descriptor_path,
-        input_args.deployment_descriptor_path,
-        input_args.fsd_path,
-        input_args.output_path.string(),
-        physical_system_descriptor.get_all_hostnames());
+    YAML::Node gsd_yaml_node = physical_system_descriptor.generate_yaml_node();
+    auto fsd_proto = get_factory_system_descriptor(
+        input_args.cabling_descriptor_path, input_args.deployment_descriptor_path, input_args.fsd_path);
     auto missing_topology =
-        validate_connectivity(fsd_path, gsd_yaml_path, input_args.fail_on_warning, physical_system_descriptor);
+        validate_connectivity(fsd_proto, gsd_yaml_node, input_args.fail_on_warning, physical_system_descriptor);
 
-    // TODO (AS): We shouldn't need to dump files to disk for validation, once validate_fsd_against_gsd can support
-    // comparing string representations of the FSD and GSD. For now, each rank dumps a file to disk, which gets deleted
-    // post validation (for all ranks except rank 0).
-    if (*distributed_context.rank() != 0) {
-        cleanup_metadata(input_args, gsd_yaml_path, fsd_path);
-    }
     return missing_topology;
 }
 

--- a/tools/scaleout/validation/run_cluster_validation.cpp
+++ b/tools/scaleout/validation/run_cluster_validation.cpp
@@ -249,7 +249,10 @@ AsicTopology run_connectivity_validation(
     }
     YAML::Node gsd_yaml_node = physical_system_descriptor.generate_yaml_node();
     auto fsd_proto = get_factory_system_descriptor(
-        input_args.cabling_descriptor_path, input_args.deployment_descriptor_path, input_args.fsd_path);
+        input_args.cabling_descriptor_path,
+        input_args.deployment_descriptor_path,
+        input_args.fsd_path,
+        physical_system_descriptor.get_all_hostnames());
     auto missing_topology =
         validate_connectivity(fsd_proto, gsd_yaml_node, input_args.fail_on_warning, physical_system_descriptor);
 

--- a/tools/scaleout/validation/utils/cluster_validation_utils.hpp
+++ b/tools/scaleout/validation/utils/cluster_validation_utils.hpp
@@ -16,6 +16,15 @@
 #include <board/board.hpp>
 #include <factory_system_descriptor/utils.hpp>
 
+// Forward declarations for in-memory validation
+namespace YAML {
+class Node;
+}
+
+namespace tt::scaleout_tools::fsd::proto {
+class FactorySystemDescriptor;
+}
+
 namespace tt::scaleout_tools {
 
 using tt::ChipId;
@@ -87,6 +96,11 @@ tt_metal::AsicTopology generate_asic_topology_from_connections(
     const std::set<PhysicalChannelConnection>& physical_connections,
     PhysicalSystemDescriptor& physical_system_descriptor);
 
+fsd::proto::FactorySystemDescriptor get_factory_system_descriptor(
+    const std::optional<std::string>& cabling_descriptor_path,
+    const std::optional<std::string>& deployment_descriptor_path,
+    const std::optional<std::string>& fsd_path);
+
 std::string get_factory_system_descriptor_path(
     const std::optional<std::string>& cabling_descriptor_path,
     const std::optional<std::string>& deployment_descriptor_path,
@@ -95,8 +109,8 @@ std::string get_factory_system_descriptor_path(
     const std::vector<std::string>& hostnames);
 
 tt_metal::AsicTopology validate_connectivity(
-    const std::string& fsd_path,
-    const std::string& gsd_yaml_path,
+    const fsd::proto::FactorySystemDescriptor& fsd_proto,
+    const YAML::Node& gsd_yaml_node,
     bool fail_on_warning,
     PhysicalSystemDescriptor& physical_system_descriptor);
 

--- a/tools/scaleout/validation/utils/cluster_validation_utils.hpp
+++ b/tools/scaleout/validation/utils/cluster_validation_utils.hpp
@@ -99,13 +99,7 @@ tt_metal::AsicTopology generate_asic_topology_from_connections(
 fsd::proto::FactorySystemDescriptor get_factory_system_descriptor(
     const std::optional<std::string>& cabling_descriptor_path,
     const std::optional<std::string>& deployment_descriptor_path,
-    const std::optional<std::string>& fsd_path);
-
-std::string get_factory_system_descriptor_path(
-    const std::optional<std::string>& cabling_descriptor_path,
-    const std::optional<std::string>& deployment_descriptor_path,
     const std::optional<std::string>& fsd_path,
-    const std::string& output_path,
     const std::vector<std::string>& hostnames);
 
 tt_metal::AsicTopology validate_connectivity(


### PR DESCRIPTION
### Ticket
No ticket, problem described in https://github.com/tenstorrent/tt-metal/pull/31341#issuecomment-3569266500
Also issue: https://github.com/tenstorrent/tt-metal/issues/33062

### Problem description
We had unnecessary disk I/O during GSD/FSD validation by working with in-memory representations throughout the validation pipeline.

### What's changed
- Add in-memory overload of validate_fsd_against_gsd() that accepts protobuf and YAML::Node objects directly
- Refactor get_factory_system_descriptor_path() to get_factory_system_descriptor() which returns FSD protobuf object instead of writing/reading from disk
- Update validate_connectivity() to use in-memory objects (YAML::Node, FSD proto)
- Update handle_workload_timeout() to use PhysicalSystemDescriptor::generate_yaml_node() and in-memory FSD generation via CablingGenerator::generate_factory_system_descriptor()
- Update run_connectivity_validation() in run_cluster_validation.cpp to use in-memory validation, eliminating need for temp file cleanup
- Remove cleanup_metadata() function as it's no longer needed

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes