### PR TITLE
Rename ttsim to ttsim-private

### DIFF
--- a/.github/workflows/ttsim.yaml
+++ b/.github/workflows/ttsim.yaml
@@ -91,7 +91,7 @@ jobs:
       - name: Checkout ttsim
         uses: actions/checkout@v4
         with:
-          repository: tenstorrent/ttsim
+          repository: tenstorrent/ttsim-private
           ref: ${{ inputs.ttsim-ref }}
           path: docker-job/ttsim
           token: ${{ secrets.TTSIM_TOKEN }}
@@ -182,7 +182,7 @@ jobs:
       - name: Checkout ttsim
         uses: actions/checkout@v4
         with:
-          repository: tenstorrent/ttsim
+          repository: tenstorrent/ttsim-private
           ref: ${{ inputs.ttsim-ref }}
           path: docker-job/ttsim
           token: ${{ secrets.TTSIM_TOKEN }}
@@ -324,7 +324,7 @@ jobs:
       - name: Checkout ttsim
         uses: actions/checkout@v4
         with:
-          repository: tenstorrent/ttsim
+          repository: tenstorrent/ttsim-private
           ref: ${{ inputs.ttsim-ref }}
           path: docker-job/ttsim
           token: ${{ secrets.TTSIM_TOKEN }}
@@ -404,7 +404,7 @@ jobs:
       - name: Checkout ttsim
         uses: actions/checkout@v4
         with:
-          repository: tenstorrent/ttsim
+          repository: tenstorrent/ttsim-private
           ref: ${{ inputs.ttsim-ref }}
           path: docker-job/ttsim
           token: ${{ secrets.TTSIM_TOKEN }}


### PR DESCRIPTION
### Ticket
none

### Problem description
tenstorrent/ttsim is being renamed to ttsim-private to make room for public repo

### What's changed
Change repo path

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes