### PR TITLE
MM/Fused/Reduce Docs Touchups 

### DIFF
--- a/docs/source/ttnn/ttnn/api.rst
+++ b/docs/source/ttnn/ttnn/api.rst
@@ -82,7 +82,6 @@ Matrix Multiplication
 
    ttnn.matmul
    ttnn.linear
-   ttnn.matmul_batched_weights
    ttnn.addmm
    ttnn.sparse_matmul
 

--- a/docs/source/ttnn/ttnn/api.rst
+++ b/docs/source/ttnn/ttnn/api.rst
@@ -414,6 +414,7 @@ Reduction
    :template: function.rst
 
    ttnn.cumprod
+   ttnn.ema
    ttnn.max
    ttnn.mean
    ttnn.min
@@ -425,6 +426,7 @@ Reduction
    ttnn.topk
    ttnn.cumsum
    ttnn.manual_seed
+   ttnn.moe
 
 Data Movement
 =============
@@ -462,7 +464,11 @@ Normalization
 
    ttnn.group_norm
    ttnn.layer_norm
+   ttnn.layer_norm_pre_all_gather
+   ttnn.layer_norm_post_all_gather
    ttnn.rms_norm
+   ttnn.rms_norm_pre_all_gather
+   ttnn.rms_norm_post_all_gather
    ttnn.batch_norm
    ttnn.softmax
    ttnn.scale_mask_softmax

--- a/tests/ttnn/docs_examples/examples_mapping.py
+++ b/tests/ttnn/docs_examples/examples_mapping.py
@@ -339,6 +339,8 @@ FUNCTION_TO_EXAMPLES_MAPPING_DICT = {
     "ttnn.prod": reduction.test_prod,
     "ttnn.topk": reduction.test_topk,
     "ttnn.cumsum": reduction.test_cumsum,
+    "ttnn.ema": reduction.test_ema,
+    "ttnn.moe": reduction.test_moe,
     "ttnn.manual_seed": reduction.test_manual_seed,
     # Data movement
     "ttnn.concat": data_movement.test_concat,

--- a/tests/ttnn/docs_examples/examples_mapping.py
+++ b/tests/ttnn/docs_examples/examples_mapping.py
@@ -363,7 +363,11 @@ FUNCTION_TO_EXAMPLES_MAPPING_DICT = {
     # Normalization
     "ttnn.group_norm": normalization.test_group_norm,
     "ttnn.layer_norm": normalization.test_layer_norm,
+    "ttnn.layer_norm_pre_all_gather": normalization.test_layernorm_distributed,
+    "ttnn.layer_norm_post_all_gather": normalization.test_layernorm_distributed,
     "ttnn.rms_norm": normalization.test_rms_norm,
+    "ttnn.rms_norm_pre_all_gather": normalization.test_rms_norm_distributed,
+    "ttnn.rms_norm_post_all_gather": normalization.test_rms_norm_distributed,
     "ttnn.batch_norm": normalization.test_batch_norm,
     "ttnn.softmax": normalization.test_softmax,
     "ttnn.scale_mask_softmax": normalization.test_scale_mask_softmax,

--- a/tests/ttnn/docs_examples/examples_mapping.py
+++ b/tests/ttnn/docs_examples/examples_mapping.py
@@ -375,7 +375,6 @@ FUNCTION_TO_EXAMPLES_MAPPING_DICT = {
     "ttnn.scale_mask_softmax_in_place": normalization.test_scale_mask_softmax_in_place,
     "ttnn.scale_causal_mask_hw_dims_softmax_in_place": normalization.test_scale_causal_mask_hw_dims_softmax_in_place,
     # Normalization Program Configs
-    # "ttnn.SoftmaxProgramConfig": normalization.test_softmax_program_config, # Lack of example
     "ttnn.SoftmaxDefaultProgramConfig": normalization.test_softmax_default_program_config,
     "ttnn.SoftmaxShardedMultiCoreProgramConfig": normalization.test_softmax_sharded_multi_core_program_config,
     # Moreh Operations

--- a/tests/ttnn/docs_examples/examples_mapping.py
+++ b/tests/ttnn/docs_examples/examples_mapping.py
@@ -376,7 +376,7 @@ FUNCTION_TO_EXAMPLES_MAPPING_DICT = {
     "ttnn.scale_causal_mask_hw_dims_softmax_in_place": normalization.test_scale_causal_mask_hw_dims_softmax_in_place,
     # Normalization Program Configs
     "ttnn.SoftmaxDefaultProgramConfig": normalization.test_softmax_default_program_config,
-    "ttnn.SoftmaxShardedMultiCoreProgramConfig": normalization.test_softmax_sharded_multi_core_program_config,
+    "ttnn.SoftmaxShardedMultiCoreProgramConfig": normalization.test_scale_mask_softmax_in_place,
     # Moreh Operations
     # "ttnn.moreh_sum": moreh.test_moreh_sum, # Lack of example
     # Transformers

--- a/tests/ttnn/docs_examples/examples_mapping.py
+++ b/tests/ttnn/docs_examples/examples_mapping.py
@@ -45,7 +45,6 @@ FUNCTION_TO_EXAMPLES_MAPPING_DICT = {
     # Matrix Multiplication
     "ttnn.matmul": matrix_multiplication.test_matmul,
     "ttnn.linear": matrix_multiplication.test_linear,
-    # "ttnn.matmul_batched_weights": matrix_multiplication.test_matmul_batched_weights, # Lack of example
     "ttnn.addmm": matrix_multiplication.test_addmm,
     "ttnn.sparse_matmul": matrix_multiplication.test_sparse_matmul,
     # Pointwise Unary

--- a/tests/ttnn/docs_examples/test_normalization_examples.py
+++ b/tests/ttnn/docs_examples/test_normalization_examples.py
@@ -361,38 +361,3 @@ def test_scale_causal_mask_hw_dims_softmax_in_place(device):
         program_config=program_config,
     )
     logger.info(f"Scale Causal Mask HW Dims Softmax In Place result: {tt_output_sharded}")
-
-
-@pytest.mark.skip("Non-working example from the documentation. GH issue: #32364")
-def test_softmax_default_program_config(device):
-    # Create input tensor
-    tensor = ttnn.rand((1, 1, 32, 64), dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
-
-    # Configure softmax program
-    compute_grid = device.compute_with_storage_grid_size()
-    program_config = ttnn.SoftmaxDefaultProgramConfig()
-
-    # Perform softmax
-    result = ttnn.softmax(tensor, dim=-1, program_config=program_config)
-    logger.info(f"Softmax with Program Config result: {result}")
-
-
-@pytest.mark.skip("Non-working example from the documentation. GH issue: #32364")
-def test_softmax_sharded_multi_core_program_config(device):
-    # Create input tensor
-    compute_grid = device.compute_with_storage_grid_size()
-    fuse_head = 2
-    batch = compute_grid.x
-    num_cores_r = compute_grid.y
-
-    input_shape = (batch, num_cores_r, fuse_head * 384, 768)
-    input_tensor = ttnn.rand(input_shape, dtype=ttnn.bfloat8_b, layout=ttnn.TILE_LAYOUT, device=device)
-
-    # Configure softmax program
-    program_config = ttnn.SoftmaxShardedMultiCoreProgramConfig(
-        compute_with_storage_grid_size=compute_grid, subblock_w=8, block_h=32, block_w=32
-    )
-
-    # Perform softmax
-    result = ttnn.softmax(input_tensor, dim=-1, program_config=program_config)
-    logger.info(f"Softmax with Sharded Multi Core Program Config result: {result}")

--- a/tests/ttnn/docs_examples/test_normalization_examples.py
+++ b/tests/ttnn/docs_examples/test_normalization_examples.py
@@ -171,6 +171,7 @@ def test_layernorm_distributed(device):
     logger.info(f"Layer Norm Pre All Gather result: {stats}")
 
     # On a distributed setup, all gather would go here to collect the stats from all devices
+    # See documentation for ttnn.all_gather for example usage of all_gather
 
     # Now apply the post-all-gather layer normalization
     output = ttnn.layer_norm_post_all_gather(input_tensor, stats)

--- a/tests/ttnn/docs_examples/test_normalization_examples.py
+++ b/tests/ttnn/docs_examples/test_normalization_examples.py
@@ -169,6 +169,24 @@ def test_layer_norm(device):
     logger.info(f"Layer Norm result: {output_tensor}")
 
 
+def test_layernorm_distributed(device):
+    # Create input tensor
+    input_tensor = ttnn.rand([1, 1, 32, 32], dtype=ttnn.DataType.BFLOAT16, layout=ttnn.TILE_LAYOUT, device=device)
+
+    # Apply pre-all-gather layer normalization
+    stats = ttnn.layer_norm_pre_all_gather(input_tensor)
+    logger.info(f"Layer Norm Pre All Gather result: {stats}")
+
+    # On a distributed setup, all gather would go here to collect the stats from all devices
+
+    # Now apply the post-all-gather layer normalization
+    output = ttnn.layer_norm_post_all_gather(input_tensor, stats)
+    logger.info(f"Layer Norm Post All Gather result: {output}")
+
+    # For reference, this two-step process is equivalent to the following
+    # output = ttnn.layer_norm(input_tensor)
+
+
 def test_rms_norm(device):
     # Setup input tensor and weight
     h, w = 32, 64
@@ -179,6 +197,25 @@ def test_rms_norm(device):
     # Apply RMS normalization
     output_tensor = ttnn.rms_norm(input_tensor, weight=weight)
     logger.info(f"RMS Norm result: {output_tensor}")
+
+
+def test_rms_norm_distributed(device):
+    # Create input tensor
+    input_tensor = ttnn.rand([1, 1, 32, 32], dtype=ttnn.DataType.BFLOAT16, layout=ttnn.TILE_LAYOUT, device=device)
+    weight = ttnn.rand([32], dtype=ttnn.DataType.BFLOAT16, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
+
+    # Apply pre-all-gather RMS normalization
+    stats = ttnn.rms_norm_pre_all_gather(input_tensor)
+    logger.info(f"RMS Norm Pre All Gather result: {stats}")
+
+    # On a distributed setup, an all gather would go here to collect the stats from all the devices
+
+    # Now apply the post-all-gather RMS normalization
+    output = ttnn.rms_norm_post_all_gather(input_tensor, stats, weight=weight)
+    logger.info(f"RMS Norm Post All Gather result: {output}")
+
+    # For reference, this two-step process is equivalent to the following
+    # output = ttnn.rms_norm(input_tensor, weight=weight)
 
 
 def test_batch_norm(device):

--- a/tests/ttnn/docs_examples/test_normalization_examples.py
+++ b/tests/ttnn/docs_examples/test_normalization_examples.py
@@ -244,6 +244,14 @@ def test_softmax(device):
     logger.info(f"Softmax result: {output_tensor}")
 
 
+def test_softmax_default_program_config(device):
+    # Create input tensor
+    tensor = ttnn.rand((1, 1, 32, 64), dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+
+    # Explicitly specify a default config
+    ttnn.softmax_in_place(tensor, dim=-1, program_config=ttnn.SoftmaxDefaultProgramConfig())
+
+
 def test_scale_mask_softmax(device):
     # Setup input tensor and mask
     compute_grid_size = device.compute_with_storage_grid_size()
@@ -270,8 +278,9 @@ def test_softmax_in_place(device):
     input_tensor = ttnn.rand(shape, dtype=ttnn.DataType.BFLOAT16, layout=ttnn.TILE_LAYOUT, device=device)
 
     # Apply in-place softmax
-    output_tensor = ttnn.softmax_in_place(input_tensor)
-    logger.info(f"Softmax In Place result: {output_tensor}")
+    logger.info(f"Input tensor before softmax in place: {input_tensor}")
+    ttnn.softmax_in_place(input_tensor)
+    logger.info(f"Input tensor after softmax in place: {input_tensor}")
 
 
 def test_scale_mask_softmax_in_place(device):

--- a/tests/ttnn/docs_examples/test_normalization_examples.py
+++ b/tests/ttnn/docs_examples/test_normalization_examples.py
@@ -203,6 +203,7 @@ def test_rms_norm_distributed(device):
     logger.info(f"RMS Norm Pre All Gather result: {stats}")
 
     # On a distributed setup, an all gather would go here to collect the stats from all the devices
+    # See documentation for ttnn.all_gather for example usage of all_gather
 
     # Now apply the post-all-gather RMS normalization
     output = ttnn.rms_norm_post_all_gather(input_tensor, stats, weight=weight)

--- a/tests/ttnn/docs_examples/test_reduction_examples.py
+++ b/tests/ttnn/docs_examples/test_reduction_examples.py
@@ -141,6 +141,32 @@ def test_cumsum(device):
     logger.info(f"Cumsum result: {tensor_output}")
 
 
+def test_ema(device):
+    # Create tensor
+    tensor_input = ttnn.rand((1, 2, 64, 128), device=device, layout=ttnn.TILE_LAYOUT)
+
+    # Apply ttnn.ema() with alpha=0.99
+    tensor_output = ttnn.ema(tensor_input, 0.99)
+    logger.info(f"EMA result: {tensor_output}")
+
+    # With preallocated output
+    preallocated_output = ttnn.rand([1, 2, 64, 128], dtype=ttnn.bfloat16, device=device, layout=ttnn.TILE_LAYOUT)
+    tensor_output = ttnn.ema(tensor_input, 0.99, out=preallocated_output)
+    logger.info(f"EMA with preallocated output result: {tensor_output}")
+
+
+def test_moe(device):
+    N, C, H, W = 1, 1, 32, 64
+    k = 32
+
+    input_tensor = ttnn.rand([N, C, H, W], dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    expert_mask = ttnn.zeros([N, C, 1, W], dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    topE_mask = ttnn.zeros([N, C, 1, k], dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+
+    tensor_output = ttnn.moe(input_tensor, expert_mask, topE_mask, k)
+    logger.info(f"MOE result: {tensor_output}")
+
+
 def test_manual_seed(device):
     # Set manual seed with scalar seed value for all cores
     ttnn.manual_seed(seeds=42, device=device)

--- a/ttnn/cpp/ttnn/operations/matmul/matmul_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul_pybind.cpp
@@ -516,7 +516,7 @@ void py_module(py::module& module) {
             memory_config(ttnn.MemoryConfig, optional): the memory configuration of the output tensor. Defaults to `None`, which will result in using ttnn.DRAM_MEMORY_CONFIG.
             dtype (ttnn.DataType): the data type of the output tensor. Defaults to `None`.
             program_config (ttnn.MatmulProgramConfig): the program configuration for the matmul operation. Defaults to `None`.
-            activation (str or ttnn.UnaryWithParam, optional): the activation function to be applied. When using sharded tensors, the :attr:`fused_activation` parameter of the :attr:`program_config` should be used instead. Defaults to `None`.
+            activation (str or ttnn.UnaryWithParam, optional): the activation function to be applied. When using sharded tensors are used, the :attr:`fused_activation` parameter of the :attr:`program_config` should be used instead. Defaults to `None`.
             compute_kernel_config (ttnn.DeviceComputeKernelConfig): the compute kernel configuration for the matmul operation. Defaults to `None`.
             core_grid (ttnn.CoreGrid): the grid on which to distribute the sharded tensor on (writes to the cores L1s). Defaults to `None`.
             output_tile (List of [int], optional): Specifies the output tile configuration. Defaults to `None`.
@@ -669,7 +669,7 @@ void py_module(py::module& module) {
             memory_config (ttnn.MemoryConfig, optional): the memory configuration of the output tensor. Defaults to `None`, which will result in using `ttnn.DRAM_MEMORY_CONFIG`.
             dtype (ttnn.DataType, optional): the data type of the output tensor. Defaults to `None`.
             program_config (MatmulProgramConfig, optional): the program configuration for the matmul operation. Defaults to `None`.
-            activation (str or ttnn.UnaryWithParam, optional): the activation function to be applied. When using sharded tensors, the :attr:`fused_activation` parameter of the :attr:`program_config` should be used instead. Defaults to `None`.
+            activation (str or ttnn.UnaryWithParam, optional): the activation function to be applied. Defaults to `None`. When using sharded tensors are used, the :attr:`fused_activation` parameter of the :attr:`program_config` should be used instead.
             compute_kernel_config (ttnn.DeviceComputeKernelConfig, optional): the compute kernel configuration for the matmul operation. Defaults to `None`.
             core_grid (ttnn.CoreGrid, optional): the grid on which to distribute the sharded tensor on (writes to the cores L1s). Defaults to `None`.
             output_tile (List of [int], optional): Specifies the output tile configuration. Defaults to `None`.
@@ -766,7 +766,7 @@ void py_module(py::module& module) {
             memory_config (ttnn.MemoryConfig, optional): the memory configuration of the output tensor. Defaults to `None`, which will result in using `ttnn.DRAM_MEMORY_CONFIG`.
             dtype (ttnn.DataType, optional): the data type of the output tensor. Defaults to `None`.
             program_config (MatmulProgramConfig, optional): the program configuration for the matmul operation. Defaults to `None`.
-            activation (str or ttnn.UnaryWithParam, optional): the activation function to be applied. When using sharded tensors, the :attr:`fused_activation` parameter of the :attr:`program_config` should be used instead. Defaults to `None`.
+            activation (str or ttnn.UnaryWithParam, optional): the activation function to be applied. Defaults to `None`. When using sharded tensors are used, the :attr:`fused_activation` parameter of the :attr:`program_config` should be used instead.
             compute_kernel_config (ttnn.DeviceComputeKernelConfig, optional): the compute kernel configuration for the matmul operation. Defaults to `None`.
             core_grid (ttnn.CoreGrid, optional): the grid on which to distribute the sharded tensor on (writes to the cores L1s). Defaults to `None`.
             output_tile (List of [int], optional): Specifies the output tile configuration. Defaults to `None`.

--- a/ttnn/cpp/ttnn/operations/matmul/matmul_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul_pybind.cpp
@@ -738,7 +738,7 @@ void py_module(py::module& module) {
 
         Args:
             input_tensor_a (ttnn.Tensor): the first tensor to be multiplied. Needs to be on the device.
-            input_tensors_b (ttnn.Tensor): the second tensor vector to be multiplied. Needs to be on the device.
+            input_tensors_b (List of ttnn.Tensor): the tensors to be multiplied. Needs to be on the device.
 
         Note:
             The tensors support the following data types and layouts:
@@ -771,9 +771,11 @@ void py_module(py::module& module) {
             core_grid (ttnn.CoreGrid, optional): the grid on which to distribute the sharded tensor on (writes to the cores L1s). Defaults to `None`.
             output_tile (List of [int], optional): Specifies the output tile configuration. Defaults to `None`.
             optional_output_tensor (ttnn.Tensor, optional): User provided on-device output tensor where the result of linear is to be written. Defaults to `None`.
+            global_cb (ttnn.GlobalCircularBuffer, optional): the global circular buffer to be used for the matmul operation. Defaults to `None`.
+            sub_device_id (ttnn.SubDeviceId, optional): the sub device id to be used for the matmul operation. Defaults to `None`.
 
         Returns:
-            ttnn.Tensor: the output tensor.
+            List of ttnn.Tensor: the output tensors.
         )doc",
         ttnn::pybind_overload_t{
             [](decltype(::ttnn::matmul_batched_weights)& self,

--- a/ttnn/cpp/ttnn/operations/matmul/matmul_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul_pybind.cpp
@@ -516,7 +516,7 @@ void py_module(py::module& module) {
             memory_config(ttnn.MemoryConfig, optional): the memory configuration of the output tensor. Defaults to `None`, which will result in using ttnn.DRAM_MEMORY_CONFIG.
             dtype (ttnn.DataType): the data type of the output tensor. Defaults to `None`.
             program_config (ttnn.MatmulProgramConfig): the program configuration for the matmul operation. Defaults to `None`.
-            activation (str or ttnn.UnaryWithParam, optional): the activation function to be applied. When using sharded tensors are used, the :attr:`fused_activation` parameter of the :attr:`program_config` should be used instead. Defaults to `None`.
+            activation (str or ttnn.UnaryWithParam, optional): the activation function to be applied. When using sharded tensors, the :attr:`fused_activation` parameter of the :attr:`program_config` should be used instead. Defaults to `None`.
             compute_kernel_config (ttnn.DeviceComputeKernelConfig): the compute kernel configuration for the matmul operation. Defaults to `None`.
             core_grid (ttnn.CoreGrid): the grid on which to distribute the sharded tensor on (writes to the cores L1s). Defaults to `None`.
             output_tile (List of [int], optional): Specifies the output tile configuration. Defaults to `None`.
@@ -669,7 +669,7 @@ void py_module(py::module& module) {
             memory_config (ttnn.MemoryConfig, optional): the memory configuration of the output tensor. Defaults to `None`, which will result in using `ttnn.DRAM_MEMORY_CONFIG`.
             dtype (ttnn.DataType, optional): the data type of the output tensor. Defaults to `None`.
             program_config (MatmulProgramConfig, optional): the program configuration for the matmul operation. Defaults to `None`.
-            activation (str or ttnn.UnaryWithParam, optional): the activation function to be applied. Defaults to `None`. When using sharded tensors are used, the :attr:`fused_activation` parameter of the :attr:`program_config` should be used instead.
+            activation (str or ttnn.UnaryWithParam, optional): the activation function to be applied. Defaults to `None`. When using sharded tensors, the :attr:`fused_activation` parameter of the :attr:`program_config` should be used instead.
             compute_kernel_config (ttnn.DeviceComputeKernelConfig, optional): the compute kernel configuration for the matmul operation. Defaults to `None`.
             core_grid (ttnn.CoreGrid, optional): the grid on which to distribute the sharded tensor on (writes to the cores L1s). Defaults to `None`.
             output_tile (List of [int], optional): Specifies the output tile configuration. Defaults to `None`.
@@ -768,7 +768,7 @@ void py_module(py::module& module) {
             memory_config (ttnn.MemoryConfig, optional): the memory configuration of the output tensor. Defaults to `None`, which will result in using `ttnn.DRAM_MEMORY_CONFIG`.
             dtype (ttnn.DataType, optional): the data type of the output tensor. Defaults to `None`.
             program_config (MatmulProgramConfig, optional): the program configuration for the matmul operation. Defaults to `None`.
-            activation (str or ttnn.UnaryWithParam, optional): the activation function to be applied. Defaults to `None`. When using sharded tensors are used, the :attr:`fused_activation` parameter of the :attr:`program_config` should be used instead.
+            activation (str or ttnn.UnaryWithParam, optional): the activation function to be applied. Defaults to `None`. When using sharded tensors, the :attr:`fused_activation` parameter of the :attr:`program_config` should be used instead.
             compute_kernel_config (ttnn.DeviceComputeKernelConfig, optional): the compute kernel configuration for the matmul operation. Defaults to `None`.
             core_grid (ttnn.CoreGrid, optional): the grid on which to distribute the sharded tensor on (writes to the cores L1s). Defaults to `None`.
             output_tile (List of [int], optional): Specifies the output tile configuration. Defaults to `None`.

--- a/ttnn/cpp/ttnn/operations/matmul/matmul_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul_pybind.cpp
@@ -734,7 +734,9 @@ void py_module(py::module& module) {
         module,
         ::ttnn::matmul_batched_weights,
         R"doc(
-        performs matrix multiplication for a single input tensor a with multiple tensors b, return a vector of output tensors.
+        DEPRECATED: This is for experimental internal use and is not supported.
+
+        Performs matrix multiplication for a single input tensor a with multiple tensors b, and returns a vector of output tensors.
 
         Args:
             input_tensor_a (ttnn.Tensor): the first tensor to be multiplied. Needs to be on the device.

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/batch_norm_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/batch_norm_pybind.cpp
@@ -64,6 +64,8 @@ void bind_batch_norm_operation(py::module& module) {
 
             These apply for all the tensor inputs to this operation, including the optional :attr:`output` tensor.
 
+            The output tensor will be in TILE layout and have the same dtype as the :attr:`input_tensor`
+
         Memory Support:
             - Interleaved: DRAM and L1
 

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm_pybind.cpp
@@ -91,13 +91,7 @@ void bind_normalization_group_norm_operation(pybind11::module& module) {
                     * - BFLOAT16, BFLOAT8_B
                       - TILE
 
-                .. list-table:: output_tensor
-                    :header-rows: 1
-
-                    * - dtype
-                      - layout
-                    * - BFLOAT16
-                      - TILE, ROW_MAJOR
+                The output will be BFLOAT16, and both the layout and the memory configuration will match the :attr:`input_tensor`.
 
             Memory Support:
               - Interleaved: DRAM and L1

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/layernorm_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/layernorm_pybind.cpp
@@ -100,14 +100,6 @@ void bind_normalization_layernorm_operation(py::module& module) {
                * - BFLOAT16, FLOAT32
                  - TILE, ROW_MAJOR
 
-            .. list-table:: stats (POST_ALL_GATHER only)
-               :header-rows: 1
-
-               * - dtype
-                 - layout
-               * - BFLOAT16
-                 - TILE
-
             .. list-table:: output_tensor
                :header-rows: 1
 
@@ -116,7 +108,7 @@ void bind_normalization_layernorm_operation(py::module& module) {
                * - BFLOAT16, FLOAT32, BFLOAT8_B
                  - TILE
 
-            Output dtype typically matches input; PRE_ALL_GATHER produces BF16
+            Output tensor will be in TILE layout and have the same dtype as the :attr:`input_tensor`
 
         Memory Support:
             - Interleaved: DRAM and L1

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/layernorm_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/layernorm_pybind.cpp
@@ -43,7 +43,7 @@ void bind_normalization_layernorm_operation(py::module& module) {
         module,
         ttnn::layer_norm,
         R"doc(
-        Compute layer norm over :attr:`input_tensor`.
+        Computes layer norm over :attr:`input_tensor`.
         See `Layer Normalization <https://arxiv.org/abs/1607.06450>`_ for more details.
 
           .. math::
@@ -121,6 +121,7 @@ void bind_normalization_layernorm_operation(py::module& module) {
             - If `residual_input_tensor` is provided, it must match the input's padded shape.
             - If TILE: `weight` and `bias` padded dim must match input's last padded dim; padded height must equal TILE_HEIGHT (i.e. 32).
             - If ROW_MAJOR: `weight` and `bias` last padded dim must be TILE_WIDTH and the stick count must align with the input width.
+
         )doc",
 
         ttnn::pybind_arguments_t{

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/layernorm_distributed_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/layernorm_distributed_pybind.cpp
@@ -28,7 +28,8 @@ void bind_normalization_layernorm_pre_all_gather_operation(py::module& module) {
         module,
         ttnn::layer_norm_pre_all_gather,
         R"doc(
-            Compute sum(:attr:`input_tensor`ˆ2) and sum(:attr:`input_tensor`) over the last dimension.
+          This op computes sum(:attr:`input_tensor`ˆ2) and sum(:attr:`input_tensor`) over the last dimension, to efficiently compute layer norm on a distributed setup.
+          Its output should be combined across devices with an all gather, then followed by :func:`ttnn.layer_norm_post_all_gather` to compute layer norm.
 
             Note:
               Supported data types and layouts by tensor ::
@@ -49,6 +50,7 @@ void bind_normalization_layernorm_pre_all_gather_operation(py::module& module) {
                 * - BFLOAT16, FLOAT32, BFLOAT8_B
                   - TILE
 
+                Output stats tensor will be in TILE layout and have dtype of BFLOAT16.
 
             Limitations:
               - Input tensors must be on-device and rank 4.
@@ -72,7 +74,8 @@ void bind_normalization_layernorm_post_all_gather_operation(py::module& module) 
         module,
         ttnn::layer_norm_post_all_gather,
         R"doc(
-            Performs the second part of a distributed layernorm operation normalizing the input based on the gathered statistics input.
+            Performs the second part of a distributed layernorm operation, normalizing the input based on the gathered statistics.
+            The input :attr:`stats` tensor should be computed by :func:`ttnn.layer_norm_pre_all_gather` and then all-gathered across devices.
 
             Note:
               Supported data types and layouts:
@@ -90,7 +93,7 @@ void bind_normalization_layernorm_post_all_gather_operation(py::module& module) 
 
                 * - dtype
                   - layout
-                * - BFLOAT16, BFLOAT8_B
+                * - BFLOAT16
                   - TILE
 
               .. list-table:: weight (gamma) and bias (beta)
@@ -100,6 +103,8 @@ void bind_normalization_layernorm_post_all_gather_operation(py::module& module) 
                   - layout
                 * - BFLOAT16
                   - ROW_MAJOR
+
+              Output tensor will be in TILE layout and have the same dtype as the :attr:`input_tensor`
 
             Limitations:
               - Input tensors must be on-device and rank 4.

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/layernorm_distributed_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/layernorm_distributed_pybind.cpp
@@ -42,7 +42,7 @@ void bind_normalization_layernorm_pre_all_gather_operation(py::module& module) {
               See `Layer Normalization <https://arxiv.org/abs/1607.06450>`_ for more details.
 
               This operation computes :math:`\sum_{}^{}x` and :math:`\sum_{}^{}x^2` over the last dimension.
-              Its output should be combined across devices with an all gather, then followed by :func:`ttnn.layer_norm_post_all_gather` to compute layer norm.
+              Its output should be combined across devices with :func:`ttnn.all_gather`, then followed by :func:`ttnn.layer_norm_post_all_gather` to compute layer norm.
 
               Args:
                 input_tensor (ttnn.Tensor): the input tensor.
@@ -115,7 +115,7 @@ void bind_normalization_layernorm_post_all_gather_operation(py::module& module) 
                 See `Layer Normalization <https://arxiv.org/abs/1607.06450>`_ for more details.
 
                 Performs the second part of a distributed layernorm operation, using the gathered statistics to compute the mean and variance, and finally normalizing the input.
-                The input :attr:`stats` tensor should be computed by gathering the output of :func:`ttnn.layer_norm_pre_all_gather` across all devices.
+                The input :attr:`stats` tensor should be computed by first using :func:`ttnn.layer_norm_pre_all_gather` and then using :func:`ttnn.all_gather` to gather the statistics across all devices.
 
                 Args:
                   input_tensor (ttnn.Tensor): the input tensor.

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/layernorm_distributed_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/layernorm_distributed_pybind.cpp
@@ -28,35 +28,62 @@ void bind_normalization_layernorm_pre_all_gather_operation(py::module& module) {
         module,
         ttnn::layer_norm_pre_all_gather,
         R"doc(
-          This op computes sum(:attr:`input_tensor`ˆ2) and sum(:attr:`input_tensor`) over the last dimension, to efficiently compute layer norm on a distributed setup.
-          Its output should be combined across devices with an all gather, then followed by :func:`ttnn.layer_norm_post_all_gather` to compute layer norm.
+              This operation is used in conjunction with :func:`ttnn.layer_norm_post_all_gather` to compute layer norm on a distributed setup, where layer norm is defined as:
 
-            Note:
-              Supported data types and layouts by tensor ::
+              .. math::
+                \text{layer_norm}(x, \gamma, \beta, \epsilon) = \frac{x - \mu}{\sqrt{\sigma^2 + \epsilon}} \cdot \gamma + \beta
 
-              .. list-table:: input_tensor
-                :header-rows: 1
+              Where:
+                  - :math:`\mu` is the mean of the input tensor. This is computed over the last dimension of the input tensor (W).
+                  - :math:`\sigma^2` is the variance of the input tensor. This is computed over the last dimension of the input tensor (W) and is biased.
+                  - :math:`\gamma` and :math:`\beta` are the learnable scale and shift parameters, respectively
+                  - :math:`\epsilon` is a small constant
 
-                * - dtype
-                  - layout
-                * - BFLOAT16, FLOAT32, BFLOAT8_B
-                  - TILE
+              See `Layer Normalization <https://arxiv.org/abs/1607.06450>`_ for more details.
 
-              .. list-table:: residual_input_tensor
-                :header-rows: 1
+              This operation computes :math:`\sum_{}^{}x` and :math:`\sum_{}^{}x^2` over the last dimension.
+              Its output should be combined across devices with an all gather, then followed by :func:`ttnn.layer_norm_post_all_gather` to compute layer norm.
 
-                * - dtype
-                  - layout
-                * - BFLOAT16, FLOAT32, BFLOAT8_B
-                  - TILE
+              Args:
+                input_tensor (ttnn.Tensor): the input tensor.
+
+              Keyword args:
+                dtype (ttnn.DataType, optional): the data type of the output tensor. Defaults to BFLOAT16.
+                residual_input_tensor (ttnn.Tensor, optional): the residual input tensor. Defaults to None.
+                compute_kernel_config (ttnn.DeviceComputeKernelConfig, optional): the compute kernel configuration. Defaults to None.
+                program_config (ttnn.ProgramConfig, optional): the program configuration. Defaults to None.
+                distributed_program_config (ttnn.LayerNormDistributedDefaultProgramConfig, optional): the distributed program configuration. Defaults to LayerNormDistributedDefaultProgramConfig().
+                memory_config (ttnn.MemoryConfig, optional): the memory configuration. Defaults to None.
+
+              Returns:
+                ttnn.Tensor: the output tensor.
+
+              Note:
+                Supported data types and layouts by tensor:
+
+                .. list-table:: input_tensor
+                  :header-rows: 1
+
+                  * - dtype
+                    - layout
+                  * - BFLOAT16, FLOAT32, BFLOAT8_B
+                    - TILE
+
+                .. list-table:: residual_input_tensor
+                  :header-rows: 1
+
+                  * - dtype
+                    - layout
+                  * - BFLOAT16, FLOAT32, BFLOAT8_B
+                    - TILE
 
                 Output stats tensor will be in TILE layout and have dtype of BFLOAT16.
 
-            Limitations:
-              - Input tensors must be on-device and rank 4.
-              - Unsharded runs: :attr:`input_tensor` must be interleaved.
-              - Sharded runs: inputs cannot be height-sharded, padded height must equal TILE_HEIGHT (32).
-              - When using :attr:`residual_input_tensor` with sharding, it must match the :attr:`input_tensor` padded shape and sharding.
+              Limitations:
+                - Input tensors must be on-device and rank 4.
+                - Unsharded runs: :attr:`input_tensor` must be interleaved.
+                - Sharded runs: inputs cannot be height-sharded, padded height must equal TILE_HEIGHT (32).
+                - When using :attr:`residual_input_tensor` with sharding, it must match the :attr:`input_tensor` padded shape and sharding.
         )doc",
         ttnn::pybind_arguments_t{
             py::arg("input_tensor"),
@@ -74,44 +101,74 @@ void bind_normalization_layernorm_post_all_gather_operation(py::module& module) 
         module,
         ttnn::layer_norm_post_all_gather,
         R"doc(
-            Performs the second part of a distributed layernorm operation, normalizing the input based on the gathered statistics.
-            The input :attr:`stats` tensor should be computed by :func:`ttnn.layer_norm_pre_all_gather` and then all-gathered across devices.
+                This operation is used in conjunction with :func:`ttnn.layer_norm_pre_all_gather` to compute layer norm on a distributed setup, where layer norm is defined as:
 
-            Note:
-              Supported data types and layouts:
+                .. math::
+                  \text{layer_norm}(x, \gamma, \beta, \epsilon) = \frac{x - \mu}{\sqrt{\sigma^2 + \epsilon}} \cdot \gamma + \beta
 
-              .. list-table:: input_tensor
-                :header-rows: 1
+                Where:
+                    - :math:`\mu` is the mean of the input tensor. This is computed over the last dimension of the input tensor (W).
+                    - :math:`\sigma^2` is the variance of the input tensor. This is computed over the last dimension of the input tensor (W) and is biased.
+                    - :math:`\gamma` and :math:`\beta` are the learnable scale and shift parameters, respectively
+                    - :math:`\epsilon` is a small constant
 
-                * - dtype
-                  - layout
-                * - BFLOAT16, BFLOAT8_B
-                  - TILE
+                See `Layer Normalization <https://arxiv.org/abs/1607.06450>`_ for more details.
 
-              .. list-table:: stats
-                :header-rows: 1
+                Performs the second part of a distributed layernorm operation, using the gathered statistics to compute the mean and variance, and finally normalizing the input.
+                The input :attr:`stats` tensor should be computed by gathering the output of :func:`ttnn.layer_norm_pre_all_gather` across all devices.
 
-                * - dtype
-                  - layout
-                * - BFLOAT16
-                  - TILE
+                Args:
+                  input_tensor (ttnn.Tensor): the input tensor.
+                  stats (ttnn.Tensor): the stats tensor.
 
-              .. list-table:: weight (gamma) and bias (beta)
-                :header-rows: 1
+                Keyword args:
+                  epsilon (float, optional): the epsilon value. Defaults to 1e-12.
+                  weight (ttnn.Tensor, optional): the weight tensor. Defaults to None.
+                  bias (ttnn.Tensor, optional): the bias tensor. Defaults to None.
+                  memory_config (ttnn.MemoryConfig, optional): the memory configuration. Defaults to None.
+                  compute_kernel_config (ttnn.DeviceComputeKernelConfig, optional): the compute kernel configuration. Defaults to None.
+                  program_config (ttnn.ProgramConfig, optional): the program configuration. Defaults to None.
+                  distributed_program_config (ttnn.LayerNormDistributedDefaultProgramConfig, optional): the distributed program configuration. Defaults to LayerNormDistributedDefaultProgramConfig().
+                  dtype (ttnn.DataType, optional): the data type of the output tensor. Defaults to None.
 
-                * - dtype
-                  - layout
-                * - BFLOAT16
-                  - ROW_MAJOR
+                Returns:
+                  ttnn.Tensor: the output tensor.
 
-              Output tensor will be in TILE layout and have the same dtype as the :attr:`input_tensor`
+                Note:
+                  Supported data types and layouts:
 
-            Limitations:
-              - Input tensors must be on-device and rank 4.
-              - The last padded dim of :attr:`stats` must be a multiple of TILE_WIDTH.
-              - The first three padded dims of :attr:`stats` must match :attr:`input_tensor`.
-              - If :attr:`weight` (gamma) is provided, :attr:`bias` (beta) must also be provided with matching layouts with their last padded dim matching TILE_WIDTH.
-              - Sharded runs: inputs cannot be height-sharded, padded height must equal TILE_HEIGHT (32), and :attr:`stats` must be sharded with `num_cores=1` and expected tile columns per device.
+                  .. list-table:: input_tensor
+                    :header-rows: 1
+
+                    * - dtype
+                      - layout
+                    * - BFLOAT16, BFLOAT8_B
+                      - TILE
+
+                  .. list-table:: stats
+                    :header-rows: 1
+
+                    * - dtype
+                      - layout
+                    * - BFLOAT16
+                      - TILE
+
+                  .. list-table:: weight (gamma) and bias (beta)
+                    :header-rows: 1
+
+                    * - dtype
+                      - layout
+                    * - BFLOAT16
+                      - ROW_MAJOR
+
+                  Output tensor will be in TILE layout and have the same dtype as the :attr:`input_tensor`
+
+                Limitations:
+                  - Input tensors must be on-device and rank 4.
+                  - The last padded dim of :attr:`stats` must be a multiple of TILE_WIDTH.
+                  - The first three padded dims of :attr:`stats` must match :attr:`input_tensor`.
+                  - If :attr:`weight` (gamma) is provided, :attr:`bias` (beta) must also be provided with matching layouts with their last padded dim matching TILE_WIDTH.
+                  - Sharded runs: inputs cannot be height-sharded, padded height must equal TILE_HEIGHT (32), and :attr:`stats` must be sharded with `num_cores=1` and expected tile columns per device.
         )doc",
         ttnn::pybind_arguments_t{
             py::arg("input_tensor"),

--- a/ttnn/cpp/ttnn/operations/normalization/rmsnorm_distributed/rmsnorm_distributed_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/rmsnorm_distributed/rmsnorm_distributed_pybind.cpp
@@ -23,7 +23,8 @@ void bind_normalization_rmsnorm_pre_all_gather_operation(py::module& module) {
         module,
         ttnn::rms_norm_pre_all_gather,
         R"doc(
-            Compute sum(:attr:`input_tensor`ˆ2) and sum(:attr:`input_tensor`) over the last dimension.
+            Computes sum(:attr:`input_tensor`ˆ2) and sum(:attr:`input_tensor`) over the last dimension, to efficiently compute RMS norm on a distributed setup.
+            Its output should be combined across devices with an all gather, then followed by :func:`ttnn.rms_norm_post_all_gather` to compute RMS norm.
 
             Note:
               Supported data types and layouts by tensor ::
@@ -43,6 +44,8 @@ void bind_normalization_rmsnorm_pre_all_gather_operation(py::module& module) {
                   - layout
                 * - BFLOAT16, FLOAT32, BFLOAT8_B
                   - TILE
+
+              Output stats tensor will in TILE layout and have dtype of BFLOAT16.
 
             Limitations:
               - All tensors must be on-device.
@@ -67,7 +70,8 @@ void bind_normalization_rmsnorm_post_all_gather_operation(py::module& module) {
         module,
         ttnn::rms_norm_post_all_gather,
         R"doc(
-            Performs the second part of a distributed RMSNorm operation normalizing the input based on the gathered statistics input.
+            Performs the second part of a distributed RMSNorm operation, normalizing the input based on the gathered statistics.
+            The input :attr:`stats` tensor should be computed by :func:`ttnn.rms_norm_pre_all_gather` and then all-gathered across devices.
 
             Note:
               Supported data types and layouts:
@@ -85,7 +89,7 @@ void bind_normalization_rmsnorm_post_all_gather_operation(py::module& module) {
 
                 * - dtype
                   - layout
-                * - BFLOAT16, BFLOAT8_B
+                * - BFLOAT16
                   - TILE
 
               .. list-table:: weight (gamma) and bias (beta)
@@ -95,6 +99,8 @@ void bind_normalization_rmsnorm_post_all_gather_operation(py::module& module) {
                   - layout
                 * - BFLOAT16, FLOAT32
                   - TILE, ROW_MAJOR
+
+              Output tensor will be in TILE layout and have the same dtype as the :attr:`input_tensor`
 
             Limitations:
               - All tensors must be on-device.

--- a/ttnn/cpp/ttnn/operations/normalization/rmsnorm_distributed/rmsnorm_distributed_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/rmsnorm_distributed/rmsnorm_distributed_pybind.cpp
@@ -105,8 +105,6 @@ void bind_normalization_rmsnorm_post_all_gather_operation(py::module& module) {
 
                 See `Root Mean Square Layer Normalization <https://arxiv.org/pdf/1910.07467>`_ for more details.
 
-                The input :attr:`stats` tensor should be computed by :func:`ttnn.rms_norm_pre_all_gather` and then all-gathered across devices.
-
                 Performs the second part of a distributed RMSNorm operation, using the gathered statistics to compute the mean and variance, and finally normalizing the input.
                 The input :attr:`stats` tensor should be computed by gathering the output of :func:`ttnn.rms_norm_pre_all_gather` across all devices.
 

--- a/ttnn/cpp/ttnn/operations/normalization/rmsnorm_distributed/rmsnorm_distributed_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/rmsnorm_distributed/rmsnorm_distributed_pybind.cpp
@@ -23,35 +23,59 @@ void bind_normalization_rmsnorm_pre_all_gather_operation(py::module& module) {
         module,
         ttnn::rms_norm_pre_all_gather,
         R"doc(
-            Computes sum(:attr:`input_tensor`ˆ2) and sum(:attr:`input_tensor`) over the last dimension, to efficiently compute RMS norm on a distributed setup.
-            Its output should be combined across devices with an all gather, then followed by :func:`ttnn.rms_norm_post_all_gather` to compute RMS norm.
+              This operation is used in conjunction with :func:`ttnn.rms_norm_post_all_gather` to compute RMS norm on a distributed setup, where RMS norm is defined as:
 
-            Note:
-              Supported data types and layouts by tensor ::
+              .. math::
+                \text{RMS_norm}(x, \gamma, \beta, \epsilon) = \frac{x}{\sqrt{\epsilon+\frac{1}{N}\sum_{i=1}^{N}x^{2}}} \cdot \gamma + \beta
 
-              .. list-table:: input_tensor
-                :header-rows: 1
+              Where:
+                  - :math:`\gamma` and :math:`\beta` are optional scale and shift parameters
+                  - :math:`\epsilon` is a small constant
 
-                * - dtype
-                  - layout
-                * - BFLOAT16, FLOAT32, BFLOAT8_B
-                  - TILE
+              See `Root Mean Square Layer Normalization <https://arxiv.org/pdf/1910.07467>`_ for more details.
 
-              .. list-table:: residual_input_tensor
-                :header-rows: 1
+              This operation computes :math:`\sum_{}^{}x` and :math:`\sum_{}^{}x^2` over the last dimension.
+              Its output should be combined across devices with an all gather, then followed by :func:`ttnn.rms_norm_post_all_gather` to compute the RMS norm.
 
-                * - dtype
-                  - layout
-                * - BFLOAT16, FLOAT32, BFLOAT8_B
-                  - TILE
+              Args:
+                input_tensor (ttnn.Tensor): the input tensor.
 
-              Output stats tensor will in TILE layout and have dtype of BFLOAT16.
+              Keyword args:
+                dtype (ttnn.DataType, optional): the data type of the output tensor. Defaults to BFLOAT16.
+                residual_input_tensor (ttnn.Tensor, optional): the residual input tensor. Defaults to None.
+                compute_kernel_config (ttnn.DeviceComputeKernelConfig, optional): the compute kernel configuration. Defaults to None.
+                program_config (ttnn.ProgramConfig, optional): the program configuration. Defaults to None.
+                distributed_program_config (ttnn.LayerNormDistributedDefaultProgramConfig, optional): the distributed program configuration. Defaults to LayerNormDistributedDefaultProgramConfig().
+                memory_config (ttnn.MemoryConfig, optional): the memory configuration. Defaults to None.
 
-            Limitations:
-              - All tensors must be on-device.
-              - Unsharded inputs must be interleaved
-              - Sharded inputs cannot be height-sharded, padded height must equal TILE_HEIGHT (32). If :attr:`residual_input_tensor` is provided, it must match input's padded shape and sharding.
+              Returns:
+                ttnn.Tensor: the output tensor.
 
+              Note:
+                Supported data types and layouts by tensor:
+
+                .. list-table:: input_tensor
+                  :header-rows: 1
+
+                  * - dtype
+                    - layout
+                  * - BFLOAT16, FLOAT32, BFLOAT8_B
+                    - TILE
+
+                .. list-table:: residual_input_tensor
+                  :header-rows: 1
+
+                  * - dtype
+                    - layout
+                  * - BFLOAT16, FLOAT32, BFLOAT8_B
+                    - TILE
+
+                Output stats tensor will in TILE layout and have dtype of BFLOAT16.
+
+              Limitations:
+                - All tensors must be on-device.
+                - Unsharded inputs must be interleaved
+                - Sharded inputs cannot be height-sharded, padded height must equal TILE_HEIGHT (32). If :attr:`residual_input_tensor` is provided, it must match input's padded shape and sharding.
               )doc",
         ttnn::pybind_arguments_t{
             py::arg("input_tensor"),
@@ -70,43 +94,73 @@ void bind_normalization_rmsnorm_post_all_gather_operation(py::module& module) {
         module,
         ttnn::rms_norm_post_all_gather,
         R"doc(
-            Performs the second part of a distributed RMSNorm operation, normalizing the input based on the gathered statistics.
-            The input :attr:`stats` tensor should be computed by :func:`ttnn.rms_norm_pre_all_gather` and then all-gathered across devices.
+                This operation is used in conjunction with :func:`ttnn.rms_norm_pre_all_gather` to compute RMS norm on a distributed setup, where RMS norm is defined as:
 
-            Note:
-              Supported data types and layouts:
+                .. math::
+                  \text{RMS_norm}(x, \gamma, \beta, \epsilon) = \frac{x}{\sqrt{\epsilon+\frac{1}{N}\sum_{i=1}^{N}x^{2}}} \cdot \gamma + \beta
 
-              .. list-table:: input_tensor
-                :header-rows: 1
+                Where:
+                    - :math:`\gamma` and :math:`\beta` are optional scale and shift parameters
+                    - :math:`\epsilon` is a small constant
 
-                * - dtype
-                  - layout
-                * - BFLOAT16, BFLOAT8_B
-                  - TILE
+                See `Root Mean Square Layer Normalization <https://arxiv.org/pdf/1910.07467>`_ for more details.
 
-              .. list-table:: stats
-                :header-rows: 1
+                The input :attr:`stats` tensor should be computed by :func:`ttnn.rms_norm_pre_all_gather` and then all-gathered across devices.
 
-                * - dtype
-                  - layout
-                * - BFLOAT16
-                  - TILE
+                Performs the second part of a distributed RMSNorm operation, using the gathered statistics to compute the mean and variance, and finally normalizing the input.
+                The input :attr:`stats` tensor should be computed by gathering the output of :func:`ttnn.rms_norm_pre_all_gather` across all devices.
 
-              .. list-table:: weight (gamma) and bias (beta)
-                :header-rows: 1
+                Args:
+                  input_tensor (ttnn.Tensor): the input tensor.
+                  stats (ttnn.Tensor): the stats tensor.
 
-                * - dtype
-                  - layout
-                * - BFLOAT16, FLOAT32
-                  - TILE, ROW_MAJOR
+                Keyword args:
+                  epsilon (float, optional): the epsilon value. Defaults to 1e-12.
+                  weight (ttnn.Tensor, optional): the weight tensor. Defaults to None.
+                  bias (ttnn.Tensor, optional): the bias tensor. Defaults to None.
+                  memory_config (ttnn.MemoryConfig, optional): the memory configuration. Defaults to None.
+                  compute_kernel_config (ttnn.DeviceComputeKernelConfig, optional): the compute kernel configuration. Defaults to None.
+                  program_config (ttnn.ProgramConfig, optional): the program configuration. Defaults to None.
+                  distributed_program_config (ttnn.LayerNormDistributedDefaultProgramConfig, optional): the distributed program configuration. Defaults to LayerNormDistributedDefaultProgramConfig().
+                  dtype (ttnn.DataType, optional): the data type of the output tensor. Defaults to None.
 
-              Output tensor will be in TILE layout and have the same dtype as the :attr:`input_tensor`
+                Returns:
+                  ttnn.Tensor: the output tensor.
 
-            Limitations:
-              - All tensors must be on-device.
-              - The last padded dim of :attr:`stats` must be a multiple of TILE_WIDTH, and its first three padded dims must match :attr:`input_tensor`.
-              - If :attr:`weight` (gamma) is provided, :attr:`bias` (beta) must also be provided. Gamma and beta must have the same layout. If this is ROW_MAJOR, last padded dim must be TILE_WIDTH.
-              - Sharded runs: inputs cannot be height-sharded; padded height must equal TILE_HEIGHT (32). When sharded, :attr:`stats` must be sharded across one core.
+                Note:
+                  Supported data types and layouts:
+
+                  .. list-table:: input_tensor
+                    :header-rows: 1
+
+                    * - dtype
+                      - layout
+                    * - BFLOAT16, BFLOAT8_B
+                      - TILE
+
+                  .. list-table:: stats
+                    :header-rows: 1
+
+                    * - dtype
+                      - layout
+                    * - BFLOAT16
+                      - TILE
+
+                  .. list-table:: weight (gamma) and bias (beta)
+                    :header-rows: 1
+
+                    * - dtype
+                      - layout
+                    * - BFLOAT16, FLOAT32
+                      - TILE, ROW_MAJOR
+
+                  Output tensor will be in TILE layout and have the same dtype as the :attr:`input_tensor`
+
+                Limitations:
+                  - All tensors must be on-device.
+                  - The last padded dim of :attr:`stats` must be a multiple of TILE_WIDTH, and its first three padded dims must match :attr:`input_tensor`.
+                  - If :attr:`weight` (gamma) is provided, :attr:`bias` (beta) must also be provided. Gamma and beta must have the same layout. If this is ROW_MAJOR, last padded dim must be TILE_WIDTH.
+                  - Sharded runs: inputs cannot be height-sharded; padded height must equal TILE_HEIGHT (32). When sharded, :attr:`stats` must be sharded across one core.
         )doc",
         ttnn::pybind_arguments_t{
             py::arg("input_tensor"),

--- a/ttnn/cpp/ttnn/operations/normalization/rmsnorm_distributed/rmsnorm_distributed_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/rmsnorm_distributed/rmsnorm_distributed_pybind.cpp
@@ -35,7 +35,7 @@ void bind_normalization_rmsnorm_pre_all_gather_operation(py::module& module) {
               See `Root Mean Square Layer Normalization <https://arxiv.org/pdf/1910.07467>`_ for more details.
 
               This operation computes :math:`\sum_{}^{}x` and :math:`\sum_{}^{}x^2` over the last dimension.
-              Its output should be combined across devices with an all gather, then followed by :func:`ttnn.rms_norm_post_all_gather` to compute the RMS norm.
+              Its output should be combined across devices with :func:`ttnn.all_gather`, then followed by :func:`ttnn.rms_norm_post_all_gather` to compute the RMS norm.
 
               Args:
                 input_tensor (ttnn.Tensor): the input tensor.
@@ -106,7 +106,7 @@ void bind_normalization_rmsnorm_post_all_gather_operation(py::module& module) {
                 See `Root Mean Square Layer Normalization <https://arxiv.org/pdf/1910.07467>`_ for more details.
 
                 Performs the second part of a distributed RMSNorm operation, using the gathered statistics to compute the mean and variance, and finally normalizing the input.
-                The input :attr:`stats` tensor should be computed by gathering the output of :func:`ttnn.rms_norm_pre_all_gather` across all devices.
+                The input :attr:`stats` tensor should be computed by first using :func:`ttnn.rms_norm_pre_all_gather` and then using :func:`ttnn.all_gather` to gather the statistics across all devices.
 
                 Args:
                   input_tensor (ttnn.Tensor): the input tensor.

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_device_operation.cpp
@@ -215,6 +215,11 @@ void SoftmaxDeviceOperation::validate_on_program_cache_miss(
                             !attributes.is_scale_causal_mask_hw_dims_softmax,
                             "Scale causal mask HW dims softmax not supported in default program config");
                     } else if constexpr (std::is_same_v<ProgramConfigType, SoftmaxShardedMultiCoreProgramConfig>) {
+                        // Ensure input tensor is sharded when using sharded program config
+                        TT_FATAL(
+                            tensors_args.input_tensor.is_sharded() &&
+                                tensors_args.input_tensor.shard_spec().has_value(),
+                            "Input tensor must be sharded when using SoftmaxShardedMultiCoreProgramConfig");
                         const auto& shape = tensors_args.input_tensor.padded_shape();
                         uint32_t M = tensors_args.input_tensor.physical_volume() / shape[-1];
                         uint32_t K = shape[-1];

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_program_factory.cpp
@@ -1269,6 +1269,11 @@ SoftmaxShardedProgramFactoryAttentionOptimized::cached_program_t SoftmaxShardedP
     tt::tt_metal::Program program{};
     auto* device = tensor_args.input_tensor.device();
 
+    // Guard against non-sharded inputs when using a sharded program config
+    TT_FATAL(
+        tensor_args.input_tensor.is_sharded() && tensor_args.input_tensor.shard_spec().has_value(),
+        "Input tensor must be sharded when using SoftmaxShardedMultiCoreProgramConfig");
+
     // convert data format
     tt::DataFormat in0_cb_data_format =
         tt::tt_metal::datatype_to_dataformat_converter(tensor_args.input_tensor.dtype());

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/softmax_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/softmax_pybind.cpp
@@ -147,9 +147,9 @@ void bind_normalization_softmax_scale_mask_operation(py::module& module) {
             Computes a fused scale-mask-softmax operation along the last dimension of the input tensor.
 
             This operation performs the following sequence:
-            1. Optionally scales the input: ``scaled = input_tensor * scale`` (if scale is provided)
-            2. Optionally applies mask: ``masked = scaled + mask`` (if mask is provided, with broadcasting)
-            3. Computes softmax: ``output = softmax(masked)``
+                1. Optionally scales the input: ``scaled = input_tensor * scale`` (if scale is provided)
+                2. Optionally applies mask: ``masked = scaled + mask`` (if mask is provided, with broadcasting)
+                3. Computes softmax: ``output = softmax(masked)``
 
             This fused operation is commonly used in attention mechanisms where scaling and masking
             are applied before the softmax operation for efficiency.
@@ -175,17 +175,17 @@ void bind_normalization_softmax_scale_mask_operation(py::module& module) {
                     :header-rows: 1
 
                     * - Dtypes
-                        - Layouts
+                      - Layouts
                     * - BFLOAT16, FLOAT32, BFLOAT8_B
-                        - TILE
+                      - TILE
 
                 .. list-table:: Mask Tensor (optional)
                     :header-rows: 1
 
                     * - Dtypes
-                        - Layouts
+                      - Layouts
                     * - BFLOAT16, BFLOAT8_B
-                        - TILE, ROW_MAJOR
+                      - TILE, ROW_MAJOR
 
             Limitations:
                 * All tensors must be on-device.
@@ -249,9 +249,9 @@ void bind_normalization_softmax_inplace_operation(py::module& module) {
                     :header-rows: 1
 
                     * - Dtypes
-                        - Layouts
+                      - Layouts
                     * - BFLOAT16, FLOAT32, BFLOAT8_B
-                        - TILE
+                      - TILE
 
             Limitations:
                 * The input tensor is modified in-place to save memory. Must already be on the device.
@@ -289,9 +289,9 @@ void bind_normalization_softmax_scale_mask_inplace_operation(py::module& module)
             Computes a fused scale-mask-softmax operation along the last dimension in-place.
 
             This operation modifies the input tensor directly and performs the following sequence:
-            1. Optionally scales the input: ``input_tensor *= scale`` (if scale is provided)
-            2. Optionally applies mask: ``input_tensor += mask`` (if mask is provided, with broadcasting)
-            3. Computes softmax: ``input_tensor = softmax(input_tensor)``
+                1. Optionally scales the input: ``input_tensor *= scale`` (if scale is provided)
+                2. Optionally applies mask: ``input_tensor += mask`` (if mask is provided, with broadcasting)
+                3. Computes softmax: ``input_tensor = softmax(input_tensor)``
 
             This in-place fused operation is commonly used in attention mechanisms and is memory-efficient
             as it reuses the input tensor for output, avoiding additional memory allocation.
@@ -317,19 +317,19 @@ void bind_normalization_softmax_scale_mask_inplace_operation(py::module& module)
                     :header-rows: 1
 
                     * - Dtypes
-                        - Layouts
+                      - Layouts
                     * - BFLOAT16, FLOAT32, BFLOAT8_B
-                        - TILE
+                      - TILE
 
                 .. list-table:: Mask Tensor (optional)
                     :header-rows: 1
 
                     * - Dtypes
-                        - Layouts
-                        - Ranks
+                      - Layouts
+                      - Ranks
                     * - BFLOAT16, BFLOAT8_B
-                        - TILE, ROW_MAJOR
-                        - 2, 3, 4
+                      - TILE, ROW_MAJOR
+                      - 2, 3, 4
 
             Limitations:
                 * All tensors must be on-device.

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/softmax_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/softmax_pybind.cpp
@@ -256,6 +256,7 @@ void bind_normalization_softmax_inplace_operation(py::module& module) {
                       - Layouts
                     * - BFLOAT16, FLOAT32, BFLOAT8_B
                       - TILE
+
                 The output tensor will be in TILE layout and have the same dtype as the :attr:`input_tensor`
 
             Limitations:

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/softmax_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/softmax_pybind.cpp
@@ -104,9 +104,11 @@ void bind_normalization_softmax_operation(py::module& module) {
                     :header-rows: 1
 
                     * - Dtypes
-                        - Layouts
+                      - Layouts
                     * - BFLOAT16, FLOAT32, BFLOAT8_B
-                        - TILE
+                      - TILE
+
+                The output tensor will be in TILE layout and have the same dtype as the :attr:`input_tensor`
 
             Memory Support:
                 - Interleaved: DRAM and L1
@@ -187,6 +189,8 @@ void bind_normalization_softmax_scale_mask_operation(py::module& module) {
                     * - BFLOAT16, BFLOAT8_B
                       - TILE, ROW_MAJOR
 
+                The output tensor will be in TILE layout and have the same dtype as the :attr:`input_tensor`
+
             Limitations:
                 * All tensors must be on-device.
                 * For ROW_MAJOR masks: intermediate dimensions (except last two) must be 1; last dimension must equal TILE_WIDTH; width must align to input tensor's tile width.
@@ -252,6 +256,7 @@ void bind_normalization_softmax_inplace_operation(py::module& module) {
                       - Layouts
                     * - BFLOAT16, FLOAT32, BFLOAT8_B
                       - TILE
+                The output tensor will be in TILE layout and have the same dtype as the :attr:`input_tensor`
 
             Limitations:
                 * The input tensor is modified in-place to save memory. Must already be on the device.
@@ -330,6 +335,8 @@ void bind_normalization_softmax_scale_mask_inplace_operation(py::module& module)
                     * - BFLOAT16, BFLOAT8_B
                       - TILE, ROW_MAJOR
                       - 2, 3, 4
+
+                The output tensor will be in TILE layout and have the same dtype as the :attr:`input_tensor`
 
             Limitations:
                 * All tensors must be on-device.
@@ -411,9 +418,11 @@ void bind_normalization_softmax_scale_casual_mask_HW_inplace_operation(py::modul
                     :header-rows: 1
 
                     * - Dtypes
-                        - Layouts
+                      - Layouts
                     * - BFLOAT16, BFLOAT8_B
-                        - TILE (interleaved)
+                      - TILE (interleaved)
+
+                The output tensor will be in TILE layout and have the same dtype as the :attr:`input_tensor`
 
             Limitations:
                 * This is an experimental/specialized feature optimized for specific transformer attention patterns.

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/ema_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/ema_pybind.cpp
@@ -56,25 +56,15 @@ void bind_reduction_ema_operation(py::module& module) {
                  - TILE
                  - 4
 
+            The output tensor will be in TILE layout and BFLOAT16.
+
         Memory Support:
             - Interleaved: DRAM and L1
 
         Limitations:
+            - Tensors should be on the device.
             - Preallocated output must have the same shape as the input
 
-        Example:
-            .. code-block:: python
-
-                # Create tensor
-                tensor_input = ttnn.rand((1, 2, 64, 128), device=device, layout=ttnn.TILE_LAYOUT)
-
-                # Apply ttnn.ema() with alpha=0.99
-                tensor_output = ttnn.ema(tensor_input, 0.99)
-
-                # With preallocated output
-                preallocated_output = ttnn.rand([1, 2, 64, 128], dtype=ttnn.bfloat16, device=device, layout=ttnn.TILE_LAYOUT)
-
-                tensor_output = ttnn.ema(tensor_input, 0.99, out=preallocated_output)
 
         )doc";
 

--- a/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions_pybind.hpp
@@ -49,11 +49,12 @@ void bind_reduction_operation(py::module& module, const reduction_operation_t& o
                 * - BFLOAT8_B
                   - ROW_MAJOR, TILE
 
+            The output tensor will be in TILE layout and have the same dtype as the :attr:`input_tensor`
+
         Memory Support:
             - Interleaved: DRAM and L1
             - Sharded (L1): Width, Height, and ND sharding
             - Output sharding will mirror the input
-            - Output layout will be tiled
         )doc",
         operation.base_name(),
         operation.python_fully_qualified_name());

--- a/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions_pybind.hpp
@@ -49,12 +49,11 @@ void bind_reduction_operation(py::module& module, const reduction_operation_t& o
                 * - BFLOAT8_B
                   - ROW_MAJOR, TILE
 
-            The output tensor will match the data type and layout of the input tensor.
-
         Memory Support:
             - Interleaved: DRAM and L1
             - Sharded (L1): Width, Height, and ND sharding
-            - Output sharding/layout will mirror the input
+            - Output sharding will mirror the input
+            - Output layout will be tiled
         )doc",
         operation.base_name(),
         operation.python_fully_qualified_name());

--- a/ttnn/cpp/ttnn/operations/reduction/moe/moe_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/moe/moe_pybind.cpp
@@ -51,7 +51,7 @@ void bind_reduction_moe_operation(py::module& module) {
                         * - BFLOAT16
                           - TILE
 
-                The output tensor will match the data type and layout of the input tensor.
+                The output tensor will be in TILE layout and BFLOAT16.
 
             Memory Support:
                 - Interleaved: DRAM and L1
@@ -64,18 +64,6 @@ void bind_reduction_moe_operation(py::module& module) {
                 - For the :attr:`expert_mask_tensor`, H must be 32 and W must match W of the :attr:`input_tensor`.
                 - All of the shape validations are performed on padded shapes.
                 - Sharding is not supported for this operation.
-
-            Example:
-                .. code-block:: python
-
-                    N, C, H, W = 1, 1, 32, 64
-                    k = 32
-
-                    input_tensor = ttnn.rand([N, C, H, W], dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
-                    expert_mask = ttnn.zeros([N, C, 1, W], dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
-                    topE_mask = ttnn.zeros([N, C, 1, k], dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
-
-                    ttnn_output = ttnn.moe(input_tensor, expert_mask, topE_mask, k)
 
         )doc";
 

--- a/ttnn/cpp/ttnn/operations/reduction/moe/moe_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/moe/moe_pybind.cpp
@@ -21,9 +21,8 @@ void bind_reduction_moe_operation(py::module& module) {
         R"doc(
             Returns the weight of the zero-th MoE expert.
 
-            Equivalent PyTorch code:
-
-            .. code-block:: python
+            Note:
+                This is equivalent to the following PyTorch code:
                 val, ind = torch.topk(input_tensor + expert_mask_tensor, k)
                 return torch.sum(torch.softmax(val+topk_mask_tensor, dim=-1)*(ind==0), dim=-1)
 

--- a/ttnn/cpp/ttnn/operations/reduction/topk/topk_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/topk_pybind.cpp
@@ -62,7 +62,8 @@ void bind_reduction_topk_operation(py::module& module) {
                     * - UINT16, UINT32
                       - TILE
 
-                The :attr:`output_value_tensor` will have the same data type as :attr:`input_tensor` and :attr:`output_index_tensor` will have UINT16 data type.
+                The :attr:`output_value_tensor` will have the same data type as :attr:`input_tensor` and will be in TILE layout.
+                The :attr:`output_index_tensor` will be UINT16 and will be in TILE layout.
 
             Memory Support:
                 - Interleaved: DRAM and L1


### PR DESCRIPTION
### Ticket
Closes https://github.com/tenstorrent/tt-metal/issues/32625
Closes https://github.com/tenstorrent/tt-metal/issues/32621
Closes https://github.com/tenstorrent/tt-metal/issues/32921

### Problem description
A number of ops in the matmul/fused/reduce categories had issues with their docs. The most common issue was not specifying the correct output tensor format/dtype. Certain ops also had defective examples or were missing examples. Finally, the distributed normalisation ops and `moe` as well as `ema` did not get their docs generated at all.

### What's changed
Fixed up the examples and removed all Pytest skips from the matmul/fused/reduce examples.
Created examples for ops that were missing them.
Corrected the .rst so that the missing docs are published. Fixed up these docs so they would also compile.
Ran a number of sanity check tests and corrected output specs.
Removed the documentation for `matmul_batched_weights` as this is an internal op.
Added validation that softmax sharded program config is only used with sharded tensors (this was not enforced previously and result in an unclear bad optional access)

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/19841307734)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests [passes](https://github.com/tenstorrent/tt-metal/actions/runs/19841311455) 
- [x] L2 Nightly Examples [passes](https://github.com/tenstorrent/tt-metal/actions/runs/19841318644)