### PR TITLE
SDXL fix perf measurement

### DIFF
--- a/models/experimental/stable_diffusion_xl_base/demo/demo_base_and_refiner.py
+++ b/models/experimental/stable_diffusion_xl_base/demo/demo_base_and_refiner.py
@@ -176,7 +176,7 @@ def run_demo_inference(
             if is_ci_env:
                 logger.info(f"Image {len(images)}/{len(prompts)} generated successfully")
             else:
-                output_path = f"output/output{len(images) - 1 + start_from}.png"
+                output_path = f"output/output{len(images) - 1 + start_from}_{use_cfg_parallel}_{capture_trace}.png"
                 pil_img.save(output_path)
                 logger.info(f"Image saved to {output_path}")
 

--- a/models/experimental/stable_diffusion_xl_base/demo/demo_base_and_refiner.py
+++ b/models/experimental/stable_diffusion_xl_base/demo/demo_base_and_refiner.py
@@ -164,6 +164,10 @@ def run_demo_inference(
         )
 
         profiler.end("end_to_end_generation")
+        if iter == 0:
+            profiler.times["end_to_end_generation"][0] -= profiler.times["auto_compile_if_needed"][0]
+            for key in profiler.times.keys():
+                profiler.times[key] = [profiler.times[key][-1]]
 
         for idx, img in enumerate(imgs):
             if iter * batch_size + idx >= len(prompts):
@@ -176,7 +180,7 @@ def run_demo_inference(
             if is_ci_env:
                 logger.info(f"Image {len(images)}/{len(prompts)} generated successfully")
             else:
-                output_path = f"output/output{len(images) - 1 + start_from}_{use_cfg_parallel}_{capture_trace}.png"
+                output_path = f"output/output{len(images) - 1 + start_from}.png"
                 pil_img.save(output_path)
                 logger.info(f"Image saved to {output_path}")
 

--- a/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_accuracy.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_accuracy.py
@@ -175,10 +175,6 @@ def test_accuracy_sdxl(
     else:
         logger.info("FID score is not calculated for less than 2 prompts.")
 
-    print(f"FID score: {fid_score}")
-    print(f"Average CLIP Score: {average_clip_score}")
-    print(f"Standard Deviation of CLIP Scores: {deviation_clip_score}")
-
     avg_gen_end_to_end = profiler.get("end_to_end_generation")
     model_name = "sdxl-tp" if use_cfg_parallel else "sdxl"
 
@@ -273,6 +269,7 @@ def test_accuracy_sdxl(
         json.dump(data, f, indent=4)
 
     logger.info(f"Test results saved to {OUT_ROOT}/{RESULTS_FILE_NAME}")
+    print(json.dumps(data, indent=4))
 
     check_clip_scores(start_from, num_prompts, prompts, clip_scores)
 

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_sdxl_combined_pipeline.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_sdxl_combined_pipeline.py
@@ -370,7 +370,9 @@ class TtSDXLCombinedPipeline:
         if denoising_split is not None and denoising_split != self.config.denoising_split:
             self.set_denoising_split(denoising_split)
 
+        profiler.start("auto_compile_if_needed")
         self._auto_compile_if_needed()
+        profiler.end("auto_compile_if_needed")
 
         profiler.start("combined_generation")
 


### PR DESCRIPTION
### Ticket
#33584 (SDXL: wrong end-to-end perf measurement)

### Problem description
When measuring end_to_end_generation time in the demo_base_and_refiner, the first iteration includes a warmup/compilation run that changes performance statistics.

- First iteration: generate() calls `_auto_compile_if_needed()` internally, which performs a warmup run to compile all models. This warmup time is included in first `end_to_end_generation` time.

- profiler times contain warmup measurements mixed with actual inference measurements.
`profiler.times["denoising_loop"]` contains warmup values at index 0, followed by actual inference values, same for
`profiler.times["vae_decode"]`, `profiler.times["encode_prompts"]`, `profiler.times["end_to_end_generation"]`

### What's changed
- compile time is taken into consideration and subtracted from first end_to_end_image_generation time
- profiler is cleared of warmup performance values

### Checklist
- [x] [sdxl demo](https://github.com/tenstorrent/tt-shield/actions/runs/19867635933/job/56938015852) passed
- [x] [sdxl accuracy](https://github.com/tenstorrent/tt-shield/actions/runs/19867605756/job/56937362180) passed