### PR TITLE
Fix paged cache update sub core grid support 

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/update_cache/paged_update_cache_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/update_cache/paged_update_cache_program_factory.cpp
@@ -112,7 +112,7 @@ PagedUpdateCacheProgramFactory::cached_program_t PagedUpdateCacheProgramFactory:
     CoreRangeSet all_cores = shard_spec.value().grid;
     uint32_t num_cores = all_cores.num_cores();
     uint32_t num_input_tiles = shard_spec.value().shape[0] * shard_spec.value().shape[1] / TILE_HW;
-    auto in1_buffer_address = shard_spec.has_value() ? input_tensor.buffer() : nullptr;
+    auto* in1_buffer_address = shard_spec.has_value() ? input_tensor.buffer() : nullptr;
 
     uint32_t num_cache_tiles = 2 * Wt;   // double buffered
     uint32_t num_interm_tiles = 2 * Wt;  // double buffered

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/update_cache/paged_update_cache_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/update_cache/paged_update_cache_program_factory.cpp
@@ -112,11 +112,7 @@ PagedUpdateCacheProgramFactory::cached_program_t PagedUpdateCacheProgramFactory:
     CoreRangeSet all_cores = shard_spec.value().grid;
     uint32_t num_cores = all_cores.num_cores();
     uint32_t num_input_tiles = shard_spec.value().shape[0] * shard_spec.value().shape[1] / TILE_HW;
-    auto bbox = all_cores.bounding_box();
-    uint32_t num_cores_x = bbox.end_coord.x + 1;
-    uint32_t num_cores_y = bbox.end_coord.y + 1;
-
-    auto* in1_buffer_address = shard_spec.has_value() ? input_tensor.buffer() : nullptr;
+    auto in1_buffer_address = shard_spec.has_value() ? input_tensor.buffer() : nullptr;
 
     uint32_t num_cache_tiles = 2 * Wt;   // double buffered
     uint32_t num_interm_tiles = 2 * Wt;  // double buffered
@@ -244,9 +240,8 @@ PagedUpdateCacheProgramFactory::cached_program_t PagedUpdateCacheProgramFactory:
         all_cores,
         tt_metal::ComputeConfig{.fp32_dest_acc_en = fp32_dest_acc_en, .compile_args = compute_kernel_args});
 
-    const auto& cores = grid_to_cores(num_cores, num_cores_x, num_cores_y, row_major);
-
-    for (uint32_t i = 0; i < num_cores; ++i) {
+    const auto& cores = corerange_to_cores(all_cores, num_cores, row_major);
+    for (uint32_t i = 0; i < cores.size(); ++i) {
         const CoreCoord& core = cores.at(i);
         const uint32_t update_idx = use_index_tensor ? 0 : operation_attributes.update_idxs.at(i);
         // Cache tile info


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/33311

### Problem description
Paged cache update supports sub core grids however there is a small bug in how the core ranges are formed.
https://github.com/tenstorrent/tt-metal/blob/dd722144e7201b1391a8991dcaf69a6cf4927adf/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/update_cache/paged_update_cache_program_factory.cpp#L247

all cores represents the bounding box of cores starting from the core that has the input tensor. then we perform a `grid_to_cores` which always picks cores starting from 0,0. So if the input tensor was not on core 0,0 there would be a mismatch and the op would not actually execute, we should use `core range_to_cores` so it would form the core vector starting from the input tensor core. 

### What's changed
- made the change to use `core range_to_cores`

### Checklist
- [ ] [APC](https://github.com/tenstorrent/tt-metal/actions/runs/19828096380)