### PR TITLE
Migrate op to new infra: move

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_move_sharded.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_move_sharded.py
@@ -7,7 +7,7 @@ from loguru import logger
 
 
 import ttnn
-from models.common.utility_functions import comp_pcc, is_wormhole_b0, is_blackhole
+from models.common.utility_functions import comp_pcc
 import torch
 import ttnn
 
@@ -16,7 +16,6 @@ shapes = [
 ]
 
 
-@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="disabled due to watcher error, see issue #5863")
 @pytest.mark.parametrize("shape", shapes)
 def test_move_op(shape, device):
     run_move_op(shape, device)

--- a/ttnn/cpp/ttnn/operations/data_movement/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/data_movement/CMakeLists.txt
@@ -58,6 +58,7 @@ target_sources(
             fill_pad/device/fill_pad_device_operation.hpp
             fill_rm/fill_rm.hpp
             fill_rm/device/fill_rm_device_operation.hpp
+            move/device/move_device_operation.hpp
             pad/pad.hpp
             permute/permute.hpp
             repeat/repeat.hpp
@@ -141,6 +142,8 @@ target_sources(
         moe_routing_remap/device/moe_routing_remap_program_factory.cpp
         move/device/move_device_operation.cpp
         move/device/move_program_factory.cpp
+        move/device/move_overlap_program_factory.cpp
+        move/device/move_sharded_program_factory.cpp
         move/move.cpp
         non_zero_indices/device/non_zero_indices_device_operation.cpp
         non_zero_indices/device/non_zero_indices_program_factory.cpp

--- a/ttnn/cpp/ttnn/operations/data_movement/copy/device/copy_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/copy/device/copy_device_operation.cpp
@@ -14,8 +14,10 @@ std::tuple<CopyDeviceOperation::operation_attributes_t, CopyDeviceOperation::ten
     const Tensor& input,
     const tt::tt_metal::MemoryConfig& output_mem_config,
     const tt::tt_metal::DataType& output_dtype,
-    const std::optional<Tensor>& preallocated_output) {
-    return {operation_attributes_t{output_mem_config, output_dtype}, tensor_args_t{input, preallocated_output}};
+    const std::optional<Tensor>& preallocated_output,
+    bool backwards) {
+    return {
+        operation_attributes_t{output_mem_config, output_dtype, backwards}, tensor_args_t{input, preallocated_output}};
 }
 
 CopyDeviceOperation::program_factory_t CopyDeviceOperation::select_program_factory(

--- a/ttnn/cpp/ttnn/operations/data_movement/copy/device/copy_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/copy/device/copy_device_operation.hpp
@@ -43,7 +43,8 @@ struct CopyDeviceOperation {
         const Tensor& input,
         const tt::tt_metal::MemoryConfig& output_mem_config,
         const tt::tt_metal::DataType& output_dtype,
-        const std::optional<Tensor>& preallocated_output);
+        const std::optional<Tensor>& preallocated_output,
+        bool backwards = false);
 };
 
 }  // namespace ttnn::operations::data_movement::copy

--- a/ttnn/cpp/ttnn/operations/data_movement/copy/device/copy_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/copy/device/copy_device_operation_types.hpp
@@ -12,6 +12,7 @@ namespace ttnn::operations::data_movement::copy {
 struct operation_attributes_t {
     tt::tt_metal::MemoryConfig output_mem_config;
     tt::tt_metal::DataType output_dtype;
+    bool backwards = false;
 };
 
 struct tensor_args_t {

--- a/ttnn/cpp/ttnn/operations/data_movement/copy/device/copy_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/copy/device/copy_program_factory.cpp
@@ -23,7 +23,7 @@ CopyProgramFactory::cached_program_t CopyProgramFactory::create(
     using namespace tt::tt_metal;
 
     const Tensor& input = tensor_args.input;
-    const bool backwards = false;
+    const bool backwards = operation_attributes.backwards;
     Program program{};
 
     const bool tilized = output.layout() == Layout::TILE;

--- a/ttnn/cpp/ttnn/operations/data_movement/move/device/move_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/move/device/move_device_operation.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -6,53 +6,76 @@
 #include "ttnn/tensor/tensor_utils.hpp"
 #include "ttnn/operations/data_movement/common/common.hpp"
 
-using namespace tt::constants;
-using namespace tt::tt_metal;
+namespace ttnn::operations::data_movement::move {
 
-namespace ttnn::operations::data_movement {
-
-void MoveDeviceOperation::validate(const std::vector<Tensor>& input_tensors) const {}
-
-std::vector<ttnn::TensorSpec> MoveDeviceOperation::compute_output_specs(
-    const std::vector<Tensor>& input_tensors) const {
-    return {input_tensors.at(1).tensor_spec()};
-}
-
-std::vector<Tensor> MoveDeviceOperation::create_output_tensors(const std::vector<Tensor>& input_tensors) const {
-    return {input_tensors.at(1)};
-}
-
-operation::ProgramWithCallbacks MoveDeviceOperation::create_program(
-    const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const {
-    const auto& input_tensor = input_tensors.at(0);
-    auto& output_tensor = output_tensors.at(0);
-
-    auto parallelization_strategy = this->move_op_parallelization_strategy;
-    switch (parallelization_strategy) {
-        case MoveOpParallelizationStrategy::MULTI_CORE_OVERLAP:
-            return move_multi_core_with_overlap(input_tensor, output_tensor);
-        case MoveOpParallelizationStrategy::MULTI_CORE_SHARDED:
-            return move_multi_core_sharded(input_tensor, output_tensor);
-        case MoveOpParallelizationStrategy::MULTI_CORE:
-        default: return move_multi_core(input_tensor, output_tensor);
+MoveDeviceOperation::program_factory_t MoveDeviceOperation::select_program_factory(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    switch (operation_attributes.move_op_parallelization_strategy) {
+        case MoveOpParallelizationStrategy::MULTI_CORE_SHARDED: return program::MoveShardedProgramFactory{};
+        case MoveOpParallelizationStrategy::MULTI_CORE_OVERLAP: return program::MoveOverlapProgramFactory{};
+        case MoveOpParallelizationStrategy::MULTI_CORE: return program::MoveProgramFactory{};
+        default: TT_FATAL(false, "Invalid move operation parallelization strategy");
     }
 }
-tt::tt_metal::operation::OpPerformanceModelGeneral<std::vector<Tensor>>
+
+void MoveDeviceOperation::validate_on_program_cache_miss(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    // TODO: #33357
+}
+
+void MoveDeviceOperation::validate_on_program_cache_hit(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    // TODO: #33357
+}
+
+MoveDeviceOperation::spec_return_value_t MoveDeviceOperation::compute_output_specs(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    // Output spec is same as output tensor spec
+    return tensor_args.output_tensor.tensor_spec();
+}
+
+MoveDeviceOperation::tensor_return_value_t MoveDeviceOperation::create_output_tensors(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    // Output tensor is already created and passed in tensor_args
+    return tensor_args.output_tensor;
+}
+
+tt::tt_metal::operation::OpPerformanceModelGeneral<MoveDeviceOperation::tensor_return_value_t>
 MoveDeviceOperation::create_op_performance_model(
-    const std::vector<Tensor>& input_tensors,
-    const std::vector<std::optional<const Tensor>>& optional_input_tensors,
-    std::vector<Tensor>& output_tensors) const {
-    const auto& input_tensor = input_tensors.at(0);
-    const auto& output_tensor = output_tensors.at(0);
-    int ideal_dev_clock_cycles = common_tm_bw_model(input_tensor, output_tensor);
-    tt::tt_metal::operation::OpPerformanceModelGeneral<std::vector<Tensor>> result(
-        input_tensors, output_tensors, ideal_dev_clock_cycles);
+    const operation_attributes_t& operation_attributes,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& tensor_return_value) {
+    const auto& input_tensor = tensor_args.input_tensor;
+    const auto& output_tensor = tensor_return_value;
+    const int ideal_dev_clock_cycles = common_tm_bw_model(input_tensor, output_tensor);
+    tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> result(
+        {input_tensor}, output_tensor, ideal_dev_clock_cycles);
     return result;
 }
 
-MoveOpParallelizationStrategy MoveDeviceOperation::get_parallelization_strategy(
-    const std::vector<Tensor>& input_tensors) const {
-    return this->move_op_parallelization_strategy;
+std::tuple<MoveDeviceOperation::operation_attributes_t, MoveDeviceOperation::tensor_args_t> MoveDeviceOperation::invoke(
+    const Tensor& input_tensor,
+    const Tensor& output_tensor,
+    const tt::tt_metal::MemoryConfig& output_mem_config,
+    const MoveOpParallelizationStrategy& move_op_parallelization_strategy) {
+    bool backwards = false;
+    if (move_op_parallelization_strategy == MoveOpParallelizationStrategy::MULTI_CORE) {
+        Buffer* src_buffer = input_tensor.buffer();
+        Buffer* dst_buffer = output_tensor.buffer();
+        const bool src_and_dst_in_l1 = src_buffer->buffer_type() == tt::tt_metal::BufferType::L1 &&
+                                       dst_buffer->buffer_type() == tt::tt_metal::BufferType::L1;
+        const uint32_t src_base = src_buffer->address();
+        const uint32_t dst_base = dst_buffer->address();
+        const uint32_t copy_size_bytes = dst_buffer->size();
+        const bool ranges_overlap = (src_base < dst_base + copy_size_bytes) && (dst_base < src_base + copy_size_bytes);
+        backwards = src_and_dst_in_l1 && ranges_overlap && (dst_base > src_base);
+    }
+    return {
+        operation_attributes_t{
+            .output_mem_config = output_mem_config,
+            .move_op_parallelization_strategy = move_op_parallelization_strategy,
+            .backwards = backwards},
+        tensor_args_t{.input_tensor = input_tensor, .output_tensor = output_tensor}};
 }
 
-}  // namespace ttnn::operations::data_movement
+}  // namespace ttnn::operations::data_movement::move

--- a/ttnn/cpp/ttnn/operations/data_movement/move/device/move_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/move/device/move_device_operation.hpp
@@ -1,35 +1,61 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
 
-#include <optional>
+#include <variant>
 #include "ttnn/tensor/tensor.hpp"
-#include "ttnn/operation.hpp"
+#include "ttnn/device_operation.hpp"
+#include "ttnn/decorators.hpp"
+#include "move_device_operation_types.hpp"
+#include "move_program_factory.hpp"
+#include "move_overlap_program_factory.hpp"
+#include "move_sharded_program_factory.hpp"
 
-namespace ttnn::operations::data_movement {
-
-enum class MoveOpParallelizationStrategy { MULTI_CORE, MULTI_CORE_OVERLAP, MULTI_CORE_SHARDED };
+namespace ttnn::operations::data_movement::move {
 
 struct MoveDeviceOperation {
-    const tt::tt_metal::MemoryConfig output_mem_config;
-    const MoveOpParallelizationStrategy move_op_parallelization_strategy;
+    // Type aliases
+    using operation_attributes_t = move::operation_attributes_t;
+    using tensor_args_t = move::tensor_args_t;
+    using tensor_return_value_t = move::tensor_return_value_t;
+    using spec_return_value_t = ttnn::TensorSpec;
 
-    void validate(const std::vector<Tensor>& input_tensors) const;
-    std::vector<ttnn::TensorSpec> compute_output_specs(const std::vector<Tensor>& input_tensors) const;
-    std::vector<Tensor> create_output_tensors(const std::vector<Tensor>& input_tensors) const;
-    tt::tt_metal::operation::ProgramWithCallbacks create_program(
-        const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const;
-    MoveOpParallelizationStrategy get_parallelization_strategy(const std::vector<Tensor>& input_tensors) const;
-    tt::tt_metal::operation::OpPerformanceModelGeneral<std::vector<Tensor>> create_op_performance_model(
-        const std::vector<Tensor>& input_tensors,
-        const std::vector<std::optional<const Tensor>>& optional_input_tensors,
-        std::vector<Tensor>& output_tensors) const;
+    using program_factory_t = std::
+        variant<program::MoveProgramFactory, program::MoveOverlapProgramFactory, program::MoveShardedProgramFactory>;
+
+    static program_factory_t select_program_factory(
+        const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
+
+    static void validate_on_program_cache_miss(
+        const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
+
+    static void validate_on_program_cache_hit(
+        const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
+
+    static spec_return_value_t compute_output_specs(
+        const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
+
+    static tensor_return_value_t create_output_tensors(
+        const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
+
+    static tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> create_op_performance_model(
+        const operation_attributes_t& operation_attributes,
+        const tensor_args_t& tensor_args,
+        tensor_return_value_t& tensor_return_value);
+
+    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
+        const Tensor& input_tensor,
+        const Tensor& output_tensor,
+        const tt::tt_metal::MemoryConfig& output_mem_config,
+        const MoveOpParallelizationStrategy& move_op_parallelization_strategy);
 };
 
-tt::tt_metal::operation::ProgramWithCallbacks move_multi_core(const Tensor& input, Tensor& output);
-tt::tt_metal::operation::ProgramWithCallbacks move_multi_core_with_overlap(const Tensor& input, Tensor& output);
-tt::tt_metal::operation::ProgramWithCallbacks move_multi_core_sharded(const Tensor& input, Tensor& output);
+}  // namespace ttnn::operations::data_movement::move
 
-}  // namespace ttnn::operations::data_movement
+// Register the operation in ttnn::prim namespace
+namespace ttnn::prim {
+constexpr auto move =
+    ttnn::register_operation<"ttnn::prim::move", ttnn::operations::data_movement::move::MoveDeviceOperation>();
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/move/device/move_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/move/device/move_device_operation_types.hpp
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/tensor/tensor.hpp"
+#include <tt-metalium/constants.hpp>
+
+namespace ttnn::operations::data_movement::move {
+
+enum class MoveOpParallelizationStrategy { MULTI_CORE, MULTI_CORE_OVERLAP, MULTI_CORE_SHARDED };
+
+// Operation attributes - non-tensor parameters
+struct operation_attributes_t {
+    tt::tt_metal::MemoryConfig output_mem_config;
+    MoveOpParallelizationStrategy move_op_parallelization_strategy;
+    bool backwards = false;
+};
+
+// Tensor arguments - tensor parameters
+struct tensor_args_t {
+    Tensor input_tensor;
+    Tensor output_tensor;
+};
+
+// Return types
+using tensor_return_value_t = Tensor;
+
+}  // namespace ttnn::operations::data_movement::move

--- a/ttnn/cpp/ttnn/operations/data_movement/move/device/move_overlap_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/move/device/move_overlap_program_factory.cpp
@@ -1,0 +1,210 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "move_device_operation_types.hpp"
+#include "move_overlap_program_factory.hpp"
+
+#include <cmath>
+#include <tt-metalium/work_split.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/allocator.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/hal.hpp>
+
+namespace ttnn::operations::data_movement::move::program {
+
+namespace {
+
+std::vector<CoreRange> get_multicast_regions(
+    const IDevice* device, const CoreRangeSet& all_cores, const CoreCoord& logical_controller) {
+    TT_ASSERT(!all_cores.ranges().empty() and all_cores.ranges().size() <= 2);
+    const CoreCoord logical_zero = {0, 0};
+    TT_ASSERT(logical_controller == logical_zero);
+
+    std::vector<CoreRange> logical_core_ranges;
+    auto split_core_range_containing_controller = [&](const CoreRange& controller_core_range) {
+        TT_ASSERT(controller_core_range.start_coord == logical_controller);
+        CoreRange right_block(
+            CoreCoord(logical_controller.x + 1, logical_controller.y), controller_core_range.end_coord);
+        CoreRange remaining_stick = CoreRange(
+            CoreCoord(logical_controller.x, logical_controller.y + 1),
+            CoreCoord(logical_controller.x, controller_core_range.end_coord.y));
+
+        logical_core_ranges.push_back(right_block);
+        logical_core_ranges.push_back(remaining_stick);
+    };
+
+    CoreRange range_0 = *all_cores.ranges().begin();
+    if (all_cores.ranges().size() == 1) {
+        split_core_range_containing_controller(range_0);
+    } else {
+        CoreRange range_1 = *all_cores.ranges().rbegin();
+        if (range_0.start_coord == logical_controller) {
+            split_core_range_containing_controller(range_0);
+            logical_core_ranges.push_back(range_1);
+        } else if (range_1.start_coord == logical_controller) {
+            split_core_range_containing_controller(range_1);
+            logical_core_ranges.push_back(range_0);
+        } else {
+            TT_THROW("Core {} is not included in set of core ranges!", logical_controller.str());
+        }
+    }
+
+    TT_ASSERT(logical_core_ranges.size() == 2 or logical_core_ranges.size() == 3);
+    return logical_core_ranges;
+}
+
+}  // namespace
+
+MoveOverlapProgramFactory::cached_program_t MoveOverlapProgramFactory::create(
+    const operation_attributes_t& operation_attributes,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& tensor_return_value) {
+    using namespace tt::constants;
+
+    const Tensor& input = tensor_args.input_tensor;
+    const tensor_return_value_t& output = tensor_return_value;
+    tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
+
+    const tt::DataFormat cb_data_format = datatype_to_dataformat_converter(input.dtype());
+    const bool tilized = input.layout() == Layout::TILE;
+    const uint32_t page_size = input.buffer()->page_size();
+
+    const uint32_t num_pages =
+        tilized ? (output.physical_volume() / TILE_HW) : (output.physical_volume() / output.padded_shape()[-1]);
+    const tt::tt_metal::IDevice* device = output.device();
+    const CoreCoord compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    const uint32_t num_cores_y = compute_with_storage_grid_size.y;
+    auto [num_cores, all_cores, core_group_1, core_group_2, num_pages_per_core_group_1, num_pages_per_core_group_2] =
+        tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_pages);
+
+    const auto num_l1_banks = compute_with_storage_grid_size.x * compute_with_storage_grid_size.y;
+    const uint32_t size_per_l1_bank = tt::tt_metal::detail::calculate_bank_size_spread(
+        output.buffer()->size(), output.buffer()->page_size(), num_l1_banks, tt::tt_metal::hal::get_l1_alignment());
+
+    // CB is being used as temp L1 buffer to copy src data into before writing to dst
+    uint32_t cb_index = 0;
+    const uint32_t aligned_page_size = round_up_to_mul32(page_size);
+    const tt::tt_metal::CircularBufferConfig cb_config =
+        tt::tt_metal::CircularBufferConfig(size_per_l1_bank, {{cb_index, cb_data_format}})
+            .set_page_size(cb_index, aligned_page_size);
+    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_config);
+
+    auto semaphore_id = tt::tt_metal::CreateSemaphore(program, all_cores, 0);
+
+    Buffer* src_buffer = input.buffer();
+    Buffer* dst_buffer = output.buffer();
+
+    std::vector<uint32_t> compile_time_args = {cb_index};
+    if (!tilized) {
+        compile_time_args.push_back(page_size);
+    }
+    tt::tt_metal::TensorAccessorArgs(*src_buffer).append_to(compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(*dst_buffer).append_to(compile_time_args);
+
+    const std::string kernel_path =
+        tilized
+            ? "ttnn/cpp/ttnn/operations/data_movement/move/device/kernels/dataflow/move_interleaved_with_overlap.cpp"
+            : "ttnn/cpp/ttnn/operations/data_movement/move/device/kernels/dataflow/"
+              "move_stick_layout_interleaved_with_overlap.cpp";
+
+    const tt::tt_metal::KernelHandle kernel_id = tt::tt_metal::CreateKernel(
+        program, kernel_path, all_cores, tt::tt_metal::DataMovementConfig{.compile_args = compile_time_args});
+
+    const CoreCoord logical_controller = CoreCoord{0, 0};
+    const CoreCoord noc_controller = device->worker_core_from_logical_core(logical_controller);
+    std::vector<CoreRange> logical_multicast_regions = get_multicast_regions(device, all_cores, logical_controller);
+
+    std::vector<CoreRange> noc_multicast_regions;
+    for (const auto& logical_cr : logical_multicast_regions) {
+        const CoreRange noc_cr(
+            device->worker_core_from_logical_core(logical_cr.start_coord),
+            device->worker_core_from_logical_core(logical_cr.end_coord));
+        noc_multicast_regions.push_back(noc_cr);
+    }
+
+    const CoreRange range_0_noc = noc_multicast_regions[0];
+    const CoreRange range_1_noc = noc_multicast_regions[1];
+    const bool do_third_multicast = (noc_multicast_regions.size() == 3);
+
+    for (uint32_t i = 0, pages_handled_per_core = 0; i < num_cores; i++) {
+        const CoreCoord core = {i / num_cores_y, i % num_cores_y};
+        uint32_t num_pages_per_core = 0;
+        if (core_group_1.contains(core)) {
+            num_pages_per_core = num_pages_per_core_group_1;
+        } else if (core_group_2.contains(core)) {
+            num_pages_per_core = num_pages_per_core_group_2;
+        } else {
+            TT_THROW("Core not in specified core ranges");
+        }
+
+        const bool is_controller = (i == 0);
+        std::vector<uint32_t> runtime_args = {
+            src_buffer->address(),
+            dst_buffer->address(),
+            pages_handled_per_core,
+            num_pages_per_core,
+            semaphore_id,
+            (uint32_t)noc_controller.x,
+            (uint32_t)noc_controller.y,
+            /*control_value=*/(num_cores - 1),
+            (uint32_t)is_controller,
+            (uint32_t)range_0_noc.start_coord.x,
+            (uint32_t)range_0_noc.start_coord.y,
+            (uint32_t)range_0_noc.end_coord.x,
+            (uint32_t)range_0_noc.end_coord.y,
+            (uint32_t)logical_multicast_regions[0].size(),
+            (uint32_t)range_1_noc.start_coord.x,
+            (uint32_t)range_1_noc.start_coord.y,
+            (uint32_t)range_1_noc.end_coord.x,
+            (uint32_t)range_1_noc.end_coord.y,
+            (uint32_t)logical_multicast_regions[1].size(),
+            (uint32_t)noc_multicast_regions.back().start_coord.x,
+            (uint32_t)noc_multicast_regions.back().start_coord.y,
+            (uint32_t)noc_multicast_regions.back().end_coord.x,
+            (uint32_t)noc_multicast_regions.back().end_coord.y,
+            (uint32_t)logical_multicast_regions.back().size(),
+            (uint32_t)do_third_multicast};
+        if (!tilized) {
+            runtime_args.push_back(aligned_page_size);
+        }
+        SetRuntimeArgs(program, kernel_id, core, runtime_args);
+        pages_handled_per_core += num_pages_per_core;
+    }
+
+    return {
+        std::move(program),
+        MoveOverlapProgramFactory::shared_variables_t{.reader_kernel_id = kernel_id, .num_cores = num_cores}};
+}
+
+void MoveOverlapProgramFactory::override_runtime_arguments(
+    MoveOverlapProgramFactory::cached_program_t& cached_program,
+    const operation_attributes_t& operation_attributes,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& tensor_return_value) {
+    using namespace tt::tt_metal;
+
+    auto& program = cached_program.program;
+    const Tensor& input = tensor_args.input_tensor;
+    tensor_return_value_t& output = tensor_return_value;
+
+    Buffer* src_buffer = input.buffer();
+    Buffer* dst_buffer = output.buffer();
+    const uint32_t num_cores = cached_program.shared_variables.num_cores;
+    const tt::tt_metal::KernelHandle reader_kernel_id = cached_program.shared_variables.reader_kernel_id;
+
+    const CoreCoord compute_with_storage_grid_size = output.device()->compute_with_storage_grid_size();
+    const uint32_t num_cores_x = compute_with_storage_grid_size.x;
+    const uint32_t num_cores_y = compute_with_storage_grid_size.y;
+    const auto cores = grid_to_cores(num_cores, num_cores_x, num_cores_y, false);
+
+    for (const CoreCoord& core : cores) {
+        auto& runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
+        runtime_args[0] = src_buffer->address();
+        runtime_args[1] = dst_buffer->address();
+    }
+}
+
+}  // namespace ttnn::operations::data_movement::move::program

--- a/ttnn/cpp/ttnn/operations/data_movement/move/device/move_overlap_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/move/device/move_overlap_program_factory.hpp
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "move_device_operation_types.hpp"
+#include "ttnn/device_operation.hpp"
+
+namespace ttnn::operations::data_movement::move::program {
+
+// Program factory for MULTI_CORE_OVERLAP strategy
+struct MoveOverlapProgramFactory {
+    struct shared_variables_t {
+        tt::tt_metal::KernelHandle reader_kernel_id = 0;
+        uint32_t num_cores = 0;
+    };
+    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
+
+    static cached_program_t create(
+        const operation_attributes_t& operation_attributes,
+        const tensor_args_t& tensor_args,
+        tensor_return_value_t& tensor_return_value);
+
+    static void override_runtime_arguments(
+        cached_program_t& cached_program,
+        const operation_attributes_t& operation_attributes,
+        const tensor_args_t& tensor_args,
+        tensor_return_value_t& tensor_return_value);
+};
+
+}  // namespace ttnn::operations::data_movement::move::program

--- a/ttnn/cpp/ttnn/operations/data_movement/move/device/move_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/move/device/move_program_factory.cpp
@@ -1,336 +1,46 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <math.h>
-
-#include <tt-metalium/work_split.hpp>
-#include "ttnn/operations/data_movement/move/device/move_device_operation.hpp"
-#include "ttnn/operations/math.hpp"
+#include "move_program_factory.hpp"
 #include "ttnn/operations/data_movement/copy/device/copy_program_factory.hpp"
 #include "ttnn/operations/data_movement/copy/device/copy_device_operation_types.hpp"
 
-#include <tt-metalium/host_api.hpp>
-#include <tt-metalium/constants.hpp>
-#include <tt-metalium/allocator.hpp>
-#include <tt-metalium/tensor_accessor_args.hpp>
-#include <algorithm>
+namespace ttnn::operations::data_movement::move::program {
 
-#include <tt-metalium/hal.hpp>
+MoveProgramFactory::cached_program_t MoveProgramFactory::create(
+    const operation_attributes_t& operation_attributes,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& tensor_return_value) {
+    const Tensor& input = tensor_args.input_tensor;
+    const tensor_return_value_t& output = tensor_return_value;
+    using copy_attrs_t = ttnn::operations::data_movement::copy::operation_attributes_t;
+    using copy_args_t = ttnn::operations::data_movement::copy::tensor_args_t;
 
-using namespace tt::constants;
-using namespace tt::tt_metal;
+    const copy_attrs_t copy_attrs{
+        operation_attributes.output_mem_config, output.dtype(), operation_attributes.backwards};
+    const copy_args_t copy_args{input, std::make_optional(output)};
 
-namespace ttnn::operations::data_movement {
-
-std::vector<CoreRange> get_multicast_regions(
-    const IDevice* device, const CoreRangeSet& all_cores, const CoreCoord& logical_controller) {
-    TT_ASSERT(!all_cores.ranges().empty() and all_cores.ranges().size() <= 2);
-    CoreCoord logical_zero = {0, 0};
-    TT_ASSERT(logical_controller == logical_zero);
-
-    std::vector<CoreRange> logical_core_ranges;
-    auto split_core_range_containing_controller = [&](const CoreRange& controller_core_range) {
-        TT_ASSERT(controller_core_range.start_coord == logical_controller);
-        CoreRange right_block(
-            CoreCoord(logical_controller.x + 1, logical_controller.y), controller_core_range.end_coord);
-        CoreRange remaining_stick = CoreRange(
-            CoreCoord(logical_controller.x, logical_controller.y + 1),
-            CoreCoord(logical_controller.x, controller_core_range.end_coord.y));
-
-        logical_core_ranges.push_back(right_block);
-        logical_core_ranges.push_back(remaining_stick);
-    };
-
-    CoreRange range_0 = *all_cores.ranges().begin();
-    if (all_cores.ranges().size() == 1) {
-        split_core_range_containing_controller(range_0);
-    } else {
-        CoreRange range_1 = *all_cores.ranges().rbegin();
-        if (range_0.start_coord == logical_controller) {
-            split_core_range_containing_controller(range_0);
-            logical_core_ranges.push_back(range_1);
-        } else if (range_1.start_coord == logical_controller) {
-            split_core_range_containing_controller(range_1);
-            logical_core_ranges.push_back(range_0);
-        } else {
-            TT_THROW("Core {} is not included in set of core ranges!", logical_controller.str());
-        }
-    }
-
-    TT_ASSERT(logical_core_ranges.size() == 2 or logical_core_ranges.size() == 3);
-    return logical_core_ranges;
+    return ttnn::operations::data_movement::copy::program::CopyProgramFactory::create(
+        copy_attrs, copy_args, tensor_return_value);
 }
 
-// This variant of move is invoked when the input buffer and output buffer overlap, which is possible because input
-// buffer is deallocated before the op runs. In this case, data in each core needs to be moved to a temporary local
-// location before being copied into the output buffer
-tt::tt_metal::operation::ProgramWithCallbacks move_multi_core_with_overlap(const Tensor& input, Tensor& output) {
-    tt::tt_metal::Program program{};
+void MoveProgramFactory::override_runtime_arguments(
+    MoveProgramFactory::cached_program_t& cached_program,
+    const operation_attributes_t& operation_attributes,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& tensor_return_value) {
+    using copy_attrs_t = ttnn::operations::data_movement::copy::operation_attributes_t;
+    using copy_args_t = ttnn::operations::data_movement::copy::tensor_args_t;
+    const Tensor& input = tensor_args.input_tensor;
+    const tensor_return_value_t& output = tensor_return_value;
 
-    tt::DataFormat cb_data_format = datatype_to_dataformat_converter(input.dtype());
+    const copy_attrs_t copy_attrs{
+        operation_attributes.output_mem_config, output.dtype(), operation_attributes.backwards};
+    const copy_args_t copy_args{input, std::make_optional(output)};
 
-    bool tilized = input.layout() == Layout::TILE;
-
-    uint32_t page_size = input.buffer()->page_size();
-
-    uint32_t num_pages =
-        tilized ? output.physical_volume() / TILE_HW : output.physical_volume() / output.padded_shape()[-1];
-    tt::tt_metal::IDevice* device = output.device();
-    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
-    uint32_t num_cores_y = compute_with_storage_grid_size.y;
-    auto [num_cores, all_cores, core_group_1, core_group_2, num_pages_per_core_group_1, num_pages_per_core_group_2] =
-        tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_pages);
-
-    const auto num_l1_banks = compute_with_storage_grid_size.x * compute_with_storage_grid_size.y;
-
-    uint32_t size_per_l1_bank = tt::tt_metal::detail::calculate_bank_size_spread(
-        output.buffer()->size(), output.buffer()->page_size(), num_l1_banks, hal::get_l1_alignment());
-
-    // CB is being used as temp L1 buffer to copy src data into before writing to dst
-    uint32_t cb_index = 0;
-    uint32_t aligned_page_size = round_up_to_mul32(page_size);
-    tt::tt_metal::CircularBufferConfig cb_config =
-        tt::tt_metal::CircularBufferConfig(size_per_l1_bank, {{cb_index, cb_data_format}})
-            .set_page_size(cb_index, aligned_page_size);
-    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_config);
-
-    auto semaphore_id = CreateSemaphore(program, all_cores, 0);
-
-    auto* src_buffer = input.buffer();
-    auto* dst_buffer = output.buffer();
-
-    std::vector<uint32_t> compile_time_args = {cb_index};
-    if (!tilized) {
-        compile_time_args.push_back(page_size);
-    }
-    TensorAccessorArgs(*src_buffer).append_to(compile_time_args);
-    TensorAccessorArgs(*dst_buffer).append_to(compile_time_args);
-
-    KernelHandle kernel_id = CreateKernel(
-        program,
-        tilized
-            ? "ttnn/cpp/ttnn/operations/data_movement/move/device/kernels/dataflow/move_interleaved_with_overlap.cpp"
-            : "ttnn/cpp/ttnn/operations/data_movement/move/device/kernels/dataflow/"
-              "move_stick_layout_interleaved_with_overlap.cpp",
-        all_cores,
-        DataMovementConfig{.compile_args = compile_time_args});
-
-    const CoreCoord logical_controller = CoreCoord{0, 0};
-    CoreCoord noc_controller = device->worker_core_from_logical_core(logical_controller);
-    std::vector<CoreRange> logical_multicast_regions = get_multicast_regions(device, all_cores, logical_controller);
-
-    std::vector<CoreRange> noc_multicast_regions;
-    for (const auto& logical_cr : logical_multicast_regions) {
-        CoreRange noc_cr(
-            device->worker_core_from_logical_core(logical_cr.start_coord),
-            device->worker_core_from_logical_core(logical_cr.end_coord));
-        noc_multicast_regions.push_back(noc_cr);
-    }
-
-    CoreRange range_0_noc = noc_multicast_regions[0];
-    CoreRange range_1_noc = noc_multicast_regions[1];
-    // if third multicast is not needed range_2_noc will be ignored
-    bool do_third_multicast = (noc_multicast_regions.size() == 3);
-
-    for (uint32_t i = 0, pages_handled_per_core = 0; i < num_cores; i++) {
-        CoreCoord core = {i / num_cores_y, i % num_cores_y};
-        uint32_t num_pages_per_core = 0;
-        if (core_group_1.contains(core)) {
-            num_pages_per_core = num_pages_per_core_group_1;
-        } else if (core_group_2.contains(core)) {
-            num_pages_per_core = num_pages_per_core_group_2;
-        } else {
-            TT_THROW("Core not in specified core ranges");
-        }
-
-        bool is_controller = (i == 0);
-        std::vector<uint32_t> runtime_args = {
-            src_buffer->address(),
-            dst_buffer->address(),
-            pages_handled_per_core,
-            num_pages_per_core,
-            semaphore_id,
-            (uint32_t)noc_controller.x,
-            (uint32_t)noc_controller.y,
-            /*control_value=*/(num_cores - 1),
-            (uint32_t)is_controller,
-            (uint32_t)range_0_noc.start_coord.x,
-            (uint32_t)range_0_noc.start_coord.y,
-            (uint32_t)range_0_noc.end_coord.x,
-            (uint32_t)range_0_noc.end_coord.y,
-            (uint32_t)logical_multicast_regions[0].size(),
-            (uint32_t)range_1_noc.start_coord.x,
-            (uint32_t)range_1_noc.start_coord.y,
-            (uint32_t)range_1_noc.end_coord.x,
-            (uint32_t)range_1_noc.end_coord.y,
-            (uint32_t)logical_multicast_regions[1].size(),
-            (uint32_t)noc_multicast_regions.back().start_coord.x,
-            (uint32_t)noc_multicast_regions.back().start_coord.y,
-            (uint32_t)noc_multicast_regions.back().end_coord.x,
-            (uint32_t)noc_multicast_regions.back().end_coord.y,
-            (uint32_t)logical_multicast_regions.back().size(),
-            (uint32_t)do_third_multicast};
-        if (!tilized) {
-            runtime_args.push_back(aligned_page_size);
-        }
-        SetRuntimeArgs(program, kernel_id, core, runtime_args);
-        pages_handled_per_core += num_pages_per_core;
-    }
-
-    auto override_runtime_args_callback = [kernel_id, num_cores, num_cores_y](
-                                              const void* operation,
-                                              Program& program,
-                                              const std::vector<Tensor>& input_tensors,
-                                              const std::vector<std::optional<const Tensor>>&,
-                                              const std::vector<Tensor>& output_tensors) {
-        auto* src_buffer = input_tensors.at(0).buffer();
-        auto* dst_buffer = output_tensors.at(0).buffer();
-
-        for (uint32_t i = 0; i < num_cores; i++) {
-            CoreCoord core = {i / num_cores_y, i % num_cores_y};
-            {
-                auto& runtime_args = GetRuntimeArgs(program, kernel_id, core);
-                runtime_args[0] = src_buffer->address();
-                runtime_args[1] = dst_buffer->address();
-            }
-        }
-    };
-
-    return {std::move(program), override_runtime_args_callback};
-}
-
-// Sharded buffers are mapped to CBs. Move from top of src CB to dst CB
-operation::ProgramWithCallbacks move_multi_core_sharded(const Tensor& input, Tensor& output) {
-    tt::tt_metal::Program program{};
-
-    tt::DataFormat cb_data_format = datatype_to_dataformat_converter(input.dtype());
-    auto shard_spec = input.shard_spec().value();
-    auto shard_shape = shard_spec.shape;
-    auto shard_grid = shard_spec.grid;
-    const auto& input_shape = input.logical_shape();
-    auto input_dtype = input.dtype();
-    auto input_layout = input.layout();
-    TT_FATAL(
-        input_layout == output.layout() && input_dtype == output.dtype() &&
-            shard_shape == output.shard_spec().value().shape && input_shape == output.logical_shape(),
-        "Error");
-    const uint32_t src_cb_sharded = tt::CBIndex::c_0;
-    const uint32_t dst_cb_sharded = tt::CBIndex::c_1;
-
-    uint32_t total_size_bytes = input.buffer()->aligned_size_per_bank();
-    uint32_t page_size_bytes = input.buffer()->aligned_page_size();
-
-    CircularBufferConfig src_cb_sharded_config =
-        CircularBufferConfig(total_size_bytes, {{src_cb_sharded, cb_data_format}})
-            .set_page_size(src_cb_sharded, page_size_bytes);
-    src_cb_sharded_config.set_globally_allocated_address(*input.buffer());
-    auto src_sharded_cb = tt::tt_metal::CreateCircularBuffer(program, shard_grid, src_cb_sharded_config);
-
-    CircularBufferConfig dst_cb_sharded_config =
-        CircularBufferConfig(total_size_bytes, {{dst_cb_sharded, cb_data_format}})
-            .set_page_size(dst_cb_sharded, page_size_bytes);
-    dst_cb_sharded_config.set_globally_allocated_address(*output.buffer());
-    auto dst_sharded_cb = tt::tt_metal::CreateCircularBuffer(program, shard_grid, dst_cb_sharded_config);
-
-    auto input_buffer_address = input.buffer()->address();
-    auto output_buffer_address = output.buffer()->address();
-
-    uint32_t move_chunk_size_bytes = output_buffer_address - input_buffer_address;
-    TT_FATAL(
-        input.buffer()->alignment() == output.buffer()->alignment(),
-        "Expected input buffer alignment ({} B) and output buffer alignment ({} B) to be equal",
-        input.buffer()->alignment(),
-        output.buffer()->alignment());
-    TT_FATAL(
-        move_chunk_size_bytes % input.buffer()->alignment() == 0,
-        "Expected chunk size bytes to move to be {} byte aligned.",
-        input.buffer()->alignment());
-    uint32_t num_chunks = total_size_bytes / move_chunk_size_bytes;
-    uint32_t remainder_chunk_size_bytes = total_size_bytes % move_chunk_size_bytes;
-
-    std::vector<uint32_t> reader_compile_time_args = {src_cb_sharded, dst_cb_sharded};
-    KernelHandle kernel_id = CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/data_movement/move/device/kernels/dataflow/reader_unary_local_l1_copy_backwards.cpp",
-        shard_grid,
-        DataMovementConfig{
-            .processor = DataMovementProcessor::RISCV_1, .noc = NOC::NOC_1, .compile_args = reader_compile_time_args});
-    const std::array runtime_args = {total_size_bytes, num_chunks, move_chunk_size_bytes, remainder_chunk_size_bytes};
-    SetRuntimeArgs(program, kernel_id, shard_grid, runtime_args);
-
-    const auto& cores = corerange_to_cores(shard_grid, std::nullopt, true);
-    auto override_runtime_args_callback = [shard_grid = shard_grid,
-                                           kernel_id = kernel_id,
-                                           src_sharded_cb = src_sharded_cb,
-                                           dst_sharded_cb = dst_sharded_cb,
-                                           total_size_bytes = total_size_bytes,
-                                           cores = cores](
-                                              const void* operation,
-                                              Program& program,
-                                              const std::vector<Tensor>& input_tensors,
-                                              const std::vector<std::optional<const Tensor>>& optional_input_tensors,
-                                              const std::vector<Tensor>& output_tensors) {
-        auto* src_buffer = input_tensors.at(0).buffer();
-        auto* dst_buffer = output_tensors.at(0).buffer();
-        UpdateDynamicCircularBufferAddress(program, src_sharded_cb, *src_buffer);
-        UpdateDynamicCircularBufferAddress(program, dst_sharded_cb, *dst_buffer);
-        auto input_buffer_address = src_buffer->address();
-        auto output_buffer_address = dst_buffer->address();
-        uint32_t move_chunk_size_bytes = output_buffer_address - input_buffer_address;
-        uint32_t num_chunks = total_size_bytes / move_chunk_size_bytes;
-        uint32_t remainder_chunk_size_bytes = total_size_bytes % move_chunk_size_bytes;
-        std::vector<uint32_t> new_runtime_args = {
-            total_size_bytes, num_chunks, move_chunk_size_bytes, remainder_chunk_size_bytes};
-        auto& runtime_args_by_core = GetRuntimeArgs(program, kernel_id);
-        for (const auto& core : cores) {
-            auto& runtime_args = runtime_args_by_core[core.x][core.y];
-            std::copy(new_runtime_args.begin(), new_runtime_args.end(), runtime_args.data());
-        }
-    };
-
-    return {.program = std::move(program), .override_runtime_arguments_callback = override_runtime_args_callback};
-}
-
-operation::ProgramWithCallbacks move_multi_core(const Tensor& input, Tensor& output) {
-    // Move operation uses copy factory under the hood
-    // Note: The backwards/src_and_dst_in_l1 parameter was never actually used in the implementation
-    using namespace ttnn::operations::data_movement::copy;
-
-    const copy::operation_attributes_t operation_attributes{output.memory_config(), output.dtype()};
-    const copy::tensor_args_t tensor_args{input, std::make_optional(output)};
-
-    copy::program::CopyProgramFactory::cached_program_t cached_program =
-        copy::program::CopyProgramFactory::create(operation_attributes, tensor_args, output);
-
-    // Extract shared variables for the callback
-    const tt::tt_metal::KernelHandle unary_reader_kernel_id = cached_program.shared_variables.unary_reader_kernel_id;
-    const tt::tt_metal::KernelHandle unary_writer_kernel_id = cached_program.shared_variables.unary_writer_kernel_id;
-    const std::vector<CoreCoord> cores = cached_program.shared_variables.cores;
-
-    auto override_runtime_args_callback = [unary_reader_kernel_id, unary_writer_kernel_id, cores](
-                                              const void* operation,
-                                              tt::tt_metal::Program& program,
-                                              const std::vector<Tensor>& input_tensors,
-                                              const std::vector<std::optional<const Tensor>>&,
-                                              const std::vector<Tensor>& output_tensors) {
-        using namespace tt::tt_metal;
-        Buffer* const src_buffer = input_tensors.at(0).buffer();
-        Buffer* const dst_buffer = output_tensors.at(0).buffer();
-
-        for (const CoreCoord& core : cores) {
-            {
-                RuntimeArgsData& runtime_args = GetRuntimeArgs(program, unary_reader_kernel_id, core);
-                runtime_args[0] = src_buffer->address();
-            }
-            {
-                RuntimeArgsData& runtime_args = GetRuntimeArgs(program, unary_writer_kernel_id, core);
-                runtime_args[0] = dst_buffer->address();
-            }
-        }
-    };
-
-    return {std::move(cached_program.program), override_runtime_args_callback};
+    ttnn::operations::data_movement::copy::program::CopyProgramFactory::override_runtime_arguments(
+        cached_program, copy_attrs, copy_args, tensor_return_value);
 }
 
 }  // namespace ttnn::operations::data_movement

--- a/ttnn/cpp/ttnn/operations/data_movement/move/device/move_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/move/device/move_program_factory.hpp
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "move_device_operation_types.hpp"
+#include "ttnn/device_operation.hpp"
+#include "ttnn/operations/data_movement/copy/device/copy_program_factory.hpp"
+
+namespace ttnn::operations::data_movement::move::program {
+
+// Program factory for MULTI_CORE and MULTI_CORE_OVERLAP strategies
+struct MoveProgramFactory {
+    using shared_variables_t = ttnn::operations::data_movement::copy::program::CopySharedVariables;
+    using cached_program_t = ttnn::operations::data_movement::copy::program::CopyProgramFactory::cached_program_t;
+
+    static cached_program_t create(
+        const operation_attributes_t& operation_attributes,
+        const tensor_args_t& tensor_args,
+        tensor_return_value_t& tensor_return_value);
+
+    static void override_runtime_arguments(
+        cached_program_t& cached_program,
+        const operation_attributes_t& operation_attributes,
+        const tensor_args_t& tensor_args,
+        tensor_return_value_t& tensor_return_value);
+};
+
+}  // namespace ttnn::operations::data_movement::move::program

--- a/ttnn/cpp/ttnn/operations/data_movement/move/device/move_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/move/device/move_sharded_program_factory.cpp
@@ -1,0 +1,129 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "move_sharded_program_factory.hpp"
+
+#include <cmath>
+#include <tt-metalium/work_split.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/allocator.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/hal.hpp>
+
+namespace ttnn::operations::data_movement::move::program {
+
+MoveShardedProgramFactory::cached_program_t MoveShardedProgramFactory::create(
+    const operation_attributes_t& operation_attributes,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& tensor_return_value) {
+    using namespace tt::constants;
+    using namespace tt::tt_metal;
+    const Tensor& input = tensor_args.input_tensor;
+    tensor_return_value_t& output = tensor_return_value;
+
+    tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
+
+    tt::DataFormat cb_data_format = datatype_to_dataformat_converter(input.dtype());
+    const auto shard_spec = input.shard_spec().value();
+    const auto shard_shape = shard_spec.shape;
+    const auto shard_grid = shard_spec.grid;
+    const auto& input_shape = input.logical_shape();
+    const DataType input_dtype = input.dtype();
+    const Layout input_layout = input.layout();
+    TT_FATAL(
+        input_layout == output.layout() && input_dtype == output.dtype() &&
+            shard_shape == output.shard_spec().value().shape && input_shape == output.logical_shape(),
+        "Error");
+    const uint32_t src_cb_sharded = tt::CBIndex::c_0;
+    const uint32_t dst_cb_sharded = tt::CBIndex::c_1;
+
+    const uint32_t total_size_bytes = input.buffer()->aligned_size_per_bank();
+    const uint32_t page_size_bytes = input.buffer()->aligned_page_size();
+
+    CircularBufferConfig src_cb_sharded_config =
+        CircularBufferConfig(total_size_bytes, {{src_cb_sharded, cb_data_format}})
+            .set_page_size(src_cb_sharded, page_size_bytes);
+    src_cb_sharded_config.set_globally_allocated_address(*input.buffer());
+    const CBHandle src_sharded_cb = tt::tt_metal::CreateCircularBuffer(program, shard_grid, src_cb_sharded_config);
+
+    CircularBufferConfig dst_cb_sharded_config =
+        CircularBufferConfig(total_size_bytes, {{dst_cb_sharded, cb_data_format}})
+            .set_page_size(dst_cb_sharded, page_size_bytes);
+    dst_cb_sharded_config.set_globally_allocated_address(*output.buffer());
+    const CBHandle dst_sharded_cb = tt::tt_metal::CreateCircularBuffer(program, shard_grid, dst_cb_sharded_config);
+
+    const uint32_t input_buffer_address = input.buffer()->address();
+    const uint32_t output_buffer_address = output.buffer()->address();
+
+    const uint32_t move_chunk_size_bytes = output_buffer_address - input_buffer_address;
+    TT_FATAL(
+        input.buffer()->alignment() == output.buffer()->alignment(),
+        "Expected input buffer alignment ({} B) and output buffer alignment ({} B) to be equal",
+        input.buffer()->alignment(),
+        output.buffer()->alignment());
+    TT_FATAL(
+        move_chunk_size_bytes % input.buffer()->alignment() == 0,
+        "Expected chunk size bytes to move to be {} byte aligned.",
+        input.buffer()->alignment());
+    const uint32_t num_chunks = total_size_bytes / move_chunk_size_bytes;
+    const uint32_t remainder_chunk_size_bytes = total_size_bytes % move_chunk_size_bytes;
+
+    std::vector<uint32_t> reader_compile_time_args = {src_cb_sharded, dst_cb_sharded};
+    KernelHandle kernel_id = CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/data_movement/move/device/kernels/dataflow/reader_unary_local_l1_copy_backwards.cpp",
+        shard_grid,
+        DataMovementConfig{
+            .processor = DataMovementProcessor::RISCV_1, .noc = NOC::NOC_1, .compile_args = reader_compile_time_args});
+
+    const std::array runtime_args = {total_size_bytes, num_chunks, move_chunk_size_bytes, remainder_chunk_size_bytes};
+    tt::tt_metal::SetRuntimeArgs(program, kernel_id, shard_grid, runtime_args);
+
+    return {
+        std::move(program),
+        MoveShardedProgramFactory::shared_variables_t{
+            .kernel_id = kernel_id,
+            .src_sharded_cb = src_sharded_cb,
+            .dst_sharded_cb = dst_sharded_cb,
+            .total_size_bytes = total_size_bytes,
+            .cores = corerange_to_cores(shard_grid, std::nullopt, true)}};
+}
+
+void MoveShardedProgramFactory::override_runtime_arguments(
+    MoveShardedProgramFactory::cached_program_t& cached_program,
+    const operation_attributes_t& operation_attributes,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& tensor_return_value) {
+    using namespace tt::tt_metal;
+
+    Program& program = cached_program.program;
+    const Tensor& input = tensor_args.input_tensor;
+    tensor_return_value_t& output = tensor_return_value;
+
+    Buffer* src_buffer = input.buffer();
+    Buffer* dst_buffer = output.buffer();
+
+    UpdateDynamicCircularBufferAddress(program, cached_program.shared_variables.src_sharded_cb, *src_buffer);
+    UpdateDynamicCircularBufferAddress(program, cached_program.shared_variables.dst_sharded_cb, *dst_buffer);
+
+    const uint32_t input_buffer_address = src_buffer->address();
+    const uint32_t output_buffer_address = dst_buffer->address();
+    const uint32_t move_chunk_size_bytes = output_buffer_address - input_buffer_address;
+    const uint32_t num_chunks = cached_program.shared_variables.total_size_bytes / move_chunk_size_bytes;
+    const uint32_t remainder_chunk_size_bytes =
+        cached_program.shared_variables.total_size_bytes % move_chunk_size_bytes;
+
+    std::vector<uint32_t> new_runtime_args = {
+        cached_program.shared_variables.total_size_bytes,
+        num_chunks,
+        move_chunk_size_bytes,
+        remainder_chunk_size_bytes};
+
+    for (const auto& core : cached_program.shared_variables.cores) {
+        SetRuntimeArgs(program, cached_program.shared_variables.kernel_id, core, new_runtime_args);
+    }
+}
+
+}  // namespace ttnn::operations::data_movement::move::program

--- a/ttnn/cpp/ttnn/operations/data_movement/move/device/move_sharded_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/move/device/move_sharded_program_factory.hpp
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "move_device_operation_types.hpp"
+#include "ttnn/device_operation.hpp"
+
+namespace ttnn::operations::data_movement::move::program {
+
+struct MoveShardedProgramFactory {
+    struct shared_variables_t {
+        tt::tt_metal::KernelHandle kernel_id = 0;
+        tt::tt_metal::CBHandle src_sharded_cb = 0;
+        tt::tt_metal::CBHandle dst_sharded_cb = 0;
+        uint32_t total_size_bytes = 0;
+        std::vector<tt::tt_metal::CoreCoord> cores;
+    };
+    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
+
+    static cached_program_t create(
+        const operation_attributes_t& operation_attributes,
+        const tensor_args_t& tensor_args,
+        tensor_return_value_t& tensor_return_value);
+
+    static void override_runtime_arguments(
+        cached_program_t& cached_program,
+        const operation_attributes_t& operation_attributes,
+        const tensor_args_t& tensor_args,
+        tensor_return_value_t& tensor_return_value);
+};
+
+}  // namespace ttnn::operations::data_movement::move::program


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/32746

### Problem description
We have 2 ways of writing ops, which should be unified into one.

### What's changed
Migrate move op to the new infrastructure.

### Checklist
- [X] [All post commit #20138471971](https://github.com/tenstorrent/tt-metal/actions/runs/20138471971) CI passes