### PR TITLE
Add support for sub core grid to nlp_concat_heads

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_nlp_concat_heads_decode.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_nlp_concat_heads_decode.py
@@ -32,7 +32,9 @@ def num_to_corerange(x):
     )
 
 
-def run_test_concat_head(device, n_local_heads, padded_local_heads, head_dim, batch, sub_core_grids=None):
+def run_test_concat_head(
+    device, n_local_heads, padded_local_heads, head_dim, batch, input_sub_core_grids=None, compute_sub_core_grids=None
+):
     ## Split Heads
     padded_batch = nearest_32(batch)
     seq_len = 1
@@ -40,12 +42,28 @@ def run_test_concat_head(device, n_local_heads, padded_local_heads, head_dim, ba
     # Prepare input
     concat_head_input = torch.rand(1, batch, padded_local_heads, head_dim)
 
-    if sub_core_grids is None:
+    if input_sub_core_grids is None:
         shard_grid = ttnn.CoreRangeSet({num_to_corerange(batch)})
     else:
-        shard_grid = ttnn.num_cores_to_corerangeset_in_subcoregrids(
-            sub_core_grids.bounding_box().start, batch, sub_core_grids, row_wise=True
+        shard_grid = input_sub_core_grids
+
+    # If the provided input sub core grids has enough cores, use that one for compute otherwise
+    # we expect a compute sub core grid which must have at least n_local_heads cores to be provided
+    if input_sub_core_grids is not None and input_sub_core_grids.num_cores() >= n_local_heads:
+        # Use the input sub core grids for compute
+        sub_core_grids = ttnn.num_cores_to_corerangeset_in_subcoregrids(
+            input_sub_core_grids.bounding_box().start, n_local_heads, input_sub_core_grids, row_wise=True
         )
+    else:
+        # Use the compute sub core grids for compute
+        assert (
+            compute_sub_core_grids is not None
+        ), "compute_sub_core_grids must be provided if input_sub_core_grids has less than n_local_heads cores"
+        sub_core_grids = compute_sub_core_grids
+        assert (
+            sub_core_grids.num_cores() >= n_local_heads
+        ), "compute_sub_core_grids must have at least n_local_heads cores"
+
     SCORES_BATCHED_MM_OUTPUT_MEMCFG = ttnn.MemoryConfig(
         ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
         ttnn.BufferType.L1,
@@ -64,10 +82,10 @@ def run_test_concat_head(device, n_local_heads, padded_local_heads, head_dim, ba
     concat_head_input_tt = torch2tt_tensor(concat_head_input, tt_device=None).to(
         device=device, mem_config=SCORES_BATCHED_MM_OUTPUT_MEMCFG
     )
-
     concat_head_output = ttnn.experimental.nlp_concat_heads_decode(
         concat_head_input_tt,
         num_heads=n_local_heads,
+        sub_core_grids=sub_core_grids,
     )  # seqlen, 1, batch, hidden_size
 
     logger.info(f"concat_head_output: {concat_head_output.memory_config()}")
@@ -104,13 +122,36 @@ def test_concat_head(
 
 
 @pytest.mark.parametrize(
-    "n_local_heads, padded_local_heads, head_dim, batch_size, sub_core_grids",
+    "n_local_heads, padded_local_heads, head_dim, batch_size, input_sub_core_grids, compute_sub_core_grids",
     (
-        (
+        (  # Test Case 0: Input is sharded on 8 cores, use all 8 cores for compute
             8,
             32,
             128,
             8,
+            ttnn.CoreRangeSet(
+                [
+                    ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(3, 1)),
+                    ttnn.CoreRange(ttnn.CoreCoord(1, 2), ttnn.CoreCoord(2, 2)),
+                ]
+            ),
+            ttnn.CoreRangeSet(
+                [
+                    ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(3, 1)),
+                    ttnn.CoreRange(ttnn.CoreCoord(1, 2), ttnn.CoreCoord(2, 2)),
+                ]
+            ),
+        ),
+        (  # Test Case 1: Input is sharded on only 1 core, use the compute sub core grids for compute
+            8,
+            32,
+            128,
+            1,
+            ttnn.CoreRangeSet(
+                [
+                    ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(1, 0)),
+                ]
+            ),
             ttnn.CoreRangeSet(
                 [
                     ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(3, 1)),
@@ -126,11 +167,20 @@ def test_concat_head_subcoregrids(
     padded_local_heads,
     head_dim,
     batch_size,
-    sub_core_grids,
+    input_sub_core_grids,
+    compute_sub_core_grids,
     mesh_device,
 ):
     torch.manual_seed(0)
 
     for i in range(3):
         # multiple loops to test program caching
-        run_test_concat_head(mesh_device, n_local_heads, padded_local_heads, head_dim, batch_size, sub_core_grids)
+        run_test_concat_head(
+            mesh_device,
+            n_local_heads,
+            padded_local_heads,
+            head_dim,
+            batch_size,
+            input_sub_core_grids,
+            compute_sub_core_grids,
+        )

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/device/nlp_concat_heads_decode_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/device/nlp_concat_heads_decode_device_operation.cpp
@@ -47,11 +47,12 @@ void NLPConcatHeadsDecodeDeviceOperation::validate(const std::vector<Tensor>& in
         shard_spec.shape[0],
         input_tensor.padded_shape()[-2]);
     auto num_cores = shard_spec.grid.num_cores();
-    TT_FATAL(num_cores == input_shape[1], "num_cores must be equal to num users");
     if (this->on_subcoregrids) {
         TT_FATAL(sub_core_grids.has_value(), "Subcoregrids must be provided if on_subcoregrids is true");
         TT_FATAL(
             sub_core_grids.value().num_cores() >= this->num_heads, "Subcoregrids must have at least num_heads cores");
+    } else {
+        TT_FATAL(num_cores == input_shape[1], "num_cores must be equal to num users");
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/device/nlp_concat_heads_decode_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/device/nlp_concat_heads_decode_device_operation.cpp
@@ -49,7 +49,9 @@ void NLPConcatHeadsDecodeDeviceOperation::validate(const std::vector<Tensor>& in
     auto num_cores = shard_spec.grid.num_cores();
     TT_FATAL(num_cores == input_shape[1], "num_cores must be equal to num users");
     if (this->on_subcoregrids) {
-        TT_FATAL(num_cores >= this->num_heads, "For subcoregrid inputs, we only support num_heads<=num_cores");
+        TT_FATAL(sub_core_grids.has_value(), "Subcoregrids must be provided if on_subcoregrids is true");
+        TT_FATAL(
+            sub_core_grids.value().num_cores() >= this->num_heads, "Subcoregrids must have at least num_heads cores");
     }
 }
 
@@ -74,8 +76,9 @@ std::vector<ttnn::TensorSpec> NLPConcatHeadsDecodeDeviceOperation::compute_outpu
         const auto input_core_ranges = input_tensor.shard_spec().value().grid.ranges();
         CoreRangeSet input_core_grid = input_tensor.shard_spec().value().grid;
         const auto start_coord = input_core_ranges[0].start_coord;
-        output_core_grid =
-            tt::tt_metal::num_cores_to_corerangeset_in_subcoregrids(start_coord, num_heads, input_core_grid, true);
+        const auto& sub_core_grids = this->sub_core_grids;
+        output_core_grid = tt::tt_metal::num_cores_to_corerangeset_in_subcoregrids(
+            start_coord, num_heads, sub_core_grids.value(), true);
     } else {
         output_core_grid = tt::tt_metal::num_cores_to_corerangeset(
             num_heads, input_tensor.device()->compute_with_storage_grid_size(), true);

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/device/nlp_concat_heads_decode_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/device/nlp_concat_heads_decode_device_operation.cpp
@@ -48,11 +48,12 @@ void NLPConcatHeadsDecodeDeviceOperation::validate(const std::vector<Tensor>& in
         input_tensor.padded_shape()[-2]);
     auto num_cores = shard_spec.grid.num_cores();
     if (this->on_subcoregrids) {
+        TT_FATAL(num_cores == input_shape[1], "Input core grid num_cores must be equal to num users");
         TT_FATAL(sub_core_grids.has_value(), "Subcoregrids must be provided if on_subcoregrids is true");
         TT_FATAL(
             sub_core_grids.value().num_cores() >= this->num_heads, "Subcoregrids must have at least num_heads cores");
     } else {
-        TT_FATAL(num_cores == input_shape[1], "num_cores must be equal to num users");
+        TT_FATAL(num_cores == input_shape[1], "Input core grid num_cores must be equal to num users");
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/device/nlp_concat_heads_decode_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/device/nlp_concat_heads_decode_device_operation.hpp
@@ -20,6 +20,7 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_nlp_concat_heads_decode
 struct NLPConcatHeadsDecodeDeviceOperation {
     const uint32_t num_heads{};
     const bool on_subcoregrids = false;
+    const std::optional<CoreRangeSet> sub_core_grids = std::nullopt;
 
     void validate(const std::vector<Tensor>& input_tensors) const;
     std::vector<ttnn::TensorSpec> compute_output_specs(const std::vector<Tensor>& input_tensors) const;

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/nlp_concat_heads_decode.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/nlp_concat_heads_decode.hpp
@@ -14,7 +14,8 @@ struct NLPConcatHeadsDecodeOperation {
         const Tensor& input_tensor,
         uint32_t num_heads,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
-        std::optional<Tensor> optional_output_tensor = std::nullopt);
+        std::optional<Tensor> optional_output_tensor = std::nullopt,
+        const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
 };
 }  // namespace operations::experimental::transformer
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/nlp_concat_heads_decode_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/nlp_concat_heads_decode_pybind.cpp
@@ -23,14 +23,16 @@ void bind_nlp_concat_heads_decode(py::module& module) {
                const ttnn::Tensor& input_tensor,
                const uint32_t num_heads,
                const std::optional<ttnn::MemoryConfig>& memory_config,
-               std::optional<ttnn::Tensor> optional_output_tensor) {
-                return self(input_tensor, num_heads, memory_config, optional_output_tensor);
+               std::optional<ttnn::Tensor> optional_output_tensor,
+               const std::optional<CoreRangeSet>& sub_core_grids) {
+                return self(input_tensor, num_heads, memory_config, optional_output_tensor, sub_core_grids);
             },
             py::arg("input_tensor").noconvert(),
             py::kw_only(),
             py::arg("num_heads").noconvert(),
             py::arg("memory_config") = std::nullopt,
-            py::arg("output_tensor") = std::nullopt});
+            py::arg("output_tensor") = std::nullopt,
+            py::arg("sub_core_grids") = std::nullopt});
 }
 
 }  // namespace ttnn::operations::experimental::transformer::detail


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/33311

### Problem 
To add support for dram prefetcher to TTT a series of ops must support running sub core grid, nlp concat heads doesn't properly support sub core grids, if the input tensor is sharded on only 1 core (meaning only 1 user or batch 1) we would previously try to form a core range set of num heads with the input tensor's shard grid. But that doesnt work since there's only 1 core. So we need to pass an additional sub core grid informing the op of which cores to use to form the compute sub core grid of num head cores.  If the input is already sharded on num heads number of cores then that compute sub core grid is not necessary to be passed

### What's changed
- added a test case for this use case
- added a sub core grid parameter to the op and form the core range set with the provided sub core grid

### Checklists
- [ ] [APC](https://github.com/tenstorrent/tt-metal/actions/runs/19748165620)
- [ ] [T3K demo](https://github.com/tenstorrent/tt-metal/actions/runs/19837549939) (failures irrelevant to my changes)