### PR TITLE
Add mux-mux, relay-mux forwarding channels for UDM [3/n]

### DIFF
--- a/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
+++ b/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
@@ -323,7 +323,9 @@ void FabricUnicastCommon(
 void UDMFabricUnicastCommon(
     BaseFabricFixture* fixture,
     NocSendType noc_send_type,
-    const std::tuple<RoutingDirection, uint32_t /*num_hops*/>& pair_ordered_dir);
+    const std::variant<
+        std::tuple<RoutingDirection, uint32_t /*num_hops*/>,
+        std::tuple<uint32_t /*src_node*/, uint32_t /*dest_node*/>>& routing_info);
 
 void FabricMulticastCommon(
     BaseFabricFixture* fixture,

--- a/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
+++ b/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
@@ -158,7 +158,10 @@ protected:
 };
 
 // Template base class for Tensix fixtures with Galaxy skip logic
-template <tt::tt_fabric::FabricConfig FabricConfigValue, tt::tt_fabric::FabricTensixConfig TensixConfigValue>
+template <
+    tt::tt_fabric::FabricConfig FabricConfigValue,
+    tt::tt_fabric::FabricTensixConfig TensixConfigValue,
+    tt::tt_fabric::FabricUDMMode UDMModeValue = tt::tt_fabric::FabricUDMMode::DISABLED>
 class FabricTensixFixtureTemplate : public BaseFabricFixture {
 private:
     inline static bool should_skip_ = false;
@@ -170,7 +173,7 @@ protected:
             should_skip_ = true;
             return;
         }
-        BaseFabricFixture::DoSetUpTestSuite(FabricConfigValue, std::nullopt, TensixConfigValue);
+        BaseFabricFixture::DoSetUpTestSuite(FabricConfigValue, std::nullopt, TensixConfigValue, UDMModeValue);
     }
 
     static void TearDownTestSuite() {
@@ -212,7 +215,7 @@ protected:
         BaseFabricFixture::DoSetUpTestSuite(
             tt::tt_fabric::FabricConfig::FABRIC_2D,
             std::nullopt,
-            tt_fabric::FabricTensixConfig::DISABLED,
+            tt_fabric::FabricTensixConfig::UDM,
             tt_fabric::FabricUDMMode::ENABLED);
     }
     static void TearDownTestSuite() { BaseFabricFixture::DoTearDownTestSuite(); }
@@ -224,7 +227,7 @@ protected:
         BaseFabricFixture::DoSetUpTestSuite(
             tt::tt_fabric::FabricConfig::FABRIC_2D,
             std::nullopt,
-            tt_fabric::FabricTensixConfig::DISABLED,
+            tt_fabric::FabricTensixConfig::UDM,
             tt_fabric::FabricUDMMode::ENABLED);
     }
     static void TearDownTestSuite() { BaseFabricFixture::DoTearDownTestSuite(); }

--- a/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
+++ b/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
@@ -194,9 +194,6 @@ protected:
 using Fabric1DTensixFixture =
     FabricTensixFixtureTemplate<tt::tt_fabric::FabricConfig::FABRIC_1D, tt::tt_fabric::FabricTensixConfig::MUX>;
 
-using NightlyFabric2DTensixUdmFixture =
-    FabricTensixFixtureTemplate<tt::tt_fabric::FabricConfig::FABRIC_2D, tt::tt_fabric::FabricTensixConfig::UDM>;
-
 class NightlyFabric1DFixture : public BaseFabricFixture {
 protected:
     static void SetUpTestSuite() { BaseFabricFixture::DoSetUpTestSuite(tt::tt_fabric::FabricConfig::FABRIC_1D); }

--- a/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
+++ b/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
@@ -322,7 +322,8 @@ void UDMFabricUnicastCommon(
     NocSendType noc_send_type,
     const std::variant<
         std::tuple<RoutingDirection, uint32_t /*num_hops*/>,
-        std::tuple<uint32_t /*src_node*/, uint32_t /*dest_node*/>>& routing_info);
+        std::tuple<uint32_t /*src_node*/, uint32_t /*dest_node*/>>& routing_info,
+    std::optional<RoutingDirection> override_initial_direction = std::nullopt);
 
 void FabricMulticastCommon(
     BaseFabricFixture* fixture,

--- a/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
+++ b/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
@@ -194,6 +194,12 @@ protected:
 using Fabric1DTensixFixture =
     FabricTensixFixtureTemplate<tt::tt_fabric::FabricConfig::FABRIC_1D, tt::tt_fabric::FabricTensixConfig::MUX>;
 
+using NightlyFabric1DTensixFixture =
+    FabricTensixFixtureTemplate<tt::tt_fabric::FabricConfig::FABRIC_1D, tt::tt_fabric::FabricTensixConfig::MUX>;
+
+using NightlyFabric2DTensixFixture =
+    FabricTensixFixtureTemplate<tt::tt_fabric::FabricConfig::FABRIC_2D, tt::tt_fabric::FabricTensixConfig::MUX>;
+
 class NightlyFabric1DFixture : public BaseFabricFixture {
 protected:
     static void SetUpTestSuite() { BaseFabricFixture::DoSetUpTestSuite(tt::tt_fabric::FabricConfig::FABRIC_1D); }

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/kernels/test_udm_read_receiver.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/kernels/test_udm_read_receiver.cpp
@@ -19,6 +19,10 @@ constexpr uint16_t packet_payload_size_bytes = static_cast<uint16_t>(get_compile
 constexpr uint32_t num_packets = get_compile_time_arg_val(6);
 constexpr uint32_t time_seed_init = get_compile_time_arg_val(7);
 constexpr uint32_t req_notification_size_bytes = get_compile_time_arg_val(8);
+constexpr uint32_t noc_x_start = get_compile_time_arg_val(9);
+constexpr uint32_t noc_y_start = get_compile_time_arg_val(10);
+constexpr uint32_t dst_dev_id = get_compile_time_arg_val(11);
+constexpr uint32_t dst_mesh_id = get_compile_time_arg_val(12);
 
 /*
  * This test kernel is a kernel to test the functionality that will be implemented in a fabric relay kernel.
@@ -35,26 +39,32 @@ void kernel_main() {
     test_results[TT_FABRIC_STATUS_INDEX] = TT_FABRIC_STATUS_STARTED;
 
     uint32_t local_data_addr = target_address;
-    uint32_t notification_addr = notification_mailbox_address;  // Where we receive and poll for notifications
+    uint32_t local_notification_buffer_addr = notification_mailbox_address;  // Local buffer for preparing notification
+    uint32_t remote_notification_dest_addr =
+        notification_mailbox_address;  // Remote destination (same offset on sender)
     uint64_t bytes_sent = 0;
 
+    // Fill all packets with data first
     for (uint32_t i = 0; i < num_packets; i++) {
         time_seed = prng_next(time_seed);
-
-        // Wait for the read request notification from sender
-        uint32_t curr_notification_addr = notification_addr + i * req_notification_size_bytes;
-        volatile tt_l1_ptr PACKET_HEADER_TYPE* request_header =
-            wait_for_notification(curr_notification_addr, time_seed, req_notification_size_bytes);
 
         uint32_t curr_local_data_addr = local_data_addr + (i * packet_payload_size_bytes);
         tt_l1_ptr uint32_t* buffer_addr = reinterpret_cast<tt_l1_ptr uint32_t*>(curr_local_data_addr);
         fill_packet_data(buffer_addr, packet_payload_size_bytes / 16, time_seed);
 
-        // Process the read request and send the data back
-        tt::tt_fabric::udm::fabric_fast_read_any_len_ack(request_header, curr_local_data_addr);
-
         bytes_sent += packet_payload_size_bytes;
     }
+
+    // Once all data has been filled in L1, notify the sender that it can issue read requests
+    notify_receiver(
+        dst_dev_id,
+        dst_mesh_id,
+        noc_x_start,
+        noc_y_start,
+        local_notification_buffer_addr,
+        remote_notification_dest_addr,
+        time_seed_init,
+        req_notification_size_bytes);
 
     // TODO: move this into fw once consolidated
     tt::tt_fabric::udm::close_fabric_connection();

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/kernels/test_udm_read_sender.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/kernels/test_udm_read_sender.cpp
@@ -35,11 +35,13 @@ void kernel_main() {
     // For read test, we use a separate notification address to avoid conflicts
     uint32_t local_read_addr = source_l1_buffer_address;
     uint32_t remote_read_addr = target_address;
-    uint32_t local_notification_addr = notification_mailbox_address;  // Where we prepare notifications
-    uint32_t remote_notification_addr =
-        notification_mailbox_address;  // Where to send notifications (same offset on receiver)
+    uint32_t local_notification_addr = notification_mailbox_address;  // Where we receive notifications
     bool match = true;
     uint32_t mismatch_addr, mismatch_val, expected_val;
+
+    // Wait for notification from receiver that all data is ready
+    volatile tt_l1_ptr PACKET_HEADER_TYPE* received_header =
+        wait_for_notification(local_notification_addr, time_seed_init, req_notification_size_bytes);
 
     for (uint32_t i = 0; i < num_packets; i++) {
         time_seed = prng_next(time_seed);
@@ -53,19 +55,6 @@ void kernel_main() {
                     get_noc_addr(noc_x_start, noc_y_start, remote_read_addr),
                     local_read_addr,
                     packet_payload_size_bytes);
-
-                // Notify the receiver that a read request has been issued
-                uint32_t notification_buffer_addr = local_notification_addr + i * req_notification_size_bytes;
-                uint32_t remote_notification_dest = remote_notification_addr + i * req_notification_size_bytes;
-                notify_receiver(
-                    dst_dev_id,
-                    dst_mesh_id,
-                    noc_x_start,
-                    noc_y_start,
-                    notification_buffer_addr,
-                    remote_notification_dest,
-                    time_seed,
-                    req_notification_size_bytes);
 
                 // wait for the read to complete
                 tt::tt_fabric::udm::fabric_read_barrier();
@@ -90,6 +79,10 @@ void kernel_main() {
             default: {
                 ASSERT(false);
             } break;
+        }
+
+        if (!match) {
+            break;
         }
 
         noc_async_writes_flushed();

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/kernels/test_udm_receiver.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/kernels/test_udm_receiver.cpp
@@ -20,6 +20,15 @@ constexpr uint32_t num_packets = get_compile_time_arg_val(6);
 constexpr uint32_t time_seed_init = get_compile_time_arg_val(7);
 constexpr uint32_t req_notification_size_bytes = get_compile_time_arg_val(8);
 
+// Helper function to poll for a value at a specific L1 address
+inline void poll_for_value(volatile tt_l1_ptr uint32_t* poll_addr, uint32_t expected_val) {
+    WAYPOINT("FPW");
+    while (expected_val != *poll_addr) {
+        invalidate_l1_cache();
+    }
+    WAYPOINT("FPD");
+}
+
 /*
  * This test kernel is a kernel to test the functionality that will be implemented in a fabric relay kernel.
  * The relay kernel would handle read/write acknowledgement and related functionality, so  the building
@@ -35,11 +44,11 @@ void kernel_main() {
     uint32_t dest_dram_addr;
 
     tt_l1_ptr uint32_t* start_addr = reinterpret_cast<tt_l1_ptr uint32_t*>(target_address);
+    volatile tt_l1_ptr uint32_t* poll_addr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(target_address + packet_payload_size_bytes - 4);
     uint32_t mismatch_addr, mismatch_val, expected_val;
     bool match = true;
     uint64_t bytes_received = 0;
-
-    uint32_t notification_addr = notification_mailbox_address;  // Where we receive notifications
 
     zero_l1_buf(test_results, test_results_size_bytes);
     test_results[TT_FABRIC_STATUS_INDEX] = TT_FABRIC_STATUS_STARTED;
@@ -48,15 +57,11 @@ void kernel_main() {
     for (uint32_t i = 0; i < num_packets; i++) {
         time_seed = prng_next(time_seed);
 
-        // Wait for the notification from sender
-        uint32_t curr_notification_addr = notification_addr + i * req_notification_size_bytes;
-        volatile tt_l1_ptr PACKET_HEADER_TYPE* received_header =
-            wait_for_notification(curr_notification_addr, time_seed, req_notification_size_bytes);
-
         switch (noc_send_type) {
             case NOC_UNICAST_WRITE: {
-                // Send write ACK back to the sender
-                tt::tt_fabric::udm::fabric_fast_write_ack(received_header);
+                // Wait for the packet data to arrive by polling on the last word
+                expected_val = time_seed + (packet_payload_size_bytes / 16) - 1;
+                poll_for_value(poll_addr, expected_val);
 
                 // Check for data correctness
                 match = check_packet_data(
@@ -64,31 +69,29 @@ void kernel_main() {
 
             } break;
             case NOC_UNICAST_INLINE_WRITE: {
-                // Send write ACK back to the sender
-                tt::tt_fabric::udm::fabric_fast_write_ack(received_header);
+                // Wait for the inline write to arrive by polling on the value
+                expected_val = time_seed;
+                poll_for_value(start_addr, expected_val);
 
                 // Check data correctness for a single uint32_t
                 uint32_t received_value = *start_addr;
-                uint32_t expected_value = time_seed;
-                if (received_value != expected_value) {
+                if (received_value != expected_val) {
                     match = false;
                     mismatch_addr = reinterpret_cast<uint32_t>(start_addr);
                     mismatch_val = received_value;
-                    expected_val = expected_value;
                     break;
                 }
             } break;
             case NOC_UNICAST_ATOMIC_INC: {
-                // Send atomic ACK back to the sender
-                tt::tt_fabric::udm::fabric_fast_atomic_ack(received_header);
+                // Wait for the atomic increment to arrive by polling on the value
+                expected_val = time_seed;
+                poll_for_value(start_addr, expected_val);
 
                 uint32_t received_value = *start_addr;
-                uint32_t expected_value = time_seed;
-                if (received_value != expected_value) {
+                if (received_value != expected_val) {
                     match = false;
                     mismatch_addr = reinterpret_cast<uint32_t>(start_addr);
                     mismatch_val = received_value;
-                    expected_val = expected_value;
                     break;
                 }
             } break;
@@ -100,6 +103,7 @@ void kernel_main() {
             break;
         }
         start_addr += packet_payload_size_bytes / 4;
+        poll_addr += packet_payload_size_bytes / 4;
         bytes_received += packet_payload_size_bytes;
     }
 

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/kernels/test_udm_sender.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/kernels/test_udm_sender.cpp
@@ -34,10 +34,6 @@ void kernel_main() {
 
     uint64_t start_timestamp = get_timestamp();
 
-    uint32_t local_notification_addr = notification_mailbox_address;  // Where we prepare notifications
-    uint32_t remote_notification_addr =
-        notification_mailbox_address;  // Where to send notifications (same offset on receiver)
-
     for (uint32_t i = 0; i < num_packets; i++) {
         time_seed = prng_next(time_seed);
 
@@ -67,18 +63,6 @@ void kernel_main() {
                 ASSERT(false);
             } break;
         }
-
-        uint32_t notification_buffer_addr = local_notification_addr + i * req_notification_size_bytes;
-        uint32_t remote_notification_dest = remote_notification_addr + i * req_notification_size_bytes;
-        notify_receiver(
-            dst_dev_id,
-            dst_mesh_id,
-            noc_x_start,
-            noc_y_start,
-            notification_buffer_addr,
-            remote_notification_dest,
-            time_seed,
-            req_notification_size_bytes);
 
         switch (noc_send_type) {
             case NOC_UNICAST_WRITE:

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_apis.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_apis.cpp
@@ -611,6 +611,63 @@ TEST_F(NightlyFabric2DFixture, TestMeshFabricUnicastNocInlineWriteWithState) {
         true);
 }
 
+// Nightly Mux Mode Tests - test mux extension for 1D
+TEST_F(NightlyFabric1DTensixFixture, TestLinearFabricMulticastNocMux) {
+    std::vector<std::tuple<RoutingDirection, uint32_t, uint32_t>> configs = {
+        std::make_tuple(RoutingDirection::E, 1, 2),
+        std::make_tuple(RoutingDirection::E, 1, 3),
+        std::make_tuple(RoutingDirection::W, 1, 2),
+        std::make_tuple(RoutingDirection::W, 1, 3),
+        std::make_tuple(RoutingDirection::N, 1, 1),
+        std::make_tuple(RoutingDirection::S, 1, 1)};
+    for (const auto& config : configs) {
+        auto [dir, start, range] = config;
+        log_info(tt::LogTest, "Testing Multicast Mux 1D: Dir={}, Start={}, Range={}", dir, start, range);
+        log_info(tt::LogTest, "  Type: NOC_UNICAST_WRITE");
+        FabricMulticastCommon(this, NOC_UNICAST_WRITE, {config});
+        log_info(tt::LogTest, "  Type: NOC_UNICAST_INLINE_WRITE");
+        FabricMulticastCommon(this, NOC_UNICAST_INLINE_WRITE, {config});
+        log_info(tt::LogTest, "  Type: NOC_UNICAST_ATOMIC_INC");
+        FabricMulticastCommon(this, NOC_UNICAST_ATOMIC_INC, {config});
+    }
+}
+// Nightly Mux Mode Tests - test mux extension for 2D
+TEST_F(NightlyFabric2DTensixFixture, TestMeshFabricMulticastNocMux) {
+    std::vector<std::vector<std::vector<std::tuple<RoutingDirection, uint32_t, uint32_t>>>> all_multicast_configs = {
+        // North + East + West combination
+        {
+            {std::make_tuple(RoutingDirection::N, 0, 1), std::make_tuple(RoutingDirection::E, 0, 2)},
+            {std::make_tuple(RoutingDirection::E, 0, 2)},
+            {std::make_tuple(RoutingDirection::W, 0, 1)},
+        },
+        {
+            {std::make_tuple(RoutingDirection::N, 0, 1), std::make_tuple(RoutingDirection::E, 0, 1)},
+            {std::make_tuple(RoutingDirection::E, 0, 1)},
+            {std::make_tuple(RoutingDirection::W, 0, 2)},
+        },
+        // South + East + West combination
+        {
+            {std::make_tuple(RoutingDirection::S, 0, 1), std::make_tuple(RoutingDirection::E, 0, 2)},
+            {std::make_tuple(RoutingDirection::E, 0, 2)},
+            {std::make_tuple(RoutingDirection::W, 0, 1)},
+        },
+        {
+            {std::make_tuple(RoutingDirection::S, 0, 1), std::make_tuple(RoutingDirection::E, 0, 1)},
+            {std::make_tuple(RoutingDirection::E, 0, 1)},
+            {std::make_tuple(RoutingDirection::W, 0, 2)},
+        },
+    };
+    for (const auto& multicast_configs : all_multicast_configs) {
+        log_info(tt::LogTest, "Testing Mesh Multicast Mux 2D - Config {}", multicast_configs);
+        log_info(tt::LogTest, "  Type: NOC_UNICAST_WRITE");
+        Fabric2DMulticastCommon(this, NOC_UNICAST_WRITE, multicast_configs, false);
+        log_info(tt::LogTest, "  Type: NOC_UNICAST_INLINE_WRITE");
+        Fabric2DMulticastCommon(this, NOC_UNICAST_INLINE_WRITE, multicast_configs, false);
+        log_info(tt::LogTest, "  Type: NOC_UNICAST_ATOMIC_INC");
+        Fabric2DMulticastCommon(this, NOC_UNICAST_ATOMIC_INC, multicast_configs, false);
+    }
+}
+
 // UDM Mode Tests - test udm api changes for 2D
 TEST_F(Fabric2DUDMModeFixture, TestUDMFabricUnicastWriteEast) {
     UDMFabricUnicastCommon(this, NOC_UNICAST_WRITE, std::make_tuple(RoutingDirection::E, 1));

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_apis.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_apis.cpp
@@ -792,6 +792,271 @@ TEST_F(NightlyFabric2DUDMModeFixture, TestUDMFabricUnicastReadFromNode7) {
     }
 }
 
+// Mux-to-Mux Forwarding Tests - test the mux's ability to forward packets to the correct downstream mux
+// These tests intentionally send packets with a non-optimal initial direction to verify mux forwarding works
+// Test cases cover scenarios where the worker sends a packet to a mux in a different direction,
+// and the mux must forward it to the correct downstream mux based on the packet's initial_direction field
+
+// Node 0 has neighbors in E and S directions
+// Forwarding to East destinations (1, 2, 3) via non-East initial direction (S)
+TEST_F(NightlyFabric2DUDMModeFixture, TestUDMFabricMuxToMuxNode0ForwardEast) {
+    for (auto initial_dir : {RoutingDirection::S}) {
+        log_info(tt::LogTest, "Node 0: Testing forward to East via initial_dir={}", initial_dir);
+        for (uint32_t dst : {1u, 2u, 3u}) {
+            log_info(tt::LogTest, "  Node 0->Node {}: Write", dst);
+            UDMFabricUnicastCommon(this, NOC_UNICAST_WRITE, std::make_tuple(0u, dst), initial_dir);
+            log_info(tt::LogTest, "  Node 0->Node {}: Read", dst);
+            UDMFabricUnicastCommon(this, NOC_UNICAST_READ, std::make_tuple(0u, dst), initial_dir);
+        }
+    }
+}
+
+// Forwarding to South destinations (4, 5, 6, 7) via non-South initial direction (E)
+TEST_F(NightlyFabric2DUDMModeFixture, TestUDMFabricMuxToMuxNode0ForwardSouth) {
+    for (auto initial_dir : {RoutingDirection::E}) {
+        log_info(tt::LogTest, "Node 0: Testing forward to South via initial_dir={}", initial_dir);
+        for (uint32_t dst : {4u, 5u, 6u, 7u}) {
+            log_info(tt::LogTest, "  Node 0->Node {}: Write", dst);
+            UDMFabricUnicastCommon(this, NOC_UNICAST_WRITE, std::make_tuple(0u, dst), initial_dir);
+            log_info(tt::LogTest, "  Node 0->Node {}: Read", dst);
+            UDMFabricUnicastCommon(this, NOC_UNICAST_READ, std::make_tuple(0u, dst), initial_dir);
+        }
+    }
+}
+
+// Node 1 has neighbors in E, W, and S directions - test all 9 combinations
+// Forwarding to East destinations (2, 3) via non-East initial directions (W, S)
+TEST_F(NightlyFabric2DUDMModeFixture, TestUDMFabricMuxToMuxNode1ForwardEast) {
+    for (auto initial_dir : {RoutingDirection::W, RoutingDirection::S}) {
+        log_info(tt::LogTest, "Node 1: Testing forward to East via initial_dir={}", initial_dir);
+        for (uint32_t dst : {2u, 3u}) {
+            log_info(tt::LogTest, "  Node 1->Node {}: Write", dst);
+            UDMFabricUnicastCommon(this, NOC_UNICAST_WRITE, std::make_tuple(1u, dst), initial_dir);
+            log_info(tt::LogTest, "  Node 1->Node {}: Read", dst);
+            UDMFabricUnicastCommon(this, NOC_UNICAST_READ, std::make_tuple(1u, dst), initial_dir);
+        }
+    }
+}
+
+// Forwarding to West destinations (0) via non-West initial directions (E, S)
+TEST_F(NightlyFabric2DUDMModeFixture, TestUDMFabricMuxToMuxNode1ForwardWest) {
+    for (auto initial_dir : {RoutingDirection::E, RoutingDirection::S}) {
+        log_info(tt::LogTest, "Node 1: Testing forward to West via initial_dir={}", initial_dir);
+        log_info(tt::LogTest, "  Node 1->Node 0: Write");
+        UDMFabricUnicastCommon(this, NOC_UNICAST_WRITE, std::make_tuple(1u, 0u), initial_dir);
+        log_info(tt::LogTest, "  Node 1->Node 0: Read");
+        UDMFabricUnicastCommon(this, NOC_UNICAST_READ, std::make_tuple(1u, 0u), initial_dir);
+    }
+}
+
+// Forwarding to South destinations (4, 5, 6, 7) via non-South initial directions (E, W)
+TEST_F(NightlyFabric2DUDMModeFixture, TestUDMFabricMuxToMuxNode1ForwardSouth) {
+    for (auto initial_dir : {RoutingDirection::E, RoutingDirection::W}) {
+        log_info(tt::LogTest, "Node 1: Testing forward to South via initial_dir={}", initial_dir);
+        for (uint32_t dst : {4u, 5u, 6u, 7u}) {
+            log_info(tt::LogTest, "  Node 1->Node {}: Write", dst);
+            UDMFabricUnicastCommon(this, NOC_UNICAST_WRITE, std::make_tuple(1u, dst), initial_dir);
+            log_info(tt::LogTest, "  Node 1->Node {}: Read", dst);
+            UDMFabricUnicastCommon(this, NOC_UNICAST_READ, std::make_tuple(1u, dst), initial_dir);
+        }
+    }
+}
+
+// Node 2 has neighbors in E, W, and S directions - test all 9 combinations
+// Forwarding to East destinations (3) via non-East initial directions (W, S)
+TEST_F(NightlyFabric2DUDMModeFixture, TestUDMFabricMuxToMuxNode2ForwardEast) {
+    for (auto initial_dir : {RoutingDirection::W, RoutingDirection::S}) {
+        log_info(tt::LogTest, "Node 2: Testing forward to East via initial_dir={}", initial_dir);
+        log_info(tt::LogTest, "  Node 2->Node 3: Write");
+        UDMFabricUnicastCommon(this, NOC_UNICAST_WRITE, std::make_tuple(2u, 3u), initial_dir);
+        log_info(tt::LogTest, "  Node 2->Node 3: Read");
+        UDMFabricUnicastCommon(this, NOC_UNICAST_READ, std::make_tuple(2u, 3u), initial_dir);
+    }
+}
+
+// Forwarding to West destinations (0, 1) via non-West initial directions (E, S)
+TEST_F(NightlyFabric2DUDMModeFixture, TestUDMFabricMuxToMuxNode2ForwardWest) {
+    for (auto initial_dir : {RoutingDirection::E, RoutingDirection::S}) {
+        log_info(tt::LogTest, "Node 2: Testing forward to West via initial_dir={}", initial_dir);
+        for (uint32_t dst : {0u, 1u}) {
+            log_info(tt::LogTest, "  Node 2->Node {}: Write", dst);
+            UDMFabricUnicastCommon(this, NOC_UNICAST_WRITE, std::make_tuple(2u, dst), initial_dir);
+            log_info(tt::LogTest, "  Node 2->Node {}: Read", dst);
+            UDMFabricUnicastCommon(this, NOC_UNICAST_READ, std::make_tuple(2u, dst), initial_dir);
+        }
+    }
+}
+
+// Forwarding to South destinations (6, 7) via non-South initial directions (E, W)
+TEST_F(NightlyFabric2DUDMModeFixture, TestUDMFabricMuxToMuxNode2ForwardSouth) {
+    for (auto initial_dir : {RoutingDirection::E, RoutingDirection::W}) {
+        log_info(tt::LogTest, "Node 2: Testing forward to South via initial_dir={}", initial_dir);
+        for (uint32_t dst : {6u, 7u}) {
+            log_info(tt::LogTest, "  Node 2->Node {}: Write", dst);
+            UDMFabricUnicastCommon(this, NOC_UNICAST_WRITE, std::make_tuple(2u, dst), initial_dir);
+            log_info(tt::LogTest, "  Node 2->Node {}: Read", dst);
+            UDMFabricUnicastCommon(this, NOC_UNICAST_READ, std::make_tuple(2u, dst), initial_dir);
+        }
+    }
+}
+
+// Node 3 has neighbors in W and S directions
+// Forwarding to West destinations (0, 1, 2) via non-West initial direction (S)
+TEST_F(NightlyFabric2DUDMModeFixture, TestUDMFabricMuxToMuxNode3ForwardWest) {
+    for (auto initial_dir : {RoutingDirection::S}) {
+        log_info(tt::LogTest, "Node 3: Testing forward to West via initial_dir={}", initial_dir);
+        for (uint32_t dst : {0u, 1u, 2u}) {
+            log_info(tt::LogTest, "  Node 3->Node {}: Write", dst);
+            UDMFabricUnicastCommon(this, NOC_UNICAST_WRITE, std::make_tuple(3u, dst), initial_dir);
+            log_info(tt::LogTest, "  Node 3->Node {}: Read", dst);
+            UDMFabricUnicastCommon(this, NOC_UNICAST_READ, std::make_tuple(3u, dst), initial_dir);
+        }
+    }
+}
+
+// Forwarding to South destinations (4, 5, 6, 7) via non-South initial direction (W)
+TEST_F(NightlyFabric2DUDMModeFixture, TestUDMFabricMuxToMuxNode3ForwardSouth) {
+    for (auto initial_dir : {RoutingDirection::W}) {
+        log_info(tt::LogTest, "Node 3: Testing forward to South via initial_dir={}", initial_dir);
+        for (uint32_t dst : {4u, 5u, 6u, 7u}) {
+            log_info(tt::LogTest, "  Node 3->Node {}: Write", dst);
+            UDMFabricUnicastCommon(this, NOC_UNICAST_WRITE, std::make_tuple(3u, dst), initial_dir);
+            log_info(tt::LogTest, "  Node 3->Node {}: Read", dst);
+            UDMFabricUnicastCommon(this, NOC_UNICAST_READ, std::make_tuple(3u, dst), initial_dir);
+        }
+    }
+}
+
+// Node 4 has neighbors in E and N directions
+// Forwarding to East destinations (5, 6, 7) via non-East initial direction (N)
+TEST_F(NightlyFabric2DUDMModeFixture, TestUDMFabricMuxToMuxNode4ForwardEast) {
+    for (auto initial_dir : {RoutingDirection::N}) {
+        log_info(tt::LogTest, "Node 4: Testing forward to East via initial_dir={}", initial_dir);
+        for (uint32_t dst : {5u, 6u, 7u}) {
+            log_info(tt::LogTest, "  Node 4->Node {}: Write", dst);
+            UDMFabricUnicastCommon(this, NOC_UNICAST_WRITE, std::make_tuple(4u, dst), initial_dir);
+            log_info(tt::LogTest, "  Node 4->Node {}: Read", dst);
+            UDMFabricUnicastCommon(this, NOC_UNICAST_READ, std::make_tuple(4u, dst), initial_dir);
+        }
+    }
+}
+
+// Forwarding to North destinations (0, 1, 2, 3) via non-North initial direction (E)
+TEST_F(NightlyFabric2DUDMModeFixture, TestUDMFabricMuxToMuxNode4ForwardNorth) {
+    for (auto initial_dir : {RoutingDirection::E}) {
+        log_info(tt::LogTest, "Node 4: Testing forward to North via initial_dir={}", initial_dir);
+        for (uint32_t dst : {0u, 1u, 2u, 3u}) {
+            log_info(tt::LogTest, "  Node 4->Node {}: Write", dst);
+            UDMFabricUnicastCommon(this, NOC_UNICAST_WRITE, std::make_tuple(4u, dst), initial_dir);
+            log_info(tt::LogTest, "  Node 4->Node {}: Read", dst);
+            UDMFabricUnicastCommon(this, NOC_UNICAST_READ, std::make_tuple(4u, dst), initial_dir);
+        }
+    }
+}
+
+// Node 5 has neighbors in E, W, and N directions - test all 9 combinations
+// Forwarding to East destinations (6, 7) via non-East initial directions (W, N)
+TEST_F(NightlyFabric2DUDMModeFixture, TestUDMFabricMuxToMuxNode5ForwardEast) {
+    for (auto initial_dir : {RoutingDirection::W, RoutingDirection::N}) {
+        log_info(tt::LogTest, "Node 5: Testing forward to East via initial_dir={}", initial_dir);
+        for (uint32_t dst : {6u, 7u}) {
+            log_info(tt::LogTest, "  Node 5->Node {}: Write", dst);
+            UDMFabricUnicastCommon(this, NOC_UNICAST_WRITE, std::make_tuple(5u, dst), initial_dir);
+            log_info(tt::LogTest, "  Node 5->Node {}: Read", dst);
+            UDMFabricUnicastCommon(this, NOC_UNICAST_READ, std::make_tuple(5u, dst), initial_dir);
+        }
+    }
+}
+
+// Forwarding to West destinations (4) via non-West initial directions (E, N)
+TEST_F(NightlyFabric2DUDMModeFixture, TestUDMFabricMuxToMuxNode5ForwardWest) {
+    for (auto initial_dir : {RoutingDirection::E, RoutingDirection::N}) {
+        log_info(tt::LogTest, "Node 5: Testing forward to West via initial_dir={}", initial_dir);
+        log_info(tt::LogTest, "  Node 5->Node 4: Write");
+        UDMFabricUnicastCommon(this, NOC_UNICAST_WRITE, std::make_tuple(5u, 4u), initial_dir);
+        log_info(tt::LogTest, "  Node 5->Node 4: Read");
+        UDMFabricUnicastCommon(this, NOC_UNICAST_READ, std::make_tuple(5u, 4u), initial_dir);
+    }
+}
+
+// Forwarding to North destinations (0, 1, 2, 3) via non-North initial directions (E, W)
+TEST_F(NightlyFabric2DUDMModeFixture, TestUDMFabricMuxToMuxNode5ForwardNorth) {
+    for (auto initial_dir : {RoutingDirection::E, RoutingDirection::W}) {
+        log_info(tt::LogTest, "Node 5: Testing forward to North via initial_dir={}", initial_dir);
+        for (uint32_t dst : {0u, 1u, 2u, 3u}) {
+            log_info(tt::LogTest, "  Node 5->Node {}: Write", dst);
+            UDMFabricUnicastCommon(this, NOC_UNICAST_WRITE, std::make_tuple(5u, dst), initial_dir);
+            log_info(tt::LogTest, "  Node 5->Node {}: Read", dst);
+            UDMFabricUnicastCommon(this, NOC_UNICAST_READ, std::make_tuple(5u, dst), initial_dir);
+        }
+    }
+}
+
+// Node 6 has neighbors in E, W, and N directions - test all 9 combinations
+// Forwarding to East destinations (7) via non-East initial directions (W, N)
+TEST_F(NightlyFabric2DUDMModeFixture, TestUDMFabricMuxToMuxNode6ForwardEast) {
+    for (auto initial_dir : {RoutingDirection::W, RoutingDirection::N}) {
+        log_info(tt::LogTest, "Node 6: Testing forward to East via initial_dir={}", initial_dir);
+        log_info(tt::LogTest, "  Node 6->Node 7: Write");
+        UDMFabricUnicastCommon(this, NOC_UNICAST_WRITE, std::make_tuple(6u, 7u), initial_dir);
+        log_info(tt::LogTest, "  Node 6->Node 7: Read");
+        UDMFabricUnicastCommon(this, NOC_UNICAST_READ, std::make_tuple(6u, 7u), initial_dir);
+    }
+}
+
+// Forwarding to West destinations (4, 5) via non-West initial directions (E, N)
+TEST_F(NightlyFabric2DUDMModeFixture, TestUDMFabricMuxToMuxNode6ForwardWest) {
+    for (auto initial_dir : {RoutingDirection::E, RoutingDirection::N}) {
+        log_info(tt::LogTest, "Node 6: Testing forward to West via initial_dir={}", initial_dir);
+        for (uint32_t dst : {4u, 5u}) {
+            log_info(tt::LogTest, "  Node 6->Node {}: Write", dst);
+            UDMFabricUnicastCommon(this, NOC_UNICAST_WRITE, std::make_tuple(6u, dst), initial_dir);
+            log_info(tt::LogTest, "  Node 6->Node {}: Read", dst);
+            UDMFabricUnicastCommon(this, NOC_UNICAST_READ, std::make_tuple(6u, dst), initial_dir);
+        }
+    }
+}
+
+// Forwarding to North destinations (0, 1, 2, 3) via non-North initial directions (E, W)
+TEST_F(NightlyFabric2DUDMModeFixture, TestUDMFabricMuxToMuxNode6ForwardNorth) {
+    for (auto initial_dir : {RoutingDirection::E, RoutingDirection::W}) {
+        log_info(tt::LogTest, "Node 6: Testing forward to North via initial_dir={}", initial_dir);
+        for (uint32_t dst : {0u, 1u, 2u, 3u}) {
+            log_info(tt::LogTest, "  Node 6->Node {}: Write", dst);
+            UDMFabricUnicastCommon(this, NOC_UNICAST_WRITE, std::make_tuple(6u, dst), initial_dir);
+            log_info(tt::LogTest, "  Node 6->Node {}: Read", dst);
+            UDMFabricUnicastCommon(this, NOC_UNICAST_READ, std::make_tuple(6u, dst), initial_dir);
+        }
+    }
+}
+
+// Node 7 has neighbors in W and N directions
+// Forwarding to West destinations (4, 5, 6) via non-West initial direction (N)
+TEST_F(NightlyFabric2DUDMModeFixture, TestUDMFabricMuxToMuxNode7ForwardWest) {
+    for (auto initial_dir : {RoutingDirection::N}) {
+        log_info(tt::LogTest, "Node 7: Testing forward to West via initial_dir={}", initial_dir);
+        for (uint32_t dst : {4u, 5u, 6u}) {
+            log_info(tt::LogTest, "  Node 7->Node {}: Write", dst);
+            UDMFabricUnicastCommon(this, NOC_UNICAST_WRITE, std::make_tuple(7u, dst), initial_dir);
+            log_info(tt::LogTest, "  Node 7->Node {}: Read", dst);
+            UDMFabricUnicastCommon(this, NOC_UNICAST_READ, std::make_tuple(7u, dst), initial_dir);
+        }
+    }
+}
+
+// Forwarding to North destinations (0, 1, 2, 3) via non-North initial direction (W)
+TEST_F(NightlyFabric2DUDMModeFixture, TestUDMFabricMuxToMuxNode7ForwardNorth) {
+    for (auto initial_dir : {RoutingDirection::W}) {
+        log_info(tt::LogTest, "Node 7: Testing forward to North via initial_dir={}", initial_dir);
+        for (uint32_t dst : {0u, 1u, 2u, 3u}) {
+            log_info(tt::LogTest, "  Node 7->Node {}: Write", dst);
+            UDMFabricUnicastCommon(this, NOC_UNICAST_WRITE, std::make_tuple(7u, dst), initial_dir);
+            log_info(tt::LogTest, "  Node 7->Node {}: Read", dst);
+            UDMFabricUnicastCommon(this, NOC_UNICAST_READ, std::make_tuple(7u, dst), initial_dir);
+        }
+    }
+}
+
 // Unicast Scatter Write
 TEST_F(NightlyFabric2DFixture, TestMeshFabricUnicastNocScatterWrite) {
     for (auto dir : {RoutingDirection::E, RoutingDirection::W, RoutingDirection::N, RoutingDirection::S}) {

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_apis.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_apis.cpp
@@ -750,6 +750,105 @@ TEST_F(NightlyFabric2DUDMModeFixture, TestUDMFabricReadSouth) {
     UDMFabricUnicastCommon(this, NOC_UNICAST_READ, std::make_tuple(RoutingDirection::S, 1));
 }
 
+// UDM Mode Write Tests with explicit src/dest node IDs - test specific node pairs that has traffic turns
+TEST_F(NightlyFabric2DUDMModeFixture, TestUDMFabricUnicastWriteFromNode0) {
+    for (uint32_t dst : {5u, 6u, 7u}) {
+        UDMFabricUnicastCommon(this, NOC_UNICAST_WRITE, std::make_tuple(0u, dst));
+        UDMFabricUnicastCommon(this, NOC_UNICAST_INLINE_WRITE, std::make_tuple(0u, dst));
+        UDMFabricUnicastCommon(this, NOC_UNICAST_ATOMIC_INC, std::make_tuple(0u, dst));
+    }
+}
+TEST_F(NightlyFabric2DUDMModeFixture, TestUDMFabricUnicastWriteFromNode1) {
+    for (uint32_t dst : {4u, 6u, 7u}) {
+        UDMFabricUnicastCommon(this, NOC_UNICAST_WRITE, std::make_tuple(1u, dst));
+        UDMFabricUnicastCommon(this, NOC_UNICAST_INLINE_WRITE, std::make_tuple(1u, dst));
+        UDMFabricUnicastCommon(this, NOC_UNICAST_ATOMIC_INC, std::make_tuple(1u, dst));
+    }
+}
+TEST_F(NightlyFabric2DUDMModeFixture, TestUDMFabricUnicastWriteFromNode2) {
+    for (uint32_t dst : {4u, 5u, 7u}) {
+        UDMFabricUnicastCommon(this, NOC_UNICAST_WRITE, std::make_tuple(2u, dst));
+        UDMFabricUnicastCommon(this, NOC_UNICAST_INLINE_WRITE, std::make_tuple(2u, dst));
+        UDMFabricUnicastCommon(this, NOC_UNICAST_ATOMIC_INC, std::make_tuple(2u, dst));
+    }
+}
+TEST_F(NightlyFabric2DUDMModeFixture, TestUDMFabricUnicastWriteFromNode3) {
+    for (uint32_t dst : {4u, 5u, 6u}) {
+        UDMFabricUnicastCommon(this, NOC_UNICAST_WRITE, std::make_tuple(3u, dst));
+        UDMFabricUnicastCommon(this, NOC_UNICAST_INLINE_WRITE, std::make_tuple(3u, dst));
+        UDMFabricUnicastCommon(this, NOC_UNICAST_ATOMIC_INC, std::make_tuple(3u, dst));
+    }
+}
+TEST_F(NightlyFabric2DUDMModeFixture, TestUDMFabricUnicastWriteFromNode4) {
+    for (uint32_t dst : {1u, 2u, 3u}) {
+        UDMFabricUnicastCommon(this, NOC_UNICAST_WRITE, std::make_tuple(4u, dst));
+        UDMFabricUnicastCommon(this, NOC_UNICAST_INLINE_WRITE, std::make_tuple(4u, dst));
+        UDMFabricUnicastCommon(this, NOC_UNICAST_ATOMIC_INC, std::make_tuple(4u, dst));
+    }
+}
+TEST_F(NightlyFabric2DUDMModeFixture, TestUDMFabricUnicastWriteFromNode5) {
+    for (uint32_t dst : {0u, 2u, 3u}) {
+        UDMFabricUnicastCommon(this, NOC_UNICAST_WRITE, std::make_tuple(5u, dst));
+        UDMFabricUnicastCommon(this, NOC_UNICAST_INLINE_WRITE, std::make_tuple(5u, dst));
+        UDMFabricUnicastCommon(this, NOC_UNICAST_ATOMIC_INC, std::make_tuple(5u, dst));
+    }
+}
+TEST_F(NightlyFabric2DUDMModeFixture, TestUDMFabricUnicastWriteFromNode6) {
+    for (uint32_t dst : {0u, 1u, 3u}) {
+        UDMFabricUnicastCommon(this, NOC_UNICAST_WRITE, std::make_tuple(6u, dst));
+        UDMFabricUnicastCommon(this, NOC_UNICAST_INLINE_WRITE, std::make_tuple(6u, dst));
+        UDMFabricUnicastCommon(this, NOC_UNICAST_ATOMIC_INC, std::make_tuple(6u, dst));
+    }
+}
+TEST_F(NightlyFabric2DUDMModeFixture, TestUDMFabricUnicastWriteFromNode7) {
+    for (uint32_t dst : {0u, 1u, 2u}) {
+        UDMFabricUnicastCommon(this, NOC_UNICAST_WRITE, std::make_tuple(7u, dst));
+        UDMFabricUnicastCommon(this, NOC_UNICAST_INLINE_WRITE, std::make_tuple(7u, dst));
+        UDMFabricUnicastCommon(this, NOC_UNICAST_ATOMIC_INC, std::make_tuple(7u, dst));
+    }
+}
+// UDM Mode Read Tests with explicit src/dest node IDs - test specific node pairs that has traffic turns
+TEST_F(NightlyFabric2DUDMModeFixture, TestUDMFabricUnicastReadFromNode0) {
+    for (uint32_t dst : {5u, 6u, 7u}) {
+        UDMFabricUnicastCommon(this, NOC_UNICAST_READ, std::make_tuple(0u, dst));
+    }
+}
+TEST_F(NightlyFabric2DUDMModeFixture, TestUDMFabricUnicastReadFromNode1) {
+    for (uint32_t dst : {4u, 6u, 7u}) {
+        UDMFabricUnicastCommon(this, NOC_UNICAST_READ, std::make_tuple(1u, dst));
+    }
+}
+TEST_F(NightlyFabric2DUDMModeFixture, TestUDMFabricUnicastReadFromNode2) {
+    for (uint32_t dst : {4u, 5u, 7u}) {
+        UDMFabricUnicastCommon(this, NOC_UNICAST_READ, std::make_tuple(2u, dst));
+    }
+}
+TEST_F(NightlyFabric2DUDMModeFixture, TestUDMFabricUnicastReadFromNode3) {
+    for (uint32_t dst : {4u, 5u, 6u}) {
+        UDMFabricUnicastCommon(this, NOC_UNICAST_READ, std::make_tuple(3u, dst));
+    }
+}
+TEST_F(NightlyFabric2DUDMModeFixture, TestUDMFabricUnicastReadFromNode4) {
+    for (uint32_t dst : {1u, 2u, 3u}) {
+        UDMFabricUnicastCommon(this, NOC_UNICAST_READ, std::make_tuple(4u, dst));
+    }
+}
+TEST_F(NightlyFabric2DUDMModeFixture, TestUDMFabricUnicastReadFromNode5) {
+    for (uint32_t dst : {0u, 2u, 3u}) {
+        UDMFabricUnicastCommon(this, NOC_UNICAST_READ, std::make_tuple(5u, dst));
+    }
+}
+TEST_F(NightlyFabric2DUDMModeFixture, TestUDMFabricUnicastReadFromNode6) {
+    for (uint32_t dst : {0u, 1u, 3u}) {
+        UDMFabricUnicastCommon(this, NOC_UNICAST_READ, std::make_tuple(6u, dst));
+    }
+}
+TEST_F(NightlyFabric2DUDMModeFixture, TestUDMFabricUnicastReadFromNode7) {
+    for (uint32_t dst : {0u, 1u, 2u}) {
+        UDMFabricUnicastCommon(this, NOC_UNICAST_READ, std::make_tuple(7u, dst));
+    }
+}
+
 // Unicast Scatter Write
 TEST_F(NightlyFabric2DFixture, TestMeshFabricUnicastNocScatterWrite) {
     for (auto dir : {RoutingDirection::E, RoutingDirection::W, RoutingDirection::N, RoutingDirection::S}) {

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_apis.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_apis.cpp
@@ -439,63 +439,6 @@ TEST_F(Fabric2DFixture, Test2DMCastConnAPI_1N1E1W) { RunTest2DMCastConnAPI(this,
 
 TEST_F(Fabric2DFixture, Test2DMCastConnAPI_7N3E) { RunTest2DMCastConnAPI(this, 7, 0, 3, 0); }
 
-// Nightly Fabric Tensix Config UDM Mode Tests - 1-3 hops
-// NOC_UNICAST_WRITE
-TEST_F(NightlyFabric2DTensixUdmFixture, TestTensixUDMFabricUnicastWriteEast) {
-    for (uint32_t hops = 1; hops <= 3; hops++) {
-        FabricUnicastCommon(this, NOC_UNICAST_WRITE, {std::make_tuple(RoutingDirection::E, hops)}, FabricApiType::Mesh);
-    }
-}
-TEST_F(NightlyFabric2DTensixUdmFixture, TestTensixUDMFabricUnicastWriteWest) {
-    for (uint32_t hops = 1; hops <= 3; hops++) {
-        FabricUnicastCommon(this, NOC_UNICAST_WRITE, {std::make_tuple(RoutingDirection::W, hops)}, FabricApiType::Mesh);
-    }
-}
-TEST_F(NightlyFabric2DTensixUdmFixture, TestTensixUDMFabricUnicastWriteNorth) {
-    FabricUnicastCommon(this, NOC_UNICAST_WRITE, {std::make_tuple(RoutingDirection::N, 1)}, FabricApiType::Mesh);
-}
-TEST_F(NightlyFabric2DTensixUdmFixture, TestTensixUDMFabricUnicastWriteSouth) {
-    FabricUnicastCommon(this, NOC_UNICAST_WRITE, {std::make_tuple(RoutingDirection::S, 1)}, FabricApiType::Mesh);
-}
-// NOC_UNICAST_ATOMIC_INC
-TEST_F(NightlyFabric2DTensixUdmFixture, TestTensixUDMFabricAtomicIncEast) {
-    for (uint32_t hops = 1; hops <= 3; hops++) {
-        FabricUnicastCommon(
-            this, NOC_UNICAST_ATOMIC_INC, {std::make_tuple(RoutingDirection::E, hops)}, FabricApiType::Mesh);
-    }
-}
-TEST_F(NightlyFabric2DTensixUdmFixture, TestTensixUDMFabricAtomicIncWest) {
-    for (uint32_t hops = 1; hops <= 3; hops++) {
-        FabricUnicastCommon(
-            this, NOC_UNICAST_ATOMIC_INC, {std::make_tuple(RoutingDirection::W, hops)}, FabricApiType::Mesh);
-    }
-}
-TEST_F(NightlyFabric2DTensixUdmFixture, TestTensixUDMFabricAtomicIncNorth) {
-    FabricUnicastCommon(this, NOC_UNICAST_ATOMIC_INC, {std::make_tuple(RoutingDirection::N, 1)}, FabricApiType::Mesh);
-}
-TEST_F(NightlyFabric2DTensixUdmFixture, TestTensixUDMFabricAtomicIncSouth) {
-    FabricUnicastCommon(this, NOC_UNICAST_ATOMIC_INC, {std::make_tuple(RoutingDirection::S, 1)}, FabricApiType::Mesh);
-}
-// NOC_UNICAST_INLINE_WRITE
-TEST_F(NightlyFabric2DTensixUdmFixture, TestTensixUDMFabricInlineWriteEast) {
-    for (uint32_t hops = 1; hops <= 3; hops++) {
-        FabricUnicastCommon(
-            this, NOC_UNICAST_INLINE_WRITE, {std::make_tuple(RoutingDirection::E, hops)}, FabricApiType::Mesh);
-    }
-}
-TEST_F(NightlyFabric2DTensixUdmFixture, TestTensixUDMFabricInlineWriteWest) {
-    for (uint32_t hops = 1; hops <= 3; hops++) {
-        FabricUnicastCommon(
-            this, NOC_UNICAST_INLINE_WRITE, {std::make_tuple(RoutingDirection::W, hops)}, FabricApiType::Mesh);
-    }
-}
-TEST_F(NightlyFabric2DTensixUdmFixture, TestTensixUDMFabricInlineWriteNorth) {
-    FabricUnicastCommon(this, NOC_UNICAST_INLINE_WRITE, {std::make_tuple(RoutingDirection::N, 1)}, FabricApiType::Mesh);
-}
-TEST_F(NightlyFabric2DTensixUdmFixture, TestTensixUDMFabricInlineWriteSouth) {
-    FabricUnicastCommon(this, NOC_UNICAST_INLINE_WRITE, {std::make_tuple(RoutingDirection::S, 1)}, FabricApiType::Mesh);
-}
-
 TEST_F(NightlyFabric2DFixture, Test2DMCast) {
     auto valid_combinations = GenerateAllValidCombinations(this);
     for (const auto& [north, south, east, west] : valid_combinations) {

--- a/tt_metal/fabric/builder/fabric_builder_config.cpp
+++ b/tt_metal/fabric/builder/fabric_builder_config.cpp
@@ -15,27 +15,24 @@ uint32_t get_sender_channel_count(const bool is_2D_routing) {
 }
 
 uint32_t get_num_tensix_sender_channels(Topology topology, tt::tt_fabric::FabricTensixConfig fabric_tensix_config) {
+    // TODO: once we support inserting tensix as downstream in UDM mode, add back the channel count for UDM mode
+    TT_FATAL(
+        fabric_tensix_config == tt::tt_fabric::FabricTensixConfig::MUX,
+        "get_num_tensix_sender_channels only supports MUX mode, got {}",
+        static_cast<uint32_t>(fabric_tensix_config));
+
     uint32_t num_channels = 0;
-    if (fabric_tensix_config == tt::tt_fabric::FabricTensixConfig::UDM) {
-        // UDM mode: MUX temporarily has 3 channels (one for worker, one for relay, one for forwarding channel between
-        // mux)
-        // TODO: later need to calculate the number of channels based on the number of worker served, plus one relay
-        // channel, plus one forwarding channel between mux. RELAY permanently has 1 channel (configured separately in
-        // its constructor)
-        num_channels = static_cast<uint32_t>(UdmMuxChannelId::NUM_CHANNELS);
-    } else {
-        // MUX mode: use topology-based channel count
-        switch (topology) {
-            case tt::tt_fabric::Topology::Linear:
-            case tt::tt_fabric::Topology::Ring:
-                num_channels = tt::tt_fabric::builder_config::num_sender_channels_1d_linear;
-                break;
-            case tt::tt_fabric::Topology::Mesh:
-            case tt::tt_fabric::Topology::Torus:
-                num_channels = tt::tt_fabric::builder_config::num_sender_channels_2d_mesh;
-                break;
-            default: TT_THROW("unknown fabric topology: {}", topology); break;
-        }
+    // MUX mode: use topology-based channel count
+    switch (topology) {
+        case tt::tt_fabric::Topology::Linear:
+        case tt::tt_fabric::Topology::Ring:
+            num_channels = tt::tt_fabric::builder_config::num_sender_channels_1d_linear;
+            break;
+        case tt::tt_fabric::Topology::Mesh:
+        case tt::tt_fabric::Topology::Torus:
+            num_channels = tt::tt_fabric::builder_config::num_sender_channels_2d_mesh;
+            break;
+        default: TT_THROW("unknown fabric topology: {}", topology); break;
     }
     return num_channels;
 }

--- a/tt_metal/fabric/builder/fabric_builder_helpers.cpp
+++ b/tt_metal/fabric/builder/fabric_builder_helpers.cpp
@@ -38,4 +38,28 @@ eth_chan_directions get_sender_channel_direction(eth_chan_directions my_directio
     }
 }
 
+std::pair<eth_chan_directions, eth_chan_directions> get_perpendicular_directions(eth_chan_directions direction) {
+    if (direction == eth_chan_directions::EAST || direction == eth_chan_directions::WEST) {
+        // E/W -> perpendicular are N/S
+        return {eth_chan_directions::NORTH, eth_chan_directions::SOUTH};
+    } else {
+        // N/S -> perpendicular are E/W
+        return {eth_chan_directions::EAST, eth_chan_directions::WEST};
+    }
+}
+
+std::vector<eth_chan_directions> get_all_other_directions(eth_chan_directions direction) {
+    std::vector<eth_chan_directions> all_directions = {
+        eth_chan_directions::EAST, eth_chan_directions::WEST, eth_chan_directions::NORTH, eth_chan_directions::SOUTH};
+
+    std::vector<eth_chan_directions> dirs;
+    for (auto dir : all_directions) {
+        if (dir != direction) {
+            dirs.push_back(dir);
+        }
+    }
+
+    return dirs;
+}
+
 }  // namespace tt::tt_fabric::builder

--- a/tt_metal/fabric/builder/fabric_builder_helpers.hpp
+++ b/tt_metal/fabric/builder/fabric_builder_helpers.hpp
@@ -4,6 +4,9 @@
 
 #pragma once
 
+#include <utility>
+#include <vector>
+
 #include "hostdevcommon/fabric_common.h"
 #include "tt_metal/fabric/builder/fabric_builder_config.hpp"
 #include "tt_metal/fabric/fabric_context.hpp"
@@ -15,6 +18,15 @@ namespace builder {
 bool is_east_or_west(eth_chan_directions direction);
 bool is_north_or_south(eth_chan_directions direction);
 eth_chan_directions get_sender_channel_direction(eth_chan_directions my_direction, size_t sender_channel_index);
+
+// Helper function to determine perpendicular directions
+// E/W direction returns N/S as perpendicular; N/S direction returns E/W as perpendicular
+std::pair<eth_chan_directions, eth_chan_directions> get_perpendicular_directions(eth_chan_directions direction);
+
+// Helper function to get directions for inter-mux connections
+// Returns all directions except the current direction, in E,W,N,S order
+std::vector<eth_chan_directions> get_all_other_directions(eth_chan_directions direction);
+
 }  // namespace builder
 
 inline uint32_t get_worker_connected_sender_channel() {

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -2171,9 +2171,7 @@ void ControlPlane::populate_fabric_connection_info(
         auto core_id = tensix_config.get_core_id_for_channel(physical_chip_id, eth_channel_id);
         // In UDM mode, get the first channel for worker connection for now.
         // TODO: have a vector of worker channels based on the current core and connected eth_channel_id
-        uint32_t tensix_sender_channel = (fabric_tensix_config == tt::tt_fabric::FabricTensixConfig::UDM)
-                                             ? static_cast<uint32_t>(UdmMuxChannelId::WORKER_CHANNEL_BASE)
-                                             : sender_channel;
+        uint32_t tensix_sender_channel = sender_channel;
 
         fill_tensix_connection_info_fields(
             tensix_connection_info, mux_core_virtual, tensix_config, tensix_sender_channel, core_id);

--- a/tt_metal/fabric/fabric_edm_packet_header.hpp
+++ b/tt_metal/fabric/fabric_edm_packet_header.hpp
@@ -26,6 +26,10 @@
 // NOLINTBEGIN(misc-unused-parameters)
 namespace tt::tt_fabric {
 
+// Helper for dependent static_assert that always evaluates to false
+template <class>
+inline constexpr bool always_false_v = false;
+
 enum TerminationSignal : uint32_t {
     KEEP_RUNNING = 0,
 
@@ -256,6 +260,9 @@ struct PacketHeaderBase {
 
     Derived& to_noc_unicast_read(const NocUnicastCommandHeader& noc_unicast_command_header, size_t payload_size_bytes) {
 #if defined(KERNEL_BUILD) || defined(FW_BUILD)
+#ifndef UDM_MODE
+        static_assert(always_false_v<Derived>, "to_noc_unicast_read requires UDM mode / relay extension to be enabled");
+#endif
         this->noc_send_type = NOC_UNICAST_READ;
         auto noc_address_components = get_noc_address_components(noc_unicast_command_header.noc_address);
         auto noc_addr = safe_get_noc_addr(
@@ -362,6 +369,9 @@ struct PacketHeaderBase {
     volatile Derived* to_noc_unicast_read(
         const NocUnicastCommandHeader& noc_unicast_command_header, size_t payload_size_bytes) volatile {
 #if defined(KERNEL_BUILD) || defined(FW_BUILD)
+#ifndef UDM_MODE
+        static_assert(always_false_v<Derived>, "to_noc_unicast_read requires UDM mode / relay extension to be enabled");
+#endif
         this->noc_send_type = NOC_UNICAST_READ;
         auto noc_address_components = get_noc_address_components(noc_unicast_command_header.noc_address);
         auto noc_addr = safe_get_noc_addr(

--- a/tt_metal/fabric/fabric_edm_packet_header.hpp
+++ b/tt_metal/fabric/fabric_edm_packet_header.hpp
@@ -169,6 +169,7 @@ struct UDMWriteControlHeader {
     uint8_t risc_id;
     uint8_t transaction_id;
     uint8_t posted;
+    uint8_t initial_direction;
 } __attribute__((packed));
 
 struct UDMReadControlHeader {
@@ -180,17 +181,18 @@ struct UDMReadControlHeader {
     uint32_t size_bytes;
     uint8_t risc_id;
     uint8_t transaction_id;
+    uint8_t initial_direction;
 } __attribute__((packed));
 
-static_assert(sizeof(UDMWriteControlHeader) == 8, "UDMWriteControlHeader size is not 8 bytes");
-static_assert(sizeof(UDMReadControlHeader) == 15, "UDMReadControlHeader size is not 15 bytes");
+static_assert(sizeof(UDMWriteControlHeader) == 9, "UDMWriteControlHeader size is not 9 bytes");
+static_assert(sizeof(UDMReadControlHeader) == 16, "UDMReadControlHeader size is not 16 bytes");
 
 union UDMControlFields {
     UDMWriteControlHeader write;
     UDMReadControlHeader read;
 } __attribute__((packed));
 
-static_assert(sizeof(UDMControlFields) == 15, "UDMControlFields size is not 15 bytes");
+static_assert(sizeof(UDMControlFields) == 16, "UDMControlFields size is not 16 bytes");
 
 // TODO: wrap this in a debug version that holds type info so we can assert for field/command/
 template <typename Derived>
@@ -691,14 +693,13 @@ static_assert(sizeof(HybridMeshPacketHeader) == 80, "sizeof(HybridMeshPacketHead
 
 struct UDMHybridMeshPacketHeader : public HybridMeshPacketHeader {
     UDMControlFields udm_control;
-    uint8_t padding[1];  // Padding to align to 80 bytes (64 base + 15 control + 1 padding = 80)
 
     // Override to return correct size for UDMHybridMeshPacketHeader
     size_t get_payload_size_including_header() volatile const {
         return get_payload_size_excluding_header() + sizeof(UDMHybridMeshPacketHeader);
     }
 } __attribute__((packed));
-static_assert(sizeof(UDMHybridMeshPacketHeader) == 96, "sizeof(UDMHybridMeshPacketHeader) is not equal to 80B");
+static_assert(sizeof(UDMHybridMeshPacketHeader) == 96, "sizeof(UDMHybridMeshPacketHeader) is not equal to 96B");
 
 // TODO: When we remove the 32B padding requirement, reduce to 16B size check
 static_assert(sizeof(PacketHeader) == 32, "sizeof(PacketHeader) is not equal to 32B");

--- a/tt_metal/fabric/fabric_router_builder.cpp
+++ b/tt_metal/fabric/fabric_router_builder.cpp
@@ -84,7 +84,7 @@ std::unique_ptr<FabricRouterBuilder> FabricRouterBuilder::build(
         get_child_builder_variant_sender_channel_injection_flags(router_injection_flags, erisc_to_router_channel_map);
 
     std::vector<bool> tensix_injection_flags;
-    if (will_create_tensix_builder) {
+    if (downstream_is_tensix_builder) {
         size_t tensix_num_channels = builder_config::get_num_tensix_sender_channels(
             topology, tt::tt_metal::MetalContext::instance().get_fabric_tensix_config());
         auto tensix_to_router_channel_map =

--- a/tt_metal/fabric/fabric_tensix_builder.cpp
+++ b/tt_metal/fabric/fabric_tensix_builder.cpp
@@ -231,8 +231,7 @@ bool FabricTensixDatamoverConfig::initialize_channel_mappings() {
 }
 
 // Helper to calculate number of channels for mux (handles both UDM and Legacy modes)
-std::map<ChannelTypes, uint32_t> get_num_mux_channels(
-    const std::vector<tt_metal::IDevice*>& all_active_devices, size_t min_eth_channels) {
+std::map<ChannelTypes, uint32_t> get_num_mux_channels() {
     std::map<ChannelTypes, uint32_t> channel_counts;
 
     auto fabric_tensix_config = tt::tt_metal::MetalContext::instance().get_fabric_tensix_config();
@@ -305,7 +304,7 @@ void FabricTensixDatamoverConfig::calculate_buffer_allocations() {
 
     // Determine num_channels_for_mux and build channel type maps based on mode
     // The helper function handles both UDM and Legacy modes internally
-    mux_channel_counts_ = get_num_mux_channels(all_active_devices, min_eth_channels_);
+    mux_channel_counts_ = get_num_mux_channels();
 
     // Calculate total number of mux channels
     num_channels_for_mux_ = 0;

--- a/tt_metal/fabric/fabric_tensix_builder.cpp
+++ b/tt_metal/fabric/fabric_tensix_builder.cpp
@@ -241,38 +241,7 @@ std::map<ChannelTypes, uint32_t> get_num_mux_channels(
         // UDM mode: calculate channels based on compute grid
         // UDM has WORKER_CHANNEL, RELAY_TO_MUX_CHANNEL, MUX_TO_MUX_CHANNEL (NO ROUTER_CHANNEL)
 
-        // Get compute grid size from first device (should be same across devices)
-        auto device = all_active_devices.front();
-        auto compute_grid = device->compute_with_storage_grid_size();
-        uint32_t num_workers = compute_grid.x * compute_grid.y;
-
-        log_info(tt::LogMetal, "num_workers: {}", num_workers);
-        log_info(tt::LogMetal, "min_eth_channels: {}", min_eth_channels);
-
-        // // Get number of active routing planes (links) from fabric context
-        // const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
-        // auto fabric_node_id = control_plane.get_fabric_node_id_from_physical_chip_id(device->id());
-        // auto active_channels = control_plane.get_active_fabric_eth_channels(fabric_node_id);
-
-        // // Count unique routing plane IDs (num_links)
-        // std::set<routing_plane_id_t> unique_routing_planes;
-        // for (const auto& [eth_chan, direction] : active_channels) {
-        //     auto routing_plane_id = control_plane.get_routing_plane_id(fabric_node_id, eth_chan);
-        //     unique_routing_planes.insert(routing_plane_id);
-        // }
-        // size_t num_links = unique_routing_planes.size();
-
-        // // If dispatch tunnel is present, exclude workers assigned to the dispatch link
-        // const bool has_dispatch_tunnel = device_has_dispatch_tunnel(device->id());
-        // if (has_dispatch_tunnel && num_links > 0) {
-        //     uint32_t num_workers_per_link = num_workers / num_links;
-        //     num_workers = num_workers - num_workers_per_link;
-        // }
-
-        // // Calculate worker channels: number of workers per routing plane
-        // uint32_t num_worker_channels = (num_workers + min_eth_channels - 1) / min_eth_channels;
-        // TODO: this is just testing original behave
-        // channel_counts[ChannelTypes::WORKER_CHANNEL] = num_worker_channels;
+        // TODO: this is just testing original behave, later PR will support full grid of workers
         channel_counts[ChannelTypes::WORKER_CHANNEL] = 1;  // Always 1 worker channel in legacy mode
 
         // Relay channels: 3 channels (LOCAL_RELAY, EAST_OR_NORTH_RELAY, WEST_OR_SOUTH_RELAY)

--- a/tt_metal/fabric/fabric_tensix_builder.hpp
+++ b/tt_metal/fabric/fabric_tensix_builder.hpp
@@ -151,7 +151,39 @@ private:
     size_t max_eth_channels_ = 0;
 
     // Helper methods for initialization
+
+    /**
+     * Computes the minimum and maximum number of non-dispatch active ethernet channels
+     * across all active devices in the system.
+     *
+     * For each device, this function:
+     * 1. Gathers active fabric ethernet channels in each routing direction
+     * 2. Filters out channels reserved for dispatch tunnels
+     * 3. Counts the remaining non-dispatch channels
+     *
+     * The results are stored in min_eth_channels_ and max_eth_channels_ member variables,
+     * which are later used by calculate_buffer_allocations() to determine buffer sizing
+     * and channel configuration.
+     */
     void find_min_max_eth_channels(const std::vector<tt_metal::IDevice*>& all_active_devices);
+
+    /**
+     * Builds per-device channel mappings using real ethernet channel IDs.
+     *
+     * For each device, creates round-robin mapping of ethernet channels to tensix cores,
+     * populating eth_chan_to_core_index_ and eth_chan_to_core_id_ maps.
+     */
+    void build_per_device_channel_mappings(const std::vector<tt_metal::IDevice*>& all_active_devices);
+
+    /**
+     * Builds the fabric_router_noc_coords_map_ to track which routers/tensix exist in each direction
+     * for each fabric node and routing plane (link index).
+     *
+     * For each active device and its ethernet channels, this function records the tensix NOC
+     * coordinates in the map, keyed by fabric node ID, routing plane ID, and direction.
+     */
+    void build_fabric_router_noc_coords_map(const std::vector<tt_metal::IDevice*>& all_active_devices);
+
     bool initialize_channel_mappings();
     void calculate_buffer_allocations();
     void create_configs();  // Creates mode-aware configs based on FabricTensixConfig

--- a/tt_metal/fabric/fabric_tensix_builder.hpp
+++ b/tt_metal/fabric/fabric_tensix_builder.hpp
@@ -97,6 +97,11 @@ public:
 
     std::pair<uint32_t, uint32_t> get_termination_address_and_signal(FabricTensixCoreType core_id) const;
 
+    // Get router NOC coordinates for a specific fabric node, routing plane, and direction
+    // Returns pointer to pair (noc_x, noc_y) if router exists, nullptr otherwise
+    const std::pair<uint32_t, uint32_t>* get_router_noc_coords(
+        const FabricNodeId& fabric_node_id, routing_plane_id_t routing_plane_id, eth_chan_directions direction) const;
+
 private:
     std::vector<CoreCoord> logical_fabric_mux_cores_;
     std::vector<CoreCoord> logical_dispatch_mux_cores_;
@@ -112,6 +117,7 @@ private:
     size_t num_channels_for_mux_{};  // Number of channels for MUX configuration
     size_t num_buffers_per_channel_{};
     size_t buffer_size_bytes_full_size_channel_{};
+    size_t space_per_risc_{};  // L1 space allocated per RISC
 
     // Base L1 addresses for each RISC ID, [risc id] -> [base addr] mapping
     std::unordered_map<FabricTensixCoreType, size_t> base_l1_addresses_;
@@ -126,6 +132,13 @@ private:
     // In MUX mode: only MUX has config
     // In UDM mode: both MUX and RELAY have configs
     std::unordered_map<FabricTensixCoreType, std::shared_ptr<FabricTensixDatamoverBaseConfig>> configs_;
+
+    // Mapping: [fabric_node_id] -> [routing_plane_id] -> [direction (E/W/N/S)] -> (noc_x, noc_y)
+    // If an entry exists, the router/tensix is active in that direction; otherwise it doesn't exist
+    std::unordered_map<
+        FabricNodeId,
+        std::unordered_map<routing_plane_id_t, std::unordered_map<eth_chan_directions, std::pair<uint32_t, uint32_t>>>>
+        fabric_router_noc_coords_map_;
 
     // Helper methods for initialization
     bool initialize_channel_mappings();

--- a/tt_metal/fabric/fabric_tensix_builder_impl.cpp
+++ b/tt_metal/fabric/fabric_tensix_builder_impl.cpp
@@ -54,7 +54,7 @@ static std::vector<eth_chan_directions> get_all_other_directions(eth_chan_direct
 
 static uint32_t get_downstream_mux_channel_id(eth_chan_directions direction, eth_chan_directions downstream_direction) {
     size_t channel_id;
-    size_t inter_mux_base_channel_id = static_cast<uint32_t>(UdmMuxChannelId::EAST_OR_WEST_MUX_CHANNEL);
+    size_t inter_mux_base_channel_id = static_cast<uint32_t>(UdmMuxInterMuxChannelId::EAST_OR_WEST_MUX_CHANNEL);
     if (downstream_direction == eth_chan_directions::EAST) {
         // For East mux as downstream:
         //   Channel 4: Accept connection from West Mux (direction=1, channel_id=1+4-1=4)
@@ -89,7 +89,7 @@ static uint32_t get_upstream_mux_channel_id(eth_chan_directions direction, eth_c
     uint32_t current_idx = static_cast<uint32_t>(direction);
 
     // Base channel for inter-mux connections
-    uint32_t base_channel = static_cast<uint32_t>(UdmMuxChannelId::EAST_OR_WEST_MUX_CHANNEL);
+    uint32_t base_channel = static_cast<uint32_t>(UdmMuxInterMuxChannelId::EAST_OR_WEST_MUX_CHANNEL);
 
     // If upstream comes before current in enum order (E=0, W=1, N=2, S=3), use index as-is
     // Otherwise subtract 1 to account for skipping the current direction
@@ -121,42 +121,30 @@ size_t FabricTensixDatamoverBaseConfig::MemoryRegion::get_total_size() const { r
 
 // Base Config Constructor
 FabricTensixDatamoverBaseConfig::FabricTensixDatamoverBaseConfig(
-    uint8_t num_full_size_channels,
-    uint8_t num_header_only_channels,
-    uint8_t num_buffers_full_size_channel,
-    uint8_t num_buffers_header_only_channel,
-    size_t buffer_size_bytes_full_size_channel,
-    size_t base_l1_address,
-    size_t l1_end_address,
-    CoreType core_type) :
-    core_type_(core_type),
-    num_full_size_channels_(num_full_size_channels),
-    num_header_only_channels_(num_header_only_channels),
-    num_buffers_full_size_channel_(
-        num_buffers_full_size_channel == 0 ? default_num_buffers : num_buffers_full_size_channel),
-    num_buffers_header_only_channel_(
-        num_buffers_header_only_channel == 0 ? default_num_buffers : num_buffers_header_only_channel),
-    buffer_size_bytes_full_size_channel_(buffer_size_bytes_full_size_channel) {
-    TT_FATAL(
-        num_full_size_channels_ > 0 || num_header_only_channels_ > 0,
-        "At least one type of channel must be configured");
+    const std::map<ChannelTypes, ChannelTypeConfig>& channel_configs, size_t base_l1_address, size_t l1_end_address) :
+    channel_configs_(channel_configs) {
+    TT_FATAL(!channel_configs_.empty(), "At least one channel type must be configured");
 
-    size_t max_buffer_size_bytes_full_size_channel = tt::tt_fabric::get_tt_fabric_channel_buffer_size_bytes();
-    TT_FATAL(
-        buffer_size_bytes_full_size_channel <= max_buffer_size_bytes_full_size_channel,
-        "Buffer size bytes for full size channel should be less than or equal to: {}, but got: {}",
-        max_buffer_size_bytes_full_size_channel,
-        buffer_size_bytes_full_size_channel);
+    // Calculate total number of channels across all types (cached as member variable)
+    num_total_channels_ = 0;
+    for (const auto& [type, config] : channel_configs_) {
+        num_total_channels_ += config.num_channels;
+    }
+
+    TT_FATAL(num_total_channels_ > 0, "Total number of channels must be greater than 0");
+
+    // Validate buffer sizes
+    size_t max_buffer_size_bytes = tt::tt_fabric::get_tt_fabric_channel_buffer_size_bytes();
+    for (const auto& [type, config] : channel_configs_) {
+        TT_FATAL(
+            config.buffer_size_bytes <= max_buffer_size_bytes,
+            "Buffer size bytes should be less than or equal to: {}, but got: {}",
+            max_buffer_size_bytes,
+            config.buffer_size_bytes);
+    }
 
     noc_aligned_address_size_bytes_ =
         tt::tt_metal::MetalContext::instance().hal().get_alignment(tt::tt_metal::HalMemType::L1);
-
-    buffer_size_bytes_header_only_channel_ = tt::tt_fabric::get_tt_fabric_packet_header_size_bytes();
-
-    full_size_channel_size_bytes_ = num_buffers_full_size_channel_ * buffer_size_bytes_full_size_channel_;
-    header_only_channel_size_bytes_ = num_buffers_header_only_channel_ * buffer_size_bytes_header_only_channel_;
-
-    auto num_total_channels = num_full_size_channels_ + num_header_only_channels_;
 
     // Initialize memory regions sequentially
     size_t current_address = base_l1_address;
@@ -170,38 +158,39 @@ FabricTensixDatamoverBaseConfig::FabricTensixDatamoverBaseConfig(
     termination_signal_region_ = MemoryRegion(current_address, noc_aligned_address_size_bytes_, 1);
     current_address = termination_signal_region_.get_end_address();
 
-    connection_info_region_ =
-        MemoryRegion(current_address, sizeof(tt::tt_fabric::EDMChannelWorkerLocationInfo), num_total_channels);
-    current_address = connection_info_region_.get_end_address();
+    // Allocate per-channel-type regions (organized by ChannelTypes)
+    // std::map already maintains sorted order by ChannelTypes enum, no need to sort!
+    for (const auto& [type, config] : channel_configs_) {
+        // Connection info region: stores EDMChannelWorkerLocationInfo per channel
+        connection_info_regions_[type] =
+            MemoryRegion(current_address, sizeof(tt::tt_fabric::EDMChannelWorkerLocationInfo), config.num_channels);
+        current_address = connection_info_regions_[type].get_end_address();
 
-    connection_handshake_region_ = MemoryRegion(current_address, noc_aligned_address_size_bytes_, num_total_channels);
-    current_address = connection_handshake_region_.get_end_address();
+        // Connection handshake region: liveness/handshake per channel
+        connection_handshake_regions_[type] =
+            MemoryRegion(current_address, noc_aligned_address_size_bytes_, config.num_channels);
+        current_address = connection_handshake_regions_[type].get_end_address();
 
-    flow_control_region_ = MemoryRegion(current_address, noc_aligned_address_size_bytes_, num_total_channels);
-    current_address = flow_control_region_.get_end_address();
+        // Flow control region: reserved/unused per channel
+        flow_control_regions_[type] =
+            MemoryRegion(current_address, noc_aligned_address_size_bytes_, config.num_channels);
+        current_address = flow_control_regions_[type].get_end_address();
 
-    buffer_index_region_ = MemoryRegion(current_address, noc_aligned_address_size_bytes_, num_total_channels);
-    current_address = buffer_index_region_.get_end_address();
+        // Buffer index region: write pointer synchronization per channel
+        buffer_index_regions_[type] =
+            MemoryRegion(current_address, noc_aligned_address_size_bytes_, config.num_channels);
+        current_address = buffer_index_regions_[type].get_end_address();
 
-    full_size_channels_region_ = MemoryRegion(current_address, full_size_channel_size_bytes_, num_full_size_channels_);
-    current_address = full_size_channels_region_.get_end_address();
-
-    header_only_channels_region_ =
-        MemoryRegion(current_address, header_only_channel_size_bytes_, num_header_only_channels_);
-
-    memory_map_end_address_ = header_only_channels_region_.get_end_address();
-
-    const auto& hal = tt_metal::MetalContext::instance().hal();
-    tt_metal::HalProgrammableCoreType hal_core_type;
-    if (core_type_ == CoreType::WORKER) {
-        hal_core_type = tt_metal::HalProgrammableCoreType::TENSIX;
-    } else if (core_type_ == CoreType::IDLE_ETH) {
-        hal_core_type = tt_metal::HalProgrammableCoreType::IDLE_ETH;
-    } else {
-        TT_THROW("Fabric Tensix Datamover does not support core type {}", static_cast<int>(core_type));
+        // Channel buffer region: actual data buffers per channel
+        size_t channel_size_bytes = config.num_buffers_per_channel * config.buffer_size_bytes;
+        channel_buffer_regions_[type] = MemoryRegion(current_address, channel_size_bytes, config.num_channels);
+        current_address = channel_buffer_regions_[type].get_end_address();
     }
 
-    core_type_index_ = hal.get_programmable_core_type_index(hal_core_type);
+    memory_map_end_address_ = current_address;
+
+    const auto& hal = tt_metal::MetalContext::instance().hal();
+    core_type_index_ = hal.get_programmable_core_type_index(tt::tt_metal::HalProgrammableCoreType::TENSIX);
 
     TT_FATAL(
         memory_map_end_address_ <= l1_end_address,
@@ -211,19 +200,40 @@ FabricTensixDatamoverBaseConfig::FabricTensixDatamoverBaseConfig(
 }
 
 // Getters
-uint8_t FabricTensixDatamoverBaseConfig::get_num_channels(FabricMuxChannelType channel_type) const {
-    return channel_type == FabricMuxChannelType::FULL_SIZE_CHANNEL ? num_full_size_channels_
-                                                                   : num_header_only_channels_;
+size_t FabricTensixDatamoverBaseConfig::get_num_channels(ChannelTypes channel_type) const {
+    // Return the number of channels for the specific channel type
+    TT_FATAL(
+        channel_configs_.find(channel_type) != channel_configs_.end(),
+        "Channel type {} not found in channel_configs_",
+        static_cast<uint32_t>(channel_type));
+    return channel_configs_.at(channel_type).num_channels;
 }
 
-uint8_t FabricTensixDatamoverBaseConfig::get_num_buffers(FabricMuxChannelType channel_type) const {
-    return channel_type == FabricMuxChannelType::FULL_SIZE_CHANNEL ? num_buffers_full_size_channel_
-                                                                   : num_buffers_header_only_channel_;
+size_t FabricTensixDatamoverBaseConfig::get_total_num_channels() const {
+    // Return the total number of channels across all channel types
+    return num_total_channels_;
 }
 
-size_t FabricTensixDatamoverBaseConfig::get_buffer_size_bytes(FabricMuxChannelType channel_type) const {
-    return channel_type == FabricMuxChannelType::FULL_SIZE_CHANNEL ? buffer_size_bytes_full_size_channel_
-                                                                   : buffer_size_bytes_header_only_channel_;
+size_t FabricTensixDatamoverBaseConfig::get_num_buffers(ChannelTypes channel_type) const {
+    // Return number of buffers for the specific channel type
+    TT_FATAL(
+        channel_configs_.find(channel_type) != channel_configs_.end(),
+        "Channel type {} not found in channel_configs_",
+        static_cast<uint32_t>(channel_type));
+    return channel_configs_.at(channel_type).num_buffers_per_channel;
+}
+
+size_t FabricTensixDatamoverBaseConfig::get_buffer_size_bytes(ChannelTypes channel_type) const {
+    // Return buffer size for the specific channel type
+    TT_FATAL(
+        channel_configs_.find(channel_type) != channel_configs_.end(),
+        "Channel type {} not found in channel_configs_",
+        static_cast<uint32_t>(channel_type));
+    return channel_configs_.at(channel_type).buffer_size_bytes;
+}
+
+const std::map<ChannelTypes, ChannelTypeConfig>& FabricTensixDatamoverBaseConfig::get_channel_configs() const {
+    return channel_configs_;
 }
 
 size_t FabricTensixDatamoverBaseConfig::get_status_address() const { return status_region_.get_address(); }
@@ -233,48 +243,43 @@ size_t FabricTensixDatamoverBaseConfig::get_termination_signal_address() const {
 }
 
 size_t FabricTensixDatamoverBaseConfig::get_channel_credits_stream_id(
-    FabricMuxChannelType channel_type, uint32_t channel_id) const {
+    ChannelTypes channel_type, uint32_t channel_id) const {
     validate_channel_id(channel_type, channel_id);
     return get_channel_global_offset(channel_type, channel_id);
 }
 
-size_t FabricTensixDatamoverBaseConfig::get_channel_base_address(
-    FabricMuxChannelType channel_type, uint32_t channel_id) const {
+size_t FabricTensixDatamoverBaseConfig::get_channel_base_address(ChannelTypes channel_type, uint32_t channel_id) const {
     validate_channel_id(channel_type, channel_id);
-    return channel_type == FabricMuxChannelType::FULL_SIZE_CHANNEL
-               ? full_size_channels_region_.get_address(channel_id)
-               : header_only_channels_region_.get_address(channel_id);
+    return channel_buffer_regions_.at(channel_type).get_address(channel_id);
 }
 
 size_t FabricTensixDatamoverBaseConfig::get_connection_info_address(
-    FabricMuxChannelType channel_type, uint32_t channel_id) const {
+    ChannelTypes channel_type, uint32_t channel_id) const {
     validate_channel_id(channel_type, channel_id);
-    return connection_info_region_.get_address(get_channel_global_offset(channel_type, channel_id));
+    return connection_info_regions_.at(channel_type).get_address(channel_id);
 }
 
 size_t FabricTensixDatamoverBaseConfig::get_connection_handshake_address(
-    FabricMuxChannelType channel_type, uint32_t channel_id) const {
+    ChannelTypes channel_type, uint32_t channel_id) const {
     validate_channel_id(channel_type, channel_id);
-    return connection_handshake_region_.get_address(get_channel_global_offset(channel_type, channel_id));
+    return connection_handshake_regions_.at(channel_type).get_address(channel_id);
 }
 
-size_t FabricTensixDatamoverBaseConfig::get_flow_control_address(
-    FabricMuxChannelType channel_type, uint32_t channel_id) const {
+size_t FabricTensixDatamoverBaseConfig::get_flow_control_address(ChannelTypes channel_type, uint32_t channel_id) const {
     validate_channel_id(channel_type, channel_id);
-    return flow_control_region_.get_address(get_channel_global_offset(channel_type, channel_id));
+    return flow_control_regions_.at(channel_type).get_address(channel_id);
 }
 
-size_t FabricTensixDatamoverBaseConfig::get_buffer_index_address(
-    FabricMuxChannelType channel_type, uint32_t channel_id) const {
+size_t FabricTensixDatamoverBaseConfig::get_buffer_index_address(ChannelTypes channel_type, uint32_t channel_id) const {
     validate_channel_id(channel_type, channel_id);
-    return buffer_index_region_.get_address(get_channel_global_offset(channel_type, channel_id));
+    return buffer_index_regions_.at(channel_type).get_address(channel_id);
 }
 
 size_t FabricTensixDatamoverBaseConfig::get_memory_map_end_address() const { return memory_map_end_address_; }
 
 // Setters
 void FabricTensixDatamoverBaseConfig::set_num_full_size_channel_iters(size_t new_val) {
-    TT_FATAL(num_full_size_channels_ > 0, "Cannot set iterations when no full size channels exist");
+    TT_FATAL(!channel_configs_.empty(), "Cannot set iterations when no channels exist");
     TT_FATAL(new_val > 0, "Number of iterations must be greater than 0");
     num_full_size_channel_iters_ = new_val;
 }
@@ -297,11 +302,23 @@ void FabricTensixDatamoverBaseConfig::set_fabric_endpoint_status_address(size_t 
 }
 
 std::vector<std::pair<size_t, size_t>> FabricTensixDatamoverBaseConfig::get_memory_regions_to_clear() const {
-    return {
-        {termination_signal_region_.get_address(), termination_signal_region_.get_total_size()},
-        {connection_handshake_region_.get_address(), connection_handshake_region_.get_total_size()},
-        {flow_control_region_.get_address(), flow_control_region_.get_total_size()},
-        {buffer_index_region_.get_address(), buffer_index_region_.get_total_size()}};
+    std::vector<std::pair<size_t, size_t>> regions;
+
+    // Always clear termination signal region
+    regions.push_back({termination_signal_region_.get_address(), termination_signal_region_.get_total_size()});
+
+    // Clear per-channel-type regions
+    for (const auto& [type, config] : channel_configs_) {
+        regions.push_back(
+            {connection_handshake_regions_.at(type).get_address(),
+             connection_handshake_regions_.at(type).get_total_size()});
+        regions.push_back(
+            {flow_control_regions_.at(type).get_address(), flow_control_regions_.at(type).get_total_size()});
+        regions.push_back(
+            {buffer_index_regions_.at(type).get_address(), buffer_index_regions_.at(type).get_total_size()});
+    }
+
+    return regions;
 }
 
 std::vector<uint32_t> FabricTensixDatamoverBaseConfig::get_run_time_args(
@@ -337,33 +354,39 @@ std::vector<uint32_t> FabricTensixDatamoverBaseConfig::get_run_time_args(
     }
 
     tt::tt_fabric::append_fabric_connection_rt_args(
-        src_fabric_node_id, dst_fabric_node_id, link_idx, program, logical_core, args, core_type_);
+        src_fabric_node_id, dst_fabric_node_id, link_idx, program, logical_core, args, CoreType::WORKER);
 
     return args;
 }
 
 // Helper methods
-void FabricTensixDatamoverBaseConfig::validate_channel_id(FabricMuxChannelType channel_type, uint8_t channel_id) const {
+void FabricTensixDatamoverBaseConfig::validate_channel_id(ChannelTypes channel_type, size_t channel_id) const {
+    // Validate that the channel_id is valid for this specific channel type
     TT_FATAL(
-        channel_id < get_num_channels(channel_type),
-        "Invalid channel id for channel type. Requested channel id: {} but maximum is {}",
+        channel_configs_.find(channel_type) != channel_configs_.end(),
+        "Channel type {} not found in channel_configs_",
+        static_cast<uint32_t>(channel_type));
+    const auto& config = channel_configs_.at(channel_type);
+
+    TT_FATAL(
+        channel_id < config.num_channels,
+        "Invalid channel id {} for channel type {}. This type has {} channels",
         channel_id,
-        get_num_channels(channel_type));
+        static_cast<uint32_t>(channel_type),
+        config.num_channels);
 }
 
-uint8_t FabricTensixDatamoverBaseConfig::get_channel_global_offset(
-    FabricMuxChannelType channel_type, uint8_t channel_id) const {
-    return (channel_type == FabricMuxChannelType::HEADER_ONLY_CHANNEL) ? num_full_size_channels_ + channel_id
-                                                                       : channel_id;
-}
+size_t FabricTensixDatamoverBaseConfig::get_channel_global_offset(ChannelTypes channel_type, size_t channel_id) const {
+    // Calculate global offset by summing channels from all channel types before this one
+    size_t global_offset = 0;
+    for (const auto& [type, config] : channel_configs_) {
+        if (type == channel_type) {
+            return global_offset + channel_id;
+        }
+        global_offset += config.num_channels;
+    }
 
-void FabricTensixDatamoverBaseConfig::append_default_stream_ids_to_ct_args(std::vector<uint32_t>& ct_args) const {
-    for (uint8_t i = 0; i < num_full_size_channels_; i++) {
-        ct_args.push_back(get_channel_credits_stream_id(FabricMuxChannelType::FULL_SIZE_CHANNEL, i));
-    }
-    for (uint8_t i = 0; i < num_header_only_channels_; i++) {
-        ct_args.push_back(get_channel_credits_stream_id(FabricMuxChannelType::HEADER_ONLY_CHANNEL, i));
-    }
+    TT_THROW("Channel type {} not found in configuration", static_cast<uint32_t>(channel_type));
 }
 
 // ==================================================================================================
@@ -371,28 +394,18 @@ void FabricTensixDatamoverBaseConfig::append_default_stream_ids_to_ct_args(std::
 // ==================================================================================================
 
 FabricTensixDatamoverMuxConfig::FabricTensixDatamoverMuxConfig(
-    uint8_t num_full_size_channels,
-    uint8_t num_header_only_channels,
-    uint8_t num_buffers_full_size_channel,
-    uint8_t num_buffers_header_only_channel,
-    size_t buffer_size_bytes_full_size_channel,
+    const std::map<ChannelTypes, ChannelTypeConfig>& channel_type_configs,
     size_t base_l1_address,
-    size_t l1_end_address,
-    CoreType core_type) :
+    size_t l1_end_address) :
     FabricTensixDatamoverBaseConfig(
-        num_full_size_channels,
-        num_header_only_channels,
-        num_buffers_full_size_channel,
-        num_buffers_header_only_channel,
-        buffer_size_bytes_full_size_channel,
+        channel_type_configs,  // Pass map directly, already sorted!
         base_l1_address,
-        l1_end_address,
-        core_type) {
-    // Allocate semaphore regions for mux → downstream mux connections (two perpendicular directions)
+        l1_end_address) {
+    // Allocate semaphore regions for mux → downstream mux connections (three perpendicular directions)
     // These are in current mux's L1 memory for downstream muxes to write flow control signals back
     size_t current_address = memory_map_end_address_;
 
-    // Allocate 2 sets of semaphore regions (one per downstream mux connection)
+    // Allocate 3 sets of semaphore regions (one per downstream mux connection)
     for (uint32_t i = 0; i < NUM_DOWNSTREAM_MUX_CONNECTIONS; i++) {
         downstream_mux_flow_control_semaphore_regions_[i] =
             MemoryRegion(current_address, noc_aligned_address_size_bytes_, 1);
@@ -422,7 +435,7 @@ MuxConnectionInfo FabricTensixDatamoverMuxConfig::get_mux_connection_info(
     uint32_t connection_region_idx,
     uint32_t stream_id) const {
     // Get downstream mux config (all muxes share the same config)
-    auto channel_type = tt::tt_fabric::FabricMuxChannelType::FULL_SIZE_CHANNEL;
+    auto channel_type = tt::tt_fabric::ChannelTypes::MUX_TO_MUX_CHANNEL;
 
     return MuxConnectionInfo{
         .active = noc_coords ? 1u : 0u,
@@ -440,15 +453,21 @@ MuxConnectionInfo FabricTensixDatamoverMuxConfig::get_mux_connection_info(
         .stream_id = stream_id};
 }
 
-std::array<MuxConnectionInfo, FabricTensixDatamoverMuxConfig::NUM_DOWNSTREAM_MUX_CONNECTIONS>
-FabricTensixDatamoverMuxConfig::get_all_mux_connection_infos(
+std::vector<MuxConnectionInfo> FabricTensixDatamoverMuxConfig::get_all_mux_connection_infos(
     const FabricNodeId& fabric_node_id, routing_plane_id_t routing_plane_id, eth_chan_directions direction) const {
+    // In legacy MUX mode, we don't have MUX_TO_MUX_CHANNEL, so return empty vector (size 0)
+    if (channel_configs_.find(tt::tt_fabric::ChannelTypes::MUX_TO_MUX_CHANNEL) == channel_configs_.end()) {
+        // Legacy MUX mode - no downstream mux connections
+        return std::vector<MuxConnectionInfo>();
+    }
+
+    // UDM mode - collect downstream mux connection info
     const auto& fabric_context = tt::tt_metal::MetalContext::instance().get_control_plane().get_fabric_context();
     const auto& tensix_config = fabric_context.get_tensix_config();
 
     auto downstream_dirs = get_all_other_directions(direction);
 
-    std::array<MuxConnectionInfo, NUM_DOWNSTREAM_MUX_CONNECTIONS> mux_infos;
+    std::vector<MuxConnectionInfo> mux_infos;
 
     // Collect connection info for each downstream mux
     for (uint32_t i = 0; i < downstream_dirs.size(); i++) {
@@ -461,14 +480,14 @@ FabricTensixDatamoverMuxConfig::get_all_mux_connection_infos(
 
         // Get the stream ID for the downstream mux's channel
         uint32_t mux_stream_id =
-            tensix_config.get_channel_credits_stream_id(downstream_mux_channel, FabricTensixCoreType::MUX);
+            get_channel_credits_stream_id(tt::tt_fabric::ChannelTypes::MUX_TO_MUX_CHANNEL, downstream_mux_channel);
 
         // Connection region index maps to the array index
         uint32_t connection_region_idx = i;
 
         // Collect connection info for this downstream mux
-        mux_infos[i] = get_mux_connection_info(
-            downstream_mux_noc_coord, downstream_mux_channel, connection_region_idx, mux_stream_id);
+        mux_infos.push_back(get_mux_connection_info(
+            downstream_mux_noc_coord, downstream_mux_channel, connection_region_idx, mux_stream_id));
     }
 
     return mux_infos;
@@ -497,28 +516,53 @@ std::vector<uint32_t> FabricTensixDatamoverMuxConfig::get_compile_time_args(
 
     auto mux_infos = get_all_mux_connection_infos(fabric_node_id, routing_plane_id, direction);
 
-    // Build compile time args following similar pattern to relay
+    // Build compile time args - organized by channel type
+    uint32_t num_channel_types = static_cast<uint32_t>(channel_configs_.size());
+
     std::vector<uint32_t> ct_args = {
-        num_full_size_channels_,                           // 0
-        num_buffers_full_size_channel_,                    // 1
-        buffer_size_bytes_full_size_channel_,              // 2
-        num_header_only_channels_,                         // 3
-        num_buffers_header_only_channel_,                  // 4
-        status_region_.get_address(),                      // 5
-        termination_signal_region_.get_address(),          // 6
-        connection_info_region_.get_address(),             // 7
-        connection_handshake_region_.get_address(),        // 8
-        flow_control_region_.get_address(),                // 9
-        full_size_channels_region_.get_address(),          // 10
-        local_fabric_router_status_region_.get_address(),  // 11
-        fabric_endpoint_status_address_,                   // 12
-        fabric_endpoint_channel_num_buffers_,              // 13
-        num_full_size_channel_iters_,                      // 14
-        num_iters_between_teardown_checks_,                // 15
-        core_type_index_,                                  // 16
-        (uint32_t)wait_for_fabric_endpoint_ready_,         // 17
-        NUM_DOWNSTREAM_MUX_CONNECTIONS                     // 18: NUM_DOWNSTREAM_MUX_CONNECTIONS
+        num_total_channels_,                               // 0: total number of channels across all types
+        status_region_.get_address(),                      // 1
+        termination_signal_region_.get_address(),          // 2
+        local_fabric_router_status_region_.get_address(),  // 3
+        fabric_endpoint_status_address_,                   // 4
+        fabric_endpoint_channel_num_buffers_,              // 5
+        num_full_size_channel_iters_,                      // 6
+        num_iters_between_teardown_checks_,                // 7
+        core_type_index_,                                  // 8
+        (uint32_t)wait_for_fabric_endpoint_ready_,         // 9
+        static_cast<uint32_t>(mux_infos.size()),  // 10: number of downstream mux connections (0 for legacy, 3 for UDM)
+        num_channel_types                         // 11: number of channel types
     };
+
+    constexpr uint32_t base_channel_id = 0;
+    // Append per-channel-type arrays (grouped by channel type, sorted by enum)
+    for (const auto& [type, config] : channel_configs_) {
+        ct_args.push_back(config.num_channels);
+    }
+    // Number of buffers per channel (one per channel type)
+    for (const auto& [type, config] : channel_configs_) {
+        ct_args.push_back(config.num_buffers_per_channel);
+    }
+    // Buffer size in bytes (one per channel type)
+    for (const auto& [type, config] : channel_configs_) {
+        ct_args.push_back(static_cast<uint32_t>(config.buffer_size_bytes));
+    }
+    // Connection info base addresses (one per channel type)
+    for (const auto& [type, region] : connection_info_regions_) {
+        ct_args.push_back(region.get_address(base_channel_id));
+    }
+    // Connection handshake base addresses (one per channel type)
+    for (const auto& [type, region] : connection_handshake_regions_) {
+        ct_args.push_back(region.get_address(base_channel_id));
+    }
+    // Flow control base addresses (one per channel type)
+    for (const auto& [type, region] : flow_control_regions_) {
+        ct_args.push_back(region.get_address(base_channel_id));
+    }
+    // Channel buffer base addresses (one per channel type)
+    for (const auto& [type, region] : channel_buffer_regions_) {
+        ct_args.push_back(region.get_address(base_channel_id));
+    }
 
     // Append downstream mux connection arrays (similar to relay's mux connection arrays)
     // Active flags array
@@ -574,20 +618,13 @@ std::vector<uint32_t> FabricTensixDatamoverMuxConfig::get_compile_time_args(
 // ==================================================================================================
 
 FabricTensixDatamoverRelayConfig::FabricTensixDatamoverRelayConfig(
-    uint8_t num_buffers_per_channel,
-    size_t buffer_size_bytes,
+    const std::map<ChannelTypes, ChannelTypeConfig>& channel_type_configs,
     size_t base_l1_address,
-    size_t l1_end_address,
-    CoreType core_type) :
+    size_t l1_end_address) :
     FabricTensixDatamoverBaseConfig(
-        1,                        // num_full_size_channels - relay uses only 1 channel
-        0,                        // num_header_only_channels - no header-only channels for relay
-        num_buffers_per_channel,  // num_buffers_full_size_channel
-        0,                        // num_buffers_header_only_channel
-        buffer_size_bytes,        // buffer_size_bytes_full_size_channel
+        channel_type_configs,  // Pass map directly, already sorted!
         base_l1_address,
-        l1_end_address,
-        core_type) {
+        l1_end_address) {
     // Allocate semaphore regions for relay → mux connections (local, downstream_en, downstream_ws)
     // These are in relay's L1 memory for the mux to write flow control signals back to the relay
     size_t current_address = memory_map_end_address_;
@@ -625,7 +662,7 @@ MuxConnectionInfo FabricTensixDatamoverRelayConfig::get_mux_connection_info(
     const auto& fabric_context = tt::tt_metal::MetalContext::instance().get_control_plane().get_fabric_context();
     const auto& tensix_config = fabric_context.get_tensix_config();
     auto mux_config = tensix_config.get_config(FabricTensixCoreType::MUX);
-    auto channel_type = tt::tt_fabric::FabricMuxChannelType::FULL_SIZE_CHANNEL;
+    auto channel_type = tt::tt_fabric::ChannelTypes::RELAY_TO_MUX_CHANNEL;
 
     return MuxConnectionInfo{
         .active = noc_coords ? 1u : 0u,
@@ -661,23 +698,45 @@ FabricTensixDatamoverRelayConfig::get_all_mux_connection_infos(
         uint32_t mux_channel_id;
         if (i == 0) {
             // Local connection
-            mux_channel_id = static_cast<uint32_t>(UdmMuxChannelId::LOCAL_RELAY_CHANNEL);
+            mux_channel_id = static_cast<uint32_t>(UdmMuxRelayToMuxChannelId::LOCAL_RELAY_CHANNEL);
         } else {
             // Downstream connection (perpendicular)
             // EAST/NORTH relay connects to EAST_OR_NORTH_RELAY_CHANNEL
             // WEST/SOUTH relay connects to WEST_OR_SOUTH_RELAY_CHANNEL
             mux_channel_id = (direction == eth_chan_directions::EAST || direction == eth_chan_directions::NORTH)
-                                 ? static_cast<uint32_t>(UdmMuxChannelId::EAST_OR_NORTH_RELAY_CHANNEL)
-                                 : static_cast<uint32_t>(UdmMuxChannelId::WEST_OR_SOUTH_RELAY_CHANNEL);
+                                 ? static_cast<uint32_t>(UdmMuxRelayToMuxChannelId::EAST_OR_NORTH_RELAY_CHANNEL)
+                                 : static_cast<uint32_t>(UdmMuxRelayToMuxChannelId::WEST_OR_SOUTH_RELAY_CHANNEL);
         }
 
         // Get stream ID for the target mux channel
-        uint32_t mux_stream_id = tensix_config.get_channel_credits_stream_id(mux_channel_id, FabricTensixCoreType::MUX);
+        auto mux_config = tensix_config.get_config(FabricTensixCoreType::MUX);
+        uint32_t mux_stream_id = mux_config->get_channel_credits_stream_id(
+            tt::tt_fabric::ChannelTypes::RELAY_TO_MUX_CHANNEL, mux_channel_id);
 
         mux_infos[i] = get_mux_connection_info(mux_noc_coord, mux_channel_id, i, mux_stream_id);
     }
 
     return mux_infos;
+}
+
+size_t FabricTensixDatamoverRelayConfig::get_channel_credits_stream_id(
+    ChannelTypes channel_type, uint32_t channel_id) const {
+    // Get base stream ID from parent class
+    size_t stream_id = FabricTensixDatamoverBaseConfig::get_channel_credits_stream_id(channel_type, channel_id);
+
+    // In UDM mode, relay stream IDs must come after mux stream IDs to avoid collisions
+    // Both mux and relay are on the same Tensix core, so they share the same stream ID space
+    const auto& fabric_context = tt::tt_metal::MetalContext::instance().get_control_plane().get_fabric_context();
+    const auto& tensix_config = fabric_context.get_tensix_config();
+
+    auto mux_config = tensix_config.get_config(FabricTensixCoreType::MUX);
+    TT_FATAL(mux_config != nullptr, "Mux config cannot be null");
+
+    // Offset relay stream IDs by the total number of mux channels (across all channel types)
+    size_t mux_channel_offset = mux_config->get_total_num_channels();
+    stream_id += mux_channel_offset;
+
+    return stream_id;
 }
 
 std::vector<uint32_t> FabricTensixDatamoverRelayConfig::get_compile_time_args(
@@ -691,30 +750,58 @@ std::vector<uint32_t> FabricTensixDatamoverRelayConfig::get_compile_time_args(
 
     // Channel IDs and stream IDs
     constexpr uint32_t router_to_relay_channel_id = static_cast<uint32_t>(UdmRelayChannelId::ROUTER_CHANNEL);
-    auto channel_type = tt::tt_fabric::FabricMuxChannelType::FULL_SIZE_CHANNEL;
-
     const auto router_to_relay_channel_stream_id =
-        tensix_config.get_channel_credits_stream_id(router_to_relay_channel_id, FabricTensixCoreType::RELAY);
+        get_channel_credits_stream_id(tt::tt_fabric::ChannelTypes::ROUTER_CHANNEL, router_to_relay_channel_id);
 
     // Collect all mux connection info
     auto mux_infos = get_all_mux_connection_infos(fabric_node_id, routing_plane_id, direction);
 
+    // Build compile time args - organized by channel type
+    uint32_t num_channel_types = static_cast<uint32_t>(channel_configs_.size());
+
+    auto channel_type = tt::tt_fabric::ChannelTypes::RELAY_TO_MUX_CHANNEL;
+
     std::vector<uint32_t> ct_args = {
-        num_buffers_full_size_channel_,                                          // 0: NUM_BUFFERS
-        buffer_size_bytes_full_size_channel_,                                    // 1: BUFFER_SIZE_BYTES
-        status_region_.get_address(),                                            // 2: status_address
-        termination_signal_region_.get_address(),                                // 3: termination_signal_address
-        connection_info_region_.get_address(),                                   // 4: connection_info_base_address
-        connection_handshake_region_.get_address(),                              // 5: connection_handshake_base_address
-        flow_control_region_.get_address(),                                      // 6: sender_flow_control_base_address
-        full_size_channels_region_.get_address(),                                // 7: channels_base_l1_address
-        router_to_relay_channel_stream_id,                                       // 8: channel_stream_id
-        num_iters_between_teardown_checks_,                                      // 9: NUM_ITERS_BETWEEN_TEARDOWN_CHECKS
-        mux_config->get_num_buffers(channel_type),                               // 10: mux_num_buffers
-        static_cast<uint32_t>(mux_config->get_buffer_size_bytes(channel_type)),  // 11: mux_buffer_size_bytes
-        local_fabric_router_status_region_.get_address(),  // 12: downstream_mux_status_readback_address
-        NUM_MUX_CONNECTIONS,                               // 13: NUM_MUX_CONNECTIONS
+        status_region_.get_address(),                                            // 0: status_address
+        termination_signal_region_.get_address(),                                // 1: termination_signal_address
+        router_to_relay_channel_stream_id,                                       // 2: channel_stream_id
+        num_iters_between_teardown_checks_,                                      // 3: NUM_ITERS_BETWEEN_TEARDOWN_CHECKS
+        mux_config->get_num_buffers(channel_type),                               // 4: mux_num_buffers
+        static_cast<uint32_t>(mux_config->get_buffer_size_bytes(channel_type)),  // 5: mux_buffer_size_bytes
+        local_fabric_router_status_region_.get_address(),  // 6: downstream_mux_status_readback_address
+        NUM_MUX_CONNECTIONS,                               // 7: NUM_MUX_CONNECTIONS
+        num_channel_types                                  // 8: number of channel types
     };
+
+    constexpr uint32_t base_channel_id = 0;
+    // Append per-channel-type arrays (grouped by channel type, sorted by enum)
+    for (const auto& [type, config] : channel_configs_) {
+        ct_args.push_back(config.num_channels);
+    }
+    // Number of buffers per channel (one per channel type)
+    for (const auto& [type, config] : channel_configs_) {
+        ct_args.push_back(config.num_buffers_per_channel);
+    }
+    // Buffer size in bytes (one per channel type)
+    for (const auto& [type, config] : channel_configs_) {
+        ct_args.push_back(static_cast<uint32_t>(config.buffer_size_bytes));
+    }
+    // Connection info base addresses (one per channel type)
+    for (const auto& [type, region] : connection_info_regions_) {
+        ct_args.push_back(region.get_address(base_channel_id));
+    }
+    // Connection handshake base addresses (one per channel type)
+    for (const auto& [type, region] : connection_handshake_regions_) {
+        ct_args.push_back(region.get_address(base_channel_id));
+    }
+    // Flow control base addresses (one per channel type)
+    for (const auto& [type, region] : flow_control_regions_) {
+        ct_args.push_back(region.get_address(base_channel_id));
+    }
+    // Channel buffer base addresses (one per channel type)
+    for (const auto& [type, region] : channel_buffer_regions_) {
+        ct_args.push_back(region.get_address(base_channel_id));
+    }
 
     // Append mux connection arrays (args 14-46 = 11 fields * 3 connections)
     // Active flags array
@@ -810,7 +897,11 @@ const char* FabricTensixDatamoverMuxBuilder::get_kernel_file_path() const {
 
 tt::tt_fabric::SenderWorkerAdapterSpec FabricTensixDatamoverMuxBuilder::build_connection_to_fabric_channel(
     uint32_t channel_id) const {
-    auto channel_type = tt::tt_fabric::FabricMuxChannelType::FULL_SIZE_CHANNEL;
+    auto channel_type = tt::tt_fabric::ChannelTypes::ROUTER_CHANNEL;
+    // minus one to skip the worker channel
+    // passed in channel id: 1, 2, 3 for the downstream connections
+    // corrected channel id: 0, 1, 2 for the downstream connections in ROUTER_CHANNEL
+    channel_id -= 1;
 
     // skip the channel liveness check if it is used for upstream connection (persistent)
     channel_connection_liveness_check_disable_array_[channel_id] = true;
@@ -862,98 +953,108 @@ void FabricTensixDatamoverMuxBuilder::create_and_compile(tt::tt_metal::Program& 
     tt::tt_metal::SetRuntimeArgs(program, mux_kernel, my_core_logical_, get_runtime_args(program));
 }
 
-std::vector<uint32_t> FabricTensixDatamoverMuxBuilder::get_channel_stream_ids(uint8_t num_full_size_channels) const {
+std::vector<uint32_t> FabricTensixDatamoverMuxBuilder::get_channel_stream_ids(ChannelTypes channel_type) const {
     const auto& fabric_context = tt::tt_metal::MetalContext::instance().get_control_plane().get_fabric_context();
-    const auto& fabric_tensix_config = tt::tt_metal::MetalContext::instance().get_fabric_tensix_config();
-    const auto& tensix_config = fabric_context.get_tensix_config();
-
+    size_t num_channels = config_->get_num_channels(channel_type);
     std::vector<uint32_t> fabric_stream_ids;
 
-    if (fabric_tensix_config == tt::tt_fabric::FabricTensixConfig::UDM) {
-        // UDM mode: one stream ID per channel
-        for (uint8_t channel = 0; channel < num_full_size_channels; channel++) {
-            const auto worker_stream_id = tensix_config.get_channel_credits_stream_id(channel, core_id_);
-            fabric_stream_ids.push_back(worker_stream_id);
+    switch (channel_type) {
+        case ChannelTypes::WORKER_CHANNEL:
+        case ChannelTypes::RELAY_TO_MUX_CHANNEL:
+        case ChannelTypes::MUX_TO_MUX_CHANNEL: {
+            // Worker channels: one stream ID per channel
+            for (size_t channel = 0; channel < num_channels; channel++) {
+                fabric_stream_ids.push_back(config_->get_channel_credits_stream_id(channel_type, channel));
+            }
+            break;
         }
-    } else {
-        // MUX mode: topology-based channels (includes fabric routers)
-        const auto topology = fabric_context.get_fabric_topology();
-        const auto worker_channel = 0;
-        const auto worker_stream_id = tensix_config.get_channel_credits_stream_id(worker_channel, core_id_);
-
-        switch (topology) {
-            case tt::tt_fabric::Topology::Linear:
-            case tt::tt_fabric::Topology::Ring:
-                fabric_stream_ids = {
-                    worker_stream_id, tt::tt_fabric::StreamRegAssignments::sender_channel_1_free_slots_stream_id};
-                break;
-            case tt::tt_fabric::Topology::Mesh:
-            case tt::tt_fabric::Topology::Torus:
-                fabric_stream_ids = {
-                    worker_stream_id,
-                    tt::tt_fabric::StreamRegAssignments::sender_channel_1_free_slots_stream_id,
-                    tt::tt_fabric::StreamRegAssignments::sender_channel_2_free_slots_stream_id,
-                    tt::tt_fabric::StreamRegAssignments::sender_channel_3_free_slots_stream_id};
-                break;
-            default: TT_THROW("Unknown fabric topology: {}", static_cast<int>(topology)); break;
+        case ChannelTypes::ROUTER_CHANNEL: {
+            // Router channels: topology-based fabric router stream IDs (only in Legacy MUX mode)
+            const auto topology = fabric_context.get_fabric_topology();
+            switch (topology) {
+                case tt::tt_fabric::Topology::Linear:
+                case tt::tt_fabric::Topology::Ring:
+                    fabric_stream_ids = {tt::tt_fabric::StreamRegAssignments::sender_channel_1_free_slots_stream_id};
+                    break;
+                case tt::tt_fabric::Topology::Mesh:
+                case tt::tt_fabric::Topology::Torus:
+                    fabric_stream_ids = {
+                        tt::tt_fabric::StreamRegAssignments::sender_channel_1_free_slots_stream_id,
+                        tt::tt_fabric::StreamRegAssignments::sender_channel_2_free_slots_stream_id,
+                        tt::tt_fabric::StreamRegAssignments::sender_channel_3_free_slots_stream_id};
+                    break;
+                default: TT_THROW("Unknown fabric topology: {}", static_cast<int>(topology)); break;
+            }
+            break;
         }
+        default: TT_THROW("Unknown channel type: {}", static_cast<uint32_t>(channel_type)); break;
     }
 
     TT_FATAL(
-        num_full_size_channels == fabric_stream_ids.size(),
-        "the number of fabric stream ids used must equal to the number of mux channels");
+        num_channels == fabric_stream_ids.size(),
+        "Channel type {} expects {} channels but got {} stream IDs",
+        static_cast<uint32_t>(channel_type),
+        num_channels,
+        fabric_stream_ids.size());
 
     return fabric_stream_ids;
 }
 
-std::vector<uint32_t> FabricTensixDatamoverMuxBuilder::get_persistent_channels_flags(
-    uint8_t num_full_size_channels) const {
+std::vector<uint32_t> FabricTensixDatamoverMuxBuilder::get_persistent_channels_flags(ChannelTypes channel_type) const {
     const auto& fabric_context = tt::tt_metal::MetalContext::instance().get_control_plane().get_fabric_context();
-    const auto& fabric_tensix_config = tt::tt_metal::MetalContext::instance().get_fabric_tensix_config();
     const auto& tensix_config = fabric_context.get_tensix_config();
-    std::vector<uint32_t> is_persistent_channels(num_full_size_channels, 0);
+    size_t num_channels = config_->get_num_channels(channel_type);
+    std::vector<uint32_t> is_persistent_channels(num_channels, 0);
 
-    if (fabric_tensix_config == tt::tt_fabric::FabricTensixConfig::UDM) {
-        // UDM mode: ensure relay and inter-mux channels are persistent
-        TT_FATAL(
-            num_full_size_channels >= static_cast<uint32_t>(UdmMuxChannelId::NUM_CHANNELS),
-            "UDM mode requires at least {} channels (got {})",
-            static_cast<uint32_t>(UdmMuxChannelId::NUM_CHANNELS),
-            num_full_size_channels);
-
-        // Local relay channel is always persistent (local relay always exists)
-        is_persistent_channels[static_cast<uint32_t>(UdmMuxChannelId::LOCAL_RELAY_CHANNEL)] = 1;
-
-        // Check upstream relay channels (perpendicular directions have relays that connect to this mux)
-        auto [upstream_relay_dir1, upstream_relay_dir2] = get_perpendicular_directions(direction_);
-        std::array<eth_chan_directions, 2> upstream_relay_dirs = {upstream_relay_dir1, upstream_relay_dir2};
-        std::array<UdmMuxChannelId, 2> upstream_relay_channels = {
-            UdmMuxChannelId::EAST_OR_NORTH_RELAY_CHANNEL, UdmMuxChannelId::WEST_OR_SOUTH_RELAY_CHANNEL};
-
-        for (size_t i = 0; i < upstream_relay_dirs.size(); i++) {
-            auto noc_coords =
-                tensix_config.get_router_noc_coords(local_fabric_node_id_, link_idx_, upstream_relay_dirs[i]);
-            if (noc_coords) {
-                is_persistent_channels[static_cast<uint32_t>(upstream_relay_channels[i])] = 1;
+    switch (channel_type) {
+        case ChannelTypes::ROUTER_CHANNEL: {
+            // Router channels: check liveness array for persistent connections (e.g., to upstream fabric routers)
+            for (size_t i = 0; i < num_channels; i++) {
+                if (channel_connection_liveness_check_disable_array_[i]) {
+                    is_persistent_channels[i] = 1;
+                }
             }
+            break;
         }
+        case ChannelTypes::RELAY_TO_MUX_CHANNEL: {
+            // Relay-to-Mux channels: check if relays exist in perpendicular directions (UDM mode only)
+            TT_FATAL(num_channels == 3, "RELAY_TO_MUX_CHANNEL should have exactly 3 channels (got {})", num_channels);
 
-        // Check inter-mux channels (all other directions have muxes that may connect to this mux)
-        auto upstream_mux_dirs = get_all_other_directions(direction_);
-        for (auto upstream_dir : upstream_mux_dirs) {
-            auto noc_coords = tensix_config.get_router_noc_coords(local_fabric_node_id_, link_idx_, upstream_dir);
-            if (noc_coords) {
-                uint32_t channel_id = get_upstream_mux_channel_id(direction_, upstream_dir);
-                is_persistent_channels[channel_id] = 1;
+            // Channel 0: Local relay (always persistent)
+            is_persistent_channels[static_cast<uint32_t>(UdmMuxRelayToMuxChannelId::LOCAL_RELAY_CHANNEL)] = 1;
+
+            // Channels 1-2: Upstream relays (perpendicular directions)
+            auto [upstream_relay_dir1, upstream_relay_dir2] = get_perpendicular_directions(direction_);
+            std::array<eth_chan_directions, 2> upstream_relay_dirs = {upstream_relay_dir1, upstream_relay_dir2};
+            std::array<UdmMuxRelayToMuxChannelId, 2> upstream_relay_channels = {
+                UdmMuxRelayToMuxChannelId::EAST_OR_NORTH_RELAY_CHANNEL,
+                UdmMuxRelayToMuxChannelId::WEST_OR_SOUTH_RELAY_CHANNEL};
+
+            for (size_t i = 0; i < upstream_relay_dirs.size(); i++) {
+                auto noc_coords =
+                    tensix_config.get_router_noc_coords(local_fabric_node_id_, link_idx_, upstream_relay_dirs[i]);
+                if (noc_coords) {
+                    is_persistent_channels[static_cast<uint32_t>(upstream_relay_channels[i])] = 1;
+                }
             }
+            break;
         }
-    } else {
-        // MUX mode: use channel_connection_liveness_check_disable_array_ to determine persistent channels
-        for (uint8_t i = 0; i < num_full_size_channels; i++) {
-            if (channel_connection_liveness_check_disable_array_[i]) {
-                is_persistent_channels[i] = 1;
+        case ChannelTypes::MUX_TO_MUX_CHANNEL: {
+            // Mux-to-Mux channels: check if muxes exist in other directions (UDM mode only)
+            TT_FATAL(num_channels == 3, "MUX_TO_MUX_CHANNEL should have exactly 3 channels (got {})", num_channels);
+
+            auto upstream_mux_dirs = get_all_other_directions(direction_);
+            for (auto upstream_dir : upstream_mux_dirs) {
+                auto noc_coords = tensix_config.get_router_noc_coords(local_fabric_node_id_, link_idx_, upstream_dir);
+                if (noc_coords) {
+                    uint32_t channel_id = get_upstream_mux_channel_id(direction_, upstream_dir);
+                    is_persistent_channels[channel_id] = 1;
+                }
             }
+            break;
         }
+        case ChannelTypes::WORKER_CHANNEL: break;  // Worker channels: always non-persistent
+        default: TT_THROW("Unknown channel type: {}", static_cast<uint32_t>(channel_type)); break;
     }
 
     return is_persistent_channels;
@@ -975,13 +1076,17 @@ std::vector<uint32_t> FabricTensixDatamoverMuxBuilder::get_compile_time_args() c
     ct_args.push_back(
         tt::tt_fabric::FabricRouterBuilder::is_bubble_flow_control_enabled(fabric_router_config.topology));
 
-    // Get stream IDs and persistent channels flags
-    uint8_t num_full_size_channels = config_->get_num_channels(tt::tt_fabric::FabricMuxChannelType::FULL_SIZE_CHANNEL);
-    auto fabric_stream_ids = get_channel_stream_ids(num_full_size_channels);
-    auto is_persistent_channels = get_persistent_channels_flags(num_full_size_channels);
+    // Append stream IDs and persistent flags grouped by channel type
+    // For each channel type: [stream_ids...], [persistent_flags...]
+    for (const auto& [type, config] : config_->get_channel_configs()) {
+        auto fabric_stream_ids = get_channel_stream_ids(type);
+        ct_args.insert(ct_args.end(), fabric_stream_ids.begin(), fabric_stream_ids.end());
+    }
 
-    ct_args.insert(ct_args.end(), fabric_stream_ids.begin(), fabric_stream_ids.end());
-    ct_args.insert(ct_args.end(), is_persistent_channels.begin(), is_persistent_channels.end());
+    for (const auto& [type, config] : config_->get_channel_configs()) {
+        auto is_persistent_channels = get_persistent_channels_flags(type);
+        ct_args.insert(ct_args.end(), is_persistent_channels.begin(), is_persistent_channels.end());
+    }
 
     // In UDM mode, add relay's termination signal address for mux to write during teardown
     if (fabric_tensix_config == tt::tt_fabric::FabricTensixConfig::UDM) {
@@ -1049,7 +1154,7 @@ FabricTensixDatamoverRelayBuilder::FabricTensixDatamoverRelayBuilder(
 
 tt::tt_fabric::SenderWorkerAdapterSpec FabricTensixDatamoverRelayBuilder::build_connection_to_fabric_channel(
     uint32_t channel_id) const {
-    auto channel_type = tt::tt_fabric::FabricMuxChannelType::FULL_SIZE_CHANNEL;
+    auto channel_type = tt::tt_fabric::ChannelTypes::ROUTER_CHANNEL;
 
     // skip the channel liveness check if it is used for upstream connection (persistent)
     channel_connection_liveness_check_disable_array_[channel_id] = true;

--- a/tt_metal/fabric/fabric_tensix_builder_impl.cpp
+++ b/tt_metal/fabric/fabric_tensix_builder_impl.cpp
@@ -457,7 +457,7 @@ std::vector<MuxConnectionInfo> FabricTensixDatamoverMuxConfig::get_all_mux_conne
     // Collect connection info for each downstream mux
     for (uint32_t i = 0; i < downstream_dirs.size(); i++) {
         auto downstream_dir = downstream_dirs[i];
-        auto downstream_mux_noc_coord =
+        const auto* downstream_mux_noc_coord =
             tensix_config.get_router_noc_coords(fabric_node_id, routing_plane_id, downstream_dir);
 
         // Calculate which channel on the downstream mux this mux should connect to
@@ -484,8 +484,8 @@ std::vector<uint32_t> FabricTensixDatamoverMuxConfig::get_compile_time_args(
     const auto& fabric_tensix_config = tt::tt_metal::MetalContext::instance().get_fabric_tensix_config();
     const auto& fabric_router_config = fabric_context.get_fabric_router_config(fabric_tensix_config);
 
-    auto channel_allocator = fabric_router_config.channel_allocator.get();
-    const auto static_channel_allocator =
+    auto* channel_allocator = fabric_router_config.channel_allocator.get();
+    auto* const static_channel_allocator =
         dynamic_cast<tt::tt_fabric::FabricStaticSizedChannelsAllocator*>(channel_allocator);
     TT_FATAL(static_channel_allocator != nullptr, "Channel allocator must be a FabricStaticSizedChannelsAllocator.");
 
@@ -676,7 +676,7 @@ FabricTensixDatamoverRelayConfig::get_all_mux_connection_infos(
 
     for (uint32_t i = 0; i < NUM_MUX_CONNECTIONS; i++) {
         auto target_dir = target_mux_dirs[i];
-        auto mux_noc_coord = tensix_config.get_router_noc_coords(fabric_node_id, routing_plane_id, target_dir);
+        const auto* mux_noc_coord = tensix_config.get_router_noc_coords(fabric_node_id, routing_plane_id, target_dir);
 
         // Determine which channel on the target mux we connect to
         uint32_t mux_channel_id;
@@ -1016,7 +1016,7 @@ std::vector<uint32_t> FabricTensixDatamoverMuxBuilder::get_persistent_channels_f
                 UdmMuxRelayToMuxChannelId::WEST_OR_SOUTH_RELAY_CHANNEL};
 
             for (size_t i = 0; i < upstream_relay_dirs.size(); i++) {
-                auto noc_coords =
+                const auto* noc_coords =
                     tensix_config.get_router_noc_coords(local_fabric_node_id_, link_idx_, upstream_relay_dirs[i]);
                 if (noc_coords) {
                     is_persistent_channels[static_cast<uint32_t>(upstream_relay_channels[i])] = 1;
@@ -1030,7 +1030,8 @@ std::vector<uint32_t> FabricTensixDatamoverMuxBuilder::get_persistent_channels_f
 
             auto upstream_mux_dirs = get_all_other_directions(direction_);
             for (auto upstream_dir : upstream_mux_dirs) {
-                auto noc_coords = tensix_config.get_router_noc_coords(local_fabric_node_id_, link_idx_, upstream_dir);
+                const auto* noc_coords =
+                    tensix_config.get_router_noc_coords(local_fabric_node_id_, link_idx_, upstream_dir);
                 if (noc_coords) {
                     uint32_t channel_id = get_upstream_mux_channel_id(direction_, upstream_dir);
                     is_persistent_channels[channel_id] = 1;

--- a/tt_metal/fabric/fabric_tensix_builder_impl.cpp
+++ b/tt_metal/fabric/fabric_tensix_builder_impl.cpp
@@ -933,7 +933,7 @@ std::vector<uint32_t> FabricTensixDatamoverMuxBuilder::get_persistent_channels_f
         }
 
         // Check inter-mux channels (all other directions have muxes that may connect to this mux)
-        auto upstream_mux_dirs = get_all_other_directions(direction_);  // Upstream for me = downstream for them
+        auto upstream_mux_dirs = get_all_other_directions(direction_);
         for (auto upstream_dir : upstream_mux_dirs) {
             auto noc_coords = tensix_config.get_router_noc_coords(local_fabric_node_id_, link_idx_, upstream_dir);
             if (noc_coords) {

--- a/tt_metal/fabric/fabric_tensix_builder_impl.cpp
+++ b/tt_metal/fabric/fabric_tensix_builder_impl.cpp
@@ -690,7 +690,7 @@ FabricTensixDatamoverRelayConfig::get_all_mux_connection_infos(
     auto [perp_dir1, perp_dir2] = get_perpendicular_directions(direction);
     std::array<eth_chan_directions, NUM_MUX_CONNECTIONS> target_mux_dirs = {direction, perp_dir1, perp_dir2};
 
-    std::array<MuxConnectionInfo, NUM_MUX_CONNECTIONS> mux_infos;
+    std::array<MuxConnectionInfo, NUM_MUX_CONNECTIONS> mux_infos{};
 
     for (uint32_t i = 0; i < NUM_MUX_CONNECTIONS; i++) {
         auto target_dir = target_mux_dirs[i];

--- a/tt_metal/fabric/fabric_tensix_builder_impl.hpp
+++ b/tt_metal/fabric/fabric_tensix_builder_impl.hpp
@@ -169,8 +169,7 @@ public:
         const FabricNodeId& dst_fabric_node_id,
         uint32_t link_idx,
         tt::tt_metal::Program& program,
-        const CoreCoord& logical_core,
-        const std::vector<bool>& sender_channel_is_traffic_injection_channel_array) const;
+        const CoreCoord& logical_core) const;
 
 protected:
     static constexpr size_t default_num_buffers = 8;

--- a/tt_metal/fabric/fabric_tensix_builder_impl.hpp
+++ b/tt_metal/fabric/fabric_tensix_builder_impl.hpp
@@ -269,6 +269,10 @@ public:
     // Get relay termination signal address (for mux to write during teardown)
     size_t get_relay_termination_signal_address() const { return termination_signal_region_.get_address(); }
 
+    // Get UDM memory pool base address and size
+    size_t get_udm_memory_pool_base_address() const { return udm_memory_pool_region_.get_address(); }
+    size_t get_udm_memory_pool_size() const { return udm_memory_pool_region_.get_total_size(); }
+
 private:
     // ==================================================================================
     // Relay-specific memory regions for relay → mux connection
@@ -295,6 +299,9 @@ private:
     // - Unused: Passed to relay's adapter constructor but never stored or accessed
     // - The relay only uses mux's buffer_index_region_ (edm_copy_of_wr_counter_addr) for sync
     MemoryRegion mux_relay_buffer_index_semaphore_region_{};
+
+    // Memory pool for storing read response data temporarily
+    MemoryRegion udm_memory_pool_region_{};
 };
 
 /**

--- a/tt_metal/fabric/fabric_tensix_builder_impl.hpp
+++ b/tt_metal/fabric/fabric_tensix_builder_impl.hpp
@@ -388,6 +388,8 @@ private:
     std::array<MemoryRegion, NUM_MUX_CONNECTIONS> mux_buffer_index_semaphore_regions_{};
 
     // Memory pool for storing read response data temporarily
+    static constexpr size_t udm_memory_pool_num_slots_ = 8;
+    size_t udm_memory_pool_slot_size_ = 0;
     MemoryRegion udm_memory_pool_region_{};
 };
 

--- a/tt_metal/fabric/fabric_tensix_builder_impl.hpp
+++ b/tt_metal/fabric/fabric_tensix_builder_impl.hpp
@@ -280,6 +280,9 @@ public:
         const FabricNodeId& fabric_node_id, routing_plane_id_t routing_plane_id, eth_chan_directions direction) const;
 
 private:
+    // Number of downstream mux connections (all directions except self = 3)
+    static constexpr uint32_t NUM_DOWNSTREAM_MUX_CONNECTIONS = 3;
+
     // ==================================================================================
     // Mux-specific: Support for inter-mux connections (mux → downstream mux)
     // Each mux can connect to 3 other muxes (all directions except itself)
@@ -292,8 +295,9 @@ private:
         uint32_t connection_region_idx,
         uint32_t stream_id) const;
 
-    // Number of downstream mux connections (all directions except self = 3)
-    static constexpr uint32_t NUM_DOWNSTREAM_MUX_CONNECTIONS = 3;
+    // Helper to collect all downstream mux connection infos
+    std::array<MuxConnectionInfo, NUM_DOWNSTREAM_MUX_CONNECTIONS> get_all_mux_connection_infos(
+        const FabricNodeId& fabric_node_id, routing_plane_id_t routing_plane_id, eth_chan_directions direction) const;
 
     // Flow control semaphores (mux → downstream mux direction) for each downstream mux connection
     // - Stored in current MUX's L1 memory
@@ -354,6 +358,10 @@ private:
 
     // Number of mux connections: [0]=local, [1]=downstream_en, [2]=downstream_ws
     static constexpr uint32_t NUM_MUX_CONNECTIONS = 3;
+
+    // Helper to collect all mux connection infos
+    std::array<MuxConnectionInfo, NUM_MUX_CONNECTIONS> get_all_mux_connection_infos(
+        const FabricNodeId& fabric_node_id, routing_plane_id_t routing_plane_id, eth_chan_directions direction) const;
 
     // Flow control semaphores (relay → mux direction) for each mux connection
     // - Stored in RELAY's L1 memory

--- a/tt_metal/fabric/fabric_tensix_builder_impl.hpp
+++ b/tt_metal/fabric/fabric_tensix_builder_impl.hpp
@@ -223,14 +223,14 @@ protected:
     //   - worker_xy: NOC coordinates (x,y) of connected worker/client
     //   - edm_read_counter: Local tracking of packets read by the local kernel
     // Remote clients populate this when establishing connection; local kernel reads it to get client NOC coords
-    std::map<ChannelTypes, MemoryRegion> connection_info_regions_{};
+    std::map<ChannelTypes, MemoryRegion> connection_info_regions_;
 
     // Connection liveness/handshake region (per channel type)
     // Remote clients write to this address to signal connection state changes:
     //   - Write 1 (open_connection_value): Client requests connection establishment
     //   - Write 2 (close_connection_request_value): Client requests connection teardown
     // Local polls these addresses to detect when clients want to connect/disconnect
-    std::map<ChannelTypes, MemoryRegion> connection_handshake_regions_{};
+    std::map<ChannelTypes, MemoryRegion> connection_handshake_regions_;
 
     // RESERVED/UNUSED: Flow control region (per channel type)
     // This region is allocated but NOT currently used by mux/relay kernels
@@ -240,7 +240,7 @@ protected:
     //   - Local decrements: increment_local_update_ptr_val(stream_id, 1) when sending packet
     //   - Remote client increments: writes to stream register via NoC when consuming packet
     // The flow_control_regions_ is passed to constructors but never stored/used (legacy/reserved)
-    std::map<ChannelTypes, MemoryRegion> flow_control_regions_{};
+    std::map<ChannelTypes, MemoryRegion> flow_control_regions_;
 
     // Buffer index synchronization region (per channel type) - used for connection lifecycle synchronization
     // This stores the write pointer (wrptr) for each channel's buffer slots, used ONLY during:
@@ -253,7 +253,7 @@ protected:
     // During normal operation: Local tracks wrptr/rdptr internally using local_write_counter/local_read_counter
     //   - These are NOT stored in buffer_index_regions_ during packet forwarding
     //   - buffer_index_regions_ is only accessed during connection establishment/teardown
-    std::map<ChannelTypes, MemoryRegion> buffer_index_regions_{};
+    std::map<ChannelTypes, MemoryRegion> buffer_index_regions_;
 
     // Channel buffer storage regions (one per channel type, sorted by ChannelTypes enum)
     // Each channel type has its own buffer region with type-specific configuration

--- a/tt_metal/fabric/hw/inc/udm/tt_fabric_udm.hpp
+++ b/tt_metal/fabric/hw/inc/udm/tt_fabric_udm.hpp
@@ -437,6 +437,8 @@ FORCE_INLINE void forward_to_downstream_mux_or_local_router(
         mux_dir = packet_header->udm_control.write.initial_direction;
     }
 
+    // DPRINT << "Mux Direction " << Direction << " mux_dir " << mux_dir <<ENDL();
+
     if (Direction != mux_dir) {
         // Forward to the correct downstream mux
         uint32_t mux_index = direction_to_mux_index_map[Direction][mux_dir];

--- a/tt_metal/fabric/hw/inc/udm/tt_fabric_udm.hpp
+++ b/tt_metal/fabric/hw/inc/udm/tt_fabric_udm.hpp
@@ -421,7 +421,7 @@ FORCE_INLINE uint32_t select_mux_connection(uint16_t dst_chip_id) {
     uint32_t mux_idx = 0;  // Default: use local connection (index 0)
     if constexpr (Direction == eth_chan_directions::EAST || Direction == eth_chan_directions::WEST) {
         // For EW relays, check if ACK packet needs NS routing by querying routing info
-        auto* routing_table = reinterpret_cast<tt_l1_ptr tensix_routing_l1_info_t*>(ROUTING_TABLE_BASE);
+        auto* routing_table = reinterpret_cast<tt_l1_ptr routing_l1_info_t*>(ROUTING_TABLE_BASE);
         auto* routing_info = reinterpret_cast<tt_l1_ptr intra_mesh_routing_path_t<2, true>*>(ROUTING_PATH_BASE_2D);
         uint16_t my_chip_id = routing_table->my_device_id;
 

--- a/tt_metal/fabric/hw/inc/udm/tt_fabric_udm_impl.hpp
+++ b/tt_metal/fabric/hw/inc/udm/tt_fabric_udm_impl.hpp
@@ -20,7 +20,16 @@ namespace tt::tt_fabric::udm {
 /**
  * @brief Enum for UDM control fields
  */
-enum class UDM_CONTROL_FIELD { POSTED, SRC_CHIP_ID, SRC_MESH_ID, SRC_NOC_X, SRC_NOC_Y, RISC_ID, TRANSACTION_ID };
+enum class UDM_CONTROL_FIELD {
+    POSTED,
+    SRC_CHIP_ID,
+    SRC_MESH_ID,
+    SRC_NOC_X,
+    SRC_NOC_Y,
+    RISC_ID,
+    TRANSACTION_ID,
+    INITIAL_DIRECTION
+};
 
 /**
  * @brief UDM (Unified Data Movement) fields for fabric write operations
@@ -61,6 +70,44 @@ struct udm_read_fields {
 };
 
 /**
+ * @brief Calculate the initial direction for a packet based on routing path
+ *
+ * Determines which direction (EAST, WEST, NORTH, SOUTH) a packet should initially
+ * take to reach the destination chip in a 2D mesh topology.
+ *
+ * @param dst_chip_id Destination chip ID
+ * @param my_chip_id Source chip ID
+ * @return Initial direction as uint32_t (eth_chan_directions enum value)
+ */
+FORCE_INLINE uint32_t calculate_initial_direction(uint16_t dst_chip_id, uint16_t my_chip_id) {
+    auto* routing_info = reinterpret_cast<tt_l1_ptr intra_mesh_routing_path_t<2, true>*>(ROUTING_PATH_BASE_2D);
+
+    uint32_t initial_dir = static_cast<uint32_t>(eth_chan_directions::EAST);
+
+    const auto& compressed_route = routing_info->paths[dst_chip_id];
+    uint8_t ns_hops = compressed_route.get_ns_hops();
+    uint8_t ew_hops = compressed_route.get_ew_hops();
+
+    if (ns_hops > 0) {
+        // is there another way to know whether it's north or south hops?
+        if (dst_chip_id < my_chip_id) {
+            initial_dir = static_cast<uint32_t>(eth_chan_directions::NORTH);
+        } else {
+            initial_dir = static_cast<uint32_t>(eth_chan_directions::SOUTH);
+        }
+    } else if (ew_hops > 0) {
+        // is there another way to know whether it's east or west hops?
+        if (dst_chip_id < my_chip_id) {
+            initial_dir = static_cast<uint32_t>(eth_chan_directions::WEST);
+        } else {
+            initial_dir = static_cast<uint32_t>(eth_chan_directions::EAST);
+        }
+    }
+
+    return initial_dir;
+}
+
+/**
  * @brief Set unicast route for UDMHybridMeshPacketHeader with UDM fields
  *
  * Configures routing and UDM control fields for hybrid mesh packet headers.
@@ -79,19 +126,27 @@ FORCE_INLINE bool fabric_write_set_unicast_route_impl(
     uint16_t dst_mesh_id) {
     tt_l1_ptr routing_l1_info_t* routing_table =
         reinterpret_cast<tt_l1_ptr routing_l1_info_t*>(MEM_TENSIX_ROUTING_TABLE_BASE);
+    uint16_t my_chip_id = routing_table->my_device_id;
+    uint16_t my_mesh_id = routing_table->my_mesh_id;
+
+    ASSERT(my_mesh_id == dst_mesh_id);  // we dont support inter-mesh for UDM mode yet
+
+    // Calculate initial direction based on routing path
+    uint32_t initial_dir = calculate_initial_direction(dst_dev_id, my_chip_id);
 
     // First call the original API by casting to base type
     bool result = fabric_set_unicast_route(
         static_cast<volatile tt_l1_ptr HybridMeshPacketHeader*>(packet_header), dst_dev_id, dst_mesh_id);
 
     // Set UDM control fields for write operations using routing table info
-    packet_header->udm_control.write.src_chip_id = routing_table->my_device_id;
-    packet_header->udm_control.write.src_mesh_id = routing_table->my_mesh_id;
+    packet_header->udm_control.write.src_chip_id = my_chip_id;
+    packet_header->udm_control.write.src_mesh_id = my_mesh_id;
     packet_header->udm_control.write.src_noc_x = udm.src_noc_x;
     packet_header->udm_control.write.src_noc_y = udm.src_noc_y;
     packet_header->udm_control.write.risc_id = udm.risc_id;
     packet_header->udm_control.write.transaction_id = udm.trid;
     packet_header->udm_control.write.posted = udm.posted;
+    packet_header->udm_control.write.initial_direction = initial_dir;
     return result;
 }
 
@@ -143,20 +198,29 @@ FORCE_INLINE bool fabric_read_set_unicast_route_impl(
     uint16_t dst_mesh_id) {
     tt_l1_ptr routing_l1_info_t* routing_table =
         reinterpret_cast<tt_l1_ptr routing_l1_info_t*>(MEM_TENSIX_ROUTING_TABLE_BASE);
+    uint16_t my_chip_id = routing_table->my_device_id;
+    uint16_t my_mesh_id = routing_table->my_mesh_id;
+
+    ASSERT(my_mesh_id == dst_mesh_id);  // we dont support inter-mesh for UDM mode yet
+
+    // Calculate initial direction based on routing path
+    uint32_t initial_dir = calculate_initial_direction(dst_dev_id, my_chip_id);
 
     // First call the original API by casting to base type
     bool result = fabric_set_unicast_route(
         static_cast<volatile tt_l1_ptr HybridMeshPacketHeader*>(packet_header), dst_dev_id, dst_mesh_id);
 
     // Set UDM control fields for read operations using routing table info
-    packet_header->udm_control.read.src_chip_id = routing_table->my_device_id;
-    packet_header->udm_control.read.src_mesh_id = routing_table->my_mesh_id;
+    packet_header->udm_control.read.src_chip_id = my_chip_id;
+    packet_header->udm_control.read.src_mesh_id = my_mesh_id;
     packet_header->udm_control.read.src_noc_x = udm.src_noc_x;
     packet_header->udm_control.read.src_noc_y = udm.src_noc_y;
     packet_header->udm_control.read.src_l1_address = udm.src_l1_address;
     packet_header->udm_control.read.size_bytes = udm.size_bytes;
     packet_header->udm_control.read.risc_id = udm.risc_id;
     packet_header->udm_control.read.transaction_id = udm.trid;
+    packet_header->udm_control.read.initial_direction = initial_dir;
+
     return result;
 }
 
@@ -231,6 +295,8 @@ FORCE_INLINE void fabric_write_set_unicast_route_control_field(volatile tt_l1_pt
         packet_header->udm_control.write.risc_id = static_cast<uint8_t>(value);
     } else if constexpr (Field == UDM_CONTROL_FIELD::TRANSACTION_ID) {
         packet_header->udm_control.write.transaction_id = static_cast<uint8_t>(value);
+    } else if constexpr (Field == UDM_CONTROL_FIELD::INITIAL_DIRECTION) {
+        packet_header->udm_control.write.initial_direction = static_cast<uint8_t>(value);
     }
 }
 

--- a/tt_metal/fabric/hw/inc/udm/udm_memory_pool.hpp
+++ b/tt_metal/fabric/hw/inc/udm/udm_memory_pool.hpp
@@ -6,118 +6,92 @@
 
 #include <cstdint>
 #include "debug/assert.h"
-#include "debug/dprint.h"
+#include "dataflow_api.h"
 #include "noc_parameters.h"
 
 namespace tt::tt_fabric::udm {
 
-// Simple memory pool manager for UDM read responses
-// This class manages allocation of variable-sized memory chunks from a fixed pool
-// in L1 memory for storing read response data temporarily before sending back ACKs.
+// Slot-based circular buffer memory pool for UDM read responses
+// All parameters are compile-time template arguments
+template <uint32_t BaseAddress, uint32_t SlotSize, uint32_t NumSlots>
 class UDMMemoryPool {
-private:
-    inline static uint32_t pool_base_ = 0;
-    inline static uint32_t pool_size_ = 0;
-    inline static uint32_t current_offset_ = 0;
-    inline static uint32_t pool_end_ = 0;
-    inline static uint32_t last_alloc_total_ =
-        0;  // Track total size (including padding) of last allocation for LIFO deallocation
+    static_assert(SlotSize % DRAM_ALIGNMENT == 0, "SlotSize must be DRAM aligned");
 
-    // Helper function to align an address to DRAM_ALIGNMENT
-    FORCE_INLINE static uint32_t align_address(uint32_t addr) {
-        // use DRAM alignment for now as it's the max alignment
-        // TODO: have extra field in the packet header for differentiating l1/dram if needed.
-        constexpr uint32_t alignment = DRAM_ALIGNMENT;
-        return (addr + alignment - 1) & ~(alignment - 1);
+private:
+    uint32_t slot_addrs_[NumSlots];
+
+    uint32_t wr_slot_idx_ = 0;
+    uint32_t rd_slot_idx_ = 0;
+    uint32_t num_used_slots_ = 0;
+
+    // Advance slot index by 1 with wrap
+    FORCE_INLINE uint32_t advance_slot_idx(uint32_t idx) const {
+        idx++;
+        if (idx >= NumSlots) {
+            idx = 0;
+        }
+        return idx;
     }
+
+    // Advance slot index by n with wrap
+    FORCE_INLINE uint32_t advance_slot_idx_n(uint32_t idx, uint32_t n) const { return (idx + n) % NumSlots; }
 
 public:
-    // Initialize the memory pool with base address and size
-    // Must be called before any allocate/deallocate operations
-    FORCE_INLINE static void init(uint32_t base_address, uint32_t size_bytes) {
-        pool_base_ = base_address;
-        pool_size_ = size_bytes;
-        current_offset_ = 0;
-        pool_end_ = base_address + size_bytes;
-    }
-
-    // Allocate a chunk of memory of the specified size
-    // Returns the L1 address of the allocated memory (aligned to DRAM_ALIGNMENT)
-    // Will hang if pool is exhausted
-    FORCE_INLINE static uint32_t allocate_memory(uint32_t size_bytes) {
-        // Align the current address to DRAM_ALIGNMENT
-        uint32_t unaligned_addr = pool_base_ + current_offset_;
-        uint32_t allocated_addr = align_address(unaligned_addr);
-        uint32_t alignment_padding = allocated_addr - unaligned_addr;
-
-        // Also align the size to ensure next allocation starts aligned
-        uint32_t aligned_size = align_address(size_bytes);
-
-        // Total allocation includes padding and aligned size
-        uint32_t total_allocation = alignment_padding + aligned_size;
-
-        ASSERT(allocated_addr + aligned_size <= pool_end_);
-        if (allocated_addr + aligned_size > pool_end_) {
-            DPRINT << "=== UDM MEMORY POOL EXHAUSTION ERROR ==="
-                   << "CRITICAL: Insufficient space in UDM memory pool"
-                   << "  - Requested Size: " << size_bytes << " bytes"
-                   << "  - Aligned Size: " << aligned_size << " bytes"
-                   << "  - Alignment Padding: " << alignment_padding << " bytes"
-                   << "  - Total Allocation: " << total_allocation << " bytes"
-                   << "  - Current Offset: " << current_offset_ << " bytes"
-                   << "  - Pool Size: " << pool_size_ << " bytes"
-                   << "  - Pool Base: 0x" << pool_base_ << "  - Pool End: 0x" << pool_end_
-                   << "  - Allocated Address: 0x" << allocated_addr
-                   << "Action: Entering infinite loop to prevent undefined behavior"
-                   << "Solution: Increase UDM memory pool size or reduce memory usage"
-                   << "=================================================\n";
-            while (1) {
-            }  // hang intentionally
+    // Constructor - pre-caches all slot addresses
+    UDMMemoryPool() {
+        for (uint32_t i = 0; i < NumSlots; i++) {
+            slot_addrs_[i] = BaseAddress + i * SlotSize;
         }
-
-        // Store the total allocation for LIFO deallocation
-        last_alloc_total_ = total_allocation;
-
-        // Update offset to account for alignment padding and the allocated size
-        current_offset_ += total_allocation;
-
-        return allocated_addr;
     }
 
-    // Deallocate a chunk of memory of the specified size
-    // This implementation uses a simple bump allocator, so deallocation
-    // just moves the offset back. Only works correctly if deallocations
-    // happen in reverse order of allocations (LIFO).
-    // NOTE: size_bytes should match the size passed to allocate_memory
-    FORCE_INLINE static void deallocate_memory(uint32_t size_bytes) {
-        // Use the stored total allocation (includes padding + aligned size)
-        // This ensures we properly reverse the allocation including any alignment padding
-        uint32_t total_dealloc = last_alloc_total_;
+    // Check if num_slots are available
+    FORCE_INLINE bool cb_has_enough_slots(uint32_t num_slots) const {
+        return (NumSlots - num_used_slots_) >= num_slots;
+    }
 
-        ASSERT(current_offset_ >= total_dealloc);
-        if (current_offset_ < total_dealloc) {
-            DPRINT << "=== UDM MEMORY POOL DEALLOCATION ERROR ==="
-                   << "CRITICAL: Attempting to deallocate more than allocated"
-                   << "  - Requested Deallocation: " << size_bytes << " bytes"
-                   << "  - Total Deallocation: " << total_dealloc << " bytes"
-                   << "  - Current Offset: " << current_offset_ << " bytes"
-                   << "Action: Entering infinite loop to prevent undefined behavior"
-                   << "=================================================\n";
-            while (1) {
-            }  // hang intentionally
+    // Helper: calculate slots needed for a given size
+    FORCE_INLINE uint32_t slots_needed(uint32_t size_bytes) const { return (size_bytes + SlotSize - 1) / SlotSize; }
+
+    // Get slot size
+    FORCE_INLINE constexpr uint32_t get_slot_size() const { return SlotSize; }
+
+    // Get slot address by index
+    FORCE_INLINE uint32_t get_slot_addr(uint32_t idx) const { return slot_addrs_[idx]; }
+
+    // Get current read slot index
+    FORCE_INLINE uint32_t get_rd_slot_idx() const { return rd_slot_idx_; }
+
+    // Get next slot index (with wrap)
+    FORCE_INLINE uint32_t get_next_slot_idx(uint32_t idx) const { return advance_slot_idx(idx); }
+
+    // Allocate slots and fill with data from noc_addr using noc_async_read
+    FORCE_INLINE void cb_allocate_and_fill_slots(uint64_t noc_addr, uint32_t size_bytes) {
+        uint32_t bytes_remaining = size_bytes;
+        uint64_t src_addr = noc_addr;
+
+        // Read slot by slot
+        while (bytes_remaining > 0) {
+            uint32_t read_size = (bytes_remaining > SlotSize) ? SlotSize : bytes_remaining;
+            noc_async_read(src_addr, slot_addrs_[wr_slot_idx_], read_size);
+
+            src_addr += read_size;
+            bytes_remaining -= read_size;
+            wr_slot_idx_ = advance_slot_idx(wr_slot_idx_);
+            num_used_slots_++;
         }
-
-        current_offset_ -= total_dealloc;
     }
 
-    // Get the current pool usage in bytes
-    FORCE_INLINE static uint32_t get_usage() { return current_offset_; }
+    // Deallocate num_slots from front
+    FORCE_INLINE void cb_deallocate_slots(uint32_t num_slots) {
+        rd_slot_idx_ = advance_slot_idx_n(rd_slot_idx_, num_slots);
+        num_used_slots_ -= num_slots;
+    }
 
-    // Get the available space in bytes
-    FORCE_INLINE static uint32_t get_available() { return pool_size_ - current_offset_; }
-
-    // Reset the pool (only use during initialization or teardown)
-    FORCE_INLINE static void reset() { current_offset_ = 0; }
+    FORCE_INLINE void reset() {
+        wr_slot_idx_ = 0;
+        rd_slot_idx_ = 0;
+        num_used_slots_ = 0;
+    }
 };
 
 }  // namespace tt::tt_fabric::udm

--- a/tt_metal/fabric/hw/inc/udm/udm_memory_pool.hpp
+++ b/tt_metal/fabric/hw/inc/udm/udm_memory_pool.hpp
@@ -1,0 +1,123 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include "debug/assert.h"
+#include "debug/dprint.h"
+#include "noc_parameters.h"
+
+namespace tt::tt_fabric::udm {
+
+// Simple memory pool manager for UDM read responses
+// This class manages allocation of variable-sized memory chunks from a fixed pool
+// in L1 memory for storing read response data temporarily before sending back ACKs.
+class UDMMemoryPool {
+private:
+    inline static uint32_t pool_base_ = 0;
+    inline static uint32_t pool_size_ = 0;
+    inline static uint32_t current_offset_ = 0;
+    inline static uint32_t pool_end_ = 0;
+    inline static uint32_t last_alloc_total_ =
+        0;  // Track total size (including padding) of last allocation for LIFO deallocation
+
+    // Helper function to align an address to DRAM_ALIGNMENT
+    FORCE_INLINE static uint32_t align_address(uint32_t addr) {
+        // use DRAM alignment for now as it's the max alignment
+        // TODO: have extra field in the packet header for differentiating l1/dram if needed.
+        constexpr uint32_t alignment = DRAM_ALIGNMENT;
+        return (addr + alignment - 1) & ~(alignment - 1);
+    }
+
+public:
+    // Initialize the memory pool with base address and size
+    // Must be called before any allocate/deallocate operations
+    FORCE_INLINE static void init(uint32_t base_address, uint32_t size_bytes) {
+        pool_base_ = base_address;
+        pool_size_ = size_bytes;
+        current_offset_ = 0;
+        pool_end_ = base_address + size_bytes;
+    }
+
+    // Allocate a chunk of memory of the specified size
+    // Returns the L1 address of the allocated memory (aligned to DRAM_ALIGNMENT)
+    // Will hang if pool is exhausted
+    FORCE_INLINE static uint32_t allocate_memory(uint32_t size_bytes) {
+        // Align the current address to DRAM_ALIGNMENT
+        uint32_t unaligned_addr = pool_base_ + current_offset_;
+        uint32_t allocated_addr = align_address(unaligned_addr);
+        uint32_t alignment_padding = allocated_addr - unaligned_addr;
+
+        // Also align the size to ensure next allocation starts aligned
+        uint32_t aligned_size = align_address(size_bytes);
+
+        // Total allocation includes padding and aligned size
+        uint32_t total_allocation = alignment_padding + aligned_size;
+
+        ASSERT(allocated_addr + aligned_size <= pool_end_);
+        if (allocated_addr + aligned_size > pool_end_) {
+            DPRINT << "=== UDM MEMORY POOL EXHAUSTION ERROR ==="
+                   << "CRITICAL: Insufficient space in UDM memory pool"
+                   << "  - Requested Size: " << size_bytes << " bytes"
+                   << "  - Aligned Size: " << aligned_size << " bytes"
+                   << "  - Alignment Padding: " << alignment_padding << " bytes"
+                   << "  - Total Allocation: " << total_allocation << " bytes"
+                   << "  - Current Offset: " << current_offset_ << " bytes"
+                   << "  - Pool Size: " << pool_size_ << " bytes"
+                   << "  - Pool Base: 0x" << pool_base_ << "  - Pool End: 0x" << pool_end_
+                   << "  - Allocated Address: 0x" << allocated_addr
+                   << "Action: Entering infinite loop to prevent undefined behavior"
+                   << "Solution: Increase UDM memory pool size or reduce memory usage"
+                   << "=================================================\n";
+            while (1) {
+            }  // hang intentionally
+        }
+
+        // Store the total allocation for LIFO deallocation
+        last_alloc_total_ = total_allocation;
+
+        // Update offset to account for alignment padding and the allocated size
+        current_offset_ += total_allocation;
+
+        return allocated_addr;
+    }
+
+    // Deallocate a chunk of memory of the specified size
+    // This implementation uses a simple bump allocator, so deallocation
+    // just moves the offset back. Only works correctly if deallocations
+    // happen in reverse order of allocations (LIFO).
+    // NOTE: size_bytes should match the size passed to allocate_memory
+    FORCE_INLINE static void deallocate_memory(uint32_t size_bytes) {
+        // Use the stored total allocation (includes padding + aligned size)
+        // This ensures we properly reverse the allocation including any alignment padding
+        uint32_t total_dealloc = last_alloc_total_;
+
+        ASSERT(current_offset_ >= total_dealloc);
+        if (current_offset_ < total_dealloc) {
+            DPRINT << "=== UDM MEMORY POOL DEALLOCATION ERROR ==="
+                   << "CRITICAL: Attempting to deallocate more than allocated"
+                   << "  - Requested Deallocation: " << size_bytes << " bytes"
+                   << "  - Total Deallocation: " << total_dealloc << " bytes"
+                   << "  - Current Offset: " << current_offset_ << " bytes"
+                   << "Action: Entering infinite loop to prevent undefined behavior"
+                   << "=================================================\n";
+            while (1) {
+            }  // hang intentionally
+        }
+
+        current_offset_ -= total_dealloc;
+    }
+
+    // Get the current pool usage in bytes
+    FORCE_INLINE static uint32_t get_usage() { return current_offset_; }
+
+    // Get the available space in bytes
+    FORCE_INLINE static uint32_t get_available() { return pool_size_ - current_offset_; }
+
+    // Reset the pool (only use during initialization or teardown)
+    FORCE_INLINE static void reset() { current_offset_ = 0; }
+};
+
+}  // namespace tt::tt_fabric::udm

--- a/tt_metal/fabric/impl/kernels/edm_fabric/fabric_router_mux_extension.cpp
+++ b/tt_metal/fabric/impl/kernels/edm_fabric/fabric_router_mux_extension.cpp
@@ -220,6 +220,9 @@ void kernel_main() {
     constexpr std::array<uint32_t, NUM_TOTAL_CHANNELS> is_persistent_channels =
         fill_array_with_next_n_args<uint32_t, IS_PERSISTENT_CHANNELS_START_IDX, NUM_TOTAL_CHANNELS>();
 
+    // Direction (last compile-time argument)
+    constexpr size_t direction = get_compile_time_arg_val(IS_PERSISTENT_CHANNELS_START_IDX + NUM_TOTAL_CHANNELS);
+
     size_t channel_base_address = channels_base_l1_address;
     size_t connection_info_address = connection_info_base_address;
     size_t connection_handshake_address = connection_handshake_base_address;

--- a/tt_metal/fabric/impl/kernels/edm_fabric/fabric_router_mux_extension.cpp
+++ b/tt_metal/fabric/impl/kernels/edm_fabric/fabric_router_mux_extension.cpp
@@ -16,25 +16,20 @@
 #include <array>
 // clang-format on
 
-constexpr size_t NUM_FULL_SIZE_CHANNELS = get_compile_time_arg_val(0);
-constexpr uint8_t NUM_BUFFERS_FULL_SIZE_CHANNEL = get_compile_time_arg_val(1);
-constexpr size_t BUFFER_SIZE_BYTES_FULL_SIZE_CHANNEL = get_compile_time_arg_val(2);
-constexpr size_t NUM_HEADER_ONLY_CHANNELS = get_compile_time_arg_val(3);
-constexpr uint8_t NUM_BUFFERS_HEADER_ONLY_CHANNEL = get_compile_time_arg_val(4);
-// header only buffer slot size is the same as the edm packet header size
+// ========== Scalar configuration values from MuxConfig::get_compile_time_args ==========
+constexpr size_t NUM_TOTAL_CHANNELS = get_compile_time_arg_val(0);
+constexpr size_t status_address = get_compile_time_arg_val(1);
+constexpr size_t termination_signal_address = get_compile_time_arg_val(2);
+constexpr size_t local_fabric_router_status_address = get_compile_time_arg_val(3);
+constexpr size_t fabric_router_status_address = get_compile_time_arg_val(4);
+constexpr uint8_t NUM_EDM_BUFFERS = get_compile_time_arg_val(5);
+constexpr size_t NUM_FULL_SIZE_CHANNELS_ITERS = get_compile_time_arg_val(6);
+constexpr size_t NUM_ITERS_BETWEEN_TEARDOWN_CHECKS = get_compile_time_arg_val(7);
+constexpr ProgrammableCoreType CORE_TYPE = static_cast<ProgrammableCoreType>(get_compile_time_arg_val(8));
+constexpr bool wait_for_fabric_endpoint = get_compile_time_arg_val(9) == 1;
+constexpr uint32_t NUM_DOWNSTREAM_MUX_CONNECTIONS = get_compile_time_arg_val(10);
+constexpr uint32_t NUM_CHANNEL_TYPES = get_compile_time_arg_val(11);
 
-constexpr size_t status_address = get_compile_time_arg_val(5);
-constexpr size_t termination_signal_address = get_compile_time_arg_val(6);
-constexpr size_t connection_info_base_address = get_compile_time_arg_val(7);
-constexpr size_t connection_handshake_base_address = get_compile_time_arg_val(8);
-constexpr size_t sender_flow_control_base_address = get_compile_time_arg_val(9);
-constexpr size_t channels_base_l1_address = get_compile_time_arg_val(10);
-constexpr size_t local_fabric_router_status_address = get_compile_time_arg_val(11);
-constexpr size_t fabric_router_status_address = get_compile_time_arg_val(12);
-
-constexpr uint8_t NUM_EDM_BUFFERS = get_compile_time_arg_val(13);
-constexpr size_t NUM_FULL_SIZE_CHANNELS_ITERS = get_compile_time_arg_val(14);
-constexpr size_t NUM_ITERS_BETWEEN_TEARDOWN_CHECKS = get_compile_time_arg_val(15);
 static_assert(NUM_EDM_BUFFERS < 256, "NUM_EDM_BUFFERS too big, maybe CT args are misconfigured");
 static_assert(
     NUM_FULL_SIZE_CHANNELS_ITERS < 256, "NUM_FULL_SIZE_CHANNELS_ITERS too big, maybe CT args are misconfigured");
@@ -42,23 +37,74 @@ static_assert(
     NUM_ITERS_BETWEEN_TEARDOWN_CHECKS < 256,
     "NUM_ITERS_BETWEEN_TEARDOWN_CHECKS too big, maybe CT args are misconfigured");
 
-constexpr ProgrammableCoreType CORE_TYPE = static_cast<ProgrammableCoreType>(get_compile_time_arg_val(16));
-constexpr bool wait_for_fabric_endpoint = get_compile_time_arg_val(17) == 1;
-constexpr size_t num_upstream_routers = get_compile_time_arg_val(18);
-constexpr size_t fabric_router_sync_address = get_compile_time_arg_val(19);
+// ========== Per-channel-type arrays (7 arrays × NUM_CHANNEL_TYPES entries) ==========
+// Legacy MUX mode has 2 channel types: WORKER_CHANNEL and ROUTER_CHANNEL
+constexpr uint32_t NUM_CHANNELS_ARRAY_START_IDX = 12;
+constexpr uint32_t NUM_BUFFERS_ARRAY_START_IDX = NUM_CHANNELS_ARRAY_START_IDX + NUM_CHANNEL_TYPES;
+constexpr uint32_t BUFFER_SIZE_ARRAY_START_IDX = NUM_BUFFERS_ARRAY_START_IDX + NUM_CHANNEL_TYPES;
+constexpr uint32_t CONNECTION_INFO_BASE_ADDR_ARRAY_START_IDX = BUFFER_SIZE_ARRAY_START_IDX + NUM_CHANNEL_TYPES;
+constexpr uint32_t CONNECTION_HANDSHAKE_BASE_ADDR_ARRAY_START_IDX =
+    CONNECTION_INFO_BASE_ADDR_ARRAY_START_IDX + NUM_CHANNEL_TYPES;
+constexpr uint32_t FLOW_CONTROL_BASE_ADDR_ARRAY_START_IDX =
+    CONNECTION_HANDSHAKE_BASE_ADDR_ARRAY_START_IDX + NUM_CHANNEL_TYPES;
+constexpr uint32_t CHANNEL_BUFFER_BASE_ADDR_ARRAY_START_IDX =
+    FLOW_CONTROL_BASE_ADDR_ARRAY_START_IDX + NUM_CHANNEL_TYPES;
+
+// ========== Extract per-channel-type configuration ==========
+// In Legacy MUX mode, we have 2 channel types:
+// [0] = WORKER_CHANNEL
+// [1] = ROUTER_CHANNEL
+constexpr std::array<uint32_t, NUM_CHANNEL_TYPES> num_channels_per_type =
+    fill_array_with_next_n_args<uint32_t, NUM_CHANNELS_ARRAY_START_IDX, NUM_CHANNEL_TYPES>();
+constexpr std::array<uint32_t, NUM_CHANNEL_TYPES> num_buffers_per_type =
+    fill_array_with_next_n_args<uint32_t, NUM_BUFFERS_ARRAY_START_IDX, NUM_CHANNEL_TYPES>();
+constexpr std::array<size_t, NUM_CHANNEL_TYPES> buffer_size_per_type =
+    fill_array_with_next_n_args<size_t, BUFFER_SIZE_ARRAY_START_IDX, NUM_CHANNEL_TYPES>();
+constexpr std::array<size_t, NUM_CHANNEL_TYPES> connection_info_base_addrs =
+    fill_array_with_next_n_args<size_t, CONNECTION_INFO_BASE_ADDR_ARRAY_START_IDX, NUM_CHANNEL_TYPES>();
+constexpr std::array<size_t, NUM_CHANNEL_TYPES> connection_handshake_base_addrs =
+    fill_array_with_next_n_args<size_t, CONNECTION_HANDSHAKE_BASE_ADDR_ARRAY_START_IDX, NUM_CHANNEL_TYPES>();
+constexpr std::array<size_t, NUM_CHANNEL_TYPES> flow_control_base_addrs =
+    fill_array_with_next_n_args<size_t, FLOW_CONTROL_BASE_ADDR_ARRAY_START_IDX, NUM_CHANNEL_TYPES>();
+constexpr std::array<size_t, NUM_CHANNEL_TYPES> channel_buffer_base_addrs =
+    fill_array_with_next_n_args<size_t, CHANNEL_BUFFER_BASE_ADDR_ARRAY_START_IDX, NUM_CHANNEL_TYPES>();
+
+// ========== Downstream mux connection arrays (11 arrays from MuxConfig) ==========
+// Note: Legacy MUX mode has NUM_DOWNSTREAM_MUX_CONNECTIONS = 0, so these arrays are empty
+constexpr uint32_t DOWNSTREAM_MUX_ARRAYS_START_IDX = CHANNEL_BUFFER_BASE_ADDR_ARRAY_START_IDX + NUM_CHANNEL_TYPES;
 
 // A channel is a "traffic injection channel" if it is a sender channel that is adding *new*
 // traffic to this dimension/ring. Examples include channels service worker traffic and
 // sender channels that receive traffic from a "turn" (e.g. an EAST channel receiving traffic from NORTH)
 // This attribute is necessary to support bubble flow control.
-constexpr bool enable_bubble_flow_control = get_compile_time_arg_val(20) != 0;
+constexpr uint32_t BUBBLE_FLOW_CONTROL_START_IDX = DOWNSTREAM_MUX_ARRAYS_START_IDX + (NUM_DOWNSTREAM_MUX_CONNECTIONS * 11);
+constexpr bool enable_bubble_flow_control = get_compile_time_arg_val(BUBBLE_FLOW_CONTROL_START_IDX) != 0;
 constexpr size_t BUBBLE_FLOW_CONTROL_INJECTION_SENDER_CHANNEL_MIN_FREE_SLOTS = 2;
-constexpr size_t FULL_SIZE_CHANNEL_INJECTION_STATUS_ARRAY_SIZE = NUM_FULL_SIZE_CHANNELS;
-constexpr size_t HEADER_ONLY_CHANNEL_INJECTION_STATUS_ARRAY_SIZE = NUM_HEADER_ONLY_CHANNELS;
 
-constexpr size_t CHANNEL_STREAM_IDS_START_IDX = 21;
+// ========== Builder-added args (from MuxBuilder::get_compile_time_args) ==========
+// Upstream routers and sync address follow after downstream mux arrays
+constexpr size_t NUM_UPSTREAM_ROUTERS_IDX = BUBBLE_FLOW_CONTROL_START_IDX + 1;
+constexpr size_t num_upstream_routers = get_compile_time_arg_val(NUM_UPSTREAM_ROUTERS_IDX);
+constexpr size_t fabric_router_sync_address = get_compile_time_arg_val(NUM_UPSTREAM_ROUTERS_IDX + 1);
+
+constexpr size_t CHANNEL_STREAM_IDS_START_IDX = NUM_UPSTREAM_ROUTERS_IDX + 2;
 
 constexpr size_t NOC_ALIGN_PADDING_BYTES = 12;
+
+// ========== Channel type indices (must match ChannelTypes enum order in host) ==========
+// In Legacy MUX mode:
+constexpr uint32_t WORKER_CHANNEL_TYPE_IDX = 0;  // WORKER_CHANNEL
+constexpr uint32_t ROUTER_CHANNEL_TYPE_IDX = 1;  // ROUTER_CHANNEL
+
+// Extract per-type configuration
+constexpr uint32_t NUM_WORKER_CHANNELS = num_channels_per_type[WORKER_CHANNEL_TYPE_IDX];
+constexpr uint32_t NUM_ROUTER_CHANNELS = num_channels_per_type[ROUTER_CHANNEL_TYPE_IDX];
+
+constexpr uint32_t NUM_BUFFERS_WORKER = num_buffers_per_type[WORKER_CHANNEL_TYPE_IDX];
+constexpr uint32_t NUM_BUFFERS_ROUTER = num_buffers_per_type[ROUTER_CHANNEL_TYPE_IDX];
+
+constexpr size_t BUFFER_SIZE_WORKER = buffer_size_per_type[WORKER_CHANNEL_TYPE_IDX];
+constexpr size_t BUFFER_SIZE_ROUTER = buffer_size_per_type[ROUTER_CHANNEL_TYPE_IDX];
 
 namespace tt::tt_fabric {
 using FabricMuxToEdmSender = WorkerToFabricEdmSenderImpl<false, NUM_EDM_BUFFERS>;
@@ -181,81 +227,91 @@ void kernel_main() {
         zero_l1_buf(reinterpret_cast<tt_l1_ptr uint32_t*>(address), size);
     }
 
-    std::array<bool, FULL_SIZE_CHANNEL_INJECTION_STATUS_ARRAY_SIZE> full_size_channel_injection_status = {};
-    std::array<bool, HEADER_ONLY_CHANNEL_INJECTION_STATUS_ARRAY_SIZE> header_only_channel_injection_status = {};
+    std::array<bool, NUM_WORKER_CHANNELS> worker_channel_injection_status = {};
+    std::array<bool, NUM_ROUTER_CHANNELS> router_channel_injection_status = {};
     if constexpr (enable_bubble_flow_control) {
-        for (size_t i = 0; i < FULL_SIZE_CHANNEL_INJECTION_STATUS_ARRAY_SIZE; i++) {
-            full_size_channel_injection_status[i] = get_arg_val<uint32_t>(rt_args_idx++);
+        for (size_t i = 0; i < NUM_WORKER_CHANNELS; i++) {
+            worker_channel_injection_status[i] = get_arg_val<bool>(rt_args_idx++);
         }
-        for (size_t i = 0; i < HEADER_ONLY_CHANNEL_INJECTION_STATUS_ARRAY_SIZE; i++) {
-            header_only_channel_injection_status[i] = get_arg_val<uint32_t>(rt_args_idx++);
+        for (size_t i = 0; i < NUM_ROUTER_CHANNELS; i++) {
+            router_channel_injection_status[i] = get_arg_val<bool>(rt_args_idx++);
         }
     }
 
     auto fabric_connection = tt::tt_fabric::FabricMuxToEdmSender::build_from_args<CORE_TYPE>(rt_args_idx);
 
-    std::array<tt::tt_fabric::FabricMuxChannelBuffer<NUM_BUFFERS_FULL_SIZE_CHANNEL>, NUM_FULL_SIZE_CHANNELS>
-        full_size_channels;
-    std::array<
-        tt::tt_fabric::FabricMuxStaticSizedChannelWorkerInterface<NUM_BUFFERS_FULL_SIZE_CHANNEL>,
-        NUM_FULL_SIZE_CHANNELS>
-        full_size_channel_worker_interfaces;
-    std::array<bool, NUM_FULL_SIZE_CHANNELS> full_size_channel_connection_established;
+    // ========== Create channel arrays grouped by type ==========
+    // Worker channels (WORKER_CHANNEL)
+    std::array<tt::tt_fabric::FabricMuxChannelBuffer<NUM_BUFFERS_WORKER>, NUM_WORKER_CHANNELS> worker_channels;
+    std::array<tt::tt_fabric::FabricMuxStaticSizedChannelWorkerInterface<NUM_BUFFERS_WORKER>, NUM_WORKER_CHANNELS>
+        worker_channel_interfaces;
+    std::array<bool, NUM_WORKER_CHANNELS> worker_channel_connection_established;
 
-    std::array<tt::tt_fabric::FabricMuxChannelBuffer<NUM_BUFFERS_HEADER_ONLY_CHANNEL>, NUM_HEADER_ONLY_CHANNELS>
-        header_only_channels;
-    std::array<
-        tt::tt_fabric::FabricMuxStaticSizedChannelWorkerInterface<NUM_BUFFERS_HEADER_ONLY_CHANNEL>,
-        NUM_HEADER_ONLY_CHANNELS>
-        header_only_channel_worker_interfaces;
-    std::array<bool, NUM_HEADER_ONLY_CHANNELS> header_only_channel_connection_established;
+    // Router channels (ROUTER_CHANNEL)
+    std::array<tt::tt_fabric::FabricMuxChannelBuffer<NUM_BUFFERS_ROUTER>, NUM_ROUTER_CHANNELS> router_channels;
+    std::array<tt::tt_fabric::FabricMuxStaticSizedChannelWorkerInterface<NUM_BUFFERS_ROUTER>, NUM_ROUTER_CHANNELS>
+        router_channel_interfaces;
+    std::array<bool, NUM_ROUTER_CHANNELS> router_channel_connection_established;
 
-    // Stream IDs
-    constexpr size_t NUM_TOTAL_CHANNELS = NUM_FULL_SIZE_CHANNELS + NUM_HEADER_ONLY_CHANNELS;
-    constexpr std::array<uint32_t, NUM_TOTAL_CHANNELS> channel_stream_ids =
-        fill_array_with_next_n_args<uint32_t, CHANNEL_STREAM_IDS_START_IDX, NUM_TOTAL_CHANNELS>();
+    // ========== Parse stream IDs and persistent flags (grouped by type) ==========
+    constexpr std::array<uint32_t, NUM_WORKER_CHANNELS> worker_stream_ids =
+        fill_array_with_next_n_args<uint32_t, CHANNEL_STREAM_IDS_START_IDX, NUM_WORKER_CHANNELS>();
+    constexpr std::array<uint32_t, NUM_ROUTER_CHANNELS> router_stream_ids = fill_array_with_next_n_args<
+        uint32_t,
+        CHANNEL_STREAM_IDS_START_IDX + NUM_WORKER_CHANNELS,
+        NUM_ROUTER_CHANNELS>();
 
-    // Persistent channel flags
     constexpr size_t IS_PERSISTENT_CHANNELS_START_IDX = CHANNEL_STREAM_IDS_START_IDX + NUM_TOTAL_CHANNELS;
-    constexpr std::array<uint32_t, NUM_TOTAL_CHANNELS> is_persistent_channels =
-        fill_array_with_next_n_args<uint32_t, IS_PERSISTENT_CHANNELS_START_IDX, NUM_TOTAL_CHANNELS>();
+    constexpr std::array<uint32_t, NUM_WORKER_CHANNELS> worker_is_persistent =
+        fill_array_with_next_n_args<uint32_t, IS_PERSISTENT_CHANNELS_START_IDX, NUM_WORKER_CHANNELS>();
+    constexpr std::array<uint32_t, NUM_ROUTER_CHANNELS> router_is_persistent = fill_array_with_next_n_args<
+        uint32_t,
+        IS_PERSISTENT_CHANNELS_START_IDX + NUM_WORKER_CHANNELS,
+        NUM_ROUTER_CHANNELS>();
 
     // Direction (last compile-time argument)
     constexpr size_t direction = get_compile_time_arg_val(IS_PERSISTENT_CHANNELS_START_IDX + NUM_TOTAL_CHANNELS);
 
-    size_t channel_base_address = channels_base_l1_address;
-    size_t connection_info_address = connection_info_base_address;
-    size_t connection_handshake_address = connection_handshake_base_address;
-    size_t sender_flow_control_address = sender_flow_control_base_address;
+    // ========== Setup worker channels (WORKER_CHANNEL) ==========
+    size_t worker_channel_base_address = channel_buffer_base_addrs[WORKER_CHANNEL_TYPE_IDX];
+    size_t worker_connection_info_address = connection_info_base_addrs[WORKER_CHANNEL_TYPE_IDX];
+    size_t worker_connection_handshake_address = connection_handshake_base_addrs[WORKER_CHANNEL_TYPE_IDX];
+    size_t worker_flow_control_address = flow_control_base_addrs[WORKER_CHANNEL_TYPE_IDX];
 
-    for (uint8_t i = 0; i < NUM_FULL_SIZE_CHANNELS; i++) {
-        setup_channel<NUM_BUFFERS_FULL_SIZE_CHANNEL>(
-            &full_size_channels[i],
-            &full_size_channel_worker_interfaces[i],
-            full_size_channel_connection_established[i],
+    for (uint32_t i = 0; i < NUM_WORKER_CHANNELS; i++) {
+        setup_channel<NUM_BUFFERS_WORKER>(
+            &worker_channels[i],
+            &worker_channel_interfaces[i],
+            worker_channel_connection_established[i],
             i,
-            BUFFER_SIZE_BYTES_FULL_SIZE_CHANNEL,
-            channel_base_address,
-            connection_info_address,
-            connection_handshake_address,
-            sender_flow_control_address,
-            StreamId{channel_stream_ids[i]},
-            is_persistent_channels[i]);
+            BUFFER_SIZE_WORKER,
+            worker_channel_base_address,
+            worker_connection_info_address,
+            worker_connection_handshake_address,
+            worker_flow_control_address,
+            StreamId{worker_stream_ids[i]},
+            worker_is_persistent[i] == 1);
     }
 
-    for (uint8_t i = 0; i < NUM_HEADER_ONLY_CHANNELS; i++) {
-        setup_channel<NUM_BUFFERS_HEADER_ONLY_CHANNEL>(
-            &header_only_channels[i],
-            &header_only_channel_worker_interfaces[i],
-            header_only_channel_connection_established[i],
+    // ========== Setup router channels (ROUTER_CHANNEL) ==========
+    size_t router_channel_base_address = channel_buffer_base_addrs[ROUTER_CHANNEL_TYPE_IDX];
+    size_t router_connection_info_address = connection_info_base_addrs[ROUTER_CHANNEL_TYPE_IDX];
+    size_t router_connection_handshake_address = connection_handshake_base_addrs[ROUTER_CHANNEL_TYPE_IDX];
+    size_t router_flow_control_address = flow_control_base_addrs[ROUTER_CHANNEL_TYPE_IDX];
+
+    for (uint32_t i = 0; i < NUM_ROUTER_CHANNELS; i++) {
+        setup_channel<NUM_BUFFERS_ROUTER>(
+            &router_channels[i],
+            &router_channel_interfaces[i],
+            router_channel_connection_established[i],
             i,
-            sizeof(PACKET_HEADER_TYPE),
-            channel_base_address,
-            connection_info_address,
-            connection_handshake_address,
-            sender_flow_control_address,
-            StreamId{channel_stream_ids[i + NUM_FULL_SIZE_CHANNELS]},
-            is_persistent_channels[i + NUM_FULL_SIZE_CHANNELS]);
+            BUFFER_SIZE_ROUTER,
+            router_channel_base_address,
+            router_connection_info_address,
+            router_connection_handshake_address,
+            router_flow_control_address,
+            StreamId{router_stream_ids[i]},
+            router_is_persistent[i] == 1);
     }
 
     volatile auto termination_signal_ptr =
@@ -281,16 +337,16 @@ void kernel_main() {
     constexpr bool use_worker_allocated_credit_address = CORE_TYPE == ProgrammableCoreType::IDLE_ETH;
     fabric_connection.open<use_worker_allocated_credit_address>();
 
-    for (uint8_t i = 0; i < NUM_FULL_SIZE_CHANNELS; i++) {
-        if (is_persistent_channels[i]) {
-            wait_for_static_connection_to_ready<NUM_BUFFERS_FULL_SIZE_CHANNEL>(full_size_channel_worker_interfaces[i]);
+    // Wait for persistent channels to be ready
+    for (uint32_t i = 0; i < NUM_WORKER_CHANNELS; i++) {
+        if (worker_is_persistent[i] == 1) {
+            wait_for_static_connection_to_ready<NUM_BUFFERS_WORKER>(worker_channel_interfaces[i]);
         }
     }
 
-    for (uint8_t i = 0; i < NUM_HEADER_ONLY_CHANNELS; i++) {
-        if (is_persistent_channels[i + NUM_FULL_SIZE_CHANNELS]) {
-            wait_for_static_connection_to_ready<NUM_BUFFERS_HEADER_ONLY_CHANNEL>(
-                header_only_channel_worker_interfaces[i]);
+    for (uint32_t i = 0; i < NUM_ROUTER_CHANNELS; i++) {
+        if (router_is_persistent[i] == 1) {
+            wait_for_static_connection_to_ready<NUM_BUFFERS_ROUTER>(router_channel_interfaces[i]);
         }
     }
 
@@ -300,45 +356,29 @@ void kernel_main() {
     uint32_t heartbeat = 0;
 #endif
     while (!got_immediate_termination_signal(termination_signal_ptr)) {
-        bool got_graceful_termination = got_graceful_termination_signal(termination_signal_ptr);
-        if (got_graceful_termination) {
-            bool all_channels_drained = true;
-            for (uint8_t channel_id = 0; channel_id < NUM_FULL_SIZE_CHANNELS; channel_id++) {
-                all_channels_drained &= get_ptr_val(channel_id) == NUM_BUFFERS_FULL_SIZE_CHANNEL;
-            }
-            for (uint8_t channel_id = 0; channel_id < NUM_HEADER_ONLY_CHANNELS; channel_id++) {
-                all_channels_drained &=
-                    get_ptr_val(channel_id + NUM_FULL_SIZE_CHANNELS) == NUM_BUFFERS_HEADER_ONLY_CHANNEL;
-            }
-
-            if (all_channels_drained) {
-                break;
-            }
-        }
-
         for (size_t i = 0; i < NUM_ITERS_BETWEEN_TEARDOWN_CHECKS; i++) {
-            for (size_t iter = 0; iter < NUM_FULL_SIZE_CHANNELS_ITERS; iter++) {
-                for (uint8_t channel_id = 0; channel_id < NUM_FULL_SIZE_CHANNELS; channel_id++) {
-                    forward_data<NUM_BUFFERS_FULL_SIZE_CHANNEL>(
-                        full_size_channels[channel_id],
-                        full_size_channel_worker_interfaces[channel_id],
-                        fabric_connection,
-                        full_size_channel_connection_established[channel_id],
-                        StreamId{channel_stream_ids[channel_id]},
-                        is_persistent_channels[channel_id],
-                        full_size_channel_injection_status[channel_id]);
-                }
+            // Process worker channels (WORKER_CHANNEL)
+            for (uint32_t channel_id = 0; channel_id < NUM_WORKER_CHANNELS; channel_id++) {
+                forward_data<NUM_BUFFERS_WORKER>(
+                    worker_channels[channel_id],
+                    worker_channel_interfaces[channel_id],
+                    fabric_connection,
+                    worker_channel_connection_established[channel_id],
+                    StreamId{worker_stream_ids[channel_id]},
+                    worker_is_persistent[channel_id] == 1,
+                    worker_channel_injection_status[channel_id]);
             }
 
-            for (uint8_t channel_id = 0; channel_id < NUM_HEADER_ONLY_CHANNELS; channel_id++) {
-                forward_data<NUM_BUFFERS_HEADER_ONLY_CHANNEL>(
-                    header_only_channels[channel_id],
-                    header_only_channel_worker_interfaces[channel_id],
+            // Process router channels (ROUTER_CHANNEL)
+            for (uint32_t channel_id = 0; channel_id < NUM_ROUTER_CHANNELS; channel_id++) {
+                forward_data<NUM_BUFFERS_ROUTER>(
+                    router_channels[channel_id],
+                    router_channel_interfaces[channel_id],
                     fabric_connection,
-                    header_only_channel_connection_established[channel_id],
-                    StreamId{channel_stream_ids[channel_id + NUM_FULL_SIZE_CHANNELS]},
-                    is_persistent_channels[channel_id + NUM_FULL_SIZE_CHANNELS],
-                    header_only_channel_injection_status[channel_id]);
+                    router_channel_connection_established[channel_id],
+                    StreamId{router_stream_ids[channel_id]},
+                    router_is_persistent[channel_id] == 1,
+                    router_channel_injection_status[channel_id]);
             }
         }
 #if defined(COMPILE_FOR_IDLE_ERISC)

--- a/tt_metal/fabric/impl/kernels/edm_fabric/fabric_router_relay_extension.cpp
+++ b/tt_metal/fabric/impl/kernels/edm_fabric/fabric_router_relay_extension.cpp
@@ -41,26 +41,42 @@ using FabricRelayToMuxSender = WorkerToFabricEdmSenderImpl<false, NUM_EDM_BUFFER
 
 static_assert(noc_index == 1, "Relay kernel requires noc_index to be 1 for correct noc address calculation");
 
-constexpr uint8_t NUM_BUFFERS = get_compile_time_arg_val(0);
-constexpr size_t BUFFER_SIZE_BYTES = get_compile_time_arg_val(1);
-constexpr size_t status_address = get_compile_time_arg_val(2);
-constexpr size_t termination_signal_address = get_compile_time_arg_val(3);
-constexpr size_t connection_info_base_address = get_compile_time_arg_val(4);
-constexpr size_t connection_handshake_base_address = get_compile_time_arg_val(5);
-constexpr size_t sender_flow_control_base_address = get_compile_time_arg_val(6);
-constexpr size_t channels_base_l1_address = get_compile_time_arg_val(7);
-constexpr size_t channel_stream_id = get_compile_time_arg_val(8);
-constexpr size_t NUM_ITERS_BETWEEN_TEARDOWN_CHECKS = get_compile_time_arg_val(9);
-constexpr size_t mux_num_buffers = get_compile_time_arg_val(10);
-constexpr size_t mux_buffer_size_bytes = get_compile_time_arg_val(11);
-constexpr size_t downstream_mux_status_readback_address = get_compile_time_arg_val(12);
+// Scalar configuration values
+constexpr size_t status_address = get_compile_time_arg_val(0);
+constexpr size_t termination_signal_address = get_compile_time_arg_val(1);
+constexpr size_t channel_stream_id = get_compile_time_arg_val(2);
+constexpr size_t NUM_ITERS_BETWEEN_TEARDOWN_CHECKS = get_compile_time_arg_val(3);
+constexpr size_t mux_num_buffers = get_compile_time_arg_val(4);
+constexpr size_t mux_buffer_size_bytes = get_compile_time_arg_val(5);
+constexpr size_t downstream_mux_status_readback_address = get_compile_time_arg_val(6);
+constexpr uint32_t NUM_MUX_CONNECTIONS = get_compile_time_arg_val(7);
+constexpr uint32_t NUM_CHANNEL_TYPES = get_compile_time_arg_val(8);
 
-// Mux connection configuration (arg 13)
-constexpr uint32_t NUM_MUX_CONNECTIONS = get_compile_time_arg_val(13);
+// Per-channel-type arrays start at index 9
+// Relay only has one channel type (ROUTER_CHANNEL), so arrays have size 1
+constexpr uint32_t NUM_CHANNELS_ARRAY_START_IDX = 9;
+constexpr uint32_t NUM_BUFFERS_ARRAY_START_IDX = NUM_CHANNELS_ARRAY_START_IDX + NUM_CHANNEL_TYPES;
+constexpr uint32_t BUFFER_SIZE_ARRAY_START_IDX = NUM_BUFFERS_ARRAY_START_IDX + NUM_CHANNEL_TYPES;
+constexpr uint32_t CONNECTION_INFO_BASE_ADDR_ARRAY_START_IDX = BUFFER_SIZE_ARRAY_START_IDX + NUM_CHANNEL_TYPES;
+constexpr uint32_t CONNECTION_HANDSHAKE_BASE_ADDR_ARRAY_START_IDX =
+    CONNECTION_INFO_BASE_ADDR_ARRAY_START_IDX + NUM_CHANNEL_TYPES;
+constexpr uint32_t FLOW_CONTROL_BASE_ADDR_ARRAY_START_IDX =
+    CONNECTION_HANDSHAKE_BASE_ADDR_ARRAY_START_IDX + NUM_CHANNEL_TYPES;
+constexpr uint32_t CHANNEL_BUFFER_BASE_ADDR_ARRAY_START_IDX =
+    FLOW_CONTROL_BASE_ADDR_ARRAY_START_IDX + NUM_CHANNEL_TYPES;
 
-// Mux connection arrays: [0]=local, [1]=downstream_en, [2]=downstream_ws (args 14-46)
-// Each array has NUM_MUX_CONNECTIONS elements, indices computed incrementally
-constexpr uint32_t MUX_ACTIVE_START_IDX = 14;
+// Extract relay channel configuration (relay has only 1 channel type with 1 channel)
+constexpr uint32_t NUM_CHANNELS = get_compile_time_arg_val(NUM_CHANNELS_ARRAY_START_IDX);
+constexpr uint8_t NUM_BUFFERS = get_compile_time_arg_val(NUM_BUFFERS_ARRAY_START_IDX);
+constexpr size_t BUFFER_SIZE_BYTES = get_compile_time_arg_val(BUFFER_SIZE_ARRAY_START_IDX);
+constexpr size_t connection_info_base_address = get_compile_time_arg_val(CONNECTION_INFO_BASE_ADDR_ARRAY_START_IDX);
+constexpr size_t connection_handshake_base_address =
+    get_compile_time_arg_val(CONNECTION_HANDSHAKE_BASE_ADDR_ARRAY_START_IDX);
+constexpr size_t sender_flow_control_base_address = get_compile_time_arg_val(FLOW_CONTROL_BASE_ADDR_ARRAY_START_IDX);
+constexpr size_t channels_base_l1_address = get_compile_time_arg_val(CHANNEL_BUFFER_BASE_ADDR_ARRAY_START_IDX);
+
+// Mux connection arrays start immediately after channel type arrays
+constexpr uint32_t MUX_ACTIVE_START_IDX = CHANNEL_BUFFER_BASE_ADDR_ARRAY_START_IDX + NUM_CHANNEL_TYPES;
 constexpr uint32_t MUX_NOC_X_START_IDX = MUX_ACTIVE_START_IDX + NUM_MUX_CONNECTIONS;
 constexpr uint32_t MUX_NOC_Y_START_IDX = MUX_NOC_X_START_IDX + NUM_MUX_CONNECTIONS;
 constexpr uint32_t MUX_BUFFER_BASE_ADDR_START_IDX = MUX_NOC_Y_START_IDX + NUM_MUX_CONNECTIONS;

--- a/tt_metal/fabric/impl/kernels/edm_fabric/fabric_router_udm_mux_extension.cpp
+++ b/tt_metal/fabric/impl/kernels/edm_fabric/fabric_router_udm_mux_extension.cpp
@@ -216,8 +216,14 @@ void forward_data(
 
         // TODO: once we group the channels into udm-worker, relay-mux, mux-mux, then we only need to check the
         // directions for the udm-worker channels.
+        // if (is_persistent_channel) {
+        //     fabric_connection.wait_for_empty_write_slot();
+        //     fabric_connection.send_payload_flush_non_blocking_from_address(
+        //         (uint32_t)packet_header, packet_header->get_payload_size_including_header());
+        // } else {
         tt::tt_fabric::udm::forward_to_downstream_mux_or_local_router<Direction>(
             packet_header, fabric_connection, downstream_mux_connections);
+        // }
 
         worker_interface.local_write_counter.increment();
         worker_interface.local_read_counter.increment();
@@ -411,7 +417,6 @@ void kernel_main() {
                 header_only_channel_worker_interfaces[i]);
         }
     }
-    // DPRINT << "mux start loop" <<ENDL();
 
     while (!got_immediate_termination_signal(termination_signal_ptr)) {
         for (size_t i = 0; i < NUM_ITERS_BETWEEN_TEARDOWN_CHECKS; i++) {

--- a/tt_metal/fabric/impl/kernels/edm_fabric/fabric_router_udm_mux_extension.cpp
+++ b/tt_metal/fabric/impl/kernels/edm_fabric/fabric_router_udm_mux_extension.cpp
@@ -252,16 +252,8 @@ void forward_data(
         invalidate_l1_cache();
         auto packet_header = reinterpret_cast<volatile tt_l1_ptr PACKET_HEADER_TYPE*>(buffer_address);
 
-        // TODO: once we group the channels into udm-worker, relay-mux, mux-mux, then we only need to check the
-        // directions for the udm-worker channels.
-        // if (is_persistent_channel) {
-        //     fabric_connection.wait_for_empty_write_slot();
-        //     fabric_connection.send_payload_flush_non_blocking_from_address(
-        //         (uint32_t)packet_header, packet_header->get_payload_size_including_header());
-        // } else {
         tt::tt_fabric::udm::forward_to_downstream_mux_or_local_router<Direction>(
             packet_header, fabric_connection, downstream_mux_connections);
-        // }
 
         worker_interface.local_write_counter.increment();
         worker_interface.local_read_counter.increment();

--- a/tt_metal/fabric/impl/kernels/edm_fabric/fabric_router_udm_mux_extension.cpp
+++ b/tt_metal/fabric/impl/kernels/edm_fabric/fabric_router_udm_mux_extension.cpp
@@ -265,7 +265,11 @@ void forward_data(
 
         noc_async_writes_flushed();
 
-        worker_interface.notify_worker_of_read_counter_update();
+        if (is_persistent_channel) {
+            worker_interface.notify_worker_of_read_counter_update();
+        } else if (channel_connection_established) {
+            worker_interface.notify_worker_of_read_counter_update();
+        }
     }
 
     if (!is_persistent_channel) {

--- a/tt_metal/fabric/impl/kernels/edm_fabric/fabric_router_udm_mux_extension.cpp
+++ b/tt_metal/fabric/impl/kernels/edm_fabric/fabric_router_udm_mux_extension.cpp
@@ -58,6 +58,8 @@ namespace tt::tt_fabric {
 using FabricMuxToEdmSender = WorkerToFabricEdmSenderImpl<false, NUM_EDM_BUFFERS>;
 }  // namespace tt::tt_fabric
 
+static_assert(noc_index == 0, "Mux kernel requires noc_index to be 0 so relay kernel can use 1");
+
 template <uint8_t NUM_BUFFERS>
 void wait_for_static_connection_to_ready(
     tt::tt_fabric::FabricMuxStaticSizedChannelWorkerInterface<NUM_BUFFERS>& worker_interface) {


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/31709)

### Problem description

Current flat channels inside the mux (worker, mux-mux, relay-mux are all in the same flatten array) is not scalable, need to change that 

relay previously not supporting sending response back, need to add support.

when relay sends back read/write response, it needs to follow the dimensional order (NS->EW), so it might not follow the reverse path of the read/write request. Need to forward to correct mux/router endpoint first.

When worker sends read/write requests to mux, each kernel will have dedicated mux endpoint, that means mux need to forward to the other muxes, if the target router endpoint is not local router.

### What's changed
change to channel type based arrays in mux kernel, on host we have worker, router, mux-mux, relay-mux channel types, based on different extension mode, mux will have different channels allocated.

Add memory pool in relay to store the read response before sending it back, add send write/read response logic.

Add mux-mux and relay-mux channels into mux kernel, add adaptors in mux and relay kernel for forwarding packets.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes
