### PR TITLE
[skip ci] Increased margin for SD VAE

### DIFF
--- a/models/demos/wormhole/stable_diffusion/tests/test_perf.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_perf.py
@@ -450,11 +450,11 @@ def test_stable_diffusion_device_perf(expected_kernel_samples_per_second):
 @pytest.mark.models_device_performance_bare_metal
 @pytest.mark.parametrize(
     "expected_kernel_samples_per_second",
-    ((2.88) if is_wormhole_b0() else (4.10),),
+    ((3.10) if is_wormhole_b0() else (4.10),),
 )
 def test_stable_diffusion_vae_device_perf(expected_kernel_samples_per_second):
     subdir = "ttnn_stable_diffusion_vae"
-    margin = 0.03
+    margin = 0.07
     batch = 1
     iterations = 1
     command = f"pytest models/demos/wormhole/stable_diffusion/tests/vae/test_vae.py::test_decoder[4-64-64-3-512-512-device_params0]"


### PR DESCRIPTION
### Problem description
The Stable diffusion VAE device perf test seems to be flaky, margin needs to be increased

### What's changed
- increased margin from `3%` to `7%`
- bumped expected samples/s `2.88` -> `3.10`