### PR TITLE
SDXL vae batch encode accuracy fix

### DIFF
--- a/models/experimental/stable_diffusion_xl_base/tests/test_common.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/test_common.py
@@ -196,12 +196,6 @@ def batch_encode_prompt_on_device(
     prompt_2 = prompt_2 or prompt
     prompt_2 = [prompt_2] if isinstance(prompt_2, str) else prompt_2
 
-    # Convert negative prompts to lists early
-    if negative_prompt is not None:
-        negative_prompt = [negative_prompt] if isinstance(negative_prompt, str) else negative_prompt
-    if negative_prompt_2 is not None:
-        negative_prompt_2 = [negative_prompt_2] if isinstance(negative_prompt_2, str) else negative_prompt_2
-
     num_devices = ttnn_device.get_num_devices()
     num_prompts = len(prompt)
     if use_cfg_parallel and num_prompts < num_devices:
@@ -209,12 +203,6 @@ def batch_encode_prompt_on_device(
         prompt = prompt + [""] * (num_devices - len(prompt))
         if prompt_2 is not None:
             prompt_2 = prompt_2 + [""] * (num_devices - len(prompt_2))
-
-        # Pad negative prompts as well
-        if negative_prompt is not None:
-            negative_prompt = negative_prompt + [""] * (num_devices - len(negative_prompt))
-        if negative_prompt_2 is not None:
-            negative_prompt_2 = negative_prompt_2 + [""] * (num_devices - len(negative_prompt_2))
 
     assert len(prompt) == num_devices, "Prompt length must be equal to number of devices"
     assert lora_scale is None, "Lora scale is not supported currently with on device text encoders"

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_sdxl_inpainting_pipeline.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_sdxl_inpainting_pipeline.py
@@ -76,8 +76,6 @@ class TtSDXLInpaintingPipeline(TtSDXLImg2ImgPipeline):
             start_latent_seed, int
         ), "start_latent_seed must be an integer or None"
 
-        if start_latent_seed is not None:
-            torch.manual_seed(start_latent_seed if fixed_seed_for_batch else start_latent_seed)
         # the function returns img_latents, noise but we don't use noise at the moment, so discard it
         img_latents = prepare_image_latents(
             self.torch_pipeline,
@@ -92,6 +90,8 @@ class TtSDXLInpaintingPipeline(TtSDXLImg2ImgPipeline):
             self.pipeline_config.strength == 1,
             True,  # Make this configurable
             None,  # passed in latents
+            start_latent_seed,
+            fixed_seed_for_batch,
         )
 
         if isinstance(img_latents, ttnn.Tensor):
@@ -118,6 +118,7 @@ class TtSDXLInpaintingPipeline(TtSDXLImg2ImgPipeline):
             all_prompt_embeds_torch.dtype,
             self.cpu_device,
             None,
+            fixed_seed_for_batch,
         )
 
         B, C, H, W = mask.shape


### PR DESCRIPTION
### Ticket
#30975

### Problem description
Changing DP changes accuracy metrics

### What's changed
- models/experimental/stable_diffusion_xl_base/tests/test_common.py
    - fixed bug with negative prompt after #32280 in `batch_encode_prompt_on_device` 
    - seed state saved after first image_latent is sampled and used to generate noise in `prepare_image_latents` when batch_size > 1
    - seed state is fixed after first masked_image_latent is sampled and used when fixed_seed_for_batch=True in 'prepare_mask_latents_inpainting`
- models/experimental/stable_diffusion_xl_base/tt/tt_sdxl_inpainting_pipeline.py
    - fixed_seed_for_batch and fixed_seed_for_batch are passed to `prepare_image_latents` and `prepare_mask_latents_inpainting`

### Checklist
- [x] [sdxl_inpaint_accuracy, T3K](https://github.com/tenstorrent/tt-shield/actions/runs/19672640986/job/56350665421)
    - `--num-prompts=10 -k "device_vae and with_trace and device_encoders and no_cfg_parallel"`
    - FID score: 333.1711202677164
    - Average CLIP Score: 31.79275870323181
- [x] [sdxl_inpaint_accuracy, T3K](https://github.com/tenstorrent/tt-shield/actions/runs/19672663428/job/56350576134)
    - `--num-prompts=10 -k "device_vae and with_trace and device_encoders and use_cfg_parallel"`
    - FID score: 333.1711202677164
    - Average CLIP Score: 31.79275870323181
- [x] [sdxl_inpaint_accuracy, n150](https://github.com/tenstorrent/tt-shield/actions/runs/19672678939/job/56350925689)
    - `--num-prompts=10 -k "device_vae and with_trace and device_encoders and no_cfg_parallel"`
    - FID score: 333.171110620373
    - Average CLIP Score: 31.792759001255035
- [x] [test_sdxl_accuracy, T3K](https://github.com/tenstorrent/tt-shield/actions/runs/19672692349/job/56350404830)
    - `--num-prompts=100 -k "device_vae and with_trace and device_encoders and no_cfg_parallel"`
- [x] [demo.py, n300](https://github.com/tenstorrent/tt-shield/actions/runs/19672765363/job/56351344804)
    - `-k "device_vae and with_trace and device_encoders"`
    

### Notes
- [sdxl_inpaint_accuracy nun on main, N150](https://github.com/tenstorrent/tt-shield/actions/runs/19677735851/job/56371646300):
    - FID score: 333.1711194306454
    - Average CLIP Score: 31.79275691509247

- comparing images from llmbox on branch, n150 on branch and n150 on main (**It turns out that images are the same even though CLIP and FID scores differ - so only the conclusion is (I guess) that differences between CPUs, can produce slightly different values of CLIP and FID**)
<img width="480" height="720" alt="image" src="https://github.com/user-attachments/assets/15a797f5-c848-4b65-b62d-af616613ebb4" />
