### PR TITLE
[skip ci] TG Resnet50 test_perf_trace_2cqs tweak

### DIFF
--- a/models/demos/ttnn_resnet/tests/test_perf_e2e_resnet50.py
+++ b/models/demos/ttnn_resnet/tests/test_perf_e2e_resnet50.py
@@ -18,7 +18,7 @@ PERF_EXPECTATIONS = {
         "test_perf": {"inference_time": 0.017, "compile_time": 60},
         "test_perf_trace": {"inference_time": 0.0068, "compile_time": 60},
         "test_perf_2cqs": {"inference_time": 0.0175, "compile_time": 60},
-        "test_perf_trace_2cqs": {"inference_time": 0.0058, "compile_time": 60},
+        "test_perf_trace_2cqs": {"inference_time": 0.0052, "compile_time": 60},
     },
 }
 


### PR DESCRIPTION
### Ticket
Galaxy Models perf is red 
https://github.com/tenstorrent/tt-metal/actions/runs/19854707574/job/56935548600#step:9:507

### Problem description
Tweak value to be encompass last couple of runs on main

### What's changed
- Tweaked `test_perf_trace_2cqs` TG value from `0.0058` to `0.0052`