### PR TITLE
Add tilizeA_B_uninit to compute_pool_2d.cpp

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/pool/test_maxpool2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/pool/test_maxpool2d.py
@@ -558,30 +558,48 @@ def test_run_max_pool_squeeze_net_model(
     )
 
 
+# @pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
+# @pytest.mark.parametrize("out_dtype", [ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat4_b])
+# @pytest.mark.parametrize("output_layout", [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT])
+# @pytest.mark.parametrize(
+#     "input_shape, shard_startegy",
+#     (
+#         (
+#             ([1, 64, 112, 112], HS),
+#             ([1, 280, 10, 10], HS),
+#             ([1, 384, 32, 32], HS),
+#             ([1, 256, 132, 20], BS),
+#             ([1, 512, 8, 6], BS),
+#             ([2, 4096, 10, 16], WS),
+#             ([1, 32768, 10, 10], WS),
+#         )
+#     ),
+# )
+# @pytest.mark.parametrize(
+#     "kernel_size",
+#     (
+#         (3, 3),
+#         (5, 5),
+#         (9, 9),
+#     ),
+# )
+# @pytest.mark.parametrize(
+#     "in_dtype",
+#     [
+#         ttnn.bfloat16,
+#         ttnn.bfloat8_b,
+#     ],
+# )
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
-@pytest.mark.parametrize("out_dtype", [ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat4_b])
-@pytest.mark.parametrize("output_layout", [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT])
+@pytest.mark.parametrize("out_dtype", [ttnn.bfloat8_b, ttnn.bfloat4_b])
+@pytest.mark.parametrize("output_layout", [ttnn.TILE_LAYOUT])
 @pytest.mark.parametrize(
     "input_shape, shard_startegy",
-    (
-        (
-            ([1, 64, 112, 112], HS),
-            ([1, 280, 10, 10], HS),
-            ([1, 384, 32, 32], HS),
-            ([1, 256, 132, 20], BS),
-            ([1, 512, 8, 6], BS),
-            ([2, 4096, 10, 16], WS),
-            ([1, 32768, 10, 10], WS),
-        )
-    ),
+    ((([1, 256, 132, 20], BS),)),
 )
 @pytest.mark.parametrize(
     "kernel_size",
-    (
-        (3, 3),
-        (5, 5),
-        (9, 9),
-    ),
+    ((3, 3),),
 )
 @pytest.mark.parametrize(
     "in_dtype",

--- a/tests/ttnn/nightly/unit_tests/operations/pool/test_maxpool2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/pool/test_maxpool2d.py
@@ -558,48 +558,30 @@ def test_run_max_pool_squeeze_net_model(
     )
 
 
-# @pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
-# @pytest.mark.parametrize("out_dtype", [ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat4_b])
-# @pytest.mark.parametrize("output_layout", [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT])
-# @pytest.mark.parametrize(
-#     "input_shape, shard_startegy",
-#     (
-#         (
-#             ([1, 64, 112, 112], HS),
-#             ([1, 280, 10, 10], HS),
-#             ([1, 384, 32, 32], HS),
-#             ([1, 256, 132, 20], BS),
-#             ([1, 512, 8, 6], BS),
-#             ([2, 4096, 10, 16], WS),
-#             ([1, 32768, 10, 10], WS),
-#         )
-#     ),
-# )
-# @pytest.mark.parametrize(
-#     "kernel_size",
-#     (
-#         (3, 3),
-#         (5, 5),
-#         (9, 9),
-#     ),
-# )
-# @pytest.mark.parametrize(
-#     "in_dtype",
-#     [
-#         ttnn.bfloat16,
-#         ttnn.bfloat8_b,
-#     ],
-# )
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
-@pytest.mark.parametrize("out_dtype", [ttnn.bfloat8_b, ttnn.bfloat4_b])
-@pytest.mark.parametrize("output_layout", [ttnn.TILE_LAYOUT])
+@pytest.mark.parametrize("out_dtype", [ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat4_b])
+@pytest.mark.parametrize("output_layout", [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT])
 @pytest.mark.parametrize(
     "input_shape, shard_startegy",
-    ((([1, 256, 132, 20], BS),)),
+    (
+        (
+            ([1, 64, 112, 112], HS),
+            ([1, 280, 10, 10], HS),
+            ([1, 384, 32, 32], HS),
+            ([1, 256, 132, 20], BS),
+            ([1, 512, 8, 6], BS),
+            ([2, 4096, 10, 16], WS),
+            ([1, 32768, 10, 10], WS),
+        )
+    ),
 )
 @pytest.mark.parametrize(
     "kernel_size",
-    ((3, 3),),
+    (
+        (3, 3),
+        (5, 5),
+        (9, 9),
+    ),
 )
 @pytest.mark.parametrize(
     "in_dtype",
@@ -608,6 +590,24 @@ def test_run_max_pool_squeeze_net_model(
         ttnn.bfloat8_b,
     ],
 )
+# @pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
+# @pytest.mark.parametrize("out_dtype", [ttnn.bfloat8_b, ttnn.bfloat4_b])
+# @pytest.mark.parametrize("output_layout", [ttnn.TILE_LAYOUT])
+# @pytest.mark.parametrize(
+#     "input_shape, shard_startegy",
+#     ((([1, 256, 132, 20], BS),)),
+# )
+# @pytest.mark.parametrize(
+#     "kernel_size",
+#     ((3, 3),),
+# )
+# @pytest.mark.parametrize(
+#     "in_dtype",
+#     [
+#         ttnn.bfloat16,
+#         ttnn.bfloat8_b,
+#     ],
+# )
 def test_max_pool2d_output_formats_and_layouts(
     device, tensor_map, input_shape, shard_startegy, kernel_size, out_dtype, output_layout, in_dtype
 ):

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_tilize_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_tilize_api.h
@@ -220,3 +220,8 @@ inline void llk_unpack_tilizeA_B_block(
         llk_unpack_tilizeA_B<neginf_srcA, reload_srcB, zero_srcA, zero_srcA_reduce>(operandA, operandB, tile_idx_a, tile_idx_b, block_c_tiles_a, num_faces, unpA_face_r_dim);
     }
 }
+
+inline void llk_unpack_tilizeA_B_uninit(const std::uint32_t operand, const std::uint32_t face_r_dim = FACE_R_DIM) {
+    std::uint32_t operand_id = get_operand_id(operand);
+    _llk_unpack_tilizeA_B_uninit_((uint)unpack_dst_format[operand_id], face_r_dim);
+}

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_A_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_A_api.h
@@ -32,39 +32,10 @@ template <
     bool is_fp32_dest_acc_en,
     StochRndType stoch_rnd_mode = StochRndType::None,
     bool disable_src_zero_flag = false>
-inline void llk_unpack_A_hw_configure_copy(
-    const llk_unpack_A_params_t* unpack_A_params, const int within_face_16x16_transpose = 0) {
-    const uint32_t unpA_operand_id = get_operand_id(unpack_A_params->unpA_operand);
-    const uint32_t unpA_num_faces = get_operand_num_faces(unpA_operand_id);
-    const uint32_t unpA_face_r_dim = get_operand_face_r_dim(unpA_operand_id);
-
-    _llk_unpack_A_hw_configure_copy_<is_fp32_dest_acc_en, stoch_rnd_mode, disable_src_zero_flag>(
-        unpack_src_format[unpA_operand_id],
-        unpack_dst_format[unpA_operand_id],
-        unpA_face_r_dim,
-        within_face_16x16_transpose,
-        unpA_num_faces);
-}
-
-template <
-    bool is_fp32_dest_acc_en,
-    StochRndType stoch_rnd_mode = StochRndType::None,
-    bool disable_src_zero_flag = false>
 inline void llk_unpack_A_hw_configure_disaggregated(
     const std::uint32_t unpA_operand, const int within_face_16x16_transpose = 0) {
     const llk_unpack_A_params_t unpack_A_params = {.unpA_operand = unpA_operand};
     llk_unpack_A_hw_configure<is_fp32_dest_acc_en, stoch_rnd_mode, disable_src_zero_flag>(
-        &unpack_A_params, within_face_16x16_transpose);
-}
-
-template <
-    bool is_fp32_dest_acc_en,
-    StochRndType stoch_rnd_mode = StochRndType::None,
-    bool disable_src_zero_flag = false>
-inline void llk_unpack_A_hw_configure_disaggregated_copy(
-    const std::uint32_t unpA_operand, const int within_face_16x16_transpose = 0) {
-    const llk_unpack_A_params_t unpack_A_params = {.unpA_operand = unpA_operand};
-    llk_unpack_A_hw_configure_copy<is_fp32_dest_acc_en, stoch_rnd_mode, disable_src_zero_flag>(
         &unpack_A_params, within_face_16x16_transpose);
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_A_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_A_api.h
@@ -32,10 +32,39 @@ template <
     bool is_fp32_dest_acc_en,
     StochRndType stoch_rnd_mode = StochRndType::None,
     bool disable_src_zero_flag = false>
+inline void llk_unpack_A_hw_configure_copy(
+    const llk_unpack_A_params_t* unpack_A_params, const int within_face_16x16_transpose = 0) {
+    const uint32_t unpA_operand_id = get_operand_id(unpack_A_params->unpA_operand);
+    const uint32_t unpA_num_faces = get_operand_num_faces(unpA_operand_id);
+    const uint32_t unpA_face_r_dim = get_operand_face_r_dim(unpA_operand_id);
+
+    _llk_unpack_A_hw_configure_copy_<is_fp32_dest_acc_en, stoch_rnd_mode, disable_src_zero_flag>(
+        unpack_src_format[unpA_operand_id],
+        unpack_dst_format[unpA_operand_id],
+        unpA_face_r_dim,
+        within_face_16x16_transpose,
+        unpA_num_faces);
+}
+
+template <
+    bool is_fp32_dest_acc_en,
+    StochRndType stoch_rnd_mode = StochRndType::None,
+    bool disable_src_zero_flag = false>
 inline void llk_unpack_A_hw_configure_disaggregated(
     const std::uint32_t unpA_operand, const int within_face_16x16_transpose = 0) {
     const llk_unpack_A_params_t unpack_A_params = {.unpA_operand = unpA_operand};
     llk_unpack_A_hw_configure<is_fp32_dest_acc_en, stoch_rnd_mode, disable_src_zero_flag>(
+        &unpack_A_params, within_face_16x16_transpose);
+}
+
+template <
+    bool is_fp32_dest_acc_en,
+    StochRndType stoch_rnd_mode = StochRndType::None,
+    bool disable_src_zero_flag = false>
+inline void llk_unpack_A_hw_configure_disaggregated_copy(
+    const std::uint32_t unpA_operand, const int within_face_16x16_transpose = 0) {
+    const llk_unpack_A_params_t unpack_A_params = {.unpA_operand = unpA_operand};
+    llk_unpack_A_hw_configure_copy<is_fp32_dest_acc_en, stoch_rnd_mode, disable_src_zero_flag>(
         &unpack_A_params, within_face_16x16_transpose);
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_tilize_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_tilize_api.h
@@ -272,7 +272,8 @@ inline void llk_unpack_fast_tilize_block(
         base_address, tile_index, unpack_src_format[operand_id], unit_dim, num_units, full_dim);
 }
 
-inline void llk_unpack_tilizeA_B_uninit(const std::uint32_t operand, const std::uint32_t face_r_dim = FACE_R_DIM) {
+inline void llk_unpack_tilizeA_B_uninit(const std::uint32_t operand) {
     std::uint32_t operand_id = get_operand_id(operand);
+    const std::uint32_t face_r_dim = get_operand_face_r_dim(operand_id);
     _llk_unpack_tilizeA_B_uninit_((uint)unpack_dst_format[operand_id], face_r_dim);
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_tilize_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_tilize_api.h
@@ -271,3 +271,8 @@ inline void llk_unpack_fast_tilize_block(
     _llk_unpack_fast_tilize_block_(
         base_address, tile_index, unpack_src_format[operand_id], unit_dim, num_units, full_dim);
 }
+
+inline void llk_unpack_tilizeA_B_uninit(const std::uint32_t operand, const std::uint32_t face_r_dim = FACE_R_DIM) {
+    std::uint32_t operand_id = get_operand_id(operand);
+    _llk_unpack_tilizeA_B_uninit_((uint)unpack_dst_format[operand_id], face_r_dim);
+}

--- a/tt_metal/include/compute_kernel_api/tilize.h
+++ b/tt_metal/include/compute_kernel_api/tilize.h
@@ -477,4 +477,6 @@ ALWI void fast_tilize_block(
 #endif
 }
 
+ALWI void tilizeA_B_uninit(uint32_t icb) { UNPACK((llk_unpack_tilizeA_B_uninit(icb))); }
+
 }  // namespace ckernel

--- a/tt_metal/include/compute_kernel_api/tilize.h
+++ b/tt_metal/include/compute_kernel_api/tilize.h
@@ -477,6 +477,6 @@ ALWI void fast_tilize_block(
 #endif
 }
 
-ALWI void tilizeA_B_uninit(uint32_t icb) { UNPACK((llk_unpack_tilizeA_B_uninit(icb))); }
+ALWI void unpack_tilizeA_B_uninit(uint32_t icb) { UNPACK((llk_unpack_tilizeA_B_uninit(icb))); }
 
 }  // namespace ckernel

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_pool_2d.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_pool_2d.cpp
@@ -263,6 +263,11 @@ void MAIN {
                         //     pre_tilize_cb_id)));
                         tensix_sync();
                         UNPACK(tilizeA_B_uninit(pre_tilize_cb_id));
+                        // nops
+                        for (uint32_t i = 0; i < 4; i++) {
+                            TTI_NOP;
+                            asm volatile("nop");
+                        }
                         tensix_sync();
                         pack_reconfig_data_format(out_cb_id);
 

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_pool_2d.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_pool_2d.cpp
@@ -262,7 +262,7 @@ void MAIN {
                         // false>(
                         //     pre_tilize_cb_id)));
                         tensix_sync();
-                        UNPACK(tilizeA_B_uninit(pre_tilize_cb_id));
+                        unpack_tilizeA_B_uninit(pre_tilize_cb_id);
                         // nops are used to avoid a race condition #33429
                         for (uint32_t i = 0; i < 10; i++) {
                             TTI_NOP;

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_pool_2d.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_pool_2d.cpp
@@ -257,9 +257,12 @@ void MAIN {
                         // We should be calling tilizeA_B_uninit and for BFP4 output may be a reconfig_data_format
                         // and also remove the tensix_syncs. Currently they are incomplete and hence the full call
                         // to unpack_A_hw_configure.
+                        // tensix_sync();
+                        // UNPACK((llk_unpack_A_hw_configure_disaggregated_copy<DST_ACCUM_MODE, StochRndType::None,
+                        // false>(
+                        //     pre_tilize_cb_id)));
                         tensix_sync();
-                        UNPACK((llk_unpack_A_hw_configure_disaggregated<DST_ACCUM_MODE, StochRndType::None, false>(
-                            pre_tilize_cb_id)));
+                        UNPACK(tilizeA_B_uninit(pre_tilize_cb_id));
                         tensix_sync();
                         pack_reconfig_data_format(out_cb_id);
 

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_pool_2d.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_pool_2d.cpp
@@ -263,7 +263,7 @@ void MAIN {
                         //     pre_tilize_cb_id)));
                         tensix_sync();
                         UNPACK(tilizeA_B_uninit(pre_tilize_cb_id));
-                        // nops are used to avoid a race condition
+                        // nops are used to avoid a race condition #33429
                         for (uint32_t i = 0; i < 10; i++) {
                             TTI_NOP;
                             asm volatile("nop");

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_pool_2d.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_pool_2d.cpp
@@ -270,8 +270,8 @@ void MAIN {
                         //     pre_tilize_cb_id)));
                         tensix_sync();
                         UNPACK(tilizeA_B_uninit(pre_tilize_cb_id));
-                        // nops
-                        for (uint32_t i = 0; i < 4; i++) {
+                        // nops are used to avoid a race condition
+                        for (uint32_t i = 0; i < 10; i++) {
                             TTI_NOP;
                             asm volatile("nop");
                         }

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_pool_2d.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_pool_2d.cpp
@@ -12,7 +12,7 @@
 #include "compute_kernel_api/tile_move_copy.h"
 #include "compute_kernel_api/add_int_sfpu.h"
 
-#define DEBUG_PRINT 0
+#define DEBUG_PRINT 1
 
 #if DEBUG_PRINT == 1
 #include "debug/dprint.h"
@@ -172,9 +172,12 @@ void MAIN {
                 }
             }
             tile_regs_acquire();
+            // starting here check below
             for (uint32_t chunk = 0; chunk < interm_reduction_chunks; chunk++) {
                 cb_wait_front(curr_in_cb_id, 1);
                 if constexpr (return_indices) {
+                    DPRINT_UNPACK(DPRINT << "A1" << ENDL());
+
                     reconfig_data_format_srca(curr_in_cb_id);
                     copy_tile(curr_in_cb_id, mpwi_cb_tile_idx, data_dst_idx);
 
@@ -184,6 +187,7 @@ void MAIN {
                     reconfig_data_format_srca(in_idx_cb_id);
                     copy_tile(in_idx_cb_id, mpwi_cb_tile_idx, index_dst_idx);
                     if (last_c_block) {
+                        DPRINT_UNPACK(DPRINT << "B1" << ENDL());
                         cb_pop_front(in_idx_cb_id, 1);
 
                         // update the current index column
@@ -203,6 +207,7 @@ void MAIN {
                             current_idx_col += stride_w;
                             copy_tile(right_inc_cb_id, mpwi_cb_tile_idx, inc_dst_idx);
                         }
+                        // copy_tile() is being called no matter what in b1
 
                         // we allow overflow here for negative values as this only occurs in padding regions
                         add_int_tile_init();
@@ -220,6 +225,7 @@ void MAIN {
                     max_reduce_with_indices<max_mpwi_kernel_size, ckernel::DataLayout::ROW_MAJOR>(
                         data_dst_idx, index_dst_idx);
                 } else {
+                    // DPRINT_UNPACK(DPRINT << "A2" << ENDL());
                     unpack_tilizeA_B_block<neginf_srca_maxpool, true, false, zero_srca_avgpool>(
                         curr_in_cb_id,
                         curr_scalar_cb_id,
@@ -229,6 +235,7 @@ void MAIN {
                         face_r_dim);
                     for (uint32_t math_tile_idx = 0; math_tile_idx < tiles_to_reduce; ++math_tile_idx) {
                         reduce_tile_math(math_tile_idx, num_faces_in_input_tile);
+                        // DPRINT_UNPACK(DPRINT << "C1" << ENDL());
                     }
                 }
                 cb_pop_front(curr_in_cb_id, 1);
@@ -268,6 +275,7 @@ void MAIN {
                             TTI_NOP;
                             asm volatile("nop");
                         }
+                        // DPRINT_UNPACK(DPRINT << "nops done" << ENDL());
                         tensix_sync();
                         pack_reconfig_data_format(out_cb_id);
 


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/27504?reload=1)

### Problem description
The `compute_pool_2d.cpp` kernel should not require `llk_unpack_A_hw_configure_disaggregated` to make the ttnn tests pass, but currently it does. We found that there was an initialization earlier in the kernel that did not have its corresponding uninit and want to make these tests pass with the proper uninit instead

### What's changed
We replace the call to `llk_unpack_A_hw_configure_disaggregated` with an unpacker tilize AB uninit. However, in order for the tests to all pass on Wormhole, we still require the usage of `tensix_sync()` and nops, suggesting we may have a race condition (to be discussed in another issue).

APIs have been added so we can use `_llk_unpack_tilizeA_B_uninit_` in the kernel

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes