### PR TITLE
[skip ci] Fix GraphQL date type in set-opened-on workflow

### DIFF
--- a/.github/workflows/set-opened-on.yaml
+++ b/.github/workflows/set-opened-on.yaml
@@ -132,7 +132,7 @@ jobs:
 
           # Set the "Opened On" field value
           UPDATE_RESP=$(gh api graphql -f query='
-          mutation($projectId:ID!, $itemId:ID!, $fieldId:ID!, $date:String!){
+          mutation($projectId:ID!, $itemId:ID!, $fieldId:ID!, $date:Date!){
             updateProjectV2ItemFieldValue(input:{
               projectId:$projectId,
               itemId:$itemId,


### PR DESCRIPTION
### Problem
Run 19933637241 failed with:
```
gh: Type mismatch on variable $date and argument date (String! / Date)
```


### Fix

### Verification
Reviewed all GraphQL queries and mutations in the workflow:
- ✅ Pagination limit: `first:100` (already fixed in #33781)
- ✅ Variable passing with `-F` flags
- ✅ All error handling in place

The date value format (YYYY-MM-DD) is already correct, just needed the proper type declaration.