### PR TITLE
Re-enable Triage tests

### DIFF
--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -312,11 +312,10 @@ jobs:
       run-metal-cpp-unit-tests: true
 
   triage-tests:
-    if: ${{ false && (
+    if: ${{
         github.ref_name == 'main' ||
         needs.find-changes.outputs.cmake-changed == 'true' ||
         needs.find-changes.outputs.any-code-changed == 'true'
-        )
       }}
     needs: [ build, find-changes ]
     strategy:

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -312,11 +312,6 @@ jobs:
       run-metal-cpp-unit-tests: true
 
   triage-tests:
-    if: ${{
-        github.ref_name == 'main' ||
-        needs.find-changes.outputs.cmake-changed == 'true' ||
-        needs.find-changes.outputs.any-code-changed == 'true'
-      }}
     needs: [ build, find-changes ]
     strategy:
       fail-fast: false

--- a/tt_metal/fabric/CMakeLists.txt
+++ b/tt_metal/fabric/CMakeLists.txt
@@ -1,6 +1,8 @@
 add_library(fabric OBJECT)
 add_library(TT::Metalium::Fabric ALIAS fabric)
 
+# DNM: Revert me
+
 # These headers are for the device, not host; will require cross compiling to lint them (future work).
 set_target_properties(
     fabric

--- a/tt_metal/fabric/CMakeLists.txt
+++ b/tt_metal/fabric/CMakeLists.txt
@@ -1,8 +1,6 @@
 add_library(fabric OBJECT)
 add_library(TT::Metalium::Fabric ALIAS fabric)
 
-# DNM: Revert me
-
 # These headers are for the device, not host; will require cross compiling to lint them (future work).
 set_target_properties(
     fabric


### PR DESCRIPTION
### Ticket
N/A

### Problem description
We disabled triage tests when it was broken just before the weekend.  It's fixed now, so time to re-enable it.
Also, we learned that files pretty much anywhere and any format can impact it.  So don't get smart with trying to save resources -- better safe than sorry.

### What's changed
* Enable triage tests
* Run unconditionally