### PR TITLE
Fix cos/sin rounding (fix SDXL tests)

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
@@ -76,14 +76,21 @@ sfpi_inline vFloat sfpu_tan<false>(vFloat x) {
     return x;
 }
 
-template <bool APPROXIMATION_MODE, int ITERATIONS>
+template <bool APPROXIMATION_MODE, bool fp32_dest_acc_en, int ITERATIONS>
 inline void calculate_tangent() {
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++) {
         vFloat v = dst_reg[0] * FRAC_1_PI;
         v -= int32_to_float(float_to_int16(v, 0), 0);
-        dst_reg[0] = sfpu_tan<APPROXIMATION_MODE>(PI * v);
-        dst_reg++;
+
+        v = sfpu_tan<APPROXIMATION_MODE>(PI * v);
+
+        if constexpr (!fp32_dest_acc_en) {
+            v = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(v, 0));
+        }
+
+        sfpi::dst_reg[0] = v;
+        sfpi::dst_reg++;
     }
 }
 
@@ -105,7 +112,7 @@ sfpi_inline vFloat sfpu_sinpi<false>(vFloat x) {
            ((((0x1.406628p-4f * xx - 0x9.93f86p-4f) * xx + 0x2.8cd64p+0f) * xx - 0x5.2aef6p+0f) * xx + 0x3.243f6cp+0f);
 }
 
-template <bool APPROXIMATION_MODE, int ITERATIONS>
+template <bool APPROXIMATION_MODE, bool fp32_dest_acc_en, int ITERATIONS = 8>
 inline void calculate_sine() {
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++) {
@@ -114,14 +121,18 @@ inline void calculate_sine() {
         v -= int32_to_float(whole_v, 0);
         v = sfpu_sinpi<APPROXIMATION_MODE>(v);
 
-        v_if(whole_v & 1) { v = -v; }
-        v_endif;
+        v = sfpi::reinterpret<sfpi::vFloat>(sfpi::reinterpret<sfpi::vInt>(v) ^ (whole_v << 31));
+
+        if constexpr (!fp32_dest_acc_en) {
+            v = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(v, 0));
+        }
+
         dst_reg[0] = v;
         dst_reg++;
     }
 }
 
-template <bool APPROXIMATION_MODE, int ITERATIONS>
+template <bool APPROXIMATION_MODE, bool fp32_dest_acc_en, int ITERATIONS = 8>
 inline void calculate_cosine() {
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++) {
@@ -130,21 +141,25 @@ inline void calculate_cosine() {
         v -= int32_to_float(whole_v, 0);
         v = sfpu_sinpi<APPROXIMATION_MODE>(v);
 
-        v_if(whole_v & 1) { v = -v; }
-        v_endif;
+        v = sfpi::reinterpret<sfpi::vFloat>(sfpi::reinterpret<sfpi::vInt>(v) ^ (whole_v << 31));
+
+        if constexpr (!fp32_dest_acc_en) {
+            v = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(v, 0));
+        }
+
         dst_reg[0] = v;
         dst_reg++;
     }
 }
 
-template <SfpuType operation, bool APPROXIMATION_MODE, int ITERATIONS = 8>
+template <SfpuType operation, bool APPROXIMATION_MODE, bool fp32_dest_acc_en, int ITERATIONS = 8>
 inline void calculate_sfpu_trig() {
     if constexpr (operation == SfpuType::sine) {
-        calculate_sine<APPROXIMATION_MODE, ITERATIONS>();
+        calculate_sine<APPROXIMATION_MODE, fp32_dest_acc_en, ITERATIONS>();
     } else if constexpr (operation == SfpuType::cosine) {
-        calculate_cosine<APPROXIMATION_MODE, ITERATIONS>();
+        calculate_cosine<APPROXIMATION_MODE, fp32_dest_acc_en, ITERATIONS>();
     } else if constexpr (operation == SfpuType::tan) {
-        calculate_tangent<APPROXIMATION_MODE, ITERATIONS>();
+        calculate_tangent<APPROXIMATION_MODE, fp32_dest_acc_en, ITERATIONS>();
     }
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_macros.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_macros.h
@@ -86,6 +86,12 @@
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                             \
         ckernel::sfpu::OP<SfpuType::TYPE, APPROXIMATE, ITERATIONS>, DST_IDX, (int)VectorMode::MODE)
 
+// For ops without extra uint parameters with type and iteration
+#define SFPU_UNARY_NO_PARAM_KERNEL_WITH_TYPE_AND_ITERATIONS_FP32_FIRST( \
+    OP, TYPE, MODE, APPROXIMATE, FP32, DST_IDX, ITERATIONS)             \
+    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                  \
+        ckernel::sfpu::OP<SfpuType::TYPE, APPROXIMATE, FP32, ITERATIONS>, DST_IDX, (int)VectorMode::MODE)
+
 // For ops where compute takes extra args
 #define SFPU_UNARY_PARAMS_KERNEL_EXTRA_ARGS(FN, MODE, APPROXIMATE, DST_IDX, PARAM0, PARAM1) \
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                                      \
@@ -183,5 +189,5 @@
 
 // For log1p op that needs three template parameters
 #define SFPU_UNARY_NO_PARAM_KERNEL_LOG1P(OP, MODE, APPROXIMATE, FAST_APPROX, FP32, DST_IDX) \
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                                \
+    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                                      \
         ckernel::sfpu::calculate_##OP<APPROXIMATE, FAST_APPROX, FP32>, DST_IDX, (int)VectorMode::MODE)

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
@@ -76,14 +76,21 @@ sfpi_inline vFloat sfpu_tan<false>(vFloat x) {
     return x;
 }
 
-template <bool APPROXIMATION_MODE, int ITERATIONS>
+template <bool APPROXIMATION_MODE, bool fp32_dest_acc_en, int ITERATIONS>
 inline void calculate_tangent() {
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++) {
         vFloat v = dst_reg[0] * FRAC_1_PI;
         v -= int32_to_float(float_to_int16(v, 0), 0);
-        dst_reg[0] = sfpu_tan<APPROXIMATION_MODE>(PI * v);
-        dst_reg++;
+
+        v = sfpu_tan<APPROXIMATION_MODE>(PI * v);
+
+        if constexpr (!fp32_dest_acc_en) {
+            v = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(v, 0));
+        }
+
+        sfpi::dst_reg[0] = v;
+        sfpi::dst_reg++;
     }
 }
 
@@ -105,7 +112,7 @@ sfpi_inline vFloat sfpu_sinpi<false>(vFloat x) {
            ((((0x1.406628p-4f * xx - 0x9.93f86p-4f) * xx + 0x2.8cd64p+0f) * xx - 0x5.2aef6p+0f) * xx + 0x3.243f6cp+0f);
 }
 
-template <bool APPROXIMATION_MODE, int ITERATIONS>
+template <bool APPROXIMATION_MODE, bool fp32_dest_acc_en, int ITERATIONS = 8>
 inline void calculate_sine() {
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++) {
@@ -114,14 +121,18 @@ inline void calculate_sine() {
         v -= int32_to_float(whole_v, 0);
         v = sfpu_sinpi<APPROXIMATION_MODE>(v);
 
-        v_if(whole_v & 1) { v = -v; }
-        v_endif;
+        v = sfpi::reinterpret<sfpi::vFloat>(sfpi::reinterpret<sfpi::vInt>(v) ^ (whole_v << 31));
+
+        if constexpr (!fp32_dest_acc_en) {
+            v = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(v, 0));
+        }
+
         dst_reg[0] = v;
         dst_reg++;
     }
 }
 
-template <bool APPROXIMATION_MODE, int ITERATIONS>
+template <bool APPROXIMATION_MODE, bool fp32_dest_acc_en, int ITERATIONS = 8>
 inline void calculate_cosine() {
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++) {
@@ -130,21 +141,25 @@ inline void calculate_cosine() {
         v -= int32_to_float(whole_v, 0);
         v = sfpu_sinpi<APPROXIMATION_MODE>(v);
 
-        v_if(whole_v & 1) { v = -v; }
-        v_endif;
+        v = sfpi::reinterpret<sfpi::vFloat>(sfpi::reinterpret<sfpi::vInt>(v) ^ (whole_v << 31));
+
+        if constexpr (!fp32_dest_acc_en) {
+            v = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(v, 0));
+        }
+
         dst_reg[0] = v;
         dst_reg++;
     }
 }
 
-template <SfpuType operation, bool APPROXIMATION_MODE, int ITERATIONS = 8>
+template <SfpuType operation, bool APPROXIMATION_MODE, bool fp32_dest_acc_en, int ITERATIONS = 8>
 inline void calculate_sfpu_trig() {
     if constexpr (operation == SfpuType::sine) {
-        calculate_sine<APPROXIMATION_MODE, ITERATIONS>();
+        calculate_sine<APPROXIMATION_MODE, fp32_dest_acc_en, ITERATIONS>();
     } else if constexpr (operation == SfpuType::cosine) {
-        calculate_cosine<APPROXIMATION_MODE, ITERATIONS>();
+        calculate_cosine<APPROXIMATION_MODE, fp32_dest_acc_en, ITERATIONS>();
     } else if constexpr (operation == SfpuType::tan) {
-        calculate_tangent<APPROXIMATION_MODE, ITERATIONS>();
+        calculate_tangent<APPROXIMATION_MODE, fp32_dest_acc_en, ITERATIONS>();
     }
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_macros.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_macros.h
@@ -86,6 +86,12 @@
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                             \
         ckernel::sfpu::OP<SfpuType::TYPE, APPROXIMATE, ITERATIONS>, DST_IDX, (int)VectorMode::MODE)
 
+// For ops without extra uint parameters with type and iteration
+#define SFPU_UNARY_NO_PARAM_KERNEL_WITH_TYPE_AND_ITERATIONS_FP32_FIRST( \
+    OP, TYPE, MODE, APPROXIMATE, FP32, DST_IDX, ITERATIONS)             \
+    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                  \
+        ckernel::sfpu::OP<SfpuType::TYPE, APPROXIMATE, FP32, ITERATIONS>, DST_IDX, (int)VectorMode::MODE)
+
 // For ops where compute takes extra args
 #define SFPU_UNARY_PARAMS_KERNEL_EXTRA_ARGS(FN, MODE, APPROXIMATE, DST_IDX, PARAM0, PARAM1) \
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                                      \

--- a/tt_metal/include/compute_kernel_api/eltwise_unary/trigonometry.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_unary/trigonometry.h
@@ -31,7 +31,10 @@ ALWI void sin_tile_init() { MATH(SFPU_UNARY_KERNEL_INIT(sine, APPROX)); }
  * | tile_index     | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
  */
 // clang-format on
-ALWI void sin_tile(uint32_t idst) { MATH(SFPU_UNARY_NO_PARAM_KERNEL_WITH_TYPE(sfpu_trig, sine, RC, APPROX, idst)); }
+ALWI void sin_tile(uint32_t idst) {
+    MATH(SFPU_UNARY_NO_PARAM_KERNEL_WITH_TYPE_AND_ITERATIONS_FP32_FIRST(
+        calculate_sfpu_trig, sine, RC, APPROX, DST_ACCUM_MODE, idst, 8));
+}
 
 /**
  * Please refer to documentation for any_init.
@@ -52,7 +55,10 @@ ALWI void cos_tile_init() { MATH(SFPU_UNARY_KERNEL_INIT(cosine, APPROX)); }
  * | tile_index     | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
  */
 // clang-format on
-ALWI void cos_tile(uint32_t idst) { MATH(SFPU_UNARY_NO_PARAM_KERNEL_WITH_TYPE(sfpu_trig, cosine, RC, APPROX, idst)); }
+ALWI void cos_tile(uint32_t idst) {
+    MATH(SFPU_UNARY_NO_PARAM_KERNEL_WITH_TYPE_AND_ITERATIONS_FP32_FIRST(
+        calculate_sfpu_trig, cosine, RC, APPROX, DST_ACCUM_MODE, idst, 8));
+}
 
 /**
  * Please refer to documentation for any_init.
@@ -96,7 +102,10 @@ ALWI void tan_tile_init() { MATH(SFPU_UNARY_KERNEL_INIT(tan, APPROX)); }
  * | tile_index     | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
  */
 // clang-format on
-ALWI void tan_tile(uint32_t idst) { MATH(SFPU_UNARY_NO_PARAM_KERNEL_WITH_TYPE(sfpu_trig, tan, RC, APPROX, idst)); }
+ALWI void tan_tile(uint32_t idst) {
+    MATH(SFPU_UNARY_NO_PARAM_KERNEL_WITH_TYPE_AND_ITERATIONS_FP32_FIRST(
+        calculate_sfpu_trig, tan, RC, APPROX, DST_ACCUM_MODE, idst, 8));
+}
 
 /**
  * Please refer to documentation for any_init.


### PR DESCRIPTION
### Ticket
#33566

### Problem description
As per the issue's information, running `python -m pytest models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_timesteps.py` fails with a PCC error on cos when enabling:

```
export TTNN_CONFIG_OVERRIDES='{
    "enable_fast_runtime_mode": false,
    "enable_comparison_mode": true,
    "comparison_mode_should_raise_exception": true,
    "comparison_mode_pcc": 0.99
}
```  

There are two reasons for this failures:
- bad bfloat16 round in SPFU kernel
- PCC is a bad metrics when dealing with tiny changes

For more details: https://github.com/tenstorrent/tt-metal/issues/33566#issuecomment-3602615800

### What's changed
This PR ensures that cos and sin rounds to nearest rather than truncate. 

Note: Since SDXL is a customer model, this is quite critical ( c.f. @cmaryanTT ), which is why I've focused on getting the fix rather than cleaning up all of `ckernel_sfpu_trigonometry.h` such as `sfpi::` (I can create an issue for this if needed)


__Before (main)__: FAIL
<img width="2115" height="175" alt="Screenshot 2025-12-02 at 19 04 02" src="https://github.com/user-attachments/assets/aa5a06ec-572e-4b4d-bbd8-fe648562aae4" />

__After (this)__: SUCCESS
<img width="1455" height="231" alt="Screenshot 2025-12-02 at 19 05 03" src="https://github.com/user-attachments/assets/5bff0667-1921-4be7-93ff-90605105f918" />

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes [OK](https://github.com/tenstorrent/tt-metal/actions/runs/19865620388)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable) [OK](https://github.com/tenstorrent/tt-metal/actions/runs/19866695193) 
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable) [OK](https://github.com/tenstorrent/tt-metal/actions/runs/19869244588), error also on [`main`](https://github.com/tenstorrent/tt-metal/actions/runs/19871998402)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes
