### PR TITLE
#31187: `ttnn.sort` op doesn`t work for dim0 fix.

### DIFF
--- a/tests/ttnn/unit_tests/operations/data_movement/test_sort.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_sort.py
@@ -25,6 +25,11 @@ TILE_WIDTH = 32
         ([11, 29, 14, 1], -1, True),
         ([1, 1, 512, 64], -1, False),
         ([1, 1, 2112, 64], -1, False),
+        ([1, 64, 64], 0, False),
+        ([1, 64, 64], 1, True),
+        ([1, 64, 64], 2, False),
+        ([1, 64], 0, False),
+        ([1, 64], 1, True),
     ],
 )
 def test_sort_standard(shape, dim, descending, device):

--- a/ttnn/cpp/ttnn/operations/data_movement/sort/docs/Sort.md
+++ b/ttnn/cpp/ttnn/operations/data_movement/sort/docs/Sort.md
@@ -21,52 +21,76 @@ The operation returns both the sorted tensor and the indices representing the or
 - memory_config (MemoryConfig, optional): Specifies memory configuration for the output tensor. Defaults to None.
 - out (tuple of Tensors, optional): Preallocated tensors for the sorted values and indices. Defaults to None.
 
-### Usage
-
-#### TTNN
-
-```python
-import ttnn
-
-# Create a TTNN tensor
-input_tensor = ttnn.Tensor([3, 1, 2])
-
-# Sort in ascending order
-sorted_tensor, indices = ttnn.sort(input_tensor)
-
-# Sort in descending order
-sorted_tensor_desc, indices_desc = ttnn.sort(input_tensor, descending=True)
-
-# Sort along a specific dimension
-input_tensor_2d = ttnn.Tensor([[3, 1, 2], [6, 5, 4]])
-sorted_tensor_dim, indices_dim = ttnn.sort(input_tensor_2d, dim=1)
-```
-
-#### Metalium
-
-```cpp
-// Create input tensor
-const ttnn::Tensor input_tensor = ...
-
-// Set sorting dim
-const int8_t dim = -1;
-
-// Set sorting params
-const bool descending = false;
-const bool stable = false;
-
-// Optional params
-std::optional<std::tuple<ttnn::Tensor&, ttnn::Tensor&>> optional_output_tensors;
-const std::optional<ttnn::MemoryConfig> memory_config;
-
-std::vector<Tensor> sorted_tensors = ttnn::sort(input_tensor, dim, descending, stable, memory_config, optional_output_tensors);
-```
-
 ### Usage Limitations
 
 - Supported index tensor types: `uint32`, `uint16`,
 - Supported value tensor types: `uint16`, `bfloat16`,
 - `stable=True` is not supported in this implementation.
+
+## Tensor Transformations
+
+Before and after the core sorting operation, the input tensor undergoes several transformations to ensure compatibility with the Bitonic Sort algorithm and hardware requirements. These transformations are transparent to the user and are automatically reversed after sorting.
+
+### Pre-Sort Transformations
+
+The `pre_sort_transform_tensor` function prepares the input tensor for sorting through the following steps:
+
+1. **Dimension Transposition**:
+   - If the sort dimension is not the last dimension, the tensor is transposed to move the sort dimension to the last position.
+   - This ensures that sorting always operates on the innermost dimension, which is required by the hardware implementation.
+
+2. **Rank Normalization to 4D**:
+   - Tensors with rank less than 4 are expanded to 4D by adding dimensions of size 1.
+   - Tensors with rank greater than 4 are reshaped to 4D by combining higher dimensions.
+   - This standardization simplifies the sorting implementation, as all strategies operate on 4D tensors.
+
+3. **Implicit Tile Padding**:
+   - Tiles may have implicit padding to align with hardware tile size (typically 32×32 elements).
+   - This padding is filled with appropriate sentinel values:
+     - `+∞` for ascending sort (ensures padded values sort to the end)
+     - `-∞` for descending sort (ensures padded values sort to the end)
+
+4. **Power-of-Two Padding**:
+   - Bitonic Sort requires the dataset size to be a power of two.
+   - If the last dimension (after implicit tile padding) is not a power of two, additional manual padding is applied.
+   - The minimum size is 2 tiles (64 elements), even if the original dimension is smaller.
+   - Padding values are `+∞` or `-∞` depending on sort order.
+
+### Post-Sort Transformations
+
+The `post_sort_transform_tensor` function reverses the pre-sort transformations to restore the original tensor structure:
+
+1. **Slice to Original Size**:
+   - If manual power-of-two padding was applied, the sorted output is sliced back to the original dimension size.
+   - Both the sorted values and indices tensors are sliced identically.
+
+2. **Rank Restoration**:
+   - Tensors are reshaped back to their original rank:
+     - Tensors originally with rank < 4 are squeezed back.
+     - Tensors originally with rank > 4 are reshaped to their original shape.
+
+3. **Dimension Transpose Back**:
+   - If the sort dimension was transposed to the last position, the tensor is transposed back to restore the original dimension order.
+   - Both sorted values and indices are transposed consistently.
+
+### Example Transformation Flow
+
+For a tensor of shape `[3, 5, 7]` sorted along dimension 0:
+
+**Pre-sort:**
+1. Transpose: `[3, 5, 7]` → `[5, 7, 3]` (move dim 0 to last)
+2. Expand to 4D: `[5, 7, 3]` → `[1, 5, 7, 3]`
+3. Tile padding: `[1, 5, 7, 3]` → `[1, 5, 7, 32]` (implicit padding to tile boundary)
+4. Power-of-two padding: `[1, 5, 7, 32]` → `[1, 5, 7, 64]` (pad to 2 tiles minimum)
+
+**Sort operation** (on transformed tensor)
+
+**Post-sort:**
+1. Slice: `[1, 5, 7, 64]` → `[1, 5, 7, 3]` (remove manual padding)
+2. Squeeze to 3D: `[1, 5, 7, 3]` → `[5, 7, 3]`
+3. Transpose back: `[5, 7, 3]` → `[3, 5, 7]` (restore original dimension order)
+
+These transformations ensure that any tensor shape and sort dimension combination can be efficiently processed by the underlying Bitonic Sort hardware implementation.
 
 ## Strategy Comparison Overview
 

--- a/ttnn/cpp/ttnn/operations/data_movement/sort/sort.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sort/sort.cpp
@@ -49,8 +49,10 @@ Tensor pre_sort_transform_tensor(
     }
     // If dim is not last dimension transpose it
     const Tensor transposed_tensor = reduction_common::perform_transpose(input_tensor, is_dim_last_idx, dim, -1);
+
     // If input is not rank 4 transorm it to 4D
     const Tensor transformed_tensor = reduction_common::transform_to_4d_tensor(transposed_tensor, is_rank_le_4d);
+
     // Fill implicit tile padding with the appropriate value
     Tensor padded_tensor = ttnn::fill_implicit_tile_padding(
         transformed_tensor,
@@ -69,12 +71,16 @@ Tensor pre_sort_transform_tensor(
         // Bitonic sort works on tiles that are the size of power of two - need at least 2 tiles
         padded_last_dim = tt::constants::TILE_WIDTH * 2;
     }
+
+    // Apply manual padding to the last dimension
+    const auto& padded_logical_shape = padded_tensor.logical_shape();
     const Tensor padded_output_tensor = ttnn::pad(
         padded_tensor,
         tt::tt_metal::Array4D(
-            {current_padded_shape[0], current_padded_shape[1], current_padded_shape[2], padded_last_dim}),
+            {padded_logical_shape[0], padded_logical_shape[1], padded_logical_shape[2], padded_last_dim}),
         tt::tt_metal::Array4D({0, 0, 0, 0}),
-        descending ? -std::numeric_limits<float>::infinity() : std::numeric_limits<float>::infinity());
+        descending ? -std::numeric_limits<float>::infinity() : std::numeric_limits<float>::infinity(),
+        /*multicore=*/true);
 
     return padded_output_tensor;
 }
@@ -86,20 +92,27 @@ std::vector<Tensor> post_sort_transform_tensor(
     const bool is_dim_last_idx,
     const Shape& original_lshape,
     const MemoryConfig& input_memory_config) {
-    const auto& input_shape = input_tensor.padded_shape();
+    // Reverse the pre-sort transformations
+    const auto& input_shape = input_tensor.logical_shape();
     const auto orig_rank = input_shape.rank();
 
     // Check if manual padding was applied for the last dimension
     const auto output_logical_shape = result[0].logical_shape();
-    if (output_logical_shape[-1] != original_lshape[-1]) {
+
+    // If manual padding was applied to last dimension, slice the output tensors to original size
+    if (output_logical_shape[-1] != original_lshape[dim < 0 ? orig_rank + dim : dim]) {
         const ttnn::SmallVector<uint32_t> step = {1, 1, 1, 1};
         const ttnn::SmallVector<uint32_t> start_index = {0, 0, 0, 0};
         const ttnn::SmallVector<uint32_t> end_index = {
-            original_lshape[-4], original_lshape[-3], original_lshape[-2], original_lshape[-1]};
+            output_logical_shape[-4],
+            output_logical_shape[-3],
+            output_logical_shape[-2],
+            original_lshape[dim < 0 ? orig_rank + dim : dim]};
         result[0] = ttnn::slice(result[0], start_index, end_index, step, input_memory_config);
         result[1] = ttnn::slice(result[1], start_index, end_index, step, input_memory_config);
     }
 
+    // Reshape back to original rank if needed
     if (orig_rank < 4) {
         result[0] = ttnn::squeeze_from_4D(result[0], orig_rank);
         result[1] = ttnn::squeeze_from_4D(result[1], orig_rank);
@@ -109,6 +122,7 @@ std::vector<Tensor> post_sort_transform_tensor(
         result[1] = ttnn::reshape(result[1], ttnn::Shape{result_shape});
     }
 
+    // Transpose back to original dimension order if needed
     if (!is_dim_last_idx) {
         result[0] = ttnn::transpose(result[0], dim, -1, input_tensor.memory_config());
         result[1] = ttnn::transpose(result[1], dim, -1, input_tensor.memory_config());

--- a/ttnn/cpp/ttnn/operations/data_movement/sort/sort_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sort/sort_pybind.cpp
@@ -27,6 +27,9 @@ void bind_sort_operation(py::module& module) {
             memory_config (ttnn.MemoryConfig, optional): Specifies the memory configuration for the output tensor. Defaults to `None`.
             out (tuple of ttnn.Tensor, optional): Preallocated output tensors for the sorted values and indices. Defaults to `None`. The index tensor must be of type uint16 or uint32.
 
+        Returns:
+            List of ttnn.Tensor: A list containing two tensors: The first tensor contains the sorted values, the second tensor contains the indices of the original elements in the sorted order.
+
         Additional info:
             * For now the `stable` argument is not supported.
 


### PR DESCRIPTION
### Ticket

#31187

### Problem description

The current implementation of `pre_sort_transform_tensor` and `post_sort_transform_tensor` used `padded_shape` instead of `logical_shape`, which caused issues for certain combinations of input tensor shapes and dimensions.

### What's changed
- Fixed transformations,
- Added test,
- Updated docs.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/19758945921