### PR TITLE
Initial implementation of ScopedLock for Device 2.0 APIs

### DIFF
--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/direct_reader_unary.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/direct_reader_unary.cpp
@@ -25,7 +25,6 @@ void kernel_main() {
     uint32_t ublock_size_bytes = cb.get_tile_size() * ublock_size_tiles;
 
     // read a ublock of tiles from src to CB, and then push the ublock to unpacker
-    auto ds = cb.debug_scope();
     for (uint32_t i = 0; i < num_tiles; i += ublock_size_tiles) {
         cb.reserve_back(ublock_size_tiles);
         noc.async_read(

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/direct_reader_unary.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/direct_reader_unary.cpp
@@ -25,6 +25,7 @@ void kernel_main() {
     uint32_t ublock_size_bytes = cb.get_tile_size() * ublock_size_tiles;
 
     // read a ublock of tiles from src to CB, and then push the ublock to unpacker
+    auto ds = cb.debug_scope();
     for (uint32_t i = 0; i < num_tiles; i += ublock_size_tiles) {
         cb.reserve_back(ublock_size_tiles);
         noc.async_read(

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -2355,6 +2355,26 @@ struct noc_traits_t {
 };
 
 /**
+ * @brief RAII style wrapper for a debug scope
+ *
+ * @tparam ReleaseFunc The function to call when this instance goes out of scope.
+ */
+template <typename ReleaseFunc = void (*)()>
+class DebugScope {
+public:
+    inline __attribute__((always_inline)) DebugScope(ReleaseFunc release_func) : release_func_(release_func) {}
+    inline __attribute__((always_inline)) ~DebugScope() { release_func_(); }
+
+    DebugScope(const DebugScope&) = delete;
+    DebugScope(DebugScope&&) = delete;
+    DebugScope& operator=(const DebugScope&) = delete;
+    DebugScope& operator=(DebugScope&&) = delete;
+
+private:
+    ReleaseFunc release_func_;
+};
+
+/**
  * @brief Noc class that provides a high-level interface for asynchronous read and write operations.
  *
  * It abstracts the details of source and destination address calculations.
@@ -2760,7 +2780,16 @@ public:
         return rd_ptr_bytes;
     }
 
+    [[nodiscard]] auto debug_scope() {
+        // TODO: Register with the debugger to track the lock
+        return DebugScope([this]() { debug_scope_release(); });
+    }
+
 private:
+    void debug_scope_release() {
+        // TODO: Unregister with the debugger
+    }
+
     uint32_t cb_id_;
 };
 

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -2359,7 +2359,7 @@ struct noc_traits_t {
  *
  * @tparam ReleaseFunc The function to call when this instance goes out of scope.
  */
-template <typename ReleaseFunc = void (*)()>
+template <typename ReleaseFunc>
 class Lock {
 public:
     inline __attribute__((always_inline)) Lock(ReleaseFunc release_func) : release_func_(release_func) {}

--- a/tt_metal/hw/inc/remote_circular_buffer_api.h
+++ b/tt_metal/hw/inc/remote_circular_buffer_api.h
@@ -576,7 +576,20 @@ public:
      */
     void commit() { update_remote_cb_config_in_l1(remote_cb_index_); }
 
+    /** @brief Acquire a scoped lock on the RemoteCircularBuffer. In debug mode, reads and writes to this remote
+     * circular buffer are tracked by the debugger while the lock is held.
+     *
+     * @return A scoped lock on the RemoteCircularBuffer
+     */
+    [[nodiscard]] auto scoped_lock() {
+        return Lock([this]() { release_scoped_lock(); });
+    }
+
 private:
+    void release_scoped_lock() {
+        // TODO: Unregister with the debugger
+    }
+
     uint32_t remote_cb_index_;
 };
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/29596

### Problem description
Some kernels need to manipulate data in their local l1 or want to have raw addr access (e.g. some niche TM algos or eth benchmarks kernels that need to read from specific l1 addresses)

With new device side apis we still want to allow this but add a structure to have this scoped within some lock. In debug mode (with Watcher enabled) we would want to assert no noc transaction is issued while lock is held by the kernel

### What's changed
Add functions to acquire/release the debug region / scoped lock for CircularBuffer, RemoteCircularBuffer, and CoreLocalMem (L1) which would allow us to track memory access in debug mode. These functions are nop at the moment.

### Checklist
All post commit
https://github.com/tenstorrent/tt-metal/actions/runs/19651361754
Blackhole post commit
https://github.com/tenstorrent/tt-metal/actions/runs/19651342798