### PR TITLE
Fix torch reference tensor in sharded layernorm tests

### DIFF
--- a/tests/ttnn/unit_tests/operations/fused/sharded_test_utils.py
+++ b/tests/ttnn/unit_tests/operations/fused/sharded_test_utils.py
@@ -199,10 +199,11 @@ def torch_layer_norm(torch_input_tensor, residual=None, weight=None, bias=None):
     Returns:
         The output tensor as a torch tensor.
     """
-    if residual is not None:
-        torch_input_tensor += residual
     return torch.nn.functional.layer_norm(
-        torch_input_tensor, normalized_shape=[torch_input_tensor.shape[1]], weight=weight, bias=bias
+        torch_input_tensor if residual is None else torch_input_tensor + residual,
+        normalized_shape=[torch_input_tensor.shape[1]],
+        weight=weight,
+        bias=bias,
     )
 
 

--- a/tests/ttnn/unit_tests/operations/fused/test_layer_norm_sharded.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_layer_norm_sharded.py
@@ -71,9 +71,6 @@ def test_layer_norm_sharded_two_stage(
 @pytest.mark.parametrize("tensor_type", ["ascending_values_repeated_rows", "random_normal"])
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
 def test_layer_norm_sharded_with_residual(device, use_welford, two_stage, tensor_type, dtype):
-    if tensor_type == "random" or tensor_type == "random_normal":
-        pytest.skip("Low PCC, see #30455")
-
     h, w, num_cores_h, num_cores_w, block_ht, block_wt, subblock_wt = simple_size_params(two_stage)
 
     residual = generate_input_tensor(h, w, "random_normal", dtype)
@@ -158,9 +155,6 @@ def test_layer_norm_sharded_with_weight_and_bias_row_major(device, use_welford, 
 @pytest.mark.parametrize("tensor_type", ["ascending_values_repeated_rows", "random"])
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
 def test_layer_norm_sharded_with_weight_and_bias_and_residual(device, use_welford, two_stage, tensor_type, dtype):
-    if tensor_type == "random" or tensor_type == "random_normal":
-        pytest.skip("Low PCC, see #30455")
-
     h, w, num_cores_h, num_cores_w, block_ht, block_wt, subblock_wt = simple_size_params(two_stage)
 
     residual = generate_input_tensor(h, w, "random_normal", dtype)


### PR DESCRIPTION
### Ticket
#30455

### Problem description
Test was incorrectly modifying torch input tensor when a residual was used, leading to invalid reference tensors.

### What's changed
Correct torch tensor is used for reference when residual is used

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/19862361099
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes