### PR TITLE
Add triage test that firmware is of the expected type

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_pgm_dispatch.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_pgm_dispatch.cpp
@@ -741,6 +741,7 @@ static int pgm_dispatch(T& state, TestInfo info) {
         // Run benchmark timing loop
         run_benchmark_timing_loop(state, info, mesh_cq, executor, tid, mesh_device);
 
+        sleep(10000);
         pass &= mesh_device->close();
     } catch (const std::exception& e) {
         pass = false;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_pgm_dispatch.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_pgm_dispatch.cpp
@@ -741,7 +741,6 @@ static int pgm_dispatch(T& state, TestInfo info) {
         // Run benchmark timing loop
         run_benchmark_timing_loop(state, info, mesh_cq, executor, tid, mesh_device);
 
-        sleep(10000);
         pass &= mesh_device->close();
     } catch (const std::exception& e) {
         pass = false;

--- a/tools/tests/triage/test_triage.py
+++ b/tools/tests/triage/test_triage.py
@@ -221,7 +221,7 @@ class TestTriage:
         global FAILURE_CHECKS
 
         FAILURE_CHECKS.clear()
-        result = run_script(
+        run_script(
             script_path=os.path.join(triage_home, "check_core_magic.py"),
             args=None,
             context=self.exalens_context,

--- a/tools/tests/triage/test_triage.py
+++ b/tools/tests/triage/test_triage.py
@@ -215,3 +215,19 @@ class TestTriage:
             assert (
                 timedelta(seconds=0) < check.result.uptime < timedelta(days=8 * 365)
             ), f"Invalid ARC uptime: {check.result.uptime}"
+
+    def test_check_core_magic(self):
+        global triage_home
+        global FAILURE_CHECKS
+
+        FAILURE_CHECKS.clear()
+        result = run_script(
+            script_path=os.path.join(triage_home, "check_core_magic.py"),
+            args=None,
+            context=self.exalens_context,
+            argv=[],
+            return_result=True,
+        )
+        assert (
+            len(FAILURE_CHECKS) == 0
+        ), f"Core magic check failed with {len(FAILURE_CHECKS)} failures: {FAILURE_CHECKS}"

--- a/tools/triage/check_core_magic.py
+++ b/tools/triage/check_core_magic.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Usage:
+    check_core_magic.py
+
+Description:
+    This script checks if the core_magic_number in each core's mailbox matches
+    the expected firmware type for that location. If there's a mismatch, it
+    attempts to read the mailbox using other firmware types to identify what
+    firmware is actually present.
+"""
+
+from ttexalens.context import Context
+from ttexalens.coordinate import OnChipCoordinate
+from ttexalens.elf import MemoryAccess
+from dispatcher_data import run as get_dispatcher_data, DispatcherData
+from elfs_cache import run as get_elfs_cache, ElfsCache
+from run_checks import run as get_run_checks
+from triage import ScriptConfig, log_check_location, run_script
+
+script_config = ScriptConfig(
+    depends=["run_checks", "dispatcher_data", "elfs_cache"],
+)
+
+
+class CoreMagicValues:
+    """
+    Holds the magic values read from firmware ELF.
+    Values are read once and cached for reuse.
+    """
+
+    def __init__(self, fw_elf):
+        # Read CoreMagicNumber enum values from firmware
+        self.worker = fw_elf.enumerators["CoreMagicNumber::WORKER"].value
+        self.active_eth = fw_elf.enumerators["CoreMagicNumber::ACTIVE_ETH"].value
+        self.idle_eth = fw_elf.enumerators["CoreMagicNumber::IDLE_ETH"].value
+
+        self.magic_to_name = {
+            self.worker: "WORKER",
+            self.active_eth: "ACTIVE_ETH",
+            self.idle_eth: "IDLE_ETH",
+        }
+
+    def get_name(self, magic_value: int) -> str | None:
+        return self.magic_to_name.get(magic_value, None)
+
+
+def get_expected_magic_for_location(location: OnChipCoordinate, magic_values: CoreMagicValues) -> tuple[int, str]:
+    """
+    Determine the expected magic number based on location type.
+    Returns (magic_value, type_name).
+    """
+    block_type = location.device.get_block_type(location)
+    if block_type == "functional_workers":
+        return magic_values.worker, "WORKER"
+    elif location in location.device.idle_eth_block_locations:
+        return magic_values.idle_eth, "IDLE_ETH"
+    elif location in location.device.active_eth_block_locations:
+        return magic_values.active_eth, "ACTIVE_ETH"
+    else:
+        # Default to worker for unknown types
+        return magic_values.worker, "WORKER"
+
+
+def try_read_magic_with_elf(
+    location: OnChipCoordinate,
+    risc_name: str,
+    fw_elf,
+    elfs_cache: ElfsCache,
+) -> int | None:
+    """
+    Attempt to read core_magic_number using the given firmware ELF.
+    Returns the magic value or None if reading fails.
+    """
+    try:
+        loc_mem_access = MemoryAccess.get(location.noc_block.get_risc_debug(risc_name))
+        mailboxes = fw_elf.read_global("mailboxes", loc_mem_access)
+        return mailboxes.core_info.core_magic_number
+    except Exception:
+        return None
+
+
+def check_core_magic(
+    location: OnChipCoordinate,
+    risc_name: str,
+    dispatcher_data: DispatcherData,
+    elfs_cache: ElfsCache,
+    magic_values: CoreMagicValues,
+):
+    """
+    Check if the core_magic_number matches the expected firmware type.
+    If mismatch, try other firmware types to identify what's actually present.
+    """
+    expected_magic, expected_type = get_expected_magic_for_location(location, magic_values)
+
+    # Get the firmware ELF for the expected type
+    try:
+        fw_elf_path = dispatcher_data.get_core_data(location, risc_name).firmware_path
+        fw_elf = elfs_cache[fw_elf_path]
+    except Exception as e:
+        log_check_location(
+            location,
+            False,
+            f"{risc_name}: Failed to get firmware ELF: {e}",
+        )
+        return
+
+    # Read the magic number from the expected mailbox location
+    actual_magic = try_read_magic_with_elf(location, risc_name, fw_elf, elfs_cache)
+
+    if actual_magic is None:
+        log_check_location(
+            location,
+            False,
+            f"{risc_name}: Failed to read core_magic_number from mailbox",
+        )
+        return
+
+    # Check if magic matches expected
+    if actual_magic == expected_magic:
+        log_check_location(
+            location,
+            True,
+            f"{risc_name}: core_magic_number OK ({expected_type})",
+        )
+        return
+
+    # Mismatch detected - try to identify what firmware type is actually present
+    actual_type_name = magic_values.get_name(actual_magic)
+
+    if actual_type_name:
+        # The magic at the expected location matches a different known type
+        log_check_location(
+            location,
+            False,
+            f"{risc_name}: core_magic_number mismatch! Expected {expected_type} (0x{expected_magic:08X}), "
+            f"found {actual_type_name} (0x{actual_magic:08X}) at expected location",
+        )
+        return
+
+    # Unknown magic at expected location - try other firmware ELFs to find a match
+    other_elfs_to_try = []
+
+    # Add the firmware ELFs we haven't tried yet
+    if expected_type != "WORKER":
+        other_elfs_to_try.append(("WORKER", dispatcher_data._brisc_elf))
+    if expected_type != "IDLE_ETH":
+        other_elfs_to_try.append(("IDLE_ETH", dispatcher_data._idle_erisc_elf))
+    if expected_type != "ACTIVE_ETH":
+        other_elfs_to_try.append(("ACTIVE_ETH", dispatcher_data._active_erisc_elf))
+
+    found_type = None
+    for type_name, other_elf in other_elfs_to_try:
+        other_magic = try_read_magic_with_elf(location, risc_name, other_elf, elfs_cache)
+        if other_magic is not None:
+            other_type_name = magic_values.get_name(other_magic)
+            if other_type_name == type_name:
+                found_type = type_name
+                break
+
+    if found_type:
+        log_check_location(
+            location,
+            False,
+            f"{risc_name}: core_magic_number mismatch! Expected {expected_type} (0x{expected_magic:08X}), "
+            f"but found {found_type} firmware at {found_type} mailbox location. "
+            f"Value at expected location: 0x{actual_magic:08X}",
+        )
+    else:
+        log_check_location(
+            location,
+            False,
+            f"{risc_name}: core_magic_number mismatch! Expected {expected_type} (0x{expected_magic:08X}), "
+            f"found unknown value 0x{actual_magic:08X}. Could not identify firmware type at other locations.",
+        )
+
+
+def run(args, context: Context):
+    BLOCK_TYPES_TO_CHECK = ["tensix", "idle_eth", "active_eth"]
+    # Only check one RISC per core since magic is core-wide, not per-RISC
+    # Use brisc for tensix, erisc/erisc0 for eth
+    RISC_CORES_TO_CHECK = ["brisc", "erisc", "erisc0"]
+
+    dispatcher_data = get_dispatcher_data(args, context)
+    elfs_cache = get_elfs_cache(args, context)
+    run_checks = get_run_checks(args, context)
+
+    # Read magic values from firmware (identical across all firmware types)
+    magic_values = CoreMagicValues(dispatcher_data._brisc_elf)
+
+    run_checks.run_per_core_check(
+        lambda location, risc_name: check_core_magic(
+            location, risc_name, dispatcher_data, elfs_cache, magic_values
+        ),
+        block_filter=BLOCK_TYPES_TO_CHECK,
+        core_filter=RISC_CORES_TO_CHECK,
+    )
+
+
+if __name__ == "__main__":
+    run_script()
+

--- a/tools/triage/check_core_magic.py
+++ b/tools/triage/check_core_magic.py
@@ -79,7 +79,7 @@ def try_read_magic_with_elf(
     try:
         loc_mem_access = MemoryAccess.get(location.noc_block.get_risc_debug(risc_name))
         mailboxes = fw_elf.read_global("mailboxes", loc_mem_access)
-        return  int.from_bytes(mailboxes.core_info.core_magic_number.read_bytes(), byteorder="little")
+        return int.from_bytes(mailboxes.core_info.core_magic_number.read_bytes(), byteorder="little")
     except Exception as e:
         return None
 
@@ -180,9 +180,7 @@ def run(args, context: Context):
     magic_values = CoreMagicValues(dispatcher_data._brisc_elf)
 
     run_checks.run_per_core_check(
-        lambda location, risc_name: check_core_magic(
-            location, risc_name, dispatcher_data, elfs_cache, magic_values
-        ),
+        lambda location, risc_name: check_core_magic(location, risc_name, dispatcher_data, elfs_cache, magic_values),
         block_filter=BLOCK_TYPES_TO_CHECK,
         core_filter=RISC_CORES_TO_CHECK,
     )
@@ -190,4 +188,3 @@ def run(args, context: Context):
 
 if __name__ == "__main__":
     run_script()
-

--- a/tools/triage/check_core_magic.py
+++ b/tools/triage/check_core_magic.py
@@ -129,19 +129,6 @@ def check_core_magic(
         )
         return
 
-    # Mismatch detected - try to identify what firmware type is actually present
-    actual_type_name = magic_values.get_name(actual_magic)
-
-    if actual_type_name:
-        # The magic at the expected location matches a different known type
-        log_check_location(
-            location,
-            False,
-            f"{risc_name}: core_magic_number mismatch! Expected {expected_type} (0x{expected_magic:08X}), "
-            f"found {actual_type_name} (0x{actual_magic:08X}) at expected location",
-        )
-        return
-
     # Unknown magic at expected location - try other firmware ELFs to find a match
     other_elfs_to_try = []
 

--- a/tools/triage/check_core_magic.py
+++ b/tools/triage/check_core_magic.py
@@ -106,17 +106,17 @@ def check_core_magic(
         fw_elf_path = dispatcher_data.get_core_data(location, risc_name).firmware_path
         fw_elf = elfs_cache[fw_elf_path]
     except Exception as e:
+        log_check_location(
+            location,
+            False,
+            f"{risc_name}: Failed to get firmware ELF: {e}",
+        )
         return
 
     # Read the magic number from the expected mailbox location
     actual_magic = try_read_magic_with_elf(location, risc_name, fw_elf)
 
     if actual_magic is None:
-        log_check_location(
-            location,
-            False,
-            f"{risc_name}: Failed to read core_magic_number from mailbox",
-        )
         return
 
     # Check if magic matches expected

--- a/tools/triage/check_core_magic.py
+++ b/tools/triage/check_core_magic.py
@@ -79,8 +79,8 @@ def try_read_magic_with_elf(
     try:
         loc_mem_access = MemoryAccess.get(location.noc_block.get_risc_debug(risc_name))
         mailboxes = fw_elf.read_global("mailboxes", loc_mem_access)
-        return mailboxes.core_info.core_magic_number
-    except Exception:
+        return  int.from_bytes(mailboxes.core_info.core_magic_number.read_bytes(), byteorder="little")
+    except Exception as e:
         return None
 
 

--- a/tools/triage/check_core_magic.py
+++ b/tools/triage/check_core_magic.py
@@ -80,6 +80,11 @@ def try_read_magic_with_elf(
         mailboxes = fw_elf.get_global("mailboxes", loc_mem_access)
         return int.from_bytes(mailboxes.core_info.core_magic_number.read_bytes(), byteorder="little")
     except Exception as e:
+        log_check_location(
+            location,
+            False,
+            f"{risc_name}: Failed to read core_magic_number from mailbox: {e}",
+        )
         return None
 
 
@@ -101,11 +106,6 @@ def check_core_magic(
         fw_elf_path = dispatcher_data.get_core_data(location, risc_name).firmware_path
         fw_elf = elfs_cache[fw_elf_path]
     except Exception as e:
-        log_check_location(
-            location,
-            False,
-            f"{risc_name}: Failed to get firmware ELF: {e}",
-        )
         return
 
     # Read the magic number from the expected mailbox location

--- a/tools/triage/check_core_magic.py
+++ b/tools/triage/check_core_magic.py
@@ -77,8 +77,7 @@ def try_read_magic_with_elf(
     """
     try:
         loc_mem_access = MemoryAccess.get(location.noc_block.get_risc_debug(risc_name))
-        mailboxes = fw_elf.get_global("mailboxes", loc_mem_access)
-        return int.from_bytes(mailboxes.core_info.core_magic_number.read_bytes(), byteorder="little")
+        return fw_elf.get_global("mailboxes", loc_mem_access).core_info.core_magic_number.read_value()
     except Exception as e:
         log_check_location(
             location,

--- a/tt_metal/hw/inc/dev_msgs.h
+++ b/tt_metal/hw/inc/dev_msgs.h
@@ -352,6 +352,12 @@ constexpr std::uint32_t MAX_VIRTUAL_NON_WORKER_CORES = 29;
 constexpr std::uint32_t MAX_PHYSICAL_NON_WORKER_CORES = 35;
 constexpr std::uint32_t MAX_HARVESTED_ON_AXIS = 2;
 constexpr std::uint8_t CORE_COORD_INVALID = 0xFF;
+
+enum class CoreMagicNumber : uint32_t {
+    WORKER = 0x50ec09a3,
+    ACTIVE_ETH = 0xc63050d1,
+    IDLE_ETH = 0x837b6cae,
+};
 struct core_info_msg_t {
     volatile uint64_t noc_pcie_addr_base;
     volatile uint64_t noc_pcie_addr_end;
@@ -368,6 +374,7 @@ struct core_info_msg_t {
     volatile uint8_t absolute_logical_x;  // Logical X coordinate of this core
     volatile uint8_t absolute_logical_y;  // Logical Y coordinate of this core
     volatile uint32_t l1_unreserved_start;
+    volatile CoreMagicNumber core_magic_number;
     uint8_t pad;  // CODEGEN:skip
 };
 
@@ -375,6 +382,7 @@ constexpr uint32_t launch_msg_buffer_num_entries = 8;
 // Equal to the maximum number of subdevices + 1. This allows all workers that aren't assigned to a subdevice to receive
 // a dummy entry.
 constexpr uint32_t go_message_num_entries = 9;
+
 struct mailboxes_t {
     struct ncrisc_halt_msg_t ncrisc_halt;
     struct subordinate_sync_msg_t subordinate_sync;

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -1237,7 +1237,11 @@ dev_msgs::core_info_msg_t MetalContext::populate_core_info_msg(
     core_info.noc_dram_addr_base() = 0;
     core_info.noc_dram_addr_end() = soc_d.dram_core_size;
     core_info.l1_unreserved_start() = align(worker_l1_unreserved_start_, hal_->get_alignment(HalMemType::DRAM));
-
+    core_info.core_magic_number() = programmable_core_type == HalProgrammableCoreType::TENSIX
+                                        ? dev_msgs::CoreMagicNumber::WORKER
+                                        : (programmable_core_type == HalProgrammableCoreType::ACTIVE_ETH
+                                               ? dev_msgs::CoreMagicNumber::ACTIVE_ETH
+                                               : dev_msgs::CoreMagicNumber::IDLE_ETH);
     const std::vector<tt::umd::CoreCoord>& pcie_cores = soc_d.get_cores(CoreType::PCIE, CoordSystem::NOC0);
     // There are multiple NoC endpoints for DRAM, but not all are exposed through the API. Watcher will flag endpoints
     // that are not exposed as invalid transactions. This helps to avoid BH issue highlighted by SYS-592 where writing


### PR DESCRIPTION
### Problem description
Currently it's possible that triage has bad assumptions about what type of firmware is running on a core, which can cause it to retrieve mailbox values from the wrong location and get garbage.

### What's changed
Add a magic value to the core info in the mailbox; that magic value will be different between workers, active ethernet, and idle ethernet. Then a check_core_magic.py script can validate that the firmware is the expected type, or it can attempt to determine what firmware might possibly be running there.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes