### PR TITLE
#33060: Add sub_core_grids support for `ttnn.gather`

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/gather/device/gather_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/gather/device/gather_device_operation.cpp
@@ -142,9 +142,10 @@ GatherDeviceOperation::invoke(
     const Tensor& input_index_tensor,
     const bool sparse_grad,
     const MemoryConfig& output_memory_config,
-    const std::optional<Tensor>& output_tensors) {
+    const std::optional<Tensor>& output_tensors,
+    const std::optional<CoreRangeSet>& sub_core_grids) {
     return {
-        operation_attributes_t{dim, sparse_grad, output_memory_config},
+        operation_attributes_t{dim, sparse_grad, output_memory_config, sub_core_grids},
         tensor_args_t{input_tensor, input_index_tensor, output_tensors}};
 }
 }  // namespace ttnn::operations::data_movement::gather

--- a/ttnn/cpp/ttnn/operations/data_movement/gather/device/gather_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/gather/device/gather_device_operation.hpp
@@ -37,7 +37,8 @@ struct GatherDeviceOperation {
         const Tensor& input_index_tensor,
         bool sparse_grad,
         const MemoryConfig& output_memory_config,
-        const std::optional<Tensor>& output_tensors);
+        const std::optional<Tensor>& output_tensors,
+        const std::optional<CoreRangeSet>& sub_core_grids);
 };
 
 }  // namespace ttnn::operations::data_movement::gather

--- a/ttnn/cpp/ttnn/operations/data_movement/gather/device/gather_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/gather/device/gather_device_operation_types.hpp
@@ -12,6 +12,7 @@ struct operation_attributes_t {
     const int8_t dim;
     const bool sparse_grad;
     const tt::tt_metal::MemoryConfig output_mem_config;
+    const std::optional<CoreRangeSet> sub_core_grids;
 };
 
 struct tensor_args_t {

--- a/ttnn/cpp/ttnn/operations/data_movement/gather/device/gather_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/gather/device/gather_program_factory.cpp
@@ -46,55 +46,28 @@ GatherProgramFactorySingleRowSingleCore::cached_program_t GatherProgramFactorySi
     // Calculate the number of cores available for computation
     auto device = tensor_args.input_tensor.device();
     const auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
-    const uint32_t total_number_of_cores = compute_with_storage_grid_size.y * compute_with_storage_grid_size.x;
+    const uint32_t max_number_of_cores = compute_with_storage_grid_size.y * compute_with_storage_grid_size.x;
 
-    // Calculate the number of cores utilized based on the input tensor shape
-    const uint32_t all_core_utilization_loop_count = Ht / total_number_of_cores;
-    const uint32_t all_core_utilization_loop_residuum = Ht % total_number_of_cores;
-
-    // Calculate core range
-    /**
-     * Calculates the core range based on the input tensor shape (Ht) and the total number of cores available
-     * in the device's compute grid. The core range determines which cores will be utilized for computation.
-     *
-     * The calculation works as follows:
-     * 1. If the height (Ht) of the input tensor is greater than or equal to the total number of cores,
-     *    all cores in the compute grid are utilized. The core range is set to cover the entire grid.
-     *
-     * 2. If Ht is smaller than the total number of cores:
-     *    - The number of rows (`core_grid_calculated_rows_number`) and columns (`core_grid_calculated_columns_number`)
-     *      required to cover Ht are calculated based on the grid dimensions.
-     *    - If both rows and columns are zero, only a single core is used.
-     *    - If only rows are zero, the core range is set to cover the required number of columns in the first row.
-     *    - Otherwise, the core range is set to cover the required rows, and if there are remaining columns,
-     *      an additional range is added to cover those columns in the next row.
-     *
-     * The resulting core range is represented as a `CoreRangeSet`, which may consist of one or more `CoreRange`
-     * objects depending on the configuration.
-     */
-    CoreRangeSet core_range;
-    if (Ht >= total_number_of_cores) {
-        core_range = CoreRangeSet(
-            CoreRange({0, 0}, {compute_with_storage_grid_size.x - 1, compute_with_storage_grid_size.y - 1}));
-    } else {
-        const uint32_t core_grid_calculated_rows_number = Ht / compute_with_storage_grid_size.x;
-        const uint32_t core_grid_calculated_columns_number = Ht % compute_with_storage_grid_size.x;
-
-        if (core_grid_calculated_rows_number == 0 && core_grid_calculated_columns_number == 0) {
-            core_range = CoreRangeSet(CoreCoord({0, 0}));
-        } else if (core_grid_calculated_rows_number == 0) {
-            core_range = CoreRangeSet(CoreRange({0, 0}, {core_grid_calculated_columns_number - 1, 0}));
-        } else {
-            core_range = CoreRangeSet(
-                CoreRange({0, 0}, {compute_with_storage_grid_size.x - 1, core_grid_calculated_rows_number - 1}));
-            if (core_grid_calculated_columns_number != 0) {
-                const CoreRange additional_range(
-                    {0, core_grid_calculated_rows_number},
-                    {core_grid_calculated_columns_number, core_grid_calculated_rows_number});
-                core_range = core_range.merge(CoreRangeSet(additional_range));
-            }
-        }
+    // Create core grid
+    CoreRangeSet core_grid =
+        tt::tt_metal::num_cores_to_corerangeset(max_number_of_cores, compute_with_storage_grid_size, true);
+    // Override core grid if sub_core_grids is provided in operation attributes
+    if (attributes.sub_core_grids.has_value()) {
+        core_grid = attributes.sub_core_grids.value();
     }
+
+    const auto
+        [total_number_of_cores,       // number of cores utilized
+         core_range,                  // set of all cores used
+         core_group_1,                // Primary core group
+         core_group_2,                // Secondary core group
+         num_tiles_per_core_group_1,  // Number of tiles each core in the primary group processes
+         num_tiles_per_core_group_2   // Number of tiles each core in the secondary group processes
+    ] = tt::tt_metal::split_work_to_cores(core_grid, Ht, true);
+    const auto work_groups = {
+        std::make_pair(core_group_1, num_tiles_per_core_group_1),
+        std::make_pair(core_group_2, num_tiles_per_core_group_2)};
+    const std::vector<CoreCoord>& cores = corerange_to_cores(core_range, total_number_of_cores, true);
 
     // Circular buffers
     constexpr uint32_t input_tensor_cb_index = tt::CBIndex::c_0;
@@ -139,14 +112,6 @@ GatherProgramFactorySingleRowSingleCore::cached_program_t GatherProgramFactorySi
         gather_reader_kernel_path,
         core_range,
         tt::tt_metal::ReaderDataMovementConfig{reader_compile_time_args});
-    SetRuntimeArgs(
-        program,
-        gather_reader_kernel_id,
-        core_range,
-        {input_index_tensor_buffer->address(),
-         all_core_utilization_loop_count ? all_core_utilization_loop_count : 1,
-         tile_width,
-         tile_height});
 
     std::vector<uint32_t> writer_compile_time_args = {
         input_tensor_cb_index,
@@ -169,44 +134,27 @@ GatherProgramFactorySingleRowSingleCore::cached_program_t GatherProgramFactorySi
         gather_writer_kernel_path,
         core_range,
         tt::tt_metal::WriterDataMovementConfig{writer_compile_time_args});
-    SetRuntimeArgs(
-        program,
-        gather_writer_kernel_id,
-        core_range,
-        {input_tensor_buffer->address(),
-         output_tensor_buffer->address(),
-         all_core_utilization_loop_count ? all_core_utilization_loop_count : 1});
 
-    // Adjust runtime arguments if cores are used more than once
-    if (all_core_utilization_loop_residuum != 0 && all_core_utilization_loop_count != 0) {
-        uint32_t residuum_count = 0;
-        for (uint32_t core_y = 0; core_y < compute_with_storage_grid_size.y; core_y++) {
-            for (uint32_t core_x = 0; core_x < compute_with_storage_grid_size.x; core_x++) {
-                const uint32_t new_loop_count = all_core_utilization_loop_count + 1;
-                const CoreCoord core = {core_x, core_y};
-
+    uint32_t id = 0;  // Offset for the next core in the group
+    for (const auto& [group, work_per_core] : work_groups) {
+        for (const auto& range : group.ranges()) {
+            for (const auto& core : range) {
                 SetRuntimeArgs(
                     program,
                     gather_reader_kernel_id,
                     core,
-                    {input_index_tensor_buffer->address(), new_loop_count, tile_width, tile_height});
-
+                    {input_index_tensor_buffer->address(), work_per_core, tile_width, tile_height, id});
                 SetRuntimeArgs(
                     program,
                     gather_writer_kernel_id,
                     core,
-                    {input_tensor_buffer->address(), output_tensor_buffer->address(), new_loop_count});
+                    {input_tensor_buffer->address(), output_tensor_buffer->address(), work_per_core, id});
+                id++;
+            }
+        }
+    }
 
-                residuum_count++;
-                if (residuum_count >= all_core_utilization_loop_residuum) {
-                    core_y = compute_with_storage_grid_size.y;  // Break outer loop
-                    break;
-                }
-            }  // core_x loop
-        }  // core_y loop
-    }  // if all_core_utilization_loop_residuum != 0 && all_core_utilization_loop_count != 0
-
-    return {std::move(program), {gather_reader_kernel_id, gather_writer_kernel_id, compute_with_storage_grid_size}};
+    return {std::move(program), {gather_reader_kernel_id, gather_writer_kernel_id, cores}};
 }
 
 void GatherProgramFactorySingleRowSingleCore::override_runtime_arguments(
@@ -218,38 +166,16 @@ void GatherProgramFactorySingleRowSingleCore::override_runtime_arguments(
     auto input_index_tensor_buffer = tensor_args.input_index_tensor.buffer();
     auto output_tensor_buffer = output_tensor.buffer();
 
-    const auto input_index_shape = tensor_args.input_index_tensor.padded_shape();
-    const uint32_t Ht =
-        (input_index_shape[0] * input_index_shape[1] * input_index_shape[2]) / tt::constants::TILE_HEIGHT;
-    const uint32_t total_number_of_cores =
-        cached_program.shared_variables.storage_grid_size.x * cached_program.shared_variables.storage_grid_size.y;
+    for (const auto& core : cached_program.shared_variables.cores) {
+        auto& gather_reader_runtime_args = tt::tt_metal::GetRuntimeArgs(
+            cached_program.program, cached_program.shared_variables.gather_reader_kernel_id, core);
+        gather_reader_runtime_args[0] = input_index_tensor_buffer->address();
 
-    // Calculate the number of cores utilized based on the input tensor shape
-    const uint32_t all_core_utilization_loop_count = Ht / total_number_of_cores;
-    const uint32_t all_core_utilization_loop_residuum = Ht % total_number_of_cores;
-
-    uint32_t residuum_count = 0;
-    for (uint32_t core_y = 0; core_y < cached_program.shared_variables.storage_grid_size.y; core_y++) {
-        for (uint32_t core_x = 0; core_x < cached_program.shared_variables.storage_grid_size.x; core_x++) {
-            const CoreCoord core = {core_x, core_y};
-            auto& gather_reader_runtime_args =
-                GetRuntimeArgs(cached_program.program, cached_program.shared_variables.gather_reader_kernel_id, core);
-            gather_reader_runtime_args[0] = input_index_tensor_buffer->address();
-
-            auto& gather_writer_runtime_args =
-                GetRuntimeArgs(cached_program.program, cached_program.shared_variables.gather_writer_kernel_id, core);
-            gather_writer_runtime_args[0] = input_tensor_buffer->address();
-            gather_writer_runtime_args[1] = output_tensor_buffer->address();
-
-            if (all_core_utilization_loop_count < 1 && all_core_utilization_loop_residuum != 0) {
-                residuum_count++;
-                if (residuum_count >= all_core_utilization_loop_residuum) {
-                    core_y = cached_program.shared_variables.storage_grid_size.y;  // Break outer loop
-                    break;
-                }
-            }
-        }  // core_x loop
-    }  // core_y loop
+        auto& gather_writer_runtime_args = tt::tt_metal::GetRuntimeArgs(
+            cached_program.program, cached_program.shared_variables.gather_writer_kernel_id, core);
+        gather_writer_runtime_args[0] = input_tensor_buffer->address();
+        gather_writer_runtime_args[1] = output_tensor_buffer->address();
+    }
 }
 
 // Single row - multi core
@@ -289,55 +215,28 @@ GatherProgramFactorySingleRowMultiCore::cached_program_t GatherProgramFactorySin
     // Calculate the number of cores available for computation
     auto device = tensor_args.input_tensor.device();
     const auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
-    const uint32_t total_number_of_cores = compute_with_storage_grid_size.y * compute_with_storage_grid_size.x;
+    const uint32_t max_number_of_cores = compute_with_storage_grid_size.y * compute_with_storage_grid_size.x;
 
-    // Calculate how many iterations of outer loop - index loop we need
-    const auto all_core_utilization_loop_count = Wt_index / total_number_of_cores;
-    const auto all_core_utilization_loop_residuum = Wt_index % total_number_of_cores;
-
-    // Calculate core range
-    /**
-     * Calculates the core range based on the input tensor shape (Wt_index) and the total number of cores available
-     * in the device's compute grid. The core range determines which cores will be utilized for computation.
-     *
-     * The calculation works as follows:
-     * 1. If the width (Wt_index) of the input index tensor is greater than or equal to the total number of cores,
-     *    all cores in the compute grid are utilized. The core range is set to cover the entire grid.
-     *
-     * 2. If Wt_index is smaller than the total number of cores:
-     *    - The number of rows (`core_grid_calculated_rows_number`) and columns
-     * (`core_grid_calculated_columns_number`) required to cover Wt_index are calculated based on the grid dimensions.
-     *    - If both rows and columns are zero, only a single core is used.
-     *    - If only rows are zero, the core range is set to cover the required number of columns in the first row.
-     *    - Otherwise, the core range is set to cover the required rows, and if there are remaining columns,
-     *      an additional range is added to cover those columns in the next row.
-     *
-     * The resulting core range is represented as a `CoreRangeSet`, which may consist of one or more `CoreRange`
-     * objects depending on the configuration.
-     */
-    CoreRangeSet core_range;
-    if (Wt_index >= total_number_of_cores) {
-        core_range = CoreRangeSet(
-            CoreRange({0, 0}, {compute_with_storage_grid_size.x - 1, compute_with_storage_grid_size.y - 1}));
-    } else {
-        const uint32_t core_grid_calculated_rows_number = Wt_index / compute_with_storage_grid_size.x;
-        const uint32_t core_grid_calculated_columns_number = Wt_index % compute_with_storage_grid_size.x;
-
-        if (core_grid_calculated_rows_number == 0 && core_grid_calculated_columns_number == 0) {
-            core_range = CoreRangeSet(CoreCoord({0, 0}));
-        } else if (core_grid_calculated_rows_number == 0) {
-            core_range = CoreRangeSet(CoreRange({0, 0}, {core_grid_calculated_columns_number - 1, 0}));
-        } else {
-            core_range = CoreRangeSet(
-                CoreRange({0, 0}, {compute_with_storage_grid_size.x - 1, core_grid_calculated_rows_number - 1}));
-            if (core_grid_calculated_columns_number != 0) {
-                const CoreRange additional_range(
-                    {0, core_grid_calculated_rows_number},
-                    {core_grid_calculated_columns_number - 1, core_grid_calculated_rows_number});
-                core_range = core_range.merge(CoreRangeSet(additional_range));
-            }
-        }
+    // Create core grid
+    CoreRangeSet core_grid =
+        tt::tt_metal::num_cores_to_corerangeset(max_number_of_cores, compute_with_storage_grid_size, true);
+    // Override core grid if sub_core_grids is provided in operation attributes
+    if (attributes.sub_core_grids.has_value()) {
+        core_grid = attributes.sub_core_grids.value();
     }
+
+    const auto
+        [total_number_of_cores,       // number of cores utilized
+         core_range,                  // set of all cores used
+         core_group_1,                // Primary core group
+         core_group_2,                // Secondary core group
+         num_tiles_per_core_group_1,  // Number of tiles each core in the primary group processes
+         num_tiles_per_core_group_2   // Number of tiles each core in the secondary group processes
+    ] = tt::tt_metal::split_work_to_cores(core_grid, Wt_index, true);
+    const auto work_groups = {
+        std::make_pair(core_group_1, num_tiles_per_core_group_1),
+        std::make_pair(core_group_2, num_tiles_per_core_group_2)};
+    const std::vector<CoreCoord>& cores = corerange_to_cores(core_range, total_number_of_cores, true);
 
     // Circular buffers
     constexpr uint32_t buffer_scale_factor = 2;
@@ -382,14 +281,6 @@ GatherProgramFactorySingleRowMultiCore::cached_program_t GatherProgramFactorySin
         gather_reader_kernel_path,
         core_range,
         tt::tt_metal::ReaderDataMovementConfig{reader_compile_time_args});
-    SetRuntimeArgs(
-        program,
-        gather_reader_kernel_id,
-        core_range,
-        {input_index_tensor_buffer->address(),
-         all_core_utilization_loop_count ? all_core_utilization_loop_count : 1,
-         tile_width,
-         tile_height});
 
     std::vector<uint32_t> writer_compile_time_args = {
         input_tensor_cb_index,
@@ -411,44 +302,27 @@ GatherProgramFactorySingleRowMultiCore::cached_program_t GatherProgramFactorySin
         gather_writer_kernel_path,
         core_range,
         tt::tt_metal::WriterDataMovementConfig{writer_compile_time_args});
-    SetRuntimeArgs(
-        program,
-        gather_writer_kernel_id,
-        core_range,
-        {input_tensor_buffer->address(),
-         output_tensor_buffer->address(),
-         all_core_utilization_loop_count ? all_core_utilization_loop_count : 1});
 
-    // Adjust runtime arguments if cores are used more than once
-    if (all_core_utilization_loop_residuum != 0 && all_core_utilization_loop_count != 0) {
-        uint32_t residuum_count = 0;
-        for (uint32_t core_y = 0; core_y < compute_with_storage_grid_size.y; core_y++) {
-            for (uint32_t core_x = 0; core_x < compute_with_storage_grid_size.x; core_x++) {
-                const uint32_t new_loop_count = all_core_utilization_loop_count + 1;
-                const CoreCoord core = {core_x, core_y};
-
+    uint32_t id = 0;  // Offset for the next core in the group
+    for (const auto& [group, work_per_core] : work_groups) {
+        for (const auto& range : group.ranges()) {
+            for (const auto& core : range) {
                 SetRuntimeArgs(
                     program,
                     gather_reader_kernel_id,
                     core,
-                    {input_index_tensor_buffer->address(), new_loop_count, tile_width, tile_height});
-
+                    {input_index_tensor_buffer->address(), work_per_core, tile_width, tile_height, id});
                 SetRuntimeArgs(
                     program,
                     gather_writer_kernel_id,
                     core,
-                    {input_tensor_buffer->address(), output_tensor_buffer->address(), new_loop_count});
+                    {input_tensor_buffer->address(), output_tensor_buffer->address(), work_per_core, id});
+                id++;
+            }
+        }
+    }
 
-                residuum_count++;
-                if (residuum_count >= all_core_utilization_loop_residuum) {
-                    core_y = compute_with_storage_grid_size.y;  // Break outer loop
-                    break;
-                }
-            }  // core_x loop
-        }  // core_y loop
-    }  // if all_core_utilization_loop_residuum != 0 && all_core_utilization_loop_count != 0
-
-    return {std::move(program), {gather_reader_kernel_id, gather_writer_kernel_id, compute_with_storage_grid_size}};
+    return {std::move(program), {gather_reader_kernel_id, gather_writer_kernel_id, cores}};
 }
 
 void GatherProgramFactorySingleRowMultiCore::override_runtime_arguments(
@@ -456,41 +330,21 @@ void GatherProgramFactorySingleRowMultiCore::override_runtime_arguments(
     const operation_attributes_t& attributes,
     const tensor_args_t& tensor_args,
     tensor_return_value_t& output_tensor) {
+    // Get tensor buffers
     auto input_tensor_buffer = tensor_args.input_tensor.buffer();
     auto input_index_tensor_buffer = tensor_args.input_index_tensor.buffer();
     auto output_tensor_buffer = output_tensor.buffer();
 
-    const auto input_index_shape = tensor_args.input_index_tensor.padded_shape();
-    const auto tile_width = tensor_args.input_tensor.tensor_spec().tile().get_width();
-    const uint32_t Wt_index = tensor_args.input_index_tensor.padded_shape()[3] / tile_width;
-    const uint32_t total_number_of_cores =
-        cached_program.shared_variables.storage_grid_size.x * cached_program.shared_variables.storage_grid_size.y;
+    // Update runtime arguments for each core
+    for (const auto& core : cached_program.shared_variables.cores) {
+        auto& gather_reader_runtime_args = tt::tt_metal::GetRuntimeArgs(
+            cached_program.program, cached_program.shared_variables.gather_reader_kernel_id, core);
+        gather_reader_runtime_args[0] = input_index_tensor_buffer->address();
 
-    // Calculate the number of cores utilized based on the input tensor shape
-    const uint32_t all_core_utilization_loop_count = Wt_index / total_number_of_cores;
-    const uint32_t all_core_utilization_loop_residuum = Wt_index % total_number_of_cores;
-
-    uint32_t residuum_count = 0;
-    for (uint32_t core_y = 0; core_y < cached_program.shared_variables.storage_grid_size.y; core_y++) {
-        for (uint32_t core_x = 0; core_x < cached_program.shared_variables.storage_grid_size.x; core_x++) {
-            const CoreCoord core = {core_x, core_y};
-            auto& gather_reader_runtime_args =
-                GetRuntimeArgs(cached_program.program, cached_program.shared_variables.gather_reader_kernel_id, core);
-            gather_reader_runtime_args[0] = input_index_tensor_buffer->address();
-
-            auto& gather_writer_runtime_args =
-                GetRuntimeArgs(cached_program.program, cached_program.shared_variables.gather_writer_kernel_id, core);
-            gather_writer_runtime_args[0] = input_tensor_buffer->address();
-            gather_writer_runtime_args[1] = output_tensor_buffer->address();
-
-            if (all_core_utilization_loop_count < 1 && all_core_utilization_loop_residuum != 0) {
-                residuum_count++;
-                if (residuum_count >= all_core_utilization_loop_residuum) {
-                    core_y = cached_program.shared_variables.storage_grid_size.y;  // Break outer loop
-                    break;
-                }
-            }
-        }  // core_x loop
-    }  // core_y loop
+        auto& gather_writer_runtime_args = tt::tt_metal::GetRuntimeArgs(
+            cached_program.program, cached_program.shared_variables.gather_writer_kernel_id, core);
+        gather_writer_runtime_args[0] = input_tensor_buffer->address();
+        gather_writer_runtime_args[1] = output_tensor_buffer->address();
+    }
 }
 }  // namespace ttnn::operations::data_movement::gather::program

--- a/ttnn/cpp/ttnn/operations/data_movement/gather/device/gather_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/gather/device/gather_program_factory.hpp
@@ -17,7 +17,7 @@ struct GatherProgramFactorySingleRowSingleCore {
     struct shared_variables_t {
         KernelHandle gather_reader_kernel_id{};
         KernelHandle gather_writer_kernel_id{};
-        CoreCoord storage_grid_size;
+        std::vector<CoreCoord> cores;
     };
 
     using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
@@ -32,7 +32,7 @@ struct GatherProgramFactorySingleRowMultiCore {
     struct shared_variables_t {
         KernelHandle gather_reader_kernel_id{};
         KernelHandle gather_writer_kernel_id{};
-        CoreCoord storage_grid_size;
+        std::vector<CoreCoord> cores;
     };
 
     using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;

--- a/ttnn/cpp/ttnn/operations/data_movement/gather/device/gather_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/gather/device/gather_program_factory.hpp
@@ -17,7 +17,7 @@ struct GatherProgramFactorySingleRowSingleCore {
     struct shared_variables_t {
         KernelHandle gather_reader_kernel_id{};
         KernelHandle gather_writer_kernel_id{};
-        std::vector<CoreCoord> cores;
+        std::vector<CoreCoord> cores{};
     };
 
     using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
@@ -32,7 +32,7 @@ struct GatherProgramFactorySingleRowMultiCore {
     struct shared_variables_t {
         KernelHandle gather_reader_kernel_id{};
         KernelHandle gather_writer_kernel_id{};
-        std::vector<CoreCoord> cores;
+        std::vector<CoreCoord> cores{};
     };
 
     using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;

--- a/ttnn/cpp/ttnn/operations/data_movement/gather/device/gather_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/gather/device/gather_program_factory.hpp
@@ -17,7 +17,7 @@ struct GatherProgramFactorySingleRowSingleCore {
     struct shared_variables_t {
         KernelHandle gather_reader_kernel_id{};
         KernelHandle gather_writer_kernel_id{};
-        std::vector<CoreCoord> cores{};
+        std::vector<CoreCoord> cores;
     };
 
     using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
@@ -32,7 +32,7 @@ struct GatherProgramFactorySingleRowMultiCore {
     struct shared_variables_t {
         KernelHandle gather_reader_kernel_id{};
         KernelHandle gather_writer_kernel_id{};
-        std::vector<CoreCoord> cores{};
+        std::vector<CoreCoord> cores;
     };
 
     using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;

--- a/ttnn/cpp/ttnn/operations/data_movement/gather/device/kernels/dataflow/gather_reader_single_row_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/gather/device/kernels/dataflow/gather_reader_single_row_multi_core.cpp
@@ -49,6 +49,7 @@ void kernel_main() {
     const uint32_t core_loop_count = get_arg_val<uint32_t>(1);
     const uint32_t tile_width = get_arg_val<uint32_t>(2);
     const uint32_t tile_height = get_arg_val<uint32_t>(3);
+    const uint32_t core_id = get_arg_val<uint32_t>(4);
 
     // Compile time args
     constexpr uint32_t input_tensor_cb_index = get_compile_time_arg_val(0);
@@ -80,8 +81,7 @@ void kernel_main() {
     constexpr uint32_t output_tensor_data_format_size =
         get_tile_size(output_tensor_cb_index) / get_tile_hw(input_tensor_cb_index);
 
-    const auto start_tile_id = get_absolute_logical_y() * compute_with_storage_grid_size_x + get_absolute_logical_x();
-    uint32_t current_index_tile_id = start_tile_id;
+    uint32_t current_index_tile_id = core_id;
 
     for (uint32_t h = 0; h < Ht; h++) {
         for (uint32_t core_loop = 0; core_loop < core_loop_count; core_loop++) {

--- a/ttnn/cpp/ttnn/operations/data_movement/gather/device/kernels/dataflow/gather_reader_single_row_single_core.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/gather/device/kernels/dataflow/gather_reader_single_row_single_core.cpp
@@ -111,6 +111,7 @@ void kernel_main() {
     const uint32_t core_loop_count = get_arg_val<uint32_t>(1);
     const uint32_t tile_width = get_arg_val<uint32_t>(2);
     const uint32_t tile_height = get_arg_val<uint32_t>(3);
+    const uint32_t core_id = get_arg_val<uint32_t>(4);
 
     // Compile time args
     constexpr uint32_t input_tensor_cb_index = get_compile_time_arg_val(0);
@@ -144,8 +145,7 @@ void kernel_main() {
 
     for (uint32_t core_loop = 0; core_loop < core_loop_count; core_loop++) {
         // Calculate tile h coordinate
-        const uint32_t h = core_loop * total_number_of_cores +
-                           get_absolute_logical_y() * compute_with_storage_grid_size_x + get_absolute_logical_x();
+        const uint32_t h = core_loop * total_number_of_cores + core_id;
 
         for (uint32_t w = 0; w < Wt_index; w++) {
             // Read index data

--- a/ttnn/cpp/ttnn/operations/data_movement/gather/device/kernels/dataflow/gather_writer_single_row_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/gather/device/kernels/dataflow/gather_writer_single_row_multi_core.cpp
@@ -18,6 +18,7 @@ void kernel_main() {
     const uint32_t input_tensor_buffer_addr = get_arg_val<uint32_t>(0);
     const uint32_t output_tensor_buffer_addr = get_arg_val<uint32_t>(1);
     const uint32_t core_loop_count = get_arg_val<uint32_t>(2);
+    const uint32_t core_id = get_arg_val<uint32_t>(3);
 
     // Compile time args
     constexpr uint32_t input_tensor_cb_index = get_compile_time_arg_val(0);
@@ -45,8 +46,7 @@ void kernel_main() {
     const auto output_tensor_dram =
         TensorAccessor(output_tensor_args, output_tensor_buffer_addr, output_tensor_tile_size_bytes);
 
-    const auto start_tile_id = get_absolute_logical_y() * compute_with_storage_grid_size_x + get_absolute_logical_x();
-    uint32_t current_index_tile_id = start_tile_id;
+    uint32_t current_index_tile_id = core_id;
 
     for (uint32_t h = 0; h < Ht; h++) {
         for (uint32_t core_loop = 0; core_loop < core_loop_count; core_loop++) {

--- a/ttnn/cpp/ttnn/operations/data_movement/gather/device/kernels/dataflow/gather_writer_single_row_single_core.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/gather/device/kernels/dataflow/gather_writer_single_row_single_core.cpp
@@ -26,6 +26,7 @@ void kernel_main() {
     const uint32_t input_tensor_buffer_addr = get_arg_val<uint32_t>(0);
     const uint32_t output_tensor_buffer_addr = get_arg_val<uint32_t>(1);
     const uint32_t core_loop_count = get_arg_val<uint32_t>(2);
+    const uint32_t core_id = get_arg_val<uint32_t>(3);
 
     // Compile time args
     constexpr uint32_t input_tensor_cb_index = get_compile_time_arg_val(0);
@@ -55,8 +56,7 @@ void kernel_main() {
 
     for (uint32_t core_loop = 0; core_loop < core_loop_count; core_loop++) {
         // Calculate tile h coordinate
-        const uint32_t h = core_loop * total_number_of_cores +
-                           get_absolute_logical_y() * compute_with_storage_grid_size_x + get_absolute_logical_x();
+        const uint32_t h = core_loop * total_number_of_cores + core_id;
 
         // Read input data
         for (uint32_t w = 0; w < Wt_input; w++) {

--- a/ttnn/cpp/ttnn/operations/data_movement/gather/docs/Gather.md
+++ b/ttnn/cpp/ttnn/operations/data_movement/gather/docs/Gather.md
@@ -20,7 +20,7 @@ Both input tensors must have the same number of dimensions, and for all dimensio
 - **sparse_grad (bool, optional)**: If True, the gradient computation will be sparse. Defaults to False. **Note: Currently not supported.**
 - **memory_config (MemoryConfig, optional)**: Specifies memory configuration for the output tensor. Defaults to None.
 - **optional_output_tensor (Tensor, optional)**: Preallocated tensor for the gathered values. Defaults to None.
-- **sub_core_grids (CoreRangeSet, optional)**: Custom core range set for multi-user execution. Allows specification of which cores should be used for the operation. Defaults to None (uses all available cores).
+- **sub_core_grids (CoreRangeSet, optional)**: Custom core range set for operation execution. Allows specification of which cores should be used for the operation. Defaults to None (uses all available cores).
 
 ### Usage
 

--- a/ttnn/cpp/ttnn/operations/data_movement/gather/docs/Gather.md
+++ b/ttnn/cpp/ttnn/operations/data_movement/gather/docs/Gather.md
@@ -20,6 +20,7 @@ Both input tensors must have the same number of dimensions, and for all dimensio
 - **sparse_grad (bool, optional)**: If True, the gradient computation will be sparse. Defaults to False. **Note: Currently not supported.**
 - **memory_config (MemoryConfig, optional)**: Specifies memory configuration for the output tensor. Defaults to None.
 - **optional_output_tensor (Tensor, optional)**: Preallocated tensor for the gathered values. Defaults to None.
+- **sub_core_grids (CoreRangeSet, optional)**: Custom core range set for multi-user execution. Allows specification of which cores should be used for the operation. Defaults to None (uses all available cores).
 
 ### Usage
 
@@ -81,6 +82,7 @@ ttnn::Tensor gathered_tensor = ttnn::gather(
 - **Memory**: Interleaved DRAM and L1 memory supported; **sharded memory not supported**
 - **Gradient**: `sparse_grad=True` is not supported in this implementation
 - **Dimension constraints**: `input_index_tensor.size(d) <= input_tensor.size(d)` for all dimensions `d != dim`
+- **Core grids**: When `sub_core_grids` is specified, the provided cores will be used for execution; otherwise, the operation uses all available compute cores
 
 ## Strategy Selection Overview
 
@@ -154,8 +156,7 @@ This strategy assigns complete rows to individual cores, providing simple and ef
 
 ```cpp
 // Core assignment based on height (Ht)
-const uint32_t core_h_id = core_loop * total_number_of_cores +
-                          get_absolute_logical_y() * grid_size_x + get_absolute_logical_x();
+const uint32_t core_h_id = core_loop * total_number_of_cores + core_id;
 
 // Each core processes: Wt_input input tiles → Wt_index output tiles
 for (uint32_t w = 0; w < Wt_index; w++) {
@@ -190,8 +191,7 @@ This strategy distributes index tiles across multiple cores within each row, max
 
 ```cpp
 // Core assignment based on index width (Wt_index)
-const auto start_tile_id = get_absolute_logical_y() * grid_size_x + get_absolute_logical_x();
-uint32_t current_index_tile_id = start_tile_id;
+uint32_t current_index_tile_id = core_id;
 
 for (uint32_t h = 0; h < Ht; h++) {
     for (uint32_t core_loop = 0; core_loop < core_loop_count; core_loop++) {

--- a/ttnn/cpp/ttnn/operations/data_movement/gather/gather.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/gather/gather.cpp
@@ -153,7 +153,8 @@ Tensor ExecuteGather::invoke(
     const Tensor& input_index_tensor,
     const bool sparse_grad,
     const std::optional<tt::tt_metal::MemoryConfig>& memory_config,
-    std::optional<Tensor> optional_output_tensor) {
+    std::optional<Tensor> optional_output_tensor,
+    const std::optional<CoreRangeSet>& sub_core_grids) {
     // Input tensor
     const ttnn::Shape& original_input_tensor_lshape = input_tensor.logical_shape();
     const auto input_tensor_rank = input_tensor.padded_shape().rank();
@@ -197,7 +198,13 @@ Tensor ExecuteGather::invoke(
     }
 
     Tensor gather_tensor = ttnn::prim::gather(
-        padded_input_tensor, dim, padded_index_tensor, sparse_grad, memory_config_value, optional_output_tensor_value);
+        padded_input_tensor,
+        dim,
+        padded_index_tensor,
+        sparse_grad,
+        memory_config_value,
+        optional_output_tensor_value,
+        sub_core_grids);
 
     return CMAKE_UNIQUE_NAMESPACE::post_gather_transform_tensor(
         input_index_tensor, gather_tensor, dim, input_index_tensor_is_dim_last_idx, original_index_tensor_lshape);

--- a/ttnn/cpp/ttnn/operations/data_movement/gather/gather.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/gather/gather.hpp
@@ -16,7 +16,8 @@ struct ExecuteGather {
         const Tensor& input_index_tensor,
         bool sparse_grad,
         const std::optional<tt::tt_metal::MemoryConfig>& memory_config,
-        std::optional<Tensor> optional_output_tensor = std::nullopt);
+        std::optional<Tensor> optional_output_tensor = std::nullopt,
+        const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
 };
 
 }  // namespace ttnn::operations::data_movement

--- a/ttnn/cpp/ttnn/operations/data_movement/gather/gather_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/gather/gather_pybind.cpp
@@ -28,7 +28,7 @@ void bind_gather_operation(py::module& module) {
             sparse_grad (bool, optional): If `True`, the gradient computation will be sparse. Defaults to `False`.
             memory_config (ttnn.MemoryConfig, optional): Specifies the memory configuration for the output tensor. Defaults to `None`.
             out (ttnn.Tensor, optional): A preallocated tensor to store the gathered values. Defaults to `None`.
-            sub_core_grids (optional): Custom core range set must be provided for multi-user execution. Defaults to `None`.
+            sub_core_grids (optional): Custom core range set for operation execution. Defaults to `None`.
 
         Additional Information:
             * Currently, the `sparse_grad` argument is not supported.

--- a/ttnn/cpp/ttnn/operations/data_movement/gather/gather_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/gather/gather_pybind.cpp
@@ -28,6 +28,7 @@ void bind_gather_operation(py::module& module) {
             sparse_grad (bool, optional): If `True`, the gradient computation will be sparse. Defaults to `False`.
             memory_config (ttnn.MemoryConfig, optional): Specifies the memory configuration for the output tensor. Defaults to `None`.
             out (ttnn.Tensor, optional): A preallocated tensor to store the gathered values. Defaults to `None`.
+            sub_core_grids (optional): Custom core range set must be provided for multi-user execution. Defaults to `None`.
 
         Additional Information:
             * Currently, the `sparse_grad` argument is not supported.
@@ -74,8 +75,16 @@ void bind_gather_operation(py::module& module) {
                const ttnn::Tensor& input_index_tensor,
                const bool sparse_grad,
                std::optional<ttnn::Tensor> optional_output_tensor,
-               const std::optional<tt::tt_metal::MemoryConfig>& memory_config) -> Tensor {
-                return self(input_tensor, dim, input_index_tensor, sparse_grad, memory_config, optional_output_tensor);
+               const std::optional<tt::tt_metal::MemoryConfig>& memory_config,
+               const std::optional<CoreRangeSet>& sub_core_grids) -> Tensor {
+                return self(
+                    input_tensor,
+                    dim,
+                    input_index_tensor,
+                    sparse_grad,
+                    memory_config,
+                    optional_output_tensor,
+                    sub_core_grids);
             },
             py::arg("input").noconvert(),
             py::arg("dim"),
@@ -83,7 +92,8 @@ void bind_gather_operation(py::module& module) {
             py::kw_only(),
             py::arg("sparse_grad") = false,
             py::arg("out") = std::nullopt,
-            py::arg("memory_config") = std::nullopt});
+            py::arg("memory_config") = std::nullopt,
+            py::arg("sub_core_grids") = std::nullopt});
 }
 
 }  // namespace ttnn::operations::data_movement::detail

--- a/ttnn/cpp/ttnn/operations/data_movement/gather/gather_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/gather/gather_pybind.cpp
@@ -28,7 +28,7 @@ void bind_gather_operation(py::module& module) {
             sparse_grad (bool, optional): If `True`, the gradient computation will be sparse. Defaults to `False`.
             memory_config (ttnn.MemoryConfig, optional): Specifies the memory configuration for the output tensor. Defaults to `None`.
             out (ttnn.Tensor, optional): A preallocated tensor to store the gathered values. Defaults to `None`.
-            sub_core_grids (optional): Custom core range set for operation execution. Defaults to `None`.
+            sub_core_grids (ttnn.CoreRangeSet, optional): Custom core range set for operation execution. Allows specification of which cores should be used for the operation. Defaults to `None`.
 
         Additional Information:
             * Currently, the `sparse_grad` argument is not supported.


### PR DESCRIPTION
### Ticket

#33060

### Problem description

`ttnn.gather` did not support the additional `sub_core_grids` argument needed when working with models such as LLama 70B.

### What's changed
- Added support for `sub_core_grids` - Custom core range set for operation execution. Allows specification of which cores should be used for the operation. Defaults to None (uses all available cores),
- Added test for new functionality,
- Updated documentation.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/19668718705