### PR TITLE
#33584: SDXL demo/accuracy test e2e time reporting

### DIFF
--- a/models/experimental/stable_diffusion_xl_base/demo/demo.py
+++ b/models/experimental/stable_diffusion_xl_base/demo/demo.py
@@ -179,7 +179,7 @@ def run_demo_inference(
         )
 
         logger.info(
-            f"Denoising loop for {batch_size} promts completed in {profiler.times['denoising_loop'][-1]:.2f} seconds"
+            f"Denoising loop for {batch_size} prompts completed in {profiler.times['denoising_loop'][-1]:.2f} seconds"
         )
         logger.info(
             f"{'On device VAE' if vae_on_device else 'Host VAE'} decoding completed in {profiler.times['vae_decode'][-1]:.2f} seconds"

--- a/models/experimental/stable_diffusion_xl_base/demo/demo.py
+++ b/models/experimental/stable_diffusion_xl_base/demo/demo.py
@@ -125,7 +125,6 @@ def run_demo_inference(
     images = []
     logger.info("Starting ttnn inference...")
     for iter in range(len(prompts) // batch_size):
-        profiler.start("end_to_end_generation")
         logger.info(
             f"Running inference for prompts {iter * batch_size + 1}-{iter * batch_size + batch_size}/{len(prompts)}"
         )
@@ -146,6 +145,7 @@ def run_demo_inference(
             else negative_prompt_2
         )
 
+        profiler.start("end_to_end_generation")
         (
             all_prompt_embeds_torch,
             torch_add_text_embeds,
@@ -169,11 +169,15 @@ def run_demo_inference(
         )
 
         imgs = tt_sdxl.generate_images()
+        profiler.end("end_to_end_generation")
 
         logger.info(
             f"Prepare input tensors for {batch_size} prompts completed in {profiler.times['prepare_input_tensors'][-1]:.2f} seconds"
         )
-        logger.info(f"Image gen for {batch_size} prompts completed in {profiler.times['image_gen'][-1]:.2f} seconds")
+        logger.info(
+            f"Image gen for {batch_size} prompts completed in {profiler.times['end_to_end_generation'][-1]:.2f} seconds"
+        )
+
         logger.info(
             f"Denoising loop for {batch_size} promts completed in {profiler.times['denoising_loop'][-1]:.2f} seconds"
         )
@@ -181,8 +185,6 @@ def run_demo_inference(
             f"{'On device VAE' if vae_on_device else 'Host VAE'} decoding completed in {profiler.times['vae_decode'][-1]:.2f} seconds"
         )
         logger.info(f"Output tensor read completed in {profiler.times['read_output_tensor'][-1]:.2f} seconds")
-
-        profiler.end("end_to_end_generation")
 
         for idx, img in enumerate(imgs):
             if iter == len(prompts) // batch_size - 1 and idx >= batch_size - needed_padding:

--- a/models/experimental/stable_diffusion_xl_base/demo/demo_base_and_refiner.py
+++ b/models/experimental/stable_diffusion_xl_base/demo/demo_base_and_refiner.py
@@ -123,7 +123,6 @@ def run_demo_inference(
     logger.info("Starting ttnn inference...")
 
     for iter in range(len(prompts) // batch_size + (1 if len(prompts) % batch_size != 0 else 0)):
-        profiler.start("end_to_end_generation")
         logger.info(
             f"Running inference for prompts {iter * batch_size + 1}-{min((iter + 1) * batch_size, len(prompts))}/{len(prompts)}"
         )
@@ -143,6 +142,8 @@ def run_demo_inference(
             else negative_prompt_2
         )
 
+        profiler.start("end_to_end_generation")
+
         # Combined pipeline will pad the batch internally if needed
         imgs = tt_sdxl_combined.generate(
             prompts=prompts_batch,
@@ -159,15 +160,15 @@ def run_demo_inference(
             guidance_rescale=guidance_rescale,
         )
 
-        logger.info(
-            f"Combined generation for batch {iter + 1} completed in {profiler.times['combined_generation'][-1]:.2f} seconds"
-        )
-
         profiler.end("end_to_end_generation")
         if iter == 0:
             profiler.times["end_to_end_generation"][0] -= profiler.times["auto_compile_if_needed"][0]
             for key in profiler.times.keys():
                 profiler.times[key] = [profiler.times[key][-1]]
+
+        logger.info(
+            f"Combined generation for batch {iter + 1} completed in {profiler.times['end_to_end_generation'][-1]:.2f} seconds"
+        )
 
         for idx, img in enumerate(imgs):
             if iter * batch_size + idx >= len(prompts):

--- a/models/experimental/stable_diffusion_xl_base/demo/demo_img2img.py
+++ b/models/experimental/stable_diffusion_xl_base/demo/demo_img2img.py
@@ -144,7 +144,6 @@ def run_demo_inference(
     out_images = []
     logger.info("Starting ttnn inference...")
     for iter in range(len(prompts) // batch_size):
-        profiler.start("end_to_end_generation")
         logger.info(
             f"Running inference for prompts {iter * batch_size + 1}-{iter * batch_size + batch_size}/{len(prompts)}"
         )
@@ -165,6 +164,7 @@ def run_demo_inference(
             else negative_prompt_2
         )
 
+        profiler.start("end_to_end_generation")
         (
             all_prompt_embeds_torch,
             torch_add_text_embeds,
@@ -190,10 +190,14 @@ def run_demo_inference(
 
         imgs = tt_sdxl.generate_images()
 
+        profiler.end("end_to_end_generation")
+
         logger.info(
             f"Prepare input tensors for {batch_size} prompts completed in {profiler.times['prepare_input_tensors'][-1]:.2f} seconds"
         )
-        logger.info(f"Image gen for {batch_size} prompts completed in {profiler.times['image_gen'][-1]:.2f} seconds")
+        logger.info(
+            f"Image gen for {batch_size} prompts completed in {profiler.times['end_to_end_generation'][-1]:.2f} seconds"
+        )
         logger.info(
             f"Denoising loop for {batch_size} prompts completed in {profiler.times['denoising_loop'][-1]:.2f} seconds"
         )
@@ -201,8 +205,6 @@ def run_demo_inference(
             f"{'On device VAE' if vae_on_device else 'Host VAE'} decoding completed in {profiler.times['vae_decode'][-1]:.2f} seconds"
         )
         logger.info(f"Output tensor read completed in {profiler.times['read_output_tensor'][-1]:.2f} seconds")
-
-        profiler.end("end_to_end_generation")
 
         for idx, img in enumerate(imgs):
             if iter == len(prompts) // batch_size - 1 and idx >= batch_size - needed_padding:

--- a/models/experimental/stable_diffusion_xl_base/demo/demo_inpainting.py
+++ b/models/experimental/stable_diffusion_xl_base/demo/demo_inpainting.py
@@ -183,7 +183,6 @@ def run_demo_inference(
     images = []
     logger.info("Starting ttnn inference...")
     for iter in range(len(prompts) // batch_size):
-        profiler.start("end_to_end_generation")
         logger.info(
             f"Running inference for prompts {iter * batch_size + 1}-{iter * batch_size + batch_size}/{len(prompts)}"
         )
@@ -204,6 +203,7 @@ def run_demo_inference(
             else negative_prompt_2
         )
 
+        profiler.start("end_to_end_generation")
         (
             all_prompt_embeds_torch,
             torch_add_text_embeds,
@@ -237,10 +237,14 @@ def run_demo_inference(
 
         imgs = tt_sdxl.generate_images()
 
+        profiler.end("end_to_end_generation")
+
         logger.info(
             f"Prepare input tensors for {batch_size} prompts completed in {profiler.times['prepare_input_tensors'][-1]:.2f} seconds"
         )
-        logger.info(f"Image gen for {batch_size} prompts completed in {profiler.times['image_gen'][-1]:.2f} seconds")
+        logger.info(
+            f"Image gen for {batch_size} prompts completed in {profiler.times['end_to_end_generation'][-1]:.2f} seconds"
+        )
         logger.info(
             f"Denoising loop for {batch_size} prompts completed in {profiler.times['denoising_loop'][-1]:.2f} seconds"
         )
@@ -248,8 +252,6 @@ def run_demo_inference(
             f"{'On device VAE' if vae_on_device else 'Host VAE'} decoding completed in {profiler.times['vae_decode'][-1]:.2f} seconds"
         )
         logger.info(f"Output tensor read completed in {profiler.times['read_output_tensor'][-1]:.2f} seconds")
-
-        profiler.end("end_to_end_generation")
 
         for idx, img in enumerate(imgs):
             if iter == len(prompts) // batch_size - 1 and idx >= batch_size - needed_padding:

--- a/models/experimental/stable_diffusion_xl_base/utils/check_sdxl_log.py
+++ b/models/experimental/stable_diffusion_xl_base/utils/check_sdxl_log.py
@@ -19,7 +19,7 @@ def extract_times(log_file: str) -> Tuple[List[float], List[float], List[float]]
     Returns:
         Tuple of (denoising_times, vae_times, output_read_times)
     """
-    denoising_pattern = r"Denoising loop for \d+ promts completed in (\d+\.\d+) seconds"
+    denoising_pattern = r"Denoising loop for \d+ prompts completed in (\d+\.\d+) seconds"
     vae_pattern = r"On device VAE decoding completed in (\d+\.\d+) seconds"
     output_read_pattern = r"Output tensor read completed in (\d+\.\d+) seconds"
 


### PR DESCRIPTION
### Ticket
#33584

### Problem description
Demo reported lower e2e time (only denoising loop and VAE included) while accuracy test included prints and list manipulations in e2e time ( specific for demo script, should not be present in production).

### What's changed
Unified e2e measurement for demo and accuracy test. It includes encoders, input tensor prep, denoising loop and VAE decoder.

### Checklist
- [x] [(Single-card) Demo tests ](https://github.com/tenstorrent/tt-metal/actions/runs/19899489774) CI passes