### PR TITLE
Migrate op to new infra: concat

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/data_movement/CMakeLists.txt
@@ -109,6 +109,10 @@ target_sources(
         concat/concat.cpp
         concat/device/concat_device_operation.cpp
         concat/device/concat_program_factory.cpp
+        concat/device/concat_s2s_tiled_program_factory.cpp
+        concat/device/concat_s2s_rm_program_factory.cpp
+        concat/device/concat_s2s_multi_program_factory.cpp
+        concat/device/concat_s2i_program_factory.cpp
         copy/copy.cpp
         copy/device/copy_device_operation.cpp
         copy/device/copy_program_factory.cpp

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_device_operation.cpp
@@ -1,36 +1,75 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "ttnn/operations/data_movement/concat/device/concat_device_operation.hpp"
-#include "ttnn/operations/core/core.hpp"
-#include "ttnn/operations/data_movement/concat/device/concat_program_factory.hpp"
+#include "concat_device_operation.hpp"
+#include "concat_program_factory.hpp"
 
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/operations/data_movement/clone/clone.hpp"
-#include "ttnn/run_operation.hpp"
+#include "ttnn/operations/core/core.hpp"  // for to_layout
 #include <tt-logger/tt-logger.hpp>
 #include "ttnn/operations/data_movement/common/common.hpp"
 
-using namespace tt::constants;
 using namespace tt::tt_metal;
 
-namespace ttnn::operations::data_movement {
+namespace ttnn::operations::data_movement::concat {
 
-ConcatOpParallelizationStrategy ConcatDeviceOperation::get_parallelization_strategy(
-    const std::vector<Tensor>& input_tensors) const {
-    if (input_tensors[0].is_sharded()) {
-        return ConcatOpParallelizationStrategy::SHARDED_MULTI_CORE;
+ConcatDeviceOperation::program_factory_t ConcatDeviceOperation::select_program_factory(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    if (tensor_args.input_tensors.empty()) {
+        TT_FATAL(false, "ConcatDeviceOperation: input_tensors cannot be empty");
+    }
+
+    const auto& input_tensors = tensor_args.input_tensors;
+    const bool is_sharded = input_tensors[0].is_sharded();
+
+    if (!is_sharded) {
+        return program::ConcatProgramFactory{};
+    }
+
+    // Sharded cases - determine which specific factory to use
+    const bool output_is_sharded = args.output_mem_config.is_sharded();
+
+    if (output_is_sharded) {
+        // Sharded-to-sharded (s2s) cases
+        if (input_tensors.size() == 2) {
+            // Optimized 2-tensor case
+            TT_FATAL(
+                input_tensors[0].layout() == input_tensors[1].layout(),
+                "Expected all input tensors to have the same layout for 2-tensor sharded concat");
+
+            if (input_tensors[0].layout() == Layout::ROW_MAJOR) {
+                return program::ConcatS2SRMProgramFactory{};
+            } else {
+                return program::ConcatS2STiledProgramFactory{};
+            }
+        } else {
+            // Multi-tensor s2s case
+            return program::ConcatS2SMultiProgramFactory{};
+        }
     } else {
-        return ConcatOpParallelizationStrategy::MULTI_CORE;
+        // Sharded-to-interleaved (s2i) case
+        return program::ConcatS2IProgramFactory{};
     }
 }
 
-void ConcatDeviceOperation::validate(const std::vector<Tensor>& input_tensors) const {
+void ConcatDeviceOperation::validate_on_program_cache_hit(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    validate_on_program_cache_miss(args, tensor_args);
+}
+
+void ConcatDeviceOperation::validate_on_program_cache_miss(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    using namespace tt::constants;
+
+    const auto& input_tensors = tensor_args.input_tensors;
+    TT_FATAL(!input_tensors.empty(), "need 1 or more tensors");
+
     const auto& first_input = input_tensors[0];
     auto shape_first = first_input.padded_shape();
-    TT_FATAL(this->dim < shape_first.rank(), "ConcatDeviceOperation dim specified is larger than input tensor rank.");
-    shape_first[this->dim] = 0;
+    TT_FATAL(args.dim < shape_first.rank(), "ConcatDeviceOperation dim specified is larger than input tensor rank.");
+    shape_first[args.dim] = 0;
     bool shard_first = input_tensors[0].is_sharded();
     bool warn_about_alignment = false;
 
@@ -43,10 +82,14 @@ void ConcatDeviceOperation::validate(const std::vector<Tensor>& input_tensors) c
         TT_FATAL(in_ref.dtype() == first_input.dtype(), "All Tensors should have same dtypes.");
         auto curr_shape = in_ref.padded_shape();
         TT_FATAL(curr_shape.rank() == shape_first.rank(), "Input tensor ranks must be equal");
-        curr_shape[this->dim] = 0;
+        curr_shape[args.dim] = 0;
         // last tensor can support without any kernel changes
-        if (in_ref.layout() == Layout::TILE and in_ref.logical_shape()[dim] != in_ref.padded_shape()[dim]) {
-            warn_about_alignment = true;
+        if (in_ref.layout() == Layout::TILE) {
+            const uint32_t logical_dim = in_ref.logical_shape()[args.dim];
+            const uint32_t padded_dim = in_ref.padded_shape()[args.dim];
+            if (logical_dim != padded_dim) {
+                warn_about_alignment = true;
+            }
         }
         TT_FATAL(curr_shape == shape_first, "concat tensors differ in shape across non-concat dimensions.");
         TT_FATAL(in_ref.is_sharded() == shard_first, "All tensors must be sharded or all must be interleaved");
@@ -73,22 +116,22 @@ void ConcatDeviceOperation::validate(const std::vector<Tensor>& input_tensors) c
             "ttnn.concat: Tile padding along concatenated dim ({}) is not "
             "directly supported. ttnn.concat will proceed by converting to "
             "row-major then retilizing. This may have adverse performance impacts.",
-            this->dim);
+            args.dim);
     }
     if (shard_first) {
         const auto memory_layout = first_input.memory_config().memory_layout();
         TT_FATAL(
-            this->output_mem_config.memory_layout() == memory_layout,
+            args.output_mem_config.memory_layout() == memory_layout,
             "Sharded output and inputs must have the same memory layout.");
-        TT_FATAL(this->output_mem_config.is_sharded(), "Output must be sharded if input is sharded.");
+        TT_FATAL(args.output_mem_config.is_sharded(), "Output must be sharded if input is sharded.");
         TT_FATAL(
-            this->output_mem_config.shard_spec().value().grid == first_input.shard_spec().value().grid,
+            args.output_mem_config.shard_spec().value().grid == first_input.shard_spec().value().grid,
             "Sharded output and inputs must have the same grid.");
-        if (this->dim == shape_first.rank() - 1) {
+        if (args.dim == shape_first.rank() - 1) {
             TT_FATAL(
                 memory_layout == TensorMemoryLayout::HEIGHT_SHARDED,
                 "Only support width concat on height-sharded tensors.");
-        } else if (this->dim == shape_first.rank() - 2) {
+        } else if (args.dim == shape_first.rank() - 2) {
             TT_FATAL(
                 memory_layout == TensorMemoryLayout::WIDTH_SHARDED,
                 "Only support height concat on width-sharded tensors.");
@@ -96,55 +139,79 @@ void ConcatDeviceOperation::validate(const std::vector<Tensor>& input_tensors) c
             TT_FATAL(false, "Only width or height concat on sharded tensors");
         }
         TT_FATAL(
-            this->groups == 1 || memory_layout == TensorMemoryLayout::HEIGHT_SHARDED,
+            args.groups == 1 || memory_layout == TensorMemoryLayout::HEIGHT_SHARDED,
             "Groups > 1 is only supported on height-sharded tensors (groups={} and memory_layout={} was provided)",
-            this->groups,
+            args.groups,
             memory_layout);
     }
 }
 
-std::vector<ttnn::TensorSpec> ConcatDeviceOperation::compute_output_specs(
-    const std::vector<Tensor>& input_tensors) const {
-    const Tensor& ref_in_tensor = input_tensors.at(0);
+spec_return_value_t ConcatDeviceOperation::compute_output_specs(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    const Tensor& ref_in_tensor = tensor_args.input_tensors.at(0);
     ttnn::Shape shape_out = ref_in_tensor.logical_shape();
-    shape_out[this->dim] = 0;
-    for (const Tensor& in_ref : input_tensors) {
+    shape_out[args.dim] = 0;
+    for (const Tensor& in_ref : tensor_args.input_tensors) {
         ttnn::Shape curr_shape = in_ref.logical_shape();
-        shape_out[this->dim] += curr_shape[this->dim];
+        shape_out[args.dim] += curr_shape[args.dim];
     }
 
-    return {TensorSpec(
-        shape_out, TensorLayout(ref_in_tensor.dtype(), PageConfig(ref_in_tensor.layout()), this->output_mem_config))};
+    return TensorSpec(
+        shape_out, TensorLayout(ref_in_tensor.dtype(), PageConfig(ref_in_tensor.layout()), args.output_mem_config));
 }
 
-operation::ProgramWithCallbacks ConcatDeviceOperation::create_program(
-    const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const {
-    switch (this->get_parallelization_strategy(input_tensors)) {
-        case ConcatOpParallelizationStrategy::SHARDED_MULTI_CORE: {
-            return detail::sharded_concat_multi_core(input_tensors, this->dim, output_tensors[0], this->groups);
-        }
-        case ConcatOpParallelizationStrategy::MULTI_CORE:
-        default: {
-            TT_FATAL(this->groups == 1, "Groups > 1 not supported for ttnn.concat with interleaved input tensors");
-            return detail::concat_multi_core(input_tensors, this->dim, output_tensors[0]);
-        }
-    };
+tensor_return_value_t ConcatDeviceOperation::create_output_tensors(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    auto output_spec = compute_output_specs(operation_attributes, tensor_args);
+    return create_device_tensor(output_spec, tensor_args.input_tensors[0].device());
 }
 
 tt::tt_metal::operation::OpPerformanceModelGeneral<std::vector<Tensor>>
 ConcatDeviceOperation::create_op_performance_model(
     const std::vector<Tensor>& input_tensors,
     const std::vector<std::optional<const Tensor>>& optional_input_tensors,
-    std::vector<Tensor>& output_tensors) const {
+    std::vector<Tensor>& output_tensors) {
+    TT_FATAL(
+        !input_tensors.empty(), "ConcatDeviceOperation::create_op_performance_model: input_tensors cannot be empty");
+    TT_FATAL(
+        !output_tensors.empty(), "ConcatDeviceOperation::create_op_performance_model: output_tensors cannot be empty");
+
     const auto& input_tensor = input_tensors.at(0);
     const auto& output_tensor = output_tensors.at(0);
+
+    // Use common_tm_bw_model with concat_op=true for concat-specific bandwidth modeling
     int ideal_dev_clock_cycles = common_tm_bw_model(input_tensor, output_tensor, false, 0, false, false, false, true);
+
     tt::tt_metal::operation::OpPerformanceModelGeneral<std::vector<Tensor>> result(
         input_tensors, output_tensors, ideal_dev_clock_cycles);
     return result;
 }
 
+std::tuple<ConcatDeviceOperation::operation_attributes_t, ConcatDeviceOperation::tensor_args_t>
+ConcatDeviceOperation::invoke(
+    const std::vector<Tensor>& input_tensors,
+    std::int64_t dim,
+    unsigned int groups,
+    const tt::tt_metal::MemoryConfig& output_mem_config) {
+    uint32_t normalized_dim = input_tensors[0].padded_shape().get_normalized_index(dim);
+
+    return {
+        operation_attributes_t{
+            .dim = normalized_dim,
+            .groups = groups,
+            .output_mem_config = output_mem_config,
+        },
+        tensor_args_t{.input_tensors = input_tensors}};
+}
+
+}  // namespace ttnn::operations::data_movement::concat
+
+namespace ttnn::operations::data_movement {
+
 namespace {
+
+using namespace tt::constants;
+
 // Calculate maximum tensors per concat based on runtime args limit
 uint32_t calculate_max_tensors_per_concat(const std::vector<Tensor>& input_tensors, const std::int64_t dim) {
     // Runtime args are limited by available L1 kernel config memory.
@@ -306,7 +373,7 @@ Tensor concat_impl(
     uint32_t normalized_dim = input_tensors[0].padded_shape().get_normalized_index(dim);
 
     if (input_tensors[0].is_sharded()) {
-        return operation::run(ConcatDeviceOperation{normalized_dim, groups, output_mem_config}, {input_tensors}).at(0);
+        return ttnn::prim::concat(input_tensors, dim, groups, output_mem_config);
     } else {
         if (input_tensors[0].layout() == Layout::ROW_MAJOR && normalized_dim == ref_rank - 1) {
             for (const auto& input_tensor : input_tensors) {
@@ -345,8 +412,7 @@ Tensor concat_impl(
             }
         }
 
-        return operation::run(ConcatDeviceOperation{normalized_dim, groups, output_mem_config}, {formatted_tensors})
-            .at(0);
+        return ttnn::prim::concat(formatted_tensors, dim, groups, output_mem_config);
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_device_operation_types.hpp
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/tensor/tensor.hpp"
+
+namespace ttnn::operations::data_movement::concat {
+
+struct operation_attributes_t {
+    uint32_t dim;
+    unsigned int groups;
+    tt::tt_metal::MemoryConfig output_mem_config;
+};
+
+struct tensor_args_t {
+    std::vector<Tensor> input_tensors;
+};
+
+using tensor_return_value_t = Tensor;
+using spec_return_value_t = TensorSpec;
+
+}  // namespace ttnn::operations::data_movement::concat

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_program_factory.cpp
@@ -1,730 +1,37 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttnn/operations/data_movement/concat/device/concat_program_factory.hpp"
 
 #include <algorithm>
-#include <numeric>
 
-#include "ttnn/operations/data_movement/concat/device/concat_device_operation.hpp"
 #include "ttnn/tensor/tensor.hpp"
 
 #include <tt-metalium/tt_align.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 
-using namespace tt;
-using namespace tt::constants;
-using namespace tt::tt_metal;
-
-namespace {
-
-uint32_t find_greatest_common_page_size(std::vector<uint32_t>& stick_sizes, uint32_t alignment) {
-    TT_FATAL(!stick_sizes.empty(), "Need at least one stick size to find page size");
-    uint32_t page_size = tt::align(stick_sizes[0], alignment);
-    for (size_t idx = 1; idx < stick_sizes.size(); idx++) {
-        const uint32_t padded_stick_size = tt::align(stick_sizes[idx], alignment);
-        page_size = std::gcd(page_size, padded_stick_size);
-    }
-    return page_size;
-}
-
-}  // namespace
-
-namespace ttnn::operations::data_movement::detail {
-
-tt_metal::operation::ProgramWithCallbacks s2s_tiled_concat_two_tensors_height_multi_core(
-    const std::vector<Tensor>& input_tensors, uint32_t dim, Tensor& output, unsigned int groups) {
-    // If we end up here for concat with more than 2 tensors on any other dim we should have
-    // taken another path
-    TT_FATAL(dim == 3, "Sharded concat with tiled inputs only supports dim=3 (was {})", dim);
-    TT_FATAL(input_tensors.size() == 2, "Expected 2 input tensors (was {})", input_tensors.size());
-
-    TT_FATAL(
-        input_tensors[0].logical_shape()[-1] == input_tensors[0].padded_shape()[-1],
-        "Cannot have padding along width dimension in input tensor 0 ({} != {})",
-        input_tensors[0].logical_shape()[-1],
-        input_tensors[0].padded_shape()[-1]);
-    TT_FATAL(
-        input_tensors[1].logical_shape()[-1] == input_tensors[1].padded_shape()[-1],
-        "Cannot have padding along width dimension in input tensor 1 ({} != {})",
-        input_tensors[1].logical_shape()[-1],
-        input_tensors[1].padded_shape()[-1]);
-
-    TT_FATAL(
-        input_tensors[0].padded_shape()[-1] % groups == 0,
-        "Input tensor 0 columns must be evenly divisible by groups (W={}, groups={})",
-        input_tensors[0].padded_shape()[-1],
-        groups);
-    TT_FATAL(
-        input_tensors[1].padded_shape()[-1] % groups == 0,
-        "Input tensor 1 columns must be evenly divisible by groups (W={}, groups={})",
-        input_tensors[1].padded_shape()[-1],
-        groups);
-
-    // The current implementation relies on not having break up tile faces so if we would
-    // need to split tiles because dim[-1] / groups < 16, we cannot proceed
-    TT_FATAL(
-        input_tensors[0].padded_shape()[-1] / groups >= TILE_HEIGHT / 2,
-        "Group size must be at least 16 for input0 (was {})",
-        input_tensors[0].padded_shape()[-1] / groups);
-    TT_FATAL(
-        input_tensors[1].padded_shape()[-1] / groups >= TILE_HEIGHT / 2,
-        "Group size must be at least 16 for input1 (was {})",
-        input_tensors[1].padded_shape()[-1] / groups);
-
-    tt_metal::Program program = tt_metal::CreateProgram();
-
-    const auto all_cores = input_tensors[0].shard_spec().value().grid;  // assume all inputs have same grid
-
-    const auto get_num_tiles_per_shard =
-        [](const std::array<uint32_t, 2>& shard_shape) -> std::tuple<uint32_t, uint32_t> {
-        TT_FATAL(shard_shape[0] % TILE_HEIGHT == 0, "Shard height must be aligned to tile height");
-        TT_FATAL(shard_shape[1] % TILE_WIDTH == 0, "Shard width must be aligned to tile width");
-        const uint32_t num_tiles_along_height = shard_shape[0] / TILE_HEIGHT;
-        const uint32_t num_tiles_along_width = shard_shape[1] / TILE_WIDTH;
-        TT_FATAL(num_tiles_along_height != 0 && num_tiles_along_width != 0, "Expected tensor to have at least 1 tiles");
-        return {num_tiles_along_height, num_tiles_along_width};
-    };
-
-    const auto get_total_num_tiles_per_shard = [](const std::tuple<uint32_t, uint32_t>& num_tiles) -> uint32_t {
-        return std::get<0>(num_tiles) * std::get<1>(num_tiles);
-    };
-
-    std::vector<std::tuple<uint32_t, uint32_t>> num_tiles_for_each_input_shard;
-    num_tiles_for_each_input_shard.reserve(input_tensors.size());
-    for (const auto& input_tensor : input_tensors) {
-        num_tiles_for_each_input_shard.push_back(get_num_tiles_per_shard(input_tensor.shard_spec()->shape));
-    }
-    const auto num_tiles_for_output_shard = get_num_tiles_per_shard(output.shard_spec()->shape);
-
-    log_debug(tt::LogOp, "Number of tiles per input tensor shard: {}", num_tiles_for_each_input_shard);
-    log_debug(tt::LogOp, "Number of tiles for output tensor shard: {}", num_tiles_for_output_shard);
-
-    const auto create_circular_buffer = [&program, &cores = all_cores](
-                                            uint32_t index,
-                                            uint32_t num_tiles,
-                                            uint32_t tile_size,
-                                            const tt::DataFormat& format,
-                                            Buffer* buffer) -> tt::tt_metal::CBHandle {
-        log_debug(
-            tt::LogOp,
-            "Creating CB (id={}) for {} tiles (each {} B) with total size {} B",
-            index,
-            num_tiles,
-            tile_size,
-            num_tiles * tile_size);
-        tt::tt_metal::CircularBufferConfig config =
-            tt::tt_metal::CircularBufferConfig(num_tiles * tile_size, {{index, format}})
-                .set_page_size(index, tile_size);
-        if (buffer) {
-            config.set_globally_allocated_address(*buffer);
-        }
-        return tt::tt_metal::CreateCircularBuffer(program, cores, config);
-    };
-
-    const auto create_cb_from_tensor =
-        [&create_circular_buffer](
-            uint32_t idx, const Tensor& input_tensor, uint32_t total_num_tiles) -> tt::tt_metal::CBHandle {
-        const auto data_format = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.dtype());
-        const auto tile_size = tt::tile_size(data_format);
-        return create_circular_buffer(idx, total_num_tiles, tile_size, data_format, input_tensor.buffer());
-    };
-
-    TT_FATAL(input_tensors.at(0).dtype() == input_tensors.at(1).dtype(), "Input tensor data types must match");
-    const auto data_format = tt::tt_metal::datatype_to_dataformat_converter(input_tensors.at(0).dtype());
-    const auto tile_size = tt::tile_size(data_format);
-
-    const uint32_t num_input_tensors = input_tensors.size();
-    std::vector<CBHandle> cb_inputs(num_input_tensors);
-    for (uint32_t idx = 0; idx < num_input_tensors; idx++) {
-        const auto& input_tensor = input_tensors.at(idx);
-        const auto total_num_tiles = get_total_num_tiles_per_shard(num_tiles_for_each_input_shard[idx]);
-        cb_inputs[idx] = create_cb_from_tensor(idx, input_tensor, total_num_tiles);
-    }
-
-    const uint32_t cb_output_id = cb_inputs.size();
-    const auto total_num_output_tiles = get_total_num_tiles_per_shard(num_tiles_for_output_shard);
-    const CBHandle cb_output = create_cb_from_tensor(cb_output_id, output, total_num_output_tiles);
-
-    auto cb_data_format = data_format;
-    auto cb_tile_size = tile_size;
-    bool bf8 = input_tensors[0].dtype() == DataType::BFLOAT8_B;
-    if (bf8) {
-        cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(DataType::BFLOAT16);
-        cb_tile_size = tt::tile_size(cb_data_format);
-    }
-
-    const auto in0_total_tiles_width = std::get<1>(num_tiles_for_each_input_shard[0]);
-    const uint32_t cb_input0_transpose_id = cb_inputs.size() + 1;
-    create_circular_buffer(cb_input0_transpose_id, in0_total_tiles_width, cb_tile_size, cb_data_format, nullptr);
-
-    const auto in1_total_tiles_width = std::get<1>(num_tiles_for_each_input_shard[1]);
-    const uint32_t cb_input1_transpose_id = cb_inputs.size() + 2;
-    create_circular_buffer(cb_input1_transpose_id, in1_total_tiles_width, cb_tile_size, cb_data_format, nullptr);
-
-    const auto out_total_tiles_width = in0_total_tiles_width + in1_total_tiles_width;
-    const uint32_t cb_concat_id = cb_inputs.size() + 3;
-    create_circular_buffer(cb_concat_id, out_total_tiles_width, cb_tile_size, cb_data_format, nullptr);
-
-    const uint32_t cb_output_transpose_id = cb_inputs.size() + 4;
-    create_circular_buffer(cb_output_transpose_id, out_total_tiles_width, tile_size, data_format, nullptr);
-
-    std::vector<uint32_t> compile_time_args_0 = {
-        0,
-        1,
-        cb_input0_transpose_id,
-        cb_input1_transpose_id,
-        cb_concat_id,
-        cb_output_transpose_id,
-        cb_output_id,
-        std::get<0>(num_tiles_for_each_input_shard[0]),
-        std::get<1>(num_tiles_for_each_input_shard[0]),
-        std::get<0>(num_tiles_for_each_input_shard[1]),
-        std::get<1>(num_tiles_for_each_input_shard[1]),
-        tile_size,
-        groups,
-    };
-    std::map<std::string, std::string> reader_defines;
-    if (bf8) {
-        reader_defines["BF8"] = "1";
-    }
-    tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/"
-        "reader_height_sharded_width_concat_two_tensors_tiled.cpp",
-        all_cores,
-        tt_metal::ReaderDataMovementConfig(compile_time_args_0, std::move(reader_defines)));
-    tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/"
-        "writer_height_sharded_width_concat_two_tensors_tiled.cpp",
-        all_cores,
-        tt_metal::WriterDataMovementConfig(compile_time_args_0));
-
-    // TODO: Skip the tile transpose in compute kernel if the following condition is true:
-    // >> (input_tensors[0].padded_shape()[-1] / groups % TILE_WIDTH == 0
-    // >> && input_tensors[1].padded_shape()[-1] / groups % TILE_WIDTH == 0)
-    constexpr uint32_t MAX_1_BYTE_TILES_PER_BATCH = 16;
-    uint32_t BatchSize = MAX_1_BYTE_TILES_PER_BATCH / input_tensors[0].element_size();
-    compile_time_args_0.push_back(BatchSize);
-    tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/compute/"
-        "height_sharded_width_concat_two_tensors.cpp",
-        all_cores,
-        tt_metal::ComputeConfig{
-            .math_fidelity = MathFidelity::HiFi4,
-            .fp32_dest_acc_en = false,
-            .math_approx_mode = false,
-            .compile_args = compile_time_args_0});
-
-    auto override_runtime_arguments_callback = [num_input_tensors, cb_inputs, cb_output](
-                                                   const void* operation,
-                                                   Program& program,
-                                                   const std::vector<Tensor>& input_tensors,
-                                                   const std::vector<std::optional<const Tensor>>&,
-                                                   const std::vector<Tensor>& output_tensors) {
-        for (uint32_t idx = 0; idx < num_input_tensors; idx++) {
-            UpdateDynamicCircularBufferAddress(program, cb_inputs[idx], *input_tensors[idx].buffer());
-        }
-        UpdateDynamicCircularBufferAddress(program, cb_output, *output_tensors[0].buffer());
-    };
-
-    return {.program = std::move(program), .override_runtime_arguments_callback = override_runtime_arguments_callback};
-}
-
-template <typename T>
-static std::array<std::vector<T>, 2> split(std::vector<T> input, std::size_t index) {
-    if (index > input.size()) {
-        throw std::out_of_range{"split index out of range"};
-    }
-    std::vector<T> second{std::make_move_iterator(input.begin() + index), std::make_move_iterator(input.end())};
-    input.erase(input.begin() + index, input.end());
-    return {std::move(input), std::move(second)};
-}
-
-static CoreRangeSet cores_to_corerangeset(const std::vector<CoreCoord>& cores) {
-    std::vector<CoreRange> core_ranges;
-    core_ranges.reserve(cores.size());
-    for (const auto& core : cores) {
-        core_ranges.push_back(CoreRange(core));
-    }
-    return CoreRangeSet(core_ranges);
-}
-
-tt_metal::operation::ProgramWithCallbacks s2s_rm_concat_two_tensors_height_multi_core(
-    const std::vector<Tensor>& input_tensors, uint32_t dim, Tensor& output, unsigned int groups) {
-    TT_FATAL(dim == 3, "Sharded concat RM only supports dim=3");
-    TT_FATAL(groups == 1 || dim == 3, "Sharded concat RM only supports groups > 1 when dim=3");
-
-    TT_FATAL(
-        input_tensors.size() == 2 && input_tensors[0].padded_shape()[-1] % groups == 0 &&
-            input_tensors[0].padded_shape()[-1] % groups == 0,
-        "Input channels must both be evenly divisible by groups");
-
-    tt_metal::Program program = tt_metal::CreateProgram();
-
-    uint32_t num_output_rows = output.padded_shape()[-2];
-    uint32_t num_input_tensors = input_tensors.size();
-
-    std::vector<CBHandle> cb_input(num_input_tensors);
-
-    tt::DataFormat cb_data_format = tt_metal::datatype_to_dataformat_converter(output.dtype());
-    auto all_cores = input_tensors[0].shard_spec().value().grid;
-
-    std::vector<uint32_t> cb_ids(num_input_tensors);
-
-    // input CBs
-    for (uint32_t input_id = 0; input_id < num_input_tensors; input_id++) {
-        auto shard_spec = input_tensors[input_id].shard_spec().value();
-        uint32_t num_input_num_units_per_shard_height = shard_spec.shape[0];
-        uint32_t num_input_num_units_per_shard_width = 1;
-        auto num_input_units = num_input_num_units_per_shard_height * num_input_num_units_per_shard_width;
-        uint32_t input_unit_size = shard_spec.shape[1] * input_tensors[input_id].element_size();
-        auto input_page_size = round_up_to_mul32(input_unit_size);
-        tt_metal::CircularBufferConfig input_cb_config =
-            tt_metal::CircularBufferConfig(num_input_units * input_page_size, {{input_id, cb_data_format}})
-                .set_page_size(input_id, input_page_size)
-                .set_globally_allocated_address(*input_tensors[input_id].buffer());
-        cb_input[input_id] = tt_metal::CreateCircularBuffer(program, all_cores, input_cb_config);
-        cb_ids[input_id] = input_id;
-    }
-
-    // output CB
-    uint32_t cb_dst_id = 16;
-    uint32_t num_output_units = output.shard_spec().value().shape[0];
-    uint32_t output_unit_size = output.shard_spec().value().shape[1] * output.element_size();
-    auto output_page_size = round_up_to_mul32(output_unit_size);
-    tt_metal::CircularBufferConfig output_cb_config =
-        tt_metal::CircularBufferConfig(num_output_units * output_page_size, {{cb_dst_id, cb_data_format}})
-            .set_page_size(cb_dst_id, output_page_size)
-            .set_globally_allocated_address(*output.buffer());
-    auto cb_output = tt_metal::CreateCircularBuffer(program, all_cores, output_cb_config);
-
-    auto output_shard_spec = output.shard_spec().value();
-    uint32_t output_stick_size = output_shard_spec.shape[1] * output.element_size();
-
-    auto input_0_shard_spec = input_tensors[0].shard_spec().value();
-    auto input_1_shard_spec = input_tensors[1].shard_spec().value();
-    auto input_0_stick_size = input_0_shard_spec.shape[1] * input_tensors[0].element_size();
-    auto input_1_stick_size = input_1_shard_spec.shape[1] * input_tensors[1].element_size();
-    auto input_0_stride = output_stick_size - input_0_stick_size;
-    auto input_1_stride = output_stick_size - input_1_stick_size;
-    uint32_t num_output_rows_per_core = input_tensors[0].shard_spec().value().shape[0];
-    auto num_pages_per_risc = div_up(num_output_rows_per_core, 2);
-
-    uint32_t num_output_rows_per_core_last = num_output_rows % num_output_rows_per_core;
-    auto num_pages_per_risc_last = div_up(num_output_rows_per_core_last, 2);
-
-    std::vector<uint32_t> compile_time_args_0 = {
-        cb_dst_id,
-        input_0_stick_size,
-        input_1_stick_size,
-        input_0_stride,
-        input_1_stride,
-        num_output_rows_per_core * num_input_tensors,
-        0,
-        num_pages_per_risc,
-        0,
-        0,
-        0,
-        groups};
-
-    std::vector<uint32_t> compile_time_args_1 = {
-        cb_dst_id,
-        input_0_stick_size,
-        input_1_stick_size,
-        input_0_stride,
-        input_1_stride,
-        num_output_rows_per_core * num_input_tensors,
-        num_pages_per_risc,
-        num_output_rows_per_core,
-        num_pages_per_risc * output_stick_size,
-        num_pages_per_risc * input_0_stick_size,
-        num_pages_per_risc * input_1_stick_size,
-        groups};
-
-    std::vector<uint32_t> compile_time_args_0_last = {
-        cb_dst_id,
-        input_0_stick_size,
-        input_1_stick_size,
-        input_0_stride,
-        input_1_stride,
-        num_output_rows_per_core_last * num_input_tensors,
-        0,
-        num_pages_per_risc_last,
-        0,
-        0,
-        0,
-        groups};
-
-    std::vector<uint32_t> compile_time_args_1_last = {
-        cb_dst_id,
-        input_0_stick_size,
-        input_1_stick_size,
-        input_0_stride,
-        input_1_stride,
-        num_output_rows_per_core_last * num_input_tensors,
-        num_pages_per_risc_last,
-        num_output_rows_per_core_last,
-        num_pages_per_risc_last * output_stick_size,
-        num_pages_per_risc_last * input_0_stick_size,
-        num_pages_per_risc_last * input_1_stick_size,
-        groups};
-
-    if (num_output_rows_per_core_last > 0) {
-        bool rm_orientation = output_shard_spec.orientation == ShardOrientation::ROW_MAJOR;
-        const auto cores = corerange_to_cores(all_cores, std::nullopt, rm_orientation);
-        const auto [first, last] = split(cores, cores.size() - 1);
-        const auto first_cores = cores_to_corerangeset(first);
-        const auto last_cores = cores_to_corerangeset(last);
-        tt_metal::CreateKernel(
-            program,
-            "ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/"
-            "reader_height_sharded_width_concat_two_tensors.cpp",
-            first_cores,
-            tt_metal::ReaderDataMovementConfig(compile_time_args_0));
-        tt_metal::CreateKernel(
-            program,
-            "ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/"
-            "reader_height_sharded_width_concat_two_tensors.cpp",
-            first_cores,
-            tt_metal::WriterDataMovementConfig(compile_time_args_1));
-
-        tt_metal::CreateKernel(
-            program,
-            "ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/"
-            "reader_height_sharded_width_concat_two_tensors.cpp",
-            last_cores,
-            tt_metal::ReaderDataMovementConfig(compile_time_args_0_last));
-        tt_metal::CreateKernel(
-            program,
-            "ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/"
-            "reader_height_sharded_width_concat_two_tensors.cpp",
-            last_cores,
-            tt_metal::WriterDataMovementConfig(compile_time_args_1_last));
-    } else {
-        tt_metal::CreateKernel(
-            program,
-            "ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/"
-            "reader_height_sharded_width_concat_two_tensors.cpp",
-            all_cores,
-            tt_metal::ReaderDataMovementConfig(compile_time_args_0));
-        tt_metal::CreateKernel(
-            program,
-            "ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/"
-            "reader_height_sharded_width_concat_two_tensors.cpp",
-            all_cores,
-            tt_metal::WriterDataMovementConfig(compile_time_args_1));
-    }
-
-    auto override_runtime_arguments_callback = [num_input_tensors, cb_input, cb_output](
-                                                   const void* operation,
-                                                   Program& program,
-                                                   const std::vector<Tensor>& input_tensors,
-                                                   const std::vector<std::optional<const Tensor>>&,
-                                                   const std::vector<Tensor>& output_tensors) {
-        for (uint32_t input_id = 0; input_id < num_input_tensors; input_id++) {
-            UpdateDynamicCircularBufferAddress(program, cb_input[input_id], *input_tensors[input_id].buffer());
-        }
-        UpdateDynamicCircularBufferAddress(program, cb_output, *output_tensors[0].buffer());
-    };
-
-    return {.program = std::move(program), .override_runtime_arguments_callback = override_runtime_arguments_callback};
-}
-
-// Concat sharded tensors into sharded output in row-major/tile layout. Currently it only supports height-sharded
-// width concat or width-sharded height concat.
-//
-// It is done by copying each row of each input sharded tensor to the right offset in the sharded output tensor
-// based on the sharded output width in bytes (output stride). This way works for both width and height concat.
-//
-// For example in width concat, rows of an input tensor are placed at the same column offset but sequential rows in
-// the output. The memory address gap between neighbor input rows is exactly the output width. In height concat, all
-// input rows are placed at column 0 but sequential rows in the output. The address gap between neighbor input rows
-// is still the output width (which is equal to the input width).
-tt_metal::operation::ProgramWithCallbacks s2s_concat_multi_core(
-    const std::vector<Tensor>& input_tensors, uint32_t dim, Tensor& output) {
-    TT_FATAL(dim == 2 || dim == 3, "Sharded concat only supports dim=2 or 3");
-    const bool is_height_concat = dim == 2;
-
-    tt_metal::Program program = tt_metal::CreateProgram();
-
-    const uint32_t num_input_tensors = input_tensors.size();
-    const uint32_t cb_dst_id = 16;
-    TT_FATAL(num_input_tensors <= cb_dst_id, "Not enough circular buffer for {} inputs.", num_input_tensors);
-    const tt::DataFormat cb_data_format = tt_metal::datatype_to_dataformat_converter(output.dtype());
-    const bool rm_layout = output.layout() == Layout::ROW_MAJOR;
-
-    // Assume inputs and output have the same element size and alignment.
-    const uint32_t element_size = input_tensors[0].element_size();
-    const uint32_t alignment = input_tensors[0].buffer()->alignment();
-
-    uint32_t page_size;
-    uint32_t elements_per_page_width;
-    uint32_t elements_per_page_height;
-    if (rm_layout) {
-        std::vector<uint32_t> all_stick_sizes;
-        all_stick_sizes.push_back(output.shard_spec().value().shape[1]);
-        std::transform(
-            input_tensors.begin(), input_tensors.end(), std::back_inserter(all_stick_sizes), [](const Tensor& tensor) {
-                return tensor.element_size() * tensor.shard_spec().value().shape[1];
-            });
-        page_size = find_greatest_common_page_size(all_stick_sizes, alignment);
-        elements_per_page_width = page_size / element_size;
-        elements_per_page_height = 1;
-    } else {
-        page_size = tt::tile_size(cb_data_format);
-        elements_per_page_width = TILE_WIDTH;
-        elements_per_page_height = TILE_HEIGHT;
-    }
-
-    std::vector<CBHandle> cb_inputs(num_input_tensors);
-    std::vector<uint32_t> input_num_pages_per_stick(num_input_tensors);
-    std::vector<uint32_t> input_num_sticks(num_input_tensors);
-    std::vector<uint32_t> input_write_offsets(num_input_tensors);
-
-    // Assume inputs and output have the same sharding grid.
-    const auto all_cores = input_tensors[0].shard_spec().value().grid;
-
-    // Input CBs
-    uint32_t curr_input_write_offset = 0;
-    for (uint32_t input_id = 0; input_id < num_input_tensors; input_id++) {
-        const auto shard_spec = input_tensors[input_id].shard_spec().value();
-        input_num_pages_per_stick[input_id] = div_up(shard_spec.shape[1], elements_per_page_width);
-        input_num_sticks[input_id] = div_up(shard_spec.shape[0], elements_per_page_height);
-        input_write_offsets[input_id] = curr_input_write_offset;
-
-        const uint32_t input_num_pages = input_num_pages_per_stick[input_id] * input_num_sticks[input_id];
-        const tt_metal::CircularBufferConfig input_cb_config =
-            tt_metal::CircularBufferConfig(page_size * input_num_pages, {{input_id, cb_data_format}})
-                .set_page_size(input_id, page_size)
-                .set_globally_allocated_address(*input_tensors[input_id].buffer());
-        cb_inputs[input_id] = tt_metal::CreateCircularBuffer(program, all_cores, input_cb_config);
-
-        curr_input_write_offset +=
-            page_size * (is_height_concat ? input_num_pages : input_num_pages_per_stick[input_id]);
-    }
-
-    // Output CB
-    const auto output_shard_spec = output.shard_spec().value();
-    const uint32_t output_num_pages_per_stick = div_up(output_shard_spec.shape[1], elements_per_page_width);
-    const uint32_t output_num_sticks = div_up(output_shard_spec.shape[0], elements_per_page_height);
-    const tt_metal::CircularBufferConfig output_cb_config =
-        tt_metal::CircularBufferConfig(
-            page_size * output_num_sticks * output_num_pages_per_stick, {{cb_dst_id, cb_data_format}})
-            .set_page_size(cb_dst_id, page_size)
-            .set_globally_allocated_address(*output.buffer());
-    auto cb_output = tt_metal::CreateCircularBuffer(program, all_cores, output_cb_config);
-
-    const uint32_t output_stride = page_size * output_num_pages_per_stick;
-    const std::vector<uint32_t> compile_time_args = {cb_dst_id, page_size, output_stride, num_input_tensors};
-
-    std::vector<uint32_t> runtime_args_0;
-    std::vector<uint32_t> runtime_args_1;
-    for (uint32_t input_id = 0; input_id < num_input_tensors; input_id++) {
-        const auto input_num_sticks_per_risc = div_up(input_num_sticks[input_id], 2);
-        runtime_args_0.push_back(input_num_pages_per_stick[input_id]);
-        runtime_args_0.push_back(input_num_sticks_per_risc);
-        runtime_args_0.push_back(input_write_offsets[input_id]);
-        runtime_args_0.push_back(0);
-        runtime_args_1.push_back(input_num_pages_per_stick[input_id]);
-        runtime_args_1.push_back(input_num_sticks[input_id] - input_num_sticks_per_risc);
-        runtime_args_1.push_back(input_write_offsets[input_id] + (output_stride * input_num_sticks_per_risc));
-        runtime_args_1.push_back(page_size * input_num_pages_per_stick[input_id] * input_num_sticks_per_risc);
-    }
-
-    tt_metal::KernelHandle unary_reader_kernel_id = tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/reader_s2s_tensor_concat.cpp",
-        all_cores,
-        tt_metal::ReaderDataMovementConfig(compile_time_args));
-
-    tt_metal::KernelHandle unary_writer_kernel_id = tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/reader_s2s_tensor_concat.cpp",
-        all_cores,
-        tt_metal::WriterDataMovementConfig(compile_time_args));
-
-    tt_metal::SetRuntimeArgs(program, unary_reader_kernel_id, all_cores, runtime_args_0);
-    tt_metal::SetRuntimeArgs(program, unary_writer_kernel_id, all_cores, runtime_args_1);
-
-    auto override_runtime_arguments_callback = [num_input_tensors, cb_dst_id, cb_inputs, cb_output](
-                                                   const void* operation,
-                                                   Program& program,
-                                                   const std::vector<Tensor>& input_tensors,
-                                                   const std::vector<std::optional<const Tensor>>&,
-                                                   const std::vector<Tensor>& output_tensors) {
-        for (uint32_t input_id = 0; input_id < num_input_tensors; input_id++) {
-            UpdateDynamicCircularBufferAddress(program, cb_inputs[input_id], *input_tensors[input_id].buffer());
-        }
-        UpdateDynamicCircularBufferAddress(program, cb_output, *output_tensors[0].buffer());
-    };
-    return {.program = std::move(program), .override_runtime_arguments_callback = override_runtime_arguments_callback};
-}
-
-tt_metal::operation::ProgramWithCallbacks s2i_rm_concat_multi_core(
-    const std::vector<Tensor>& input_tensors, uint32_t dim, Tensor& output) {
-    tt_metal::Program program = tt_metal::CreateProgram();
-
-    // CoreRangeSet all_cores({CoreRange(CoreCoord(0,0), compute_with_storage_grid_size)});
-
-    uint32_t num_output_rows = output.padded_shape()[-1];
-    uint32_t num_input_tensors = input_tensors.size();
-
-    std::vector<CBHandle> cb_input(num_input_tensors);
-    std::vector<uint32_t> input_num_units_per_shard_height(num_input_tensors);
-    std::vector<uint32_t> input_num_units_per_shard_width(num_input_tensors);
-
-    tt::DataFormat cb_data_format = tt_metal::datatype_to_dataformat_converter(output.dtype());
-    auto all_cores = input_tensors[0].shard_spec().value().grid;
-
-    std::vector<uint32_t> cb_ids(num_input_tensors);
-    uint32_t input_unit_size = input_tensors[0].shard_spec().value().shape[1] * input_tensors[0].element_size();
-    // input CBs
-    for (uint32_t input_id = 0; input_id < num_input_tensors; input_id++) {
-        auto shard_spec = input_tensors[input_id].shard_spec().value();
-        input_num_units_per_shard_height[input_id] = shard_spec.shape[0];
-        input_num_units_per_shard_width[input_id] = 1;
-        auto num_input_units = input_num_units_per_shard_height[input_id] * input_num_units_per_shard_width[input_id];
-        auto input_page_size = round_up_to_mul32(input_unit_size);
-        tt_metal::CircularBufferConfig input_cb_config =
-            tt_metal::CircularBufferConfig(num_input_units * input_page_size, {{input_id, cb_data_format}})
-                .set_page_size(input_id, input_page_size)
-                .set_globally_allocated_address(*input_tensors[input_id].buffer());
-        cb_input[input_id] = tt_metal::CreateCircularBuffer(program, all_cores, input_cb_config);
-        cb_ids[input_id] = input_id;
-    }
-
-    std::vector<uint32_t> reader_compile_time_args = {num_input_tensors};
-    std::vector<uint32_t> writer_compile_time_args = {num_input_tensors, input_unit_size};
-    TensorAccessorArgs(*output.buffer()).append_to(writer_compile_time_args);
-
-    tt_metal::KernelHandle unary_reader_kernel_id = tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/reader_s2i_width.cpp",
-        all_cores,
-        tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
-
-    tt_metal::KernelHandle unary_writer_kernel_id = tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/writer_s2i_width.cpp",
-        all_cores,
-        tt_metal::WriterDataMovementConfig(writer_compile_time_args));
-
-    bool row_wise = input_tensors[0].shard_spec().value().orientation == ShardOrientation::ROW_MAJOR;
-    auto cores = corerange_to_cores(all_cores, std::nullopt, row_wise);
-    auto input_cores = input_tensors[0].shard_spec().value().grid;
-    uint32_t num_output_rows_per_core = div_up(num_output_rows, input_cores.num_cores());
-
-    uint32_t core_id = 0;
-    for (auto core : cores) {
-        auto input_shard_spec = input_tensors[0].shard_spec().value();
-        uint32_t curr_num_output_rows;
-        if (input_cores.contains(core)) {
-            curr_num_output_rows = num_output_rows_per_core;
-        } else {
-            curr_num_output_rows = 0;
-        }
-
-        std::vector<uint32_t> reader_runtime_args = {};
-        std::vector<uint32_t> writer_runtime_args = {
-            output.buffer()->address(),
-            core_id,
-            curr_num_output_rows,
-            num_input_tensors * input_shard_spec.shape[0],
-            input_shard_spec.shape[0]};
-        for (uint32_t input_id = 0; input_id < num_input_tensors; input_id++) {
-            reader_runtime_args.push_back(input_id);
-            reader_runtime_args.push_back(input_shard_spec.shape[0]);
-            writer_runtime_args.push_back(input_id);
-        }
-        tt_metal::SetRuntimeArgs(program, unary_reader_kernel_id, core, reader_runtime_args);
-
-        tt_metal::SetRuntimeArgs(program, unary_writer_kernel_id, core, writer_runtime_args);
-        core_id++;
-    }
-
-    auto override_runtime_arguments_callback =
-        [unary_reader_kernel_id, unary_writer_kernel_id, all_cores, num_input_tensors](
-            const void* operation,
-            Program& program,
-            const std::vector<Tensor>& input_tensors,
-            const std::vector<std::optional<const Tensor>>&,
-            const std::vector<Tensor>& output_tensors) {
-            bool row_wise = input_tensors[0].shard_spec().value().orientation == ShardOrientation::ROW_MAJOR;
-            auto* dst_buffer = output_tensors.at(0).buffer();
-            auto cores = corerange_to_cores(all_cores, std::nullopt, row_wise);
-            auto input_cores = input_tensors[0].shard_spec().value().grid;
-            uint32_t num_output_rows = output_tensors[0].padded_shape()[-1];
-            uint32_t num_output_rows_per_core = div_up(num_output_rows, input_cores.num_cores());
-            for (auto core : cores) {
-                uint32_t curr_num_input_tensors;
-                uint32_t curr_num_output_rows;
-                if (input_cores.contains(core)) {
-                    curr_num_input_tensors = num_input_tensors;
-                    curr_num_output_rows = num_output_rows_per_core;
-                } else {
-                    curr_num_input_tensors = 0;
-                    curr_num_output_rows = 0;
-                }
-
-                std::vector<uint32_t> reader_runtime_args = {curr_num_input_tensors};
-                std::vector<uint32_t> writer_runtime_args = {
-                    dst_buffer->address(), curr_num_input_tensors, curr_num_output_rows};
-                for (uint32_t input_id = 0; input_id < num_input_tensors; input_id++) {
-                    UpdateDynamicCircularBufferAddress(program, input_id, *dst_buffer);
-                    auto input_shard_spec = input_tensors[input_id].shard_spec().value();
-                    reader_runtime_args.push_back(input_id);
-                    reader_runtime_args.push_back(input_shard_spec.shape[1]);
-                    writer_runtime_args.push_back(input_id);
-                }
-                tt_metal::SetRuntimeArgs(program, unary_reader_kernel_id, core, reader_runtime_args);
-
-                tt_metal::SetRuntimeArgs(program, unary_writer_kernel_id, core, writer_runtime_args);
-            }
-        };
-
-    return {.program = std::move(program), .override_runtime_arguments_callback = override_runtime_arguments_callback};
-}
-
-tt_metal::operation::ProgramWithCallbacks sharded_concat_multi_core(
-    const std::vector<Tensor>& input_tensors, uint32_t dim, Tensor& output, unsigned int groups) {
-    if (output.is_sharded()) {
-        if (input_tensors.size() == 2) {
-            // There are unrolled kernels for the case where we have 2 hight-sharded kernels. Currently
-            // we only support 2 tile inputs OR 2 row-major inputs.
-            TT_FATAL(
-                input_tensors.at(0).layout() == input_tensors.at(1).layout(),
-                "Expected all input tensors to have the same layout");
-            if (input_tensors.at(0).layout() == Layout::ROW_MAJOR) {
-                return s2s_rm_concat_two_tensors_height_multi_core(input_tensors, dim, output, groups);
-            } else {
-                return s2s_tiled_concat_two_tensors_height_multi_core(input_tensors, dim, output, groups);
-            }
-        } else {
-            TT_FATAL(
-                groups == 1,
-                "Sharded ttnn.concat with groups > 1 is only supported for 2 sharded input and sharded output "
-                "tensors");
-            return s2s_concat_multi_core(input_tensors, dim, output);
-        }
-    } else {
-        TT_FATAL(
-            groups == 1,
-            "Sharded ttnn.concat with groups > 1 is only supported for 2 sharded input and sharded output tensors");
-        return s2i_rm_concat_multi_core(input_tensors, dim, output);
-    }
-}
-
-tt_metal::operation::ProgramWithCallbacks concat_multi_core(
-    const std::vector<Tensor>& input_tensors, const uint32_t dim, const Tensor& output) {
-    tt_metal::Program program = tt_metal::CreateProgram();
-
-    tt_metal::IDevice* device = output.device();
-
-    const tt::DataFormat cb_data_format = tt_metal::datatype_to_dataformat_converter(output.dtype());
+namespace ttnn::operations::data_movement::concat::program {
+
+ConcatProgramFactory::cached_program_t ConcatProgramFactory::create(
+    const operation_attributes_t& operation_attributes,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& tensor_return_value) {
+    using namespace tt::constants;
+    using namespace tt::tt_metal;
+
+    const auto& input_tensors = tensor_args.input_tensors;
+    const uint32_t dim = operation_attributes.dim;
+    const Tensor& output = tensor_return_value;
+
+    Program program = CreateProgram();
+    KernelHandle reader_kernel_id = 0;
+    KernelHandle writer_kernel_id = 0;
+    std::vector<CoreCoord> cores;
+
+    IDevice* device = output.device();
+
+    const tt::DataFormat cb_data_format = datatype_to_dataformat_converter(output.dtype());
 
     const bool rm_layout = output.layout() == Layout::ROW_MAJOR;
 
@@ -732,7 +39,7 @@ tt_metal::operation::ProgramWithCallbacks concat_multi_core(
 
     uint32_t num_output_pages;
     uint32_t single_page_size;
-    uint32_t common_align_len = std::max(input_tensors[0].buffer()->alignment(), output.buffer()->alignment());
+    const uint32_t common_align_len = std::max(input_tensors[0].buffer()->alignment(), output.buffer()->alignment());
     if (rm_layout) {
         num_output_pages = output.physical_volume() / output.padded_shape()[-1];
         single_page_size = tt::align(output.element_size() * output.padded_shape()[-1], common_align_len);
@@ -741,25 +48,25 @@ tt_metal::operation::ProgramWithCallbacks concat_multi_core(
         single_page_size = tt::tile_size(cb_data_format);
     }
 
-    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
-    uint32_t num_cores_x = compute_with_storage_grid_size.x;
-    uint32_t num_cores_y = compute_with_storage_grid_size.y;
+    const CoreCoord compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    const uint32_t num_cores_x = compute_with_storage_grid_size.x;
+    const uint32_t num_cores_y = compute_with_storage_grid_size.y;
     auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
-        tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_output_pages, rm_orientation);
+        split_work_to_cores(compute_with_storage_grid_size, num_output_pages, rm_orientation);
 
-    uint32_t num_input_tensors = input_tensors.size();
+    const uint32_t num_input_tensors = input_tensors.size();
 
-    tt_metal::Buffer* dst_buffer = output.buffer();
+    Buffer* dst_buffer = output.buffer();
     TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
 
-    uint32_t src0_cb_index = 0;
-    uint32_t num_input_pages = 2;
-    tt_metal::CircularBufferConfig cb_src0_config =
-        tt_metal::CircularBufferConfig(num_input_pages * single_page_size, {{src0_cb_index, cb_data_format}})
+    const uint32_t src0_cb_index = 0;
+    const uint32_t num_input_pages = 2;
+    CircularBufferConfig cb_src0_config =
+        CircularBufferConfig(num_input_pages * single_page_size, {{src0_cb_index, cb_data_format}})
             .set_page_size(src0_cb_index, single_page_size);
-    tt_metal::CreateCircularBuffer(program, all_cores, cb_src0_config);
+    CreateCircularBuffer(program, all_cores, cb_src0_config);
 
-    uint32_t num_dims = output.padded_shape().rank();
+    const uint32_t num_dims = output.padded_shape().rank();
 
     std::vector<uint32_t> src_addr(num_input_tensors);
     std::vector<uint32_t> num_pages_per_block(num_input_tensors);
@@ -822,18 +129,15 @@ tt_metal::operation::ProgramWithCallbacks concat_multi_core(
         }
     }
     std::vector<uint32_t> common_reader_kernel_args = {0, 0, 0};
-    common_reader_kernel_args.insert(common_reader_kernel_args.end(), src_addr.begin(), src_addr.end());
+    common_reader_kernel_args.insert(common_reader_kernel_args.end(), src_addr.cbegin(), src_addr.cend());
     common_reader_kernel_args.insert(
-        common_reader_kernel_args.end(), num_pages_per_block.begin(), num_pages_per_block.end());
+        common_reader_kernel_args.end(), num_pages_per_block.cbegin(), num_pages_per_block.cend());
 
     // Reader compile-time args
     // Data is 32 byte aligned
-    std::vector<uint32_t> reader_compile_time_args = {
-        (std::uint32_t)src0_cb_index,
-        (std::uint32_t)num_input_tensors,
-    };
+    std::vector<uint32_t> reader_compile_time_args = {src0_cb_index, num_input_tensors};
     reader_compile_time_args.insert(
-        reader_compile_time_args.end(), page_size_per_tensor.begin(), page_size_per_tensor.end());
+        reader_compile_time_args.end(), page_size_per_tensor.cbegin(), page_size_per_tensor.cend());
     for (uint32_t i = 0; i < num_input_tensors; ++i) {
         TensorAccessorArgs(*input_tensors[i].buffer()).append_to(reader_compile_time_args);
     }
@@ -853,35 +157,30 @@ tt_metal::operation::ProgramWithCallbacks concat_multi_core(
     TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
 
     // Tilized reader
-    tt_metal::KernelHandle unary_reader_kernel_id = tt_metal::CreateKernel(
+    reader_kernel_id = CreateKernel(
         program,
         rm_layout ? "ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/"
                     "reader_concat_stick_layout_interleaved_start_id.cpp"
                   : "ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/"
                     "reader_concat_interleaved_start_id.cpp",
         all_cores,
-        tt_metal::ReaderDataMovementConfig(reader_compile_time_args, concat_defines));
+        ReaderDataMovementConfig(reader_compile_time_args, concat_defines));
 
-    tt_metal::KernelHandle unary_writer_kernel_id = tt_metal::CreateKernel(
+    writer_kernel_id = CreateKernel(
         program,
         rm_layout
             ? "ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/dataflow/writer_unary_stick_layout_interleaved_start_id.cpp"
-            : "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/"
-              "writer_unary_interleaved_start_id.cpp",
+            : "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp",
         all_cores,
-        tt_metal::WriterDataMovementConfig(writer_compile_time_args));
+        WriterDataMovementConfig(writer_compile_time_args));
 
-    const auto cores = grid_to_cores(num_cores, num_cores_x, num_cores_y, rm_orientation);
-    uint32_t g1_num_cores = core_group_1.num_cores();
+    cores = grid_to_cores(num_cores, num_cores_x, num_cores_y, rm_orientation);
+    const uint32_t g1_num_cores = core_group_1.num_cores();
     for (uint32_t i = 0, num_pages_written = 0; i < cores.size(); ++i) {
         const CoreCoord& core = cores[i];
-        uint32_t num_pages_per_core = 0;
-        if (i < g1_num_cores) {
-            num_pages_per_core = num_tiles_per_core_group_1;
-        } else {
-            num_pages_per_core = num_tiles_per_core_group_2;
-        }
-        uint32_t block_id = num_pages_written / num_output_pages_per_block;
+        const uint32_t num_pages_per_core =
+            (i < g1_num_cores) ? num_tiles_per_core_group_1 : num_tiles_per_core_group_2;
+        const uint32_t block_id = num_pages_written / num_output_pages_per_block;
         uint32_t id_within_block = num_pages_written % num_output_pages_per_block;
         uint32_t curr_tensor = 0;
         uint32_t curr_tensor_id = 0;
@@ -914,39 +213,42 @@ tt_metal::operation::ProgramWithCallbacks concat_multi_core(
         } else {
             writer_kernel_args = {dst_buffer->address(), num_pages_per_core, num_pages_written};
         }
-        tt_metal::SetRuntimeArgs(program, unary_reader_kernel_id, core, reader_kernel_args);
+        SetRuntimeArgs(program, reader_kernel_id, core, reader_kernel_args);
 
-        tt_metal::SetRuntimeArgs(program, unary_writer_kernel_id, core, writer_kernel_args);
+        SetRuntimeArgs(program, writer_kernel_id, core, writer_kernel_args);
         num_pages_written += num_pages_per_core;
     }
 
-    auto override_runtime_args_callback = [unary_reader_kernel_id, unary_writer_kernel_id, cores](
-                                              const void* operation,
-                                              Program& program,
-                                              const std::vector<Tensor>& input_tensors,
-                                              const std::vector<std::optional<const Tensor>>&,
-                                              const std::vector<Tensor>& output_tensors) {
-        std::vector<uint32_t> src_addrs(input_tensors.size());
-        for (uint32_t i = 0; i < input_tensors.size(); ++i) {
-            src_addrs[i] = input_tensors[i].buffer()->address();
-        }
-
-        auto* dst_buffer = output_tensors.at(0).buffer();
-
-        for (const auto& core : cores) {
-            {
-                auto& runtime_args = GetRuntimeArgs(program, unary_reader_kernel_id, core);
-                std::copy(src_addrs.begin(), src_addrs.end(), runtime_args.data() + 3);
-            }
-
-            {
-                auto& runtime_args = GetRuntimeArgs(program, unary_writer_kernel_id, core);
-                runtime_args[0] = dst_buffer->address();
-            }
-        }
-    };
-
-    return {std::move(program), override_runtime_args_callback};
+    return {std::move(program), {reader_kernel_id, writer_kernel_id, cores}};
 }
 
-}  // namespace ttnn::operations::data_movement::detail
+void ConcatProgramFactory::override_runtime_arguments(
+    cached_program_t& cached_program,
+    const operation_attributes_t& operation_attributes,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& tensor_return_value) {
+    using namespace tt::tt_metal;
+
+    auto& program = cached_program.program;
+    const auto& shared_vars = cached_program.shared_variables;
+
+    std::vector<uint32_t> src_addrs(tensor_args.input_tensors.size());
+    for (uint32_t i = 0; i < tensor_args.input_tensors.size(); ++i) {
+        src_addrs[i] = tensor_args.input_tensors[i].buffer()->address();
+    }
+
+    Buffer* dst_buffer = tensor_return_value.buffer();
+
+    for (const CoreCoord& core : shared_vars.cores) {
+        {
+            auto& runtime_args = GetRuntimeArgs(program, shared_vars.reader_kernel_id, core);
+            std::copy(src_addrs.cbegin(), src_addrs.cend(), runtime_args.data() + 3);
+        }
+        {
+            auto& runtime_args = GetRuntimeArgs(program, shared_vars.writer_kernel_id, core);
+            runtime_args[0] = dst_buffer->address();
+        }
+    }
+}
+
+}  // namespace ttnn::operations::data_movement::concat::program

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_s2i_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_s2i_program_factory.cpp
@@ -1,0 +1,145 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "concat_s2i_program_factory.hpp"
+
+#include "ttnn/tensor/tensor.hpp"
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/work_split.hpp>
+#include <vector>
+
+namespace ttnn::operations::data_movement::concat::program {
+
+ConcatS2IProgramFactory::cached_program_t ConcatS2IProgramFactory::create(
+    const operation_attributes_t& operation_attributes,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& tensor_return_value) {
+    using namespace tt::constants;
+    using namespace tt::tt_metal;
+
+    const std::vector<Tensor>& input_tensors = tensor_args.input_tensors;
+    Tensor& output = tensor_return_value;
+    Program program = CreateProgram();
+
+    // CoreRangeSet all_cores({CoreRange(CoreCoord(0,0), compute_with_storage_grid_size)});
+
+    const uint32_t num_output_rows = output.padded_shape()[-1];
+    const uint32_t num_input_tensors = input_tensors.size();
+
+    const tt::DataFormat cb_data_format = datatype_to_dataformat_converter(output.dtype());
+    const CoreRangeSet all_cores = input_tensors[0].shard_spec().value().grid;
+
+    const uint32_t input_unit_size = input_tensors[0].shard_spec().value().shape[1] * input_tensors[0].element_size();
+    // input CBs
+    for (uint32_t input_id = 0; input_id < num_input_tensors; input_id++) {
+        constexpr uint32_t input_num_units_per_shard_width = 1;
+        const ShardSpec& shard_spec = input_tensors[input_id].shard_spec().value();
+        const uint32_t num_input_units = shard_spec.shape[0] * input_num_units_per_shard_width;
+        const uint32_t input_page_size = round_up_to_mul32(input_unit_size);
+        CircularBufferConfig input_cb_config =
+            CircularBufferConfig(num_input_units * input_page_size, {{input_id, cb_data_format}})
+                .set_page_size(input_id, input_page_size)
+                .set_globally_allocated_address(*input_tensors[input_id].buffer());
+        CreateCircularBuffer(program, all_cores, input_cb_config);
+    }
+
+    std::vector<uint32_t> reader_compile_time_args = {num_input_tensors};
+    std::vector<uint32_t> writer_compile_time_args = {num_input_tensors, input_unit_size};
+    TensorAccessorArgs(*output.buffer()).append_to(writer_compile_time_args);
+
+    KernelHandle unary_reader_kernel_id = CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/reader_s2i_width.cpp",
+        all_cores,
+        ReaderDataMovementConfig(reader_compile_time_args));
+
+    KernelHandle unary_writer_kernel_id = CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/writer_s2i_width.cpp",
+        all_cores,
+        WriterDataMovementConfig(writer_compile_time_args));
+
+    const bool row_wise = input_tensors[0].shard_spec().value().orientation == ShardOrientation::ROW_MAJOR;
+    const auto cores = corerange_to_cores(all_cores, std::nullopt, row_wise);
+    const auto input_cores = input_tensors[0].shard_spec().value().grid;
+    const uint32_t num_output_rows_per_core = tt::div_up(num_output_rows, input_cores.num_cores());
+
+    uint32_t core_id = 0;
+    for (const CoreCoord& core : cores) {
+        const ShardSpec& input_shard_spec = input_tensors[0].shard_spec().value();
+        uint32_t curr_num_output_rows = (input_cores.contains(core)) ? num_output_rows_per_core : 0;
+
+        std::vector<uint32_t> reader_runtime_args;
+        reader_runtime_args.reserve(num_input_tensors * 2);
+        std::vector<uint32_t> writer_runtime_args = {
+            output.buffer()->address(),
+            core_id,
+            curr_num_output_rows,
+            num_input_tensors * input_shard_spec.shape[0],
+            input_shard_spec.shape[0]};
+        for (uint32_t input_id = 0; input_id < num_input_tensors; input_id++) {
+            reader_runtime_args.push_back(input_id);
+            reader_runtime_args.push_back(input_shard_spec.shape[0]);
+            writer_runtime_args.push_back(input_id);
+        }
+        SetRuntimeArgs(program, unary_reader_kernel_id, core, reader_runtime_args);
+
+        SetRuntimeArgs(program, unary_writer_kernel_id, core, writer_runtime_args);
+        core_id++;
+    }
+
+    return {
+        std::move(program),
+        {.num_input_tensors = num_input_tensors,
+         .reader_kernel_id = unary_reader_kernel_id,
+         .writer_kernel_id = unary_writer_kernel_id,
+         .all_cores = all_cores}};
+}
+
+void ConcatS2IProgramFactory::override_runtime_arguments(
+    cached_program_t& cached_program,
+    const operation_attributes_t& operation_attributes,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& tensor_return_value) {
+    using namespace tt::tt_metal;
+
+    auto& program = cached_program.program;
+    const auto& shared_vars = cached_program.shared_variables;
+
+    const bool row_wise = tensor_args.input_tensors[0].shard_spec().value().orientation == ShardOrientation::ROW_MAJOR;
+    Buffer* dst_buffer = tensor_return_value.buffer();
+    auto cores = corerange_to_cores(shared_vars.all_cores, std::nullopt, row_wise);
+    auto input_cores = tensor_args.input_tensors[0].shard_spec().value().grid;
+    const uint32_t num_output_rows = tensor_return_value.padded_shape()[-1];
+    const uint32_t num_output_rows_per_core = tt::div_up(num_output_rows, input_cores.num_cores());
+
+    for (const CoreCoord& core : cores) {
+        uint32_t curr_num_input_tensors;
+        uint32_t curr_num_output_rows;
+        if (input_cores.contains(core)) {
+            curr_num_input_tensors = shared_vars.num_input_tensors;
+            curr_num_output_rows = num_output_rows_per_core;
+        } else {
+            curr_num_input_tensors = 0;
+            curr_num_output_rows = 0;
+        }
+
+        std::vector<uint32_t> reader_runtime_args = {curr_num_input_tensors};
+        std::vector<uint32_t> writer_runtime_args = {
+            dst_buffer->address(), curr_num_input_tensors, curr_num_output_rows};
+        for (uint32_t input_id = 0; input_id < shared_vars.num_input_tensors; input_id++) {
+            UpdateDynamicCircularBufferAddress(program, input_id, *dst_buffer);
+            const ShardSpec& input_shard_spec = tensor_args.input_tensors[input_id].shard_spec().value();
+            reader_runtime_args.push_back(input_id);
+            reader_runtime_args.push_back(input_shard_spec.shape[1]);
+            writer_runtime_args.push_back(input_id);
+        }
+        SetRuntimeArgs(program, shared_vars.reader_kernel_id, core, reader_runtime_args);
+        SetRuntimeArgs(program, shared_vars.writer_kernel_id, core, writer_runtime_args);
+    }
+}
+
+}  // namespace ttnn::operations::data_movement::concat::program

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_s2i_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_s2i_program_factory.hpp
@@ -6,19 +6,19 @@
 
 #include "concat_device_operation_types.hpp"
 #include "ttnn/device_operation.hpp"
-#include <tt-metalium/work_split.hpp>
 
 namespace ttnn::operations::data_movement::concat::program {
 
-// Shared variables for interleaved concat
-struct ConcatSharedVariables {
+// Shared variables for s2i concat
+struct ConcatS2ISharedVariables {
+    uint32_t num_input_tensors = 0;
     tt::tt_metal::KernelHandle reader_kernel_id = 0;
     tt::tt_metal::KernelHandle writer_kernel_id = 0;
-    std::vector<CoreCoord> cores;
+    CoreRangeSet all_cores;
 };
 
-struct ConcatProgramFactory {
-    using shared_variables_t = ConcatSharedVariables;
+struct ConcatS2IProgramFactory {
+    using shared_variables_t = ConcatS2ISharedVariables;
     using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
 
     static cached_program_t create(

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_s2s_multi_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_s2s_multi_program_factory.cpp
@@ -1,0 +1,168 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "concat_s2s_multi_program_factory.hpp"
+
+#include <algorithm>
+#include <numeric>
+
+#include "ttnn/tensor/tensor.hpp"
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/tt_align.hpp>
+
+namespace ttnn::operations::data_movement::concat::program {
+
+namespace {
+
+uint32_t find_greatest_common_page_size(std::vector<uint32_t>& stick_sizes, uint32_t alignment) {
+    TT_FATAL(!stick_sizes.empty(), "Need at least one stick size to find page size");
+    uint32_t page_size = tt::align(stick_sizes[0], alignment);
+    for (size_t idx = 1; idx < stick_sizes.size(); idx++) {
+        const uint32_t padded_stick_size = tt::align(stick_sizes[idx], alignment);
+        page_size = std::gcd(page_size, padded_stick_size);
+    }
+    return page_size;
+}
+
+}  // namespace
+
+ConcatS2SMultiProgramFactory::cached_program_t ConcatS2SMultiProgramFactory::create(
+    const operation_attributes_t& operation_attributes,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& tensor_return_value) {
+    using namespace tt::constants;
+    using namespace tt::tt_metal;
+
+    const auto& input_tensors = tensor_args.input_tensors;
+    const uint32_t dim = operation_attributes.dim;
+    Tensor& output = tensor_return_value;
+    TT_FATAL(dim == 2 || dim == 3, "Sharded concat only supports dim=2 or 3");
+    const bool is_height_concat = dim == 2;
+
+    Program program = CreateProgram();
+
+    const uint32_t num_input_tensors = input_tensors.size();
+    const uint32_t cb_dst_id = 16;
+    TT_FATAL(num_input_tensors <= cb_dst_id, "Not enough circular buffer for {} inputs.", num_input_tensors);
+    const tt::DataFormat cb_data_format = datatype_to_dataformat_converter(output.dtype());
+    const bool rm_layout = output.layout() == Layout::ROW_MAJOR;
+
+    // Assume inputs and output have the same element size and alignment.
+    const uint32_t element_size = input_tensors[0].element_size();
+    const uint32_t alignment = input_tensors[0].buffer()->alignment();
+
+    uint32_t page_size;
+    uint32_t elements_per_page_width;
+    uint32_t elements_per_page_height;
+    if (rm_layout) {
+        std::vector<uint32_t> all_stick_sizes;
+        all_stick_sizes.reserve(input_tensors.size() + 1);
+        all_stick_sizes.push_back(output.shard_spec().value().shape[1]);
+        std::transform(
+            input_tensors.begin(), input_tensors.end(), std::back_inserter(all_stick_sizes), [](const Tensor& tensor) {
+                return tensor.element_size() * tensor.shard_spec().value().shape[1];
+            });
+        page_size = find_greatest_common_page_size(all_stick_sizes, alignment);
+        elements_per_page_width = page_size / element_size;
+        elements_per_page_height = 1;
+    } else {
+        page_size = tt::tile_size(cb_data_format);
+        elements_per_page_width = TILE_WIDTH;
+        elements_per_page_height = TILE_HEIGHT;
+    }
+
+    std::vector<CBHandle> cb_inputs(num_input_tensors);
+    std::vector<uint32_t> input_num_pages_per_stick(num_input_tensors);
+    std::vector<uint32_t> input_num_sticks(num_input_tensors);
+    std::vector<uint32_t> input_write_offsets(num_input_tensors);
+
+    // Assume inputs and output have the same sharding grid.
+    const auto all_cores = input_tensors[0].shard_spec().value().grid;
+
+    // Input CBs
+    uint32_t curr_input_write_offset = 0;
+    for (uint32_t input_id = 0; input_id < num_input_tensors; input_id++) {
+        const auto shard_spec = input_tensors[input_id].shard_spec().value();
+        input_num_pages_per_stick[input_id] = tt::div_up(shard_spec.shape[1], elements_per_page_width);
+        input_num_sticks[input_id] = tt::div_up(shard_spec.shape[0], elements_per_page_height);
+        input_write_offsets[input_id] = curr_input_write_offset;
+
+        const uint32_t input_num_pages = input_num_pages_per_stick[input_id] * input_num_sticks[input_id];
+        const CircularBufferConfig input_cb_config =
+            CircularBufferConfig(page_size * input_num_pages, {{input_id, cb_data_format}})
+                .set_page_size(input_id, page_size)
+                .set_globally_allocated_address(*input_tensors[input_id].buffer());
+        cb_inputs[input_id] = CreateCircularBuffer(program, all_cores, input_cb_config);
+
+        curr_input_write_offset +=
+            page_size * (is_height_concat ? input_num_pages : input_num_pages_per_stick[input_id]);
+    }
+
+    // Output CB
+    const auto output_shard_spec = output.shard_spec().value();
+    const uint32_t output_num_pages_per_stick = tt::div_up(output_shard_spec.shape[1], elements_per_page_width);
+    const uint32_t output_num_sticks = tt::div_up(output_shard_spec.shape[0], elements_per_page_height);
+    const CircularBufferConfig output_cb_config =
+        CircularBufferConfig(page_size * output_num_sticks * output_num_pages_per_stick, {{cb_dst_id, cb_data_format}})
+            .set_page_size(cb_dst_id, page_size)
+            .set_globally_allocated_address(*output.buffer());
+    auto cb_output = CreateCircularBuffer(program, all_cores, output_cb_config);
+
+    const uint32_t output_stride = page_size * output_num_pages_per_stick;
+    const std::vector<uint32_t> compile_time_args = {cb_dst_id, page_size, output_stride, num_input_tensors};
+
+    std::vector<uint32_t> runtime_args_0;
+    std::vector<uint32_t> runtime_args_1;
+    for (uint32_t input_id = 0; input_id < num_input_tensors; input_id++) {
+        const auto input_num_sticks_per_risc = tt::div_up(input_num_sticks[input_id], 2);
+        runtime_args_0.push_back(input_num_pages_per_stick[input_id]);
+        runtime_args_0.push_back(input_num_sticks_per_risc);
+        runtime_args_0.push_back(input_write_offsets[input_id]);
+        runtime_args_0.push_back(0);
+        runtime_args_1.push_back(input_num_pages_per_stick[input_id]);
+        runtime_args_1.push_back(input_num_sticks[input_id] - input_num_sticks_per_risc);
+        runtime_args_1.push_back(input_write_offsets[input_id] + (output_stride * input_num_sticks_per_risc));
+        runtime_args_1.push_back(page_size * input_num_pages_per_stick[input_id] * input_num_sticks_per_risc);
+    }
+
+    KernelHandle unary_reader_kernel_id = CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/reader_s2s_tensor_concat.cpp",
+        all_cores,
+        ReaderDataMovementConfig(compile_time_args));
+
+    KernelHandle unary_writer_kernel_id = CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/reader_s2s_tensor_concat.cpp",
+        all_cores,
+        WriterDataMovementConfig(compile_time_args));
+
+    SetRuntimeArgs(program, unary_reader_kernel_id, all_cores, runtime_args_0);
+    SetRuntimeArgs(program, unary_writer_kernel_id, all_cores, runtime_args_1);
+
+    return {
+        std::move(program),
+        {.num_input_tensors = num_input_tensors,
+         .cb_inputs = cb_inputs,
+         .cb_output = cb_output,
+         .all_cores = all_cores}};
+}
+
+void ConcatS2SMultiProgramFactory::override_runtime_arguments(
+    cached_program_t& cached_program,
+    const operation_attributes_t& operation_attributes,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& tensor_return_value) {
+    auto& program = cached_program.program;
+    const auto& shared_vars = cached_program.shared_variables;
+
+    for (uint32_t input_id = 0; input_id < shared_vars.num_input_tensors; input_id++) {
+        tt::tt_metal::UpdateDynamicCircularBufferAddress(
+            program, shared_vars.cb_inputs[input_id], *tensor_args.input_tensors[input_id].buffer());
+    }
+    tt::tt_metal::UpdateDynamicCircularBufferAddress(program, shared_vars.cb_output, *tensor_return_value.buffer());
+}
+
+}  // namespace ttnn::operations::data_movement::concat::program

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_s2s_multi_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_s2s_multi_program_factory.hpp
@@ -6,19 +6,19 @@
 
 #include "concat_device_operation_types.hpp"
 #include "ttnn/device_operation.hpp"
-#include <tt-metalium/work_split.hpp>
 
 namespace ttnn::operations::data_movement::concat::program {
 
-// Shared variables for interleaved concat
-struct ConcatSharedVariables {
-    tt::tt_metal::KernelHandle reader_kernel_id = 0;
-    tt::tt_metal::KernelHandle writer_kernel_id = 0;
-    std::vector<CoreCoord> cores;
+// Shared variables for s2s multi-tensor concat
+struct ConcatS2SMultiSharedVariables {
+    uint32_t num_input_tensors = 0;
+    std::vector<tt::tt_metal::CBHandle> cb_inputs;
+    tt::tt_metal::CBHandle cb_output = 0;
+    CoreRangeSet all_cores;
 };
 
-struct ConcatProgramFactory {
-    using shared_variables_t = ConcatSharedVariables;
+struct ConcatS2SMultiProgramFactory {
+    using shared_variables_t = ConcatS2SMultiSharedVariables;
     using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
 
     static cached_program_t create(

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_s2s_rm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_s2s_rm_program_factory.cpp
@@ -1,0 +1,234 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "concat_s2s_rm_program_factory.hpp"
+
+#include <algorithm>
+
+#include "ttnn/tensor/tensor.hpp"
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/work_split.hpp>
+#include <tt-metalium/tt_align.hpp>
+
+namespace ttnn::operations::data_movement::concat::program {
+
+template <typename T>
+static std::pair<std::vector<T>, std::vector<T>> split(std::vector<T> input, std::size_t index) {
+    if (index > input.size()) {
+        throw std::out_of_range{"split index out of range"};
+    }
+    std::vector<T> second{std::make_move_iterator(input.begin() + index), std::make_move_iterator(input.end())};
+    input.erase(input.begin() + index, input.end());
+    return {std::move(input), std::move(second)};
+}
+
+static CoreRangeSet cores_to_corerangeset(const std::vector<CoreCoord>& cores) {
+    std::vector<CoreRange> core_ranges;
+    core_ranges.reserve(cores.size());
+    std::transform(cores.begin(), cores.end(), std::back_inserter(core_ranges), [](const CoreCoord& core) {
+        return CoreRange(core);
+    });
+    return CoreRangeSet(core_ranges);
+}
+
+ConcatS2SRMProgramFactory::cached_program_t ConcatS2SRMProgramFactory::create(
+    const operation_attributes_t& operation_attributes,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& tensor_return_value) {
+    using namespace tt::constants;
+    using namespace tt::tt_metal;
+
+    const std::vector<Tensor>& input_tensors = tensor_args.input_tensors;
+    const uint32_t dim = operation_attributes.dim;
+    Tensor& output = tensor_return_value;
+    const unsigned int groups = operation_attributes.groups;
+    TT_FATAL(dim == 3, "Sharded concat RM only supports dim=3");
+    TT_FATAL(groups == 1 || dim == 3, "Sharded concat RM only supports groups > 1 when dim=3");
+
+    TT_FATAL(
+        input_tensors.size() == 2 && input_tensors[0].padded_shape()[-1] % groups == 0 &&
+            input_tensors[1].padded_shape()[-1] % groups == 0,
+        "Input channels must both be evenly divisible by groups");
+
+    Program program = CreateProgram();
+
+    const uint32_t num_output_rows = output.padded_shape()[-2];
+    const uint32_t num_input_tensors = input_tensors.size();
+
+    std::vector<CBHandle> cb_input(num_input_tensors);
+
+    tt::DataFormat cb_data_format = datatype_to_dataformat_converter(output.dtype());
+    const CoreRangeSet all_cores = input_tensors[0].shard_spec().value().grid;
+
+    std::vector<uint32_t> cb_ids(num_input_tensors);
+
+    // input CBs
+    for (uint32_t input_id = 0; input_id < num_input_tensors; input_id++) {
+        constexpr uint32_t num_input_num_units_per_shard_width = 1;
+        const ShardSpec shard_spec = input_tensors[input_id].shard_spec().value();
+        const uint32_t num_input_num_units_per_shard_height = shard_spec.shape[0];
+        const uint32_t num_input_units = num_input_num_units_per_shard_height * num_input_num_units_per_shard_width;
+        const uint32_t input_unit_size = shard_spec.shape[1] * input_tensors[input_id].element_size();
+        const uint32_t input_page_size = round_up_to_mul32(input_unit_size);
+        CircularBufferConfig input_cb_config =
+            CircularBufferConfig(num_input_units * input_page_size, {{input_id, cb_data_format}})
+                .set_page_size(input_id, input_page_size)
+                .set_globally_allocated_address(*input_tensors[input_id].buffer());
+        cb_input[input_id] = CreateCircularBuffer(program, all_cores, input_cb_config);
+        cb_ids[input_id] = input_id;
+    }
+
+    // output CB
+    constexpr uint32_t cb_dst_id = 16;
+    const uint32_t num_output_units = output.shard_spec().value().shape[0];
+    const uint32_t output_unit_size = output.shard_spec().value().shape[1] * output.element_size();
+    const uint32_t output_page_size = round_up_to_mul32(output_unit_size);
+    CircularBufferConfig output_cb_config =
+        CircularBufferConfig(num_output_units * output_page_size, {{cb_dst_id, cb_data_format}})
+            .set_page_size(cb_dst_id, output_page_size)
+            .set_globally_allocated_address(*output.buffer());
+    CBHandle cb_output = CreateCircularBuffer(program, all_cores, output_cb_config);
+
+    const ShardSpec output_shard_spec = output.shard_spec().value();
+    const uint32_t output_stick_size = output_shard_spec.shape[1] * output.element_size();
+
+    const ShardSpec input_0_shard_spec = input_tensors[0].shard_spec().value();
+    const ShardSpec input_1_shard_spec = input_tensors[1].shard_spec().value();
+    const uint32_t input_0_stick_size = input_0_shard_spec.shape[1] * input_tensors[0].element_size();
+    const uint32_t input_1_stick_size = input_1_shard_spec.shape[1] * input_tensors[1].element_size();
+    const uint32_t input_0_stride = output_stick_size - input_0_stick_size;
+    const uint32_t input_1_stride = output_stick_size - input_1_stick_size;
+    const uint32_t num_output_rows_per_core = input_tensors[0].shard_spec().value().shape[0];
+    const uint32_t num_pages_per_risc = tt::div_up(num_output_rows_per_core, 2);
+
+    const uint32_t num_output_rows_per_core_last = num_output_rows % num_output_rows_per_core;
+    const uint32_t num_pages_per_risc_last = tt::div_up(num_output_rows_per_core_last, 2);
+
+    std::vector<uint32_t> compile_time_args_0 = {
+        cb_dst_id,
+        input_0_stick_size,
+        input_1_stick_size,
+        input_0_stride,
+        input_1_stride,
+        num_output_rows_per_core * num_input_tensors,
+        0,
+        num_pages_per_risc,
+        0,
+        0,
+        0,
+        groups};
+
+    std::vector<uint32_t> compile_time_args_1 = {
+        cb_dst_id,
+        input_0_stick_size,
+        input_1_stick_size,
+        input_0_stride,
+        input_1_stride,
+        num_output_rows_per_core * num_input_tensors,
+        num_pages_per_risc,
+        num_output_rows_per_core,
+        num_pages_per_risc * output_stick_size,
+        num_pages_per_risc * input_0_stick_size,
+        num_pages_per_risc * input_1_stick_size,
+        groups};
+
+    std::vector<uint32_t> compile_time_args_0_last = {
+        cb_dst_id,
+        input_0_stick_size,
+        input_1_stick_size,
+        input_0_stride,
+        input_1_stride,
+        num_output_rows_per_core_last * num_input_tensors,
+        0,
+        num_pages_per_risc_last,
+        0,
+        0,
+        0,
+        groups};
+
+    std::vector<uint32_t> compile_time_args_1_last = {
+        cb_dst_id,
+        input_0_stick_size,
+        input_1_stick_size,
+        input_0_stride,
+        input_1_stride,
+        num_output_rows_per_core_last * num_input_tensors,
+        num_pages_per_risc_last,
+        num_output_rows_per_core_last,
+        num_pages_per_risc_last * output_stick_size,
+        num_pages_per_risc_last * input_0_stick_size,
+        num_pages_per_risc_last * input_1_stick_size,
+        groups};
+
+    if (num_output_rows_per_core_last > 0) {
+        const bool rm_orientation = output_shard_spec.orientation == ShardOrientation::ROW_MAJOR;
+        const std::vector<CoreCoord> cores = corerange_to_cores(all_cores, std::nullopt, rm_orientation);
+        const auto [first, last] = split(cores, cores.size() - 1);
+        const CoreRangeSet first_cores = cores_to_corerangeset(first);
+        const CoreRangeSet last_cores = cores_to_corerangeset(last);
+        CreateKernel(
+            program,
+            "ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/"
+            "reader_height_sharded_width_concat_two_tensors.cpp",
+            first_cores,
+            ReaderDataMovementConfig(compile_time_args_0));
+        CreateKernel(
+            program,
+            "ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/"
+            "reader_height_sharded_width_concat_two_tensors.cpp",
+            first_cores,
+            WriterDataMovementConfig(compile_time_args_1));
+
+        CreateKernel(
+            program,
+            "ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/"
+            "reader_height_sharded_width_concat_two_tensors.cpp",
+            last_cores,
+            ReaderDataMovementConfig(compile_time_args_0_last));
+        CreateKernel(
+            program,
+            "ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/"
+            "reader_height_sharded_width_concat_two_tensors.cpp",
+            last_cores,
+            WriterDataMovementConfig(compile_time_args_1_last));
+    } else {
+        CreateKernel(
+            program,
+            "ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/"
+            "reader_height_sharded_width_concat_two_tensors.cpp",
+            all_cores,
+            ReaderDataMovementConfig(compile_time_args_0));
+        CreateKernel(
+            program,
+            "ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/"
+            "reader_height_sharded_width_concat_two_tensors.cpp",
+            all_cores,
+            WriterDataMovementConfig(compile_time_args_1));
+    }
+
+    return {
+        std::move(program),
+        {.num_input_tensors = num_input_tensors,
+         .cb_inputs = cb_input,
+         .cb_output = cb_output,
+         .all_cores = all_cores}};
+}
+
+void ConcatS2SRMProgramFactory::override_runtime_arguments(
+    cached_program_t& cached_program,
+    const operation_attributes_t& operation_attributes,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& tensor_return_value) {
+    auto& program = cached_program.program;
+    const auto& shared_vars = cached_program.shared_variables;
+
+    for (uint32_t input_id = 0; input_id < shared_vars.num_input_tensors; input_id++) {
+        UpdateDynamicCircularBufferAddress(
+            program, shared_vars.cb_inputs[input_id], *tensor_args.input_tensors[input_id].buffer());
+    }
+    UpdateDynamicCircularBufferAddress(program, shared_vars.cb_output, *tensor_return_value.buffer());
+}
+
+}  // namespace ttnn::operations::data_movement::concat::program

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_s2s_rm_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_s2s_rm_program_factory.hpp
@@ -6,19 +6,19 @@
 
 #include "concat_device_operation_types.hpp"
 #include "ttnn/device_operation.hpp"
-#include <tt-metalium/work_split.hpp>
 
 namespace ttnn::operations::data_movement::concat::program {
 
-// Shared variables for interleaved concat
-struct ConcatSharedVariables {
-    tt::tt_metal::KernelHandle reader_kernel_id = 0;
-    tt::tt_metal::KernelHandle writer_kernel_id = 0;
-    std::vector<CoreCoord> cores;
+// Shared variables for s2s row-major concat
+struct ConcatS2SRMSharedVariables {
+    uint32_t num_input_tensors = 0;
+    std::vector<tt::tt_metal::CBHandle> cb_inputs;
+    tt::tt_metal::CBHandle cb_output = 0;
+    CoreRangeSet all_cores;
 };
 
-struct ConcatProgramFactory {
-    using shared_variables_t = ConcatSharedVariables;
+struct ConcatS2SRMProgramFactory {
+    using shared_variables_t = ConcatS2SRMSharedVariables;
     using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
 
     static cached_program_t create(

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_s2s_tiled_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_s2s_tiled_program_factory.cpp
@@ -1,0 +1,231 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "concat_s2s_tiled_program_factory.hpp"
+
+#include <algorithm>
+
+#include "tt-metalium/buffer.hpp"
+#include "ttnn/tensor/tensor.hpp"
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/constants.hpp>
+
+namespace ttnn::operations::data_movement::concat::program {
+
+ConcatS2STiledProgramFactory::cached_program_t ConcatS2STiledProgramFactory::create(
+    const operation_attributes_t& operation_attributes,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& tensor_return_value) {
+    using namespace tt::constants;
+    using namespace tt::tt_metal;
+
+    const std::vector<Tensor>& input_tensors = tensor_args.input_tensors;
+    const uint32_t dim = operation_attributes.dim;
+    const unsigned int groups = operation_attributes.groups;
+    Tensor& output = tensor_return_value;
+    // If we end up here for concat with more than 2 tensors on any other dim we should have
+    // taken another path
+    TT_FATAL(dim == 3, "Sharded concat with tiled inputs only supports dim=3 (was {})", dim);
+    TT_FATAL(input_tensors.size() == 2, "Expected 2 input tensors (was {})", input_tensors.size());
+    TT_FATAL(input_tensors[0].shard_spec().has_value(), "Input tensor 0 must be sharded");
+    TT_FATAL(input_tensors[1].shard_spec().has_value(), "Input tensor 1 must be sharded");
+    TT_FATAL(output.shard_spec().has_value(), "Output must be sharded");
+
+    TT_FATAL(
+        input_tensors[0].logical_shape()[-1] == input_tensors[0].padded_shape()[-1],
+        "Cannot have padding along width dimension in input tensor 0 ({} != {})",
+        input_tensors[0].logical_shape()[-1],
+        input_tensors[0].padded_shape()[-1]);
+    TT_FATAL(
+        input_tensors[1].logical_shape()[-1] == input_tensors[1].padded_shape()[-1],
+        "Cannot have padding along width dimension in input tensor 1 ({} != {})",
+        input_tensors[1].logical_shape()[-1],
+        input_tensors[1].padded_shape()[-1]);
+
+    TT_FATAL(
+        input_tensors[0].padded_shape()[-1] % groups == 0,
+        "Input tensor 0 columns must be evenly divisible by groups (W={}, groups={})",
+        input_tensors[0].padded_shape()[-1],
+        groups);
+    TT_FATAL(
+        input_tensors[1].padded_shape()[-1] % groups == 0,
+        "Input tensor 1 columns must be evenly divisible by groups (W={}, groups={})",
+        input_tensors[1].padded_shape()[-1],
+        groups);
+
+    // The current implementation relies on not having break up tile faces so if we would
+    // need to split tiles because dim[-1] / groups < 16, we cannot proceed
+    TT_FATAL(
+        input_tensors[0].padded_shape()[-1] / groups >= TILE_HEIGHT / 2,
+        "Group size must be at least 16 for input0 (was {})",
+        input_tensors[0].padded_shape()[-1] / groups);
+    TT_FATAL(
+        input_tensors[1].padded_shape()[-1] / groups >= TILE_HEIGHT / 2,
+        "Group size must be at least 16 for input1 (was {})",
+        input_tensors[1].padded_shape()[-1] / groups);
+
+    Program program = CreateProgram();
+
+    const CoreRangeSet all_cores = input_tensors[0].shard_spec().value().grid;  // assume all inputs have same grid
+
+    const auto get_num_tiles_per_shard = [](const ShardSpec& shard_spec) -> std::pair<uint32_t, uint32_t> {
+        const std::array<uint32_t, 2> shard_shape = shard_spec.shape;
+        TT_FATAL(shard_shape[0] % TILE_HEIGHT == 0, "Shard height must be aligned to tile height");
+        TT_FATAL(shard_shape[1] % TILE_WIDTH == 0, "Shard width must be aligned to tile width");
+        const uint32_t num_tiles_along_height = shard_shape[0] / TILE_HEIGHT;
+        const uint32_t num_tiles_along_width = shard_shape[1] / TILE_WIDTH;
+        TT_FATAL(num_tiles_along_height != 0 && num_tiles_along_width != 0, "Expected tensor to have at least 1 tiles");
+        return {num_tiles_along_height, num_tiles_along_width};
+    };
+
+    const auto get_total_num_tiles_per_shard = [](const std::pair<uint32_t, uint32_t>& num_tiles) -> uint32_t {
+        return num_tiles.first * num_tiles.second;
+    };
+
+    std::vector<std::pair<uint32_t, uint32_t>> num_tiles_for_each_input_shard;
+    num_tiles_for_each_input_shard.reserve(input_tensors.size());
+    std::transform(
+        input_tensors.begin(),
+        input_tensors.end(),
+        std::back_inserter(num_tiles_for_each_input_shard),
+        [&get_num_tiles_per_shard](const Tensor& input_tensor) {
+            return get_num_tiles_per_shard(input_tensor.shard_spec().value());
+        });
+    const std::pair<uint32_t, uint32_t> num_tiles_for_output_shard =
+        get_num_tiles_per_shard(output.shard_spec().value());
+
+    const auto create_circular_buffer = [&program, &cores = all_cores](
+                                            uint32_t index,
+                                            uint32_t num_tiles,
+                                            uint32_t tile_size,
+                                            const tt::DataFormat& format,
+                                            Buffer* buffer) -> CBHandle {
+        CircularBufferConfig config =
+            CircularBufferConfig(num_tiles * tile_size, {{index, format}}).set_page_size(index, tile_size);
+        if (buffer) {
+            config.set_globally_allocated_address(*buffer);
+        }
+        return CreateCircularBuffer(program, cores, config);
+    };
+
+    const auto create_cb_from_tensor =
+        [&create_circular_buffer](uint32_t idx, const Tensor& input_tensor, uint32_t total_num_tiles) -> CBHandle {
+        const auto data_format = datatype_to_dataformat_converter(input_tensor.dtype());
+        const auto tile_size = tt::tile_size(data_format);
+        return create_circular_buffer(idx, total_num_tiles, tile_size, data_format, input_tensor.buffer());
+    };
+
+    TT_FATAL(input_tensors.at(0).dtype() == input_tensors.at(1).dtype(), "Input tensor data types must match");
+    const tt::DataFormat data_format = datatype_to_dataformat_converter(input_tensors.at(0).dtype());
+    const uint32_t tile_size = tt::tile_size(data_format);
+
+    const uint32_t num_input_tensors = input_tensors.size();
+    std::vector<CBHandle> cb_inputs(num_input_tensors);
+    for (uint32_t idx = 0; idx < num_input_tensors; idx++) {
+        const Tensor& input_tensor = input_tensors.at(idx);
+        const uint32_t total_num_tiles = get_total_num_tiles_per_shard(num_tiles_for_each_input_shard[idx]);
+        cb_inputs[idx] = create_cb_from_tensor(idx, input_tensor, total_num_tiles);
+    }
+
+    const uint32_t cb_output_id = cb_inputs.size();
+    const uint32_t total_num_output_tiles = get_total_num_tiles_per_shard(num_tiles_for_output_shard);
+    const CBHandle cb_output = create_cb_from_tensor(cb_output_id, output, total_num_output_tiles);
+
+    tt::DataFormat cb_data_format = data_format;
+    uint32_t cb_tile_size = tile_size;
+    const bool is_bf8 = input_tensors[0].dtype() == DataType::BFLOAT8_B;
+    if (is_bf8) {
+        cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(DataType::BFLOAT16);
+        cb_tile_size = tt::tile_size(cb_data_format);
+    }
+
+    const uint32_t in0_total_tiles_width = num_tiles_for_each_input_shard[0].second;
+    const uint32_t cb_input0_transpose_id = cb_inputs.size() + 1;
+    create_circular_buffer(cb_input0_transpose_id, in0_total_tiles_width, cb_tile_size, cb_data_format, nullptr);
+
+    const uint32_t in1_total_tiles_width = num_tiles_for_each_input_shard[1].second;
+    const uint32_t cb_input1_transpose_id = cb_inputs.size() + 2;
+    create_circular_buffer(cb_input1_transpose_id, in1_total_tiles_width, cb_tile_size, cb_data_format, nullptr);
+
+    const uint32_t out_total_tiles_width = in0_total_tiles_width + in1_total_tiles_width;
+    const uint32_t cb_concat_id = cb_inputs.size() + 3;
+    create_circular_buffer(cb_concat_id, out_total_tiles_width, cb_tile_size, cb_data_format, nullptr);
+
+    const uint32_t cb_output_transpose_id = cb_inputs.size() + 4;
+    create_circular_buffer(cb_output_transpose_id, out_total_tiles_width, tile_size, data_format, nullptr);
+
+    // TODO: Skip the tile transpose in compute kernel if the following condition is true:
+    // >> (input_tensors[0].padded_shape()[-1] / groups % TILE_WIDTH == 0
+    // >> && input_tensors[1].padded_shape()[-1] / groups % TILE_WIDTH == 0)
+    constexpr uint32_t MAX_1_BYTE_TILES_PER_BATCH = 16;
+    const uint32_t batch_size = MAX_1_BYTE_TILES_PER_BATCH / input_tensors[0].element_size();
+
+    std::vector<uint32_t> compile_time_args_0 = {
+        0,
+        1,
+        cb_input0_transpose_id,
+        cb_input1_transpose_id,
+        cb_concat_id,
+        cb_output_transpose_id,
+        cb_output_id,
+        num_tiles_for_each_input_shard[0].first,
+        num_tiles_for_each_input_shard[0].second,
+        num_tiles_for_each_input_shard[1].first,
+        num_tiles_for_each_input_shard[1].second,
+        tile_size,
+        groups,
+        batch_size,
+    };
+    std::map<std::string, std::string> reader_defines;
+    if (is_bf8) {
+        reader_defines["BF8"] = "1";
+    }
+    CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/"
+        "reader_height_sharded_width_concat_two_tensors_tiled.cpp",
+        all_cores,
+        ReaderDataMovementConfig(compile_time_args_0, std::move(reader_defines)));
+    CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/"
+        "writer_height_sharded_width_concat_two_tensors_tiled.cpp",
+        all_cores,
+        WriterDataMovementConfig(compile_time_args_0));
+
+    CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/compute/"
+        "height_sharded_width_concat_two_tensors.cpp",
+        all_cores,
+        ComputeConfig{
+            .math_fidelity = MathFidelity::HiFi4,
+            .fp32_dest_acc_en = false,
+            .math_approx_mode = false,
+            .compile_args = compile_time_args_0});
+
+    return {
+        std::move(program),
+        {.num_input_tensors = num_input_tensors,
+         .cb_inputs = cb_inputs,
+         .cb_output = cb_output,
+         .all_cores = all_cores}};
+}
+
+void ConcatS2STiledProgramFactory::override_runtime_arguments(
+    cached_program_t& cached_program,
+    const operation_attributes_t& operation_attributes,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& tensor_return_value) {
+    auto& program = cached_program.program;
+    const auto& shared_vars = cached_program.shared_variables;
+
+    for (uint32_t input_id = 0; input_id < shared_vars.num_input_tensors; input_id++) {
+        UpdateDynamicCircularBufferAddress(
+            program, shared_vars.cb_inputs[input_id], *tensor_args.input_tensors[input_id].buffer());
+    }
+    UpdateDynamicCircularBufferAddress(program, shared_vars.cb_output, *tensor_return_value.buffer());
+}
+
+}  // namespace ttnn::operations::data_movement::concat::program

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_s2s_tiled_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_s2s_tiled_program_factory.hpp
@@ -6,19 +6,19 @@
 
 #include "concat_device_operation_types.hpp"
 #include "ttnn/device_operation.hpp"
-#include <tt-metalium/work_split.hpp>
 
 namespace ttnn::operations::data_movement::concat::program {
 
-// Shared variables for interleaved concat
-struct ConcatSharedVariables {
-    tt::tt_metal::KernelHandle reader_kernel_id = 0;
-    tt::tt_metal::KernelHandle writer_kernel_id = 0;
-    std::vector<CoreCoord> cores;
+// Shared variables for s2s tiled concat
+struct ConcatS2STiledSharedVariables {
+    uint32_t num_input_tensors = 0;
+    std::vector<tt::tt_metal::CBHandle> cb_inputs;
+    tt::tt_metal::CBHandle cb_output = 0;
+    CoreRangeSet all_cores;
 };
 
-struct ConcatProgramFactory {
-    using shared_variables_t = ConcatSharedVariables;
+struct ConcatS2STiledProgramFactory {
+    using shared_variables_t = ConcatS2STiledSharedVariables;
     using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
 
     static cached_program_t create(


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/32741

### Problem description

We have 2 ways of writing ops, which should be unified into one.

### What's changed

Migrate concat op to the new infrastructure.

### Checklist
- [X] [All post commit #19965136674](https://github.com/tenstorrent/tt-metal/actions/runs/19965136674) CI passes except C++ unit tests (timeout, happens all the time, not related).