### PR TITLE
#33386: Sort indices dtype fix.

### DIFF
--- a/tests/ttnn/unit_tests/operations/data_movement/test_sort.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_sort.py
@@ -76,7 +76,7 @@ def test_sort_prealocated_output(shape, dim, descending, device):
     torch_sort_values, torch_sort_indices = torch.sort(input, dim=dim, descending=descending)
 
     ttnn_sort_values = ttnn.zeros_like(ttnn_input)
-    ttnn_sort_indices = ttnn.zeros_like(ttnn_input)
+    ttnn_sort_indices = ttnn.zeros_like(ttnn_input, dtype=ttnn.uint16)
     ttnn.sort(ttnn_input, dim=dim, descending=descending, out=(ttnn_sort_values, ttnn_sort_indices))
 
     assert torch_sort_values.shape == ttnn_sort_values.shape

--- a/ttnn/cpp/ttnn/operations/data_movement/sort/sort.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sort/sort.cpp
@@ -135,18 +135,6 @@ bool validate_optional_output_tensors_for_early_exit(
     return output_tensor_0.logical_shape() == original_lshape && output_tensor_1.logical_shape() == original_lshape;
 }
 
-void convert_tensor_dtype(Tensor& tensor, const DataType& target_dtype, MeshDevice* device) {
-    if (tensor.dtype() == target_dtype) {
-        // No need to change the dtype
-        return;
-    }
-    // Convert the tensor to the target dtype
-    // ttnn::to_dtype does not convert the tensor on Device, need to move it to CPU first
-    tensor = tensor.cpu();  // blocking
-    tensor = ttnn::to_dtype(tensor, target_dtype);
-    tensor = tensor.to_device(device);
-}
-
 }  // namespace CMAKE_UNIQUE_NAMESPACE
 }  // namespace
 
@@ -188,11 +176,6 @@ std::vector<Tensor> ExecuteSort::invoke(
 
         output_tensors[1] = CMAKE_UNIQUE_NAMESPACE::pre_sort_transform_tensor(
             output_tensors[1].value(), dim, is_dim_last_idx, is_rank_le_4d, descending);
-
-        const auto target_index_dtype = DataType::UINT16;
-        CMAKE_UNIQUE_NAMESPACE::convert_tensor_dtype(
-            output_tensors[1].value(), target_index_dtype, input_tensor.device());
-
     } else {
         output_tensors = std::vector<std::optional<Tensor>>{
             std::nullopt,  // Placeholder for values tensor


### PR DESCRIPTION
### Ticket

#33386

### Problem description

When passing optional preallocated output tensors, the program only changed indices dtype to uint16.

### What's changed
- Removed 
- Updated test.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/19763443171