### PR TITLE
Enable PinnedMemory on Wormhole

### DIFF
--- a/tt_metal/api/tt-metalium/experimental/pinned_memory.hpp
+++ b/tt_metal/api/tt-metalium/experimental/pinned_memory.hpp
@@ -47,9 +47,10 @@ struct MemoryPinningParameters {
 class PinnedMemory {
 public:
     /**
-     * @brief NOC address and the MMIO device ID where it's usable from. This address may have a 64-bit offset, so it
-     * must be used with noc_wwrite_with_state and the variant of noc_read_with_state that takes src_noc_addr as an
-     * argument.
+     * @brief NOC address and the MMIO device ID where it's usable from.
+     *
+     * This address may have a 64-bit offset, so it must be used with noc_wwrite_with_state and the variant of
+     * noc_read_with_state that takes src_noc_addr as an argument.
      */
     struct NocAddr {
         uint32_t pcie_xy_enc;

--- a/tt_metal/api/tt-metalium/experimental/pinned_memory.hpp
+++ b/tt_metal/api/tt-metalium/experimental/pinned_memory.hpp
@@ -46,7 +46,13 @@ struct MemoryPinningParameters {
  */
 class PinnedMemory {
 public:
+    /**
+     * @brief NOC address and the MMIO device ID where it's usable from. This address may have a 64-bit offset, so it
+     * must be used with noc_wwrite_with_state and the variant of noc_read_with_state that takes src_noc_addr as an
+     * argument.
+     */
     struct NocAddr {
+        uint32_t pcie_xy_enc;
         uint64_t addr;
         ChipId device_id;
     };

--- a/tt_metal/distributed/pinned_memory.cpp
+++ b/tt_metal/distributed/pinned_memory.cpp
@@ -355,7 +355,7 @@ experimental::MemoryPinningParameters GetMemoryPinningParameters(distributed::Me
     experimental::MemoryPinningParameters params{};
     params.max_pins = hal.get_max_pinned_memory_count();
     params.max_total_pin_size = hal.get_total_pinned_memory_size();
-    // Ideally use a 64 bit addresses through the NOC, but otherwise use the iATU to translate 36 bit addresses to 64
+    // Ideally use a 64-bit addresses through the NOC, but otherwise use the iATU to translate 36-bit addresses to 64
     // bit addresses.
     params.can_map_to_noc = MetalContext::instance().hal().get_supports_64_bit_pcie_addressing() ||
                             MetalContext::instance().get_cluster().is_noc_mapping_enabled();

--- a/tt_metal/distributed/pinned_memory.cpp
+++ b/tt_metal/distributed/pinned_memory.cpp
@@ -187,9 +187,17 @@ std::optional<PinnedMemory::NocAddr> PinnedMemoryImpl::get_noc_addr(ChipId devic
     if (buffer_it == device_buffers_.end()) {
         return std::nullopt;
     }
+    const auto& soc = tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(mmio_device_id);
+    const auto& pcie_cores = soc.get_cores(CoreType::PCIE, CoordSystem::NOC0);
+    TT_ASSERT(!pcie_cores.empty());
+    auto pcie_xy = pcie_cores.front();
+    uint32_t pcie_xy_enc = tt::tt_metal::MetalContext::instance().hal().noc_xy_pcie64_encoding(pcie_xy.x, pcie_xy.y);
 
     if (use_64bit_address_space_) {
-        return PinnedMemory::NocAddr{buffer_it->second->get_device_io_addr(host_offset_), mmio_device_id};
+        return PinnedMemory::NocAddr{
+            .pcie_xy_enc = pcie_xy_enc,
+            .addr = buffer_it->second->get_device_io_addr(host_offset_),
+            .device_id = mmio_device_id};
     }
 
     auto noc_addr_opt = buffer_it->second->get_noc_addr();
@@ -198,7 +206,10 @@ std::optional<PinnedMemory::NocAddr> PinnedMemoryImpl::get_noc_addr(ChipId devic
     }
 
     // Return NOC address and the MMIO device ID where it's usable from
-    return PinnedMemory::NocAddr{noc_addr_opt.value() + static_cast<uint64_t>(host_offset_), mmio_device_id};
+    return PinnedMemory::NocAddr{
+        .pcie_xy_enc = pcie_xy_enc,
+        .addr = noc_addr_opt.value() + static_cast<uint64_t>(host_offset_),
+        .device_id = mmio_device_id};
 }
 
 std::vector<ChipId> PinnedMemoryImpl::get_device_ids() const {
@@ -333,7 +344,7 @@ std::unique_ptr<PinnedMemory> PinnedMemory::Create(
     return std::unique_ptr<PinnedMemory>(new PinnedMemory(devices, host_ptr, buffer_size, map_to_noc));
 }
 
-experimental::MemoryPinningParameters GetMemoryPinningParameters(distributed::MeshDevice& mesh_device) {
+experimental::MemoryPinningParameters GetMemoryPinningParameters(distributed::MeshDevice& /* mesh_device */) {
     // Use UMD Cluster to determine IOMMU and NOC mapping support and arch
     bool iommu_enabled = MetalContext::instance().get_cluster().is_iommu_enabled();
     if (!iommu_enabled) {
@@ -344,8 +355,10 @@ experimental::MemoryPinningParameters GetMemoryPinningParameters(distributed::Me
     experimental::MemoryPinningParameters params{};
     params.max_pins = hal.get_max_pinned_memory_count();
     params.max_total_pin_size = hal.get_total_pinned_memory_size();
-    // Disable NOC mapping until tested, except on Blackhole where it's supported.
-    params.can_map_to_noc = (mesh_device.arch() == tt::ARCH::BLACKHOLE);
+    // Ideally use a 64 bit addresses through the NOC, but otherwise use the iATU to translate 36 bit addresses to 64
+    // bit addresses.
+    params.can_map_to_noc = MetalContext::instance().hal().get_supports_64_bit_pcie_addressing() ||
+                            MetalContext::instance().get_cluster().is_noc_mapping_enabled();
     return params;
 }
 

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -206,6 +206,8 @@ bool Cluster::is_base_routing_fw_enabled(tt::tt_metal::ClusterType cluster_type)
 
 bool Cluster::is_iommu_enabled() const { return this->iommu_enabled_; }
 
+bool Cluster::is_noc_mapping_enabled() const { return this->noc_mapping_enabled_; }
+
 Cluster::Cluster(llrt::RunTimeOptions& rtoptions, const tt_metal::Hal& hal) : rtoptions_(rtoptions), hal_(hal) {
     ZoneScoped;
     log_info(tt::LogDevice, "Opening user mode device driver");
@@ -322,6 +324,7 @@ void Cluster::initialize_device_drivers() {
 
     // Cache IOMMU status (expensive to query repeatedly)
     this->iommu_enabled_ = false;
+    this->noc_mapping_enabled_ = false;
     if (this->target_type_ == tt::TargetDevice::Silicon) {
         const auto& mmio_ids = this->driver_->get_target_mmio_device_ids();
         if (!mmio_ids.empty()) {
@@ -329,6 +332,7 @@ void Cluster::initialize_device_drivers() {
             auto pci = this->driver_->get_chip(mmio_id)->get_tt_device()->get_pci_device();
             if (pci) {
                 this->iommu_enabled_ = pci->is_iommu_enabled();
+                this->noc_mapping_enabled_ = pci->is_mapping_buffer_to_noc_supported();
             }
         }
     }

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -316,6 +316,8 @@ public:
 
     // Returns whether IOMMU is enabled on the system (cached at init time)
     bool is_iommu_enabled() const;
+    // Returns whether NOC mapping is enabled on the system (cached at init time)
+    bool is_noc_mapping_enabled() const;
 
     tt::tt_metal::ClusterType get_cluster_type() const;
 
@@ -389,6 +391,8 @@ private:
 
     // Cached system IOMMU status to avoid slow queries at MeshDevice construction
     bool iommu_enabled_ = false;
+    // Cached system NOC mapping status to avoid slow queries at MeshDevice construction
+    bool noc_mapping_enabled_ = false;
 
     // Need to hold reference to cluster descriptor to detect total number of devices available in cluster
     // UMD static APIs `detect_available_device_ids` and `detect_number_of_chips` only returns number of MMIO mapped


### PR DESCRIPTION
### Ticket

[#25675](https://github.com/tenstorrent/tt-metal/issues/25675)

### Problem description
Currently PinnedMemory is only enabled on Blackhole, not Wormhole. This is because Wormhole needs to use the outbound iATU to map NoC addresses to bus addresses, and that wasn't setup before.

### What's changed
Make PinnedMemory::NocAddr 64-bit-aware (with 32 bits for NOC address and 64 bits for the linear offset). Then move the code to generate a NoC address into PinnedMemory::get_noc_addr, and make sure it can handle both the blackhole and wormhole cases. Add a flag for determining if iATU translation is available to Cluster, and check that when determining MemoryPinningParameters.can_map_to_noc.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes