### PR TITLE
#0: [skip ci] Re-add test_tt_fabric stability suite, and remove one case that's hanging. Sanity should be passing

### DIFF
--- a/.github/workflows/upstream-tests.yaml
+++ b/.github/workflows/upstream-tests.yaml
@@ -240,7 +240,7 @@ jobs:
         timeout-minutes: 10
         run: docker pull ${{ needs.get-image-tags.outputs.bh-glx-image-tag }}
       - name: Run image
-        timeout-minutes: 90
+        timeout-minutes: 65
         env:
           HF_MODEL: /mnt/MLPerf/tt_dnn-models/meta-llama/Llama-3.1-8B-Instruct
           TT_CACHE_PATH: /mnt/MLPerf/tt_dnn-models/meta-llama/Llama-3.1-8B-Instruct

--- a/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
+++ b/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
@@ -229,10 +229,9 @@ test_suite_bh_glx_metal_unit_tests() {
     ./build/tools/scaleout/run_cluster_validation --cabling-descriptor-path tools/tests/scaleout/cabling_descriptors/bh_galaxy_xy_torus.textproto --hard-fail --send-traffic
     RELIABILITY_MODE=relaxed ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="*Fabric2D*.*"
     RELIABILITY_MODE=relaxed ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="*Fabric1D*.*":-NightlyFabric1DFixture.TestEDMConnectionStressTestQuick
-    # RELIABILITY_MODE=relaxed TT_METAL_CLEAR_L1=1 build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_sanity_common.yaml
+    RELIABILITY_MODE=relaxed TT_METAL_CLEAR_L1=1 build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_sanity_common.yaml
     # Disable 2 ERISC mode for deadlock stability tests - These validate 2D Torus (QSFP Link) stability
-    # Let's see if disabling this helps
-    # TT_METAL_DISABLE_FABRIC_TWO_ERISC=1 RELIABILITY_MODE=relaxed TT_METAL_CLEAR_L1=1  build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_deadlock_stability_bh_6U_galaxy.yaml
+    TT_METAL_DISABLE_FABRIC_TWO_ERISC=1 RELIABILITY_MODE=relaxed TT_METAL_CLEAR_L1=1  build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_deadlock_stability_bh_6U_galaxy.yaml
 
     # Dispatch
     build/test/tt_metal/unit_tests_eth --gtest_filter=UnitMeshCQMultiDeviceProgramFixture.ActiveEthKernelsSendInterleavedBufferAllConnectedChips

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_deadlock_stability_bh_6U_galaxy.yaml
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_deadlock_stability_bh_6U_galaxy.yaml
@@ -127,20 +127,20 @@ Tests:
 # ================================================
 # 2D Torus (Y)
 # ================================================
-  - name: UnicastAlltoAll
-    fabric_setup:
-      topology: Torus
-      torus_config: Y
-      num_links: 2
+  # - name: UnicastAlltoAll
+  #   fabric_setup:
+  #     topology: Torus
+  #     torus_config: Y
+  #     num_links: 2
 
-    parametrization_params:
-      size: [256, 512, 1024]
-      num_packets: [2000]
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
-    defaults:
-      ftype: unicast
-    patterns:
-      - type: all_to_all
+  #   parametrization_params:
+  #     size: [256, 512, 1024]
+  #     num_packets: [2000]
+  #     ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
+  #   defaults:
+  #     ftype: unicast
+  #   patterns:
+  #     - type: all_to_all
 # ================================================
 # 2D Torus (XY) (low latency)
 # ================================================

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_deadlock_stability_bh_6U_galaxy.yaml
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_deadlock_stability_bh_6U_galaxy.yaml
@@ -127,6 +127,7 @@ Tests:
 # ================================================
 # 2D Torus (Y)
 # ================================================
+# Hangs: https://github.com/tenstorrent/tt-metal/issues/33456
   # - name: UnicastAlltoAll
   #   fabric_setup:
   #     topology: Torus


### PR DESCRIPTION
…
### Ticket

https://github.com/tenstorrent/tt-metal/issues/33456

And Aditya re-read my work, no need to disable all those tests

### Problem description

Disable one case for perf microbenchmark

### What's changed

Re-enable other tests and disable one bad hanging case.

### Checklist
- [ ] upstream https://github.com/tenstorrent/tt-metal/actions/runs/19807372370
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes