### PR TITLE
#32708: Migrate op to new infra: nlp_concat_heads_boltz

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_boltz/device/nlp_concat_heads_boltz_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_boltz/device/nlp_concat_heads_boltz_device_operation.cpp
@@ -4,11 +4,21 @@
 
 #include "nlp_concat_heads_boltz_device_operation.hpp"
 
-namespace ttnn::operations::experimental::transformer {
+namespace ttnn::operations::experimental::nlp_concat_heads_boltz {
 
-// Generic NLP ConcatHeadsBoltz op
-void NLPConcatHeadsBoltzDeviceOperation::validate(const std::vector<Tensor>& input_tensors) const {
-    const auto& input_tensor = input_tensors.at(0);
+NLPConcatHeadsBoltzDeviceOperation::program_factory_t NLPConcatHeadsBoltzDeviceOperation::select_program_factory(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    return program::NLPConcatHeadsBoltzProgramFactory{};
+}
+
+void NLPConcatHeadsBoltzDeviceOperation::validate_on_program_cache_hit(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    validate_on_program_cache_miss(args, tensor_args);
+}
+
+void NLPConcatHeadsBoltzDeviceOperation::validate_on_program_cache_miss(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    const auto& input_tensor = tensor_args.input;
 
     TT_FATAL(input_tensor.storage_type() == tt::tt_metal::StorageType::DEVICE, "Operands to TM need to be on device!");
     TT_FATAL(input_tensor.buffer() != nullptr, "Operands to TM need to be allocated in buffers on device!");
@@ -44,20 +54,32 @@ void NLPConcatHeadsBoltzDeviceOperation::validate(const std::vector<Tensor>& inp
             shard_spec.shape[0],
             input_tensor.padded_shape()[-2]);
         TT_FATAL(
-            this->output_mem_config.memory_layout() != tt::tt_metal::TensorMemoryLayout::HEIGHT_SHARDED,
+            args.output_mem_config.memory_layout() != tt::tt_metal::TensorMemoryLayout::HEIGHT_SHARDED,
             "Output memory config layout must not be HEIGHT_SHARDED but got {}",
-            this->output_mem_config.memory_layout());
+            args.output_mem_config.memory_layout());
     } else {
         TT_FATAL(
-            this->output_mem_config.memory_layout() == tt::tt_metal::TensorMemoryLayout::INTERLEAVED,
+            args.output_mem_config.memory_layout() == tt::tt_metal::TensorMemoryLayout::INTERLEAVED,
             "Output memory config layout must be INTERLEAVED but got {}",
-            this->output_mem_config.memory_layout());
+            args.output_mem_config.memory_layout());
+    }
+
+    if (tensor_args.preallocated_output.has_value()) {
+        const auto computed_output_spec = compute_output_specs(args, tensor_args);
+        const auto& preallocated_output = tensor_args.preallocated_output.value();
+        TT_FATAL(
+            preallocated_output.logical_shape() == computed_output_spec.logical_shape(),
+            "Preallocated output shape must match computed output shape");
     }
 }
 
-std::vector<ttnn::TensorSpec> NLPConcatHeadsBoltzDeviceOperation::compute_output_specs(
-    const std::vector<Tensor>& input_tensors) const {
-    const auto& input_tensor = input_tensors.at(0);
+NLPConcatHeadsBoltzDeviceOperation::spec_return_value_t NLPConcatHeadsBoltzDeviceOperation::compute_output_specs(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    if (tensor_args.preallocated_output.has_value()) {
+        return tensor_args.preallocated_output->tensor_spec();
+    }
+
+    const auto& input_tensor = tensor_args.input;
     const auto& input_shape = input_tensor.logical_shape();
 
     auto num_heads = input_shape[0];
@@ -68,31 +90,39 @@ std::vector<ttnn::TensorSpec> NLPConcatHeadsBoltzDeviceOperation::compute_output
 
     Shape output_shape({1, sequence_length, sequence_length, hidden_dim});
 
-    if (this->output_mem_config.is_sharded()) {
+    if (args.output_mem_config.is_sharded()) {
         tt::tt_metal::ShardSpec shard_spec = input_tensor.shard_spec().value();
         uint32_t heads_per_shard = shard_spec.shape[0] / input_tensor.padded_shape()[-2];
         shard_spec.shape = {shard_spec.shape[0] / heads_per_shard, shard_spec.shape[1] * heads_per_shard};
-        auto mem_config = this->output_mem_config.with_shard_spec(shard_spec);
-        return {TensorSpec(
+        auto mem_config = args.output_mem_config.with_shard_spec(shard_spec);
+        return TensorSpec(
             output_shape,
             tt::tt_metal::TensorLayout(
-                input_tensor.dtype(), tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE), mem_config))};
+                input_tensor.dtype(), tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE), mem_config));
     }
 
-    return {TensorSpec(
+    return TensorSpec(
         output_shape,
         tt::tt_metal::TensorLayout(
-            input_tensor.dtype(), tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE), output_mem_config))};
+            input_tensor.dtype(), tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE), args.output_mem_config));
 }
 
-tt::tt_metal::operation::ProgramWithCallbacks NLPConcatHeadsBoltzDeviceOperation::create_program(
-    const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const {
-    const auto& input_tensor = input_tensors.at(0);
-    auto& output_tensor = output_tensors.at(0);
-
-    CoreCoord compute_with_storage_grid_size = input_tensor.device()->compute_with_storage_grid_size();
-
-    return multi_core_nlp_concat_heads_boltz(input_tensor, output_tensor, compute_with_storage_grid_size);
+NLPConcatHeadsBoltzDeviceOperation::tensor_return_value_t NLPConcatHeadsBoltzDeviceOperation::create_output_tensors(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    if (tensor_args.preallocated_output.has_value()) {
+        return tensor_args.preallocated_output.value();
+    }
+    const auto output_spec = compute_output_specs(operation_attributes, tensor_args);
+    return create_device_tensor(output_spec, tensor_args.input.device());
 }
 
-}  // namespace ttnn::operations::experimental::transformer
+std::
+    tuple<NLPConcatHeadsBoltzDeviceOperation::operation_attributes_t, NLPConcatHeadsBoltzDeviceOperation::tensor_args_t>
+    NLPConcatHeadsBoltzDeviceOperation::invoke(
+        const Tensor& input_tensor,
+        const tt::tt_metal::MemoryConfig& memory_config,
+        std::optional<Tensor> optional_output_tensor) {
+    return {operation_attributes_t{memory_config}, tensor_args_t{input_tensor, std::move(optional_output_tensor)}};
+}
+
+}  // namespace ttnn::operations::experimental::nlp_concat_heads_boltz

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_boltz/device/nlp_concat_heads_boltz_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_boltz/device/nlp_concat_heads_boltz_device_operation.cpp
@@ -8,7 +8,7 @@ namespace ttnn::operations::experimental::nlp_concat_heads_boltz {
 
 NLPConcatHeadsBoltzDeviceOperation::program_factory_t NLPConcatHeadsBoltzDeviceOperation::select_program_factory(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
-    return program::NLPConcatHeadsBoltzProgramFactory{};
+    return NLPConcatHeadsBoltzProgramFactory{};
 }
 
 void NLPConcatHeadsBoltzDeviceOperation::validate_on_program_cache_hit(

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_boltz/device/nlp_concat_heads_boltz_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_boltz/device/nlp_concat_heads_boltz_device_operation.hpp
@@ -18,7 +18,7 @@ struct NLPConcatHeadsBoltzDeviceOperation {
     using tensor_args_t = nlp_concat_heads_boltz::tensor_args_t;
     using spec_return_value_t = nlp_concat_heads_boltz::spec_return_value_t;
     using tensor_return_value_t = nlp_concat_heads_boltz::tensor_return_value_t;
-    using program_factory_t = std::variant<program::NLPConcatHeadsBoltzProgramFactory>;
+    using program_factory_t = std::variant<NLPConcatHeadsBoltzProgramFactory>;
 
     static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_boltz/device/nlp_concat_heads_boltz_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_boltz/device/nlp_concat_heads_boltz_device_operation.hpp
@@ -7,19 +7,39 @@
 #include <optional>
 
 #include "ttnn/tensor/tensor.hpp"
-#include "ttnn/run_operation.hpp"
+#include "ttnn/decorators.hpp"
+#include "nlp_concat_heads_boltz_device_operation_types.hpp"
+#include "nlp_concat_heads_boltz_program_factory.hpp"
 
-namespace ttnn::operations::experimental::transformer {
-
-tt::tt_metal::operation::ProgramWithCallbacks multi_core_nlp_concat_heads_boltz(
-    const Tensor& input_tensor_a, Tensor& output, CoreCoord compute_with_storage_grid_size);
+namespace ttnn::operations::experimental::nlp_concat_heads_boltz {
 
 struct NLPConcatHeadsBoltzDeviceOperation {
-    tt::tt_metal::MemoryConfig output_mem_config;
-    void validate(const std::vector<Tensor>& input_tensors) const;
-    std::vector<ttnn::TensorSpec> compute_output_specs(const std::vector<Tensor>& input_tensors) const;
-    tt::tt_metal::operation::ProgramWithCallbacks create_program(
-        const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const;
+    using operation_attributes_t = nlp_concat_heads_boltz::operation_attributes_t;
+    using tensor_args_t = nlp_concat_heads_boltz::tensor_args_t;
+    using spec_return_value_t = nlp_concat_heads_boltz::spec_return_value_t;
+    using tensor_return_value_t = nlp_concat_heads_boltz::tensor_return_value_t;
+    using program_factory_t = std::variant<program::NLPConcatHeadsBoltzProgramFactory>;
+
+    static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
+
+    static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
+    static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
+
+    static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
+
+    static tensor_return_value_t create_output_tensors(
+        const operation_attributes_t& operation_attributes, const tensor_args_t&);
+
+    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
+        const Tensor& input_tensor,
+        const tt::tt_metal::MemoryConfig& memory_config,
+        std::optional<Tensor> optional_output_tensor);
 };
 
-}  // namespace ttnn::operations::experimental::transformer
+}  // namespace ttnn::operations::experimental::nlp_concat_heads_boltz
+
+namespace ttnn::prim {
+constexpr auto nlp_concat_heads_boltz = ttnn::register_operation<
+    "ttnn::prim::nlp_concat_heads_boltz",
+    ttnn::operations::experimental::nlp_concat_heads_boltz::NLPConcatHeadsBoltzDeviceOperation>();
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_boltz/device/nlp_concat_heads_boltz_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_boltz/device/nlp_concat_heads_boltz_device_operation_types.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_boltz/device/nlp_concat_heads_boltz_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_boltz/device/nlp_concat_heads_boltz_device_operation_types.hpp
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/tensor/tensor.hpp"
+
+namespace ttnn::operations::experimental::nlp_concat_heads_boltz {
+
+struct operation_attributes_t {
+    tt::tt_metal::MemoryConfig output_mem_config;
+};
+
+struct tensor_args_t {
+    Tensor input;
+    std::optional<Tensor> preallocated_output;
+};
+
+using tensor_return_value_t = Tensor;
+using spec_return_value_t = TensorSpec;
+
+}  // namespace ttnn::operations::experimental::nlp_concat_heads_boltz

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_boltz/device/nlp_concat_heads_boltz_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_boltz/device/nlp_concat_heads_boltz_program_factory.cpp
@@ -4,17 +4,23 @@
 
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/constants.hpp>
-#include "nlp_concat_heads_boltz_device_operation.hpp"
+#include "nlp_concat_heads_boltz_program_factory.hpp"
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 
-namespace ttnn::operations::experimental::transformer {
+namespace ttnn::operations::experimental::nlp_concat_heads_boltz {
+namespace program {
 
 using namespace tt::constants;
 using namespace tt;
 
-tt::tt_metal::operation::ProgramWithCallbacks multi_core_nlp_concat_heads_boltz(
-    const Tensor& a, Tensor& output, CoreCoord compute_with_storage_grid_size) {
+NLPConcatHeadsBoltzProgramFactory::cached_program_t NLPConcatHeadsBoltzProgramFactory::create(
+    const operation_attributes_t& operation_attributes,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& output) {
+    const auto& a = tensor_args.input;
+    CoreCoord compute_with_storage_grid_size = a.device()->compute_with_storage_grid_size();
+
     const auto& ashape = a.padded_shape();
 
     tt::DataFormat cb_data_format = tt_metal::datatype_to_dataformat_converter(a.dtype());
@@ -187,35 +193,48 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_nlp_concat_heads_boltz(
         }
     }
 
-    auto override_runtime_arguments_callback = [reader_kernel_id, writer_kernel_id, cb_src0, cb_out, cores](
-                                                   const void* operation,
-                                                   tt::tt_metal::Program& program,
-                                                   const std::vector<Tensor>& input_tensors,
-                                                   const std::vector<std::optional<const Tensor>>&,
-                                                   const std::vector<Tensor>& output_tensors) {
-        const auto src_buffer = input_tensors.at(0).buffer();
-        const auto dst_buffer = output_tensors.at(0).buffer();
-        const bool in_sharded = input_tensors.at(0).is_sharded();
-        const bool out_sharded = output_tensors.at(0).is_sharded();
-        if (in_sharded) {
-            UpdateDynamicCircularBufferAddress(program, cb_src0, *src_buffer);
-        } else {
-            for (const auto& core : cores) {
-                auto& runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
-                runtime_args[0] = src_buffer->address();
-            }
-        }
-
-        if (out_sharded) {
-            UpdateDynamicCircularBufferAddress(program, cb_out, *dst_buffer);
-        } else {
-            for (const auto& core : cores) {
-                auto& runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
-                runtime_args[0] = dst_buffer->address();
-            }
-        }
-    };
-    return {.program = std::move(program), .override_runtime_arguments_callback = override_runtime_arguments_callback};
+    // Return cached program with shared variables
+    return cached_program_t{
+        std::move(program),
+        {.reader_kernel_id = reader_kernel_id,
+         .writer_kernel_id = writer_kernel_id,
+         .cores = cores,
+         .cb_src0 = cb_src0,
+         .cb_out = cb_out}};
 }
 
-}  // namespace ttnn::operations::experimental::transformer
+void NLPConcatHeadsBoltzProgramFactory::override_runtime_arguments(
+    cached_program_t& cached_program,
+    const operation_attributes_t& operation_attributes,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& output) {
+    auto& program = cached_program.program;
+    auto& shared_variables = cached_program.shared_variables;
+
+    const auto& input = tensor_args.input;
+    const auto src_buffer = input.buffer();
+    const auto dst_buffer = output.buffer();
+    const bool in_sharded = input.is_sharded();
+    const bool out_sharded = output.is_sharded();
+
+    if (in_sharded) {
+        UpdateDynamicCircularBufferAddress(program, shared_variables.cb_src0, *src_buffer);
+    } else {
+        for (const auto& core : shared_variables.cores) {
+            auto& runtime_args = GetRuntimeArgs(program, shared_variables.reader_kernel_id, core);
+            runtime_args[0] = src_buffer->address();
+        }
+    }
+
+    if (out_sharded) {
+        UpdateDynamicCircularBufferAddress(program, shared_variables.cb_out, *dst_buffer);
+    } else {
+        for (const auto& core : shared_variables.cores) {
+            auto& runtime_args = GetRuntimeArgs(program, shared_variables.writer_kernel_id, core);
+            runtime_args[0] = dst_buffer->address();
+        }
+    }
+}
+
+}  // namespace program
+}  // namespace ttnn::operations::experimental::nlp_concat_heads_boltz

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_boltz/device/nlp_concat_heads_boltz_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_boltz/device/nlp_concat_heads_boltz_program_factory.cpp
@@ -9,7 +9,6 @@
 #include <tt-metalium/tensor_accessor_args.hpp>
 
 namespace ttnn::operations::experimental::nlp_concat_heads_boltz {
-namespace program {
 
 using namespace tt::constants;
 using namespace tt;

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_boltz/device/nlp_concat_heads_boltz_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_boltz/device/nlp_concat_heads_boltz_program_factory.cpp
@@ -235,5 +235,4 @@ void NLPConcatHeadsBoltzProgramFactory::override_runtime_arguments(
     }
 }
 
-}  // namespace program
 }  // namespace ttnn::operations::experimental::nlp_concat_heads_boltz

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_boltz/device/nlp_concat_heads_boltz_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_boltz/device/nlp_concat_heads_boltz_program_factory.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_boltz/device/nlp_concat_heads_boltz_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_boltz/device/nlp_concat_heads_boltz_program_factory.hpp
@@ -11,11 +11,11 @@
 namespace ttnn::operations::experimental::nlp_concat_heads_boltz {
 
 struct NLPConcatHeadsBoltzSharedVariables {
-    tt::tt_metal::KernelHandle reader_kernel_id;
-    tt::tt_metal::KernelHandle writer_kernel_id;
+    tt::tt_metal::KernelHandle reader_kernel_id{};
+    tt::tt_metal::KernelHandle writer_kernel_id{};
     std::vector<CoreCoord> cores;
-    tt::tt_metal::CBHandle cb_src0;
-    tt::tt_metal::CBHandle cb_out;
+    tt::tt_metal::CBHandle cb_src0{};
+    tt::tt_metal::CBHandle cb_out{};
 };
 
 struct NLPConcatHeadsBoltzProgramFactory {

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_boltz/device/nlp_concat_heads_boltz_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_boltz/device/nlp_concat_heads_boltz_program_factory.hpp
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/device_operation.hpp"
+#include "nlp_concat_heads_boltz_device_operation_types.hpp"
+
+namespace ttnn::operations::experimental::nlp_concat_heads_boltz {
+namespace program {
+
+struct NLPConcatHeadsBoltzSharedVariables {
+    tt::tt_metal::KernelHandle reader_kernel_id;
+    tt::tt_metal::KernelHandle writer_kernel_id;
+    std::vector<CoreCoord> cores;
+    tt::tt_metal::CBHandle cb_src0;
+    tt::tt_metal::CBHandle cb_out;
+};
+
+struct NLPConcatHeadsBoltzProgramFactory {
+    using shared_variables_t = NLPConcatHeadsBoltzSharedVariables;
+    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
+
+    static cached_program_t create(
+        const operation_attributes_t& operation_attributes,
+        const tensor_args_t& tensor_args,
+        tensor_return_value_t& tensor_return_value);
+
+    static void override_runtime_arguments(
+        cached_program_t& cached_program,
+        const operation_attributes_t& operation_attributes,
+        const tensor_args_t& tensor_args,
+        tensor_return_value_t& tensor_return_value);
+};
+
+}  // namespace program
+}  // namespace ttnn::operations::experimental::nlp_concat_heads_boltz

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_boltz/device/nlp_concat_heads_boltz_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_boltz/device/nlp_concat_heads_boltz_program_factory.hpp
@@ -9,7 +9,6 @@
 #include "nlp_concat_heads_boltz_device_operation_types.hpp"
 
 namespace ttnn::operations::experimental::nlp_concat_heads_boltz {
-namespace program {
 
 struct NLPConcatHeadsBoltzSharedVariables {
     tt::tt_metal::KernelHandle reader_kernel_id;
@@ -35,5 +34,4 @@ struct NLPConcatHeadsBoltzProgramFactory {
         tensor_return_value_t& tensor_return_value);
 };
 
-}  // namespace program
 }  // namespace ttnn::operations::experimental::nlp_concat_heads_boltz

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_boltz/nlp_concat_heads_boltz.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_boltz/nlp_concat_heads_boltz.cpp
@@ -14,12 +14,8 @@ ttnn::Tensor NLPConcatHeadsBoltzOperation::invoke(
     const Tensor& input_tensor,
     const std::optional<MemoryConfig>& memory_config,
     std::optional<Tensor> optional_output_tensor) {
-    return tt::tt_metal::operation::run(
-               NLPConcatHeadsBoltzDeviceOperation{memory_config.value_or(input_tensor.memory_config())},
-               {input_tensor},
-               {},
-               {std::move(optional_output_tensor)})
-        .at(0);
+    return ttnn::prim::nlp_concat_heads_boltz(
+        input_tensor, memory_config.value_or(input_tensor.memory_config()), std::move(optional_output_tensor));
 }
 
 }  // namespace ttnn::operations::experimental::transformer


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/32708)

### Problem description
Migrating nlp_concat_heads_boltz op to new device op infra

### What's changed

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes ([link to run](https://github.com/tenstorrent/tt-metal/actions/runs/19714813564))
- [x] L2 nightly cpp tests ([link to run](https://github.com/tenstorrent/tt-metal/actions/runs/19714806921))
- [x] New/Existing tests provide coverage for changes