### PR TITLE
Move DPRINT parsing logic to separate class

### DIFF
--- a/tt_metal/impl/CMakeLists.txt
+++ b/tt_metal/impl/CMakeLists.txt
@@ -65,6 +65,7 @@ set(IMPL_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/dispatch/kernel_config/relay_mux.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dispatch/util/dispatch_settings.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/debug/dprint_server.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/debug/dprint_parser.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/debug/inspector/data.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/debug/inspector/inspector.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/debug/inspector/logger.cpp

--- a/tt_metal/impl/CMakeLists.txt
+++ b/tt_metal/impl/CMakeLists.txt
@@ -65,7 +65,6 @@ set(IMPL_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/dispatch/kernel_config/relay_mux.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dispatch/util/dispatch_settings.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/debug/dprint_server.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/debug/dprint_parser.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/debug/inspector/data.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/debug/inspector/inspector.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/debug/inspector/logger.cpp
@@ -88,6 +87,7 @@ set(IMPL_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/lightmetal/lightmetal_capture.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/lightmetal/lightmetal_capture_utils.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/lightmetal/host_api_capture_helpers.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/debug/dprint_parser.cpp
 )
 
 # Include helper functions and generate headers from flatbuffer schemas

--- a/tt_metal/impl/debug/dprint_parser.cpp
+++ b/tt_metal/impl/debug/dprint_parser.cpp
@@ -1,0 +1,460 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dprint_parser.hpp"
+
+#include <math.h>
+#include <cstring>
+#include <iomanip>
+#include <string>
+
+#include <enchantum/enchantum.hpp>
+#include <enchantum/scoped.hpp>
+#include <tt-metalium/blockfloat_common.hpp>
+#include <tt_stl/assert.hpp>
+
+#include "fmt/base.h"
+#include "hostdevcommon/dprint_common.h"
+#include "hostdevcommon/kernel_structs.h"
+#include "tt_backend_api_types.hpp"
+
+using std::setw;
+using std::string;
+using std::to_string;
+
+namespace tt::tt_metal {
+
+DPrintParser::DPrintParser(std::string line_prefix) :
+    line_prefix_(std::move(line_prefix)), prev_type_(DPrintTypeID_Count), most_recent_setw_(0) {}
+
+// Helper function implementations (from dprint_server.cpp anonymous namespace)
+
+inline float DPrintParser::bfloat16_to_float(uint16_t bfloat_val) {
+    uint32_t uint32_data = ((uint32_t)bfloat_val) << 16;
+    float f;
+    std::memcpy(&f, &uint32_data, sizeof(f));
+    return f;
+}
+
+void DPrintParser::AssertSize(uint8_t sz, uint8_t expected_sz) {
+    TT_ASSERT(
+        sz == expected_sz,
+        "DPrint token size ({}) did not match expected ({}), potential data corruption in the DPrint buffer.",
+        sz,
+        expected_sz);
+}
+
+void DPrintParser::ResetStream(std::ostringstream* stream) {
+    stream->str("");
+    stream->clear();
+}
+
+bool DPrintParser::StreamEndsWithNewlineChar(const std::ostringstream* stream) {
+    const string stream_str = stream->str();
+    return !stream_str.empty() && stream_str.back() == '\n';
+}
+
+void DPrintParser::PrintTileSlice(uint8_t* ptr) {
+    TileSliceHostDev<0> ts_copy{};  // Make a copy since ptr might not be properly aligned
+    std::memcpy(&ts_copy, ptr, sizeof(TileSliceHostDev<0>));
+    TileSliceHostDev<0>* ts = &ts_copy;
+    TT_ASSERT(
+        offsetof(TileSliceHostDev<0>, data) % sizeof(uint32_t) == 0,
+        "TileSliceHostDev<0> data field is not properly aligned");
+    uint8_t* data = ptr + offsetof(TileSliceHostDev<0>, data);
+
+    // Read any error codes and handle accordingly
+    tt::CBIndex cb = static_cast<tt::CBIndex>(ts->cb_id);
+    switch (ts->return_code) {
+        case DPrintOK: break;  // Continue to print the tile slice
+        case DPrintErrorBadPointer: {
+            uint32_t ptr = ts->cb_ptr;
+            uint8_t count = ts->data_count;
+            intermediate_stream_ << fmt::format(
+                "Tried printing {}: BAD TILE POINTER (ptr={}, count={})\n",
+                enchantum::scoped::to_string(cb), ptr, count);
+            return;
+        }
+        case DPrintErrorUnsupportedFormat: {
+            tt::DataFormat data_format = static_cast<tt::DataFormat>(ts->data_format);
+            intermediate_stream_ << fmt::format(
+                "Tried printing {}: Unsupported data format ({})\n",
+                enchantum::scoped::to_string(cb),
+                data_format);
+            return;
+        }
+        case DPrintErrorMath:
+            intermediate_stream_ << "Warning: MATH core does not support TileSlice printing, omitting print...\n";
+            return;
+        case DPrintErrorEthernet:
+            intermediate_stream_ << "Warning: Ethernet core does not support TileSlice printing, omitting print...\n";
+            return;
+        default:
+            intermediate_stream_ << fmt::format(
+                "Warning: TileSlice printing failed with unknown return code {}, omitting print...\n", ts->return_code);
+            return;
+    }
+
+    // No error codes, print the TileSlice
+    uint32_t i = 0;
+    bool count_exceeded = false;
+    for (int h = ts->slice_range.h0; h < ts->slice_range.h1; h += ts->slice_range.hs) {
+        for (int w = ts->slice_range.w0; w < ts->slice_range.w1; w += ts->slice_range.ws) {
+            // If the number of data specified by the SliceRange exceeds the number that was
+            // saved in the print buffer (set by the MAX_COUNT template parameter in the
+            // TileSlice), then break early.
+            if (i >= ts->data_count) {
+                count_exceeded = true;
+                break;
+            }
+            tt::DataFormat data_format = static_cast<tt::DataFormat>(ts->data_format);
+            switch (data_format) {
+                case tt::DataFormat::Float16_b: {
+                    uint16_t* float16_b_ptr = reinterpret_cast<uint16_t*>(data);
+                    intermediate_stream_ << bfloat16_to_float(float16_b_ptr[i]);
+                    break;
+                }
+                case tt::DataFormat::Float32: {
+                    float* float32_ptr = reinterpret_cast<float*>(data);
+                    intermediate_stream_ << float32_ptr[i];
+                    break;
+                }
+                case tt::DataFormat::Bfp4_b:
+                case tt::DataFormat::Bfp8_b: {
+                    // Saved the exponent and data together
+                    uint16_t* data_ptr = reinterpret_cast<uint16_t*>(data);
+                    uint8_t val = (data_ptr[i] >> 8) & 0xFF;
+                    uint8_t exponent = data_ptr[i] & 0xFF;
+                    uint32_t bit_val = convert_bfp_to_u32(data_format, val, exponent, false);
+                    intermediate_stream_ << *reinterpret_cast<float*>(&bit_val);
+                    break;
+                }
+                case tt::DataFormat::Int8: {
+                    int8_t* data_ptr = reinterpret_cast<int8_t*>(data);
+                    intermediate_stream_ << (int)data_ptr[i];
+                    break;
+                }
+                case tt::DataFormat::UInt8: {
+                    uint8_t* data_ptr = reinterpret_cast<uint8_t*>(data);
+                    intermediate_stream_ << (unsigned int)data_ptr[i];
+                    break;
+                }
+                case tt::DataFormat::UInt16: {
+                    uint16_t* data_ptr = reinterpret_cast<uint16_t*>(data);
+                    intermediate_stream_ << (unsigned int)data_ptr[i];
+                    break;
+                }
+                case tt::DataFormat::Int32: {
+                    int32_t* data_ptr = reinterpret_cast<int32_t*>(data);
+                    intermediate_stream_ << (int)data_ptr[i];
+                    break;
+                }
+                case tt::DataFormat::UInt32: {
+                    uint32_t* data_ptr = reinterpret_cast<uint32_t*>(data);
+                    intermediate_stream_ << (unsigned int)data_ptr[i];
+                    break;
+                }
+                default: break;
+            }
+            if (w + ts->slice_range.ws < ts->slice_range.w1) {
+                intermediate_stream_ << " ";
+            }
+            i++;
+        }
+
+        // Break outer loop as well if MAX COUNT exceeded, also print a message to let the user
+        // know that the slice has been truncated.
+        if (count_exceeded) {
+            intermediate_stream_ << "<TileSlice data truncated due to exceeding max count ("
+                                 << to_string(ts->data_count) << ")>\n";
+            break;
+        }
+
+        if (ts->endl_rows) {
+            intermediate_stream_ << "\n";
+        }
+    }
+}
+
+// Create a float from a given bit pattern, given the number of bits for the exponent and mantissa.
+// Assumes the following order of bits in the input data:
+//   [sign bit][mantissa bits][exponent bits]
+float DPrintParser::make_float(uint8_t exp_bit_count, uint8_t mantissa_bit_count, uint32_t data) {
+    int sign = (data >> (exp_bit_count + mantissa_bit_count)) & 0x1;
+    const int exp_mask = (1 << (exp_bit_count)) - 1;
+    int exp_bias = (1 << (exp_bit_count - 1)) - 1;
+    int exp_val = (data & exp_mask) - exp_bias;
+    const int mantissa_mask = ((1 << mantissa_bit_count) - 1) << exp_bit_count;
+    int mantissa_val = (data & mantissa_mask) >> exp_bit_count;
+    float result = 1.0 + ((float)mantissa_val / (float)(1 << mantissa_bit_count));
+    result = result * pow(2, exp_val);
+    if (sign) {
+        result = -result;
+    }
+    return result;
+}
+
+// Prints a given datum in the array, given the data_format
+void DPrintParser::PrintTensixRegisterData(int setwidth, uint32_t datum, uint16_t data_format) {
+    switch (data_format) {
+        case static_cast<std::uint8_t>(tt::DataFormat::Float16):
+        case static_cast<std::uint8_t>(tt::DataFormat::Bfp8):
+        case static_cast<std::uint8_t>(tt::DataFormat::Bfp4):
+        case static_cast<std::uint8_t>(tt::DataFormat::Bfp2):
+        case static_cast<std::uint8_t>(tt::DataFormat::Lf8):
+            intermediate_stream_ << setw(setwidth) << make_float(5, 10, datum & 0xffff) << " ";
+            intermediate_stream_ << setw(setwidth) << make_float(5, 10, (datum >> 16) & 0xffff) << " ";
+            break;
+        case static_cast<std::uint8_t>(tt::DataFormat::Bfp8_b):
+        case static_cast<std::uint8_t>(tt::DataFormat::Bfp4_b):
+        case static_cast<std::uint8_t>(tt::DataFormat::Bfp2_b):
+        case static_cast<std::uint8_t>(tt::DataFormat::Float16_b):
+            intermediate_stream_ << setw(setwidth) << make_float(8, 7, datum & 0xffff) << " ";
+            intermediate_stream_ << setw(setwidth) << make_float(8, 7, (datum >> 16) & 0xffff) << " ";
+            break;
+        case static_cast<std::uint8_t>(tt::DataFormat::Tf32):
+            intermediate_stream_ << setw(setwidth) << make_float(8, 10, datum) << " ";
+            break;
+        case static_cast<std::uint8_t>(tt::DataFormat::Float32): {
+            float value;
+            memcpy(&value, &datum, sizeof(float));
+            intermediate_stream_ << setw(setwidth) << value << " ";
+        } break;
+        case static_cast<std::uint8_t>(tt::DataFormat::UInt32):
+            intermediate_stream_ << setw(setwidth) << datum << " ";
+            break;
+        case static_cast<std::uint8_t>(tt::DataFormat::UInt16):
+            intermediate_stream_ << setw(setwidth) << (datum & 0xffff) << " ";
+            intermediate_stream_ << setw(setwidth) << (datum >> 16) << " ";
+            break;
+        case static_cast<std::uint8_t>(tt::DataFormat::Int32):
+            intermediate_stream_ << setw(setwidth) << static_cast<int32_t>(datum) << " ";
+            break;
+        default: intermediate_stream_ << "Unknown data format " << data_format << " "; break;
+    }
+}
+
+// Prints a typed uint32 array given the number of elements including the type.
+// If force_element_type is set to a valid type, it is assumed that the type is not included in the
+// data array, and the type is forced to be the given type.
+void DPrintParser::PrintTypedUint32Array(
+    int setwidth, uint32_t raw_element_count, uint32_t* data, TypedU32_ARRAY_Format force_array_type) {
+    uint16_t array_type = data[raw_element_count - 1] >> 16;
+    uint16_t array_subtype = data[raw_element_count - 1] & 0xffff;
+
+    raw_element_count = (force_array_type == TypedU32_ARRAY_Format_INVALID) ? raw_element_count : raw_element_count + 1;
+
+    for (uint32_t i = 0; i < raw_element_count - 1; i++) {
+        switch (array_type) {
+            case TypedU32_ARRAY_Format_Raw: intermediate_stream_ << std::hex << "0x" << data[i] << " "; break;
+            case TypedU32_ARRAY_Format_Tensix_Config_Register_Data_Format_Type:
+                PrintTensixRegisterData(setwidth, data[i], array_subtype);
+                break;
+            default: intermediate_stream_ << "Unknown type " << array_type; break;
+        }
+    }
+}
+
+// Helper to collect a completed line with prefix
+std::string DPrintParser::get_completed_line() {
+    std::string line;
+    if (!line_prefix_.empty()) {
+        line += line_prefix_;
+    }
+    if (!intermediate_stream_.str().empty()) {
+        line += intermediate_stream_.str();
+    }
+    ResetStream(&intermediate_stream_);
+    return line;
+}
+
+DPrintParser::ParseResult DPrintParser::parse(const uint8_t* data, size_t len) {
+    ParseResult result;
+    result.bytes_consumed = 0;
+
+    // Parse the input codes
+    size_t pos = 0;
+    while (pos < len) {
+        DPrintTypeID code = static_cast<DPrintTypeID>(data[pos++]);
+        TT_ASSERT(pos <= len);
+        uint8_t sz = data[pos++];
+        TT_ASSERT(pos <= len);
+        const uint8_t* ptr = data + pos;
+
+        // Possible to break before pos == len due to waiting on another core's raise.
+        bool break_due_to_wait = false;
+
+        // we are sharing the same output file between debug print threads for multiple cores
+        switch (code) {
+            case DPrintCSTR:  // const char*
+            {
+                // null terminating char was included in size and should be present in the buffer
+                const char* cptr = reinterpret_cast<const char*>(ptr);
+                const size_t cptr_len = strnlen(cptr, len - 2);
+                if (cptr_len == len - 2) {
+                    intermediate_stream_ << "STRING BUFFER OVERFLOW DETECTED\n";
+                    result.completed_lines.push_back(get_completed_line());
+                } else {
+                    // if we come across a newline char, we should transfer the data up to the newline to the output
+                    // stream and flush it
+                    const char* newline_pos = strchr(cptr, '\n');
+                    bool contains_newline = newline_pos != nullptr;
+                    while (contains_newline) {
+                        const char* pos_after_newline = newline_pos + 1;
+                        const uint32_t substr_len = pos_after_newline - cptr;
+
+                        // strchr returns nullptr if it encounters a null terminator,
+                        // so we can guarantee that this is valid data since it was
+                        // already checked. We don't need to append a '\0' because
+                        // the stream operator only takes upto '\0' when passed
+                        // a char* (wrt the previous impl)
+                        const std::string_view substr_upto_newline(cptr, substr_len);
+
+                        intermediate_stream_ << substr_upto_newline;
+                        result.completed_lines.push_back(get_completed_line());
+                        cptr = pos_after_newline;
+                        newline_pos = strchr(cptr, '\n');
+                        contains_newline = newline_pos != nullptr;
+                    }
+                    intermediate_stream_ << cptr;
+                }
+                AssertSize(sz, cptr_len + 1);
+                break;
+            }
+            case DPrintTILESLICE: PrintTileSlice(const_cast<uint8_t*>(ptr)); break;
+
+            case DPrintENDL:
+                if (prev_type_ != DPrintTILESLICE || !StreamEndsWithNewlineChar(&intermediate_stream_)) {
+                    intermediate_stream_ << '\n';
+                }
+                result.completed_lines.push_back(get_completed_line());
+                AssertSize(sz, 1);
+                break;
+            case DPrintSETW: {
+                char val = ptr[0];
+                intermediate_stream_ << setw(val);
+                most_recent_setw_ = val;
+                AssertSize(sz, 1);
+                break;
+            }
+            case DPrintSETPRECISION:
+                intermediate_stream_ << std::setprecision(*ptr);
+                AssertSize(sz, 1);
+                break;
+            case DPrintFIXED:
+                intermediate_stream_ << std::fixed;
+                AssertSize(sz, 1);
+                break;
+            case DPrintDEFAULTFLOAT:
+                intermediate_stream_ << std::defaultfloat;
+                AssertSize(sz, 1);
+                break;
+            case DPrintHEX:
+                intermediate_stream_ << std::hex;
+                AssertSize(sz, 1);
+                break;
+            case DPrintOCT:
+                intermediate_stream_ << std::oct;
+                AssertSize(sz, 1);
+                break;
+            case DPrintDEC:
+                intermediate_stream_ << std::dec;
+                AssertSize(sz, 1);
+                break;
+            case DPrintUINT8:
+                // iostream default uint8_t printing is as char, not an int
+                intermediate_stream_ << *reinterpret_cast<const uint8_t*>(ptr);
+                AssertSize(sz, 1);
+                break;
+            case DPrintUINT16: {
+                uint16_t value;
+                memcpy(&value, ptr, sizeof(uint16_t));
+                intermediate_stream_ << value;
+                AssertSize(sz, 2);
+            } break;
+            case DPrintUINT32: {
+                uint32_t value;
+                memcpy(&value, ptr, sizeof(uint32_t));
+                intermediate_stream_ << value;
+                AssertSize(sz, 4);
+            } break;
+            case DPrintUINT64: {
+                uint64_t value;
+                memcpy(&value, ptr, sizeof(uint64_t));
+                intermediate_stream_ << value;
+                AssertSize(sz, 8);
+            } break;
+            case DPrintINT8: {
+                int8_t value;
+                memcpy(&value, ptr, sizeof(int8_t));
+                intermediate_stream_ << (int)value;  // Cast to int to ensure it prints as a number, not a char
+                AssertSize(sz, 1);
+            } break;
+            case DPrintINT16: {
+                int16_t value;
+                memcpy(&value, ptr, sizeof(int16_t));
+                intermediate_stream_ << value;
+                AssertSize(sz, 2);
+            } break;
+            case DPrintINT32: {
+                int32_t value;
+                memcpy(&value, ptr, sizeof(int32_t));
+                intermediate_stream_ << value;
+                AssertSize(sz, 4);
+            } break;
+            case DPrintINT64: {
+                int64_t value;
+                memcpy(&value, ptr, sizeof(int64_t));
+                intermediate_stream_ << value;
+                AssertSize(sz, 8);
+            } break;
+            case DPrintFLOAT32: {
+                float value;
+                memcpy(&value, ptr, sizeof(float));
+                intermediate_stream_ << value;
+                AssertSize(sz, 4);
+            } break;
+            case DPrintBFLOAT16: {
+                uint16_t rawValue;
+                memcpy(&rawValue, ptr, sizeof(uint16_t));
+                float value = bfloat16_to_float(rawValue);
+                intermediate_stream_ << value;
+                AssertSize(sz, 2);
+            } break;
+            case DPrintCHAR:
+                intermediate_stream_ << *reinterpret_cast<const char*>(ptr);
+                AssertSize(sz, 1);
+                break;
+            case DPrintU32_ARRAY:
+                PrintTypedUint32Array(
+                    most_recent_setw_,
+                    sz / 4,
+                    const_cast<uint32_t*>(reinterpret_cast<const uint32_t*>(ptr)),
+                    TypedU32_ARRAY_Format_Raw);
+                break;
+            case DPrintTYPED_U32_ARRAY:
+                PrintTypedUint32Array(
+                    most_recent_setw_, sz / 4, const_cast<uint32_t*>(reinterpret_cast<const uint32_t*>(ptr)));
+                break;
+            default: TT_THROW("Unexpected debug print type pos {:#x} len {:#x} code {}", pos, len, (uint32_t)code);
+        }
+
+        prev_type_ = code;
+
+        pos += sz;  // parse the payload size
+        TT_ASSERT(pos <= len);
+
+        // Break due to wait (we'll get the rest of the print buffer after the raise).
+        if (break_due_to_wait) {
+            break;
+        }
+    }
+
+    result.bytes_consumed = pos;
+    return result;
+}
+
+std::string DPrintParser::flush() { return get_completed_line(); }
+
+}  // namespace tt::tt_metal

--- a/tt_metal/impl/debug/dprint_parser.hpp
+++ b/tt_metal/impl/debug/dprint_parser.hpp
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+ * Parses debug print data from device buffers.
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "hostdevcommon/dprint_common.h"
+
+namespace tt::tt_metal {
+
+class DPrintParser {
+public:
+    struct ParseResult {
+        std::vector<std::string> completed_lines;
+        size_t bytes_consumed;
+    };
+
+    explicit DPrintParser(std::string line_prefix = "");
+    ParseResult parse(const uint8_t* data, size_t len);
+    std::string flush();
+
+private:
+    std::string line_prefix_;
+    std::ostringstream intermediate_stream_;
+    DPrintTypeID prev_type_;
+    char most_recent_setw_;
+
+    // Helper methods (from dprint_server.cpp anonymous namespace)
+    static float bfloat16_to_float(uint16_t bfloat_val);
+    static float make_float(uint8_t exp_bit_count, uint8_t mantissa_bit_count, uint32_t data);
+    static void AssertSize(uint8_t sz, uint8_t expected_sz);
+    static bool StreamEndsWithNewlineChar(const std::ostringstream* stream);
+    static void ResetStream(std::ostringstream* stream);
+
+    void PrintTileSlice(uint8_t* ptr);
+    void PrintTensixRegisterData(int setwidth, uint32_t datum, uint16_t data_format);
+    void PrintTypedUint32Array(
+        int setwidth,
+        uint32_t raw_element_count,
+        uint32_t* data,
+        TypedU32_ARRAY_Format force_array_type = TypedU32_ARRAY_Format_INVALID);
+
+    std::string get_completed_line();
+};
+
+}  // namespace tt::tt_metal

--- a/tt_metal/impl/debug/dprint_parser.hpp
+++ b/tt_metal/impl/debug/dprint_parser.hpp
@@ -22,7 +22,7 @@ class DPrintParser {
 public:
     struct ParseResult {
         std::vector<std::string> completed_lines;
-        size_t bytes_consumed;
+        size_t bytes_consumed{};
     };
 
     explicit DPrintParser(std::string line_prefix = "");
@@ -32,8 +32,8 @@ public:
 private:
     std::string line_prefix_;
     std::ostringstream intermediate_stream_;
-    DPrintTypeID prev_type_;
-    char most_recent_setw_;
+    DPrintTypeID prev_type_{DPrintTypeID_Count};
+    char most_recent_setw_{0};
 
     // Helper methods (from dprint_server.cpp anonymous namespace)
     static float bfloat16_to_float(uint16_t bfloat_val);
@@ -42,12 +42,12 @@ private:
     static bool StreamEndsWithNewlineChar(const std::ostringstream* stream);
     static void ResetStream(std::ostringstream* stream);
 
-    void PrintTileSlice(uint8_t* ptr);
+    void PrintTileSlice(const uint8_t* ptr);
     void PrintTensixRegisterData(int setwidth, uint32_t datum, uint16_t data_format);
     void PrintTypedUint32Array(
         int setwidth,
         uint32_t raw_element_count,
-        uint32_t* data,
+        const uint32_t* data,
         TypedU32_ARRAY_Format force_array_type = TypedU32_ARRAY_Format_INVALID);
 
     std::string get_completed_line();


### PR DESCRIPTION
### Ticket
Self-motivated :)

### Problem description
dprint_server.cpp was a big ball of mud

### What's changed
Code parsing dprint protocol has been encapsulated in a class. No functional changes has been made, it's a purely structural code refactor. Having a look on the class interface should be enough here.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes