### PR TITLE
Combine three parsing functions into one

### DIFF
--- a/tests/ttnn/unit_tests/gtests/test_graph_add.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_graph_add.cpp
@@ -93,14 +93,13 @@ TEST_P(AddOpGraphTestFixture, AddGraphTrace) {
 
         // per core buffer allocation size
         {
-            auto cb_peak_size_per_core = graph::extract_circular_buffers_peak_size_per_core(json_trace);
-            EXPECT_EQ(cb_peak_size_per_core, params.expected_cb_peak_per_core);
-
             auto compute_with_storage_grid_size = device_->compute_with_storage_grid_size();
             size_t interleaved_storage_cores = compute_with_storage_grid_size.x * compute_with_storage_grid_size.y;
 
-            auto l1_peak_per_core =
-                graph::extract_l1_buffer_allocation_peak_size_per_core(json_trace, interleaved_storage_cores);
+            const auto& [cb_peak_size_per_core, l1_peak_per_core, peak_memory_usage_per_core] =
+                graph::extract_resource_usage_per_core(json_trace, interleaved_storage_cores);
+
+            EXPECT_EQ(cb_peak_size_per_core, params.expected_cb_peak_per_core);
             EXPECT_EQ(l1_peak_per_core, params.expected_l1_peak_per_core);
         }
 

--- a/ttnn/api/ttnn/graph/graph_query_op_constraints.hpp
+++ b/ttnn/api/ttnn/graph/graph_query_op_constraints.hpp
@@ -24,13 +24,11 @@ namespace detail {
 // Helper to temporarily change logger level
 class LogLevelGuard {
 public:
-    explicit LogLevelGuard(spdlog::level::level_enum new_level)
-        : saved_level_(tt::LoggerRegistry::instance().get(tt::LogOp)->level()) {
+    explicit LogLevelGuard(spdlog::level::level_enum new_level) :
+        saved_level_(tt::LoggerRegistry::instance().get(tt::LogOp)->level()) {
         tt::LoggerRegistry::instance().set_level(new_level);
     }
-    ~LogLevelGuard() {
-        tt::LoggerRegistry::instance().set_level(saved_level_);
-    }
+    ~LogLevelGuard() { tt::LoggerRegistry::instance().set_level(saved_level_); }
     LogLevelGuard(const LogLevelGuard&) = delete;
     LogLevelGuard& operator=(const LogLevelGuard&) = delete;
 
@@ -139,10 +137,9 @@ auto query_op_constraints(Op op, tt::tt_metal::distributed::MeshDevice* device, 
 
     // extract memory footprint from the trace
     auto interleaved_storage_cores = device->allocator()->get_num_banks(tt::tt_metal::BufferType::L1);
-    size_t cb_peak_size_per_core = extract_circular_buffers_peak_size_per_core(op_trace);
-    size_t l1_buffers_peak_per_core =
-        extract_l1_buffer_allocation_peak_size_per_core(op_trace, interleaved_storage_cores);
-    size_t peak_memory_usage_per_core = extract_peak_memory_usage(op_trace, interleaved_storage_cores);
+    const auto& [cb_peak_size_per_core, l1_buffers_peak_per_core, peak_memory_usage_per_core] =
+        extract_resource_usage_per_core(op_trace, interleaved_storage_cores);
+
     size_t l1_output_buffer_per_core = output.buffer()->is_dram() ? 0
                                                                   : extract_l1_output_buffer_allocation_size_per_core(
                                                                         output, interleaved_storage_cores);

--- a/ttnn/api/ttnn/graph/graph_trace_utils.hpp
+++ b/ttnn/api/ttnn/graph/graph_trace_utils.hpp
@@ -17,6 +17,12 @@ struct OperationInfo {
     std::vector<std::string> arguments;
 };
 
+struct PeakMemoryUsagePerCore {
+    size_t peak_cb = 0;
+    size_t peak_l1 = 0;
+    size_t peak_total = 0;
+};
+
 enum class ExecutionStatus { Success, Error };
 
 uint32_t extract_peak_L1_memory_usage(const nlohmann::json& trace);
@@ -26,13 +32,18 @@ uint32_t extract_l1_output_buffer_allocation_size_per_core(
     const ttnn::Tensor& output_tensor, size_t interleaved_storage_cores);
 
 // Returns the worst-case memory allocation per core for the peak L1 usage. Ignores DRAM buffers.
+[[deprecated("Use extract_resource_usage_per_core instead")]]
 uint32_t extract_l1_buffer_allocation_peak_size_per_core(const nlohmann::json& trace, size_t interleaved_storage_cores);
 
 // Returns peak size of circular buffer allocations for a given trace
+[[deprecated("Use extract_resource_usage_per_core instead")]]
 uint32_t extract_circular_buffers_peak_size_per_core(const nlohmann::json& trace);
 
 // Returns peak size of memory (circular buffers + L1) allocated per core for a given trace
+[[deprecated("Use extract_resource_usage_per_core instead")]]
 uint32_t extract_peak_memory_usage(const nlohmann::json& trace, size_t interleaved_storage_cores);
+
+PeakMemoryUsagePerCore extract_resource_usage_per_core(const nlohmann::json& trace, size_t interleaved_storage_cores);
 
 // Returns count of intermediate and output tensors
 std::pair<uint32_t, uint32_t> count_intermediate_and_output_tensors(const nlohmann::json& trace);

--- a/ttnn/core/graph/graph_trace_utils.cpp
+++ b/ttnn/core/graph/graph_trace_utils.cpp
@@ -257,72 +257,15 @@ uint32_t extract_l1_output_buffer_allocation_size_per_core(
 
 uint32_t extract_l1_buffer_allocation_peak_size_per_core(
     const nlohmann::json& trace, size_t interleaved_storage_cores) {
-    uint32_t current_size_per_core = 0;
-    uint32_t peak_size_per_core = 0;
-
-    for (const auto& node : trace) {
-        // process only buffer allocation and deallocation nodes
-        if (node.at(kNodeType) != kNodeBufferAllocate && node.at(kNodeType) != kNodeBufferDeallocate) {
-            continue;
-        }
-
-        // skip dram buffer allocation/deallocation
-        if (node.at(kParams).at(kType) == "DRAM") {
-            continue;
-        }
-
-        uint32_t page_size = std::stoi(node.at(kParams).at(kPageSize).get<std::string>());
-        uint32_t num_of_cores = std::stoi(node.at(kParams).at(kNumCores).get<std::string>());
-        if (num_of_cores == 0) {
-            num_of_cores = interleaved_storage_cores;
-        }
-
-        if (node.at(kNodeType) == kNodeBufferAllocate) {
-            auto total_size = std::stoi(node.at(kParams).at(kSize).get<std::string>());
-            auto alloc_size = detail::worst_case_per_core_allocation(total_size, page_size, num_of_cores);
-            current_size_per_core += alloc_size;
-            peak_size_per_core = std::max(peak_size_per_core, current_size_per_core);
-        } else  // kNodeBufferDeallocate
-        {
-            auto total_size = std::stoi(node.at(kParams).at(kSize).get<std::string>());
-            auto alloc_size = detail::worst_case_per_core_allocation(total_size, page_size, num_of_cores);
-            current_size_per_core -= alloc_size;
-        }
-    }
-
-    return peak_size_per_core;
+    const auto& [cb_peak_size_per_core, l1_buffers_peak_per_core, peak_memory_usage_per_core] =
+        extract_resource_usage_per_core(trace, interleaved_storage_cores);
+    return l1_buffers_peak_per_core;
 }
 
 uint32_t extract_circular_buffers_peak_size_per_core(const nlohmann::json& trace) {
-    uint32_t current_size_per_core = 0;
-    uint32_t peak_size_per_core = 0;
-
-    size_t counter_expected = 0;
-    for (const auto& node : trace) {
-        // expect a trace to be sorted by counter (execution order)
-        if (node.at(kCounter).get<size_t>() == counter_expected) {
-            counter_expected++;
-        } else {
-            TT_THROW("Graph trace counter/execution out of order");
-        }
-
-        // process only circular buffer allocation and deallocation nodes
-        if (node.at(kNodeType) != kNodeCBAllocate && node.at(kNodeType) != kNodeCBDeallocateAll) {
-            continue;
-        }
-
-        if (node.at(kNodeType) == kNodeCBAllocate) {
-            bool is_globally_allocated = std::stoi(node.at(kParams).at(kGloballyAllocated).get<std::string>()) == 1;
-            if (!is_globally_allocated) {
-                current_size_per_core += std::stoi(node.at(kParams).at(kSize).get<std::string>());
-                peak_size_per_core = std::max(peak_size_per_core, current_size_per_core);
-            }
-        } else {  // kNodeCBDeallocateAll
-            current_size_per_core = 0;
-        }
-    }
-
-    return peak_size_per_core;
+    const auto& [cb_peak_size_per_core, l1_buffers_peak_per_core, peak_memory_usage_per_core] =
+        extract_resource_usage_per_core(trace, 1);
+    return cb_peak_size_per_core;
 }
 
 // calculate the size of buffer allocated/deallocated on each core
@@ -338,37 +281,9 @@ static uint32_t calculate_buffer_allocation_size(const nlohmann::json& node, siz
 }
 
 uint32_t extract_peak_memory_usage(const nlohmann::json& trace, size_t interleaved_storage_cores) {
-    uint32_t current_size = 0;
-    uint32_t cb_size = 0;
-    uint32_t peak_size = 0;
-
-    for (const auto& node : trace) {
-        if (node.at(kNodeType) == kNodeCBAllocate) {
-            bool is_globally_allocated = std::stoi(node.at(kParams).at(kGloballyAllocated).get<std::string>()) == 1;
-            if (!is_globally_allocated) {
-                uint32_t alloc_size = std::stoi(node.at(kParams).at(kSize).get<std::string>());
-                current_size += alloc_size;
-                cb_size += alloc_size;
-                peak_size = std::max(peak_size, current_size);
-            }
-        } else if (node.at(kNodeType) == kNodeCBDeallocateAll) {
-            current_size -= cb_size;
-            cb_size = 0;
-        } else if (node.at(kNodeType) == kNodeBufferAllocate) {
-            if (node.at(kParams).at(kType) == "DRAM") {
-                continue;
-            }
-            current_size += calculate_buffer_allocation_size(node, interleaved_storage_cores);
-            peak_size = std::max(peak_size, current_size);
-        } else if (node.at(kNodeType) == kNodeBufferDeallocate) {
-            if (node.at(kParams).at(kType) == "DRAM") {
-                continue;
-            }
-            current_size -= calculate_buffer_allocation_size(node, interleaved_storage_cores);
-        }
-    }
-
-    return peak_size;
+    const auto& [cb_peak_size_per_core, l1_buffers_peak_per_core, peak_memory_usage_per_core] =
+        extract_resource_usage_per_core(trace, interleaved_storage_cores);
+    return peak_memory_usage_per_core;
 }
 
 PeakMemoryUsagePerCore extract_resource_usage_per_core(const nlohmann::json& trace, size_t interleaved_storage_cores) {


### PR DESCRIPTION
Avoid parsing trace file multiple times.

### Ticket
N/A

### Problem description
The three functions, `extract_circular_buffers_peak_size_per_core`, `extract_l1_buffer_allocation_peak_size_per_core`, and `extract_peak_memory_usage` all extract the memory usage numbers by parsing the trace json file. The process can be made more efficient by combining the three into one.

### What's changed
Created one function `extract_resource_usage_per_core` that extracts all three numbers, and marked existing functions deprecated.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes