### PR TITLE
#0: enhance comp_ulp message

### DIFF
--- a/models/common/utility_functions.py
+++ b/models/common/utility_functions.py
@@ -649,8 +649,8 @@ def comp_ulp(golden, calculated, ulp_threshold, allow_nonfinite=False):
     message = f"Max ULP Delta: {ulp_delta}"
     if not within_threshold:
         ulp_index = torch.argmax(ulp_tensor)
-        ulp_index_tuple = torch.unravel_index(ulp_index, golden.shape)
-        message += f" @ {[int(x) for x in ulp_index_tuple]} = |{calculated[ulp_index_tuple]} - {golden[ulp_index_tuple]}| / {ulp_value[ulp_index_tuple]}"
+        ulp_index_tuple = tuple(int(idx) for idx in torch.unravel_index(ulp_index, golden.shape))
+        message += f" @ {list(ulp_index_tuple)} = |{calculated[ulp_index_tuple]} - {golden[ulp_index_tuple]}| / {ulp_value[ulp_index_tuple]}"
     return (within_threshold, message)
 
 

--- a/models/common/utility_functions.py
+++ b/models/common/utility_functions.py
@@ -643,9 +643,16 @@ def comp_ulp(golden, calculated, ulp_threshold, allow_nonfinite=False):
         calculated = calculated.type(golden.dtype)
         ulp_value = ulp_value.type(golden.dtype)  # Convert ULP to higher precision (for sub-1 ULP measurements)
 
-    ulp_delta = torch.max(torch.abs(calculated - golden) / ulp_value)
-
-    return (ulp_delta <= ulp_threshold, f"Max ULP Delta: {ulp_delta}")
+    ulp_tensor = torch.abs(calculated - golden) / ulp_value
+    ulp_delta = torch.max(ulp_tensor)
+    within_threshold = ulp_delta <= ulp_threshold
+    if within_threshold:
+        message = f"Max ULP Delta: {ulp_delta}"
+    else:
+        ulp_index = torch.argmax(ulp_tensor)
+        ulp_index_tuple = torch.unravel_index(ulp_index, golden.shape)
+        message = f"Max ULP Delta: {ulp_delta} @ {[int(x) for x in ulp_index_tuple]} = |{calculated[ulp_index_tuple]} - {golden[ulp_index_tuple]}| / {ulp_value[ulp_index_tuple]}"
+    return (within_threshold, message)
 
 
 def calculate_detailed_ulp_stats(expected, actual):

--- a/models/common/utility_functions.py
+++ b/models/common/utility_functions.py
@@ -646,12 +646,11 @@ def comp_ulp(golden, calculated, ulp_threshold, allow_nonfinite=False):
     ulp_tensor = torch.abs(calculated - golden) / ulp_value
     ulp_delta = torch.max(ulp_tensor)
     within_threshold = ulp_delta <= ulp_threshold
-    if within_threshold:
-        message = f"Max ULP Delta: {ulp_delta}"
-    else:
+    message = f"Max ULP Delta: {ulp_delta}"
+    if not within_threshold:
         ulp_index = torch.argmax(ulp_tensor)
         ulp_index_tuple = torch.unravel_index(ulp_index, golden.shape)
-        message = f"Max ULP Delta: {ulp_delta} @ {[int(x) for x in ulp_index_tuple]} = |{calculated[ulp_index_tuple]} - {golden[ulp_index_tuple]}| / {ulp_value[ulp_index_tuple]}"
+        message += f" @ {[int(x) for x in ulp_index_tuple]} = |{calculated[ulp_index_tuple]} - {golden[ulp_index_tuple]}| / {ulp_value[ulp_index_tuple]}"
     return (within_threshold, message)
 
 


### PR DESCRIPTION
### Ticket
Link to Github Issue N/A

### Problem description
When getting a ULP failure, not knowing the index position and individual values that go into the calculation makes knowing the severity of the error and debugging the error difficult. Especially when the error is an ND failure in piplines that's not reproducible locally.

### What's changed
If ULP fails, print out the index and individual values leading to the failure.

Tested locally that the error output is as expected:
```
>       assert ulp_passed, ulp_message
E       AssertionError: Max ULP Delta: 12244.0 @ [327, 1006, 0] = |0.123931884765625 - 0.12402310967445374| / 7.450580596923828e-09
```


### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/19749231475
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes