### PR TITLE
Add log probs feature to TT-Transformers on T3K

### DIFF
--- a/models/common/sampling/generator.py
+++ b/models/common/sampling/generator.py
@@ -19,6 +19,7 @@ logger = logging.getLogger(__name__)
 @dataclass(frozen=True)
 class _TraceKey:
     penalties_on: bool
+    log_probs_on: bool
 
 
 class SamplingGenerator:
@@ -63,8 +64,8 @@ class SamplingGenerator:
     def _new_trace_state(self):
         return {"id": None, "input": None, "output": None, "kwargs": {}}
 
-    def _trace_slot(self, penalties_on: bool):
-        key = _TraceKey(penalties_on=penalties_on)
+    def _trace_slot(self, penalties_on: bool, log_probs_on: bool):
+        key = _TraceKey(penalties_on=penalties_on, log_probs_on=log_probs_on)
         slot = self._trace_states.get(key)
         if slot is None:
             slot = self._new_trace_state()
@@ -73,13 +74,14 @@ class SamplingGenerator:
 
     def reset_trace(self):
         """
-        Drop any cached trace metadata for both penalties/no-penalties paths.
+        Drop any cached trace metadata for both penalties/no-penalties and log-probs/no-log-probs paths.
         """
         for key, slot in self._trace_states.items():
             if slot["id"] is not None:
                 logger.debug(
-                    "Resetting sampling trace (penalties=%s, trace_id=%s)",
+                    "Resetting sampling trace (penalties=%s, log_probs=%s, trace_id=%s)",
                     key.penalties_on,
+                    key.log_probs_on,
                     slot["id"],
                 )
         self._trace_states.clear()
@@ -106,7 +108,10 @@ class SamplingGenerator:
     # ---------------------------------------------------------------------
     def reset_sampling_params(self, sampling_params):
         self.tt_sampling.reset_params(
-            k=sampling_params.top_k, p=sampling_params.top_p, temp=sampling_params.temperature
+            k=sampling_params.top_k,
+            p=sampling_params.top_p,
+            temp=sampling_params.temperature,
+            enable_log_probs=sampling_params.enable_log_probs,
         )
         self.tt_penalties.reset_params(
             sampling_params.presence_penalty, sampling_params.frequency_penalty, sampling_params.repetition_penalty
@@ -116,6 +121,7 @@ class SamplingGenerator:
             and self._is_default_penalty(sampling_params.frequency_penalty, self._DEFAULT_PENALTIES["frequency"])
             and self._is_default_penalty(sampling_params.repetition_penalty, self._DEFAULT_PENALTIES["repetition"])
         )
+        self._log_probs_active = self.tt_sampling.log_probs_calculator.enable_log_probs
 
     def _validate_trace_inputs(self, slot, logits: ttnn.Tensor, tt_out_tok: Optional[ttnn.Tensor]):
         if slot["input"] is None or slot["output"] is None:
@@ -126,11 +132,18 @@ class SamplingGenerator:
                 "The provided logits tensor does not match the tensor used during trace capture. "
                 "Call `reset_trace()` before tracing with new tensors."
             )
-        if tt_out_tok is not None and tt_out_tok is not slot["output"]:
-            raise ValueError(
-                "The provided output tensor does not match the tensor used during trace capture. "
-                "Call `reset_trace()` before tracing with new tensors."
-            )
+        if isinstance(slot["output"], tuple):
+            if tt_out_tok is not None and tt_out_tok is not slot["output"][0]:
+                raise ValueError(
+                    "The provided output tensor does not match the tensor used during trace capture. "
+                    "Call `reset_trace()` before tracing with new tensors."
+                )
+        else:
+            if tt_out_tok is not None and tt_out_tok is not slot["output"]:
+                raise ValueError(
+                    "The provided output tensor does not match the tensor used during trace capture. "
+                    "Call `reset_trace()` before tracing with new tensors."
+                )
 
     def _run_sampling(
         self,
@@ -141,8 +154,8 @@ class SamplingGenerator:
     ):
         if penalties_on:
             self.tt_penalties.apply(logits)
-        tt_tokens = self.tt_sampling(logits, tt_out_tok=tt_out_tok)
-        return tt_tokens
+        tt_tokens, tt_log_probs = self.tt_sampling(logits, tt_out_tok=tt_out_tok)
+        return tt_tokens, tt_log_probs
 
     def capture_trace(
         self,
@@ -154,8 +167,9 @@ class SamplingGenerator:
         Capture a trace of the sampling pipeline for the given configuration.
         """
         penalties_on = self._penalties_active
+        log_probs_on = self._log_probs_active
 
-        key, slot = self._trace_slot(penalties_on)
+        key, slot = self._trace_slot(penalties_on, log_probs_on)
 
         logger.debug("Pre-compiling sampling path before trace capture (penalties=%s)", penalties_on)
         self._run_sampling(
@@ -173,9 +187,17 @@ class SamplingGenerator:
         ttnn.end_trace_capture(self.mesh_device, trace_id, cq_id=self.cq_id)
         ttnn.synchronize_device(self.mesh_device)
 
+        if tt_out_tok is not None:
+            if isinstance(sampled, tuple):
+                output = (tt_out_tok, sampled[-1])
+            else:
+                output = (tt_out_tok, sampled)
+        else:
+            output = sampled
+
         slot["id"] = trace_id
         slot["input"] = logits
-        slot["output"] = tt_out_tok or sampled
+        slot["output"] = output
         slot["kwargs"] = {"tt_out_tok": tt_out_tok}
 
         return slot["output"]
@@ -204,6 +226,7 @@ class SamplingGenerator:
         """
 
         penalties_on = self._penalties_active
+        log_probs_on = self._log_probs_active
         use_internal_trace = enable_trace and self.enable_internal_trace
 
         if not use_internal_trace:
@@ -213,7 +236,7 @@ class SamplingGenerator:
                 tt_out_tok=tt_out_tok,
             )
         else:
-            key, slot = self._trace_slot(penalties_on)
+            key, slot = self._trace_slot(penalties_on, log_probs_on)
             if slot["id"] is None:
                 return self.capture_trace(
                     logits,

--- a/models/common/sampling/generator.py
+++ b/models/common/sampling/generator.py
@@ -247,7 +247,10 @@ class SamplingGenerator:
             tt_out = self._execute_trace(key)
 
         if penalties_on and tt_out is not None:
-            self.tt_penalties.update_output_tokens(tt_out)
+            if isinstance(tt_out, tuple):
+                self.tt_penalties.update_output_tokens(tt_out[0])
+            else:
+                self.tt_penalties.update_output_tokens(tt_out)
         return tt_out
 
     def reset_seed(self, seed):

--- a/models/common/tests/test_sampling.py
+++ b/models/common/tests/test_sampling.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import torch
 import torch.nn.functional as F

--- a/models/common/tests/test_sampling.py
+++ b/models/common/tests/test_sampling.py
@@ -1,0 +1,71 @@
+import pytest
+import torch
+import torch.nn.functional as F
+
+import ttnn
+from models.common.utility_functions import comp_pcc
+from models.common.utils import LogProbsCalculator
+
+
+@pytest.mark.parametrize(
+    "shape",
+    [  # TODO: Add llama3.1-8b T3K shapes
+        [1, 1, 32, 8 * 18992],  # Qwen3 on T3K
+    ],
+)
+@pytest.mark.parametrize(
+    "device_params",
+    [
+        ({"fabric_config": ttnn.FabricConfig.FABRIC_1D}),
+    ],
+    indirect=["device_params"],
+    ids=["fabric_linear"],
+)
+def test_log_probs_calculation(shape, mesh_device):
+    seed = 1234
+    torch.manual_seed(seed)
+
+    log_probs_calculator = LogProbsCalculator(mesh_device)
+
+    torch_tensor = torch.randn(shape)
+    # shuffle the tensor in last 2 dimensions
+    for i in range(shape[-2]):
+        torch_tensor[:, :, i, :] = torch_tensor[:, :, i, torch.randperm(shape[-1])]
+
+    argmax_tensor = torch.argmax(torch_tensor, dim=-1, keepdim=True)
+    indices_tensor = argmax_tensor.reshape(
+        argmax_tensor.shape[0], argmax_tensor.shape[1], argmax_tensor.shape[-1], argmax_tensor.shape[-2]
+    )
+    # Push inputs to device
+    logits_tensor = ttnn.from_torch(
+        torch_tensor,
+        device=mesh_device,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        mesh_mapper=ttnn.ShardTensorToMesh(mesh_device, dim=-1),
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    ttnn_indices_tensor = ttnn.from_torch(
+        indices_tensor,
+        device=mesh_device,
+        dtype=ttnn.int32,
+        layout=ttnn.TILE_LAYOUT,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    log_probs_calculator.set_log_probs_mode(True)
+    tt_log_probs = log_probs_calculator.calculate_log_probs(logits_tensor, ttnn_indices_tensor)
+    log_probs_tt_host = ttnn.to_torch(tt_log_probs, mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=3))
+    log_probs_tt_host = log_probs_tt_host[:, :, :1, :32]
+
+    # Calculate log-probs for each user on each chip using torch
+    log_probs_torch = F.log_softmax(torch_tensor.float(), dim=-1)
+    log_probs_torch_argmax = torch.gather(log_probs_torch, dim=-1, index=argmax_tensor)
+    log_probs_torch_argmax = torch.reshape(log_probs_torch_argmax, (1, 1, 1, 32))
+
+    passing, pcc = comp_pcc(log_probs_torch_argmax, log_probs_tt_host, pcc=0.99)
+    print(f"pcc={pcc}")
+
+    assert passing, f"Assertion failed, PCC={pcc}"

--- a/models/common/utils.py
+++ b/models/common/utils.py
@@ -226,9 +226,8 @@ class LogProbsCalculator:
         log-prob(x) = logits(x) - global_max - log(global_exp_sum)
         """
         out = ttnn.subtract(sampled_logits_tensor, self.global_max)
-        out = ttnn.subtract(out, ttnn.log(self.global_exp_sum))
-
-        return out
+        # Subtract to self.output_tensor
+        ttnn.subtract(out, ttnn.log(self.global_exp_sum), output_tensor=self.output_tensor)
 
     def calculate_log_probs(
         self,
@@ -254,7 +253,7 @@ class LogProbsCalculator:
         # Prepare relevant logits for each user on each chip
         relevant_logits = self._prepare_relevant_logits(logits_tensor, indices_tensor)
 
-        # Calculate log-probs for each user on each chip
-        log_probs = self._calculate_log_probs(relevant_logits)
+        # Calculate log-probs for each user on each chip and stores in self.output_tensor
+        self._calculate_log_probs(relevant_logits)
 
-        return log_probs
+        return self.output_tensor

--- a/models/common/utils.py
+++ b/models/common/utils.py
@@ -5,6 +5,8 @@ import torch
 import torch.nn.functional as F
 from torch import Tensor
 
+import ttnn
+
 
 def top_k_top_p_filtering(
     logits: Tensor,
@@ -45,3 +47,200 @@ def top_k_top_p_filtering(
         indices_to_remove = sorted_indices_to_remove.scatter(1, sorted_indices, sorted_indices_to_remove)
         logits[indices_to_remove] = filter_value
     return logits
+
+
+class LogProbsCalculator:
+    """
+    Class to calculate log-probs for a given logits tensor and indices tensor.
+
+    Args:
+        mesh_device: MeshDevice to use for all-gather operations
+    """
+
+    def __init__(self, mesh_device: ttnn.MeshDevice):
+        self.global_max = None
+        self.global_exp_sum = None
+        self.mesh_device = mesh_device
+        self.enable_log_probs = False  # default to False
+
+        # Create mask for each user on each chip.
+        batch_size = 32
+
+        num_devices = self.mesh_device.get_num_devices()
+        # TODO: Test this for 6U Galaxy
+        # Enforce working on 8 devices instead of all 32 since logits are sharded across 8 devices
+        num_devices_for_sharding = 8 if num_devices == 32 else num_devices
+
+        # Create mask tensor with shape (num_devices, batch_size)
+        # Each row will have device_id starting from 0 to num_devices - 1
+        mask_tensor = torch.arange(num_devices_for_sharding).unsqueeze(1).expand(num_devices_for_sharding, batch_size)
+
+        if self.mesh_device.get_num_devices() == 32:
+            self.cluster_shape = (8, 4)
+            mesh_mapper = ttnn.ShardTensor2dMesh(self.mesh_device, dims=(None, 0), mesh_shape=self.cluster_shape)
+        elif self.mesh_device.get_num_devices() == 8:
+            mesh_mapper = ttnn.ShardTensorToMesh(self.mesh_device, dim=0)
+        else:
+            # TODO: Implement method for other number of devices, for now replicate tensor to mesh to support all the ops
+            mesh_mapper = ttnn.ReplicateTensorToMesh(self.mesh_device)
+
+        self.mask = ttnn.as_tensor(
+            mask_tensor,
+            dtype=ttnn.bfloat16,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            device=self.mesh_device,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            preprocess=lambda x: x.to(torch.bfloat16),
+            mesh_mapper=mesh_mapper,
+        )
+        self.output_tensor = ttnn.as_tensor(
+            torch.ones(1, 1, 1, batch_size),
+            dtype=ttnn.bfloat16,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            device=self.mesh_device,
+            layout=ttnn.TILE_LAYOUT,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
+        )
+
+    def set_log_probs_mode(self, enable_log_probs: bool | list[bool] = False):
+        if isinstance(enable_log_probs, list):
+            # If any of the users in the batch have log_probs enabled,
+            # then whole batch will run log-probs calculation
+            enable_log_probs_result = any(enable_log_probs)
+        else:
+            enable_log_probs_result = enable_log_probs
+
+        self.enable_log_probs = enable_log_probs_result
+
+    def _compute_global_stats(
+        self,
+        logits_tensor: ttnn.Tensor,
+    ):
+        """
+        To calculate log-probs, we need to calculate the global max and global sum(exp(logits - global_max)) for each chip.
+        This is done by all-gathering the max and sum(exp(logits - global_max)) for each chip and then taking the max and sum of the gathered tensors.
+        log-prob formula: log-prob(x) = logits(x) - global_max - log(sum(exp(logits - global_max)))
+
+        Args:
+            logits_tensor (ttnn.Tensor): Logits as model output (1, 1, batch_size, vocab_size_per_device)
+        """
+        # Calculate local max
+        local_max_tensor = ttnn.max(logits_tensor, dim=-1, keepdim=True)
+
+        # All-gather local max to get global max
+        gathered_max_tensors = ttnn.all_gather(
+            local_max_tensor,
+            dim=3,
+            num_links=1,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            cluster_axis=None,
+            topology=ttnn.Topology.Linear,
+        )
+        self.global_max = ttnn.max(gathered_max_tensors, dim=-1, keepdim=True)
+
+        # Calculate stable local sum-exp using subtract of global-max from each local logit
+        subtracted_tensor = ttnn.subtract(logits_tensor, self.global_max)
+        sum_exp_tensor = ttnn.sum(ttnn.exp(subtracted_tensor), dim=-1, keepdim=True)
+
+        # All-gather stable local sum-exp to get global sum-exp
+        gathered_sum_exp_tensors = ttnn.all_gather(
+            sum_exp_tensor,
+            dim=3,
+            num_links=1,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            cluster_axis=None,
+            topology=ttnn.Topology.Linear,
+        )
+        self.global_exp_sum = ttnn.sum(gathered_sum_exp_tensors, dim=-1, keepdim=True)
+
+        # reshape global_max and global_exp_sum to support same output shape as sampling output -> (1, 1, 1, 32)
+        self.global_max = ttnn.reshape(self.global_max, (1, 1, 1, 32))
+        self.global_exp_sum = ttnn.reshape(self.global_exp_sum, (1, 1, 1, 32))
+
+    def _prepare_relevant_logits(self, logits_tensor: ttnn.Tensor, global_idx_tensor: ttnn.Tensor):
+        """
+        Prepare global idx tensor with correct values on all devices.
+        """
+        size_per_device = logits_tensor.shape[-1]
+
+        # convert global_idx_tensor to ttnn.TILE_LAYOUT
+        global_idx_tilized_tensor = ttnn.to_layout(global_idx_tensor, ttnn.TILE_LAYOUT)
+
+        # TODO: Raise an issue on this since for UINT_32 ttnn.div produces incorrect output (all zeros)
+        global_idx_tilized_tensor = ttnn.typecast(global_idx_tilized_tensor, ttnn.float32)
+
+        # Get chip_id for each user based on global_idx values in global_idx_tensor
+        chip_ids_tensor = ttnn.div(
+            global_idx_tilized_tensor, size_per_device, round_mode="floor", memory_config=ttnn.DRAM_MEMORY_CONFIG
+        )
+
+        # Get local index for each user based on global_idx values in global_idx_tensor
+        remainder_tensor = ttnn.remainder(
+            global_idx_tilized_tensor, size_per_device, memory_config=ttnn.DRAM_MEMORY_CONFIG
+        )
+
+        # Convert remainder_tensor to int32
+        remainder_tensor = ttnn.reshape(ttnn.typecast(remainder_tensor, ttnn.uint32), (1, 1, 32, 1))
+
+        # Get logits for each user on each chip based on local index
+        selected_logits_tensor = ttnn.gather(logits_tensor, dim=3, index=remainder_tensor)
+
+        selected_logits_tensor = ttnn.reshape(selected_logits_tensor, (1, 1, 1, 32))
+        # Compare mask to chip_ids tensor and select correct positions for each user on all chips inplace
+        ttnn.eq_(chip_ids_tensor, self.mask)
+
+        # Multiply selected_logits_tensor with chip_ids_tensor to get expected logits for each user
+        selected_logits_tensor = ttnn.multiply(selected_logits_tensor, chip_ids_tensor)
+
+        # Use ttnn.all_gather to get logits across all devices
+        selected_logits_tensor = ttnn.all_gather(
+            selected_logits_tensor,
+            dim=2,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            cluster_axis=None,
+            topology=ttnn.Topology.Linear,
+        )
+
+        # Apply sum over device dimension to get logits for each user on all chips
+        selected_logits_tensor = ttnn.sum(selected_logits_tensor, dim=2, keepdim=True)
+
+        return selected_logits_tensor
+
+    def _calculate_log_probs(self, sampled_logits_tensor: ttnn.Tensor):
+        """
+        Calculate log-probs for a given logits tensor with formula:
+        log-prob(x) = logits(x) - global_max - log(global_exp_sum)
+        """
+        out = ttnn.subtract(sampled_logits_tensor, self.global_max)
+        out = ttnn.subtract(out, ttnn.log(self.global_exp_sum))
+
+        return out
+
+    def calculate_log_probs(
+        self,
+        logits_tensor: ttnn.Tensor,
+        indices_tensor: ttnn.Tensor,
+    ):
+        """
+        Calculate log-probs for a given logits tensor and indices tensor.
+        """
+        if not self.enable_log_probs:
+            return self.output_tensor
+
+        if self.mesh_device.get_num_devices() != 8:
+            return self.output_tensor
+
+        # Calculating log-probs requires bfloat16 precision for near-stable sum-exp calculation
+        if logits_tensor.dtype == ttnn.bfloat8_b:
+            logits_tensor = ttnn.typecast(logits_tensor, ttnn.bfloat16)
+
+        # Compute global max and global sum(exp(logits - global_max)) for each chip
+        self._compute_global_stats(logits_tensor)
+
+        # Prepare relevant logits for each user on each chip
+        relevant_logits = self._prepare_relevant_logits(logits_tensor, indices_tensor)
+
+        # Calculate log-probs for each user on each chip
+        log_probs = self._calculate_log_probs(relevant_logits)
+
+        return log_probs

--- a/models/demos/gemma3/demo/text_demo.py
+++ b/models/demos/gemma3/demo/text_demo.py
@@ -952,7 +952,7 @@ def test_demo_text(
                 out_tok[0] = token_acc.collect_predicted_tokens(out_tok[0].item())
 
             # Run decode forward
-            logits = generator.decode_forward_text(
+            logits, _ = generator.decode_forward_text(
                 out_tok,
                 current_pos,
                 enable_trace=enable_trace,

--- a/models/demos/gpt_oss/demo/text_demo.py
+++ b/models/demos/gpt_oss/demo/text_demo.py
@@ -391,7 +391,7 @@ def test_gpt_oss_demo(
                 profiler.start(f"inference_decode_time_{iteration}", iteration=batch_idx)
 
             # Decode forward (matching tt_transformers call)
-            logits = generator.decode_forward_text(
+            logits, _ = generator.decode_forward_text(
                 out_tok,
                 current_pos,
                 enable_trace=enable_trace,

--- a/models/demos/gpt_oss/tests/unit/test_model.py
+++ b/models/demos/gpt_oss/tests/unit/test_model.py
@@ -104,7 +104,7 @@ def run_accuracy(
     for i in range(1, len(reference_tokens)):
         # Use decode for subsequent tokens with teacher forcing (use reference tokens)
         with torch.no_grad():
-            logits = generator.decode_forward_text(
+            logits, _ = generator.decode_forward_text(
                 out_tok,  # out_tok (current token)
                 current_pos,  # current_pos
                 enable_trace=False,  # enable_trace

--- a/models/demos/gpt_oss/tt/model.py
+++ b/models/demos/gpt_oss/tt/model.py
@@ -253,13 +253,16 @@ class Model:
         rope_mats = self.rope_setup.get_rot_mats(rot_mat_idxs)
 
         # Forward through layers and head (shared with prefill)
-        return self._forward_layers_and_head(
+        out = self._forward_layers_and_head(
             hidden_states=hidden_states,
             rope_mats=rope_mats,
             current_pos=current_pos,
             page_table=page_table,
             kv_cache=kv_cache,
         )
+        # Return logits and None for log-probs for compatibility with generator interface
+        # TODO: Add log-probs return value once sampling_on_device is supported
+        return out, None
 
     def ttnn_prefill_forward(
         self,

--- a/models/demos/llama3_70b_galaxy/tt/generator.py
+++ b/models/demos/llama3_70b_galaxy/tt/generator.py
@@ -627,6 +627,9 @@ class Generator:
 
     def read_decode_output(self, tt_out, async_read=True):
         if not async_read:
+            if isinstance(tt_out, tuple):
+                # Get logits and skip log-probs
+                tt_out = tt_out[0]
             return tt_out.cpu()
 
         logits, read_event = self.model.process_output_decode(tt_out)

--- a/models/demos/llama3_70b_galaxy/tt/llama_model.py
+++ b/models/demos/llama3_70b_galaxy/tt/llama_model.py
@@ -495,6 +495,10 @@ class TtTransformer(LightweightModule):
         if isinstance(tt_out, list):
             tt_out = tt_out[0]
 
+        if isinstance(tt_out, tuple):
+            # Get logits and skip log-probs
+            tt_out = tt_out[0]
+
         tt_out_cpu = tt_out.cpu(blocking=False, cq_id=0)
         return tt_out_cpu, ttnn.record_event(self.mesh_device, 0)
 

--- a/models/demos/qwen25_vl/demo/demo.py
+++ b/models/demos/qwen25_vl/demo/demo.py
@@ -514,7 +514,7 @@ def test_demo(
                 profiler.start(f"inference_decode_time_{iteration}", iteration=batch_idx)
 
             # Run decode forward
-            logits = generator.decode_forward_text(
+            logits, _ = generator.decode_forward_text(
                 out_tok,
                 current_pos,
                 enable_trace=enable_trace,

--- a/models/tt_transformers/demo/simple_text_demo.py
+++ b/models/tt_transformers/demo/simple_text_demo.py
@@ -322,6 +322,30 @@ def prepare_generator_args(
             None,  # num_layers, if None -> defaults to all layers
             "full",  # performs both prefill and decode
         ),
+        (  # Batch-32 run (Throughput) - 32 users, small prompt with log-probs
+            "models/tt_transformers/demo/sample_prompts/input_data_questions_prefill_128.json",  # input_prompts
+            True,  # instruct mode
+            1,  # repeat_batches
+            1024,  # max_seq_len
+            32,  # batch_size
+            200,  # max_generated_tokens
+            True,  # paged_attention
+            {"page_block_size": 32, "page_max_num_blocks_per_dp": 1024},  # page_params
+            {
+                "temperature": torch.linspace(0.0, 1.0, steps=32).tolist(),
+                "top_p": torch.linspace(0.08, 1.0, steps=32).tolist(),
+                "top_k": torch.arange(1, 33).tolist(),  # 1 to 32 inclusive
+                "enable_log_probs": [True] * 32,
+            },  # sampling_params (non-uniform)
+            True,  # stop_at_eos
+            False,  # ci_only
+            1,  # data_parallel
+            False,  # token_accuracy
+            False,  # stress_test
+            True,  # enable_trace
+            None,  # num_layers, if None -> defaults to all layers
+            "full",  # performs both prefill and decode
+        ),
         (  # long-context-64k run - Single user, long prompt (may vary based on the model's tokenizer)
             "models/tt_transformers/demo/sample_prompts/input_data_long_64k.json",  # input_prompts
             True,  # instruct mode
@@ -671,6 +695,7 @@ def prepare_generator_args(
     ids=[
         "batch-1",  # latency
         "batch-32",  # throughput
+        "batch-32-log-probs",  # throughput with log-probs
         "long-context-64k",  # 64k context, max_seq_len=128k
         "long-context-32k",  # 32k context, max_seq_len=32k
         "long-context-16k",  # 16k context, max_seq_len=32k
@@ -1007,6 +1032,9 @@ def test_demo_text(
                 repetition_penalty=sampling_params["repetition_penalty"]
                 if "repetition_penalty" in sampling_params
                 else 1.0,
+                enable_log_probs=sampling_params["enable_log_probs"]
+                if "enable_log_probs" in sampling_params
+                else False,
             )
             if model[0]._supports_on_device_sampling
             else None
@@ -1015,7 +1043,7 @@ def test_demo_text(
             # host sampling only supports single sample param for all users in a batch
             sampling_params["temperature"] = sampling_params["temperature"][0]
             sampling_params["top_p"] = sampling_params["top_p"][0]
-
+            sampling_params["enable_log_probs"] = sampling_params["enable_log_probs"][0]
         # Initial positions
         current_pos = torch.tensor([decoding_pos[b] if mode == "full" else 0 for b in range(global_batch_size)])
 
@@ -1049,7 +1077,7 @@ def test_demo_text(
                 out_tok[0] = token_acc.collect_predicted_tokens(out_tok[0].item())
 
             # Run decode forward
-            logits = generator.decode_forward_text(
+            logits, log_probs = generator.decode_forward_text(
                 out_tok,
                 current_pos,
                 enable_trace=enable_trace,

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -43,6 +43,7 @@ class SamplingParams:
     frequency_penalty: float | list[float] = 0.0
     repetition_penalty: float | list[float] = 1.0
     seed: int | list[int] = 0
+    enable_log_probs: bool | list[bool] = False
 
 
 SAMPLING_PARAM_FIELDS = tuple(f.name for f in fields(SamplingParams))
@@ -575,8 +576,7 @@ class Generator:
         Performs text decode step.
         Returns tt_logits on device
         """
-        tt_logits = []
-
+        tt_output = []
         tt_tokens = []
         tt_current_pos = []
         tt_rot_mat_idxs = []
@@ -597,7 +597,7 @@ class Generator:
 
         for i in range(self.data_parallel):
             user_kv_cache = kv_cache[i] if kv_cache is not None else None
-            tt_logits_i = self.model[i].ttnn_decode_forward(
+            tt_logits_i, tt_log_probs_i = self.model[i].ttnn_decode_forward(
                 tt_tokens[i],
                 tt_current_pos[i],
                 rot_mat_idxs=tt_rot_mat_idxs[i],
@@ -605,9 +605,9 @@ class Generator:
                 kv_cache=user_kv_cache,
                 sampling_on_device=sampling_on_device,
             )
-            tt_logits.append(tt_logits_i)
+            tt_output.append((tt_logits_i, tt_log_probs_i))
 
-        return tt_logits
+        return tt_output
 
     def _capture_decode_trace_text(
         self,
@@ -1055,7 +1055,7 @@ class Generator:
         read_from_device=True,
     ):
         if not self.model_args[0].is_llama_vision():
-            return self.decode_forward_text(
+            output = self.decode_forward_text(
                 tokens,
                 start_pos,
                 enable_trace=enable_trace,
@@ -1063,7 +1063,7 @@ class Generator:
                 kv_cache=kv_cache,
             )
         else:
-            return self.decode_forward_llama_vision(
+            output = self.decode_forward_llama_vision(
                 start_pos,
                 tokens,
                 prefill_cross_attention_masks,
@@ -1077,19 +1077,38 @@ class Generator:
                 enable_trace,
                 read_from_device,
             )
+        # skip returning log-probs
+        if isinstance(output, tuple):
+            return output[0]
+        else:
+            return output
 
     # Note: This function is called by vLLM
     def read_decode_output(self, tt_out, async_read=False):
         """
-        Input tt_out is a list of ttnn device tensors
+        Input tt_out is list of tuples of (tt_out_tok, tt_log_probs)
+
         """
         if not async_read:
-            return [out.cpu() for out in tt_out]
+            # output is a tuple of (tt_out_tok, tt_log_probs)
+            if isinstance(tt_out[0], tuple):
+                return [
+                    (out[0].cpu(), out[1].cpu() if out[1] is not None else None)  # logits should never be None
+                    for out in tt_out
+                ]
+            elif isinstance(tt_out[0], ttnn.Tensor):
+                return [out.cpu() for out in tt_out]
 
         host_outputs = []
         read_events = []
         for i in range(self.data_parallel):
-            host_outputs.append(tt_out[i].cpu(blocking=False))
+            if isinstance(tt_out[i], tuple):
+                outputs = (tt_out[i][0].cpu(blocking=False), tt_out[i][1].cpu(blocking=False))  # logits  # log-probs
+                host_outputs.append(outputs)
+            elif isinstance(tt_out[i], ttnn.Tensor):
+                outputs = tt_out[i].cpu(blocking=False)
+                host_outputs.append(outputs)
+
             read_events.append(ttnn.record_event(self.model[i].mesh_device, 0))
 
         return host_outputs, read_events
@@ -1103,13 +1122,31 @@ class Generator:
         max_batch_size_per_model = self.model_args[0].max_batch_size
 
         logits = []
+        log_probs = []
         for i in range(self.data_parallel):
-            logits_i = self.model[i].process_output_decode(
-                tt_out[i], max_batch_size_per_model, S=1, is_tokens=is_tokens
-            )
-            logits.append(logits_i)
-
-        return torch.cat(logits, 0)
+            if isinstance(tt_out[i], tuple):
+                logits_i = self.model[i].process_output_decode(
+                    tt_out[i][0], max_batch_size_per_model, S=1, is_tokens=is_tokens
+                )
+                log_probs_i = (
+                    self.model[i].process_output_decode(
+                        tt_out[i][1], max_batch_size_per_model, S=1, is_tokens=is_tokens, is_log_probs=True
+                    )
+                    if tt_out[i][1] is not None
+                    else torch.ones(logits_i.shape)
+                )
+                logits.append(logits_i)
+                log_probs.append(log_probs_i)
+            elif isinstance(tt_out[i], ttnn.Tensor):
+                logits_i = self.model[i].process_output_decode(
+                    tt_out[i], max_batch_size_per_model, S=1, is_tokens=is_tokens
+                )
+                logits.append(logits_i)
+                # add dummy tensor for log_probs
+                log_probs.append(torch.ones(logits_i.shape))
+            else:
+                raise ValueError(f"Invalid type of tt_out: {type(tt_out[i])}")
+        return (torch.cat(logits, 0), torch.cat(log_probs, 0))
 
     def _decode_forward_no_trace(
         self,
@@ -1176,10 +1213,11 @@ class Generator:
             tt_cross_page_table.append(tt_cross_page_table_i)
 
         tt_logits = []
+        tt_log_probs = []
         for i in range(self.data_parallel):
             user_kv_cache = kv_cache[i] if kv_cache is not None else None
             xattn_cache = xattn_caches[i] if xattn_caches is not None else None
-            tt_logits_i = self.model[i].ttnn_decode_forward(
+            tt_logits_i, tt_log_probs_i = self.model[i].ttnn_decode_forward(
                 tt_h[i],
                 tt_xattn_mask[i],
                 tt_full_text_mask_expand_1NSH[i],
@@ -1192,8 +1230,9 @@ class Generator:
                 cross_page_table=tt_cross_page_table[i],
             )
             tt_logits.append(tt_logits_i)
+            tt_log_probs.append(tt_log_probs_i)
 
-        return tt_logits
+        return tt_logits, tt_log_probs
 
     def _capture_trace(
         self,
@@ -1255,8 +1294,8 @@ class Generator:
         for i in range(self.data_parallel):
             user_kv_cache = kv_cache[i] if kv_cache is not None else None
             xattn_cache = xattn_caches[i] if xattn_caches is not None else None
-            # tt_logits_rm unused later, no need to make a list
-            tt_logits_rm = self.model[i].ttnn_decode_forward(
+            # tt_logits_rm and tt_log_probs_rm unused later, no need to make a list
+            tt_logits_rm, tt_log_probs_rm = self.model[i].ttnn_decode_forward(
                 tt_h[i],
                 tt_xattn_mask[i],
                 tt_full_text_mask_expand_1NSH[i],
@@ -1337,6 +1376,7 @@ class Generator:
         tt_h_trace_input = tt_h
 
         tt_logits_rm = []
+        tt_log_probs_rm = []
         trace_ids = {}
         # Do on-device transformations of inputs before forward
         for i in range(self.data_parallel):
@@ -1360,7 +1400,7 @@ class Generator:
                 B=B,
             )
 
-            tt_logits_rm_i = self.model[i].ttnn_decode_forward(
+            tt_logits_rm_i, tt_log_probs_rm_i = self.model[i].ttnn_decode_forward(
                 tt_h_transform,
                 tt_xattn_mask_transform,
                 tt_full_text_mask_expand_1NSH_transform,
@@ -1373,12 +1413,14 @@ class Generator:
                 cross_page_table=tt_cross_page_table[i],
             )
             tt_logits_rm.append(tt_logits_rm_i)
+            tt_log_probs_rm.append(tt_log_probs_rm_i)
             ttnn.end_trace_capture(self.model_args[i].mesh_device, trace_id, cq_id=0)
         logger.info("Done Capturing Decode Trace")
 
         return (
             trace_ids,
             tt_logits_rm,
+            tt_log_probs_rm,
             tt_h,
             tt_xattn_mask,
             tt_full_text_mask_expand_1NSH,

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -1525,6 +1525,7 @@ class Generator:
             (
                 trace_ids,
                 tt_logits_rm,
+                tt_log_probs_rm,
                 tt_h,
                 tt_xattn_mask,
                 tt_full_text_mask_expand_1NSH,

--- a/models/tt_transformers/tt/model.py
+++ b/models/tt_transformers/tt/model.py
@@ -473,7 +473,7 @@ class Transformer(LightweightModule):
             # Send output logits to DRAM so L1 is not reserved for ttnn tracing and can be used by subsequent operations
             tt_logits = ttnn.to_memory_config(tt_logits, ttnn.DRAM_MEMORY_CONFIG)
 
-        return tt_logits, None  # TODO: Add log_probs_return_value
+        return tt_logits, None
 
     def forward(
         self,

--- a/models/tt_transformers/tt/model.py
+++ b/models/tt_transformers/tt/model.py
@@ -329,7 +329,7 @@ class Transformer(LightweightModule):
         )
         return tt_tokens
 
-    def concat_host_output(self, tt_out):
+    def concat_host_output(self, tt_out, is_log_probs=False):
         """
         Concatenate the output of the devices into a single host tensor.
         """
@@ -341,7 +341,14 @@ class Transformer(LightweightModule):
 
         rows, cols = self.args.cluster_shape
         mesh_shape = [torch_out_tensors[i : i + cols] for i in range(0, len(torch_out_tensors), cols)]
-        row_concatenated = [torch.cat(row, dim=col_dim) for row in mesh_shape]
+        if is_log_probs:
+            row_concatenated = []
+            for row in mesh_shape:
+                row_reshaped = [tensor.reshape(1, 1, -1, 1) for tensor in row]
+                row_concatenated.append(torch.cat(row_reshaped, dim=col_dim))
+        else:
+            row_concatenated = [torch.cat(row, dim=col_dim) for row in mesh_shape]
+
         return torch.cat(row_concatenated, dim=row_dim)
 
     def process_output_prefill(self, tt_out, last_token_idx):
@@ -351,15 +358,16 @@ class Transformer(LightweightModule):
         """
         return self.concat_host_output(tt_out.cpu())[0, 0, last_token_idx, : self.vocab_size]
 
-    def process_output_decode(self, tt_out, B, S=1, is_tokens=False):
+    def process_output_decode(self, tt_out, B, S=1, is_tokens=False, is_log_probs=False):
         """
         Input is ttnn host tensor of logits if is_tokens=False, otherwise tokens. Output is the corresponding torch tensor.
         """
-        if is_tokens:
+        if is_tokens or is_log_probs:
             # Pad to 32 to match the expected batch size for decode operations (tiles are 32x32)
             padded_batch_size = 32
-            tt_out = ttnn.reshape(tt_out, ttnn.Shape([1, 1, padded_batch_size, 1]))
-            return self.concat_host_output(tt_out)[0, 0, :B, 0]
+            if not is_log_probs:
+                tt_out = ttnn.reshape(tt_out, ttnn.Shape([1, 1, padded_batch_size, 1]))
+            return self.concat_host_output(tt_out, is_log_probs)[0, 0, :B, 0]
         if self.args.num_devices > 1:
             tt_out = ttnn.to_torch(ttnn.get_device_tensors(tt_out)[0]).float()
         else:
@@ -432,12 +440,13 @@ class Transformer(LightweightModule):
             self._increment_decode_positions_device(current_pos, rot_mat_idxs)
             if capture_sampling_trace:
                 return tt_logits
-            tt_toks = self.sampling.sample(
+            tt_toks, tt_log_probs = self.sampling.sample(
                 tt_logits,
                 tt_out_tok=x,
                 enable_trace=False,
             )
-            return tt_toks
+
+            return tt_toks, tt_log_probs
 
         # Gather the output across all devices and untilize the tensor (for argmax)
         if self.args.num_devices > 1:
@@ -464,7 +473,7 @@ class Transformer(LightweightModule):
             # Send output logits to DRAM so L1 is not reserved for ttnn tracing and can be used by subsequent operations
             tt_logits = ttnn.to_memory_config(tt_logits, ttnn.DRAM_MEMORY_CONFIG)
 
-        return tt_logits
+        return tt_logits, None  # TODO: Add log_probs_return_value
 
     def forward(
         self,

--- a/models/tt_transformers/tt/multimodal/llama_vision_model.py
+++ b/models/tt_transformers/tt/multimodal/llama_vision_model.py
@@ -739,7 +739,9 @@ class CrossAttentionTransformer(torch.nn.Module):
             cross_page_table=cross_page_table,
         )
         tt_out = ttnn.to_layout(logits, ttnn.ROW_MAJOR_LAYOUT)
-        return tt_out
+
+        # Return logits and None for log-probs for compatibility with generator interface
+        return tt_out, None
 
 
 def _stack_images(


### PR DESCRIPTION
### Ticket
#[32262](https://github.com/tenstorrent/tt-metal/issues/32262)

### Problem description
We are missing log-probs feature in tt-metal which is requirement for UF release eow.

### Feature description: 
For each sampled token by sampling op, it's required to return log-probability of it. It gives confidence of token that is sampled as extra information apart from produced token. 

### What's changed
- Implementation of LogProbsCalculator class for calculating log-probs
- Added unit tests with Qwen3 shapes
- Integration into simple_text_demo.py 
- To calculate it, LogProbsCalculator class is responsible for. All the implementation

Warning: Implementation of penalties here should be skipped reviewing since it's rebase to @sraizada-tt's branch: 

Review appreciated on: 
- `logProbsCalculator` class inside utils.py
- propagation in `generator.py`
- ignore function names in unit testing since it's still not polished. Mostly early opened to get early feedback on implementation and integration approach 
cc: @skhorasganiTT @sraizada-tt @rdraskicTT your feedback is much appreciated!

pipelines: 
- [BH Multi-card demo](https://github.com/tenstorrent/tt-metal/actions/runs/19853858206)
- [Galaxy Quick](https://github.com/tenstorrent/tt-metal/actions/runs/19854152113)
- [Galaxy Demo](https://github.com/tenstorrent/tt-metal/actions/runs/19854177690)
- [(Single-card) Demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/19853904911)
- [(T3K) demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/19853915344)
