### PR TITLE
[skip ci] Add always to create-and-upload-draft-release

### DIFF
--- a/.github/workflows/package-and-release.yaml
+++ b/.github/workflows/package-and-release.yaml
@@ -220,7 +220,7 @@ jobs:
     # May accidentally create two releases without restricting to 1 job
     concurrency: create_upload_draft_release
     runs-on: ubuntu-latest
-    if: ${{ always() && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/stable' || startsWith(github.ref, 'refs/tags/v') || inputs.dry-run) }}
+    if: ${{ always() && needs.create-tag.result == 'success' && needs.create-release-notes.result == 'success' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/stable' || startsWith(github.ref, 'refs/tags/v') || inputs.dry-run) }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/package-and-release.yaml
+++ b/.github/workflows/package-and-release.yaml
@@ -220,7 +220,7 @@ jobs:
     # May accidentally create two releases without restricting to 1 job
     concurrency: create_upload_draft_release
     runs-on: ubuntu-latest
-    if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/stable' || startsWith(github.ref, 'refs/tags/v') || inputs.dry-run }}
+    if: ${{ always() && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/stable' || startsWith(github.ref, 'refs/tags/v') || inputs.dry-run) }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
### Problem description
Currently we only upload draft release when tests in Package and release workflow are successful. We want them to create draft release when ever buil-test-publish step is finished not looking at status of it. 

### What's changed
Add `always()` to if statement for `create-and-upload-draft-release`