### PR TITLE
fix bug in metal-exalens remapping

### DIFF
--- a/tools/triage/run_checks.py
+++ b/tools/triage/run_checks.py
@@ -87,9 +87,12 @@ class DeviceDescription:
 
     def __init__(self, device: Device, metal_device_id_mapping: MetalDeviceIdMapping):
         self.device = device
-        # Check if exalens device._id maps to the same unique_id as device.unique_id
-        inspector_unique_id = metal_device_id_mapping.get_unique_id(device._id)
-        self.use_unique_id = inspector_unique_id != device.unique_id
+        # Check if exalens device._id maps to the same unique_id as metal device id
+        if metal_device_id_mapping.has_metal_device_id(device._id):
+            inspector_unique_id = metal_device_id_mapping.get_unique_id(device._id)
+            self.use_unique_id = inspector_unique_id != device.unique_id
+        else:
+            self.use_unique_id = False
 
 
 def device_description_serializer(device_desc: DeviceDescription) -> str:
@@ -187,8 +190,7 @@ def get_devices(
     elif len(devices) == 1 and devices[0].lower() == "all":
         device_ids = [int(id) for id in context.devices.keys()]
     else:
-        metal_device_ids = [int(id) for id in devices]
-        device_ids = _convert_metal_device_ids_to_device_ids(metal_device_ids, metal_device_id_mapping, context)
+        device_ids = [int(id) for id in devices]
 
     return [context.devices[id] for id in device_ids]
 


### PR DESCRIPTION
### Ticket
/

### Problem description
Fixing metal-exalens remapping corner cases

### What's changed
get_devices will interpret user specified devices as exalens device ids
fix missing key in map

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes