### PR TITLE
enhance fetching time from dram to l1 cmddat_q through prefetching

### DIFF
--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -2055,13 +2055,13 @@ inline void RISC_POST_HEARTBEAT(uint32_t& heartbeat) {
  * | skip_ptr_update (template argument) | Whether to skip updating counters              | bool      | true or false | False    |
  */
 // clang-format on
-template <bool skip_ptr_update = false>
+template <bool skip_ptr_update = false, bool skip_cmdbuf_chk = false>
 FORCE_INLINE void noc_async_read_one_packet_with_state_with_trid(
     uint32_t src_base_addr, uint32_t src_addr, uint32_t dest_addr, uint32_t trid = 0, uint8_t noc = noc_index) {
     RECORD_NOC_EVENT(NocEventType::READ_WITH_STATE_AND_TRID);
 
     WAYPOINT("NRDW");
-    ncrisc_noc_fast_read_with_transaction_id<noc_mode, skip_ptr_update>(
+    ncrisc_noc_fast_read_with_transaction_id<noc_mode, skip_ptr_update, skip_cmdbuf_chk>(
         noc, read_cmd_buf, src_base_addr, src_addr, dest_addr, trid);
     WAYPOINT("NRDD");
 }

--- a/tt_metal/hw/inc/tt-1xx/blackhole/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/tt-1xx/blackhole/noc_nonblocking_api.h
@@ -897,6 +897,8 @@ inline __attribute__((always_inline)) void ncrisc_noc_fast_read_with_transaction
 
     if constexpr (!skip_cmdbuf_chk) {
         while (!noc_cmd_buf_ready(noc, cmd_buf));
+    } else {
+        ASSERT(noc_cmd_buf_ready(noc, cmd_buf));
     }
     while (NOC_STATUS_READ_REG(noc, NIU_MST_REQS_OUTSTANDING_ID(trid)) > ((NOC_MAX_TRANSACTION_ID_COUNT + 1) / 2));
 

--- a/tt_metal/hw/inc/tt-1xx/blackhole/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/tt-1xx/blackhole/noc_nonblocking_api.h
@@ -886,7 +886,7 @@ inline __attribute__((always_inline)) void noc_fast_atomic_increment(
 }
 
 // issue noc reads while wait for outstanding transactions done
-template <uint8_t noc_mode = DM_DEDICATED_NOC, bool skip_ptr_update = false>
+template <uint8_t noc_mode = DM_DEDICATED_NOC, bool skip_ptr_update = false, bool skip_cmdbuf_chk = false>
 inline __attribute__((always_inline)) void ncrisc_noc_fast_read_with_transaction_id(
     uint32_t noc, uint32_t cmd_buf, uint32_t src_base_addr, uint32_t src_addr, uint32_t dest_addr, uint32_t trid) {
     if constexpr (noc_mode == DM_DYNAMIC_NOC && !skip_ptr_update) {
@@ -895,7 +895,9 @@ inline __attribute__((always_inline)) void ncrisc_noc_fast_read_with_transaction
     uint32_t src_addr_;
     src_addr_ = src_base_addr + src_addr;
 
-    while (!noc_cmd_buf_ready(noc, cmd_buf));
+    if constexpr (!skip_cmdbuf_chk) {
+        while (!noc_cmd_buf_ready(noc, cmd_buf));
+    }
     while (NOC_STATUS_READ_REG(noc, NIU_MST_REQS_OUTSTANDING_ID(trid)) > ((NOC_MAX_TRANSACTION_ID_COUNT + 1) / 2));
 
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_RET_ADDR_LO, dest_addr);

--- a/tt_metal/hw/inc/tt-1xx/wormhole/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/tt-1xx/wormhole/noc_nonblocking_api.h
@@ -687,7 +687,7 @@ inline __attribute__((always_inline)) void noc_fast_atomic_increment(
 }
 
 // issue noc reads while wait for outstanding transactions done
-template <uint8_t noc_mode = DM_DEDICATED_NOC, bool skip_ptr_update = false>
+template <uint8_t noc_mode = DM_DEDICATED_NOC, bool skip_ptr_update = false, bool skip_cmdbuf_chk = false>
 inline __attribute__((always_inline)) void ncrisc_noc_fast_read_with_transaction_id(
     uint32_t noc, uint32_t cmd_buf, uint32_t src_base_addr, uint32_t src_addr, uint32_t dest_addr, uint32_t trid) {
     if constexpr (noc_mode == DM_DYNAMIC_NOC && !skip_ptr_update) {
@@ -696,7 +696,9 @@ inline __attribute__((always_inline)) void ncrisc_noc_fast_read_with_transaction
     uint32_t src_addr_;
     src_addr_ = src_base_addr + src_addr;
 
-    while (!noc_cmd_buf_ready(noc, cmd_buf));
+    if constexpr (!skip_cmdbuf_chk) {
+        while (!noc_cmd_buf_ready(noc, cmd_buf));
+    }
     while (NOC_STATUS_READ_REG(noc, NIU_MST_REQS_OUTSTANDING_ID(trid)) > ((NOC_MAX_TRANSACTION_ID_COUNT + 1) / 2));
 
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_RET_ADDR_LO, dest_addr);

--- a/tt_metal/hw/inc/tt-1xx/wormhole/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/tt-1xx/wormhole/noc_nonblocking_api.h
@@ -10,6 +10,7 @@
 #include "dev_msgs.h"
 #include "noc_overlay_parameters.h"
 #include "risc_attribs.h"
+#include "debug/assert.h"
 
 #if defined(COMPILE_FOR_BRISC)
 constexpr std::underlying_type_t<TensixProcessorTypes> proc_type =
@@ -698,6 +699,8 @@ inline __attribute__((always_inline)) void ncrisc_noc_fast_read_with_transaction
 
     if constexpr (!skip_cmdbuf_chk) {
         while (!noc_cmd_buf_ready(noc, cmd_buf));
+    } else {
+        ASSERT(noc_cmd_buf_ready(noc, cmd_buf));
     }
     while (NOC_STATUS_READ_REG(noc, NIU_MST_REQS_OUTSTANDING_ID(trid)) > ((NOC_MAX_TRANSACTION_ID_COUNT + 1) / 2));
 

--- a/tt_metal/hw/inc/tt-2xx/quasar/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/tt-2xx/quasar/noc_nonblocking_api.h
@@ -786,7 +786,7 @@ inline __attribute__((always_inline)) void noc_fast_atomic_increment(
 }
 
 // issue noc reads while wait for outstanding transactions done
-template <uint8_t noc_mode = DM_DEDICATED_NOC, bool skip_ptr_update = false>
+template <uint8_t noc_mode = DM_DEDICATED_NOC, bool skip_ptr_update = false, bool skip_cmdbuf_chk = false>
 inline __attribute__((always_inline)) void ncrisc_noc_fast_read_with_transaction_id(
     uint32_t noc, uint32_t cmd_buf, uint32_t src_base_addr, uint32_t src_addr, uint32_t dest_addr, uint32_t trid) {
     if constexpr (noc_mode == DM_DYNAMIC_NOC && !skip_ptr_update) {
@@ -795,7 +795,9 @@ inline __attribute__((always_inline)) void ncrisc_noc_fast_read_with_transaction
     uint32_t src_addr_;
     src_addr_ = src_base_addr + src_addr;
 
-    while (!noc_cmd_buf_ready(noc, cmd_buf));
+    if constexpr (!skip_cmdbuf_chk) {
+        while (!noc_cmd_buf_ready(noc, cmd_buf));
+    }
     while (NOC_STATUS_READ_REG(noc, NIU_MST_REQS_OUTSTANDING_ID(trid)) > ((NOC_MAX_TRANSACTION_ID + 1) / 2));
 
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_RET_ADDR_LO, dest_addr);

--- a/tt_metal/hw/inc/tt-2xx/quasar/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/tt-2xx/quasar/noc_nonblocking_api.h
@@ -797,6 +797,8 @@ inline __attribute__((always_inline)) void ncrisc_noc_fast_read_with_transaction
 
     if constexpr (!skip_cmdbuf_chk) {
         while (!noc_cmd_buf_ready(noc, cmd_buf));
+    } else {
+        ASSERT(noc_cmd_buf_ready(noc, cmd_buf));
     }
     while (NOC_STATUS_READ_REG(noc, NIU_MST_REQS_OUTSTANDING_ID(trid)) > ((NOC_MAX_TRANSACTION_ID + 1) / 2));
 

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -1061,9 +1061,9 @@ uint32_t process_stall(uint32_t cmd_ptr) {
     return CQ_PREFETCH_CMD_BARE_MIN_SIZE;
 }
 
-// This function reads data from the DRAM and populate the cmddat_q l1 buffer.
-// It starts by fetching initial chunk of 16KB from DRAM and then prefetch
-// the rest and return to have the initial cmddat_q to be processed.
+// This function reads data from the DRAM and populates the cmddat_q l1 buffer.
+// It starts by fetching initial chunk of 16KB from DRAM and then prefetches
+// the rest and returns to have the initial cmddat_q to be processed.
 // All fetching from DRAM stops at the end of cmddat_q until the cmddat_q are
 // processed.  Then it repeats again.
 // Note:

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -225,6 +225,10 @@ struct PrefetchExecBufState {
     uint32_t log_page_size;
     uint32_t pages;
     uint32_t length;
+    uint32_t read_ptr;
+    uint32_t prefetch_page_id;
+    uint32_t prefetch_pages_read;
+    uint32_t prefetch_length;
 };
 
 // Global Variables
@@ -1057,34 +1061,136 @@ uint32_t process_stall(uint32_t cmd_ptr) {
     return CQ_PREFETCH_CMD_BARE_MIN_SIZE;
 }
 
-void paged_read_into_cmddat_q(uint32_t read_ptr, PrefetchExecBufState& exec_buf_state) {
+// This function reads data from the DRAM and populate the cmddat_q l1 buffer.
+// It starts by fetching initial chunk of 16KB from DRAM and then prefetch
+// the rest and return to have the initial cmddat_q to be processed.
+// All fetching from DRAM stops at the end of cmddat_q until the cmddat_q are
+// processed.  Then it repeats again.
+// Note:
+//   exec_buf_state.page_id, base_addr, log_page_size, pages, read_ptr must
+//     be initialized to start using this function.
+//   exec_buf_state.read_ptr needs to be reset to cmddat_q_base when
+//     all commands are processed to reset.
+void paged_read_into_cmddat_q(PrefetchExecBufState& exec_buf_state) {
     uint32_t page_id = exec_buf_state.page_id;
     uint32_t base_addr = exec_buf_state.base_addr;
     uint32_t log_page_size = exec_buf_state.log_page_size;
     uint32_t page_size = 1 << log_page_size;
     uint32_t pages = exec_buf_state.pages;
+    uint32_t read_ptr = exec_buf_state.read_ptr;
+    uint32_t max_read_pages;
+    constexpr uint32_t INITIAL_FETCH_SIZE = 16 * 1024;                           // 16KB (OPTIMIZE HERE)
+    constexpr uint32_t PREFETCH_FETCH_SIZE = cmddat_q_end - INITIAL_FETCH_SIZE;  // the rest
 
-    // TODO: tune how much is read
-    uint32_t max_trace_buffer_pages_in_cmd_dat_q = cmddat_q_size >> log_page_size;
-    uint32_t pages_at_once =
-        (max_trace_buffer_pages_in_cmd_dat_q > pages) ? pages : max_trace_buffer_pages_in_cmd_dat_q;
-    uint32_t read_length = pages_at_once << log_page_size;
-    uint32_t pages_read = pages_at_once;
-
-    auto addr_gen = TensorAccessor(tensor_accessor::make_interleaved_dspec</*is_dram=*/true>(), base_addr, page_size);
-
-    while (pages_at_once != 0) {
-        invalidate_l1_cache();
-        uint64_t noc_addr = addr_gen.get_noc_addr(page_id);
-        noc_async_read(noc_addr, read_ptr, page_size);
-        read_ptr += page_size;
-        page_id++;
-        pages_at_once--;
+    // cmddat_q do not wrap around
+    // reset all prefetch members when read_ptr is at the beginning of cmddat_q
+    if (read_ptr == cmddat_q_base) {
+        // DPRINT << "  entry: prefetch reset" << ENDL();
+        exec_buf_state.prefetch_page_id = exec_buf_state.page_id;
+        exec_buf_state.prefetch_pages_read = 0;
+        exec_buf_state.prefetch_length = 0;
     }
 
-    exec_buf_state.page_id = page_id;
-    exec_buf_state.pages -= pages_read;
-    exec_buf_state.length += read_length;
+    // DPRINT << "  entry: page_id:     " << exec_buf_state.page_id << ENDL();
+    // DPRINT << "  entry: page_size:   " << page_size << ENDL();
+    // DPRINT << "  entry: pages:       " << exec_buf_state.pages << ENDL();
+    // DPRINT << "  entry: read_ptr:    " << exec_buf_state.read_ptr << ENDL();
+    // DPRINT << "  entry: length:      " << exec_buf_state.length << ENDL();
+
+    auto addr_gen = TensorAccessor(tensor_accessor::make_interleaved_dspec</*is_dram=*/true>(), base_addr, page_size);
+    // set transaction ID to 1 for all read
+    noc_async_read_set_trid(1);
+
+    // initial read
+    if (exec_buf_state.prefetch_pages_read == 0) {
+        max_read_pages = cmddat_q_end - read_ptr;
+        uint32_t initial_read_pages = (INITIAL_FETCH_SIZE + page_size - 1) >> log_page_size;
+        if (INITIAL_FETCH_SIZE > max_read_pages) {
+            initial_read_pages = (max_read_pages + page_size - 1) >> log_page_size;
+        }
+        // DPRINT << "  initial: max_read_pages:     " << max_read_pages << ENDL();
+        // DPRINT << "  initial: INITIAL_FETCH_SIZE: " << INITIAL_FETCH_SIZE << ENDL();
+        uint32_t initial_pages_at_once = (initial_read_pages > pages) ? pages : initial_read_pages;
+        uint32_t initial_read_length = initial_pages_at_once << log_page_size;
+        uint32_t initial_pages_read = initial_pages_at_once;
+        // DPRINT << "  initial: initial_read_length: " << initial_read_length << ENDL();
+        // DPRINT << "  initial: initial_pages_read:  " << initial_pages_read << ENDL();
+
+        while (initial_pages_at_once != 0) {
+            invalidate_l1_cache();
+            uint64_t noc_addr = addr_gen.get_noc_addr(page_id);
+            noc_async_read_one_packet_set_state(noc_addr, page_size);
+            noc_async_read_one_packet_with_state_with_trid<false, true>(noc_addr, 0, read_ptr, 1);
+            read_ptr += page_size;
+            page_id++;
+            initial_pages_at_once--;
+        }
+        noc_async_read_barrier_with_trid(1);
+        // update length always after barrier to make sure data in cmddat_q
+        exec_buf_state.page_id = page_id;
+        pages -= initial_pages_read;
+        exec_buf_state.pages = pages;
+        exec_buf_state.length += initial_read_length;
+        exec_buf_state.read_ptr = read_ptr;
+    } else if (exec_buf_state.length == 0) {
+        // add barrier to wait for prefetch noc read to complete
+        noc_async_read_barrier_with_trid(1);
+        // update always after barrier to make sure data in cmddat_q
+        page_id = exec_buf_state.prefetch_page_id;
+        exec_buf_state.page_id = page_id;
+        pages -= exec_buf_state.prefetch_pages_read;
+        exec_buf_state.pages = pages;
+        exec_buf_state.length += exec_buf_state.prefetch_length;
+        exec_buf_state.prefetch_pages_read = 0;
+        exec_buf_state.prefetch_length = 0;
+        // DPRINT << "  barrier: page_id:             " << exec_buf_state.page_id << ENDL();
+        // DPRINT << "  barrier: pages:               " << exec_buf_state.pages << ENDL();
+        // DPRINT << "  barrier: length:              " << exec_buf_state.length << ENDL();
+        // DPRINT << "  barrier: prefetch_pages_read: " << exec_buf_state.prefetch_pages_read << ENDL();
+        // DPRINT << "  barrier: prefetch_length:     " << exec_buf_state.prefetch_length << ENDL();
+    }
+
+    // prefetch only when
+    // 1. there wasn't a previous prefetch
+    // 2. there is still space left in cmddat_q
+    // 3. there are still pages to prefetch
+    if (exec_buf_state.prefetch_pages_read == 0 && read_ptr < cmddat_q_end && exec_buf_state.pages > 0) {
+        max_read_pages = cmddat_q_end - read_ptr;
+        uint32_t prefetch_read_pages = (PREFETCH_FETCH_SIZE + page_size - 1) >> log_page_size;
+        if (PREFETCH_FETCH_SIZE > max_read_pages) {
+            prefetch_read_pages = (max_read_pages + page_size - 1) >> log_page_size;
+        }
+        // DPRINT << "  prefetch: max_read_pages:      " << max_read_pages << ENDL();
+        // DPRINT << "  prefetch: PREFETCH_FETCH_SIZE: " << PREFETCH_FETCH_SIZE << ENDL();
+        uint32_t prefetch_pages_at_once = (prefetch_read_pages > pages) ? pages : prefetch_read_pages;
+        uint32_t prefetch_read_length = prefetch_pages_at_once << log_page_size;
+        uint32_t prefetch_pages_read = prefetch_pages_at_once;
+
+        while (prefetch_pages_at_once != 0) {
+            invalidate_l1_cache();
+            uint64_t noc_addr = addr_gen.get_noc_addr(page_id);
+            noc_async_read_one_packet_set_state(noc_addr, page_size);
+            noc_async_read_one_packet_with_state_with_trid<false, true>(noc_addr, 0, read_ptr, 1);
+            read_ptr += page_size;
+            page_id++;
+            prefetch_pages_at_once--;
+        }
+        // update length always after barrier to make sure data in cmddat_q
+        exec_buf_state.prefetch_page_id = page_id;
+        exec_buf_state.prefetch_pages_read = prefetch_pages_read;
+        exec_buf_state.prefetch_length = prefetch_read_length;
+        exec_buf_state.read_ptr = read_ptr;
+        // DPRINT << "  prefetch: prefetch_page_id:    " << exec_buf_state.prefetch_page_id << ENDL();
+        // DPRINT << "  prefetch: prefetch_pages_read: " << exec_buf_state.prefetch_pages_read << ENDL();
+        // DPRINT << "  prefetch: prefetch_length:     " << exec_buf_state.prefetch_length << ENDL();
+    }
+
+    // DPRINT << "  exit: page_id:     " << exec_buf_state.page_id << ENDL();
+    // DPRINT << "  exit: page_size:   " << page_size << ENDL();
+    // DPRINT << "  exit: pages:       " << exec_buf_state.pages << ENDL();
+    // DPRINT << "  exit: read_ptr:    " << exec_buf_state.read_ptr << ENDL();
+    // DPRINT << "  exit: length:      " << exec_buf_state.length << ENDL();
+    // DPRINT << ENDL();
 }
 
 // processes the relay_inline cmd from an exec_buf
@@ -1122,15 +1228,20 @@ FORCE_INLINE static uint32_t process_exec_buf_relay_inline_cmd(
         length -= remaining;
         stride -= remaining_stride;
         exec_buf_state.length = 0;
-        data_ptr = cmddat_q_base;
-        cmd_ptr = cmddat_q_base;
+        cmd_ptr += remaining_stride;
+        // reset if cmd_ptr is at end of cmddat_q
+        if (cmd_ptr == cmddat_q_end) {
+            // DPRINT << "  cmd_ptr/read_ptr reset" << ENDL();
+            cmd_ptr = cmddat_q_base;
+            exec_buf_state.read_ptr = cmddat_q_base;
+        }
+        data_ptr = cmd_ptr;
 
         // fetch more
         noc_async_writes_flushed(RelayInlineState::downstream_noc_index);
-        paged_read_into_cmddat_q(cmd_ptr, exec_buf_state);
+        paged_read_into_cmddat_q(exec_buf_state);
         remaining = exec_buf_state.length;
         remaining_stride = exec_buf_state.length;
-        noc_async_read_barrier();
     }
     write_downstream<RelayInlineState::downstream_cb_base_addr, RelayInlineState::downstream_write_cmd_buf>(
         data_ptr,
@@ -1177,13 +1288,18 @@ static uint32_t process_exec_buf_relay_inline_noflush_cmd(
         length -= remaining;
         stride -= remaining_stride;
         exec_buf_state.length = 0;
-        data_ptr = cmddat_q_base;
-        cmd_ptr = cmddat_q_base;
+        cmd_ptr += remaining_stride;
+        // reset if cmd_ptr is at end of cmddat_q
+        if (cmd_ptr == cmddat_q_end) {
+            // DPRINT << "  cmd_ptr/read_ptr reset" << ENDL();
+            cmd_ptr = cmddat_q_base;
+            exec_buf_state.read_ptr = cmddat_q_base;
+        }
+        data_ptr = cmd_ptr;
 
         // fetch more
         noc_async_writes_flushed();
-        paged_read_into_cmddat_q(cmd_ptr, exec_buf_state);
-        noc_async_read_barrier();
+        paged_read_into_cmddat_q(exec_buf_state);
         remaining = exec_buf_state.length;
         remaining_stride = exec_buf_state.length;
     }
@@ -1218,10 +1334,15 @@ void* copy_into_l1_cache(
         sub_cmds_length -= remaining;
         stride -= remaining_stride;
         exec_buf_state.length = 0;
-        cmd_ptr = cmddat_q_base;
+        cmd_ptr += remaining_stride;
+        // reset if cmd_ptr is at end of cmddat_q
+        if (cmd_ptr == cmddat_q_end) {
+            // DPRINT << "  cmd_ptr/read_ptr reset" << ENDL();
+            cmd_ptr = cmddat_q_base;
+            exec_buf_state.read_ptr = cmddat_q_base;
+        }
         l1_ptr = (volatile uint32_t tt_l1_ptr*)(cmd_ptr);
-        paged_read_into_cmddat_q(cmd_ptr, exec_buf_state);
-        noc_async_read_barrier();
+        paged_read_into_cmddat_q(exec_buf_state);
         remaining = exec_buf_state.length;
         remaining_stride = exec_buf_state.length;
     }
@@ -1266,20 +1387,36 @@ uint32_t process_exec_buf_cmd(
     // the exec_buf contains the release commands
     volatile CQPrefetchCmd tt_l1_ptr* cmd = (volatile CQPrefetchCmd tt_l1_ptr*)cmd_ptr_outer;
 
+    // setup exec_buf_state the first time
     exec_buf_state.page_id = 0;
     exec_buf_state.base_addr = cmd->exec_buf.base_addr;
     exec_buf_state.log_page_size = cmd->exec_buf.log_page_size;
     exec_buf_state.pages = cmd->exec_buf.pages;
     exec_buf_state.length = 0;
+    exec_buf_state.read_ptr = cmddat_q_base;
+    uint32_t cmd_ptr = cmddat_q_base;
+    // DPRINT << "process_exec_buf_cmd" << ENDL();
+    // DPRINT << "  cmddat_q_base= " << cmddat_q_base << ENDL();
+    // DPRINT << "  cmddat_q_end=  " << cmddat_q_end << ENDL();
 
     bool done = false;
     while (!done) {
-        uint32_t cmd_ptr = cmddat_q_base;
+        // DeviceZoneScopedN("PEBC: 1st loop");
+        // reset if cmd_ptr is at end of cmddat_q
+        if (cmd_ptr == cmddat_q_end) {
+            // DPRINT << "  cmd_ptr/read_ptr reset" << ENDL();
+            cmd_ptr = cmddat_q_base;
+            exec_buf_state.read_ptr = cmddat_q_base;
+        }
+        // {
+        // DeviceZoneScopedN("PEBC: paged_read");
+        paged_read_into_cmddat_q(exec_buf_state);
+        // }
 
-        paged_read_into_cmddat_q(cmd_ptr, exec_buf_state);
-        noc_async_read_barrier();
-
+        // DPRINT << "  process_cmd" << ENDL();
         while (exec_buf_state.length > 0) {
+            // DPRINT << "  cmd_ptr= " << cmd_ptr << ENDL();
+            // DPRINT << "  length= " << exec_buf_state.length << ENDL();
             uint32_t stride;
             done = process_cmd<false, true>(cmd_ptr, downstream_data_ptr, stride, l1_cache, exec_buf_state);
 

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -1080,7 +1080,7 @@ void paged_read_into_cmddat_q(PrefetchExecBufState& exec_buf_state) {
     uint32_t read_ptr = exec_buf_state.read_ptr;
     uint32_t max_read_pages;
     constexpr uint32_t INITIAL_FETCH_SIZE = 16 * 1024;                           // 16KB (OPTIMIZE HERE)
-    constexpr uint32_t PREFETCH_FETCH_SIZE = cmddat_q_end - INITIAL_FETCH_SIZE;  // the rest
+    constexpr uint32_t PREFETCH_FETCH_SIZE = cmddat_q_size - INITIAL_FETCH_SIZE;  // the rest
 
     // cmddat_q do not wrap around
     // reset all prefetch members when read_ptr is at the beginning of cmddat_q


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/29684

### Problem description
The cmddat_q fetching from dram to l1 is currently implemented sequentially with no prefetching. Can be optimized with prefetching.

### What's changed
The paged_read_into_cmddat_q is optimized with prefetching. Start with initial fetching from DRAM and then prefetch the rest while process cmddat_q in parallel. Overall, 5% improvement.

Note:
unit_tests_api, unit_tests_device and unit_tests_dispatch passes
(Single-card) Fast dispatch frequent tests passes (all better)

### Checklist
- [X] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes