### PR TITLE
TT-Fabric Intermesh Traffic VC (VC1) Support [2/n]

### DIFF
--- a/tt_metal/fabric/builder/connection_writer_adapter.hpp
+++ b/tt_metal/fabric/builder/connection_writer_adapter.hpp
@@ -74,10 +74,12 @@ protected:
     ~ChannelConnectionWriterAdapter() = default;
 
 private:
-    std::array<std::optional<size_t>, builder_config::num_receiver_channels> downstream_edm_vcs_noc_x = {};
-    std::array<std::optional<size_t>, builder_config::num_receiver_channels> downstream_edm_vcs_noc_y = {};
-    std::array<std::optional<size_t>, builder_config::num_receiver_channels> downstream_edm_vcs_worker_registration_address = {};
-    std::array<std::optional<size_t>, builder_config::num_receiver_channels> downstream_edm_vcs_worker_location_info_address = {};
+    std::array<std::optional<size_t>, builder_config::num_max_receiver_channels> downstream_edm_vcs_noc_x = {};
+    std::array<std::optional<size_t>, builder_config::num_max_receiver_channels> downstream_edm_vcs_noc_y = {};
+    std::array<std::optional<size_t>, builder_config::num_max_receiver_channels>
+        downstream_edm_vcs_worker_registration_address = {};
+    std::array<std::optional<size_t>, builder_config::num_max_receiver_channels>
+        downstream_edm_vcs_worker_location_info_address = {};
 };
 
 /*
@@ -117,8 +119,9 @@ private:
     uint32_t pack_downstream_noc_y_rt_arg(uint32_t vc_idx) const;
     uint32_t pack_downstream_noc_x_rt_arg(uint32_t vc_idx) const;
     uint32_t encode_noc_ord_for_2d(
-        const std::array<std::vector<std::pair<eth_chan_directions, CoreCoord>>, builder_config::num_receiver_channels>&
-            downstream_edms_connected_by_vc,
+        const std::array<
+            std::vector<std::pair<eth_chan_directions, CoreCoord>>,
+            builder_config::num_max_receiver_channels>& downstream_edms_connected_by_vc,
         uint32_t vc_idx,
         const std::function<uint32_t(CoreCoord)>& get_noc_ord) const;
 
@@ -127,35 +130,35 @@ private:
     std::unordered_set<uint32_t> downstream_edms_connected_by_vc_set;
 
     // holds which downstream cores a given receiver/inbound channel VC can feed into
-    std::array<std::vector<std::pair<eth_chan_directions, CoreCoord>>, builder_config::num_receiver_channels>
+    std::array<std::vector<std::pair<eth_chan_directions, CoreCoord>>, builder_config::num_max_receiver_channels>
         downstream_edms_connected_by_vc = {};
 
     // holds the number of buffer slots per downstream sender channel
-    std::array<std::optional<size_t>, builder_config::num_sender_channels> sender_channels_num_buffers = {};
+    std::array<std::optional<size_t>, builder_config::num_max_sender_channels> sender_channels_num_buffers = {};
 
     // holds the number of buffer slots per downstream VC. i.e. if forwarding to VC 0, use index 0 in the
     // array, if forwarding to VC 1, use index 1 in the array
-    std::array<size_t, builder_config::num_receiver_channels> downstream_sender_channels_num_buffers = {};
+    std::array<size_t, builder_config::num_max_receiver_channels> downstream_sender_channels_num_buffers = {};
 
     // For VC0: holds base addresses for up to 3 downstream EDMs (indexed by compact index)
     std::array<
         std::array<std::optional<size_t>, builder_config::max_downstream_edms>,
-        builder_config::num_receiver_channels>
+        builder_config::num_max_receiver_channels>
         downstream_edm_buffer_base_addresses = {};
 
     uint32_t downstream_edms_connected = 0;
 
     std::array<
         std::array<std::optional<size_t>, builder_config::max_downstream_edms>,
-        builder_config::num_receiver_channels>
+        builder_config::num_max_receiver_channels>
         downstream_edm_worker_registration_addresses = {};
     std::array<
         std::array<std::optional<size_t>, builder_config::max_downstream_edms>,
-        builder_config::num_receiver_channels>
+        builder_config::num_max_receiver_channels>
         downstream_edm_worker_location_info_addresses = {};
     std::array<
         std::array<std::optional<size_t>, builder_config::max_downstream_edms>,
-        builder_config::num_receiver_channels>
+        builder_config::num_max_receiver_channels>
         downstream_edm_buffer_index_semaphore_addresses = {};
 
     bool is_2D_routing = false;

--- a/tt_metal/fabric/builder/fabric_builder_config.hpp
+++ b/tt_metal/fabric/builder/fabric_builder_config.hpp
@@ -47,7 +47,7 @@ static constexpr std::size_t num_sender_channels_1d_linear = 2;
 static constexpr std::size_t num_sender_channels_2d_mesh = 4;
 
 static constexpr std::size_t num_sender_channels_1d = 2;
-static constexpr std::size_t num_sender_channels_2d = 7;
+static constexpr std::size_t num_sender_channels_2d = 8;
 static constexpr std::size_t num_max_sender_channels = std::max(num_sender_channels_1d, num_sender_channels_2d);
 static constexpr std::size_t num_receiver_channels_1d = 1;
 static constexpr std::size_t num_receiver_channels_2d = 2;

--- a/tt_metal/fabric/builder/fabric_builder_config.hpp
+++ b/tt_metal/fabric/builder/fabric_builder_config.hpp
@@ -49,8 +49,6 @@ static constexpr std::size_t num_sender_channels_2d_mesh = 4;
 static constexpr std::size_t num_sender_channels_1d = 2;
 // VC0: Up to Worker + 3 of [N/E/S/W]
 // VC1: Z + Up to 3 of [N/E/S/W]
-// VC0: Up to Worker + 3 of [N/E/S/W]
-// VC1: Z + Up to 3 of [N/E/S/W]
 static constexpr std::size_t num_sender_channels_2d = 8;
 static constexpr std::size_t num_max_sender_channels = std::max(num_sender_channels_1d, num_sender_channels_2d);
 static constexpr std::size_t num_receiver_channels_1d = 1;

--- a/tt_metal/fabric/builder/fabric_builder_config.hpp
+++ b/tt_metal/fabric/builder/fabric_builder_config.hpp
@@ -47,6 +47,8 @@ static constexpr std::size_t num_sender_channels_1d_linear = 2;
 static constexpr std::size_t num_sender_channels_2d_mesh = 4;
 
 static constexpr std::size_t num_sender_channels_1d = 2;
+// VC0: Up to Worker + 3 of [N/E/S/W]
+// VC1: Z + Up to 3 of [N/E/S/W]
 static constexpr std::size_t num_sender_channels_2d = 8;
 static constexpr std::size_t num_max_sender_channels = std::max(num_sender_channels_1d, num_sender_channels_2d);
 static constexpr std::size_t num_receiver_channels_1d = 1;

--- a/tt_metal/fabric/builder/fabric_builder_config.hpp
+++ b/tt_metal/fabric/builder/fabric_builder_config.hpp
@@ -49,6 +49,8 @@ static constexpr std::size_t num_sender_channels_2d_mesh = 4;
 static constexpr std::size_t num_sender_channels_1d = 2;
 // VC0: Up to Worker + 3 of [N/E/S/W]
 // VC1: Z + Up to 3 of [N/E/S/W]
+// VC0: Up to Worker + 3 of [N/E/S/W]
+// VC1: Z + Up to 3 of [N/E/S/W]
 static constexpr std::size_t num_sender_channels_2d = 8;
 static constexpr std::size_t num_max_sender_channels = std::max(num_sender_channels_1d, num_sender_channels_2d);
 static constexpr std::size_t num_receiver_channels_1d = 1;

--- a/tt_metal/fabric/builder/fabric_builder_config.hpp
+++ b/tt_metal/fabric/builder/fabric_builder_config.hpp
@@ -45,15 +45,13 @@ static constexpr std::size_t num_sender_channels_with_tensix_config = 1;
 // num sender channels based on more accurate topology
 static constexpr std::size_t num_sender_channels_1d_linear = 2;
 static constexpr std::size_t num_sender_channels_2d_mesh = 4;
-static constexpr std::size_t num_sender_channels_1d_ring = 2;
-static constexpr std::size_t num_sender_channels_2d_torus = 4;
 
 static constexpr std::size_t num_sender_channels_1d = 2;
 static constexpr std::size_t num_sender_channels_2d = 7;
-static constexpr std::size_t num_sender_channels = std::max(num_sender_channels_1d, num_sender_channels_2d);
+static constexpr std::size_t num_max_sender_channels = std::max(num_sender_channels_1d, num_sender_channels_2d);
 static constexpr std::size_t num_receiver_channels_1d = 1;
 static constexpr std::size_t num_receiver_channels_2d = 2;
-static constexpr std::size_t num_receiver_channels = std::max(num_receiver_channels_1d, num_receiver_channels_2d);
+static constexpr std::size_t num_max_receiver_channels = std::max(num_receiver_channels_1d, num_receiver_channels_2d);
 
 static constexpr std::size_t num_downstream_edms_vc0 = 1;
 static constexpr std::size_t num_downstream_edms_2d_vc0 = 3;

--- a/tt_metal/fabric/builder/fabric_core_placement.cpp
+++ b/tt_metal/fabric/builder/fabric_core_placement.cpp
@@ -42,28 +42,28 @@ void run_default_galaxy_optimizer(
 
     if (enable_noc_selection_opt) {
         if (edm_builder1.get_noc_x() < edm_builder2.get_noc_x()) {
-            for (uint32_t i = 0; i < builder_config::num_receiver_channels; i++) {
+            for (uint32_t i = 0; i < builder_config::num_max_receiver_channels; i++) {
                 edm_builder1.config.receiver_channel_forwarding_noc_ids[i] = 0;
                 edm_builder2.config.receiver_channel_forwarding_noc_ids[i] = 1;
             }
-            for (uint32_t i = 0; i < builder_config::num_receiver_channels; i++) {
+            for (uint32_t i = 0; i < builder_config::num_max_receiver_channels; i++) {
                 edm_builder1.config.receiver_channel_local_write_noc_ids[i] = 1;
                 edm_builder2.config.receiver_channel_local_write_noc_ids[i] = 1;
             }
-            for (uint32_t i = 0; i < builder_config::num_sender_channels; i++) {
+            for (uint32_t i = 0; i < builder_config::num_max_sender_channels; i++) {
                 edm_builder1.config.sender_channel_ack_noc_ids[i] = 1;
                 edm_builder2.config.sender_channel_ack_noc_ids[i] = 0;
             }
         } else if (edm_builder1.get_noc_x() > edm_builder2.get_noc_x()) {
-            for (uint32_t i = 0; i < builder_config::num_receiver_channels; i++) {
+            for (uint32_t i = 0; i < builder_config::num_max_receiver_channels; i++) {
                 edm_builder1.config.receiver_channel_forwarding_noc_ids[i] = 1;
                 edm_builder2.config.receiver_channel_forwarding_noc_ids[i] = 0;
             }
-            for (uint32_t i = 0; i < builder_config::num_receiver_channels; i++) {
+            for (uint32_t i = 0; i < builder_config::num_max_receiver_channels; i++) {
                 edm_builder1.config.receiver_channel_local_write_noc_ids[i] = 1;
                 edm_builder2.config.receiver_channel_local_write_noc_ids[i] = 1;
             }
-            for (uint32_t i = 0; i < builder_config::num_sender_channels; i++) {
+            for (uint32_t i = 0; i < builder_config::num_max_sender_channels; i++) {
                 edm_builder1.config.sender_channel_ack_noc_ids[i] = 0;
                 edm_builder2.config.sender_channel_ack_noc_ids[i] = 1;
             }

--- a/tt_metal/fabric/builder/fabric_remote_channels_allocator.cpp
+++ b/tt_metal/fabric/builder/fabric_remote_channels_allocator.cpp
@@ -13,9 +13,9 @@ namespace tt::tt_fabric {
 FabricRemoteChannelsAllocator::FabricRemoteChannelsAllocator(
     const FabricStaticSizedChannelsAllocator& static_allocator) :
     FabricChannelAllocator(static_allocator.topology_, static_allocator.options_, static_allocator.memory_regions_),
-    num_used_receiver_channels_(builder_config::num_receiver_channels) {
+    num_used_receiver_channels_(builder_config::num_max_receiver_channels) {
     // Extract remote receiver channel information from the static allocator
-    for (size_t i = 0; i < builder_config::num_receiver_channels; i++) {
+    for (size_t i = 0; i < builder_config::num_max_receiver_channels; i++) {
         this->remote_receiver_channels_base_address_[i] = static_allocator.remote_receiver_channels_base_address[i];
         this->remote_receiver_channels_num_buffers_[i] = static_allocator.remote_receiver_channels_num_buffers[i];
     }
@@ -38,19 +38,19 @@ void FabricRemoteChannelsAllocator::emit_ct_args(std::vector<uint32_t>& ct_args)
 
 size_t FabricRemoteChannelsAllocator::get_remote_receiver_channel_base_address(size_t channel_id) const {
     TT_FATAL(
-        channel_id < builder_config::num_receiver_channels,
+        channel_id < builder_config::num_max_receiver_channels,
         "Channel ID {} out of bounds (max {})",
         channel_id,
-        builder_config::num_receiver_channels - 1);
+        builder_config::num_max_receiver_channels - 1);
     return this->remote_receiver_channels_base_address_[channel_id];
 }
 
 size_t FabricRemoteChannelsAllocator::get_remote_receiver_channel_num_buffers(size_t channel_id) const {
     TT_FATAL(
-        channel_id < builder_config::num_receiver_channels,
+        channel_id < builder_config::num_max_receiver_channels,
         "Channel ID {} out of bounds (max {})",
         channel_id,
-        builder_config::num_receiver_channels - 1);
+        builder_config::num_max_receiver_channels - 1);
     return this->remote_receiver_channels_num_buffers_[channel_id];
 }
 

--- a/tt_metal/fabric/builder/fabric_remote_channels_allocator.hpp
+++ b/tt_metal/fabric/builder/fabric_remote_channels_allocator.hpp
@@ -76,8 +76,8 @@ public:
     void print(std::ostream& os) const override;
 
 private:
-    std::array<size_t, builder_config::num_receiver_channels> remote_receiver_channels_base_address_ = {};
-    std::array<size_t, builder_config::num_receiver_channels> remote_receiver_channels_num_buffers_ = {};
+    std::array<size_t, builder_config::num_max_receiver_channels> remote_receiver_channels_base_address_ = {};
+    std::array<size_t, builder_config::num_max_receiver_channels> remote_receiver_channels_num_buffers_ = {};
     size_t num_used_receiver_channels_ = 0;
 };
 

--- a/tt_metal/fabric/builder/fabric_static_sized_channels_allocator.cpp
+++ b/tt_metal/fabric/builder/fabric_static_sized_channels_allocator.cpp
@@ -58,10 +58,10 @@ FabricStaticSizedChannelsAllocator::FabricStaticSizedChannelsAllocator(
     for (const auto& region : memory_regions) {
         this->max_l1_loading_size = std::max(this->max_l1_loading_size, region.get_end_address());
     }
-    std::array<size_t, builder_config::num_sender_channels> num_sender_buffer_slots = {0};
-    std::array<size_t, builder_config::num_sender_channels> num_remote_sender_buffer_slots = {0};
-    std::array<size_t, builder_config::num_receiver_channels> num_receiver_buffer_slots = {0};
-    std::array<size_t, builder_config::num_receiver_channels> num_remote_receiver_buffer_slots = {0};
+    std::array<size_t, builder_config::num_max_sender_channels> num_sender_buffer_slots = {0};
+    std::array<size_t, builder_config::num_max_sender_channels> num_remote_sender_buffer_slots = {0};
+    std::array<size_t, builder_config::num_max_receiver_channels> num_receiver_buffer_slots = {0};
+    std::array<size_t, builder_config::num_max_receiver_channels> num_remote_receiver_buffer_slots = {0};
 
     bool has_tensix_extension = options.fabric_tensix_config != tt::tt_fabric::FabricTensixConfig::DISABLED;
 
@@ -183,10 +183,10 @@ FabricStaticSizedChannelsAllocator::FabricStaticSizedChannelsAllocator(
 void FabricStaticSizedChannelsAllocator::configure_buffer_slots_helper(
     Topology topology,
     const FabricEriscDatamoverOptions& options,
-    std::array<size_t, builder_config::num_sender_channels>& num_sender_buffer_slots,
-    std::array<size_t, builder_config::num_sender_channels>& num_remote_sender_buffer_slots,
-    std::array<size_t, builder_config::num_receiver_channels>& num_receiver_buffer_slots,
-    std::array<size_t, builder_config::num_receiver_channels>& num_remote_receiver_buffer_slots) {
+    std::array<size_t, builder_config::num_max_sender_channels>& num_sender_buffer_slots,
+    std::array<size_t, builder_config::num_max_sender_channels>& num_remote_sender_buffer_slots,
+    std::array<size_t, builder_config::num_max_receiver_channels>& num_receiver_buffer_slots,
+    std::array<size_t, builder_config::num_max_receiver_channels>& num_remote_receiver_buffer_slots) {
     // fabric with tensix extension uses different buffer slots options, since only one or two sender channels are
     // used by fabric router, while other sender channels are skipped and have 0 buffer slots.
     static const std::vector<std::vector<std::pair<size_t, size_t>>> default_with_tensix_buffer_slot_options = {

--- a/tt_metal/fabric/builder/fabric_static_sized_channels_allocator.hpp
+++ b/tt_metal/fabric/builder/fabric_static_sized_channels_allocator.hpp
@@ -79,10 +79,10 @@ private:
     void configure_buffer_slots_helper(
         tt::tt_fabric::Topology topology,
         const tt::tt_fabric::FabricEriscDatamoverOptions& options,
-        std::array<size_t, tt::tt_fabric::builder_config::num_sender_channels>& num_sender_buffer_slots,
-        std::array<size_t, tt::tt_fabric::builder_config::num_sender_channels>& num_remote_sender_buffer_slots,
-        std::array<size_t, tt::tt_fabric::builder_config::num_receiver_channels>& num_receiver_buffer_slots,
-        std::array<size_t, tt::tt_fabric::builder_config::num_receiver_channels>& num_remote_receiver_buffer_slots);
+        std::array<size_t, tt::tt_fabric::builder_config::num_max_sender_channels>& num_sender_buffer_slots,
+        std::array<size_t, tt::tt_fabric::builder_config::num_max_sender_channels>& num_remote_sender_buffer_slots,
+        std::array<size_t, tt::tt_fabric::builder_config::num_max_receiver_channels>& num_receiver_buffer_slots,
+        std::array<size_t, tt::tt_fabric::builder_config::num_max_receiver_channels>& num_remote_receiver_buffer_slots);
 
     // Configuration parameters
     size_t num_used_sender_channels = 0;
@@ -97,24 +97,24 @@ private:
         builder_config::num_sender_channels_with_tensix_config;
 
     // Channel size and buffer information
-    std::array<std::size_t, builder_config::num_sender_channels> sender_channels_size_bytes = {};
-    std::array<std::size_t, builder_config::num_receiver_channels> receiver_channels_size_bytes = {};
-    std::array<size_t, builder_config::num_sender_channels> sender_channels_num_buffers = {};
-    std::array<size_t, builder_config::num_receiver_channels> receiver_channels_num_buffers = {};
+    std::array<std::size_t, builder_config::num_max_sender_channels> sender_channels_size_bytes = {};
+    std::array<std::size_t, builder_config::num_max_receiver_channels> receiver_channels_size_bytes = {};
+    std::array<size_t, builder_config::num_max_sender_channels> sender_channels_num_buffers = {};
+    std::array<size_t, builder_config::num_max_receiver_channels> receiver_channels_num_buffers = {};
 
     // Remote channels sizes, used to calculate the remote buffer addresses.
-    std::array<std::size_t, builder_config::num_sender_channels> remote_sender_channels_size_bytes = {};
-    std::array<std::size_t, builder_config::num_receiver_channels> remote_receiver_channels_size_bytes = {};
+    std::array<std::size_t, builder_config::num_max_sender_channels> remote_sender_channels_size_bytes = {};
+    std::array<std::size_t, builder_config::num_max_receiver_channels> remote_receiver_channels_size_bytes = {};
     // Remote recv channels number of buffers, use by the local sender channel to check free slots.
-    std::array<std::size_t, builder_config::num_sender_channels> remote_sender_channels_num_buffers = {};
-    std::array<size_t, builder_config::num_receiver_channels> remote_receiver_channels_num_buffers = {};
+    std::array<std::size_t, builder_config::num_max_sender_channels> remote_sender_channels_num_buffers = {};
+    std::array<size_t, builder_config::num_max_receiver_channels> remote_receiver_channels_num_buffers = {};
     // Downstream sender channels number of buffers, used by the local receiver channel to check free slots.
 
-    std::array<size_t, builder_config::num_sender_channels> sender_channels_base_address = {};
-    std::array<size_t, builder_config::num_receiver_channels> receiver_channels_base_address = {};
+    std::array<size_t, builder_config::num_max_sender_channels> sender_channels_base_address = {};
+    std::array<size_t, builder_config::num_max_receiver_channels> receiver_channels_base_address = {};
     // the base addr per remote channel, used by local channels.
-    std::array<size_t, builder_config::num_sender_channels> remote_sender_channels_base_address = {};
-    std::array<size_t, builder_config::num_receiver_channels> remote_receiver_channels_base_address = {};
+    std::array<size_t, builder_config::num_max_sender_channels> remote_sender_channels_base_address = {};
+    std::array<size_t, builder_config::num_max_receiver_channels> remote_receiver_channels_base_address = {};
 };
 
 // Implementation of virtual print method

--- a/tt_metal/fabric/builder/static_sized_channel_connection_writer_adapter.cpp
+++ b/tt_metal/fabric/builder/static_sized_channel_connection_writer_adapter.cpp
@@ -185,7 +185,8 @@ uint32_t StaticSizedChannelConnectionWriterAdapter::pack_downstream_noc_x_rt_arg
  * X and Y have separate uint32s
  */
 uint32_t StaticSizedChannelConnectionWriterAdapter::encode_noc_ord_for_2d(
-    const std::array<std::vector<std::pair<eth_chan_directions, CoreCoord>>, builder_config::num_receiver_channels>& downstream_edms_connected_by_vc,
+    const std::array<std::vector<std::pair<eth_chan_directions, CoreCoord>>, builder_config::num_max_receiver_channels>&
+        downstream_edms_connected_by_vc,
     uint32_t vc_idx,
     const std::function<uint32_t(CoreCoord)>& get_noc_ord) const {
     if (vc_idx == 1) {

--- a/tt_metal/fabric/erisc_datamover_builder.cpp
+++ b/tt_metal/fabric/erisc_datamover_builder.cpp
@@ -106,8 +106,8 @@ void configure_risc_settings(
     bool& enable_handshake,
     bool& enable_context_switch,
     bool& enable_interrupts,
-    std::array<bool, builder_config::num_sender_channels>& is_sender_channel_serviced,
-    std::array<bool, builder_config::num_receiver_channels>& is_receiver_channel_serviced) {
+    std::array<bool, builder_config::num_max_sender_channels>& is_sender_channel_serviced,
+    std::array<bool, builder_config::num_max_receiver_channels>& is_receiver_channel_serviced) {
     if (arch == tt::ARCH::WORMHOLE_B0) {
         // Wormhole: All RISC cores handle both sender and receiver channels
         enable_handshake = true;
@@ -166,14 +166,14 @@ void update_sender_channel_servicing(
         for (auto& risc_config : risc_configs) {
             risc_config.reset_sender_channel_serviced();
             // Set the channel corresponding to the current direction
-            for (size_t i = 0; i < builder_config::num_sender_channels; i++) {
+            for (size_t i = 0; i < builder_config::num_max_sender_channels; i++) {
                 risc_config.set_sender_channel_serviced(i, i == target_channel);
             }
         }
     } else if (arch == tt::ARCH::BLACKHOLE) {
         risc_configs[0].reset_sender_channel_serviced();
         // Set the channel corresponding to the current direction
-        for (size_t i = 0; i < builder_config::num_sender_channels; i++) {
+        for (size_t i = 0; i < builder_config::num_max_sender_channels; i++) {
             risc_configs[0].set_sender_channel_serviced(i, i == target_channel);
         }
     }
@@ -489,7 +489,7 @@ FabricEriscDatamoverConfig::FabricEriscDatamoverConfig(
         std::make_shared<tt::tt_fabric::ChannelToPoolMapping>(remote_channels_recipe);
 
     // set default noc and cmd bufs (current setup in TG 4U)
-    for (uint32_t i = 0; i < builder_config::num_receiver_channels; i++) {
+    for (uint32_t i = 0; i < builder_config::num_max_receiver_channels; i++) {
         this->receiver_channel_forwarding_noc_ids[i] = FabricEriscDatamoverConfig::DEFAULT_RECEIVER_FORWARDING_NOC;
         this->receiver_channel_forwarding_data_cmd_buf_ids[i] = FabricEriscDatamoverConfig::WR_REG_CMD_BUF;
         this->receiver_channel_forwarding_sync_cmd_buf_ids[i] = FabricEriscDatamoverConfig::RD_CMD_BUF;
@@ -503,7 +503,7 @@ FabricEriscDatamoverConfig::FabricEriscDatamoverConfig(
             this->receiver_channel_forwarding_data_cmd_buf_ids[i] = FabricEriscDatamoverConfig::WR_CMD_BUF;
         }
     }
-    for (uint32_t i = 0; i < builder_config::num_sender_channels; i++) {
+    for (uint32_t i = 0; i < builder_config::num_max_sender_channels; i++) {
         this->sender_channel_ack_noc_ids[i] = FabricEriscDatamoverConfig::DEFAULT_SENDER_ACK_NOC;
         this->sender_channel_ack_cmd_buf_ids[i] = FabricEriscDatamoverConfig::AT_CMD_BUF;
 
@@ -659,9 +659,9 @@ FabricEriscDatamoverBuilder::FabricEriscDatamoverBuilder(
         receiver_channels_downstream_flow_control_semaphore_id,
     const std::array<std::optional<size_t>, builder_config::max_downstream_edms>&
         receiver_channels_downstream_teardown_semaphore_id,
-    const std::array<size_t, builder_config::num_sender_channels>& sender_channels_flow_control_semaphore_id,
-    const std::array<size_t, builder_config::num_sender_channels>& sender_channels_connection_semaphore_id,
-    const std::array<size_t, builder_config::num_sender_channels>& sender_channels_buffer_index_semaphore_id,
+    const std::array<size_t, builder_config::num_max_sender_channels>& sender_channels_flow_control_semaphore_id,
+    const std::array<size_t, builder_config::num_max_sender_channels>& sender_channels_connection_semaphore_id,
+    const std::array<size_t, builder_config::num_max_sender_channels>& sender_channels_buffer_index_semaphore_id,
 
     const FabricEriscDatamoverConfig& config,
     eth_chan_directions direction,
@@ -899,6 +899,10 @@ std::vector<uint32_t> FabricEriscDatamoverBuilder::get_compile_time_args(uint32_
     auto ct_args = std::vector<uint32_t>(stream_ids.begin(), stream_ids.end());
     ct_args.push_back(0xFFEE0001);
 
+    // Maximum channel counts from builder_config
+    ct_args.push_back(builder_config::num_max_sender_channels);
+    ct_args.push_back(builder_config::num_max_receiver_channels);
+
     // add the downstream tensix connection arg here, num_downstream_tensix_connections
     ct_args.push_back(this->num_downstream_tensix_connections);
 
@@ -1111,12 +1115,12 @@ std::vector<uint32_t> FabricEriscDatamoverBuilder::get_runtime_args() const {
     auto args_pt2 = std::vector<uint32_t>{};
 
     // Pack downstream teardown semaphores (always send MAX_NUM_SENDER_CHANNELS for compatibility)
-    for (uint32_t i = 0; i < builder_config::num_sender_channels; i++) {
+    for (uint32_t i = 0; i < builder_config::num_max_sender_channels; i++) {
         args_pt2.push_back(this->receiver_channels_downstream_teardown_semaphore_id[i].value_or(-1));
     }
 
     // Pack sender flow control semaphores (always send MAX_NUM_SENDER_CHANNELS)
-    for (uint32_t i = 0; i < builder_config::num_sender_channels; i++) {
+    for (uint32_t i = 0; i < builder_config::num_max_sender_channels; i++) {
         args_pt2.push_back(this->sender_channels_flow_control_semaphore_id[i]);
     }
 
@@ -1174,9 +1178,9 @@ FabricEriscDatamoverBuilder FabricEriscDatamoverBuilder::build(
     bool build_in_worker_connection_mode,
     eth_chan_directions direction,
     bool has_tensix_extension) {
-    std::array<size_t, builder_config::num_sender_channels> sender_channels_buffer_index_semaphore_id{};
-    std::array<size_t, builder_config::num_sender_channels> sender_channels_flow_control_semaphore_id{};
-    std::array<size_t, builder_config::num_sender_channels> sender_channels_connection_semaphore_id{};
+    std::array<size_t, builder_config::num_max_sender_channels> sender_channels_buffer_index_semaphore_id{};
+    std::array<size_t, builder_config::num_max_sender_channels> sender_channels_flow_control_semaphore_id{};
+    std::array<size_t, builder_config::num_max_sender_channels> sender_channels_connection_semaphore_id{};
     std::array<std::optional<size_t>, builder_config::max_downstream_edms>
         receiver_channels_downstream_flow_control_semaphore_id;
     std::array<std::optional<size_t>, builder_config::max_downstream_edms>
@@ -1206,7 +1210,7 @@ FabricEriscDatamoverBuilder FabricEriscDatamoverBuilder::build(
         *remote_multi_pool_allocator->get_pool(0));
 
     if (build_in_worker_connection_mode) {
-        for (uint32_t i = 0; i < builder_config::num_receiver_channels; i++) {
+        for (uint32_t i = 0; i < builder_config::num_max_receiver_channels; i++) {
             receiver_channels_downstream_flow_control_semaphore_id[i] = 0;
             receiver_channels_downstream_teardown_semaphore_id[i] = 0;
         }
@@ -1214,7 +1218,7 @@ FabricEriscDatamoverBuilder FabricEriscDatamoverBuilder::build(
         sender_channels_buffer_index_semaphore_id[0] = config.sender_channels_buffer_index_semaphore_address[0];
         sender_channels_flow_control_semaphore_id[0] = config.sender_channels_local_flow_control_semaphore_address[0];
         sender_channels_connection_semaphore_id[0] = config.sender_channels_connection_semaphore_address[0];
-        for (uint32_t i = 1; i < builder_config::num_sender_channels; i++) {
+        for (uint32_t i = 1; i < builder_config::num_max_sender_channels; i++) {
             sender_channels_flow_control_semaphore_id[i] = 0;
             sender_channels_connection_semaphore_id[i] = 0;
             sender_channels_buffer_index_semaphore_id[i] = 0;

--- a/tt_metal/fabric/erisc_datamover_builder.cpp
+++ b/tt_metal/fabric/erisc_datamover_builder.cpp
@@ -395,7 +395,9 @@ FabricEriscDatamoverConfig::FabricEriscDatamoverConfig(
     // Remove VC1 adjustments once VC1 sender/receiver channels are fully implemented
     // For 2D routing (Mesh/Torus), VC1 channels (sender channels 4-6, receiver channel 1) are not yet implemented
     // so we exclude them from allocation
+    // Also diccount for the Z edge channel
     if ((topology == Topology::Mesh || topology == Topology::Torus) && is_2D_routing) {
+        // discount vc1 and z channels.
         this->num_used_sender_channels -= builder_config::get_vc1_downstream_edm_count(is_2D_routing) + 1;
         this->num_used_receiver_channels = 1;  // Only VC0 receiver implemented
         this->num_fwd_paths -= builder_config::get_vc1_downstream_edm_count(is_2D_routing) + 1;

--- a/tt_metal/fabric/erisc_datamover_builder.cpp
+++ b/tt_metal/fabric/erisc_datamover_builder.cpp
@@ -396,9 +396,9 @@ FabricEriscDatamoverConfig::FabricEriscDatamoverConfig(
     // For 2D routing (Mesh/Torus), VC1 channels (sender channels 4-6, receiver channel 1) are not yet implemented
     // so we exclude them from allocation
     if ((topology == Topology::Mesh || topology == Topology::Torus) && is_2D_routing) {
-        this->num_used_sender_channels -= builder_config::get_vc1_downstream_edm_count(is_2D_routing);
+        this->num_used_sender_channels -= builder_config::get_vc1_downstream_edm_count(is_2D_routing) + 1;
         this->num_used_receiver_channels = 1;  // Only VC0 receiver implemented
-        this->num_fwd_paths -= builder_config::get_vc1_downstream_edm_count(is_2D_routing);
+        this->num_fwd_paths -= builder_config::get_vc1_downstream_edm_count(is_2D_routing) + 1;
     }
 
     for (uint32_t i = 0; i < this->num_used_sender_channels; i++) {
@@ -938,6 +938,7 @@ std::vector<uint32_t> FabricEriscDatamoverBuilder::get_compile_time_args(uint32_
         config.sender_channels_worker_conn_info_base_address[4],
         config.sender_channels_worker_conn_info_base_address[5],
         config.sender_channels_worker_conn_info_base_address[6],
+        config.sender_channels_worker_conn_info_base_address[7],
 
         this->termination_signal_ptr,
         this->edm_local_sync_ptr,
@@ -954,6 +955,7 @@ std::vector<uint32_t> FabricEriscDatamoverBuilder::get_compile_time_args(uint32_
         config.risc_configs[risc_id].is_sender_channel_serviced(4),
         config.risc_configs[risc_id].is_sender_channel_serviced(5),
         config.risc_configs[risc_id].is_sender_channel_serviced(6),
+        config.risc_configs[risc_id].is_sender_channel_serviced(7),
         config.risc_configs[risc_id].is_receiver_channel_serviced(0),
         config.risc_configs[risc_id].is_receiver_channel_serviced(1),
         config.risc_configs[risc_id].enable_handshake(),
@@ -1101,11 +1103,19 @@ std::vector<uint32_t> FabricEriscDatamoverBuilder::get_runtime_args() const {
         this->sender_channels_connection_semaphore_id[1],
         this->sender_channels_connection_semaphore_id[2],
         this->sender_channels_connection_semaphore_id[3],
+        this->sender_channels_connection_semaphore_id[4],
+        this->sender_channels_connection_semaphore_id[5],
+        this->sender_channels_connection_semaphore_id[6],
+        this->sender_channels_connection_semaphore_id[7],
 
         this->downstream_vcs_sender_channel_buffer_index_semaphore_id[0],
         this->downstream_vcs_sender_channel_buffer_index_semaphore_id[1],
         this->downstream_vcs_sender_channel_buffer_index_semaphore_id[2],
         this->downstream_vcs_sender_channel_buffer_index_semaphore_id[3],
+        this->downstream_vcs_sender_channel_buffer_index_semaphore_id[4],
+        this->downstream_vcs_sender_channel_buffer_index_semaphore_id[5],
+        this->downstream_vcs_sender_channel_buffer_index_semaphore_id[6],
+        this->downstream_vcs_sender_channel_buffer_index_semaphore_id[7],
     };
 
     receiver_channel_to_downstream_adapter->pack_inbound_channel_rt_args(0, rt_args);

--- a/tt_metal/fabric/erisc_datamover_builder.hpp
+++ b/tt_metal/fabric/erisc_datamover_builder.hpp
@@ -106,34 +106,51 @@ Receiver channel side registers are defined here to receive free-slot credits fr
 */
 struct StreamRegAssignments {
     // Packet send/ack/complete stream IDs
-    static constexpr uint32_t to_receiver_0_pkts_sent_id = 0;
-    static constexpr uint32_t to_receiver_1_pkts_sent_id = 1;
-    static constexpr uint32_t to_sender_0_pkts_acked_id = 2;
-    static constexpr uint32_t to_sender_1_pkts_acked_id = 3;
-    static constexpr uint32_t to_sender_2_pkts_acked_id = 4;
-    static constexpr uint32_t to_sender_3_pkts_acked_id = 5;
-    static constexpr uint32_t to_sender_0_pkts_completed_id = 6;
-    static constexpr uint32_t to_sender_1_pkts_completed_id = 7;
-    static constexpr uint32_t to_sender_2_pkts_completed_id = 8;
-    static constexpr uint32_t to_sender_3_pkts_completed_id = 9;
-    static constexpr uint32_t to_sender_4_pkts_completed_id = 10;
-    static constexpr uint32_t to_sender_5_pkts_completed_id = 11;
-    static constexpr uint32_t to_sender_6_pkts_completed_id = 12;
+    static constexpr uint32_t to_receiver_0_pkts_sent_id = 0;      // VC0 Ethernet Rx
+    static constexpr uint32_t to_receiver_1_pkts_sent_id = 1;      // VC1 Ethernet Rx
+    static constexpr uint32_t to_sender_0_pkts_acked_id = 2;       // VC0 Ethernet Sender Channel 0
+    static constexpr uint32_t to_sender_1_pkts_acked_id = 3;       // VC0 Ethernet Sender Channel 1
+    static constexpr uint32_t to_sender_2_pkts_acked_id = 4;       // VC0 Ethernet Sender Channel 2
+    static constexpr uint32_t to_sender_3_pkts_acked_id = 5;       // VC0 Ethernet Sender Channel 3
+    static constexpr uint32_t to_sender_0_pkts_completed_id = 6;   // VC0 Tensix Worker on upstream device
+    static constexpr uint32_t to_sender_1_pkts_completed_id = 7;   // VC0 Passthrough from upstream device X/Y edge
+    static constexpr uint32_t to_sender_2_pkts_completed_id = 8;   // VC0 Passthrough from upstream device X/Y edge
+    static constexpr uint32_t to_sender_3_pkts_completed_id = 9;   // VC0 Passthrough from upstream device X/Y edge
+    static constexpr uint32_t to_sender_4_pkts_completed_id = 10;  // VC1 Passthrough from upstream device Z edge
+    static constexpr uint32_t to_sender_5_pkts_completed_id = 11;  // VC1 Passthrough from upstream device X/Y edge
+    static constexpr uint32_t to_sender_6_pkts_completed_id = 12;  // VC1 Passthrough from upstream device X/Y edge
+    static constexpr uint32_t to_sender_7_pkts_completed_id = 13;  // VC1 Passthrough from upstream device X/Y edge
     // Receiver channel free slots stream IDs
-    static constexpr uint32_t vc_0_free_slots_from_downstream_edge_1 = 13;
-    static constexpr uint32_t vc_0_free_slots_from_downstream_edge_2 = 14;
-    static constexpr uint32_t vc_0_free_slots_from_downstream_edge_3 = 15;
-    static constexpr uint32_t vc_1_free_slots_from_downstream_edge_1 = 16;
-    static constexpr uint32_t vc_1_free_slots_from_downstream_edge_2 = 17;
-    static constexpr uint32_t vc_1_free_slots_from_downstream_edge_3 = 18;
-    // Sender channel free slots stream IDs
-    static constexpr uint32_t sender_channel_0_free_slots_stream_id = 19;  // for tensix worker
-    static constexpr uint32_t sender_channel_1_free_slots_stream_id = 20;  // for upstream edge on: 1D->VC0, 2D->VC0
-    static constexpr uint32_t sender_channel_2_free_slots_stream_id = 21;  // for upstream edge on: 2D->VC0
-    static constexpr uint32_t sender_channel_3_free_slots_stream_id = 22;  // for upstream edge on: 2D->VC0
-    static constexpr uint32_t sender_channel_4_free_slots_stream_id = 23;  // for upstream edge on: 2D->VC1
-    static constexpr uint32_t sender_channel_5_free_slots_stream_id = 24;  // for upstream edge on: 2D->VC1
-    static constexpr uint32_t sender_channel_6_free_slots_stream_id = 25;  // for upstream edge on: 2D->VC1
+    static constexpr uint32_t vc_0_free_slots_from_downstream_edge_1 =
+        14;  // for downstream E/W/N/S edge on: 2D X/Y Router->VC0, E edge on: 2D Z Router->VC0
+    static constexpr uint32_t vc_0_free_slots_from_downstream_edge_2 =
+        15;  // for downstream E/W/N/S edge on: 2D X/Y Router->VC0, W edge on: 2D Z Router->VC0
+    static constexpr uint32_t vc_0_free_slots_from_downstream_edge_3 =
+        16;  // for downstream E/W/N/S edge on: 2D X/Y Router->VC0, N edge on: 2D Z Router->VC0
+    static constexpr uint32_t vc_0_free_slots_from_downstream_edge_4 =
+        17;  // for downstream Z edge on: 2D+Z X/Y Router->VC0, S edge on: 2D Z Router->VC0
+    static constexpr uint32_t vc_1_free_slots_from_downstream_edge_1 =
+        18;  // for downstream E/W/N/S edge on: 2D X/Y Router->VC1
+    static constexpr uint32_t vc_1_free_slots_from_downstream_edge_2 =
+        19;  // for downstream E/W/N/S edge on: 2D X/Y Router->VC1
+    static constexpr uint32_t vc_1_free_slots_from_downstream_edge_3 =
+        20;  // for downstream E/W/N/S edge on: 2D X/Y Router->VC1
+    // Sender channel free slots stream IDs.
+    // Decremented by respective upstream senders.
+    static constexpr uint32_t sender_channel_0_free_slots_stream_id = 21;  // for upstream tensix worker
+    static constexpr uint32_t sender_channel_1_free_slots_stream_id =
+        22;  // for upstream edge on: 1D->VC0, E/W/N/S edge on: 2D X/Y Router->VC0, E edge on: 2D Z Router->VC0
+    static constexpr uint32_t sender_channel_2_free_slots_stream_id =
+        23;  // for upstream E/W/N/S edge on: 2D X/Y Router->VC0, W edge on: 2D Z Router->VC0
+    static constexpr uint32_t sender_channel_3_free_slots_stream_id =
+        24;  // for upstream E/W/N/S edge on: 2D X/Y Router->VC0, N edge on: 2D Z Router->VC0
+    static constexpr uint32_t sender_channel_4_free_slots_stream_id =
+        25;  // for upstream E/W/N/S edge on: 2D X/Y Router->VC1, S edge on: 2D Z Router->VC0
+    static constexpr uint32_t sender_channel_5_free_slots_stream_id =
+        26;  // for upstream E/W/N/S edge on: 2D X/Y Router->VC1
+    static constexpr uint32_t sender_channel_6_free_slots_stream_id =
+        27;  // for upstream E/W/N/S edge on: 2D X/Y Router->VC1
+    static constexpr uint32_t sender_channel_7_free_slots_stream_id = 28;  // for upstream Z edge on: 2D+Z->VC1
 
     // Local tensix relay free slots stream ID (UDM mode only)
     static constexpr uint32_t tensix_relay_local_free_slots_stream_id = 29;
@@ -155,9 +172,11 @@ struct StreamRegAssignments {
             to_sender_4_pkts_completed_id,
             to_sender_5_pkts_completed_id,
             to_sender_6_pkts_completed_id,
+            to_sender_7_pkts_completed_id,
             vc_0_free_slots_from_downstream_edge_1,
             vc_0_free_slots_from_downstream_edge_2,
             vc_0_free_slots_from_downstream_edge_3,
+            vc_0_free_slots_from_downstream_edge_4,
             vc_1_free_slots_from_downstream_edge_1,
             vc_1_free_slots_from_downstream_edge_2,
             vc_1_free_slots_from_downstream_edge_3,
@@ -168,6 +187,7 @@ struct StreamRegAssignments {
             sender_channel_4_free_slots_stream_id,
             sender_channel_5_free_slots_stream_id,
             sender_channel_6_free_slots_stream_id,
+            sender_channel_7_free_slots_stream_id,
             tensix_relay_local_free_slots_stream_id,
             multi_risc_teardown_sync_stream_id};
         return stream_ids;
@@ -215,21 +235,22 @@ struct FabricEriscDatamoverConfig {
 
     std::vector<FabricRiscConfig> risc_configs;
     // ----------- Sender Channels
-    std::array<std::size_t, builder_config::num_sender_channels> sender_channels_buffer_index_address = {};
+    std::array<std::size_t, builder_config::num_max_sender_channels> sender_channels_buffer_index_address = {};
     // Connection info layout:
     // 0: buffer_index_rdptr -> Tells EDM the address in worker L1 to update EDM's copy of channel rdptr
     // 1: worker_teardown_semaphore_address -> Tells EDM where to signal connection teardown completion in worker's L1
     // 2: WorkerXY (as uint32_t)
     // 3: Hold's EDM's rdptr for the buffer index in the channel
-    std::array<std::size_t, builder_config::num_sender_channels> sender_channels_worker_conn_info_base_address = {};
-    std::array<std::size_t, builder_config::num_sender_channels> sender_channels_local_flow_control_semaphore_address =
-        {};
-    std::array<std::size_t, builder_config::num_sender_channels> sender_channels_producer_terminate_connection_address =
-        {};
+    std::array<std::size_t, builder_config::num_max_sender_channels> sender_channels_worker_conn_info_base_address = {};
+    std::array<std::size_t, builder_config::num_max_sender_channels>
+        sender_channels_local_flow_control_semaphore_address = {};
+    std::array<std::size_t, builder_config::num_max_sender_channels>
+        sender_channels_producer_terminate_connection_address = {};
     // persistent mode field
-    std::array<std::size_t, builder_config::num_sender_channels> sender_channels_connection_semaphore_address = {};
+    std::array<std::size_t, builder_config::num_max_sender_channels> sender_channels_connection_semaphore_address = {};
     // persistent mode field
-    std::array<std::size_t, builder_config::num_sender_channels> sender_channels_buffer_index_semaphore_address = {};
+    std::array<std::size_t, builder_config::num_max_sender_channels> sender_channels_buffer_index_semaphore_address =
+        {};
 
     static_assert(sizeof(tt::tt_fabric::EDMChannelWorkerLocationInfo) % field_size == 0);
 
@@ -274,14 +295,16 @@ struct FabricEriscDatamoverConfig {
     Topology topology = Topology::Linear;
 
     // add the noc-usage and cmd_buf-usage here
-    std::array<std::size_t, builder_config::num_receiver_channels> receiver_channel_forwarding_noc_ids = {};
-    std::array<std::size_t, builder_config::num_receiver_channels> receiver_channel_forwarding_data_cmd_buf_ids = {};
-    std::array<std::size_t, builder_config::num_receiver_channels> receiver_channel_forwarding_sync_cmd_buf_ids = {};
-    std::array<std::size_t, builder_config::num_receiver_channels> receiver_channel_local_write_noc_ids = {};
-    std::array<std::size_t, builder_config::num_receiver_channels> receiver_channel_local_write_cmd_buf_ids = {};
+    std::array<std::size_t, builder_config::num_max_receiver_channels> receiver_channel_forwarding_noc_ids = {};
+    std::array<std::size_t, builder_config::num_max_receiver_channels> receiver_channel_forwarding_data_cmd_buf_ids =
+        {};
+    std::array<std::size_t, builder_config::num_max_receiver_channels> receiver_channel_forwarding_sync_cmd_buf_ids =
+        {};
+    std::array<std::size_t, builder_config::num_max_receiver_channels> receiver_channel_local_write_noc_ids = {};
+    std::array<std::size_t, builder_config::num_max_receiver_channels> receiver_channel_local_write_cmd_buf_ids = {};
 
-    std::array<std::size_t, builder_config::num_sender_channels> sender_channel_ack_noc_ids = {};
-    std::array<std::size_t, builder_config::num_sender_channels> sender_channel_ack_cmd_buf_ids = {};
+    std::array<std::size_t, builder_config::num_max_sender_channels> sender_channel_ack_noc_ids = {};
+    std::array<std::size_t, builder_config::num_max_sender_channels> sender_channel_ack_cmd_buf_ids = {};
 
     // emd vcs
     std::size_t edm_noc_vc = 0;
@@ -334,8 +357,8 @@ private:
     bool enable_handshake_ = false;
     bool enable_context_switch_ = false;
     bool enable_interrupts_ = false;
-    std::array<bool, builder_config::num_sender_channels> is_sender_channel_serviced_{};
-    std::array<bool, builder_config::num_receiver_channels> is_receiver_channel_serviced_{};
+    std::array<bool, builder_config::num_max_sender_channels> is_sender_channel_serviced_{};
+    std::array<bool, builder_config::num_max_receiver_channels> is_receiver_channel_serviced_{};
     bool telemetry_enabled_ = true;
     uint8_t telemetry_stats_mask_ = 0xFF;
 };
@@ -405,9 +428,9 @@ public:
             receiver_channels_downstream_flow_control_semaphore_id,
         const std::array<std::optional<size_t>, builder_config::max_downstream_edms>&
             receiver_channels_downstream_teardown_semaphore_id,
-        const std::array<size_t, builder_config::num_sender_channels>& sender_channels_flow_control_semaphore_id,
-        const std::array<size_t, builder_config::num_sender_channels>& sender_channels_connection_semaphore_id,
-        const std::array<size_t, builder_config::num_sender_channels>& sender_channels_buffer_index_semaphore_id,
+        const std::array<size_t, builder_config::num_max_sender_channels>& sender_channels_flow_control_semaphore_id,
+        const std::array<size_t, builder_config::num_max_sender_channels>& sender_channels_connection_semaphore_id,
+        const std::array<size_t, builder_config::num_max_sender_channels>& sender_channels_buffer_index_semaphore_id,
 
         const FabricEriscDatamoverConfig& config,
         eth_chan_directions direction,
@@ -483,12 +506,12 @@ public:
     std::array<std::shared_ptr<tt::tt_fabric::FabricChannelAllocator>, builder_config::max_downstream_edms>
         downstream_allocators = {};
 
-    std::array<size_t, builder_config::num_receiver_channels> receiver_channels_num_buffers = {};
-    std::array<size_t, builder_config::num_receiver_channels> remote_receiver_channels_num_buffers = {};
-    std::array<size_t, builder_config::num_receiver_channels> local_receiver_channels_buffer_address = {};
-    std::array<size_t, builder_config::num_receiver_channels> remote_receiver_channels_base_address = {};
+    std::array<size_t, builder_config::num_max_receiver_channels> receiver_channels_num_buffers = {};
+    std::array<size_t, builder_config::num_max_receiver_channels> remote_receiver_channels_num_buffers = {};
+    std::array<size_t, builder_config::num_max_receiver_channels> local_receiver_channels_buffer_address = {};
+    std::array<size_t, builder_config::num_max_receiver_channels> remote_receiver_channels_base_address = {};
 
-    std::array<size_t, builder_config::num_sender_channels> local_sender_channels_connection_info_addr = {};
+    std::array<size_t, builder_config::num_max_sender_channels> local_sender_channels_connection_info_addr = {};
 
     size_t termination_signal_ptr = 0;
     size_t edm_local_sync_ptr = 0;
@@ -502,14 +525,15 @@ public:
         receiver_channels_downstream_flow_control_semaphore_id = {};
     std::array<std::optional<size_t>, builder_config::max_downstream_edms>
         receiver_channels_downstream_teardown_semaphore_id = {};
-    std::array<size_t, builder_config::num_sender_channels> sender_channels_flow_control_semaphore_id = {};
-    std::array<size_t, builder_config::num_sender_channels> sender_channels_connection_semaphore_id = {};
-    std::array<size_t, builder_config::num_sender_channels> sender_channels_buffer_index_semaphore_id = {};
+    std::array<size_t, builder_config::num_max_sender_channels> sender_channels_flow_control_semaphore_id = {};
+    std::array<size_t, builder_config::num_max_sender_channels> sender_channels_connection_semaphore_id = {};
+    std::array<size_t, builder_config::num_max_sender_channels> sender_channels_buffer_index_semaphore_id = {};
 
-    std::array<size_t, builder_config::num_sender_channels> downstream_vcs_sender_channel_buffer_index_semaphore_id =
-        {};
+    std::array<size_t, builder_config::num_max_sender_channels>
+        downstream_vcs_sender_channel_buffer_index_semaphore_id = {};
 
-    mutable std::array<bool, builder_config::num_sender_channels> sender_channel_connection_liveness_check_disable_array = {};
+    mutable std::array<bool, builder_config::num_max_sender_channels>
+        sender_channel_connection_liveness_check_disable_array = {};
 
     mutable std::vector<bool> sender_channel_is_traffic_injection_channel_array;
 

--- a/tt_metal/fabric/fabric_tensix_builder_impl.hpp
+++ b/tt_metal/fabric/fabric_tensix_builder_impl.hpp
@@ -465,7 +465,8 @@ private:
     bool has_fabric_router_ = true;
 
     // Channel connection liveness check disable array
-    mutable std::array<bool, builder_config::num_sender_channels> channel_connection_liveness_check_disable_array_{};
+    mutable std::array<bool, builder_config::num_max_sender_channels>
+        channel_connection_liveness_check_disable_array_{};
 
     // Upstream router coordinates for sync
     std::vector<uint32_t> upstream_routers_noc_x_;
@@ -526,7 +527,8 @@ private:
     std::shared_ptr<FabricTensixDatamoverRelayConfig> config_;
 
     // Channel connection liveness check disable array
-    mutable std::array<bool, builder_config::num_sender_channels> channel_connection_liveness_check_disable_array_{};
+    mutable std::array<bool, builder_config::num_max_sender_channels>
+        channel_connection_liveness_check_disable_array_{};
 
     // Router coordinate for sync (relay connects to one local router)
     uint32_t router_noc_x_ = 0;

--- a/tt_metal/fabric/hw/inc/edm_fabric/fabric_connection_interface.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/fabric_connection_interface.hpp
@@ -18,6 +18,6 @@ static constexpr uint32_t close_connection_request_value = 2;
 // default assigned stream ID for the worker connection credits
 // worker writes to the auto-inc register of this stream ID to notify
 // fabric router of new packets availale.
-static constexpr uint32_t sender_channel_0_free_slots_stream_id = 19;
+static constexpr uint32_t sender_channel_0_free_slots_stream_id = 21;
 
 };  // namespace tt::tt_fabric::connection_interface

--- a/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_router_ct_args.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_router_ct_args.hpp
@@ -80,7 +80,7 @@ constexpr size_t MAX_NUM_SENDER_CHANNELS = get_compile_time_arg_val(MAX_NUM_SEND
 constexpr size_t MAX_NUM_RECEIVER_CHANNELS_IDX = MAX_NUM_SENDER_CHANNELS_IDX + 1;
 constexpr size_t MAX_NUM_RECEIVER_CHANNELS = get_compile_time_arg_val(MAX_NUM_RECEIVER_CHANNELS_IDX);
 constexpr size_t MAX_NUM_SENDER_CHANNELS_VC0 = 4;  // Channels 0-3
-constexpr size_t MAX_NUM_SENDER_CHANNELS_VC1 = 3;  // Channels 4-6 (2D only)
+constexpr size_t MAX_NUM_SENDER_CHANNELS_VC1 = 4;  // Channels 4-7 (2D only)
 
 // Downstream tensix connections argument (after stream IDs, marker, and max channel counts)
 constexpr size_t NUM_DS_OR_LOCAL_TENSIX_CONNECTIONS_IDX = MAX_NUM_RECEIVER_CHANNELS_IDX + 1;
@@ -262,6 +262,7 @@ constexpr size_t local_sender_channel_3_connection_info_addr = get_compile_time_
 constexpr size_t local_sender_channel_4_connection_info_addr = get_compile_time_arg_val(MAIN_CT_ARGS_IDX_1 + 4);
 constexpr size_t local_sender_channel_5_connection_info_addr = get_compile_time_arg_val(MAIN_CT_ARGS_IDX_1 + 5);
 constexpr size_t local_sender_channel_6_connection_info_addr = get_compile_time_arg_val(MAIN_CT_ARGS_IDX_1 + 6);
+constexpr size_t local_sender_channel_7_connection_info_addr = get_compile_time_arg_val(MAIN_CT_ARGS_IDX_1 + 7);
 
 // TODO: CONVERT TO SEMAPHORE
 constexpr size_t MAIN_CT_ARGS_IDX_2 = MAIN_CT_ARGS_IDX_1 + MAX_NUM_SENDER_CHANNELS;
@@ -543,6 +544,7 @@ constexpr std::array<uint32_t, MAX_NUM_SENDER_CHANNELS> to_sender_packets_acked_
             // VC1
             0,  // Padding upto MAX_NUM_SENDER_CHANNELS. VC1 does not use first level acks.
             0,
+            0,
             0});
 
 // data section
@@ -555,7 +557,8 @@ constexpr std::array<uint32_t, MAX_NUM_SENDER_CHANNELS> to_sender_packets_comple
             to_sender_3_pkts_completed_id,
             to_sender_4_pkts_completed_id,
             to_sender_5_pkts_completed_id,
-            to_sender_6_pkts_completed_id});
+            to_sender_6_pkts_completed_id,
+            to_sender_7_pkts_completed_id});
 
 // Miscellaneous configuration
 

--- a/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_router_ct_args.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_router_ct_args.hpp
@@ -23,15 +23,9 @@
 
 constexpr size_t NUM_ROUTER_CARDINAL_DIRECTIONS = 4;
 
-constexpr size_t MAX_NUM_RECEIVER_CHANNELS = 2;
-constexpr size_t MAX_NUM_SENDER_CHANNELS = 7;
-constexpr size_t MAX_NUM_SENDER_CHANNELS_VC0 = 4;  // Channels 0-3
-constexpr size_t MAX_NUM_SENDER_CHANNELS_VC1 = 3;  // Channels 4-6 (2D only)
-// Compile Time args
-
 constexpr bool SPECIAL_MARKER_CHECK_ENABLED = true;
 
-// Stream IDs from compile time arguments (first 23 arguments)
+// Stream IDs from compile time arguments (first 28 arguments)
 constexpr size_t STREAM_ID_ARGS_START_IDX = 0;
 constexpr uint32_t to_receiver_0_pkts_sent_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 0);
 constexpr uint32_t to_receiver_1_pkts_sent_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 1);
@@ -46,42 +40,54 @@ constexpr uint32_t to_sender_3_pkts_completed_id = get_compile_time_arg_val(STRE
 constexpr uint32_t to_sender_4_pkts_completed_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 10);
 constexpr uint32_t to_sender_5_pkts_completed_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 11);
 constexpr uint32_t to_sender_6_pkts_completed_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 12);
+constexpr uint32_t to_sender_7_pkts_completed_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 13);
 constexpr uint32_t vc_0_free_slots_from_downstream_edge_1_stream_id =
-    get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 13);
-constexpr uint32_t vc_0_free_slots_from_downstream_edge_2_stream_id =
     get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 14);
-constexpr uint32_t vc_0_free_slots_from_downstream_edge_3_stream_id =
+constexpr uint32_t vc_0_free_slots_from_downstream_edge_2_stream_id =
     get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 15);
-constexpr uint32_t vc_1_free_slots_from_downstream_edge_1_stream_id =
+constexpr uint32_t vc_0_free_slots_from_downstream_edge_3_stream_id =
     get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 16);
-constexpr uint32_t vc_1_free_slots_from_downstream_edge_2_stream_id =
+constexpr uint32_t vc_0_free_slots_from_downstream_edge_4_stream_id =
     get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 17);
-constexpr uint32_t vc_1_free_slots_from_downstream_edge_3_stream_id =
+constexpr uint32_t vc_1_free_slots_from_downstream_edge_1_stream_id =
     get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 18);
-constexpr uint32_t sender_channel_0_free_slots_stream_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 19);
-constexpr uint32_t sender_channel_1_free_slots_stream_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 20);
-constexpr uint32_t sender_channel_2_free_slots_stream_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 21);
-constexpr uint32_t sender_channel_3_free_slots_stream_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 22);
-constexpr uint32_t sender_channel_4_free_slots_stream_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 23);
-constexpr uint32_t sender_channel_5_free_slots_stream_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 24);
-constexpr uint32_t sender_channel_6_free_slots_stream_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 25);
-constexpr uint32_t tensix_relay_local_free_slots_stream_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 26);
-constexpr uint32_t MULTI_RISC_TEARDOWN_SYNC_STREAM_ID = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 27);
+constexpr uint32_t vc_1_free_slots_from_downstream_edge_2_stream_id =
+    get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 19);
+constexpr uint32_t vc_1_free_slots_from_downstream_edge_3_stream_id =
+    get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 20);
+constexpr uint32_t sender_channel_0_free_slots_stream_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 21);
+constexpr uint32_t sender_channel_1_free_slots_stream_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 22);
+constexpr uint32_t sender_channel_2_free_slots_stream_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 23);
+constexpr uint32_t sender_channel_3_free_slots_stream_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 24);
+constexpr uint32_t sender_channel_4_free_slots_stream_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 25);
+constexpr uint32_t sender_channel_5_free_slots_stream_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 26);
+constexpr uint32_t sender_channel_6_free_slots_stream_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 27);
+constexpr uint32_t sender_channel_7_free_slots_stream_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 28);
+constexpr uint32_t tensix_relay_local_free_slots_stream_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 29);
+constexpr uint32_t MULTI_RISC_TEARDOWN_SYNC_STREAM_ID = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 30);
 
 // Special marker after stream IDs
-constexpr size_t STREAM_IDS_END_MARKER_IDX = STREAM_ID_ARGS_START_IDX + 28;
+constexpr size_t STREAM_IDS_END_MARKER_IDX = STREAM_ID_ARGS_START_IDX + 31;
 constexpr size_t STREAM_IDS_END_MARKER = 0xFFEE0001;
 static_assert(
     !SPECIAL_MARKER_CHECK_ENABLED || get_compile_time_arg_val(STREAM_IDS_END_MARKER_IDX) == STREAM_IDS_END_MARKER,
     "Stream IDs end marker not found. This implies some arguments were misaligned between host and device. Double "
     "check the CT args.");
 
-// Downstream tensix connections argument (after stream IDs and marker)
-constexpr size_t NUM_DS_OR_LOCAL_TENSIX_CONNECTIONS_IDX = STREAM_IDS_END_MARKER_IDX + 1;
+// Maximum channel counts (from builder_config::num_max_sender_channels and builder_config::num_max_receiver_channels)
+constexpr size_t MAX_NUM_SENDER_CHANNELS_IDX = STREAM_IDS_END_MARKER_IDX + 1;
+constexpr size_t MAX_NUM_SENDER_CHANNELS = get_compile_time_arg_val(MAX_NUM_SENDER_CHANNELS_IDX);
+constexpr size_t MAX_NUM_RECEIVER_CHANNELS_IDX = MAX_NUM_SENDER_CHANNELS_IDX + 1;
+constexpr size_t MAX_NUM_RECEIVER_CHANNELS = get_compile_time_arg_val(MAX_NUM_RECEIVER_CHANNELS_IDX);
+constexpr size_t MAX_NUM_SENDER_CHANNELS_VC0 = 4;  // Channels 0-3
+constexpr size_t MAX_NUM_SENDER_CHANNELS_VC1 = 3;  // Channels 4-6 (2D only)
+
+// Downstream tensix connections argument (after stream IDs, marker, and max channel counts)
+constexpr size_t NUM_DS_OR_LOCAL_TENSIX_CONNECTIONS_IDX = MAX_NUM_RECEIVER_CHANNELS_IDX + 1;
 constexpr uint32_t num_ds_or_local_tensix_connections =
     get_compile_time_arg_val(NUM_DS_OR_LOCAL_TENSIX_CONNECTIONS_IDX);
 
-// Main configuration arguments (after stream IDs, marker, and downstream tensix connections)
+// Main configuration arguments (after stream IDs, marker, max channel counts, and downstream tensix connections)
 constexpr size_t SENDER_CHANNEL_NOC_CONFIG_START_IDX = NUM_DS_OR_LOCAL_TENSIX_CONNECTIONS_IDX + 1;
 constexpr size_t NUM_SENDER_CHANNELS = get_compile_time_arg_val(SENDER_CHANNEL_NOC_CONFIG_START_IDX);
 constexpr size_t NUM_RECEIVER_CHANNELS_CT_ARG_IDX = SENDER_CHANNEL_NOC_CONFIG_START_IDX + 1;
@@ -104,14 +110,16 @@ static_assert(
     NUM_SENDER_CHANNELS <= MAX_NUM_SENDER_CHANNELS,
     "NUM_SENDER_CHANNELS must be less than or equal to MAX_NUM_SENDER_CHANNELS");
 static_assert(
-    wait_for_host_signal_IDX == 34,
-    "wait_for_host_signal_IDX must be 34 (28 stream IDs + 1 marker + 1 tensix connections + 4 config args)");
+    wait_for_host_signal_IDX == 39,
+    "wait_for_host_signal_IDX must be 39 (31 stream IDs + 1 marker + 2 max channel counts + 1 tensix connections + 4 "
+    "config args)");
 static_assert(
     get_compile_time_arg_val(wait_for_host_signal_IDX) == 0 || get_compile_time_arg_val(wait_for_host_signal_IDX) == 1,
     "wait_for_host_signal must be 0 or 1");
 static_assert(
-    MAIN_CT_ARGS_START_IDX == 35,
-    "MAIN_CT_ARGS_START_IDX must be 35 (28 stream IDs + 1 marker + 1 tensix connections + 5 config args)");
+    MAIN_CT_ARGS_START_IDX == 40,
+    "MAIN_CT_ARGS_START_IDX must be 40 (31 stream IDs + 1 marker + 2 max channel counts + 1 tensix connections + 5 "
+    "config args)");
 
 constexpr uint32_t SWITCH_INTERVAL =
 #ifndef DEBUG_PRINT_ENABLED

--- a/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
+++ b/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
@@ -311,13 +311,13 @@ static constexpr std::array<uint32_t, MAX_NUM_SENDER_CHANNELS> sender_channel_fr
     sender_channel_4_free_slots_stream_id,
     sender_channel_5_free_slots_stream_id,
     sender_channel_6_free_slots_stream_id};
-static_assert(sender_channel_free_slots_stream_ids[0] == 19);
-static_assert(sender_channel_free_slots_stream_ids[1] == 20);
-static_assert(sender_channel_free_slots_stream_ids[2] == 21);
-static_assert(sender_channel_free_slots_stream_ids[3] == 22);
-static_assert(sender_channel_free_slots_stream_ids[4] == 23);
-static_assert(sender_channel_free_slots_stream_ids[5] == 24);
-static_assert(sender_channel_free_slots_stream_ids[6] == 25);
+static_assert(sender_channel_free_slots_stream_ids[0] == 21);
+static_assert(sender_channel_free_slots_stream_ids[1] == 22);
+static_assert(sender_channel_free_slots_stream_ids[2] == 23);
+static_assert(sender_channel_free_slots_stream_ids[3] == 24);
+static_assert(sender_channel_free_slots_stream_ids[4] == 25);
+static_assert(sender_channel_free_slots_stream_ids[5] == 26);
+static_assert(sender_channel_free_slots_stream_ids[6] == 27);
 
 // For 2D fabric: maps compact index to downstream direction for each my_direction
 // For 1D fabric: only 1 downstream direction per router (EAST forwards to WEST in 1D linear topology)
@@ -2254,7 +2254,7 @@ void kernel_main() {
     [[maybe_unused]]
     const auto downstream_vc0_noc_interface_buffer_index_local_addr = 0;
 
-    // Read MAX_NUM_SENDER_CHANNELS teardown semaphores (host packs builder_config::num_sender_channels = 7)
+    // Read MAX_NUM_SENDER_CHANNELS teardown semaphores (host packs builder_config::num_max_sender_channels = 7)
     const auto my_sem_for_teardown_from_edm_0 = get_arg_val<uint32_t>(arg_idx++);
     const auto my_sem_for_teardown_from_edm_1 = get_arg_val<uint32_t>(arg_idx++);
     const auto my_sem_for_teardown_from_edm_2 = get_arg_val<uint32_t>(arg_idx++);
@@ -2266,8 +2266,8 @@ void kernel_main() {
     ////////////////////////
     // Sender runtime args
     ////////////////////////
-    // Read MAX_NUM_SENDER_CHANNELS sender worker semaphore pointers (host packs builder_config::num_sender_channels =
-    // 7)
+    // Read MAX_NUM_SENDER_CHANNELS sender worker semaphore pointers (host packs builder_config::num_max_sender_channels
+    // = 7)
     auto sender0_worker_semaphore_ptr = reinterpret_cast<volatile uint32_t*>(get_arg_val<uint32_t>(arg_idx++));
     auto sender1_worker_semaphore_ptr = reinterpret_cast<volatile uint32_t*>(get_arg_val<uint32_t>(arg_idx++));
     auto sender2_worker_semaphore_ptr = reinterpret_cast<volatile uint32_t*>(get_arg_val<uint32_t>(arg_idx++));

--- a/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
+++ b/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
@@ -2181,25 +2181,17 @@ void kernel_main() {
         init_ptr_val<to_sender_packets_acked_streams[2]>(0);
         init_ptr_val<to_sender_packets_acked_streams[3]>(0);
 
-        // Initialize completion streams for channels 2-7 using compile-time loop
-        [&]<size_t... Is>(std::index_sequence<Is...>) {
-            ((init_ptr_val<to_sender_packets_completed_streams[Is + 2]>(0)), ...);
-        }(std::make_index_sequence<6>{});
-
-        // Initialize sender channel free slots for channels 2-3 (VC0)
-        init_ptr_val<sender_channel_free_slots_stream_ids[2]>(SENDER_NUM_BUFFERS_ARRAY[2]);  // Compact index 1
-        init_ptr_val<sender_channel_free_slots_stream_ids[3]>(SENDER_NUM_BUFFERS_ARRAY[3]);  // Compact index 2
-
-        // Initialize sender channel free slots for channels 4-7 (VC1) conditionally based on NUM_SENDER_CHANNELS
+        // Initialize completion streams and sender channel free slots for channels 2-7 using compile-time loop
         // SENDER_NUM_BUFFERS_ARRAY[] is sized to NUM_SENDER_CHANNELS, which is the number of used sender channels.
         [&]<size_t... Is>(std::index_sequence<Is...>) {
             (([&]() {
-                 if constexpr (NUM_SENDER_CHANNELS > (Is + 4)) {
-                     init_ptr_val<sender_channel_free_slots_stream_ids[Is + 4]>(SENDER_NUM_BUFFERS_ARRAY[Is + 4]);
+                 init_ptr_val<to_sender_packets_completed_streams[Is + 2]>(0);
+                 if constexpr (NUM_SENDER_CHANNELS > (Is + 2)) {
+                     init_ptr_val<sender_channel_free_slots_stream_ids[Is + 2]>(SENDER_NUM_BUFFERS_ARRAY[Is + 2]);
                  }
              }()),
              ...);
-        }(std::make_index_sequence<4>{});
+        }(std::make_index_sequence<6>{});
     }
 
     if constexpr (code_profiling_enabled_timers_bitfield != 0) {

--- a/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
+++ b/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
@@ -2180,29 +2180,26 @@ void kernel_main() {
         init_ptr_val<to_receiver_packets_sent_streams[1]>(0);
         init_ptr_val<to_sender_packets_acked_streams[2]>(0);
         init_ptr_val<to_sender_packets_acked_streams[3]>(0);
-        init_ptr_val<to_sender_packets_completed_streams[2]>(0);
-        init_ptr_val<to_sender_packets_completed_streams[3]>(0);
-        init_ptr_val<to_sender_packets_completed_streams[4]>(0);                             // VC1 channel 0
-        init_ptr_val<to_sender_packets_completed_streams[5]>(0);                             // VC1 channel 1
-        init_ptr_val<to_sender_packets_completed_streams[6]>(0);                             // VC1 channel 2
-        init_ptr_val<to_sender_packets_completed_streams[7]>(0);                             // VC1 channel 3
+
+        // Initialize completion streams for channels 2-7 using compile-time loop
+        [&]<size_t... Is>(std::index_sequence<Is...>) {
+            ((init_ptr_val<to_sender_packets_completed_streams[Is + 2]>(0)), ...);
+        }(std::make_index_sequence<6>{});
+
+        // Initialize sender channel free slots for channels 2-3 (VC0)
         init_ptr_val<sender_channel_free_slots_stream_ids[2]>(SENDER_NUM_BUFFERS_ARRAY[2]);  // Compact index 1
         init_ptr_val<sender_channel_free_slots_stream_ids[3]>(SENDER_NUM_BUFFERS_ARRAY[3]);  // Compact index 2
+
+        // Initialize sender channel free slots for channels 4-7 (VC1) conditionally based on NUM_SENDER_CHANNELS
         // SENDER_NUM_BUFFERS_ARRAY[] is sized to NUM_SENDER_CHANNELS, which is the number of used sender channels.
-        // Not the max number of sender channels. So we need to check if the number of used sender channels is greater
-        // than 4, 5, 6, or 7 before initializing the stream IDs for those channels.
-        if constexpr (NUM_SENDER_CHANNELS > 4) {
-            init_ptr_val<sender_channel_free_slots_stream_ids[4]>(SENDER_NUM_BUFFERS_ARRAY[4]);  // VC1 channel 0
-        }
-        if constexpr (NUM_SENDER_CHANNELS > 5) {
-            init_ptr_val<sender_channel_free_slots_stream_ids[5]>(SENDER_NUM_BUFFERS_ARRAY[5]);  // VC1 channel 1
-        }
-        if constexpr (NUM_SENDER_CHANNELS > 6) {
-            init_ptr_val<sender_channel_free_slots_stream_ids[6]>(SENDER_NUM_BUFFERS_ARRAY[6]);  // VC1 channel 2
-        }
-        if constexpr (NUM_SENDER_CHANNELS > 7) {
-            init_ptr_val<sender_channel_free_slots_stream_ids[7]>(SENDER_NUM_BUFFERS_ARRAY[7]);  // VC1 channel 3
-        }
+        [&]<size_t... Is>(std::index_sequence<Is...>) {
+            (([&]() {
+                 if constexpr (NUM_SENDER_CHANNELS > (Is + 4)) {
+                     init_ptr_val<sender_channel_free_slots_stream_ids[Is + 4]>(SENDER_NUM_BUFFERS_ARRAY[Is + 4]);
+                 }
+             }()),
+             ...);
+        }(std::make_index_sequence<4>{});
     }
 
     if constexpr (code_profiling_enabled_timers_bitfield != 0) {

--- a/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
+++ b/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
@@ -310,7 +310,8 @@ static constexpr std::array<uint32_t, MAX_NUM_SENDER_CHANNELS> sender_channel_fr
     sender_channel_3_free_slots_stream_id,
     sender_channel_4_free_slots_stream_id,
     sender_channel_5_free_slots_stream_id,
-    sender_channel_6_free_slots_stream_id};
+    sender_channel_6_free_slots_stream_id,
+    sender_channel_7_free_slots_stream_id};
 static_assert(sender_channel_free_slots_stream_ids[0] == 21);
 static_assert(sender_channel_free_slots_stream_ids[1] == 22);
 static_assert(sender_channel_free_slots_stream_ids[2] == 23);
@@ -318,6 +319,7 @@ static_assert(sender_channel_free_slots_stream_ids[3] == 24);
 static_assert(sender_channel_free_slots_stream_ids[4] == 25);
 static_assert(sender_channel_free_slots_stream_ids[5] == 26);
 static_assert(sender_channel_free_slots_stream_ids[6] == 27);
+static_assert(sender_channel_free_slots_stream_ids[7] == 28);
 
 // For 2D fabric: maps compact index to downstream direction for each my_direction
 // For 1D fabric: only 1 downstream direction per router (EAST forwards to WEST in 1D linear topology)
@@ -2180,11 +2182,27 @@ void kernel_main() {
         init_ptr_val<to_sender_packets_acked_streams[3]>(0);
         init_ptr_val<to_sender_packets_completed_streams[2]>(0);
         init_ptr_val<to_sender_packets_completed_streams[3]>(0);
-        init_ptr_val<to_sender_packets_completed_streams[4]>(0);
-        init_ptr_val<to_sender_packets_completed_streams[5]>(0);
-        init_ptr_val<to_sender_packets_completed_streams[6]>(0);
+        init_ptr_val<to_sender_packets_completed_streams[4]>(0);                             // VC1 channel 0
+        init_ptr_val<to_sender_packets_completed_streams[5]>(0);                             // VC1 channel 1
+        init_ptr_val<to_sender_packets_completed_streams[6]>(0);                             // VC1 channel 2
+        init_ptr_val<to_sender_packets_completed_streams[7]>(0);                             // VC1 channel 3
         init_ptr_val<sender_channel_free_slots_stream_ids[2]>(SENDER_NUM_BUFFERS_ARRAY[2]);  // Compact index 1
         init_ptr_val<sender_channel_free_slots_stream_ids[3]>(SENDER_NUM_BUFFERS_ARRAY[3]);  // Compact index 2
+        // SENDER_NUM_BUFFERS_ARRAY[] is sized to NUM_SENDER_CHANNELS, which is the number of used sender channels.
+        // Not the max number of sender channels. So we need to check if the number of used sender channels is greater
+        // than 4, 5, 6, or 7 before initializing the stream IDs for those channels.
+        if constexpr (NUM_SENDER_CHANNELS > 4) {
+            init_ptr_val<sender_channel_free_slots_stream_ids[4]>(SENDER_NUM_BUFFERS_ARRAY[4]);  // VC1 channel 0
+        }
+        if constexpr (NUM_SENDER_CHANNELS > 5) {
+            init_ptr_val<sender_channel_free_slots_stream_ids[5]>(SENDER_NUM_BUFFERS_ARRAY[5]);  // VC1 channel 1
+        }
+        if constexpr (NUM_SENDER_CHANNELS > 6) {
+            init_ptr_val<sender_channel_free_slots_stream_ids[6]>(SENDER_NUM_BUFFERS_ARRAY[6]);  // VC1 channel 2
+        }
+        if constexpr (NUM_SENDER_CHANNELS > 7) {
+            init_ptr_val<sender_channel_free_slots_stream_ids[7]>(SENDER_NUM_BUFFERS_ARRAY[7]);  // VC1 channel 3
+        }
     }
 
     if constexpr (code_profiling_enabled_timers_bitfield != 0) {
@@ -2209,10 +2227,18 @@ void kernel_main() {
     const size_t local_sender_channel_1_connection_semaphore_addr = get_arg_val<uint32_t>(arg_idx++);
     const size_t local_sender_channel_2_connection_semaphore_addr = get_arg_val<uint32_t>(arg_idx++);
     const size_t local_sender_channel_3_connection_semaphore_addr = get_arg_val<uint32_t>(arg_idx++);
+    const size_t local_sender_channel_4_connection_semaphore_addr = get_arg_val<uint32_t>(arg_idx++);
+    const size_t local_sender_channel_5_connection_semaphore_addr = get_arg_val<uint32_t>(arg_idx++);
+    const size_t local_sender_channel_6_connection_semaphore_addr = get_arg_val<uint32_t>(arg_idx++);
+    const size_t local_sender_channel_7_connection_semaphore_addr = get_arg_val<uint32_t>(arg_idx++);
     const size_t local_sender_channel_0_connection_buffer_index_id = get_arg_val<uint32_t>(arg_idx++);
     const size_t local_sender_channel_1_connection_buffer_index_id = get_arg_val<uint32_t>(arg_idx++);
     const size_t local_sender_channel_2_connection_buffer_index_id = get_arg_val<uint32_t>(arg_idx++);
     const size_t local_sender_channel_3_connection_buffer_index_id = get_arg_val<uint32_t>(arg_idx++);
+    const size_t local_sender_channel_4_connection_buffer_index_id = get_arg_val<uint32_t>(arg_idx++);
+    const size_t local_sender_channel_5_connection_buffer_index_id = get_arg_val<uint32_t>(arg_idx++);
+    const size_t local_sender_channel_6_connection_buffer_index_id = get_arg_val<uint32_t>(arg_idx++);
+    const size_t local_sender_channel_7_connection_buffer_index_id = get_arg_val<uint32_t>(arg_idx++);
 
     // downstream EDM VC0 connection info
     const auto has_downstream_edm_vc0_buffer_connection = get_arg_val<uint32_t>(arg_idx++);
@@ -2254,7 +2280,7 @@ void kernel_main() {
     [[maybe_unused]]
     const auto downstream_vc0_noc_interface_buffer_index_local_addr = 0;
 
-    // Read MAX_NUM_SENDER_CHANNELS teardown semaphores (host packs builder_config::num_max_sender_channels = 7)
+    // Read MAX_NUM_SENDER_CHANNELS teardown semaphores (host packs builder_config::num_max_sender_channels = 8)
     const auto my_sem_for_teardown_from_edm_0 = get_arg_val<uint32_t>(arg_idx++);
     const auto my_sem_for_teardown_from_edm_1 = get_arg_val<uint32_t>(arg_idx++);
     const auto my_sem_for_teardown_from_edm_2 = get_arg_val<uint32_t>(arg_idx++);
@@ -2262,12 +2288,13 @@ void kernel_main() {
     const auto my_sem_for_teardown_from_edm_4 = get_arg_val<uint32_t>(arg_idx++);
     const auto my_sem_for_teardown_from_edm_5 = get_arg_val<uint32_t>(arg_idx++);
     const auto my_sem_for_teardown_from_edm_6 = get_arg_val<uint32_t>(arg_idx++);
+    const auto my_sem_for_teardown_from_edm_7 = get_arg_val<uint32_t>(arg_idx++);
 
     ////////////////////////
     // Sender runtime args
     ////////////////////////
     // Read MAX_NUM_SENDER_CHANNELS sender worker semaphore pointers (host packs builder_config::num_max_sender_channels
-    // = 7)
+    // = 8)
     auto sender0_worker_semaphore_ptr = reinterpret_cast<volatile uint32_t*>(get_arg_val<uint32_t>(arg_idx++));
     auto sender1_worker_semaphore_ptr = reinterpret_cast<volatile uint32_t*>(get_arg_val<uint32_t>(arg_idx++));
     auto sender2_worker_semaphore_ptr = reinterpret_cast<volatile uint32_t*>(get_arg_val<uint32_t>(arg_idx++));
@@ -2275,6 +2302,7 @@ void kernel_main() {
     auto sender4_worker_semaphore_ptr = reinterpret_cast<volatile uint32_t*>(get_arg_val<uint32_t>(arg_idx++));
     auto sender5_worker_semaphore_ptr = reinterpret_cast<volatile uint32_t*>(get_arg_val<uint32_t>(arg_idx++));
     auto sender6_worker_semaphore_ptr = reinterpret_cast<volatile uint32_t*>(get_arg_val<uint32_t>(arg_idx++));
+    auto sender7_worker_semaphore_ptr = reinterpret_cast<volatile uint32_t*>(get_arg_val<uint32_t>(arg_idx++));
 
     ///////////////////////////////////////////////
     // Local tensix (relay) connection runtime args
@@ -2324,6 +2352,26 @@ void kernel_main() {
             *reinterpret_cast<volatile uint32_t*>(local_sender_channel_3_connection_buffer_index_id) = 0;
             *sender3_worker_semaphore_ptr = 0;
         }
+        if constexpr (is_sender_channel_serviced[4]) {
+            *reinterpret_cast<volatile uint32_t*>(local_sender_channel_4_connection_semaphore_addr) = 0;
+            *reinterpret_cast<volatile uint32_t*>(local_sender_channel_4_connection_buffer_index_id) = 0;
+            *sender4_worker_semaphore_ptr = 0;
+        }
+        if constexpr (is_sender_channel_serviced[5]) {
+            *reinterpret_cast<volatile uint32_t*>(local_sender_channel_5_connection_semaphore_addr) = 0;
+            *reinterpret_cast<volatile uint32_t*>(local_sender_channel_5_connection_buffer_index_id) = 0;
+            *sender5_worker_semaphore_ptr = 0;
+        }
+        if constexpr (is_sender_channel_serviced[6]) {
+            *reinterpret_cast<volatile uint32_t*>(local_sender_channel_6_connection_semaphore_addr) = 0;
+            *reinterpret_cast<volatile uint32_t*>(local_sender_channel_6_connection_buffer_index_id) = 0;
+            *sender6_worker_semaphore_ptr = 0;
+        }
+        if constexpr (is_sender_channel_serviced[7]) {
+            *reinterpret_cast<volatile uint32_t*>(local_sender_channel_7_connection_semaphore_addr) = 0;
+            *reinterpret_cast<volatile uint32_t*>(local_sender_channel_7_connection_buffer_index_id) = 0;
+            *sender7_worker_semaphore_ptr = 0;
+        }
     }
     *edm_status_ptr = tt::tt_fabric::EDMStatus::STARTED;
 
@@ -2351,6 +2399,7 @@ void kernel_main() {
                 my_sem_for_teardown_from_edm_4,
                 my_sem_for_teardown_from_edm_5,
                 my_sem_for_teardown_from_edm_6,
+                my_sem_for_teardown_from_edm_7,
             });
 
     // create the remote receiver channel buffers using multi-pool system
@@ -2375,19 +2424,27 @@ void kernel_main() {
         SENDER_TO_POOL_IDX>::make();
 
     std::array<size_t, NUM_SENDER_CHANNELS> local_sender_connection_live_semaphore_addresses =
-        take_first_n_elements<NUM_SENDER_CHANNELS, MAX_NUM_SENDER_CHANNELS_VC0, size_t>(
-            std::array<size_t, MAX_NUM_SENDER_CHANNELS_VC0>{
+        take_first_n_elements<NUM_SENDER_CHANNELS, MAX_NUM_SENDER_CHANNELS, size_t>(
+            std::array<size_t, MAX_NUM_SENDER_CHANNELS>{
                 local_sender_channel_0_connection_semaphore_addr,
                 local_sender_channel_1_connection_semaphore_addr,
                 local_sender_channel_2_connection_semaphore_addr,
-                local_sender_channel_3_connection_semaphore_addr});
+                local_sender_channel_3_connection_semaphore_addr,
+                local_sender_channel_4_connection_semaphore_addr,
+                local_sender_channel_5_connection_semaphore_addr,
+                local_sender_channel_6_connection_semaphore_addr,
+                local_sender_channel_7_connection_semaphore_addr});
     std::array<size_t, NUM_SENDER_CHANNELS> local_sender_connection_info_addresses =
-        take_first_n_elements<NUM_SENDER_CHANNELS, MAX_NUM_SENDER_CHANNELS_VC0, size_t>(
-            std::array<size_t, MAX_NUM_SENDER_CHANNELS_VC0>{
+        take_first_n_elements<NUM_SENDER_CHANNELS, MAX_NUM_SENDER_CHANNELS, size_t>(
+            std::array<size_t, MAX_NUM_SENDER_CHANNELS>{
                 local_sender_channel_0_connection_info_addr,
                 local_sender_channel_1_connection_info_addr,
                 local_sender_channel_2_connection_info_addr,
-                local_sender_channel_3_connection_info_addr});
+                local_sender_channel_3_connection_info_addr,
+                local_sender_channel_4_connection_info_addr,
+                local_sender_channel_5_connection_info_addr,
+                local_sender_channel_6_connection_info_addr,
+                local_sender_channel_7_connection_info_addr});
 
     for (size_t i = 0; i < NUM_SENDER_CHANNELS; i++) {
         auto connection_worker_info_ptr = reinterpret_cast<volatile tt::tt_fabric::EDMChannelWorkerLocationInfo*>(


### PR DESCRIPTION
Add streams and args for Z edge.
We need a max sender channel count of 8 split over 2 VCs to support Z routers.
Renamed `builder_config::num_sender_channels`, `builder_config::num_receiver_channels` to `builder_config::num_max_sender_channels`, `builder_config::num_max_receiver_channels`.
This is so that we know that these values mean max possible sender/receiver channels supported across all configs.
And that these are referenced when reserving housekeeping fields for all channels.

Other places where we use num_sender_channels/num_receiver_channels are then for the number of active/used channels which are config dependent.

### Ticket
https://github.com/tenstorrent/tt-metal/issues/32580

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes