### PR TITLE
Increase Fabric init timeout. Check expected value before timeout for…

### DIFF
--- a/tt_metal/api/tt-metalium/device_pool.hpp
+++ b/tt_metal/api/tt-metalium/device_pool.hpp
@@ -105,7 +105,7 @@ private:
     void init_fabric(const std::vector<tt_metal::IDevice*>& active_devices) const;
     void initialize_active_devices() const;
     void add_devices_to_pool(const std::vector<ChipId>& device_ids);
-    void wait_for_fabric_router_sync(uint32_t timeout_ms = 10000) const;
+    void wait_for_fabric_router_sync(uint32_t timeout_ms = 5000) const;
     tt_metal::IDevice* get_device(ChipId id) const;
     void teardown_fd(const std::unordered_set<ChipId>& devices_to_close);
 

--- a/tt_metal/api/tt-metalium/device_pool.hpp
+++ b/tt_metal/api/tt-metalium/device_pool.hpp
@@ -105,7 +105,7 @@ private:
     void init_fabric(const std::vector<tt_metal::IDevice*>& active_devices) const;
     void initialize_active_devices() const;
     void add_devices_to_pool(const std::vector<ChipId>& device_ids);
-    void wait_for_fabric_router_sync(uint32_t timeout_ms = 5000) const;
+    void wait_for_fabric_router_sync(uint32_t timeout_ms = 10000) const;
     tt_metal::IDevice* get_device(ChipId id) const;
     void teardown_fd(const std::unordered_set<ChipId>& devices_to_close);
 

--- a/tt_metal/impl/device/device_pool.cpp
+++ b/tt_metal/impl/device/device_pool.cpp
@@ -659,7 +659,7 @@ void DevicePool::wait_for_fabric_router_sync(uint32_t timeout_ms) const {
         while (master_router_status[0] != expected_status) {
             tt_metal::detail::ReadFromDeviceL1(
                 dev, master_router_logical_core, router_sync_address, 4, master_router_status, CoreType::ETH);
-            // If the read value mathces expected status, then we can break out of the loop
+            // If the read value matches expected status, then we can break out of the loop
             // No need to check for timeout in this case.
             if (master_router_status[0] == expected_status) {
                 break;

--- a/tt_metal/impl/device/device_pool.cpp
+++ b/tt_metal/impl/device/device_pool.cpp
@@ -659,7 +659,11 @@ void DevicePool::wait_for_fabric_router_sync(uint32_t timeout_ms) const {
         while (master_router_status[0] != expected_status) {
             tt_metal::detail::ReadFromDeviceL1(
                 dev, master_router_logical_core, router_sync_address, 4, master_router_status, CoreType::ETH);
-
+            // If the read value mathces expected status, then we can break out of the loop
+            // No need to check for timeout in this case.
+            if (master_router_status[0] == expected_status) {
+                break;
+            }
             // Check for timeout
             auto current_time = std::chrono::steady_clock::now();
             auto elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(current_time - start_time).count();

--- a/tt_metal/impl/device/device_pool.cpp
+++ b/tt_metal/impl/device/device_pool.cpp
@@ -358,7 +358,7 @@ void DevicePool::initialize_fabric_and_dispatch_fw() const {
     this->initialize_active_devices();
 
     this->wait_for_fabric_router_sync(
-        tt::tt_metal::MetalContext::instance().rtoptions().get_simulator_enabled() ? 15000 : 5000);
+        tt::tt_metal::MetalContext::instance().rtoptions().get_simulator_enabled() ? 15000 : 10000);
     log_trace(tt::LogMetal, "Fabric and Dispatch Firmware initialized");
 }
 


### PR DESCRIPTION
… boundary cases.

### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes