### PR TITLE
Correct the condition for enable_activation_reuse

### DIFF
--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
@@ -434,8 +434,9 @@ Conv2dBlockConfig determine_per_core_conv_block_config(
     if (parallel_config.shard_scheme == TensorMemoryLayout::HEIGHT_SHARDED && enable_activation_reuse) {
         const uint32_t output_image_width_ntiles = tt::div_up(output_width, tt::constants::TILE_HEIGHT);
         TT_FATAL(
-            act_block_h_ntiles > output_image_width_ntiles,
-            "Activation reuse needs act block h ({}) to be bigger than output image width in tiles ({}) for the "
+            act_block_h_ntiles >= output_image_width_ntiles,
+            "Activation reuse needs act block h ({}) to be greater than or equal to output image width in tiles ({}) "
+            "for the "
             "optimization to give boost",
             act_block_h_ntiles,
             output_image_width_ntiles);


### PR DESCRIPTION
### Ticket
#21689

### Problem description
For enable_activation_reuse functionality, activation block height ntiles can be equal to output image width ntiles.

### What's changed
Enable equality for activation block height ntiles and output image width ntiles.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI [running](https://github.com/tenstorrent/tt-metal/actions/runs/19853157305)
-  [X] [Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) CI passes [Link](https://github.com/tenstorrent/tt-metal/actions/runs/19848111967)
- [X] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable) [Link](https://github.com/tenstorrent/tt-metal/actions/runs/19848115455)
- [X] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes [Link](https://github.com/tenstorrent/tt-metal/actions/runs/19848118048/job/56869712994)
- [X] [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/19848120411) CI same as main