### PR TITLE
Conv wrapper return output shape - issue #30591

### DIFF
--- a/models/experimental/oft/tt/tt_oftnet.py
+++ b/models/experimental/oft/tt/tt_oftnet.py
@@ -101,7 +101,7 @@ class TTOftNet:
             for i in range(topdown_layers)
         ]
 
-        self.head = TtConv2d(layer_args.head["optimized_configuration"], device)
+        self.head = TtConv2d(layer_args.head["optimized_configuration"], device, return_output_dim=True)
         self.mean = ttnn.from_torch(
             mean, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
         )
@@ -311,8 +311,7 @@ class TTOftNet:
     def forward_predict_encoded_outputs(self, device, td):
         """Predict encoded outputs and slice them"""
         signpost(header="Head started")
-        out_h, out_w = 159, 159  # todo plumb return output shape from common conv wrapper
-        outputs = self.head(td)
+        outputs, (out_h, out_w) = self.head(td)
         logger.debug(f"Head output shape: {outputs.shape}, dtype: {outputs.dtype} {out_h=} {out_w=}")
         outputs = ttnn.permute(outputs, (0, 3, 1, 2), memory_config=ttnn.L1_MEMORY_CONFIG)
         outputs = ttnn.reshape(outputs, (1, -1, 9, out_h, out_w))

--- a/models/experimental/oft/tt/tt_oftnet.py
+++ b/models/experimental/oft/tt/tt_oftnet.py
@@ -101,7 +101,7 @@ class TTOftNet:
             for i in range(topdown_layers)
         ]
 
-        self.head = TtConv2d(layer_args.head["optimized_configuration"], device, return_output_dim=True)
+        self.head = TtConv2d(layer_args.head["optimized_configuration"], device)
         self.mean = ttnn.from_torch(
             mean, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
         )
@@ -311,7 +311,7 @@ class TTOftNet:
     def forward_predict_encoded_outputs(self, device, td):
         """Predict encoded outputs and slice them"""
         signpost(header="Head started")
-        outputs, (out_h, out_w) = self.head(td)
+        outputs, (out_h, out_w) = self.head(td, return_output_dim=True)
         logger.debug(f"Head output shape: {outputs.shape}, dtype: {outputs.dtype} {out_h=} {out_w=}")
         outputs = ttnn.permute(outputs, (0, 3, 1, 2), memory_config=ttnn.L1_MEMORY_CONFIG)
         outputs = ttnn.reshape(outputs, (1, -1, 9, out_h, out_w))

--- a/models/tt_cnn/tests/test_builder.py
+++ b/models/tt_cnn/tests/test_builder.py
@@ -567,9 +567,9 @@ def test_conv2d_return_output_dim(input_size, channel_config, kernel_config, dev
     )
 
     torch_input_tensor, ttnn_input_tensor = create_conv2d_input_tensor(configuration)
-    layer = TtConv2d(configuration, device, return_output_dim=True)
+    layer = TtConv2d(configuration, device)
 
-    ttnn_output_tensor, (H, W) = layer(ttnn_input_tensor)
+    ttnn_output_tensor, (H, W) = layer(ttnn_input_tensor, return_output_dim=True)
 
     expected_h = (input_height + 2 * padding - (kernel_size - 1) - 1) // 1 + 1
     expected_w = (input_width + 2 * padding - (kernel_size - 1) - 1) // 1 + 1
@@ -603,9 +603,9 @@ def test_conv2d_return_output_dim_with_channel_slicing(input_size, channels, ker
     torch_input_tensor, ttnn_input_tensor = create_conv2d_input_tensor(configuration)
     ttnn_input_tensor = ttnn.to_device(ttnn_input_tensor, device, memory_config=ttnn.DRAM_MEMORY_CONFIG)
 
-    layer = TtConv2d(configuration, device, return_output_dim=True)
+    layer = TtConv2d(configuration, device)
 
-    ttnn_output_tensor, (H, W) = layer(ttnn_input_tensor)
+    ttnn_output_tensor, (H, W) = layer(ttnn_input_tensor, return_output_dim=True)
 
     expected_h = (input_height + 2 * padding - (kernel_size - 1) - 1) // 1 + 1
     expected_w = (input_width + 2 * padding - (kernel_size - 1) - 1) // 1 + 1

--- a/models/tt_cnn/tests/test_builder.py
+++ b/models/tt_cnn/tests/test_builder.py
@@ -548,6 +548,73 @@ def test_conv2d_configuration_from_model_args(input_size, channel_config, batch_
 
 
 @pytest.mark.parametrize("device_params", [DEVICE_PARAMS], indirect=True)
+@pytest.mark.parametrize("input_size", INPUT_SIZES)
+@pytest.mark.parametrize("channel_config", CHANNEL_CONFIGS)
+@pytest.mark.parametrize("kernel_config", KERNEL_CONFIGS)
+def test_conv2d_return_output_dim(input_size, channel_config, kernel_config, device):
+    input_height, input_width = input_size
+    in_channels, out_channels = channel_config["in_channels"], channel_config["out_channels"]
+    kernel_size, padding = kernel_config["kernel_size"], kernel_config["padding"]
+
+    configuration = Conv2dConfiguration.with_random_weights(
+        input_height=input_height,
+        input_width=input_width,
+        in_channels=in_channels,
+        out_channels=out_channels,
+        batch_size=1,
+        kernel_size=(kernel_size, kernel_size),
+        padding=(padding, padding),
+    )
+
+    torch_input_tensor, ttnn_input_tensor = create_conv2d_input_tensor(configuration)
+    layer = TtConv2d(configuration, device, return_output_dim=True)
+
+    ttnn_output_tensor, (H, W) = layer(ttnn_input_tensor)
+
+    expected_h = (input_height + 2 * padding - (kernel_size - 1) - 1) // 1 + 1
+    expected_w = (input_width + 2 * padding - (kernel_size - 1) - 1) // 1 + 1
+
+    assert H == expected_h, f"Height mismatch: got {H}, expected {expected_h}"
+    assert W == expected_w, f"Width mismatch: got {W}, expected {expected_w}"
+
+
+@pytest.mark.parametrize("device_params", [DEVICE_PARAMS], indirect=True)
+@pytest.mark.parametrize("input_size", SLICE_INPUT_SIZES)
+@pytest.mark.parametrize("channels", SLICE_CHANNEL_CONFIGS)
+@pytest.mark.parametrize("kernel_config", KERNEL_CONFIGS)
+def test_conv2d_return_output_dim_with_channel_slicing(input_size, channels, kernel_config, device):
+    input_height, input_width = input_size
+    in_channels, out_channels = channels["in_channels"], channels["out_channels"]
+    kernel_size, padding = kernel_config["kernel_size"], kernel_config["padding"]
+
+    slice_strategy = ChannelSliceStrategyConfiguration(num_slices=4)
+
+    configuration = Conv2dConfiguration.with_random_weights(
+        input_height=input_height,
+        input_width=input_width,
+        in_channels=in_channels,
+        out_channels=out_channels,
+        batch_size=1,
+        kernel_size=(kernel_size, kernel_size),
+        padding=(padding, padding),
+        slice_strategy=slice_strategy,
+    )
+
+    torch_input_tensor, ttnn_input_tensor = create_conv2d_input_tensor(configuration)
+    ttnn_input_tensor = ttnn.to_device(ttnn_input_tensor, device, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+
+    layer = TtConv2d(configuration, device, return_output_dim=True)
+
+    ttnn_output_tensor, (H, W) = layer(ttnn_input_tensor)
+
+    expected_h = (input_height + 2 * padding - (kernel_size - 1) - 1) // 1 + 1
+    expected_w = (input_width + 2 * padding - (kernel_size - 1) - 1) // 1 + 1
+
+    assert H == expected_h
+    assert W == expected_w
+
+
+@pytest.mark.parametrize("device_params", [DEVICE_PARAMS], indirect=True)
 def test_conv2d_slicing_validation_errors(device):
     """Test that validation errors are raised correctly for Conv2D slicing"""
 

--- a/models/tt_cnn/tt/builder.py
+++ b/models/tt_cnn/tt/builder.py
@@ -2,7 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-from dataclasses import dataclass, replace
+from dataclasses import dataclass
 from typing import Optional, Tuple, Union
 
 import torch
@@ -168,8 +168,6 @@ class Conv2dConfiguration:
 
     deallocate_activation: bool = False
     reallocate_halo_output: bool = True
-
-    return_output_dim: bool = False
 
     config_tensors_in_dram: bool = False
 
@@ -510,9 +508,7 @@ class TtConv2d:
         self,
         configuration: Conv2dConfiguration,
         device: ttnn.Device,
-        return_output_dim: bool = False,
     ):
-        configuration = replace(configuration, return_output_dim=return_output_dim)
         self.configuration = configuration
         self.conv2d_config = to_conv2d_config(configuration)
         self.compute_config = to_compute_config(configuration, device)
@@ -661,7 +657,7 @@ class TtConv2d:
 
         return accumulated_output, (h_out, w_out)
 
-    def __call__(self, x):
+    def __call__(self, x, return_output_dim: bool = False):
         if not self.weight_slices:
             # No slicing
             x, [h_out, w_out], [self.weight, self.bias] = ttnn.conv2d(
@@ -676,7 +672,7 @@ class TtConv2d:
         else:
             x, (h_out, w_out) = self._apply_channel_slicing(x)
 
-        if self.configuration.return_output_dim:
+        if return_output_dim:
             return x, (h_out, w_out)
 
         return x


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/30591)

### Problem description
TtConv2d did not offer an option to return output dimensions.

### What's changed
ttnn.conv2d can return output dimensions via return_output_dim parameter.
When user calls TtConv2d now he can pass return_output_dim to obtain the dimensions. This way all the code that previously did not require output dims will not be affected.
models/tt_cnn/tt/builder.py - added parameter to __call__ of TtConv2d
models/tt_cnn/tests/test_builder.py - added two tests for checking output dims (with and without channel slicing)
models/experimental/oft/tt/tt_oftnet.py - removed magic numbers in forward_predict_encoded_outputs and obtained them via passing return_output_dim=True.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/19760068664)
- [x] [Blackhole nightly 20 cores](https://github.com/tenstorrent/tt-metal/actions/runs/19760088340)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/runs/19760065503)

- [x] New/Existing tests provide coverage for changes