### PR TITLE
Fix expm1 accuracy

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_expm1.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_expm1.py
@@ -12,7 +12,8 @@ from tests.ttnn.utils_for_testing import assert_with_ulp
 def flush_subnormal_values(tensor):
     # f32 and bf16 numbers are subnormals if exponent == 0
     # i.e. if  their value < 2**(-126)
-    mask = torch.abs(tensor) < 2 ** (-126)
+    SUBNORMAL_THRESHOLD = 2.0 ** (-126)
+    mask = torch.abs(tensor) < SUBNORMAL_THRESHOLD
     tensor[mask] = 0.0
     return tensor
 

--- a/tests/ttnn/unit_tests/operations/eltwise/test_expm1.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_expm1.py
@@ -10,7 +10,9 @@ from tests.ttnn.utils_for_testing import assert_with_ulp
 
 
 def flush_subnormal_values(tensor):
-    mask = tensor < 2 ** (-126)
+    # f32 and bf16 numbers are subnormals if exponent == 0
+    # i.e. if  their value < 2**(-126)
+    mask = torch.abs(tensor) < 2 ** (-126)
     tensor[mask] = 0.0
     return tensor
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_expm1.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_expm1.h
@@ -25,7 +25,7 @@ sfpi_inline sfpi::vFloat _sfpu_expm1_(sfpi::vFloat val) {
     sfpi::vFloat y = sfpi::vConstNeg1;
     v_if(sfpi::abs(val) < sfpi::s2vFloat16b(0.4f)) {
         // When x is very small, exp(x) is very close to 1. Hence, for improved precision, we use Taylor expansion of
-        // expm1(x) = x + (x^2/2) + (x^3/3^2)
+        // expm1(x) = x + (x^2/2) + (x^3/6)
         // In Horner form, on reducing further : y = (val * (val * (val * 0.166f + 0.5f )+ 1)
         y = val * (sfpi::vConst1 + val * (sfpi::vFloat(0.5f) + val * sfpi::vFloat(0.166f)));
     }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_expm1.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_expm1.h
@@ -23,7 +23,7 @@ namespace sfpu {
 template <bool is_fp32_dest_acc_en = false>
 sfpi_inline sfpi::vFloat _sfpu_expm1_(sfpi::vFloat val) {
     sfpi::vFloat y = sfpi::vConstNeg1;
-    v_if(sfpi::abs(val) < sfpi::vFloat(1e-3f)) {
+    v_if(sfpi::abs(val) < sfpi::s2vFloat16b(0.4f)) {
         // When x is very small, exp(x) is very close to 1. Hence, for improved precision, we use Taylor expansion of
         // expm1(x) = x + (x^2/2) + (x^3/3^2)
         // In Horner form, on reducing further : y = (val * (val * (val * 0.166f + 0.5f )+ 1)

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_expm1.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_expm1.h
@@ -25,7 +25,7 @@ sfpi_inline sfpi::vFloat _sfpu_expm1_(sfpi::vFloat val) {
     sfpi::vFloat y = sfpi::vConstNeg1;
     v_if(sfpi::abs(val) < sfpi::s2vFloat16b(0.4f)) {
         // When x is very small, exp(x) is very close to 1. Hence, for improved precision, we use Taylor expansion of
-        // expm1(x) = x + (x^2/2) + (x^3/3^2)
+        // expm1(x) = x + (x^2/2) + (x^3/6)
         // In Horner form, on reducing further : y = (val * (val * (val * 0.166f + 0.5f )+ 1)
         y = val * (sfpi::vConst1 + val * (sfpi::vFloat(0.5f) + val * sfpi::vFloat(0.166f)));
     }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_expm1.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_expm1.h
@@ -23,7 +23,7 @@ namespace sfpu {
 template <bool is_fp32_dest_acc_en = false>
 sfpi_inline sfpi::vFloat _sfpu_expm1_(sfpi::vFloat val) {
     sfpi::vFloat y = sfpi::vConstNeg1;
-    v_if(sfpi::abs(val) < sfpi::vFloat(1e-3f)) {
+    v_if(sfpi::abs(val) < sfpi::s2vFloat16b(0.4f)) {
         // When x is very small, exp(x) is very close to 1. Hence, for improved precision, we use Taylor expansion of
         // expm1(x) = x + (x^2/2) + (x^3/3^2)
         // In Horner form, on reducing further : y = (val * (val * (val * 0.166f + 0.5f )+ 1)


### PR DESCRIPTION
### Ticket
#28187

### Problem description
expm1 has a large ULP error near 0. Its implementation does switch to a polynomial approximation near 0, but the range where this approximation is used is too small. 

### What's changed
- Increase range of polynomial approximation for expm1. 
- Adjust test values: remove mask on range, and flush subnormal inputs and outputs to 0 (subnormals are not supported by the hardware). Threshold value is increased from 1 to 1.5 to tolerate data points with ULP error of 1.2.

#### Accuracy improvement

ULP error spike near 0 is gone. The maximum ULP error across the whole range for normal numbers is <2. 
There is no significant performance impact. 

<img width="2421" height="1510" alt="expm1-accurate-bfloat16" src="https://github.com/user-attachments/assets/9de82c83-174d-43ab-8b45-b29a62e86430" />



### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes [OK](https://github.com/tenstorrent/tt-metal/actions/runs/19646143914)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable) [OK](https://github.com/tenstorrent/tt-metal/actions/runs/19646147524)
- [x] L1 Nightly [OK](https://github.com/tenstorrent/tt-metal/actions/runs/19646156123)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [x] New/Existing tests provide coverage for changes