### PR TITLE
[skip ci] Bumped expected device perf for stable diffusion VAE

### DIFF
--- a/models/demos/wormhole/stable_diffusion/tests/test_perf.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_perf.py
@@ -450,7 +450,7 @@ def test_stable_diffusion_device_perf(expected_kernel_samples_per_second):
 @pytest.mark.models_device_performance_bare_metal
 @pytest.mark.parametrize(
     "expected_kernel_samples_per_second",
-    ((1.45) if is_wormhole_b0() else (2.05),),
+    ((2.88) if is_wormhole_b0() else (4.10),),
 )
 def test_stable_diffusion_vae_device_perf(expected_kernel_samples_per_second):
     subdir = "ttnn_stable_diffusion_vae"


### PR DESCRIPTION
### Problem description
Latest device perf run is [red](https://github.com/tenstorrent/tt-metal/actions/runs/19854825612) because of stable diffusion VAE

### What's changed
- bumped stable diffusion VAE expected perf values