### PR TITLE
improve PCC of `ttnn.experimental.intimg` on client's architecture

### DIFF
--- a/tests/ttnn/unit_tests/operations/reduce/test_intimg.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_intimg.py
@@ -29,9 +29,10 @@ def ttnn_integral_image_channel_last(features_nhwc):
         # fmt: off
         ([1, 12, 40, 256]),
         ([1, 24, 80, 256]),
-        ([1, 48, 160, 256])
+        ([1, 48, 160, 256]),
+        ([1, 96, 160, 256])
     ],
-    ids=["OFT32", "OFT16", "OFT8"],
+    ids=["OFT32", "OFT16", "OFT8", "big_one"],
 )
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32], ids=["bfloat16", "float32"])
 @pytest.mark.parametrize("memory_config", [ttnn.DRAM_MEMORY_CONFIG], ids=["DRAM"])
@@ -51,7 +52,7 @@ def test_cumsum_channel_last(device, input_shape_nhwc, dtype, memory_config):
     )
     output_tensor = ttnn_integral_image_cumsum_channel_last(input_tensor)
     ttnn_output_tensor = ttnn.to_torch(output_tensor)
-    assert_with_pcc(torch_output_tensor, ttnn_output_tensor, pcc=0.999)
+    assert_with_pcc(torch_output_tensor, ttnn_output_tensor, pcc=0.998)
 
     # experimental intimg
     input_tensor = ttnn.from_torch(
@@ -59,4 +60,4 @@ def test_cumsum_channel_last(device, input_shape_nhwc, dtype, memory_config):
     )
     output_tensor_2 = ttnn_integral_image_channel_last(input_tensor)
     ttnn_output_tensor_2 = ttnn.to_torch(output_tensor_2)
-    assert_with_pcc(torch_output_tensor, ttnn_output_tensor_2, pcc=0.999)
+    assert_with_pcc(torch_output_tensor, ttnn_output_tensor_2, pcc=0.998)

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/integral_image/device/intimg_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/integral_image/device/intimg_program_factory.cpp
@@ -92,17 +92,22 @@ IntImgProgramFactory::cached_program_t IntImgProgramFactory::create(
 
     const auto tile_spec = input_tensor.tensor_spec().tile();
 
-    const uint32_t tiles_num_per_cb = 48;
+    const uint32_t tiles_num_per_full_block_depth_cb = BLOCK_DEPTH;
+    const uint32_t tiles_num_per_small_cb = 2;
     const auto core_range_set = CoreRangeSet{{{0, 0}, {CORES_X - 1, CORES_Y - 1}}};
-    create_cb(program, input_tensor.dtype(), IntImgCB::START, core_range_set, 4);
-    create_cb(program, input_tensor.dtype(), IntImgCB::INPUT, core_range_set, tiles_num_per_cb);
-    create_cb(program, input_tensor.dtype(), IntImgCB::ACC, core_range_set, tiles_num_per_cb);
-    create_cb(program, input_tensor.dtype(), IntImgCB::CUMSUM_STAGE_0, core_range_set, tiles_num_per_cb);
-    create_cb(program, input_tensor.dtype(), IntImgCB::CUMSUM_STAGE_1, core_range_set, tiles_num_per_cb);
-    create_cb(program, input_tensor.dtype(), IntImgCB::CUMSUM_STAGE_2, core_range_set, tiles_num_per_cb);
-    create_cb(program, input_tensor.dtype(), IntImgCB::OUTPUT, core_range_set, tiles_num_per_cb);
-    create_cb(program, input_tensor.dtype(), IntImgCB::AXIS_2_BUFFER, core_range_set, 4);
-    create_cb(program, input_tensor.dtype(), IntImgCB::AXIS_3_BUFFER, core_range_set, tiles_num_per_cb);
+    create_cb(program, input_tensor.dtype(), IntImgCB::START, core_range_set, tiles_num_per_small_cb);
+    create_cb(program, input_tensor.dtype(), IntImgCB::INPUT, core_range_set, tiles_num_per_full_block_depth_cb);
+    create_cb(program, input_tensor.dtype(), IntImgCB::ACC, core_range_set, tiles_num_per_small_cb);
+    create_cb(
+        program, input_tensor.dtype(), IntImgCB::CUMSUM_STAGE_0, core_range_set, tiles_num_per_full_block_depth_cb);
+    create_cb(
+        program, input_tensor.dtype(), IntImgCB::CUMSUM_STAGE_1, core_range_set, tiles_num_per_full_block_depth_cb);
+    create_cb(
+        program, input_tensor.dtype(), IntImgCB::CUMSUM_STAGE_2, core_range_set, tiles_num_per_full_block_depth_cb);
+    create_cb(program, input_tensor.dtype(), IntImgCB::OUTPUT, core_range_set, tiles_num_per_full_block_depth_cb);
+    create_cb(program, input_tensor.dtype(), IntImgCB::AXIS_2_BUFFER, core_range_set, tiles_num_per_small_cb);
+    create_cb(
+        program, input_tensor.dtype(), IntImgCB::AXIS_3_BUFFER, core_range_set, tiles_num_per_full_block_depth_cb);
     // create_cb(program, input_tensor.dtype(), IntImgCB::AXIS_3_BUFFER_1, core_range_set, tiles_num_per_cb);
 
     std::vector<uint32_t> compute_compile_time_args{

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/integral_image/device/intimg_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/integral_image/device/intimg_program_factory.cpp
@@ -78,7 +78,7 @@ IntImgProgramFactory::cached_program_t IntImgProgramFactory::create(
     auto& output_tensor{tensor_return_value};
     const auto& input_shape{input_tensor.padded_shape()};
 
-    constexpr uint32_t BLOCK_DEPTH = 32;
+    constexpr uint32_t BLOCK_DEPTH = 48;
 
     Program program{};
 
@@ -92,18 +92,16 @@ IntImgProgramFactory::cached_program_t IntImgProgramFactory::create(
 
     const auto tile_spec = input_tensor.tensor_spec().tile();
 
-    // if input dtype is 16bit, use 48 tiles per cb to preload tiles
-    // if 32bit, there's enough space for as may as 32 tiles per cb that the kernels expect as the minimum
-    const uint32_t tiles_num_per_cb = (dst_cb_data_format == DataFormat::Float32) ? 32 : 48;
+    const uint32_t tiles_num_per_cb = 48;
     const auto core_range_set = CoreRangeSet{{{0, 0}, {CORES_X - 1, CORES_Y - 1}}};
-    create_cb(program, input_tensor.dtype(), IntImgCB::START, core_range_set, tiles_num_per_cb);
+    create_cb(program, input_tensor.dtype(), IntImgCB::START, core_range_set, 4);
     create_cb(program, input_tensor.dtype(), IntImgCB::INPUT, core_range_set, tiles_num_per_cb);
     create_cb(program, input_tensor.dtype(), IntImgCB::ACC, core_range_set, tiles_num_per_cb);
     create_cb(program, input_tensor.dtype(), IntImgCB::CUMSUM_STAGE_0, core_range_set, tiles_num_per_cb);
     create_cb(program, input_tensor.dtype(), IntImgCB::CUMSUM_STAGE_1, core_range_set, tiles_num_per_cb);
     create_cb(program, input_tensor.dtype(), IntImgCB::CUMSUM_STAGE_2, core_range_set, tiles_num_per_cb);
     create_cb(program, input_tensor.dtype(), IntImgCB::OUTPUT, core_range_set, tiles_num_per_cb);
-    create_cb(program, input_tensor.dtype(), IntImgCB::AXIS_2_BUFFER, core_range_set, tiles_num_per_cb);
+    create_cb(program, input_tensor.dtype(), IntImgCB::AXIS_2_BUFFER, core_range_set, 4);
     create_cb(program, input_tensor.dtype(), IntImgCB::AXIS_3_BUFFER, core_range_set, tiles_num_per_cb);
     // create_cb(program, input_tensor.dtype(), IntImgCB::AXIS_3_BUFFER_1, core_range_set, tiles_num_per_cb);
 

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/integral_image/device/kernels/common.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/integral_image/device/kernels/common.hpp
@@ -152,6 +152,6 @@ FORCE_INLINE uint32_t get_tile_id(
     return tile_id;
 }
 
-FORCE_INLINE constexpr uint32_t block_depth_ceil(uint32_t value, uint32_t block_depth = 32) {
+FORCE_INLINE constexpr uint32_t ceil(uint32_t value, uint32_t block_depth) {
     return (value + block_depth - 1) / block_depth;
 }

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/integral_image/device/kernels/intimg_compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/integral_image/device/kernels/intimg_compute.cpp
@@ -79,7 +79,7 @@ FORCE_INLINE void cumsum_cube_axis_2(
     uint32_t cb_cumsum_stage_0,
     uint32_t cb_axis_2_buffer,
     bool save_last_tile,
-    uint32_t block_depth = 32) {
+    uint32_t block_depth) {
     ReadCBGuard start_cb_read_guard{cb_start, ONE_TILE};
 
     bool enable_reload = false;
@@ -135,8 +135,7 @@ FORCE_INLINE void cumsum_cube_axis_2(
     cb_pop_front(cb_acc, ONE_TILE);
 }
 
-FORCE_INLINE void cumsum_cube_axis_3(
-    uint32_t cb_cumsum_stage_wip, uint32_t cb_cumsum_output, uint32_t block_depth = 32) {
+FORCE_INLINE void cumsum_cube_axis_3(uint32_t cb_cumsum_stage_wip, uint32_t cb_cumsum_output, uint32_t block_depth) {
     for (uint32_t tile_i = 0; tile_i < block_depth; ++tile_i) {
         ReadCBGuard read_cumsum_guard{cb_cumsum_stage_wip, ONE_TILE};
         WriteCBGuard cumsum_output_write_guard{cb_cumsum_output, ONE_TILE};
@@ -162,7 +161,7 @@ FORCE_INLINE void propagate_tile_into_cube(
     uint32_t cb_cumsum_stage_a,
     uint32_t cb_cumsum_stage_b,
     bool save_last_tile,
-    uint32_t block_depth = 32) {
+    uint32_t block_depth) {
     cb_wait_front(cb_axis_2_buffer, ONE_TILE);
     for (uint32_t tile_i = 0; tile_i < block_depth; ++tile_i) {
         ReadCBGuard cb_cumsum_stage_0_guard{cb_cumsum_stage_a, ONE_TILE};
@@ -193,7 +192,7 @@ FORCE_INLINE void propagate_tile_into_cube(
 }
 
 FORCE_INLINE void get_and_propagate_adder_cube(
-    uint32_t cb_cumsum_stage_X, uint32_t cb_axis_3_buffer_read, uint32_t cb_output, uint32_t block_depth = 32) {
+    uint32_t cb_cumsum_stage_X, uint32_t cb_axis_3_buffer_read, uint32_t cb_output, uint32_t block_depth) {
     // there is the necessity to receive a block
 
     for (uint32_t tile_i = 0; tile_i < block_depth; ++tile_i) {
@@ -271,8 +270,8 @@ namespace NAMESPACE {
 void MAIN {
     constexpr auto ctas{get_ctas()};
 
-    constexpr uint32_t num_blocks_in_row = block_depth_ceil(ctas.input_depth, ctas.block_depth);
-    constexpr uint32_t num_blocks_in_column = block_depth_ceil(ctas.input_height, 32);
+    constexpr uint32_t num_blocks_in_row = ceil(ctas.input_depth, ctas.block_depth);
+    constexpr uint32_t num_blocks_in_column = ceil(ctas.input_height, ctas.tile_height);
 
     for (uint32_t rows_block_i = 0; rows_block_i < num_blocks_in_column; ++rows_block_i) {
         perform_intimg_along_row_chunk(ctas, num_blocks_in_row, rows_block_i);

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/integral_image/device/kernels/intimg_compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/integral_image/device/kernels/intimg_compute.cpp
@@ -272,7 +272,7 @@ void MAIN {
     constexpr auto ctas{get_ctas()};
 
     constexpr uint32_t num_blocks_in_row = block_depth_ceil(ctas.input_depth, ctas.block_depth);
-    constexpr uint32_t num_blocks_in_column = block_depth_ceil(ctas.input_height, ctas.block_depth);
+    constexpr uint32_t num_blocks_in_column = block_depth_ceil(ctas.input_height, 32);
 
     for (uint32_t rows_block_i = 0; rows_block_i < num_blocks_in_column; ++rows_block_i) {
         perform_intimg_along_row_chunk(ctas, num_blocks_in_row, rows_block_i);

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/integral_image/device/kernels/intimg_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/integral_image/device/kernels/intimg_reader.cpp
@@ -57,9 +57,9 @@ void kernel_main() {
     constexpr auto ctas = get_ctas();
     using input_number_type = std_type_t<get_dataformat(ctas.input_cb)>;
     const auto input_addr_gtor = TensorAccessor(ctas.input_args, input_base_addr, get_tile_size(ctas.input_cb));
-    constexpr uint32_t num_slices_along_channels = block_depth_ceil(ctas.num_channels, ctas.block_depth);
+    constexpr uint32_t num_slices_along_channels = block_depth_ceil(ctas.num_channels, 32);
     constexpr uint32_t num_blocks_in_row = block_depth_ceil(ctas.input_depth, ctas.block_depth);
-    constexpr uint32_t num_blocks_in_column = block_depth_ceil(ctas.input_height, ctas.block_depth);
+    constexpr uint32_t num_blocks_in_column = block_depth_ceil(ctas.input_height, 32);
 
     const auto core_x = get_absolute_logical_x();
     const auto core_y = get_absolute_logical_y();

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/integral_image/device/kernels/intimg_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/integral_image/device/kernels/intimg_reader.cpp
@@ -57,9 +57,9 @@ void kernel_main() {
     constexpr auto ctas = get_ctas();
     using input_number_type = std_type_t<get_dataformat(ctas.input_cb)>;
     const auto input_addr_gtor = TensorAccessor(ctas.input_args, input_base_addr, get_tile_size(ctas.input_cb));
-    constexpr uint32_t num_slices_along_channels = block_depth_ceil(ctas.num_channels, 32);
-    constexpr uint32_t num_blocks_in_row = block_depth_ceil(ctas.input_depth, ctas.block_depth);
-    constexpr uint32_t num_blocks_in_column = block_depth_ceil(ctas.input_height, 32);
+    constexpr uint32_t num_slices_along_channels = ceil(ctas.num_channels, ctas.tile_width);
+    constexpr uint32_t num_blocks_in_row = ceil(ctas.input_depth, ctas.block_depth);
+    constexpr uint32_t num_blocks_in_column = ceil(ctas.input_height, ctas.tile_width);
 
     const auto core_x = get_absolute_logical_x();
     const auto core_y = get_absolute_logical_y();

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/integral_image/device/kernels/intimg_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/integral_image/device/kernels/intimg_writer.cpp
@@ -18,7 +18,7 @@ FORCE_INLINE void receive_upper_block(
     uint32_t num_blocks_in_column,
     uint32_t num_slices_along_channels,
     uint32_t block_depth,
-    uint32_t generic_block_depth = 32) {
+    uint32_t generic_block_depth) {
     for (uint32_t tile_i = 0; tile_i < block_depth; ++tile_i) {
         const uint32_t read_tile_id = get_tile_id(
             num_blocks_in_column,
@@ -42,7 +42,7 @@ FORCE_INLINE void output_block(
     uint32_t num_blocks_in_column,
     uint32_t num_slices_along_channels,
     uint32_t block_depth,
-    uint32_t generic_block_depth = 32) {
+    uint32_t generic_block_depth) {
     for (uint32_t inner_tile_stride = 0; inner_tile_stride < block_depth; ++inner_tile_stride) {
         const uint32_t write_tile_id = get_tile_id(
             num_blocks_in_column,
@@ -62,9 +62,9 @@ void kernel_main() {
     const uint32_t output_base_addr = get_arg_val<uint32_t>(0);
     constexpr auto ctas = get_ctas();
     const auto output_addr_gtor = TensorAccessor(ctas.output_args, output_base_addr, get_tile_size(ctas.output_cb));
-    constexpr uint32_t num_slices_along_channels = block_depth_ceil(ctas.num_channels, 32);
-    constexpr uint32_t num_blocks_in_row = block_depth_ceil(ctas.input_depth, ctas.block_depth);
-    constexpr uint32_t num_blocks_in_column = block_depth_ceil(ctas.input_height, 32);
+    constexpr uint32_t num_slices_along_channels = ceil(ctas.num_channels, ctas.tile_width);
+    constexpr uint32_t num_blocks_in_row = ceil(ctas.input_depth, ctas.block_depth);
+    constexpr uint32_t num_blocks_in_column = ceil(ctas.input_height, ctas.tile_height);
 
     const auto core_x = get_absolute_logical_x();
     const auto core_y = get_absolute_logical_y();

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/integral_image/device/kernels/intimg_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/integral_image/device/kernels/intimg_writer.cpp
@@ -62,9 +62,9 @@ void kernel_main() {
     const uint32_t output_base_addr = get_arg_val<uint32_t>(0);
     constexpr auto ctas = get_ctas();
     const auto output_addr_gtor = TensorAccessor(ctas.output_args, output_base_addr, get_tile_size(ctas.output_cb));
-    constexpr uint32_t num_slices_along_channels = block_depth_ceil(ctas.num_channels, ctas.block_depth);
+    constexpr uint32_t num_slices_along_channels = block_depth_ceil(ctas.num_channels, 32);
     constexpr uint32_t num_blocks_in_row = block_depth_ceil(ctas.input_depth, ctas.block_depth);
-    constexpr uint32_t num_blocks_in_column = block_depth_ceil(ctas.input_height, ctas.block_depth);
+    constexpr uint32_t num_blocks_in_column = block_depth_ceil(ctas.input_height, 32);
 
     const auto core_x = get_absolute_logical_x();
     const auto core_y = get_absolute_logical_y();


### PR DESCRIPTION
### Ticket
#33380

### Problem description
for certain inputs, PCC of `ttnn.experimental.intimg` appeared to be around 0.90-0.95

### What's changed
extend block size to be of 48 depth instead of 32 (which works for the largest of the customer's shapes, which is `[1, 48, 160, 256]`, avoiding propagation along axis 2nd/4 and thus reducing number of additions done

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes