### PR TITLE
#33138: Add sub_core_grids to unary infra and ops like exp, log

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/eltwise/test_unary_subcoregrids.py
+++ b/tests/ttnn/nightly/unit_tests/operations/eltwise/test_unary_subcoregrids.py
@@ -1,0 +1,103 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import ttnn
+import pytest
+from tests.ttnn.utils_for_testing import assert_with_ulp
+
+
+@pytest.mark.parametrize(
+    "shape, sub_core_grid",
+    [
+        (
+            (torch.Size([1, 2, 32, 960])),
+            ttnn.CoreRangeSet(
+                [
+                    ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(3, 6)),
+                    ttnn.CoreRange(ttnn.CoreCoord(5, 0), ttnn.CoreCoord(6, 6)),
+                ]
+            ),
+        ),
+        (
+            (torch.Size([1, 7, 32, 96])),
+            ttnn.CoreRangeSet(
+                [
+                    ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(1, 6)),
+                ]
+            ),
+        ),
+        (
+            (torch.Size([1, 8, 32, 128])),
+            ttnn.CoreRangeSet(
+                [
+                    ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(1, 6)),
+                ]
+            ),
+        ),
+        (
+            (torch.Size([1, 17, 32, 32])),
+            ttnn.CoreRangeSet(
+                [
+                    ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(1, 6)),
+                ]
+            ),
+        ),
+        (
+            (torch.Size([1, 1, 32, 128 * 1024])),
+            ttnn.CoreRangeSet(
+                [
+                    ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 6)),
+                    ttnn.CoreRange(ttnn.CoreCoord(5, 0), ttnn.CoreCoord(6, 6)),
+                ]
+            ),
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        torch.bfloat16,
+    ],
+)
+@pytest.mark.parametrize(
+    "ttnn_op, atol_threshold, high, low",
+    [
+        (ttnn.log, 4e-2, 100, 1),
+        (ttnn.log10, 4e-2, 100, 1),
+        (ttnn.log1p, 4e-2, 100, 1),
+        (ttnn.log2, 7e-2, 100, 1),
+    ],
+)
+def test_unary_subcore_grid(device, shape, sub_core_grid, dtype, ttnn_op, atol_threshold, high, low):
+    """Test unary operations with sub_core_grids parameter"""
+    torch.manual_seed(0)
+    torch_dtype = dtype
+    ttnn_dtype = ttnn.bfloat16
+
+    num_elements = torch.prod(torch.tensor(shape)).item()
+    torch_input = torch.linspace(high, low, num_elements, dtype=torch_dtype)
+    torch_input = torch_input[:num_elements].reshape(shape)
+
+    # Get golden result from torch
+    golden_function = ttnn.get_golden_function(ttnn_op)
+    torch_output = golden_function(torch_input, device=device)
+
+    ttnn_input = ttnn.from_torch(
+        torch_input,
+        dtype=ttnn_dtype,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    # Run operation with sub_core_grids
+    ttnn_output = ttnn_op(ttnn_input, sub_core_grids=sub_core_grid)
+
+    # Convert output back to torch
+    ttnn_output = ttnn.to_torch(ttnn_output)
+
+    # Compare with golden using specified thresholds
+    all_close_assert = torch.allclose(ttnn_output, torch_output, atol=atol_threshold)
+    assert all_close_assert

--- a/tests/ttnn/nightly/unit_tests/operations/eltwise/test_unary_subcoregrids.py
+++ b/tests/ttnn/nightly/unit_tests/operations/eltwise/test_unary_subcoregrids.py
@@ -5,7 +5,6 @@
 import torch
 import ttnn
 import pytest
-from tests.ttnn.utils_for_testing import assert_with_ulp
 
 
 @pytest.mark.parametrize(
@@ -45,7 +44,7 @@ from tests.ttnn.utils_for_testing import assert_with_ulp
             ),
         ),
         (
-            (torch.Size([1, 1, 32, 128 * 1024])),
+            (torch.Size([1, 1, 32, 32 * 1024])),
             ttnn.CoreRangeSet(
                 [
                     ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 6)),

--- a/tests/ttnn/unit_tests/operations/eltwise/test_exp_21f.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_exp_21f.py
@@ -76,7 +76,7 @@ def test_exp_arange_masking(device):
             ),
         ),
         (
-            (torch.Size([1, 1, 32, 128 * 1024])),
+            (torch.Size([1, 1, 32, 32 * 1024])),
             ttnn.CoreRangeSet(
                 [
                     ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(3, 6)),

--- a/tests/ttnn/unit_tests/operations/eltwise/test_exp_21f.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_exp_21f.py
@@ -40,12 +40,51 @@ def test_exp_arange_masking(device):
 
 
 @pytest.mark.parametrize(
-    "input_shapes",
-    (
-        (torch.Size([1, 1, 32, 32])),
-        (torch.Size([1, 2, 64, 120])),
-        (torch.Size([1, 3, 320, 320])),
-    ),
+    "input_shapes, sub_core_grid",
+    [
+        (
+            (torch.Size([1, 2, 32, 960])),
+            ttnn.CoreRangeSet(
+                [
+                    ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(3, 6)),
+                    ttnn.CoreRange(ttnn.CoreCoord(5, 0), ttnn.CoreCoord(6, 6)),
+                ]
+            ),
+        ),
+        (
+            (torch.Size([1, 7, 32, 96])),
+            ttnn.CoreRangeSet(
+                [
+                    ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(1, 6)),
+                ]
+            ),
+        ),
+        (
+            (torch.Size([1, 8, 32, 128])),
+            ttnn.CoreRangeSet(
+                [
+                    ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(1, 6)),
+                ]
+            ),
+        ),
+        (
+            (torch.Size([1, 17, 32, 32])),
+            ttnn.CoreRangeSet(
+                [
+                    ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(1, 6)),
+                ]
+            ),
+        ),
+        (
+            (torch.Size([1, 1, 32, 128 * 1024])),
+            ttnn.CoreRangeSet(
+                [
+                    ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(3, 6)),
+                    ttnn.CoreRange(ttnn.CoreCoord(5, 0), ttnn.CoreCoord(6, 6)),
+                ]
+            ),
+        ),
+    ],
 )
 @pytest.mark.parametrize(
     "low, high",
@@ -54,7 +93,7 @@ def test_exp_arange_masking(device):
         (-87.0, 88.5),
     ],
 )
-def test_exp_ULP(input_shapes, low, high, device):
+def test_exp_ULP_subcoregrid(input_shapes, sub_core_grid, low, high, device):
     num_elements = torch.prod(torch.tensor(input_shapes)).item()
     torch_input = torch.linspace(high, low, num_elements, dtype=torch.bfloat16)
     torch_input = torch_input[:num_elements].reshape(input_shapes)
@@ -70,7 +109,7 @@ def test_exp_ULP(input_shapes, low, high, device):
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
     )
 
-    tt_result = ttnn.exp(tt_in)
+    tt_result = ttnn.exp(tt_in, sub_core_grids=sub_core_grid)
     result = ttnn.to_torch(tt_result)
     assert_with_ulp(golden, result, 1)
 

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_device_operation.hpp
@@ -26,7 +26,7 @@ struct UnaryDeviceOperation {
     using tensor_args_t = unary::tensor_args_t;
     using spec_return_value_t = unary::spec_return_value_t;
     using tensor_return_value_t = unary::tensor_return_value_t;
-    using program_factory_t = std::variant<program::UnaryProgramFactory, program::UnaryShardedProgramFactory>;
+    using program_factory_t = std::variant<program::UnaryProgramFactory, program::UnarySubCoreGridProgramFactory, program::UnaryShardedProgramFactory>;
 
     static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
 
@@ -49,7 +49,8 @@ struct UnaryDeviceOperation {
         bool fp32_dest_acc_en,
         bool preserve_fp32_precision,
         bool bfp8_pack_precise,
-        const std::optional<Tensor>& preallocated_output);
+        const std::optional<Tensor>& preallocated_output,
+        const std::optional<CoreRangeSet>& sub_core_grids);
 };
 
 }  // namespace ttnn::operations::unary

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_device_operation_types.hpp
@@ -19,6 +19,7 @@ struct operation_attributes_t {
     const bool fp32_dest_acc_en = false;
     const bool preserve_fp32_precision = false;
     const bool bfp8_pack_precise = false;
+    const std::optional<CoreRangeSet> sub_core_grids = std::nullopt;
 };
 
 struct tensor_args_t {

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_program_factory.cpp
@@ -217,4 +217,211 @@ void UnaryProgramFactory::override_runtime_arguments(
     }
 }
 
+// Sub Core Grids : should be fused later with UnaryProgramFactory directing all_device_cores to use cores from
+// sub_core_grids and update the override args accordingly after adding cores as rtargs
+UnarySubCoreGridProgramFactory::cached_program_t UnarySubCoreGridProgramFactory::create(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args, tensor_return_value_t& output) {
+    using namespace tt;
+    using namespace tt::tt_metal;
+
+    const auto& input = tensor_args.input;
+    const auto& ops_chain = args.op_chain;
+    uint32_t packed_scalar1 = 0u;
+    uint32_t packed_scalar2 = 0u;
+    const auto& sub_core_grids = args.sub_core_grids;
+
+    TT_FATAL(sub_core_grids.has_value(), "sub_core_grids cannot be null");
+
+    tt::tt_metal::Program program{};
+
+    tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input.dtype());
+    uint32_t single_tile_size = tt::tile_size(cb_data_format);
+    tt::DataFormat cb_data_format_output = tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
+    uint32_t single_tile_size_output = tt::tile_size(cb_data_format_output);
+
+    uint32_t num_tiles = input.physical_volume() / tt::constants::TILE_HW;
+
+    // TODO:
+    // auto compute_with_storage_grid_size = sub_core_grids.value();
+    // auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
+    //     tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_tiles);
+
+    uint32_t ncores = sub_core_grids->num_cores();
+
+    TT_FATAL(ncores != 0, "number of cores cannot be 0");
+
+    for (uint32_t core_id = ncores; core_id >= 1; core_id--) {
+        if (num_tiles % ncores == 0) {
+            break;
+        } else {
+            ncores--;
+        }
+    }
+    TT_FATAL(
+        (num_tiles % (ncores) == 0),
+        "{} num of tiles are not split uniformly across {} num of cores",
+        num_tiles,
+        ncores);
+
+    auto cores = corerange_to_cores(sub_core_grids.value(), ncores, true);
+    auto all_cores = num_cores_to_corerangeset_in_subcoregrids(cores[0], ncores, sub_core_grids.value(), true);
+    if (ncores == 1) {
+        all_cores = ttnn::CoreRangeSet(ttnn::CoreRange(cores[0]));
+    }
+
+    uint32_t ntiles_per_block = num_tiles / ncores;
+    uint32_t nblocks = (num_tiles / ntiles_per_block);
+    uint32_t nblocks_per_core = nblocks / ncores;
+    std::vector<CoreCoord> cores_with_rtargs;
+
+    uint32_t num_input_tiles = ntiles_per_block * 2;
+
+    uint32_t src0_cb_index = tt::CBIndex::c_0;
+    tt::tt_metal::CircularBufferConfig cb_src0_config =
+        tt::tt_metal::CircularBufferConfig(num_input_tiles * single_tile_size, {{src0_cb_index, cb_data_format}})
+            .set_page_size(src0_cb_index, single_tile_size);
+    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_src0_config);
+
+    uint32_t tmp0_cb_index = tt::CBIndex::c_1;  // temporary buffer for intermediate results
+    if (ops_chain[0].type() == UnaryOpType::HARDSHRINK || ops_chain[0].type() == UnaryOpType::CBRT) {
+        tt::tt_metal::CircularBufferConfig cb_tmp0_config =
+            tt::tt_metal::CircularBufferConfig(num_input_tiles * single_tile_size, {{tmp0_cb_index, cb_data_format}})
+                .set_page_size(tmp0_cb_index, single_tile_size);
+        tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_tmp0_config);
+    }
+
+    uint32_t output_cb_index = tt::CBIndex::c_2;
+    uint32_t num_output_tiles = ntiles_per_block * 2;
+    tt::tt_metal::CircularBufferConfig cb_output_config =
+        tt::tt_metal::CircularBufferConfig(
+            num_output_tiles * single_tile_size_output, {{output_cb_index, cb_data_format_output}})
+            .set_page_size(output_cb_index, single_tile_size_output);
+    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_output_config);
+
+    auto src_buffer = input.buffer();
+    auto dst_buffer = output.buffer();
+
+    std::vector<uint32_t> reader_compile_time_args;
+    tt::tt_metal::TensorAccessorArgs(*src_buffer).append_to(reader_compile_time_args);
+    std::vector<uint32_t> writer_compile_time_args = {(std::uint32_t)output_cb_index};
+    tt::tt_metal::TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
+
+    tt::tt_metal::KernelHandle unary_reader_kernel_id = tt::tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_interleaved_start_id.cpp",
+        all_cores,
+        tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
+
+    tt::tt_metal::KernelHandle unary_writer_kernel_id = tt::tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp",
+        all_cores,
+        tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args));
+
+    std::vector<uint32_t> compute_kernel_args = {
+        (uint32_t)nblocks_per_core,  // per_core_block_cnt
+        (uint32_t)ntiles_per_block,  // per_block_num_tiles // per_core_block_size
+    };
+
+    std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
+    if (args.preserve_fp32_precision) {
+        unpack_to_dest_mode[src0_cb_index] = UnpackToDestMode::UnpackToDestFp32;
+        unpack_to_dest_mode[tmp0_cb_index] = UnpackToDestMode::UnpackToDestFp32;
+    }
+
+    bool math_approx_mode = std::all_of(
+        args.op_chain.begin(), args.op_chain.end(), [](const auto& u) { return utils::get_op_approx_mode(u.type()); });
+    std::map<std::string, std::string> unary_defines = utils::get_block_defines(args.op_chain, "0", "0", input.dtype());
+
+    if (input.dtype() == DataType::FLOAT32) {
+        unary_defines["INP_FLOAT32"] = "1";
+    } else if (input.dtype() == DataType::INT32) {
+        unary_defines["INP_INT32"] = "1";
+    } else if (input.dtype() == DataType::UINT32) {
+        unary_defines["INP_UINT32"] = "1";
+    } else {
+        unary_defines["INP_FLOAT"] = "1";
+    }
+
+    if (!ops_chain[0].empty()) {
+        switch (ops_chain[0].type()) {
+            case UnaryOpType::HARDSHRINK:
+                packed_scalar1 = utils::pack_scalar_runtime_arg(ops_chain[0], 0, input.dtype());
+                break;
+            case UnaryOpType::WHERE_TSS:
+                packed_scalar1 = utils::pack_scalar_runtime_arg(ops_chain[0], 0, input.dtype());
+                packed_scalar2 = utils::pack_scalar_runtime_arg(ops_chain[0], 1, input.dtype());
+                break;
+            default: break;
+        }
+    }
+
+    auto path = utils::get_compute_kernel_path(ops_chain[0].type(), compute_root, input.dtype());
+
+    auto eltwise_unary_kernel_id = tt::tt_metal::CreateKernel(
+        program,
+        path,
+        all_cores,
+        tt::tt_metal::ComputeConfig{
+            .math_fidelity = MathFidelity::HiFi4,
+            .fp32_dest_acc_en = args.fp32_dest_acc_en,
+            .unpack_to_dest_mode = unpack_to_dest_mode,
+            .bfp8_pack_precise = args.bfp8_pack_precise,
+            .math_approx_mode = math_approx_mode,
+            .compile_args = compute_kernel_args,
+            .defines = unary_defines});
+
+    uint32_t tile_start_id = 0;
+    auto ntiles_per_core = ntiles_per_block * nblocks_per_core;
+
+    for (uint32_t i = 0; i < cores.size(); i++) {
+        CoreCoord core = cores[i];
+
+        tt::tt_metal::SetRuntimeArgs(
+            program, unary_reader_kernel_id, core, {src_buffer->address(), ntiles_per_core, tile_start_id});
+
+        tt::tt_metal::SetRuntimeArgs(
+            program, unary_writer_kernel_id, core, {dst_buffer->address(), ntiles_per_core, tile_start_id});
+
+        tt::tt_metal::SetRuntimeArgs(program, eltwise_unary_kernel_id, core, {packed_scalar1, packed_scalar2});
+
+        cores_with_rtargs.push_back(core);
+        tile_start_id += ntiles_per_core;
+    }
+
+    return cached_program_t{std::move(program), {unary_reader_kernel_id, unary_writer_kernel_id, cores_with_rtargs}};
+}
+
+void UnarySubCoreGridProgramFactory::override_runtime_arguments(
+    cached_program_t& cached_program,
+    const operation_attributes_t& operation_attributes,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& output) {
+    auto& unary_reader_kernel_id = cached_program.shared_variables.unary_reader_kernel_id;
+    auto& unary_writer_kernel_id = cached_program.shared_variables.unary_writer_kernel_id;
+    auto& cores_with_rtargs = cached_program.shared_variables.cores_with_rtargs;
+
+    auto& program = cached_program.program;
+
+    const auto& input = tensor_args.input;
+    auto src_buffer = input.buffer();
+    auto dst_buffer = output.buffer();
+
+    {
+        auto& runtime_args_by_core = GetRuntimeArgs(program, unary_reader_kernel_id);
+        for (const CoreCoord& core : cores_with_rtargs) {
+            auto& runtime_args = runtime_args_by_core[core.x][core.y];
+            runtime_args[0] = src_buffer->address();
+        }
+    }
+
+    {
+        auto& runtime_args_by_core = GetRuntimeArgs(program, unary_writer_kernel_id);
+        for (const CoreCoord& core : cores_with_rtargs) {
+            auto& runtime_args = runtime_args_by_core[core.x][core.y];
+            runtime_args[0] = dst_buffer->address();
+        }
+    }
+}
+
 }  // namespace ttnn::operations::unary::program

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_program_factory.hpp
@@ -32,8 +32,8 @@ struct UnaryProgramFactory {
 
 struct UnarySubCoreGridProgramFactory {
     struct shared_variables_t {
-        tt::tt_metal::KernelHandle unary_reader_kernel_id;
-        tt::tt_metal::KernelHandle unary_writer_kernel_id;
+        tt::tt_metal::KernelHandle unary_reader_kernel_id{};
+        tt::tt_metal::KernelHandle unary_writer_kernel_id{};
         std::vector<CoreCoord> cores_with_rtargs;
     };
     using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_program_factory.hpp
@@ -30,4 +30,24 @@ struct UnaryProgramFactory {
         tensor_return_value_t& tensor_return_value);
 };
 
+struct UnarySubCoreGridProgramFactory {
+    struct shared_variables_t {
+        tt::tt_metal::KernelHandle unary_reader_kernel_id;
+        tt::tt_metal::KernelHandle unary_writer_kernel_id;
+        std::vector<CoreCoord> cores_with_rtargs;
+    };
+    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
+
+    static cached_program_t create(
+        const operation_attributes_t& operation_attributes,
+        const tensor_args_t& tensor_args,
+        tensor_return_value_t& tensor_return_value);
+
+    static void override_runtime_arguments(
+        cached_program_t& cached_program,
+        const operation_attributes_t& operation_attributes,
+        const tensor_args_t& tensor_args,
+        tensor_return_value_t& tensor_return_value);
+};
+
 }  // namespace ttnn::operations::unary::program

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_sharded_program_factory.cpp
@@ -29,11 +29,13 @@ UnaryShardedProgramFactory::cached_program_t UnaryShardedProgramFactory::create(
     uint32_t packed_scalar2 = 0u;
     tt::tt_metal::Program program = CreateProgram();
 
+    TT_FATAL(args.sub_core_grids.has_value(), "Sub core grids are not supported for sharded input tensors");
     auto shard_spec = input.shard_spec().value();
     auto all_cores = shard_spec.grid;
     uint32_t ncores = shard_spec.num_cores();
 
     auto out_shard_spec = output.shard_spec().value();
+
     TT_FATAL(
         out_shard_spec.num_cores() == ncores,
         "Output tensor should have same number of cores {} as input tensor {}",

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_sharded_program_factory.cpp
@@ -29,7 +29,7 @@ UnaryShardedProgramFactory::cached_program_t UnaryShardedProgramFactory::create(
     uint32_t packed_scalar2 = 0u;
     tt::tt_metal::Program program = CreateProgram();
 
-    TT_FATAL(args.sub_core_grids.has_value(), "Sub core grids are not supported for sharded input tensors");
+    TT_FATAL(args.sub_core_grids == std::nullopt, "Sub core grids are not supported for sharded input tensors");
     auto shard_spec = input.shard_spec().value();
     auto all_cores = shard_spec.grid;
     uint32_t ncores = shard_spec.num_cores();

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
@@ -22,7 +22,8 @@ inline Tensor unary_impl(
     const Tensor& input_tensor,
     const std::vector<EltwiseUnaryWithParam>& op_chain,
     const std::optional<MemoryConfig>& memory_config = std::nullopt,
-    const std::optional<Tensor>& optional_output_tensor = std::nullopt) {
+    const std::optional<Tensor>& optional_output_tensor = std::nullopt,
+    const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt) {
     TT_FATAL(!op_chain.empty(), "Op chain cannot be empty");
     DataType input_dtype = input_tensor.dtype();
     DataType output_dtype = (op_chain[0].type() == UnaryOpType::TYPECAST)
@@ -46,7 +47,8 @@ inline Tensor unary_impl(
         fp32_dest_acc_en,
         preserve_fp32_precision,
         bfp8_pack_precise,
-        optional_output_tensor);
+        optional_output_tensor,
+        sub_core_grids);
 }
 
 }  // namespace detail
@@ -126,12 +128,14 @@ Tensor ExecuteUnaryWithFastAndApproximateMode<unary_op_type>::invoke(
     const Tensor& input_tensor,
     const bool parameter,
     const std::optional<MemoryConfig>& memory_config,
-    const std::optional<Tensor>& optional_output_tensor) {
+    const std::optional<Tensor>& optional_output_tensor,
+    const std::optional<CoreRangeSet>& sub_core_grids) {
     return detail::unary_impl(
         input_tensor,
         {UnaryWithParam{unary_op_type, static_cast<float>(parameter)}},
         memory_config,
-        optional_output_tensor);
+        optional_output_tensor,
+        sub_core_grids);
 }
 
 template struct ExecuteUnaryWithFastAndApproximateMode<UnaryOpType::EXP>;

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary.hpp
@@ -27,7 +27,8 @@ struct ExecuteUnaryWithFastAndApproximateMode {
         const Tensor& input_tensor,
         bool parameter = false,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
-        const std::optional<Tensor>& optional_output_tensor = std::nullopt);
+        const std::optional<Tensor>& optional_output_tensor = std::nullopt,
+        const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
 };
 
 template <UnaryOpType unary_op_type>

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.cpp
@@ -476,6 +476,7 @@ void bind_unary_operation_with_fast_and_approximate_mode(
             fast_and_approximate_mode (bool, optional): Use the fast and approximate mode. Defaults to `False`.
             memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
             output_tensor (ttnn.Tensor, optional): preallocated output tensor. Defaults to `None`.
+            sub_core_grids (ttnn.CoreRangeSet, optional): sub core grids for the operation. Defaults to `None`.
 
         Returns:
             ttnn.Tensor: the output tensor.
@@ -510,14 +511,16 @@ void bind_unary_operation_with_fast_and_approximate_mode(
                const Tensor& input_tensor,
                const bool parameter,
                const std::optional<MemoryConfig>& memory_config,
-               const std::optional<ttnn::Tensor>& output_tensor) -> ttnn::Tensor {
-                return self(input_tensor, parameter, memory_config, output_tensor);
+               const std::optional<ttnn::Tensor>& output_tensor,
+               const std::optional<CoreRangeSet>& sub_core_grids) -> ttnn::Tensor {
+                return self(input_tensor, parameter, memory_config, output_tensor, sub_core_grids);
             },
             py::arg("input_tensor"),
             py::kw_only(),
             py::arg("fast_and_approximate_mode") = false,
             py::arg("memory_config") = std::nullopt,
-            py::arg("output_tensor") = std::nullopt});
+            py::arg("output_tensor") = std::nullopt,
+            py::arg("sub_core_grids") = std::nullopt});
 }
 
 template <typename unary_operation_t>


### PR DESCRIPTION
### Ticket
Link to Github Issue #33138

### Problem description
Missing sub_core_grids support in unary infra and ops like exp, log

### What's changed
Added sub_core_grids to unary infra and ops like exp, log for non-sharded inputs

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/19673142138
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/19673161738
- [x] Nightly L2 Eltwise  https://github.com/tenstorrent/tt-metal/actions/runs/19673154690
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [x] New/Existing tests provide coverage for changes