### PR TITLE
Fix ODR violation in tt-telemetry unit tests

### DIFF
--- a/tt_telemetry/tests/CMakeLists.txt
+++ b/tt_telemetry/tests/CMakeLists.txt
@@ -29,7 +29,6 @@ target_link_libraries(
         tt_metal # Need this for tt::umd::Cluster destructor
         telemetry_libs
         fmt::fmt-header-only
-        TT::ScaleoutTools # For protobuf dependencies
         protobuf::libprotobuf # For protobuf runtime
 )
 


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Building with `./build_metal.sh --build-all --build-type=ASan` produces:

```
[1685/1870] Linking CXX executable tt_telemetry/telemetry_unit_tests
FAILED: tt_telemetry/telemetry_unit_tests tt_telemetry/tests/telemetry_unit_tests[1]_tests.cmake /work/build/tt_telemetry/tests/telemetry_unit_tests[1]_tests.cmake
: && /usr/bin/clang++-17 -O3 -g -DDEBUG -fno-omit-frame-pointer -fno-omit-frame-pointer -fsanitize=address,leak,undefined -fno-omit-frame-pointer -fsanitize=address,leak,undefined -fuse-ld=lld -Xlinker --dependency-file=tt_telemetry/tests/CMakeFiles/telemetry_unit_tests.dir/link.d tools/scaleout/CMakeFiles/scaleout_tools.dir/node/node.cpp.o tools/scaleout/CMakeFiles/scaleout_tools.dir/node/node_types.cpp.o tools/scaleout/CMakeFiles/scaleout_tools.dir/board/board.cpp.o tools/scaleout/CMakeFiles/scaleout_tools.dir/cabling_generator/cabling_generator.cpp.o tools/scaleout/CMakeFiles/scaleout_tools.dir/connector/connector.cpp.o tools/scaleout/CMakeFiles/scaleout_tools.dir/factory_system_descriptor/utils.cpp.o tools/scaleout/CMakeFiles/scaleout_tools.dir/protobuf/factory_system_descriptor.pb.cc.o tools/scaleout/CMakeFiles/scaleout_tools.dir/protobuf/node_config.pb.cc.o tools/scaleout/CMakeFiles/scaleout_tools.dir/protobuf/cluster_config.pb.cc.o tools/scaleout/CMakeFiles/scaleout_tools.dir/protobuf/deployment.pb.cc.o tools/scaleout/CMakeFiles/scaleout_tools.dir/protobuf/ethernet_link_metrics.pb.cc.o tt_telemetry/tests/CMakeFiles/telemetry_unit_tests.dir/test_exception_handling.cpp.o tt_telemetry/tests/CMakeFiles/telemetry_unit_tests.dir/test_custom_labels.cpp.o tt_telemetry/tests/CMakeFiles/telemetry_unit_tests.dir/test_physical_link_info.cpp.o tt_telemetry/tests/CMakeFiles/telemetry_unit_tests.dir/test_ethernet_path_parsing.cpp.o tt_telemetry/tests/CMakeFiles/telemetry_unit_tests.dir/test_topology_helper_api.cpp.o -o tt_telemetry/telemetry_unit_tests  -Wl,-rpath,/work/build/tt_metal:/work/build/lib:/work/build/tt_metal/third_party/umd/device:/work/build/tt_stl  lib/libgmock.a  lib/libgtest.a  lib/libgtest_main.a  tt_metal/libtt_metal.so  _deps/protobuf-build/libprotobuf.a  lib/libgtest.a  lib/libtracy.so.0.10.0  -ldl  /usr/lib/x86_64-linux-gnu/libz.so  tt_metal/third_party/umd/device/libdevice.so  tt_stl/libtt_stl.so  _deps/yaml-cpp-build/libyaml-cpp.a && cd /work/build/tt_telemetry/tests && /usr/bin/cmake -D TEST_TARGET=telemetry_unit_tests -D TEST_EXECUTABLE=/work/build/tt_telemetry/telemetry_unit_tests -D TEST_EXECUTOR= -D TEST_WORKING_DIR=/work/build/tt_telemetry/tests -D TEST_EXTRA_ARGS= -D TEST_PROPERTIES= -D TEST_PREFIX= -D TEST_SUFFIX= -D TEST_FILTER= -D NO_PRETTY_TYPES=FALSE -D NO_PRETTY_VALUES=FALSE -D TEST_LIST=telemetry_unit_tests_TESTS -D CTEST_FILE=/work/build/tt_telemetry/tests/telemetry_unit_tests[1]_tests.cmake -D TEST_DISCOVERY_TIMEOUT=5 -D TEST_DISCOVERY_EXTRA_ARGS= -D TEST_XML_OUTPUT_DIR= -P /usr/share/cmake-4.2/Modules/GoogleTestAddTests.cmake
=================================================================
==15055==ERROR: AddressSanitizer: odr-violation (0x55675039c7e0):
  [1] size=62 'typeinfo name for tt::scaleout_tools::fsd::proto::FactorySystemDescriptor_Host' /work/build/tools/scaleout/protobuf/factory_system_descriptor.pb.cc
  [2] size=62 'typeinfo name for tt::scaleout_tools::fsd::proto::FactorySystemDescriptor_Host' /work/build/tools/scaleout/protobuf/factory_system_descriptor.pb.cc
These globals were registered at these points:
  [1]:
    #0 0x556750544046 in __asan_register_globals (/work/build/tt_telemetry/telemetry_unit_tests+0x667046) (BuildId: 21f4ca86c9cceef0)
    #1 0x556750545169 in __asan_register_elf_globals (/work/build/tt_telemetry/telemetry_unit_tests+0x668169) (BuildId: 21f4ca86c9cceef0)
    #2 0x7f9539a11eba in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x29eba) (BuildId: 4f7b0c955c3d81d7cac1501a2498b69d1d82bfe7)
  [2]:
    #0 0x556750544046 in __asan_register_globals (/work/build/tt_telemetry/telemetry_unit_tests+0x667046) (BuildId: 21f4ca86c9cceef0)
    #1 0x556750545169 in __asan_register_elf_globals (/work/build/tt_telemetry/telemetry_unit_tests+0x668169) (BuildId: 21f4ca86c9cceef0)
    #2 0x7f95424d647d  (/lib64/ld-linux-x86-64.so.2+0x647d) (BuildId: acaf96d7b1a6bad57b559d646233d5dc1a23257c)
```

### What's changed
Removed a redundant dependency on ScaleoutTools.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes