### PR TITLE
[Reduce APC] Run ccl from cpp-unit-tests on merge gate

### DIFF
--- a/.github/workflows/all-post-commit-workflows.yaml
+++ b/.github/workflows/all-post-commit-workflows.yaml
@@ -164,7 +164,6 @@ jobs:
       runner-label: ${{ matrix.test-group.runner-label }}
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       gtest_filter: "*-*NIGHTLY_*"
   tt-train-cpp-unit-tests:
     needs: [build-artifact, find-changed-files]

--- a/.github/workflows/apc-select-tests.yaml
+++ b/.github/workflows/apc-select-tests.yaml
@@ -181,7 +181,6 @@ jobs:
       runner-label: ${{ matrix.test-group.runner-label }}
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       enable-watcher: ${{ inputs.enable-watcher || false }}
 
   tt-train-cpp-unit-tests:

--- a/.github/workflows/blackhole-post-commit.yaml
+++ b/.github/workflows/blackhole-post-commit.yaml
@@ -159,7 +159,6 @@ jobs:
       runner-label: ${{ matrix.test-group }}
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       enable-watcher: ${{ inputs.enable-watcher || false }}
       gtest_filter: ${{ contains(inputs.runner-label, 'P100') && '*' || '*-*NIGHTLY_*' }}
   models-unit-tests:

--- a/.github/workflows/cpp-post-commit.yaml
+++ b/.github/workflows/cpp-post-commit.yaml
@@ -84,7 +84,7 @@ jobs:
             requested_cpp_tests=$(jq '[.[] | select(.name == "CCL")]' <<< "$requested_cpp_tests")
             echo "[info] after filtering for merge-gate-call (CCL only): $requested_cpp_tests"
           # Exclude CCL if both nightly-run and merge-gate-call are false
-          elif [[ "${{ inputs.nightly-run }}" == "false" && ("${{ inputs.runner-label }}" == "N150" || "${{ inputs.runner-label }}" == "N300") ]]; then
+          elif [[ "${{ inputs.nightly-run }}" == "false" && ( "${{ inputs.runner-label }}" == "N150" || "${{ inputs.runner-label }}" == "N300" ) ]]; then
             requested_cpp_tests=$(jq '[.[] | select(.name != "CCL")]' <<< "$requested_cpp_tests")
             echo "[info] after filtering out CCL for regular post-commit: $requested_cpp_tests"
           fi

--- a/.github/workflows/cpp-post-commit.yaml
+++ b/.github/workflows/cpp-post-commit.yaml
@@ -19,9 +19,6 @@ on:
       build-artifact-name:
         required: true
         type: string
-      wheel-artifact-name:
-        required: true
-        type: string
       enable-watcher:
         description: 'Enable watcher'
         default: false
@@ -33,6 +30,10 @@ on:
         description: "Filter for gtest"
       nightly-run:
         description: 'Is this a nightly run'
+        required: false
+        type: boolean
+        default: false
+      merge-gate-call:
         required: false
         type: boolean
         default: false
@@ -78,6 +79,16 @@ jobs:
           requested_cpp_tests=$(jq --argjson nightly_run "${{ inputs.nightly-run }}" '[.[] | select(.nightly == $nightly_run)]' <<< "$requested_cpp_tests")
           echo "[info] after filtering for requested workflow tests: $requested_cpp_tests"
 
+          # Filter for merge-gate-call: only keep CCL tests
+          if [[ "${{ inputs.merge-gate-call }}" == "true" ]]; then
+            requested_cpp_tests=$(jq '[.[] | select(.name == "CCL")]' <<< "$requested_cpp_tests")
+            echo "[info] after filtering for merge-gate-call (CCL only): $requested_cpp_tests"
+          # Exclude CCL if both nightly-run and merge-gate-call are false
+          elif [[ "${{ inputs.nightly-run }}" == "false" && ("${{ inputs.runner-label }}" == "N150" || "${{ inputs.runner-label }}" == "N300") ]]; then
+            requested_cpp_tests=$(jq '[.[] | select(.name != "CCL")]' <<< "$requested_cpp_tests")
+            echo "[info] after filtering out CCL for regular post-commit: $requested_cpp_tests"
+          fi
+
           # Check that we have a valid test list that's not empty
           echo "$requested_cpp_tests" | jq -e 'if type != "array" then error("Not a valid JSON array") elif length == 0 then error("Test list is empty") else . end' && echo "Valid test configs"
           echo "cpp-tests=$(echo $requested_cpp_tests | tr -d '\n')" >> "$GITHUB_OUTPUT"
@@ -121,9 +132,6 @@ jobs:
         timeout-minutes: 10
         with:
           build-artifact-name: ${{ inputs.build-artifact-name }}
-          # Unsure why these C++ tests need the wheel...  a cleanup to do separately
-          # https://github.com/tenstorrent/tt-metal/issues/20166
-          wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
           enable-watcher: ${{ inputs.enable-watcher }}
       - name: ${{ matrix.test-group.name }} tests
         #GH Issue 16167

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -96,12 +96,12 @@ jobs:
         uses: tenstorrent/tt-metal/.github/actions/find-changed-files@v0.63.0
 
   build:
-    # if: ${{ github.ref_name == 'main' ||
-    #         needs.find-changes.outputs.cmake-changed == 'true' ||
-    #         needs.find-changes.outputs.any-code-changed == 'true' ||
-    #         needs.find-changes.outputs.docs-changed == 'true' ||
-    #         needs.find-changes.outputs.build-workflows-changed == 'true'
-    #     }}
+    if: ${{ github.ref_name == 'main' ||
+            needs.find-changes.outputs.cmake-changed == 'true' ||
+            needs.find-changes.outputs.any-code-changed == 'true' ||
+            needs.find-changes.outputs.docs-changed == 'true' ||
+            needs.find-changes.outputs.build-workflows-changed == 'true'
+        }}
     needs: find-changes
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
@@ -319,11 +319,11 @@ jobs:
 
   cpp-merge-gate-tests:
     needs: [build, find-changes]
-    # if: ${{ github.ref_name == 'main' ||
-    #         needs.find-changes.outputs.cmake-changed == 'true' ||
-    #         needs.find-changes.outputs.tt-metalium-changed == 'true' ||
-    #         needs.find-changes.outputs.tt-metalium-or-tt-nn-tests-changed == 'true'
-    #     }}
+    if: ${{ github.ref_name == 'main' ||
+            needs.find-changes.outputs.cmake-changed == 'true' ||
+            needs.find-changes.outputs.tt-metalium-changed == 'true' ||
+            needs.find-changes.outputs.tt-metalium-or-tt-nn-tests-changed == 'true'
+        }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -317,7 +317,7 @@ jobs:
       build-artifact-name: ${{ needs.build.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build.outputs.wheel-artifact-name }}
 
-    cpp-merge-gate-tests:
+  cpp-merge-gate-tests:
     needs: [build, find-changes]
     # if: ${{ github.ref_name == 'main' ||
     #         needs.find-changes.outputs.cmake-changed == 'true' ||

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -96,12 +96,12 @@ jobs:
         uses: tenstorrent/tt-metal/.github/actions/find-changed-files@v0.63.0
 
   build:
-    if: ${{ github.ref_name == 'main' ||
-            needs.find-changes.outputs.cmake-changed == 'true' ||
-            needs.find-changes.outputs.any-code-changed == 'true' ||
-            needs.find-changes.outputs.docs-changed == 'true' ||
-            needs.find-changes.outputs.build-workflows-changed == 'true'
-        }}
+    # if: ${{ github.ref_name == 'main' ||
+    #         needs.find-changes.outputs.cmake-changed == 'true' ||
+    #         needs.find-changes.outputs.any-code-changed == 'true' ||
+    #         needs.find-changes.outputs.docs-changed == 'true' ||
+    #         needs.find-changes.outputs.build-workflows-changed == 'true'
+    #     }}
     needs: find-changes
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
@@ -316,6 +316,29 @@ jobs:
       docker-image: ${{ needs.build.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build.outputs.wheel-artifact-name }}
+
+    cpp-merge-gate-tests:
+    needs: [build, find-changes]
+    # if: ${{ github.ref_name == 'main' ||
+    #         needs.find-changes.outputs.cmake-changed == 'true' ||
+    #         needs.find-changes.outputs.tt-metalium-changed == 'true' ||
+    #         needs.find-changes.outputs.tt-metalium-or-tt-nn-tests-changed == 'true'
+    #     }}
+    strategy:
+      fail-fast: false
+      matrix:
+        test-group: [
+          { arch: wormhole_b0, runner-label: N300 }
+        ]
+    uses: ./.github/workflows/cpp-post-commit.yaml
+    secrets: inherit
+    with:
+      docker-image: ${{ needs.build.outputs.dev-docker-image }}
+      build-artifact-name: ${{ needs.build.outputs.build-artifact-name }}
+      arch: ${{ matrix.test-group.arch }}
+      runner-label: ${{ matrix.test-group.runner-label }}
+      gtest_filter: "*-*NIGHTLY_*"
+      merge-gate-call: true
 
   ttsim-unit-tests:
     if: ${{ github.ref_name == 'main' ||

--- a/.github/workflows/pipeline-select.yaml
+++ b/.github/workflows/pipeline-select.yaml
@@ -106,4 +106,3 @@ jobs:
       runner-label: tt-ubuntu-2204-n300-stable
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}

--- a/.github/workflows/tt-metal-l2-nightly.yaml
+++ b/.github/workflows/tt-metal-l2-nightly.yaml
@@ -142,7 +142,6 @@ jobs:
       runner-label: ${{ matrix.test-group.runner-label }}
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       gtest_filter: "*NIGHTLY_*"
       nightly-run: true
   # Metal IOMMU Unit Tests


### PR DESCRIPTION
### What's changed
Remove ccl in cpp-unit-tests from APC and add it into merge gate

### Checklist
- [x] Merge-gate CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/19910469609

- [x] All post commit CI run: https://github.com/tenstorrent/tt-metal/actions/runs/19936699571
- [x] BHPC CI run: https://github.com/tenstorrent/tt-metal/actions/runs/19869073129

On average this jobs adds about 6 mins to merge-gate.

Average job runtime in the past 7 days
<img width="1393" height="498" alt="Screenshot 2025-12-02 at 9 29 17 AM" src="https://github.com/user-attachments/assets/e9954606-5335-44e9-887a-2205a1a61236" />

Job failure is rates are 0% in the past 7 days
<img width="686" height="813" alt="Screenshot 2025-12-02 at 9 28 40 AM" src="https://github.com/user-attachments/assets/ded4f455-d476-4a35-908d-4959526354ee" />