### PR TITLE
Fixes for sampling penalties 

### DIFF
--- a/.github/workflows/galaxy-demo-tests-impl.yaml
+++ b/.github/workflows/galaxy-demo-tests-impl.yaml
@@ -151,6 +151,7 @@ jobs:
           pytest -n auto models/demos/llama3_70b_galaxy/demo/demo_decode.py -k "full" --timeout 1000
           pytest -n auto models/demos/llama3_70b_galaxy/demo/text_demo.py -k "repeat" --timeout 1000
           pytest -n auto models/demos/llama3_70b_galaxy/demo/text_demo.py -k "pcc-80L" --timeout 1000
+          pytest -n auto models/demos/llama3_70b_galaxy/demo/text_demo.py -k "batch-32-non-uniform-sampling" --timeout 1000
       - name: Run Llama3 long context demo tests (direct pytest)
         if: ${{ matrix.test-group.model == 'llama3_long_context' }}
         timeout-minutes: ${{ matrix.test-group.timeout }}

--- a/.github/workflows/galaxy-demo-tests-impl.yaml
+++ b/.github/workflows/galaxy-demo-tests-impl.yaml
@@ -151,7 +151,7 @@ jobs:
           pytest -n auto models/demos/llama3_70b_galaxy/demo/demo_decode.py -k "full" --timeout 1000
           pytest -n auto models/demos/llama3_70b_galaxy/demo/text_demo.py -k "repeat" --timeout 1000
           pytest -n auto models/demos/llama3_70b_galaxy/demo/text_demo.py -k "pcc-80L" --timeout 1000
-          pytest -n auto models/demos/llama3_70b_galaxy/demo/text_demo.py -k "batch-32-non-uniform-sampling" --timeout 1000
+          pytest -n auto models/demos/llama3_70b_galaxy/demo/text_demo.py -k "batch-32-non-uniform-sampling" --timeout 500
       - name: Run Llama3 long context demo tests (direct pytest)
         if: ${{ matrix.test-group.model == 'llama3_long_context' }}
         timeout-minutes: ${{ matrix.test-group.timeout }}

--- a/models/common/sampling/README.md
+++ b/models/common/sampling/README.md
@@ -20,12 +20,13 @@ sampling = SamplingGenerator(args=args, mesh_device=mesh_device, tt_ccl=tt_ccl)
 params = format_sampling_params(user_params, max_batch_size=32)
 sampling.reset_sampling_params(params)
 
+sampling.reset_seed(seed)
+
 sampling.reset_prompt_tokens(prompt_tokens)   # torch tensor shaped [B, S]
 sampling.reset_output_state(output_tokens)
 
 tt_tokens = sampling.sample(
     tt_logits,
-    seed=seed,
     tt_out_tok=tt_out_buffer,
 )
 ```
@@ -42,5 +43,3 @@ Before running decode, set `generator.enable_split_sampling = True` (or
    captures/executes a dedicated sampling trace immediately afterward.
 2. **Single trace:** Sampling runs inline as part of the model trace for
    maximum performance.
-
-Toggling the flag is inexpensive and can be done at runtime per request.

--- a/models/common/sampling/generator.py
+++ b/models/common/sampling/generator.py
@@ -29,7 +29,7 @@ class SamplingGenerator:
     Typical usage:
         generator = SamplingGenerator(args=args, mesh_device=mesh_device, tt_ccl=tt_ccl)
         generator.reset_sampling_params(k=..., p=..., temp=...)
-        tokens = generator.sample(logits, seed=seed, enable_trace=True)
+        tokens = generator.sample(logits, enable_trace=True)
     """
 
     _DEFAULT_PENALTIES = {
@@ -137,19 +137,17 @@ class SamplingGenerator:
         logits,
         *,
         penalties_on: bool,
-        seed: Optional[int],
         tt_out_tok: Optional[ttnn.Tensor],
     ):
         if penalties_on:
             self.tt_penalties.apply(logits)
-        tt_tokens = self.tt_sampling(logits, seed=seed, tt_out_tok=tt_out_tok)
+        tt_tokens = self.tt_sampling(logits, tt_out_tok=tt_out_tok)
         return tt_tokens
 
     def capture_trace(
         self,
         logits: ttnn.Tensor,
         *,
-        seed: Optional[int] = None,
         tt_out_tok: Optional[ttnn.Tensor] = None,
     ) -> ttnn.Tensor:
         """
@@ -163,7 +161,6 @@ class SamplingGenerator:
         self._run_sampling(
             logits,
             penalties_on=penalties_on,
-            seed=seed,
             tt_out_tok=tt_out_tok,
         )
 
@@ -171,7 +168,6 @@ class SamplingGenerator:
         sampled = self._run_sampling(
             logits,
             penalties_on=penalties_on,
-            seed=seed,
             tt_out_tok=tt_out_tok,
         )
         ttnn.end_trace_capture(self.mesh_device, trace_id, cq_id=self.cq_id)
@@ -180,7 +176,7 @@ class SamplingGenerator:
         slot["id"] = trace_id
         slot["input"] = logits
         slot["output"] = tt_out_tok or sampled
-        slot["kwargs"] = {"seed": seed, "tt_out_tok": tt_out_tok}
+        slot["kwargs"] = {"tt_out_tok": tt_out_tok}
 
         return slot["output"]
 
@@ -200,7 +196,6 @@ class SamplingGenerator:
         logits: ttnn.Tensor,
         *,
         enable_trace: bool = True,
-        seed: Optional[int] = None,
         tt_out_tok: Optional[ttnn.Tensor] = None,
     ) -> ttnn.Tensor:
         """
@@ -215,7 +210,6 @@ class SamplingGenerator:
             tt_out = self._run_sampling(
                 logits,
                 penalties_on=penalties_on,
-                seed=seed,
                 tt_out_tok=tt_out_tok,
             )
         else:
@@ -223,7 +217,6 @@ class SamplingGenerator:
             if slot["id"] is None:
                 return self.capture_trace(
                     logits,
-                    seed=seed,
                     tt_out_tok=tt_out_tok,
                 )
 

--- a/models/common/sampling/tt_penalties.py
+++ b/models/common/sampling/tt_penalties.py
@@ -34,16 +34,19 @@ def apply_penalties(logits: ttnn.Tensor, context: Optional[PenaltyContext]) -> t
         return logits
 
     op_kwargs = {"sub_core_grids": context.sub_core_grids} if context.sub_core_grids else {}
-
     # frequency
     freq_term = ttnn.multiply(context.output_counts, context.frequency_penalties, **op_kwargs)
-    logits = ttnn.subtract(logits, freq_term, output_tensor=logits, **op_kwargs)
+    freq_term_bf16 = ttnn.typecast(freq_term, ttnn.bfloat16, **op_kwargs)
     freq_term.deallocate()
+    logits = ttnn.subtract(logits, freq_term_bf16, output_tensor=logits, **op_kwargs)
+    freq_term_bf16.deallocate()
 
     # presence
     presence_term = ttnn.multiply(context.output_mask, context.presence_penalties, **op_kwargs)
-    logits = ttnn.subtract(logits, presence_term, output_tensor=logits, **op_kwargs)
+    presence_term_bf16 = ttnn.typecast(presence_term, ttnn.bfloat16, **op_kwargs)
     presence_term.deallocate()
+    logits = ttnn.subtract(logits, presence_term_bf16, output_tensor=logits, **op_kwargs)
+    presence_term_bf16.deallocate()
 
     # repetition
 
@@ -56,10 +59,10 @@ def apply_penalties(logits: ttnn.Tensor, context: Optional[PenaltyContext]) -> t
     inverse_penalties = ttnn.where(combined_mask, context.inverse_repetition_penalties, 1.0, **op_kwargs)
     combined_mask.deallocate()
 
-    # If logits are >1, divide by penalty, otherwise multiply by penalty.
+    # If logits are >0, divide by penalty, otherwise multiply by penalty.
     logits_bf16 = ttnn.typecast(logits, ttnn.bfloat16, **op_kwargs)
-    logits_gt1 = ttnn.gt(logits_bf16, 1, **op_kwargs)
-    scaling = ttnn.where(logits_gt1, penalties, inverse_penalties, **op_kwargs)
+    logits_gt1 = ttnn.gt(logits_bf16, 0, **op_kwargs)
+    scaling = ttnn.where(logits_gt1, inverse_penalties, penalties, **op_kwargs)
     logits_gt1.deallocate()
     penalties.deallocate()
     inverse_penalties.deallocate()
@@ -84,9 +87,10 @@ class TTPenalties(LightweightModule):
         self.num_devices = num_devices
         self.needs_padding = False
         if self.vocab_size == args.vocab_size:
-            # need to add one tile padding for the histogram to handle padded tokens
+            # need to add at least one tile padding for the histogram to handle padded tokens
             tile_width = 32
-            self.vocab_size += tile_width * num_devices
+            padding = tile_width - ((self.vocab_size // num_devices) % tile_width)
+            self.vocab_size += padding * num_devices
             self.needs_padding = True
         self.sub_core_grids = getattr(args, "sub_core_grids", None)
         self._op_kwargs = {"sub_core_grids": self.sub_core_grids} if self.sub_core_grids else {}
@@ -162,6 +166,8 @@ class TTPenalties(LightweightModule):
         return tensor.view(self.max_batch_size, 1)
 
     def reset_prompt_tokens(self, prompt_tokens: torch.Tensor):
+        # replaces -1s in prompt_tokens with self.vocab_size - 1
+        prompt_tokens = torch.where(prompt_tokens == -1, self.vocab_size - 1, prompt_tokens)
         prompt_tokens = self._alloc_int_buffer(
             host=prompt_tokens.reshape(-1, prompt_tokens.shape[-1]),
             shard_dims=(None, None),
@@ -175,6 +181,8 @@ class TTPenalties(LightweightModule):
         self.token_bin_counts_and_mask(new_tokens=prompt_tokens, src=src, mask=self.prompt_mask)
 
     def reset_output_tokens(self, tokens):
+        # replaces -1s in tokens with self.vocab_size - 1
+        tokens = torch.where(tokens == -1, self.vocab_size - 1, tokens)
         tokens_tt = ttnn.from_torch(
             tokens.reshape(-1, 1), device=self.mesh_device, dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT
         )
@@ -201,7 +209,10 @@ class TTPenalties(LightweightModule):
     def token_bin_counts_and_mask(self, new_tokens, src, counts=None, mask=None, counts_sliced=None):
         counts_new = ttnn.scatter_add(self.zeros, 1, new_tokens, src, **self._op_kwargs)
         new_tokens.deallocate()
-        counts_new = ttnn.to_layout(counts_new, ttnn.TILE_LAYOUT, **self._op_kwargs)
+        # need to use use_low_perf because llama galaxy runs out of L1 otherwise
+        counts_new = ttnn.tilize(
+            counts_new, **self._op_kwargs, use_low_perf=True if self.sub_core_grids is not None else False
+        )
         if counts:
             counts = ttnn.add(counts, counts_new, output_tensor=counts, **self._op_kwargs)
         else:

--- a/models/common/sampling/tt_sampling.py
+++ b/models/common/sampling/tt_sampling.py
@@ -58,8 +58,7 @@ class TTSampling(LightweightModule):
         # Multi-step reduction is supported only on single device
         self.multi_step_reduction = list(mesh_device.shape) == [1, 1]
         self.tt_ccl = tt_ccl
-        self.vocab_size = args.vocab_size
-        self.padded_vocab_size = getattr(args, "padded_vocab_size", None)
+        self.padded_vocab_size = getattr(args, "padded_vocab_size", args.vocab_size)
         self.max_batch_size = 32
         self.max_top_k = getattr(args, "max_top_k", 32)
         self.cluster_shape = args.cluster_shape
@@ -124,11 +123,8 @@ class TTSampling(LightweightModule):
         indices_device_offsets = torch.ones(
             1, 1, self.max_batch_size, self.max_top_k * num_devices_in_mesh, dtype=torch.int64
         )
-        per_device_vocab_size = (
-            self.vocab_size // num_devices_in_mesh
-            if self.cluster_shape[0] * self.cluster_shape[1] <= 8
-            else self.padded_vocab_size // num_devices_in_mesh
-        )
+        per_device_vocab_size = self.padded_vocab_size // num_devices_in_mesh
+
         for device_id in range(num_devices_in_mesh):
             indices_device_offsets[:, :, :, device_id * self.max_top_k : (device_id + 1) * self.max_top_k] = (
                 device_id * per_device_vocab_size
@@ -209,7 +205,6 @@ class TTSampling(LightweightModule):
     def forward(
         self,
         x: ttnn.Tensor,
-        seed: int = 0,
         tt_out_tok: ttnn.Tensor = None,
     ):
         """
@@ -221,7 +216,6 @@ class TTSampling(LightweightModule):
 
         Args:
             x: Input logits tensor
-            seed: Random seed for sampling
             tt_out_tok: Optional output tensor to write results to
 
         Returns:
@@ -340,7 +334,6 @@ class TTSampling(LightweightModule):
             k=self.k_tensor,
             p=self.p_tensor,
             temp=self.temp_tensor,
-            seed=seed,
             sub_core_grids=ttnn.num_cores_to_corerangeset_in_subcoregrids(
                 self.start_core, self.max_batch_size, self.sub_core_grids, row_wise=True
             )

--- a/models/demos/llama3_70b_galaxy/demo/demo_decode.py
+++ b/models/demos/llama3_70b_galaxy/demo/demo_decode.py
@@ -377,7 +377,8 @@ def run_llama3_demo(
         )
 
         # Sampling
-        _ = tt_sampling(tt_out[0], seed, tt_out_tok=tt_out_tok)  # Compile once with setting the seed
+        ttnn.manual_seed(seed, sub_core_grids=model_args.sub_core_grids)
+        _ = tt_sampling(tt_out[0], tt_out_tok=tt_out_tok)  # Compile
         logger.info(f"Sampling done")
 
     if not stress_test:

--- a/models/demos/llama3_70b_galaxy/demo/demo_decode.py
+++ b/models/demos/llama3_70b_galaxy/demo/demo_decode.py
@@ -377,7 +377,7 @@ def run_llama3_demo(
         )
 
         # Sampling
-        ttnn.manual_seed(seed, sub_core_grids=model_args.sub_core_grids)
+        ttnn.manual_seed(seed, sub_core_grids=model_args.sub_core_grids, device=mesh_device)
         _ = tt_sampling(tt_out[0], tt_out_tok=tt_out_tok)  # Compile
         logger.info(f"Sampling done")
 

--- a/models/demos/llama3_70b_galaxy/demo/text_demo.py
+++ b/models/demos/llama3_70b_galaxy/demo/text_demo.py
@@ -229,6 +229,10 @@ def create_tt_model(
                 "temperature": torch.linspace(0.0, 1.0, steps=32).tolist(),
                 "top_p": torch.linspace(0.08, 1.0, steps=32).tolist(),
                 "top_k": torch.arange(1, 33).tolist(),  # 1 to 32 inclusive
+                "presence_penalty": torch.linspace(-2.0, 2.0, steps=32).tolist(),
+                "frequency_penalty": torch.linspace(-2.0, 2.0, steps=32).tolist(),
+                "repetition_penalty": torch.linspace(0.8, 1.5, steps=32).tolist(),
+                "seed": torch.randint(0, 33, size=(32,)).tolist(),
             },  # sampling_params (non-uniform)
             False,  # stop_at_eos
             False,  # apc_test
@@ -807,7 +811,19 @@ def test_demo_text(
         temperature = sampling_params["temperature"]
         top_k = sampling_params.get("top_k", 32)
         top_p = sampling_params["top_p"]
-        device_sampling_params = SamplingParams(temperature=temperature, top_k=top_k, top_p=top_p)
+        presence_penalty = sampling_params.get("presence_penalty", 0.0)
+        frequency_penalty = sampling_params.get("frequency_penalty", 0.0)
+        repetition_penalty = sampling_params.get("repetition_penalty", 1.0)
+        seed = sampling_params.get("seed", 0)
+        device_sampling_params = SamplingParams(
+            temperature=temperature,
+            top_k=top_k,
+            top_p=top_p,
+            presence_penalty=presence_penalty,
+            frequency_penalty=frequency_penalty,
+            repetition_penalty=repetition_penalty,
+            seed=seed,
+        )
         if batch_idx == 0:
             logger.info("Starting prefill warmup...")
             profiler.start(f"compile_prefill", iteration=batch_idx)
@@ -953,6 +969,8 @@ def test_demo_text(
                     tt_out_logits_saved=tt_out_logits_saved,
                     is_cur_pos_sharded=is_cur_pos_sharded,
                     is_page_table_sharded=is_page_table_sharded,
+                    prompt_tokens=input_tokens_prefill_pt,
+                    output_tokens=prefilled_token,
                 )
                 read_events.append(read_event)
                 tt_out_toks.append(tt_out_tok)

--- a/models/demos/llama3_70b_galaxy/tests/test_llama_accuracy.py
+++ b/models/demos/llama3_70b_galaxy/tests/test_llama_accuracy.py
@@ -239,7 +239,7 @@ def test_tt_model_acc(
         )
 
         # Sampling
-        tt_out_tok = tt_sampling(tt_out[0], seed)
+        tt_out_tok = tt_sampling(tt_out[0])
 
         # Update the idxs
         ttnn.plus_one(

--- a/models/demos/llama3_70b_galaxy/tests/test_llama_model.py
+++ b/models/demos/llama3_70b_galaxy/tests/test_llama_model.py
@@ -318,7 +318,7 @@ def test_llama_model_inference(
                 page_table=page_table_tt,
             )
             # Sampling
-            tt_out_tok = tt_sampling(tt_out[0], seed)
+            tt_out_tok = tt_sampling(tt_out[0])
 
             # Convert ttnn tensor to torch tensor
             mesh_composer = ttnn.ConcatMesh2dToTensor(

--- a/models/demos/llama3_70b_galaxy/tests/test_llama_model_nd.py
+++ b/models/demos/llama3_70b_galaxy/tests/test_llama_model_nd.py
@@ -218,7 +218,7 @@ def test_llama_model_inference(
                 page_table=page_table_tt,
             )
             # Sampling
-            tt_out_tok = tt_sampling(tt_out[0], seed)
+            tt_out_tok = tt_sampling(tt_out[0])
 
             tt_out_tok_device0 = ttnn.get_device_tensors(tt_out_tok)[0]
             tt_out_tok_cpu = tt_out_tok_device0.cpu(blocking=True, cq_id=0)

--- a/models/demos/llama3_70b_galaxy/tests/unit_tests/test_sampling.py
+++ b/models/demos/llama3_70b_galaxy/tests/unit_tests/test_sampling.py
@@ -292,7 +292,7 @@ def test_llama_sampling_inference(
     if use_tracing:
         try:
             logger.info("Compile Llama Sampling")
-            ttnn.manual_seed(seed)
+            ttnn.manual_seed(seed, device=mesh_device, sub_core_grids=model_args.sub_core_grids)
             tt_outputs = tt_sampling(tt_input)  # Setting random seed
 
             tt_outputs = tt_sampling(tt_input)  # Compiling without seed; will generate new pseudo-random numbers
@@ -346,7 +346,7 @@ def test_llama_sampling_inference(
         tt_outputs_torch = []
         for i in range(num_samples):
             if i == 0:
-                ttnn.manual_seed(seed)
+                ttnn.manual_seed(seed, device=mesh_device, sub_core_grids=model_args.sub_core_grids)
                 tt_outputs = tt_sampling(tt_input)
             else:
                 tt_outputs = tt_sampling(

--- a/models/demos/llama3_70b_galaxy/tests/unit_tests/test_sampling.py
+++ b/models/demos/llama3_70b_galaxy/tests/unit_tests/test_sampling.py
@@ -292,8 +292,8 @@ def test_llama_sampling_inference(
     if use_tracing:
         try:
             logger.info("Compile Llama Sampling")
-
-            tt_outputs = tt_sampling(tt_input, seed=seed)  # Setting random seed
+            ttnn.manual_seed(seed)
+            tt_outputs = tt_sampling(tt_input)  # Setting random seed
 
             tt_outputs = tt_sampling(tt_input)  # Compiling without seed; will generate new pseudo-random numbers
 
@@ -346,7 +346,8 @@ def test_llama_sampling_inference(
         tt_outputs_torch = []
         for i in range(num_samples):
             if i == 0:
-                tt_outputs = tt_sampling(tt_input, seed=seed)
+                ttnn.manual_seed(seed)
+                tt_outputs = tt_sampling(tt_input)
             else:
                 tt_outputs = tt_sampling(
                     tt_input,

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -637,7 +637,7 @@ class Generator:
             ttnn.end_trace_capture(self.model_args[i].mesh_device, trace_id, cq_id=0)
 
             if split_enabled:
-                sampling_module.sample(logits=tt_out_trace[i], tt_out_tok=device_inputs[i][0])
+                sampling_module.capture_trace(logits=tt_out_trace[i], tt_out_tok=device_inputs[i][0])
         logger.info("Done Capturing Decode Trace")
 
         return trace_ids, tt_out_trace, *device_inputs

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -635,6 +635,9 @@ class Generator:
                 )
             )
             ttnn.end_trace_capture(self.model_args[i].mesh_device, trace_id, cq_id=0)
+
+            if split_enabled:
+                sampling_module.sample(logits=tt_out_trace[i], tt_out_tok=device_inputs[i][0])
         logger.info("Done Capturing Decode Trace")
 
         return trace_ids, tt_out_trace, *device_inputs


### PR DESCRIPTION
This PR fixes several issues with sampling penalties in the LLaMA model implementation, including correcting the repetition penalty logic, adding proper type conversions, and improving padding calculations for device operations.

Key Changes:

Fixed repetition penalty threshold from >1 to >0 and corrected the scaling direction (inverse vs normal penalties)
Added bfloat16 type conversions for frequency and presence penalty terms to ensure compatibility with logits
Updated padding calculation to properly handle tile alignment for vocabulary size across multiple devices

### Checklist
galaxy demo tests: https://github.com/tenstorrent/tt-metal/actions/runs/19852602930/job/56894820619