### PR TITLE
[skip ci] Set fail fast to false for build test publish

### DIFF
--- a/.github/workflows/package-and-release.yaml
+++ b/.github/workflows/package-and-release.yaml
@@ -118,6 +118,7 @@ jobs:
     uses: ./.github/workflows/release-build-test-publish.yaml
     secrets: inherit
     strategy:
+      fail-fast: false
       matrix:
         version: [22.04, 24.04]
     with:


### PR DESCRIPTION
### Problem description
When one matrix job finishes before other one, it fails everything.

### What's changed
Set `fail-fast` to false for `build-test-publish` matrix