### PR TITLE
[DM] Porting unary dram primitive to 2.0 API + one to one read me fixes

### DIFF
--- a/tests/tt_metal/tt_metal/data_movement/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/README.md
@@ -31,7 +31,7 @@ Both API versions run the same test cases but use different underlying implement
 
 | Name                        | ID(s)                           | Description                                                                             |
 | ----------                  | -----                           | ----------------------------------------------------                                    |
-| DRAM Unary                  | 0-3                             | Transactions between DRAM and a single Tensix core.                                     |
+| DRAM Unary                  | 0-3, 40                         | Transactions between DRAM and a single Tensix core.                                     |
 | One to One                  | 4, 50, 150-151, 158             | Write transactions between two Tensix cores.                                            |
 | One From One                | 5, 51, 152-153, 159             | Read transactions between two Tensix cores.                                             |
 | One to all                  | 6-8, 52, 154-155, 170-172       | Writes transaction from one core to all cores.                                          |

--- a/tests/tt_metal/tt_metal/data_movement/dram_unary/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/dram_unary/README.md
@@ -56,4 +56,4 @@ This test suite now includes tests using the new device 2.0 experimental NOC API
 
 ### Device 2.0 Kernels:
 - `writer_unary_2_0.cpp`: Implements the writer functionality using the experimental NOC API
-- `reader_unary_2_0.cpp`: Implements the writer functionality using the experimental NOC API
+- `reader_unary_2_0.cpp`: Implements the reader functionality using the experimental NOC API

--- a/tests/tt_metal/tt_metal/data_movement/dram_unary/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/dram_unary/README.md
@@ -30,15 +30,30 @@ The tests use the Mesh Device API with fast dispatch mode:
 | l1_data_format                | DataFormat            | Data format of data that will be moved. |
 | core_coord                    | CoreCoord             | Logical coordinates for the Tensix core. |
 | dram_channel                  | uint32_t              | Specifies which DRAM channel to use for the test. |
+| virtual_channel               | uint32_t              | Option to specify unicast VC for each transaction. |
+| use_2_0_api                   | bool                  | Determines if the test uses the experimental device 2.0 API. |
 
 ## Test Cases
 Each test case uses bfloat16 as L1 data format and flit size (32B for WH, 64B for BH) as page size.
 Each test case has multiple runs, and each run has a unique runtime host id, assigned by a global counter.
 
-1. **DRAM Packet Sizes**: Tests different number of transactions and transaction sizes by varying the num_of_transactions and pages_per_transaction parameters. Various packet configurations are tested between DRAM and Tensix core.
+1. **TensixDataMovementDRAMPacketSizes** (Test ID: 0) - Tests different number of transactions and transaction sizes by varying the num_of_transactions and pages_per_transaction parameters. Various packet configurations are tested between DRAM and Tensix core.
 
-2. **DRAM Core Locations**: Tests data movement between DRAM and different Tensix core locations to evaluate performance across various core positions on the chip.
+2. **TensixDataMovementDRAMCoreLocations** (Test ID: 1) - Tests data movement between DRAM and different Tensix core locations to evaluate performance across various core positions on the chip.
 
-3. **DRAM Channels**: Tests data movement using different DRAM channels to evaluate bandwidth utilization across multiple memory interfaces.
+3. **TensixDataMovementDRAMChannels** (Test ID: 2) - Tests data movement using different DRAM channels to evaluate bandwidth utilization across multiple memory interfaces.
 
-4. **DRAM Directed Ideal**: Tests the most optimal data movement setup between DRAM and a Tensix core that maximizes the transaction size and performs enough transactions to amortize initialization overhead.
+4. **TensixDataMovementDRAMDirectedIdeal** (Test ID: 3) - Tests the most optimal data movement setup between DRAM and a Tensix core that maximizes the transaction size and performs enough transactions to amortize initialization overhead.
+
+5. **TensixDataMovementDRAMPacketSizes2_0** (Test ID: 40) - Device 2.0 API version of the packet sizes test. Tests the same packet size variations as test ID 0 but uses the experimental NOC API with structured endpoints and virtual channel support.
+
+## Device 2.0 API Tests
+This test suite now includes tests using the new device 2.0 experimental NOC API. These tests provide the same functionality as the original tests but use an updated API design:
+
+### Key Features of Device 2.0 API Tests:
+- **Experimental NOC API**: Uses `experimental::Noc`, `experimental::UnicastEndpoint`, `experimental::Semaphore` and `experimental::AllocatorBankType` for structured NOC operations
+- **Structured Arguments**: Source and destination arguments are defined using structured `noc_traits_t` types
+
+### Device 2.0 Kernels:
+- `writer_unary_2_0.cpp`: Implements the writer functionality using the experimental NOC API
+- `reader_unary_2_0.cpp`: Implements the writer functionality using the experimental NOC API

--- a/tests/tt_metal/tt_metal/data_movement/dram_unary/kernels/reader_unary_2_0.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/dram_unary/kernels/reader_unary_2_0.cpp
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dataflow_api.h"
+
+// DRAM to L1 read
+void kernel_main() {
+    constexpr uint32_t test_id = get_compile_time_arg_val(0);
+    constexpr uint32_t num_of_transactions = get_compile_time_arg_val(1);
+    constexpr uint32_t pages_per_transaction = get_compile_time_arg_val(2);
+    constexpr uint32_t bytes_per_page = get_compile_time_arg_val(3);
+    constexpr uint32_t dram_addr = get_compile_time_arg_val(4);
+    constexpr uint32_t dram_channel = get_compile_time_arg_val(5);
+    constexpr uint32_t local_l1_addr = get_compile_time_arg_val(6);
+    constexpr uint32_t sem_id = get_compile_time_arg_val(7);
+
+    constexpr uint32_t bytes_per_transaction = pages_per_transaction * bytes_per_page;
+
+    experimental::Noc noc(noc_index);
+    experimental::UnicastEndpoint unicast_endpoint;
+    experimental::Semaphore semaphore(sem_id);
+    constexpr experimental::AllocatorBankType bank_type = experimental::AllocatorBankType::DRAM;
+
+    {
+        DeviceZoneScopedN("RISCV1");
+        for (uint32_t i = 0; i < num_of_transactions; i++) {
+            noc.async_read(
+                experimental::AllocatorBank<bank_type>(),
+                unicast_endpoint,
+                bytes_per_transaction,
+                {
+                    .bank_id = dram_channel,
+                    .addr = dram_addr,
+                },
+                {
+                    .addr = local_l1_addr,
+                });
+        }
+        noc.async_read_barrier();
+    }
+
+    // Set the semaphore to indicate that the writer can proceed
+    semaphore.set(1);
+
+    DeviceTimestampedData("Test id", test_id);
+
+    DeviceTimestampedData("Number of transactions", num_of_transactions);
+    DeviceTimestampedData("Transaction size in bytes", bytes_per_transaction);
+}

--- a/tests/tt_metal/tt_metal/data_movement/dram_unary/kernels/writer_unary_2_0.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/dram_unary/kernels/writer_unary_2_0.cpp
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dataflow_api.h"
+#include "dataflow_api_common.h"
+
+// L1 to DRAM write
+void kernel_main() {
+    constexpr uint32_t test_id = get_compile_time_arg_val(0);
+    constexpr uint32_t num_of_transactions = get_compile_time_arg_val(1);
+    constexpr uint32_t pages_per_transaction = get_compile_time_arg_val(2);
+    constexpr uint32_t bytes_per_page = get_compile_time_arg_val(3);
+    constexpr uint32_t dram_addr = get_compile_time_arg_val(4);
+    constexpr uint32_t dram_channel = get_compile_time_arg_val(5);
+    constexpr uint32_t local_l1_addr = get_compile_time_arg_val(6);
+    constexpr uint32_t sem_id = get_compile_time_arg_val(7);
+    constexpr uint32_t virtual_channel = get_compile_time_arg_val(8);
+
+    constexpr uint32_t bytes_per_transaction = pages_per_transaction * bytes_per_page;
+
+    experimental::Noc noc(noc_index);
+    experimental::UnicastEndpoint unicast_endpoint;
+    experimental::Semaphore semaphore(sem_id);
+    constexpr experimental::AllocatorBankType bank_type = experimental::AllocatorBankType::DRAM;
+
+    // Wait for semaphore to be set by the reader
+    semaphore.down(1);
+
+    {
+        DeviceZoneScopedN("RISCV0");
+        for (uint32_t i = 0; i < num_of_transactions; i++) {
+            noc.async_write(
+                unicast_endpoint,
+                experimental::AllocatorBank<bank_type>(),
+                bytes_per_transaction,
+                {
+                    .addr = local_l1_addr,
+                },
+                {
+                    .bank_id = dram_channel,
+                    .addr = dram_addr,
+                },
+                virtual_channel);
+        }
+        noc.async_write_barrier();
+    }
+
+    DeviceTimestampedData("Test id", test_id);
+
+    DeviceTimestampedData("Number of transactions", num_of_transactions);
+    DeviceTimestampedData("Transaction size in bytes", bytes_per_transaction);
+
+    DeviceTimestampedData("DRAM Channel", dram_channel);
+    DeviceTimestampedData("Virtual Channel", virtual_channel);
+}

--- a/tests/tt_metal/tt_metal/data_movement/dram_unary/test_unary_dram.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/dram_unary/test_unary_dram.cpp
@@ -27,6 +27,7 @@ struct DramConfig {
     CoreCoord core_coord = {0, 0};
     uint32_t dram_channel = 0;
     uint32_t virtual_channel = 0;
+    bool use_2_0_api = false;  // Use Device 2.0 API
 };
 
 /// @brief Does Dram --> Reader --> L1 CB --> Writer --> Dram.
@@ -84,9 +85,19 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const DramCo
         (uint32_t)test_config.virtual_channel};
 
     // Kernels
+    std::string kernels_dir = "tests/tt_metal/tt_metal/data_movement/dram_unary/kernels/";
+    std::string reader_kernel_filename = "reader_unary";
+    std::string writer_kernel_filename = "writer_unary";
+    if (test_config.use_2_0_api) {
+        reader_kernel_filename += "_2_0";
+        writer_kernel_filename += "_2_0";
+    }
+    std::string reader_kernel_path = kernels_dir + reader_kernel_filename + ".cpp";
+    std::string writer_kernel_path = kernels_dir + writer_kernel_filename + ".cpp";
+
     CreateKernel(
         program,
-        "tests/tt_metal/tt_metal/data_movement/dram_unary/kernels/reader_unary.cpp",
+        reader_kernel_path,
         test_config.core_coord,
         DataMovementConfig{
             .processor = DataMovementProcessor::RISCV_1,
@@ -95,7 +106,7 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const DramCo
 
     CreateKernel(
         program,
-        "tests/tt_metal/tt_metal/data_movement/dram_unary/kernels/writer_unary.cpp",
+        writer_kernel_path,
         test_config.core_coord,
         DataMovementConfig{
             .processor = DataMovementProcessor::RISCV_0,
@@ -186,7 +197,8 @@ void packet_sizes_test(
     const shared_ptr<distributed::MeshDevice>& mesh_device,
     uint32_t test_case_id,
     CoreCoord core_coord = {0, 0},
-    uint32_t dram_channel = 0) {
+    uint32_t dram_channel = 0,
+    bool use_2_0_api = false) {
     auto [bytes_per_page, max_reservable_bytes, max_reservable_pages] =
         unit_tests::dm::compute_physical_constraints(mesh_device);
 
@@ -209,7 +221,9 @@ void packet_sizes_test(
                 .bytes_per_page = bytes_per_page,
                 .l1_data_format = DataFormat::Float16_b,
                 .core_coord = core_coord,
-                .dram_channel = dram_channel};
+                .dram_channel = dram_channel,
+                .virtual_channel = 0,
+                .use_2_0_api = use_2_0_api};
 
             // Run
             EXPECT_TRUE(run_dm(mesh_device, test_config));
@@ -275,6 +289,17 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementDRAMDirectedIdeal) {
     uint32_t test_id = 3;
 
     unit_tests::dm::dram::directed_ideal_test(get_mesh_device(), test_id);
+}
+
+/* ========== Test case for varying transaction numbers and sizes with 2.0 API; Test id = 40 ========== */
+TEST_F(GenericMeshDeviceFixture, TensixDataMovementDRAMPacketSizes2_0) {
+    unit_tests::dm::dram::packet_sizes_test(
+        get_mesh_device(),
+        40,      // Test case ID
+        {0, 0},  // Core coordinates (default)
+        0,       // DRAM channel (default)
+        true     // Use 2.0 API
+    );
 }
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/data_movement/one_to_one/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/one_to_one/README.md
@@ -30,9 +30,9 @@ The tests use the Mesh Device API with fast dispatch mode:
 | pages_per_transaction     | uint32_t              | Size of the issued noc transactions in pages. |
 | bytes_per_page            | uint32_t              | Size of a page in bytes. Arbitrary value with a minimum of flit size per architecture. |
 | l1_data_format            | DataFormat            | Data format data that will be moved. |
-| virtual_channel           | N/A                   | (1) Option to specify unicast VC for each transaction, (2) Option for a sub-test that uses a separate VC for each transaction (TODO)|
-| noc                       | N/A                   | Specify which NOC to use for the test, (1) Use only one specified NOC, (2) Use both NOCs (TODO)|
-| posted                    | N/A                   | Posted flag. Determines if write is posted or non-posted (TODO)|
+| num_virtual_channels      | uint32_t              | Number of virtual channels to cycle through (must be > 1 for cycling). |
+| noc_id                    | NOC                   | Specify which NOC to use for the test. |
+| use_2_0_api               | bool                  | Determines if the test uses the experimental device 2.0 API. |
 
 ## Test Cases
 Each test case uses bfloat16 as L1 data format and flit size (32B for WH, 64B for BH) as page size.

--- a/tests/tt_metal/tt_metal/data_movement/python/test_mappings/test_information.yaml
+++ b/tests/tt_metal/tt_metal/data_movement/python/test_mappings/test_information.yaml
@@ -119,6 +119,9 @@ tests:
   30:
     name: "One from All Directed Ideal"
 
+  40:
+    name: "DRAM Packet Sizes 2.0"
+
   50:
     name: "One to One Directed Ideal"
 


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/orgs/tenstorrent/projects/135/views/10?pane=issue&itemId=135814059&issue=tenstorrent%7Ctt-metal%7C31236)

### Problem description
There are new Databuffer APIs for Metal 2.0 here: https://github.com/tenstorrent/tt-metal/blob/main/tt_metal/hw/inc/dataflow_api.h#L2360

### What's changed
List of tests this PR ports to new APIs:

Dram unary (has semaphore sets + interleaved reads)

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [x] [(TM-DM) Data Movement Test Suit](https://github.com/tenstorrent/tt-metal/actions/workflows/tm-data-movement-wrapper.yaml)