### PR TITLE
Remove build-artifact for tt-cnn-unit-tests

### DIFF
--- a/.github/workflows/blackhole-post-commit.yaml
+++ b/.github/workflows/blackhole-post-commit.yaml
@@ -243,7 +243,6 @@ jobs:
       arch: blackhole
       runner-label: ${{ matrix.test-group }}
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
 
   blackhole-20-cores-tests:

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -187,11 +187,11 @@ jobs:
       product: tt-nn
 
   build-asan:
-    # if: ${{ github.ref_name == 'main' ||
-    #         needs.find-changes.outputs.cmake-changed == 'true' ||
-    #         needs.find-changes.outputs.any-code-changed == 'true' ||
-    #         needs.find-changes.outputs.build-workflows-changed == 'true'
-    #     }}
+    if: ${{ github.ref_name == 'main' ||
+            needs.find-changes.outputs.cmake-changed == 'true' ||
+            needs.find-changes.outputs.any-code-changed == 'true' ||
+            needs.find-changes.outputs.build-workflows-changed == 'true'
+        }}
     needs: find-changes
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
@@ -273,12 +273,12 @@ jobs:
   # TT-CNN Unit tests
   tt-cnn-unit-tests:
     needs: [build, find-changes]
-    # if: ${{ github.ref_name == 'main' ||
-    #         needs.find-changes.outputs.cmake-changed == 'true' ||
-    #         needs.find-changes.outputs.tt-metalium-changed == 'true' ||
-    #         needs.find-changes.outputs.tt-nn-changed == 'true' ||
-    #         needs.find-changes.outputs.tt-metalium-or-tt-nn-tests-changed == 'true'
-    #     }}
+    if: ${{ github.ref_name == 'main' ||
+            needs.find-changes.outputs.cmake-changed == 'true' ||
+            needs.find-changes.outputs.tt-metalium-changed == 'true' ||
+            needs.find-changes.outputs.tt-nn-changed == 'true' ||
+            needs.find-changes.outputs.tt-metalium-or-tt-nn-tests-changed == 'true'
+        }}
     secrets: inherit
     strategy:
       fail-fast: false

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -96,12 +96,12 @@ jobs:
         uses: tenstorrent/tt-metal/.github/actions/find-changed-files@v0.63.0
 
   build:
-    # if: ${{ github.ref_name == 'main' ||
-    #         needs.find-changes.outputs.cmake-changed == 'true' ||
-    #         needs.find-changes.outputs.any-code-changed == 'true' ||
-    #         needs.find-changes.outputs.docs-changed == 'true' ||
-    #         needs.find-changes.outputs.build-workflows-changed == 'true'
-    #     }}
+    if: ${{ github.ref_name == 'main' ||
+            needs.find-changes.outputs.cmake-changed == 'true' ||
+            needs.find-changes.outputs.any-code-changed == 'true' ||
+            needs.find-changes.outputs.docs-changed == 'true' ||
+            needs.find-changes.outputs.build-workflows-changed == 'true'
+        }}
     needs: find-changes
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
@@ -272,7 +272,7 @@ jobs:
 
   # TT-CNN Unit tests
   tt-cnn-unit-tests:
-    needs: [build-asan, find-changes]
+    needs: [build, find-changes]
     # if: ${{ github.ref_name == 'main' ||
     #         needs.find-changes.outputs.cmake-changed == 'true' ||
     #         needs.find-changes.outputs.tt-metalium-changed == 'true' ||

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -96,12 +96,12 @@ jobs:
         uses: tenstorrent/tt-metal/.github/actions/find-changed-files@v0.63.0
 
   build:
-    if: ${{ github.ref_name == 'main' ||
-            needs.find-changes.outputs.cmake-changed == 'true' ||
-            needs.find-changes.outputs.any-code-changed == 'true' ||
-            needs.find-changes.outputs.docs-changed == 'true' ||
-            needs.find-changes.outputs.build-workflows-changed == 'true'
-        }}
+    # if: ${{ github.ref_name == 'main' ||
+    #         needs.find-changes.outputs.cmake-changed == 'true' ||
+    #         needs.find-changes.outputs.any-code-changed == 'true' ||
+    #         needs.find-changes.outputs.docs-changed == 'true' ||
+    #         needs.find-changes.outputs.build-workflows-changed == 'true'
+    #     }}
     needs: find-changes
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
@@ -273,12 +273,12 @@ jobs:
   # TT-CNN Unit tests
   tt-cnn-unit-tests:
     needs: [build, find-changes]
-    if: ${{ github.ref_name == 'main' ||
-            needs.find-changes.outputs.cmake-changed == 'true' ||
-            needs.find-changes.outputs.tt-metalium-changed == 'true' ||
-            needs.find-changes.outputs.tt-nn-changed == 'true' ||
-            needs.find-changes.outputs.tt-metalium-or-tt-nn-tests-changed == 'true'
-        }}
+    # if: ${{ github.ref_name == 'main' ||
+    #         needs.find-changes.outputs.cmake-changed == 'true' ||
+    #         needs.find-changes.outputs.tt-metalium-changed == 'true' ||
+    #         needs.find-changes.outputs.tt-nn-changed == 'true' ||
+    #         needs.find-changes.outputs.tt-metalium-or-tt-nn-tests-changed == 'true'
+    #     }}
     secrets: inherit
     strategy:
       fail-fast: false
@@ -292,7 +292,6 @@ jobs:
       arch: ${{ matrix.test-group.arch }}
       runner-label: ${{ matrix.test-group.runner-label }}
       docker-image: ${{ needs.build.outputs.dev-docker-image }}
-      build-artifact-name: ${{ needs.build.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build.outputs.wheel-artifact-name }}
 
   ttsim-unit-tests:

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -187,11 +187,11 @@ jobs:
       product: tt-nn
 
   build-asan:
-    if: ${{ github.ref_name == 'main' ||
-            needs.find-changes.outputs.cmake-changed == 'true' ||
-            needs.find-changes.outputs.any-code-changed == 'true' ||
-            needs.find-changes.outputs.build-workflows-changed == 'true'
-        }}
+    # if: ${{ github.ref_name == 'main' ||
+    #         needs.find-changes.outputs.cmake-changed == 'true' ||
+    #         needs.find-changes.outputs.any-code-changed == 'true' ||
+    #         needs.find-changes.outputs.build-workflows-changed == 'true'
+    #     }}
     needs: find-changes
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
@@ -272,7 +272,7 @@ jobs:
 
   # TT-CNN Unit tests
   tt-cnn-unit-tests:
-    needs: [build, find-changes]
+    needs: [build-asan, find-changes]
     # if: ${{ github.ref_name == 'main' ||
     #         needs.find-changes.outputs.cmake-changed == 'true' ||
     #         needs.find-changes.outputs.tt-metalium-changed == 'true' ||

--- a/.github/workflows/tt-cnn-post-commit.yaml
+++ b/.github/workflows/tt-cnn-post-commit.yaml
@@ -20,9 +20,6 @@ on:
       docker-image:
         required: true
         type: string
-      build-artifact-name:
-        required: true
-        type: string
       wheel-artifact-name:
         required: true
         type: string
@@ -51,9 +48,6 @@ on:
         type: number
         default: 10
       docker-image:
-        required: true
-        type: string
-      build-artifact-name:
         required: true
         type: string
       wheel-artifact-name:


### PR DESCRIPTION
### What's changed
build-artifact is not used and it is not needed for tt-cnn-unit-tests in merge-gate

### Checklist
- [x] Merge-gate CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/19717620915

Also passes in BHPC here: https://github.com/tenstorrent/tt-metal/actions/runs/19828176677/job/56819982013