### PR TITLE
#0: Add transpose_within_face to copy_tile_to_dst_init_short

### DIFF
--- a/docs/source/tt-metalium/tt_metal/apis/kernel_apis/pack_unpack/copy_tile.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/kernel_apis/pack_unpack/copy_tile.rst
@@ -6,4 +6,4 @@ copy_tile
 .. doxygenfunction:: copy_tile_init(uint32_t cbid)
 .. doxygenfunction:: copy_tile(uint32_t in_cb_id, uint32_t in_tile_index, uint32_t dst_tile_index)
 .. doxygenfunction:: copy_tile_to_dst_init_short_with_dt(uint32_t old_cbid, uint32_t new_cbid, uint32_t transpose = 0)
-.. doxygenfunction:: copy_tile_to_dst_init_short(uint32_t cbid, uint32_t transpose = 0, bool transpose_within_16x16_face = false)
+.. doxygenfunction:: copy_tile_to_dst_init_short(uint32_t cbid, uint32_t transpose = 0, uint32_t transpose_within_16x16_face = 0)

--- a/docs/source/tt-metalium/tt_metal/apis/kernel_apis/pack_unpack/copy_tile.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/kernel_apis/pack_unpack/copy_tile.rst
@@ -6,4 +6,4 @@ copy_tile
 .. doxygenfunction:: copy_tile_init(uint32_t cbid)
 .. doxygenfunction:: copy_tile(uint32_t in_cb_id, uint32_t in_tile_index, uint32_t dst_tile_index)
 .. doxygenfunction:: copy_tile_to_dst_init_short_with_dt(uint32_t old_cbid, uint32_t new_cbid, uint32_t transpose = 0)
-.. doxygenfunction:: copy_tile_to_dst_init_short(uint32_t cbid, uint32_t transpose = 0)
+.. doxygenfunction:: copy_tile_to_dst_init_short(uint32_t cbid, uint32_t transpose = 0, bool transpose_within_16x16_face = false)

--- a/tt_metal/include/compute_kernel_api/tile_move_copy.h
+++ b/tt_metal/include/compute_kernel_api/tile_move_copy.h
@@ -24,10 +24,11 @@ namespace ckernel {
  * |-------------|---------------------------------------------------|----------|----------------------------------------------------|----------|
  * | cbid        | The identifier of the input circular buffer (CB)  | uint32_t | 0 to 31                                            | False    |
  * | transpose   | Flag to perform transpose on SrcA                 | uint32_t | Any positive value will indicate tranpose is set   | False    |
- * | transpose_within_16x16_face | Flag to perform transpose within 16x16 face | bool     | True if transpose within 16x16 face is set        | False    |
+ * | transpose_within_16x16_face | Flag to perform transpose within 16x16 face | uint32_t | Any positive value will indicate transpose within 16x16 face is set        | False    |
  */
 // clang-format on
-ALWI void copy_tile_to_dst_init_short(uint32_t cbid, uint32_t transpose = 0, bool transpose_within_16x16_face = false) {
+ALWI void copy_tile_to_dst_init_short(
+    uint32_t cbid, uint32_t transpose = 0, uint32_t transpose_within_16x16_face = false) {
     UNPACK((llk_unpack_A_init<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, UnpackToDestEn>(
         transpose, transpose_within_16x16_face, cbid)));
     MATH((llk_math_eltwise_unary_datacopy_init<A2D, DST_ACCUM_MODE, BroadcastType::NONE>(

--- a/tt_metal/include/compute_kernel_api/tile_move_copy.h
+++ b/tt_metal/include/compute_kernel_api/tile_move_copy.h
@@ -24,11 +24,12 @@ namespace ckernel {
  * |-------------|---------------------------------------------------|----------|----------------------------------------------------|----------|
  * | cbid        | The identifier of the input circular buffer (CB)  | uint32_t | 0 to 31                                            | False    |
  * | transpose   | Flag to perform transpose on SrcA                 | uint32_t | Any positive value will indicate tranpose is set   | False    |
+ * | transpose_within_16x16_face | Flag to perform transpose within 16x16 face | bool     | True if transpose within 16x16 face is set        | False    |
  */
 // clang-format on
-ALWI void copy_tile_to_dst_init_short(uint32_t cbid, uint32_t transpose = 0) {
+ALWI void copy_tile_to_dst_init_short(uint32_t cbid, uint32_t transpose = 0, bool transpose_within_16x16_face = false) {
     UNPACK((llk_unpack_A_init<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, UnpackToDestEn>(
-        transpose, false /*transpose within 16x16 face*/, cbid)));
+        transpose, transpose_within_16x16_face, cbid)));
     MATH((llk_math_eltwise_unary_datacopy_init<A2D, DST_ACCUM_MODE, BroadcastType::NONE>(
         false /*transpose of faces*/, false /*transpose within 16x16 face*/, cbid)));
 }


### PR DESCRIPTION
### Ticket
N/A

### Problem description
copy_tile_to_dst_init_short can't transpose within 16x16 face. This is needed to optimize SDPA perf where we need to maintain face layout within a tile, but transpose datums within faces, to prepare for reduction after copy_tile modified in that way.

### What's changed
Added a flag to copy_tile_to_dst_init_short to enable transpose within face, without changing face layout within a tile.

reduce_c will then call this as copy_tile_to_dst_init_short(prev_max_cb, false, true);

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes