### PR TITLE
Add config tensor in dram support for trasposed_conv2d

### DIFF
--- a/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/conv_transpose2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/conv_transpose2d.cpp
@@ -158,7 +158,9 @@ Result ConvTranpose2dOperation::invoke(
             0,
             false,
             parallel_config.shard_orientation == ShardOrientation::COL_MAJOR,
-            input_tensor_post_tm.memory_config());
+            input_tensor_post_tm.memory_config(),
+            /*is_out_tiled*/ true,
+            conv_config.config_tensors_in_dram);
 
         if (conv_config.deallocate_activation) {
             input_tensor_post_tm.deallocate(/*force*/ true);
@@ -288,7 +290,7 @@ Result ConvTranpose2dOperation::invoke(
         conv_config.enable_weights_double_buffer,
         false,  // full_inner_dim
         false,  // enable_activation_reuse
-        false,  // config_tensors_in_dram
+        conv_config.config_tensors_in_dram,
         conv_config.force_split_reader);
     if (memory_config.has_value() && memory_config.value() != conv_output.memory_config()) {
         conv_output = ttnn::to_memory_config(conv_output, memory_config.value(), std::nullopt);


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/33284)

### Problem description
Conv2dConfig::config_tensors_in_dram is ignored in transposed_conv2d implementation.

### What's changed
config_tensors_in_dram is now respected in halo and conv2d for transposed_conv2d impl

### Checklist
  - [x] [All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/runs/19717641489)
  - [x] [Blackhole post-commit tests](https://github.com/tenstorrent/tt-metal/actions/runs/19717646331)