### PR TITLE
[skip ci] quick modification to aggregate tool

### DIFF
--- a/.github/actions/analyze-workflow-data/lib/reporting.js
+++ b/.github/actions/analyze-workflow-data/lib/reporting.js
@@ -633,7 +633,7 @@ async function enrichRegressions(regressedDetails, filteredGrouped, errorSnippet
         if (item.run_id) {
           item.error_snippets = errorSnippetsCache.get(item.run_id) || await fetchErrorSnippetsForRun(
             item.run_id,
-            20,
+            Number.POSITIVE_INFINITY,
             undefined,
             getAnnotationsDirForRunId(item.run_id)
           );
@@ -748,7 +748,7 @@ async function enrichStayedFailing(stayedFailingDetails, filteredGrouped, errorS
         if (item.run_id) {
           item.error_snippets = errorSnippetsCache.get(item.run_id) || await fetchErrorSnippetsForRun(
             item.run_id,
-            20,
+            Number.POSITIVE_INFINITY,
             undefined,
             getAnnotationsDirForRunId(item.run_id)
           );
@@ -804,7 +804,19 @@ function buildRegressionsSection(regressedDetails, context) {
   const lines = regressedDetails.map(it => {
     const workflowName = it.workflow_url ? `<a href="${it.workflow_url}">${it.name}</a>` : it.name;
     const timeSinceSuccess = getTimeSinceLastSuccess(it.name);
-    const timeBadge = timeSinceSuccess !== EMPTY_VALUE ? ` <em>(Last success: ${timeSinceSuccess})</em>` : '';
+    const workflowFileName = it.workflow_path
+      ? it.workflow_path
+        .replace(/^\.github\/workflows\//, '')
+        .replace(/\.ya?ml$/i, '')
+      : '';
+    const badgeParts = [];
+    if (timeSinceSuccess !== EMPTY_VALUE) {
+      badgeParts.push(`Last success: ${timeSinceSuccess}`);
+    }
+    if (workflowFileName) {
+      badgeParts.push(`workflow file: ${workflowFileName}`);
+    }
+    const timeBadge = badgeParts.length ? ` <em>(${badgeParts.join(', ')})</em>` : '';
 
     if (it.first_failed_run_url) {
       const sha = it.first_failed_head_short || (it.first_failed_head_sha ? it.first_failed_head_sha.substring(0, SHA_SHORT_LENGTH) : undefined);
@@ -866,7 +878,19 @@ function buildStayedFailingSection(stayedFailingDetails, context) {
   const lines = stayedFailingDetails.map(it => {
     const workflowName = it.workflow_url ? `<a href="${it.workflow_url}">${it.name}</a>` : it.name;
     const timeSinceSuccess = getTimeSinceLastSuccess(it.name);
-    const timeBadge = timeSinceSuccess !== EMPTY_VALUE ? ` <em>(Last success: ${timeSinceSuccess})</em>` : '';
+    const workflowFileName = it.workflow_path
+      ? it.workflow_path
+        .replace(/^\.github\/workflows\//, '')
+        .replace(/\.ya?ml$/i, '')
+      : '';
+    const badgeParts = [];
+    if (timeSinceSuccess !== EMPTY_VALUE) {
+      badgeParts.push(`Last success: ${timeSinceSuccess}`);
+    }
+    if (workflowFileName) {
+      badgeParts.push(`workflow file: ${workflowFileName}`);
+    }
+    const timeBadge = badgeParts.length ? ` <em>(${badgeParts.join(', ')})</em>` : '';
 
     if (it.first_failed_run_url) {
       const sha = it.first_failed_head_short || (it.first_failed_head_sha ? it.first_failed_head_sha.substring(0, SHA_SHORT_LENGTH) : undefined);

--- a/.github/actions/analyze-workflow-data/lib/reporting.js
+++ b/.github/actions/analyze-workflow-data/lib/reporting.js
@@ -790,6 +790,22 @@ async function enrichStayedFailing(stayedFailingDetails, filteredGrouped, errorS
   }
 }
 
+function buildWorkflowBadge(workflowPath, timeSinceSuccess) {
+  const workflowFileName = workflowPath
+    ? workflowPath
+      .replace(/^\.github\/workflows\//, '')
+      .replace(/\.ya?ml$/i, '')
+    : '';
+  const badgeParts = [];
+  if (timeSinceSuccess !== EMPTY_VALUE) {
+    badgeParts.push(`Last success: ${timeSinceSuccess}`);
+  }
+  if (workflowFileName) {
+    badgeParts.push(`workflow file: ${workflowFileName}`);
+  }
+  return badgeParts.length ? ` <em>(${badgeParts.join(', ')})</em>` : '';
+}
+
 /**
  * Builds the regressions section of the report
  * @param {Array} regressedDetails - Array of enriched regression detail objects
@@ -804,19 +820,7 @@ function buildRegressionsSection(regressedDetails, context) {
   const lines = regressedDetails.map(it => {
     const workflowName = it.workflow_url ? `<a href="${it.workflow_url}">${it.name}</a>` : it.name;
     const timeSinceSuccess = getTimeSinceLastSuccess(it.name);
-    const workflowFileName = it.workflow_path
-      ? it.workflow_path
-        .replace(/^\.github\/workflows\//, '')
-        .replace(/\.ya?ml$/i, '')
-      : '';
-    const badgeParts = [];
-    if (timeSinceSuccess !== EMPTY_VALUE) {
-      badgeParts.push(`Last success: ${timeSinceSuccess}`);
-    }
-    if (workflowFileName) {
-      badgeParts.push(`workflow file: ${workflowFileName}`);
-    }
-    const timeBadge = badgeParts.length ? ` <em>(${badgeParts.join(', ')})</em>` : '';
+    const timeBadge = buildWorkflowBadge(it.workflow_path, timeSinceSuccess);
 
     if (it.first_failed_run_url) {
       const sha = it.first_failed_head_short || (it.first_failed_head_sha ? it.first_failed_head_sha.substring(0, SHA_SHORT_LENGTH) : undefined);
@@ -878,19 +882,7 @@ function buildStayedFailingSection(stayedFailingDetails, context) {
   const lines = stayedFailingDetails.map(it => {
     const workflowName = it.workflow_url ? `<a href="${it.workflow_url}">${it.name}</a>` : it.name;
     const timeSinceSuccess = getTimeSinceLastSuccess(it.name);
-    const workflowFileName = it.workflow_path
-      ? it.workflow_path
-        .replace(/^\.github\/workflows\//, '')
-        .replace(/\.ya?ml$/i, '')
-      : '';
-    const badgeParts = [];
-    if (timeSinceSuccess !== EMPTY_VALUE) {
-      badgeParts.push(`Last success: ${timeSinceSuccess}`);
-    }
-    if (workflowFileName) {
-      badgeParts.push(`workflow file: ${workflowFileName}`);
-    }
-    const timeBadge = badgeParts.length ? ` <em>(${badgeParts.join(', ')})</em>` : '';
+    const timeBadge = buildWorkflowBadge(it.workflow_path, timeSinceSuccess);
 
     if (it.first_failed_run_url) {
       const sha = it.first_failed_head_short || (it.first_failed_head_sha ? it.first_failed_head_sha.substring(0, SHA_SHORT_LENGTH) : undefined);

--- a/.github/workflows/aggregate-workflow-data.yaml
+++ b/.github/workflows/aggregate-workflow-data.yaml
@@ -256,6 +256,6 @@ jobs:
       - name: Post regressions to Slack
         uses: ./.github/actions/slack-report-analyze-workflow-data
         with:
-          slack_webhook_url: ${{ secrets.SLACK_TESTING_CHANNEL }}
+          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_AGGREGATE_PIPELINE_STATUS_ALERT }}
           regressed_workflows: ${{ needs.analyze-data.outputs.regressed_workflows }}
           alert_all_message: ${{ needs.analyze-data.outputs.alert_all_message }}

--- a/.github/workflows/aggregate-workflow-data.yaml
+++ b/.github/workflows/aggregate-workflow-data.yaml
@@ -256,6 +256,6 @@ jobs:
       - name: Post regressions to Slack
         uses: ./.github/actions/slack-report-analyze-workflow-data
         with:
-          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_AGGREGATE_PIPELINE_STATUS_ALERT }}
+          slack_webhook_url: ${{ secrets.SLACK_TESTING_CHANNEL }}
           regressed_workflows: ${{ needs.analyze-data.outputs.regressed_workflows }}
           alert_all_message: ${{ needs.analyze-data.outputs.alert_all_message }}


### PR DESCRIPTION
### Ticket
NA

### Problem description
Sometimes errors wouldn't be reported because there was a cap on how many snippets could be shown. Also, for using the auto-triage tool, the aggregate workflow tool didn't have the exact name of the workflow file, so running auto-triage often required finding the exact name of the workflow file.

### What's changed
the cap on error snippets has been removed and the aggregate workflow tool now writes the name of the workflow file in the report.

### Checklist
- [x] [Aggregate Workflow Data](https://github.com/tenstorrent/tt-metal/actions/workflows/aggregate-workflow-data.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/19834445100