### PR TITLE
Add deadlock avoidance for UDM [5/n] 

### DIFF
--- a/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
+++ b/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
@@ -391,6 +391,8 @@ void UDMFabricUnicastCommon(
     std::optional<RoutingDirection> override_initial_direction = std::nullopt,
     std::optional<std::vector<std::pair<CoreCoord, CoreCoord>>> worker_coords_list = std::nullopt);
 
+void UDMFabricUnicastAllToAllCommon(BaseFabricFixture* fixture, NocSendType noc_send_type);
+
 void FabricMulticastCommon(
     BaseFabricFixture* fixture,
     NocSendType noc_send_type,

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/kernels/test_udm_read_receiver_all_to_all.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/kernels/test_udm_read_receiver_all_to_all.cpp
@@ -1,0 +1,99 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dataflow_api.h"
+#include "tests/tt_metal/tt_metal/perf_microbenchmark/common/kernel_utils.hpp"
+#include "tt_metal/fabric/hw/inc/tt_fabric_status.h"
+#include "tests/tt_metal/tt_fabric/fabric_data_movement/kernels/test_udm_utils.hpp"
+#include "tt_metal/fabric/fabric_edm_packet_header.hpp"
+#include <type_traits>
+
+constexpr uint32_t test_results_addr_arg = get_compile_time_arg_val(0);
+constexpr uint32_t test_results_size_bytes = get_compile_time_arg_val(1);
+tt_l1_ptr uint32_t* const test_results = reinterpret_cast<tt_l1_ptr uint32_t*>(test_results_addr_arg);
+constexpr uint32_t notification_mailbox_address = get_compile_time_arg_val(2);
+constexpr uint32_t target_address_base = get_compile_time_arg_val(3);
+constexpr NocSendType noc_send_type = static_cast<NocSendType>(get_compile_time_arg_val(4));
+constexpr uint16_t packet_payload_size_bytes = static_cast<uint16_t>(get_compile_time_arg_val(5));
+constexpr uint32_t num_packets = get_compile_time_arg_val(6);
+constexpr uint32_t time_seed_init = get_compile_time_arg_val(7);
+constexpr uint32_t req_notification_size_bytes = get_compile_time_arg_val(8);
+// Total number of devices in the mesh
+constexpr uint32_t num_devices = get_compile_time_arg_val(9);
+// Per-reader L1 region size
+constexpr uint32_t per_reader_l1_size = get_compile_time_arg_val(10);
+// This data provider's device index - skip this slot (no one reads from self)
+constexpr uint32_t provider_device_idx = get_compile_time_arg_val(11);
+
+/*
+ * All-to-all read receiver (data provider) kernel.
+ * Fills L1 with data for all readers (N-1 readers).
+ * Uses simple indexing: slot i contains data for reader device i.
+ * Skips slot = provider_device_idx (no one reads from self).
+ *
+ * Runtime args: for each reader: (noc_x, noc_y, dst_dev_id, dst_mesh_id)
+ */
+void kernel_main() {
+    tt::tt_fabric::udm::fabric_local_state_init();
+
+    zero_l1_buf(test_results, test_results_size_bytes);
+    test_results[TT_FABRIC_STATUS_INDEX] = TT_FABRIC_STATUS_STARTED;
+
+    uint64_t bytes_filled = 0;
+
+    // Fill data for each reader using simple indexing
+    // Slot i contains data for reader device i
+    for (uint32_t reader_idx = 0; reader_idx < num_devices; reader_idx++) {
+        if (reader_idx == provider_device_idx) {
+            continue;  // Skip self - no one reads from their own device
+        }
+
+        // Calculate L1 address for this reader's data
+        uint32_t target_address = target_address_base + reader_idx * per_reader_l1_size;
+
+        // Use time_seed offset by reader_idx for unique data per reader
+        uint32_t time_seed = time_seed_init + reader_idx;
+
+        // Fill all packets for this reader
+        for (uint32_t i = 0; i < num_packets; i++) {
+            time_seed = prng_next(time_seed);
+
+            uint32_t curr_local_data_addr = target_address + (i * packet_payload_size_bytes);
+            tt_l1_ptr uint32_t* buffer_addr = reinterpret_cast<tt_l1_ptr uint32_t*>(curr_local_data_addr);
+            fill_packet_data(buffer_addr, packet_payload_size_bytes / 16, time_seed);
+
+            bytes_filled += packet_payload_size_bytes;
+        }
+    }
+
+    // Notify all readers that data is ready
+    // Runtime args: for each reader: (noc_x, noc_y, dst_dev_id, dst_mesh_id)
+    uint32_t arg_index = 0;
+    uint32_t num_readers = num_devices - 1;  // All devices except self
+    for (uint32_t reader = 0; reader < num_readers; reader++) {
+        uint32_t noc_x = get_arg_val<uint32_t>(arg_index++);
+        uint32_t noc_y = get_arg_val<uint32_t>(arg_index++);
+        uint32_t dst_dev_id = get_arg_val<uint32_t>(arg_index++);
+        uint32_t dst_mesh_id = get_arg_val<uint32_t>(arg_index++);
+
+        uint32_t local_notification_buffer_addr = notification_mailbox_address;
+        uint32_t remote_notification_dest_addr = notification_mailbox_address;
+
+        notify_receiver(
+            dst_dev_id,
+            dst_mesh_id,
+            noc_x,
+            noc_y,
+            local_notification_buffer_addr,
+            remote_notification_dest_addr,
+            time_seed_init,
+            req_notification_size_bytes);
+    }
+
+    tt::tt_fabric::udm::close_fabric_connection();
+
+    test_results[TT_FABRIC_STATUS_INDEX] = TT_FABRIC_STATUS_PASS;
+    test_results[TT_FABRIC_WORD_CNT_INDEX] = (uint32_t)bytes_filled;
+    test_results[TT_FABRIC_WORD_CNT_INDEX + 1] = bytes_filled >> 32;
+}

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/kernels/test_udm_read_sender_all_to_all.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/kernels/test_udm_read_sender_all_to_all.cpp
@@ -1,0 +1,134 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tt_metal/fabric/hw/inc/tt_fabric_status.h"
+#include "tests/tt_metal/tt_fabric/fabric_data_movement/kernels/test_udm_utils.hpp"
+
+constexpr uint32_t test_results_addr_arg = get_compile_time_arg_val(0);
+constexpr uint32_t test_results_size_bytes = get_compile_time_arg_val(1);
+tt_l1_ptr uint32_t* const test_results = reinterpret_cast<tt_l1_ptr uint32_t*>(test_results_addr_arg);
+constexpr uint32_t notification_mailbox_address = get_compile_time_arg_val(2);
+constexpr uint32_t target_address_base = get_compile_time_arg_val(3);
+constexpr NocSendType noc_send_type = static_cast<NocSendType>(get_compile_time_arg_val(4));
+constexpr uint32_t source_l1_buffer_address = get_compile_time_arg_val(5);
+constexpr uint16_t packet_payload_size_bytes = static_cast<uint16_t>(get_compile_time_arg_val(6));
+constexpr uint32_t num_packets = get_compile_time_arg_val(7);
+constexpr uint32_t time_seed_init = get_compile_time_arg_val(8);
+constexpr uint32_t req_notification_size_bytes = get_compile_time_arg_val(9);
+// Per-reader L1 region size on data provider
+constexpr uint32_t per_reader_l1_size = get_compile_time_arg_val(10);
+// Number of data providers to read from (N-1 for all-to-all)
+constexpr uint32_t num_providers = get_compile_time_arg_val(11);
+// This reader's device index - used directly as L1 slot index on data providers
+constexpr uint32_t reader_device_idx = get_compile_time_arg_val(12);
+
+/*
+ * All-to-all read sender (reader) kernel.
+ * Issues fabric read requests to all other devices.
+ * Uses simple indexing: reads from slot = reader_device_idx on all data providers.
+ *
+ * Runtime args: for each provider: (noc_x, noc_y, dst_dev_id, dst_mesh_id)
+ */
+void kernel_main() {
+    tt::tt_fabric::udm::fabric_local_state_init();
+
+    zero_l1_buf(test_results, test_results_size_bytes);
+    test_results[TT_FABRIC_STATUS_INDEX] = TT_FABRIC_STATUS_STARTED;
+
+    uint64_t start_timestamp = get_timestamp();
+    uint64_t total_bytes_read = 0;
+    bool match = true;
+    uint32_t mismatch_addr, mismatch_val, expected_val;
+
+    // This reader always reads from slot = reader_device_idx on data providers
+    uint32_t remote_read_addr_base = target_address_base + reader_device_idx * per_reader_l1_size;
+
+    // Use time_seed offset by reader_device_idx for expected data validation
+    uint32_t time_seed_base = time_seed_init + reader_device_idx;
+
+    // Runtime args: for each provider: (noc_x, noc_y, dst_dev_id, dst_mesh_id)
+    uint32_t arg_index = 0;
+
+    // Loop over all data providers
+    for (uint32_t prov = 0; prov < num_providers; prov++) {
+        uint32_t noc_x_start = get_arg_val<uint32_t>(arg_index++);
+        uint32_t noc_y_start = get_arg_val<uint32_t>(arg_index++);
+        uint32_t dst_dev_id = get_arg_val<uint32_t>(arg_index++);
+        uint32_t dst_mesh_id = get_arg_val<uint32_t>(arg_index++);
+
+        uint32_t remote_read_addr = remote_read_addr_base;
+        uint32_t local_read_addr = source_l1_buffer_address;
+        uint32_t time_seed = time_seed_base;
+
+        // Wait for notification from this data provider that data is ready
+        volatile tt_l1_ptr PACKET_HEADER_TYPE* received_header =
+            wait_for_notification(notification_mailbox_address, time_seed_init, req_notification_size_bytes);
+
+        for (uint32_t i = 0; i < num_packets; i++) {
+            time_seed = prng_next(time_seed);
+
+            switch (noc_send_type) {
+                case NOC_UNICAST_READ: {
+                    // Issue a read request to the remote device
+                    tt::tt_fabric::udm::fabric_fast_read_any_len(
+                        dst_dev_id,
+                        dst_mesh_id,
+                        get_noc_addr(noc_x_start, noc_y_start, remote_read_addr),
+                        local_read_addr,
+                        packet_payload_size_bytes);
+
+                    // Wait for the read to complete
+                    tt::tt_fabric::udm::fabric_read_barrier();
+
+                    // Check the received data
+                    match = check_packet_data(
+                        reinterpret_cast<tt_l1_ptr uint32_t*>(local_read_addr),
+                        packet_payload_size_bytes / 16,
+                        time_seed,
+                        mismatch_addr,
+                        mismatch_val,
+                        expected_val);
+
+                    if (!match) {
+                        DPRINT << "Data mismatch at provider " << prov << " packet " << i << "\n";
+                        DPRINT << "  Mismatch addr: " << mismatch_addr << "\n";
+                        DPRINT << "  Mismatch val: " << mismatch_val << "\n";
+                        DPRINT << "  Expected val: " << expected_val << "\n";
+                    }
+                } break;
+                default: {
+                    ASSERT(false);
+                } break;
+            }
+            if (!match) {
+                break;
+            }
+            noc_async_writes_flushed();
+            remote_read_addr += packet_payload_size_bytes;
+            local_read_addr += packet_payload_size_bytes;
+        }
+
+        total_bytes_read += packet_payload_size_bytes * num_packets;
+    }
+
+    tt::tt_fabric::udm::close_fabric_connection();
+
+    uint64_t cycles_elapsed = get_timestamp() - start_timestamp;
+
+    noc_async_write_barrier();
+
+    if (!match) {
+        test_results[TT_FABRIC_STATUS_INDEX] = TT_FABRIC_STATUS_DATA_MISMATCH;
+        test_results[TT_FABRIC_MISC_INDEX + 12] = mismatch_addr;
+        test_results[TT_FABRIC_MISC_INDEX + 13] = mismatch_val;
+        test_results[TT_FABRIC_MISC_INDEX + 14] = expected_val;
+    } else {
+        test_results[TT_FABRIC_STATUS_INDEX] = TT_FABRIC_STATUS_PASS;
+    }
+
+    test_results[TT_FABRIC_CYCLES_INDEX] = (uint32_t)cycles_elapsed;
+    test_results[TT_FABRIC_CYCLES_INDEX + 1] = cycles_elapsed >> 32;
+    test_results[TT_FABRIC_WORD_CNT_INDEX] = (uint32_t)total_bytes_read;
+    test_results[TT_FABRIC_WORD_CNT_INDEX + 1] = total_bytes_read >> 32;
+}

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/kernels/test_udm_receiver_all_to_all.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/kernels/test_udm_receiver_all_to_all.cpp
@@ -1,0 +1,140 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dataflow_api.h"
+#include "tests/tt_metal/tt_metal/perf_microbenchmark/common/kernel_utils.hpp"
+#include "tt_metal/fabric/hw/inc/tt_fabric_status.h"
+#include "tests/tt_metal/tt_fabric/fabric_data_movement/kernels/test_udm_utils.hpp"
+#include "tt_metal/fabric/fabric_edm_packet_header.hpp"
+#include <type_traits>
+
+constexpr uint32_t test_results_addr_arg = get_compile_time_arg_val(0);
+constexpr uint32_t test_results_size_bytes = get_compile_time_arg_val(1);
+tt_l1_ptr uint32_t* const test_results = reinterpret_cast<tt_l1_ptr uint32_t*>(test_results_addr_arg);
+constexpr uint32_t notification_mailbox_address = get_compile_time_arg_val(2);
+constexpr uint32_t target_address_base = get_compile_time_arg_val(3);
+constexpr NocSendType noc_send_type = static_cast<NocSendType>(get_compile_time_arg_val(4));
+constexpr uint16_t packet_payload_size_bytes = static_cast<uint16_t>(get_compile_time_arg_val(5));
+constexpr uint32_t num_packets = get_compile_time_arg_val(6);
+constexpr uint32_t time_seed_init = get_compile_time_arg_val(7);
+constexpr uint32_t req_notification_size_bytes = get_compile_time_arg_val(8);
+// Total number of devices in the mesh
+constexpr uint32_t num_devices = get_compile_time_arg_val(9);
+// Per-sender L1 region size
+constexpr uint32_t per_sender_l1_size = get_compile_time_arg_val(10);
+// This receiver's device index - skip this slot (no one sends to self)
+constexpr uint32_t receiver_device_idx = get_compile_time_arg_val(11);
+
+// Helper function to poll for a value at a specific L1 address
+inline void poll_for_value(volatile tt_l1_ptr uint32_t* poll_addr, uint32_t expected_val) {
+    WAYPOINT("FPW");
+    while (expected_val != *poll_addr) {
+        invalidate_l1_cache();
+    }
+    WAYPOINT("FPD");
+}
+
+/*
+ * All-to-all receiver kernel.
+ * Receives packets from all other devices (N-1 senders).
+ * Uses simple indexing: slot i contains data from sender device i.
+ * Skips slot = receiver_device_idx (no one sends to self).
+ */
+void kernel_main() {
+    tt::tt_fabric::udm::fabric_local_state_init();
+
+    zero_l1_buf(test_results, test_results_size_bytes);
+    test_results[TT_FABRIC_STATUS_INDEX] = TT_FABRIC_STATUS_STARTED;
+
+    uint32_t mismatch_addr, mismatch_val, expected_val;
+    bool match = true;
+    uint64_t bytes_received = 0;
+
+    // Loop through all device slots, skip our own
+    for (uint32_t sender_idx = 0; sender_idx < num_devices; sender_idx++) {
+        if (sender_idx == receiver_device_idx) {
+            continue;  // Skip self - no one sends to their own device
+        }
+
+        // Calculate L1 address for this sender's data
+        uint32_t target_address = target_address_base + sender_idx * per_sender_l1_size;
+
+        // Use time_seed offset by sender_idx for expected data validation
+        uint32_t time_seed = time_seed_init + sender_idx;
+
+        tt_l1_ptr uint32_t* start_addr = reinterpret_cast<tt_l1_ptr uint32_t*>(target_address);
+        volatile tt_l1_ptr uint32_t* poll_addr =
+            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(target_address + packet_payload_size_bytes - 4);
+
+        // Process packets from this sender
+        for (uint32_t i = 0; i < num_packets; i++) {
+            time_seed = prng_next(time_seed);
+
+            switch (noc_send_type) {
+                case NOC_UNICAST_WRITE: {
+                    // Wait for the packet data to arrive by polling on the last word
+                    expected_val = time_seed + (packet_payload_size_bytes / 16) - 1;
+                    poll_for_value(poll_addr, expected_val);
+
+                    // Check for data correctness
+                    match = check_packet_data(
+                        start_addr,
+                        packet_payload_size_bytes / 16,
+                        time_seed,
+                        mismatch_addr,
+                        mismatch_val,
+                        expected_val);
+                } break;
+                case NOC_UNICAST_INLINE_WRITE: {
+                    // Wait for the inline write to arrive by polling on the value
+                    expected_val = time_seed;
+                    poll_for_value(start_addr, expected_val);
+
+                    // Check data correctness for a single uint32_t
+                    uint32_t received_value = *start_addr;
+                    if (received_value != expected_val) {
+                        match = false;
+                        mismatch_addr = reinterpret_cast<uint32_t>(start_addr);
+                        mismatch_val = received_value;
+                    }
+                } break;
+                case NOC_UNICAST_ATOMIC_INC: {
+                    // Wait for the atomic increment to arrive by polling on the value
+                    expected_val = time_seed;
+                    poll_for_value(start_addr, expected_val);
+
+                    uint32_t received_value = *start_addr;
+                    if (received_value != expected_val) {
+                        match = false;
+                        mismatch_addr = reinterpret_cast<uint32_t>(start_addr);
+                        mismatch_val = received_value;
+                    }
+                } break;
+                default: {
+                    ASSERT(false);
+                } break;
+            }
+            if (!match) {
+                break;
+            }
+            start_addr += packet_payload_size_bytes / 4;
+            poll_addr += packet_payload_size_bytes / 4;
+            bytes_received += packet_payload_size_bytes;
+        }
+    }
+
+    tt::tt_fabric::udm::close_fabric_connection();
+
+    if (!match) {
+        test_results[TT_FABRIC_STATUS_INDEX] = TT_FABRIC_STATUS_DATA_MISMATCH;
+        test_results[TT_FABRIC_MISC_INDEX + 12] = mismatch_addr;
+        test_results[TT_FABRIC_MISC_INDEX + 13] = mismatch_val;
+        test_results[TT_FABRIC_MISC_INDEX + 14] = expected_val;
+    } else {
+        test_results[TT_FABRIC_STATUS_INDEX] = TT_FABRIC_STATUS_PASS;
+    }
+
+    test_results[TT_FABRIC_WORD_CNT_INDEX] = (uint32_t)bytes_received;
+    test_results[TT_FABRIC_WORD_CNT_INDEX + 1] = bytes_received >> 32;
+}

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/kernels/test_udm_sender_all_to_all.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/kernels/test_udm_sender_all_to_all.cpp
@@ -1,0 +1,127 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tt_metal/fabric/hw/inc/tt_fabric_status.h"
+#include "tests/tt_metal/tt_fabric/fabric_data_movement/kernels/test_udm_utils.hpp"
+
+constexpr uint32_t test_results_addr_arg = get_compile_time_arg_val(0);
+constexpr uint32_t test_results_size_bytes = get_compile_time_arg_val(1);
+tt_l1_ptr uint32_t* const test_results = reinterpret_cast<tt_l1_ptr uint32_t*>(test_results_addr_arg);
+constexpr uint32_t notification_mailbox_address = get_compile_time_arg_val(2);
+constexpr uint32_t target_address_base = get_compile_time_arg_val(3);
+constexpr NocSendType noc_send_type = static_cast<NocSendType>(get_compile_time_arg_val(4));
+constexpr uint32_t source_l1_buffer_address = get_compile_time_arg_val(5);
+constexpr uint16_t packet_payload_size_bytes = static_cast<uint16_t>(get_compile_time_arg_val(6));
+constexpr uint32_t num_packets = get_compile_time_arg_val(7);
+constexpr uint32_t time_seed_init = get_compile_time_arg_val(8);
+constexpr uint32_t req_notification_size_bytes = get_compile_time_arg_val(9);
+// Per-sender L1 region size on receiver
+constexpr uint32_t per_sender_l1_size = get_compile_time_arg_val(10);
+// Number of destinations (N-1 for all-to-all)
+constexpr uint32_t num_destinations = get_compile_time_arg_val(11);
+// This sender's device index - used directly as L1 slot index on receivers
+constexpr uint32_t sender_device_idx = get_compile_time_arg_val(12);
+
+/*
+ * All-to-all sender kernel.
+ * Sends packets to all other devices.
+ * Uses simple indexing: sender device N writes to slot N on all receivers.
+ *
+ * Runtime args: for each destination: (noc_x, noc_y, dst_dev_id, dst_mesh_id)
+ */
+void kernel_main() {
+    tt::tt_fabric::udm::fabric_local_state_init();
+
+    zero_l1_buf(test_results, test_results_size_bytes);
+    test_results[TT_FABRIC_STATUS_INDEX] = TT_FABRIC_STATUS_STARTED;
+
+    uint64_t start_timestamp = get_timestamp();
+    uint64_t total_bytes_sent = 0;
+
+    // This sender always writes to slot = sender_device_idx on receivers
+    uint32_t target_address = target_address_base + sender_device_idx * per_sender_l1_size;
+
+    // Use time_seed offset by sender_device_idx for unique data per sender
+    uint32_t time_seed_base = time_seed_init + sender_device_idx;
+
+    // Runtime args: for each destination: (noc_x, noc_y, dst_dev_id, dst_mesh_id)
+    uint32_t arg_index = 0;
+
+    // Loop over all destinations
+    for (uint32_t dest = 0; dest < num_destinations; dest++) {
+        uint32_t noc_x_start = get_arg_val<uint32_t>(arg_index++);
+        uint32_t noc_y_start = get_arg_val<uint32_t>(arg_index++);
+        uint32_t dst_dev_id = get_arg_val<uint32_t>(arg_index++);
+        uint32_t dst_mesh_id = get_arg_val<uint32_t>(arg_index++);
+
+        uint32_t time_seed = time_seed_base;
+        uint32_t current_target_address = target_address;
+
+        for (uint32_t i = 0; i < num_packets; i++) {
+            time_seed = prng_next(time_seed);
+
+            tt_l1_ptr uint32_t* start_addr = reinterpret_cast<tt_l1_ptr uint32_t*>(source_l1_buffer_address);
+            fill_packet_data(start_addr, packet_payload_size_bytes / 16, time_seed);
+
+            switch (noc_send_type) {
+                case NOC_UNICAST_WRITE: {
+                    tt::tt_fabric::udm::fabric_fast_write_any_len(
+                        dst_dev_id,
+                        dst_mesh_id,
+                        source_l1_buffer_address,
+                        get_noc_addr(noc_x_start, noc_y_start, current_target_address),
+                        packet_payload_size_bytes);
+                } break;
+                case NOC_UNICAST_INLINE_WRITE: {
+                    uint32_t inline_value = time_seed;
+                    tt::tt_fabric::udm::fabric_fast_write_dw_inline(
+                        dst_dev_id,
+                        dst_mesh_id,
+                        inline_value,
+                        get_noc_addr(noc_x_start, noc_y_start, current_target_address));
+                } break;
+                case NOC_UNICAST_ATOMIC_INC: {
+                    uint32_t incr_value = time_seed;
+                    tt::tt_fabric::udm::fabric_fast_atomic_inc(
+                        dst_dev_id,
+                        dst_mesh_id,
+                        incr_value,
+                        get_noc_addr(noc_x_start, noc_y_start, current_target_address));
+                } break;
+                default: {
+                    ASSERT(false);
+                } break;
+            }
+
+            switch (noc_send_type) {
+                case NOC_UNICAST_WRITE:
+                case NOC_UNICAST_INLINE_WRITE: {
+                    tt::tt_fabric::udm::fabric_write_barrier();
+                } break;
+                case NOC_UNICAST_ATOMIC_INC: {
+                    tt::tt_fabric::udm::fabric_atomic_barrier();
+                } break;
+                default: {
+                    ASSERT(false);
+                } break;
+            }
+            noc_async_writes_flushed();
+            current_target_address += packet_payload_size_bytes;
+        }
+
+        total_bytes_sent += packet_payload_size_bytes * num_packets;
+    }
+
+    tt::tt_fabric::udm::close_fabric_connection();
+
+    uint64_t cycles_elapsed = get_timestamp() - start_timestamp;
+
+    noc_async_write_barrier();
+
+    test_results[TT_FABRIC_STATUS_INDEX] = TT_FABRIC_STATUS_PASS;
+    test_results[TT_FABRIC_CYCLES_INDEX] = (uint32_t)cycles_elapsed;
+    test_results[TT_FABRIC_CYCLES_INDEX + 1] = cycles_elapsed >> 32;
+    test_results[TT_FABRIC_WORD_CNT_INDEX] = (uint32_t)total_bytes_sent;
+    test_results[TT_FABRIC_WORD_CNT_INDEX + 1] = total_bytes_sent >> 32;
+}

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
@@ -2533,7 +2533,7 @@ void UDMFabricUnicastAllToAllCommon(BaseFabricFixture* fixture, NocSendType noc_
     for (size_t i = 0; i < NUM_DEVICES; i++) {
         FabricNodeId fabric_node_id(MeshId{0}, static_cast<uint32_t>(i));
         ChipId physical_device_id = control_plane.get_physical_chip_id_from_fabric_node_id(fabric_node_id);
-        auto device_ptr = fixture->get_device(physical_device_id);
+        const auto& device_ptr = fixture->get_device(physical_device_id);
         if (!device_ptr) {
             continue;
         }
@@ -2583,7 +2583,7 @@ void UDMFabricUnicastAllToAllCommon(BaseFabricFixture* fixture, NocSendType noc_
     // Check if receiver has enough L1 space for N device slots (simple indexing: slot i for device i)
     // Note: slot receiver_device_idx is unused but we allocate it for simplicity
     uint32_t total_receiver_l1_needed = static_cast<uint32_t>(num_active_devices) * per_sender_l1_size;
-    auto& hal = tt_metal::MetalContext::instance().hal();
+    const auto& hal = tt_metal::MetalContext::instance().hal();
     uint32_t l1_base = hal.get_dev_addr(
         tt::tt_metal::HalProgrammableCoreType::TENSIX, tt::tt_metal::HalL1MemAddrType::DEFAULT_UNRESERVED);
     uint32_t l1_size = hal.get_dev_size(
@@ -2617,6 +2617,7 @@ void UDMFabricUnicastAllToAllCommon(BaseFabricFixture* fixture, NocSendType noc_
 
     // Create programs for each device (each device has both sender and receiver programs)
     std::vector<tt_metal::Program> programs;
+    programs.reserve(num_active_devices);
     for (size_t dev_idx = 0; dev_idx < num_active_devices; dev_idx++) {
         programs.push_back(tt_metal::CreateProgram());
     }

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
@@ -2506,6 +2506,349 @@ void UDMFabricUnicastCommon(
     }
 }
 
+void UDMFabricUnicastAllToAllCommon(BaseFabricFixture* fixture, NocSendType noc_send_type) {
+    // All-to-all test: all devices send to all other devices simultaneously
+    // Sender cores are in the top half of compute grid, receiver cores are in the bottom half
+    // Each receiver core receives from N-1 senders (one from each other device)
+    // Each sender writes to a different L1 address offset on the receiver based on sender_device_idx
+
+    auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+    const auto& devices = fixture->get_devices();
+    const size_t NUM_DEVICES = devices.size();
+
+    if (NUM_DEVICES < 2) {
+        GTEST_SKIP() << "Test requires at least 2 devices";
+    }
+
+    const auto topology = control_plane.get_fabric_context().get_fabric_topology();
+
+    // Get compute grid size from first device
+    auto grid_size = devices[0]->get_devices()[0]->compute_with_storage_grid_size();
+
+    // Split grid into top half (senders) and bottom half (receivers)
+    uint32_t receiver_y_start = grid_size.y / 2;
+
+    if (receiver_y_start == 0 || receiver_y_start >= grid_size.y) {
+        GTEST_SKIP() << "Compute grid too small to split into sender/receiver halves";
+    }
+
+    // Receiver core at (0, receiver_y_start) - single receiver core per device
+    CoreCoord receiver_logical_core = {0, receiver_y_start};
+
+    uint32_t num_packets = 10;
+    uint32_t time_seed = std::chrono::system_clock::now().time_since_epoch().count();
+
+    // Get device info and create programs
+    std::vector<FabricNodeId> fabric_node_ids;
+    std::vector<ChipId> physical_device_ids;
+    std::vector<std::shared_ptr<tt::tt_metal::distributed::MeshDevice>> device_ptrs;
+
+    for (size_t i = 0; i < NUM_DEVICES; i++) {
+        FabricNodeId fabric_node_id(MeshId{0}, static_cast<uint32_t>(i));
+        ChipId physical_device_id = control_plane.get_physical_chip_id_from_fabric_node_id(fabric_node_id);
+        auto device_ptr = fixture->get_device(physical_device_id);
+        if (!device_ptr) {
+            continue;
+        }
+        fabric_node_ids.push_back(fabric_node_id);
+        physical_device_ids.push_back(physical_device_id);
+        device_ptrs.push_back(device_ptr);
+    }
+
+    const size_t num_active_devices = device_ptrs.size();
+    if (num_active_devices < 2) {
+        GTEST_SKIP() << "Not enough active devices for all-to-all test";
+    }
+
+    const uint32_t num_other_devices = static_cast<uint32_t>(num_active_devices - 1);
+
+    // Calculate number of sender/receiver cores per device (all cores in top/bottom half)
+    uint32_t sender_rows = receiver_y_start;                  // Number of rows in top half
+    uint32_t receiver_rows = grid_size.y - receiver_y_start;  // Number of rows in bottom half
+    uint32_t num_sender_cores = sender_rows * grid_size.x;
+    uint32_t num_receiver_cores = receiver_rows * grid_size.x;
+    // Use the minimum as the number of sender-receiver pairs
+    uint32_t num_core_pairs = std::min(num_sender_cores, num_receiver_cores);
+
+    log_info(
+        tt::LogTest,
+        "All-to-all test: {} devices, {} sender-receiver pairs per device, sending to {} other devices",
+        num_active_devices,
+        num_core_pairs,
+        num_other_devices);
+
+    auto worker_mem_map = generate_worker_mem_map(device_ptrs[0], topology);
+
+    if (noc_send_type == NOC_UNICAST_INLINE_WRITE or noc_send_type == NOC_UNICAST_ATOMIC_INC) {
+        worker_mem_map.packet_payload_size_bytes = 16;  // l1 aligned
+    } else {
+        auto single_payload_size_bytes = worker_mem_map.packet_payload_size_bytes;
+        worker_mem_map.packet_payload_size_bytes = single_payload_size_bytes * 2 - 16;
+    }
+
+    // Per-sender L1 region size on receiver
+    uint32_t per_sender_l1_size = num_packets * worker_mem_map.packet_payload_size_bytes;
+
+    // Check if receiver has enough L1 space for N device slots (simple indexing: slot i for device i)
+    // Note: slot receiver_device_idx is unused but we allocate it for simplicity
+    uint32_t total_receiver_l1_needed = static_cast<uint32_t>(num_active_devices) * per_sender_l1_size;
+    auto& hal = tt_metal::MetalContext::instance().hal();
+    uint32_t l1_base = hal.get_dev_addr(
+        tt::tt_metal::HalProgrammableCoreType::TENSIX, tt::tt_metal::HalL1MemAddrType::DEFAULT_UNRESERVED);
+    uint32_t l1_size = hal.get_dev_size(
+        tt::tt_metal::HalProgrammableCoreType::TENSIX, tt::tt_metal::HalL1MemAddrType::DEFAULT_UNRESERVED);
+    uint32_t l1_end = l1_base + l1_size;
+    if (worker_mem_map.target_address + total_receiver_l1_needed > l1_end) {
+        GTEST_SKIP() << "Not enough L1 space on receiver for " << num_other_devices << " senders. Need "
+                     << total_receiver_l1_needed << " bytes starting at " << worker_mem_map.target_address
+                     << ", but L1 ends at " << l1_end;
+    }
+
+    constexpr uint32_t req_notification_size_bytes = 128;
+
+    // Determine kernel paths based on operation type
+    const bool is_read = (noc_send_type == NOC_UNICAST_READ);
+    const char* sender_kernel_path =
+        is_read ? "tests/tt_metal/tt_fabric/fabric_data_movement/kernels/test_udm_read_sender_all_to_all.cpp"
+                : "tests/tt_metal/tt_fabric/fabric_data_movement/kernels/test_udm_sender_all_to_all.cpp";
+    const char* receiver_kernel_path =
+        is_read ? "tests/tt_metal/tt_fabric/fabric_data_movement/kernels/test_udm_read_receiver_all_to_all.cpp"
+                : "tests/tt_metal/tt_fabric/fabric_data_movement/kernels/test_udm_receiver_all_to_all.cpp";
+
+    // Create programs for each device (each device has both sender and receiver programs)
+    std::vector<tt_metal::Program> sender_programs;
+    std::vector<tt_metal::Program> receiver_programs;
+
+    for (size_t dev_idx = 0; dev_idx < num_active_devices; dev_idx++) {
+        sender_programs.push_back(tt_metal::CreateProgram());
+        receiver_programs.push_back(tt_metal::CreateProgram());
+    }
+
+    // Create sender and receiver kernels for each device
+    for (size_t dev_idx = 0; dev_idx < num_active_devices; dev_idx++) {
+        const auto& device_ptr = device_ptrs[dev_idx];
+
+        // This device's index - used directly as L1 slot index (simple indexing)
+        uint32_t this_device_idx = static_cast<uint32_t>(dev_idx);
+
+        // Sender compile time args - includes num_destinations and sender_device_idx
+        std::vector<uint32_t> sender_compile_time_args = {
+            worker_mem_map.test_results_address,
+            worker_mem_map.test_results_size_bytes,
+            worker_mem_map.notification_mailbox_address,
+            worker_mem_map.target_address,  // target_address_base
+            noc_send_type,
+            worker_mem_map.source_l1_buffer_address,
+            worker_mem_map.packet_payload_size_bytes,
+            num_packets,
+            time_seed,
+            req_notification_size_bytes,
+            per_sender_l1_size,  // per_sender_l1_size
+            num_other_devices,   // num_destinations (N-1)
+            this_device_idx};    // sender_device_idx (writes to slot this_device_idx)
+
+        // Receiver compile time args - includes num_devices and receiver_device_idx
+        std::vector<uint32_t> receiver_compile_time_args = {
+            worker_mem_map.test_results_address,
+            worker_mem_map.test_results_size_bytes,
+            worker_mem_map.notification_mailbox_address,
+            worker_mem_map.target_address,  // target_address_base
+            noc_send_type,
+            worker_mem_map.packet_payload_size_bytes,
+            num_packets,
+            time_seed,
+            req_notification_size_bytes,
+            static_cast<uint32_t>(num_active_devices),  // num_devices (total N)
+            per_sender_l1_size,                         // per_sender_l1_size
+            this_device_idx};                           // receiver_device_idx (skip this slot)
+
+        // Collect all sender-receiver core pairs (top half senders, bottom half receivers)
+        std::vector<CoreCoord> sender_logical_cores;
+        std::vector<CoreCoord> receiver_logical_cores;
+        for (uint32_t i = 0; i < num_core_pairs; i++) {
+            uint32_t x = i % grid_size.x;
+            uint32_t sender_y = i / grid_size.x;
+            uint32_t receiver_y = receiver_y_start + sender_y;
+            sender_logical_cores.push_back({x, sender_y});
+            receiver_logical_cores.push_back({x, receiver_y});
+        }
+
+        // Create sender kernel for all sender cores on this device
+        CoreRangeSet sender_core_range(sender_logical_cores);
+        auto sender_kernel = tt_metal::CreateKernel(
+            sender_programs[dev_idx],
+            sender_kernel_path,
+            sender_core_range,
+            tt_metal::DataMovementConfig{
+                .processor = tt_metal::DataMovementProcessor::RISCV_0,
+                .noc = tt_metal::NOC::RISCV_0_default,
+                .compile_args = sender_compile_time_args});
+
+        // Set runtime args per sender core
+        // Each sender sends to the corresponding receiver on ALL other devices
+        for (uint32_t core_idx = 0; core_idx < num_core_pairs; core_idx++) {
+            CoreCoord sender_logical_core = sender_logical_cores[core_idx];
+            CoreCoord receiver_logical_core = receiver_logical_cores[core_idx];
+
+            // Runtime args: for each destination: (noc_x, noc_y, dst_dev_id, dst_mesh_id)
+            std::vector<uint32_t> sender_runtime_args;
+            for (size_t dest_idx = 0; dest_idx < num_active_devices; dest_idx++) {
+                if (dest_idx == dev_idx) {
+                    continue;  // Skip self
+                }
+                const auto& dest_fabric_node_id = fabric_node_ids[dest_idx];
+                const auto& dest_device_ptr = device_ptrs[dest_idx];
+                CoreCoord receiver_virtual_core = dest_device_ptr->worker_core_from_logical_core(receiver_logical_core);
+
+                sender_runtime_args.push_back(receiver_virtual_core.x);
+                sender_runtime_args.push_back(receiver_virtual_core.y);
+                sender_runtime_args.push_back(dest_fabric_node_id.chip_id);
+                sender_runtime_args.push_back(dest_fabric_node_id.mesh_id.get());
+            }
+            tt_metal::SetRuntimeArgs(sender_programs[dev_idx], sender_kernel, sender_logical_core, sender_runtime_args);
+        }
+
+        // Create receiver kernel for all receiver cores on this device
+        CoreRangeSet receiver_core_range(receiver_logical_cores);
+        auto receiver_kernel = tt_metal::CreateKernel(
+            receiver_programs[dev_idx],
+            receiver_kernel_path,
+            receiver_core_range,
+            tt_metal::DataMovementConfig{
+                .processor = tt_metal::DataMovementProcessor::RISCV_0,
+                .noc = tt_metal::NOC::RISCV_0_default,
+                .compile_args = receiver_compile_time_args});
+
+        // For reads: receiver (data provider) needs to notify all readers
+        // Runtime args: (noc_x, noc_y, dst_dev_id, dst_mesh_id) for each reader
+        if (is_read) {
+            for (uint32_t core_idx = 0; core_idx < num_core_pairs; core_idx++) {
+                CoreCoord sender_logical_core = sender_logical_cores[core_idx];
+                CoreCoord receiver_logical_core = receiver_logical_cores[core_idx];
+
+                std::vector<uint32_t> receiver_runtime_args;
+                for (size_t reader_idx = 0; reader_idx < num_active_devices; reader_idx++) {
+                    if (reader_idx == dev_idx) {
+                        continue;  // Skip self
+                    }
+                    const auto& reader_fabric_node_id = fabric_node_ids[reader_idx];
+                    const auto& reader_device_ptr = device_ptrs[reader_idx];
+                    // The reader's sender core at the same position reads from this receiver
+                    CoreCoord reader_sender_virtual_core =
+                        reader_device_ptr->worker_core_from_logical_core(sender_logical_core);
+
+                    receiver_runtime_args.push_back(reader_sender_virtual_core.x);
+                    receiver_runtime_args.push_back(reader_sender_virtual_core.y);
+                    receiver_runtime_args.push_back(reader_fabric_node_id.chip_id);
+                    receiver_runtime_args.push_back(reader_fabric_node_id.mesh_id.get());
+                }
+                tt_metal::SetRuntimeArgs(
+                    receiver_programs[dev_idx], receiver_kernel, receiver_logical_core, receiver_runtime_args);
+            }
+        }
+
+        // Clear target L1 memory for all N device slots (simple indexing uses N slots, slot receiver_device_idx unused)
+        if (noc_send_type == NOC_UNICAST_ATOMIC_INC) {
+            uint32_t total_l1_to_clear = static_cast<uint32_t>(num_active_devices) * per_sender_l1_size;
+            for (uint32_t core_idx = 0; core_idx < num_core_pairs; core_idx++) {
+                CoreCoord receiver_logical_core = receiver_logical_cores[core_idx];
+                std::vector<uint32_t> zeros(total_l1_to_clear / sizeof(uint32_t), 0);
+                tt_metal::detail::WriteToDeviceL1(
+                    device_ptr->get_devices()[0],
+                    receiver_logical_core,
+                    worker_mem_map.target_address,
+                    zeros,
+                    CoreType::WORKER);
+            }
+        }
+    }
+
+    // Run all receiver programs first (non-blocking)
+    for (size_t dev_idx = 0; dev_idx < num_active_devices; dev_idx++) {
+        fixture->RunProgramNonblocking(device_ptrs[dev_idx], receiver_programs[dev_idx]);
+    }
+
+    // Run all sender programs (non-blocking)
+    for (size_t dev_idx = 0; dev_idx < num_active_devices; dev_idx++) {
+        fixture->RunProgramNonblocking(device_ptrs[dev_idx], sender_programs[dev_idx]);
+    }
+
+    // Wait for all senders to complete
+    for (size_t dev_idx = 0; dev_idx < num_active_devices; dev_idx++) {
+        fixture->WaitForSingleProgramDone(device_ptrs[dev_idx], sender_programs[dev_idx]);
+    }
+
+    // Wait for all receivers to complete
+    for (size_t dev_idx = 0; dev_idx < num_active_devices; dev_idx++) {
+        fixture->WaitForSingleProgramDone(device_ptrs[dev_idx], receiver_programs[dev_idx]);
+    }
+
+    // Validate results for all devices
+    for (size_t dev_idx = 0; dev_idx < num_active_devices; dev_idx++) {
+        const auto& device_ptr = device_ptrs[dev_idx];
+        const auto& fabric_node_id = fabric_node_ids[dev_idx];
+
+        uint64_t total_sender_bytes = 0;
+        uint64_t total_receiver_bytes = 0;
+
+        // Check all sender-receiver core pairs
+        for (uint32_t core_idx = 0; core_idx < num_core_pairs; core_idx++) {
+            uint32_t x = core_idx % grid_size.x;
+            uint32_t sender_y = core_idx / grid_size.x;
+            uint32_t receiver_y = receiver_y_start + sender_y;
+            CoreCoord sender_logical_core = {x, sender_y};
+            CoreCoord receiver_logical_core = {x, receiver_y};
+
+            // Check sender status
+            std::vector<uint32_t> sender_status;
+            tt_metal::detail::ReadFromDeviceL1(
+                device_ptr->get_devices()[0],
+                sender_logical_core,
+                worker_mem_map.test_results_address,
+                worker_mem_map.test_results_size_bytes,
+                sender_status,
+                CoreType::WORKER);
+            EXPECT_EQ(sender_status[TT_FABRIC_STATUS_INDEX], TT_FABRIC_STATUS_PASS)
+                << "Sender failed on device " << fabric_node_id.chip_id << " core (" << x << "," << sender_y << ")";
+
+            uint64_t sender_words =
+                ((uint64_t)sender_status[TT_FABRIC_WORD_CNT_INDEX + 1] << 32) | sender_status[TT_FABRIC_WORD_CNT_INDEX];
+            total_sender_bytes += sender_words;
+
+            // Check receiver status
+            std::vector<uint32_t> receiver_status;
+            tt_metal::detail::ReadFromDeviceL1(
+                device_ptr->get_devices()[0],
+                receiver_logical_core,
+                worker_mem_map.test_results_address,
+                worker_mem_map.test_results_size_bytes,
+                receiver_status,
+                CoreType::WORKER);
+            EXPECT_EQ(receiver_status[TT_FABRIC_STATUS_INDEX], TT_FABRIC_STATUS_PASS)
+                << "Receiver failed on device " << fabric_node_id.chip_id << " core (" << x << "," << receiver_y << ")";
+
+            uint64_t receiver_words = ((uint64_t)receiver_status[TT_FABRIC_WORD_CNT_INDEX + 1] << 32) |
+                                      receiver_status[TT_FABRIC_WORD_CNT_INDEX];
+            total_receiver_bytes += receiver_words;
+        }
+
+        // Expected bytes: num_core_pairs cores, each sending/receiving num_other_devices * num_packets * payload
+        uint64_t expected_bytes_per_core = num_other_devices * num_packets * worker_mem_map.packet_payload_size_bytes;
+        uint64_t expected_total_bytes = num_core_pairs * expected_bytes_per_core;
+        EXPECT_EQ(total_sender_bytes, expected_total_bytes)
+            << "Total sender byte count mismatch on device " << fabric_node_id.chip_id;
+        EXPECT_EQ(total_receiver_bytes, expected_total_bytes)
+            << "Total receiver byte count mismatch on device " << fabric_node_id.chip_id;
+    }
+
+    log_info(
+        tt::LogTest,
+        "All-to-all test passed: {} devices, {} core pairs, each sending to {} other devices",
+        num_active_devices,
+        num_core_pairs,
+        num_other_devices);
+}
+
 void Fabric2DMulticastCommon(
     BaseFabricFixture* fixture,
     NocSendType noc_send_type,

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
@@ -2608,7 +2608,6 @@ void UDMFabricUnicastAllToAllCommon(BaseFabricFixture* fixture, NocSendType noc_
 
     // Determine kernel paths based on operation type
     const bool is_read = (noc_send_type == NOC_UNICAST_READ);
-    log_info(tt::LogTest, "All-to-all test read {}", is_read);
     const char* sender_kernel_path =
         is_read ? "tests/tt_metal/tt_fabric/fabric_data_movement/kernels/test_udm_read_sender_all_to_all.cpp"
                 : "tests/tt_metal/tt_fabric/fabric_data_movement/kernels/test_udm_sender_all_to_all.cpp";

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_apis.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_apis.cpp
@@ -881,6 +881,25 @@ TEST_F(NightlyFabric2DUDMModeFixture, TestUDMFabricUnicastReadAllWorkerCoords) {
     }
 }
 
+// UDM Mode All-to-All Tests - all devices send to all other devices simultaneously
+// Senders are on top half of compute grid, receivers are on bottom half
+// Each receiver receives from N-1 senders at different L1 locations
+TEST_F(NightlyFabric2DUDMModeFixture, TestUDMFabricUnicastWriteAllToAll) {
+    UDMFabricUnicastAllToAllCommon(this, NOC_UNICAST_WRITE);
+}
+
+TEST_F(NightlyFabric2DUDMModeFixture, TestUDMFabricUnicastInlineWriteAllToAll) {
+    UDMFabricUnicastAllToAllCommon(this, NOC_UNICAST_INLINE_WRITE);
+}
+
+TEST_F(NightlyFabric2DUDMModeFixture, TestUDMFabricUnicastAtomicIncAllToAll) {
+    UDMFabricUnicastAllToAllCommon(this, NOC_UNICAST_ATOMIC_INC);
+}
+
+TEST_F(NightlyFabric2DUDMModeFixture, TestUDMFabricUnicastReadAllToAll) {
+    UDMFabricUnicastAllToAllCommon(this, NOC_UNICAST_READ);
+}
+
 // Mux-to-Mux Forwarding Tests - test the mux's ability to forward packets to the correct downstream mux
 // These tests intentionally send packets with a non-optimal initial direction to verify mux forwarding works
 // Test cases cover scenarios where the worker sends a packet to a mux in a different direction,

--- a/tt_metal/fabric/fabric_tensix_builder_impl.hpp
+++ b/tt_metal/fabric/fabric_tensix_builder_impl.hpp
@@ -402,6 +402,12 @@ private:
     static constexpr size_t udm_memory_pool_num_slots_ = 8;
     size_t udm_memory_pool_slot_size_ = 0;
     MemoryRegion udm_memory_pool_region_{};
+
+    // Response pool for tracking pending responses
+    // Size of RegisteredResponse is 32 bytes (defined in udm_registered_response_pool.hpp)
+    static constexpr size_t udm_registered_response_slot_size_ = 32;
+    size_t udm_registered_response_num_slots_ = 0;
+    MemoryRegion udm_registered_response_pool_region_{};
 };
 
 /**

--- a/tt_metal/fabric/hw/inc/udm/tt_fabric_udm.hpp
+++ b/tt_metal/fabric/hw/inc/udm/tt_fabric_udm.hpp
@@ -642,7 +642,7 @@ FORCE_INLINE void fabric_fast_read_ack(
     uint32_t slot_size = memory_pool.get_slot_size();
 
     // Bytes to send: min of bytes in pool and slot size (handles partial last slot)
-    uint32_t bytes_to_send = std::min((uint32_t)response->bytes_remaining_, slot_size);
+    uint32_t bytes_to_send = std::min((uint32_t)response->bytes_remaining, slot_size);
 
     if (response->is_last_send(slot_size)) {
         // Last packet - use fused atomic increment

--- a/tt_metal/fabric/hw/inc/udm/tt_fabric_udm.hpp
+++ b/tt_metal/fabric/hw/inc/udm/tt_fabric_udm.hpp
@@ -492,40 +492,33 @@ FORCE_INLINE uint32_t select_relay_to_mux_connection(uint16_t dst_chip_id) {
  *
  * This function sends an atomic increment to the sender's counter to acknowledge
  * receipt of a packet (write, atomic, etc.). It extracts the sender's information from
- * the received packet's UDM control fields and sends an atomic increment to the
- * appropriate counter based on the FabricBarrierType template parameter.
+ * the registered response and sends an atomic increment to the appropriate counter
+ * based on the FabricBarrierType template parameter.
  *
- * For 2D fabrics with multiple mux connections, this function intelligently routes the ACK:
- * - If relay is NS-oriented: use local connection (same NS dimension)
- * - If relay is EW-oriented and ACK needs NS routing: use perpendicular NS connection
- * - Otherwise: use local connection
+ * Note: The mux connection is already selected by the caller based on routing logic.
+ * Only non-posted operations are registered, so no posted flag check is needed.
  *
  * @tparam BarrierType The type of barrier counter to increment (e.g., NONPOSTED_WRITES_ACKED, NONPOSTED_ATOMICS_ACKED)
- * @tparam Direction Direction of this relay (EAST=0, WEST=1, NORTH=2, SOUTH=3)
  * @tparam FabricConnectionType The connection type
- * @tparam NumConnections Number of mux connections (1 for single connection, 3 for mux array)
- * @param connections Array of mux connections [local, downstream_en, downstream_ws] or single connection
- * @param received_header Pointer to the received packet header containing UDM control fields
+ * @param connection Single mux connection (already selected by caller)
+ * @param response Pointer to the registered response containing sender information
  * @param increment_value The value to increment the counter by (default 1)
  * @param flush Whether to flush the atomic operation (default false)
  */
-template <FabricBarrierType BarrierType, uint32_t Direction, typename FabricConnectionType, size_t NumConnections>
+template <FabricBarrierType BarrierType, typename FabricConnectionType>
 FORCE_INLINE void fabric_fast_ack(
-    std::array<FabricConnectionType, NumConnections>& connections,
-    volatile tt_l1_ptr PACKET_HEADER_TYPE* received_header,
+    FabricConnectionType& connection,
+    volatile RegisteredResponse* response,
     uint32_t increment_value = 1,
     bool flush = false) {
-    // if this is a posted operation then we simply exit
-    if (received_header->udm_control.write.posted) {
-        return;
-    }
+    ASSERT(connection.edm_has_space_for_packet());
     volatile tt_l1_ptr PACKET_HEADER_TYPE* ack_header = get_or_allocate_header();
 
-    uint8_t src_chip_id = received_header->udm_control.write.src_chip_id;
-    uint16_t src_mesh_id = received_header->udm_control.write.src_mesh_id;
-    uint8_t src_noc_x = received_header->udm_control.write.src_noc_x;
-    uint8_t src_noc_y = received_header->udm_control.write.src_noc_y;
-    uint8_t src_risc_id = received_header->udm_control.write.risc_id;
+    uint8_t src_chip_id = response->src_chip_id;
+    uint16_t src_mesh_id = response->src_mesh_id;
+    uint8_t src_noc_x = response->src_noc_x;
+    uint8_t src_noc_y = response->src_noc_y;
+    uint8_t src_risc_id = response->risc_id;
 
     uint32_t counter_addr = get_fabric_counter_address<BarrierType>(src_risc_id);
 
@@ -533,44 +526,49 @@ FORCE_INLINE void fabric_fast_ack(
         NocUnicastAtomicIncCommandHeader(get_noc_addr(src_noc_x, src_noc_y, counter_addr), increment_value, flush));
     fabric_write_set_unicast_route(ack_header, src_chip_id, src_mesh_id, 0, 1);  // trid=0, posted=1
 
-    // Determine which mux connection to use for sending the ACK
-    uint32_t mux_idx = select_relay_to_mux_connection<Direction>(src_chip_id);
-
-    connections[mux_idx].wait_for_empty_write_slot();
-    // Use blocking mode to barrier before issue the credits to the receiver, as the order of noc writes to l1 (payload)
-    // and to reg (credit) is not guaranteed.
-    connections[mux_idx].send_payload_blocking_from_address(
-        reinterpret_cast<uint32_t>(ack_header), sizeof(PACKET_HEADER_TYPE));
+    connection.send_payload_blocking_from_address(reinterpret_cast<uint32_t>(ack_header), sizeof(PACKET_HEADER_TYPE));
 }
 
 /**
  * @brief Send a write acknowledgment back to the sender
  *
  * Wrapper function that calls fabric_fast_ack with NONPOSTED_WRITES_ACKED barrier type.
+ * Accepts a RegisteredResponse containing sender information and a pre-selected mux connection.
+ *
+ * @tparam FabricConnectionType The connection type
+ * @param connection Single mux connection (already selected by caller)
+ * @param response Pointer to the registered response containing sender information
+ * @param increment_value The value to increment the counter by (default 1)
+ * @param flush Whether to flush the atomic operation (default false)
  */
-template <uint32_t Direction, typename FabricConnectionType, size_t NumConnections>
+template <typename FabricConnectionType>
 FORCE_INLINE void fabric_fast_write_ack(
-    std::array<FabricConnectionType, NumConnections>& connections,
-    volatile tt_l1_ptr PACKET_HEADER_TYPE* received_header,
+    FabricConnectionType& connection,
+    volatile RegisteredResponse* response,
     uint32_t increment_value = 1,
     bool flush = false) {
-    fabric_fast_ack<FabricBarrierType::NONPOSTED_WRITES_ACKED, Direction>(
-        connections, received_header, increment_value, flush);
+    fabric_fast_ack<FabricBarrierType::NONPOSTED_WRITES_ACKED>(connection, response, increment_value, flush);
 }
 
 /**
  * @brief Send an atomic increment acknowledgment back to the sender
  *
  * Wrapper function that calls fabric_fast_ack with NONPOSTED_ATOMICS_ACKED barrier type.
+ * Accepts a RegisteredResponse containing sender information and a pre-selected mux connection.
+ *
+ * @tparam FabricConnectionType The connection type
+ * @param connection Single mux connection (already selected by caller)
+ * @param response Pointer to the registered response containing sender information
+ * @param increment_value The value to increment the counter by (default 1)
+ * @param flush Whether to flush the atomic operation (default false)
  */
-template <uint32_t Direction, typename FabricConnectionType, size_t NumConnections>
+template <typename FabricConnectionType>
 FORCE_INLINE void fabric_fast_atomic_ack(
-    std::array<FabricConnectionType, NumConnections>& connections,
-    volatile tt_l1_ptr PACKET_HEADER_TYPE* received_header,
+    FabricConnectionType& connection,
+    volatile RegisteredResponse* response,
     uint32_t increment_value = 1,
     bool flush = false) {
-    fabric_fast_ack<FabricBarrierType::NONPOSTED_ATOMICS_ACKED, Direction>(
-        connections, received_header, increment_value, flush);
+    fabric_fast_ack<FabricBarrierType::NONPOSTED_ATOMICS_ACKED>(connection, response, increment_value, flush);
 }
 
 /**
@@ -608,99 +606,57 @@ FORCE_INLINE void fabric_fast_read_any_len(
 }
 
 /**
- * @brief Internal helper for sending a single read response packet
+ * @brief Send ONE read response slot back to the requester
  *
- * @tparam use_fused_atomic Whether to use fused atomic increment (for last packet)
- * @param connection Fabric connection to use
- * @param packet_header Packet header with routing already configured
- * @param src_addr Source address in local L1 memory
- * @param dest_addr Destination NOC address
- * @param len_bytes Number of bytes to write
- * @param counter_noc_addr NOC address of the counter to increment (only used if use_fused_atomic is true)
- */
-template <bool use_fused_atomic, typename FabricConnectionType>
-FORCE_INLINE void fabric_fast_read_ack(
-    FabricConnectionType& connection,
-    volatile tt_l1_ptr PACKET_HEADER_TYPE* packet_header,
-    uint32_t src_addr,
-    uint64_t dest_addr,
-    uint32_t len_bytes,
-    uint64_t counter_noc_addr = 0) {
-    if constexpr (use_fused_atomic) {
-        packet_header->to_noc_fused_unicast_write_atomic_inc(
-            NocUnicastAtomicIncFusedCommandHeader(dest_addr, counter_noc_addr, 1, true /* flush */), len_bytes);
-    } else {
-        packet_header->to_noc_unicast_write(NocUnicastCommandHeader{dest_addr}, len_bytes);
-    }
-
-    connection.wait_for_empty_write_slot();
-    connection.send_payload_without_header_non_blocking_from_address(src_addr, len_bytes);
-    // Use blocking mode to barrier before issue the credits to the receiver, as the order of noc writes to l1 (payload)
-    // and to reg (credit) is not guaranteed.
-    connection.send_payload_blocking_from_address(
-        reinterpret_cast<uint32_t>(packet_header), sizeof(PACKET_HEADER_TYPE));
-}
-
-/**
- * @brief Process a read request and send the requested data back to the requester
+ * Sends a single slot from the memory pool to the requester. Automatically uses
+ * fused atomic increment on the last packet (detected via response->is_last_slot()).
  *
- * This function processes a received read request packet by extracting the request
- * parameters from the UDM control fields and sending the requested data back to
- * the source. It reads slot by slot from the UDMMemoryPool circular buffer to
- * handle wrap-around correctly, and uses a fused atomic increment on the last
- * packet to signal completion.
- *
- * @tparam Direction Direction of this relay (EAST=0, WEST=1, NORTH=2, SOUTH=3)
  * @tparam FabricConnectionType The connection type
- * @tparam NumConnections Number of mux connections
- * @param connections Array of mux connections [local, downstream_en, downstream_ws]
- * @param received_header Pointer to the received read request packet header
+ * @tparam UDMMemoryPoolType The memory pool type
+ * @param connection Single mux connection (already selected by caller)
+ * @param response Pointer to the registered response containing sender information
  * @param memory_pool Reference to the UDM memory pool instance
  */
-template <uint32_t Direction, typename FabricConnectionType, size_t NumConnections, typename UDMMemoryPoolType>
-FORCE_INLINE void fabric_fast_read_any_len_ack(
-    std::array<FabricConnectionType, NumConnections>& connections,
-    volatile tt_l1_ptr PACKET_HEADER_TYPE* received_header,
-    UDMMemoryPoolType& memory_pool) {
+template <typename FabricConnectionType, typename UDMMemoryPoolType>
+FORCE_INLINE void fabric_fast_read_ack(
+    FabricConnectionType& connection, volatile RegisteredResponse* response, UDMMemoryPoolType& memory_pool) {
+    ASSERT(connection.edm_has_space_for_packet());
+
+    uint8_t src_chip_id = response->src_chip_id;
+    uint16_t src_mesh_id = response->src_mesh_id;
+    uint8_t src_noc_x = response->src_noc_x;
+    uint8_t src_noc_y = response->src_noc_y;
+    uint8_t src_risc_id = response->risc_id;
+    uint8_t transaction_id = response->transaction_id;
+    uint32_t src_l1_address = response->src_l1_address;
+
     volatile tt_l1_ptr PACKET_HEADER_TYPE* response_header = get_or_allocate_header();
 
-    // Extract read request parameters from the received header
-    uint8_t src_chip_id = received_header->udm_control.read.src_chip_id;
-    uint16_t src_mesh_id = received_header->udm_control.read.src_mesh_id;
-    uint8_t src_noc_x = received_header->udm_control.read.src_noc_x;
-    uint8_t src_noc_y = received_header->udm_control.read.src_noc_y;
-    uint32_t src_l1_address = received_header->udm_control.read.src_l1_address;
-    uint32_t size_bytes = received_header->udm_control.read.size_bytes;
-    uint8_t src_risc_id = received_header->udm_control.read.risc_id;
-    uint8_t transaction_id = received_header->udm_control.read.transaction_id;
-    uint64_t dest_addr = get_noc_addr(src_noc_x, src_noc_y, src_l1_address);
-
-    // Calculate the counter address for the final atomic increment
-    uint32_t counter_addr = get_fabric_counter_address<FabricBarrierType::READS_NUM_ACKED>(src_risc_id);
-    uint64_t counter_noc_addr = get_noc_addr(src_noc_x, src_noc_y, counter_addr);
-
-    // Determine which mux connection to use
-    uint32_t mux_idx = select_relay_to_mux_connection<Direction>(src_chip_id);
-
+    // Set up routing
     fabric_write_set_unicast_route(response_header, src_chip_id, src_mesh_id, transaction_id, 1 /* posted */);
 
-    // Read slot by slot from memory pool
+    // Get source address from memory pool and destination address from response
+    uint32_t src_addr = memory_pool.get_slot_addr(memory_pool.get_rd_slot_idx());
+    uint64_t dest_addr = get_noc_addr(src_noc_x, src_noc_y, src_l1_address);
     uint32_t slot_size = memory_pool.get_slot_size();
-    uint32_t slot_idx = memory_pool.get_rd_slot_idx();
 
-    while (size_bytes > slot_size) {
-        uint32_t src_addr = memory_pool.get_slot_addr(slot_idx);
-        fabric_fast_read_ack<false>(connections[mux_idx], response_header, src_addr, dest_addr, slot_size);
+    // Bytes to send: min of bytes in pool and slot size (handles partial last slot)
+    uint32_t bytes_to_send = std::min((uint32_t)response->bytes_remaining_, slot_size);
 
-        slot_idx = memory_pool.get_next_slot_idx(slot_idx);
-        dest_addr += slot_size;
-        size_bytes -= slot_size;
+    if (response->is_last_send(slot_size)) {
+        // Last packet - use fused atomic increment
+        uint32_t counter_addr = get_fabric_counter_address<FabricBarrierType::READS_NUM_ACKED>(src_risc_id);
+        uint64_t counter_noc_addr = get_noc_addr(src_noc_x, src_noc_y, counter_addr);
+        response_header->to_noc_fused_unicast_write_atomic_inc(
+            NocUnicastAtomicIncFusedCommandHeader(dest_addr, counter_noc_addr, 1, true /* flush */), bytes_to_send);
+    } else {
+        response_header->to_noc_unicast_write(NocUnicastCommandHeader{dest_addr}, bytes_to_send);
     }
 
-    // Send final chunk with atomic increment
-    uint32_t src_addr = memory_pool.get_slot_addr(slot_idx);
-    fabric_fast_read_ack<true>(
-        connections[mux_idx], response_header, src_addr, dest_addr, size_bytes, counter_noc_addr);
+    connection.send_payload_without_header_non_blocking_from_address(src_addr, bytes_to_send);
+    // Use blocking mode to barrier before issue the credits to the receiver
+    connection.send_payload_blocking_from_address(
+        reinterpret_cast<uint32_t>(response_header), sizeof(PACKET_HEADER_TYPE));
 }
 
 }  // namespace tt::tt_fabric::udm

--- a/tt_metal/fabric/hw/inc/udm/udm_memory_pool.hpp
+++ b/tt_metal/fabric/hw/inc/udm/udm_memory_pool.hpp
@@ -61,14 +61,15 @@ public:
     FORCE_INLINE uint32_t get_next_slot_idx(uint32_t idx) const { return advance_slot_idx(idx); }
 
     // Allocate slots for a read response - bytes based
-    // Reads from response->read_noc_address (auto-advanced), updates bytes_remaining
-    // Returns true if we allocated any bytes
+    // Performs partial allocation: allocates min(bytes_needed, available_space).
+    // Reads from response->read_noc_address (auto-advanced), updates bytes_remaining and bytes_to_allocate.
+    // Callers should check response->bytes_to_allocate to determine if more allocation is needed.
     FORCE_INLINE void cb_allocate_and_fill_slots(volatile RegisteredResponse* response) {
-        uint32_t bytes_to_allocate = response->bytes_to_allocate_;
+        uint32_t bytes_to_allocate = response->bytes_to_allocate;
         uint32_t available_slots = get_num_available_slots();
         bool can_allocate = (bytes_to_allocate != 0) && (available_slots != 0);
         if (can_allocate) {
-            // Calculate bytes to read: min of bytes needed and available space
+            // Partial allocation: allocate as much as available space allows
             uint32_t bytes_to_read = std::min(bytes_to_allocate, available_slots * SlotSize);
             uint32_t bytes_allocated = bytes_to_read;
 

--- a/tt_metal/fabric/hw/inc/udm/udm_memory_pool.hpp
+++ b/tt_metal/fabric/hw/inc/udm/udm_memory_pool.hpp
@@ -8,6 +8,7 @@
 #include "debug/assert.h"
 #include "dataflow_api.h"
 #include "noc_parameters.h"
+#include "udm_registered_response_pool.hpp"
 
 namespace tt::tt_fabric::udm {
 
@@ -44,13 +45,8 @@ public:
         }
     }
 
-    // Check if num_slots are available
-    FORCE_INLINE bool cb_has_enough_slots(uint32_t num_slots) const {
-        return (NumSlots - num_used_slots_) >= num_slots;
-    }
-
-    // Helper: calculate slots needed for a given size
-    FORCE_INLINE uint32_t slots_needed(uint32_t size_bytes) const { return (size_bytes + SlotSize - 1) / SlotSize; }
+    // Get number of available slots
+    FORCE_INLINE uint32_t get_num_available_slots() const { return NumSlots - num_used_slots_; }
 
     // Get slot size
     FORCE_INLINE constexpr uint32_t get_slot_size() const { return SlotSize; }
@@ -64,20 +60,38 @@ public:
     // Get next slot index (with wrap)
     FORCE_INLINE uint32_t get_next_slot_idx(uint32_t idx) const { return advance_slot_idx(idx); }
 
-    // Allocate slots and fill with data from noc_addr using noc_async_read
-    FORCE_INLINE void cb_allocate_and_fill_slots(uint64_t noc_addr, uint32_t size_bytes) {
-        uint32_t bytes_remaining = size_bytes;
-        uint64_t src_addr = noc_addr;
+    // Allocate slots for a read response - bytes based
+    // Reads from response->read_noc_address (auto-advanced), updates bytes_remaining
+    // Returns true if we allocated any bytes
+    FORCE_INLINE void cb_allocate_and_fill_slots(volatile RegisteredResponse* response) {
+        uint32_t bytes_to_allocate = response->bytes_to_allocate_;
+        uint32_t available_slots = get_num_available_slots();
+        bool can_allocate = (bytes_to_allocate != 0) && (available_slots != 0);
+        if (can_allocate) {
+            // Calculate bytes to read: min of bytes needed and available space
+            uint32_t bytes_to_read = std::min(bytes_to_allocate, available_slots * SlotSize);
+            uint32_t bytes_allocated = bytes_to_read;
 
-        // Read slot by slot
-        while (bytes_remaining > 0) {
-            uint32_t read_size = (bytes_remaining > SlotSize) ? SlotSize : bytes_remaining;
-            noc_async_read(src_addr, slot_addrs_[wr_slot_idx_], read_size);
+            // Read from current address (already points to next unread location)
+            uint64_t src_addr = response->read_noc_address;
 
-            src_addr += read_size;
-            bytes_remaining -= read_size;
+            // Read full slots
+            while (bytes_to_read > SlotSize) {
+                noc_async_read(src_addr, slot_addrs_[wr_slot_idx_], SlotSize);
+                src_addr += SlotSize;
+                bytes_to_read -= SlotSize;
+                wr_slot_idx_ = advance_slot_idx(wr_slot_idx_);
+                num_used_slots_++;
+            }
+            // Read final slot (may be partial)
+            noc_async_read(src_addr, slot_addrs_[wr_slot_idx_], bytes_to_read);
             wr_slot_idx_ = advance_slot_idx(wr_slot_idx_);
             num_used_slots_++;
+
+            noc_async_read_barrier();
+
+            // Update response: advance read address, update byte counters
+            response->complete_allocation(bytes_allocated);
         }
     }
 
@@ -85,12 +99,6 @@ public:
     FORCE_INLINE void cb_deallocate_slots(uint32_t num_slots) {
         rd_slot_idx_ = advance_slot_idx_n(rd_slot_idx_, num_slots);
         num_used_slots_ -= num_slots;
-    }
-
-    FORCE_INLINE void reset() {
-        wr_slot_idx_ = 0;
-        rd_slot_idx_ = 0;
-        num_used_slots_ = 0;
     }
 };
 

--- a/tt_metal/fabric/hw/inc/udm/udm_registered_response_pool.hpp
+++ b/tt_metal/fabric/hw/inc/udm/udm_registered_response_pool.hpp
@@ -1,0 +1,168 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include "debug/assert.h"
+#include "dataflow_api.h"
+#include "noc_parameters.h"
+#include "fabric/fabric_edm_packet_header.hpp"
+
+namespace tt::tt_fabric::udm {
+
+/**
+ * @brief Registered response entry for tracking pending write/read responses
+ *
+ * This struct contains all information needed to send a response back to the requestor
+ * after the NOC operation completes. For writes, this includes acknowledgment info.
+ * For reads, this includes source location and memory pool slot tracking.
+ */
+struct RegisteredResponse {
+    uint8_t noc_send_type;
+    uint8_t risc_id;
+    uint8_t mux_index;
+
+    // Common fields from UDMControlFields (excluding initial_direction)
+    uint8_t src_chip_id;
+    uint16_t src_mesh_id;
+    uint8_t src_noc_x;
+    uint8_t src_noc_y;
+    uint8_t transaction_id;
+
+    // Memory pool tracking for reads (bytes-based, no slot counting)
+    uint16_t bytes_remaining_;  // Bytes in memory pool waiting to be sent
+
+    // Padding to reach 32 bytes
+    uint8_t padding[5];
+
+    // Read-specific fields
+    uint32_t src_l1_address;
+    uint32_t bytes_to_allocate_;  // Bytes remaining to allocate from source
+    uint64_t read_noc_address;    // Where to read from next (updated after allocation)
+
+    // Helper to populate fields from header
+    // For reads, also pass noc_addr; for writes, it's ignored
+    template <tt::tt_fabric::NocSendType noc_send_type, typename HeaderType>
+    FORCE_INLINE void populate_from_header(
+        const volatile HeaderType& header, uint8_t mux_index, uint64_t noc_addr = 0) volatile {
+        this->noc_send_type = noc_send_type;
+        this->risc_id = header.risc_id;
+        this->mux_index = mux_index;
+
+        src_chip_id = header.src_chip_id;
+        src_mesh_id = header.src_mesh_id;
+        src_noc_x = header.src_noc_x;
+        src_noc_y = header.src_noc_y;
+        transaction_id = header.transaction_id;
+
+        // For reads, populate read-specific fields (compile-time check)
+        if constexpr (noc_send_type == tt::tt_fabric::NocSendType::NOC_UNICAST_READ) {
+            src_l1_address = header.src_l1_address;
+            bytes_to_allocate_ = header.size_bytes;
+            read_noc_address = noc_addr;
+            bytes_remaining_ = 0;
+        }
+    }
+
+    // Check if there are bytes in memory pool to send
+    FORCE_INLINE bool has_data_to_send() const volatile { return bytes_remaining_ > 0; }
+
+    // Check if this is the last slot to send (for fused atomic on final packet)
+    // True when: all bytes allocated AND only one slot's worth (or less) remaining
+    FORCE_INLINE bool is_last_send(uint32_t slot_size) const volatile {
+        return bytes_to_allocate_ == 0 && bytes_remaining_ <= slot_size;
+    }
+
+    // Called after allocating: advance read address, update byte counters
+    FORCE_INLINE void complete_allocation(uint32_t bytes_allocated) volatile {
+        read_noc_address += bytes_allocated;
+        bytes_to_allocate_ -= bytes_allocated;
+        bytes_remaining_ += bytes_allocated;
+    }
+
+    // Called after sending ONE slot: advance dest address, decrement bytes
+    // Returns true if all data has been sent
+    FORCE_INLINE bool complete_send(uint32_t slot_size) volatile {
+        uint32_t bytes_sent = std::min((uint32_t)bytes_remaining_, slot_size);
+
+        src_l1_address += bytes_sent;
+        bytes_remaining_ -= bytes_sent;
+
+        return bytes_remaining_ == 0 && bytes_to_allocate_ == 0;
+    }
+} __attribute__((packed));
+
+static_assert(sizeof(RegisteredResponse) == 32, "RegisteredResponse must be exactly 32 bytes");
+
+/**
+ * @brief Pool for managing registered responses that are pending completion
+ *
+ * This pool manages a circular buffer of RegisteredResponse entries in L1 memory.
+ * Unlike UDMMemoryPool which stores actual data in an array, this pool only maintains
+ * read/write indices and accesses the L1 memory directly via pointers, as the number
+ * of slots can be very large (thousands).
+ */
+template <uint32_t BaseAddress, uint32_t NumSlots>
+class RegisteredResponsePool {
+private:
+    uint32_t wr_slot_idx_ = 0;
+    uint32_t rd_slot_idx_ = 0;
+    uint32_t num_used_slots_ = 0;
+
+    static constexpr uint32_t SLOT_SIZE = sizeof(RegisteredResponse);
+
+    // Get pointer to response slot at index
+    FORCE_INLINE volatile RegisteredResponse* get_slot_ptr(uint32_t idx) const {
+        uint32_t addr = BaseAddress + idx * SLOT_SIZE;
+        return reinterpret_cast<volatile RegisteredResponse*>(addr);
+    }
+
+    // Advance slot index by 1 with wrap
+    FORCE_INLINE uint32_t advance_slot_idx(uint32_t idx) const {
+        idx++;
+        if (idx >= NumSlots) {
+            idx = 0;
+        }
+        return idx;
+    }
+
+public:
+    // Constructor
+    RegisteredResponsePool() = default;
+
+    // Check if pool has space for a new entry
+    FORCE_INLINE bool has_space() const { return num_used_slots_ < NumSlots; }
+
+    // Check if pool is empty
+    FORCE_INLINE bool is_empty() const { return num_used_slots_ == 0; }
+
+    // Get pointer to current write slot (for registering new response)
+    FORCE_INLINE volatile RegisteredResponse* get_unregistered_slot() {
+        ASSERT(has_space());
+        return get_slot_ptr(wr_slot_idx_);
+    }
+
+    // Get pointer to current read slot (for processing next response)
+    FORCE_INLINE volatile RegisteredResponse* get_registered_slot() const {
+        ASSERT(!is_empty());
+        return get_slot_ptr(rd_slot_idx_);
+    }
+
+    // Register a new response (allocate write slot)
+    FORCE_INLINE void register_response() {
+        ASSERT(has_space());
+        wr_slot_idx_ = advance_slot_idx(wr_slot_idx_);
+        num_used_slots_++;
+    }
+
+    // Unregister a response (deallocate read slot)
+    FORCE_INLINE void unregister_response() {
+        ASSERT(!is_empty());
+        rd_slot_idx_ = advance_slot_idx(rd_slot_idx_);
+        num_used_slots_--;
+    }
+};
+
+}  // namespace tt::tt_fabric::udm

--- a/tt_metal/fabric/impl/kernels/edm_fabric/fabric_router_relay_extension.cpp
+++ b/tt_metal/fabric/impl/kernels/edm_fabric/fabric_router_relay_extension.cpp
@@ -265,7 +265,7 @@ __attribute__((optimize("jump-tables"))) FORCE_INLINE void execute_noc_txn_or_re
         case tt::tt_fabric::NocSendType::NOC_UNICAST_INLINE_WRITE: {
             const auto noc_addr = header.command_fields.unicast_inline_write.noc_address;
             const auto value = header.command_fields.unicast_inline_write.value;
-            noc_inline_dw_write<InlineWriteDst::DEFAULT, true>(noc_addr, value);
+            noc_inline_dw_write(noc_addr, value);
             // temporarily place here until we have txn id support
             noc_async_writes_flushed();
             // Register response for non-posted writes

--- a/tt_metal/fabric/impl/kernels/edm_fabric/fabric_router_relay_extension.cpp
+++ b/tt_metal/fabric/impl/kernels/edm_fabric/fabric_router_relay_extension.cpp
@@ -190,6 +190,8 @@ void setup_channel(
 }
 
 // Helper function to register a response in the response pool
+// Precondition: response_pool.has_space() must be true before calling.
+// This invariant is critical for the deadlock avoidance mechanism.
 template <uint32_t Direction, tt::tt_fabric::NocSendType noc_send_type, typename RegisteredResponsePoolType>
 FORCE_INLINE void register_write_or_atomic_response(
     volatile tt_l1_ptr PACKET_HEADER_TYPE* const packet_header, RegisteredResponsePoolType& response_pool) {
@@ -205,6 +207,8 @@ FORCE_INLINE void register_write_or_atomic_response(
 }
 
 // Helper function to register a read response in the response pool
+// Precondition: response_pool.has_space() must be true before calling.
+// This invariant is critical for the deadlock avoidance mechanism.
 template <uint32_t Direction, typename RegisteredResponsePoolType, typename UDMMemoryPoolType>
 FORCE_INLINE void register_read_response(
     volatile tt_l1_ptr PACKET_HEADER_TYPE* const packet_header,
@@ -418,8 +422,7 @@ FORCE_INLINE bool process_read_response(
     allocate_read_memory(memory_pool, response);
 
     // Send if we have bytes in memory pool
-    bool response_completed;
-    response_completed = send_read_response_data<Direction>(mux_connections, memory_pool, response);
+    bool response_completed = send_read_response_data<Direction>(mux_connections, memory_pool, response);
     return response_completed;
 }
 

--- a/tt_metal/fabric/impl/kernels/edm_fabric/fabric_router_relay_extension.cpp
+++ b/tt_metal/fabric/impl/kernels/edm_fabric/fabric_router_relay_extension.cpp
@@ -15,6 +15,7 @@
 #include "tt_metal/fabric/hw/inc/noc_addr.h"
 #include "tt_metal/fabric/hw/inc/udm/tt_fabric_udm.hpp"
 #include "tt_metal/fabric/hw/inc/udm/udm_memory_pool.hpp"
+#include "tt_metal/fabric/hw/inc/udm/udm_registered_response_pool.hpp"
 
 #include <cstddef>
 #include <array>
@@ -124,9 +125,11 @@ constexpr size_t udm_memory_pool_base_address = get_compile_time_arg_val(LOCAL_M
 constexpr size_t udm_memory_pool_slot_size = get_compile_time_arg_val(LOCAL_MUX_STATUS_ADDRESS_IDX + 2);
 constexpr size_t udm_memory_pool_num_slots = get_compile_time_arg_val(LOCAL_MUX_STATUS_ADDRESS_IDX + 3);
 constexpr size_t direction = get_compile_time_arg_val(LOCAL_MUX_STATUS_ADDRESS_IDX + 4);
-constexpr size_t router_noc_x = get_compile_time_arg_val(LOCAL_MUX_STATUS_ADDRESS_IDX + 5);
-constexpr size_t router_noc_y = get_compile_time_arg_val(LOCAL_MUX_STATUS_ADDRESS_IDX + 6);
-constexpr size_t fabric_router_sync_address = get_compile_time_arg_val(LOCAL_MUX_STATUS_ADDRESS_IDX + 7);
+constexpr size_t udm_registered_response_pool_base_address = get_compile_time_arg_val(LOCAL_MUX_STATUS_ADDRESS_IDX + 5);
+constexpr size_t udm_registered_response_pool_num_slots = get_compile_time_arg_val(LOCAL_MUX_STATUS_ADDRESS_IDX + 6);
+constexpr size_t router_noc_x = get_compile_time_arg_val(LOCAL_MUX_STATUS_ADDRESS_IDX + 7);
+constexpr size_t router_noc_y = get_compile_time_arg_val(LOCAL_MUX_STATUS_ADDRESS_IDX + 8);
+constexpr size_t fabric_router_sync_address = get_compile_time_arg_val(LOCAL_MUX_STATUS_ADDRESS_IDX + 9);
 
 // Mux connection array indices: [0]=local, [1]=downstream_en, [2]=downstream_ws
 constexpr uint32_t LOCAL_MUX_IDX = 0;
@@ -186,24 +189,65 @@ void setup_channel(
     channel_connection_established = false;
 }
 
-template <uint32_t Direction, typename RelayToMuxSenderType, size_t NumMuxConnections, typename UDMMemoryPoolType>
-__attribute__((optimize("jump-tables"))) FORCE_INLINE void execute_noc_txn_to_local_chip(
+// Helper function to register a response in the response pool
+template <uint32_t Direction, tt::tt_fabric::NocSendType noc_send_type, typename RegisteredResponsePoolType>
+FORCE_INLINE void register_write_or_atomic_response(
+    volatile tt_l1_ptr PACKET_HEADER_TYPE* const packet_header, RegisteredResponsePoolType& response_pool) {
+    ASSERT(response_pool.has_space());
+    // Only register non-posted operations
+    if (!packet_header->udm_control.write.posted) {
+        volatile tt::tt_fabric::udm::RegisteredResponse* response = response_pool.get_unregistered_slot();
+        uint8_t mux_idx =
+            tt::tt_fabric::udm::select_relay_to_mux_connection<Direction>(packet_header->udm_control.write.src_chip_id);
+        response->template populate_from_header<noc_send_type>(packet_header->udm_control.write, mux_idx);
+        response_pool.register_response();
+    }
+}
+
+// Helper function to register a read response in the response pool
+template <uint32_t Direction, typename RegisteredResponsePoolType, typename UDMMemoryPoolType>
+FORCE_INLINE void register_read_response(
+    volatile tt_l1_ptr PACKET_HEADER_TYPE* const packet_header,
+    RegisteredResponsePoolType& response_pool,
+    UDMMemoryPoolType& memory_pool) {
+    ASSERT(response_pool.has_space());
+    ASSERT(packet_header->udm_control.read.size_bytes > 0);
+
+    const uint64_t read_noc_addr = packet_header->command_fields.unicast_read.noc_address;
+    uint8_t mux_idx =
+        tt::tt_fabric::udm::select_relay_to_mux_connection<Direction>(packet_header->udm_control.read.src_chip_id);
+
+    volatile tt::tt_fabric::udm::RegisteredResponse* response = response_pool.get_unregistered_slot();
+    response->template populate_from_header<tt::tt_fabric::NocSendType::NOC_UNICAST_READ>(
+        packet_header->udm_control.read, mux_idx, read_noc_addr);
+
+    response_pool.register_response();
+}
+
+template <
+    uint32_t Direction,
+    typename RelayToMuxSenderType,
+    size_t NumMuxConnections,
+    typename UDMMemoryPoolType,
+    typename RegisteredResponsePoolType>
+__attribute__((optimize("jump-tables"))) FORCE_INLINE void execute_noc_txn_or_register_response(
     std::array<RelayToMuxSenderType, NumMuxConnections>& mux_connections,
     volatile tt_l1_ptr PACKET_HEADER_TYPE* const packet_header,
-    UDMMemoryPoolType& memory_pool) {
+    UDMMemoryPoolType& memory_pool,
+    RegisteredResponsePoolType& response_pool) {
     const auto& header = *packet_header;
     uint16_t payload_size_bytes = header.payload_size_bytes;
     uint32_t payload_start_address = reinterpret_cast<size_t>(packet_header) + sizeof(PACKET_HEADER_TYPE);
 
-    tt::tt_fabric::NocSendType noc_send_type = header.noc_send_type;
-    switch (noc_send_type) {
+    switch (header.noc_send_type) {
         case tt::tt_fabric::NocSendType::NOC_UNICAST_WRITE: {
             const auto noc_addr = header.command_fields.unicast_write.noc_address;
             noc_async_write_one_packet(payload_start_address, noc_addr, payload_size_bytes);
             // temporarily place here until we have txn id support
             noc_async_writes_flushed();
-            // writes done, send ack back
-            tt::tt_fabric::udm::fabric_fast_write_ack<Direction>(mux_connections, packet_header);
+            // Register response for non-posted writes
+            register_write_or_atomic_response<Direction, tt::tt_fabric::NocSendType::NOC_UNICAST_WRITE>(
+                packet_header, response_pool);
         } break;
 
         case tt::tt_fabric::NocSendType::NOC_UNICAST_ATOMIC_INC: {
@@ -213,9 +257,9 @@ __attribute__((optimize("jump-tables"))) FORCE_INLINE void execute_noc_txn_to_lo
                 noc_async_write_barrier();
             }
             noc_semaphore_inc(noc_addr, increment);
-            // writes done, send ack back
-            tt::tt_fabric::udm::fabric_fast_atomic_ack<Direction>(mux_connections, packet_header);
-
+            // Register response for non-posted atomics
+            register_write_or_atomic_response<Direction, tt::tt_fabric::NocSendType::NOC_UNICAST_ATOMIC_INC>(
+                packet_header, response_pool);
         } break;
 
         case tt::tt_fabric::NocSendType::NOC_UNICAST_INLINE_WRITE: {
@@ -224,8 +268,9 @@ __attribute__((optimize("jump-tables"))) FORCE_INLINE void execute_noc_txn_to_lo
             noc_inline_dw_write<InlineWriteDst::DEFAULT, true>(noc_addr, value);
             // temporarily place here until we have txn id support
             noc_async_writes_flushed();
-            // writes done, send ack back
-            tt::tt_fabric::udm::fabric_fast_write_ack<Direction>(mux_connections, packet_header);
+            // Register response for non-posted writes
+            register_write_or_atomic_response<Direction, tt::tt_fabric::NocSendType::NOC_UNICAST_INLINE_WRITE>(
+                packet_header, response_pool);
         } break;
 
         case tt::tt_fabric::NocSendType::NOC_FUSED_UNICAST_ATOMIC_INC: {
@@ -238,8 +283,9 @@ __attribute__((optimize("jump-tables"))) FORCE_INLINE void execute_noc_txn_to_lo
                 noc_async_write_barrier();
             }
             noc_semaphore_inc(semaphore_dest_address, increment);
-            // writes done, send ack back - Do we also need to send atomic inc response back?
-            tt::tt_fabric::udm::fabric_fast_write_ack<Direction>(mux_connections, packet_header);
+            // Register response for non-posted fused atomics
+            register_write_or_atomic_response<Direction, tt::tt_fabric::NocSendType::NOC_FUSED_UNICAST_ATOMIC_INC>(
+                packet_header, response_pool);
         } break;
 
         case tt::tt_fabric::NocSendType::NOC_UNICAST_SCATTER_WRITE: {
@@ -257,24 +303,14 @@ __attribute__((optimize("jump-tables"))) FORCE_INLINE void execute_noc_txn_to_lo
             }
             // temporarily place here until we have txn id support
             noc_async_writes_flushed();
-            // writes done, send ack back
-            tt::tt_fabric::udm::fabric_fast_write_ack<Direction>(mux_connections, packet_header);
+            // Register response for non-posted scatter writes
+            register_write_or_atomic_response<Direction, tt::tt_fabric::NocSendType::NOC_UNICAST_SCATTER_WRITE>(
+                packet_header, response_pool);
         } break;
 
         case tt::tt_fabric::NocSendType::NOC_UNICAST_READ: {
-            const auto noc_addr = header.command_fields.unicast_read.noc_address;
-            const auto size_bytes = header.udm_control.read.size_bytes;
-            const auto num_slots = memory_pool.slots_needed(size_bytes);
-            // wait for space, allocate slots, and fill with noc_async_read (handles wrap)
-            while (!memory_pool.cb_has_enough_slots(num_slots)) {
-            }
-            memory_pool.cb_allocate_and_fill_slots(noc_addr, size_bytes);
-            // temporarily place here until we have txn id support
-            noc_async_read_barrier();
-            // reads done, send ack back (reads slot by slot from memory pool)
-            tt::tt_fabric::udm::fabric_fast_read_any_len_ack<Direction>(mux_connections, packet_header, memory_pool);
-            // free slots (FIFO)
-            memory_pool.cb_deallocate_slots(num_slots);
+            // Register the read response
+            register_read_response<Direction>(packet_header, response_pool, memory_pool);
         } break;
         default: {
             ASSERT(false);
@@ -282,21 +318,28 @@ __attribute__((optimize("jump-tables"))) FORCE_INLINE void execute_noc_txn_to_lo
     };
 }
 
-template <uint32_t Direction, uint8_t NUM_BUFFERS, uint8_t NUM_MUX_BUFFERS, typename UDMMemoryPoolType>
-void forward_data(
+// Main function to process inbound packets from the local router
+template <
+    uint32_t Direction,
+    uint8_t NUM_BUFFERS,
+    uint8_t NUM_MUX_BUFFERS,
+    typename UDMMemoryPoolType,
+    typename RegisteredResponsePoolType>
+void process_inbound_packet(
     tt::tt_fabric::FabricRelayChannelBuffer<NUM_BUFFERS>& channel,
     tt::tt_fabric::FabricRelayStaticSizedChannelWorkerInterface<NUM_BUFFERS>& worker_interface,
     std::array<tt::tt_fabric::FabricRelayToMuxSender<NUM_MUX_BUFFERS>, NUM_MUX_CONNECTIONS>& mux_connections,
     bool& channel_connection_established,
     StreamId my_channel_free_slots_stream_id,
-    UDMMemoryPoolType& memory_pool) {
+    UDMMemoryPoolType& memory_pool,
+    RegisteredResponsePoolType& response_pool) {
     bool has_unsent_payload = get_ptr_val(my_channel_free_slots_stream_id.get()) != NUM_BUFFERS;
     if (has_unsent_payload) {
         size_t buffer_address = channel.get_buffer_address(worker_interface.local_write_counter.get_buffer_index());
         invalidate_l1_cache();
         auto packet_header = reinterpret_cast<volatile tt_l1_ptr PACKET_HEADER_TYPE*>(buffer_address);
 
-        execute_noc_txn_to_local_chip<Direction>(mux_connections, packet_header, memory_pool);
+        execute_noc_txn_or_register_response<Direction>(mux_connections, packet_header, memory_pool, response_pool);
 
         worker_interface.local_write_counter.increment();
         worker_interface.local_read_counter.increment();
@@ -305,6 +348,108 @@ void forward_data(
 
         constexpr bool enable_deadlock_avoidance = true;  // not used
         worker_interface.template notify_persistent_connection_of_free_space<enable_deadlock_avoidance>(1);
+    }
+}
+
+// Helper: Send write/atomic response using existing fabric_fast_ack functions
+template <uint32_t Direction, typename RelayToMuxSenderType, size_t NumMuxConnections>
+FORCE_INLINE bool send_write_or_atomic_response(
+    std::array<RelayToMuxSenderType, NumMuxConnections>& mux_connections,
+    volatile tt::tt_fabric::udm::RegisteredResponse* response) {
+    uint32_t mux_idx = response->mux_index;
+    bool has_space_for_packet = mux_connections[mux_idx].edm_has_space_for_packet();
+    if (has_space_for_packet) {
+        switch (response->noc_send_type) {
+            case tt::tt_fabric::NocSendType::NOC_UNICAST_ATOMIC_INC:
+            case tt::tt_fabric::NocSendType::NOC_FUSED_UNICAST_ATOMIC_INC:
+                tt::tt_fabric::udm::fabric_fast_atomic_ack(mux_connections[mux_idx], response);
+                break;
+            case tt::tt_fabric::NocSendType::NOC_UNICAST_WRITE:
+            case tt::tt_fabric::NocSendType::NOC_UNICAST_INLINE_WRITE:
+            case tt::tt_fabric::NocSendType::NOC_UNICAST_SCATTER_WRITE:
+                tt::tt_fabric::udm::fabric_fast_write_ack(mux_connections[mux_idx], response);
+                break;
+            default: ASSERT(false); break;
+        }
+    }
+    return has_space_for_packet;
+}
+
+// Helper: Try to allocate memory pool slots for current read response chunk
+// Returns true if we allocated any slots (caller should then send them)
+template <typename UDMMemoryPoolType>
+FORCE_INLINE void allocate_read_memory(
+    UDMMemoryPoolType& memory_pool, volatile tt::tt_fabric::udm::RegisteredResponse* response) {
+    memory_pool.cb_allocate_and_fill_slots(response);
+}
+
+// Helper: Send ONE read response slot using fabric_fast_read_ack
+// Returns true if ALL slots have been sent (response complete)
+template <uint32_t Direction, typename RelayToMuxSenderType, size_t NumMuxConnections, typename UDMMemoryPoolType>
+FORCE_INLINE bool send_read_response_data(
+    std::array<RelayToMuxSenderType, NumMuxConnections>& mux_connections,
+    UDMMemoryPoolType& memory_pool,
+    volatile tt::tt_fabric::udm::RegisteredResponse* response) {
+    uint32_t mux_idx = response->mux_index;
+    bool response_completed = false;
+    bool has_space_for_packet = mux_connections[mux_idx].edm_has_space_for_packet();
+    if (has_space_for_packet && response->has_data_to_send()) {
+        constexpr uint32_t num_slots_dealloc = 1;
+        // Send one slot (helper handles fused atomic on last slot)
+        tt::tt_fabric::udm::fabric_fast_read_ack(mux_connections[mux_idx], response, memory_pool);
+
+        // Deallocate ONE slot from memory pool
+        memory_pool.cb_deallocate_slots(num_slots_dealloc);
+
+        // Update response: advance dest address, decrement counters
+        response_completed = response->complete_send(memory_pool.get_slot_size());
+    }
+    return response_completed;
+}
+
+// Helper: Process read response - allocate memory and send data back in chunks
+// Returns true when ALL chunks have been sent (response complete)
+template <uint32_t Direction, typename RelayToMuxSenderType, size_t NumMuxConnections, typename UDMMemoryPoolType>
+FORCE_INLINE bool process_read_response(
+    std::array<RelayToMuxSenderType, NumMuxConnections>& mux_connections,
+    UDMMemoryPoolType& memory_pool,
+    volatile tt::tt_fabric::udm::RegisteredResponse* response) {
+    // Allocate more slots if needed and space available
+    allocate_read_memory(memory_pool, response);
+
+    // Send if we have bytes in memory pool
+    bool response_completed;
+    response_completed = send_read_response_data<Direction>(mux_connections, memory_pool, response);
+    return response_completed;
+}
+
+// Main function to process responses from the registered response pool
+template <
+    uint32_t Direction,
+    typename RelayToMuxSenderType,
+    size_t NumMuxConnections,
+    typename UDMMemoryPoolType,
+    typename RegisteredResponsePoolType>
+FORCE_INLINE void process_response(
+    std::array<RelayToMuxSenderType, NumMuxConnections>& mux_connections,
+    UDMMemoryPoolType& memory_pool,
+    RegisteredResponsePoolType& response_pool) {
+    if (!response_pool.is_empty()) {
+        // Get the current response to process
+        volatile tt::tt_fabric::udm::RegisteredResponse* response = response_pool.get_registered_slot();
+
+        bool response_complete = false;
+        if (response->noc_send_type == tt::tt_fabric::NocSendType::NOC_UNICAST_READ) {
+            // Handle read response - allocate memory, read data, send back
+            response_complete = process_read_response<Direction>(mux_connections, memory_pool, response);
+        } else {
+            // Handle write/atomic response
+            response_complete = send_write_or_atomic_response<Direction>(mux_connections, response);
+        }
+        // Unregister response if complete
+        if (response_complete) {
+            response_pool.unregister_response();
+        }
     }
 }
 
@@ -318,6 +463,11 @@ void kernel_main() {
     tt::tt_fabric::udm::
         UDMMemoryPool<udm_memory_pool_base_address, udm_memory_pool_slot_size, udm_memory_pool_num_slots>
             memory_pool;
+
+    // Initialize the registered response pool for tracking pending responses
+    tt::tt_fabric::udm::
+        RegisteredResponsePool<udm_registered_response_pool_base_address, udm_registered_response_pool_num_slots>
+            response_pool;
 
     // clear out memory regions
     auto num_regions_to_clear = get_arg_val<uint32_t>(rt_args_idx++);
@@ -413,13 +563,18 @@ void kernel_main() {
 
     while (!got_immediate_termination_signal<true>(termination_signal_ptr)) {
         for (size_t i = 0; i < NUM_ITERS_BETWEEN_TEARDOWN_CHECKS; i++) {
-            forward_data<direction, NUM_BUFFERS, mux_num_buffers>(
+            process_inbound_packet<direction, NUM_BUFFERS, mux_num_buffers>(
                 channel,
                 worker_interface,
                 mux_connections,
                 channel_connection_established,
                 StreamId{channel_stream_id},
-                memory_pool);
+                memory_pool,
+                response_pool);
+
+            // Process registered responses (send acks for completed operations)
+            process_response<direction, tt::tt_fabric::FabricRelayToMuxSender<mux_num_buffers>, NUM_MUX_CONNECTIONS>(
+                mux_connections, memory_pool, response_pool);
         }
     }
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/31709

### Problem description
When we issue non posted read/write through fabric, we need to make sure the receiving device is non-blocking, meaning relay kernel will always be able to process the next packets, otherwise deadlock can happen.
Ex,
A device is sending read requests to B, B is also sending read requests to A, when B's relay kernel receives the request, and B's receiving channel filled up, thus A is stalled. Meanwhile, B sending to A requests, A's relay kernel also filled up the receiving channel. now, B's response is trying to send back to A, but A's receiving channel is already filled up, thus deadlock happen.
The simple approach is to never let relay stall, and always be able to process next packet.

### What's changed
Add a 20K slot pool in relay for registering the next packet response (32B, register the src device info, plus some ptrs for tracking read response).
Workers will send only have one read/write request on the flight, in wormhole t3k, we have 56 workers per device, 8 devices, so 448 on flight traffic which never fill up the 20K slot. Further optimization would be add a check in the UDM api to stall when we reach the max allowed traffic on the flight.
In blackhole, galaxy, we have 32 devices, 140 workers each, 4480 on flight is allowed, so we also won't fill up the pool.

Further change to allow multi-mesh would be spill the registered response pool to DRAM, to allowed ideally unlimited number of responses.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes