### PR TITLE
add more cores to 2x harvesting to support further harvested P150s

### DIFF
--- a/tt_metal/core_descriptors/blackhole_140_arch_fabric_mux.yaml
+++ b/tt_metal/core_descriptors/blackhole_140_arch_fabric_mux.yaml
@@ -149,7 +149,7 @@ unharvested:
         end: [11, 8]
 
 
-      # First half for fabric mux, second half for dispatch (12 cores total -> 6 each)
+      # First half for fabric mux, second half for dispatch (14 cores total -> 8/4 each)
       fabric_mux_cores:
         [[0, -1], [1, -1], [2, -1], [3, -1], [4, -1], [5, -1], [6, -1], [7, -1]]
 
@@ -165,7 +165,7 @@ unharvested:
         end: [11, 8]
 
 
-      # First half for fabric mux, second half for dispatch (12 cores total -> 6 each)
+      # First half for fabric mux, second half for dispatch (14 cores total -> 8/4 each)
       fabric_mux_cores:
         [[0, -1], [1, -1], [2, -1], [3, -1], [4, -1], [5, -1], [6, -1], [7, -1]]
 

--- a/tt_metal/core_descriptors/blackhole_140_arch_fabric_mux.yaml
+++ b/tt_metal/core_descriptors/blackhole_140_arch_fabric_mux.yaml
@@ -151,10 +151,10 @@ unharvested:
 
       # First half for fabric mux, second half for dispatch (12 cores total -> 6 each)
       fabric_mux_cores:
-        [[0, -1], [1, -1], [2, -1], [3, -1], [4, -1], [5, -1]]
+        [[0, -1], [1, -1], [2, -1], [3, -1], [4, -1], [5, -1], [6, -1], [7, -1]]
 
       dispatch_cores:
-        [[6, -1], [7, -1], [8, -1], [9, -1], [10, -1], [11, -1]]
+        [[8, -1], [9, -1], [10, -1], [11, -1]]
 
       dispatch_core_type:
         "tensix"
@@ -167,10 +167,10 @@ unharvested:
 
       # First half for fabric mux, second half for dispatch (12 cores total -> 6 each)
       fabric_mux_cores:
-        [[0, -1], [1, -1], [2, -1], [3, -1], [4, -1], [5, -1]]
+        [[0, -1], [1, -1], [2, -1], [3, -1], [4, -1], [5, -1], [6, -1], [7, -1]]
 
       dispatch_cores:
-        [[6, -1], [7, -1], [8, -1], [9, -1], [10, -1], [11, -1]]
+        [[8, -1], [9, -1], [10, -1], [11, -1]]
 
       dispatch_core_type:
         "tensix"


### PR DESCRIPTION
### Problem description
soft harvesting caused selection of 2xharvested field in desc, add more cores to it to make tests pass

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [x] upstream tests on current fw: https://github.com/tenstorrent/tt-metal/actions/runs/19876005017
- [x] CI on harvested experimental fw: https://github.com/tenstorrent/tt-metal/actions/runs/19871819152/job/56950304923
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/19875496642
- [x] BH nightly https://github.com/tenstorrent/tt-metal/actions/runs/19875505667
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes