### PR TITLE
Fix block-sharded matmul tile calculation

### DIFF
--- a/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
@@ -2496,3 +2496,60 @@ def test_linear_with_non_tile_aligned_bias(device, input_shape, weight_shape):
 
     # Verify correctness
     assert_with_pcc(torch_output, output, pcc=0.99)
+
+
+def test_matmul_block_sharded_input_with_padding(device):
+    """
+    Test matmul with block-sharded input where logical shape differs from physical shard shape due to padding.
+
+    This test verifies that matmul correctly handles block-sharded inputs with padding:
+    - Input 0: (4096, 16) block_sharded on 8x1 cores, logical shape (4096, 16) but physical padded to (512, 32) per shard
+    - Input 1: (16, 128) interleaved, DRAM
+    """
+    torch.manual_seed(0)
+
+    input_a_shape = (4096, 16)
+    input_b_shape = (16, 128)
+    expected_output_shape = (4096, 128)
+
+    torch_input_a = torch.randn(input_a_shape, dtype=torch.bfloat16)
+    torch_input_b = torch.randn(input_b_shape, dtype=torch.bfloat16)
+    torch_output = torch.matmul(torch_input_a, torch_input_b)
+
+    # Input 0: Create with TILE layout, pad width from 16 to 32, then block shard
+    ttnn_input_a = ttnn.from_torch(
+        torch_input_a,
+        layout=ttnn.TILE_LAYOUT,
+        tile=ttnn.Tile((32, 32)),
+        device=device,
+        dtype=ttnn.bfloat16,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    ttnn_input_a = ttnn.reshape(ttnn_input_a, input_a_shape, padded_shape=(4096, 32))
+
+    # Input 1: Interleaved, DRAM
+    ttnn_input_b = ttnn.from_torch(
+        torch_input_b,
+        layout=ttnn.TILE_LAYOUT,
+        tile=ttnn.Tile((32, 32)),
+        device=device,
+        dtype=ttnn.bfloat16,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    # Block shard input 0: 8x1 cores, shard shape [512, 32]
+    input_a_sharded_memory_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+        ttnn.BufferType.L1,
+        ttnn.ShardSpec(
+            ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 0))]),
+            [512, 32],
+            ttnn.ShardOrientation.COL_MAJOR,
+        ),
+    )
+    ttnn_input_a = ttnn.to_memory_config(ttnn_input_a, input_a_sharded_memory_config)
+
+    ttnn_output = ttnn.matmul(ttnn_input_a, ttnn_input_b, transpose_a=False, transpose_b=False)
+
+    output = ttnn.to_torch(ttnn_output)
+    assert_with_pcc(torch_output, output, pcc=0.99)

--- a/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
@@ -2510,7 +2510,6 @@ def test_matmul_block_sharded_input_with_padding(device):
 
     input_a_shape = (4096, 16)
     input_b_shape = (16, 128)
-    expected_output_shape = (4096, 128)
 
     torch_input_a = torch.randn(input_a_shape, dtype=torch.bfloat16)
     torch_input_b = torch.randn(input_b_shape, dtype=torch.bfloat16)

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
@@ -799,12 +799,12 @@ MatmulProgramConfig create_matmul_program_config(
                 compute_kernel_config,
                 output_dtype);
         }
-        uint32_t k = a_shape[-1] / ttnn::TILE_SIZE;
-        uint32_t n = b_shape[-1] / ttnn::TILE_SIZE;
+        uint32_t k = div_up(a_shape[-1], ttnn::TILE_SIZE);
+        uint32_t n = div_up(b_shape[-1], ttnn::TILE_SIZE);
         auto shard_shape = input_tensor_a_memory_config.shard_spec().value().shape;
-        m_tiles_per_core = shard_shape[0] / ttnn::TILE_SIZE;
-        n_tiles_per_core = (n * shard_shape[1]) / (k * ttnn::TILE_SIZE);
-        k_tiles_per_core = std::gcd(shard_shape[1] / ttnn::TILE_SIZE, k);
+        m_tiles_per_core = div_up(shard_shape[0], ttnn::TILE_SIZE);
+        n_tiles_per_core = div_up(n * shard_shape[1], k * ttnn::TILE_SIZE);
+        k_tiles_per_core = std::gcd(div_up(shard_shape[1], ttnn::TILE_SIZE), k);
     }
 
     n_tiles_per_core = std::max(n_tiles_per_core, (unsigned int)1);
@@ -1943,10 +1943,10 @@ void Matmul::validate(
                             program_config.in0_block_w);
                         if (!program_config.gather_in0) {  // Padding allowed for gather_in0
                             TT_FATAL(
-                            (shard_shape[1] / in0_tile_shape[1]) % program_config.in0_block_w == 0,
-                            "Error: shard_shape[1] ({}) / in0_tile_shape[1] ({}) must be divisible by in0_block_w.",
-                            shard_shape[1],
-                            in0_tile_shape[1]);
+                                (shard_shape[1] / in0_tile_shape[1]) % program_config.in0_block_w == 0,
+                                "Error: shard_shape[1] ({}) / in0_tile_shape[1] ({}) must be divisible by in0_block_w.",
+                                shard_shape[1],
+                                in0_tile_shape[1]);
                         }
                     }
                     if (this->output_mem_config.is_sharded()) {

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
@@ -799,12 +799,12 @@ MatmulProgramConfig create_matmul_program_config(
                 compute_kernel_config,
                 output_dtype);
         }
-        uint32_t k = div_up(a_shape[-1], ttnn::TILE_SIZE);
-        uint32_t n = div_up(b_shape[-1], ttnn::TILE_SIZE);
+        uint32_t k = a_padded_shape[-1] / ttnn::TILE_SIZE;
+        uint32_t n = b_padded_shape[-1] / ttnn::TILE_SIZE;
         auto shard_shape = input_tensor_a_memory_config.shard_spec().value().shape;
-        m_tiles_per_core = div_up(shard_shape[0], ttnn::TILE_SIZE);
-        n_tiles_per_core = div_up(n * shard_shape[1], k * ttnn::TILE_SIZE);
-        k_tiles_per_core = std::gcd(div_up(shard_shape[1], ttnn::TILE_SIZE), k);
+        m_tiles_per_core = shard_shape[0] / ttnn::TILE_SIZE;
+        n_tiles_per_core = (n * shard_shape[1]) / (k * ttnn::TILE_SIZE);
+        k_tiles_per_core = std::gcd(shard_shape[1] / ttnn::TILE_SIZE, k);
     }
 
     n_tiles_per_core = std::max(n_tiles_per_core, (unsigned int)1);


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-forge/issues/710)

### Problem description
The current implementation of the matmul kernel uses the logical shape instead of the padded shape when calculating the number of tiles for block-sharded input.

This caused multiple models to break when run in tt-xla with the optimizer enabled. Specifically, when the logical shape has a last dimension less than 32, it calculates 0 tiles, which later leads to a divide-by-zero floating-point exception.

### What's changed
- Changed `logical_shape` with `padded_shape` in number of tiles calculation
- Added a new test that was previously crashing with `Floating point exception (core dumped)`

CI runs:
- [All post-commit](https://github.com/tenstorrent/tt-metal/actions/runs/19963008166) ✅ 
- [Blackhole post-commit](https://github.com/tenstorrent/tt-metal/actions/runs/19962957813) ✅ 
- [Frequent models](https://github.com/tenstorrent/tt-metal/actions/runs/19929183025) 
- [Device perf](https://github.com/tenstorrent/tt-metal/actions/runs/19962973704) ✅ 
- [Nightly L2](https://github.com/tenstorrent/tt-metal/actions/runs/19929207615) ✅ 

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [x] New/Existing tests provide coverage for changes