### PR TITLE
Fix TT_METAL_CACHE default base_path to use subdirectory 

### DIFF
--- a/ttnn/ttnn/distributed/ttrun.py
+++ b/ttnn/ttnn/distributed/ttrun.py
@@ -117,7 +117,7 @@ def get_rank_environment(binding: RankBinding, config: TTRunConfig) -> Dict[str,
         )
     else:
         # Use default pattern when TT_METAL_CACHE is not set
-        base_path = f"{Path.home()}/.cache"
+        base_path = f"{Path.home()}/.cache/"
 
     # Apply consistent rank suffix pattern to both user-provided and default paths
     cache_path = f"{base_path}_{hostname}_rank{binding.rank}"


### PR DESCRIPTION
### Ticket

#33680

### Problem description
Missing / causes default rank-binding-appended base path to become a new dir in HOME rather than a subdir of .cache, like `.cache_wh-lb-46-special-<USER>-for-reservation-47108_rank1`. 

### What's changed
Add trailing / to default .cache path to create subdirectories in .cache folder instead of top level path.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes