### PR TITLE
Fix paged_cache hash

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fill_cache/paged_fill_cache_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fill_cache/paged_fill_cache_device_operation.cpp
@@ -78,7 +78,10 @@ tt::stl::hash::hash_t PagedFillCacheDeviceOperation::compute_program_hash(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     auto program_factory = select_program_factory(args, tensor_args);
 
-    return operation::hash_operation<PagedFillCacheDeviceOperation>(args, tensor_args, program_factory.index());
+    // Exclude batch_idx_fallback from hash since it's a runtime-only parameter (used only in runtime args)
+    // Include mesh_coords since it affects program factory selection
+    return operation::hash_operation<PagedFillCacheDeviceOperation>(
+        args.mesh_coords, tensor_args, program_factory.index());
 }
 
 std::tuple<PagedFillCacheDeviceOperation::operation_attributes_t, PagedFillCacheDeviceOperation::tensor_args_t>

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fused_update_cache/paged_fused_update_cache_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fused_update_cache/paged_fused_update_cache_device_operation.cpp
@@ -254,8 +254,20 @@ tt::stl::hash::hash_t PagedFusedUpdateCacheDeviceOperation::compute_program_hash
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     auto program_factory = select_program_factory(operation_attributes, tensor_args);
 
+    // Exclude runtime-only parameters from hash:
+    // - update_idxs: values are runtime-only (used only in runtime args), size is validated to match input tensor shape
+    // (already in tensor_args)
+    // - batch_offset: validated to be 0, doesn't affect program structure
+    // Include parameters that affect program structure:
+    // - compute_kernel_config: affects compile-time args (fp32_dest_acc_en)
+    // - share_cache: affects program structure (semaphore setup)
+    // - mesh_coords: affects program factory selection
     return operation::hash_operation<PagedFusedUpdateCacheDeviceOperation>(
-        operation_attributes, tensor_args, program_factory.index());
+        operation_attributes.compute_kernel_config,
+        operation_attributes.share_cache,
+        operation_attributes.mesh_coords,
+        tensor_args,
+        program_factory.index());
 }
 
 std::tuple<


### PR DESCRIPTION
### Ticket
None

### Problem description
Previous PR that migrated paged_cache ops from legacy infra broke the hashing
https://github.com/tenstorrent/tt-metal/actions/runs/19624916209/job/56216495820

### What's changed
Figured that we created way more entries in the cache than necessary because some runtime args were included.
Fixed

### Checklist
- [x] Ran same tests locally