### PR TITLE
Use TT_UMD_USE_BOOST flag to make UMD use boost::asio

### DIFF
--- a/tt_metal/third_party/CMakeLists.txt
+++ b/tt_metal/third_party/CMakeLists.txt
@@ -2,5 +2,6 @@ set(CMAKE_C_CLANG_TIDY "")
 set(CMAKE_CXX_CLANG_TIDY "")
 set(CMAKE_VERIFY_INTERFACE_HEADER_SETS FALSE)
 set(TT_UMD_ENABLE_CLANG_TIDY OFF CACHE BOOL "Disable clang-tidy checks for UMD" FORCE)
+set(TT_UMD_USE_BOOST ON CACHE BOOL "Force UMD to use boost asio instead of standalone" FORCE)
 
 add_subdirectory(umd)


### PR DESCRIPTION
### Ticket
UMD issue

### Problem description
UMD wants to use asio, but asio comes in two forms:
- standalone
- boost

It's the same library, but it can be provided as a part of boost or standalone, UMD wants to use standalone in a general case, but also provide the functionality to be used with tt-metal with boost. The flag TT_UMD_USE_BOOST controls if the super-project want to enforce UMD to use boost asio, or if UMD will use standalone.

### What's changed
- Added one line that makes UMD use boost asio in tt-metal.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes