### PR TITLE
#33488: update cb size calculation in softmax

### DIFF
--- a/tests/ttnn/unit_tests/operations/fused/test_softmax.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_softmax.py
@@ -483,3 +483,15 @@ def test_softmax_accuracy(device, shape, fp32_acc_en, math_approx_mode, expected
     output_torch = ttnn_output.cpu().to_torch()
 
     assert_with_ulp(torch_output, output_torch, expected_ulp)
+
+
+def test_softmax_4096x4096_fp32(device):
+    torch.manual_seed(0)
+    torch_input_tensor = torch.rand((1, 1, 4096, 4096), dtype=torch.float32)
+    torch_output = torch.ops.aten._softmax.default(torch_input_tensor, dim=3, half_to_float=False)
+
+    ttnn_input_tensor = ttnn.from_torch(torch_input_tensor, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
+
+    ttnn_output_tensor = ttnn.softmax(ttnn_input_tensor, dim=3)
+    output_torch = ttnn_output_tensor.cpu().to_torch()
+    assert_with_pcc(torch_output, output_torch, 0.998)

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_program_factory.cpp
@@ -799,9 +799,14 @@ SoftmaxProgramFactoryAttentionOptimized::cached_program_t SoftmaxProgramFactoryA
     uint32_t cb_length = in0_t;
     bool use_large_kernel = false;
     // Noisy CB estimator, if the cbs used take up 90% of L1 switch to large kernel implementation
-    uint32_t cb_size_sum_bytes = (in0_t * in0_tile_size) + (im0_t * im_tile_size);
+    constexpr uint32_t single_tile_cb_count = 5;
+    uint32_t cb_size_sum_bytes = (in0_t * in0_tile_size) + (im0_t * im_tile_size) + (out0_t * out0_tile_size) +
+                                 (single_tile_cb_count * im_tile_size);
+    if (attributes.numeric_stable) {
+        cb_size_sum_bytes += im4_t * im_tile_size;
+    }
     if (tensor_args.mask.has_value()) {
-        cb_size_sum_bytes += (im3_t * im_tile_size) + (im4_t * im_tile_size);
+        cb_size_sum_bytes += (im3_t * im_tile_size) + (in3_t * scalar_tile_size) + (in4_t * mask_tile_size);
     }
 
     // Program specific checks

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_program_factory.cpp
@@ -799,7 +799,7 @@ SoftmaxProgramFactoryAttentionOptimized::cached_program_t SoftmaxProgramFactoryA
     uint32_t cb_length = in0_t;
     bool use_large_kernel = false;
     // Noisy CB estimator, if the cbs used take up 90% of L1 switch to large kernel implementation
-    constexpr uint32_t single_tile_cb_count = 5;
+    constexpr uint32_t single_tile_cb_count = 5;  // approximate
     uint32_t cb_size_sum_bytes = (in0_t * in0_tile_size) + (im0_t * im_tile_size) + (out0_t * out0_tile_size) +
                                  (single_tile_cb_count * im_tile_size);
     if (attributes.numeric_stable) {


### PR DESCRIPTION
### Ticket
Link to Github Issue #33488 

### Problem description
When checking for L1 usage, some CBs were missing and one was accounted for when mask was used instead of the numeric stable flag.

### What's changed
- update the CB usage calculation

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/19835522600
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes