### PR TITLE
[skip ci] removing manual run monitoring 

### DIFF
--- a/.github/actions/fetch-workflow-data/lib/fetching.js
+++ b/.github/actions/fetch-workflow-data/lib/fetching.js
@@ -278,6 +278,24 @@ function groupRunsByName(runs) {
 const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
 
 /**
+ * Remove manually triggered workflow runs.
+ * @param {Array} runs - Runs to filter
+ * @param {string} source - Label used in logs
+ * @returns {Array} Filtered runs
+ */
+function filterManualRuns(runs, source) {
+  if (!Array.isArray(runs) || runs.length === 0) {
+    return runs;
+  }
+  const filteredRuns = runs.filter(run => run.event !== 'workflow_dispatch');
+  const removed = runs.length - filteredRuns.length;
+  if (removed > 0) {
+    core.info(`[${source}] Filtered out ${removed} manually triggered runs (workflow_dispatch)`);
+  }
+  return filteredRuns;
+}
+
+/**
  * Fetches new workflow runs from GitHub API
  * @param {object} octokit - Octokit client
  * @param {object} context - GitHub Actions context
@@ -310,16 +328,7 @@ async function fetchNewWorkflowRuns(octokit, context, days, cachedRunIds, workfl
     core.info(`[FETCH] Total new runs fetched: ${newRuns.length} (from ${workflowIds.length} workflows)`);
   }
 
-  // Filter out manually triggered runs (workflow_dispatch)
-  const beforeFilter = newRuns.length;
-  newRuns = newRuns.filter(run => run.event !== 'workflow_dispatch');
-  const filteredCount = beforeFilter - newRuns.length;
-  if (filteredCount > 0) {
-    core.info(`[FETCH] Filtered out ${filteredCount} manually triggered runs (workflow_dispatch)`);
-  }
-  core.info(`[FETCH] Final count after filtering: ${newRuns.length} runs`);
-
-  return newRuns;
+  return filterManualRuns(newRuns, 'FETCH');
 }
 
 /**
@@ -351,11 +360,14 @@ function mergeAndDeduplicateRuns(previousRuns, newRuns, days) {
 
   // Filter by date (branch and status are already filtered at API level)
   const cutoff = getCutoffDate(days);
-  const beforeFilter = mergedRuns.length;
+  const beforeDateFilter = mergedRuns.length;
   mergedRuns = mergedRuns.filter(run =>
     new Date(run.created_at) >= cutoff
   );
-  core.info(`[MERGE] After filtering (date>=${cutoff.toISOString()}): ${mergedRuns.length} runs (removed ${beforeFilter - mergedRuns.length})`);
+  core.info(`[MERGE] After filtering (date>=${cutoff.toISOString()}): ${mergedRuns.length} runs (removed ${beforeDateFilter - mergedRuns.length})`);
+
+  mergedRuns = filterManualRuns(mergedRuns, 'MERGE');
+  core.info(`[MERGE] Final count after all filtering: ${mergedRuns.length} runs`);
   core.info(`[MERGE] Note: branch and status=completed were already filtered at API level`);
 
   return mergedRuns;

--- a/.github/actions/fetch-workflow-data/lib/fetching.js
+++ b/.github/actions/fetch-workflow-data/lib/fetching.js
@@ -310,6 +310,15 @@ async function fetchNewWorkflowRuns(octokit, context, days, cachedRunIds, workfl
     core.info(`[FETCH] Total new runs fetched: ${newRuns.length} (from ${workflowIds.length} workflows)`);
   }
 
+  // Filter out manually triggered runs (workflow_dispatch)
+  const beforeFilter = newRuns.length;
+  newRuns = newRuns.filter(run => run.event !== 'workflow_dispatch');
+  const filteredCount = beforeFilter - newRuns.length;
+  if (filteredCount > 0) {
+    core.info(`[FETCH] Filtered out ${filteredCount} manually triggered runs (workflow_dispatch)`);
+  }
+  core.info(`[FETCH] Final count after filtering: ${newRuns.length} runs`);
+
   return newRuns;
 }
 

--- a/.github/workflows/aggregate-workflow-data.yaml
+++ b/.github/workflows/aggregate-workflow-data.yaml
@@ -256,6 +256,6 @@ jobs:
       - name: Post regressions to Slack
         uses: ./.github/actions/slack-report-analyze-workflow-data
         with:
-          slack_webhook_url: ${{ secrets.SLACK_TESTING_CHANNEL }}
+          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_AGGREGATE_PIPELINE_STATUS_ALERT }}
           regressed_workflows: ${{ needs.analyze-data.outputs.regressed_workflows }}
           alert_all_message: ${{ needs.analyze-data.outputs.alert_all_message }}

--- a/.github/workflows/aggregate-workflow-data.yaml
+++ b/.github/workflows/aggregate-workflow-data.yaml
@@ -256,6 +256,6 @@ jobs:
       - name: Post regressions to Slack
         uses: ./.github/actions/slack-report-analyze-workflow-data
         with:
-          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_AGGREGATE_PIPELINE_STATUS_ALERT }}
+          slack_webhook_url: ${{ secrets.SLACK_TESTING_CHANNEL }}
           regressed_workflows: ${{ needs.analyze-data.outputs.regressed_workflows }}
           alert_all_message: ${{ needs.analyze-data.outputs.alert_all_message }}


### PR DESCRIPTION
### Ticket
NA

### Problem description
We don't want to monitor pipelines that were dispatched manually since those are often canceled. 

### What's changed
Workflow runs triggered manually are now filtered out in the fetching stage.


[FETCH] Completed all workflows. Total: added 3 new runs, skipped 1410 cached, 0 old
[FETCH] Fetched 3 new runs (skipped cached runs during fetch)
[FETCH] Total new runs fetched: 3 (from 33 workflows)
[MERGE] Merging 2583 cached runs + 3 new runs
[MERGE] After deduplication: 2586 unique runs (by run id + attempt)
[MERGE] After filtering (date>=2025-11-11T21:18:10.151Z): 2586 runs (removed 0)
**[MERGE] Filtered out 80 manually triggered runs (workflow_dispatch)**
[MERGE] Final count after all filtering: 2506 runs
[MERGE] Note: branch and status=completed were already filtered at API level
[MERGE] Grouped into 35 workflows
[RECHECK] Checking all 35 workflows for newer attempts
[RECHECK] No newer attempts found


### Checklist
- [x] [Aggregate Workflow Data](https://github.com/tenstorrent/tt-metal/actions/workflows/aggregate-workflow-data.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/19717617962