### PR TITLE
Remove silent defaults from DeepSeekV3 demo and tests

### DIFF
--- a/.github/workflows/galaxy-deepseek-tests-impl.yaml
+++ b/.github/workflows/galaxy-deepseek-tests-impl.yaml
@@ -45,6 +45,7 @@ jobs:
         ARCH_NAME: ${{ matrix.test-group.arch }}
         DEEPSEEK_V3_HF_MODEL: /mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528
         DEEPSEEK_V3_CACHE: /mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-Cache
+        MESH_DEVICE: TG
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G

--- a/models/demos/deepseek_v3/conftest.py
+++ b/models/demos/deepseek_v3/conftest.py
@@ -11,7 +11,7 @@ from transformers import AutoConfig
 
 import ttnn
 from models.demos.deepseek_v3.tt.ccl import CCL
-from models.demos.deepseek_v3.utils.test_utils import load_state_dict
+from models.demos.deepseek_v3.utils.test_utils import load_state_dict, system_name_to_mesh_shape
 from tests.scripts.common import get_updated_device_params
 
 RESET_WEIGHT_CACHE_OPTION = "--recalculate-weights"
@@ -42,21 +42,14 @@ def mesh_device(request, device_params):
     """
     import ttnn
 
-    device_ids = ttnn.get_device_ids()
-    request.node.pci_ids = [ttnn.GetPCIeDeviceID(i) for i in device_ids]
+    request.node.pci_ids = ttnn.get_pcie_device_ids()
 
     # Override mesh shape based on MESH_DEVICE environment variable
-    mesh_device_env = os.getenv("MESH_DEVICE")
-    if mesh_device_env == "DUAL":
-        default_mesh_shape = ttnn.MeshShape(8, 8)  # If running on DUAL system
-    elif mesh_device_env == "QUAD":
-        default_mesh_shape = ttnn.MeshShape(16, 8)  # If running on QUAD system
-    elif mesh_device_env == "TG" or len(device_ids) == 32:  # If running on Galaxy system
-        default_mesh_shape = ttnn.MeshShape(4, 8)
-    elif hasattr(request, "param") and isinstance(request.param, tuple):
-        default_mesh_shape = ttnn.MeshShape(*request.param)
-    else:
-        default_mesh_shape = ttnn.MeshShape(1, len(device_ids))
+    requested_system_name = os.getenv("MESH_DEVICE")
+    if requested_system_name is None:
+        raise ValueError("Environment variable $MESH_DEVICE is not set. Please set it to DUAL, QUAD, or TG.")
+    mesh_shape = system_name_to_mesh_shape(requested_system_name.upper())
+    logger.info(f"Selected MESH_DEVICE: '{requested_system_name}' - mesh shape will be set to: {mesh_shape}")
 
     updated_device_params = get_updated_device_params(device_params)
 
@@ -64,10 +57,10 @@ def mesh_device(request, device_params):
     if fabric_config:
         ttnn.set_fabric_config(fabric_config)
 
-    updated_device_params.setdefault("mesh_shape", default_mesh_shape)
+    updated_device_params.setdefault("mesh_shape", mesh_shape)
     mesh_device = ttnn.open_mesh_device(**updated_device_params)
 
-    logger.debug(f"multidevice with {mesh_device.get_num_devices()} devices is created with shape {mesh_device.shape}")
+    logger.debug(f"Mesh device with {mesh_device.get_num_devices()} devices is created with shape {mesh_device.shape}")
     yield mesh_device
 
     for submesh in mesh_device.get_submeshes():
@@ -76,6 +69,7 @@ def mesh_device(request, device_params):
     ttnn.close_mesh_device(mesh_device)
     if fabric_config:
         ttnn.set_fabric_config(ttnn.FabricConfig.DISABLED)
+
     del mesh_device
 
 
@@ -93,7 +87,7 @@ def hf_config(model_path):
 
 @pytest.fixture(scope="session")
 def state_dict(model_path):
-    return load_state_dict(model_path, "")
+    yield load_state_dict(model_path, "")
 
 
 @pytest.fixture(scope="session")

--- a/models/demos/deepseek_v3/demo/README.md
+++ b/models/demos/deepseek_v3/demo/README.md
@@ -32,7 +32,7 @@ export MESH_DEVICE=DUAL
 python models/demos/deepseek_v3/demo/demo.py \
   "Explain quantum tunneling in one paragraph." \
   --model-path $DEEPSEEK_V3_HF_MODEL \
-  --cache-path $DEEPSEEK_V3_CACHE \
+  --cache-dir $DEEPSEEK_V3_CACHE \
   --max-new-tokens 64
 ```
 
@@ -45,10 +45,11 @@ export DEEPSEEK_V3_HF_MODEL=/proj_sw/user_dev/deepseek-ai/DeepSeek-R1-0528
 # What system type are we running on? (Can be TG, DUAL, QUAD)
 export MESH_DEVICE=DUAL
 
-# Model path only needs config (tokenizer optional) and defaults to models/demos/deepseek_v3/reference
+# Model path only needs config (tokenizer optional)
 python models/demos/deepseek_v3/demo/demo.py \
   --random-weights --single-layer mlp \
   --model-path $DEEPSEEK_V3_HF_MODEL \
+  --cache-dir $DEEPSEEK_V3_CACHE \
   --max-new-tokens 16
 ```
 

--- a/models/demos/deepseek_v3/demo/README.md
+++ b/models/demos/deepseek_v3/demo/README.md
@@ -14,10 +14,6 @@ The script supports two practical modes:
   - Full‑model mode: requires config, tokenizer, and `.safetensors`
   - Random‑weights mode: requires config; tokenizer is optional (dummy tokenization is used if missing)
 
-Common environment variables:
-- `DEEPSEEK_V3_HF_MODEL`: Path to a local Hugging Face model directory that contains config (and tokenizer + safetensors for full‑model mode). Defaults to `models/demos/deepseek_v3/reference`.
-- `DEEPSEEK_V3_CACHE`: Optional path where converted TTNN weights and caches are written. Defaults to `generated/deepseek_v3`.
-
 Tokenizer (full‑model mode): expect one of `tokenizer.model`, `tokenizer.json`, `spiece.model`, or `tokenizer_config.json`.
 
 ## Quick Start
@@ -28,31 +24,31 @@ Use this when you have a local DeepSeek‑V3 model (config, tokenizer, and `.saf
 ```bash
 # Point to a local HF model directory (contains tokenizer + .safetensors)
 export DEEPSEEK_V3_HF_MODEL=/proj_sw/user_dev/deepseek-ai/DeepSeek-R1-0528
-# Optional: where to store converted TTNN weights
+# Where to store converted TTNN weights
 export DEEPSEEK_V3_CACHE=/proj_sw/user_dev/deepseek_ttnn_cache_all_61_layers
+# What system type are we running on? (Can be TG, DUAL, QUAD)
+export MESH_DEVICE=DUAL
 
 python models/demos/deepseek_v3/demo/demo.py \
   "Explain quantum tunneling in one paragraph." \
+  --model-path $DEEPSEEK_V3_HF_MODEL \
+  --cache-path $DEEPSEEK_V3_CACHE \
   --max-new-tokens 64
-```
-
-You can also pass `--model-path` instead of setting the env var:
-
-```bash
-python models/demos/deepseek_v3/demo/demo.py \
-  "Write a haiku about compilers." \
-  --model-path /proj_sw/user_dev/deepseek-ai/DeepSeek-R1-0528 \
-  --max-new-tokens 32
 ```
 
 ### 2) Single‑layer with random weights (fast)
 Runs a minimal single‑layer pipeline with randomly initialized weights. This does not require `.safetensors`, and the tokenizer is optional. If no tokenizer is found, the demo synthesizes simple token IDs. The prompt is not used in this mode, so you don’t need to provide one.
 
 ```bash
-# Model path only needs config (tokenizer optional) and defaults to models/demos/deepseek_v3/reference
+# Point to a local HF model directory (contains tokenizer + .safetensors)
+export DEEPSEEK_V3_HF_MODEL=/proj_sw/user_dev/deepseek-ai/DeepSeek-R1-0528
+# What system type are we running on? (Can be TG, DUAL, QUAD)
+export MESH_DEVICE=DUAL
 
+# Model path only needs config (tokenizer optional) and defaults to models/demos/deepseek_v3/reference
 python models/demos/deepseek_v3/demo/demo.py \
   --random-weights --single-layer mlp \
+  --model-path $DEEPSEEK_V3_HF_MODEL \
   --max-new-tokens 16
 ```
 
@@ -69,35 +65,16 @@ usage: DeepSeek-V3 Demo on TT-NN [-h] [--model-path PATH] [--max-new-tokens N]
 ```
 
 - `prompt`: Text prompt to generate from (required in full‑model mode; ignored in `--random-weights`).
-- `--model-path PATH`: Local HF model directory. Defaults to `$DEEPSEEK_V3_HF_MODEL` or `models/demos/deepseek_v3/reference`.
+- `--model-path PATH`: Local HF model directory.
   - Full‑model mode requires tokenizer files and at least one `.safetensors` shard.
   - Random‑weights mode only requires `config.json`; tokenizer is optional.
 - `--max-new-tokens N`: Number of tokens to generate (default: 32). Greedy decoding only.
-- `--cache-dir PATH`: Where to store converted TTNN weights and caches (default: `$DEEPSEEK_V3_CACHE` or `generated/deepseek_v3`).
+- `--cache-dir PATH`: Where to store converted TTNN weights and caches.
 - `--random-weights`: Use randomly initialized weights derived from the HF config (no safetensors).
 - `--single-layer {mlp,moe}`: With `--random-weights`, request a single‑layer run. `mlp` is supported; `moe` is not.
 
-## Examples
-
-- Explicit model and cache paths:
-  ```bash
-  python models/demos/deepseek_v3/demo/demo.py \
-    "Summarize the history of RISC architectures." \
-    --model-path /proj_sw/user_dev/deepseek-ai/DeepSeek-R1-0528 \
-    --cache-dir /proj_sw/user_dev/deepseek_ttnn_cache_all_61_layers \
-    --max-new-tokens 80
-  ```
-
-- Fast pipeline check, no safetensors, no prompt:
-  ```bash
-  python models/demos/deepseek_v3/demo/demo.py \
-    --model-path /proj_sw/user_dev/deepseek-ai/DeepSeek-R1-0528 \
-    --random-weights --single-layer mlp \
-    --max-new-tokens 8
-  ```
-
 ## Behavior and Output
-- The demo opens a mesh device based on available device IDs (e.g., `4x8` mesh for 32 devices, otherwise a single row).
+- The demo opens a mesh device based on specified system type (`TG`, `DUAL`, `QUAD`).
 - Prefill is emulated by iterating decode steps over the prompt before generating new tokens.
 - Prints the generated text between separators:
   ```

--- a/models/demos/deepseek_v3/demo/demo.py
+++ b/models/demos/deepseek_v3/demo/demo.py
@@ -182,7 +182,7 @@ def validate_model_path(model_path_str: str, require_safetensors: bool, require_
     # Config: always required so AutoConfig can load
     has_config = (mp / "config.json").exists()
     if not has_config:
-        raise SystemExit("config.json not found in the model directory." f"Checked: '{mp}'.")
+        raise SystemExit(f"config.json not found in the model directory. Checked: '{mp}'.")
 
     # Tokenizer files: common possibilities (optional in random-weights mode)
     if require_tokenizer:
@@ -193,7 +193,7 @@ def validate_model_path(model_path_str: str, require_safetensors: bool, require_
         if not has_tokenizer:
             raise SystemExit(
                 "Tokenizer files not found in the model directory. Expected one of: "
-                "tokenizer.model, tokenizer.json, spiece.model, tokenizer_config.json."
+                "tokenizer.model, tokenizer.json, spiece.model, tokenizer_config.json. "
                 f"Checked: '{mp}'."
             )
 
@@ -201,7 +201,7 @@ def validate_model_path(model_path_str: str, require_safetensors: bool, require_
         # Weights: require at least one safetensors shard
         has_safetensors = len(glob(str(mp / "*.safetensors"))) > 0
         if not has_safetensors:
-            raise SystemExit("No .safetensors files found in the model directory." f"Checked: '{mp}'.")
+            raise SystemExit("No .safetensors files found in the model directory. " f"Checked: '{mp}'.")
 
 
 def run_demo(

--- a/models/demos/deepseek_v3/tt/generator_vllm.py
+++ b/models/demos/deepseek_v3/tt/generator_vllm.py
@@ -40,8 +40,18 @@ class DeepseekV3ForCausalLM(DeepseekGenerator):
     def initialize_vllm_model(
         cls, hf_config, mesh_device, max_batch_size, max_seq_len, tt_data_parallel=1, optimizations: str = None
     ):
-        model_path = os.getenv("DEEPSEEK_V3_HF_MODEL", "models/demos/deepseek_v3/reference")
-        cache_dir = os.getenv("DEEPSEEK_V3_CACHE", "generated/deepseek_v3")
+        model_path = os.environ.get("DEEPSEEK_V3_HF_MODEL")
+        cache_dir = os.environ.get("DEEPSEEK_V3_CACHE")
+        if not model_path:
+            raise ValueError(
+                "DEEPSEEK_V3_HF_MODEL is not set. Set the environment variable or initialize via the demo "
+                "entrypoint with an explicit --model-path."
+            )
+        if not cache_dir:
+            raise ValueError(
+                "DEEPSEEK_V3_CACHE is not set. Set the environment variable or initialize via the demo "
+                "entrypoint with an explicit --cache-dir."
+            )
         tokenizer = load_tokenizer(model_path)
 
         model = cls(

--- a/models/demos/deepseek_v3/utils/test_utils.py
+++ b/models/demos/deepseek_v3/utils/test_utils.py
@@ -488,3 +488,13 @@ def get_rope_tensors(
     if position_ids is None:
         return rope_setup.get_rot_mats_table(seq_len)
     return rope_setup.get_rot_mats(position_ids)
+
+
+def system_name_to_mesh_shape(system_name: str) -> ttnn.MeshShape:
+    if system_name == "TG":
+        return ttnn.MeshShape(4, 8)
+    elif system_name == "DUAL":
+        return ttnn.MeshShape(8, 8)
+    elif system_name == "QUAD":
+        return ttnn.MeshShape(16, 8)
+    raise ValueError(f"Unsupported system name: {system_name}. Supported values are DUAL, QUAD, and TG.")

--- a/models/demos/deepseek_v3/utils/test_utils.py
+++ b/models/demos/deepseek_v3/utils/test_utils.py
@@ -65,22 +65,21 @@ def get_quant_scale(tensor: torch.Tensor, block_shape: Sequence[int]) -> torch.T
 def dequantize_state_dict(state_dict, hf_config, dtype=torch.bfloat16):
     dequantized_state_dict = {}
 
-    for name, tensor in state_dict.items():
-        if name.endswith("_scale_inv"):
-            continue
+    # Avoid materializing any unneeded tensors by iterating over keys and filtering
+    for name in {k for k in state_dict.keys() if not k.endswith("_scale_inv")}:
+        tensor = state_dict[name]
+        if tensor is None:
+            raise ValueError(f"Expected tensor {name} to exist in state_dict but it was None")
 
-        if tensor is not None:
-            # Look for corresponding scale tensor
-            scale_name = name + "_scale_inv"
-            if scale_name in state_dict:
-                scale_tensor = state_dict[scale_name]
-                # Dequantize using the scale
-                dequantized_tensor = dequantize(
-                    tensor, scale_tensor, hf_config.quantization_config["weight_block_size"]
-                )
-                dequantized_state_dict[name] = dequantized_tensor.to(dtype)
-            else:
-                dequantized_state_dict[name] = tensor.to(dtype)
+        # Look for corresponding scale tensor
+        scale_name = name + "_scale_inv"
+        if scale_name in state_dict:
+            scale_tensor = state_dict[scale_name]
+            # Dequantize using the scale
+            dequantized_tensor = dequantize(tensor, scale_tensor, hf_config.quantization_config["weight_block_size"])
+            dequantized_state_dict[name] = dequantized_tensor.to(dtype)
+        else:
+            dequantized_state_dict[name] = tensor.to(dtype)
 
     return dequantized_state_dict
 


### PR DESCRIPTION
### Summary

This PR removes silent defaults in the DeepSeek-V3 demo and tests, making system selection and model/cache inputs explicit. 

The motivation for this change is to avoid user error by failing fast and providing useful errors messages to improve overall developer productivity.

### What's Changed
- `MESH_DEVICE` must be explicitly set (DUAL, QUAD, or TG); mesh shape is derived via a single utility.
- Demo CLI requires explicit `--model-path` and `--cache-dir`.
- VLLM path initialization now requires DEEPSEEK_V3_HF_MODEL and DEEPSEEK_V3_CACHE to be set (raises clearly if missing).
- Update dequantization to avoid materializing all tensors from the state_dict by using `.keys()` instead of `items()`
Use canonical `ttnn.get_pcie_device_ids()` instead of getting device IDs which seems to have better startup performance.

### Checklist
- [ ] [(Galaxy) DeepSeek tests](https://github.com/tenstorrent/tt-metal/actions/runs/19912620435)