### PR TITLE
Fix validate_deprecation to respect directory scope and check staged hanges

### DIFF
--- a/scripts/validate_api/git_utils.py
+++ b/scripts/validate_api/git_utils.py
@@ -88,16 +88,20 @@ def parse_diff_for_removed_lines(diff_output: str, pattern_matcher) -> List[Tupl
 
 
 def get_changed_file_paths(base_ref: str, head_ref: str = "HEAD") -> List[str]:
-    """List of changed files (paths) (includes deleted ones)"""
-    output = run_git(["git", "diff", "--name-only", base_ref, head_ref])
-    return [f for f in output.strip().split("\n") if f]
+    """List of changed files (paths) (includes deleted ones and staged changes)."""
+    committed = run_git(["git", "diff", "--name-only", base_ref, head_ref])
+    staged = run_git(["git", "diff", "--name-only", "--cached"])
+    all_files = {f for f in (committed + staged).split("\n") if f.strip()}
+    return list(all_files)
 
 
 def get_diff(files: List[str], base_ref: str, head_ref: str = "HEAD") -> str:
-    """Get git concatenated diff for specified files."""
+    """Get git concatenated diff for specified files (includes both committed and staged changes)."""
     if not files:
         return ""
-    return run_git(["git", "diff", "-U0", base_ref, head_ref, "--"] + files)
+    committed_diff = run_git(["git", "diff", "-U0", base_ref, head_ref, "--"] + files)
+    staged_diff = run_git(["git", "diff", "-U0", "--cached", "--"] + files)
+    return committed_diff + staged_diff
 
 
 def compute_ranges(numbers: List[int]) -> List[Tuple[int, int]]:

--- a/scripts/validate_api/validate_deprecation.py
+++ b/scripts/validate_api/validate_deprecation.py
@@ -49,10 +49,13 @@ class DeprecatedItem(NamedTuple):
         return self.age_days is not None and self.age_days >= Config.MIN_DEPRECATION_DAYS
 
 
-def find_removed_deprecations(base_ref: str = "origin/main") -> List[DeprecatedItem]:
+def find_removed_deprecations(files: List[str], base_ref: str = "origin/main") -> List[DeprecatedItem]:
     # Get all C++ files that changed (including deleted ones)
     changed_files = git_utils.get_changed_file_paths(base_ref)
-    changed_cpp_files = [f for f in changed_files if is_cpp_source(f)]
+
+    # Only check changed files that are in the provided file list
+    files_set = set(files)
+    changed_cpp_files = [f for f in changed_files if f in files_set]
 
     if not changed_cpp_files:
         return []
@@ -176,7 +179,7 @@ def main() -> int:
 
     source_files = find_cpp_sources(directory)
     existing = find_existing_deprecations(source_files)
-    removed = find_removed_deprecations(base_ref)
+    removed = find_removed_deprecations(source_files, base_ref)
 
     return print_report(existing, removed)
 


### PR DESCRIPTION
### Ticket
Internal slack thread

### Problem description
API validation script was doing deprecation removal check on entire repository, instead of provided directory.

### What's changed
- Bug has been fixed:
  - find_removed_deprecations now only checks files within the specified directory
- Additionally:
  - Both get_changed_file_paths() and get_diff() now include staged changes alongside committed changes

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes