### PR TITLE
Fix regressino from commit fa37904

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/transformer/create_qkv_heads_from_separate_tensors/device/create_qkv_heads_from_separate_tensors_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/create_qkv_heads_from_separate_tensors/device/create_qkv_heads_from_separate_tensors_program_factory.hpp
@@ -12,11 +12,11 @@ namespace ttnn::operations::experimental::create_qkv_heads_from_separate_tensors
 
 struct CreateQKVHeadsSeparateTensorsProgramFactory {
     struct shared_variables_t {
-        uint32_t cb_in0_id;
-        uint32_t cb_in1_id;
-        uint32_t cb_out0_id;
-        uint32_t cb_out1_id;
-        uint32_t cb_out2_id;
+        tt::tt_metal::CBHandle cb_in0_id = 0;
+        tt::tt_metal::CBHandle cb_in1_id = 0;
+        tt::tt_metal::CBHandle cb_out0_id = 0;
+        tt::tt_metal::CBHandle cb_out1_id = 0;
+        tt::tt_metal::CBHandle cb_out2_id = 0;
     };
 
     using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;


### PR DESCRIPTION
Commit #fa37904 regressed ttnn.create_qkv_heads and SD1.4 is failing due to his.

Pipeline running tests for the op
https://github.com/tenstorrent/tt-metal/actions/runs/19665288929