### PR TITLE
Migrate op to new infra: prod_all

### DIFF
--- a/ttnn/cpp/ttnn/operations/reduction/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/reduction/CMakeLists.txt
@@ -59,6 +59,7 @@ target_sources(
         generic/device/reduce_op.cpp
         generic/device/common.cpp
         generic/generic_reductions.cpp
+        prod/device/prod_all_device_operation.cpp
         prod/device/prod_nc_op.cpp
         prod/device/prod_nc_program_factory.cpp
         prod/device/prod_op_all.cpp

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_all_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_all_device_operation.cpp
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "prod_all_device_operation.hpp"
+
+#include <tt-metalium/constants.hpp>
+
+namespace ttnn::operations::reduction::prod_all {
+
+ProdAllDeviceOperation::program_factory_t ProdAllDeviceOperation::select_program_factory(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    return program::ProdAllProgramFactory{};
+}
+
+void ProdAllDeviceOperation::validate_on_program_cache_hit(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    validate_on_program_cache_miss(args, tensor_args);
+}
+
+void ProdAllDeviceOperation::validate_on_program_cache_miss(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    const auto& input = tensor_args.input;
+
+    TT_FATAL(
+        input.storage_type() == tt::tt_metal::StorageType::DEVICE,
+        "Operands need to be on device! Got storage type: {}",
+        input.storage_type());
+    TT_FATAL(input.buffer() != nullptr, "Operands need to be allocated in buffers on device!");
+    TT_FATAL(
+        input.layout() == tt::tt_metal::Layout::TILE, "Input Layout must be tilized, got layout: {}", input.layout());
+    TT_FATAL(
+        input.memory_config().memory_layout() == tt::tt_metal::TensorMemoryLayout::INTERLEAVED,
+        "Memory layout must be INTERLEAVED, got: {}",
+        input.memory_config().memory_layout());
+    TT_FATAL(
+        input.dtype() == tt::tt_metal::DataType::BFLOAT16,
+        "Error - unsupported data type for prod, expected BFLOAT16 but got {}.",
+        input.dtype());
+}
+
+ProdAllDeviceOperation::spec_return_value_t ProdAllDeviceOperation::compute_output_specs(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    const auto& input = tensor_args.input;
+    return TensorSpec(
+        ttnn::Shape({1, 1, 1, tt::constants::TILE_HW}),
+        tt::tt_metal::TensorLayout(
+            input.dtype(), tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE), args.output_mem_config));
+}
+
+ProdAllDeviceOperation::tensor_return_value_t ProdAllDeviceOperation::create_output_tensors(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    return create_device_tensor(compute_output_specs(operation_attributes, tensor_args), tensor_args.input.device());
+}
+
+std::tuple<ProdAllDeviceOperation::operation_attributes_t, ProdAllDeviceOperation::tensor_args_t>
+ProdAllDeviceOperation::invoke(const Tensor& input, const tt::tt_metal::MemoryConfig& output_mem_config) {
+    return {operation_attributes_t{.output_mem_config = output_mem_config}, tensor_args_t{.input = input}};
+}
+
+}  // namespace ttnn::operations::reduction::prod_all

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_all_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_all_device_operation.hpp
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "prod_all_device_operation_types.hpp"
+#include "prod_all_program_factory.hpp"
+
+#include "ttnn/decorators.hpp"
+#include "ttnn/device_operation.hpp"
+
+namespace ttnn::operations::reduction::prod_all {
+
+struct ProdAllDeviceOperation {
+    using operation_attributes_t = prod_all::operation_attributes_t;
+    using tensor_args_t = prod_all::tensor_args_t;
+    using spec_return_value_t = prod_all::spec_return_value_t;
+    using tensor_return_value_t = prod_all::tensor_return_value_t;
+    using program_factory_t = std::variant<program::ProdAllProgramFactory>;
+
+    static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
+
+    static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
+    static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
+
+    static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
+
+    static tensor_return_value_t create_output_tensors(
+        const operation_attributes_t& operation_attributes, const tensor_args_t&);
+
+    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
+        const Tensor& input, const tt::tt_metal::MemoryConfig& output_mem_config);
+};
+
+}  // namespace ttnn::operations::reduction::prod_all
+
+namespace ttnn::prim {
+constexpr auto prod_all =
+    ttnn::register_operation<"ttnn::prim::prod_all", ttnn::operations::reduction::prod_all::ProdAllDeviceOperation>();
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_all_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_all_device_operation_types.hpp
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/tensor/tensor.hpp"
+
+namespace ttnn::operations::reduction::prod_all {
+
+struct operation_attributes_t {
+    tt::tt_metal::MemoryConfig output_mem_config;
+};
+
+struct tensor_args_t {
+    Tensor input;
+};
+
+using tensor_return_value_t = Tensor;
+
+using spec_return_value_t = TensorSpec;
+
+}  // namespace ttnn::operations::reduction::prod_all

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_all_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_all_program_factory.cpp
@@ -1,67 +1,71 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
-//
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC.
 // SPDX-License-Identifier: Apache-2.0
 
-#include "ttnn/operations/reduction/prod/device/prod_op_all.hpp"
+#include "prod_all_program_factory.hpp"
+
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 
-namespace tt {
-using namespace constants;
-namespace operations {
-namespace primary {
+namespace ttnn::operations::reduction::prod_all::program {
 
-tt::tt_metal::operation::ProgramWithCallbacks prod_single_core(
-    const tt::tt_metal::Tensor& a, const tt::tt_metal::Tensor& output) {
-    tt::tt_metal::Program program{};
+ProdAllProgramFactory::cached_program_t ProdAllProgramFactory::create(
+    const operation_attributes_t& operation_attributes,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& tensor_return_value) {
+    using namespace tt;
+    using namespace tt::tt_metal;
+    using namespace tt::constants;
+
+    const auto& input = tensor_args.input;
+    auto& output = tensor_return_value;
+
+    Program program{};
 
     CoreRange core({0, 0}, {0, 0});
 
-    tt::DataFormat cb_data_format = tt_metal::datatype_to_dataformat_converter(a.dtype());
-    uint32_t single_tile_size = tt::tile_size(cb_data_format);
+    DataFormat cb_data_format = datatype_to_dataformat_converter(input.dtype());
+    uint32_t single_tile_size = tile_size(cb_data_format);
 
-    uint32_t num_tiles = a.physical_volume() / TILE_HW;
-
-    // This should allocate a DRAM buffer on the device
+    uint32_t num_tiles = input.physical_volume() / TILE_HW;
 
     uint32_t num_input_tiles = 2;
-    tt_metal::CircularBufferConfig cb_src0_config =
-        tt_metal::CircularBufferConfig(num_input_tiles * single_tile_size, {{tt::CBIndex::c_0, cb_data_format}})
-            .set_page_size(tt::CBIndex::c_0, single_tile_size);
-    tt_metal::CreateCircularBuffer(program, core, cb_src0_config);
+    CircularBufferConfig cb_src0_config =
+        CircularBufferConfig(num_input_tiles * single_tile_size, {{CBIndex::c_0, cb_data_format}})
+            .set_page_size(CBIndex::c_0, single_tile_size);
+    CreateCircularBuffer(program, core, cb_src0_config);
 
-    tt_metal::CircularBufferConfig cb_inter_config =
-        tt_metal::CircularBufferConfig(num_input_tiles * single_tile_size, {{tt::CBIndex::c_2, cb_data_format}})
-            .set_page_size(tt::CBIndex::c_2, single_tile_size);
-    tt_metal::CreateCircularBuffer(program, core, cb_inter_config);
+    CircularBufferConfig cb_inter_config =
+        CircularBufferConfig(num_input_tiles * single_tile_size, {{CBIndex::c_2, cb_data_format}})
+            .set_page_size(CBIndex::c_2, single_tile_size);
+    CreateCircularBuffer(program, core, cb_inter_config);
 
-    uint32_t output_cb_index = tt::CBIndex::c_3;
+    uint32_t output_cb_index = CBIndex::c_3;
     uint32_t num_output_tiles = 2;
-    tt_metal::CircularBufferConfig cb_output_config =
-        tt_metal::CircularBufferConfig(num_output_tiles * single_tile_size, {{output_cb_index, cb_data_format}})
+    CircularBufferConfig cb_output_config =
+        CircularBufferConfig(num_output_tiles * single_tile_size, {{output_cb_index, cb_data_format}})
             .set_page_size(output_cb_index, single_tile_size);
-    tt_metal::CreateCircularBuffer(program, core, cb_output_config);
+    CreateCircularBuffer(program, core, cb_output_config);
 
-    auto* src_buffer = a.buffer();
+    auto* src_buffer = input.buffer();
     auto* dst_buffer = output.buffer();
 
     std::vector<uint32_t> reader_compile_time_args;
-    tt_metal::TensorAccessorArgs(*src_buffer).append_to(reader_compile_time_args);
-    std::vector<uint32_t> writer_compile_time_args = {(std::uint32_t)output_cb_index};
-    tt_metal::TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
+    TensorAccessorArgs(*src_buffer).append_to(reader_compile_time_args);
+    std::vector<uint32_t> writer_compile_time_args = {static_cast<uint32_t>(output_cb_index)};
+    TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
 
-    tt_metal::KernelHandle unary_reader_kernel_id = tt_metal::CreateKernel(
+    KernelHandle unary_reader_kernel_id = CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_interleaved_start_id.cpp",
         core,
-        tt_metal::ReaderDataMovementConfig{reader_compile_time_args});
+        ReaderDataMovementConfig{reader_compile_time_args});
 
-    tt_metal::KernelHandle unary_writer_kernel_id = tt_metal::CreateKernel(
+    KernelHandle unary_writer_kernel_id = CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp",
         core,
-        tt_metal::WriterDataMovementConfig{writer_compile_time_args});
+        WriterDataMovementConfig{writer_compile_time_args});
 
     std::vector<uint32_t> compute_kernel_args = {
         num_tiles,  // per_core_block_cnt
@@ -70,11 +74,11 @@ tt::tt_metal::operation::ProgramWithCallbacks prod_single_core(
 
     bool fp32_dest_acc_en = false;
     bool math_approx_mode = true;
-    tt_metal::CreateKernel(
+    CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/reduction/prod/device/kernels/compute/prod_all.cpp",
         core,
-        tt_metal::ComputeConfig{
+        ComputeConfig{
             .math_fidelity = MathFidelity::HiFi4,
             .fp32_dest_acc_en = fp32_dest_acc_en,
             .math_approx_mode = math_approx_mode,
@@ -84,31 +88,33 @@ tt::tt_metal::operation::ProgramWithCallbacks prod_single_core(
 
     SetRuntimeArgs(program, unary_writer_kernel_id, core, {dst_buffer->address(), /*num_tiles=*/1, 0});
 
-    auto override_runtime_args_callback = [unary_reader_kernel_id, unary_writer_kernel_id](
-                                              const void* operation,
-                                              const tt::tt_metal::Program& program,
-                                              const std::vector<tt::tt_metal::Tensor>& input_tensors,
-                                              const std::vector<std::optional<const tt::tt_metal::Tensor>>&,
-                                              const std::vector<tt::tt_metal::Tensor>& output_tensors) {
-        auto* src_buffer = input_tensors.at(0).buffer();
-
-        auto* dst_buffer = output_tensors.at(0).buffer();
-
-        CoreCoord core = {0, 0};
-
-        {
-            auto& runtime_args = GetRuntimeArgs(program, unary_reader_kernel_id, core);
-            runtime_args[0] = src_buffer->address();
-        }
-
-        {
-            auto& runtime_args = GetRuntimeArgs(program, unary_writer_kernel_id, core);
-            runtime_args[0] = dst_buffer->address();
-        }
-    };
-    return {std::move(program), override_runtime_args_callback};
+    return {std::move(program), {unary_reader_kernel_id, unary_writer_kernel_id}};
 }
 
-}  // namespace primary
-}  // namespace operations
-}  // namespace tt
+void ProdAllProgramFactory::override_runtime_arguments(
+    cached_program_t& cached_program,
+    const operation_attributes_t& operation_attributes,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& tensor_return_value) {
+    using namespace tt::tt_metal;
+
+    auto& program = cached_program.program;
+    auto& shared_variables = cached_program.shared_variables;
+
+    auto* src_buffer = tensor_args.input.buffer();
+    auto* dst_buffer = tensor_return_value.buffer();
+
+    CoreCoord core = {0, 0};
+
+    {
+        auto& runtime_args = GetRuntimeArgs(program, shared_variables.unary_reader_kernel_id, core);
+        runtime_args[0] = src_buffer->address();
+    }
+
+    {
+        auto& runtime_args = GetRuntimeArgs(program, shared_variables.unary_writer_kernel_id, core);
+        runtime_args[0] = dst_buffer->address();
+    }
+}
+
+}  // namespace ttnn::operations::reduction::prod_all::program

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_all_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_all_program_factory.hpp
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "prod_all_device_operation_types.hpp"
+
+#include "ttnn/device_operation.hpp"
+
+namespace ttnn::operations::reduction::prod_all::program {
+
+struct ProdAllProgramFactory {
+    struct shared_variables_t {
+        tt::tt_metal::KernelHandle unary_reader_kernel_id;
+        tt::tt_metal::KernelHandle unary_writer_kernel_id;
+    };
+
+    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
+
+    static cached_program_t create(
+        const operation_attributes_t& operation_attributes,
+        const tensor_args_t& tensor_args,
+        tensor_return_value_t& tensor_return_value);
+
+    static void override_runtime_arguments(
+        cached_program_t& cached_program,
+        const operation_attributes_t& operation_attributes,
+        const tensor_args_t& tensor_args,
+        tensor_return_value_t& tensor_return_value);
+};
+
+}  // namespace ttnn::operations::reduction::prod_all::program

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_all_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_all_program_factory.hpp
@@ -11,8 +11,8 @@ namespace ttnn::operations::reduction::prod_all::program {
 
 struct ProdAllProgramFactory {
     struct shared_variables_t {
-        tt::tt_metal::KernelHandle unary_reader_kernel_id;
-        tt::tt_metal::KernelHandle unary_writer_kernel_id;
+        tt::tt_metal::KernelHandle unary_reader_kernel_id{};
+        tt::tt_metal::KernelHandle unary_writer_kernel_id{};
     };
 
     using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_op_all.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_op_all.cpp
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
-//
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC.
 // SPDX-License-Identifier: Apache-2.0
 
 #include "prod_op_all.hpp"

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_op_all.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_op_all.cpp
@@ -2,65 +2,17 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <algorithm>
-#include <optional>
 #include "prod_op_all.hpp"
-#include "ttnn/operations/eltwise/unary/unary.hpp"
-#include <tt-metalium/constants.hpp>
+#include "prod_all_device_operation.hpp"
+
 #include <ttnn/operations/functions.hpp>
-#include "tools/profiler/op_profiler.hpp"
 
-#include <umd/device/cluster_descriptor.hpp>  // ClusterDescriptor
-
-namespace tt {
-using namespace constants;
-namespace operations {
-namespace primary {
-
-void Prod_op::validate(const std::vector<tt::tt_metal::Tensor>& input_tensors) const {
-    const auto& input_tensor_a = input_tensors.at(0);
-    TT_FATAL(
-        input_tensor_a.storage_type() == tt::tt_metal::StorageType::DEVICE,
-        "Operands need to be on device! Got storage type: {}",
-        input_tensor_a.storage_type());
-    TT_FATAL(input_tensor_a.buffer() != nullptr, "Operands need to be allocated in buffers on device!");
-    TT_FATAL(
-        (input_tensor_a.layout() == tt::tt_metal::Layout::TILE),
-        "Input Layout must be tilized, got layout: {}",
-        input_tensor_a.layout());
-    TT_FATAL(
-        input_tensor_a.memory_config().memory_layout() == tt::tt_metal::TensorMemoryLayout::INTERLEAVED,
-        "Memory layout must be INTERLEAVED, got: {}",
-        input_tensor_a.memory_config().memory_layout());
-    TT_FATAL(
-        input_tensor_a.dtype() == tt::tt_metal::DataType::BFLOAT16,
-        "Error - unsupported data type for prod, expected BFLOAT16 but got {}.",
-        input_tensor_a.dtype());
-}
-
-std::vector<tt::tt_metal::TensorSpec> Prod_op::compute_output_specs(
-    const std::vector<tt::tt_metal::Tensor>& input_tensors) const {
-    const auto& input_tensor = input_tensors.at(0);
-    return {tt::tt_metal::TensorSpec(
-        ttnn::Shape({1, 1, 1, TILE_HW}),
-        tt::tt_metal::TensorLayout(
-            input_tensor.dtype(), tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE), output_mem_config))};
-}
-
-tt::tt_metal::operation::ProgramWithCallbacks Prod_op::create_program(
-    const std::vector<tt::tt_metal::Tensor>& input_tensors, std::vector<tt::tt_metal::Tensor>& output_tensors) const {
-    const auto& input_tensor_a = input_tensors.at(0);
-    auto& output_tensor = output_tensors.at(0);
-    return prod_single_core(input_tensor_a, output_tensor);
-}
+namespace tt::operations::primary {
 
 tt::tt_metal::Tensor prod_all(const tt::tt_metal::Tensor& input, const tt::tt_metal::MemoryConfig& output_mem_config) {
-    tt::tt_metal::Tensor result =
-        tt::tt_metal::operation::run(Prod_op{.output_mem_config = output_mem_config}, {input}).at(0);
+    tt::tt_metal::Tensor result = ttnn::prim::prod_all(input, output_mem_config);
     return ttnn::prod_result_computation_WH_B0<bfloat16>(
         result, result.dtype(), result.layout(), result.device(), output_mem_config);
 }
 
-}  // namespace primary
-}  // namespace operations
-}  // namespace tt
+}  // namespace tt::operations::primary

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_op_all.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_op_all.hpp
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
-//
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_op_all.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_op_all.hpp
@@ -1,41 +1,16 @@
-/*
- * SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
- *
- * SPDX-License-Identifier: Apache-2.0
- */
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 #pragma once
+
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/run_operation.hpp"
 
-namespace tt {
-
-namespace operations {
-
-namespace primary {
-
-/*
- * prod product
- */
-
-struct Prod_op {
-    const tt::tt_metal::MemoryConfig output_mem_config;
-    const tt::tt_metal::DataType output_dtype;  // TODO: Uplift output_dtype as an option for general dot/bmm
-    void validate(const std::vector<tt::tt_metal::Tensor>& input_tensors) const;
-    std::vector<tt::tt_metal::TensorSpec> compute_output_specs(
-        const std::vector<tt::tt_metal::Tensor>& input_tensors) const;
-    tt::tt_metal::operation::ProgramWithCallbacks create_program(
-        const std::vector<tt::tt_metal::Tensor>& input_tensors,
-        std::vector<tt::tt_metal::Tensor>& output_tensors) const;
-};
-
-tt::tt_metal::operation::ProgramWithCallbacks prod_single_core(
-    const tt::tt_metal::Tensor& input_tensor_a, const tt::tt_metal::Tensor& output_tensor);
+namespace tt::operations::primary {
 
 tt::tt_metal::Tensor prod_all(
     const tt::tt_metal::Tensor& input,
     const tt::tt_metal::MemoryConfig& mem_config = tt::tt_metal::operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
-}  // namespace primary
 
-}  // namespace operations
-}  // namespace tt
+}  // namespace tt::operations::primary

--- a/ttnn/cpp/ttnn/operations/reduction/prod/prod.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/prod.cpp
@@ -1,18 +1,18 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
-//
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC.
 // SPDX-License-Identifier: Apache-2.0
 
 #include "prod.hpp"
 #include "device/prod_nc_op.hpp"
 #include "device/prod_op_all.hpp"
-#include "ttnn/operations/creation.hpp"
-#include "ttnn/operations/data_movement/slice/slice.hpp"
-#include "ttnn/operations/data_movement/permute/permute.hpp"
-#include "ttnn/operations/functions.hpp"
-#include "ttnn/operations/data_movement/squeeze/squeeze.hpp"
-#include "ttnn/operations/data_movement/common/common.hpp"
+
 #include "ttnn/operations/core/core.hpp"
+#include "ttnn/operations/creation.hpp"
+#include "ttnn/operations/data_movement/common/common.hpp"
+#include "ttnn/operations/data_movement/permute/permute.hpp"
+#include "ttnn/operations/data_movement/slice/slice.hpp"
+#include "ttnn/operations/data_movement/squeeze/squeeze.hpp"
 #include "ttnn/operations/data_movement/tilize_with_val_padding/tilize_with_val_padding.hpp"
+#include "ttnn/operations/functions.hpp"
 
 namespace ttnn::operations::reduction {
 

--- a/ttnn/cpp/ttnn/operations/reduction/prod/prod.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/prod.cpp
@@ -9,7 +9,6 @@
 #include "ttnn/operations/data_movement/slice/slice.hpp"
 #include "ttnn/operations/data_movement/permute/permute.hpp"
 #include "ttnn/operations/functions.hpp"
-#include "ttnn/types.hpp"
 #include "ttnn/operations/data_movement/squeeze/squeeze.hpp"
 #include "ttnn/operations/data_movement/common/common.hpp"
 #include "ttnn/operations/core/core.hpp"
@@ -17,7 +16,7 @@
 
 namespace ttnn::operations::reduction {
 
-inline Tensor prod_all(const Tensor& input_a, const MemoryConfig& output_mem_config) {
+inline Tensor compute_prod_all(const Tensor& input_a, const MemoryConfig& output_mem_config) {
     auto formatted_input_tensor = input_a;
     if (formatted_input_tensor.layout() != Layout::TILE) {
         auto a_pad_shape = ttnn::operations::data_movement::pad_to_tile_shape(input_a.padded_shape());
@@ -82,7 +81,7 @@ Tensor ProdOperation::invoke(
 
     // If no dim is provided, compute the prod across all dimensions
     if (!dim.has_value()) {
-        Tensor result = prod_all(input_a, output_mem_config);
+        Tensor result = compute_prod_all(input_a, output_mem_config);
         if (keepdim) {
             // Reshape to have all dimensions (as many as the input rank) set to 1.
             ttnn::SmallVector<uint32_t> output_shape(old_rank, 1);
@@ -199,7 +198,7 @@ Tensor ProdOperation::invoke(
     auto mem_cfg = memory_config.value_or(input.memory_config());
 
     if (dims.empty()) {
-        return prod_all(input, mem_cfg);
+        return compute_prod_all(input, mem_cfg);
     }
     return tt::operations::primary::prod_nc(input, output, dims, mem_cfg);
 }


### PR DESCRIPTION
- Create prod_all_device_operation_types.hpp with operation_attributes_t and tensor_args_t
- Create prod_all_program_factory.hpp with ProdAllProgramFactory and shared_variables_t
- Create prod_all_device_operation.hpp with ProdAllDeviceOperation and prim registration
- Create prod_all_device_operation.cpp with device operation implementation
- Refactor prod_all_program_factory.cpp to TMP pattern (cached_program_t, override_runtime_arguments)
- Update prod_op_all.cpp to use ttnn::prim::prod_all instead of operation::run
- Remove legacy Prod_op struct from prod_op_all.hpp
- Rename local prod_all function to compute_prod_all in prod.cpp to avoid namespace collision
- Add prod_all_device_operation.cpp to CMakeLists.txt

### Ticket
https://github.com/tenstorrent/tt-metal/issues/32700

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/19906895063)
- [X] Code analysis: https://github.com/tenstorrent/tt-metal/actions/runs/19907349385