### PR TITLE
Convert some compile time arguments to runtime arguments for  dispatch kernels

### DIFF
--- a/.github/workflows/test-dispatch.yaml
+++ b/.github/workflows/test-dispatch.yaml
@@ -10,7 +10,7 @@ on:
           - wormhole_b0
           - blackhole
       runner-label:
-        description: 'Optional: N150, N300, BH, config-t3000, config-tg. for example: ["in-service", "config-t3000"]'
+        description: 'Optional: N150, N300, BH, config-t3000, topology-6u. for example: ["in-service", "config-t3000"]'
         required: true
         type: string
         default: '["in-service"]'

--- a/tests/tt_metal/tt_metal/device/galaxy_fixture.hpp
+++ b/tests/tt_metal/tt_metal/device/galaxy_fixture.hpp
@@ -15,6 +15,7 @@ namespace tt::tt_metal {
 class GalaxyFixture : public MeshDispatchFixture {
 protected:
     bool SkipTestSuiteIfNotGalaxyMotherboard() {
+        this->arch_ = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
         const size_t num_devices = tt::tt_metal::GetNumAvailableDevices();
         return !(this->arch_ == tt::ARCH::WORMHOLE_B0 && num_devices >= 32);
     }
@@ -43,6 +44,11 @@ protected:
             GTEST_SKIP() << "This test can only run on TG";
         }
     }
+    void SetUp() override {
+        this->DetectDispatchMode();
+        this->SkipTestSuiteIfNotTG();
+        MeshDispatchFixture::SetUp();
+    };
 };
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/device/galaxy_fixture.hpp
+++ b/tests/tt_metal/tt_metal/device/galaxy_fixture.hpp
@@ -13,13 +13,13 @@
 namespace tt::tt_metal {
 
 class GalaxyFixture : public MeshDispatchFixture {
-protected:
     bool SkipTestSuiteIfNotGalaxyMotherboard() {
         this->arch_ = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
         const size_t num_devices = tt::tt_metal::GetNumAvailableDevices();
         return !(this->arch_ == tt::ARCH::WORMHOLE_B0 && num_devices >= 32);
     }
 
+protected:
     void SetUp() override {
         this->DetectDispatchMode();
         if (this->SkipTestSuiteIfNotGalaxyMotherboard()) {
@@ -32,23 +32,26 @@ private:
     std::map<ChipId, std::shared_ptr<distributed::MeshDevice>> device_ids_to_devices_;
 };
 
-class TGFixture : public GalaxyFixture {
-protected:
+class TGFixture : public MeshDispatchFixture {
     void SkipTestSuiteIfNotTG() {
-        if (this->SkipTestSuiteIfNotGalaxyMotherboard()) {
-            GTEST_SKIP() << "Not a galaxy mobo";
+        if (tt::get_arch_from_string(tt::test_utils::get_umd_arch_name()) != tt::ARCH::WORMHOLE_B0) {
+            GTEST_SKIP() << "This test can only run on Wormhole B0";
         }
         const size_t num_devices = tt::tt_metal::GetNumAvailableDevices();
         const size_t num_pcie_devices = tt::tt_metal::GetNumPCIeDevices();
-        if (!(num_devices == 32 && num_pcie_devices == 4)) {
+        if ((num_devices != 32) or (num_pcie_devices != 4)) {
             GTEST_SKIP() << "This test can only run on TG";
         }
     }
+
+protected:
     void SetUp() override {
-        this->DetectDispatchMode();
         this->SkipTestSuiteIfNotTG();
         MeshDispatchFixture::SetUp();
     };
+
+private:
+    std::map<ChipId, std::shared_ptr<distributed::MeshDevice>> device_ids_to_devices_;
 };
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/device/test_device_pool.cpp
+++ b/tests/tt_metal/tt_metal/device/test_device_pool.cpp
@@ -30,7 +30,8 @@ void CloseDevicesInPool() {
 }
 
 TEST(DevicePool, DevicePoolOpenClose) {
-    std::vector<ChipId> device_ids{*tt::tt_metal::MetalContext::instance().get_cluster().all_chip_ids().begin()};
+    auto all_chip_ids = MetalContext::instance().get_cluster().all_chip_ids();
+    std::vector<ChipId> device_ids{all_chip_ids.begin(), all_chip_ids.end()};
     int num_hw_cqs = 1;
     int l1_small_size = 1024;
     const auto& dispatch_core_config = tt_metal::MetalContext::instance().rtoptions().get_dispatch_core_config();
@@ -42,16 +43,6 @@ TEST(DevicePool, DevicePoolOpenClose) {
         ASSERT_TRUE(dev->is_initialized());
     }
 
-    // Close then get devices again
-    for (const auto& dev : devices) {
-        dev->close();
-    }
-    devices = DevicePool::instance().get_all_active_devices();
-    for (const auto& dev : devices) {
-        ASSERT_EQ((int)(dev->allocator()->get_config().l1_small_size), l1_small_size);
-        ASSERT_EQ((int)(dev->num_hw_cqs()), num_hw_cqs);
-        ASSERT_TRUE(dev->is_initialized());
-    }
     CloseDevicesInPool();
 }
 

--- a/tests/tt_metal/tt_metal/device/test_galaxy_cluster_api.cpp
+++ b/tests/tt_metal/tt_metal/device/test_galaxy_cluster_api.cpp
@@ -11,6 +11,7 @@
 #include <unordered_set>
 #include <vector>
 
+#include <tt-logger/tt-logger.hpp>
 #include <tt-metalium/core_coord.hpp>
 #include "galaxy_fixture.hpp"
 #include "impl/context/metal_context.hpp"
@@ -56,6 +57,12 @@ std::unordered_set<ChipId> get_ethernet_connected_device_ids(const ChipId device
     return connected_device_ids;
 }
 
+TEST_F(GalaxyFixture, Initialize) {
+    log_info(LogTest, "GalaxyFixture initialized with {} devices", this->devices_.size());
+    // If we reach here, the fixture has initialized successfully
+    SUCCEED();
+}
+
 // Validate that every pair of adjacent galaxy chips has 4 links between them
 // The reason that this test is in TGFixture instead of GalaxyFixture is
 // because there are 2 links between adjacent Galaxy chips that are on different
@@ -99,7 +106,7 @@ TEST_F(TGFixture, ActiveEthValidateNumLinksBetweenAdjacentGalaxyChips) {
 
 // Validate that each MMIO chip links to two separate Galaxy chips,
 // and that each Galaxy chip links to at most one MMIO chip
-TEST_F(GalaxyFixture, ActiveEthValidateLinksBetweenMMIOAndGalaxyChips) {
+TEST_F(GalaxyFixture, DISABLED_ActiveEthValidateLinksBetweenMMIOAndGalaxyChips) {
     for (const auto& mesh_device : this->devices_) {
         auto* device = mesh_device->get_devices()[0];
         const ChipId device_id = device->id();
@@ -149,7 +156,7 @@ TEST_F(GalaxyFixture, ValidateAllGalaxyChipsAreUnharvested) {
 }
 
 // Validate that all MMIO chips have a single row harvested
-TEST_F(GalaxyFixture, ValidateAllMMIOChipsHaveSingleRowHarvested) {
+TEST_F(GalaxyFixture, DISABLED_ValidateAllMMIOChipsHaveSingleRowHarvested) {
     for (const auto& mesh_device : this->devices_) {
         auto* device = mesh_device->get_devices()[0];
         const ChipId device_id = device->id();

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
@@ -527,7 +527,7 @@ inline void DeviceData::overflow_check(IDevice* device) {
 }
 
 template <bool is_dram_variant, bool is_host_variant>
-void configure_kernel_variant(
+KernelHandle configure_kernel_variant(
     Program& program,
     const std::string& path,
     const std::map<std::string, std::string>& defines_in,
@@ -565,7 +565,7 @@ void configure_kernel_variant(
 
     defines.insert(defines_in.begin(), defines_in.end());
 
-    tt::tt_metal::CreateKernel(
+    return tt::tt_metal::CreateKernel(
         program,
         path,
         {my_core},

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -2114,16 +2114,30 @@ void configure_for_single_chip(
 
         {"NUM_HOPS", std::to_string(0)},
 
-        {"MY_DEV_ID", std::to_string(0)},
         {"EW_DIM", std::to_string(0)},
         {"TO_MESH_ID", std::to_string(0)},
-        {"TO_DEV_ID", std::to_string(0)},
-        {"ROUTER_DIRECTION", std::to_string(0)},
     };
+
+    // Initialize runtime args offsets
+    int rta_offset = 0;
+    uint32_t offsetof_my_dev_id = rta_offset++;
+    uint32_t offsetof_to_dev_id = rta_offset++;
+    uint32_t offsetof_router_direction = rta_offset++;
+    std::vector<uint32_t> runtime_args(rta_offset);
+
+    prefetch_defines["OFFSETOF_MY_DEV_ID"] = std::to_string(offsetof_my_dev_id);
+    prefetch_defines["OFFSETOF_TO_DEV_ID"] = std::to_string(offsetof_to_dev_id);
+    prefetch_defines["OFFSETOF_ROUTER_DIRECTION"] = std::to_string(offsetof_router_direction);
+
+    // Initialize runtime args
+    runtime_args[offsetof_my_dev_id] = 0;
+    runtime_args[offsetof_to_dev_id] = 0;
+    runtime_args[offsetof_router_direction] = 0;
 
     constexpr NOC my_noc_index = NOC::NOC_0;
     constexpr NOC dispatch_upstream_noc_index = NOC::NOC_1;
 
+    KernelHandle kernel_handle;
     if (split_prefetcher_g) {
         log_info(LogTest, "split prefetcher test");
 
@@ -2140,7 +2154,7 @@ void configure_for_single_chip(
             std::to_string(prefetch_d_buffer_pages * (1 << DispatchSettings::PREFETCH_D_BUFFER_LOG_PAGE_SIZE));
         prefetch_defines["SCRATCH_DB_BASE"] = std::to_string(scratch_db_base);
         CoreCoord phys_prefetch_d_upstream_core = phys_prefetch_core_g;
-        configure_kernel_variant<true, false>(
+        kernel_handle = configure_kernel_variant<true, false>(
             program,
             "tt_metal/impl/dispatch/kernels/cq_prefetch.cpp",
             prefetch_defines,
@@ -2154,6 +2168,8 @@ void configure_for_single_chip(
             my_noc_index,
             my_noc_index);
 
+        tt_metal::SetRuntimeArgs(program, kernel_handle, prefetch_d_core, runtime_args);
+
         // prefetch_h
         prefetch_defines["DOWNSTREAM_CB_BASE"] = std::to_string(prefetch_d_buffer_base);
         prefetch_defines["DOWNSTREAM_CB_LOG_PAGE_SIZE"] =
@@ -2165,7 +2181,7 @@ void configure_for_single_chip(
         prefetch_defines["CMDDAT_Q_SIZE"] = std::to_string(cmddat_q_size_g);
         prefetch_defines["SCRATCH_DB_BASE"] = std::to_string(scratch_db_base);
         CoreCoord phys_prefetch_h_downstream_core = phys_prefetch_d_core;
-        configure_kernel_variant<false, true>(
+        kernel_handle = configure_kernel_variant<false, true>(
             program,
             "tt_metal/impl/dispatch/kernels/cq_prefetch.cpp",
             prefetch_defines,
@@ -2178,13 +2194,15 @@ void configure_for_single_chip(
             my_noc_index,
             my_noc_index,
             my_noc_index);
+
+        tt_metal::SetRuntimeArgs(program, kernel_handle, prefetch_core, runtime_args);
     } else {
         uint32_t scratch_db_base =
             cmddat_q_base + ((cmddat_q_size_g + noc_read_alignment - 1) / noc_read_alignment * noc_read_alignment);
         TT_ASSERT(scratch_db_base < 1024 * 1024);  // L1 size
         prefetch_defines["SCRATCH_DB_BASE"] = std::to_string(scratch_db_base);
 
-        configure_kernel_variant<true, true>(
+        kernel_handle = configure_kernel_variant<true, true>(
             program,
             "tt_metal/impl/dispatch/kernels/cq_prefetch.cpp",
             prefetch_defines,
@@ -2197,6 +2215,8 @@ void configure_for_single_chip(
             my_noc_index,
             my_noc_index,
             my_noc_index);
+
+        tt_metal::SetRuntimeArgs(program, kernel_handle, prefetch_core, runtime_args);
     }
 
     uint32_t host_completion_queue_wr_ptr = MetalContext::instance()
@@ -2283,6 +2303,21 @@ void configure_for_single_chip(
         {"WORKER_MCAST_GRID", "0"},
         {"NUM_WORKER_CORES_TO_MCAST", "0"},
     };
+    // Initialize runtime args offsets
+    rta_offset = 0;
+    offsetof_my_dev_id = rta_offset++;
+    offsetof_to_dev_id = rta_offset++;
+    offsetof_router_direction = rta_offset++;
+    runtime_args.resize(rta_offset);
+
+    dispatch_defines["OFFSETOF_MY_DEV_ID"] = std::to_string(offsetof_my_dev_id);
+    dispatch_defines["OFFSETOF_TO_DEV_ID"] = std::to_string(offsetof_to_dev_id);
+    dispatch_defines["OFFSETOF_ROUTER_DIRECTION"] = std::to_string(offsetof_router_direction);
+
+    // Initialize runtime args
+    runtime_args[offsetof_my_dev_id] = 0;
+    runtime_args[offsetof_to_dev_id] = 0;
+    runtime_args[offsetof_router_direction] = 0;
 
     CoreCoord phys_upstream_from_dispatch_core = split_prefetcher_g ? phys_prefetch_d_core : phys_prefetch_core_g;
     if (split_dispatcher_g) {
@@ -2302,7 +2337,7 @@ void configure_for_single_chip(
         dispatch_d_defines["IS_D_VARIANT"] = "1";
         dispatch_d_defines["IS_H_VARIANT"] = "0";
 
-        configure_kernel_variant<true, false>(
+        kernel_handle = configure_kernel_variant<true, false>(
             program,
             "tt_metal/impl/dispatch/kernels/cq_dispatch.cpp",
             dispatch_d_defines,
@@ -2315,6 +2350,8 @@ void configure_for_single_chip(
             my_noc_index,
             dispatch_upstream_noc_index,
             my_noc_index);
+
+        tt_metal::SetRuntimeArgs(program, kernel_handle, dispatch_core, runtime_args);
 
         // dispatch_h
         CoreCoord phys_dispatch_h_upstream_core = phys_dispatch_core;
@@ -2332,7 +2369,7 @@ void configure_for_single_chip(
         dispatch_h_defines["IS_D_VARIANT"] = "0";
         dispatch_h_defines["IS_H_VARIANT"] = "1";
 
-        configure_kernel_variant<false, true>(
+        kernel_handle = configure_kernel_variant<false, true>(
             program,
             "tt_metal/impl/dispatch/kernels/cq_dispatch.cpp",
             dispatch_h_defines,
@@ -2345,8 +2382,10 @@ void configure_for_single_chip(
             my_noc_index,
             dispatch_upstream_noc_index,
             my_noc_index);
+
+        tt_metal::SetRuntimeArgs(program, kernel_handle, dispatch_h_core, runtime_args);
     } else {
-        configure_kernel_variant<true, true>(
+        kernel_handle = configure_kernel_variant<true, true>(
             program,
             "tt_metal/impl/dispatch/kernels/cq_dispatch.cpp",
             dispatch_defines,
@@ -2359,6 +2398,8 @@ void configure_for_single_chip(
             my_noc_index,
             dispatch_upstream_noc_index,
             my_noc_index);
+
+        tt_metal::SetRuntimeArgs(program, kernel_handle, dispatch_core, runtime_args);
     }
 }
 

--- a/tt_metal/impl/dispatch/kernel_config/dispatch.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch.hpp
@@ -55,6 +55,11 @@ struct dispatch_static_config_t {
 
     std::optional<bool> is_d_variant;
     std::optional<bool> is_h_variant;
+
+    // Offsets of runtime args
+    std::optional<uint32_t> offsetof_my_dev_id;
+    std::optional<uint32_t> offsetof_to_dev_id;
+    std::optional<uint32_t> offsetof_router_direction;
 };
 
 struct dispatch_dependent_config_t {
@@ -101,6 +106,8 @@ public:
     void GenerateStaticConfigs() override;
 
     void GenerateDependentConfigs() override;
+
+    void InitializeRuntimeArgsValues() override;
 
     void ConfigureCore() override;
 

--- a/tt_metal/impl/dispatch/kernel_config/fd_kernel.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/fd_kernel.cpp
@@ -160,7 +160,7 @@ KernelHandle FDKernel::configure_kernel_variant(
     }
 
     if (GetCoreType() == CoreType::WORKER) {
-        return tt::tt_metal::CreateKernel(
+        kernel_handle_ = tt::tt_metal::CreateKernel(
             *program_,
             path,
             logical_core_,
@@ -172,7 +172,7 @@ KernelHandle FDKernel::configure_kernel_variant(
                 .defines = defines,
                 .opt_level = opt_level});
     } else {
-        return tt::tt_metal::CreateKernel(
+        kernel_handle_ = tt::tt_metal::CreateKernel(
             *program_,
             path,
             logical_core_,
@@ -183,10 +183,19 @@ KernelHandle FDKernel::configure_kernel_variant(
                 .defines = defines,
                 .opt_level = opt_level});
     }
+
+    return kernel_handle_;
 }
 
 void FDKernel::create_edm_connection_sems(FDKernelEdmConnectionAttributes& attributes) {
     attributes.worker_flow_control_sem = tt::tt_metal::CreateSemaphore(*program_, logical_core_, 0, GetCoreType());
     attributes.worker_buffer_index_sem = tt::tt_metal::CreateSemaphore(*program_, logical_core_, 0, GetCoreType());
     attributes.worker_teardown_sem = tt::tt_metal::CreateSemaphore(*program_, logical_core_, 0, GetCoreType());
+}
+
+void FDKernel::SetRuntimeArgs() {
+    TT_ASSERT(program_ != nullptr, "Program must be set before setting runtime args");
+    if (not runtime_args_.empty()) {
+        tt_metal::SetRuntimeArgs(*program_, kernel_handle_, logical_core_, runtime_args_);
+    }
 }

--- a/tt_metal/impl/dispatch/kernel_config/fd_kernel.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/fd_kernel.hpp
@@ -190,7 +190,7 @@ protected:
     Program* program_ = nullptr;
     tt_cxy_pair logical_core_;
     FDKernelType kernel_type_ = FDKernelType::UNSET;
-    KernelHandle kernel_handle_;
+    KernelHandle kernel_handle_{std::numeric_limits<KernelHandle>::max()};  // Invalid handle
     ChipId device_id_;
     ChipId servicing_device_id_;  // Remote chip that this PREFETCH_H/DISPATCH_H is servicing
     int node_id_;

--- a/tt_metal/impl/dispatch/kernel_config/fd_kernel.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/fd_kernel.hpp
@@ -99,6 +99,10 @@ public:
     // after GenerateStaticConfigs for all upstream/downstream kernels.
     virtual void GenerateDependentConfigs() = 0;
 
+    virtual void InitializeRuntimeArgsValues() {}
+    // Populate the runtime args for this kernel.
+    virtual void SetRuntimeArgs();
+
     // Use all configs and add this kernel to its Program. Called after GenerateStaticConfigs/GenerateDependentConfigs.
     virtual void CreateKernel() = 0;
 
@@ -182,10 +186,11 @@ protected:
     static uint32_t GetTunnelStop(ChipId device_id);
     // Create and populate semaphores for the EDM connection
     void create_edm_connection_sems(FDKernelEdmConnectionAttributes& attributes);
-    tt::tt_metal::IDevice* device_ = nullptr;  // Set at configuration time by AddDeviceAndProgram()
-    tt::tt_metal::Program* program_ = nullptr;
+    IDevice* device_ = nullptr;  // Set at configuration time by AddDeviceAndProgram()
+    Program* program_ = nullptr;
     tt_cxy_pair logical_core_;
     FDKernelType kernel_type_ = FDKernelType::UNSET;
+    KernelHandle kernel_handle_;
     ChipId device_id_;
     ChipId servicing_device_id_;  // Remote chip that this PREFETCH_H/DISPATCH_H is servicing
     int node_id_;
@@ -194,6 +199,8 @@ protected:
 
     std::vector<FDKernel*> upstream_kernels_;
     std::vector<FDKernel*> downstream_kernels_;
+
+    std::vector<uint32_t> runtime_args_;
 };
 
 }  // namespace tt_metal

--- a/tt_metal/impl/dispatch/kernel_config/prefetch.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/prefetch.hpp
@@ -57,6 +57,11 @@ struct prefetch_static_config_t {
 
     std::optional<bool> is_d_variant;
     std::optional<bool> is_h_variant;
+
+    // Offsets of runtime args
+    std::optional<uint32_t> offsetof_my_dev_id;
+    std::optional<uint32_t> offsetof_to_dev_id;
+    std::optional<uint32_t> offsetof_router_direction;
 };
 
 struct prefetch_dependent_config_t {
@@ -100,6 +105,8 @@ public:
     void GenerateStaticConfigs() override;
 
     void GenerateDependentConfigs() override;
+
+    void InitializeRuntimeArgsValues() override;
 
     void ConfigureCore() override;
 

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -103,11 +103,8 @@ constexpr size_t fabric_worker_buffer_index_sem = FABRIC_WORKER_BUFFER_INDEX_SEM
 
 constexpr uint8_t num_hops = NUM_HOPS;
 
-constexpr uint32_t my_dev_id = MY_DEV_ID;
 constexpr uint32_t ew_dim = EW_DIM;
 constexpr uint32_t to_mesh_id = TO_MESH_ID;
-constexpr uint32_t to_dev_id = TO_DEV_ID;
-constexpr uint32_t router_direction = ROUTER_DIRECTION;
 
 constexpr bool is_2d_fabric = FABRIC_2D;
 
@@ -236,6 +233,11 @@ static uint32_t rd_block_idx = 0;
 static uint32_t upstream_total_acquired_page_count = 0;
 static uint32_t ringbuffer_wp = scratch_db_base;
 static uint32_t ringbuffer_offset = 0;
+
+// Runtime args
+static uint32_t my_dev_id;
+static uint32_t to_dev_id;
+static uint32_t router_direction;
 
 CQRelayClient<fabric_mux_num_buffers_per_channel, fabric_mux_channel_buffer_size_bytes, fabric_header_rb_base>
     relay_client;
@@ -1841,14 +1843,11 @@ void kernel_main_h() {
         fabric_worker_buffer_index_sem,
         fabric_mux_status_address,
         my_fabric_sync_status_addr,
-        my_dev_id,
-        to_dev_id,
         to_mesh_id,
         ew_dim,
-        router_direction,
         fabric_header_rb_base,
         num_hops,
-        NCRISC_WR_CMD_BUF>(get_noc_addr_helper(downstream_noc_xy, 0));
+        NCRISC_WR_CMD_BUF>(get_noc_addr_helper(downstream_noc_xy, 0), my_dev_id, to_dev_id, router_direction);
 
     while (!done) {
         fetch_q_get_cmds<sizeof(CQPrefetchHToPrefetchDHeader)>(fence, cmd_ptr, pcie_read_ptr);
@@ -1901,14 +1900,11 @@ void kernel_main_d() {
         fabric_worker_buffer_index_sem,
         fabric_mux_status_address,
         my_fabric_sync_status_addr,
-        my_dev_id,
-        to_dev_id,
         to_mesh_id,
         ew_dim,
-        router_direction,
         fabric_header_rb_base,
         num_hops,
-        NCRISC_WR_CMD_BUF>(get_noc_addr_helper(downstream_noc_xy, 0));
+        NCRISC_WR_CMD_BUF>(get_noc_addr_helper(downstream_noc_xy, 0), my_dev_id, to_dev_id, router_direction);
 #else
     cq_noc_async_write_init_state<CQ_NOC_sNdl, false, false, DispatchRelayInlineState::downstream_write_cmd_buf>(
         0, get_noc_addr_helper(downstream_noc_xy, downstream_data_ptr), 0, my_noc_index);
@@ -1984,6 +1980,11 @@ void kernel_main() {
 #else
     DPRINT << "prefetcher_" << is_h_variant << is_d_variant << ": start" << ENDL();
 #endif
+
+    // Get runtime args
+    my_dev_id = get_arg_val<uint32_t>(OFFSETOF_MY_DEV_ID);
+    to_dev_id = get_arg_val<uint32_t>(OFFSETOF_TO_DEV_ID);
+    router_direction = get_arg_val<uint32_t>(OFFSETOF_ROUTER_DIRECTION);
 
     if (is_h_variant and is_d_variant) {
         kernel_main_hd();

--- a/tt_metal/impl/dispatch/kernels/cq_relay.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_relay.hpp
@@ -46,15 +46,13 @@ public:
         uint32_t worker_buffer_index_sem,
         uint32_t mux_status_address,
         uint32_t local_mux_status_address,
-        uint32_t my_dev_id,
-        uint32_t to_dev_id,
         uint32_t to_mesh_id,
         uint32_t ew_dim,
-        uint32_t router_direction,
         uint32_t packet_header_addr,
         uint8_t num_hops,
         uint8_t downstream_cmd_buf>
-    FORCE_INLINE void init(uint64_t downstream_noc_addr) {
+    FORCE_INLINE void init(
+        uint64_t downstream_noc_addr, uint32_t my_dev_id, uint32_t to_dev_id, uint32_t router_direction) {
         WAYPOINT("FMCW");
 #if defined(FABRIC_RELAY)
         edm.template init<fd_core_type>(

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -433,9 +433,10 @@ void Kernel::set_runtime_args(const CoreCoord& logical_core, stl::Span<const uin
     //                  Should this check only be enabled in debug mode?
     TT_ASSERT(
         this->is_on_logical_core(logical_core),
-        "Cannot set runtime args for core {} since kernel {} is not placed on it!",
+        "Cannot set runtime args for core {} since kernel {} is not placed on it. core range set: {}!",
         logical_core.str(),
-        this->name());
+        this->name(),
+        core_range_set_.str());
 
     // Keep state for validation, to be able to check from both set_runtime_args() and set_common_runtime_args() APIs.
 


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/33323)

### Problem description
See Issue for details

### What's changed
See issue for details

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes