### PR TITLE
Add Int8 support to JIT compiler data format conversion

### DIFF
--- a/tt_metal/jit_build/data_format.cpp
+++ b/tt_metal/jit_build/data_format.cpp
@@ -235,6 +235,8 @@ DataFormat get_single_pack_src_format(
             pack_src_format = DataFormat::UInt16;
         } else if (data_format == DataFormat::UInt8) {
             pack_src_format = DataFormat::UInt8;
+        } else if (data_format == DataFormat::Int8) {
+            pack_src_format = DataFormat::Int8;
         } else {
             TT_THROW("No valid conversion from fp32 dest to output format = {}", data_format);
         }


### PR DESCRIPTION
This adds Int8 as a valid source format for packer conversion when using fp32 destination accumulator, enabling Int8 matmul operations.

### Ticket
No ticket

### Problem description
Needed for int8 matmul to work

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/19771686860
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes https://github.com/tenstorrent/tt-metal/actions/runs/19771688741