### PR TITLE
#31054: Add uint32 LLK APIs for unary comp ops 

### DIFF
--- a/tests/ttnn/unit_tests/gtests/CMakeLists.txt
+++ b/tests/ttnn/unit_tests/gtests/CMakeLists.txt
@@ -64,6 +64,7 @@ target_sources(
         test_launch_operation.cpp # TODO: Fix data race (TSan) then shift-left
         test_matmul_benchmark.cpp
         test_relational_int.cpp
+        test_relational_uint.cpp
         test_rsub_int.cpp
         test_sub_int.cpp
 )

--- a/tests/ttnn/unit_tests/gtests/test_relational_uint.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_relational_uint.cpp
@@ -1,0 +1,217 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <fmt/base.h>
+#include <gtest/gtest.h>
+#include <stdint.h>
+#include <array>
+#include <memory>
+#include <optional>
+#include <iostream>
+
+#include <tt_stl/assert.hpp>
+#include <tt-metalium/bfloat16.hpp>
+#include <tt-metalium/shape.hpp>
+#include "ttnn/decorators.hpp"
+#include "ttnn/device.hpp"
+#include "ttnn/operations/core/core.hpp"
+#include "ttnn/operations/creation.hpp"
+#include "ttnn/operations/eltwise/unary/unary.hpp"
+#include "ttnn/operations/functions.hpp"
+#include "ttnn/tensor/shape/shape.hpp"
+#include "ttnn/tensor/types.hpp"
+#include "ttnn/types.hpp"
+#include "ttnn_test_fixtures.hpp"
+#include "ttnn/tensor/to_string.hpp"
+
+namespace ttnn::operations::unary::test {
+
+struct RelationalUnaryU32Param {
+    uint32_t scalar_input;
+    uint32_t scalar_param;
+    uint32_t h;
+    uint32_t w;
+};
+
+class RelationalUnaryU32Fixture : public TTNNFixtureWithDevice,
+                                  public testing::WithParamInterface<RelationalUnaryU32Param> {};
+
+static ttnn::Tensor make_uint_tensor(ttnn::MeshDevice& device, uint32_t h, uint32_t w, uint32_t fill_value) {
+    std::array<uint32_t, 2> dimensions = {h, w};
+    ttnn::Shape shape(dimensions);
+    constexpr DataType dtype = DataType::UINT32;
+    auto zero_tensor = ttnn::zeros(shape, dtype, ttnn::TILE_LAYOUT, device);
+    return ttnn::fill(zero_tensor, fill_value);
+}
+
+TEST_P(RelationalUnaryU32Fixture, EqUnaryMatchesExpected) {
+    auto p = GetParam();
+    auto& device = *device_;
+    auto input_tensor = make_uint_tensor(device, p.h, p.w, p.scalar_input);
+    auto output = ttnn::eq_unary(input_tensor, p.scalar_param);
+
+    uint32_t expected_value = (p.scalar_input == p.scalar_param) ? 1u : 0u;
+    std::array<uint32_t, 2> dims = {p.h, p.w};
+    ttnn::Shape shape(dims);
+    auto expected = make_uint_tensor(device, p.h, p.w, expected_value);
+
+    auto expected_host = ttnn::from_device(expected);
+    auto output_host = ttnn::from_device(output);
+    std::cout << "op_name\t: eq_unary (uint32)\n";
+    std::cout << "scalar_input\t: " << p.scalar_input << "\n";
+    std::cout << ttnn::to_string(input_tensor);
+    std::cout << "scalar_param\t: " << p.scalar_param << "\n";
+    std::cout << "actual output:" << std::endl;
+    // output.print();
+    std::cout << ttnn::to_string(output);
+    std::cout << "\nexpected output:" << std::endl;
+    // expected.print();
+    std::cout << ttnn::to_string(expected);
+    TT_FATAL(ttnn::allclose<uint32_t>(expected_host, output_host), "eq_unary uint32 result mismatch");
+}
+
+TEST_P(RelationalUnaryU32Fixture, NeUnaryMatchesExpected) {
+    auto p = GetParam();
+    auto& device = *device_;
+    auto input_tensor = make_uint_tensor(device, p.h, p.w, p.scalar_input);
+    auto output = ttnn::ne_unary(input_tensor, p.scalar_param);
+
+    uint32_t expected_value = (p.scalar_input != p.scalar_param) ? 1u : 0u;
+    std::array<uint32_t, 2> dims = {p.h, p.w};
+    ttnn::Shape shape(dims);
+    auto expected = make_uint_tensor(device, p.h, p.w, expected_value);
+
+    auto expected_host = ttnn::from_device(expected);
+    auto output_host = ttnn::from_device(output);
+    std::cout << "op_name\t: ne_unary (uint32)\n";
+    std::cout << "scalar_input\t: " << p.scalar_input << "\n";
+    std::cout << ttnn::to_string(input_tensor);
+    std::cout << "scalar_param\t: " << p.scalar_param << "\n";
+    std::cout << "actual output:" << std::endl;
+    // output.print();
+    std::cout << ttnn::to_string(output);
+    std::cout << "\nexpected output:" << std::endl;
+    // expected.print();
+    std::cout << ttnn::to_string(expected);
+    TT_FATAL(ttnn::allclose<uint32_t>(expected_host, output_host), "ne_unary uint32 result mismatch");
+}
+
+TEST_P(RelationalUnaryU32Fixture, GtUnaryMatchesExpected) {
+    auto p = GetParam();
+    auto& device = *device_;
+    auto input_tensor = make_uint_tensor(device, p.h, p.w, p.scalar_input);
+    auto output = ttnn::gt_unary(input_tensor, p.scalar_param);
+
+    uint32_t expected_value = (p.scalar_input > p.scalar_param) ? 1u : 0u;
+    std::array<uint32_t, 2> dims = {p.h, p.w};
+    ttnn::Shape shape(dims);
+    auto expected = make_uint_tensor(device, p.h, p.w, expected_value);
+
+    auto expected_host = ttnn::from_device(expected);
+    auto output_host = ttnn::from_device(output);
+    std::cout << "op_name\t: gt_unary (uint32)\n";
+    std::cout << "scalar_input\t: " << p.scalar_input << "\n";
+    std::cout << ttnn::to_string(input_tensor);
+    std::cout << "scalar_param\t: " << p.scalar_param << "\n";
+    std::cout << "actual output:" << std::endl;
+    // output.print();
+    std::cout << ttnn::to_string(output);
+    std::cout << "\nexpected output:" << std::endl;
+    // expected.print();
+    std::cout << ttnn::to_string(expected);
+    TT_FATAL(ttnn::allclose<uint32_t>(expected_host, output_host), "gt_unary uint32 result mismatch");
+}
+
+TEST_P(RelationalUnaryU32Fixture, LtUnaryMatchesExpected) {
+    auto p = GetParam();
+    auto& device = *device_;
+    auto input_tensor = make_uint_tensor(device, p.h, p.w, p.scalar_input);
+    auto output = ttnn::lt_unary(input_tensor, p.scalar_param);
+
+    uint32_t expected_value = (p.scalar_input < p.scalar_param) ? 1u : 0u;
+    std::array<uint32_t, 2> dims = {p.h, p.w};
+    ttnn::Shape shape(dims);
+    auto expected = make_uint_tensor(device, p.h, p.w, expected_value);
+
+    auto expected_host = ttnn::from_device(expected);
+    auto output_host = ttnn::from_device(output);
+    std::cout << "op_name\t: lt_unary (uint32)\n";
+    std::cout << "scalar_input\t: " << p.scalar_input << "\n";
+    std::cout << ttnn::to_string(input_tensor);
+    std::cout << "scalar_param\t: " << p.scalar_param << "\n";
+    std::cout << "actual output:" << std::endl;
+    //  output.print();
+    std::cout << ttnn::to_string(output);
+    std::cout << "\nexpected output:" << std::endl;
+    // expected.print();
+    std::cout << ttnn::to_string(expected);
+    TT_FATAL(ttnn::allclose<uint32_t>(expected_host, output_host), "lt_unary uint32 result mismatch");
+}
+
+TEST_P(RelationalUnaryU32Fixture, GeUnaryMatchesExpected) {
+    auto p = GetParam();
+    auto& device = *device_;
+    auto input_tensor = make_uint_tensor(device, p.h, p.w, p.scalar_input);
+    auto output = ttnn::ge_unary(input_tensor, p.scalar_param);
+
+    uint32_t expected_value = (p.scalar_input >= p.scalar_param) ? 1u : 0u;
+    std::array<uint32_t, 2> dims = {p.h, p.w};
+    ttnn::Shape shape(dims);
+    auto expected = make_uint_tensor(device, p.h, p.w, expected_value);
+
+    auto expected_host = ttnn::from_device(expected);
+    auto output_host = ttnn::from_device(output);
+    std::cout << "op_name\t: ge_unary (uint32)\n";
+    std::cout << "scalar_input\t: " << p.scalar_input << "\n";
+    std::cout << ttnn::to_string(input_tensor);
+    std::cout << "scalar_param\t: " << p.scalar_param << "\n";
+    std::cout << "actual output:" << std::endl;
+    // output.print();
+    std::cout << ttnn::to_string(output);
+    std::cout << "\nexpected output:" << std::endl;
+    // expected.print();
+    std::cout << ttnn::to_string(expected);
+    TT_FATAL(ttnn::allclose<uint32_t>(expected_host, output_host), "ge_unary uint32 result mismatch");
+}
+
+TEST_P(RelationalUnaryU32Fixture, LeUnaryMatchesExpected) {
+    auto p = GetParam();
+    auto& device = *device_;
+    auto input_tensor = make_uint_tensor(device, p.h, p.w, p.scalar_input);
+    auto output = ttnn::le_unary(input_tensor, p.scalar_param);
+
+    uint32_t expected_value = (p.scalar_input <= p.scalar_param) ? 1u : 0u;
+    std::array<uint32_t, 2> dims = {p.h, p.w};
+    ttnn::Shape shape(dims);
+    auto expected = make_uint_tensor(device, p.h, p.w, expected_value);
+
+    auto expected_host = ttnn::from_device(expected);
+    auto output_host = ttnn::from_device(output);
+    std::cout << "op_name\t: le_unary (uint32)\n";
+    std::cout << "scalar_input\t: " << p.scalar_input << "\n";
+    std::cout << ttnn::to_string(input_tensor);
+    std::cout << "scalar_param\t: " << p.scalar_param << "\n";
+    std::cout << "actual output:" << std::endl;
+    // output.print();
+    std::cout << ttnn::to_string(output);
+    std::cout << "\nexpected output:" << std::endl;
+    // expected.print();
+    std::cout << ttnn::to_string(expected);
+    TT_FATAL(ttnn::allclose<uint32_t>(expected_host, output_host), "le_unary uint32 result mismatch");
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    RelationalUnaryU32Tests,
+    RelationalUnaryU32Fixture,
+    ::testing::Values(
+        RelationalUnaryU32Param{0u, 0u, 128, 32},       // eq at zero
+        RelationalUnaryU32Param{1u, 0u, 128, 32},       // gt, ne
+        RelationalUnaryU32Param{0u, 1u, 64, 64},        // lt, ne, le
+        RelationalUnaryU32Param{42u, 42u, 32, 32},      // eq
+        RelationalUnaryU32Param{100u, 458u, 128, 128},  // lt, ne, le
+        RelationalUnaryU32Param{564u, 118u, 64, 128},   // gt, ge, ne
+        RelationalUnaryU32Param{2147483645u, 2147483647u, 32, 32},
+        RelationalUnaryU32Param{2147483647u, 0u, 8, 8}));
+
+}  // namespace ttnn::operations::unary::test

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_comp.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_comp.h
@@ -12,110 +12,148 @@
 namespace ckernel {
 namespace sfpu {
 
-template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_unary_ne(uint value) {
-    // SFPU microcode
-    sfpi::vFloat s = Converter::as_float(value);
+// template <bool APPROXIMATION_MODE, int ITERATIONS>
+// inline void calculate_unary_ne(uint value) {
+//     // SFPU microcode
+//     sfpi::vFloat s = Converter::as_float(value);
 
+// #pragma GCC unroll 8
+//     for (int d = 0; d < ITERATIONS; d++) {
+//         sfpi::vFloat v = sfpi::dst_reg[0];
+//         v_if(v == s) { v = 0.0f; }
+//         v_else { v = 1.0f; }
+//         v_endif;
+
+//         sfpi::dst_reg[0] = v;
+
+//         sfpi::dst_reg++;
+//     }
+// }
+
+// template <bool APPROXIMATION_MODE, int ITERATIONS>
+// inline void calculate_unary_eq(uint value) {
+//     // SFPU microcode
+//     sfpi::vFloat s = Converter::as_float(value);
+
+// #pragma GCC unroll 8
+//     for (int d = 0; d < ITERATIONS; d++) {
+//         sfpi::vFloat v = sfpi::dst_reg[0];
+//         v_if(v == s) { v = 1.0f; }
+//         v_else { v = 0.0f; }
+//         v_endif;
+
+//         sfpi::dst_reg[0] = v;
+
+//         sfpi::dst_reg++;
+//     }
+// }
+
+// template <bool APPROXIMATION_MODE, int ITERATIONS>
+// inline void calculate_unary_gt(uint value) {
+//     // SFPU microcode
+//     sfpi::vFloat s = Converter::as_float(value);
+
+// #pragma GCC unroll 8
+//     for (int d = 0; d < ITERATIONS; d++) {
+//         sfpi::vFloat v = sfpi::dst_reg[0];
+//         v_if(v > s) { v = 1.0f; }
+//         v_else { v = 0.0f; }
+//         v_endif;
+
+//         sfpi::dst_reg[0] = v;
+
+//         sfpi::dst_reg++;
+//     }
+// }
+
+// template <bool APPROXIMATION_MODE, int ITERATIONS>
+// inline void calculate_unary_lt(uint value) {
+//     // SFPU microcode
+//     sfpi::vFloat s = Converter::as_float(value);
+
+// #pragma GCC unroll 8
+//     for (int d = 0; d < ITERATIONS; d++) {
+//         sfpi::vFloat v = sfpi::dst_reg[0];
+//         v_if(v < s) { v = 1.0f; }
+//         v_else { v = 0.0f; }
+//         v_endif;
+
+//         sfpi::dst_reg[0] = v;
+
+//         sfpi::dst_reg++;
+//     }
+// }
+
+// template <bool APPROXIMATION_MODE, int ITERATIONS>
+// inline void calculate_unary_ge(uint value) {
+//     // SFPU microcode
+//     sfpi::vFloat s = Converter::as_float(value);
+
+// #pragma GCC unroll 8
+//     for (int d = 0; d < ITERATIONS; d++) {
+//         sfpi::vFloat v = sfpi::dst_reg[0];
+//         v_if(v < s) { v = 0.0f; }
+//         v_else { v = 1.0f; }
+//         v_endif;
+
+//         sfpi::dst_reg[0] = v;
+
+//         sfpi::dst_reg++;
+//     }
+// }
+
+// template <bool APPROXIMATION_MODE, int ITERATIONS>
+// inline void calculate_unary_le(uint value) {
+//     // SFPU microcode
+//     sfpi::vFloat s = Converter::as_float(value);
+
+// #pragma GCC unroll 8
+//     for (int d = 0; d < ITERATIONS; d++) {
+//         sfpi::vFloat v = sfpi::dst_reg[0];
+//         v_if(v > s) { v = 0.0f; }
+//         v_else { v = 1.0f; }
+//         v_endif;
+
+//         sfpi::dst_reg[0] = v;
+
+//         sfpi::dst_reg++;
+//     }
+// }
+
+template <bool APPROXIMATION_MODE, SfpuType COMP_MODE, int ITERATIONS = 8>
+inline void calculate_unary_comparison(uint value) {
+    sfpi::vFloat scalar = Converter::as_float(value);
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
-        sfpi::vFloat v = sfpi::dst_reg[0];
-        v_if(v == s) { v = 0.0f; }
-        v_else { v = 1.0f; }
-        v_endif;
+        sfpi::vFloat in = sfpi::dst_reg[0];
 
-        sfpi::dst_reg[0] = v;
+        if constexpr (COMP_MODE == SfpuType::unary_ne) {
+            v_if(in == scalar) { in = sfpi::vConst0; }
+            v_else { in = sfpi::vConst1; }
+            v_endif;
+        } else if constexpr (COMP_MODE == SfpuType::unary_eq) {
+            v_if(in == scalar) { in = sfpi::vConst1; }
+            v_else { in = sfpi::vConst0; }
+            v_endif;
+        } else if constexpr (COMP_MODE == SfpuType::unary_gt) {
+            v_if(in > scalar) { in = sfpi::vConst1; }
+            v_else { in = sfpi::vConst0; }
+            v_endif;
+        } else if constexpr (COMP_MODE == SfpuType::unary_lt) {
+            v_if(in < scalar) { in = sfpi::vConst1; }
+            v_else { in = sfpi::vConst0; }
+            v_endif;
+        } else if constexpr (COMP_MODE == SfpuType::unary_ge) {
+            v_if(in < scalar) { in = sfpi::vConst0; }
+            v_else { in = sfpi::vConst1; }
+            v_endif;
+        } else if constexpr (COMP_MODE == SfpuType::unary_le) {
+            v_if(in > scalar) { in = sfpi::vConst0; }
+            v_else { in = sfpi::vConst1; }
+            v_endif;
+        }
 
-        sfpi::dst_reg++;
-    }
-}
-
-template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_unary_eq(uint value) {
-    // SFPU microcode
-    sfpi::vFloat s = Converter::as_float(value);
-
-#pragma GCC unroll 8
-    for (int d = 0; d < ITERATIONS; d++) {
-        sfpi::vFloat v = sfpi::dst_reg[0];
-        v_if(v == s) { v = 1.0f; }
-        v_else { v = 0.0f; }
-        v_endif;
-
-        sfpi::dst_reg[0] = v;
-
-        sfpi::dst_reg++;
-    }
-}
-
-template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_unary_gt(uint value) {
-    // SFPU microcode
-    sfpi::vFloat s = Converter::as_float(value);
-
-#pragma GCC unroll 8
-    for (int d = 0; d < ITERATIONS; d++) {
-        sfpi::vFloat v = sfpi::dst_reg[0];
-        v_if(v > s) { v = 1.0f; }
-        v_else { v = 0.0f; }
-        v_endif;
-
-        sfpi::dst_reg[0] = v;
-
-        sfpi::dst_reg++;
-    }
-}
-
-template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_unary_lt(uint value) {
-    // SFPU microcode
-    sfpi::vFloat s = Converter::as_float(value);
-
-#pragma GCC unroll 8
-    for (int d = 0; d < ITERATIONS; d++) {
-        sfpi::vFloat v = sfpi::dst_reg[0];
-        v_if(v < s) { v = 1.0f; }
-        v_else { v = 0.0f; }
-        v_endif;
-
-        sfpi::dst_reg[0] = v;
-
-        sfpi::dst_reg++;
-    }
-}
-
-template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_unary_ge(uint value) {
-    // SFPU microcode
-    sfpi::vFloat s = Converter::as_float(value);
-
-#pragma GCC unroll 8
-    for (int d = 0; d < ITERATIONS; d++) {
-        sfpi::vFloat v = sfpi::dst_reg[0];
-        v_if(v < s) { v = 0.0f; }
-        v_else { v = 1.0f; }
-        v_endif;
-
-        sfpi::dst_reg[0] = v;
-
-        sfpi::dst_reg++;
-    }
-}
-
-template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_unary_le(uint value) {
-    // SFPU microcode
-    sfpi::vFloat s = Converter::as_float(value);
-
-#pragma GCC unroll 8
-    for (int d = 0; d < ITERATIONS; d++) {
-        sfpi::vFloat v = sfpi::dst_reg[0];
-        v_if(v > s) { v = 0.0f; }
-        v_else { v = 1.0f; }
-        v_endif;
-
-        sfpi::dst_reg[0] = v;
-
+        sfpi::dst_reg[0] = in;
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_comp.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_comp.h
@@ -158,5 +158,45 @@ inline void calculate_unary_comparison(uint value) {
     }
 }
 
+template <bool APPROXIMATION_MODE, SfpuType COMP_MODE, int ITERATIONS = 8>
+inline void calculate_unary_comparison_uint(uint value) {
+    sfpi::vUInt scalar = value;
+    sfpi::vUInt one = 1u;
+    sfpi::vUInt zero = 0u;
+#pragma GCC unroll 8
+    for (int d = 0; d < ITERATIONS; d++) {
+        sfpi::vUInt in = sfpi::dst_reg[0];
+
+        if constexpr (COMP_MODE == SfpuType::unary_ne) {
+            v_if(in == scalar) { in = zero; }
+            v_else { in = one; }
+            v_endif;
+        } else if constexpr (COMP_MODE == SfpuType::unary_eq) {
+            v_if(in == scalar) { in = one; }
+            v_else { in = zero; }
+            v_endif;
+        } else if constexpr (COMP_MODE == SfpuType::unary_gt) {
+            v_if(in > scalar) { in = one; }
+            v_else { in = 0u; }
+            v_endif;
+        } else if constexpr (COMP_MODE == SfpuType::unary_lt) {
+            v_if(in < scalar) { in = one; }
+            v_else { in = zero; }
+            v_endif;
+        } else if constexpr (COMP_MODE == SfpuType::unary_ge) {
+            v_if(in < scalar) { in = zero; }
+            v_else { in = one; }
+            v_endif;
+        } else if constexpr (COMP_MODE == SfpuType::unary_le) {
+            v_if(in > scalar) { in = zero; }
+            v_else { in = one; }
+            v_endif;
+        }
+
+        sfpi::dst_reg[0] = in;
+        sfpi::dst_reg++;
+    }
+}
+
 }  // namespace sfpu
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_unary_comp.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_unary_comp.h
@@ -29,7 +29,10 @@ inline void llk_math_eltwise_unary_sfpu_unary_ne_int32(
 template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_unary_ne(uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_unary_ne<APPROXIMATE, ITERATIONS>, dst_index, vector_mode, param0);
+        ckernel::sfpu::calculate_unary_comparison<APPROXIMATE, SfpuType::unary_ne, ITERATIONS>,
+        dst_index,
+        vector_mode,
+        param0);
 }
 
 // Unary equal
@@ -51,7 +54,10 @@ inline void llk_math_eltwise_unary_sfpu_unary_eq_int32(
 template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_unary_eq(uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_unary_eq<APPROXIMATE, ITERATIONS>, dst_index, vector_mode, param0);
+        ckernel::sfpu::calculate_unary_comparison<APPROXIMATE, SfpuType::unary_eq, ITERATIONS>,
+        dst_index,
+        vector_mode,
+        param0);
 }
 
 // Unary greater than
@@ -73,7 +79,10 @@ inline void llk_math_eltwise_unary_sfpu_unary_gt_int32(
 template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_unary_gt(uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_unary_gt<APPROXIMATE, ITERATIONS>, dst_index, vector_mode, param0);
+        ckernel::sfpu::calculate_unary_comparison<APPROXIMATE, SfpuType::unary_gt, ITERATIONS>,
+        dst_index,
+        vector_mode,
+        param0);
 }
 
 // Unary lesser than
@@ -95,7 +104,10 @@ inline void llk_math_eltwise_unary_sfpu_unary_lt_int32(
 template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_unary_lt(uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_unary_lt<APPROXIMATE, ITERATIONS>, dst_index, vector_mode, param0);
+        ckernel::sfpu::calculate_unary_comparison<APPROXIMATE, SfpuType::unary_lt, ITERATIONS>,
+        dst_index,
+        vector_mode,
+        param0);
 }
 
 // Unary greater than or equal to
@@ -117,7 +129,10 @@ inline void llk_math_eltwise_unary_sfpu_unary_ge_int32(
 template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_unary_ge(uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_unary_ge<APPROXIMATE, ITERATIONS>, dst_index, vector_mode, param0);
+        ckernel::sfpu::calculate_unary_comparison<APPROXIMATE, SfpuType::unary_ge, ITERATIONS>,
+        dst_index,
+        vector_mode,
+        param0);
 }
 
 // Unary lesser than or equal to
@@ -139,6 +154,9 @@ inline void llk_math_eltwise_unary_sfpu_unary_le_int32(
 template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_unary_le(uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_unary_le<APPROXIMATE, ITERATIONS>, dst_index, vector_mode, param0);
+        ckernel::sfpu::calculate_unary_comparison<APPROXIMATE, SfpuType::unary_le, ITERATIONS>,
+        dst_index,
+        vector_mode,
+        param0);
 }
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_unary_comp.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_unary_comp.h
@@ -34,6 +34,15 @@ inline void llk_math_eltwise_unary_sfpu_unary_ne(uint dst_index, uint param0, in
         vector_mode,
         param0);
 }
+template <bool APPROXIMATE, int ITERATIONS = 8>
+inline void llk_math_eltwise_unary_sfpu_unary_ne_uint32(
+    uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        ckernel::sfpu::calculate_unary_comparison_uint<APPROXIMATE, SfpuType::unary_ne, ITERATIONS>,
+        dst_index,
+        vector_mode,
+        param0);
+}
 
 // Unary equal
 template <bool APPROXIMATE>
@@ -55,6 +64,15 @@ template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_unary_eq(uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
         ckernel::sfpu::calculate_unary_comparison<APPROXIMATE, SfpuType::unary_eq, ITERATIONS>,
+        dst_index,
+        vector_mode,
+        param0);
+}
+template <bool APPROXIMATE, int ITERATIONS = 8>
+inline void llk_math_eltwise_unary_sfpu_unary_eq_uint32(
+    uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        ckernel::sfpu::calculate_unary_comparison_uint<APPROXIMATE, SfpuType::unary_eq, ITERATIONS>,
         dst_index,
         vector_mode,
         param0);
@@ -84,7 +102,15 @@ inline void llk_math_eltwise_unary_sfpu_unary_gt(uint dst_index, uint param0, in
         vector_mode,
         param0);
 }
-
+template <bool APPROXIMATE, int ITERATIONS = 8>
+inline void llk_math_eltwise_unary_sfpu_unary_gt_uint32(
+    uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        ckernel::sfpu::calculate_unary_comparison_uint<APPROXIMATE, SfpuType::unary_gt, ITERATIONS>,
+        dst_index,
+        vector_mode,
+        param0);
+}
 // Unary lesser than
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_unary_lt_init() {
@@ -109,7 +135,15 @@ inline void llk_math_eltwise_unary_sfpu_unary_lt(uint dst_index, uint param0, in
         vector_mode,
         param0);
 }
-
+template <bool APPROXIMATE, int ITERATIONS = 8>
+inline void llk_math_eltwise_unary_sfpu_unary_lt_uint32(
+    uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        ckernel::sfpu::calculate_unary_comparison_uint<APPROXIMATE, SfpuType::unary_lt, ITERATIONS>,
+        dst_index,
+        vector_mode,
+        param0);
+}
 // Unary greater than or equal to
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_unary_ge_init() {
@@ -134,7 +168,15 @@ inline void llk_math_eltwise_unary_sfpu_unary_ge(uint dst_index, uint param0, in
         vector_mode,
         param0);
 }
-
+template <bool APPROXIMATE, int ITERATIONS = 8>
+inline void llk_math_eltwise_unary_sfpu_unary_ge_uint32(
+    uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        ckernel::sfpu::calculate_unary_comparison_uint<APPROXIMATE, SfpuType::unary_ge, ITERATIONS>,
+        dst_index,
+        vector_mode,
+        param0);
+}
 // Unary lesser than or equal to
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_unary_le_init() {
@@ -155,6 +197,15 @@ template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_unary_le(uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
         ckernel::sfpu::calculate_unary_comparison<APPROXIMATE, SfpuType::unary_le, ITERATIONS>,
+        dst_index,
+        vector_mode,
+        param0);
+}
+template <bool APPROXIMATE, int ITERATIONS = 8>
+inline void llk_math_eltwise_unary_sfpu_unary_le_uint32(
+    uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        ckernel::sfpu::calculate_unary_comparison_uint<APPROXIMATE, SfpuType::unary_le, ITERATIONS>,
         dst_index,
         vector_mode,
         param0);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_comp.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_comp.h
@@ -12,110 +12,148 @@
 namespace ckernel {
 namespace sfpu {
 
-template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_unary_ne(uint value) {
-    // SFPU microcode
-    sfpi::vFloat s = Converter::as_float(value);
+// template <bool APPROXIMATION_MODE, int ITERATIONS>
+// inline void calculate_unary_ne(uint value) {
+//     // SFPU microcode
+//     sfpi::vFloat s = Converter::as_float(value);
 
+// #pragma GCC unroll 8
+//     for (int d = 0; d < ITERATIONS; d++) {
+//         sfpi::vFloat v = sfpi::dst_reg[0];
+//         v_if(v == s) { v = 0.0f; }
+//         v_else { v = 1.0f; }
+//         v_endif;
+
+//         sfpi::dst_reg[0] = v;
+
+//         sfpi::dst_reg++;
+//     }
+// }
+
+// template <bool APPROXIMATION_MODE, int ITERATIONS>
+// inline void calculate_unary_eq(uint value) {
+//     // SFPU microcode
+//     sfpi::vFloat s = Converter::as_float(value);
+
+// #pragma GCC unroll 8
+//     for (int d = 0; d < ITERATIONS; d++) {
+//         sfpi::vFloat v = sfpi::dst_reg[0];
+//         v_if(v == s) { v = 1.0f; }
+//         v_else { v = 0.0f; }
+//         v_endif;
+
+//         sfpi::dst_reg[0] = v;
+
+//         sfpi::dst_reg++;
+//     }
+// }
+
+// template <bool APPROXIMATION_MODE, int ITERATIONS>
+// inline void calculate_unary_gt(uint value) {
+//     // SFPU microcode
+//     sfpi::vFloat s = Converter::as_float(value);
+
+// #pragma GCC unroll 8
+//     for (int d = 0; d < ITERATIONS; d++) {
+//         sfpi::vFloat v = sfpi::dst_reg[0];
+//         v_if(v > s) { v = 1.0f; }
+//         v_else { v = 0.0f; }
+//         v_endif;
+
+//         sfpi::dst_reg[0] = v;
+
+//         sfpi::dst_reg++;
+//     }
+// }
+
+// template <bool APPROXIMATION_MODE, int ITERATIONS>
+// inline void calculate_unary_lt(uint value) {
+//     // SFPU microcode
+//     sfpi::vFloat s = Converter::as_float(value);
+
+// #pragma GCC unroll 8
+//     for (int d = 0; d < ITERATIONS; d++) {
+//         sfpi::vFloat v = sfpi::dst_reg[0];
+//         v_if(v < s) { v = 1.0f; }
+//         v_else { v = 0.0f; }
+//         v_endif;
+
+//         sfpi::dst_reg[0] = v;
+
+//         sfpi::dst_reg++;
+//     }
+// }
+
+// template <bool APPROXIMATION_MODE, int ITERATIONS>
+// inline void calculate_unary_ge(uint value) {
+//     // SFPU microcode
+//     sfpi::vFloat s = Converter::as_float(value);
+
+// #pragma GCC unroll 8
+//     for (int d = 0; d < ITERATIONS; d++) {
+//         sfpi::vFloat v = sfpi::dst_reg[0];
+//         v_if(v < s) { v = 0.0f; }
+//         v_else { v = 1.0f; }
+//         v_endif;
+
+//         sfpi::dst_reg[0] = v;
+
+//         sfpi::dst_reg++;
+//     }
+// }
+
+// template <bool APPROXIMATION_MODE, int ITERATIONS>
+// inline void calculate_unary_le(uint value) {
+//     // SFPU microcode
+//     sfpi::vFloat s = Converter::as_float(value);
+
+// #pragma GCC unroll 8
+//     for (int d = 0; d < ITERATIONS; d++) {
+//         sfpi::vFloat v = sfpi::dst_reg[0];
+//         v_if(v > s) { v = 0.0f; }
+//         v_else { v = 1.0f; }
+//         v_endif;
+
+//         sfpi::dst_reg[0] = v;
+
+//         sfpi::dst_reg++;
+//     }
+// }
+
+template <bool APPROXIMATION_MODE, SfpuType COMP_MODE, int ITERATIONS = 8>
+inline void calculate_unary_comparison(uint value) {
+    sfpi::vFloat scalar = Converter::as_float(value);
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
-        sfpi::vFloat v = sfpi::dst_reg[0];
-        v_if(v == s) { v = 0.0f; }
-        v_else { v = 1.0f; }
-        v_endif;
+        sfpi::vFloat in = sfpi::dst_reg[0];
 
-        sfpi::dst_reg[0] = v;
+        if constexpr (COMP_MODE == SfpuType::unary_ne) {
+            v_if(in == scalar) { in = sfpi::vConst0; }
+            v_else { in = sfpi::vConst1; }
+            v_endif;
+        } else if constexpr (COMP_MODE == SfpuType::unary_eq) {
+            v_if(in == scalar) { in = sfpi::vConst1; }
+            v_else { in = sfpi::vConst0; }
+            v_endif;
+        } else if constexpr (COMP_MODE == SfpuType::unary_gt) {
+            v_if(in > scalar) { in = sfpi::vConst1; }
+            v_else { in = sfpi::vConst0; }
+            v_endif;
+        } else if constexpr (COMP_MODE == SfpuType::unary_lt) {
+            v_if(in < scalar) { in = sfpi::vConst1; }
+            v_else { in = sfpi::vConst0; }
+            v_endif;
+        } else if constexpr (COMP_MODE == SfpuType::unary_ge) {
+            v_if(in < scalar) { in = sfpi::vConst0; }
+            v_else { in = sfpi::vConst1; }
+            v_endif;
+        } else if constexpr (COMP_MODE == SfpuType::unary_le) {
+            v_if(in > scalar) { in = sfpi::vConst0; }
+            v_else { in = sfpi::vConst1; }
+            v_endif;
+        }
 
-        sfpi::dst_reg++;
-    }
-}
-
-template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_unary_eq(uint value) {
-    // SFPU microcode
-    sfpi::vFloat s = Converter::as_float(value);
-
-#pragma GCC unroll 8
-    for (int d = 0; d < ITERATIONS; d++) {
-        sfpi::vFloat v = sfpi::dst_reg[0];
-        v_if(v == s) { v = 1.0f; }
-        v_else { v = 0.0f; }
-        v_endif;
-
-        sfpi::dst_reg[0] = v;
-
-        sfpi::dst_reg++;
-    }
-}
-
-template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_unary_gt(uint value) {
-    // SFPU microcode
-    sfpi::vFloat s = Converter::as_float(value);
-
-#pragma GCC unroll 8
-    for (int d = 0; d < ITERATIONS; d++) {
-        sfpi::vFloat v = sfpi::dst_reg[0];
-        v_if(v > s) { v = 1.0f; }
-        v_else { v = 0.0f; }
-        v_endif;
-
-        sfpi::dst_reg[0] = v;
-
-        sfpi::dst_reg++;
-    }
-}
-
-template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_unary_lt(uint value) {
-    // SFPU microcode
-    sfpi::vFloat s = Converter::as_float(value);
-
-#pragma GCC unroll 8
-    for (int d = 0; d < ITERATIONS; d++) {
-        sfpi::vFloat v = sfpi::dst_reg[0];
-        v_if(v < s) { v = 1.0f; }
-        v_else { v = 0.0f; }
-        v_endif;
-
-        sfpi::dst_reg[0] = v;
-
-        sfpi::dst_reg++;
-    }
-}
-
-template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_unary_ge(uint value) {
-    // SFPU microcode
-    sfpi::vFloat s = Converter::as_float(value);
-
-#pragma GCC unroll 8
-    for (int d = 0; d < ITERATIONS; d++) {
-        sfpi::vFloat v = sfpi::dst_reg[0];
-        v_if(v < s) { v = 0.0f; }
-        v_else { v = 1.0f; }
-        v_endif;
-
-        sfpi::dst_reg[0] = v;
-
-        sfpi::dst_reg++;
-    }
-}
-
-template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_unary_le(uint value) {
-    // SFPU microcode
-    sfpi::vFloat s = Converter::as_float(value);
-
-#pragma GCC unroll 8
-    for (int d = 0; d < ITERATIONS; d++) {
-        sfpi::vFloat v = sfpi::dst_reg[0];
-        v_if(v > s) { v = 0.0f; }
-        v_else { v = 1.0f; }
-        v_endif;
-
-        sfpi::dst_reg[0] = v;
-
+        sfpi::dst_reg[0] = in;
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_comp.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_comp.h
@@ -158,5 +158,45 @@ inline void calculate_unary_comparison(uint value) {
     }
 }
 
+template <bool APPROXIMATION_MODE, SfpuType COMP_MODE, int ITERATIONS = 8>
+inline void calculate_unary_comparison_uint(uint value) {
+    sfpi::vUInt scalar = value;
+    sfpi::vUInt one = 1u;
+    sfpi::vUInt zero = 0u;
+#pragma GCC unroll 8
+    for (int d = 0; d < ITERATIONS; d++) {
+        sfpi::vUInt in = sfpi::dst_reg[0];
+
+        if constexpr (COMP_MODE == SfpuType::unary_ne) {
+            v_if(in == scalar) { in = zero; }
+            v_else { in = one; }
+            v_endif;
+        } else if constexpr (COMP_MODE == SfpuType::unary_eq) {
+            v_if(in == scalar) { in = one; }
+            v_else { in = zero; }
+            v_endif;
+        } else if constexpr (COMP_MODE == SfpuType::unary_gt) {
+            v_if(in > scalar) { in = one; }
+            v_else { in = 0u; }
+            v_endif;
+        } else if constexpr (COMP_MODE == SfpuType::unary_lt) {
+            v_if(in < scalar) { in = one; }
+            v_else { in = zero; }
+            v_endif;
+        } else if constexpr (COMP_MODE == SfpuType::unary_ge) {
+            v_if(in < scalar) { in = zero; }
+            v_else { in = one; }
+            v_endif;
+        } else if constexpr (COMP_MODE == SfpuType::unary_le) {
+            v_if(in > scalar) { in = zero; }
+            v_else { in = one; }
+            v_endif;
+        }
+
+        sfpi::dst_reg[0] = in;
+        sfpi::dst_reg++;
+    }
+}
+
 }  // namespace sfpu
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_unary_comp.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_unary_comp.h
@@ -29,7 +29,10 @@ inline void llk_math_eltwise_unary_sfpu_unary_ne_int32(
 template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_unary_ne(uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_unary_ne<APPROXIMATE, ITERATIONS>, dst_index, vector_mode, param0);
+        ckernel::sfpu::calculate_unary_comparison<APPROXIMATE, SfpuType::unary_ne, ITERATIONS>,
+        dst_index,
+        vector_mode,
+        param0);
 }
 
 // Unary equal
@@ -51,7 +54,10 @@ inline void llk_math_eltwise_unary_sfpu_unary_eq_int32(
 template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_unary_eq(uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_unary_eq<APPROXIMATE, ITERATIONS>, dst_index, vector_mode, param0);
+        ckernel::sfpu::calculate_unary_comparison<APPROXIMATE, SfpuType::unary_eq, ITERATIONS>,
+        dst_index,
+        vector_mode,
+        param0);
 }
 
 // Unary greater than
@@ -73,7 +79,10 @@ inline void llk_math_eltwise_unary_sfpu_unary_gt_int32(
 template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_unary_gt(uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_unary_gt<APPROXIMATE, ITERATIONS>, dst_index, vector_mode, param0);
+        ckernel::sfpu::calculate_unary_comparison<APPROXIMATE, SfpuType::unary_gt, ITERATIONS>,
+        dst_index,
+        vector_mode,
+        param0);
 }
 
 // Unary lesser than
@@ -95,7 +104,10 @@ inline void llk_math_eltwise_unary_sfpu_unary_lt_int32(
 template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_unary_lt(uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_unary_lt<APPROXIMATE, ITERATIONS>, dst_index, vector_mode, param0);
+        ckernel::sfpu::calculate_unary_comparison<APPROXIMATE, SfpuType::unary_lt, ITERATIONS>,
+        dst_index,
+        vector_mode,
+        param0);
 }
 
 // Unary greater than or equal to
@@ -117,7 +129,10 @@ inline void llk_math_eltwise_unary_sfpu_unary_ge_int32(
 template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_unary_ge(uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_unary_ge<APPROXIMATE, ITERATIONS>, dst_index, vector_mode, param0);
+        ckernel::sfpu::calculate_unary_comparison<APPROXIMATE, SfpuType::unary_ge, ITERATIONS>,
+        dst_index,
+        vector_mode,
+        param0);
 }
 
 // Unary lesser than or equal to
@@ -139,6 +154,9 @@ inline void llk_math_eltwise_unary_sfpu_unary_le_int32(
 template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_unary_le(uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_unary_le<APPROXIMATE, ITERATIONS>, dst_index, vector_mode, param0);
+        ckernel::sfpu::calculate_unary_comparison<APPROXIMATE, SfpuType::unary_le, ITERATIONS>,
+        dst_index,
+        vector_mode,
+        param0);
 }
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_unary_comp.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_unary_comp.h
@@ -34,6 +34,15 @@ inline void llk_math_eltwise_unary_sfpu_unary_ne(uint dst_index, uint param0, in
         vector_mode,
         param0);
 }
+template <bool APPROXIMATE, int ITERATIONS = 8>
+inline void llk_math_eltwise_unary_sfpu_unary_ne_uint32(
+    uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        ckernel::sfpu::calculate_unary_comparison_uint<APPROXIMATE, SfpuType::unary_ne, ITERATIONS>,
+        dst_index,
+        vector_mode,
+        param0);
+}
 
 // Unary equal
 template <bool APPROXIMATE>
@@ -60,6 +69,16 @@ inline void llk_math_eltwise_unary_sfpu_unary_eq(uint dst_index, uint param0, in
         param0);
 }
 
+template <bool APPROXIMATE, int ITERATIONS = 8>
+inline void llk_math_eltwise_unary_sfpu_unary_eq_uint32(
+    uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        ckernel::sfpu::calculate_unary_comparison_uint<APPROXIMATE, SfpuType::unary_eq, ITERATIONS>,
+        dst_index,
+        vector_mode,
+        param0);
+}
+
 // Unary greater than
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_unary_gt_init() {
@@ -80,6 +99,15 @@ template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_unary_gt(uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
         ckernel::sfpu::calculate_unary_comparison<APPROXIMATE, SfpuType::unary_gt, ITERATIONS>,
+        dst_index,
+        vector_mode,
+        param0);
+}
+template <bool APPROXIMATE, int ITERATIONS = 8>
+inline void llk_math_eltwise_unary_sfpu_unary_gt_uint32(
+    uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        ckernel::sfpu::calculate_unary_comparison_uint<APPROXIMATE, SfpuType::unary_gt, ITERATIONS>,
         dst_index,
         vector_mode,
         param0);
@@ -110,6 +138,16 @@ inline void llk_math_eltwise_unary_sfpu_unary_lt(uint dst_index, uint param0, in
         param0);
 }
 
+template <bool APPROXIMATE, int ITERATIONS = 8>
+inline void llk_math_eltwise_unary_sfpu_unary_lt_uint32(
+    uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        ckernel::sfpu::calculate_unary_comparison_uint<APPROXIMATE, SfpuType::unary_lt, ITERATIONS>,
+        dst_index,
+        vector_mode,
+        param0);
+}
+
 // Unary greater than or equal to
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_unary_ge_init() {
@@ -135,6 +173,16 @@ inline void llk_math_eltwise_unary_sfpu_unary_ge(uint dst_index, uint param0, in
         param0);
 }
 
+template <bool APPROXIMATE, int ITERATIONS = 8>
+inline void llk_math_eltwise_unary_sfpu_unary_ge_uint32(
+    uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        ckernel::sfpu::calculate_unary_comparison_uint<APPROXIMATE, SfpuType::unary_ge, ITERATIONS>,
+        dst_index,
+        vector_mode,
+        param0);
+}
+
 // Unary lesser than or equal to
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_unary_le_init() {
@@ -155,6 +203,16 @@ template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_unary_le(uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
         ckernel::sfpu::calculate_unary_comparison<APPROXIMATE, SfpuType::unary_le, ITERATIONS>,
+        dst_index,
+        vector_mode,
+        param0);
+}
+
+template <bool APPROXIMATE, int ITERATIONS = 8>
+inline void llk_math_eltwise_unary_sfpu_unary_le_uint32(
+    uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        ckernel::sfpu::calculate_unary_comparison_uint<APPROXIMATE, SfpuType::unary_le, ITERATIONS>,
         dst_index,
         vector_mode,
         param0);

--- a/tt_metal/include/compute_kernel_api/eltwise_unary/comp.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_unary/comp.h
@@ -57,6 +57,9 @@ ALWI void unary_ne_tile_int32(uint32_t idst, uint32_t param0) {
     MATH((llk_math_eltwise_unary_sfpu_unary_ne_int32<APPROX>(idst, param0)));
 }
 
+ALWI void unary_ne_tile_uint32(uint32_t idst, uint32_t param0) {
+    MATH((llk_math_eltwise_unary_sfpu_unary_ne_uint32<APPROX>(idst, param0)));
+}
 // unary eq : if x == value --> 1.0, else 0.0
 // clang-format off
 /**
@@ -100,6 +103,9 @@ ALWI void unary_eq_tile_init() { MATH((llk_math_eltwise_unary_sfpu_unary_eq_init
 // clang-format on
 ALWI void unary_eq_tile_int32(uint32_t idst, uint32_t param0) {
     MATH((llk_math_eltwise_unary_sfpu_unary_eq_int32<APPROX>(idst, param0)));
+}
+ALWI void unary_eq_tile_uint32(uint32_t idst, uint32_t param0) {
+    MATH((llk_math_eltwise_unary_sfpu_unary_eq_uint32<APPROX>(idst, param0)));
 }
 
 // unary gt : if x > value --> 1.0, else 0.0
@@ -146,6 +152,9 @@ ALWI void unary_gt_tile_init() { MATH((llk_math_eltwise_unary_sfpu_unary_gt_init
 ALWI void unary_gt_tile_int32(uint32_t idst, uint32_t param0) {
     MATH((llk_math_eltwise_unary_sfpu_unary_gt_int32<APPROX>(idst, param0)));
 }
+ALWI void unary_gt_tile_uint32(uint32_t idst, uint32_t param0) {
+    MATH((llk_math_eltwise_unary_sfpu_unary_gt_uint32<APPROX>(idst, param0)));
+}
 
 // unary ge : if x >= value --> 1.0, else 0.0
 // clang-format off
@@ -191,6 +200,9 @@ ALWI void unary_ge_tile_init() { MATH((llk_math_eltwise_unary_sfpu_unary_ge_init
 ALWI void unary_ge_tile_int32(uint32_t idst, uint32_t param0) {
     MATH((llk_math_eltwise_unary_sfpu_unary_ge_int32<APPROX>(idst, param0)));
 }
+ALWI void unary_ge_tile_uint32(uint32_t idst, uint32_t param0) {
+    MATH((llk_math_eltwise_unary_sfpu_unary_ge_uint32<APPROX>(idst, param0)));
+}
 
 // unary lt : if x < value --> 1.0, else 0.0
 // clang-format off
@@ -231,7 +243,9 @@ ALWI void unary_lt_tile(uint32_t idst, uint32_t param0) {
 ALWI void unary_lt_tile_int32(uint32_t idst, uint32_t param0) {
     MATH((llk_math_eltwise_unary_sfpu_unary_lt_int32<APPROX>(idst, param0)));
 }
-
+ALWI void unary_lt_tile_uint32(uint32_t idst, uint32_t param0) {
+    MATH((llk_math_eltwise_unary_sfpu_unary_lt_uint32<APPROX>(idst, param0)));
+}
 /**
  * Please refer to documentation for any_init.
  */
@@ -276,7 +290,9 @@ ALWI void unary_le_tile(uint32_t idst, uint32_t param0) {
 ALWI void unary_le_tile_int32(uint32_t idst, uint32_t param0) {
     MATH((llk_math_eltwise_unary_sfpu_unary_le_int32<APPROX>(idst, param0)));
 }
-
+ALWI void unary_le_tile_uint32(uint32_t idst, uint32_t param0) {
+    MATH((llk_math_eltwise_unary_sfpu_unary_le_uint32<APPROX>(idst, param0)));
+}
 /**
  * Please refer to documentation for any_init.
  */

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
@@ -356,10 +356,13 @@ std::pair<std::string, std::string> get_op_init_and_func_parameterized(
         case UnaryOpType::UNARY_NE:
             TT_FATAL(
                 input_dtype.has_value(), "Missing input dtype: Expected a valid input dtype, but none was provided.");
-            if (input_dtype == DataType::INT32 || input_dtype == DataType::UINT32) {
+            if (input_dtype == DataType::INT32) {
                 op_init_and_name = {
                     "unary_ne_tile_init();",
                     fmt::format("unary_ne_tile_int32({}, {}u);", idst, std::bit_cast<uint32_t>(param0_raw))};
+            } else if (input_dtype == DataType::UINT32) {
+                op_init_and_name = {
+                    "unary_ne_tile_init();", fmt::format("unary_ne_tile_uint32({}, {}u);", idst, (uint)params[0])};
             } else {
                 op_init_and_name = {
                     "unary_ne_tile_init();",
@@ -369,10 +372,13 @@ std::pair<std::string, std::string> get_op_init_and_func_parameterized(
         case UnaryOpType::UNARY_EQ:
             TT_FATAL(
                 input_dtype.has_value(), "Missing input dtype: Expected a valid input dtype, but none was provided.");
-            if (input_dtype == DataType::INT32 || input_dtype == DataType::UINT32) {
+            if (input_dtype == DataType::INT32) {
                 op_init_and_name = {
                     "unary_eq_tile_init();",
                     fmt::format("unary_eq_tile_int32({}, {}u);", idst, std::bit_cast<uint32_t>(param0_raw))};
+            } else if (input_dtype == DataType::UINT32) {
+                op_init_and_name = {
+                    "unary_eq_tile_init();", fmt::format("unary_eq_tile_uint32({}, {}u);", idst, (uint)params[0])};
             } else {
                 op_init_and_name = {
                     "unary_eq_tile_init();",
@@ -382,10 +388,13 @@ std::pair<std::string, std::string> get_op_init_and_func_parameterized(
         case UnaryOpType::UNARY_GT:
             TT_FATAL(
                 input_dtype.has_value(), "Missing input dtype: Expected a valid input dtype, but none was provided.");
-            if (input_dtype == DataType::INT32 || input_dtype == DataType::UINT32) {
+            if (input_dtype == DataType::INT32) {
                 op_init_and_name = {
                     "unary_gt_tile_init();",
                     fmt::format("unary_gt_tile_int32({}, {});", idst, std::bit_cast<uint32_t>(param0_raw))};
+            } else if (input_dtype == DataType::UINT32) {
+                op_init_and_name = {
+                    "unary_gt_tile_init();", fmt::format("unary_gt_tile_uint32({}, {});", idst, (uint)params[0])};
             } else {
                 op_init_and_name = {
                     "unary_gt_tile_init();",
@@ -395,10 +404,13 @@ std::pair<std::string, std::string> get_op_init_and_func_parameterized(
         case UnaryOpType::UNARY_LT:
             TT_FATAL(
                 input_dtype.has_value(), "Missing input dtype: Expected a valid input dtype, but none was provided.");
-            if (input_dtype == DataType::INT32 || input_dtype == DataType::UINT32) {
+            if (input_dtype == DataType::INT32) {
                 op_init_and_name = {
                     "unary_lt_tile_init();",
                     fmt::format("unary_lt_tile_int32({}, {});", idst, std::bit_cast<uint32_t>(param0_raw))};
+            } else if (input_dtype == DataType::UINT32) {
+                op_init_and_name = {
+                    "unary_lt_tile_init();", fmt::format("unary_lt_tile_uint32({}, {});", idst, (uint)params[0])};
             } else {
                 op_init_and_name = {
                     "unary_lt_tile_init();",
@@ -408,10 +420,13 @@ std::pair<std::string, std::string> get_op_init_and_func_parameterized(
         case UnaryOpType::UNARY_GE:
             TT_FATAL(
                 input_dtype.has_value(), "Missing input dtype: Expected a valid input dtype, but none was provided.");
-            if (input_dtype == DataType::INT32 || input_dtype == DataType::UINT32) {
+            if (input_dtype == DataType::INT32) {
                 op_init_and_name = {
                     "unary_ge_tile_init();",
                     fmt::format("unary_ge_tile_int32({}, {});", idst, std::bit_cast<uint32_t>(param0_raw))};
+            } else if (input_dtype == DataType::UINT32) {
+                op_init_and_name = {
+                    "unary_ge_tile_init();", fmt::format("unary_ge_tile_uint32({}, {});", idst, (uint)params[0])};
             } else {
                 op_init_and_name = {
                     "unary_ge_tile_init();",
@@ -421,10 +436,13 @@ std::pair<std::string, std::string> get_op_init_and_func_parameterized(
         case UnaryOpType::UNARY_LE:
             TT_FATAL(
                 input_dtype.has_value(), "Missing input dtype: Expected a valid input dtype, but none was provided.");
-            if (input_dtype == DataType::INT32 || input_dtype == DataType::UINT32) {
+            if (input_dtype == DataType::INT32) {
                 op_init_and_name = {
                     "unary_le_tile_init();",
                     fmt::format("unary_le_tile_int32({}, {});", idst, std::bit_cast<uint32_t>(param0_raw))};
+            } else if (input_dtype == DataType::UINT32) {
+                op_init_and_name = {
+                    "unary_le_tile_init();", fmt::format("unary_le_tile_uint32({}, {});", idst, (uint)params[0])};
             } else {
                 op_init_and_name = {
                     "unary_le_tile_init();",


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes