### PR TITLE
Make Test2CQMultiDevicePrograms* Tests Faster

### DIFF
--- a/tests/ttnn/unit_tests/gtests/test_multi_cq_multi_dev.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_multi_cq_multi_dev.cpp
@@ -62,7 +62,7 @@ TEST_F(MultiCommandQueueT3KFixture, Test2CQMultiDeviceProgramsOnCQ1) {
                     host_data[j] = bfloat16(static_cast<float>(i + dev_idx));
                 }
                 // Pre-compute expected output: input goes through dispatch_ops_to_device which applies -32x + 128
-                float expected_val = -1 * (i + dev_idx) * 32 + 128;
+                float expected_val = (-1 * (i + dev_idx) * 32) + 128;
                 for (uint32_t j = 0; j < buf_size_datums; j++) {
                     expected_data[j] = bfloat16(expected_val);
                 }
@@ -123,7 +123,7 @@ TEST_F(MultiCommandQueueT3KFixture, Test2CQMultiDeviceProgramsOnCQ0) {
                     host_data[j] = bfloat16(static_cast<float>(i + dev_idx));
                 }
                 // Pre-compute expected output: input goes through dispatch_ops_to_device which applies -32x + 128
-                float expected_val = -1 * (i + dev_idx) * 32 + 128;
+                float expected_val = (-1 * (i + dev_idx) * 32) + 128;
                 for (uint32_t j = 0; j < buf_size_datums; j++) {
                     expected_data[j] = bfloat16(expected_val);
                 }
@@ -178,7 +178,7 @@ TEST_F(MultiCommandQueueT3KFixture, Test2CQMultiDeviceWithCQ1Only) {
                     host_data[j] = bfloat16(static_cast<float>(i + dev_idx));
                 }
                 // Pre-compute expected output: input goes through dispatch_ops_to_device which applies -32x + 128
-                float expected_val = -1 * (i + dev_idx) * 32 + 128;
+                float expected_val = (-1 * (i + dev_idx) * 32) + 128;
                 for (uint32_t j = 0; j < buf_size_datums; j++) {
                     expected_data[j] = bfloat16(expected_val);
                 }

--- a/tests/ttnn/unit_tests/gtests/test_multi_cq_multi_dev.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_multi_cq_multi_dev.cpp
@@ -5,6 +5,7 @@
 #include <fmt/base.h>
 #include <gtest/gtest.h>
 #include <stdint.h>
+#include <cstring>
 #include <tt-metalium/bfloat16.hpp>
 #include <tt-metalium/event.hpp>
 #include <map>
@@ -49,6 +50,7 @@ TEST_F(MultiCommandQueueT3KFixture, Test2CQMultiDeviceProgramsOnCQ1) {
     uint32_t datum_size_bytes = 2;
     auto host_data = std::shared_ptr<bfloat16[]>(new bfloat16[buf_size_datums]);
     auto readback_data = std::shared_ptr<bfloat16[]>(new bfloat16[buf_size_datums]);
+    auto expected_data = std::shared_ptr<bfloat16[]>(new bfloat16[buf_size_datums]);
     for (int outer_loop = 0; outer_loop < 2; outer_loop++) {
         log_info(LogTest, "Running outer loop {}", outer_loop);
         for (int i = 0; i < 5; i++) {
@@ -56,9 +58,15 @@ TEST_F(MultiCommandQueueT3KFixture, Test2CQMultiDeviceProgramsOnCQ1) {
                 auto dev_idx = dev.first;
                 auto device = dev.second;
 
-                for (int j = 0; j < buf_size_datums; j++) {
+                for (uint32_t j = 0; j < buf_size_datums; j++) {
                     host_data[j] = bfloat16(static_cast<float>(i + dev_idx));
                 }
+                // Pre-compute expected output: input goes through dispatch_ops_to_device which applies -32x + 128
+                float expected_val = -1 * (i + dev_idx) * 32 + 128;
+                for (uint32_t j = 0; j < buf_size_datums; j++) {
+                    expected_data[j] = bfloat16(expected_val);
+                }
+
                 TensorSpec tensor_spec(shape, TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE), mem_cfg));
                 ASSERT_EQ(buf_size_datums * datum_size_bytes, tensor_spec.compute_packed_buffer_size_bytes());
                 auto input_tensor = allocate_tensor_on_device(tensor_spec, device.get());
@@ -85,9 +93,8 @@ TEST_F(MultiCommandQueueT3KFixture, Test2CQMultiDeviceProgramsOnCQ1) {
                      readback_data,
                      readback_data});
 
-                for (int j = 0; j < 3 * 2048 * 2048; j++) {
-                    ASSERT_EQ(static_cast<float>(readback_data[j]), -1 * (i + dev_idx) * 32 + 128);
-                }
+                ASSERT_EQ(std::memcmp(readback_data.get(), expected_data.get(), buf_size_datums * datum_size_bytes), 0)
+                    << "Data mismatch at outer_loop " << outer_loop << " iteration " << i << " device " << dev_idx;
             }
         }
     }
@@ -101,6 +108,7 @@ TEST_F(MultiCommandQueueT3KFixture, Test2CQMultiDeviceProgramsOnCQ0) {
     uint32_t datum_size_bytes = 2;
     auto host_data = std::shared_ptr<bfloat16[]>(new bfloat16[buf_size_datums]);
     auto readback_data = std::shared_ptr<bfloat16[]>(new bfloat16[buf_size_datums]);
+    auto expected_data = std::shared_ptr<bfloat16[]>(new bfloat16[buf_size_datums]);
 
     TensorSpec tensor_spec(shape, TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE), mem_cfg));
     ASSERT_EQ(buf_size_datums * datum_size_bytes, tensor_spec.compute_packed_buffer_size_bytes());
@@ -111,9 +119,15 @@ TEST_F(MultiCommandQueueT3KFixture, Test2CQMultiDeviceProgramsOnCQ0) {
                 auto dev_idx = dev.first;
                 auto device = dev.second;
 
-                for (int j = 0; j < buf_size_datums; j++) {
+                for (uint32_t j = 0; j < buf_size_datums; j++) {
                     host_data[j] = bfloat16(static_cast<float>(i + dev_idx));
                 }
+                // Pre-compute expected output: input goes through dispatch_ops_to_device which applies -32x + 128
+                float expected_val = -1 * (i + dev_idx) * 32 + 128;
+                for (uint32_t j = 0; j < buf_size_datums; j++) {
+                    expected_data[j] = bfloat16(expected_val);
+                }
+
                 auto input_tensor = allocate_tensor_on_device(tensor_spec, device.get());
 
                 ttnn::write_buffer(
@@ -125,7 +139,6 @@ TEST_F(MultiCommandQueueT3KFixture, Test2CQMultiDeviceProgramsOnCQ0) {
                 auto output_tensor = ttnn::test_utils::dispatch_ops_to_device(input_tensor, QueueId(0));
                 auto workload_event = ttnn::record_event(device->mesh_command_queue(0));
                 ttnn::wait_for_event(device->mesh_command_queue(1), workload_event);
-                // std::this_thread::sleep_for(std::chrono::milliseconds(50));
                 ttnn::read_buffer(
                     ttnn::QueueId(1),
                     output_tensor,
@@ -138,9 +151,8 @@ TEST_F(MultiCommandQueueT3KFixture, Test2CQMultiDeviceProgramsOnCQ0) {
                      readback_data,
                      readback_data});
 
-                for (int j = 0; j < 3 * 2048 * 2048; j++) {
-                    ASSERT_EQ(static_cast<float>(readback_data[j]), -1 * (i + dev_idx) * 32 + 128);
-                }
+                ASSERT_EQ(std::memcmp(readback_data.get(), expected_data.get(), buf_size_datums * datum_size_bytes), 0)
+                    << "Data mismatch at outer_loop " << outer_loop << " iteration " << i << " device " << dev_idx;
             }
         }
     }
@@ -151,8 +163,10 @@ TEST_F(MultiCommandQueueT3KFixture, Test2CQMultiDeviceWithCQ1Only) {
 
     ttnn::Shape shape{1, 3, 2048, 2048};
     uint32_t buf_size_datums = 2048 * 2048 * 3;
+    uint32_t datum_size_bytes = 2;
     auto host_data = std::shared_ptr<bfloat16[]>(new bfloat16[buf_size_datums]);
     auto readback_data = std::shared_ptr<bfloat16[]>(new bfloat16[buf_size_datums]);
+    auto expected_data = std::shared_ptr<bfloat16[]>(new bfloat16[buf_size_datums]);
 
     for (int outer_loop = 0; outer_loop < 2; outer_loop++) {
         log_info(LogTest, "Running outer loop {}", outer_loop);
@@ -160,8 +174,13 @@ TEST_F(MultiCommandQueueT3KFixture, Test2CQMultiDeviceWithCQ1Only) {
             for (auto& dev : this->devs) {
                 auto dev_idx = dev.first;
                 auto device = dev.second;
-                for (int j = 0; j < buf_size_datums; j++) {
+                for (uint32_t j = 0; j < buf_size_datums; j++) {
                     host_data[j] = bfloat16(static_cast<float>(i + dev_idx));
+                }
+                // Pre-compute expected output: input goes through dispatch_ops_to_device which applies -32x + 128
+                float expected_val = -1 * (i + dev_idx) * 32 + 128;
+                for (uint32_t j = 0; j < buf_size_datums; j++) {
+                    expected_data[j] = bfloat16(expected_val);
                 }
 
                 TensorSpec tensor_spec(shape, TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE), mem_cfg));
@@ -188,9 +207,8 @@ TEST_F(MultiCommandQueueT3KFixture, Test2CQMultiDeviceWithCQ1Only) {
                      readback_data,
                      readback_data});
 
-                for (int j = 0; j < 3 * 2048 * 2048; j++) {
-                    ASSERT_EQ(static_cast<float>(readback_data[j]), -1 * (i + dev_idx) * 32 + 128);
-                }
+                ASSERT_EQ(std::memcmp(readback_data.get(), expected_data.get(), buf_size_datums * datum_size_bytes), 0)
+                    << "Data mismatch at outer_loop " << outer_loop << " iteration " << i << " device " << dev_idx;
             }
         }
     }


### PR DESCRIPTION
### Ticket
NA

### Problem description
These three tests take ~1 minute each causing log jam in T3K Merge Gate.
- MultiCommandQueueT3KFixture.Test2CQMultiDeviceProgramsOnCQ1
- MultiCommandQueueT3KFixture.Test2CQMultiDeviceProgramsOnCQ0
- MultiCommandQueueT3KFixture.Test2CQMultiDeviceWithCQ1Only

### What's changed
- Do bulk comparison instead of elementwise comparison.

#### Impact
- Each test ~25% Faster saving ~1 minute of runtime in every Merge Gate T3K run.

### Checklist
- Merge Gate: https://github.com/tenstorrent/tt-metal/actions/runs/19945678139