### PR TITLE
Initial refactor of test_prefetcher.cpp

### DIFF
--- a/tests/scripts/run_cpp_fd2_tests.sh
+++ b/tests/scripts/run_cpp_fd2_tests.sh
@@ -13,16 +13,20 @@ run_test_with_watcher() {
     TT_METAL_WATCHER=1 TT_METAL_WATCHER_NOINLINE=1 $1
     echo
 };
-#############################################
-# TEST_PREFETCHER TESTS                     #
-#############################################
-echo "Running test_prefetcher with fast dispatch mode..";
+# Unset the variable for these tests
+(
+    unset TT_METAL_SLOW_DISPATCH_MODE
+    #############################################
+    # TEST_PREFETCHER TESTS                     #
+    #############################################
+    echo "Running test_prefetcher with fast dispatch mode..";
 
-run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher"
+    run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher"
 
-#############################################
-# TEST_DISPATCHER TESTS                     #
-#############################################
-echo "Running test_dispatcher with fast dispatch mode..";
+    #############################################
+    # TEST_DISPATCHER TESTS                     #
+    #############################################
+    echo "Running test_dispatcher with fast dispatch mode..";
 
-run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_dispatcher"
+    run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_dispatcher"
+)

--- a/tests/scripts/run_cpp_fd2_tests.sh
+++ b/tests/scripts/run_cpp_fd2_tests.sh
@@ -2,31 +2,6 @@
 
 set -eo pipefail
 
-if [[ -z "$TT_METAL_HOME" ]]; then
-    echo "Must provide TT_METAL_HOME in environment" 1>&2
-    exit 1
-fi
-
-if [[ -z "$TT_METAL_SLOW_DISPATCH_MODE" ]]; then
-    echo "Must provide TT_METAL_SLOW_DISPATCH_MODE in environment" 1>&2
-    exit 1
-fi
-
-if [[ -z "$ARCH_NAME" ]]; then
-    echo "Must provide ARCH_NAME in environment" 1>&2
-    exit 1
-fi
-
-export TT_METAL_CLEAR_L1=1
-
-# Not super obvious which test is which during runtime unless you count, so occasionally sprinkle echo statements
-# to make it easier to see where we are.
-
-#############################################
-# TEST_PREFETCHER TESTS                     #
-#############################################
-echo "Running test_prefetcher tests now...";
-
 run_test() {
     echo $1
     $1
@@ -38,68 +13,16 @@ run_test_with_watcher() {
     TT_METAL_WATCHER=1 TT_METAL_WATCHER_NOINLINE=1 $1
     echo
 };
+#############################################
+# TEST_PREFETCHER TESTS                     #
+#############################################
+echo "Running test_prefetcher with fast dispatch mode..";
 
-run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 0 -i 5"  # TrueSmoke Test
-run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 1 -i 5"  # Smoke Test
-run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 2 -i 5"  # Random Test
-run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 2 -i 5 -b" # Random Test, big data
-run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 3 -i 5"  # PCIE Test
-run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 4 -i 5"  # Paged DRAM Read Test
-run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 5 -i 5"  # Paged DRAM Write + Read Test
-run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 6 -i 5"  # Host Test
-run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 7 -i 5"  # Packed Read Test
-run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 8 -i 5"  # Ringbuffer Test
-run_test_with_watcher "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 7 -i 10 -x -mpps" # Packed Read Test w/ max num subcmds
-run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 1 -i 1000 -rb"  # Smoke Test
-run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 2 -i 1000 -rb"  # Random Test
-
-echo "split pre/dis tests"
-run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 0 -i 5 -spre -sdis" # TrueSmoke Test
-run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 1 -i 5 -spre -sdis" # Smoke Test
-run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 2 -i 5 -spre -sdis" # Random Test
-run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 3 -i 5 -spre -sdis" # PCIE Test
-run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 4 -i 5 -spre -sdis" # Paged DRAM Read Test
-run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 5 -i 5 -spre -sdis" # Paged DRAM Write + Read Test
-run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 6 -i 5 -spre -sdis" # Host Test
-run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 7 -i 5 -spre -sdis" # Packed Read Test
-run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 8 -i 5 -spre -sdis"  # Ringbuffer Test
-run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 9 -i 5 -spre" # Raw Copy Test
-run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 9 -i 5 -spre -sdis" # Raw Copy Test
-run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 1 -i 1000 -rb -spre -sdis"  # Smoke Test
-run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 2 -i 1000 -rb -spre -sdis"  # Random Test
-
-echo "exec_buf tests"
-run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 0 -i 5 -x" # TrueSmoke Test
-run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 1 -i 5 -x" # Smoke Test
-run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 2 -i 5 -x" # Random Test
-run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 3 -i 5 -x" # PCIE Test
-run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 4 -i 5 -x" # Paged DRAM Read Test
-run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 5 -i 5 -x" # Paged DRAM Write + Read Test
-run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 6 -i 5 -x" # Host Test
-run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 7 -i 5 -x" # Packed Read Test
-run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 8 -i 5 -x" # Rinbuffer Test
-
-run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 1 -i 5 -x -spre" # Smoke Test
-run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 1 -i 5 -x -spre -sdis" # Smoke Test
-run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 2 -i 5 -x -spre -sdis" # Random Test
-run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 6 -i 5 -x -spre -sdis" # Host Test
-run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 7 -i 5 -x -spre -sdis" # Packed Read Test
-run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 1 -i 1000 -x -rb -spre -sdis"  # Smoke Test
-run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 2 -i 1000 -x -rb -spre -sdis"  # Random Test
-
-# Testcase: Paged Write Cmd to DRAM. 256 pages, 256b size.
-./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 4 -i 1 -dpgs 256 -dpgr 256
-# Testcase: Paged Write Cmd to DRAM. 120 pages, 64b size.
-./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 4 -i 1 -dpgs 64 -dpgr 120
+run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher"
 
 #############################################
 # TEST_DISPATCHER TESTS                     #
 #############################################
-echo "Running test_dispatcher with fast dispatch mode (unsetting TT_METAL_SLOW_DISPATCH_MODE)..";
+echo "Running test_dispatcher with fast dispatch mode..";
 
-# Unset the variable for these tests
-(
-    #This is temporary until we refactor test_prefetcher.cpp to use FDMeshCommandQueue
-    unset TT_METAL_SLOW_DISPATCH_MODE
-    run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_dispatcher"
-)
+run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_dispatcher"

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <cstdint>
 #include <unordered_map>
+#include <random>
 #include <tt-metalium/core_coord.hpp>
 #include <tt-logger/tt-logger.hpp>
 #include <tt-metalium/host_api.hpp>
@@ -25,16 +26,26 @@
 #include <variant>
 #include <llrt/tt_cluster.hpp>
 
+#include "tt_metal/distributed/fd_mesh_command_queue.hpp"
+#include "tt_metal/impl/dispatch/device_command.hpp"
+#include "dispatch/device_command_calculator.hpp"
+#include "command_queue_fixture.hpp"
+#include "tests/tt_metal/tt_metal/common/mesh_dispatch_fixture.hpp"
+#include "tt_metal/impl/dispatch/system_memory_manager.hpp"
+#include <impl/dispatch/dispatch_mem_map.hpp>
+#include "tests/tt_metal/tt_metal/common/multi_device_fixture.hpp"
+
 using namespace tt::tt_metal;  // test only
 
-extern bool debug_g;
-extern bool use_coherent_data_g;
-extern uint32_t dispatch_buffer_page_size_g;
-extern uint32_t min_xfer_size_bytes_g;
-extern uint32_t max_xfer_size_bytes_g;
-extern bool send_to_all_g;
-extern bool perf_test_g;
-extern uint32_t hugepage_issue_buffer_size_g;
+struct DispatchTestConfig {
+    bool use_coherent_data = false;
+    uint32_t dispatch_buffer_page_size = 1u << tt::tt_metal::DispatchSettings::DISPATCH_BUFFER_LOG_PAGE_SIZE;
+    uint32_t min_xfer_size_bytes = 16;
+    uint32_t max_xfer_size_bytes = 4096;
+    bool send_to_all = true;
+    bool perf_test = false;
+    uint32_t hugepage_issue_buffer_size = 256 * 1024 * 1024;
+};
 
 struct one_core_data_t {
     tt::CoreType core_type{tt::CoreType::COUNT};
@@ -54,6 +65,11 @@ private:
     uint64_t base_result_data_addr[static_cast<size_t>(tt::CoreType::COUNT)]{};
     std::unordered_map<CoreCoord, std::unordered_map<uint32_t, one_core_data_t>> all_data;
     CoreCoord host_core;
+    size_t host_data_index = 0;
+
+    // Test Config
+    bool use_coherent_data_;
+    uint32_t hugepage_issue_buffer_size_;
 
     // Validate a single core's worth of results vs expected
     bool validate_one_core(
@@ -74,7 +90,8 @@ public:
         uint32_t dram_data_addr,
         void* pcie_data_addr,
         bool is_banked,
-        uint32_t dram_data_size_words);
+        uint32_t dram_data_size_words,
+        const DispatchTestConfig& cfg);
 
     // Add expected data to a core
     void push_one(CoreCoord core, int bank, uint32_t datum);
@@ -116,7 +133,10 @@ inline DeviceData::DeviceData(
     uint32_t dram_data_addr,
     void* pcie_data_addr,
     bool is_banked,
-    uint32_t dram_data_size_words) {
+    uint32_t dram_data_size_words,
+    const DispatchTestConfig& cfg) :
+    use_coherent_data_(cfg.use_coherent_data),
+    hugepage_issue_buffer_size_(cfg.hugepage_issue_buffer_size) {
     this->base_data_addr[static_cast<int>(tt::CoreType::WORKER)] = l1_data_addr;
     this->base_data_addr[static_cast<int>(tt::CoreType::PCIE)] = (uint64_t)pcie_data_addr;
     this->base_data_addr[static_cast<int>(tt::CoreType::DRAM)] = dram_data_addr;
@@ -196,7 +216,7 @@ inline void DeviceData::prepopulate_dram(IDevice* device, uint32_t size_words) {
 
         // Generate random or coherent data per bank of specific size.
         for (uint32_t i = 0; i < size_words; i++) {
-            uint32_t datum = (use_coherent_data_g) ? (((bank_id & 0xFF) << 24) | i) : std::rand();
+            uint32_t datum = (use_coherent_data_) ? (((bank_id & 0xFF) << 24) | i) : std::rand();
 
             // Note: don't bump amt_written
             data.data.push_back(datum);
@@ -325,6 +345,7 @@ inline void DeviceData::relevel(CoreRange range) {
 // Result expected results
 inline void DeviceData::reset() {
     this->amt_written = 0;
+    host_data_index = 0;
     for (auto& [coord, bank_device_data] : this->all_data) {
         for (auto& [bank, one_core_data] : bank_device_data) {
             tt::CoreType core_type = one_core_data.core_type;
@@ -447,7 +468,6 @@ inline bool DeviceData::validate_host(
 
     bool failed = false;
 
-    static int host_data_index = 0;
     uint32_t* results = (uint32_t*)this->base_data_addr[static_cast<int>(tt::CoreType::PCIE)];
 
     int fail_count = 0;
@@ -471,7 +491,7 @@ inline bool DeviceData::validate_host(
 
         host_data_index++;
 
-        if (host_data_index * sizeof(uint32_t) > hugepage_issue_buffer_size_g) {
+        if (host_data_index * sizeof(uint32_t) > hugepage_issue_buffer_size_) {
             TT_THROW("Host test hugepage data wrap not (yet) supported, reduce test size/iterations");
         }
     }
@@ -517,7 +537,7 @@ inline void DeviceData::overflow_check(IDevice* device) {
                     "Test overflowed L1 memory");
             } else if (one_core_data.core_type == tt::CoreType::PCIE) {
                 TT_FATAL(
-                    one_core_data.data.size() * sizeof(uint32_t) <= hugepage_issue_buffer_size_g,
+                    one_core_data.data.size() * sizeof(uint32_t) <= hugepage_issue_buffer_size_,
                     "Test overflowed PCIE memory");
             } else if (one_core_data.core_type == tt::CoreType::DRAM) {
                 // TODO
@@ -526,580 +546,608 @@ inline void DeviceData::overflow_check(IDevice* device) {
     }
 }
 
-template <bool is_dram_variant, bool is_host_variant>
-KernelHandle configure_kernel_variant(
-    Program& program,
-    const std::string& path,
-    const std::map<std::string, std::string>& defines_in,
-    std::vector<uint32_t> compile_args,
-    CoreCoord my_core,
-    CoreCoord phys_my_core,
-    CoreCoord phys_upstream_core,
-    CoreCoord phys_downstream_core,
-    IDevice* device,
-    NOC my_noc_index,
-    NOC upstream_noc_index,
-    NOC downstream_noc_index) {
-    auto my_virtual_noc_coords = device->virtual_noc0_coordinate(my_noc_index, phys_my_core);
-    auto upstream_virtual_noc_coords = device->virtual_noc0_coordinate(upstream_noc_index, phys_upstream_core);
-    auto downstream_virtual_noc_coords = device->virtual_noc0_coordinate(downstream_noc_index, phys_downstream_core);
+namespace tt::tt_dispatch_tests {
+namespace Common {
 
-    std::map<std::string, std::string> defines = {
-        {"DISPATCH_KERNEL", "1"},
-        {"MY_NOC_X", std::to_string(my_virtual_noc_coords.x)},
-        {"MY_NOC_Y", std::to_string(my_virtual_noc_coords.y)},
-        {"UPSTREAM_NOC_INDEX", std::to_string(upstream_noc_index)},
-        {"UPSTREAM_NOC_X", std::to_string(upstream_virtual_noc_coords.x)},
-        {"UPSTREAM_NOC_Y", std::to_string(upstream_virtual_noc_coords.y)},
-        {"DOWNSTREAM_NOC_X", std::to_string(downstream_virtual_noc_coords.x)},
-        {"DOWNSTREAM_NOC_Y", std::to_string(downstream_virtual_noc_coords.y)},
-        {"DOWNSTREAM_SUBORDINATE_NOC_X", std::to_string(0xff)},
-        {"DOWNSTREAM_SUBORDINATE_NOC_Y", std::to_string(0xff)},  // todo, add dispatch_s testing
-        {"FD_CORE_TYPE", std::to_string(0)},                     // todo, support dispatch on eth
-        {"IS_D_VARIANT", std::to_string(is_dram_variant)},
-        {"IS_H_VARIANT", std::to_string(is_host_variant)},
+// Forward declare the accessor
+// This accessor class provides test access to private members
+// of FDMeshCommandQueue
+class FDMeshCQTestAccessor {
+public:
+    static tt_metal::SystemMemoryManager& sysmem(tt_metal::distributed::FDMeshCommandQueue& cq) {
+        return cq.reference_sysmem_manager();
+    }
+};
+
+namespace DeviceDataUpdater {
+
+// Update DeviceData for linear write
+// Mirrors a dispatcher linear-write transaction into the DeviceData expectation model
+// Takes provided payload and pushes exactly those values into destination worker_range
+void update_linear_write(
+    const std::vector<uint32_t>& payload, DeviceData& device_data, const CoreRange& worker_range, bool is_mcast) {
+    // Update expected device_data
+    if (is_mcast) {
+        for (const uint32_t datum : payload) {
+            device_data.push_range(worker_range, datum, true);
+        }
+    } else {
+        for (const uint32_t datum : payload) {
+            device_data.push_one(worker_range.start_coord, 0, datum);
+        }
+    }
+    // Relevel for next multicast command
+    if (is_mcast) {
+        device_data.relevel(tt::CoreType::WORKER);
+    }
+}
+
+// Update DeviceData for paged write
+// Tracks page-wise writes so validate() can check DRAM/L1 bank contents after the test runs
+void update_paged_write(
+    const std::vector<uint32_t>& payload,
+    DeviceData& device_data,
+    const CoreCoord& bank_core,
+    uint32_t bank_id,
+    uint32_t page_alignment) {
+    for (const uint32_t datum : payload) {
+        device_data.push_one(bank_core, bank_id, datum);
+    }
+    device_data.pad(bank_core, bank_id, page_alignment);
+}
+
+// Update DeviceData for packed write
+// Applies packed write payloads to every selected worker
+void update_packed_write(
+    const std::vector<uint32_t>& payload,
+    DeviceData& device_data,
+    const std::vector<CoreCoord>& worker_cores,
+    uint32_t l1_alignment) {
+    // Update expected device_data for all cores
+    for (const auto& core : worker_cores) {
+        for (const uint32_t datum : payload) {
+            device_data.push_one(core, 0, datum);
+        }
+        device_data.pad(core, 0, l1_alignment);
+    }
+
+    // Re-relevel for next command
+    device_data.relevel(tt::CoreType::WORKER);
+}
+}  // namespace DeviceDataUpdater
+
+// Host-side helpers used by tests to emit the same CQ commands
+// that dispatcher code emits. This namespace replicates the production code's command generation logic
+// for testing purposes.
+// This will be ported to common.h when test_prefetcher.cpp is refactored
+namespace CommandBuilder {
+
+// Emits a single linear write, optionally multicast, with inline data
+template <bool flush_prefetch, bool inline_data>
+HostMemDeviceCommand build_linear_write_command(
+    const std::vector<uint32_t>& payload,
+    const CoreRange& worker_range,
+    bool is_mcast,
+    uint32_t noc_xy,
+    uint32_t addr,
+    uint32_t xfer_size_bytes) {
+    // Calculate the command size using DeviceCommandCalculator
+    // Pre-calculate the exact size to allocate correct amount of memory in HostMemDeviceCommand buffer
+    DeviceCommandCalculator cmd_calc;
+    cmd_calc.add_dispatch_write_linear<flush_prefetch, inline_data>(xfer_size_bytes);
+    const uint32_t command_size_bytes = cmd_calc.write_offset_bytes();
+
+    // Create the HostMemDeviceCommand with pre-calculated size
+    HostMemDeviceCommand cmd(command_size_bytes);
+
+    // Add the dispatch write linear command
+    cmd.add_dispatch_write_linear<flush_prefetch, inline_data>(
+        is_mcast ? worker_range.size() : 0,  // num_mcast_dests
+        noc_xy,                              // NOC coordinates
+        addr,                                // destination address
+        xfer_size_bytes,                     // data size
+        payload.data()                       // payload data
+    );
+
+    return cmd;
+}
+
+// Emits a paged write (DRAM or L1) chunk
+// payload is already stitched together for all pages in the chunk
+template <bool inline_data>
+HostMemDeviceCommand build_paged_write_command(
+    const std::vector<uint32_t>& payload,
+    uint32_t base_addr,
+    uint32_t page_size_bytes,
+    uint32_t pages_in_chunk,
+    uint16_t start_page_cmd,
+    bool is_dram) {
+    // Calculate the command size
+    DeviceCommandCalculator cmd_calc;
+    cmd_calc.add_dispatch_write_paged<inline_data>(page_size_bytes, pages_in_chunk);
+    const uint32_t command_size_bytes = cmd_calc.write_offset_bytes();
+
+    // Create the HostMemDeviceCommand with pre-calculated size
+    HostMemDeviceCommand cmd(command_size_bytes);
+
+    // Add the dispatch write paged command
+    cmd.add_dispatch_write_paged<inline_data>(
+        true,                           // flush_prefetch (inline data)
+        static_cast<uint8_t>(is_dram),  // is_dram
+        start_page_cmd,                 // start_page
+        base_addr,                      // base_addr
+        page_size_bytes,                // page_size
+        pages_in_chunk,                 // pages
+        payload.data()                  // payload for this chunk
+    );
+
+    return cmd;
+}
+
+// Serializes a packed-unicast command including sub-command table
+// and optional replicated payloads when stride is enabled
+HostMemDeviceCommand build_packed_write_command(
+    const std::vector<uint32_t>& payload,
+    const std::vector<CQDispatchWritePackedUnicastSubCmd>& sub_cmds,
+    uint32_t common_addr,
+    uint32_t l1_alignment,
+    uint32_t packed_write_max_unicast_sub_cmds,
+    bool no_stride) {
+    const uint32_t num_sub_cmds = static_cast<uint32_t>(sub_cmds.size());
+    const uint32_t sub_cmds_bytes = tt::align(num_sub_cmds * sizeof(CQDispatchWritePackedUnicastSubCmd), l1_alignment);
+    uint32_t num_data_copies = no_stride ? 1u : static_cast<uint32_t>(num_sub_cmds);
+
+    // Pre-calculate all sizes needed
+    const uint32_t payload_size_bytes = payload.size() * sizeof(uint32_t);
+    const uint32_t data_bytes = num_data_copies * tt::align(payload_size_bytes, l1_alignment);
+    const uint32_t payload_bytes = tt::align(sizeof(CQDispatchCmd) + sub_cmds_bytes, l1_alignment) + data_bytes;
+
+    // Calculate the command size
+    DeviceCommandCalculator cmd_calc;
+    cmd_calc.add_dispatch_write_packed<CQDispatchWritePackedUnicastSubCmd>(
+        num_sub_cmds,        // num_sub_cmds
+        payload_size_bytes,  // packed_data_sizeB
+        packed_write_max_unicast_sub_cmds,
+        no_stride  // no_stride
+    );
+    const uint32_t command_size_bytes = cmd_calc.write_offset_bytes();
+
+    // Create the HostMemDeviceCommand with pre-calculated size
+    HostMemDeviceCommand cmd(command_size_bytes);
+
+    // Build data_collection pointing to the payload
+    std::vector<std::pair<const void*, uint32_t>> data_collection;
+    const void* payload_data = payload.data();
+
+    if (no_stride) {
+        data_collection.emplace_back(payload_data, payload_size_bytes);
+    } else {
+        data_collection.resize(num_sub_cmds, {payload_data, payload_size_bytes});
+    }
+
+    // Add the dispatch write packed command
+    cmd.add_dispatch_write_packed<CQDispatchWritePackedUnicastSubCmd>(
+        0,                                          // type
+        num_sub_cmds,                               // num_sub_cmds
+        common_addr,                                // common_addr
+        static_cast<uint16_t>(payload_size_bytes),  // packed_data_sizeB
+        payload_bytes,                              // payload_sizeB
+        sub_cmds,                                   // sub_cmds
+        data_collection,                            // data_collection
+        packed_write_max_unicast_sub_cmds,          // packed_write_max_unicast_sub_cmds
+        0,                                          // offset_idx
+        no_stride);                                 // no_stride
+
+    return cmd;
+}
+
+}  // namespace CommandBuilder
+
+// This will be ported to common.h when test_prefetcher.cpp is refactored
+// DispatchPayloadGenerator is used to generate payloads for the tests
+class DispatchPayloadGenerator {
+public:
+    struct Config {
+        bool use_coherent_data = false;
+        uint32_t coherent_start_val = COHERENT_DATA_START_VALUE;
+        uint32_t seed = 0;
+
+        // Perf test configuration
+        bool perf_test = false;
+        uint32_t min_xfer_size_bytes = 0;
+        uint32_t max_xfer_size_bytes = 0;
     };
 
-    compile_args.push_back(is_dram_variant);
-    compile_args.push_back(is_host_variant);
-
-    defines.insert(defines_in.begin(), defines_in.end());
-
-    return tt::tt_metal::CreateKernel(
-        program,
-        path,
-        {my_core},
-        tt::tt_metal::DataMovementConfig{
-            .processor = tt::tt_metal::DataMovementProcessor::RISCV_0,
-            .noc = my_noc_index,
-            .compile_args = compile_args,
-            .defines = defines,
-            .opt_level = KernelBuildOptLevel::Os});
-}
-
-// Specific to this test. This test doesn't use Buffers, and for Storage cores in L1 that have 2 banks, they are
-// intended to be allocated top-down and carry "negative" offsets via bank_to_l1_offset for cores that have 2 banks.
-// This function will scan through all banks bank_to_l1_offset and return the minimum required buffer addr to avoid
-// bank_to_l1_offset being applied and underflowing.  In GS this is basically 512B or half the L1 Bank size.
-inline uint32_t get_min_required_buffer_addr(IDevice* device, bool is_dram) {
-    int32_t smallest_offset = std::numeric_limits<int32_t>::max();
-    BufferType buffer_type = is_dram ? BufferType::DRAM : BufferType::L1;
-    uint32_t num_banks = device->allocator()->get_num_banks(buffer_type);
-
-    for (int bank_id = 0; bank_id < num_banks; bank_id++) {
-        int32_t offset = device->allocator()->get_bank_offset(buffer_type, bank_id);
-        smallest_offset = offset < smallest_offset ? offset : smallest_offset;
-    }
-
-    // If negative, flip it and this becomes the min required positive offset for a buffer in bank.
-    uint32_t min_required_positive_offset = smallest_offset < 0 ? 0 - smallest_offset : 0;
-    log_debug(
-        tt::LogTest,
-        "{} - smallest_offset: {} min_required_positive_offset: {}",
-        __FUNCTION__,
-        smallest_offset,
-        min_required_positive_offset);
-
-    return min_required_positive_offset;
-}
-
-inline void generate_random_payload(std::vector<uint32_t>& cmds, uint32_t length) {
-    for (uint32_t i = 0; i < length; i++) {
-        uint32_t datum = (use_coherent_data_g) ? i : std::rand();
-        cmds.push_back(datum);
-    }
-}
-
-inline void generate_random_payload(
-    std::vector<uint32_t>& cmds,
-    const CoreRange& workers,
-    DeviceData& data,
-    uint32_t length_words,
-    std::variant<CQDispatchCmd, CQDispatchCmdLarge> cmd,
-    bool is_mcast = false,
-    bool prepend_cmd = false) {
-    static uint32_t coherent_count = 0;
-
-    auto num_uint32s = std::visit(
-        ttsl::overloaded{
-            [](const CQDispatchCmd& cmd1) { return sizeof(CQDispatchCmd) / sizeof(uint32_t); },
-            [](const CQDispatchCmdLarge& cmd1) { return sizeof(CQDispatchCmdLarge) / sizeof(uint32_t); }},
-        cmd);
-
-    // Host data puts the command in the datastream...
-    if (prepend_cmd) {
-        // just get a pointer
-        uint32_t* cmdp = std::visit(
-            ttsl::overloaded{
-                [](CQDispatchCmd& cmd1) { return reinterpret_cast<uint32_t*>(&cmd1); },
-                [](CQDispatchCmdLarge& cmd1) { return reinterpret_cast<uint32_t*>(&cmd1); }},
-            cmd);
-        TT_ASSERT(cmdp, "Obtaining pointer to the data in variant type failed");
-        for (int i = 0; i < num_uint32s; ++i) {
-            data.push_range(workers, cmdp[i], is_mcast);
-        }
-    }
-
-    // Note: the dst address marches in unison regardless of whether or not a core is written to
-    for (uint32_t i = 0; i < length_words; i++) {
-        uint32_t datum = (use_coherent_data_g) ? coherent_count++ : std::rand();
-        cmds.push_back(datum);
-        data.push_range(workers, datum, is_mcast);
-    }
-}
-
-// Generate a random payload for a paged write command. Note: Doesn't currently support using the base_addr here.
-inline void generate_random_paged_payload(
-    IDevice* device,
-    CQDispatchCmd cmd,
-    std::vector<uint32_t>& cmds,
-    DeviceData& data,
-    uint32_t start_page,
-    bool is_dram) {
-    static uint32_t coherent_count = 0x100;  // Abitrary starting value, avoid 0x0 since matches with DRAM prefill.
-    auto buf_type = is_dram ? BufferType::DRAM : BufferType::L1;
-    uint32_t num_banks = device->allocator()->get_num_banks(buf_type);
-    uint32_t words_per_page = cmd.write_paged.page_size / sizeof(uint32_t);
-    log_debug(
-        tt::LogTest,
-        "Starting {} w/ is_dram: {} start_page: {} words_per_page: {}",
-        __FUNCTION__,
-        is_dram,
-        start_page,
-        words_per_page);
-
-    // Note: the dst address marches in unison regardless of whether or not a core is written to
-    uint32_t page_size_alignment_bytes = device->allocator()->get_alignment(buf_type);
-    for (uint32_t page_id = start_page; page_id < start_page + cmd.write_paged.pages; page_id++) {
-        CoreCoord bank_core;
-        uint32_t bank_id = page_id % num_banks;
-        [[maybe_unused]] uint32_t bank_offset =
-            tt::align(cmd.write_paged.page_size, page_size_alignment_bytes) * (page_id / num_banks);
-
-        if (is_dram) {
-            auto dram_channel = device->allocator_impl()->get_dram_channel_from_bank_id(bank_id);
-            bank_core = device->logical_core_from_dram_channel(dram_channel);
+    DispatchPayloadGenerator(const Config& cfg) : config_(cfg), coherent_count_(cfg.coherent_start_val) {
+        if (config_.seed == 0) {
+            std::random_device rd;
+            rng_.seed(rd());
         } else {
-            bank_core = device->allocator()->get_logical_core_from_bank_id(bank_id);
+            rng_.seed(config_.seed);
         }
-
-        // Generate data and add to cmd for sending to device, and device_data for correctness checking.
-        for (uint32_t i = 0; i < words_per_page; i++) {
-            uint32_t datum = (use_coherent_data_g) ? (((page_id & 0xFF) << 24) | coherent_count++) : std::rand();
-            log_debug(
-                tt::LogTest,
-                "{} - Setting {} page_id: {} word: {} on core: {} (bank_id: {} bank_offset: {}) => datum: 0x{:x}",
-                __FUNCTION__,
-                is_dram ? "DRAM" : "L1",
-                page_id,
-                i,
-                bank_core.str(),
-                bank_id,
-                bank_offset,
-                datum);
-            cmds.push_back(datum);  // Push to device.
-            data.push_one(bank_core, bank_id, datum);
-        }
-
-        data.pad(bank_core, bank_id, page_size_alignment_bytes);
     }
+
+    // Getter to log the seed used
+    uint32_t get_seed() const { return config_.seed; }
+
+    // Helper for random number generation in a range [min, max]
+    template <typename T>
+    T get_rand(T min, T max) {
+        static_assert(std::is_integral<T>::value, "T must be an integral type");
+        std::uniform_int_distribution<T> dist(min, max);
+        return dist(rng_);
+    }
+
+    // Helper for generating a random boolean (replaces std::rand() % 2)
+    bool get_rand_bool() { return (bool_dist(rng_) != 0); }
+
+    // Generates either deterministic (coherent) or random 32-bit words
+    // for the requested byte count
+    // In coherent mode, the counter is incremented so validation knows
+    // the exact pattern
+    std::vector<uint32_t> generate_payload(uint32_t xfer_size_bytes) {
+        const uint32_t size_words = xfer_size_bytes / sizeof(uint32_t);
+        std::vector<uint32_t> payload;
+        payload.reserve(size_words);
+
+        for (uint32_t i = 0; i < size_words; ++i) {
+            const uint32_t datum = config_.use_coherent_data ? coherent_count_++ : uint32_dist(rng_);
+            payload.push_back(datum);
+        }
+
+        return payload;
+    }
+
+    // Generate payload with page id
+    // Pass page_id to use for coherent data generation
+    std::vector<uint32_t> generate_payload_with_page_id(uint32_t page_size_words, uint32_t page_id) {
+        std::vector<uint32_t> payload;
+        payload.reserve(page_size_words);
+
+        for (uint32_t i = 0; i < page_size_words; ++i) {
+            const uint32_t datum = config_.use_coherent_data
+                                       ? (((page_id & 0xFF) << 24) | (coherent_count_++ & 0xFFFFFF))
+                                       : uint32_dist(rng_);
+            payload.push_back(datum);
+        }
+
+        return payload;
+    }
+
+    // Helper to generate payload data for a given core
+    // Pass core_id to use for coherent data generation
+    std::vector<uint32_t> generate_payload_with_core(
+        const CoreCoord& core_id,  // Pass the core to use
+        uint32_t xfer_size_bytes) {
+        const uint32_t size_words = xfer_size_bytes / sizeof(uint32_t);
+        std::vector<uint32_t> payload;
+        payload.reserve(size_words);
+
+        for (uint32_t i = 0; i < size_words; ++i) {
+            const uint32_t datum =
+                config_.use_coherent_data
+                    ? (((core_id.x & 0xFF) << 16) | ((core_id.y & 0xFF) << 24) | (coherent_count_++ & 0xFFFF))
+                    : uint32_dist(rng_);
+            payload.push_back(datum);
+        }
+
+        return payload;
+    }
+
+    // Chooses a payload size in 16B units, respecting perf mode clamps and remaining budget
+    uint32_t get_random_size(uint32_t max_allowed, uint32_t bytes_per_unit, uint32_t remaining_bytes) {
+        // Generate random transfer size
+        std::uniform_int_distribution<uint32_t> dist(1, max_allowed);
+        uint32_t xfer_size_16B = dist(rng_);
+        uint32_t xfer_size_bytes = xfer_size_16B * bytes_per_unit;  // Convert 16B units to bytes
+
+        // Clamp to remaining bytes
+        xfer_size_bytes = std::min(xfer_size_bytes, remaining_bytes);
+
+        // Apply perf_test_ constraints if enabled
+        if (config_.perf_test) {
+            xfer_size_bytes = std::clamp(xfer_size_bytes, config_.min_xfer_size_bytes, config_.max_xfer_size_bytes);
+        }
+
+        return xfer_size_bytes;
+    }
+
+private:
+    // Start offset to avoid 0x0 which matches DRAM prefill
+    static constexpr uint32_t COHERENT_DATA_START_VALUE = 0x100;
+    Config config_{};
+    uint32_t coherent_count_ = COHERENT_DATA_START_VALUE;
+
+    // Random number generation
+    std::mt19937 rng_;
+    // Distributions for random number generation
+    std::uniform_int_distribution<int> bool_dist{0, 1};
+    std::uniform_int_distribution<uint32_t> uint32_dist{
+        std::numeric_limits<uint32_t>::min(), std::numeric_limits<uint32_t>::max()};
+};
+
+namespace PackedWriteUtils {
+// Build subcmds once - reused for all commands
+inline std::vector<CQDispatchWritePackedUnicastSubCmd> build_sub_cmds(
+    IDevice* device, const std::vector<CoreCoord>& worker_cores, tt::tt_metal::NOC downstream_noc) {
+    std::vector<CQDispatchWritePackedUnicastSubCmd> sub_cmds;
+    sub_cmds.reserve(worker_cores.size());
+    for (const auto& core : worker_cores) {
+        const CoreCoord virtual_core = device->virtual_core_from_logical_core(core, CoreType::WORKER);
+        CQDispatchWritePackedUnicastSubCmd sub_cmd{};
+        sub_cmd.noc_xy_addr = device->get_noc_unicast_encoding(downstream_noc, virtual_core);
+        sub_cmds.push_back(sub_cmd);
+    }
+    return sub_cmds;
 }
 
-inline void generate_random_packed_payload(
-    std::vector<uint32_t>& cmds,
-    std::vector<CoreCoord>& worker_cores,
-    DeviceData& data,
-    uint32_t size_words,
-    bool repeat = false) {
-    static uint32_t coherent_count = 0;
-    const uint32_t bank_id = 0;  // No interleaved pages here.
+// Clamp xfer_size to fit within max_fetch_bytes_
+inline uint32_t clamp_to_max_fetch(
+    uint32_t max_fetch_bytes,
+    uint32_t xfer_size_bytes,
+    uint32_t num_sub_cmds,
+    uint32_t packed_write_max_unicast_sub_cmds,
+    bool no_stride,
+    uint32_t l1_alignment) {
+    // Calculate the command size
+    DeviceCommandCalculator cmd_calc;
+    cmd_calc.add_dispatch_write_packed<CQDispatchWritePackedUnicastSubCmd>(
+        num_sub_cmds,     // num_sub_cmds
+        xfer_size_bytes,  // packed_data_sizeB
+        packed_write_max_unicast_sub_cmds,
+        no_stride  // no_stride
+    );
+    uint32_t command_size_bytes = cmd_calc.write_offset_bytes();
 
-    bool first_core = true;
-    std::vector<uint32_t> results;
-    CoreCoord first_worker = worker_cores[0];
-    for (uint32_t i = 0; i < size_words; i++) {
-        uint32_t datum =
-            (use_coherent_data_g) ? ((first_worker.x << 16) | (first_worker.y << 24) | coherent_count++) : std::rand();
-        results.push_back(datum);
+    // If the command size is less than max_fetch_bytes_, return the transfer size
+    if (command_size_bytes <= max_fetch_bytes) {
+        return xfer_size_bytes;
     }
-    for (CoreCoord core : worker_cores) {
-        for (uint32_t i = 0; i < size_words; i++) {
-            data.push_one(core, bank_id, results[i]);
-            if (!repeat || first_core) {
-                cmds.push_back(results[i]);
+
+    // Else, linearly decrement by alignment until it fits
+    uint32_t result = xfer_size_bytes;
+    while (result > 0 && command_size_bytes > max_fetch_bytes) {
+        result -= l1_alignment;
+        cmd_calc.add_dispatch_write_packed<CQDispatchWritePackedUnicastSubCmd>(
+            num_sub_cmds,  // num_sub_cmds
+            result,        // packed_data_sizeB
+            packed_write_max_unicast_sub_cmds,
+            no_stride  // no_stride
+        );
+        command_size_bytes = cmd_calc.write_offset_bytes();
+    }
+
+    return result;
+}
+}  // namespace PackedWriteUtils
+
+// BaseTestFixture forms the basis for prefetch and dispatcher tests.
+// Inherits from GenericMeshDeviceFixture which determines the mesh device type automatically
+class BaseTestFixture : public tt_metal::GenericMeshDeviceFixture {
+public:
+    virtual ~BaseTestFixture() = default;
+
+protected:
+    // DispatchPayloadGenerator for generating payloads
+    std::unique_ptr<DispatchPayloadGenerator> payload_generator_;
+
+    // Common constants
+    static constexpr CoreCoord default_worker_start = {0, 1};
+    static constexpr uint32_t bytes_per_16B_unit = 16;  // conversion factor to convert 16-byte "chunks" to bytes
+    static constexpr uint32_t wait_completion_timeout = 10000;  // wait in milliseconds
+
+    // Common setup for all dispatch tests
+    // Provides shared wiring for mesh device access,
+    // and command-buffer helpers so derived fixtures
+    // only implement workload-specific planning
+    tt_metal::distributed::FDMeshCommandQueue* fdcq_ = nullptr;
+    tt_metal::SystemMemoryManager* mgr_ = nullptr;
+    tt_metal::distributed::MeshDevice::IDevice* device_ = nullptr;
+
+    // HW properties
+    uint32_t host_alignment_ = 0;
+    uint32_t max_fetch_bytes_ = 0;
+
+    // Knobs
+    uint32_t dispatch_buffer_page_size_ = 0;
+    bool send_to_all_ = false;
+
+    // Test Config defaults
+    DispatchTestConfig cfg_;
+
+    void SetUp() override {
+        tt_metal::GenericMeshDeviceFixture::SetUp();
+
+        // Setup Config
+        DispatchPayloadGenerator::Config pgcfg;
+        pgcfg.use_coherent_data = cfg_.use_coherent_data;
+        pgcfg.perf_test = cfg_.perf_test;
+        pgcfg.min_xfer_size_bytes = cfg_.min_xfer_size_bytes;
+        pgcfg.max_xfer_size_bytes = cfg_.max_xfer_size_bytes;
+
+        // Handle Seeding
+        std::random_device rd;
+        pgcfg.seed = rd();
+
+        // Initialize Generator
+        payload_generator_ = std::make_unique<DispatchPayloadGenerator>(pgcfg);
+        log_info(tt::LogTest, "Random seed set to {}", pgcfg.seed);
+
+        // These are used for test logic (loops, alignment, etc.) rather than generation
+        dispatch_buffer_page_size_ = cfg_.dispatch_buffer_page_size;
+        send_to_all_ = cfg_.send_to_all;
+
+        // Initialize common pointers
+        auto& mcq = mesh_device_->mesh_command_queue();
+        fdcq_ = &dynamic_cast<distributed::FDMeshCommandQueue&>(mcq);
+        // mgr_ = &FDMeshCQTestAccessor::sysmem(*fdcq_);
+        device_ = mesh_device_->get_devices()[0];
+        mgr_ = &device_->sysmem_manager();  // Use Chip 0's SystemMemoryManager
+
+        // Initialize common HW properties
+        host_alignment_ = tt_metal::MetalContext::instance().hal().get_alignment(tt_metal::HalMemType::HOST);
+        max_fetch_bytes_ = tt_metal::MetalContext::instance().dispatch_mem_map().max_prefetch_command_size();
+    }
+
+    // Helper function that polls completion queue until expected data is written into by dispatcher
+    // Without this, we can fail verification as there can a be race condition
+    void wait_for_completion_queue_bytes(uint32_t total_expected_cq_payload, uint32_t timeout_ms = 0) {
+        std::atomic<bool> exit_condition{false};
+        const auto start = std::chrono::steady_clock::now();
+        uint32_t avail = 0;
+        while (avail < total_expected_cq_payload) {
+            const uint32_t completion_queue_write_ptr_and_toggle =
+                mgr_->completion_queue_wait_front(fdcq_->id(), exit_condition);
+            const uint32_t completion_q_write_ptr = (completion_queue_write_ptr_and_toggle & 0x7fffffff) << 4;
+            const uint32_t completion_q_write_toggle = completion_queue_write_ptr_and_toggle >> (31);
+            const uint32_t completion_q_read_toggle = mgr_->get_completion_queue_read_toggle(fdcq_->id());
+            const uint32_t completion_q_read_ptr = mgr_->get_completion_queue_read_ptr(fdcq_->id());
+            const uint32_t limit = mgr_->get_completion_queue_limit(fdcq_->id());  // offset of end, in bytes
+
+            if (completion_q_write_ptr > completion_q_read_ptr and
+                completion_q_write_toggle == completion_q_read_toggle) {
+                avail = completion_q_write_ptr - completion_q_read_ptr;
+            } else {
+                avail = (limit - completion_q_read_ptr) + completion_q_write_ptr;
+            }
+
+            const auto elapsed =
+                std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start).count();
+            if (elapsed > timeout_ms) {
+                exit_condition.store(true);
+                TT_FATAL(
+                    false,
+                    "CQ wait timed out after {} ms (needed {} bytes, had {})",
+                    elapsed,
+                    total_expected_cq_payload,
+                    avail);
             }
         }
 
-        cmds.resize(
-            padded_size(cmds.size(), MetalContext::instance().hal().get_alignment(HalMemType::L1) / sizeof(uint32_t)));
-        data.pad(core, bank_id, MetalContext::instance().hal().get_alignment(HalMemType::L1));
-        first_core = false;
-    }
-}
-
-inline void add_bare_dispatcher_cmd(std::vector<uint32_t>& cmds, std::variant<CQDispatchCmd, CQDispatchCmdLarge> cmd) {
-    static_assert(
-        sizeof(CQDispatchCmd) % sizeof(uint32_t) == 0, "CQDispatchCmd size must be a multiple of uint32_t size");
-    static_assert(
-        sizeof(CQDispatchCmdLarge) % sizeof(uint32_t) == 0,
-        "CQDispatchCmdLarge size must be a multiple of uint32_t size");
-    const size_t num_uint32s = std::visit(
-        ttsl::overloaded{
-            [](const CQDispatchCmd& cmd) { return sizeof(CQDispatchCmd) / sizeof(uint32_t); },
-            [](const CQDispatchCmdLarge& cmd) { return sizeof(CQDispatchCmdLarge) / sizeof(uint32_t); }},
-        cmd);
-
-    // just get a pointer
-    uint32_t* cmdp = std::visit(
-        ttsl::overloaded{
-            [](CQDispatchCmd& cmd1) { return reinterpret_cast<uint32_t*>(&cmd1); },
-            [](CQDispatchCmdLarge& cmd1) { return reinterpret_cast<uint32_t*>(&cmd1); }},
-        cmd);
-    TT_ASSERT(cmdp, "Obtaining pointer to the data in variant type failed");
-    for (size_t i = 0; i < num_uint32s; i++) {
-        cmds.push_back(cmdp[i]);
-    }
-}
-
-inline size_t debug_prologue(std::vector<uint32_t>& cmds) {
-    size_t prior = cmds.size();
-
-    if (debug_g) {
-        CQDispatchCmd debug_cmd{};
-        memset(&debug_cmd, 0, sizeof(CQDispatchCmd));
-
-        debug_cmd.base.cmd_id = CQ_DISPATCH_CMD_DEBUG;
-        // compiler compains w/o these filled in later fields
-        debug_cmd.debug.key = 0;
-        debug_cmd.debug.size = 0;
-        debug_cmd.debug.stride = 0;
-        add_bare_dispatcher_cmd(cmds, debug_cmd);
+        log_info(
+            LogTest, "written in completion queue {} B vs expected amount {} B: ", avail, total_expected_cq_payload);
     }
 
-    return prior;
-}
+    // Helper function to report performance
+    void report_performance(
+        DeviceData& device_data,
+        size_t num_cores_to_log,
+        std::chrono::duration<double> elapsed,
+        uint32_t num_iterations) {
+        const float total_words = static_cast<float>(device_data.size()) * num_iterations;
+        const float bw_gbps = total_words * sizeof(uint32_t) / (elapsed.count() * 1024.0 * 1024.0 * 1024.0);
 
-inline void debug_epilogue(std::vector<uint32_t>& cmds, size_t prior_end) {
-    if (debug_g) {
-        // Doing a checksum on the full command length is problematic in the kernel
-        // as it requires the debug code to pull all the pages in before the actual
-        // command is processed.  So, limit this to doing a checksum on the first page
-        // (which is disappointing).  Any other value requires the checksum code to handle
-        // buffer wrap which then messes up the routines w/ the embedded insn - not worth it
-        CQDispatchCmd* debug_cmd_ptr;
-        debug_cmd_ptr = (CQDispatchCmd*)&cmds[prior_end];
-        uint32_t full_size = ((cmds.size() - prior_end) * sizeof(uint32_t)) - sizeof(CQDispatchCmd);
-        uint32_t max_size = dispatch_buffer_page_size_g - sizeof(CQDispatchCmd);
-        uint32_t size = (full_size > max_size) ? max_size : full_size;
-        debug_cmd_ptr->debug.size = size;
-        debug_cmd_ptr->debug.stride = sizeof(CQDispatchCmd);
-    }
-}
-
-inline void add_dispatcher_cmd(
-    std::vector<uint32_t>& cmds, std::variant<CQDispatchCmd, CQDispatchCmdLarge> cmd, uint32_t length) {
-    size_t prior_end = debug_prologue(cmds);
-
-    add_bare_dispatcher_cmd(cmds, cmd);
-    uint32_t length_words = length / sizeof(uint32_t);
-    generate_random_payload(cmds, length_words);
-
-    debug_epilogue(cmds, prior_end);
-}
-
-inline void add_dispatcher_cmd(
-    std::vector<uint32_t>& cmds,
-    const CoreRange& workers,
-    DeviceData& device_data,
-    std::variant<CQDispatchCmd, CQDispatchCmdLarge> cmd,
-    uint32_t length,
-    bool is_mcast = false,
-    bool prepend_cmd = false) {
-    size_t prior_end = debug_prologue(cmds);
-
-    add_bare_dispatcher_cmd(cmds, cmd);
-    uint32_t length_words = length / sizeof(uint32_t);
-    generate_random_payload(cmds, workers, device_data, length_words, cmd, is_mcast, prepend_cmd);
-
-    debug_epilogue(cmds, prior_end);
-}
-
-inline void add_dispatcher_paged_cmd(
-    IDevice* device,
-    std::vector<uint32_t>& cmds,
-    DeviceData& device_data,
-    CQDispatchCmd cmd,
-    uint32_t start_page,
-    bool is_dram) {
-    size_t prior_end = debug_prologue(cmds);
-    add_bare_dispatcher_cmd(cmds, cmd);
-    generate_random_paged_payload(device, cmd, cmds, device_data, start_page, is_dram);
-    debug_epilogue(cmds, prior_end);
-}
-
-inline void add_dispatcher_packed_cmd(
-    IDevice* device,
-    std::vector<uint32_t>& cmds,
-    std::vector<CoreCoord>& worker_cores,
-    DeviceData& device_data,
-    CQDispatchCmd cmd,
-    uint32_t size_words,
-    bool repeat = false) {
-    size_t prior_end = debug_prologue(cmds);
-
-    add_bare_dispatcher_cmd(cmds, cmd);
-    for (CoreCoord core : worker_cores) {
-        CoreCoord phys_worker_core = device->worker_core_from_logical_core(core);
-        cmds.push_back(
-            tt::tt_metal::MetalContext::instance().hal().noc_xy_encoding(phys_worker_core.x, phys_worker_core.y));
-    }
-    cmds.resize(
-        padded_size(cmds.size(), MetalContext::instance().hal().get_alignment(HalMemType::L1) / sizeof(uint32_t)));
-
-    generate_random_packed_payload(cmds, worker_cores, device_data, size_words, repeat);
-
-    debug_epilogue(cmds, prior_end);
-}
-
-// bare: doesn't generate random payload data, for use w/ eg, dram reads
-inline void gen_bare_dispatcher_unicast_write_cmd(
-    IDevice* device, std::vector<uint32_t>& cmds, CoreCoord worker_core, DeviceData& device_data, uint32_t length) {
-    CQDispatchCmdLarge cmd{};
-    memset(&cmd, 0, sizeof(CQDispatchCmdLarge));
-
-    CoreCoord phys_worker_core = device->worker_core_from_logical_core(worker_core);
-    const uint32_t bank_id = 0;  // No interleaved pages here.
-
-    cmd.base.cmd_id = CQ_DISPATCH_CMD_WRITE_LINEAR;
-    cmd.write_linear.noc_xy_addr =
-        tt::tt_metal::MetalContext::instance().hal().noc_xy_encoding(phys_worker_core.x, phys_worker_core.y);
-    cmd.write_linear.addr = device_data.get_result_data_addr(worker_core, bank_id);
-    cmd.write_linear.length = length;
-    cmd.write_linear.num_mcast_dests = 0;
-
-    TT_FATAL(
-        (cmd.write_linear.addr & (MetalContext::instance().hal().get_alignment(HalMemType::L1) - 1)) == 0, "Error");
-
-    add_bare_dispatcher_cmd(cmds, cmd);
-}
-
-inline void gen_dispatcher_unicast_write_cmd(
-    IDevice* device, std::vector<uint32_t>& cmds, CoreCoord worker_core, DeviceData& device_data, uint32_t length) {
-    CQDispatchCmdLarge cmd{};
-    memset(&cmd, 0, sizeof(CQDispatchCmdLarge));
-
-    CoreCoord phys_worker_core = device->worker_core_from_logical_core(worker_core);
-    const uint32_t bank_id = 0;  // No interleaved pages here.
-
-    cmd.base.cmd_id = CQ_DISPATCH_CMD_WRITE_LINEAR;
-    cmd.write_linear.noc_xy_addr =
-        tt::tt_metal::MetalContext::instance().hal().noc_xy_encoding(phys_worker_core.x, phys_worker_core.y);
-    cmd.write_linear.addr = device_data.get_result_data_addr(worker_core, bank_id);
-    cmd.write_linear.length = length;
-    cmd.write_linear.num_mcast_dests = 0;
-
-    add_dispatcher_cmd(cmds, worker_core, device_data, cmd, length);
-}
-
-inline void gen_dispatcher_multicast_write_cmd(
-    IDevice* device,
-    std::vector<uint32_t>& cmds,
-    CoreRange worker_core_range,
-    DeviceData& device_data,
-    uint32_t length) {
-    // Pad w/ blank data until all workers are at the same address
-    // TODO Hmm, ideally only need to relevel the core range
-    device_data.relevel(tt::CoreType::WORKER);
-
-    CQDispatchCmdLarge cmd{};
-    memset(&cmd, 0, sizeof(CQDispatchCmdLarge));
-
-    CoreCoord physical_start = device->worker_core_from_logical_core(worker_core_range.start_coord);
-    CoreCoord physical_end = device->worker_core_from_logical_core(worker_core_range.end_coord);
-
-    cmd.base.cmd_id = CQ_DISPATCH_CMD_WRITE_LINEAR;
-    cmd.write_linear.noc_xy_addr = tt::tt_metal::MetalContext::instance().hal().noc_multicast_encoding(
-        physical_start.x, physical_start.y, physical_end.x, physical_end.y);
-    cmd.write_linear.addr = device_data.get_result_data_addr(worker_core_range.start_coord);
-    cmd.write_linear.length = length;
-    cmd.write_linear.num_mcast_dests = worker_core_range.size();
-
-    add_dispatcher_cmd(cmds, worker_core_range, device_data, cmd, length, true);
-}
-
-inline void gen_dispatcher_paged_write_cmd(
-    IDevice* device,
-    std::vector<uint32_t>& cmds,
-    DeviceData& device_data,
-    bool is_dram,
-    uint32_t start_page,
-    uint32_t page_size,
-    uint32_t pages) {
-    BufferType buffer_type = is_dram ? BufferType::DRAM : BufferType::L1;
-    uint32_t page_size_alignment_bytes = device->allocator()->get_alignment(buffer_type);
-    uint32_t num_banks = device->allocator()->get_num_banks(buffer_type);
-    tt::CoreType core_type = is_dram ? tt::CoreType::DRAM : tt::CoreType::WORKER;
-
-    // Not safe to mix paged L1 and paged DRAM writes currently in this test since same book-keeping.
-    static uint32_t prev_is_dram = -1;
-    TT_ASSERT(
-        prev_is_dram == -1 || prev_is_dram == is_dram,
-        "Mixing paged L1 and paged DRAM writes not supported in this test.");
-    prev_is_dram = is_dram;
-
-    // Assumption embedded in this function (seems reasonable, true with a single buffer) that paged size will never
-    // change.
-    static uint32_t prev_page_size = -1;
-    TT_ASSERT(
-        prev_page_size == -1 || prev_page_size == page_size,
-        "Page size changed between calls to gen_dispatcher_paged_write_cmd - not supported.");
-    prev_page_size = page_size;
-
-    // For the CMD generation, start_page is 8 bits, so much wrap around, and increase base_addr instead based on page
-    // size, which assumes page size never changed between calls to this function (checked above).
-    uint32_t bank_offset = tt::align(page_size, page_size_alignment_bytes) * (start_page / num_banks);
-    // TODO: make this take the latest address, change callers to not manage this
-    uint32_t base_addr = device_data.get_base_result_addr(core_type) + bank_offset;
-    uint16_t start_page_cmd = start_page % num_banks;
-
-    CQDispatchCmd cmd{};
-    memset(&cmd, 0, sizeof(CQDispatchCmd));
-    cmd.base.cmd_id = CQ_DISPATCH_CMD_WRITE_PAGED;
-    cmd.write_paged.is_dram = is_dram;
-    cmd.write_paged.start_page = start_page_cmd;
-    cmd.write_paged.base_addr = base_addr;
-    cmd.write_paged.page_size = page_size;
-    cmd.write_paged.pages = pages;
-
-    log_debug(
-        tt::LogTest,
-        "Adding CQ_DISPATCH_CMD_WRITE_PAGED - is_dram: {} start_page: {} start_page_cmd: {} base_addr: 0x{:x} "
-        "bank_offset: 0x{:x} page_size: {} pages: {})",
-        is_dram,
-        start_page,
-        start_page_cmd,
-        base_addr,
-        bank_offset,
-        page_size,
-        pages);
-
-    add_dispatcher_paged_cmd(device, cmds, device_data, cmd, start_page, is_dram);
-}
-
-inline void gen_dispatcher_packed_write_cmd(
-    IDevice* device,
-    std::vector<uint32_t>& cmds,
-    std::vector<CoreCoord>& worker_cores,
-    DeviceData& device_data,
-    uint32_t size_words,
-    bool repeat = false) {
-    // Pad w/ blank data until all workers are at the same address
-    device_data.relevel(tt::CoreType::WORKER);
-
-    CQDispatchCmd cmd{};
-    memset(&cmd, 0, sizeof(CQDispatchCmd));
-
-    cmd.base.cmd_id = CQ_DISPATCH_CMD_WRITE_PACKED;
-    cmd.write_packed.flags =
-        repeat ? CQ_DISPATCH_CMD_PACKED_WRITE_FLAG_NO_STRIDE : CQ_DISPATCH_CMD_PACKED_WRITE_FLAG_NONE;
-    cmd.write_packed.count = worker_cores.size();
-    cmd.write_packed.addr = device_data.get_result_data_addr(worker_cores[0]);
-    cmd.write_packed.size = size_words * sizeof(uint32_t);
-
-    uint32_t sub_cmds_size =
-        padded_size(worker_cores.size() * sizeof(CQDispatchWritePackedUnicastSubCmd), sizeof(CQDispatchCmd));
-    TT_FATAL(
-        repeat == false ||
-            size_words * sizeof(uint32_t) + sizeof(CQDispatchCmd) + sub_cmds_size <= dispatch_buffer_page_size_g,
-        "Error");
-
-    add_dispatcher_packed_cmd(device, cmds, worker_cores, device_data, cmd, size_words, repeat);
-}
-
-inline void gen_rnd_dispatcher_packed_write_cmd(IDevice* device, std::vector<uint32_t>& cmds, DeviceData& device_data) {
-    // Note: this cmd doesn't clamp to a max size which means it can overflow L1 buffer
-    // However, this cmd doesn't send much data and the L1 buffer is < L1 limit, so...
-
-    uint32_t xfer_size_words = (std::rand() % (dispatch_buffer_page_size_g / sizeof(uint32_t))) + 1;
-    uint32_t xfer_size_bytes = xfer_size_words * sizeof(uint32_t);
-    if (perf_test_g) {
-        TT_ASSERT(max_xfer_size_bytes_g <= dispatch_buffer_page_size_g);
-        xfer_size_bytes = std::min(xfer_size_bytes, max_xfer_size_bytes_g);
-        xfer_size_bytes = std::max(xfer_size_bytes, min_xfer_size_bytes_g);
+        log_info(
+            LogTest,
+            "BW: {:.3f} GB/s (total_words: {:.0f}, size: {:.2f} MB, iterations: {}, cores: {})",
+            bw_gbps,
+            total_words,
+            total_words * sizeof(uint32_t) / (1024.0 * 1024.0),
+            num_iterations,
+            num_cores_to_log);
     }
 
-    std::vector<CoreCoord> gets_data;
-    while (gets_data.empty()) {
-        for (auto& [core, one_worker] : device_data.get_data()) {
-            if (device_data.core_and_bank_present(core, 0) && one_worker[0].core_type == tt::CoreType::WORKER) {
-                if (send_to_all_g || std::rand() % 2) {
-                    gets_data.push_back(core);
-                }
+    // Helper function to execute generated commands
+    // Orchestrates the command buffer reservation, writing, and submission
+    virtual void execute_generated_commands(
+        const std::vector<HostMemDeviceCommand>& commands_per_iteration,
+        DeviceData& device_data,
+        size_t num_cores_to_log,
+        uint32_t num_iterations,
+        bool wait_for_completion = true,
+        bool wait_for_host_writes = false) {
+        // PHASE 2: Calculate total command buffer size
+        uint64_t per_iter_total = 0;
+        for (const auto& cmd : commands_per_iteration) {
+            per_iter_total += cmd.size_bytes();
+        }
+
+        const uint64_t total_cmd_bytes = num_iterations * per_iter_total;
+        log_info(tt::LogTest, "Total command bytes: {}", total_cmd_bytes);
+
+        // PHASE 3: Reserve and write commands
+        // Reserve a continuous block in the system memory issue queue for all commands across all iterations
+        // This memory is mapped and visible to the device's prefetcher kernel
+        void* cmd_buffer_base = mgr_->issue_queue_reserve(total_cmd_bytes, fdcq_->id());
+
+        // Use DeviceCommand helper (HugepageDeviceCommand) to write to the issue queue memory
+        // Two stage command construction:
+        // 1. Staging (HostMemDeviceCommand):
+        //    - commands_per_iteration: vector of HostMemDeviceCommand objects which holds a deep copy
+        //      of each command header + payload assembled offline without holding issue queue space
+        // 2. Writing (HugepageDeviceCommand):
+        //    - wraps a pointer that points directly to the issue queue memory (cmd_buffer_base)
+        //    - the loop below copies staged commands into the issue queue memory
+        HugepageDeviceCommand dc(cmd_buffer_base, total_cmd_bytes);
+
+        // Store the size of each command entry (per-chunk)
+        std::vector<uint32_t> entry_sizes;
+
+        // Calculate the total number of entries to reserve
+        size_t total_num_entries = num_iterations * commands_per_iteration.size();
+        entry_sizes.reserve(total_num_entries);
+
+        // Write commands to the command buffer for all iterations
+        for (uint32_t iter = 0; iter < num_iterations; ++iter) {
+            for (const auto& cmd : commands_per_iteration) {
+                // Add the command data to the command buffer
+                dc.add_data(cmd.data(), cmd.size_bytes(), cmd.size_bytes());
+                entry_sizes.push_back(cmd.size_bytes());
             }
         }
-    }
 
-    bool repeat = std::rand() % 2;
-    if (repeat) {
-        // TODO fix this if/when we add mcast
-        uint32_t sub_cmds_size = padded_size(
-            gets_data.size() * sizeof(uint32_t), MetalContext::instance().hal().get_alignment(HalMemType::L1));
-        if (xfer_size_bytes + sizeof(CQDispatchCmd) + sub_cmds_size > dispatch_buffer_page_size_g) {
-            static bool warned = false;
-            if (!warned) {
-                log_warning(
-                    tt::LogTest,
-                    "Clamping packed_write cmd w/ stride=0 size to fit a dispatch page.  Adjust max/min xfer sizes for "
-                    "reliable perf data");
-                warned = true;
-            }
-            xfer_size_bytes = dispatch_buffer_page_size_g - sizeof(CQDispatchCmd) - sub_cmds_size;
+        // Add barrier wait command after all commands across all iterations
+        // Helpful to ensure all commands are completed flush before terminating
+        // Without this, there can be occasional timeouts in MetalContext::initialize_and_launch_firmware()
+        // between test fixtures possibly because the previously issued commands
+        // are not completed before next firmware launch
+        DeviceCommandCalculator cmd_calc;
+        cmd_calc.add_dispatch_wait();
+        HostMemDeviceCommand cmd(cmd_calc.write_offset_bytes());
+        cmd.add_dispatch_wait(CQ_DISPATCH_CMD_WAIT_FLAG_BARRIER, 0, 0, 0);
+        dc.add_data(cmd.data(), cmd.size_bytes(), cmd.size_bytes());
+        entry_sizes.push_back(cmd.size_bytes());
+
+        // Verifies destination memory bounds
+        device_data.overflow_check(device_);
+
+        // PHASE 4: Submit and execute commands
+        // Update host-side write pointer
+        // Tells the SystemMemoryManager that valid data exists in the issue queue upto this point
+        mgr_->issue_queue_push_back(dc.write_offset_bytes(), fdcq_->id());
+
+        // Write the commands to the device-side fetch queue
+        // This updates the read/write pointers in the Device's L1 memory, effectively
+        // Signals to the prefetcher kernel that new commands are available to fetch
+        const auto start = std::chrono::steady_clock::now();
+        for (const uint32_t sz : entry_sizes) {
+            mgr_->fetch_queue_reserve_back(fdcq_->id());
+            mgr_->fetch_queue_write(sz, fdcq_->id());
+        }
+
+        // Wait for completion of the issued commands
+        if (wait_for_completion) {
+            distributed::Finish(mesh_device_->mesh_command_queue());
+        } else if (wait_for_host_writes) {
+            uint32_t total_expected_cq_payload = device_data.size() * sizeof(uint32_t);
+            // For host writes, wait until expected data is written into completion queue by dispatcher
+            wait_for_completion_queue_bytes(total_expected_cq_payload, wait_completion_timeout);
+        }
+        const auto end = std::chrono::steady_clock::now();
+
+        const std::chrono::duration<double> elapsed = end - start;
+        log_info(tt::LogTest, "Ran in {:f} ms (for {} iterations)", elapsed.count() * 1000.0, num_iterations);
+
+        // Validate results
+        const bool pass = device_data.validate(device_);
+        EXPECT_TRUE(pass) << "Dispatcher test failed validation";
+
+        // Report performance
+        if (pass) {
+            report_performance(device_data, num_cores_to_log, elapsed, num_iterations);
         }
     }
+};
 
-    gen_dispatcher_packed_write_cmd(device, cmds, gets_data, device_data, xfer_size_bytes / sizeof(uint32_t), repeat);
-}
-
-inline void gen_dispatcher_host_write_cmd(std::vector<uint32_t>& cmds, DeviceData& device_data, uint32_t length) {
-    CQDispatchCmd cmd{};
-    memset(&cmd, 0, sizeof(CQDispatchCmd));
-
-    cmd.base.cmd_id = CQ_DISPATCH_CMD_WRITE_LINEAR_H_HOST;
-    // Include cmd in transfer
-    cmd.write_linear_host.length = length + sizeof(CQDispatchCmd);
-
-    add_dispatcher_cmd(cmds, device_data.get_host_core(), device_data, cmd, length, false, true);
-}
-
-inline void gen_bare_dispatcher_host_write_cmd(std::vector<uint32_t>& cmds, uint32_t length) {
-    CQDispatchCmd cmd{};
-    memset(&cmd, 0, sizeof(CQDispatchCmd));
-
-    cmd.base.cmd_id = CQ_DISPATCH_CMD_WRITE_LINEAR_H_HOST;
-    // Include cmd in transfer
-    cmd.write_linear_host.length = length + sizeof(CQDispatchCmd);
-
-    add_bare_dispatcher_cmd(cmds, cmd);
-}
-
-inline void gen_dispatcher_set_write_offset_cmd(
-    std::vector<uint32_t>& cmds, uint32_t wo0, uint32_t wo1 = 0, uint32_t wo2 = 0) {
-    CQDispatchCmd cmd{};
-    memset(&cmd, 0, sizeof(CQDispatchCmd));
-
-    cmd.base.cmd_id = CQ_DISPATCH_CMD_SET_WRITE_OFFSET;
-    cmd.set_write_offset.offset_count = 3;
-    add_bare_dispatcher_cmd(cmds, cmd);
-    cmds.push_back(wo0);
-    cmds.push_back(wo1);
-    cmds.push_back(wo2);
-}
-
-inline void gen_dispatcher_terminate_cmd(std::vector<uint32_t>& cmds) {
-    CQDispatchCmd cmd{};
-    memset(&cmd, 0, sizeof(CQDispatchCmd));
-
-    cmd.base.cmd_id = CQ_DISPATCH_CMD_TERMINATE;
-    uint32_t payload_length = 0;
-    add_dispatcher_cmd(cmds, cmd, payload_length);
-}
+}  // namespace Common
+}  // namespace tt::tt_dispatch_tests

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
@@ -48,8 +48,6 @@ constexpr uint32_t DEFAULT_ITERATIONS_LINEAR_WRITE = 3;
 constexpr uint32_t DEFAULT_ITERATIONS_PAGED_WRITE = 1;
 constexpr uint32_t DEFAULT_ITERATIONS_PACKED_WRITE = 1;
 constexpr uint32_t DEFAULT_ITERATIONS_PACKED_WRITE_LARGE = 1;
-constexpr uint32_t DRAM_DATA_SIZE_BYTES = 16 * 1024 * 1024;
-constexpr uint32_t DRAM_DATA_SIZE_WORDS = DRAM_DATA_SIZE_BYTES / sizeof(uint32_t);
 
 // Params that control the data volume, iteration count, and multicast/unicast
 // for the linear write test
@@ -823,13 +821,13 @@ INSTANTIATE_TEST_SUITE_P(
     DispatchLinearWriteTestFixture,
     ::testing::Values(
         // Testcase: 49152 bytes (Unicast)
-        LinearWriteParams{49152, DEFAULT_ITERATIONS_LINEAR_WRITE, DRAM_DATA_SIZE_WORDS, false},
+        LinearWriteParams{49152, DEFAULT_ITERATIONS_LINEAR_WRITE, Common::DRAM_DATA_SIZE_WORDS, false},
         // Testcase: 196608 bytes (Unicast)
-        LinearWriteParams{196608, DEFAULT_ITERATIONS_LINEAR_WRITE, DRAM_DATA_SIZE_WORDS, false},
+        LinearWriteParams{196608, DEFAULT_ITERATIONS_LINEAR_WRITE, Common::DRAM_DATA_SIZE_WORDS, false},
         // Testcase: 49152 bytes (Multicast)
-        LinearWriteParams{49152, DEFAULT_ITERATIONS_LINEAR_WRITE, DRAM_DATA_SIZE_WORDS, true},
+        LinearWriteParams{49152, DEFAULT_ITERATIONS_LINEAR_WRITE, Common::DRAM_DATA_SIZE_WORDS, true},
         // Testcase: 196608 bytes (Multicast)
-        LinearWriteParams{196608, DEFAULT_ITERATIONS_LINEAR_WRITE, DRAM_DATA_SIZE_WORDS, true}),
+        LinearWriteParams{196608, DEFAULT_ITERATIONS_LINEAR_WRITE, Common::DRAM_DATA_SIZE_WORDS, true}),
     [](const testing::TestParamInfo<LinearWriteParams>& info) {
         return std::to_string(info.param.transfer_size_bytes) + "B_" + std::to_string(info.param.num_iterations) +
                "iter_" + std::to_string(info.param.dram_data_size_words) + "words_" +
@@ -841,21 +839,21 @@ INSTANTIATE_TEST_SUITE_P(
     DispatchPagedWriteTestFixture,
     ::testing::Values(
         // Testcase: 512 pages x 16 bytes (DRAM)
-        PagedWriteParams{16, 512, DEFAULT_ITERATIONS_PAGED_WRITE, DRAM_DATA_SIZE_WORDS, true},
+        PagedWriteParams{16, 512, DEFAULT_ITERATIONS_PAGED_WRITE, Common::DRAM_DATA_SIZE_WORDS, true},
         // Testcase: 512 pages x 16 bytes (L1)
-        PagedWriteParams{16, 512, DEFAULT_ITERATIONS_PAGED_WRITE, DRAM_DATA_SIZE_WORDS, false},
+        PagedWriteParams{16, 512, DEFAULT_ITERATIONS_PAGED_WRITE, Common::DRAM_DATA_SIZE_WORDS, false},
         // Testcase: 128 pages x 2048 bytes (DRAM)
-        PagedWriteParams{2048, 128, DEFAULT_ITERATIONS_PAGED_WRITE, DRAM_DATA_SIZE_WORDS, true},
+        PagedWriteParams{2048, 128, DEFAULT_ITERATIONS_PAGED_WRITE, Common::DRAM_DATA_SIZE_WORDS, true},
         // Testcase: 128 pages x 2048 bytes (L1)
-        PagedWriteParams{2048, 128, DEFAULT_ITERATIONS_PAGED_WRITE, DRAM_DATA_SIZE_WORDS, false},
+        PagedWriteParams{2048, 128, DEFAULT_ITERATIONS_PAGED_WRITE, Common::DRAM_DATA_SIZE_WORDS, false},
         // Testcase: 10 pages x 4128 bytes (not 4K-aligned) (DRAM)
-        PagedWriteParams{4128, 10, DEFAULT_ITERATIONS_PAGED_WRITE, DRAM_DATA_SIZE_WORDS, true},
+        PagedWriteParams{4128, 10, DEFAULT_ITERATIONS_PAGED_WRITE, Common::DRAM_DATA_SIZE_WORDS, true},
         // Testcase: 13 pages x 16 bytes (arbitrary non-even numbers) (DRAM)
-        PagedWriteParams{16, 13, DEFAULT_ITERATIONS_PAGED_WRITE, DRAM_DATA_SIZE_WORDS, true},
+        PagedWriteParams{16, 13, DEFAULT_ITERATIONS_PAGED_WRITE, Common::DRAM_DATA_SIZE_WORDS, true},
         // Testcase: 13 pages x 16 bytes (arbitrary non-even numbers) (L1)
-        PagedWriteParams{16, 13, DEFAULT_ITERATIONS_PAGED_WRITE, DRAM_DATA_SIZE_WORDS, false},
+        PagedWriteParams{16, 13, DEFAULT_ITERATIONS_PAGED_WRITE, Common::DRAM_DATA_SIZE_WORDS, false},
         // Testcase: 100 pages x 8192 bytes (high BW) (DRAM)
-        PagedWriteParams{8192, 100, DEFAULT_ITERATIONS_PAGED_WRITE, DRAM_DATA_SIZE_WORDS, true}),
+        PagedWriteParams{8192, 100, DEFAULT_ITERATIONS_PAGED_WRITE, Common::DRAM_DATA_SIZE_WORDS, true}),
     [](const testing::TestParamInfo<PagedWriteParams>& info) {
         std::stringstream ss;
         ss << "page_size" << info.param.page_size << "_np" << info.param.num_pages << "_iter"
@@ -868,9 +866,9 @@ INSTANTIATE_TEST_SUITE_P(
     DispatchPackedWriteTestFixture,
     ::testing::Values(
         // Testcase: 786432 bytes (Unicast)
-        PackedWriteParams{786432, DEFAULT_ITERATIONS_PACKED_WRITE, DRAM_DATA_SIZE_WORDS},
+        PackedWriteParams{786432, DEFAULT_ITERATIONS_PACKED_WRITE, Common::DRAM_DATA_SIZE_WORDS},
         // Testcase: 819200 bytes (Unicast)
-        PackedWriteParams{819200, DEFAULT_ITERATIONS_PACKED_WRITE, DRAM_DATA_SIZE_WORDS}),
+        PackedWriteParams{819200, DEFAULT_ITERATIONS_PACKED_WRITE, Common::DRAM_DATA_SIZE_WORDS}),
     [](const testing::TestParamInfo<PackedWriteParams>& info) {
         return std::to_string(info.param.transfer_size_bytes) + "B_" + std::to_string(info.param.num_iterations) +
                "iter_" + std::to_string(info.param.dram_data_size_words) + "words_";
@@ -881,9 +879,9 @@ INSTANTIATE_TEST_SUITE_P(
     DispatchPackedWriteLargeTestFixture,
     ::testing::Values(
         // Testcase: 40960 bytes
-        PackedWriteParams{40960, DEFAULT_ITERATIONS_PACKED_WRITE_LARGE, DRAM_DATA_SIZE_WORDS},
+        PackedWriteParams{40960, DEFAULT_ITERATIONS_PACKED_WRITE_LARGE, Common::DRAM_DATA_SIZE_WORDS},
         // Testcase: 409600 bytes
-        PackedWriteParams{409600, DEFAULT_ITERATIONS_PACKED_WRITE_LARGE, DRAM_DATA_SIZE_WORDS}),
+        PackedWriteParams{409600, DEFAULT_ITERATIONS_PACKED_WRITE_LARGE, Common::DRAM_DATA_SIZE_WORDS}),
     [](const testing::TestParamInfo<PackedWriteParams>& info) {
         return std::to_string(info.param.transfer_size_bytes) + "B_" + std::to_string(info.param.num_iterations) +
                "iter_" + std::to_string(info.param.dram_data_size_words) + "words_";

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
@@ -14,13 +14,9 @@
 #include "tt_metal/test_utils/stimulus.hpp"
 #include "tt_metal/impl/dispatch/kernels/cq_commands.hpp"
 #include <umd/device/types/core_coordinates.hpp>
-#include <impl/dispatch/dispatch_mem_map.hpp>
 #include "tt_metal/impl/context/metal_context.hpp"
 #include <tt-metalium/tt_align.hpp>
-#include "tt_metal/impl/dispatch/system_memory_manager.hpp"
-#include "command_queue_fixture.hpp"
 #include "tt_metal/impl/dispatch/topology.hpp"
-#include "dispatch/device_command_calculator.hpp"
 #include "tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h"
 
 /*
@@ -32,7 +28,7 @@
  *
  * The test flow follows a "Shadow Model" pattern:
  * 1. Plan: Determine transfer sizes, destinations, and command types.
- * 2. Shadow: Update `DeviceData` (the expectation model) to reflect what *should* happen.
+ * 2. Shadow: Update `DeviceData` (the expectation model) to reflect what should happen.
  * 3. Build: Use `DeviceCommand` and `DeviceCommandCalculator` to construct binary
  *    command packets (HostMemDeviceCommand) exactly as the runtime would.
  * 4. Execute and Validate: Push these raw commands directly into the Issue Queue and notify the hardware.
@@ -45,19 +41,8 @@
  * - Dispatcher: Kernel that parses commands and issues writes/signals to Worker cores.
  */
 
-// Temporary globals shared with legacy test_prefetcher.cpp and common.h
-// In the refactor of test_prefetcher.cpp, they will be encapsulated in a struct DispatchTestContext
-// that can be passed to common.h and test fixtures.
-bool use_coherent_data_g = false;  // Use sequential test data vs random
-uint32_t dispatch_buffer_page_size_g =
-    1 << tt::tt_metal::DispatchSettings::DISPATCH_BUFFER_LOG_PAGE_SIZE;  // Dispatch buffer page size (bytes)
-uint32_t min_xfer_size_bytes_g = 16;                                     // Min transfer size for random commands
-uint32_t max_xfer_size_bytes_g = 4096;                                   // Max transfer size for random commands
-bool send_to_all_g = true;                                               // Send to all cores vs random subset
-bool perf_test_g = false;                                                // Perf mode: use consistent sizes
-uint32_t hugepage_issue_buffer_size_g;                                   // Hugepage issue buffer size (runtime)
-
-namespace tt::tt_dispatch::dispatcher_tests {
+namespace tt::tt_dispatch_tests {
+namespace dispatcher_tests {
 
 constexpr uint32_t DEFAULT_ITERATIONS_LINEAR_WRITE = 3;
 constexpr uint32_t DEFAULT_ITERATIONS_PAGED_WRITE = 1;
@@ -65,15 +50,6 @@ constexpr uint32_t DEFAULT_ITERATIONS_PACKED_WRITE = 1;
 constexpr uint32_t DEFAULT_ITERATIONS_PACKED_WRITE_LARGE = 1;
 constexpr uint32_t DRAM_DATA_SIZE_BYTES = 16 * 1024 * 1024;
 constexpr uint32_t DRAM_DATA_SIZE_WORDS = DRAM_DATA_SIZE_BYTES / sizeof(uint32_t);
-
-// Forward declare the accessor
-// Exposes the internal system memory manager of the FDMeshCommandQueue
-class FDMeshCQTestAccessor {
-public:
-    static tt_metal::SystemMemoryManager& sysmem(tt_metal::distributed::FDMeshCommandQueue& cq) {
-        return cq.reference_sysmem_manager();
-    }
-};
 
 // Params that control the data volume, iteration count, and multicast/unicast
 // for the linear write test
@@ -102,61 +78,7 @@ struct PackedWriteParams {
     uint32_t dram_data_size_words{};
 };
 
-// This will be ported to common.h when test_prefetcher.cpp is refactored
 namespace DeviceDataUpdater {
-
-// Update DeviceData for linear write
-// Mirrors a dispatcher linear-write transaction into the DeviceData expectation model
-void update_linear_write(
-    const std::vector<uint32_t>& payload, DeviceData& device_data, const CoreRange& worker_range, bool is_mcast) {
-    // Update expected device_data
-    if (is_mcast) {
-        for (const uint32_t datum : payload) {
-            device_data.push_range(worker_range, datum, true);
-        }
-    } else {
-        for (const uint32_t datum : payload) {
-            device_data.push_one(worker_range.start_coord, 0, datum);
-        }
-    }
-    // Relevel for next multicast command
-    if (is_mcast) {
-        device_data.relevel(tt::CoreType::WORKER);
-    }
-}
-
-// Update DeviceData for paged write
-// Tracks page-wise writes so validate() can check DRAM/L1 bank contents after the test runs
-void update_paged_write(
-    const std::vector<uint32_t>& payload,
-    DeviceData& device_data,
-    const CoreCoord& bank_core,
-    uint32_t bank_id,
-    uint32_t page_alignment) {
-    for (const uint32_t datum : payload) {
-        device_data.push_one(bank_core, bank_id, datum);
-    }
-    device_data.pad(bank_core, bank_id, page_alignment);
-}
-
-// Update DeviceData for packed write
-// Applies packed write payloads to every selected worker
-void update_packed_write(
-    const std::vector<uint32_t>& payload,
-    DeviceData& device_data,
-    const std::vector<CoreCoord>& worker_cores,
-    uint32_t l1_alignment) {
-    // Update expected device_data for all cores
-    for (const auto& core : worker_cores) {
-        for (const uint32_t datum : payload) {
-            device_data.push_one(core, 0, datum);
-        }
-        device_data.pad(core, 0, l1_alignment);
-    }
-
-    // Re-relevel for next command
-    device_data.relevel(tt::CoreType::WORKER);
-}
 
 // Update DeviceData for packed large write
 // Populates DeviceData for the packed-large multicast path
@@ -176,132 +98,12 @@ void update_packed_large_write(
         }
     }
 }
-};  // namespace DeviceDataUpdater
+}  // namespace DeviceDataUpdater
 
 // Host-side helpers used by tests to emit the same CQ commands
 // that dispatcher code emits. This namespace replicates the production code's command generation logic
 // for testing purposes.
-// This will be ported to common.h when test_prefetcher.cpp is refactored
 namespace CommandBuilder {
-
-// Emits a single linear write, optionally multicast, with inline data
-template <bool flush_prefetch, bool inline_data>
-HostMemDeviceCommand build_linear_write_command(
-    const std::vector<uint32_t>& payload,
-    const CoreRange& worker_range,
-    bool is_mcast,
-    uint32_t noc_xy,
-    uint32_t addr,
-    uint32_t xfer_size_bytes) {
-    // Calculate the command size using DeviceCommandCalculator
-    // Pre-calculate the exact size to allocate correct amount of memory in HostMemDeviceCommand buffer
-    DeviceCommandCalculator cmd_calc;
-    cmd_calc.add_dispatch_write_linear<flush_prefetch, inline_data>(xfer_size_bytes);
-    const uint32_t command_size_bytes = cmd_calc.write_offset_bytes();
-
-    // Create the HostMemDeviceCommand with pre-calculated size
-    HostMemDeviceCommand cmd(command_size_bytes);
-
-    // Add the dispatch write linear command
-    cmd.add_dispatch_write_linear<flush_prefetch, inline_data>(
-        is_mcast ? worker_range.size() : 0,  // num_mcast_dests
-        noc_xy,                              // NOC coordinates
-        addr,                                // destination address
-        xfer_size_bytes,                     // data size
-        payload.data()                       // payload data
-    );
-
-    return cmd;
-}
-
-// Emits a paged write (DRAM or L1) chunk
-// payload is already stitched together for all pages in the chunk
-template <bool hugepage_write>
-HostMemDeviceCommand build_paged_write_command(
-    const std::vector<uint32_t>& payload,
-    uint32_t base_addr,
-    uint32_t page_size_bytes,
-    uint32_t pages_in_chunk,
-    uint16_t start_page_cmd,
-    bool is_dram) {
-    // Calculate the command size
-    DeviceCommandCalculator cmd_calc;
-    cmd_calc.add_dispatch_write_paged<hugepage_write>(page_size_bytes, pages_in_chunk);
-    const uint32_t command_size_bytes = cmd_calc.write_offset_bytes();
-
-    // Create the HostMemDeviceCommand with pre-calculated size
-    HostMemDeviceCommand cmd(command_size_bytes);
-
-    // Add the dispatch write paged command
-    cmd.add_dispatch_write_paged<hugepage_write>(
-        true,                           // flush_prefetch (inline data)
-        static_cast<uint8_t>(is_dram),  // is_dram
-        start_page_cmd,                 // start_page
-        base_addr,                      // base_addr
-        page_size_bytes,                // page_size
-        pages_in_chunk,                 // pages
-        payload.data()                  // payload for this chunk
-    );
-
-    return cmd;
-}
-
-// Serializes a packed-unicast command including sub-command table
-// and optional replicated payloads when stride is enabled
-HostMemDeviceCommand build_packed_write_command(
-    const std::vector<uint32_t>& payload,
-    const std::vector<CQDispatchWritePackedUnicastSubCmd>& sub_cmds,
-    uint32_t common_addr,
-    uint32_t l1_alignment,
-    uint32_t packed_write_max_unicast_sub_cmds,
-    bool no_stride) {
-    const uint32_t num_sub_cmds = static_cast<uint32_t>(sub_cmds.size());
-    const uint32_t sub_cmds_bytes = tt::align(num_sub_cmds * sizeof(CQDispatchWritePackedUnicastSubCmd), l1_alignment);
-    uint32_t num_data_copies = no_stride ? 1u : static_cast<uint32_t>(num_sub_cmds);
-
-    // Pre-calculate all sizes needed
-    const uint32_t payload_size_bytes = payload.size() * sizeof(uint32_t);
-    const uint32_t data_bytes = num_data_copies * tt::align(payload_size_bytes, l1_alignment);
-    const uint32_t payload_bytes = tt::align(sizeof(CQDispatchCmd) + sub_cmds_bytes, l1_alignment) + data_bytes;
-
-    // Calculate the command size
-    DeviceCommandCalculator cmd_calc;
-    cmd_calc.add_dispatch_write_packed<CQDispatchWritePackedUnicastSubCmd>(
-        num_sub_cmds,        // num_sub_cmds
-        payload_size_bytes,  // packed_data_sizeB
-        packed_write_max_unicast_sub_cmds,
-        no_stride  // no_stride
-    );
-    const uint32_t command_size_bytes = cmd_calc.write_offset_bytes();
-
-    // Create the HostMemDeviceCommand with pre-calculated size
-    HostMemDeviceCommand cmd(command_size_bytes);
-
-    // Build data_collection pointing to the payload
-    std::vector<std::pair<const void*, uint32_t>> data_collection;
-    const void* payload_data = payload.data();
-
-    if (no_stride) {
-        data_collection.emplace_back(payload_data, payload_size_bytes);
-    } else {
-        data_collection.resize(num_sub_cmds, {payload_data, payload_size_bytes});
-    }
-
-    // Add the dispatch write packed command
-    cmd.add_dispatch_write_packed<CQDispatchWritePackedUnicastSubCmd>(
-        0,                                          // type
-        num_sub_cmds,                               // num_sub_cmds
-        common_addr,                                // common_addr
-        static_cast<uint16_t>(payload_size_bytes),  // packed_data_sizeB
-        payload_bytes,                              // payload_sizeB
-        sub_cmds,                                   // sub_cmds
-        data_collection,                            // data_collection
-        packed_write_max_unicast_sub_cmds,          // packed_write_max_unicast_sub_cmds
-        0,                                          // offset_idx
-        no_stride);                                 // no_stride
-
-    return cmd;
-}
 
 //  Builds a multi-transaction packed-large command
 //  payload spans map 1:1 with the sub-command list
@@ -337,303 +139,12 @@ HostMemDeviceCommand build_packed_large_write_command(
 
     return cmd;
 }
-};  // namespace CommandBuilder
+}  // namespace CommandBuilder
 
-// This will be ported to common.h when test_prefetcher.cpp is refactored
-// DispatchPayloadGenerator is used to generate payloads for the tests
-class DispatchPayloadGenerator {
-public:
-    struct Config {
-        bool use_coherent_data = false;
-        uint32_t coherent_start_val = COHERENT_DATA_START_VALUE;
-        uint32_t seed = 0;
-
-        // Perf test configuration
-        bool perf_test = false;
-        uint32_t min_xfer_size_bytes = 0;
-        uint32_t max_xfer_size_bytes = 0;
-    };
-
-    DispatchPayloadGenerator(const Config& cfg) : config_(cfg), coherent_count_(cfg.coherent_start_val) {
-        if (config_.seed == 0) {
-            std::random_device rd;
-            rng_.seed(rd());
-        } else {
-            rng_.seed(config_.seed);
-        }
-    }
-
-    // Getter to log the seed used
-    uint32_t get_seed() const { return config_.seed; }
-
-    // Helper for random number generation in a range [min, max]
-    template <typename T>
-    T get_rand(T min, T max) {
-        static_assert(std::is_integral<T>::value, "T must be an integral type");
-        std::uniform_int_distribution<T> dist(min, max);
-        return dist(rng_);
-    }
-
-    // Helper for generating a random boolean (replaces std::rand() % 2)
-    bool get_rand_bool() { return (bool_dist(rng_) != 0); }
-
-    // Generates either deterministic (coherent) or random 32-bit words
-    // for the requested byte count
-    // In coherent mode, the counter is incremented so validation knows
-    // the exact pattern
-    std::vector<uint32_t> generate_payload(uint32_t xfer_size_bytes) {
-        const uint32_t size_words = xfer_size_bytes / sizeof(uint32_t);
-        std::vector<uint32_t> payload;
-        payload.reserve(size_words);
-
-        for (uint32_t i = 0; i < size_words; ++i) {
-            const uint32_t datum = config_.use_coherent_data ? coherent_count_++ : uint32_dist(rng_);
-            payload.push_back(datum);
-        }
-
-        return payload;
-    }
-
-    // Generate payload with page id
-    // Pass page_id to use for coherent data generation
-    std::vector<uint32_t> generate_payload_with_page_id(uint32_t page_size_words, uint32_t page_id) {
-        std::vector<uint32_t> payload;
-        payload.reserve(page_size_words);
-
-        for (uint32_t i = 0; i < page_size_words; ++i) {
-            const uint32_t datum = config_.use_coherent_data
-                                       ? (((page_id & 0xFF) << 24) | (coherent_count_++ & 0xFFFFFF))
-                                       : uint32_dist(rng_);
-            payload.push_back(datum);
-        }
-
-        return payload;
-    }
-
-    // Helper to generate payload data for a given core
-    // Pass core_id to use for coherent data generation
-    std::vector<uint32_t> generate_payload_with_core(
-        const CoreCoord& core_id,  // Pass the core to use
-        uint32_t xfer_size_bytes) {
-        const uint32_t size_words = xfer_size_bytes / sizeof(uint32_t);
-        std::vector<uint32_t> payload;
-        payload.reserve(size_words);
-
-        for (uint32_t i = 0; i < size_words; ++i) {
-            const uint32_t datum =
-                config_.use_coherent_data
-                    ? (((core_id.x & 0xFF) << 16) | ((core_id.y & 0xFF) << 24) | (coherent_count_++ & 0xFFFF))
-                    : uint32_dist(rng_);
-            payload.push_back(datum);
-        }
-
-        return payload;
-    }
-
-    // Chooses a payload size in 16B units, respecting perf mode clamps and remaining budget
-    uint32_t get_random_size(uint32_t max_allowed, uint32_t bytes_per_unit, uint32_t remaining_bytes) {
-        // Generate random transfer size
-        std::uniform_int_distribution<uint32_t> dist(1, max_allowed);
-        uint32_t xfer_size_16B = dist(rng_);
-        uint32_t xfer_size_bytes = xfer_size_16B * bytes_per_unit;  // Convert 16B units to bytes
-
-        // Clamp to remaining bytes
-        xfer_size_bytes = std::min(xfer_size_bytes, remaining_bytes);
-
-        // Apply perf_test_ constraints if enabled
-        if (config_.perf_test) {
-            xfer_size_bytes = std::clamp(xfer_size_bytes, config_.min_xfer_size_bytes, config_.max_xfer_size_bytes);
-        }
-
-        return xfer_size_bytes;
-    }
-
-private:
-    // Start offset to avoid 0x0 which matches DRAM prefill
-    static constexpr uint32_t COHERENT_DATA_START_VALUE = 0x100;
-    Config config_{};
-    uint32_t coherent_count_ = COHERENT_DATA_START_VALUE;
-
-    // Random number generation
-    std::mt19937 rng_;
-    // Distributions for random number generation
-    std::uniform_int_distribution<int> bool_dist{0, 1};
-    std::uniform_int_distribution<uint32_t> uint32_dist{
-        std::numeric_limits<uint32_t>::min(), std::numeric_limits<uint32_t>::max()};
-};
-
-class BaseDispatchTestFixture : public tt_metal::UnitMeshCQSingleCardFixture {
+class BaseDispatchTestFixture : public Common::BaseTestFixture {
 protected:
-    // DispatchPayloadGenerator for generating payloads
-    std::unique_ptr<DispatchPayloadGenerator> payload_generator_;
-
     // Common constants
     static constexpr uint32_t MAX_XFER_SIZE_16B = 4 * 1024;  // Shouldn't exceed max_fetch_bytes_
-    static constexpr CoreCoord default_worker_start = {0, 1};
-    static constexpr uint32_t bytes_per_16B_unit = 16;  // conversion factor to convert 16-byte "chunks" to bytes
-
-    // Common setup for all dispatch tests
-    // Provides shared wiring for mesh device access,
-    // and command-buffer helpers so derived fixtures
-    // only implement workload-specific planning
-    tt_metal::distributed::MeshDevice* mesh_device_ = nullptr;
-    tt_metal::distributed::FDMeshCommandQueue* fdcq_ = nullptr;
-    tt_metal::SystemMemoryManager* mgr_ = nullptr;
-    tt_metal::distributed::MeshDevice::IDevice* device_ = nullptr;
-
-    // HW properties
-    uint32_t host_alignment_ = 0;
-    uint32_t max_fetch_bytes_ = 0;
-
-    // Knobs from globals
-    uint32_t dispatch_buffer_page_size_ = 0;
-    bool send_to_all_ = false;
-
-    void SetUp() override {
-        tt_metal::UnitMeshCQSingleCardFixture::SetUp();
-
-        // Setup Config
-        DispatchPayloadGenerator::Config cfg;
-        cfg.use_coherent_data = use_coherent_data_g;  // derived from globals
-        cfg.perf_test = perf_test_g;
-        cfg.min_xfer_size_bytes = min_xfer_size_bytes_g;
-        cfg.max_xfer_size_bytes = max_xfer_size_bytes_g;
-
-        // Handle Seeding
-        std::random_device rd;
-        cfg.seed = rd();
-
-        // Initialize Generator
-        payload_generator_ = std::make_unique<DispatchPayloadGenerator>(cfg);
-        log_info(tt::LogTest, "Random seed set to {}", cfg.seed);
-
-        // These are used for test logic (loops, alignment, etc.) rather than generation
-        dispatch_buffer_page_size_ = dispatch_buffer_page_size_g;
-        send_to_all_ = send_to_all_g;
-
-        // Initialize common pointers
-        mesh_device_ = devices_[0].get();
-        auto& mcq = mesh_device_->mesh_command_queue();
-        fdcq_ = &dynamic_cast<distributed::FDMeshCommandQueue&>(mcq);
-        mgr_ = &FDMeshCQTestAccessor::sysmem(*fdcq_);
-        device_ = mesh_device_->get_devices()[0];
-
-        // Initialize common HW properties
-        host_alignment_ = tt_metal::MetalContext::instance().hal().get_alignment(tt_metal::HalMemType::HOST);
-        max_fetch_bytes_ = tt_metal::MetalContext::instance().dispatch_mem_map().max_prefetch_command_size();
-    }
-
-    // Helper function to report performance
-    void report_performance(
-        DeviceData& device_data,
-        size_t num_cores_to_log,
-        std::chrono::duration<double> elapsed,
-        uint32_t num_iterations) {
-        const float total_words = static_cast<float>(device_data.size()) * num_iterations;
-        const float bw_gbps = total_words * sizeof(uint32_t) / (elapsed.count() * 1024.0 * 1024.0 * 1024.0);
-
-        log_info(
-            LogTest,
-            "BW: {:.3f} GB/s (total_words: {:.0f}, size: {:.2f} MB, iterations: {}, cores: {})",
-            bw_gbps,
-            total_words,
-            total_words * sizeof(uint32_t) / (1024.0 * 1024.0),
-            num_iterations,
-            num_cores_to_log);
-    }
-
-    // Helper function to execute generated commands
-    // Orchestrates the command buffer reservation, writing, and submission
-    void execute_generated_commands(
-        const std::vector<HostMemDeviceCommand>& commands_per_iteration,
-        DeviceData& device_data,
-        size_t num_cores_to_log,
-        uint32_t num_iterations) {
-        // PHASE 2: Calculate total command buffer size
-        uint64_t per_iter_total = 0;
-        for (const auto& cmd : commands_per_iteration) {
-            per_iter_total += cmd.size_bytes();
-        }
-
-        const uint64_t total_cmd_bytes = num_iterations * per_iter_total;
-        log_info(tt::LogTest, "Total command bytes: {}", total_cmd_bytes);
-
-        // PHASE 3: Reserve and write commands
-        // Reserve a continuous block in the system memory issue queue for all commands across all iterations
-        // This memory is mapped and visible to the device's prefetcher kernel
-        void* cmd_buffer_base = mgr_->issue_queue_reserve(total_cmd_bytes, fdcq_->id());
-
-        // Use DeviceCommand helper (HugepageDeviceCommand) to write to the issue queue memory
-        // Two stage command construction:
-        // 1. Staging (HostMemDeviceCommand):
-        //    - commands_per_iteration: vector of HostMemDeviceCommand objects which holds a deep copy
-        //      of each command header + payload assembled offline without holding issue queue space
-        // 2. Writing (HugepageDeviceCommand):
-        //    - wraps a pointer that points directly to the issue queue memory (cmd_buffer_base)
-        //    - the loop below copies staged commands into the issue queue memory
-        HugepageDeviceCommand dc(cmd_buffer_base, total_cmd_bytes);
-
-        // Store the size of each command entry (per-chunk)
-        std::vector<uint32_t> entry_sizes;
-
-        // Calculate the total number of entries to reserve
-        size_t total_num_entries = num_iterations * commands_per_iteration.size();
-        entry_sizes.reserve(total_num_entries);
-
-        // Write commands to the command buffer for all iterations
-        for (uint32_t iter = 0; iter < num_iterations; ++iter) {
-            for (const auto& cmd : commands_per_iteration) {
-                // Add the command data to the command buffer
-                dc.add_data(cmd.data(), cmd.size_bytes(), cmd.size_bytes());
-                entry_sizes.push_back(cmd.size_bytes());
-            }
-        }
-
-        // Add barrier wait command after all commands across all iterations
-        // Helpful to ensure all commands are completed flush before terminating
-        // Without this, there can be occasional timeouts in MetalContext::initialize_and_launch_firmware()
-        // between test fixtures possibly because the previously issued commands
-        // are not completed before next firmware launch
-        DeviceCommandCalculator cmd_calc;
-        cmd_calc.add_dispatch_wait();
-        HostMemDeviceCommand cmd(cmd_calc.write_offset_bytes());
-        cmd.add_dispatch_wait(CQ_DISPATCH_CMD_WAIT_FLAG_BARRIER, 0, 0, 0);
-        dc.add_data(cmd.data(), cmd.size_bytes(), cmd.size_bytes());
-        entry_sizes.push_back(cmd.size_bytes());
-
-        // Verifies destination memory bounds
-        device_data.overflow_check(device_);
-
-        // PHASE 4: Submit and execute commands
-        // Update host-side write pointer
-        // Tells the SystemMemoryManager that valid data exists in the issue queue upto this point
-        mgr_->issue_queue_push_back(dc.write_offset_bytes(), fdcq_->id());
-
-        // Write the commands to the device-side fetch queue
-        // This updates the read/write pointers in the Device's L1 memory, effectively
-        // Signals to the prefetcher kernel that new commands are available to fetch
-        const auto start = std::chrono::steady_clock::now();
-        for (const uint32_t sz : entry_sizes) {
-            mgr_->fetch_queue_reserve_back(fdcq_->id());
-            mgr_->fetch_queue_write(sz, fdcq_->id());
-        }
-
-        // Wait for completion of the issued commands
-        distributed::Finish(mesh_device_->mesh_command_queue());
-        const auto end = std::chrono::steady_clock::now();
-
-        const std::chrono::duration<double> elapsed = end - start;
-        log_info(tt::LogTest, "Ran in {:.3f} ms (for {} iterations)", elapsed.count() * 1000.0, num_iterations);
-
-        // Validate results
-        const bool pass = device_data.validate(device_);
-        EXPECT_TRUE(pass) << "Dispatcher test failed validation";
-
-        // Report performance
-        if (pass) {
-            report_performance(device_data, num_cores_to_log, elapsed, num_iterations);
-        }
-    }
 };
 
 class DispatchLinearWriteTestFixture : public BaseDispatchTestFixture,
@@ -699,11 +210,12 @@ public:
             std::vector<uint32_t> payload = payload_generator_->generate_payload(xfer_size_bytes);
 
             // Update DeviceData for linear write
-            DeviceDataUpdater::update_linear_write(payload, device_data, worker_range, is_mcast_);
+            Common::DeviceDataUpdater::update_linear_write(payload, device_data, worker_range, is_mcast_);
 
             // Create the HostMemDeviceCommand
-            HostMemDeviceCommand cmd = CommandBuilder::build_linear_write_command<flush_prefetch_, inline_data_>(
-                payload, worker_range, is_mcast_, noc_xy, addr, xfer_size_bytes);
+            HostMemDeviceCommand cmd =
+                Common::CommandBuilder::build_linear_write_command<flush_prefetch_, inline_data_>(
+                    payload, worker_range, is_mcast_, noc_xy, addr, xfer_size_bytes);
 
             commands_per_iteration.push_back(std::move(cmd));
             remaining_bytes -= xfer_size_bytes;
@@ -746,7 +258,7 @@ class DispatchPagedWriteTestFixture : public BaseDispatchTestFixture,
     }
 
 protected:
-    static constexpr bool hugepage_write_ = true;
+    static constexpr bool inline_data_ = true;
 
 public:
     void SetUp() override {
@@ -800,7 +312,7 @@ public:
                     payload_generator_->generate_payload_with_page_id(page_size_words, page_id);
 
                 // Update DeviceData for paged write
-                DeviceDataUpdater::update_paged_write(
+                Common::DeviceDataUpdater::update_paged_write(
                     page_payload, device_data, bank_core, bank_id, page_size_alignment_bytes);
 
                 // Append page payload to chunk payload
@@ -815,7 +327,7 @@ public:
             const uint16_t start_page_cmd = absolute_start_page % num_banks;
 
             // Create the HostMemDeviceCommand
-            HostMemDeviceCommand cmd = CommandBuilder::build_paged_write_command<hugepage_write_>(
+            HostMemDeviceCommand cmd = Common::CommandBuilder::build_paged_write_command<inline_data_>(
                 chunk_payload, base_addr, page_size_bytes, pages_in_chunk, start_page_cmd, is_dram_);
 
             commands_per_iteration.push_back(std::move(cmd));
@@ -847,19 +359,6 @@ class DispatchPackedWriteTestFixture : public BaseDispatchTestFixture,
     uint32_t num_iterations_{};
     uint32_t dram_data_size_words_{};
 
-    // Build subcmds once - reused for all commands
-    std::vector<CQDispatchWritePackedUnicastSubCmd> build_sub_cmds(const std::vector<CoreCoord>& worker_cores) {
-        std::vector<CQDispatchWritePackedUnicastSubCmd> sub_cmds;
-        sub_cmds.reserve(worker_cores.size());
-        for (const auto& core : worker_cores) {
-            const CoreCoord virtual_core = device_->virtual_core_from_logical_core(core, CoreType::WORKER);
-            CQDispatchWritePackedUnicastSubCmd sub_cmd{};
-            sub_cmd.noc_xy_addr = device_->get_noc_unicast_encoding(k_dispatch_downstream_noc, virtual_core);
-            sub_cmds.push_back(sub_cmd);
-        }
-        return sub_cmds;
-    }
-
     // Clamp xfer_size to fit within max_fetch_bytes_
     uint32_t clamp_to_max_fetch(
         uint32_t xfer_size_bytes,
@@ -867,35 +366,13 @@ class DispatchPackedWriteTestFixture : public BaseDispatchTestFixture,
         uint32_t packed_write_max_unicast_sub_cmds,
         bool no_stride,
         uint32_t l1_alignment) {
-        // Calculate the command size
-        DeviceCommandCalculator cmd_calc;
-        cmd_calc.add_dispatch_write_packed<CQDispatchWritePackedUnicastSubCmd>(
-            num_sub_cmds,     // num_sub_cmds
-            xfer_size_bytes,  // packed_data_sizeB
+        return Common::PackedWriteUtils::clamp_to_max_fetch(
+            max_fetch_bytes_,
+            xfer_size_bytes,
+            num_sub_cmds,
             packed_write_max_unicast_sub_cmds,
-            no_stride  // no_stride
-        );
-        uint32_t command_size_bytes = cmd_calc.write_offset_bytes();
-        // If the command size is less than max_fetch_bytes_, return the transfer size
-        if (command_size_bytes <= max_fetch_bytes_) {
-            return xfer_size_bytes;
-        }
-
-        // Else, linearly decrement by alignment until it fits
-        // We can use binary search to speed this up
-        uint32_t result = xfer_size_bytes;
-        while (result > 0 && command_size_bytes > max_fetch_bytes_) {
-            result -= l1_alignment;
-            cmd_calc.add_dispatch_write_packed<CQDispatchWritePackedUnicastSubCmd>(
-                num_sub_cmds,  // num_sub_cmds
-                result,        // packed_data_sizeB
-                packed_write_max_unicast_sub_cmds,
-                no_stride  // no_stride
-            );
-            command_size_bytes = cmd_calc.write_offset_bytes();
-        }
-
-        return result;
+            no_stride,
+            l1_alignment);
     };
 
 public:
@@ -926,7 +403,8 @@ public:
             tt::align(num_sub_cmds * sizeof(CQDispatchWritePackedUnicastSubCmd), l1_alignment);
 
         // Build subcmds once - reused for all commands
-        std::vector<CQDispatchWritePackedUnicastSubCmd> sub_cmds = build_sub_cmds(worker_cores);
+        std::vector<CQDispatchWritePackedUnicastSubCmd> sub_cmds =
+            Common::PackedWriteUtils::build_sub_cmds(device_, worker_cores, k_dispatch_downstream_noc);
 
         // Relevel once before generating commands
         device_data.relevel(tt::CoreType::WORKER);
@@ -965,9 +443,9 @@ public:
             std::vector<uint32_t> payload = payload_generator_->generate_payload_with_core(fw, xfer_size_bytes);
 
             // Update expected device_data for all cores
-            DeviceDataUpdater::update_packed_write(payload, device_data, worker_cores, l1_alignment);
+            Common::DeviceDataUpdater::update_packed_write(payload, device_data, worker_cores, l1_alignment);
 
-            HostMemDeviceCommand cmd = CommandBuilder::build_packed_write_command(
+            HostMemDeviceCommand cmd = Common::CommandBuilder::build_packed_write_command(
                 payload, sub_cmds, common_addr, l1_alignment, packed_write_max_unicast_sub_cmds, no_stride);
 
             // Add command to batch
@@ -1171,7 +649,7 @@ TEST_P(DispatchLinearWriteTestFixture, LinearWrite) {
     const uint32_t l1_base = device_->allocator()->get_base_allocator_addr(HalMemType::L1);
     const uint32_t dram_base = device_->allocator()->get_base_allocator_addr(HalMemType::DRAM);
 
-    DeviceData device_data(device_, worker_range, l1_base, dram_base, nullptr, false, dram_data_size_words);
+    DeviceData device_data(device_, worker_range, l1_base, dram_base, nullptr, false, dram_data_size_words, cfg_);
 
     // Calculate the overhead for a linear write command using DeviceCommandCalculator
     // Substracting the overhead from max_fetch_bytes_ gives the max allowed payload size per command
@@ -1217,7 +695,7 @@ TEST_P(DispatchPagedWriteTestFixture, PagedWrite) {
     const uint32_t l1_base = device_->allocator()->get_base_allocator_addr(HalMemType::L1);
     const uint32_t dram_base = device_->allocator()->get_base_allocator_addr(HalMemType::DRAM);
 
-    DeviceData device_data(device_, worker_range, l1_base, dram_base, nullptr, true, dram_data_size_words);
+    DeviceData device_data(device_, worker_range, l1_base, dram_base, nullptr, true, dram_data_size_words, cfg_);
 
     const auto buf_type = is_dram ? BufferType::DRAM : BufferType::L1;
     const uint32_t page_size_alignment_bytes = device_->allocator()->get_alignment(buf_type);
@@ -1233,7 +711,7 @@ TEST_P(DispatchPagedWriteTestFixture, PagedWrite) {
     // 0 pages for overhead only
     // Substracting the overhead from max_fetch_bytes_ gives the max allowed payload size per command
     DeviceCommandCalculator cmd_calc;
-    cmd_calc.add_dispatch_write_paged<hugepage_write_>(page_size_bytes, 0);
+    cmd_calc.add_dispatch_write_paged<inline_data_>(page_size_bytes, 0);
     const uint32_t overhead_bytes = cmd_calc.write_offset_bytes();
     const uint32_t max_payload_per_cmd_bytes = max_fetch_bytes_ - overhead_bytes;
 
@@ -1273,7 +751,7 @@ TEST_P(DispatchPackedWriteTestFixture, WritePackedUnicast) {
     const uint32_t l1_base = device_->allocator()->get_base_allocator_addr(HalMemType::L1);
     const uint32_t dram_base = device_->allocator()->get_base_allocator_addr(HalMemType::DRAM);
 
-    DeviceData device_data(device_, worker_range, l1_base, dram_base, nullptr, false, dram_data_size_words);
+    DeviceData device_data(device_, worker_range, l1_base, dram_base, nullptr, false, dram_data_size_words, cfg_);
 
     const uint32_t l1_alignment = tt::tt_metal::MetalContext::instance().hal().get_alignment(HalMemType::L1);
     const uint32_t packed_write_max_unicast_sub_cmds =
@@ -1326,7 +804,7 @@ TEST_P(DispatchPackedWriteLargeTestFixture, WriteLargePackedMulticast) {
     const uint32_t dram_base = device_->allocator()->get_base_allocator_addr(HalMemType::DRAM);
 
     // Setup DeviceData for validation
-    DeviceData device_data(device_, worker_range, l1_base, dram_base, nullptr, false, dram_data_size_words);
+    DeviceData device_data(device_, worker_range, l1_base, dram_base, nullptr, false, dram_data_size_words, cfg_);
 
     // Get alignment requirements
     const uint32_t l1_alignment = tt::tt_metal::MetalContext::instance().hal().get_alignment(HalMemType::L1);
@@ -1409,4 +887,5 @@ INSTANTIATE_TEST_SUITE_P(
                "iter_" + std::to_string(info.param.dram_data_size_words) + "words_";
     });
 
-}  // namespace tt::tt_dispatch::dispatcher_tests
+}  // namespace dispatcher_tests
+}  // namespace tt::tt_dispatch_tests

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
@@ -646,8 +646,8 @@ TEST_P(DispatchLinearWriteTestFixture, LinearWrite) {
     }
     const CoreRange worker_range = {first_worker, last_worker};
 
-    const uint32_t l1_base = device_->allocator()->get_base_allocator_addr(HalMemType::L1);
-    const uint32_t dram_base = device_->allocator()->get_base_allocator_addr(HalMemType::DRAM);
+    const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
+    const uint32_t dram_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::DRAM);
 
     DeviceData device_data(device_, worker_range, l1_base, dram_base, nullptr, false, dram_data_size_words, cfg_);
 
@@ -692,14 +692,14 @@ TEST_P(DispatchPagedWriteTestFixture, PagedWrite) {
     const CoreCoord last_worker = {first_worker.x + 1, first_worker.y + 1};
     const CoreRange worker_range = {first_worker, last_worker};
 
-    const uint32_t l1_base = device_->allocator()->get_base_allocator_addr(HalMemType::L1);
-    const uint32_t dram_base = device_->allocator()->get_base_allocator_addr(HalMemType::DRAM);
+    const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
+    const uint32_t dram_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::DRAM);
 
     DeviceData device_data(device_, worker_range, l1_base, dram_base, nullptr, true, dram_data_size_words, cfg_);
 
     const auto buf_type = is_dram ? BufferType::DRAM : BufferType::L1;
-    const uint32_t page_size_alignment_bytes = device_->allocator()->get_alignment(buf_type);
-    const uint32_t num_banks = device_->allocator()->get_num_banks(buf_type);
+    const uint32_t page_size_alignment_bytes = device_->allocator_impl()->get_alignment(buf_type);
+    const uint32_t num_banks = device_->allocator_impl()->get_num_banks(buf_type);
     const tt::CoreType core_type = is_dram ? tt::CoreType::DRAM : tt::CoreType::WORKER;
 
     // Generate random page size
@@ -748,8 +748,8 @@ TEST_P(DispatchPackedWriteTestFixture, WritePackedUnicast) {
     const CoreCoord last_worker = {first_worker.x + 1, first_worker.y + 1};
     const CoreRange worker_range = {first_worker, last_worker};
 
-    const uint32_t l1_base = device_->allocator()->get_base_allocator_addr(HalMemType::L1);
-    const uint32_t dram_base = device_->allocator()->get_base_allocator_addr(HalMemType::DRAM);
+    const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
+    const uint32_t dram_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::DRAM);
 
     DeviceData device_data(device_, worker_range, l1_base, dram_base, nullptr, false, dram_data_size_words, cfg_);
 
@@ -800,8 +800,8 @@ TEST_P(DispatchPackedWriteLargeTestFixture, WriteLargePackedMulticast) {
     const CoreRange worker_range = {first_worker, last_worker};
 
     // Get memory base addresses
-    const uint32_t l1_base = device_->allocator()->get_base_allocator_addr(HalMemType::L1);
-    const uint32_t dram_base = device_->allocator()->get_base_allocator_addr(HalMemType::DRAM);
+    const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
+    const uint32_t dram_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::DRAM);
 
     // Setup DeviceData for validation
     DeviceData device_data(device_, worker_range, l1_base, dram_base, nullptr, false, dram_data_size_words, cfg_);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
@@ -41,8 +41,7 @@
  * - Dispatcher: Kernel that parses commands and issues writes/signals to Worker cores.
  */
 
-namespace tt::tt_dispatch_tests {
-namespace dispatcher_tests {
+namespace tt::tt_dispatch_tests::dispatcher_tests {
 
 constexpr uint32_t DEFAULT_ITERATIONS_LINEAR_WRITE = 3;
 constexpr uint32_t DEFAULT_ITERATIONS_PAGED_WRITE = 1;
@@ -887,5 +886,4 @@ INSTANTIATE_TEST_SUITE_P(
                "iter_" + std::to_string(info.param.dram_data_size_words) + "words_";
     });
 
-}  // namespace dispatcher_tests
-}  // namespace tt::tt_dispatch_tests
+}  // namespace tt::tt_dispatch_tests::dispatcher_tests

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -1166,7 +1166,7 @@ protected:
         // Random length (bytes), aligned to L1, capped by remaining
         uint32_t data_size_bytes = payload_generator_->get_rand<uint32_t>(l1_alignment_, avail_bytes);
         data_size_bytes = tt::align(data_size_bytes, l1_alignment_);
-        data_size_bytes = std::min(data_size_bytes, std::min(avail_bytes, remaining_bytes));
+        data_size_bytes = std::min({data_size_bytes, avail_bytes, remaining_bytes});
         if (data_size_bytes == 0 || data_size_bytes > avail_bytes) {
             return std::nullopt;
         }
@@ -1937,7 +1937,7 @@ TEST_P(RandomTestFixture, RandomTest) {
             //     CoreRange single_worker_range = {worker_core, worker_core};
             //     auto result = gen_random_linear_read_cmd(device_data, worker_core, noc_xy, remaining_bytes);
             //     if(result.has_value()){
-            //         const HostMemDeviceCommand& cmd = *result;
+            //         HostMemDeviceCommand& cmd = *result;
             //         commands_per_iteration.push_back(std::move(cmd));
             //     }
             //     break;
@@ -1947,7 +1947,7 @@ TEST_P(RandomTestFixture, RandomTest) {
                 auto result =
                     gen_random_dram_paged_cmd(device_data, worker_core, single_worker_range, noc_xy, remaining_bytes);
                 if (result.has_value()) {
-                    const HostMemDeviceCommand& cmd = *result;
+                    HostMemDeviceCommand& cmd = *result;
                     commands_per_iteration.push_back(std::move(cmd));
                 }
                 break;
@@ -1957,7 +1957,7 @@ TEST_P(RandomTestFixture, RandomTest) {
                 CoreRange multi_worker_range = {worker_core, last_worker};
                 auto result = gen_random_inline_cmd(device_data, multi_worker_range, noc_xy, remaining_bytes);
                 if (result.has_value()) {
-                    const HostMemDeviceCommand& cmd = *result;
+                    HostMemDeviceCommand& cmd = *result;
                     commands_per_iteration.push_back(std::move(cmd));
                 }
                 break;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -2,2607 +2,2255 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <chrono>
-#include <emmintrin.h>
-#include <fmt/base.h>
-#include <stdio.h>
-#include <cstdint>
+#include "gtest/gtest.h"
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/tt_align.hpp>
-#include <tt-metalium/tt_metal.hpp>
-#include <algorithm>
-#include <cstdlib>
-#include <cstring>
-#include <exception>
-#include <iomanip>
-#include <map>
-#include <memory>
-#include <optional>
-#include <sstream>
-#include <stdexcept>
-#include <string>
-#include <thread>
-#include <unordered_map>
-#include <unordered_set>
-#include <variant>
-#include <vector>
+#include <tt-metalium/mesh_device.hpp>
+#include <tt-metalium/distributed.hpp>
+#include <chrono>
 
-#include <tt-metalium/allocator.hpp>
-#include <tt_stl/assert.hpp>
-#include <tt-metalium/buffer_types.hpp>
-#include "common.h"
-#include <tt-metalium/core_coord.hpp>
-#include <tt-metalium/data_types.hpp>
-#include <tt-metalium/device.hpp>
-#include <tt-metalium/hal_types.hpp>
-#include <tt-metalium/kernel_types.hpp>
-#include "llrt.hpp"
-#include <tt-logger/tt-logger.hpp>
-#include <tt-metalium/program.hpp>
-#include "impl/dispatch/command_queue_common.hpp"
-#include "impl/dispatch/dispatch_settings.hpp"
-#include "test_common.hpp"
-#include "impl/context/metal_context.hpp"
+#include "tests/tt_metal/tt_metal/common/mesh_dispatch_fixture.hpp"
+#include "tt_metal/distributed/fd_mesh_command_queue.hpp"
+#include "tt_metal/impl/dispatch/device_command.hpp"
+#include "tt_metal/test_utils/stimulus.hpp"
 #include "tt_metal/impl/dispatch/kernels/cq_commands.hpp"
 #include <umd/device/types/core_coordinates.hpp>
-#include <umd/device/tt_io.hpp>
-#include <umd/device/types/xy_pair.hpp>
-#include <impl/dispatch/dispatch_mem_map.hpp>
+#include "tt_metal/impl/context/metal_context.hpp"
+#include <tt-metalium/tt_align.hpp>
+#include "tt_metal/impl/dispatch/topology.hpp"
+#include "tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h"
+#include <impl/dispatch/dispatch_query_manager.hpp>
 
-#define CQ_PREFETCH_CMD_BARE_MIN_SIZE \
-    tt::tt_metal::MetalContext::instance().hal().get_alignment(tt::tt_metal::HalMemType::HOST)
+/*
+ * FAST PREFETCHER MICROBENCHMARK SUITE
+ *
+ * Architecture Overview:
+ * This test suite validates the Fast Dispatcher (FD) kernel mechanisms by bypassing the
+ * standard high-level Enqueue APIs and directly constructing low-level command sequences.
+ *
+ * The test flow follows a "Shadow Model" pattern:
+ * 1. Plan: Determine transfer sizes, destinations, and command types.
+ * 2. Shadow: Update `DeviceData` (the expectation model) to reflect what should happen.
+ * 3. Build: Use `DeviceCommand` and `DeviceCommandCalculator` to construct binary
+ *    command packets (HostMemDeviceCommand) exactly as the runtime would.
+ * 4. Execute and Validate: Push these raw commands directly into the Issue Queue and notify the hardware.
+ *    Read back device memory and compare against `DeviceData` to validate the correctness of the command execution.
+ *
+ * Key Concepts:
+ * - Issue Queue: Host-resident ring buffer where commands are written.
+ * - Fetch Queue: Device-resident ring buffer (pointers) telling the Prefetcher where to look.
+ * - Prefetcher: Kernel that pulls commands from Host/DRAM and relays them.
+ * - Dispatcher: Kernel that parses commands and issues writes/signals to Worker cores.
+ */
 
-constexpr uint32_t DEFAULT_TEST_TYPE = 0;
-constexpr uint32_t DEVICE_DATA_SIZE = 768 * 1024;
-constexpr uint32_t MAX_PAGE_SIZE = 256 * 1024;  // bigger than scratch_db_page_size
-constexpr uint32_t DRAM_PAGE_SIZE_DEFAULT = 1024;
-constexpr uint32_t DRAM_PAGES_TO_READ_DEFAULT = 16;
+namespace tt::tt_dispatch_tests {
+namespace prefetcher_tests {
 
-constexpr uint32_t DRAM_EXEC_BUF_DEFAULT_BASE_ADDR = 0x1f400000;  // magic, half of dram
-constexpr uint32_t DRAM_EXEC_BUF_DEFAULT_LOG_PAGE_SIZE = 10;
-
-constexpr uint32_t DEFAULT_HUGEPAGE_ISSUE_BUFFER_SIZE = 256 * 1024 * 1024;
-constexpr uint32_t DEFAULT_HUGEPAGE_COMPLETION_BUFFER_SIZE = 256 * 1024 * 1024;
-constexpr uint32_t DEFAULT_PREFETCH_Q_ENTRIES = 1024;
-constexpr uint32_t DEFAULT_CMDDAT_Q_SIZE =
-    (128 * 1024) + (2 * sizeof(CQPrefetchCmd)) + (2 * sizeof(CQDispatchCmdLarge));
-constexpr uint32_t DEFAULT_SCRATCH_DB_SIZE = 16 * 1024;
-
-constexpr uint32_t DEFAULT_ITERATIONS = 10000;
-
-// constexpr uint32_t PREFETCH_Q_LOG_MINSIZE = 4;
-// constexpr uint32_t PCIE_ALIGNMENT = ((1 << PREFETCH_Q_LOG_MINSIZE) > CQ_PREFETCH_CMD_BARE_MIN_SIZE) ? (1 <<
-// PREFETCH_Q_LOG_MINSIZE) : CQ_PREFETCH_CMD_BARE_MIN_SIZE;
-
+constexpr uint32_t DEFAULT_ITERATIONS = 5;
+constexpr uint32_t DEFAULT_ITERATIONS_SMOKE_RANDOM = 1000;
 constexpr uint32_t DRAM_DATA_SIZE_BYTES = 16 * 1024 * 1024;
 constexpr uint32_t DRAM_DATA_SIZE_WORDS = DRAM_DATA_SIZE_BYTES / sizeof(uint32_t);
+constexpr uint32_t DEVICE_DATA_SIZE = 768 * 1024;
+constexpr uint32_t DRAM_PAGE_SIZE_DEFAULT = 1024;
+constexpr uint32_t DRAM_PAGES_TO_READ_DEFAULT = 16;
+constexpr uint32_t DEFAULT_SCRATCH_DB_SIZE = 16 * 1024;
 
-constexpr uint32_t PCIE_TRANSFER_SIZE_DEFAULT = 4096;
-
-constexpr uint32_t host_data_dirty_pattern = 0xbaadf00d;
-
-constexpr tt::CoreType DISPATCH_CORE_TYPE =
-    tt::CoreType::WORKER;  // If this changes, need to pass it into CreateDevice. TODO: Clean this up when when we clean
-                           // up single device creation.
-
-//////////////////////////////////////////////////////////////////////////////////////////
-// Test dispatch program performance
-//
-// Times dispatching program to M cores, N processors, of various sizes, CBs, runtime args
-//////////////////////////////////////////////////////////////////////////////////////////
-using std::vector;
-using namespace tt;
-
-uint32_t iterations_g = DEFAULT_ITERATIONS;
-
-bool warmup_g = false;
-bool debug_g;
-uint32_t max_prefetch_command_size_g;
-
-uint32_t dispatch_buffer_page_size_g = 1 << DispatchSettings::DISPATCH_BUFFER_LOG_PAGE_SIZE;
-uint32_t prefetch_q_entries_g;
-uint32_t hugepage_issue_buffer_size_g;
-void* host_hugepage_completion_buffer_base_g;
-uint32_t cmddat_q_size_g;
-uint32_t scratch_db_size_g;
-uint32_t num_dram_banks_g;
-bool use_coherent_data_g;
-uint32_t test_type_g;
-bool readback_every_iteration_g;
-uint32_t big_g;
-uint32_t pcie_transfer_size_g;
-uint32_t dram_page_size_g;
-uint32_t dram_pages_to_read_g;
-
-uint32_t bytes_of_data_g = 0;
-bool initialize_device_g = true;
-uint32_t dispatch_wait_addr_g;
-bool split_prefetcher_g;
-bool split_dispatcher_g;
-uint32_t prefetch_d_buffer_size_g;
-bool use_dram_exec_buf_g = false;
-bool relay_max_packed_paged_submcds = false;
-uint32_t exec_buf_log_page_size_g;
-
-CoreCoord first_worker_g = {0, 1};
-CoreRange all_workers_g = {
-    first_worker_g,
-    {first_worker_g.x + 1, first_worker_g.y + 1},
+// Params that control the data volume, iteration count
+// for the packed / large packed write test
+struct PagedReadParams {
+    uint32_t page_size{};       // Page size in bytes
+    uint32_t num_pages{};       // Number of pages
+    uint32_t num_iterations{};  // Number of iterations for the test
+    uint32_t dram_data_size_words{};
+    bool use_exec_buf{};  // Whether to use exec buff
 };
-CoreCoord phys_prefetch_core_g;
 
-bool send_to_all_g = false;
-bool perf_test_g = false;
+namespace DeviceDataUpdater {
 
-uint32_t max_xfer_size_bytes_g = dispatch_buffer_page_size_g;
-uint32_t min_xfer_size_bytes_g = 4;
-uint32_t l1_buf_base_g;
-uint32_t test_device_id_g = 0;
-
-void init(int argc, char** argv) {
-    auto default_settings =
-        DispatchSettings::defaults(DISPATCH_CORE_TYPE, tt::tt_metal::MetalContext::instance().get_cluster(), 1);
-
-    std::vector<std::string> input_args(argv, argv + argc);
-
-    if (test_args::has_command_option(input_args, "-h") || test_args::has_command_option(input_args, "--help")) {
-        log_info(LogTest, "Usage:");
-        log_info(
-            LogTest,
-            "  -t: test type: 0:Terminate 1:Smoke 2:Random 3:PCIe 4:DRAM-read 5:DRAM-write-read 6:Host 7:Packed-read "
-            "8:Ringbuffer-read"
-            "(default {})",
-            DEFAULT_TEST_TYPE);
-        log_info(LogTest, "  -w: warm-up before starting timer (default disabled)");
-        log_info(LogTest, "  -i: host iterations (default {})", DEFAULT_ITERATIONS);
-        log_info(LogTest, " -wx: right-most worker in grid (default {})", all_workers_g.end_coord.x);
-        log_info(LogTest, " -wy: bottom-most worker in grid (default {})", all_workers_g.end_coord.y);
-        log_info(
-            LogTest,
-            "  -b: run a \"big\" test (fills memory w/ fewer transactions) (default false)",
-            DEFAULT_TEST_TYPE);
-        log_info(
-            LogTest,
-            " -rb: gen data, readback and test every iteration - disable for perf measurements (default true)");
-        log_info(LogTest, "  -c: use coherent data as payload (default false)");
-        log_info(LogTest, "  -d: wrap all commands in debug commands and clear DRAM to known state (default disabled)");
-        log_info(LogTest, "  -hp: host huge page issue buffer size (default {})", DEFAULT_HUGEPAGE_ISSUE_BUFFER_SIZE);
-        log_info(LogTest, "  -pq: prefetch queue entries (default {})", DEFAULT_PREFETCH_Q_ENTRIES);
-        log_info(LogTest, "  -cs: cmddat q size (default {})", DEFAULT_CMDDAT_Q_SIZE);
-        log_info(LogTest, "-pdcs: prefetch_d cmddat cb size (default {})", default_settings.prefetch_d_buffer_size_);
-        log_info(LogTest, "  -ss: scratch cb size (default {})", DEFAULT_SCRATCH_DB_SIZE);
-        log_info(
-            LogTest,
-            " -pcies: size of data to transfer in pcie bw test type (default: {})",
-            PCIE_TRANSFER_SIZE_DEFAULT);
-        log_info(LogTest, " -dpgs: dram page size in dram bw test type (default: {})", DRAM_PAGE_SIZE_DEFAULT);
-        log_info(LogTest, " -dpgr: dram pages to read in dram bw test type (default: {})", DRAM_PAGES_TO_READ_DEFAULT);
-        log_info(LogTest, " -spre: split prefetcher into H and D variants (default not split)");
-        log_info(LogTest, " -sdis: split dispatcher into H and the other thing variants (default not split)");
-        log_info(LogTest, "  -device_id: Device on which the test will be run, default = 0");
-        log_info(LogTest, "  -x: execute commands from dram exec_buf (default 0)");
-        log_info(LogTest, "  -mpps: give prefetcher the maximum number of packed data submcds to relay to dispatcher");
-        log_info(LogTest, "-xpls: execute buffer log dram page size (default {})", DRAM_EXEC_BUF_DEFAULT_LOG_PAGE_SIZE);
-        log_info(LogTest, "  -s: seed for randomized tests (default 1)");
-        exit(0);
-    }
-
-    warmup_g = test_args::has_command_option(input_args, "-w");
-    iterations_g = test_args::get_command_option_uint32(input_args, "-i", DEFAULT_ITERATIONS);
-    hugepage_issue_buffer_size_g =
-        test_args::get_command_option_uint32(input_args, "-hp", DEFAULT_HUGEPAGE_ISSUE_BUFFER_SIZE);
-    prefetch_q_entries_g = test_args::get_command_option_uint32(input_args, "-hq", DEFAULT_PREFETCH_Q_ENTRIES);
-    cmddat_q_size_g = test_args::get_command_option_uint32(input_args, "-cs", DEFAULT_CMDDAT_Q_SIZE);
-    max_prefetch_command_size_g =
-        cmddat_q_size_g / 2 - (CQ_PREFETCH_CMD_BARE_MIN_SIZE - 1);  // note: half this for best perf
-    scratch_db_size_g = test_args::get_command_option_uint32(input_args, "-ss", DEFAULT_SCRATCH_DB_SIZE);
-    use_coherent_data_g = test_args::has_command_option(input_args, "-c");
-    readback_every_iteration_g = !test_args::has_command_option(input_args, "-rb");
-    pcie_transfer_size_g = test_args::get_command_option_uint32(input_args, "-pcies", PCIE_TRANSFER_SIZE_DEFAULT);
-    dram_page_size_g = test_args::get_command_option_uint32(input_args, "-dpgs", DRAM_PAGE_SIZE_DEFAULT);
-    dram_pages_to_read_g = test_args::get_command_option_uint32(input_args, "-dpgr", DRAM_PAGES_TO_READ_DEFAULT);
-    prefetch_d_buffer_size_g =
-        test_args::get_command_option_uint32(input_args, "-pdcs", default_settings.prefetch_d_buffer_size_);
-
-    test_type_g = test_args::get_command_option_uint32(input_args, "-t", DEFAULT_TEST_TYPE);
-    all_workers_g.end_coord.x = test_args::get_command_option_uint32(input_args, "-wx", all_workers_g.end_coord.x);
-    all_workers_g.end_coord.y = test_args::get_command_option_uint32(input_args, "-wy", all_workers_g.end_coord.y);
-    split_prefetcher_g = test_args::has_command_option(input_args, "-spre");
-    split_dispatcher_g = test_args::has_command_option(input_args, "-sdis");
-    use_dram_exec_buf_g = test_args::has_command_option(input_args, "-x");
-    relay_max_packed_paged_submcds = test_args::has_command_option(input_args, "-mpps");
-    exec_buf_log_page_size_g =
-        test_args::get_command_option_uint32(input_args, "-xpls", DRAM_EXEC_BUF_DEFAULT_LOG_PAGE_SIZE);
-
-    test_device_id_g = test_args::get_command_option_uint32(input_args, "-device_id", 0);
-
-    uint32_t seed = test_args::get_command_option_uint32(input_args, "-s", 1);
-    std::srand(seed);
-    big_g = test_args::has_command_option(input_args, "-b");
-    debug_g = test_args::has_command_option(input_args, "-d");
-
-    if (debug_g && use_dram_exec_buf_g) {
-        log_fatal(tt::LogTest, "Exec buf is not supported with debug commands");
-        exit(0);
-    }
-}
-
-void dirty_host_completion_buffer(uint32_t* host_hugepage_completion_buffer) {
-    for (int i = 0; i < DEFAULT_HUGEPAGE_COMPLETION_BUFFER_SIZE / sizeof(uint32_t); i++) {
-        host_hugepage_completion_buffer[i] = host_data_dirty_pattern;
-    }
-    tt_driver_atomics::sfence();
-}
-
-uint32_t round_cmd_size_up(uint32_t size) {
-    uint32_t align_mask = MetalContext::instance().hal().get_alignment(HalMemType::HOST) - 1;
-
-    return (size + align_mask) & ~align_mask;
-}
-
-void add_bare_prefetcher_cmd(vector<uint32_t>& cmds, CQPrefetchCmd& cmd, bool pad = false) {
-    uint32_t* ptr = (uint32_t*)&cmd;
-    for (int i = 0; i < sizeof(CQPrefetchCmd) / sizeof(uint32_t); i++) {
-        cmds.push_back(*ptr++);
-    }
-
-    if (pad) {
-        // Pad debug cmd to always be the alignment size
-        for (uint32_t i = 0; i < (CQ_PREFETCH_CMD_BARE_MIN_SIZE - sizeof(CQPrefetchCmd)) / sizeof(uint32_t); i++) {
-            cmds.push_back(std::rand());
-        }
-    }
-}
-
-void add_bare_prefetcher_cmd(vector<uint32_t>& cmds, CQPrefetchCmdLarge& cmd, bool pad = false) {
-    uint32_t* ptr = (uint32_t*)&cmd;
-    for (int i = 0; i < sizeof(CQPrefetchCmdLarge) / sizeof(uint32_t); i++) {
-        cmds.push_back(*ptr++);
-    }
-
-    if (pad) {
-        // Pad debug cmd to always be the alignment size
-        for (uint32_t i = 0; i < (CQ_PREFETCH_CMD_BARE_MIN_SIZE - sizeof(CQPrefetchCmdLarge)) / sizeof(uint32_t); i++) {
-            cmds.push_back(std::rand());
-        }
-    }
-}
-
-void add_prefetcher_packed_paged_read_cmd(
-    vector<uint32_t>& cmds, vector<CQPrefetchRelayPagedPackedSubCmd>& sub_cmds, uint32_t length) {
-    CQPrefetchCmd cmd{};
-    cmd.base.cmd_id = CQ_PREFETCH_CMD_RELAY_PAGED_PACKED;
-
-    uint32_t stride = (sub_cmds.size() * sizeof(CQPrefetchRelayPagedPackedSubCmd)) + sizeof(CQPrefetchCmd);
-    uint32_t aligned_stride = round_cmd_size_up(stride);
-    cmd.relay_paged_packed.total_length = length;
-    cmd.relay_paged_packed.stride = aligned_stride;
-    cmd.relay_paged_packed.count = sub_cmds.size();
-
-    uint32_t* ptr = (uint32_t*)&cmd;
-    for (int i = 0; i < sizeof(CQPrefetchCmd) / sizeof(uint32_t); i++) {
-        cmds.push_back(*ptr++);
-    }
-
-    constexpr size_t uint32_count = sizeof(CQPrefetchRelayPagedPackedSubCmd) / sizeof(uint32_t);
-    std::vector<uint32_t> tmp_buffer(uint32_count);
-
-    for (const auto& sub_cmd : sub_cmds) {
-        std::memcpy(tmp_buffer.data(), &sub_cmd, sizeof(CQPrefetchRelayPagedPackedSubCmd));
-        cmds.insert(cmds.end(), tmp_buffer.begin(), tmp_buffer.end());
-    }
-
-    for (int i = 0; i < (aligned_stride - stride) / sizeof(uint32_t); i++) {
-        cmds.push_back(0);
-    }
-}
-
-void add_prefetcher_paged_read_cmd(
-    vector<uint32_t>& cmds,
-    vector<uint32_t>& sizes,
-    uint32_t start_page,
-    uint32_t base_addr,
-    uint32_t page_size,
-    uint32_t pages,
-    bool is_dram,
-    uint32_t length_adjust) {
-    CQPrefetchCmd cmd{};
-    cmd.base.cmd_id = CQ_PREFETCH_CMD_RELAY_PAGED;
-
-    cmd.relay_paged.start_page = start_page & CQ_PREFETCH_RELAY_PAGED_START_PAGE_MASK;
-    cmd.relay_paged.is_dram_and_length_adjust = (is_dram << CQ_PREFETCH_RELAY_PAGED_IS_DRAM_SHIFT) |
-                                                (length_adjust & CQ_PREFETCH_RELAY_PAGED_LENGTH_ADJUST_MASK);
-    cmd.relay_paged.base_addr = base_addr;
-    cmd.relay_paged.page_size = page_size;
-    cmd.relay_paged.pages = pages;
-    log_debug(
-        tt::LogTest,
-        "Generating CQ_PREFETCH_CMD_RELAY_PAGED w/ is_dram: {} start_page: {} base_addr: {} page_size: {} pages: {}",
-        is_dram,
-        start_page,
-        base_addr,
-        page_size,
-        pages);
-
-    add_bare_prefetcher_cmd(cmds, cmd, true);
-}
-
-void add_prefetcher_linear_read_cmd(IDevice* device,
-                                    vector<uint32_t>& cmds,
-                                    vector<uint32_t>& sizes,
-                                    CoreCoord worker_core,
-                                    uint32_t addr,
-                                    uint32_t length) {
-    CoreCoord phys_worker_core = device->worker_core_from_logical_core(worker_core);
-
-    CQPrefetchCmdLarge cmd{};
-    cmd.base.cmd_id = CQ_PREFETCH_CMD_RELAY_LINEAR;
-
-    cmd.relay_linear.pad1 = 0;
-    cmd.relay_linear.noc_xy_addr =
-        tt::tt_metal::MetalContext::instance().hal().noc_xy_encoding(phys_worker_core.x, phys_worker_core.y);
-    cmd.relay_linear.addr = addr;
-    cmd.relay_linear.length = length;
-
-    add_bare_prefetcher_cmd(cmds, cmd, true);
-}
-
-void add_prefetcher_debug_prologue(vector<uint32_t>& cmds) {
-    if (debug_g) {
-        CQPrefetchCmd debug_cmd{};
-        debug_cmd.base.cmd_id = CQ_PREFETCH_CMD_DEBUG;
-        add_bare_prefetcher_cmd(cmds, debug_cmd, true);
-    }
-}
-
-void add_prefetcher_debug_epilogue(vector<uint32_t>& cmds, size_t prior_end) {
-    if (debug_g) {
-        CQPrefetchCmd* debug_cmd_ptr;
-        debug_cmd_ptr = (CQPrefetchCmd*)&cmds[prior_end];
-        debug_cmd_ptr->debug.size = (cmds.size() - prior_end) * sizeof(uint32_t) - sizeof(CQPrefetchCmd);
-        debug_cmd_ptr->debug.stride = CQ_PREFETCH_CMD_BARE_MIN_SIZE;
-    }
-}
-
-void add_prefetcher_cmd_to_hostq(
-    vector<uint32_t>& cmds, vector<uint32_t>& sizes, const std::vector<uint32_t>& payload, size_t prior_end) {
-    uint32_t cmd_size_bytes = (cmds.size() - prior_end) * sizeof(uint32_t);
-    for (int i = 0; i < payload.size(); i++) {
-        cmds.push_back(payload[i]);
-    }
-    uint32_t payload_length_bytes = payload.size() * sizeof(uint32_t);
-    uint32_t pad_size_bytes =
-        round_cmd_size_up(cmd_size_bytes + payload_length_bytes) - payload_length_bytes - cmd_size_bytes;
-    for (int i = 0; i < pad_size_bytes / sizeof(uint32_t); i++) {
-        cmds.push_back(0);
-    }
-    uint32_t new_size = (cmds.size() - prior_end) * sizeof(uint32_t);
-    TT_FATAL(
-        new_size <= max_prefetch_command_size_g,
-        "Generated prefetcher command {} exceeds max command size {} (padding size {} B)",
-        new_size,
-        max_prefetch_command_size_g,
-        pad_size_bytes);
-    TT_FATAL((new_size >> DispatchSettings::PREFETCH_Q_LOG_MINSIZE) < 0xFFFF, "HostQ command too large to represent");
-    sizes.push_back(new_size >> DispatchSettings::PREFETCH_Q_LOG_MINSIZE);
-}
-
-void add_prefetcher_cmd(vector<uint32_t>& cmds, vector<uint32_t>& sizes, CQPrefetchCmd cmd) {
-    vector<uint32_t> empty_payload;
-    vector<uint32_t> data;
-
-    auto prior_end = cmds.size();
-
-    add_prefetcher_debug_prologue(cmds);
-    add_bare_prefetcher_cmd(cmds, cmd);
-    add_prefetcher_cmd_to_hostq(cmds, sizes, empty_payload, prior_end);
-    add_prefetcher_debug_epilogue(cmds, prior_end);
-}
-
-void add_prefetcher_cmd(
-    vector<uint32_t>& cmds, vector<uint32_t>& sizes, CQPrefetchCmdId id, vector<uint32_t>& payload) {
-    vector<uint32_t> data;
-
-    auto prior_end = cmds.size();
-
-    add_prefetcher_debug_prologue(cmds);
-
-    CQPrefetchCmd cmd{};
-    memset(&cmd, 0, sizeof(CQPrefetchCmd));
-    cmd.base.cmd_id = id;
-
-    uint32_t payload_length_bytes = payload.size() * sizeof(uint32_t);
-    switch (id) {
-        case CQ_PREFETCH_CMD_RELAY_PAGED: TT_ASSERT(false); break;
-
-        case CQ_PREFETCH_CMD_RELAY_INLINE:
-        case CQ_PREFETCH_CMD_RELAY_INLINE_NOFLUSH:
-        case CQ_PREFETCH_CMD_EXEC_BUF_END:
-            cmd.relay_inline.length = payload_length_bytes;
-            cmd.relay_inline.stride = round_cmd_size_up(payload_length_bytes + sizeof(CQPrefetchCmd));
-            break;
-
-        case CQ_PREFETCH_CMD_STALL: break;
-
-        case CQ_PREFETCH_CMD_DEBUG: {
-            static uint32_t key = 0;
-            cmd.debug.key = ++key;
-            cmd.debug.size = payload_length_bytes;
-            cmd.debug.stride = round_cmd_size_up(payload_length_bytes + sizeof(CQPrefetchCmd));
-        } break;
-
-        case CQ_PREFETCH_CMD_TERMINATE: break;
-
-        default: fprintf(stderr, "Invalid prefetcher command: %d\n", id); break;
-    }
-
-    add_bare_prefetcher_cmd(cmds, cmd);
-    add_prefetcher_cmd_to_hostq(cmds, sizes, payload, prior_end);
-    add_prefetcher_debug_epilogue(cmds, prior_end);
-}
-
-// Model a paged read by updating worker data with interleaved/paged DRAM data, for validation later.
-void add_paged_dram_data_to_device_data(
-    IDevice* device,
+void update_paged_dram_read(
     const CoreRange& workers,
     DeviceData& device_data,
-    uint32_t start_page,
-    uint32_t base_addr,
-    uint32_t page_size,
-    uint32_t pages,
-    uint32_t length_adjust) {
-    uint32_t base_addr_words = base_addr / sizeof(uint32_t);
-    uint32_t page_size_words = page_size / sizeof(uint32_t);
-    uint32_t length_adjust_words = length_adjust / sizeof(uint32_t);
-
-    // Get data from DRAM map, add to all workers, but only set valid for cores included in workers range.
-    TT_ASSERT(start_page < num_dram_banks_g);
-    uint32_t last_page = start_page + pages;
-    for (uint32_t page_idx = start_page; page_idx < last_page; page_idx++) {
-        uint32_t dram_bank_id = page_idx % num_dram_banks_g;
-        auto dram_channel = device->allocator_impl()->get_dram_channel_from_bank_id(dram_bank_id);
-        CoreCoord bank_core = device->logical_core_from_dram_channel(dram_channel);
-        uint32_t bank_offset = base_addr_words + (page_size_words * (page_idx / num_dram_banks_g));
-
-        if (page_idx == last_page - 1) {
-            page_size_words -= length_adjust_words;
-        }
-        for (uint32_t j = 0; j < page_size_words; j++) {
-            uint32_t datum = device_data.at(bank_core, dram_bank_id, bank_offset + j);
-            device_data.push_range(workers, datum, false);
-        }
+    const CoreCoord& bank_core,
+    uint32_t bank_id,
+    uint32_t bank_offset,
+    uint32_t page_size_words) {
+    for (uint32_t j = 0; j < page_size_words; j++) {
+        uint32_t datum = device_data.at(bank_core, bank_id, bank_offset + j);
+        device_data.push_range(workers, datum, false);
     }
 }
 
-// Packed page read from dram to linear write to worker
-void gen_dram_packed_read_cmd(
-    IDevice* device,
-    vector<uint32_t>& prefetch_cmds,
-    vector<uint32_t>& cmd_sizes,
-    DeviceData& device_data,
-    CoreCoord worker_core,
-    uint32_t log_page_size,
-    vector<uint32_t>& lengths) {
-    vector<uint32_t> dispatch_cmds;
-    vector<CQPrefetchRelayPagedPackedSubCmd> sub_cmds;
+// Write the expected dispatch info into the device data for validation
+// This should match the data inside completion queue on the host side
+// The shadow model must have command header + generated payload for validation since dispatch
+// copies both into completion buffer
+void update_host_data(DeviceData& device_data, const std::vector<uint32_t>& data, uint32_t data_size_bytes) {
+    uint32_t data_size_words = data_size_bytes / sizeof(uint32_t);
+    CQDispatchCmd expected_cmd{};
+    expected_cmd.base.cmd_id = CQ_DISPATCH_CMD_WRITE_LINEAR_H_HOST;
+    // Include cmd in transfer
+    expected_cmd.write_linear_host.length = data_size_bytes + sizeof(CQDispatchCmd);
+    expected_cmd.write_linear_host.is_event = false;
+    expected_cmd.write_linear_host.pad1 = 0;
+    expected_cmd.write_linear_host.pad2 = HostMemDeviceCommand::random_padding_value();
 
-    uint32_t total_length = 0;
-    for (auto length : lengths) {
-        total_length += length;
+    uint32_t* cmd_as_words = reinterpret_cast<uint32_t*>(&expected_cmd);
+    for (uint32_t i = 0; i < sizeof(CQDispatchCmd) / sizeof(uint32_t); i++) {
+        device_data.push_one(device_data.get_host_core(), 0, cmd_as_words[i]);
     }
-    gen_bare_dispatcher_unicast_write_cmd(device, dispatch_cmds, worker_core, device_data, total_length);
-    add_prefetcher_cmd(prefetch_cmds, cmd_sizes, CQ_PREFETCH_CMD_RELAY_INLINE_NOFLUSH, dispatch_cmds);
 
-    uint32_t page_size = 1 << log_page_size;
-    int count = 0;
-    uint32_t dram_data_base_addr = device->allocator()->get_base_allocator_addr(HalMemType::DRAM);
-    for (auto length : lengths) {
-        TT_ASSERT((length & (MetalContext::instance().hal().get_alignment(HalMemType::DRAM) - 1)) == 0);
-        CQPrefetchRelayPagedPackedSubCmd sub_cmd{};
-        sub_cmd.start_page = 0;  // TODO: randomize?
-        sub_cmd.log_page_size = log_page_size;
-        sub_cmd.base_addr = dram_data_base_addr + count * page_size;
-        sub_cmd.length = length;
-        sub_cmds.push_back(sub_cmd);
-        count++;
+    for (uint32_t i = 0; i < data_size_words; i++) {
+        device_data.push_one(device_data.get_host_core(), 0, data[i]);
+    }
+}
 
-        // Model the packed paged read in this function by updating worker data with interleaved/paged DRAM data, for
-        // validation later.
-        uint32_t length_words = length / sizeof(uint32_t);
-        uint32_t base_addr_words = (sub_cmd.base_addr - dram_data_base_addr) / sizeof(uint32_t);
-        uint32_t page_size_words = page_size / sizeof(uint32_t);
+// Mirrors a read-from-source operation
+// Looks up existing data in device_data and pushes those into destination workers
+// Used when hardware will read from DRAM/L1 and copy whatever is already modeled there
+void update_read(
+    const CoreCoord& worker_core,
+    DeviceData& device_data,
+    const CoreCoord& bank_core,
+    uint32_t bank_id,
+    uint32_t bank_offset,
+    uint32_t page_size_words) {
+    for (uint32_t j = 0; j < page_size_words; j++) {
+        uint32_t datum = device_data.at(bank_core, bank_id, bank_offset + j);
+        device_data.push_one(worker_core, datum);
+    }
+}
+}  // namespace DeviceDataUpdater
 
-        // Get data from DRAM map, add to all workers, but only set valid for cores included in workers range.
-        uint32_t page_idx = sub_cmd.start_page;
-        for (uint32_t i = 0; i < length_words; i += page_size_words) {
-            uint32_t dram_bank_id = page_idx % num_dram_banks_g;
-            auto dram_channel = device->allocator_impl()->get_dram_channel_from_bank_id(dram_bank_id);
-            CoreCoord bank_core = device->logical_core_from_dram_channel(dram_channel);
-            uint32_t bank_offset = base_addr_words + (page_size_words * (page_idx / num_dram_banks_g));
+class BasePrefetcherTestFixture : public Common::BaseTestFixture,
+                                  public ::testing::WithParamInterface<PagedReadParams> {
+protected:
+    // Common constants
+    static constexpr uint32_t HOST_DATA_DIRTY_PATTERN = 0xbaadf00d;
+    static constexpr uint32_t PCIE_TRANSFER_SIZE_DEFAULT = 4096;
+    static constexpr uint32_t MIN_READ_SIZE = 128;  // Minimum meaningful transfer size, aligns with DRAM
+    static constexpr uint32_t DEFAULT_PREFETCH_Q_ENTRIES = 1024;
+    static constexpr uint32_t DRAM_EXEC_BUF_DEFAULT_BASE_ADDR = 0x1f400000;  // Magic, half of dram
+    static constexpr uint32_t DRAM_EXEC_BUF_DEFAULT_LOG_PAGE_SIZE = 10;
 
-            uint32_t words = (page_size_words > length_words - i) ? length_words - i : page_size_words;
-            for (uint32_t j = 0; j < words; j++) {
-                uint32_t datum = device_data.at(bank_core, dram_bank_id, bank_offset + j);
-                device_data.push_one(worker_core, datum);
+    // Default values for inline data and flush prefetch for prefetcher tests
+    static constexpr bool inline_data_ = false;
+    static constexpr bool flush_prefetch_ = false;
+    static constexpr bool hugepage_write_ = true;
+
+    uint32_t dram_base_;
+    uint32_t num_banks_;
+    uint32_t l1_alignment_;
+    uint32_t packed_write_max_unicast_sub_cmds_;
+
+    // Exec Buf Configuration
+    bool use_exec_buf_{};
+
+    void SetUp() override {
+        BaseTestFixture::SetUp();
+        dram_base_ = device_->allocator()->get_base_allocator_addr(HalMemType::DRAM);
+        num_banks_ = device_->allocator()->get_num_banks(BufferType::DRAM);
+        l1_alignment_ = tt::tt_metal::MetalContext::instance().hal().get_alignment(HalMemType::L1);
+        packed_write_max_unicast_sub_cmds_ =
+            device_->compute_with_storage_grid_size().x * device_->compute_with_storage_grid_size().y;
+
+        // Init Test params
+        const auto params = GetParam();
+        page_size_ = params.page_size;
+        num_pages_ = params.num_pages;
+        num_iterations_ = params.num_iterations;
+        dram_data_size_words_ = params.dram_data_size_words;
+        use_exec_buf_ = params.use_exec_buf;
+    }
+
+    void execute_generated_commands(
+        const std::vector<HostMemDeviceCommand>& commands_per_iteration,
+        DeviceData& device_data,
+        size_t num_cores_to_log,
+        uint32_t num_iterations,
+        bool wait_for_completion = true,
+        bool wait_for_host_writes = false) override {
+        if (use_exec_buf_) {
+            execute_generated_commands_exec_buff(
+                commands_per_iteration,
+                device_data,
+                num_cores_to_log,
+                num_iterations,
+                wait_for_completion,
+                wait_for_host_writes,
+                *this);
+            return;
+        }
+        // Non exec buff execution in BaseTestFixture
+        BaseTestFixture::execute_generated_commands(
+            commands_per_iteration, device_data, num_cores_to_log, num_iterations, wait_for_completion);
+    }
+
+    uint32_t get_page_size() const { return page_size_; }
+    uint32_t get_num_pages() const { return num_pages_; }
+    uint32_t get_num_iterations() const { return num_iterations_; }
+    uint32_t get_dram_data_size_words() const { return dram_data_size_words_; }
+
+private:
+    uint32_t page_size_{};
+    uint32_t num_pages_{};
+    uint32_t num_iterations_{};
+    uint32_t dram_data_size_words_{};
+
+    // Helper function to execute generated commands via exec buff on device
+    // Orchestrates the command buffer reservation, writing, and submission
+    void execute_generated_commands_exec_buff(
+        const std::vector<HostMemDeviceCommand>& commands_per_iteration,
+        DeviceData& device_data,
+        size_t num_cores_to_log,
+        uint32_t num_iterations,
+        bool wait_for_completion,
+        bool wait_for_host_writes,
+        BasePrefetcherTestFixture& fixture) {
+        // 1. Add all commands to be uploaded into exec buff into a single vector
+        std::vector<uint32_t> exec_buf_data;
+        for (uint32_t i = 0; i < num_iterations; i++) {
+            for (const auto& cmd : commands_per_iteration) {
+                const uint32_t* src_ptr = reinterpret_cast<uint32_t*>(cmd.data());
+                const uint32_t* end_ptr =
+                    reinterpret_cast<uint32_t*>(cmd.data()) + (cmd.size_bytes() / sizeof(uint32_t));
+                exec_buf_data.insert(exec_buf_data.end(), src_ptr, end_ptr);
+            }
+        }
+
+        // Append a barrier wait command after all commands across all iterations
+        // Helpful to ensure all commands are completed flush before exec_buf_end
+        DeviceCommandCalculator wait_calc;
+        wait_calc.add_dispatch_wait();
+        HostMemDeviceCommand wait_cmd(wait_calc.write_offset_bytes());
+        wait_cmd.add_dispatch_wait(CQ_DISPATCH_CMD_WAIT_FLAG_BARRIER, 0, 0, 0);
+        const uint32_t* wptr = reinterpret_cast<const uint32_t*>(wait_cmd.data());
+        const uint32_t* wend = wptr + (wait_cmd.size_bytes() / sizeof(uint32_t));
+        exec_buf_data.insert(exec_buf_data.end(), wptr, wend);
+
+        // 2. Append exec_buf_end command (terminate the trace execution and switch back to issue queue)
+        DeviceCommandCalculator exec_buf_end_calc;
+        exec_buf_end_calc.add_prefetch_exec_buf_end();
+        DeviceCommand exec_terminate(exec_buf_end_calc.write_offset_bytes());
+        exec_terminate.add_prefetch_exec_buf_end();
+        const uint32_t* src_ptr = reinterpret_cast<uint32_t*>(exec_terminate.data());
+        const uint32_t* end_ptr =
+            reinterpret_cast<uint32_t*>(exec_terminate.data()) + (exec_terminate.size_bytes() / sizeof(uint32_t));
+        exec_buf_data.insert(exec_buf_data.end(), src_ptr, end_ptr);
+
+        // 3. Write exec buff data into DRAM
+        const uint32_t page_size = 1 << fixture.DRAM_EXEC_BUF_DEFAULT_LOG_PAGE_SIZE;
+        const uint32_t exec_buf_base_addr = fixture.DRAM_EXEC_BUF_DEFAULT_BASE_ADDR;
+
+        // Pad data to full page alignment
+        size_t size_bytes = exec_buf_data.size() * sizeof(uint32_t);
+        log_info(tt::LogTest, "Total exec buff bytes: {}", size_bytes);
+        size_t padded_size_bytes = tt::align(size_bytes, page_size);
+        exec_buf_data.resize(padded_size_bytes / sizeof(uint32_t));
+        log_info(tt::LogTest, "Padded total exec buff bytes: {}", padded_size_bytes);
+
+        uint32_t num_pages = padded_size_bytes / page_size;
+        uint32_t data_idx = 0;
+
+        // Create pages of exec buff data and write to DRAM
+        for (uint32_t page_idx = 0; page_idx < num_pages; page_idx++) {
+            uint32_t bank_id = page_idx % fixture.num_banks_;
+            uint32_t bank_offset = (page_idx / fixture.num_banks_) * page_size;
+            uint32_t addr = exec_buf_base_addr + bank_offset;
+
+            std::vector<uint32_t> page_data(
+                exec_buf_data.begin() + data_idx, exec_buf_data.begin() + data_idx + (page_size / sizeof(uint32_t)));
+
+            detail::WriteToDeviceDRAMChannel(device_, bank_id, addr, page_data);
+
+            data_idx += (page_size / sizeof(uint32_t));
+        }
+
+        // Ensure DRAM writes are visible to device
+        MetalContext::instance().get_cluster().dram_barrier(device_->id());
+
+        // 4. Reserve and Write exec_buff command
+        DeviceCommandCalculator exec_buf_calc;
+        exec_buf_calc.add_prefetch_exec_buf();
+        uint32_t cmd_size = exec_buf_calc.write_offset_bytes();
+        void* cmd_buffer_base = mgr_->issue_queue_reserve(cmd_size, fdcq_->id());
+        // Use DeviceCommand helper (HugepageDeviceCommand) to write to the issue queue memory
+        HugepageDeviceCommand exec_cmd(cmd_buffer_base, cmd_size);
+        exec_cmd.add_prefetch_exec_buf(exec_buf_base_addr, fixture.DRAM_EXEC_BUF_DEFAULT_LOG_PAGE_SIZE, num_pages);
+
+        // Verifies destination memory bounds
+        device_data.overflow_check(device_);
+
+        // Submit and execute commands
+        mgr_->issue_queue_push_back(exec_cmd.write_offset_bytes(), fdcq_->id());
+
+        // Write the commands to the device-side fetch queue with STALL FLAG
+        const auto start = std::chrono::steady_clock::now();
+        mgr_->fetch_queue_reserve_back(fdcq_->id());
+        mgr_->fetch_queue_write(cmd_size, fdcq_->id(), true);  // stall_prefetcher = true with exec buff execution
+
+        // Wait for completion of the issued commands
+        if (wait_for_completion) {
+            distributed::Finish(mesh_device_->mesh_command_queue());
+        } else if (wait_for_host_writes) {
+            uint32_t total_expected_cq_payload = device_data.size() * sizeof(uint32_t);
+            // For host writes, wait until expected data is written into completion queue by dispatcher
+            wait_for_completion_queue_bytes(total_expected_cq_payload, wait_completion_timeout);
+        }
+        const auto end = std::chrono::steady_clock::now();
+
+        const std::chrono::duration<double> elapsed = end - start;
+        log_info(tt::LogTest, "Ran in {:.3f} ms (for {} iterations)", elapsed.count() * 1000.0, num_iterations);
+
+        // Validate results
+        const bool pass = device_data.validate(device_);
+        EXPECT_TRUE(pass) << "Dispatcher test failed validation";
+
+        // Report performance
+        if (pass) {
+            report_performance(device_data, num_cores_to_log, elapsed, num_iterations);
+        }
+    }
+};
+
+class PrefecherHostTextFixture : virtual public BasePrefetcherTestFixture {
+protected:
+    void pad_host_data(DeviceData& device_data) {
+        one_core_data_t& host_data = device_data.get_data()[device_data.get_host_core()][0];
+
+        int pad =
+            dispatch_buffer_page_size_ - ((host_data.data.size() * sizeof(uint32_t)) % dispatch_buffer_page_size_);
+        pad = pad % dispatch_buffer_page_size_;
+
+        for (int i = 0; i < pad / sizeof(uint32_t); i++) {
+            device_data.push_one(device_data.get_host_core(), 0, HOST_DATA_DIRTY_PATTERN);  // Use 0xbaadf00d
+        }
+    }
+
+    void dirty_host_completion_buffer(void* completion_queue_buffer, uint32_t size_bytes) {
+        uint32_t* buffer = static_cast<uint32_t*>(completion_queue_buffer);
+        uint32_t size_words = size_bytes / sizeof(uint32_t);
+
+        for (uint32_t i = 0; i < size_words; i++) {
+            buffer[i] = HOST_DATA_DIRTY_PATTERN;  // 0xbaadf00d
+        }
+
+        tt_driver_atomics::sfence();
+    }
+};
+
+class PrefetcherPackedReadTestFixture : virtual public BasePrefetcherTestFixture {
+protected:
+    std::vector<CQPrefetchRelayPagedPackedSubCmd> build_sub_cmds(
+        const std::vector<uint32_t>& lengths,
+        DeviceData& device_data,
+        uint32_t log_packed_read_page_size,
+        uint32_t n_sub_cmds) {
+        uint32_t count = 0;
+        uint32_t page_size_bytes = 1 << log_packed_read_page_size;
+        std::vector<CQPrefetchRelayPagedPackedSubCmd> sub_cmds;
+        sub_cmds.reserve(n_sub_cmds);
+        for (auto length : lengths) {
+            TT_ASSERT((length & (MetalContext::instance().hal().get_alignment(HalMemType::DRAM) - 1)) == 0);
+            CQPrefetchRelayPagedPackedSubCmd sub_cmd{};
+            sub_cmd.start_page = 0;
+            sub_cmd.log_page_size = log_packed_read_page_size;
+            sub_cmd.base_addr = dram_base_ + count * page_size_bytes;
+            sub_cmd.length = length;
+            sub_cmds.push_back(sub_cmd);
+            count++;
+
+            // Model the packed paged read in this function by updating worker data with interleaved/paged DRAM data,
+            // for validation later.
+            // TODO: see if this whole thing can fit in update_read()
+            uint32_t length_words = length / sizeof(uint32_t);
+            uint32_t base_addr_words = (sub_cmd.base_addr - dram_base_) / sizeof(uint32_t);
+            uint32_t page_size_words = page_size_bytes / sizeof(uint32_t);
+
+            // Get data from DRAM map, add to all workers, but only set valid for cores included in workers range.
+            uint32_t page_idx = sub_cmd.start_page;
+            for (uint32_t i = 0; i < length_words; i += page_size_words) {
+                uint32_t dram_bank_id = page_idx % num_banks_;
+                auto dram_channel = device_->allocator()->get_dram_channel_from_bank_id(dram_bank_id);
+                CoreCoord bank_core = device_->logical_core_from_dram_channel(dram_channel);
+                uint32_t bank_offset = base_addr_words + (page_size_words * (page_idx / num_banks_));
+
+                uint32_t words = (page_size_words > length_words - i) ? length_words - i : page_size_words;
+
+                DeviceDataUpdater::update_read(
+                    default_worker_start, device_data, bank_core, dram_bank_id, bank_offset, words);
+
+                page_idx++;
+            }
+        }
+
+        return sub_cmds;
+    }
+};
+
+class PrefetcherRingbufferReadTestFixture : virtual public BasePrefetcherTestFixture {
+    static constexpr uint32_t MAX_PAGE_OFFSET = 5;
+
+public:
+    // Set ring buffer offset to arbitrary number
+    static constexpr uint32_t WRITE_OFFSET = 1234;
+
+    void populate_ringbuffer_from_dram(
+        HostMemDeviceCommand& cmd,
+        const std::vector<uint32_t>& lengths,
+        DeviceData& device_data,
+        uint32_t ringbuffer_read_page_size_log2,
+        uint32_t n_sub_cmds) {
+        bool reset = false;
+        uint32_t page_size_bytes = 1 << ringbuffer_read_page_size_log2;
+        uint32_t count = 0;
+
+        for (auto length : lengths) {
+            uint8_t wraparound_flag = 0;
+            if (!reset) {
+                wraparound_flag = CQ_PREFETCH_PAGED_TO_RING_BUFFER_FLAG_RESET_TO_START;
+                reset = true;
             }
 
-            page_idx++;
+            CQPrefetchPagedToRingbufferCmd ringbuffer_cmd{};
+            ringbuffer_cmd.flags = wraparound_flag;
+            ringbuffer_cmd.log2_page_size = ringbuffer_read_page_size_log2;
+            // RECOMMENDED: Use uint16_t instead of uint8_t for std::uniform_int_distribution, then cast it to uint8_t
+            ringbuffer_cmd.start_page =
+                static_cast<uint8_t>(payload_generator_->get_rand<uint16_t>(0, MAX_PAGE_OFFSET - 1));
+            ringbuffer_cmd.wp_offset_update = length;
+            ringbuffer_cmd.base_addr = dram_base_ + count * page_size_bytes;
+            ringbuffer_cmd.length = length;
+
+            cmd.add_prefetch_paged_to_ringbuffer(ringbuffer_cmd);
+            count++;
+
+            // Model the paged to ringbuffer read in this function by updating worker data with interleaved/paged DRAM
+            // data, for validation later.
+            uint32_t length_words = length / sizeof(uint32_t);
+            uint32_t base_addr_words = (ringbuffer_cmd.base_addr - dram_base_) / sizeof(uint32_t);
+            uint32_t page_size_words = page_size_bytes / sizeof(uint32_t);
+
+            // Get data from DRAM map, add to worker.
+            uint32_t page_idx = ringbuffer_cmd.start_page;
+            for (uint32_t i = 0; i < length_words; i += page_size_words) {
+                uint32_t dram_bank_id = page_idx % num_banks_;
+                auto dram_channel = device_->allocator()->get_dram_channel_from_bank_id(dram_bank_id);
+                CoreCoord bank_core = device_->logical_core_from_dram_channel(dram_channel);
+                uint32_t bank_offset = base_addr_words + (page_size_words * (page_idx / num_banks_));
+
+                uint32_t words = (page_size_words > length_words - i) ? length_words - i : page_size_words;
+                DeviceDataUpdater::update_read(
+                    default_worker_start, device_data, bank_core, dram_bank_id, bank_offset, words);
+
+                page_idx++;
+            }
         }
     }
 
-    auto prior_end = prefetch_cmds.size();
-    add_prefetcher_packed_paged_read_cmd(prefetch_cmds, sub_cmds, total_length);
-    uint32_t new_size = (prefetch_cmds.size() - prior_end) * sizeof(uint32_t);
-    TT_ASSERT(new_size <= max_prefetch_command_size_g, "Generated prefetcher command exceeds max command size");
-    TT_ASSERT((new_size >> DispatchSettings::PREFETCH_Q_LOG_MINSIZE) < 0xFFFF, "HostQ command too large to represent");
-    cmd_sizes.push_back(new_size >> DispatchSettings::PREFETCH_Q_LOG_MINSIZE);
+    std::vector<CQPrefetchRelayRingbufferSubCmd> build_sub_cmds(
+        const std::vector<uint32_t>& lengths, uint32_t n_sub_cmds) {
+        std::vector<CQPrefetchRelayRingbufferSubCmd> sub_cmds;
+        sub_cmds.reserve(n_sub_cmds);
+
+        uint32_t current_offset = 0;
+        for (auto length : lengths) {
+            CQPrefetchRelayRingbufferSubCmd sub_cmd{};
+            sub_cmd.start = current_offset - WRITE_OFFSET;  // Since set_ringbuffer_offset is set to WRITE_OFFSET
+            sub_cmd.length = length;
+            current_offset += length;
+            sub_cmds.push_back(sub_cmd);
+        }
+
+        return sub_cmds;
+    }
+};
+
+// This fixture is useful for commands like CQ_PREFETCH_CMD_RELAY_LINEAR_H,
+// where we need multi-chip device environment and needs PREFETCH_H / PREFETCH_D split
+class PrefetchRelayLinearHTestFixture : public BasePrefetcherTestFixture {
+protected:
+    static constexpr uint32_t MIN_READ_SIZE = 32;
+
+    tt_metal::distributed::MeshDevice::IDevice* mmio_device_ = nullptr;
+    tt_metal::distributed::MeshDevice::IDevice* remote_device_ = nullptr;
+
+    void SetUp() override {
+        BasePrefetcherTestFixture::SetUp();
+
+        // Skip single-chips
+        // Check if we are running in a configuration where we have a distinct MMIO and Remote device
+        // This test targets PREFETCH_H (MMIO) -> PREFETCH_D (Remote) -> DISPATCHER (Remote)
+        // Skip on anything not wormhole
+        if (device_->arch() != tt::ARCH::WORMHOLE_B0) {
+            GTEST_SKIP() << "Skipping RelayLinearHTest: Test only supported on WORMHOLE_B0.";
+        }
+
+        mmio_device_ = mesh_device_->get_devices()[0];
+        remote_device_ = mesh_device_->get_devices()[1];
+        // Override the base class device_ to use remote device
+        device_ = remote_device_;
+        // We need access to remote chips issue queue to execute commands like
+        // CQ_PREFETCH_CMD_RELAY_LINEAR_H in PREFETCH_H (channel 1 region)
+        mgr_ = &remote_device_->sysmem_manager();
+
+        // Execution through exec_buf is always disabled for standalone commands like
+        // CQ_PREFETCH_CMD_RELAY_LINEAR_H
+        use_exec_buf_ = false;
+    }
+};
+
+class PrefetcherSmokeTestFixture : public PrefetcherRingbufferReadTestFixture,
+                                   public PrefetcherPackedReadTestFixture,
+                                   public PrefecherHostTextFixture {
+protected:
+};
+
+// Host-side helpers used by tests to emit the same CQ commands
+// that prefetcher/dispatcher code emits. This namespace replicates the production code's command generation logic
+// for testing purposes.
+namespace CommandBuilder {
+
+HostMemDeviceCommand build_dispatch_terminate() {
+    bool dispatch_sub_enabled = MetalContext::instance().get_dispatch_query_manager().dispatch_s_enabled();
+    // Calculate total command buffer size needed
+    DeviceCommandCalculator calc;
+    calc.add_dispatch_wait();
+    calc.add_dispatch_terminate();
+    if (dispatch_sub_enabled) {
+        calc.add_dispatch_terminate();
+    }
+    const uint32_t total_cmd_bytes = calc.write_offset_bytes();
+    HostMemDeviceCommand cmd(total_cmd_bytes);
+    cmd.add_dispatch_wait(CQ_DISPATCH_CMD_WAIT_FLAG_BARRIER, 0, 0, 0);
+    cmd.add_dispatch_terminate();
+    if (dispatch_sub_enabled) {
+        cmd.add_dispatch_terminate(DispatcherSelect::DISPATCH_SUBORDINATE);
+    }
+
+    return cmd;
 }
 
-// Interleaved/Paged Read of DRAM to Worker L1
-void gen_dram_read_cmd(
-    IDevice* device,
-    vector<uint32_t>& prefetch_cmds,
-    vector<uint32_t>& cmd_sizes,
-    DeviceData& device_data,
-    CoreCoord worker_core,
+HostMemDeviceCommand build_prefetch_terminate() {
+    // Calculate total command buffer size needed
+    DeviceCommandCalculator calc;
+    calc.add_prefetch_terminate();
+    const uint32_t total_cmd_bytes = calc.write_offset_bytes();
+    HostMemDeviceCommand cmd(total_cmd_bytes);
+    cmd.add_prefetch_terminate();
+
+    return cmd;
+}
+
+HostMemDeviceCommand build_dispatch_prefetch_stall() {
+    // Calculate the command size
+    DeviceCommandCalculator calc;
+    calc.add_dispatch_wait_with_prefetch_stall();
+    const uint32_t command_size_bytes = calc.write_offset_bytes();
+
+    // Create the HostMemDeviceCommand with pre-calculated size
+    HostMemDeviceCommand cmd(command_size_bytes);
+
+    cmd.add_dispatch_wait_with_prefetch_stall(
+        CQ_DISPATCH_CMD_WAIT_FLAG_BARRIER | CQ_DISPATCH_CMD_WAIT_FLAG_WAIT_MEMORY, 0, 0, 0);
+
+    return cmd;
+}
+
+HostMemDeviceCommand build_dispatch_write_offset(tt::stl::Span<const uint32_t> write_offsets) {
+    // Calculate the command size
+    DeviceCommandCalculator calc;
+    calc.add_dispatch_set_write_offsets(write_offsets.size());
+    const uint32_t command_size_bytes = calc.write_offset_bytes();
+
+    // Create the HostMemDeviceCommand with pre-calculated size
+    HostMemDeviceCommand cmd(command_size_bytes);
+
+    cmd.add_dispatch_set_write_offsets(write_offsets);
+
+    return cmd;
+}
+
+template <bool inline_data>
+HostMemDeviceCommand build_prefetch_relay_linear_host(uint32_t noc_xy, uint32_t addr, uint32_t data_size_bytes) {
+    DeviceCommandCalculator calc;
+    calc.add_dispatch_write_linear_host();
+    calc.add_prefetch_relay_linear();
+    const uint32_t total_cmd_bytes = calc.write_offset_bytes();
+
+    // Create the HostMemDeviceCommand with pre-calculated size
+    HostMemDeviceCommand cmd(total_cmd_bytes);
+    // Dispatcher command to write data from prefetcher into completion buffer
+    cmd.add_dispatch_write_host<inline_data>(
+        false,            // flush_prefetch
+        data_size_bytes,  // data_sizeB
+        false,            // is_event
+        0,                // pad1
+        nullptr           // data
+    );
+
+    // Relay data from L1 to dispatcher using NOC
+    cmd.add_prefetch_relay_linear(noc_xy, data_size_bytes, addr);
+
+    return cmd;
+}
+
+template <bool inline_data>
+HostMemDeviceCommand build_relay_inline_host(const std::vector<uint32_t>& payload, uint32_t data_size_bytes) {
+    DeviceCommandCalculator calc;
+    calc.add_dispatch_write_linear_host_event(data_size_bytes);
+    const uint32_t total_cmd_bytes = calc.write_offset_bytes();
+
+    // Create the HostMemDeviceCommand with pre-calculated size
+    HostMemDeviceCommand cmd(total_cmd_bytes);
+    // Dispatcher command to write data from prefetcher into completion buffer
+    cmd.add_dispatch_write_host<inline_data>(
+        true,             // flush_prefetch
+        data_size_bytes,  // data_sizeB
+        false,            // is_event
+        0,                // pad1
+        payload.data()    // data
+    );
+
+    return cmd;
+}
+
+template <bool flush_prefetch, bool inline_data>
+HostMemDeviceCommand build_prefetch_relay_linear_read(
+    uint32_t noc_xy, uint32_t dst_addr, uint32_t src_addr, uint32_t transfer_size) {
+    DeviceCommandCalculator calc;
+    calc.add_dispatch_write_linear<flush_prefetch, inline_data>(transfer_size);
+    calc.add_prefetch_relay_linear();
+    const uint32_t total_cmd_bytes = calc.write_offset_bytes();
+
+    // Create the HostMemDeviceCommand with pre-calculated size
+    HostMemDeviceCommand cmd(total_cmd_bytes);
+    cmd.add_dispatch_write_linear<flush_prefetch, inline_data>(
+        0,              // num_mcast_dests
+        noc_xy,         // NOC coordinates
+        dst_addr,       // destination address
+        transfer_size,  // data size
+        nullptr         // payload data
+    );
+
+    // Relay data from L1 to dispatcher using NOC
+    cmd.add_prefetch_relay_linear(noc_xy, transfer_size, src_addr);
+
+    return cmd;
+}
+
+template <bool flush_prefetch, bool inline_data>
+HostMemDeviceCommand build_prefetch_relay_paged(
+    uint32_t noc_xy,
+    uint32_t addr,
     uint32_t start_page,
     uint32_t base_addr,
-    uint32_t page_size,
-    uint32_t pages,
-    uint32_t length_adjust) {
-    vector<uint32_t> dispatch_cmds;
-    const bool is_dram = true;
+    uint32_t page_size_bytes,
+    uint32_t pages_in_chunk,
+    uint32_t length_adjust = 0) {
+    DeviceCommandCalculator calc;
+    uint32_t transfer_size = page_size_bytes * pages_in_chunk;
+    calc.add_dispatch_write_linear<flush_prefetch, inline_data>(transfer_size);
+    calc.add_prefetch_relay_paged();
+    const uint32_t total_cmd_bytes = calc.write_offset_bytes();
 
-    // Device code assumes padding to 32 bytes
-    TT_ASSERT((length_adjust & 0x1f) == 0);
+    // Create the HostMemDeviceCommand with pre-calculated size
+    HostMemDeviceCommand cmd(total_cmd_bytes);
 
-    uint32_t device_data_size = (page_size * pages) - length_adjust;
-    log_trace(
-        tt::LogTest,
-        "Starting {} with worker_core: {} start_page: {} base_addr: 0x{:x} page_size: {} pages: {}. device_data_size: "
-        "0x{:x}",
-        __FUNCTION__,
-        worker_core.str(),
-        start_page,
-        base_addr,
-        page_size,
-        pages,
-        device_data_size);
+    cmd.add_dispatch_write_linear<flush_prefetch, inline_data>(
+        0,              // num_mcast_dests
+        noc_xy,         // NOC coordinates
+        addr,           // destination address
+        transfer_size,  // data size
+        nullptr         // payload data
+    );
 
-    gen_bare_dispatcher_unicast_write_cmd(device, dispatch_cmds, worker_core, device_data, device_data_size);
-    add_prefetcher_cmd(prefetch_cmds, cmd_sizes, CQ_PREFETCH_CMD_RELAY_INLINE_NOFLUSH, dispatch_cmds);
+    cmd.add_prefetch_relay_paged(true, start_page, base_addr, page_size_bytes, pages_in_chunk, length_adjust);
 
-    auto prior_end = prefetch_cmds.size();
-    uint32_t dram_data_base_addr = device->allocator()->get_base_allocator_addr(HalMemType::DRAM);
-    add_prefetcher_paged_read_cmd(
-        prefetch_cmds,
-        cmd_sizes,
-        start_page,
-        base_addr + dram_data_base_addr,
-        page_size,
-        pages,
-        is_dram,
-        length_adjust);
-
-    uint32_t new_size = (prefetch_cmds.size() - prior_end) * sizeof(uint32_t);
-    TT_ASSERT(new_size <= max_prefetch_command_size_g, "Generated prefetcher command exceeds max command size");
-    TT_ASSERT((new_size >> DispatchSettings::PREFETCH_Q_LOG_MINSIZE) < 0xFFFF, "HostQ command too large to represent");
-    cmd_sizes.push_back(new_size >> DispatchSettings::PREFETCH_Q_LOG_MINSIZE);
-
-    // Model the paged read in this function by updating worker data with interleaved/paged DRAM data, for validation
-    // later.
-    add_paged_dram_data_to_device_data(
-        device, worker_core, device_data, start_page, base_addr, page_size, pages, length_adjust);
+    return cmd;
 }
 
-// Interleaved/Paged Write to DRAM.
-void gen_dram_write_cmd(
-    IDevice* device,
-    vector<uint32_t>& prefetch_cmds,
-    vector<uint32_t>& cmd_sizes,
+template <bool flush_prefetch, bool inline_data>
+HostMemDeviceCommand build_prefetch_relay_paged_packed(
+    const std::vector<CQPrefetchRelayPagedPackedSubCmd>& sub_cmds,
+    uint32_t noc_xy,
+    uint32_t addr,
+    uint32_t total_length) {
+    const uint32_t n_sub_cmds = sub_cmds.size();
+    // Calculate the command size using DeviceCommandCalculator
+    DeviceCommandCalculator calc;
+    calc.add_dispatch_write_linear<flush_prefetch, inline_data>(total_length);
+    calc.add_prefetch_relay_paged_packed(n_sub_cmds);
+    const uint32_t total_cmd_bytes = calc.write_offset_bytes();
+
+    // Create the HostMemDeviceCommand with pre-calculated size
+    HostMemDeviceCommand cmd(total_cmd_bytes);
+
+    cmd.add_dispatch_write_linear<flush_prefetch, inline_data>(
+        0,             // num_mcast_dests
+        noc_xy,        // NOC coordinates
+        addr,          // destination address
+        total_length,  // data size
+        nullptr        // payload data
+    );
+
+    // Add the prefetch relay paged packed
+    cmd.add_prefetch_relay_paged_packed(total_length, sub_cmds, n_sub_cmds);
+
+    return cmd;
+}
+
+template <bool flush_prefetch, bool inline_data>
+HostMemDeviceCommand build_prefetch_ringbuffer_relay(
+    const std::vector<CQPrefetchRelayRingbufferSubCmd>& sub_cmds,
+    const std::vector<uint32_t>& lengths,
     DeviceData& device_data,
-    uint32_t start_page,
-    uint32_t page_size,
-    uint32_t pages) {
-    vector<uint32_t> dispatch_cmds;
-    const bool is_dram = true;
-    log_trace(
-        tt::LogTest,
-        "Starting {} with is_dram: {} start_page: {} page_size: {} pages: {}",
-        __FUNCTION__,
-        is_dram,
-        start_page,
-        page_size,
-        pages);
-
-    gen_dispatcher_paged_write_cmd(device, dispatch_cmds, device_data, is_dram, start_page, page_size, pages);
-    add_prefetcher_cmd(prefetch_cmds, cmd_sizes, CQ_PREFETCH_CMD_RELAY_INLINE, dispatch_cmds);
-}
-
-void gen_wait_and_stall_cmd(IDevice* device, vector<uint32_t>& prefetch_cmds, vector<uint32_t>& cmd_sizes) {
-    vector<uint32_t> dispatch_cmds;
-
-    CQDispatchCmd wait{};
-    wait.base.cmd_id = CQ_DISPATCH_CMD_WAIT;
-    wait.wait.flags = CQ_DISPATCH_CMD_WAIT_FLAG_BARRIER | CQ_DISPATCH_CMD_WAIT_FLAG_NOTIFY_PREFETCH |
-                      CQ_DISPATCH_CMD_WAIT_FLAG_WAIT_MEMORY;
-    wait.wait.addr = dispatch_wait_addr_g;
-    wait.wait.count = 0;
-    add_bare_dispatcher_cmd(dispatch_cmds, wait);
-    add_prefetcher_cmd(prefetch_cmds, cmd_sizes, CQ_PREFETCH_CMD_RELAY_INLINE, dispatch_cmds);
-
-    vector<uint32_t> empty_payload;  // don't give me grief, it is just a test
-    add_prefetcher_cmd(prefetch_cmds, cmd_sizes, CQ_PREFETCH_CMD_STALL, empty_payload);
-}
-
-// This is pretty much a blit: copies from worker core's start of data back to the end of data
-void gen_linear_read_cmd(
-    IDevice* device,
-    vector<uint32_t>& prefetch_cmds,
-    vector<uint32_t>& cmd_sizes,
-    DeviceData& device_data,
-    CoreCoord worker_core,
-    uint32_t length,
-    uint32_t offset = 0) {
-    vector<uint32_t> dispatch_cmds;
-    const uint32_t bank_id = 0;  // No interleaved pages here.
-
-    // Stall because we are reading data that was previously written
-    gen_wait_and_stall_cmd(device, prefetch_cmds, cmd_sizes);
-
-    gen_bare_dispatcher_unicast_write_cmd(device, dispatch_cmds, worker_core, device_data, length);
-    add_prefetcher_cmd(prefetch_cmds, cmd_sizes, CQ_PREFETCH_CMD_RELAY_INLINE_NOFLUSH, dispatch_cmds);
-
-    auto prior_end = prefetch_cmds.size();
-    uint32_t addr = device_data.get_base_result_addr(device_data.get_core_type(worker_core));
-    add_prefetcher_linear_read_cmd(
-        device, prefetch_cmds, cmd_sizes, worker_core, addr + (offset * sizeof(uint32_t)), length);
-    uint32_t new_size = (prefetch_cmds.size() - prior_end) * sizeof(uint32_t);
-    TT_ASSERT(new_size <= max_prefetch_command_size_g, "Generated prefetcher command exceeds max command size");
-    TT_ASSERT((new_size >> DispatchSettings::PREFETCH_Q_LOG_MINSIZE) < 0xFFFF, "HostQ command too large to represent");
-    cmd_sizes.push_back(new_size >> DispatchSettings::PREFETCH_Q_LOG_MINSIZE);
-
-    // Add linear data to worker data:
-    uint32_t length_words = length / sizeof(uint32_t);
-    for (uint32_t i = 0; i < length_words; i++) {
-        device_data.push_one(worker_core, device_data.at(worker_core, bank_id, offset + i));
+    PrefetcherRingbufferReadTestFixture& fixture,
+    uint32_t noc_xy,
+    uint32_t addr,
+    uint32_t total_length,
+    uint32_t ringbuffer_read_page_size_log2) {
+    const uint32_t n_sub_cmds = sub_cmds.size();
+    // Calculate the command size using DeviceCommandCalculator
+    DeviceCommandCalculator calc;
+    for (uint32_t i = 0; i < n_sub_cmds; i++) {
+        calc.add_prefetch_paged_to_ringbuffer();
     }
-    device_data.pad(worker_core, bank_id, MetalContext::instance().hal().get_alignment(HalMemType::L1));
+    calc.add_prefetch_set_ringbuffer_offset();
+    calc.add_dispatch_write_linear<false, false>(total_length);
+    calc.add_prefetch_relay_ringbuffer(n_sub_cmds);
+    const uint32_t total_cmd_bytes = calc.write_offset_bytes();
+
+    // Create the HostMemDeviceCommand with pre-calculated size
+    HostMemDeviceCommand cmd(total_cmd_bytes);
+
+    // First, we populate the ringbuffer
+    fixture.populate_ringbuffer_from_dram(cmd, lengths, device_data, ringbuffer_read_page_size_log2, n_sub_cmds);
+
+    // Second, we set the read offset in the ring buffer
+    cmd.add_prefetch_set_ringbuffer_offset(fixture.WRITE_OFFSET);
+
+    // Third, we write the dispatch command to the dispatcher
+    cmd.add_dispatch_write_linear<flush_prefetch, inline_data>(
+        0,             // num_mcast_dests
+        noc_xy,        // NOC coordinates
+        addr,          // destination address
+        total_length,  // data size
+        nullptr        // payload data
+    );
+
+    // Lastly, relay the subcommands from ringbuffer in L1 to dispatcher
+    cmd.add_prefetch_relay_ringbuffer(n_sub_cmds, sub_cmds);
+
+    return cmd;
 }
 
-void gen_dispatcher_delay_cmd(
-    IDevice* device, vector<uint32_t>& prefetch_cmds, vector<uint32_t>& cmd_sizes, uint32_t count) {
-    vector<uint32_t> dispatch_cmds;
+}  // namespace CommandBuilder
 
-    CQDispatchCmd delay{};
-    delay.base.cmd_id = CQ_DISPATCH_CMD_DELAY;
-    delay.delay.delay = count;
-    add_bare_dispatcher_cmd(dispatch_cmds, delay);
-    add_prefetcher_cmd(prefetch_cmds, cmd_sizes, CQ_PREFETCH_CMD_RELAY_INLINE, dispatch_cmds);
-}
+class RandomTestFixture : public BasePrefetcherTestFixture {
+    bool big_chunk_ = true;                                // TODO: make this parameterized
+    static constexpr uint32_t MAX_PAGE_SIZE = 256 * 1024;  // TODO: make it equal to actual scratch_db_page_size
 
-void gen_paged_read_dram_test(
-    IDevice* device,
-    vector<uint32_t>& prefetch_cmds,
-    vector<uint32_t>& cmd_sizes,
-    DeviceData& device_data,
-    CoreCoord worker_core) {
-    uint32_t pages_read = 0;
-    bool finished = false;
+protected:
+    std::optional<HostMemDeviceCommand> gen_random_linear_cmd(
+        DeviceData& device_data,
+        const CoreCoord& worker_core,
+        uint32_t noc_xy,
+        uint32_t addr_base,
+        uint32_t& remaining_bytes) {
+        // Random length (bytes), aligned to 4, capped by remaining
+        uint32_t data_size_bytes = payload_generator_->get_rand<uint32_t>(0, dispatch_buffer_page_size_ - 1);
+        data_size_bytes &= ~(sizeof(uint32_t) - 1);
+        data_size_bytes = std::min(data_size_bytes, remaining_bytes);
+        if (data_size_bytes == 0) {
+            return std::nullopt;
+        }
 
-    log_info(
-        tt::LogTest,
-        "Running Paged Read DRAM test with num_pages: {} page_size: {} to worker_core: {}",
-        dram_pages_to_read_g,
-        dram_page_size_g,
-        worker_core.str());
-    while (!finished) {
-        uint32_t start_page = pages_read % num_dram_banks_g;
-        uint32_t base_addr = (pages_read / num_dram_banks_g) * dram_page_size_g;
+        // Random offset within a dispatch page, aligned to 4
+        uint32_t offset_bytes = payload_generator_->get_rand<uint32_t>(0, dispatch_buffer_page_size_ - 1);
+        offset_bytes &= ~(sizeof(uint32_t) - 1);
 
-        gen_dram_read_cmd(
-            device,
-            prefetch_cmds,
-            cmd_sizes,
+        // Destination address and payload
+        uint32_t dst_addr = device_data.get_result_data_addr(worker_core, 0);
+        std::vector<uint32_t> payload = payload_generator_->generate_payload(data_size_bytes);
+
+        // Source address
+        uint32_t src_addr = device_data.get_base_result_addr(device_data.get_core_type(worker_core)) + offset_bytes;
+
+        // Model the write
+        const CoreRange worker_range{worker_core, worker_core};
+        Common::DeviceDataUpdater::update_linear_write(payload, device_data, worker_range, false);
+
+        // Build command (dispatch write + relay)
+        HostMemDeviceCommand cmd = CommandBuilder::build_prefetch_relay_linear_read<flush_prefetch_, inline_data_>(
+            noc_xy, dst_addr, src_addr, data_size_bytes);
+
+        remaining_bytes -= data_size_bytes;
+        return cmd;
+    }
+
+    std::optional<HostMemDeviceCommand> gen_random_dram_paged_cmd(
+        DeviceData& device_data,
+        const CoreCoord& worker_core,
+        const CoreRange& worker_range,
+        uint32_t noc_xy,
+        uint32_t& remaining_bytes) {
+        const uint32_t dram_alignment = MetalContext::instance().hal().get_alignment(HalMemType::DRAM);
+        uint32_t start_page = payload_generator_->get_rand<uint32_t>(0, num_banks_ - 1);
+        // Calculate how many pages fit in this chunk
+        uint32_t max_bytes_in_chunk = big_chunk_ ? MAX_PAGE_SIZE : 4096;
+        uint32_t page_size = (payload_generator_->get_rand<uint32_t>(0, max_bytes_in_chunk)) & ~(dram_alignment - 1);
+        page_size = std::max(page_size, dram_alignment);
+        // Ensure we don't exceed remaining bytes
+        if (page_size > remaining_bytes) {
+            page_size = remaining_bytes & ~(dram_alignment - 1);
+            if (page_size == 0) {
+                return std::nullopt;  // Cannot proceed if less than alignment
+            }
+        }
+        uint32_t page_size_words = page_size / sizeof(uint32_t);
+
+        // Calculate max random size we can read
+        uint32_t max_data = big_chunk_ ? DEVICE_DATA_SIZE : DEVICE_DATA_SIZE / 8;
+        uint32_t max = DEVICE_DATA_SIZE - (device_data.size() * sizeof(uint32_t));
+        max = std::max(max, max_data);  // (max > max_data) ? max_data : max;
+
+        // Randomize base address in DRAM
+        uint32_t random_offset =
+            (payload_generator_->get_rand<uint32_t>(0, DRAM_DATA_SIZE_BYTES / 2 - 1)) & ~(dram_alignment - 1);
+        // Randomize total size to read
+        uint32_t size = payload_generator_->get_rand<uint32_t>(0, max - 1);
+        size = std::max(size, page_size);
+        // Calculate number of pages
+        uint32_t pages = size / page_size;
+        // Clamp pages to remaining bytes if needed
+        if (pages * page_size > remaining_bytes) {
+            pages = remaining_bytes / page_size;
+        }
+
+        if (pages == 0) {
+            return std::nullopt;
+        }
+
+        // Validation check
+        TT_ASSERT(random_offset + (start_page * page_size + pages * page_size / num_banks_) < DRAM_DATA_SIZE_BYTES);
+
+        // TODO: Randomize length adjust
+        uint32_t length_adjust = 0;
+
+        // Calculate absolute address for command
+        uint32_t cmd_base_addr = dram_base_ + random_offset;
+        uint32_t addr = device_data.get_result_data_addr(worker_core, 0);
+        HostMemDeviceCommand cmd = CommandBuilder::build_prefetch_relay_paged<flush_prefetch_, inline_data_>(
+            noc_xy, addr, start_page, cmd_base_addr, page_size, pages, length_adjust);
+
+        // Use offset words for validation indexing
+        uint32_t validation_base_addr_words = random_offset / sizeof(uint32_t);
+        uint32_t length_adjust_words = length_adjust / sizeof(uint32_t);
+        uint32_t last_page = start_page + pages;
+
+        for (uint32_t page_idx = start_page; page_idx < last_page; ++page_idx) {
+            const uint32_t bank_id = page_idx % num_banks_;
+            uint32_t bank_offset = validation_base_addr_words + page_size_words * (page_idx / num_banks_);
+
+            // Get the logical core for this bank
+            const auto dram_channel = device_->allocator()->get_dram_channel_from_bank_id(bank_id);
+            const CoreCoord bank_core = device_->logical_core_from_dram_channel(dram_channel);
+            uint32_t words_to_read = page_size_words;
+            if (page_idx == last_page - 1) {
+                words_to_read -= length_adjust_words;
+            }
+
+            // Update DeviceData for paged read
+            DeviceDataUpdater::update_paged_dram_read(
+                worker_range, device_data, bank_core, bank_id, bank_offset, words_to_read);
+        }
+
+        uint32_t actual_data_size = (page_size * pages) - length_adjust;
+        remaining_bytes -= actual_data_size;
+        return cmd;
+    }
+
+    std::optional<HostMemDeviceCommand> gen_random_inline_cmd(
+        DeviceData& device_data, const CoreRange& worker_range, uint32_t noc_xy, uint32_t& remaining_bytes) {
+        // Randomize the dispatcher command we choose to relay
+        uint32_t random_dispatch_cmd = payload_generator_->get_rand<uint32_t>(0, 1);
+
+        switch (random_dispatch_cmd) {
+            case 0:
+                // Unicast Write
+                {
+                    uint32_t cmd_size_bytes = host_alignment_;  // CQ_PREFETCH_CMD_BARE_MIN_SIZE
+
+                    // New implementation using get_random_size:
+                    uint32_t max_prefetch_command_size = max_fetch_bytes_;
+                    uint32_t max_size = big_chunk_ ? max_prefetch_command_size : max_prefetch_command_size / 16;
+
+                    // Subtract overhead to get max payload size allowed
+                    uint32_t max_payload_bytes = max_size - cmd_size_bytes;
+                    uint32_t max_xfer_size_16b = max_payload_bytes >> 4;
+
+                    // get_random_size handles:
+                    uint32_t xfer_size_bytes = payload_generator_->get_random_size(
+                        max_xfer_size_16b,   // max_allowed (in 16B units)
+                        bytes_per_16B_unit,  // bytes_per_unit
+                        remaining_bytes      // remaining_bytes
+                    );
+
+                    TT_ASSERT(xfer_size_bytes > 0);
+
+                    // Capture address before updating device_data
+                    uint32_t addr = device_data.get_result_data_addr(worker_range.start_coord, 0);
+
+                    // Generate payload
+                    std::vector<uint32_t> payload = payload_generator_->generate_payload(xfer_size_bytes);
+
+                    // Update DeviceData for linear write
+                    Common::DeviceDataUpdater::update_linear_write(payload, device_data, worker_range, false);
+
+                    // Build the command: Dispatch Write Linear (Unicast) wrapped in Prefetch Relay Inline
+                    HostMemDeviceCommand cmd = Common::CommandBuilder::build_linear_write_command<true, true>(
+                        payload, worker_range, false, noc_xy, addr, xfer_size_bytes);
+
+                    remaining_bytes -= xfer_size_bytes;
+                    return cmd;
+                }
+                break;
+            case 1:
+                // Packed Unicast Write
+                {
+                    // Randomly pick worker cores once for all commands
+                    std::vector<CoreCoord> worker_cores;
+
+                    for (uint32_t y = worker_range.start_coord.y; y <= worker_range.end_coord.y; ++y) {
+                        for (uint32_t x = worker_range.start_coord.x; x <= worker_range.end_coord.x; ++x) {
+                            if (send_to_all_ || payload_generator_->get_rand_bool()) {
+                                worker_cores.push_back({x, y});
+                            }
+                        }
+                    }
+
+                    if (worker_cores.empty()) {
+                        worker_cores.push_back(default_worker_start);
+                    }
+                    const uint32_t num_sub_cmds = static_cast<uint32_t>(worker_cores.size());
+                    const uint32_t sub_cmds_bytes =
+                        tt::align(num_sub_cmds * sizeof(CQDispatchWritePackedUnicastSubCmd), l1_alignment_);
+
+                    // Build sub-commands
+                    std::vector<CQDispatchWritePackedUnicastSubCmd> sub_cmds =
+                        Common::PackedWriteUtils::build_sub_cmds(device_, worker_cores, k_dispatch_downstream_noc);
+                    // Relevel once before generating commands
+                    device_data.relevel(tt::CoreType::WORKER);
+
+                    // Size and Clamp
+                    uint32_t xfer_size_bytes =
+                        payload_generator_->get_random_size(dispatch_buffer_page_size_, 1, remaining_bytes);
+                    TT_ASSERT(xfer_size_bytes > 0);
+                    bool no_stride = payload_generator_->get_rand_bool();
+
+                    // Clamp for dispatch page size (no_stride mode)
+                    if (no_stride) {
+                        const uint32_t max_allowed =
+                            dispatch_buffer_page_size_ - sizeof(CQDispatchCmd) - sub_cmds_bytes;
+                        if (xfer_size_bytes > max_allowed) {
+                            log_warning(tt::LogTest, "Clamping packed_write cmd w/ no_stride to fit dispatch page");
+                            xfer_size_bytes = max_allowed;
+                        }
+                    }
+
+                    xfer_size_bytes = Common::PackedWriteUtils::clamp_to_max_fetch(
+                        max_fetch_bytes_,
+                        xfer_size_bytes,
+                        num_sub_cmds,
+                        packed_write_max_unicast_sub_cmds_,
+                        no_stride,
+                        l1_alignment_);
+
+                    const CoreCoord& fw = worker_cores[0];
+                    // Capture address before updating device_data
+                    uint32_t addr = device_data.get_result_data_addr(fw, 0);
+                    // Generate Payload
+                    std::vector<uint32_t> payload = payload_generator_->generate_payload_with_core(fw, xfer_size_bytes);
+                    // Update expected device_data for all cores
+                    Common::DeviceDataUpdater::update_packed_write(payload, device_data, worker_cores, l1_alignment_);
+
+                    // Build Command
+                    HostMemDeviceCommand cmd = Common::CommandBuilder::build_packed_write_command(
+                        payload, sub_cmds, addr, l1_alignment_, packed_write_max_unicast_sub_cmds_, no_stride);
+
+                    remaining_bytes -= xfer_size_bytes;
+                    return cmd;
+                }
+                break;
+            default: TT_THROW("Invalid random_dispatch_cmd {} in gen_random_inline_cmd", random_dispatch_cmd);
+        }
+        return std::nullopt;
+    }
+};
+
+struct HelperInfo {
+    uint32_t dram_base_;
+    uint32_t num_banks_;
+    uint32_t l1_alignment_;
+    uint32_t packed_write_max_unicast_sub_cmds_;
+    uint32_t dispatch_buffer_page_size_;
+};
+
+// TODO: add CQ_PREFETCH_CMD_DEBUG
+class SmokeTestHelper {
+    tt_metal::distributed::MeshDevice::IDevice* device_;
+    DeviceData& device_data_;
+    std::vector<HostMemDeviceCommand>& cmds_;
+    std::unique_ptr<Common::DispatchPayloadGenerator> payload_generator_;
+
+    HelperInfo info_;
+
+public:
+    SmokeTestHelper(
+        tt_metal::distributed::MeshDevice::IDevice* device,
+        DeviceData& device_data,
+        std::vector<HostMemDeviceCommand>& cmds,
+        HelperInfo info) :
+        device_(device), device_data_(device_data), cmds_(cmds), info_(info) {
+        // Initialize simple payload generator
+        Common::DispatchPayloadGenerator::Config cfg;
+        cfg.seed = 1234;  // Deterministic seed for smoke test
+        payload_generator_ = std::make_unique<Common::DispatchPayloadGenerator>(cfg);
+    }
+
+    // Create individual HostMemDeviceCommand linear write cmds of size length
+    void add_unicast_write(const CoreRange worker_range, uint32_t length) {
+        const auto worker = worker_range.start_coord;
+        const CoreCoord first_virt_worker = device_->virtual_core_from_logical_core(worker, CoreType::WORKER);
+        uint32_t noc_xy = device_->get_noc_unicast_encoding(k_dispatch_downstream_noc, first_virt_worker);
+        const bool is_mcast_ = false;
+        const bool flush_prefetch = true;
+        const bool inline_data = true;  // send data inline
+        // Capture address before updating device_data
+        uint32_t addr = device_data_.get_result_data_addr(worker, 0);
+        // Generate payload
+        std::vector<uint32_t> payload = payload_generator_->generate_payload(length);
+        // Update DeviceData for linear write
+        Common::DeviceDataUpdater::update_linear_write(payload, device_data_, worker_range, is_mcast_);
+        // Create the HostMemDeviceCommand
+        HostMemDeviceCommand cmd = Common::CommandBuilder::build_linear_write_command<flush_prefetch, inline_data>(
+            payload, worker_range, is_mcast_, noc_xy, addr, length);
+        // Add command
+        cmds_.push_back(cmd);
+    }
+
+    // Same as add_unicast_write except all lengths merged into a single fetchQ entry
+    void add_merged_unicast_writes(const CoreRange worker_range, const std::vector<uint32_t>& lengths) {
+        const auto worker = worker_range.start_coord;
+        const CoreCoord first_virt_worker = device_->virtual_core_from_logical_core(worker, CoreType::WORKER);
+        uint32_t noc_xy = device_->get_noc_unicast_encoding(k_dispatch_downstream_noc, first_virt_worker);
+        const bool is_mcast_ = false;
+        const bool flush_prefetch = true;
+        const bool inline_data = true;
+
+        // Calculate size of a single merged entry of all lengths
+        DeviceCommandCalculator cmd_calc;
+        for (const auto length : lengths) {
+            cmd_calc.add_dispatch_write_linear<flush_prefetch, inline_data>(length);
+        }
+
+        const uint32_t command_size_bytes = cmd_calc.write_offset_bytes();
+
+        // Create the HostMemDeviceCommand for single merged entry
+        HostMemDeviceCommand cmd(command_size_bytes);
+
+        // Add all lengths into single cmd
+        for (const auto length : lengths) {
+            // Capture address before updating device_data
+            uint32_t addr = device_data_.get_result_data_addr(worker, 0);
+            // Generate payload
+            std::vector<uint32_t> payload = payload_generator_->generate_payload(length);
+            // Update DeviceData for linear write
+            Common::DeviceDataUpdater::update_linear_write(payload, device_data_, worker_range, is_mcast_);
+            // Add the dispatch write linear command
+            cmd.add_dispatch_write_linear<flush_prefetch, inline_data>(
+                is_mcast_ ? worker_range.size() : 0,  // num_mcast_dests
+                noc_xy,                               // NOC coordinates
+                addr,                                 // destination address
+                length,                               // data size
+                payload.data()                        // payload data
+            );
+        }
+        // Add command
+        cmds_.push_back(cmd);
+    }
+
+    // build_packed callable = PrefetcherPackedReadTestFixture::build_sub_cmds
+    void add_packed_dram_read(
+        const CoreRange worker_range,
+        const uint32_t log_packed_read_page_size,
+        const std::vector<uint32_t>& lengths,
+        std::function<std::vector<CQPrefetchRelayPagedPackedSubCmd>(
+            const std::vector<uint32_t>& lengths, DeviceData&, uint32_t log_page_sz, uint32_t n_sub_cmds)>
+            build_packed) {
+        const auto worker = worker_range.start_coord;
+        const CoreCoord last_virt_worker = device_->virtual_core_from_logical_core(worker, CoreType::WORKER);
+        uint32_t noc_xy = device_->get_noc_unicast_encoding(k_dispatch_downstream_noc, last_virt_worker);
+
+        const uint32_t total_length = std::accumulate(lengths.begin(), lengths.end(), 0);
+        const uint32_t n_sub_cmds = lengths.size();
+        const bool flush_prefetch = false;
+        const bool inline_data = false;
+
+        uint32_t l1_addr = device_data_.get_result_data_addr(worker, 0);
+
+        std::vector<CQPrefetchRelayPagedPackedSubCmd> sub_cmds =
+            build_packed(lengths, device_data_, log_packed_read_page_size, n_sub_cmds);
+
+        HostMemDeviceCommand cmd = CommandBuilder::build_prefetch_relay_paged_packed<flush_prefetch, inline_data>(
+            sub_cmds, noc_xy, l1_addr, total_length);
+
+        // Add command
+        cmds_.push_back(cmd);
+    }
+
+    void add_paged_dram_read(
+        const CoreRange worker_range,
+        uint32_t start_page,
+        uint32_t base_addr_offset,
+        uint32_t page_size_bytes,
+        uint32_t num_pages,
+        uint32_t length_adjust) {
+        const auto worker = worker_range.start_coord;
+        const CoreCoord first_worker = device_->virtual_core_from_logical_core(worker, CoreType::WORKER);
+        uint32_t noc_xy = device_->get_noc_unicast_encoding(k_dispatch_downstream_noc, first_worker);
+        const bool flush_prefetch = false;
+        const bool inline_data = false;
+
+        const uint32_t max_bytes_in_chunk = num_pages * page_size_bytes;
+        const uint32_t pages_in_chunk = max_bytes_in_chunk / page_size_bytes;
+        const uint32_t page_size_words = page_size_bytes / sizeof(uint32_t);
+        const uint32_t base_addr_words = base_addr_offset / sizeof(uint32_t);
+        uint32_t base_addr = info_.dram_base_ + base_addr_offset;
+
+        // Capture address before updating device_data
+        uint32_t l1_addr = device_data_.get_result_data_addr(worker, 0);
+
+        HostMemDeviceCommand cmd = CommandBuilder::build_prefetch_relay_paged<flush_prefetch, inline_data>(
+            noc_xy, l1_addr, start_page, base_addr, page_size_bytes, pages_in_chunk);
+
+        for (uint32_t page = 0; page < pages_in_chunk; ++page) {
+            const uint32_t page_id = start_page + page;
+            const uint32_t bank_id = page_id % info_.num_banks_;
+            uint32_t bank_offset = base_addr_words + (page_size_words * (page_id / info_.num_banks_));
+
+            // Get the logical core for this bank
+            const auto dram_channel = device_->allocator()->get_dram_channel_from_bank_id(bank_id);
+            const CoreCoord bank_core = device_->logical_core_from_dram_channel(dram_channel);
+
+            // Update DeviceData for paged read
+            DeviceDataUpdater::update_paged_dram_read(
+                worker_range, device_data_, bank_core, bank_id, bank_offset, page_size_words);
+        }
+
+        // Add command
+        cmds_.push_back(cmd);
+    }
+
+    // Length should always be less than max_fetch_bytes_
+    void add_packed_write(const std::vector<CoreCoord>& worker_cores, uint32_t length, bool no_stride = false) {
+        const uint32_t num_sub_cmds = static_cast<uint32_t>(worker_cores.size());
+        const uint32_t sub_cmds_bytes =
+            tt::align(num_sub_cmds * sizeof(CQDispatchWritePackedUnicastSubCmd), info_.l1_alignment_);
+
+        // Build sub-commands
+        std::vector<CQDispatchWritePackedUnicastSubCmd> sub_cmds =
+            Common::PackedWriteUtils::build_sub_cmds(device_, worker_cores, k_dispatch_downstream_noc);
+        // Relevel once before generating commands
+        device_data_.relevel(tt::CoreType::WORKER);
+
+        // Clamp for dispatch page size (no_stride mode)
+        if (no_stride) {
+            const uint32_t max_allowed = info_.dispatch_buffer_page_size_ - sizeof(CQDispatchCmd) - sub_cmds_bytes;
+            if (length > max_allowed) {
+                log_warning(tt::LogTest, "Clamping packed_write cmd w/ no_stride to fit dispatch page");
+                length = max_allowed;
+            }
+        }
+
+        const CoreCoord& fw = worker_cores[0];
+        // Capture address before updating device_data
+        uint32_t addr = device_data_.get_result_data_addr(fw);
+        // Generate Payload
+        auto payload = payload_generator_->generate_payload_with_core(fw, length);
+        // Update expected device_data for all cores
+        Common::DeviceDataUpdater::update_packed_write(payload, device_data_, worker_cores, info_.l1_alignment_);
+
+        // Build Command
+        HostMemDeviceCommand cmd = Common::CommandBuilder::build_packed_write_command(
+            payload, sub_cmds, addr, info_.l1_alignment_, info_.packed_write_max_unicast_sub_cmds_, no_stride);
+
+        // Add command
+        cmds_.push_back(cmd);
+    }
+
+    // L1 read to L1 write in same core
+    // For this function to run, there needs to prior data present in L1 already
+    // This function needs to run after L1 writes by previous commands
+    void add_linear_read(const CoreRange worker_range, uint32_t length, uint32_t offset_from_current = 0) {
+        const auto worker = worker_range.start_coord;
+        const CoreCoord first_worker = device_->virtual_core_from_logical_core(worker, CoreType::WORKER);
+        uint32_t noc_xy = device_->get_noc_unicast_encoding(k_dispatch_downstream_noc, first_worker);
+        const uint32_t bank_id = 0;
+
+        constexpr bool flush_prefetch = false;
+        constexpr bool inline_data = false;
+
+        // Copy already existing data from exisitng addresses src core's L1 region
+        const uint32_t src_addr =
+            device_data_.get_base_result_addr(device_data_.get_core_type(worker)) + offset_from_current;
+        // Write data to the next free/append position in modeled L1 stream
+        const uint32_t dst_addr = device_data_.get_result_data_addr(worker, 0);  // append point
+
+        // Shadow model: copy existing L1 data from src offset
+        const uint32_t words = length / sizeof(uint32_t);
+        const uint32_t offset_words = offset_from_current / sizeof(uint32_t);
+        DeviceDataUpdater::update_read(worker, device_data_, worker, bank_id, offset_words, words);
+        device_data_.pad(worker, bank_id, MetalContext::instance().hal().get_alignment(HalMemType::L1));
+
+        // Barrier/stall to avoid RAW hazards
+        HostMemDeviceCommand stall_cmd = CommandBuilder::build_dispatch_prefetch_stall();
+        cmds_.push_back(stall_cmd);
+
+        // Blit: dispatcher linear write (dest) + relay linear read (src)
+        HostMemDeviceCommand cmd = CommandBuilder::build_prefetch_relay_linear_read<flush_prefetch, inline_data>(
+            noc_xy, dst_addr, src_addr, length);
+
+        cmds_.push_back(cmd);
+    }
+
+    void add_host_write(uint32_t length, std::function<void(DeviceData&)> pad_host_data) {
+        constexpr bool inline_data = true;
+        std::vector<uint32_t> payload = payload_generator_->generate_payload(length);
+
+        DeviceDataUpdater::update_host_data(device_data_, payload, length);
+
+        // Create the HostMemDeviceCommand with pre-calculated size
+        HostMemDeviceCommand cmd = CommandBuilder::build_relay_inline_host<inline_data>(payload, length);
+
+        cmds_.push_back(cmd);
+
+        // The completion queue is page-aligned (4KB pages)
+        // Each write reserves full pages but only writes actual data,
+        // leaving the remainder untouched (still 0xbaadf00d)
+        // This ensures padding areas retain the sentinel value for validation
+        pad_host_data(device_data_);
+    }
+};
+
+using namespace tt::tt_metal;
+
+// In this we, we test the terminate command by adding a linear write unicast
+// with a small payload followed by commands to terminate prefetcher and dispatcher.
+// exec_buf enabled execution needs special handling
+TEST_P(BasePrefetcherTestFixture, TestTerminate) {
+    log_info(tt::LogTest, "BasePrefetcherTestFixture - TestTerminate - Test Start");
+
+    // Test parameters
+    constexpr uint32_t xfer_size_bytes = 16;  // Very small write size
+    const uint32_t num_iterations = get_num_iterations();
+    const uint32_t dram_data_size_words = get_dram_data_size_words();
+
+    const CoreCoord first_worker = default_worker_start;
+    const CoreCoord last_worker = {first_worker.x + 1, first_worker.y + 1};
+    const CoreRange worker_range = {first_worker, last_worker};
+
+    const uint32_t l1_base = device_->allocator()->get_base_allocator_addr(HalMemType::L1);
+
+    DeviceData device_data(device_, worker_range, l1_base, dram_base_, nullptr, false, dram_data_size_words, cfg_);
+
+    const CoreCoord first_virt_worker = device_->virtual_core_from_logical_core(first_worker, CoreType::WORKER);
+    uint32_t noc_xy = device_->get_noc_unicast_encoding(k_dispatch_downstream_noc, first_virt_worker);
+
+    // Capture address before updating device_data
+    uint32_t l1_addr = device_data.get_result_data_addr(first_worker, 0);
+
+    // Generate payload
+    std::vector<uint32_t> payload = payload_generator_->generate_payload(xfer_size_bytes);
+
+    std::vector<HostMemDeviceCommand> work_cmds;
+    HostMemDeviceCommand linear_write_cmd = Common::CommandBuilder::build_linear_write_command<true, true>(
+        payload, worker_range, false, noc_xy, l1_addr, xfer_size_bytes);
+    work_cmds.push_back(std::move(linear_write_cmd));
+
+    std::vector<HostMemDeviceCommand> terminate_cmds;
+    HostMemDeviceCommand dispatch_term_cmd = CommandBuilder::build_dispatch_terminate();
+    terminate_cmds.push_back(std::move(dispatch_term_cmd));
+    HostMemDeviceCommand prefetch_term_cmd = CommandBuilder::build_prefetch_terminate();
+    terminate_cmds.push_back(std::move(prefetch_term_cmd));
+
+    // Don't wait for Finish()
+    bool wait_for_completion = false;
+
+    // If exec_buf is enabled, we must split execution
+    // 1. Run workload (executes in exec_buf)
+    // 2. Run terminate (must execute in issue queue, not exec_buf.
+    // Executing terminate in exec_buf leads to a hang since exec_buf_end is never reached)
+    if (use_exec_buf_) {
+        // Step 1: Execute workload in exec_buf
+        execute_generated_commands(
+            work_cmds,
             device_data,
-            worker_core,
-            start_page,
-            base_addr,
-            dram_page_size_g,
-            dram_pages_to_read_g,
-            0);
+            worker_range.size(),
+            num_iterations,
+            false);  // Don't wait (device not done yet)
 
-        bytes_of_data_g += dram_page_size_g * dram_pages_to_read_g;
-        pages_read += dram_pages_to_read_g;
+        // Step 2: Switch to Issue Queue for termination
+        use_exec_buf_ = false;
+        execute_generated_commands(
+            terminate_cmds,
+            device_data,
+            0,
+            1,
+            wait_for_completion);  // Don't wait (device terminates)
+    } else {
+        // Standard flow: All commands in one Issue Queue stream
+        work_cmds.insert(work_cmds.end(), terminate_cmds.begin(), terminate_cmds.end());
 
-        uint32_t all_valid_device_data_size = device_data.size() * sizeof(uint32_t);
-        finished = all_valid_device_data_size >= DEVICE_DATA_SIZE;
+        execute_generated_commands(work_cmds, device_data, worker_range.size(), num_iterations, wait_for_completion);
     }
+}
+
+// Relay pre-populated data from DRAM using prefetcher to dispatcher, write it to L1 and validate it
+TEST_P(BasePrefetcherTestFixture, DRAMToL1PagedRead) {
+    log_info(tt::LogTest, "BasePrefetcherTestFixture - DRAMToL1PagedRead - Test Start");
+
+    const uint32_t num_iterations = get_num_iterations();
+    const uint32_t dram_data_size_words = get_dram_data_size_words();
+    const uint32_t page_size_bytes = get_page_size();
+    const uint32_t num_pages = get_num_pages();
+    const uint32_t page_size_words = page_size_bytes / sizeof(uint32_t);
+
+    // Setup target worker cores
+    const CoreCoord first_worker = default_worker_start;
+    const CoreCoord last_worker = first_worker;
+    const CoreRange worker_range = {first_worker, last_worker};
+
+    const uint32_t l1_base = device_->allocator()->get_base_allocator_addr(HalMemType::L1);
+
+    // Compute NOC encoding once
+    const CoreCoord first_virt_worker = device_->virtual_core_from_logical_core(first_worker, CoreType::WORKER);
+    const uint32_t noc_xy = device_->get_noc_unicast_encoding(k_dispatch_downstream_noc, first_virt_worker);
+
+    // No L1 -> Host writes, so pcie_data_addr is nullptr
+    // We test DRAM -> L1
+    DeviceData device_data(device_, worker_range, l1_base, dram_base_, nullptr, false, dram_data_size_words, cfg_);
+
+    std::vector<HostMemDeviceCommand> commands_per_iteration;
+    uint32_t absolute_start_page = 0;
+    uint32_t remaining_bytes = DEVICE_DATA_SIZE;
+
+    while (remaining_bytes > 0) {
+        // Calculate how many pages fit in this chunk
+        uint32_t max_bytes_in_chunk = num_pages * page_size_bytes;
+        uint32_t bytes_in_chunk = std::min(remaining_bytes, max_bytes_in_chunk);
+        uint32_t pages_in_chunk = bytes_in_chunk / page_size_bytes;
+
+        uint32_t start_page = absolute_start_page % num_banks_;
+        uint32_t base_addr = (absolute_start_page / num_banks_) * page_size_bytes + dram_base_;
+
+        // Capture address before updating device_data
+        uint32_t l1_addr = device_data.get_result_data_addr(first_worker, 0);
+
+        // Relay paged from prefetcher -> linear write from dispatcher to L1
+        HostMemDeviceCommand cmd = CommandBuilder::build_prefetch_relay_paged<flush_prefetch_, inline_data_>(
+            noc_xy, l1_addr, start_page, base_addr, page_size_bytes, pages_in_chunk);
+
+        // Shadow model updated per page
+        for (uint32_t page = 0; page < pages_in_chunk; ++page) {
+            const uint32_t page_id = absolute_start_page + page;
+            const uint32_t bank_id = page_id % num_banks_;
+            uint32_t bank_offset = page_size_words * (page_id / num_banks_);
+
+            // Get the logical core for this bank
+            const auto dram_channel = device_->allocator()->get_dram_channel_from_bank_id(bank_id);
+            const CoreCoord bank_core = device_->logical_core_from_dram_channel(dram_channel);
+
+            // Update DeviceData for paged read
+            DeviceDataUpdater::update_paged_dram_read(
+                worker_range, device_data, bank_core, bank_id, bank_offset, page_size_words);
+        }
+
+        commands_per_iteration.push_back(std::move(cmd));
+
+        absolute_start_page += pages_in_chunk;
+        remaining_bytes -= bytes_in_chunk;
+    }
+
+    execute_generated_commands(commands_per_iteration, device_data, worker_range.size(), num_iterations);
+}
+
+// In this test, the prefetcher reads from L1 and relays it to dispatcher. Dispatcher then
+// writes the data to the host completion queue.
+// Note: Since we're writing into completion queue, we skip distributed::Finish
+TEST_P(PrefecherHostTextFixture, HostTest) {
+    log_info(tt::LogTest, "PrefecherHostTextFixture - HostTest - Test Start");
+
+    const uint32_t max_data_size = DEVICE_DATA_SIZE;
+    const uint32_t max_data_size_words = max_data_size / sizeof(uint32_t);
+    const uint32_t dram_data_size_words = DRAM_DATA_SIZE_WORDS;  // this->get_dram_data_size_words();
+    const uint32_t num_iterations = 1;                           // this->get_num_iterations();
+
+    std::vector<uint32_t> data(max_data_size_words);
+    for (uint32_t i = 0; i < max_data_size_words; i++) {
+        data[i] = i;
+    }
+
+    // Setup target worker cores
+    const CoreCoord first_worker = default_worker_start;
+    const CoreCoord last_worker = {first_worker.x + 1, first_worker.y + 1};
+    const CoreRange worker_range = {first_worker, last_worker};
+
+    uint32_t l1_base = device_->allocator()->get_base_allocator_addr(HalMemType::L1);
+    CoreCoord phys_worker_core = device_->worker_core_from_logical_core(first_worker);
+    // Write data into L1 for prefetcher to read it later
+    MetalContext::instance().get_cluster().write_core(device_->id(), phys_worker_core, data, l1_base);
+    MetalContext::instance().get_cluster().l1_barrier(device_->id());
+
+    // Compute NOC encoding once
+    const CoreCoord first_virt_worker = device_->virtual_core_from_logical_core(first_worker, CoreType::WORKER);
+    const uint32_t noc_xy = device_->get_noc_unicast_encoding(k_dispatch_downstream_noc, first_virt_worker);
+
+    // Get completion queue buffer pointer
+    void* completion_queue_buffer = mgr_->get_completion_queue_ptr(fdcq_->id());
+    uint32_t completion_queue_size = mgr_->get_completion_queue_size(fdcq_->id());
+    // Pre-fill with dirty pattern:
+    // The dispatcher writes commands and data but doesn't overwrite padding regions
+    // Pre-filling ensures padding areas retain the sentinel value for validation
+    dirty_host_completion_buffer(completion_queue_buffer, completion_queue_size);
+
+    DeviceData device_data(
+        device_, worker_range, l1_base, dram_base_, completion_queue_buffer, false, dram_data_size_words, cfg_);
+
+    std::vector<HostMemDeviceCommand> commands_per_iteration;
+
+    for (uint32_t count = 1; count < 100; count++) {
+        uint32_t max_limit = max_data_size_words / 100;
+        uint32_t data_size_words = payload_generator_->get_rand<uint32_t>(0, max_limit - 1) * count + 1;
+        uint32_t data_size_bytes = data_size_words * sizeof(uint32_t);
+
+        // Create the HostMemDeviceCommand with pre-calculated size
+        HostMemDeviceCommand cmd =
+            CommandBuilder::build_prefetch_relay_linear_host<inline_data_>(noc_xy, l1_base, data_size_bytes);
+
+        commands_per_iteration.push_back(cmd);
+
+        DeviceDataUpdater::update_host_data(device_data, data, data_size_bytes);
+
+        // The completion queue is page-aligned (4KB pages)
+        // Each write reserves full pages but only writes actual data,
+        // leaving the remainder untouched (still 0xbaadf00d)
+        // This ensures padding areas retain the sentinel value for validation
+        pad_host_data(device_data);
+    }
+
+    // Skip distributed::Finish since we are manually writing into the completion queue
+    // which Finish doesn't expect
+    bool wait_for_completion = false;
+    // For host writes, we need to wait for all writes to be written into the completion queue
+    bool wait_for_host_writes = true;
+    execute_generated_commands(
+        commands_per_iteration,
+        device_data,
+        worker_range.size(),
+        num_iterations,
+        wait_for_completion,
+        wait_for_host_writes);
+}
+
+// This tests relay of packed paged data using prefetcher to dispacher
+// with multiple sub commands
+TEST_P(PrefetcherPackedReadTestFixture, PackedReadTest) {
+    log_info(tt::LogTest, "PrefetcherPackedReadTestFixture - PackedReadTest - Test Start");
+
+    const uint32_t num_iterations = 1;
+    const uint32_t dram_data_size_words = DRAM_DATA_SIZE_WORDS;
+    const bool relay_max_packed_paged_submcds = true;  // TODO: randomize?
+
+    // Setup target worker cores
+    const CoreCoord first_worker = default_worker_start;
+    const CoreCoord last_worker = {first_worker.x + 1, first_worker.y + 1};
+    const CoreRange worker_range = {first_worker, last_worker};
+
+    const uint32_t l1_base = device_->allocator()->get_base_allocator_addr(HalMemType::L1);
+    const auto dram_alignment = MetalContext::instance().hal().get_alignment(HalMemType::DRAM);
+
+    // Compute NOC encoding once
+    const CoreCoord first_virt_worker = device_->virtual_core_from_logical_core(first_worker, CoreType::WORKER);
+    const uint32_t noc_xy = device_->get_noc_unicast_encoding(k_dispatch_downstream_noc, first_virt_worker);
+
+    DeviceData device_data(device_, worker_range, l1_base, dram_base_, nullptr, false, dram_data_size_words, cfg_);
+
+    std::vector<HostMemDeviceCommand> commands_per_iteration;
+
+    uint32_t remaining_bytes = DEVICE_DATA_SIZE;
+
+    constexpr uint32_t max_size128b = (DEFAULT_SCRATCH_DB_SIZE / 2) >> 7;
+    while (remaining_bytes > 0) {
+        uint32_t packed_read_page_size =
+            payload_generator_->get_rand<uint32_t>(0, 2) + 9;  // log2 values. i.e., 512, 1024, 2048
+        uint32_t n_sub_cmds = relay_max_packed_paged_submcds ? CQ_PREFETCH_CMD_RELAY_PAGED_PACKED_MAX_SUB_CMDS
+                                                             : payload_generator_->get_rand<uint32_t>(0, 6) + 1;
+        uint32_t max_read_size = std::min((1 << packed_read_page_size) * num_banks_, remaining_bytes);
+
+        std::vector<uint32_t> lengths;
+        lengths.reserve(n_sub_cmds);
+        uint32_t total_length = 0;
+        for (uint32_t i = 0; i < n_sub_cmds; i++) {
+            // limit the length to min and max read size
+            uint32_t length = tt::align(
+                std::min(
+                    std::max(MIN_READ_SIZE, (payload_generator_->get_rand<uint32_t>(0, max_size128b - 1)) << 7),
+                    max_read_size),
+                dram_alignment);
+            total_length += length;
+            lengths.push_back(length);
+        }
+
+        // If we're about to exceed DEVICE_DATA_SIZE, then exit
+        if (device_data.size() * sizeof(uint32_t) + total_length > DEVICE_DATA_SIZE) {
+            break;
+        }
+
+        uint32_t l1_addr = device_data.get_result_data_addr(first_worker, 0);
+
+        // Create n_sub_cmds
+        std::vector<CQPrefetchRelayPagedPackedSubCmd> sub_cmds =
+            build_sub_cmds(lengths, device_data, packed_read_page_size, n_sub_cmds);
+
+        HostMemDeviceCommand cmd = CommandBuilder::build_prefetch_relay_paged_packed<flush_prefetch_, inline_data_>(
+            sub_cmds, noc_xy, l1_addr, total_length);
+
+        commands_per_iteration.push_back(std::move(cmd));
+        remaining_bytes -= total_length;
+    }
+
+    execute_generated_commands(commands_per_iteration, device_data, worker_range.size(), num_iterations);
+}
+
+// Ring Buffer operates differently than others
+// Data is first staged (cached) into Ringbuffer (L1) from DRAM
+// Then, we relay command header + data into dispatcher
+// Note: Ring buffer is stateful as we set the ringbuffer offset on first load
+TEST_P(PrefetcherRingbufferReadTestFixture, RingbufferReadTest) {
+    log_info(tt::LogTest, "PrefetcherRingbufferReadTestFixture - RingbufferReadTest - Test Start");
+
+    const uint32_t num_iterations = get_num_iterations();
+    const uint32_t dram_data_size_words = get_dram_data_size_words();
+
+    // Setup target worker cores
+    const CoreCoord first_worker = default_worker_start;
+    const CoreCoord last_worker = {first_worker.x + 1, first_worker.y + 1};
+    const CoreRange worker_range = {first_worker, last_worker};
+
+    const uint32_t l1_base = device_->allocator()->get_base_allocator_addr(HalMemType::L1);
+    const auto dram_alignment = MetalContext::instance().hal().get_alignment(HalMemType::DRAM);
+
+    // Compute NOC encoding once
+    const CoreCoord first_virt_worker = device_->virtual_core_from_logical_core(first_worker, CoreType::WORKER);
+    const uint32_t noc_xy = device_->get_noc_unicast_encoding(k_dispatch_downstream_noc, first_virt_worker);
+
+    DeviceData device_data(device_, worker_range, l1_base, dram_base_, nullptr, false, dram_data_size_words, cfg_);
+
+    std::vector<HostMemDeviceCommand> commands_per_iteration;
+
+    uint32_t remaining_bytes = DEVICE_DATA_SIZE;
+
+    while (remaining_bytes > 0) {
+        uint32_t ringbuffer_read_page_size_log2 =
+            payload_generator_->get_rand<uint32_t>(0, 2) + 9;  // log2 values. i.e., 512, 1024, 2048
+        uint32_t n_sub_cmds = payload_generator_->get_rand<uint32_t>(0, 6) + 1;
+        uint32_t max_read_size = std::min((1 << ringbuffer_read_page_size_log2) * num_banks_, remaining_bytes);
+
+        std::vector<uint32_t> lengths;
+        lengths.reserve(n_sub_cmds);
+
+        uint32_t total_length = 0;
+        for (uint32_t i = 0; i < n_sub_cmds; i++) {
+            // limit the length to min and max read size
+            uint32_t length = tt::align(
+                std::min(
+                    max_read_size,
+                    std::max(MIN_READ_SIZE, payload_generator_->get_rand<uint32_t>(0, DEFAULT_SCRATCH_DB_SIZE - 1))),
+                dram_alignment);
+            total_length += length;
+            lengths.push_back(length);
+        }
+
+        // If we're about to exceed DEVICE_DATA_SIZE, then exit
+        if (device_data.size() * sizeof(uint32_t) + total_length > DEVICE_DATA_SIZE) {
+            break;
+        }
+
+        uint32_t l1_addr = device_data.get_result_data_addr(first_worker, 0);
+
+        // We build the sub commands to relay them from the ringbuffer to the dispatcher
+        std::vector<CQPrefetchRelayRingbufferSubCmd> sub_cmds = build_sub_cmds(lengths, n_sub_cmds);
+
+        HostMemDeviceCommand cmd = CommandBuilder::build_prefetch_ringbuffer_relay<flush_prefetch_, inline_data_>(
+            sub_cmds, lengths, device_data, *this, noc_xy, l1_addr, total_length, ringbuffer_read_page_size_log2);
+
+        commands_per_iteration.push_back(std::move(cmd));
+        remaining_bytes -= total_length;
+    }
+
+    execute_generated_commands(commands_per_iteration, device_data, worker_range.size(), num_iterations);
 }
 
 // End-To-End Paged/Interleaved Write+Read test that does the following:
-//  1. Paged Write of host data to DRAM banks by dispatcher cmd, followed by stall to avoid RAW hazard
+//  1. Paged Write of host data to DRAM banks by dispatcher, followed by stall to avoid RAW hazard
 //  2. Paged Read of DRAM banks by prefetcher, relay data to dispatcher for linear write to L1.
 //  3. Do previous 2 steps in a loop, reading and writing new data until DEVICE_DATA_SIZE bytes is written to worker
 //  core.
-void gen_paged_write_read_dram_test(
-    IDevice* device,
-    vector<uint32_t>& prefetch_cmds,
-    vector<uint32_t>& cmd_sizes,
-    DeviceData& device_data,
-    CoreCoord worker_core,
-    uint32_t dst_addr) {
-    // Keep a running total, to correctly calculate start page, base addr, write addr based on num banks.
-    uint32_t pages_written = 0;
-    bool finished = false;
+TEST_P(BasePrefetcherTestFixture, PagedReadWriteTest) {
+    log_info(tt::LogTest, "BasePrefetcherTestFixture - PagedReadWriteTest - Test Start");
 
-    log_info(
-        tt::LogTest,
-        "Running Paged Write+Read DRAM test with num_pages: {} page_size: {} to worker_core: {}",
-        dram_pages_to_read_g,
-        dram_page_size_g,
-        worker_core.str());
-    while (!finished) {
-        // TODO: writes/reads are inconsistent on using page or page % num_dram_banks
-        uint32_t start_page = pages_written % num_dram_banks_g;
-        uint32_t base_addr = (pages_written / num_dram_banks_g) * dram_page_size_g;  // For paged read/write
+    // Test parameters
+    const uint32_t num_iterations = get_num_iterations();
+    const uint32_t dram_data_size_words = get_dram_data_size_words();
+    const uint32_t page_size_bytes = get_page_size();
+    const uint32_t num_pages = get_num_pages();
+    const uint32_t page_size_words = page_size_bytes / sizeof(uint32_t);
 
-        gen_dram_write_cmd(
-            device, prefetch_cmds, cmd_sizes, device_data, pages_written, dram_page_size_g, dram_pages_to_read_g);
-        gen_wait_and_stall_cmd(device, prefetch_cmds, cmd_sizes);
-        gen_dram_read_cmd(
-            device,
-            prefetch_cmds,
-            cmd_sizes,
-            device_data,
-            worker_core,
-            start_page,
-            base_addr,
-            dram_page_size_g,
-            dram_pages_to_read_g,
-            0);
-        bytes_of_data_g += dram_page_size_g * dram_pages_to_read_g;
-        pages_written += dram_pages_to_read_g;
+    // Setup target worker cores
+    const CoreCoord first_worker = default_worker_start;
+    const CoreCoord last_worker = first_worker;  // {first_worker.x + 1, first_worker.y + 1};
+    const CoreRange worker_range = {first_worker, last_worker};
 
-        uint32_t all_valid_device_data_size = device_data.size() * sizeof(uint32_t);
-        finished = all_valid_device_data_size >= DEVICE_DATA_SIZE;
+    const uint32_t l1_base = device_->allocator()->get_base_allocator_addr(HalMemType::L1);
 
-        log_debug(
-            tt::LogTest,
-            "{} - Finished gen cmds w/ device_data_size: 0x{:x} finished: {} pages_written: {} num_banks: {} "
-            "(start_page: {} base_addr: 0x{:x}",
-            __FUNCTION__,
-            all_valid_device_data_size,
-            finished,
-            pages_written,
-            num_dram_banks_g,
-            start_page,
-            base_addr);
-    }
-}
+    // Compute NOC encoding once
+    const CoreCoord first_virt_worker = device_->virtual_core_from_logical_core(first_worker, CoreType::WORKER);
+    const uint32_t noc_xy = device_->get_noc_unicast_encoding(k_dispatch_downstream_noc, first_virt_worker);
 
-void gen_pcie_test(
-    IDevice* device,
-    vector<uint32_t>& prefetch_cmds,
-    vector<uint32_t>& cmd_sizes,
-    DeviceData& device_data,
-    CoreCoord worker_core) {
-    vector<uint32_t> dispatch_cmds;
+    DeviceData device_data(device_, worker_range, l1_base, dram_base_, nullptr, false, dram_data_size_words, cfg_);
 
-    while (device_data.size() * sizeof(uint32_t) < DEVICE_DATA_SIZE) {
-        dispatch_cmds.resize(0);
-        gen_dispatcher_unicast_write_cmd(device, dispatch_cmds, worker_core, device_data, pcie_transfer_size_g);
-        add_prefetcher_cmd(prefetch_cmds, cmd_sizes, CQ_PREFETCH_CMD_RELAY_INLINE, dispatch_cmds);
-        bytes_of_data_g += pcie_transfer_size_g;
-    }
-}
+    const uint32_t page_size_alignment_bytes = device_->allocator()->get_alignment(BufferType::DRAM);
 
-static void pad_host_data(DeviceData& device_data) {
-    one_core_data_t& host_data = device_data.get_data()[device_data.get_host_core()][0];
+    std::vector<HostMemDeviceCommand> commands_per_iteration;
 
-    int pad = dispatch_buffer_page_size_g - ((host_data.data.size() * sizeof(uint32_t)) % dispatch_buffer_page_size_g);
-    pad = pad % dispatch_buffer_page_size_g;
-    for (int i = 0; i < pad / sizeof(uint32_t); i++) {
-        device_data.push_one(device_data.get_host_core(), 0, host_data_dirty_pattern);
-    }
+    uint32_t remaining_bytes = DEVICE_DATA_SIZE;
+    uint32_t absolute_start_page = 0;
 
-    if (host_data.data.size() * sizeof(uint32_t) > hugepage_issue_buffer_size_g) {
-        TT_THROW("Host test hugepage data wrap not (yet) supported, reduce test size");
-    }
-}
+    // This loop generates commands, payloads, and updates expectations all at once
+    // Each iteration represents one "chunk" that fits in max_payload_per_cmd_bytes
+    while (remaining_bytes > 0) {
+        // Calculate how many pages fit in this chunk
+        uint32_t max_bytes_in_chunk = num_pages * page_size_bytes;
+        uint32_t bytes_in_chunk = std::min(remaining_bytes, max_bytes_in_chunk);
+        uint32_t pages_in_chunk = bytes_in_chunk / page_size_bytes;
 
-void gen_host_test(
-    IDevice* device, vector<uint32_t>& prefetch_cmds, vector<uint32_t>& cmd_sizes, DeviceData& device_data) {
-    constexpr uint32_t max_data_size = DEVICE_DATA_SIZE;
+        // Generate payload & update expectations for this chunk
+        std::vector<uint32_t> chunk_payload;
+        chunk_payload.reserve(pages_in_chunk * page_size_words);
 
-    // Read data from a worker so we can get reasonable BW measurements
-    // TODO: extend the DRAM mechanism for pre-fill to workers
-    vector<uint32_t> data;
-    data.reserve(max_data_size / sizeof(uint32_t));
-    for (uint32_t i = 0; i < max_data_size / sizeof(uint32_t); i++) {
-        data.push_back(i);
-    }
-    CoreCoord phys_worker_core = device->worker_core_from_logical_core(first_worker_g);
-    tt::tt_metal::MetalContext::instance().get_cluster().write_core(
-        device->id(), phys_worker_core, data, l1_buf_base_g);
-    tt::tt_metal::MetalContext::instance().get_cluster().l1_barrier(device->id());
+        for (uint32_t page = 0; page < pages_in_chunk; ++page) {
+            const uint32_t page_id = absolute_start_page + page;
+            const uint32_t bank_id = page_id % num_banks_;
 
-    for (int count = 1; count < 100; count++) {
-        uint32_t data_size_words = (std::rand() % ((max_data_size / 100 / sizeof(uint32_t)) * count)) + 1;
-        uint32_t data_size_bytes = data_size_words * sizeof(uint32_t);
+            // Get the logical core for this bank
+            const auto dram_channel = device_->allocator()->get_dram_channel_from_bank_id(bank_id);
+            const CoreCoord bank_core = device_->logical_core_from_dram_channel(dram_channel);
 
-        std::vector<uint32_t> dispatch_cmds;
-        gen_bare_dispatcher_host_write_cmd(dispatch_cmds, data_size_bytes);
-        add_prefetcher_cmd(prefetch_cmds, cmd_sizes, CQ_PREFETCH_CMD_RELAY_INLINE_NOFLUSH, dispatch_cmds);
-        auto prior_end = prefetch_cmds.size();
-        add_prefetcher_linear_read_cmd(
-            device, prefetch_cmds, cmd_sizes, first_worker_g, l1_buf_base_g, data_size_bytes);
-        uint32_t new_size = (prefetch_cmds.size() - prior_end) * sizeof(uint32_t);
-        cmd_sizes.push_back(new_size >> DispatchSettings::PREFETCH_Q_LOG_MINSIZE);
+            // Generate payload with page id
+            std::vector<uint32_t> page_payload =
+                payload_generator_->generate_payload_with_page_id(page_size_words, page_id);
 
-        // write host writes the command back to the host
-        for (auto datum : dispatch_cmds) {
-            device_data.push_one(device_data.get_host_core(), 0, datum);
-        }
-        for (int i = 0; i < data_size_words; i++) {
-            uint32_t datum = data[i];
-            device_data.push_one(device_data.get_host_core(), 0, datum);
-        }
-        pad_host_data(device_data);
-    }
-}
+            // Update DeviceData for paged write
+            Common::DeviceDataUpdater::update_paged_write(
+                page_payload, device_data, bank_core, bank_id, page_size_alignment_bytes);
 
-void gen_rnd_linear_cmd(
-    IDevice* device,
-    vector<uint32_t>& prefetch_cmds,
-    vector<uint32_t>& cmd_sizes,
-    DeviceData& device_data,
-    CoreCoord worker_core) {
-    vector<uint32_t> dispatch_cmds;
-
-    // Hmm, how big a size to test?
-    int max_linear_cmd_read_size = 20 * dispatch_buffer_page_size_g;  // XXXXX 10 *
-    uint32_t size = std::rand() % max_linear_cmd_read_size;
-    size &= ~(sizeof(uint32_t) - 1);
-    uint32_t offset = std::rand() % dispatch_buffer_page_size_g;
-    offset = (offset >> 2) << 2;
-    device_data.relevel(DISPATCH_CORE_TYPE);  // XXXXX shouldn't be needed
-    if (device_data.size_at(worker_core, 0) * sizeof(uint32_t) < max_linear_cmd_read_size + offset) {
-        // Not enough data yet, just bail on this cmd
-        return;
-    }
-    gen_linear_read_cmd(device, prefetch_cmds, cmd_sizes, device_data, worker_core, size, offset);
-}
-
-void gen_rnd_dram_paged_cmd(
-    IDevice* device,
-    vector<uint32_t>& prefetch_cmds,
-    vector<uint32_t>& cmd_sizes,
-    DeviceData& device_data,
-    CoreCoord worker_core) {
-    vector<uint32_t> dispatch_cmds;
-
-    const uint32_t dram_alignment = MetalContext::instance().hal().get_alignment(HalMemType::DRAM);
-    uint32_t start_page = std::rand() % num_dram_banks_g;
-    uint32_t max_page_size = big_g ? MAX_PAGE_SIZE : 4096;
-    uint32_t page_size = (std::rand() % (max_page_size + 1)) & ~(dram_alignment - 1);
-    page_size = std::max(page_size, dram_alignment);
-    uint32_t max_data = big_g ? DEVICE_DATA_SIZE : DEVICE_DATA_SIZE / 8;
-    uint32_t max = DEVICE_DATA_SIZE - (device_data.size() * sizeof(uint32_t));
-    max = (max > max_data) ? max_data : max;
-    // start in bottom half of valid dram data to not worry about overflowing valid data
-    uint32_t base_addr = (std::rand() % (DRAM_DATA_SIZE_BYTES / 2)) & ~(dram_alignment - 1);
-    uint32_t size = std::rand() % max;
-    size = std::max(size, page_size);
-    uint32_t pages = size / page_size;
-    TT_ASSERT(base_addr + (start_page * page_size + pages * page_size / num_dram_banks_g) < DRAM_DATA_SIZE_BYTES);
-
-    uint32_t length_adjust = std::rand() % page_size;
-    length_adjust = (length_adjust >> 5) << 5;
-    if (length_adjust > CQ_PREFETCH_RELAY_PAGED_LENGTH_ADJUST_MASK) {
-        length_adjust = CQ_PREFETCH_RELAY_PAGED_LENGTH_ADJUST_MASK;
-        length_adjust = (length_adjust >> 5) << 5;
-    }
-
-    if (device_data.size() * sizeof(uint32_t) + page_size * pages - length_adjust + l1_buf_base_g >=
-        device->l1_size_per_core()) {
-        // try try again
-        return;
-    }
-
-    gen_dram_read_cmd(
-        device,
-        prefetch_cmds,
-        cmd_sizes,
-        device_data,
-        worker_core,
-        start_page,
-        base_addr,
-        page_size,
-        pages,
-        length_adjust);
-}
-
-void gen_rnd_inline_cmd(
-    IDevice* device,
-    vector<uint32_t>& prefetch_cmds,
-    vector<uint32_t>& cmd_sizes,
-    DeviceData& device_data,
-    CoreCoord worker_core) {
-    vector<uint32_t> dispatch_cmds;
-
-    // Randomize the dispatcher command we choose to relay
-    // XXXX revisit the randomness of this, these commands get under-weighted
-
-    uint32_t which_cmd = std::rand() % 2;
-    switch (which_cmd) {
-        case 0:
-            // unicast write
-            {
-                uint32_t cmd_size_bytes = CQ_PREFETCH_CMD_BARE_MIN_SIZE;
-                if (debug_g) {
-                    cmd_size_bytes += sizeof(CQDispatchCmd);
-                }
-                uint32_t max_size = big_g ? max_prefetch_command_size_g : max_prefetch_command_size_g / 16;
-                uint32_t max_xfer_size_16b = (max_size - cmd_size_bytes) >> 4;
-                uint32_t xfer_size_16B = (std::rand() & (max_xfer_size_16b - 1));
-                // Note: this may overflow the DEVICE_DATA_SIZE, but by little enough that it won't overflow L1
-                uint32_t xfer_size_bytes = xfer_size_16B << 4;
-
-                gen_dispatcher_unicast_write_cmd(device, dispatch_cmds, worker_core, device_data, xfer_size_bytes);
-            }
-            break;
-        case 1:
-            // packed unicast write
-            gen_rnd_dispatcher_packed_write_cmd(device, dispatch_cmds, device_data);
-            break;
-        default: TT_THROW("Invalid which_cmd {} in gen_rnd_inline_cmd", which_cmd);
-    }
-
-    add_prefetcher_cmd(prefetch_cmds, cmd_sizes, CQ_PREFETCH_CMD_RELAY_INLINE, dispatch_cmds);
-}
-
-void gen_rnd_debug_cmd(vector<uint32_t>& prefetch_cmds, vector<uint32_t>& cmd_sizes, DeviceData& device_data) {
-    vector<uint32_t> rnd_payload;
-    generate_random_payload(rnd_payload, (std::rand() % (dispatch_buffer_page_size_g - sizeof(CQDispatchCmd))) + 1);
-    add_prefetcher_cmd(prefetch_cmds, cmd_sizes, CQ_PREFETCH_CMD_DEBUG, rnd_payload);
-}
-
-void gen_packed_read_test(
-    IDevice* device, vector<uint32_t>& prefetch_cmds, vector<uint32_t>& cmd_sizes, DeviceData& device_data) {
-    static constexpr uint32_t min_read_size = 128;
-    bool done = false;
-    while (!done) {
-        uint32_t packed_read_page_size = (std::rand() % 3) + 9;  // log2 values. i.e., 512, 1024, 2048
-        uint32_t n_sub_cmds =
-            relay_max_packed_paged_submcds ? CQ_PREFETCH_CMD_RELAY_PAGED_PACKED_MAX_SUB_CMDS : (std::rand() % 7) + 1;
-        uint32_t max_read_size = (1 << packed_read_page_size) * num_dram_banks_g;
-        auto dram_alignment = MetalContext::instance().hal().get_alignment(HalMemType::DRAM);
-        vector<uint32_t> lengths;
-        uint32_t total_length = 0;
-        for (uint32_t i = 0; i < n_sub_cmds; i++) {
-            uint32_t max_size128b = (scratch_db_size_g / 2) >> 7;
-            // limit the length to min and max read size
-            uint32_t length = tt::align(
-                std::min(std::max(min_read_size, (std::rand() % max_size128b) << 7), max_read_size), dram_alignment);
-            total_length += length;
-            lengths.push_back(length);
+            // Append page payload to chunk payload
+            chunk_payload.insert(chunk_payload.end(), page_payload.begin(), page_payload.end());
         }
 
-        if (device_data.size() * sizeof(uint32_t) + total_length > DEVICE_DATA_SIZE) {
-            // got close-ish to the end anyway...
-            done = true;
-        } else {
-            gen_dram_packed_read_cmd(
-                device, prefetch_cmds, cmd_sizes, device_data, first_worker_g, packed_read_page_size, lengths);
-        }
-    }
-}
+        // Calculate base address for the command
+        const uint32_t bank_offset =
+            tt::align(page_size_bytes, page_size_alignment_bytes) * (absolute_start_page / num_banks_);
+        const uint32_t base_addr = device_data.get_base_result_addr(tt::CoreType::DRAM) + bank_offset;
+        // Calculate start page for the command
+        const uint16_t start_page_cmd = absolute_start_page % num_banks_;
 
-template <typename T>
-void update_cmd_sizes(std::vector<uint32_t>& prefetch_cmds, vector<uint32_t>& cmd_sizes, T updater) {
-    auto prior_end = prefetch_cmds.size();
-    updater();
-    uint32_t new_size = (prefetch_cmds.size() - prior_end) * sizeof(uint32_t);
-    cmd_sizes.push_back(new_size >> DispatchSettings::PREFETCH_Q_LOG_MINSIZE);
-}
+        //  Step 1: Paged Write of host data to DRAM banks by dispatcher cmd
+        HostMemDeviceCommand cmd_dispatch_dram = Common::CommandBuilder::build_paged_write_command<hugepage_write_>(
+            chunk_payload, base_addr, page_size_bytes, pages_in_chunk, start_page_cmd, true);
+        commands_per_iteration.push_back(std::move(cmd_dispatch_dram));
 
-template <typename T>
-void copy_struct_to_vector(std::vector<uint32_t>& prefetch_cmds, T& cmd) {
-    static_assert(
-        sizeof(T) % sizeof(uint32_t) == 0, "CQPrefetchCmd must be a multiple of 4 bytes to be copied to vector");
-    size_t current_size = prefetch_cmds.size();
-    prefetch_cmds.resize(current_size + (sizeof(T) / sizeof(uint32_t)));
-    memcpy(&prefetch_cmds[current_size], &cmd, sizeof(T));
-}
+        // Followed by stall to avoid RAW hazard
+        HostMemDeviceCommand cmd_stall = CommandBuilder::build_dispatch_prefetch_stall();
+        commands_per_iteration.push_back(std::move(cmd_stall));
 
-void pad_vector(std::vector<uint32_t>& prefetch_cmds, uint32_t pad_bytes) {
-    TT_ASSERT(pad_bytes % sizeof(uint32_t) == 0, "Padding must be a multiple of 4 bytes to be copied to vector");
-    for (int i = 0; i < pad_bytes / sizeof(uint32_t); i++) {
-        prefetch_cmds.push_back(0);
-    }
-}
+        uint32_t l1_addr = device_data.get_result_data_addr(first_worker, 0);
 
-// ringbuffer read from dram to linear write to worker
-void gen_dram_ringbuffer_read_cmd(
-    IDevice* device,
-    vector<uint32_t>& prefetch_cmds,
-    vector<uint32_t>& cmd_sizes,
-    DeviceData& device_data,
-    CoreCoord worker_core,
-    uint32_t log_page_size,
-    vector<uint32_t>& lengths) {
-    vector<uint32_t> dispatch_cmds;
+        // Step 2: Paged Read of DRAM banks by prefetcher, relay data to dispatcher for linear write to L1
+        HostMemDeviceCommand cmd_prefetch = CommandBuilder::build_prefetch_relay_paged<flush_prefetch_, inline_data_>(
+            noc_xy, l1_addr, start_page_cmd, base_addr, page_size_bytes, pages_in_chunk);
+        commands_per_iteration.push_back(std::move(cmd_prefetch));
 
-    uint32_t total_length = 0;
-    for (auto length : lengths) {
-        total_length += length;
-    }
-    gen_bare_dispatcher_unicast_write_cmd(device, dispatch_cmds, worker_core, device_data, total_length);
-    bool reset = false;
-    uint32_t page_size = 1 << log_page_size;
-    int count = 0;
+        for (uint32_t page = 0; page < pages_in_chunk; ++page) {
+            const uint32_t page_id = absolute_start_page + page;
+            const uint32_t bank_id = page_id % num_banks_;
+            // Add dram_data_size_words since we're reading after the pre-populated DRAM data
+            uint32_t bank_offset = dram_data_size_words + page_size_words * (page_id / num_banks_);
 
-    std::vector<CQPrefetchRelayRingbufferSubCmd> sub_cmds;
-    uint32_t dram_data_base_addr = device->allocator()->get_base_allocator_addr(HalMemType::DRAM);
-    for (auto length : lengths) {
-        constexpr uint32_t max_page_offset = 5;
-        CQPrefetchCmd cmd{};
-        cmd.base.cmd_id = CQ_PREFETCH_CMD_PAGED_TO_RINGBUFFER;
-        auto& ringbuffer_cmd = cmd.paged_to_ringbuffer;
-        if (!reset) {
-            ringbuffer_cmd.flags = CQ_PREFETCH_PAGED_TO_RING_BUFFER_FLAG_RESET_TO_START;
-            reset = true;
-        }
-        ringbuffer_cmd.start_page = rand() % max_page_offset;
-        ringbuffer_cmd.log2_page_size = log_page_size;
-        ringbuffer_cmd.base_addr = dram_data_base_addr + count * page_size;
-        ringbuffer_cmd.length = length;
-        ringbuffer_cmd.wp_offset_update = length;
-        count++;
+            // Get the logical core for this bank
+            const auto dram_channel = device_->allocator()->get_dram_channel_from_bank_id(bank_id);
+            const CoreCoord bank_core = device_->logical_core_from_dram_channel(dram_channel);
 
-        update_cmd_sizes(prefetch_cmds, cmd_sizes, [&]() { add_bare_prefetcher_cmd(prefetch_cmds, cmd, true); });
-
-        // Model the paged to ringbuffer read in this function by updating worker data with interleaved/paged DRAM data,
-        // for validation later.
-        uint32_t length_words = length / sizeof(uint32_t);
-        uint32_t base_addr_words = (ringbuffer_cmd.base_addr - dram_data_base_addr) / sizeof(uint32_t);
-        uint32_t page_size_words = page_size / sizeof(uint32_t);
-
-        // Get data from DRAM map, add to worker.
-        uint32_t page_idx = ringbuffer_cmd.start_page;
-        for (uint32_t i = 0; i < length_words; i += page_size_words) {
-            uint32_t dram_bank_id = page_idx % num_dram_banks_g;
-            auto dram_channel = device->allocator_impl()->get_dram_channel_from_bank_id(dram_bank_id);
-            CoreCoord bank_core = device->logical_core_from_dram_channel(dram_channel);
-            uint32_t bank_offset = base_addr_words + (page_size_words * (page_idx / num_dram_banks_g));
-
-            uint32_t words = (page_size_words > length_words - i) ? length_words - i : page_size_words;
-            for (uint32_t j = 0; j < words; j++) {
-                uint32_t datum = device_data.at(bank_core, dram_bank_id, bank_offset + j);
-                device_data.push_one(worker_core, datum);
-            }
-
-            page_idx++;
-        }
-    }
-
-    constexpr uint32_t kWriteOffset = 1234;  // arbitrary
-
-    update_cmd_sizes(prefetch_cmds, cmd_sizes, [&]() {
-        CQPrefetchCmd cmd{};
-        cmd.base.cmd_id = CQ_PREFETCH_CMD_SET_RINGBUFFER_OFFSET;
-        cmd.set_ringbuffer_offset.offset = kWriteOffset;
-        add_bare_prefetcher_cmd(prefetch_cmds, cmd, true);
-    });
-
-    size_t current_offset = 0;
-    for (auto length : lengths) {
-        CQPrefetchRelayRingbufferSubCmd sub_cmd{};
-        sub_cmd.start = current_offset - kWriteOffset;
-        sub_cmd.length = length;
-        current_offset += length;
-        sub_cmds.push_back(sub_cmd);
-    }
-
-    add_prefetcher_cmd(prefetch_cmds, cmd_sizes, CQ_PREFETCH_CMD_RELAY_INLINE_NOFLUSH, dispatch_cmds);
-    update_cmd_sizes(prefetch_cmds, cmd_sizes, [&]() {
-        CQPrefetchCmd cmd{};
-        cmd.base.cmd_id = CQ_PREFETCH_CMD_RELAY_RINGBUFFER;
-
-        uint32_t stride = (sub_cmds.size() * sizeof(CQPrefetchRelayRingbufferSubCmd)) + sizeof(CQPrefetchCmd);
-        uint32_t aligned_stride = round_cmd_size_up(stride);
-        cmd.relay_ringbuffer.stride = aligned_stride;
-        cmd.relay_ringbuffer.count = sub_cmds.size();
-
-        copy_struct_to_vector(prefetch_cmds, cmd);
-
-        for (const auto& sub_cmd : sub_cmds) {
-            copy_struct_to_vector(prefetch_cmds, sub_cmd);
-        }
-        pad_vector(prefetch_cmds, aligned_stride - stride);
-    });
-}
-
-void gen_ringbuffer_read_test(
-    IDevice* device, vector<uint32_t>& prefetch_cmds, vector<uint32_t>& cmd_sizes, DeviceData& device_data) {
-    static constexpr uint32_t min_read_size = 128;
-    bool done = false;
-    while (!done) {
-        uint32_t ringbuffer_read_page_size_log2 = (std::rand() % 3) + 9;  // log2 values. i.e., 512, 1024, 2048
-        uint32_t max_read_size = (1 << ringbuffer_read_page_size_log2) * num_dram_banks_g;
-        auto dram_alignment = MetalContext::instance().hal().get_alignment(HalMemType::DRAM);
-        // arbitrary.
-        uint32_t n_sub_cmds = (std::rand() % 7) + 1;
-        vector<uint32_t> lengths;
-        uint32_t total_length = 0;
-        for (uint32_t i = 0; i < n_sub_cmds; i++) {
-            // limit the length to min and max read size
-            uint32_t length = tt::align(
-                std::min(max_read_size, std::max(min_read_size, std::rand() % scratch_db_size_g)), dram_alignment);
-            length = std::min(scratch_db_size_g - total_length, length);
-            if (length == 0) {
-                break;
-            }
-            total_length += length;
-            lengths.push_back(length);
+            // Update DeviceData for paged read
+            DeviceDataUpdater::update_paged_dram_read(
+                worker_range, device_data, bank_core, bank_id, bank_offset, page_size_words);
         }
 
-        if (device_data.size() * sizeof(uint32_t) + total_length > DEVICE_DATA_SIZE) {
-            // got close-ish to the end anyway...
-            done = true;
-        } else {
-            gen_dram_ringbuffer_read_cmd(
-                device, prefetch_cmds, cmd_sizes, device_data, first_worker_g, ringbuffer_read_page_size_log2, lengths);
-        }
-        done = true;
+        // Update loop state
+        remaining_bytes -= bytes_in_chunk;
+        absolute_start_page += pages_in_chunk;
     }
+
+    execute_generated_commands(commands_per_iteration, device_data, worker_range.size(), num_iterations);
 }
 
-void gen_rnd_test(
-    IDevice* device, vector<uint32_t>& prefetch_cmds, vector<uint32_t>& cmd_sizes, DeviceData& device_data) {
-    while (device_data.size() * sizeof(uint32_t) < DEVICE_DATA_SIZE) {
+// This tests random configurations of commands like CQ_PREFETCH_CMD_RELAY_LINEAR, CQ_PREFETCH_CMD_RELAY_PAGED,
+// CQ_PREFETCH_CMD_RELAY_INLINE etc
+TEST_P(RandomTestFixture, RandomTest) {
+    log_info(tt::LogTest, "RandomTestFixture - RandomTest - Test Start");
+
+    const uint32_t num_iterations = get_num_iterations();
+    const uint32_t dram_data_size_words = get_dram_data_size_words();
+
+    // Setup target worker cores
+    const CoreCoord first_worker = default_worker_start;
+    const CoreCoord last_worker = {first_worker.x + 1, first_worker.y + 1};
+    const CoreRange worker_range = {first_worker, last_worker};
+
+    const uint32_t l1_base = device_->allocator()->get_base_allocator_addr(HalMemType::L1);
+
+    DeviceData device_data(device_, worker_range, l1_base, dram_base_, nullptr, false, dram_data_size_words, cfg_);
+
+    std::vector<HostMemDeviceCommand> commands_per_iteration;
+
+    uint32_t remaining_bytes = DEVICE_DATA_SIZE;
+
+    while (remaining_bytes > 0) {
         // Assumes terminate is the last command...
-        uint32_t cmd = std::rand() % CQ_PREFETCH_CMD_TERMINATE;
-        uint32_t x = rand() % (all_workers_g.end_coord.x - first_worker_g.x);
-        uint32_t y = rand() % (all_workers_g.end_coord.y - first_worker_g.y);
+        uint32_t cmd = payload_generator_->get_rand<uint32_t>(0, CQ_PREFETCH_CMD_TERMINATE - 1);
+        const uint32_t limit_x = (worker_range.end_coord.x - first_worker.x - 1);
+        const uint32_t limit_y = (worker_range.end_coord.y - first_worker.y - 1);
+        uint32_t x = payload_generator_->get_rand<uint32_t>(0, limit_x);
+        uint32_t y = payload_generator_->get_rand<uint32_t>(0, limit_y);
 
-        CoreCoord worker_core(first_worker_g.x + x, first_worker_g.y + y);
+        CoreCoord worker_core(first_worker.x + x, first_worker.y + y);
+        // Compute NOC encoding once
+        const CoreCoord worker_core_virt = device_->virtual_core_from_logical_core(worker_core, CoreType::WORKER);
+        const uint32_t noc_xy = device_->get_noc_unicast_encoding(k_dispatch_downstream_noc, worker_core_virt);
 
         switch (cmd) {
-            case CQ_PREFETCH_CMD_RELAY_LINEAR:
-                // TODO: disabled for now
-                // test issue w/ handling re-leveling of results data after paged commands
-                // gen_rnd_linear_cmd(device, prefetch_cmds, cmd_sizes, device_data, worker_core);
+            case CQ_PREFETCH_CMD_RELAY_LINEAR: {
+                CoreRange single_worker_range = {worker_core, worker_core};
+                // // TODO: disabled for now
+                // // test issue w/ handling re-leveling of results data after paged commands
+                // auto result = gen_random_linear_cmd(device_data, worker_core, noc_xy, l1_addr, remaining_bytes);
+                // if(result.has_value()){
+                //     HostMemDeviceCommand cmd = *result;
+                //     commands_per_iteration.push_back(cmd);
+                // }
                 break;
-            case CQ_PREFETCH_CMD_RELAY_PAGED:
-                gen_rnd_dram_paged_cmd(device, prefetch_cmds, cmd_sizes, device_data, worker_core);
+            }
+            case CQ_PREFETCH_CMD_RELAY_PAGED: {
+                CoreRange single_worker_range = {worker_core, worker_core};
+                auto result =
+                    gen_random_dram_paged_cmd(device_data, worker_core, single_worker_range, noc_xy, remaining_bytes);
+                if (result.has_value()) {
+                    HostMemDeviceCommand cmd = *result;
+                    commands_per_iteration.push_back(cmd);
+                }
                 break;
-            case CQ_PREFETCH_CMD_RELAY_INLINE:
-                gen_rnd_inline_cmd(device, prefetch_cmds, cmd_sizes, device_data, worker_core);
+            }
+            case CQ_PREFETCH_CMD_RELAY_INLINE: {
+                const CoreCoord last_worker = {worker_core.x + 1, worker_core.y + 1};
+                CoreRange multi_worker_range = {worker_core, last_worker};
+                auto result = gen_random_inline_cmd(device_data, multi_worker_range, noc_xy, remaining_bytes);
+                if (result.has_value()) {
+                    HostMemDeviceCommand cmd = *result;
+                    commands_per_iteration.push_back(cmd);
+                }
                 break;
+            }
             case CQ_PREFETCH_CMD_RELAY_INLINE_NOFLUSH: break;
             case CQ_PREFETCH_CMD_STALL: break;
-            case CQ_PREFETCH_CMD_DEBUG:
-                if (!use_dram_exec_buf_g) {
-                    // Splitting debug cmds not implemented for exec_bufs (yet)
-                    gen_rnd_debug_cmd(prefetch_cmds, cmd_sizes, device_data);
-                }
-                break;
-            default: gen_rnd_test(device, prefetch_cmds, cmd_sizes, device_data); break;
-        }
-    }
-}
-
-void gen_prefetcher_exec_buf_cmd_and_write_to_dram(
-    IDevice* device, vector<uint32_t>& prefetch_cmds, vector<uint32_t> exec_buf_cmds, vector<uint32_t>& cmd_sizes) {
-    vector<uint32_t> empty_payload;  // don't give me grief, it is just a test
-
-    // Add the semaphore release for prefetch_h
-    CQDispatchCmd dcmd{};
-    memset(&dcmd, 0, sizeof(CQDispatchCmd));
-
-    // cmddat_q in prefetch_d is re-used for exec_buf
-    // prefetch_h stalls at start of exec_buf by removing its downstream credits
-    // This command releases prefetch_h from the stall by restoring credits
-    dcmd.base.cmd_id = CQ_DISPATCH_CMD_EXEC_BUF_END;
-
-    vector<uint32_t> dispatch_cmds;
-    vector<uint32_t> empty_sizes;  // unused for the exec_buf but call below needs it
-    add_bare_dispatcher_cmd(dispatch_cmds, dcmd);
-
-    add_prefetcher_cmd(exec_buf_cmds, empty_sizes, CQ_PREFETCH_CMD_EXEC_BUF_END, dispatch_cmds);
-
-    // writes cmds to dram
-    num_dram_banks_g = device->allocator()->get_num_banks(BufferType::DRAM);
-
-    uint32_t page_size = 1 << exec_buf_log_page_size_g;
-
-    uint32_t length = exec_buf_cmds.size() * sizeof(uint32_t);
-    length += (page_size - (length & (page_size - 1))) & (page_size - 1);  // rounded up to full pages
-    exec_buf_cmds.resize(length / sizeof(uint32_t));  // make sure access to the last segment do not overrun the buffer
-
-    uint32_t pages = length / page_size;
-    uint32_t index = 0;
-    for (uint32_t page_id = 0; page_id < pages; page_id++) {
-        uint32_t bank_id = page_id % num_dram_banks_g;
-        std::vector<uint32_t> exec_buf_page(exec_buf_cmds.begin() + index / sizeof(uint32_t), exec_buf_cmds.begin() + (index + page_size) / sizeof(uint32_t));
-        tt::tt_metal::detail::WriteToDeviceDRAMChannel(
-            device,
-            bank_id,
-            DRAM_EXEC_BUF_DEFAULT_BASE_ADDR + ((page_id / num_dram_banks_g) * page_size),
-            exec_buf_page);
-
-        index += page_size;
-    }
-    tt::tt_metal::MetalContext::instance().get_cluster().dram_barrier(device->id());
-
-    CQPrefetchCmd cmd{};
-    cmd.base.cmd_id = CQ_PREFETCH_CMD_EXEC_BUF;
-    cmd.exec_buf.pad1 = 0;
-    cmd.exec_buf.pad2 = 0;
-    cmd.exec_buf.base_addr = DRAM_EXEC_BUF_DEFAULT_BASE_ADDR;
-    cmd.exec_buf.log_page_size = exec_buf_log_page_size_g;
-    cmd.exec_buf.pages = pages;
-
-    add_prefetcher_cmd(prefetch_cmds, cmd_sizes, cmd);
-
-    // CQ_PREFETCH_CMD_EXEC_BUF command requires stall_prefetcher flag to be set. This is MSB on FetchQ entry
-    // Hacky, but set it here, on the last cmd_size (FetchQ entry write, later)
-    const bool stall_prefetcher = true;
-    cmd_sizes[cmd_sizes.size() - 1] |=
-        (stall_prefetcher << ((sizeof(DispatchSettings::prefetch_q_entry_type) * 8) - 1));
-}
-
-void gen_smoke_test(
-    IDevice* device,
-    vector<uint32_t>& prefetch_cmds,
-    vector<uint32_t>& cmd_sizes,
-    DeviceData& device_data,
-    CoreCoord worker_core,
-    CoreCoord another_worker_core) {
-    vector<uint32_t> empty_payload;  // don't give me grief, it is just a test
-    vector<uint32_t> dispatch_cmds;
-    const uint32_t dram_alignment = MetalContext::instance().hal().get_alignment(HalMemType::DRAM);
-
-    if (!use_dram_exec_buf_g) {
-        add_prefetcher_cmd(prefetch_cmds, cmd_sizes, CQ_PREFETCH_CMD_DEBUG, empty_payload);
-
-        vector<uint32_t> rnd_payload;
-        generate_random_payload(rnd_payload, 17);
-        add_prefetcher_cmd(prefetch_cmds, cmd_sizes, CQ_PREFETCH_CMD_DEBUG, rnd_payload);
-    }
-
-    // Write to worker
-    dispatch_cmds.resize(0);
-    device_data.reset();
-    gen_dispatcher_unicast_write_cmd(device, dispatch_cmds, worker_core, device_data, 32);
-    add_prefetcher_cmd(prefetch_cmds, cmd_sizes, CQ_PREFETCH_CMD_RELAY_INLINE, dispatch_cmds);
-
-    // Write to worker
-    dispatch_cmds.resize(0);
-    gen_dispatcher_unicast_write_cmd(device, dispatch_cmds, worker_core, device_data, 1026);
-    add_prefetcher_cmd(prefetch_cmds, cmd_sizes, CQ_PREFETCH_CMD_RELAY_INLINE, dispatch_cmds);
-
-    // Write to worker
-    dispatch_cmds.resize(0);
-    gen_dispatcher_unicast_write_cmd(device, dispatch_cmds, worker_core, device_data, 8448);
-    add_prefetcher_cmd(prefetch_cmds, cmd_sizes, CQ_PREFETCH_CMD_RELAY_INLINE, dispatch_cmds);
-
-    // Check some hard page alignment sizes
-    dispatch_cmds.resize(0);
-    gen_dispatcher_unicast_write_cmd(device, dispatch_cmds, worker_core, device_data, dispatch_buffer_page_size_g);
-    add_prefetcher_cmd(prefetch_cmds, cmd_sizes, CQ_PREFETCH_CMD_RELAY_INLINE, dispatch_cmds);
-
-    dispatch_cmds.resize(0);
-    gen_dispatcher_unicast_write_cmd(
-        device, dispatch_cmds, worker_core, device_data, dispatch_buffer_page_size_g - sizeof(CQDispatchCmdLarge));
-    add_prefetcher_cmd(prefetch_cmds, cmd_sizes, CQ_PREFETCH_CMD_RELAY_INLINE, dispatch_cmds);
-
-    dispatch_cmds.resize(0);
-    gen_dispatcher_unicast_write_cmd(device, dispatch_cmds, worker_core, device_data, 2 * dispatch_buffer_page_size_g);
-    add_prefetcher_cmd(prefetch_cmds, cmd_sizes, CQ_PREFETCH_CMD_RELAY_INLINE, dispatch_cmds);
-
-    dispatch_cmds.resize(0);
-    gen_dispatcher_unicast_write_cmd(
-        device,
-        dispatch_cmds,
-        worker_core,
-        device_data,
-        (2 * dispatch_buffer_page_size_g) - sizeof(CQDispatchCmdLarge));
-    add_prefetcher_cmd(prefetch_cmds, cmd_sizes, CQ_PREFETCH_CMD_RELAY_INLINE, dispatch_cmds);
-
-    // Merge 4 commands in the FetchQ
-    dispatch_cmds.resize(0);
-    gen_dispatcher_unicast_write_cmd(device, dispatch_cmds, worker_core, device_data, 112);
-    add_prefetcher_cmd(prefetch_cmds, cmd_sizes, CQ_PREFETCH_CMD_RELAY_INLINE, dispatch_cmds);
-    dispatch_cmds.resize(0);
-    gen_dispatcher_unicast_write_cmd(device, dispatch_cmds, worker_core, device_data, 608);
-    add_prefetcher_cmd(prefetch_cmds, cmd_sizes, CQ_PREFETCH_CMD_RELAY_INLINE, dispatch_cmds);
-    dispatch_cmds.resize(0);
-    gen_dispatcher_unicast_write_cmd(device, dispatch_cmds, worker_core, device_data, 64);
-    add_prefetcher_cmd(prefetch_cmds, cmd_sizes, CQ_PREFETCH_CMD_RELAY_INLINE, dispatch_cmds);
-    dispatch_cmds.resize(0);
-    gen_dispatcher_unicast_write_cmd(device, dispatch_cmds, worker_core, device_data, 96);
-    add_prefetcher_cmd(prefetch_cmds, cmd_sizes, CQ_PREFETCH_CMD_RELAY_INLINE, dispatch_cmds);
-
-    // Tests sending multiple commands w/ 1 FetchQ entry
-    uint32_t combined_size = cmd_sizes[cmd_sizes.size() - 1] + cmd_sizes[cmd_sizes.size() - 2] +
-                             cmd_sizes[cmd_sizes.size() - 3] + cmd_sizes[cmd_sizes.size() - 4];
-
-    cmd_sizes[cmd_sizes.size() - 4] = combined_size;
-    cmd_sizes.pop_back();
-    cmd_sizes.pop_back();
-    cmd_sizes.pop_back();
-
-    // Use another_worker_core as worker_core is filling up
-    // Do this before dram paged commands below which level up the results across cores
-    vector<uint32_t> lengths;
-    constexpr uint32_t packed_read_page_size = 10;
-    lengths.push_back(256);
-    gen_dram_packed_read_cmd(
-        device, prefetch_cmds, cmd_sizes, device_data, another_worker_core, packed_read_page_size, lengths);
-
-    lengths.push_back(512);
-    gen_dram_packed_read_cmd(
-        device, prefetch_cmds, cmd_sizes, device_data, another_worker_core, packed_read_page_size, lengths);
-
-    lengths.resize(0);
-    lengths.push_back(1024);
-    gen_dram_packed_read_cmd(
-        device, prefetch_cmds, cmd_sizes, device_data, another_worker_core, packed_read_page_size, lengths);
-    lengths.push_back(2048);
-    gen_dram_packed_read_cmd(
-        device, prefetch_cmds, cmd_sizes, device_data, another_worker_core, packed_read_page_size, lengths);
-
-    lengths.resize(0);
-    uint32_t length_to_read = tt::align(2080, dram_alignment);
-    lengths.push_back(length_to_read);
-    gen_dram_packed_read_cmd(
-        device, prefetch_cmds, cmd_sizes, device_data, another_worker_core, packed_read_page_size, lengths);
-
-    lengths.push_back(length_to_read);
-    gen_dram_packed_read_cmd(
-        device, prefetch_cmds, cmd_sizes, device_data, another_worker_core, packed_read_page_size + 1, lengths);
-
-    // when adding read lengths based on some calculations to generate test cases
-    // ensure they are aligned properly so they work on all page table configs
-    lengths.resize(0);
-    lengths.push_back(tt::align(scratch_db_size_g / 8, dram_alignment));
-    lengths.push_back(tt::align(scratch_db_size_g / 8, dram_alignment));
-    lengths.push_back(tt::align(scratch_db_size_g / 8, dram_alignment));
-    lengths.push_back(tt::align(scratch_db_size_g / 4, dram_alignment));  // won't fit in first pass
-    lengths.push_back(tt::align(scratch_db_size_g / 2, dram_alignment));  // won't fit in second pass
-    gen_dram_packed_read_cmd(
-        device, prefetch_cmds, cmd_sizes, device_data, another_worker_core, packed_read_page_size, lengths);
-
-    lengths.resize(0);
-    lengths.push_back(tt::align((scratch_db_size_g / 4) + (2 * 1024) + 32, dram_alignment));
-    lengths.push_back(tt::align((scratch_db_size_g / 4) + (3 * 1024) + 32, dram_alignment));
-    lengths.push_back(tt::align(scratch_db_size_g / 2, dram_alignment));
-    lengths.push_back(tt::align((scratch_db_size_g / 8) + (5 * 1024) + 96, dram_alignment));
-    gen_dram_packed_read_cmd(
-        device, prefetch_cmds, cmd_sizes, device_data, another_worker_core, packed_read_page_size, lengths);
-
-    // Read from dram, write to worker
-    // start_page, base addr, page_size, pages
-    gen_dram_read_cmd(
-        device, prefetch_cmds, cmd_sizes, device_data, worker_core, 0, 0, dram_alignment, num_dram_banks_g, 0);
-    gen_dram_read_cmd(
-        device, prefetch_cmds, cmd_sizes, device_data, worker_core, 0, 0, dram_alignment, num_dram_banks_g, 0);
-    gen_dram_read_cmd(
-        device,
-        prefetch_cmds,
-        cmd_sizes,
-        device_data,
-        worker_core,
-        4,
-        dram_alignment,
-        dram_alignment * 2,
-        num_dram_banks_g,
-        0);
-
-    gen_dram_read_cmd(device, prefetch_cmds, cmd_sizes, device_data, worker_core, 0, 0, 128, 128, 0);
-    gen_dram_read_cmd(
-        device, prefetch_cmds, cmd_sizes, device_data, worker_core, 4, dram_alignment, 2048, num_dram_banks_g + 4, 0);
-    gen_dram_read_cmd(
-        device,
-        prefetch_cmds,
-        cmd_sizes,
-        device_data,
-        worker_core,
-        5,
-        dram_alignment,
-        2048,
-        (num_dram_banks_g * 3) + 1,
-        0);
-    gen_dram_read_cmd(
-        device,
-        prefetch_cmds,
-        cmd_sizes,
-        device_data,
-        worker_core,
-        3,
-        tt::align(128, dram_alignment),
-        6144,
-        num_dram_banks_g - 1,
-        0);
-
-    gen_dram_read_cmd(device, prefetch_cmds, cmd_sizes, device_data, worker_core, 0, 0, 128, 128, 32);
-    gen_dram_read_cmd(
-        device,
-        prefetch_cmds,
-        cmd_sizes,
-        device_data,
-        worker_core,
-        4,
-        dram_alignment,
-        2048,
-        num_dram_banks_g * 2,
-        1536);
-    gen_dram_read_cmd(
-        device,
-        prefetch_cmds,
-        cmd_sizes,
-        device_data,
-        worker_core,
-        5,
-        dram_alignment,
-        2048,
-        (num_dram_banks_g * 2) + 1,
-        256);
-    gen_dram_read_cmd(
-        device,
-        prefetch_cmds,
-        cmd_sizes,
-        device_data,
-        worker_core,
-        3,
-        tt::align(128, dram_alignment),
-        6144,
-        num_dram_banks_g - 1,
-        640);
-
-    // Large pages
-    gen_dram_read_cmd(
-        device,
-        prefetch_cmds,
-        cmd_sizes,
-        device_data,
-        worker_core,
-        0,
-        0,
-        (scratch_db_size_g / 2) + dram_alignment,
-        2,
-        128);  // just a little larger than the scratch_db, length_adjust backs into prior page
-    gen_dram_read_cmd(
-        device, prefetch_cmds, cmd_sizes, device_data, worker_core, 0, 0, scratch_db_size_g, 2, 0);  // exactly the
-                                                                                                     // scratch db size
-
-    // Forces length_adjust to back into prior read.  Device reads pages, shouldn't be a problem...
-    uint32_t page_size = 256 + dram_alignment;
-    uint32_t length = (scratch_db_size_g / 2 / page_size * page_size) + page_size;
-    gen_dram_read_cmd(
-        device, prefetch_cmds, cmd_sizes, device_data, worker_core, 3, 128, page_size, length / page_size, 160);
-
-    // Send inline data to (maybe) multiple cores
-    dispatch_cmds.resize(0);
-    vector<CoreCoord> worker_cores;
-    worker_cores.push_back(first_worker_g);
-    gen_dispatcher_packed_write_cmd(device, dispatch_cmds, worker_cores, device_data, 4);
-    add_prefetcher_cmd(prefetch_cmds, cmd_sizes, CQ_PREFETCH_CMD_RELAY_INLINE, dispatch_cmds);
-
-    dispatch_cmds.resize(0);
-    worker_cores.resize(0);
-    for (uint32_t y = all_workers_g.start_coord.y; y <= all_workers_g.end_coord.y; y++) {
-        for (uint32_t x = all_workers_g.start_coord.x; x <= all_workers_g.end_coord.x; x++) {
-            CoreCoord worker_core(x, y);
-            worker_cores.push_back(worker_core);
-        }
-    }
-    gen_dispatcher_packed_write_cmd(device, dispatch_cmds, worker_cores, device_data, 12);
-    add_prefetcher_cmd(prefetch_cmds, cmd_sizes, CQ_PREFETCH_CMD_RELAY_INLINE, dispatch_cmds);
-
-    dispatch_cmds.resize(0);
-    gen_dispatcher_packed_write_cmd(device, dispatch_cmds, worker_cores, device_data, 12, true);
-    add_prefetcher_cmd(prefetch_cmds, cmd_sizes, CQ_PREFETCH_CMD_RELAY_INLINE, dispatch_cmds);
-
-    dispatch_cmds.resize(0);
-    worker_cores.resize(0);
-    worker_cores.push_back(first_worker_g);
-    worker_cores.push_back(all_workers_g.end_coord);
-    gen_dispatcher_packed_write_cmd(device, dispatch_cmds, worker_cores, device_data, 156);
-    add_prefetcher_cmd(prefetch_cmds, cmd_sizes, CQ_PREFETCH_CMD_RELAY_INLINE, dispatch_cmds);
-
-    // These tests copy data from earlier tests so can't run first
-    gen_linear_read_cmd(device, prefetch_cmds, cmd_sizes, device_data, worker_core, 32);
-    gen_linear_read_cmd(device, prefetch_cmds, cmd_sizes, device_data, worker_core, 65 * 1024);
-    gen_linear_read_cmd(
-        device,
-        prefetch_cmds,
-        cmd_sizes,
-        device_data,
-        worker_core,
-        dispatch_buffer_page_size_g - sizeof(CQDispatchCmdLarge));
-    gen_linear_read_cmd(device, prefetch_cmds, cmd_sizes, device_data, worker_core, dispatch_buffer_page_size_g);
-    gen_linear_read_cmd(
-        device,
-        prefetch_cmds,
-        cmd_sizes,
-        device_data,
-        worker_core,
-        (2 * dispatch_buffer_page_size_g) - sizeof(CQDispatchCmdLarge));
-    gen_linear_read_cmd(device, prefetch_cmds, cmd_sizes, device_data, worker_core, 2 * dispatch_buffer_page_size_g);
-
-    // Test wait/stall
-    gen_dispatcher_delay_cmd(device, prefetch_cmds, cmd_sizes, 1024 * 1024);
-    dispatch_cmds.resize(0);
-    gen_dispatcher_unicast_write_cmd(device, dispatch_cmds, worker_core, device_data, 1024);
-    add_prefetcher_cmd(prefetch_cmds, cmd_sizes, CQ_PREFETCH_CMD_RELAY_INLINE, dispatch_cmds);
-    gen_wait_and_stall_cmd(device, prefetch_cmds, cmd_sizes);
-    gen_linear_read_cmd(
-        device,
-        prefetch_cmds,
-        cmd_sizes,
-        device_data,
-        worker_core,
-        32,
-        device_data.size_at(worker_core, 0) - (32 / sizeof(uint32_t)));
-
-    // Touch test write offset
-    // Making sure this really works by doing a write would break lots of
-    // existing test infra, so not tested yet. TODO
-    dispatch_cmds.resize(0);
-    uint32_t write_offset = 48;
-    gen_dispatcher_set_write_offset_cmd(dispatch_cmds, write_offset);
-    add_prefetcher_cmd(prefetch_cmds, cmd_sizes, CQ_PREFETCH_CMD_RELAY_INLINE, dispatch_cmds);
-    dispatch_cmds.resize(0);
-    write_offset = 0;
-    gen_dispatcher_set_write_offset_cmd(dispatch_cmds, write_offset);
-    add_prefetcher_cmd(prefetch_cmds, cmd_sizes, CQ_PREFETCH_CMD_RELAY_INLINE, dispatch_cmds);
-
-    // Test host
-    if (!use_dram_exec_buf_g) {
-        for (int multiplier = 1; multiplier <= 3; multiplier++) {
-            dispatch_cmds.resize(0);
-            gen_dispatcher_host_write_cmd(dispatch_cmds, device_data, multiplier * 32);
-            add_prefetcher_cmd(prefetch_cmds, cmd_sizes, CQ_PREFETCH_CMD_RELAY_INLINE, dispatch_cmds);
-            pad_host_data(device_data);
-
-            dispatch_cmds.resize(0);
-            gen_dispatcher_host_write_cmd(dispatch_cmds, device_data, multiplier * 36);
-            add_prefetcher_cmd(prefetch_cmds, cmd_sizes, CQ_PREFETCH_CMD_RELAY_INLINE, dispatch_cmds);
-            pad_host_data(device_data);
-
-            dispatch_cmds.resize(0);
-            gen_dispatcher_host_write_cmd(dispatch_cmds, device_data, multiplier * 1024);
-            add_prefetcher_cmd(prefetch_cmds, cmd_sizes, CQ_PREFETCH_CMD_RELAY_INLINE, dispatch_cmds);
-            pad_host_data(device_data);
-
-            dispatch_cmds.resize(0);
-            gen_dispatcher_host_write_cmd(
-                dispatch_cmds, device_data, (multiplier * dispatch_buffer_page_size_g) - (2 * sizeof(CQDispatchCmd)));
-            add_prefetcher_cmd(prefetch_cmds, cmd_sizes, CQ_PREFETCH_CMD_RELAY_INLINE, dispatch_cmds);
-            pad_host_data(device_data);
-
-            dispatch_cmds.resize(0);
-            gen_dispatcher_host_write_cmd(
-                dispatch_cmds, device_data, (multiplier * dispatch_buffer_page_size_g) - sizeof(CQDispatchCmd));
-            add_prefetcher_cmd(prefetch_cmds, cmd_sizes, CQ_PREFETCH_CMD_RELAY_INLINE, dispatch_cmds);
-            pad_host_data(device_data);
-
-            dispatch_cmds.resize(0);
-            gen_dispatcher_host_write_cmd(dispatch_cmds, device_data, multiplier * dispatch_buffer_page_size_g);
-            add_prefetcher_cmd(prefetch_cmds, cmd_sizes, CQ_PREFETCH_CMD_RELAY_INLINE, dispatch_cmds);
-            pad_host_data(device_data);
-
-            dispatch_cmds.resize(0);
-            gen_dispatcher_host_write_cmd(
-                dispatch_cmds, device_data, (multiplier * dispatch_buffer_page_size_g) + sizeof(CQDispatchCmd));
-            add_prefetcher_cmd(prefetch_cmds, cmd_sizes, CQ_PREFETCH_CMD_RELAY_INLINE, dispatch_cmds);
-            pad_host_data(device_data);
-
-            dispatch_cmds.resize(0);
-            gen_dispatcher_host_write_cmd(
-                dispatch_cmds, device_data, (multiplier * dispatch_buffer_page_size_g) + sizeof(CQDispatchCmd));
-            add_prefetcher_cmd(prefetch_cmds, cmd_sizes, CQ_PREFETCH_CMD_RELAY_INLINE, dispatch_cmds);
-            pad_host_data(device_data);
+            case CQ_PREFETCH_CMD_DEBUG: break; break;
+            default: break;
         }
     }
 
-    // Test Paged DRAM Write and Read. FIXME - Needs work - hits asserts.
-    // gen_dram_write_cmd(device, prefetch_cmds, cmd_sizes, device_data, 0, 32, 64, 128);
-    // gen_wait_and_stall_cmd(device, prefetch_cmds, cmd_sizes);
-    // gen_dram_read_cmd(device, prefetch_cmds, cmd_sizes, device_data, worker_core, 0, 32, 64, 128);
+    execute_generated_commands(commands_per_iteration, device_data, worker_range.size(), num_iterations);
 }
 
-void gen_relay_linear_h_test(
-    IDevice* device, vector<uint32_t>& prefetch_cmds, vector<uint32_t>& cmd_sizes, DeviceData& device_data) {
-    static constexpr uint32_t min_read_size = 32;
+// This test targets relay linear H command: PREFETCH_H (MMIO) -> PREFETCH_D (Remote) -> DISPATCHER (Remote)
+TEST_P(PrefetchRelayLinearHTestFixture, RelayLinearHTest) {
+    log_info(tt::LogTest, "PrefetchRelayLinearHTestFixture - RelayLinearHTest - Test Start");
+
     const uint32_t max_read_size =
-        std::min(scratch_db_size_g, prefetch_q_entries_g * (uint32_t)sizeof(DispatchSettings::prefetch_q_entry_type)) -
+        std::min(
+            DEFAULT_SCRATCH_DB_SIZE,
+            DEFAULT_PREFETCH_Q_ENTRIES * (uint32_t)sizeof(DispatchSettings::prefetch_q_entry_type)) -
         64;
 
-    bool done = false;
-    uint32_t dram_data_base_addr = device->allocator()->get_base_allocator_addr(HalMemType::DRAM);
-    while (!done) {
-        // Generate random read size, ensure it's aligned
-        auto dram_alignment = MetalContext::instance().hal().get_alignment(HalMemType::DRAM);
-        uint32_t length = tt::align(std::max(min_read_size, std::rand() % max_read_size), dram_alignment);
+    // Test parameters
+    const uint32_t num_iterations = get_num_iterations();
+    const uint32_t dram_data_size_words = get_dram_data_size_words();
 
-        if (device_data.size() * sizeof(uint32_t) + length > DEVICE_DATA_SIZE) {
-            // Close to the end, finish up
-            done = true;
-        } else {
-            // Generate the dispatcher write command first
-            vector<uint32_t> dispatch_cmds;
-            gen_bare_dispatcher_unicast_write_cmd(device, dispatch_cmds, first_worker_g, device_data, length);
+    // Setup target worker cores
+    const CoreCoord first_worker = default_worker_start;
+    const CoreCoord last_worker = {first_worker.x + 1, first_worker.y + 1};
+    const CoreRange worker_range = {first_worker, last_worker};
 
-            // Add the CQ_PREFETCH_CMD_RELAY_INLINE_NOFLUSH with the dispatch command as payload
-            add_prefetcher_cmd(prefetch_cmds, cmd_sizes, CQ_PREFETCH_CMD_RELAY_INLINE_NOFLUSH, dispatch_cmds);
+    const uint32_t l1_base = mmio_device_->allocator()->get_base_allocator_addr(HalMemType::L1);
+    const auto dram_alignment = MetalContext::instance().hal().get_alignment(HalMemType::DRAM);
 
-            // Create the relay linear H command
-            CQPrefetchCmdLarge cmd{};
-            cmd.base.cmd_id = CQ_PREFETCH_CMD_RELAY_LINEAR_H;
+    // Compute NOC encoding: Destination (Worker on Remote Device) -> Use device_ (Chip 1)
+    const CoreCoord first_virt_worker = remote_device_->virtual_core_from_logical_core(first_worker, CoreType::WORKER);
+    const uint32_t noc_xy = remote_device_->get_noc_unicast_encoding(k_dispatch_downstream_noc, first_virt_worker);
 
-            // Set up the source NOC address - we'll read from DRAM where data is initialized
-            // Use DRAM bank 0 for simplicity
-            const uint32_t dram_bank_id = 0;
-            auto dram_channel = device->allocator_impl()->get_dram_channel_from_bank_id(dram_bank_id);
-            CoreCoord dram_logical_core = device->logical_core_from_dram_channel(dram_channel);
-            CoreCoord dram_physical_core = tt::tt_metal::MetalContext::instance()
-                                               .get_cluster()
-                                               .get_soc_desc(device->id())
-                                               .get_preferred_worker_core_for_dram_view(dram_channel, NOC::NOC_0);
-            cmd.relay_linear_h.noc_xy_addr = device->get_noc_unicast_encoding(NOC::NOC_0, dram_physical_core);
+    // Source (DRAM on MMIO Device) -> Use mmio_device_ (Chip 0)
+    auto mmio_dram_base = mmio_device_->allocator()->get_base_allocator_addr(HalMemType::DRAM);
+    DeviceData device_data(
+        mmio_device_, worker_range, l1_base, mmio_dram_base, nullptr, false, dram_data_size_words, cfg_);
 
-            [[maybe_unused]] auto offset = device->allocator()->get_bank_offset(BufferType::DRAM, dram_bank_id);
-            // Read from DRAM result data address where data is stored
-            // DeviceData uses the logical coordinates as keys
-            cmd.relay_linear_h.addr = dram_data_base_addr + offset;
-            cmd.relay_linear_h.length = length;
+    std::vector<HostMemDeviceCommand> commands_per_iteration;
 
-            // Add the command
-            update_cmd_sizes(prefetch_cmds, cmd_sizes, [&]() { add_bare_prefetcher_cmd(prefetch_cmds, cmd, true); });
+    uint32_t remaining_bytes = DEVICE_DATA_SIZE;
 
-            // Update device data to simulate the data that would be written
-            // For relay linear H, we're reading from DRAM which should already be populated.
-            // We need to simulate writing that DRAM data to the target worker core.
-            uint32_t length_words = length / sizeof(uint32_t);
+    while (remaining_bytes > 0) {
+        uint32_t length = std::min(
+            tt::align(
+                std::max(MIN_READ_SIZE, payload_generator_->get_rand<uint32_t>(0, max_read_size - 1)), dram_alignment),
+            remaining_bytes);
 
-            // Ensure DRAM data exists
-            TT_FATAL(
-                device_data.core_and_bank_present(dram_logical_core, dram_bank_id),
-                "DRAM core {} bank {} not present in device data",
-                dram_logical_core.str(),
-                dram_bank_id);
-            TT_FATAL(
-                length_words <= device_data.size_at(dram_logical_core, dram_bank_id),
-                "Requested length {} words exceeds available DRAM data {} words at core {} bank {}",
-                length_words,
-                device_data.size_at(dram_logical_core, dram_bank_id),
-                dram_logical_core.str(),
-                dram_bank_id);
+        // Capture address before updating device_data
+        uint32_t l1_addr = device_data.get_result_data_addr(first_worker, 0);
 
-            for (uint32_t i = 0; i < length_words; i++) {
-                // Get the actual data from DRAM - it must exist
-                uint32_t data_value = device_data.at(dram_logical_core, dram_bank_id, i);
-                device_data.push_one(first_worker_g, data_value);
-            }
+        DeviceCommandCalculator calc;
+        calc.add_dispatch_write_linear<false, false>(length);
+        const uint32_t dispatch_cmd_size = calc.write_offset_bytes();
+
+        // Create the HostMemDeviceCommand with pre-calculated size
+        HostMemDeviceCommand cmd1(dispatch_cmd_size);
+
+        cmd1.add_dispatch_write_linear<false, false>(
+            0,        // num_mcast_dests
+            noc_xy,   // NOC coordinates
+            l1_addr,  // destination address
+            length,   // data size
+            nullptr   // payload data
+        );
+
+        commands_per_iteration.push_back(cmd1);
+
+        const uint32_t total_cmd_bytes = tt::align(sizeof(CQPrefetchCmdLarge), host_alignment_);
+
+        // Create the HostMemDeviceCommand with pre-calculated size
+        HostMemDeviceCommand cmd2(total_cmd_bytes);
+
+        // Create the relay linear H command
+        CQPrefetchCmdLarge cmd{};
+        std::memset(&cmd, 0, sizeof(CQPrefetchCmdLarge));
+        cmd.base.cmd_id = CQ_PREFETCH_CMD_RELAY_LINEAR_H;
+
+        // Source (DRAM on MMIO Device) -> Use mmio_device_ (Chip 0)
+        const uint32_t dram_bank_id = 0;
+        auto dram_channel = mmio_device_->allocator()->get_dram_channel_from_bank_id(dram_bank_id);
+        CoreCoord dram_logical_core = mmio_device_->logical_core_from_dram_channel(dram_channel);
+        CoreCoord dram_physical_core = MetalContext::instance()
+                                           .get_cluster()
+                                           .get_soc_desc(mmio_device_->id())
+                                           .get_preferred_worker_core_for_dram_view(dram_channel, NOC::NOC_0);
+        cmd.relay_linear_h.noc_xy_addr =
+            mmio_device_->get_noc_unicast_encoding(k_dispatch_downstream_noc, dram_physical_core);
+
+        [[maybe_unused]] auto offset = mmio_device_->allocator()->get_bank_offset(BufferType::DRAM, dram_bank_id);
+        // Read from DRAM result data address where data is stored
+        // DeviceData uses the logical coordinates as keys
+        cmd.relay_linear_h.addr = mmio_dram_base + offset;
+        cmd.relay_linear_h.length = length;
+        cmd.relay_linear_h.pad1 = 0;
+        cmd.relay_linear_h.pad2 = 0;
+
+        uint32_t length_words = length / sizeof(uint32_t);
+
+        // Use reserve_space to properly update cmd_write_offsetB
+        CQPrefetchCmdLarge* cmd_ptr = cmd2.reserve_space<CQPrefetchCmdLarge*>(sizeof(CQPrefetchCmdLarge));
+        std::memcpy(cmd_ptr, &cmd, sizeof(CQPrefetchCmdLarge));
+
+        // Align the write offset for any padding needed
+        cmd2.align_write_offset();
+
+        commands_per_iteration.push_back(cmd2);
+
+        DeviceDataUpdater::update_read(
+            default_worker_start, device_data, dram_logical_core, dram_bank_id, 0, length_words);
+
+        remaining_bytes -= length;
+    }
+
+    execute_generated_commands(commands_per_iteration, device_data, worker_range.size(), num_iterations);
+}
+
+// Smoke test of prefetcher/dispatcher commands
+TEST_P(PrefetcherSmokeTestFixture, SmokeTest) {
+    log_info(tt::LogTest, "PrefetcherSmokeTestFixture - SmokeTest - Test Start");
+
+    const uint32_t num_iterations = get_num_iterations();
+    const uint32_t dram_data_size_words = get_dram_data_size_words();
+
+    // Setup target worker cores
+    const CoreCoord first_worker = default_worker_start;
+    const CoreCoord last_worker = first_worker;
+    const CoreRange worker_range = {first_worker, last_worker};
+
+    const uint32_t l1_base = device_->allocator()->get_base_allocator_addr(HalMemType::L1);
+
+    DeviceData device_data(device_, worker_range, l1_base, dram_base_, nullptr, false, dram_data_size_words, cfg_);
+
+    std::vector<HostMemDeviceCommand> commands_per_iteration;
+
+    HelperInfo info{
+        dram_base_, num_banks_, l1_alignment_, packed_write_max_unicast_sub_cmds_, dispatch_buffer_page_size_};
+    // Instantiate Helper
+    SmokeTestHelper helper(device_, device_data, commands_per_iteration, info);
+
+    // Section 1: Unicast
+    // Important: reset device_data from prior tests if smoke test isn't the first
+    // device_data.reset();
+    helper.add_unicast_write(worker_range, 32);
+    helper.add_unicast_write(worker_range, 1026);
+    helper.add_unicast_write(worker_range, 8448);
+    helper.add_unicast_write(worker_range, dispatch_buffer_page_size_);
+    helper.add_unicast_write(worker_range, dispatch_buffer_page_size_ - sizeof(CQDispatchCmdLarge));
+    helper.add_unicast_write(worker_range, 2 * dispatch_buffer_page_size_);
+    helper.add_unicast_write(worker_range, (2 * dispatch_buffer_page_size_) - sizeof(CQDispatchCmdLarge));
+
+    // Section 2: Merged Unicast Writes
+    helper.add_merged_unicast_writes(worker_range, {112, 608, 64, 96});
+
+    // Section 3: packed read
+    constexpr uint32_t log_packed_read_page_size = 10;
+    const uint32_t dram_alignment = MetalContext::instance().hal().get_alignment(HalMemType::DRAM);
+    const uint32_t length_to_read = tt::align(2080, dram_alignment);
+    const uint32_t length_to_read_sdb = tt::align(DEFAULT_SCRATCH_DB_SIZE / 8, dram_alignment);
+    // Create and pass PrefetcherPackedReadTestFixture::build_sub_cmds callable
+    auto build_packed =
+        [this](
+            const std::vector<uint32_t>& lengths, DeviceData& device_data, uint32_t log_page_sz, uint32_t n_sub_cmds) {
+            return PrefetcherPackedReadTestFixture::build_sub_cmds(lengths, device_data, log_page_sz, n_sub_cmds);
+        };
+    // Uses last_worker as first_worker is filling up
+    helper.add_packed_dram_read(worker_range, log_packed_read_page_size, {256, 512}, build_packed);
+    helper.add_packed_dram_read(worker_range, log_packed_read_page_size, {1024, 2048}, build_packed);
+    helper.add_packed_dram_read(worker_range, log_packed_read_page_size, {length_to_read}, build_packed);
+    helper.add_packed_dram_read(
+        worker_range, log_packed_read_page_size + 1, {length_to_read, length_to_read}, build_packed);
+
+    std::vector<uint32_t> lengths{
+        length_to_read_sdb,
+        length_to_read_sdb,
+        length_to_read_sdb,
+        tt::align(DEFAULT_SCRATCH_DB_SIZE / 4, dram_alignment),   // won't fit in first pass
+        tt::align(DEFAULT_SCRATCH_DB_SIZE / 2, dram_alignment)};  // won't fit in second pass
+    helper.add_packed_dram_read(worker_range, log_packed_read_page_size + 1, lengths, build_packed);
+
+    lengths.clear();
+    lengths.push_back(tt::align((DEFAULT_SCRATCH_DB_SIZE / 4) + (2 * 1024) + 32, dram_alignment));
+    lengths.push_back(tt::align((DEFAULT_SCRATCH_DB_SIZE / 4) + (3 * 1024) + 32, dram_alignment));
+    lengths.push_back(tt::align(DEFAULT_SCRATCH_DB_SIZE / 2, dram_alignment));
+    lengths.push_back(tt::align((DEFAULT_SCRATCH_DB_SIZE / 8) + (5 * 1024) + 96, dram_alignment));
+    helper.add_packed_dram_read(worker_range, log_packed_read_page_size, lengths, build_packed);
+
+    // Section 4: Read from dram, write to worker
+    //                              start_page,                      base addr,      page_size,           pages,
+    //                              length_adjust
+    helper.add_paged_dram_read(worker_range, 0, 0, dram_alignment, num_banks_, 0);
+    helper.add_paged_dram_read(worker_range, 4, dram_alignment, dram_alignment * 2, num_banks_, 0);
+    helper.add_paged_dram_read(worker_range, 4, dram_alignment, dram_alignment * 2, num_banks_, 0);
+    helper.add_paged_dram_read(worker_range, 0, 0, 128, 128, 0);
+    helper.add_paged_dram_read(worker_range, 4, dram_alignment, 2048, num_banks_ + 4, 0);
+    helper.add_paged_dram_read(worker_range, 5, dram_alignment, 2048, (num_banks_ * 3) + 1, 0);
+    helper.add_paged_dram_read(worker_range, 3, tt::align(128, dram_alignment), 6144, num_banks_ - 1, 0);
+    helper.add_paged_dram_read(worker_range, 3, tt::align(128, dram_alignment), 6144, num_banks_ - 1, 0);
+    helper.add_paged_dram_read(worker_range, 0, 0, 128, 128, 32);
+    helper.add_paged_dram_read(worker_range, 4, dram_alignment, 2048, num_banks_ * 2, 1536);
+    helper.add_paged_dram_read(worker_range, 5, dram_alignment, 2048, (num_banks_ * 2) + 1, 256);
+    helper.add_paged_dram_read(worker_range, 3, tt::align(128, dram_alignment), 6144, num_banks_ - 1, 640);
+    // Large pages
+    helper.add_paged_dram_read(worker_range, 0, 0, DEFAULT_SCRATCH_DB_SIZE / 2 + dram_alignment, 2, 128);
+    helper.add_paged_dram_read(worker_range, 0, 0, DEFAULT_SCRATCH_DB_SIZE, 2, 0);
+    // Forces length_adjust to back into prior read.  Device reads pages, shouldn't be a problem...
+    uint32_t page_size = 256 + dram_alignment;
+    uint32_t length = (DEFAULT_SCRATCH_DB_SIZE / 2 / page_size * page_size) + page_size;
+    helper.add_paged_dram_read(worker_range, 3, 128, page_size, length / page_size, 160);
+
+    // Section 5: Inline packed writes
+    const CoreCoord first_worker_2x2 = default_worker_start;
+    const CoreCoord last_worker_2x2 = {first_worker_2x2.x + 1, first_worker_2x2.y + 1};
+    const CoreRange worker_range_2x2 = {first_worker_2x2, last_worker_2x2};
+    // Pick worker cores once for all commands
+    std::vector<CoreCoord> worker_cores{first_worker_2x2};
+    helper.add_packed_write(worker_cores, 4);
+    worker_cores.clear();
+    for (uint32_t y = worker_range_2x2.start_coord.y; y <= worker_range_2x2.end_coord.y; ++y) {
+        for (uint32_t x = worker_range_2x2.start_coord.x; x <= worker_range_2x2.end_coord.x; ++x) {
+            worker_cores.push_back({x, y});
         }
     }
+    helper.add_packed_write(worker_cores, 12);
+    helper.add_packed_write(worker_cores, 12, true);
+    worker_cores.clear();
+    worker_cores.push_back(first_worker_2x2);
+    worker_cores.push_back(last_worker_2x2);
+    helper.add_packed_write(worker_cores, 156);
+
+    // Section 6: Linear read -> Linear write test
+    // Note: this test is dependent on already written data in L1
+    // So it reads the above data from prior commands and needs to run after those
+    helper.add_linear_read(worker_range, 32);
+    helper.add_linear_read(worker_range, 65 * 1024);
+    helper.add_linear_read(worker_range, dispatch_buffer_page_size_ - sizeof(CQDispatchCmdLarge));
+    helper.add_linear_read(worker_range, (2 * dispatch_buffer_page_size_) - sizeof(CQDispatchCmdLarge));
+    helper.add_linear_read(worker_range, (2 * dispatch_buffer_page_size_));
+    // Skipping CQ_DISPATCH_CMD_DELAY from the legacy test here
+    helper.add_unicast_write(worker_range, 1024);
+    // Barrier/stall to avoid RAW hazards
+    HostMemDeviceCommand stall_cmd = CommandBuilder::build_dispatch_prefetch_stall();
+    commands_per_iteration.push_back(std::move(stall_cmd));
+    uint32_t length_bytes = 32;
+    uint32_t offset_words = device_data.size_at(worker_range.start_coord, 0) - (length_bytes / sizeof(uint32_t));
+    uint32_t offset_bytes = offset_words * sizeof(uint32_t);
+    helper.add_linear_read(worker_range, length_bytes, offset_bytes);
+
+    // Section 7: Write offset
+    // Simple Smoke test: do a change write_offset_idx to 48 and back to 0
+    std::array<uint32_t, CQ_DISPATCH_MAX_WRITE_OFFSETS> write_offset1 = {48, 0, 0, 0};
+    std::array<uint32_t, CQ_DISPATCH_MAX_WRITE_OFFSETS> write_offset2 = {};
+    HostMemDeviceCommand write_offset_cmd1 = CommandBuilder::build_dispatch_write_offset(write_offset1);
+    HostMemDeviceCommand write_offset_cmd2 = CommandBuilder::build_dispatch_write_offset(write_offset2);
+    commands_per_iteration.push_back(std::move(write_offset_cmd1));
+    commands_per_iteration.push_back(std::move(write_offset_cmd2));
+
+    // Execute
+    execute_generated_commands(commands_per_iteration, device_data, worker_range.size(), num_iterations);
 }
 
-void gen_prefetcher_cmds(
-    IDevice* device,
-    vector<uint32_t>& prefetch_cmds,
-    vector<uint32_t>& cmd_sizes,
-    DeviceData& device_data,
-    uint32_t dst_addr) {
-    switch (test_type_g) {
-        case 0:
-            // No cmds, tests terminating - true smoke test
-            break;
-        case 1:
-            gen_smoke_test(device, prefetch_cmds, cmd_sizes, device_data, first_worker_g, all_workers_g.end_coord);
-            break;
-        case 2: gen_rnd_test(device, prefetch_cmds, cmd_sizes, device_data); break;
-        case 3: gen_pcie_test(device, prefetch_cmds, cmd_sizes, device_data, first_worker_g); break;
-        case 4: gen_paged_read_dram_test(device, prefetch_cmds, cmd_sizes, device_data, first_worker_g); break;
-        case 5:
-            gen_paged_write_read_dram_test(device, prefetch_cmds, cmd_sizes, device_data, first_worker_g, dst_addr);
-            break;
-        case 6: gen_host_test(device, prefetch_cmds, cmd_sizes, device_data); break;
-        case 7: gen_packed_read_test(device, prefetch_cmds, cmd_sizes, device_data); break;
-        case 8: gen_ringbuffer_read_test(device, prefetch_cmds, cmd_sizes, device_data); break;
-        case 9: gen_relay_linear_h_test(device, prefetch_cmds, cmd_sizes, device_data); break;
-        default:
-            log_fatal(tt::LogTest, "Unknown test: {}", test_type_g);
-            exit(0);
-            break;
+// Smoke test for writes to Host from dispatcher
+// This needed to be separate since it executes differently than others
+// (we skip distributed::Finish)
+TEST_P(PrefetcherSmokeTestFixture, HostSmokeTest) {
+    log_info(tt::LogTest, "PrefetcherSmokeTestFixture - HostSmokeTest - Test Start");
+
+    const uint32_t num_iterations = get_num_iterations();
+    const uint32_t dram_data_size_words = get_dram_data_size_words();
+
+    // Setup target worker cores
+    const CoreCoord first_worker = default_worker_start;
+    const CoreCoord last_worker = {first_worker.x + 1, first_worker.y + 1};
+    const CoreRange worker_range = {first_worker, last_worker};
+
+    const uint32_t l1_base = device_->allocator()->get_base_allocator_addr(HalMemType::L1);
+
+    // Get completion queue buffer pointer
+    void* completion_queue_buffer = mgr_->get_completion_queue_ptr(fdcq_->id());
+    uint32_t completion_queue_size = mgr_->get_completion_queue_size(fdcq_->id());
+    // Pre-fill with dirty pattern:
+    // The dispatcher writes commands and data but doesn't overwrite padding regions
+    // Pre-filling ensures padding areas retain the sentinel value for validation
+    dirty_host_completion_buffer(completion_queue_buffer, completion_queue_size);
+
+    DeviceData device_data(
+        device_, worker_range, l1_base, dram_base_, completion_queue_buffer, false, dram_data_size_words, cfg_);
+
+    std::vector<HostMemDeviceCommand> commands_per_iteration;
+
+    HelperInfo info{
+        dram_base_, num_banks_, l1_alignment_, packed_write_max_unicast_sub_cmds_, dispatch_buffer_page_size_};
+    // Instantiate Helper
+    SmokeTestHelper helper(device_, device_data, commands_per_iteration, info);
+
+    // device_data.reset();
+    auto add_host_write_func = [this](DeviceData& device_data) {
+        return PrefecherHostTextFixture::pad_host_data(device_data);
+    };
+
+    for (uint32_t multiplier = 1; multiplier < 3; multiplier++) {
+        helper.add_host_write(multiplier * 32, add_host_write_func);
+        helper.add_host_write(multiplier * 36, add_host_write_func);
+        helper.add_host_write(multiplier * 1024, add_host_write_func);
+        helper.add_host_write(
+            (multiplier * dispatch_buffer_page_size_) - (2 * sizeof(CQDispatchCmd)), add_host_write_func);
+        helper.add_host_write((multiplier * dispatch_buffer_page_size_) - sizeof(CQDispatchCmd), add_host_write_func);
+        helper.add_host_write((multiplier * dispatch_buffer_page_size_), add_host_write_func);
+        helper.add_host_write((multiplier * dispatch_buffer_page_size_) + sizeof(CQDispatchCmd), add_host_write_func);
     }
 
-    device_data.overflow_check(device);
+    // Skip distributed::Finish since we are manually writing into the completion queue
+    // which Finish doesn't expect
+    bool wait_for_completion = false;
+    // For host writes, we need to wait for all writes to be written into the completion queue
+    bool wait_for_host_writes = true;
+    execute_generated_commands(
+        commands_per_iteration,
+        device_data,
+        worker_range.size(),
+        num_iterations,
+        wait_for_completion,
+        wait_for_host_writes);
 }
 
-void gen_terminate_cmds(vector<uint32_t>& prefetch_cmds, vector<uint32_t>& cmd_sizes) {
-    vector<uint32_t> empty_payload;  // don't give me grief, it is just a test
-    vector<uint32_t> dispatch_cmds;
-
-    // Terminate dispatcher
-    dispatch_cmds.resize(0);
-    gen_dispatcher_terminate_cmd(dispatch_cmds);
-    add_prefetcher_cmd(prefetch_cmds, cmd_sizes, CQ_PREFETCH_CMD_RELAY_INLINE, dispatch_cmds);
-
-    // Terminate prefetcher
-    add_prefetcher_cmd(prefetch_cmds, cmd_sizes, CQ_PREFETCH_CMD_TERMINATE, empty_payload);
-}
-
-// Ideally would work by cachelines, but the min size is less than that
-void nt_memcpy(uint8_t* __restrict dst, const uint8_t* __restrict src, size_t n) {
-    size_t num_lines = n / CQ_PREFETCH_CMD_BARE_MIN_SIZE;
-
-    size_t i;
-    for (i = 0; i < num_lines; i++) {
-        size_t j;
-        for (j = 0; j < CQ_PREFETCH_CMD_BARE_MIN_SIZE / sizeof(__m128i); j++) {
-            // __m128i blk = _mm_stream_load_si128((__m128i *)src);
-            __m128i blk = _mm_loadu_si128((const __m128i*)src);
-            /* non-temporal store */
-            _mm_stream_si128((__m128i*)dst, blk);
-            src += sizeof(__m128i);
-            dst += sizeof(__m128i);
-        }
-        n -= CQ_PREFETCH_CMD_BARE_MIN_SIZE;
-    }
-
-    if (num_lines > 0) {
-        tt_driver_atomics::sfence();
-    }
-}
-
-void write_prefetcher_cmd(
-    IDevice* device,
-    vector<uint32_t>& cmds,
-    uint32_t& cmd_offset,
-    DispatchSettings::prefetch_q_entry_type cmd_size16b,
-    uint32_t*& host_mem_ptr,
-    uint32_t& prefetch_q_dev_ptr,
-    uint32_t& prefetch_q_dev_fence,
-    uint32_t prefetch_q_base,
-    uint32_t prefetch_q_rd_ptr_addr,
-    CoreCoord phys_prefetch_core,
-    umd::Writer& prefetch_q_writer) {
-    static vector<uint32_t> read_vec;  // static to avoid realloc
-
-    // wait for space
-    while (prefetch_q_dev_ptr == prefetch_q_dev_fence) {
-        tt::tt_metal::MetalContext::instance().get_cluster().read_core(
-            read_vec, sizeof(uint32_t), tt_cxy_pair(device->id(), phys_prefetch_core), prefetch_q_rd_ptr_addr);
-        prefetch_q_dev_fence = read_vec[0];
-    }
-
-    // wrap
-    if (prefetch_q_dev_ptr ==
-        prefetch_q_base + prefetch_q_entries_g * sizeof(DispatchSettings::prefetch_q_entry_type)) {
-        prefetch_q_dev_ptr = prefetch_q_base;
-
-        while (prefetch_q_dev_ptr == prefetch_q_dev_fence) {
-            tt::tt_metal::MetalContext::instance().get_cluster().read_core(
-                read_vec, sizeof(uint32_t), tt_cxy_pair(device->id(), phys_prefetch_core), prefetch_q_rd_ptr_addr);
-            prefetch_q_dev_fence = read_vec[0];
-        }
-    }
-
-    constexpr uint32_t prefetch_q_msb_mask = (1 << ((sizeof(DispatchSettings::prefetch_q_entry_type) * 8) - 1));
-    uint32_t cmd_size_bytes = (cmd_size16b & ~prefetch_q_msb_mask) << DispatchSettings::PREFETCH_Q_LOG_MINSIZE;
-    uint32_t cmd_size_words = cmd_size_bytes / sizeof(uint32_t);
-
-    nt_memcpy((uint8_t*)host_mem_ptr, (uint8_t*)&cmds[cmd_offset], cmd_size_bytes);
-    cmd_offset += cmd_size_words;
-    host_mem_ptr += cmd_size_words;
-    uint32_t pcie_alignment = MetalContext::instance().hal().get_alignment(HalMemType::HOST);
-    uintptr_t int_host_ptr = reinterpret_cast<uintptr_t>(host_mem_ptr);
-    if (tt::align(int_host_ptr, pcie_alignment) != int_host_ptr) {
-        auto prev_cmd_offset = cmd_offset - cmd_size_words;
-        auto prev_cmd = reinterpret_cast<CQPrefetchCmd&>(cmds[prev_cmd_offset]);
-        auto prev_cmd_id = prev_cmd.base.cmd_id;
-        fmt::println(
-            "PCIE unaligned increment into host hugepage, last command:{}, last size:{}, new ptr:{:#X}",
-            prev_cmd_id,
-            cmd_size_words,
-            int_host_ptr);
-        assert(0);
-    }
-
-    // This updates FetchQ where each entry of type prefetch_q_entry_type is size in 16B.
-    prefetch_q_writer.write(prefetch_q_dev_ptr, cmd_size16b);
-
-    prefetch_q_dev_ptr += sizeof(DispatchSettings::prefetch_q_entry_type);
-}
-
-void write_prefetcher_cmds(
-    uint32_t iterations,
-    IDevice* device,
-    vector<uint32_t> prefetch_cmds,  // yes copy for dram_exec_buf
-    vector<uint32_t>& cmd_sizes,
-    void* host_hugepage_base,
-    uint32_t dev_hugepage_base,
-    uint32_t prefetch_q_base,
-    uint32_t prefetch_q_rd_ptr_addr,
-    CoreCoord phys_prefetch_core,
-    umd::Writer& prefetch_q_writer,
-    bool is_control_only) {
-    static uint32_t* host_mem_ptr;
-    static uint32_t prefetch_q_dev_ptr;
-    static uint32_t prefetch_q_dev_fence;
-
-    if (!is_control_only && use_dram_exec_buf_g) {
-        // Write cmds to DRAM, generate a new command to execute those commands
-        cmd_sizes.resize(0);
-        vector<uint32_t> exec_buf_cmds = prefetch_cmds;
-        prefetch_cmds.resize(0);
-        gen_prefetcher_exec_buf_cmd_and_write_to_dram(device, prefetch_cmds, exec_buf_cmds, cmd_sizes);
-    }
-
-    if (initialize_device_g) {
-        vector<uint32_t> prefetch_q(DEFAULT_PREFETCH_Q_ENTRIES, 0);
-        vector<uint32_t> prefetch_q_rd_ptr_addr_data;
-
-        prefetch_q_rd_ptr_addr_data.push_back(
-            prefetch_q_base + (prefetch_q_entries_g * sizeof(DispatchSettings::prefetch_q_entry_type)));
-        tt::tt_metal::MetalContext::instance().get_cluster().write_core(
-            device->id(), phys_prefetch_core, prefetch_q_rd_ptr_addr_data, prefetch_q_rd_ptr_addr);
-        tt::tt_metal::MetalContext::instance().get_cluster().write_core(
-            device->id(), phys_prefetch_core, prefetch_q, prefetch_q_base);
-
-        host_mem_ptr = (uint32_t*)host_hugepage_base;
-        prefetch_q_dev_ptr = prefetch_q_base;
-        prefetch_q_dev_fence =
-            prefetch_q_base + prefetch_q_entries_g * sizeof(DispatchSettings::prefetch_q_entry_type);
-        initialize_device_g = false;
-    }
-
-    for (uint32_t i = 0; i < iterations; i++) {
-        uint32_t cmd_ptr = 0;
-        for (uint32_t j = 0; j < cmd_sizes.size(); j++) {
-            uint32_t cmd_size_words =
-                ((uint32_t)cmd_sizes[j] << DispatchSettings::PREFETCH_Q_LOG_MINSIZE) / sizeof(uint32_t);
-            if ((void*)(host_mem_ptr + cmd_size_words) >
-                (void*)((uint8_t*)host_hugepage_base + hugepage_issue_buffer_size_g)) {
-                // Wrap huge page
-                host_mem_ptr = (uint32_t*)host_hugepage_base;
-            }
-
-            write_prefetcher_cmd(
-                device,
-                prefetch_cmds,
-                cmd_ptr,
-                cmd_sizes[j],
-                host_mem_ptr,
-                prefetch_q_dev_ptr,
-                prefetch_q_dev_fence,
-                prefetch_q_base,
-                prefetch_q_rd_ptr_addr,
-                phys_prefetch_core,
-                prefetch_q_writer);
-        }
-    }
-}
-
-// Clear DRAM (helpful for paged write to DRAM debug to have a fresh slate)
-void initialize_dram_banks(IDevice* device) {
-    auto num_banks = device->allocator()->get_num_banks(BufferType::DRAM);
-    auto bank_size = DRAM_DATA_SIZE_WORDS * sizeof(uint32_t);  // device->allocator()->get_bank_size(BufferType::DRAM);
-    auto fill = std::vector<uint32_t>(bank_size / sizeof(uint32_t), 0xBADDF00D);
-
-    for (int bank_id = 0; bank_id < num_banks; bank_id++) {
-        log_info(tt::LogTest, "Initializing DRAM {} bytes for bank_id: {}", bank_size, bank_id);
-        tt::tt_metal::detail::WriteToDeviceDRAMChannel(device, bank_id, 0, fill);
-    }
-}
-
-std::chrono::duration<double> run_test(
-    uint32_t iterations,
-    IDevice* device,
-    Program& program,
-    IDevice* device_r,
-    Program& program_r,
-    vector<uint32_t>& cmd_sizes,
-    vector<uint32_t>& terminate_sizes,
-    vector<uint32_t>& cmds,
-    vector<uint32_t>& terminate_cmds,
-    void* host_hugepage_base,
-    uint32_t dev_hugepage_base,
-    uint32_t prefetch_q_base,
-    uint32_t prefetch_q_rd_ptr_addr,
-    CoreCoord phys_prefetch_core,
-    umd::Writer& prefetch_q_writer) {
-    auto start = std::chrono::system_clock::now();
-
-    std::thread t1([&]() {
-        write_prefetcher_cmds(
-            iterations,
-            device,
-            cmds,
-            cmd_sizes,
-            host_hugepage_base,
-            dev_hugepage_base,
-            prefetch_q_base,
-            prefetch_q_rd_ptr_addr,
-            phys_prefetch_core,
-            prefetch_q_writer,
-            false);
-        write_prefetcher_cmds(
-            1,
-            device,
-            terminate_cmds,
-            terminate_sizes,
-            host_hugepage_base,
-            dev_hugepage_base,
-            prefetch_q_base,
-            prefetch_q_rd_ptr_addr,
-            phys_prefetch_core,
-            prefetch_q_writer,
-            true);
+// All BasePrefetcherTestFixture tests with exec buff enabled / disabled
+INSTANTIATE_TEST_SUITE_P(
+    PrefetcherTests,
+    BasePrefetcherTestFixture,
+    ::testing::Values(
+        // With exec buf disabled
+        PagedReadParams{
+            DRAM_PAGE_SIZE_DEFAULT, DRAM_PAGES_TO_READ_DEFAULT, DEFAULT_ITERATIONS, DRAM_DATA_SIZE_WORDS, false},
+        // With exec buf enabled
+        PagedReadParams{
+            DRAM_PAGE_SIZE_DEFAULT, DRAM_PAGES_TO_READ_DEFAULT, DEFAULT_ITERATIONS, DRAM_DATA_SIZE_WORDS, true}),
+    [](const testing::TestParamInfo<PagedReadParams>& info) {
+        return std::to_string(info.param.page_size) + "B_" + std::to_string(info.param.num_pages) + "pages_" +
+               std::to_string(info.param.num_iterations) + "iter_" + std::to_string(info.param.dram_data_size_words) +
+               "words_" + (info.param.use_exec_buf ? "use_exec_buf_enabled" : "use_exec_buf_disabled");
     });
-    tt_metal::detail::LaunchProgram(device, program, false);
-    tt_metal::detail::WaitProgramDone(device, program);
-    t1.join();
 
-    auto end = std::chrono::system_clock::now();
-
-    return end - start;
-}
-
-void configure_for_single_chip(
-    IDevice* device,
-    Program& program,
-    void*& host_hugepage_base,
-    uint32_t prefetch_q_base,
-    uint32_t prefetch_q_rd_ptr_addr,
-    uint32_t dev_hugepage_base_g) {
-    uint32_t dispatch_buffer_pages =
-        MetalContext::instance().dispatch_mem_map(DISPATCH_CORE_TYPE).dispatch_buffer_block_size_pages() *
-        DispatchSettings::DISPATCH_BUFFER_SIZE_BLOCKS;
-    uint32_t num_compute_cores =
-        device->compute_with_storage_grid_size().x * device->compute_with_storage_grid_size().y;
-
-    CoreCoord prefetch_core = {0, 0};
-    CoreCoord prefetch_d_core = {3, 0};
-    CoreCoord dispatch_core = {4, 0};
-    CoreCoord dispatch_h_core = {7, 0};
-
-    phys_prefetch_core_g = device->worker_core_from_logical_core(prefetch_core);
-    CoreCoord phys_prefetch_d_core = device->worker_core_from_logical_core(prefetch_d_core);
-    CoreCoord phys_dispatch_core = device->worker_core_from_logical_core(dispatch_core);
-    CoreCoord phys_dispatch_h_core = device->worker_core_from_logical_core(dispatch_h_core);
-
-    uint32_t l1_unreserved_base = device->allocator()->get_base_allocator_addr(HalMemType::L1);
-
-    // Want different buffers on each core, instead use big buffer and self-manage it
-    uint32_t l1_unreserved_base_aligned = tt::align(
-        l1_unreserved_base,
-        (1 << DispatchSettings::DISPATCH_BUFFER_LOG_PAGE_SIZE));  // Was not aligned, lately.
-    TT_ASSERT((l1_buf_base_g & ((1 << DispatchSettings::DISPATCH_BUFFER_LOG_PAGE_SIZE) - 1)) == 0);
-
-    uint32_t dispatch_buffer_base = l1_buf_base_g;
-    uint32_t prefetch_d_buffer_base = l1_buf_base_g;
-    uint32_t prefetch_d_buffer_pages = prefetch_d_buffer_size_g >> DispatchSettings::PREFETCH_D_BUFFER_LOG_PAGE_SIZE;
-    dispatch_wait_addr_g = l1_unreserved_base_aligned + MetalContext::instance().hal().get_alignment(HalMemType::L1);
-    vector<uint32_t> zero_data(0);
-    tt::tt_metal::MetalContext::instance().get_cluster().write_core(
-        device->id(), phys_dispatch_core, zero_data, dispatch_wait_addr_g);
-
-    uint32_t prefetch_q_size = prefetch_q_entries_g * sizeof(DispatchSettings::prefetch_q_entry_type);
-    uint32_t noc_read_alignment = MetalContext::instance().hal().get_alignment(HalMemType::HOST);
-    uint32_t cmddat_q_base =
-        prefetch_q_base + ((prefetch_q_size + noc_read_alignment - 1) / noc_read_alignment * noc_read_alignment);
-
-    // Implementation syncs w/ device on prefetch_q but not on hugepage, ie, assumes we can't run
-    // so far ahead in the hugepage that we overright un-read commands since we'll first
-    // stall on the prefetch_q
-    TT_ASSERT(
-        hugepage_issue_buffer_size_g > prefetch_q_entries_g * max_prefetch_command_size_g,
-        "Shrink the max command size or grow the hugepage buffer size or shrink the prefetch_q size");
-    TT_ASSERT(cmddat_q_size_g >= 2 * max_prefetch_command_size_g);
-
-    // NOTE: this test hijacks hugepage
-    ChipId mmio_device_id =
-        tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(device->id());
-    uint16_t channel =
-        tt::tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(device->id());
-    host_hugepage_base =
-        (void*)tt::tt_metal::MetalContext::instance().get_cluster().host_dma_address(0, mmio_device_id, channel);
-    host_hugepage_base = (void*)((uint8_t*)host_hugepage_base + dev_hugepage_base_g);
-    host_hugepage_completion_buffer_base_g = (void*)((uint8_t*)host_hugepage_base + hugepage_issue_buffer_size_g);
-    uint32_t dev_hugepage_completion_buffer_base = dev_hugepage_base_g + hugepage_issue_buffer_size_g;
-    uint32_t* host_hugepage_completion_buffer = (uint32_t*)host_hugepage_completion_buffer_base_g;
-    vector<uint32_t> tmp = {dev_hugepage_completion_buffer_base >> 4};
-    CoreCoord phys_dispatch_host_core = split_dispatcher_g ? phys_dispatch_h_core : phys_dispatch_core;
-    uint32_t completion_q_wr_ptr = MetalContext::instance()
-                                       .dispatch_mem_map(DISPATCH_CORE_TYPE)
-                                       .get_device_command_queue_addr(CommandQueueDeviceAddrType::COMPLETION_Q_WR);
-    uint32_t completion_q_rd_ptr = MetalContext::instance()
-                                       .dispatch_mem_map(DISPATCH_CORE_TYPE)
-                                       .get_device_command_queue_addr(CommandQueueDeviceAddrType::COMPLETION_Q_RD);
-    tt::tt_metal::MetalContext::instance().get_cluster().write_core(
-        device->id(), phys_dispatch_host_core, tmp, completion_q_wr_ptr);
-    tt::tt_metal::MetalContext::instance().get_cluster().write_core(
-        device->id(), phys_dispatch_host_core, tmp, completion_q_rd_ptr);
-    dirty_host_completion_buffer(host_hugepage_completion_buffer);
-
-    const uint32_t prefetch_core_sem_0_id = tt_metal::CreateSemaphore(program, {prefetch_core}, 0);
-    const uint32_t prefetch_d_core_sem_0_id = tt_metal::CreateSemaphore(program, {prefetch_d_core}, 0);
-    TT_ASSERT(prefetch_core_sem_0_id == prefetch_d_core_sem_0_id);
-    const uint32_t prefetch_sync_sem = prefetch_core_sem_0_id;
-
-    const uint32_t prefetch_downstream_buffer_pages =
-        split_prefetcher_g ? prefetch_d_buffer_pages : dispatch_buffer_pages;
-    const uint32_t prefetch_core_sem_1_id =
-        tt_metal::CreateSemaphore(program, {prefetch_core}, prefetch_downstream_buffer_pages);
-    const uint32_t prefetch_downstream_cb_sem = prefetch_core_sem_1_id;
-
-    const uint32_t prefetch_d_core_sem_1_id = tt_metal::CreateSemaphore(program, {prefetch_d_core}, 0);
-    const uint32_t prefetch_d_core_sem_2_id =
-        tt_metal::CreateSemaphore(program, {prefetch_d_core}, dispatch_buffer_pages);
-    const uint32_t prefetch_d_upstream_cb_sem = prefetch_d_core_sem_1_id;
-    const uint32_t prefetch_d_downstream_cb_sem = prefetch_d_core_sem_2_id;
-
-    tt_metal::CreateSemaphore(program, {dispatch_core}, 0);
-
-    const uint32_t dispatch_core_sem_1_id = tt_metal::CreateSemaphore(program, {dispatch_core}, 0);  // 1
-    const uint32_t dispatch_cb_sem = dispatch_core_sem_1_id;
-
-    const uint32_t dispatch_core_sem_2_id = tt_metal::CreateSemaphore(program, {dispatch_core}, dispatch_buffer_pages);
-    const uint32_t dispatch_downstream_cb_sem = dispatch_core_sem_2_id;
-
-    const uint32_t dispatch_h_core_sem_0_id = tt_metal::CreateSemaphore(program, {dispatch_h_core}, 0);
-    const uint32_t dispatch_h_cb_sem = dispatch_h_core_sem_0_id;
-
-    std::map<std::string, std::string> prefetch_defines = {
-        {"DOWNSTREAM_CB_BASE", std::to_string(dispatch_buffer_base)},  // overridden below for prefetch_h
-        {"DOWNSTREAM_CB_LOG_PAGE_SIZE",
-         std::to_string(DispatchSettings::DISPATCH_BUFFER_LOG_PAGE_SIZE)},        // overridden below for prefetch_h
-        {"DOWNSTREAM_CB_PAGES", std::to_string(dispatch_buffer_pages)},           // overridden below for prefetch_h
-        {"MY_DOWNSTREAM_CB_SEM_ID", std::to_string(prefetch_downstream_cb_sem)},  // overridden below for prefetch_d
-        {"DOWNSTREAM_CB_SEM_ID", std::to_string(dispatch_cb_sem)},                // overridden below for prefetch_h
-        {"PCIE_BASE", std::to_string(dev_hugepage_base_g)},
-        {"PCIE_SIZE", std::to_string(hugepage_issue_buffer_size_g)},
-        {"PREFETCH_Q_BASE", std::to_string(prefetch_q_base)},
-        {"PREFETCH_Q_SIZE",
-         std::to_string(prefetch_q_entries_g * (uint32_t)sizeof(DispatchSettings::prefetch_q_entry_type))},
-        {"PREFETCH_Q_RD_PTR_ADDR", std::to_string(prefetch_q_rd_ptr_addr)},
-        {"PREFETCH_Q_PCIE_RD_PTR_ADDR", std::to_string(prefetch_q_rd_ptr_addr + sizeof(uint32_t))},
-        {"CMDDAT_Q_BASE", std::to_string(cmddat_q_base)},    // overridden for split below
-        {"CMDDAT_Q_SIZE", std::to_string(cmddat_q_size_g)},  // overridden for split below
-        {"SCRATCH_DB_BASE", std::to_string(0)},              // scratch_db_base filled in below if used
-        {"SCRATCH_DB_SIZE", std::to_string(scratch_db_size_g)},
-        {"DOWNSTREAM_SYNC_SEM_ID", std::to_string(prefetch_sync_sem)},
-        {"CMDDAT_Q_PAGES", std::to_string(prefetch_d_buffer_pages)},            // prefetch_d only
-        {"MY_UPSTREAM_CB_SEM_ID", std::to_string(prefetch_d_upstream_cb_sem)},  // prefetch_d only
-        {"UPSTREAM_CB_SEM_ID", std::to_string(prefetch_downstream_cb_sem)},     // prefetch_d only
-        {"CMDDAT_Q_LOG_PAGE_SIZE", std::to_string(DispatchSettings::PREFETCH_D_BUFFER_LOG_PAGE_SIZE)},
-        {"CMDDAT_Q_BLOCKS", std::to_string(DispatchSettings::PREFETCH_D_BUFFER_BLOCKS)},  // prefetch_d only
-        {"DISPATCH_S_BUFFER_BASE", std::to_string(0)},           // unused: for prefetch_hd <--> dispatch_hd
-        {"MY_DISPATCH_S_CB_SEM_ID", std::to_string(0)},          // unused: for prefetch_hd <--> dispatch_hd
-        {"DOWNSTREAM_DISPATCH_S_CB_SEM_ID", std::to_string(0)},  // unused: for prefetch_hd <--> dispatch_hd
-        {"DISPATCH_S_BUFFER_SIZE", std::to_string(0)},           // unused: for prefetch_hd <--> dispatch_hd
-        {"DISPATCH_S_CB_LOG_PAGE_SIZE", std::to_string(0)},      // unused: for prefetch_hd <--> dispatch_hd
-        {"RINGBUFFER_SIZE", std::to_string(scratch_db_size_g)},
-        // Fabric configuration - set to 0
-        {"FABRIC_HEADER_RB_BASE", std::to_string(0)},
-        {"FABRIC_HEADER_RB_ENTRIES", std::to_string(0)},
-        {"MY_FABRIC_SYNC_STATUS_ADDR", std::to_string(0)},
-
-        {"FABRIC_MUX_X", std::to_string(0)},
-        {"FABRIC_MUX_Y", std::to_string(0)},
-        {"FABRIC_MUX_NUM_BUFFERS_PER_CHANNEL", std::to_string(0)},
-        {"FABRIC_MUX_CHANNEL_BUFFER_SIZE_BYTES", std::to_string(0)},
-        {"FABRIC_MUX_CHANNEL_BASE_ADDRESS", std::to_string(0)},
-        {"FABRIC_MUX_CONNECTION_INFO_ADDRESS", std::to_string(0)},
-        {"FABRIC_MUX_CONNECTION_HANDSHAKE_ADDRESS", std::to_string(0)},
-        {"FABRIC_MUX_FLOW_CONTROL_ADDRESS", std::to_string(0)},
-        {"FABRIC_MUX_BUFFER_INDEX_ADDRESS", std::to_string(0)},
-        {"FABRIC_MUX_STATUS_ADDRESS", std::to_string(0)},
-        {"FABRIC_MUX_TERMINATION_SIGNAL_ADDRESS", std::to_string(0)},
-        {"WORKER_CREDITS_STREAM_ID", std::to_string(0)},
-
-        {"FABRIC_WORKER_FLOW_CONTROL_SEM", std::to_string(0)},
-        {"FABRIC_WORKER_TEARDOWN_SEM", std::to_string(0)},
-        {"FABRIC_WORKER_BUFFER_INDEX_SEM", std::to_string(0)},
-
-        {"NUM_HOPS", std::to_string(0)},
-
-        {"EW_DIM", std::to_string(0)},
-        {"TO_MESH_ID", std::to_string(0)},
-    };
-
-    // Initialize runtime args offsets
-    int rta_offset = 0;
-    uint32_t offsetof_my_dev_id = rta_offset++;
-    uint32_t offsetof_to_dev_id = rta_offset++;
-    uint32_t offsetof_router_direction = rta_offset++;
-    std::vector<uint32_t> runtime_args(rta_offset);
-
-    prefetch_defines["OFFSETOF_MY_DEV_ID"] = std::to_string(offsetof_my_dev_id);
-    prefetch_defines["OFFSETOF_TO_DEV_ID"] = std::to_string(offsetof_to_dev_id);
-    prefetch_defines["OFFSETOF_ROUTER_DIRECTION"] = std::to_string(offsetof_router_direction);
-
-    // Initialize runtime args
-    runtime_args[offsetof_my_dev_id] = 0;
-    runtime_args[offsetof_to_dev_id] = 0;
-    runtime_args[offsetof_router_direction] = 0;
-
-    constexpr NOC my_noc_index = NOC::NOC_0;
-    constexpr NOC dispatch_upstream_noc_index = NOC::NOC_1;
-
-    KernelHandle kernel_handle;
-    if (split_prefetcher_g) {
-        log_info(LogTest, "split prefetcher test");
-
-        // prefetch_d
-        uint32_t scratch_db_base =
-            prefetch_d_buffer_base + (((prefetch_d_buffer_pages << DispatchSettings::PREFETCH_D_BUFFER_LOG_PAGE_SIZE) +
-                                       noc_read_alignment - 1) /
-                                      noc_read_alignment * noc_read_alignment);
-        TT_ASSERT(scratch_db_base < 1024 * 1024);  // L1 size
-
-        prefetch_defines["MY_DOWNSTREAM_CB_SEM_ID"] = std::to_string(prefetch_d_downstream_cb_sem);
-        prefetch_defines["CMDDAT_Q_BASE"] = std::to_string(prefetch_d_buffer_base);
-        prefetch_defines["CMDDAT_Q_SIZE"] =
-            std::to_string(prefetch_d_buffer_pages * (1 << DispatchSettings::PREFETCH_D_BUFFER_LOG_PAGE_SIZE));
-        prefetch_defines["SCRATCH_DB_BASE"] = std::to_string(scratch_db_base);
-        CoreCoord phys_prefetch_d_upstream_core = phys_prefetch_core_g;
-        kernel_handle = configure_kernel_variant<true, false>(
-            program,
-            "tt_metal/impl/dispatch/kernels/cq_prefetch.cpp",
-            prefetch_defines,
-            {},
-            prefetch_d_core,
-            phys_prefetch_d_core,
-            phys_prefetch_d_upstream_core,
-            phys_dispatch_core,
-            device,
-            my_noc_index,
-            my_noc_index,
-            my_noc_index);
-
-        tt_metal::SetRuntimeArgs(program, kernel_handle, prefetch_d_core, runtime_args);
-
-        // prefetch_h
-        prefetch_defines["DOWNSTREAM_CB_BASE"] = std::to_string(prefetch_d_buffer_base);
-        prefetch_defines["DOWNSTREAM_CB_LOG_PAGE_SIZE"] =
-            std::to_string(DispatchSettings::PREFETCH_D_BUFFER_LOG_PAGE_SIZE);
-        prefetch_defines["DOWNSTREAM_CB_PAGES"] = std::to_string(prefetch_d_buffer_pages);
-        prefetch_defines["MY_DOWNSTREAM_CB_SEM_ID"] = std::to_string(prefetch_downstream_cb_sem);
-        prefetch_defines["DOWNSTREAM_CB_SEM_ID"] = std::to_string(prefetch_d_upstream_cb_sem);
-        prefetch_defines["CMDDAT_Q_BASE"] = std::to_string(cmddat_q_base);
-        prefetch_defines["CMDDAT_Q_SIZE"] = std::to_string(cmddat_q_size_g);
-        prefetch_defines["SCRATCH_DB_BASE"] = std::to_string(scratch_db_base);
-        CoreCoord phys_prefetch_h_downstream_core = phys_prefetch_d_core;
-        kernel_handle = configure_kernel_variant<false, true>(
-            program,
-            "tt_metal/impl/dispatch/kernels/cq_prefetch.cpp",
-            prefetch_defines,
-            {},
-            prefetch_core,
-            phys_prefetch_core_g,
-            {0xffffffff, 0xffffffff},  // upstream core unused
-            phys_prefetch_h_downstream_core,
-            device,
-            my_noc_index,
-            my_noc_index,
-            my_noc_index);
-
-        tt_metal::SetRuntimeArgs(program, kernel_handle, prefetch_core, runtime_args);
-    } else {
-        uint32_t scratch_db_base =
-            cmddat_q_base + ((cmddat_q_size_g + noc_read_alignment - 1) / noc_read_alignment * noc_read_alignment);
-        TT_ASSERT(scratch_db_base < 1024 * 1024);  // L1 size
-        prefetch_defines["SCRATCH_DB_BASE"] = std::to_string(scratch_db_base);
-
-        kernel_handle = configure_kernel_variant<true, true>(
-            program,
-            "tt_metal/impl/dispatch/kernels/cq_prefetch.cpp",
-            prefetch_defines,
-            {},
-            prefetch_core,
-            phys_prefetch_core_g,
-            {0xffffffff, 0xffffffff},  // upstream core unused
-            phys_dispatch_core,
-            device,
-            my_noc_index,
-            my_noc_index,
-            my_noc_index);
-
-        tt_metal::SetRuntimeArgs(program, kernel_handle, prefetch_core, runtime_args);
-    }
-
-    uint32_t host_completion_queue_wr_ptr = MetalContext::instance()
-                                                .dispatch_mem_map(DISPATCH_CORE_TYPE)
-                                                .get_host_command_queue_addr(CommandQueueHostAddrType::COMPLETION_Q_WR);
-    uint32_t dev_completion_queue_wr_ptr =
-        MetalContext::instance()
-            .dispatch_mem_map(DISPATCH_CORE_TYPE)
-            .get_device_command_queue_addr(CommandQueueDeviceAddrType::COMPLETION_Q_WR);
-    uint32_t dev_completion_queue_rd_ptr =
-        MetalContext::instance()
-            .dispatch_mem_map(DISPATCH_CORE_TYPE)
-            .get_device_command_queue_addr(CommandQueueDeviceAddrType::COMPLETION_Q_RD);
-
-    std::map<std::string, std::string> dispatch_defines = {
-        {"DISPATCH_CB_BASE", std::to_string(dispatch_buffer_base)},
-        {"DISPATCH_CB_LOG_PAGE_SIZE", std::to_string(DispatchSettings::DISPATCH_BUFFER_LOG_PAGE_SIZE)},
-        {"DISPATCH_CB_PAGES",
-         std::to_string(
-             DispatchSettings::DISPATCH_BUFFER_SIZE_BLOCKS *
-             MetalContext::instance().dispatch_mem_map(DISPATCH_CORE_TYPE).dispatch_buffer_block_size_pages())},
-        {"MY_DISPATCH_CB_SEM_ID", std::to_string(dispatch_cb_sem)},  // will be overridden for variants
-        {"UPSTREAM_DISPATCH_CB_SEM_ID",
-         std::to_string(
-             split_prefetcher_g ? prefetch_d_downstream_cb_sem
-                                : prefetch_downstream_cb_sem)},  // will be overridden for variants
-        {"DISPATCH_CB_BLOCKS", std::to_string(DispatchSettings::DISPATCH_BUFFER_SIZE_BLOCKS)},
-        {"UPSTREAM_SYNC_SEM", std::to_string(prefetch_sync_sem)},
-        {"COMMAND_QUEUE_BASE_ADDR", "0"},  // true base of hugepage
-        {"COMPLETION_QUEUE_BASE_ADDR", std::to_string(dev_hugepage_completion_buffer_base)},
-        {"COMPLETION_QUEUE_SIZE", std::to_string(DEFAULT_HUGEPAGE_COMPLETION_BUFFER_SIZE)},
-        {"DOWNSTREAM_CB_BASE", std::to_string(dispatch_buffer_base)},
-        {"DOWNSTREAM_CB_SIZE",
-         std::to_string((1 << DispatchSettings::DISPATCH_BUFFER_LOG_PAGE_SIZE) * dispatch_buffer_pages)},
-        {"MY_DOWNSTREAM_CB_SEM_ID", "0"},            // unused on hd, filled in below for h and d
-        {"DOWNSTREAM_CB_SEM_ID", "0"},               // unused on hd, filled in below for h and d
-        {"SPLIT_DISPATCH_PAGE_PREAMBLE_SIZE", "0"},  // unused unless tunneler is between h and d
-        {"SPLIT_PREFETCH", std::to_string(split_prefetcher_g)},
-        {"PREFETCH_H_NOC_XY",
-         std::to_string(tt::tt_metal::MetalContext::instance().hal().noc_xy_encoding(
-             phys_prefetch_core_g.x, phys_prefetch_core_g.y))},
-        {"PREFETCH_H_LOCAL_DOWNSTREAM_SEM_ADDR", std::to_string(prefetch_downstream_cb_sem)},
-        {"PREFETCH_H_MAX_CREDITS", std::to_string(prefetch_downstream_buffer_pages)},
-        {"PACKED_WRITE_MAX_UNICAST_SUB_CMDS", std::to_string(num_compute_cores)},  // max_write_packed_cores
-        {"DISPATCH_S_SYNC_SEM_BASE_ADDR", "0"},
-        {"MAX_NUM_WORKER_SEMS", std::to_string(DispatchSettings::DISPATCH_MESSAGE_ENTRIES)},
-        {"MAX_NUM_GO_SIGNAL_NOC_DATA_ENTRIES", std::to_string(DispatchSettings::DISPATCH_GO_SIGNAL_NOC_DATA_ENTRIES)},
-        {"MCAST_GO_SIGNAL_ADDR", "0"},
-        {"UNICAST_GO_SIGNAL_ADDR", "0"},
-        {"DISTRIBUTED_DISPATCHER", "0"},
-        {"HOST_COMPLETION_Q_WR_PTR", std::to_string(host_completion_queue_wr_ptr)},
-        {"DEV_COMPLETION_Q_WR_PTR", std::to_string(dev_completion_queue_wr_ptr)},
-        {"DEV_COMPLETION_Q_RD_PTR", std::to_string(dev_completion_queue_rd_ptr)},
-        {"FIRST_STREAM_USED",
-         std::to_string(MetalContext::instance().dispatch_mem_map(DISPATCH_CORE_TYPE).get_dispatch_stream_index(0))},
-        {"VIRTUALIZE_UNICAST_CORES", "0"},    // unused for single device
-        {"NUM_VIRTUAL_UNICAST_CORES", "0"},   // unused for single device
-        {"NUM_PHYSICAL_UNICAST_CORES", "0"},  // unused for single device
-        {"FABRIC_HEADER_RB_BASE", "0"},
-        {"FABRIC_HEADER_RB_ENTRIES", "0"},
-        {"MY_FABRIC_SYNC_STATUS_ADDR", "0"},
-        {"FABRIC_MUX_X", "0"},
-        {"FABRIC_MUX_Y", "0"},
-        {"FABRIC_MUX_NUM_BUFFERS_PER_CHANNEL", "0"},
-        {"FABRIC_MUX_CHANNEL_BUFFER_SIZE_BYTES", "0"},
-        {"FABRIC_MUX_CHANNEL_BASE_ADDRESS", "0"},
-        {"FABRIC_MUX_CONNECTION_INFO_ADDRESS", "0"},
-        {"FABRIC_MUX_CONNECTION_HANDSHAKE_ADDRESS", "0"},
-        {"FABRIC_MUX_FLOW_CONTROL_ADDRESS", "0"},
-        {"FABRIC_MUX_BUFFER_INDEX_ADDRESS", "0"},
-        {"FABRIC_MUX_STATUS_ADDRESS", "0"},
-        {"FABRIC_MUX_TERMINATION_SIGNAL_ADDRESS", "0"},
-        {"WORKER_CREDITS_STREAM_ID", "0"},
-        {"FABRIC_WORKER_FLOW_CONTROL_SEM", "0"},
-        {"FABRIC_WORKER_TEARDOWN_SEM", "0"},
-        {"FABRIC_WORKER_BUFFER_INDEX_SEM", "0"},
-        {"NUM_HOPS", "0"},
-        {"MY_DEV_ID", "0"},
-        {"EW_DIM", "0"},
-        {"TO_MESH_ID", "0"},
-        {"TO_DEV_ID", "0"},
-        {"ROUTER_DIRECTION", "0"},
-        {"FABRIC_2D", "0"},
-        {"WORKER_MCAST_GRID", "0"},
-        {"NUM_WORKER_CORES_TO_MCAST", "0"},
-    };
-    // Initialize runtime args offsets
-    rta_offset = 0;
-    offsetof_my_dev_id = rta_offset++;
-    offsetof_to_dev_id = rta_offset++;
-    offsetof_router_direction = rta_offset++;
-    runtime_args.resize(rta_offset);
-
-    dispatch_defines["OFFSETOF_MY_DEV_ID"] = std::to_string(offsetof_my_dev_id);
-    dispatch_defines["OFFSETOF_TO_DEV_ID"] = std::to_string(offsetof_to_dev_id);
-    dispatch_defines["OFFSETOF_ROUTER_DIRECTION"] = std::to_string(offsetof_router_direction);
-
-    // Initialize runtime args
-    runtime_args[offsetof_my_dev_id] = 0;
-    runtime_args[offsetof_to_dev_id] = 0;
-    runtime_args[offsetof_router_direction] = 0;
-
-    CoreCoord phys_upstream_from_dispatch_core = split_prefetcher_g ? phys_prefetch_d_core : phys_prefetch_core_g;
-    if (split_dispatcher_g) {
-        log_info(LogTest, "split dispatcher test");
-
-        // dispatch_hd and dispatch_d
-        constexpr uint32_t dispatch_d_preamble_size = 0;
-        CoreCoord phys_dispatch_d_downstream_core = phys_dispatch_h_core;
-
-        std::map<std::string, std::string> dispatch_d_defines = dispatch_defines;
-        dispatch_d_defines["MY_DOWNSTREAM_CB_SEM_ID"] = std::to_string(dispatch_downstream_cb_sem);
-        dispatch_d_defines["DOWNSTREAM_CB_SEM_ID"] = std::to_string(dispatch_h_cb_sem);
-        dispatch_d_defines["SPLIT_DISPATCH_PAGE_PREAMBLE_SIZE"] = std::to_string(dispatch_d_preamble_size);
-        dispatch_d_defines["MAX_NUM_WORKER_SEMS"] = std::to_string(DispatchSettings::DISPATCH_MESSAGE_ENTRIES);
-        dispatch_d_defines["MAX_NUM_GO_SIGNAL_NOC_DATA_ENTRIES"] =
-            std::to_string(DispatchSettings::DISPATCH_GO_SIGNAL_NOC_DATA_ENTRIES);
-        dispatch_d_defines["IS_D_VARIANT"] = "1";
-        dispatch_d_defines["IS_H_VARIANT"] = "0";
-
-        kernel_handle = configure_kernel_variant<true, false>(
-            program,
-            "tt_metal/impl/dispatch/kernels/cq_dispatch.cpp",
-            dispatch_d_defines,
-            {},
-            dispatch_core,
-            phys_dispatch_core,
-            phys_upstream_from_dispatch_core,
-            phys_dispatch_d_downstream_core,
-            device,
-            my_noc_index,
-            dispatch_upstream_noc_index,
-            my_noc_index);
-
-        tt_metal::SetRuntimeArgs(program, kernel_handle, dispatch_core, runtime_args);
-
-        // dispatch_h
-        CoreCoord phys_dispatch_h_upstream_core = phys_dispatch_core;
-
-        std::map<std::string, std::string> dispatch_h_defines = dispatch_defines;
-        dispatch_h_defines["MY_DISPATCH_CB_SEM_ID"] = std::to_string(dispatch_h_cb_sem);
-        dispatch_h_defines["UPSTREAM_DISPATCH_CB_SEM_ID"] = std::to_string(dispatch_downstream_cb_sem);
-        dispatch_h_defines["MY_DOWNSTREAM_CB_SEM_ID"] = std::to_string(dispatch_h_cb_sem);
-        dispatch_h_defines["DOWNSTREAM_CB_SEM_ID"] = std::to_string(dispatch_downstream_cb_sem);
-        dispatch_h_defines["SPLIT_DISPATCH_PAGE_PREAMBLE_SIZE"] = "0";  // preamble size
-        dispatch_h_defines["MAX_NUM_WORKER_SEMS"] =
-            "1";  // max_num_worker_sems is used for array sizing, set to 1 even if array isn't used
-        dispatch_h_defines["MAX_NUM_GO_SIGNAL_NOC_DATA_ENTRIES"] =
-            "1";  // max_num_go_signal_noc_data_entries is used for array sizing, set to 1 even if array isn't used
-        dispatch_h_defines["IS_D_VARIANT"] = "0";
-        dispatch_h_defines["IS_H_VARIANT"] = "1";
-
-        kernel_handle = configure_kernel_variant<false, true>(
-            program,
-            "tt_metal/impl/dispatch/kernels/cq_dispatch.cpp",
-            dispatch_h_defines,
-            {},
-            dispatch_h_core,
-            phys_dispatch_h_core,
-            phys_dispatch_h_upstream_core,
-            {0xffffffff, 0xffffffff},
-            device,
-            my_noc_index,
-            dispatch_upstream_noc_index,
-            my_noc_index);
-
-        tt_metal::SetRuntimeArgs(program, kernel_handle, dispatch_h_core, runtime_args);
-    } else {
-        kernel_handle = configure_kernel_variant<true, true>(
-            program,
-            "tt_metal/impl/dispatch/kernels/cq_dispatch.cpp",
-            dispatch_defines,
-            {},
-            dispatch_core,
-            phys_dispatch_core,
-            phys_upstream_from_dispatch_core,
-            {0xffffffff, 0xffffffff},
-            device,
-            my_noc_index,
-            dispatch_upstream_noc_index,
-            my_noc_index);
-
-        tt_metal::SetRuntimeArgs(program, kernel_handle, dispatch_core, runtime_args);
-    }
-}
-
-int main(int argc, char** argv) {
-    log_info(tt::LogTest, "test_prefetcher.cpp - Test Start");
-    auto* slow_dispatch_mode = getenv("TT_METAL_SLOW_DISPATCH_MODE");
-    TT_FATAL(slow_dispatch_mode, "This test only supports TT_METAL_SLOW_DISPATCH_MODE");
-
-    init(argc, argv);
-
-    bool pass = true;
-    try {
-        int num_devices = tt_metal::GetNumAvailableDevices();
-        if (test_device_id_g >= num_devices) {
-            log_info(
-                LogTest, "Device {} is not valid. Highest valid device id = {}.", test_device_id_g, num_devices - 1);
-            throw std::runtime_error("Invalid Device Id.");
-        }
-
-        tt_metal::IDevice* device = tt_metal::CreateDevice(test_device_id_g);
-        tt_metal::IDevice* device_r = device;
-        if (!device->is_mmio_capable()) {
-            log_info(LogTest, "Device {} is not valid. This test only supports MMIO capable devices", test_device_id_g);
-            throw std::runtime_error("Invalid Device Id.");
-        }
-
-        tt_metal::Program program = tt_metal::CreateProgram();
-        tt_metal::Program program_r = tt_metal::CreateProgram();
-
-        void* host_hugepage_base;
-        uint32_t l1_unreserved_base = device->allocator()->get_base_allocator_addr(HalMemType::L1);
-        uint32_t l1_unreserved_base_aligned = tt::align(
-            l1_unreserved_base,
-            (1 << DispatchSettings::DISPATCH_BUFFER_LOG_PAGE_SIZE));  // Was not aligned, lately.
-        l1_buf_base_g =
-            l1_unreserved_base_aligned + (1 << DispatchSettings::DISPATCH_BUFFER_LOG_PAGE_SIZE);  // Reserve a page.
-        uint32_t prefetch_q_base = l1_buf_base_g;
-        uint32_t prefetch_q_rd_ptr_addr = l1_unreserved_base_aligned;
-        uint32_t cq_start = MetalContext::instance()
-                                .dispatch_mem_map(DISPATCH_CORE_TYPE)
-                                .get_host_command_queue_addr(CommandQueueHostAddrType::UNRESERVED);
-        uint32_t dev_hugepage_base_g = 2 * (cq_start * sizeof(uint32_t));  // HOST_CQ uses some at the start address
-
-        configure_for_single_chip(
-            device, program, host_hugepage_base, prefetch_q_base, prefetch_q_rd_ptr_addr, dev_hugepage_base_g);
-
-        if ((1 << exec_buf_log_page_size_g) * device->allocator()->get_num_banks(BufferType::DRAM) > cmddat_q_size_g) {
-            log_fatal(
-                tt::LogTest,
-                "Exec buffer must fit in cmddat_q, page size too large ({})",
-                1 << exec_buf_log_page_size_g);
-            exit(0);
-        }
-
-        log_info(LogTest, "Hugepage buffer size {}", std::to_string(hugepage_issue_buffer_size_g));
-        log_info(LogTest, "Prefetch prefetch_q entries {}", std::to_string(prefetch_q_entries_g));
-        log_info(LogTest, "CmdDat buffer size {}", std::to_string(cmddat_q_size_g));
-        log_info(LogTest, "Prefetch scratch buffer size {}", std::to_string(scratch_db_size_g));
-        log_info(LogTest, "Max command size {}", std::to_string(max_prefetch_command_size_g));
-        if (test_type_g >= 2) {
-            perf_test_g = true;
-        }
-        if (test_type_g == 3) {
-            perf_test_g = true;
-            log_info(LogTest, "PCIE transfer size {}", std::to_string(pcie_transfer_size_g));
-        }
-        if (test_type_g == 4) {
-            perf_test_g = true;
-            log_info(LogTest, "DRAM page size {}", std::to_string(dram_page_size_g));
-            log_info(LogTest, "DRAM pages to read {}", std::to_string(dram_pages_to_read_g));
-        }
-        if (use_dram_exec_buf_g) {
-            log_info(LogTest, "Exec commands in DRAM exec_buf w/ page_size={}", 1 << exec_buf_log_page_size_g);
-        }
-        if (debug_g) {
-            log_info(LogTest, "Debug mode enabled");
-        }
-        log_info(LogTest, "Iterations: {}", iterations_g);
-
-        umd::Writer prefetch_q_writer = tt::tt_metal::MetalContext::instance().get_cluster().get_static_tlb_writer(
-            tt_cxy_pair(device->id(), phys_prefetch_core_g));
-
-        vector<uint32_t> cmds, terminate_cmds;
-        vector<uint32_t> cmd_sizes, terminate_sizes;
-        DeviceData device_data(
-            device,
-            all_workers_g,
-            l1_buf_base_g,
-            device->allocator()->get_base_allocator_addr(HalMemType::DRAM),
-            static_cast<uint32_t*>(host_hugepage_completion_buffer_base_g),
-            false,
-            DRAM_DATA_SIZE_WORDS);
-        num_dram_banks_g = device->allocator()->get_num_banks(BufferType::DRAM);
-
-        if (debug_g) {
-            initialize_dram_banks(device);
-        }
-
-        tt::tt_metal::MetalContext::instance().get_cluster().l1_barrier(device->id());
-        tt::tt_metal::MetalContext::instance().get_cluster().dram_barrier(device->id());
-
-        // Cache stuff
-        gen_terminate_cmds(terminate_cmds, terminate_sizes);
-        gen_prefetcher_cmds(device_r, cmds, cmd_sizes, device_data, l1_buf_base_g);
-        if (warmup_g) {
-            log_info(tt::LogTest, "Warming up cache now...");
-            run_test(
-                1,
-                device,
-                program,
-                device_r,
-                program_r,
-                cmd_sizes,
-                terminate_sizes,
-                cmds,
-                terminate_cmds,
-                host_hugepage_base,
-                dev_hugepage_base_g,
-                prefetch_q_base,
-                prefetch_q_rd_ptr_addr,
-                phys_prefetch_core_g,
-                prefetch_q_writer);
-            initialize_device_g = true;
-        }
-
-        log_info(
-            tt::LogTest,
-            "Generating cmds and running {} iterations (readback_every_iter: {}) now...",
-            iterations_g,
-            readback_every_iteration_g);
-        if (readback_every_iteration_g) {
-            for (int i = 0; i < iterations_g; i++) {
-                log_info(LogTest, "Iteration: {}", std::to_string(i));
-                initialize_device_g = true;
-                cmds.resize(0);
-                cmd_sizes.resize(0);
-                device_data.reset();
-                gen_prefetcher_cmds(device_r, cmds, cmd_sizes, device_data, l1_buf_base_g);
-                run_test(
-                    1,
-                    device,
-                    program,
-                    device_r,
-                    program_r,
-                    cmd_sizes,
-                    terminate_sizes,
-                    cmds,
-                    terminate_cmds,
-                    host_hugepage_base,
-                    dev_hugepage_base_g,
-                    prefetch_q_base,
-                    prefetch_q_rd_ptr_addr,
-                    phys_prefetch_core_g,
-                    prefetch_q_writer);
-                pass &= device_data.validate(device_r);
-                if (!pass) {
-                    break;
-                }
-            }
-        } else {
-            auto elapsed_seconds = run_test(
-                iterations_g,
-                device,
-                program,
-                device_r,
-                program_r,
-                cmd_sizes,
-                terminate_sizes,
-                cmds,
-                terminate_cmds,
-                host_hugepage_base,
-                dev_hugepage_base_g,
-                prefetch_q_base,
-                prefetch_q_rd_ptr_addr,
-                phys_prefetch_core_g,
-                prefetch_q_writer);
-
-            log_info(LogTest, "Ran in {}us", elapsed_seconds.count() * 1000 * 1000);
-            log_info(LogTest, "Ran in {}us per iteration", elapsed_seconds.count() * 1000 * 1000 / iterations_g);
-            log_warning(LogTest, "Performance mode, not validating results");
-            if (test_type_g == 2 || test_type_g == 3) {
-                float bw =
-                    (long int)bytes_of_data_g * iterations_g / (elapsed_seconds.count() * 1000.0 * 1000.0 * 1000.0);
-                std::stringstream ss;
-                ss << std::fixed << std::setprecision(3) << bw;
-                log_info(LogTest, "Sent {} bytes", bytes_of_data_g * iterations_g);
-                log_info(LogTest, "BW: {} GB/s", ss.str());
-            }
-        }
-
-        pass &= tt_metal::CloseDevice(device);
-    } catch (const std::exception& e) {
-        pass = false;
-        log_fatal(tt::LogTest, "{}", e.what());
-    }
-
-    tt::tt_metal::MetalContext::instance().rtoptions().set_kernels_nullified(false);
-
-    if (pass) {
-        log_info(LogTest, "test_prefetcher.cpp - Test Passed");
-        return 0;
-    } else {
-        log_fatal(LogTest, "test_prefetcher.cpp - Test Failed\n");
-        return 1;
-    }
-}
+// PrefetcherSmokeTestFixture tests with exec buff enabled / disabled
+INSTANTIATE_TEST_SUITE_P(
+    PrefetcherTests,
+    PrefetcherSmokeTestFixture,
+    ::testing::Values(
+        // With exec buf disabled
+        PagedReadParams{
+            DRAM_PAGE_SIZE_DEFAULT, DRAM_PAGES_TO_READ_DEFAULT, DEFAULT_ITERATIONS, DRAM_DATA_SIZE_WORDS, false},
+        // With exec buf enabled
+        PagedReadParams{
+            DRAM_PAGE_SIZE_DEFAULT, DRAM_PAGES_TO_READ_DEFAULT, DEFAULT_ITERATIONS, DRAM_DATA_SIZE_WORDS, true},
+        // With exec buf disabled + higher iterations
+        PagedReadParams{
+            DRAM_PAGE_SIZE_DEFAULT,
+            DRAM_PAGES_TO_READ_DEFAULT,
+            DEFAULT_ITERATIONS_SMOKE_RANDOM,
+            DRAM_DATA_SIZE_WORDS,
+            false},
+        // With exec buf enabled + higher iterations
+        PagedReadParams{
+            DRAM_PAGE_SIZE_DEFAULT,
+            DRAM_PAGES_TO_READ_DEFAULT,
+            DEFAULT_ITERATIONS_SMOKE_RANDOM,
+            DRAM_DATA_SIZE_WORDS,
+            true}),
+    [](const testing::TestParamInfo<PagedReadParams>& info) {
+        return std::to_string(info.param.page_size) + "B_" + std::to_string(info.param.num_pages) + "pages_" +
+               std::to_string(info.param.num_iterations) + "iter_" + std::to_string(info.param.dram_data_size_words) +
+               "words_" + (info.param.use_exec_buf ? "use_exec_buf_enabled" : "use_exec_buf_disabled");
+    });
+
+// PrefecherHostTextFixture test with exec buff enabled / disabled
+INSTANTIATE_TEST_SUITE_P(
+    PrefetcherTests,
+    PrefecherHostTextFixture,
+    ::testing::Values(
+        // With exec buf disabled
+        PagedReadParams{
+            DRAM_PAGE_SIZE_DEFAULT, DRAM_PAGES_TO_READ_DEFAULT, DEFAULT_ITERATIONS, DRAM_DATA_SIZE_WORDS, false},
+        // With exec buf enabled
+        PagedReadParams{
+            DRAM_PAGE_SIZE_DEFAULT, DRAM_PAGES_TO_READ_DEFAULT, DEFAULT_ITERATIONS, DRAM_DATA_SIZE_WORDS, true}),
+    [](const testing::TestParamInfo<PagedReadParams>& info) {
+        return std::to_string(info.param.page_size) + "B_" + std::to_string(info.param.num_pages) + "pages_" +
+               std::to_string(info.param.num_iterations) + "iter_" + std::to_string(info.param.dram_data_size_words) +
+               "words_" + (info.param.use_exec_buf ? "use_exec_buf_enabled" : "use_exec_buf_disabled");
+    });
+
+// PrefetcherPackedReadTestFixture test with exec buff enabled / disabled
+INSTANTIATE_TEST_SUITE_P(
+    PrefetcherTests,
+    PrefetcherPackedReadTestFixture,
+    ::testing::Values(
+        // With exec buf disabled
+        PagedReadParams{
+            DRAM_PAGE_SIZE_DEFAULT, DRAM_PAGES_TO_READ_DEFAULT, DEFAULT_ITERATIONS, DRAM_DATA_SIZE_WORDS, false},
+        // With exec buf enabled
+        PagedReadParams{
+            DRAM_PAGE_SIZE_DEFAULT, DRAM_PAGES_TO_READ_DEFAULT, DEFAULT_ITERATIONS, DRAM_DATA_SIZE_WORDS, true}),
+    [](const testing::TestParamInfo<PagedReadParams>& info) {
+        return std::to_string(info.param.page_size) + "B_" + std::to_string(info.param.num_pages) + "pages_" +
+               std::to_string(info.param.num_iterations) + "iter_" + std::to_string(info.param.dram_data_size_words) +
+               "words_" + (info.param.use_exec_buf ? "use_exec_buf_enabled" : "use_exec_buf_disabled");
+    });
+
+// PrefetcherRingbufferReadTestFixture test with exec buff enabled / disabled
+INSTANTIATE_TEST_SUITE_P(
+    PrefetcherTests,
+    PrefetcherRingbufferReadTestFixture,
+    ::testing::Values(
+        // With exec buf disabled
+        PagedReadParams{
+            DRAM_PAGE_SIZE_DEFAULT, DRAM_PAGES_TO_READ_DEFAULT, DEFAULT_ITERATIONS, DRAM_DATA_SIZE_WORDS, false},
+        // With exec buf enabled
+        PagedReadParams{
+            DRAM_PAGE_SIZE_DEFAULT, DRAM_PAGES_TO_READ_DEFAULT, DEFAULT_ITERATIONS, DRAM_DATA_SIZE_WORDS, true}),
+    [](const testing::TestParamInfo<PagedReadParams>& info) {
+        return std::to_string(info.param.page_size) + "B_" + std::to_string(info.param.num_pages) + "pages_" +
+               std::to_string(info.param.num_iterations) + "iter_" + std::to_string(info.param.dram_data_size_words) +
+               "words_" + (info.param.use_exec_buf ? "use_exec_buf_enabled" : "use_exec_buf_disabled");
+    });
+
+// RandomTestFixture test with exec buff enabled / disabled
+INSTANTIATE_TEST_SUITE_P(
+    PrefetcherTests,
+    RandomTestFixture,
+    ::testing::Values(
+        // With exec buf disabled
+        PagedReadParams{
+            DRAM_PAGE_SIZE_DEFAULT, DRAM_PAGES_TO_READ_DEFAULT, DEFAULT_ITERATIONS, DRAM_DATA_SIZE_WORDS, false},
+        // With exec buf enabled
+        PagedReadParams{
+            DRAM_PAGE_SIZE_DEFAULT, DRAM_PAGES_TO_READ_DEFAULT, DEFAULT_ITERATIONS, DRAM_DATA_SIZE_WORDS, true},
+        // With exec buf disabled + higher iterations
+        PagedReadParams{
+            DRAM_PAGE_SIZE_DEFAULT,
+            DRAM_PAGES_TO_READ_DEFAULT,
+            DEFAULT_ITERATIONS_SMOKE_RANDOM,
+            DRAM_DATA_SIZE_WORDS,
+            false},
+        // With exec buf enabled + higher iterations
+        PagedReadParams{
+            DRAM_PAGE_SIZE_DEFAULT,
+            DRAM_PAGES_TO_READ_DEFAULT,
+            DEFAULT_ITERATIONS_SMOKE_RANDOM,
+            DRAM_DATA_SIZE_WORDS,
+            true}),
+    [](const testing::TestParamInfo<PagedReadParams>& info) {
+        return std::to_string(info.param.page_size) + "B_" + std::to_string(info.param.num_pages) + "pages_" +
+               std::to_string(info.param.num_iterations) + "iter_" + std::to_string(info.param.dram_data_size_words) +
+               "words_" + (info.param.use_exec_buf ? "use_exec_buf_enabled" : "use_exec_buf_disabled");
+    });
+
+// Runs only with exec buff disabled - RELAY_LINEAR_H must be standalone
+INSTANTIATE_TEST_SUITE_P(
+    PrefetcherTests,
+    PrefetchRelayLinearHTestFixture,
+    ::testing::Values(
+        // With exec buf disabled
+        PagedReadParams{
+            DRAM_PAGE_SIZE_DEFAULT, DRAM_PAGES_TO_READ_DEFAULT, DEFAULT_ITERATIONS, DRAM_DATA_SIZE_WORDS, false}),
+    [](const testing::TestParamInfo<PagedReadParams>& info) {
+        return std::to_string(info.param.page_size) + "B_" + std::to_string(info.param.num_pages) + "pages_" +
+               std::to_string(info.param.num_iterations) + "iter_" + std::to_string(info.param.dram_data_size_words) +
+               "words_" + (info.param.use_exec_buf ? "use_exec_buf_enabled" : "use_exec_buf_disabled");
+    });
+
+}  // namespace prefetcher_tests
+}  // namespace tt::tt_dispatch_tests

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -146,8 +146,8 @@ protected:
 
     void SetUp() override {
         BaseTestFixture::SetUp();
-        dram_base_ = device_->allocator()->get_base_allocator_addr(HalMemType::DRAM);
-        num_banks_ = device_->allocator()->get_num_banks(BufferType::DRAM);
+        dram_base_ = device_->allocator_impl()->get_base_allocator_addr(HalMemType::DRAM);
+        num_banks_ = device_->allocator_impl()->get_num_banks(BufferType::DRAM);
         l1_alignment_ = tt::tt_metal::MetalContext::instance().hal().get_alignment(HalMemType::L1);
         packed_write_max_unicast_sub_cmds_ =
             device_->compute_with_storage_grid_size().x * device_->compute_with_storage_grid_size().y;
@@ -369,7 +369,7 @@ protected:
             uint32_t page_idx = sub_cmd.start_page;
             for (uint32_t i = 0; i < length_words; i += page_size_words) {
                 uint32_t dram_bank_id = page_idx % num_banks_;
-                auto dram_channel = device_->allocator()->get_dram_channel_from_bank_id(dram_bank_id);
+                auto dram_channel = device_->allocator_impl()->get_dram_channel_from_bank_id(dram_bank_id);
                 CoreCoord bank_core = device_->logical_core_from_dram_channel(dram_channel);
                 uint32_t bank_offset = base_addr_words + (page_size_words * (page_idx / num_banks_));
 
@@ -433,7 +433,7 @@ public:
             uint32_t page_idx = ringbuffer_cmd.start_page;
             for (uint32_t i = 0; i < length_words; i += page_size_words) {
                 uint32_t dram_bank_id = page_idx % num_banks_;
-                auto dram_channel = device_->allocator()->get_dram_channel_from_bank_id(dram_bank_id);
+                auto dram_channel = device_->allocator_impl()->get_dram_channel_from_bank_id(dram_bank_id);
                 CoreCoord bank_core = device_->logical_core_from_dram_channel(dram_channel);
                 uint32_t bank_offset = base_addr_words + (page_size_words * (page_idx / num_banks_));
 
@@ -852,7 +852,7 @@ protected:
             uint32_t bank_offset = validation_base_addr_words + page_size_words * (page_idx / num_banks_);
 
             // Get the logical core for this bank
-            const auto dram_channel = device_->allocator()->get_dram_channel_from_bank_id(bank_id);
+            const auto dram_channel = device_->allocator_impl()->get_dram_channel_from_bank_id(bank_id);
             const CoreCoord bank_core = device_->logical_core_from_dram_channel(dram_channel);
             uint32_t words_to_read = page_size_words;
             if (page_idx == last_page - 1) {
@@ -1139,7 +1139,7 @@ public:
             uint32_t bank_offset = base_addr_words + (page_size_words * (page_id / info_.num_banks_));
 
             // Get the logical core for this bank
-            const auto dram_channel = device_->allocator()->get_dram_channel_from_bank_id(bank_id);
+            const auto dram_channel = device_->allocator_impl()->get_dram_channel_from_bank_id(bank_id);
             const CoreCoord bank_core = device_->logical_core_from_dram_channel(dram_channel);
 
             // Update DeviceData for paged read
@@ -1259,7 +1259,7 @@ TEST_P(BasePrefetcherTestFixture, TestTerminate) {
     const CoreCoord last_worker = {first_worker.x + 1, first_worker.y + 1};
     const CoreRange worker_range = {first_worker, last_worker};
 
-    const uint32_t l1_base = device_->allocator()->get_base_allocator_addr(HalMemType::L1);
+    const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
 
     DeviceData device_data(device_, worker_range, l1_base, dram_base_, nullptr, false, dram_data_size_words, cfg_);
 
@@ -1330,7 +1330,7 @@ TEST_P(BasePrefetcherTestFixture, DRAMToL1PagedRead) {
     const CoreCoord last_worker = first_worker;
     const CoreRange worker_range = {first_worker, last_worker};
 
-    const uint32_t l1_base = device_->allocator()->get_base_allocator_addr(HalMemType::L1);
+    const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
 
     // Compute NOC encoding once
     const CoreCoord first_virt_worker = device_->virtual_core_from_logical_core(first_worker, CoreType::WORKER);
@@ -1367,7 +1367,7 @@ TEST_P(BasePrefetcherTestFixture, DRAMToL1PagedRead) {
             uint32_t bank_offset = page_size_words * (page_id / num_banks_);
 
             // Get the logical core for this bank
-            const auto dram_channel = device_->allocator()->get_dram_channel_from_bank_id(bank_id);
+            const auto dram_channel = device_->allocator_impl()->get_dram_channel_from_bank_id(bank_id);
             const CoreCoord bank_core = device_->logical_core_from_dram_channel(dram_channel);
 
             // Update DeviceData for paged read
@@ -1405,7 +1405,7 @@ TEST_P(PrefecherHostTextFixture, HostTest) {
     const CoreCoord last_worker = {first_worker.x + 1, first_worker.y + 1};
     const CoreRange worker_range = {first_worker, last_worker};
 
-    uint32_t l1_base = device_->allocator()->get_base_allocator_addr(HalMemType::L1);
+    uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
     CoreCoord phys_worker_core = device_->worker_core_from_logical_core(first_worker);
     // Write data into L1 for prefetcher to read it later
     MetalContext::instance().get_cluster().write_core(device_->id(), phys_worker_core, data, l1_base);
@@ -1476,7 +1476,7 @@ TEST_P(PrefetcherPackedReadTestFixture, PackedReadTest) {
     const CoreCoord last_worker = {first_worker.x + 1, first_worker.y + 1};
     const CoreRange worker_range = {first_worker, last_worker};
 
-    const uint32_t l1_base = device_->allocator()->get_base_allocator_addr(HalMemType::L1);
+    const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
     const auto dram_alignment = MetalContext::instance().hal().get_alignment(HalMemType::DRAM);
 
     // Compute NOC encoding once
@@ -1547,7 +1547,7 @@ TEST_P(PrefetcherRingbufferReadTestFixture, RingbufferReadTest) {
     const CoreCoord last_worker = {first_worker.x + 1, first_worker.y + 1};
     const CoreRange worker_range = {first_worker, last_worker};
 
-    const uint32_t l1_base = device_->allocator()->get_base_allocator_addr(HalMemType::L1);
+    const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
     const auto dram_alignment = MetalContext::instance().hal().get_alignment(HalMemType::DRAM);
 
     // Compute NOC encoding once
@@ -1621,7 +1621,7 @@ TEST_P(BasePrefetcherTestFixture, PagedReadWriteTest) {
     const CoreCoord last_worker = first_worker;  // {first_worker.x + 1, first_worker.y + 1};
     const CoreRange worker_range = {first_worker, last_worker};
 
-    const uint32_t l1_base = device_->allocator()->get_base_allocator_addr(HalMemType::L1);
+    const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
 
     // Compute NOC encoding once
     const CoreCoord first_virt_worker = device_->virtual_core_from_logical_core(first_worker, CoreType::WORKER);
@@ -1629,7 +1629,7 @@ TEST_P(BasePrefetcherTestFixture, PagedReadWriteTest) {
 
     DeviceData device_data(device_, worker_range, l1_base, dram_base_, nullptr, false, dram_data_size_words, cfg_);
 
-    const uint32_t page_size_alignment_bytes = device_->allocator()->get_alignment(BufferType::DRAM);
+    const uint32_t page_size_alignment_bytes = device_->allocator_impl()->get_alignment(BufferType::DRAM);
 
     std::vector<HostMemDeviceCommand> commands_per_iteration;
 
@@ -1653,7 +1653,7 @@ TEST_P(BasePrefetcherTestFixture, PagedReadWriteTest) {
             const uint32_t bank_id = page_id % num_banks_;
 
             // Get the logical core for this bank
-            const auto dram_channel = device_->allocator()->get_dram_channel_from_bank_id(bank_id);
+            const auto dram_channel = device_->allocator_impl()->get_dram_channel_from_bank_id(bank_id);
             const CoreCoord bank_core = device_->logical_core_from_dram_channel(dram_channel);
 
             // Generate payload with page id
@@ -1698,7 +1698,7 @@ TEST_P(BasePrefetcherTestFixture, PagedReadWriteTest) {
             uint32_t bank_offset = dram_data_size_words + page_size_words * (page_id / num_banks_);
 
             // Get the logical core for this bank
-            const auto dram_channel = device_->allocator()->get_dram_channel_from_bank_id(bank_id);
+            const auto dram_channel = device_->allocator_impl()->get_dram_channel_from_bank_id(bank_id);
             const CoreCoord bank_core = device_->logical_core_from_dram_channel(dram_channel);
 
             // Update DeviceData for paged read
@@ -1727,7 +1727,7 @@ TEST_P(RandomTestFixture, RandomTest) {
     const CoreCoord last_worker = {first_worker.x + 1, first_worker.y + 1};
     const CoreRange worker_range = {first_worker, last_worker};
 
-    const uint32_t l1_base = device_->allocator()->get_base_allocator_addr(HalMemType::L1);
+    const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
 
     DeviceData device_data(device_, worker_range, l1_base, dram_base_, nullptr, false, dram_data_size_words, cfg_);
 
@@ -1809,7 +1809,7 @@ TEST_P(PrefetchRelayLinearHTestFixture, RelayLinearHTest) {
     const CoreCoord last_worker = {first_worker.x + 1, first_worker.y + 1};
     const CoreRange worker_range = {first_worker, last_worker};
 
-    const uint32_t l1_base = mmio_device_->allocator()->get_base_allocator_addr(HalMemType::L1);
+    const uint32_t l1_base = mmio_device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
     const auto dram_alignment = MetalContext::instance().hal().get_alignment(HalMemType::DRAM);
 
     // Compute NOC encoding: Destination (Worker on Remote Device) -> Use device_ (Chip 1)
@@ -1817,7 +1817,7 @@ TEST_P(PrefetchRelayLinearHTestFixture, RelayLinearHTest) {
     const uint32_t noc_xy = remote_device_->get_noc_unicast_encoding(k_dispatch_downstream_noc, first_virt_worker);
 
     // Source (DRAM on MMIO Device) -> Use mmio_device_ (Chip 0)
-    auto mmio_dram_base = mmio_device_->allocator()->get_base_allocator_addr(HalMemType::DRAM);
+    auto mmio_dram_base = mmio_device_->allocator_impl()->get_base_allocator_addr(HalMemType::DRAM);
     DeviceData device_data(
         mmio_device_, worker_range, l1_base, mmio_dram_base, nullptr, false, dram_data_size_words, cfg_);
 
@@ -1863,7 +1863,7 @@ TEST_P(PrefetchRelayLinearHTestFixture, RelayLinearHTest) {
 
         // Source (DRAM on MMIO Device) -> Use mmio_device_ (Chip 0)
         const uint32_t dram_bank_id = 0;
-        auto dram_channel = mmio_device_->allocator()->get_dram_channel_from_bank_id(dram_bank_id);
+        auto dram_channel = mmio_device_->allocator_impl()->get_dram_channel_from_bank_id(dram_bank_id);
         CoreCoord dram_logical_core = mmio_device_->logical_core_from_dram_channel(dram_channel);
         CoreCoord dram_physical_core = MetalContext::instance()
                                            .get_cluster()
@@ -1872,7 +1872,7 @@ TEST_P(PrefetchRelayLinearHTestFixture, RelayLinearHTest) {
         cmd.relay_linear_h.noc_xy_addr =
             mmio_device_->get_noc_unicast_encoding(k_dispatch_downstream_noc, dram_physical_core);
 
-        [[maybe_unused]] auto offset = mmio_device_->allocator()->get_bank_offset(BufferType::DRAM, dram_bank_id);
+        [[maybe_unused]] auto offset = mmio_device_->allocator_impl()->get_bank_offset(BufferType::DRAM, dram_bank_id);
         // Read from DRAM result data address where data is stored
         // DeviceData uses the logical coordinates as keys
         cmd.relay_linear_h.addr = mmio_dram_base + offset;
@@ -1912,7 +1912,7 @@ TEST_P(PrefetcherSmokeTestFixture, SmokeTest) {
     const CoreCoord last_worker = first_worker;
     const CoreRange worker_range = {first_worker, last_worker};
 
-    const uint32_t l1_base = device_->allocator()->get_base_allocator_addr(HalMemType::L1);
+    const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
 
     DeviceData device_data(device_, worker_range, l1_base, dram_base_, nullptr, false, dram_data_size_words, cfg_);
 
@@ -2058,7 +2058,7 @@ TEST_P(PrefetcherSmokeTestFixture, HostSmokeTest) {
     const CoreCoord last_worker = {first_worker.x + 1, first_worker.y + 1};
     const CoreRange worker_range = {first_worker, last_worker};
 
-    const uint32_t l1_base = device_->allocator()->get_base_allocator_addr(HalMemType::L1);
+    const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
 
     // Get completion queue buffer pointer
     void* completion_queue_buffer = mgr_->get_completion_queue_ptr(fdcq_->id());

--- a/tt_metal/distributed/fd_mesh_command_queue.hpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.hpp
@@ -19,9 +19,9 @@
 
 // Forward declaration of the FDMeshCQTestAccessor class
 // This is used to access the system memory manager from cq test fixtures
-namespace tt::tt_dispatch::dispatcher_tests {
+namespace tt::tt_dispatch_tests::Common {
 class FDMeshCQTestAccessor;
-}  // namespace tt::tt_dispatch::dispatcher_tests
+}  // namespace tt::tt_dispatch_tests::Common
 
 namespace tt::tt_metal::distributed {
 
@@ -42,7 +42,7 @@ class FDMeshCommandQueue final : public MeshCommandQueueBase {
 private:
     // This class can now access private members of FDMeshCommandQueue
     // This is used to access the system memory manager from cq test fixtures
-    friend class tt_dispatch::dispatcher_tests::FDMeshCQTestAccessor;
+    friend class tt_dispatch_tests::Common::FDMeshCQTestAccessor;
 
     void populate_read_descriptor_queue();
     void populate_virtual_program_dispatch_core();

--- a/tt_metal/distributed/fd_mesh_command_queue.hpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.hpp
@@ -19,9 +19,9 @@
 
 // Forward declaration of the FDMeshCQTestAccessor class
 // This is used to access the system memory manager from cq test fixtures
-namespace tt::tt_dispatch_tests::Common {
+namespace tt::tt_metal::tt_dispatch_tests::Common {
 class FDMeshCQTestAccessor;
-}  // namespace tt::tt_dispatch_tests::Common
+}  // namespace tt::tt_metal::tt_dispatch_tests::Common
 
 namespace tt::tt_metal::distributed {
 

--- a/tt_metal/impl/dispatch/device_command_calculator.hpp
+++ b/tt_metal/impl/dispatch/device_command_calculator.hpp
@@ -156,6 +156,12 @@ public:
         this->cmd_write_offsetB += tt::align(sizeof(CQPrefetchCmd), this->pcie_alignment);
     }
 
+    void add_prefetch_exec_buf() { this->cmd_write_offsetB += tt::align(sizeof(CQPrefetchCmd), this->pcie_alignment); }
+
+    void add_prefetch_exec_buf_end() {
+        this->cmd_write_offsetB += tt::align(sizeof(CQPrefetchCmd) + sizeof(CQDispatchCmd), this->pcie_alignment);
+    }
+
     template <typename PackedSubCmd>
     void add_dispatch_write_packed(
         uint16_t num_sub_cmds,

--- a/tt_metal/impl/dispatch/system_memory_manager.cpp
+++ b/tt_metal/impl/dispatch/system_memory_manager.cpp
@@ -293,9 +293,9 @@ uint32_t SystemMemoryManager::get_completion_queue_read_ptr(const uint8_t cq_id)
     return this->cq_interfaces[cq_id].completion_fifo_rd_ptr << 4;
 }
 
-void* SystemMemoryManager::get_completion_queue_ptr(const uint8_t cq_id) const {
+void* SystemMemoryManager::get_completion_queue_ptr(uint8_t cq_id) const {
     // The completion queue follows issue queue in contiguous memory
-    // get_issue_queue_limit() returns absolute device address where the issue queue resides
+    // get_issue_queue_limit() returns absolute device address where the issue queue ends.
     // We subtract channel_offset (absolute device channel base) to get relative offset,
     // then add it to cq_sysmem_start (host channel base) to get host virtual address
     return (void*)(this->cq_sysmem_start + (this->get_issue_queue_limit(cq_id) - this->channel_offset));

--- a/tt_metal/impl/dispatch/system_memory_manager.cpp
+++ b/tt_metal/impl/dispatch/system_memory_manager.cpp
@@ -293,6 +293,14 @@ uint32_t SystemMemoryManager::get_completion_queue_read_ptr(const uint8_t cq_id)
     return this->cq_interfaces[cq_id].completion_fifo_rd_ptr << 4;
 }
 
+void* SystemMemoryManager::get_completion_queue_ptr(const uint8_t cq_id) const {
+    // The completion queue follows issue queue in contiguous memory
+    // get_issue_queue_limit() returns absolute device address where the issue queue resides
+    // We subtract channel_offset (absolute device channel base) to get relative offset,
+    // then add it to cq_sysmem_start (host channel base) to get host virtual address
+    return (void*)(this->cq_sysmem_start + (this->get_issue_queue_limit(cq_id) - this->channel_offset));
+}
+
 uint32_t SystemMemoryManager::get_completion_queue_read_toggle(const uint8_t cq_id) const {
     return this->cq_interfaces[cq_id].completion_fifo_rd_toggle;
 }

--- a/tt_metal/impl/dispatch/system_memory_manager.hpp
+++ b/tt_metal/impl/dispatch/system_memory_manager.hpp
@@ -78,6 +78,8 @@ public:
 
     void send_completion_queue_read_ptr(uint8_t cq_id) const;
 
+    void* get_completion_queue_ptr(const uint8_t cq_id) const;
+
     void wrap_issue_queue_wr_ptr(uint8_t cq_id);
 
     void wrap_completion_queue_rd_ptr(uint8_t cq_id);

--- a/tt_metal/impl/dispatch/system_memory_manager.hpp
+++ b/tt_metal/impl/dispatch/system_memory_manager.hpp
@@ -78,7 +78,7 @@ public:
 
     void send_completion_queue_read_ptr(uint8_t cq_id) const;
 
-    void* get_completion_queue_ptr(const uint8_t cq_id) const;
+    void* get_completion_queue_ptr(uint8_t cq_id) const;
 
     void wrap_issue_queue_wr_ptr(uint8_t cq_id);
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/29913

### Problem description

The legacy `test_prefetcher.cpp` used custom command emission, diverging from Fast Dispatch (FD) infra. This made tests harder to maintain.

We want gtests that:

1. Use an existing `FDMeshCommandQueue`
2. Borrow its `SystemMemoryManager`
3. Build commands via `DeviceCommand` helpers and `DeviceCommandCalculator`
4. Preserve coverage of 9/10 legacy tests Terminate, Smoke tests, L1-to-Host writes, DRAM-to-L1 Paged Read, Packed Read, Ringbuffer Relay, End-to-End Paged Read+Write, Random command test, Relay Linear H.

### What's changed

Refactored `test_prefetcher.cpp`:
- Converted all legacy tests to GTests inheriting from `BasePrefetcherTestFixture`.
- Tests now use `FDMeshCommandQueue` and `SystemMemoryManager` instead of managing custom command queues.
- All tests apart from Relay Linear H are parameterized to run with and without `exec_buf`
- PCIE to L1 write (linear unicast write), is deprecated from legacy as we cover it in `test_dispatcher.cpp`'s `LinearWrite`.
- For L1-to-Host writes, `distributed::Finish` is disabled and added a helper `wait_for_completion_queue_bytes` to poll the completion queue until all expected writes complete before validation.
- Deprecated split prefetcher/dispatcher command line args as we ensure tests pass on a multi-chip wormhole device (internally handled with FD).

Shared Infrastructure:
- Shared infra like bandwidth validation, bandwidth measurements, command execution, `DeviceData` expectation model etc are all in `common.h`
- We inherit test fixtures from `GenericMeshDeviceFixture` instead of `UnitMeshCQSingleCardFixture` for multi-chip device testing of all commands.
- Centralized `CommandBuilder` helpers and `PackedWriteUtils` for standard dispatcher commands (Linear, Paged, Packed writes) so both test suites use the exact same generation logic.
- Removed all globals from `test_prefetcher.cpp` and `test_dispatcher.cpp`. We use `DispatchTestConfig` to store those.

DeviceCommandCalculator
- added `add_prefetch_exec_buf` and `add_prefetch_exec_buf_end` for command size calculation with `exec_buf`

SystemMemoryManager:
- added `get_completion_queue_ptr` to get the completion queue access for host writes.


### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes
