### PR TITLE
[skip ci] Create change log by release type

### DIFF
--- a/.github/workflows/package-and-release.yaml
+++ b/.github/workflows/package-and-release.yaml
@@ -163,7 +163,7 @@ jobs:
 
 
   create-changelog:
-    needs: [create-tag]
+    needs: [create-tag, release-precheck]
     permissions: read-all
     runs-on: ubuntu-latest
     steps:
@@ -172,7 +172,8 @@ jobs:
         uses: mikepenz/release-changelog-builder-action@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          ignorePreReleases: true
+          fromTag: ${{ needs.release-precheck.outputs.tag-type == 'dev' && 'latest-dev' || (needs.release-precheck.outputs.tag-type == 'rc' && 'latest-rc' || 'latest') }}
+          toTag: ${{ needs.create-tag.outputs.version }}
           failOnError: true
           outputFile: CHANGELOG.txt
       - name: Output changelog

--- a/.github/workflows/package-and-release.yaml
+++ b/.github/workflows/package-and-release.yaml
@@ -167,12 +167,44 @@ jobs:
     permissions: read-all
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Get previous tag for changelog
+        id: get-previous-tag
+        run: |
+          # Fetch all tags
+          git fetch --tags --force origin
+
+          release_type="${{ needs.release-precheck.outputs.tag-type }}"
+          echo "Release type: $release_type"
+
+          if [[ "$release_type" == "dev" ]]; then
+            # For dev releases, find the second latest dev tag (contains -dev) - skip the current one
+            previous_tag=$(git tag -l --sort=-version:refname | grep -E ".*-dev.*" | sed -n '2p' || echo "")
+          elif [[ "$release_type" == "rc" ]]; then
+            # For rc releases, find the second latest rc tag (contains -rc) - skip the current one
+            previous_tag=$(git tag -l --sort=-version:refname | grep -E ".*-rc.*" | sed -n '2p' || echo "")
+          else
+            # For prod releases, find the second latest stable release (no -dev or -rc suffix) - skip the current one
+            previous_tag=$(git tag -l --sort=-version:refname | grep -v -E ".*(dev|rc).*" | sed -n '2p' || echo "")
+          fi
+
+          if [[ -z "$previous_tag" ]]; then
+            echo "No previous tag found for release type: $release_type"
+            echo "Using first commit as fallback"
+            previous_tag=$(git rev-list --max-parents=0 HEAD)
+          fi
+
+          echo "Previous tag: $previous_tag"
+          echo "previous-tag=$previous_tag" >> "$GITHUB_OUTPUT"
       - name: Create changelog
         id: create-changelog
         uses: mikepenz/release-changelog-builder-action@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          fromTag: ${{ needs.release-precheck.outputs.tag-type == 'dev' && 'latest-dev' || (needs.release-precheck.outputs.tag-type == 'rc' && 'latest-rc' || 'latest') }}
+          fromTag: ${{ steps.get-previous-tag.outputs.previous-tag }}
           toTag: ${{ needs.create-tag.outputs.version }}
           failOnError: true
           outputFile: CHANGELOG.txt

--- a/.github/workflows/package-and-release.yaml
+++ b/.github/workflows/package-and-release.yaml
@@ -93,10 +93,10 @@ jobs:
           # Run once to check for errors
           ./scripts/build_scripts/get_should_create_release.sh ${{ fromJSON(steps.get-is-release-candidate-and-tag-type.outputs.is-release-candidate) && '--release-candidate' || '' }}
           shouldCreateRelease=$(scripts/build_scripts/get_should_create_release.sh ${{ fromJSON(steps.get-is-release-candidate-and-tag-type.outputs.is-release-candidate) && '--release-candidate' || '' }})
-          if [ "$shouldCreateRelease" != "true" ]; then
-            echo "should-create-release is false, no release needed. Exiting workflow."
-            exit 1
-          fi
+          # if [ "$shouldCreateRelease" != "true" ]; then
+          #   echo "should-create-release is false, no release needed. Exiting workflow."
+          #   exit 1
+          # fi
           echo "should-create-release is true, proceeding with release workflow."
 
   create-tag:

--- a/.github/workflows/package-and-release.yaml
+++ b/.github/workflows/package-and-release.yaml
@@ -93,10 +93,10 @@ jobs:
           # Run once to check for errors
           ./scripts/build_scripts/get_should_create_release.sh ${{ fromJSON(steps.get-is-release-candidate-and-tag-type.outputs.is-release-candidate) && '--release-candidate' || '' }}
           shouldCreateRelease=$(scripts/build_scripts/get_should_create_release.sh ${{ fromJSON(steps.get-is-release-candidate-and-tag-type.outputs.is-release-candidate) && '--release-candidate' || '' }})
-          # if [ "$shouldCreateRelease" != "true" ]; then
-          #   echo "should-create-release is false, no release needed. Exiting workflow."
-          #   exit 1
-          # fi
+          if [ "$shouldCreateRelease" != "true" ]; then
+            echo "should-create-release is false, no release needed. Exiting workflow."
+            exit 1
+          fi
           echo "should-create-release is true, proceeding with release workflow."
 
   create-tag:

--- a/.github/workflows/package-and-release.yaml
+++ b/.github/workflows/package-and-release.yaml
@@ -181,14 +181,14 @@ jobs:
           echo "Release type: $release_type"
 
           if [[ "$release_type" == "dev" ]]; then
-            # For dev releases, find the second latest dev tag (contains -dev) - skip the current one
-            previous_tag=$(git tag -l --sort=-version:refname | grep -E ".*-dev.*" | sed -n '2p' || echo "")
+            # For dev releases, find the second latest dev tag (v*.*.0-dev followed by date) - skip the current one
+            previous_tag=$(git tag -l --sort=-version:refname | grep -E "^v[0-9]+\.[0-9]+\.[0-9]+-dev[0-9]{8}$" | sed -n '2p' || echo "")
           elif [[ "$release_type" == "rc" ]]; then
-            # For rc releases, find the second latest rc tag (contains -rc) - skip the current one
-            previous_tag=$(git tag -l --sort=-version:refname | grep -E ".*-rc.*" | sed -n '2p' || echo "")
+            # For rc releases, find the second latest rc tag (v*.*.0-rc followed by number) - skip the current one
+            previous_tag=$(git tag -l --sort=-version:refname | grep -E "^v[0-9]+\.[0-9]+\.[0-9]+-rc[0-9]+$" | sed -n '2p' || echo "")
           else
-            # For prod releases, find the second latest stable release (no -dev or -rc suffix) - skip the current one
-            previous_tag=$(git tag -l --sort=-version:refname | grep -v -E ".*(dev|rc).*" | sed -n '2p' || echo "")
+            # For prod releases, find the second latest stable release (v*.*.* with no suffix) - skip the current one
+            previous_tag=$(git tag -l --sort=-version:refname | grep -E "^v[0-9]+\.[0-9]+\.[0-9]+$" | sed -n '2p' || echo "")
           fi
 
           if [[ -z "$previous_tag" ]]; then

--- a/.github/workflows/package-and-release.yaml
+++ b/.github/workflows/package-and-release.yaml
@@ -200,6 +200,7 @@ jobs:
           echo "Previous tag: $previous_tag"
           echo "previous-tag=$previous_tag" >> "$GITHUB_OUTPUT"
       - name: Create changelog
+        if: ${{ !inputs.dry-run }}
         id: create-changelog
         uses: mikepenz/release-changelog-builder-action@v4
         with:
@@ -208,9 +209,14 @@ jobs:
           toTag: ${{ needs.create-tag.outputs.version }}
           failOnError: true
           outputFile: CHANGELOG.txt
+      - name: Create empty changelog for dry run
+        if: ${{ inputs.dry-run }}
+        run: echo "Changelog generation skipped for dry run" > CHANGELOG.txt
       - name: Output changelog
+        if: ${{ !inputs.dry-run }}
         run: cat CHANGELOG.txt
       - name: Upload changelog as artifact
+        if: ${{ !inputs.dry-run }}
         uses: actions/upload-artifact@v4
         timeout-minutes: 10
         with:

--- a/.github/workflows/package-and-release.yaml
+++ b/.github/workflows/package-and-release.yaml
@@ -224,6 +224,7 @@ jobs:
           path: CHANGELOG.txt
 
   create-release-notes:
+    if: ${{ !inputs.dry-run }}
     needs: create-changelog
     permissions: read-all
     runs-on: ubuntu-latest

--- a/.github/workflows/release-build-test-publish.yaml
+++ b/.github/workflows/release-build-test-publish.yaml
@@ -52,40 +52,40 @@ jobs:
         fetch-depth: 0
         skip-tt-train: false
 
-  single-card-demo-tests:
-    needs: build-artifact
-    if: ${{ inputs.tag-version != '' }}
-    secrets: inherit
-    uses: ./.github/workflows/single-card-demo-tests-impl.yaml
-    with:
-      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-      arch: wormhole_b0
-      mlperf-read-only: ${{ !(github.ref == 'refs/heads/stable' || startsWith(github.ref, 'refs/tags/v')) }}
+  # single-card-demo-tests:
+  #   needs: build-artifact
+  #   if: ${{ inputs.tag-version != '' }}
+  #   secrets: inherit
+  #   uses: ./.github/workflows/single-card-demo-tests-impl.yaml
+  #   with:
+  #     docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+  #     build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+  #     wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+  #     arch: wormhole_b0
+  #     mlperf-read-only: ${{ !(github.ref == 'refs/heads/stable' || startsWith(github.ref, 'refs/tags/v')) }}
 
-  t3000-demo-tests:
-    needs: build-artifact
-    if: ${{ inputs.version == inputs.main-os-version && inputs.tag-version != '' }}
-    secrets: inherit
-    uses: ./.github/workflows/t3000-demo-tests-impl.yaml
-    with:
-      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-      mlperf-read-only: ${{ !(github.ref == 'refs/heads/stable' || startsWith(github.ref, 'refs/tags/v')) }}
+  # t3000-demo-tests:
+  #   needs: build-artifact
+  #   if: ${{ inputs.version == inputs.main-os-version && inputs.tag-version != '' }}
+  #   secrets: inherit
+  #   uses: ./.github/workflows/t3000-demo-tests-impl.yaml
+  #   with:
+  #     docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+  #     wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+  #     build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+  #     mlperf-read-only: ${{ !(github.ref == 'refs/heads/stable' || startsWith(github.ref, 'refs/tags/v')) }}
 
-  galaxy-demos:
-    needs: build-artifact
-    if: ${{ inputs.version == inputs.main-os-version && inputs.tag-version != '' }}
-    uses: ./.github/workflows/galaxy-demo-tests-impl.yaml
-    secrets: inherit
-    with:
-      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-      topology: topology-6u
-      mlperf-read-only: ${{ !(github.ref == 'refs/heads/stable' || startsWith(github.ref, 'refs/tags/v')) }}
+  # galaxy-demos:
+  #   needs: build-artifact
+  #   if: ${{ inputs.version == inputs.main-os-version && inputs.tag-version != '' }}
+  #   uses: ./.github/workflows/galaxy-demo-tests-impl.yaml
+  #   secrets: inherit
+  #   with:
+  #     docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+  #     wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+  #     build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+  #     topology: topology-6u
+  #     mlperf-read-only: ${{ !(github.ref == 'refs/heads/stable' || startsWith(github.ref, 'refs/tags/v')) }}
 
 
   create-docker-release-image:

--- a/.github/workflows/release-build-test-publish.yaml
+++ b/.github/workflows/release-build-test-publish.yaml
@@ -52,40 +52,40 @@ jobs:
         fetch-depth: 0
         skip-tt-train: false
 
-  # single-card-demo-tests:
-  #   needs: build-artifact
-  #   if: ${{ inputs.tag-version != '' }}
-  #   secrets: inherit
-  #   uses: ./.github/workflows/single-card-demo-tests-impl.yaml
-  #   with:
-  #     docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-  #     build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-  #     wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-  #     arch: wormhole_b0
-  #     mlperf-read-only: ${{ !(github.ref == 'refs/heads/stable' || startsWith(github.ref, 'refs/tags/v')) }}
+  single-card-demo-tests:
+    needs: build-artifact
+    if: ${{ inputs.tag-version != '' }}
+    secrets: inherit
+    uses: ./.github/workflows/single-card-demo-tests-impl.yaml
+    with:
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+      arch: wormhole_b0
+      mlperf-read-only: ${{ !(github.ref == 'refs/heads/stable' || startsWith(github.ref, 'refs/tags/v')) }}
 
-  # t3000-demo-tests:
-  #   needs: build-artifact
-  #   if: ${{ inputs.version == inputs.main-os-version && inputs.tag-version != '' }}
-  #   secrets: inherit
-  #   uses: ./.github/workflows/t3000-demo-tests-impl.yaml
-  #   with:
-  #     docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-  #     wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-  #     build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-  #     mlperf-read-only: ${{ !(github.ref == 'refs/heads/stable' || startsWith(github.ref, 'refs/tags/v')) }}
+  t3000-demo-tests:
+    needs: build-artifact
+    if: ${{ inputs.version == inputs.main-os-version && inputs.tag-version != '' }}
+    secrets: inherit
+    uses: ./.github/workflows/t3000-demo-tests-impl.yaml
+    with:
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+      mlperf-read-only: ${{ !(github.ref == 'refs/heads/stable' || startsWith(github.ref, 'refs/tags/v')) }}
 
-  # galaxy-demos:
-  #   needs: build-artifact
-  #   if: ${{ inputs.version == inputs.main-os-version && inputs.tag-version != '' }}
-  #   uses: ./.github/workflows/galaxy-demo-tests-impl.yaml
-  #   secrets: inherit
-  #   with:
-  #     docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-  #     wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-  #     build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-  #     topology: topology-6u
-  #     mlperf-read-only: ${{ !(github.ref == 'refs/heads/stable' || startsWith(github.ref, 'refs/tags/v')) }}
+  galaxy-demos:
+    needs: build-artifact
+    if: ${{ inputs.version == inputs.main-os-version && inputs.tag-version != '' }}
+    uses: ./.github/workflows/galaxy-demo-tests-impl.yaml
+    secrets: inherit
+    with:
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+      topology: topology-6u
+      mlperf-read-only: ${{ !(github.ref == 'refs/heads/stable' || startsWith(github.ref, 'refs/tags/v')) }}
 
 
   create-docker-release-image:


### PR DESCRIPTION
### Problem description
Currently we are leaving for change log to be created by default with `mikepenz/release-changelog-builder-action@v4`

### What's changed
Add calculation which release type it is, and then calculate change log for that release type

### Checklist
- [x] [Package and release (dev)](https://github.com/tenstorrent/tt-metal/actions/runs/19857860146/job/56900318917) CI passes
- [x] [Package and release (rc)](https://github.com/tenstorrent/tt-metal/actions/runs/19858458885/job/56902362803) CI passes