### PR TITLE
Update CMakeLists.txt to include new header file for embedding device…

### DIFF
--- a/ttnn/cpp/ttnn/operations/embedding/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/embedding/CMakeLists.txt
@@ -17,7 +17,14 @@ target_sources(
         FILE_SET api
         TYPE HEADERS
         BASE_DIRS ${FixmeOpAPIDir}
-        FILES embedding.hpp device/embedding_device_operation.hpp device/embedding_device_operation_types.hpp
+        FILES
+            embedding.hpp
+            device/embedding_device_operation.hpp
+            device/embedding_device_operation_types.hpp
+            device/embeddings_fused_program_factory.hpp
+            device/embeddings_rm_program_factory.hpp
+            device/embeddings_tilized_indices_program_factory.hpp
+            device/embedding_program_factory_common.hpp
         FILE_SET kernels
         TYPE HEADERS
         BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}

--- a/ttnn/cpp/ttnn/operations/embedding/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/embedding/CMakeLists.txt
@@ -17,7 +17,7 @@ target_sources(
         FILE_SET api
         TYPE HEADERS
         BASE_DIRS ${FixmeOpAPIDir}
-        FILES embedding.hpp device/embedding_device_operation.hpp
+        FILES embedding.hpp device/embedding_device_operation.hpp device/embedding_device_operation_types.hpp
         FILE_SET kernels
         TYPE HEADERS
         BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}


### PR DESCRIPTION
… operations

### What's changed
- Added `device/embedding_device_operation_types.hpp` to the list of header files in the target_sources for embedding operations.

### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes