### PR TITLE
Validation: Always check for missing in gsd, extra only in strict

### DIFF
--- a/tools/scaleout/factory_system_descriptor/utils.cpp
+++ b/tools/scaleout/factory_system_descriptor/utils.cpp
@@ -408,21 +408,20 @@ std::set<PhysicalChannelConnection> validate_fsd_against_gsd_impl(
     std::set<PhysicalChannelConnection> missing_in_gsd;
     std::set<PhysicalChannelConnection> extra_in_gsd;
 
-    // Always find connections in GSD but not in FSD (both validation modes check this)
-    for (const auto& conn : discovered_connections) {
-        if (generated_connections.find(conn) == generated_connections.end()) {
-            extra_in_gsd.insert(conn);
+    // Always find connections in FSD but not in GSD (both validation modes check this)
+    for (const auto& conn : generated_connections) {
+        if (discovered_hostnames.contains(conn.first.hostname) && discovered_hostnames.contains(conn.second.hostname)) {
+            if (not discovered_connections.contains(conn)) {
+                missing_in_gsd.insert(conn);
+            }
         }
     }
 
-    // Only in strict validation: also find connections in FSD but not in GSD
+    // Only in strict validation: also find connections in GSD but not in FSD
     if (strict_validation) {
-        for (const auto& conn : generated_connections) {
-            if (discovered_hostnames.contains(conn.first.hostname) &&
-                discovered_hostnames.contains(conn.second.hostname)) {
-                if (not discovered_connections.contains(conn)) {
-                    missing_in_gsd.insert(conn);
-                }
+        for (const auto& conn : discovered_connections) {
+            if (generated_connections.find(conn) == generated_connections.end()) {
+                extra_in_gsd.insert(conn);
             }
         }
     }

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -2750,8 +2750,8 @@ void ControlPlane::validate_torus_setup(tt::tt_fabric::FabricConfig fabric_confi
         cabling_descriptor_path,
         all_hostnames,
         gsd_yaml,
-        false,  // strict_validation
-        false   // assert_on_connection_mismatch
+        true,  // strict_validation
+        true   // assert_on_connection_mismatch
     );
 
     log_debug(tt::LogFabric, "Torus validation passed for configuration: {}", enchantum::to_string(fabric_config));

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -2750,8 +2750,8 @@ void ControlPlane::validate_torus_setup(tt::tt_fabric::FabricConfig fabric_confi
         cabling_descriptor_path,
         all_hostnames,
         gsd_yaml,
-        true,  // strict_validation
-        true   // assert_on_connection_mismatch
+        false,  // strict_validation
+        true    // assert_on_connection_mismatch
     );
 
     log_debug(tt::LogFabric, "Torus validation passed for configuration: {}", enchantum::to_string(fabric_config));


### PR DESCRIPTION
### Ticket
No ticket

### Problem description
The validation logic in validate_fsd_against_gsd_impl was checking connections in the wrong direction. By default, it was finding connections present in the Generated System Descriptor (GSD) but missing in the Factory System Descriptor (FSD), when it should have been checking for connections expected by the FSD but missing in the discovered GSD. Additionally, the torus validation was running in non-strict mode without assertions, potentially allowing misconfigurations to pass silently.

### What's changed
- Swapped validation logic: default mode now checks for connections in FSD missing from GSD (previously was opposite)
- Strict validation mode now checks for extra connections in GSD not in FSD
- Torus validation changed to strict_validation=true and assert_on_connection_mismatch=true
- Validation now fails fast on mismatches instead of silently logging discrepancies

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes