### PR TITLE
[NOT FOR REVIEW] Allow pinned memory writes from host to device

### DIFF
--- a/tests/tt_metal/distributed/test_mesh_buffer.cpp
+++ b/tests/tt_metal/distributed/test_mesh_buffer.cpp
@@ -9,6 +9,8 @@
 #include <array>
 #include <cstddef>
 #include <initializer_list>
+#include <iomanip>
+#include <iostream>
 #include <memory>
 #include <numeric>
 #include <optional>
@@ -80,6 +82,83 @@ struct DeviceLocalShardedBufferTestConfig {
             this->tensor2d_shape_in_pages());
     }
 };
+
+// Helper function to print detailed mismatch information between two uint32_t vectors
+template <typename T>
+void print_vector_mismatch_details(const std::vector<T>& dst_aligned, const std::vector<T>& src) {
+    if (dst_aligned == src) {
+        return;  // No mismatch, nothing to print
+    }
+
+    size_t size = std::min(dst_aligned.size(), src.size());
+    std::vector<std::pair<size_t, size_t>> mismatch_ranges;  // pairs of (start_offset, count)
+
+    // Find all ranges of mismatches
+    size_t i = 0;
+    while (i < size) {
+        if (dst_aligned[i] != src[i]) {
+            size_t start = i;
+            size_t count = 0;
+            while (i < size && dst_aligned[i] != src[i]) {
+                count++;
+                i++;
+            }
+            mismatch_ranges.emplace_back(start, count);
+        } else {
+            i++;
+        }
+    }
+
+    // Print information for each mismatch range
+    std::cout << "\n=== DATA MISMATCH DETECTED ===\n";
+    std::cout << "Total elements: " << size << "\n";
+    std::cout << "Number of mismatch ranges: " << mismatch_ranges.size() << "\n\n";
+
+    for (const auto& [start_offset, mismatch_count] : mismatch_ranges) {
+        std::cout << "Mismatch Range: offset=" << start_offset << ", count=" << mismatch_count << "\n";
+
+        // Print header
+        std::cout << "Offset   ";
+        for (int j = 0; j < 8; j++) {
+            std::cout << " | Dst:" << j << "    Src:" << j << "   ";
+        }
+        std::cout << "|\n";
+        std::cout << std::string(190, '-') << "\n";
+
+        // Print up to 128 pairs (or the actual count if less)
+        size_t pairs_to_print = std::min(mismatch_count, size_t(128));
+
+        for (size_t offset = 0; offset < pairs_to_print; offset += 8) {
+            size_t pairs_in_line = std::min(size_t(8), pairs_to_print - offset);
+
+            // Print offset for this line
+            std::cout << std::setw(8) << std::left << (start_offset + offset) << " ";
+
+            // Print 8 pairs (or fewer if at the end)
+            for (size_t j = 0; j < pairs_in_line; j++) {
+                size_t idx = start_offset + offset + j;
+                std::cout << " | 0x" << std::hex << std::setfill('0') << std::setw(8) << dst_aligned[idx] << " 0x"
+                          << std::hex << std::setfill('0') << std::setw(8) << src[idx];
+                std::cout << std::dec << std::setfill(' ');
+            }
+            // Fill remaining columns if less than 8 pairs in this line
+            for (size_t j = pairs_in_line; j < 8; j++) {
+                std::cout << " |                      ";
+            }
+            std::cout << " |\n";
+        }
+
+        if (mismatch_count > 128) {
+            std::cout << "... (" << (mismatch_count - 128) << " more mismatched values not shown)\n";
+        }
+        std::cout << "\n";
+    }
+
+    if (dst_aligned.size() != src.size()) {
+        std::cout << "WARNING: Size mismatch - dst_aligned.size()=" << dst_aligned.size()
+                  << ", src.size()=" << src.size() << "\n";
+    }
+}
 
 TEST_F(MeshBufferTest2x4, ShardedBufferInitialization) {
     const DeviceLocalBufferConfig device_local_config{
@@ -617,42 +696,45 @@ TEST_F(MeshBufferTestSuite, EnqueueReadShardsWithPinnedMemoryFullRange) {
     std::vector<uint32_t> src(bytes_per_device / sizeof(uint32_t), 0);
     std::iota(src.begin(), src.end(), 0);
 
-    distributed::MeshCoordinate coord(0, 0);
-    auto write_transfer = distributed::MeshCommandQueue::ShardDataTransfer{
-        .shard_coord = coord,
-        .host_data = static_cast<void*>(const_cast<uint32_t*>(src.data())),
-        .pinned_memory = nullptr,
-        .region = BufferRegion(0, bytes_per_device),
-    };
-    mesh_device_->mesh_command_queue().enqueue_write_shards(mesh_buffer, {write_transfer}, /*blocking=*/true);
-
     // Prepare destination buffer and pin the entire destination range for the target shard
     auto dst = std::make_shared<vector_aligned<uint32_t>>(bytes_per_device / sizeof(uint32_t), 0);
     uint32_t* dst_ptr_aligned = reinterpret_cast<uint32_t*>(dst->data());
-
     // Create HostBuffer on top of dst
     HostBuffer host_buffer(
         tt::stl::Span<uint32_t>(dst_ptr_aligned, bytes_per_device / sizeof(uint32_t)), MemoryPin(dst));
+    distributed::MeshCoordinateRange coord_range(mesh_device_->shape());
+    for (auto coord : coord_range) {
+        log_info(tt::LogTest, "Testing reading to pinned memory for shard at coord {}", coord);
+        auto write_transfer = distributed::MeshCommandQueue::ShardDataTransfer{
+            .shard_coord = coord,
+            .host_data = static_cast<void*>(const_cast<uint32_t*>(src.data())),
+            .pinned_memory = nullptr,
+            .region = BufferRegion(0, bytes_per_device),
+        };
+        mesh_device_->mesh_command_queue().enqueue_write_shards(mesh_buffer, {write_transfer}, /*blocking=*/true);
+        // Initialize read destination and send read request
+        std::fill(dst->begin(), dst->end(), 0);
+        auto coordinate_range_set = MeshCoordinateRangeSet(MeshCoordinateRange(coord, coord));
+        auto pinned_unique = mesh_device_->pin_memory(
+            coordinate_range_set,
+            host_buffer,
+            /*map_to_noc=*/true);
+        std::shared_ptr<PinnedMemory> pinned_shared = std::move(pinned_unique);
 
-    auto coordinate_range_set = MeshCoordinateRangeSet(MeshCoordinateRange(coord, coord));
-    auto pinned_unique = mesh_device_->pin_memory(
-        coordinate_range_set,
-        host_buffer,
-        /*map_to_noc=*/true);
-    std::shared_ptr<PinnedMemory> pinned_shared = std::move(pinned_unique);
+        // Read back using enqueue_read_shards with pinned_memory populated
+        auto read_transfer = distributed::MeshCommandQueue::ShardDataTransfer{
+            .shard_coord = coord,
+            .host_data = static_cast<void*>(dst_ptr_aligned),
+            .pinned_memory = pinned_shared,
+            .region = BufferRegion(0, bytes_per_device),
+        };
+        mesh_device_->mesh_command_queue().enqueue_read_shards({read_transfer}, mesh_buffer, /*blocking=*/true);
 
-    // Read back using enqueue_read_shards with pinned_memory populated
-    auto read_transfer = distributed::MeshCommandQueue::ShardDataTransfer{
-        .shard_coord = coord,
-        .host_data = static_cast<void*>(dst_ptr_aligned),
-        .pinned_memory = pinned_shared,
-        .region = BufferRegion(0, bytes_per_device),
-    };
-    mesh_device_->mesh_command_queue().enqueue_read_shards({read_transfer}, mesh_buffer, /*blocking=*/true);
+        std::vector<uint32_t> dst_aligned(dst_ptr_aligned, dst_ptr_aligned + (bytes_per_device / sizeof(uint32_t)));
 
-    std::vector<uint32_t> dst_aligned(dst_ptr_aligned, dst_ptr_aligned + (bytes_per_device / sizeof(uint32_t)));
-
-    EXPECT_EQ(dst_aligned, src);
+        print_vector_mismatch_details(dst_aligned, src);
+        EXPECT_EQ(dst_aligned, src);
+    }
 }
 
 TEST_F(MeshBufferTestSuite, EnqueueReadShardsWithPinnedMemoryFullRangeUnaligned) {
@@ -677,15 +759,6 @@ TEST_F(MeshBufferTestSuite, EnqueueReadShardsWithPinnedMemoryFullRangeUnaligned)
     std::vector<uint8_t> src(bytes_per_device, 0);
     std::iota(src.begin(), src.end(), 0);
 
-    distributed::MeshCoordinate coord(0, 0);
-    auto write_transfer = distributed::MeshCommandQueue::ShardDataTransfer{
-        .shard_coord = coord,
-        .host_data = src.data(),
-        .pinned_memory = nullptr,
-        .region = BufferRegion(0, bytes_per_device),
-    };
-    mesh_device_->mesh_command_queue().enqueue_write_shards(mesh_buffer, {write_transfer}, /*blocking=*/true);
-
     constexpr size_t unaligned_shift = 3;
     // Prepare destination buffer and pin the entire destination range for the target shard
     auto dst = std::make_shared<vector_aligned<uint8_t>>(bytes_per_device + unaligned_shift, 0);
@@ -695,25 +768,102 @@ TEST_F(MeshBufferTestSuite, EnqueueReadShardsWithPinnedMemoryFullRangeUnaligned)
     HostBuffer host_buffer(
         tt::stl::Span<uint8_t>(dst_ptr_unaligned, bytes_per_device), MemoryPin(dst));
 
-    auto coordinate_range_set = MeshCoordinateRangeSet(MeshCoordinateRange(coord, coord));
-    auto pinned_unique = mesh_device_->pin_memory(
-        coordinate_range_set,
-        host_buffer,
-        /*map_to_noc=*/true);
-    std::shared_ptr<PinnedMemory> pinned_shared = std::move(pinned_unique);
+    distributed::MeshCoordinateRange coord_range(mesh_device_->shape());
+    for (auto coord : coord_range) {
+        log_info(tt::LogTest, "Testing reading to unaligned pinned memory for shard at coord {}", coord);
+        auto write_transfer = distributed::MeshCommandQueue::ShardDataTransfer{
+            .shard_coord = coord,
+            .host_data = src.data(),
+            .pinned_memory = nullptr,
+            .region = BufferRegion(0, bytes_per_device),
+        };
+        mesh_device_->mesh_command_queue().enqueue_write_shards(mesh_buffer, {write_transfer}, /*blocking=*/true);
+        // Initialize read destination and send read request
+        std::fill(dst->begin(), dst->end(), 0);
+        auto coordinate_range_set = MeshCoordinateRangeSet(MeshCoordinateRange(coord, coord));
+        auto pinned_unique = mesh_device_->pin_memory(
+            coordinate_range_set,
+            host_buffer,
+            /*map_to_noc=*/true);
+        std::shared_ptr<PinnedMemory> pinned_shared = std::move(pinned_unique);
 
-    // Read back using enqueue_read_shards with pinned_memory populated
-    auto read_transfer = distributed::MeshCommandQueue::ShardDataTransfer{
-        .shard_coord = coord,
-        .host_data = static_cast<void*>(dst_ptr_unaligned),
-        .pinned_memory = pinned_shared,
-        .region = BufferRegion(0, bytes_per_device),
-    };
-    mesh_device_->mesh_command_queue().enqueue_read_shards({read_transfer}, mesh_buffer, /*blocking=*/true);
+        // Read back using enqueue_read_shards with pinned_memory populated
+        auto read_transfer = distributed::MeshCommandQueue::ShardDataTransfer{
+            .shard_coord = coord,
+            .host_data = static_cast<void*>(dst_ptr_unaligned),
+            .pinned_memory = pinned_shared,
+            .region = BufferRegion(0, bytes_per_device),
+        };
+        mesh_device_->mesh_command_queue().enqueue_read_shards({read_transfer}, mesh_buffer, /*blocking=*/true);
 
-    std::vector<uint8_t> dst_aligned(dst_ptr_unaligned, dst_ptr_unaligned + bytes_per_device);
+        std::vector<uint8_t> dst_aligned(dst_ptr_unaligned, dst_ptr_unaligned + bytes_per_device);
 
-    EXPECT_EQ(dst_aligned, src);
+        EXPECT_EQ(dst_aligned, src);
+    }
+}
+
+TEST_F(MeshBufferTestSuite, EnqueueWriteShardsWithPinnedMemoryFullRange) {
+    if (!mesh_device_->get_memory_pinning_parameters().can_map_to_noc) {
+        GTEST_SKIP() << "Mapping host memory to NOC is not supported on this system";
+        return;
+    }
+    uint32_t single_tile_size = ::tt::tile_size(DataFormat::UInt32);
+
+    // Use a replicated mesh buffer so per-device buffers are interleaved (not sharded)
+    DeviceLocalBufferConfig per_device_buffer_config{
+        .page_size = single_tile_size, .buffer_type = BufferType::DRAM, .bottom_up = true};
+
+    // Make the buffer multiple tiles to exercise multi-page transfers
+    const uint32_t tiles_per_device = 128;
+    const uint32_t bytes_per_device = tiles_per_device * single_tile_size;
+
+    ReplicatedBufferConfig global_buffer_config{.size = bytes_per_device};
+    auto mesh_buffer = MeshBuffer::create(global_buffer_config, per_device_buffer_config, mesh_device_.get());
+
+    auto& hal = tt::tt_metal::MetalContext::instance().hal();
+    constexpr int device_read_align{32};
+    ASSERT_TRUE(device_read_align == hal.get_read_alignment(HalMemType::HOST))
+        << "Source vector alignment must be equal to PCIE read alignment: " << hal.get_read_alignment(HalMemType::HOST)
+        << std::endl;
+    // Prepare write source buffer and pin the entire destination range for the target shard
+    auto src = std::make_shared<std::vector<uint32_t, tt::stl::aligned_allocator<uint32_t, device_read_align>>>(
+        bytes_per_device / sizeof(uint32_t), 0);
+    std::iota(src->begin(), src->end(), 0);
+    // Create HostBuffer on top of src
+    HostBuffer host_buffer(tt::stl::Span<uint32_t>(src->data(), bytes_per_device / sizeof(uint32_t)), MemoryPin(src));
+    // Prepare read destination buffer. Use aigned vector for ease of verification with src above.
+    auto dst = std::vector<uint32_t, tt::stl::aligned_allocator<uint32_t, device_read_align>>(
+        bytes_per_device / sizeof(uint32_t), 0);
+
+    distributed::MeshCoordinateRange coord_range(mesh_device_->shape());
+    for (auto coord : coord_range) {
+        log_info(tt::LogTest, "Testing writing from pinned memory to shard at coord {}", coord);
+        auto coordinate_range_set = MeshCoordinateRangeSet(MeshCoordinateRange(coord, coord));
+        auto pinned_unique = mesh_device_->pin_memory(
+            coordinate_range_set,
+            host_buffer,
+            /*map_to_noc=*/true);
+        std::shared_ptr<PinnedMemory> pinned_shared = std::move(pinned_unique);
+
+        auto write_transfer = distributed::MeshCommandQueue::ShardDataTransfer{
+            .shard_coord = coord,
+            .host_data = static_cast<void*>(src->data()),
+            .pinned_memory = pinned_shared,
+            .region = BufferRegion(0, bytes_per_device),
+        };
+        mesh_device_->mesh_command_queue().enqueue_write_shards(mesh_buffer, {write_transfer}, /*blocking=*/true);
+
+        // Read back via hugepage
+        std::fill(dst.begin(), dst.end(), 0);
+        auto read_transfer = distributed::MeshCommandQueue::ShardDataTransfer{
+            .shard_coord = coord,
+            .host_data = static_cast<void*>(dst.data()),
+            .pinned_memory = nullptr,
+            .region = BufferRegion(0, bytes_per_device),
+        };
+        mesh_device_->mesh_command_queue().enqueue_read_shards({read_transfer}, mesh_buffer, /*blocking=*/true);
+        EXPECT_EQ(*src, dst);
+    }
 }
 
 }  // namespace

--- a/tests/tt_metal/tt_metal/device/test_device.cpp
+++ b/tests/tt_metal/tt_metal/device/test_device.cpp
@@ -35,6 +35,14 @@
 #include "impl/context/metal_context.hpp"
 #include "tt_cluster.hpp"
 #include "tt_metal/test_utils/stimulus.hpp"
+// Mesh device test dependencies
+#include <tt-metalium/distributed.hpp>
+#include <tt-metalium/mesh_coord.hpp>
+#include <tt-metalium/pinned_memory.hpp>
+#include <tt-metalium/host_buffer.hpp>
+#include <tt-metalium/vector_aligned.hpp>
+#include "tests/tt_metal/tt_metal/common/multi_device_fixture.hpp"
+#include "command_queue_fixture.hpp"
 
 namespace tt::tt_metal {
 
@@ -315,7 +323,7 @@ TEST_F(MeshDeviceFixture, TensixTestL1ToPCIeAt16BAlignedAddress) {
         DataMovementConfig{
             .processor = DataMovementProcessor::RISCV_1,
             .noc = NOC::RISCV_0_default,
-            .compile_args = {base_l1_src_address, base_pcie_dst_address, num_16b_writes}});
+            .compile_args = {base_l1_src_address, base_pcie_dst_address, 0, num_16b_writes}});
 
     distributed::EnqueueMeshWorkload(cq, workload, false);
 
@@ -379,6 +387,84 @@ TEST_F(BlackholeSingleCardFixture, TensixL1DataCache) {
 
     tt_metal::detail::ReadFromDeviceL1(device, core, l1_unreserved_base, sizeof(uint32_t), random_vec);
     EXPECT_EQ(random_vec[0], value_to_write);
+}
+
+// Test to ensure writing from 16B aligned L1 address to 16B aligned pinned memory works using MeshDevice
+TEST_F(UnitMeshCQSingleCardFixture, MeshL1ToPinnedMemoryAt16BAlignedAddress) {
+    using tt::tt_metal::distributed::EnqueueMeshWorkload;
+    using tt::tt_metal::distributed::MeshCoordinate;
+    using tt::tt_metal::distributed::MeshCoordinateRange;
+    using tt::tt_metal::distributed::MeshCoordinateRangeSet;
+    using tt::tt_metal::distributed::MeshWorkload;
+
+    auto mesh_device = devices_.at(0);
+
+    // Skip if mapping to NOC isn't supported on this system
+    if (!mesh_device->get_memory_pinning_parameters().can_map_to_noc) {
+        GTEST_SKIP() << "Mapping host memory to NOC is not supported on this system";
+    }
+
+    // Use first device from the mesh for this test
+    MeshCoordinate target_coord(0, 0);
+    IDevice* device = mesh_device->get_device(target_coord);
+    EXPECT_TRUE(device->is_mmio_capable());
+
+    CoreCoord logical_core(0, 0);
+
+    uint32_t base_l1_src_address = device->allocator()->get_base_allocator_addr(HalMemType::L1) +
+                                   MetalContext::instance().hal().get_alignment(HalMemType::L1);
+
+    uint32_t size_bytes = 2048 * 128;
+    std::vector<uint32_t> src =
+        tt::test_utils::generate_uniform_random_vector<uint32_t>(0, UINT32_MAX, size_bytes / sizeof(uint32_t));
+    EXPECT_EQ(MetalContext::instance().hal().get_alignment(HalMemType::L1), 16);
+    uint32_t num_16b_writes = size_bytes / MetalContext::instance().hal().get_alignment(HalMemType::L1);
+
+    // Allocate and pin host memory
+    auto aligned_buf = std::make_shared<tt::tt_metal::vector_aligned<uint32_t>>(size_bytes / sizeof(uint32_t), 0);
+    tt::tt_metal::HostBuffer host_buffer_view(
+        tt::stl::Span<uint32_t>(aligned_buf->data(), aligned_buf->size()), tt::tt_metal::MemoryPin(aligned_buf));
+    auto coordinate_range_set = MeshCoordinateRangeSet(MeshCoordinateRange(target_coord, target_coord));
+    auto pinned_memory = mesh_device->pin_memory(
+        coordinate_range_set,
+        host_buffer_view,
+        true  // map_to_noc
+    );
+
+    // Get the pinned memory address that the device can write to
+    uint64_t pinned_memory_device_addr = pinned_memory->get_device_addr(device->id());
+
+    // Write source data to L1
+    tt_metal::detail::WriteToDeviceL1(device, logical_core, base_l1_src_address, src);
+
+    // Create program and kernel for mesh workload
+    tt_metal::Program program = tt_metal::CreateProgram();
+    CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/pcie_write_16b.cpp",
+        logical_core,
+        DataMovementConfig{
+            .processor = DataMovementProcessor::RISCV_1,
+            .noc = NOC::RISCV_0_default,
+            .compile_args = {
+                base_l1_src_address,
+                (uint32_t)pinned_memory_device_addr,
+                (uint32_t)(pinned_memory_device_addr >> 32),
+                num_16b_writes}});
+
+    // Create mesh workload and add program
+    MeshWorkload mesh_workload;
+    MeshCoordinateRange device_range(target_coord, target_coord);
+    mesh_workload.add_program(device_range, std::move(program));
+
+    // Launch workload using mesh command queue
+    auto& mesh_cq = mesh_device->mesh_command_queue();
+    EnqueueMeshWorkload(mesh_cq, mesh_workload, true);  // blocking = true
+
+    // Verify the data was written correctly to pinned memory
+    // Compare with a std::vector copy to avoid allocator type mismatch in EXPECT_EQ
+    std::vector<uint32_t> aligned_copy(aligned_buf->begin(), aligned_buf->end());
+    EXPECT_EQ(src, aligned_copy);
 }
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/pcie_write_16b.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/pcie_write_16b.cpp
@@ -8,13 +8,14 @@
 
 void kernel_main() {
     constexpr uint32_t base_l1_src_address = get_compile_time_arg_val(0);
-    constexpr uint32_t base_pcie_dst_address = get_compile_time_arg_val(1);
-    constexpr uint32_t num_16b_writes = get_compile_time_arg_val(2);
+    constexpr uint32_t base_pcie_dst_address_low = get_compile_time_arg_val(1);
+    constexpr uint32_t base_pcie_dst_address_high = get_compile_time_arg_val(2);
+    constexpr uint32_t num_16b_writes = get_compile_time_arg_val(3);
 
     uint64_t pcie_core_noc_encoding = uint64_t(NOC_XY_PCIE_ENCODING(PCIE_NOC_X, PCIE_NOC_Y));
 
     uint32_t l1_src_address = base_l1_src_address;
-    uint32_t pcie_dst_address = base_pcie_dst_address;
+    uint64_t pcie_dst_address = base_pcie_dst_address_low | (uint64_t(base_pcie_dst_address_high) << 32);
     for (uint32_t i = 0; i < num_16b_writes; i++) {
         uint64_t dst_noc_addr = pcie_core_noc_encoding | pcie_dst_address;
         noc_async_write(l1_src_address, dst_noc_addr, L1_ALIGNMENT);

--- a/tests/ttnn/benchmark/python/benchmark_device_copies.py
+++ b/tests/ttnn/benchmark/python/benchmark_device_copies.py
@@ -93,8 +93,11 @@ def test_benchmark_copy_device_to_host_tensor(benchmark, device_id):
     device_tensor = ttnn.rand(DEFAULT_TENSOR_SIZE, dtype=DEFAULT_DTYPE, layout=DEFAULT_LAYOUT, device=device)
     host_tensor = ttnn.allocate_tensor_on_host(device_tensor.spec, device)
 
+    ttnn.synchronize_device(device)
+
     def run():
         ttnn.copy_device_to_host_tensor(device_tensor, host_tensor)
         ttnn.synchronize_device(device)
 
     benchmark(run)
+    ttnn.close_device(device)

--- a/tt_metal/api/tt-metalium/host_buffer.hpp
+++ b/tt_metal/api/tt-metalium/host_buffer.hpp
@@ -17,6 +17,7 @@
 #include <vector>
 
 namespace tt::tt_metal {
+class PinnedMemory;
 
 // HostBuffer is a wrapper around contiguous data, which can either be owned or borrowed from external sources (Python
 // objects, mmap-ed regions, etc).
@@ -65,10 +66,14 @@ public:
     // Returns the memory pin of the host buffer.
     MemoryPin pin() const { return pin_; }
 
+    void set_pinned_memory(std::shared_ptr<PinnedMemory> pinned_memory);
+    std::shared_ptr<PinnedMemory> get_pinned_memory() const;
+
 private:
     MemoryPin pin_;
     tt::stl::Span<std::byte> view_;
     const std::type_info* type_info_ = nullptr;
+    std::shared_ptr<PinnedMemory> pinned_memory_ = nullptr;
 };
 
 template <typename T>

--- a/tt_metal/api/tt-metalium/mesh_command_queue.hpp
+++ b/tt_metal/api/tt-metalium/mesh_command_queue.hpp
@@ -83,7 +83,7 @@ public:
         MeshCoordinate shard_coord;
         void* host_data = nullptr;
         std::shared_ptr<PinnedMemory> pinned_memory = nullptr;
-        std::optional<BufferRegion> region;
+        std::optional<BufferRegion> region = std::nullopt;
     };
 
     // MeshBuffer Write APIs
@@ -92,9 +92,13 @@ public:
         const void* host_data,
         const MeshCoordinateRange& device_range,
         bool blocking,
-        std::optional<BufferRegion> region = std::nullopt) = 0;
+        std::optional<BufferRegion> region = std::nullopt,
+        std::shared_ptr<tt_metal::PinnedMemory> pinned_memory = nullptr) = 0;
     virtual void enqueue_write_mesh_buffer(
-        const std::shared_ptr<MeshBuffer>& buffer, const void* host_data, bool blocking) = 0;
+        const std::shared_ptr<MeshBuffer>& buffer,
+        const void* host_data,
+        bool blocking,
+        std::shared_ptr<tt_metal::PinnedMemory> pinned_memory = nullptr) = 0;
     virtual void enqueue_write_shards(
         const std::shared_ptr<MeshBuffer>& mesh_buffer,
         const std::vector<ShardDataTransfer>& shard_data_transfers,

--- a/tt_metal/api/tt-metalium/mesh_command_queue.hpp
+++ b/tt_metal/api/tt-metalium/mesh_command_queue.hpp
@@ -82,6 +82,7 @@ public:
     struct ShardDataTransfer {
         MeshCoordinate shard_coord;
         void* host_data = nullptr;
+        std::shared_ptr<PinnedMemory> pinned_memory = nullptr;
         std::optional<BufferRegion> region;
     };
 

--- a/tt_metal/api/tt-metalium/mesh_device.hpp
+++ b/tt_metal/api/tt-metalium/mesh_device.hpp
@@ -16,9 +16,7 @@
 #include <set>
 #include <string>
 #include <tuple>
-#include <unordered_map>
 #include <unordered_set>
-#include <utility>
 #include <vector>
 
 #include <hostdevcommon/common_values.hpp>
@@ -34,6 +32,7 @@
 #include <tt-metalium/sub_device_types.hpp>
 #include <umd/device/types/arch.hpp>
 #include <umd/device/types/core_coordinates.hpp>
+#include <tt-metalium/host_buffer.hpp>
 
 namespace tt {
 namespace tt_metal {
@@ -41,6 +40,7 @@ class Allocator;
 class CommandQueue;
 class SubDevice;
 class SystemMemoryManager;
+class PinnedMemory;
 namespace program_cache {
 namespace detail {
 struct ProgramCache;
@@ -133,6 +133,16 @@ private:
     std::shared_ptr<MeshTraceBuffer>& create_mesh_trace(const MeshTraceId& trace_id);
 
     std::lock_guard<std::mutex> lock_api() { return std::lock_guard<std::mutex>(api_mutex_); }
+
+public:
+    struct MemoryPinningParameters {
+        uint32_t max_pins;
+        uint64_t max_total_pin_size;
+        bool can_map_to_noc;
+    };
+
+private:
+    MemoryPinningParameters memory_pinning_params_{};
 
 public:
     MeshDevice(
@@ -312,6 +322,20 @@ public:
     // Currently expose users to the dispatch thread pool through the MeshDevice
     void enqueue_to_thread_pool(std::function<void()>&& f);
     void wait_for_thread_pool();
+
+    /**
+     * @brief Pin existing host memory for a specific set of mesh coordinates
+     * @param coordinate_range_set Set of mesh coordinates to pin memory for
+     * @param host_buffer Existing host memory to map (must not be null)
+     * @param buffer_size Size of buffer to map to each device
+     * @param map_to_noc Whether to map the buffer to the NOC
+     * @return Unique pointer to the created PinnedMemory instance
+     */
+    std::unique_ptr<PinnedMemory> pin_memory(
+        const MeshCoordinateRangeSet& coordinate_range_set, HostBuffer& host_buffer, bool map_to_noc = false);
+
+    MemoryPinningParameters get_memory_pinning_parameters() const;
+
     static std::shared_ptr<MeshDevice> create(
         const MeshDeviceConfig& config,
         size_t l1_small_size = DEFAULT_L1_SMALL_SIZE,

--- a/tt_metal/api/tt-metalium/pinned_memory.hpp
+++ b/tt_metal/api/tt-metalium/pinned_memory.hpp
@@ -1,0 +1,152 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <utility>
+#include <vector>
+
+#include <umd/device/types/cluster_descriptor_types.h>  // chip_id_t
+
+namespace tt::umd {
+class SysmemBuffer;
+}
+
+namespace tt::tt_metal {
+
+class IDevice;
+class PinnedMemoryImpl;
+
+namespace distributed {
+class MeshDevice;
+class MeshEvent;
+}  // namespace distributed
+
+/**
+ * @brief PinnedMemory manages system memory buffers across multiple devices.
+ *
+ * This class provides a convenient wrapper around UMD SysmemBuffers, managing
+ * one buffer per device in a mesh or set of devices. It handles allocation,
+ * mapping, and access to pinned system memory that can be accessed by the devices.
+ */
+class PinnedMemory {
+public:
+    struct NocAddr {
+        uint64_t addr;
+        chip_id_t device_id;
+    };
+
+    ~PinnedMemory();
+
+    // Move semantics
+    PinnedMemory(PinnedMemory&& other) noexcept;
+    PinnedMemory& operator=(PinnedMemory&& other) noexcept;
+
+    // Delete copy semantics
+    PinnedMemory(const PinnedMemory&) = delete;
+    PinnedMemory& operator=(const PinnedMemory&) = delete;
+
+    /**
+     * @brief Get the underlying SysmemBuffer for a specific device
+     * @param device_id The device ID to get the buffer for
+     * @return Reference to the SysmemBuffer
+     */
+    tt::umd::SysmemBuffer& get_buffer(chip_id_t device_id);
+    const tt::umd::SysmemBuffer& get_buffer(chip_id_t device_id) const;
+
+    /**
+     * @brief Get host pointer to the shared pinned memory
+     * @return Host pointer to the buffer (same for all devices)
+     */
+    void* get_host_ptr();
+    const void* get_host_ptr() const;
+
+    /**
+     * @brief Get device address for a specific device's buffer
+     * @param device_id The device ID to get the device address for
+     * @return Device address of the buffer
+     */
+    uint64_t get_device_addr(chip_id_t device_id) const;
+
+    /**
+     * @brief Get NOC address and the chip where it's usable from
+     * @param device_id The device ID to get the NOC address for
+     * @return Optional pair of (NOC address, MMIO chip ID) if buffer is mapped to NOC, nullopt otherwise
+     */
+    std::optional<NocAddr> get_noc_addr(chip_id_t device_id) const;
+
+    /**
+     * @brief Get the buffer size.
+     * @return Size of the pinned region in bytes.
+     */
+    size_t get_buffer_size() const;
+
+    /**
+     * @brief Get all device IDs managed by this PinnedMemory
+     * @return Vector of device IDs
+     */
+    std::vector<chip_id_t> get_device_ids() const;
+
+    /**
+     * @brief Check if a device ID is managed by this PinnedMemory
+     * @param device_id The device ID to check
+     * @return True if the device is managed, false otherwise
+     */
+    bool has_device(chip_id_t device_id) const;
+
+    /**
+     * @brief Check if the pinned memory is usable from NOC for a specific device
+     * @param device_id The device ID to check
+     * @return True if the device can access the buffer via NOC (i.e., map_to_noc is true and device is MMIO-capable)
+     */
+    bool usable_from_noc(chip_id_t device_id) const;
+
+    /**
+     * @brief Add a barrier event that must complete before memory can be locked
+     * @param event The MeshEvent to add as a barrier
+     *
+     * This method adds an event to the barrier queue. The event must complete
+     * before the memory can be safely accessed via lock().
+     */
+    void add_barrier_event(const distributed::MeshEvent& event);
+
+    /**
+     * @brief Lock the pinned memory for host access
+     * @return Pointer to the host memory that can be safely accessed
+     *
+     * This method blocks until all pending barrier events have completed,
+     * then returns a pointer to the pinned memory. The memory should be
+     * unlocked with unlock() when access is no longer needed.
+     */
+    void* lock();
+
+    /**
+     * @brief Unlock the pinned memory
+     *
+     * This method releases the lock on the pinned memory, allowing it to be
+     * safely accessed by devices again. Currently this is a no-op but should
+     * be called for future compatibility and clarity of intent.
+     */
+    void unlock();
+
+private:
+    friend class distributed::MeshDevice;
+
+    /**
+     * @brief Construct PinnedMemory by mapping existing host memory to devices
+     * @param devices Vector of devices to map buffers for
+     * @param host_buffer Existing host memory to map (must not be null)
+     * @param buffer_size Size of buffer to map
+     * @param map_to_noc Whether to map the buffer to the NOC
+     */
+    PinnedMemory(const std::vector<IDevice*>& devices, void* host_buffer, size_t buffer_size, bool map_to_noc = false);
+
+    std::unique_ptr<PinnedMemoryImpl> pImpl;
+};
+
+}  // namespace tt::tt_metal

--- a/tt_metal/common/host_buffer.cpp
+++ b/tt_metal/common/host_buffer.cpp
@@ -42,6 +42,10 @@ tt::stl::Span<std::byte> HostBuffer::view_bytes() & noexcept { return view_; }
 
 tt::stl::Span<const std::byte> HostBuffer::view_bytes() const& noexcept { return view_; }
 
+void HostBuffer::set_pinned_memory(std::shared_ptr<PinnedMemory> pinned_memory) { pinned_memory_ = pinned_memory; }
+
+std::shared_ptr<PinnedMemory> HostBuffer::get_pinned_memory() const { return pinned_memory_; }
+
 bool operator==(const HostBuffer& a, const HostBuffer& b) noexcept {
     auto a_view = a.view_bytes();
     auto b_view = b.view_bytes();

--- a/tt_metal/distributed/CMakeLists.txt
+++ b/tt_metal/distributed/CMakeLists.txt
@@ -14,6 +14,7 @@ set(DISTRIBUTED_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/mesh_trace.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/mesh_workload.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/mesh_workload_utils.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/pinned_memory.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/system_mesh.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/system_mesh_translation_map.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/distributed_host_buffer.cpp

--- a/tt_metal/distributed/fd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.cpp
@@ -49,6 +49,7 @@
 #include <umd/device/types/xy_pair.hpp>
 #include <tt-metalium/graph_tracking.hpp>
 #include <tt_stl/overloaded.hpp>
+#include <tt-metalium/pinned_memory.hpp>
 
 namespace tt {
 namespace tt_metal {
@@ -520,7 +521,8 @@ void FDMeshCommandQueue::write_shard_to_device(
     const MeshCoordinate& device_coord,
     const void* src,
     const std::optional<BufferRegion>& region,
-    tt::stl::Span<const SubDeviceId> sub_device_ids) {
+    tt::stl::Span<const SubDeviceId> sub_device_ids,
+    std::shared_ptr<PinnedMemory> pinned_memory) {
     if (!mesh_device_->is_local(device_coord)) {
         return;
     }
@@ -537,7 +539,13 @@ void FDMeshCommandQueue::write_shard_to_device(
 
     sub_device_ids = buffer_dispatch::select_sub_device_ids(mesh_device_, sub_device_ids);
     buffer_dispatch::write_to_device_buffer(
-        src, *shard_view, id_, expected_num_workers_completed_, this->dispatch_core_type(), sub_device_ids);
+        src,
+        *shard_view,
+        id_,
+        expected_num_workers_completed_,
+        this->dispatch_core_type(),
+        sub_device_ids,
+        pinned_memory);
 }
 
 void FDMeshCommandQueue::read_shard_from_device(

--- a/tt_metal/distributed/fd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.cpp
@@ -544,6 +544,7 @@ void FDMeshCommandQueue::read_shard_from_device(
     const MeshBuffer& buffer,
     const MeshCoordinate& device_coord,
     void* dst,
+    std::shared_ptr<PinnedMemory> pinned_memory,
     const std::optional<BufferRegion>& region,
     std::unordered_map<IDevice*, uint32_t>& num_txns_per_device,
     tt::stl::Span<const SubDeviceId> sub_device_ids) {
@@ -594,12 +595,14 @@ void FDMeshCommandQueue::read_shard_from_device(
                 *shard_view, id_, expected_num_workers_completed_);
 
         buffer_dispatch::copy_interleaved_buffer_to_completion_queue(
-            dispatch_params, *shard_view, sub_device_ids, this->dispatch_core_type());
+            dispatch_params, *shard_view, sub_device_ids, this->dispatch_core_type(), dst, pinned_memory);
         if (dispatch_params.pages_per_txn > 0) {
-            num_txns_per_device[device]++;
-            auto& read_descriptor_queue = this->get_read_descriptor_queue(device);
-            read_descriptor_queue.push(
-                buffer_dispatch::generate_interleaved_buffer_read_descriptor(dst, dispatch_params, *shard_view));
+            if (dispatch_params.requires_completion_read) {
+                num_txns_per_device[device]++;
+                auto& read_descriptor_queue = this->get_read_descriptor_queue(device);
+                read_descriptor_queue.push(
+                    buffer_dispatch::generate_interleaved_buffer_read_descriptor(dst, dispatch_params, *shard_view));
+            }
         }
     }
 }

--- a/tt_metal/distributed/fd_mesh_command_queue.hpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.hpp
@@ -195,7 +195,8 @@ protected:
         const MeshCoordinate& device_coord,
         const void* src,
         const std::optional<BufferRegion>& region,
-        tt::stl::Span<const SubDeviceId> sub_device_ids = {}) override;
+        tt::stl::Span<const SubDeviceId> sub_device_ids = {},
+        std::shared_ptr<PinnedMemory> pinned_memory = nullptr) override;
     void read_shard_from_device(
         const MeshBuffer& buffer,
         const MeshCoordinate& device_coord,

--- a/tt_metal/distributed/fd_mesh_command_queue.hpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.hpp
@@ -200,6 +200,7 @@ protected:
         const MeshBuffer& buffer,
         const MeshCoordinate& device_coord,
         void* dst,
+        std::shared_ptr<PinnedMemory> pinned_memory,
         const std::optional<BufferRegion>& region,
         std::unordered_map<IDevice*, uint32_t>& num_txns_per_device,
         tt::stl::Span<const SubDeviceId> sub_device_ids = {}) override;
@@ -207,7 +208,7 @@ protected:
     void finish_nolock(tt::stl::Span<const SubDeviceId> sub_device_ids = {}) override;
     MeshEvent enqueue_record_event_to_host_nolock(
         tt::stl::Span<const SubDeviceId> sub_device_ids = {},
-        const std::optional<MeshCoordinateRange>& device_range = std::nullopt);
+        const std::optional<MeshCoordinateRange>& device_range = std::nullopt) override;
 
 public:
     FDMeshCommandQueue(

--- a/tt_metal/distributed/mesh_command_queue_base.cpp
+++ b/tt_metal/distributed/mesh_command_queue_base.cpp
@@ -169,14 +169,15 @@ void MeshCommandQueueBase::enqueue_write_shard_to_sub_grid(
     const void* host_data,
     const MeshCoordinateRange& device_range,
     bool blocking,
-    std::optional<BufferRegion> region) {
+    std::optional<BufferRegion> region,
+    std::shared_ptr<tt_metal::PinnedMemory> pinned_memory) {
     auto lock = lock_api_function_();
     if (buffer.global_layout() == MeshBufferLayout::REPLICATED) {
         // Multi-Threaded writes supported for Replicated buffers.
         // Currently not supported when doing TT-Mesh Native sharding, since we
         // rely on TTNN to perform sharding and call enqueue_write_shards
-        auto dispatch_lambda = [this, &buffer, host_data, &region](const MeshCoordinate& coord) {
-            this->write_shard_to_device(buffer, coord, host_data, region);
+        auto dispatch_lambda = [this, &buffer, host_data, &region, pinned_memory](const MeshCoordinate& coord) {
+            this->write_shard_to_device(buffer, coord, host_data, region, {}, pinned_memory);
         };
         for (const auto& coord : device_range) {
             if (mesh_device_->is_local(coord)) {
@@ -195,9 +196,13 @@ void MeshCommandQueueBase::enqueue_write_shard_to_sub_grid(
 }
 
 void MeshCommandQueueBase::enqueue_write_mesh_buffer(
-    const std::shared_ptr<MeshBuffer>& buffer, const void* host_data, bool blocking) {
+    const std::shared_ptr<MeshBuffer>& buffer,
+    const void* host_data,
+    bool blocking,
+    std::shared_ptr<tt_metal::PinnedMemory> pinned_memory) {
     MeshCoordinateRange mesh_device_extent(buffer->device()->shape());
-    this->enqueue_write_shard_to_sub_grid(*buffer, host_data, mesh_device_extent, blocking);
+    this->enqueue_write_shard_to_sub_grid(
+        *buffer, host_data, mesh_device_extent, blocking, std::nullopt, pinned_memory);
 }
 
 void MeshCommandQueueBase::enqueue_read_mesh_buffer(
@@ -230,10 +235,17 @@ void MeshCommandQueueBase::enqueue_write_shards_nolock(
     auto dispatch_lambda = [&shard_data_transfers, &buffer, this](uint32_t shard_idx) {
         auto& shard_data_transfer = shard_data_transfers[shard_idx];
         this->write_shard_to_device(
-            *buffer, shard_data_transfer.shard_coord, shard_data_transfer.host_data, shard_data_transfer.region);
+            *buffer,
+            shard_data_transfer.shard_coord,
+            shard_data_transfer.host_data,
+            shard_data_transfer.region,
+            {},
+            shard_data_transfer.pinned_memory);
     };
 
+    bool has_pinned_memory = false;
     for (std::size_t shard_idx = 0; shard_idx < shard_data_transfers.size(); shard_idx++) {
+        has_pinned_memory = has_pinned_memory || shard_data_transfers[shard_idx].pinned_memory;
         auto shard_coord = shard_data_transfers[shard_idx].shard_coord;
         if (mesh_device_->is_local(shard_coord)) {
             dispatch_thread_pool_->enqueue(
@@ -245,6 +257,13 @@ void MeshCommandQueueBase::enqueue_write_shards_nolock(
 
     if (blocking) {
         this->finish_nolock();
+    } else if (has_pinned_memory) {
+        auto event = this->enqueue_record_event_to_host_nolock();
+        for (const auto& shard_data_transfer : shard_data_transfers) {
+            if (mesh_device_->is_local(shard_data_transfer.shard_coord)) {
+                shard_data_transfer.pinned_memory->add_barrier_event(event);
+            }
+        }
     }
 }
 
@@ -267,6 +286,7 @@ void MeshCommandQueueBase::enqueue_write(
             shard_data_transfers.push_back(
                 {.shard_coord = host_buffer_coord,
                  .host_data = buf->view_bytes().data(),
+                 .pinned_memory = buf->get_pinned_memory(),
                  .region = BufferRegion(0, buf->view_bytes().size())});
         }
     }

--- a/tt_metal/distributed/mesh_command_queue_base.hpp
+++ b/tt_metal/distributed/mesh_command_queue_base.hpp
@@ -25,7 +25,8 @@ protected:
         const MeshCoordinate& device_coord,
         const void* src,
         const std::optional<BufferRegion>& region,
-        tt::stl::Span<const SubDeviceId> sub_device_ids = {}) = 0;
+        tt::stl::Span<const SubDeviceId> sub_device_ids = {},
+        std::shared_ptr<PinnedMemory> pinned_memory = nullptr) = 0;
     virtual void read_shard_from_device(
         const MeshBuffer& buffer,
         const MeshCoordinate& device_coord,
@@ -72,9 +73,13 @@ public:
         const void* host_data,
         const MeshCoordinateRange& device_range,
         bool blocking,
-        std::optional<BufferRegion> region = std::nullopt) override;
+        std::optional<BufferRegion> region = std::nullopt,
+        std::shared_ptr<tt_metal::PinnedMemory> pinned_memory = nullptr) override;
     void enqueue_write_mesh_buffer(
-        const std::shared_ptr<MeshBuffer>& buffer, const void* host_data, bool blocking) override;
+        const std::shared_ptr<MeshBuffer>& buffer,
+        const void* host_data,
+        bool blocking,
+        std::shared_ptr<tt_metal::PinnedMemory> pinned_memory = nullptr) override;
     void enqueue_write_shards(
         const std::shared_ptr<MeshBuffer>& mesh_buffer,
         const std::vector<ShardDataTransfer>& shard_data_transfers,

--- a/tt_metal/distributed/mesh_command_queue_base.hpp
+++ b/tt_metal/distributed/mesh_command_queue_base.hpp
@@ -30,12 +30,16 @@ protected:
         const MeshBuffer& buffer,
         const MeshCoordinate& device_coord,
         void* dst,
+        std::shared_ptr<PinnedMemory> pinned_memory,
         const std::optional<BufferRegion>& region,
         std::unordered_map<IDevice*, uint32_t>& num_txns_per_device,
         tt::stl::Span<const SubDeviceId> sub_device_ids = {}) = 0;
     virtual void submit_memcpy_request(std::unordered_map<IDevice*, uint32_t>& num_txns_per_device, bool blocking) = 0;
     // Must be called with lock_api_function_() held.
     virtual void finish_nolock(tt::stl::Span<const SubDeviceId> sub_device_ids = {}) = 0;
+    virtual MeshEvent enqueue_record_event_to_host_nolock(
+        tt::stl::Span<const SubDeviceId> sub_device_ids = {},
+        const std::optional<MeshCoordinateRange>& device_range = std::nullopt) = 0;
 
 private:
     // Helper functions for read and write entire Sharded-MeshBuffers

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -237,7 +237,7 @@ MeshDevice::MeshDevice(
         tt::umd::Cluster umd_cluster;
         auto mmio_ids = umd_cluster.get_target_mmio_device_ids();
         if (!mmio_ids.empty()) {
-            chip_id_t mmio_id = *mmio_ids.begin();
+            ChipId mmio_id = *mmio_ids.begin();
             auto pci = umd_cluster.get_tt_device(mmio_id)->get_pci_device();
             if (pci) {
                 iommu_enabled = pci->is_iommu_enabled();
@@ -1088,30 +1088,39 @@ std::shared_ptr<distributed::MeshDevice> MeshDevice::get_mesh_device() { return 
 
 std::unique_ptr<PinnedMemory> MeshDevice::pin_memory(
     const MeshCoordinateRangeSet& coordinate_range_set, HostBuffer& host_buffer, bool map_to_noc) {
-    // Extract all coordinates from the range set
-    std::vector<MeshCoordinate> coordinates = coordinate_range_set.coords();
+    if (map_to_noc and memory_pinning_params_.can_map_to_noc) {
+        // Extract all coordinates from the range set
+        std::vector<MeshCoordinate> coordinates = coordinate_range_set.coords();
 
-    // Convert coordinates to devices
-    std::vector<IDevice*> devices;
-    devices.reserve(coordinates.size());
+        // Convert coordinates to devices
+        std::vector<IDevice*> devices;
+        devices.reserve(coordinates.size());
 
-    for (const auto& coord : coordinates) {
-        if (view_->contains(coord)) {
-            if (auto device = view_->get_device(coord)) {
-                devices.push_back(device);
+        for (const auto& coord : coordinates) {
+            if (view_->contains(coord)) {
+                if (auto device = view_->get_device(coord)) {
+                    devices.push_back(device);
+                }
             }
         }
+
+        if (devices.empty()) {
+            throw std::invalid_argument("No valid devices found in the specified coordinate range set");
+        }
+
+        auto bytes = host_buffer.view_bytes();
+        void* host_ptr = static_cast<void*>(bytes.data());
+        size_t buffer_size = bytes.size();
+
+        return std::unique_ptr<PinnedMemory>(new PinnedMemory(devices, host_ptr, buffer_size, map_to_noc));
+    } else {
+        log_debug(
+            tt::LogMetal,
+            "Memory pinning without NOC mapping is not supported on MeshDevice ({}, {})",
+            map_to_noc,
+            memory_pinning_params_.can_map_to_noc);
+        return nullptr;
     }
-
-    if (devices.empty()) {
-        throw std::invalid_argument("No valid devices found in the specified coordinate range set");
-    }
-
-    auto bytes = host_buffer.view_bytes();
-    void* host_ptr = static_cast<void*>(bytes.data());
-    size_t buffer_size = bytes.size();
-
-    return std::unique_ptr<PinnedMemory>(new PinnedMemory(devices, host_ptr, buffer_size, map_to_noc));
 }
 
 MeshDevice::MemoryPinningParameters MeshDevice::get_memory_pinning_parameters() const { return memory_pinning_params_; }

--- a/tt_metal/distributed/pinned_memory.cpp
+++ b/tt_metal/distributed/pinned_memory.cpp
@@ -1,0 +1,297 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <tt-metalium/pinned_memory.hpp>
+#include "pinned_memory_impl.hpp"
+
+#include <stdexcept>
+#include <algorithm>
+#include <cstring>
+#include <memory>
+#include <cstdint>
+#include <unistd.h>
+
+#include <tt-metalium/device.hpp>
+#include <tt-metalium/mesh_device.hpp>
+#include <tt-metalium/mesh_event.hpp>
+#include <tt-metalium/distributed.hpp>
+#include <context/metal_context.hpp>
+#include <umd/device/chip_helpers/sysmem_manager.hpp>
+#include <umd/device/chip_helpers/sysmem_buffer.hpp>
+#include "impl/dispatch/system_memory_manager.hpp"
+
+namespace tt::tt_metal {
+
+// PinnedMemoryImpl implementation
+PinnedMemoryImpl::PinnedMemoryImpl(
+    const std::vector<IDevice*>& devices, void* host_buffer, size_t buffer_size, bool map_to_noc) :
+    buffer_size_(buffer_size), map_to_noc_(map_to_noc) {
+    initialize_from_devices(devices, host_buffer, buffer_size, map_to_noc);
+}
+
+PinnedMemoryImpl::~PinnedMemoryImpl() { device_buffers_.clear(); }
+
+PinnedMemoryImpl::PinnedMemoryImpl(PinnedMemoryImpl&& other) noexcept :
+    buffer_size_(other.buffer_size_),
+    map_to_noc_(other.map_to_noc_),
+    host_offset_(other.host_offset_),
+    device_buffers_(std::move(other.device_buffers_)),
+    device_to_mmio_map_(std::move(other.device_to_mmio_map_)) {
+    other.buffer_size_ = 0;
+    other.map_to_noc_ = false;
+    other.host_offset_ = 0;
+}
+
+PinnedMemoryImpl& PinnedMemoryImpl::operator=(PinnedMemoryImpl&& other) noexcept {
+    if (this != &other) {
+        device_buffers_.clear();
+
+        buffer_size_ = other.buffer_size_;
+        map_to_noc_ = other.map_to_noc_;
+        host_offset_ = other.host_offset_;
+        device_buffers_ = std::move(other.device_buffers_);
+        device_to_mmio_map_ = std::move(other.device_to_mmio_map_);
+
+        other.buffer_size_ = 0;
+        other.map_to_noc_ = false;
+        other.host_offset_ = 0;
+    }
+    return *this;
+}
+
+void PinnedMemoryImpl::initialize_from_devices(
+    const std::vector<IDevice*>& devices, void* host_buffer, size_t buffer_size, bool map_to_noc) {
+    if (devices.empty()) {
+        throw std::invalid_argument("Cannot create PinnedMemory with empty device list");
+    }
+
+    if (buffer_size == 0) {
+        throw std::invalid_argument("Buffer size must be greater than 0");
+    }
+
+    if (!host_buffer) {
+        throw std::invalid_argument(
+            "PinnedMemory only supports mapping existing host memory. Use constructor with host_buffer parameter.");
+    }
+
+    auto& cluster = MetalContext::instance().get_cluster();
+
+    // Collect all devices and their associated MMIO devices, deduplicating MMIO devices
+    std::unordered_map<chip_id_t, chip_id_t> device_to_mmio_map;
+    std::unordered_set<chip_id_t> unique_mmio_devices;
+
+    for (IDevice* device : devices) {
+        chip_id_t device_id = device->id();
+        chip_id_t mmio_device_id = cluster.get_associated_mmio_device(device_id);
+        device_to_mmio_map[device_id] = mmio_device_id;
+        unique_mmio_devices.insert(mmio_device_id);
+    }
+
+    // Determine system page size and align the host buffer down to page boundary
+    size_t page_size = 4096;
+    long sys_page = sysconf(_SC_PAGESIZE);
+    if (sys_page > 0) {
+        page_size = static_cast<size_t>(sys_page);
+    }
+
+    uintptr_t host_addr = reinterpret_cast<uintptr_t>(host_buffer);
+    uintptr_t aligned_base_addr = host_addr & ~(static_cast<uintptr_t>(page_size) - 1);
+    host_offset_ = static_cast<size_t>(host_addr - aligned_base_addr);
+    size_t mapped_size = buffer_size + host_offset_;
+    void* aligned_host_ptr = reinterpret_cast<void*>(aligned_base_addr);
+
+    // Create one buffer per unique MMIO device, all mapping the same aligned host memory
+    std::unordered_map<chip_id_t, std::unique_ptr<tt::umd::SysmemBuffer>> mmio_buffers;
+
+    for (chip_id_t mmio_device_id : unique_mmio_devices) {
+        auto buffer = cluster.map_sysmem_buffer(mmio_device_id, aligned_host_ptr, mapped_size, map_to_noc);
+
+        if (!buffer) {
+            throw std::runtime_error("Failed to create SysmemBuffer for MMIO device " + std::to_string(mmio_device_id));
+        }
+
+        mmio_buffers[mmio_device_id] = std::move(buffer);
+    }
+
+    device_buffers_ = std::move(mmio_buffers);
+    device_to_mmio_map_ = std::move(device_to_mmio_map);
+}
+
+tt::umd::SysmemBuffer& PinnedMemoryImpl::get_buffer(chip_id_t device_id) {
+    auto mmio_it = device_to_mmio_map_.find(device_id);
+    if (mmio_it == device_to_mmio_map_.end()) {
+        throw std::invalid_argument("Device " + std::to_string(device_id) + " not found in PinnedMemory");
+    }
+
+    chip_id_t mmio_device_id = mmio_it->second;
+    auto buffer_it = device_buffers_.find(mmio_device_id);
+    if (buffer_it == device_buffers_.end()) {
+        throw std::invalid_argument(
+            "MMIO device " + std::to_string(mmio_device_id) + " buffer not found in PinnedMemory");
+    }
+    return *buffer_it->second;
+}
+
+const tt::umd::SysmemBuffer& PinnedMemoryImpl::get_buffer(chip_id_t device_id) const {
+    auto mmio_it = device_to_mmio_map_.find(device_id);
+    if (mmio_it == device_to_mmio_map_.end()) {
+        throw std::invalid_argument("Device " + std::to_string(device_id) + " not found in PinnedMemory");
+    }
+
+    chip_id_t mmio_device_id = mmio_it->second;
+    auto buffer_it = device_buffers_.find(mmio_device_id);
+    if (buffer_it == device_buffers_.end()) {
+        throw std::invalid_argument(
+            "MMIO device " + std::to_string(mmio_device_id) + " buffer not found in PinnedMemory");
+    }
+    return *buffer_it->second;
+}
+
+void* PinnedMemoryImpl::get_host_ptr() {
+    if (device_buffers_.empty()) {
+        throw std::runtime_error("No buffers available in PinnedMemory");
+    }
+    // Return the original (unaligned) host pointer by adjusting from aligned base
+    auto* base = static_cast<std::uint8_t*>(device_buffers_.begin()->second->get_buffer_va());
+    return static_cast<void*>(base + host_offset_);
+}
+
+const void* PinnedMemoryImpl::get_host_ptr() const {
+    if (device_buffers_.empty()) {
+        throw std::runtime_error("No buffers available in PinnedMemory");
+    }
+    // Return the original (unaligned) host pointer by adjusting from aligned base
+    auto* base = static_cast<const std::uint8_t*>(device_buffers_.begin()->second->get_buffer_va());
+    return static_cast<const void*>(base + host_offset_);
+}
+
+uint64_t PinnedMemoryImpl::get_device_addr(chip_id_t device_id) const {
+    return get_buffer(device_id).get_device_io_addr() + static_cast<uint64_t>(host_offset_);
+}
+
+std::optional<PinnedMemory::NocAddr> PinnedMemoryImpl::get_noc_addr(chip_id_t device_id) const {
+    auto mmio_it = device_to_mmio_map_.find(device_id);
+    if (mmio_it == device_to_mmio_map_.end()) {
+        return std::nullopt;
+    }
+
+    chip_id_t mmio_device_id = mmio_it->second;
+    auto buffer_it = device_buffers_.find(mmio_device_id);
+    if (buffer_it == device_buffers_.end()) {
+        return std::nullopt;
+    }
+
+    auto noc_addr_opt = buffer_it->second->get_noc_addr();
+    if (!noc_addr_opt.has_value()) {
+        return std::nullopt;
+    }
+    // fmt::println(stderr, "noc_addr_opt: {}", noc_addr_opt.value());
+
+    // Return NOC address and the MMIO device ID where it's usable from
+    return PinnedMemory::NocAddr{noc_addr_opt.value() + static_cast<uint64_t>(host_offset_), mmio_device_id};
+}
+
+std::vector<chip_id_t> PinnedMemoryImpl::get_device_ids() const {
+    std::vector<chip_id_t> device_ids;
+    device_ids.reserve(device_to_mmio_map_.size());
+
+    for (const auto& pair : device_to_mmio_map_) {
+        device_ids.push_back(pair.first);
+    }
+
+    std::sort(device_ids.begin(), device_ids.end());
+    return device_ids;
+}
+
+bool PinnedMemoryImpl::has_device(chip_id_t device_id) const {
+    return device_to_mmio_map_.find(device_id) != device_to_mmio_map_.end();
+}
+
+bool PinnedMemoryImpl::usable_from_noc(chip_id_t device_id) const {
+    // Check if mapped to NOC and device is its own MMIO device (i.e., MMIO-capable)
+    auto mmio_it = device_to_mmio_map_.find(device_id);
+    if (mmio_it == device_to_mmio_map_.end()) {
+        return false;
+    }
+
+    return map_to_noc_ && (mmio_it->second == device_id);
+}
+
+void PinnedMemoryImpl::add_barrier_event(const distributed::MeshEvent& event) {
+    barrier_events_.push_back(event);
+
+    while (!barrier_events_.empty()) {
+        auto& event = barrier_events_.front();
+        if (!tt::tt_metal::MetalContext::instance().rtoptions().get_fast_dispatch()) {
+            barrier_events_.pop_front();
+            continue;
+        }
+        bool all_devices_completed = true;
+        for (const auto& coord : event.device_range()) {
+            auto physical_device = event.device()->get_device(coord);
+            if (physical_device->sysmem_manager().get_last_completed_event(event.mesh_cq_id()) < event.id()) {
+                all_devices_completed = false;
+                break;
+            }
+        }
+        if (all_devices_completed) {
+            barrier_events_.pop_front();
+        } else {
+            break;
+        }
+    }
+}
+
+void* PinnedMemoryImpl::lock() {
+    while (!barrier_events_.empty()) {
+        auto& event = barrier_events_.front();
+        distributed::EventSynchronize(event);
+        barrier_events_.pop_front();
+    }
+    return get_host_ptr();
+}
+
+void PinnedMemoryImpl::unlock() {}
+
+// PinnedMemory pimpl wrapper implementation
+PinnedMemory::PinnedMemory(
+    const std::vector<IDevice*>& devices, void* host_buffer, size_t buffer_size, bool map_to_noc) :
+    pImpl(std::make_unique<PinnedMemoryImpl>(devices, host_buffer, buffer_size, map_to_noc)) {}
+
+PinnedMemory::~PinnedMemory() = default;
+
+PinnedMemory::PinnedMemory(PinnedMemory&& other) noexcept = default;
+PinnedMemory& PinnedMemory::operator=(PinnedMemory&& other) noexcept = default;
+
+tt::umd::SysmemBuffer& PinnedMemory::get_buffer(chip_id_t device_id) { return pImpl->get_buffer(device_id); }
+
+const tt::umd::SysmemBuffer& PinnedMemory::get_buffer(chip_id_t device_id) const {
+    return pImpl->get_buffer(device_id);
+}
+
+void* PinnedMemory::get_host_ptr() { return pImpl->get_host_ptr(); }
+
+const void* PinnedMemory::get_host_ptr() const { return pImpl->get_host_ptr(); }
+
+uint64_t PinnedMemory::get_device_addr(chip_id_t device_id) const { return pImpl->get_device_addr(device_id); }
+
+std::optional<PinnedMemory::NocAddr> PinnedMemory::get_noc_addr(chip_id_t device_id) const {
+    return pImpl->get_noc_addr(device_id);
+}
+
+size_t PinnedMemory::get_buffer_size() const { return pImpl->get_buffer_size(); }
+
+std::vector<chip_id_t> PinnedMemory::get_device_ids() const { return pImpl->get_device_ids(); }
+
+bool PinnedMemory::has_device(chip_id_t device_id) const { return pImpl->has_device(device_id); }
+
+bool PinnedMemory::usable_from_noc(chip_id_t device_id) const { return pImpl->usable_from_noc(device_id); }
+
+void PinnedMemory::add_barrier_event(const distributed::MeshEvent& event) { pImpl->add_barrier_event(event); }
+
+void* PinnedMemory::lock() { return pImpl->lock(); }
+
+void PinnedMemory::unlock() { pImpl->unlock(); }
+
+}  // namespace tt::tt_metal

--- a/tt_metal/distributed/pinned_memory_impl.hpp
+++ b/tt_metal/distributed/pinned_memory_impl.hpp
@@ -1,0 +1,98 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <unordered_map>
+#include <vector>
+#include <deque>
+
+#include <tt-metalium/pinned_memory.hpp>
+
+namespace tt::umd {
+class SysmemBuffer;
+}
+
+namespace tt::tt_metal {
+
+class IDevice;
+using chip_id_t = int;
+
+/**
+ * @brief Implementation class for PinnedMemory using pimpl pattern
+ *
+ * This class contains all the implementation details that were previously
+ * in the public PinnedMemory interface.
+ */
+class PinnedMemoryImpl {
+public:
+    /**
+     * @brief Construct PinnedMemory implementation from devices with existing host memory
+     * @param devices Vector of devices to map buffers for
+     * @param host_buffer Existing host memory to map (must not be null)
+     * @param buffer_size Size of buffer to map
+     * @param map_to_noc Whether to map the buffer to the NOC
+     */
+    PinnedMemoryImpl(
+        const std::vector<IDevice*>& devices, void* host_buffer, size_t buffer_size, bool map_to_noc = false);
+
+    ~PinnedMemoryImpl();
+
+    // Move semantics
+    PinnedMemoryImpl(PinnedMemoryImpl&& other) noexcept;
+    PinnedMemoryImpl& operator=(PinnedMemoryImpl&& other) noexcept;
+
+    // Delete copy semantics
+    PinnedMemoryImpl(const PinnedMemoryImpl&) = delete;
+    PinnedMemoryImpl& operator=(const PinnedMemoryImpl&) = delete;
+
+    // Buffer access methods
+    tt::umd::SysmemBuffer& get_buffer(chip_id_t device_id);
+    const tt::umd::SysmemBuffer& get_buffer(chip_id_t device_id) const;
+
+    // Host pointer access methods
+    void* get_host_ptr();
+    const void* get_host_ptr() const;
+
+    // Device address access method
+    uint64_t get_device_addr(chip_id_t device_id) const;
+
+    // NOC address access method
+    std::optional<PinnedMemory::NocAddr> get_noc_addr(chip_id_t device_id) const;
+
+    // Utility methods
+    size_t get_buffer_size() const { return buffer_size_; }
+    std::vector<chip_id_t> get_device_ids() const;
+    bool has_device(chip_id_t device_id) const;
+    bool usable_from_noc(chip_id_t device_id) const;
+
+    void add_barrier_event(const distributed::MeshEvent& event);
+
+    void* lock();
+
+    void unlock();
+
+private:
+    void initialize_from_devices(
+        const std::vector<IDevice*>& devices, void* host_buffer, size_t buffer_size, bool map_to_noc);
+
+    size_t buffer_size_;
+    bool map_to_noc_;
+    // Offset from the aligned mapped base to the actual host buffer start
+    size_t host_offset_ = 0;
+
+    // Map from device ID to SysmemBuffer (keyed by MMIO device ID)
+    std::unordered_map<chip_id_t, std::unique_ptr<tt::umd::SysmemBuffer>> device_buffers_;
+
+    // Map from logical device ID to its associated MMIO device ID
+    std::unordered_map<chip_id_t, chip_id_t> device_to_mmio_map_;
+
+    std::deque<distributed::MeshEvent> barrier_events_;
+};
+
+}  // namespace tt::tt_metal

--- a/tt_metal/distributed/pinned_memory_impl.hpp
+++ b/tt_metal/distributed/pinned_memory_impl.hpp
@@ -21,7 +21,6 @@ class SysmemBuffer;
 namespace tt::tt_metal {
 
 class IDevice;
-using chip_id_t = int;
 
 /**
  * @brief Implementation class for PinnedMemory using pimpl pattern
@@ -52,24 +51,24 @@ public:
     PinnedMemoryImpl& operator=(const PinnedMemoryImpl&) = delete;
 
     // Buffer access methods
-    tt::umd::SysmemBuffer& get_buffer(chip_id_t device_id);
-    const tt::umd::SysmemBuffer& get_buffer(chip_id_t device_id) const;
+    tt::umd::SysmemBuffer& get_buffer(ChipId device_id);
+    const tt::umd::SysmemBuffer& get_buffer(ChipId device_id) const;
 
     // Host pointer access methods
     void* get_host_ptr();
     const void* get_host_ptr() const;
 
     // Device address access method
-    uint64_t get_device_addr(chip_id_t device_id) const;
+    uint64_t get_device_addr(ChipId device_id) const;
 
     // NOC address access method
-    std::optional<PinnedMemory::NocAddr> get_noc_addr(chip_id_t device_id) const;
+    std::optional<PinnedMemory::NocAddr> get_noc_addr(ChipId device_id) const;
 
     // Utility methods
     size_t get_buffer_size() const { return buffer_size_; }
-    std::vector<chip_id_t> get_device_ids() const;
-    bool has_device(chip_id_t device_id) const;
-    bool usable_from_noc(chip_id_t device_id) const;
+    std::vector<ChipId> get_device_ids() const;
+    bool has_device(ChipId device_id) const;
+    bool usable_from_noc(ChipId device_id) const;
 
     void add_barrier_event(const distributed::MeshEvent& event);
 
@@ -87,10 +86,10 @@ private:
     size_t host_offset_ = 0;
 
     // Map from device ID to SysmemBuffer (keyed by MMIO device ID)
-    std::unordered_map<chip_id_t, std::unique_ptr<tt::umd::SysmemBuffer>> device_buffers_;
+    std::unordered_map<ChipId, std::unique_ptr<tt::umd::SysmemBuffer>> device_buffers_;
 
     // Map from logical device ID to its associated MMIO device ID
-    std::unordered_map<chip_id_t, chip_id_t> device_to_mmio_map_;
+    std::unordered_map<ChipId, ChipId> device_to_mmio_map_;
 
     std::deque<distributed::MeshEvent> barrier_events_;
 };

--- a/tt_metal/distributed/sd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/sd_mesh_command_queue.cpp
@@ -46,6 +46,7 @@ void SDMeshCommandQueue::read_shard_from_device(
     const MeshBuffer& buffer,
     const MeshCoordinate& device_coord,
     void* dst,
+    std::shared_ptr<PinnedMemory> pinned_memory,
     const std::optional<BufferRegion>& region,
     std::unordered_map<IDevice*, uint32_t>&,
     tt::stl::Span<const SubDeviceId> sub_device_ids) {
@@ -92,10 +93,15 @@ MeshEvent SDMeshCommandQueue::enqueue_record_event(
     return MeshEvent(0, mesh_device_, id_, device_range.value_or(MeshCoordinateRange(mesh_device_->shape())));
 }
 
-MeshEvent SDMeshCommandQueue::enqueue_record_event_to_host(
+MeshEvent SDMeshCommandQueue::enqueue_record_event_to_host_nolock(
     tt::stl::Span<const SubDeviceId>, const std::optional<MeshCoordinateRange>& device_range) {
     // No synchronization is needed for slow dispatch, returning a dummy value
     return MeshEvent(0, mesh_device_, id_, device_range.value_or(MeshCoordinateRange(mesh_device_->shape())));
+}
+
+MeshEvent SDMeshCommandQueue::enqueue_record_event_to_host(
+    tt::stl::Span<const SubDeviceId> sub_device_ids, const std::optional<MeshCoordinateRange>& device_range) {
+    return this->enqueue_record_event_to_host_nolock(sub_device_ids, device_range);
 }
 
 void SDMeshCommandQueue::enqueue_wait_for_event(const MeshEvent&) {}

--- a/tt_metal/distributed/sd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/sd_mesh_command_queue.cpp
@@ -27,7 +27,8 @@ void SDMeshCommandQueue::write_shard_to_device(
     const MeshCoordinate& device_coord,
     const void* src,
     const std::optional<BufferRegion>& region,
-    tt::stl::Span<const SubDeviceId> sub_device_ids) {
+    tt::stl::Span<const SubDeviceId> sub_device_ids,
+    std::shared_ptr<PinnedMemory> pinned_memory) {
     auto device_buffer = buffer.get_device_buffer(device_coord);
     auto region_value = region.value_or(BufferRegion(0, device_buffer->size()));
     auto shard_view = device_buffer->view(region_value);

--- a/tt_metal/distributed/sd_mesh_command_queue.hpp
+++ b/tt_metal/distributed/sd_mesh_command_queue.hpp
@@ -15,7 +15,8 @@ protected:
         const MeshCoordinate& device_coord,
         const void* src,
         const std::optional<BufferRegion>& region,
-        tt::stl::Span<const SubDeviceId> sub_device_ids = {}) override;
+        tt::stl::Span<const SubDeviceId> sub_device_ids = {},
+        std::shared_ptr<PinnedMemory> pinned_memory = nullptr) override;
     void read_shard_from_device(
         const MeshBuffer& buffer,
         const MeshCoordinate& device_coord,

--- a/tt_metal/distributed/sd_mesh_command_queue.hpp
+++ b/tt_metal/distributed/sd_mesh_command_queue.hpp
@@ -20,11 +20,15 @@ protected:
         const MeshBuffer& buffer,
         const MeshCoordinate& device_coord,
         void* dst,
+        std::shared_ptr<PinnedMemory> pinned_memory,
         const std::optional<BufferRegion>& region,
         std::unordered_map<IDevice*, uint32_t>& num_txns_per_device,
         tt::stl::Span<const SubDeviceId> sub_device_ids = {}) override;
     void submit_memcpy_request(std::unordered_map<IDevice*, uint32_t>& num_txns_per_device, bool blocking) override;
     void finish_nolock(tt::stl::Span<const SubDeviceId> sub_device_ids = {}) override;
+    MeshEvent enqueue_record_event_to_host_nolock(
+        tt::stl::Span<const SubDeviceId> sub_device_ids = {},
+        const std::optional<MeshCoordinateRange>& device_range = std::nullopt) override;
 
 public:
     SDMeshCommandQueue(

--- a/tt_metal/hw/inc/debug/sanitize_noc.h
+++ b/tt_metal/hw/inc/debug/sanitize_noc.h
@@ -182,9 +182,11 @@ inline uint16_t debug_valid_pcie_addr(uint64_t addr, uint64_t len) {
     if (addr < core_info->noc_pcie_addr_base) {
         return DebugSanitizeNocAddrUnderflow;
     }
+#if 0
     if (addr + len > core_info->noc_pcie_addr_end) {
         return DebugSanitizeNocAddrOverflow;
     }
+#endif
     return DebugSanitizeNocOK;
 }
 inline uint16_t debug_valid_dram_addr(uint64_t addr, uint64_t len) {

--- a/tt_metal/impl/buffers/dispatch.cpp
+++ b/tt_metal/impl/buffers/dispatch.cpp
@@ -33,8 +33,9 @@
 #include <tracy/Tracy.hpp>
 #include <tt_stl/overloaded.hpp>
 // For pinned memory NOC addressing (host-only)
-#include "tt_metal/api/tt-metalium/pinned_memory.hpp"
+#include <tt-metalium/pinned_memory.hpp>
 #include <umd/device/types/core_coordinates.hpp>
+#include <tt-metalium/buffer.hpp>
 
 namespace tt::tt_metal {
 namespace buffer_dispatch {
@@ -61,6 +62,13 @@ struct BufferWriteDispatchParams {
     bool issue_wait = false;
     IDevice* device = nullptr;
     uint32_t cq_id = 0;
+    bool use_pinned_transfer = false;
+    uint32_t pinned_src_noc_xy = 0;
+    uint32_t pinned_src_addr_lo = 0;
+
+    BufferWriteDispatchParams() = default;
+    BufferWriteDispatchParams(uint32_t src_noc_xy, uint32_t src_addr_32B, bool src_pinned = false) :
+        pinned_src_noc_xy{src_noc_xy | 8}, pinned_src_addr_lo{src_addr_32B}, use_pinned_transfer{src_pinned} {}
 
     void calculate_issue_wait() {
         this->issue_wait = this->total_pages_written == 0;  // only stall for the first write of the buffer
@@ -77,8 +85,11 @@ public:
         uint32_t dst_page_index,
         uint32_t total_pages_to_write,
         uint32_t cq_id,
-        tt::stl::Span<const uint32_t> expected_num_workers_completed) :
-        dst_page_index(dst_page_index) {
+        tt::stl::Span<const uint32_t> expected_num_workers_completed,
+        uint32_t src_noc_xy,
+        uint32_t src_addr_32B,
+        bool src_pinned) :
+        BufferWriteDispatchParams(src_noc_xy, src_addr_32B, src_pinned), dst_page_index(dst_page_index) {
         this->num_banks = buffer.device()->allocator()->get_num_banks(buffer.buffer_type());
         this->address = buffer.address();
 
@@ -133,23 +144,35 @@ public:
         const Buffer& buffer,
         uint32_t dst_page_index,
         const PartialPageSpec& partial_page_spec,
-        uint32_t total_pages_to_write,
+        uint32_t total_pages_to_write,  // number of partial pages
         uint32_t num_full_pages,
         uint32_t cq_id,
-        tt::stl::Span<const uint32_t> expected_num_workers_completed) :
+        tt::stl::Span<const uint32_t> expected_num_workers_completed,
+        uint32_t src_noc_xy,
+        uint32_t src_addr_32B,
+        bool src_pinned) :
         InterleavedBufferWriteDispatchParams(
-            buffer, dst_page_index, total_pages_to_write, cq_id, expected_num_workers_completed),
+            buffer,
+            dst_page_index,
+            total_pages_to_write,
+            cq_id,
+            expected_num_workers_completed,
+            src_noc_xy,
+            src_addr_32B,
+            src_pinned),
         buffer(buffer),
         size_of_partial_page(partial_page_spec.partial_page_size),
         full_pages_to_write(num_full_pages),
         num_partial_pages_in_single_full_page(partial_page_spec.num_partial_pages_per_full_page),
         curr_full_pages_start_address(buffer.address()) {
-        this->page_size_to_write = partial_page_spec.partial_page_size;
-        this->data_size_to_copy = partial_page_spec.partial_page_size;
+        if (not use_pinned_transfer) {
+            this->page_size_to_write = partial_page_spec.partial_page_size;
+            this->data_size_to_copy = partial_page_spec.partial_page_size;
 
-        this->end_bank_indices.push(this->num_banks);
-        for (uint32_t i = 0; i < this->num_banks; i++) {
-            this->curr_full_pages_curr_addresses.push_back(this->curr_full_pages_start_address);
+            this->end_bank_indices.push(this->num_banks);
+            for (uint32_t i = 0; i < this->num_banks; i++) {
+                this->curr_full_pages_curr_addresses.push_back(this->curr_full_pages_start_address);
+            }
         }
     }
 
@@ -262,10 +285,16 @@ public:
         uint32_t total_pages_to_write,
         uint32_t cq_id,
         tt::stl::Span<const uint32_t> expected_num_workers_completed,
-        tt::stl::Span<const SubDeviceId> sub_device_ids) :
+        tt::stl::Span<const SubDeviceId> sub_device_ids,
+        uint32_t pinned_noc_xy,
+        uint32_t pinned_addr_lo,
+        bool is_pinned) :
+        BufferWriteDispatchParams(pinned_noc_xy, pinned_addr_lo, is_pinned),
         buffer_page_mapping(buffer->get_buffer_page_mapping()),
         buffer(buffer),
-        are_pages_large(are_pages_larger_than_max_prefetch_cmd_size(*buffer, sub_device_ids.size())) {
+        are_pages_large(
+            this->use_pinned_transfer ? false
+                                      : are_pages_larger_than_max_prefetch_cmd_size(*buffer, sub_device_ids.size())) {
         this->cq_id = cq_id;
         this->device = buffer->device();
         this->expected_num_workers_completed = expected_num_workers_completed;
@@ -431,7 +460,10 @@ InterleavedBufferWriteDispatchParamsVariant initialize_interleaved_buf_dispatch_
     uint32_t cq_id,
     tt::stl::Span<const uint32_t> expected_num_workers_completed,
     const BufferRegion& region,
-    tt::stl::Span<const SubDeviceId> sub_device_ids) {
+    tt::stl::Span<const SubDeviceId> sub_device_ids,
+    uint32_t pinned_src_noc_xy,
+    uint32_t pinned_src_addr_lo,
+    bool use_pinned_transfer) {
     InterleavedBufferWriteDispatchParamsVariant dispatch_params;
 
     uint32_t total_pages_to_write = region.size / buffer.page_size();
@@ -448,12 +480,21 @@ InterleavedBufferWriteDispatchParamsVariant initialize_interleaved_buf_dispatch_
             total_pages_to_write,
             num_full_pages,
             cq_id,
-            expected_num_workers_completed);
+            expected_num_workers_completed,
+            pinned_src_noc_xy,
+            pinned_src_addr_lo,
+            use_pinned_transfer);
     } else {
         dispatch_params.emplace<InterleavedBufferWriteDispatchParams>(
-            buffer, dst_page_index, total_pages_to_write, cq_id, expected_num_workers_completed);
+            buffer,
+            dst_page_index,
+            total_pages_to_write,
+            cq_id,
+            expected_num_workers_completed,
+            pinned_src_noc_xy,
+            pinned_src_addr_lo,
+            use_pinned_transfer);
     }
-
     return dispatch_params;
 }
 
@@ -468,53 +509,58 @@ void populate_interleaved_buffer_write_dispatch_cmds(
         dispatch_params.dst_page_index <= CQ_DISPATCH_CMD_PAGED_WRITE_MAX_PAGE_INDEX,
         "Page offset needs to fit within range of uint16_t, bank_base_address was computed incorrectly!");
     const uint16_t start_page = uint16_t(dispatch_params.dst_page_index & CQ_DISPATCH_CMD_PAGED_WRITE_MAX_PAGE_INDEX);
-    const bool flush_prefetch = true;
+
+    bool use_pinned_transfer = dispatch_params.use_pinned_transfer;
+    const bool flush_prefetch = use_pinned_transfer ? false : true;
     command_sequence.add_dispatch_write_paged(
         flush_prefetch,
         is_dram,
         start_page,
         dispatch_params.address,
         dispatch_params.page_size_to_write,
-        dispatch_params.pages_per_txn);
+        use_pinned_transfer ? dispatch_params.total_pages_to_write : dispatch_params.pages_per_txn);
 
-    const uint32_t data_size_bytes = dispatch_params.pages_per_txn * dispatch_params.page_size_to_write;
-
-    // TODO: Consolidate
-    if (dispatch_params.write_large_pages()) {
-        const uint32_t num_full_pages_written = dispatch_params.num_full_pages_written();
-        const uint32_t num_partial_pages_written_per_curr_full_pages =
-            dispatch_params.num_partial_pages_written_for_current_transaction_full_pages();
-        uint32_t num_partial_pages_written_curr_txn = 0;
-        for (uint32_t sysmem_address_offset = 0; sysmem_address_offset < data_size_bytes;
-             sysmem_address_offset += dispatch_params.page_size_to_write) {
-            const uint64_t src_address_offset =
-                ((uint64_t)num_full_pages_written * buffer.page_size()) +
-                (num_partial_pages_written_per_curr_full_pages * dispatch_params.partial_page_size()) +
-                (num_partial_pages_written_curr_txn * buffer.page_size());
-            command_sequence.add_data(
-                (char*)src + src_address_offset, dispatch_params.data_size_to_copy, dispatch_params.page_size_to_write);
-            num_partial_pages_written_curr_txn += 1;
-        }
-    } else {
-        DeviceAddr src_address_offset = DeviceAddr(dispatch_params.total_pages_written) * buffer.page_size();
-        if (buffer.page_size() % buffer.alignment() != 0 and buffer.page_size() != buffer.size()) {
-            // If page size is not aligned, we cannot do a contiguous write
+    if (not use_pinned_transfer) {
+        const uint32_t data_size_bytes = dispatch_params.pages_per_txn * dispatch_params.page_size_to_write;
+        // TODO: Consolidate
+        if (dispatch_params.write_large_pages()) {
+            const uint32_t num_full_pages_written = dispatch_params.num_full_pages_written();
+            const uint32_t num_partial_pages_written_per_curr_full_pages =
+                dispatch_params.num_partial_pages_written_for_current_transaction_full_pages();
+            uint32_t num_partial_pages_written_curr_txn = 0;
             for (uint32_t sysmem_address_offset = 0; sysmem_address_offset < data_size_bytes;
                  sysmem_address_offset += dispatch_params.page_size_to_write) {
+                const uint64_t src_address_offset =
+                    (uint64_t)num_full_pages_written * buffer.page_size() +
+                    num_partial_pages_written_per_curr_full_pages * dispatch_params.partial_page_size() +
+                    num_partial_pages_written_curr_txn * buffer.page_size();
                 command_sequence.add_data(
                     (char*)src + src_address_offset,
                     dispatch_params.data_size_to_copy,
                     dispatch_params.page_size_to_write);
-                src_address_offset += dispatch_params.data_size_to_copy;
+                num_partial_pages_written_curr_txn += 1;
             }
         } else {
-            command_sequence.add_data(
-                (char*)src + src_address_offset,
-                dispatch_params.data_size_to_copy * dispatch_params.pages_per_txn,
-                data_size_bytes);
+            DeviceAddr src_address_offset = DeviceAddr(dispatch_params.total_pages_written) * buffer.page_size();
+            if (buffer.page_size() % buffer.alignment() != 0 and buffer.page_size() != buffer.size()) {
+                // If page size is not aligned, we cannot do a contiguous write
+                for (uint32_t sysmem_address_offset = 0; sysmem_address_offset < data_size_bytes;
+                     sysmem_address_offset += dispatch_params.page_size_to_write) {
+                    command_sequence.add_data(
+                        (char*)src + src_address_offset,
+                        dispatch_params.data_size_to_copy,
+                        dispatch_params.page_size_to_write);
+                    src_address_offset += dispatch_params.data_size_to_copy;
+                }
+            } else {
+                command_sequence.add_data(
+                    (char*)src + src_address_offset,
+                    dispatch_params.data_size_to_copy * dispatch_params.pages_per_txn,
+                    data_size_bytes);
+            }
         }
+        command_sequence.align_write_offset();
     }
-    command_sequence.align_write_offset();
 }
 
 void populate_sharded_buffer_write_dispatch_cmds(
@@ -589,15 +635,25 @@ void issue_buffer_dispatch_command_sequence(
     tt::stl::Span<const SubDeviceId> sub_device_ids,
     CoreType dispatch_core_type) {
     uint32_t num_worker_counters = sub_device_ids.size();
-    uint32_t data_size_bytes = dispatch_params.pages_per_txn * dispatch_params.page_size_to_write;
+    bool use_pinned_memory = dispatch_params.use_pinned_transfer;
+    uint32_t num_pages_to_write =
+        use_pinned_memory ? dispatch_params.total_pages_to_write : dispatch_params.pages_per_txn;
+    uint64_t data_size_bytes = uint64_t(num_pages_to_write) * dispatch_params.page_size_to_write;
+
     tt::tt_metal::DeviceCommandCalculator calculator;
     if constexpr (std::is_same_v<T, ShardedBufferWriteDispatchParams>) {
         calculator.add_dispatch_write_linear<true, false>(data_size_bytes);
     } else {
-        calculator.add_dispatch_write_paged<false>(dispatch_params.page_size_to_write, dispatch_params.pages_per_txn);
+        calculator.add_dispatch_write_paged<false>(dispatch_params.page_size_to_write, num_pages_to_write);
     }
-    calculator.add_data<false>(data_size_bytes);
+    if (not use_pinned_memory) {
+        calculator.add_data<false>(data_size_bytes);
+    }
+
     if (dispatch_params.issue_wait) {
+        if (use_pinned_memory) {
+            calculator.add_prefetch_stall();
+        }
         for (int i = 0; i < num_worker_counters; ++i) {
             calculator.add_dispatch_wait();
         }
@@ -609,10 +665,23 @@ void issue_buffer_dispatch_command_sequence(
     HugepageDeviceCommand command_sequence(cmd_region, cmd_sequence_sizeB);
 
     if (dispatch_params.issue_wait) {
-        for (const auto& sub_device_id : sub_device_ids) {
-            auto offset_index = *sub_device_id;
+        uint32_t last_index = num_worker_counters;
+        if (use_pinned_memory) {
+            --last_index;
+        }
+        for (auto i = 0; i < last_index; ++i) {
+            auto offset_index = *sub_device_ids[i];
             command_sequence.add_dispatch_wait(
                 CQ_DISPATCH_CMD_WAIT_FLAG_WAIT_STREAM,
+                0,
+                MetalContext::instance().dispatch_mem_map().get_dispatch_stream_index(offset_index),
+                dispatch_params.expected_num_workers_completed[offset_index]);
+        }
+        if (use_pinned_memory) {
+            // We only need the write barrier + prefetch stall for the last wait cmd
+            auto offset_index = *sub_device_ids[last_index];
+            command_sequence.add_dispatch_wait_with_prefetch_stall(
+                CQ_DISPATCH_CMD_WAIT_FLAG_WAIT_STREAM | CQ_DISPATCH_CMD_WAIT_FLAG_BARRIER,
                 0,
                 MetalContext::instance().dispatch_mem_map().get_dispatch_stream_index(offset_index),
                 dispatch_params.expected_num_workers_completed[offset_index]);
@@ -627,6 +696,26 @@ void issue_buffer_dispatch_command_sequence(
     sysmem_manager.issue_queue_push_back(cmd_sequence_sizeB, dispatch_params.cq_id);
     sysmem_manager.fetch_queue_reserve_back(dispatch_params.cq_id);
     sysmem_manager.fetch_queue_write(cmd_sequence_sizeB, dispatch_params.cq_id);
+
+    if (use_pinned_memory) {
+        // Send CQ_PREFETCH_CMD_RELAY_LINEAR_H command in a separate fetch Q entry to ensure it will be processed in
+        // prefetch_h for remote device. If we don't do this, prefetch_h will "fetch" it along with the
+        // CQ_PREFETCH_CMD_RELAY_INLINE_NOFLUSH command and send it to prefetch_d
+        calculator.clear();
+        calculator.add_prefetch_relay_linear_h();
+        const uint32_t cmd_sequence_sizeB = calculator.write_offset_bytes();
+        void* cmd_region = sysmem_manager.issue_queue_reserve(cmd_sequence_sizeB, dispatch_params.cq_id);
+        HugepageDeviceCommand command_sequence(cmd_region, cmd_sequence_sizeB);
+
+        const uint64_t data_size_bytes =
+            (uint64_t)dispatch_params.total_pages_to_write * dispatch_params.page_size_to_write;
+        command_sequence.add_prefetch_relay_linear_h(
+            dispatch_params.pinned_src_noc_xy, data_size_bytes, dispatch_params.pinned_src_addr_lo);
+
+        sysmem_manager.issue_queue_push_back(cmd_sequence_sizeB, dispatch_params.cq_id);
+        sysmem_manager.fetch_queue_reserve_back(dispatch_params.cq_id);
+        sysmem_manager.fetch_queue_write(cmd_sequence_sizeB, dispatch_params.cq_id);
+    }
 }
 
 // Top level helper functions to write buffer data
@@ -637,29 +726,39 @@ void write_interleaved_buffer_to_device(
     const BufferDispatchConstants& buf_dispatch_constants,
     tt::stl::Span<const SubDeviceId> sub_device_ids,
     CoreType dispatch_core_type) {
-    uint32_t byte_offset_in_cq = MetalContext::instance().hal().get_alignment(
-        HalMemType::HOST);  // data appended after CQ_PREFETCH_CMD_RELAY_INLINE
-                            // + CQ_DISPATCH_CMD_WRITE_PAGED
+    bool use_pinned_memory = dispatch_params.use_pinned_transfer;
+
+    // data appended after CQ_PREFETCH_CMD_RELAY_INLINE + CQ_DISPATCH_CMD_WRITE_PAGED
+    uint32_t byte_offset_in_cq = MetalContext::instance().hal().get_alignment(HalMemType::HOST);
+
     dispatch_params.calculate_issue_wait();
     update_offset_on_issue_wait_cmd(byte_offset_in_cq, dispatch_params.issue_wait, sub_device_ids.size());
-    while (dispatch_params.total_pages_to_write > 0) {
-        if (dispatch_params.is_page_offset_out_of_bounds()) {
-            dispatch_params.update_params_to_be_within_bounds();
-        }
 
-        const int32_t num_pages_available_in_cq =
-            calculate_num_pages_available_in_cq(dispatch_params, buf_dispatch_constants, byte_offset_in_cq);
-        if (num_pages_available_in_cq <= 0) {
-            SystemMemoryManager& sysmem_manager = dispatch_params.device->sysmem_manager();
-            sysmem_manager.wrap_issue_queue_wr_ptr(dispatch_params.cq_id);
-            continue;
-        }
-
-        log_debug(tt::LogDispatch, "write_interleaved_buffer_to_device for command queue {}", dispatch_params.cq_id);
-
-        dispatch_params.calculate_num_pages_for_write_transaction(num_pages_available_in_cq);
+    if (use_pinned_memory) {
         issue_buffer_dispatch_command_sequence(src, buffer, dispatch_params, sub_device_ids, dispatch_core_type);
-        dispatch_params.update_params_after_write_transaction();
+    } else {
+        // Prefetcher will read from hugepage in one or more iterations depending on transfer size
+        while (dispatch_params.total_pages_to_write > 0) {
+            // Ensure page offset can fit in uint16_t
+            if (dispatch_params.is_page_offset_out_of_bounds()) {
+                dispatch_params.update_params_to_be_within_bounds();
+            }
+
+            const int32_t num_pages_available_in_cq =
+                calculate_num_pages_available_in_cq(dispatch_params, buf_dispatch_constants, byte_offset_in_cq);
+            if (num_pages_available_in_cq <= 0) {
+                SystemMemoryManager& sysmem_manager = dispatch_params.device->sysmem_manager();
+                sysmem_manager.wrap_issue_queue_wr_ptr(dispatch_params.cq_id);
+                continue;
+            }
+
+            log_debug(
+                tt::LogDispatch, "write_interleaved_buffer_to_device for command queue {}", dispatch_params.cq_id);
+
+            dispatch_params.calculate_num_pages_for_write_transaction(num_pages_available_in_cq);
+            issue_buffer_dispatch_command_sequence(src, buffer, dispatch_params, sub_device_ids, dispatch_core_type);
+            dispatch_params.update_params_after_write_transaction();
+        }
     }
 }
 
@@ -681,6 +780,8 @@ void write_sharded_buffer_to_core(
         return;
     }
 
+    bool use_pinned_memory = dispatch_params.use_pinned_transfer;
+
     dispatch_params.reset_params_for_core(core, core_page_mapping);
 
     DeviceCommandCalculator calculator;
@@ -689,20 +790,24 @@ void write_sharded_buffer_to_core(
     dispatch_params.calculate_issue_wait();
     update_offset_on_issue_wait_cmd(data_offset_bytes, dispatch_params.issue_wait, sub_device_ids.size());
 
-    while (dispatch_params.core_num_pages_remaining_to_write != 0) {
-        const int32_t num_pages_available_in_cq =
-            calculate_num_pages_available_in_cq(dispatch_params, buf_dispatch_constants, data_offset_bytes);
-        if (num_pages_available_in_cq <= 0) {
-            SystemMemoryManager& sysmem_manager = dispatch_params.device->sysmem_manager();
-            sysmem_manager.wrap_issue_queue_wr_ptr(dispatch_params.cq_id);
-            continue;
-        }
-
-        log_debug(tt::LogDispatch, "write_sharded_buffer_to_core for command queue {}", dispatch_params.cq_id);
-
-        dispatch_params.calculate_params_for_write_transaction(num_pages_available_in_cq);
+    if (use_pinned_memory) {
         issue_buffer_dispatch_command_sequence(src, buffer, dispatch_params, sub_device_ids, dispatch_core_type);
-        dispatch_params.update_params_after_write_transaction();
+    } else {
+        while (dispatch_params.core_num_pages_remaining_to_write != 0) {
+            const int32_t num_pages_available_in_cq =
+                calculate_num_pages_available_in_cq(dispatch_params, buf_dispatch_constants, data_offset_bytes);
+            if (num_pages_available_in_cq <= 0) {
+                SystemMemoryManager& sysmem_manager = dispatch_params.device->sysmem_manager();
+                sysmem_manager.wrap_issue_queue_wr_ptr(dispatch_params.cq_id);
+                continue;
+            }
+
+            log_debug(tt::LogDispatch, "write_sharded_buffer_to_core for command queue {}", dispatch_params.cq_id);
+
+            dispatch_params.calculate_params_for_write_transaction(num_pages_available_in_cq);
+            issue_buffer_dispatch_command_sequence(src, buffer, dispatch_params, sub_device_ids, dispatch_core_type);
+            dispatch_params.update_params_after_write_transaction();
+        }
     }
 }
 
@@ -713,8 +818,10 @@ void write_to_device_buffer(
     uint32_t cq_id,
     tt::stl::Span<const uint32_t> expected_num_workers_completed,
     CoreType dispatch_core_type,
-    tt::stl::Span<const SubDeviceId> sub_device_ids) {
+    tt::stl::Span<const SubDeviceId> sub_device_ids,
+    std::shared_ptr<tt_metal::PinnedMemory> pinned_memory) {
     SystemMemoryManager& sysmem_manager = buffer.device()->sysmem_manager();
+    auto& hal = tt::tt_metal::MetalContext::instance().hal();
 
     if (tt::tt_metal::GraphTracker::instance().hook_write_to_device(&buffer)) {
         return;
@@ -724,10 +831,64 @@ void write_to_device_buffer(
         generate_buffer_dispatch_constants(sysmem_manager, dispatch_core_type, cq_id);
 
     // TODO: When writing to L1, modify this function to use enqueue_write_to_core
-
+    // Determine whether pinned direct read is feasible, and derive src noc params
+    const bool is_unpadded = (buffer.page_size() == buffer.aligned_page_size());
+    const bool has_pinned_inputs = (src != nullptr && pinned_memory != nullptr);
+    uint32_t pinned_src_noc_xy = 0;
+    uint32_t pinned_src_addr_lo = 0;
+    bool use_pinned_transfer = false;
+    if (has_pinned_inputs && is_unpadded && !is_sharded(buffer.buffer_layout())) {
+        auto device_id = buffer.device()->id();
+        const auto& cluster = MetalContext::instance().get_cluster();
+        const ChipId mmio_device_id = cluster.get_associated_mmio_device(device_id);
+        auto noc_addr_pair_opt = pinned_memory->get_noc_addr(device_id);
+        if (noc_addr_pair_opt.has_value() and noc_addr_pair_opt->device_id == mmio_device_id) {
+            const uint64_t pinned_noc_base = noc_addr_pair_opt->addr;
+            const uint8_t* pinned_host_base = static_cast<const uint8_t*>(pinned_memory->get_host_ptr());
+            const uint8_t* src_ptr = static_cast<const uint8_t*>(src);
+            const uint64_t pinned_size = pinned_memory->get_buffer_size();
+            auto region = buffer.root_buffer_region();
+            const uint8_t* src_region_start = src_ptr + region.offset;
+            const uint8_t* src_region_end = src_region_start + region.size;
+            if (reinterpret_cast<uintptr_t>(src_region_start) % hal.get_read_alignment(HalMemType::HOST) != 0) {
+                log_info(
+                    tt::LogMetal,
+                    "Pinned source memory start address {:#x} must be aligned {} B",
+                    reinterpret_cast<uintptr_t>(src_region_start),
+                    hal.get_read_alignment(HalMemType::HOST));
+            } else if ((src_ptr < pinned_host_base) or (pinned_host_base + pinned_size < src_region_end)) {
+                log_info(
+                    tt::LogMetal,
+                    "Pinned memory region must contain source buffer region: pinned region start:{:#X} end:{:#X} src "
+                    "start:{:#X} end:{:#X}",
+                    (uintptr_t)pinned_host_base,
+                    (uintptr_t)pinned_host_base + pinned_size,
+                    (uintptr_t)src_ptr,
+                    (uintptr_t)src_ptr + region.offset + region.size);
+            } else {
+                const uint64_t pcie_base = cluster.get_pcie_base_addr_from_device(mmio_device_id);
+                const uint64_t src_offset_base = static_cast<uintptr_t>(src_region_start - pinned_host_base);
+                const uint64_t src_noc_addr = pinned_noc_base + src_offset_base;
+                pinned_src_addr_lo = static_cast<uint32_t>(src_noc_addr - pcie_base);
+                const auto& soc = cluster.get_soc_desc(mmio_device_id);
+                const auto& pcie_cores = soc.get_cores(CoreType::PCIE, CoordSystem::NOC0);
+                TT_FATAL(!pcie_cores.empty(), "No PCIE core found on MMIO device {}", mmio_device_id);
+                pinned_src_noc_xy =
+                    MetalContext::instance().hal().noc_xy_encoding(pcie_cores.front().x, pcie_cores.front().y);
+                use_pinned_transfer = true;
+            }
+        }
+    }
     if (is_sharded(buffer.buffer_layout())) {
         ShardedBufferWriteDispatchParams dispatch_params(
-            &buffer, buffer.size() / buffer.page_size(), cq_id, expected_num_workers_completed, sub_device_ids);
+            &buffer,
+            buffer.size() / buffer.page_size(),
+            cq_id,
+            expected_num_workers_completed,
+            sub_device_ids,
+            pinned_src_noc_xy,
+            pinned_src_addr_lo,
+            use_pinned_transfer);
         const std::vector<CoreCoord>& cores = dispatch_params.buffer_page_mapping->all_cores;
         // Since we read core by core we are reading the device pages sequentially
         for (uint32_t core_id = 0; core_id < buffer.num_cores(); ++core_id) {
@@ -750,7 +911,14 @@ void write_to_device_buffer(
         auto region = buffer.root_buffer_region();
         InterleavedBufferWriteDispatchParamsVariant dispatch_params_variant =
             initialize_interleaved_buf_dispatch_params(
-                *root_buffer, cq_id, expected_num_workers_completed, region, sub_device_ids);
+                *root_buffer,
+                cq_id,
+                expected_num_workers_completed,
+                region,
+                sub_device_ids,
+                pinned_src_noc_xy,
+                pinned_src_addr_lo,
+                use_pinned_transfer);
 
         InterleavedBufferWriteDispatchParams* dispatch_params = std::visit(
             ttsl::overloaded{
@@ -825,15 +993,14 @@ void issue_read_buffer_dispatch_command_sequence(
     // Precompute whether pinned direct write is feasible, and derive dst noc params
     const bool is_unpadded = (buffer.page_size() == dispatch_params.padded_page_size);
     const bool has_pinned_inputs = (dispatch_params.dst != nullptr && dispatch_params.pinned_memory != nullptr);
-    const uint32_t xfer_bytes = dispatch_params.pages_per_txn * dispatch_params.padded_page_size;
+    const uint64_t xfer_bytes = uint64_t(dispatch_params.pages_per_txn) * dispatch_params.padded_page_size;
     bool use_pinned_transfer = false;
     uint32_t pinned_dst_noc_xy = 0;
     uint32_t pinned_dst_addr_lo = 0;
 
     if (has_pinned_inputs && is_unpadded) {
-        const chip_id_t mmio_device_id =
-            tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(
-                dispatch_params.device->id());
+        const ChipId mmio_device_id = tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(
+            dispatch_params.device->id());
         auto noc_addr_pair_opt = dispatch_params.pinned_memory->get_noc_addr(dispatch_params.device->id());
         if (noc_addr_pair_opt.has_value() && noc_addr_pair_opt->device_id == mmio_device_id) {
             const uint64_t pinned_noc_base = noc_addr_pair_opt->addr;
@@ -851,7 +1018,7 @@ void issue_read_buffer_dispatch_command_sequence(
                 const uint64_t dst_noc_addr = pinned_noc_base + dst_offset_base;
                 pinned_dst_addr_lo = static_cast<uint32_t>(dst_noc_addr - pcie_base);
                 const auto& soc = cluster.get_soc_desc(mmio_device_id);
-                const auto& pcie_cores = soc.get_cores(CoreType::PCIE, tt::umd::CoordSystem::NOC0);
+                const auto& pcie_cores = soc.get_cores(CoreType::PCIE, CoordSystem::NOC0);
                 TT_FATAL(!pcie_cores.empty(), "No PCIE core found on MMIO device {}", mmio_device_id);
                 pinned_dst_noc_xy =
                     MetalContext::instance().hal().noc_xy_encoding(pcie_cores.front().x, pcie_cores.front().y);

--- a/tt_metal/impl/buffers/dispatch.hpp
+++ b/tt_metal/impl/buffers/dispatch.hpp
@@ -114,7 +114,8 @@ void write_to_device_buffer(
     uint32_t cq_id,
     tt::stl::Span<const uint32_t> expected_num_workers_completed,
     CoreType dispatch_core_type,
-    tt::stl::Span<const SubDeviceId> sub_device_ids);
+    tt::stl::Span<const SubDeviceId> sub_device_ids,
+    std::shared_ptr<tt_metal::PinnedMemory> pinned_memory = nullptr);
 
 ShardedBufferReadDispatchParams initialize_sharded_buf_read_dispatch_params(
     Buffer& buffer, uint32_t cq_id, tt::stl::Span<const uint32_t> expected_num_workers_completed);

--- a/tt_metal/impl/buffers/dispatch.hpp
+++ b/tt_metal/impl/buffers/dispatch.hpp
@@ -28,6 +28,8 @@ enum class TensorMemoryLayout;
 
 namespace tt::tt_metal {
 
+class PinnedMemory;
+
 // Used so the host knows how to properly copy data into user space from the completion queue (in hugepages)
 struct ReadBufferDescriptor {
     uint32_t page_size;
@@ -73,6 +75,9 @@ struct BufferReadDispatchParams {
     uint32_t total_pages_to_read = 0;
     uint32_t total_pages_read = 0;
     uint32_t num_banks = 0;
+    bool requires_completion_read = true;
+    void* dst = nullptr;
+    std::shared_ptr<PinnedMemory> pinned_memory = nullptr;
 
     virtual ~BufferReadDispatchParams() = default;
 
@@ -130,7 +135,9 @@ void copy_interleaved_buffer_to_completion_queue(
     BufferReadDispatchParams& dispatch_params,
     Buffer& buffer,
     tt::stl::Span<const SubDeviceId> sub_device_ids,
-    CoreType dispatch_core_type);
+    CoreType dispatch_core_type,
+    void* dst = nullptr,
+    const std::shared_ptr<PinnedMemory>& pinned_memory = nullptr);
 
 void copy_completion_queue_data_into_user_space(
     const ReadBufferDescriptor& read_buffer_descriptor,

--- a/tt_metal/impl/dispatch/device_command.cpp
+++ b/tt_metal/impl/dispatch/device_command.cpp
@@ -357,6 +357,50 @@ void DeviceCommand<hugepage_write>::add_dispatch_write_linear(
 }
 
 template <bool hugepage_write>
+template <bool flush_prefetch, bool inline_data>
+void DeviceCommand<hugepage_write>::add_dispatch_write_linear_h(
+    uint8_t num_mcast_dests,
+    uint32_t noc_xy_addr,
+    uint32_t addr,
+    uint32_t data_sizeB,
+    const void* data,
+    uint32_t write_offset_index) {
+    uint32_t payload_sizeB = sizeof(CQDispatchCmdLarge) + (flush_prefetch ? data_sizeB : 0);
+    this->add_prefetch_relay_inline(flush_prefetch, payload_sizeB);
+
+    auto initialize_write_cmd = [&](CQDispatchCmdLarge* write_cmd) {
+        write_cmd->base.cmd_id = CQ_DISPATCH_CMD_WRITE_LINEAR_H;
+        write_cmd->write_linear.num_mcast_dests = num_mcast_dests;
+        write_cmd->write_linear.write_offset_index = write_offset_index;
+        write_cmd->write_linear.noc_xy_addr = noc_xy_addr;
+        write_cmd->write_linear.addr = addr;
+        write_cmd->write_linear.length = data_sizeB;
+    };
+    CQDispatchCmdLarge* write_cmd_dst = this->reserve_space<CQDispatchCmdLarge*>(sizeof(CQDispatchCmdLarge));
+
+    if constexpr (hugepage_write) {
+        alignas(MEMCPY_ALIGNMENT) CQDispatchCmdLarge write_cmd{};
+        initialize_write_cmd(&write_cmd);
+        this->memcpy(write_cmd_dst, &write_cmd, sizeof(CQDispatchCmdLarge));
+    } else {
+        initialize_write_cmd(write_cmd_dst);
+    }
+
+    if constexpr (flush_prefetch && inline_data) {
+        TT_ASSERT(data != nullptr);
+        this->add_data(data, data_sizeB, data_sizeB);
+    }
+
+    if constexpr (!flush_prefetch) {
+        this->cmd_write_offsetB = tt::align(this->cmd_write_offsetB, this->pcie_alignment);
+    }
+}
+
+// Explicit template instantiations for add_dispatch_write_linear_h
+template void DeviceCommand<true>::add_dispatch_write_linear_h<false, false>(
+    uint8_t, uint32_t, uint32_t, uint32_t, const void*, uint32_t);
+
+template <bool hugepage_write>
 void DeviceCommand<hugepage_write>::add_dispatch_go_signal_mcast(
     uint32_t wait_count,
     uint32_t go_signal,

--- a/tt_metal/impl/dispatch/device_command.hpp
+++ b/tt_metal/impl/dispatch/device_command.hpp
@@ -88,6 +88,16 @@ public:
         const void* data = nullptr,
         uint32_t write_offset_index = 0);
 
+    // Like add_dispatch_write_linear, but emits CQ_DISPATCH_CMD_WRITE_LINEAR_H (dispatch_h variant).
+    template <bool flush_prefetch = true, bool inline_data = false>
+    void add_dispatch_write_linear_h(
+        uint8_t num_mcast_dests,
+        uint32_t noc_xy_addr,
+        uint32_t addr,
+        uint32_t data_sizeB,
+        const void* data = nullptr,
+        uint32_t write_offset_index = 0);
+
     void add_dispatch_go_signal_mcast(
         uint32_t wait_count,
         uint32_t go_signal,

--- a/tt_metal/impl/dispatch/device_command.hpp
+++ b/tt_metal/impl/dispatch/device_command.hpp
@@ -56,7 +56,9 @@ public:
 
     void add_dispatch_wait_with_prefetch_stall(uint32_t flags, uint32_t address, uint32_t stream, uint32_t count);
 
-    void add_prefetch_relay_linear(uint32_t noc_xy_addr, DeviceAddr lengthB, uint32_t addr);
+    void add_prefetch_relay_linear(uint32_t noc_xy_addr, DeviceAddr lengthB, uint64_t addr);
+
+    void add_prefetch_relay_linear_h(uint32_t noc_xy_addr, DeviceAddr lengthB, uint64_t addr);
 
     void add_prefetch_relay_paged(
         uint8_t is_dram,
@@ -93,8 +95,8 @@ public:
     void add_dispatch_write_linear_h(
         uint8_t num_mcast_dests,
         uint32_t noc_xy_addr,
-        uint32_t addr,
-        uint32_t data_sizeB,
+        uint64_t addr,
+        uint64_t data_sizeB,
         const void* data = nullptr,
         uint32_t write_offset_index = 0);
 

--- a/tt_metal/impl/dispatch/device_command_calculator.hpp
+++ b/tt_metal/impl/dispatch/device_command_calculator.hpp
@@ -67,6 +67,23 @@ public:
         }
     }
 
+    // Calculator sizing for CQ_DISPATCH_CMD_WRITE_LINEAR_H (dispatch_h linear write)
+    // Mirrors add_dispatch_write_linear for sizing/alignment purposes.
+    template <bool flush_prefetch = true, bool inline_data = false>
+    void add_dispatch_write_linear_h(uint32_t data_sizeB) {
+        this->add_prefetch_relay_inline();
+        this->cmd_write_offsetB += sizeof(CQDispatchCmdLarge);
+
+        if constexpr (flush_prefetch) {
+            if constexpr (inline_data) {
+                this->add_data(data_sizeB);
+                this->cmd_write_offsetB = tt::align(this->cmd_write_offsetB, this->pcie_alignment);
+            }
+        } else {
+            this->cmd_write_offsetB = tt::align(this->cmd_write_offsetB, this->pcie_alignment);
+        }
+    }
+
     void add_dispatch_write_linear_host_event(uint32_t data_sizeB) {
         this->add_prefetch_relay_inline();
         this->cmd_write_offsetB += sizeof(CQDispatchCmd) + data_sizeB;

--- a/tt_metal/impl/dispatch/device_command_calculator.hpp
+++ b/tt_metal/impl/dispatch/device_command_calculator.hpp
@@ -33,6 +33,10 @@ public:
         this->cmd_write_offsetB += sizeof(CQPrefetchCmdLarge);
         this->cmd_write_offsetB = tt::align(this->cmd_write_offsetB, this->pcie_alignment);
     }
+    void add_prefetch_relay_linear_h() {
+        this->cmd_write_offsetB += sizeof(CQPrefetchCmdLarge);
+        this->cmd_write_offsetB = tt::align(this->cmd_write_offsetB, this->pcie_alignment);
+    }
 
     void add_prefetch_stall() {
         this->cmd_write_offsetB += sizeof(CQPrefetchCmd);
@@ -70,7 +74,7 @@ public:
     // Calculator sizing for CQ_DISPATCH_CMD_WRITE_LINEAR_H (dispatch_h linear write)
     // Mirrors add_dispatch_write_linear for sizing/alignment purposes.
     template <bool flush_prefetch = true, bool inline_data = false>
-    void add_dispatch_write_linear_h(uint32_t data_sizeB) {
+    void add_dispatch_write_linear_h(uint64_t data_sizeB) {
         this->add_prefetch_relay_inline();
         this->cmd_write_offsetB += sizeof(CQDispatchCmdLarge);
 

--- a/tt_metal/impl/dispatch/kernels/cq_commands.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_commands.hpp
@@ -96,11 +96,10 @@ struct CQPrefetchRelayLinearCmd {
 // Flushes an extra page at the end (so it can only be used after CQ_PREFETCH_CMD_RELAY_INLINE_NOFLUSH). Must be only
 // command in fetchq entry.
 struct CQPrefetchRelayLinearHCmd {
-    uint8_t pad1;
-    uint16_t pad2;
+    uint16_t pad1;
+    uint64_t length;
     uint32_t noc_xy_addr;
     uint64_t addr;
-    uint32_t length;  // Length must be <= min(scratch_db_size, max command size) - sizeof(CQPrefetchHToPrefetchDHeader)
 } __attribute__((packed));
 
 constexpr uint32_t CQ_PREFETCH_RELAY_PAGED_START_PAGE_MASK = 0xff;

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -842,6 +842,24 @@ void Cluster::read_sysmem(
     this->driver_->read_from_sysmem(vec, addr, channel & HOST_MEM_CHANNELS_MASK, size_in_bytes, src_device_id);
 }
 
+std::unique_ptr<tt::umd::SysmemBuffer> Cluster::allocate_sysmem_buffer(
+    chip_id_t device_id, size_t sysmem_buffer_size, bool map_to_noc) const {
+    tt::umd::SysmemManager* sysmem_manager = this->driver_->get_chip(device_id)->get_sysmem_manager();
+    if (!sysmem_manager) {
+        TT_THROW("Failed to get SysmemManager for device {}", device_id);
+    }
+    return sysmem_manager->allocate_sysmem_buffer(sysmem_buffer_size, map_to_noc);
+}
+
+std::unique_ptr<tt::umd::SysmemBuffer> Cluster::map_sysmem_buffer(
+    chip_id_t device_id, void* buffer, size_t sysmem_buffer_size, bool map_to_noc) const {
+    tt::umd::SysmemManager* sysmem_manager = this->driver_->get_chip(device_id)->get_sysmem_manager();
+    if (!sysmem_manager) {
+        TT_THROW("Failed to get SysmemManager for device {}", device_id);
+    }
+    return sysmem_manager->map_sysmem_buffer(buffer, sysmem_buffer_size, map_to_noc);
+}
+
 void Cluster::verify_sw_fw_versions(
     int device_id, std::uint32_t sw_version, std::vector<std::uint32_t> &fw_versions) const {
     umd::tt_version sw(sw_version), fw_first_eth_core(fw_versions.at(0));

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -843,7 +843,7 @@ void Cluster::read_sysmem(
 }
 
 std::unique_ptr<tt::umd::SysmemBuffer> Cluster::allocate_sysmem_buffer(
-    chip_id_t device_id, size_t sysmem_buffer_size, bool map_to_noc) const {
+    ChipId device_id, size_t sysmem_buffer_size, bool map_to_noc) const {
     tt::umd::SysmemManager* sysmem_manager = this->driver_->get_chip(device_id)->get_sysmem_manager();
     if (!sysmem_manager) {
         TT_THROW("Failed to get SysmemManager for device {}", device_id);
@@ -852,7 +852,7 @@ std::unique_ptr<tt::umd::SysmemBuffer> Cluster::allocate_sysmem_buffer(
 }
 
 std::unique_ptr<tt::umd::SysmemBuffer> Cluster::map_sysmem_buffer(
-    chip_id_t device_id, void* buffer, size_t sysmem_buffer_size, bool map_to_noc) const {
+    ChipId device_id, void* buffer, size_t sysmem_buffer_size, bool map_to_noc) const {
     tt::umd::SysmemManager* sysmem_manager = this->driver_->get_chip(device_id)->get_sysmem_manager();
     if (!sysmem_manager) {
         TT_THROW("Failed to get SysmemManager for device {}", device_id);

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -212,6 +212,12 @@ public:
     void read_sysmem(
         void* mem_ptr, uint32_t size_in_bytes, uint64_t addr, ChipId src_device_id, uint16_t channel) const;
 
+    // System memory buffer allocation methods
+    std::unique_ptr<tt::umd::SysmemBuffer> allocate_sysmem_buffer(
+        chip_id_t device_id, size_t sysmem_buffer_size, bool map_to_noc = false) const;
+    std::unique_ptr<tt::umd::SysmemBuffer> map_sysmem_buffer(
+        chip_id_t device_id, void* buffer, size_t sysmem_buffer_size, bool map_to_noc = false) const;
+
     int get_device_aiclk(const ChipId& chip_id) const;
 
     void dram_barrier(ChipId chip_id) const;

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -214,9 +214,9 @@ public:
 
     // System memory buffer allocation methods
     std::unique_ptr<tt::umd::SysmemBuffer> allocate_sysmem_buffer(
-        chip_id_t device_id, size_t sysmem_buffer_size, bool map_to_noc = false) const;
+        ChipId device_id, size_t sysmem_buffer_size, bool map_to_noc = false) const;
     std::unique_ptr<tt::umd::SysmemBuffer> map_sysmem_buffer(
-        chip_id_t device_id, void* buffer, size_t sysmem_buffer_size, bool map_to_noc = false) const;
+        ChipId device_id, void* buffer, size_t sysmem_buffer_size, bool map_to_noc = false) const;
 
     int get_device_aiclk(const ChipId& chip_id) const;
 

--- a/ttnn/api/ttnn/tensor/tensor.hpp
+++ b/ttnn/api/ttnn/tensor/tensor.hpp
@@ -240,6 +240,7 @@ public:
 
     // Returns host `Storage`.
     // Throws if the tensor is not on host.
+    HostStorage& host_storage() &;
     const HostStorage& host_storage() const&;
     const HostStorage& host_storage() const&& = delete;  // prevents dangling reference to temporaries.
 

--- a/ttnn/core/device.cpp
+++ b/ttnn/core/device.cpp
@@ -4,6 +4,7 @@
 
 #include "ttnn/device.hpp"
 #include <tt-metalium/device_pool.hpp>
+#include <tt-metalium/pinned_memory.hpp>
 
 namespace tt::tt_metal::tensor_impl {
 void clear_pinned_memories_cache();
@@ -31,7 +32,7 @@ void close_device(IDevice& device) {
     // TODO #20966: Remove single device support and branches + dynamic_cast
     if (auto mesh_device = dynamic_cast<MeshDevice*>(&device)) {
         fmt::println(stderr, "Clearing pinned memories cache");
-        tt::tt_metal::tensor_impl::clear_pinned_memories_cache();
+        tt::tt_metal::clear_pinned_memories_cache();
         mesh_device->close();
     } else {
         tt::DevicePool::instance().close_device(device.id());

--- a/ttnn/core/device.cpp
+++ b/ttnn/core/device.cpp
@@ -5,6 +5,10 @@
 #include "ttnn/device.hpp"
 #include <tt-metalium/device_pool.hpp>
 
+namespace tt::tt_metal::tensor_impl {
+void clear_pinned_memories_cache();
+}
+
 namespace ttnn {
 
 namespace device {
@@ -26,6 +30,8 @@ void disable_and_clear_program_cache(IDevice& device) { device.disable_and_clear
 void close_device(IDevice& device) {
     // TODO #20966: Remove single device support and branches + dynamic_cast
     if (auto mesh_device = dynamic_cast<MeshDevice*>(&device)) {
+        fmt::println(stderr, "Clearing pinned memories cache");
+        tt::tt_metal::tensor_impl::clear_pinned_memories_cache();
         mesh_device->close();
     } else {
         tt::DevicePool::instance().close_device(device.id());

--- a/ttnn/core/tensor/tensor.cpp
+++ b/ttnn/core/tensor/tensor.cpp
@@ -665,6 +665,12 @@ const HostStorage& Tensor::host_storage() const& {
     return *host_storage;
 }
 
+HostStorage& Tensor::host_storage() & {
+    auto* host_storage = std::get_if<HostStorage>(&this->storage());
+    TT_FATAL(host_storage != nullptr, "Expected Tensor with HostStorage, got {}", this->storage_type());
+    return *host_storage;
+}
+
 distributed::MeshDevice* Tensor::device() const {
     if (this->mesh_device_.has_value()) {
         return this->mesh_device_.value();

--- a/ttnn/core/tensor/tensor_impl.cpp
+++ b/ttnn/core/tensor/tensor_impl.cpp
@@ -3,6 +3,7 @@
 
 #include "ttnn/tensor/tensor_impl.hpp"
 #include <fmt/format.h>
+#include <functional>
 #include <optional>
 
 #include <sys/mman.h>
@@ -611,8 +612,9 @@ DeviceStorage replicate_to_mesh_buffer(
         expected_packed_buffer_size_bytes);
 
     std::optional<uint8_t> cq_id_int = cq_id.has_value() ? std::make_optional(cq_id.value().get()) : std::nullopt;
+    bool blocking = false;
     mesh_device->mesh_command_queue(cq_id_int).enqueue_write_mesh_buffer(
-        mesh_buffer, data_to_write.data(), /*blocking=*/false);
+        mesh_buffer, data_to_write.data(), blocking, buffer.get_pinned_memory());
 
     std::vector<distributed::MeshCoordinate> coords;
     coords.reserve(mesh_device->shape().mesh_size());
@@ -732,7 +734,7 @@ void copy_to_host(const Tensor& device_tensor, Tensor& host_tensor, bool blockin
 
     const DistributedHostBuffer& distributed_host_buffer = host_tensor.host_storage().buffer();
 
-    std::vector<PinnedMemoryWrapper> pinned_memories_to_cache;
+    std::vector<tt_metal::PinnedMemoryWrapper> pinned_memories_to_cache;
 
     bool use_pinned = device->get_memory_pinning_parameters().can_map_to_noc;
 
@@ -748,21 +750,19 @@ void copy_to_host(const Tensor& device_tensor, Tensor& host_tensor, bool blockin
             if (shard.has_value()) {
                 auto range_set =
                     distributed::MeshCoordinateRangeSet{distributed::MeshCoordinateRange{device_coord, device_coord}};
-                std::shared_ptr<tt_metal::PinnedMemory> pinned_memory;
-                for (auto& pinned_memory_wrapper : pinned_memories_cache) {
-                    if (pinned_memory_wrapper.device_range == range_set &&
-                        pinned_memory_wrapper.pinned_memory->get_host_ptr() == shard->view_bytes().data() &&
-                        pinned_memory_wrapper.pinned_memory->get_buffer_size() == shard->view_bytes().size()) {
-                        pinned_memory = pinned_memory_wrapper.pinned_memory;
-                        break;
-                    }
-                }
+                std::function<bool(const tt_metal::PinnedMemoryWrapper&)> predicate =
+                    [&](const tt_metal::PinnedMemoryWrapper& pinned_memory_wrapper) {
+                        return pinned_memory_wrapper.device_range == range_set &&
+                               pinned_memory_wrapper.pinned_memory->get_host_ptr() == shard->view_bytes().data() &&
+                               pinned_memory_wrapper.pinned_memory->get_buffer_size() == shard->view_bytes().size();
+                    };
+                std::shared_ptr<tt_metal::PinnedMemory> pinned_memory = tt_metal::find_matching_pin_in_cache(predicate);
                 if (pinned_memory == nullptr) {
                     // TODO: on blackhole, limit size of cache to avoid pinning arbitrarily many buffers.
                     try {
                         pinned_memory = device->pin_memory(range_set, *shard, /*map_to_noc=*/true);
                     } catch (const std::exception& e) {
-                        pinned_memories_cache.clear();
+                        tt_metal::clear_pinned_memories_cache();
                     }
                     if (pinned_memory == nullptr) {
                         try {
@@ -771,7 +771,7 @@ void copy_to_host(const Tensor& device_tensor, Tensor& host_tensor, bool blockin
                         }
                     }
                     if (pinned_memory != nullptr) {
-                        pinned_memories_to_cache.push_back(PinnedMemoryWrapper{range_set, pinned_memory});
+                        pinned_memories_to_cache.push_back(tt_metal::PinnedMemoryWrapper{range_set, pinned_memory});
                     }
                 }
                 shard->set_pinned_memory(pinned_memory);
@@ -781,7 +781,7 @@ void copy_to_host(const Tensor& device_tensor, Tensor& host_tensor, bool blockin
     }
 
     for (auto& pinned_memory_wrapper : pinned_memories_to_cache) {
-        pinned_memories_cache.push_back(pinned_memory_wrapper);
+        tt_metal::add_pin_to_cache(std::move(pinned_memory_wrapper));
     }
 
     DistributedHostBuffer dst_distributed_host_buffer = DistributedHostBuffer::create(device->get_view());
@@ -822,7 +822,52 @@ void copy_to_device(const Tensor& host_tensor, Tensor& device_tensor, std::optio
         host_tensor.tensor_spec().page_config() == device_tensor.tensor_spec().page_config(),
         "Host tensor has different page config");
 
-    auto mesh_buffer = device_tensor.device_storage().mesh_buffer;
+    const auto& device_storage = device_tensor.device_storage();
+    auto mesh_buffer = device_storage.mesh_buffer;
+    ttnn::MeshDevice* device = mesh_buffer->device();
+    std::vector<tt_metal::PinnedMemoryWrapper> pinned_memories_to_cache;
+    bool use_pinned = device->get_memory_pinning_parameters().can_map_to_noc;
+    const DistributedHostBuffer& distributed_host_buffer = host_tensor.host_storage().buffer();
+    for (const auto& device_coord : device_storage.coords) {
+        auto shard = distributed_host_buffer.get_shard(device_coord);
+        if (use_pinned) {
+            if (shard.has_value()) {
+                auto range_set =
+                    distributed::MeshCoordinateRangeSet{distributed::MeshCoordinateRange{device_coord, device_coord}};
+                std::function<bool(const tt_metal::PinnedMemoryWrapper&)> predicate =
+                    [&](const tt_metal::PinnedMemoryWrapper& pinned_memory_wrapper) {
+                        return pinned_memory_wrapper.device_range == range_set &&
+                               pinned_memory_wrapper.pinned_memory->get_host_ptr() == shard->view_bytes().data() &&
+                               pinned_memory_wrapper.pinned_memory->get_buffer_size() == shard->view_bytes().size();
+                    };
+                std::shared_ptr<tt_metal::PinnedMemory> pinned_memory = tt_metal::find_matching_pin_in_cache(predicate);
+                if (pinned_memory == nullptr) {
+                    // TODO: on blackhole, limit size of cache to avoid pinning arbitrarily many buffers.
+                    try {
+                        pinned_memory = device->pin_memory(range_set, *shard, /*map_to_noc=*/true);
+                    } catch (const std::exception& e) {
+                        tt_metal::clear_pinned_memories_cache();
+                    }
+                    if (pinned_memory == nullptr) {
+                        try {
+                            pinned_memory = device->pin_memory(range_set, *shard, /*map_to_noc=*/true);
+                        } catch (const std::exception& e) {
+                        }
+                    }
+                    if (pinned_memory != nullptr) {
+                        pinned_memories_to_cache.push_back(tt_metal::PinnedMemoryWrapper{range_set, pinned_memory});
+                    }
+                } else {
+                    // to ensure strict memory ordering
+                    pinned_memory->lock();
+                }
+                shard->set_pinned_memory(pinned_memory);
+            }
+        }
+    }
+    for (auto& pinned_memory_wrapper : pinned_memories_to_cache) {
+        tt_metal::add_pin_to_cache(std::move(pinned_memory_wrapper));
+    }
 
     auto [mesh_storage, topology] = to_device_mesh_buffer<T>(
         host_tensor.storage(),


### PR DESCRIPTION
### Ticket
[Link to Github Issue
[](https://github.com/tenstorrent/tt-metal/issues/25675)](https://github.com/tenstorrent/tt-metal/issues/25675)

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes