### PR TITLE
#33711: Add semaphore ID to program descriptor

### DIFF
--- a/models/demos/deepseek_v3_b1/micro_ops/gather/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/gather/op.py
@@ -102,17 +102,14 @@ class GatherSingleCore:
                     noc1_cores.append(core)
 
         # Create semaphores
-        # Note: semaphore_ids 0 and 1 are used for NOC0 and NOC1 receivers respectively
-        # TODO: Add semaphore_ids to semaphore descriptor to ensure we are using the correct semaphore ids (#33711)
-        noc0_receiver_semaphore_id = 0
-        noc1_receiver_semaphore_id = 1
-
         noc0_receiver_semaphore_descriptor = ttnn.SemaphoreDescriptor(
+            id=0,
             core_ranges=all_cores,
             initial_value=0,
         )
 
         noc1_receiver_semaphore_descriptor = ttnn.SemaphoreDescriptor(
+            id=1,
             core_ranges=all_cores,
             initial_value=0,
         )
@@ -137,8 +134,8 @@ class GatherSingleCore:
             receiver_compile_args = [
                 len(noc0_cores),
                 len(noc1_cores),
-                noc0_receiver_semaphore_id,
-                noc1_receiver_semaphore_id,
+                noc0_receiver_semaphore_descriptor.id,
+                noc1_receiver_semaphore_descriptor.id,
             ]
 
             receiver_kernel_descriptor = ttnn.KernelDescriptor(
@@ -184,7 +181,7 @@ class GatherSingleCore:
             0,  # semaphore (will be set per NOC)
         ]
         if not noc0_core_range_set.empty():
-            sender_compile_args[3] = noc0_receiver_semaphore_id
+            sender_compile_args[3] = noc0_receiver_semaphore_descriptor.id
             sender_noc0_kernel_descriptor = ttnn.KernelDescriptor(
                 kernel_source=sender_kernel_path,
                 source_type=ttnn.KernelDescriptor.SourceType.FILE_PATH,
@@ -199,7 +196,7 @@ class GatherSingleCore:
             kernels.append(sender_noc0_kernel_descriptor)
 
         if not noc1_core_range_set.empty():
-            sender_compile_args[3] = noc1_receiver_semaphore_id
+            sender_compile_args[3] = noc1_receiver_semaphore_descriptor.id
             sender_noc1_kernel_descriptor = ttnn.KernelDescriptor(
                 kernel_source=sender_kernel_path,
                 source_type=ttnn.KernelDescriptor.SourceType.FILE_PATH,

--- a/tests/ttnn/unit_tests/gtests/test_generic_op.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_generic_op.cpp
@@ -886,4 +886,172 @@ TEST_F(TTNNFixtureWithDevice, TestGenericOpProgramCache) {
         this->device_->num_program_cache_entries());
 }
 
+TEST_F(TTNNFixtureWithDevice, TestGenericOpSemaphoreDescriptorValidId) {
+    // Test that valid semaphore IDs work correctly
+    log_info(tt::LogTest, "Running {}", __func__);
+
+    ttnn::Shape shape{1, 1, tt::constants::TILE_HEIGHT, tt::constants::TILE_WIDTH};
+    Tensor input_tensor = ttnn::random::random(shape, DataType::BFLOAT16);
+    Tensor device_input_tensor = input_tensor.to_layout(Layout::TILE).to_device(this->device_);
+    Tensor device_output_tensor = tt::tt_metal::create_device_tensor(device_input_tensor.tensor_spec(), this->device_);
+
+    auto input_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(device_input_tensor.dtype());
+    uint32_t num_tiles = device_input_tensor.physical_volume() / tt::constants::TILE_HW;
+
+    CoreCoord core = {0, 0};
+    CoreRange core_range = {core, core};
+    CoreRangeSet device_cores = CoreRangeSet(core_range);
+    tt::CBIndex cb_in_id = tt::CBIndex::c_0;
+    tt::CBIndex cb_out_id = tt::CBIndex::c_16;
+
+    CBDescriptor input_cb_descriptor = {
+        .total_size = 2 * tt::tile_size(input_cb_data_format),
+        .core_ranges = device_cores,
+        .format_descriptors = {{cb_in_id, input_cb_data_format, tt::tile_size(input_cb_data_format)}},
+    };
+    CBDescriptor output_cb_descriptor = {
+        .total_size = 2 * tt::tile_size(input_cb_data_format),
+        .core_ranges = device_cores,
+        .format_descriptors = {{cb_out_id, input_cb_data_format, tt::tile_size(input_cb_data_format)}},
+    };
+
+    SemaphoreDescriptor sem_descriptor_0 = {
+        .core_type = tt::CoreType::WORKER,
+        .core_ranges = device_cores,
+        .initial_value = 0,
+        .id = 0,
+    };
+    SemaphoreDescriptor sem_descriptor_1 = {
+        .core_type = tt::CoreType::WORKER,
+        .core_ranges = device_cores,
+        .initial_value = 1,
+        .id = 1,
+    };
+
+    KernelDescriptor::CompileTimeArgs reader_ct_args;
+    TensorAccessorArgs(*device_input_tensor.buffer()).append_to(reader_ct_args);
+    KernelDescriptor::CompileTimeArgs writer_ct_args = {(uint32_t)cb_out_id};
+    TensorAccessorArgs(*device_output_tensor.buffer()).append_to(writer_ct_args);
+
+    const std::vector<std::pair<std::string, std::string>> sfpu_defines = {
+        {"SFPU_OP_EXP_INCLUDE", "1"}, {"SFPU_OP_CHAIN_0", "exp_tile_init(); exp_tile(0);"}};
+
+    ProgramDescriptor program_descriptor = {
+        .kernels =
+            {{
+                 .kernel_source = "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/"
+                                  "reader_unary_interleaved_start_id.cpp",
+                 .core_ranges = device_cores,
+                 .compile_time_args = reader_ct_args,
+                 .runtime_args = {{{device_input_tensor.buffer()->address(), num_tiles, 0u}}},
+                 .config = tt::tt_metal::ReaderConfigDescriptor{},
+             },
+             {
+                 .kernel_source = "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/"
+                                  "writer_unary_interleaved_start_id.cpp",
+                 .core_ranges = device_cores,
+                 .compile_time_args = writer_ct_args,
+                 .runtime_args = {{{device_output_tensor.buffer()->address(), num_tiles, 0u}}},
+                 .config = tt::tt_metal::WriterConfigDescriptor{},
+             },
+             {
+                 .kernel_source = "tt_metal/kernels/compute/eltwise_sfpu.cpp",
+                 .core_ranges = device_cores,
+                 .compile_time_args = {num_tiles, 1},
+                 .defines = sfpu_defines,
+                 .runtime_args = {{{}}},
+                 .config = tt::tt_metal::ComputeConfigDescriptor{},
+             }},
+        .semaphores = {sem_descriptor_0, sem_descriptor_1},
+        .cbs = {input_cb_descriptor, output_cb_descriptor},
+    };
+
+    ttnn::generic_op(std::vector{device_input_tensor, device_output_tensor}, program_descriptor);
+    Tensor golden = ttnn::exp(device_input_tensor);
+    ASSERT_TRUE(ttnn::allclose<bfloat16>(golden.cpu(), device_output_tensor.cpu()));
+}
+
+TEST_F(TTNNFixtureWithDevice, TestGenericOpSemaphoreDescriptorInvalidIdExceedsMax) {
+    // Test that semaphore ID exceeding NUM_SEMAPHORES (16) throws an error
+    log_info(tt::LogTest, "Running {}", __func__);
+
+    CoreCoord core = {0, 0};
+    CoreRange core_range = {core, core};
+    CoreRangeSet device_cores = CoreRangeSet(core_range);
+
+    SemaphoreDescriptor invalid_sem_descriptor = {
+        .core_type = tt::CoreType::WORKER,
+        .core_ranges = device_cores,
+        .initial_value = 0,
+        .id = 16,
+    };
+
+    ProgramDescriptor program_descriptor = {
+        .kernels = {},
+        .semaphores = {invalid_sem_descriptor},
+        .cbs = {},
+    };
+
+    EXPECT_THROW({ tt::tt_metal::Program program(program_descriptor); }, std::exception);
+}
+
+TEST_F(TTNNFixtureWithDevice, TestGenericOpSemaphoreDescriptorDuplicateIdOnOverlappingCores) {
+    // Test that duplicate semaphore IDs on overlapping cores throw an error
+    log_info(tt::LogTest, "Running {}", __func__);
+
+    CoreCoord core = {0, 0};
+    CoreRange core_range = {core, core};
+    CoreRangeSet device_cores = CoreRangeSet(core_range);
+
+    SemaphoreDescriptor sem_descriptor_0 = {
+        .core_type = tt::CoreType::WORKER,
+        .core_ranges = device_cores,
+        .initial_value = 0,
+        .id = 0,
+    };
+    SemaphoreDescriptor sem_descriptor_duplicate = {
+        .core_type = tt::CoreType::WORKER,
+        .core_ranges = device_cores,
+        .initial_value = 1,
+        .id = 0,
+    };
+
+    ProgramDescriptor program_descriptor = {
+        .kernels = {},
+        .semaphores = {sem_descriptor_0, sem_descriptor_duplicate},
+        .cbs = {},
+    };
+
+    EXPECT_THROW({ tt::tt_metal::Program program(program_descriptor); }, std::exception);
+}
+
+TEST_F(TTNNFixtureWithDevice, TestGenericOpSemaphoreDescriptorSameIdNonOverlappingCores) {
+    // Test that same semaphore ID on non-overlapping cores is allowed
+    log_info(tt::LogTest, "Running {}", __func__);
+
+    CoreRangeSet cores_0 = CoreRangeSet(CoreRange({0, 0}, {0, 0}));
+    CoreRangeSet cores_1 = CoreRangeSet(CoreRange({1, 0}, {1, 0}));
+
+    SemaphoreDescriptor sem_on_core_0 = {
+        .core_type = tt::CoreType::WORKER,
+        .core_ranges = cores_0,
+        .initial_value = 0,
+        .id = 0,
+    };
+    SemaphoreDescriptor sem_on_core_1 = {
+        .core_type = tt::CoreType::WORKER,
+        .core_ranges = cores_1,
+        .initial_value = 1,
+        .id = 0,
+    };
+
+    ProgramDescriptor program_descriptor = {
+        .kernels = {},
+        .semaphores = {sem_on_core_0, sem_on_core_1},
+        .cbs = {},
+    };
+
+    EXPECT_NO_THROW({ tt::tt_metal::Program program(program_descriptor); });
+}
+
 }  // namespace ttnn::operations::generic::test

--- a/tt_metal/api/tt-metalium/program_descriptors.hpp
+++ b/tt_metal/api/tt-metalium/program_descriptors.hpp
@@ -139,8 +139,6 @@ struct ProgramDescriptor {
     SemaphoreDescriptors semaphores;
     CBDescriptors cbs;
     std::optional<ttsl::hash::hash_t> custom_program_hash;
-
-    uint32_t add_semaphore(CoreRangeSet core_ranges, uint32_t initial_value, CoreType core_type = CoreType::WORKER);
 };
 
 }  // namespace tt::tt_metal

--- a/tt_metal/api/tt-metalium/program_descriptors.hpp
+++ b/tt_metal/api/tt-metalium/program_descriptors.hpp
@@ -67,7 +67,7 @@ struct CBDescriptor {
 };
 
 struct SemaphoreDescriptor {
-    uint32_t id;
+    uint32_t id{};
     CoreType core_type = CoreType::WORKER;
     CoreRangeSet core_ranges;
     uint32_t initial_value = 0;

--- a/tt_metal/api/tt-metalium/program_descriptors.hpp
+++ b/tt_metal/api/tt-metalium/program_descriptors.hpp
@@ -67,7 +67,7 @@ struct CBDescriptor {
 };
 
 struct SemaphoreDescriptor {
-    uint8_t id;
+    uint32_t id;
     CoreType core_type = CoreType::WORKER;
     CoreRangeSet core_ranges;
     uint32_t initial_value = 0;

--- a/tt_metal/api/tt-metalium/program_descriptors.hpp
+++ b/tt_metal/api/tt-metalium/program_descriptors.hpp
@@ -67,10 +67,10 @@ struct CBDescriptor {
 };
 
 struct SemaphoreDescriptor {
+    uint8_t id;
     CoreType core_type = CoreType::WORKER;
     CoreRangeSet core_ranges;
     uint32_t initial_value = 0;
-    uint32_t id;
 };
 
 struct ReaderConfigDescriptor {};

--- a/tt_metal/api/tt-metalium/program_descriptors.hpp
+++ b/tt_metal/api/tt-metalium/program_descriptors.hpp
@@ -70,6 +70,7 @@ struct SemaphoreDescriptor {
     CoreType core_type = CoreType::WORKER;
     CoreRangeSet core_ranges;
     uint32_t initial_value = 0;
+    uint32_t id;
 };
 
 struct ReaderConfigDescriptor {};

--- a/tt_metal/impl/program/program_descriptors.cpp
+++ b/tt_metal/impl/program/program_descriptors.cpp
@@ -12,9 +12,4 @@ namespace tt::tt_metal {
 TileDescriptor::TileDescriptor(const Tile& tile) :
     height(tile.get_height()), width(tile.get_width()), transpose(tile.get_transpose_of_faces()) {}
 
-uint32_t ProgramDescriptor::add_semaphore(CoreRangeSet core_ranges, uint32_t initial_value, CoreType core_type) {
-    semaphores.emplace_back(core_type, std::move(core_ranges), initial_value);
-    return semaphores.size() - 1;
-}
-
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/program/program_impl.hpp
+++ b/tt_metal/impl/program/program_impl.hpp
@@ -279,6 +279,9 @@ public:
 
     void add_semaphore(const CoreRangeSet& crs, uint32_t semaphore_id, uint32_t init_value, CoreType core_type);
 
+    // Validates that a semaphore ID is within bounds and not already in use on overlapping cores
+    void validate_semaphore_id(const CoreRangeSet& crs, uint32_t semaphore_id, CoreType core_type) const;
+
     bool runs_on_noc_unicast_only_cores();
     bool runs_on_noc_multicast_only_cores();
 

--- a/ttnn/cpp/ttnn-pybind/program_descriptors.cpp
+++ b/ttnn/cpp/ttnn-pybind/program_descriptors.cpp
@@ -381,7 +381,7 @@ void py_module_types(py::module& module) {
         Default constructor for SemaphoreDescriptor.
     )pbdoc")
         .def(
-            py::init<uint8_t, tt::CoreType, CoreRangeSet, uint32_t>(),
+            py::init<uint32_t, tt::CoreType, CoreRangeSet, uint32_t>(),
             py::arg("id"),
             py::arg("core_type") = tt::CoreType::WORKER,
             py::arg("core_ranges"),

--- a/ttnn/cpp/ttnn-pybind/program_descriptors.cpp
+++ b/ttnn/cpp/ttnn-pybind/program_descriptors.cpp
@@ -381,19 +381,19 @@ void py_module_types(py::module& module) {
         Default constructor for SemaphoreDescriptor.
     )pbdoc")
         .def(
-            py::init<tt::CoreType, CoreRangeSet, uint32_t, uint32_t>(),
+            py::init<uint8_t, tt::CoreType, CoreRangeSet, uint32_t>(),
+            py::arg("id"),
             py::arg("core_type") = tt::CoreType::WORKER,
             py::arg("core_ranges"),
             py::arg("initial_value"),
-            py::arg("id"),
             R"pbdoc(
-                Initialize a SemaphoreDescriptor with core type, core ranges, initial value, and id.
+                Initialize a SemaphoreDescriptor with id, core type, core ranges, and initial value.
             )pbdoc")
+        .def_readonly("id", &tt::tt_metal::SemaphoreDescriptor::id, "Semaphore ID")
         .def_readwrite("core_type", &tt::tt_metal::SemaphoreDescriptor::core_type, "Type of core for the semaphore")
         .def_readwrite("core_ranges", &tt::tt_metal::SemaphoreDescriptor::core_ranges, "Core ranges for the semaphore")
         .def_readwrite(
-            "initial_value", &tt::tt_metal::SemaphoreDescriptor::initial_value, "Initial value for the semaphore")
-        .def_readonly("id", &tt::tt_metal::SemaphoreDescriptor::id, "Semaphore ID");
+            "initial_value", &tt::tt_metal::SemaphoreDescriptor::initial_value, "Initial value for the semaphore");
 
     py::class_<tt::tt_metal::ProgramDescriptor>(module, "ProgramDescriptor", R"pbdoc(
         Descriptor for a complete program.

--- a/ttnn/cpp/ttnn-pybind/program_descriptors.cpp
+++ b/ttnn/cpp/ttnn-pybind/program_descriptors.cpp
@@ -381,17 +381,19 @@ void py_module_types(py::module& module) {
         Default constructor for SemaphoreDescriptor.
     )pbdoc")
         .def(
-            py::init<tt::CoreType, CoreRangeSet, uint32_t>(),
+            py::init<tt::CoreType, CoreRangeSet, uint32_t, uint32_t>(),
             py::arg("core_type") = tt::CoreType::WORKER,
             py::arg("core_ranges"),
             py::arg("initial_value"),
+            py::arg("id"),
             R"pbdoc(
-                Initialize a SemaphoreDescriptor with core type, core ranges, and initial value.
+                Initialize a SemaphoreDescriptor with core type, core ranges, initial value, and id.
             )pbdoc")
         .def_readwrite("core_type", &tt::tt_metal::SemaphoreDescriptor::core_type, "Type of core for the semaphore")
         .def_readwrite("core_ranges", &tt::tt_metal::SemaphoreDescriptor::core_ranges, "Core ranges for the semaphore")
         .def_readwrite(
-            "initial_value", &tt::tt_metal::SemaphoreDescriptor::initial_value, "Initial value for the semaphore");
+            "initial_value", &tt::tt_metal::SemaphoreDescriptor::initial_value, "Initial value for the semaphore")
+        .def_readonly("id", &tt::tt_metal::SemaphoreDescriptor::id, "Semaphore ID");
 
     py::class_<tt::tt_metal::ProgramDescriptor>(module, "ProgramDescriptor", R"pbdoc(
         Descriptor for a complete program.


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/33711)

### Problem description
Currently with python generic ops, `SemaphoreDescriptor` is passed into `ProgramDescriptor`, which selects unique IDs for each semaphore regardless of the core ranges. We also cannot currently access semaphore ID from the descriptor, which needs to be passed into kernels. The current workaround creates multiple sources of truth by initializing local semaphore ID variables that are decoupled from the descriptors. We want to be able to pass the ID into the descriptor, validate it, and store it so it can be passed to kernel descriptors.

### What's changed

- `id` field added to `SemaphoreDescriptor` struct
- Updated `SemaphoreDescriptor` constructor pybind
- Logic for checking semaphore ID validity
    - Must be less than `NUM_SEMAPHORES` (16)
    - Must not exist already for an overlapping core range
- Added cpp unit tests for valid and invalid semaphore IDs
- Deleted unused `add_semaphore` function in ProgramDescriptor

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes ([link to run](https://github.com/tenstorrent/tt-metal/actions/runs/19970350388))
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes