### PR TITLE
#32626: Remove `Moreh` operations from docs

### DIFF
--- a/docs/source/ttnn/ttnn/api.rst
+++ b/docs/source/ttnn/ttnn/api.rst
@@ -489,17 +489,6 @@ Normalization Program Configs
    ttnn.SoftmaxDefaultProgramConfig
    ttnn.SoftmaxShardedMultiCoreProgramConfig
 
-
-Moreh Operations
-================
-
-.. autosummary::
-   :toctree: api
-   :nosignatures:
-   :template: function.rst
-
-   ttnn.moreh_sum
-
 Transformer
 ===========
 

--- a/tests/ttnn/docs_examples/examples_mapping.py
+++ b/tests/ttnn/docs_examples/examples_mapping.py
@@ -377,8 +377,6 @@ FUNCTION_TO_EXAMPLES_MAPPING_DICT = {
     # Normalization Program Configs
     "ttnn.SoftmaxDefaultProgramConfig": normalization.test_softmax_default_program_config,
     "ttnn.SoftmaxShardedMultiCoreProgramConfig": normalization.test_scale_mask_softmax_in_place,
-    # Moreh Operations
-    # "ttnn.moreh_sum": moreh.test_moreh_sum, # Lack of example
     # Transformers
     # "ttnn.transformer.split_query_key_value_and_split_heads": transformer.test_split_query_key_value_and_split_heads, # Lack of example
     # "ttnn.transformer.concatenate_heads": transformer.test_concatenate_heads, # Lack of example


### PR DESCRIPTION
### Ticket

#32626

### Problem description
Based on the conversation in the ticket, operations under the `Moreh` category will not be supported in the future, and we are not planning to include them in the documentation. 

### What's changed
- Removed `Moreh` category and all operations from docs.