### PR TITLE
 #0: Fix Mochi jobs in Galaxy Demo and Galaxy Perf workflows

### DIFF
--- a/.github/workflows/galaxy-demo-tests-impl.yaml
+++ b/.github/workflows/galaxy-demo-tests-impl.yaml
@@ -84,6 +84,7 @@ jobs:
         timeout-minutes: ${{ matrix.test-group.timeout }}
         env:
           TT_DIT_CACHE_DIR: /tmp/TT_DIT_CACHE
+          NO_PROMPT: 1
         run: |
           pytest -n auto \
             models/experimental/tt_dit/tests/models/mochi/test_pipeline_mochi.py \

--- a/.github/workflows/galaxy-model-perf-tests-impl.yaml
+++ b/.github/workflows/galaxy-model-perf-tests-impl.yaml
@@ -135,7 +135,7 @@ jobs:
               "arch": "wormhole_b0",
               "save-perf-data": true,
               "timeout": 20,
-              "cmd": "export TT_DIT_CACHE_DIR=\"/tmp/TT_DIT_CACHE\" && pytest models/experimental/tt_dit/tests/models/mochi/test_performance_mochi.py -k \"4x8sp1tp0 and yes_use_cache\"",
+              "cmd": "export TT_DIT_CACHE_DIR=\"/tmp/TT_DIT_CACHE\" && export NO_PROMPT=1 && pytest models/experimental/tt_dit/tests/models/mochi/test_performance_mochi.py -k \"4x8sp1tp0 and yes_use_cache\"",
               "owner_id": "U09ELB03XRU"
             } # Stephen Osborne
           ]' --compact-output)


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description

As part of the change in how Galaxy Demo, Galaxy Model Perf workflows run in #32991 there was an environment variable that was missed. It was required for operation of Mochi tests.

### What's changed
Re-add the NO_PROMPT=1 variable to respective mochi jobs.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes