### PR TITLE
[tt-train] Update tt-train code owners: replace rfurko-tt with new team members

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -361,7 +361,17 @@ docs/source/tt-metalium/tt_metal/apis/kernel_apis/data_movement/ @abhullar-tt @r
 dockerfile/upstream_test_images/ @tenstorrent/metalium-developers-infra @tenstorrent/codeowner-bypass
 
 # tt-train
-tt-train/** @dmakoviichuk-tt @rfurko-tt @ayerofieiev-tt @tenstorrent/codeowner-bypass
+# Primary owners: @dmakoviichuk-tt @ayerofieiev-tt
+tt-train/** @dmakoviichuk-tt @ayerofieiev-tt @tenstorrent/codeowner-bypass
+
+# Kernel development
+tt-train/sources/ttml/metal/** @mdragulaTT @vmelnykovTT @dyurshevichTT @zbaczewskiTT @tenstorrent/codeowner-bypass
+# Ops
+tt-train/sources/ttml/ops/** @mdragulaTT @vmelnykovTT @dyurshevichTT @tenstorrent/codeowner-bypass
+tt-train/tests/ops/** @mdragulaTT @vmelnykovTT @dyurshevichTT @tenstorrent/codeowner-bypass
+# Optimizers
+tt-train/sources/ttml/optimizers/** @zbaczewskiTT @tenstorrent/codeowner-bypass
+tt-train/tests/optimizers/** @zbaczewskiTT @tenstorrent/codeowner-bypass
 
 # tt-telemetry
 tt_telemetry/** @btrzynadlowski-tt @tt-asaigal @kluongTT @cfjchu @tt-aho @SeanNijjar @aliuTT @Riddy21 @agupta-tt @tenstorrent/codeowner-bypass

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -361,17 +361,16 @@ docs/source/tt-metalium/tt_metal/apis/kernel_apis/data_movement/ @abhullar-tt @r
 dockerfile/upstream_test_images/ @tenstorrent/metalium-developers-infra @tenstorrent/codeowner-bypass
 
 # tt-train
-# Primary owners: @dmakoviichuk-tt @ayerofieiev-tt
+# primary owners
 tt-train/** @dmakoviichuk-tt @ayerofieiev-tt @tenstorrent/codeowner-bypass
-
-# Kernel development
+# kernel development
 tt-train/sources/ttml/metal/** @mdragulaTT @vmelnykovTT @dyurshevichTT @zbaczewskiTT @tenstorrent/codeowner-bypass
-# Ops
+# ops
 tt-train/sources/ttml/ops/** @mdragulaTT @vmelnykovTT @dyurshevichTT @tenstorrent/codeowner-bypass
-tt-train/tests/ops/** @mdragulaTT @vmelnykovTT @dyurshevichTT @tenstorrent/codeowner-bypass
-# Optimizers
+# optimizers
 tt-train/sources/ttml/optimizers/** @zbaczewskiTT @tenstorrent/codeowner-bypass
-tt-train/tests/optimizers/** @zbaczewskiTT @tenstorrent/codeowner-bypass
+# tests
+tt-train/tests/** @mdragulaTT @vmelnykovTT @dyurshevichTT @zbaczewskiTT @athompsonTT @abustamanteTT @tenstorrent/codeowner-bypass
 
 # tt-telemetry
 tt_telemetry/** @btrzynadlowski-tt @tt-asaigal @kluongTT @cfjchu @tt-aho @SeanNijjar @aliuTT @Riddy21 @agupta-tt @tenstorrent/codeowner-bypass


### PR DESCRIPTION
Remove rfurko-tt and add mdragulaTT, vmelnykovTT, dyurshevichTT, and zbaczewskiTT as owners for ops and optimizers sections in tt-train.

### Ticket
N/A

### Problem description
Code ownership for tt-train ops and optimizers sections needed to be updated to reflect current team structure.

### What's changed
Updated CODEOWNERS file for tt-train repository sections:
- Added @mdragulaTT, @vmelnykovTT, @dyurshevichTT, @zbaczewskiTT tt-train/sources/ttml/metal/** 
- Added @mdragulaTT, @vmelnykovTT, @dyurshevichTT tt-train/sources/ttml/ops/**
- Added @zbaczewskiTT as owner for tt-train/sources/ttml/optimizers/**
- Applied same ownership structure to corresponding test directories

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes