### PR TITLE
Delete jit_build/genfiles.{cpp,hpp} from jitapi

### DIFF
--- a/tt_metal/CMakeLists.txt
+++ b/tt_metal/CMakeLists.txt
@@ -213,8 +213,6 @@ target_sources(
             kernels/dataflow/reader_unary.cpp
             kernels/dataflow/writer_unary.cpp
             kernels/dataflow/writer_unary_1.cpp
-            jit_build/genfiles.cpp
-            jit_build/genfiles.hpp
             ${TT_LLK_HEADERS}
 )
 


### PR DESCRIPTION
### Ticket
n/a

### Problem description
jit_build/genfiles.{cpp,hpp} are compiled into metal library.  They shouldn't be needed at run time and therefore don't need to be packaged.

### What's changed
Deleted

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/19682859185) CI passes