### PR TITLE
Modified galaxy CI tests to account for torus links

### DIFF
--- a/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/galaxy/all_post_commit/test_all_gather_apc.py
+++ b/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/galaxy/all_post_commit/test_all_gather_apc.py
@@ -242,7 +242,7 @@ def test_all_gather_4D_line(
 @pytest.mark.parametrize("chunks_per_sync", [20])
 @pytest.mark.parametrize("num_workers_per_link", [2])
 @pytest.mark.parametrize("num_buffers_per_channel", [2])
-def test_all_gather_everything_RING(
+def test_all_gather_everything_ring(
     bh_2d_mesh_device,
     num_devices,
     ag_output_shape,

--- a/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/galaxy/all_post_commit/test_all_gather_apc.py
+++ b/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/galaxy/all_post_commit/test_all_gather_apc.py
@@ -235,14 +235,14 @@ def test_all_gather_4D_line(
 @pytest.mark.parametrize(
     "device_params, all_gather_topology",
     [
-        ({"fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 90112}, ttnn.Topology.Linear),
+        ({"fabric_config": ttnn.FabricConfig.FABRIC_1D_RING, "trace_region_size": 90112}, ttnn.Topology.Ring),
     ],
     indirect=["device_params"],
 )
 @pytest.mark.parametrize("chunks_per_sync", [20])
 @pytest.mark.parametrize("num_workers_per_link", [2])
 @pytest.mark.parametrize("num_buffers_per_channel", [2])
-def test_all_gather_8D(
+def test_all_gather_everything_RING(
     bh_2d_mesh_device,
     num_devices,
     ag_output_shape,

--- a/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/galaxy/all_post_commit/test_all_to_all_combine_bh.py
+++ b/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/galaxy/all_post_commit/test_all_to_all_combine_bh.py
@@ -152,8 +152,6 @@ def test_all_to_all_combine_no_trace(
     dtype,
     test_skew,
 ):
-    if topology == ttnn.Topology.Ring:
-        pytest.skip("Galaxy is currently mesh only")
     devices = mesh_shape[0] * mesh_shape[1]
     batch = batches_per_device * devices
     experts = experts_per_device * devices

--- a/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/galaxy/all_post_commit/test_reduce_scatter_apc.py
+++ b/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/galaxy/all_post_commit/test_reduce_scatter_apc.py
@@ -255,13 +255,10 @@ def test_rs_row_nightly_ring(
     num_workers_per_link,
     num_buffers_per_channel,
 ):
-    pytest.skip("Galaxy is currently mesh only")
-
     if cluster_axis == 0:
         submesh_device = bh_2d_mesh_device.create_submesh(ttnn.MeshShape((num_devices, 1)))
     else:
         submesh_device = bh_2d_mesh_device.create_submesh(ttnn.MeshShape((1, num_devices)))
-    cluster_axis = 0
     run_reduce_scatter_impl(
         submesh_device,
         num_devices,

--- a/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/galaxy/nightly/test_all_gather_nightly.py
+++ b/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/galaxy/nightly/test_all_gather_nightly.py
@@ -288,7 +288,6 @@ def test_all_gather_ring_nightly(
     num_buffers_per_channel,
     cluster_axis,
 ):
-    pytest.skip("Galaxy is currently mesh only")
     num_devices = bh_2d_mesh_device.shape[cluster_axis]
     if cluster_axis == 0:
         submesh_device = bh_2d_mesh_device.create_submesh(ttnn.MeshShape((num_devices, 1)))

--- a/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/galaxy/nightly/test_all_to_all_combine_bh.py
+++ b/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/galaxy/nightly/test_all_to_all_combine_bh.py
@@ -139,8 +139,6 @@ def test_all_to_all_combine_no_trace(
     dtype,
     test_skew,
 ):
-    if topology == ttnn.Topology.Ring:
-        pytest.skip("Galaxy is currently mesh only")
     devices = mesh_shape[0] * mesh_shape[1]
     batch = batches_per_device * devices
     experts = experts_per_device * devices

--- a/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/galaxy/nightly/test_minimal_reduce_scatter_async_bh.py
+++ b/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/galaxy/nightly/test_minimal_reduce_scatter_async_bh.py
@@ -41,8 +41,6 @@ def run_reduce_scatter_impl(
     num_workers_per_link=None,
     num_buffers_per_channel=None,
 ):
-    if rs_topology == ttnn.Topology.Ring:
-        pytest.skip("Galaxy is currently mesh only")
     torch.manual_seed(0)
 
     # Set the default config
@@ -525,13 +523,9 @@ def test_reduce_scatter_async_sharded_to_sharded(
     ones_tensor,
     rs_topology,
 ):
-    if rs_topology == ttnn.Topology.Ring:
-        pytest.skip("Galaxy is currently mesh only")
     adjusted_intermediate_shard_shape = intermediate_shard_shape[:]
     if rs_topology == ttnn.Topology.Linear:
         adjusted_intermediate_shard_shape[0] *= 2
-    else:
-        pytest.skip("Galaxy is currently mesh only")
     input_shard_spec = ttnn.ShardSpec(
         input_shard_grid,
         input_shard_shape,
@@ -650,8 +644,6 @@ def test_reduce_scatter_async_interleaved_to_sharded(
     ones_tensor,
     rs_topology,
 ):
-    if rs_topology == ttnn.Topology.Ring:
-        pytest.skip("Galaxy is currently mesh only")
     adjusted_intermediate_shard_shape = intermediate_shard_shape[:]
     if rs_topology == ttnn.Topology.Linear:
         adjusted_intermediate_shard_shape[0] *= 2
@@ -758,8 +750,6 @@ def test_reduce_scatter_async_sharded_to_interleaved(
     ones_tensor,
     rs_topology,
 ):
-    if rs_topology == ttnn.Topology.Ring:
-        pytest.skip("Galaxy is currently mesh only")
     input_shard_spec = ttnn.ShardSpec(
         input_shard_grid,
         input_shard_shape,
@@ -787,4 +777,112 @@ def test_reduce_scatter_async_sharded_to_interleaved(
         num_iters=num_iters,
         ones_tensor=ones_tensor,
         mem_config_intermediate=mem_config_intermediate,
+    )
+
+
+@skip_for_wormhole_b0()
+@skip_for_n_or_less_dev(1)
+@pytest.mark.parametrize("num_links", [1], ids=["1link"])
+@pytest.mark.parametrize(
+    "num_devices,cluster_axis, rs_input_shape, dim, layout, rs_input_dtype",
+    [
+        (4, 1, [1, 1, 13, 512], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),  # use batching when fused
+        (4, 1, [3, 1, 41, 512], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),  # use batching when fused
+        (4, 1, [8, 1, 512, 2560], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),  # use batching when fused
+        (4, 1, [4, 1, 1024, 2560], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),  # use batching when fused
+        (4, 1, [1, 1, 1024, 2560], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),  # use batching when fused
+        (4, 1, [1, 1, 352, 2560], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),  # use batching when fused
+        (4, 1, [2, 1, 2048, 2560], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),  # use batching when fused
+        (4, 1, [1, 1, 4096, 2560], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),  # use batching when fused
+        # Composite-RS tests
+        (4, 1, [1, 1, 1, 8], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16),
+        (4, 1, [1, 1, 1, 16], 3, ttnn.TILE_LAYOUT, ttnn.bfloat8_b),
+        (4, 1, [1, 1, 32, 32], 3, ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16),
+    ],
+    ids=[
+        "padded_dim_2_test_one",
+        "padded_dim_2_test_two",
+        "batch_8",
+        "batch_4",
+        "batch_1_sd35_spatial",
+        "batch_1_sd35_prompt",
+        "batch_2",
+        "batch_1",
+        "composite_rs_test_one",
+        "composite_rs_test_two",
+        "composite_rs_test_three",
+    ],
+)
+@pytest.mark.parametrize(
+    "mem_config_input, mem_config_rs",
+    [
+        (
+            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM),
+            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM),
+        )
+    ],
+)
+@pytest.mark.parametrize(
+    "enable_trace, num_iters",
+    [
+        (False, 1),
+        (True, 10),
+    ],
+)
+@pytest.mark.parametrize(
+    "ones_tensor",
+    [
+        False,
+    ],
+    ids=["random"],
+)
+@pytest.mark.parametrize(
+    "use_barrier, use_persistent_buffers",
+    [
+        (True, False),
+    ],
+    ids=["barrier_without_persistent_buffers"],
+)
+@pytest.mark.parametrize(
+    "device_params, rs_topology",
+    [
+        ({"fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 1171456}, ttnn.Topology.Linear),
+    ],
+    indirect=["device_params"],
+)
+def test_reduce_scatter_async_ring(
+    bh_2d_mesh_device,
+    num_devices,
+    num_links,
+    rs_input_shape,
+    dim,
+    layout,
+    rs_input_dtype,
+    mem_config_input,
+    mem_config_rs,
+    enable_trace,
+    num_iters,
+    ones_tensor,
+    use_barrier,
+    use_persistent_buffers,
+    cluster_axis,
+    rs_topology,
+):
+    run_reduce_scatter_impl(
+        bh_2d_mesh_device,
+        num_devices,
+        rs_input_shape,
+        dim,
+        num_links,
+        rs_input_dtype,
+        layout,
+        mem_config_input,
+        mem_config_rs,
+        rs_topology=rs_topology,
+        enable_trace=enable_trace,
+        num_iters=num_iters,
+        ones_tensor=ones_tensor,
+        use_barrier=use_barrier,
+        cluster_axis=cluster_axis,
+        use_persistent_buffers=use_persistent_buffers,
     )


### PR DESCRIPTION
https://github.com/tenstorrent/tt-metal/issues/33821


In this PR we add coverage on the BH Galaxy APC and Nightly Tests as we now have wraparound links available.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/19942358513
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) https://github.com/tenstorrent/tt-metal/actions/runs/19942383516
- [ ] Blackhole Nightly https://github.com/tenstorrent/tt-metal/actions/runs/19942417955