### PR TITLE
[Reduce APC] Remove cpp N150 runs from APC

### DIFF
--- a/.github/workflows/all-post-commit-workflows.yaml
+++ b/.github/workflows/all-post-commit-workflows.yaml
@@ -155,8 +155,7 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          { arch: wormhole_b0, runner-label: N150 },
-          { arch: wormhole_b0, runner-label: N300 },
+          { arch: wormhole_b0, runner-label: N300 }
         ]
     if: ${{ needs.find-changed-files.outputs.test-everything == 'true' }}
     uses: ./.github/workflows/cpp-post-commit.yaml


### PR DESCRIPTION
### What's changed
Remove cpp N150 runs from APC. cpp-unit-tests are still run on N150 in the L2-Nightly pipeline: https://github.com/tenstorrent/tt-metal/actions/runs/19884102250/job/56988362917
- [X] APC CI run: https://github.com/tenstorrent/tt-metal/actions/runs/19903221875