### PR TITLE
High accuracy fp32 exp

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
@@ -165,8 +165,8 @@ sfpi_inline sfpi::vFloat _sfpu_exp_f32_accurate_(sfpi::vFloat val) {
     sfpi::vFloat result = sfpi::vConst0;
 
     // Clamp to prevent overflow/underflow
-    constexpr float OVERFLOW_THRESHOLD = 127.0f;
-    constexpr float UNDERFLOW_THRESHOLD = -127.0f;
+    constexpr float OVERFLOW_THRESHOLD = 128.0f;
+    constexpr float UNDERFLOW_THRESHOLD = -128.0f;
 
     // Step 1: Compute k = round(x / ln(2))
     // z = x / ln(2) = x * (1/ln(2))

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_exp.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_exp.h
@@ -13,10 +13,10 @@ namespace ckernel {
 template <
     bool APPROXIMATE,
     bool FAST_APPROX,
+    bool is_fp32_dest_acc_en,
     bool SCALE_EN = false,
     bool SKIP_POSITIVE_CHECK = false,
-    int ITERATIONS = 8,
-    bool is_fp32_dest_acc_en = false>
+    int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_exponential(
     uint dst_index,
     int vector_mode = (int)VectorMode::RC,
@@ -25,10 +25,10 @@ inline void llk_math_eltwise_unary_sfpu_exponential(
         ckernel::sfpu::calculate_exponential<
             APPROXIMATE,
             FAST_APPROX,
+            is_fp32_dest_acc_en,
             SCALE_EN,
             ITERATIONS,
-            SKIP_POSITIVE_CHECK,
-            is_fp32_dest_acc_en>,
+            SKIP_POSITIVE_CHECK>,
         dst_index,
         vector_mode,
         param0);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
@@ -10,7 +10,6 @@
 #include "sfpu/ckernel_sfpu_converter.h"
 #include "ckernel_sfpu_conversions.h"
 #include "sfpi.h"
-#include "third_party/tt_llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_polyval.h"
 
 namespace ckernel {
 namespace sfpu {
@@ -179,19 +178,18 @@ sfpi_inline sfpi::vFloat _sfpu_exp_f32_accurate_(sfpi::vFloat val) {
 
     // Check for special cases
     sfpi::vInt exp_bits = sfpi::exexp(z);
-    sfpi::vInt man_bits = sfpi::exman9(z);
 
-    v_if(exp_bits == 255 && man_bits != 0) {
-        // NaN: exponent = 255 (all 1s) and mantissa != 0
-        result = std::numeric_limits<float>::quiet_NaN();
-    }
-    v_elseif(z >= OVERFLOW_THRESHOLD) {
+    v_if(z >= OVERFLOW_THRESHOLD) {
         // Overflow
         result = std::numeric_limits<float>::infinity();
     }
     v_elseif(z <= UNDERFLOW_THRESHOLD) {
         // Underflow
         result = sfpi::vConst0;
+    }
+    v_elseif(exp_bits == 255) {
+        // infinity (exp = 255 && man != 0) already taken care of by previous conditionals
+        result = std::numeric_limits<float>::quiet_NaN();
     }
     v_else {
         // Round z to nearest integer using round-to-nearest-even
@@ -272,10 +270,10 @@ sfpi_inline sfpi::vFloat _sfpu_exp_improved_<true>(sfpi::vFloat val) {
 template <
     bool APPROXIMATION_MODE,
     bool FAST_APPROX,
+    bool is_fp32_dest_acc_en,
     bool SCALE_EN = false,
     int ITERATIONS = 8,
-    bool SKIP_POSITIVE_CHECK = false,
-    bool is_fp32_dest_acc_en = false>
+    bool SKIP_POSITIVE_CHECK = false>
 void calculate_exponential(const uint exp_base_scale_factor = p_sfpu::kCONST_1_FP16B) {
     if constexpr (APPROXIMATION_MODE) {
         _calculate_exponential_<APPROXIMATION_MODE, SCALE_EN, ITERATIONS, FAST_APPROX, SKIP_POSITIVE_CHECK>(

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
@@ -166,8 +166,8 @@ sfpi_inline sfpi::vFloat _sfpu_exp_f32_accurate_(sfpi::vFloat val) {
     sfpi::vFloat result = sfpi::vConst0;
 
     // Clamp to prevent overflow/underflow
-    constexpr float OVERFLOW_THRESHOLD = 127.0f;
-    constexpr float UNDERFLOW_THRESHOLD = -127.0f;
+    constexpr float OVERFLOW_THRESHOLD = 128.0f;
+    constexpr float UNDERFLOW_THRESHOLD = -128.0f;
 
     // Step 1: Compute k = round(x / ln(2))
     // z = x / ln(2) = x * (1/ln(2))

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
@@ -7,6 +7,7 @@
 #include "ckernel.h"
 #include "sfpu/ckernel_sfpu_exp.h"
 #include "sfpu/ckernel_sfpu_polyval.h"
+#include "sfpu/ckernel_sfpu_converter.h"
 #include "ckernel_sfpu_conversions.h"
 #include "sfpi.h"
 #include "third_party/tt_llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_polyval.h"
@@ -136,9 +137,8 @@ sfpi_inline sfpi::vFloat _sfpu_exp_61f_(sfpi::vFloat val) {
 
 // Utility function to round a float to a 32-bit integer while also calculating the
 // integer part of the rounded value
-sfpi_inline sfpi::vFloat _sfpu_round_int32_(sfpi::vFloat z, sfpi::vInt& k_int) {
-    // From Hacker's Delight
-    // sfpi::vFloat c231 = 12582912.f;  // 2^23 + 2^22
+sfpi_inline sfpi::vFloat _sfpu_round_nearest_int32_(sfpi::vFloat z, sfpi::vInt& k_int) {
+    // From Hacker's Delight: round-to-nearest-even method
     // float -> int32 (round to nearest even): n = (x + float(c231)) - int32(c231)
     // round-to-nearest-even: n = (x + float(c231)) - float(c231)
     // where c231 = 0x4B400000 (2^23 + 2^22)
@@ -153,10 +153,13 @@ sfpi_inline sfpi::vFloat _sfpu_round_int32_(sfpi::vFloat z, sfpi::vInt& k_int) {
 
 /*
  * This function implements exp(x) using Cody-Waite range reduction for improved accuracy.
+ * Target accuracy: < 1 ULP for float32.
+ *
+ * Algorithm:
  * 1. Handle special cases (overflow, underflow, NaN)
  * 2. Convert to base-2: exp(x) = 2^(x/ln2)
  * 3. Range reduction using Cody-Waite: compute k, then r = x - k*ln2_hi - k*ln2_lo
- * 4. Compute exp(r) using polynomial approximation
+ * 4. Compute exp(r) using polynomial approximation (Taylor series)
  * 5. Scale by 2^k: result = 2^k * exp(r)
  *
  * @param val The input value (sfpi::vFloat vector), can be any floating point number
@@ -191,16 +194,17 @@ sfpi_inline sfpi::vFloat _sfpu_exp_f32_accurate_(sfpi::vFloat val) {
         result = sfpi::vConst0;
     }
     v_else {
-        // Use floor(z + 0.5) for rounding to nearest integer
+        // Round z to nearest integer using round-to-nearest-even
         sfpi::vInt k_int;
-        sfpi::vFloat k = _sfpu_round_int32_(z, k_int);
+        sfpi::vFloat k = _sfpu_round_nearest_int32_(z, k_int);
 
         // Step 2: Cody-Waite range reduction
         // Compute r = x - k*ln(2) in extended precision
         // r = x - k*LN2_HI - k*LN2_LO
         // This provides better accuracy than simple r = x - k*ln(2)
-        // Cody-Waite constants: ln(2) split into high and low parts
-        // LN2_HI has lower 12 bits zeroed for exact multiplication
+        // Cody-Waite constants: ln(2) split into high and low parts for extended precision.
+        // LN2_HI is chosen so that k*LN2_HI can be computed exactly for integer k in the valid range.
+        // LN2_LO contains the remainder: LN2_HI + LN2_LO ≈ -ln(2)
 
         // We want to do:
         // 1) r_hi = val - k * LN2_HI
@@ -213,17 +217,15 @@ sfpi_inline sfpi::vFloat _sfpu_exp_f32_accurate_(sfpi::vFloat val) {
         constexpr float LN2_LO = -3.19461832987e-05f;   // Low bits of ln(2)
 
         // First subtract k * LN2_HI
-        // sfpi::vFloat temp1 = k * LN2_HI;
         sfpi::vFloat r_hi = k * LN2_HI + val;
 
         // Then subtract k * LN2_LO
-        // sfpi::vFloat temp2 = k * LN2_LO;
         sfpi::vFloat r = k * LN2_LO + r_hi;
 
-        // Step 3: Polynomial approximation for exp(r)
-        // exp(r) = 1 + r + r²/2! + r³/3! + r⁴/4! + r⁵/5! + r⁶/6! + r⁷/7!
-        // Use 7th order polynomial for better accuracy
-        // Coefficients in ascending order: c0, c1, c2, c3, c4, c5, c6, c7
+        // Step 3: Polynomial approximation for exp(r) using Taylor series
+        // exp(r) ~= 1 + r + r²/2! + r³/3! + r⁴/4! + r⁵/5! + r⁶/6! + r⁷/7!
+        // Use 7th order polynomial (Taylor series coefficients) for < 1 ULP accuracy
+        // Coefficients in ascending order of powers: c0, c1, c2, c3, c4, c5, c6, c7
         sfpi::vFloat p = PolynomialEvaluator::eval(
             r,
             sfpi::vConst1,  // c0 = 1
@@ -258,7 +260,7 @@ sfpi_inline sfpi::vFloat _sfpu_exp_improved_(sfpi::vFloat val);
 // is_fp32_dest_acc_en == false
 template <>
 sfpi_inline sfpi::vFloat _sfpu_exp_improved_<false>(sfpi::vFloat val) {
-    return _sfpu_exp_21f_(val);
+    return _sfpu_exp_21f_<false>(val);
 }
 
 // is_fp32_dest_acc_en == true

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
@@ -9,6 +9,7 @@
 #include "sfpu/ckernel_sfpu_polyval.h"
 #include "ckernel_sfpu_conversions.h"
 #include "sfpi.h"
+#include "third_party/tt_llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_polyval.h"
 
 namespace ckernel {
 namespace sfpu {
@@ -133,19 +134,137 @@ sfpi_inline sfpi::vFloat _sfpu_exp_61f_(sfpi::vFloat val) {
     return y;
 }
 
+// Utility function to round a float to a 32-bit integer while also calculating the
+// integer part of the rounded value
+sfpi_inline sfpi::vFloat _sfpu_round_int32_(sfpi::vFloat z, sfpi::vInt& k_int) {
+    // From Hacker's Delight
+    // sfpi::vFloat c231 = 12582912.f;  // 2^23 + 2^22
+    // float -> int32 (round to nearest even): n = (x + float(c231)) - int32(c231)
+    // round-to-nearest-even: n = (x + float(c231)) - float(c231)
+    // where c231 = 0x4B400000 (2^23 + 2^22)
+    const sfpi::vFloat c231 = Converter::as_float(0x4B400000U);  // 2^23 + 2^22
+
+    sfpi::vFloat tmp = z + c231;
+    sfpi::vFloat k = tmp - c231;
+    k_int = sfpi::reinterpret<sfpi::vInt>(tmp) - sfpi::reinterpret<sfpi::vInt>(c231);
+
+    return k;
+}
+
+/*
+ * This function implements exp(x) using Cody-Waite range reduction for improved accuracy.
+ * 1. Handle special cases (overflow, underflow, NaN)
+ * 2. Convert to base-2: exp(x) = 2^(x/ln2)
+ * 3. Range reduction using Cody-Waite: compute k, then r = x - k*ln2_hi - k*ln2_lo
+ * 4. Compute exp(r) using polynomial approximation
+ * 5. Scale by 2^k: result = 2^k * exp(r)
+ *
+ * @param val The input value (sfpi::vFloat vector), can be any floating point number
+ * @return sfpi::vFloat Result of exp(val)
+ */
+sfpi_inline sfpi::vFloat _sfpu_exp_f32_accurate_(sfpi::vFloat val) {
+    sfpi::vFloat result = sfpi::vConst0;
+
+    // Clamp to prevent overflow/underflow
+    constexpr float OVERFLOW_THRESHOLD = 127.0f;
+    constexpr float UNDERFLOW_THRESHOLD = -127.0f;
+
+    // Step 1: Compute k = round(x / ln(2))
+    // z = x / ln(2) = x * (1/ln(2))
+    constexpr float INV_LN2 = 1.4426950408889634f;  // 1/ln(2)
+    sfpi::vFloat z = val * INV_LN2;
+
+    // Check for special cases
+    sfpi::vInt exp_bits = sfpi::exexp(z);
+    sfpi::vInt man_bits = sfpi::exman9(z);
+
+    v_if(exp_bits == 255 && man_bits != 0) {
+        // NaN: exponent = 255 (all 1s) and mantissa != 0
+        result = std::numeric_limits<float>::quiet_NaN();
+    }
+    v_elseif(z >= OVERFLOW_THRESHOLD) {
+        // Overflow
+        result = std::numeric_limits<float>::infinity();
+    }
+    v_elseif(z <= UNDERFLOW_THRESHOLD) {
+        // Underflow
+        result = sfpi::vConst0;
+    }
+    v_else {
+        // Use floor(z + 0.5) for rounding to nearest integer
+        sfpi::vInt k_int;
+        sfpi::vFloat k = _sfpu_round_int32_(z, k_int);
+
+        // Step 2: Cody-Waite range reduction
+        // Compute r = x - k*ln(2) in extended precision
+        // r = x - k*LN2_HI - k*LN2_LO
+        // This provides better accuracy than simple r = x - k*ln(2)
+        // Cody-Waite constants: ln(2) split into high and low parts
+        // LN2_HI has lower 12 bits zeroed for exact multiplication
+
+        // We want to do:
+        // 1) r_hi = val - k * LN2_HI
+        // 2) r = r_hi - k * LN2_LO
+        // Since SFPMAD can only do VD = VA * VB + VC we transform the expressions to:
+        // 1) r_hi = val + k * (-LN2_HI)
+        // 2) r = r_hi + k * (-LN2_LO)
+        // Where LN2_HI and LN2_LO are negated
+        constexpr float LN2_HI = -0.6931152343750000f;  // High bits of ln(2)
+        constexpr float LN2_LO = -3.19461832987e-05f;   // Low bits of ln(2)
+
+        // First subtract k * LN2_HI
+        // sfpi::vFloat temp1 = k * LN2_HI;
+        sfpi::vFloat r_hi = k * LN2_HI + val;
+
+        // Then subtract k * LN2_LO
+        // sfpi::vFloat temp2 = k * LN2_LO;
+        sfpi::vFloat r = k * LN2_LO + r_hi;
+
+        // Step 3: Polynomial approximation for exp(r)
+        // exp(r) = 1 + r + r²/2! + r³/3! + r⁴/4! + r⁵/5! + r⁶/6! + r⁷/7!
+        // Use 7th order polynomial for better accuracy
+        // Coefficients in ascending order: c0, c1, c2, c3, c4, c5, c6, c7
+        sfpi::vFloat p = PolynomialEvaluator::eval(
+            r,
+            sfpi::vConst1,  // c0 = 1
+            sfpi::vConst1,  // c1 = 1
+            0.5f,           // c2 = 1/2!
+            1.0f / 6.0f,    // c3 = 1/3!
+            1.0f / 24.0f,   // c4 = 1/4!
+            1.0f / 120.0f,  // c5 = 1/5!
+            1.0f / 720.0f,  // c6 = 1/6!
+            1.0f / 5040.0f  // c7 = 1/7!
+        );
+
+        // Step 4: Scale by 2^k using exponent manipulation
+        // ldexp(p, k_int) = p * 2^k
+        // We do this by adding k_int to the exponent of p
+        // Get the current exponent of p (without bias)
+        sfpi::vInt p_exp = sfpi::exexp_nodebias(p);
+        // Add k_int to get the new exponent
+        sfpi::vInt new_exp = p_exp + k_int;
+
+        // Set the new exponent
+        result = sfpi::setexp(p, new_exp);
+    }
+    v_endif;
+
+    return result;
+}
+
 template <bool is_fp32_dest_acc_en>
 sfpi_inline sfpi::vFloat _sfpu_exp_improved_(sfpi::vFloat val);
 
 // is_fp32_dest_acc_en == false
 template <>
 sfpi_inline sfpi::vFloat _sfpu_exp_improved_<false>(sfpi::vFloat val) {
-    return _sfpu_exp_21f_<false>(val);
+    return _sfpu_exp_21f_(val);
 }
 
 // is_fp32_dest_acc_en == true
 template <>
 sfpi_inline sfpi::vFloat _sfpu_exp_improved_<true>(sfpi::vFloat val) {
-    return _sfpu_exp_61f_(val);
+    return _sfpu_exp_f32_accurate_(val);
 }
 
 template <

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_exp.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_exp.h
@@ -13,10 +13,10 @@ namespace ckernel {
 template <
     bool APPROXIMATE,
     bool FAST_APPROX,
+    bool is_fp32_dest_acc_en,
     bool SCALE_EN = false,
     bool SKIP_POSITIVE_CHECK = false,
-    int ITERATIONS = 8,
-    bool is_fp32_dest_acc_en = false>
+    int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_exponential(
     uint dst_index,
     int vector_mode = (int)VectorMode::RC,
@@ -25,10 +25,10 @@ inline void llk_math_eltwise_unary_sfpu_exponential(
         ckernel::sfpu::calculate_exponential<
             APPROXIMATE,
             FAST_APPROX,
+            is_fp32_dest_acc_en,
             SCALE_EN,
             ITERATIONS,
-            SKIP_POSITIVE_CHECK,
-            is_fp32_dest_acc_en>,
+            SKIP_POSITIVE_CHECK>,
         dst_index,
         vector_mode,
         param0);

--- a/tt_metal/include/compute_kernel_api/eltwise_unary/exp.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_unary/exp.h
@@ -57,10 +57,10 @@ ALWI void exp_tile(uint32_t idst, int vector_mode = (int)VectorMode::RC, uint16_
     MATH((llk_math_eltwise_unary_sfpu_exponential<
           approx,
           fast_and_approx,
+          DST_ACCUM_MODE,
           scale_en,
           skip_positive_check,
-          iterations,
-          DST_ACCUM_MODE>(idst, vector_mode, scale)));
+          iterations>(idst, vector_mode, scale)));
 }
 
 }  // namespace ckernel


### PR DESCRIPTION
### Ticket
#33692

### Problem description

Maximum ULP error of ttnn.exp for float32 is >150. We would like to be as low as possible (ideally < 1 float32 ULP).


### What's changed

Add new approximation of exp: The error of this approximation is at most 1 ULP in float32, which is up to ~30 to 150 times better than current exp on main (c.f. graph)

#### Accuracy improvement. 

New float32 exponential is always within 1 ULP of torch reference.  

<img width="580" height="378" alt="exp-accurate-float32" src="https://github.com/user-attachments/assets/562f1199-5df0-432d-844d-33d926542c49" />

Zoomed-in version:

<img width="580" height="378" alt="exp-accurate-zoom-float32" src="https://github.com/user-attachments/assets/d7f1d03f-2ff6-4992-afa4-7a36ca622c3f" />


#### Performance

For float32 data: 

Wormhole:

| Name | Max ULP error | Cycles/Datum | Cycles/Tile |
| - | - | - | - |
| exp+approx | 720'000 | 1.02 | 1045 |
| exp+fast+approx | 380'000 | 0.30 | 311 |
| exp (main) | 150 | 2.56 | 2619 |
| exp (new) |  1 | 2.56 | 2533 |

Blackhole:

| Name | Max ULP error | Cycles/Datum | Cycles/Tile |
| - | - | - | - |
| exp+approx | 720'000 | 1.01 | 1037 |
| exp+fast+approx | 380'000 | 0.26 | 266 |
| exp (main) | 150 | 2.52 | 2578 |
| exp (new) |  1 | 2.52 | 2548 |


### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes [OK](https://github.com/tenstorrent/tt-metal/actions/runs/20097326939)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable) [OK](https://github.com/tenstorrent/tt-metal/actions/runs/20097330326/job/57668685447)
- [x] L2 Nightly [OK, unrelated failures/failures on main](https://github.com/tenstorrent/tt-metal/actions/runs/20031351454)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/20033062452
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/20033055431
- [x] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models). [OK, unrelated failures/failures Las on main](https://github.com/tenstorrent/tt-metal/actions/runs/20033057489)
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes