### PR TITLE
SD expected device perf bump

### DIFF
--- a/models/demos/wormhole/stable_diffusion/tests/test_perf.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_perf.py
@@ -420,7 +420,7 @@ def test_stable_diffusion_perf(
 @pytest.mark.models_device_performance_bare_metal
 @pytest.mark.parametrize(
     "expected_kernel_samples_per_second",
-    ((12.8) if is_wormhole_b0() else (20.0),),
+    ((13.2) if is_wormhole_b0() else (20.0),),
 )
 def test_stable_diffusion_device_perf(expected_kernel_samples_per_second):
     subdir = "ttnn_stable_diffusion"


### PR DESCRIPTION
### Problem description
Device perf CI is red on latest main due to SD being faster than expected
https://github.com/tenstorrent/tt-metal/actions/runs/19695459464/job/56420307971#step:6:661
https://github.com/tenstorrent/tt-metal/actions/runs/19690700817/job/56406345964#step:6:660
https://github.com/tenstorrent/tt-metal/actions/runs/19686811479/job/56394745033#step:6:661
### What's changed
- Bumped `stable_diffusion`  expected kernel samples per second from 12.8 to 13.2 for Wormhole B0
