### PR TITLE
Adding act_block_h to conv2d dram oft test

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
@@ -4555,7 +4555,12 @@ def test_conv2d_dram_oft(
     packer_l1_acc,
 ):
     skip_if_not_blackhole_20_cores(device)
+
+    act_block_h_override = 32*8
+    config_override = {}
+    config_override["act_block_h"] = act_block_h_override
     batch_size = 1
+
     run_conv(
         device,
         torch_tensor_map,
@@ -4572,7 +4577,7 @@ def test_conv2d_dram_oft(
         stride[0],
         stride[1],
         padding,
-        config_override=None,
+        config_override=config_override,
         dilation_h=dilation[0],
         dilation_w=dilation[1],
         has_bias=has_bias,


### PR DESCRIPTION
### Problem description
Recent [change](https://github.com/tenstorrent/tt-metal/commit/e1b34d5de2fc8317c32f9ea79e2bdf33dbfbbd1e#diff-8073ef1c99564aab7070eeda83fb89f5c06b7d5b44b116536b2ea918f46bf66c) with disabling act_block_h_override and act_block_w_div in auto-shard codepath caused bos conv [nightly](https://github.com/tenstorrent/tt-metal/actions/runs/19694157281/job/56416147298) tests to fail 

### What's changed
Added act_block_h to conv config 

### Checklist
- [x] [Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/runs/19704726219)