### PR TITLE
Remove tt-metalium API directory from device side includes

### DIFF
--- a/tt_metal/hw/firmware/src/tt-1xx/trisc.cc
+++ b/tt_metal/hw/firmware/src/tt-1xx/trisc.cc
@@ -19,7 +19,7 @@
 #include "circular_buffer.h"
 #include "circular_buffer_init.h"
 #endif
-#include "circular_buffer_constants.h"
+#include "tt-metalium/circular_buffer_constants.h"
 // clang-format on
 
 #if defined(PROFILE_KERNEL)

--- a/tt_metal/hw/inc/circular_buffer.h
+++ b/tt_metal/hw/inc/circular_buffer.h
@@ -6,7 +6,7 @@
 
 #include <cstdint>
 
-#include "circular_buffer_constants.h"
+#include "tt-metalium/circular_buffer_constants.h"
 #include "risc_attribs.h"
 
 constexpr static std::uint32_t REMOTE_CIRCULAR_BUFFER_ALIGNED_PAGE_SIZE = L1_ALIGNMENT;

--- a/tt_metal/hw/inc/circular_buffer_init.h
+++ b/tt_metal/hw/inc/circular_buffer_init.h
@@ -7,7 +7,7 @@
 #include <cstdint>
 
 #include "circular_buffer.h"
-#include "circular_buffer_constants.h"
+#include "tt-metalium/circular_buffer_constants.h"
 #include "remote_circular_buffer_api.h"
 #include "risc_attribs.h"
 

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -248,8 +248,7 @@ void JitBuildEnv::init(
         root_ + "tt_metal/hw/inc",
         root_ + "tt_metal/hostdevcommon/api",
         root_ + "tt_metal/hw/inc/debug",
-        root_ + "tt_metal/api/",
-        root_ + "tt_metal/api/tt-metalium/"};
+        root_ + "tt_metal/api/"};
 
     std::ostringstream oss;
     for (size_t i = 0; i < includeDirs.size(); ++i) {


### PR DESCRIPTION
### Ticket
Partially related: #31083 , #20036

### Problem description
Currently, device is able to include symbols from the `tt-metalium` folder which is intended for host APIs.

### What's changed
This PR does not address the issue but removes the direct directory includes for `tt-metalium`, this allows includes of host side APIs to be more descriptive and grepable so it's easier to cleanup in the future.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/19650310428)