### PR TITLE
SDXL: Convert VAE output to channel-first, Row-Major

### DIFF
--- a/models/experimental/stable_diffusion_xl_base/tests/test_common.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/test_common.py
@@ -886,8 +886,7 @@ def run_tt_image_gen(
         profiler.end("read_output_tensor")
 
         B, C, H, W = output_shape
-        output_tensor = output_tensor.reshape(batch_size * B, H, W, C)
-        imgs = torch.permute(output_tensor, (0, 3, 1, 2))
+        imgs = output_tensor.reshape(batch_size * B, C, H, W)
     else:
         profiler.start("read_output_tensor")
         latents = ttnn.to_torch(tt_latents, mesh_composer=ttnn.ConcatMeshToTensor(ttnn_device, dim=0))[:batch_size, ...]
@@ -1073,8 +1072,7 @@ def run_tt_image_gen_inpainting(
         profiler.end("read_output_tensor")
 
         B, C, H, W = output_shape
-        output_tensor = output_tensor.reshape(batch_size * B, H, W, C)
-        imgs = torch.permute(output_tensor, (0, 3, 1, 2))
+        imgs = output_tensor.reshape(batch_size * B, C, H, W)
     else:
         profiler.start("read_output_tensor")
         latents = ttnn.to_torch(tt_latents, mesh_composer=ttnn.ConcatMeshToTensor(ttnn_device, dim=0))[:batch_size, ...]

--- a/models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_autoencoder_kl.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_autoencoder_kl.py
@@ -79,8 +79,7 @@ def test_vae(
         output_tensor, [C, H, W] = tt_vae.decode(ttnn_input_tensor, [B, C, H, W])
 
         output_tensor = ttnn.to_torch(output_tensor, mesh_composer=ttnn.ConcatMeshToTensor(device, dim=0)).float()
-        output_tensor = output_tensor.reshape(B, H, W, C)
-        output_tensor = torch.permute(output_tensor, (0, 3, 1, 2))
+        output_tensor = output_tensor.reshape(B, C, H, W)
     logger.info("TT model done")
 
     del vae

--- a/models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_decoder.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_decoder.py
@@ -63,8 +63,7 @@ def test_vae_decoder(device, input_shape, pcc, debug_mode, is_ci_env, reset_seed
     logger.info("TT model done")
 
     output_tensor = ttnn.to_torch(output_tensor, mesh_composer=ttnn.ConcatMeshToTensor(device, dim=0)).float()
-    output_tensor = output_tensor.reshape(B, H, W, C)
-    output_tensor = torch.permute(output_tensor, (0, 3, 1, 2))
+    output_tensor = output_tensor.reshape(B, C, H, W)
 
     del vae
     gc.collect()


### PR DESCRIPTION
### Ticket
-
### Problem description
VAE output was [1, 1, 1024, 1024, 3[32]], in tiled format, resulting in huge tensor being read over PCIE, and then untilized, permuted on host.

### What's changed
Use convert_to_chw op to do the channel-first RM converison on device, and then transfer data to host.
~0.1s E2E improvement (single chip scenario)
~0.6s E2E improvement in DP=32 Galaxy scenario

### Checklist
- [x] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/19669772401l) CI passes (if applicable)