### PR TITLE
Revert "Implement in-memory GSD/FSD validation to avoid disk I/O (#33055)"

### DIFF
--- a/tools/scaleout/CMakeLists.txt
+++ b/tools/scaleout/CMakeLists.txt
@@ -77,8 +77,6 @@ target_link_libraries(
     PRIVATE
         enchantum::enchantum
         protobuf::libprotobuf
-        yaml-cpp::yaml-cpp
-        scaleout_tools
         tt_metal
 )
 target_compile_features(scaleout_tools PUBLIC cxx_std_20)

--- a/tools/scaleout/factory_system_descriptor/utils.cpp
+++ b/tools/scaleout/factory_system_descriptor/utils.cpp
@@ -518,16 +518,6 @@ std::set<PhysicalChannelConnection> validate_fsd_against_gsd(
     return validate_fsd_against_gsd_impl(generated_fsd, discovered_gsd, strict_validation, assert_on_connection_mismatch, log_output);
 }
 
-std::set<PhysicalChannelConnection> validate_fsd_against_gsd(
-    const fsd::proto::FactorySystemDescriptor& fsd_proto,
-    const YAML::Node& gsd_yaml_node,
-    bool strict_validation,
-    bool assert_on_connection_mismatch,
-    bool log_output) {
-    return validate_fsd_against_gsd_impl(
-        fsd_proto, gsd_yaml_node, strict_validation, assert_on_connection_mismatch, log_output);
-}
-
 std::set<PhysicalChannelConnection> validate_cabling_descriptor_against_gsd(
     const std::string& cabling_descriptor_path,
     const std::vector<std::string>& hostnames,

--- a/tools/scaleout/factory_system_descriptor/utils.hpp
+++ b/tools/scaleout/factory_system_descriptor/utils.hpp
@@ -31,25 +31,6 @@ std::set<PhysicalChannelConnection> validate_fsd_against_gsd(
     bool assert_on_connection_mismatch = true,
     bool log_output = true);
 
-// In-memory overload for validating FSD against GSD without disk I/O
-// Validates that the Factory System Descriptor (FSD) protobuf matches the Global System Descriptor (GSD) YAML node
-// This overload operates on in-memory data structures, avoiding file I/O operations
-// Parameters:
-//   - fsd_proto: The FSD protobuf object (in-memory)
-//   - gsd_yaml_node: The GSD YAML node (in-memory)
-//   - strict_validation: If true, checks that all connections match bidirectionally
-//                        If false, only checks that GSD connections exist in FSD
-//   - assert_on_connection_mismatch: If true, throws an error if there are connection mismatches
-//                                    If false, missing connections are logged without an error being thrown
-//   - log_output: If true, logs validation results
-// Returns: Set of physical channel connections that are missing or mismatched
-std::set<PhysicalChannelConnection> validate_fsd_against_gsd(
-    const fsd::proto::FactorySystemDescriptor& fsd_proto,
-    const YAML::Node& gsd_yaml_node,
-    bool strict_validation = true,
-    bool assert_on_connection_mismatch = true,
-    bool log_output = true);
-
 // Validate cabling descriptor against discovered system topology
 std::set<PhysicalChannelConnection> validate_cabling_descriptor_against_gsd(
     const std::string& cabling_descriptor_path,

--- a/tools/scaleout/validation/run_cluster_validation.cpp
+++ b/tools/scaleout/validation/run_cluster_validation.cpp
@@ -18,8 +18,6 @@
 #include <cabling_generator/cabling_generator.hpp>
 #include <tt-metalium/hal.hpp>
 #include "tools/scaleout/validation/utils/cluster_validation_utils.hpp"
-#include <yaml-cpp/yaml.h>
-#include "protobuf/factory_system_descriptor.pb.h"
 #include <llrt/tt_cluster.hpp>
 
 namespace tt::scaleout_tools {
@@ -242,20 +240,42 @@ PhysicalSystemDescriptor generate_physical_system_descriptor(const InputArgs& in
     }
 }
 
+void cleanup_metadata(const InputArgs& input_args, const std::string& gsd_file, const std::string& fsd_file) {
+    // Remove GSD file
+    std::filesystem::remove(gsd_file);
+    if (!input_args.fsd_path.has_value()) {
+        // Remove FSD file
+        std::filesystem::remove(fsd_file);
+    } else {
+        TT_FATAL(fsd_file == input_args.fsd_path.value(), "Internal error: Expected FSD File Paths to match");
+    }
+}
+
 AsicTopology run_connectivity_validation(
     const InputArgs& input_args, PhysicalSystemDescriptor& physical_system_descriptor) {
     if (!input_args.validate_connectivity) {
         return {};
     }
-    YAML::Node gsd_yaml_node = physical_system_descriptor.generate_yaml_node();
-    auto fsd_proto = get_factory_system_descriptor(
+    const auto& distributed_context = tt::tt_metal::MetalContext::instance().global_distributed_context();
+    std::string gsd_yaml_filename = "global_system_descriptor_" + std::to_string(*distributed_context.rank()) + ".yaml";
+    std::string gsd_yaml_path = input_args.output_path / gsd_yaml_filename;
+    physical_system_descriptor.dump_to_yaml(gsd_yaml_path);
+
+    const auto fsd_path = get_factory_system_descriptor_path(
         input_args.cabling_descriptor_path,
         input_args.deployment_descriptor_path,
         input_args.fsd_path,
+        input_args.output_path.string(),
         physical_system_descriptor.get_all_hostnames());
     auto missing_topology =
-        validate_connectivity(fsd_proto, gsd_yaml_node, input_args.fail_on_warning, physical_system_descriptor);
+        validate_connectivity(fsd_path, gsd_yaml_path, input_args.fail_on_warning, physical_system_descriptor);
 
+    // TODO (AS): We shouldn't need to dump files to disk for validation, once validate_fsd_against_gsd can support
+    // comparing string representations of the FSD and GSD. For now, each rank dumps a file to disk, which gets deleted
+    // post validation (for all ranks except rank 0).
+    if (*distributed_context.rank() != 0) {
+        cleanup_metadata(input_args, gsd_yaml_path, fsd_path);
+    }
     return missing_topology;
 }
 

--- a/tools/scaleout/validation/utils/cluster_validation_utils.cpp
+++ b/tools/scaleout/validation/utils/cluster_validation_utils.cpp
@@ -21,10 +21,6 @@
 #include <tt-metalium/device.hpp>
 #include <tt-metalium/distributed.hpp>
 #include <enchantum/enchantum.hpp>
-#include <cabling_generator/cabling_generator.hpp>
-#include <google/protobuf/text_format.h>
-#include <yaml-cpp/yaml.h>
-#include "protobuf/factory_system_descriptor.pb.h"
 #include <llrt/tt_cluster.hpp>
 
 namespace tt::scaleout_tools {
@@ -951,17 +947,20 @@ void handle_workload_timeout(
         log_output_rank0("Re-running discovery to check for link failures");
         ctx.physical_system_descriptor.run_discovery(true, true);
 
-        log_output_rank0("Generating Global System Descriptor in-memory");
-        YAML::Node gsd_yaml_node = ctx.physical_system_descriptor.generate_yaml_node();
+        const auto& distributed_context = tt::tt_metal::MetalContext::instance().global_distributed_context();
+        std::string gsd_yaml_filename =
+            "timeout_global_system_descriptor_" + std::to_string(*distributed_context.rank()) + ".yaml";
+        std::string gsd_yaml_path = validation_config.output_path / gsd_yaml_filename;
+        ctx.physical_system_descriptor.dump_to_yaml(gsd_yaml_path);
 
-        log_output_rank0("Obtaining Factory System Descriptor");
-        auto fsd_proto = get_factory_system_descriptor(
+        const auto fsd_file_path = get_factory_system_descriptor_path(
             validation_config.cabling_descriptor_path,
             validation_config.deployment_descriptor_path,
             validation_config.fsd_path,
+            validation_config.output_path.string(),
             ctx.physical_system_descriptor.get_all_hostnames());
         validate_connectivity(
-            fsd_proto, gsd_yaml_node, validation_config.fail_on_warning, ctx.physical_system_descriptor);
+            fsd_file_path, gsd_yaml_path, validation_config.fail_on_warning, ctx.physical_system_descriptor);
     } else {
         log_output_rank0(
             "WARNING: Cannot validate Global System Descriptor against Factory System Descriptor, "
@@ -1512,55 +1511,45 @@ void perform_link_reset(
     log_output_rank0("Link reset completed. Please run the validation tool again to verify the link.");
 }
 
-fsd::proto::FactorySystemDescriptor get_factory_system_descriptor(
+std::string get_factory_system_descriptor_path(
     const std::optional<std::string>& cabling_descriptor_path,
     const std::optional<std::string>& deployment_descriptor_path,
     const std::optional<std::string>& fsd_path,
+    const std::string& output_path,
     const std::vector<std::string>& hostnames) {
-    if (!cabling_descriptor_path.has_value() && !fsd_path.has_value()) {
-        TT_THROW("Either cabling_descriptor_path or fsd_path must be provided");
-    }
-
+    std::string fsd_file_path;
     if (cabling_descriptor_path.has_value()) {
+        const auto& distributed_context = tt::tt_metal::MetalContext::instance().global_distributed_context();
         log_output_rank0("Creating Factory System Descriptor (Golden Representation)");
-        tt::scaleout_tools::CablingGenerator cabling_generator;
+        CablingGenerator cabling_generator;
+        std::string filename =
+            "generated_factory_system_descriptor_" + std::to_string(*distributed_context.rank()) + ".textproto";
+        fsd_file_path = std::filesystem::path(output_path) / filename;
+
         if (!deployment_descriptor_path.has_value()) {
-            TT_FATAL(
-                hostnames.size() == 1,
-                "Expected exactly one host in the cluster when no deployment descriptor is provided");
+            TT_FATAL(hostnames.size() == 1, "Expected exactly one host in the cluster when no deployment descriptor is provided");
             cabling_generator = tt::scaleout_tools::CablingGenerator(cabling_descriptor_path.value(), hostnames);
         } else {
             cabling_generator = tt::scaleout_tools::CablingGenerator(
                 cabling_descriptor_path.value(), deployment_descriptor_path.value());
         }
-        return cabling_generator.generate_factory_system_descriptor();
+        cabling_generator.emit_factory_system_descriptor(fsd_file_path);
     } else {
-        // Load FSD from file
-        fsd::proto::FactorySystemDescriptor fsd_proto;
-        std::ifstream fsd_file(fsd_path.value());
-        if (!fsd_file.is_open()) {
-            TT_THROW("Failed to open FSD file: {}", fsd_path.value());
-        }
-        std::string fsd_content((std::istreambuf_iterator<char>(fsd_file)), std::istreambuf_iterator<char>());
-        fsd_file.close();
-        if (!google::protobuf::TextFormat::ParseFromString(fsd_content, &fsd_proto)) {
-            TT_THROW("Failed to parse FSD protobuf from file: {}", fsd_path.value());
-        }
-        return fsd_proto;
+        fsd_file_path = fsd_path.value();
     }
+    return fsd_file_path;
 }
 
 tt_metal::AsicTopology validate_connectivity(
-    const fsd::proto::FactorySystemDescriptor& fsd_proto,
-    const YAML::Node& gsd_yaml_node,
+    const std::string& fsd_path,
+    const std::string& gsd_yaml_path,
     bool fail_on_warning,
     PhysicalSystemDescriptor& physical_system_descriptor) {
-    log_output_rank0(
-        "Validating Factory System Descriptor (Golden Representation) against Global System Descriptor (in-memory)");
+    log_output_rank0("Validating Factory System Descriptor (Golden Representation) against Global System Descriptor");
     const auto& distributed_context = tt::tt_metal::MetalContext::instance().global_distributed_context();
     auto missing_physical_connections = tt::scaleout_tools::validate_fsd_against_gsd(
-        fsd_proto,
-        gsd_yaml_node,
+        fsd_path,
+        gsd_yaml_path,
         true /* strict_validation */,
         fail_on_warning,
         *distributed_context.rank() == 0 /* log_output */);

--- a/tools/scaleout/validation/utils/cluster_validation_utils.hpp
+++ b/tools/scaleout/validation/utils/cluster_validation_utils.hpp
@@ -16,15 +16,6 @@
 #include <board/board.hpp>
 #include <factory_system_descriptor/utils.hpp>
 
-// Forward declarations for in-memory validation
-namespace YAML {
-class Node;
-}
-
-namespace tt::scaleout_tools::fsd::proto {
-class FactorySystemDescriptor;
-}
-
 namespace tt::scaleout_tools {
 
 using tt::ChipId;
@@ -96,15 +87,16 @@ tt_metal::AsicTopology generate_asic_topology_from_connections(
     const std::set<PhysicalChannelConnection>& physical_connections,
     PhysicalSystemDescriptor& physical_system_descriptor);
 
-fsd::proto::FactorySystemDescriptor get_factory_system_descriptor(
+std::string get_factory_system_descriptor_path(
     const std::optional<std::string>& cabling_descriptor_path,
     const std::optional<std::string>& deployment_descriptor_path,
     const std::optional<std::string>& fsd_path,
+    const std::string& output_path,
     const std::vector<std::string>& hostnames);
 
 tt_metal::AsicTopology validate_connectivity(
-    const fsd::proto::FactorySystemDescriptor& fsd_proto,
-    const YAML::Node& gsd_yaml_node,
+    const std::string& fsd_path,
+    const std::string& gsd_yaml_path,
     bool fail_on_warning,
     PhysicalSystemDescriptor& physical_system_descriptor);
 


### PR DESCRIPTION
…

This reverts commit b11ea45c7a71108cc30f437a0d494bafa480885e.

This broke T3K APC https://github.com/tenstorrent/tt-metal/actions/runs/19929735126

### Ticket

APC breakage

### Problem description

This broke T3K APC

### What's changed

@jpanasiukTT has said we can revert for now

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes
