### PR TITLE
Revert "Adding sub grid support to reshape (#33174)"

### DIFF
--- a/tests/ttnn/unit_tests/base_functionality/test_reshape.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_reshape.py
@@ -394,54 +394,6 @@ def test_reshape_tile(device, input_shape, output_shape, layout, memory_config, 
     assert_with_pcc(torch_result, output, 0.9999)
 
 
-@pytest.mark.parametrize(
-    "input_shape, output_shape",
-    [
-        ((1, 1445, 192), (1445, 192)),
-        ((1, 256), (1, 1, 256)),
-        ((16, 1, 32), (16, 1, 32)),
-    ],
-)
-@pytest.mark.parametrize("memory_config", [ttnn.L1_MEMORY_CONFIG, ttnn.DRAM_MEMORY_CONFIG])
-@pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT])
-@pytest.mark.parametrize(
-    "dtype", [(torch.bfloat16, ttnn.bfloat16), (torch.int32, ttnn.uint32), (torch.float32, ttnn.float32)]
-)
-@pytest.mark.parametrize(
-    "sub_core_grids",
-    (
-        # single core
-        ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(1, 0))]),
-        # multiple disjoint cores
-        ttnn.CoreRangeSet(
-            [
-                ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(3, 6)),
-                ttnn.CoreRange(ttnn.CoreCoord(5, 0), ttnn.CoreCoord(6, 6)),
-            ]
-        ),
-    ),
-)
-def test_reshape_subgrid(device, input_shape, output_shape, layout, memory_config, dtype, sub_core_grids):
-    if memory_config == ttnn.L1_MEMORY_CONFIG and input_shape in [(2888, 49, 96), (1, 1500, 1, 512)]:
-        pytest.xfail("Test case is too big for L1")
-
-    torch_dtype, ttnn_dtype = dtype
-
-    size = math.prod(input_shape)
-    torch_input_tensor = torch.linspace(1, size, size, dtype=torch_dtype).reshape(input_shape)
-
-    if torch_dtype == torch.int32:
-        torch_input_tensor = torch_input_tensor.abs()
-
-    torch_result = torch_input_tensor.reshape(output_shape)
-    input_tensor = ttnn.from_torch(
-        torch_input_tensor, layout=layout, dtype=ttnn_dtype, device=device, memory_config=memory_config
-    )
-    ttnn_output = ttnn.reshape(input_tensor, output_shape, sub_core_grids=sub_core_grids)
-    output = ttnn.to_torch(ttnn_output)
-    assert_with_pcc(torch_result, output, 0.9999)
-
-
 @pytest.mark.parametrize("recreate_mapping_tensor", (ttnn.TileReshapeMapMode.CACHE, ttnn.TileReshapeMapMode.RECREATE))
 def test_reshape_tile_program_cache(device, recreate_mapping_tensor):
     for input_shape, output_shape in ((1, 8, 8), (1, 16, 4)), ((16, 1, 5), (4, 2, 10)):

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/host/reshape_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/host/reshape_program_factory.hpp
@@ -8,10 +8,8 @@
 
 namespace ttnn::operations::data_movement::reshape {
 
-tt::tt_metal::operation::ProgramWithCallbacks rm_reshape_preparer(
-    const Tensor& input, const Tensor& output, std::optional<CoreRangeSet> sub_core_grid);
+tt::tt_metal::operation::ProgramWithCallbacks rm_reshape_preparer(const Tensor& input, const Tensor& output);
 
-tt::tt_metal::operation::ProgramWithCallbacks reshape_tiled_program_factory(
-    const Tensor& input, const Tensor& output, std::optional<CoreRangeSet> sub_core_grid);
+tt::tt_metal::operation::ProgramWithCallbacks reshape_tiled_program_factory(const Tensor& input, const Tensor& output);
 
 }  // namespace ttnn::operations::data_movement::reshape

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/host/reshape_rm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/host/reshape_rm_program_factory.cpp
@@ -31,7 +31,7 @@
 namespace ttnn::operations::data_movement::reshape {
 
 tt::tt_metal::operation::ProgramWithCallbacks rm_reshape_preparer_single_risk(
-    const Tensor& input, const Tensor& output, std::optional<CoreRangeSet> sub_core_grid) {
+    const Tensor& input, const Tensor& output) {
     tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
     // get datum size
     tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input.dtype());
@@ -41,10 +41,8 @@ tt::tt_metal::operation::ProgramWithCallbacks rm_reshape_preparer_single_risk(
     auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
     uint32_t num_cores_x = compute_with_storage_grid_size.x;
     uint32_t num_cores_y = compute_with_storage_grid_size.y;
-    CoreRange default_cores({0, 0}, {num_cores_x - 1, num_cores_y - 1});
-    CoreRangeSet total_cores = sub_core_grid.has_value() ? sub_core_grid.value() : CoreRangeSet(default_cores);
-    uint32_t num_cores_total = total_cores.size();
-
+    uint32_t num_cores_total = num_cores_x * num_cores_y;
+    CoreRange total_cores({0, 0}, {num_cores_x - 1, num_cores_y - 1});
     auto input_log_shape = input.logical_shape();
     auto output_log_shape = output.logical_shape();
     log_debug(tt::LogOp, "row major reshape");
@@ -117,110 +115,118 @@ tt::tt_metal::operation::ProgramWithCallbacks rm_reshape_preparer_single_risk(
             tt::tt_metal::WriterDataMovementConfig(compile_time_args));
     }
     uint32_t done = 0;
-    for (auto core : corerange_to_cores(total_cores, std::nullopt)) {
-        if (done == 1) {
-            const std::vector<uint32_t> reader_runtime_args = {
-                src_buffer->address(), dst_buffer->address(), source_read_size_bytes, 0, 0, 0, 0, 1
-
-            };
-            tt::tt_metal::SetRuntimeArgs(program, reader_kernel_id, core, reader_runtime_args);
-            if (can_use_dual_kernel) {
-                tt::tt_metal::SetRuntimeArgs(program, reader_kernel_id2, core, reader_runtime_args);
-            }
-        } else {
-            // Create the circular buffers
-
-            // set the runtime args
-            // set the compile time args
-            const uint32_t start_of_read = read_start_page;
-            uint32_t end_of_read = read_start_page + responsibility;
-            end_of_read = end_of_read < input_log_shape[-2] ? end_of_read : input_log_shape[-2];
-            uint32_t pages_for_this_core = end_of_read - start_of_read;
-            uint32_t write_jump = (pages_for_this_core * source_page_size_bytes) / dest_page_size_bytes;
-
-            if (can_use_dual_kernel) {
-                // Split work in half - determine split point and second write position
-                uint32_t mid_read, second_write_pos;
-                if (source_page_size_bytes >= dest_page_size_bytes) {
-                    // Split by input pages
-                    uint32_t half_pages = pages_for_this_core / 2;
-                    mid_read = start_of_read + half_pages;
-                    second_write_pos = write_start_page + (half_pages * source_page_size_bytes / dest_page_size_bytes);
-                } else {
-                    // Split by output pages
-                    uint32_t total_bytes_for_core = pages_for_this_core * source_page_size_bytes;
-                    uint32_t total_output_pages_for_core = total_bytes_for_core / dest_page_size_bytes;
-                    uint32_t half_output_pages = total_output_pages_for_core / 2;
-                    mid_read = start_of_read + (half_output_pages * dest_page_size_bytes / source_page_size_bytes);
-                    second_write_pos = write_start_page + half_output_pages;
-                }
-
-                std::vector<uint32_t> runtime_args = {
-                    src_buffer->address(),
-                    dst_buffer->address(),
-                    source_read_size_bytes,
-                    start_of_read,
-                    mid_read,
-                    write_start_page,
-                    0,
-                    0};
-
-                tt::tt_metal::SetRuntimeArgs(program, reader_kernel_id, core, runtime_args);
-
-                runtime_args[3] = mid_read;
-                runtime_args[4] = end_of_read;
-                runtime_args[5] = second_write_pos;
-
-                tt::tt_metal::SetRuntimeArgs(program, reader_kernel_id2, core, runtime_args);
-            } else {
-                // Original single kernel approach
+    for (int core_x = 0; core_x < num_cores_x; core_x++) {
+        for (int core_y = 0; core_y < num_cores_y; core_y++) {
+            CoreCoord core = {core_x, core_y};
+            if (done == 1) {
                 const std::vector<uint32_t> reader_runtime_args = {
-                    src_buffer->address(),
-                    dst_buffer->address(),
-                    source_read_size_bytes,
-                    start_of_read,
-                    end_of_read,
-                    write_start_page,
-                    0,  // write_start_offset removed (always 0)
-                    done};
+                    src_buffer->address(), dst_buffer->address(), source_read_size_bytes, 0, 0, 0, 0, 1
+
+                };
                 tt::tt_metal::SetRuntimeArgs(program, reader_kernel_id, core, reader_runtime_args);
+                if (can_use_dual_kernel) {
+                    tt::tt_metal::SetRuntimeArgs(program, reader_kernel_id2, core, reader_runtime_args);
+                }
+            } else {
+                // Create the circular buffers
+
+                // set the runtime args
+                // set the compile time args
+                const uint32_t start_of_read = read_start_page;
+                uint32_t end_of_read = read_start_page + responsibility;
+                end_of_read = end_of_read < input_log_shape[-2] ? end_of_read : input_log_shape[-2];
+                uint32_t pages_for_this_core = end_of_read - start_of_read;
+                uint32_t write_jump = (pages_for_this_core * source_page_size_bytes) / dest_page_size_bytes;
+
+                if (can_use_dual_kernel) {
+                    // Split work in half - determine split point and second write position
+                    uint32_t mid_read, second_write_pos;
+                    if (source_page_size_bytes >= dest_page_size_bytes) {
+                        // Split by input pages
+                        uint32_t half_pages = pages_for_this_core / 2;
+                        mid_read = start_of_read + half_pages;
+                        second_write_pos =
+                            write_start_page + (half_pages * source_page_size_bytes / dest_page_size_bytes);
+                    } else {
+                        // Split by output pages
+                        uint32_t total_bytes_for_core = pages_for_this_core * source_page_size_bytes;
+                        uint32_t total_output_pages_for_core = total_bytes_for_core / dest_page_size_bytes;
+                        uint32_t half_output_pages = total_output_pages_for_core / 2;
+                        mid_read = start_of_read + (half_output_pages * dest_page_size_bytes / source_page_size_bytes);
+                        second_write_pos = write_start_page + half_output_pages;
+                    }
+
+                    std::vector<uint32_t> runtime_args = {
+                        src_buffer->address(),
+                        dst_buffer->address(),
+                        source_read_size_bytes,
+                        start_of_read,
+                        mid_read,
+                        write_start_page,
+                        0,
+                        0};
+
+                    tt::tt_metal::SetRuntimeArgs(program, reader_kernel_id, core, runtime_args);
+
+                    runtime_args[3] = mid_read;
+                    runtime_args[4] = end_of_read;
+                    runtime_args[5] = second_write_pos;
+
+                    tt::tt_metal::SetRuntimeArgs(program, reader_kernel_id2, core, runtime_args);
+                } else {
+                    // Original single kernel approach
+                    const std::vector<uint32_t> reader_runtime_args = {
+                        src_buffer->address(),
+                        dst_buffer->address(),
+                        source_read_size_bytes,
+                        start_of_read,
+                        end_of_read,
+                        write_start_page,
+                        0,  // write_start_offset removed (always 0)
+                        done};
+                    tt::tt_metal::SetRuntimeArgs(program, reader_kernel_id, core, reader_runtime_args);
+                }
+                write_start_page += write_jump;
+                read_start_page = end_of_read;
+                done = (end_of_read == input_log_shape[-2]) ? 1 : 0;
             }
-            write_start_page += write_jump;
-            read_start_page = end_of_read;
-            done = (end_of_read == input_log_shape[-2]) ? 1 : 0;
         }
     }
-    auto override_runtime_args_callback = [reader_kernel_id, reader_kernel_id2, can_use_dual_kernel, total_cores](
-                                              const void* operation,
-                                              const tt::tt_metal::Program& program,
-                                              const std::vector<Tensor>& input_tensors,
-                                              const std::vector<std::optional<const Tensor>>&,
-                                              const std::vector<Tensor>& output_tensors) {
-        tt::tt_metal::Buffer* src_buffer = input_tensors.at(0).buffer();
-        tt::tt_metal::Buffer* dst_buffer = output_tensors.at(0).buffer();
+    auto override_runtime_args_callback =
+        [reader_kernel_id, reader_kernel_id2, can_use_dual_kernel, num_cores_x, num_cores_y](
+            const void* operation,
+            const tt::tt_metal::Program& program,
+            const std::vector<Tensor>& input_tensors,
+            const std::vector<std::optional<const Tensor>>&,
+            const std::vector<Tensor>& output_tensors) {
+            tt::tt_metal::Buffer* src_buffer = input_tensors.at(0).buffer();
+            tt::tt_metal::Buffer* dst_buffer = output_tensors.at(0).buffer();
 
-        for (auto core : corerange_to_cores(total_cores, std::nullopt)) {
-            // Update buffer addresses for primary kernel
-            {
-                auto& runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
-                runtime_args[0] = src_buffer->address();  // src_buffer address
-                runtime_args[1] = dst_buffer->address();  // dst_buffer address
-            }
+            for (int core_x = 0; core_x < num_cores_x; core_x++) {
+                for (int core_y = 0; core_y < num_cores_y; core_y++) {
+                    CoreCoord core = {core_x, core_y};
 
-            // Update buffer addresses for dual kernel if enabled
-            if (can_use_dual_kernel) {
-                auto& runtime_args = GetRuntimeArgs(program, reader_kernel_id2, core);
-                runtime_args[0] = src_buffer->address();  // src_buffer address
-                runtime_args[1] = dst_buffer->address();  // dst_buffer address
+                    // Update buffer addresses for primary kernel
+                    {
+                        auto& runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
+                        runtime_args[0] = src_buffer->address();  // src_buffer address
+                        runtime_args[1] = dst_buffer->address();  // dst_buffer address
+                    }
+
+                    // Update buffer addresses for dual kernel if enabled
+                    if (can_use_dual_kernel) {
+                        auto& runtime_args = GetRuntimeArgs(program, reader_kernel_id2, core);
+                        runtime_args[0] = src_buffer->address();  // src_buffer address
+                        runtime_args[1] = dst_buffer->address();  // dst_buffer address
+                    }
+                }
             }
-        }
-    };
+        };
     return {.program = std::move(program), .override_runtime_arguments_callback = override_runtime_args_callback};
 }
 
-tt::tt_metal::operation::ProgramWithCallbacks rm_reshape_preparer(
-    const Tensor& input, const Tensor& output, std::optional<CoreRangeSet> sub_core_grid) {
-    return rm_reshape_preparer_single_risk(input, output, std::move(sub_core_grid));
+tt::tt_metal::operation::ProgramWithCallbacks rm_reshape_preparer(const Tensor& input, const Tensor& output) {
+    return rm_reshape_preparer_single_risk(input, output);
 }
 
 };  // namespace ttnn::operations::data_movement::reshape

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/host/reshape_tiled_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/host/reshape_tiled_program_factory.cpp
@@ -286,7 +286,7 @@ Tensor compute_reshape_mapping_host_tensor(
 // the scratch page is copied to its output destination.
 
 tt::tt_metal::operation::ProgramWithCallbacks reshape_tiled_program_factory(
-    const Tensor& input_tensor, const Tensor& output_tensor, std::optional<CoreRangeSet> sub_core_grid) {
+    const Tensor& input_tensor, const Tensor& output_tensor) {
     const auto& input_shape = input_tensor.logical_shape();
     const auto& output_shape = output_tensor.logical_shape();
 
@@ -359,8 +359,7 @@ tt::tt_metal::operation::ProgramWithCallbacks reshape_tiled_program_factory(
 
     const auto
         [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
-            sub_core_grid.has_value() ? tt::tt_metal::split_work_to_cores(sub_core_grid.value(), num_output_pages)
-                                      : tt::tt_metal::split_work_to_cores(grid, num_output_pages);
+            tt::tt_metal::split_work_to_cores(grid, num_output_pages);
 
     TT_ASSERT(num_cores <= num_output_pages);
 

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_device_operation.cpp
@@ -60,11 +60,10 @@ ReshapeDeviceOperation::create_op_performance_model(
 operation::ProgramWithCallbacks ReshapeDeviceOperation::create_program(
     const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const {
     if (input_tensors.at(0).layout() == Layout::ROW_MAJOR) {
-        return operations::data_movement::reshape::rm_reshape_preparer(
-            input_tensors.at(0), output_tensors.at(0), this->sub_core_grid);
+        return operations::data_movement::reshape::rm_reshape_preparer(input_tensors.at(0), output_tensors.at(0));
     } else {
         return operations::data_movement::reshape::reshape_tiled_program_factory(
-            input_tensors.at(0), output_tensors.at(0), this->sub_core_grid);
+            input_tensors.at(0), output_tensors.at(0));
     }
 }
 
@@ -79,13 +78,6 @@ tt::tt_metal::operation::Hash ReshapeDeviceOperation::compute_program_hash(
     // don't hash on ReshapeDeviceOperation::recreate_mapping_tensor
 
     return tt::tt_metal::operation::hash_operation<ReshapeDeviceOperation>(
-        input_shape,
-        layout,
-        input_mem_config,
-        input_dtype,
-        this->logical_output_shape,
-        this->output_mem_config,
-        this->sub_core_grid.has_value(),
-        sub_core_grid.has_value() ? sub_core_grid.value() : CoreRangeSet(CoreRange({0, 0}, {0, 0})));
+        input_shape, layout, input_mem_config, input_dtype, this->logical_output_shape, this->output_mem_config);
 }
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_device_operation.hpp
@@ -14,7 +14,6 @@ struct ReshapeDeviceOperation {
     const ttnn::Shape padded_output_shape;
     tt::tt_metal::MemoryConfig output_mem_config;
     const bool recreate_mapping_tensor;
-    std::optional<CoreRangeSet> sub_core_grid;
 
     // Required functions to all tensor op functions
     void update_structure(const Tensor& input_tensor);

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.hpp
@@ -35,23 +35,20 @@ struct ReshapeViewOperation {
         const ttnn::Shape& logical_shape,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         const std::optional<PadValue>& pad_value = std::nullopt,
-        TileReshapeMapMode = TileReshapeMapMode::CACHE,
-        const std::optional<CoreRangeSet>& sub_core_grid = std::nullopt);
+        TileReshapeMapMode = TileReshapeMapMode::CACHE);
     static ttnn::Tensor invoke(
         const ttnn::Tensor& input_tensor,
         const ttnn::Shape& logical_shape,
         const ttnn::Shape& padded_shape,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         const std::optional<PadValue>& pad_value = std::nullopt,
-        TileReshapeMapMode = TileReshapeMapMode::CACHE,
-        const std::optional<CoreRangeSet>& sub_core_grid = std::nullopt);
+        TileReshapeMapMode = TileReshapeMapMode::CACHE);
     static ttnn::Tensor invoke(
         const ttnn::Tensor& input_tensor,
         tt::stl::Span<const int32_t> shape_vector,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         const std::optional<PadValue>& pad_value = std::nullopt,
-        TileReshapeMapMode = TileReshapeMapMode::CACHE,
-        const std::optional<CoreRangeSet>& sub_core_grid = std::nullopt);
+        TileReshapeMapMode = TileReshapeMapMode::CACHE);
 };
 
 }  // namespace operations::data_movement

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape_pybind.cpp
@@ -28,17 +28,15 @@ void bind_reshape_view(pybind11::module& module, const data_movement_operation_t
                const ttnn::Shape& shape,
                const std::optional<MemoryConfig>& memory_config,
                const std::optional<PadValue>& pad_value,
-               const ttnn::TileReshapeMapMode reshape_tile_mode,
-               const std::optional<CoreRangeSet>& sub_core_grids) -> ttnn::Tensor {
-                return self(input_tensor, shape, memory_config, pad_value, reshape_tile_mode, sub_core_grids);
+               const ttnn::TileReshapeMapMode reshape_tile_mode) -> ttnn::Tensor {
+                return self(input_tensor, shape, memory_config, pad_value, reshape_tile_mode);
             },
             py::arg("input_tensor"),
             py::arg("shape"),
             py::kw_only(),
             py::arg("memory_config") = std::nullopt,
             py::arg("pad_value") = std::nullopt,
-            py::arg("reshape_tile_mode") = ttnn::TileReshapeMapMode::CACHE,
-            py::arg("sub_core_grids") = std::nullopt},
+            py::arg("reshape_tile_mode") = ttnn::TileReshapeMapMode::CACHE},
         ttnn::pybind_overload_t{
             [](const data_movement_operation_t& self,
                const ttnn::Tensor& input_tensor,
@@ -46,16 +44,8 @@ void bind_reshape_view(pybind11::module& module, const data_movement_operation_t
                const ttnn::Shape& padded_shape,
                const std::optional<MemoryConfig>& memory_config,
                const std::optional<PadValue>& pad_value,
-               const ttnn::TileReshapeMapMode reshape_tile_mode,
-               const std::optional<CoreRangeSet>& sub_core_grids) -> ttnn::Tensor {
-                return self(
-                    input_tensor,
-                    logical_shape,
-                    padded_shape,
-                    memory_config,
-                    pad_value,
-                    reshape_tile_mode,
-                    sub_core_grids);
+               const ttnn::TileReshapeMapMode reshape_tile_mode) -> ttnn::Tensor {
+                return self(input_tensor, logical_shape, padded_shape, memory_config, pad_value, reshape_tile_mode);
             },
             py::arg("input_tensor"),
             py::arg("logical_shape"),
@@ -63,25 +53,22 @@ void bind_reshape_view(pybind11::module& module, const data_movement_operation_t
             py::kw_only(),
             py::arg("memory_config") = std::nullopt,
             py::arg("pad_value") = std::nullopt,
-            py::arg("reshape_tile_mode") = ttnn::TileReshapeMapMode::CACHE,
-            py::arg("sub_core_grids") = std::nullopt},
+            py::arg("reshape_tile_mode") = ttnn::TileReshapeMapMode::CACHE},
         ttnn::pybind_overload_t{
             [](const data_movement_operation_t& self,
                const ttnn::Tensor& input_tensor,
                const ttnn::SmallVector<int32_t>& shape,
                const std::optional<MemoryConfig>& memory_config,
                const std::optional<PadValue>& pad_value,
-               const ttnn::TileReshapeMapMode reshape_tile_mode,
-               const std::optional<CoreRangeSet>& sub_core_grids) -> ttnn::Tensor {
-                return self(input_tensor, shape, memory_config, pad_value, reshape_tile_mode, sub_core_grids);
+               const ttnn::TileReshapeMapMode reshape_tile_mode) -> ttnn::Tensor {
+                return self(input_tensor, shape, memory_config, pad_value, reshape_tile_mode);
             },
             py::arg("input_tensor"),
             py::arg("shape"),
             py::kw_only(),
             py::arg("memory_config") = std::nullopt,
             py::arg("pad_value") = std::nullopt,
-            py::arg("recreate_mapping_tensor") = ttnn::TileReshapeMapMode::CACHE,
-            py::arg("sub_core_grids") = std::nullopt});
+            py::arg("recreate_mapping_tensor") = ttnn::TileReshapeMapMode::CACHE});
 }
 }  // namespace detail
 
@@ -108,8 +95,6 @@ void py_bind_reshape_view(pybind11::module& module) {
                 * :attr:`memory_config`: Memory Config of the output tensor. Default is to match input tensor memory config
                 * :attr:`pad_value` (number): Value to pad the output tensor. Default is 0
                 * :attr:`recreate_mapping_tensor` (bool): Advanced option. Set to true to recompute and realloc mapping tensor. This may alleviate DRAM fragmentation but is slow.
-                * :attr:`sub_core_grids` (CoreRangeSet, optional): Specifies sub-core grid ranges for advanced core selection control. Default uses all the cores in the device.
-
 
             Returns:
                 ttnn.Tensor: the output tensor with the new shape.


### PR DESCRIPTION
### Problem description
- reshape causes device perf to be [red](https://github.com/tenstorrent/tt-metal/actions/runs/19728077078) due to this commit 

### What's changed
- reverts commit a17527ebecd97425dcc68e532c815b64f9bbf134

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI [in progess](https://github.com/tenstorrent/tt-metal/actions/runs/19731771353)
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI [in progress](https://github.com/tenstorrent/tt-metal/actions/runs/19731776174)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI [in progress](https://github.com/tenstorrent/tt-metal/actions/runs/19731779232)