### PR TITLE
Lazily load DeepSeek V3 state_dict via LazyStateDict

### DIFF
--- a/models/demos/deepseek_v3/tests/test_lazy_state_dict.py
+++ b/models/demos/deepseek_v3/tests/test_lazy_state_dict.py
@@ -282,6 +282,9 @@ def test_cache_reuse_across_views_single_open(tmp_path: Path, monkeypatch: pytes
     # Access via prefixed view
     sub = sub_state_dict(state, "model.layers.0.")
     _ = sub["w"]
+    # Views must share underlying structures (no copying of cache or index)
+    assert sub._cache is state._cache
+    assert sub._full_to_file is state._full_to_file
     assert open_counts.get(file1.name, 0) == 1
 
 

--- a/models/demos/deepseek_v3/tests/test_lazy_state_dict.py
+++ b/models/demos/deepseek_v3/tests/test_lazy_state_dict.py
@@ -1,0 +1,118 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import importlib
+import json
+from pathlib import Path
+
+import pytest
+import safetensors.torch
+import torch
+
+from models.demos.deepseek_v3.utils.config_helpers import get_state_dicts, sub_state_dict
+from models.demos.deepseek_v3.utils.test_utils import load_state_dict
+
+
+def _write_index(model_dir: Path, weight_map: dict[str, str]) -> None:
+    index = {"metadata": {}, "weight_map": weight_map}
+    (model_dir / "model.safetensors.index.json").write_text(json.dumps(index))
+
+
+def test_lazy_state_dict_access_single_key(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    model_dir = tmp_path / "model"
+    model_dir.mkdir(parents=True, exist_ok=True)
+
+    # Create two safetensors files with disjoint keys
+    file1 = model_dir / "model-00001-of-00002.safetensors"
+    file2 = model_dir / "model-00002-of-00002.safetensors"
+    t1 = torch.randn(2, 3, dtype=torch.bfloat16)
+    t2 = torch.randn(4, 5, dtype=torch.bfloat16)
+    safetensors.torch.save_file({"w1": t1}, str(file1))
+    safetensors.torch.save_file({"w2": t2}, str(file2))
+    _write_index(model_dir, {"w1": file1.name, "w2": file2.name})
+
+    # Count safetensors.safe_open calls
+    lsd = importlib.import_module("models.demos.deepseek_v3.utils.lazy_state_dict")
+    open_counts: dict[str, int] = {}
+    original_safe_open = lsd.safe_open
+
+    def counting_safe_open(path, *args, **kwargs):
+        name = Path(path).name
+        open_counts[name] = open_counts.get(name, 0) + 1
+        return original_safe_open(path, *args, **kwargs)
+
+    monkeypatch.setattr(lsd, "safe_open", counting_safe_open, raising=True)
+
+    # Lazily load and access only one key
+    state = load_state_dict(model_dir, "")
+    v1 = state["w1"]
+    assert torch.equal(v1, t1)
+    assert open_counts.get(file1.name, 0) == 1
+    assert open_counts.get(file2.name, 0) == 0
+
+
+def test_lazy_sub_state_dict_prefix(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    model_dir = tmp_path / "model"
+    model_dir.mkdir(parents=True, exist_ok=True)
+
+    file1 = model_dir / "model-00001-of-00002.safetensors"
+    file2 = model_dir / "model-00002-of-00002.safetensors"
+    t_0_foo = torch.randn(2, 2)
+    t_0_bar = torch.randn(1, 3)
+    t_1_foo = torch.randn(3, 1)
+    safetensors.torch.save_file(
+        {"model.layers.0.foo": t_0_foo, "model.layers.0.bar": t_0_bar},
+        str(file1),
+    )
+    safetensors.torch.save_file({"model.layers.1.foo": t_1_foo}, str(file2))
+    _write_index(
+        model_dir,
+        {
+            "model.layers.0.foo": file1.name,
+            "model.layers.0.bar": file1.name,
+            "model.layers.1.foo": file2.name,
+        },
+    )
+
+    lsd = importlib.import_module("models.demos.deepseek_v3.utils.lazy_state_dict")
+    open_counts: dict[str, int] = {}
+    original_safe_open = lsd.safe_open
+
+    def counting_safe_open(path, *args, **kwargs):
+        name = Path(path).name
+        open_counts[name] = open_counts.get(name, 0) + 1
+        return original_safe_open(path, *args, **kwargs)
+
+    monkeypatch.setattr(lsd, "safe_open", counting_safe_open, raising=True)
+
+    state = load_state_dict(model_dir, "")
+    sub = sub_state_dict(state, "model.layers.0.")
+    keys = sorted(list(sub.keys()))
+    assert keys == ["bar", "foo"]
+
+    # Access one value; only file1 is opened
+    v = sub["foo"]
+    assert torch.equal(v, t_0_foo)
+    assert open_counts.get(file1.name, 0) == 1
+    assert open_counts.get(file2.name, 0) == 0
+
+
+def test_get_state_dicts_integration(tmp_path: Path):
+    model_dir = tmp_path / "model"
+    model_dir.mkdir(parents=True, exist_ok=True)
+
+    file1 = model_dir / "model-00001-of-00001.safetensors"
+    key_full = "model.layers.0.k"
+    t = torch.randn(2, 2, dtype=torch.float32)
+    safetensors.torch.save_file({key_full: t}, str(file1))
+    _write_index(model_dir, {key_full: file1.name})
+
+    state = load_state_dict(model_dir, "")
+    sub = sub_state_dict(state, "model.layers.0.")
+
+    out = get_state_dicts((sub,), "k", shape=(2, 2), dtype=torch.float32)
+    assert out.shape == (1, 2, 2)
+    assert torch.equal(out[0], t)

--- a/models/demos/deepseek_v3/utils/config_helpers.py
+++ b/models/demos/deepseek_v3/utils/config_helpers.py
@@ -15,6 +15,7 @@ from transformers.configuration_utils import PretrainedConfig
 
 import ttnn
 from models.demos.deepseek_v3.utils.config_dataclass import SavedWeight
+from models.demos.deepseek_v3.utils.lazy_state_dict import LazyStateDict
 from models.demos.deepseek_v3.utils.run_config import WeightConfig
 
 # Constants
@@ -575,8 +576,8 @@ def get_state_dicts(
 
 def sub_state_dict(state_dict: dict[str, torch.Tensor], prefix: str, num_layers: int | None = None):
     """Get a subset of the state dict with a given prefix."""
-    # If this is a lazy state dict (or compatible), return a lazy view to preserve laziness.
-    if hasattr(state_dict, "view_with_prefix"):
+    # Preserve laziness when applicable by returning a LazyStateDict view.
+    if isinstance(state_dict, LazyStateDict):
         return state_dict.view_with_prefix(prefix, num_layers)
     if num_layers is None:
         return {k[len(prefix) :]: v for k, v in state_dict.items() if k.startswith(prefix)}

--- a/models/demos/deepseek_v3/utils/config_helpers.py
+++ b/models/demos/deepseek_v3/utils/config_helpers.py
@@ -575,6 +575,9 @@ def get_state_dicts(
 
 def sub_state_dict(state_dict: dict[str, torch.Tensor], prefix: str, num_layers: int | None = None):
     """Get a subset of the state dict with a given prefix."""
+    # If this is a lazy state dict (or compatible), return a lazy view to preserve laziness.
+    if hasattr(state_dict, "view_with_prefix"):
+        return state_dict.view_with_prefix(prefix, num_layers)
     if num_layers is None:
         return {k[len(prefix) :]: v for k, v in state_dict.items() if k.startswith(prefix)}
     else:

--- a/models/demos/deepseek_v3/utils/lazy_state_dict.py
+++ b/models/demos/deepseek_v3/utils/lazy_state_dict.py
@@ -15,9 +15,16 @@ from safetensors import safe_open
 
 class LazyStateDict(Mapping[str, torch.Tensor]):
     """
-    Mapping-like view over HuggingFace safetensors weights that loads tensors lazily on access.
+    Mapping-like view over HuggingFace safetensors that loads tensors lazily on access.
 
-    Keys are exposed relative to the configured base prefix. Values are cached after first access.
+    Invariants and behavior:
+    - Keys exposed by the mapping are trimmed by the configured base prefix; internally we keep
+      the full HuggingFace key.
+    - Tensors are loaded lazily on first access and cached; the cache is shared across views and
+      keyed by the full parameter name to avoid collisions across prefixes while allowing reuse
+      of identical parameters accessed through different views.
+    - The mapping is read-only and assumes the index file and weight files do not change during
+      the process lifetime.
     """
 
     def __init__(
@@ -31,19 +38,34 @@ class LazyStateDict(Mapping[str, torch.Tensor]):
     ):
         self._model_path = Path(model_path)
         self._base_prefix = base_prefix
+
+        # If _full_to_file is provided then we are a now a view ofthe original LazyStateDict.
         if _full_to_file is None:
             index_path = self._model_path / "model.safetensors.index.json"
-            weight_map = json.load(index_path.open("r"))["weight_map"]
-            self._full_to_file = dict(weight_map)
+            if not index_path.is_file():
+                raise ValueError(f"Unable to find index file at {index_path}. Is the model path correct?")
+            try:
+                with index_path.open("r", encoding="utf-8") as f:
+                    index_obj = json.load(f)
+            except Exception as e:
+                raise ValueError(f"Failed to parse index JSON at {index_path}: {e}") from e
+            self._full_to_file = dict(index_obj["weight_map"])
         else:
             self._full_to_file = _full_to_file
         self._cache: dict[str, torch.Tensor] = {} if _cache is None else _cache
         self._num_layers: Optional[int] = _num_layers
 
-    def view_with_prefix(self, prefix: str, num_layers: int | None = None) -> "LazyStateDict":
+    def view_with_prefix(self, prefix: str, num_layers: Optional[int] = None) -> "LazyStateDict":
         """
         Return a new LazyStateDict view narrowed to keys under base_prefix + prefix.
-        Values cache is shared between views.
+
+        - Keys yielded by the view are trimmed by the combined prefix (i.e., callers
+          see keys relative to base_prefix + prefix).
+        - If num_layers is provided, the view only exposes keys whose layer index
+          parsed from \"model.layers.<idx>.…\" is strictly less than num_layers.
+        - The underlying cache is shared across views and is keyed by the full key
+          (the original HuggingFace parameter name), preventing collisions across
+          different prefixes while allowing reuse for the same full key.
         """
         combined_prefix = self._base_prefix + prefix
         return LazyStateDict(
@@ -60,42 +82,49 @@ class LazyStateDict(Mapping[str, torch.Tensor]):
     def _passes_layer_filter(self, full_key: str) -> bool:
         if self._num_layers is None:
             return True
-        if full_key.startswith("model.layers."):
-            suffix = full_key.removeprefix("model.layers.")
-            digits = []
-            for ch in suffix:
-                if ch.isdigit():
-                    digits.append(ch)
-                else:
-                    break
-            if digits:
-                try:
-                    layer_idx = int("".join(digits))
-                    return layer_idx < self._num_layers
-                except ValueError:
-                    return True
-        return True
+        prefix = "model.layers."
+        if not full_key.startswith(prefix):
+            return True
+        layer_part = full_key[len(prefix) :].split(".", 1)[0]
+        return (not layer_part.isdigit()) or (int(layer_part) < self._num_layers)
 
     def __getitem__(self, key: str) -> torch.Tensor:
+        """
+        Get the tensor for a key relative to our current base prefix.
+
+        Raises:
+            KeyError: if the full key does not exist in the index or is filtered out by num_layers.
+            FileNotFoundError: if the index points to a weight file that does not exist on disk.
+        """
         full_key = self._full_key(key)
         if full_key in self._cache:
             return self._cache[full_key]
         if full_key not in self._full_to_file or not self._passes_layer_filter(full_key):
             raise KeyError(key)
-        file_name = self._full_to_file[full_key]
-        file_path = self._model_path / file_name
-        with safe_open(file_path, framework="pt", device="cpu") as f:
+        filename = self._full_to_file[full_key]
+        filepath = self._model_path / filename
+        if not filepath.exists():
+            raise FileNotFoundError(
+                f"Attempted to load weight {full_key} from file {filepath} but the file does not exist."
+            )
+        with safe_open(filepath, framework="pt", device="cpu") as f:
             tensor = f.get_tensor(full_key)
         self._cache[full_key] = tensor
         return tensor
 
     def __contains__(self, key: object) -> bool:
+        """
+        Return True if the key is present in the current view
+        """
         if not isinstance(key, str):
-            return False
+            raise TypeError(f"Key must be a string but got {type(key)}")
         full_key = self._full_key(key)
         return full_key in self._full_to_file and self._passes_layer_filter(full_key)
 
     def __iter__(self) -> Iterator[str]:
+        """
+        Iterate keys present under the current view
+        """
         base = self._base_prefix
         for full_key in self._full_to_file.keys():
             if not full_key.startswith(base):
@@ -105,5 +134,8 @@ class LazyStateDict(Mapping[str, torch.Tensor]):
             yield full_key[len(base) :]
 
     def __len__(self) -> int:
-        # Iterate once to count to avoid computing and storing an intermediate list
+        """
+        Number of keys visible in this view after filters. Computed by iterating the
+        filtered keys at call time.
+        """
         return sum(1 for _ in self.__iter__())

--- a/models/demos/deepseek_v3/utils/lazy_state_dict.py
+++ b/models/demos/deepseek_v3/utils/lazy_state_dict.py
@@ -68,12 +68,16 @@ class LazyStateDict(Mapping[str, torch.Tensor]):
           different prefixes while allowing reuse for the same full key.
         """
         combined_prefix = self._base_prefix + prefix
+
+        # Inherit parent's layer filter if not explicitly overridden
+        child_num_layers = self._num_layers if num_layers is None else num_layers
+
         return LazyStateDict(
             self._model_path,
             combined_prefix,
             _full_to_file=self._full_to_file,
             _cache=self._cache,
-            _num_layers=num_layers,
+            _num_layers=child_num_layers,
         )
 
     def _full_key(self, key: str) -> str:

--- a/models/demos/deepseek_v3/utils/lazy_state_dict.py
+++ b/models/demos/deepseek_v3/utils/lazy_state_dict.py
@@ -7,9 +7,11 @@ from __future__ import annotations
 import json
 from collections.abc import Iterator, Mapping
 from pathlib import Path
+from time import perf_counter
 from typing import Optional
 
 import torch
+from loguru import logger
 from safetensors import safe_open
 
 
@@ -35,12 +37,14 @@ class LazyStateDict(Mapping[str, torch.Tensor]):
         _full_to_file: Optional[dict[str, str]] = None,
         _cache: Optional[dict[str, torch.Tensor]] = None,
         _num_layers: Optional[int] = None,
+        _file_handles: Optional[dict[str, object]] = None,
     ):
         self._model_path = Path(model_path)
         self._base_prefix = base_prefix
 
         # If _full_to_file is provided then we are a now a view ofthe original LazyStateDict.
         if _full_to_file is None:
+            t0 = perf_counter()
             index_path = self._model_path / "model.safetensors.index.json"
             if not index_path.is_file():
                 raise ValueError(f"Unable to find index file at {index_path}. Is the model path correct?")
@@ -50,10 +54,66 @@ class LazyStateDict(Mapping[str, torch.Tensor]):
             except Exception as e:
                 raise ValueError(f"Failed to parse index JSON at {index_path}: {e}") from e
             self._full_to_file = dict(index_obj["weight_map"])
+            elapsed_ms = (perf_counter() - t0) * 1e3
+
+            num_keys = len(self._full_to_file)
+            num_files = len(set(self._full_to_file.values()))
+            if num_keys <= 0:
+                raise ValueError(f"No keys found in index file at {index_path}")
+            if num_files <= 0:
+                raise ValueError(f"No files found in index file at {index_path}")
+            logger.info(
+                f"LazyStateDict initialized from {index_path} ({num_keys} keys across {num_files} files) in {elapsed_ms:.1f} ms"
+            )
         else:
             self._full_to_file = _full_to_file
-        self._cache: dict[str, torch.Tensor] = {} if _cache is None else _cache
+
         self._num_layers: Optional[int] = _num_layers
+
+        # Cache of open safetensors handles keyed by filename to avoid repeated mmaps
+        self._file_handles: dict[str, object] = {} if _file_handles is None else _file_handles
+        self._cache: dict[str, torch.Tensor] = {} if _cache is None else _cache
+
+    def _get_handle(self, filename: str):
+        """
+        Return a cached safe_open handle for a shard filename, opening it on first use.
+        """
+        handle = self._file_handles.get(filename)
+        if handle is not None:
+            return handle
+        filepath = self._model_path / filename
+        handle = safe_open(filepath, framework="pt", device="cpu")
+        self._file_handles[filename] = handle
+        return handle
+
+    def close(self) -> None:
+        """
+        Close all cached shard handles and clear cached tensors and accounting.
+        After calling this, previously returned tensors may become invalid if they
+        referenced the underlying mmap. Further accesses will lazily reopen shards.
+        """
+        if self._file_handles:
+            for filename, handle in list(self._file_handles.items()):
+                try:
+                    close_fn = getattr(handle, "close", None)
+                    if callable(close_fn):
+                        close_fn()
+                except Exception as e:
+                    logger.error(f"Failed to close handle for '{filename}': {e}")
+            self._file_handles.clear()
+        # Clear cached tensors and accounting to avoid stale references to mmaps
+        if self._cache:
+            self._cache.clear()
+
+    def __del__(self):
+        self.close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self.close()
+        return False
 
     def view_with_prefix(self, prefix: str, num_layers: Optional[int] = None) -> "LazyStateDict":
         """
@@ -71,6 +131,9 @@ class LazyStateDict(Mapping[str, torch.Tensor]):
 
         # Inherit parent's layer filter if not explicitly overridden
         child_num_layers = self._num_layers if num_layers is None else num_layers
+        logger.debug(
+            f"LazyStateDict view created: base_prefix='{self._base_prefix}', add_prefix='{prefix}', combined='{combined_prefix}', num_layers={child_num_layers}"
+        )
 
         return LazyStateDict(
             self._model_path,
@@ -78,6 +141,7 @@ class LazyStateDict(Mapping[str, torch.Tensor]):
             _full_to_file=self._full_to_file,
             _cache=self._cache,
             _num_layers=child_num_layers,
+            _file_handles=self._file_handles,
         )
 
     def _full_key(self, key: str) -> str:
@@ -105,15 +169,17 @@ class LazyStateDict(Mapping[str, torch.Tensor]):
             return self._cache[full_key]
         if full_key not in self._full_to_file or not self._passes_layer_filter(full_key):
             raise KeyError(key)
+
         filename = self._full_to_file[full_key]
         filepath = self._model_path / filename
         if not filepath.exists():
-            raise FileNotFoundError(
-                f"Attempted to load weight {full_key} from file {filepath} but the file does not exist."
-            )
-        with safe_open(filepath, framework="pt", device="cpu") as f:
-            tensor = f.get_tensor(full_key)
+            raise KeyError(f"Attempted to load weight {full_key} from file {filepath} but the file does not exist.")
+
+        # Reuse shard-level handle to avoid creating a new mmap per tensor
+        f = self._get_handle(filename)
+        tensor = f.get_tensor(full_key)
         self._cache[full_key] = tensor
+
         return tensor
 
     def __contains__(self, key: object) -> bool:

--- a/models/demos/deepseek_v3/utils/lazy_state_dict.py
+++ b/models/demos/deepseek_v3/utils/lazy_state_dict.py
@@ -77,16 +77,16 @@ class LazyStateDict(Mapping[str, torch.Tensor]):
         return True
 
     def __getitem__(self, key: str) -> torch.Tensor:
-        if key in self._cache:
-            return self._cache[key]
         full_key = self._full_key(key)
+        if full_key in self._cache:
+            return self._cache[full_key]
         if full_key not in self._full_to_file or not self._passes_layer_filter(full_key):
             raise KeyError(key)
         file_name = self._full_to_file[full_key]
         file_path = self._model_path / file_name
         with safe_open(file_path, framework="pt", device="cpu") as f:
             tensor = f.get_tensor(full_key)
-        self._cache[key] = tensor
+        self._cache[full_key] = tensor
         return tensor
 
     def __contains__(self, key: object) -> bool:

--- a/models/demos/deepseek_v3/utils/lazy_state_dict.py
+++ b/models/demos/deepseek_v3/utils/lazy_state_dict.py
@@ -1,0 +1,109 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator, Mapping
+from pathlib import Path
+from typing import Optional
+
+import torch
+from safetensors import safe_open
+
+
+class LazyStateDict(Mapping[str, torch.Tensor]):
+    """
+    Mapping-like view over HuggingFace safetensors weights that loads tensors lazily on access.
+
+    Keys are exposed relative to the configured base prefix. Values are cached after first access.
+    """
+
+    def __init__(
+        self,
+        model_path: Path,
+        base_prefix: str = "",
+        *,
+        _full_to_file: Optional[dict[str, str]] = None,
+        _cache: Optional[dict[str, torch.Tensor]] = None,
+        _num_layers: Optional[int] = None,
+    ):
+        self._model_path = Path(model_path)
+        self._base_prefix = base_prefix
+        if _full_to_file is None:
+            index_path = self._model_path / "model.safetensors.index.json"
+            weight_map = json.load(index_path.open("r"))["weight_map"]
+            self._full_to_file = dict(weight_map)
+        else:
+            self._full_to_file = _full_to_file
+        self._cache: dict[str, torch.Tensor] = {} if _cache is None else _cache
+        self._num_layers: Optional[int] = _num_layers
+
+    def view_with_prefix(self, prefix: str, num_layers: int | None = None) -> "LazyStateDict":
+        """
+        Return a new LazyStateDict view narrowed to keys under base_prefix + prefix.
+        Values cache is shared between views.
+        """
+        combined_prefix = self._base_prefix + prefix
+        return LazyStateDict(
+            self._model_path,
+            combined_prefix,
+            _full_to_file=self._full_to_file,
+            _cache=self._cache,
+            _num_layers=num_layers,
+        )
+
+    def _full_key(self, key: str) -> str:
+        return self._base_prefix + key
+
+    def _passes_layer_filter(self, full_key: str) -> bool:
+        if self._num_layers is None:
+            return True
+        if full_key.startswith("model.layers."):
+            suffix = full_key.removeprefix("model.layers.")
+            digits = []
+            for ch in suffix:
+                if ch.isdigit():
+                    digits.append(ch)
+                else:
+                    break
+            if digits:
+                try:
+                    layer_idx = int("".join(digits))
+                    return layer_idx < self._num_layers
+                except ValueError:
+                    return True
+        return True
+
+    def __getitem__(self, key: str) -> torch.Tensor:
+        if key in self._cache:
+            return self._cache[key]
+        full_key = self._full_key(key)
+        if full_key not in self._full_to_file or not self._passes_layer_filter(full_key):
+            raise KeyError(key)
+        file_name = self._full_to_file[full_key]
+        file_path = self._model_path / file_name
+        with safe_open(file_path, framework="pt", device="cpu") as f:
+            tensor = f.get_tensor(full_key)
+        self._cache[key] = tensor
+        return tensor
+
+    def __contains__(self, key: object) -> bool:
+        if not isinstance(key, str):
+            return False
+        full_key = self._full_key(key)
+        return full_key in self._full_to_file and self._passes_layer_filter(full_key)
+
+    def __iter__(self) -> Iterator[str]:
+        base = self._base_prefix
+        for full_key in self._full_to_file.keys():
+            if not full_key.startswith(base):
+                continue
+            if not self._passes_layer_filter(full_key):
+                continue
+            yield full_key[len(base) :]
+
+    def __len__(self) -> int:
+        # Iterate once to count to avoid computing and storing an intermediate list
+        return sum(1 for _ in self.__iter__())


### PR DESCRIPTION
### Summary

This commit introduces a new type `LazyStateDict` that memory-maps safetensors and only loads entries from disk on first access. This significantly reduces startup time when only a subset of the state_dict is needed, without changing existing call sites. 

Previously, we loaded the entire state_dict into memory even if only one weight was required.

### Checklist
- [x] [Galaxy-DeepSeek-tests](https://github.com/tenstorrent/tt-metal/actions/runs/19721225821)