### PR TITLE
#0: Convenience Compute API changes

### DIFF
--- a/tt_metal/include/compute_kernel_api/bcast.h
+++ b/tt_metal/include/compute_kernel_api/bcast.h
@@ -28,8 +28,8 @@ namespace ckernel {
  * This function configures the unpacker, math, and packer threads for broadcast operations. In order for broadcast operations to be performed,
  * this function call must be followed by calls to `unary_bcast`.
  *
- * NOTE: This function is a so-called "full init" which will be deprecated in the futuree in favor of using `unary_bcast_init_short` preceded
- * by `ompute_kernel_hw_startup`.
+ * NOTE: This function is a so-called "full init" which will be deprecated in the future in favor of using `unary_bcast_init_short` preceded
+ * by `compute_kernel_hw_startup`.
  *
  * Return value: None
  *
@@ -66,7 +66,7 @@ ALWI void unary_bcast_init(uint32_t icb, uint32_t ocb) {
  * Performs a minimal hardware and software initialization for unary broadcast operations for provided circular buffer identifier (CB ID).
  * This function configures only the unpacker and math threads for broadcast operations, without touching the packer or destination buffer
  * addressing state. This is the preferred init function when mixing broadcast operations with other operations like `copy_tile` in loops.
-* The broadcast operation copies/expands data according to the specified broadcast type:
+ * The broadcast operation copies/expands data according to the specified broadcast type:
  * - BroadcastType::NONE: No broadcast (direct copy)
  * - BroadcastType::ROW: Broadcast along rows (repeat row data across columns)
  * - BroadcastType::COL: Broadcast along columns (repeat column data across rows)

--- a/tt_metal/include/compute_kernel_api/reduce.h
+++ b/tt_metal/include/compute_kernel_api/reduce.h
@@ -120,7 +120,8 @@ ALWI void reduce_tile(uint32_t icb, uint32_t icb_scaler, uint32_t itile, uint32_
 
 // clang-format off
 /**
- * Performs a math-only reduction operation on a tile in the DST register. Assumes that source tiles are already in source registers.
+ * Performs a math-only reduction operation on a tile in the SrcA register. Assumes that the operand tile is already in the SrcA register and that
+ * the scaler is already in the SrcB register.
  *
  * | Param Type | Name                      | Description                                                                             | Type      | Valid Range                                    | Required |
  * |------------|---------------------------|-----------------------------------------------------------------------------------------|-----------|------------------------------------------------|----------|


### PR DESCRIPTION
### Ticket
N/A

### Problem description
`unary_bcast` operation only has a "full" init variant which is not intended to be used anywhere other than the start of the kernel.
`reduce_tile_math` has an misleading comment in the description. 

### What's changed
1. Add a short version of the init for `unary_bcast` operation.
2. Change `reduce_tile_math` comment to be more precise.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes