### PR TITLE
Fix set-opened-on workflow: null handling, token validation, and pagination

### DIFF
--- a/.github/workflows/set-opened-on.yaml
+++ b/.github/workflows/set-opened-on.yaml
@@ -24,6 +24,12 @@ jobs:
         run: |
           set -e
 
+          # Validate token is set
+          if [ -z "$GH_TOKEN" ]; then
+            echo "Error: GH_TOKEN (DATE_AUTOMATION secret) is not set" >&2
+            exit 1
+          fi
+
           # Extract date from issue creation timestamp
           RAW_CREATED="${{ github.event.issue.created_at }}"
           OPENED_DATE="${RAW_CREATED%%T*}"
@@ -50,10 +56,18 @@ jobs:
             exit 1
           }
 
-          # Check for GraphQL errors
+          # Check for GraphQL errors (including permission issues)
           if echo "$RESP" | jq -e '.errors' > /dev/null 2>&1; then
             echo "Error: GraphQL returned errors:" >&2
             echo "$RESP" | jq '.errors' >&2
+            
+            # Check specifically for scope issues
+            if echo "$RESP" | jq -e '.errors[] | select(.type == "INSUFFICIENT_SCOPES")' > /dev/null 2>&1; then
+              echo "" >&2
+              echo "Token is missing required scopes. Please update DATE_AUTOMATION secret with:" >&2
+              echo "  - read:project (to read project data)" >&2
+              echo "  - project or write:project (to update fields)" >&2
+            fi
             exit 1
           fi
 
@@ -63,7 +77,7 @@ jobs:
             echo "Error: Project '$PROJECT_NUMBER' not found in org '$ORG'" >&2
             echo "This may be due to:" >&2
             echo "  - Project doesn't exist" >&2
-            echo "  - Token lacks 'read:project' scope" >&2
+            echo "  - Token lacks 'read:project' scope (or token is expired)" >&2
             echo "  - Token doesn't have access to the organization" >&2
             exit 1
           fi
@@ -101,6 +115,12 @@ jobs:
           if echo "$ADD_RESP" | jq -e '.errors' > /dev/null 2>&1; then
             echo "Error: Failed to add issue to project:" >&2
             echo "$ADD_RESP" | jq '.errors' >&2
+            
+            # Check for scope/permission issues
+            if echo "$ADD_RESP" | jq -e '.errors[] | select(.type == "INSUFFICIENT_SCOPES" or .message | contains("permission"))' > /dev/null 2>&1; then
+              echo "" >&2
+              echo "Token may lack 'project' or 'write:project' scope" >&2
+            fi
             exit 1
           fi
 
@@ -133,6 +153,12 @@ jobs:
           if echo "$UPDATE_RESP" | jq -e '.errors' > /dev/null 2>&1; then
             echo "Error: Failed to set field value:" >&2
             echo "$UPDATE_RESP" | jq '.errors' >&2
+            
+            # Check for scope/permission issues
+            if echo "$UPDATE_RESP" | jq -e '.errors[] | select(.type == "INSUFFICIENT_SCOPES" or .message | contains("permission"))' > /dev/null 2>&1; then
+              echo "" >&2
+              echo "Token may lack 'project' or 'write:project' scope" >&2
+            fi
             exit 1
           fi
 

--- a/.github/workflows/set-opened-on.yaml
+++ b/.github/workflows/set-opened-on.yaml
@@ -40,7 +40,7 @@ jobs:
             organization(login:$org){
               projectV2(number:$number){
                 id
-                fields(first:200){
+                fields(first:100){
                   nodes {
                     ... on ProjectV2FieldCommon {
                       id

--- a/.github/workflows/set-opened-on.yaml
+++ b/.github/workflows/set-opened-on.yaml
@@ -117,7 +117,7 @@ jobs:
             echo "$ADD_RESP" | jq '.errors' >&2
 
             # Check for scope/permission issues
-            if echo "$ADD_RESP" | jq -e '.errors[] | select(.type == "INSUFFICIENT_SCOPES" or .message | contains("permission"))' > /dev/null 2>&1; then
+            if echo "$ADD_RESP" | jq -e '.errors[] | select(.type == "INSUFFICIENT_SCOPES" or (.message // "" | contains("permission")))' > /dev/null 2>&1; then
               echo "" >&2
               echo "Token may lack 'project' or 'write:project' scope" >&2
             fi
@@ -155,7 +155,7 @@ jobs:
             echo "$UPDATE_RESP" | jq '.errors' >&2
 
             # Check for scope/permission issues
-            if echo "$UPDATE_RESP" | jq -e '.errors[] | select(.type == "INSUFFICIENT_SCOPES" or .message | contains("permission"))' > /dev/null 2>&1; then
+            if echo "$UPDATE_RESP" | jq -e '.errors[] | select(.type == "INSUFFICIENT_SCOPES" or (.message // "" | contains("permission")))' > /dev/null 2>&1; then
               echo "" >&2
               echo "Token may lack 'project' or 'write:project' scope" >&2
             fi

--- a/.github/workflows/set-opened-on.yaml
+++ b/.github/workflows/set-opened-on.yaml
@@ -4,7 +4,8 @@ on:
   issues:
     types: [opened]
 
-# This job uses your fine-grained PAT secret (DATE_AUTOMATION) via gh CLI.
+# This job uses a fine-grained PAT secret (DATE_AUTOMATION) via gh CLI.
+# Required token scopes: read:project, project (or write:project)
 # No repo write perms needed from the Actions token itself.
 permissions:
   contents: read
@@ -57,12 +58,17 @@ jobs:
           fi
 
           PROJECT_ID=$(echo "$RESP" | jq -r '.data.organization.projectV2.id // empty')
-          FIELD_ID=$(echo "$RESP" | jq -r --arg NAME "$OPENED_ON_FIELD_NAME" '.data.organization.projectV2.fields.nodes[] | select(. != null and .name==$NAME) | .id // empty')
-
+          
           if [ -z "$PROJECT_ID" ]; then
             echo "Error: Project '$PROJECT_NUMBER' not found in org '$ORG'" >&2
+            echo "This may be due to:" >&2
+            echo "  - Project doesn't exist" >&2
+            echo "  - Token lacks 'read:project' scope" >&2
+            echo "  - Token doesn't have access to the organization" >&2
             exit 1
           fi
+
+          FIELD_ID=$(echo "$RESP" | jq -r --arg NAME "$OPENED_ON_FIELD_NAME" '.data.organization.projectV2.fields.nodes[] | select(. != null and .name==$NAME) | .id // empty')
 
           if [ -z "$FIELD_ID" ]; then
             echo "Error: Field '$OPENED_ON_FIELD_NAME' not found in project" >&2

--- a/.github/workflows/set-opened-on.yaml
+++ b/.github/workflows/set-opened-on.yaml
@@ -60,7 +60,7 @@ jobs:
           if echo "$RESP" | jq -e '.errors' > /dev/null 2>&1; then
             echo "Error: GraphQL returned errors:" >&2
             echo "$RESP" | jq '.errors' >&2
-            
+
             # Check specifically for scope issues
             if echo "$RESP" | jq -e '.errors[] | select(.type == "INSUFFICIENT_SCOPES")' > /dev/null 2>&1; then
               echo "" >&2
@@ -72,7 +72,7 @@ jobs:
           fi
 
           PROJECT_ID=$(echo "$RESP" | jq -r '.data.organization.projectV2.id // empty')
-          
+
           if [ -z "$PROJECT_ID" ]; then
             echo "Error: Project '$PROJECT_NUMBER' not found in org '$ORG'" >&2
             echo "This may be due to:" >&2
@@ -115,7 +115,7 @@ jobs:
           if echo "$ADD_RESP" | jq -e '.errors' > /dev/null 2>&1; then
             echo "Error: Failed to add issue to project:" >&2
             echo "$ADD_RESP" | jq '.errors' >&2
-            
+
             # Check for scope/permission issues
             if echo "$ADD_RESP" | jq -e '.errors[] | select(.type == "INSUFFICIENT_SCOPES" or .message | contains("permission"))' > /dev/null 2>&1; then
               echo "" >&2
@@ -153,7 +153,7 @@ jobs:
           if echo "$UPDATE_RESP" | jq -e '.errors' > /dev/null 2>&1; then
             echo "Error: Failed to set field value:" >&2
             echo "$UPDATE_RESP" | jq '.errors' >&2
-            
+
             # Check for scope/permission issues
             if echo "$UPDATE_RESP" | jq -e '.errors[] | select(.type == "INSUFFICIENT_SCOPES" or .message | contains("permission"))' > /dev/null 2>&1; then
               echo "" >&2


### PR DESCRIPTION
### Problem
The workflow was failing due to multiple issues discovered during testing:
1. Token missing required scopes (read:project, project)
2. GraphQL pagination limit exceeded (requested 200, max is 100)
3. Null projectV2 causing jq iteration errors

### Changes
**Token Validation:**
- Check if GH_TOKEN is set
- Detect INSUFFICIENT_SCOPES errors with helpful messages
- Check for permission errors in all mutations
- Validate PROJECT_ID before accessing fields (prevents null iteration)

**GraphQL Fixes:**
- Changed fields(first:200) to fields(first:100) per API limits
- Improved error messages for expired/invalid tokens

**Documentation:**
- Added required token scopes in comments
- Clear error messages explaining how to fix issues

### Testing
- Fixed run 19930322727 (null projectV2 - missing token scopes)
- Fixed run 19931467882 (pagination limit)

### Error Handling
The workflow now has comprehensive error checking:
- ✅ Token not set
- ✅ Token expired/invalid  
- ✅ Token missing required scopes
- ✅ Project not found
- ✅ Field not found
- ✅ All GraphQL errors
- ✅ All mutation failures