### PR TITLE
TT-Fabric Intermesh Traffic VC (VC1) Support [1/n]

### DIFF
--- a/tt_metal/fabric/builder/fabric_builder_config.cpp
+++ b/tt_metal/fabric/builder/fabric_builder_config.cpp
@@ -14,6 +14,10 @@ uint32_t get_sender_channel_count(const bool is_2D_routing) {
     return is_2D_routing ? builder_config::num_sender_channels_2d : builder_config::num_sender_channels_1d;
 }
 
+uint32_t get_receiver_channel_count(const bool is_2D_routing) {
+    return is_2D_routing ? builder_config::num_receiver_channels_2d : builder_config::num_receiver_channels_1d;
+}
+
 uint32_t get_num_tensix_sender_channels(Topology topology, tt::tt_fabric::FabricTensixConfig fabric_tensix_config) {
     // TODO: once we support inserting tensix as downstream in UDM mode, add back the channel count for UDM mode
     TT_FATAL(
@@ -38,11 +42,16 @@ uint32_t get_num_tensix_sender_channels(Topology topology, tt::tt_fabric::Fabric
 }
 
 uint32_t get_downstream_edm_count(bool is_2D_routing) {
-    return is_2D_routing ? builder_config::num_downstream_edms_2d : builder_config::num_downstream_edms;
+    return is_2D_routing ? builder_config::num_downstream_edms_2d : builder_config::num_downstream_edms_1d;
 }
 
 uint32_t get_vc0_downstream_edm_count(bool is_2D_routing) {
     return is_2D_routing ? builder_config::num_downstream_edms_2d_vc0 : builder_config::num_downstream_edms_vc0;
+}
+
+uint32_t get_vc1_downstream_edm_count(bool is_2D_routing) {
+    TT_FATAL(is_2D_routing == true, "VC1 is only supported for 2D routing");
+    return builder_config::num_downstream_edms_2d_vc1;
 }
 
 }  // namespace builder_config

--- a/tt_metal/fabric/builder/fabric_builder_config.cpp
+++ b/tt_metal/fabric/builder/fabric_builder_config.cpp
@@ -50,7 +50,7 @@ uint32_t get_vc0_downstream_edm_count(bool is_2D_routing) {
 }
 
 uint32_t get_vc1_downstream_edm_count(bool is_2D_routing) {
-    TT_FATAL(is_2D_routing == true, "VC1 is only supported for 2D routing");
+    TT_FATAL(is_2D_routing, "VC1 is only supported for 2D routing");
     return builder_config::num_downstream_edms_2d_vc1;
 }
 

--- a/tt_metal/fabric/builder/fabric_builder_config.hpp
+++ b/tt_metal/fabric/builder/fabric_builder_config.hpp
@@ -74,6 +74,8 @@ uint32_t get_downstream_edm_count(bool is_2D_routing);
 
 uint32_t get_vc0_downstream_edm_count(bool is_2D_routing);
 
+uint32_t get_vc1_downstream_edm_count(bool is_2D_routing);
+
 }  // namespace builder_config
 
 /**

--- a/tt_metal/fabric/builder/fabric_builder_config.hpp
+++ b/tt_metal/fabric/builder/fabric_builder_config.hpp
@@ -49,19 +49,24 @@ static constexpr std::size_t num_sender_channels_1d_ring = 2;
 static constexpr std::size_t num_sender_channels_2d_torus = 4;
 
 static constexpr std::size_t num_sender_channels_1d = 2;
-static constexpr std::size_t num_sender_channels_2d = 4;
+static constexpr std::size_t num_sender_channels_2d = 7;
 static constexpr std::size_t num_sender_channels = std::max(num_sender_channels_1d, num_sender_channels_2d);
-static constexpr std::size_t num_downstream_sender_channels = num_sender_channels - 1;
+// static constexpr std::size_t num_downstream_sender_channels = num_sender_channels - 1;
 
-static constexpr std::size_t num_receiver_channels = 1;
+static constexpr std::size_t num_receiver_channels_1d = 1;
+static constexpr std::size_t num_receiver_channels_2d = 1;
+static constexpr std::size_t num_receiver_channels = std::max(num_receiver_channels_1d, num_receiver_channels_2d);
 
 static constexpr std::size_t num_downstream_edms_vc0 = 1;
 static constexpr std::size_t num_downstream_edms_2d_vc0 = 3;
-static constexpr std::size_t num_downstream_edms = num_downstream_edms_vc0;
-static constexpr std::size_t num_downstream_edms_2d = num_downstream_edms_2d_vc0;
-static constexpr std::size_t max_downstream_edms = std::max(num_downstream_edms, num_downstream_edms_2d);
+static constexpr std::size_t num_downstream_edms_2d_vc1 = 3;
+static constexpr std::size_t num_downstream_edms_1d = num_downstream_edms_vc0;
+static constexpr std::size_t num_downstream_edms_2d = num_downstream_edms_2d_vc0 + num_downstream_edms_2d_vc1;
+static constexpr std::size_t max_downstream_edms = std::max(num_downstream_edms_1d, num_downstream_edms_2d);
 
 uint32_t get_sender_channel_count(bool is_2D_routing);
+
+uint32_t get_receiver_channel_count(bool is_2D_routing);
 
 uint32_t get_num_tensix_sender_channels(Topology topology, tt::tt_fabric::FabricTensixConfig fabric_tensix_config);
 

--- a/tt_metal/fabric/builder/fabric_builder_config.hpp
+++ b/tt_metal/fabric/builder/fabric_builder_config.hpp
@@ -51,8 +51,6 @@ static constexpr std::size_t num_sender_channels_2d_torus = 4;
 static constexpr std::size_t num_sender_channels_1d = 2;
 static constexpr std::size_t num_sender_channels_2d = 7;
 static constexpr std::size_t num_sender_channels = std::max(num_sender_channels_1d, num_sender_channels_2d);
-// static constexpr std::size_t num_downstream_sender_channels = num_sender_channels - 1;
-
 static constexpr std::size_t num_receiver_channels_1d = 1;
 static constexpr std::size_t num_receiver_channels_2d = 2;
 static constexpr std::size_t num_receiver_channels = std::max(num_receiver_channels_1d, num_receiver_channels_2d);

--- a/tt_metal/fabric/builder/fabric_builder_config.hpp
+++ b/tt_metal/fabric/builder/fabric_builder_config.hpp
@@ -54,7 +54,7 @@ static constexpr std::size_t num_sender_channels = std::max(num_sender_channels_
 // static constexpr std::size_t num_downstream_sender_channels = num_sender_channels - 1;
 
 static constexpr std::size_t num_receiver_channels_1d = 1;
-static constexpr std::size_t num_receiver_channels_2d = 1;
+static constexpr std::size_t num_receiver_channels_2d = 2;
 static constexpr std::size_t num_receiver_channels = std::max(num_receiver_channels_1d, num_receiver_channels_2d);
 
 static constexpr std::size_t num_downstream_edms_vc0 = 1;

--- a/tt_metal/fabric/builder/static_sized_channel_connection_writer_adapter.cpp
+++ b/tt_metal/fabric/builder/static_sized_channel_connection_writer_adapter.cpp
@@ -81,14 +81,20 @@ void StaticSizedChannelConnectionWriterAdapter::add_local_tensix_connection(
     this->relay_connection_info.is_connected = true;
 }
 
-void StaticSizedChannelConnectionWriterAdapter::pack_inbound_channel_rt_args(uint32_t vc_idx, std::vector<uint32_t>& args_out) const {
-    TT_FATAL(vc_idx == 0, "VC1 is not supported for static-sized channel connection writer adapter");
+void StaticSizedChannelConnectionWriterAdapter::pack_inbound_channel_rt_args(
+    uint32_t vc_idx, std::vector<uint32_t>& args_out) const {
     if (is_2D_routing) {
-        // For VC0 in 2D: pack connection mask and data for 3 downstream EDMs
-        args_out.push_back(this->downstream_edms_connected);  // 3-bit mask
+        // For 2D: Temporary, until support for VC1 is added
+        TT_FATAL(vc_idx == 0, "VC1 is not supported for 2D routing");
+        // Get the appropriate downstream EDM count based on VC index
+        uint32_t num_downstream_edms = (vc_idx == 0) ? builder_config::get_vc0_downstream_edm_count(is_2D_routing)
+                                                     : builder_config::get_vc1_downstream_edm_count(is_2D_routing);
 
-        // Pack 3 buffer base addresses (one per compact index 0-2)
-        for (size_t compact_idx = 0; compact_idx < builder_config::num_downstream_edms_2d_vc0; compact_idx++) {
+        // Pack connection mask (3-bit mask for 3 downstream EDMs)
+        args_out.push_back(this->downstream_edms_connected);
+
+        // Pack buffer base addresses (one per compact index)
+        for (size_t compact_idx = 0; compact_idx < num_downstream_edms; compact_idx++) {
             uint32_t buffer_addr = this->downstream_edm_buffer_base_addresses[vc_idx][compact_idx].value_or(0);
             args_out.push_back(buffer_addr);
         }
@@ -97,22 +103,23 @@ void StaticSizedChannelConnectionWriterAdapter::pack_inbound_channel_rt_args(uin
         args_out.push_back(this->pack_downstream_noc_x_rt_arg(vc_idx));
         args_out.push_back(this->pack_downstream_noc_y_rt_arg(vc_idx));
 
-        // Pack 3 worker registration addresses (connection handshake addresses)
-        for (size_t compact_idx = 0; compact_idx < builder_config::num_downstream_edms_2d_vc0; compact_idx++) {
+        // Pack worker registration addresses (connection handshake addresses)
+        for (size_t compact_idx = 0; compact_idx < num_downstream_edms; compact_idx++) {
             args_out.push_back(this->downstream_edm_worker_registration_addresses[vc_idx][compact_idx].value_or(0));
         }
 
-        // Pack 3 worker location info addresses
-        for (size_t compact_idx = 0; compact_idx < builder_config::num_downstream_edms_2d_vc0; compact_idx++) {
+        // Pack worker location info addresses
+        for (size_t compact_idx = 0; compact_idx < num_downstream_edms; compact_idx++) {
             args_out.push_back(this->downstream_edm_worker_location_info_addresses[vc_idx][compact_idx].value_or(0));
         }
 
-        // Pack 3 buffer index semaphore addresses
-        for (size_t compact_idx = 0; compact_idx < builder_config::num_downstream_edms_2d_vc0; compact_idx++) {
+        // Pack buffer index semaphore addresses
+        for (size_t compact_idx = 0; compact_idx < num_downstream_edms; compact_idx++) {
             args_out.push_back(this->downstream_edm_buffer_index_semaphore_addresses[vc_idx][compact_idx].value_or(0));
         }
     } else {
-        // For 1D: single downstream connection (backward compatible)
+        // For 1D: single downstream connection (only VC0 supported)
+        TT_FATAL(vc_idx == 0, "VC1 is not supported for 1D routing");
         bool has_connection = this->downstream_edms_connected != 0;
 
         uint32_t buffer_addr = this->downstream_edm_buffer_base_addresses[vc_idx][0].value_or(0);

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -58,6 +58,7 @@
 #include "tt_metal/fabric/serialization/intermesh_connections_serialization.hpp"
 #include <tt-metalium/experimental/fabric/topology_mapper.hpp>
 #include "tt_metal/fabric/builder/fabric_static_sized_channels_allocator.hpp"
+#include "tt_metal/fabric/hw/inc/edm_fabric/fabric_connection_interface.hpp"
 
 namespace tt::tt_fabric {
 
@@ -2138,7 +2139,8 @@ void ControlPlane::populate_fabric_connection_info(
     tt::tt_fabric::fabric_connection_info_t& tensix_connection_info,
     ChipId physical_chip_id,
     chan_id_t eth_channel_id) const {
-    constexpr uint16_t WORKER_FREE_SLOTS_STREAM_ID = 17;
+    constexpr uint16_t WORKER_FREE_SLOTS_STREAM_ID =
+        tt::tt_fabric::connection_interface::sender_channel_0_free_slots_stream_id;
     const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
     const auto& fabric_context = this->get_fabric_context();
     // Sender channel 0 is always for local worker in the new design

--- a/tt_metal/fabric/debug/README.md
+++ b/tt_metal/fabric/debug/README.md
@@ -59,17 +59,17 @@ python3 tt_metal/fabric/debug/fabric_erisc_dumper.py --fabric-streams --stream-g
 The tool provides specialized fabric stream register modes for different aspects of fabric debugging:
 
 #### Flow Control Debugging (Buffer Free Slots)
-- **`sender_free_slots`**: Monitor sender channel buffer space (streams 17-21)
-- **`receiver_free_slots`**: Monitor receiver channel buffer space (streams 12-16)
+- **`sender_free_slots`**: Monitor sender channel buffer space (streams 19-25)
+- **`receiver_free_slots`**: Monitor receiver channel buffer space (streams 13-18)
 - **`all_fabric_free_slots`**: Complete view of all fabric flow control registers (DEFAULT)
 
 **Interpretation:** HIGH values = good (buffers have space for more packets)
 
 #### Acknowledgment and Completion Stream Monitoring (Remote Buffer Status)
-- **`sender_acks`**: Monitor ack stream remote buffer status (streams 2-6)
-- **`sender_completions`**: Monitor completion stream remote buffer status (streams 7-11)
+- **`sender_acks`**: Monitor ack stream remote buffer status (streams 2-5)
+- **`sender_completions`**: Monitor completion stream remote buffer status (streams 6-12)
 - **`receiver_pkts_sent`**: Monitor packet sent stream remote buffer status (streams 0-1)
-- **`all_acks_and_completions`**: Combined view of all ack/completion streams (streams 2-11)
+- **`all_acks_and_completions`**: Combined view of all ack/completion streams (streams 2-12)
 
 **Interpretation:** LOW/ZERO values = good (remote side consuming acks/completions immediately)
 These streams send credits/acks to remote routers. The BUF_SPACE_AVAILABLE register shows buffer space at the remote destination. Zero means the remote side is processing immediately (expected when idle or running smoothly). **Increasing values may indicate the remote side is NOT consuming acks/completions**

--- a/tt_metal/fabric/debug/fabric_erisc_constants.py
+++ b/tt_metal/fabric/debug/fabric_erisc_constants.py
@@ -83,32 +83,42 @@ STREAM_REGISTER_INDICES = {
 FABRIC_STREAM_GROUPS = {
     # ========== Buffer Free Slots (Flow Control) ==========
     "sender_free_slots": {
-        "stream_ids": [17, 18, 19, 20, 21],
-        "labels": ["sender_ch0", "sender_ch1", "sender_ch2", "sender_ch3", "sender_ch4_vc1"],
+        "stream_ids": [17, 18, 19, 20, 21, 22, 23],
+        "labels": ["sender_ch0", "sender_ch1", "sender_ch2", "sender_ch3", "sender_ch4", "sender_ch5", "sender_ch6"],
         "title": "SENDER CHANNEL FREE SLOTS",
         "description": "Fabric sender channel buffer space available (free slots) for flow control",
         "register_type": "BUF_SPACE_AVAILABLE",
     },
     "receiver_free_slots": {
-        "stream_ids": [12, 13, 14, 15, 16],
-        "labels": ["recv_east", "recv_west", "recv_north", "recv_south", "recv_downstream_vc1"],
+        "stream_ids": [12, 13, 14, 24, 25, 26],
+        "labels": [
+            "recv_vc0_edge1",
+            "recv_vc0_edge2",
+            "recv_vc0_edge3",
+            "recv_vc1_edge1",
+            "recv_vc1_edge2",
+            "recv_vc1_edge3",
+        ],
         "title": "RECEIVER CHANNEL FREE SLOTS",
         "description": "Fabric receiver channel buffer space available (free slots) for flow control",
         "register_type": "BUF_SPACE_AVAILABLE",
     },
     "all_fabric_free_slots": {
-        "stream_ids": [12, 13, 14, 15, 16, 17, 18, 19, 20, 21],
+        "stream_ids": [12, 13, 14, 24, 25, 26, 17, 18, 19, 20, 21, 22, 23],
         "labels": [
-            "recv_east",  # Stream 12: East receiver channel
-            "recv_west",  # Stream 13: West receiver channel
-            "recv_north",  # Stream 14: North receiver channel
-            "recv_south",  # Stream 15: South receiver channel
-            "recv_downstream_vc1",  # Stream 16: Downstream VC1 receiver
+            "recv_vc0_edge1",  # Stream 12: VC0 downstream edge 1
+            "recv_vc0_edge2",  # Stream 13: VC0 downstream edge 2
+            "recv_vc0_edge3",  # Stream 14: VC0 downstream edge 3
+            "recv_vc1_edge1",  # Stream 24: VC1 downstream edge 1
+            "recv_vc1_edge2",  # Stream 25: VC1 downstream edge 2
+            "recv_vc1_edge3",  # Stream 26: VC1 downstream edge 3
             "sender_ch0",  # Stream 17: Sender channel 0
             "sender_ch1",  # Stream 18: Sender channel 1
             "sender_ch2",  # Stream 19: Sender channel 2
             "sender_ch3",  # Stream 20: Sender channel 3
-            "sender_ch4_vc1",  # Stream 21: Sender channel 4 VC1
+            "sender_ch4",  # Stream 21: Sender channel 4
+            "sender_ch5",  # Stream 22: Sender channel 5
+            "sender_ch6",  # Stream 23: Sender channel 6
         ],
         "title": "ALL FABRIC STREAM FREE SLOTS",
         "description": "Complete view of all fabric EDM sender/receiver buffer space for flow control debugging",
@@ -116,16 +126,24 @@ FABRIC_STREAM_GROUPS = {
     },
     # ========== Packet Acknowledgment Streams (Remote Buffer Status) ==========
     "sender_acks": {
-        "stream_ids": [2, 3, 4, 5, 6],
-        "labels": ["sender_ch0_ack", "sender_ch1_ack", "sender_ch2_ack", "sender_ch3_ack", "sender_ch4_ack"],
+        "stream_ids": [2, 3, 4, 5],
+        "labels": ["sender_ch0_ack", "sender_ch1_ack", "sender_ch2_ack", "sender_ch3_ack"],
         "title": "SENDER CHANNEL PACKET ACKNOWLEDGMENT STREAMS",
         "description": "Remote buffer space for ack streams (to_sender_X_pkts_acked). LOW/ZERO = remote consuming acks",
         "register_type": "BUF_SPACE_AVAILABLE",
     },
     # ========== Packet Completion Streams (Remote Buffer Status) ==========
     "sender_completions": {
-        "stream_ids": [7, 8, 9, 10, 11],
-        "labels": ["sender_ch0_comp", "sender_ch1_comp", "sender_ch2_comp", "sender_ch3_comp", "sender_ch4_comp"],
+        "stream_ids": [7, 8, 9, 10, 11, 15, 16],
+        "labels": [
+            "sender_ch0_comp",
+            "sender_ch1_comp",
+            "sender_ch2_comp",
+            "sender_ch3_comp",
+            "sender_ch4_comp",
+            "sender_ch5_comp",
+            "sender_ch6_comp",
+        ],
         "title": "SENDER CHANNEL PACKET COMPLETION STREAMS",
         "description": "Remote buffer space for completion streams (to_sender_X_pkts_completed). LOW/ZERO = remote consuming completions",
         "register_type": "BUF_SPACE_AVAILABLE",
@@ -140,18 +158,19 @@ FABRIC_STREAM_GROUPS = {
     },
     # ========== Combined Acks and Completions ==========
     "all_acks_and_completions": {
-        "stream_ids": [2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
+        "stream_ids": [2, 3, 4, 5, 7, 8, 9, 10, 11, 15, 16],
         "labels": [
             "sender_ch0_ack",  # Stream 2
             "sender_ch1_ack",  # Stream 3
             "sender_ch2_ack",  # Stream 4
             "sender_ch3_ack",  # Stream 5
-            "sender_ch4_ack",  # Stream 6
             "sender_ch0_comp",  # Stream 7
             "sender_ch1_comp",  # Stream 8
             "sender_ch2_comp",  # Stream 9
             "sender_ch3_comp",  # Stream 10
             "sender_ch4_comp",  # Stream 11
+            "sender_ch5_comp",  # Stream 15
+            "sender_ch6_comp",  # Stream 16
         ],
         "title": "ALL SENDER ACK AND COMPLETION STREAMS",
         "description": "Remote buffer space for ack/completion streams. LOW/ZERO = remote side processing normally",

--- a/tt_metal/fabric/debug/fabric_erisc_constants.py
+++ b/tt_metal/fabric/debug/fabric_erisc_constants.py
@@ -75,22 +75,22 @@ STREAM_REGISTER_INDICES = {
 # These streams are used for fabric flow control and backpressure management
 
 # IMPORTANT: Interpretation of BUF_SPACE_AVAILABLE values:
-# - Streams 12-21 (buffer free slots): HIGH values = good (buffers have space)
-# - Streams 0-11 (ack/completion): LOW/ZERO values = good (remote side consuming immediately)
+# - Streams 13-25 (buffer free slots): HIGH values = good (buffers have space)
+# - Streams 0-12 (ack/completion): LOW/ZERO values = good (remote side consuming immediately)
 #   For ack/completion streams, the register shows remote destination buffer space.
 #   Zero means remote side is processing acks/completions as they arrive (expected when idle).
 
 FABRIC_STREAM_GROUPS = {
     # ========== Buffer Free Slots (Flow Control) ==========
     "sender_free_slots": {
-        "stream_ids": [17, 18, 19, 20, 21, 22, 23],
+        "stream_ids": [19, 20, 21, 22, 23, 24, 25],
         "labels": ["sender_ch0", "sender_ch1", "sender_ch2", "sender_ch3", "sender_ch4", "sender_ch5", "sender_ch6"],
         "title": "SENDER CHANNEL FREE SLOTS",
         "description": "Fabric sender channel buffer space available (free slots) for flow control",
         "register_type": "BUF_SPACE_AVAILABLE",
     },
     "receiver_free_slots": {
-        "stream_ids": [12, 13, 14, 24, 25, 26],
+        "stream_ids": [13, 14, 15, 16, 17, 18],
         "labels": [
             "recv_vc0_edge1",
             "recv_vc0_edge2",
@@ -104,21 +104,21 @@ FABRIC_STREAM_GROUPS = {
         "register_type": "BUF_SPACE_AVAILABLE",
     },
     "all_fabric_free_slots": {
-        "stream_ids": [12, 13, 14, 24, 25, 26, 17, 18, 19, 20, 21, 22, 23],
+        "stream_ids": [13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25],
         "labels": [
-            "recv_vc0_edge1",  # Stream 12: VC0 downstream edge 1
-            "recv_vc0_edge2",  # Stream 13: VC0 downstream edge 2
-            "recv_vc0_edge3",  # Stream 14: VC0 downstream edge 3
-            "recv_vc1_edge1",  # Stream 24: VC1 downstream edge 1
-            "recv_vc1_edge2",  # Stream 25: VC1 downstream edge 2
-            "recv_vc1_edge3",  # Stream 26: VC1 downstream edge 3
-            "sender_ch0",  # Stream 17: Sender channel 0
-            "sender_ch1",  # Stream 18: Sender channel 1
-            "sender_ch2",  # Stream 19: Sender channel 2
-            "sender_ch3",  # Stream 20: Sender channel 3
-            "sender_ch4",  # Stream 21: Sender channel 4
-            "sender_ch5",  # Stream 22: Sender channel 5
-            "sender_ch6",  # Stream 23: Sender channel 6
+            "recv_vc0_edge1",  # Stream 13: VC0 downstream edge 1
+            "recv_vc0_edge2",  # Stream 14: VC0 downstream edge 2
+            "recv_vc0_edge3",  # Stream 15: VC0 downstream edge 3
+            "recv_vc1_edge1",  # Stream 16: VC1 downstream edge 1
+            "recv_vc1_edge2",  # Stream 17: VC1 downstream edge 2
+            "recv_vc1_edge3",  # Stream 18: VC1 downstream edge 3
+            "sender_ch0",  # Stream 19: Sender channel 0
+            "sender_ch1",  # Stream 20: Sender channel 1
+            "sender_ch2",  # Stream 21: Sender channel 2
+            "sender_ch3",  # Stream 22: Sender channel 3
+            "sender_ch4",  # Stream 23: Sender channel 4
+            "sender_ch5",  # Stream 24: Sender channel 5
+            "sender_ch6",  # Stream 25: Sender channel 6
         ],
         "title": "ALL FABRIC STREAM FREE SLOTS",
         "description": "Complete view of all fabric EDM sender/receiver buffer space for flow control debugging",
@@ -134,7 +134,7 @@ FABRIC_STREAM_GROUPS = {
     },
     # ========== Packet Completion Streams (Remote Buffer Status) ==========
     "sender_completions": {
-        "stream_ids": [7, 8, 9, 10, 11, 15, 16],
+        "stream_ids": [6, 7, 8, 9, 10, 11, 12],
         "labels": [
             "sender_ch0_comp",
             "sender_ch1_comp",
@@ -158,19 +158,19 @@ FABRIC_STREAM_GROUPS = {
     },
     # ========== Combined Acks and Completions ==========
     "all_acks_and_completions": {
-        "stream_ids": [2, 3, 4, 5, 7, 8, 9, 10, 11, 15, 16],
+        "stream_ids": [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
         "labels": [
             "sender_ch0_ack",  # Stream 2
             "sender_ch1_ack",  # Stream 3
             "sender_ch2_ack",  # Stream 4
             "sender_ch3_ack",  # Stream 5
-            "sender_ch0_comp",  # Stream 7
-            "sender_ch1_comp",  # Stream 8
-            "sender_ch2_comp",  # Stream 9
-            "sender_ch3_comp",  # Stream 10
-            "sender_ch4_comp",  # Stream 11
-            "sender_ch5_comp",  # Stream 15
-            "sender_ch6_comp",  # Stream 16
+            "sender_ch0_comp",  # Stream 6
+            "sender_ch1_comp",  # Stream 7
+            "sender_ch2_comp",  # Stream 8
+            "sender_ch3_comp",  # Stream 9
+            "sender_ch4_comp",  # Stream 10
+            "sender_ch5_comp",  # Stream 11
+            "sender_ch6_comp",  # Stream 12
         ],
         "title": "ALL SENDER ACK AND COMPLETION STREAMS",
         "description": "Remote buffer space for ack/completion streams. LOW/ZERO = remote side processing normally",

--- a/tt_metal/fabric/debug/fabric_erisc_utils.py
+++ b/tt_metal/fabric/debug/fabric_erisc_utils.py
@@ -34,7 +34,7 @@ def get_stream_reg_address(stream_id: int, reg_name: str, arch: str) -> int:
     indices are architecture-specific.
 
     Args:
-        stream_id: Stream ID (typically 0-31, fabric uses 12-21)
+        stream_id: Stream ID (typically 0-31)
         reg_name: Register name (BUF_SPACE_AVAILABLE, BUF_SIZE, BUF_SPACE_UPDATE)
         arch: Architecture string (wormhole, blackhole)
 

--- a/tt_metal/fabric/erisc_datamover_builder.cpp
+++ b/tt_metal/fabric/erisc_datamover_builder.cpp
@@ -390,10 +390,12 @@ FabricEriscDatamoverConfig::FabricEriscDatamoverConfig(
     // -1 to discount for the tensix worker channel
     this->num_fwd_paths = this->num_used_sender_channels - 1;
 
-    // TODO: For 2D routing, if there is only one mesh, we need to discount for inter-mesh vc.
-    if (topology == Topology::Mesh && is_2D_routing) {
+    // TODO: Remove VC1 adjustments once VC1 sender/receiver channels are fully implemented
+    // For 2D routing (Mesh/Torus), VC1 channels (sender channels 4-6, receiver channel 1) are not yet implemented
+    // so we exclude them from allocation
+    if ((topology == Topology::Mesh || topology == Topology::Torus) && is_2D_routing) {
         this->num_used_sender_channels -= builder_config::get_vc1_downstream_edm_count(is_2D_routing);
-        this->num_used_receiver_channels = 1;
+        this->num_used_receiver_channels = 1;  // Only VC0 receiver implemented
         this->num_fwd_paths -= builder_config::get_vc1_downstream_edm_count(is_2D_routing);
     }
 

--- a/tt_metal/fabric/erisc_datamover_builder.cpp
+++ b/tt_metal/fabric/erisc_datamover_builder.cpp
@@ -392,8 +392,9 @@ FabricEriscDatamoverConfig::FabricEriscDatamoverConfig(
 
     // TODO: For 2D routing, if there is only one mesh, we need to discount for inter-mesh vc.
     if (topology == Topology::Mesh && is_2D_routing) {
-        this->num_used_sender_channels -= 3;
-        this->num_fwd_paths -= 3;
+        this->num_used_sender_channels -= builder_config::get_vc1_downstream_edm_count(is_2D_routing);
+        this->num_used_receiver_channels = 1;
+        this->num_fwd_paths -= builder_config::get_vc1_downstream_edm_count(is_2D_routing);
     }
 
     for (uint32_t i = 0; i < this->num_used_sender_channels; i++) {
@@ -919,6 +920,7 @@ std::vector<uint32_t> FabricEriscDatamoverBuilder::get_compile_time_args(uint32_
         config.risc_configs[risc_id].is_sender_channel_serviced(5),
         config.risc_configs[risc_id].is_sender_channel_serviced(6),
         config.risc_configs[risc_id].is_receiver_channel_serviced(0),
+        config.risc_configs[risc_id].is_receiver_channel_serviced(1),
         config.risc_configs[risc_id].enable_handshake(),
         config.risc_configs[risc_id].enable_context_switch(),
         config.risc_configs[risc_id].enable_interrupts(),

--- a/tt_metal/fabric/erisc_datamover_builder.cpp
+++ b/tt_metal/fabric/erisc_datamover_builder.cpp
@@ -390,7 +390,8 @@ FabricEriscDatamoverConfig::FabricEriscDatamoverConfig(
     // -1 to discount for the tensix worker channel
     this->num_fwd_paths = this->num_used_sender_channels - 1;
 
-    // TODO: Remove VC1 adjustments once VC1 sender/receiver channels are fully implemented
+    // TODO: https://github.com/tenstorrent/tt-metal/issues/32561
+    // Remove VC1 adjustments once VC1 sender/receiver channels are fully implemented
     // For 2D routing (Mesh/Torus), VC1 channels (sender channels 4-6, receiver channel 1) are not yet implemented
     // so we exclude them from allocation
     if ((topology == Topology::Mesh || topology == Topology::Torus) && is_2D_routing) {

--- a/tt_metal/fabric/erisc_datamover_builder.cpp
+++ b/tt_metal/fabric/erisc_datamover_builder.cpp
@@ -384,11 +384,17 @@ FabricEriscDatamoverConfig::FabricEriscDatamoverConfig(
 
     this->channel_buffer_size_bytes = channel_buffer_size_bytes;
     this->num_used_sender_channels = builder_config::get_sender_channel_count(is_2D_routing);
-    this->num_used_receiver_channels = builder_config::num_receiver_channels;
+    this->num_used_receiver_channels = builder_config::get_receiver_channel_count(is_2D_routing);
 
     // Default, assuming deadlock avoidance is enabled
     // -1 to discount for the tensix worker channel
     this->num_fwd_paths = this->num_used_sender_channels - 1;
+
+    // TODO: For 2D routing, if there is only one mesh, we need to discount for inter-mesh vc.
+    if (topology == Topology::Mesh && is_2D_routing) {
+        this->num_used_sender_channels -= 3;
+        this->num_fwd_paths -= 3;
+    }
 
     for (uint32_t i = 0; i < this->num_used_sender_channels; i++) {
         TT_FATAL(
@@ -644,9 +650,9 @@ FabricEriscDatamoverBuilder::FabricEriscDatamoverBuilder(
     const FabricNodeId& local_fabric_node_id,
     const FabricNodeId& peer_fabric_node_id,
 
-    const std::array<std::optional<size_t>, FabricEriscDatamoverConfig::max_downstream_edms>&
+    const std::array<std::optional<size_t>, builder_config::max_downstream_edms>&
         receiver_channels_downstream_flow_control_semaphore_id,
-    const std::array<std::optional<size_t>, FabricEriscDatamoverConfig::max_downstream_edms>&
+    const std::array<std::optional<size_t>, builder_config::max_downstream_edms>&
         receiver_channels_downstream_teardown_semaphore_id,
     const std::array<size_t, builder_config::num_sender_channels>& sender_channels_flow_control_semaphore_id,
     const std::array<size_t, builder_config::num_sender_channels>& sender_channels_connection_semaphore_id,
@@ -893,6 +899,9 @@ std::vector<uint32_t> FabricEriscDatamoverBuilder::get_compile_time_args(uint32_
         config.sender_channels_worker_conn_info_base_address[1],
         config.sender_channels_worker_conn_info_base_address[2],
         config.sender_channels_worker_conn_info_base_address[3],
+        config.sender_channels_worker_conn_info_base_address[4],
+        config.sender_channels_worker_conn_info_base_address[5],
+        config.sender_channels_worker_conn_info_base_address[6],
 
         this->termination_signal_ptr,
         this->edm_local_sync_ptr,
@@ -906,6 +915,9 @@ std::vector<uint32_t> FabricEriscDatamoverBuilder::get_compile_time_args(uint32_
         config.risc_configs[risc_id].is_sender_channel_serviced(1),
         config.risc_configs[risc_id].is_sender_channel_serviced(2),
         config.risc_configs[risc_id].is_sender_channel_serviced(3),
+        config.risc_configs[risc_id].is_sender_channel_serviced(4),
+        config.risc_configs[risc_id].is_sender_channel_serviced(5),
+        config.risc_configs[risc_id].is_sender_channel_serviced(6),
         config.risc_configs[risc_id].is_receiver_channel_serviced(0),
         config.risc_configs[risc_id].enable_handshake(),
         config.risc_configs[risc_id].enable_context_switch(),
@@ -1132,9 +1144,9 @@ FabricEriscDatamoverBuilder FabricEriscDatamoverBuilder::build(
     std::array<size_t, builder_config::num_sender_channels> sender_channels_buffer_index_semaphore_id{};
     std::array<size_t, builder_config::num_sender_channels> sender_channels_flow_control_semaphore_id{};
     std::array<size_t, builder_config::num_sender_channels> sender_channels_connection_semaphore_id{};
-    std::array<std::optional<size_t>, FabricEriscDatamoverConfig::max_downstream_edms>
+    std::array<std::optional<size_t>, builder_config::max_downstream_edms>
         receiver_channels_downstream_flow_control_semaphore_id;
-    std::array<std::optional<size_t>, FabricEriscDatamoverConfig::max_downstream_edms>
+    std::array<std::optional<size_t>, builder_config::max_downstream_edms>
         receiver_channels_downstream_teardown_semaphore_id;
 
     auto remote_pool_allocators =

--- a/tt_metal/fabric/erisc_datamover_builder.hpp
+++ b/tt_metal/fabric/erisc_datamover_builder.hpp
@@ -116,15 +116,24 @@ struct StreamRegAssignments {
     static constexpr uint32_t to_sender_1_pkts_completed_id = 8;
     static constexpr uint32_t to_sender_2_pkts_completed_id = 9;
     static constexpr uint32_t to_sender_3_pkts_completed_id = 10;
+    static constexpr uint32_t to_sender_4_pkts_completed_id = 11;
+    static constexpr uint32_t to_sender_5_pkts_completed_id = 15;
+    static constexpr uint32_t to_sender_6_pkts_completed_id = 16;
     // Receiver channel free slots stream IDs
     static constexpr uint32_t vc_0_free_slots_from_downstream_edge_1 = 12;
     static constexpr uint32_t vc_0_free_slots_from_downstream_edge_2 = 13;
     static constexpr uint32_t vc_0_free_slots_from_downstream_edge_3 = 14;
+    static constexpr uint32_t vc_1_free_slots_from_downstream_edge_1 = 24;
+    static constexpr uint32_t vc_1_free_slots_from_downstream_edge_2 = 25;
+    static constexpr uint32_t vc_1_free_slots_from_downstream_edge_3 = 26;
     // Sender channel free slots stream IDs
     static constexpr uint32_t sender_channel_0_free_slots_stream_id = 17;  // for tensix worker
     static constexpr uint32_t sender_channel_1_free_slots_stream_id = 18;  // for upstream edge on: 1D->VC0, 2D->VC0
     static constexpr uint32_t sender_channel_2_free_slots_stream_id = 19;  // for upstream edge on: 2D->VC0
     static constexpr uint32_t sender_channel_3_free_slots_stream_id = 20;  // for upstream edge on: 2D->VC0
+    static constexpr uint32_t sender_channel_4_free_slots_stream_id = 21;  // for upstream edge on: 2D->VC1
+    static constexpr uint32_t sender_channel_5_free_slots_stream_id = 22;  // for upstream edge on: 2D->VC1
+    static constexpr uint32_t sender_channel_6_free_slots_stream_id = 23;  // for upstream edge on: 2D->VC1
 
     // Local tensix relay free slots stream ID (UDM mode only)
     static constexpr uint32_t tensix_relay_local_free_slots_stream_id = 29;
@@ -143,12 +152,22 @@ struct StreamRegAssignments {
             to_sender_1_pkts_completed_id,
             to_sender_2_pkts_completed_id,
             to_sender_3_pkts_completed_id,
+            to_sender_4_pkts_completed_id,
+            to_sender_5_pkts_completed_id,
+            to_sender_6_pkts_completed_id,
             vc_0_free_slots_from_downstream_edge_1,
             vc_0_free_slots_from_downstream_edge_2,
             vc_0_free_slots_from_downstream_edge_3,
+            vc_1_free_slots_from_downstream_edge_1,
+            vc_1_free_slots_from_downstream_edge_2,
+            vc_1_free_slots_from_downstream_edge_3,
+            sender_channel_0_free_slots_stream_id,
             sender_channel_1_free_slots_stream_id,
             sender_channel_2_free_slots_stream_id,
             sender_channel_3_free_slots_stream_id,
+            sender_channel_4_free_slots_stream_id,
+            sender_channel_5_free_slots_stream_id,
+            sender_channel_6_free_slots_stream_id,
             tensix_relay_local_free_slots_stream_id,
             multi_risc_teardown_sync_stream_id};
         return stream_ids;
@@ -170,11 +189,6 @@ struct FabricEriscDatamoverConfig {
     static constexpr uint32_t BLACKHOLE_SINGLE_ERISC_MODE_RECEIVER_LOCAL_WRITE_NOC = 1;
     static constexpr uint32_t BLACKHOLE_SINGLE_ERISC_MODE_SENDER_ACK_NOC = 1;
 
-    static constexpr std::size_t num_downstream_edms_vc0 = 1;
-    static constexpr std::size_t num_downstream_edms_2d_vc0 = 3;
-    static constexpr std::size_t num_downstream_edms = num_downstream_edms_vc0;
-    static constexpr std::size_t num_downstream_edms_2d = num_downstream_edms_2d_vc0;
-    static constexpr std::size_t max_downstream_edms = std::max(num_downstream_edms, num_downstream_edms_2d);
     static constexpr uint32_t num_virtual_channels = 2;
 
     static constexpr std::size_t field_size = 16;
@@ -221,8 +235,10 @@ struct FabricEriscDatamoverConfig {
 
     // ----------- Receiver Channels
     // persistent mode field
-    std::array<std::size_t, max_downstream_edms> receiver_channels_downstream_flow_control_semaphore_address = {};
-    std::array<std::size_t, max_downstream_edms> receiver_channels_downstream_teardown_semaphore_address = {};
+    std::array<std::size_t, builder_config::max_downstream_edms>
+        receiver_channels_downstream_flow_control_semaphore_address = {};
+    std::array<std::size_t, builder_config::max_downstream_edms>
+        receiver_channels_downstream_teardown_semaphore_address = {};
 
     // Conditionally used fields. BlackHole with 2-erisc uses these fields for sending credits back to sender.
     // We use/have these fields because we can't send reg-writes over Ethernet on both TXQs. Therefore,
@@ -378,9 +394,9 @@ public:
         const FabricNodeId& local_fabric_node_id,
         const FabricNodeId& peer_fabric_node_id,
 
-        const std::array<std::optional<size_t>, FabricEriscDatamoverConfig::max_downstream_edms>&
+        const std::array<std::optional<size_t>, builder_config::max_downstream_edms>&
             receiver_channels_downstream_flow_control_semaphore_id,
-        const std::array<std::optional<size_t>, FabricEriscDatamoverConfig::max_downstream_edms>&
+        const std::array<std::optional<size_t>, builder_config::max_downstream_edms>&
             receiver_channels_downstream_teardown_semaphore_id,
         const std::array<size_t, builder_config::num_sender_channels>& sender_channels_flow_control_semaphore_id,
         const std::array<size_t, builder_config::num_sender_channels>& sender_channels_connection_semaphore_id,
@@ -458,7 +474,8 @@ public:
     size_t channel_buffer_size = 0;
 
     std::shared_ptr<tt::tt_fabric::ChannelConnectionWriterAdapter> receiver_channel_to_downstream_adapter;
-    std::array<std::shared_ptr<tt::tt_fabric::FabricChannelAllocator>, FabricEriscDatamoverConfig::max_downstream_edms> downstream_allocators = {};
+    std::array<std::shared_ptr<tt::tt_fabric::FabricChannelAllocator>, builder_config::max_downstream_edms>
+        downstream_allocators = {};
 
     std::array<size_t, builder_config::num_receiver_channels> receiver_channels_num_buffers = {};
     std::array<size_t, builder_config::num_receiver_channels> remote_receiver_channels_num_buffers = {};
@@ -475,9 +492,9 @@ public:
 
     // Semaphore IDs
     // this is the receiver channel's local sem for flow controlling with downstream fabric sender
-    std::array<std::optional<size_t>, FabricEriscDatamoverConfig::max_downstream_edms>
+    std::array<std::optional<size_t>, builder_config::max_downstream_edms>
         receiver_channels_downstream_flow_control_semaphore_id = {};
-    std::array<std::optional<size_t>, FabricEriscDatamoverConfig::max_downstream_edms>
+    std::array<std::optional<size_t>, builder_config::max_downstream_edms>
         receiver_channels_downstream_teardown_semaphore_id = {};
     std::array<size_t, builder_config::num_sender_channels> sender_channels_flow_control_semaphore_id = {};
     std::array<size_t, builder_config::num_sender_channels> sender_channels_connection_semaphore_id = {};

--- a/tt_metal/fabric/erisc_datamover_builder.hpp
+++ b/tt_metal/fabric/erisc_datamover_builder.hpp
@@ -112,28 +112,28 @@ struct StreamRegAssignments {
     static constexpr uint32_t to_sender_1_pkts_acked_id = 3;
     static constexpr uint32_t to_sender_2_pkts_acked_id = 4;
     static constexpr uint32_t to_sender_3_pkts_acked_id = 5;
-    static constexpr uint32_t to_sender_0_pkts_completed_id = 7;
-    static constexpr uint32_t to_sender_1_pkts_completed_id = 8;
-    static constexpr uint32_t to_sender_2_pkts_completed_id = 9;
-    static constexpr uint32_t to_sender_3_pkts_completed_id = 10;
-    static constexpr uint32_t to_sender_4_pkts_completed_id = 11;
-    static constexpr uint32_t to_sender_5_pkts_completed_id = 15;
-    static constexpr uint32_t to_sender_6_pkts_completed_id = 16;
+    static constexpr uint32_t to_sender_0_pkts_completed_id = 6;
+    static constexpr uint32_t to_sender_1_pkts_completed_id = 7;
+    static constexpr uint32_t to_sender_2_pkts_completed_id = 8;
+    static constexpr uint32_t to_sender_3_pkts_completed_id = 9;
+    static constexpr uint32_t to_sender_4_pkts_completed_id = 10;
+    static constexpr uint32_t to_sender_5_pkts_completed_id = 11;
+    static constexpr uint32_t to_sender_6_pkts_completed_id = 12;
     // Receiver channel free slots stream IDs
-    static constexpr uint32_t vc_0_free_slots_from_downstream_edge_1 = 12;
-    static constexpr uint32_t vc_0_free_slots_from_downstream_edge_2 = 13;
-    static constexpr uint32_t vc_0_free_slots_from_downstream_edge_3 = 14;
-    static constexpr uint32_t vc_1_free_slots_from_downstream_edge_1 = 24;
-    static constexpr uint32_t vc_1_free_slots_from_downstream_edge_2 = 25;
-    static constexpr uint32_t vc_1_free_slots_from_downstream_edge_3 = 26;
+    static constexpr uint32_t vc_0_free_slots_from_downstream_edge_1 = 13;
+    static constexpr uint32_t vc_0_free_slots_from_downstream_edge_2 = 14;
+    static constexpr uint32_t vc_0_free_slots_from_downstream_edge_3 = 15;
+    static constexpr uint32_t vc_1_free_slots_from_downstream_edge_1 = 16;
+    static constexpr uint32_t vc_1_free_slots_from_downstream_edge_2 = 17;
+    static constexpr uint32_t vc_1_free_slots_from_downstream_edge_3 = 18;
     // Sender channel free slots stream IDs
-    static constexpr uint32_t sender_channel_0_free_slots_stream_id = 17;  // for tensix worker
-    static constexpr uint32_t sender_channel_1_free_slots_stream_id = 18;  // for upstream edge on: 1D->VC0, 2D->VC0
-    static constexpr uint32_t sender_channel_2_free_slots_stream_id = 19;  // for upstream edge on: 2D->VC0
-    static constexpr uint32_t sender_channel_3_free_slots_stream_id = 20;  // for upstream edge on: 2D->VC0
-    static constexpr uint32_t sender_channel_4_free_slots_stream_id = 21;  // for upstream edge on: 2D->VC1
-    static constexpr uint32_t sender_channel_5_free_slots_stream_id = 22;  // for upstream edge on: 2D->VC1
-    static constexpr uint32_t sender_channel_6_free_slots_stream_id = 23;  // for upstream edge on: 2D->VC1
+    static constexpr uint32_t sender_channel_0_free_slots_stream_id = 19;  // for tensix worker
+    static constexpr uint32_t sender_channel_1_free_slots_stream_id = 20;  // for upstream edge on: 1D->VC0, 2D->VC0
+    static constexpr uint32_t sender_channel_2_free_slots_stream_id = 21;  // for upstream edge on: 2D->VC0
+    static constexpr uint32_t sender_channel_3_free_slots_stream_id = 22;  // for upstream edge on: 2D->VC0
+    static constexpr uint32_t sender_channel_4_free_slots_stream_id = 23;  // for upstream edge on: 2D->VC1
+    static constexpr uint32_t sender_channel_5_free_slots_stream_id = 24;  // for upstream edge on: 2D->VC1
+    static constexpr uint32_t sender_channel_6_free_slots_stream_id = 25;  // for upstream edge on: 2D->VC1
 
     // Local tensix relay free slots stream ID (UDM mode only)
     static constexpr uint32_t tensix_relay_local_free_slots_stream_id = 29;

--- a/tt_metal/fabric/hw/inc/edm_fabric/fabric_connection_interface.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/fabric_connection_interface.hpp
@@ -18,6 +18,6 @@ static constexpr uint32_t close_connection_request_value = 2;
 // default assigned stream ID for the worker connection credits
 // worker writes to the auto-inc register of this stream ID to notify
 // fabric router of new packets availale.
-static constexpr uint32_t sender_channel_0_free_slots_stream_id = 17;
+static constexpr uint32_t sender_channel_0_free_slots_stream_id = 19;
 
 };  // namespace tt::tt_fabric::connection_interface

--- a/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_router_ct_args.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_router_ct_args.hpp
@@ -492,11 +492,13 @@ constexpr std::array<uint32_t, MAX_NUM_RECEIVER_CHANNELS> to_receiver_packets_se
 constexpr std::array<uint32_t, MAX_NUM_SENDER_CHANNELS> to_sender_packets_acked_streams =
     take_first_n_elements<MAX_NUM_SENDER_CHANNELS, MAX_NUM_SENDER_CHANNELS, uint32_t>(
         std::array<uint32_t, MAX_NUM_SENDER_CHANNELS>{
+            // VC0
             to_sender_0_pkts_acked_id,
             to_sender_1_pkts_acked_id,
             to_sender_2_pkts_acked_id,
             to_sender_3_pkts_acked_id,
-            0,
+            // VC1
+            0,  // Padding upto MAX_NUM_SENDER_CHANNELS. VC1 does not use first level acks.
             0,
             0});
 

--- a/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_router_ct_args.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_router_ct_args.hpp
@@ -22,8 +22,9 @@
 constexpr size_t NUM_ROUTER_CARDINAL_DIRECTIONS = 4;
 
 constexpr size_t MAX_NUM_RECEIVER_CHANNELS = 1;
-constexpr size_t MAX_NUM_SENDER_CHANNELS = 4;
-
+constexpr size_t MAX_NUM_SENDER_CHANNELS = 7;
+constexpr size_t MAX_NUM_SENDER_CHANNELS_VC0 = 4;  // Channels 0-3
+constexpr size_t MAX_NUM_SENDER_CHANNELS_VC1 = 3;  // Channels 4-6 (2D only)
 // Compile Time args
 
 constexpr bool SPECIAL_MARKER_CHECK_ENABLED = true;
@@ -40,20 +41,33 @@ constexpr uint32_t to_sender_0_pkts_completed_id = get_compile_time_arg_val(STRE
 constexpr uint32_t to_sender_1_pkts_completed_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 7);
 constexpr uint32_t to_sender_2_pkts_completed_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 8);
 constexpr uint32_t to_sender_3_pkts_completed_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 9);
+constexpr uint32_t to_sender_4_pkts_completed_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 10);
+constexpr uint32_t to_sender_5_pkts_completed_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 11);
+constexpr uint32_t to_sender_6_pkts_completed_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 12);
 constexpr uint32_t vc_0_free_slots_from_downstream_edge_1_stream_id =
-    get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 10);
+    get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 13);
 constexpr uint32_t vc_0_free_slots_from_downstream_edge_2_stream_id =
-    get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 11);
+    get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 14);
 constexpr uint32_t vc_0_free_slots_from_downstream_edge_3_stream_id =
-    get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 12);
-constexpr uint32_t sender_channel_1_free_slots_stream_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 13);
-constexpr uint32_t sender_channel_2_free_slots_stream_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 14);
-constexpr uint32_t sender_channel_3_free_slots_stream_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 15);
-constexpr uint32_t tensix_relay_local_free_slots_stream_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 16);
-constexpr uint32_t MULTI_RISC_TEARDOWN_SYNC_STREAM_ID = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 17);
+    get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 15);
+constexpr uint32_t vc_1_free_slots_from_downstream_edge_1_stream_id =
+    get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 16);
+constexpr uint32_t vc_1_free_slots_from_downstream_edge_2_stream_id =
+    get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 17);
+constexpr uint32_t vc_1_free_slots_from_downstream_edge_3_stream_id =
+    get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 18);
+constexpr uint32_t sender_channel_0_free_slots_stream_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 19);
+constexpr uint32_t sender_channel_1_free_slots_stream_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 20);
+constexpr uint32_t sender_channel_2_free_slots_stream_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 21);
+constexpr uint32_t sender_channel_3_free_slots_stream_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 22);
+constexpr uint32_t sender_channel_4_free_slots_stream_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 23);
+constexpr uint32_t sender_channel_5_free_slots_stream_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 24);
+constexpr uint32_t sender_channel_6_free_slots_stream_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 25);
+constexpr uint32_t tensix_relay_local_free_slots_stream_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 26);
+constexpr uint32_t MULTI_RISC_TEARDOWN_SYNC_STREAM_ID = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 27);
 
 // Special marker after stream IDs
-constexpr size_t STREAM_IDS_END_MARKER_IDX = STREAM_ID_ARGS_START_IDX + 18;
+constexpr size_t STREAM_IDS_END_MARKER_IDX = STREAM_ID_ARGS_START_IDX + 28;
 constexpr size_t STREAM_IDS_END_MARKER = 0xFFEE0001;
 static_assert(
     !SPECIAL_MARKER_CHECK_ENABLED || get_compile_time_arg_val(STREAM_IDS_END_MARKER_IDX) == STREAM_IDS_END_MARKER,
@@ -88,14 +102,14 @@ static_assert(
     NUM_SENDER_CHANNELS <= MAX_NUM_SENDER_CHANNELS,
     "NUM_SENDER_CHANNELS must be less than or equal to MAX_NUM_SENDER_CHANNELS");
 static_assert(
-    wait_for_host_signal_IDX == 24,
-    "wait_for_host_signal_IDX must be 28 (24 stream IDs + 1 marker + 1 tensix connections + 4 config args)");
+    wait_for_host_signal_IDX == 34,
+    "wait_for_host_signal_IDX must be 34 (28 stream IDs + 1 marker + 1 tensix connections + 4 config args)");
 static_assert(
     get_compile_time_arg_val(wait_for_host_signal_IDX) == 0 || get_compile_time_arg_val(wait_for_host_signal_IDX) == 1,
     "wait_for_host_signal must be 0 or 1");
 static_assert(
-    MAIN_CT_ARGS_START_IDX == 25,
-    "MAIN_CT_ARGS_START_IDX must be 29 (24 stream IDs + 1 marker + 1 tensix connections + 5 config args)");
+    MAIN_CT_ARGS_START_IDX == 35,
+    "MAIN_CT_ARGS_START_IDX must be 35 (28 stream IDs + 1 marker + 1 tensix connections + 5 config args)");
 
 constexpr uint32_t SWITCH_INTERVAL =
 #ifndef DEBUG_PRINT_ENABLED
@@ -235,9 +249,12 @@ constexpr size_t local_sender_channel_0_connection_info_addr = get_compile_time_
 constexpr size_t local_sender_channel_1_connection_info_addr = get_compile_time_arg_val(MAIN_CT_ARGS_IDX_1 + 1);
 constexpr size_t local_sender_channel_2_connection_info_addr = get_compile_time_arg_val(MAIN_CT_ARGS_IDX_1 + 2);
 constexpr size_t local_sender_channel_3_connection_info_addr = get_compile_time_arg_val(MAIN_CT_ARGS_IDX_1 + 3);
+constexpr size_t local_sender_channel_4_connection_info_addr = get_compile_time_arg_val(MAIN_CT_ARGS_IDX_1 + 4);
+constexpr size_t local_sender_channel_5_connection_info_addr = get_compile_time_arg_val(MAIN_CT_ARGS_IDX_1 + 5);
+constexpr size_t local_sender_channel_6_connection_info_addr = get_compile_time_arg_val(MAIN_CT_ARGS_IDX_1 + 6);
 
 // TODO: CONVERT TO SEMAPHORE
-constexpr size_t MAIN_CT_ARGS_IDX_2 = MAIN_CT_ARGS_IDX_1 + 4;
+constexpr size_t MAIN_CT_ARGS_IDX_2 = MAIN_CT_ARGS_IDX_1 + MAX_NUM_SENDER_CHANNELS;
 constexpr uint32_t termination_signal_addr = get_compile_time_arg_val(MAIN_CT_ARGS_IDX_2);
 constexpr uint32_t edm_local_sync_ptr_addr =
     wait_for_host_signal ? get_compile_time_arg_val(MAIN_CT_ARGS_IDX_2 + 1) : 0;
@@ -478,7 +495,10 @@ constexpr std::array<uint32_t, MAX_NUM_SENDER_CHANNELS> to_sender_packets_acked_
             to_sender_0_pkts_acked_id,
             to_sender_1_pkts_acked_id,
             to_sender_2_pkts_acked_id,
-            to_sender_3_pkts_acked_id});
+            to_sender_3_pkts_acked_id,
+            0,
+            0,
+            0});
 
 // data section
 constexpr std::array<uint32_t, MAX_NUM_SENDER_CHANNELS> to_sender_packets_completed_streams =
@@ -487,7 +507,10 @@ constexpr std::array<uint32_t, MAX_NUM_SENDER_CHANNELS> to_sender_packets_comple
             to_sender_0_pkts_completed_id,
             to_sender_1_pkts_completed_id,
             to_sender_2_pkts_completed_id,
-            to_sender_3_pkts_completed_id});
+            to_sender_3_pkts_completed_id,
+            to_sender_4_pkts_completed_id,
+            to_sender_5_pkts_completed_id,
+            to_sender_6_pkts_completed_id});
 
 // Miscellaneous configuration
 

--- a/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_router_ct_args.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_router_ct_args.hpp
@@ -21,7 +21,7 @@
 
 constexpr size_t NUM_ROUTER_CARDINAL_DIRECTIONS = 4;
 
-constexpr size_t MAX_NUM_RECEIVER_CHANNELS = 1;
+constexpr size_t MAX_NUM_RECEIVER_CHANNELS = 2;
 constexpr size_t MAX_NUM_SENDER_CHANNELS = 7;
 constexpr size_t MAX_NUM_SENDER_CHANNELS_VC0 = 4;  // Channels 0-3
 constexpr size_t MAX_NUM_SENDER_CHANNELS_VC1 = 3;  // Channels 4-6 (2D only)
@@ -486,7 +486,7 @@ constexpr std::array<uint8_t, MAX_NUM_RECEIVER_CHANNELS> RX_CH_TRID_STARTS =
 
 constexpr std::array<uint32_t, MAX_NUM_RECEIVER_CHANNELS> to_receiver_packets_sent_streams =
     take_first_n_elements<MAX_NUM_RECEIVER_CHANNELS, MAX_NUM_RECEIVER_CHANNELS, uint32_t>(
-        std::array<uint32_t, MAX_NUM_RECEIVER_CHANNELS>{to_receiver_0_pkts_sent_id});
+        std::array<uint32_t, MAX_NUM_RECEIVER_CHANNELS>{to_receiver_0_pkts_sent_id, to_receiver_1_pkts_sent_id});
 
 // not in symbol table - because not used
 constexpr std::array<uint32_t, MAX_NUM_SENDER_CHANNELS> to_sender_packets_acked_streams =

--- a/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
+++ b/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
@@ -2214,6 +2214,9 @@ void kernel_main() {
     // We make sure to do this before we handshake to guarantee that the registers are
     // initialized before the other side has any possibility of modifying them.
     init_ptr_val<to_receiver_packets_sent_streams[0]>(0);
+    if constexpr (NUM_RECEIVER_CHANNELS > 1) {
+        init_ptr_val<to_receiver_packets_sent_streams[1]>(0);
+    }
     init_ptr_val<to_sender_packets_acked_streams[0]>(0);
     init_ptr_val<to_sender_packets_acked_streams[1]>(0);
     init_ptr_val<to_sender_packets_acked_streams[2]>(0);

--- a/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
+++ b/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
@@ -311,10 +311,13 @@ static constexpr std::array<uint32_t, MAX_NUM_SENDER_CHANNELS> sender_channel_fr
     sender_channel_4_free_slots_stream_id,
     sender_channel_5_free_slots_stream_id,
     sender_channel_6_free_slots_stream_id};
-static_assert(sender_channel_free_slots_stream_ids[0] == 17);
-static_assert(sender_channel_free_slots_stream_ids[1] == 18);
-static_assert(sender_channel_free_slots_stream_ids[2] == 19);
-static_assert(sender_channel_free_slots_stream_ids[3] == 20);
+static_assert(sender_channel_free_slots_stream_ids[0] == 19);
+static_assert(sender_channel_free_slots_stream_ids[1] == 20);
+static_assert(sender_channel_free_slots_stream_ids[2] == 21);
+static_assert(sender_channel_free_slots_stream_ids[3] == 22);
+static_assert(sender_channel_free_slots_stream_ids[4] == 23);
+static_assert(sender_channel_free_slots_stream_ids[5] == 24);
+static_assert(sender_channel_free_slots_stream_ids[6] == 25);
 
 // For 2D fabric: maps compact index to downstream direction for each my_direction
 // For 1D fabric: only 1 downstream direction per router (EAST forwards to WEST in 1D linear topology)

--- a/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
+++ b/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
@@ -2217,32 +2217,29 @@ void kernel_main() {
     // We make sure to do this before we handshake to guarantee that the registers are
     // initialized before the other side has any possibility of modifying them.
     init_ptr_val<to_receiver_packets_sent_streams[0]>(0);
-    if constexpr (NUM_RECEIVER_CHANNELS > 1) {
-        init_ptr_val<to_receiver_packets_sent_streams[1]>(0);
-    }
     init_ptr_val<to_sender_packets_acked_streams[0]>(0);
     init_ptr_val<to_sender_packets_acked_streams[1]>(0);
-    init_ptr_val<to_sender_packets_acked_streams[2]>(0);
     init_ptr_val<to_sender_packets_completed_streams[0]>(0);
     init_ptr_val<to_sender_packets_completed_streams[1]>(0);
-    init_ptr_val<to_sender_packets_completed_streams[2]>(0);
     // The first sender channel in the array is always for the transient/worker connection
     init_ptr_val<sender_channel_free_slots_stream_ids[0]>(SENDER_NUM_BUFFERS_ARRAY[0]);  // LOCAL WORKER
     init_ptr_val<sender_channel_free_slots_stream_ids[1]>(SENDER_NUM_BUFFERS_ARRAY[1]);  // Compact index 0
-    init_ptr_val<sender_channel_free_slots_stream_ids[2]>(SENDER_NUM_BUFFERS_ARRAY[2]);  // Compact index 1
-    // TODO: change to per channel downstream buffers.
-    init_ptr_val<vc_0_free_slots_from_downstream_edge_1_stream_id>(DOWNSTREAM_SENDER_NUM_BUFFERS_VC0);
-    init_ptr_val<vc_0_free_slots_from_downstream_edge_2_stream_id>(DOWNSTREAM_SENDER_NUM_BUFFERS_VC0);
-    init_ptr_val<vc_0_free_slots_from_downstream_edge_3_stream_id>(DOWNSTREAM_SENDER_NUM_BUFFERS_VC0);
 
     if constexpr (NUM_ACTIVE_ERISCS > 1) {
         wait_for_other_local_erisc();
     }
 
     if constexpr (is_2d_fabric) {
-        init_ptr_val<sender_channel_free_slots_stream_ids[3]>(SENDER_NUM_BUFFERS_ARRAY[3]);  // Compact index 2
+        init_ptr_val<to_receiver_packets_sent_streams[1]>(0);
+        init_ptr_val<to_sender_packets_acked_streams[2]>(0);
         init_ptr_val<to_sender_packets_acked_streams[3]>(0);
+        init_ptr_val<to_sender_packets_completed_streams[2]>(0);
         init_ptr_val<to_sender_packets_completed_streams[3]>(0);
+        init_ptr_val<to_sender_packets_completed_streams[4]>(0);
+        init_ptr_val<to_sender_packets_completed_streams[5]>(0);
+        init_ptr_val<to_sender_packets_completed_streams[6]>(0);
+        init_ptr_val<sender_channel_free_slots_stream_ids[2]>(SENDER_NUM_BUFFERS_ARRAY[2]);  // Compact index 1
+        init_ptr_val<sender_channel_free_slots_stream_ids[3]>(SENDER_NUM_BUFFERS_ARRAY[3]);  // Compact index 2
     }
 
     if constexpr (code_profiling_enabled_timers_bitfield != 0) {


### PR DESCRIPTION
Add initial plumbing for Inter-mesh VC (VC1) channel streams.
Allocate VC1 sender/receiver channel streams and hook up runtime and compile time arguments.
This virtual channel receives traffic only from inter-mesh routers and forwards to downstream edges.
There is no worker sender channel required for VC1.
Every outbound router supports only 3 sender channels for the 3 inbound edges.

VC1 support will be added incrementally. This is first PR to reserve streams and setup builder to reserve housekeeping for up to 7 sender channels. 4 for VC0 and 3 for VC1.

### Ticket
https://github.com/tenstorrent/tt-metal/issues/32580

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

- [x] [T3000 nightly tests] https://github.com/tenstorrent/tt-metal/actions/runs/19915569703
- [x] [T3000 unit tests] https://github.com/tenstorrent/tt-metal/actions/runs/19915558714
- [x] [All post commit] https://github.com/tenstorrent/tt-metal/actions/runs/19915546824
- [x] [Galaxy quick] https://github.com/tenstorrent/tt-metal/actions/runs/19915580541

### Local Testing
#### WH Galaxy
- [x] tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_sanity_common.yaml
- [x] tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_stability_6U_galaxy.yaml
- [x] tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_deadlock_stability_6U_galaxy.yaml
- [x] tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_ubench_6U_galaxy_quick.yaml
- [x] tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_ubench_2d_torus_6U_galaxy.yaml

#### BH Galaxy
- [x] tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_sanity_common.yaml
- [x] tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_stability_6U_galaxy.yaml
- [x] tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_deadlock_stability_bh_6U_galaxy.yaml

#### WH LB
- [x] tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_sanity_common.yaml
- [x] tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_stability.yaml
- [x] tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_ubench_at_least_2x2_mesh.yaml
- [x]  ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="\*Fabric\*Fixture.*"

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes