### PR TITLE
Move TT_METAL_DISABLE_XIP_DUMP to RunTimeOptions

### DIFF
--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -72,6 +72,7 @@ enum class EnvVarID {
     TT_METAL_GTEST_ETH_DISPATCH,         // Use Ethernet cores for dispatch in tests
     TT_METAL_SKIP_LOADING_FW,            // Skip firmware loading
     TT_METAL_SKIP_DELETING_BUILT_CACHE,  // Skip cache deletion on cleanup
+    TT_METAL_DISABLE_XIP_DUMP,           // Disable XIP dump
 
     // ========================================
     // HARDWARE CONFIGURATION
@@ -1034,6 +1035,15 @@ void RunTimeOptions::HandleEnvVar(EnvVarID id, const char* value) {
         // Usage: export TT_METAL_NUMA_BASED_AFFINITY=1
         case EnvVarID::TT_METAL_NUMA_BASED_AFFINITY: {
             this->numa_based_affinity = is_env_enabled(value);
+            break;
+        }
+
+        // TT_METAL_DISABLE_XIP_DUMP
+        // Disable XIP dump
+        // Default: false
+        // Usage: export TT_METAL_DISABLE_XIP_DUMP=1
+        case EnvVarID::TT_METAL_DISABLE_XIP_DUMP: {
+            this->disable_xip_dump = is_env_enabled(value);
             break;
         }
     }

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -237,6 +237,9 @@ class RunTimeOptions {
     // To be used for NUMA node based thread binding
     bool numa_based_affinity = false;
 
+    // Disable XIP dump
+    bool disable_xip_dump = false;
+
 public:
     RunTimeOptions();
     RunTimeOptions(const RunTimeOptions&) = delete;
@@ -555,6 +558,8 @@ public:
     void set_force_jit_compile(bool enable) { force_jit_compile = enable; }
 
     bool get_numa_based_affinity() const { return numa_based_affinity; }
+
+    bool get_disable_xip_dump() const { return disable_xip_dump; }
 
     // Parse all feature-specific environment variables, after hal is initialized.
     // (Needed because syntax of some env vars is arch-dependent.)

--- a/tt_metal/llrt/tt_memory.cpp
+++ b/tt_metal/llrt/tt_memory.cpp
@@ -10,6 +10,7 @@
 #include <span>
 
 #include "tt_elffile.hpp"
+#include "tt_metal/impl/context/metal_context.hpp"
 
 namespace ll_api {
 
@@ -29,7 +30,8 @@ memory::memory(const std::string& path, Loading loading) : loading_(loading) {
         elf.MakeExecuteInPlace();
 
         // debug: dump disassembly after XIP transform
-        if (std::getenv("TT_METAL_DISABLE_XIP_DUMP") == nullptr) {
+        // this output is used for tt-triage
+        if (!tt::tt_metal::MetalContext::instance().rtoptions().get_disable_xip_dump()) {
             // Write the modified ELF out and run objdump -S -d on it
             std::string out_elf_path = std::string(path) + ".xip.elf";
             try {


### PR DESCRIPTION
### Ticket
N/A

### Problem description
This dangling environment variable belongs in the RunTimeOptions

### What's changed
Move TT_METAL_DISABLE_XIP_DUMP to RunTimeOptions

### Checklist
All post commit
https://github.com/tenstorrent/tt-metal/actions/runs/19650309416
Blackhole post commit
https://github.com/tenstorrent/tt-metal/actions/runs/19650311702