### PR TITLE
Use refiner for SDXL img2img demo

### DIFF
--- a/models/experimental/stable_diffusion_xl_base/demo/demo_img2img.py
+++ b/models/experimental/stable_diffusion_xl_base/demo/demo_img2img.py
@@ -9,14 +9,14 @@ import torch
 from diffusers import StableDiffusionXLImg2ImgPipeline
 from PIL import Image
 from loguru import logger
-from transformers import CLIPTextModelWithProjection, CLIPTextModel
+from transformers import CLIPTextModelWithProjection
 from models.experimental.stable_diffusion_xl_base.tests.test_common import (
     SDXL_L1_SMALL_SIZE,
     SDXL_TRACE_REGION_SIZE,
     SDXL_FABRIC_CONFIG,
     MAX_SEQUENCE_LENGTH,
     TEXT_ENCODER_2_PROJECTION_DIM,
-    CONCATENATED_TEXT_EMBEDINGS_SIZE,
+    CONCATENATED_TEXT_EMBEDINGS_SIZE_REFINER,
 )
 import os
 from models.common.utility_functions import profiler
@@ -78,14 +78,13 @@ def run_demo_inference(
     # 1. Load components
     profiler.start("diffusion_pipeline_from_pretrained")
     pipeline = StableDiffusionXLImg2ImgPipeline.from_pretrained(
-        "stabilityai/stable-diffusion-xl-base-1.0",
+        "stabilityai/stable-diffusion-xl-refiner-1.0",
         torch_dtype=torch.float32,
         use_safetensors=True,
         local_files_only=is_ci_env,
     ).to("cpu")
     profiler.end("diffusion_pipeline_from_pretrained")
 
-    assert isinstance(pipeline.text_encoder, CLIPTextModel), "pipeline.text_encoder is not a CLIPTextModel"
     assert isinstance(
         pipeline.text_encoder_2, CLIPTextModelWithProjection
     ), "pipeline.text_encoder_2 is not a CLIPTextModelWithProjection"
@@ -122,7 +121,9 @@ def run_demo_inference(
 
     tt_latents, tt_prompt_embeds, tt_add_text_embeds = tt_sdxl.generate_input_tensors(
         torch_image=torch.randn(batch_size, 3, 1024, 1024),
-        all_prompt_embeds_torch=torch.randn(batch_size, 2, MAX_SEQUENCE_LENGTH, CONCATENATED_TEXT_EMBEDINGS_SIZE),
+        all_prompt_embeds_torch=torch.randn(
+            batch_size, 2, MAX_SEQUENCE_LENGTH, CONCATENATED_TEXT_EMBEDINGS_SIZE_REFINER
+        ),
         torch_add_text_embeds=torch.randn(batch_size, 2, TEXT_ENCODER_2_PROJECTION_DIM),
         timesteps=timesteps,
         sigmas=sigmas,
@@ -262,11 +263,11 @@ def prepare_device(mesh_device, use_cfg_parallel):
 )
 @pytest.mark.parametrize(
     "num_inference_steps",
-    ((30),),
+    ((50),),
 )
 @pytest.mark.parametrize(
     "guidance_scale",
-    ((7.5),),
+    ((5.0),),
 )
 @pytest.mark.parametrize(
     "vae_on_device",
@@ -294,7 +295,7 @@ def prepare_device(mesh_device, use_cfg_parallel):
 )
 @pytest.mark.parametrize(
     "strength",
-    ((0.6),),
+    ((0.3),),
 )
 @pytest.mark.parametrize(
     "prompt_2, negative_prompt_2, crop_coords_top_left, guidance_rescale, timesteps, sigmas",

--- a/models/experimental/stable_diffusion_xl_base/tests/test_common.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/test_common.py
@@ -22,9 +22,9 @@ from models.experimental.stable_diffusion_xl_base.vae.tt.tt_autoencoder_kl impor
 # For basic SDXL demo, L1 small size of 23000 is enough,
 # but for inpainting/img2img, we need larger L1 small due
 # to having an extra VAE encode call, which increases it.
-# For simplicity, increase both to 29000 as there's enough
+# For simplicity, increase both to 30500 as there's enough
 # space left in base variant as well.
-SDXL_L1_SMALL_SIZE = 30000
+SDXL_L1_SMALL_SIZE = 30500
 SDXL_TRACE_REGION_SIZE = 34000000
 SDXL_BASE_REFINER_TRACE_REGION_SIZE = 51429376
 SDXL_CI_WEIGHTS_PATH = "/mnt/MLPerf/tt_dnn-models/hf_home"
@@ -32,6 +32,7 @@ SDXL_FABRIC_CONFIG = ttnn.FabricConfig.FABRIC_1D
 MAX_SEQUENCE_LENGTH = 77
 TEXT_ENCODER_2_PROJECTION_DIM = 1280
 CONCATENATED_TEXT_EMBEDINGS_SIZE = 2048  # text_encoder_1_hidden_size + text_encoder_2_hidden_size (768 + 1280)
+CONCATENATED_TEXT_EMBEDINGS_SIZE_REFINER = 1280
 
 
 def create_tt_clip_text_encoders(pipeline, ttnn_device):

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_sdxl_combined_pipeline.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_sdxl_combined_pipeline.py
@@ -19,6 +19,7 @@ from models.experimental.stable_diffusion_xl_base.tests.test_common import (
     MAX_SEQUENCE_LENGTH,
     TEXT_ENCODER_2_PROJECTION_DIM,
     CONCATENATED_TEXT_EMBEDINGS_SIZE,
+    CONCATENATED_TEXT_EMBEDINGS_SIZE_REFINER,
 )
 
 
@@ -279,7 +280,9 @@ class TtSDXLCombinedPipeline:
         if self.config.use_refiner:
             logger.info("Allocating device tensors for refiner pipeline...")
             dummy_latents = torch.randn(self.batch_size, 4, 128, 128)
-            refiner_dummy_embeds = torch.randn(self.batch_size, 2, MAX_SEQUENCE_LENGTH, 1280)
+            refiner_dummy_embeds = torch.randn(
+                self.batch_size, 2, MAX_SEQUENCE_LENGTH, CONCATENATED_TEXT_EMBEDINGS_SIZE_REFINER
+            )
 
             _, _, _ = self.refiner_pipeline.generate_input_tensors(
                 all_prompt_embeds_torch=refiner_dummy_embeds,
@@ -432,7 +435,9 @@ class TtSDXLCombinedPipeline:
                 refiner_prompt_embeds,
                 refiner_add_text_embeds,
             ) = self.refiner_pipeline.generate_input_tensors(
-                all_prompt_embeds_torch=torch.randn(self.batch_size, 2, MAX_SEQUENCE_LENGTH, 1280),
+                all_prompt_embeds_torch=torch.randn(
+                    self.batch_size, 2, MAX_SEQUENCE_LENGTH, CONCATENATED_TEXT_EMBEDINGS_SIZE_REFINER
+                ),
                 torch_add_text_embeds=torch_add_text_embeds,
                 torch_image=base_latents,
                 fixed_seed_for_batch=True,


### PR DESCRIPTION
### Ticket
#33333 

### Problem description
In the diffusers library, code examples use the refiners Unet to refine the input image for the image-to-image pipeline. Until now, only SDXL base UNet was used

### What's changed
Diffusers library has default `num_inference_steps` set to `50`, `guidance_scale` set to `5.0` and `strength` set to `0.3` and we now mirror that in our demo. `L1_SMALL` size increased to `30500`. Currently the image looks like this:

<img width="300" height="300" alt="image" src="https://github.com/user-attachments/assets/af6181f9-ab2f-4b0b-be97-222e0866c156" />

This should probably be investigated: I noticed that when `strength` parameter is set to `0.6`, the image turns out a bit weird and not like the one ran on nvidia:

<img width="300" height="300" alt="image" src="https://github.com/user-attachments/assets/8fc9e7d2-317d-4ad3-a3ff-6b8a3b3ce8ba" />


### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/19768027179) CI fails, same error on main, t3k fast tests
- [x] [L2 nightly](https://github.com/tenstorrent/tt-metal/actions/runs/19768041963) CI passes
- [x] [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/19768033387) CI passes