### PR TITLE
Restore old behviour of SD3.5 VAE

### DIFF
--- a/models/experimental/tt_dit/layers/conv2d.py
+++ b/models/experimental/tt_dit/layers/conv2d.py
@@ -289,7 +289,7 @@ class Conv2d(Module):
                 batch_size=b,
                 input_height=h,
                 input_width=w,
-                conv_config=None,
+                conv_config=ttnn.Conv2dConfig(act_block_h_override=32),
                 compute_config=self.compute_config,
                 slice_config=slice_config,
                 return_output_dim=True,


### PR DESCRIPTION
Commit https://github.com/tenstorrent/tt-metal/commit/e1b34d5de2fc8317c32f9ea79e2bdf33dbfbbd1e
regressed SD3.5 VAE

This change restores the old behaviour from the model side.

(T3K) T3000 model perf tests - https://github.com/tenstorrent/tt-metal/actions/runs/19677290502