### PR TITLE
Run paged llama attention prefill unit test instead of default attention

### DIFF
--- a/models/demos/llama3_70b_galaxy/tests/unit_tests/test_llama_attention_prefill.py
+++ b/models/demos/llama3_70b_galaxy/tests/unit_tests/test_llama_attention_prefill.py
@@ -21,7 +21,8 @@ from models.demos.llama3_70b_galaxy.tt.prefetcher_common import TtLlamaPrefetche
 from models.demos.llama3_70b_galaxy.tt.llama_ccl import TT_CCL
 
 
-# @pytest.mark.skip(reason="Skipping test due to failure here, fix to be revisited: https://github.com/tenstorrent/tt-metal/issues/33677")
+# TODO: The default attention path (paged_attention=False) of this testcauses this issue https://github.com/tenstorrent/tt-metal/issues/33677
+# although it is not used in production, the fix should be properly revisited.
 @torch.no_grad()
 @pytest.mark.parametrize(
     "mesh_device",

--- a/models/demos/llama3_70b_galaxy/tests/unit_tests/test_llama_attention_prefill.py
+++ b/models/demos/llama3_70b_galaxy/tests/unit_tests/test_llama_attention_prefill.py
@@ -21,6 +21,7 @@ from models.demos.llama3_70b_galaxy.tt.prefetcher_common import TtLlamaPrefetche
 from models.demos.llama3_70b_galaxy.tt.llama_ccl import TT_CCL
 
 
+# @pytest.mark.skip(reason="Skipping test due to failure here, fix to be revisited: https://github.com/tenstorrent/tt-metal/issues/33677")
 @torch.no_grad()
 @pytest.mark.parametrize(
     "mesh_device",
@@ -32,14 +33,8 @@ from models.demos.llama3_70b_galaxy.tt.llama_ccl import TT_CCL
 # Model and attention prefill tests should run both with and without paged attention to debug any issues that may occur with default attention
 @pytest.mark.parametrize(
     "paged_attention",
-    (
-        # True,
-        False,
-    ),
-    ids=(
-        # "paged_attention",
-        "default_attention",
-    ),
+    (True,),
+    ids=("paged_attention",),
 )
 @pytest.mark.parametrize(
     "page_params",


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/33677

### Problem description
Failure due to tensor composer shapes, proper fix to be revisited.

### What's changed
- run the paged llama attention version of the prefill test

### Checklist
- [ ] [Galaxy unit test](https://github.com/tenstorrent/tt-metal/actions/runs/19902123718) Passed with paged attention