### PR TITLE
#32584: increase default matmul accuracy

### DIFF
--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
@@ -1387,9 +1387,7 @@ Matmul create_matmul_struct(
         ((input_tensor_a.dtype() == DataType::BFLOAT8_B || input_tensor_a.dtype() == DataType::BFLOAT4_B) &&
          (input_tensor_b.dtype() == DataType::BFLOAT8_B || input_tensor_b.dtype() == DataType::BFLOAT4_B));
     const auto increase_fidelity = !has_program_config && !has_user_grid && !are_inputs_low_precision_df;
-    auto math_fidelity = increase_fidelity ? MathFidelity::HiFi2 : MathFidelity::LoFi;
-    bool are_inputs_32F = (input_tensor_a.dtype() == DataType::FLOAT32 && input_tensor_b.dtype() == DataType::FLOAT32);
-    math_fidelity = are_inputs_32F ? MathFidelity::HiFi4 : math_fidelity;
+    auto math_fidelity = increase_fidelity ? MathFidelity::HiFi4 : MathFidelity::LoFi;
 
     bool broadcast_batch =
         parameters.bcast_batch.value_or(get_broadcast_batch(input_tensor_a, input_tensor_b, parameters.program_config));
@@ -1427,14 +1425,13 @@ Matmul create_matmul_struct(
             output_dtype = input_tensor_a.dtype();
         }
     }
-    bool is_float_32 = output_dtype == DataType::FLOAT32;
     auto kernel_config_val = init_device_compute_kernel_config(
         arch,
         parameters.compute_kernel_config,
         math_fidelity,
         /*default_approx_mode=*/false,
-        /*default_fp32_acc=*/is_float_32,
-        /*default_l1_acc=*/!is_float_32);
+        /*default_fp32_acc=*/true,
+        /*default_l1_acc=*/true);
     auto in0_tile = input_tensor_a.tensor_spec().tile();
     auto in1_tile = input_tensor_b.tensor_spec().tile();
 

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
@@ -1388,10 +1388,6 @@ Matmul create_matmul_struct(
          (input_tensor_b.dtype() == DataType::BFLOAT8_B || input_tensor_b.dtype() == DataType::BFLOAT4_B));
     const auto increase_fidelity = !has_program_config && !has_user_grid && !are_inputs_low_precision_df;
     auto math_fidelity = increase_fidelity ? MathFidelity::HiFi3 : MathFidelity::LoFi;
-    std::optional<DataType> output_dtype = parameters.output_dtype;
-    bool is_float_32 = (input_tensor_a.dtype() == DataType::FLOAT32 && input_tensor_b.dtype() == DataType::FLOAT32) ||
-                       (output_dtype == DataType::FLOAT32);
-    math_fidelity = is_float_32 ? MathFidelity::HiFi4 : math_fidelity;
 
     bool broadcast_batch =
         parameters.bcast_batch.value_or(get_broadcast_batch(input_tensor_a, input_tensor_b, parameters.program_config));
@@ -1401,6 +1397,7 @@ Matmul create_matmul_struct(
         !optional_output_tensors.empty() && optional_output_tensors.at(0).has_value();
     MemoryConfig output_mem_config = parameters.output_mem_config;
 
+    std::optional<DataType> output_dtype = parameters.output_dtype;
     if (is_optional_output_tensor) {
         const auto& optional_output_tensor = optional_output_tensors.at(0);
         if (output_mem_config == tt::tt_metal::operation::DEFAULT_OUTPUT_MEMORY_CONFIG) {
@@ -1428,6 +1425,9 @@ Matmul create_matmul_struct(
             output_dtype = input_tensor_a.dtype();
         }
     }
+    bool is_float_32 = (input_tensor_a.dtype() == DataType::FLOAT32 && input_tensor_b.dtype() == DataType::FLOAT32) ||
+                       (output_dtype == DataType::FLOAT32);
+    math_fidelity = is_float_32 ? MathFidelity::HiFi4 : math_fidelity;
     auto kernel_config_val = init_device_compute_kernel_config(
         arch,
         parameters.compute_kernel_config,

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
@@ -1387,7 +1387,7 @@ Matmul create_matmul_struct(
         ((input_tensor_a.dtype() == DataType::BFLOAT8_B || input_tensor_a.dtype() == DataType::BFLOAT4_B) &&
          (input_tensor_b.dtype() == DataType::BFLOAT8_B || input_tensor_b.dtype() == DataType::BFLOAT4_B));
     const auto increase_fidelity = !has_program_config && !has_user_grid && !are_inputs_low_precision_df;
-    auto math_fidelity = increase_fidelity ? MathFidelity::HiFi4 : MathFidelity::LoFi;
+    auto math_fidelity = increase_fidelity ? MathFidelity::HiFi3 : MathFidelity::LoFi;
 
     bool broadcast_batch =
         parameters.bcast_batch.value_or(get_broadcast_batch(input_tensor_a, input_tensor_b, parameters.program_config));
@@ -1425,12 +1425,13 @@ Matmul create_matmul_struct(
             output_dtype = input_tensor_a.dtype();
         }
     }
+    bool is_float_32 = output_dtype == DataType::FLOAT32;
     auto kernel_config_val = init_device_compute_kernel_config(
         arch,
         parameters.compute_kernel_config,
         math_fidelity,
         /*default_approx_mode=*/false,
-        /*default_fp32_acc=*/true,
+        /*default_fp32_acc=*/is_float_32 || increase_fidelity,
         /*default_l1_acc=*/true);
     auto in0_tile = input_tensor_a.tensor_spec().tile();
     auto in1_tile = input_tensor_b.tensor_spec().tile();


### PR DESCRIPTION
### Ticket
Link to Github Issue #32584

### Problem description


### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes