### PR TITLE
MoE: Fuse `untilize` with `all_to_all_dispatch`

### DIFF
--- a/tests/nightly/t3000/ccl/test_all_to_all_dispatch.py
+++ b/tests/nightly/t3000/ccl/test_all_to_all_dispatch.py
@@ -551,13 +551,13 @@ def run_all_to_all_dispatch_test(
 @pytest.mark.parametrize("cluster_axis", [0, 1], ids=["cluster_row", "cluster_col"])
 @pytest.mark.parametrize("experts_per_device", [8])
 @pytest.mark.parametrize("select_experts_k", [8])
-@pytest.mark.parametrize("hidden_size", [7168])
+@pytest.mark.parametrize("hidden_size", [32])
 @pytest.mark.parametrize("input_layout", [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT])
 @pytest.mark.parametrize(
     "batches_per_device, seq_len, num_iters, warmup_iters, input_memory_config, output_memory_config",
     [
-        (16, 2, 1, 1, ttnn.DRAM_MEMORY_CONFIG, ttnn.DRAM_MEMORY_CONFIG),  # b16s2, dram-dram
-        (1, 3, 1, 1, ttnn.L1_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG),  # b1s3, l1-l1
+        (16, 2, 2, 1, ttnn.DRAM_MEMORY_CONFIG, ttnn.DRAM_MEMORY_CONFIG),  # b16s2, dram-dram
+        (1, 3, 2, 1, ttnn.L1_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG),  # b1s3, l1-l1
     ],
     ids=["b16s2-dram", "b1s3-l1"],
 )

--- a/tests/nightly/t3000/ccl/test_all_to_all_dispatch.py
+++ b/tests/nightly/t3000/ccl/test_all_to_all_dispatch.py
@@ -2,8 +2,6 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-from math import prod
-
 import torch
 import pytest
 import random

--- a/tests/ttnn/unit_tests/operations/data_movement/test_untilize.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_untilize.py
@@ -1311,7 +1311,7 @@ def test_untilize_multi_core_buffer_type_variations(
     # Test
     input_torch_tensor = torch.randn(tensor_shape, dtype=torch.bfloat16)
     input_ttnn_tensor = ttnn.from_torch(input_torch_tensor, dtype=dtype, layout=ttnn.TILE_LAYOUT)
-    input_ttnn_tensor = ttnn.to_device(input_ttnn_tensor, device, memory_config=input_memory_config)
+    input_ttnn_tensor = ttnn.to_device(input_ttnn_tensor, adevice, memory_config=input_memory_config)
     ttnn_output_tensor = ttnn.untilize(
         input_ttnn_tensor, memory_config=output_memory_config, use_multicore=True, use_pack_untilize=use_pack_untilize
     )
@@ -1320,7 +1320,7 @@ def test_untilize_multi_core_buffer_type_variations(
 
 
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16])
-@pytest.mark.parametrize("tensor_shape", [[1, 1, 128, 7168], [1, 1, 2048, 7168], [1, 1, 4096, 7168]])
+@pytest.mark.parametrize("tensor_shape", [[1, 1, 128, 7168],[1, 1, 2048, 7168],[1, 1, 4096, 7168]])
 @pytest.mark.parametrize("input_buffer_type", [ttnn.BufferType.DRAM])
 @pytest.mark.parametrize("output_buffer_type", [ttnn.BufferType.DRAM])
 def test_untilize_deepseek(
@@ -1330,10 +1330,16 @@ def test_untilize_deepseek(
     input_buffer_type,
     output_buffer_type,
 ):
+    
     input_torch_tensor = torch.randn(tensor_shape, dtype=torch.bfloat16)
     input_ttnn_tensor = ttnn.from_torch(input_torch_tensor, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device)
-    sub_core_range = ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 3))])
-
-    ttnn_output_tensor = ttnn.untilize(input_ttnn_tensor, sub_core_grids=sub_core_range, _internal_row_wise=True)
+    sub_core_range = ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 1))])
+    
+    semaphore = ttnn.create_global_semaphore(device, sub_core_range, 0)
+    
+    ttnn_output_tensor = ttnn.untilize(input_ttnn_tensor, sub_core_grids=sub_core_range, _internal_row_wise=True) #, _internal_semaphore=semaphore)
 
     assert_with_pcc(input_torch_tensor, ttnn.to_torch(ttnn_output_tensor), 0.9999)
+
+
+

--- a/tests/ttnn/unit_tests/operations/data_movement/test_untilize.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_untilize.py
@@ -1317,3 +1317,23 @@ def test_untilize_multi_core_buffer_type_variations(
     )
 
     assert_with_pcc(input_torch_tensor, ttnn.to_torch(ttnn_output_tensor), 0.9999)
+
+
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16])
+@pytest.mark.parametrize("tensor_shape", [[1, 1, 128, 7168], [1, 1, 2048, 7168], [1, 1, 4096, 7168]])
+@pytest.mark.parametrize("input_buffer_type", [ttnn.BufferType.DRAM])
+@pytest.mark.parametrize("output_buffer_type", [ttnn.BufferType.DRAM])
+def test_untilize_deepseek(
+    device,
+    dtype,
+    tensor_shape,
+    input_buffer_type,
+    output_buffer_type,
+):
+    input_torch_tensor = torch.randn(tensor_shape, dtype=torch.bfloat16)
+    input_ttnn_tensor = ttnn.from_torch(input_torch_tensor, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device)
+    sub_core_range = ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 3))])
+
+    ttnn_output_tensor = ttnn.untilize(input_ttnn_tensor, sub_core_grids=sub_core_range, _internal_row_wise=True)
+
+    assert_with_pcc(input_torch_tensor, ttnn.to_torch(ttnn_output_tensor), 0.9999)

--- a/tests/ttnn/unit_tests/operations/data_movement/test_untilize.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_untilize.py
@@ -1320,7 +1320,9 @@ def test_untilize_multi_core_buffer_type_variations(
 
 
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16])
-@pytest.mark.parametrize("tensor_shape", [[1, 1, 128, 7168], [1, 1, 2048, 7168], [1, 1, 4096, 7168]])
+@pytest.mark.parametrize(
+    "tensor_shape", [[1, 1, 32, 7168], [1, 1, 8, 7168], [1, 1, 128, 7168], [1, 1, 2048, 7168], [1, 1, 4096, 7168]]
+)
 @pytest.mark.parametrize("end_core_coord", [(0, 0), (0, 1), (0, 3)])
 @pytest.mark.parametrize("input_buffer_type", [ttnn.BufferType.DRAM])
 @pytest.mark.parametrize("output_buffer_type", [ttnn.BufferType.DRAM])

--- a/ttnn/cpp/ttnn/operations/ccl/all_to_all_dispatch/all_to_all_dispatch.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_to_all_dispatch/all_to_all_dispatch.hpp
@@ -17,7 +17,7 @@ struct ExecuteAllToAllDispatch {
         const ttnn::Tensor& expert_indices_tensor,
         const ttnn::Tensor& expert_mapping_tensor,
         std::optional<uint32_t> axis = std::nullopt,
-        const std::optional<std::array<ttnn::Tensor, 2>>& optional_output_tensors = std::nullopt,
+        const std::optional<std::array<ttnn::Tensor, 3>>& optional_output_tensors = std::nullopt,
         std::optional<uint32_t> num_links = std::nullopt,
         std::optional<tt::tt_fabric::Topology> topology = std::nullopt,
         const std::optional<ttnn::MemoryConfig>& memory_config = std::nullopt,

--- a/ttnn/cpp/ttnn/operations/ccl/all_to_all_dispatch/all_to_all_dispatch_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_to_all_dispatch/all_to_all_dispatch_pybind.cpp
@@ -78,7 +78,7 @@ void py_bind_all_to_all_dispatch(py::module& module) {
                const std::optional<uint32_t> cluster_axis,
                const std::optional<tt::tt_metal::SubDeviceId>& subdevice_id,
                const std::optional<ttnn::MemoryConfig>& memory_config,
-               const std::optional<std::array<ttnn::Tensor, 2>>& output_tensors,
+               const std::optional<std::array<ttnn::Tensor, 3>>& output_tensors,
                const std::optional<uint32_t> num_links,
                const std::optional<tt::tt_fabric::Topology> topology) {
                 return self(

--- a/ttnn/cpp/ttnn/operations/ccl/all_to_all_dispatch/device/all_to_all_dispatch_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_to_all_dispatch/device/all_to_all_dispatch_device_operation.cpp
@@ -108,7 +108,7 @@ AllToAllDispatchDeviceOperation::spec_return_value_t AllToAllDispatchDeviceOpera
     }
 
     // final batch in the metadata tensor
-    uint32_t batch = (output_concat_dim == 1) ? input_shape[0] * dispatch_devices : input_shape[0];
+    uint32_t batch = (output_concat_dim == 1) ? indices_shape[0] * dispatch_devices : indices_shape[0];
     uint32_t selected_experts_k = indices_shape[-1];
     uint32_t seq_len = (output_concat_dim == 2) ? indices_shape[-2] * dispatch_devices : indices_shape[-2];
 
@@ -139,8 +139,9 @@ AllToAllDispatchDeviceOperation::spec_return_value_t AllToAllDispatchDeviceOpera
 
     std::optional<TensorSpec> untilized_input_tensor = std::nullopt;
     if (input_tensor.layout() == tt::tt_metal::Layout::TILE) {
+        Shape intermediate_shape({indices_shape[0], 1, seq_len, hidden_size});
         untilized_input_tensor.emplace(
-            input_shape,
+            intermediate_shape,
             tt::tt_metal::TensorLayout(
                 input_tensor.dtype(),
                 tt::tt_metal::PageConfig(tt::tt_metal::Layout::ROW_MAJOR),

--- a/ttnn/cpp/ttnn/operations/ccl/all_to_all_dispatch/device/all_to_all_dispatch_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_to_all_dispatch/device/all_to_all_dispatch_device_operation.cpp
@@ -155,17 +155,22 @@ AllToAllDispatchDeviceOperation::spec_return_value_t AllToAllDispatchDeviceOpera
         auto preallocated_output_spec = output_tensors.at(0).tensor_spec();
         auto preallocated_metadata_spec = output_tensors.at(1).tensor_spec();
         std::optional<TensorSpec> preallocated_untilized_intermediate_spec{output_tensors.at(2).tensor_spec()};
-        return std::make_tuple(
-            preallocated_output_spec, preallocated_metadata_spec, preallocated_untilized_intermediate_spec);
+        return {
+            .output_tokens_spec = preallocated_output_spec,
+            .metadata_spec = preallocated_metadata_spec,
+            .untilized_input_tensor = preallocated_untilized_intermediate_spec};
     }
-    return std::make_tuple(output_tokens_spec, metadata_spec, untilized_input_tensor);
+    return {
+        .output_tokens_spec = output_tokens_spec,
+        .metadata_spec = metadata_spec,
+        .untilized_input_tensor = untilized_input_tensor};
 }
 
 AllToAllDispatchDeviceOperation::tensor_return_value_t AllToAllDispatchDeviceOperation::create_output_tensors(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     if (tensor_args.optional_output_tensors.has_value()) {
         const auto& optional_tensors = tensor_args.optional_output_tensors.value();
-        return std::make_tuple(optional_tensors[0], optional_tensors[1], std::make_optional(optional_tensors[2]));
+        return {optional_tensors[0], optional_tensors[1], std::make_optional(optional_tensors[2])};
     }
     const auto [output_spec, metadata_spec, untilize_intermediate_spec] =
         compute_output_specs(operation_attributes, tensor_args);
@@ -179,7 +184,10 @@ AllToAllDispatchDeviceOperation::tensor_return_value_t AllToAllDispatchDeviceOpe
             create_device_tensor(untilize_intermediate_spec.value(), tensor_args.input_tensor.device());
     }
 
-    return {output_tensor, metadata_tensor, intermediate_untilize_tensor};
+    return {
+        .output_tokens = output_tensor,
+        .output_metadata = metadata_tensor,
+        .optional_untilized_intermediate = intermediate_untilize_tensor};
 }
 
 std::tuple<AllToAllDispatchDeviceOperation::operation_attributes_t, AllToAllDispatchDeviceOperation::tensor_args_t>

--- a/ttnn/cpp/ttnn/operations/ccl/all_to_all_dispatch/device/all_to_all_dispatch_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_to_all_dispatch/device/all_to_all_dispatch_device_operation.cpp
@@ -59,8 +59,8 @@ void AllToAllDispatchDeviceOperation::validate_on_program_cache_miss(
             TT_FATAL(
                 untilize_intermediate_spec.value() == intermediate_tensor.tensor_spec(),
                 "Optional intermediate RM tensor spec {} does not match computed output spec {}",
-                sparse_token_tensor.tensor_spec(),
-                output_spec);
+                intermediate_tensor.tensor_spec(),
+                untilize_intermediate_spec.value());
         }
     }
     TT_FATAL(operation_attributes.num_links > 0, "Number of links must be greater than 0");
@@ -88,7 +88,7 @@ AllToAllDispatchDeviceOperation::spec_return_value_t AllToAllDispatchDeviceOpera
     auto indices_shape = tensor_args.expert_indices_tensor.tensor_spec().logical_shape();
     auto mapping_shape = tensor_args.expert_mapping_tensor.tensor_spec().logical_shape();
 
-    auto mesh_device = input_tensor.device();
+    auto* mesh_device = input_tensor.device();
     const auto& mesh_view = mesh_device->get_view();
     uint32_t output_concat_dim = operation_attributes.output_concat_dim;
 

--- a/ttnn/cpp/ttnn/operations/ccl/all_to_all_dispatch/device/all_to_all_dispatch_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_to_all_dispatch/device/all_to_all_dispatch_device_operation.hpp
@@ -6,7 +6,7 @@
 
 #include <variant>
 #include <optional>
-
+#include "ttnn/operations/data_movement/untilize/device/untilize_program_factory.hpp"
 #include "ttnn/distributed/types.hpp"
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/core.hpp"
@@ -70,6 +70,8 @@ struct AllToAllDispatchDeviceOperation {
             std::vector<CoreCoord> cores;
             const GlobalSemaphore init_semaphore;
             const GlobalSemaphore cross_device_semaphore;
+            const std::optional<GlobalSemaphore> untilize_sync_semaphore;
+            const std::optional<data_movement::untilize::FuseableUntilizeCallback> untilize_callback;
         };
         using cached_mesh_workload_t = ttnn::device_operation::AdaptedCachedMeshWorkload<shared_variables_t>;
 

--- a/ttnn/cpp/ttnn/operations/ccl/all_to_all_dispatch/device/all_to_all_dispatch_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_to_all_dispatch/device/all_to_all_dispatch_device_operation.hpp
@@ -55,12 +55,12 @@ struct AllToAllDispatchDeviceOperation {
         const Tensor input_tensor;
         const Tensor expert_indices_tensor;
         const Tensor expert_mapping_tensor;
-        const std::optional<std::array<Tensor, 2>> optional_output_tensors;
+        const std::optional<std::array<Tensor, 3>> optional_output_tensors;
     };
 
-    using spec_return_value_t = std::array<ttnn::TensorSpec, 2>;
+    using spec_return_value_t = std::tuple<ttnn::TensorSpec, ttnn::TensorSpec, std::optional<ttnn::TensorSpec>>;
 
-    using tensor_return_value_t = std::array<Tensor, 2>;
+    using tensor_return_value_t = std::tuple<Tensor, Tensor, std::optional<Tensor>>;
 
     struct AllToAllDispatchSparse {
         // Shared variables are the variables that are shared between the create and override_runtime_arguments methods
@@ -119,7 +119,7 @@ struct AllToAllDispatchDeviceOperation {
         const ttnn::Tensor& expert_indices_tensor,
         const ttnn::Tensor& expert_mapping_tensor,
         std::optional<uint32_t> axis,
-        const std::optional<std::array<ttnn::Tensor, 2>>& optional_output_tensors,
+        const std::optional<std::array<ttnn::Tensor, 3>>& optional_output_tensors,
         uint32_t num_links,
         tt::tt_fabric::Topology topology,
         const ttnn::MemoryConfig& memory_config,

--- a/ttnn/cpp/ttnn/operations/ccl/all_to_all_dispatch/device/all_to_all_dispatch_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_to_all_dispatch/device/all_to_all_dispatch_device_operation.hpp
@@ -58,9 +58,17 @@ struct AllToAllDispatchDeviceOperation {
         const std::optional<std::array<Tensor, 3>> optional_output_tensors;
     };
 
-    using spec_return_value_t = std::tuple<ttnn::TensorSpec, ttnn::TensorSpec, std::optional<ttnn::TensorSpec>>;
+    struct tensor_return_value_t {
+        Tensor output_tokens;
+        Tensor output_metadata;
+        std::optional<Tensor> optional_untilized_intermediate;
+    };
 
-    using tensor_return_value_t = std::tuple<Tensor, Tensor, std::optional<Tensor>>;
+    struct spec_return_value_t{
+        ttnn::TensorSpec output_tokens_spec;
+        ttnn::TensorSpec metadata_spec;
+        std::optional<ttnn::TensorSpec> untilized_input_tensor;
+    };
 
     struct AllToAllDispatchSparse {
         // Shared variables are the variables that are shared between the create and override_runtime_arguments methods
@@ -89,7 +97,7 @@ struct AllToAllDispatchDeviceOperation {
             const ttnn::MeshCoordinateRangeSet& tensor_coords,
             const GlobalSemaphore& init_semaphore,
             const GlobalSemaphore& cross_device_semaphore,
-            const std::optional<GlobalSemaphore>& untilize_sync_semaphore);
+            const std::optional<GlobalSemaphore> & untilize_sync_semaphore);
 
         static void override_runtime_arguments(
             cached_mesh_workload_t& cached_program,

--- a/ttnn/cpp/ttnn/operations/ccl/all_to_all_dispatch/device/all_to_all_dispatch_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_to_all_dispatch/device/all_to_all_dispatch_device_operation.hpp
@@ -88,7 +88,8 @@ struct AllToAllDispatchDeviceOperation {
             tensor_return_value_t& tensor_return_value,
             const ttnn::MeshCoordinateRangeSet& tensor_coords,
             const GlobalSemaphore& init_semaphore,
-            const GlobalSemaphore& cross_device_semaphore);
+            const GlobalSemaphore& cross_device_semaphore,
+            const std::optional<GlobalSemaphore>& untilize_sync_semaphore);
 
         static void override_runtime_arguments(
             cached_mesh_workload_t& cached_program,

--- a/ttnn/cpp/ttnn/operations/ccl/all_to_all_dispatch/device/all_to_all_dispatch_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_to_all_dispatch/device/all_to_all_dispatch_program_factory.cpp
@@ -132,8 +132,8 @@ AllToAllDispatchDeviceOperation::AllToAllDispatchSparse::create_at(
     auto input_tensor = tensor_args.input_tensor;
     auto indices_tensor = tensor_args.expert_indices_tensor;
     auto mapping_tensor = tensor_args.expert_mapping_tensor;
-    const auto& output_tensor = tensor_return_value.at(0);
-    const auto& metadata_tensor = tensor_return_value.at(1);
+    const auto& output_tensor = std::get<0>(tensor_return_value);
+    const auto& metadata_tensor = std::get<1>(tensor_return_value);
     auto num_links = operation_attributes.num_links;
     auto topology = operation_attributes.topology;
 
@@ -483,8 +483,8 @@ void AllToAllDispatchDeviceOperation::AllToAllDispatchSparse::override_runtime_a
         const auto& binary_writer_kernel_id = shared_variables.binary_writer_kernel_id;
         const auto& cores = shared_variables.cores;
 
-        const auto& output_tensor = tensor_return_value.at(0);
-        const auto& metadata_tensor = tensor_return_value.at(1);
+        const auto& output_tensor = std::get<0>(tensor_return_value);
+        const auto& metadata_tensor = std::get<1>(tensor_return_value);
 
         for (const auto& core : cores) {
             auto& reader_runtime_args = tt::tt_metal::GetRuntimeArgs(program, ternary_reader_kernel_id, core);

--- a/ttnn/cpp/ttnn/operations/ccl/all_to_all_dispatch/device/kernels/dataflow/writer_all_to_all_dispatch.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_to_all_dispatch/device/kernels/dataflow/writer_all_to_all_dispatch.cpp
@@ -91,7 +91,9 @@ void kernel_main() {
     constexpr uint32_t write_page_by_page = get_compile_time_arg_val(35);
     constexpr uint32_t linearized_mesh_coord = get_compile_time_arg_val(36);
 
-    constexpr auto input_args = TensorAccessorArgs<37>();
+    // CT arg 37 is unused here
+
+    constexpr auto input_args = TensorAccessorArgs<38>();
     constexpr auto indices_args = TensorAccessorArgs<input_args.next_compile_time_args_offset()>();
     constexpr auto mapping_args = TensorAccessorArgs<indices_args.next_compile_time_args_offset()>();
     constexpr auto output_args = TensorAccessorArgs<mapping_args.next_compile_time_args_offset()>();

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/pack_untilize.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/pack_untilize.cpp
@@ -15,7 +15,13 @@ void MAIN {
 #else
     constexpr uint32_t max_bct = 8;
 #endif
+
+#ifndef VARIABLE_BLOCK_COUNT
     constexpr uint32_t per_core_block_cnt = get_compile_time_arg_val(0);
+#else
+    const auto per_core_block_cnt = get_arg_val<uint32_t>(0);
+#endif
+
     constexpr uint32_t per_core_block_tile_cnt = get_compile_time_arg_val(1);
     constexpr uint32_t src_cb_id = get_compile_time_arg_val(2);
     constexpr uint32_t out_cb_id = get_compile_time_arg_val(3);

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize.cpp
@@ -8,7 +8,11 @@
 
 namespace NAMESPACE {
 void MAIN {
+#ifndef VARIABLE_BLOCK_COUNT
     constexpr uint32_t per_core_block_cnt = get_compile_time_arg_val(0);
+#else
+    const auto per_core_block_cnt = get_arg_val<uint32_t>(0);
+#endif
     constexpr uint32_t per_core_block_tile_cnt = get_compile_time_arg_val(1);
     constexpr uint32_t src_cb_id = get_compile_time_arg_val(2);
     constexpr uint32_t out_cb_id = get_compile_time_arg_val(3);

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/dataflow/writer_unary_stick_layout_split_rows_interleaved_parallel_columns.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/dataflow/writer_unary_stick_layout_split_rows_interleaved_parallel_columns.cpp
@@ -72,6 +72,7 @@ void kernel_main() {
     uint64_t mcast_sync_semaphore_noc_addr =
         get_noc_multicast_addr(noc_start_x, noc_start_y, noc_end_x, noc_end_y, sync_semaphore_addr);
 
+    DPRINT << "sem wait val: " << start_stick_id << "\n";
     noc_semaphore_wait(sync_semaphore_ptr, start_stick_id);
     noc_semaphore_set(sync_semaphore_ptr, start_stick_id+num_sticks);
 

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/dataflow/writer_unary_stick_layout_split_rows_interleaved_parallel_columns.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/dataflow/writer_unary_stick_layout_split_rows_interleaved_parallel_columns.cpp
@@ -12,11 +12,12 @@ void kernel_main() {
 
     uint32_t arg_idx = 0;
     const uint32_t dst_addr = get_arg_val<uint32_t>(arg_idx++);
-    const uint32_t num_sticks = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t padded_num_sticks = get_arg_val<uint32_t>(arg_idx++);
     const uint32_t num_tiles_per_core = get_arg_val<uint32_t>(arg_idx++);
     const uint32_t tile_width_size = get_arg_val<uint32_t>(arg_idx++);
     const uint32_t start_stick_id = get_arg_val<uint32_t>(arg_idx++);
     uint32_t offset_within_stick = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t logical_num_sticks = get_arg_val<uint32_t>(arg_idx++);
 
     constexpr uint32_t stick_size = get_compile_time_arg_val(0);
 
@@ -26,33 +27,34 @@ void kernel_main() {
 
     uint64_t base_dst_noc_addr[tile_height];
 
-    auto write_tiles = [&](const uint32_t& num_tiles, const uint32_t& width_size, const uint32_t& stride_size) {
-        cb_wait_front(cb_id_out0, num_tiles);
+    auto write_tiles = [&](const uint32_t curr_tile_height, const uint32_t width_size, const uint32_t stride_size) {
+        cb_wait_front(cb_id_out0, 1);
         uint32_t l1_read_addr = get_read_ptr(cb_id_out0);
-        for (uint32_t k = 0; k < tile_height; k++) {
+        for (uint32_t k = 0; k < curr_tile_height; k++) {
             uint64_t dst_noc_addr = base_dst_noc_addr[k];
             noc_async_write(l1_read_addr, dst_noc_addr, width_size);
             l1_read_addr += width_size;
             base_dst_noc_addr[k] += width_size + stride_size;
         }
         noc_async_write_barrier();
-        cb_pop_front(cb_id_out0, num_tiles);
+        cb_pop_front(cb_id_out0, 1);
     };
 
     uint32_t stick_id = start_stick_id;
 
-    for (uint32_t i = 0; i < num_sticks / tile_height; i++) {
+    for (uint32_t i = 0; i < padded_num_sticks / tile_height; i++) {
         // may need an ifdef here if this kernel is used elsewhere.
+        uint32_t curr_tile_height = std::min(tile_height, logical_num_sticks - stick_id);
         uint32_t curr_offset = offset_within_stick;
         for (uint32_t tile_id = 0; tile_id < num_tiles_per_core; tile_id++) {
-            for (uint32_t j = 0; j < tile_height; j++) {
+            for (uint32_t j = 0; j < curr_tile_height; j++) {
                 base_dst_noc_addr[j] = get_noc_addr(j + stick_id, s, curr_offset);
             }
-            write_tiles(1, tile_width_size, stick_size - curr_offset - tile_width_size);
+            write_tiles(curr_tile_height, tile_width_size, stick_size - curr_offset - tile_width_size);
             curr_offset += tile_width_size;
         }
 
-        stick_id += tile_height;
+        stick_id += curr_tile_height;
     }
 
 #ifdef FUSED_OP_SYNC
@@ -61,8 +63,6 @@ void kernel_main() {
     constexpr uint32_t noc_end_x = get_compile_time_arg_val(num_ct_args + 2);
     constexpr uint32_t noc_end_y = get_compile_time_arg_val(num_ct_args + 3);
     constexpr uint32_t num_dests = get_compile_time_arg_val(num_ct_args + 4);
-    constexpr uint32_t total_col_tiles = get_compile_time_arg_val(num_ct_args + 5);
-    constexpr auto total_num_sticks = tile_height * total_col_tiles;
 
     if constexpr (num_dests == 0) {
         return;
@@ -74,13 +74,18 @@ void kernel_main() {
     uint64_t mcast_sync_semaphore_noc_addr =
         get_noc_multicast_addr(noc_start_x, noc_start_y, noc_end_x, noc_end_y, sync_semaphore_addr);
 
+    DPRINT << "sync sem: " << *sync_semaphore_ptr << " start_stick_id: " << start_stick_id
+           << " padded_num_sticks: " << padded_num_sticks << "\n";
     noc_semaphore_wait(sync_semaphore_ptr, start_stick_id);
-    noc_semaphore_set(sync_semaphore_ptr, start_stick_id+num_sticks);
+    noc_semaphore_set(sync_semaphore_ptr, stick_id);
 
     noc_semaphore_set_multicast(sync_semaphore_addr, mcast_sync_semaphore_noc_addr, num_dests);
+    noc_async_write_barrier();
 
     // clean up
-    noc_semaphore_wait(sync_semaphore_ptr, total_num_sticks);
+    DPRINT << "clean up sem: " << *sync_semaphore_ptr << " logical_num_sticks: " << logical_num_sticks << "\n";
+    noc_semaphore_wait(sync_semaphore_ptr, logical_num_sticks);
     noc_semaphore_set(sync_semaphore_ptr, 0u);
+    DPRINT << "DONE" << "\n";
 #endif
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/dataflow/writer_unary_stick_layout_split_rows_interleaved_parallel_columns.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/dataflow/writer_unary_stick_layout_split_rows_interleaved_parallel_columns.cpp
@@ -61,6 +61,8 @@ void kernel_main() {
     constexpr uint32_t noc_end_x = get_compile_time_arg_val(num_ct_args + 2);
     constexpr uint32_t noc_end_y = get_compile_time_arg_val(num_ct_args + 3);
     constexpr uint32_t num_dests = get_compile_time_arg_val(num_ct_args + 4);
+    constexpr uint32_t total_col_tiles = get_compile_time_arg_val(num_ct_args + 5);
+    constexpr auto total_num_sticks = tile_height * total_col_tiles;
 
     if constexpr (num_dests == 0) {
         return;
@@ -72,10 +74,13 @@ void kernel_main() {
     uint64_t mcast_sync_semaphore_noc_addr =
         get_noc_multicast_addr(noc_start_x, noc_start_y, noc_end_x, noc_end_y, sync_semaphore_addr);
 
-    DPRINT << "sem wait val: " << start_stick_id << "\n";
     noc_semaphore_wait(sync_semaphore_ptr, start_stick_id);
     noc_semaphore_set(sync_semaphore_ptr, start_stick_id+num_sticks);
 
-    noc_semaphore_set_multicast_loopback_src(sync_semaphore_addr, mcast_sync_semaphore_noc_addr, num_dests);
+    noc_semaphore_set_multicast(sync_semaphore_addr, mcast_sync_semaphore_noc_addr, num_dests);
+
+    // clean up
+    noc_semaphore_wait(sync_semaphore_ptr, total_num_sticks);
+    noc_semaphore_set(sync_semaphore_ptr, 0u);
 #endif
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_op.cpp
@@ -232,6 +232,15 @@ operation::ProgramWithCallbacks Untilize::create_program(
         return detail::untilize_single_core(
             input_tensor_a, output_tensor, this->use_pack_untilize, this->fp32_dest_acc_en);
     }
+    if (this->sub_core_grids.has_value() && this->_internal_row_wise) {
+        // implementation for op fusing. Exposed here for testing.
+        return detail::untilize_row_wise_fuseable(
+            input_tensor_a,
+            output_tensor,
+            this->use_pack_untilize,
+            this->fp32_dest_acc_en,
+            this->sub_core_grids.value());
+    }
     if (this->sub_core_grids.has_value()) {
         // If sub_core_grids parameter is provided, use custom sub_core_grid implementation instead
         // of the standard multicore implementation or the block multicore implementation.

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_op.cpp
@@ -239,6 +239,8 @@ operation::ProgramWithCallbacks Untilize::create_program(
             output_tensor,
             this->use_pack_untilize,
             this->fp32_dest_acc_en,
+            this->sub_core_grids.value(),
+            this->_internal_semaphore,
             this->sub_core_grids.value());
     }
     if (this->sub_core_grids.has_value()) {

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_op.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_op.hpp
@@ -29,8 +29,7 @@ struct Untilize {
     const bool enough_space_height;
     const uint32_t pf_type;
     const bool _internal_row_wise;
-    const std::optional<ttnn::GlobalSemaphore> _internal_semaphore;
-    
+    const std::optional<tt::tt_metal::GlobalSemaphore> _internal_semaphore;
 
     void validate(const std::vector<Tensor>& input_tensors) const;
     std::vector<ttnn::TensorSpec> compute_output_specs(const std::vector<Tensor>& input_tensors) const;
@@ -41,5 +40,4 @@ struct Untilize {
         const std::vector<std::optional<const Tensor>>& optional_input_tensors,
         std::vector<Tensor>& output_tensors) const;
 };
-
 }  // namespace ttnn::operations::data_movement

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_op.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_op.hpp
@@ -29,6 +29,8 @@ struct Untilize {
     const bool enough_space_height;
     const uint32_t pf_type;
     const bool _internal_row_wise;
+    const std::optional<ttnn::GlobalSemaphore> _internal_semaphore;
+    
 
     void validate(const std::vector<Tensor>& input_tensors) const;
     std::vector<ttnn::TensorSpec> compute_output_specs(const std::vector<Tensor>& input_tensors) const;

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_op.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_op.hpp
@@ -28,6 +28,7 @@ struct Untilize {
     const bool enough_space_width;
     const bool enough_space_height;
     const uint32_t pf_type;
+    const bool _internal_row_wise;
 
     void validate(const std::vector<Tensor>& input_tensors) const;
     std::vector<ttnn::TensorSpec> compute_output_specs(const std::vector<Tensor>& input_tensors) const;

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_program_factory.hpp
@@ -24,4 +24,12 @@ tt::tt_metal::operation::ProgramWithCallbacks untilize_multi_core(
 tt::tt_metal::operation::ProgramWithCallbacks untilize_single_core(
     const Tensor& a, Tensor& output, bool use_pack_untilize, bool fp32_dest_acc_en);
 
+operation::ProgramWithCallbacks untilize_row_wise_fuseable(
+    const Tensor& input_tensor,
+    Tensor& output_tensor,
+    bool use_pack_untilize,
+    bool fp32_dest_acc_en,
+    const CoreRangeSet& sub_core_grids,
+    uint32_t max_tiles_per_block = 1);
+
 }  // namespace ttnn::operations::data_movement::detail

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_program_factory.hpp
@@ -7,7 +7,8 @@
 #include "ttnn/operation.hpp"
 #include "untilize_op.hpp"
 
-namespace ttnn::operations::data_movement::detail {
+namespace ttnn::operations::data_movement {
+namespace detail {
 
 tt::tt_metal::operation::ProgramWithCallbacks untilize_multi_core_sub_core_grids(
     const Tensor& a, Tensor& output, bool use_pack_untilize, bool fp32_dest_acc_en, const CoreRangeSet& sub_core_grids);
@@ -24,14 +25,27 @@ tt::tt_metal::operation::ProgramWithCallbacks untilize_multi_core(
 tt::tt_metal::operation::ProgramWithCallbacks untilize_single_core(
     const Tensor& a, Tensor& output, bool use_pack_untilize, bool fp32_dest_acc_en);
 
-operation::ProgramWithCallbacks untilize_row_wise_fuseable(
+tt::tt_metal::operation::ProgramWithCallbacks untilize_row_wise_fuseable(
     const Tensor& input_tensor,
-    Tensor& output_tensor,
+    const Tensor& output_tensor,
     bool use_pack_untilize,
     bool fp32_dest_acc_en,
     const CoreRangeSet& sub_core_grids,
     const std::optional<GlobalSemaphore>& _internal_semaphore,
     const std::optional<CoreRangeSet>& sync_core_grids,
-    uint32_t max_tiles_per_block=1);
-    
-}  // namespace ttnn::operations::data_movement::detail
+    uint32_t max_tiles_per_block = 1);
+}  // namespace detail
+
+namespace untilize {
+tt::tt_metal::operation::ProgramWithCallbacks untilize_row_wise_fuseable(
+    tt::tt_metal::Program& program,
+    const Tensor& input_tensor,
+    const Tensor& output_tensor,
+    bool use_pack_untilize,
+    bool fp32_dest_acc_en,
+    const CoreRangeSet& sub_core_grids,
+    const std::optional<GlobalSemaphore>& _internal_semaphore,
+    const std::optional<CoreRangeSet>& sync_core_grids,
+    uint32_t max_tiles_per_block = 1);
+}  // namespace untilize
+}  // namespace ttnn::operations::data_movement

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_program_factory.hpp
@@ -37,7 +37,11 @@ tt::tt_metal::operation::ProgramWithCallbacks untilize_row_wise_fuseable(
 }  // namespace detail
 
 namespace untilize {
-tt::tt_metal::operation::ProgramWithCallbacks untilize_row_wise_fuseable(
+
+using FuseableUntilizeCallback =
+    std::function<void(const std::optional<GlobalSemaphore>&, Program&, const Tensor&, const Tensor&)>;
+
+FuseableUntilizeCallback untilize_row_wise_fuseable(
     tt::tt_metal::Program& program,
     const Tensor& input_tensor,
     const Tensor& output_tensor,

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_program_factory.hpp
@@ -31,15 +31,15 @@ tt::tt_metal::operation::ProgramWithCallbacks untilize_row_wise_fuseable(
     bool use_pack_untilize,
     bool fp32_dest_acc_en,
     const CoreRangeSet& sub_core_grids,
-    const std::optional<GlobalSemaphore>& _internal_semaphore,
+    const std::optional<tt::tt_metal::GlobalSemaphore>& _internal_semaphore,
     const std::optional<CoreRangeSet>& sync_core_grids,
     uint32_t max_tiles_per_block = 1);
 }  // namespace detail
 
 namespace untilize {
 
-using FuseableUntilizeCallback =
-    std::function<void(const std::optional<GlobalSemaphore>&, Program&, const Tensor&, const Tensor&)>;
+using FuseableUntilizeCallback = std::function<void(
+    const std::optional<tt::tt_metal::GlobalSemaphore>&, tt::tt_metal::Program&, const Tensor&, const Tensor&)>;
 
 FuseableUntilizeCallback untilize_row_wise_fuseable(
     tt::tt_metal::Program& program,
@@ -48,7 +48,7 @@ FuseableUntilizeCallback untilize_row_wise_fuseable(
     bool use_pack_untilize,
     bool fp32_dest_acc_en,
     const CoreRangeSet& sub_core_grids,
-    const std::optional<GlobalSemaphore>& _internal_semaphore,
+    const std::optional<tt::tt_metal::GlobalSemaphore>& _internal_semaphore,
     const std::optional<CoreRangeSet>& sync_core_grids,
     uint32_t max_tiles_per_block = 1);
 }  // namespace untilize

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_program_factory.hpp
@@ -30,6 +30,8 @@ operation::ProgramWithCallbacks untilize_row_wise_fuseable(
     bool use_pack_untilize,
     bool fp32_dest_acc_en,
     const CoreRangeSet& sub_core_grids,
-    uint32_t max_tiles_per_block = 1);
-
+    const std::optional<GlobalSemaphore>& _internal_semaphore,
+    const std::optional<CoreRangeSet>& sync_core_grids,
+    uint32_t max_tiles_per_block=1);
+    
 }  // namespace ttnn::operations::data_movement::detail

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/untilize.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/untilize.cpp
@@ -40,7 +40,8 @@ ttnn::Tensor ExecuteUntilize::invoke(
     bool use_multicore,
     bool use_pack_untilize,
     const std::optional<CoreRangeSet>& sub_core_grids,
-    const bool _internal_row_wise) {
+    const bool _internal_row_wise,
+    const std::optional<GlobalSemaphore> & _internal_semaphore) {
     bool fp32_dest_acc_en =
         input_tensor.dtype() ==
         DataType::UINT32;  // MT: Currently only uint32 is moved to DST directly, fp32 is converted to fp16b
@@ -70,7 +71,8 @@ ttnn::Tensor ExecuteUntilize::invoke(
                 ttnn::operations::data_movement::get_pf_type(
                     memory_config.has_value() ? memory_config.value().is_sharded() : input_tensor.is_sharded(),
                     input_tensor),
-                _internal_row_wise},
+                _internal_row_wise,
+                _internal_semaphore},
             {input_tensor},
             {},
             {})[0];

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/untilize.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/untilize.cpp
@@ -39,7 +39,8 @@ ttnn::Tensor ExecuteUntilize::invoke(
     const std::optional<MemoryConfig>& memory_config,
     bool use_multicore,
     bool use_pack_untilize,
-    const std::optional<CoreRangeSet>& sub_core_grids) {
+    const std::optional<CoreRangeSet>& sub_core_grids,
+    const bool _internal_row_wise) {
     bool fp32_dest_acc_en =
         input_tensor.dtype() ==
         DataType::UINT32;  // MT: Currently only uint32 is moved to DST directly, fp32 is converted to fp16b
@@ -68,7 +69,8 @@ ttnn::Tensor ExecuteUntilize::invoke(
                 enough_space_height,
                 ttnn::operations::data_movement::get_pf_type(
                     memory_config.has_value() ? memory_config.value().is_sharded() : input_tensor.is_sharded(),
-                    input_tensor)},
+                    input_tensor),
+                _internal_row_wise},
             {input_tensor},
             {},
             {})[0];

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/untilize.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/untilize.hpp
@@ -16,7 +16,8 @@ struct ExecuteUntilize {
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         bool use_multicore = true,
         bool use_pack_untilize = true,
-        const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
+        const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt,
+        bool _internal_row_wise = false);
 };
 
 }  // namespace operations::data_movement

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/untilize.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/untilize.hpp
@@ -17,7 +17,8 @@ struct ExecuteUntilize {
         bool use_multicore = true,
         bool use_pack_untilize = true,
         const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt,
-        bool _internal_row_wise = false);
+        bool _internal_row_wise = false,
+        const std::optional<GlobalSemaphore> & _internal_semaphore = std::nullopt);
 };
 
 }  // namespace operations::data_movement

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/untilize.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/untilize.hpp
@@ -6,6 +6,7 @@
 
 #include <optional>
 #include "ttnn/decorators.hpp"
+#include "ttnn/global_semaphore.hpp"
 
 namespace ttnn {
 namespace operations::data_movement {

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/untilize_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/untilize_pybind.cpp
@@ -47,14 +47,17 @@ void bind_untilize(py::module& module) {
                const std::optional<MemoryConfig>& memory_config,
                bool use_multicore,
                bool use_pack_untilize,
-               const std::optional<CoreRangeSet>&& sub_core_grids) {
-                return self(input_tensor, memory_config, use_multicore, use_pack_untilize, sub_core_grids);
+               const std::optional<CoreRangeSet>&& sub_core_grids,
+               const bool _internal_row_wise) {
+                return self(
+                    input_tensor, memory_config, use_multicore, use_pack_untilize, sub_core_grids, _internal_row_wise);
             },
             py::arg("input_tensor"),
             py::kw_only(),
             py::arg("memory_config") = std::nullopt,
             py::arg("use_multicore") = true,
             py::arg("use_pack_untilize") = true,
-            py::arg("sub_core_grids") = std::nullopt});
+            py::arg("sub_core_grids") = std::nullopt,
+            py::arg("_internal_row_wise") = false});
 }
 }  // namespace ttnn::operations::data_movement::detail

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/untilize_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/untilize_pybind.cpp
@@ -49,7 +49,7 @@ void bind_untilize(py::module& module) {
                bool use_pack_untilize,
                const std::optional<CoreRangeSet>& sub_core_grids,
                const bool _internal_row_wise,
-               const std::optional<ttnn::GlobalSemaphore> & _internal_semaphore) {
+               const std::optional<ttnn::GlobalSemaphore>& _internal_semaphore) {
                 return self(input_tensor, memory_config, use_multicore, use_pack_untilize, sub_core_grids, _internal_row_wise,_internal_semaphore);
             },
             py::arg("input_tensor"),
@@ -58,7 +58,7 @@ void bind_untilize(py::module& module) {
             py::arg("use_multicore") = true,
             py::arg("use_pack_untilize") = true,
             py::arg("sub_core_grids") = std::nullopt,
-            py::arg("_internal_row_wise")=false,
-            py::arg("_internal_semaphore")=std::nullopt});
+            py::arg("_internal_row_wise") = false,
+            py::arg("_internal_semaphore") = std::nullopt});
 }
 }  // namespace ttnn::operations::data_movement::detail

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/untilize_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/untilize_pybind.cpp
@@ -47,10 +47,10 @@ void bind_untilize(py::module& module) {
                const std::optional<MemoryConfig>& memory_config,
                bool use_multicore,
                bool use_pack_untilize,
-               const std::optional<CoreRangeSet>&& sub_core_grids,
-               const bool _internal_row_wise) {
-                return self(
-                    input_tensor, memory_config, use_multicore, use_pack_untilize, sub_core_grids, _internal_row_wise);
+               const std::optional<CoreRangeSet>& sub_core_grids,
+               const bool _internal_row_wise,
+               const std::optional<ttnn::GlobalSemaphore> & _internal_semaphore) {
+                return self(input_tensor, memory_config, use_multicore, use_pack_untilize, sub_core_grids, _internal_row_wise,_internal_semaphore);
             },
             py::arg("input_tensor"),
             py::kw_only(),
@@ -58,6 +58,7 @@ void bind_untilize(py::module& module) {
             py::arg("use_multicore") = true,
             py::arg("use_pack_untilize") = true,
             py::arg("sub_core_grids") = std::nullopt,
-            py::arg("_internal_row_wise") = false});
+            py::arg("_internal_row_wise")=false,
+            py::arg("_internal_semaphore")=std::nullopt});
 }
 }  // namespace ttnn::operations::data_movement::detail


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/33855

### Problem description
A2A Dispatch works internally in row major but consumes tiled inputs. Fuse an untilize op to transparently do the conversion.

### What's changed
- Build a simplified untilize op where cores operate on whole rows, but without needing to load the whole row into L1. This is to simplify signaling for fusion. It's less efficient than other algorithms but should be sufficient for this. Also add some semaphores to this op to signal when a set of pages, and those preceding it, is ready.
- Fuse this untilize op into A2A dispatch. The reader waits for a semaphore signal from the untilize that indicates its pages are available.


### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] T3000 nightly tests https://github.com/tenstorrent/tt-metal/actions/runs/19974414705
- [ ] New/Existing tests provide coverage for changes