### PR TITLE
[skip ci] Add libc++ to CMakePresets

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -74,6 +74,12 @@
         "targets": ["all"]
       },
       {
+        "name": "dev-libcpp",
+        "configurePreset": "libcpp",
+        "configuration": "Release",
+        "targets": ["all"]
+      },
+      {
         "name": "debug",
         "configurePreset": "default",
         "configuration": "Debug",

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -48,6 +48,16 @@
           "BUILD_TT_TRAIN": {"value": "OFF"}
         },
         "toolchainFile": "cmake/x86_64-linux-gcc-12-toolchain.cmake"
+      },
+      {
+        "name": "libcpp",
+        "inherits": "default",
+        "description": "Build using libc++",
+        "binaryDir": "${sourceDir}/.build/libcpp",
+        "cacheVariables": {
+          "BUILD_TT_TRAIN": {"value": "OFF"}
+        },
+        "toolchainFile": "cmake/x86_64-linux-clang-17-libcpp-toolchain.cmake"
       }
     ],
     "buildPresets": [


### PR DESCRIPTION
### Ticket
N/A

### Problem description
libc++ is more strict than libstdc++, so surprises can show up in CI.

### What's changed
Make it easier to run builds locally against libc++.