### PR TITLE
Fix ttnn.log accuracy

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_math.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_math.py
@@ -17,9 +17,12 @@ from loguru import logger
 def run_math_unary_test(device, h, w, ttnn_function, pcc=0.9999):
     torch.manual_seed(0)
 
+    # Generate random [0; 1] tensor
     torch_input_tensor = torch.rand((h, w), dtype=torch.bfloat16)
     if "digamma" in str(ttnn_function):
-        torch_input_tensor += 100.0
+        # Scale and shift range to [2; 102] for digamma
+        torch_input_tensor = torch_input_tensor * 100.0 + 2.0
+
     golden_function = ttnn.get_golden_function(ttnn_function)
     torch_output_tensor = golden_function(torch_input_tensor)
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_erfinv.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_erfinv.h
@@ -6,7 +6,6 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
-#include "noc_nonblocking_api.h"
 #include "ckernel_sfpu_log.h"
 
 #include "sfpi.h"

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_erfinv.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_erfinv.h
@@ -64,7 +64,7 @@ sfpi_inline sfpi::vFloat calculate_erfinv_body(sfpi::vFloat in) {
     // result = sqrt(calculated_value)
     sfpi::vFloat result = calculate_sqrt_custom<false>(calculated_value);
 
-    return log_value;
+    return result;
 }
 
 template <bool APPROXIMATION_MODE>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_erfinv.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_erfinv.h
@@ -19,6 +19,8 @@ sfpi_inline sfpi::vFloat calculate_sqrt_custom(sfpi::vFloat in) {
     sfpi::vFloat val = in;
     sfpi::vFloat out;
     v_if(val != 0.0f) {
+        // Magic number 0x5f37 is used as an approximation constant in the fast inverse square root algorithm.
+        // See: https://en.wikipedia.org/wiki/Fast_inverse_square_root
         sfpi::vUInt magic = sfpi::reinterpret<sfpi::vUInt>(sfpi::vFloat(sfpi::s2vFloat16b(0x5f37)));
         sfpi::vFloat approx = sfpi::reinterpret<sfpi::vFloat>(magic - (sfpi::reinterpret<sfpi::vUInt>(val) >> 1));
         for (int r = 0; r < 2; r++) {
@@ -35,7 +37,7 @@ template <bool APPROXIMATION_MODE>
 sfpi_inline sfpi::vFloat calculate_erfinv_body(sfpi::vFloat in) {
     sfpi::vFloat log_value = in * in;
     log_value = 1 - log_value;
-    log_value = calculate_log_body<false, false, true>(log_value, 0);
+    log_value = calculate_log_body<false, false, true>(log_value, 0);  // use fp32 to avoid intermediate rounding
     sfpi::vFloat temp = log_value * 0.5;
     temp = 4.5469 + temp;
     temp = -temp;

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_erfinv.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_erfinv.h
@@ -6,21 +6,21 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
+#include "noc_nonblocking_api.h"
 #include "ckernel_sfpu_log.h"
-#include "sfpi.h"
 
-using namespace sfpi;
+#include "sfpi.h"
 
 namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE>
-sfpi_inline vFloat calculate_sqrt_custom(vFloat in) {
-    vFloat val = in;
-    vFloat out;
+sfpi_inline sfpi::vFloat calculate_sqrt_custom(sfpi::vFloat in) {
+    sfpi::vFloat val = in;
+    sfpi::vFloat out;
     v_if(val != 0.0f) {
-        vUInt magic = reinterpret<vUInt>(vFloat(s2vFloat16b(0x5f37)));
-        vFloat approx = reinterpret<vFloat>(magic - (reinterpret<vUInt>(val) >> 1));
+        sfpi::vUInt magic = sfpi::reinterpret<sfpi::vUInt>(sfpi::vFloat(sfpi::s2vFloat16b(0x5f37)));
+        sfpi::vFloat approx = sfpi::reinterpret<sfpi::vFloat>(magic - (sfpi::reinterpret<sfpi::vUInt>(val) >> 1));
         for (int r = 0; r < 2; r++) {
             approx = ((approx * approx) * (val * -0.5f) + 1.5f) * approx;
         }
@@ -32,48 +32,48 @@ sfpi_inline vFloat calculate_sqrt_custom(vFloat in) {
 }
 
 template <bool APPROXIMATION_MODE>
-sfpi_inline vFloat calculate_erfinv_body(vFloat in) {
-    vFloat log_value = in * in;
+sfpi_inline sfpi::vFloat calculate_erfinv_body(sfpi::vFloat in) {
+    sfpi::vFloat log_value = in * in;
     log_value = 1 - log_value;
-    dst_reg[0] = log_value;
-    calculate_log_body<true, false>(0);
-    log_value = dst_reg[0];
-    vFloat temp = dst_reg[0] * 0.5;
+    log_value = calculate_log_body<false, false, true>(log_value, 0);
+    sfpi::vFloat temp = log_value * 0.5;
     temp = 4.5469 + temp;
     temp = -temp;
-    vFloat calculated_value = (temp * temp) - (log_value * 7.1427);
-    vFloat intermediate_result = calculate_sqrt_custom<false>(calculated_value);
+
+    sfpi::vFloat calculated_value = (temp * temp) - (log_value * 7.1427);
+    sfpi::vFloat intermediate_result = calculate_sqrt_custom<false>(calculated_value);
     calculated_value = temp + intermediate_result;
     log_value = calculate_sqrt_custom<false>(calculated_value);
-    dst_reg[0] = log_value;
     return log_value;
 }
 
 template <bool APPROXIMATION_MODE>
 inline void calculate_erfinv() {
     // SFPU microcode
-    for (int d = 0; d < 8; d++) {
-        vFloat v = dst_reg[0];
-        v_if(v == 1.0f) { dst_reg[0] = std::numeric_limits<float>::infinity(); }
-        v_elseif(v == -1.0f) { dst_reg[0] = -std::numeric_limits<float>::infinity(); }
+    constexpr int ITERATIONS = 8;
+    for (int d = 0; d < ITERATIONS; d++) {
+        sfpi::vFloat v = sfpi::dst_reg[0];
+        sfpi::vFloat result;
+        v_if(v == 1.0f) { result = std::numeric_limits<float>::infinity(); }
+        v_elseif(v == -1.0f) { result = -std::numeric_limits<float>::infinity(); }
         v_elseif((v < -1.0f) || (v > 1.0f)) {  // Nan not supported
-            dst_reg[0] = std::numeric_limits<float>::quiet_NaN();
+            result = std::numeric_limits<float>::quiet_NaN();
         }
         v_elseif(v < 0.0f) {
-            calculate_erfinv_body<true>(v);
-            dst_reg[0] = -dst_reg[0];
+            result = calculate_erfinv_body<true>(v);
+            result = -result;
         }
-        v_else { calculate_erfinv_body<true>(v); }
+        v_else { result = calculate_erfinv_body<true>(v); }
         v_endif;
-        dst_reg++;
+
+        sfpi::dst_reg[0] = result;
+        sfpi::dst_reg++;
     }
 }
 
 template <bool APPROXIMATION_MODE>
 void erfinv_init() {
-    vConstFloatPrgm0 = 0.692871f;  // ln2
-    vConstFloatPrgm1 = 0.1058f;
-    vConstFloatPrgm2 = -0.7166f;
+    log_init<false, false, false>();
 }
 
 }  // namespace sfpu

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_erfinv.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_erfinv.h
@@ -22,9 +22,9 @@ sfpi_inline sfpi::vFloat calculate_sqrt_custom(sfpi::vFloat in) {
         // See: https://en.wikipedia.org/wiki/Fast_inverse_square_root
         sfpi::vUInt magic = sfpi::reinterpret<sfpi::vUInt>(sfpi::vFloat(sfpi::s2vFloat16b(0x5f37)));
         sfpi::vFloat approx = sfpi::reinterpret<sfpi::vFloat>(magic - (sfpi::reinterpret<sfpi::vUInt>(val) >> 1));
-        for (int r = 0; r < 2; r++) {
-            approx = ((approx * approx) * (val * -0.5f) + 1.5f) * approx;
-        }
+        sfpi::vFloat neg_half_val = val * -0.5f;
+        approx = ((approx * approx) * neg_half_val + 1.5f) * approx;
+        approx = ((approx * approx) * neg_half_val + 1.5f) * approx;
         out = approx * val;
     }
     v_else { out = val; }
@@ -34,17 +34,36 @@ sfpi_inline sfpi::vFloat calculate_sqrt_custom(sfpi::vFloat in) {
 
 template <bool APPROXIMATION_MODE>
 sfpi_inline sfpi::vFloat calculate_erfinv_body(sfpi::vFloat in) {
+    // Algorithm based on "A handy approximation for the error function and its inverse" by Sergei Winitzki (2008)
+    // This approximation defines erfinv(x) as:
+    // erfinv(x) = sqrt( - 2/(pi*a) - log(1 - x^2)/2 + sqrt( ( 2/(pi*a) + log(1 - x^2)) ^2 - 1/a log(1 - x^2)) )
+    // Where a is a polynomial coefficient used in the approximation of the error function (and re-used in inverse error
+    // function)
+
+    // Compute log(1 - x^2)
     sfpi::vFloat log_value = in * in;
     log_value = 1 - log_value;
     log_value = calculate_log_body<false, false, true>(log_value, 0);  // use fp32 to avoid intermediate rounding
+
     sfpi::vFloat temp = log_value * 0.5;
-    temp = 4.5469 + temp;
+
+    // Paper sets a constant a = 0.147.
+    // This constant is used to compute two constant expressions:
+    constexpr float TwoPiA = 4.330746750799873f;   // 2 / (pi * a)
+    constexpr float OneDivA = 6.802721088435375f;  // 1/a
+
+    // tmp = -2 / (pi * a) - log(1 - x^2)/2
+    temp = TwoPiA + temp;
     temp = -temp;
 
-    sfpi::vFloat calculated_value = (temp * temp) - (log_value * 7.1427);
+    // calculated_value = temp + sqrt( temp^2 - log_value / a)
+    sfpi::vFloat calculated_value = (temp * temp) - (log_value * OneDivA);
     sfpi::vFloat intermediate_result = calculate_sqrt_custom<false>(calculated_value);
     calculated_value = temp + intermediate_result;
-    log_value = calculate_sqrt_custom<false>(calculated_value);
+
+    // result = sqrt(calculated_value)
+    sfpi::vFloat result = calculate_sqrt_custom<false>(calculated_value);
+
     return log_value;
 }
 
@@ -55,17 +74,19 @@ inline void calculate_erfinv() {
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat v = sfpi::dst_reg[0];
         sfpi::vFloat result;
-        v_if(v == 1.0f) { result = std::numeric_limits<float>::infinity(); }
-        v_elseif(v == -1.0f) { result = -std::numeric_limits<float>::infinity(); }
-        v_elseif((v < -1.0f) || (v > 1.0f)) {  // Nan not supported
+
+        // Since erfinv(-x) = -erfinv(x), we can compute the result for the absolute value of the input.
+        // This reduces the number of edge cases.
+        sfpi::vFloat abs_v = sfpi::abs(v);
+
+        v_if(abs_v == 1.0f) { result = std::numeric_limits<float>::infinity(); }
+        v_elseif(abs_v > 1.0f) {  // Nan not supported
             result = std::numeric_limits<float>::quiet_NaN();
         }
-        v_elseif(v < 0.0f) {
-            result = calculate_erfinv_body<true>(v);
-            result = -result;
-        }
-        v_else { result = calculate_erfinv_body<true>(v); }
+        v_else { result = calculate_erfinv_body<true>(abs_v); }
         v_endif;
+
+        result = sfpi::setsgn(result, v);  // restore sign
 
         sfpi::dst_reg[0] = result;
         sfpi::dst_reg++;

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_log.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_log.h
@@ -117,8 +117,7 @@ sfpi_inline sfpi::vFloat calculate_log_f32_body(sfpi::vFloat val, const uint log
         // This ensures m is in [sqrt(2)/2, sqrt(2)] ≈ [0.707, 1.414]
         constexpr float SQRT2 = 1.4142135623730951f;  // sqrt(2)
         v_if(m >= SQRT2) {
-            // m = m * 0.5f;  // Divide by 2
-            m = m * 0.5f;
+            m = m * 0.5f;   // Divide by 2
             exp = exp + 1;  // Increment exponent
         }
         v_endif;

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_log.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_log.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -6,51 +6,44 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
-
-using namespace sfpi;
+#include "sfpu/ckernel_sfpu_polyval.h"
 
 namespace ckernel {
 namespace sfpu {
 
-template <bool FAST_APPROX, bool HAS_BASE_SCALING>
-sfpi_inline void calculate_log_body(const uint log_base_scale_factor) {
-    ////////////////////////////
-    // Load From dest + "normalize to calculation range"
-    ////////////////////////////
-    vFloat in = dst_reg[0];
-    vFloat x = setexp(in, 127);  // set exp to exp bias (put in range of 1-2)
+template <bool FAST_APPROX, bool HAS_BASE_SCALING, bool is_fp32_dest_acc_en = false>
+sfpi_inline sfpi::vFloat calculate_log_body(sfpi::vFloat in, const uint log_base_scale_factor) {
+    ///////////////////////////////////
+    // "normalize to calculation range"
+    ///////////////////////////////////
+    sfpi::vFloat x = sfpi::setexp(in, 127);  // set exp to exp bias (put in range of 1-2)
 
-    // XXXXXX ask Namal? if we can derive the coefficients below to higher precision
-    ////////////////////////////
-    // Calculate Cheby Approximation using Horner Form Multiplication: 3rd Order
-    // x* ( x* (A*x + B) + C) + D
-    // A :0.1058, B: -0.3942, C: 0.9813, D: 0.006
-    // Run above on (x-1) so x is in ln(x+1), plug (x-1 into equation above to
-    // save the subtract and get A',B',C',D'):
-    // A' = A
-    // B' = -3A + B
-    // C' = 3a -2B + C
-    // D' = -A + B - C + D
-    // A':0.1058, B':-0.7116, C':2.0871, D':-1.4753
-    ////////////////////////////
-    vFloat a = vConstFloatPrgm1;
-    vFloat b = vConstFloatPrgm2;
-    // XXXXX try variants of the below: B'=.7122, C'=2.0869
-    vFloat series_result = x * (x * (x * a + b) + 2.0871) + -1.4753f;
+    // Minimax approximation of log(x) over [1; 2] calculated using Sollya with the following command:
+    // > fpminimax(log(x), 5, [|single...|], [1+2^(-20); 2], relative);
+    sfpi::vFloat series_result = PolynomialEvaluator::eval(
+        x,
+        sfpi::vConstFloatPrgm1,
+        sfpi::vConstFloatPrgm2,
+        -2.800232410430908,
+        1.3681391477584839,
+        -0.3706687390804291,
+        0.04224011301994324);
 
     ////////////////////////////
     // Convert exponent to float
     ////////////////////////////
-    vInt exp = exexp(in);
-    v_if(exp < 0) { exp = setsgn(~exp + 1, 1); }
+    sfpi::vInt exp = sfpi::exexp(in);
+
+    // Convert negative numbers: signed -> sign-magnitude
+    v_if(exp < 0) { exp = sfpi::setsgn(~exp + 1, 1); }
     v_endif;
 
-    vFloat expf = int32_to_float(exp, 0);
-    vFloat vConstLn2 = vConstFloatPrgm0;
-    vFloat result = expf * vConstLn2 + series_result;  // exp correction: ln(1+x) + exp*ln(2)
+    sfpi::vFloat expf = sfpi::int32_to_float(exp, 0);
+    sfpi::vFloat vConstLn2 = sfpi::vConstFloatPrgm0;
+    sfpi::vFloat result = expf * vConstLn2 + series_result;  // exp correction: ln(1+x) + exp*ln(2)
 
     if constexpr (HAS_BASE_SCALING) {
-        result *= s2vFloat16a(log_base_scale_factor);
+        result *= sfpi::s2vFloat16a(log_base_scale_factor);
     }
 
     ////////////////////////////
@@ -72,25 +65,157 @@ sfpi_inline void calculate_log_body(const uint log_base_scale_factor) {
         v_endif;
     }
 
-    dst_reg[0] = result;
+    if constexpr (!is_fp32_dest_acc_en) {
+        result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
+    }
+
+    return result;
 }
 
-template <bool APPROXIMATION_MODE, bool FAST_APPROX, bool HAS_BASE_SCALING, int ITERATIONS = 8>
+/*
+ * This function implements ln(x) using polynomial approximation.
+ * 1. Handle special cases (x <= 0, infinity, NaN)
+ * 2. Extract exponent and mantissa: x = 2^n × m
+ * 3. Reduce range: adjust m to be in [sqrt(2)/2, sqrt(2)]
+ * 4. Compute ln(m) using polynomial approximation
+ * 5. Return n×ln(2) + ln(m)
+ */
+template <bool HAS_BASE_SCALING>
+sfpi_inline sfpi::vFloat calculate_log_f32_body(sfpi::vFloat val, const uint log_base_scale_factor) {
+    sfpi::vFloat result = sfpi::vConst0;
+
+    // Check for special cases
+    sfpi::vInt exp = sfpi::exexp(val);        // Get debiased exponent
+    sfpi::vInt man_bits = sfpi::exman9(val);  // Get mantissa bits
+
+    // Check for NaN: exponent = 128 (255 - 127, meaning original exp = 255) and mantissa != 0
+    // Note: exexp returns debiased, so exp == 128 means original exp = 255
+    v_if(exp == 128 && man_bits != 0) {
+        // NaN: exponent = 255 and mantissa != 0
+        result = std::numeric_limits<float>::quiet_NaN();
+    }
+    v_elseif(val < sfpi::vConst0) {
+        // Negative input -> NaN
+        result = std::numeric_limits<float>::quiet_NaN();
+    }
+    v_elseif(val == sfpi::vConst0) {
+        // Zero input -> -inf
+        result = -std::numeric_limits<float>::infinity();
+    }
+    v_elseif(exp == 128 && man_bits == 0) {
+        // Infinity: exponent = 255 and mantissa = 0
+        result = std::numeric_limits<float>::infinity();
+    }
+    v_else {
+        // Step 1: Extract exponent and mantissa
+        // Extract mantissa and construct m in [1, 2)
+        // Use setexp to normalize to [1, 2) range by setting exponent to 127 (bias)
+        sfpi::vFloat m = sfpi::setexp(val, 127);
+
+        // Step 2: Range reduction
+        // If m >= sqrt(2), divide by 2 and increment exponent
+        // This ensures m is in [sqrt(2)/2, sqrt(2)] ≈ [0.707, 1.414]
+        constexpr float SQRT2 = 1.4142135623730951f;  // sqrt(2)
+        v_if(m >= SQRT2) {
+            // m = m * 0.5f;  // Divide by 2
+            m = m * 0.5f;
+            exp = exp + 1;  // Increment exponent
+        }
+        v_endif;
+
+        // Step 3: Transform to z = (m - 1) / (m + 1)
+        // This maps m ∈ [0.707, 1.414] to z ∈ [-0.172, 0.172]
+        // ln(m) = 2 × (z + z³/3 + z⁵/5 + z⁷/7 + ...)
+        sfpi::vFloat m_minus_1 = m - sfpi::vConst1;
+        sfpi::vFloat m_plus_1 = m + sfpi::vConst1;
+
+        // Compute z = (m - 1) / (m + 1) using reciprocal
+        // z = m_minus_1 * (1 / m_plus_1)
+        sfpi::vFloat m_plus_1_recip = _sfpu_reciprocal_<2>(m_plus_1);
+        sfpi::vFloat z = m_minus_1 * m_plus_1_recip;
+
+        // Compute z**2 for polynomial evaluation
+        sfpi::vFloat z2 = z * z;
+
+        // Step 4: Polynomial approximation using odd powers
+        // ln(m) = 2z(1 + (z**2)/3 + (z**4)/5 + (z**6)/7 + (z**8)/9 + (z**10)/11)
+        // Using Horner's method: p = 1 + z**2 * (c3 + z**2 * (c5 + z**2 * (c7 + z**2 * (c9 + z**2 * c11))))
+
+        // Polynomial coefficients for ln(m) where m in [sqrt(2)/2, sqrt(2)]
+        // ln(m) = 2z(1 + z²/3 + z⁴/5 + z⁶/7 + z⁸/9 + z¹⁰/11)
+        // where z = (m - 1) / (m + 1)
+        sfpi::vFloat p = PolynomialEvaluator::eval(
+            z2,
+            sfpi::vConst1,
+            0.3333333333333333f,
+            0.2f,
+            0.14285714285714285f,
+            0.1111111111111111f,
+            .09090909090909091f);
+
+        // Final computation: ln(m) = 2 * z * p
+        sfpi::vFloat ln_m = 2.0f * (z * p);
+
+        // We want to convert exponent to floating point using int32 -> float conversion.
+        // However, int32_to_float takes a sign-magnitude
+        // This is not an issue for positive numbers (same representation)
+        // For negative numbers, we need to explicitly convert to sign-magnitude format
+        v_if(exp < 0) {
+            // Compute absolute value: ~exp + 1 (two's complement negation)
+            sfpi::vInt exp_abs = ~exp + 1;
+            // Convert to sign-magnitude negative: setsgn(value, 1) sets MSB to 1
+            exp = sfpi::setsgn(exp_abs, 1);
+        }
+        v_endif;
+
+        // Convert to float - int32_to_float handles sign-magnitude format correctly
+        sfpi::vFloat expf = sfpi::int32_to_float(exp, 0);
+
+        // Step 5: Combine: ln(x) = exp×ln(2) + ln(m)
+        constexpr float LN2 = 0.6931471805599453f;  // log(2)
+        result = expf * LN2 + ln_m;                 // log(x) = log2(x) / log(2)
+
+        if constexpr (HAS_BASE_SCALING) {
+            result *= sfpi::vFloat(log_base_scale_factor);
+        }
+    }
+    v_endif;
+
+    return result;
+}
+
+template <
+    bool APPROXIMATION_MODE,
+    bool FAST_APPROX,
+    bool HAS_BASE_SCALING,
+    bool is_fp32_dest_acc_en = false,
+    int ITERATIONS = 8>
 inline void calculate_log(uint log_base_scale_factor) {
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
-        calculate_log_body<FAST_APPROX, HAS_BASE_SCALING>(log_base_scale_factor);
-        dst_reg++;
+        sfpi::vFloat in = sfpi::dst_reg[0];
+        sfpi::vFloat result;
+        if constexpr (!is_fp32_dest_acc_en) {
+            result = calculate_log_body<FAST_APPROX, HAS_BASE_SCALING, is_fp32_dest_acc_en>(in, log_base_scale_factor);
+        } else {
+            result = calculate_log_f32_body<HAS_BASE_SCALING>(in, log_base_scale_factor);
+        }
+        sfpi::dst_reg[0] = result;
+        sfpi::dst_reg++;
     }
 }
 
-template <bool APPROXIMATION_MODE, bool FAST_APPROX>
+template <bool APPROXIMATION_MODE, bool FAST_APPROX, bool is_fp32_dest_acc_en = false>
 inline void log_init() {
-    vConstFloatPrgm0 = 0.692871f;  // ln2
+    if constexpr (!is_fp32_dest_acc_en) {
+        sfpi::vConstFloatPrgm0 = 0.693147182464599609375;  // ln(2)
 
-    // XXXXX could do these to higher precision
-    vConstFloatPrgm1 = 0.1058f;
-    vConstFloatPrgm2 = -0.7166f;
+        // XXXXX could do these to higher precision
+        sfpi::vConstFloatPrgm1 = -2.0069785118103027;
+        sfpi::vConstFloatPrgm2 = 3.767500400543213;
+    } else {
+        _init_reciprocal_</*approximation_mode*/ false, /*legacy_compat*/ false>();
+    }
 }
 
 }  // namespace sfpu

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_log.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_log.h
@@ -43,7 +43,7 @@ sfpi_inline sfpi::vFloat calculate_log_body(sfpi::vFloat in, const uint log_base
     sfpi::vFloat result = expf * vConstLn2 + series_result;  // exp correction: ln(1+x) + exp*ln(2)
 
     if constexpr (HAS_BASE_SCALING) {
-        result *= sfpi::s2vFloat16a(log_base_scale_factor);
+        result *= sfpi::reinterpret<sfpi::vFloat>(sfpi::vUInt(log_base_scale_factor));
     }
 
     ////////////////////////////
@@ -176,7 +176,7 @@ sfpi_inline sfpi::vFloat calculate_log_f32_body(sfpi::vFloat val, const uint log
         result = expf * LN2 + ln_m;                 // log(x) = log2(x) / log(2)
 
         if constexpr (HAS_BASE_SCALING) {
-            result *= sfpi::vFloat(log_base_scale_factor);
+            result *= sfpi::reinterpret<sfpi::vFloat>(sfpi::vUInt(log_base_scale_factor));
         }
     }
     v_endif;
@@ -209,8 +209,6 @@ template <bool APPROXIMATION_MODE, bool FAST_APPROX, bool is_fp32_dest_acc_en = 
 inline void log_init() {
     if constexpr (!is_fp32_dest_acc_en) {
         sfpi::vConstFloatPrgm0 = 0.693147182464599609375;  // ln(2)
-
-        // XXXXX could do these to higher precision
         sfpi::vConstFloatPrgm1 = -2.0069785118103027;
         sfpi::vConstFloatPrgm2 = 3.767500400543213;
     } else {

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_log.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_log.h
@@ -10,9 +10,10 @@
 
 namespace ckernel {
 
-template <bool APPROXIMATE, bool FAST_APPROX>
+template <bool APPROXIMATE, bool FAST_APPROX, bool is_fp32_dest_acc_en>
 inline void llk_math_eltwise_unary_sfpu_log_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::log, APPROXIMATE>(sfpu::log_init<APPROXIMATE, FAST_APPROX>);
+    llk_math_eltwise_unary_sfpu_init<SfpuType::log, APPROXIMATE>(
+        sfpu::log_init<APPROXIMATE, FAST_APPROX, is_fp32_dest_acc_en>);
 }
 
 template <bool APPROXIMATE, bool FAST_APPROX, bool is_fp32_dest_acc_en>
@@ -21,9 +22,10 @@ inline void llk_math_eltwise_unary_sfpu_log(uint dst_index, int vector_mode = (i
         ckernel::sfpu::calculate_log<APPROXIMATE, FAST_APPROX, false, is_fp32_dest_acc_en>, dst_index, vector_mode, 0);
 }
 
-template <bool APPROXIMATE, bool FAST_APPROX>
+template <bool APPROXIMATE, bool FAST_APPROX, bool is_fp32_dest_acc_en>
 inline void llk_math_eltwise_unary_sfpu_log_with_base_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::log_with_base, APPROXIMATE>(sfpu::log_init<APPROXIMATE, FAST_APPROX>);
+    llk_math_eltwise_unary_sfpu_init<SfpuType::log_with_base, APPROXIMATE>(
+        sfpu::log_init<APPROXIMATE, FAST_APPROX, is_fp32_dest_acc_en>);
 }
 
 template <bool APPROXIMATE, bool FAST_APPROX, bool is_fp32_dest_acc_en>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_log.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_log.h
@@ -15,10 +15,10 @@ inline void llk_math_eltwise_unary_sfpu_log_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::log, APPROXIMATE>(sfpu::log_init<APPROXIMATE, FAST_APPROX>);
 }
 
-template <bool APPROXIMATE, bool FAST_APPROX>
+template <bool APPROXIMATE, bool FAST_APPROX, bool is_fp32_dest_acc_en>
 inline void llk_math_eltwise_unary_sfpu_log(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_log<APPROXIMATE, FAST_APPROX, false>, dst_index, vector_mode, 0);
+        ckernel::sfpu::calculate_log<APPROXIMATE, FAST_APPROX, false, is_fp32_dest_acc_en>, dst_index, vector_mode, 0);
 }
 
 template <bool APPROXIMATE, bool FAST_APPROX>
@@ -26,11 +26,14 @@ inline void llk_math_eltwise_unary_sfpu_log_with_base_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::log_with_base, APPROXIMATE>(sfpu::log_init<APPROXIMATE, FAST_APPROX>);
 }
 
-template <bool APPROXIMATE, bool FAST_APPROX>
+template <bool APPROXIMATE, bool FAST_APPROX, bool is_fp32_dest_acc_en>
 inline void llk_math_eltwise_unary_sfpu_log_with_base(
     uint dst_index, uint base_scale, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_log<APPROXIMATE, FAST_APPROX, true>, dst_index, vector_mode, base_scale);
+        ckernel::sfpu::calculate_log<APPROXIMATE, FAST_APPROX, true, is_fp32_dest_acc_en>,
+        dst_index,
+        vector_mode,
+        base_scale);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_erfinv.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_erfinv.h
@@ -23,9 +23,9 @@ sfpi_inline sfpi::vFloat calculate_sqrt_custom(sfpi::vFloat in) {
         // See: https://en.wikipedia.org/wiki/Fast_inverse_square_root
         sfpi::vUInt magic = sfpi::reinterpret<sfpi::vUInt>(sfpi::vFloat(sfpi::s2vFloat16b(0x5f37)));
         sfpi::vFloat approx = sfpi::reinterpret<sfpi::vFloat>(magic - (sfpi::reinterpret<sfpi::vUInt>(val) >> 1));
-        for (int r = 0; r < 2; r++) {
-            approx = ((approx * approx) * (val * -0.5f) + 1.5f) * approx;
-        }
+        sfpi::vFloat neg_half_val = val * -0.5f;
+        approx = ((approx * approx) * neg_half_val + 1.5f) * approx;
+        approx = ((approx * approx) * neg_half_val + 1.5f) * approx;
         out = approx * val;
     }
     v_else { out = val; }
@@ -35,17 +35,36 @@ sfpi_inline sfpi::vFloat calculate_sqrt_custom(sfpi::vFloat in) {
 
 template <bool APPROXIMATION_MODE>
 sfpi_inline sfpi::vFloat calculate_erfinv_body(sfpi::vFloat in) {
+    // Algorithm based on "A handy approximation for the error function and its inverse" by Sergei Winitzki (2008)
+    // This approximation defines erfinv(x) as:
+    // erfinv(x) = sqrt( - 2/(pi*a) - log(1 - x^2)/2 + sqrt( ( 2/(pi*a) + log(1 - x^2)) ^2 - 1/a log(1 - x^2)) )
+    // Where a is a polynomial coefficient used in the approximation of the error function (and re-used in inverse error
+    // function)
+
+    // Compute log(1 - x^2)
     sfpi::vFloat log_value = in * in;
     log_value = 1 - log_value;
     log_value = calculate_log_body<false, false, true>(log_value, 0);  // use fp32 to avoid intermediate rounding
+
     sfpi::vFloat temp = log_value * 0.5;
-    temp = 4.5469 + temp;
+
+    // Paper sets a constant a = 0.147.
+    // This constant is used to compute two constant expressions:
+    constexpr float TwoPiA = 4.330746750799873f;   // 2 / (pi * a)
+    constexpr float OneDivA = 6.802721088435375f;  // 1/a
+
+    // tmp = -2 / (pi * a) - log(1 - x^2)/2
+    temp = TwoPiA + temp;
     temp = -temp;
 
-    sfpi::vFloat calculated_value = (temp * temp) - (log_value * 7.1427);
+    // calculated_value = temp + sqrt( temp^2 - log_value / a)
+    sfpi::vFloat calculated_value = (temp * temp) - (log_value * OneDivA);
     sfpi::vFloat intermediate_result = calculate_sqrt_custom<false>(calculated_value);
     calculated_value = temp + intermediate_result;
-    log_value = calculate_sqrt_custom<false>(calculated_value);
+
+    // result = sqrt(calculated_value)
+    sfpi::vFloat result = calculate_sqrt_custom<false>(calculated_value);
+
     return log_value;
 }
 
@@ -56,17 +75,19 @@ inline void calculate_erfinv() {
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat v = sfpi::dst_reg[0];
         sfpi::vFloat result;
-        v_if(v == 1.0f) { result = std::numeric_limits<float>::infinity(); }
-        v_elseif(v == -1.0f) { result = -std::numeric_limits<float>::infinity(); }
-        v_elseif((v < -1.0f) || (v > 1.0f)) {  // Nan not supported
+
+        // Since erfinv(-x) = -erfinv(x), we can compute the result for the absolute value of the input.
+        // This reduces the number of edge cases.
+        sfpi::vFloat abs_v = sfpi::abs(v);
+
+        v_if(abs_v == 1.0f) { result = std::numeric_limits<float>::infinity(); }
+        v_elseif(abs_v > 1.0f) {  // Nan not supported
             result = std::numeric_limits<float>::quiet_NaN();
         }
-        v_elseif(v < 0.0f) {
-            result = calculate_erfinv_body<true>(v);
-            result = -result;
-        }
-        v_else { result = calculate_erfinv_body<true>(v); }
+        v_else { result = calculate_erfinv_body<true>(abs_v); }
         v_endif;
+
+        result = sfpi::setsgn(result, v);  // restore sign
 
         sfpi::dst_reg[0] = result;
         sfpi::dst_reg++;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_erfinv.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_erfinv.h
@@ -11,18 +11,16 @@
 
 #include "sfpi.h"
 
-using namespace sfpi;
-
 namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE>
-sfpi_inline vFloat calculate_sqrt_custom(vFloat in) {
-    vFloat val = in;
-    vFloat out;
+sfpi_inline sfpi::vFloat calculate_sqrt_custom(sfpi::vFloat in) {
+    sfpi::vFloat val = in;
+    sfpi::vFloat out;
     v_if(val != 0.0f) {
-        vUInt magic = reinterpret<vUInt>(vFloat(s2vFloat16b(0x5f37)));
-        vFloat approx = reinterpret<vFloat>(magic - (reinterpret<vUInt>(val) >> 1));
+        sfpi::vUInt magic = sfpi::reinterpret<sfpi::vUInt>(sfpi::vFloat(sfpi::s2vFloat16b(0x5f37)));
+        sfpi::vFloat approx = sfpi::reinterpret<sfpi::vFloat>(magic - (sfpi::reinterpret<sfpi::vUInt>(val) >> 1));
         for (int r = 0; r < 2; r++) {
             approx = ((approx * approx) * (val * -0.5f) + 1.5f) * approx;
         }
@@ -34,48 +32,48 @@ sfpi_inline vFloat calculate_sqrt_custom(vFloat in) {
 }
 
 template <bool APPROXIMATION_MODE>
-sfpi_inline vFloat calculate_erfinv_body(vFloat in) {
-    vFloat log_value = in * in;
+sfpi_inline sfpi::vFloat calculate_erfinv_body(sfpi::vFloat in) {
+    sfpi::vFloat log_value = in * in;
     log_value = 1 - log_value;
-    dst_reg[0] = log_value;
-    calculate_log_body<true, false>(0);
-    log_value = dst_reg[0];
-    vFloat temp = dst_reg[0] * 0.5;
+    log_value = calculate_log_body<false, false, true>(log_value, 0);
+    sfpi::vFloat temp = log_value * 0.5;
     temp = 4.5469 + temp;
     temp = -temp;
-    vFloat calculated_value = (temp * temp) - (log_value * 7.1427);
-    vFloat intermediate_result = calculate_sqrt_custom<false>(calculated_value);
+
+    sfpi::vFloat calculated_value = (temp * temp) - (log_value * 7.1427);
+    sfpi::vFloat intermediate_result = calculate_sqrt_custom<false>(calculated_value);
     calculated_value = temp + intermediate_result;
     log_value = calculate_sqrt_custom<false>(calculated_value);
-    dst_reg[0] = log_value;
     return log_value;
 }
 
 template <bool APPROXIMATION_MODE>
 inline void calculate_erfinv() {
     // SFPU microcode
-    for (int d = 0; d < 8; d++) {
-        vFloat v = dst_reg[0];
-        v_if(v == 1.0f) { dst_reg[0] = std::numeric_limits<float>::infinity(); }
-        v_elseif(v == -1.0f) { dst_reg[0] = -std::numeric_limits<float>::infinity(); }
+    constexpr int ITERATIONS = 8;
+    for (int d = 0; d < ITERATIONS; d++) {
+        sfpi::vFloat v = sfpi::dst_reg[0];
+        sfpi::vFloat result;
+        v_if(v == 1.0f) { result = std::numeric_limits<float>::infinity(); }
+        v_elseif(v == -1.0f) { result = -std::numeric_limits<float>::infinity(); }
         v_elseif((v < -1.0f) || (v > 1.0f)) {  // Nan not supported
-            dst_reg[0] = std::numeric_limits<float>::quiet_NaN();
+            result = std::numeric_limits<float>::quiet_NaN();
         }
         v_elseif(v < 0.0f) {
-            calculate_erfinv_body<true>(v);
-            dst_reg[0] = -dst_reg[0];
+            result = calculate_erfinv_body<true>(v);
+            result = -result;
         }
-        v_else { calculate_erfinv_body<true>(v); }
+        v_else { result = calculate_erfinv_body<true>(v); }
         v_endif;
-        dst_reg++;
+
+        sfpi::dst_reg[0] = result;
+        sfpi::dst_reg++;
     }
 }
 
 template <bool APPROXIMATION_MODE>
 void erfinv_init() {
-    vConstFloatPrgm0 = 0.692871f;  // ln2
-    vConstFloatPrgm1 = 0.1058f;
-    vConstFloatPrgm2 = -0.7166f;
+    log_init<false, false, false>();
 }
 
 }  // namespace sfpu

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_erfinv.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_erfinv.h
@@ -65,7 +65,7 @@ sfpi_inline sfpi::vFloat calculate_erfinv_body(sfpi::vFloat in) {
     // result = sqrt(calculated_value)
     sfpi::vFloat result = calculate_sqrt_custom<false>(calculated_value);
 
-    return log_value;
+    return result;
 }
 
 template <bool APPROXIMATION_MODE>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_erfinv.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_erfinv.h
@@ -19,6 +19,8 @@ sfpi_inline sfpi::vFloat calculate_sqrt_custom(sfpi::vFloat in) {
     sfpi::vFloat val = in;
     sfpi::vFloat out;
     v_if(val != 0.0f) {
+        // Magic number 0x5f37 is used as an approximation constant in the fast inverse square root algorithm.
+        // See: https://en.wikipedia.org/wiki/Fast_inverse_square_root
         sfpi::vUInt magic = sfpi::reinterpret<sfpi::vUInt>(sfpi::vFloat(sfpi::s2vFloat16b(0x5f37)));
         sfpi::vFloat approx = sfpi::reinterpret<sfpi::vFloat>(magic - (sfpi::reinterpret<sfpi::vUInt>(val) >> 1));
         for (int r = 0; r < 2; r++) {
@@ -35,7 +37,7 @@ template <bool APPROXIMATION_MODE>
 sfpi_inline sfpi::vFloat calculate_erfinv_body(sfpi::vFloat in) {
     sfpi::vFloat log_value = in * in;
     log_value = 1 - log_value;
-    log_value = calculate_log_body<false, false, true>(log_value, 0);
+    log_value = calculate_log_body<false, false, true>(log_value, 0);  // use fp32 to avoid intermediate rounding
     sfpi::vFloat temp = log_value * 0.5;
     temp = 4.5469 + temp;
     temp = -temp;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_log.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_log.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -8,13 +8,11 @@
 #include "ckernel_defs.h"
 #include "sfpu/ckernel_sfpu_polyval.h"
 
-using namespace sfpi;
-
 namespace ckernel {
 namespace sfpu {
 
 template <bool FAST_APPROX, bool HAS_BASE_SCALING, bool is_fp32_dest_acc_en = false>
-sfpi_inline void calculate_log_body(sfpi::vFloat in, const uint log_base_scale_factor) {
+sfpi_inline sfpi::vFloat calculate_log_body(sfpi::vFloat in, const uint log_base_scale_factor) {
     ///////////////////////////////////
     // "normalize to calculation range"
     ///////////////////////////////////
@@ -35,6 +33,8 @@ sfpi_inline void calculate_log_body(sfpi::vFloat in, const uint log_base_scale_f
     // Convert exponent to float
     ////////////////////////////
     sfpi::vInt exp = sfpi::exexp(in);
+
+    // Convert negative numbers: signed -> sign-magnitude
     v_if(exp < 0) { exp = sfpi::setsgn(~exp + 1, 1); }
     v_endif;
 
@@ -68,68 +68,46 @@ sfpi_inline void calculate_log_body(sfpi::vFloat in, const uint log_base_scale_f
     if constexpr (!is_fp32_dest_acc_en) {
         result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
     }
+
+    return result;
 }
 
 /*
  * This function implements ln(x) using polynomial approximation.
- * Algorithm based on ln_fp32 from operations.py:
  * 1. Handle special cases (x <= 0, infinity, NaN)
  * 2. Extract exponent and mantissa: x = 2^n × m
  * 3. Reduce range: adjust m to be in [sqrt(2)/2, sqrt(2)]
  * 4. Compute ln(m) using polynomial approximation
  * 5. Return n×ln(2) + ln(m)
- *
- * @param val The input value (sfpi::vFloat vector), can be any floating point number
- * @return sfpi::vFloat Result of ln(val)
  */
-sfpi_inline sfpi::vFloat calculate_log_f32_body(sfpi::vFloat val) {
+template <bool HAS_BASE_SCALING>
+sfpi_inline sfpi::vFloat calculate_log_f32_body(sfpi::vFloat val, const uint log_base_scale_factor) {
     sfpi::vFloat result = sfpi::vConst0;
 
-    // Constants (all in fp32)
-    constexpr float LN2 = 0.6931471805599453f;    // ln(2)
-    constexpr float SQRT2 = 1.4142135623730951f;  // sqrt(2)
-    constexpr float HALF = 0.5f;
-    constexpr float ONE = 1.0f;
-    constexpr float TWO = 2.0f;
-    constexpr float ZERO = 0.0f;
-    constexpr int BIAS = 127;  // IEEE 754 bias
-
-    // Polynomial coefficients for ln(m) where m in [sqrt(2)/2, sqrt(2)]
-    // ln(m) = 2z(1 + z²/3 + z⁴/5 + z⁶/7 + z⁸/9 + z¹⁰/11)
-    // where z = (m - 1) / (m + 1)
-    constexpr float c11 = 0.09090909090909091f;  // 1/11
-    constexpr float c9 = 0.1111111111111111f;    // 1/9
-    constexpr float c7 = 0.14285714285714285f;   // 1/7
-    constexpr float c5 = 0.2f;                   // 1/5
-    constexpr float c3 = 0.3333333333333333f;    // 1/3
-
     // Check for special cases
-    sfpi::vInt exp_bits = sfpi::exexp(val);   // Get debiased exponent
+    sfpi::vInt exp = sfpi::exexp(val);        // Get debiased exponent
     sfpi::vInt man_bits = sfpi::exman9(val);  // Get mantissa bits
 
     // Check for NaN: exponent = 128 (255 - 127, meaning original exp = 255) and mantissa != 0
-    // Actually, exexp returns debiased, so exp_bits == 128 means original exp = 255
-    v_if(exp_bits == 128 && man_bits != 0) {
+    // Note: exexp returns debiased, so exp == 128 means original exp = 255
+    v_if(exp == 128 && man_bits != 0) {
         // NaN: exponent = 255 and mantissa != 0
         result = std::numeric_limits<float>::quiet_NaN();
     }
-    v_elseif(val < sfpi::vFloat(ZERO)) {
-        // Negative input
+    v_elseif(val < sfpi::vConst0) {
+        // Negative input -> NaN
         result = std::numeric_limits<float>::quiet_NaN();
     }
-    v_elseif(val == sfpi::vFloat(ZERO)) {
-        // Zero input
+    v_elseif(val == sfpi::vConst0) {
+        // Zero input -> -inf
         result = -std::numeric_limits<float>::infinity();
     }
-    v_elseif(exp_bits == 128 && man_bits == 0) {
+    v_elseif(exp == 128 && man_bits == 0) {
         // Infinity: exponent = 255 and mantissa = 0
         result = std::numeric_limits<float>::infinity();
     }
     v_else {
         // Step 1: Extract exponent and mantissa
-        // Extract exponent (debiased) - exexp already returns debiased exponent
-        sfpi::vInt exp = sfpi::exexp(val);
-
         // Extract mantissa and construct m in [1, 2)
         // Use setexp to normalize to [1, 2) range by setting exponent to 127 (bias)
         sfpi::vFloat m = sfpi::setexp(val, 127);
@@ -137,81 +115,71 @@ sfpi_inline sfpi::vFloat calculate_log_f32_body(sfpi::vFloat val) {
         // Step 2: Range reduction
         // If m >= sqrt(2), divide by 2 and increment exponent
         // This ensures m is in [sqrt(2)/2, sqrt(2)] ≈ [0.707, 1.414]
-        v_if(m >= sfpi::vFloat(SQRT2)) {
-            m = m * sfpi::vFloat(HALF);  // Divide by 2
-            exp = exp + 1;               // Increment exponent
+        constexpr float SQRT2 = 1.4142135623730951f;  // sqrt(2)
+        v_if(m >= SQRT2) {
+            // m = m * 0.5f;  // Divide by 2
+            m = m * 0.5f;
+            exp = exp + 1;  // Increment exponent
         }
         v_endif;
 
         // Step 3: Transform to z = (m - 1) / (m + 1)
         // This maps m ∈ [0.707, 1.414] to z ∈ [-0.172, 0.172]
         // ln(m) = 2 × (z + z³/3 + z⁵/5 + z⁷/7 + ...)
-        sfpi::vFloat m_minus_1 = m - sfpi::vFloat(ONE);
-        sfpi::vFloat m_plus_1 = m + sfpi::vFloat(ONE);
+        sfpi::vFloat m_minus_1 = m - sfpi::vConst1;
+        sfpi::vFloat m_plus_1 = m + sfpi::vConst1;
 
         // Compute z = (m - 1) / (m + 1) using reciprocal
         // z = m_minus_1 * (1 / m_plus_1)
-        sfpi::vFloat m_plus_1_recip = ckernel::sfpu::_sfpu_reciprocal_<2>(m_plus_1);
+        sfpi::vFloat m_plus_1_recip = _sfpu_reciprocal_<2>(m_plus_1);
         sfpi::vFloat z = m_minus_1 * m_plus_1_recip;
 
-        // Compute z² for polynomial evaluation
+        // Compute z**2 for polynomial evaluation
         sfpi::vFloat z2 = z * z;
 
         // Step 4: Polynomial approximation using odd powers
+        // ln(m) = 2z(1 + (z**2)/3 + (z**4)/5 + (z**6)/7 + (z**8)/9 + (z**10)/11)
+        // Using Horner's method: p = 1 + z**2 * (c3 + z**2 * (c5 + z**2 * (c7 + z**2 * (c9 + z**2 * c11))))
+
+        // Polynomial coefficients for ln(m) where m in [sqrt(2)/2, sqrt(2)]
         // ln(m) = 2z(1 + z²/3 + z⁴/5 + z⁶/7 + z⁸/9 + z¹⁰/11)
-        // Using Horner's method: p = 1 + z²*(c3 + z²*(c5 + z²*(c7 + z²*(c9 + z²*c11))))
-        sfpi::vFloat p = sfpi::vFloat(c11);
-
-        sfpi::vFloat temp = z2 * p;
-        p = sfpi::vFloat(c9) + temp;
-
-        temp = z2 * p;
-        p = sfpi::vFloat(c7) + temp;
-
-        temp = z2 * p;
-        p = sfpi::vFloat(c5) + temp;
-
-        temp = z2 * p;
-        p = sfpi::vFloat(c3) + temp;
-
-        temp = z2 * p;
-        p = sfpi::vFloat(ONE) + temp;
+        // where z = (m - 1) / (m + 1)
+        sfpi::vFloat p = PolynomialEvaluator::eval(
+            z2,
+            sfpi::vConst1,
+            0.3333333333333333f,
+            0.2f,
+            0.14285714285714285f,
+            0.1111111111111111f,
+            .09090909090909091f);
 
         // Final computation: ln(m) = 2 * z * p
-        temp = z * p;
-        sfpi::vFloat ln_m = sfpi::vFloat(TWO) * temp;
+        sfpi::vFloat ln_m = 2.0f * (z * p);
 
-        // Step 5: Combine: ln(x) = exp×ln(2) + ln(m)
-        // Convert exponent to float (exp is already debiased from exexp)
-        // Follow the same pattern as ckernel_sfpu_log.h:
-        // For negative exp, convert to sign-magnitude format for int32_to_float
-        // int32_to_float automatically interprets the sign bit correctly
-        sfpi::vInt exp_for_convert = exp;
-
-        // Convert negative exponents to sign-magnitude format
-        // setsgn(abs_value, 1) creates negative in sign-magnitude (MSB=1)
-        // int32_to_float will interpret this as negative float
+        // We want to convert exponent to floating point using int32 -> float conversion.
+        // However, int32_to_float takes a sign-magnitude
+        // This is not an issue for positive numbers (same representation)
+        // For negative numbers, we need to explicitly convert to sign-magnitude format
         v_if(exp < 0) {
             // Compute absolute value: ~exp + 1 (two's complement negation)
             sfpi::vInt exp_abs = ~exp + 1;
             // Convert to sign-magnitude negative: setsgn(value, 1) sets MSB to 1
-            exp_for_convert = sfpi::setsgn(exp_abs, 1);
+            exp = sfpi::setsgn(exp_abs, 1);
         }
         v_endif;
 
         // Convert to float - int32_to_float handles sign-magnitude format correctly
-        // For sign-magnitude: MSB=1 means negative, MSB=0 means positive
-        sfpi::vFloat expf = sfpi::int32_to_float(exp_for_convert, 0);
+        sfpi::vFloat expf = sfpi::int32_to_float(exp, 0);
 
-        temp = expf * sfpi::vFloat(LN2);
-        result = temp + ln_m;
+        // Step 5: Combine: ln(x) = exp×ln(2) + ln(m)
+        constexpr float LN2 = 0.6931471805599453f;  // log(2)
+        result = expf * LN2 + ln_m;                 // log(x) = log2(x) / log(2)
+
+        if constexpr (HAS_BASE_SCALING) {
+            result *= sfpi::vFloat(log_base_scale_factor);
+        }
     }
     v_endif;
-
-    //  if constexpr (!is_fp32_dest_acc_en) {
-    //      // Convert to bfloat16 if needed
-    //      result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
-    //  }
 
     return result;
 }
@@ -230,7 +198,7 @@ inline void calculate_log(uint log_base_scale_factor) {
         if constexpr (!is_fp32_dest_acc_en) {
             result = calculate_log_body<FAST_APPROX, HAS_BASE_SCALING, is_fp32_dest_acc_en>(in, log_base_scale_factor);
         } else {
-            result = calculate_log_f32_body(in);
+            result = calculate_log_f32_body<HAS_BASE_SCALING>(in, log_base_scale_factor);
         }
         sfpi::dst_reg[0] = result;
         sfpi::dst_reg++;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_log.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_log.h
@@ -14,11 +14,10 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool FAST_APPROX, bool HAS_BASE_SCALING, bool is_fp32_dest_acc_en = false>
-sfpi_inline void calculate_log_body(const uint log_base_scale_factor) {
-    ////////////////////////////
-    // Load From dest + "normalize to calculation range"
-    ////////////////////////////
-    sfpi::vFloat in = sfpi::dst_reg[0];
+sfpi_inline void calculate_log_body(sfpi::vFloat in, const uint log_base_scale_factor) {
+    ///////////////////////////////////
+    // "normalize to calculation range"
+    ///////////////////////////////////
     sfpi::vFloat x = sfpi::setexp(in, 127);  // set exp to exp bias (put in range of 1-2)
 
     // Minimax approximation of log(x) over [1; 2] calculated using Sollya with the following command:
@@ -69,8 +68,152 @@ sfpi_inline void calculate_log_body(const uint log_base_scale_factor) {
     if constexpr (!is_fp32_dest_acc_en) {
         result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
     }
+}
 
-    sfpi::dst_reg[0] = result;
+/*
+ * This function implements ln(x) using polynomial approximation.
+ * Algorithm based on ln_fp32 from operations.py:
+ * 1. Handle special cases (x <= 0, infinity, NaN)
+ * 2. Extract exponent and mantissa: x = 2^n × m
+ * 3. Reduce range: adjust m to be in [sqrt(2)/2, sqrt(2)]
+ * 4. Compute ln(m) using polynomial approximation
+ * 5. Return n×ln(2) + ln(m)
+ *
+ * @param val The input value (sfpi::vFloat vector), can be any floating point number
+ * @return sfpi::vFloat Result of ln(val)
+ */
+sfpi_inline sfpi::vFloat calculate_log_f32_body(sfpi::vFloat val) {
+    sfpi::vFloat result = sfpi::vConst0;
+
+    // Constants (all in fp32)
+    constexpr float LN2 = 0.6931471805599453f;    // ln(2)
+    constexpr float SQRT2 = 1.4142135623730951f;  // sqrt(2)
+    constexpr float HALF = 0.5f;
+    constexpr float ONE = 1.0f;
+    constexpr float TWO = 2.0f;
+    constexpr float ZERO = 0.0f;
+    constexpr int BIAS = 127;  // IEEE 754 bias
+
+    // Polynomial coefficients for ln(m) where m in [sqrt(2)/2, sqrt(2)]
+    // ln(m) = 2z(1 + z²/3 + z⁴/5 + z⁶/7 + z⁸/9 + z¹⁰/11)
+    // where z = (m - 1) / (m + 1)
+    constexpr float c11 = 0.09090909090909091f;  // 1/11
+    constexpr float c9 = 0.1111111111111111f;    // 1/9
+    constexpr float c7 = 0.14285714285714285f;   // 1/7
+    constexpr float c5 = 0.2f;                   // 1/5
+    constexpr float c3 = 0.3333333333333333f;    // 1/3
+
+    // Check for special cases
+    sfpi::vInt exp_bits = sfpi::exexp(val);   // Get debiased exponent
+    sfpi::vInt man_bits = sfpi::exman9(val);  // Get mantissa bits
+
+    // Check for NaN: exponent = 128 (255 - 127, meaning original exp = 255) and mantissa != 0
+    // Actually, exexp returns debiased, so exp_bits == 128 means original exp = 255
+    v_if(exp_bits == 128 && man_bits != 0) {
+        // NaN: exponent = 255 and mantissa != 0
+        result = std::numeric_limits<float>::quiet_NaN();
+    }
+    v_elseif(val < sfpi::vFloat(ZERO)) {
+        // Negative input
+        result = std::numeric_limits<float>::quiet_NaN();
+    }
+    v_elseif(val == sfpi::vFloat(ZERO)) {
+        // Zero input
+        result = -std::numeric_limits<float>::infinity();
+    }
+    v_elseif(exp_bits == 128 && man_bits == 0) {
+        // Infinity: exponent = 255 and mantissa = 0
+        result = std::numeric_limits<float>::infinity();
+    }
+    v_else {
+        // Step 1: Extract exponent and mantissa
+        // Extract exponent (debiased) - exexp already returns debiased exponent
+        sfpi::vInt exp = sfpi::exexp(val);
+
+        // Extract mantissa and construct m in [1, 2)
+        // Use setexp to normalize to [1, 2) range by setting exponent to 127 (bias)
+        sfpi::vFloat m = sfpi::setexp(val, 127);
+
+        // Step 2: Range reduction
+        // If m >= sqrt(2), divide by 2 and increment exponent
+        // This ensures m is in [sqrt(2)/2, sqrt(2)] ≈ [0.707, 1.414]
+        v_if(m >= sfpi::vFloat(SQRT2)) {
+            m = m * sfpi::vFloat(HALF);  // Divide by 2
+            exp = exp + 1;               // Increment exponent
+        }
+        v_endif;
+
+        // Step 3: Transform to z = (m - 1) / (m + 1)
+        // This maps m ∈ [0.707, 1.414] to z ∈ [-0.172, 0.172]
+        // ln(m) = 2 × (z + z³/3 + z⁵/5 + z⁷/7 + ...)
+        sfpi::vFloat m_minus_1 = m - sfpi::vFloat(ONE);
+        sfpi::vFloat m_plus_1 = m + sfpi::vFloat(ONE);
+
+        // Compute z = (m - 1) / (m + 1) using reciprocal
+        // z = m_minus_1 * (1 / m_plus_1)
+        sfpi::vFloat m_plus_1_recip = ckernel::sfpu::_sfpu_reciprocal_<2>(m_plus_1);
+        sfpi::vFloat z = m_minus_1 * m_plus_1_recip;
+
+        // Compute z² for polynomial evaluation
+        sfpi::vFloat z2 = z * z;
+
+        // Step 4: Polynomial approximation using odd powers
+        // ln(m) = 2z(1 + z²/3 + z⁴/5 + z⁶/7 + z⁸/9 + z¹⁰/11)
+        // Using Horner's method: p = 1 + z²*(c3 + z²*(c5 + z²*(c7 + z²*(c9 + z²*c11))))
+        sfpi::vFloat p = sfpi::vFloat(c11);
+
+        sfpi::vFloat temp = z2 * p;
+        p = sfpi::vFloat(c9) + temp;
+
+        temp = z2 * p;
+        p = sfpi::vFloat(c7) + temp;
+
+        temp = z2 * p;
+        p = sfpi::vFloat(c5) + temp;
+
+        temp = z2 * p;
+        p = sfpi::vFloat(c3) + temp;
+
+        temp = z2 * p;
+        p = sfpi::vFloat(ONE) + temp;
+
+        // Final computation: ln(m) = 2 * z * p
+        temp = z * p;
+        sfpi::vFloat ln_m = sfpi::vFloat(TWO) * temp;
+
+        // Step 5: Combine: ln(x) = exp×ln(2) + ln(m)
+        // Convert exponent to float (exp is already debiased from exexp)
+        // Follow the same pattern as ckernel_sfpu_log.h:
+        // For negative exp, convert to sign-magnitude format for int32_to_float
+        // int32_to_float automatically interprets the sign bit correctly
+        sfpi::vInt exp_for_convert = exp;
+
+        // Convert negative exponents to sign-magnitude format
+        // setsgn(abs_value, 1) creates negative in sign-magnitude (MSB=1)
+        // int32_to_float will interpret this as negative float
+        v_if(exp < 0) {
+            // Compute absolute value: ~exp + 1 (two's complement negation)
+            sfpi::vInt exp_abs = ~exp + 1;
+            // Convert to sign-magnitude negative: setsgn(value, 1) sets MSB to 1
+            exp_for_convert = sfpi::setsgn(exp_abs, 1);
+        }
+        v_endif;
+
+        // Convert to float - int32_to_float handles sign-magnitude format correctly
+        // For sign-magnitude: MSB=1 means negative, MSB=0 means positive
+        sfpi::vFloat expf = sfpi::int32_to_float(exp_for_convert, 0);
+
+        temp = expf * sfpi::vFloat(LN2);
+        result = temp + ln_m;
+    }
+    v_endif;
+
+    //  if constexpr (!is_fp32_dest_acc_en) {
+    //      // Convert to bfloat16 if needed
+    //      result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
+    //  }
+
+    return result;
 }
 
 template <
@@ -82,18 +225,29 @@ template <
 inline void calculate_log(uint log_base_scale_factor) {
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
-        calculate_log_body<FAST_APPROX, HAS_BASE_SCALING, is_fp32_dest_acc_en>(log_base_scale_factor);
+        sfpi::vFloat in = sfpi::dst_reg[0];
+        sfpi::vFloat result;
+        if constexpr (!is_fp32_dest_acc_en) {
+            result = calculate_log_body<FAST_APPROX, HAS_BASE_SCALING, is_fp32_dest_acc_en>(in, log_base_scale_factor);
+        } else {
+            result = calculate_log_f32_body(in);
+        }
+        sfpi::dst_reg[0] = result;
         sfpi::dst_reg++;
     }
 }
 
-template <bool APPROXIMATION_MODE, bool FAST_APPROX>
+template <bool APPROXIMATION_MODE, bool FAST_APPROX, bool is_fp32_dest_acc_en = false>
 inline void log_init() {
-    sfpi::vConstFloatPrgm0 = 0.693147182464599609375;  // ln(2)
+    if constexpr (!is_fp32_dest_acc_en) {
+        sfpi::vConstFloatPrgm0 = 0.693147182464599609375;  // ln(2)
 
-    // XXXXX could do these to higher precision
-    sfpi::vConstFloatPrgm1 = -2.0069785118103027;
-    sfpi::vConstFloatPrgm2 = 3.767500400543213;
+        // XXXXX could do these to higher precision
+        sfpi::vConstFloatPrgm1 = -2.0069785118103027;
+        sfpi::vConstFloatPrgm2 = 3.767500400543213;
+    } else {
+        _init_reciprocal_</*approximation_mode*/ false, /*legacy_compat*/ false>();
+    }
 }
 
 }  // namespace sfpu

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_log.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_log.h
@@ -43,7 +43,7 @@ sfpi_inline sfpi::vFloat calculate_log_body(sfpi::vFloat in, const uint log_base
     sfpi::vFloat result = expf * vConstLn2 + series_result;  // exp correction: ln(1+x) + exp*ln(2)
 
     if constexpr (HAS_BASE_SCALING) {
-        result *= sfpi::s2vFloat16a(log_base_scale_factor);
+        result *= sfpi::reinterpret<sfpi::vFloat>(sfpi::vUInt(log_base_scale_factor));
     }
 
     ////////////////////////////
@@ -176,7 +176,7 @@ sfpi_inline sfpi::vFloat calculate_log_f32_body(sfpi::vFloat val, const uint log
         result = expf * LN2 + ln_m;                 // log(x) = log2(x) / log(2)
 
         if constexpr (HAS_BASE_SCALING) {
-            result *= sfpi::vFloat(log_base_scale_factor);
+            result *= sfpi::reinterpret<sfpi::vFloat>(sfpi::vUInt(log_base_scale_factor));
         }
     }
     v_endif;
@@ -209,8 +209,6 @@ template <bool APPROXIMATION_MODE, bool FAST_APPROX, bool is_fp32_dest_acc_en = 
 inline void log_init() {
     if constexpr (!is_fp32_dest_acc_en) {
         sfpi::vConstFloatPrgm0 = 0.693147182464599609375;  // ln(2)
-
-        // XXXXX could do these to higher precision
         sfpi::vConstFloatPrgm1 = -2.0069785118103027;
         sfpi::vConstFloatPrgm2 = 3.767500400543213;
     } else {

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_log.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_log.h
@@ -10,9 +10,10 @@
 
 namespace ckernel {
 
-template <bool APPROXIMATE, bool FAST_APPROX>
+template <bool APPROXIMATE, bool FAST_APPROX, bool is_fp32_dest_acc_en>
 inline void llk_math_eltwise_unary_sfpu_log_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::log, APPROXIMATE>(sfpu::log_init<APPROXIMATE, FAST_APPROX>);
+    llk_math_eltwise_unary_sfpu_init<SfpuType::log, APPROXIMATE>(
+        sfpu::log_init<APPROXIMATE, FAST_APPROX, is_fp32_dest_acc_en>);
 }
 
 template <bool APPROXIMATE, bool FAST_APPROX, bool is_fp32_dest_acc_en>
@@ -21,9 +22,10 @@ inline void llk_math_eltwise_unary_sfpu_log(uint dst_index, int vector_mode = (i
         ckernel::sfpu::calculate_log<APPROXIMATE, FAST_APPROX, false, is_fp32_dest_acc_en>, dst_index, vector_mode, 0);
 }
 
-template <bool APPROXIMATE, bool FAST_APPROX>
+template <bool APPROXIMATE, bool FAST_APPROX, bool is_fp32_dest_acc_en>
 inline void llk_math_eltwise_unary_sfpu_log_with_base_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::log_with_base, APPROXIMATE>(sfpu::log_init<APPROXIMATE, FAST_APPROX>);
+    llk_math_eltwise_unary_sfpu_init<SfpuType::log_with_base, APPROXIMATE>(
+        sfpu::log_init<APPROXIMATE, FAST_APPROX, is_fp32_dest_acc_en>);
 }
 
 template <bool APPROXIMATE, bool FAST_APPROX, bool is_fp32_dest_acc_en>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_log.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_log.h
@@ -15,10 +15,10 @@ inline void llk_math_eltwise_unary_sfpu_log_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::log, APPROXIMATE>(sfpu::log_init<APPROXIMATE, FAST_APPROX>);
 }
 
-template <bool APPROXIMATE, bool FAST_APPROX>
+template <bool APPROXIMATE, bool FAST_APPROX, bool is_fp32_dest_acc_en>
 inline void llk_math_eltwise_unary_sfpu_log(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_log<APPROXIMATE, FAST_APPROX, false>, dst_index, vector_mode, 0);
+        ckernel::sfpu::calculate_log<APPROXIMATE, FAST_APPROX, false, is_fp32_dest_acc_en>, dst_index, vector_mode, 0);
 }
 
 template <bool APPROXIMATE, bool FAST_APPROX>
@@ -26,11 +26,14 @@ inline void llk_math_eltwise_unary_sfpu_log_with_base_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::log_with_base, APPROXIMATE>(sfpu::log_init<APPROXIMATE, FAST_APPROX>);
 }
 
-template <bool APPROXIMATE, bool FAST_APPROX>
+template <bool APPROXIMATE, bool FAST_APPROX, bool is_fp32_dest_acc_en>
 inline void llk_math_eltwise_unary_sfpu_log_with_base(
     uint dst_index, uint base_scale, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_log<APPROXIMATE, FAST_APPROX, true>, dst_index, vector_mode, base_scale);
+        ckernel::sfpu::calculate_log<APPROXIMATE, FAST_APPROX, true, is_fp32_dest_acc_en>,
+        dst_index,
+        vector_mode,
+        base_scale);
 }
 
 }  // namespace ckernel

--- a/tt_metal/include/compute_kernel_api.h
+++ b/tt_metal/include/compute_kernel_api.h
@@ -97,13 +97,16 @@ ALWI void log_tile_init() {
  * acquired state via *acquire_dst* call. This call is blocking and is only
  * available on the compute engine.
  *
+ * Note: The base scale is the bit representation of the inverse of the log base.
+ * e.g. 1/ln(2) for log2(x) is 0x3fb8aa3b.
+ *
  * Return value: None
  *
  * | Argument        | Description                                                                | Type     | Valid Range                                           | Required |
  * |-----------------|----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
  * | idst            | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
  */
- // clang-format on
+// clang-format on
 template <bool fast_and_approx = false>
 ALWI void log_tile(uint32_t idst) {
     MATH((llk_math_eltwise_unary_sfpu_log<APPROX, fast_and_approx, DST_ACCUM_MODE>(idst)));
@@ -130,7 +133,7 @@ ALWI void log_with_base_tile_init() {
  * | Argument        | Description                                                                | Type     | Valid Range                                           | Required |
  * |-----------------|----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
  * | idst            | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
- * | base_scale      | The log base                                                               | uint32_t | Postive integers                                      | True     |
+ * | base_scale      | Bit representation of Inverse of log base e.g. 1/ln(2) to compute log2(x)  | uint32_t | Postive integers                                      | True     |
  */
 // clang-format on
 template <bool fast_and_approx = false>

--- a/tt_metal/include/compute_kernel_api.h
+++ b/tt_metal/include/compute_kernel_api.h
@@ -106,7 +106,7 @@ ALWI void log_tile_init() {
  // clang-format on
 template <bool fast_and_approx = false>
 ALWI void log_tile(uint32_t idst) {
-    MATH((llk_math_eltwise_unary_sfpu_log<APPROX, fast_and_approx>(idst)));
+    MATH((llk_math_eltwise_unary_sfpu_log<APPROX, fast_and_approx, DST_ACCUM_MODE>(idst)));
 }
 
 /**
@@ -134,7 +134,7 @@ ALWI void log_with_base_tile_init() {
 // clang-format on
 template <bool fast_and_approx = false>
 ALWI void log_with_base_tile(uint32_t idst, uint32_t base_scale) {
-    MATH((llk_math_eltwise_unary_sfpu_log_with_base<APPROX, fast_and_approx>(idst, base_scale)));
+    MATH((llk_math_eltwise_unary_sfpu_log_with_base<APPROX, fast_and_approx, DST_ACCUM_MODE>(idst, base_scale)));
 }
 
 // TODO: Move to trigonometry.h

--- a/tt_metal/include/compute_kernel_api.h
+++ b/tt_metal/include/compute_kernel_api.h
@@ -87,7 +87,7 @@ ALWI void sigmoid_tile(uint32_t idst) {
  */
 template <bool fast_and_approx = false>
 ALWI void log_tile_init() {
-    MATH((llk_math_eltwise_unary_sfpu_log_init<APPROX, fast_and_approx>()));  // TODO(AP): move out init
+    MATH((llk_math_eltwise_unary_sfpu_log_init<APPROX, fast_and_approx, DST_ACCUM_MODE>()));  // TODO(AP): move out init
 }
 
 // clang-format off
@@ -114,7 +114,8 @@ ALWI void log_tile(uint32_t idst) {
  */
 template <bool fast_and_approx = false>
 ALWI void log_with_base_tile_init() {
-    MATH((llk_math_eltwise_unary_sfpu_log_with_base_init<APPROX, fast_and_approx>()));  // TODO(AP): move out init
+    MATH((llk_math_eltwise_unary_sfpu_log_with_base_init<APPROX, fast_and_approx, DST_ACCUM_MODE>()));  // TODO(AP):
+                                                                                                        // move out init
 }
 
 // clang-format off

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
@@ -177,13 +177,13 @@ std::pair<std::string, std::string> get_op_init_and_func_parameterized(
             // log10[x] = log[x]/log[10] = log[x]*0.4342944819032518; FP32@U32 0x3ede5bd9; FP16@U16 0x36f3;
             op_init_and_name = {
                 fmt::format("log_with_base_tile_init<{}u>();", (uint32_t)param0),
-                fmt::format("log_with_base_tile<{1}u>({0}, 0x36f3u);", idst, (uint32_t)param0)};
+                fmt::format("log_with_base_tile<{1}u>({0}, 0x3ede5bd9u);", idst, (uint32_t)param0)};
             break;
 
         case UnaryOpType::LOG2:  // log2[x] = log[x]*1.4426950408889634f; FP32@U32 0x3fb8aa3b; FP16@U16 0x3dc5;
             op_init_and_name = {
                 fmt::format("log_with_base_tile_init<{}u>();", (uint32_t)param0),
-                fmt::format("log_with_base_tile<{1}u>({0}, 0x3dc5u);", idst, (uint32_t)param0)};
+                fmt::format("log_with_base_tile<{1}u>({0}, 0x3fb8aa3bu);", idst, (uint32_t)param0)};
             break;
         case UnaryOpType::LOG1P:
             op_init_and_name = {
@@ -662,10 +662,12 @@ std::pair<std::string, std::string> get_op_init_and_func_default(
             break;
         case UnaryOpType::LOG10:
             // log10[x] = log[x]/log[10] = log[x]*0.4342944819032518; FP32@U32 0x3ede5bd9; FP16@U16 0x36f3;
-            op_init_and_name = {"log_with_base_tile_init();", fmt::format("log_with_base_tile({}, 0x36f3u);", idst)};
+            op_init_and_name = {
+                "log_with_base_tile_init();", fmt::format("log_with_base_tile({}, 0x3ede5bd9u);", idst)};
             break;
         case UnaryOpType::LOG2:  // log2[x] = log[x]*1.4426950408889634f; FP32@U32 0x3fb8aa3b; FP16@U16 0x3dc5;
-            op_init_and_name = {"log_with_base_tile_init();", fmt::format("log_with_base_tile({}, 0x3dc5u);", idst)};
+            op_init_and_name = {
+                "log_with_base_tile_init();", fmt::format("log_with_base_tile({}, 0x3fb8aa3bu);", idst)};
             break;
         case UnaryOpType::ABS: op_init_and_name = {"abs_tile_init();", fmt::format("abs_tile({});", idst)}; break;
         case UnaryOpType::ABS_INT32:


### PR DESCRIPTION
### Ticket
#33695

### Problem description
ttnn.log is inaccurate around 1:
- With bfloat16, max ULP error is >200
- With float32, max ULP error is > 700'000

### What's changed

To summarize, this PR improves the accuracy of log (especially around 1) by factors of:
- x 200 for bfloat16 (>200 max bfloat16 ULP of error -> 1)
- x 50'000 for float32 (>700'000 max float32 ULP of error -> 4)

For a more detailed list changes:
- Update bfloat16 to be accurate within 1 bfloat16 ULP (improved polynomial approximation, more accurate constants, proper rounding)
- Add float32 implementation that is accurate within 4 float32 ULP
- Update documentation for `log_with_base_tile()` LLK
- Fix ttnn.digamma test by sampling on [2; 102] rather than [100; 101]. 
- Fix ttnn.erfinv to be compatible with new `calculate_log()` + clean up `erfinv_tile()` implementation.
 
#### Accuracy improvement

<img width="688" height="378" alt="log-accurate-bfloat16" src="https://github.com/user-attachments/assets/3b934c91-f8e6-4352-8d4d-e66c3deab006" />

<img width="856" height="378" alt="log-accurate-float32" src="https://github.com/user-attachments/assets/5592a409-7b68-4d41-ae21-a70daa798c32" />

#### Performance impact
 
Both versions have a performance trade-off: 
- the bfloat16 version is 1.2 time slower than on main (~20% slower)
- the float32 version is 2.4 times slower than on main

Both versions likely have room for optimization.

__Wormhole__
| Name | dtype | Cycles/Datum | Cycles/Tile |
| - | - | - | - |
| log (main) | bfloat16 | 1.32 | 1357 |
| log (new) | bfloat16 | 1.61 | 1646 |
| - | - | - | - |
| log (main) | float32 | 1.44 | 1477 |
| log (new) | float32 | 3.54 | 3589  |

### erfinv improvements

The log improvements and the refactoring of erfinv kernel improve erfinv quite significantly:

Its maximum error decreases by a factor of ~1000 and it is 'inaccurate' on a much smaller range. 

<img width="856" height="378" alt="erfinv-bfloat16" src="https://github.com/user-attachments/assets/4bcbd3ea-a307-4513-aed7-c174046fdf5d" />

Furthermore, the new erfinv is nearly x2 times faster: 

| Name | dtype | Cycles/Datum | Cycles/Tile |
| - | - | - | - |
| log (main) | bfloat16 |  10.8 | 11080 | 
| log (new) | bfloat16 | 5.47 | 5598 |


### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/19761299376
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/19761309772
- [x] L2 Nightly: [OK, failed on unrelated tests](https://github.com/tenstorrent/tt-metal/actions/runs/19761319478)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/19762996976
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/19763035505
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models). [OK, hangs unrelated](https://github.com/tenstorrent/tt-metal/actions/runs/19762991969)
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main) https://github.com/tenstorrent/tt-metal/actions/runs/19766289905
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release) https://github.com/tenstorrent/tt-metal/actions/runs/19766284732
- [x] New/Existing tests provide coverage for changes