### PR TITLE
[skip ci] ttnn device operation migration cursor commands

### DIFF
--- a/.cursor/commands/ttnn/verify-device-operation-hash.md
+++ b/.cursor/commands/ttnn/verify-device-operation-hash.md
@@ -438,7 +438,7 @@ Use this checklist to verify your hash implementation:
 
 **Build:**
 ```bash
-./build_metal.sh -c -e --debug --without-python-bindings
+./build_metal.sh -c -e --debug
 ```
 
 **Test:**

--- a/ttnn/cursor/DEVICE_OPERATION_MIGRATION_GUIDE.md
+++ b/ttnn/cursor/DEVICE_OPERATION_MIGRATION_GUIDE.md
@@ -516,7 +516,10 @@ Tensor hash includes:
 - Alignment dimensions (vector of uint32_t)
 
 **If the legacy operation does not implement `compute_program_hash`**,
-Simply hash operation_attributes and tensors_args
+Do not implement `compute_program_hash` in the newly-migrated operation, because we want to mimic how the legacy was hashed.
+
+**If the legacy operation implements `compute_program_hash`**,
+Include everything that was in the legacy into the new hash. Make sure to include `tensor_args` as a whole.
 
 **What must be included in hash:**
 Anything that affects the compiled kernel binary:
@@ -614,7 +617,7 @@ Great examples of operations migrated to TMP:
 To build the project with debug symbols (without Python bindings for faster builds during development):
 
 ```bash
-./build_metal.sh -c -e --debug --without-python-bindings
+./build_metal.sh -c -e --debug
 ```
 
 ### Running Tests


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Currently, the build instructions specify to build without pybinds. We want to remove this flag so that pytests accurately reflect the effects of our migration changes. Also, nothing new should be added to program hashes

### What's changed

- Removed `--without-python-bindings` flag from build instructions
- Specifying that new program hash should mimic that of legacy op

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes