### PR TITLE
Re-enable the tests for (Galaxy) Frequent Pipeline.

### DIFF
--- a/tests/scripts/run_tests.sh
+++ b/tests/scripts/run_tests.sh
@@ -186,18 +186,13 @@ unit_tg_device() {
 }
 
 # Run tg frequent tests
-# DEPRECATED: Galaxy frequent tests now call pytest directly from GitHub Actions workflow
-# See: .github/workflows/galaxy-frequent-tests-impl.yaml
 frequent_tg_device() {
     local tt_arch=$1
     local pipeline_type=$2
     local dispatch_mode=$3
     local model=$4
 
-    echo "ERROR: frequent_tg_device is deprecated."
-    echo "Galaxy frequent tests now run directly from GitHub Actions workflow."
-    echo "See: .github/workflows/galaxy-frequent-tests-impl.yaml"
-    exit 1
+    ./tests/scripts/tg/run_tg_frequent_tests.sh --model "$model"
 }
 
 # Run tg demo tests


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
The tests were disabled prematurely. Workflow (Galaxy) Frequent changes were rolled back but tests were not re-enabled.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes