### PR TITLE
Fix topk hang caused by Qwen3-32B shapes on BH LB

### DIFF
--- a/tests/ttnn/unit_tests/operations/reduce/test_topk.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_topk.py
@@ -89,6 +89,7 @@ def run_topk_test(N, C, H, W, k, dtype, dim, sorted, largest, device, sub_core_g
         (1, 1, 32, 8192, 3, 6),  # passed
         (1, 2048, 1, 64, 1, 8),  # passed
         (1, 1, 32, 32768, 3, 3000),  # passed
+        (1, 1, 32, 18992, 3, 3000),  # passed
     ),
 )
 @pytest.mark.parametrize(

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/compute/topk_common_funcs.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/compute/topk_common_funcs.hpp
@@ -19,6 +19,7 @@ void process_and_sort_tiles(
     for (uint32_t wt = 0; wt < Wt; wt += 2) {
         acquire_dst();
         // local sort into k groups
+        // for the last iteration, we only need to wait for 1 tile if Wt is odd, otherwise we wait for 2 tiles
         uint32_t tiles_to_wait = ((Wt % 2 != 0) && (wt + 2 > Wt)) ? 1 : 2;
         cb_wait_front(input_cb_index, tiles_to_wait);
         cb_wait_front(index_cb_index, tiles_to_wait);

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/compute/topk_common_funcs.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/compute/topk_common_funcs.hpp
@@ -19,34 +19,38 @@ void process_and_sort_tiles(
     for (uint32_t wt = 0; wt < Wt; wt += 2) {
         acquire_dst();
         // local sort into k groups
-        cb_wait_front(input_cb_index, 2);
-        cb_wait_front(index_cb_index, 2);
+        uint32_t tiles_to_wait = ((Wt % 2 != 0) && (wt + 2 > Wt)) ? 1 : 2;
+        cb_wait_front(input_cb_index, tiles_to_wait);
+        cb_wait_front(index_cb_index, tiles_to_wait);
 
         reconfig_data_format_srca(input_cb_index);
         transpose_wh_init_short(input_cb_index);
         transpose_wh_tile(input_cb_index, 0, 0);
-        transpose_wh_tile(input_cb_index, 1, 1);
-
+        if (tiles_to_wait == 2) {
+            transpose_wh_tile(input_cb_index, 1, 1);
+        }
         reconfig_data_format_srca(index_cb_index);
         transpose_wh_init_short(index_cb_index);
         transpose_wh_tile(index_cb_index, 0, 2);
-        transpose_wh_tile(index_cb_index, 1, 3);
-
+        if (tiles_to_wait == 2) {
+            transpose_wh_tile(index_cb_index, 1, 3);
+        }
         // llk_topk_sort -> inplace
         ckernel::topk_local_sort(0, (int)ascending, end_phase);
-
         // pack value tiles into cb_intermed0
         pack_reconfig_data_format(input_transposed_cb_index);
         pack_tile(0, input_transposed_cb_index);
-        pack_tile(1, input_transposed_cb_index);
-
+        if (tiles_to_wait == 2) {
+            pack_tile(1, input_transposed_cb_index);
+        }
         // pack index tiles into cb_intermed1
         pack_reconfig_data_format(index_transposed_cb_index);
         pack_tile(2, index_transposed_cb_index);
-        pack_tile(3, index_transposed_cb_index);
-
-        cb_pop_front(input_cb_index, 2);
-        cb_pop_front(index_cb_index, 2);
+        if (tiles_to_wait == 2) {
+            pack_tile(3, index_transposed_cb_index);
+        }
+        cb_pop_front(input_cb_index, tiles_to_wait);
+        cb_pop_front(index_cb_index, tiles_to_wait);
         release_dst();
         ascending = switch_dir ? !ascending : ascending;
     }


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/32821

### Problem description
There was a hang in topk for specifically Qwen 3 32B shapes on BH LB, the hypothesized reason for the hang was the following:
- the op first pads the vocab size from 18992 to 19008 (now divisble by 64) then splits it across 66 cores for my case, so each core has 9 tiles
- the reader pushes tiles 1 at a time for 9 times, but the compute for some reason iterates and waits 2 tiles at a time uptil 9tiles so it will essentially loop 5 times but on the last iteration there is only 1 tile pushed so its waiting for 2 tiles when only 1 tile is pushed, so the fix was to only wait for 1 tile on the last iteration and when the Wt assigned to that core isnt divisble by 2

### What's changed
- mentioned above
- faulty unit test provided in the issue is no longer hanging, ran full model demo and there was no hang and has good outputs
- added Qwen shape to unit test with k=3000, pcc is passing

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/19715759253) CI passes