### PR TITLE
Fix nlp concat heads L2 nightly tests due to missing sub core grid

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_nlp_concat_heads_decode.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_nlp_concat_heads_decode.py
@@ -49,16 +49,15 @@ def run_test_concat_head(
 
     # If the provided input sub core grids has enough cores, use that one for compute otherwise
     # we expect a compute sub core grid which must have at least n_local_heads cores to be provided
-    if input_sub_core_grids is not None and input_sub_core_grids.num_cores() >= n_local_heads:
-        # Use the input sub core grids for compute
+
+    if shard_grid.num_cores() >= n_local_heads:
         sub_core_grids = ttnn.num_cores_to_corerangeset_in_subcoregrids(
-            input_sub_core_grids.bounding_box().start, n_local_heads, input_sub_core_grids, row_wise=True
+            shard_grid.bounding_box().start, n_local_heads, shard_grid, row_wise=True
         )
     else:
-        # Use the compute sub core grids for compute
         assert (
             compute_sub_core_grids is not None
-        ), "compute_sub_core_grids must be provided if input_sub_core_grids has less than n_local_heads cores"
+        ), "compute_sub_core_grids must be provided if shard_grid has less than n_local_heads cores"
         sub_core_grids = compute_sub_core_grids
         assert (
             sub_core_grids.num_cores() >= n_local_heads
@@ -82,6 +81,7 @@ def run_test_concat_head(
     concat_head_input_tt = torch2tt_tensor(concat_head_input, tt_device=None).to(
         device=device, mem_config=SCORES_BATCHED_MM_OUTPUT_MEMCFG
     )
+
     concat_head_output = ttnn.experimental.nlp_concat_heads_decode(
         concat_head_input_tt,
         num_heads=n_local_heads,
@@ -104,7 +104,8 @@ def run_test_concat_head(
 
 @pytest.mark.parametrize(
     "n_local_heads, padded_local_heads, head_dim, batch_size",
-    ((8, 32, 128, 32), (17, 32, 96, 32), (32, 32, 64, 32), (8, 32, 128, 16)),
+    # ((8, 32, 128, 32), (17, 32, 96, 32), (32, 32, 64, 32), (8, 32, 128, 16)),
+    ((17, 32, 96, 32),),
 )
 @pytest.mark.parametrize("mesh_device", [pytest.param((1, 1), id="1x1_grid")], indirect=True)
 def test_concat_head(

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_nlp_concat_heads_decode.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_nlp_concat_heads_decode.py
@@ -104,8 +104,7 @@ def run_test_concat_head(
 
 @pytest.mark.parametrize(
     "n_local_heads, padded_local_heads, head_dim, batch_size",
-    # ((8, 32, 128, 32), (17, 32, 96, 32), (32, 32, 64, 32), (8, 32, 128, 16)),
-    ((17, 32, 96, 32),),
+    ((8, 32, 128, 32), (17, 32, 96, 32), (32, 32, 64, 32), (8, 32, 128, 16)),
 )
 @pytest.mark.parametrize("mesh_device", [pytest.param((1, 1), id="1x1_grid")], indirect=True)
 def test_concat_head(


### PR DESCRIPTION
### Problem description
There were failures in L2 nightly for test_nlp_concat_heads op because we didn't pass sub core grids as a parameter. When passed there was another failure due to the odd test case of 17 heads the sub core grid to core range set api truncated the core range set, so it was trying place 17 shards of output across 16 cores (last core was truncated because of this issue), this PR depends on the fix here (https://github.com/tenstorrent/tt-metal/pull/33597). 

### What's changed
- Fixed the test to pass in a sub core grid

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/19882090384) 
- [x] [L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/runs/19885610030)

Will initiate runs when the sub core grid fix is merged.