### PR TITLE
Ncvetkovic/config consolidation

### DIFF
--- a/tests/tt_metal/tt_metal/test_kernels/compute/3T/matmul_large_block_zm/zm_3m_math.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/3T/matmul_large_block_zm/zm_3m_math.cpp
@@ -75,7 +75,7 @@ void math_main() {
     constexpr bool spill = num_blocks > 1U;
     bool enable_reload = false;
 
-    llk_math_hw_configure_disaggregated(0, 1);
+    llk_math_hw_configure(0, 1);
 
     for (uint32_t block = 0U; block < num_blocks; block++) {
         bool last_out = block == num_blocks - 1U;
@@ -93,6 +93,7 @@ void math_main() {
                         llk_math_eltwise_unary_datacopy<A2D, DST_ACCUM_MODE, BroadcastType::NONE>(i);
                     }
                 }
+                // NC: This doesn't have a second runtime param?
                 llk_math_matmul_init<MATH_FIDELITY>(0);
 
                 int dst_index = 0;

--- a/tests/tt_metal/tt_metal/test_kernels/compute/3T/matmul_large_block_zm/zm_3m_pack.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/3T/matmul_large_block_zm/zm_3m_pack.cpp
@@ -91,9 +91,9 @@ inline void pack_block(
 void pack_main() {
     uint32_t in0_block_w = get_compile_time_arg_val(0);
     llk_pack_init();
-    llk_pack_dest_init<DST_ACCUM_MODE, false>();
-    llk_init_packer_dest_offset_registers<DstTileFaceLayout::RowMajor, false>();
-    llk_pack_hw_configure_disaggregated<DST_ACCUM_MODE, false>(16);
+    llk_pack_dest_init<DST_ACCUM_MODE>();
+    llk_init_packer_dest_offset_registers<false>();
+    llk_pack_hw_configure<DST_ACCUM_MODE>(16);
     // inner block size in tiles
     uint32_t in0_num_subblocks = get_compile_time_arg_val(1);
     // outer row block size (in inner row blocks)

--- a/tests/tt_metal/tt_metal/test_kernels/compute/3T/matmul_large_block_zm/zm_3m_unpack.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/3T/matmul_large_block_zm/zm_3m_unpack.cpp
@@ -160,7 +160,7 @@ void unpack_main() {
         matmul_out_intermediate_cb_id = 25;  // Given 24 is no longer available, we use 25 instead
     }
 
-    llk_unpack_AB_matmul_hw_configure_disaggregated(0, 1, 0);
+    llk_unpack_hw_configure(0, 1, 0);
 
     uint32_t reblock_cb_id = 26;
 

--- a/tests/tt_metal/tt_metal/test_kernels/compute/3T/matmul_large_block_zm/zm_3m_unpack.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/3T/matmul_large_block_zm/zm_3m_unpack.cpp
@@ -7,6 +7,7 @@
 #include "llk_unpack_tilize_api.h"
 #include "llk_unpack_untilize_api.h"
 #include "llk_unpack_A_api.h"
+#include "llk_unpack_AB_api.h"
 #include "llk_unpack_AB_matmul_api.h"
 namespace NAMESPACE {
 

--- a/tests/tt_metal/tt_metal/test_kernels/compute/3T/untilize_A_and_eltwise_binary/chlkc_math.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/3T/untilize_A_and_eltwise_binary/chlkc_math.cpp
@@ -15,7 +15,7 @@ void math_main() {
     uint32_t per_core_block_c_tiles = get_compile_time_arg_val(2);
 
     llk_math_pack_sync_init<DST_ACCUM_MODE>();
-    llk_math_hw_configure_disaggregated(0, 1);
+    llk_math_hw_configure(0, 1);
     for (uint32_t block = 0; block < per_core_num_blocks; block++) {
         for (uint32_t r = 0; r < per_core_block_r_tiles; r++) {
             // Untilize

--- a/tests/tt_metal/tt_metal/test_kernels/compute/3T/untilize_A_and_eltwise_binary/chlkc_pack.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/3T/untilize_A_and_eltwise_binary/chlkc_pack.cpp
@@ -12,8 +12,8 @@ void pack_main() {
     uint32_t per_core_block_r_tiles = get_compile_time_arg_val(1);
     uint32_t per_core_block_c_tiles = get_compile_time_arg_val(2);
     llk_pack_init();
-    llk_pack_hw_configure_disaggregated<DST_ACCUM_MODE, false>(16);
-    llk_pack_dest_init<DST_ACCUM_MODE, false>();
+    llk_pack_hw_configure<DST_ACCUM_MODE>(16);
+    llk_pack_dest_init<DST_ACCUM_MODE>();
 
     for (uint32_t block = 0; block < per_core_num_blocks; block++) {
         for (uint32_t r = 0; r < per_core_block_r_tiles; r++) {

--- a/tests/tt_metal/tt_metal/test_kernels/compute/3T/untilize_A_and_eltwise_binary/chlkc_unpack.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/3T/untilize_A_and_eltwise_binary/chlkc_unpack.cpp
@@ -14,8 +14,7 @@ void unpack_main() {
     uint32_t per_core_block_r_tiles = get_compile_time_arg_val(1);
     uint32_t per_core_block_c_tiles = get_compile_time_arg_val(2);
 
-    llk_unpack_AB_hw_configure_disaggregated<DST_ACCUM_MODE>(0, 1);
-    // llk_unpack_untilize_hw_configure_disaggregated(0);
+    llk_unpack_hw_configure<DST_ACCUM_MODE>(0, 1);
 
     // llk_unpack_untilize_init(0);
     for (uint32_t block = 0U; block < per_core_num_blocks; ++block) {

--- a/tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy_3m.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy_3m.cpp
@@ -19,7 +19,7 @@ void math_main() {
     int __outer_loop_iter;
     MATH((llk_math_eltwise_unary_datacopy_init<A2D, DST_ACCUM_MODE, BroadcastType::NONE>(0, 0, 0)));
     llk_math_pack_sync_init<DST_ACCUM_MODE>();
-    llk_math_hw_configure_disaggregated(0, 0);
+    llk_math_hw_configure(0, 0);
     constexpr uint32_t per_core_tile_cnt = get_compile_time_arg_val(0);
     for (uint32_t b = 0; b < per_core_tile_cnt; ++b) {
         llk_math_wait_for_dest_available();
@@ -36,8 +36,8 @@ void math_main() {
 void pack_main() {
     int __outer_loop_iter;
     llk_pack_init();
-    llk_pack_hw_configure_disaggregated<DST_ACCUM_MODE, false>(16);
-    llk_pack_dest_init<DST_ACCUM_MODE, false>();
+    llk_pack_hw_configure<DST_ACCUM_MODE>(16);
+    llk_pack_dest_init<DST_ACCUM_MODE>();
     constexpr uint32_t per_core_tile_cnt = get_compile_time_arg_val(0);
     for (uint32_t b = 0; b < per_core_tile_cnt; ++b) {
         llk_packer_wait_for_math_done();
@@ -53,7 +53,7 @@ void pack_main() {
 void unpack_main() {
     int __outer_loop_iter;
     UNPACK((llk_unpack_A_init<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE>()));
-    UNPACK((llk_unpack_A_hw_configure_disaggregated<DST_ACCUM_MODE>(0)));
+    UNPACK((llk_unpack_hw_configure<DST_ACCUM_MODE>(0, 1)));
     constexpr uint32_t per_core_tile_cnt = get_compile_time_arg_val(0);
     for (uint32_t b = 0; b < per_core_tile_cnt; ++b) {
         llk_wait_tiles(0, 1);

--- a/tests/tt_metal/tt_metal/test_kernels/compute/untilA_elwbin_3m.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/untilA_elwbin_3m.cpp
@@ -25,7 +25,7 @@ void math_main() {
     uint32_t per_core_block_c_tiles = get_compile_time_arg_val(2);
 
     llk_math_pack_sync_init<DST_ACCUM_MODE>();
-    llk_math_hw_configure_disaggregated(0, 1);
+    llk_math_hw_configure(0, 1);
     for (uint32_t block = 0; block < per_core_num_blocks; block++) {
         for (uint32_t r = 0; r < per_core_block_r_tiles; r++) {
             // Untilize
@@ -58,8 +58,7 @@ void unpack_main() {
     uint32_t per_core_block_r_tiles = get_compile_time_arg_val(1);
     uint32_t per_core_block_c_tiles = get_compile_time_arg_val(2);
 
-    llk_unpack_AB_hw_configure_disaggregated<DST_ACCUM_MODE>(0, 1);
-    // llk_unpack_untilize_hw_configure_disaggregated(0);
+    llk_unpack_hw_configure<DST_ACCUM_MODE>(0, 1);
 
     // llk_unpack_untilize_init(0);
     for (uint32_t block = 0U; block < per_core_num_blocks; ++block) {
@@ -94,8 +93,8 @@ void pack_main() {
     uint32_t per_core_block_r_tiles = get_compile_time_arg_val(1);
     uint32_t per_core_block_c_tiles = get_compile_time_arg_val(2);
     llk_pack_init();
-    llk_pack_hw_configure_disaggregated<DST_ACCUM_MODE, false>(16);
-    llk_pack_dest_init<DST_ACCUM_MODE, false>();
+    llk_pack_hw_configure<DST_ACCUM_MODE>(16);
+    llk_pack_dest_init<DST_ACCUM_MODE>();
 
     for (uint32_t block = 0; block < per_core_num_blocks; block++) {
         for (uint32_t r = 0; r < per_core_block_r_tiles; r++) {

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_common_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_common_api.h
@@ -21,7 +21,7 @@
 /*************************************************************************
  * LLK MATH COMMON
  *************************************************************************/
-inline void llk_math_hw_configure_disaggregated(const std::uint32_t srca_operand, const std::uint32_t srcb_operand) {
+inline void llk_math_hw_configure(const std::uint32_t srca_operand, const std::uint32_t srcb_operand) {
     std::uint32_t srca_operand_id = get_operand_id(srca_operand);
     std::uint32_t srcb_operand_id = get_operand_id(srcb_operand);
     _llk_math_hw_configure_(unpack_dst_format[srca_operand_id], unpack_dst_format[srcb_operand_id]);
@@ -57,28 +57,28 @@ inline void llk_math_debug_dump(std::uint8_t* data, std::uint32_t byte_size) { _
 
 inline void llk_math_debug_dump_seek(std::uint8_t offset) { _llk_math_debug_dump_seek_(offset); }
 
-template <bool is_fp32_dest_acc_en, bool to_from_int8 = false>
+template <bool is_fp32_dest_acc_en>
 inline void llk_math_reconfig_data_format_srca(const std::uint32_t srca_new_operand) {
     std::uint32_t new_srca_operand_id = get_operand_id(srca_new_operand);
-    _llk_math_reconfig_data_format_srca_<is_fp32_dest_acc_en, to_from_int8>(unpack_dst_format[new_srca_operand_id]);
+    _llk_math_reconfig_data_format_srca_<is_fp32_dest_acc_en>(unpack_dst_format[new_srca_operand_id]);
 }
 
-template <bool is_fp32_dest_acc_en, bool to_from_int8 = false>
+template <bool is_fp32_dest_acc_en>
 inline void llk_math_reconfig_data_format_srcb(const std::uint32_t srcb_new_operand) {
     std::uint32_t new_srcb_operand_id = get_operand_id(srcb_new_operand);
-    _llk_math_reconfig_data_format_srcb_<is_fp32_dest_acc_en, to_from_int8>(unpack_dst_format[new_srcb_operand_id]);
+    _llk_math_reconfig_data_format_srcb_<is_fp32_dest_acc_en>(unpack_dst_format[new_srcb_operand_id]);
 }
 
-template <bool is_fp32_dest_acc_en, bool to_from_int8 = false>
+template <bool is_fp32_dest_acc_en>
 inline void llk_math_reconfig_data_format(const std::uint32_t srca_new_operand, const std::uint32_t srcb_new_operand) {
     std::uint32_t new_srca_operand_id = get_operand_id(srca_new_operand);
     std::uint32_t new_srcb_operand_id = get_operand_id(srcb_new_operand);
 
-    _llk_math_reconfig_data_format_<is_fp32_dest_acc_en, to_from_int8>(
+    _llk_math_reconfig_data_format_<is_fp32_dest_acc_en>(
         unpack_dst_format[new_srca_operand_id], unpack_dst_format[new_srcb_operand_id]);
 }
 
-template <bool is_fp32_dest_acc_en, bool to_from_int8 = false>
+template <bool is_fp32_dest_acc_en>
 inline void llk_math_reconfig_data_format(
     const std::uint32_t srca_old_operand,
     const std::uint32_t srca_new_operand,
@@ -91,33 +91,33 @@ inline void llk_math_reconfig_data_format(
 
     if ((unpack_dst_format[old_srca_operand_id] != unpack_dst_format[new_srca_operand_id]) &&
         (unpack_dst_format[old_srcb_operand_id] != unpack_dst_format[new_srcb_operand_id])) {
-        llk_math_reconfig_data_format<is_fp32_dest_acc_en, to_from_int8>(srca_new_operand, srcb_new_operand);
+        llk_math_reconfig_data_format<is_fp32_dest_acc_en>(srca_new_operand, srcb_new_operand);
     } else if ((unpack_dst_format[old_srca_operand_id] != unpack_dst_format[new_srca_operand_id])) {
-        llk_math_reconfig_data_format_srca<is_fp32_dest_acc_en, to_from_int8>(srca_new_operand);
+        llk_math_reconfig_data_format_srca<is_fp32_dest_acc_en>(srca_new_operand);
     } else if ((unpack_dst_format[old_srcb_operand_id] != unpack_dst_format[new_srcb_operand_id])) {
-        llk_math_reconfig_data_format_srcb<is_fp32_dest_acc_en, to_from_int8>(srcb_new_operand);
+        llk_math_reconfig_data_format_srcb<is_fp32_dest_acc_en>(srcb_new_operand);
     }
 }
 
-template <bool is_fp32_dest_acc_en, bool to_from_int8 = false>
+template <bool is_fp32_dest_acc_en>
 inline void llk_math_reconfig_data_format_srca(
     const std::uint32_t srca_old_operand, const std::uint32_t srca_new_operand) {
     std::uint32_t old_srca_operand_id = get_operand_id(srca_old_operand);
     std::uint32_t new_srca_operand_id = get_operand_id(srca_new_operand);
 
     if ((unpack_dst_format[old_srca_operand_id] != unpack_dst_format[new_srca_operand_id])) {
-        llk_math_reconfig_data_format_srca<is_fp32_dest_acc_en, to_from_int8>(srca_new_operand);
+        llk_math_reconfig_data_format_srca<is_fp32_dest_acc_en>(srca_new_operand);
     }
 }
 
-template <bool is_fp32_dest_acc_en, bool to_from_int8 = false>
+template <bool is_fp32_dest_acc_en>
 inline void llk_math_reconfig_data_format_srcb(
     const std::uint32_t srcb_old_operand, const std::uint32_t srcb_new_operand) {
     std::uint32_t old_srcb_operand_id = get_operand_id(srcb_old_operand);
     std::uint32_t new_srcb_operand_id = get_operand_id(srcb_new_operand);
 
     if ((unpack_dst_format[old_srcb_operand_id] != unpack_dst_format[new_srcb_operand_id])) {
-        llk_math_reconfig_data_format_srcb<is_fp32_dest_acc_en, to_from_int8>(srcb_new_operand);
+        llk_math_reconfig_data_format_srcb<is_fp32_dest_acc_en>(srcb_new_operand);
     }
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_common_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_common_api.h
@@ -21,12 +21,10 @@
 /*************************************************************************
  * LLK MATH COMMON
  *************************************************************************/
-template <bool untilize_en = false, bool skip_inputs = false>
 inline void llk_math_hw_configure_disaggregated(const std::uint32_t srca_operand, const std::uint32_t srcb_operand) {
     std::uint32_t srca_operand_id = get_operand_id(srca_operand);
     std::uint32_t srcb_operand_id = get_operand_id(srcb_operand);
-    _llk_math_hw_configure_<untilize_en, skip_inputs>(
-        unpack_dst_format[srca_operand_id], unpack_dst_format[srcb_operand_id]);
+    _llk_math_hw_configure_(unpack_dst_format[srca_operand_id], unpack_dst_format[srcb_operand_id]);
 }
 
 inline void llk_math_wait_for_dest_available() {

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_common_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_common_api.h
@@ -27,6 +27,8 @@ inline void llk_math_hw_configure(const std::uint32_t srca_operand, const std::u
     _llk_math_hw_configure_(unpack_dst_format[srca_operand_id], unpack_dst_format[srcb_operand_id]);
 }
 
+inline void llk_math_configure_remap(bool remap_enabled) { _llk_math_configure_remap_(remap_enabled); }
+
 inline void llk_math_wait_for_dest_available() {
     WAYPOINT("MWDW");
     _llk_math_wait_for_dest_available_<DST_SYNC_MODE>();

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_matmul_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_matmul_api.h
@@ -30,7 +30,7 @@ inline void llk_math_matmul_init(
     const std::uint32_t in1_tile_r_dim = get_operand_tile_r_dim(in1_id);
     const std::uint32_t in1_tile_c_dim = get_operand_tile_c_dim(in1_id);
 
-    _llk_math_matmul_init_<NUM_FIDELITY_PHASES, DstTileFaceLayout::RowMajor, THROTTLE_LEVEL>(
+    _llk_math_matmul_init_<NUM_FIDELITY_PHASES, THROTTLE_LEVEL>(
         in0_tile_r_dim,
         in0_tile_c_dim,
         in1_tile_r_dim,
@@ -49,6 +49,5 @@ inline void llk_math_matmul(
     const std::uint32_t ct_dim = 1,
     const std::uint32_t rt_dim = 1,
     const std::uint32_t kt_dim = 1) {
-    _llk_math_matmul_<NUM_FIDELITY_PHASES, DstTileFaceLayout::RowMajor, THROTTLE_LEVEL>(
-        dst_index, transpose, ct_dim, rt_dim, kt_dim);
+    _llk_math_matmul_<NUM_FIDELITY_PHASES, THROTTLE_LEVEL>(dst_index, transpose, ct_dim, rt_dim, kt_dim);
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_matmul_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_matmul_api.h
@@ -42,7 +42,7 @@ inline void llk_math_matmul_init(
         kt_dim);
 }
 
-template <int NUM_FIDELITY_PHASES, int THROTTLE_LEVEL = 0, uint32_t num_faces = 4 /*not used*/>
+template <int NUM_FIDELITY_PHASES, int THROTTLE_LEVEL = 0>
 inline void llk_math_matmul(
     const uint dst_index,
     const bool transpose = false,

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_api.h
@@ -35,112 +35,23 @@ inline void llk_pack_mop_config(const uint32_t output) {
         pack_dst_format[output_id], face_r_dim, tile_c_dim, num_faces, partial_face, narrow_tile);
 }
 
-template <bool is_fp32_dest_acc_en, bool untilize = false, bool tilize = false>
-inline void llk_pack_hw_configure(const llk_pack_params_t* pack_params) {
-    const std::uint32_t output_id = get_output_id(pack_params->pack_output);
+template <bool is_fp32_dest_acc_en>
+inline void llk_pack_hw_configure(std::uint32_t pack_output) {
+    const std::uint32_t output_id = get_output_id(pack_output);
     const std::uint32_t face_r_dim = get_output_face_r_dim(output_id);
     const std::uint32_t tile_c_dim = get_output_tile_c_dim(output_id);
     const std::uint32_t num_faces = get_output_num_faces(output_id);
     const bool partial_face = get_output_partial_face(output_id);
     const bool narrow_tile = get_output_narrow_tile(output_id);
 
-    _llk_pack_hw_configure_<is_fp32_dest_acc_en, untilize, tilize>(
+    _llk_pack_hw_configure_<is_fp32_dest_acc_en>(
         pack_src_format[output_id],
         pack_dst_format[output_id],
         face_r_dim,
         tile_c_dim,
         num_faces,
         partial_face,
-        narrow_tile,
-        pack_params->relu_config.val);
-}
-
-template <
-    bool is_fp32_dest_acc_en,
-    bool untilize = false,
-    ReluType relu_type = ReluType::NO_RELU,
-    std::uint32_t relu_threshold = 0,
-    bool tilize = false>
-inline void llk_pack_hw_configure_disaggregated(std::uint32_t pack_output) {
-    llk_pack_params_t llk_pack_params = {
-        .pack_output = pack_output,
-        .relu_config = {
-            .f = {
-                .ApplyRelu = (std::uint32_t)relu_type,
-                .Threshold = relu_threshold,
-            }}};
-    llk_pack_hw_configure<is_fp32_dest_acc_en, untilize, tilize>(&llk_pack_params);
-}
-
-template <bool is_fp32_dest_acc_en, bool untilize = false, bool tilize = false>
-inline void llk_pack_untilize_hw_configure(
-    const llk_pack_params_t* pack_params, const std::uint32_t face_r_dim, const std::uint32_t num_faces) {
-    const std::uint32_t output_id = get_output_id(pack_params->pack_output);
-    const std::uint32_t tile_c_dim = get_output_tile_c_dim(output_id);
-    const bool partial_face = get_output_partial_face(output_id);
-    const bool narrow_tile = get_output_narrow_tile(output_id);
-
-    _llk_pack_hw_configure_<is_fp32_dest_acc_en, untilize, tilize>(
-        pack_src_format[output_id],
-        pack_dst_format[output_id],
-        face_r_dim,
-        tile_c_dim,
-        num_faces,
-        partial_face,
-        narrow_tile,
-        pack_params->relu_config.val);
-}
-
-template <
-    bool is_fp32_dest_acc_en,
-    bool untilize = false,
-    ReluType relu_type = ReluType::NO_RELU,
-    std::uint32_t relu_threshold = 0,
-    bool tilize = false>
-inline void llk_pack_untilize_hw_configure_disaggregated(
-    std::uint32_t pack_output, std::uint32_t face_r_dim = 16, std::uint32_t num_faces = 4) {
-    llk_pack_params_t llk_pack_params = {
-        .pack_output = pack_output,
-        .relu_config = {
-            .f = {
-                .ApplyRelu = (std::uint32_t)relu_type,
-                .Threshold = relu_threshold,
-            }}};
-    llk_pack_untilize_hw_configure<is_fp32_dest_acc_en, untilize, tilize>(&llk_pack_params, face_r_dim, num_faces);
-}
-
-template <PoolType type, ReduceDim dim, bool is_fp32_dest_acc_en, bool untilize = false>
-inline void llk_pack_reduce_hw_configure(const llk_pack_params_t* pack_params) {
-    const std::uint32_t output_id = get_output_id(pack_params->pack_output);
-    const std::uint32_t face_r_dim = get_output_face_r_dim(output_id);
-    const std::uint32_t tile_c_dim = get_output_tile_c_dim(output_id);
-    const std::uint32_t num_faces = get_output_num_faces(output_id);
-    const bool partial_face = get_output_partial_face(output_id);
-    const bool narrow_tile = get_output_narrow_tile(output_id);
-
-    _llk_pack_reduce_hw_configure_<type, dim, is_fp32_dest_acc_en, untilize>(
-        pack_src_format[output_id],
-        pack_dst_format[output_id],
-        face_r_dim,
-        tile_c_dim,
-        num_faces,
-        partial_face,
-        narrow_tile,
-        pack_params->relu_config.val);
-}
-
-template <
-    PoolType type,
-    ReduceDim dim,
-    bool is_fp32_dest_acc_en,
-    bool untilize = false,
-    ReluType relu_type = ReluType::NO_RELU,
-    std::uint32_t relu_threshold = 0>
-inline void llk_pack_reduce_hw_configure_disaggregated(std::uint32_t pack_output) {
-    llk_pack_params_t llk_pack_params = {
-        .pack_output = pack_output,
-        .relu_config = {.f = {.ApplyRelu = (std::uint32_t)relu_type, .Threshold = relu_threshold}}};
-    llk_pack_reduce_hw_configure<type, dim, is_fp32_dest_acc_en, untilize>(&llk_pack_params);
+        narrow_tile);
 }
 
 template <bool untilize = false, bool zero_output = false, bool tilize = false>
@@ -153,7 +64,7 @@ inline void llk_pack_init(const std::uint32_t pack_output = 16) {
     const bool partial_face = get_output_partial_face(output_id);
     const bool narrow_tile = get_output_narrow_tile(output_id);
 
-    _llk_pack_init_<untilize, zero_output, false, tilize>(
+    _llk_pack_init_<untilize, zero_output, tilize>(
         pack_dst_format[output_id], face_r_dim, tile_c_dim, num_faces, partial_face, narrow_tile);
 
     set_packer_strides<untilize, tilize>(pack_src_format[output_id], pack_dst_format[output_id], tile_c_dim);
@@ -197,7 +108,7 @@ inline void llk_pack(std::uint32_t tile_index, std::uint32_t output, std::uint32
 template <
     std::uint32_t block_ct_dim = 8,
     std::uint32_t full_ct_dim = block_ct_dim,
-    bool narrow_row = false /* unused */,
+    bool narrow_row = false,
     std::uint32_t row_num_datums = TILE_C_DIM /* unused */>
 inline void llk_pack_untilize_init(
     std::uint32_t output, const std::uint32_t face_r_dim = FACE_R_DIM, const std::uint32_t num_faces = 4) {
@@ -226,8 +137,8 @@ inline void llk_pack_untilize_uninit(std::uint32_t output) {
 template <
     std::uint32_t block_ct_dim = 8,
     std::uint32_t full_ct_dim = block_ct_dim,
-    bool narrow_row = false /* unused */,
-    std::uint32_t row_num_datums = TILE_C_DIM /* unused */,
+    bool narrow_row = false,
+    std::uint32_t row_num_datums = TILE_C_DIM,
     uint32_t tile_dst_ct_offset = 0>
 inline void llk_pack_untilize(
     std::uint32_t block_rt_dim,
@@ -296,7 +207,7 @@ inline void llk_init_packer_dest_offset_registers(const std::uint32_t pack_outpu
     _llk_init_packer_dest_offset_registers_<DST_SYNC_MODE>(face_r_dim, narrow_tile);
 }
 
-template <bool is_fp32_dest_acc_en, bool untilize = false>
+template <bool is_fp32_dest_acc_en>
 inline void llk_pack_dest_init(const std::uint32_t pack_output = 16) {
     const std::uint32_t output_id = get_output_id(pack_output);
     const std::uint32_t face_r_dim = get_output_face_r_dim(output_id);
@@ -309,6 +220,7 @@ template <bool mail2math = true, bool mail2pack = true>
 inline void llk_pack_get_tile(std::uint32_t output, std::uint32_t tile_index, std::uint32_t* p_tile) {
     _llk_pack_get_tile_<mail2math, mail2pack>(tile_index, p_tile);
 }
+
 template <bool mail2math = true, bool mail2pack = true>
 inline void llk_pack_release_tile(std::uint32_t output) {
     _llk_pack_release_tile_<mail2math, mail2pack>();
@@ -318,24 +230,22 @@ inline void llk_pack_debug_dump(std::uint8_t* data, std::uint32_t byte_size) { _
 
 inline void llk_pack_debug_dump_seek(std::uint8_t offset) { _llk_pack_debug_dump_seek_(offset); }
 
-template <bool is_fp32_dest_acc_en, bool is_tile_dim_reconfig_en = false>
+template <bool is_fp32_dest_acc_en>
 inline void llk_pack_reconfig_data_format(const std::uint32_t new_output) {
     const std::uint32_t output_id = get_output_id(new_output);
     const std::uint32_t face_r_dim = get_output_face_r_dim(output_id);
     const std::uint32_t tile_c_dim = get_output_tile_c_dim(output_id);
     const std::uint32_t num_faces = get_output_num_faces(output_id);
     const bool partial_face = get_output_partial_face(output_id);
-    const bool narrow_tile = get_output_narrow_tile(output_id);
 
-    _llk_pack_reconfig_data_format_<is_fp32_dest_acc_en, is_tile_dim_reconfig_en, false>(
+    _llk_pack_reconfig_data_format_<is_fp32_dest_acc_en>(
         pack_src_format[output_id],
         pack_dst_format[output_id],
         get_local_cb_interface(output_id).fifo_page_size,
         face_r_dim,
         tile_c_dim,
         num_faces,
-        partial_face,
-        narrow_tile);
+        partial_face);
 }
 
 template <bool is_fp32_dest_acc_en, bool is_tile_dim_reconfig_en = false>
@@ -363,38 +273,3 @@ inline void llk_pack_reduce_mask_config() {
 }
 
 inline void llk_pack_reduce_mask_clear() { _llk_pack_reduce_mask_clear_(); }
-
-// FIXME-WH-UPLIFT
-template <ReduceDim dim, bool is_fp32_dest_acc_en, bool at_kernel_start = false, bool revert = false>
-inline void llk_pack_reduce_config_v2(uint32_t icb_out) {
-    const bool untilize = false;
-    if constexpr (at_kernel_start) {
-        const std::uint32_t output_id = get_output_id(icb_out);
-        const std::uint32_t face_r_dim = get_output_face_r_dim(output_id);
-        const std::uint32_t tile_c_dim = get_output_tile_c_dim(output_id);
-        const std::uint32_t num_faces = get_output_num_faces(output_id);
-        const bool partial_face = get_output_partial_face(output_id);
-        const bool narrow_tile = get_output_narrow_tile(output_id);
-        const llk_relu_config_u relu_config = {
-            .f = {
-                .ApplyRelu = (std::uint32_t)ReluType::NO_RELU,
-                .Threshold = 0,
-            }};
-
-        _llk_pack_hw_configure_<is_fp32_dest_acc_en, untilize>(
-            pack_src_format[output_id],
-            pack_dst_format[output_id],
-            face_r_dim,
-            tile_c_dim,
-            num_faces,
-            partial_face,
-            narrow_tile,
-            relu_config.val);
-    }
-
-    if constexpr (revert) {
-        _llk_pack_reduce_mask_clear_();
-    } else {
-        _llk_pack_reduce_mask_config_<untilize, dim>();
-    }
-}

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_api.h
@@ -239,16 +239,10 @@ inline void llk_pack_reconfig_data_format(const std::uint32_t new_output) {
     const bool partial_face = get_output_partial_face(output_id);
 
     _llk_pack_reconfig_data_format_<is_fp32_dest_acc_en>(
-        pack_src_format[output_id],
-        pack_dst_format[output_id],
-        get_local_cb_interface(output_id).fifo_page_size,
-        face_r_dim,
-        tile_c_dim,
-        num_faces,
-        partial_face);
+        pack_src_format[output_id], pack_dst_format[output_id], face_r_dim, tile_c_dim, num_faces, partial_face);
 }
 
-template <bool is_fp32_dest_acc_en, bool is_tile_dim_reconfig_en = false>
+template <bool is_fp32_dest_acc_en>
 inline void llk_pack_reconfig_data_format(const std::uint32_t old_output, const std::uint32_t new_output) {
     std::uint32_t old_output_id = get_output_id(old_output);
     std::uint32_t new_output_id = get_output_id(new_output);
@@ -256,10 +250,7 @@ inline void llk_pack_reconfig_data_format(const std::uint32_t old_output, const 
     if ((pack_dst_format[old_output_id] != pack_dst_format[new_output_id]) &&
         (pack_dst_format[old_output_id] != (uint)DataFormat::Invalid) &&
         (pack_dst_format[new_output_id] != (uint)DataFormat::Invalid)) {
-        llk_pack_reconfig_data_format<is_fp32_dest_acc_en, is_tile_dim_reconfig_en>(new_output);
-    } else if constexpr (is_tile_dim_reconfig_en) {
-        // Same format but different tile dims
-        llk_pack_mop_config<false, false>(new_output);
+        llk_pack_reconfig_data_format<is_fp32_dest_acc_en>(new_output);
     }
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_param_structs.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_param_structs.h
@@ -22,46 +22,6 @@ struct llk_unpack_AB_matmul_params_t {
     std::uint32_t transpose_xy_srca;
 };
 
-struct llk_unpack_AB_params_t {
-    std::uint32_t unpA_operand;
-    std::uint32_t unpB_operand;
-};
-
-struct llk_unpack_reduce_params_t {
-    std::uint32_t unpA_operand;
-    // std::uint32_t unpB_operand;  // TODO: Should be removed when llk hw args are cleaned up
-};
-
-struct llk_unpack_tilize_params_t {
-    std::uint32_t unpA_operand;
-    std::uint32_t unpA_block_c_dim;
-};
-
-struct llk_unpack_untilize_params_t {
-    std::uint32_t unpA_operand;
-};
-
-//***
-//  Math LLK param structs
-//***
-
-struct llk_math_eltwise_binary_params_t {
-    std::int32_t unused;
-};
-
-struct llk_math_eltwise_unary_params_t {
-    std::int32_t sfpu_params[6];  // TODO: Fix how we assign this from hlkc
-    std::int32_t unused;
-};
-
-struct llk_math_matmul_params_t {
-    std::int32_t unused;
-};
-
-struct llk_math_reduce_params_t {
-    std::int32_t unused;
-};
-
 //***
 //  Pack LLK param structs
 //***

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_api.h
@@ -10,35 +10,25 @@
  * LLK UNPACK AB
  *************************************************************************/
 
-template <bool is_fp32_dest_acc_en, StochRndType stoch_rnd_mode = StochRndType::None>
-inline void llk_unpack_AB_hw_configure(
-    const llk_unpack_AB_params_t* unpack_AB_params, const int within_face_16x16_transpose = 0) {
+template <bool is_fp32_dest_acc_en>
+inline void llk_unpack_hw_configure(const std::uint32_t unpA_operand, const std::uint32_t unpB_operand) {
     // In0 -> unpA
     // In1 -> unpB
-    const uint32_t unpA_operand_id = get_operand_id(unpack_AB_params->unpA_operand);
-    const uint32_t unpB_operand_id = get_operand_id(unpack_AB_params->unpB_operand);
+    const uint32_t unpA_operand_id = get_operand_id(unpA_operand);
+    const uint32_t unpB_operand_id = get_operand_id(unpB_operand);
 
     // unpA -> srcA
     // unpB -> srcB
     const uint32_t num_faces = get_operand_num_faces(unpA_operand_id);    // num faces in unpA and unpB are the same
     const uint32_t face_r_dim = get_operand_face_r_dim(unpA_operand_id);  // face r dim in unpA and unpB are the same
 
-    _llk_unpack_AB_hw_configure_<is_fp32_dest_acc_en, stoch_rnd_mode>(
+    _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
         unpack_src_format[unpA_operand_id],
         unpack_src_format[unpB_operand_id],
         unpack_dst_format[unpA_operand_id],
         unpack_dst_format[unpB_operand_id],
         face_r_dim,
-        within_face_16x16_transpose,
         num_faces);
-}
-
-template <bool is_fp32_dest_acc_en, StochRndType stoch_rnd_mode = StochRndType::None>
-inline void llk_unpack_AB_hw_configure_disaggregated(
-    const std::uint32_t unpA_operand, const std::uint32_t unpB_operand, const int within_face_16x16_transpose = 0) {
-    const llk_unpack_AB_params_t unpack_AB_params = {.unpA_operand = unpA_operand, .unpB_operand = unpB_operand};
-
-    llk_unpack_AB_hw_configure<is_fp32_dest_acc_en, stoch_rnd_mode>(&unpack_AB_params, within_face_16x16_transpose);
 }
 
 template <BroadcastType BType = BroadcastType::NONE>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_matmul_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_matmul_api.h
@@ -55,7 +55,9 @@ __attribute__((always_inline)) inline void llk_unpack_AB_matmul_init(
         unpA_num_faces,
         unpB_num_faces,
         partial_face_a,
-        partial_face_b);
+        partial_face_b,
+        get_local_cb_interface(operandA_id).fifo_page_size,
+        get_local_cb_interface(operandB_id).fifo_page_size);
 }
 
 inline void llk_unpack_AB_matmul(

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_matmul_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_matmul_api.h
@@ -10,45 +10,6 @@
  * LLK UNPACK AB MATMUL
  *************************************************************************/
 
-template <bool is_fp32_dest_acc_en, StochRndType stoch_rnd_mode = StochRndType::None>
-inline void llk_unpack_AB_matmul_hw_configure(const llk_unpack_AB_matmul_params_t* unpack_AB_params) {
-    const bool transpose_xy_srca = unpack_AB_params->transpose_xy_srca;
-
-    // In0 -> unpB
-    // In1 -> unpA
-    const uint32_t unpA_operand_id = get_operand_id(unpack_AB_params->unpB_operand);
-    const uint32_t unpB_operand_id = get_operand_id(unpack_AB_params->unpA_operand);
-
-    // unpA -> srcA
-    // unpB -> srcB
-    const uint32_t unpA_num_faces = get_operand_num_faces(unpA_operand_id);
-    const uint32_t unpB_num_faces = get_operand_num_faces(unpB_operand_id);
-
-    const uint32_t unpA_face_r_dim = get_operand_face_r_dim(unpA_operand_id);
-    const uint32_t unpB_face_r_dim = get_operand_face_r_dim(unpB_operand_id);
-
-    _llk_unpack_AB_matmul_hw_configure_<is_fp32_dest_acc_en, stoch_rnd_mode>(
-        unpack_src_format[unpA_operand_id],
-        unpack_src_format[unpB_operand_id],
-        unpack_dst_format[unpA_operand_id],
-        unpack_dst_format[unpB_operand_id],
-        unpA_face_r_dim,
-        unpB_face_r_dim,
-        transpose_xy_srca,
-        unpA_num_faces,
-        unpB_num_faces,
-        get_local_cb_interface(unpA_operand_id).fifo_page_size,
-        get_local_cb_interface(unpB_operand_id).fifo_page_size);
-}
-
-template <bool is_fp32_dest_acc_en, StochRndType stoch_rnd_mode = StochRndType::None>
-inline void llk_unpack_AB_matmul_hw_configure_disaggregated(
-    const std::uint32_t unpA_operand, const std::uint32_t unpB_operand, const std::uint32_t transpose_xy_srca = 0) {
-    const llk_unpack_AB_matmul_params_t unpack_AB_matmul_params = {
-        .unpA_operand = unpA_operand, .unpB_operand = unpB_operand, .transpose_xy_srca = transpose_xy_srca};
-    llk_unpack_AB_matmul_hw_configure<is_fp32_dest_acc_en, stoch_rnd_mode>(&unpack_AB_matmul_params);
-}
-
 inline void llk_unpack_AB_matmul_mop_config(
     const bool transpose,
     const std::uint32_t ct_dim,

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_A_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_A_api.h
@@ -11,35 +11,6 @@
  *************************************************************************/
 
 template <
-    bool is_fp32_dest_acc_en,
-    StochRndType stoch_rnd_mode = StochRndType::None,
-    bool disable_src_zero_flag = false>
-inline void llk_unpack_A_hw_configure(
-    const llk_unpack_A_params_t* unpack_A_params, const int within_face_16x16_transpose = 0) {
-    const uint32_t unpA_operand_id = get_operand_id(unpack_A_params->unpA_operand);
-    const uint32_t unpA_num_faces = get_operand_num_faces(unpA_operand_id);
-    const uint32_t unpA_face_r_dim = get_operand_face_r_dim(unpA_operand_id);
-
-    _llk_unpack_A_hw_configure_<is_fp32_dest_acc_en, stoch_rnd_mode, disable_src_zero_flag>(
-        unpack_src_format[unpA_operand_id],
-        unpack_dst_format[unpA_operand_id],
-        unpA_face_r_dim,
-        within_face_16x16_transpose,
-        unpA_num_faces);
-}
-
-template <
-    bool is_fp32_dest_acc_en,
-    StochRndType stoch_rnd_mode = StochRndType::None,
-    bool disable_src_zero_flag = false>
-inline void llk_unpack_A_hw_configure_disaggregated(
-    const std::uint32_t unpA_operand, const int within_face_16x16_transpose = 0) {
-    const llk_unpack_A_params_t unpack_A_params = {.unpA_operand = unpA_operand};
-    llk_unpack_A_hw_configure<is_fp32_dest_acc_en, stoch_rnd_mode, disable_src_zero_flag>(
-        &unpack_A_params, within_face_16x16_transpose);
-}
-
-template <
     BroadcastType BType = BroadcastType::NONE,
     bool acc_to_dest = false,
     EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE,

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_common_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_common_api.h
@@ -53,75 +53,65 @@ inline void llk_unpack_debug_dump(std::uint8_t* data, std::uint32_t byte_size) {
 
 inline void llk_unpack_debug_dump_seek(std::uint8_t offset) { _llk_unpack_debug_dump_seek_(offset); }
 
-template <bool is_fp32_dest_acc_en, bool to_from_int8 = false, bool is_tile_dim_reconfig_en = false>
+template <bool is_fp32_dest_acc_en>
 inline void llk_unpack_reconfig_data_format_srca(const std::uint32_t srca_new_operand) {
     const std::uint32_t srca_operand_id = get_operand_id(srca_new_operand);
     const std::uint32_t num_faces = get_operand_num_faces(srca_operand_id);
     const std::uint32_t face_r_dim = get_operand_face_r_dim(srca_operand_id);
-    _llk_unpack_reconfig_data_format_srca_impl_<is_fp32_dest_acc_en, to_from_int8>(
+    _llk_unpack_reconfig_data_format_srca_impl_<is_fp32_dest_acc_en>(
         unpack_src_format[srca_operand_id],
         unpack_dst_format[srca_operand_id],
         get_local_cb_interface(srca_operand_id).fifo_page_size);
 }
 
-template <bool is_fp32_dest_acc_en, bool to_from_int8 = false, bool is_tile_dim_reconfig_en = false>
+template <bool is_fp32_dest_acc_en>
 inline void llk_unpack_reconfig_data_format_srcb(const std::uint32_t srcb_new_operand) {
     std::uint32_t srcb_operand_id = get_operand_id(srcb_new_operand);
     const std::uint32_t num_faces = get_operand_num_faces(srcb_operand_id);
     const std::uint32_t face_r_dim = get_operand_face_r_dim(srcb_operand_id);
-    _llk_unpack_reconfig_data_format_srcb_impl_<is_fp32_dest_acc_en, to_from_int8>(
+    _llk_unpack_reconfig_data_format_srcb_impl_<is_fp32_dest_acc_en>(
         unpack_src_format[srcb_operand_id],
         unpack_dst_format[srcb_operand_id],
         get_local_cb_interface(srcb_operand_id).fifo_page_size);
 }
 
-template <bool is_fp32_dest_acc_en, bool to_from_int8 = false, bool is_tile_dim_reconfig_en = false>
+template <bool is_fp32_dest_acc_en>
 inline void llk_unpack_reconfig_data_format_srca(
     const std::uint32_t srca_old_operand, const std::uint32_t srca_new_operand) {
     std::uint32_t old_srca_operand_id = get_operand_id(srca_old_operand);
     std::uint32_t new_srca_operand_id = get_operand_id(srca_new_operand);
 
     if (should_reconfigure_cbs(srca_old_operand, srca_new_operand)) {
-        llk_unpack_reconfig_data_format_srca<is_fp32_dest_acc_en, to_from_int8, is_tile_dim_reconfig_en>(
-            srca_new_operand);
-    } else if constexpr (is_tile_dim_reconfig_en) {
-        llk_unpack_reconfig_data_format_srca<is_fp32_dest_acc_en, to_from_int8, is_tile_dim_reconfig_en>(
-            srca_new_operand);
+        llk_unpack_reconfig_data_format_srca<is_fp32_dest_acc_en>(srca_new_operand);
     }
 }
 
-template <bool is_fp32_dest_acc_en, bool to_from_int8 = false, bool is_tile_dim_reconfig_en = false>
+template <bool is_fp32_dest_acc_en>
 inline void llk_unpack_reconfig_data_format_srcb(
     const std::uint32_t srcb_old_operand, const std::uint32_t srcb_new_operand) {
     std::uint32_t old_srcb_operand_id = get_operand_id(srcb_old_operand);
     std::uint32_t new_srcb_operand_id = get_operand_id(srcb_new_operand);
 
     if (should_reconfigure_cbs(srcb_old_operand, srcb_new_operand)) {
-        llk_unpack_reconfig_data_format_srcb<is_fp32_dest_acc_en, to_from_int8, is_tile_dim_reconfig_en>(
-            srcb_new_operand);
-    } else if constexpr (is_tile_dim_reconfig_en) {
-        llk_unpack_reconfig_data_format_srcb<is_fp32_dest_acc_en, to_from_int8, is_tile_dim_reconfig_en>(
-            srcb_new_operand);
+        llk_unpack_reconfig_data_format_srcb<is_fp32_dest_acc_en>(srcb_new_operand);
     }
 }
 
-template <bool is_fp32_dest_acc_en, bool to_from_int8 = false, bool is_tile_dim_reconfig_en = false>
+template <bool is_fp32_dest_acc_en>
 inline void llk_unpack_reconfig_data_format(
     const std::uint32_t srca_new_operand, const std::uint32_t srcb_new_operand) {
-    llk_unpack_reconfig_data_format_srca<is_fp32_dest_acc_en, to_from_int8, is_tile_dim_reconfig_en>(srca_new_operand);
-    llk_unpack_reconfig_data_format_srcb<is_fp32_dest_acc_en, to_from_int8, is_tile_dim_reconfig_en>(srcb_new_operand);
+    llk_unpack_reconfig_data_format_srca<is_fp32_dest_acc_en>(srca_new_operand);
+    llk_unpack_reconfig_data_format_srcb<is_fp32_dest_acc_en>(srcb_new_operand);
 }
 
-template <bool is_fp32_dest_acc_en, bool to_from_int8 = false, bool is_tile_dim_reconfig_en = false>
+template <bool is_fp32_dest_acc_en>
 inline void llk_unpack_reconfig_data_format(
     const std::uint32_t srca_old_operand,
     const std::uint32_t srca_new_operand,
     const std::uint32_t srcb_old_operand,
     const std::uint32_t srcb_new_operand) {
-    llk_unpack_reconfig_data_format_srca<is_fp32_dest_acc_en, to_from_int8, is_tile_dim_reconfig_en>(
-        srca_old_operand, srca_new_operand);
-    llk_unpack_reconfig_data_format_srcb<is_fp32_dest_acc_en, to_from_int8, is_tile_dim_reconfig_en>(
-        srcb_old_operand, srcb_new_operand);
+    llk_unpack_reconfig_data_format_srca<is_fp32_dest_acc_en>(srca_old_operand, srca_new_operand);
+    llk_unpack_reconfig_data_format_srcb<is_fp32_dest_acc_en>(srcb_old_operand, srcb_new_operand);
 }
 
 inline void llk_unpack_dbg_feature_disable() { _llk_unpack_dbg_feature_disable_(); }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_common_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_common_api.h
@@ -117,6 +117,10 @@ inline void llk_enable_int8_fpu_math() { _llk_enable_int8_fpu_math_(); }
 
 inline void llk_unpack_set_srcb_dummy_valid() { _llk_unpack_set_srcb_dummy_valid_(); }
 
+inline void llk_unpack_disable_src_zero_flag(bool disable_src_zero_flag) {
+    _llk_unpack_disable_src_zero_flag_(disable_src_zero_flag);
+}
+
 // All TILE_SIZE related functions were deprecared in BBE for WH.  The following is needed for pack_shifted so just
 // keeping here.
 // FIXME: Need to review and adjust accordingly

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_common_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_common_api.h
@@ -59,9 +59,7 @@ inline void llk_unpack_reconfig_data_format_srca(const std::uint32_t srca_new_op
     const std::uint32_t num_faces = get_operand_num_faces(srca_operand_id);
     const std::uint32_t face_r_dim = get_operand_face_r_dim(srca_operand_id);
     _llk_unpack_reconfig_data_format_srca_impl_<is_fp32_dest_acc_en>(
-        unpack_src_format[srca_operand_id],
-        unpack_dst_format[srca_operand_id],
-        get_local_cb_interface(srca_operand_id).fifo_page_size);
+        unpack_src_format[srca_operand_id], unpack_dst_format[srca_operand_id]);
 }
 
 template <bool is_fp32_dest_acc_en>
@@ -70,9 +68,7 @@ inline void llk_unpack_reconfig_data_format_srcb(const std::uint32_t srcb_new_op
     const std::uint32_t num_faces = get_operand_num_faces(srcb_operand_id);
     const std::uint32_t face_r_dim = get_operand_face_r_dim(srcb_operand_id);
     _llk_unpack_reconfig_data_format_srcb_impl_<is_fp32_dest_acc_en>(
-        unpack_src_format[srcb_operand_id],
-        unpack_dst_format[srcb_operand_id],
-        get_local_cb_interface(srcb_operand_id).fifo_page_size);
+        unpack_src_format[srcb_operand_id], unpack_dst_format[srcb_operand_id]);
 }
 
 template <bool is_fp32_dest_acc_en>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_reduce_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_reduce_api.h
@@ -10,41 +10,6 @@
  * LLK UNPACK REDUCE
  *************************************************************************/
 
-template <PoolType type, ReduceDim dim, bool is_fp32_dest_acc_en, StochRndType stoch_rnd_mode = StochRndType::None>
-inline void llk_unpack_reduce_hw_configure(
-    const llk_unpack_reduce_params_t* unpack_reduce_params, const float const_mult) {
-    constexpr bool within_face_16x16_transpose = (ReduceDim::REDUCE_ROW == dim);
-
-    const std::uint32_t unpA_operand_id = get_operand_id(unpack_reduce_params->unpA_operand);
-    const std::uint32_t unpA_num_faces = get_operand_num_faces(unpA_operand_id);
-    const std::uint32_t unpA_face_r_dim = get_operand_face_r_dim(unpA_operand_id);
-
-    constexpr std::uint32_t unpB_src_format = (std::uint32_t)DataFormat::Float32;
-    const std::uint32_t unpB_dst_format =
-        ((std::uint32_t)unpack_dst_format[unpA_operand_id] == (std::uint32_t)DataFormat::Int8)
-            ? (std::uint32_t)DataFormat::Float16
-            :  // Int8 is treated as fp16_a
-            ((((std::uint32_t)unpack_dst_format[unpA_operand_id] >> 2) & 0x1) ? (std::uint32_t)DataFormat::Float16_b
-                                                                              : (std::uint32_t)DataFormat::Float16);
-
-    _llk_unpack_reduce_hw_configure_<is_fp32_dest_acc_en, stoch_rnd_mode>(
-        unpack_src_format[unpA_operand_id],
-        unpB_src_format,
-        unpack_dst_format[unpA_operand_id],
-        unpB_dst_format,
-        unpA_face_r_dim,
-        unpA_face_r_dim,
-        within_face_16x16_transpose,
-        unpA_num_faces,
-        unpA_num_faces);
-}
-
-template <PoolType type, ReduceDim dim, bool is_fp32_dest_acc_en, StochRndType stoch_rnd_mode = StochRndType::None>
-inline void llk_unpack_reduce_hw_configure_disaggregated(const std::uint32_t unpA_operand, const float mult) {
-    const llk_unpack_reduce_params_t unpack_reduce_params = {.unpA_operand = unpA_operand};
-    llk_unpack_reduce_hw_configure<type, dim, is_fp32_dest_acc_en, stoch_rnd_mode>(&unpack_reduce_params, mult);
-}
-
 template <PoolType type, ReduceDim dim>
 inline void llk_unpack_reduce_mop_config() {
     _llk_unpack_reduce_mop_config_<type, dim>();

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_tilize_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_tilize_api.h
@@ -11,29 +11,6 @@
  * LLK UNPACK TILIZE
  *************************************************************************/
 
-template <bool is_fp32_dest_acc_en>
-inline void llk_unpack_tilize_hw_configure(const llk_unpack_A_params_t *unpack_tilize_params) {
-    constexpr bool within_face_16x16_transpose = false;
-    constexpr StochRndType stoch_rnd_mode = StochRndType::None;
-
-    const uint32_t unpA_operand_id = get_operand_id(unpack_tilize_params->unpA_operand);
-    const uint32_t unpA_num_faces = get_operand_num_faces(unpA_operand_id);
-    const uint32_t unpA_face_r_dim = get_operand_face_r_dim(unpA_operand_id);
-
-    _llk_unpack_tilize_hw_configure_<is_fp32_dest_acc_en, stoch_rnd_mode>(
-        unpack_src_format[unpA_operand_id],
-        unpack_dst_format[unpA_operand_id],
-        unpA_face_r_dim,
-        within_face_16x16_transpose,
-        unpA_num_faces);
-}
-
-template <bool is_fp32_dest_acc_en>
-inline void llk_unpack_tilize_hw_configure_disaggregated(const std::uint32_t unpA_operand) {
-    const llk_unpack_A_params_t unpack_tilize_params = {.unpA_operand = unpA_operand};
-    llk_unpack_tilize_hw_configure<is_fp32_dest_acc_en>(&unpack_tilize_params);
-}
-
 inline void llk_unpack_tilize_mop_config(const std::uint32_t operand) {
     std::uint32_t operand_id = get_operand_id(operand);
     const bool narrow_tile = get_operand_narrow_tile(operand_id);
@@ -100,42 +77,6 @@ inline void llk_unpack_tilize_block(std::uint32_t operand, std::uint32_t block_c
 /*************************************************************************
  * LLK UNPACK TILIZE SRC A, UNPACK SRC B
  *************************************************************************/
-
-template <bool is_fp32_dest_acc_en, StochRndType stoch_rnd_mode = StochRndType::None>
-inline void llk_unpack_tilizeA_B_hw_configure(
-    const llk_unpack_AB_params_t *unpack_tilizeA_B_params, const int within_face_16x16_transpose = 0) {
-    // In0 -> unpA
-    // In1 -> unpB
-    const uint32_t unpA_operand_id = get_operand_id(unpack_tilizeA_B_params->unpA_operand);
-    const uint32_t unpB_operand_id = get_operand_id(unpack_tilizeA_B_params->unpB_operand);
-
-    // unpA -> srcA
-    // Unpack only 1x16 row of datums to SrcA per UNPACK instruction
-    const uint32_t num_faces_a = get_operand_num_faces(unpA_operand_id);
-    const uint32_t face_r_dim_a = get_operand_face_r_dim(unpA_operand_id);
-
-    // unpB -> srcB
-    const uint32_t num_faces_b = get_operand_num_faces(unpB_operand_id);
-    const uint32_t face_r_dim_b = get_operand_face_r_dim(unpB_operand_id);
-    configure_unpack_AB<is_fp32_dest_acc_en, false, false, false>(
-        unpack_src_format[unpA_operand_id],
-        unpack_src_format[unpB_operand_id],
-        unpack_dst_format[unpA_operand_id],
-        unpack_dst_format[unpB_operand_id],
-        face_r_dim_a,
-        face_r_dim_b,
-        within_face_16x16_transpose,
-        num_faces_a,
-        num_faces_b);
-}
-
-template <bool is_fp32_dest_acc_en, StochRndType stoch_rnd_mode = StochRndType::None>
-inline void llk_unpack_tilizeA_B_hw_configure_disaggregated(
-    const std::uint32_t unpA_operand, const std::uint32_t unpB_operand, const int within_face_16x16_transpose = 0) {
-    const llk_unpack_AB_params_t unpack_tilizeA_B_params = {.unpA_operand = unpA_operand, .unpB_operand = unpB_operand};
-    llk_unpack_tilizeA_B_hw_configure<is_fp32_dest_acc_en, stoch_rnd_mode>(
-        &unpack_tilizeA_B_params, within_face_16x16_transpose);
-}
 
 // TODO: add support for all the template parameters
 template <bool neginf_srcA = false, std::uint32_t reload_srcB = false, bool zero_srcA = false, bool zero_srcA_reduce = false>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_untilize_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_untilize_api.h
@@ -9,31 +9,6 @@
 /*************************************************************************
  * LLK UNPACK UNTILIZE
  *************************************************************************/
-template <bool is_fp32_dest_acc_en>
-inline void llk_unpack_untilize_hw_configure(const llk_unpack_A_params_t* unpack_untilize_params) {
-    constexpr bool is_row_pool = false;
-    constexpr bool within_face_16x16_transpose = false;
-    constexpr StochRndType stoch_rnd_mode = StochRndType::None;
-
-    const uint32_t unpA_operand_id = get_operand_id(unpack_untilize_params->unpA_operand);
-    const uint32_t unpA_num_faces = 4;
-    const uint32_t unpA_face_r_dim = FACE_R_DIM;
-
-    _llk_unpack_untilize_hw_configure_<is_fp32_dest_acc_en, stoch_rnd_mode>(
-        unpack_src_format[unpA_operand_id],
-        unpack_dst_format[unpA_operand_id],
-        unpA_face_r_dim,
-        within_face_16x16_transpose,
-        unpA_num_faces);
-}
-
-template <bool is_fp32_dest_acc_en>
-inline void llk_unpack_untilize_hw_configure_disaggregated(const std::uint32_t unpA_operand) {
-    const llk_unpack_A_params_t unpack_untilize_params = {
-        .unpA_operand = unpA_operand,
-    };
-    llk_unpack_untilize_hw_configure<is_fp32_dest_acc_en>(&unpack_untilize_params);
-}
 
 inline void llk_unpack_untilize_mop_config() { _llk_unpack_untilize_mop_config_(); }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_common_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_common_api.h
@@ -21,13 +21,10 @@
 /*************************************************************************
  * LLK MATH COMMON
  *************************************************************************/
-template <bool untilize_en = false, bool skip_inputs = false>
 inline void llk_math_hw_configure_disaggregated(const std::uint32_t srca_operand, const std::uint32_t srcb_operand) {
-    if constexpr (skip_inputs == false) {
-        std::uint32_t srca_operand_id = get_operand_id(srca_operand);
-        std::uint32_t srcb_operand_id = get_operand_id(srcb_operand);
-        _llk_math_hw_configure_<untilize_en>(unpack_dst_format[srca_operand_id], unpack_dst_format[srcb_operand_id]);
-    }
+    std::uint32_t srca_operand_id = get_operand_id(srca_operand);
+    std::uint32_t srcb_operand_id = get_operand_id(srcb_operand);
+    _llk_math_hw_configure_(unpack_dst_format[srca_operand_id], unpack_dst_format[srcb_operand_id]);
 }
 
 inline void llk_math_wait_for_dest_available() {

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_common_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_common_api.h
@@ -21,7 +21,7 @@
 /*************************************************************************
  * LLK MATH COMMON
  *************************************************************************/
-inline void llk_math_hw_configure_disaggregated(const std::uint32_t srca_operand, const std::uint32_t srcb_operand) {
+inline void llk_math_hw_configure(const std::uint32_t srca_operand, const std::uint32_t srcb_operand) {
     std::uint32_t srca_operand_id = get_operand_id(srca_operand);
     std::uint32_t srcb_operand_id = get_operand_id(srcb_operand);
     _llk_math_hw_configure_(unpack_dst_format[srca_operand_id], unpack_dst_format[srcb_operand_id]);
@@ -57,28 +57,28 @@ inline void llk_math_debug_dump(std::uint8_t* data, std::uint32_t byte_size) { _
 
 inline void llk_math_debug_dump_seek(std::uint8_t offset) { _llk_math_debug_dump_seek_(offset); }
 
-template <bool is_fp32_dest_acc_en, bool to_from_int8 = false>
+template <bool is_fp32_dest_acc_en>
 inline void llk_math_reconfig_data_format_srca(const std::uint32_t srca_new_operand) {
     std::uint32_t new_srca_operand_id = get_operand_id(srca_new_operand);
-    _llk_math_reconfig_data_format_srca_<is_fp32_dest_acc_en, to_from_int8>(unpack_dst_format[new_srca_operand_id]);
+    _llk_math_reconfig_data_format_srca_<is_fp32_dest_acc_en>(unpack_dst_format[new_srca_operand_id]);
 }
 
-template <bool is_fp32_dest_acc_en, bool to_from_int8 = false>
+template <bool is_fp32_dest_acc_en>
 inline void llk_math_reconfig_data_format_srcb(const std::uint32_t srcb_new_operand) {
     std::uint32_t new_srcb_operand_id = get_operand_id(srcb_new_operand);
-    _llk_math_reconfig_data_format_srcb_<is_fp32_dest_acc_en, to_from_int8>(unpack_dst_format[new_srcb_operand_id]);
+    _llk_math_reconfig_data_format_srcb_<is_fp32_dest_acc_en>(unpack_dst_format[new_srcb_operand_id]);
 }
 
-template <bool is_fp32_dest_acc_en, bool to_from_int8 = false>
+template <bool is_fp32_dest_acc_en>
 inline void llk_math_reconfig_data_format(const std::uint32_t srca_new_operand, const std::uint32_t srcb_new_operand) {
     std::uint32_t new_srca_operand_id = get_operand_id(srca_new_operand);
     std::uint32_t new_srcb_operand_id = get_operand_id(srcb_new_operand);
 
-    _llk_math_reconfig_data_format_<is_fp32_dest_acc_en, to_from_int8>(
+    _llk_math_reconfig_data_format_<is_fp32_dest_acc_en>(
         unpack_dst_format[new_srca_operand_id], unpack_dst_format[new_srcb_operand_id]);
 }
 
-template <bool is_fp32_dest_acc_en, bool to_from_int8 = false>
+template <bool is_fp32_dest_acc_en>
 inline void llk_math_reconfig_data_format(
     const std::uint32_t srca_old_operand,
     const std::uint32_t srca_new_operand,
@@ -91,33 +91,33 @@ inline void llk_math_reconfig_data_format(
 
     if ((unpack_dst_format[old_srca_operand_id] != unpack_dst_format[new_srca_operand_id]) &&
         (unpack_dst_format[old_srcb_operand_id] != unpack_dst_format[new_srcb_operand_id])) {
-        llk_math_reconfig_data_format<is_fp32_dest_acc_en, to_from_int8>(srca_new_operand, srcb_new_operand);
+        llk_math_reconfig_data_format<is_fp32_dest_acc_en>(srca_new_operand, srcb_new_operand);
     } else if ((unpack_dst_format[old_srca_operand_id] != unpack_dst_format[new_srca_operand_id])) {
-        llk_math_reconfig_data_format_srca<is_fp32_dest_acc_en, to_from_int8>(srca_new_operand);
+        llk_math_reconfig_data_format_srca<is_fp32_dest_acc_en>(srca_new_operand);
     } else if ((unpack_dst_format[old_srcb_operand_id] != unpack_dst_format[new_srcb_operand_id])) {
-        llk_math_reconfig_data_format_srcb<is_fp32_dest_acc_en, to_from_int8>(srcb_new_operand);
+        llk_math_reconfig_data_format_srcb<is_fp32_dest_acc_en>(srcb_new_operand);
     }
 }
 
-template <bool is_fp32_dest_acc_en, bool to_from_int8 = false>
+template <bool is_fp32_dest_acc_en>
 inline void llk_math_reconfig_data_format_srca(
     const std::uint32_t srca_old_operand, const std::uint32_t srca_new_operand) {
     std::uint32_t old_srca_operand_id = get_operand_id(srca_old_operand);
     std::uint32_t new_srca_operand_id = get_operand_id(srca_new_operand);
 
     if ((unpack_dst_format[old_srca_operand_id] != unpack_dst_format[new_srca_operand_id])) {
-        llk_math_reconfig_data_format_srca<is_fp32_dest_acc_en, to_from_int8>(srca_new_operand);
+        llk_math_reconfig_data_format_srca<is_fp32_dest_acc_en>(srca_new_operand);
     }
 }
 
-template <bool is_fp32_dest_acc_en, bool to_from_int8 = false>
+template <bool is_fp32_dest_acc_en>
 inline void llk_math_reconfig_data_format_srcb(
     const std::uint32_t srcb_old_operand, const std::uint32_t srcb_new_operand) {
     std::uint32_t old_srcb_operand_id = get_operand_id(srcb_old_operand);
     std::uint32_t new_srcb_operand_id = get_operand_id(srcb_new_operand);
 
     if ((unpack_dst_format[old_srcb_operand_id] != unpack_dst_format[new_srcb_operand_id])) {
-        llk_math_reconfig_data_format_srcb<is_fp32_dest_acc_en, to_from_int8>(srcb_new_operand);
+        llk_math_reconfig_data_format_srcb<is_fp32_dest_acc_en>(srcb_new_operand);
     }
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_matmul_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_matmul_api.h
@@ -30,7 +30,7 @@ inline void llk_math_matmul_init(
     const std::uint32_t in1_tile_r_dim = get_operand_tile_r_dim(in1_id);
     const std::uint32_t in1_tile_c_dim = get_operand_tile_c_dim(in1_id);
 
-    _llk_math_matmul_init_<NUM_FIDELITY_PHASES, DstTileFaceLayout::RowMajor, THROTTLE_LEVEL>(
+    _llk_math_matmul_init_<NUM_FIDELITY_PHASES, THROTTLE_LEVEL>(
         in0_tile_r_dim,
         in0_tile_c_dim,
         in1_tile_r_dim,
@@ -49,6 +49,5 @@ inline void llk_math_matmul(
     const std::uint32_t ct_dim = 1,
     const std::uint32_t rt_dim = 1,
     const std::uint32_t kt_dim = 1) {
-    _llk_math_matmul_<NUM_FIDELITY_PHASES, DstTileFaceLayout::RowMajor, THROTTLE_LEVEL>(
-        dst_index, transpose, ct_dim, rt_dim, kt_dim);
+    _llk_math_matmul_<NUM_FIDELITY_PHASES, THROTTLE_LEVEL>(dst_index, transpose, ct_dim, rt_dim, kt_dim);
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_matmul_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_matmul_api.h
@@ -42,7 +42,7 @@ inline void llk_math_matmul_init(
         kt_dim);
 }
 
-template <int NUM_FIDELITY_PHASES, int THROTTLE_LEVEL = 0, uint32_t num_faces = 4 /*not used*/>
+template <int NUM_FIDELITY_PHASES, int THROTTLE_LEVEL = 0>
 inline void llk_math_matmul(
     const uint dst_index,
     const bool transpose = false,

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h
@@ -31,110 +31,20 @@ inline void llk_pack_mop_config(const uint32_t output) {
     const bool partial_face = get_output_partial_face(output_id) && IS_BFP_FORMAT((uint)pack_dst_format[output_id]);
     const bool narrow_tile = get_output_narrow_tile(output_id);
 
-    _llk_pack_mop_config_<untilize, zero_output, false>(
+    _llk_pack_mop_config_<untilize, zero_output>(
         pack_dst_format[output_id], face_r_dim, num_faces, partial_face, narrow_tile);
 }
 
-template <bool is_fp32_dest_acc_en, bool untilize = false>
-inline void llk_pack_hw_configure(const llk_pack_params_t* pack_params) {
-    const std::uint32_t output_id = get_output_id(pack_params->pack_output);
+template <bool is_fp32_dest_acc_en>
+inline void llk_pack_hw_configure(std::uint32_t pack_output) {
+    const std::uint32_t output_id = get_output_id(pack_output);
     const std::uint32_t face_r_dim = get_output_face_r_dim(output_id);
     const std::uint32_t num_faces = get_output_num_faces(output_id);
     const bool partial_face = get_output_partial_face(output_id);
     const bool narrow_tile = get_output_narrow_tile(output_id);
 
-    _llk_pack_hw_configure_<is_fp32_dest_acc_en, untilize>(
-        pack_src_format[output_id],
-        pack_dst_format[output_id],
-        face_r_dim,
-        num_faces,
-        partial_face,
-        narrow_tile,
-        pack_params->relu_config.val);
-}
-
-template <
-    bool is_fp32_dest_acc_en,
-    bool untilize = false,
-    ReluType relu_type = ReluType::NO_RELU,
-    std::uint32_t relu_threshold = 0,
-    bool tilize = false /*unused*/>
-inline void llk_pack_hw_configure_disaggregated(std::uint32_t pack_output) {
-    llk_pack_params_t llk_pack_params = {
-        .pack_output = pack_output,
-        .relu_config = {
-            .f = {
-                .ApplyRelu = (std::uint32_t)relu_type,
-                .Threshold = relu_threshold,
-            }}};
-    llk_pack_hw_configure<is_fp32_dest_acc_en, untilize>(&llk_pack_params);
-}
-
-template <bool is_fp32_dest_acc_en, bool untilize = false>
-inline void llk_pack_untilize_hw_configure(
-    const llk_pack_params_t* pack_params, const std::uint32_t face_r_dim, const std::uint32_t num_faces) {
-    const std::uint32_t output_id = get_output_id(pack_params->pack_output);
-    const bool partial_face = get_output_partial_face(output_id);
-    const bool narrow_tile = get_output_narrow_tile(output_id);
-
-    _llk_pack_hw_configure_<is_fp32_dest_acc_en, untilize>(
-        pack_src_format[output_id],
-        pack_dst_format[output_id],
-        face_r_dim,
-        num_faces,
-        partial_face,
-        narrow_tile,
-        pack_params->relu_config.val);
-}
-
-template <
-    bool is_fp32_dest_acc_en,
-    bool untilize = false,
-    ReluType relu_type = ReluType::NO_RELU,
-    std::uint32_t relu_threshold = 0,
-    bool tilize = false /*unused*/>
-inline void llk_pack_untilize_hw_configure_disaggregated(
-    std::uint32_t pack_output, std::uint32_t face_r_dim = 16, std::uint32_t num_faces = 4) {
-    llk_pack_params_t llk_pack_params = {
-        .pack_output = pack_output,
-        .relu_config = {
-            .f = {
-                .ApplyRelu = (std::uint32_t)relu_type,
-                .Threshold = relu_threshold,
-            }}};
-    llk_pack_untilize_hw_configure<is_fp32_dest_acc_en, untilize>(&llk_pack_params, face_r_dim, num_faces);
-}
-
-template <PoolType type, ReduceDim dim, bool is_fp32_dest_acc_en, bool untilize = false>
-inline void llk_pack_reduce_hw_configure(const llk_pack_params_t* pack_params) {
-    const std::uint32_t output_id = get_output_id(pack_params->pack_output);
-    const std::uint32_t face_r_dim = get_output_face_r_dim(output_id);
-    const std::uint32_t num_faces = get_output_num_faces(output_id);
-    const bool partial_face = get_output_partial_face(output_id);
-    const bool narrow_tile = get_output_narrow_tile(output_id);
-
-    _llk_pack_reduce_hw_configure_<type, dim, is_fp32_dest_acc_en, untilize>(
-        pack_src_format[output_id],
-        pack_dst_format[output_id],
-        face_r_dim,
-        num_faces,
-        partial_face,
-        narrow_tile,
-        pack_params->relu_config.val);
-}
-
-template <
-    PoolType type,
-    ReduceDim dim,
-    bool is_fp32_dest_acc_en,
-    bool untilize = false,
-    ReluType relu_type = ReluType::NO_RELU,
-    std::uint32_t relu_threshold = 0>
-inline void llk_pack_reduce_hw_configure_disaggregated(std::uint32_t pack_output) {
-    llk_pack_params_t llk_pack_params = {
-        .pack_output = pack_output,
-        .relu_config = {.f = {.ApplyRelu = (std::uint32_t)relu_type, .Threshold = relu_threshold}}};
-    llk_pack_reduce_hw_configure<type, dim, is_fp32_dest_acc_en, untilize>(&llk_pack_params);
+    _llk_pack_hw_configure_<is_fp32_dest_acc_en>(
+        pack_src_format[output_id], pack_dst_format[output_id], face_r_dim, num_faces, partial_face, narrow_tile);
 }
 
 template <bool untilize = false, bool zero_output = false, bool tilize = false /*unused*/>
@@ -145,7 +55,7 @@ inline void llk_pack_init(const std::uint32_t pack_output = 16) {
     const bool partial_face = get_output_partial_face(output_id);
     const bool narrow_tile = get_output_narrow_tile(output_id);
 
-    _llk_pack_init_<untilize, zero_output, false>(
+    _llk_pack_init_<untilize, zero_output>(
         pack_dst_format[output_id], face_r_dim, num_faces, partial_face, narrow_tile);
 
     set_packer_l1_offset(pack_dst_format[output_id]);
@@ -280,20 +190,6 @@ inline void llk_matmul_pack(
  * LLK PACK FAST TILIZE
  *************************************************************************/
 
-template <bool is_fp32_dest_acc_en>
-inline void llk_pack_fast_tilize_hw_configure(const llk_pack_params_t* pack_params) {
-    const std::uint32_t output_id = get_output_id(pack_params->pack_output);
-
-    _llk_pack_fast_tilize_hw_configure_<is_fp32_dest_acc_en>(pack_src_format[output_id], pack_dst_format[output_id]);
-}
-
-template <bool is_fp32_dest_acc_en>
-inline void llk_pack_fast_tilize_hw_configure_disaggregated(const std::uint32_t pack_output) {
-    const llk_pack_params_t llk_pack_params = {.pack_output = pack_output};
-
-    llk_pack_fast_tilize_hw_configure<is_fp32_dest_acc_en>(&llk_pack_params);
-}
-
 inline void llk_pack_fast_tilize_init(
     const std::uint32_t input_operand, const std::uint32_t pack_output, const std::uint32_t unit_dim) {
     const std::uint8_t input_id = get_output_id(input_operand);
@@ -353,13 +249,13 @@ inline void llk_init_packer_dest_offset_registers(const std::uint32_t pack_outpu
     _llk_init_packer_dest_offset_registers_<DST_SYNC_MODE, untilize>(face_r_dim, narrow_tile);
 }
 
-template <bool is_fp32_dest_acc_en, bool untilize = false>
+template <bool is_fp32_dest_acc_en>
 inline void llk_pack_dest_init(const std::uint32_t pack_output = 16) {
     const std::uint32_t output_id = get_output_id(pack_output);
     const std::uint32_t face_r_dim = get_output_face_r_dim(output_id);
     const bool narrow_tile = get_output_narrow_tile(output_id);
 
-    _llk_pack_dest_init_<DST_SYNC_MODE, is_fp32_dest_acc_en, untilize>(face_r_dim, narrow_tile);
+    _llk_pack_dest_init_<DST_SYNC_MODE, is_fp32_dest_acc_en>(face_r_dim, narrow_tile);
 }
 
 template <bool mail2math = true, bool mail2pack = true>
@@ -376,22 +272,20 @@ inline void llk_pack_debug_dump(std::uint8_t* data, std::uint32_t byte_size) { _
 
 inline void llk_pack_debug_dump_seek(std::uint8_t offset) { _llk_pack_debug_dump_seek_(offset); }
 
-template <bool is_fp32_dest_acc_en, bool is_tile_dim_reconfig_en = false>
+template <bool is_fp32_dest_acc_en>
 inline void llk_pack_reconfig_data_format(const std::uint32_t new_output) {
     const std::uint32_t output_id = get_output_id(new_output);
     const std::uint32_t face_r_dim = get_output_face_r_dim(output_id);
     const std::uint32_t num_faces = get_output_num_faces(output_id);
     const bool partial_face = get_output_partial_face(output_id);
-    const bool narrow_tile = get_output_narrow_tile(output_id);
 
-    _llk_pack_reconfig_data_format_<is_fp32_dest_acc_en, is_tile_dim_reconfig_en>(
+    _llk_pack_reconfig_data_format_<is_fp32_dest_acc_en>(
         pack_src_format[output_id],
         pack_dst_format[output_id],
         get_local_cb_interface(output_id).fifo_page_size,
         face_r_dim,
         num_faces,
-        partial_face,
-        narrow_tile);
+        partial_face);
 }
 
 template <bool is_fp32_dest_acc_en, bool is_tile_dim_reconfig_en = false>
@@ -419,36 +313,3 @@ inline void llk_pack_reduce_mask_config() {
 }
 
 inline void llk_pack_reduce_mask_clear() { _llk_pack_reduce_mask_clear_(); }
-
-// FIXME-WH-UPLIFT
-template <ReduceDim dim, bool is_fp32_dest_acc_en, bool at_kernel_start = false, bool revert = false>
-inline void llk_pack_reduce_config_v2(uint32_t icb_out) {
-    const bool untilize = false;
-    if constexpr (at_kernel_start) {
-        const std::uint32_t output_id = get_output_id(icb_out);
-        const std::uint32_t face_r_dim = get_output_face_r_dim(output_id);
-        const std::uint32_t num_faces = get_output_num_faces(output_id);
-        const bool partial_face = get_output_partial_face(output_id);
-        const bool narrow_tile = get_output_narrow_tile(output_id);
-        const llk_relu_config_u relu_config = {
-            .f = {
-                .ApplyRelu = (std::uint32_t)ReluType::NO_RELU,
-                .Threshold = 0,
-            }};
-
-        _llk_pack_hw_configure_<is_fp32_dest_acc_en, untilize>(
-            pack_src_format[output_id],
-            pack_dst_format[output_id],
-            face_r_dim,
-            num_faces,
-            partial_face,
-            narrow_tile,
-            relu_config.val);
-    }
-
-    if constexpr (revert) {
-        _llk_pack_reduce_mask_clear_();
-    } else {
-        _llk_pack_reduce_mask_config_<untilize, dim>();
-    }
-}

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h
@@ -280,15 +280,10 @@ inline void llk_pack_reconfig_data_format(const std::uint32_t new_output) {
     const bool partial_face = get_output_partial_face(output_id);
 
     _llk_pack_reconfig_data_format_<is_fp32_dest_acc_en>(
-        pack_src_format[output_id],
-        pack_dst_format[output_id],
-        get_local_cb_interface(output_id).fifo_page_size,
-        face_r_dim,
-        num_faces,
-        partial_face);
+        pack_src_format[output_id], pack_dst_format[output_id], face_r_dim, num_faces, partial_face);
 }
 
-template <bool is_fp32_dest_acc_en, bool is_tile_dim_reconfig_en = false>
+template <bool is_fp32_dest_acc_en>
 inline void llk_pack_reconfig_data_format(const std::uint32_t old_output, const std::uint32_t new_output) {
     std::uint32_t old_output_id = get_output_id(old_output);
     std::uint32_t new_output_id = get_output_id(new_output);
@@ -296,10 +291,7 @@ inline void llk_pack_reconfig_data_format(const std::uint32_t old_output, const 
     if ((pack_dst_format[old_output_id] != pack_dst_format[new_output_id]) &&
         (pack_dst_format[old_output_id] != (uint)DataFormat::Invalid) &&
         (pack_dst_format[new_output_id] != (uint)DataFormat::Invalid)) {
-        llk_pack_reconfig_data_format<is_fp32_dest_acc_en, is_tile_dim_reconfig_en>(new_output);
-    } else if constexpr (is_tile_dim_reconfig_en) {
-        // Same format but different tile dims
-        llk_pack_mop_config<false, false>(new_output);
+        llk_pack_reconfig_data_format<is_fp32_dest_acc_en>(new_output);
     }
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h
@@ -31,7 +31,7 @@ inline void llk_pack_mop_config(const uint32_t output) {
     const bool partial_face = get_output_partial_face(output_id) && IS_BFP_FORMAT((uint)pack_dst_format[output_id]);
     const bool narrow_tile = get_output_narrow_tile(output_id);
 
-    _llk_pack_mop_config_<untilize, zero_output, DstTileFaceLayout::RowMajor, false>(
+    _llk_pack_mop_config_<untilize, zero_output, false>(
         pack_dst_format[output_id], face_r_dim, num_faces, partial_face, narrow_tile);
 }
 
@@ -43,12 +43,9 @@ inline void llk_pack_hw_configure(const llk_pack_params_t* pack_params) {
     const bool partial_face = get_output_partial_face(output_id);
     const bool narrow_tile = get_output_narrow_tile(output_id);
 
-    const std::uint32_t tile_size = get_local_cb_interface(output_id).fifo_page_size;
-
     _llk_pack_hw_configure_<is_fp32_dest_acc_en, untilize>(
         pack_src_format[output_id],
         pack_dst_format[output_id],
-        tile_size,
         face_r_dim,
         num_faces,
         partial_face,
@@ -80,12 +77,9 @@ inline void llk_pack_untilize_hw_configure(
     const bool partial_face = get_output_partial_face(output_id);
     const bool narrow_tile = get_output_narrow_tile(output_id);
 
-    const std::uint32_t tile_size = get_local_cb_interface(output_id).fifo_page_size;
-
     _llk_pack_hw_configure_<is_fp32_dest_acc_en, untilize>(
         pack_src_format[output_id],
         pack_dst_format[output_id],
-        tile_size,
         face_r_dim,
         num_faces,
         partial_face,
@@ -119,12 +113,9 @@ inline void llk_pack_reduce_hw_configure(const llk_pack_params_t* pack_params) {
     const bool partial_face = get_output_partial_face(output_id);
     const bool narrow_tile = get_output_narrow_tile(output_id);
 
-    const std::uint32_t tile_size = get_local_cb_interface(output_id).fifo_page_size;
-
     _llk_pack_reduce_hw_configure_<type, dim, is_fp32_dest_acc_en, untilize>(
         pack_src_format[output_id],
         pack_dst_format[output_id],
-        tile_size,
         face_r_dim,
         num_faces,
         partial_face,
@@ -154,7 +145,7 @@ inline void llk_pack_init(const std::uint32_t pack_output = 16) {
     const bool partial_face = get_output_partial_face(output_id);
     const bool narrow_tile = get_output_narrow_tile(output_id);
 
-    _llk_pack_init_<untilize, zero_output, DstTileFaceLayout::RowMajor, false>(
+    _llk_pack_init_<untilize, zero_output, false>(
         pack_dst_format[output_id], face_r_dim, num_faces, partial_face, narrow_tile);
 
     set_packer_l1_offset(pack_dst_format[output_id]);
@@ -220,20 +211,17 @@ inline void llk_pack(std::uint32_t tile_index, std::uint32_t output, std::uint32
 template <
     std::uint32_t block_ct_dim = 8,
     std::uint32_t full_ct_dim = block_ct_dim,
-    bool diagonal = false,
     bool narrow_row = false,
     std::uint32_t row_num_datums = TILE_C_DIM>
 inline void llk_pack_untilize_init(
     std::uint32_t output, const std::uint32_t face_r_dim = FACE_R_DIM, const std::uint32_t num_faces = 4) {
     const std::uint32_t output_id = get_output_id(output);
 
-    _llk_pack_untilize_init_<block_ct_dim, full_ct_dim, diagonal, narrow_row, row_num_datums>(
+    _llk_pack_untilize_init_<block_ct_dim, full_ct_dim, narrow_row, row_num_datums>(
         pack_dst_format[output_id], face_r_dim, num_faces);
 
     // Pack row by row
-    if constexpr (diagonal) {
-        TT_SETADCXX(p_setadc::PAC, 1 - 1, 0x0);
-    } else if constexpr (narrow_row) {
+    if constexpr (narrow_row) {
         TT_SETADCXX(p_setadc::PAC, row_num_datums - 1, 0x0);
     } else {
         TT_SETADCXX(p_setadc::PAC, FACE_C_DIM - 1, 0x0);
@@ -243,7 +231,6 @@ inline void llk_pack_untilize_init(
 template <
     std::uint32_t block_ct_dim = 8,
     std::uint32_t full_ct_dim = block_ct_dim,
-    bool diagonal = false,
     bool narrow_row = false,
     std::uint32_t row_num_datums = TILE_C_DIM,
     uint32_t tile_dst_ct_offset = 0>
@@ -263,7 +250,7 @@ inline void llk_pack_untilize(
             16;
 
     for (std::uint32_t block_rt = 0; block_rt < block_rt_dim; block_rt++) {
-        _llk_pack_untilize_<block_ct_dim, full_ct_dim, diagonal, narrow_row, row_num_datums, tile_dst_ct_offset>(
+        _llk_pack_untilize_<block_ct_dim, full_ct_dim, narrow_row, row_num_datums, tile_dst_ct_offset>(
             pack_tile_addr,
             pack_dst_format[output_id],
             face_r_dim,
@@ -357,14 +344,13 @@ inline void llk_pack_dest_section_done() {
     _llk_pack_dest_section_done_<DST_SYNC_MODE, is_fp32_dest_acc_en>();
 }
 
-template <bool untilize = false, bool diagonal = false>
+template <bool untilize = false>
 inline void llk_init_packer_dest_offset_registers(const std::uint32_t pack_output = 16) {
     const std::uint32_t output_id = get_output_id(pack_output);
     const std::uint32_t face_r_dim = get_output_face_r_dim(output_id);
     const bool narrow_tile = get_output_narrow_tile(output_id);
 
-    _llk_init_packer_dest_offset_registers_<DST_SYNC_MODE, DstTileFaceLayout::RowMajor, untilize, diagonal>(
-        face_r_dim, narrow_tile);
+    _llk_init_packer_dest_offset_registers_<DST_SYNC_MODE, untilize>(face_r_dim, narrow_tile);
 }
 
 template <bool is_fp32_dest_acc_en, bool untilize = false>
@@ -373,8 +359,7 @@ inline void llk_pack_dest_init(const std::uint32_t pack_output = 16) {
     const std::uint32_t face_r_dim = get_output_face_r_dim(output_id);
     const bool narrow_tile = get_output_narrow_tile(output_id);
 
-    _llk_pack_dest_init_<DST_SYNC_MODE, is_fp32_dest_acc_en, DstTileFaceLayout::RowMajor, untilize>(
-        face_r_dim, narrow_tile);
+    _llk_pack_dest_init_<DST_SYNC_MODE, is_fp32_dest_acc_en, untilize>(face_r_dim, narrow_tile);
 }
 
 template <bool mail2math = true, bool mail2pack = true>
@@ -399,7 +384,7 @@ inline void llk_pack_reconfig_data_format(const std::uint32_t new_output) {
     const bool partial_face = get_output_partial_face(output_id);
     const bool narrow_tile = get_output_narrow_tile(output_id);
 
-    _llk_pack_reconfig_data_format_<is_fp32_dest_acc_en, is_tile_dim_reconfig_en, DstTileFaceLayout::RowMajor>(
+    _llk_pack_reconfig_data_format_<is_fp32_dest_acc_en, is_tile_dim_reconfig_en>(
         pack_src_format[output_id],
         pack_dst_format[output_id],
         get_local_cb_interface(output_id).fifo_page_size,
@@ -445,7 +430,6 @@ inline void llk_pack_reduce_config_v2(uint32_t icb_out) {
         const std::uint32_t num_faces = get_output_num_faces(output_id);
         const bool partial_face = get_output_partial_face(output_id);
         const bool narrow_tile = get_output_narrow_tile(output_id);
-        const std::uint32_t tile_size = get_local_cb_interface(output_id).fifo_page_size;
         const llk_relu_config_u relu_config = {
             .f = {
                 .ApplyRelu = (std::uint32_t)ReluType::NO_RELU,
@@ -455,7 +439,6 @@ inline void llk_pack_reduce_config_v2(uint32_t icb_out) {
         _llk_pack_hw_configure_<is_fp32_dest_acc_en, untilize>(
             pack_src_format[output_id],
             pack_dst_format[output_id],
-            tile_size,
             face_r_dim,
             num_faces,
             partial_face,

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_param_structs.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_param_structs.h
@@ -22,46 +22,6 @@ struct llk_unpack_AB_matmul_params_t {
     std::uint32_t transpose_xy_srca;
 };
 
-struct llk_unpack_AB_params_t {
-    std::uint32_t unpA_operand;
-    std::uint32_t unpB_operand;
-};
-
-struct llk_unpack_reduce_params_t {
-    std::uint32_t unpA_operand;
-    // std::uint32_t unpB_operand;  // TODO: Should be removed when llk hw args are cleaned up
-};
-
-struct llk_unpack_tilize_params_t {
-    std::uint32_t unpA_operand;
-    std::uint32_t unpA_block_c_dim;
-};
-
-struct llk_unpack_untilize_params_t {
-    std::uint32_t unpA_operand;
-};
-
-//***
-//  Math LLK param structs
-//***
-
-struct llk_math_eltwise_binary_params_t {
-    std::int32_t unused;
-};
-
-struct llk_math_eltwise_unary_params_t {
-    std::int32_t sfpu_params[6];  // TODO: Fix how we assign this from hlkc
-    std::int32_t unused;
-};
-
-struct llk_math_matmul_params_t {
-    std::int32_t unused;
-};
-
-struct llk_math_reduce_params_t {
-    std::int32_t unused;
-};
-
 //***
 //  Pack LLK param structs
 //***

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_AB_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_AB_api.h
@@ -10,35 +10,25 @@
  * LLK UNPACK AB
  *************************************************************************/
 
-template <bool is_fp32_dest_acc_en, StochRndType stoch_rnd_mode = StochRndType::None>
-inline void llk_unpack_AB_hw_configure(
-    const llk_unpack_AB_params_t* unpack_AB_params, const int within_face_16x16_transpose = 0) {
+template <bool is_fp32_dest_acc_en>
+inline void llk_unpack_hw_configure(const std::uint32_t unpA_operand, const std::uint32_t unpB_operand) {
     // In0 -> unpA
     // In1 -> unpB
-    const uint32_t unpA_operand_id = get_operand_id(unpack_AB_params->unpA_operand);
-    const uint32_t unpB_operand_id = get_operand_id(unpack_AB_params->unpB_operand);
+    const uint32_t unpA_operand_id = get_operand_id(unpA_operand);
+    const uint32_t unpB_operand_id = get_operand_id(unpB_operand);
 
     // unpA -> srcA
     // unpB -> srcB
     const uint32_t num_faces = get_operand_num_faces(unpA_operand_id);    // num faces in unpA and unpB are the same
     const uint32_t face_r_dim = get_operand_face_r_dim(unpA_operand_id);  // face r dim in unpA and unpB are the same
 
-    _llk_unpack_AB_hw_configure_<is_fp32_dest_acc_en, stoch_rnd_mode>(
+    _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
         unpack_src_format[unpA_operand_id],
         unpack_src_format[unpB_operand_id],
         unpack_dst_format[unpA_operand_id],
         unpack_dst_format[unpB_operand_id],
         face_r_dim,
-        within_face_16x16_transpose,
         num_faces);
-}
-
-template <bool is_fp32_dest_acc_en, StochRndType stoch_rnd_mode = StochRndType::None>
-inline void llk_unpack_AB_hw_configure_disaggregated(
-    const std::uint32_t unpA_operand, const std::uint32_t unpB_operand, const int within_face_16x16_transpose = 0) {
-    const llk_unpack_AB_params_t unpack_AB_params = {.unpA_operand = unpA_operand, .unpB_operand = unpB_operand};
-
-    llk_unpack_AB_hw_configure<is_fp32_dest_acc_en, stoch_rnd_mode>(&unpack_AB_params, within_face_16x16_transpose);
 }
 
 template <BroadcastType BType = BroadcastType::NONE>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_AB_matmul_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_AB_matmul_api.h
@@ -55,7 +55,9 @@ __attribute__((always_inline)) inline void llk_unpack_AB_matmul_init(
         unpA_num_faces,
         unpB_num_faces,
         partial_face_a,
-        partial_face_b);
+        partial_face_b,
+        get_local_cb_interface(operandA_id).fifo_page_size,
+        get_local_cb_interface(operandB_id).fifo_page_size);
 }
 
 inline void llk_unpack_AB_matmul(

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_AB_matmul_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_AB_matmul_api.h
@@ -10,45 +10,6 @@
  * LLK UNPACK AB MATMUL
  *************************************************************************/
 
-template <bool is_fp32_dest_acc_en, StochRndType stoch_rnd_mode = StochRndType::None>
-inline void llk_unpack_AB_matmul_hw_configure(const llk_unpack_AB_matmul_params_t* unpack_AB_params) {
-    const bool transpose_xy_srca = unpack_AB_params->transpose_xy_srca;
-
-    // In0 -> unpB
-    // In1 -> unpA
-    const uint32_t unpA_operand_id = get_operand_id(unpack_AB_params->unpB_operand);
-    const uint32_t unpB_operand_id = get_operand_id(unpack_AB_params->unpA_operand);
-
-    // unpA -> srcA
-    // unpB -> srcB
-    const uint32_t unpA_num_faces = get_operand_num_faces(unpA_operand_id);
-    const uint32_t unpB_num_faces = get_operand_num_faces(unpB_operand_id);
-
-    const uint32_t unpA_face_r_dim = get_operand_face_r_dim(unpA_operand_id);
-    const uint32_t unpB_face_r_dim = get_operand_face_r_dim(unpB_operand_id);
-
-    _llk_unpack_AB_matmul_hw_configure_<is_fp32_dest_acc_en, stoch_rnd_mode>(
-        unpack_src_format[unpA_operand_id],
-        unpack_src_format[unpB_operand_id],
-        unpack_dst_format[unpA_operand_id],
-        unpack_dst_format[unpB_operand_id],
-        unpA_face_r_dim,
-        unpB_face_r_dim,
-        transpose_xy_srca,
-        unpA_num_faces,
-        unpB_num_faces,
-        get_local_cb_interface(unpA_operand_id).fifo_page_size,
-        get_local_cb_interface(unpB_operand_id).fifo_page_size);
-}
-
-template <bool is_fp32_dest_acc_en, StochRndType stoch_rnd_mode = StochRndType::None>
-inline void llk_unpack_AB_matmul_hw_configure_disaggregated(
-    const std::uint32_t unpA_operand, const std::uint32_t unpB_operand, const std::uint32_t transpose_xy_srca = 0) {
-    const llk_unpack_AB_matmul_params_t unpack_AB_matmul_params = {
-        .unpA_operand = unpA_operand, .unpB_operand = unpB_operand, .transpose_xy_srca = transpose_xy_srca};
-    llk_unpack_AB_matmul_hw_configure<is_fp32_dest_acc_en, stoch_rnd_mode>(&unpack_AB_matmul_params);
-}
-
 inline void llk_unpack_AB_matmul_mop_config(
     const bool transpose,
     const std::uint32_t ct_dim,

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_A_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_A_api.h
@@ -11,35 +11,6 @@
  *************************************************************************/
 
 template <
-    bool is_fp32_dest_acc_en,
-    StochRndType stoch_rnd_mode = StochRndType::None,
-    bool disable_src_zero_flag = false>
-inline void llk_unpack_A_hw_configure(
-    const llk_unpack_A_params_t* unpack_A_params, const int within_face_16x16_transpose = 0) {
-    const uint32_t unpA_operand_id = get_operand_id(unpack_A_params->unpA_operand);
-    const uint32_t unpA_num_faces = get_operand_num_faces(unpA_operand_id);
-    const uint32_t unpA_face_r_dim = get_operand_face_r_dim(unpA_operand_id);
-
-    _llk_unpack_A_hw_configure_<is_fp32_dest_acc_en, stoch_rnd_mode, disable_src_zero_flag>(
-        unpack_src_format[unpA_operand_id],
-        unpack_dst_format[unpA_operand_id],
-        unpA_face_r_dim,
-        within_face_16x16_transpose,
-        unpA_num_faces);
-}
-
-template <
-    bool is_fp32_dest_acc_en,
-    StochRndType stoch_rnd_mode = StochRndType::None,
-    bool disable_src_zero_flag = false>
-inline void llk_unpack_A_hw_configure_disaggregated(
-    const std::uint32_t unpA_operand, const int within_face_16x16_transpose = 0) {
-    const llk_unpack_A_params_t unpack_A_params = {.unpA_operand = unpA_operand};
-    llk_unpack_A_hw_configure<is_fp32_dest_acc_en, stoch_rnd_mode, disable_src_zero_flag>(
-        &unpack_A_params, within_face_16x16_transpose);
-}
-
-template <
     BroadcastType BType = BroadcastType::NONE,
     bool acc_to_dest = false,
     EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE,

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_common_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_common_api.h
@@ -117,6 +117,10 @@ inline void llk_enable_int8_fpu_math() { _llk_enable_int8_fpu_math_(); }
 
 inline void llk_unpack_set_srcb_dummy_valid() { _llk_unpack_set_srcb_dummy_valid_(); }
 
+inline void llk_unpack_disable_src_zero_flag(bool disable_src_zero_flag) {
+    _llk_unpack_disable_src_zero_flag_(disable_src_zero_flag);
+}
+
 // All TILE_SIZE related functions were deprecared in BBE for WH.  The following is needed for pack_shifted so just
 // keeping here.
 // FIXME: Need to review and adjust accordingly

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_common_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_common_api.h
@@ -59,9 +59,7 @@ inline void llk_unpack_reconfig_data_format_srca(const std::uint32_t srca_new_op
     const std::uint32_t num_faces = get_operand_num_faces(srca_operand_id);
     const std::uint32_t face_r_dim = get_operand_face_r_dim(srca_operand_id);
     _llk_unpack_reconfig_data_format_srca_impl_<is_fp32_dest_acc_en>(
-        unpack_src_format[srca_operand_id],
-        unpack_dst_format[srca_operand_id],
-        get_local_cb_interface(srca_operand_id).fifo_page_size);
+        unpack_src_format[srca_operand_id], unpack_dst_format[srca_operand_id]);
 }
 
 template <bool is_fp32_dest_acc_en>
@@ -70,9 +68,7 @@ inline void llk_unpack_reconfig_data_format_srcb(const std::uint32_t srcb_new_op
     const std::uint32_t num_faces = get_operand_num_faces(srcb_operand_id);
     const std::uint32_t face_r_dim = get_operand_face_r_dim(srcb_operand_id);
     _llk_unpack_reconfig_data_format_srcb_impl_<is_fp32_dest_acc_en>(
-        unpack_src_format[srcb_operand_id],
-        unpack_dst_format[srcb_operand_id],
-        get_local_cb_interface(srcb_operand_id).fifo_page_size);
+        unpack_src_format[srcb_operand_id], unpack_dst_format[srcb_operand_id]);
 }
 
 template <bool is_fp32_dest_acc_en>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_common_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_common_api.h
@@ -53,75 +53,65 @@ inline void llk_unpack_debug_dump(std::uint8_t* data, std::uint32_t byte_size) {
 
 inline void llk_unpack_debug_dump_seek(std::uint8_t offset) { _llk_unpack_debug_dump_seek_(offset); }
 
-template <bool is_fp32_dest_acc_en, bool to_from_int8 = false, bool is_tile_dim_reconfig_en = false>
+template <bool is_fp32_dest_acc_ene>
 inline void llk_unpack_reconfig_data_format_srca(const std::uint32_t srca_new_operand) {
     const std::uint32_t srca_operand_id = get_operand_id(srca_new_operand);
     const std::uint32_t num_faces = get_operand_num_faces(srca_operand_id);
     const std::uint32_t face_r_dim = get_operand_face_r_dim(srca_operand_id);
-    _llk_unpack_reconfig_data_format_srca_impl_<is_fp32_dest_acc_en, to_from_int8>(
+    _llk_unpack_reconfig_data_format_srca_impl_<is_fp32_dest_acc_en>(
         unpack_src_format[srca_operand_id],
         unpack_dst_format[srca_operand_id],
         get_local_cb_interface(srca_operand_id).fifo_page_size);
 }
 
-template <bool is_fp32_dest_acc_en, bool to_from_int8 = false, bool is_tile_dim_reconfig_en = false>
+template <bool is_fp32_dest_acc_en>
 inline void llk_unpack_reconfig_data_format_srcb(const std::uint32_t srcb_new_operand) {
     std::uint32_t srcb_operand_id = get_operand_id(srcb_new_operand);
     const std::uint32_t num_faces = get_operand_num_faces(srcb_operand_id);
     const std::uint32_t face_r_dim = get_operand_face_r_dim(srcb_operand_id);
-    _llk_unpack_reconfig_data_format_srcb_impl_<is_fp32_dest_acc_en, to_from_int8>(
+    _llk_unpack_reconfig_data_format_srcb_impl_<is_fp32_dest_acc_en>(
         unpack_src_format[srcb_operand_id],
         unpack_dst_format[srcb_operand_id],
         get_local_cb_interface(srcb_operand_id).fifo_page_size);
 }
 
-template <bool is_fp32_dest_acc_en, bool to_from_int8 = false, bool is_tile_dim_reconfig_en = false>
+template <bool is_fp32_dest_acc_en>
 inline void llk_unpack_reconfig_data_format_srca(
     const std::uint32_t srca_old_operand, const std::uint32_t srca_new_operand) {
     std::uint32_t old_srca_operand_id = get_operand_id(srca_old_operand);
     std::uint32_t new_srca_operand_id = get_operand_id(srca_new_operand);
 
     if (should_reconfigure_cbs(srca_old_operand, srca_new_operand)) {
-        llk_unpack_reconfig_data_format_srca<is_fp32_dest_acc_en, to_from_int8, is_tile_dim_reconfig_en>(
-            srca_new_operand);
-    } else if constexpr (is_tile_dim_reconfig_en) {
-        llk_unpack_reconfig_data_format_srca<is_fp32_dest_acc_en, to_from_int8, is_tile_dim_reconfig_en>(
-            srca_new_operand);
+        llk_unpack_reconfig_data_format_srca<is_fp32_dest_acc_en>(srca_new_operand);
     }
 }
 
-template <bool is_fp32_dest_acc_en, bool to_from_int8 = false, bool is_tile_dim_reconfig_en = false>
+template <bool is_fp32_dest_acc_en>
 inline void llk_unpack_reconfig_data_format_srcb(
     const std::uint32_t srcb_old_operand, const std::uint32_t srcb_new_operand) {
     std::uint32_t old_srcb_operand_id = get_operand_id(srcb_old_operand);
     std::uint32_t new_srcb_operand_id = get_operand_id(srcb_new_operand);
 
     if (should_reconfigure_cbs(srcb_old_operand, srcb_new_operand)) {
-        llk_unpack_reconfig_data_format_srcb<is_fp32_dest_acc_en, to_from_int8, is_tile_dim_reconfig_en>(
-            srcb_new_operand);
-    } else if constexpr (is_tile_dim_reconfig_en) {
-        llk_unpack_reconfig_data_format_srcb<is_fp32_dest_acc_en, to_from_int8, is_tile_dim_reconfig_en>(
-            srcb_new_operand);
+        llk_unpack_reconfig_data_format_srcb<is_fp32_dest_acc_en>(srcb_new_operand);
     }
 }
 
-template <bool is_fp32_dest_acc_en, bool to_from_int8 = false, bool is_tile_dim_reconfig_en = false>
+template <bool is_fp32_dest_acc_en>
 inline void llk_unpack_reconfig_data_format(
     const std::uint32_t srca_new_operand, const std::uint32_t srcb_new_operand) {
-    llk_unpack_reconfig_data_format_srca<is_fp32_dest_acc_en, to_from_int8, is_tile_dim_reconfig_en>(srca_new_operand);
-    llk_unpack_reconfig_data_format_srcb<is_fp32_dest_acc_en, to_from_int8, is_tile_dim_reconfig_en>(srcb_new_operand);
+    llk_unpack_reconfig_data_format_srca<is_fp32_dest_acc_en>(srca_new_operand);
+    llk_unpack_reconfig_data_format_srcb<is_fp32_dest_acc_en>(srcb_new_operand);
 }
 
-template <bool is_fp32_dest_acc_en, bool to_from_int8 = false, bool is_tile_dim_reconfig_en = false>
+template <bool is_fp32_dest_acc_en>
 inline void llk_unpack_reconfig_data_format(
     const std::uint32_t srca_old_operand,
     const std::uint32_t srca_new_operand,
     const std::uint32_t srcb_old_operand,
     const std::uint32_t srcb_new_operand) {
-    llk_unpack_reconfig_data_format_srca<is_fp32_dest_acc_en, to_from_int8, is_tile_dim_reconfig_en>(
-        srca_old_operand, srca_new_operand);
-    llk_unpack_reconfig_data_format_srcb<is_fp32_dest_acc_en, to_from_int8, is_tile_dim_reconfig_en>(
-        srcb_old_operand, srcb_new_operand);
+    llk_unpack_reconfig_data_format_srca<is_fp32_dest_acc_en>(srca_old_operand, srca_new_operand);
+    llk_unpack_reconfig_data_format_srcb<is_fp32_dest_acc_en>(srcb_old_operand, srcb_new_operand);
 }
 
 inline void llk_unpack_dbg_feature_disable() { _llk_unpack_dbg_feature_disable_(); }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_common_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_common_api.h
@@ -53,7 +53,7 @@ inline void llk_unpack_debug_dump(std::uint8_t* data, std::uint32_t byte_size) {
 
 inline void llk_unpack_debug_dump_seek(std::uint8_t offset) { _llk_unpack_debug_dump_seek_(offset); }
 
-template <bool is_fp32_dest_acc_ene>
+template <bool is_fp32_dest_acc_en>
 inline void llk_unpack_reconfig_data_format_srca(const std::uint32_t srca_new_operand) {
     const std::uint32_t srca_operand_id = get_operand_id(srca_new_operand);
     const std::uint32_t num_faces = get_operand_num_faces(srca_operand_id);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_reduce_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_reduce_api.h
@@ -10,49 +10,6 @@
  * LLK UNPACK REDUCE
  *************************************************************************/
 
-template <
-    PoolType type,
-    ReduceDim dim,
-    bool is_fp32_dest_acc_en,
-    StochRndType stoch_rnd_mode = StochRndType::None>
-inline void llk_unpack_reduce_hw_configure(
-    const llk_unpack_reduce_params_t* unpack_reduce_params, const float const_mult) {
-    constexpr bool within_face_16x16_transpose = (ReduceDim::REDUCE_ROW == dim);
-
-    const std::uint32_t unpA_operand_id = get_operand_id(unpack_reduce_params->unpA_operand);
-    const std::uint32_t unpA_num_faces = get_operand_num_faces(unpA_operand_id);
-    const std::uint32_t unpA_face_r_dim = get_operand_face_r_dim(unpA_operand_id);
-
-    constexpr std::uint32_t unpB_src_format = (std::uint32_t)DataFormat::Float32;
-    const std::uint32_t unpB_dst_format =
-        ((std::uint32_t)unpack_dst_format[unpA_operand_id] == (std::uint32_t)DataFormat::Int8)
-            ? (std::uint32_t)DataFormat::Float16
-            :  // Int8 is treated as fp16_a
-            ((((std::uint32_t)unpack_dst_format[unpA_operand_id] >> 2) & 0x1) ? (std::uint32_t)DataFormat::Float16_b
-                                                                              : (std::uint32_t)DataFormat::Float16);
-
-    _llk_unpack_reduce_hw_configure_<is_fp32_dest_acc_en, stoch_rnd_mode>(
-        unpack_src_format[unpA_operand_id],
-        unpB_src_format,
-        unpack_dst_format[unpA_operand_id],
-        unpB_dst_format,
-        unpA_face_r_dim,
-        unpA_face_r_dim,
-        within_face_16x16_transpose,
-        unpA_num_faces,
-        unpA_num_faces);
-}
-
-template <
-    PoolType type,
-    ReduceDim dim,
-    bool is_fp32_dest_acc_en,
-    StochRndType stoch_rnd_mode = StochRndType::None>
-inline void llk_unpack_reduce_hw_configure_disaggregated(const std::uint32_t unpA_operand, const float mult) {
-    const llk_unpack_reduce_params_t unpack_reduce_params = {.unpA_operand = unpA_operand};
-    llk_unpack_reduce_hw_configure<type, dim, is_fp32_dest_acc_en, stoch_rnd_mode>(&unpack_reduce_params, mult);
-}
-
 template <PoolType type, ReduceDim dim>
 inline void llk_unpack_reduce_mop_config() {
     _llk_unpack_reduce_mop_config_<type, dim>();

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_tilize_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_tilize_api.h
@@ -11,29 +11,6 @@
  * LLK UNPACK TILIZE
  *************************************************************************/
 
-template <bool is_fp32_dest_acc_en>
-inline void llk_unpack_tilize_hw_configure(const llk_unpack_A_params_t* unpack_tilize_params) {
-    constexpr bool within_face_16x16_transpose = false;
-    constexpr StochRndType stoch_rnd_mode = StochRndType::None;
-
-    const uint32_t unpA_operand_id = get_operand_id(unpack_tilize_params->unpA_operand);
-    const uint32_t unpA_num_faces = get_operand_num_faces(unpA_operand_id);
-    const uint32_t unpA_face_r_dim = get_operand_face_r_dim(unpA_operand_id);
-
-    _llk_unpack_tilize_hw_configure_<is_fp32_dest_acc_en, stoch_rnd_mode>(
-        unpack_src_format[unpA_operand_id],
-        unpack_dst_format[unpA_operand_id],
-        unpA_face_r_dim,
-        within_face_16x16_transpose,
-        unpA_num_faces);
-}
-
-template <bool is_fp32_dest_acc_en>
-inline void llk_unpack_tilize_hw_configure_disaggregated(const std::uint32_t unpA_operand) {
-    const llk_unpack_A_params_t unpack_tilize_params = {.unpA_operand = unpA_operand};
-    llk_unpack_tilize_hw_configure<is_fp32_dest_acc_en>(&unpack_tilize_params);
-}
-
 inline void llk_unpack_tilize_mop_config(const std::uint32_t operand) {
     std::uint32_t operand_id = get_operand_id(operand);
     const bool narrow_tile = get_operand_narrow_tile(operand_id);
@@ -108,38 +85,6 @@ inline void llk_unpack_tilize_block(
 /*************************************************************************
  * LLK UNPACK TILIZE SRC A, UNPACK SRC B
  *************************************************************************/
-
-template <bool is_fp32_dest_acc_en, StochRndType stoch_rnd_mode = StochRndType::None>
-inline void llk_unpack_tilizeA_B_hw_configure(
-    const llk_unpack_AB_params_t* unpack_tilizeA_B_params, const int within_face_16x16_transpose = 0) {
-    // In0 -> unpA
-    // In1 -> unpB
-    const uint32_t unpA_operand_id = get_operand_id(unpack_tilizeA_B_params->unpA_operand);
-    const uint32_t unpB_operand_id = get_operand_id(unpack_tilizeA_B_params->unpB_operand);
-
-    // unpA -> srcA
-    // unpB -> srcB
-    const uint32_t num_faces = get_operand_num_faces(unpA_operand_id);  // num faces in unpA and unpB are the same
-
-    const uint32_t face_r_dim = get_operand_face_r_dim(unpA_operand_id);  // face r dim in unpA and unpB are the same
-
-    _llk_unpack_AB_hw_configure_<is_fp32_dest_acc_en, stoch_rnd_mode>(
-        unpack_src_format[unpA_operand_id],
-        unpack_src_format[unpB_operand_id],
-        unpack_dst_format[unpA_operand_id],
-        unpack_dst_format[unpB_operand_id],
-        face_r_dim,
-        within_face_16x16_transpose,
-        num_faces);
-}
-
-template <bool is_fp32_dest_acc_en, StochRndType stoch_rnd_mode = StochRndType::None>
-inline void llk_unpack_tilizeA_B_hw_configure_disaggregated(
-    const std::uint32_t unpA_operand, const std::uint32_t unpB_operand, const int within_face_16x16_transpose = 0) {
-    const llk_unpack_AB_params_t unpack_tilizeA_B_params = {.unpA_operand = unpA_operand, .unpB_operand = unpB_operand};
-    llk_unpack_tilizeA_B_hw_configure<is_fp32_dest_acc_en, stoch_rnd_mode>(
-        &unpack_tilizeA_B_params, within_face_16x16_transpose);
-}
 
 template <
     bool neginf_srcA = false,
@@ -232,21 +177,6 @@ inline void llk_unpack_tilizeA_B_block(
 /*************************************************************************
  * LLK UNPACK FAST TILIZE SRC A
  *************************************************************************/
-
-template <bool is_fp32_dest_acc_en>
-inline void llk_unpack_fast_tilize_hw_configure(const llk_unpack_A_params_t* unpack_tilize_params) {
-    const uint32_t unpA_operand_id = get_operand_id(unpack_tilize_params->unpA_operand);
-
-    _llk_unpack_fast_tilize_hw_configure_<is_fp32_dest_acc_en>(
-        unpack_src_format[unpA_operand_id], unpack_dst_format[unpA_operand_id]);
-}
-
-template <bool is_fp32_dest_acc_en>
-inline void llk_unpack_fast_tilize_hw_configure_disaggregated(const std::uint32_t unpA_operand) {
-    const llk_unpack_A_params_t unpack_tilize_params = {.unpA_operand = unpA_operand};
-
-    llk_unpack_fast_tilize_hw_configure<is_fp32_dest_acc_en>(&unpack_tilize_params);
-}
 
 inline void llk_unpack_fast_tilize_init(const std::uint32_t operand, std::uint32_t full_dim) {
     const std::uint32_t operand_id = get_operand_id(operand);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_untilize_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_untilize_api.h
@@ -9,31 +9,6 @@
 /*************************************************************************
  * LLK UNPACK UNTILIZE
  *************************************************************************/
-template <bool is_fp32_dest_acc_en>
-inline void llk_unpack_untilize_hw_configure(const llk_unpack_A_params_t* unpack_untilize_params) {
-    constexpr bool is_row_pool = false;
-    constexpr bool within_face_16x16_transpose = false;
-    constexpr StochRndType stoch_rnd_mode = StochRndType::None;
-
-    const uint32_t unpA_operand_id = get_operand_id(unpack_untilize_params->unpA_operand);
-    const uint32_t unpA_num_faces = 4;
-    const uint32_t unpA_face_r_dim = FACE_R_DIM;
-
-    _llk_unpack_untilize_hw_configure_<is_fp32_dest_acc_en, stoch_rnd_mode>(
-        unpack_src_format[unpA_operand_id],
-        unpack_dst_format[unpA_operand_id],
-        unpA_face_r_dim,
-        within_face_16x16_transpose,
-        unpA_num_faces);
-}
-
-template <bool is_fp32_dest_acc_en>
-inline void llk_unpack_untilize_hw_configure_disaggregated(const std::uint32_t unpA_operand) {
-    const llk_unpack_A_params_t unpack_untilize_params = {
-        .unpA_operand = unpA_operand,
-    };
-    llk_unpack_untilize_hw_configure<is_fp32_dest_acc_en>(&unpack_untilize_params);
-}
 
 inline void llk_unpack_untilize_mop_config() { _llk_unpack_untilize_mop_config_(); }
 

--- a/tt_metal/include/compute_kernel_api/bcast.h
+++ b/tt_metal/include/compute_kernel_api/bcast.h
@@ -7,13 +7,14 @@
 #include "compute_kernel_api/common.h"
 #ifdef TRISC_MATH
 #include "llk_math_binary_api.h"
-#include "llk_math_matmul_api.h"
 #include "llk_math_common.h"
+#include "llk_math_common_api.h"
+#include "llk_math_matmul_api.h"
 #include "llk_math_unary_datacopy_api.h"
 #endif
 #ifdef TRISC_UNPACK
-#include "llk_unpack_AB_api.h"
 #include "llk_unpack_A_api.h"
+#include "llk_unpack_AB_api.h"
 #endif
 #ifdef TRISC_PACK
 #include "llk_pack.h"

--- a/tt_metal/include/compute_kernel_api/bcast.h
+++ b/tt_metal/include/compute_kernel_api/bcast.h
@@ -29,7 +29,7 @@ ALWI void unary_bcast_init(uint32_t icb, uint32_t ocb) {
     const bool enable_unpack_to_dest = data_copy_type == A2D;
 
     // Will configure A & B in similar way
-    UNPACK((llk_unpack_hw_configure<DST_ACCUM_MODE>(icb)));
+    UNPACK((llk_unpack_hw_configure<DST_ACCUM_MODE>(icb, icb /* second operand, unused for this operation*/)));
     UNPACK((llk_unpack_A_init<bcast_type, false, EltwiseBinaryReuseDestType::NONE, enable_unpack_to_dest>(
         false, false /*transpose within 16x16 face*/, icb)));
 
@@ -69,7 +69,8 @@ void reconfigure_unary_bcast(uint32_t old_icb, uint32_t new_icb, uint32_t old_oc
 
     if (unpacker_src_format_change || unpacker_dst_format_change) {
         // Will configure A & B in similar way
-        UNPACK((llk_unpack_hw_configure<DST_ACCUM_MODE>(new_icb)));
+        UNPACK(
+            (llk_unpack_hw_configure<DST_ACCUM_MODE>(new_icb, new_icb /* second operand, unused for this operation*/)));
     }
 
     if (unpacker_src_format_change || unpacker_dst_format_change || bcast_type_change) {

--- a/tt_metal/include/compute_kernel_api/bcast.h
+++ b/tt_metal/include/compute_kernel_api/bcast.h
@@ -29,18 +29,18 @@ ALWI void unary_bcast_init(uint32_t icb, uint32_t ocb) {
     const bool enable_unpack_to_dest = data_copy_type == A2D;
 
     // Will configure A & B in similar way
-    UNPACK((llk_unpack_A_hw_configure_disaggregated<DST_ACCUM_MODE>(icb)));
+    UNPACK((llk_unpack_hw_configure<DST_ACCUM_MODE>(icb)));
     UNPACK((llk_unpack_A_init<bcast_type, false, EltwiseBinaryReuseDestType::NONE, enable_unpack_to_dest>(
         false, false /*transpose within 16x16 face*/, icb)));
 
     MATH((llk_math_eltwise_unary_datacopy_init<data_copy_type, DST_ACCUM_MODE, bcast_type>(
         false /*transpose of faces*/, false /*transpose within 16x16 face*/, icb)));
     MATH((llk_math_pack_sync_init<DST_ACCUM_MODE>()));
-    MATH((llk_math_hw_configure_disaggregated(icb, icb)));
+    MATH((llk_math_hw_configure(icb, icb)));
 
-    PACK((llk_pack_hw_configure_disaggregated<DST_ACCUM_MODE, false>(ocb)));
+    PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(ocb)));
     PACK((llk_pack_init<false>(ocb)));
-    PACK((llk_pack_dest_init<DST_ACCUM_MODE, false>()));
+    PACK((llk_pack_dest_init<DST_ACCUM_MODE>()));
 }
 
 template <BroadcastType bcast_type>
@@ -69,7 +69,7 @@ void reconfigure_unary_bcast(uint32_t old_icb, uint32_t new_icb, uint32_t old_oc
 
     if (unpacker_src_format_change || unpacker_dst_format_change) {
         // Will configure A & B in similar way
-        UNPACK((llk_unpack_A_hw_configure_disaggregated<DST_ACCUM_MODE>(new_icb)));
+        UNPACK((llk_unpack_hw_configure<DST_ACCUM_MODE>(new_icb)));
     }
 
     if (unpacker_src_format_change || unpacker_dst_format_change || bcast_type_change) {
@@ -78,7 +78,7 @@ void reconfigure_unary_bcast(uint32_t old_icb, uint32_t new_icb, uint32_t old_oc
     }
 
     if (unpacker_dst_format_change) {
-        MATH((llk_math_hw_configure_disaggregated(new_icb, new_icb)));
+        MATH((llk_math_hw_configure(new_icb, new_icb)));
     }
 
     if (unpacker_dst_format_change || bcast_type_change) {
@@ -205,20 +205,20 @@ void init_bcast(uint32_t icb0, uint32_t icb1, uint32_t ocb) {
         MATH((llk_math_eltwise_binary_init<tBcastOp, tBcastDim>()));
     }
 
-    UNPACK((llk_unpack_AB_hw_configure_disaggregated<DST_ACCUM_MODE>(icb0, icb1)));
+    UNPACK((llk_unpack_hw_configure<DST_ACCUM_MODE>(icb0, icb1)));
     UNPACK((llk_unpack_AB_init<tBcastDim>(icb0, icb1)));
     // TODO(AP): running this specific init after common AB init causes a hang
 
     // clone of general init for AB TODO(AP): commonize
     // UNPACK(( llk_unpack_AB_init<BroadcastType::NONE>() ));
-    // UNPACK(( llk_unpack_AB_hw_configure_disaggregated<DST_ACCUM_MODE>(icb0, icb1) ));
+    // UNPACK(( llk_unpack_hw_configure<DST_ACCUM_MODE>(icb0, icb1) ));
 
-    PACK((llk_pack_hw_configure_disaggregated<DST_ACCUM_MODE, false>(ocb)));
+    PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(ocb)));
     PACK((llk_pack_init(ocb)));
-    PACK((llk_pack_dest_init<DST_ACCUM_MODE, false>()));
+    PACK((llk_pack_dest_init<DST_ACCUM_MODE>()));
 
     MATH((llk_math_pack_sync_init<DST_ACCUM_MODE>()));
-    MATH((llk_math_hw_configure_disaggregated(icb0, icb1)));
+    MATH((llk_math_hw_configure(icb0, icb1)));
 }
 
 /*

--- a/tt_metal/include/compute_kernel_api/compute_kernel_hw_startup.h
+++ b/tt_metal/include/compute_kernel_api/compute_kernel_hw_startup.h
@@ -38,19 +38,14 @@ namespace ckernel {
  */
 // clang-format on
 ALWI void compute_kernel_hw_startup(uint32_t icb0, uint32_t icb1, uint32_t ocb) {
-    UNPACK((llk_unpack_AB_hw_configure_disaggregated<DST_ACCUM_MODE>(icb0, icb1)));
+    UNPACK((llk_unpack_hw_configure<DST_ACCUM_MODE>(icb0, icb1)));
 
     MATH((llk_math_pack_sync_init<DST_ACCUM_MODE>()));
-    MATH((llk_math_hw_configure_disaggregated(icb0, icb1)));
+    MATH((llk_math_hw_configure(icb0, icb1)));
 
     PACK((llk_pack_init<false /*untilize*/, false /*zero_output*/, false /*tilize*/>(ocb)));
-    PACK((llk_pack_hw_configure_disaggregated<
-          DST_ACCUM_MODE,
-          false /*untilize*/,
-          ReluType::NO_RELU,
-          0 /*relu_treshold*/,
-          false /*tilize*/>(ocb)));
-    PACK((llk_pack_dest_init<DST_ACCUM_MODE, false /*untilize*/>(ocb)));
+    PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(ocb)));
+    PACK((llk_pack_dest_init<DST_ACCUM_MODE>(ocb)));
 }
 
 // clang-format off

--- a/tt_metal/include/compute_kernel_api/compute_kernel_hw_startup.h
+++ b/tt_metal/include/compute_kernel_api/compute_kernel_hw_startup.h
@@ -41,7 +41,7 @@ ALWI void compute_kernel_hw_startup(uint32_t icb0, uint32_t icb1, uint32_t ocb) 
     UNPACK((llk_unpack_AB_hw_configure_disaggregated<DST_ACCUM_MODE>(icb0, icb1)));
 
     MATH((llk_math_pack_sync_init<DST_ACCUM_MODE>()));
-    MATH((llk_math_hw_configure_disaggregated<false /*untilize*/, false /*skip_inputs*/>(icb0, icb1)));
+    MATH((llk_math_hw_configure_disaggregated(icb0, icb1)));
 
     PACK((llk_pack_init<false /*untilize*/, false /*zero_output*/, false /*tilize*/>(ocb)));
     PACK((llk_pack_hw_configure_disaggregated<

--- a/tt_metal/include/compute_kernel_api/eltwise_binary.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_binary.h
@@ -7,10 +7,11 @@
 #include "compute_kernel_api/common.h"
 #ifdef TRISC_MATH
 #include "llk_math_binary_api.h"
+#include "llk_math_common_api.h"
 #endif
 #ifdef TRISC_UNPACK
-#include "llk_unpack_AB_api.h"
 #include "llk_unpack_A_api.h"
+#include "llk_unpack_AB_api.h"
 #endif
 
 namespace ckernel {

--- a/tt_metal/include/compute_kernel_api/eltwise_binary.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_binary.h
@@ -28,15 +28,15 @@ namespace ckernel {
  */
 // clang-format on
 ALWI void binary_op_init_common(uint32_t icb0, uint32_t icb1, uint32_t ocb) {
-    UNPACK((llk_unpack_AB_hw_configure_disaggregated<DST_ACCUM_MODE>(icb0, icb1)));
+    UNPACK((llk_unpack_hw_configure<DST_ACCUM_MODE>(icb0, icb1)));
     UNPACK((llk_unpack_AB_init<BroadcastType::NONE>(icb0, icb1)));
 
     MATH((llk_math_pack_sync_init<DST_ACCUM_MODE>()));
-    MATH((llk_math_hw_configure_disaggregated(icb0, icb1)));
+    MATH((llk_math_hw_configure(icb0, icb1)));
 
-    PACK((llk_pack_hw_configure_disaggregated<DST_ACCUM_MODE, false>(ocb)));
+    PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(ocb)));
     PACK((llk_pack_init(ocb)));
-    PACK((llk_pack_dest_init<DST_ACCUM_MODE, false>()));
+    PACK((llk_pack_dest_init<DST_ACCUM_MODE>()));
 }
 
 // clang-format off

--- a/tt_metal/include/compute_kernel_api/eltwise_unary/eltwise_unary.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_unary/eltwise_unary.h
@@ -19,6 +19,7 @@ namespace ckernel {
 ALWI void unary_op_init_common(uint32_t icb, uint32_t ocb) {
     UNPACK((llk_unpack_hw_configure<DST_ACCUM_MODE>(icb, icb /* second operand, unused for this operation*/)));
     // TODO LP disable zero flags
+    UNPACK((llk_unpack_disable_src_zero_flag(true)));
     UNPACK((llk_unpack_A_init<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, UnpackToDestEn>(
         false /*transpose of faces*/, false /*transpose within 16x16 face*/, icb)));
 
@@ -42,6 +43,7 @@ ALWI void unary_op_init_common(uint32_t icb, uint32_t ocb) {
 ALWI void unary_op_init_common_no_pack(uint32_t icb) {
     UNPACK((llk_unpack_hw_configure<DST_ACCUM_MODE>(icb, icb /* second operand, unused for this operation*/)));
     // TODO LP disable zero flags
+    UNPACK((llk_unpack_disable_src_zero_flag(true)));
     UNPACK((llk_unpack_A_init<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, UnpackToDestEn>(
         false /*transpose of faces*/, false /*transpose within 16x16 face*/, icb)));
 

--- a/tt_metal/include/compute_kernel_api/eltwise_unary/eltwise_unary.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_unary/eltwise_unary.h
@@ -15,7 +15,7 @@
 namespace ckernel {
 
 ALWI void unary_op_init_common(uint32_t icb, uint32_t ocb) {
-    UNPACK((llk_unpack_hw_configure<DST_ACCUM_MODE>(icb)));
+    UNPACK((llk_unpack_hw_configure<DST_ACCUM_MODE>(icb, icb /* second operand, unused for this operation*/)));
     // TODO LP disable zero flags
     UNPACK((llk_unpack_A_init<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, UnpackToDestEn>(
         false /*transpose of faces*/, false /*transpose within 16x16 face*/, icb)));
@@ -38,7 +38,7 @@ ALWI void unary_op_init_common(uint32_t icb, uint32_t ocb) {
  */
 // clang-format on
 ALWI void unary_op_init_common_no_pack(uint32_t icb) {
-    UNPACK((llk_unpack_hw_configure<DST_ACCUM_MODE>(icb)));
+    UNPACK((llk_unpack_hw_configure<DST_ACCUM_MODE>(icb, icb /* second operand, unused for this operation*/)));
     // TODO LP disable zero flags
     UNPACK((llk_unpack_A_init<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, UnpackToDestEn>(
         false /*transpose of faces*/, false /*transpose within 16x16 face*/, icb)));

--- a/tt_metal/include/compute_kernel_api/eltwise_unary/eltwise_unary.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_unary/eltwise_unary.h
@@ -6,10 +6,12 @@
 
 #include "compute_kernel_api/common.h"
 #ifdef TRISC_MATH
+#include "llk_math_common_api.h"
 #include "llk_math_unary_datacopy_api.h"
 #endif
 #ifdef TRISC_UNPACK
 #include "llk_unpack_A_api.h"
+#include "llk_unpack_AB_api.h"
 #endif
 
 namespace ckernel {

--- a/tt_metal/include/compute_kernel_api/eltwise_unary/eltwise_unary.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_unary/eltwise_unary.h
@@ -16,6 +16,7 @@ namespace ckernel {
 
 ALWI void unary_op_init_common(uint32_t icb, uint32_t ocb) {
     UNPACK((llk_unpack_A_hw_configure_disaggregated<DST_ACCUM_MODE, StochRndType::None, true>(icb)));
+    // TODO LP disable zero flags
     UNPACK((llk_unpack_A_init<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, UnpackToDestEn>(
         false /*transpose of faces*/, false /*transpose within 16x16 face*/, icb)));
 
@@ -38,6 +39,7 @@ ALWI void unary_op_init_common(uint32_t icb, uint32_t ocb) {
 // clang-format on
 ALWI void unary_op_init_common_no_pack(uint32_t icb) {
     UNPACK((llk_unpack_A_hw_configure_disaggregated<DST_ACCUM_MODE, StochRndType::None, true>(icb)));
+    // TODO LP disable zero flags
     UNPACK((llk_unpack_A_init<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, UnpackToDestEn>(
         false /*transpose of faces*/, false /*transpose within 16x16 face*/, icb)));
 

--- a/tt_metal/include/compute_kernel_api/eltwise_unary/eltwise_unary.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_unary/eltwise_unary.h
@@ -15,19 +15,19 @@
 namespace ckernel {
 
 ALWI void unary_op_init_common(uint32_t icb, uint32_t ocb) {
-    UNPACK((llk_unpack_A_hw_configure_disaggregated<DST_ACCUM_MODE, StochRndType::None, true>(icb)));
+    UNPACK((llk_unpack_hw_configure<DST_ACCUM_MODE>(icb)));
     // TODO LP disable zero flags
     UNPACK((llk_unpack_A_init<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, UnpackToDestEn>(
         false /*transpose of faces*/, false /*transpose within 16x16 face*/, icb)));
 
-    PACK((llk_pack_hw_configure_disaggregated<DST_ACCUM_MODE, false>(ocb)));
+    PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(ocb)));
     PACK((llk_pack_init<false>(ocb)));
-    PACK((llk_pack_dest_init<DST_ACCUM_MODE, false>()));
+    PACK((llk_pack_dest_init<DST_ACCUM_MODE>()));
 
     MATH((llk_math_eltwise_unary_datacopy_init<A2D, DST_ACCUM_MODE, BroadcastType::NONE>(
         false /*transpose of faces*/, false /*transpose within 16x16 face*/, icb)));
     MATH((llk_math_pack_sync_init<DST_ACCUM_MODE>()));
-    MATH((llk_math_hw_configure_disaggregated(icb, icb)));
+    MATH((llk_math_hw_configure(icb, icb)));
 }
 
 // clang-format off
@@ -38,14 +38,14 @@ ALWI void unary_op_init_common(uint32_t icb, uint32_t ocb) {
  */
 // clang-format on
 ALWI void unary_op_init_common_no_pack(uint32_t icb) {
-    UNPACK((llk_unpack_A_hw_configure_disaggregated<DST_ACCUM_MODE, StochRndType::None, true>(icb)));
+    UNPACK((llk_unpack_hw_configure<DST_ACCUM_MODE>(icb)));
     // TODO LP disable zero flags
     UNPACK((llk_unpack_A_init<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, UnpackToDestEn>(
         false /*transpose of faces*/, false /*transpose within 16x16 face*/, icb)));
 
     MATH((llk_math_eltwise_unary_datacopy_init<A2D, DST_ACCUM_MODE, BroadcastType::NONE>(
         false /*transpose of faces*/, false /*transpose within 16x16 face*/, icb)));
-    MATH((llk_math_hw_configure_disaggregated(icb, icb)));
+    MATH((llk_math_hw_configure(icb, icb)));
 }
 
 ALWI void init_sfpu(uint32_t icb, uint32_t ocb) { unary_op_init_common(icb, ocb); }

--- a/tt_metal/include/compute_kernel_api/matmul.h
+++ b/tt_metal/include/compute_kernel_api/matmul.h
@@ -6,9 +6,11 @@
 
 #include "compute_kernel_api/common.h"
 #ifdef TRISC_MATH
+#include "llk_math_common_api.h"
 #include "llk_math_matmul_api.h"
 #endif
 #ifdef TRISC_UNPACK
+#include "llk_unpack_AB_api.h"
 #include "llk_unpack_AB_matmul_api.h"
 #endif
 // defines the default throttle level for matmul kernels (default 0)

--- a/tt_metal/include/compute_kernel_api/matmul.h
+++ b/tt_metal/include/compute_kernel_api/matmul.h
@@ -89,16 +89,16 @@ ALWI void matmul_block_math_dynamic_throttle(
  */
 // clang-format on
 ALWI void mm_init(uint32_t in0_cb_id, uint32_t in1_cb_id, uint32_t out_cb_id, const uint32_t transpose = 0) {
-    UNPACK((llk_unpack_AB_matmul_hw_configure_disaggregated<DST_ACCUM_MODE>(in0_cb_id, in1_cb_id)));
+    UNPACK((llk_unpack_hw_configure<DST_ACCUM_MODE>(in0_cb_id, in1_cb_id)));
     UNPACK((llk_unpack_AB_matmul_init(in0_cb_id, in1_cb_id, transpose)));
 
     MATH((llk_math_matmul_init<MATH_FIDELITY, MM_THROTTLE>(in0_cb_id, in1_cb_id, transpose)));
     MATH((llk_math_pack_sync_init<DST_ACCUM_MODE>()));
-    MATH((llk_math_hw_configure_disaggregated(in0_cb_id, in1_cb_id)));
+    MATH((llk_math_hw_configure(in0_cb_id, in1_cb_id)));
 
-    PACK((llk_pack_hw_configure_disaggregated<DST_ACCUM_MODE, false>(out_cb_id)));
+    PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(out_cb_id)));
     PACK((llk_pack_init(out_cb_id)));
-    PACK((llk_pack_dest_init<DST_ACCUM_MODE, false>()));
+    PACK((llk_pack_dest_init<DST_ACCUM_MODE>()));
 }
 
 // clang-format off
@@ -214,20 +214,20 @@ ALWI void mm_block_init(
     uint32_t ct_dim = 1,
     uint32_t rt_dim = 1,
     uint32_t kt_dim = 1) {
-    UNPACK((llk_unpack_AB_matmul_hw_configure_disaggregated<DST_ACCUM_MODE>(in0_cb_id, in1_cb_id)));
+    UNPACK((llk_unpack_hw_configure<DST_ACCUM_MODE>(in0_cb_id, in1_cb_id)));
     UNPACK((llk_unpack_AB_matmul_init(in0_cb_id, in1_cb_id, transpose, ct_dim, rt_dim, kt_dim)));
 
     MATH((llk_math_matmul_init<MATH_FIDELITY, MM_THROTTLE>(in0_cb_id, in1_cb_id, transpose, ct_dim, rt_dim, kt_dim)));
     MATH((llk_math_pack_sync_init<DST_ACCUM_MODE>()));
-    MATH((llk_math_hw_configure_disaggregated(in0_cb_id, in1_cb_id)));
+    MATH((llk_math_hw_configure(in0_cb_id, in1_cb_id)));
 #ifdef ARCH_BLACKHOLE
     // Dynamic throttling is only available on Blackhole architecture
     MATH((throttled_mop_status = 0));
 #endif
 
-    PACK((llk_pack_hw_configure_disaggregated<DST_ACCUM_MODE, false>(out_cb_id)));
+    PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(out_cb_id)));
     PACK((llk_pack_init<false, false>(out_cb_id)));
-    PACK((llk_pack_dest_init<DST_ACCUM_MODE, false>()));
+    PACK((llk_pack_dest_init<DST_ACCUM_MODE>()));
 }
 
 // clang-format off

--- a/tt_metal/include/compute_kernel_api/pack_untilize.h
+++ b/tt_metal/include/compute_kernel_api/pack_untilize.h
@@ -62,9 +62,9 @@ template <
 ALWI void pack_untilize_dest_init(uint32_t ocb, uint32_t face_r_dim = 16, uint32_t num_faces = 4) {
 #ifdef ARCH_BLACKHOLE
     // Needed for setting swizzle_32b:
-    MATH((llk_math_hw_configure(0, 0)));
-    MATH((llk_math_configure_remap(true /* remap enabled */)));
+    // MATH((llk_math_hw_configure(0, 0)));
     // TODO LP, set swizzle here
+    MATH((llk_math_configure_remap(true /* remap enabled */)));
 #endif
     // A workaround for tt-metal#17132. Should be addressed more systematically.
     // NC: Need to pass face_r_dim and num_faces as CB metadata, not as runtime arg

--- a/tt_metal/include/compute_kernel_api/pack_untilize.h
+++ b/tt_metal/include/compute_kernel_api/pack_untilize.h
@@ -62,8 +62,6 @@ template <
 ALWI void pack_untilize_dest_init(uint32_t ocb, uint32_t face_r_dim = 16, uint32_t num_faces = 4) {
 #ifdef ARCH_BLACKHOLE
     // Needed for setting swizzle_32b:
-    // MATH((llk_math_hw_configure(0, 0)));
-    // TODO LP, set swizzle here
     MATH((llk_math_configure_remap(true /* remap enabled */)));
 #endif
     // A workaround for tt-metal#17132. Should be addressed more systematically.

--- a/tt_metal/include/compute_kernel_api/pack_untilize.h
+++ b/tt_metal/include/compute_kernel_api/pack_untilize.h
@@ -6,6 +6,7 @@
 
 #include "compute_kernel_api/common.h"
 #ifdef TRISC_MATH
+#include "llk_math_common_api.h"
 #include "llk_math_unary_datacopy_api.h"
 #endif
 #ifdef TRISC_UNPACK

--- a/tt_metal/include/compute_kernel_api/pack_untilize.h
+++ b/tt_metal/include/compute_kernel_api/pack_untilize.h
@@ -61,7 +61,8 @@ template <
 ALWI void pack_untilize_dest_init(uint32_t ocb, uint32_t face_r_dim = 16, uint32_t num_faces = 4) {
 #ifdef ARCH_BLACKHOLE
     // Needed for setting swizzle_32b:
-    MATH((llk_math_hw_configure_disaggregated<true, true>(0, 0)));
+    MATH((llk_math_hw_configure_disaggregated(0, 0)));
+    // TODO LP, set swizzle here
 #endif
     // A workaround for tt-metal#17132. Should be addressed more systematically.
     PACK(

--- a/tt_metal/include/compute_kernel_api/pack_untilize.h
+++ b/tt_metal/include/compute_kernel_api/pack_untilize.h
@@ -62,11 +62,12 @@ ALWI void pack_untilize_dest_init(uint32_t ocb, uint32_t face_r_dim = 16, uint32
 #ifdef ARCH_BLACKHOLE
     // Needed for setting swizzle_32b:
     MATH((llk_math_hw_configure(0, 0)));
+    MATH((llk_math_configure_remap(true /* remap enabled */)));
     // TODO LP, set swizzle here
 #endif
     // A workaround for tt-metal#17132. Should be addressed more systematically.
     // NC: Need to pass face_r_dim and num_faces as CB metadata, not as runtime arg
-    PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(ocb, face_r_dim, num_faces)));
+    PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(ocb)));
     PACK((llk_pack_untilize_init<block_ct_dim, full_ct_dim, narrow_row, row_num_datums>(ocb, face_r_dim, num_faces)));
     PACK((llk_init_packer_dest_offset_registers<true>(ocb)));
 }

--- a/tt_metal/include/compute_kernel_api/reconfig_data_format.h
+++ b/tt_metal/include/compute_kernel_api/reconfig_data_format.h
@@ -11,61 +11,55 @@ namespace ckernel {
 /**
  * Helper function to reconfigure srca and srcb data formats.
  */
-template <bool to_from_int8 = false>
 ALWI void reconfig_data_format(const uint32_t srca_new_operand, const uint32_t srcb_new_operand) {
-    UNPACK((llk_unpack_reconfig_data_format<DST_ACCUM_MODE, to_from_int8>(srca_new_operand, srcb_new_operand)));
-    MATH((llk_math_reconfig_data_format<DST_ACCUM_MODE, to_from_int8>(srca_new_operand, srcb_new_operand)));
+    UNPACK((llk_unpack_reconfig_data_format<DST_ACCUM_MODE>(srca_new_operand, srcb_new_operand)));
+    MATH((llk_math_reconfig_data_format<DST_ACCUM_MODE>(srca_new_operand, srcb_new_operand)));
 }
 
 /**
  * Helper function to reconfigure srca/srcb data formats, only if they differ from existing formats.
  */
-template <bool to_from_int8 = false>
 ALWI void reconfig_data_format(
     const uint32_t srca_old_operand,
     const uint32_t srca_new_operand,
     const uint32_t srcb_old_operand,
     const uint32_t srcb_new_operand) {
-    UNPACK((llk_unpack_reconfig_data_format<DST_ACCUM_MODE, to_from_int8>(
+    UNPACK((llk_unpack_reconfig_data_format<DST_ACCUM_MODE>(
         srca_old_operand, srca_new_operand, srcb_old_operand, srcb_new_operand)));
-    MATH((llk_math_reconfig_data_format<DST_ACCUM_MODE, to_from_int8>(
+    MATH((llk_math_reconfig_data_format<DST_ACCUM_MODE>(
         srca_old_operand, srca_new_operand, srcb_old_operand, srcb_new_operand)));
 }
 
 /**
  * Helper function to reconfigure srca data format.
  */
-template <bool to_from_int8 = false>
 ALWI void reconfig_data_format_srca(const uint32_t srca_new_operand) {
-    UNPACK((llk_unpack_reconfig_data_format_srca<DST_ACCUM_MODE, to_from_int8>(srca_new_operand)));
-    MATH((llk_math_reconfig_data_format_srca<DST_ACCUM_MODE, to_from_int8>(srca_new_operand)));
+    UNPACK((llk_unpack_reconfig_data_format_srca<DST_ACCUM_MODE>(srca_new_operand)));
+    MATH((llk_math_reconfig_data_format_srca<DST_ACCUM_MODE>(srca_new_operand)));
 }
 
 /**
  * Helper function to reconfigure srca input data format, only if it differs from existing format.
  */
-template <bool to_from_int8 = false>
 ALWI void reconfig_data_format_srca(const uint32_t srca_old_operand, const uint32_t srca_new_operand) {
-    UNPACK((llk_unpack_reconfig_data_format_srca<DST_ACCUM_MODE, to_from_int8>(srca_old_operand, srca_new_operand)));
-    MATH((llk_math_reconfig_data_format_srca<DST_ACCUM_MODE, to_from_int8>(srca_old_operand, srca_new_operand)));
+    UNPACK((llk_unpack_reconfig_data_format_srca<DST_ACCUM_MODE>(srca_old_operand, srca_new_operand)));
+    MATH((llk_math_reconfig_data_format_srca<DST_ACCUM_MODE>(srca_old_operand, srca_new_operand)));
 }
 
 /**
  * Helper function to reconfigure srcb input data format.
  */
-template <bool to_from_int8 = false>
 ALWI void reconfig_data_format_srcb(const uint32_t srcb_new_operand) {
-    UNPACK((llk_unpack_reconfig_data_format_srcb<DST_ACCUM_MODE, to_from_int8>(srcb_new_operand)));
-    MATH((llk_math_reconfig_data_format_srcb<DST_ACCUM_MODE, to_from_int8>(srcb_new_operand)));
+    UNPACK((llk_unpack_reconfig_data_format_srcb<DST_ACCUM_MODE>(srcb_new_operand)));
+    MATH((llk_math_reconfig_data_format_srcb<DST_ACCUM_MODE>(srcb_new_operand)));
 }
 
 /**
  * Helper function to reconfigure srcb input data format, only if it differs from existing format.
  */
-template <bool to_from_int8 = false>
 ALWI void reconfig_data_format_srcb(const uint32_t srcb_old_operand, const uint32_t srcb_new_operand) {
-    UNPACK((llk_unpack_reconfig_data_format_srcb<DST_ACCUM_MODE, to_from_int8>(srcb_old_operand, srcb_new_operand)));
-    MATH((llk_math_reconfig_data_format_srcb<DST_ACCUM_MODE, to_from_int8>(srcb_old_operand, srcb_new_operand)));
+    UNPACK((llk_unpack_reconfig_data_format_srcb<DST_ACCUM_MODE>(srcb_old_operand, srcb_new_operand)));
+    MATH((llk_math_reconfig_data_format_srcb<DST_ACCUM_MODE>(srcb_old_operand, srcb_new_operand)));
 }
 
 }  // namespace ckernel

--- a/tt_metal/include/compute_kernel_api/tilize.h
+++ b/tt_metal/include/compute_kernel_api/tilize.h
@@ -385,7 +385,8 @@ ALWI void fast_tilize_init(uint32_t icb, uint32_t full_dim, uint32_t ocb) {
 
 ALWI void fast_tilize_init_with_dt(uint32_t icb, uint32_t full_dim, uint32_t ocb) {
     UNPACK((llk_unpack_reconfig_data_format<DST_ACCUM_MODE>(icb, icb)));
-    MATH((llk_math_reconfig_data_format<true, true>(icb, icb)));
+    // NC: second template arguement was to_from_int8 = true, what to do here?
+    MATH((llk_math_reconfig_data_format<true>(icb, icb)));
 
     fast_tilize_init(icb, full_dim, ocb);
 }

--- a/tt_metal/include/compute_kernel_api/tilize.h
+++ b/tt_metal/include/compute_kernel_api/tilize.h
@@ -95,17 +95,17 @@ ALWI void tilizeA_B_reduce_init(
     uint32_t ocb,
     uint32_t num_faces = 4,
     uint32_t face_r_dim = 16) {
-    UNPACK((llk_unpack_tilizeA_B_hw_configure_disaggregated<DST_ACCUM_MODE>(icb0, icb1_scaler)));
+    UNPACK((llk_unpack_hw_configure<DST_ACCUM_MODE>(icb0, icb1_scaler)));
     UNPACK((llk_unpack_tilizeA_B_init<neginf_srcA, true, false, zero_srcA_reduce>(
         icb0, icb1_scaler, block, num_faces, face_r_dim, 1)));
 
     MATH((llk_math_reduce_init<REDUCE_OP, REDUCE_DIM, DST_ACCUM_MODE, MATH_FIDELITY>()));
     MATH((llk_math_pack_sync_init<DST_ACCUM_MODE>()));
-    MATH((llk_math_hw_configure_disaggregated(icb0, icb1_scaler)));
+    MATH((llk_math_hw_configure(icb0, icb1_scaler)));
 
-    PACK((llk_pack_hw_configure_disaggregated<DST_ACCUM_MODE, false>(ocb)));
+    PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(ocb)));
     PACK((llk_pack_init(ocb)));
-    PACK((llk_pack_dest_init<DST_ACCUM_MODE, false>(ocb)));
+    PACK((llk_pack_dest_init<DST_ACCUM_MODE>(ocb)));
 }
 #endif
 
@@ -173,7 +173,7 @@ ALWI void tilize_init_short_with_dt_no_pack(uint32_t old_icb, uint32_t new_icb, 
 // while the *_no_pack variants do not configure the packer, testing has shown that this call is
 // still necessary to ensure the data type is properly updated
 #ifdef ARCH_BLACKHOLE
-    PACK((_llk_pack_init_<false, false, DstTileFaceLayout::RowMajor, false, true>(
+    PACK((_llk_pack_init_<false /*untilize*/, false /*zero_output*/, true /*tilize en*/>(
         pack_dst_format[new_icb],
         get_output_face_r_dim(new_icb),
         get_output_tile_c_dim(new_icb),

--- a/tt_metal/include/compute_kernel_api/tilize.h
+++ b/tt_metal/include/compute_kernel_api/tilize.h
@@ -6,11 +6,13 @@
 
 #include "compute_kernel_api/common.h"
 #ifdef TRISC_MATH
-#include "llk_math_unary_datacopy_api.h"
-#include "llk_math_reduce_api.h"
+#include "llk_math_common_api.h"
 #include "llk_math_matmul_api.h"
+#include "llk_math_reduce_api.h"
+#include "llk_math_unary_datacopy_api.h"
 #endif
 #ifdef TRISC_UNPACK
+#include "llk_unpack_AB_api.h"
 #include "llk_unpack_tilize_api.h"
 #endif
 

--- a/tt_metal/include/compute_kernel_api/transpose_wh.h
+++ b/tt_metal/include/compute_kernel_api/transpose_wh.h
@@ -7,12 +7,13 @@
 #include "compute_kernel_api/common.h"
 #ifdef TRISC_MATH
 #include "llk_math_common_api.h"
-#include "llk_math_unary_datacopy_api.h"
 #include "llk_math_transpose_dest_api.h"
+#include "llk_math_unary_datacopy_api.h"
 #endif
 #ifdef TRISC_UNPACK
 #include "llk_unpack_common_api.h"
 #include "llk_unpack_A_api.h"
+#include "llk_unpack_AB_api.h"
 #endif
 
 namespace ckernel {

--- a/tt_metal/include/compute_kernel_api/transpose_wh.h
+++ b/tt_metal/include/compute_kernel_api/transpose_wh.h
@@ -33,15 +33,16 @@ ALWI void transpose_wh_init(uint32_t icb, uint32_t ocb) {
     const bool is_int32 = (src_format & 0xf) == (std::uint32_t)DataFormat::Int32;
 
     if (is_int32) {
-        UNPACK((llk_unpack_hw_configure<DST_ACCUM_MODE>(icb, false)));
+        // NC: Second argument doesn't exist, should be within_face_16x16_transpose = false, move to init instead.
+        UNPACK((llk_unpack_hw_configure<DST_ACCUM_MODE>(icb, icb /* second operand, unused for this operation*/)));
         // TODO LP disable zero flags
         UNPACK((llk_unpack_A_init<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, UnpackToDestEn>(
             true, false, icb)));
         MATH((llk_math_eltwise_unary_datacopy_init<A2D, DST_ACCUM_MODE, BroadcastType::NONE>(true, false, icb)));
         MATH((llk_math_transpose_dest_init<false, true>()));
     } else {
-        // NC: Second argument doesn't exist, should be within_face_16x16_transpose, move to init instead.
-        UNPACK((llk_unpack_hw_configure<DST_ACCUM_MODE>(icb, true)));
+        // NC: Second argument doesn't exist, should be within_face_16x16_transpose = true, move to init instead.
+        UNPACK((llk_unpack_hw_configure<DST_ACCUM_MODE>(icb, icb /* second operand, unused for this operation*/)));
         UNPACK((llk_unpack_A_init<BroadcastType::NONE, true, EltwiseBinaryReuseDestType::NONE>(true, true, icb)));
         MATH((llk_math_eltwise_unary_datacopy_init<A2D, DST_ACCUM_MODE, BroadcastType::NONE>(true, true, icb)));
     }

--- a/tt_metal/include/compute_kernel_api/transpose_wh.h
+++ b/tt_metal/include/compute_kernel_api/transpose_wh.h
@@ -34,6 +34,7 @@ ALWI void transpose_wh_init(uint32_t icb, uint32_t ocb) {
 
     if (is_int32) {
         UNPACK((llk_unpack_A_hw_configure_disaggregated<DST_ACCUM_MODE, StochRndType::None, true>(icb, false)));
+        // TODO LP disable zero flags
         UNPACK((llk_unpack_A_init<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, UnpackToDestEn>(
             true, false, icb)));
         MATH((llk_math_eltwise_unary_datacopy_init<A2D, DST_ACCUM_MODE, BroadcastType::NONE>(true, false, icb)));

--- a/tt_metal/include/compute_kernel_api/transpose_wh.h
+++ b/tt_metal/include/compute_kernel_api/transpose_wh.h
@@ -37,6 +37,7 @@ ALWI void transpose_wh_init(uint32_t icb, uint32_t ocb) {
         // NC: Second argument doesn't exist, should be within_face_16x16_transpose = false, move to init instead.
         UNPACK((llk_unpack_hw_configure<DST_ACCUM_MODE>(icb, icb /* second operand, unused for this operation*/)));
         // TODO LP disable zero flags
+        UNPACK((llk_unpack_disable_src_zero_flag(true)));
         UNPACK((llk_unpack_A_init<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, UnpackToDestEn>(
             true, false, icb)));
         MATH((llk_math_eltwise_unary_datacopy_init<A2D, DST_ACCUM_MODE, BroadcastType::NONE>(true, false, icb)));

--- a/tt_metal/include/compute_kernel_api/transpose_wh.h
+++ b/tt_metal/include/compute_kernel_api/transpose_wh.h
@@ -33,24 +33,25 @@ ALWI void transpose_wh_init(uint32_t icb, uint32_t ocb) {
     const bool is_int32 = (src_format & 0xf) == (std::uint32_t)DataFormat::Int32;
 
     if (is_int32) {
-        UNPACK((llk_unpack_A_hw_configure_disaggregated<DST_ACCUM_MODE, StochRndType::None, true>(icb, false)));
+        UNPACK((llk_unpack_hw_configure<DST_ACCUM_MODE>(icb, false)));
         // TODO LP disable zero flags
         UNPACK((llk_unpack_A_init<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, UnpackToDestEn>(
             true, false, icb)));
         MATH((llk_math_eltwise_unary_datacopy_init<A2D, DST_ACCUM_MODE, BroadcastType::NONE>(true, false, icb)));
         MATH((llk_math_transpose_dest_init<false, true>()));
     } else {
-        UNPACK((llk_unpack_A_hw_configure_disaggregated<DST_ACCUM_MODE, StochRndType::None, false>(icb, true)));
+        // NC: Second argument doesn't exist, should be within_face_16x16_transpose, move to init instead.
+        UNPACK((llk_unpack_hw_configure<DST_ACCUM_MODE>(icb, true)));
         UNPACK((llk_unpack_A_init<BroadcastType::NONE, true, EltwiseBinaryReuseDestType::NONE>(true, true, icb)));
         MATH((llk_math_eltwise_unary_datacopy_init<A2D, DST_ACCUM_MODE, BroadcastType::NONE>(true, true, icb)));
     }
     MATH((llk_math_pack_sync_init<DST_ACCUM_MODE>()));
-    MATH((llk_math_hw_configure_disaggregated(icb, icb)));
+    MATH((llk_math_hw_configure(icb, icb)));
 #endif
 
-    PACK((llk_pack_hw_configure_disaggregated<DST_ACCUM_MODE, false>(ocb)));
+    PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(ocb)));
     PACK((llk_pack_init(ocb)));
-    PACK((llk_pack_dest_init<DST_ACCUM_MODE, false>()));
+    PACK((llk_pack_dest_init<DST_ACCUM_MODE>()));
 }
 
 /**

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/compute/transpose_wh_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/compute/transpose_wh_rm.cpp
@@ -65,13 +65,13 @@ ALWI void transpose_with_pack_untilize_narrow_row(uint32_t cb_tilize, uint32_t c
         if (w == Wt - 1) {  // last row
             cb_reserve_back(cb_out, pack_num_pages_last_row_col);
             tile_regs_wait();
-            pack_untilize_dest<Ht, Ht, false, use_narrow_row, row_size>(cb_out);
+            pack_untilize_dest<Ht, Ht, use_narrow_row, row_size>(cb_out);
             tile_regs_release();
             cb_push_back(cb_out, pack_num_pages_last_row_col);
         } else {
             cb_reserve_back(cb_out, pack_num_pages_last_col);
             tile_regs_wait();
-            pack_untilize_dest<Ht, Ht, false, use_narrow_row, row_size>(cb_out);
+            pack_untilize_dest<Ht, Ht, use_narrow_row, row_size>(cb_out);
             tile_regs_release();
             cb_push_back(cb_out, pack_num_pages_last_col);
         }

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_pool_2d.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_pool_2d.cpp
@@ -281,6 +281,7 @@ void MAIN {
                         MATH((llk_math_reduce_init<REDUCE_OP, REDUCE_DIM, DST_ACCUM_MODE, MATH_FIDELITY>()));
 #ifdef ARCH_BLACKHOLE
                         // need this on BH to set swizzle bit before pack untilize dest
+                        // TODO LP, set swizzle with specific function
                         MATH((llk_math_hw_configure_disaggregated<true, true>(0, 0)));
 #endif
                         PACK((llk_pack_untilize_init<max_tiles_per_iter, max_tiles_per_iter, false, false, TILE_C_DIM>(

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_pool_2d.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_pool_2d.cpp
@@ -281,10 +281,7 @@ void MAIN {
                         MATH((llk_math_reduce_init<REDUCE_OP, REDUCE_DIM, DST_ACCUM_MODE, MATH_FIDELITY>()));
 #ifdef ARCH_BLACKHOLE
                         // need this on BH to set swizzle bit before pack untilize dest
-                        // TODO LP, set swizzle with specific function
-                        // NC: Need to handle differently:
-                        // MATH((llk_math_hw_configure_disaggregated<true, true>(0, 0)));
-                        MATH((llk_math_hw_configure(0, 0)));
+                        MATH((llk_math_configure_remap(true /* remap enabled */)));
 #endif
                         PACK((llk_pack_untilize_init<max_tiles_per_iter, max_tiles_per_iter, false, TILE_C_DIM>(
                             pre_tilize_cb_id, 1, num_faces_in_output_tile)));

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_pool_2d.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_pool_2d.cpp
@@ -256,10 +256,9 @@ void MAIN {
                         // Workaround until #27504 is not closed
                         // We should be calling tilizeA_B_uninit and for BFP4 output may be a reconfig_data_format
                         // and also remove the tensix_syncs. Currently they are incomplete and hence the full call
-                        // to unpack_A_hw_configure.
+                        // to llk_unpack_hw_configure.
                         tensix_sync();
-                        UNPACK((llk_unpack_A_hw_configure_disaggregated<DST_ACCUM_MODE, StochRndType::None, false>(
-                            pre_tilize_cb_id)));
+                        UNPACK((llk_unpack_hw_configure<DST_ACCUM_MODE>(pre_tilize_cb_id)));
                         tensix_sync();
                         pack_reconfig_data_format(out_cb_id);
 
@@ -282,9 +281,11 @@ void MAIN {
 #ifdef ARCH_BLACKHOLE
                         // need this on BH to set swizzle bit before pack untilize dest
                         // TODO LP, set swizzle with specific function
-                        MATH((llk_math_hw_configure_disaggregated<true, true>(0, 0)));
+                        // NC: Need to handle differently:
+                        // MATH((llk_math_hw_configure_disaggregated<true, true>(0, 0)));
+                        MATH((llk_math_hw_configure(0, 0)));
 #endif
-                        PACK((llk_pack_untilize_init<max_tiles_per_iter, max_tiles_per_iter, false, false, TILE_C_DIM>(
+                        PACK((llk_pack_untilize_init<max_tiles_per_iter, max_tiles_per_iter, false, TILE_C_DIM>(
                             pre_tilize_cb_id, 1, num_faces_in_output_tile)));
                     }
                 } else {

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_pool_2d.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_pool_2d.cpp
@@ -258,7 +258,8 @@ void MAIN {
                         // and also remove the tensix_syncs. Currently they are incomplete and hence the full call
                         // to llk_unpack_hw_configure.
                         tensix_sync();
-                        UNPACK((llk_unpack_hw_configure<DST_ACCUM_MODE>(pre_tilize_cb_id)));
+                        UNPACK((llk_unpack_hw_configure<DST_ACCUM_MODE>(
+                            pre_tilize_cb_id, pre_tilize_cb_id /* second operand, unused for this operation*/)));
                         tensix_sync();
                         pack_reconfig_data_format(out_cb_id);
 


### PR DESCRIPTION
### Ticket
#33824 

### Problem description
We have many different llk-api HW configs for different threads doing the same thing.

What's changed
We unified all these into a single HW config llk-api call per thread.
Additionally, we removed unnecessary parameters and functions on llk-api and compute-api level.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes