### PR TITLE
[POOL] avg_pool2d documentation example fix and global_avg_pool latex formatting correction

### DIFF
--- a/tests/ttnn/docs_examples/test_pooling_examples.py
+++ b/tests/ttnn/docs_examples/test_pooling_examples.py
@@ -59,7 +59,6 @@ def test_max_pool2d():
     ttnn.close_device(device)
 
 
-@pytest.mark.skip("Non-working example from the documentation. GH issue: #32364")
 def test_avg_pool2d():
     device = ttnn.CreateDevice(0, l1_small_size=8192)
     # Define input parameters
@@ -67,7 +66,6 @@ def test_avg_pool2d():
     stride_h, stride_w = 1, 1
     pad_h, pad_w = 0, 0
     nchw_shape = (4, 256, 40, 40)
-    dilation_h, dilation_w = 1, 1
     in_N, in_C, in_H, in_W = nchw_shape
     input_shape = (1, 1, in_N * in_H * in_W, in_C)
 
@@ -87,7 +85,6 @@ def test_avg_pool2d():
         kernel_size=[kernel_h, kernel_w],
         stride=[stride_h, stride_w],
         padding=[pad_h, pad_w],
-        dilation=[dilation_h, dilation_w],
         ceil_mode=False,
         count_include_pad=True,
         divisor_override=None,
@@ -97,6 +94,7 @@ def test_avg_pool2d():
         reallocate_halo_output=True,
         dtype=ttnn.bfloat16,
         output_layout=ttnn.ROW_MAJOR_LAYOUT,
+        compute_kernel_config=None,
     )
     logger.info(f"Output: {tt_output}")
     ttnn.close_device(device)

--- a/ttnn/cpp/ttnn/operations/pool/global_avg_pool/global_avg_pool_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/global_avg_pool/global_avg_pool_pybind.cpp
@@ -21,7 +21,7 @@ void bind_global_avg_pool2d(py::module& module) {
         Applies {0} to :attr:`input_tensor` by performing a 2D adaptive average pooling over an input signal composed of several input planes. This operation computes the average of all elements in each channel across the entire spatial dimensions.
 
         .. math::
-            {0}(\\mathrm{{input\\_tensor}}_i)
+            global\_avg\_pool(\mathrm{{input\_tensor}}_i)
 
         Args:
             input_tensor (ttnn.Tensor): the input tensor. Typically of shape (batch_size, channels, height, width).


### PR DESCRIPTION
### Ticket
[32630](https://github.com/tenstorrent/tt-metal/issues/32630)

### Problem description
1. Test being built from documentation for avg_pool2d had dilation argument being passed so the incorrect function signature was generated. When this argument is removed test is passing successfully.
2. Latex formatting for global avg pool op was incorrect due to adequate escape characters missing 
<img width="518" height="134" alt="image" src="https://github.com/user-attachments/assets/d25533af-1b42-4692-b9f2-eb2e142041ff" />


### What's changed
1. Dilation argument deleted and added compute_kernel_config argument 
2. Latex formatting corrected

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/19828733540)
- [x] [Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/runs/19828710688)