### PR TITLE
Migrate op to new infra: prod_nc

### DIFF
--- a/ttnn/cpp/ttnn/operations/reduction/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/reduction/CMakeLists.txt
@@ -60,6 +60,7 @@ target_sources(
         generic/device/common.cpp
         generic/generic_reductions.cpp
         prod/device/prod_nc_op.cpp
+        prod/device/prod_nc_device_operation.cpp
         prod/device/prod_nc_program_factory.cpp
         prod/device/prod_op_all.cpp
         prod/prod.cpp

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_device_operation.cpp
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "prod_nc_device_operation.hpp"
+
+namespace ttnn::operations::reduction::prod_nc {
+
+ProdNcDeviceOperation::program_factory_t ProdNcDeviceOperation::select_program_factory(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    return program::ProdNcProgramFactory{};
+}
+
+void ProdNcDeviceOperation::validate_on_program_cache_hit(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    validate_on_program_cache_miss(args, tensor_args);
+}
+
+void ProdNcDeviceOperation::validate_on_program_cache_miss(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    TT_FATAL((args.dim >= 0 && args.dim <= 3), "dim should be 0 - 3");
+    const auto& input = tensor_args.input;
+    const auto& output = tensor_args.output;
+
+    auto input_shape = input.padded_shape();
+    TT_FATAL((input_shape.rank() == 4), "rank should be 4, got rank: {}", input_shape.rank());
+    const auto& output_shape = output.padded_shape();
+    auto input_shape_wo_padding = input.logical_shape();
+
+    if (args.dim == 0 || args.dim == 1) {
+        input_shape[args.dim] = 1;
+        input_shape_wo_padding[args.dim] = 1;
+    }
+
+    for (int i = 0; i < input_shape.rank(); ++i) {
+        TT_FATAL(
+            input_shape[i] == output_shape[i],
+            "Input and output shapes must match at dimension {}, got input: {} vs output: {}",
+            i,
+            input_shape[i],
+            output_shape[i]);
+    }
+
+    // prod supports only bfloat16, per ttnn/cpp/ttnn/operations/reduction/prod/prod_pybind.hpp
+    TT_FATAL(
+        input.dtype() == tt::tt_metal::DataType::BFLOAT16,
+        "Error - unsupported data type for prod, expected BFLOAT16 but got {}.",
+        input.dtype());
+}
+
+ProdNcDeviceOperation::spec_return_value_t ProdNcDeviceOperation::compute_output_specs(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    // Inplace operation - return output tensor's spec
+    return tensor_args.output.tensor_spec();
+}
+
+ProdNcDeviceOperation::tensor_return_value_t ProdNcDeviceOperation::create_output_tensors(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    // Inplace operation - return output tensor
+    return tensor_args.output;
+}
+
+std::tuple<ProdNcDeviceOperation::operation_attributes_t, ProdNcDeviceOperation::tensor_args_t>
+ProdNcDeviceOperation::invoke(const Tensor& input, const Tensor& output, int64_t dim) {
+    return {operation_attributes_t{.dim = dim}, tensor_args_t{.input = input, .output = output}};
+}
+
+}  // namespace ttnn::operations::reduction::prod_nc

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_device_operation.hpp
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "prod_nc_device_operation_types.hpp"
+#include "prod_nc_program_factory.hpp"
+
+#include "ttnn/decorators.hpp"
+#include "ttnn/tensor/tensor.hpp"
+
+namespace ttnn::operations::reduction::prod_nc {
+
+struct ProdNcDeviceOperation {
+    using operation_attributes_t = prod_nc::operation_attributes_t;
+    using tensor_args_t = prod_nc::tensor_args_t;
+    using spec_return_value_t = prod_nc::spec_return_value_t;
+    using tensor_return_value_t = prod_nc::tensor_return_value_t;
+    using program_factory_t = std::variant<program::ProdNcProgramFactory>;
+    using shared_variables_t = program::ProdNcProgramFactory::shared_variables_t;
+
+    static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
+
+    static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
+    static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
+
+    static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
+
+    static tensor_return_value_t create_output_tensors(
+        const operation_attributes_t& operation_attributes, const tensor_args_t&);
+
+    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
+        const Tensor& input, const Tensor& output, int64_t dim);
+};
+
+}  // namespace ttnn::operations::reduction::prod_nc
+
+namespace ttnn::prim {
+constexpr auto prod_nc =
+    ttnn::register_operation<"ttnn::prim::prod_nc", ttnn::operations::reduction::prod_nc::ProdNcDeviceOperation>();
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_device_operation_types.hpp
@@ -12,8 +12,8 @@ struct operation_attributes_t {
 };
 
 struct tensor_args_t {
-    const Tensor& input;
-    const Tensor& output;  // Note: output is passed as input (inplace pattern)
+    Tensor input;
+    Tensor output;  // Note: output is passed as input (inplace pattern)
 };
 
 using tensor_return_value_t = Tensor;

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_device_operation_types.hpp
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/tensor/tensor.hpp"
+
+namespace ttnn::operations::reduction::prod_nc {
+
+struct operation_attributes_t {
+    int64_t dim;
+};
+
+struct tensor_args_t {
+    const Tensor& input;
+    const Tensor& output;  // Note: output is passed as input (inplace pattern)
+};
+
+using tensor_return_value_t = Tensor;
+
+using spec_return_value_t = TensorSpec;
+
+}  // namespace ttnn::operations::reduction::prod_nc

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_op.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_op.cpp
@@ -29,8 +29,6 @@ Tensor create_output_tensor(
         output_shape, input_tensor.dtype(), tt_metal::Layout::TILE, input_tensor.device(), mem_config);
 }
 
-}  // namespace
-
 // output as arg
 Tensor prod_(const Tensor& input, const Tensor& output, const int64_t& dim) {
     ttnn::prim::prod_nc(input, output, dim);
@@ -46,6 +44,8 @@ Tensor prod_(const Tensor& input, const int64_t& dim, const MemoryConfig& mem_co
     ttnn::prim::prod_nc(input, output, dim);
     return output;
 }
+
+}  // namespace
 
 Tensor prod_nc(
     const Tensor& input,

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_op.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_op.cpp
@@ -2,91 +2,38 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "ttnn/operations/moreh/moreh_helper_functions.hpp"
 #include "prod_nc_op.hpp"
+#include "prod_nc_device_operation.hpp"
 
-namespace tt {
+namespace tt::operations::primary {
 
-using namespace constants;
-namespace operations {
-namespace primary {
+namespace {
 
-////////////////////////////////////////////////////////////////////////////
-//                         Prod
-////////////////////////////////////////////////////////////////////////////
-void Prod::validate(const std::vector<Tensor>& inputs) const {
-    TT_FATAL((dim >= 0 && dim <= 3), "dim should be 0 - 3");
-    const auto& input = inputs.at(0);
-    const auto& output = inputs.at(1);
-
-    auto input_shape = input.padded_shape();
-    TT_FATAL((input_shape.rank() == 4), "rank should be 4, got rank: {}", input_shape.rank());
-    const auto& output_shape = output.padded_shape();
-    auto input_shape_wo_padding = input.logical_shape();
-
-    if (dim == 0 || dim == 1) {
-        input_shape[dim] = 1;
-        input_shape_wo_padding[dim] = 1;
-    }
-
-    for (int i = 0; i < input_shape.rank(); ++i) {
-        TT_FATAL(
-            input_shape[i] == output_shape[i],
-            "Input and output shapes must match at dimension {}, got input: {} vs output: {}",
-            i,
-            input_shape[i],
-            output_shape[i]);
-        // TT_FATAL(input_shape_wo_padding[i] == output_shape_wo_padding[i], "Error");
-    }
-
-    // prod supports only bfloat16, per ttnn/cpp/ttnn/operations/reduction/prod/prod_pybind.hpp
-    TT_FATAL(
-        input.dtype() == tt::tt_metal::DataType::BFLOAT16,
-        "Error - unsupported data type for prod, expected BFLOAT16 but got {}.",
-        input.dtype());
-}
-
-std::vector<Tensor> Prod::create_output_tensors(const std::vector<Tensor>& inputs) const {
-    // Inplace
-    return {};
-}
-
-std::vector<TensorSpec> Prod::compute_output_specs(const std::vector<Tensor>&) const {
-    // Inplace
-    return {};
-}
-
-operation::ProgramWithCallbacks Prod::create_program(
-    const std::vector<Tensor>& inputs, std::vector<Tensor>& outputs) const {
-    const auto& input = inputs.at(0);
-    const auto& output = inputs.at(1);
-
-    return prod_nc_format(input, output, dim);
-}
-
-ttnn::Shape compute_output_shape(const ttnn::Shape& input_shape, const int64_t& dim) {
+ttnn::Shape compute_output_shape(const ttnn::Shape& input_shape, int64_t dim) {
     auto output_shape = input_shape;
     switch (dim) {
         case 0:
         case 1: output_shape[dim] = 1; break;
         default: TT_THROW("Unsupported dim {} for prod nc op", dim);
     }
-
     return output_shape;
 }
 
-inline Tensor create_output_tensor(
+Tensor create_output_tensor(
     const Tensor& input_tensor, const ttnn::Shape& output_shape, const MemoryConfig& mem_config) {
     TT_FATAL(
-        input_tensor.storage_type() == StorageType::DEVICE,
+        input_tensor.storage_type() == tt_metal::StorageType::DEVICE,
         "Input tensor must be stored on device. Storage type: {}",
         input_tensor.storage_type());
-    return create_device_tensor(output_shape, input_tensor.dtype(), Layout::TILE, input_tensor.device(), mem_config);
+    return tt_metal::create_device_tensor(
+        output_shape, input_tensor.dtype(), tt_metal::Layout::TILE, input_tensor.device(), mem_config);
 }
+
+}  // namespace
 
 // output as arg
 Tensor prod_(const Tensor& input, const Tensor& output, const int64_t& dim) {
-    operation::run(Prod{.dim = dim}, {input, output});
+    ttnn::prim::prod_nc(input, output, dim);
     return output;
 }
 
@@ -96,7 +43,7 @@ Tensor prod_(const Tensor& input, const int64_t& dim, const MemoryConfig& mem_co
     auto output_shape = compute_output_shape(input_shape, dim);
     auto output = create_output_tensor(input, output_shape, mem_config);
 
-    operation::run(Prod{.dim = dim}, {input, output});
+    ttnn::prim::prod_nc(input, output, dim);
     return output;
 }
 
@@ -121,6 +68,4 @@ Tensor prod_nc(
     return output;
 }
 
-}  // namespace primary
-}  // namespace operations
-}  // namespace tt
+}  // namespace tt::operations::primary

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_op.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_op.cpp
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
-//
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC.
 // SPDX-License-Identifier: Apache-2.0
 
 #include "prod_nc_op.hpp"

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_op.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_op.hpp
@@ -1,15 +1,14 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
-//
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
 
+#include "ttnn/run_operation.hpp"
+#include "ttnn/tensor/tensor.hpp"
+
 #include <optional>
 #include <utility>
 #include <vector>
-
-#include "ttnn/run_operation.hpp"
-#include "ttnn/tensor/tensor.hpp"
 
 namespace tt {
 

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_op.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_op.hpp
@@ -4,7 +4,6 @@
 
 #pragma once
 
-#include <functional>
 #include <optional>
 #include <utility>
 #include <vector>
@@ -19,23 +18,6 @@ namespace operations {
 namespace primary {
 
 using namespace tt_metal;
-
-struct Prod {
-    int64_t dim;
-    void validate(const std::vector<Tensor>& inputs) const;
-    std::vector<TensorSpec> compute_output_specs(const std::vector<Tensor>& inputs) const;
-    std::vector<Tensor> create_output_tensors(const std::vector<Tensor>& inputs) const;
-    tt::tt_metal::operation::ProgramWithCallbacks create_program(
-        const std::vector<Tensor>& inputs, std::vector<Tensor>& outputs) const;
-};
-
-tt::tt_metal::operation::ProgramWithCallbacks prod_nc_format(const Tensor& input, const Tensor& output, int64_t dim);
-
-Tensor prod_(
-    const Tensor& input,
-    std::optional<std::reference_wrapper<const Tensor>> output,
-    const int64_t& dim,
-    const MemoryConfig& mem_config = tt::tt_metal::operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
 Tensor prod_nc(
     const Tensor& input,

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_program_factory.cpp
@@ -4,21 +4,25 @@
 
 #include <string>
 
+#include "prod_nc_program_factory.hpp"
 #include "ttnn/operations/moreh/moreh_helper_functions.hpp"
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
-#include "ttnn/operation.hpp"
 
-namespace tt {
-using namespace constants;
-namespace operations {
+namespace ttnn::operations::reduction::prod_nc::program {
 
-namespace primary {
+using namespace tt::constants;
 
-tt::tt_metal::operation::ProgramWithCallbacks prod_nc_format(
-    const tt::tt_metal::Tensor& input, const tt::tt_metal::Tensor& output, int64_t dim) {
+ProdNcProgramFactory::cached_program_t ProdNcProgramFactory::create(
+    const operation_attributes_t& operation_attributes,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& tensor_return_value) {
+    const auto& input = tensor_args.input;
+    const auto& output = tensor_args.output;
+    const int64_t dim = operation_attributes.dim;
+
     TT_FATAL(dim == 0 || dim == 1, "Dimension ({}) must be either 0 or 1", dim);
 
     ////////////////////////////////////////////////////////////////////////////
@@ -30,7 +34,7 @@ tt::tt_metal::operation::ProgramWithCallbacks prod_nc_format(
     ////////////////////////////////////////////////////////////////////////////
     //                         Parameters Setup
     ////////////////////////////////////////////////////////////////////////////
-    const auto cb_data_format = datatype_to_dataformat_converter(output.dtype());
+    const auto cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
 
     const auto& input_shape = input.padded_shape();
 
@@ -44,9 +48,9 @@ tt::tt_metal::operation::ProgramWithCallbacks prod_nc_format(
     const auto input_tile_offset = (dim == 0) ? (CHtWt) : (HtWt);
     const auto num_output_tiles = output.physical_volume() / TILE_HW;
 
-    log_debug(LogTest, "N {} C {} Ht {} Wt {}", N, C, Ht, Wt);
+    log_debug(tt::LogTest, "N {} C {} Ht {} Wt {}", N, C, Ht, Wt);
     log_debug(
-        LogTest,
+        tt::LogTest,
         "dim {} num_reduce_input_tile {} input_tile_offset {}, num_output_tiles {}",
         dim,
         num_reduce_input_tile,
@@ -79,10 +83,10 @@ tt::tt_metal::operation::ProgramWithCallbacks prod_nc_format(
         all_cores,
         cb_data_format,
         {
-            {CBIndex::c_0, in0_t},        // input
-            {CBIndex::c_1, in1_t},        // zero
-            {CBIndex::c_2, intermed0_t},  // accumulated sum
-            {CBIndex::c_3, out0_t},       // output
+            {tt::CBIndex::c_0, in0_t},        // input
+            {tt::CBIndex::c_1, in1_t},        // zero
+            {tt::CBIndex::c_2, intermed0_t},  // accumulated sum
+            {tt::CBIndex::c_3, out0_t},       // output
         });
 
     ////////////////////////////////////////////////////////////////////////////
@@ -92,7 +96,7 @@ tt::tt_metal::operation::ProgramWithCallbacks prod_nc_format(
     std::vector<uint32_t> reader_compile_time_args = {static_cast<uint32_t>(dim)};
     tt::tt_metal::TensorAccessorArgs(*input.buffer()).append_to(reader_compile_time_args);
 
-    constexpr uint32_t cb_id_out = CBIndex::c_3;
+    constexpr uint32_t cb_id_out = tt::CBIndex::c_3;
     std::vector<uint32_t> writer_compile_time_args = {(std::uint32_t)cb_id_out};
     tt::tt_metal::TensorAccessorArgs(*output.buffer()).append_to(writer_compile_time_args);
 
@@ -130,7 +134,7 @@ tt::tt_metal::operation::ProgramWithCallbacks prod_nc_format(
     //                      RuntimeArgs SetUp
     ////////////////////////////////////////////////////////////////////////////
     for (uint32_t i = 0, tile_offset = 0; i < num_cores_to_be_used; ++i) {
-        CoreCoord core = {i / num_cores_y, i % num_cores_y};
+        tt::tt_metal::CoreCoord core = {i / num_cores_y, i % num_cores_y};
 
         uint32_t num_tiles_per_core;
         if (core_group_1.contains(core)) {
@@ -141,7 +145,7 @@ tt::tt_metal::operation::ProgramWithCallbacks prod_nc_format(
             TT_THROW("Core not in specified core ranges.");
         }
 
-        SetRuntimeArgs(
+        tt::tt_metal::SetRuntimeArgs(
             program,
             reader_kernel_id,
             core,
@@ -154,7 +158,7 @@ tt::tt_metal::operation::ProgramWithCallbacks prod_nc_format(
              CHtWt,
              static_cast<uint32_t>(dim)});
 
-        SetRuntimeArgs(
+        tt::tt_metal::SetRuntimeArgs(
             program,
             writer_kernel_id,
             core,
@@ -164,41 +168,50 @@ tt::tt_metal::operation::ProgramWithCallbacks prod_nc_format(
              static_cast<uint32_t>(ttnn::operations::is_dram(output))});
 
         if (core_group_1.contains(core)) {
-            SetRuntimeArgs(program, compute_kernel_1_id, core, {num_reduce_input_tile, num_tiles_per_core});
+            tt::tt_metal::SetRuntimeArgs(
+                program, compute_kernel_1_id, core, {num_reduce_input_tile, num_tiles_per_core});
         } else if (core_group_2.contains(core)) {
             TT_FATAL(compute_kernel_2_id.has_value(), "compute_kernel_2_id needs to have a value");
-            SetRuntimeArgs(program, compute_kernel_2_id.value(), core, {num_reduce_input_tile, num_tiles_per_core});
+            tt::tt_metal::SetRuntimeArgs(
+                program, compute_kernel_2_id.value(), core, {num_reduce_input_tile, num_tiles_per_core});
         } else {
             TT_THROW("Core not in specified core ranges.");
         }
         tile_offset += num_tiles_per_core;
     }
 
-    auto override_runtime_arguments_callback = [reader_kernel_id, writer_kernel_id, num_cores_to_be_used, num_cores_y](
-                                                   const void* operation,
-                                                   const tt::tt_metal::Program& program,
-                                                   const std::vector<tt::tt_metal::Tensor>& input_tensors,
-                                                   const std::vector<std::optional<const tt::tt_metal::Tensor>>&,
-                                                   const std::vector<tt::tt_metal::Tensor>& output_tensors) {
-        const auto* input_buffer = input_tensors.at(0).buffer();
-        const auto* output_buffer = input_tensors.at(1).buffer();
-        for (uint32_t i = 0; i < num_cores_to_be_used; ++i) {
-            CoreCoord core = {i / num_cores_y, i % num_cores_y};
-            {
-                auto& runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
-                runtime_args[0] = input_buffer->address();
-            }
-
-            {
-                auto& runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
-                runtime_args[0] = output_buffer->address();
-            }
-        }
-    };
-
-    return {.program = std::move(program), .override_runtime_arguments_callback = override_runtime_arguments_callback};
+    return {
+        std::move(program),
+        shared_variables_t{
+            .reader_kernel_id = reader_kernel_id,
+            .writer_kernel_id = writer_kernel_id,
+            .num_cores_to_be_used = num_cores_to_be_used,
+            .num_cores_y = num_cores_y}};
 }
 
-}  // namespace primary
-}  // namespace operations
-}  // namespace tt
+void ProdNcProgramFactory::override_runtime_arguments(
+    cached_program_t& cached_program,
+    const operation_attributes_t& operation_attributes,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& tensor_return_value) {
+    auto& program = cached_program.program;
+    const auto& shared_variables = cached_program.shared_variables;
+
+    const auto* input_buffer = tensor_args.input.buffer();
+    const auto* output_buffer = tensor_args.output.buffer();
+
+    for (uint32_t i = 0; i < shared_variables.num_cores_to_be_used; ++i) {
+        tt::tt_metal::CoreCoord core = {i / shared_variables.num_cores_y, i % shared_variables.num_cores_y};
+        {
+            auto& runtime_args = tt::tt_metal::GetRuntimeArgs(program, shared_variables.reader_kernel_id, core);
+            runtime_args[0] = input_buffer->address();
+        }
+
+        {
+            auto& runtime_args = tt::tt_metal::GetRuntimeArgs(program, shared_variables.writer_kernel_id, core);
+            runtime_args[0] = output_buffer->address();
+        }
+    }
+}
+
+}  // namespace ttnn::operations::reduction::prod_nc::program

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_program_factory.cpp
@@ -1,15 +1,15 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
-//
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC.
 // SPDX-License-Identifier: Apache-2.0
-
-#include <string>
 
 #include "prod_nc_program_factory.hpp"
 #include "ttnn/operations/moreh/moreh_helper_functions.hpp"
-#include <tt-metalium/work_split.hpp>
+
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/work_split.hpp>
+
+#include <string>
 
 namespace ttnn::operations::reduction::prod_nc::program {
 

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_program_factory.hpp
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/device_operation.hpp"
+#include "prod_nc_device_operation_types.hpp"
+
+namespace ttnn::operations::reduction::prod_nc::program {
+
+struct ProdNcProgramFactory {
+    struct shared_variables_t {
+        tt::tt_metal::KernelHandle reader_kernel_id;
+        tt::tt_metal::KernelHandle writer_kernel_id;
+        uint32_t num_cores_to_be_used;
+        uint32_t num_cores_y;
+    };
+
+    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
+
+    static cached_program_t create(
+        const operation_attributes_t& operation_attributes,
+        const tensor_args_t& tensor_args,
+        tensor_return_value_t& tensor_return_value);
+
+    static void override_runtime_arguments(
+        cached_program_t& cached_program,
+        const operation_attributes_t& operation_attributes,
+        const tensor_args_t& tensor_args,
+        tensor_return_value_t& tensor_return_value);
+};
+
+}  // namespace ttnn::operations::reduction::prod_nc::program

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_program_factory.hpp
@@ -10,10 +10,10 @@ namespace ttnn::operations::reduction::prod_nc::program {
 
 struct ProdNcProgramFactory {
     struct shared_variables_t {
-        tt::tt_metal::KernelHandle reader_kernel_id;
-        tt::tt_metal::KernelHandle writer_kernel_id;
-        uint32_t num_cores_to_be_used;
-        uint32_t num_cores_y;
+        tt::tt_metal::KernelHandle reader_kernel_id{};
+        tt::tt_metal::KernelHandle writer_kernel_id{};
+        uint32_t num_cores_to_be_used{};
+        uint32_t num_cores_y{};
     };
 
     using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_program_factory.hpp
@@ -3,8 +3,8 @@
 
 #pragma once
 
-#include "ttnn/device_operation.hpp"
 #include "prod_nc_device_operation_types.hpp"
+#include "ttnn/device_operation.hpp"
 
 namespace ttnn::operations::reduction::prod_nc::program {
 

--- a/ttnn/cpp/ttnn/operations/reduction/prod/prod.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/prod.cpp
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
-//
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC.
 // SPDX-License-Identifier: Apache-2.0
 
 #include "prod.hpp"

--- a/ttnn/cpp/ttnn/operations/reduction/prod/prod.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/prod.cpp
@@ -32,7 +32,7 @@ inline Tensor prod_all(const Tensor& input_a, const MemoryConfig& output_mem_con
     return tt::operations::primary::prod_all(formatted_input_tensor, output_mem_config);
 }
 
-inline Tensor prod_nc(const Tensor& temp, int64_t dim, const MemoryConfig& output_mem_config) {
+inline Tensor compute_prod_nc(const Tensor& temp, int64_t dim, const MemoryConfig& output_mem_config) {
     // layout conversion
     auto formatted_input_tensor = temp;
     if (formatted_input_tensor.layout() == Layout::ROW_MAJOR) {
@@ -124,7 +124,7 @@ Tensor ProdOperation::invoke(
         // Dim0 grows to include the rest of the dimensions, and our "third last" dim moves into dim1, which is our 4D
         // reduction dim
         auto input_tensor_4d = data_movement::squeeze_from_ND_to_4D(permuted);
-        Tensor result = prod_nc(input_tensor_4d, /*dim=*/1, output_mem_config);
+        Tensor result = compute_prod_nc(input_tensor_4d, /*dim=*/1, output_mem_config);
 
         // Unsqueeze dim0 to restore the original tensor rank
         ttnn::Shape output_shape = ttnn::Shape(input_shape);
@@ -161,7 +161,7 @@ Tensor ProdOperation::invoke(
             ttnn::SmallVector<int64_t> permute_dims = {3, 0, 1, 2};
             temp = ttnn::permute(input_tensor_4d, permute_dims, output_mem_config);
         }
-        Tensor result = prod_nc(temp, dim_4d, output_mem_config);
+        Tensor result = compute_prod_nc(temp, dim_4d, output_mem_config);
         // Permute and unpad result for dim 2,3. Don't need to process dim 0,1.
         auto step = ttnn::SmallVector<uint32_t>({1, 1, 1, 1});
         if (dim_4d == 0 || dim_4d == 1 || dim_4d == -4 || dim_4d == -3) {


### PR DESCRIPTION
### Problem description
TMP migration, prod_nc OP

### Ticket
[Link to Github Issue 32699](https://github.com/tenstorrent/tt-metal/issues/32699)


### What's changed
- Create prod_nc_device_operation_types.hpp with operation_attributes_t and tensor_args_t
- Create prod_nc_program_factory.hpp with ProdNcProgramFactory and shared_variables_t
- Create prod_nc_device_operation.hpp with ProdNcDeviceOperation and prim registration
- Create prod_nc_device_operation.cpp with device operation implementation
- Refactor prod_nc_program_factory.cpp to TMP pattern (cached_program_t, override_runtime_arguments)
- Update prod_nc_op.cpp to use ttnn::prim::prod_nc instead of operation::run
- Remove legacy Prod struct from prod_nc_op.hpp
- Add prod_nc_device_operation.cpp to CMakeLists.txt

### Checklist
- [X] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes - https://github.com/tenstorrent/tt-metal/actions/runs/19906624848
- [X] Code analysis https://github.com/tenstorrent/tt-metal/actions/runs/19907310717