### PR TITLE
TG Model perf upper limit threshold

### DIFF
--- a/.github/workflows/galaxy-model-perf-tests-impl.yaml
+++ b/.github/workflows/galaxy-model-perf-tests-impl.yaml
@@ -76,7 +76,7 @@ jobs:
               "arch": "wormhole_b0",
               "save-perf-data": false,
               "timeout": 30,
-              "cmd": "TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE=\"7,7\" pytest -n auto models/demos/ttnn_resnet/tests/test_perf_e2e_resnet50.py -m \"model_perf_tg\" && python3 models/perf/merge_perf_results.py"
+              "cmd": "TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE=\"7,7\" pytest -n auto models/demos/ttnn_resnet/tests/test_perf_e2e_resnet50.py -m \"model_perf_tg\" && python3 models/perf/merge_perf_results.py --upper-threshold 1.10"
             },
             {
               "name": "Galaxy DiT SD3.5 model perf tests",

--- a/models/demos/ttnn_resnet/tests/test_perf_e2e_resnet50.py
+++ b/models/demos/ttnn_resnet/tests/test_perf_e2e_resnet50.py
@@ -18,7 +18,7 @@ PERF_EXPECTATIONS = {
         "test_perf": {"inference_time": 0.017, "compile_time": 60},
         "test_perf_trace": {"inference_time": 0.0068, "compile_time": 60},
         "test_perf_2cqs": {"inference_time": 0.0175, "compile_time": 60},
-        "test_perf_trace_2cqs": {"inference_time": 0.0048, "compile_time": 60},
+        "test_perf_trace_2cqs": {"inference_time": 0.0058, "compile_time": 60},
     },
 }
 

--- a/models/perf/merge_perf_results.py
+++ b/models/perf/merge_perf_results.py
@@ -36,6 +36,18 @@ def parse_args() -> argparse.Namespace:
         default="",
         help="REPORT or CHECK or leave empty to do both",
     )
+    parser.add_argument(
+        "--upper-threshold",
+        type=float,
+        default=1.0,
+        help="Upper threshold multiplier for performance regression checks (default: 1.0)",
+    )
+    parser.add_argument(
+        "--lower-threshold",
+        type=float,
+        default=0.80,
+        help="Lower threshold multiplier for performance improvement checks (default: 0.80)",
+    )
     return parser.parse_args()
 
 
@@ -45,7 +57,11 @@ if __name__ == "__main__":
     if str(args.modelperf) == "REPORT":
         merge_perf_files(fname, "perf", expected_cols)
     elif str(args.modelperf) == "CHECK":
-        check_perf_results(fname, expected_cols, check_cols)
+        check_perf_results(
+            fname, expected_cols, check_cols, lower_threshold=args.lower_threshold, upper_threshold=args.upper_threshold
+        )
     else:
         merge_perf_files(fname, "perf", expected_cols)
-        check_perf_results(fname, expected_cols, check_cols)
+        check_perf_results(
+            fname, expected_cols, check_cols, lower_threshold=args.lower_threshold, upper_threshold=args.upper_threshold
+        )


### PR DESCRIPTION
  ### Problem description
  Performance tests were experiencing false positives due to inflexible
  threshold configurations. The performance checking system only used a
  lower threshold (0.80) to detect when models ran too fast, but lacked
  an upper threshold to provide tolerance for minor performance
  variations. This caused tests to fail on small, acceptable performance
  regressions.

  Additionally, the ResNet50 trace_2cqs test had an expected inference
  time that was too optimistic (0.0048s), causing frequent test failures
  in CI.

  ### What's changed
  This PR introduces configurable performance thresholds to make
  performance testing more robust:

  1. Configurable thresholds: Added --upper-threshold and
     --lower-threshold command-line arguments to merge_perf_results.py,
     allowing tests to specify acceptable performance variation ranges
     - Default lower threshold: 0.80 (20% improvement triggers update)
     - Default upper threshold: 1.0 (no regression tolerance by default)

  2. Galaxy CNN tests tolerance: Updated Galaxy model performance tests
     workflow to use a 10% upper threshold (--upper-threshold 1.10) for
     ResNet50 tests, providing reasonable tolerance for performance
     variations

  3. Updated ResNet50 expectations: Adjusted trace_2cqs expected
     inference time from 0.0048s to 0.0058s to reflect realistic
     performance measurements

  ### Checklist
- [X] [(Galaxy) model perf tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) CI [script worked](https://github.com/tenstorrent/tt-metal/actions/runs/19761355982/job/56624539241)