### PR TITLE
Stable Diffusion VAE device perf test

### DIFF
--- a/models/demos/wormhole/stable_diffusion/tests/test_perf.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_perf.py
@@ -450,7 +450,7 @@ def test_stable_diffusion_device_perf(expected_kernel_samples_per_second):
 @pytest.mark.models_device_performance_bare_metal
 @pytest.mark.parametrize(
     "expected_kernel_samples_per_second",
-    ((1.55) if is_wormhole_b0() else (1.0),),
+    ((1.45) if is_wormhole_b0() else (2.05),),
 )
 def test_stable_diffusion_vae_device_perf(expected_kernel_samples_per_second):
     subdir = "ttnn_stable_diffusion_vae"
@@ -463,7 +463,7 @@ def test_stable_diffusion_vae_device_perf(expected_kernel_samples_per_second):
     inference_time_key = "AVG DEVICE KERNEL SAMPLES/S"
     expected_perf_cols = {inference_time_key: expected_kernel_samples_per_second}
 
-    post_processed_results = run_device_perf(command, subdir, iterations, cols, batch, has_signposts=False)
+    post_processed_results = run_device_perf(command, subdir, iterations, cols, batch, has_signposts=True)
     expected_results = check_device_perf(post_processed_results, margin, expected_perf_cols, assert_on_fail=True)
     prep_device_perf_report(
         model_name=f"stable_diffusion_vae_{batch}batch",

--- a/models/demos/wormhole/stable_diffusion/tests/test_perf.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_perf.py
@@ -445,3 +445,30 @@ def test_stable_diffusion_device_perf(expected_kernel_samples_per_second):
         expected_results=expected_results,
         comments="",
     )
+
+
+@pytest.mark.models_device_performance_bare_metal
+@pytest.mark.parametrize(
+    "expected_kernel_samples_per_second",
+    ((1.55) if is_wormhole_b0() else (1.0),),
+)
+def test_stable_diffusion_vae_device_perf(expected_kernel_samples_per_second):
+    subdir = "ttnn_stable_diffusion_vae"
+    margin = 0.03
+    batch = 1
+    iterations = 1
+    command = f"pytest models/demos/wormhole/stable_diffusion/tests/vae/test_vae.py::test_decoder[4-64-64-3-512-512-device_params0]"
+    cols = ["DEVICE FW", "DEVICE KERNEL", "DEVICE BRISC KERNEL"]
+
+    inference_time_key = "AVG DEVICE KERNEL SAMPLES/S"
+    expected_perf_cols = {inference_time_key: expected_kernel_samples_per_second}
+
+    post_processed_results = run_device_perf(command, subdir, iterations, cols, batch, has_signposts=False)
+    expected_results = check_device_perf(post_processed_results, margin, expected_perf_cols, assert_on_fail=True)
+    prep_device_perf_report(
+        model_name=f"stable_diffusion_vae_{batch}batch",
+        batch_size=batch,
+        post_processed_results=post_processed_results,
+        expected_results=expected_results,
+        comments="",
+    )

--- a/models/demos/wormhole/stable_diffusion/tests/vae/test_vae.py
+++ b/models/demos/wormhole/stable_diffusion/tests/vae/test_vae.py
@@ -59,8 +59,18 @@ def test_decoder(
     ttnn_input = ttnn.from_torch(
         torch_input.permute([0, 2, 3, 1]), device=device, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16
     )
-    ttnn_output = ttnn_model.decode(ttnn_input)
 
+    use_signpost = True
+    try:
+        from tracy import signpost
+    except ModuleNotFoundError:
+        use_signpost = False
+
+    if use_signpost:
+        signpost(header="start")
+    ttnn_output = ttnn_model.decode(ttnn_input)
+    if use_signpost:
+        signpost(header="stop")
     ttnn_output = ttnn.reshape(ttnn_output, [1, output_height, output_width, out_channels])
     ttnn_output = ttnn.permute(ttnn_output, [0, 3, 1, 2])
     ttnn_output = ttnn.to_torch(ttnn_output)

--- a/models/demos/wormhole/stable_diffusion/tt/vae/ttnn_vae_decoder.py
+++ b/models/demos/wormhole/stable_diffusion/tt/vae/ttnn_vae_decoder.py
@@ -97,11 +97,14 @@ class VaeDecoder:
 
     def __call__(self, hidden_states):
         hidden_states = self.conv_in(hidden_states)
+        ttnn.ReadDeviceProfiler(self.device)
 
         hidden_states = self.midblock(hidden_states)
+        ttnn.ReadDeviceProfiler(self.device)
 
         for upblock in self.upblocks:
             hidden_states = upblock(hidden_states)
+            ttnn.ReadDeviceProfiler(self.device)
 
         hidden_states = ttnn.typecast(hidden_states, ttnn.bfloat16)
 
@@ -118,10 +121,12 @@ class VaeDecoder:
             epsilon=GROUPNORM_EPSILON,
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
         )
+        ttnn.ReadDeviceProfiler(self.device)
 
         hidden_states = ttnn.silu(hidden_states, output_tensor=hidden_states)
         self.conv_out.conv_config.enable_weights_double_buffer = False
         self.conv_out.conv_config.enable_act_double_buffer = False
         hidden_states = self.conv_out(hidden_states)
+        ttnn.ReadDeviceProfiler(self.device)
 
         return hidden_states

--- a/models/demos/wormhole/stable_diffusion/tt/vae/ttnn_vae_midblock.py
+++ b/models/demos/wormhole/stable_diffusion/tt/vae/ttnn_vae_midblock.py
@@ -2,6 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+import ttnn
 from models.demos.wormhole.stable_diffusion.tt.vae.ttnn_vae_attention import Attention
 from models.demos.wormhole.stable_diffusion.tt.vae.ttnn_vae_resnet import ResnetBlock
 
@@ -16,6 +17,7 @@ class MidBlock:
         input_width,
         resnet_norm_num_blocks=[(1, 1), (1, 1)],
     ):
+        self.device = device
         self.resnets = []
         self.resnets.append(
             ResnetBlock(
@@ -50,6 +52,8 @@ class MidBlock:
 
     def __call__(self, hidden_states):
         hidden_states = self.resnets[0](hidden_states)
+        ttnn.ReadDeviceProfiler(self.device)
         hidden_states = self.attention(hidden_states)
+        ttnn.ReadDeviceProfiler(self.device)
         hidden_states = self.resnets[1](hidden_states)
         return hidden_states

--- a/models/demos/wormhole/stable_diffusion/tt/vae/ttnn_vae_upblock.py
+++ b/models/demos/wormhole/stable_diffusion/tt/vae/ttnn_vae_upblock.py
@@ -2,6 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+import ttnn
 from models.demos.wormhole.stable_diffusion.tt.vae.ttnn_vae_resnet import ResnetBlock
 from models.demos.wormhole.stable_diffusion.tt.vae.ttnn_vae_upsample import UpsampleBlock
 
@@ -19,6 +20,7 @@ class UpDecoderBlock:
         output_width,
         resnet_norm_blocks=[(1, 1), (1, 1), (1, 1)],
     ):
+        self.device = device
         self.resnets = []
         for i in range(3):
             self.resnets.append(
@@ -50,6 +52,7 @@ class UpDecoderBlock:
     def __call__(self, hidden_states):
         for resnet in self.resnets:
             hidden_states = resnet(hidden_states)
+            ttnn.ReadDeviceProfiler(self.device)
 
         if self.upsample:
             hidden_states = self.upsample(hidden_states)


### PR DESCRIPTION
### Problem description
- previously didn't test device perf for Stable diffusion 1.4 VAE

### What's changed
- added device perf test for SD vae
-  added necessary `ttnn.ReadDeviceProfiler` so that ops aren't dropped from report

### Checklist
- [x] [All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/19709378605)
- [X] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI [added VAE tests pass](https://github.com/tenstorrent/tt-metal/actions/runs/19702937118)