### PR TITLE
Fix for failing Sentencebert Galaxy Tests

### DIFF
--- a/models/demos/tg/sentence_bert/tests/device_perf_test.py
+++ b/models/demos/tg/sentence_bert/tests/device_perf_test.py
@@ -49,11 +49,9 @@ def test_perf_device_bare_metal_sentence_bert_tg(batch_size, expected_perf, test
     expected_perf = expected_perf if is_wormhole_b0() else 0
     expected_inference_time = 1 / (expected_perf * (1 - margin))
 
-    # Set TT_GH_CI_INFRA environment variable when running on CI to use local weights instead of HuggingFace
-    if "TT_GH_CI_INFRA" in os.environ:
-        os.environ["TT_GH_CI_INFRA"] = "1"
-
-    command = f"pytest models/demos/wormhole/sentence_bert/tests/pcc/{pcc_file}.py::{function_name}"
+    # Prepare command with TT_GH_CI_INFRA environment variable when running on CI
+    env_prefix = "TT_GH_CI_INFRA=1 " if "TT_GH_CI_INFRA" in os.environ else ""
+    command = f"{env_prefix}pytest models/demos/wormhole/sentence_bert/tests/pcc/{pcc_file}.py::{function_name}"
     cols = ["DEVICE FW", "DEVICE KERNEL", "DEVICE BRISC KERNEL"]
 
     inference_time_key = "AVG DEVICE KERNEL SAMPLES/S"

--- a/models/demos/tg/sentence_bert/tests/device_perf_test.py
+++ b/models/demos/tg/sentence_bert/tests/device_perf_test.py
@@ -48,7 +48,7 @@ def test_perf_device_bare_metal_sentence_bert_tg(batch_size, expected_perf, test
     expected_perf = expected_perf if is_wormhole_b0() else 0
     expected_inference_time = 1 / (expected_perf * (1 - margin))
 
-    command = f"pytest models/demos/sentence_bert/ttnn/{pcc_file}.py::{function_name}"
+    command = f"pytest models/demos/wormhole/sentence_bert/tests/pcc/{pcc_file}.py::{function_name}"
     cols = ["DEVICE FW", "DEVICE KERNEL", "DEVICE BRISC KERNEL"]
 
     inference_time_key = "AVG DEVICE KERNEL SAMPLES/S"

--- a/models/demos/tg/sentence_bert/tests/device_perf_test.py
+++ b/models/demos/tg/sentence_bert/tests/device_perf_test.py
@@ -48,7 +48,7 @@ def test_perf_device_bare_metal_sentence_bert_tg(batch_size, expected_perf, test
     expected_perf = expected_perf if is_wormhole_b0() else 0
     expected_inference_time = 1 / (expected_perf * (1 - margin))
 
-    command = f"pytest models/demos/sentence_bert/tests/pcc/{pcc_file}.py::{function_name}"
+    command = f"pytest models/demos/sentence_bert/ttnn/{pcc_file}.py::{function_name}"
     cols = ["DEVICE FW", "DEVICE KERNEL", "DEVICE BRISC KERNEL"]
 
     inference_time_key = "AVG DEVICE KERNEL SAMPLES/S"

--- a/models/demos/tg/sentence_bert/tests/device_perf_test.py
+++ b/models/demos/tg/sentence_bert/tests/device_perf_test.py
@@ -2,6 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+import os
 import time
 
 import pytest
@@ -47,6 +48,10 @@ def test_perf_device_bare_metal_sentence_bert_tg(batch_size, expected_perf, test
     margin = 0.05
     expected_perf = expected_perf if is_wormhole_b0() else 0
     expected_inference_time = 1 / (expected_perf * (1 - margin))
+
+    # Set TT_GH_CI_INFRA environment variable when running on CI to use local weights instead of HuggingFace
+    if "TT_GH_CI_INFRA" in os.environ:
+        os.environ["TT_GH_CI_INFRA"] = "1"
 
     command = f"pytest models/demos/wormhole/sentence_bert/tests/pcc/{pcc_file}.py::{function_name}"
     cols = ["DEVICE FW", "DEVICE KERNEL", "DEVICE BRISC KERNEL"]

--- a/models/demos/tg/sentence_bert/tests/device_perf_test.py
+++ b/models/demos/tg/sentence_bert/tests/device_perf_test.py
@@ -2,7 +2,6 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-import os
 import time
 
 import pytest
@@ -49,9 +48,7 @@ def test_perf_device_bare_metal_sentence_bert_tg(batch_size, expected_perf, test
     expected_perf = expected_perf if is_wormhole_b0() else 0
     expected_inference_time = 1 / (expected_perf * (1 - margin))
 
-    # Prepare command with TT_GH_CI_INFRA environment variable when running on CI
-    env_prefix = "TT_GH_CI_INFRA=1 " if "TT_GH_CI_INFRA" in os.environ else ""
-    command = f"{env_prefix}pytest models/demos/wormhole/sentence_bert/tests/pcc/{pcc_file}.py::{function_name}"
+    command = f"pytest models/demos/wormhole/sentence_bert/tests/pcc/{pcc_file}.py::{function_name}"
     cols = ["DEVICE FW", "DEVICE KERNEL", "DEVICE BRISC KERNEL"]
 
     inference_time_key = "AVG DEVICE KERNEL SAMPLES/S"

--- a/tests/scripts/tg/run_tg_model_perf_tests.sh
+++ b/tests/scripts/tg/run_tg_model_perf_tests.sh
@@ -37,7 +37,8 @@ run_tg_sentence_bert_tests() {
 
   echo "LOG_METAL: Running run_tg_sentence_bert_tests"
 
-  TT_GH_CI_INFRA=1 pytest models/demos/tg/sentence_bert/tests/device_perf_test.py ; fail+=$?
+  export TT_GH_CI_INFRA=1
+  pytest models/demos/tg/sentence_bert/tests/device_perf_test.py ; fail+=$?
   # Merge all the generated reports
   env python3 models/perf/merge_perf_results.py; fail+=$?
 

--- a/tests/scripts/tg/run_tg_model_perf_tests.sh
+++ b/tests/scripts/tg/run_tg_model_perf_tests.sh
@@ -37,7 +37,7 @@ run_tg_sentence_bert_tests() {
 
   echo "LOG_METAL: Running run_tg_sentence_bert_tests"
 
-  pytest models/demos/tg/sentence_bert/tests/device_perf_test.py ; fail+=$?
+  TT_GH_CI_INFRA=1 pytest models/demos/tg/sentence_bert/tests/device_perf_test.py ; fail+=$?
   # Merge all the generated reports
   env python3 models/perf/merge_perf_results.py; fail+=$?
 


### PR DESCRIPTION
### Ticket
Sentence Bert tests failing as filepaths changed

### Problem description
Sentence Bert tests failing as filepaths changed and that is fixed
Failing CI: https://github.com/tenstorrent/tt-metal/actions/runs/19647255480/job/56266269661

### What's changed
Changed the path string in the testing code.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/19656957599)
- [ ] [Galaxy model perf test](https://github.com/tenstorrent/tt-metal/actions/runs/19656943833)