### PR TITLE
Add profiler options to disable pushing device data to Tracy and disable dumping device data to files

### DIFF
--- a/tools/tracy/__main__.py
+++ b/tools/tracy/__main__.py
@@ -106,8 +106,8 @@ def main():
         default=False,
     )
     parser.add_option(
-        "--disable-device-data-dump-to-tracy",
-        dest="disable_device_data_dump_to_tracy",
+        "--disable-device-data-push-to-tracy",
+        dest="disable_device_data_push_to_tracy",
         action="store_true",
         help="Disable pushing collected device data to Tracy GUI",
         default=False,
@@ -204,7 +204,7 @@ def main():
     if options.disable_device_data_dump_to_files:
         os.environ["TT_METAL_PROFILER_DISABLE_DUMP_TO_FILES"] = "1"
 
-    if options.disable_device_data_dump_to_tracy:
+    if options.disable_device_data_push_to_tracy:
         os.environ["TT_METAL_PROFILER_DISABLE_PUSH_TO_TRACY"] = "1"
 
     if options.sync_host_device:

--- a/tools/tracy/__main__.py
+++ b/tools/tracy/__main__.py
@@ -99,6 +99,20 @@ def main():
         default=False,
     )
     parser.add_option(
+        "--disable-device-data-dump-to-files",
+        dest="disable_device_data_dump_to_files",
+        action="store_true",
+        help="Disable dumping collected device data to files",
+        default=False,
+    )
+    parser.add_option(
+        "--disable-device-data-dump-to-tracy",
+        dest="disable_device_data_dump_to_tracy",
+        action="store_true",
+        help="Disable pushing collected device data to Tracy GUI",
+        default=False,
+    )
+    parser.add_option(
         "--collect-noc-traces",
         dest="collect_noc_traces",
         action="store_true",
@@ -186,6 +200,12 @@ def main():
 
     if options.mid_run_device_data:
         os.environ["TT_METAL_PROFILER_MID_RUN_DUMP"] = "1"
+
+    if options.disable_device_data_dump_to_files:
+        os.environ["TT_METAL_PROFILER_DISABLE_DUMP_TO_FILES"] = "1"
+
+    if options.disable_device_data_dump_to_tracy:
+        os.environ["TT_METAL_PROFILER_DISABLE_PUSH_TO_TRACY"] = "1"
 
     if options.sync_host_device:
         os.environ["TT_METAL_PROFILER_SYNC"] = "1"

--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -1988,7 +1988,8 @@ bool isSyncInfoNewer(const SyncInfo& old_info, const SyncInfo& new_info) {
 void DeviceProfiler::writeDeviceResultsToFiles() const {
 #if defined(TRACY_ENABLE)
     ZoneScoped;
-    if (!getDeviceProfilerState()) {
+    if (!getDeviceProfilerState() ||
+        tt::tt_metal::MetalContext::instance().rtoptions().get_profiler_disable_dump_to_files()) {
         return;
     }
 
@@ -2015,10 +2016,11 @@ void DeviceProfiler::writeDeviceResultsToFiles() const {
 void DeviceProfiler::pushTracyDeviceResults(
     std::vector<std::reference_wrapper<const tracy::TTDeviceMarker>>& device_markers_vec) {
 #if defined(TRACY_ENABLE)
-    if (!getDeviceProfilerState()) {
+    ZoneScoped;
+    if (!getDeviceProfilerState() ||
+        tt::tt_metal::MetalContext::instance().rtoptions().get_profiler_disable_push_to_tracy()) {
         return;
     }
-    ZoneScoped;
 
     // If this device is root, it may have new sync info updated with syncDeviceHost
     for (auto& [core, info] : device_core_sync_info) {

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -111,6 +111,8 @@ enum class EnvVarID {
     TT_METAL_PROFILER_MID_RUN_DUMP,                // Force mid-run profiler dumps
     TT_METAL_PROFILER_CPP_POST_PROCESS,            // Enable C++ post-processing for profiler
     TT_METAL_TRACY_MID_RUN_PUSH,                   // Force Tracy mid-run pushes
+    TT_METAL_PROFILER_DISABLE_DUMP_TO_FILES,       // Disable dumping collected device data to files
+    TT_METAL_PROFILER_DISABLE_PUSH_TO_TRACY,       // Disable pushing collected device data to Tracy GUI
     TT_METAL_GTEST_NUM_HW_CQS,                     // Number of HW command queues in tests
     TT_METAL_ARC_DEBUG_BUFFER_SIZE,                // ARC processor debug buffer size
     TT_METAL_OPERATION_TIMEOUT_SECONDS,            // Operation timeout duration
@@ -736,6 +738,30 @@ void RunTimeOptions::HandleEnvVar(EnvVarID id, const char* value) {
         // Default: false (no mid-run pushes)
         // Usage: export TT_METAL_TRACY_MID_RUN_PUSH=1
         case EnvVarID::TT_METAL_TRACY_MID_RUN_PUSH: this->tracy_mid_run_push = true; break;
+
+        // TT_METAL_PROFILER_DISABLE_DUMP_TO_FILES
+        // Disables dumping collected device data to files.
+        // Default: false (dump to files)
+        // Usage: export TT_METAL_PROFILER_DISABLE_DUMP_TO_FILES=1
+        case EnvVarID::TT_METAL_PROFILER_DISABLE_DUMP_TO_FILES: {
+            // Only disable dumping to files if device profiler is also enabled
+            if (this->profiler_enabled && is_env_enabled(value)) {
+                this->profiler_disable_dump_to_files = true;
+            }
+            break;
+        }
+
+        // TT_METAL_PROFILER_DISABLE_PUSH_TO_TRACY
+        // Disables pushing collected device data to Tracy GUI.
+        // Default: false (push to Tracy GUI)
+        // Usage: export TT_METAL_PROFILER_DISABLE_PUSH_TO_TRACY=1
+        case EnvVarID::TT_METAL_PROFILER_DISABLE_PUSH_TO_TRACY: {
+            // Only disable pushing to Tracy GUI if device profiler is also enabled
+            if (this->profiler_enabled && is_env_enabled(value)) {
+                this->profiler_disable_push_to_tracy = true;
+            }
+            break;
+        }
 
         // TT_METAL_GTEST_NUM_HW_CQS
         // Number of hardware command queues to use in tests.

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -139,6 +139,8 @@ class RunTimeOptions {
     bool profiler_noc_events_enabled = false;
     uint32_t profiler_perf_counter_mode = 0;
     std::string profiler_noc_events_report_path;
+    bool profiler_disable_dump_to_files = false;
+    bool profiler_disable_push_to_tracy = false;
 
     bool null_kernels = false;
     // Kernels should return early, skipping the rest of the kernel. Kernels
@@ -450,6 +452,8 @@ public:
     bool get_profiler_noc_events_enabled() const { return profiler_noc_events_enabled; }
     uint32_t get_profiler_perf_counter_mode() const { return profiler_perf_counter_mode; }
     std::string get_profiler_noc_events_report_path() const { return profiler_noc_events_report_path; }
+    bool get_profiler_disable_dump_to_files() const { return profiler_disable_dump_to_files; }
+    bool get_profiler_disable_push_to_tracy() const { return profiler_disable_push_to_tracy; }
 
     void set_kernels_nullified(bool v) { null_kernels = v; }
     bool get_kernels_nullified() const { return null_kernels; }


### PR DESCRIPTION
https://github.com/tenstorrent/tt-metal/issues/16787

This PR adds two environment variables for disabling pushes to Tracy and/or dumps to files:
 - `TT_METAL_PROFILER_DISABLE_DUMP_TO_FILES`
 - `TT_METAL_PROFILER_DISABLE_PUSH_TO_TRACY`

Note that if C++ post-processing is enabled, the post-processed results will still be dumped out to the CSV file.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/19746844018)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (https://github.com/tenstorrent/tt-metal/actions/runs/19746848849)
- [x] [T3K Profiler] (https://github.com/tenstorrent/tt-metal/actions/runs/19746853833)
- [x] New/Existing tests provide coverage for changes