### PR TITLE
Generic Reduction - Add Sub Core Grid Support

### DIFF
--- a/tests/ttnn/unit_tests/operations/reduce/test_sum.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_sum.py
@@ -133,4 +133,4 @@ def test_sum_subcores(device, sub_core_grids, dtype, shape):
     output_tensor = ttnn.from_device(output_tensor)
     output_tensor = ttnn.to_torch(output_tensor)
 
-    assert_with_pcc(torch_output_tensor, output_tensor)
+    assert_with_pcc(torch_output_tensor, output_tensor, 0.999)

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/multi_core_w/reduce_op_multi_core_w.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/multi_core_w/reduce_op_multi_core_w.cpp
@@ -22,7 +22,8 @@ operation::ProgramWithCallbacks reduce_multi_core_w(
     Tensor& output,
     ReduceOpMath reduce_op,
     const ttnn::DeviceComputeKernelConfig& compute_kernel_config,
-    float scaler) {
+    float scaler,
+    const std::optional<CoreRangeSet>& sub_core_grids) {
     const auto& shape = a.padded_shape();
     uint32_t W = shape[3], H = shape[2], NC = shape[1] * shape[0];
 
@@ -46,8 +47,18 @@ operation::ProgramWithCallbacks reduce_multi_core_w(
 
     auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
     auto num_rows = NC * Ht;
-    auto [num_cores, all_cores, core_group_1, core_group_2, num_rows_per_core_group_1, num_rows_per_core_group_2] =
-        tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_rows);
+    uint32_t num_cores;
+    CoreRangeSet all_cores, core_group_1, core_group_2;
+    uint32_t num_rows_per_core_group_1, num_rows_per_core_group_2;
+    if (sub_core_grids.has_value()) {
+        std::tie(
+            num_cores, all_cores, core_group_1, core_group_2, num_rows_per_core_group_1, num_rows_per_core_group_2) =
+            tt::tt_metal::split_work_to_cores(*sub_core_grids, num_rows);
+    } else {
+        std::tie(
+            num_cores, all_cores, core_group_1, core_group_2, num_rows_per_core_group_1, num_rows_per_core_group_2) =
+            tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_rows);
+    }
 
     uint32_t src0_cb_index = 0;
     uint32_t num_input_tiles = 2;
@@ -127,8 +138,18 @@ operation::ProgramWithCallbacks reduce_multi_core_w(
     }
 
     uint32_t out_dim_divider = Wt;
-    const auto& cores =
-        grid_to_cores(num_cores, compute_with_storage_grid_size.x, compute_with_storage_grid_size.y, false);
+    std::vector<CoreCoord> cores;
+    if (sub_core_grids.has_value()) {
+        for (const auto& range : all_cores.ranges()) {
+            for (int y = range.start_coord.y; y <= range.end_coord.y; ++y) {
+                for (int x = range.start_coord.x; x <= range.end_coord.x; ++x) {
+                    cores.emplace_back(x, y);
+                }
+            }
+        }
+    } else {
+        cores = grid_to_cores(num_cores, compute_with_storage_grid_size.x, compute_with_storage_grid_size.y, false);
+    }
     for (uint32_t i = 0, num_tiles_read = 0; i < num_cores; i++) {
         const CoreCoord& core = cores[i];
         uint32_t num_rows_per_core = 0;

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op.hpp
@@ -12,6 +12,8 @@
 #include "ttnn/operation.hpp"
 
 #include "common.hpp"
+#include <tt-metalium/core_coord.hpp>
+#include <optional>
 
 namespace tt {
 
@@ -23,19 +25,22 @@ tt::tt_metal::operation::ProgramWithCallbacks reduce_single_core_hw(
     Tensor& output_tensor,
     ReduceOpMath reduce_math,
     const ttnn::DeviceComputeKernelConfig& compute_kernel_config,
-    float scaler = 1.0f);
+    float scaler = 1.0f,
+    const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
 tt::tt_metal::operation::ProgramWithCallbacks reduce_multi_core_h(
     const Tensor& input_tensor,
     Tensor& output_tensor,
     ReduceOpMath reduce_math,
     const ttnn::DeviceComputeKernelConfig& compute_kernel_config,
-    float scaler = 1.0f);
+    float scaler = 1.0f,
+    const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
 tt::tt_metal::operation::ProgramWithCallbacks reduce_multi_core_w(
     const Tensor& input_tensor,
     Tensor& output_tensor,
     ReduceOpMath reduce_math,
     const ttnn::DeviceComputeKernelConfig& compute_kernel_config,
-    float scaler = 1.0f);
+    float scaler = 1.0f,
+    const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
 
 struct Reduce {
     const ReduceOpMath math_op;
@@ -44,6 +49,7 @@ struct Reduce {
     const MemoryConfig output_mem_config;
     const DataType output_dtype;
     ttnn::DeviceComputeKernelConfig compute_kernel_config;
+    std::optional<CoreRangeSet> sub_core_grids;
 
     void validate(const std::vector<Tensor>& input_tensors) const;
     std::vector<ttnn::TensorSpec> compute_output_specs(const std::vector<Tensor>& input_tensors) const;
@@ -59,7 +65,8 @@ Tensor reduce(
     float scaler = 1.0f,
     const MemoryConfig& output_mem_config = tt::tt_metal::operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
     const std::optional<DataType>& output_dtype = std::nullopt,
-    const std::optional<ttnn::DeviceComputeKernelConfig>& compute_kernel_config = std::nullopt);
+    const std::optional<ttnn::DeviceComputeKernelConfig>& compute_kernel_config = std::nullopt,
+    const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
 
 }  // namespace tt_metal
 

--- a/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.cpp
@@ -177,7 +177,8 @@ static Tensor reduce_impl(
     const std::optional<MemoryConfig>& memory_config_arg,
     const std::optional<DeviceComputeKernelConfig>& compute_kernel_config,
     float scalar,
-    const ttnn::SmallVector<int>& non_height_width_dims) {
+    const ttnn::SmallVector<int>& non_height_width_dims,
+    const std::optional<CoreRangeSet>& sub_core_grids) {
     using ttnn::operations::experimental::auto_format::AutoFormat;
     auto input_shape = input_tensor_arg.logical_shape();
     auto rank = input_shape.size();
@@ -226,7 +227,8 @@ static Tensor reduce_impl(
                             memory_config,
                             compute_kernel_config,
                             effective_scalar,
-                            non_height_width_dims);
+                            non_height_width_dims,
+                            sub_core_grids);
                     } else {
                         output_tensor = reduce_impl<ReduceType::Sum>(
                             output_tensor,
@@ -235,7 +237,8 @@ static Tensor reduce_impl(
                             memory_config,
                             compute_kernel_config,
                             effective_scalar,
-                            non_height_width_dims);
+                            non_height_width_dims,
+                            sub_core_grids);
                     }
                     if (transpose) {
                         output_tensor = ttnn::transpose(output_tensor, i_dim, -2, memory_config, pad_value);
@@ -287,7 +290,8 @@ static Tensor reduce_impl(
                 scalar,
                 memory_config,
                 std::nullopt,
-                compute_kernel_config);
+                compute_kernel_config,
+                sub_core_grids);
         } else if constexpr (reduce_type == ReduceType::Mean) {
             output_tensor = tt::tt_metal::reduce(
                 input_tensor,
@@ -296,7 +300,8 @@ static Tensor reduce_impl(
                 scalar / reduced_volume,
                 memory_config,
                 std::nullopt,
-                compute_kernel_config);
+                compute_kernel_config,
+                sub_core_grids);
         } else if constexpr (reduce_type == ReduceType::Max) {
             output_tensor = tt::tt_metal::reduce(
                 input_tensor,
@@ -305,7 +310,8 @@ static Tensor reduce_impl(
                 scalar,
                 memory_config,
                 std::nullopt,
-                compute_kernel_config);
+                compute_kernel_config,
+                sub_core_grids);
         } else if constexpr (reduce_type == ReduceType::Min) {
             output_tensor = tt::tt_metal::reduce(
                 input_tensor,
@@ -314,7 +320,8 @@ static Tensor reduce_impl(
                 scalar,
                 memory_config,
                 std::nullopt,
-                compute_kernel_config);
+                compute_kernel_config,
+                sub_core_grids);
         } else {
             TT_THROW("Unsupported reduction operation");
         }
@@ -331,7 +338,8 @@ static Tensor std_var_impl(
     const std::optional<DeviceComputeKernelConfig>& compute_kernel_config,
     float scalar,
     const ttnn::SmallVector<int>& non_height_width_dims,
-    bool correction) {
+    bool correction,
+    const std::optional<CoreRangeSet>& sub_core_grids) {
     using ttnn::operations::experimental::auto_format::AutoFormat;
     auto input_shape = input_tensor_arg.logical_shape();
     auto rank = input_shape.size();
@@ -365,7 +373,14 @@ static Tensor std_var_impl(
     scalar /= reduced_volume;
 
     auto mean_tensor = reduce_impl<ReduceType::Sum>(
-        input_tensor_arg, dim, keepdim, memory_config_arg, compute_kernel_config, scalar, non_height_width_dims);
+        input_tensor_arg,
+        dim,
+        keepdim,
+        memory_config_arg,
+        compute_kernel_config,
+        scalar,
+        non_height_width_dims,
+        sub_core_grids);
 
     auto mean_square_tensor = reduce_impl<ReduceType::Sum>(
         ttnn::pow(input_tensor_arg, 2.0f, memory_config),
@@ -374,7 +389,8 @@ static Tensor std_var_impl(
         memory_config_arg,
         compute_kernel_config,
         scalar,
-        non_height_width_dims);
+        non_height_width_dims,
+        sub_core_grids);
     Tensor output_tensor =
         ttnn::subtract(mean_square_tensor, ttnn::pow(mean_tensor, 2.0f, memory_config), std::nullopt, memory_config);
     if constexpr (reduce_type == ReduceType::Std) {
@@ -419,7 +435,8 @@ Tensor Reduce<reduce_type>::invoke(
     const std::optional<MemoryConfig>& memory_config_arg,
     const std::optional<DeviceComputeKernelConfig>& compute_kernel_config,
     float scalar,
-    bool correction) {
+    bool correction,
+    const std::optional<CoreRangeSet>& sub_core_grids) {
     ttnn::SmallVector<int> dim = generate_reduce_dim(input_tensor_arg, dim_arg);
     float pad_value = get_pad_value(reduce_type);
     bool is_tiled = input_tensor_arg.layout() == TILE_LAYOUT;
@@ -451,10 +468,18 @@ Tensor Reduce<reduce_type>::invoke(
             compute_kernel_config,
             scalar,
             non_height_width_dims,
-            correction);
+            correction,
+            sub_core_grids);
     }
     return reduce_impl<reduce_type>(
-        input_tensor, dim, keepdim, memory_config_arg, compute_kernel_config, scalar, non_height_width_dims);
+        input_tensor,
+        dim,
+        keepdim,
+        memory_config_arg,
+        compute_kernel_config,
+        scalar,
+        non_height_width_dims,
+        sub_core_grids);
 }
 
 Tensor pool_sum(

--- a/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.cpp
@@ -495,7 +495,8 @@ Tensor pool_sum(
         memory_config_arg,
         compute_kernel_config,
         scalar,
-        /*non_height_width_dims=*/{});
+        /*non_height_width_dims=*/{},
+        /*sub_core_grids=*/std::nullopt);
 }
 
 template struct Reduce<ReduceType::Sum>;

--- a/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.hpp
@@ -9,6 +9,7 @@
 
 #include "ttnn/decorators.hpp"
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
+#include <tt-metalium/core_coord.hpp>
 
 namespace ttnn {
 namespace operations::reduction {
@@ -31,7 +32,8 @@ struct Reduce {
         const std::optional<MemoryConfig>& memory_config_arg = std::nullopt,
         const std::optional<DeviceComputeKernelConfig>& compute_kernel_config = std::nullopt,
         float scalar = 1.0f,
-        bool correction = true);
+        bool correction = true,
+        const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
 };
 
 // Entry point for pool op, which uses non-standard tensors that cannot be padded.

--- a/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions_pybind.hpp
@@ -29,6 +29,7 @@ void bind_reduction_operation(py::module& module, const reduction_operation_t& o
             compute_kernel_config (ttnn.ComputeKernelConfig, optional): Compute kernel configuration for the operation. Defaults to `None`.
             scalar (float, optional): A scaling factor to be applied to the input tensor. Defaults to `1.0`.
             correction (bool, optional): Applies only to :func:`ttnn.std` - whether to apply Bessel's correction (i.e. N-1). Defaults to `True`.
+            sub_core_grids (ttnn.CoreRangeSet, optional): Subcore grids to use for the operation. Defaults to `None`, which will use all cores.
 
         Returns:
             ttnn.Tensor: the output tensor.

--- a/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions_pybind.hpp
@@ -70,7 +70,8 @@ void bind_reduction_operation(py::module& module, const reduction_operation_t& o
             py::arg("memory_config") = std::nullopt,
             py::arg("compute_kernel_config") = std::nullopt,
             py::arg("scalar") = 1.0f,
-            py::arg("correction") = true});
+            py::arg("correction") = true,
+            py::arg("sub_core_grids") = std::nullopt});
 }
 
 }  // namespace ttnn::operations::reduction::detail


### PR DESCRIPTION
### Ticket
#33144

### Problem description
Model team requires the ability to specify `sub_core_grids` to enable Llama3.3-70b on Galaxy.

The generic reductions, including `max` and `sum`, do not have this support and always use the entire available core grid (or core 0,0 for single core implementations).

### What's changed
Added the `sub_core_grids` parameter to generic reduces. This is used for `split_work_to_cores` instead of the entire compute grid.

Added a testcase for `sum` to show how this can be used.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/19679937968)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests [matches main](https://github.com/tenstorrent/tt-metal/actions/runs/19679937968) 