### PR TITLE
Decouple SDXL and SD 1.4 device perf tests

### DIFF
--- a/.github/workflows/perf-device-models-impl.yaml
+++ b/.github/workflows/perf-device-models-impl.yaml
@@ -186,13 +186,21 @@ jobs:
         if: ${{ !cancelled() && !matrix.test-info.civ2-compatible && fromJSON(needs.define-models.outputs.models-to-run)['non-civ2'] }}
         timeout-minutes: ${{ matrix.test-info.timeout }}
 
-      - name: stable_diffusion tests
+      - name: stable_diffusion_xl tests
         uses: tenstorrent/tt-metal/.github/actions/single-card-perf-test@main
         with:
-          device_perf_model_name: "stable_diffusion"
+          device_perf_model_name: "stable_diffusion_xl"
+          commands: |
+            ${{ matrix.test-info.arch == 'wormhole_b0' && 'pytest models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py -m models_device_performance_bare_metal' || '' }}
+        if: ${{ !cancelled() && matrix.test-info.civ2-compatible && (matrix.test-info.job-set1 || matrix.test-info.job-blackhole-set1) && fromJSON(needs.define-models.outputs.models-to-run)['stable-diffusion'] }}
+        timeout-minutes: ${{ matrix.test-info.timeout }}
+
+      - name: stable_diffusion_1_4 tests
+        uses: tenstorrent/tt-metal/.github/actions/single-card-perf-test@main
+        with:
+          device_perf_model_name: "stable_diffusion_1_4"
           commands: |
             pytest models/demos/${{ matrix.test-info.arch == 'blackhole' && 'blackhole' || 'wormhole' }}/stable_diffusion/tests -m models_device_performance_bare_metal --timeout=600
-            ${{ matrix.test-info.arch == 'wormhole_b0' && 'pytest models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py -m models_device_performance_bare_metal' || '' }}
         if: ${{ !cancelled() && matrix.test-info.civ2-compatible && (matrix.test-info.job-set1 || matrix.test-info.job-blackhole-set1) && fromJSON(needs.define-models.outputs.models-to-run)['stable-diffusion'] }}
         timeout-minutes: ${{ matrix.test-info.timeout }}
 

--- a/.github/workflows/perf-device-models-impl.yaml
+++ b/.github/workflows/perf-device-models-impl.yaml
@@ -40,7 +40,8 @@ jobs:
 
           # Initialize models JSON with all false
           models_json='{
-            "stable-diffusion": false,
+            "stable-diffusion-xl": false,
+            "stable-diffusion-1-4": false,
             "distilbert": false,
             "vgg": false,
             "vgg-unet": false,
@@ -102,9 +103,9 @@ jobs:
           # Define which models belong to each matrix group
           group_models='{
             "N300 WH B0 not yet ported": ["non-civ2"],
-            "N300 WH B0 Set 1": ["stable-diffusion", "distilbert", "vgg", "bert-tiny", "squeezebert", "vgg-unet", "resnet50", "ufld-v2", "sentence-bert", "functional-unet", "vit"],
+            "N300 WH B0 Set 1": ["stable-diffusion-xl", "stable-diffusion-1-4", "distilbert", "vgg", "bert-tiny", "squeezebert", "vgg-unet", "resnet50", "ufld-v2", "sentence-bert", "functional-unet", "vit"],
             "N300 WH B0 Set 2": ["mamba", "metal-bert-large-11", "mobilenetv2", "vanilla-unet", "swin-v2", "swin-s", "vovnet", "efficientnetb0"],
-            "P150 BH": ["stable-diffusion", "vgg-unet", "resnet50", "ufld-v2", "sentence-bert", "functional-unet", "vit", "oft", "panoptic-deeplab"]
+            "P150 BH": ["stable-diffusion-1-4", "vgg-unet", "resnet50", "ufld-v2", "sentence-bert", "functional-unet", "vit", "oft", "panoptic-deeplab"]
           }'
 
           # Original matrix definition
@@ -192,7 +193,7 @@ jobs:
           device_perf_model_name: "stable_diffusion_xl"
           commands: |
             ${{ matrix.test-info.arch == 'wormhole_b0' && 'pytest models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py -m models_device_performance_bare_metal' || '' }}
-        if: ${{ !cancelled() && matrix.test-info.civ2-compatible && (matrix.test-info.job-set1 || matrix.test-info.job-blackhole-set1) && fromJSON(needs.define-models.outputs.models-to-run)['stable-diffusion'] }}
+        if: ${{ !cancelled() && matrix.test-info.civ2-compatible && (matrix.test-info.job-set1 || matrix.test-info.job-blackhole-set1) && fromJSON(needs.define-models.outputs.models-to-run)['stable-diffusion-xl'] }}
         timeout-minutes: ${{ matrix.test-info.timeout }}
 
       - name: stable_diffusion_1_4 tests
@@ -201,7 +202,7 @@ jobs:
           device_perf_model_name: "stable_diffusion_1_4"
           commands: |
             pytest models/demos/${{ matrix.test-info.arch == 'blackhole' && 'blackhole' || 'wormhole' }}/stable_diffusion/tests -m models_device_performance_bare_metal --timeout=600
-        if: ${{ !cancelled() && matrix.test-info.civ2-compatible && (matrix.test-info.job-set1 || matrix.test-info.job-blackhole-set1) && fromJSON(needs.define-models.outputs.models-to-run)['stable-diffusion'] }}
+        if: ${{ !cancelled() && matrix.test-info.civ2-compatible && (matrix.test-info.job-set1 || matrix.test-info.job-blackhole-set1) && fromJSON(needs.define-models.outputs.models-to-run)['stable-diffusion-1-4'] }}
         timeout-minutes: ${{ matrix.test-info.timeout }}
 
       - name: distilbert tests


### PR DESCRIPTION
### Problem description
SDXL and SD 1.4 perf tests are coupled together within `stable_diffusion tests` step of the `N300 WH B0 Set 1 device perf` job in `(Single-card) Device perf regressions`.

This leads to confusion as the mentioned models are not the same, they have different implementations and are owned by separate teams. In addition to this SDXL is a model in production and needs to be closely monitored in the CI. This proves difficult if its counterpart (tested before it in the CI) fails and the test set errors out before testing the second model.

### What's changed
Tests for the mentioned models are split into separate steps in the job.

### Checklist
- [x] [(Single-card) Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/runs/19886404904/job/56994919440) CI passes