### PR TITLE
#0: remove unnecessary to_layout from tests

### DIFF
--- a/tests/ttnn/unit_tests/operations/fused/sharded_test_utils.py
+++ b/tests/ttnn/unit_tests/operations/fused/sharded_test_utils.py
@@ -147,7 +147,6 @@ def ttnn_layer_norm_sharded(
         ),
     )
 
-    output_ttnn = ttnn.to_layout(output_ttnn, ttnn.ROW_MAJOR_LAYOUT)
     output_ttnn = ttnn.from_device(output_ttnn)
     return ttnn.to_torch(output_ttnn)
 
@@ -185,7 +184,6 @@ def ttnn_rms_norm_sharded(device, tt_input_tensor, block_ht, block_wt, subblock_
         ),
     )
 
-    output_ttnn = ttnn.to_layout(output_ttnn, ttnn.ROW_MAJOR_LAYOUT)
     output_ttnn = ttnn.from_device(output_ttnn)
     return ttnn.to_torch(output_ttnn)
 

--- a/tests/ttnn/unit_tests/operations/fused/test_layer_norm.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_layer_norm.py
@@ -23,7 +23,6 @@ def test_layer_norm(device, h, w, use_welford):
     input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
     program_config = ttnn.LayerNormDefaultProgramConfig(use_welford=use_welford)
     output_tensor = ttnn.layer_norm(input_tensor, program_config=program_config)
-    output_tensor = ttnn.to_layout(output_tensor, ttnn.ROW_MAJOR_LAYOUT)
     output_tensor = ttnn.from_device(output_tensor)
     output_tensor = ttnn.to_torch(output_tensor)
 
@@ -50,7 +49,6 @@ def test_layer_norm_with_weight_and_bias(device, h, w, use_welford):
 
     program_config = ttnn.LayerNormDefaultProgramConfig(use_welford=use_welford)
     output_tensor = ttnn.layer_norm(input_tensor, weight=weight, bias=bias, program_config=program_config)
-    output_tensor = ttnn.to_layout(output_tensor, ttnn.ROW_MAJOR_LAYOUT)
     output_tensor = ttnn.from_device(output_tensor)
     output_tensor = ttnn.to_torch(output_tensor)
 
@@ -77,7 +75,6 @@ def test_layer_norm_with_weight_and_bias_row_major(device, h, w, use_welford):
 
     program_config = ttnn.LayerNormDefaultProgramConfig(use_welford=use_welford)
     output_tensor = ttnn.layer_norm(input_tensor, weight=weight, bias=bias, program_config=program_config)
-    output_tensor = ttnn.to_layout(output_tensor, ttnn.ROW_MAJOR_LAYOUT)
     output_tensor = ttnn.from_device(output_tensor)
     output_tensor = ttnn.to_torch(output_tensor)
 
@@ -111,7 +108,6 @@ def test_layer_norm_with_weight_bias_and_residual_input(device, h, w, use_welfor
         bias=bias,
         program_config=program_config,
     )
-    output_tensor = ttnn.to_layout(output_tensor, ttnn.ROW_MAJOR_LAYOUT)
     output_tensor = ttnn.from_device(output_tensor)
     output_tensor = ttnn.to_torch(output_tensor)
 
@@ -151,7 +147,6 @@ def test_layer_norm_with_tile_layout(device, h, w):
         bias=bias,
     )
 
-    output_tensor = ttnn.to_layout(output_tensor, ttnn.ROW_MAJOR_LAYOUT)
     output_tensor = ttnn.from_device(output_tensor)
     output_tensor = ttnn.to_torch(output_tensor)
 
@@ -174,7 +169,6 @@ def test_large_layer_norm(device, h, w, use_welford, dtype):
     input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
     program_config = ttnn.LayerNormDefaultProgramConfig(use_welford=use_welford)
     output_tensor = ttnn.layer_norm(input_tensor, program_config=program_config)
-    output_tensor = ttnn.to_layout(output_tensor, ttnn.ROW_MAJOR_LAYOUT)
     output_tensor = ttnn.from_device(output_tensor)
     output_tensor = ttnn.to_torch(output_tensor)
 
@@ -201,7 +195,6 @@ def test_large_layer_norm_with_weight_and_bias(device, h, w, use_welford):
 
     program_config = ttnn.LayerNormDefaultProgramConfig(use_welford=use_welford)
     output_tensor = ttnn.layer_norm(input_tensor, weight=weight, bias=bias, program_config=program_config)
-    output_tensor = ttnn.to_layout(output_tensor, ttnn.ROW_MAJOR_LAYOUT)
     output_tensor = ttnn.from_device(output_tensor)
     output_tensor = ttnn.to_torch(output_tensor)
 
@@ -224,7 +217,6 @@ def test_large_layer_norm_with_weight(device, h, w, use_welford):
 
     program_config = ttnn.LayerNormDefaultProgramConfig(use_welford=use_welford)
     output_tensor = ttnn.layer_norm(input_tensor, weight=weight, program_config=program_config)
-    output_tensor = ttnn.to_layout(output_tensor, ttnn.ROW_MAJOR_LAYOUT)
     output_tensor = ttnn.from_device(output_tensor)
     output_tensor = ttnn.to_torch(output_tensor)
 
@@ -247,7 +239,6 @@ def test_large_layer_norm_with_bias(device, h, w, use_welford):
 
     program_config = ttnn.LayerNormDefaultProgramConfig(use_welford=use_welford)
     output_tensor = ttnn.layer_norm(input_tensor, bias=bias, program_config=program_config)
-    output_tensor = ttnn.to_layout(output_tensor, ttnn.ROW_MAJOR_LAYOUT)
     output_tensor = ttnn.from_device(output_tensor)
     output_tensor = ttnn.to_torch(output_tensor)
 
@@ -281,7 +272,6 @@ def test_large_layer_norm_with_legacy_reduction_and_rsqrt(device, h, w, legacy_r
     output_tensor = ttnn.layer_norm(
         input_tensor, bias=bias, compute_kernel_config=compute_kernel_config, program_config=program_config
     )
-    output_tensor = ttnn.to_layout(output_tensor, ttnn.ROW_MAJOR_LAYOUT)
     output_tensor = ttnn.from_device(output_tensor)
     output_tensor = ttnn.to_torch(output_tensor)
 
@@ -318,7 +308,6 @@ def test_large_layer_norm_with_weight_bias_and_residual_input(device, h, w, use_
         bias=bias,
         program_config=program_config,
     )
-    output_tensor = ttnn.to_layout(output_tensor, ttnn.ROW_MAJOR_LAYOUT)
     output_tensor = ttnn.from_device(output_tensor)
     output_tensor = ttnn.to_torch(output_tensor)
 
@@ -345,7 +334,6 @@ def test_l1_interleaved(device, use_welford, dtype):
     )
     program_config = ttnn.LayerNormDefaultProgramConfig(use_welford=use_welford)
     output_tensor = ttnn.layer_norm(input_tensor, program_config=program_config)
-    output_tensor = ttnn.to_layout(output_tensor, ttnn.ROW_MAJOR_LAYOUT)
     output_tensor = ttnn.from_device(output_tensor)
     output_tensor = ttnn.to_torch(output_tensor)
 

--- a/tests/ttnn/unit_tests/operations/fused/test_softmax.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_softmax.py
@@ -480,7 +480,6 @@ def test_softmax_accuracy(device, shape, fp32_acc_en, math_approx_mode, expected
         ttnn_tensor, dim=-1, compute_kernel_config=compute_kernel_config, numeric_stable=numeric_stable
     )
 
-    ttnn_output = ttnn.to_layout(ttnn_output, ttnn.ROW_MAJOR_LAYOUT)
     output_torch = ttnn_output.cpu().to_torch()
 
     assert_with_ulp(torch_output, output_torch, expected_ulp)

--- a/tests/ttnn/unit_tests/operations/matmul/test_experimental.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_experimental.py
@@ -29,7 +29,6 @@ def test_ttnn_experimental_tensor_exp(device, height, width):
 
     input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
     output_tensor = ttnn.exp(input_tensor)
-    output_tensor = ttnn.to_layout(output_tensor, ttnn.ROW_MAJOR_LAYOUT)
     output_tensor = ttnn.from_device(output_tensor)
     output_tensor = ttnn.to_torch(output_tensor)
 

--- a/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
@@ -1734,7 +1734,6 @@ def test_sharded_matmul(
         input_tensor_b = ttnn.to_memory_config(input_tensor_b, input_b_sharded_memory_config)
 
     output = ttnn.matmul(input_tensor_a, input_tensor_b, memory_config=ttnn.DRAM_MEMORY_CONFIG)
-    output = ttnn.to_layout(output, ttnn.ROW_MAJOR_LAYOUT)
     output = ttnn.from_device(output)
     output = ttnn.to_torch(output)
 


### PR DESCRIPTION
### Ticket
Link to Github Issue N/A

### Problem description
There are unnecessary to_layout calls that when debugging increase the surface of what needs to be looked at.

### What's changed
Remove unnecessary to_layout calls.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/19683624267
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes