### PR TITLE
[skip ci] Move impl of GraphTracer::instance to cpp

### DIFF
--- a/tt_metal/api/tt-metalium/graph_tracking.hpp
+++ b/tt_metal/api/tt-metalium/graph_tracking.hpp
@@ -93,10 +93,7 @@ public:
     GraphTracker(const GraphTracker&) = delete;
     GraphTracker(GraphTracker&&) = delete;
 
-    static GraphTracker& instance() {
-        static GraphTracker tracker;
-        return tracker;
-    }
+    static GraphTracker& instance();
 
     bool is_enabled() const;
 

--- a/tt_metal/graph/graph_tracking.cpp
+++ b/tt_metal/graph/graph_tracking.cpp
@@ -15,6 +15,11 @@ class IDevice;
 
 namespace tt::tt_metal {
 
+GraphTracker& GraphTracker::instance() {
+    static GraphTracker tracker;
+    return tracker;
+}
+
 bool GraphTracker::is_enabled() const { return (not processors.empty()); }
 
 void GraphTracker::push_processor(const std::shared_ptr<IGraphProcessor>& new_processor) {


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/33273

### Problem description
Every consumer of shared lib gets their own copy of tracker instance, resulting in odr

### What's changed
Move impl to cpp so that object stays in data section of the main library and does not get duplicated in consumers.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/19713842362)