### PR TITLE
Fix Distributed RMSNorm hang caused by CB sizing

### DIFF
--- a/models/experimental/tt_dit/tests/unit/test_normalization.py
+++ b/models/experimental/tt_dit/tests/unit/test_normalization.py
@@ -173,6 +173,14 @@ def test_layernorm(
         [(2, 4), 0],
         [(4, 2), 1],
     ],
+    ids=[
+        "1x2_1",
+        "2x1_0",
+        "2x2_0",
+        "2x2_1",
+        "2x4_0",
+        "4x2_1",
+    ],
     indirect=["mesh_device"],
 )
 @pytest.mark.parametrize(
@@ -180,7 +188,9 @@ def test_layernorm(
     [
         (1, 1, 4096, 2432),  # spatial norm
         (1, 1, 333, 2432),  # prompt norm
+        (1, 1, 32768, 384),
     ],
+    ids=["shape1", "shape2", "shape3"],
 )
 @pytest.mark.parametrize(
     ("norm_eltwise_affine, bias"),
@@ -188,6 +198,7 @@ def test_layernorm(
         (True, False),
         (False, False),
     ],
+    ids=["yes_eltwise_no_bias", "no_eltwise_no_bias"],
 )
 @pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True)
 def test_distributed_rms_norm(

--- a/tests/ttnn/nightly/unit_tests/operations/transformers/test_distributed_fused_rmsnorm.py
+++ b/tests/ttnn/nightly/unit_tests/operations/transformers/test_distributed_fused_rmsnorm.py
@@ -233,6 +233,42 @@ def test_distributed_fused_rmsnorm_sweep_shapes(
 @pytest.mark.parametrize("stats_dtype", [ttnn.bfloat16], ids=["BFLOAT16_stats"])
 @pytest.mark.parametrize(
     "seqlen",
+    [32, 4096],
+    ids=["seqlen32", "seqlen4096"],
+)
+@pytest.mark.parametrize("hidden_dim", [320, 2432], ids=["hidden_dim320", "hidden_dim2432"])
+@pytest.mark.parametrize("num_heads_per_device", [1], ids=["num_heads1"])
+@pytest.mark.parametrize("use_weight", [True], ids=["has_weight"])
+@pytest.mark.parametrize("use_rope", [False], ids=["no_rope"])
+@pytest.mark.parametrize("num_simulated_devices", [2], ids=["num_simulated_devices2"])
+def test_distributed_fused_rmsnorm_odd_hidden_dim(
+    device,
+    num_simulated_devices,
+    seqlen,
+    hidden_dim,
+    dtype,
+    stats_dtype,
+    num_heads_per_device,
+    use_weight,
+    use_rope,
+    reset_seeds,
+):
+    """
+    This test case ensures that the hidden dim tiles is a number not divisible by DST size,
+    testing that CB sizes are correct in order to prevent hangs.
+    """
+    num_heads = num_heads_per_device * num_simulated_devices
+    check_hidden_dim_divisible_by_num_heads(hidden_dim, num_heads)
+    inp_shape = (1, 1, seqlen, hidden_dim)
+    run_distributed_fused_rmsnorm(
+        device, num_simulated_devices, inp_shape, dtype, stats_dtype, num_heads_per_device, use_weight, use_rope
+    )
+
+
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16], ids=["BFLOAT16_in"])
+@pytest.mark.parametrize("stats_dtype", [ttnn.bfloat16], ids=["BFLOAT16_stats"])
+@pytest.mark.parametrize(
+    "seqlen",
     [9472, 18944],
     ids=["seqlen9472", "seqlen18944"],
 )

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/fused_distributed_rmsnorm/device/multicore/rmsnorm_post_all_gather_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/fused_distributed_rmsnorm/device/multicore/rmsnorm_post_all_gather_op_multi_core.cpp
@@ -199,7 +199,7 @@ tt::tt_metal::operation::ProgramWithCallbacks fused_rmsnorm_post_allgather_multi
     const uint32_t reduce_result_cb_num_tiles = 1;
     const uint32_t output_cb_num_tiles = dst_reg_count * double_buffer_constant;
     // kernels use weight_cb in granularity of dst_reg_count, so we need to size appropriately
-    const uint32_t weight_cb_num_tiles = std::max(num_tile_cols, dst_reg_count);
+    const uint32_t weight_cb_num_tiles = tt::round_up(num_tile_cols, dst_reg_count);
     const uint32_t intermediate_cb_num_tiles = dst_reg_count;
     const uint32_t transformation_mat_cb_num_tiles = 1;
     const uint32_t rope_cos_sin_cb_num_tiles = head_dim_tiles;


### PR DESCRIPTION
### Problem description
Certain shapes led to hangs in `ttnn.experimental.wan_fused_rmsnorm_post_allgather` due to incorrect sizing of the weight CB.

### What's changed
Ensure that weight CB is sized as a multiple of the DST granularity. This is in alignment with how the weight CB is produced by reader and consumed by compute.

### Checklist
- [x] L2 nightly https://github.com/tenstorrent/tt-metal/actions/runs/19707831573