### PR TITLE
update fabric bw test report col names for superset

### DIFF
--- a/.github/workflows/galaxy-quick-impl.yaml
+++ b/.github/workflows/galaxy-quick-impl.yaml
@@ -84,6 +84,16 @@ jobs:
         if: ${{ !cancelled() }}
         with:
           prefix: "test_reports_"
+      - name: Upload benchmark data
+        ## Only upload fabric benchmark data for main branch
+        if: ${{ !cancelled() && github.ref_name == 'main' && contains(matrix.test-group.name, 'Run health tests') }}
+        uses: tenstorrent/tt-metal/.github/actions/upload-data-via-sftp@main
+        with:
+          ssh-private-key: ${{ secrets.SFTP_BENCHMARK_WRITER_KEY }}
+          sftp-batchfile: /work/.github/actions/upload-data-via-sftp/fabric_bandwidth_benchmark_data_batchfile.txt
+          username: ${{ secrets.SFTP_FABRIC_BENCHMARK_WRITER_USERNAME }}
+          hostname: ${{ secrets.SFTP_FABRIC_BENCHMARK_WRITER_HOSTNAME }}
+          path: /work
       - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
         if: always()
   quick-wh-glx-quick:

--- a/.github/workflows/galaxy-quick-impl.yaml
+++ b/.github/workflows/galaxy-quick-impl.yaml
@@ -86,7 +86,7 @@ jobs:
           prefix: "test_reports_"
       - name: Upload benchmark data
         ## Only upload fabric benchmark data for main branch
-        if: ${{ !cancelled() && github.ref_name == 'main' && contains(matrix.test-group.name, 'Run health tests') }}
+        if: ${{ !cancelled() && github.ref_name == 'main' }}
         uses: tenstorrent/tt-metal/.github/actions/upload-data-via-sftp@main
         with:
           ssh-private-key: ${{ secrets.SFTP_BENCHMARK_WRITER_KEY }}

--- a/.github/workflows/t3000-fast-tests-impl.yaml
+++ b/.github/workflows/t3000-fast-tests-impl.yaml
@@ -112,7 +112,7 @@ jobs:
           prefix: "test_reports_"
       - name: Upload benchmark data
         ## Only upload fabric benchmark data for main branch
-        if: ${{ !cancelled() && github.ref_name == 'main' && contains(matrix.test-group.name, 't3k fabric tests') }}
+        if: ${{ !cancelled() && github.ref_name == 'main'}}
         uses: tenstorrent/tt-metal/.github/actions/upload-data-via-sftp@main
         with:
           ssh-private-key: ${{ secrets.SFTP_BENCHMARK_WRITER_KEY }}

--- a/.github/workflows/t3000-fast-tests-impl.yaml
+++ b/.github/workflows/t3000-fast-tests-impl.yaml
@@ -110,6 +110,16 @@ jobs:
         if: ${{ !cancelled() }}
         with:
           prefix: "test_reports_"
+      - name: Upload benchmark data
+        ## Only upload fabric benchmark data for main branch
+        if: ${{ !cancelled() && github.ref_name == 'main' && contains(matrix.test-group.name, 't3k fabric tests') }}
+        uses: tenstorrent/tt-metal/.github/actions/upload-data-via-sftp@main
+        with:
+          ssh-private-key: ${{ secrets.SFTP_BENCHMARK_WRITER_KEY }}
+          sftp-batchfile: /work/.github/actions/upload-data-via-sftp/fabric_bandwidth_benchmark_data_batchfile.txt
+          username: ${{ secrets.SFTP_FABRIC_BENCHMARK_WRITER_USERNAME }}
+          hostname: ${{ secrets.SFTP_FABRIC_BENCHMARK_WRITER_HOSTNAME }}
+          path: /work
       - name: Generate gtest annotations on failure
         uses: tenstorrent/tt-metal/.github/actions/generate-gtest-failure-message@main
         if: ${{ failure() }}

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/golden/golden_bandwidth_summary_wormhole_b0_galaxy.csv
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/golden/golden_bandwidth_summary_wormhole_b0_galaxy.csv
@@ -1,4 +1,4 @@
-test_name,ftype,ntype,topology,num_devices,num_links,packet_size,iterations,avg_cycles,avg_packets_per_s,avg_bandwidth_GB_per_s,bw_min_GB_per_s,bw_max_GB_per_s,bw_std_dev_GB_per_s,tolerance_percent
+test_name,ftype,ntype,topology,num_devices,num_links,packet_size,iterations,avg_cycles,avg_packets_per_s,avg_bandwidth_gigabytes_per_s,bw_min_gigabytes_per_s,bw_max_gigabytes_per_s,bw_std_dev_gigabytes_per_s,tolerance_percent
 LinearMulticast,CHIP_MULTICAST,NOC_UNICAST_WRITE,Linear,"[4,8]",1,2048,3,41854741.000000,3344902.294207,6.850360,6.847170,6.853376,0.002536,1.000000
 LinearMulticast,CHIP_MULTICAST,NOC_UNICAST_WRITE,Linear,"[4,8]",2,2048,3,41904743.666667,3340910.612711,6.842185,6.840947,6.843328,0.000974,1.000000
 LinearMulticast,CHIP_MULTICAST,NOC_UNICAST_WRITE,Linear,"[4,8]",3,2048,3,41914315.666667,3340148.018380,6.840623,6.838494,6.844103,0.002481,1.000000

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/golden/golden_bandwidth_summary_wormhole_b0_t3k.csv
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/golden/golden_bandwidth_summary_wormhole_b0_t3k.csv
@@ -1,4 +1,4 @@
-test_name,ftype,ntype,topology,num_devices,num_links,packet_size,iterations,Avg Cycles,Avg Packets/s,Avg Bandwidth (GB/s),BW Min (GB/s),BW Max (GB/s),BW Std Dev (GB/s),tolerance_percent
+test_name,ftype,ntype,topology,num_devices,num_links,packet_size,iterations,Avg Cycles,avg_packets_per_s,avg_bandwidth_gigabytes_per_s,bw_min_gigabytes_per_s,bw_max_gigabytes_per_s,bw_std_dev_gigabytes_per_s,tolerance_percent
 LinearMulticast,CHIP_MULTICAST,NOC_UNICAST_WRITE,Linear,"[2,4]",1,2048,3,15955145.000000,3760542.694378,7.701591,7.699559,7.704277,0.001981,1.000000
 LinearMulticast,CHIP_MULTICAST,NOC_FUSED_UNICAST_ATOMIC_INC,Linear,"[2,4]",1,2048,3,30059949.333333,1996011.426477,4.087831,4.086990,4.088923,0.000809,1.000000
 LinearMulticast,CHIP_MULTICAST,NOC_UNICAST_SCATTER_WRITE,Linear,"[2,4]",1,2048,3,17432544.666667,3441838.332120,7.048885,7.048330,7.049746,0.000617,1.000000

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/golden/golden_bandwidth_summary_wormhole_b0_t3k.csv
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/golden/golden_bandwidth_summary_wormhole_b0_t3k.csv
@@ -1,4 +1,4 @@
-test_name,ftype,ntype,topology,num_devices,num_links,packet_size,iterations,Avg Cycles,avg_packets_per_s,avg_bandwidth_gigabytes_per_s,bw_min_gigabytes_per_s,bw_max_gigabytes_per_s,bw_std_dev_gigabytes_per_s,tolerance_percent
+test_name,ftype,ntype,topology,num_devices,num_links,packet_size,iterations,avg_cycles,avg_packets_per_s,avg_bandwidth_gigabytes_per_s,bw_min_gigabytes_per_s,bw_max_gigabytes_per_s,bw_std_dev_gigabytes_per_s,tolerance_percent
 LinearMulticast,CHIP_MULTICAST,NOC_UNICAST_WRITE,Linear,"[2,4]",1,2048,3,15955145.000000,3760542.694378,7.701591,7.699559,7.704277,0.001981,1.000000
 LinearMulticast,CHIP_MULTICAST,NOC_FUSED_UNICAST_ATOMIC_INC,Linear,"[2,4]",1,2048,3,30059949.333333,1996011.426477,4.087831,4.086990,4.088923,0.000809,1.000000
 LinearMulticast,CHIP_MULTICAST,NOC_UNICAST_SCATTER_WRITE,Linear,"[2,4]",1,2048,3,17432544.666667,3441838.332120,7.048885,7.048330,7.049746,0.000617,1.000000

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_context.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_context.hpp
@@ -99,10 +99,10 @@ enum class BandwidthStatistics {
 };
 // The header of each statistic in the Bandwidth Summary CSV
 const std::unordered_map<BandwidthStatistics, std::string> BandwidthStatisticsHeader = {
-    {BandwidthStatistics::BandwidthMean, "avg_bandwidth_GB_per_s"},
-    {BandwidthStatistics::BandwidthMin, "bw_min_GB_per_s"},
-    {BandwidthStatistics::BandwidthMax, "bw_max_GB_per_s"},
-    {BandwidthStatistics::BandwidthStdDev, "bw_std_dev_GB_per_s"},
+    {BandwidthStatistics::BandwidthMean, "avg_bandwidth_gigabytes_per_s"},
+    {BandwidthStatistics::BandwidthMin, "bw_min_gigabytes_per_s"},
+    {BandwidthStatistics::BandwidthMax, "bw_max_gigabytes_per_s"},
+    {BandwidthStatistics::BandwidthStdDev, "bw_std_dev_gigabytes_per_s"},
     {BandwidthStatistics::PacketsPerSecondMean, "avg_packets_per_s"},
     {BandwidthStatistics::CyclesMean, "avg_cycles"},
 };


### PR DESCRIPTION
For clarity and consistency with superset databases, we need to update field names from "GB_per_s" to "gigabytes_per_second". This also ensures compatibility with tools that are case insensitive.

Results upload was also enabled in a couple extra pipeline jobs


### Checklist
- [x] T3K Quick: https://github.com/tenstorrent/tt-metal/actions/runs/19707679727
- [x] Galaxy Quick: https://github.com/tenstorrent/tt-metal/actions/runs/19707688874
no regressions