### PR TITLE
Add ClosetBox fabric test configuration

### DIFF
--- a/tests/tt_metal/distributed/config/16_n300_lb_closetbox_rank_bindings.yaml
+++ b/tests/tt_metal/distributed/config/16_n300_lb_closetbox_rank_bindings.yaml
@@ -1,0 +1,35 @@
+mesh_graph_desc_path: tests/tt_metal/tt_fabric/custom_mesh_descriptors/16_n300_lb_closetbox_mgd.textproto
+
+rank_bindings:
+  - rank: 0
+    mesh_id: 0
+  - rank: 1
+    mesh_id: 1
+  - rank: 2
+    mesh_id: 2
+  - rank: 3
+    mesh_id: 3
+  - rank: 4
+    mesh_id: 4
+  - rank: 5
+    mesh_id: 5
+  - rank: 6
+    mesh_id: 6
+  - rank: 7
+    mesh_id: 7
+  - rank: 8
+    mesh_id: 8
+  - rank: 9
+    mesh_id: 9
+  - rank: 10
+    mesh_id: 10
+  - rank: 11
+    mesh_id: 11
+  - rank: 12
+    mesh_id: 12
+  - rank: 13
+    mesh_id: 13
+  - rank: 14
+    mesh_id: 14
+  - rank: 15
+    mesh_id: 15

--- a/tests/tt_metal/tt_fabric/custom_mesh_descriptors/16_n300_lb_closetbox_mgd.textproto
+++ b/tests/tt_metal/tt_fabric/custom_mesh_descriptors/16_n300_lb_closetbox_mgd.textproto
@@ -1,0 +1,220 @@
+# --- Meshes ---------------------------------------------------------------
+
+mesh_descriptors {
+  name: "M0"
+  arch: WORMHOLE_B0
+  device_topology { dims: [ 2, 4 ] }
+  host_topology   { dims: [ 1, 1 ] }
+  channels {
+    count: 2
+    policy: STRICT
+  }
+}
+
+# --- Graphs ---------------------------------------------------------------
+
+graph_descriptors {
+  name: "G0"
+  type: "FABRIC"
+  # Instances: mesh ids 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15 (all 2x4)
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 0 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 1 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 2 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 3 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 4 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 5 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 6 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 7 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 8 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 9 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 10 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 11 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 12 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 13 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 14 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 15 } }
+
+  # M0 <-> M1
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 0 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 1 } }
+    channels { count: 2 }
+  }
+  # M0 <-> M2
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 0 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 2 } }
+    channels { count: 2 }
+  }
+  # M0 <-> M3
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 0 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 3 } }
+    channels { count: 2 }
+  }
+  # M0 <-> M8
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 0 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 8 } }
+    channels { count: 2 }
+  }
+  # M1 <-> M2
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 1 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 2 } }
+    channels { count: 2 }
+  }
+  # M1 <-> M3
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 1 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 3 } }
+    channels { count: 2 }
+  }
+  # M2 <-> M3
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 2 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 3 } }
+    channels { count: 2 }
+  }
+  # M2 <-> M5
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 2 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 5 } }
+    channels { count: 2 }
+  }
+  # M3 <-> M12
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 3 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 12 } }
+    channels { count: 2 }
+  }
+  # M4 <-> M5
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 4 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 5 } }
+    channels { count: 2 }
+  }
+  # M4 <-> M6
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 4 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 6 } }
+    channels { count: 2 }
+  }
+  # M4 <-> M7
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 4 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 7 } }
+    channels { count: 2 }
+  }
+  # M4 <-> M11
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 4 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 11 } }
+    channels { count: 2 }
+  }
+  # M5 <-> M6
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 5 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 6 } }
+    channels { count: 2 }
+  }
+  # M5 <-> M7
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 5 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 7 } }
+    channels { count: 2 }
+  }
+  # M6 <-> M7
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 6 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 7 } }
+    channels { count: 2 }
+  }
+  # M7 <-> M15
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 7 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 15 } }
+    channels { count: 2 }
+  }
+  # M8 <-> M9
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 8 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 9 } }
+    channels { count: 2 }
+  }
+  # M8 <-> M10
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 8 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 10 } }
+    channels { count: 2 }
+  }
+  # M8 <-> M11
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 8 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 11 } }
+    channels { count: 2 }
+  }
+  # M9 <-> M10
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 9 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 10 } }
+    channels { count: 2 }
+  }
+  # M9 <-> M11
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 9 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 11 } }
+    channels { count: 2 }
+  }
+  # M10 <-> M11
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 10 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 11 } }
+    channels { count: 2 }
+  }
+  # M10 <-> M13
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 10 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 13 } }
+    channels { count: 2 }
+  }
+  # M12 <-> M13
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 12 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 13 } }
+    channels { count: 2 }
+  }
+  # M12 <-> M14
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 12 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 14 } }
+    channels { count: 2 }
+  }
+  # M12 <-> M15
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 12 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 15 } }
+    channels { count: 2 }
+  }
+  # M13 <-> M14
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 13 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 14 } }
+    channels { count: 2 }
+  }
+  # M13 <-> M15
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 13 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 15 } }
+    channels { count: 2 }
+  }
+  # M14 <-> M15
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 14 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 15 } }
+    channels { count: 2 }
+  }
+}
+
+# --- Instantiation ----------------------------------------------------------
+top_level_instance { graph { graph_descriptor: "G0" graph_id: 0 } }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_16_n300_lb_closetbox.yaml
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_16_n300_lb_closetbox.yaml
@@ -2,10 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-allocation_policies:
-    receiver:
-      max_configs_per_core: 2
-
 Tests:
   # ======================================================================================
   # Routing within a superpod (cluster of 4 loudboxes)
@@ -14,7 +10,6 @@ Tests:
   - name: "ClosetBoxWithinSuperpod"
     fabric_setup:
       topology: Mesh
-      routing_type: Dynamic
 
     top_level_iterations: 3
 
@@ -43,7 +38,6 @@ Tests:
   - name: "ClosetBoxAcrossSuperpods"
     fabric_setup:
       topology: Mesh
-      routing_type: Dynamic
 
     top_level_iterations: 3
 
@@ -75,7 +69,6 @@ Tests:
     enable_flow_control: true
     fabric_setup:
       topology: Mesh
-      routing_type: Dynamic
 
     parametrization_params:
       ntype: [unicast_write]

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_16_n300_lb_closetbox.yaml
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_16_n300_lb_closetbox.yaml
@@ -1,0 +1,86 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+allocation_policies:
+    receiver:
+      max_configs_per_core: 2
+
+Tests:
+  # ======================================================================================
+  # Routing within a superpod (cluster of 4 loudboxes)
+  # Tests routing from Mesh 0 to Meshes 1-3 (all in Superpod 1)
+  # ======================================================================================
+  - name: "ClosetBoxWithinSuperpod"
+    fabric_setup:
+      topology: Mesh
+      routing_type: Dynamic
+
+    top_level_iterations: 3
+
+    parametrization_params:
+      size: [64, 128]
+      num_packets: [50]
+
+    defaults:
+      ftype: unicast
+      ntype: unicast_write
+
+    senders:
+      - device: [0, [0, 0]]
+        patterns:
+          - destination:
+              device: [1, [0, 0]]
+          - destination:
+              device: [2, [1, 1]]
+          - destination:
+              device: [3, [0, 1]]
+
+  # ======================================================================================
+  # Routing across superpods
+  # Tests routing from Mesh 0 (Superpod 1) to Meshes 12-15 (Superpod 4)
+  # ======================================================================================
+  - name: "ClosetBoxAcrossSuperpods"
+    fabric_setup:
+      topology: Mesh
+      routing_type: Dynamic
+
+    top_level_iterations: 3
+
+    parametrization_params:
+      size: [64, 128]
+      num_packets: [50]
+
+    defaults:
+      ftype: unicast
+      ntype: unicast_write
+
+    senders:
+      - device: [0, [0, 0]]
+        patterns:
+          - destination:
+              device: [12, [0, 0]]
+          - destination:
+              device: [13, [1, 1]]
+          - destination:
+              device: [14, [0, 2]]
+          - destination:
+              device: [15, [1, 3]]
+
+  # ======================================================================================
+  # All-to-All Pattern (Sequential): Fabric stress test
+  # 16 meshes * 8 chips = 128 chips (vs 5 galaxies with 160 chips)
+  # ======================================================================================
+  - name: "ClosetBoxSequentialAllToAll"
+    enable_flow_control: true
+    fabric_setup:
+      topology: Mesh
+      routing_type: Dynamic
+
+    parametrization_params:
+      ntype: [unicast_write]
+      size: [128]
+      num_packets: [250]
+
+    patterns:
+      - type: sequential_all_to_all


### PR DESCRIPTION
### Ticket
Partially https://github.com/tenstorrent/tt-metal/issues/32258

### Problem description
- No test configuration existed for 16-node N300 ClosetBox cluster topology
- Unable to run fabric routing tests on 16-node ClosetBox hardware
- Missing mesh graph descriptor and rank bindings for this configuration

### What's changed
- Added 16-node ClosetBox mesh graph descriptor
- Added rank bindings configuration
- dded routing test suite

The mgd was generated using changes from https://github.com/tenstorrent/tt-metal/pull/32462

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes
