### PR TITLE
SDPA decode optimization: contiguous core groups within head/batch for sub core grids

### DIFF
--- a/models/demos/llama3_70b_galaxy/conftest.py
+++ b/models/demos/llama3_70b_galaxy/conftest.py
@@ -11,9 +11,9 @@ def ensure_gc():
     gc.collect()
 
 
-@pytest.fixture(autouse=True)
-def ensure_devices(ensure_devices_tg):
-    pass
+# @pytest.fixture(autouse=True)
+# def ensure_devices(ensure_devices_tg):
+#     pass
 
 
 @pytest.fixture

--- a/models/demos/llama3_70b_galaxy/tests/unit_tests/test_llama_ops.py
+++ b/models/demos/llama3_70b_galaxy/tests/unit_tests/test_llama_ops.py
@@ -166,10 +166,8 @@ def test_llama_tg_LayerNorm(
         (
             ttnn.CoreCoord(1, 0),
             ttnn.CoreRangeSet(
-                [
-                    ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(3, 9)),
-                    ttnn.CoreRange(ttnn.CoreCoord(5, 0), ttnn.CoreCoord(6, 9)),
-                ]
+                [ttnn.CoreRange(ttnn.CoreCoord(1, i), ttnn.CoreCoord(3, i)) for i in range(8)]
+                + [ttnn.CoreRange(ttnn.CoreCoord(5, i), ttnn.CoreCoord(5, i)) for i in range(8)]
             ),
         ),
     ],

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_scaled_dot_product_attention_decode.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_scaled_dot_product_attention_decode.py
@@ -964,9 +964,7 @@ def run_test_sdpa_decode_paged_attention_single_iter(
         compute_sub_core_grids = None
     else:
         shard_grid = ttnn.num_cores_to_corerangeset_in_subcoregrids(start_core, b, sub_core_grids, row_wise=True)
-        compute_sub_core_grids = ttnn.num_cores_to_corerangeset_in_subcoregrids(
-            start_core, grid_size[0] * grid_size[1], sub_core_grids, row_wise=True
-        )
+        compute_sub_core_grids = sub_core_grids
 
     shard_spec = ttnn.ShardSpec(shard_grid, (padded_num_heads, d), ttnn.ShardOrientation.ROW_MAJOR)
     height_sharded_memcfg = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, shard_spec)


### PR DESCRIPTION
### Problem description
Currently for each head group cores are not contiguous, which makes reasoning about performance very challenging and can introduce a lot of unnecessary NOC traffic, slowing down the time for online softmax correction. We group each head batch group of cores to be all in the same row within the sub core grid, the reducer is always at the largest x coordinate, so all cores send to the reducer to the right, traffic is much more predictable and does not interfere with other head groups.

### What's changed
- mentioned above

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes