### PR TITLE
Add Missing Functionality in Cluster Validation

### DIFF
--- a/tools/scaleout/factory_system_descriptor/utils.cpp
+++ b/tools/scaleout/factory_system_descriptor/utils.cpp
@@ -487,6 +487,10 @@ std::set<PhysicalChannelConnection> validate_fsd_against_gsd_impl(
                     std::cout << "Note: " << missing_in_gsd.size()
                               << " missing connections detected but ignored due to relaxed mode." << std::endl;
                 }
+                if (!extra_in_gsd.empty()) {
+                    std::cout << "Note: " << extra_in_gsd.size()
+                              << " extra connections detected but ignored due to relaxed mode." << std::endl;
+                }
             }
             // Return empty set since we're treating this as success in relaxed mode
             return {};

--- a/tools/scaleout/factory_system_descriptor/utils.hpp
+++ b/tools/scaleout/factory_system_descriptor/utils.hpp
@@ -6,6 +6,7 @@
 
 #include <string>
 #include <set>
+#include <optional>
 #include <cabling_generator/cabling_generator.hpp>
 #include <vector>
 
@@ -24,12 +25,15 @@ namespace tt::scaleout_tools {
 //                        If false, only checks that GSD connections exist in FSD
 //   - assert_on_connection_mismatch: If true, throws an error if there are connection mismatches
 //                                    If false, missing connections are logged without an error being thrown
+//   - min_connections: If specified, enables relaxed validation mode where missing connections
+//                      are not reported as errors if the total discovered connections >= this value
 std::set<PhysicalChannelConnection> validate_fsd_against_gsd(
     const std::string& fsd_filename,
     const std::string& gsd_filename,
     bool strict_validation = true,
     bool assert_on_connection_mismatch = true,
-    bool log_output = true);
+    bool log_output = true,
+    std::optional<uint32_t> min_connections = std::nullopt);
 
 // In-memory overload for validating FSD against GSD without disk I/O
 // Validates that the Factory System Descriptor (FSD) protobuf matches the Global System Descriptor (GSD) YAML node

--- a/tools/scaleout/factory_system_descriptor/utils.hpp
+++ b/tools/scaleout/factory_system_descriptor/utils.hpp
@@ -26,7 +26,8 @@ namespace tt::scaleout_tools {
 //   - assert_on_connection_mismatch: If true, throws an error if there are connection mismatches
 //                                    If false, missing connections are logged without an error being thrown
 //   - min_connections: If specified, enables relaxed validation mode where missing connections
-//                      are not reported as errors if the total discovered connections >= this value
+//                      are not reported as errors if each expected ASIC pair has at least this many
+//                      discovered connections (checked at per-ASIC-pair granularity)
 std::set<PhysicalChannelConnection> validate_fsd_against_gsd(
     const std::string& fsd_filename,
     const std::string& gsd_filename,

--- a/tools/scaleout/factory_system_descriptor/utils.hpp
+++ b/tools/scaleout/factory_system_descriptor/utils.hpp
@@ -9,12 +9,25 @@
 #include <optional>
 #include <cabling_generator/cabling_generator.hpp>
 #include <vector>
+#include <tuple>
 
 namespace YAML {
     class Node;
 }
 
 namespace tt::scaleout_tools {
+
+// An AsicId uniquely identifies an ASIC by (hostname, tray_id, asic_location)
+using AsicId = std::tuple<std::string, uint32_t, uint32_t>;
+
+// Check if all expected ASIC pairs have at least min_connections discovered connections
+// Returns true if all pairs satisfy the minimum, false otherwise
+// insufficient_connections is populated with pairs that don't meet the minimum
+bool check_min_connection_count_satisfied(
+    const std::set<PhysicalChannelConnection>& discovered_connections,
+    const std::set<std::pair<PhysicalChannelEndpoint, PhysicalChannelEndpoint>>& generated_connections,
+    uint32_t min_connections,
+    std::vector<std::pair<std::pair<AsicId, AsicId>, uint32_t>>& insufficient_connections);
 
 // Common utility function for validating FSD against discovered GSD
 // Validates that the Factory System Descriptor (FSD) matches the Global System Descriptor (GSD)
@@ -47,13 +60,17 @@ std::set<PhysicalChannelConnection> validate_fsd_against_gsd(
 //   - assert_on_connection_mismatch: If true, throws an error if there are connection mismatches
 //                                    If false, missing connections are logged without an error being thrown
 //   - log_output: If true, logs validation results
+//   - min_connections: If specified, enables relaxed validation mode where missing connections
+//                      are not reported as errors if each expected ASIC pair has at least this many
+//                      discovered connections (checked at per-ASIC-pair granularity)
 // Returns: Set of physical channel connections that are missing or mismatched
 std::set<PhysicalChannelConnection> validate_fsd_against_gsd(
     const fsd::proto::FactorySystemDescriptor& fsd_proto,
     const YAML::Node& gsd_yaml_node,
     bool strict_validation = true,
     bool assert_on_connection_mismatch = true,
-    bool log_output = true);
+    bool log_output = true,
+    std::optional<uint32_t> min_connections = std::nullopt);
 
 // Validate cabling descriptor against discovered system topology
 std::set<PhysicalChannelConnection> validate_cabling_descriptor_against_gsd(

--- a/tools/scaleout/validation/run_cluster_validation.cpp
+++ b/tools/scaleout/validation/run_cluster_validation.cpp
@@ -24,35 +24,7 @@
 
 namespace tt::scaleout_tools {
 
-<<<<<<< HEAD
 using tt::tt_metal::AsicTopology;
-=======
-// Validation (default) mode arguments and their descriptions
-const std::unordered_map<std::string_view, std::string_view> VALIDATION_ARGS = {
-    {"--cabling-descriptor-path", "Path to cabling descriptor"},
-    {"--deployment-descriptor-path", "Path to deployment descriptor"},
-    {"--factory-descriptor-path", "Path to factory descriptor"},
-    {"--global-descriptor-path", "Path to global descriptor"},
-    {"--output-path", "Path to output directory"},
-    {"--hard-fail", "Fail on warning"},
-    {"--log-ethernet-metrics", "Log live ethernet statistics"},
-    {"--print-connectivity", "Print Ethernet Connectivity between ASICs"},
-    {"--send-traffic", "Send traffic across detected links"},
-    {"--num-iterations", "Number of iterations to send traffic"},
-    {"--data-size", "Data size (bytes) sent across each link per iteration"},
-    {"--packet-size-bytes", "Packet size (bytes) sent across each link"},
-    {"--sweep-traffic-configs", "Sweep pre-generated traffic configurations across detected links (stress testing)"},
-    {"--min-connections", "Minimum connections per ASIC pair required for relaxed validation mode"}};
-
-// link_reset subcommand arguments and their descriptions
-const std::unordered_map<std::string_view, std::string_view> LINK_RETRAIN_ARGS = {
-    {"--host", "Host name of the source ASIC"},
-    {"--tray-id", "Tray ID of the source ASIC"},
-    {"--asic-location", "ASIC location of the source ASIC"},
-    {"--channel", "Channel ID to reset"},
-    {"--help", "Print usage information"}};
-
->>>>>>> 1daffd581d (review)
 using tt::tt_metal::PhysicalSystemDescriptor;
 
 enum class CommandMode {
@@ -247,7 +219,6 @@ void parse_validation_args(int argc, char* argv[], InputArgs& input_args) {
 
         log_output_rank0("Generating System Validation Logs in " + input_args.output_path.string());
 
-<<<<<<< HEAD
         // Parse boolean flags
         input_args.fail_on_warning = result["hard-fail"].as<bool>();
         input_args.log_ethernet_metrics = result["log-ethernet-metrics"].as<bool>();
@@ -266,7 +237,6 @@ void parse_validation_args(int argc, char* argv[], InputArgs& input_args) {
                 "Relaxed validation mode enabled. Minimum connections per ASIC pair: " +
                 std::to_string(input_args.min_connections.value()));
         }
-<<<<<<< HEAD
 
     } catch (const cxxopts::exceptions::exception& e) {
         std::cerr << "Error parsing arguments: " << e.what() << std::endl;

--- a/tools/scaleout/validation/run_cluster_validation.cpp
+++ b/tools/scaleout/validation/run_cluster_validation.cpp
@@ -24,7 +24,35 @@
 
 namespace tt::scaleout_tools {
 
+<<<<<<< HEAD
 using tt::tt_metal::AsicTopology;
+=======
+// Validation (default) mode arguments and their descriptions
+const std::unordered_map<std::string_view, std::string_view> VALIDATION_ARGS = {
+    {"--cabling-descriptor-path", "Path to cabling descriptor"},
+    {"--deployment-descriptor-path", "Path to deployment descriptor"},
+    {"--factory-descriptor-path", "Path to factory descriptor"},
+    {"--global-descriptor-path", "Path to global descriptor"},
+    {"--output-path", "Path to output directory"},
+    {"--hard-fail", "Fail on warning"},
+    {"--log-ethernet-metrics", "Log live ethernet statistics"},
+    {"--print-connectivity", "Print Ethernet Connectivity between ASICs"},
+    {"--send-traffic", "Send traffic across detected links"},
+    {"--num-iterations", "Number of iterations to send traffic"},
+    {"--data-size", "Data size (bytes) sent across each link per iteration"},
+    {"--packet-size-bytes", "Packet size (bytes) sent across each link"},
+    {"--sweep-traffic-configs", "Sweep pre-generated traffic configurations across detected links (stress testing)"},
+    {"--min-connections", "Minimum connections per ASIC pair required for relaxed validation mode"}};
+
+// link_reset subcommand arguments and their descriptions
+const std::unordered_map<std::string_view, std::string_view> LINK_RETRAIN_ARGS = {
+    {"--host", "Host name of the source ASIC"},
+    {"--tray-id", "Tray ID of the source ASIC"},
+    {"--asic-location", "ASIC location of the source ASIC"},
+    {"--channel", "Channel ID to reset"},
+    {"--help", "Print usage information"}};
+
+>>>>>>> 1daffd581d (review)
 using tt::tt_metal::PhysicalSystemDescriptor;
 
 enum class CommandMode {
@@ -238,6 +266,7 @@ void parse_validation_args(int argc, char* argv[], InputArgs& input_args) {
                 "Relaxed validation mode enabled. Minimum connections per ASIC pair: " +
                 std::to_string(input_args.min_connections.value()));
         }
+<<<<<<< HEAD
 
     } catch (const cxxopts::exceptions::exception& e) {
         std::cerr << "Error parsing arguments: " << e.what() << std::endl;

--- a/tools/scaleout/validation/run_cluster_validation.cpp
+++ b/tools/scaleout/validation/run_cluster_validation.cpp
@@ -219,6 +219,7 @@ void parse_validation_args(int argc, char* argv[], InputArgs& input_args) {
 
         log_output_rank0("Generating System Validation Logs in " + input_args.output_path.string());
 
+<<<<<<< HEAD
         // Parse boolean flags
         input_args.fail_on_warning = result["hard-fail"].as<bool>();
         input_args.log_ethernet_metrics = result["log-ethernet-metrics"].as<bool>();

--- a/tools/scaleout/validation/utils/cluster_validation_utils.cpp
+++ b/tools/scaleout/validation/utils/cluster_validation_utils.cpp
@@ -1559,7 +1559,8 @@ tt_metal::AsicTopology validate_connectivity(
     const fsd::proto::FactorySystemDescriptor& fsd_proto,
     const YAML::Node& gsd_yaml_node,
     bool fail_on_warning,
-    PhysicalSystemDescriptor& physical_system_descriptor) {
+    PhysicalSystemDescriptor& physical_system_descriptor,
+    std::optional<uint32_t> min_connections) {
     log_output_rank0(
         "Validating Factory System Descriptor (Golden Representation) against Global System Descriptor (in-memory)");
     const auto& distributed_context = tt::tt_metal::MetalContext::instance().global_distributed_context();
@@ -1568,7 +1569,8 @@ tt_metal::AsicTopology validate_connectivity(
         gsd_yaml_node,
         true /* strict_validation */,
         fail_on_warning,
-        *distributed_context.rank() == 0 /* log_output */);
+        *distributed_context.rank() == 0 /* log_output */,
+        min_connections);
     log_output_rank0("Factory System Descriptor (Golden Representation) Validation Complete");
     return generate_asic_topology_from_connections(missing_physical_connections, physical_system_descriptor);
 }

--- a/tools/scaleout/validation/utils/cluster_validation_utils.hpp
+++ b/tools/scaleout/validation/utils/cluster_validation_utils.hpp
@@ -38,7 +38,6 @@ struct ConnectivityValidationConfig {
     std::optional<std::string> deployment_descriptor_path = std::nullopt;
     std::optional<std::string> fsd_path = std::nullopt;
     bool fail_on_warning = false;
-    std::optional<uint32_t> min_connections = std::nullopt;  // Relaxed validation mode
 };
 
 // ============================================================================

--- a/tools/scaleout/validation/utils/cluster_validation_utils.hpp
+++ b/tools/scaleout/validation/utils/cluster_validation_utils.hpp
@@ -38,6 +38,7 @@ struct ConnectivityValidationConfig {
     std::optional<std::string> deployment_descriptor_path = std::nullopt;
     std::optional<std::string> fsd_path = std::nullopt;
     bool fail_on_warning = false;
+    std::optional<uint32_t> min_connections = std::nullopt;  // Relaxed validation mode
 };
 
 // ============================================================================
@@ -106,6 +107,7 @@ tt_metal::AsicTopology validate_connectivity(
     const fsd::proto::FactorySystemDescriptor& fsd_proto,
     const YAML::Node& gsd_yaml_node,
     bool fail_on_warning,
-    PhysicalSystemDescriptor& physical_system_descriptor);
+    PhysicalSystemDescriptor& physical_system_descriptor,
+    std::optional<uint32_t> min_connections = std::nullopt);
 
 }  // namespace tt::scaleout_tools

--- a/tools/tests/scaleout/CMakeLists.txt
+++ b/tools/tests/scaleout/CMakeLists.txt
@@ -17,6 +17,7 @@ target_link_libraries(
         gmock_main
         enchantum::enchantum
         protobuf::libprotobuf
+        yaml-cpp::yaml-cpp
 )
 
 # Test for link retraining validation


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/33462

### Problem description
- Error messages like `"Port Connections found in FSD but missing in GSD"` are confusing for users and don't clearly indicate what's wrong
- No way to run `run_cluster_validation` in a relaxed mode similar to `test_system_health --min-connections`
- Users can't easily validate partial cluster connectivity without triggering errors

### What's changed
- Improved error messages to say `"Physical Discovery found X missing/extra port/cable connections"` for clarity
- Added `--min-connections` CLI argument to enable relaxed validation mode that skips errors when discovered connections >= threshold
- Added unit tests to verify the new relaxed validation mode behavior

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes