### PR TITLE
PDL atol/rtol check

### DIFF
--- a/models/experimental/panoptic_deeplab/tests/pcc/common.py
+++ b/models/experimental/panoptic_deeplab/tests/pcc/common.py
@@ -19,8 +19,8 @@ def get_abs_and_relative_error(tensor_a, tensor_b):
     return abs_error, relative_error
 
 
-def check_with_tolerance(abs_err, rel_err, exp_atol, exp_rtol):
-    return abs_err <= exp_atol and rel_err <= exp_rtol
+def check_with_tolerance(abs_err, rel_err, exp_abs_err, exp_rel_err):
+    return abs_err <= exp_abs_err and rel_err <= exp_rel_err
 
 
 def check_ttnn_output(
@@ -29,14 +29,18 @@ def check_ttnn_output(
     ttnn_output,
     to_channel_first=False,
     output_channels=None,
+    output_shape=None,
     exp_pcc=0.999,
-    exp_atol=1e-08,
-    exp_rtol=1e-05,
+    exp_abs_err=1e-08,
+    exp_rel_err=1e-05,
 ):
     ttnn_output_torch = ttnn.to_torch(ttnn_output)
 
     if to_channel_first:
         ttnn_output_torch = ttnn_output_torch.permute(0, 3, 1, 2)  # NHWC to NCHW
+
+    if output_shape:
+        ttnn_output_torch = torch.reshape(ttnn_output_torch, output_shape)
 
     if output_channels is not None:
         logger.debug(f"Slicing {layer_name} output from {ttnn_output_torch.shape[1]} to {output_channels} channels")
@@ -44,7 +48,7 @@ def check_ttnn_output(
 
     abs_err, rel_err = get_abs_and_relative_error(pytorch_output, ttnn_output_torch)
     passed_pcc, pcc = check_with_pcc(pytorch_output, ttnn_output_torch, exp_pcc)
-    passed_tolerance = check_with_tolerance(abs_err, rel_err, exp_atol, exp_rtol)
+    passed_tolerance = check_with_tolerance(abs_err, rel_err, exp_abs_err, exp_rel_err)
     special_char = "✅" if passed_pcc and passed_tolerance else "❌"
     logger.warning(
         f"{special_char} Output {layer_name}: {passed_pcc=}, {pcc=}, {passed_tolerance=}, {abs_err=:.3f}, {rel_err=:.3f}"

--- a/models/experimental/panoptic_deeplab/tests/pcc/common.py
+++ b/models/experimental/panoptic_deeplab/tests/pcc/common.py
@@ -30,8 +30,8 @@ def check_ttnn_output(
     to_channel_first=False,
     output_channels=None,
     exp_pcc=0.999,
-    exp_atol=12.0,
-    exp_rtol=5.0,
+    exp_atol=1e-08,
+    exp_rtol=1e-05,
 ):
     ttnn_output_torch = ttnn.to_torch(ttnn_output)
 

--- a/models/experimental/panoptic_deeplab/tests/pcc/test_insemb.py
+++ b/models/experimental/panoptic_deeplab/tests/pcc/test_insemb.py
@@ -128,6 +128,8 @@ def test_ttnn_insemb(device, model_location_generator):
             to_channel_first=False,
             output_channels=ttnn_model.instance_head.get_center_output_channels_for_slicing(),
             exp_pcc=0.887,
+            exp_atol=0.09,
+            exp_rtol=27.5,
         )
     )
     all_passed.append(
@@ -138,9 +140,11 @@ def test_ttnn_insemb(device, model_location_generator):
             to_channel_first=False,
             output_channels=ttnn_model.instance_head.get_offset_output_channels_for_slicing(),
             exp_pcc=0.742,
+            exp_atol=6.8,
+            exp_rtol=5.0,
         )
     )
 
     # Fail test based on PCC results
-    assert all(all_passed), f"PDL outputs did not pass the PCC check {all_passed=}"
-    logger.info("All PCC tests passed!")
+    assert all(all_passed), f"PDL outputs did not pass the PCC and tolerance check {all_passed=}"
+    logger.info("All PCC and tolerance tests passed!")

--- a/models/experimental/panoptic_deeplab/tests/pcc/test_insemb.py
+++ b/models/experimental/panoptic_deeplab/tests/pcc/test_insemb.py
@@ -128,8 +128,8 @@ def test_ttnn_insemb(device, model_location_generator):
             to_channel_first=False,
             output_channels=ttnn_model.instance_head.get_center_output_channels_for_slicing(),
             exp_pcc=0.887,
-            exp_atol=0.09,
-            exp_rtol=27.5,
+            exp_abs_err=0.09,
+            exp_rel_err=27.5,
         )
     )
     all_passed.append(
@@ -140,8 +140,8 @@ def test_ttnn_insemb(device, model_location_generator):
             to_channel_first=False,
             output_channels=ttnn_model.instance_head.get_offset_output_channels_for_slicing(),
             exp_pcc=0.742,
-            exp_atol=6.8,
-            exp_rtol=5.0,
+            exp_abs_err=6.8,
+            exp_rel_err=5.0,
         )
     )
 

--- a/models/experimental/panoptic_deeplab/tests/pcc/test_resnet.py
+++ b/models/experimental/panoptic_deeplab/tests/pcc/test_resnet.py
@@ -8,7 +8,7 @@ ResNet Tests for Panoptic DeepLab using real weights from model_final_bd324a.pkl
 import pytest
 import torch
 import ttnn
-from tests.ttnn.utils_for_testing import assert_with_pcc, check_with_pcc
+from tests.ttnn.utils_for_testing import assert_with_pcc
 from loguru import logger
 
 from models.experimental.panoptic_deeplab.tt.model_preprocessing import (
@@ -24,6 +24,7 @@ from models.experimental.panoptic_deeplab.tt.common import (
     get_panoptic_deeplab_config,
     preprocess_nchw_input_tensor,
 )
+from models.experimental.panoptic_deeplab.tests.pcc.common import check_ttnn_output
 
 
 def create_panoptic_models(device, weights_path):
@@ -253,16 +254,40 @@ def test_resnet_full_pcc(device, batch_size, height, width, reset_seeds, model_l
         "res5": 0.9945,
     }
 
+    layer_exp_abs_err = {
+        "res2": 0.1,
+        "res3": 0.04,
+        "res4": 0.02,
+        "res5": 0.01,
+    }
+
+    layer_exp_rel_err = {
+        "res2": 0.3,
+        "res3": 0.6,
+        "res4": 0.3,
+        "res5": 0.6,
+    }
+
     for layer_name in ["res2", "res3", "res4", "res5"]:
         torch_output = torch_outputs[layer_name]
         ttnn_output = ttnn_outputs[layer_name]
-        ttnn_output_torch = ttnn.to_torch(ttnn_output).permute(0, 3, 1, 2).reshape(torch_output.shape)
 
         pcc_threshold = layer_pcc_thresholds[layer_name]
-        pcc_passed, pcc_message = check_with_pcc(torch_output, ttnn_output_torch, pcc_threshold)
-        logger.info(f"ResNet {layer_name} PCC: {pcc_message}")
+        exp_abs_err = layer_exp_abs_err[layer_name]
+        exp_rel_err = layer_exp_rel_err[layer_name]
 
-        if not pcc_passed:
+        passed = check_ttnn_output(
+            layer_name,
+            torch_output,
+            ttnn_output,
+            to_channel_first=True,
+            output_shape=torch_output.shape,
+            exp_pcc=pcc_threshold,
+            exp_abs_err=exp_abs_err,
+            exp_rel_err=exp_rel_err,
+        )
+
+        if not passed:
             failed_layers.append(layer_name)
 
-    assert len(failed_layers) == 0, f"ResNet full PCC test failed for layers: {failed_layers}"
+    assert len(failed_layers) == 0, f"ResNet full PCC and tolerance tests failed for layers: {failed_layers}"

--- a/models/experimental/panoptic_deeplab/tests/pcc/test_semseg.py
+++ b/models/experimental/panoptic_deeplab/tests/pcc/test_semseg.py
@@ -121,7 +121,7 @@ def test_ttnn_semseg(device, model_location_generator):
         to_channel_first=False,
         output_channels=ttnn_model.semantic_head.get_output_channels_for_slicing(),
         exp_pcc=0.972,
-        exp_atol=2.0,
-        exp_rtol=0.4,
+        exp_abs_err=2.0,
+        exp_rel_err=0.4,
     )
     assert passed, f"Semantic segmentation PCC and tolerance tests failed"

--- a/models/experimental/panoptic_deeplab/tests/pcc/test_semseg.py
+++ b/models/experimental/panoptic_deeplab/tests/pcc/test_semseg.py
@@ -121,5 +121,7 @@ def test_ttnn_semseg(device, model_location_generator):
         to_channel_first=False,
         output_channels=ttnn_model.semantic_head.get_output_channels_for_slicing(),
         exp_pcc=0.972,
+        exp_atol=2.0,
+        exp_rtol=0.4,
     )
-    assert passed, f"Semantic segmentation PCC test failed"
+    assert passed, f"Semantic segmentation PCC and tolerance tests failed"

--- a/models/experimental/panoptic_deeplab/tests/pcc/test_tt_model.py
+++ b/models/experimental/panoptic_deeplab/tests/pcc/test_tt_model.py
@@ -138,7 +138,7 @@ def test_model_panoptic_deeplab(device, model_category, model_location_generator
             to_channel_first=False,
             output_channels=ttnn_model.semantic_head.get_output_channels_for_slicing(),
             exp_pcc=0.986,
-            exp_atol=2.0,
+            exp_atol=1.3,
             exp_rtol=0.4,
         )
     )
@@ -151,8 +151,8 @@ def test_model_panoptic_deeplab(device, model_category, model_location_generator
                 to_channel_first=False,
                 output_channels=ttnn_model.instance_head.get_center_output_channels_for_slicing(),
                 exp_pcc=0.805,
-                exp_atol=0.09,
-                exp_rtol=31.0,
+                exp_atol=0.1,
+                exp_rtol=2.0,
             )
         )
         all_passed.append(
@@ -163,8 +163,8 @@ def test_model_panoptic_deeplab(device, model_category, model_location_generator
                 to_channel_first=False,
                 output_channels=ttnn_model.instance_head.get_offset_output_channels_for_slicing(),
                 exp_pcc=0.990,
-                exp_atol=9.8,
-                exp_rtol=5.0,
+                exp_atol=10.4,
+                exp_rtol=0.6,
             )
         )
 

--- a/models/experimental/panoptic_deeplab/tests/pcc/test_tt_model.py
+++ b/models/experimental/panoptic_deeplab/tests/pcc/test_tt_model.py
@@ -163,5 +163,5 @@ def test_model_panoptic_deeplab(device, model_category, model_location_generator
         )
 
     # Fail test based on PCC results
-    assert all(all_passed), f"PDL outputs did not pass the PCC check {all_passed=}"
-    logger.info("All PCC tests passed!")
+    assert all(all_passed), f"PDL outputs did not pass the PCC and tolerance check {all_passed=}"
+    logger.info("All PCC and tolerance tests passed!")

--- a/models/experimental/panoptic_deeplab/tests/pcc/test_tt_model.py
+++ b/models/experimental/panoptic_deeplab/tests/pcc/test_tt_model.py
@@ -138,8 +138,8 @@ def test_model_panoptic_deeplab(device, model_category, model_location_generator
             to_channel_first=False,
             output_channels=ttnn_model.semantic_head.get_output_channels_for_slicing(),
             exp_pcc=0.986,
-            exp_atol=1.3,
-            exp_rtol=0.4,
+            exp_abs_err=1.3,
+            exp_rel_err=0.4,
         )
     )
     if model_category == PANOPTIC_DEEPLAB:
@@ -151,8 +151,8 @@ def test_model_panoptic_deeplab(device, model_category, model_location_generator
                 to_channel_first=False,
                 output_channels=ttnn_model.instance_head.get_center_output_channels_for_slicing(),
                 exp_pcc=0.805,
-                exp_atol=0.1,
-                exp_rtol=2.0,
+                exp_abs_err=0.1,
+                exp_rel_err=2.0,
             )
         )
         all_passed.append(
@@ -163,8 +163,8 @@ def test_model_panoptic_deeplab(device, model_category, model_location_generator
                 to_channel_first=False,
                 output_channels=ttnn_model.instance_head.get_offset_output_channels_for_slicing(),
                 exp_pcc=0.990,
-                exp_atol=10.4,
-                exp_rtol=0.6,
+                exp_abs_err=10.4,
+                exp_rel_err=0.6,
             )
         )
 

--- a/models/experimental/panoptic_deeplab/tests/pcc/test_tt_model.py
+++ b/models/experimental/panoptic_deeplab/tests/pcc/test_tt_model.py
@@ -138,6 +138,8 @@ def test_model_panoptic_deeplab(device, model_category, model_location_generator
             to_channel_first=False,
             output_channels=ttnn_model.semantic_head.get_output_channels_for_slicing(),
             exp_pcc=0.986,
+            exp_atol=2.0,
+            exp_rtol=0.4,
         )
     )
     if model_category == PANOPTIC_DEEPLAB:
@@ -149,6 +151,8 @@ def test_model_panoptic_deeplab(device, model_category, model_location_generator
                 to_channel_first=False,
                 output_channels=ttnn_model.instance_head.get_center_output_channels_for_slicing(),
                 exp_pcc=0.805,
+                exp_atol=0.09,
+                exp_rtol=31.0,
             )
         )
         all_passed.append(
@@ -159,6 +163,8 @@ def test_model_panoptic_deeplab(device, model_category, model_location_generator
                 to_channel_first=False,
                 output_channels=ttnn_model.instance_head.get_offset_output_channels_for_slicing(),
                 exp_pcc=0.990,
+                exp_atol=9.8,
+                exp_rtol=5.0,
             )
         )
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/33224

### Problem description
PCC check is not a good metric for segmentation models output check. The idea is to also check absolute and relative error in addition to PCC for the PDL outputs.

### What's changed
This PR adds check for absolute and relative errors inside PDL tests. `check_ttnn_output()` now also checks if relative and absolute errors are equal or below expected `exp_abs_err` and `exp_rel_err` tolerance values. Default values for `exp_abs_err` and `exp_rel_err` are taken from NumPy documentation: https://numpy.org/doc/stable/reference/generated/numpy.allclose.html.

### Checklist
- [ ] [All-post commit](https://github.com/tenstorrent/tt-metal/actions/runs/19761078195) CI passes
- [ ] [Blackhole nightly tests](https://github.com/tenstorrent/tt-metal/actions/runs/19761949987) CI passes
- [ ] [(Single-card) Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/runs/19761101605) CI passes