### PR TITLE
Fix exception handling in build.cpp

### DIFF
--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -42,16 +42,6 @@ namespace fs = std::filesystem;
 using namespace std;
 using namespace tt;
 
-namespace {
-
-void sync_events(auto& events) {
-    for (auto& f : events) {
-        f.get();
-    }
-}
-
-}  // namespace
-
 namespace tt::tt_metal {
 
 namespace {
@@ -478,7 +468,7 @@ size_t JitBuildState::compile(const string& out_dir, const JitBuildSettings* set
         }
     }
 
-    sync_events(events);
+    sync_build_steps(events);
 
     if (tt::tt_metal::MetalContext::instance().rtoptions().get_watcher_enabled()) {
         dump_kernel_defines_and_args(env_.get_out_kernel_root_path());
@@ -607,7 +597,7 @@ void jit_build_subset(JitBuildStateSubset build_subset, const JitBuildSettings* 
         launch_build_step([&build, settings] { build.build(settings); }, events);
     }
 
-    sync_events(events);
+    sync_build_steps(events);
     for (auto& build : build_subset) {
         write_successful_jit_build_marker(build, settings);
     }
@@ -619,7 +609,7 @@ void launch_build_step(const std::function<void()>& build_func, std::vector<std:
 
 void sync_build_steps(std::vector<std::shared_future<void>>& events) {
     for (auto& event : events) {
-        event.wait();
+        event.get();
     }
 }
 


### PR DESCRIPTION
### Ticket
n/a

### Problem description
We should call get() instead of wait() to propagate exceptions happened in build tasks.

### What's changed

Changed `wait` to `get`.
Also, `sync_events` is the same as `sync_build_steps`; deleted the former.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/19688517262) CI passes

Manually compiled a bad kernel and verified exception is not swallowed.