### PR TITLE
add configurable max packet size when building fabric

### DIFF
--- a/tests/tt_metal/tt_fabric/fabric_router/test_custom_routing_tables.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_custom_routing_tables.cpp
@@ -21,7 +21,7 @@ constexpr auto k_ReliabilityMode = tt::tt_fabric::FabricReliabilityMode::STRICT_
 
 std::unique_ptr<tt::tt_fabric::ControlPlane> make_control_plane(const std::filesystem::path& graph_desc) {
     auto control_plane = std::make_unique<tt::tt_fabric::ControlPlane>(graph_desc.string());
-    control_plane->initialize_fabric_context(k_FabricConfig);
+    control_plane->initialize_fabric_context(k_FabricConfig, tt::tt_fabric::FabricRouterConfig{});
     control_plane->configure_routing_tables_for_fabric_ethernet_channels(k_FabricConfig, k_ReliabilityMode);
     return control_plane;
 }

--- a/tests/tt_metal/tt_fabric/fabric_router/test_routing_tables.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_routing_tables.cpp
@@ -28,7 +28,7 @@ constexpr auto kReliabilityMode = tt::tt_fabric::FabricReliabilityMode::STRICT_S
 
 std::unique_ptr<tt::tt_fabric::ControlPlane> make_control_plane(const std::filesystem::path& graph_desc) {
     auto control_plane = std::make_unique<tt::tt_fabric::ControlPlane>(graph_desc.string());
-    control_plane->initialize_fabric_context(kFabricConfig);
+    control_plane->initialize_fabric_context(kFabricConfig, tt::tt_fabric::FabricRouterConfig{});
     control_plane->configure_routing_tables_for_fabric_ethernet_channels(kFabricConfig, kReliabilityMode);
 
     return control_plane;
@@ -39,7 +39,7 @@ std::unique_ptr<tt::tt_fabric::ControlPlane> make_control_plane(
     const std::map<tt::tt_fabric::FabricNodeId, tt::ChipId>& logical_mesh_chip_id_to_physical_chip_id_mapping) {
     auto control_plane = std::make_unique<tt::tt_fabric::ControlPlane>(
         graph_desc.string(), logical_mesh_chip_id_to_physical_chip_id_mapping);
-    control_plane->initialize_fabric_context(kFabricConfig);
+    control_plane->initialize_fabric_context(kFabricConfig, tt::tt_fabric::FabricRouterConfig{});
     control_plane->configure_routing_tables_for_fabric_ethernet_channels(kFabricConfig, kReliabilityMode);
 
     return control_plane;
@@ -81,7 +81,7 @@ std::unique_ptr<RoutingTableGeneratorTestHelper> make_routing_table_generator(co
 
 std::unique_ptr<tt::tt_fabric::ControlPlane> make_control_plane_1d(const std::filesystem::path& graph_desc) {
     auto control_plane = std::make_unique<tt::tt_fabric::ControlPlane>(graph_desc.string());
-    control_plane->initialize_fabric_context(kFabricConfig1D);
+    control_plane->initialize_fabric_context(kFabricConfig1D, tt::tt_fabric::FabricRouterConfig{});
     control_plane->configure_routing_tables_for_fabric_ethernet_channels(kFabricConfig1D, kReliabilityMode);
 
     return control_plane;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_sanity_common.yaml
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_sanity_common.yaml
@@ -359,33 +359,21 @@ Tests:
             destination:
               device: [0, 1]
 
-  - name: "FabricMuxSimpleUnicastWriteMesh"
-    skip: [GALAXY, BLACKHOLE_GALAXY]
+  - name: "CustomMaxPacketSizeLinear"
+    sync: true
     fabric_setup:
-      topology: Mesh
-      fabric_tensix_config: Mux
+      topology: Linear
+      max_packet_size: 7616
 
-    senders:
-      - device: [0, 1]
-        patterns:
-          - ftype: unicast
-            ntype: unicast_write
-            size: 1024
-            num_packets: 100
-            destination:
-              device: [0, 0]
-
-  - name: "FabricMuxAllToAllUnicastMesh"
-    skip: [GALAXY, BLACKHOLE_GALAXY]
-    fabric_setup:
-      topology: Mesh
-      fabric_tensix_config: Mux
+    parametrization_params:
+      num_links: [1, 2, 3, 4]
+      ntype: [unicast_write, fused_atomic_inc, unicast_scatter_write]
+      size: [2048, 4096, 7616]
 
     defaults:
-      ftype: unicast
-      ntype: unicast_write
-      size: 1024
-      num_packets: 100
+      ftype: mcast
+      num_packets: 20000
 
     patterns:
       - type: all_to_all
+        iterations: 3

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common.hpp
@@ -161,7 +161,7 @@ public:
                 close_devices();
             }
             log_info(tt::LogTest, "Opening devices with fabric reliability mode: {}", reliability_mode);
-            open_devices_internal(new_fabric_config, fabric_tensix_config, reliability_mode);
+            open_devices_internal(new_fabric_config, fabric_tensix_config, reliability_mode, fabric_setup);
 
             topology_ = topology;
         } else {
@@ -1525,9 +1525,22 @@ private:
     void open_devices_internal(
         tt::tt_fabric::FabricConfig fabric_config,
         tt_fabric::FabricTensixConfig fabric_tensix_config,
-        tt_fabric::FabricReliabilityMode reliability_mode) {
+        tt_fabric::FabricReliabilityMode reliability_mode,
+        const TestFabricSetup& fabric_setup) {
         // Set fabric config FIRST, before any control plane access, this will reset control plane in metal context
-        tt::tt_fabric::SetFabricConfig(fabric_config, reliability_mode, std::nullopt, fabric_tensix_config);
+        // Create FabricRouterConfig if max_packet_size is specified
+        tt::tt_fabric::FabricRouterConfig router_config{};
+        if (fabric_setup.max_packet_size.has_value()) {
+            router_config.max_packet_payload_size_bytes = fabric_setup.max_packet_size.value();
+        }
+
+        tt::tt_fabric::SetFabricConfig(
+            fabric_config,
+            reliability_mode,
+            std::nullopt,
+            fabric_tensix_config,
+            tt::tt_fabric::FabricUDMMode::DISABLED,
+            router_config);
 
         // Now it's safe to initialize control plane (will use correct mesh graph descriptor)
         // first need to re-init contorl plane so that it checks out the latest fabric config.

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common_types.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common_types.hpp
@@ -124,6 +124,7 @@ struct TestFabricSetup {
     std::optional<tt_fabric::FabricReliabilityMode> fabric_reliability_mode;
     uint32_t num_links{};
     std::optional<std::string> torus_config;  // For Torus topology: "X", "Y", or "XY"
+    std::optional<uint32_t> max_packet_size;  // Custom max packet size for router
 };
 
 struct HighLevelPatternConfig {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_config.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_config.cpp
@@ -349,6 +349,10 @@ TestFabricSetup YamlConfigParser::parse_fabric_setup(const YAML::Node& fabric_se
         fabric_setup.num_links = 1;
     }
 
+    if (fabric_setup_yaml["max_packet_size"]) {
+        fabric_setup.max_packet_size = parse_scalar<uint32_t>(fabric_setup_yaml["max_packet_size"]);
+    }
+
     // Handle torus_config for Torus topology
     if (fabric_setup.topology == Topology::Torus) {
         if (fabric_setup_yaml["torus_config"]) {

--- a/tt_metal/api/tt-metalium/experimental/fabric/control_plane.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/control_plane.hpp
@@ -184,7 +184,8 @@ public:
     void set_routing_mode(uint16_t mode);
     uint16_t get_routing_mode() const;
 
-    void initialize_fabric_context(tt_fabric::FabricConfig fabric_config);
+    void initialize_fabric_context(
+        tt_fabric::FabricConfig fabric_config, const tt_fabric::FabricRouterConfig& router_config);
 
     FabricContext& get_fabric_context() const;
 

--- a/tt_metal/api/tt-metalium/experimental/fabric/fabric.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/fabric.hpp
@@ -118,13 +118,15 @@ tt::tt_fabric::Topology get_fabric_topology();
  * | num_routing_planes  | Number of routing planes         | optional<uint8_t>      | No       |
  * | fabric_tensix_config| Tensix fabric configuration      | FabricTensixConfig     | No       |
  * | fabric_udm_mode     | Unified DataMovement mode        | FabricUDMMode          | No       |
+ * | router_config       | Router-level configuration       | FabricRouterConfig     | No       |
  */
 void SetFabricConfig(
     FabricConfig fabric_config,
     FabricReliabilityMode reliability_mode = FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE,
     std::optional<uint8_t> num_routing_planes = std::nullopt,
     FabricTensixConfig fabric_tensix_config = FabricTensixConfig::DISABLED,
-    FabricUDMMode fabric_udm_mode = FabricUDMMode::DISABLED);
+    FabricUDMMode fabric_udm_mode = FabricUDMMode::DISABLED,
+    FabricRouterConfig router_config = FabricRouterConfig{});
 
 FabricConfig GetFabricConfig();
 

--- a/tt_metal/api/tt-metalium/experimental/fabric/fabric_types.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/fabric_types.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <stdint.h>
+#include <optional>
 #include <tt_stl/strong_type.hpp>
 
 namespace tt::tt_fabric {
@@ -32,6 +33,14 @@ enum class FabricTensixConfig : uint32_t {
 enum class FabricUDMMode : uint32_t {
     DISABLED = 0,
     ENABLED = 1,
+};
+
+// Configuration for router-level parameters
+// Extensible for future router tuning (buffer counts, VC settings, etc.)
+struct FabricRouterConfig {
+    // Optional override for maximum packet payload size (bytes)
+    // If not set, uses architecture and routing mode defaults
+    std::optional<size_t> max_packet_payload_size_bytes = std::nullopt;
 };
 
 enum class FabricType {

--- a/tt_metal/fabric/builder/fabric_static_sized_channels_allocator.cpp
+++ b/tt_metal/fabric/builder/fabric_static_sized_channels_allocator.cpp
@@ -190,20 +190,20 @@ void FabricStaticSizedChannelsAllocator::configure_buffer_slots_helper(
     // fabric with tensix extension uses different buffer slots options, since only one or two sender channels are
     // used by fabric router, while other sender channels are skipped and have 0 buffer slots.
     static const std::vector<std::vector<std::pair<size_t, size_t>>> default_with_tensix_buffer_slot_options = {
-        {{16, 16}, {8, 16}, {8, 8}},                     // WORMHOLE_B0: {sender_slots, receiver_slots}
-        {{32, 32}, {16, 32}, {16, 16}, {8, 16}, {8, 8}}  // BLACKHOLE: {sender_slots, receiver_slots}
+        {{16, 16}, {8, 16}, {8, 8}, {4, 4}, {2, 2}},                     // WORMHOLE_B0: {sender_slots, receiver_slots}
+        {{32, 32}, {16, 32}, {16, 16}, {8, 16}, {8, 8}, {4, 4}, {2, 2}}  // BLACKHOLE: {sender_slots, receiver_slots}
     };
 
     auto get_num_buffer_slots = [](Topology topology,
                                    size_t arch_index) -> const std::vector<std::pair<size_t, size_t>>& {
         // Architecture-specific buffer slot configurations
         static const std::vector<std::vector<std::pair<size_t, size_t>>> mesh_buffer_slot_options = {
-            {{7, 11}, {4, 8}},  // WORMHOLE_B0: {sender_slots, receiver_slots}
-            {{8, 16}, {8, 8}, {4, 8}}   // BLACKHOLE: {sender_slots, receiver_slots}
+            {{7, 11}, {4, 8}, {4, 4}, {2, 2}},         // WORMHOLE_B0: {sender_slots, receiver_slots}
+            {{8, 16}, {8, 8}, {4, 8}, {4, 4}, {2, 2}}  // BLACKHOLE: {sender_slots, receiver_slots}
         };
         static const std::vector<std::vector<std::pair<size_t, size_t>>> other_buffer_slot_options = {
-            {{8, 16}},  // WORMHOLE_B0: {sender_slots, receiver_slots}
-            {{32, 32}, {16, 32}, {16, 16}, {8, 16}, {8, 8}, {4, 8}}  // BLACKHOLE: {sender_slots,
+            {{8, 16}, {4, 8}, {4, 4}, {2, 2}},  // WORMHOLE_B0: {sender_slots, receiver_slots}
+            {{32, 32}, {16, 32}, {16, 16}, {8, 16}, {8, 8}, {4, 8}, {4, 4}, {2, 2}}  // BLACKHOLE: {sender_slots,
         };
 
         static tt::stl::Indestructible<std::vector<std::vector<std::pair<size_t, size_t>>>> mesh_slots(

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -1915,9 +1915,10 @@ void ControlPlane::set_routing_mode(uint16_t mode) {
 
 uint16_t ControlPlane::get_routing_mode() const { return this->routing_mode_; }
 
-void ControlPlane::initialize_fabric_context(tt_fabric::FabricConfig fabric_config) {
+void ControlPlane::initialize_fabric_context(
+    tt_fabric::FabricConfig fabric_config, const tt_fabric::FabricRouterConfig& router_config) {
     TT_FATAL(this->fabric_context_ == nullptr, "Trying to re-initialize fabric context");
-    this->fabric_context_ = std::make_unique<FabricContext>(fabric_config);
+    this->fabric_context_ = std::make_unique<FabricContext>(fabric_config, router_config);
 }
 
 FabricContext& ControlPlane::get_fabric_context() const {

--- a/tt_metal/fabric/erisc_datamover_builder.cpp
+++ b/tt_metal/fabric/erisc_datamover_builder.cpp
@@ -48,6 +48,16 @@ class Program;
 
 namespace tt::tt_fabric {
 
+size_t FabricEriscDatamoverBuilder::get_max_packet_payload_size_for_arch(tt::ARCH arch) {
+    switch (arch) {
+        case tt::ARCH::WORMHOLE_B0: return max_packet_payload_size_bytes_wormhole;
+        case tt::ARCH::BLACKHOLE: return max_packet_payload_size_bytes_blackhole;
+        default:
+            TT_FATAL(false, "Custom packet sizes not supported for architecture: {}", tt::arch_to_str(arch));
+            return 0;  // unreachable
+    }
+}
+
 // The channel structure is as follows:
 //              &header->  |----------------| channel_base_address
 //                         |    header      |

--- a/tt_metal/fabric/erisc_datamover_builder.hpp
+++ b/tt_metal/fabric/erisc_datamover_builder.hpp
@@ -389,12 +389,23 @@ class FabricEriscDatamoverBuilder : public FabricDatamoverBuilderBase {
 public:
     static constexpr size_t default_firmware_context_switch_interval = 10000;
     static constexpr auto default_firmware_context_switch_type = FabricEriscDatamoverContextSwitchType::WAIT_FOR_IDLE;
+
+    // Default packet payload sizes (optimized for 4 tiles of Bfp8_b)
+    // Users can configure larger sizes up to architecture-specific maximums
+    // via FabricRouterConfig in SetFabricConfig()
     // payload only, no header
     static constexpr size_t default_packet_payload_size_bytes = tt::tile_size(tt::DataFormat::Bfp8_b) * 4;
     static constexpr size_t default_mesh_packet_payload_size_bytes = tt::tile_size(tt::DataFormat::Bfp8_b) * 4;
 
+    // Architecture-specific maximum packet payload size limits
+    static constexpr size_t max_packet_payload_size_bytes_wormhole = 7 * 1088;    // 7616 bytes
+    static constexpr size_t max_packet_payload_size_bytes_blackhole = 14 * 1088;  // 15232 bytes
+
     static_assert(default_packet_payload_size_bytes == 4352, "Packet size must be 4352 bytes");
     static_assert(default_mesh_packet_payload_size_bytes == 4352, "Mesh packet size must be 4352 bytes");
+
+    // Get architecture-specific maximum packet payload size
+    static size_t get_max_packet_payload_size_for_arch(tt::ARCH arch);
 
     FabricEriscDatamoverBuilder(
         const CoreCoord& my_eth_core_logical,

--- a/tt_metal/fabric/fabric.cpp
+++ b/tt_metal/fabric/fabric.cpp
@@ -336,9 +336,10 @@ void SetFabricConfig(
     FabricReliabilityMode reliability_mode,
     std::optional<uint8_t> num_routing_planes,
     FabricTensixConfig fabric_tensix_config,
-    FabricUDMMode fabric_udm_mode) {
+    FabricUDMMode fabric_udm_mode,
+    FabricRouterConfig router_config) {
     tt::tt_metal::MetalContext::instance().set_fabric_config(
-        fabric_config, reliability_mode, num_routing_planes, fabric_tensix_config, fabric_udm_mode);
+        fabric_config, reliability_mode, num_routing_planes, fabric_tensix_config, fabric_udm_mode, router_config);
 }
 
 std::optional<eth_chan_directions> get_eth_forwarding_direction(

--- a/tt_metal/fabric/fabric_context.hpp
+++ b/tt_metal/fabric/fabric_context.hpp
@@ -35,7 +35,8 @@ public:
     static constexpr auto routing_directions = {
         RoutingDirection::N, RoutingDirection::S, RoutingDirection::E, RoutingDirection::W};
 
-    explicit FabricContext(tt::tt_fabric::FabricConfig fabric_config);
+    explicit FabricContext(
+        tt::tt_fabric::FabricConfig fabric_config, const FabricRouterConfig& router_config = FabricRouterConfig{});
     ~FabricContext();
 
     // Non-copyable, non-movable
@@ -81,9 +82,11 @@ private:
     std::unordered_map<MeshId, bool> check_for_wrap_around_mesh() const;
     size_t compute_packet_header_size_bytes() const;
     size_t compute_max_payload_size_bytes() const;
+    size_t validate_and_apply_packet_size(size_t requested_size) const;
 
     tt::tt_fabric::FabricConfig fabric_config_{};
     tt::tt_fabric::Topology topology_{};
+    FabricRouterConfig router_config_{};
 
     bool is_2D_routing_enabled_ = false;
     bool bubble_flow_control_enabled_ = false;

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -579,7 +579,8 @@ void MetalContext::set_fabric_config(
     tt_fabric::FabricReliabilityMode reliability_mode,
     std::optional<uint8_t> num_routing_planes,
     tt_fabric::FabricTensixConfig fabric_tensix_config,
-    tt_fabric::FabricUDMMode fabric_udm_mode) {
+    tt_fabric::FabricUDMMode fabric_udm_mode,
+    tt_fabric::FabricRouterConfig router_config) {
     // Changes to fabric force a re-init. TODO: We should supply the fabric config in the same way as the dispatch
     // config, not through this function exposed in the detail API.
     force_reinit_ = true;
@@ -636,6 +637,7 @@ void MetalContext::set_fabric_config(
     // Set the fabric tensix config
     this->set_fabric_tensix_config(fabric_tensix_config);
     this->fabric_udm_mode_ = fabric_udm_mode;
+    this->fabric_router_config_ = router_config;
 }
 
 void MetalContext::initialize_fabric_config() {
@@ -647,7 +649,7 @@ void MetalContext::initialize_fabric_config() {
         this->fabric_config_, this->num_fabric_active_routing_planes_);
     auto& control_plane = this->get_control_plane();
     if (tt::tt_fabric::is_tt_fabric_config(this->fabric_config_)) {
-        control_plane.initialize_fabric_context(this->fabric_config_);
+        control_plane.initialize_fabric_context(this->fabric_config_, this->fabric_router_config_);
     }
     control_plane.configure_routing_tables_for_fabric_ethernet_channels(
         this->fabric_config_, this->fabric_reliability_mode_);
@@ -666,6 +668,8 @@ void MetalContext::initialize_fabric_tensix_datamover_config() {
 }
 
 tt_fabric::FabricConfig MetalContext::get_fabric_config() const { return fabric_config_; }
+
+const tt_fabric::FabricRouterConfig& MetalContext::get_fabric_router_config() const { return fabric_router_config_; }
 
 void MetalContext::set_fabric_tensix_config(tt_fabric::FabricTensixConfig fabric_tensix_config) {
     fabric_tensix_config_ = fabric_tensix_config;

--- a/tt_metal/impl/context/metal_context.hpp
+++ b/tt_metal/impl/context/metal_context.hpp
@@ -89,10 +89,12 @@ public:
             tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE,
         std::optional<uint8_t> num_routing_planes = std::nullopt,
         tt_fabric::FabricTensixConfig fabric_tensix_config = tt_fabric::FabricTensixConfig::DISABLED,
-        tt_fabric::FabricUDMMode fabric_udm_mode = tt_fabric::FabricUDMMode::DISABLED);
+        tt_fabric::FabricUDMMode fabric_udm_mode = tt_fabric::FabricUDMMode::DISABLED,
+        tt_fabric::FabricRouterConfig router_config = tt_fabric::FabricRouterConfig{});
     void initialize_fabric_config();
     void initialize_fabric_tensix_datamover_config();
     tt_fabric::FabricConfig get_fabric_config() const;
+    const tt_fabric::FabricRouterConfig& get_fabric_router_config() const;
 
     distributed::multihost::DistributedContext& global_distributed_context();
     std::shared_ptr<distributed::multihost::DistributedContext> get_distributed_context_ptr();
@@ -196,6 +198,7 @@ private:
     tt_fabric::FabricConfig fabric_config_ = tt_fabric::FabricConfig::DISABLED;
     tt_fabric::FabricTensixConfig fabric_tensix_config_ = tt_fabric::FabricTensixConfig::DISABLED;
     tt_fabric::FabricUDMMode fabric_udm_mode_ = tt_fabric::FabricUDMMode::DISABLED;
+    tt_fabric::FabricRouterConfig fabric_router_config_ = tt_fabric::FabricRouterConfig{};
     std::shared_ptr<distributed::multihost::DistributedContext> distributed_context_;
 
     // We are using a thread_local to allow each thread to have its own command queue id stack.

--- a/ttnn/cpp/ttnn-pybind/fabric.cpp
+++ b/ttnn/cpp/ttnn-pybind/fabric.cpp
@@ -56,7 +56,8 @@ void py_bind_fabric_api(py::module& module) {
         py::arg("reliability_mode") = tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE,
         py::arg("num_planes") = std::nullopt,
         py::arg("fabric_tensix_config") = tt::tt_fabric::FabricTensixConfig::DISABLED,
-        py::arg("fabric_udm_mode") = tt::tt_fabric::FabricUDMMode::DISABLED);
+        py::arg("fabric_udm_mode") = tt::tt_fabric::FabricUDMMode::DISABLED,
+        py::arg("router_config") = tt::tt_fabric::FabricRouterConfig{});
 }
 
 }  // namespace ttnn::fabric


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes