### PR TITLE
[skip ci] Speed up MultiProducerCommandQueueTest

### DIFF
--- a/tests/ttnn/unit_tests/gtests/test_multiprod_queue.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_multiprod_queue.cpp
@@ -44,7 +44,7 @@ TEST_F(MultiProducerCommandQueueTest, Stress) {
     // Test thread safety.
     auto* device = this->device_;
 
-    const ttnn::Shape tensor_shape{1, 1, 1024, 1024};
+    const ttnn::Shape tensor_shape{1, 1, 256, 256};
     const MemoryConfig mem_cfg = MemoryConfig{tt::tt_metal::TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
     const TensorLayout tensor_layout(DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), mem_cfg);
     const TensorSpec tensor_spec(tensor_shape, tensor_layout);
@@ -61,12 +61,12 @@ TEST_F(MultiProducerCommandQueueTest, Stress) {
     const Tensor t0_host_tensor = Tensor::from_vector(t0_host_data, tensor_spec);
     const Tensor t1_host_tensor = Tensor::from_vector(t1_host_data, tensor_spec);
 
-    constexpr int kNumIterations = 100;
+    constexpr int kNumIterations = 25;
     std::thread t0([&]() {
         for (int j = 0; j < kNumIterations; j++) {
             Tensor t0_tensor = t0_host_tensor.to_device(device, mem_cfg, t0_io_cq);
             EXPECT_TRUE(is_device_tensor(t0_tensor));
-            EXPECT_THAT(t0_tensor.to_vector<float>(t0_io_cq), Pointwise(FloatEq(), t0_host_data));
+            EXPECT_EQ(t0_tensor.to_vector<float>(t0_io_cq), t0_host_data);
         }
     });
 
@@ -74,7 +74,7 @@ TEST_F(MultiProducerCommandQueueTest, Stress) {
         for (int j = 0; j < kNumIterations; j++) {
             Tensor t1_tensor = t1_host_tensor.to_device(device, mem_cfg, t1_io_cq);
             EXPECT_TRUE(is_device_tensor(t1_tensor));
-            EXPECT_THAT(t1_tensor.to_vector<float>(t1_io_cq), Pointwise(FloatEq(), t1_host_data));
+            EXPECT_EQ(t1_tensor.to_vector<float>(t1_io_cq), t1_host_data);
         }
     });
 

--- a/tests/ttnn/unit_tests/gtests/test_multiprod_queue.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_multiprod_queue.cpp
@@ -32,7 +32,6 @@ namespace tt::tt_metal {
 namespace {
 
 using ::testing::Eq;
-using ::testing::FloatEq;
 using ::testing::Pointwise;
 using ::tt::tt_metal::is_device_tensor;
 


### PR DESCRIPTION
### Ticket
NA

### Problem description
The MultiProducerCommandQueueTest.Stress test was taking ~2.5 minutes (150 seconds) to run on a N300 AND a T3K machine. This test validates thread safety of multi-producer command queue access, but the excessive runtime was caused by unnecessarily large data transfers and expensive per-element floating-point comparisons using gmock matchers.

### What's changed
Optimized the stress test parameters while preserving its thread-safety validation purpose:
- Reduced tensor size from 1024×1024 to 256×256 — The test validates concurrent queue access, not data throughput. Smaller tensors still exercise the same thread-safety code paths while reducing data transfer overhead from 4MB to 256KB per iteration.
- Reduced iterations from 100 to 25 — 25 iterations per thread (50 total concurrent operations) is sufficient to stress test thread safety without excessive repetition.
- Replaced Pointwise(FloatEq(), ...) with EXPECT_EQ — Since the test performs raw memory copies (host → device → host) with no arithmetic, exact equality is expected. EXPECT_EQ on vectors uses optimized comparison, whereas Pointwise(FloatEq()) creates a gmock matcher object for each element and performs individual floating-point approximate comparisons.
#### Impact
Test runtime reduced from ~150 seconds to ~3.4 seconds (44× faster) while maintaining full data verification on every iteration.

### Checklist
This test is only ran in PR Gate / Merge Gate.