### PR TITLE
[skip ci] Modify stable_diffusion vae expected perf

### DIFF
--- a/models/demos/wormhole/stable_diffusion/tests/test_perf.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_perf.py
@@ -450,7 +450,7 @@ def test_stable_diffusion_device_perf(expected_kernel_samples_per_second):
 @pytest.mark.models_device_performance_bare_metal
 @pytest.mark.parametrize(
     "expected_kernel_samples_per_second",
-    ((3.10) if is_wormhole_b0() else (4.10),),
+    ((2.95) if is_wormhole_b0() else (4.10),),
 )
 def test_stable_diffusion_vae_device_perf(expected_kernel_samples_per_second):
     subdir = "ttnn_stable_diffusion_vae"


### PR DESCRIPTION
### Problem description
In PR https://github.com/tenstorrent/tt-metal/pull/33559 expected device perf was changed to `3.1` 
samples/s which fits local runs, but values on CI are `2.865 - 2.896` So CI fails.
https://github.com/tenstorrent/tt-metal/actions/runs/19858264630/job/56902313911#step:6:838
https://github.com/tenstorrent/tt-metal/actions/runs/19867102855/job/56933512301#step:6:839
https://github.com/tenstorrent/tt-metal/actions/runs/19871998402/job/56950887922#step:6:839
https://github.com/tenstorrent/tt-metal/actions/runs/19876462618/job/56967251805#step:6:844
https://github.com/tenstorrent/tt-metal/actions/runs/19880474030/job/56977388244#step:6:844

### What's changed
- change stable_diffusion expected perf value to be `2.95` with margin of `7%` which fits all of the examples

### Checklist
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/19888378115)