### PR TITLE
SDXL UNet optimizations

### DIFF
--- a/models/experimental/stable_diffusion_xl_base/refiner/tests/pcc/test_module_tt_crossattndownblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/refiner/tests/pcc/test_module_tt_crossattndownblock2d.py
@@ -88,6 +88,7 @@ def test_crossattndown(
         layout=ttnn.TILE_LAYOUT,
         memory_config=ttnn.L1_MEMORY_CONFIG,
     )
+    ttnn_temb_tensor = ttnn.silu(ttnn_temb_tensor)
     ttnn_encoder_tensor = ttnn.from_torch(
         torch_encoder_tensor,
         dtype=ttnn.bfloat16,

--- a/models/experimental/stable_diffusion_xl_base/refiner/tests/pcc/test_module_tt_crossattnmidblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/refiner/tests/pcc/test_module_tt_crossattnmidblock2d.py
@@ -83,6 +83,7 @@ def test_crossattnmid(
         layout=ttnn.TILE_LAYOUT,
         memory_config=ttnn.L1_MEMORY_CONFIG,
     )
+    ttnn_temb_tensor = ttnn.silu(ttnn_temb_tensor)
     ttnn_encoder_tensor = ttnn.from_torch(
         torch_encoder_tensor,
         dtype=ttnn.bfloat16,

--- a/models/experimental/stable_diffusion_xl_base/refiner/tests/pcc/test_module_tt_crossattnupblock.py
+++ b/models/experimental/stable_diffusion_xl_base/refiner/tests/pcc/test_module_tt_crossattnupblock.py
@@ -109,6 +109,7 @@ def test_crossattnup(
         ttnn_residual_tensors = ttnn_residual_tensors + (ttnn_residual,)
 
     ttnn_temb_tensor = ttnn.from_torch(torch_temb_tensor, dtype=ttnn.bfloat16, device=device, layout=ttnn.TILE_LAYOUT)
+    ttnn_temb_tensor = ttnn.silu(ttnn_temb_tensor)
     ttnn_encoder_tensor = ttnn.from_torch(
         torch_encoder_tensor, dtype=ttnn.bfloat16, device=device, layout=ttnn.TILE_LAYOUT
     )

--- a/models/experimental/stable_diffusion_xl_base/refiner/tests/pcc/test_module_tt_crossattnupblock.py
+++ b/models/experimental/stable_diffusion_xl_base/refiner/tests/pcc/test_module_tt_crossattnupblock.py
@@ -37,7 +37,7 @@ from models.experimental.stable_diffusion_xl_base.tests.test_common import SDXL_
             12,
             768,
             2,
-            0.990,
+            0.989,
         ),
     ],
 )

--- a/models/experimental/stable_diffusion_xl_base/refiner/tests/pcc/test_module_tt_downblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/refiner/tests/pcc/test_module_tt_downblock2d.py
@@ -62,6 +62,7 @@ def test_downblock2d(device, temb_shape, input_shape, block_id, pcc, debug_mode,
         layout=ttnn.TILE_LAYOUT,
         memory_config=ttnn.L1_MEMORY_CONFIG,
     )
+    ttnn_temb_tensor = ttnn.silu(ttnn_temb_tensor)
     ttnn_output_tensor, output_shape, _ = tt_downblock.forward(ttnn_input_tensor, [B, C, H, W], ttnn_temb_tensor)
 
     output_tensor = ttnn.to_torch(ttnn_output_tensor)

--- a/models/experimental/stable_diffusion_xl_base/refiner/tests/pcc/test_module_tt_resnetblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/refiner/tests/pcc/test_module_tt_resnetblock2d.py
@@ -107,6 +107,7 @@ def test_resnetblock2d(
         layout=ttnn.TILE_LAYOUT,
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
     )
+    ttnn_temb_tensor = ttnn.silu(ttnn_temb_tensor)
     ttnn_output_tensor, output_shape = tt_resnet.forward(ttnn_input_tensor, ttnn_temb_tensor, [B, C, H, W])
 
     output_tensor = ttnn.to_torch(ttnn_output_tensor)

--- a/models/experimental/stable_diffusion_xl_base/refiner/tests/pcc/test_module_tt_transformerblock.py
+++ b/models/experimental/stable_diffusion_xl_base/refiner/tests/pcc/test_module_tt_transformerblock.py
@@ -18,7 +18,7 @@ from models.experimental.stable_diffusion_xl_base.tests.test_common import SDXL_
     "input_shape, encoder_shape, down_block_id, block_id, query_dim, num_attn_heads, out_dim, pcc, block_type",
     [
         ((1, 4096, 768), (1, 77, 1280), 1, 0, 768, 12, 768, 0.999, "down_blocks"),
-        ((1, 4096, 768), (1, 77, 1280), 1, 1, 768, 12, 768, 0.999, "down_blocks"),
+        ((1, 4096, 768), (1, 77, 1280), 1, 1, 768, 12, 768, 0.998, "down_blocks"),
         ((1, 1024, 1536), (1, 77, 1280), 2, 0, 1536, 24, 1536, 0.999, "down_blocks"),
         ((1, 1024, 1536), (1, 77, 1280), 2, 1, 1536, 24, 1536, 0.998, "down_blocks"),
         ((1, 256, 1536), (1, 77, 1280), -1, 0, 1536, 24, 1536, 0.998, "mid_block"),

--- a/models/experimental/stable_diffusion_xl_base/refiner/tests/pcc/test_module_tt_unet.py
+++ b/models/experimental/stable_diffusion_xl_base/refiner/tests/pcc/test_module_tt_unet.py
@@ -155,7 +155,7 @@ def run_refiner_unet_model(
 
     ttnn.ReadDeviceProfiler(device)
 
-    _, pcc_message = assert_with_pcc(torch_output_tensor, output_tensor, 0.997)
+    _, pcc_message = assert_with_pcc(torch_output_tensor, output_tensor, 0.996)
     logger.info(f"PCC of first iteration is: {pcc_message}")
 
     for _ in range(iterations - 1):

--- a/models/experimental/stable_diffusion_xl_base/refiner/tests/pcc/test_module_tt_upblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/refiner/tests/pcc/test_module_tt_upblock2d.py
@@ -92,6 +92,7 @@ def test_upblock(
         ttnn_residual_tensors = ttnn_residual_tensors + (ttnn_residual,)
 
     ttnn_temb_tensor = ttnn.from_torch(torch_temb_tensor, dtype=ttnn.bfloat16, device=device, layout=ttnn.TILE_LAYOUT)
+    ttnn_temb_tensor = ttnn.silu(ttnn_temb_tensor)
     ttnn_output_tensor, output_shape = tt_crosattn.forward(
         ttnn_input_tensor,
         ttnn_residual_tensors,

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_crossattndownblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_crossattndownblock2d.py
@@ -88,6 +88,7 @@ def test_crossattndown(
         layout=ttnn.TILE_LAYOUT,
         memory_config=ttnn.L1_MEMORY_CONFIG,
     )
+    ttnn_temb_tensor = ttnn.silu(ttnn_temb_tensor)
     ttnn_encoder_tensor = ttnn.from_torch(
         torch_encoder_tensor,
         dtype=ttnn.bfloat16,

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_crossattnmidblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_crossattnmidblock2d.py
@@ -83,6 +83,7 @@ def test_crossattnmid(
         layout=ttnn.TILE_LAYOUT,
         memory_config=ttnn.L1_MEMORY_CONFIG,
     )
+    ttnn_temb_tensor = ttnn.silu(ttnn_temb_tensor)
     ttnn_encoder_tensor = ttnn.from_torch(
         torch_encoder_tensor,
         dtype=ttnn.bfloat16,

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_crossattnupblock.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_crossattnupblock.py
@@ -109,6 +109,7 @@ def test_crossattnup(
         ttnn_residual_tensors = ttnn_residual_tensors + (ttnn_residual,)
 
     ttnn_temb_tensor = ttnn.from_torch(torch_temb_tensor, dtype=ttnn.bfloat16, device=device, layout=ttnn.TILE_LAYOUT)
+    ttnn_temb_tensor = ttnn.silu(ttnn_temb_tensor)
     ttnn_encoder_tensor = ttnn.from_torch(
         torch_encoder_tensor, dtype=ttnn.bfloat16, device=device, layout=ttnn.TILE_LAYOUT
     )

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_downblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_downblock2d.py
@@ -56,6 +56,7 @@ def test_downblock2d(device, temb_shape, input_shape, debug_mode, is_ci_env, res
         layout=ttnn.TILE_LAYOUT,
         memory_config=ttnn.L1_MEMORY_CONFIG,
     )
+    ttnn_temb_tensor = ttnn.silu(ttnn_temb_tensor)
     ttnn_output_tensor, output_shape, _ = tt_downblock.forward(ttnn_input_tensor, [B, C, H, W], ttnn_temb_tensor)
 
     output_tensor = ttnn.to_torch(ttnn_output_tensor)

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_resnetblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_resnetblock2d.py
@@ -99,6 +99,7 @@ def test_resnetblock2d(
         layout=ttnn.TILE_LAYOUT,
         memory_config=ttnn.L1_MEMORY_CONFIG,
     )
+    ttnn_temb_tensor = ttnn.silu(ttnn_temb_tensor)
     ttnn_output_tensor, output_shape = tt_resnet.forward(ttnn_input_tensor, ttnn_temb_tensor, [B, C, H, W])
 
     output_tensor = ttnn.to_torch(ttnn_output_tensor)

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_upblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_upblock2d.py
@@ -77,6 +77,7 @@ def test_upblock(
         ttnn_residual_tensors = ttnn_residual_tensors + (ttnn_residual,)
 
     ttnn_temb_tensor = ttnn.from_torch(torch_temb_tensor, dtype=ttnn.bfloat16, device=device, layout=ttnn.TILE_LAYOUT)
+    ttnn_temb_tensor = ttnn.silu(ttnn_temb_tensor)
     ttnn_output_tensor, output_shape = tt_crosattn.forward(
         ttnn_input_tensor,
         ttnn_residual_tensors,

--- a/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
@@ -117,7 +117,7 @@ def test_refiner_unet(
 
 @pytest.mark.models_device_performance_bare_metal
 def test_sdxl_refiner_unet_perf_device():
-    expected_device_perf_cycles_per_iteration = 529_581_745
+    expected_device_perf_cycles_per_iteration = 523_063_550
 
     command = f"pytest models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py::test_refiner_unet"
     cols = ["DEVICE FW", "DEVICE KERNEL", "DEVICE BRISC KERNEL"]

--- a/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
@@ -52,7 +52,7 @@ def test_unet(
 
 @pytest.mark.models_device_performance_bare_metal
 def test_sdxl_unet_perf_device():
-    expected_device_perf_cycles_per_iteration = 160_034_773
+    expected_device_perf_cycles_per_iteration = 158_803_279
 
     command = f"pytest models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py::test_unet"
     cols = ["DEVICE FW", "DEVICE KERNEL", "DEVICE BRISC KERNEL"]

--- a/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
@@ -52,7 +52,7 @@ def test_unet(
 
 @pytest.mark.models_device_performance_bare_metal
 def test_sdxl_unet_perf_device():
-    expected_device_perf_cycles_per_iteration = 163_890_516
+    expected_device_perf_cycles_per_iteration = 160_034_773
 
     command = f"pytest models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py::test_unet"
     cols = ["DEVICE FW", "DEVICE KERNEL", "DEVICE BRISC KERNEL"]

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_attention.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_attention.py
@@ -61,7 +61,13 @@ class TtAttention(LightweightModule):
 
         if self.is_self_attention == True:
             self.sdpa_program_config.q_chunk_size = 128
-            self.sdpa_program_config.k_chunk_size = 1024 if self.heads == 20 else 512
+            if out_dim == 640:
+                self.sdpa_program_config.k_chunk_size = 512
+            # TODO: 512 should be possible, latents base optimizations regressed this
+            elif out_dim == 768:
+                self.sdpa_program_config.k_chunk_size = 256
+            else:
+                self.sdpa_program_config.k_chunk_size = 1024
             fused_qkv_weights = torch.cat(
                 [
                     torch.transpose(q_weights, -2, -1),

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_attention.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_attention.py
@@ -61,7 +61,7 @@ class TtAttention(LightweightModule):
 
         if self.is_self_attention == True:
             self.sdpa_program_config.q_chunk_size = 128
-            if out_dim == 640:
+            if out_dim == 640 or out_dim == 1536:
                 self.sdpa_program_config.k_chunk_size = 512
             # TODO: 512 should be possible, latents base optimizations regressed this
             elif out_dim == 768:

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_attention.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_attention.py
@@ -97,33 +97,14 @@ class TtAttention(LightweightModule):
         B, C, H, W = list(hidden_states.shape)
 
         if self.is_self_attention:
-            if self.q_program_config is not None:
-                if hidden_states.shape[-1] == 640:
-                    memory_config = ttnn.create_sharded_memory_config(
-                        shape=(1, 1, 512, 256),
-                        core_grid=ttnn.CoreGrid(y=8, x=8),
-                        strategy=ttnn.ShardStrategy.BLOCK,
-                        use_height_and_width_as_shard_shape=True,
-                    )
-                else:
-                    memory_config = ttnn.create_sharded_memory_config(
-                        shape=(1, 1, 1024 // 8, 3840 // 8),
-                        core_grid=ttnn.CoreGrid(y=8, x=8),
-                        strategy=ttnn.ShardStrategy.BLOCK,
-                        use_height_and_width_as_shard_shape=True,
-                    )
-            else:
-                memory_config = None
-
             qkv_fused = ttnn.matmul(
                 hidden_states,
                 self.tt_qkv_weights,
-                memory_config=memory_config,
+                memory_config=ttnn.L1_MEMORY_CONFIG,
                 dtype=ttnn.bfloat16,
                 compute_kernel_config=self.q_compute_kernel_config,
                 program_config=self.q_program_config,
             )
-            qkv_fused = ttnn.sharded_to_interleaved(qkv_fused, ttnn.L1_MEMORY_CONFIG)
 
             (
                 q_heads,

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_crossattnupblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_crossattnupblock2d.py
@@ -98,7 +98,7 @@ class TtCrossAttnUpBlock2D(LightweightModule):
         ttnn.ReadDeviceProfiler(self.device)
 
         if self.upsamplers is not None:
-            hidden_states = ttnn.reshape(hidden_states, [B, H, W, C])
             hidden_states = ttnn.to_layout(hidden_states, ttnn.ROW_MAJOR_LAYOUT)
+            hidden_states = ttnn.reshape(hidden_states, [B, H, W, C])
             hidden_states, [C, H, W] = self.upsamplers.forward(hidden_states)
         return hidden_states, [C, H, W]

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_unet.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_unet.py
@@ -306,8 +306,6 @@ class TtUNet2DConditionModel(LightweightModule):
         sample = ttnn.to_memory_config(sample, ttnn.DRAM_MEMORY_CONFIG)
         residuals = (sample,)
 
-        temb = ttnn.typecast(temb, dtype=ttnn.bfloat16)
-
         ttnn.ReadDeviceProfiler(self.device)
         for i, down_block in enumerate(self.down_blocks):
             if isinstance(down_block, TtDownBlock2D):
@@ -371,8 +369,6 @@ class TtUNet2DConditionModel(LightweightModule):
         )
 
         sample = ttnn.silu(sample)
-
-        # sample = ttnn.sharded_to_interleaved(sample, ttnn.L1_MEMORY_CONFIG)
 
         [sample, [H, W], [tt_conv2_weights, tt_conv2_bias]] = ttnn.conv2d(
             input_tensor=sample,

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_unet.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_unet.py
@@ -272,7 +272,7 @@ class TtUNet2DConditionModel(LightweightModule):
         temb_add = ttnn.to_layout(temb_add, ttnn.TILE_LAYOUT)
         temb_add = self.add_embedding.forward(temb_add)
 
-        temb = ttnn.add(temb, temb_add, use_legacy=False)
+        temb = ttnn.add_(temb, temb_add, use_legacy=False, activations=[ttnn.UnaryWithParam(ttnn.UnaryOpType.SILU)])
         ttnn.deallocate(temb_add)
 
         [sample, [H, W], [tt_conv1_weights, tt_conv1_bias]] = ttnn.conv2d(
@@ -372,7 +372,7 @@ class TtUNet2DConditionModel(LightweightModule):
 
         sample = ttnn.silu(sample)
 
-        sample = ttnn.sharded_to_interleaved(sample, ttnn.L1_MEMORY_CONFIG)
+        # sample = ttnn.sharded_to_interleaved(sample, ttnn.L1_MEMORY_CONFIG)
 
         [sample, [H, W], [tt_conv2_weights, tt_conv2_bias]] = ttnn.conv2d(
             input_tensor=sample,

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_upblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_upblock2d.py
@@ -60,8 +60,8 @@ class TtUpBlock2D(LightweightModule):
             hidden_states, [C, H, W] = resnet.forward(hidden_states, temb, [B, C, H, W])
 
         if self.upsamplers is not None:
-            hidden_states = ttnn.reshape(hidden_states, [B, H, W, C])
             hidden_states = ttnn.to_layout(hidden_states, ttnn.ROW_MAJOR_LAYOUT)
+            hidden_states = ttnn.reshape(hidden_states, [B, H, W, C])
             hidden_states, [C, H, W] = self.upsamplers.forward(hidden_states)
 
         return hidden_states, [C, H, W]


### PR DESCRIPTION
### What's changed
Set of perf optimizations for SDXL base includes:

- typecast removed
- resnet temb silu fused with binary before UNet blocks
- I2S done from L1 not DRAM for the unaligned cases
- resnet conv matmul weights set to bfp8
- some S2I removed
- inplace adds where its beneficial

### Checklist
- [x] [Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/runs/19665935947) CI passes
- [x] [(Single-card) Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/runs/19641267498) CI passes
- [x] [(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/19669599662) CI passes
- [x] [(Single-card) Demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/19641344361) CI passes