### PR TITLE
[skip ci] Fix galaxy quick in select galaxy pipelines

### DIFF
--- a/.github/workflows/pipeline-select-galaxy.yaml
+++ b/.github/workflows/pipeline-select-galaxy.yaml
@@ -183,7 +183,6 @@ jobs:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-      topology-6u: true
   galaxy-unit-tests:
     if: ${{ needs.determine-tests.outputs.run-unit == 'true' }}
     needs: [build-artifact, determine-tests]


### PR DESCRIPTION
### Problem description
Select galaxy pipelines is failing when trying to invoke galaxy quick workflow because it is setting parameter that doesn't exist

### What's changed
Remove topology-6u from workflow call