### PR TITLE
Add option to move Fabric init and Teardown to a separate utility

### DIFF
--- a/.github/workflows/galaxy-quick-impl.yaml
+++ b/.github/workflows/galaxy-quick-impl.yaml
@@ -144,10 +144,19 @@ jobs:
           pytest models/demos/llama3_70b_galaxy/demo/demo_decode.py -k "quick";
           pytest models/demos/llama3_70b_galaxy/tests/unit_tests/test_llama_model_prefill.py;
           # CCL smoke tests - exactly one representative test from each op category
-          pytest "tests/nightly/tg/ccl/test_minimal_all_gather_async.py::test_all_gather_async[wormhole_b0-mesh_device0-normal-2-2-20-fabric_linear-DRAM_memconfig-sd35_prompt_check-3links]" --timeout=300;
-          pytest "tests/nightly/tg/ccl/test_all_to_all_combine_6U.py::test_all_to_all_combine_8x4[wormhole_b0-dram_in_l1_out_axis0-bfloat16-None-num_links_4-2-dense-s2-7000-8-256-32-8x4_grid-False-fabric_2d]" --timeout=300;
-          pytest "tests/nightly/tg/ccl/test_all_to_all_dispatch_6U.py::test_all_to_all_dispatch_8x4[wormhole_b0-l1_in_dram_out-dtype0-None-4-s2-7168-8-256-32-8x4_grid-False-fabric_1d_line]" --timeout=300;
-          pytest "tests/nightly/tg/ccl/test_minimal_reduce_scatter_async.py::test_reduce_scatter_async[wormhole_b0-mesh_device0-8-2-2-fabric_linear-mem_config_input0-mem_config_rs0-batch_8-perf-3links]" --timeout=300;
+
+          # Use Fabric Manager to initialize/teardown Fabric 2D and run all tests without initializing/tearing down fabric
+          ./build/tools/scaleout/run_fabric_manager --mesh-shape 8x4 --fabric-config FABRIC_2D --initialize-fabric
+          pytest "tests/nightly/tg/ccl/test_all_to_all_combine_6U.py::test_all_to_all_combine_8x4[wormhole_b0-dram_in_l1_out_axis0-bfloat16-None-num_links_4-2-dense-s2-7000-8-256-32-8x4_grid-False-fabric_manager_enabled_2d]" --timeout=300;
+          ./build/tools/scaleout/run_fabric_manager --mesh-shape 8x4 --fabric-config FABRIC_2D --terminate-fabric
+
+          # Use Fabric Manager to initialize/teardown Fabric 1D and run all tests without initializing/tearing down fabric
+          ./build/tools/scaleout/run_fabric_manager --mesh-shape 8x4 --fabric-config FABRIC_1D --initialize-fabric
+          pytest "tests/nightly/tg/ccl/test_minimal_all_gather_async.py::test_all_gather_async[wormhole_b0-mesh_device0-normal-2-2-20-fabric_manager_enabled_linear-DRAM_memconfig-sd35_prompt_check-3links]" --timeout=300;
+          pytest "tests/nightly/tg/ccl/test_minimal_reduce_scatter_async.py::test_reduce_scatter_async[wormhole_b0-mesh_device0-8-2-2-fabric_manager_enabled_linear-mem_config_input0-mem_config_rs0-batch_8-perf-3links]" --timeout=300;
+          pytest "tests/nightly/tg/ccl/test_all_to_all_dispatch_6U.py::test_all_to_all_dispatch_8x4[wormhole_b0-l1_in_dram_out-dtype0-None-4-s2-7168-8-256-32-8x4_grid-False-fabric_manager_enabled_1d_line]" --timeout=300;
+          ./build/tools/scaleout/run_fabric_manager --mesh-shape 8x4 --fabric-config FABRIC_1D --terminate-fabric
+
           pytest "tests/nightly/tg/ccl/test_all_broadcast.py::test_all_broadcast_trace[wormhole_b0-mesh_device0-device_params0-3-mem_config0-deepseek_1]" --timeout=300;
           pytest "tests/nightly/tg/ccl/test_all_reduce.py::test_line_all_reduce_on_TG_rows_post_commit[wormhole_b0-device_params0-math_op0-8x4_grid-8-buffer_type0-input_dtype0-4-2-per_chip_output_shape0-layout0]" --timeout=300;
       - uses: tenstorrent/tt-metal/.github/actions/slack-report@main

--- a/conftest.py
+++ b/conftest.py
@@ -341,7 +341,7 @@ def reset_fabric(fabric_config):
 # Set fabric config to passed in value
 # Do nothing if not set
 # Must be called before creating the mesh device
-def set_fabric(fabric_config, reliability_mode=None, fabric_tensix_config=None):
+def set_fabric(fabric_config, reliability_mode=None, fabric_tensix_config=None, fabric_manager=None):
     import ttnn
 
     # If fabric_config is not None, set it to fabric_config
@@ -356,7 +356,12 @@ def set_fabric(fabric_config, reliability_mode=None, fabric_tensix_config=None):
         if fabric_tensix_config is None:
             fabric_tensix_config = get_default_fabric_tensix_config()
 
-        ttnn.set_fabric_config(fabric_config, reliability_mode, None, fabric_tensix_config)  # num_planes
+        if fabric_manager is None:
+            fabric_manager = ttnn.FabricManagerMode.DEFAULT
+
+        ttnn.set_fabric_config(
+            fabric_config, reliability_mode, None, fabric_tensix_config, ttnn.FabricUDMMode.DISABLED, fabric_manager
+        )
 
 
 def get_default_fabric_tensix_config():
@@ -414,7 +419,8 @@ def mesh_device(request, silicon_arch_name, device_params):
     fabric_config = updated_device_params.pop("fabric_config", None)
     fabric_tensix_config = updated_device_params.pop("fabric_tensix_config", None)
     reliability_mode = updated_device_params.pop("reliability_mode", None)
-    set_fabric(fabric_config, reliability_mode, fabric_tensix_config)
+    fabric_manager = updated_device_params.pop("fabric_manager", None)
+    set_fabric(fabric_config, reliability_mode, fabric_tensix_config, fabric_manager)
     mesh_device = ttnn.open_mesh_device(mesh_shape=mesh_shape, **updated_device_params)
 
     logger.debug(f"multidevice with {mesh_device.get_num_devices()} devices is created")

--- a/tests/nightly/tg/ccl/test_all_to_all_combine_6U.py
+++ b/tests/nightly/tg/ccl/test_all_to_all_combine_6U.py
@@ -31,8 +31,26 @@ from tests.nightly.t3000.ccl.test_all_to_all_combine import (
             "reliability_mode": ttnn.FabricReliabilityMode.RELAXED_INIT,
             "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
         },
+        {
+            "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
+            "reliability_mode": ttnn.FabricReliabilityMode.RELAXED_INIT,
+            "fabric_config": ttnn.FabricConfig.FABRIC_2D,
+            "fabric_manager": ttnn.FabricManagerMode.ENABLED,
+        },
+        {
+            "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
+            "reliability_mode": ttnn.FabricReliabilityMode.RELAXED_INIT,
+            "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+            "fabric_manager": ttnn.FabricManagerMode.ENABLED,
+        },
     ],
-    ids=["fabric_2d", "fabric_1d_line", "fabric_1d_ring"],
+    ids=[
+        "fabric_2d",
+        "fabric_1d_line",
+        "fabric_1d_ring",
+        "fabric_manager_enabled_2d",
+        "fabric_manager_enabled_1d_line",
+    ],
     indirect=True,
 )
 @pytest.mark.parametrize("trace_mode", [False])

--- a/tests/nightly/tg/ccl/test_all_to_all_dispatch_6U.py
+++ b/tests/nightly/tg/ccl/test_all_to_all_dispatch_6U.py
@@ -41,8 +41,14 @@ from tracy import signpost
             "reliability_mode": ttnn.FabricReliabilityMode.RELAXED_INIT,
             "fabric_config": ttnn.FabricConfig.FABRIC_2D,
         },
+        {
+            "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
+            "reliability_mode": ttnn.FabricReliabilityMode.RELAXED_INIT,
+            "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+            "fabric_manager": ttnn.FabricManagerMode.ENABLED,
+        },
     ],
-    ids=["fabric_1d_line", "fabric_1d_ring", "fabric_2d"],
+    ids=["fabric_1d_line", "fabric_1d_ring", "fabric_2d", "fabric_manager_enabled_1d_line"],
     indirect=True,
 )
 @pytest.mark.parametrize("trace_mode", [False])

--- a/tests/nightly/tg/ccl/test_minimal_all_gather_async.py
+++ b/tests/nightly/tg/ccl/test_minimal_all_gather_async.py
@@ -39,10 +39,24 @@ from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_
 @pytest.mark.parametrize(
     "device_params, all_gather_topology",
     [
-        ({"fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 90112}, ttnn.Topology.Linear),
+        (
+            {
+                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+                "trace_region_size": 90112,
+            },
+            ttnn.Topology.Linear,
+        ),
+        (
+            {
+                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+                "fabric_manager": ttnn.FabricManagerMode.ENABLED,
+                "trace_region_size": 90112,
+            },
+            ttnn.Topology.Linear,
+        ),
     ],
     indirect=["device_params"],
-    ids=["fabric_linear"],
+    ids=["fabric_linear", "fabric_manager_enabled_linear"],
 )
 @pytest.mark.parametrize("chunks_per_sync", [20])
 @pytest.mark.parametrize("num_workers_per_link", [2])

--- a/tests/nightly/tg/ccl/test_minimal_reduce_scatter_async.py
+++ b/tests/nightly/tg/ccl/test_minimal_reduce_scatter_async.py
@@ -47,10 +47,24 @@ from models.common.utility_functions import skip_for_blackhole, skip_for_wormhol
 @pytest.mark.parametrize(
     "device_params, rs_topology",
     [
-        ({"fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 90112}, ttnn.Topology.Linear),
+        (
+            {
+                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+                "trace_region_size": 90112,
+            },
+            ttnn.Topology.Linear,
+        ),
+        (
+            {
+                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+                "fabric_manager": ttnn.FabricManagerMode.ENABLED,
+                "trace_region_size": 90112,
+            },
+            ttnn.Topology.Linear,
+        ),
     ],
     indirect=["device_params"],
-    ids=["fabric_linear"],
+    ids=["fabric_linear", "fabric_manager_enabled_linear"],
 )
 @pytest.mark.parametrize("chunks_per_sync", [2])
 @pytest.mark.parametrize("num_workers_per_link", [2])

--- a/tools/scaleout/CMakeLists.txt
+++ b/tools/scaleout/CMakeLists.txt
@@ -7,6 +7,12 @@ add_executable(
     validation/utils/cluster_validation_utils.cpp
 )
 
+add_executable(
+    run_fabric_manager
+    fabric_manager/run_fabric_manager.cpp
+    fabric_manager/utils/fabric_manager_utils.cpp
+)
+
 # Library target
 add_library(scaleout_tools OBJECT)
 add_library(TT::ScaleoutTools ALIAS scaleout_tools)
@@ -60,6 +66,10 @@ target_include_directories(run_cluster_validation PRIVATE "$<TARGET_PROPERTY:TT:
 target_include_directories(run_cluster_validation PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 target_include_directories(run_cluster_validation SYSTEM PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
+target_include_directories(run_fabric_manager PRIVATE "$<TARGET_PROPERTY:TT::Metalium,INCLUDE_DIRECTORIES>")
+target_include_directories(run_fabric_manager PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(run_fabric_manager SYSTEM PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+
 target_link_libraries(
     scaleout_tools
     PUBLIC
@@ -88,6 +98,16 @@ target_link_libraries(
         protobuf::libprotobuf
         tt_metal
         cxxopts::cxxopts
+)
+
+# Separate binary to get functional coverage for CI. End user fabric manager tool is productized at https://github.com/tenstorrent/tt-fabric-manager
+target_link_libraries(
+    run_fabric_manager
+    PRIVATE
+        TT::ScaleoutTools
+        enchantum::enchantum
+        protobuf::libprotobuf
+        tt_metal
 )
 target_compile_features(scaleout_tools PUBLIC cxx_std_20)
 target_precompile_headers(scaleout_tools REUSE_FROM TT::CommonPCH)

--- a/tools/scaleout/fabric_manager/run_fabric_manager.cpp
+++ b/tools/scaleout/fabric_manager/run_fabric_manager.cpp
@@ -1,0 +1,203 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <iostream>
+#include <string>
+#include <optional>
+#include <chrono>
+#include <sstream>
+
+#include <factory_system_descriptor/utils.hpp>
+#include "tt_metal/fabric/physical_system_descriptor.hpp"
+#include <tt-metalium/distributed.hpp>
+#include "tt_metal/impl/context/metal_context.hpp"
+#include "tests/tt_metal/test_utils/test_common.hpp"
+#include <cabling_generator/cabling_generator.hpp>
+#include <tt-metalium/hal.hpp>
+#include "tools/scaleout/fabric_manager/utils/fabric_manager_utils.hpp"
+#include <enchantum/enchantum.hpp>
+
+namespace tt::scaleout_tools {
+
+// Captures current list of supported input args
+struct InputArgs {
+    std::filesystem::path output_path = "";
+    bool initialize_fabric = false;
+    bool terminate_fabric = false;
+    bool help = false;
+    std::optional<std::string> fabric_config = std::nullopt;
+    std::optional<std::string> reliability_mode = std::nullopt;
+    std::optional<uint8_t> num_routing_planes = std::nullopt;
+    std::optional<std::string> fabric_tensix_config = std::nullopt;
+    std::optional<std::string> fabric_udm_mode = std::nullopt;
+    std::optional<std::string> mesh_shape = std::nullopt;
+};
+
+std::filesystem::path generate_output_dir() {
+    const auto& rt_options = tt::tt_metal::MetalContext::instance().rtoptions();
+    std::filesystem::path output_dir_path = rt_options.get_root_dir() + "fabric_manager_logs/";
+    std::filesystem::create_directories(output_dir_path);
+    return output_dir_path;
+}
+
+InputArgs parse_input_args(const std::vector<std::string>& args_vec) {
+    InputArgs input_args;
+
+    if (test_args::has_command_option(args_vec, "--output-path")) {
+        input_args.output_path = std::filesystem::path(test_args::get_command_option(args_vec, "--output-path"));
+    } else {
+        input_args.output_path = generate_output_dir();
+    }
+    if (test_args::has_command_option(args_vec, "--fabric-config")) {
+        input_args.fabric_config = test_args::get_command_option(args_vec, "--fabric-config");
+    }
+    if (test_args::has_command_option(args_vec, "--reliability-mode")) {
+        input_args.reliability_mode = test_args::get_command_option(args_vec, "--reliability-mode");
+    }
+    if (test_args::has_command_option(args_vec, "--num-routing-planes")) {
+        input_args.num_routing_planes = std::stoi(test_args::get_command_option(args_vec, "--num-routing-planes"));
+    }
+    if (test_args::has_command_option(args_vec, "--fabric-tensix-config")) {
+        input_args.fabric_tensix_config = test_args::get_command_option(args_vec, "--fabric-tensix-config");
+    }
+    if (test_args::has_command_option(args_vec, "--fabric-udm-mode")) {
+        input_args.fabric_udm_mode = test_args::get_command_option(args_vec, "--fabric-udm-mode");
+    }
+    if (test_args::has_command_option(args_vec, "--mesh-shape")) {
+        input_args.mesh_shape = test_args::get_command_option(args_vec, "--mesh-shape");
+    }
+    log_output_rank("Generating Fabric Management Logs in " + input_args.output_path.string());
+
+    input_args.initialize_fabric = test_args::has_command_option(args_vec, "--initialize-fabric");
+    input_args.terminate_fabric = test_args::has_command_option(args_vec, "--terminate-fabric");
+    input_args.help = test_args::has_command_option(args_vec, "--help");
+
+    TT_FATAL(
+        !(input_args.initialize_fabric && input_args.terminate_fabric),
+        "Cannot specify both --initialize-fabric and --terminate-fabric simultaneously");
+
+    return input_args;
+}
+
+void print_usage_info() {
+    std::cout << "Utility to manage Fabric Configuration and Routing for a Multi-Node TT Cluster" << std::endl;
+    std::cout << "Provides fabric management capabilities including initialization and termination" << std::endl
+              << std::endl;
+    std::cout << "Arguments:" << std::endl;
+    std::cout << "  --output-path: Path to output directory" << std::endl;
+    std::cout << "  --fabric-config: Fabric configuration mode (FABRIC_1D, FABRIC_2D, etc.)" << std::endl;
+    std::cout << "  --reliability-mode: Fabric reliability mode (STRICT_SYSTEM_HEALTH_SETUP_MODE, etc.)" << std::endl;
+    std::cout << "  --num-routing-planes: Number of routing planes" << std::endl;
+    std::cout << "  --fabric-tensix-config: Fabric tensix configuration (DISABLED, MUX)" << std::endl;
+    std::cout << "  --fabric-udm-mode: Fabric UDM mode (DISABLED, ENABLED)" << std::endl;
+    std::cout << "  --initialize-fabric: Initialize fabric configuration" << std::endl;
+    std::cout << "  --mesh-shape: Mesh shape in ROWxCOL or ROW,COL format (e.g., 8x4 or 8,4)" << std::endl;
+    std::cout << "  --terminate-fabric: Terminate fabric configuration" << std::endl;
+    std::cout << "  --help: Print usage information" << std::endl << std::endl;
+    std::cout << "To run on a multi-node cluster, use mpirun with a --hostfile option" << std::endl;
+}
+
+void set_config_vars() {
+    // This tool must be run with slow dispatch mode, since
+    // it manages fabric configuration which shouldn't
+    // be running fabric routers during configuration
+    setenv("TT_METAL_SLOW_DISPATCH_MODE", "1", 1);
+    // Set env vars required by Control Plane when running on a multi-node cluster
+    setenv("TT_MESH_HOST_RANK", "0", 1);
+    setenv("TT_MESH_ID", "0", 1);
+}
+
+}  // namespace tt::scaleout_tools
+
+int main(int argc, char* argv[]) {
+    using namespace tt::scaleout_tools;
+
+    set_config_vars();
+
+    auto input_args = parse_input_args(std::vector<std::string>(argv, argv + argc));
+    if (input_args.help) {
+        print_usage_info();
+        return 0;
+    }
+
+    const auto& distributed_context = tt::tt_metal::MetalContext::instance().global_distributed_context();
+
+    // Parse enums and mesh shape if fabric operations are requested
+    if (input_args.initialize_fabric || input_args.terminate_fabric) {
+        TT_FATAL(
+            input_args.mesh_shape.has_value(),
+            "--mesh-shape is required when using --initialize-fabric or --terminate-fabric");
+
+        // Parse enum values
+        std::optional<tt::tt_fabric::FabricConfig> fabric_config_enum = std::nullopt;
+        if (input_args.fabric_config.has_value()) {
+            fabric_config_enum = enchantum::cast<tt::tt_fabric::FabricConfig>(input_args.fabric_config.value());
+        }
+
+        std::optional<tt::tt_fabric::FabricReliabilityMode> reliability_mode_enum = std::nullopt;
+        if (input_args.reliability_mode.has_value()) {
+            reliability_mode_enum =
+                enchantum::cast<tt::tt_fabric::FabricReliabilityMode>(input_args.reliability_mode.value());
+        }
+
+        std::optional<tt::tt_fabric::FabricTensixConfig> fabric_tensix_config_enum = std::nullopt;
+        if (input_args.fabric_tensix_config.has_value()) {
+            fabric_tensix_config_enum =
+                enchantum::cast<tt::tt_fabric::FabricTensixConfig>(input_args.fabric_tensix_config.value());
+        }
+
+        std::optional<tt::tt_fabric::FabricUDMMode> fabric_udm_mode_enum = std::nullopt;
+        if (input_args.fabric_udm_mode.has_value()) {
+            fabric_udm_mode_enum = enchantum::cast<tt::tt_fabric::FabricUDMMode>(input_args.fabric_udm_mode.value());
+        }
+
+        // Parse mesh shape
+        std::string mesh_shape_str = input_args.mesh_shape.value();
+        size_t delimiter_pos = mesh_shape_str.find('x');
+        if (delimiter_pos == std::string::npos) {
+            delimiter_pos = mesh_shape_str.find(',');
+        }
+        TT_FATAL(
+            delimiter_pos != std::string::npos,
+            "Invalid mesh shape format: {}. Expected format: ROWxCOL or ROW,COL (e.g., 8x4 or 8,4)",
+            mesh_shape_str);
+        uint32_t mesh_width;
+        uint32_t mesh_height;
+        try {
+            mesh_width = std::stoul(mesh_shape_str.substr(0, delimiter_pos));
+            mesh_height = std::stoul(mesh_shape_str.substr(delimiter_pos + 1));
+        } catch (const std::exception& e) {
+            TT_FATAL(false, "Failed to parse mesh shape: {}. Error: {}", mesh_shape_str, e.what());
+        }
+        tt::tt_metal::distributed::MeshShape mesh_shape(mesh_width, mesh_height);
+
+        // Configure fabric if requested
+        if (input_args.initialize_fabric) {
+            configure_fabric_routing(
+                fabric_config_enum,
+                reliability_mode_enum,
+                input_args.num_routing_planes,
+                fabric_tensix_config_enum,
+                fabric_udm_mode_enum,
+                tt::tt_fabric::FabricManagerMode::INIT_FABRIC,
+                mesh_shape,
+                input_args.output_path);
+        }
+
+        if (input_args.terminate_fabric) {
+            configure_fabric_routing(
+                fabric_config_enum,
+                reliability_mode_enum,
+                input_args.num_routing_planes,
+                fabric_tensix_config_enum,
+                fabric_udm_mode_enum,
+                tt::tt_fabric::FabricManagerMode::TERMINATE_FABRIC,
+                mesh_shape,
+                input_args.output_path);
+        }
+    }
+
+    distributed_context.barrier();
+    return 0;
+}

--- a/tools/scaleout/fabric_manager/utils/fabric_manager_utils.cpp
+++ b/tools/scaleout/fabric_manager/utils/fabric_manager_utils.cpp
@@ -1,0 +1,177 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tools/scaleout/fabric_manager/utils/fabric_manager_utils.hpp"
+
+#include <iostream>
+#include <iomanip>
+#include <fstream>
+#include <sstream>
+#include <algorithm>
+#include <chrono>
+
+#include "tests/tt_metal/test_utils/test_common.hpp"
+#include "tt_metal/impl/context/metal_context.hpp"
+#include <tt-metalium/hal.hpp>
+#include <tt-metalium/program.hpp>
+#include <tt-metalium/device.hpp>
+#include <tt-metalium/distributed.hpp>
+#include <tt-metalium/experimental/fabric/fabric.hpp>
+#include <enchantum/enchantum.hpp>
+#include <llrt/tt_cluster.hpp>
+
+namespace tt::scaleout_tools {
+
+// ============================================================================
+// Utility Functions
+// ============================================================================
+
+void log_output_rank(const std::string& message, std::optional<int> rank) {
+    if (rank.has_value()) {
+        if (*rank == *tt::tt_metal::MetalContext::instance().global_distributed_context().rank()) {
+            log_info(tt::LogDistributed, "{}", message);
+        }
+    } else {
+        log_info(tt::LogDistributed, "{}", message);
+    }
+}
+
+// ============================================================================
+// Fabric Configuration Functions
+// ============================================================================
+
+void configure_fabric_routing(
+    const std::optional<tt::tt_fabric::FabricConfig>& fabric_config,
+    const std::optional<tt::tt_fabric::FabricReliabilityMode>& reliability_mode,
+    const std::optional<uint8_t>& num_routing_planes,
+    const std::optional<tt::tt_fabric::FabricTensixConfig>& fabric_tensix_config,
+    const std::optional<tt::tt_fabric::FabricUDMMode>& fabric_udm_mode,
+    const tt::tt_fabric::FabricManagerMode& fabric_manager,
+    const tt::tt_metal::distributed::MeshShape& mesh_shape,
+    const std::filesystem::path& output_path) {
+    log_output_rank("Configuring Fabric Routing");
+
+    // Use provided enum values or defaults
+    tt::tt_fabric::FabricConfig fabric_config_enum = fabric_config.value_or(tt::tt_fabric::FabricConfig::DISABLED);
+    tt::tt_fabric::FabricReliabilityMode reliability_mode_enum =
+        reliability_mode.value_or(tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
+    tt::tt_fabric::FabricTensixConfig fabric_tensix_config_enum =
+        fabric_tensix_config.value_or(tt::tt_fabric::FabricTensixConfig::DISABLED);
+    tt::tt_fabric::FabricUDMMode fabric_udm_mode_enum =
+        fabric_udm_mode.value_or(tt::tt_fabric::FabricUDMMode::DISABLED);
+
+    if (fabric_config.has_value()) {
+        log_output_rank(fmt::format("Setting fabric config to: {}", enchantum::to_string(fabric_config_enum)), 0);
+    }
+    if (reliability_mode.has_value()) {
+        log_output_rank(fmt::format("Setting reliability mode to: {}", enchantum::to_string(reliability_mode_enum)), 0);
+    }
+    if (fabric_tensix_config.has_value()) {
+        log_output_rank(
+            fmt::format("Setting fabric tensix config to: {}", enchantum::to_string(fabric_tensix_config_enum)), 0);
+    }
+    if (fabric_udm_mode.has_value()) {
+        log_output_rank(fmt::format("Setting fabric UDM mode to: {}", enchantum::to_string(fabric_udm_mode_enum)), 0);
+    }
+    log_output_rank(fmt::format("Using mesh shape: {}x{}", mesh_shape[0], mesh_shape[1]), 0);
+
+    tt::tt_fabric::SetFabricConfig(
+        fabric_config_enum,
+        reliability_mode_enum,
+        num_routing_planes,
+        fabric_tensix_config_enum,
+        fabric_udm_mode_enum,
+        fabric_manager);
+
+    tt::tt_metal::distributed::MeshDeviceConfig mesh_device_config(mesh_shape);
+    auto mesh_device = tt::tt_metal::distributed::MeshDevice::create(mesh_device_config);
+    auto status = get_fabric_status();
+    log_fabric_status_to_file(status, output_path);
+    // After mesh_device goes out of scope, routing tables and fabric kernels are kept alive, but metal context is reset
+}
+
+// ============================================================================
+// Fabric Information and Monitoring Functions
+// ============================================================================
+
+void log_fabric_status(const std::filesystem::path& output_path) {
+    auto status = get_fabric_status();
+    log_fabric_status_to_file(status, output_path);
+}
+
+// ============================================================================
+// Fabric Status and Health Functions
+// ============================================================================
+
+FabricStatus get_fabric_status() {
+    FabricStatus status;
+
+    try {
+        auto& context = tt::tt_metal::MetalContext::instance();
+
+        // Get SetFabricConfig parameters from MetalContext
+        status.fabric_config = context.get_fabric_config();
+        status.fabric_configured = (status.fabric_config != tt::tt_fabric::FabricConfig::DISABLED);
+        status.fabric_tensix_config = context.get_fabric_tensix_config();
+        status.fabric_udm_mode = context.get_fabric_udm_mode();
+        status.fabric_manager = context.get_fabric_manager();
+
+        // Print fabric node IDs
+        auto& control_plane = context.get_control_plane();
+        const auto& cluster = tt_metal::MetalContext::instance().get_cluster();
+
+        log_output_rank("Fabric Node IDs:");
+        for (auto chip_id : cluster.all_chip_ids()) {
+            auto fabric_node_id = control_plane.get_fabric_node_id_from_physical_chip_id(chip_id);
+            log_output_rank(fmt::format("  Chip ID: {}, Fabric Node ID: {}", chip_id, fabric_node_id));
+        }
+
+    } catch (const std::exception& e) {
+        log_output_rank("Error getting fabric status: " + std::string(e.what()));
+    }
+
+    return status;
+}
+
+void log_fabric_status_to_file(const FabricStatus& status, const std::filesystem::path& output_path) {
+    std::filesystem::path status_file = output_path / "fabric_status.txt";
+    std::ofstream file(status_file);
+
+    if (file.is_open()) {
+        auto now = std::chrono::system_clock::now();
+        auto time_t = std::chrono::system_clock::to_time_t(now);
+
+        file << "Fabric Status Report" << std::endl;
+        file << "Generated: " << std::put_time(std::localtime(&time_t), "%Y-%m-%d %H:%M:%S") << std::endl;
+        file << "==========================================" << std::endl;
+        file << "Fabric Configured: " << (status.fabric_configured ? "Yes" : "No") << std::endl;
+        file << "Fabric Initialized: " << (status.fabric_initialized ? "Yes" : "No") << std::endl;
+        file << std::endl;
+        file << "SetFabricConfig Parameters:" << std::endl;
+        file << "  Fabric Config: " << enchantum::to_string(status.fabric_config) << std::endl;
+        file << "  Reliability Mode: " << enchantum::to_string(status.reliability_mode) << std::endl;
+        file << "  Num Routing Planes: " << static_cast<int>(status.num_routing_planes) << std::endl;
+        file << "  Fabric Tensix Config: " << enchantum::to_string(status.fabric_tensix_config) << std::endl;
+        file << "  Fabric UDM Mode: " << enchantum::to_string(status.fabric_udm_mode) << std::endl;
+        file << "  Fabric Manager: " << enchantum::to_string(status.fabric_manager) << std::endl;
+        file << std::endl;
+        file << "Additional Status:" << std::endl;
+        file << "  Number of Active Ethernet Channels: " << status.num_active_ethernet_channels << std::endl;
+        file << "  Active Chips: " << status.active_chips.size() << std::endl;
+        for (const auto& chip_id : status.active_chips) {
+            file << "    Chip ID: " << chip_id << std::endl;
+        }
+        file << "  Active Hosts: " << status.active_hosts.size() << std::endl;
+        for (const auto& host : status.active_hosts) {
+            file << "    Host: " << host << std::endl;
+        }
+
+        file.close();
+        log_output_rank("✓ Fabric status written to: " + status_file.string());
+    } else {
+        log_output_rank("✗ Warning: Could not open status file for writing: " + status_file.string());
+    }
+}
+
+}  // namespace tt::scaleout_tools

--- a/tools/scaleout/fabric_manager/utils/fabric_manager_utils.hpp
+++ b/tools/scaleout/fabric_manager/utils/fabric_manager_utils.hpp
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <string>
+#include <vector>
+#include <map>
+#include <unordered_map>
+#include <memory>
+#include <filesystem>
+#include "tt_metal/api/tt-metalium/experimental/fabric/control_plane.hpp"
+#include "tt_metal/api/tt-metalium/experimental/fabric/fabric_types.hpp"
+#include "tt_metal/fabric/physical_system_descriptor.hpp"
+#include "tt_metal/impl/context/metal_context.hpp"
+#include <tt-metalium/mesh_coord.hpp>
+
+namespace tt::scaleout_tools {
+
+// ============================================================================
+// Utility Functions
+// ============================================================================
+
+void log_output_rank(const std::string& message, std::optional<int> rank = std::nullopt);
+
+// ============================================================================
+// Fabric Configuration Functions
+// ============================================================================
+
+void configure_fabric_routing(
+    const std::optional<tt::tt_fabric::FabricConfig>& fabric_config,
+    const std::optional<tt::tt_fabric::FabricReliabilityMode>& reliability_mode,
+    const std::optional<uint8_t>& num_routing_planes,
+    const std::optional<tt::tt_fabric::FabricTensixConfig>& fabric_tensix_config,
+    const std::optional<tt::tt_fabric::FabricUDMMode>& fabric_udm_mode,
+    const tt::tt_fabric::FabricManagerMode& fabric_manager,
+    const tt::tt_metal::distributed::MeshShape& mesh_shape,
+    const std::filesystem::path& output_path);
+
+// ============================================================================
+// Fabric Information and Monitoring Functions
+// ============================================================================
+
+void log_fabric_status(const std::filesystem::path& output_path);
+
+// ============================================================================
+// Fabric Status and Health Functions
+// ============================================================================
+
+struct FabricStatus {
+    bool fabric_configured = false;
+    bool fabric_initialized = false;
+
+    // SetFabricConfig parameters
+    tt::tt_fabric::FabricConfig fabric_config = tt::tt_fabric::FabricConfig::DISABLED;
+    tt::tt_fabric::FabricReliabilityMode reliability_mode =
+        tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE;
+    uint8_t num_routing_planes = 0;
+    tt::tt_fabric::FabricTensixConfig fabric_tensix_config = tt::tt_fabric::FabricTensixConfig::DISABLED;
+    tt::tt_fabric::FabricUDMMode fabric_udm_mode = tt::tt_fabric::FabricUDMMode::DISABLED;
+    tt::tt_fabric::FabricManagerMode fabric_manager = tt::tt_fabric::FabricManagerMode::DEFAULT;
+
+    // Additional status info
+    uint32_t num_active_ethernet_channels = 0;
+    std::vector<std::string> active_hosts;
+    std::vector<tt::ChipId> active_chips;
+};
+
+FabricStatus get_fabric_status();
+void log_fabric_status_to_file(const FabricStatus& status, const std::filesystem::path& output_path);
+
+}  // namespace tt::scaleout_tools

--- a/tt_metal/api/tt-metalium/experimental/fabric/fabric.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/fabric.hpp
@@ -116,13 +116,15 @@ tt::tt_fabric::Topology get_fabric_topology();
  * | num_routing_planes  | Number of routing planes         | optional<uint8_t>      | No       |
  * | fabric_tensix_config| Tensix fabric configuration      | FabricTensixConfig     | No       |
  * | fabric_udm_mode     | Unified DataMovement mode        | FabricUDMMode          | No       |
+ * | fabric_manager      | Fabric manager mode              | FabricManagerMode      | No       |
  */
 void SetFabricConfig(
     FabricConfig fabric_config,
     FabricReliabilityMode reliability_mode = FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE,
     std::optional<uint8_t> num_routing_planes = std::nullopt,
     FabricTensixConfig fabric_tensix_config = FabricTensixConfig::DISABLED,
-    FabricUDMMode fabric_udm_mode = FabricUDMMode::DISABLED);
+    FabricUDMMode fabric_udm_mode = FabricUDMMode::DISABLED,
+    FabricManagerMode fabric_manager = FabricManagerMode::DEFAULT);
 
 FabricConfig GetFabricConfig();
 

--- a/tt_metal/api/tt-metalium/experimental/fabric/fabric_types.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/fabric_types.hpp
@@ -35,6 +35,19 @@ enum class FabricUDMMode : uint32_t {
     ENABLED = 1,
 };
 
+// Fabric manager mode configuration
+enum class FabricManagerMode : uint32_t {
+    INIT_FABRIC = 1 << 0,
+    TERMINATE_FABRIC = 1 << 1,
+    ENABLED = (INIT_FABRIC & TERMINATE_FABRIC),
+    DEFAULT =
+        (INIT_FABRIC |
+         TERMINATE_FABRIC),  // Maintains behaviour of Metal runtime, which fully initializes and terminates fabric
+};
+FabricManagerMode operator|(FabricManagerMode lhs, FabricManagerMode rhs);
+FabricManagerMode operator&(FabricManagerMode lhs, FabricManagerMode rhs);
+bool has_flag(FabricManagerMode flags, FabricManagerMode test_flag);
+
 enum class FabricType {
     MESH = 1 << 0,
     TORUS_X = 1 << 1,  // Connections along mesh_coord[1]

--- a/tt_metal/fabric/fabric.cpp
+++ b/tt_metal/fabric/fabric.cpp
@@ -334,9 +334,10 @@ void SetFabricConfig(
     FabricReliabilityMode reliability_mode,
     std::optional<uint8_t> num_routing_planes,
     FabricTensixConfig fabric_tensix_config,
-    FabricUDMMode fabric_udm_mode) {
+    FabricUDMMode fabric_udm_mode,
+    FabricManagerMode fabric_manager) {
     tt::tt_metal::MetalContext::instance().set_fabric_config(
-        fabric_config, reliability_mode, num_routing_planes, fabric_tensix_config, fabric_udm_mode);
+        fabric_config, reliability_mode, num_routing_planes, fabric_tensix_config, fabric_udm_mode, fabric_manager);
 }
 
 std::optional<eth_chan_directions> get_eth_forwarding_direction(

--- a/tt_metal/fabric/fabric_types.cpp
+++ b/tt_metal/fabric/fabric_types.cpp
@@ -6,6 +6,16 @@
 
 namespace tt::tt_fabric {
 
+FabricManagerMode operator|(FabricManagerMode lhs, FabricManagerMode rhs) {
+    return static_cast<FabricManagerMode>(static_cast<uint32_t>(lhs) | static_cast<uint32_t>(rhs));
+}
+
+FabricManagerMode operator&(FabricManagerMode lhs, FabricManagerMode rhs) {
+    return static_cast<FabricManagerMode>(static_cast<uint32_t>(lhs) & static_cast<uint32_t>(rhs));
+}
+
+bool has_flag(FabricManagerMode flags, FabricManagerMode test) { return (flags & test) == test; }
+
 FabricType operator|(FabricType lhs, FabricType rhs) {
     return static_cast<FabricType>(static_cast<uint32_t>(lhs) | static_cast<uint32_t>(rhs));
 }

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -241,7 +241,9 @@ void MetalContext::initialize(
     }
 
     // Set internal routing for active ethernet cores, this is required for our FW to run
-    cluster_->set_internal_routing_info_for_ethernet_cores(true);
+    if (has_flag(MetalContext::instance().get_fabric_manager(), tt_fabric::FabricManagerMode::INIT_FABRIC)) {
+        cluster_->set_internal_routing_info_for_ethernet_cores(true);
+    }
 
     // Initialize debug tools, reset cores, init FW
     if (dprint_server_) {
@@ -546,9 +548,15 @@ void MetalContext::clear_launch_messages_on_eth_cores(ChipId device_id) {
     };
 
     for (const auto& eth_core : this->get_control_plane().get_active_ethernet_cores(device_id)) {
+        if (!has_flag(MetalContext::instance().get_fabric_manager(), tt_fabric::FabricManagerMode::INIT_FABRIC)) {
+            continue;
+        }
         clear_ethernet_core(eth_core, HalProgrammableCoreType::ACTIVE_ETH);
     }
     for (const auto& eth_core : this->get_control_plane().get_inactive_ethernet_cores(device_id)) {
+        if (!has_flag(MetalContext::instance().get_fabric_manager(), tt_fabric::FabricManagerMode::INIT_FABRIC)) {
+            continue;
+        }
         clear_ethernet_core(eth_core, HalProgrammableCoreType::IDLE_ETH);
     }
 
@@ -608,7 +616,8 @@ void MetalContext::set_fabric_config(
     tt_fabric::FabricReliabilityMode reliability_mode,
     std::optional<uint8_t> num_routing_planes,
     tt_fabric::FabricTensixConfig fabric_tensix_config,
-    tt_fabric::FabricUDMMode fabric_udm_mode) {
+    tt_fabric::FabricUDMMode fabric_udm_mode,
+    tt_fabric::FabricManagerMode fabric_manager) {
     // Changes to fabric force a re-init. TODO: We should supply the fabric config in the same way as the dispatch
     // config, not through this function exposed in the detail API.
     force_reinit_ = true;
@@ -665,6 +674,7 @@ void MetalContext::set_fabric_config(
     // Set the fabric tensix config
     this->set_fabric_tensix_config(fabric_tensix_config);
     this->fabric_udm_mode_ = fabric_udm_mode;
+    this->fabric_manager_ = fabric_manager;
 }
 
 void MetalContext::initialize_fabric_config() {
@@ -705,6 +715,8 @@ void MetalContext::set_fabric_tensix_config(tt_fabric::FabricTensixConfig fabric
 tt_fabric::FabricTensixConfig MetalContext::get_fabric_tensix_config() const { return fabric_tensix_config_; }
 
 tt_fabric::FabricUDMMode MetalContext::get_fabric_udm_mode() const { return fabric_udm_mode_; }
+
+tt_fabric::FabricManagerMode MetalContext::get_fabric_manager() const { return fabric_manager_; }
 
 void MetalContext::construct_control_plane(const std::filesystem::path& mesh_graph_desc_path) {
     if (!logical_mesh_chip_id_to_physical_chip_id_mapping_.empty()) {
@@ -777,40 +789,41 @@ void MetalContext::reset_cores(ChipId device_id) {
     // Assert worker cores + dispatch cores, in case they were in a bad state from before.
     std::unordered_map<ChipId, std::unordered_set<CoreCoord>> device_to_early_exit_cores;
 
-    // Active ethernet
-    if (hal_->get_eth_fw_is_cooperative()) {
-        for (const auto& logical_core : this->get_control_plane().get_active_ethernet_cores(device_id)) {
-            CoreCoord virtual_core =
-                cluster_->get_virtual_coordinate_from_logical_coordinates(device_id, logical_core, CoreType::ETH);
-            if (erisc_app_still_running(device_id, virtual_core)) {
-                log_info(
-                    tt::LogMetal,
-                    "While initializing device {}, active ethernet dispatch core {} detected as still "
-                    "running, issuing exit signal.",
-                    device_id,
-                    virtual_core.str());
-                erisc_send_exit_signal(device_id, virtual_core, false /* is_idle_eth */);
-                device_to_early_exit_cores[device_id].insert(virtual_core);
+    if (has_flag(MetalContext::instance().get_fabric_manager(), tt_fabric::FabricManagerMode::INIT_FABRIC)) {
+        // Active ethernet
+        if (hal_->get_eth_fw_is_cooperative()) {
+            for (const auto& logical_core : this->get_control_plane().get_active_ethernet_cores(device_id)) {
+                CoreCoord virtual_core =
+                    cluster_->get_virtual_coordinate_from_logical_coordinates(device_id, logical_core, CoreType::ETH);
+                if (erisc_app_still_running(device_id, virtual_core)) {
+                    log_info(
+                        tt::LogMetal,
+                        "While initializing device {}, active ethernet dispatch core {} detected as still "
+                        "running, issuing exit signal.",
+                        device_id,
+                        virtual_core.str());
+                    erisc_send_exit_signal(device_id, virtual_core, false /* is_idle_eth */);
+                    device_to_early_exit_cores[device_id].insert(virtual_core);
+                }
             }
-        }
-    } else {
-        for (const auto& logical_core : this->get_control_plane().get_active_ethernet_cores(device_id)) {
-            // Ensure exit to base firmware. Send this before assertion subordinate cores otherwise if we stop the
-            // subordinates we could hang waiting for subordinates to finish
-            CoreCoord virtual_core =
-                cluster_->get_virtual_coordinate_from_logical_coordinates(device_id, logical_core, CoreType::ETH);
-            if (rtoptions_.get_enable_2_erisc_mode()) {
-                erisc_send_exit_signal(
-                    device_id, virtual_core, false /* is_idle_eth */);  // Stop any running erisc kernels
-                llrt::internal_::return_to_base_firmware_and_wait_for_heartbeat(device_id, virtual_core);
+        } else {
+            for (const auto& logical_core : this->get_control_plane().get_active_ethernet_cores(device_id)) {
+                // Ensure exit to base firmware. Send this before assertion subordinate cores otherwise if we stop the
+                // subordinates we could hang waiting for subordinates to finish
+                CoreCoord virtual_core =
+                    cluster_->get_virtual_coordinate_from_logical_coordinates(device_id, logical_core, CoreType::ETH);
+                if (rtoptions_.get_enable_2_erisc_mode()) {
+                    erisc_send_exit_signal(
+                        device_id, virtual_core, false /* is_idle_eth */);  // Stop any running erisc kernels
+                    llrt::internal_::return_to_base_firmware_and_wait_for_heartbeat(device_id, virtual_core);
+                }
+                // Only send reset to subordinate cores
+                // Assert all cores except ERISC0, which is running base firmware.
+                tt::umd::RiscType reset_val = tt::umd::RiscType::ALL_TENSIX & ~tt::umd::RiscType::ERISC0;
+                cluster_->assert_risc_reset_at_core(tt_cxy_pair(device_id, virtual_core), reset_val);
             }
-            // Only send reset to subordinate cores
-            // Assert all cores except ERISC0, which is running base firmware.
-            tt::umd::RiscType reset_val = tt::umd::RiscType::ALL_TENSIX & ~tt::umd::RiscType::ERISC0;
-            cluster_->assert_risc_reset_at_core(tt_cxy_pair(device_id, virtual_core), reset_val);
         }
     }
-
     // Early exiting dispatch cores should show RUN_MSG_DONE when they exit.
     for (auto& id_and_cores : device_to_early_exit_cores) {
         const int timeout_ms = 10000;  // 10 seconds for now
@@ -838,13 +851,15 @@ void MetalContext::reset_cores(ChipId device_id) {
         }
     }
 
-    // Reset idle ethernet cores
-    for (const auto& logical_core : this->get_control_plane().get_inactive_ethernet_cores(device_id)) {
-        CoreCoord virtual_core =
-            cluster_->get_virtual_coordinate_from_logical_coordinates(device_id, logical_core, CoreType::ETH);
-        cluster_->assert_risc_reset_at_core(tt_cxy_pair(device_id, virtual_core), tt::umd::RiscType::ALL);
+    if (has_flag(
+            tt::tt_metal::MetalContext::instance().get_fabric_manager(), tt_fabric::FabricManagerMode::INIT_FABRIC)) {
+        // Reset idle ethernet cores
+        for (const auto& logical_core : this->get_control_plane().get_inactive_ethernet_cores(device_id)) {
+            CoreCoord virtual_core =
+                cluster_->get_virtual_coordinate_from_logical_coordinates(device_id, logical_core, CoreType::ETH);
+            cluster_->assert_risc_reset_at_core(tt_cxy_pair(device_id, virtual_core), tt::umd::RiscType::ALL);
+        }
     }
-
     cluster_->l1_barrier(device_id);
 }
 
@@ -1188,6 +1203,9 @@ void MetalContext::initialize_firmware(
         }
         case HalProgrammableCoreType::ACTIVE_ETH:
         case HalProgrammableCoreType::IDLE_ETH: {
+            if (!has_flag(MetalContext::instance().get_fabric_manager(), tt_fabric::FabricManagerMode::INIT_FABRIC)) {
+                break;
+            }
             const bool is_idle_eth = core_type == HalProgrammableCoreType::IDLE_ETH;
             const bool is_active_eth = !is_idle_eth;
             tt::umd::RiscType reset_val = tt::umd::RiscType::ALL_TENSIX;

--- a/tt_metal/impl/context/metal_context.hpp
+++ b/tt_metal/impl/context/metal_context.hpp
@@ -102,7 +102,8 @@ public:
             tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE,
         std::optional<uint8_t> num_routing_planes = std::nullopt,
         tt_fabric::FabricTensixConfig fabric_tensix_config = tt_fabric::FabricTensixConfig::DISABLED,
-        tt_fabric::FabricUDMMode fabric_udm_mode = tt_fabric::FabricUDMMode::DISABLED);
+        tt_fabric::FabricUDMMode fabric_udm_mode = tt_fabric::FabricUDMMode::DISABLED,
+        tt_fabric::FabricManagerMode fabric_manager = tt_fabric::FabricManagerMode::DEFAULT);
     void initialize_fabric_config();
     void initialize_fabric_tensix_datamover_config();
     tt_fabric::FabricConfig get_fabric_config() const;
@@ -117,6 +118,9 @@ public:
 
     // Fabric UDM mode configuration
     tt_fabric::FabricUDMMode get_fabric_udm_mode() const;
+
+    // Fabric manager mode configuration
+    tt_fabric::FabricManagerMode get_fabric_manager() const;
 
     // This is used to track the current thread's command queue id stack
     using CommandQueueIdStack = std::vector<uint8_t>;
@@ -227,6 +231,7 @@ private:
     uint8_t num_fabric_active_routing_planes_ = 0;
     std::map<tt_fabric::FabricNodeId, ChipId> logical_mesh_chip_id_to_physical_chip_id_mapping_;
     std::optional<std::string> custom_mesh_graph_desc_path_ = std::nullopt;
+    tt_fabric::FabricManagerMode fabric_manager_ = tt_fabric::FabricManagerMode::DEFAULT;
 };
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -309,9 +309,15 @@ void Device::init_command_queue_device() {
         }
     }
     for (const auto& logical_core : this->get_active_ethernet_cores()) {
+        if (!has_flag(MetalContext::instance().get_fabric_manager(), tt_fabric::FabricManagerMode::INIT_FABRIC)) {
+            continue;
+        }
         reset_launch_message_rd_ptr(logical_core, CoreType::ETH);
     }
     for (const auto& logical_core : this->get_inactive_ethernet_cores()) {
+        if (!has_flag(MetalContext::instance().get_fabric_manager(), tt_fabric::FabricManagerMode::INIT_FABRIC)) {
+            continue;
+        }
         reset_launch_message_rd_ptr(logical_core, CoreType::ETH);
     }
     if (watcher_lock) {

--- a/ttnn/cpp/ttnn-nanobind/fabric.cpp
+++ b/ttnn/cpp/ttnn-nanobind/fabric.cpp
@@ -56,6 +56,19 @@ void bind_fabric_api(nb::module_& mod) {
         .value("DISABLED", tt::tt_fabric::FabricUDMMode::DISABLED)
         .value("ENABLED", tt::tt_fabric::FabricUDMMode::ENABLED);
 
+    nb::enum_<tt::tt_fabric::FabricManagerMode>(mod, "FabricManagerMode", R"(
+        Specifies the fabric manager mode configuration.
+        Values:
+            DEFAULT: Fabric is not managed by a separate process (default).
+            ENABLED: Fabric is maintained by a separate fabric manager process.
+            INIT_FABRIC: Initialize the fabric.
+            TERMINATE_FABRIC: Terminate the fabric.
+        )")
+        .value("DEFAULT", tt::tt_fabric::FabricManagerMode::DEFAULT)
+        .value("ENABLED", tt::tt_fabric::FabricManagerMode::ENABLED)
+        .value("INIT_FABRIC", tt::tt_fabric::FabricManagerMode::INIT_FABRIC)
+        .value("TERMINATE_FABRIC", tt::tt_fabric::FabricManagerMode::TERMINATE_FABRIC);
+
     mod.def(
         "set_fabric_config",
         &tt::tt_fabric::SetFabricConfig,
@@ -63,7 +76,8 @@ void bind_fabric_api(nb::module_& mod) {
         nb::arg("reliability_mode") = nb::cast(tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE),
         nb::arg("num_planes") = nb::none(),
         nb::arg("fabric_tensix_config") = nb::cast(tt::tt_fabric::FabricTensixConfig::DISABLED),
-        nb::arg("fabric_udm_mode") = nb::cast(tt::tt_fabric::FabricUDMMode::DISABLED));
+        nb::arg("fabric_udm_mode") = nb::cast(tt::tt_fabric::FabricUDMMode::DISABLED),
+        nb::arg("fabric_manager_mode") = nb::cast(tt::tt_fabric::FabricManagerMode::DEFAULT));
 }
 
 }  // namespace ttnn::fabric

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -145,7 +145,14 @@ from ttnn._ttnn.global_circular_buffer import (
     create_global_circular_buffer,
 )
 
-from ttnn._ttnn.fabric import FabricConfig, FabricReliabilityMode, FabricTensixConfig, set_fabric_config
+from ttnn._ttnn.fabric import (
+    FabricConfig,
+    FabricReliabilityMode,
+    FabricTensixConfig,
+    FabricUDMMode,
+    FabricManagerMode,
+    set_fabric_config,
+)
 
 # Import cluster functions and types
 from ttnn._ttnn import cluster


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/31279)
### Problem description
Initial changes to introduce an offline fabric manager utility.

### What's changed
- Add a SetFabricConfig option to select how MetalContext behaves wrt fabric initializing and teardown.
- Updated some CCL tests to use this. Saves about 10s for fabric init and teardown per process.
- Currently, the tool is a prototype of the functionality needed to support a wider effort for Fabric Manager tool. https://docs.google.com/document/d/1mcwmYcvwFr9DUh6Uj-Z27eUlrGcQv50jqhYcgPn3B4s/edit?tab=t.0#heading=h.fvqznrtra1m9

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes


Multi Host: https://github.com/tenstorrent/tt-metal/actions/runs/20309532140
Galaxy Quick: https://github.com/tenstorrent/tt-metal/actions/runs/20285010476