### PR TITLE
Add full grid worker forwarding channels for UDM Mux [4/n] 

### DIFF
--- a/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
+++ b/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
@@ -373,7 +373,8 @@ void UDMFabricUnicastCommon(
     const std::variant<
         std::tuple<RoutingDirection, uint32_t /*num_hops*/>,
         std::tuple<uint32_t /*src_node*/, uint32_t /*dest_node*/>>& routing_info,
-    std::optional<RoutingDirection> override_initial_direction = std::nullopt);
+    std::optional<RoutingDirection> override_initial_direction = std::nullopt,
+    std::optional<std::vector<std::pair<CoreCoord, CoreCoord>>> worker_coords_list = std::nullopt);
 
 void FabricMulticastCommon(
     BaseFabricFixture* fixture,

--- a/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
+++ b/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
@@ -213,28 +213,44 @@ protected:
 };
 
 class Fabric2DUDMModeFixture : public BaseFabricFixture {
+private:
+    inline static bool should_skip_ = false;
+
 protected:
     static void SetUpTestSuite() {
+        // Check specifically for Wormhole Galaxy
+        arch_ = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
+        bool is_wormhole_galaxy = (arch_ == tt::ARCH::WORMHOLE_B0) &&
+                                  (tt::tt_metal::MetalContext::instance().get_cluster().is_ubb_galaxy() ||
+                                   tt::tt_metal::MetalContext::instance().get_cluster().is_galaxy_cluster());
+
+        if (is_wormhole_galaxy) {
+            should_skip_ = true;
+            return;
+        }
+
         BaseFabricFixture::DoSetUpTestSuite(
             tt::tt_fabric::FabricConfig::FABRIC_2D,
             std::nullopt,
             tt_fabric::FabricTensixConfig::UDM,
             tt_fabric::FabricUDMMode::ENABLED);
     }
-    static void TearDownTestSuite() { BaseFabricFixture::DoTearDownTestSuite(); }
+
+    static void TearDownTestSuite() {
+        if (!should_skip_) {
+            BaseFabricFixture::DoTearDownTestSuite();
+        }
+    }
+
+    void SetUp() override {
+        if (should_skip_) {
+            GTEST_SKIP() << "Tensix fixture tests are not supported on Wormhole Galaxy systems";
+        }
+        BaseFabricFixture::SetUp();
+    }
 };
 
-class NightlyFabric2DUDMModeFixture : public BaseFabricFixture {
-protected:
-    static void SetUpTestSuite() {
-        BaseFabricFixture::DoSetUpTestSuite(
-            tt::tt_fabric::FabricConfig::FABRIC_2D,
-            std::nullopt,
-            tt_fabric::FabricTensixConfig::UDM,
-            tt_fabric::FabricUDMMode::ENABLED);
-    }
-    static void TearDownTestSuite() { BaseFabricFixture::DoTearDownTestSuite(); }
-};
+class NightlyFabric2DUDMModeFixture : public Fabric2DUDMModeFixture {};
 
 class NightlyFabric2DFixture : public BaseFabricFixture {
 protected:

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/kernels/test_udm_read_receiver.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/kernels/test_udm_read_receiver.cpp
@@ -19,10 +19,8 @@ constexpr uint16_t packet_payload_size_bytes = static_cast<uint16_t>(get_compile
 constexpr uint32_t num_packets = get_compile_time_arg_val(6);
 constexpr uint32_t time_seed_init = get_compile_time_arg_val(7);
 constexpr uint32_t req_notification_size_bytes = get_compile_time_arg_val(8);
-constexpr uint32_t noc_x_start = get_compile_time_arg_val(9);
-constexpr uint32_t noc_y_start = get_compile_time_arg_val(10);
-constexpr uint32_t dst_dev_id = get_compile_time_arg_val(11);
-constexpr uint32_t dst_mesh_id = get_compile_time_arg_val(12);
+constexpr uint32_t dst_dev_id = get_compile_time_arg_val(9);
+constexpr uint32_t dst_mesh_id = get_compile_time_arg_val(10);
 
 /*
  * This test kernel is a kernel to test the functionality that will be implemented in a fabric relay kernel.
@@ -32,6 +30,12 @@ constexpr uint32_t dst_mesh_id = get_compile_time_arg_val(12);
 void kernel_main() {
     // TODO: move this into fw once consolidated
     tt::tt_fabric::udm::fabric_local_state_init();
+
+    // Per-core sender coordinates from runtime args
+    // TODO: once we dont need any runtime args for fabric connection, we can start from 0 offset
+    uint32_t start_offset = 3;
+    uint32_t noc_x_start = get_arg_val<uint32_t>(start_offset++);
+    uint32_t noc_y_start = get_arg_val<uint32_t>(start_offset);
 
     uint32_t time_seed = time_seed_init;
 

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/kernels/test_udm_read_receiver.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/kernels/test_udm_read_receiver.cpp
@@ -32,10 +32,9 @@ void kernel_main() {
     tt::tt_fabric::udm::fabric_local_state_init();
 
     // Per-core sender coordinates from runtime args
-    // TODO: once we dont need any runtime args for fabric connection, we can start from 0 offset
-    uint32_t start_offset = 3;
-    uint32_t noc_x_start = get_arg_val<uint32_t>(start_offset++);
-    uint32_t noc_y_start = get_arg_val<uint32_t>(start_offset);
+    uint32_t arg_index = 0;
+    uint32_t noc_x_start = get_arg_val<uint32_t>(arg_index++);
+    uint32_t noc_y_start = get_arg_val<uint32_t>(arg_index);
 
     uint32_t time_seed = time_seed_init;
 

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/kernels/test_udm_read_sender.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/kernels/test_udm_read_sender.cpp
@@ -24,10 +24,9 @@ void kernel_main() {
     tt::tt_fabric::udm::fabric_local_state_init();
 
     // Per-core receiver coordinates from runtime args
-    // TODO: once we dont need any runtime args for fabric connection, we can start from 0 offset
-    uint32_t start_offset = 3;
-    uint32_t noc_x_start = get_arg_val<uint32_t>(start_offset++);
-    uint32_t noc_y_start = get_arg_val<uint32_t>(start_offset);
+    uint32_t arg_index = 0;
+    uint32_t noc_x_start = get_arg_val<uint32_t>(arg_index++);
+    uint32_t noc_y_start = get_arg_val<uint32_t>(arg_index);
 
     uint32_t time_seed = time_seed_init;
 

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/kernels/test_udm_read_sender.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/kernels/test_udm_read_sender.cpp
@@ -15,15 +15,19 @@ constexpr uint32_t source_l1_buffer_address = get_compile_time_arg_val(5);
 constexpr uint16_t packet_payload_size_bytes = static_cast<uint16_t>(get_compile_time_arg_val(6));
 constexpr uint32_t num_packets = get_compile_time_arg_val(7);
 constexpr uint32_t time_seed_init = get_compile_time_arg_val(8);
-constexpr uint32_t noc_x_start = get_compile_time_arg_val(9);
-constexpr uint32_t noc_y_start = get_compile_time_arg_val(10);
-constexpr uint32_t dst_dev_id = get_compile_time_arg_val(11);
-constexpr uint32_t dst_mesh_id = get_compile_time_arg_val(12);
-constexpr uint32_t req_notification_size_bytes = get_compile_time_arg_val(13);
+constexpr uint32_t dst_dev_id = get_compile_time_arg_val(9);
+constexpr uint32_t dst_mesh_id = get_compile_time_arg_val(10);
+constexpr uint32_t req_notification_size_bytes = get_compile_time_arg_val(11);
 
 void kernel_main() {
     // TODO: move this into fw once consolidated
     tt::tt_fabric::udm::fabric_local_state_init();
+
+    // Per-core receiver coordinates from runtime args
+    // TODO: once we dont need any runtime args for fabric connection, we can start from 0 offset
+    uint32_t start_offset = 3;
+    uint32_t noc_x_start = get_arg_val<uint32_t>(start_offset++);
+    uint32_t noc_y_start = get_arg_val<uint32_t>(start_offset);
 
     uint32_t time_seed = time_seed_init;
 

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/kernels/test_udm_sender.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/kernels/test_udm_sender.cpp
@@ -24,10 +24,9 @@ void kernel_main() {
     tt::tt_fabric::udm::fabric_local_state_init();
 
     // Per-core receiver coordinates from runtime args
-    // TODO: once we dont need any runtime args for fabric connection, we can start from 0 offset
-    uint32_t start_offset = 3;
-    uint32_t noc_x_start = get_arg_val<uint32_t>(start_offset++);
-    uint32_t noc_y_start = get_arg_val<uint32_t>(start_offset);
+    uint32_t arg_index = 0;
+    uint32_t noc_x_start = get_arg_val<uint32_t>(arg_index++);
+    uint32_t noc_y_start = get_arg_val<uint32_t>(arg_index);
 
     uint32_t time_seed = time_seed_init;
 

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/kernels/test_udm_sender.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/kernels/test_udm_sender.cpp
@@ -15,18 +15,20 @@ constexpr uint32_t source_l1_buffer_address = get_compile_time_arg_val(5);
 constexpr uint16_t packet_payload_size_bytes = static_cast<uint16_t>(get_compile_time_arg_val(6));
 constexpr uint32_t num_packets = get_compile_time_arg_val(7);
 constexpr uint32_t time_seed_init = get_compile_time_arg_val(8);
-constexpr uint32_t noc_x_start = get_compile_time_arg_val(9);
-constexpr uint32_t noc_y_start = get_compile_time_arg_val(10);
-constexpr uint32_t dst_dev_id = get_compile_time_arg_val(11);
-constexpr uint32_t dst_mesh_id = get_compile_time_arg_val(12);
-constexpr uint32_t req_notification_size_bytes = get_compile_time_arg_val(13);
+constexpr uint32_t dst_dev_id = get_compile_time_arg_val(9);
+constexpr uint32_t dst_mesh_id = get_compile_time_arg_val(10);
+constexpr uint32_t req_notification_size_bytes = get_compile_time_arg_val(11);
 
 void kernel_main() {
     // TODO: move this into fw once consolidated
     tt::tt_fabric::udm::fabric_local_state_init();
 
-    // Runtime args are set up by append_fabric_connection_rt_args and used internally by fabric_fast_write
-    // We don't need to read them explicitly here
+    // Per-core receiver coordinates from runtime args
+    // TODO: once we dont need any runtime args for fabric connection, we can start from 0 offset
+    uint32_t start_offset = 3;
+    uint32_t noc_x_start = get_arg_val<uint32_t>(start_offset++);
+    uint32_t noc_y_start = get_arg_val<uint32_t>(start_offset);
+
     uint32_t time_seed = time_seed_init;
 
     zero_l1_buf(test_results, test_results_size_bytes);

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
@@ -2284,9 +2284,15 @@ void UDMFabricUnicastCommon(
     const std::variant<
         std::tuple<RoutingDirection, uint32_t /*num_hops*/>,
         std::tuple<uint32_t /*src_node*/, uint32_t /*dest_node*/>>& routing_info,
-    std::optional<RoutingDirection> override_initial_direction) {
-    CoreCoord sender_logical_core = {0, 0};
-    CoreCoord receiver_logical_core = {1, 0};
+    std::optional<RoutingDirection> override_initial_direction,
+    std::optional<std::vector<std::pair<CoreCoord, CoreCoord>>> worker_coords_list) {
+    // Build list of worker coordinate pairs - default to single pair (0,0) -> (1,0)
+    std::vector<std::pair<CoreCoord, CoreCoord>> worker_pairs;
+    if (worker_coords_list.has_value()) {
+        worker_pairs = worker_coords_list.value();
+    } else {
+        worker_pairs.push_back({CoreCoord{0, 0}, CoreCoord{1, 0}});
+    }
     uint32_t num_packets = 10;
     uint32_t time_seed = std::chrono::system_clock::now().time_since_epoch().count();
 
@@ -2339,12 +2345,10 @@ void UDMFabricUnicastCommon(
     }
 
     auto receiver_device = fixture->get_device(dst_physical_device_id);
-
     auto sender_device = fixture->get_device(src_physical_device_id);
-    CoreCoord sender_virtual_core = sender_device->worker_core_from_logical_core(sender_logical_core);
-    CoreCoord receiver_virtual_core = receiver_device->worker_core_from_logical_core(receiver_logical_core);
 
     tt_metal::Program sender_program = tt_metal::CreateProgram();
+    tt_metal::Program receiver_program = tt_metal::CreateProgram();
 
     auto worker_mem_map = generate_worker_mem_map(sender_device, topology);
 
@@ -2356,10 +2360,41 @@ void UDMFabricUnicastCommon(
     }
 
     // Define req_notification_size_bytes for read operations
-    // Must include full packet header (80B max) + sync data (48B)
     constexpr uint32_t req_notification_size_bytes = 128;
 
-    std::vector<uint32_t> compile_time_args = {
+    // Set up fabric connection destination for override_initial_direction
+    FabricNodeId fabric_connection_dest_node_id = dest_fabric_node_id;
+    if (override_initial_direction.has_value()) {
+        auto neighbors = control_plane.get_intra_chip_neighbors(src_fabric_node_id, override_initial_direction.value());
+        if (neighbors.empty()) {
+            GTEST_SKIP() << "No neighbor found in the specified initial direction "
+                         << static_cast<int>(override_initial_direction.value()) << " from node "
+                         << src_fabric_node_id.chip_id;
+        }
+        fabric_connection_dest_node_id = FabricNodeId(src_fabric_node_id.mesh_id, neighbors[0]);
+    }
+
+    // Select kernel paths based on operation type
+    const char* sender_kernel_path =
+        (noc_send_type == NOC_UNICAST_READ)
+            ? "tests/tt_metal/tt_fabric/fabric_data_movement/kernels/test_udm_read_sender.cpp"
+            : "tests/tt_metal/tt_fabric/fabric_data_movement/kernels/test_udm_sender.cpp";
+    const char* receiver_kernel_path =
+        (noc_send_type == NOC_UNICAST_READ)
+            ? "tests/tt_metal/tt_fabric/fabric_data_movement/kernels/test_udm_read_receiver.cpp"
+            : "tests/tt_metal/tt_fabric/fabric_data_movement/kernels/test_udm_receiver.cpp";
+
+    // Build CoreRangeSets for all sender and receiver cores
+    std::vector<CoreCoord> sender_cores, receiver_cores;
+    for (const auto& [sender_logical_core, receiver_logical_core] : worker_pairs) {
+        sender_cores.push_back(sender_logical_core);
+        receiver_cores.push_back(receiver_logical_core);
+    }
+    CoreRangeSet sender_core_range(sender_cores);
+    CoreRangeSet receiver_core_range(receiver_cores);
+
+    // Sender compile time args (per-core receiver coords moved to runtime args)
+    std::vector<uint32_t> sender_compile_time_args = {
         worker_mem_map.test_results_address,
         worker_mem_map.test_results_size_bytes,
         worker_mem_map.notification_mailbox_address,
@@ -2369,60 +2404,20 @@ void UDMFabricUnicastCommon(
         worker_mem_map.packet_payload_size_bytes,
         num_packets,
         time_seed,
-        receiver_virtual_core.x,
-        receiver_virtual_core.y,
         dest_fabric_node_id.chip_id,
-        dest_fabric_node_id.mesh_id.get()};
-
-    // Add req_notification_size_bytes for both read and write operations
-    compile_time_args.push_back(req_notification_size_bytes);
-
-    // Set up fabric connection runtime args
-    // If override_initial_direction is provided, connect to the mux in that direction instead
-    FabricNodeId fabric_connection_dest_node_id = dest_fabric_node_id;
-    if (override_initial_direction.has_value()) {
-        // Get the neighbor in the override direction - this will be the mux we connect to
-        auto neighbors = control_plane.get_intra_chip_neighbors(src_fabric_node_id, override_initial_direction.value());
-        if (neighbors.empty()) {
-            GTEST_SKIP() << "No neighbor found in the specified initial direction "
-                         << static_cast<int>(override_initial_direction.value()) << " from node "
-                         << src_fabric_node_id.chip_id;
-        }
-        // Use the first neighbor in override_initial_direction as the fabric connection destination
-        fabric_connection_dest_node_id = FabricNodeId(src_fabric_node_id.mesh_id, neighbors[0]);
-    }
-
-    uint32_t sender_link_idx = 0;
-    std::vector<uint32_t> sender_runtime_args;
-    append_fabric_connection_rt_args(
-        src_fabric_node_id,
-        fabric_connection_dest_node_id,  // Connect to the mux in override direction if specified
-        sender_link_idx,
-        sender_program,
-        sender_logical_core,
-        sender_runtime_args);
-
-    // Select sender kernel based on operation type
-    const char* sender_kernel_path =
-        (noc_send_type == NOC_UNICAST_READ)
-            ? "tests/tt_metal/tt_fabric/fabric_data_movement/kernels/test_udm_read_sender.cpp"
-            : "tests/tt_metal/tt_fabric/fabric_data_movement/kernels/test_udm_sender.cpp";
+        dest_fabric_node_id.mesh_id.get(),
+        req_notification_size_bytes};
 
     auto sender_kernel = tt_metal::CreateKernel(
         sender_program,
         sender_kernel_path,
-        {sender_logical_core},
+        sender_core_range,
         tt_metal::DataMovementConfig{
             .processor = tt_metal::DataMovementProcessor::RISCV_0,
             .noc = tt_metal::NOC::RISCV_0_default,
-            .compile_args = compile_time_args});
+            .compile_args = sender_compile_time_args});
 
-    tt_metal::SetRuntimeArgs(sender_program, sender_kernel, sender_logical_core, sender_runtime_args);
-
-    // Create receiver program
-    tt_metal::Program receiver_program = tt_metal::CreateProgram();
-
-    // Create receiver compile time args
+    // Receiver compile time args (per-core sender coords moved to runtime args)
     std::vector<uint32_t> receiver_compile_time_args = {
         worker_mem_map.test_results_address,
         worker_mem_map.test_results_size_bytes,
@@ -2431,57 +2426,64 @@ void UDMFabricUnicastCommon(
         noc_send_type,
         worker_mem_map.packet_payload_size_bytes,
         num_packets,
-        time_seed};
-
-    // Add req_notification_size_bytes for both read and write operations
-    receiver_compile_time_args.push_back(req_notification_size_bytes);
-
-    // For read operations, receiver needs sender's NOC coordinates and fabric IDs to send notifications
-    if (noc_send_type == NOC_UNICAST_READ) {
-        receiver_compile_time_args.push_back(sender_virtual_core.x);
-        receiver_compile_time_args.push_back(sender_virtual_core.y);
-        receiver_compile_time_args.push_back(src_fabric_node_id.chip_id);
-        receiver_compile_time_args.push_back(src_fabric_node_id.mesh_id.get());
-    }
-
-    // Select receiver kernel based on operation type
-    const char* receiver_kernel_path =
-        (noc_send_type == NOC_UNICAST_READ)
-            ? "tests/tt_metal/tt_fabric/fabric_data_movement/kernels/test_udm_read_receiver.cpp"
-            : "tests/tt_metal/tt_fabric/fabric_data_movement/kernels/test_udm_receiver.cpp";
+        time_seed,
+        req_notification_size_bytes,
+        src_fabric_node_id.chip_id,
+        src_fabric_node_id.mesh_id.get()};
 
     auto receiver_kernel = tt_metal::CreateKernel(
         receiver_program,
         receiver_kernel_path,
-        {receiver_logical_core},
+        receiver_core_range,
         tt_metal::DataMovementConfig{
             .processor = tt_metal::DataMovementProcessor::RISCV_0,
             .noc = tt_metal::NOC::RISCV_0_default,
             .compile_args = receiver_compile_time_args});
 
-    // Set up fabric connection runtime args for receiver to send ACKs back to sender
-    std::vector<uint32_t> receiver_runtime_args;
-    uint32_t receiver_link_idx = 0;
-    append_fabric_connection_rt_args(
-        dest_fabric_node_id,
-        src_fabric_node_id,
-        receiver_link_idx,
-        receiver_program,
-        receiver_logical_core,
-        receiver_runtime_args);
+    // Set per-core runtime args (receiver/sender coords + fabric connection)
+    for (const auto& [sender_logical_core, receiver_logical_core] : worker_pairs) {
+        CoreCoord sender_virtual_core = sender_device->worker_core_from_logical_core(sender_logical_core);
+        CoreCoord receiver_virtual_core = receiver_device->worker_core_from_logical_core(receiver_logical_core);
 
-    tt_metal::SetRuntimeArgs(receiver_program, receiver_kernel, receiver_logical_core, receiver_runtime_args);
+        // Sender runtime args: receiver coords first, then fabric connection
+        uint32_t sender_link_idx = 0;
+        std::vector<uint32_t> sender_runtime_args;
+        append_fabric_connection_rt_args(
+            src_fabric_node_id,
+            fabric_connection_dest_node_id,
+            sender_link_idx,
+            sender_program,
+            sender_logical_core,
+            sender_runtime_args);
+        sender_runtime_args.push_back(receiver_virtual_core.x);
+        sender_runtime_args.push_back(receiver_virtual_core.y);
+        tt_metal::SetRuntimeArgs(sender_program, sender_kernel, sender_logical_core, sender_runtime_args);
 
-    // Clear target L1 memory for atomic increments since we expect initial values to be 0
-    if (noc_send_type == NOC_UNICAST_ATOMIC_INC) {
-        uint32_t total_size_to_clear = num_packets * worker_mem_map.packet_payload_size_bytes;
-        std::vector<uint32_t> zeros(total_size_to_clear / sizeof(uint32_t), 0);
-        tt_metal::detail::WriteToDeviceL1(
-            receiver_device->get_devices()[0],
+        // Receiver runtime args: sender coords first, then fabric connection
+        uint32_t receiver_link_idx = 0;
+        std::vector<uint32_t> receiver_runtime_args;
+        append_fabric_connection_rt_args(
+            dest_fabric_node_id,
+            src_fabric_node_id,
+            receiver_link_idx,
+            receiver_program,
             receiver_logical_core,
-            worker_mem_map.target_address,
-            zeros,
-            CoreType::WORKER);
+            receiver_runtime_args);
+        receiver_runtime_args.push_back(sender_virtual_core.x);
+        receiver_runtime_args.push_back(sender_virtual_core.y);
+        tt_metal::SetRuntimeArgs(receiver_program, receiver_kernel, receiver_logical_core, receiver_runtime_args);
+
+        // Clear target L1 memory for atomic increments
+        if (noc_send_type == NOC_UNICAST_ATOMIC_INC) {
+            uint32_t total_size_to_clear = num_packets * worker_mem_map.packet_payload_size_bytes;
+            std::vector<uint32_t> zeros(total_size_to_clear / sizeof(uint32_t), 0);
+            tt_metal::detail::WriteToDeviceL1(
+                receiver_device->get_devices()[0],
+                receiver_logical_core,
+                worker_mem_map.target_address,
+                zeros,
+                CoreType::WORKER);
+        }
     }
 
     // Run programs
@@ -2490,32 +2492,38 @@ void UDMFabricUnicastCommon(
     fixture->WaitForSingleProgramDone(sender_device, sender_program);
     fixture->WaitForSingleProgramDone(receiver_device, receiver_program);
 
-    // Check results
-    std::vector<uint32_t> sender_status;
-    tt_metal::detail::ReadFromDeviceL1(
-        sender_device->get_devices()[0],
-        sender_logical_core,
-        worker_mem_map.test_results_address,
-        worker_mem_map.test_results_size_bytes,
-        sender_status,
-        CoreType::WORKER);
-    EXPECT_EQ(sender_status[TT_FABRIC_STATUS_INDEX], TT_FABRIC_STATUS_PASS);
+    // Check results for all worker pairs
+    for (const auto& [sender_logical_core, receiver_logical_core] : worker_pairs) {
+        std::vector<uint32_t> sender_status;
+        tt_metal::detail::ReadFromDeviceL1(
+            sender_device->get_devices()[0],
+            sender_logical_core,
+            worker_mem_map.test_results_address,
+            worker_mem_map.test_results_size_bytes,
+            sender_status,
+            CoreType::WORKER);
+        EXPECT_EQ(sender_status[TT_FABRIC_STATUS_INDEX], TT_FABRIC_STATUS_PASS)
+            << "Sender failed at core (" << sender_logical_core.x << ", " << sender_logical_core.y << ")";
 
-    std::vector<uint32_t> receiver_status;
-    tt_metal::detail::ReadFromDeviceL1(
-        receiver_device->get_devices()[0],
-        receiver_logical_core,
-        worker_mem_map.test_results_address,
-        worker_mem_map.test_results_size_bytes,
-        receiver_status,
-        CoreType::WORKER);
-    EXPECT_EQ(receiver_status[TT_FABRIC_STATUS_INDEX], TT_FABRIC_STATUS_PASS);
+        std::vector<uint32_t> receiver_status;
+        tt_metal::detail::ReadFromDeviceL1(
+            receiver_device->get_devices()[0],
+            receiver_logical_core,
+            worker_mem_map.test_results_address,
+            worker_mem_map.test_results_size_bytes,
+            receiver_status,
+            CoreType::WORKER);
+        EXPECT_EQ(receiver_status[TT_FABRIC_STATUS_INDEX], TT_FABRIC_STATUS_PASS)
+            << "Receiver failed at core (" << receiver_logical_core.x << ", " << receiver_logical_core.y << ")";
 
-    uint64_t sender_words =
-        ((uint64_t)sender_status[TT_FABRIC_WORD_CNT_INDEX + 1] << 32) | sender_status[TT_FABRIC_WORD_CNT_INDEX];
-    uint64_t receiver_words =
-        ((uint64_t)receiver_status[TT_FABRIC_WORD_CNT_INDEX + 1] << 32) | receiver_status[TT_FABRIC_WORD_CNT_INDEX];
-    EXPECT_EQ(sender_words, receiver_words);
+        uint64_t sender_words =
+            ((uint64_t)sender_status[TT_FABRIC_WORD_CNT_INDEX + 1] << 32) | sender_status[TT_FABRIC_WORD_CNT_INDEX];
+        uint64_t receiver_words =
+            ((uint64_t)receiver_status[TT_FABRIC_WORD_CNT_INDEX + 1] << 32) | receiver_status[TT_FABRIC_WORD_CNT_INDEX];
+        EXPECT_EQ(sender_words, receiver_words)
+            << "Word count mismatch at sender (" << sender_logical_core.x << ", " << sender_logical_core.y
+            << ") -> receiver (" << receiver_logical_core.x << ", " << receiver_logical_core.y << ")";
+    }
 }
 
 void Fabric2DMulticastCommon(

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
@@ -2446,31 +2446,11 @@ void UDMFabricUnicastCommon(
         CoreCoord receiver_virtual_core = receiver_device->worker_core_from_logical_core(receiver_logical_core);
 
         // Sender runtime args: receiver coords first, then fabric connection
-        uint32_t sender_link_idx = 0;
-        std::vector<uint32_t> sender_runtime_args;
-        append_fabric_connection_rt_args(
-            src_fabric_node_id,
-            fabric_connection_dest_node_id,
-            sender_link_idx,
-            sender_program,
-            sender_logical_core,
-            sender_runtime_args);
-        sender_runtime_args.push_back(receiver_virtual_core.x);
-        sender_runtime_args.push_back(receiver_virtual_core.y);
+        std::vector<uint32_t> sender_runtime_args = {receiver_virtual_core.x, receiver_virtual_core.y};
         tt_metal::SetRuntimeArgs(sender_program, sender_kernel, sender_logical_core, sender_runtime_args);
 
         // Receiver runtime args: sender coords first, then fabric connection
-        uint32_t receiver_link_idx = 0;
-        std::vector<uint32_t> receiver_runtime_args;
-        append_fabric_connection_rt_args(
-            dest_fabric_node_id,
-            src_fabric_node_id,
-            receiver_link_idx,
-            receiver_program,
-            receiver_logical_core,
-            receiver_runtime_args);
-        receiver_runtime_args.push_back(sender_virtual_core.x);
-        receiver_runtime_args.push_back(sender_virtual_core.y);
+        std::vector<uint32_t> receiver_runtime_args = {sender_virtual_core.x, sender_virtual_core.y};
         tt_metal::SetRuntimeArgs(receiver_program, receiver_kernel, receiver_logical_core, receiver_runtime_args);
 
         // Clear target L1 memory for atomic increments

--- a/tt_metal/api/tt-metalium/experimental/fabric/control_plane.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/control_plane.hpp
@@ -306,6 +306,12 @@ private:
         ChipId physical_chip_id,
         chan_id_t eth_channel_id) const;
 
+    // UDM-specific helper to write per-worker connection info to each worker core's L1
+    void write_udm_fabric_connections_to_tensix_cores(
+        ChipId physical_chip_id,
+        const tt::tt_fabric::tensix_fabric_connections_l1_info_t& fabric_worker_connections,
+        const tt::tt_fabric::tensix_fabric_connections_l1_info_t& fabric_dispatcher_connections) const;
+
     void assign_direction_to_fabric_eth_chan(
         const FabricNodeId& fabric_node_id, chan_id_t chan_id, RoutingDirection direction);
 

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -1724,15 +1724,21 @@ void ControlPlane::write_fabric_connections_to_tensix_cores(MeshId mesh_id, Chip
         }
     }
 
-    // Write fabric connections (fabric router config) to mux cores and tensix connections (tensix config) to worker
-    // cores
-    write_to_worker_or_fabric_tensix_cores(
-        &fabric_worker_connections,      // worker_data - goes to mux cores
-        &fabric_dispatcher_connections,  // dispatcher_data - goes to dispatcher cores
-        &fabric_tensix_connections,      // tensix_extension_data - goes to worker cores
-        sizeof(tt::tt_fabric::tensix_fabric_connections_l1_info_t),
-        tt::tt_metal::HalL1MemAddrType::TENSIX_FABRIC_CONNECTIONS,
-        physical_chip_id);
+    const auto& fabric_tensix_config = tt::tt_metal::MetalContext::instance().get_fabric_tensix_config();
+    if (fabric_tensix_config == tt::tt_fabric::FabricTensixConfig::UDM) {
+        // UDM mode: use per-worker connections
+        this->write_udm_fabric_connections_to_tensix_cores(
+            physical_chip_id, fabric_worker_connections, fabric_dispatcher_connections);
+    } else {
+        // Non UDM mode: same connection info for all workers
+        write_to_worker_or_fabric_tensix_cores(
+            &fabric_worker_connections,      // worker_data - goes to mux cores
+            &fabric_dispatcher_connections,  // dispatcher_data - goes to dispatcher cores
+            &fabric_tensix_connections,      // tensix_extension_data - goes to worker cores
+            sizeof(tt::tt_fabric::tensix_fabric_connections_l1_info_t),
+            tt::tt_metal::HalL1MemAddrType::TENSIX_FABRIC_CONNECTIONS,
+            physical_chip_id);
+    }
 }
 
 std::vector<chan_id_t> ControlPlane::get_active_fabric_eth_routing_planes_in_direction(
@@ -2179,6 +2185,68 @@ void ControlPlane::populate_fabric_connection_info(
             tensix_connection_info, mux_core_virtual, tensix_config, tensix_sender_channel, core_id);
     } else {
         dispatcher_connection_info = worker_connection_info;
+    }
+}
+
+// UDM-specific: write per-worker connection info to each worker core's L1
+void ControlPlane::write_udm_fabric_connections_to_tensix_cores(
+    ChipId physical_chip_id,
+    const tt::tt_fabric::tensix_fabric_connections_l1_info_t& fabric_mux_connections,
+    const tt::tt_fabric::tensix_fabric_connections_l1_info_t& fabric_dispatcher_connections) const {
+    const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
+    const auto& fabric_context = this->get_fabric_context();
+    const auto& tensix_config = fabric_context.get_tensix_config();
+
+    // Get mux and dispatcher cores
+    std::unordered_set<CoreCoord> fabric_mux_cores_translated = tensix_config.get_translated_fabric_mux_cores();
+    std::unordered_set<CoreCoord> dispatch_mux_cores_translated = tensix_config.get_translated_dispatch_mux_cores();
+
+    const auto& soc_desc = cluster.get_soc_desc(physical_chip_id);
+    const std::vector<tt::umd::CoreCoord>& all_tensix_cores =
+        soc_desc.get_cores(CoreType::TENSIX, CoordSystem::TRANSLATED);
+
+    // Build per-worker connection info and write to each worker core
+    for (const auto& tensix_core : all_tensix_cores) {
+        CoreCoord core_coord(tensix_core.x, tensix_core.y);
+
+        // Determine core type
+        const void* data_to_write = nullptr;
+        if (fabric_mux_cores_translated.find(core_coord) != fabric_mux_cores_translated.end()) {
+            // Mux core: write fabric_mux_connections (passed in from caller)
+            data_to_write = &fabric_mux_connections;
+        } else if (dispatch_mux_cores_translated.find(core_coord) != dispatch_mux_cores_translated.end()) {
+            // Dispatcher core: write fabric_dispatcher_connections (passed in from caller)
+            data_to_write = &fabric_dispatcher_connections;
+        } else {
+            // Worker core: build per-worker connection info
+            tt::tt_fabric::tensix_fabric_connections_l1_info_t worker_connections = {};
+
+            // Get worker assignment info (tensix core + channel index) with a single lookup
+            auto tensix_info = tensix_config.get_worker_tensix_info(physical_chip_id, core_coord);
+
+            // Populate worker-specific tensix mux connection for ALL eth channel indices
+            for (uint8_t eth_chan = 0;
+                 eth_chan < tt::tt_fabric::tensix_fabric_connections_l1_info_t::MAX_FABRIC_ENDPOINTS;
+                 eth_chan++) {
+                auto& connection_info = worker_connections.read_only[eth_chan];
+                fill_tensix_connection_info_fields(
+                    connection_info,
+                    tensix_info.tensix_core,
+                    tensix_config,
+                    tensix_info.channel_index,
+                    FabricTensixCoreType::MUX);
+            }
+
+            data_to_write = &worker_connections;
+        }
+
+        // Write to L1
+        cluster.write_core(
+            data_to_write,
+            sizeof(tt::tt_fabric::tensix_fabric_connections_l1_info_t),
+            tt_cxy_pair(physical_chip_id, core_coord),
+            tt_metal::MetalContext::instance().hal().get_dev_addr(
+                tt_metal::HalProgrammableCoreType::TENSIX, tt::tt_metal::HalL1MemAddrType::TENSIX_FABRIC_CONNECTIONS));
     }
 }
 

--- a/tt_metal/fabric/fabric_init.cpp
+++ b/tt_metal/fabric/fabric_init.cpp
@@ -267,17 +267,10 @@ std::unique_ptr<tt::tt_metal::Program> create_and_compile_tt_fabric_program(tt::
     // Compile all fabric tensix builders through router builders
     if (tt::tt_metal::MetalContext::instance().get_fabric_tensix_config() !=
         tt::tt_fabric::FabricTensixConfig::DISABLED) {
-        // Track which directions have been built (for UDM mode finalization)
-        std::set<tt::tt_fabric::eth_chan_directions> built_directions;
-
         // First pass: compile all existing tensix builders (from active eth channels)
         for (auto& [eth_chan, router_builder] : router_builders) {
             if (router_builder->has_tensix_builder()) {
                 router_builder->get_tensix_builder().create_and_compile(*fabric_program_ptr);
-
-                // Register the direction of this tensix builder
-                auto direction = router_builder->get_tensix_builder().get_direction();
-                built_directions.insert(direction);
             }
         }
 

--- a/tt_metal/fabric/fabric_tensix_builder.cpp
+++ b/tt_metal/fabric/fabric_tensix_builder.cpp
@@ -112,6 +112,7 @@ void FabricTensixDatamoverConfig::find_min_max_eth_channels(const std::vector<tt
 void FabricTensixDatamoverConfig::build_per_device_channel_mappings(
     const std::vector<tt_metal::IDevice*>& all_active_devices) {
     const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+    const auto& fabric_tensix_config = tt::tt_metal::MetalContext::instance().get_fabric_tensix_config();
 
     // Create per-device channel mappings using real ethernet channel IDs
     for (const auto& device : all_active_devices) {
@@ -436,7 +437,7 @@ std::map<ChannelTypes, uint32_t> FabricTensixDatamoverConfig::calculate_mux_chan
         // UDM has WORKER_CHANNEL, RELAY_TO_MUX_CHANNEL, MUX_TO_MUX_CHANNEL (NO ROUTER_CHANNEL)
 
         // Calculate num_worker_channels using first device (all devices have same configuration)
-        auto first_device = all_active_devices.front();
+        auto* first_device = all_active_devices.front();
         auto workers_by_column = build_workers_by_column(first_device);
         auto tensix_cores_for_workers = get_tensix_cores_for_workers(first_device);
 
@@ -453,7 +454,7 @@ std::map<ChannelTypes, uint32_t> FabricTensixDatamoverConfig::calculate_mux_chan
 
         // Build per-device worker-to-tensix maps
         // fabric_tensix_noc_coords_map_ is indexed by fabric_node_id, so process each device
-        for (auto device : all_active_devices) {
+        for (auto* device : all_active_devices) {
             auto device_workers = build_workers_by_column(device);
             auto device_tensix_cores = get_tensix_cores_for_workers(device);
 

--- a/tt_metal/fabric/fabric_tensix_builder.cpp
+++ b/tt_metal/fabric/fabric_tensix_builder.cpp
@@ -417,6 +417,11 @@ void FabricTensixDatamoverConfig::assign_workers_to_tensix_cores(
 
     for (size_t i = 0; i < workers_by_column.size(); i++) {
         size_t tensix_idx = i / num_worker_channels;
+        TT_FATAL(
+            tensix_idx < tensix_cores_for_workers.size(),
+            "tensix_idx {} exceeds tensix_cores_for_workers size {}",
+            tensix_idx,
+            tensix_cores_for_workers.size());
         CoreCoord tensix_core = tensix_cores_for_workers[tensix_idx];
         uint32_t channel_index = i % num_worker_channels;
         // Store tensix core and channel index together

--- a/tt_metal/fabric/fabric_tensix_builder.cpp
+++ b/tt_metal/fabric/fabric_tensix_builder.cpp
@@ -19,8 +19,10 @@
 #include "dispatch/kernel_config/relay_mux.hpp"
 #include "tt_metal/fabric/builder/fabric_static_sized_channels_allocator.hpp"
 #include "tt_align.hpp"
+#include <array>
 #include <bit>
 #include <algorithm>
+#include <set>
 #include <utility>
 
 namespace tt::tt_fabric {
@@ -45,7 +47,7 @@ void FabricTensixDatamoverConfig::find_min_max_eth_channels(const std::vector<tt
 
     auto device_id = all_active_devices.front()->id();
     const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
-    const bool has_dispatch_tunnel = device_has_dispatch_tunnel(device_id);
+    has_dispatch_tunnel_ = device_has_dispatch_tunnel(device_id);
 
     for (const auto& device : all_active_devices) {
         std::unordered_map<RoutingDirection, std::vector<chan_id_t>> active_fabric_eth_channels;
@@ -75,13 +77,13 @@ void FabricTensixDatamoverConfig::find_min_max_eth_channels(const std::vector<tt
 
         std::vector<chan_id_t> non_dispatch_active_channels;
         for (const auto& [direction, remote_fabric_node_id] : chip_neighbors) {
-            uint32_t dispatch_link_idx =
+            dispatch_link_idx_ =
                 tt_metal::RelayMux::get_dispatch_link_index(fabric_node_id, remote_fabric_node_id, device);
 
             for (const auto& eth_chan : active_fabric_eth_channels[direction]) {
                 auto link_idx = control_plane.get_routing_plane_id(fabric_node_id, eth_chan);
 
-                if (!(has_dispatch_tunnel && link_idx == dispatch_link_idx)) {
+                if (!(has_dispatch_tunnel_ && link_idx == dispatch_link_idx_)) {
                     non_dispatch_active_channels.push_back(eth_chan);
                 }
             }
@@ -107,7 +109,6 @@ void FabricTensixDatamoverConfig::build_per_device_channel_mappings(
     for (const auto& device : all_active_devices) {
         auto dev_id = device->id();
         auto fabric_node_id = control_plane.get_fabric_node_id_from_physical_chip_id(dev_id);
-
         // Get all active ethernet channels for this device
         auto active_channels = control_plane.get_active_fabric_eth_channels(fabric_node_id);
 
@@ -116,22 +117,33 @@ void FabricTensixDatamoverConfig::build_per_device_channel_mappings(
         eth_chan_to_core_id_[dev_id] = std::unordered_map<size_t, FabricTensixCoreType>();
 
         // Create round-robin mapping using the actual ethernet channel IDs from active_channels
+        // Skip dispatch link channels - they don't get tensix builders
         size_t channel_index = 0;
         for (auto [eth_chan_id, eth_chan_dir] : active_channels) {
-            size_t core_index = channel_index % logical_fabric_mux_cores_.size();
-            eth_chan_to_core_index_[dev_id][eth_chan_id] = core_index;
+            routing_plane_id_t routing_plane_id = control_plane.get_routing_plane_id(fabric_node_id, eth_chan_id);
+            eth_chan_to_core_index_[dev_id][eth_chan_id] = channel_index;
+
+            // Also populate direction_to_core_index_ for active directions
+            direction_to_core_index_[dev_id][routing_plane_id][eth_chan_dir] = channel_index;
 
             // Determine core type: In both MUX and UDM modes, all worker channels go to MUX (core type 0)
             // The RELAY (core type 1) in UDM mode handles fabric-to-fabric routing, not worker channels
             FabricTensixCoreType core_id = FabricTensixCoreType::MUX;  // Always assign to MUX
             eth_chan_to_core_id_[dev_id][eth_chan_id] = core_id;
 
-            channel_index++;
+            if (!(has_dispatch_tunnel_ && routing_plane_id == dispatch_link_idx_)) {
+                channel_index++;
+            }
+        }
+
+        // In UDM mode, track missing directions for inter-mux communication
+        if (fabric_tensix_config == tt::tt_fabric::FabricTensixConfig::UDM) {
+            track_missing_directions_for_udm(device, fabric_node_id, active_channels, channel_index);
         }
     }
 }
 
-void FabricTensixDatamoverConfig::build_fabric_router_noc_coords_map(
+void FabricTensixDatamoverConfig::build_fabric_tensix_noc_coords_map(
     const std::vector<tt_metal::IDevice*>& all_active_devices) {
     const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
 
@@ -152,8 +164,10 @@ void FabricTensixDatamoverConfig::build_fabric_router_noc_coords_map(
             // Get the tensix NOC coordinates for this channel
             auto [noc_x, noc_y] = get_noc_xy(device, eth_chan_id);
 
-            // Record this direction's router/tensix NOC coordinates for this fabric node + routing plane
-            fabric_router_noc_coords_map_[fabric_node_id][routing_plane_id][eth_chan_dir] = {noc_x, noc_y};
+            // Record in both maps - fabric_tensix_noc_coords_map_ (all) and fabric_active_tensix_noc_coords_map_
+            // (active only)
+            fabric_tensix_noc_coords_map_[fabric_node_id][routing_plane_id][eth_chan_dir] = {noc_x, noc_y};
+            fabric_active_tensix_noc_coords_map_[fabric_node_id][routing_plane_id][eth_chan_dir] = {noc_x, noc_y};
         }
     }
 }
@@ -165,6 +179,103 @@ FabricTensixDatamoverConfig::FabricTensixDatamoverConfig() {
     }
     calculate_buffer_allocations();
     create_configs();  // Mode-aware config creation
+}
+
+void FabricTensixDatamoverConfig::track_missing_directions_for_udm(
+    tt::tt_metal::IDevice* device,
+    const FabricNodeId& fabric_node_id,
+    const std::set<std::pair<chan_id_t, eth_chan_directions>>& active_channels,
+    size_t& channel_index) {
+    const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+    ChipId dev_id = device->id();
+
+    // Collect all active (routing_plane_id, direction) pairs from active_channels
+    // Skip dispatch routing planes (using pre-calculated dispatch link info)
+    std::set<std::pair<routing_plane_id_t, eth_chan_directions>> active_plane_directions;
+    std::set<routing_plane_id_t> active_routing_planes;
+    for (const auto& [eth_chan_id, eth_chan_dir] : active_channels) {
+        routing_plane_id_t routing_plane_id = control_plane.get_routing_plane_id(fabric_node_id, eth_chan_id);
+
+        // Skip dispatch routing plane
+        if (has_dispatch_tunnel_ && routing_plane_id == dispatch_link_idx_) {
+            continue;
+        }
+
+        active_plane_directions.insert({routing_plane_id, eth_chan_dir});
+        active_routing_planes.insert(routing_plane_id);
+    }
+
+    // For each active routing plane, check which of the 4 directions (E, W, N, S) are missing
+    std::set<std::pair<routing_plane_id_t, eth_chan_directions>> missing_plane_dirs;
+    for (auto routing_plane_id : active_routing_planes) {
+        for (uint8_t dir_idx = 0; dir_idx < eth_chan_directions::COUNT; dir_idx++) {
+            auto dir = static_cast<eth_chan_directions>(dir_idx);
+            if (active_plane_directions.find({routing_plane_id, dir}) == active_plane_directions.end()) {
+                missing_plane_dirs.insert({routing_plane_id, dir});
+            }
+        }
+    }
+
+    if (!missing_plane_dirs.empty()) {
+        // Calculate how many cores are remaining
+        // channel_index represents the number of active directions already assigned
+        size_t total_cores = logical_fabric_mux_cores_.size();
+        size_t cores_used = channel_index;
+        size_t cores_remaining = (cores_used < total_cores) ? (total_cores - cores_used) : 0;
+
+        // Only add as many missing directions as we have remaining cores
+        size_t missing_dirs_to_add = std::min(missing_plane_dirs.size(), cores_remaining);
+
+        if (missing_dirs_to_add == 0) {
+            log_warning(
+                tt::LogMetal,
+                "Device {}: No remaining cores for missing directions. "
+                "Total cores: {}, cores used by active channels: {}, missing directions: {}",
+                dev_id,
+                total_cores,
+                cores_used,
+                missing_plane_dirs.size());
+            return;
+        }
+
+        if (missing_dirs_to_add < missing_plane_dirs.size()) {
+            log_warning(
+                tt::LogMetal,
+                "Device {}: Not enough cores for all missing directions. "
+                "Adding {} out of {} missing directions. Total cores: {}, cores used: {}",
+                dev_id,
+                missing_dirs_to_add,
+                missing_plane_dirs.size(),
+                total_cores,
+                cores_used);
+        }
+
+        // Only store the missing directions we're actually adding
+        std::set<std::pair<routing_plane_id_t, eth_chan_directions>> added_missing_dirs;
+        size_t added_count = 0;
+
+        for (const auto& [routing_plane_id, missing_dir] : missing_plane_dirs) {
+            if (added_count >= missing_dirs_to_add) {
+                break;
+            }
+
+            size_t core_index = channel_index;
+            direction_to_core_index_[dev_id][routing_plane_id][missing_dir] = core_index;
+
+            // Also populate fabric_tensix_noc_coords_map_ for missing directions
+            CoreCoord logical_core = logical_fabric_mux_cores_[core_index];
+            CoreCoord translated_core = device->worker_core_from_logical_core(logical_core);
+            fabric_tensix_noc_coords_map_[fabric_node_id][routing_plane_id][missing_dir] = {
+                translated_core.x, translated_core.y};
+
+            added_missing_dirs.insert({routing_plane_id, missing_dir});
+            channel_index++;
+            added_count++;
+        }
+
+        // Store only the missing directions that were actually added
+        missing_directions_per_device_[dev_id] = added_missing_dirs;
+    }
 }
 
 bool FabricTensixDatamoverConfig::initialize_channel_mappings() {
@@ -240,7 +351,7 @@ bool FabricTensixDatamoverConfig::initialize_channel_mappings() {
     build_per_device_channel_mappings(all_active_devices);
 
     // Third pass: Build the fabric_router_noc_coords_map_
-    build_fabric_router_noc_coords_map(all_active_devices);
+    build_fabric_tensix_noc_coords_map(all_active_devices);
 
     return true;
 }
@@ -519,10 +630,10 @@ std::pair<uint32_t, uint32_t> FabricTensixDatamoverConfig::get_termination_addre
         config->get_termination_signal_address(), tt::tt_fabric::TerminationSignal::IMMEDIATELY_TERMINATE);
 }
 
-const std::pair<uint32_t, uint32_t>* FabricTensixDatamoverConfig::get_router_noc_coords(
+const std::pair<uint32_t, uint32_t>* FabricTensixDatamoverConfig::get_tensix_noc_coords(
     const FabricNodeId& fabric_node_id, routing_plane_id_t routing_plane_id, eth_chan_directions direction) const {
-    auto node_it = fabric_router_noc_coords_map_.find(fabric_node_id);
-    if (node_it == fabric_router_noc_coords_map_.end()) {
+    auto node_it = fabric_tensix_noc_coords_map_.find(fabric_node_id);
+    if (node_it == fabric_tensix_noc_coords_map_.end()) {
         return nullptr;
     }
 
@@ -539,6 +650,81 @@ const std::pair<uint32_t, uint32_t>* FabricTensixDatamoverConfig::get_router_noc
     return &(dir_it->second);
 }
 
+const std::pair<uint32_t, uint32_t>* FabricTensixDatamoverConfig::get_active_tensix_noc_coords(
+    const FabricNodeId& fabric_node_id, routing_plane_id_t routing_plane_id, eth_chan_directions direction) const {
+    auto node_it = fabric_active_tensix_noc_coords_map_.find(fabric_node_id);
+    if (node_it == fabric_active_tensix_noc_coords_map_.end()) {
+        return nullptr;
+    }
+
+    auto plane_it = node_it->second.find(routing_plane_id);
+    if (plane_it == node_it->second.end()) {
+        return nullptr;
+    }
+
+    auto dir_it = plane_it->second.find(direction);
+    if (dir_it == plane_it->second.end()) {
+        return nullptr;
+    }
+
+    return &(dir_it->second);
+}
+
+const std::set<std::pair<routing_plane_id_t, eth_chan_directions>>& FabricTensixDatamoverConfig::get_missing_directions(
+    ChipId device_id) const {
+    auto it = missing_directions_per_device_.find(device_id);
+    if (it == missing_directions_per_device_.end()) {
+        return empty_directions_set_;
+    }
+    return it->second;
+}
+
+bool FabricTensixDatamoverConfig::has_missing_directions(ChipId device_id) const {
+    auto it = missing_directions_per_device_.find(device_id);
+    return it != missing_directions_per_device_.end() && !it->second.empty();
+}
+
+size_t FabricTensixDatamoverConfig::get_core_index_for_direction(
+    ChipId device_id, routing_plane_id_t routing_plane_id, eth_chan_directions direction) const {
+    auto dev_it = direction_to_core_index_.find(device_id);
+    TT_FATAL(dev_it != direction_to_core_index_.end(), "Device {} not found in direction_to_core_index_", device_id);
+
+    auto plane_it = dev_it->second.find(routing_plane_id);
+    TT_FATAL(
+        plane_it != dev_it->second.end(),
+        "Routing plane {} not found for device {} in direction_to_core_index_",
+        routing_plane_id,
+        device_id);
+
+    auto dir_it = plane_it->second.find(direction);
+    TT_FATAL(
+        dir_it != plane_it->second.end(),
+        "Direction {} not found for device {}, routing plane {} in direction_to_core_index_",
+        static_cast<uint32_t>(direction),
+        device_id,
+        routing_plane_id);
+
+    return dir_it->second;
+}
+
+CoreCoord FabricTensixDatamoverConfig::get_core_for_direction(
+    ChipId device_id, routing_plane_id_t routing_plane_id, eth_chan_directions direction) const {
+    size_t core_index = get_core_index_for_direction(device_id, routing_plane_id, direction);
+    TT_FATAL(
+        core_index < logical_fabric_mux_cores_.size(),
+        "Core index {} out of bounds for logical_fabric_mux_cores_ (size {})",
+        core_index,
+        logical_fabric_mux_cores_.size());
+    return logical_fabric_mux_cores_[core_index];
+}
+
+std::pair<uint32_t, uint32_t> FabricTensixDatamoverConfig::get_noc_xy_for_direction(
+    tt::tt_metal::IDevice* device, routing_plane_id_t routing_plane_id, eth_chan_directions direction) const {
+    CoreCoord logical_core = get_core_for_direction(device->id(), routing_plane_id, direction);
+    CoreCoord translated_core = device->worker_core_from_logical_core(logical_core);
+    return {translated_core.x, translated_core.y};
+}
+
 // FabricTensixDatamoverBuilder implementation
 
 template <typename BuilderType, typename ConfigType>
@@ -552,7 +738,8 @@ std::unique_ptr<BuilderType> FabricTensixDatamoverBuilder::create_builder(
     uint32_t link_idx,
     uint32_t noc_x,
     uint32_t noc_y,
-    eth_chan_directions direction) {
+    eth_chan_directions direction,
+    bool has_fabric_router) {
     // Check if the core type is active (for relay, may return nullptr)
     if (!tensix_config.is_core_id_active(core_type)) {
         return nullptr;
@@ -574,7 +761,8 @@ std::unique_ptr<BuilderType> FabricTensixDatamoverBuilder::create_builder(
         noc_x,
         noc_y,
         config,
-        direction);
+        direction,
+        has_fabric_router);
 }
 
 FabricTensixDatamoverBuilder::FabricTensixDatamoverBuilder(
@@ -618,6 +806,7 @@ FabricTensixDatamoverBuilder FabricTensixDatamoverBuilder::build(
     uint32_t link_idx = control_plane.get_routing_plane_id(local_fabric_node_id, ethernet_channel_id);
 
     // Create mux builder (always needed in both MUX and UDM modes)
+    // has_fabric_router = true because this is a normal build with an actual eth channel/router
     auto mux_builder = create_builder<FabricTensixDatamoverMuxBuilder, FabricTensixDatamoverMuxConfig>(
         FabricTensixCoreType::MUX,
         tensix_config,
@@ -628,7 +817,8 @@ FabricTensixDatamoverBuilder FabricTensixDatamoverBuilder::build(
         link_idx,
         noc_x,
         noc_y,
-        direction);
+        direction,
+        true /* has_fabric_router */);
 
     // Create relay builder (only in UDM mode if relay core is active)
     std::unique_ptr<FabricTensixDatamoverRelayBuilder> relay_builder = nullptr;
@@ -643,7 +833,8 @@ FabricTensixDatamoverBuilder FabricTensixDatamoverBuilder::build(
             link_idx,
             noc_x,
             noc_y,
-            direction);
+            direction,
+            true /* has_fabric_router - not used for relay*/);
     }
 
     auto builder = FabricTensixDatamoverBuilder(
@@ -662,6 +853,75 @@ FabricTensixDatamoverBuilder FabricTensixDatamoverBuilder::build(
     }
 
     return builder;
+}
+
+FabricTensixDatamoverBuilder FabricTensixDatamoverBuilder::build_for_missing_direction(
+    tt::tt_metal::IDevice* device,
+    tt::tt_metal::Program& /*program*/,
+    tt::tt_fabric::FabricNodeId local_fabric_node_id,
+    routing_plane_id_t routing_plane_id,
+    eth_chan_directions direction) {
+    const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+    const auto& fabric_context = control_plane.get_fabric_context();
+    const auto& tensix_config = fabric_context.get_tensix_config();
+    auto fabric_tensix_config = tt::tt_metal::MetalContext::instance().get_fabric_tensix_config();
+
+    // This method is only valid for UDM mode
+    TT_FATAL(
+        fabric_tensix_config == tt::tt_fabric::FabricTensixConfig::UDM,
+        "build_for_missing_direction is only valid in UDM mode");
+
+    // Get core for this (routing_plane_id, direction) pair (assigned in initialize_channel_mappings)
+    CoreCoord my_core_logical = tensix_config.get_core_for_direction(device->id(), routing_plane_id, direction);
+
+    // Get NOC coordinates for this (routing_plane_id, direction) pair
+    auto [noc_x, noc_y] = tensix_config.get_noc_xy_for_direction(device, routing_plane_id, direction);
+
+    // Use the routing_plane_id as the link_idx
+    uint32_t link_idx = routing_plane_id;
+
+    // For missing directions, get remote_fabric_node_id from any valid neighbor direction
+    // We need a valid remote_fabric_node_id even for missing directions
+    FabricNodeId remote_fabric_node_id = local_fabric_node_id;
+    for (const auto& routing_dir : tt::tt_fabric::FabricContext::routing_directions) {
+        auto neighbors = control_plane.get_chip_neighbors(local_fabric_node_id, routing_dir);
+        if (!neighbors.empty()) {
+            remote_fabric_node_id = FabricNodeId(neighbors.begin()->first, neighbors.begin()->second[0]);
+            break;
+        }
+    }
+
+    // For missing directions, we don't have a real eth channel
+    // Use 0 as a placeholder - it's not used for anything meaningful in this case
+    uint32_t ethernet_channel_id = 0;
+
+    // Create mux builder only (no relay for missing directions since there's no router)
+    // has_fabric_router = false because this is a missing direction with no actual router
+    auto mux_builder = create_builder<FabricTensixDatamoverMuxBuilder, FabricTensixDatamoverMuxConfig>(
+        FabricTensixCoreType::MUX,
+        tensix_config,
+        my_core_logical,
+        local_fabric_node_id,
+        remote_fabric_node_id,
+        ethernet_channel_id,
+        link_idx,
+        noc_x,
+        noc_y,
+        direction,
+        false /* has_fabric_router */);
+
+    // No relay builder for missing directions - these are purely for inter-mux forwarding
+    std::unique_ptr<FabricTensixDatamoverRelayBuilder> relay_builder = nullptr;
+
+    return FabricTensixDatamoverBuilder(
+        std::move(mux_builder),
+        std::move(relay_builder),
+        my_core_logical,
+        local_fabric_node_id,
+        remote_fabric_node_id,
+        noc_x,
+        noc_y,
+        direction);
 }
 
 void FabricTensixDatamoverBuilder::create_and_compile(tt::tt_metal::Program& program) {

--- a/tt_metal/fabric/fabric_tensix_builder.cpp
+++ b/tt_metal/fabric/fabric_tensix_builder.cpp
@@ -370,16 +370,16 @@ std::vector<CoreCoord> FabricTensixDatamoverConfig::build_workers_by_column(tt::
     auto compute_grid = device->compute_with_storage_grid_size();
     uint32_t total_workers = compute_grid.x * compute_grid.y;
 
-    std::vector<CoreCoord> workers_by_column;
-    workers_by_column.reserve(total_workers);
+    std::vector<CoreCoord> workers_by_column(total_workers);
 
     // Sort by column: x first (outer loop), then y within each column (inner loop)
     // This ensures workers in the same column are contiguous and get assigned to the same tensix
+    size_t idx = 0;
     for (uint32_t x = 0; x < compute_grid.x; x++) {
         for (uint32_t y = 0; y < compute_grid.y; y++) {
             CoreCoord logical_worker(x, y);
             CoreCoord translated_worker = device->worker_core_from_logical_core(logical_worker);
-            workers_by_column.push_back(translated_worker);
+            workers_by_column[idx++] = translated_worker;
         }
     }
 
@@ -771,11 +771,11 @@ const std::pair<uint32_t, uint32_t>* FabricTensixDatamoverConfig::get_active_ten
     return &(dir_it->second);
 }
 
-const std::set<std::pair<routing_plane_id_t, eth_chan_directions>>& FabricTensixDatamoverConfig::get_missing_directions(
+std::set<std::pair<routing_plane_id_t, eth_chan_directions>> FabricTensixDatamoverConfig::get_missing_directions(
     ChipId device_id) const {
     auto it = missing_directions_per_device_.find(device_id);
     if (it == missing_directions_per_device_.end()) {
-        return empty_directions_set_;
+        return {};
     }
     return it->second;
 }

--- a/tt_metal/fabric/fabric_tensix_builder.hpp
+++ b/tt_metal/fabric/fabric_tensix_builder.hpp
@@ -112,7 +112,7 @@ public:
     // Get the set of missing (routing_plane_id, direction) pairs for a device
     // Only applicable in UDM mode - returns empty set in MUX mode or if all directions have channels
     // Each pair represents a routing plane that doesn't have a tensix builder in that direction
-    const std::set<std::pair<routing_plane_id_t, eth_chan_directions>>& get_missing_directions(ChipId device_id) const;
+    std::set<std::pair<routing_plane_id_t, eth_chan_directions>> get_missing_directions(ChipId device_id) const;
 
     // Check if a device has any missing directions
     bool has_missing_directions(ChipId device_id) const;
@@ -206,8 +206,6 @@ private:
     // Each pair represents a routing plane that needs a tensix builder in that direction
     std::unordered_map<ChipId, std::set<std::pair<routing_plane_id_t, eth_chan_directions>>>
         missing_directions_per_device_;
-    // Empty set for devices without missing directions (or in MUX mode)
-    static inline const std::set<std::pair<routing_plane_id_t, eth_chan_directions>> empty_directions_set_{};
 
     // [device_id][routing_plane_id][direction] -> core_index mapping for ALL directions (active + missing)
     // This is the authoritative lookup for (routing_plane_id, direction) -> core_index

--- a/tt_metal/fabric/fabric_tensix_builder.hpp
+++ b/tt_metal/fabric/fabric_tensix_builder.hpp
@@ -6,6 +6,7 @@
 
 #include <stdint.h>
 #include <optional>
+#include <set>
 #include <vector>
 #include <memory>
 #include <unordered_map>
@@ -97,10 +98,37 @@ public:
 
     std::pair<uint32_t, uint32_t> get_termination_address_and_signal(FabricTensixCoreType core_id) const;
 
-    // Get router NOC coordinates for a specific fabric node, routing plane, and direction
-    // Returns pointer to pair (noc_x, noc_y) if router exists, nullptr otherwise
-    const std::pair<uint32_t, uint32_t>* get_router_noc_coords(
+    // Get tensix NOC coordinates for a specific fabric node, routing plane, and direction
+    // Returns pointer to pair (noc_x, noc_y) if tensix exists, nullptr otherwise
+    // This includes both active directions (from eth channels) and missing directions (UDM mode)
+    const std::pair<uint32_t, uint32_t>* get_tensix_noc_coords(
         const FabricNodeId& fabric_node_id, routing_plane_id_t routing_plane_id, eth_chan_directions direction) const;
+
+    // Get tensix NOC coordinates for active directions only (directions with eth channels)
+    // Returns pointer to pair (noc_x, noc_y) if active tensix exists, nullptr otherwise
+    const std::pair<uint32_t, uint32_t>* get_active_tensix_noc_coords(
+        const FabricNodeId& fabric_node_id, routing_plane_id_t routing_plane_id, eth_chan_directions direction) const;
+
+    // Get the set of missing (routing_plane_id, direction) pairs for a device
+    // Only applicable in UDM mode - returns empty set in MUX mode or if all directions have channels
+    // Each pair represents a routing plane that doesn't have a tensix builder in that direction
+    const std::set<std::pair<routing_plane_id_t, eth_chan_directions>>& get_missing_directions(ChipId device_id) const;
+
+    // Check if a device has any missing directions
+    bool has_missing_directions(ChipId device_id) const;
+
+    // Get core index for a (routing_plane_id, direction) pair on a device
+    // Used for missing direction tensix builders where there's no eth channel
+    size_t get_core_index_for_direction(
+        ChipId device_id, routing_plane_id_t routing_plane_id, eth_chan_directions direction) const;
+
+    // Get core for a (routing_plane_id, direction) pair on a device
+    CoreCoord get_core_for_direction(
+        ChipId device_id, routing_plane_id_t routing_plane_id, eth_chan_directions direction) const;
+
+    // Get NOC coordinates for a (routing_plane_id, direction) pair on a device
+    std::pair<uint32_t, uint32_t> get_noc_xy_for_direction(
+        tt::tt_metal::IDevice* device, routing_plane_id_t routing_plane_id, eth_chan_directions direction) const;
 
 private:
     std::vector<CoreCoord> logical_fabric_mux_cores_;
@@ -134,11 +162,18 @@ private:
     std::unordered_map<FabricTensixCoreType, std::shared_ptr<FabricTensixDatamoverBaseConfig>> configs_;
 
     // Mapping: [fabric_node_id] -> [routing_plane_id] -> [direction (E/W/N/S)] -> (noc_x, noc_y)
-    // If an entry exists, the router/tensix is active in that direction; otherwise it doesn't exist
+    // Contains ALL directions (active + missing in UDM mode)
     std::unordered_map<
         FabricNodeId,
         std::unordered_map<routing_plane_id_t, std::unordered_map<eth_chan_directions, std::pair<uint32_t, uint32_t>>>>
-        fabric_router_noc_coords_map_;
+        fabric_tensix_noc_coords_map_;
+
+    // Mapping for ACTIVE directions only (directions with eth channels)
+    // [fabric_node_id] -> [routing_plane_id] -> [direction (E/W/N/S)] -> (noc_x, noc_y)
+    std::unordered_map<
+        FabricNodeId,
+        std::unordered_map<routing_plane_id_t, std::unordered_map<eth_chan_directions, std::pair<uint32_t, uint32_t>>>>
+        fabric_active_tensix_noc_coords_map_;
 
     // Channel type configuration maps (sorted by ChannelTypes enum)
     // [channel type] -> [number of channels of that type]
@@ -149,6 +184,24 @@ private:
     // Cached min/max ethernet channels across all devices
     size_t min_eth_channels_ = 0;
     size_t max_eth_channels_ = 0;
+
+    // Dispatch link info (same for all devices, calculated once in find_min_max_eth_channels)
+    uint32_t dispatch_link_idx_ = 0;
+    bool has_dispatch_tunnel_ = false;
+
+    // Per-device missing (routing_plane_id, direction) pairs without active eth channels
+    // Only populated in UDM mode - for edge devices that don't have neighbors in all 4 directions
+    // Each pair represents a routing plane that needs a tensix builder in that direction
+    std::unordered_map<ChipId, std::set<std::pair<routing_plane_id_t, eth_chan_directions>>>
+        missing_directions_per_device_;
+    // Empty set for devices without missing directions (or in MUX mode)
+    static inline const std::set<std::pair<routing_plane_id_t, eth_chan_directions>> empty_directions_set_{};
+
+    // [device_id][routing_plane_id][direction] -> core_index mapping for ALL directions (active + missing)
+    // This is the authoritative lookup for (routing_plane_id, direction) -> core_index
+    // Populated for both active directions (from eth channels) and missing directions (UDM mode)
+    std::unordered_map<ChipId, std::unordered_map<routing_plane_id_t, std::unordered_map<eth_chan_directions, size_t>>>
+        direction_to_core_index_;
 
     // Helper methods for initialization
 
@@ -188,6 +241,16 @@ private:
     void calculate_buffer_allocations();
     void create_configs();  // Creates mode-aware configs based on FabricTensixConfig
 
+    // Helper to track missing directions for UDM mode
+    // For edge devices that don't have neighbors in all 4 directions, tracks which (routing_plane_id, direction)
+    // pairs are missing and assigns core indices for the missing direction tensix builders
+    // Also populates fabric_tensix_noc_coords_map_ for the missing directions
+    void track_missing_directions_for_udm(
+        tt::tt_metal::IDevice* device,
+        const FabricNodeId& fabric_node_id,
+        const std::set<std::pair<chan_id_t, eth_chan_directions>>& active_channels,
+        size_t& channel_index);
+
     // Helper methods for config creation
     std::shared_ptr<FabricTensixDatamoverMuxConfig> create_mux_config(FabricTensixCoreType core_id);
     std::shared_ptr<FabricTensixDatamoverRelayConfig> create_relay_config(FabricTensixCoreType core_id);
@@ -210,6 +273,17 @@ public:
         uint32_t ethernet_channel_id,
         eth_chan_directions direction,
         std::vector<bool>&& sender_channel_injection_flags);
+
+    // Static builder method for missing directions (UDM mode only)
+    // Creates a tensix builder for a direction that doesn't have an active eth channel
+    // This is used for edge devices that need tensix builders in all 4 directions for inter-mux communication
+    // routing_plane_id specifies which routing plane (link index) this tensix builder belongs to
+    static FabricTensixDatamoverBuilder build_for_missing_direction(
+        tt::tt_metal::IDevice* device,
+        tt::tt_metal::Program& program,
+        tt::tt_fabric::FabricNodeId local_fabric_node_id,
+        routing_plane_id_t routing_plane_id,
+        eth_chan_directions direction);
 
     // Create and compile the kernel(s) based on mode
     void create_and_compile(tt::tt_metal::Program& program);
@@ -255,7 +329,8 @@ private:
         uint32_t link_idx,
         uint32_t noc_x,
         uint32_t noc_y,
-        eth_chan_directions direction);
+        eth_chan_directions direction,
+        bool has_fabric_router);
 
     // Sub-builders based on mode
     std::unique_ptr<FabricTensixDatamoverMuxBuilder> mux_builder_;      // Always created

--- a/tt_metal/fabric/fabric_tensix_builder.hpp
+++ b/tt_metal/fabric/fabric_tensix_builder.hpp
@@ -251,7 +251,7 @@ private:
      * For each active device and its ethernet channels, this function records the tensix NOC
      * coordinates in the map, keyed by fabric node ID, routing plane ID, and direction.
      */
-    void build_fabric_router_noc_coords_map(const std::vector<tt_metal::IDevice*>& all_active_devices);
+    void build_fabric_tensix_noc_coords_map(const std::vector<tt_metal::IDevice*>& all_active_devices);
 
     bool initialize_channel_mappings();
     void calculate_buffer_allocations();

--- a/tt_metal/fabric/fabric_tensix_builder.hpp
+++ b/tt_metal/fabric/fabric_tensix_builder.hpp
@@ -133,7 +133,7 @@ public:
     // UDM mode: Worker assignment info
     struct WorkerTensixInfo {
         CoreCoord tensix_core;   // The tensix mux core assigned to this worker
-        uint32_t channel_index;  // The channel index on that tensix mux core
+        uint32_t channel_index{};  // The channel index on that tensix mux core
     };
 
     // Get worker assignment info (tensix core + channel index) for a specific worker (UDM mode only)

--- a/tt_metal/fabric/fabric_tensix_builder.hpp
+++ b/tt_metal/fabric/fabric_tensix_builder.hpp
@@ -132,7 +132,7 @@ public:
 
     // UDM mode: Worker assignment info
     struct WorkerTensixInfo {
-        CoreCoord tensix_core;   // The tensix mux core assigned to this worker
+        CoreCoord tensix_core;     // The tensix mux core assigned to this worker (virtual coordinate)
         uint32_t channel_index{};  // The channel index on that tensix mux core
     };
 

--- a/tt_metal/fabric/fabric_tensix_builder_impl.cpp
+++ b/tt_metal/fabric/fabric_tensix_builder_impl.cpp
@@ -844,10 +844,7 @@ FabricTensixDatamoverMuxBuilder::FabricTensixDatamoverMuxBuilder(
     ethernet_channel_id_(ethernet_channel_id),
     link_idx_(link_idx),
     core_id_(core_id),
-    noc_x_(noc_x),
-    noc_y_(noc_y),
     config_(std::move(config)),
-    direction_(direction),
     has_fabric_router_(has_fabric_router) {
     channel_connection_liveness_check_disable_array_.fill(false);
     TT_FATAL(config_ != nullptr, "Config cannot be null");
@@ -988,7 +985,8 @@ std::vector<uint32_t> FabricTensixDatamoverMuxBuilder::get_persistent_channels_f
             TT_FATAL(num_channels == 3, "RELAY_TO_MUX_CHANNEL should have exactly 3 channels (got {})", num_channels);
 
             // Channel 0: Local relay (not persistent for non-active tensix core)
-            auto noc_coords = tensix_config.get_active_tensix_noc_coords(local_fabric_node_id_, link_idx_, direction_);
+            const auto* noc_coords =
+                tensix_config.get_active_tensix_noc_coords(local_fabric_node_id_, link_idx_, direction_);
             if (noc_coords) {
                 is_persistent_channels[static_cast<uint32_t>(UdmMuxRelayToMuxChannelId::LOCAL_RELAY_CHANNEL)] = 1;
             }

--- a/tt_metal/fabric/fabric_tensix_builder_impl.cpp
+++ b/tt_metal/fabric/fabric_tensix_builder_impl.cpp
@@ -378,8 +378,7 @@ FabricTensixDatamoverMuxConfig::FabricTensixDatamoverMuxConfig(
     }
 
     // Allocate channel storage region for storing channel arrays in L1 (4KB)
-    constexpr size_t channel_storage_size = 4 * 1024;  // 4KB for channel storage
-    channel_storage_region_ = MemoryRegion(current_address, channel_storage_size, 1);
+    channel_storage_region_ = MemoryRegion(current_address, channel_storage_size_, 1);
     current_address = channel_storage_region_.get_end_address();
 
     memory_map_end_address_ = current_address;

--- a/tt_metal/fabric/fabric_tensix_builder_impl.cpp
+++ b/tt_metal/fabric/fabric_tensix_builder_impl.cpp
@@ -430,7 +430,7 @@ std::vector<MuxConnectionInfo> FabricTensixDatamoverMuxConfig::get_all_mux_conne
     for (uint32_t i = 0; i < downstream_dirs.size(); i++) {
         auto downstream_dir = downstream_dirs[i];
         const auto* downstream_mux_noc_coord =
-            tensix_config.get_router_noc_coords(fabric_node_id, routing_plane_id, downstream_dir);
+            tensix_config.get_tensix_noc_coords(fabric_node_id, routing_plane_id, downstream_dir);
 
         // Calculate which channel on the downstream mux this mux should connect to
         uint32_t downstream_mux_channel = get_downstream_mux_channel_id(direction, downstream_dir);
@@ -648,7 +648,7 @@ FabricTensixDatamoverRelayConfig::get_all_mux_connection_infos(
 
     for (uint32_t i = 0; i < NUM_MUX_CONNECTIONS; i++) {
         auto target_dir = target_mux_dirs[i];
-        const auto* mux_noc_coord = tensix_config.get_router_noc_coords(fabric_node_id, routing_plane_id, target_dir);
+        const auto* mux_noc_coord = tensix_config.get_tensix_noc_coords(fabric_node_id, routing_plane_id, target_dir);
 
         // Determine which channel on the target mux we connect to
         uint32_t mux_channel_id;
@@ -830,7 +830,8 @@ FabricTensixDatamoverMuxBuilder::FabricTensixDatamoverMuxBuilder(
     uint32_t noc_x,
     uint32_t noc_y,
     std::shared_ptr<FabricTensixDatamoverMuxConfig> config,
-    eth_chan_directions direction) :
+    eth_chan_directions direction,
+    bool has_fabric_router) :
     FabricDatamoverBuilderBase(noc_x, noc_y, direction),
     my_core_logical_(my_core_logical),
     local_fabric_node_id_(local_fabric_node_id),
@@ -838,7 +839,11 @@ FabricTensixDatamoverMuxBuilder::FabricTensixDatamoverMuxBuilder(
     ethernet_channel_id_(ethernet_channel_id),
     link_idx_(link_idx),
     core_id_(core_id),
-    config_(std::move(config)) {
+    noc_x_(noc_x),
+    noc_y_(noc_y),
+    config_(std::move(config)),
+    direction_(direction),
+    has_fabric_router_(has_fabric_router) {
     channel_connection_liveness_check_disable_array_.fill(false);
     TT_FATAL(config_ != nullptr, "Config cannot be null");
 }
@@ -977,8 +982,11 @@ std::vector<uint32_t> FabricTensixDatamoverMuxBuilder::get_persistent_channels_f
             // Relay-to-Mux channels: check if relays exist in perpendicular directions (UDM mode only)
             TT_FATAL(num_channels == 3, "RELAY_TO_MUX_CHANNEL should have exactly 3 channels (got {})", num_channels);
 
-            // Channel 0: Local relay (always persistent)
-            is_persistent_channels[static_cast<uint32_t>(UdmMuxRelayToMuxChannelId::LOCAL_RELAY_CHANNEL)] = 1;
+            // Channel 0: Local relay (not persistent for non-active tensix core)
+            auto noc_coords = tensix_config.get_active_tensix_noc_coords(local_fabric_node_id_, link_idx_, direction_);
+            if (noc_coords) {
+                is_persistent_channels[static_cast<uint32_t>(UdmMuxRelayToMuxChannelId::LOCAL_RELAY_CHANNEL)] = 1;
+            }
 
             // Channels 1-2: Upstream relays (perpendicular directions)
             auto [upstream_relay_dir1, upstream_relay_dir2] = builder::get_perpendicular_directions(direction_);
@@ -989,7 +997,7 @@ std::vector<uint32_t> FabricTensixDatamoverMuxBuilder::get_persistent_channels_f
 
             for (size_t i = 0; i < upstream_relay_dirs.size(); i++) {
                 const auto* noc_coords =
-                    tensix_config.get_router_noc_coords(local_fabric_node_id_, link_idx_, upstream_relay_dirs[i]);
+                    tensix_config.get_active_tensix_noc_coords(local_fabric_node_id_, link_idx_, upstream_relay_dirs[i]);
                 if (noc_coords) {
                     is_persistent_channels[static_cast<uint32_t>(upstream_relay_channels[i])] = 1;
                 }
@@ -1001,9 +1009,11 @@ std::vector<uint32_t> FabricTensixDatamoverMuxBuilder::get_persistent_channels_f
             TT_FATAL(num_channels == 3, "MUX_TO_MUX_CHANNEL should have exactly 3 channels (got {})", num_channels);
 
             auto upstream_mux_dirs = builder::get_all_other_directions(direction_);
+            // for mux to mux channel, we need to check all the tensix cores, since there are mux kernel in the
+            // non-active tensix cores as well
             for (auto upstream_dir : upstream_mux_dirs) {
                 const auto* noc_coords =
-                    tensix_config.get_router_noc_coords(local_fabric_node_id_, link_idx_, upstream_dir);
+                    tensix_config.get_tensix_noc_coords(local_fabric_node_id_, link_idx_, upstream_dir);
                 if (noc_coords) {
                     uint32_t channel_id = get_upstream_mux_channel_id(direction_, upstream_dir);
                     is_persistent_channels[channel_id] = 1;
@@ -1059,8 +1069,11 @@ std::vector<uint32_t> FabricTensixDatamoverMuxBuilder::get_compile_time_args() c
         }
     }
 
-    // Add direction as the last argument
+    // Add direction
     ct_args.push_back(static_cast<uint32_t>(direction_));
+
+    // Add has_fabric_router flag (1 = has router, 0 = no router / missing direction)
+    ct_args.push_back(static_cast<uint32_t>(has_fabric_router_ ? 1 : 0));
 
     return ct_args;
 }
@@ -1097,7 +1110,8 @@ FabricTensixDatamoverRelayBuilder::FabricTensixDatamoverRelayBuilder(
     uint32_t noc_x,
     uint32_t noc_y,
     std::shared_ptr<FabricTensixDatamoverRelayConfig> config,
-    eth_chan_directions direction) :
+    eth_chan_directions direction,
+    bool /*has_fabric_router*/) :
     FabricDatamoverBuilderBase(noc_x, noc_y, direction),
     my_core_logical_(my_core_logical),
     local_fabric_node_id_(local_fabric_node_id),

--- a/tt_metal/fabric/fabric_tensix_builder_impl.hpp
+++ b/tt_metal/fabric/fabric_tensix_builder_impl.hpp
@@ -462,7 +462,7 @@ private:
 
     // Whether this mux has a fabric router to connect to
     // False for missing directions in UDM mode (inter-mux forwarding only)
-    bool has_fabric_router_;
+    bool has_fabric_router_ = true;
 
     // Channel connection liveness check disable array
     mutable std::array<bool, builder_config::num_sender_channels> channel_connection_liveness_check_disable_array_{};

--- a/tt_metal/fabric/fabric_tensix_builder_impl.hpp
+++ b/tt_metal/fabric/fabric_tensix_builder_impl.hpp
@@ -410,7 +410,8 @@ public:
         uint32_t noc_x,
         uint32_t noc_y,
         std::shared_ptr<FabricTensixDatamoverMuxConfig> config,
-        eth_chan_directions direction);
+        eth_chan_directions direction,
+        bool has_fabric_router);
 
     void create_and_compile(tt::tt_metal::Program& program);
 
@@ -447,6 +448,13 @@ private:
 
     std::shared_ptr<FabricTensixDatamoverMuxConfig> config_;
 
+    // Direction for routing
+    eth_chan_directions direction_;
+
+    // Whether this mux has a fabric router to connect to
+    // False for missing directions in UDM mode (inter-mux forwarding only)
+    bool has_fabric_router_;
+
     // Channel connection liveness check disable array
     mutable std::array<bool, builder_config::num_sender_channels> channel_connection_liveness_check_disable_array_{};
 
@@ -473,7 +481,8 @@ public:
         uint32_t noc_x,
         uint32_t noc_y,
         std::shared_ptr<FabricTensixDatamoverRelayConfig> config,
-        eth_chan_directions direction);
+        eth_chan_directions direction,
+        bool /*has_fabric_router*/);
 
     void create_and_compile(tt::tt_metal::Program& program);
 

--- a/tt_metal/fabric/fabric_tensix_builder_impl.hpp
+++ b/tt_metal/fabric/fabric_tensix_builder_impl.hpp
@@ -282,6 +282,9 @@ private:
     // Number of downstream mux connections (all directions except self = 3)
     static constexpr uint32_t NUM_DOWNSTREAM_MUX_CONNECTIONS = 3;
 
+    // Channel storage size for storing channel arrays in L1
+    static constexpr size_t channel_storage_size_ = 4096;  // 4KB for channel storage
+
     // ==================================================================================
     // Mux-specific: Support for inter-mux connections (mux → downstream mux)
     // Each mux can connect to 3 other muxes (all directions except itself)

--- a/tt_metal/fabric/fabric_tensix_builder_impl.hpp
+++ b/tt_metal/fabric/fabric_tensix_builder_impl.hpp
@@ -315,6 +315,15 @@ private:
     // Buffer index synchronization (mux → downstream mux direction) for each downstream mux connection
     // - Stored in current MUX's L1 memory
     std::array<MemoryRegion, NUM_DOWNSTREAM_MUX_CONNECTIONS> downstream_mux_buffer_index_semaphore_regions_{};
+
+    // Channel storage region: L1 memory for storing channel objects and interfaces
+    // Used by the kernel to place channel buffers and interfaces instead of global memory
+    MemoryRegion channel_storage_region_{};
+
+public:
+    // Getter for channel storage address
+    size_t get_channel_storage_base_address() const { return channel_storage_region_.get_address(); }
+    size_t get_channel_storage_size() const { return channel_storage_region_.get_total_size(); }
 };
 
 /**

--- a/tt_metal/fabric/fabric_tensix_builder_impl.hpp
+++ b/tt_metal/fabric/fabric_tensix_builder_impl.hpp
@@ -457,9 +457,6 @@ private:
 
     std::shared_ptr<FabricTensixDatamoverMuxConfig> config_;
 
-    // Direction for routing
-    eth_chan_directions direction_;
-
     // Whether this mux has a fabric router to connect to
     // False for missing directions in UDM mode (inter-mux forwarding only)
     bool has_fabric_router_;

--- a/tt_metal/fabric/impl/kernels/edm_fabric/fabric_router_udm_mux_extension.cpp
+++ b/tt_metal/fabric/impl/kernels/edm_fabric/fabric_router_udm_mux_extension.cpp
@@ -470,11 +470,6 @@ void kernel_main() {
     // In UDM mode, mux does NOT signal upstream routers - the relay will do that
     // (upstream routers connect to relay, not mux)
 
-    auto* routing_table = reinterpret_cast<tt_l1_ptr routing_l1_info_t*>(ROUTING_TABLE_BASE);
-    uint16_t my_chip_id = routing_table->my_device_id;
-    // DPRINT << " mux my_chip_id " << my_chip_id << " direction " << (uint)direction << " has_fabric_router " <<
-    // (uint)has_fabric_router <<ENDL();
-
     // Only wait for and open fabric router connection if we have a router
     if constexpr (has_fabric_router) {
         // wait for fabric router to be ready before setting up the connection
@@ -489,11 +484,7 @@ void kernel_main() {
         fabric_connection.open<false>();
     }
 
-    // DPRINT << " mux my_chip_id " << my_chip_id << " direction " << (uint)direction << " Done " <<ENDL();
-
     status_ptr[0] = tt::tt_fabric::FabricMuxStatus::READY_FOR_TRAFFIC;
-
-    // DPRINT << " mux my_chip_id " << my_chip_id << " direction " << (uint)direction << " Done " <<ENDL();
 
     // Before connecting to downstream muxes, wait for their status to turn into READY_FOR_TRAFFIC
     // Use status_address (our own status address) as the readback location


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/31709

### Problem description
We need to let the Mux service all the workers in a local chip, and we need to split the workers into chunks and assign them to different mux for saving channel space in mux.

Edge chips miss certain directions, ex, top-left chip only has east and south router, this caused uneven assignment of workers to mux, and can cause too many channels being added to mux.

### What's changed
Assign workers to the mux, partition the worker gird into columns, each mux serve a subset of workers.

Add missing directions mux core to each chip, ex, t3k top left corner will have extra west direction mux being built. 

Modify control plane so that each worker has the correct mux info to connect to.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes