### PR TITLE
Remove duplicate sender channel 0 stream id definition. Pass sender c…

### DIFF
--- a/tt_metal/fabric/builder/fabric_builder_config.cpp
+++ b/tt_metal/fabric/builder/fabric_builder_config.cpp
@@ -48,6 +48,10 @@ uint32_t get_vc0_downstream_edm_count(bool is_2D_routing) {
     return is_2D_routing ? builder_config::num_downstream_edms_2d_vc0 : builder_config::num_downstream_edms_vc0;
 }
 
+uint32_t get_vc1_downstream_edm_count(bool is_2D_routing) {
+    return is_2D_routing ? builder_config::num_downstream_edms_2d_vc1 : builder_config::num_downstream_edms_vc1;
+}
+
 }  // namespace builder_config
 
 }  // namespace tt::tt_fabric

--- a/tt_metal/fabric/builder/fabric_builder_config.hpp
+++ b/tt_metal/fabric/builder/fabric_builder_config.hpp
@@ -65,25 +65,37 @@ static constexpr std::size_t num_sender_channels_1d_ring = 2;
 static constexpr std::size_t num_sender_channels_2d_torus = 4;
 
 static constexpr std::size_t num_sender_channels_1d = 2;
-static constexpr std::size_t num_sender_channels_2d = 4;
+static constexpr std::size_t num_sender_channels_2d = 7;  // Channels 0-6 (includes VC1 channels 4-6 for 2D)
 static constexpr std::size_t num_sender_channels = std::max(num_sender_channels_1d, num_sender_channels_2d);
 static constexpr std::size_t num_downstream_sender_channels = num_sender_channels - 1;
 
-static constexpr std::size_t num_receiver_channels = 1;
+static constexpr std::size_t num_receiver_channels_1d = 1;
+static constexpr std::size_t num_receiver_channels_2d = 2;
+static constexpr std::size_t num_receiver_channels = std::max(num_receiver_channels_1d, num_receiver_channels_2d);
 
 static constexpr std::size_t num_downstream_edms_vc0 = 1;
+static constexpr std::size_t num_downstream_edms_vc1 = 0;  // VC1 not used in 1D
 static constexpr std::size_t num_downstream_edms_2d_vc0 = 3;
-static constexpr std::size_t num_downstream_edms = num_downstream_edms_vc0;
-static constexpr std::size_t num_downstream_edms_2d = num_downstream_edms_2d_vc0;
+static constexpr std::size_t num_downstream_edms_2d_vc1 = 3;  // VC1 has 3 downstream EDMs in 2D
+static constexpr std::size_t num_downstream_edms =
+    num_downstream_edms_vc0 + num_downstream_edms_vc1;
+static constexpr std::size_t num_downstream_edms_2d =
+    num_downstream_edms_2d_vc0 + num_downstream_edms_2d_vc1;
 static constexpr std::size_t max_downstream_edms = std::max(num_downstream_edms, num_downstream_edms_2d);
 
-uint32_t get_sender_channel_count(bool is_2D_routing);
+uint32_t get_sender_channel_count(const bool is_2D_routing);
+
+inline uint32_t get_receiver_channel_count(const bool is_2D_routing) {
+    return is_2D_routing ? builder_config::num_receiver_channels_2d : builder_config::num_receiver_channels_1d;
+}
 
 uint32_t get_num_tensix_sender_channels(Topology topology, tt::tt_fabric::FabricTensixConfig fabric_tensix_config);
 
 uint32_t get_downstream_edm_count(bool is_2D_routing);
 
 uint32_t get_vc0_downstream_edm_count(bool is_2D_routing);
+
+uint32_t get_vc1_downstream_edm_count(bool is_2D_routing);
 
 }  // namespace builder_config
 

--- a/tt_metal/fabric/builder/fabric_remote_channels_allocator.cpp
+++ b/tt_metal/fabric/builder/fabric_remote_channels_allocator.cpp
@@ -13,7 +13,7 @@ namespace tt::tt_fabric {
 FabricRemoteChannelsAllocator::FabricRemoteChannelsAllocator(
     const FabricStaticSizedChannelsAllocator& static_allocator) :
     FabricChannelAllocator(static_allocator.topology_, static_allocator.options_, static_allocator.memory_regions_),
-    num_used_receiver_channels_(builder_config::num_receiver_channels) {
+    num_used_receiver_channels_(static_allocator.get_num_receiver_channels()) {
     // Extract remote receiver channel information from the static allocator
     for (size_t i = 0; i < builder_config::num_receiver_channels; i++) {
         this->remote_receiver_channels_base_address_[i] = static_allocator.remote_receiver_channels_base_address[i];

--- a/tt_metal/fabric/builder/static_sized_channel_connection_writer_adapter.cpp
+++ b/tt_metal/fabric/builder/static_sized_channel_connection_writer_adapter.cpp
@@ -83,12 +83,14 @@ void StaticSizedChannelConnectionWriterAdapter::add_local_tensix_connection(
 }
 
 void StaticSizedChannelConnectionWriterAdapter::pack_inbound_channel_rt_args(uint32_t vc_idx, std::vector<uint32_t>& args_out) const {
-    if (vc_idx == 0 && is_2D_routing) {
-        // For VC0 in 2D: pack connection mask and data for 3 downstream EDMs
+    if ((vc_idx == 0 || vc_idx == 1) && is_2D_routing) {
+        // For VC0 and VC1 in 2D: pack connection mask and data for 3 downstream EDMs
+        size_t num_downstream =
+            (vc_idx == 0) ? builder_config::num_downstream_edms_2d_vc0 : builder_config::num_downstream_edms_2d_vc1;
         args_out.push_back(this->downstream_edms_connected);  // 3-bit mask
 
         // Pack 3 buffer base addresses (one per compact index 0-2)
-        for (size_t compact_idx = 0; compact_idx < builder_config::num_downstream_edms_2d_vc0; compact_idx++) {
+        for (size_t compact_idx = 0; compact_idx < num_downstream; compact_idx++) {
             uint32_t buffer_addr = this->downstream_edm_buffer_base_addresses[vc_idx][compact_idx].value_or(0);
             args_out.push_back(buffer_addr);
         }
@@ -98,17 +100,17 @@ void StaticSizedChannelConnectionWriterAdapter::pack_inbound_channel_rt_args(uin
         args_out.push_back(this->pack_downstream_noc_y_rt_arg(vc_idx));
 
         // Pack 3 worker registration addresses (connection handshake addresses)
-        for (size_t compact_idx = 0; compact_idx < builder_config::num_downstream_edms_2d_vc0; compact_idx++) {
+        for (size_t compact_idx = 0; compact_idx < num_downstream; compact_idx++) {
             args_out.push_back(this->downstream_edm_worker_registration_addresses[vc_idx][compact_idx].value_or(0));
         }
 
         // Pack 3 worker location info addresses
-        for (size_t compact_idx = 0; compact_idx < builder_config::num_downstream_edms_2d_vc0; compact_idx++) {
+        for (size_t compact_idx = 0; compact_idx < num_downstream; compact_idx++) {
             args_out.push_back(this->downstream_edm_worker_location_info_addresses[vc_idx][compact_idx].value_or(0));
         }
 
         // Pack 3 buffer index semaphore addresses
-        for (size_t compact_idx = 0; compact_idx < builder_config::num_downstream_edms_2d_vc0; compact_idx++) {
+        for (size_t compact_idx = 0; compact_idx < num_downstream; compact_idx++) {
             args_out.push_back(this->downstream_edm_buffer_index_semaphore_addresses[vc_idx][compact_idx].value_or(0));
         }
     } else {

--- a/tt_metal/fabric/debug/README.md
+++ b/tt_metal/fabric/debug/README.md
@@ -59,20 +59,21 @@ python3 tt_metal/fabric/debug/fabric_erisc_dumper.py --fabric-streams --stream-g
 The tool provides specialized fabric stream register modes for different aspects of fabric debugging:
 
 #### Flow Control Debugging (Buffer Free Slots)
-- **`sender_free_slots`**: Monitor sender channel buffer space (streams 17-21)
-- **`receiver_free_slots`**: Monitor receiver channel buffer space (streams 12-16)
+- **`sender_free_slots`**: Monitor sender channel buffer space (streams 18-25)
+- **`receiver_free_slots`**: Monitor receiver channel buffer space (streams 11-17)
 - **`all_fabric_free_slots`**: Complete view of all fabric flow control registers (DEFAULT)
 
 **Interpretation:** HIGH values = good (buffers have space for more packets)
 
-#### Acknowledgment and Completion Stream Monitoring (Remote Buffer Status)
-- **`sender_acks`**: Monitor ack stream remote buffer status (streams 2-6)
-- **`sender_completions`**: Monitor completion stream remote buffer status (streams 7-11)
-- **`receiver_pkts_sent`**: Monitor packet sent stream remote buffer status (streams 0-1)
-- **`all_acks_and_completions`**: Combined view of all ack/completion streams (streams 2-11)
+#### Completion Stream Monitoring (Remote Buffer Status)
+- **`sender_completions`**: Monitor completion stream remote buffer status (streams 3-10)
+- **`receiver_pkts_sent`**: Monitor packet sent stream remote buffer status (streams 0-2)
+- **`all_acks_and_completions`**: Combined view of all completion streams (streams 0-10)
 
-**Interpretation:** LOW/ZERO values = good (remote side consuming acks/completions immediately)
-These streams send credits/acks to remote routers. The BUF_SPACE_AVAILABLE register shows buffer space at the remote destination. Zero means the remote side is processing immediately (expected when idle or running smoothly). **Increasing values may indicate the remote side is NOT consuming acks/completions**
+**Note:** Ack streams (streams 2-6) have been removed - only completion streams are now used.
+
+**Interpretation:** LOW/ZERO values = good (remote side consuming completions immediately)
+These streams send credits to remote routers. The BUF_SPACE_AVAILABLE register shows buffer space at the remote destination. Zero means the remote side is processing immediately (expected when idle or running smoothly). **Increasing values may indicate the remote side is NOT consuming completions**
 
 Example matrix output:
 ```
@@ -80,9 +81,9 @@ Example matrix output:
 ALL FABRIC STREAM FREE SLOTS:
 (Complete view of all fabric EDM sender/receiver buffer space for flow control debugging)
 
-                    Stream12   Stream13   Stream14   Stream15   Stream16   Stream17   Stream18   Stream19   Stream20   Stream21
-Dev0 Core(0,5):     0x00001234 0x00001235 0x00001236 0x00001237 0x00001238 0x00001239 0x0000123a 0x0000123b 0x0000123c 0x0000123d
-Dev0 Core(0,7):     0x00001244 0x00001245 0x00001246 0x00001247 0x00001248 0x00001249 0x0000124a 0x0000124b 0x0000124c 0x0000124d
+                    Stream11   Stream12   Stream13   Stream14   Stream15   Stream16   Stream17   Stream18   Stream19   Stream20   Stream21   Stream22   Stream23   Stream24   Stream25
+Dev0 Core(0,5):     0x00001234 0x00001235 0x00001236 0x00001237 0x00001238 0x00001239 0x0000123a 0x0000123b 0x0000123c 0x0000123d 0x0000123e 0x0000123f 0x00001240 0x00001241 0x00001242
+Dev0 Core(0,7):     0x00001244 0x00001245 0x00001246 0x00001247 0x00001248 0x00001249 0x0000124a 0x0000124b 0x0000124c 0x0000124d 0x0000124e 0x0000124f 0x00001250 0x00001251 0x00001252
 ```
 
 ### Requirements

--- a/tt_metal/fabric/debug/fabric_erisc_constants.py
+++ b/tt_metal/fabric/debug/fabric_erisc_constants.py
@@ -75,40 +75,58 @@ STREAM_REGISTER_INDICES = {
 # These streams are used for fabric flow control and backpressure management
 
 # IMPORTANT: Interpretation of BUF_SPACE_AVAILABLE values:
-# - Streams 12-21 (buffer free slots): HIGH values = good (buffers have space)
-# - Streams 0-11 (ack/completion): LOW/ZERO values = good (remote side consuming immediately)
+# - Streams 13+ (buffer free slots): HIGH values = good (buffers have space)
+# - Streams 0-12 (sent/ack/completion): LOW/ZERO values = good (remote side consuming immediately)
 #   For ack/completion streams, the register shows remote destination buffer space.
 #   Zero means remote side is processing acks/completions as they arrive (expected when idle).
 
 FABRIC_STREAM_GROUPS = {
     # ========== Buffer Free Slots (Flow Control) ==========
     "sender_free_slots": {
-        "stream_ids": [17, 18, 19, 20, 21],
-        "labels": ["sender_ch0", "sender_ch1", "sender_ch2", "sender_ch3", "sender_ch4_vc1"],
+        "stream_ids": [19, 20, 21, 22, 23, 24, 25],
+        "labels": [
+            "sender_ch0",
+            "sender_ch1",
+            "sender_ch2",
+            "sender_ch3",
+            "sender_ch4_vc1",
+            "sender_ch5_vc1",
+            "sender_ch6_vc1",
+        ],
         "title": "SENDER CHANNEL FREE SLOTS",
         "description": "Fabric sender channel buffer space available (free slots) for flow control",
         "register_type": "BUF_SPACE_AVAILABLE",
     },
     "receiver_free_slots": {
-        "stream_ids": [12, 13, 14, 15, 16],
-        "labels": ["recv_east", "recv_west", "recv_north", "recv_south", "recv_downstream_vc1"],
+        "stream_ids": [13, 14, 15, 16, 17, 18],
+        "labels": [
+            "recv_vc0_edge1",
+            "recv_vc0_edge2",
+            "recv_vc0_edge3",
+            "recv_vc1_edge1",
+            "recv_vc1_edge2",
+            "recv_vc1_edge3",
+        ],
         "title": "RECEIVER CHANNEL FREE SLOTS",
         "description": "Fabric receiver channel buffer space available (free slots) for flow control",
         "register_type": "BUF_SPACE_AVAILABLE",
     },
     "all_fabric_free_slots": {
-        "stream_ids": [12, 13, 14, 15, 16, 17, 18, 19, 20, 21],
+        "stream_ids": [13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25],
         "labels": [
-            "recv_east",  # Stream 12: East receiver channel
-            "recv_west",  # Stream 13: West receiver channel
-            "recv_north",  # Stream 14: North receiver channel
-            "recv_south",  # Stream 15: South receiver channel
-            "recv_downstream_vc1",  # Stream 16: Downstream VC1 receiver
-            "sender_ch0",  # Stream 17: Sender channel 0
-            "sender_ch1",  # Stream 18: Sender channel 1
-            "sender_ch2",  # Stream 19: Sender channel 2
-            "sender_ch3",  # Stream 20: Sender channel 3
-            "sender_ch4_vc1",  # Stream 21: Sender channel 4 VC1
+            "recv_vc0_edge1",  # Stream 13: VC0 from downstream edge 1
+            "recv_vc0_edge2",  # Stream 14: VC0 from downstream edge 2
+            "recv_vc0_edge3",  # Stream 15: VC0 from downstream edge 3
+            "recv_vc1_edge1",  # Stream 16: VC1 from downstream edge 1
+            "recv_vc1_edge2",  # Stream 17: VC1 from downstream edge 2
+            "recv_vc1_edge3",  # Stream 18: VC1 from downstream edge 3
+            "sender_ch0",  # Stream 19: Sender channel 0
+            "sender_ch1",  # Stream 20: Sender channel 1
+            "sender_ch2",  # Stream 21: Sender channel 2
+            "sender_ch3",  # Stream 22: Sender channel 3
+            "sender_ch4_vc1",  # Stream 23: Sender channel 4 VC1
+            "sender_ch5_vc1",  # Stream 24: Sender channel 5 VC1
+            "sender_ch6_vc1",  # Stream 25: Sender channel 6 VC1
         ],
         "title": "ALL FABRIC STREAM FREE SLOTS",
         "description": "Complete view of all fabric EDM sender/receiver buffer space for flow control debugging",
@@ -116,16 +134,24 @@ FABRIC_STREAM_GROUPS = {
     },
     # ========== Packet Acknowledgment Streams (Remote Buffer Status) ==========
     "sender_acks": {
-        "stream_ids": [2, 3, 4, 5, 6],
-        "labels": ["sender_ch0_ack", "sender_ch1_ack", "sender_ch2_ack", "sender_ch3_ack", "sender_ch4_ack"],
+        "stream_ids": [2, 3, 4, 5],
+        "labels": ["sender_ch0_ack", "sender_ch1_ack", "sender_ch2_ack", "sender_ch3_ack"],
         "title": "SENDER CHANNEL PACKET ACKNOWLEDGMENT STREAMS",
         "description": "Remote buffer space for ack streams (to_sender_X_pkts_acked). LOW/ZERO = remote consuming acks",
         "register_type": "BUF_SPACE_AVAILABLE",
     },
     # ========== Packet Completion Streams (Remote Buffer Status) ==========
     "sender_completions": {
-        "stream_ids": [7, 8, 9, 10, 11],
-        "labels": ["sender_ch0_comp", "sender_ch1_comp", "sender_ch2_comp", "sender_ch3_comp", "sender_ch4_comp"],
+        "stream_ids": [6, 7, 8, 9, 10, 11, 12],
+        "labels": [
+            "sender_ch0_comp",
+            "sender_ch1_comp",
+            "sender_ch2_comp",
+            "sender_ch3_comp",
+            "sender_ch4_comp",
+            "sender_ch5_comp",
+            "sender_ch6_comp",
+        ],
         "title": "SENDER CHANNEL PACKET COMPLETION STREAMS",
         "description": "Remote buffer space for completion streams (to_sender_X_pkts_completed). LOW/ZERO = remote consuming completions",
         "register_type": "BUF_SPACE_AVAILABLE",
@@ -140,18 +166,19 @@ FABRIC_STREAM_GROUPS = {
     },
     # ========== Combined Acks and Completions ==========
     "all_acks_and_completions": {
-        "stream_ids": [2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
+        "stream_ids": [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
         "labels": [
             "sender_ch0_ack",  # Stream 2
             "sender_ch1_ack",  # Stream 3
             "sender_ch2_ack",  # Stream 4
             "sender_ch3_ack",  # Stream 5
-            "sender_ch4_ack",  # Stream 6
-            "sender_ch0_comp",  # Stream 7
-            "sender_ch1_comp",  # Stream 8
-            "sender_ch2_comp",  # Stream 9
-            "sender_ch3_comp",  # Stream 10
-            "sender_ch4_comp",  # Stream 11
+            "sender_ch0_comp",  # Stream 6
+            "sender_ch1_comp",  # Stream 7
+            "sender_ch2_comp",  # Stream 8
+            "sender_ch3_comp",  # Stream 9
+            "sender_ch4_comp",  # Stream 10
+            "sender_ch5_comp",  # Stream 11
+            "sender_ch6_comp",  # Stream 12
         ],
         "title": "ALL SENDER ACK AND COMPLETION STREAMS",
         "description": "Remote buffer space for ack/completion streams. LOW/ZERO = remote side processing normally",

--- a/tt_metal/fabric/erisc_datamover_builder.hpp
+++ b/tt_metal/fabric/erisc_datamover_builder.hpp
@@ -26,6 +26,7 @@
 #include "tt_metal/fabric/builder/fabric_builder_config.hpp"
 #include "tt_metal/fabric/builder/connection_writer_adapter.hpp"
 #include "tt_metal/fabric/fabric_datamover_builder_base.hpp"
+#include "tt_metal/fabric/hw/inc/fabric_stream_ids.hpp"
 
 namespace tt::tt_fabric {
 
@@ -136,71 +137,8 @@ Receiver channel side registers are defined here to receive free-slot credits fr
                           └─────────────────────────────────┘
                                    South Router
 */
-struct StreamRegAssignments {
-    // Packet send/ack/complete stream IDs
-    static constexpr uint32_t to_receiver_0_pkts_sent_id = 0;
-    static constexpr uint32_t to_receiver_1_pkts_sent_id = 1;
-    static constexpr uint32_t to_sender_0_pkts_acked_id = 2;
-    static constexpr uint32_t to_sender_1_pkts_acked_id = 3;
-    static constexpr uint32_t to_sender_2_pkts_acked_id = 4;
-    static constexpr uint32_t to_sender_3_pkts_acked_id = 5;
-    static constexpr uint32_t to_sender_4_pkts_acked_id = 6;
-    static constexpr uint32_t to_sender_0_pkts_completed_id = 7;
-    static constexpr uint32_t to_sender_1_pkts_completed_id = 8;
-    static constexpr uint32_t to_sender_2_pkts_completed_id = 9;
-    static constexpr uint32_t to_sender_3_pkts_completed_id = 10;
-    static constexpr uint32_t to_sender_4_pkts_completed_id = 11;
-    // Receiver channel free slots stream IDs
-    static constexpr uint32_t vc_0_free_slots_from_downstream_edge_1 = 12;
-    static constexpr uint32_t vc_0_free_slots_from_downstream_edge_2 = 13;
-    static constexpr uint32_t vc_0_free_slots_from_downstream_edge_3 = 14;
-    static constexpr uint32_t vc_1_free_slots_from_downstream_edge_1 = 15;
-    // Sender channel free slots stream IDs
-    static constexpr uint32_t sender_channel_0_free_slots_stream_id = 17;  // for tensix worker
-    static constexpr uint32_t sender_channel_1_free_slots_stream_id = 18;  // for upstream edge on: 1D->VC0, 2D->VC0
-    static constexpr uint32_t sender_channel_2_free_slots_stream_id = 19;  // for upstream edge on: 1D->VC1, 2D->VC0
-    static constexpr uint32_t sender_channel_3_free_slots_stream_id = 20;  // for upstream edge on: 2D->VC0
-    static constexpr uint32_t sender_channel_4_free_slots_stream_id = 21;  // for upstream edge on: 2D->VC1
-    // Used by Lite Fabric
-    // Consult tt_metal/lite_fabric/hw/inc/constants.hpp to ensure no conflicts
-    static constexpr uint32_t reserved_lite_fabric_0_stream_id = 23;
-    static constexpr uint32_t reserved_lite_fabric_1_stream_id = 24;
-    static constexpr uint32_t reserved_lite_fabric_2_stream_id = 25;
-    static constexpr uint32_t reserved_lite_fabric_3_stream_id = 26;
-    static constexpr uint32_t reserved_lite_fabric_4_stream_id = 27;
-    static constexpr uint32_t reserved_lite_fabric_5_stream_id = 28;
-    // Local tensix relay free slots stream ID (UDM mode only)
-    static constexpr uint32_t tensix_relay_local_free_slots_stream_id = 29;
-    // Multi-RISC teardown synchronization stream ID
-    static constexpr uint32_t multi_risc_teardown_sync_stream_id = 31;
-
-    static const auto& get_all_stream_ids() {
-        static constexpr std::array stream_ids = {
-            to_receiver_0_pkts_sent_id,
-            to_receiver_1_pkts_sent_id,
-            to_sender_0_pkts_acked_id,
-            to_sender_1_pkts_acked_id,
-            to_sender_2_pkts_acked_id,
-            to_sender_3_pkts_acked_id,
-            to_sender_4_pkts_acked_id,
-            to_sender_0_pkts_completed_id,
-            to_sender_1_pkts_completed_id,
-            to_sender_2_pkts_completed_id,
-            to_sender_3_pkts_completed_id,
-            to_sender_4_pkts_completed_id,
-            vc_0_free_slots_from_downstream_edge_1,
-            vc_0_free_slots_from_downstream_edge_2,
-            vc_0_free_slots_from_downstream_edge_3,
-            vc_1_free_slots_from_downstream_edge_1,
-            sender_channel_1_free_slots_stream_id,
-            sender_channel_2_free_slots_stream_id,
-            sender_channel_3_free_slots_stream_id,
-            sender_channel_4_free_slots_stream_id,
-            tensix_relay_local_free_slots_stream_id,
-            multi_risc_teardown_sync_stream_id};
-        return stream_ids;
-    }
-};
+// Moved to tt_metal/fabric/hw/inc/fabric_stream_ids.hpp
+using StreamRegAssignments = tt::tt_fabric::StreamRegAssignments;
 
 struct FabricEriscDatamoverConfig {
     static constexpr uint32_t WR_CMD_BUF = 0;      // for large writes

--- a/tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_worker_adapters.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_worker_adapters.hpp
@@ -115,7 +115,7 @@ struct WorkerToFabricEdmSenderImpl {
             auto writer_send_sem_id = get_arg_val<uint32_t>(arg_idx++);
             writer_send_sem_addr =
                 reinterpret_cast<volatile uint32_t*>(get_semaphore<my_core_type>(writer_send_sem_id));
-            worker_free_slots_stream_id = tt::tt_fabric::connection_interface::sender_channel_0_free_slots_stream_id;
+            worker_free_slots_stream_id = get_arg_val<uint32_t>(arg_idx++);
         }
 
         // DEAD CODE

--- a/tt_metal/fabric/hw/inc/edm_fabric/fabric_connection_interface.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/fabric_connection_interface.hpp
@@ -15,9 +15,4 @@ static constexpr uint32_t unused_connection_value = 0;
 static constexpr uint32_t open_connection_value = 1;
 static constexpr uint32_t close_connection_request_value = 2;
 
-// default assigned stream ID for the worker connection credits
-// worker writes to the auto-inc register of this stream ID to notify
-// fabric router of new packets availale.
-static constexpr uint32_t sender_channel_0_free_slots_stream_id = 17;
-
 };  // namespace tt::tt_fabric::connection_interface

--- a/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_router_ct_args.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_router_ct_args.hpp
@@ -21,14 +21,18 @@
 
 constexpr size_t NUM_ROUTER_CARDINAL_DIRECTIONS = 4;
 
-constexpr size_t MAX_NUM_RECEIVER_CHANNELS = 2;
-constexpr size_t MAX_NUM_SENDER_CHANNELS = 5;
+constexpr size_t MAX_NUM_RECEIVER_CHANNELS = 2;    // VC0, VC1 (VC1 only in 2D)
+constexpr size_t MAX_NUM_SENDER_CHANNELS = 7;      // Channels 0-6 (channels 4-6 for VC1, only in 2D)
+constexpr size_t MAX_NUM_SENDER_CHANNELS_VC0 = 4;  // Channels 0-3
+constexpr size_t MAX_NUM_SENDER_CHANNELS_VC1 = 3;  // Channels 4-6 (2D only)
+
+constexpr size_t MAX_NUM_SENDER_CHANNELS_INTRA_MESH = MAX_NUM_SENDER_CHANNELS_VC0;
 
 // Compile Time args
 
 constexpr bool SPECIAL_MARKER_CHECK_ENABLED = true;
 
-// Stream IDs from compile time arguments (first 23 arguments)
+// Stream IDs from compile time arguments (first 27 arguments)
 constexpr size_t STREAM_ID_ARGS_START_IDX = 0;
 constexpr uint32_t to_receiver_0_pkts_sent_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 0);
 constexpr uint32_t to_receiver_1_pkts_sent_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 1);
@@ -36,30 +40,43 @@ constexpr uint32_t to_sender_0_pkts_acked_id = get_compile_time_arg_val(STREAM_I
 constexpr uint32_t to_sender_1_pkts_acked_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 3);
 constexpr uint32_t to_sender_2_pkts_acked_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 4);
 constexpr uint32_t to_sender_3_pkts_acked_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 5);
-constexpr uint32_t to_sender_4_pkts_acked_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 6);
-constexpr uint32_t to_sender_0_pkts_completed_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 7);
-constexpr uint32_t to_sender_1_pkts_completed_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 8);
-constexpr uint32_t to_sender_2_pkts_completed_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 9);
-constexpr uint32_t to_sender_3_pkts_completed_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 10);
-constexpr uint32_t to_sender_4_pkts_completed_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 11);
+constexpr uint32_t to_sender_0_pkts_completed_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 6);
+constexpr uint32_t to_sender_1_pkts_completed_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 7);
+constexpr uint32_t to_sender_2_pkts_completed_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 8);
+constexpr uint32_t to_sender_3_pkts_completed_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 9);
+constexpr uint32_t to_sender_4_pkts_completed_id =
+    get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 10);  // VC1 (2D only)
+constexpr uint32_t to_sender_5_pkts_completed_id =
+    get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 11);  // VC1 sender ch 1 (2D only)
+constexpr uint32_t to_sender_6_pkts_completed_id =
+    get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 12);  // VC1 sender ch 2 (2D only)
 constexpr uint32_t vc_0_free_slots_from_downstream_edge_1_stream_id =
-    get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 12);
-constexpr uint32_t vc_0_free_slots_from_downstream_edge_2_stream_id =
     get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 13);
-constexpr uint32_t vc_0_free_slots_from_downstream_edge_3_stream_id =
+constexpr uint32_t vc_0_free_slots_from_downstream_edge_2_stream_id =
     get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 14);
-constexpr uint32_t vc_1_free_slots_from_downstream_edge_1_stream_id =
+constexpr uint32_t vc_0_free_slots_from_downstream_edge_3_stream_id =
     get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 15);
-constexpr uint32_t sender_channel_1_free_slots_stream_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 16);
-constexpr uint32_t sender_channel_2_free_slots_stream_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 17);
-constexpr uint32_t sender_channel_3_free_slots_stream_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 18);
-constexpr uint32_t sender_channel_4_free_slots_stream_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 19);
-constexpr uint32_t tensix_relay_local_free_slots_stream_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 20);
-// vc1_sender_channel_free_slots_stream_id is the same as sender_channel_4_free_slots_stream_id (stream ID 21)
-constexpr uint32_t MULTI_RISC_TEARDOWN_SYNC_STREAM_ID = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 21);
+constexpr uint32_t vc_1_free_slots_from_downstream_edge_1_stream_id =
+    get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 16);  // VC1 (2D only)
+constexpr uint32_t vc_1_free_slots_from_downstream_edge_2_stream_id =
+    get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 17);  // VC1 (2D only)
+constexpr uint32_t vc_1_free_slots_from_downstream_edge_3_stream_id =
+    get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 18);  // VC1 (2D only)
+constexpr uint32_t sender_channel_0_free_slots_stream_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 19);
+constexpr uint32_t sender_channel_1_free_slots_stream_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 20);
+constexpr uint32_t sender_channel_2_free_slots_stream_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 21);
+constexpr uint32_t sender_channel_3_free_slots_stream_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 22);
+constexpr uint32_t sender_channel_4_free_slots_stream_id =
+    get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 23);  // VC1 (2D only)
+constexpr uint32_t sender_channel_5_free_slots_stream_id =
+    get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 24);  // VC1 (2D only)
+constexpr uint32_t sender_channel_6_free_slots_stream_id =
+    get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 25);  // VC1 (2D only)
+constexpr uint32_t tensix_relay_local_free_slots_stream_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 26);
+constexpr uint32_t MULTI_RISC_TEARDOWN_SYNC_STREAM_ID = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 27);
 
 // Special marker after stream IDs
-constexpr size_t STREAM_IDS_END_MARKER_IDX = STREAM_ID_ARGS_START_IDX + 22;
+constexpr size_t STREAM_IDS_END_MARKER_IDX = STREAM_ID_ARGS_START_IDX + 28;
 constexpr size_t STREAM_IDS_END_MARKER = 0xFFEE0001;
 static_assert(
     !SPECIAL_MARKER_CHECK_ENABLED || get_compile_time_arg_val(STREAM_IDS_END_MARKER_IDX) == STREAM_IDS_END_MARKER,
@@ -94,14 +111,14 @@ static_assert(
     NUM_SENDER_CHANNELS <= MAX_NUM_SENDER_CHANNELS,
     "NUM_SENDER_CHANNELS must be less than or equal to MAX_NUM_SENDER_CHANNELS");
 static_assert(
-    wait_for_host_signal_IDX == 28,
-    "wait_for_host_signal_IDX must be 28 (24 stream IDs + 1 marker + 1 tensix connections + 4 config args)");
+    wait_for_host_signal_IDX == 34,
+    "wait_for_host_signal_IDX must be 34 (28 stream IDs + 1 marker + 1 tensix connections + 4 config args)");
 static_assert(
     get_compile_time_arg_val(wait_for_host_signal_IDX) == 0 || get_compile_time_arg_val(wait_for_host_signal_IDX) == 1,
     "wait_for_host_signal must be 0 or 1");
 static_assert(
-    MAIN_CT_ARGS_START_IDX == 29,
-    "MAIN_CT_ARGS_START_IDX must be 29 (24 stream IDs + 1 marker + 1 tensix connections + 5 config args)");
+    MAIN_CT_ARGS_START_IDX == 35,
+    "MAIN_CT_ARGS_START_IDX must be 35 (28 stream IDs + 1 marker + 1 tensix connections + 5 config args)");
 
 constexpr uint32_t SWITCH_INTERVAL =
 #ifndef DEBUG_PRINT_ENABLED
@@ -494,7 +511,7 @@ constexpr std::array<uint32_t, MAX_NUM_RECEIVER_CHANNELS> to_receiver_packets_se
     take_first_n_elements<MAX_NUM_RECEIVER_CHANNELS, MAX_NUM_RECEIVER_CHANNELS, uint32_t>(
         std::array<uint32_t, MAX_NUM_RECEIVER_CHANNELS>{to_receiver_0_pkts_sent_id, to_receiver_1_pkts_sent_id});
 
-// not in symbol table - because not used
+// data section
 constexpr std::array<uint32_t, MAX_NUM_SENDER_CHANNELS> to_sender_packets_acked_streams =
     take_first_n_elements<MAX_NUM_SENDER_CHANNELS, MAX_NUM_SENDER_CHANNELS, uint32_t>(
         std::array<uint32_t, MAX_NUM_SENDER_CHANNELS>{
@@ -502,9 +519,10 @@ constexpr std::array<uint32_t, MAX_NUM_SENDER_CHANNELS> to_sender_packets_acked_
             to_sender_1_pkts_acked_id,
             to_sender_2_pkts_acked_id,
             to_sender_3_pkts_acked_id,
-            to_sender_4_pkts_acked_id});
+            0,    // No ack for sender channel 4
+            0,    // No ack for sender channel 5
+            0});  // No ack for sender channel 6
 
-// data section
 constexpr std::array<uint32_t, MAX_NUM_SENDER_CHANNELS> to_sender_packets_completed_streams =
     take_first_n_elements<MAX_NUM_SENDER_CHANNELS, MAX_NUM_SENDER_CHANNELS, uint32_t>(
         std::array<uint32_t, MAX_NUM_SENDER_CHANNELS>{
@@ -512,7 +530,9 @@ constexpr std::array<uint32_t, MAX_NUM_SENDER_CHANNELS> to_sender_packets_comple
             to_sender_1_pkts_completed_id,
             to_sender_2_pkts_completed_id,
             to_sender_3_pkts_completed_id,
-            to_sender_4_pkts_completed_id});
+            to_sender_4_pkts_completed_id,
+            to_sender_5_pkts_completed_id,    // VC1 sender ch 1 (2D only)
+            to_sender_6_pkts_completed_id});  // VC1 sender ch 2 (2D only)
 
 // Miscellaneous configuration
 

--- a/tt_metal/fabric/hw/inc/edm_fabric/fabric_router_flow_control.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/fabric_router_flow_control.hpp
@@ -154,15 +154,15 @@ struct SenderChannelFromReceiverCounterBasedCreditsReceiver {
 struct SenderChannelFromReceiverStreamRegisterFreeSlotsBasedCreditsReceiver {
     SenderChannelFromReceiverStreamRegisterFreeSlotsBasedCreditsReceiver() = default;
     SenderChannelFromReceiverStreamRegisterFreeSlotsBasedCreditsReceiver(size_t sender_channel_index) :
-        to_sender_packets_acked_stream(to_sender_packets_acked_streams[sender_channel_index]),
         to_sender_packets_completed_stream(to_sender_packets_completed_streams[sender_channel_index]) {}
 
+    // Ack streams removed - only completion streams are now used
     FORCE_INLINE uint32_t get_num_unprocessed_acks_from_receiver() {
-        return get_ptr_val(to_sender_packets_acked_stream);
+        return 0;  // Acks no longer tracked separately
     }
 
     FORCE_INLINE void increment_num_processed_acks(size_t num_acks) {
-        increment_local_update_ptr_val(to_sender_packets_acked_stream, -num_acks);
+        // No-op - acks no longer tracked separately
     }
 
     FORCE_INLINE uint32_t get_num_unprocessed_completions_from_receiver() {
@@ -173,7 +173,6 @@ struct SenderChannelFromReceiverStreamRegisterFreeSlotsBasedCreditsReceiver {
         increment_local_update_ptr_val(to_sender_packets_completed_stream, -num_completions);
     }
 
-    uint32_t to_sender_packets_acked_stream;
     uint32_t to_sender_packets_completed_stream;
 };
 

--- a/tt_metal/fabric/hw/inc/fabric_stream_ids.hpp
+++ b/tt_metal/fabric/hw/inc/fabric_stream_ids.hpp
@@ -1,0 +1,100 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include <array>
+
+namespace tt::tt_fabric {
+
+/**
+ * @brief Stream register assignments for fabric datamover
+ *
+ * This struct defines the stream IDs used by the fabric datamover for various purposes.
+ * Stream IDs 0-26 are used by the fabric datamover.
+ * Stream IDs 27-32 are reserved for lite fabric to avoid conflicts.
+ *
+ * @note When modifying these assignments, ensure no conflicts with lite_fabric/hw/inc/constants.hpp
+ */
+struct StreamRegAssignments {
+    // Packet send/complete stream IDs
+    static constexpr uint32_t to_receiver_0_pkts_sent_id = 0;
+    static constexpr uint32_t to_receiver_1_pkts_sent_id = 1;
+    // Packet acknowledgment stream IDs (only sender channels 0-3)
+    static constexpr uint32_t to_sender_0_pkts_acked_id = 2;
+    static constexpr uint32_t to_sender_1_pkts_acked_id = 3;
+    static constexpr uint32_t to_sender_2_pkts_acked_id = 4;
+    static constexpr uint32_t to_sender_3_pkts_acked_id = 5;
+    // Packet completion stream IDs (sender channels 0-6)
+    static constexpr uint32_t to_sender_0_pkts_completed_id = 6;
+    static constexpr uint32_t to_sender_1_pkts_completed_id = 7;
+    static constexpr uint32_t to_sender_2_pkts_completed_id = 8;
+    static constexpr uint32_t to_sender_3_pkts_completed_id = 9;
+    static constexpr uint32_t to_sender_4_pkts_completed_id = 10;  // VC1 compact 0 (2D only)
+    static constexpr uint32_t to_sender_5_pkts_completed_id = 11;  // VC1 compact 1 (2D only)
+    static constexpr uint32_t to_sender_6_pkts_completed_id = 12;  // VC1 compact 2 (2D only)
+    // Receiver channel free slots stream IDs
+    static constexpr uint32_t vc_0_free_slots_from_downstream_edge_1 = 13;
+    static constexpr uint32_t vc_0_free_slots_from_downstream_edge_2 = 14;
+    static constexpr uint32_t vc_0_free_slots_from_downstream_edge_3 = 15;
+    static constexpr uint32_t vc_1_free_slots_from_downstream_edge_1 = 16;  // VC1 (2D only)
+    static constexpr uint32_t vc_1_free_slots_from_downstream_edge_2 = 17;  // VC1 (2D only)
+    static constexpr uint32_t vc_1_free_slots_from_downstream_edge_3 = 18;  // VC1 (2D only)
+    // Sender channel free slots stream IDs
+    static constexpr uint32_t sender_channel_0_free_slots_stream_id = 19;  // for tensix worker
+    static constexpr uint32_t sender_channel_1_free_slots_stream_id = 20;  // VC0 compact 0
+    static constexpr uint32_t sender_channel_2_free_slots_stream_id = 21;  // VC0 compact 1
+    static constexpr uint32_t sender_channel_3_free_slots_stream_id = 22;  // VC0 compact 2
+    static constexpr uint32_t sender_channel_4_free_slots_stream_id = 23;  // VC1 compact 0 (2D only)
+    static constexpr uint32_t sender_channel_5_free_slots_stream_id = 24;  // VC1 compact 1 (2D only)
+    static constexpr uint32_t sender_channel_6_free_slots_stream_id = 25;  // VC1 compact 2 (2D only)
+    // Local tensix relay free slots stream ID (UDM mode only)
+    static constexpr uint32_t tensix_relay_local_free_slots_stream_id = 26;
+    // Used by Lite Fabric (stream IDs 27-32 reserved)
+    // Consult tt_metal/lite_fabric/hw/inc/constants.hpp to ensure no conflicts
+    static constexpr uint32_t reserved_lite_fabric_0_stream_id = 26;
+    static constexpr uint32_t reserved_lite_fabric_1_stream_id = 27;
+    static constexpr uint32_t reserved_lite_fabric_2_stream_id = 28;
+    static constexpr uint32_t reserved_lite_fabric_3_stream_id = 29;
+    static constexpr uint32_t reserved_lite_fabric_4_stream_id = 30;
+    static constexpr uint32_t reserved_lite_fabric_5_stream_id = 31;
+    // Multi-RISC teardown synchronization stream ID (reuses to_receiver_0_pkts_sent_id)
+    static constexpr uint32_t multi_risc_teardown_sync_stream_id = 0;
+
+    static const auto& get_all_stream_ids() {
+        static constexpr std::array stream_ids = {
+            to_receiver_0_pkts_sent_id,
+            to_receiver_1_pkts_sent_id,
+            to_sender_0_pkts_acked_id,
+            to_sender_1_pkts_acked_id,
+            to_sender_2_pkts_acked_id,
+            to_sender_3_pkts_acked_id,
+            to_sender_0_pkts_completed_id,
+            to_sender_1_pkts_completed_id,
+            to_sender_2_pkts_completed_id,
+            to_sender_3_pkts_completed_id,
+            to_sender_4_pkts_completed_id,
+            to_sender_5_pkts_completed_id,
+            to_sender_6_pkts_completed_id,
+            vc_0_free_slots_from_downstream_edge_1,
+            vc_0_free_slots_from_downstream_edge_2,
+            vc_0_free_slots_from_downstream_edge_3,
+            vc_1_free_slots_from_downstream_edge_1,
+            vc_1_free_slots_from_downstream_edge_2,
+            vc_1_free_slots_from_downstream_edge_3,
+            sender_channel_0_free_slots_stream_id,
+            sender_channel_1_free_slots_stream_id,
+            sender_channel_2_free_slots_stream_id,
+            sender_channel_3_free_slots_stream_id,
+            sender_channel_4_free_slots_stream_id,
+            sender_channel_5_free_slots_stream_id,
+            sender_channel_6_free_slots_stream_id,
+            tensix_relay_local_free_slots_stream_id,
+            multi_risc_teardown_sync_stream_id};
+        return stream_ids;  // 28 stream IDs
+    }
+};
+
+}  // namespace tt::tt_fabric

--- a/tt_metal/lite_fabric/hw/inc/constants.hpp
+++ b/tt_metal/lite_fabric/hw/inc/constants.hpp
@@ -8,6 +8,7 @@
 #include <cstdint>
 #include <array>
 #include "tt_metal/lite_fabric/hw/inc/header.hpp"
+#include "tt_metal/fabric/hw/inc/fabric_stream_ids.hpp"
 
 #if defined(KERNEL_BUILD) || defined(FW_BUILD)
 #include "tt_metal/fabric/hw/inc/edm_fabric/compile_time_arg_tmp.hpp"
@@ -17,13 +18,15 @@
 namespace lite_fabric {
 
 // STREAM REGISTER ASSIGNMENT
-// Consult tt_metal/fabric/erisc_datamover_builder.hpp StreamRegAssignments to ensure no conflicts
-constexpr uint32_t to_receiver_0_pkts_sent_id = 23;
-constexpr uint32_t to_sender_0_pkts_acked_id = 24;
-constexpr uint32_t to_sender_0_pkts_completed_id = 25;
-constexpr uint32_t to_receiver_1_pkts_sent_id = 26;
-constexpr uint32_t to_sender_1_pkts_acked_id = 27;
-constexpr uint32_t to_sender_1_pkts_completed_id = 28;
+// Use reserved stream IDs from fabric datamover to avoid conflicts
+constexpr uint32_t to_receiver_0_pkts_sent_id = tt::tt_fabric::StreamRegAssignments::reserved_lite_fabric_0_stream_id;
+constexpr uint32_t to_sender_0_pkts_acked_id = tt::tt_fabric::StreamRegAssignments::reserved_lite_fabric_1_stream_id;
+constexpr uint32_t to_sender_0_pkts_completed_id =
+    tt::tt_fabric::StreamRegAssignments::reserved_lite_fabric_2_stream_id;
+constexpr uint32_t to_receiver_1_pkts_sent_id = tt::tt_fabric::StreamRegAssignments::reserved_lite_fabric_3_stream_id;
+constexpr uint32_t to_sender_1_pkts_acked_id = tt::tt_fabric::StreamRegAssignments::reserved_lite_fabric_4_stream_id;
+constexpr uint32_t to_sender_1_pkts_completed_id =
+    tt::tt_fabric::StreamRegAssignments::reserved_lite_fabric_5_stream_id;
 
 // Max two but only using 1 for now
 constexpr size_t MAX_NUM_RECEIVER_CHANNELS = 2;


### PR DESCRIPTION
Remove duplicate sender channel 0 stream id definition. Pass sender channel 0 stream id as compile arg to router and runtime arg to worker.

Remove first level ack and associated streams.

Remove ack handshake and streams. Add streams and config for VC2 with some hacks to keep backward compatibility. VC2 hookup will be done when mesh count > 1.

Fix runtime arg ordering

### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes