### PR TITLE
Add sharded support for ttnn.clone operation

### DIFF
--- a/tests/ttnn/unit_tests/operations/data_movement/test_clone.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_clone.py
@@ -72,7 +72,8 @@ def run_clone(
         device=device,
         dtype=get_lib_dtype(ttnn, input_dtype),
         layout=ttnn.TILE_LAYOUT if tilized else ttnn.ROW_MAJOR_LAYOUT,
-    ).to(device, input_memory_config)
+        memory_config=input_memory_config,
+    )
 
     ttnn_output = ttnn.clone(
         ttnn_input,
@@ -270,3 +271,164 @@ def test_clone_callback(
     logger.info(f"num_program_cache_entries_list={num_program_cache_entries_list}")
     assert num_program_cache_entries_list[0] > 0
     assert num_program_cache_entries_list[0] == num_program_cache_entries_list[1]
+
+
+@pytest.mark.parametrize(
+    "shape",
+    [
+        [1, 1, 64 * 32, 64 * 32],
+    ],
+)
+@pytest.mark.parametrize(
+    "shard_strategy",
+    [
+        ttnn.ShardStrategy.HEIGHT,
+        ttnn.ShardStrategy.WIDTH,
+        ttnn.ShardStrategy.BLOCK,
+    ],
+)
+@pytest.mark.parametrize(
+    "shard_orientation",
+    [
+        ttnn.ShardOrientation.ROW_MAJOR,
+        ttnn.ShardOrientation.COL_MAJOR,
+    ],
+)
+@pytest.mark.parametrize(
+    "input_dtype",
+    [
+        "bfloat16",
+        "float32",
+    ],
+)
+def test_clone_sharded_tilized(
+    shape,
+    shard_strategy,
+    shard_orientation,
+    input_dtype,
+    device,
+):
+    """
+    Test case to verify the clone operation with tilized sharded tensors.
+    Tests various sharding strategies (HEIGHT, WIDTH, BLOCK) with identical input/output shard specs.
+    """
+    torch.manual_seed(2024)
+
+    compute_grid_size = device.compute_with_storage_grid_size()
+
+    shard_grid = ttnn.CoreGrid(y=compute_grid_size.y, x=compute_grid_size.x)
+
+    shard_memory_config = ttnn.create_sharded_memory_config(
+        shape=shape,
+        core_grid=shard_grid,
+        strategy=shard_strategy,
+        orientation=shard_orientation,
+    )
+
+    run_clone(
+        shape=shape,
+        input_memory_config=shard_memory_config,
+        output_memory_config=shard_memory_config,
+        input_dtype=input_dtype,
+        output_dtype=None,
+        tilized=True,
+        compute_kernel_options=None,
+        device=device,
+    )
+
+
+@pytest.mark.parametrize(
+    "shape",
+    [
+        [1, 1, 128, 64],
+    ],
+)
+@pytest.mark.parametrize(
+    "shard_strategy",
+    [
+        ttnn.ShardStrategy.HEIGHT,
+        ttnn.ShardStrategy.BLOCK,
+    ],
+)
+@pytest.mark.parametrize(
+    "input_dtype",
+    [
+        "bfloat16",
+        "float32",
+    ],
+)
+def test_clone_sharded_row_major(
+    shape,
+    shard_strategy,
+    input_dtype,
+    device,
+):
+    """
+    Test case to verify the clone operation with sharded tensors in ROW_MAJOR layout.
+    """
+    torch.manual_seed(2024)
+
+    compute_grid_size = device.compute_with_storage_grid_size()
+
+    shard_grid = ttnn.CoreGrid(y=compute_grid_size.y, x=compute_grid_size.x)
+
+    shard_memory_config = ttnn.create_sharded_memory_config(
+        shape=shape,
+        core_grid=shard_grid,
+        strategy=shard_strategy,
+        orientation=ttnn.ShardOrientation.ROW_MAJOR,
+    )
+
+    run_clone(
+        shape=shape,
+        input_memory_config=shard_memory_config,
+        output_memory_config=shard_memory_config,
+        input_dtype=input_dtype,
+        output_dtype=None,
+        tilized=False,
+        compute_kernel_options=None,
+        device=device,
+    )
+
+
+@pytest.mark.parametrize(
+    "input_dtype, output_dtype",
+    [
+        ("bfloat16", "float32"),
+        ("float32", "bfloat16"),
+    ],
+)
+def test_clone_sharded_dtype_conversion(
+    input_dtype,
+    output_dtype,
+    device,
+):
+    """
+    Test case to verify the clone operation with sharded tensors and dtype conversion.
+    Dtype conversion is only supported with TILE layout.
+    """
+    torch.manual_seed(2024)
+
+    shape = [1, 1, 64 * 32, 32]
+
+    compute_grid_size = device.compute_with_storage_grid_size()
+
+    shard_grid = ttnn.CoreGrid(y=compute_grid_size.y, x=compute_grid_size.x)
+
+    shard_memory_config = ttnn.create_sharded_memory_config(
+        shape=shape,
+        core_grid=shard_grid,
+        strategy=ttnn.ShardStrategy.HEIGHT,
+        orientation=ttnn.ShardOrientation.ROW_MAJOR,
+    )
+
+    run_clone(
+        shape=shape,
+        input_memory_config=shard_memory_config,
+        output_memory_config=shard_memory_config,
+        input_dtype=input_dtype,
+        output_dtype=output_dtype,
+        tilized=True,
+        compute_kernel_options=None,
+        device=device,
+    )

--- a/ttnn/cpp/ttnn/operations/data_movement/clone/device/clone_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/clone/device/clone_device_operation.cpp
@@ -14,12 +14,31 @@ void CloneOperation::validate_inputs(
     }
     TT_FATAL(input.storage_type() == StorageType::DEVICE, "Clone: input must be on device");
     TT_FATAL(input.buffer() != nullptr, "Clone: input must be allocated in buffer on device");
-    TT_FATAL(
-        input.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED,
-        "Clone: not currently support sharding");
-    TT_FATAL(
-        operation_attributes.memory_config.memory_layout() == TensorMemoryLayout::INTERLEAVED,
-        "Clone: not currently support sharding");
+
+    auto input_memory_layout = input.memory_config().memory_layout();
+    auto output_memory_layout = operation_attributes.memory_config.memory_layout();
+    bool input_sharded = input_memory_layout != TensorMemoryLayout::INTERLEAVED;
+    bool output_sharded = output_memory_layout != TensorMemoryLayout::INTERLEAVED;
+
+    if (input_sharded && output_sharded) {
+        TT_FATAL(
+            input_memory_layout == output_memory_layout,
+            "Clone: input and output must have the same memory layout when both are sharded");
+
+        auto input_shard_spec = input.buffer()->shard_spec();
+        auto output_shard_spec = operation_attributes.memory_config.shard_spec();
+
+        TT_FATAL(output_shard_spec.has_value(), "Clone: output memory config must have shard spec when sharded");
+
+        TT_FATAL(
+            input_shard_spec.tensor_shard_spec == output_shard_spec.value(),
+            "Clone: input and output shard specs must be identical (same grid, shape, and orientation)");
+    } else if (input_sharded || output_sharded) {
+        TT_FATAL(
+            false,
+            "Clone: mixed sharded/interleaved layout not currently supported. Both input and output must have the same "
+            "layout.");
+    }
 }
 
 CloneOperation::program_factory_t CloneOperation::select_program_factory(

--- a/ttnn/cpp/ttnn/operations/data_movement/clone/device/kernels/read_kernel_rm_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/clone/device/kernels/read_kernel_rm_sharded.cpp
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dataflow_api.h"
+
+void kernel_main() {
+    uint32_t input_buffer_address = get_arg_val<uint32_t>(0);
+    uint32_t stick_size = get_arg_val<uint32_t>(1);
+    uint32_t num_sticks = get_arg_val<uint32_t>(2);
+
+    constexpr uint32_t src_cb_id = get_compile_time_arg_val(0);
+    constexpr uint32_t input_page_size = get_compile_time_arg_val(1);
+
+    uint64_t local_l1_read_addr = get_noc_addr(input_buffer_address);
+
+    for (uint32_t i = 0; i < num_sticks; ++i) {
+        cb_reserve_back(src_cb_id, 1);
+        uint32_t src_cb_write_addr = get_write_ptr(src_cb_id);
+
+        noc_async_read(local_l1_read_addr, src_cb_write_addr, stick_size);
+        noc_async_read_barrier();
+
+        cb_push_back(src_cb_id, 1);
+        local_l1_read_addr += stick_size;
+    }
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/clone/device/kernels/read_kernel_rm_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/clone/device/kernels/read_kernel_rm_sharded.cpp
@@ -10,8 +10,6 @@ void kernel_main() {
     uint32_t num_sticks = get_arg_val<uint32_t>(2);
 
     constexpr uint32_t src_cb_id = get_compile_time_arg_val(0);
-    constexpr uint32_t input_page_size = get_compile_time_arg_val(1);
-
     uint64_t local_l1_read_addr = get_noc_addr(input_buffer_address);
 
     for (uint32_t i = 0; i < num_sticks; ++i) {

--- a/ttnn/cpp/ttnn/operations/data_movement/clone/device/kernels/read_kernel_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/clone/device/kernels/read_kernel_sharded.cpp
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dataflow_api.h"
+
+void kernel_main() {
+    uint32_t input_buffer_address = get_arg_val<uint32_t>(0);
+    uint32_t num_tiles = get_arg_val<uint32_t>(1);
+
+    constexpr uint32_t src_cb_id = get_compile_time_arg_val(0);
+
+    const uint32_t tile_size = get_tile_size(src_cb_id);
+    uint64_t local_l1_read_addr = get_noc_addr(input_buffer_address);
+
+    for (uint32_t i = 0; i < num_tiles; ++i) {
+        cb_reserve_back(src_cb_id, 1);
+        uint32_t src_cb_write_addr = get_write_ptr(src_cb_id);
+
+        noc_async_read(local_l1_read_addr, src_cb_write_addr, tile_size);
+        noc_async_read_barrier();
+
+        cb_push_back(src_cb_id, 1);
+        local_l1_read_addr += tile_size;
+    }
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/clone/device/kernels/write_kernel_rm_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/clone/device/kernels/write_kernel_rm_sharded.cpp
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dataflow_api.h"
+
+void kernel_main() {
+    uint32_t output_buffer_address = get_arg_val<uint32_t>(0);
+    uint32_t stick_size = get_arg_val<uint32_t>(1);
+    uint32_t num_sticks = get_arg_val<uint32_t>(2);
+
+    constexpr uint32_t dst_cb_id = get_compile_time_arg_val(0);
+    constexpr uint32_t output_page_size = get_compile_time_arg_val(1);
+
+    uint64_t local_l1_write_addr = get_noc_addr(output_buffer_address);
+
+    for (uint32_t i = 0; i < num_sticks; ++i) {
+        cb_wait_front(dst_cb_id, 1);
+        uint32_t dst_cb_read_addr = get_read_ptr(dst_cb_id);
+
+        noc_async_write(dst_cb_read_addr, local_l1_write_addr, stick_size);
+        noc_async_write_barrier();
+
+        cb_pop_front(dst_cb_id, 1);
+        local_l1_write_addr += stick_size;
+    }
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/clone/device/kernels/write_kernel_rm_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/clone/device/kernels/write_kernel_rm_sharded.cpp
@@ -10,7 +10,6 @@ void kernel_main() {
     uint32_t num_sticks = get_arg_val<uint32_t>(2);
 
     constexpr uint32_t dst_cb_id = get_compile_time_arg_val(0);
-    constexpr uint32_t output_page_size = get_compile_time_arg_val(1);
 
     uint64_t local_l1_write_addr = get_noc_addr(output_buffer_address);
 

--- a/ttnn/cpp/ttnn/operations/data_movement/clone/device/kernels/write_kernel_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/clone/device/kernels/write_kernel_sharded.cpp
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dataflow_api.h"
+
+void kernel_main() {
+    uint32_t output_buffer_address = get_arg_val<uint32_t>(0);
+    uint32_t num_tiles = get_arg_val<uint32_t>(1);
+
+    constexpr uint32_t dst_cb_id = get_compile_time_arg_val(0);
+
+    const uint32_t tile_size = get_tile_size(dst_cb_id);
+    uint64_t local_l1_write_addr = get_noc_addr(output_buffer_address);
+
+    for (uint32_t i = 0; i < num_tiles; ++i) {
+        cb_wait_front(dst_cb_id, 1);
+        uint32_t dst_cb_read_addr = get_read_ptr(dst_cb_id);
+
+        noc_async_write(dst_cb_read_addr, local_l1_write_addr, tile_size);
+        noc_async_write_barrier();
+
+        cb_pop_front(dst_cb_id, 1);
+        local_l1_write_addr += tile_size;
+    }
+}


### PR DESCRIPTION
### Problem description
SDXL needs sharded support for clone operation

### What's changed
Added support for sharded input/output to ttnn.clone operation. Added 4 new kernels: reader_tile, writer_tile, reader_row_major and writer_row_major.

Since I'm not an op developer, please check if I've added all necessary support for this. Also, not entirely sure what CI runs to trigger so correct me if I missed some.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/19821141876) CI passes
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/runs/19821279413) CI passes
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/runs/19821172390) CI passes
- [x] [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/19821303470) CI passes
- [x] [L2 nightly](https://github.com/tenstorrent/tt-metal/actions/runs/19913952734) CI passes