### PR TITLE
Correct fold test case.

### DIFF
--- a/tests/ttnn/unit_tests/operations/conv/data_movement/test_fold_op.py
+++ b/tests/ttnn/unit_tests/operations/conv/data_movement/test_fold_op.py
@@ -131,7 +131,7 @@ def test_fold_with_permute_for_dram_tensor(device, nhw, channels, stride, paddin
         diff = torch.abs(torch_output_tensor - tt_output_tensor) / torch_output_tensor.abs().mean()
         assert torch.all(diff < threshold), f"Max diff: {diff.max()}, Threshold: {threshold} "
     else:
-        torch.equal(torch_output_tensor, tt_output_tensor)
+        assert torch.equal(torch_output_tensor, tt_output_tensor)
 
 
 def pad_and_fold_with_permute_and_reshape_on_device(
@@ -458,7 +458,7 @@ def run_fold_sharded_test(device, act_shape, stride_h, stride_w, padding, core_g
         tt_out = ttnn.fold(tt_input, stride_h=stride_h, stride_w=stride_w, padding=list(padding))
         actual = tt2torch_tensor(tt_out)
 
-        torch.testing.assert_close(actual, expected)
+        assert torch.equal(expected, actual), f"Expected: {expected}, Actual: {actual}"
         tt_input.deallocate()
         tt_out.deallocate()
 

--- a/tests/ttnn/unit_tests/operations/conv/data_movement/test_fold_op.py
+++ b/tests/ttnn/unit_tests/operations/conv/data_movement/test_fold_op.py
@@ -131,7 +131,9 @@ def test_fold_with_permute_for_dram_tensor(device, nhw, channels, stride, paddin
         diff = torch.abs(torch_output_tensor - tt_output_tensor) / torch_output_tensor.abs().mean()
         assert torch.all(diff < threshold), f"Max diff: {diff.max()}, Threshold: {threshold} "
     else:
-        assert torch.equal(torch_output_tensor, tt_output_tensor)
+        assert torch.equal(
+            torch_output_tensor, tt_output_tensor
+        ), f"Expected: {torch_output_tensor}, Actual: {tt_output_tensor}"
 
 
 def pad_and_fold_with_permute_and_reshape_on_device(


### PR DESCRIPTION
### Problem description
For part of test case for dram assert is missing and sharded test cases uses all_close instead of equal

### What's changed
Add assert and use `torch.equal` instead of `torch.all_close`.

### Checklist
- [X] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI [Passes](https://github.com/tenstorrent/tt-metal/actions/runs/19847054917)
- [X] [Nightly l2](https://github.com/tenstorrent/tt-metal/actions/runs/19847132025) CI Passes