### PR TITLE
Hash based socket send/recv ops based on MeshSocket (input)

### DIFF
--- a/tt_metal/api/tt-metalium/mesh_socket.hpp
+++ b/tt_metal/api/tt-metalium/mesh_socket.hpp
@@ -14,8 +14,9 @@ namespace tt::tt_metal::distributed {
 
 // Multi-Dimensional coordinate struct used to access individual cores in a MeshDevice.
 struct MeshCoreCoord {
-    MeshCoordinate device_coord;
-    CoreCoord core_coord;
+    MeshCoordinate device_coord = MeshCoordinate(0);
+    CoreCoord core_coord = CoreCoord(0, 0);
+
     bool operator==(const MeshCoreCoord& other) const {
         return device_coord == other.device_coord && core_coord == other.core_coord;
     }
@@ -25,8 +26,8 @@ struct MeshCoreCoord {
 // Used to determine which cores the socket config must be written to and the sender to receiver mapping.
 // Cannot reuse senders and receivers in a single socket context. Each socket connection is 1:1.
 struct SocketConnection {
-    MeshCoreCoord sender_core;
-    MeshCoreCoord receiver_core;
+    MeshCoreCoord sender_core = {};
+    MeshCoreCoord receiver_core = {};
 
     bool operator==(const SocketConnection& other) const {
         return sender_core == other.sender_core && receiver_core == other.receiver_core;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/recv_async/device/recv_async_op.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/recv_async/device/recv_async_op.hpp
@@ -26,8 +26,7 @@ struct RecvAsync {
     auto attributes() const {
         using tt::stl::reflection::Attribute;
         std::vector<std::tuple<std::string, Attribute>> attrs;
-        // TODO #25011: Adding mesh_socket requires reflection support including json serialization
-        // attrs.emplace_back("mesh_socket", mesh_socket);
+        attrs.emplace_back("mesh_socket", mesh_socket);
         return attrs;
     }
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/send_async/device/send_async_op.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/send_async/device/send_async_op.hpp
@@ -26,8 +26,7 @@ struct SendAsync {
     auto attributes() const {
         using tt::stl::reflection::Attribute;
         std::vector<std::tuple<std::string, Attribute>> attrs;
-        // TODO #25011: Adding mesh_socket requires reflection support including json serialization
-        // attrs.emplace_back("mesh_socket", mesh_socket);
+        attrs.emplace_back("mesh_socket", mesh_socket);
         return attrs;
     }
 


### PR DESCRIPTION
### Ticket
No Ticket.

### Problem description
- Socket Based Send/Recv ops are currently not hashed based on the `MeshSocket` they use
- This can cause the incorrect socket to be used for an op invocation if a user spawns more than one socket per process

### What's changed
- Resolve compile failures caused when hashing socket attributes (`MeshCoreCoord ` and  `SocketConnection` were missing default values, required by `tt_stl/tt_stl/reflection.hpp`)
- Include socket attributes in program hash

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes