### PR TITLE
Add CI script to enforce API deprecation policy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,9 +45,14 @@ repos:
       args: ["--style=file"]
 - repo: local
   hooks:
-    - id: validate-metalium-api
-      name: validate-metalium-public-apis
-      entry: python3 scripts/validate_metalium_api.py tt_metal/api
+    - id: validate-metalium-includes
+      name: validate-metalium-includes
+      entry: python3 scripts/validate_api/validate_includes.py tt_metal/api
+      language: system
+      pass_filenames: false
+    - id: validate-metalium-deprecation
+      name: validate-metalium-deprecation
+      entry: python3 scripts/validate_api/validate_deprecation.py tt_metal/api origin/main
       language: system
       pass_filenames: false
 - repo: local

--- a/scripts/validate_api/common.py
+++ b/scripts/validate_api/common.py
@@ -1,0 +1,36 @@
+"""Common utilities for API validation scripts."""
+
+import os
+from typing import Callable, List, Tuple, TypeVar
+
+T = TypeVar("T")
+
+# Shared constant for C++ source file extensions
+CPP_EXTENSIONS = (".hpp", ".h", ".cpp", ".cc", ".cxx")
+
+
+def partition(predicate: Callable[[T], bool], items: List[T]) -> Tuple[List[T], List[T]]:
+    """Split items into (matching, non-matching) based on predicate.
+
+    Example: partition(lambda x: x > 5, [3, 7, 1, 9]) → ([7, 9], [3, 1])
+    """
+    matching = [item for item in items if predicate(item)]
+    non_matching = [item for item in items if not predicate(item)]
+    return matching, non_matching
+
+
+def is_cpp_source(filepath: str) -> bool:
+    """Check if a file path is a C++ source file."""
+    return filepath.endswith(CPP_EXTENSIONS)
+
+
+def find_cpp_sources(directory: str, skip_files: set[str] = None) -> list[str]:
+    """Find all C++ source files in directory, optionally skipping certain files."""
+    skip_files = skip_files or set()
+
+    return [
+        os.path.join(root, fname)
+        for root, _, files in os.walk(directory)
+        for fname in files
+        if fname.endswith(CPP_EXTENSIONS) and fname not in skip_files
+    ]

--- a/scripts/validate_api/common.py
+++ b/scripts/validate_api/common.py
@@ -3,7 +3,7 @@
 """Common utilities for API validation scripts."""
 
 import os
-from typing import Callable, List, Tuple, TypeVar
+from typing import Callable, List, Optional, Tuple, TypeVar
 
 T = TypeVar("T")
 
@@ -26,7 +26,7 @@ def is_cpp_source(filepath: str) -> bool:
     return filepath.endswith(CPP_EXTENSIONS)
 
 
-def find_cpp_sources(directory: str, skip_files: set[str] = None) -> list[str]:
+def find_cpp_sources(directory: str, skip_files: Optional[set[str]] = None) -> list[str]:
     """Find all C++ source files in directory, optionally skipping certain files."""
     skip_files = skip_files or set()
 

--- a/scripts/validate_api/common.py
+++ b/scripts/validate_api/common.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
 """Common utilities for API validation scripts."""
 
 import os

--- a/scripts/validate_api/git_utils.py
+++ b/scripts/validate_api/git_utils.py
@@ -1,0 +1,115 @@
+"""Git operations for API validation scripts."""
+
+import subprocess
+import sys
+from itertools import groupby
+from typing import Dict, List, Optional, Tuple
+
+
+def run_git(cmd: List[str], cwd: str = ".") -> str:
+    try:
+        result = subprocess.run(cmd, cwd=cwd, capture_output=True, text=True, check=True)
+        return result.stdout
+    except subprocess.CalledProcessError as e:
+        raise RuntimeError(f"Git command failed: {' '.join(cmd)}\n{e.stderr}")
+
+
+def get_blame_timestamps(file_path: str, line_ranges: List[Tuple[int, int]], ref: str = "HEAD") -> Dict[int, int]:
+    """Get unix timestamps for when lines were last modified.
+
+    Returns: {line_number: unix_timestamp}
+    Example: {10: 1699123456, 11: 1699123456, 20: 1701345678}
+    """
+    timestamps = {}
+    for start, end in line_ranges:
+        try:
+            output = run_git(["git", "blame", "--porcelain", f"-L{start},{end}", ref, "--", file_path])
+            lines = output.split("\n")
+            for i, line in enumerate(lines):
+                parts = line.split()
+                if len(parts) >= 3 and parts[1].isdigit():
+                    line_num = int(parts[2])
+                    # Look ahead for committer-time
+                    for j in range(i + 1, min(i + 10, len(lines))):
+                        if lines[j].startswith("committer-time "):
+                            timestamps[line_num] = int(lines[j].split()[1])
+                            break
+        except (RuntimeError, ValueError) as e:
+            print(f"Warning: git blame failed for {file_path}:{start}-{end}: {e}", file=sys.stderr)
+            continue
+    return timestamps
+
+
+def parse_diff_for_removed_lines(diff_output: str, pattern_matcher) -> List[Tuple[str, int, str]]:
+    """Parse git diff to find removed lines matching a pattern.
+
+    Returns: [(file_path, line_number, content), ...]
+    """
+    results = []
+    current_file = None
+    old_line = 0
+
+    for line in diff_output.split("\n"):
+        if line.startswith("--- a/"):
+            current_file = line[6:]
+        elif line.startswith("@@ "):
+            # Parse hunk header: @@ -10,3 +9,0 @@
+            parts = line.split()
+            if len(parts) >= 2:
+                old_range = parts[1][1:]  # Remove '-' prefix
+                old_line = int(old_range.split(",")[0] if "," in old_range else old_range)
+        elif line.startswith("-") and not line.startswith("---"):
+            if current_file and pattern_matcher.search(line[1:]):
+                results.append((current_file, old_line, line[1:]))
+            old_line += 1
+        elif line.startswith(" "):
+            old_line += 1
+
+    return results
+
+
+def get_changed_file_paths(base_ref: str, head_ref: str = "HEAD") -> List[str]:
+    """List of changed files (paths) (includes deleted ones)"""
+    output = run_git(["git", "diff", "--name-only", base_ref, head_ref])
+    return [f for f in output.strip().split("\n") if f]
+
+
+def get_diff(files: List[str], base_ref: str, head_ref: str = "HEAD") -> str:
+    """Get git concatenated diff for specified files."""
+    if not files:
+        return ""
+    return run_git(["git", "diff", "-U0", base_ref, head_ref, "--"] + files)
+
+
+def compute_ranges(numbers: List[int]) -> List[Tuple[int, int]]:
+    """Convert numbers to contiguous ranges. [1,2,3,7,8] → [(1,3), (7,8)]"""
+    return [
+        (min(nums), max(nums))
+        for _, nums in [
+            (key, [item[1] for item in group])
+            for key, group in groupby(enumerate(sorted(numbers)), lambda x: x[1] - x[0])
+        ]
+    ]
+
+
+def get_timestamps_for_items(items: List[Tuple[str, int, str]], ref: str) -> Dict[Tuple[str, int], Optional[int]]:
+    """Get git blame timestamps for items at ref.
+
+    items: [(file_path, line_number, content), ...]
+    Returns: {(file_path, line_number): unix_timestamp, ...}
+    """
+    # Group by file for efficient git blame operations
+    files_to_lines = {}
+    for file_path, line_num, _ in items:
+        if file_path not in files_to_lines:
+            files_to_lines[file_path] = []
+        files_to_lines[file_path].append(line_num)
+
+    # Get timestamps for each file
+    result = {}
+    for file_path, line_numbers in files_to_lines.items():
+        timestamps = get_blame_timestamps(file_path, compute_ranges(line_numbers), ref)
+        for line_num in line_numbers:
+            result[(file_path, line_num)] = timestamps.get(line_num)
+
+    return result

--- a/scripts/validate_api/git_utils.py
+++ b/scripts/validate_api/git_utils.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
 """Git operations for API validation scripts."""
 
 import subprocess

--- a/scripts/validate_api/validate_deprecation.py
+++ b/scripts/validate_api/validate_deprecation.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
 """Validate C++ deprecation policy: items must age 30+ days before removal.
 
 Example: [[deprecated]] void oldFunc(); must exist 30+ days before deletion.
@@ -144,7 +146,9 @@ def print_report(existing: List[DeprecatedItem], removed: List[DeprecatedItem]) 
         for item in violations:
             if item.age_days is not None:
                 wait = Config.MIN_DEPRECATION_DAYS - item.age_days
-                print(f"  • {item.file_path}:{item.line_number} - {item.age_days:.1f} days old, wait {wait:.1f} more days")
+                print(
+                    f"  • {item.file_path}:{item.line_number} - {item.age_days:.1f} days old, wait {wait:.1f} more days"
+                )
             else:
                 print(f"  • {item.file_path}:{item.line_number} - unknown age")
 

--- a/scripts/validate_api/validate_deprecation.py
+++ b/scripts/validate_api/validate_deprecation.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Validate C++ deprecation policy: items must age 30+ days before removal.
+
+Example: [[deprecated]] void oldFunc(); must exist 30+ days before deletion.
+Exit codes: 0 (success), 1 (violations or errors)
+"""
+
+import re
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, Iterator, List, NamedTuple, Optional, Tuple
+
+from common import find_cpp_sources, is_cpp_source, partition
+import git_utils
+
+
+class Config:
+    """Deprecation policy configuration."""
+
+    MIN_DEPRECATION_DAYS = 30
+    SECONDS_PER_DAY = 86400
+
+
+DEPRECATION_PATTERN = re.compile(r'\[\[deprecated(?:\(["\'].*?["\']\))?\]\]', re.IGNORECASE)
+
+
+class DeprecatedItem(NamedTuple):
+    """A deprecated code element with metadata."""
+
+    file_path: str
+    line_number: int
+    content: str
+    timestamp: Optional[int]  # Unix timestamp when added
+    is_removed: bool  # True if removed in current branch
+
+    @property
+    def age_days(self) -> Optional[float]:
+        """Days since deprecation was added."""
+        if self.timestamp is None:
+            return None
+        return (datetime.now().timestamp() - self.timestamp) / Config.SECONDS_PER_DAY
+
+    @property
+    def can_remove(self) -> bool:
+        """Check if old enough to remove."""
+        return self.age_days is not None and self.age_days >= Config.MIN_DEPRECATION_DAYS
+
+
+def find_removed_deprecations(base_ref: str = "origin/main") -> List[DeprecatedItem]:
+    # Get all C++ files that changed (including deleted ones)
+    changed_files = git_utils.get_changed_file_paths(base_ref)
+    changed_cpp_files = [f for f in changed_files if is_cpp_source(f)]
+
+    if not changed_cpp_files:
+        return []
+
+    # Get diff for these files (git diff handles deleted files properly)
+    try:
+        diff = git_utils.get_diff(changed_cpp_files, base_ref)
+        items = git_utils.parse_diff_for_removed_lines(diff, DEPRECATION_PATTERN)
+    except RuntimeError as e:
+        print(f"Error: Failed to get diff: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    # Timestamp from base_ref shows when the removed deprecation was originally added
+    timestamps = git_utils.get_timestamps_for_items(items, base_ref)
+    return [
+        DeprecatedItem(file_path, line_num, content, timestamps.get((file_path, line_num)), is_removed=True)
+        for file_path, line_num, content in items
+    ]
+
+
+def scan_file_for_deprecations(file_path: str) -> Iterator[Tuple[str, int, str]]:
+    try:
+        # errors='ignore' handles corrupted UTF-8 or binary files that may have been misidentified
+        with open(file_path, "r", encoding="utf-8", errors="ignore") as f:
+            yield from (
+                (file_path, line_num, line.rstrip("\n"))
+                for line_num, line in enumerate(f, 1)
+                if DEPRECATION_PATTERN.search(line)
+            )
+    except IOError as e:
+        print(f"Warning: Cannot read {file_path}: {e}", file=sys.stderr)
+        return
+
+
+def find_existing_deprecations(files: List[str]) -> List[DeprecatedItem]:
+    items: List[DeprecatedItem] = [item for file_path in files for item in scan_file_for_deprecations(file_path)]
+
+    # HEAD is correct here: we want timestamps from current branch history for existing deprecations
+    timestamps = git_utils.get_timestamps_for_items(items, "HEAD")
+    return [
+        DeprecatedItem(
+            file_path,
+            line_num,
+            content,
+            timestamps.get((file_path, line_num)),
+            is_removed=False,
+        )
+        for file_path, line_num, content in items
+    ]
+
+
+def print_report(existing: List[DeprecatedItem], removed: List[DeprecatedItem]) -> int:
+    print(f"\n{'='*80}")
+    print(f"DEPRECATION REPORT")
+    print(f"{'='*80}")
+
+    # Report existing deprecations
+    if existing:
+        ready = [i for i in existing if i.can_remove]
+        recent = [i for i in existing if i.age_days is not None and not i.can_remove]
+        unknown = [i for i in existing if i.age_days is None]
+
+        print(f"\n📊 Existing: {len(existing)} deprecations")
+        for items, label in [
+            (ready, f"ready to remove (≥{Config.MIN_DEPRECATION_DAYS} days)"),
+            (recent, "not ready yet"),
+            (unknown, "unknown age"),
+        ]:
+            if items:
+                print(f"  • {len(items)} {label}")
+
+        print(f"\n📋 Existing deprecations:")
+        for item in sorted(existing, key=lambda x: (x.file_path, x.line_number)):
+            age_str = f"{item.age_days:.1f} days" if item.age_days is not None else "unknown"
+            status = "✓ removable" if item.can_remove else "⏳ too recent" if item.age_days is not None else "? unknown"
+            print(f"  [{status}] {item.file_path}:{item.line_number} (age: {age_str})")
+
+    # Report violations
+    violations, valid = partition(lambda i: not i.can_remove, removed)
+
+    if removed:
+        print(f"\n📋 Removed deprecations:")
+        for item in sorted(removed, key=lambda x: (x.file_path, x.line_number)):
+            age_str = f"{item.age_days:.1f} days" if item.age_days is not None else "unknown"
+            status = "✅ valid" if item.can_remove else "❌ violation"
+            print(f"  [{status}] {item.file_path}:{item.line_number} (age: {age_str})")
+
+    if violations:
+        print(f"\n❌ POLICY VIOLATIONS: {len(violations)} items removed too early")
+        print(f"   (must wait {Config.MIN_DEPRECATION_DAYS} days before removal)")
+        for item in violations:
+            if item.age_days is not None:
+                wait = Config.MIN_DEPRECATION_DAYS - item.age_days
+                print(f"  • {item.file_path}:{item.line_number} - {item.age_days:.1f} days old, wait {wait:.1f} more days")
+            else:
+                print(f"  • {item.file_path}:{item.line_number} - unknown age")
+
+    # Summary
+    print(f"\n{'='*80}")
+    if violations:
+        print(f"FAILED: {len(violations)} violation{'s' if len(violations) != 1 else ''}")
+    else:
+        print("PASSED: No violations")
+
+    return 1 if violations else 0
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print(f"Usage: {sys.argv[0]} <directory> [base_ref]")
+        return 1
+
+    directory = sys.argv[1]
+    base_ref = sys.argv[2] if len(sys.argv) > 2 else "origin/main"
+
+    if not Path(directory).exists():
+        print(f"Error: Directory '{directory}' does not exist", file=sys.stderr)
+        return 1
+
+    source_files = find_cpp_sources(directory)
+    existing = find_existing_deprecations(source_files)
+    removed = find_removed_deprecations(base_ref)
+
+    return print_report(existing, removed)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/validate_api/validate_deprecation.py
+++ b/scripts/validate_api/validate_deprecation.py
@@ -11,7 +11,7 @@ import re
 import sys
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, Iterator, List, NamedTuple, Optional, Tuple
+from typing import Iterator, List, NamedTuple, Optional, Tuple
 
 from common import find_cpp_sources, is_cpp_source, partition
 import git_utils
@@ -88,7 +88,7 @@ def scan_file_for_deprecations(file_path: str) -> Iterator[Tuple[str, int, str]]
 
 
 def find_existing_deprecations(files: List[str]) -> List[DeprecatedItem]:
-    items: List[DeprecatedItem] = [item for file_path in files for item in scan_file_for_deprecations(file_path)]
+    items: List[Tuple[str, int, str]] = [item for file_path in files for item in scan_file_for_deprecations(file_path)]
 
     # HEAD is correct here: we want timestamps from current branch history for existing deprecations
     timestamps = git_utils.get_timestamps_for_items(items, "HEAD")

--- a/scripts/validate_api/validate_includes.py
+++ b/scripts/validate_api/validate_includes.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
 """Validate #include directives in C++ source files."""
 
 import re

--- a/scripts/validate_api/validate_includes.py
+++ b/scripts/validate_api/validate_includes.py
@@ -183,6 +183,7 @@ class Include(NamedTuple):
             return Include(source_file, line_num, match.group(1), quoted=True)
         if match := ANGLE_INCLUDE_PATTERN.match(line):
             return Include(source_file, line_num, match.group(1), quoted=False)
+        return None
 
     @property
     def prefix(self) -> Optional[str]:


### PR DESCRIPTION
### Problem description

Recently SW Ecosystem team adopted a policy of 30-day grace period before removing deprecated API items (in tt_metal/api). Manual enforcement of this policy produces additional review overhead and is error-prone. To automatize this and let developers verify their changes on their own, we introduce a python script that will run as part of pre-commit checks and alarm if it detects any policy violations.

### What's changed
- Readability refactor + minor bugfixes of pre-existing script to validate includes
- Add script to validate deprecations

Script behavior:
- Scan for deprecations in existing files - report removable deprecations
- Scan for deprecations in PR changes (including removed files) and use git blame to get last-modified timestamp - report any deletions (violations) of deprecations that were added/modified less than 30 days ago.

Example output:

<img width="1360" height="1424" alt="image" src="https://github.com/user-attachments/assets/66acee86-72ad-4b60-b4cf-c337e8be96a9" />



Script has been manually smoke-tested on a branch with fake-time commits: `prybicki/api-validation-deprecation-test`


### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes