### PR TITLE
Adding stateful 2.0 read and write apis

### DIFF
--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -2391,6 +2391,8 @@ public:
 
     enum class McastMode { INCLUDE_SRC, EXCLUDE_SRC };
 
+    enum class VcSelection { DEFAULT, CUSTOM };
+
     static constexpr uint32_t INVALID_TXN_ID = 0xFFFFFFFF;
 
 private:
@@ -2470,14 +2472,108 @@ public:
         const dst_args_t<Dst>& dst_args,
         uint32_t read_req_vc = NOC_UNICAST_WRITE_VC,
         uint32_t trid = INVALID_TXN_ID) const {
-        // TODO (#31407): Add support for read with transaction id
-        static_assert(txn_id_mode == TxnIdMode::DISABLED);
-        noc_async_read<max_page_size, enable_noc_tracing>(
-            get_src_ptr<AddressType::NOC>(src, src_args),
-            get_dst_ptr<AddressType::LOCAL_L1>(dst, dst_args),
+        if constexpr (txn_id_mode == TxnIdMode::ENABLED) {
+            noc_async_read_set_trid(trid, noc_id_);
+            uint64_t src_noc_addr = get_src_ptr<AddressType::NOC>(src, src_args);
+            static_assert(
+                max_page_size <= NOC_MAX_BURST_SIZE,
+                "Read with transaction id is not supported for page sizes greater than NOC_MAX_BURST_SIZE");
+            noc_async_read_one_packet_set_state(src_noc_addr, size_bytes, read_req_vc, noc_id_);
+            noc_async_read_one_packet_with_state_with_trid(
+                static_cast<uint32_t>((src_noc_addr >> NOC_ADDR_COORD_SHIFT) & NOC_COORDINATE_MASK),
+                static_cast<uint32_t>(src_noc_addr),
+                get_dst_ptr<AddressType::LOCAL_L1>(dst, dst_args),
+                trid,
+                noc_id_);
+        } else {
+            noc_async_read<max_page_size, enable_noc_tracing>(
+                get_src_ptr<AddressType::NOC>(src, src_args),
+                get_dst_ptr<AddressType::LOCAL_L1>(dst, dst_args),
+                size_bytes,
+                noc_id_,
+                read_req_vc);
+        }
+    }
+
+    /**
+     * @brief Sets the stateful registers for an asynchronous read from a specified source
+     *
+     * This is used to set up state for async_read_with_state, use async_read instead if state preservation is not
+     * needed.
+     *
+     * @see async_read_with_state and async_read_barrier.
+     *
+     * @param src Source object (e.g., TensorAccessor)
+     * @param size_bytes Size of the data transfer in bytes
+     * @param src_args Additional arguments for source address calculation
+     * @param vc Virtual channel to use for the read request when vc_selection is CUSTOM (default: 0)
+     * @tparam vc_selection Whether to use a custom specified virtual channel (default: DEFAULT)
+     * @tparam max_page_size Maximum page size for the transfer (default: NOC_MAX_BURST_SIZE + 1)
+     */
+    template <
+        VcSelection vc_selection = VcSelection::DEFAULT,
+        uint32_t max_page_size = NOC_MAX_BURST_SIZE + 1,
+        typename Src>
+    void set_async_read_state(
+        const Src& src, uint32_t size_bytes, const src_args_t<Src>& src_args, uint8_t vc = 0) const {
+        auto src_noc_addr = get_src_ptr<AddressType::NOC>(src, src_args);
+        DEBUG_SANITIZE_NO_LINKED_TRANSACTION(noc_id_, DEBUG_SANITIZE_NOC_UNICAST);
+        RECORD_NOC_EVENT_WITH_ADDR(
+            NocEventType::READ_SET_STATE,
+            src_noc_addr,
             size_bytes,
-            noc_id_,
-            read_req_vc);
+            (vc_selection == VcSelection::CUSTOM) ? static_cast<int8_t>(vc) : -1);
+
+        WAYPOINT("NASW");
+        ncrisc_noc_read_set_state<noc_mode, max_page_size <= NOC_MAX_BURST_SIZE, vc_selection == VcSelection::CUSTOM>(
+            noc_id_, read_cmd_buf, src_noc_addr, size_bytes, vc);
+        WAYPOINT("NASD");
+    }
+
+    /**
+     * @brief Initiates an asynchronous read from a specified source based on previously set state
+     *
+     * This must be preceded by a call to set_async_read_state where Src is at same noc location as the one used in
+     * set_async_read_state
+     *
+     * @see set_async_read_state and async_read_barrier.
+     *
+     * @param src Source object (e.g., TensorAccessor)
+     * @param dst Destination object (e.g., local L1 memory)
+     * @param size_bytes Size of the data transfer in bytes, this must be equal to the value set in set_async_read_state
+     * if max_page_size <= NOC_MAX_BURST_SIZE
+     * @param src_args Additional arguments for source address calculation
+     * @param dst_args Additional arguments for destination address calculation
+     * @param vc Virtual channel to use for the read request when vc_selection is CUSTOM (default: 0)
+     * @tparam vc_selection Whether to use a custom specified virtual channel (default: DEFAULT)
+     * @tparam max_page_size Maximum page size for the transfer (default: NOC_MAX_BURST_SIZE + 1)
+     */
+    template <
+        VcSelection vc_selection = VcSelection::DEFAULT,
+        uint32_t max_page_size = NOC_MAX_BURST_SIZE + 1,
+        typename Src,
+        typename Dst>
+    void async_read_with_state(
+        const Src& src,
+        const Dst& dst,
+        uint32_t size_bytes,
+        const src_args_t<Src>& src_args,
+        const dst_args_t<Dst>& dst_args,
+        uint8_t vc = 0) const {
+        // TODO (#33966): Need to make sure set state was called and with same template params
+        if constexpr (max_page_size <= NOC_MAX_BURST_SIZE) {
+            noc_async_read_one_packet_with_state<true, vc_selection == VcSelection::CUSTOM>(
+                (uint32_t)get_src_ptr<AddressType::NOC>(src, src_args),
+                get_dst_ptr<AddressType::LOCAL_L1>(dst, dst_args),
+                vc,
+                noc_id_);
+        } else {
+            noc_async_read_with_state(
+                (uint32_t)get_src_ptr<AddressType::NOC>(src, src_args),
+                get_dst_ptr<AddressType::LOCAL_L1>(dst, dst_args),
+                size_bytes,
+                noc_id_);
+        }
     }
 
     /** @brief Initiates an asynchronous write.
@@ -2594,6 +2690,91 @@ public:
             noc_async_write_multicast_loopback_src(src_addr, dst_noc_addr, size_bytes, num_dsts, linked, noc_id_);
         } else if constexpr (mcast_mode == McastMode::EXCLUDE_SRC) {
             noc_async_write_multicast<max_page_size>(src_addr, dst_noc_addr, size_bytes, num_dsts, linked, noc_id_);
+        }
+    }
+
+    /**
+     * @brief Sets the stateful registers for an asynchronous write
+     *
+     * This function is used to set up the state for async_write_with_state, async_write can be used if state
+     * preservation is not needed
+     *
+     * @see async_write_with_state and async_write_barrier.
+     *
+     * @param dst Destination object (e.g., local L1 memory)
+     * @param size_bytes Size of the data transfer in bytes
+     * @param dst_args Additional arguments for destination address calculation
+     * @param vc Virtual channel to use for the write request (default: NOC_UNICAST_WRITE_VC)
+     * @tparam response_mode Whether the write is posted or non-posted (default: NON_POSTED)
+     * @tparam max_page_size Maximum page size for the transfer (default: NOC_MAX_BURST_SIZE + 1)
+     */
+    template <
+        ResponseMode response_mode = ResponseMode::NON_POSTED,
+        uint32_t max_page_size = NOC_MAX_BURST_SIZE + 1,
+        typename Dst>
+    void set_async_write_state(
+        const Dst& dst, uint32_t size_bytes, const dst_args_t<Dst>& dst_args, uint8_t vc = NOC_UNICAST_WRITE_VC) const {
+        DEBUG_SANITIZE_NO_LINKED_TRANSACTION(noc_id_, DEBUG_SANITIZE_NOC_UNICAST);
+        auto dst_noc_addr = get_dst_ptr<AddressType::NOC>(dst, dst_args);
+        RECORD_NOC_EVENT_WITH_ADDR(NocEventType::WRITE_SET_STATE, dst_noc_addr, size_bytes, vc);
+
+        WAYPOINT("NWPW");
+        ncrisc_noc_write_set_state<response_mode == ResponseMode::POSTED, max_page_size <= NOC_MAX_BURST_SIZE>(
+            noc_id_, write_cmd_buf, dst_noc_addr, size_bytes, vc);
+        WAYPOINT("NWPD");
+    }
+
+    /**
+     * @brief Initiates an asynchronous write to a specified destination based on previously set state
+     *
+     * This must be preceded by a call to set_async_write_state where Dst is at same noc location as the one used in
+     * set_async_write_state
+     *
+     * @see set_async_write_state and async_write_barrier.
+     *
+     * @param src Source object (e.g., local L1 memory)
+     * @param dst Destination object (e.g., TensorAccessor)
+     * @param size_bytes Size of the data transfer in bytes, this must be equal to the value set in
+     * set_async_write_state if max_page_size <= NOC_MAX_BURST_SIZE
+     * @param src_args Additional arguments for source address calculation
+     * @param dst_args Additional arguments for destination address calculation
+     * @param vc Virtual channel to use for the write request (default: NOC_UNICAST_WRITE_VC)
+     * @tparam response_mode Whether the write is posted or non-posted (default: NON_POSTED)
+     * @tparam max_page_size Maximum page size for the transfer (default: NOC_MAX_BURST_SIZE + 1)
+     */
+    template <
+        ResponseMode response_mode = ResponseMode::NON_POSTED,
+        uint32_t max_page_size = NOC_MAX_BURST_SIZE + 1,
+        typename Src,
+        typename Dst>
+    void async_write_with_state(
+        const Src& src,
+        const Dst& dst,
+        uint32_t size_bytes,
+        const src_args_t<Src>& src_args,
+        const dst_args_t<Dst>& dst_args,
+        uint8_t vc = NOC_UNICAST_WRITE_VC) const {
+        if constexpr (max_page_size <= NOC_MAX_BURST_SIZE) {
+            noc_async_write_one_packet_with_state<response_mode == ResponseMode::POSTED>(
+                get_src_ptr<AddressType::LOCAL_L1>(src, src_args),
+                (uint32_t)get_dst_ptr<AddressType::NOC>(dst, dst_args),
+                noc_id_);
+        } else {
+            RECORD_NOC_EVENT_WITH_ADDR(NocEventType::WRITE_WITH_STATE, 0ull, 0, -1);
+            // In order to sanitize, need to grab full noc addr + xfer size from state.
+            auto src_addr = get_src_ptr<AddressType::LOCAL_L1>(src, src_args);
+            auto dst_addr =
+                get_dst_ptr<AddressType::NOC>(dst, dst_args);  // NoC target was programmed in set_async_write_state
+            DEBUG_SANITIZE_NOC_WRITE_TRANSACTION_WITH_ADDR_AND_SIZE_STATE(noc_id_, dst_addr, src_addr);
+
+            WAYPOINT("NWPW");
+            ncrisc_noc_write_any_len_with_state<noc_mode, response_mode == ResponseMode::POSTED>(
+                noc_id_,
+                write_cmd_buf,
+                get_src_ptr<AddressType::LOCAL_L1>(src, src_args),
+                (uint32_t)get_dst_ptr<AddressType::NOC>(dst, dst_args),
+                size_bytes);
+            WAYPOINT("NWPD");
         }
     }
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/29599

### Problem description
Adding stateful read/write apis to NoC class and support for non-stateful async_read with transaction id. 
Also added enum to allow users to specify whether they need to specify custom VC assignment 


### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/20036524437) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/20036539292) CI with demo tests passes (if applicable)