### PR TITLE
Fix DPRINT test parallel execution race condition

### DIFF
--- a/tests/tt_metal/tt_metal/debug_tools/debug_tools_fixture.hpp
+++ b/tests/tt_metal/tt_metal/debug_tools/debug_tools_fixture.hpp
@@ -48,6 +48,13 @@ public:
         MetalContext::instance().dprint_server()->await();
     }
 
+    // Destructor ensures file descriptor is closed even if SetUp() throws
+    ~DPrintMeshFixture() {
+        if (memfd_ >= 0) {
+            close(memfd_);
+        }
+    }
+
 protected:
     int memfd_ = -1;  // File descriptor for memory-backed file
     // Running with dprint + watcher enabled can make the code size blow up, so let's force watcher

--- a/tests/tt_metal/tt_metal/debug_tools/debug_tools_fixture.hpp
+++ b/tests/tt_metal/tt_metal/debug_tools/debug_tools_fixture.hpp
@@ -11,6 +11,12 @@
 #include "hal_types.hpp"
 #include <impl/debug/dprint_server.hpp>
 #include <impl/debug/watcher_server.hpp>
+#include <sys/mman.h>
+#include <unistd.h>
+#include <cstring>
+#include <cerrno>
+#include "tt_stl/assert.hpp"
+#include "fmt/format.h"
 
 namespace tt::tt_metal {
 
@@ -32,7 +38,7 @@ class DebugToolsMeshFixture : public MeshDispatchFixture {
 // A version of MeshDispatchFixture with DPrint enabled on all cores.
 class DPrintMeshFixture : public DebugToolsMeshFixture {
 public:
-    inline static const std::string dprint_file_name = "gtest_dprint_log.txt";
+    std::string dprint_file_name;
 
     // A function to run a program, according to which dispatch mode is set.
     void RunProgram(const std::shared_ptr<distributed::MeshDevice>& mesh_device, distributed::MeshWorkload& workload) {
@@ -43,9 +49,25 @@ public:
     }
 
 protected:
+    int memfd_ = -1;  // File descriptor for memory-backed file
     // Running with dprint + watcher enabled can make the code size blow up, so let's force watcher
     // disabled for DPRINT tests.
     void SetUp() override {
+        // Create a unique memory-backed file for this test to avoid parallel test conflicts
+        const testing::TestInfo* test_info = testing::UnitTest::GetInstance()->current_test_info();
+        std::string test_desc = fmt::format("dprint_{}_{}_{}",
+            getpid(),
+            test_info->test_suite_name(),
+            test_info->name());
+
+        memfd_ = memfd_create(test_desc.c_str(), 0);
+        if (memfd_ < 0) {
+            TT_THROW("Failed to create memory file descriptor: {}", strerror(errno));
+        }
+
+        // Use /proc/self/fd path which works transparently with ofstream/ifstream
+        dprint_file_name = fmt::format("/proc/self/fd/{}", memfd_);
+
         // The core range (virtual) needs to be set >= the set of all cores
         // used by all tests using this fixture, so set dprint enabled for
         // all cores and all devices
@@ -73,6 +95,12 @@ protected:
         // Parent class tears down devices
         DebugToolsMeshFixture::TearDown();
         ExtraTearDown();
+
+        // Close the memory-backed file descriptor
+        if (memfd_ >= 0) {
+            close(memfd_);
+            memfd_ = -1;
+        }
 
         // Reset DPrint settings
         tt::tt_metal::MetalContext::instance().rtoptions().set_feature_cores(tt::llrt::RunTimeDebugFeatureDprint, {});

--- a/tests/tt_metal/tt_metal/debug_tools/debug_tools_fixture.hpp
+++ b/tests/tt_metal/tt_metal/debug_tools/debug_tools_fixture.hpp
@@ -49,7 +49,7 @@ public:
     }
 
     // Destructor ensures file descriptor is closed even if SetUp() throws
-    ~DPrintMeshFixture() {
+    ~DPrintMeshFixture() override {
         if (memfd_ >= 0) {
             close(memfd_);
         }

--- a/tests/tt_metal/tt_metal/debug_tools/dprint/test_eth_cores.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/dprint/test_eth_cores.cpp
@@ -93,7 +93,7 @@ void RunTest(
         fixture->RunProgram(mesh_device, workload);
 
         // Check the print log against golden output.
-        EXPECT_TRUE(FilesMatchesString(DPrintMeshFixture::dprint_file_name, golden_output));
+        EXPECT_TRUE(FilesMatchesString(fixture->dprint_file_name, golden_output));
 
         // Clear the log file for the next core's test
         MetalContext::instance().dprint_server()->clear_log_file();

--- a/tests/tt_metal/tt_metal/debug_tools/dprint/test_mute_print_server.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/dprint/test_mute_print_server.cpp
@@ -70,7 +70,7 @@ void RunTest(DPrintMeshFixture* fixture, std::shared_ptr<distributed::MeshDevice
     run_program(2);
 
     // Check the print log against golden output.
-    EXPECT_TRUE(FilesMatchesString(DPrintMeshFixture::dprint_file_name, golden_output));
+    EXPECT_TRUE(FilesMatchesString(fixture->dprint_file_name, golden_output));
 }
 }
 }

--- a/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_before_finish.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_before_finish.cpp
@@ -78,12 +78,7 @@ void RunTest(DPrintMeshFixture* fixture, const std::shared_ptr<distributed::Mesh
             expected_output.push_back(fmt::format("({},{}) After wait...", x, y));
         }
     }
-    EXPECT_TRUE(
-        FileContainsAllStrings(
-            DPrintMeshFixture::dprint_file_name,
-            expected_output
-        )
-    );
+    EXPECT_TRUE(FileContainsAllStrings(fixture->dprint_file_name, expected_output));
 }
 
 TEST_F(DPrintMeshFixture, TensixTestPrintFinish) {

--- a/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_buffering.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_buffering.cpp
@@ -95,7 +95,7 @@ void RunTest(DPrintMeshFixture* fixture, const std::shared_ptr<distributed::Mesh
     fixture->RunProgram(mesh_device, workload);
 
     // Check the print log against golden output.
-    EXPECT_TRUE(FileContainsAllStrings(DPrintMeshFixture::dprint_file_name, golden_output));
+    EXPECT_TRUE(FileContainsAllStrings(fixture->dprint_file_name, golden_output));
 }
 }  // namespace CMAKE_UNIQUE_NAMESPACE
 }  // namespace

--- a/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_config_register.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_config_register.cpp
@@ -398,7 +398,7 @@ static void print_config_reg(
     fixture->RunProgram(mesh_device, workload);
 
     // Check the print log against golden output.
-    EXPECT_TRUE(FilesMatchesString(DPrintMeshFixture::dprint_file_name, golden_output));
+    EXPECT_TRUE(FilesMatchesString(fixture->dprint_file_name, golden_output));
 }
 
 TEST_F(DPrintMeshFixture, ConfigRegAluTestPrint) {

--- a/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_prepend_device_core_risc.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_prepend_device_core_risc.cpp
@@ -108,7 +108,7 @@ void RunTest(
     fixture->RunProgram(mesh_device, workload);
 
     // Check the print log against golden output.
-    EXPECT_TRUE(FileContainsAllStrings(DPrintMeshFixture::dprint_file_name, golden_output));
+    EXPECT_TRUE(FileContainsAllStrings(fixture->dprint_file_name, golden_output));
 }
 }  // namespace CMAKE_UNIQUE_NAMESPACE
 }  // namespace

--- a/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_tensix_dest.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_tensix_dest.cpp
@@ -416,10 +416,9 @@ static bool reader_datacopy_writer(
     // Check the print log against golden output.
     if (config.data_format == tt::DataFormat::Float32 && arch == ARCH::WORMHOLE_B0) {
         // Skip all device-side warning lines added before each tile print
-        DeleteLinesStartingWith(
-            DPrintMeshFixture::dprint_file_name, "WARNING: Float32 on Wormhole displays limited precision");
+        DeleteLinesStartingWith(fixture->dprint_file_name, "WARNING: Float32 on Wormhole displays limited precision");
     }
-    EXPECT_TRUE(FilesMatchesString(DPrintMeshFixture::dprint_file_name, golden_output));
+    EXPECT_TRUE(FilesMatchesString(fixture->dprint_file_name, golden_output));
 
     // Compare input and output data
     return input_data == output_data;


### PR DESCRIPTION

### Ticket
#32669 

### Problem description
Race condition when DPRINT run in parallel due to writing to the same file

### What's changed
Each test now uses memfd_create and gets its own isolated in-memory file path: /proc/self/fd/{N}

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes