### PR TITLE
#0: Codeowners file updated for OP docs example files.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -248,16 +248,16 @@ tests/sweep_framework/sweep_utils/conv_transpose2d_common.py @tenstorrent/metali
 tests/sweep_framework/sweep_utils/max_pool2d_with_indices_common.py @tenstorrent/metalium-developers-convolutions @tenstorrent/codeowner-bypass
 
 # OP docs examples
-tests/ttnn/docs_examples/test_backward_examples.py @patrickroberts @sjameelTT @ntarafdar @dchenTT @tenstorrent/codeowner-bypass
-tests/ttnn/docs_examples/test_complex_unary_examples.py @patrickroberts @sjameelTT @ntarafdar @dchenTT @tenstorrent/codeowner-bypass
+tests/ttnn/docs_examples/test_backward_examples.py @tenstorrent/metalium-developers-eltwise @tenstorrent/codeowner-bypass
+tests/ttnn/docs_examples/test_complex_unary_examples.py @tenstorrent/metalium-developers-eltwise @tenstorrent/codeowner-bypass
 tests/ttnn/docs_examples/test_core_examples.py @tenstorrent/metalium-developers-ttnn-core @tenstorrent/codeowner-bypass
 tests/ttnn/docs_examples/test_data_movement_examples.py @tenstorrent/metalium-developers-ops-data-movement @tenstorrent/codeowner-bypass
-tests/ttnn/docs_examples/test_eltwise_*_examples.py @patrickroberts @sjameelTT @ntarafdar @dchenTT @tenstorrent/codeowner-bypass
+tests/ttnn/docs_examples/test_eltwise_*_examples.py @tenstorrent/metalium-developers-eltwise @tenstorrent/codeowner-bypass
 tests/ttnn/docs_examples/test_embedding_examples.py @tenstorrent/metalium-developers-ops-data-movement @tenstorrent/codeowner-bypass
-tests/ttnn/docs_examples/test_losses_examples.py @patrickroberts @sjameelTT @ntarafdar @dchenTT @tenstorrent/codeowner-bypass
+tests/ttnn/docs_examples/test_losses_examples.py @tenstorrent/metalium-developers-eltwise @tenstorrent/codeowner-bypass
 tests/ttnn/docs_examples/test_matrix_multiplication_examples.py @tenstorrent/metalium-developers-mmfusedreduce @tenstorrent/codeowner-bypass
 tests/ttnn/docs_examples/test_normalization_examples.py @tenstorrent/metalium-developers-mmfusedreduce @tenstorrent/codeowner-bypass
-tests/ttnn/docs_examples/test_pointwise_*_examples.py @patrickroberts @sjameelTT @ntarafdar @dchenTT @tenstorrent/codeowner-bypass
+tests/ttnn/docs_examples/test_pointwise_*_examples.py @tenstorrent/metalium-developers-eltwise @tenstorrent/codeowner-bypass
 tests/ttnn/docs_examples/test_pooling_examples.py @tenstorrent/metalium-developers-convolutions @tenstorrent/codeowner-bypass
 tests/ttnn/docs_examples/test_reduction_examples.py @tenstorrent/metalium-developers-mmfusedreduce @tenstorrent/codeowner-bypass
 tests/ttnn/docs_examples/test_tensor_creation_examples.py @tenstorrent/metalium-developers-ttnn-core @tenstorrent/codeowner-bypass

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -252,13 +252,12 @@ tests/ttnn/docs_examples/test_backward_examples.py @patrickroberts @sjameelTT @n
 tests/ttnn/docs_examples/test_complex_unary_examples.py @patrickroberts @sjameelTT @ntarafdar @dchenTT @tenstorrent/codeowner-bypass
 tests/ttnn/docs_examples/test_core_examples.py @tenstorrent/metalium-developers-ttnn-core @tenstorrent/codeowner-bypass
 tests/ttnn/docs_examples/test_data_movement_examples.py @tenstorrent/metalium-developers-ops-data-movement @tenstorrent/codeowner-bypass
-tests/ttnn/docs_examples/test_eltwise_unary_examples.py @patrickroberts @sjameelTT @ntarafdar @dchenTT @tenstorrent/codeowner-bypass
+tests/ttnn/docs_examples/test_eltwise_*_examples.py @patrickroberts @sjameelTT @ntarafdar @dchenTT @tenstorrent/codeowner-bypass
 tests/ttnn/docs_examples/test_embedding_examples.py @tenstorrent/metalium-developers-ops-data-movement @tenstorrent/codeowner-bypass
 tests/ttnn/docs_examples/test_losses_examples.py @patrickroberts @sjameelTT @ntarafdar @dchenTT @tenstorrent/codeowner-bypass
 tests/ttnn/docs_examples/test_matrix_multiplication_examples.py @tenstorrent/metalium-developers-mmfusedreduce @tenstorrent/codeowner-bypass
 tests/ttnn/docs_examples/test_normalization_examples.py @tenstorrent/metalium-developers-mmfusedreduce @tenstorrent/codeowner-bypass
-tests/ttnn/docs_examples/test_pointwise_binary_examples.py @patrickroberts @sjameelTT @ntarafdar @dchenTT @tenstorrent/codeowner-bypass
-tests/ttnn/docs_examples/test_pointwise_ternary_examples.py @patrickroberts @sjameelTT @ntarafdar @dchenTT @tenstorrent/codeowner-bypass
+tests/ttnn/docs_examples/test_pointwise_*_examples.py @patrickroberts @sjameelTT @ntarafdar @dchenTT @tenstorrent/codeowner-bypass
 tests/ttnn/docs_examples/test_pooling_examples.py @tenstorrent/metalium-developers-convolutions @tenstorrent/codeowner-bypass
 tests/ttnn/docs_examples/test_reduction_examples.py @tenstorrent/metalium-developers-mmfusedreduce @tenstorrent/codeowner-bypass
 tests/ttnn/docs_examples/test_tensor_creation_examples.py @tenstorrent/metalium-developers-ttnn-core @tenstorrent/codeowner-bypass

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -247,6 +247,22 @@ tests/sweep_framework/sweep_utils/conv2d_common.py @tenstorrent/metalium-develop
 tests/sweep_framework/sweep_utils/conv_transpose2d_common.py @tenstorrent/metalium-developers-convolutions @tenstorrent/codeowner-bypass
 tests/sweep_framework/sweep_utils/max_pool2d_with_indices_common.py @tenstorrent/metalium-developers-convolutions @tenstorrent/codeowner-bypass
 
+# OP docs examples
+tests/ttnn/docs_examples/test_backward_examples.py @patrickroberts @sjameelTT @ntarafdar @dchenTT @tenstorrent/codeowner-bypass
+tests/ttnn/docs_examples/test_complex_unary_examples.py @patrickroberts @sjameelTT @ntarafdar @dchenTT @tenstorrent/codeowner-bypass
+tests/ttnn/docs_examples/test_core_examples.py @tenstorrent/metalium-developers-ttnn-core @tenstorrent/codeowner-bypass
+tests/ttnn/docs_examples/test_data_movement_examples.py @tenstorrent/metalium-developers-ops-data-movement @tenstorrent/codeowner-bypass
+tests/ttnn/docs_examples/test_eltwise_unary_examples.py @patrickroberts @sjameelTT @ntarafdar @dchenTT @tenstorrent/codeowner-bypass
+tests/ttnn/docs_examples/test_embedding_examples.py @tenstorrent/metalium-developers-ops-data-movement @tenstorrent/codeowner-bypass
+tests/ttnn/docs_examples/test_losses_examples.py @patrickroberts @sjameelTT @ntarafdar @dchenTT @tenstorrent/codeowner-bypass
+tests/ttnn/docs_examples/test_matrix_multiplication_examples.py @tenstorrent/metalium-developers-mmfusedreduce @tenstorrent/codeowner-bypass
+tests/ttnn/docs_examples/test_normalization_examples.py @tenstorrent/metalium-developers-mmfusedreduce @tenstorrent/codeowner-bypass
+tests/ttnn/docs_examples/test_pointwise_binary_examples.py @patrickroberts @sjameelTT @ntarafdar @dchenTT @tenstorrent/codeowner-bypass
+tests/ttnn/docs_examples/test_pointwise_ternary_examples.py @patrickroberts @sjameelTT @ntarafdar @dchenTT @tenstorrent/codeowner-bypass
+tests/ttnn/docs_examples/test_pooling_examples.py @tenstorrent/metalium-developers-convolutions @tenstorrent/codeowner-bypass
+tests/ttnn/docs_examples/test_reduction_examples.py @tenstorrent/metalium-developers-mmfusedreduce @tenstorrent/codeowner-bypass
+tests/ttnn/docs_examples/test_tensor_creation_examples.py @tenstorrent/metalium-developers-ttnn-core @tenstorrent/codeowner-bypass
+
 # TTNN Distributed
 ttnn/ttnn/distributed/ @tenstorrent/metalium-developers-ttnn-core @tenstorrent/codeowner-bypass
 tests/ttnn/distributed/ @tenstorrent/metalium-developers-ttnn-core @tenstorrent/codeowner-bypass


### PR DESCRIPTION
### Ticket

This PR is based on comment: https://github.com/tenstorrent/tt-metal/pull/33495#issuecomment-3597835823 for the functionality introduced in https://github.com/tenstorrent/tt-metal/pull/32079

### What's changed

- Updated Codeowners file so that all operation examples files have a code owner from their operations owners.