### PR TITLE
ttnn.log calls wrong recip init on Blackhole for float32

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_log.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_log.h
@@ -56,14 +56,12 @@ sfpi_inline sfpi::vFloat calculate_log_body(sfpi::vFloat in, const uint log_base
 
     if constexpr (!FAST_APPROX) {
         sfpi::vInt exp = sfpi::exexp(in);
-        sfpi::vInt man = sfpi::exman9(in);
-        sfpi::vInt signbit = sfpi::reinterpret<sfpi::vInt>(in) & 0x80000000;  // returns 0 for +ve value
-        v_if((exp == 128 && man != 0) || in < 0.0F) {
-            result = std::numeric_limits<float>::quiet_NaN();  // returns nan for fp32 and inf for bf16
-        }
-        v_elseif(sfpi::reinterpret<sfpi::vInt>(in) == 0x7F800000) {
+        v_if(sfpi::reinterpret<sfpi::vInt>(in) == 0x7F800000) {
             // If input is infinity, return infinity
             result = std::numeric_limits<float>::infinity();
+        }
+        v_elseif(exp == 128 || in < 0.f) {                     // +inf or negative input -> NaN
+            result = std::numeric_limits<float>::quiet_NaN();  // returns nan for fp32 and inf for bf16
         }
         v_endif;
     }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_log.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_log.h
@@ -88,22 +88,16 @@ sfpi_inline sfpi::vFloat calculate_log_f32_body(sfpi::vFloat val, const uint log
     sfpi::vInt exp = sfpi::exexp(val);        // Get debiased exponent
     sfpi::vInt man_bits = sfpi::exman9(val);  // Get mantissa bits
 
-    // Check for NaN: exponent = 128 (255 - 127, meaning original exp = 255) and mantissa != 0
-    // Note: exexp returns debiased, so exp == 128 means original exp = 255
-    v_if(exp == 128 && man_bits != 0) {
-        // NaN: exponent = 255 and mantissa != 0
-        result = std::numeric_limits<float>::quiet_NaN();
-    }
-    v_elseif(val < sfpi::vConst0) {
-        // Negative input -> NaN
+    v_if((exp == 128 && man_bits != 0) || val < sfpi::vConst0) {  // If NaN or negative input
         result = std::numeric_limits<float>::quiet_NaN();
     }
     v_elseif(val == sfpi::vConst0) {
         // Zero input -> -inf
         result = -std::numeric_limits<float>::infinity();
     }
-    v_elseif(exp == 128 && man_bits == 0) {
-        // Infinity: exponent = 255 and mantissa = 0
+    v_elseif(exp == 128) {
+        // NaN case already taken care of.
+        // This means that input is infinity (and no need to verify mantissa)
         result = std::numeric_limits<float>::infinity();
     }
     v_else {
@@ -212,8 +206,8 @@ inline void log_init() {
         // _init_sfpu_reciprocal_ sets vConstFloatPrgm0 to 2.0f
         _init_sfpu_reciprocal_</*approximation_mode*/ false>();
         // But we can use 2 other programmable constants:
-        sfpi::vConstFloatPrgm1 = 1.4142135623730951f;  // sqrt(2)
-        sfpi::vConstFloatPrgm2 = 0.6931471805599453f;  // log(2)
+        sfpi::vConstFloatPrgm1 = 1.4142135381698608f;   // sqrt(2)
+        sfpi::vConstFloatPrgm2 = 0.69314718246459961f;  // log(2)
     }
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_log.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_log.h
@@ -11,7 +11,7 @@
 namespace ckernel {
 namespace sfpu {
 
-template <bool FAST_APPROX, bool HAS_BASE_SCALING, bool is_fp32_dest_acc_en = false>
+template <bool FAST_APPROX, bool HAS_BASE_SCALING, bool is_fp32_dest_acc_en>
 sfpi_inline sfpi::vFloat calculate_log_body(sfpi::vFloat in, const uint log_base_scale_factor) {
     ///////////////////////////////////
     // "normalize to calculation range"
@@ -185,7 +185,7 @@ template <
     bool APPROXIMATION_MODE,
     bool FAST_APPROX,
     bool HAS_BASE_SCALING,
-    bool is_fp32_dest_acc_en = false,
+    bool is_fp32_dest_acc_en,
     int ITERATIONS = 8>
 inline void calculate_log(uint log_base_scale_factor) {
 #pragma GCC unroll 8
@@ -194,7 +194,6 @@ inline void calculate_log(uint log_base_scale_factor) {
         sfpi::vFloat result;
         if constexpr (!is_fp32_dest_acc_en) {
             result = calculate_log_body<FAST_APPROX, HAS_BASE_SCALING, is_fp32_dest_acc_en>(in, log_base_scale_factor);
-            // result = sfpi::vConst0;
         } else {
             result = calculate_log_f32_body<HAS_BASE_SCALING>(in, log_base_scale_factor);
         }
@@ -203,16 +202,16 @@ inline void calculate_log(uint log_base_scale_factor) {
     }
 }
 
-template <bool APPROXIMATION_MODE, bool FAST_APPROX, bool is_fp32_dest_acc_en = false>
+template <bool APPROXIMATION_MODE, bool FAST_APPROX, bool is_fp32_dest_acc_en>
 inline void log_init() {
     if constexpr (!is_fp32_dest_acc_en) {
         sfpi::vConstFloatPrgm0 = 0.693147182464599609375;  // ln(2)
         sfpi::vConstFloatPrgm1 = -2.0069785118103027;
         sfpi::vConstFloatPrgm2 = 3.767500400543213;
     } else {
-        // _init_sfpu_reciprocal_ set vConstFloatPrgm0 = 2.0f
+        // _init_sfpu_reciprocal_ sets vConstFloatPrgm0 to 2.0f
         _init_sfpu_reciprocal_</*approximation_mode*/ false>();
-        // But we can use the other 2 programmable constants:
+        // But we can use 2 other programmable constants:
         sfpi::vConstFloatPrgm1 = 1.4142135623730951f;  // sqrt(2)
         sfpi::vConstFloatPrgm2 = 0.6931471805599453f;  // log(2)
     }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_log.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_log.h
@@ -83,7 +83,7 @@ sfpi_inline sfpi::vFloat calculate_log_body(sfpi::vFloat in, const uint log_base
  */
 template <bool HAS_BASE_SCALING>
 sfpi_inline sfpi::vFloat calculate_log_f32_body(sfpi::vFloat val, const uint log_base_scale_factor) {
-    sfpi::vFloat result = sfpi::vConst0;
+    sfpi::vFloat result;
 
     // Check for special cases
     sfpi::vInt exp = sfpi::exexp(val);  // Get debiased exponent
@@ -95,7 +95,7 @@ sfpi_inline sfpi::vFloat calculate_log_f32_body(sfpi::vFloat val, const uint log
     v_elseif(exp == 128 || val < 0.f) {                    // +inf or negative input -> NaN
         result = std::numeric_limits<float>::quiet_NaN();  // returns nan for fp32 and inf for bf16
     }
-    v_elseif(val == sfpi::vConst0) {
+    v_elseif(val == 0.f) {
         // Zero input -> -inf
         result = -std::numeric_limits<float>::infinity();
     }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_log.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_log.h
@@ -61,7 +61,10 @@ sfpi_inline sfpi::vFloat calculate_log_body(sfpi::vFloat in, const uint log_base
         v_if((exp == 128 && man != 0) || in < 0.0F) {
             result = std::numeric_limits<float>::quiet_NaN();  // returns nan for fp32 and inf for bf16
         }
-        v_elseif(signbit == 0 && exp == 128 && man == 0) { result = std::numeric_limits<float>::infinity(); }
+        v_elseif(sfpi::reinterpret<sfpi::vInt>(in) == 0x7F800000) {
+            // If input is infinity, return infinity
+            result = std::numeric_limits<float>::infinity();
+        }
         v_endif;
     }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_log.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_log.h
@@ -83,7 +83,7 @@ sfpi_inline sfpi::vFloat calculate_log_body(sfpi::vFloat in, const uint log_base
  */
 template <bool HAS_BASE_SCALING>
 sfpi_inline sfpi::vFloat calculate_log_f32_body(sfpi::vFloat val, const uint log_base_scale_factor) {
-    sfpi::vFloat result = sfpi::vConst0;
+    sfpi::vFloat result;
 
     // Check for special cases
     sfpi::vInt exp = sfpi::exexp(val);  // Get debiased exponent
@@ -95,7 +95,7 @@ sfpi_inline sfpi::vFloat calculate_log_f32_body(sfpi::vFloat val, const uint log
     v_elseif(exp == 128 || val < 0.f) {                    // +inf or negative input -> NaN
         result = std::numeric_limits<float>::quiet_NaN();  // returns nan for fp32 and inf for bf16
     }
-    v_elseif(val == sfpi::vConst0) {
+    v_elseif(val == 0.0f) {
         // Zero input -> -inf
         result = -std::numeric_limits<float>::infinity();
     }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_log.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_log.h
@@ -56,14 +56,12 @@ sfpi_inline sfpi::vFloat calculate_log_body(sfpi::vFloat in, const uint log_base
 
     if constexpr (!FAST_APPROX) {
         sfpi::vInt exp = sfpi::exexp(in);
-        sfpi::vInt man = sfpi::exman9(in);
-        sfpi::vInt signbit = sfpi::reinterpret<sfpi::vInt>(in) & 0x80000000;  // returns 0 for +ve value
-        v_if((exp == 128 && man != 0) || in < 0.0F) {
-            result = std::numeric_limits<float>::quiet_NaN();  // returns nan for fp32 and inf for bf16
-        }
-        v_elseif(sfpi::reinterpret<sfpi::vInt>(in) == 0x7F800000) {
+        v_if(sfpi::reinterpret<sfpi::vInt>(in) == 0x7F800000) {
             // If input is infinity, return infinity
             result = std::numeric_limits<float>::infinity();
+        }
+        v_elseif(exp == 128 || in < 0.f) {                     // +inf or negative input -> NaN
+            result = std::numeric_limits<float>::quiet_NaN();  // returns nan for fp32 and inf for bf16
         }
         v_endif;
     }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_log.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_log.h
@@ -11,7 +11,7 @@
 namespace ckernel {
 namespace sfpu {
 
-template <bool FAST_APPROX, bool HAS_BASE_SCALING, bool is_fp32_dest_acc_en = false>
+template <bool FAST_APPROX, bool HAS_BASE_SCALING, bool is_fp32_dest_acc_en>
 sfpi_inline sfpi::vFloat calculate_log_body(sfpi::vFloat in, const uint log_base_scale_factor) {
     ///////////////////////////////////
     // "normalize to calculation range"
@@ -188,7 +188,7 @@ template <
     bool APPROXIMATION_MODE,
     bool FAST_APPROX,
     bool HAS_BASE_SCALING,
-    bool is_fp32_dest_acc_en = false,
+    bool is_fp32_dest_acc_en,
     int ITERATIONS = 8>
 inline void calculate_log(uint log_base_scale_factor) {
 #pragma GCC unroll 8
@@ -205,7 +205,7 @@ inline void calculate_log(uint log_base_scale_factor) {
     }
 }
 
-template <bool APPROXIMATION_MODE, bool FAST_APPROX, bool is_fp32_dest_acc_en = false>
+template <bool APPROXIMATION_MODE, bool FAST_APPROX, bool is_fp32_dest_acc_en>
 inline void log_init() {
     if constexpr (!is_fp32_dest_acc_en) {
         sfpi::vConstFloatPrgm0 = 0.693147182464599609375;  // ln(2)

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_log.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_log.h
@@ -86,22 +86,18 @@ sfpi_inline sfpi::vFloat calculate_log_f32_body(sfpi::vFloat val, const uint log
     sfpi::vFloat result = sfpi::vConst0;
 
     // Check for special cases
-    sfpi::vInt exp = sfpi::exexp(val);        // Get debiased exponent
-    sfpi::vInt man_bits = sfpi::exman9(val);  // Get mantissa bits
+    sfpi::vInt exp = sfpi::exexp(val);  // Get debiased exponent
 
-    // Check for NaN: exponent = 128 (255 - 127, meaning original exp = 255) and mantissa != 0
-    // Note: exexp returns debiased, so exp == 128 means original exp = 255
-    v_if((exp == 128 && man_bits != 0) || val < sfpi::vConst0) {  // If NaN or negative input
-        result = std::numeric_limits<float>::quiet_NaN();
+    v_if(sfpi::reinterpret<sfpi::vInt>(val) == 0x7F800000) {
+        // If input is infinity, return infinity
+        result = std::numeric_limits<float>::infinity();
+    }
+    v_elseif(exp == 128 || val < 0.f) {                    // +inf or negative input -> NaN
+        result = std::numeric_limits<float>::quiet_NaN();  // returns nan for fp32 and inf for bf16
     }
     v_elseif(val == sfpi::vConst0) {
         // Zero input -> -inf
         result = -std::numeric_limits<float>::infinity();
-    }
-    v_elseif(exp == 128) {
-        // NaN case already taken care of.
-        // This means that input is infinity (and no need to verify mantissa)
-        result = std::numeric_limits<float>::infinity();
     }
     v_else {
         // Step 1: Extract exponent and mantissa

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_log.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_log.h
@@ -61,7 +61,10 @@ sfpi_inline sfpi::vFloat calculate_log_body(sfpi::vFloat in, const uint log_base
         v_if((exp == 128 && man != 0) || in < 0.0F) {
             result = std::numeric_limits<float>::quiet_NaN();  // returns nan for fp32 and inf for bf16
         }
-        v_elseif(signbit == 0 && exp == 128 && man == 0) { result = std::numeric_limits<float>::infinity(); }
+        v_elseif(sfpi::reinterpret<sfpi::vInt>(in) == 0x7F800000) {
+            // If input is infinity, return infinity
+            result = std::numeric_limits<float>::infinity();
+        }
         v_endif;
     }
 


### PR DESCRIPTION
### Ticket
#33802

### Problem description
#33391 improved accuracy of `ttnn.log` on Wormhole and for bfloat16 on Blackhole. 
The float32 version of `log_tile` relies on reciprocal, which got recently improved. On Blackhole, the init functions changed, but the log implementation on Blackhole did not adjust for this. 

### What's changed
- Log init on Blackhole now calls the correct init function for reciprocal.
- Small optimizations of float32 log on Blackhole (new recip uses fewer programmable constants -> can use them for log). 
- Don't set default value for `is_fp32_acc_dst_en`

Accuracy is now comparable to that of wormhole within 5 ULP of golden result for float32.

#### Performance (Blackhole & float32): 

(main is already calling faster recip, speed-up mainly comes from leveraging programmable registers)

| Type | Name | Cycles/Datum | Cycles/Tiles |
| - | - | - | - |
| bfloat16 | log (main) | 1.60 | 1635 | 
| bfloat16 | log (new) | 1.47 | 1506 |
| float32 | log (main) | 2.97 | 3044 |
| float32 | log (new) | 2.84 | 2653 |


### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes [OK, fabric/unrelated failures](https://github.com/tenstorrent/tt-metal/actions/runs/20029056691)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable) [OK](https://github.com/tenstorrent/tt-metal/actions/runs/20029061770)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable) [OK](https://github.com/tenstorrent/tt-metal/actions/runs/20030299384)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable) [OK](https://github.com/tenstorrent/tt-metal/actions/runs/20030276456)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes