### PR TITLE
Temporary removal of falcon7b from device perf test

### DIFF
--- a/.github/workflows/perf-device-models-impl.yaml
+++ b/.github/workflows/perf-device-models-impl.yaml
@@ -180,7 +180,8 @@ jobs:
           device_perf_model_name: "non-civ2_tests"
           commands: |
             pytest models/demos/mnist/tests -m models_device_performance_bare_metal
-            pytest models/demos/falcon7b_common/tests -m models_device_performance_bare_metal
+            # TODO: return this once issue https://github.com/tenstorrent/tt-metal/issues/33467 is resolved
+            # pytest models/demos/falcon7b_common/tests -m models_device_performance_bare_metal
             pytest models/demos/segformer/tests/perf -m models_device_performance_bare_metal
         if: ${{ !cancelled() && !matrix.test-info.civ2-compatible && fromJSON(needs.define-models.outputs.models-to-run)['non-civ2'] }}
         timeout-minutes: ${{ matrix.test-info.timeout }}


### PR DESCRIPTION
### Problem description
Falcon7b fails in device perf due to PCC assert
https://github.com/tenstorrent/tt-metal/actions/runs/19814356970/job/56762900856#step:5:2644

### What's changed
- Commented the test out until said issue #33467 is resolved

### Checklist
- [X] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/19817729385/job/56773226830)