### PR TITLE
Telemetry: Expose remaining firmware versions

### DIFF
--- a/tt_telemetry/telemetry/arc/arc_metrics.cpp
+++ b/tt_telemetry/telemetry/arc/arc_metrics.cpp
@@ -125,8 +125,6 @@ void create_arc_metrics(
                         MetricUnit::CELSIUS));
 
                     // Create String metrics for firmware version information
-                    // Note: Additional firmware versions (ARC, M3, Flash) are not yet exposed
-                    // and require UMD support. See related UMD issue for details.
                     string_metrics.push_back(std::make_unique<ARCStringMetric>(
                         asic_descriptor.value(),
                         firmware_provider,
@@ -144,6 +142,54 @@ void create_arc_metrics(
                             // Decode using tt_version constructor which handles the bit packing
                             tt::umd::tt_version eth_ver(firmware_provider->get_eth_fw_version());
                             return eth_ver.str();
+                        },
+                        MetricUnit::UNITLESS));
+
+                    string_metrics.push_back(std::make_unique<ARCStringMetric>(
+                        asic_descriptor.value(),
+                        firmware_provider,
+                        "CMFirmwareVersion",
+                        [firmware_provider]() -> std::optional<std::string> {
+                            if (auto version_opt = firmware_provider->get_cm_fw_version()) {
+                                return version_opt->to_string();
+                            }
+                            return std::nullopt;
+                        },
+                        MetricUnit::UNITLESS));
+
+                    string_metrics.push_back(std::make_unique<ARCStringMetric>(
+                        asic_descriptor.value(),
+                        firmware_provider,
+                        "DMAppFirmwareVersion",
+                        [firmware_provider]() -> std::optional<std::string> {
+                            if (auto version_opt = firmware_provider->get_dm_app_fw_version()) {
+                                return version_opt->to_string();
+                            }
+                            return std::nullopt;
+                        },
+                        MetricUnit::UNITLESS));
+
+                    string_metrics.push_back(std::make_unique<ARCStringMetric>(
+                        asic_descriptor.value(),
+                        firmware_provider,
+                        "DMBootloaderFirmwareVersion",
+                        [firmware_provider]() -> std::optional<std::string> {
+                            if (auto version_opt = firmware_provider->get_dm_bl_fw_version()) {
+                                return version_opt->to_string();
+                            }
+                            return std::nullopt;
+                        },
+                        MetricUnit::UNITLESS));
+
+                    string_metrics.push_back(std::make_unique<ARCStringMetric>(
+                        asic_descriptor.value(),
+                        firmware_provider,
+                        "TTFlashVersion",
+                        [firmware_provider]() -> std::optional<std::string> {
+                            if (auto version_opt = firmware_provider->get_tt_flash_version()) {
+                                return version_opt->to_string();
+                            }
+                            return std::nullopt;
                         },
                         MetricUnit::UNITLESS));
                 } else {


### PR DESCRIPTION
### Ticket
Solves #31144

### Problem description
PR #31706 exposed `FirmwareBundleVersion` and `EthernetFirmwareVersion` as telemetry string metrics, but could not expose the remaining firmware component versions (CM/ARC, DM/M3 app, DM/M3 bootloader, and TT Flash) because UMD lacked the necessary APIs. This was tracked in tenstorrent/tt-umd#1567.

UMD PR tenstorrent/tt-umd#1595 has since been merged, adding `get_cm_fw_version()`, `get_dm_app_fw_version()`, `get_dm_bl_fw_version()`, and `get_tt_flash_version()` methods to `FirmwareInfoProvider`. These methods return `std::optional<semver_t>` with uniform version formatting.

### What's changed
Added four new string metrics to `create_arc_metrics()` in `tt_telemetry/telemetry/arc/arc_metrics.cpp`:

- `CMFirmwareVersion` - exposes CM/ARC firmware version via `get_cm_fw_version()`
- `DMAppFirmwareVersion` - exposes DM/M3 application firmware version via `get_dm_app_fw_version()`
- `DMBootloaderFirmwareVersion` - exposes DM/M3 bootloader firmware version via `get_dm_bl_fw_version()`
- `TTFlashVersion` - exposes TT Flash version via `get_tt_flash_version()`

Each metric follows the existing `ARCStringMetric` pattern and converts `std::optional<semver_t>` to string using `semver_t::to_string()`. The obsolete comment about requiring UMD support has been removed.

Telemetry now exposes all six firmware version components that `tt-smi` provides, completing the feature requested in #31144.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes