### PR TITLE
Update DispatchCoreConfig to use ETH type by default instead of WORKER

### DIFF
--- a/tt_metal/api/tt-metalium/dispatch_core_common.hpp
+++ b/tt_metal/api/tt-metalium/dispatch_core_common.hpp
@@ -40,7 +40,7 @@ private:
     static DispatchCoreAxis get_default_axis();
 
 public:
-    DispatchCoreConfig() : type_(DispatchCoreType::WORKER) {}
+    DispatchCoreConfig() : type_(DispatchCoreType::ETH) {}
 
     DispatchCoreConfig(DispatchCoreType type) : type_(type) {}
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/33635

### Problem description
ttnn.open_device() api is defaulting the dispatch core config but to WORKER which makes the user to manually switch to ETH to use all cores

### What's changed
Change the default config

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes