### PR TITLE
Added a fix to the invalid test in test_strided_all_gather_minimal_matmul_async for t3k

### DIFF
--- a/tests/nightly/t3000/ccl/test_strided_all_gather_minimal_matmul_async.py
+++ b/tests/nightly/t3000/ccl/test_strided_all_gather_minimal_matmul_async.py
@@ -253,7 +253,7 @@ def run_strided_all_gather_minimal_matmul_impl(
 
         # Capture the trace
         trace_id = ttnn.begin_trace_capture(mesh_device, cq_id=0)
-        tt_all_gather_out_tensor = run_op(0)
+        tt_all_gather_out_tensor, tt_matmul_out_tensor = run_op(0)
         ttnn.end_trace_capture(mesh_device, trace_id, cq_id=0)
         ttnn.synchronize_device(mesh_device)
         logger.info(f"Done capturing trace")
@@ -264,6 +264,7 @@ def run_strided_all_gather_minimal_matmul_impl(
             ttnn.execute_trace(mesh_device, trace_id, cq_id=0, blocking=False)
             ttnn.synchronize_device(mesh_device)
             tt_all_gather_out_tensor_list.append(tt_all_gather_out_tensor)
+            tt_matmul_out_tensor_list.append(tt_matmul_out_tensor)
         logger.info(f"Done executing trace")
         signpost("stop")
     else:


### PR DESCRIPTION
### Ticket
T3k nightly was failing on an invalid function call

### Problem description
T3k nightly was failing on a bad function call. Problem was traced to the run_op returning a tuple containing the all gather and the matmul tensor, instead of splitting them and writing them to the array to compare expected output the whole tuple was being written when doing trace mode resulting in an invalid call
### What's changed
Patched the issue

t3k nightly run https://github.com/tenstorrent/tt-metal/actions/runs/19908114792