### PR TITLE
Migrate op to new infra: copy

### DIFF
--- a/ttnn/cpp/ttnn/operations/core/to_memory_config/to_memory_config_op.hpp
+++ b/ttnn/cpp/ttnn/operations/core/to_memory_config/to_memory_config_op.hpp
@@ -96,13 +96,11 @@ struct ToMemoryConfig {
                     .at(0);
             } else {
                 // L1 to DRAM or DRAM to L1
-                return tt::tt_metal::operation::run(
-                           ttnn::operations::data_movement::CopyDeviceOperation{
-                               memory_config, dtype.value_or(tensor.dtype())},
-                           {tensor},
-                           {},
-                           optional_output_tensors)
-                    .at(0);
+                return ttnn::prim::copy(
+                    tensor,
+                    memory_config,
+                    dtype.value_or(tensor.dtype()),
+                    optional_output_tensors.empty() ? std::nullopt : optional_output_tensors.at(0));
             }
         }
 

--- a/ttnn/cpp/ttnn/operations/data_movement/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/data_movement/CMakeLists.txt
@@ -52,6 +52,8 @@ target_sources(
             concat/concat.hpp
             copy/copy.hpp
             copy/device/copy_device_operation.hpp
+            copy/device/copy_program_factory.hpp
+            copy/device/copy_device_operation_types.hpp
             fill_pad/fill_pad.hpp
             fill_pad/device/fill_pad_device_operation.hpp
             fill_rm/fill_rm.hpp

--- a/ttnn/cpp/ttnn/operations/data_movement/copy/copy.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/copy/copy.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -15,9 +15,7 @@ using namespace tt::tt_metal;
 namespace ttnn::operations::data_movement {
 
 ttnn::Tensor CopyOperation::invoke(const Tensor& src_tensor, const Tensor& dst_tensor) {
-    operation::run(
-        CopyDeviceOperation{dst_tensor.memory_config(), dst_tensor.dtype()}, {src_tensor, dst_tensor}, {}, {});
-    return dst_tensor;
+    return ttnn::prim::copy(src_tensor, dst_tensor.memory_config(), dst_tensor.dtype(), std::make_optional(dst_tensor));
 }
 
 ttnn::Tensor AssignOperation::invoke(
@@ -25,12 +23,7 @@ ttnn::Tensor AssignOperation::invoke(
     const MemoryConfig& output_mem_config,
     std::optional<const DataType> output_dtype,
     std::optional<Tensor> optional_output_tensor) {
-    return operation::run(
-               CopyDeviceOperation{output_mem_config, output_dtype.value_or(input.dtype())},
-               {input},
-               {},
-               {std::move(optional_output_tensor)})
-        .at(0);
+    return ttnn::prim::copy(input, output_mem_config, output_dtype.value_or(input.dtype()), optional_output_tensor);
 }
 
 ttnn::Tensor AssignOperation::invoke(
@@ -39,8 +32,7 @@ ttnn::Tensor AssignOperation::invoke(
 }
 
 ttnn::Tensor AssignOperation::invoke(const Tensor& input_a, const Tensor& input_b) {
-    operation::run(CopyDeviceOperation{input_b.memory_config(), input_b.dtype()}, {input_a, input_b}, {}, {});
-    return input_b;
+    return ttnn::prim::copy(input_a, input_b.memory_config(), input_b.dtype(), std::make_optional(input_b));
 }
 
 }  // namespace ttnn::operations::data_movement

--- a/ttnn/cpp/ttnn/operations/data_movement/copy/device/copy_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/copy/device/copy_device_operation.cpp
@@ -1,19 +1,33 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
 #include "copy_device_operation.hpp"
-#include "ttnn/tensor/tensor_utils.hpp"
-#include "ttnn/operations/data_movement/common/common.hpp"
+#include "copy_program_factory.hpp"
+#include "ttnn/operations/data_movement/common/common.hpp"  // common_tm_bw_model
 
-using namespace tt::constants;
+namespace ttnn::operations::data_movement::copy {
+
 using namespace tt::tt_metal;
 
-namespace ttnn::operations::data_movement {
+std::tuple<CopyDeviceOperation::operation_attributes_t, CopyDeviceOperation::tensor_args_t> CopyDeviceOperation::invoke(
+    const Tensor& input,
+    const tt::tt_metal::MemoryConfig& output_mem_config,
+    const tt::tt_metal::DataType& output_dtype,
+    const std::optional<Tensor>& preallocated_output) {
+    return {operation_attributes_t{output_mem_config, output_dtype}, tensor_args_t{input, preallocated_output}};
+}
 
-void CopyDeviceOperation::validate_with_output_tensors(
-    const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const {
-    const auto& input_tensor_a = input_tensors.at(0);
+CopyDeviceOperation::program_factory_t CopyDeviceOperation::select_program_factory(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    return copy::program::CopyProgramFactory{};
+}
+
+void CopyDeviceOperation::validate_on_program_cache_miss(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    using namespace tt::constants;
+
+    const Tensor& input_tensor_a = tensor_args.input;
     TT_FATAL(
         input_tensor_a.dtype() == DataType::BFLOAT16 or input_tensor_a.dtype() == DataType::BFLOAT8_B or
             input_tensor_a.dtype() == DataType::FLOAT32 or input_tensor_a.dtype() == DataType::BFLOAT4_B or
@@ -21,113 +35,92 @@ void CopyDeviceOperation::validate_with_output_tensors(
         "ttnn.copy only supports float, bfloat and int32 inputs but got {}",
         input_tensor_a.dtype());
     TT_FATAL(
-        this->output_dtype == DataType::BFLOAT16 or this->output_dtype == DataType::BFLOAT8_B or
-            this->output_dtype == DataType::FLOAT32 or this->output_dtype == DataType::BFLOAT4_B or
-            this->output_dtype == DataType::UINT32 or this->output_dtype == DataType::INT32,
+        operation_attributes.output_dtype == DataType::BFLOAT16 or
+            operation_attributes.output_dtype == DataType::BFLOAT8_B or
+            operation_attributes.output_dtype == DataType::FLOAT32 or
+            operation_attributes.output_dtype == DataType::BFLOAT4_B or
+            operation_attributes.output_dtype == DataType::UINT32 or
+            operation_attributes.output_dtype == DataType::INT32,
         "ttnn.copy only supports float, bfloat and int32 output tensors but got {}",
-        this->output_dtype);
+        operation_attributes.output_dtype);
     TT_FATAL(input_tensor_a.storage_type() == StorageType::DEVICE, "Operands to copy need to be on device!");
     TT_FATAL(input_tensor_a.buffer() != nullptr, "Operands to copy need to be allocated in buffers on device!");
 
-    if (input_tensors.size() == 2) {
-        const auto& dst_tensor = input_tensors[1];
+    // Determine the actual output dtype based on preallocated output if present
+    DataType output_dtype = operation_attributes.output_dtype;
+    if (tensor_args.preallocated_output.has_value()) {
+        const Tensor& out_tensor = tensor_args.preallocated_output.value();
         TT_FATAL(
-            input_tensor_a.padded_shape() == dst_tensor.padded_shape(),
-            "Input tensor padded shape ({}) must equal destination tensor padded shape ({})",
+            out_tensor.logical_shape() == input_tensor_a.logical_shape() &&
+                out_tensor.padded_shape() == input_tensor_a.padded_shape(),
+            "Input tensor shape {}/{} does not match output tensor shape {}/{}",
+            input_tensor_a.logical_shape(),
             input_tensor_a.padded_shape(),
-            dst_tensor.padded_shape());
-        TT_FATAL(
-            input_tensor_a.layout() == dst_tensor.layout(),
-            "Input tensor layout ({}) must equal destination tensor layout ({})",
-            input_tensor_a.layout(),
-            dst_tensor.layout());
-        TT_FATAL(
-            input_tensor_a.memory_config().memory_layout() == dst_tensor.memory_config().memory_layout(),
-            "Input tensor memory layout ({}) must equal destination tensor memory layout ({})",
-            input_tensor_a.memory_config().memory_layout(),
-            dst_tensor.memory_config().memory_layout());
-    }
-    DataType output_dtype = this->output_dtype;
-    if (!output_tensors.empty() && output_tensors.at(0).has_value()) {
-        const auto& out_tensor = output_tensors.at(0).value();
-        const auto& output_shape_tensor = input_tensors.size() == 2 ? input_tensors[1] : input_tensor_a;
-        TT_FATAL(
-            out_tensor.logical_shape() == output_shape_tensor.logical_shape() &&
-                out_tensor.padded_shape() == output_shape_tensor.padded_shape(),
-            "The input tensors need a shape of {}/{}, however the output tensor is only {}/{}",
-            output_shape_tensor.logical_shape(),
-            output_shape_tensor.padded_shape(),
             out_tensor.logical_shape(),
             out_tensor.padded_shape());
+        TT_FATAL(
+            input_tensor_a.layout() == out_tensor.layout(),
+            "Input tensor layout ({}) must equal output tensor layout ({})",
+            input_tensor_a.layout(),
+            out_tensor.layout());
+        TT_FATAL(
+            input_tensor_a.memory_config().memory_layout() == out_tensor.memory_config().memory_layout(),
+            "Input tensor memory layout ({}) must equal output tensor memory layout ({})",
+            input_tensor_a.memory_config().memory_layout(),
+            out_tensor.memory_config().memory_layout());
+        // Use the preallocated output's dtype for subsequent validation
         output_dtype = out_tensor.dtype();
     }
+
+    // Check if dtype conversion is supported (only on TILE layout)
     if (output_dtype != input_tensor_a.dtype()) {
         TT_FATAL(input_tensor_a.layout() == Layout::TILE, "Only tile layout supports dtype conversion");
     }
-    auto out_mem_config = (!output_tensors.empty() && output_tensors.at(0).has_value())
-                              ? output_tensors.at(0).value().memory_config()
-                              : this->output_mem_config;
 }
 
-std::vector<ttnn::TensorSpec> CopyDeviceOperation::compute_output_specs(
-    const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const {
-    if (!output_tensors.empty() && output_tensors[0].has_value()) {
-        return {output_tensors[0]->tensor_spec()};
-    }
-    if (input_tensors.size() == 2) {
-        return {input_tensors[1].tensor_spec()};
+void CopyDeviceOperation::validate_on_program_cache_hit(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    validate_on_program_cache_miss(operation_attributes, tensor_args);
+}
+
+CopyDeviceOperation::spec_return_value_t CopyDeviceOperation::compute_output_specs(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    if (tensor_args.preallocated_output.has_value()) {
+        return tensor_args.preallocated_output->tensor_spec();
     }
 
-    const auto& input_tensor = input_tensors.at(0);
-    return {TensorSpec(
+    const Tensor& input_tensor = tensor_args.input;
+    return TensorSpec(
         input_tensor.logical_shape(),
         TensorLayout::fromPaddedShape(
-            output_dtype,
+            operation_attributes.output_dtype,
             PageConfig(input_tensor.layout()),
-            output_mem_config,
+            operation_attributes.output_mem_config,
             input_tensor.logical_shape(),
-            input_tensor.padded_shape()))};
+            input_tensor.padded_shape()));
 }
 
-std::vector<Tensor> CopyDeviceOperation::create_output_tensors(
-    const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const {
-    if (!output_tensors.empty() && output_tensors[0].has_value()) {
-        return {output_tensors[0].value()};
-    }
-    if (input_tensors.size() == 2) {
-        return {input_tensors[1]};
-    }
-    const auto& input_tensor = input_tensors.at(0);
-    auto spec = compute_output_specs(input_tensors, output_tensors)[0];
-    return {create_device_tensor(spec, input_tensor.device())};
-}
 tt::tt_metal::operation::OpPerformanceModelGeneral<std::vector<Tensor>>
 CopyDeviceOperation::create_op_performance_model(
     const std::vector<Tensor>& input_tensors,
     const std::vector<std::optional<const Tensor>>& optional_input_tensors,
-    std::vector<Tensor>& output_tensors) const {
+    std::vector<Tensor>& output_tensors) {
     const auto& input_tensor = input_tensors.at(0);
     const auto& output_tensor = output_tensors.at(0);
-    int ideal_dev_clock_cycles = common_tm_bw_model(input_tensor, output_tensor);
+    const int ideal_dev_clock_cycles = common_tm_bw_model(input_tensor, output_tensor);
     tt::tt_metal::operation::OpPerformanceModelGeneral<std::vector<Tensor>> result(
         input_tensors, output_tensors, ideal_dev_clock_cycles);
     return result;
 }
 
-operation::ProgramWithCallbacks CopyDeviceOperation::create_program(
-    const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const {
-    const auto& input_tensor = input_tensors.at(0);
-    const auto& output_tensor = output_tensors.at(0);
-
-    switch (CopyDeviceOperation::get_parallelization_strategy(input_tensors)) {
-        case CopyOpParallelizationStrategy::MULTI_CORE:
-        default: return copy_multi_core(input_tensor, output_tensor);
+CopyDeviceOperation::tensor_return_value_t CopyDeviceOperation::create_output_tensors(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    if (tensor_args.preallocated_output.has_value()) {
+        return tensor_args.preallocated_output.value();
     }
+    const Tensor& input_tensor = tensor_args.input;
+    const spec_return_value_t spec = compute_output_specs(operation_attributes, tensor_args);
+    return create_device_tensor(spec, input_tensor.device());
 }
 
-CopyOpParallelizationStrategy CopyDeviceOperation::get_parallelization_strategy(
-    const std::vector<Tensor>& input_tensors) const {
-    return CopyOpParallelizationStrategy::MULTI_CORE;
-}
-
-}  // namespace ttnn::operations::data_movement
+}  // namespace ttnn::operations::data_movement::copy

--- a/ttnn/cpp/ttnn/operations/data_movement/copy/device/copy_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/copy/device/copy_device_operation.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -6,33 +6,49 @@
 
 #include <optional>
 #include "ttnn/tensor/tensor.hpp"
-#include "ttnn/run_operation.hpp"
+#include "ttnn/decorators.hpp"
+#include "copy_device_operation_types.hpp"
+#include "copy_program_factory.hpp"
 
-namespace ttnn::operations::data_movement {
-
-enum class CopyOpParallelizationStrategy { MULTI_CORE };
+namespace ttnn::operations::data_movement::copy {
 
 struct CopyDeviceOperation {
-    const tt::tt_metal::MemoryConfig output_mem_config;
-    const tt::tt_metal::DataType output_dtype{};
+    using operation_attributes_t = copy::operation_attributes_t;
+    using tensor_args_t = copy::tensor_args_t;
+    using spec_return_value_t = copy::spec_return_value_t;
+    using tensor_return_value_t = copy::tensor_return_value_t;
+    using program_factory_t = std::variant<copy::program::CopyProgramFactory>;
 
-    void validate_with_output_tensors(
-        const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const;
-    std::vector<ttnn::TensorSpec> compute_output_specs(
-        const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const;
-    tt::tt_metal::operation::OpPerformanceModelGeneral<std::vector<Tensor>> create_op_performance_model(
+    static program_factory_t select_program_factory(
+        const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
+
+    static void validate_on_program_cache_hit(
+        const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
+
+    static void validate_on_program_cache_miss(
+        const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
+
+    static spec_return_value_t compute_output_specs(
+        const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
+
+    static tt::tt_metal::operation::OpPerformanceModelGeneral<std::vector<Tensor>> create_op_performance_model(
         const std::vector<Tensor>& input_tensors,
         const std::vector<std::optional<const Tensor>>& optional_input_tensors,
-        std::vector<Tensor>& output_tensors) const;
+        std::vector<Tensor>& output_tensors);
 
-    std::vector<Tensor> create_output_tensors(
-        const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const;
-    tt::tt_metal::operation::ProgramWithCallbacks create_program(
-        const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const;
-    CopyOpParallelizationStrategy get_parallelization_strategy(const std::vector<Tensor>& input_tensors) const;
+    static tensor_return_value_t create_output_tensors(
+        const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
+
+    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
+        const Tensor& input,
+        const tt::tt_metal::MemoryConfig& output_mem_config,
+        const tt::tt_metal::DataType& output_dtype,
+        const std::optional<Tensor>& preallocated_output);
 };
 
-tt::tt_metal::operation::ProgramWithCallbacks copy_multi_core(
-    const Tensor& input, const Tensor& output, bool backwards = false);
+}  // namespace ttnn::operations::data_movement::copy
 
-}  // namespace ttnn::operations::data_movement
+namespace ttnn::prim {
+constexpr auto copy =
+    ttnn::register_operation<"ttnn::prim::copy", ttnn::operations::data_movement::copy::CopyDeviceOperation>();
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/copy/device/copy_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/copy/device/copy_device_operation_types.hpp
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <optional>
+#include "ttnn/tensor/tensor.hpp"
+
+namespace ttnn::operations::data_movement::copy {
+
+struct operation_attributes_t {
+    tt::tt_metal::MemoryConfig output_mem_config;
+    tt::tt_metal::DataType output_dtype;
+};
+
+struct tensor_args_t {
+    Tensor input;
+    std::optional<Tensor> preallocated_output;
+};
+
+using spec_return_value_t = TensorSpec;
+using tensor_return_value_t = Tensor;
+
+}  // namespace ttnn::operations::data_movement::copy

--- a/ttnn/cpp/ttnn/operations/data_movement/copy/device/copy_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/copy/device/copy_program_factory.cpp
@@ -5,79 +5,82 @@
 #include <math.h>
 
 #include <tt-metalium/work_split.hpp>
-#include "copy_device_operation.hpp"
-#include "ttnn/operations/math.hpp"
+#include "copy_program_factory.hpp"
 
 #include <tt-metalium/constants.hpp>
-#include <algorithm>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-metalium/tt_align.hpp>
 #include "ttnn/operations/ccl/sharding_addrgen_helper.hpp"
 
-using namespace tt::constants;
-using namespace tt::tt_metal;
+namespace ttnn::operations::data_movement::copy::program {
 
-namespace ttnn::operations::data_movement {
+CopyProgramFactory::cached_program_t CopyProgramFactory::create(
+    const copy::operation_attributes_t& operation_attributes,
+    const copy::tensor_args_t& tensor_args,
+    copy::tensor_return_value_t& output) {
+    using namespace tt::constants;
+    using namespace tt::tt_metal;
 
-operation::ProgramWithCallbacks copy_multi_core(const Tensor& input, const Tensor& output, bool backwards) {
-    tt::tt_metal::Program program{};
+    const Tensor& input = tensor_args.input;
+    const bool backwards = false;
+    Program program{};
 
-    bool tilized = output.layout() == Layout::TILE;
-    bool sharded = input.memory_config().memory_layout() != TensorMemoryLayout::INTERLEAVED;
-    tt::DataFormat input_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input.dtype());
+    const bool tilized = output.layout() == Layout::TILE;
+    const bool sharded = input.memory_config().memory_layout() != TensorMemoryLayout::INTERLEAVED;
+    const tt::DataFormat input_cb_data_format = datatype_to_dataformat_converter(input.dtype());
     uint32_t input_unit_size = tilized ? tt::tile_size(input_cb_data_format)
                                        : input.padded_shape()[-1] * input.element_size();
-    uint32_t full_input_row = input_unit_size;
+    const uint32_t full_input_row = input_unit_size;
     if (sharded && !tilized) {
         input_unit_size = input.memory_config().shard_spec()->shape[1] * input.element_size();
     }
-    tt::DataFormat output_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
+    const tt::DataFormat output_cb_data_format = datatype_to_dataformat_converter(output.dtype());
     uint32_t output_unit_size = tilized ? tt::tile_size(output_cb_data_format)
                                         : output.padded_shape()[-1] * output.element_size();
-    uint32_t full_output_row = output_unit_size;
+    const uint32_t full_output_row = output_unit_size;
     if (sharded && !tilized) {
         output_unit_size = output.memory_config().shard_spec()->shape[1] * output.element_size();
     }
 
-    bool convert_dtype = input_cb_data_format != output_cb_data_format;
+    const bool convert_dtype = input_cb_data_format != output_cb_data_format;
 
-    uint32_t num_units =
+    const uint32_t num_units =
         tilized ? output.physical_volume() / TILE_HW : output.physical_volume() / output.padded_shape()[-1];
 
-    tt::tt_metal::IDevice* device = output.device();
+    IDevice* device = output.device();
 
-    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
-    uint32_t num_cores_x = compute_with_storage_grid_size.x;
-    uint32_t num_cores_y = compute_with_storage_grid_size.y;
-    auto [num_cores, all_cores, core_group_1, core_group_2, num_units_per_core_group_1, num_units_per_core_group_2] =
-        tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_units);
+    const CoreCoord compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    const uint32_t num_cores_x = compute_with_storage_grid_size.x;
+    const uint32_t num_cores_y = compute_with_storage_grid_size.y;
+    const auto
+        [num_cores, all_cores, core_group_1, core_group_2, num_units_per_core_group_1, num_units_per_core_group_2] =
+            split_work_to_cores(compute_with_storage_grid_size, num_units);
 
-    uint32_t src0_cb_index = tt::CBIndex::c_0;
-    uint32_t num_input_units = 2;
-    auto input_alignment = input.buffer()->alignment();
-    uint32_t aligned_input_unit_size = tt::align(input_unit_size, input_alignment);
-    tt::tt_metal::CircularBufferConfig cb_src0_config =
-        tt::tt_metal::CircularBufferConfig(
-            num_input_units * aligned_input_unit_size, {{src0_cb_index, input_cb_data_format}})
+    const uint32_t src0_cb_index = tt::CBIndex::c_0;
+    const uint32_t num_input_units = 2;
+    const uint32_t input_alignment = input.buffer()->alignment();
+    const uint32_t aligned_input_unit_size = tt::align(input_unit_size, input_alignment);
+    const CircularBufferConfig cb_src0_config =
+        CircularBufferConfig(num_input_units * aligned_input_unit_size, {{src0_cb_index, input_cb_data_format}})
             .set_page_size(src0_cb_index, aligned_input_unit_size);
-    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_src0_config);
+    CreateCircularBuffer(program, all_cores, cb_src0_config);
 
     uint32_t output_cb_index = src0_cb_index;  // same as input cb
     if (convert_dtype) {
         output_cb_index = tt::CBIndex::c_16;
-        uint32_t num_output_units = 2;
-        auto output_alignment = output.buffer()->alignment();
-        uint32_t aligned_output_unit_size = tt::align(output_unit_size, output_alignment);
-        tt::tt_metal::CircularBufferConfig output_cb_config =
-            tt::tt_metal::CircularBufferConfig(
+        const uint32_t num_output_units = 2;
+        const uint32_t output_alignment = output.buffer()->alignment();
+        const uint32_t aligned_output_unit_size = tt::align(output_unit_size, output_alignment);
+        const CircularBufferConfig output_cb_config =
+            CircularBufferConfig(
                 num_output_units * aligned_output_unit_size, {{output_cb_index, output_cb_data_format}})
                 .set_page_size(output_cb_index, aligned_output_unit_size);
-        tt::tt_metal::CreateCircularBuffer(program, all_cores, output_cb_config);
+        CreateCircularBuffer(program, all_cores, output_cb_config);
     }
 
-    auto* src_buffer = input.buffer();
-    auto* dst_buffer = output.buffer();
+    Buffer* src_buffer = input.buffer();
+    Buffer* dst_buffer = output.buffer();
 
     std::vector<uint32_t> reader_compile_time_args, writer_compile_time_args;
     if (tilized) {
@@ -98,41 +101,41 @@ operation::ProgramWithCallbacks copy_multi_core(const Tensor& input, const Tenso
     if (backwards) {
         kernel_defines["BACKWARDS"] = "1";
     }
-    std::string reader_rm_path =
+    const std::string reader_rm_path =
         sharded ? "ttnn/cpp/ttnn/operations/data_movement/copy/device/kernels/reader_unary_stick_start_id.cpp"
                 : "ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/dataflow/reader_unary_stick_layout_interleaved_start_id.cpp";
-    tt::tt_metal::KernelHandle unary_reader_kernel_id = tt::tt_metal::CreateKernel(
+    const KernelHandle unary_reader_kernel_id = CreateKernel(
         program,
         tilized ? "ttnn/cpp/ttnn/operations/data_movement/copy/device/kernels/reader_unary_start_id.cpp"
                 : reader_rm_path,
         all_cores,
-        tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args, kernel_defines));
+        ReaderDataMovementConfig(reader_compile_time_args, kernel_defines));
 
-    std::string writer_rm_path =
+    const std::string writer_rm_path =
         sharded ? "ttnn/cpp/ttnn/operations/data_movement/copy/device/kernels/writer_unary_stick_start_id.cpp"
                 : "ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/dataflow/writer_unary_stick_layout_interleaved_start_id.cpp";
-    tt::tt_metal::KernelHandle unary_writer_kernel_id = tt::tt_metal::CreateKernel(
+    const KernelHandle unary_writer_kernel_id = CreateKernel(
         program,
         tilized ? "ttnn/cpp/ttnn/operations/data_movement/copy/device/kernels/writer_unary_start_id.cpp"
                 : writer_rm_path,
         all_cores,
-        tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args, kernel_defines));
+        WriterDataMovementConfig(writer_compile_time_args, kernel_defines));
 
     if (convert_dtype) {
-        std::vector<uint32_t> compute_kernel_args_group_1 = {num_units_per_core_group_1};
-        tt::tt_metal::CreateKernel(
+        const std::vector<uint32_t> compute_kernel_args_group_1 = {num_units_per_core_group_1};
+        CreateKernel(
             program,
             "ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/compute/eltwise_copy.cpp",
             core_group_1,
-            tt::tt_metal::ComputeConfig{.compile_args = compute_kernel_args_group_1});
+            ComputeConfig{.compile_args = compute_kernel_args_group_1});
 
         if (!core_group_2.ranges().empty()) {
-            std::vector<uint32_t> compute_kernel_args_group_2 = {num_units_per_core_group_2};
-            tt::tt_metal::CreateKernel(
+            const std::vector<uint32_t> compute_kernel_args_group_2 = {num_units_per_core_group_2};
+            CreateKernel(
                 program,
                 "ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/compute/eltwise_copy.cpp",
                 core_group_2,
-                tt::tt_metal::ComputeConfig{.compile_args = compute_kernel_args_group_2});
+                ComputeConfig{.compile_args = compute_kernel_args_group_2});
         }
     }
 
@@ -141,12 +144,12 @@ operation::ProgramWithCallbacks copy_multi_core(const Tensor& input, const Tenso
         start_id = num_units - 1;
     }
 
-    uint32_t g1_numcores = core_group_1.num_cores();
-    auto cores = grid_to_cores(num_cores, num_cores_x, num_cores_y, false);
+    const uint32_t g1_numcores = core_group_1.num_cores();
+    const std::vector<CoreCoord> cores = grid_to_cores(num_cores, num_cores_x, num_cores_y, false);
 
     for (uint32_t i = 0; i < cores.size(); ++i) {
         const CoreCoord& core = cores.at(i);
-        uint32_t num_units_per_core = i < g1_numcores ? num_units_per_core_group_1 : num_units_per_core_group_2;
+        const uint32_t num_units_per_core = i < g1_numcores ? num_units_per_core_group_1 : num_units_per_core_group_2;
 
         if (tilized) {
             std::vector<uint32_t> reader_runtime_args = {src_buffer->address(), num_units_per_core, start_id};
@@ -155,8 +158,8 @@ operation::ProgramWithCallbacks copy_multi_core(const Tensor& input, const Tenso
                 shard_builder::extend_sharding_run_time_args(input, reader_runtime_args);
                 shard_builder::extend_sharding_run_time_args(input, writer_runtime_args);
             }
-            tt::tt_metal::SetRuntimeArgs(program, unary_reader_kernel_id, core, reader_runtime_args);
-            tt::tt_metal::SetRuntimeArgs(program, unary_writer_kernel_id, core, writer_runtime_args);
+            SetRuntimeArgs(program, unary_reader_kernel_id, core, reader_runtime_args);
+            SetRuntimeArgs(program, unary_writer_kernel_id, core, writer_runtime_args);
         } else {
             std::vector<uint32_t> reader_runtime_args = {
                 src_buffer->address(), input_unit_size, num_units_per_core, start_id, full_input_row / input_unit_size};
@@ -170,8 +173,8 @@ operation::ProgramWithCallbacks copy_multi_core(const Tensor& input, const Tenso
                 shard_builder::extend_sharding_run_time_args(input, reader_runtime_args);
                 shard_builder::extend_sharding_run_time_args(input, writer_runtime_args);
             }
-            tt::tt_metal::SetRuntimeArgs(program, unary_reader_kernel_id, core, reader_runtime_args);
-            tt::tt_metal::SetRuntimeArgs(program, unary_writer_kernel_id, core, writer_runtime_args);
+            SetRuntimeArgs(program, unary_reader_kernel_id, core, reader_runtime_args);
+            SetRuntimeArgs(program, unary_writer_kernel_id, core, writer_runtime_args);
         }
         if (backwards) {
             start_id -= num_units_per_core;
@@ -180,30 +183,39 @@ operation::ProgramWithCallbacks copy_multi_core(const Tensor& input, const Tenso
         }
     }
 
-    auto override_runtime_args_callback = [unary_reader_kernel_id, unary_writer_kernel_id, cores](
-                                              const void* operation,
-                                              Program& program,
-                                              const std::vector<Tensor>& input_tensors,
-                                              const std::vector<std::optional<const Tensor>>&,
-                                              const std::vector<Tensor>& output_tensors) {
-        auto* src_buffer = input_tensors.at(0).buffer();
-
-        auto* dst_buffer = output_tensors.at(0).buffer();
-
-        for (const auto& core : cores) {
-            {
-                auto& runtime_args = GetRuntimeArgs(program, unary_reader_kernel_id, core);
-                runtime_args[0] = src_buffer->address();
-            }
-
-            {
-                auto& runtime_args = GetRuntimeArgs(program, unary_writer_kernel_id, core);
-                runtime_args[0] = dst_buffer->address();
-            }
-        }
-    };
-
-    return {std::move(program), override_runtime_args_callback};
+    return {
+        std::move(program),
+        {.unary_reader_kernel_id = unary_reader_kernel_id,
+         .unary_writer_kernel_id = unary_writer_kernel_id,
+         .cores = cores}};
 }
 
-}  // namespace ttnn::operations::data_movement
+void CopyProgramFactory::override_runtime_arguments(
+    cached_program_t& cached_program,
+    const copy::operation_attributes_t& operation_attributes,
+    const copy::tensor_args_t& tensor_args,
+    copy::tensor_return_value_t& output) {
+    using namespace tt::tt_metal;
+
+    Program& program = cached_program.program;
+    const KernelHandle unary_reader_kernel_id = cached_program.shared_variables.unary_reader_kernel_id;
+    const KernelHandle unary_writer_kernel_id = cached_program.shared_variables.unary_writer_kernel_id;
+    const std::vector<CoreCoord>& cores = cached_program.shared_variables.cores;
+
+    Buffer* const src_buffer = tensor_args.input.buffer();
+    Buffer* const dst_buffer = output.buffer();
+
+    for (const CoreCoord& core : cores) {
+        {
+            RuntimeArgsData& runtime_args = GetRuntimeArgs(program, unary_reader_kernel_id, core);
+            runtime_args[0] = src_buffer->address();
+        }
+
+        {
+            RuntimeArgsData& runtime_args = GetRuntimeArgs(program, unary_writer_kernel_id, core);
+            runtime_args[0] = dst_buffer->address();
+        }
+    }
+}
+
+}  // namespace ttnn::operations::data_movement::copy::program

--- a/ttnn/cpp/ttnn/operations/data_movement/copy/device/copy_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/copy/device/copy_program_factory.hpp
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/device_operation.hpp"
+#include "copy_device_operation_types.hpp"
+
+namespace ttnn::operations::data_movement::copy::program {
+
+struct CopySharedVariables {
+    tt::tt_metal::KernelHandle unary_reader_kernel_id{};
+    tt::tt_metal::KernelHandle unary_writer_kernel_id{};
+    std::vector<CoreCoord> cores;
+};
+
+struct CopyProgramFactory {
+    using shared_variables_t = CopySharedVariables;
+    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
+
+    static cached_program_t create(
+        const copy::operation_attributes_t& operation_attributes,
+        const copy::tensor_args_t& tensor_args,
+        copy::tensor_return_value_t& output);
+
+    static void override_runtime_arguments(
+        cached_program_t& cached_program,
+        const copy::operation_attributes_t& operation_attributes,
+        const copy::tensor_args_t& tensor_args,
+        copy::tensor_return_value_t& output);
+};
+
+}  // namespace ttnn::operations::data_movement::copy::program

--- a/ttnn/cpp/ttnn/operations/experimental/copy/typecast/typecast.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/copy/typecast/typecast.cpp
@@ -14,13 +14,8 @@ ttnn::Tensor TypecastOperation::invoke(
     const DataType& dtype,
     const std::optional<MemoryConfig>& output_mem_config,
     const std::optional<Tensor>& optional_output_tensor) {
-    return tt::tt_metal::operation::run(
-               ttnn::operations::data_movement::CopyDeviceOperation{
-                   output_mem_config.value_or(input_tensor.memory_config()), dtype},
-               {input_tensor},
-               {},
-               {optional_output_tensor})
-        .at(0);
+    return ttnn::prim::copy(
+        input_tensor, output_mem_config.value_or(input_tensor.memory_config()), dtype, optional_output_tensor);
 }
 
 }  // namespace ttnn::operations::experimental::copy


### PR DESCRIPTION
### Ticket
[#32742](https://github.com/tenstorrent/tt-metal/issues/32742)

### Problem description
First, it is confusing to have 2 infrastructures to write operations.
Second, it is harder to do mass refactoring/development with AI because we follow 2 structures.

### What's changed
Migrate copy op to the new infrastructure.

### Notes
[Move op](https://github.com/tenstorrent/tt-metal/pull/33173) depends on copy, possible merge conflicts.

### Checklist
- [X] [All post commit #20098639830](https://github.com/tenstorrent/tt-metal/actions/runs/20098639830) CI passes