### PR TITLE
Implement indirect for pimpl usage

### DIFF
--- a/tt_stl/CMakeLists.txt
+++ b/tt_stl/CMakeLists.txt
@@ -28,6 +28,7 @@ target_sources(
             tt_stl/type_name.hpp
             tt_stl/unique_any.hpp
             tt_stl/assert.hpp
+            tt_stl/indirect.hpp
     PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/tt_stl/llvm/llvm_small_vector.cpp
 )

--- a/tt_stl/tests/CMakeLists.txt
+++ b/tt_stl/tests/CMakeLists.txt
@@ -1,3 +1,6 @@
+# PImpl test utility library (separate compilation to test incomplete types)
+add_subdirectory(test_indirect_util)
+
 # Smoke tests (fast, not necessarily thorough)
 add_library(unit_tests_stl_smoke OBJECT)
 add_library(TT::Metalium::Test::STL::Smoke ALIAS unit_tests_stl_smoke)
@@ -9,6 +12,7 @@ target_sources(
         test_cleanup.cpp
         test_indestructible.cpp
         test_indirect.cpp
+        test_indirect_pimpl.cpp
         test_optional_reference.cpp
         test_span.cpp
         test_strong_type.cpp
@@ -21,6 +25,7 @@ target_link_libraries(
         gtest
         gtest_main
         TT::STL
+        test_indirect_util
 )
 
 add_executable(unit_tests_stl)

--- a/tt_stl/tests/CMakeLists.txt
+++ b/tt_stl/tests/CMakeLists.txt
@@ -8,6 +8,7 @@ target_sources(
     PRIVATE
         test_cleanup.cpp
         test_indestructible.cpp
+        test_indirect.cpp
         test_optional_reference.cpp
         test_span.cpp
         test_strong_type.cpp

--- a/tt_stl/tests/test_indirect.cpp
+++ b/tt_stl/tests/test_indirect.cpp
@@ -353,34 +353,6 @@ TEST(IndirectTest, DeductionGuide) {
 // TODO: Add test for incomplete type support (PImpl pattern)
 // This would require a more complex test setup with separate compilation units
 
-// Test with polymorphic types
-TEST(IndirectTest, PolymorphicTypes) {
-    struct Base {
-        int value;
-        explicit Base(int v) : value(v) {}
-
-        Base(const Base&) = default;
-        Base(Base&&) noexcept = default;
-
-        Base& operator=(const Base&) = default;
-        Base& operator=(Base&&) noexcept = default;
-
-        virtual ~Base() = default;
-        virtual int get() const { return value; }
-    };
-
-    struct Derived : Base {
-        explicit Derived(int v) : Base(v) {}
-        int get() const override { return value * 2; }
-    };
-
-    indirect<Base> b(Base{42});
-    EXPECT_EQ(b->get(), 42);
-
-    indirect<Derived> d(Derived{21});
-    EXPECT_EQ(d->get(), 42);
-}
-
 // Test move semantics with rvalue dereference
 TEST(IndirectTest, RvalueDereference) {
     struct MoveOnly {

--- a/tt_stl/tests/test_indirect.cpp
+++ b/tt_stl/tests/test_indirect.cpp
@@ -361,7 +361,7 @@ TEST(IndirectTest, RvalueDereference) {
     };
 
     indirect<MoveOnly> i(MoveOnly{42});
-    MoveOnly extracted = std::move(i);
+    MoveOnly extracted = *std::move(i);
 
     EXPECT_EQ(*extracted.ptr, 42);
 }

--- a/tt_stl/tests/test_indirect.cpp
+++ b/tt_stl/tests/test_indirect.cpp
@@ -15,13 +15,12 @@ namespace {
 
 // Helper class for testing
 struct TestValue {
-    int value;
+    int value{};
 
-    TestValue() : value(0) {}
+    TestValue() = default;
     explicit TestValue(int v) : value(v) {}
 
-    bool operator==(const TestValue& other) const { return value == other.value; }
-    auto operator<=>(const TestValue& other) const { return value <=> other.value; }
+    auto operator<=>(const TestValue& other) const = default;
 };
 
 // Test default construction
@@ -341,7 +340,9 @@ TEST(IndirectTest, ComparisonWithT) {
 // Test deduction guide
 TEST(IndirectTest, DeductionGuide) {
     auto i = indirect(42);
-    static_assert(std::is_same_v<decltype(i), indirect<int>>);
+    static_assert(requires {
+        { indirect(42) } -> std::same_as<indirect<int>>;
+    });
     EXPECT_EQ(*i, 42);
 
     auto s = indirect(std::string("hello"));
@@ -388,7 +389,7 @@ TEST(IndirectTest, RvalueDereference) {
     };
 
     indirect<MoveOnly> i(MoveOnly{42});
-    MoveOnly extracted = *std::move(i);
+    MoveOnly extracted = std::move(i);
 
     EXPECT_EQ(*extracted.ptr, 42);
 }

--- a/tt_stl/tests/test_indirect.cpp
+++ b/tt_stl/tests/test_indirect.cpp
@@ -83,6 +83,7 @@ TEST(IndirectTest, CopyConstructionFromValueless) {
     indirect<int> i2(std::move(i1));
 
     // i1 is now valueless
+    // NOLINTNEXTLINE(bugprone-use-after-move)
     EXPECT_TRUE(i1.valueless_after_move());
 
     // Copy from valueless should create a valueless indirect
@@ -95,6 +96,7 @@ TEST(IndirectTest, MoveConstruction) {
     indirect<TestValue> i1(TestValue(42));
     indirect<TestValue> i2(std::move(i1));
 
+    // NOLINTNEXTLINE(bugprone-use-after-move)
     EXPECT_TRUE(i1.valueless_after_move());
     EXPECT_FALSE(i2.valueless_after_move());
     EXPECT_EQ(i2->value, 42);
@@ -120,6 +122,7 @@ TEST(IndirectTest, CopyAssignmentFromValueless) {
     indirect<int> i2(std::move(i1));
 
     // i1 is now valueless
+    // NOLINTNEXTLINE(bugprone-use-after-move)
     EXPECT_TRUE(i1.valueless_after_move());
 
     indirect<int> i3(100);
@@ -134,6 +137,7 @@ TEST(IndirectTest, CopyAssignmentToValueless) {
     indirect<int> i2(std::move(i1));
 
     // i1 is now valueless
+    // NOLINTNEXTLINE(bugprone-use-after-move)
     EXPECT_TRUE(i1.valueless_after_move());
 
     indirect<int> i3(100);
@@ -161,6 +165,7 @@ TEST(IndirectTest, MoveAssignment) {
 
     i2 = std::move(i1);
 
+    // NOLINTNEXTLINE(bugprone-use-after-move)
     EXPECT_TRUE(i1.valueless_after_move());
     EXPECT_FALSE(i2.valueless_after_move());
     EXPECT_EQ(i2->value, 42);
@@ -191,6 +196,7 @@ TEST(IndirectTest, ValueAssignmentToValueless) {
     indirect<int> i2(std::move(i1));
 
     // i1 is now valueless
+    // NOLINTNEXTLINE(bugprone-use-after-move)
     EXPECT_TRUE(i1.valueless_after_move());
 
     i1 = 100;
@@ -351,6 +357,13 @@ TEST(IndirectTest, PolymorphicTypes) {
     struct Base {
         int value;
         explicit Base(int v) : value(v) {}
+
+        Base(const Base&) = default;
+        Base(Base&&) noexcept = default;
+
+        Base& operator=(const Base&) = default;
+        Base& operator=(Base&&) noexcept = default;
+
         virtual ~Base() = default;
         virtual int get() const { return value; }
     };

--- a/tt_stl/tests/test_indirect.cpp
+++ b/tt_stl/tests/test_indirect.cpp
@@ -1,0 +1,384 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+#include <tt_stl/indirect.hpp>
+
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace ttsl {
+namespace {
+
+// Helper class for testing
+struct TestValue {
+    int value;
+
+    TestValue() : value(0) {}
+    explicit TestValue(int v) : value(v) {}
+
+    bool operator==(const TestValue& other) const { return value == other.value; }
+    auto operator<=>(const TestValue& other) const { return value <=> other.value; }
+};
+
+// Test default construction
+TEST(IndirectTest, DefaultConstruction) {
+    indirect<int> i;
+    EXPECT_FALSE(i.valueless_after_move());
+    EXPECT_EQ(*i, 0);
+}
+
+// Test construction with value
+TEST(IndirectTest, ConstructionWithValue) {
+    indirect<int> i(42);
+    EXPECT_FALSE(i.valueless_after_move());
+    EXPECT_EQ(*i, 42);
+}
+
+// Test in-place construction
+TEST(IndirectTest, InPlaceConstruction) {
+    indirect<std::string> s(std::in_place, "hello");
+    EXPECT_FALSE(s.valueless_after_move());
+    EXPECT_EQ(*s, "hello");
+}
+
+// Test in-place construction with multiple arguments
+TEST(IndirectTest, InPlaceConstructionMultipleArgs) {
+    indirect<std::string> s(std::in_place, 5, 'x');
+    EXPECT_FALSE(s.valueless_after_move());
+    EXPECT_EQ(*s, "xxxxx");
+}
+
+// Test in-place construction with initializer list
+TEST(IndirectTest, InPlaceConstructionInitializerList) {
+    indirect<std::vector<int>> v(std::in_place, {1, 2, 3, 4, 5});
+    EXPECT_FALSE(v.valueless_after_move());
+    EXPECT_EQ(v->size(), 5);
+    EXPECT_EQ(v, std::vector<int>({1, 2, 3, 4, 5}));
+}
+
+// Test copy construction
+TEST(IndirectTest, CopyConstruction) {
+    indirect<TestValue> i1(TestValue(42));
+    indirect<TestValue> i2(i1);
+
+    EXPECT_FALSE(i1.valueless_after_move());
+    EXPECT_FALSE(i2.valueless_after_move());
+    EXPECT_EQ(i1->value, 42);
+    EXPECT_EQ(i2->value, 42);
+    EXPECT_EQ(i1, i2);
+
+    // Test value semantics - modifying one doesn't affect the other
+    i1->value = 100;
+    EXPECT_EQ(i1->value, 100);
+    EXPECT_EQ(i2->value, 42);  // i2 should not be affected
+}
+
+// Test copy construction from valueless indirect
+TEST(IndirectTest, CopyConstructionFromValueless) {
+    indirect<int> i1(42);
+    indirect<int> i2(std::move(i1));
+
+    // i1 is now valueless
+    EXPECT_TRUE(i1.valueless_after_move());
+
+    // Copy from valueless should create a valueless indirect
+    indirect<int> i3(i1);
+    EXPECT_TRUE(i3.valueless_after_move());
+}
+
+// Test move construction
+TEST(IndirectTest, MoveConstruction) {
+    indirect<TestValue> i1(TestValue(42));
+    indirect<TestValue> i2(std::move(i1));
+
+    EXPECT_TRUE(i1.valueless_after_move());
+    EXPECT_FALSE(i2.valueless_after_move());
+    EXPECT_EQ(i2->value, 42);
+}
+
+// Test copy assignment
+TEST(IndirectTest, CopyAssignment) {
+    indirect<TestValue> i1(TestValue(42));
+    indirect<TestValue> i2(TestValue(100));
+
+    i2 = i1;
+
+    EXPECT_FALSE(i1.valueless_after_move());
+    EXPECT_FALSE(i2.valueless_after_move());
+    EXPECT_EQ(i1->value, 42);
+    EXPECT_EQ(i2->value, 42);
+    EXPECT_EQ(i1, i2);
+}
+
+// Test copy assignment from valueless to valid
+TEST(IndirectTest, CopyAssignmentFromValueless) {
+    indirect<int> i1(42);
+    indirect<int> i2(std::move(i1));
+
+    // i1 is now valueless
+    EXPECT_TRUE(i1.valueless_after_move());
+
+    indirect<int> i3(100);
+    i3 = i1;
+
+    EXPECT_TRUE(i3.valueless_after_move());
+}
+
+// Test copy assignment from valid to valueless
+TEST(IndirectTest, CopyAssignmentToValueless) {
+    indirect<int> i1(42);
+    indirect<int> i2(std::move(i1));
+
+    // i1 is now valueless
+    EXPECT_TRUE(i1.valueless_after_move());
+
+    indirect<int> i3(100);
+    i1 = i3;
+
+    EXPECT_FALSE(i1.valueless_after_move());
+    EXPECT_EQ(*i1, 100);
+}
+
+// Test self-assignment
+TEST(IndirectTest, SelfCopyAssignment) {
+    indirect<int> i(42);
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wself-assign-overloaded"
+    i = i;
+#pragma clang diagnostic pop
+    EXPECT_FALSE(i.valueless_after_move());
+    EXPECT_EQ(*i, 42);
+}
+
+// Test move assignment
+TEST(IndirectTest, MoveAssignment) {
+    indirect<TestValue> i1(TestValue(42));
+    indirect<TestValue> i2(TestValue(100));
+
+    i2 = std::move(i1);
+
+    EXPECT_TRUE(i1.valueless_after_move());
+    EXPECT_FALSE(i2.valueless_after_move());
+    EXPECT_EQ(i2->value, 42);
+}
+
+// Test self-move-assignment
+TEST(IndirectTest, SelfMoveAssignment) {
+    indirect<int> i(42);
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wself-move"
+    i = std::move(i);
+#pragma clang diagnostic pop
+    EXPECT_FALSE(i.valueless_after_move());
+    EXPECT_EQ(*i, 42);
+}
+
+// Test value assignment
+TEST(IndirectTest, ValueAssignment) {
+    indirect<int> i(42);
+    i = 100;
+    EXPECT_FALSE(i.valueless_after_move());
+    EXPECT_EQ(*i, 100);
+}
+
+// Test value assignment to valueless indirect
+TEST(IndirectTest, ValueAssignmentToValueless) {
+    indirect<int> i1(42);
+    indirect<int> i2(std::move(i1));
+
+    // i1 is now valueless
+    EXPECT_TRUE(i1.valueless_after_move());
+
+    i1 = 100;
+    EXPECT_FALSE(i1.valueless_after_move());
+    EXPECT_EQ(*i1, 100);
+}
+
+// Test dereference operators
+TEST(IndirectTest, DereferenceOperators) {
+    indirect<int> i(42);
+
+    // Non-const lvalue reference
+    EXPECT_EQ(*i, 42);
+    *i = 100;
+    EXPECT_EQ(*i, 100);
+
+    // Const lvalue reference
+    const indirect<int>& ci = i;
+    EXPECT_EQ(*ci, 100);
+
+    // Rvalue reference
+    indirect<int> i2(42);
+    int&& rv = *std::move(i2);
+    EXPECT_EQ(rv, 42);
+}
+
+// Test arrow operator
+TEST(IndirectTest, ArrowOperator) {
+    struct Point {
+        int x, y;
+        int sum() const { return x + y; }
+    };
+
+    indirect<Point> p(Point{3, 4});
+    EXPECT_EQ(p->x, 3);
+    EXPECT_EQ(p->y, 4);
+    EXPECT_EQ(p->sum(), 7);
+
+    p->x = 10;
+    EXPECT_EQ(p->x, 10);
+}
+
+// Test const propagation
+TEST(IndirectTest, ConstPropagation) {
+    struct Mutable {
+        int value;
+        void modify() { value = 100; }
+        int get() const { return value; }
+    };
+
+    indirect<Mutable> m(Mutable{42});
+    EXPECT_EQ(m->get(), 42);
+
+    m->modify();
+    EXPECT_EQ(m->get(), 100);
+
+    const indirect<Mutable>& cm = m;
+    EXPECT_EQ(cm->get(), 100);
+    // The following should not compile (const propagation):
+    // cm->modify();
+}
+
+// Test swap member function
+TEST(IndirectTest, SwapMember) {
+    indirect<int> i1(42);
+    indirect<int> i2(100);
+
+    i1.swap(i2);
+
+    EXPECT_EQ(*i1, 100);
+    EXPECT_EQ(*i2, 42);
+}
+
+// Test swap free function
+TEST(IndirectTest, SwapFree) {
+    indirect<int> i1(42);
+    indirect<int> i2(100);
+
+    swap(i1, i2);
+
+    EXPECT_EQ(*i1, 100);
+    EXPECT_EQ(*i2, 42);
+}
+
+// Test swap with valueless
+TEST(IndirectTest, SwapWithValueless) {
+    indirect<int> i1(42);
+    indirect<int> temp(100);
+    indirect<int> i2(std::move(temp));
+
+    // i2's source (temp) is valueless
+    EXPECT_FALSE(i1.valueless_after_move());
+    EXPECT_FALSE(i2.valueless_after_move());
+
+    swap(i1, i2);
+
+    EXPECT_EQ(*i1, 100);
+    EXPECT_EQ(*i2, 42);
+}
+
+// Test equality operator
+TEST(IndirectTest, EqualityOperator) {
+    indirect<int> i1(42);
+    indirect<int> i2(42);
+    indirect<int> i3(100);
+
+    EXPECT_EQ(i1, i2);
+    EXPECT_NE(i1, i3);
+}
+
+// Test comparison with different types
+TEST(IndirectTest, ComparisonDifferentTypes) {
+    indirect<int> i1(42);
+    indirect<double> d1(42.0);
+    indirect<double> d2(100.0);
+
+    EXPECT_EQ(i1, d1);
+    EXPECT_NE(i1, d2);
+}
+
+// Test spaceship operator
+TEST(IndirectTest, SpaceshipOperator) {
+    indirect<int> i1(42);
+    indirect<int> i2(100);
+
+    EXPECT_LT(i1, i2);
+    EXPECT_GT(i2, i1);
+    EXPECT_LE(i1, i2);
+    EXPECT_GE(i2, i1);
+}
+
+// Test comparison with T directly
+TEST(IndirectTest, ComparisonWithT) {
+    indirect<int> i(42);
+
+    EXPECT_EQ(i, 42);
+    EXPECT_NE(i, 100);
+    EXPECT_LT(i, 100);
+    EXPECT_GT(i, 10);
+}
+
+// Test deduction guide
+TEST(IndirectTest, DeductionGuide) {
+    auto i = indirect(42);
+    static_assert(std::is_same_v<decltype(i), indirect<int>>);
+    EXPECT_EQ(*i, 42);
+
+    auto s = indirect(std::string("hello"));
+    static_assert(std::is_same_v<decltype(s), indirect<std::string>>);
+    EXPECT_EQ(*s, "hello");
+}
+
+// TODO: Add test for incomplete type support (PImpl pattern)
+// This would require a more complex test setup with separate compilation units
+
+// Test with polymorphic types
+TEST(IndirectTest, PolymorphicTypes) {
+    struct Base {
+        int value;
+        explicit Base(int v) : value(v) {}
+        virtual ~Base() = default;
+        virtual int get() const { return value; }
+    };
+
+    struct Derived : Base {
+        explicit Derived(int v) : Base(v) {}
+        int get() const override { return value * 2; }
+    };
+
+    indirect<Base> b(Base{42});
+    EXPECT_EQ(b->get(), 42);
+
+    indirect<Derived> d(Derived{21});
+    EXPECT_EQ(d->get(), 42);
+}
+
+// Test move semantics with rvalue dereference
+TEST(IndirectTest, RvalueDereference) {
+    struct MoveOnly {
+        std::unique_ptr<int> ptr;
+        explicit MoveOnly(int v) : ptr(std::make_unique<int>(v)) {}
+    };
+
+    indirect<MoveOnly> i(MoveOnly{42});
+    MoveOnly extracted = *std::move(i);
+
+    EXPECT_EQ(*extracted.ptr, 42);
+}
+
+}  // namespace
+}  // namespace ttsl

--- a/tt_stl/tests/test_indirect_pimpl.cpp
+++ b/tt_stl/tests/test_indirect_pimpl.cpp
@@ -1,0 +1,118 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+#include <tt_stl/indirect.hpp>
+
+#include "test_indirect_util/widget.hpp"
+
+namespace ttsl {
+namespace {
+
+// These tests demonstrate that indirect<Widget> works with incomplete types!
+// Widget is only forward-declared in widget.hpp - the full definition
+// is in widget.cpp which is compiled separately and linked.
+// This proves that indirect can hold and manage incomplete types.
+
+// Test basic construction with incomplete type
+TEST(IndirectPImplTest, BasicConstruction) {
+    // Widget is incomplete here, but indirect<Widget> works!
+    indirect<Widget> w = createWidget();
+    EXPECT_EQ(getWidgetValue(w), 0);
+}
+
+// Test construction with value
+TEST(IndirectPImplTest, ConstructionWithValue) {
+    indirect<Widget> w = createWidget(42);
+    EXPECT_EQ(getWidgetValue(w), 42);
+}
+
+// Test copy construction
+TEST(IndirectPImplTest, CopyConstruction) {
+    indirect<Widget> w1 = createWidget(42);
+    indirect<Widget> w2 = w1;
+
+    EXPECT_EQ(getWidgetValue(w1), 42);
+    EXPECT_EQ(getWidgetValue(w2), 42);
+
+    // Verify deep copy - modifying one doesn't affect the other
+    setWidgetValue(w1, 100);
+    EXPECT_EQ(getWidgetValue(w1), 100);
+    EXPECT_EQ(getWidgetValue(w2), 42);
+}
+
+// Test move construction
+TEST(IndirectPImplTest, MoveConstruction) {
+    indirect<Widget> w1 = createWidget(42);
+    indirect<Widget> w2 = std::move(w1);
+
+    EXPECT_TRUE(w1.valueless_after_move());
+    EXPECT_EQ(getWidgetValue(w2), 42);
+}
+
+// Test copy assignment
+TEST(IndirectPImplTest, CopyAssignment) {
+    indirect<Widget> w1 = createWidget(42);
+    indirect<Widget> w2 = createWidget(100);
+
+    w2 = w1;
+
+    EXPECT_EQ(getWidgetValue(w1), 42);
+    EXPECT_EQ(getWidgetValue(w2), 42);
+
+    // Verify deep copy
+    setWidgetValue(w1, 200);
+    EXPECT_EQ(getWidgetValue(w1), 200);
+    EXPECT_EQ(getWidgetValue(w2), 42);
+}
+
+// Test move assignment
+TEST(IndirectPImplTest, MoveAssignment) {
+    indirect<Widget> w1 = createWidget(42);
+    indirect<Widget> w2 = createWidget(100);
+
+    w2 = std::move(w1);
+
+    EXPECT_TRUE(w1.valueless_after_move());
+    EXPECT_EQ(getWidgetValue(w2), 42);
+}
+
+// Test dereference and manipulation
+TEST(IndirectPImplTest, DereferenceAndManipulate) {
+    indirect<Widget> w = createWidget(123);
+
+    EXPECT_EQ(getWidgetValue(w), 123);
+
+    setWidgetValue(w, 456);
+    EXPECT_EQ(getWidgetValue(w), 456);
+}
+
+// Test const correctness
+TEST(IndirectPImplTest, ConstCorrectness) {
+    indirect<Widget> w = createWidget(42);
+    const indirect<Widget>& cw = w;
+
+    EXPECT_EQ(getWidgetValue(cw), 42);
+
+    setWidgetValue(w, 100);
+    EXPECT_EQ(getWidgetValue(cw), 100);
+}
+
+// Test multiple operations
+TEST(IndirectPImplTest, MultipleOperations) {
+    indirect<Widget> w1 = createWidget(10);
+    indirect<Widget> w2 = createWidget(20);
+    indirect<Widget> w3 = w1;
+
+    setWidgetValue(w1, getWidgetValue(w1) + getWidgetValue(w2));
+    EXPECT_EQ(getWidgetValue(w1), 30);
+    EXPECT_EQ(getWidgetValue(w2), 20);
+    EXPECT_EQ(getWidgetValue(w3), 10);
+
+    w3 = w2;
+    EXPECT_EQ(getWidgetValue(w3), 20);
+}
+
+}  // namespace
+}  // namespace ttsl

--- a/tt_stl/tests/test_indirect_util/CMakeLists.txt
+++ b/tt_stl/tests/test_indirect_util/CMakeLists.txt
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Library for PImpl test utilities
+# This library is compiled separately to ensure that indirect
+# can properly handle incomplete types (PImpl pattern)
+add_library(test_indirect_util STATIC)
+
+target_sources(
+    test_indirect_util
+    PRIVATE
+        widget.cpp
+    PUBLIC
+        FILE_SET HEADERS
+        BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/..
+        FILES widget.hpp
+)
+
+target_link_libraries(test_indirect_util PUBLIC TT::STL)

--- a/tt_stl/tests/test_indirect_util/widget.cpp
+++ b/tt_stl/tests/test_indirect_util/widget.cpp
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "widget.hpp"
+
+namespace ttsl {
+
+// Full Widget definition - only visible in this translation unit
+// This is the COMPLETE TYPE that is incomplete in widget.hpp
+class Widget {
+public:
+    int value;
+
+    Widget() : value(0) {}
+    explicit Widget(int v) : value(v) {}
+};
+
+// Factory function implementations
+// These create indirect<Widget> where Widget is complete
+indirect<Widget> createWidget() { return indirect<Widget>(Widget()); }
+
+indirect<Widget> createWidget(int value) { return indirect<Widget>(Widget(value)); }
+
+int getWidgetValue(const indirect<Widget>& w) { return w->value; }
+
+void setWidgetValue(indirect<Widget>& w, int value) { w->value = value; }
+
+}  // namespace ttsl

--- a/tt_stl/tests/test_indirect_util/widget.hpp
+++ b/tt_stl/tests/test_indirect_util/widget.hpp
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <tt_stl/indirect.hpp>
+
+namespace ttsl {
+
+// Forward declaration only - Widget is an INCOMPLETE TYPE in this header
+// The full definition is in widget.cpp
+// This allows testing indirect<Widget> with an incomplete type
+class Widget;
+
+// Factory functions to create and manipulate Widget
+// These return/accept indirect<Widget> where Widget is incomplete in this header
+// but complete in widget.cpp where these functions are defined
+indirect<Widget> createWidget();
+indirect<Widget> createWidget(int value);
+int getWidgetValue(const indirect<Widget>& w);
+void setWidgetValue(indirect<Widget>& w, int value);
+
+}  // namespace ttsl

--- a/tt_stl/tt_stl/indirect.hpp
+++ b/tt_stl/tt_stl/indirect.hpp
@@ -173,7 +173,7 @@ public:
             return *this;
         }
 
-        this->p = std::move(other.p);
+        this->p = *std::move(other);
         return *this;
     }
 

--- a/tt_stl/tt_stl/indirect.hpp
+++ b/tt_stl/tt_stl/indirect.hpp
@@ -244,7 +244,11 @@ public:
     }
 
     template <class U>
-    friend constexpr auto operator<=>(const indirect& lhs, const U& rhs) {
+    friend constexpr auto operator<=>(const indirect& lhs, const U& rhs) -> decltype(*lhs <=> rhs) {
+        if (lhs.valueless_after_move()) {
+            return std::strong_ordering::less;
+        }
+
         return *lhs <=> rhs;
     }
 

--- a/tt_stl/tt_stl/indirect.hpp
+++ b/tt_stl/tt_stl/indirect.hpp
@@ -218,7 +218,7 @@ public:
     // [indirect.swap], swap
     constexpr void swap(indirect& other) noexcept { std::swap(this->p, other.p); }
 
-    friend constexpr void swap(indirect& lhs, indirect& rhs) noexcept { std::swap(lhs.p, rhs.p); }
+    friend constexpr void swap(indirect& lhs, indirect& rhs) noexcept { lhs.swap(rhs); }
 
     // [indirect.relops], relational operators
     template <class U>

--- a/tt_stl/tt_stl/indirect.hpp
+++ b/tt_stl/tt_stl/indirect.hpp
@@ -173,7 +173,7 @@ public:
             return *this;
         }
 
-        this->p = *std::move(other);
+        this->p = std::move(other).p;
         return *this;
     }
 

--- a/tt_stl/tt_stl/indirect.hpp
+++ b/tt_stl/tt_stl/indirect.hpp
@@ -223,11 +223,17 @@ public:
     // [indirect.relops], relational operators
     template <class U>
     friend constexpr bool operator==(const indirect& lhs, const indirect<U>& rhs) noexcept(noexcept(*lhs == *rhs)) {
+        if (lhs.valueless_after_move() || rhs.valueless_after_move()) {
+            return lhs.valueless_after_move() && rhs.valueless_after_move();
+        }
         return *lhs == *rhs;
     }
 
     template <class U>
     friend constexpr auto operator<=>(const indirect& lhs, const indirect<U>& rhs) {
+        if (lhs.valueless_after_move() || rhs.valueless_after_move()) {
+            return !lhs.valueless_after_move() <=> !rhs.valueless_after_move();
+        }
         return *lhs <=> *rhs;
     }
 

--- a/tt_stl/tt_stl/indirect.hpp
+++ b/tt_stl/tt_stl/indirect.hpp
@@ -94,7 +94,7 @@ public:
      */
     constexpr indirect(indirect&& other) noexcept {
         std::swap(this->p, other.p);
-        other.p.release();
+        other.p.reset();
     }
 
     /**
@@ -153,7 +153,7 @@ public:
         }
 
         if (other.valueless_after_move()) {
-            this->p.release();
+            this->p.reset();
         } else if (this->valueless_after_move()) {
             this->p = std::make_unique<T>(*other);
         } else {

--- a/tt_stl/tt_stl/indirect.hpp
+++ b/tt_stl/tt_stl/indirect.hpp
@@ -1,0 +1,233 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <initializer_list>
+#include <memory>
+#include <type_traits>
+#include <utility>
+
+/**
+ * This is an implementation of C++26 compliant std::indirect without allocator support.
+ * When we switch in C++26, please replace and alias this class as
+ *
+ * ```C++
+ * template<typename T>
+ * using ttsl::indirect = std::indirect<T>;
+ * ```
+ *
+ * Please refer to cppreference/ eel.is for documentation.
+ */
+
+namespace ttsl {
+
+/**
+ * Implementation of std::indirect without allocator support.
+ *
+ * Indirect manages the lifetime of owned object (like a unique_ptr) while retaining value semantic.
+ *
+ * By value semantic, it means that The behavior of special functions like copy assignment/ construction of indirect is
+ * the same as it's underlying type (unlike that of unique_ptr, which is deleted).
+ *
+ * Indirect also handles const propogation correctly as if it's the underlying value. e.g. a dereference to a const
+ * indirect returns a const reference. Unlike a pointer semantic where the pointer and the pointed-to type can exhibit
+ * different const properties.
+ *
+ * This class is very helpful for pimpl pattern, where the wrapper class needs to act like the internal class on
+ * capabilities like copy, assignment and const correctness.
+ *
+ * Note that
+ * - indirect have a move-from state similar to unique_ptr, where the indirect will become valueless and essentially a
+ * null pointer.
+ * - The owned type can be an incomplete type (as would be required by pimpl).
+ * - Dereference a R-value indirect is safe, as the managed object will be moved out.
+ */
+template <typename T>
+class indirect {
+public:
+    using value_type = T;
+    using pointer = /* allocator_traits<Allocator>::pointer */ T*;
+    using const_pointer = /* allocator_traits<Allocator>::const_pointer */ const T*;
+
+    /**
+     * Construct an owned object with the default initializer
+     *
+     * See also: https://en.cppreference.com/w/cpp/memory/indirect/indirect.html
+     */
+    constexpr explicit indirect() : p(std::make_unique<T>()) {}
+
+    /**
+     * Construct an owned object that is the copy of *other
+     *
+     * See also: https://en.cppreference.com/w/cpp/memory/indirect/indirect.html
+     */
+    constexpr indirect(const indirect& other) {
+        if (other.p) {
+            this->p = std::make_unique<T>(*other);
+        }
+    }
+
+    /**
+     * Transfer the ownership of other's owned object. The underlying object will not be moved and other will enter
+     * valueless state.  Similiar move constructing a unique_ptr.
+     *
+     * See also: https://en.cppreference.com/w/cpp/memory/indirect/indirect.html
+     */
+    constexpr indirect(indirect&& other) noexcept {
+        std::swap(this->p, other.p);
+        other.p.release();
+    }
+
+    /*
+     * Construct an owned object with std::forward<U>(u).
+     *
+     * This is often helpful to do with conversion operators.
+     *
+     * See also: https://en.cppreference.com/w/cpp/memory/indirect/indirect.html
+     */
+    template <class U = T>
+    constexpr explicit indirect(U&& u)
+        requires(
+            !std::is_same_v<std::remove_cvref_t<U>, indirect> &&         //
+            !std::is_same_v<std::remove_cvref_t<U>, std::in_place_t> &&  //
+            std::is_constructible_v<T, U>)
+    {
+        this->p = std::make_unique<T>(std::forward<T>(u));
+    }
+
+    /**
+     * Inplace construct an owned object using us... similar to std::make_unique
+     *
+     * See also: https://en.cppreference.com/w/cpp/memory/indirect/indirect.html
+     */
+    template <class... Us>
+    constexpr explicit indirect(std::in_place_t, Us&&... us)
+        requires(std::is_constructible_v<T, Us...>)
+    {
+        this->p = std::make_unique<T>(std::forward<Us>(us)...);
+    }
+
+    /**
+     * Inplace construct an owned object using initializer list (and other (us...) args)
+     *
+     * See also: https://en.cppreference.com/w/cpp/memory/indirect/indirect.html
+     */
+    template <class I, class... Us>
+    constexpr explicit indirect(std::in_place_t, std::initializer_list<I> ilist, Us&&... us)
+        requires(std::is_constructible_v<T, std::initializer_list<I>, Us...>)
+    {
+        this->p = std::make_unique<T>(std::move(ilist), std::forward<Us>(us)...);
+    }
+
+    // [indirect.dtor], destructor
+    constexpr ~indirect() = default;
+
+    // [indirect.assign], assignment
+    /**
+     * Copy assigns the internally owned object with other.
+     *
+     * See also: https://en.cppreference.com/w/cpp/memory/indirect/operator=.html
+     */
+    constexpr indirect& operator=(const indirect& other) {
+        if (std::addressof(other) == this) {
+            return *this;
+        }
+
+        if (other.valueless_after_move()) {
+            this->p.release();
+        } else if (this->valueless_after_move()) {
+            this->p = std::make_unique<T>(*other);
+        } else {
+            **this = *other;
+        }
+        return *this;
+    }
+
+    /**
+     * Transfers the ownership of owned object from other to this. The underlying object will not be move assigned, and
+     * other will be in a valueless state.
+     *
+     * See also: https://en.cppreference.com/w/cpp/memory/indirect/operator=.html
+     */
+    constexpr indirect& operator=(indirect&& other) noexcept {
+        if (std::addressof(other) == this) {
+            return *this;
+        }
+
+        this->p = std::move(other.p);
+        return *this;
+    }
+
+    /**
+     * Move assigns the underlying object with u.
+     *
+     * See also: https://en.cppreference.com/w/cpp/memory/indirect/operator=.html
+     */
+    template <class U = T>
+    constexpr indirect& operator=(U&& u)
+        requires(
+            !std::is_same_v<std::remove_cvref_t<U>, indirect> &&  //
+            std::is_constructible_v<T, U> &&                      //
+            std::is_assignable_v<T&, U>)
+    {
+        if (this->valueless_after_move()) {
+            this->p = std::make_unique<U>(std::forward<U>(u));
+        } else {
+            **this = std::forward<U>(u);
+        }
+
+        return *this;
+    }
+
+    // [indirect.obs], observers
+    /* Obtain a const reference to the owned object. */
+    constexpr const T& operator*() const& noexcept { return *p; }
+    /* Obtain a (mutable) reference to the owned object. */
+    constexpr T& operator*() & noexcept { return *p; }
+    /* Obtain a const R-value reference to the owned object. */
+    constexpr const T&& operator*() const&& noexcept { return std::move(*p); }
+    /* Obtain a mutable R-value reference to the owned object. */
+    constexpr T&& operator*() && noexcept { return std::move(*p); }
+    /* Obtain a const pointer to the owned object */
+    constexpr const_pointer operator->() const noexcept { return p.get(); }
+    /* Obtain a mutable pointer to the owned object */
+    constexpr pointer operator->() noexcept { return p.get(); }
+    /* Checks if this class is in a moved from state, this can happen if this object has been used to move construct/
+     * move assign other indirects, think unique_ptr */
+    constexpr bool valueless_after_move() const noexcept { return !bool(p); }
+
+    // [indirect.swap], swap
+    constexpr void swap(indirect& other) noexcept { std::swap(this->p, other.p); }
+
+    friend constexpr void swap(indirect& lhs, indirect& rhs) noexcept { std::swap(lhs.p, rhs.p); }
+
+    // [indirect.relops], relational operators
+    template <class U>
+    friend constexpr bool operator==(const indirect& lhs, const indirect<U>& rhs) noexcept(noexcept(*lhs == *rhs)) {
+        return *lhs == *rhs;
+    }
+
+    template <class U>
+    friend constexpr auto operator<=>(const indirect& lhs, const indirect<U>& rhs) {
+        return *lhs <=> *rhs;
+    }
+
+    // [indirect.comp.with.t], comparison with T
+    template <class U>
+    friend constexpr bool operator==(const indirect& lhs, const U& rhs) noexcept(noexcept(*lhs == rhs)) {
+        return *lhs == rhs;
+    }
+
+    template <class U>
+    friend constexpr auto operator<=>(const indirect& lhs, const U& rhs) {
+        return *lhs <=> rhs;
+    }
+
+private:
+    std::unique_ptr<T> p;
+};
+
+template <class Value>
+indirect(Value) -> indirect<Value>;
+
+}  // namespace ttsl


### PR DESCRIPTION
### Ticket

### Problem description
Runtime is reducing their public API surface area, 
a bunch of classes has been pimpled using `unique_ptr`.
However, to correctly implement pimpl using the `unique_ptr` requires manually reimplement special member functions like copy constructor and copy assignment,
which could be error prone.

### What's changed
This PR implements `std::indirect` as it appears in C++26 without allocator support to use as a general utility class for tt\_stl.
Which is a unique\_ptr with value semantics, that can be used with pimpl pattern.

Note that allocator support is omitted as we don't use custom C++ allocator anywhere and implementation is non-trivial.

### Checklist
- [x] New/Existing tests provide coverage for changes