### PR TITLE
[skip ci] [Reduce APC] Run ccl and tools from cpp-unit-tests on merge gate

### DIFF
--- a/.github/workflows/cpp-post-commit.yaml
+++ b/.github/workflows/cpp-post-commit.yaml
@@ -84,7 +84,7 @@ jobs:
 
           # Filter for merge-gate-call: only keep CCL and tools tests
           if [[ "${{ inputs.merge-gate-call }}" == "true" ]]; then
-            requested_cpp_tests=$(jq '[.[] | select(.name == "CCL" or .name == "tools")]' <<< "$requested_cpp_tests")
+            requested_cpp_tests=$(jq '[.[] | select(.name == "CCL" or .name == "tools" or .name == "eth, misc, and user kernel path" or .name == "distributed")]' <<< "$requested_cpp_tests")
             echo "[info] after filtering for merge-gate-call (CCL and tools only): $requested_cpp_tests"
           fi
 

--- a/.github/workflows/cpp-post-commit.yaml
+++ b/.github/workflows/cpp-post-commit.yaml
@@ -19,9 +19,9 @@ on:
       build-artifact-name:
         required: true
         type: string
-      wheel-artifact-name:
-        required: true
-        type: string
+      # wheel-artifact-name:
+      #   required: true
+      #   type: string
       enable-watcher:
         description: 'Enable watcher'
         default: false
@@ -133,7 +133,7 @@ jobs:
           build-artifact-name: ${{ inputs.build-artifact-name }}
           # Unsure why these C++ tests need the wheel...  a cleanup to do separately
           # https://github.com/tenstorrent/tt-metal/issues/20166
-          wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
+          # wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
           enable-watcher: ${{ inputs.enable-watcher }}
       - name: ${{ matrix.test-group.name }} tests
         #GH Issue 16167

--- a/.github/workflows/cpp-post-commit.yaml
+++ b/.github/workflows/cpp-post-commit.yaml
@@ -36,6 +36,10 @@ on:
         required: false
         type: boolean
         default: false
+      merge-gate-call:
+        required: false
+        type: boolean
+        default: false
 jobs:
   define-cpp-tests:
     runs-on: ubuntu-latest
@@ -77,6 +81,12 @@ jobs:
 
           requested_cpp_tests=$(jq --argjson nightly_run "${{ inputs.nightly-run }}" '[.[] | select(.nightly == $nightly_run)]' <<< "$requested_cpp_tests")
           echo "[info] after filtering for requested workflow tests: $requested_cpp_tests"
+
+          # Filter for merge-gate-call: only keep CCL and tools tests
+          if [[ "${{ inputs.merge-gate-call }}" == "true" ]]; then
+            requested_cpp_tests=$(jq '[.[] | select(.name == "CCL" or .name == "tools")]' <<< "$requested_cpp_tests")
+            echo "[info] after filtering for merge-gate-call (CCL and tools only): $requested_cpp_tests"
+          fi
 
           # Check that we have a valid test list that's not empty
           echo "$requested_cpp_tests" | jq -e 'if type != "array" then error("Not a valid JSON array") elif length == 0 then error("Test list is empty") else . end' && echo "Valid test configs"

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -96,12 +96,12 @@ jobs:
         uses: tenstorrent/tt-metal/.github/actions/find-changed-files@v0.63.0
 
   build:
-    # if: ${{ github.ref_name == 'main' ||
-    #         needs.find-changes.outputs.cmake-changed == 'true' ||
-    #         needs.find-changes.outputs.any-code-changed == 'true' ||
-    #         needs.find-changes.outputs.docs-changed == 'true' ||
-    #         needs.find-changes.outputs.build-workflows-changed == 'true'
-    #     }}
+    if: ${{ github.ref_name == 'main' ||
+            needs.find-changes.outputs.cmake-changed == 'true' ||
+            needs.find-changes.outputs.any-code-changed == 'true' ||
+            needs.find-changes.outputs.docs-changed == 'true' ||
+            needs.find-changes.outputs.build-workflows-changed == 'true'
+        }}
     needs: find-changes
     uses: ./.github/workflows/build-artifact.yaml
     permissions:

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -96,12 +96,12 @@ jobs:
         uses: tenstorrent/tt-metal/.github/actions/find-changed-files@v0.63.0
 
   build:
-    if: ${{ github.ref_name == 'main' ||
-            needs.find-changes.outputs.cmake-changed == 'true' ||
-            needs.find-changes.outputs.any-code-changed == 'true' ||
-            needs.find-changes.outputs.docs-changed == 'true' ||
-            needs.find-changes.outputs.build-workflows-changed == 'true'
-        }}
+    # if: ${{ github.ref_name == 'main' ||
+    #         needs.find-changes.outputs.cmake-changed == 'true' ||
+    #         needs.find-changes.outputs.any-code-changed == 'true' ||
+    #         needs.find-changes.outputs.docs-changed == 'true' ||
+    #         needs.find-changes.outputs.build-workflows-changed == 'true'
+    #     }}
     needs: find-changes
     uses: ./.github/workflows/build-artifact.yaml
     permissions:

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -96,12 +96,12 @@ jobs:
         uses: tenstorrent/tt-metal/.github/actions/find-changed-files@v0.63.0
 
   build:
-    if: ${{ github.ref_name == 'main' ||
-            needs.find-changes.outputs.cmake-changed == 'true' ||
-            needs.find-changes.outputs.any-code-changed == 'true' ||
-            needs.find-changes.outputs.docs-changed == 'true' ||
-            needs.find-changes.outputs.build-workflows-changed == 'true'
-        }}
+    # if: ${{ github.ref_name == 'main' ||
+    #         needs.find-changes.outputs.cmake-changed == 'true' ||
+    #         needs.find-changes.outputs.any-code-changed == 'true' ||
+    #         needs.find-changes.outputs.docs-changed == 'true' ||
+    #         needs.find-changes.outputs.build-workflows-changed == 'true'
+    #     }}
     needs: find-changes
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
@@ -271,7 +271,7 @@ jobs:
       merge-gate-call: true
 
   cpp-merge-gate-tests:
-    needs: [build-asan, find-changes]
+    needs: [build, find-changes]
     # if: ${{ github.ref_name == 'main' ||
     #         needs.find-changes.outputs.cmake-changed == 'true' ||
     #         needs.find-changes.outputs.tt-metalium-changed == 'true' ||
@@ -287,8 +287,8 @@ jobs:
     uses: ./.github/workflows/cpp-post-commit.yaml
     secrets: inherit
     with:
-      docker-image: ${{ needs.build-asan.outputs.dev-docker-image }}
-      build-artifact-name: ${{ needs.build-asan.outputs.build-artifact-name }}
+      docker-image: ${{ needs.build.outputs.dev-docker-image }}
+      build-artifact-name: ${{ needs.build.outputs.build-artifact-name }}
       arch: ${{ matrix.test-group.arch }}
       runner-label: ${{ matrix.test-group.runner-label }}
       gtest_filter: "*-*NIGHTLY_*"

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -271,7 +271,7 @@ jobs:
       merge-gate-call: true
 
   cpp-merge-gate-tests:
-    needs: [build, find-changes]
+    needs: [build-asan, find-changes]
     # if: ${{ github.ref_name == 'main' ||
     #         needs.find-changes.outputs.cmake-changed == 'true' ||
     #         needs.find-changes.outputs.tt-metalium-changed == 'true' ||
@@ -287,9 +287,8 @@ jobs:
     uses: ./.github/workflows/cpp-post-commit.yaml
     secrets: inherit
     with:
-      docker-image: ${{ needs.build.outputs.dev-docker-image }}
-      build-artifact-name: ${{ needs.build.outputs.build-artifact-name }}
-      wheel-artifact-name: ${{ needs.build.outputs.wheel-artifact-name }}
+      docker-image: ${{ needs.build-asan.outputs.dev-docker-image }}
+      build-artifact-name: ${{ needs.build-asan.outputs.build-artifact-name }}
       arch: ${{ matrix.test-group.arch }}
       runner-label: ${{ matrix.test-group.runner-label }}
       gtest_filter: "*-*NIGHTLY_*"

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -270,6 +270,31 @@ jobs:
       runner-label: ${{ matrix.test-group.runner-label }}
       merge-gate-call: true
 
+  cpp-merge-gate-tests:
+    needs: [build, find-changes]
+    # if: ${{ github.ref_name == 'main' ||
+    #         needs.find-changes.outputs.cmake-changed == 'true' ||
+    #         needs.find-changes.outputs.tt-metalium-changed == 'true' ||
+    #         needs.find-changes.outputs.tt-metalium-or-tt-nn-tests-changed == 'true'
+    #     }}
+    strategy:
+      fail-fast: false
+      matrix:
+        test-group: [
+          { arch: wormhole_b0, runner-label: N150 },
+          { arch: wormhole_b0, runner-label: N300 },
+        ]
+    uses: ./.github/workflows/cpp-post-commit.yaml
+    secrets: inherit
+    with:
+      docker-image: ${{ needs.build.outputs.dev-docker-image }}
+      build-artifact-name: ${{ needs.build.outputs.build-artifact-name }}
+      wheel-artifact-name: ${{ needs.build.outputs.wheel-artifact-name }}
+      arch: ${{ matrix.test-group.arch }}
+      runner-label: ${{ matrix.test-group.runner-label }}
+      gtest_filter: "*-*NIGHTLY_*"
+      merge-gate-call: true
+  
   ttsim-unit-tests:
     if: ${{ github.ref_name == 'main' ||
             needs.find-changes.outputs.any-code-changed == 'true'

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -294,7 +294,7 @@ jobs:
       runner-label: ${{ matrix.test-group.runner-label }}
       gtest_filter: "*-*NIGHTLY_*"
       merge-gate-call: true
-  
+
   ttsim-unit-tests:
     if: ${{ github.ref_name == 'main' ||
             needs.find-changes.outputs.any-code-changed == 'true'


### PR DESCRIPTION
### What's changed
Remove ccl and tools in cpp-unit-tests from APC and add it into merge gate

### Checklist
- [ ] All post commit CI passes:
- [x] Merge Gate passes: https://github.com/tenstorrent/tt-metal/actions/runs/19584554110/job/56091122710