### PR TITLE
Migrate op to new infra: embedding_backward

### DIFF
--- a/ttnn/cpp/ttnn/operations/embedding_backward/device/embedding_backward_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding_backward/device/embedding_backward_device_operation.cpp
@@ -5,23 +5,33 @@
 #include "ttnn/operations/embedding_backward/device/embedding_backward_device_operation.hpp"
 
 #include <tt-metalium/constants.hpp>
-#include "ttnn/run_operation.hpp"
 
 using namespace tt::constants;
-using namespace std;
 using namespace tt::tt_metal;
 
 namespace ttnn::operations::embedding_backward {
 
-void EmbeddingBackward::validate(const std::vector<Tensor> &input_tensors) const {
-    TT_FATAL(input_tensors.size() == 2, "Must have between 2 input tensors");
+EmbeddingBackwardDeviceOperation::program_factory_t EmbeddingBackwardDeviceOperation::select_program_factory(
+    const operation_attributes_t&, const tensor_args_t&) {
+    return program::EmbeddingBackwardProgramFactory{};
+}
 
-    const auto &index_tensor = input_tensors.at(0);
-    const auto &grad_tensor = input_tensors.at(1);
-    const auto &index_tensor_shape = index_tensor.padded_shape();
-    const auto &grad_tensor_shape = grad_tensor.padded_shape();
+void EmbeddingBackwardDeviceOperation::validate_on_program_cache_hit(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    validate_on_program_cache_miss(operation_attributes, tensor_args);
+}
 
-    TT_FATAL(index_tensor.layout() == Layout::ROW_MAJOR, "Index tensor layout must be ROW_MAJOR but got {}", index_tensor.layout());
+void EmbeddingBackwardDeviceOperation::validate_on_program_cache_miss(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    const auto& index_tensor = tensor_args.index_tensor;
+    const auto& grad_tensor = tensor_args.grad_tensor;
+    const auto& index_tensor_shape = index_tensor.padded_shape();
+    const auto& grad_tensor_shape = grad_tensor.padded_shape();
+
+    TT_FATAL(
+        index_tensor.layout() == Layout::ROW_MAJOR,
+        "Index tensor layout must be ROW_MAJOR but got {}",
+        index_tensor.layout());
     TT_FATAL(
         index_tensor.dtype() == DataType::UINT32 or index_tensor.dtype() == DataType::BFLOAT16,
         "Index tensor must be UINT32 or BFLOAT16");
@@ -41,12 +51,13 @@ void EmbeddingBackward::validate(const std::vector<Tensor> &input_tensors) const
         grad_tensor.dtype() == DataType::BFLOAT16 or grad_tensor.dtype() == DataType::BFLOAT8_B,
         "Output gradient tensor must be BFLOAT16 or BFLOAT8_B");
     TT_FATAL(
-        grad_tensor.dtype() == this->output_dtype, "Output and input gradient tensors must have the same dtype");
+        grad_tensor.dtype() == operation_attributes.output_dtype,
+        "Output and input gradient tensors must have the same dtype");
 
     TT_FATAL(
         grad_tensor.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED or
             index_tensor.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED or
-            this->output_mem_config.memory_layout() == TensorMemoryLayout::INTERLEAVED,
+            operation_attributes.output_mem_config.memory_layout() == TensorMemoryLayout::INTERLEAVED,
         "Embedding b/w does not currently support sharding");
 
     TT_FATAL(
@@ -64,21 +75,50 @@ void EmbeddingBackward::validate(const std::vector<Tensor> &input_tensors) const
         "Number of rows in gradient tensor must be equal to number of indices in index tensor");
 }
 
-std::vector<TensorSpec> EmbeddingBackward::compute_output_specs(
-    const std::vector<Tensor> &input_tensors) const {
-    const auto &grad_tensor = input_tensors.at(1);
+EmbeddingBackwardDeviceOperation::spec_return_value_t EmbeddingBackwardDeviceOperation::compute_output_specs(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    const auto& grad_tensor = tensor_args.grad_tensor;
     auto embedding_dim = grad_tensor.logical_shape()[-1];
 
-    ttnn::Shape output_shape({1, 1, this->num_embeddings, embedding_dim});
-    return {TensorSpec(output_shape, TensorLayout(output_dtype, PageConfig(Layout::TILE), output_mem_config))};
+    ttnn::Shape output_shape({1, 1, operation_attributes.num_embeddings, embedding_dim});
+    return TensorSpec(
+        output_shape,
+        TensorLayout(
+            operation_attributes.output_dtype,
+            PageConfig(Layout::TILE),
+            operation_attributes.output_mem_config));
 }
 
-operation::ProgramWithCallbacks EmbeddingBackward::create_program(
-    const std::vector<Tensor> &input_tensors, std::vector<Tensor> &output_tensors) const {
-    const auto &index_tensor = input_tensors.at(0);
-    const auto &grad_tensor = input_tensors.at(1);
-    auto &output_tensor = output_tensors.at(0);
-    return detail::embedding_backward_multi_core(index_tensor, grad_tensor, output_tensor, this->num_embeddings);
+EmbeddingBackwardDeviceOperation::tensor_return_value_t EmbeddingBackwardDeviceOperation::create_output_tensors(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    if (tensor_args.preallocated_output.has_value()) {
+        return tensor_args.preallocated_output.value();
+    }
+    auto output_spec = compute_output_specs(operation_attributes, tensor_args);
+    return create_device_tensor(output_spec, tensor_args.grad_tensor.device());
+}
+
+std::tuple<EmbeddingBackwardDeviceOperation::operation_attributes_t, EmbeddingBackwardDeviceOperation::tensor_args_t>
+EmbeddingBackwardDeviceOperation::invoke(
+    const Tensor& index_tensor,
+    const Tensor& grad_tensor,
+    const tt::tt_metal::MemoryConfig& output_mem_config,
+    const tt::tt_metal::DataType& output_dtype,
+    uint32_t num_embeddings,
+    const std::optional<Tensor>& preallocated_output) {
+    operation_attributes_t operation_attributes{
+        .output_mem_config = output_mem_config,
+        .output_dtype = output_dtype,
+        .num_embeddings = num_embeddings,
+    };
+
+    tensor_args_t tensor_args{
+        .index_tensor = index_tensor,
+        .grad_tensor = grad_tensor,
+        .preallocated_output = preallocated_output,
+    };
+
+    return {operation_attributes, tensor_args};
 }
 
 }  // namespace ttnn::operations::embedding_backward

--- a/ttnn/cpp/ttnn/operations/embedding_backward/device/embedding_backward_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/embedding_backward/device/embedding_backward_device_operation.hpp
@@ -5,11 +5,11 @@
 #pragma once
 
 #include "ttnn/tensor/tensor.hpp"
-#include "ttnn/operation.hpp"
 #include "ttnn/device_operation.hpp"
 
 #include "embedding_backward_device_operation_types.hpp"
 #include "embedding_backward_program_factory.hpp"
+#include "ttnn/operations/core/core.hpp"
 
 namespace ttnn::operations::embedding_backward {
 

--- a/ttnn/cpp/ttnn/operations/embedding_backward/device/embedding_backward_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/embedding_backward/device/embedding_backward_device_operation.hpp
@@ -6,24 +6,45 @@
 
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/operation.hpp"
+#include "ttnn/device_operation.hpp"
+
+#include "embedding_backward_device_operation_types.hpp"
+#include "embedding_backward_program_factory.hpp"
 
 namespace ttnn::operations::embedding_backward {
 
-namespace detail {
-tt::tt_metal::operation::ProgramWithCallbacks embedding_backward_multi_core(
-    const Tensor& index_tensor, const Tensor& grad_tensor, Tensor& output, uint32_t num_embeddings);
-}
+struct EmbeddingBackwardDeviceOperation {
+    using operation_attributes_t = embedding_backward::operation_attributes_t;
+    using tensor_args_t = embedding_backward::tensor_args_t;
+    using spec_return_value_t = embedding_backward::spec_return_value_t;
+    using tensor_return_value_t = embedding_backward::tensor_return_value_t;
+    using program_factory_t = std::variant<program::EmbeddingBackwardProgramFactory>;
 
-struct EmbeddingBackward {
-    tt::tt_metal::MemoryConfig output_mem_config;
-    tt::tt_metal::DataType output_dtype;
-    uint32_t num_embeddings;
+    static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
 
-    void validate(const std::vector<Tensor> &input_tensors) const;
-    std::vector<TensorSpec> compute_output_specs(const std::vector<Tensor> &input_tensors) const;
-    tt::tt_metal::operation::ProgramWithCallbacks create_program(
-        const std::vector<Tensor> &input_tensors, std::vector<Tensor> &output_tensors) const;
-    tt::stl::reflection::Attributes attributes() const;
+    static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
+    static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
+
+    static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
+
+    static tensor_return_value_t create_output_tensors(
+        const operation_attributes_t& operation_attributes, const tensor_args_t&);
+
+    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
+        const Tensor& index_tensor,
+        const Tensor& grad_tensor,
+        const tt::tt_metal::MemoryConfig& output_mem_config,
+        const tt::tt_metal::DataType& output_dtype,
+        uint32_t num_embeddings,
+        const std::optional<Tensor>& preallocated_output);
 };
 
 }  // namespace ttnn::operations::embedding_backward
+
+namespace ttnn::prim {
+
+constexpr auto embedding_backward = ttnn::register_operation<
+    "ttnn::prim::embedding_backward",
+    ttnn::operations::embedding_backward::EmbeddingBackwardDeviceOperation>();
+
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/embedding_backward/device/embedding_backward_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/embedding_backward/device/embedding_backward_device_operation_types.hpp
@@ -11,14 +11,14 @@ namespace ttnn::operations::embedding_backward {
 namespace embedding_backward {
 
 struct operation_attributes_t {
-    const tt::tt_metal::MemoryConfig output_mem_config;
-    const tt::tt_metal::DataType output_dtype;
-    const uint32_t num_embeddings;
+    tt::tt_metal::MemoryConfig output_mem_config;
+    tt::tt_metal::DataType output_dtype;
+    uint32_t num_embeddings;
 };
 
 struct tensor_args_t {
-    const Tensor& index_tensor;
-    const Tensor& grad_tensor;
+    Tensor index_tensor;
+    Tensor grad_tensor;
     std::optional<Tensor> preallocated_output;
 };
 

--- a/ttnn/cpp/ttnn/operations/embedding_backward/device/embedding_backward_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/embedding_backward/device/embedding_backward_device_operation_types.hpp
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/tensor/tensor.hpp"
+
+namespace ttnn::operations::embedding_backward {
+
+namespace embedding_backward {
+
+struct operation_attributes_t {
+    const tt::tt_metal::MemoryConfig output_mem_config;
+    const tt::tt_metal::DataType output_dtype;
+    const uint32_t num_embeddings;
+};
+
+struct tensor_args_t {
+    const Tensor& index_tensor;
+    const Tensor& grad_tensor;
+    std::optional<Tensor> preallocated_output;
+};
+
+using spec_return_value_t = ttnn::TensorSpec;
+using tensor_return_value_t = Tensor;
+
+}  // namespace embedding_backward
+
+}  // namespace ttnn::operations::embedding_backward

--- a/ttnn/cpp/ttnn/operations/embedding_backward/device/embedding_backward_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/embedding_backward/device/embedding_backward_device_operation_types.hpp
@@ -12,8 +12,8 @@ namespace embedding_backward {
 
 struct operation_attributes_t {
     tt::tt_metal::MemoryConfig output_mem_config;
-    tt::tt_metal::DataType output_dtype;
-    uint32_t num_embeddings;
+    tt::tt_metal::DataType output_dtype = tt::tt_metal::DataType::INVALID;
+    uint32_t num_embeddings = 0;
 };
 
 struct tensor_args_t {

--- a/ttnn/cpp/ttnn/operations/embedding_backward/device/embedding_backward_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding_backward/device/embedding_backward_program_factory.cpp
@@ -8,26 +8,30 @@
 #include "ttnn/operations/math.hpp"
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
-#include "ttnn/operations/embedding_backward/device/embedding_backward_device_operation.hpp"
+
+#include "ttnn/operations/embedding_backward/device/embedding_backward_program_factory.hpp"
 
 using namespace tt;
 using namespace tt::constants;
 using namespace tt::tt_metal;
 
-namespace ttnn::operations::embedding_backward::detail {
+namespace ttnn::operations::embedding_backward::program {
 
-operation::ProgramWithCallbacks embedding_backward_multi_core(
-    const Tensor& index_tensor, const Tensor& grad_tensor, Tensor& output, const uint32_t num_embeddings) {
+EmbeddingBackwardProgramFactory::cached_program_t EmbeddingBackwardProgramFactory::create(
+    const embedding_backward::operation_attributes_t& operation_attributes,
+    const embedding_backward::tensor_args_t& tensor_args,
+    embedding_backward::tensor_return_value_t& tensor_return_value) {
     ////////////////////////////////////////////////////////////////////////////
     //                 Buffer Setup
     ////////////////////////////////////////////////////////////////////////////
 
-    tt_metal::Buffer* index_tensor_buffer = index_tensor.buffer();
-    tt_metal::Buffer* grad_tensor_buffer = grad_tensor.buffer();
-    tt_metal::Buffer* out_buffer = output.buffer();
+    tt_metal::Buffer* index_tensor_buffer = tensor_args.index_tensor.buffer();
+    tt_metal::Buffer* grad_tensor_buffer = tensor_args.grad_tensor.buffer();
+    tt_metal::Buffer* out_buffer = tensor_return_value.buffer();
 
-    IDevice* device = grad_tensor.device();
+    auto device = tensor_args.grad_tensor.device();
 
+    const auto& index_tensor = tensor_args.index_tensor;
     ////////////////////////////////////////////////////////////////////////////
     //                      Application Setup
     ////////////////////////////////////////////////////////////////////////////
@@ -37,10 +41,10 @@ operation::ProgramWithCallbacks embedding_backward_multi_core(
     uint32_t index_element_size_bytes = index_tensor.element_size();
     constexpr uint32_t INPUT_SIZE = 32;
 
-    tt::DataFormat grad_cb_data_format = datatype_to_dataformat_converter(grad_tensor.dtype());
+    tt::DataFormat grad_cb_data_format = datatype_to_dataformat_converter(tensor_args.grad_tensor.dtype());
     uint32_t grad_single_tile_size = tt::tile_size(grad_cb_data_format);
 
-    tt::DataFormat index_cb_data_format = datatype_to_dataformat_converter(index_tensor.dtype());
+    tt::DataFormat index_cb_data_format = datatype_to_dataformat_converter(tensor_args.index_tensor.dtype());
     uint32_t index_single_page_size =
         INPUT_SIZE * index_element_size_bytes;  // Only need 32 at most at a time, which is less than full page size
     uint32_t index_page_size = index_tensor.padded_shape()[-1] * index_element_size_bytes;
@@ -48,17 +52,17 @@ operation::ProgramWithCallbacks embedding_backward_multi_core(
     tt::DataFormat mask_cb_data_format = tt::DataFormat::UInt8;
     uint32_t mask_single_page_size = INPUT_SIZE * 1;  // UInt8 is 1 byte per element
 
-    tt::DataFormat output_cb_data_format = datatype_to_dataformat_converter(output.dtype());
+    tt::DataFormat output_cb_data_format = datatype_to_dataformat_converter(tensor_return_value.dtype());
     uint32_t output_single_tile_size = tt::tile_size(output_cb_data_format);
 
-    uint32_t embedding_dim = grad_tensor.padded_shape()[-1];
+    uint32_t embedding_dim = tensor_args.grad_tensor.padded_shape()[-1];
     uint32_t embedding_tiles = embedding_dim / TILE_WIDTH;
 
-    uint32_t batch_size = index_tensor.padded_shape()[0];
-    uint32_t seq_len_tiles = index_tensor.padded_shape()[-1] / TILE_WIDTH;
+    uint32_t batch_size = tensor_args.index_tensor.padded_shape()[0];
+    uint32_t seq_len_tiles = tensor_args.index_tensor.padded_shape()[-1] / TILE_WIDTH;
     uint32_t input_height_tiles = batch_size * seq_len_tiles;
 
-    uint32_t num_embeddings_tiles = num_embeddings / TILE_HEIGHT;
+    uint32_t num_embeddings_tiles = operation_attributes.num_embeddings / TILE_HEIGHT;
 
     // We split work based on the number of tiles in the embedding dimension
     auto grid_size = device->compute_with_storage_grid_size();
@@ -105,8 +109,8 @@ operation::ProgramWithCallbacks embedding_backward_multi_core(
         (uint32_t)seq_len_tiles,
         (uint32_t)num_embeddings_tiles,
         (uint32_t)index_page_size,
-        (uint32_t)(index_tensor.dtype() == DataType::BFLOAT16),
-        (uint32_t)(output.dtype() == DataType::BFLOAT16)};
+        (uint32_t)(tensor_args.index_tensor.dtype() == DataType::BFLOAT16),
+        (uint32_t)(tensor_return_value.dtype() == DataType::BFLOAT16)};
     TensorAccessorArgs(*grad_tensor_buffer).append_to(reader_compile_time_args);
     TensorAccessorArgs(*index_tensor_buffer).append_to(reader_compile_time_args);
     TensorAccessorArgs(*out_buffer).append_to(reader_compile_time_args);
@@ -150,29 +154,29 @@ operation::ProgramWithCallbacks embedding_backward_multi_core(
 
         offset += reader_runtime_args[5];
     }
-
-    auto override_runtime_args_callback = [reader_kernel_id, cores, device](
-                                              const void* operation,
-                                              Program& program,
-                                              const std::vector<Tensor>& input_tensors,
-                                              const std::vector<std::optional<const Tensor>>& optional_tensors,
-                                              const std::vector<Tensor>& output_tensors) {
-        auto index_dram_buffer = input_tensors.at(0).buffer();
-        auto grad_dram_buffer = input_tensors.at(1).buffer();
-        auto output_dram_buffer = output_tensors.at(0).buffer();
-
-        auto& runtime_args_by_core = GetRuntimeArgs(program, reader_kernel_id);
-        for (const auto& core : cores) {
-            {
-                auto& runtime_args = runtime_args_by_core[core.x][core.y];
-                runtime_args[0] = grad_dram_buffer->address();
-                runtime_args[1] = index_dram_buffer->address();
-                runtime_args[2] = output_dram_buffer->address();
-            }
-        }
-    };
-
-    return {std::move(program), override_runtime_args_callback};
+    return cached_program_t{
+        std::move(program), {.reader_kernel_id = reader_kernel_id, .cores = cores, .device = device}};
 }
 
-}  // namespace ttnn::operations::embedding_backward::detail
+void EmbeddingBackwardProgramFactory::override_runtime_arguments(
+    cached_program_t& cached_program,
+    const embedding_backward::operation_attributes_t&,
+    const embedding_backward::tensor_args_t& tensor_args,
+    embedding_backward::tensor_return_value_t& tensor_return_value) {
+    auto index_dram_buffer = tensor_args.index_tensor.buffer();
+    auto grad_dram_buffer = tensor_args.grad_tensor.buffer();
+    auto output_dram_buffer = tensor_return_value.buffer();
+
+    auto& program = cached_program.program;
+    const auto& shared_variables = cached_program.shared_variables;
+
+    auto& runtime_args_by_core = GetRuntimeArgs(program, shared_variables.reader_kernel_id);
+    for (const auto& core : shared_variables.cores) {
+        auto& runtime_args = runtime_args_by_core[core.x][core.y];
+        runtime_args[0] = grad_dram_buffer->address();
+        runtime_args[1] = index_dram_buffer->address();
+        runtime_args[2] = output_dram_buffer->address();
+    }
+}
+
+}  // namespace ttnn::operations::embedding_backward::program

--- a/ttnn/cpp/ttnn/operations/embedding_backward/device/embedding_backward_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/embedding_backward/device/embedding_backward_program_factory.hpp
@@ -16,9 +16,9 @@ using namespace tt::tt_metal;
 
 struct EmbeddingBackwardProgramFactory {
     struct shared_variables_t {
-        KernelHandle reader_kernel_id;
+        KernelHandle reader_kernel_id{};
         std::vector<CoreCoord> cores;
-        distributed::MeshDevice* device;
+        distributed::MeshDevice* device = nullptr;
     };
 
     using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;

--- a/ttnn/cpp/ttnn/operations/embedding_backward/device/embedding_backward_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/embedding_backward/device/embedding_backward_program_factory.hpp
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "embedding_backward_device_operation_types.hpp"
+
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/work_split.hpp>
+#include "ttnn/device_operation.hpp"
+
+namespace ttnn::operations::embedding_backward::program {
+
+using namespace tt::tt_metal;
+
+struct EmbeddingBackwardProgramFactory {
+    struct shared_variables_t {
+        KernelHandle reader_kernel_id;
+        std::vector<CoreCoord> cores;
+        distributed::MeshDevice* device;
+    };
+
+    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
+
+    static cached_program_t create(
+        const embedding_backward::operation_attributes_t& operation_attributes,
+        const embedding_backward::tensor_args_t& tensor_args,
+        embedding_backward::tensor_return_value_t& tensor_return_value);
+
+    static void override_runtime_arguments(
+        cached_program_t& cached_program,
+        const embedding_backward::operation_attributes_t& operation_attributes,
+        const embedding_backward::tensor_args_t& tensor_args,
+        embedding_backward::tensor_return_value_t& tensor_return_value);
+};
+
+}  // namespace ttnn::operations::embedding_backward::program

--- a/ttnn/cpp/ttnn/operations/embedding_backward/embedding_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding_backward/embedding_backward.cpp
@@ -27,16 +27,11 @@ Tensor EmbeddingBackwardOperation::invoke(
     auto sentence_size = input_shape[-1];
     auto input_tensor = ttnn::reshape(input_tensor_arg, ttnn::Shape({batch_size, 1, 1, sentence_size}));
 
-    auto input_gradient =
-        tt::tt_metal::operation::run(
-            EmbeddingBackward{
-                .output_mem_config = memory_config.value_or(output_gradient_tensor_arg.memory_config()),
-                .output_dtype = dtype.value_or(output_gradient_tensor_arg.dtype()),
-                .num_embeddings = num_embeddings},
-            {input_tensor, output_gradient_tensor_arg})
-            .at(0);
+    const auto output_mem_config = memory_config.value_or(output_gradient_tensor_arg.memory_config());
+    const auto out_dtype = dtype.value_or(output_gradient_tensor_arg.dtype());
 
-    return input_gradient;
+    return ttnn::prim::embedding_backward(
+        input_tensor, output_gradient_tensor_arg, output_mem_config, out_dtype, num_embeddings, optional_output_tensor);
 }
 
 }  // namespace ttnn::operations::embedding_backward


### PR DESCRIPTION
### Ticket
[#32688
](https://github.com/tenstorrent/tt-metal/issues/32688)
### Problem description
Migrating the embedding_backward operation to device_operation.
### What's changed
The embedding_backward operation now migrated to new TMP infra.
Changes analogous to https://gist.github.com/ayerofieiev-tt/d40981adcf3959bb7d32c54f4a42f650.


### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/19654911512) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/19654926617) CI with demo tests passes (if applicable)
- [x] [L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/runs/19654937924)
- [x] New/Existing tests provide coverage for changes