### PR TITLE
Resolve Segfault in Cluster Validation when Deployment Desc is not specified

### DIFF
--- a/tools/scaleout/validation/run_cluster_validation.cpp
+++ b/tools/scaleout/validation/run_cluster_validation.cpp
@@ -173,7 +173,8 @@ AsicTopology run_connectivity_validation(
         input_args.cabling_descriptor_path,
         input_args.deployment_descriptor_path,
         input_args.fsd_path,
-        input_args.output_path.string());
+        input_args.output_path.string(),
+        physical_system_descriptor.get_all_hostnames());
     auto missing_topology =
         validate_connectivity(fsd_path, gsd_yaml_path, input_args.fail_on_warning, physical_system_descriptor);
 

--- a/tools/scaleout/validation/utils/cluster_validation_utils.cpp
+++ b/tools/scaleout/validation/utils/cluster_validation_utils.cpp
@@ -957,7 +957,8 @@ void handle_workload_timeout(
             validation_config.cabling_descriptor_path,
             validation_config.deployment_descriptor_path,
             validation_config.fsd_path,
-            validation_config.output_path.string());
+            validation_config.output_path.string(),
+            ctx.physical_system_descriptor.get_all_hostnames());
         validate_connectivity(
             fsd_file_path, gsd_yaml_path, validation_config.fail_on_warning, ctx.physical_system_descriptor);
     } else {
@@ -1434,16 +1435,24 @@ std::string get_factory_system_descriptor_path(
     const std::optional<std::string>& cabling_descriptor_path,
     const std::optional<std::string>& deployment_descriptor_path,
     const std::optional<std::string>& fsd_path,
-    const std::string& output_path) {
+    const std::string& output_path,
+    const std::vector<std::string>& hostnames) {
     std::string fsd_file_path;
     if (cabling_descriptor_path.has_value()) {
         const auto& distributed_context = tt::tt_metal::MetalContext::instance().global_distributed_context();
         log_output_rank0("Creating Factory System Descriptor (Golden Representation)");
-        tt::scaleout_tools::CablingGenerator cabling_generator(
-            cabling_descriptor_path.value(), deployment_descriptor_path.value());
+        CablingGenerator cabling_generator;
         std::string filename =
             "generated_factory_system_descriptor_" + std::to_string(*distributed_context.rank()) + ".textproto";
         fsd_file_path = std::filesystem::path(output_path) / filename;
+
+        if (!deployment_descriptor_path.has_value()) {
+            TT_FATAL(hostnames.size() == 1, "Expected exactly one host in the cluster when no deployment descriptor is provided");
+            cabling_generator = tt::scaleout_tools::CablingGenerator(cabling_descriptor_path.value(), hostnames);
+        } else {
+            cabling_generator = tt::scaleout_tools::CablingGenerator(
+                cabling_descriptor_path.value(), deployment_descriptor_path.value());
+        }
         cabling_generator.emit_factory_system_descriptor(fsd_file_path);
     } else {
         fsd_file_path = fsd_path.value();

--- a/tools/scaleout/validation/utils/cluster_validation_utils.hpp
+++ b/tools/scaleout/validation/utils/cluster_validation_utils.hpp
@@ -77,7 +77,8 @@ std::string get_factory_system_descriptor_path(
     const std::optional<std::string>& cabling_descriptor_path,
     const std::optional<std::string>& deployment_descriptor_path,
     const std::optional<std::string>& fsd_path,
-    const std::string& output_path);
+    const std::string& output_path,
+    const std::vector<std::string>& hostnames);
 
 tt_metal::AsicTopology validate_connectivity(
     const std::string& fsd_path,


### PR DESCRIPTION
### Ticket
No Ticket.

### Problem description
- Validation without a deployment descriptor was broken in commit: https://github.com/tenstorrent/tt-metal/commit/527d114a747f56a170a868cce4f77c2a23633d96, since hostnames were not correctly propagated

### What's changed
- Propagate the hostnames from the GSD into the `get_factory_system_descriptor_path` to generate an FSD without a Deployment Descriptor for single host validation

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes