### PR TITLE
Revert "Add support for VLLM engine V1 in Qwen2.5-VL. (#33347)"

### DIFF
--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -204,22 +204,6 @@ jobs:
               "co-owner-2-id": "U08CEGF78ET"
             },
             {
-              "name": "[WH-T3K][v1] Qwen2.5-VL-72B-Instruct",
-              "model": "Qwen/Qwen2.5-VL-72B-Instruct",
-              "server-timeout": 10,
-              "benchmark-timeout": 5,
-              "runner-label": "config-t3000",
-              "arch": "arch-wormhole_b0",
-              "mesh-device": "T3K",
-              "tt-llama-text-ver": "tt_transformers",
-              "override-tt-config": "{\"fabric_config\": \"FABRIC_1D\", \"trace_region_size\": 28467200}",
-              "use-vllm-v1": true,
-              "structured-output": true,
-              "multimodal": true,
-              "additional-server-args": "--max_model_len 2048",
-              "co-owner-1-id": "U07RY6B5FLJ",
-            },
-            {
               "name": "[BH-LB][v1] Llama-3.1-8B-Instruct",
               "model": "meta-llama/Llama-3.1-8B-Instruct",
               "server-timeout": 35,

--- a/models/demos/qwen25_vl/tt/generator_vllm.py
+++ b/models/demos/qwen25_vl/tt/generator_vllm.py
@@ -7,17 +7,12 @@ from types import SimpleNamespace
 from typing import Mapping, Optional
 
 import torch
-import vllm.envs as envs
 from loguru import logger
 from transformers.models.qwen2_5_vl.modeling_qwen2_5_vl import (
     Qwen2_5_VLForConditionalGeneration as Ref_Qwen2_5_VLForConditionalGeneration,
 )
 from vllm.model_executor.models.interfaces import SupportsMultiModal
-from vllm.model_executor.models.qwen2_5_vl import (
-    Qwen2_5_VLDummyInputsBuilder,
-    Qwen2_5_VLMultiModalProcessor,
-    Qwen2_5_VLProcessingInfo,
-)
+from vllm.model_executor.models.qwen2_5_vl import Qwen2_5_VLProcessingInfo
 from vllm.multimodal import MULTIMODAL_REGISTRY
 
 import ttnn
@@ -102,9 +97,7 @@ class TT_Qwen2_5_VLProcessingInfo(Qwen2_5_VLProcessingInfo):
 
 # TODO: Eventually replace MultiModalProcessor with vllm.model_executor.models.qwen2_5_vl::Qwen2_5_VLMultiModalProcessor
 @MULTIMODAL_REGISTRY.register_processor(
-    Qwen2_5_VLMultiModalProcessor if envs.VLLM_USE_V1 else MultiModalProcessor,
-    info=TT_Qwen2_5_VLProcessingInfo,
-    dummy_inputs=Qwen2_5_VLDummyInputsBuilder if envs.VLLM_USE_V1 else DummyInputsBuilder,
+    MultiModalProcessor, info=TT_Qwen2_5_VLProcessingInfo, dummy_inputs=DummyInputsBuilder
 )
 class Qwen2_5_VLForConditionalGeneration(QwenVLGenerator, SupportsMultiModal):
     def __init__(self, *args, **kwargs):
@@ -173,10 +166,10 @@ class Qwen2_5_VLForConditionalGeneration(QwenVLGenerator, SupportsMultiModal):
     def prefill_forward(
         self,
         tokens,
+        images,
         page_table,
         kv_cache,
         prompt_lens,  # [INFO] prompt_lens is pre-padding number of tokens after text-image processing
-        **kwargs,  # images for V0, pixel_values and image_grid_thw for V1
     ):
         # [INFO] tokens are padded to the same length by appending 0s; change the padding to use pad_token_id
         pad_token_id = self.tokenizer.pad_token_id
@@ -186,78 +179,28 @@ class Qwen2_5_VLForConditionalGeneration(QwenVLGenerator, SupportsMultiModal):
 
         # reconstruct the inputs that Qwen2.5-VL expects
         inputs = CustomNamespace()
-        if envs.VLLM_USE_V1:
-            inputs.input_ids = tokens.to(torch.int64)  # TODO: Derive dtype, like V0 does (see below)?
-            # Construct inputs.attention_mask with shape [batch_size, padded_seq_len] like tokens,
-            # where each row has ones in the first prompt_lens[i] positions and zeros elsewhere
-            inputs.attention_mask = torch.zeros(
-                (tokens.shape[0], padded_seq_len), dtype=inputs.input_ids.dtype, device=tokens.device
-            )
-            for i, plen in enumerate(prompt_lens):
-                inputs.attention_mask[i, :plen] = 1
-
-            if (
-                "pixel_values" in kwargs
-                and len(kwargs["pixel_values"]) > 0
-                and kwargs["pixel_values"][0] is not None
-                # kwargs["pixel_values"] is a list,
-                # each element is a list of images for one user
-                # We only check if the first user's pixel_values is not None
-                # as we currently do not support mixed inputs of text-only
-                # users and text-image users
-            ):
-                inputs.pixel_values = torch.concat(
-                    [im for user_pixel_values in kwargs["pixel_values"] for im in user_pixel_values], dim=0
-                )
-                inputs.image_grid_thw = torch.concat(
-                    [im for user_image_grid_thw in kwargs["image_grid_thw"] for im in user_image_grid_thw], dim=0
-                )
-                # Vision prefill
-                image_embeds = self.visual_model(inputs.pixel_values, grid_thw=inputs.image_grid_thw)
-            else:
-                # text-only users
-                image_embeds = torch.tensor([], dtype=torch.bfloat16, device=tokens.device)
-        else:  # V0
-            if (
-                "images" in kwargs
-                and isinstance(kwargs["images"], list)
-                and len(kwargs["images"]) > 0
-                and kwargs["images"][0] is not None
-                and "attention_mask" in kwargs["images"][0]
-            ):
-                inputs.input_ids = tokens.to(kwargs["images"][0].attention_mask.dtype)
-            else:
-                inputs.input_ids = tokens
-
-            inputs.attention_mask = torch.concat(
-                [
-                    torch.nn.functional.pad(
-                        im.attention_mask, (0, padded_seq_len - im.attention_mask.shape[-1]), value=0
-                    )
-                    if im is not None
-                    else torch.ones_like(tokens[i : i + 1], dtype=tokens.dtype)
-                    for i, im in enumerate(kwargs["images"])
-                ],
-                dim=0,
-            )
-            if (
-                "images" in kwargs
-                and len(kwargs["images"]) > 0
-                and kwargs["images"][0] is not None
-                and "pixel_values" in kwargs["images"][0]
-            ):
-                # we currently do not support mixed inputs of text-only users and text-image users; hence checking images[0] is enough
-                inputs.pixel_values = torch.concat([im.pixel_values for im in kwargs["images"]], dim=0)
-                inputs.image_grid_thw = torch.concat([im.image_grid_thw for im in kwargs["images"]], dim=0)
-
-                image_embeds = self.visual_model(inputs.pixel_values, grid_thw=inputs.image_grid_thw)
-            else:
-                # text-only users
-                image_embeds = torch.tensor([], dtype=torch.bfloat16, device=tokens.device)
+        inputs.input_ids = tokens.to(images[0].attention_mask.dtype) if images[0] is not None else tokens
+        inputs.attention_mask = torch.concat(
+            [
+                torch.nn.functional.pad(im.attention_mask, (0, padded_seq_len - im.attention_mask.shape[-1]), value=0)
+                if im is not None
+                else torch.ones_like(tokens[i : i + 1], dtype=tokens.dtype)
+                for i, im in enumerate(images)
+            ],
+            dim=0,
+        )
+        if images[0] is not None and "pixel_values" in images[0]:
+            # we currently do not support mixed inputs of text-only users and text-image users; hence checking images[0] is enough
+            inputs.pixel_values = torch.concat([im.pixel_values for im in images], dim=0)
+            inputs.image_grid_thw = torch.concat([im.image_grid_thw for im in images], dim=0)
+            # Vision prefill
+            image_embeds = self.visual_model(inputs.pixel_values, grid_thw=inputs.image_grid_thw)
+        else:
+            # text-only users
+            image_embeds = torch.tensor([], dtype=torch.bfloat16)
 
         # Prepare text + vision inputs for decoder model
         text_embeds = self.reference_model.model.language_model.embed_tokens(inputs.input_ids)
-
         input_embeds = merge_vision_tokens(inputs.input_ids, text_embeds, image_embeds, self.reference_model.config)
         (
             input_prefill_pt,


### PR DESCRIPTION
This reverts commit fbf64ac8a27ccfd7642c79620076356a6641ab07.

### Problem description
This commit `breaks models-unit-tests` in apc

### What's changed
Revert of fbf64ac8a27ccfd7642c79620076356a6641ab07

### Checklist
- [x] [(APC) Select and Run Post-Commit Tests (models-unit-tests)](https://github.com/tenstorrent/tt-metal/actions/runs/19891219303) CI passes