### PR TITLE
#33805: add noc async write barriers to some kernels

### DIFF
--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_writer_tiled_out_1d_mcast_sender_conv_weights_tiled_col_to_rm_blocks.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_writer_tiled_out_1d_mcast_sender_conv_weights_tiled_col_to_rm_blocks.cpp
@@ -338,4 +338,5 @@ void kernel_main() {
             start_reader_idx = reader_idx + static_cast<uint32_t>(packed_reader_indices_ptr[reader_idx] & 0xffff) + 1;
         }
     }  // out_num_blocks_h
+    noc_async_write_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/dataflow/coordinator_single_row_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/dataflow/coordinator_single_row_multi_core.cpp
@@ -103,7 +103,7 @@ void kernel_main() {
 
         // Set signal to start processing
         noc_semaphore_set_multicast(coordinator_to_cores_semaphore_id, semaphore_global_multicast_addr, number_of_dest);
-        noc_async_atomic_barrier();
+        noc_async_write_barrier();
 
         // Calculate sorting stages
         uint32_t stages = 0;
@@ -116,7 +116,7 @@ void kernel_main() {
                 // Set signal to start processing next sub-stage
                 noc_semaphore_set_multicast(
                     coordinator_to_cores_semaphore_id, semaphore_global_multicast_addr, number_of_dest);
-                noc_async_atomic_barrier();
+                noc_async_write_barrier();
 
                 // Wait until cores will process and save data
                 noc_semaphore_wait(semaphore_ptr, number_of_confirmations);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/kernels/reader_bmm_tile_layout_in1_ring_all_gather.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/kernels/reader_bmm_tile_layout_in1_ring_all_gather.cpp
@@ -56,6 +56,7 @@ void do_signaling(uint32_t& rt_args_idx) {
         noc_semaphore_wait(pv_semaphore_ptr, target_sem_value);
         noc_semaphore_set(pv_semaphore_ptr, 1);
         noc_semaphore_set_multicast(pv_semaphore, signalling_semaphore_address, num_signalling_semaphores);
+        noc_async_write_barrier();
     } else {
         const uint64_t sem_addr = get_noc_addr(pv_core_x, pv_core_y, pv_semaphore);
         noc_semaphore_inc(sem_addr, 1);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/kernels/reader_bmm_tile_layout_in1_ring_all_gather.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/kernels/reader_bmm_tile_layout_in1_ring_all_gather.cpp
@@ -56,7 +56,6 @@ void do_signaling(uint32_t& rt_args_idx) {
         noc_semaphore_wait(pv_semaphore_ptr, target_sem_value);
         noc_semaphore_set(pv_semaphore_ptr, 1);
         noc_semaphore_set_multicast(pv_semaphore, signalling_semaphore_address, num_signalling_semaphores);
-        noc_async_write_barrier();
     } else {
         const uint64_t sem_addr = get_noc_addr(pv_core_x, pv_core_y, pv_semaphore);
         noc_semaphore_inc(sem_addr, 1);
@@ -83,6 +82,7 @@ void kernel_main() {
     if (core_type == (uint32_t)CORE_TYPE::IDLE_CORE || core_type == (uint32_t)CORE_TYPE::HOP_CORE) {
         if constexpr (needs_signaler) {
             do_signaling(rt_args_idx);
+            noc_async_write_barrier();
         }
         return;
     }
@@ -194,4 +194,5 @@ void kernel_main() {
     experimental::update_remote_cb_config_in_l1(remote_cb_id);
     noc_async_atomic_barrier();
 #endif
+    noc_async_write_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_ring_all_gather.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_ring_all_gather.cpp
@@ -56,7 +56,6 @@ void do_signaling(uint32_t& rt_args_idx) {
         noc_semaphore_wait(pv_semaphore_ptr, target_sem_value);
         noc_semaphore_set(pv_semaphore_ptr, 1);
         noc_semaphore_set_multicast(pv_semaphore, signalling_semaphore_address, num_signalling_semaphores);
-        noc_async_write_barrier();
     } else {
         const uint64_t sem_addr = get_noc_addr(pv_core_x, pv_core_y, pv_semaphore);
         noc_semaphore_inc(sem_addr, 1);
@@ -83,6 +82,7 @@ void kernel_main() {
     if (core_type == (uint32_t)CORE_TYPE::IDLE_CORE || core_type == (uint32_t)CORE_TYPE::HOP_CORE) {
         if constexpr (needs_signaler) {
             do_signaling(rt_args_idx);
+            noc_async_write_barrier();
         }
         return;
     }
@@ -193,4 +193,5 @@ void kernel_main() {
     experimental::update_remote_cb_config_in_l1(remote_cb_id);
     noc_async_atomic_barrier();
 #endif
+    noc_async_write_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_ring_all_gather.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_ring_all_gather.cpp
@@ -56,6 +56,7 @@ void do_signaling(uint32_t& rt_args_idx) {
         noc_semaphore_wait(pv_semaphore_ptr, target_sem_value);
         noc_semaphore_set(pv_semaphore_ptr, 1);
         noc_semaphore_set_multicast(pv_semaphore, signalling_semaphore_address, num_signalling_semaphores);
+        noc_async_write_barrier();
     } else {
         const uint64_t sem_addr = get_noc_addr(pv_core_x, pv_core_y, pv_semaphore);
         noc_semaphore_inc(sem_addr, 1);

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
@@ -574,4 +574,5 @@ void kernel_main() {
         cb_id_out0,
         batch * out_num_nonzero_subblocks_h * out_num_nonzero_subblocks_w * out_subblock_w * out_subblock_h);
 #endif
+    noc_async_write_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_ln_pre_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_ln_pre_allgather.cpp
@@ -101,6 +101,7 @@ void kernel_main() {
             noc_semaphore_wait(reduce_receiver_semaphore_addr_ptr, num_blocks - 1);
             noc_semaphore_set(reduce_receiver_semaphore_addr_ptr, 0);
             noc_semaphore_set_multicast(reduce_sender_semaphore_addr, reduce_sender_semaphore_noc_addr, num_blocks - 1);
+            noc_async_write_barrier();
         }
 
         // read data from other cores - first stage reduce

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_ln_pre_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_ln_pre_allgather.cpp
@@ -101,7 +101,6 @@ void kernel_main() {
             noc_semaphore_wait(reduce_receiver_semaphore_addr_ptr, num_blocks - 1);
             noc_semaphore_set(reduce_receiver_semaphore_addr_ptr, 0);
             noc_semaphore_set_multicast(reduce_sender_semaphore_addr, reduce_sender_semaphore_noc_addr, num_blocks - 1);
-            noc_async_write_barrier();
         }
 
         // read data from other cores - first stage reduce
@@ -162,4 +161,5 @@ void kernel_main() {
         }
     };
     global_reduce_sender(cb_ex_partial2, cb_ex_external2, cb_ex2);
+    noc_async_write_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/reader_argmax_interleaved_multicore.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/reader_argmax_interleaved_multicore.cpp
@@ -364,7 +364,7 @@ void kernel_main() {
                     noc_semaphore_set_multicast(start_sem_local_addr, start_sem_noc_addr1, num_cores1);
                 }
 
-                noc_async_atomic_barrier();
+                noc_async_write_barrier();
             }
         }
 

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/reader_final_topk.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/reader_final_topk.cpp
@@ -42,10 +42,10 @@ void kernel_main() {
 
         // Update the multicast address for the receiver semaphore, to allow the senders to write
         noc_semaphore_set_multicast(receiver_semaphore, mcast_receiver_semaphore_noc_addr, num_dests);
-        noc_async_write_barrier();
         noc_semaphore_wait(sender_semaphore_addr, Wt_final);
 
         cb_push_back(final_values_cb_index, Wt_final);
         cb_push_back(final_indices_cb_index, Wt_final);
     }
+    noc_async_write_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/reader_final_topk.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/reader_final_topk.cpp
@@ -42,6 +42,7 @@ void kernel_main() {
 
         // Update the multicast address for the receiver semaphore, to allow the senders to write
         noc_semaphore_set_multicast(receiver_semaphore, mcast_receiver_semaphore_noc_addr, num_dests);
+        noc_async_write_barrier();
         noc_semaphore_wait(sender_semaphore_addr, Wt_final);
 
         cb_push_back(final_values_cb_index, Wt_final);


### PR DESCRIPTION
### Ticket
Link to Github Issue #33805

### Problem description
Some kernels had atomic instead of write barriers and others were missing write barriers after noc semaphore set multicast calls (which are regular writes).

### What's changed
- replace atomic with write barriers where appropriate
- add write barriers at the end of kernels otherwise

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/19937161938
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes