### PR TITLE
Fixing print tests with ND failures in tt-sim

### DIFF
--- a/tests/tt_metal/tt_metal/test_kernels/misc/brisc_print.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/brisc_print.cpp
@@ -4,6 +4,8 @@
 
 #include "dataflow_api.h"
 #include "debug/dprint_test_common.h"
+#include "ckernel.h"
+#include "ckernel_defs.h"
 
 /*
  * Test printing from a kernel running on BRISC.
@@ -18,7 +20,15 @@ void kernel_main() {
     for (uint16_t idx = 0; idx < 32 * 32; idx++) {
         ptr[idx] = BF16(idx + bfloat16_base);
     }
+
+    // Let the other threads (ncrisc) know we're done writing to CB
     cb_push_back(cb_id_in0, 1);
 
+    // Let the trisc threads know that they can proceed
+    mailbox_write(ckernel::ThreadId::MathThreadId, 1);
+    mailbox_write(ckernel::ThreadId::PackThreadId, 1);
+    mailbox_write(ckernel::ThreadId::UnpackThreadId, 1);
+
+    
     DPRINT_DATA0(DPRINT << "Test Debug Print: Data0" << ENDL(); print_test_data(););
 }

--- a/tests/tt_metal/tt_metal/test_kernels/misc/brisc_print.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/brisc_print.cpp
@@ -29,6 +29,5 @@ void kernel_main() {
     mailbox_write(ckernel::ThreadId::PackThreadId, 1);
     mailbox_write(ckernel::ThreadId::UnpackThreadId, 1);
 
-    
     DPRINT_DATA0(DPRINT << "Test Debug Print: Data0" << ENDL(); print_test_data(););
 }

--- a/tests/tt_metal/tt_metal/test_kernels/misc/ncrisc_print.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/ncrisc_print.cpp
@@ -9,9 +9,9 @@
  * Test printing from a kernel running on NCRISC.
  */
 
-void kernel_main() { 
+void kernel_main() {
     // Wait for BRISC to finish writing to CB, then call DPRINT
     constexpr uint32_t cb_id_in0 = tt::CBIndex::c_0;
     cb_wait_front(cb_id_in0, 1);
-    DPRINT_DATA1(DPRINT << "Test Debug Print: Data1" << ENDL(); print_test_data();); 
+    DPRINT_DATA1(DPRINT << "Test Debug Print: Data1" << ENDL(); print_test_data(););
 }

--- a/tests/tt_metal/tt_metal/test_kernels/misc/ncrisc_print.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/ncrisc_print.cpp
@@ -9,4 +9,9 @@
  * Test printing from a kernel running on NCRISC.
  */
 
-void kernel_main() { DPRINT_DATA1(DPRINT << "Test Debug Print: Data1" << ENDL(); print_test_data();); }
+void kernel_main() { 
+    // Wait for BRISC to finish writing to CB, then call DPRINT
+    constexpr uint32_t cb_id_in0 = tt::CBIndex::c_0;
+    cb_wait_front(cb_id_in0, 1);
+    DPRINT_DATA1(DPRINT << "Test Debug Print: Data1" << ENDL(); print_test_data();); 
+}

--- a/tests/tt_metal/tt_metal/test_kernels/misc/trisc_print.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/trisc_print.cpp
@@ -10,8 +10,14 @@
  */
 namespace NAMESPACE {
 void MAIN {
+    // Wait for BRISC to signal it is done writing to CB, then call DPRINT
+    UNPACK(mailbox_read(ThreadId::BriscThreadId););
     DPRINT_UNPACK(DPRINT << "Test Debug Print: Unpack" << ENDL(); print_test_data(););
+
+    MATH(mailbox_read(ThreadId::BriscThreadId););
     DPRINT_MATH(DPRINT << "Test Debug Print: Math" << ENDL(); print_test_data(););
+
+    PACK(mailbox_read(ThreadId::BriscThreadId););
     DPRINT_PACK(DPRINT << "Test Debug Print: Pack" << ENDL(); print_test_data(););
 }
 }  // namespace NAMESPACE


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/ttsim-private/issues/198)

### Problem description
In these tests, brisc writes data to a CB and all cores at that coordinate read some of that data and write it to individual files. However, there is no control flow so it is possible for the non-brisc cores to read the data from the CB before the brisc is done writing. This has caused non-deterministic failures in tt-sim.

### What's changed
Added control flow to the tests. ncrisc now depends on `cb_wait_front` and trisc cores depend on mailbox communication.

Confirmed these tests pass on both HW & tt-sim. ND behaviour in tt-sim tests has disappeared and tests now pass reliably.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes