### PR TITLE
Fix FP32 binary operations by limiting debug feature disable to Int32

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_A_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_A_api.h
@@ -71,7 +71,9 @@ inline void llk_unpack_A_init(
 
     const std::uint32_t operand_unpack_src_format = unpack_src_format[operand_id];
     const std::uint32_t operand_unpack_dst_format = unpack_dst_format[operand_id];
-    if (unpack_to_dest && is_32bit_input(operand_unpack_src_format, operand_unpack_dst_format)) {
+    // Set debug feature disable only for Int32 (not Float32) - workaround for tt-llk#868
+    if (unpack_to_dest && ((operand_unpack_src_format & 0xF) == (uint)DataFormat::Int32) &&
+        ((operand_unpack_dst_format & 0xF) == (uint)DataFormat::Int32)) {
         llk_unpack_dbg_feature_disable();
     }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_A_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_A_api.h
@@ -71,7 +71,9 @@ inline void llk_unpack_A_init(
 
     const std::uint32_t operand_unpack_src_format = unpack_src_format[operand_id];
     const std::uint32_t operand_unpack_dst_format = unpack_dst_format[operand_id];
-    if (unpack_to_dest && is_32bit_input(operand_unpack_src_format, operand_unpack_dst_format)) {
+    // Set debug feature disable only for Int32 (not Float32) - workaround for tt-llk#868
+    if (unpack_to_dest && ((operand_unpack_src_format & 0xF) == (uint)DataFormat::Int32) &&
+        ((operand_unpack_dst_format & 0xF) == (uint)DataFormat::Int32)) {
         llk_unpack_dbg_feature_disable();
     }
 


### PR DESCRIPTION
### Ticket
tt_llk: [#868](https://github.com/tenstorrent/tt-llk/issues/868)

### Problem description
`binary_dest_reuse_tiles()` with `ELWMUL` was accumulating results instead of overwriting them, causing values to be doubled. The root cause was the debug feature disable bit being set for all 32-bit formats (including Float32), which interfered with MOVD2B and FP32 accumulation operations. 

### What's changed
Restricted debug feature disable to Int32 only: Modified `llk_unpack_A_init()` in both WH and BH to set the debug feature disable bit only when unpacking Int32 formats.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes