### PR TITLE
Enable panoptic deeplab model on all cores @ BH P150

### DIFF
--- a/.github/workflows/blackhole-demo-tests-impl.yaml
+++ b/.github/workflows/blackhole-demo-tests-impl.yaml
@@ -23,6 +23,7 @@ on:
 
 jobs:
   single-card-demo-tests:
+    if: ${{ inputs.runner-label == 'P100' || inputs.runner-label == 'P150' }}
     strategy:
       fail-fast: false
       matrix:
@@ -48,22 +49,9 @@ jobs:
             runs-on: ["in-service", "${{ inputs.runner-label }}", "pipeline-perf"],
             cmd: pytest -sv models/experimental/functional_unet/tests/test_unet_perf.py -k "test_unet_trace_perf and not test_unet_trace_perf_multi_device",
             owner_id: U06ECNVR0EN # Evan Smal
-          },
-          { # This test shall be executed on the BH with 20 cores
-            name: "panoptic_deeplab demo - 20 cores",
-            arch: blackhole,
-            runs-on: "tt-ubuntu-2204-p150b-viommu-stable",
-            cmd: 'TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE="4, 3" pytest models/experimental/panoptic_deeplab/demo/demo.py::test_panoptic_deeplab_demo',
-            owner_id: U08AWRT6U3E # Boris Janjic
-          },
-          { # This test shall be executed on the BH P150 on 130 cores
-            name: "panoptic_deeplab demo - 130 cores",
-            arch: blackhole,
-            runs-on: "tt-ubuntu-2204-p150b-viommu-stable",
-            cmd: 'pytest models/experimental/panoptic_deeplab/demo/demo.py::test_panoptic_deeplab_demo',
-            owner_id: U09LK84G4TF # Nikola Milicevic
-          },
+          }
         ]
+
     name: ${{ matrix.test-group.name }}
     runs-on: ${{ matrix.test-group.runs-on }}
     container:
@@ -137,3 +125,64 @@ jobs:
           owner: ${{ matrix.test-group.owner_id }}
       - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
         if: always()
+  single-card-p150-demo-tests:
+    if: ${{ inputs.runner-label == 'p150b' }}
+    strategy:
+      # Do not fail-fast because we need to ensure all tests go to completion
+      # so we try not to get hanging machines
+      fail-fast: false
+      matrix:
+        test-group: [
+            { # This test shall be executed on the BH with 20 cores
+              name: "panoptic_deeplab demo - 20 cores",
+              arch: blackhole,
+              cmd: 'TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE="4, 3" pytest models/experimental/panoptic_deeplab/demo/demo.py::test_panoptic_deeplab_demo',
+              owner_id: U09LK84G4TF # Nikola Milicevic
+            },
+            { # This test shall be executed on the BH P150 on 130 cores
+              name: "panoptic_deeplab demo - 130 cores",
+              arch: blackhole,
+              cmd: 'pytest models/experimental/panoptic_deeplab/demo/demo.py::test_panoptic_deeplab_demo',
+              owner_id: U09LK84G4TF # Nikola Milicevic
+            },
+          ]
+    name: ${{ matrix.test-group.name }}
+    runs-on: ${{ format('tt-ubuntu-2204-{0}-viommu-stable', inputs.runner-label) }}
+    container:
+      image: harbor.ci.tenstorrent.net/${{ inputs.docker-image || 'docker-image-unresolved!'}}
+      env:
+        PYTHONPATH: /work
+        LD_LIBRARY_PATH: /work/build/lib
+        ARCH_NAME: ${{ inputs.arch_name }}
+        LOGURU_LEVEL: INFO
+      volumes:
+        - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
+        - /dev/hugepages-1G:/dev/hugepages-1G
+      options: "--device /dev/tenstorrent -e TT_GH_CI_INFRA"
+    defaults:
+      run:
+        shell: bash
+        working-directory: /work # https://github.com/actions/runner/issues/878
+    steps:
+      - name: ⬇️  Setup Job
+        uses: tenstorrent/tt-metal/.github/actions/setup-job@5b5c6ff5b54025e165d189371cda93d2b9ef6115
+        timeout-minutes: 10
+        with:
+          build-artifact-name: ${{ inputs.build-artifact-name }}
+          wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
+
+      - name: Run frequent reg tests scripts
+        timeout-minutes: 180
+        run: ${{ matrix.test-group.cmd }}
+
+      - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
+        timeout-minutes: 10
+        if: ${{ !cancelled() }}
+        with:
+          prefix: "test_reports_"
+
+      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
+        if: ${{ failure() }}
+        with:
+          slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+          owner: ${{ matrix.test-group.owner_id }}

--- a/.github/workflows/blackhole-demo-tests-impl.yaml
+++ b/.github/workflows/blackhole-demo-tests-impl.yaml
@@ -56,8 +56,8 @@ jobs:
             cmd: 'TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE="4, 3" pytest models/experimental/panoptic_deeplab/demo/demo.py::test_panoptic_deeplab_demo',
             owner_id: U08AWRT6U3E # Boris Janjic
           },
-          { # This test shall be executed on the BH on all cores
-            name: "panoptic_deeplab demo - all cores",
+          { # This test shall be executed on the BH P150 on 130 cores
+            name: "panoptic_deeplab demo - 130 cores",
             arch: blackhole,
             runs-on: "tt-ubuntu-2204-p150b-viommu-stable",
             cmd: 'pytest models/experimental/panoptic_deeplab/demo/demo.py::test_panoptic_deeplab_demo',

--- a/.github/workflows/blackhole-demo-tests-impl.yaml
+++ b/.github/workflows/blackhole-demo-tests-impl.yaml
@@ -50,12 +50,19 @@ jobs:
             owner_id: U06ECNVR0EN # Evan Smal
           },
           { # This test shall be executed on the BH with 20 cores
-            name: "panoptic_deeplab demo",
+            name: "panoptic_deeplab demo - 20 cores",
             arch: blackhole,
             runs-on: "tt-ubuntu-2204-p150b-viommu-stable",
             cmd: 'TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE="4, 3" pytest models/experimental/panoptic_deeplab/demo/demo.py::test_panoptic_deeplab_demo',
             owner_id: U08AWRT6U3E # Boris Janjic
-          }
+          },
+          { # This test shall be executed on the BH on all cores
+            name: "panoptic_deeplab demo - all cores",
+            arch: blackhole,
+            runs-on: "tt-ubuntu-2204-p150b-viommu-stable",
+            cmd: 'pytest models/experimental/panoptic_deeplab/demo/demo.py::test_panoptic_deeplab_demo',
+            owner_id: U09LK84G4TF # Nikola Milicevic
+          },
         ]
     name: ${{ matrix.test-group.name }}
     runs-on: ${{ matrix.test-group.runs-on }}

--- a/.github/workflows/blackhole-demo-tests.yaml
+++ b/.github/workflows/blackhole-demo-tests.yaml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test-group: ["P100", "P150"]
+        test-group: ["P100", "P150", "p150b"]
     with:
       runner-label: ${{ matrix.test-group }}
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}

--- a/.github/workflows/blackhole-nightly-tests-impl.yaml
+++ b/.github/workflows/blackhole-nightly-tests-impl.yaml
@@ -25,17 +25,28 @@ on:
 
 jobs:
   nightly-bh-models:
+    if: ${{ inputs.runner-label == 'P100' || inputs.runner-label == 'P150' }}
     strategy:
       # Do not fail-fast because we need to ensure all tests go to completion
       # so we try not to get hanging machines
       fail-fast: false
       matrix:
         test-group: [
-            { model: whisper, owner_id: U05RWH3QUPM , cmd: pytest tests/nightly/single_card/whisper },  #Salar Hosseini
-            { model: llama3.1-8b, owner_id: U03PUAKE719, cmd: HF_MODEL=meta-llama/Llama-3.1-8B-Instruct TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/meta-llama/Llama-3.1-8B-Instruct pytest models/tt_transformers/demo/simple_text_demo.py -k performance-ci-stress-1 }, # Miguel Tairum
+            {
+              model: whisper,
+              owner_id: U05RWH3QUPM, #Salar Hosseini
+              runs-on: ["cloud-virtual-machine", "in-service", "${{ inputs.runner-label }}", "pipeline-functional"],
+              cmd: pytest tests/nightly/single_card/whisper
+            },
+            {
+              model: llama3.1-8b,
+              owner_id: U03PUAKE719, # Miguel Tairum
+              runs-on: ["cloud-virtual-machine", "in-service", "${{ inputs.runner-label }}", "pipeline-functional"],
+              cmd: HF_MODEL=meta-llama/Llama-3.1-8B-Instruct TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/meta-llama/Llama-3.1-8B-Instruct pytest models/tt_transformers/demo/simple_text_demo.py -k performance-ci-stress-1
+            },
           ]
     name: Nightly ${{ inputs.runner-label }} ${{ matrix.test-group.model }}
-    runs-on: ["cloud-virtual-machine", "in-service", "${{ inputs.runner-label }}", "pipeline-functional"]
+    runs-on: ${{ matrix.test-group.runs-on }}
     container:
       image: ${{ inputs.docker-image }}
       env:
@@ -85,10 +96,8 @@ jobs:
 
       - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
         if: always()
-
   nightly-bh-models-ci-v2:
-    # Only run once (not for each matrix value in parent workflow)
-    if: ${{ inputs.runner-label == 'P150' }}
+    if: ${{ inputs.runner-label == 'p150b' }}
     strategy:
       # Do not fail-fast because we need to ensure all tests go to completion
       # so we try not to get hanging machines
@@ -97,9 +106,9 @@ jobs:
         test-group: [
             { model: panoptic-deeplab, owner_id: U09LK84G4TF, cmd: pytest models/experimental/panoptic_deeplab/tests/pcc/ }, # Nikola Milicevic
           ]
-    name: Nightly all cores ${{ matrix.test-group.model }}
+    name: Nightly 20 cores ${{ matrix.test-group.model }}
     # CIv2 to get weights
-    runs-on: tt-ubuntu-2204-p150b-stable
+    runs-on: ${{ format('tt-ubuntu-2204-{0}-stable', inputs.runner-label) }}
     container:
       image: harbor.ci.tenstorrent.net/${{ inputs.docker-image || 'docker-image-unresolved!'}}
       env:

--- a/.github/workflows/blackhole-nightly-tests-impl.yaml
+++ b/.github/workflows/blackhole-nightly-tests-impl.yaml
@@ -32,21 +32,11 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-            {
-              model: whisper,
-              owner_id: U05RWH3QUPM, #Salar Hosseini
-              runs-on: ["cloud-virtual-machine", "in-service", "${{ inputs.runner-label }}", "pipeline-functional"],
-              cmd: pytest tests/nightly/single_card/whisper
-            },
-            {
-              model: llama3.1-8b,
-              owner_id: U03PUAKE719, # Miguel Tairum
-              runs-on: ["cloud-virtual-machine", "in-service", "${{ inputs.runner-label }}", "pipeline-functional"],
-              cmd: HF_MODEL=meta-llama/Llama-3.1-8B-Instruct TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/meta-llama/Llama-3.1-8B-Instruct pytest models/tt_transformers/demo/simple_text_demo.py -k performance-ci-stress-1
-            },
+            { model: whisper, owner_id: U05RWH3QUPM , cmd: pytest tests/nightly/single_card/whisper },  #Salar Hosseini
+            { model: llama3.1-8b, owner_id: U03PUAKE719, cmd: HF_MODEL=meta-llama/Llama-3.1-8B-Instruct TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/meta-llama/Llama-3.1-8B-Instruct pytest models/tt_transformers/demo/simple_text_demo.py -k performance-ci-stress-1 }, # Miguel Tairum
           ]
     name: Nightly ${{ inputs.runner-label }} ${{ matrix.test-group.model }}
-    runs-on: ${{ matrix.test-group.runs-on }}
+    runs-on: ["cloud-virtual-machine", "in-service", "${{ inputs.runner-label }}", "pipeline-functional"]
     container:
       image: ${{ inputs.docker-image }}
       env:
@@ -106,7 +96,7 @@ jobs:
         test-group: [
             { model: panoptic-deeplab, owner_id: U09LK84G4TF, cmd: pytest models/experimental/panoptic_deeplab/tests/pcc/ }, # Nikola Milicevic
           ]
-    name: Nightly 20 cores ${{ matrix.test-group.model }}
+    name: Nightly P150 130 cores ${{ matrix.test-group.model }}
     # CIv2 to get weights
     runs-on: ${{ format('tt-ubuntu-2204-{0}-stable', inputs.runner-label) }}
     container:

--- a/.github/workflows/blackhole-nightly-tests-impl.yaml
+++ b/.github/workflows/blackhole-nightly-tests-impl.yaml
@@ -85,3 +85,56 @@ jobs:
 
       - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
         if: always()
+
+  nightly-bh-models-ci-v2:
+    # Only run once (not for each matrix value in parent workflow)
+    if: ${{ inputs.runner-label == 'P150' }}
+    strategy:
+      # Do not fail-fast because we need to ensure all tests go to completion
+      # so we try not to get hanging machines
+      fail-fast: false
+      matrix:
+        test-group: [
+            { model: panoptic-deeplab, owner_id: U09LK84G4TF, cmd: pytest models/experimental/panoptic_deeplab/tests/pcc/ }, # Nikola Milicevic
+          ]
+    name: Nightly all cores ${{ matrix.test-group.model }}
+    # CIv2 to get weights
+    runs-on: tt-ubuntu-2204-p150b-stable
+    container:
+      image: harbor.ci.tenstorrent.net/${{ inputs.docker-image || 'docker-image-unresolved!'}}
+      env:
+        PYTHONPATH: /work
+        LD_LIBRARY_PATH: /work/build/lib
+        ARCH_NAME: ${{ inputs.arch_name }}
+        LOGURU_LEVEL: INFO
+      volumes:
+        - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
+        - /dev/hugepages-1G:/dev/hugepages-1G
+      options: "--device /dev/tenstorrent -e TT_GH_CI_INFRA"
+    defaults:
+      run:
+        shell: bash
+        working-directory: /work # https://github.com/actions/runner/issues/878
+    steps:
+      - name: ⬇️  Setup Job
+        uses: tenstorrent/tt-metal/.github/actions/setup-job@5b5c6ff5b54025e165d189371cda93d2b9ef6115
+        timeout-minutes: 10
+        with:
+          build-artifact-name: ${{ inputs.build-artifact-name }}
+          wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
+
+      - name: Run frequent reg tests scripts
+        timeout-minutes: 180
+        run: ${{ matrix.test-group.cmd }}
+
+      - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
+        timeout-minutes: 10
+        if: ${{ !cancelled() }}
+        with:
+          prefix: "test_reports_"
+
+      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
+        if: ${{ failure() }}
+        with:
+          slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+          owner: ${{ matrix.test-group.owner_id }}

--- a/.github/workflows/blackhole-nightly-tests.yaml
+++ b/.github/workflows/blackhole-nightly-tests.yaml
@@ -51,7 +51,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        card_type: ["P100", "P150"]  # Cannot use P150b yet because CIv2 is using LFC and not MLPerf
+        card_type: ["P100", "P150", "p150b"]  # P100, P150 -> CIv1, p150b -> CIv2; mapped to jobs in impl workflow
     secrets: inherit
     with:
       runner-label: ${{ matrix.card_type }}

--- a/.github/workflows/perf-device-models-impl.yaml
+++ b/.github/workflows/perf-device-models-impl.yaml
@@ -394,7 +394,7 @@ jobs:
             pytest models/experimental/panoptic_deeplab/tests/test_device_perf_pdl.py::test_device_perf_pdl_20_cores -m models_device_performance_bare_metal --timeout=600
         if: ${{ !cancelled() && matrix.test-info.civ2-compatible && matrix.test-info.job-blackhole-set1 && fromJSON(needs.define-models.outputs.models-to-run)['panoptic-deeplab'] }}
 
-      - name: panoptic_deeplab tests (all cores)
+      - name: panoptic_deeplab tests (130 cores)
         uses: tenstorrent/tt-metal/.github/actions/single-card-perf-test@main
         with:
           device_perf_model_name: "panoptic_deeplab_130_cores"

--- a/.github/workflows/perf-device-models-impl.yaml
+++ b/.github/workflows/perf-device-models-impl.yaml
@@ -384,14 +384,22 @@ jobs:
             pytest models/experimental/oft/tests/test_device_perf_oft.py -m models_device_performance_bare_metal --timeout=600
         if: ${{ !cancelled() && matrix.test-info.civ2-compatible &&  matrix.test-info.job-blackhole-set1 && fromJSON(needs.define-models.outputs.models-to-run)['oft'] }}
 
-      - name: panoptic_deeplab tests
+      - name: panoptic_deeplab tests (20 cores)
         env:
           TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE: "4,3"
         uses: tenstorrent/tt-metal/.github/actions/single-card-perf-test@main
         with:
-          device_perf_model_name: "panoptic_deeplab"
+          device_perf_model_name: "panoptic_deeplab_20_cores"
           commands: |
-            pytest models/experimental/panoptic_deeplab/tests/test_device_perf_pdl.py -m models_device_performance_bare_metal --timeout=600
+            pytest models/experimental/panoptic_deeplab/tests/test_device_perf_pdl.py::test_device_perf_pdl_20_cores -m models_device_performance_bare_metal --timeout=600
+        if: ${{ !cancelled() && matrix.test-info.civ2-compatible && matrix.test-info.job-blackhole-set1 && fromJSON(needs.define-models.outputs.models-to-run)['panoptic-deeplab'] }}
+
+      - name: panoptic_deeplab tests (all cores)
+        uses: tenstorrent/tt-metal/.github/actions/single-card-perf-test@main
+        with:
+          device_perf_model_name: "panoptic_deeplab_all_cores"
+          commands: |
+            pytest models/experimental/panoptic_deeplab/tests/test_device_perf_pdl.py::test_device_perf_pdl_all_cores -m models_device_performance_bare_metal --timeout=600
         if: ${{ !cancelled() && matrix.test-info.civ2-compatible && matrix.test-info.job-blackhole-set1 && fromJSON(needs.define-models.outputs.models-to-run)['panoptic-deeplab'] }}
 
       - name: Merge test reports

--- a/.github/workflows/perf-device-models-impl.yaml
+++ b/.github/workflows/perf-device-models-impl.yaml
@@ -397,9 +397,9 @@ jobs:
       - name: panoptic_deeplab tests (all cores)
         uses: tenstorrent/tt-metal/.github/actions/single-card-perf-test@main
         with:
-          device_perf_model_name: "panoptic_deeplab_all_cores"
+          device_perf_model_name: "panoptic_deeplab_130_cores"
           commands: |
-            pytest models/experimental/panoptic_deeplab/tests/test_device_perf_pdl.py::test_device_perf_pdl_all_cores -m models_device_performance_bare_metal --timeout=600
+            pytest models/experimental/panoptic_deeplab/tests/test_device_perf_pdl.py::test_device_perf_pdl_130_cores -m models_device_performance_bare_metal --timeout=600
         if: ${{ !cancelled() && matrix.test-info.civ2-compatible && matrix.test-info.job-blackhole-set1 && fromJSON(needs.define-models.outputs.models-to-run)['panoptic-deeplab'] }}
 
       - name: Merge test reports

--- a/models/experimental/panoptic_deeplab/README.md
+++ b/models/experimental/panoptic_deeplab/README.md
@@ -53,8 +53,10 @@ TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE="4,3" pytest models/experimental/panopti
 
 ### Run Device Performance Tests
 ```bash
-# Test full model performance
-TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE="4,3" pytest models/experimental/panoptic_deeplab/tests/test_device_perf_pdl.py
+# Test full model performance on 20 cores
+TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE="4,3" pytest models/experimental/panoptic_deeplab/tests/test_device_perf_pdl.py::test_device_perf_pdl_20_cores
+# Test full model performance on all cores
+pytest models/experimental/panoptic_deeplab/tests/test_device_perf_pdl.py::test_device_perf_pdl_all_cores
 ```
 
 ### Run the Demo

--- a/models/experimental/panoptic_deeplab/README.md
+++ b/models/experimental/panoptic_deeplab/README.md
@@ -1,7 +1,7 @@
 # Panoptic DeepLab
 
 ## Platforms:
-    Made for BOS chips, mostly tested on Blackhole with a core grid of 20 cores.
+    Made for BOS chips, tested on Blackhole with both 20-core (5x4 grid) and all-core configurations.
 
 ## Introduction
 Panoptic DeepLab is a unified model for panoptic segmentation that combines semantic segmentation and instance segmentation into a single framework. The model uses a shared ResNet backbone with separate heads for semantic segmentation and instance embedding prediction, enabling comprehensive scene understanding by simultaneously identifying both "stuff" (background regions like road, sky) and "things" (countable objects like cars, people).
@@ -21,15 +21,22 @@ Place the downloaded `model_final_bd324a.pkl` file in `models/experimental/panop
 
 ## How to Run
 
+The model supports both optimized 20-core (5x4 grid) and all-core configurations:
+- **20 cores (optimized)**: Set `TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE="4,3"`
+- **All cores**: Omit/Unset `TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE` for device default core grid
+
 ### Run the Full Model Test
 ```bash
-# From tt-metal root directory
+# 20-core optimized configuration
 TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE="4,3" pytest models/experimental/panoptic_deeplab/tests/pcc/test_tt_model.py
+
+# All cores full grid configuration (13x10 on blackhole)
+pytest models/experimental/panoptic_deeplab/tests/pcc/test_tt_model.py
 ```
 
 ### Run Component Tests
 ```bash
-# Test ASPP component
+# Test ASPP component (works on any core configuration)
 TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE="4,3" pytest models/experimental/panoptic_deeplab/tests/pcc/test_aspp.py
 
 # Test ResNet backbone
@@ -41,6 +48,8 @@ TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE="4,3" pytest models/experimental/panopti
 # Test instance embedding head
 TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE="4,3" pytest models/experimental/panoptic_deeplab/tests/pcc/test_insemb.py
 ```
+
+**Note**: All tests automatically adapt to the available core grid. The 20-core configuration uses optimized matmul configs, while other configurations use auto-config for flexibility.
 
 ### Run Device Performance Tests
 ```bash

--- a/models/experimental/panoptic_deeplab/README.md
+++ b/models/experimental/panoptic_deeplab/README.md
@@ -1,7 +1,7 @@
 # Panoptic DeepLab
 
 ## Platforms:
-    Made for BOS chips, tested on Blackhole with both 20-core (5x4 grid) and all-core configurations.
+    Made for BOS chips, tested on Blackhole with both 20-core (5x4 grid) and P150 all-core (13x10 grid - 130 cores) configurations.
 
 ## Introduction
 Panoptic DeepLab is a unified model for panoptic segmentation that combines semantic segmentation and instance segmentation into a single framework. The model uses a shared ResNet backbone with separate heads for semantic segmentation and instance embedding prediction, enabling comprehensive scene understanding by simultaneously identifying both "stuff" (background regions like road, sky) and "things" (countable objects like cars, people).
@@ -21,18 +21,20 @@ Place the downloaded `model_final_bd324a.pkl` file in `models/experimental/panop
 
 ## How to Run
 
-The model supports both optimized 20-core (5x4 grid) and all-core configurations:
+The model supports both optimized 20-core (5x4 grid) and all-core (13x10 grid) configurations:
 - **20 cores (optimized)**: Set `TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE="4,3"`
-- **All cores**: Omit/Unset `TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE` for device default core grid
+- **130 cores**: Omit/Unset `TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE` for P150 device to use all cores (13x10 grid)
+
 
 ### Run the Full Model Test
 ```bash
 # 20-core optimized configuration
 TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE="4,3" pytest models/experimental/panoptic_deeplab/tests/pcc/test_tt_model.py
 
-# All cores full grid configuration (13x10 on blackhole)
+# 130-core grid configuration (13x10 on Blackhole P150)
 pytest models/experimental/panoptic_deeplab/tests/pcc/test_tt_model.py
 ```
+**Note**: All following tests can be run with or without TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE
 
 ### Run Component Tests
 ```bash
@@ -48,8 +50,6 @@ TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE="4,3" pytest models/experimental/panopti
 # Test instance embedding head
 TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE="4,3" pytest models/experimental/panoptic_deeplab/tests/pcc/test_insemb.py
 ```
-
-**Note**: All tests automatically adapt to the available core grid. The 20-core configuration uses optimized matmul configs, while other configurations use auto-config for flexibility.
 
 ### Run Device Performance Tests
 ```bash

--- a/models/experimental/panoptic_deeplab/demo/demo.py
+++ b/models/experimental/panoptic_deeplab/demo/demo.py
@@ -13,7 +13,6 @@ from models.experimental.panoptic_deeplab.tt.model_preprocessing import (
     create_panoptic_deeplab_parameters,
     fuse_conv_bn_parameters,
 )
-from tests.ttnn.unit_tests.base_functionality.test_bh_20_cores_sharding import skip_if_not_blackhole_20_cores
 from models.experimental.panoptic_deeplab.tt.tt_model import TtPanopticDeepLab, create_resnet_dtype_config
 from models.experimental.panoptic_deeplab.reference.pytorch_model import PytorchPanopticDeepLab
 from models.experimental.panoptic_deeplab.tt.common import (
@@ -293,7 +292,10 @@ def run_panoptic_deeplab_demo(
 )
 @pytest.mark.parametrize("model_category", [PANOPTIC_DEEPLAB, DEEPLAB_V3_PLUS])
 def test_panoptic_deeplab_demo(device, output_dir, model_category, model_location_generator):
-    skip_if_not_blackhole_20_cores(device)
+    compute_grid = device.compute_with_storage_grid_size()
+    logger.info(
+        f"Running demo test on compute grid: {compute_grid.x}x{compute_grid.y} ({compute_grid.x * compute_grid.y} cores)"
+    )
     images, weights_path, output_dir = preprocess_input_params(
         output_dir, model_category, current_dir=__file__, model_location_generator=model_location_generator
     )

--- a/models/experimental/panoptic_deeplab/demo/demo.py
+++ b/models/experimental/panoptic_deeplab/demo/demo.py
@@ -27,6 +27,7 @@ from models.experimental.panoptic_deeplab.demo.demo_utils import (
     create_deeplab_v3plus_visualization,
     save_predictions,
     preprocess_input_params,
+    skip_if_not_blackhole_20_or_130_cores,
 )
 from models.experimental.panoptic_deeplab.tests.pcc.common import check_ttnn_output
 
@@ -292,10 +293,8 @@ def run_panoptic_deeplab_demo(
 )
 @pytest.mark.parametrize("model_category", [PANOPTIC_DEEPLAB, DEEPLAB_V3_PLUS])
 def test_panoptic_deeplab_demo(device, output_dir, model_category, model_location_generator):
-    compute_grid = device.compute_with_storage_grid_size()
-    logger.info(
-        f"Running demo test on compute grid: {compute_grid.x}x{compute_grid.y} ({compute_grid.x * compute_grid.y} cores)"
-    )
+    skip_if_not_blackhole_20_or_130_cores(device)
+
     images, weights_path, output_dir = preprocess_input_params(
         output_dir, model_category, current_dir=__file__, model_location_generator=model_location_generator
     )

--- a/models/experimental/panoptic_deeplab/demo/demo_utils.py
+++ b/models/experimental/panoptic_deeplab/demo/demo_utils.py
@@ -15,6 +15,8 @@ from models.experimental.panoptic_deeplab.tt.common import (
     get_panoptic_deeplab_weights_path,
     load_images,
 )
+from models.common.utility_functions import is_blackhole
+import pytest
 
 # Cityscapes dataset configuration
 CITYSCAPES_CATEGORIES = [
@@ -457,3 +459,16 @@ def create_panoptic_visualization(
     blended = cv2.addWeighted(original_image, 1 - alpha, vis_image, alpha, 0)
 
     return blended, {"segments": segments_info, "panoptic_seg": panoptic_seg, "pure_vis": vis_image}
+
+
+def skip_if_not_blackhole_20_or_130_cores(device):
+    """
+    This function is meant to be run only inside pytest tests.
+    """
+    if not is_blackhole():
+        pytest.skip("This test is intended to run only on Blackhole devices with 20 or 130 cores.")
+    compute_grid = device.compute_with_storage_grid_size()
+    if not ((compute_grid.x == 5 and compute_grid.y == 4) or (compute_grid.x == 13 and compute_grid.y == 10)):
+        pytest.skip(
+            f"This test is intended to run only on Blackhole devices with 20 or 130 cores. Core grid [{compute_grid.x},{compute_grid.y}] must be [5, 4] or [13, 10]."
+        )

--- a/models/experimental/panoptic_deeplab/tests/pcc/common.py
+++ b/models/experimental/panoptic_deeplab/tests/pcc/common.py
@@ -6,6 +6,8 @@ import ttnn
 from tests.ttnn.utils_for_testing import check_with_pcc
 from loguru import logger
 import math
+from models.common.utility_functions import is_blackhole
+import pytest
 
 
 def get_abs_and_relative_error(tensor_a, tensor_b):
@@ -59,3 +61,29 @@ def check_ttnn_output(
         )
 
     return passed_pcc and passed_tolerance
+
+
+def skip_if_not_blackhole_20_cores(device):
+    """
+    This function is meant to be run only inside pytest tests.
+    """
+    if not is_blackhole():
+        pytest.skip("This test is intended to run only on Blackhole devices with 20 cores.")
+    compute_grid = device.compute_with_storage_grid_size()
+    if compute_grid.x != 5 or compute_grid.y != 4:
+        pytest.skip(
+            f"This test is intended to run only on Blackhole devices with 20 cores. Core grid [{compute_grid.x},{compute_grid.y}] must be [5, 4]."
+        )
+
+
+def skip_if_not_blackhole_130_cores(device):
+    """
+    This function is meant to be run only inside pytest tests.
+    """
+    if not is_blackhole():
+        pytest.skip("This test is intended to run only on Blackhole P150 devices with 130 cores.")
+    compute_grid = device.compute_with_storage_grid_size()
+    if compute_grid.x != 13 or compute_grid.y != 10:
+        pytest.skip(
+            f"This test is intended to run only on Blackhole P150 devices with 130 cores. Core grid [{compute_grid.x},{compute_grid.y}] must be [13, 10]."
+        )

--- a/models/experimental/panoptic_deeplab/tests/pcc/test_aspp.py
+++ b/models/experimental/panoptic_deeplab/tests/pcc/test_aspp.py
@@ -115,15 +115,24 @@ def test_ttnn_aspp(device, model_location_generator):
     ttnn_aspp_output_torch = ttnn.to_torch(ttnn_aspp_output).permute(0, 3, 1, 2)
     ttnn_aspp_output_torch = torch.reshape(ttnn_aspp_output_torch, (1, 256, 32, 64))
 
+    # PCC values differ between 20-core (5x4) and all-core configurations
+    is_20_core_grid = compute_grid.x == 5 and compute_grid.y == 4
+
+    if is_20_core_grid:
+        aspp_pcc, aspp_abs_err, aspp_rel_err = 0.99, 0.03, 0.4
+    else:
+        # Relaxed tolerances for all-core grid with auto-generated program config
+        aspp_pcc, aspp_abs_err, aspp_rel_err = 0.99, 0.1, 1.0
+
     passed = check_ttnn_output(
         "aspp_output",
         pytorch_aspp_output,
         ttnn_aspp_output,
         to_channel_first=True,
         output_shape=(1, 256, 32, 64),
-        exp_pcc=0.99,
-        exp_abs_err=0.03,
-        exp_rel_err=0.4,
+        exp_pcc=aspp_pcc,
+        exp_abs_err=aspp_abs_err,
+        exp_rel_err=aspp_rel_err,
     )
 
     assert passed, f"ASPP PCC and tolerance test failed"

--- a/models/experimental/panoptic_deeplab/tests/pcc/test_aspp.py
+++ b/models/experimental/panoptic_deeplab/tests/pcc/test_aspp.py
@@ -121,8 +121,7 @@ def test_ttnn_aspp(device, model_location_generator):
     if is_20_core_grid:
         aspp_pcc, aspp_abs_err, aspp_rel_err = 0.99, 0.03, 0.4
     else:
-        # Relaxed tolerances for all-core grid with auto-generated program config
-        aspp_pcc, aspp_abs_err, aspp_rel_err = 0.99, 0.1, 1.0
+        aspp_pcc, aspp_abs_err, aspp_rel_err = 0.998, 0.04, 0.5
 
     passed = check_ttnn_output(
         "aspp_output",

--- a/models/experimental/panoptic_deeplab/tests/pcc/test_aspp.py
+++ b/models/experimental/panoptic_deeplab/tests/pcc/test_aspp.py
@@ -18,12 +18,33 @@ from models.experimental.panoptic_deeplab.tt.common import (
     get_panoptic_deeplab_weights_path,
     get_panoptic_deeplab_config,
 )
-from models.experimental.panoptic_deeplab.tests.pcc.common import check_ttnn_output
+from models.experimental.panoptic_deeplab.tests.pcc.common import (
+    check_ttnn_output,
+    skip_if_not_blackhole_130_cores,
+    skip_if_not_blackhole_20_cores,
+)
 
 
+@pytest.mark.parametrize(
+    "pcc_values, skip_check",
+    [
+        (
+            {"pcc": 0.99, "abs_err": 0.03, "rel_err": 0.4},
+            skip_if_not_blackhole_20_cores,
+        ),
+        (
+            {"pcc": 0.998, "abs_err": 0.04, "rel_err": 0.5},
+            skip_if_not_blackhole_130_cores,
+        ),
+    ],
+    ids=["20_cores", "130_cores"],
+)
 @pytest.mark.parametrize("device_params", [{"l1_small_size": PDL_L1_SMALL_SIZE}], indirect=True)
-def test_ttnn_aspp(device, model_location_generator):
+def test_ttnn_aspp(device, pcc_values, skip_check, model_location_generator):
     """Test ASPP component using the full model with real weights."""
+
+    # Skip test if device doesn't match the expected grid configuration
+    skip_check(device)
 
     compute_grid = device.compute_with_storage_grid_size()
     logger.info(
@@ -115,23 +136,16 @@ def test_ttnn_aspp(device, model_location_generator):
     ttnn_aspp_output_torch = ttnn.to_torch(ttnn_aspp_output).permute(0, 3, 1, 2)
     ttnn_aspp_output_torch = torch.reshape(ttnn_aspp_output_torch, (1, 256, 32, 64))
 
-    # PCC values differ between 20-core (5x4) and all-core configurations
-    is_20_core_grid = compute_grid.x == 5 and compute_grid.y == 4
-
-    if is_20_core_grid:
-        aspp_pcc, aspp_abs_err, aspp_rel_err = 0.99, 0.03, 0.4
-    else:
-        aspp_pcc, aspp_abs_err, aspp_rel_err = 0.998, 0.04, 0.5
-
+    # Extract PCC thresholds from parameters
     passed = check_ttnn_output(
         "aspp_output",
         pytorch_aspp_output,
         ttnn_aspp_output,
         to_channel_first=True,
         output_shape=(1, 256, 32, 64),
-        exp_pcc=aspp_pcc,
-        exp_abs_err=aspp_abs_err,
-        exp_rel_err=aspp_rel_err,
+        exp_pcc=pcc_values["pcc"],
+        exp_abs_err=pcc_values["abs_err"],
+        exp_rel_err=pcc_values["rel_err"],
     )
 
     assert passed, f"ASPP PCC and tolerance test failed"

--- a/models/experimental/panoptic_deeplab/tests/pcc/test_aspp.py
+++ b/models/experimental/panoptic_deeplab/tests/pcc/test_aspp.py
@@ -26,8 +26,9 @@ def test_ttnn_aspp(device, model_location_generator):
     """Test ASPP component using the full model with real weights."""
 
     compute_grid = device.compute_with_storage_grid_size()
-    if compute_grid.x != 5 or compute_grid.y != 4:
-        pytest.skip(f"Test requires compute grid size of 5x4, but got {compute_grid.x}x{compute_grid.y}")
+    logger.info(
+        f"Running test on compute grid: {compute_grid.x}x{compute_grid.y} ({compute_grid.x * compute_grid.y} cores)"
+    )
 
     torch.manual_seed(0)
 

--- a/models/experimental/panoptic_deeplab/tests/pcc/test_insemb.py
+++ b/models/experimental/panoptic_deeplab/tests/pcc/test_insemb.py
@@ -27,8 +27,9 @@ def test_ttnn_insemb(device, model_location_generator):
     """Test instance embedding head using the full model with real weights."""
 
     compute_grid = device.compute_with_storage_grid_size()
-    if compute_grid.x != 5 or compute_grid.y != 4:
-        pytest.skip(f"Test requires compute grid size of 5x4, but got {compute_grid.x}x{compute_grid.y}")
+    logger.info(
+        f"Running test on compute grid: {compute_grid.x}x{compute_grid.y} ({compute_grid.x * compute_grid.y} cores)"
+    )
 
     torch.manual_seed(0)
 

--- a/models/experimental/panoptic_deeplab/tests/pcc/test_insemb.py
+++ b/models/experimental/panoptic_deeplab/tests/pcc/test_insemb.py
@@ -127,9 +127,8 @@ def test_ttnn_insemb(device, model_location_generator):
         center_pcc, center_abs_err, center_rel_err = 0.887, 0.09, 27.5
         offset_pcc, offset_abs_err, offset_rel_err = 0.742, 6.8, 5.0
     else:
-        # Relaxed tolerances for all-core grid with auto-generated program config
-        center_pcc, center_abs_err, center_rel_err = 0.88, 5.0, 30.0
-        offset_pcc, offset_abs_err, offset_rel_err = 0.74, 10.0, 10.0
+        center_pcc, center_abs_err, center_rel_err = 0.887, 0.09, 27.5
+        offset_pcc, offset_abs_err, offset_rel_err = 0.741, 6.8, 5.0
 
     all_passed = []
     all_passed.append(

--- a/models/experimental/panoptic_deeplab/tests/pcc/test_insemb.py
+++ b/models/experimental/panoptic_deeplab/tests/pcc/test_insemb.py
@@ -120,6 +120,17 @@ def test_ttnn_insemb(device, model_location_generator):
     logger.info("Running TTNN instance embedding head test...")
     ttnn_center_out_tt, ttnn_offset_out_tt, _, _ = ttnn_model.instance_head(ttnn_features)
 
+    # PCC values differ between 20-core (5x4) and all-core configurations
+    is_20_core_grid = compute_grid.x == 5 and compute_grid.y == 4
+
+    if is_20_core_grid:
+        center_pcc, center_abs_err, center_rel_err = 0.887, 0.09, 27.5
+        offset_pcc, offset_abs_err, offset_rel_err = 0.742, 6.8, 5.0
+    else:
+        # Relaxed tolerances for all-core grid with auto-generated program config
+        center_pcc, center_abs_err, center_rel_err = 0.88, 5.0, 30.0
+        offset_pcc, offset_abs_err, offset_rel_err = 0.74, 10.0, 10.0
+
     all_passed = []
     all_passed.append(
         check_ttnn_output(
@@ -128,9 +139,9 @@ def test_ttnn_insemb(device, model_location_generator):
             ttnn_center_out_tt,
             to_channel_first=False,
             output_channels=ttnn_model.instance_head.get_center_output_channels_for_slicing(),
-            exp_pcc=0.887,
-            exp_abs_err=0.09,
-            exp_rel_err=27.5,
+            exp_pcc=center_pcc,
+            exp_abs_err=center_abs_err,
+            exp_rel_err=center_rel_err,
         )
     )
     all_passed.append(
@@ -140,9 +151,9 @@ def test_ttnn_insemb(device, model_location_generator):
             ttnn_offset_out_tt,
             to_channel_first=False,
             output_channels=ttnn_model.instance_head.get_offset_output_channels_for_slicing(),
-            exp_pcc=0.742,
-            exp_abs_err=6.8,
-            exp_rel_err=5.0,
+            exp_pcc=offset_pcc,
+            exp_abs_err=offset_abs_err,
+            exp_rel_err=offset_rel_err,
         )
     )
 

--- a/models/experimental/panoptic_deeplab/tests/pcc/test_resnet.py
+++ b/models/experimental/panoptic_deeplab/tests/pcc/test_resnet.py
@@ -102,8 +102,9 @@ def create_panoptic_models(device, weights_path):
 def test_resnet_stem_pcc(device, input_shape_nchw, reset_seeds, model_location_generator):
     """Test ResNet stem layer PCC between PyTorch and TTNN implementations."""
     compute_grid = device.compute_with_storage_grid_size()
-    if compute_grid.x != 5 or compute_grid.y != 4:
-        pytest.skip(f"Test requires compute grid size of 5x4, but got {compute_grid.x}x{compute_grid.y}")
+    logger.info(
+        f"Running test on compute grid: {compute_grid.x}x{compute_grid.y} ({compute_grid.x * compute_grid.y} cores)"
+    )
 
     torch.manual_seed(0)
 
@@ -147,8 +148,9 @@ def test_resnet_layer_pcc(
     """Test ResNet individual layer PCC between PyTorch and TTNN implementations."""
 
     compute_grid = device.compute_with_storage_grid_size()
-    if compute_grid.x != 5 or compute_grid.y != 4:
-        pytest.skip(f"Test requires compute grid size of 5x4, but got {compute_grid.x}x{compute_grid.y}")
+    logger.info(
+        f"Running test on compute grid: {compute_grid.x}x{compute_grid.y} ({compute_grid.x * compute_grid.y} cores)"
+    )
 
     torch.manual_seed(0)
 
@@ -223,8 +225,9 @@ def test_resnet_layer_pcc(
 def test_resnet_full_pcc(device, batch_size, height, width, reset_seeds, model_location_generator):
     """Test full ResNet PCC between PyTorch and TTNN implementations."""
     compute_grid = device.compute_with_storage_grid_size()
-    if compute_grid.x != 5 or compute_grid.y != 4:
-        pytest.skip(f"Test requires compute grid size of 5x4, but got {compute_grid.x}x{compute_grid.y}")
+    logger.info(
+        f"Running test on compute grid: {compute_grid.x}x{compute_grid.y} ({compute_grid.x * compute_grid.y} cores)"
+    )
 
     torch.manual_seed(0)
 

--- a/models/experimental/panoptic_deeplab/tests/pcc/test_resnet.py
+++ b/models/experimental/panoptic_deeplab/tests/pcc/test_resnet.py
@@ -272,12 +272,11 @@ def test_resnet_full_pcc(device, batch_size, height, width, reset_seeds, model_l
             "res5": 0.6,
         }
     else:
-        # Very relaxed tolerances for all-core grid with auto-generated program config
         layer_pcc_thresholds = {
-            "res2": 0.99,
-            "res3": 0.99,
-            "res4": 0.99,
-            "res5": 0.99,
+            "res2": 0.999,
+            "res3": 0.999,
+            "res4": 0.999,
+            "res5": 0.992,
         }
         layer_exp_abs_err = {
             "res2": 0.5,
@@ -286,9 +285,9 @@ def test_resnet_full_pcc(device, batch_size, height, width, reset_seeds, model_l
             "res5": 0.5,
         }
         layer_exp_rel_err = {
-            "res2": 0.7,
-            "res3": 0.7,
-            "res4": 0.7,
+            "res2": 0.3,
+            "res3": 0.6,
+            "res4": 0.3,
             "res5": 0.7,
         }
 

--- a/models/experimental/panoptic_deeplab/tests/pcc/test_resnet.py
+++ b/models/experimental/panoptic_deeplab/tests/pcc/test_resnet.py
@@ -249,27 +249,48 @@ def test_resnet_full_pcc(device, batch_size, height, width, reset_seeds, model_l
         torch_outputs = pytorch_model.backbone(torch_input)
 
     failed_layers = []
-    # Set layer-specific PCC thresholds based on test failures
-    layer_pcc_thresholds = {
-        "res2": 0.998,
-        "res3": 0.997,
-        "res4": 0.9965,
-        "res5": 0.9945,
-    }
+    # PCC values differ between 20-core (5x4) and all-core configurations
+    is_20_core_grid = compute_grid.x == 5 and compute_grid.y == 4
 
-    layer_exp_abs_err = {
-        "res2": 0.1,
-        "res3": 0.04,
-        "res4": 0.02,
-        "res5": 0.01,
-    }
-
-    layer_exp_rel_err = {
-        "res2": 0.3,
-        "res3": 0.6,
-        "res4": 0.3,
-        "res5": 0.6,
-    }
+    if is_20_core_grid:
+        layer_pcc_thresholds = {
+            "res2": 0.998,
+            "res3": 0.997,
+            "res4": 0.9965,
+            "res5": 0.9945,
+        }
+        layer_exp_abs_err = {
+            "res2": 0.1,
+            "res3": 0.04,
+            "res4": 0.02,
+            "res5": 0.01,
+        }
+        layer_exp_rel_err = {
+            "res2": 0.3,
+            "res3": 0.6,
+            "res4": 0.3,
+            "res5": 0.6,
+        }
+    else:
+        # Very relaxed tolerances for all-core grid with auto-generated program config
+        layer_pcc_thresholds = {
+            "res2": 0.99,
+            "res3": 0.99,
+            "res4": 0.99,
+            "res5": 0.99,
+        }
+        layer_exp_abs_err = {
+            "res2": 0.5,
+            "res3": 0.5,
+            "res4": 0.5,
+            "res5": 0.5,
+        }
+        layer_exp_rel_err = {
+            "res2": 0.7,
+            "res3": 0.7,
+            "res4": 0.7,
+            "res5": 0.7,
+        }
 
     for layer_name in ["res2", "res3", "res4", "res5"]:
         torch_output = torch_outputs[layer_name]

--- a/models/experimental/panoptic_deeplab/tests/pcc/test_resnet.py
+++ b/models/experimental/panoptic_deeplab/tests/pcc/test_resnet.py
@@ -24,7 +24,11 @@ from models.experimental.panoptic_deeplab.tt.common import (
     get_panoptic_deeplab_config,
     preprocess_nchw_input_tensor,
 )
-from models.experimental.panoptic_deeplab.tests.pcc.common import check_ttnn_output
+from models.experimental.panoptic_deeplab.tests.pcc.common import (
+    check_ttnn_output,
+    skip_if_not_blackhole_130_cores,
+    skip_if_not_blackhole_20_cores,
+)
 
 
 def create_panoptic_models(device, weights_path):
@@ -94,13 +98,25 @@ def create_panoptic_models(device, weights_path):
     return pytorch_model, ttnn_model
 
 
+@pytest.mark.parametrize(
+    "pcc_threshold, skip_check",
+    [
+        (0.99, skip_if_not_blackhole_20_cores),
+        (0.99, skip_if_not_blackhole_130_cores),
+    ],
+    ids=["20_cores", "130_cores"],
+)
 @pytest.mark.parametrize("device_params", [{"l1_small_size": PDL_L1_SMALL_SIZE}], indirect=True)
 @pytest.mark.parametrize(
     "input_shape_nchw",
     [(1, 3, 512, 1024)],
 )
-def test_resnet_stem_pcc(device, input_shape_nchw, reset_seeds, model_location_generator):
+def test_resnet_stem_pcc(device, pcc_threshold, skip_check, input_shape_nchw, reset_seeds, model_location_generator):
     """Test ResNet stem layer PCC between PyTorch and TTNN implementations."""
+
+    # Skip test if device doesn't match the expected grid configuration
+    skip_check(device)
+
     compute_grid = device.compute_with_storage_grid_size()
     logger.info(
         f"Running test on compute grid: {compute_grid.x}x{compute_grid.y} ({compute_grid.x * compute_grid.y} cores)"
@@ -129,23 +145,39 @@ def test_resnet_stem_pcc(device, input_shape_nchw, reset_seeds, model_location_g
         torch_stem_output = pytorch_model.backbone.stem(torch_input)
 
     ttnn_output_torch = ttnn.to_torch(ttnn_stem_output).permute(0, 3, 1, 2).reshape(torch_stem_output.shape)
-    pcc_passed, pcc_message = assert_with_pcc(torch_stem_output, ttnn_output_torch, 0.99)
+    pcc_passed, pcc_message = assert_with_pcc(torch_stem_output, ttnn_output_torch, pcc_threshold)
 
     logger.info(f"ResNet stem PCC: {pcc_message}")
     assert pcc_passed, f"ResNet stem PCC test failed: {pcc_message}"
 
 
+@pytest.mark.parametrize(
+    "layer_pcc_values, skip_check",
+    [
+        (
+            [("res2", 0.99), ("res3", 0.99), ("res4", 0.99), ("res5", 0.99)],
+            skip_if_not_blackhole_20_cores,
+        ),
+        (
+            [("res2", 0.99), ("res3", 0.99), ("res4", 0.99), ("res5", 0.99)],
+            skip_if_not_blackhole_130_cores,
+        ),
+    ],
+    ids=["20_cores", "130_cores"],
+)
 @pytest.mark.parametrize("device_params", [{"l1_small_size": PDL_L1_SMALL_SIZE}], indirect=True)
 @pytest.mark.parametrize("batch_size", [1])
 @pytest.mark.parametrize(
     "height,width",
     [(512, 1024)],
 )
-@pytest.mark.parametrize("layer_name, expected_pcc", [("res2", 0.99), ("res3", 0.99), ("res4", 0.99), ("res5", 0.99)])
 def test_resnet_layer_pcc(
-    device, batch_size, height, width, layer_name, expected_pcc, reset_seeds, model_location_generator
+    device, layer_pcc_values, skip_check, batch_size, height, width, reset_seeds, model_location_generator
 ):
     """Test ResNet individual layer PCC between PyTorch and TTNN implementations."""
+
+    # Skip test if device doesn't match the expected grid configuration
+    skip_check(device)
 
     compute_grid = device.compute_with_storage_grid_size()
     logger.info(
@@ -169,61 +201,98 @@ def test_resnet_layer_pcc(
         "res5": (1024, 1 / 16, 1 / 16),
     }
 
-    in_channels, h_factor, w_factor = layer_specs[layer_name]
-    layer_height = int(height * h_factor)
-    layer_width = int(width * w_factor)
+    failed_layers = []
 
-    torch_layer_input = torch.randn(batch_size, in_channels, layer_height, layer_width, dtype=torch.bfloat16)
-    ttnn_layer_input = ttnn.from_torch(
-        torch_layer_input.permute(0, 2, 3, 1),
-        dtype=ttnn.bfloat16,
-        device=device,
-        layout=ttnn.ROW_MAJOR_LAYOUT,
-    )
+    for layer_name, expected_pcc in layer_pcc_values:
+        in_channels, h_factor, w_factor = layer_specs[layer_name]
+        layer_height = int(height * h_factor)
+        layer_width = int(width * w_factor)
 
-    if layer_name == "res2":
-        for block in ttnn_model.backbone.res2:
-            ttnn_layer_input = block(ttnn_layer_input)
-        ttnn_layer_output = ttnn_layer_input
-    elif layer_name == "res3":
-        for block in ttnn_model.backbone.res3:
-            ttnn_layer_input = block(ttnn_layer_input)
-        ttnn_layer_output = ttnn_layer_input
-    elif layer_name == "res4":
-        for block in ttnn_model.backbone.res4:
-            ttnn_layer_input = block(ttnn_layer_input)
-        ttnn_layer_output = ttnn_layer_input
-    elif layer_name == "res5":
-        for block in ttnn_model.backbone.res5:
-            ttnn_layer_input = block(ttnn_layer_input)
-        ttnn_layer_output = ttnn_layer_input
+        torch_layer_input = torch.randn(batch_size, in_channels, layer_height, layer_width, dtype=torch.bfloat16)
+        ttnn_layer_input = ttnn.from_torch(
+            torch_layer_input.permute(0, 2, 3, 1),
+            dtype=ttnn.bfloat16,
+            device=device,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+        )
 
-    with torch.no_grad():
         if layer_name == "res2":
-            torch_layer_output = pytorch_model.backbone.res2(torch_layer_input)
+            for block in ttnn_model.backbone.res2:
+                ttnn_layer_input = block(ttnn_layer_input)
+            ttnn_layer_output = ttnn_layer_input
         elif layer_name == "res3":
-            torch_layer_output = pytorch_model.backbone.res3(torch_layer_input)
+            for block in ttnn_model.backbone.res3:
+                ttnn_layer_input = block(ttnn_layer_input)
+            ttnn_layer_output = ttnn_layer_input
         elif layer_name == "res4":
-            torch_layer_output = pytorch_model.backbone.res4(torch_layer_input)
+            for block in ttnn_model.backbone.res4:
+                ttnn_layer_input = block(ttnn_layer_input)
+            ttnn_layer_output = ttnn_layer_input
         elif layer_name == "res5":
-            torch_layer_output = pytorch_model.backbone.res5(torch_layer_input)
+            for block in ttnn_model.backbone.res5:
+                ttnn_layer_input = block(ttnn_layer_input)
+            ttnn_layer_output = ttnn_layer_input
 
-    ttnn_output_torch = ttnn.to_torch(ttnn_layer_output).permute(0, 3, 1, 2).reshape(torch_layer_output.shape)
+        with torch.no_grad():
+            if layer_name == "res2":
+                torch_layer_output = pytorch_model.backbone.res2(torch_layer_input)
+            elif layer_name == "res3":
+                torch_layer_output = pytorch_model.backbone.res3(torch_layer_input)
+            elif layer_name == "res4":
+                torch_layer_output = pytorch_model.backbone.res4(torch_layer_input)
+            elif layer_name == "res5":
+                torch_layer_output = pytorch_model.backbone.res5(torch_layer_input)
 
-    pcc_passed, pcc_message = assert_with_pcc(torch_layer_output, ttnn_output_torch, expected_pcc)
+        ttnn_output_torch = ttnn.to_torch(ttnn_layer_output).permute(0, 3, 1, 2).reshape(torch_layer_output.shape)
 
-    logger.info(f"ResNet {layer_name} PCC: {pcc_message}")
-    assert pcc_passed, f"ResNet {layer_name} PCC test failed: {pcc_message}"
+        pcc_passed, pcc_message = assert_with_pcc(torch_layer_output, ttnn_output_torch, expected_pcc)
+
+        logger.info(f"ResNet {layer_name} PCC: {pcc_message}")
+
+        if not pcc_passed:
+            failed_layers.append(layer_name)
+
+    assert len(failed_layers) == 0, f"ResNet layer PCC tests failed for layers: {failed_layers}"
 
 
+@pytest.mark.parametrize(
+    "pcc_values, skip_check",
+    [
+        (
+            {
+                "res2": {"pcc": 0.998, "abs_err": 0.1, "rel_err": 0.3},
+                "res3": {"pcc": 0.997, "abs_err": 0.04, "rel_err": 0.6},
+                "res4": {"pcc": 0.9965, "abs_err": 0.02, "rel_err": 0.3},
+                "res5": {"pcc": 0.9945, "abs_err": 0.01, "rel_err": 0.6},
+            },
+            skip_if_not_blackhole_20_cores,
+        ),
+        (
+            {
+                "res2": {"pcc": 0.999, "abs_err": 0.5, "rel_err": 0.3},
+                "res3": {"pcc": 0.999, "abs_err": 0.5, "rel_err": 0.6},
+                "res4": {"pcc": 0.999, "abs_err": 0.5, "rel_err": 0.3},
+                "res5": {"pcc": 0.992, "abs_err": 0.5, "rel_err": 0.7},
+            },
+            skip_if_not_blackhole_130_cores,
+        ),
+    ],
+    ids=["20_cores", "130_cores"],
+)
 @pytest.mark.parametrize("device_params", [{"l1_small_size": PDL_L1_SMALL_SIZE}], indirect=True)
 @pytest.mark.parametrize("batch_size", [1])
 @pytest.mark.parametrize(
     "height,width",
     [(512, 1024)],
 )
-def test_resnet_full_pcc(device, batch_size, height, width, reset_seeds, model_location_generator):
+def test_resnet_full_pcc(
+    device, pcc_values, skip_check, batch_size, height, width, reset_seeds, model_location_generator
+):
     """Test full ResNet PCC between PyTorch and TTNN implementations."""
+
+    # Skip test if device doesn't match the expected grid configuration
+    skip_check(device)
+
     compute_grid = device.compute_with_storage_grid_size()
     logger.info(
         f"Running test on compute grid: {compute_grid.x}x{compute_grid.y} ({compute_grid.x * compute_grid.y} cores)"
@@ -249,55 +318,16 @@ def test_resnet_full_pcc(device, batch_size, height, width, reset_seeds, model_l
         torch_outputs = pytorch_model.backbone(torch_input)
 
     failed_layers = []
-    # PCC values differ between 20-core (5x4) and all-core configurations
-    is_20_core_grid = compute_grid.x == 5 and compute_grid.y == 4
-
-    if is_20_core_grid:
-        layer_pcc_thresholds = {
-            "res2": 0.998,
-            "res3": 0.997,
-            "res4": 0.9965,
-            "res5": 0.9945,
-        }
-        layer_exp_abs_err = {
-            "res2": 0.1,
-            "res3": 0.04,
-            "res4": 0.02,
-            "res5": 0.01,
-        }
-        layer_exp_rel_err = {
-            "res2": 0.3,
-            "res3": 0.6,
-            "res4": 0.3,
-            "res5": 0.6,
-        }
-    else:
-        layer_pcc_thresholds = {
-            "res2": 0.999,
-            "res3": 0.999,
-            "res4": 0.999,
-            "res5": 0.992,
-        }
-        layer_exp_abs_err = {
-            "res2": 0.5,
-            "res3": 0.5,
-            "res4": 0.5,
-            "res5": 0.5,
-        }
-        layer_exp_rel_err = {
-            "res2": 0.3,
-            "res3": 0.6,
-            "res4": 0.3,
-            "res5": 0.7,
-        }
 
     for layer_name in ["res2", "res3", "res4", "res5"]:
         torch_output = torch_outputs[layer_name]
         ttnn_output = ttnn_outputs[layer_name]
 
-        pcc_threshold = layer_pcc_thresholds[layer_name]
-        exp_abs_err = layer_exp_abs_err[layer_name]
-        exp_rel_err = layer_exp_rel_err[layer_name]
+        # Extract PCC thresholds from parameters
+        layer_vals = pcc_values[layer_name]
+        pcc_threshold = layer_vals["pcc"]
+        exp_abs_err = layer_vals["abs_err"]
+        exp_rel_err = layer_vals["rel_err"]
 
         passed = check_ttnn_output(
             layer_name,

--- a/models/experimental/panoptic_deeplab/tests/pcc/test_semseg.py
+++ b/models/experimental/panoptic_deeplab/tests/pcc/test_semseg.py
@@ -26,8 +26,9 @@ from models.experimental.panoptic_deeplab.tests.pcc.common import check_ttnn_out
 def test_ttnn_semseg(device, model_location_generator):
     """Test semantic segmentation head using the full model with real weights."""
     compute_grid = device.compute_with_storage_grid_size()
-    if compute_grid.x != 5 or compute_grid.y != 4:
-        pytest.skip(f"Test requires compute grid size of 5x4, but got {compute_grid.x}x{compute_grid.y}")
+    logger.info(
+        f"Running test on compute grid: {compute_grid.x}x{compute_grid.y} ({compute_grid.x * compute_grid.y} cores)"
+    )
 
     torch.manual_seed(0)
 

--- a/models/experimental/panoptic_deeplab/tests/pcc/test_semseg.py
+++ b/models/experimental/panoptic_deeplab/tests/pcc/test_semseg.py
@@ -121,8 +121,7 @@ def test_ttnn_semseg(device, model_location_generator):
     if is_20_core_grid:
         semantic_pcc, semantic_abs_err, semantic_rel_err = 0.972, 2.0, 0.4
     else:
-        # Relaxed tolerances for all-core grid with auto-generated program config
-        semantic_pcc, semantic_abs_err, semantic_rel_err = 0.972, 4.5, 2.0
+        semantic_pcc, semantic_abs_err, semantic_rel_err = 0.972, 1.9, 0.4
 
     passed = check_ttnn_output(
         "Semantic",

--- a/models/experimental/panoptic_deeplab/tests/pcc/test_semseg.py
+++ b/models/experimental/panoptic_deeplab/tests/pcc/test_semseg.py
@@ -19,12 +19,34 @@ from models.experimental.panoptic_deeplab.tt.common import (
     get_panoptic_deeplab_weights_path,
     get_panoptic_deeplab_config,
 )
-from models.experimental.panoptic_deeplab.tests.pcc.common import check_ttnn_output
+from models.experimental.panoptic_deeplab.tests.pcc.common import (
+    check_ttnn_output,
+    skip_if_not_blackhole_130_cores,
+    skip_if_not_blackhole_20_cores,
+)
 
 
+@pytest.mark.parametrize(
+    "pcc_values, skip_check",
+    [
+        (
+            {"pcc": 0.972, "abs_err": 2.0, "rel_err": 0.4},
+            skip_if_not_blackhole_20_cores,
+        ),
+        (
+            {"pcc": 0.972, "abs_err": 1.9, "rel_err": 0.4},
+            skip_if_not_blackhole_130_cores,
+        ),
+    ],
+    ids=["20_cores", "130_cores"],
+)
 @pytest.mark.parametrize("device_params", [{"l1_small_size": PDL_L1_SMALL_SIZE}], indirect=True)
-def test_ttnn_semseg(device, model_location_generator):
+def test_ttnn_semseg(device, pcc_values, skip_check, model_location_generator):
     """Test semantic segmentation head using the full model with real weights."""
+
+    # Skip test if device doesn't match the expected grid configuration
+    skip_check(device)
+
     compute_grid = device.compute_with_storage_grid_size()
     logger.info(
         f"Running test on compute grid: {compute_grid.x}x{compute_grid.y} ({compute_grid.x * compute_grid.y} cores)"
@@ -115,22 +137,15 @@ def test_ttnn_semseg(device, model_location_generator):
     logger.info("Running TTNN semantic segmentation head test...")
     ttnn_out_tt, _ = ttnn_model.semantic_head(ttnn_features)
 
-    # PCC values differ between 20-core (5x4) and all-core configurations
-    is_20_core_grid = compute_grid.x == 5 and compute_grid.y == 4
-
-    if is_20_core_grid:
-        semantic_pcc, semantic_abs_err, semantic_rel_err = 0.972, 2.0, 0.4
-    else:
-        semantic_pcc, semantic_abs_err, semantic_rel_err = 0.972, 1.9, 0.4
-
+    # Extract PCC thresholds from parameters
     passed = check_ttnn_output(
         "Semantic",
         torch_out,
         ttnn_out_tt,
         to_channel_first=False,
         output_channels=ttnn_model.semantic_head.get_output_channels_for_slicing(),
-        exp_pcc=semantic_pcc,
-        exp_abs_err=semantic_abs_err,
-        exp_rel_err=semantic_rel_err,
+        exp_pcc=pcc_values["pcc"],
+        exp_abs_err=pcc_values["abs_err"],
+        exp_rel_err=pcc_values["rel_err"],
     )
     assert passed, f"Semantic segmentation PCC and tolerance tests failed"

--- a/models/experimental/panoptic_deeplab/tests/pcc/test_tt_model.py
+++ b/models/experimental/panoptic_deeplab/tests/pcc/test_tt_model.py
@@ -24,7 +24,6 @@ from models.experimental.panoptic_deeplab.tt.common import (
 )
 from models.experimental.panoptic_deeplab.tests.pcc.common import check_ttnn_output
 from models.experimental.panoptic_deeplab.tt.common import preprocess_nchw_input_tensor
-from tests.ttnn.unit_tests.base_functionality.test_bh_20_cores_sharding import skip_if_not_blackhole_20_cores
 
 
 @pytest.mark.parametrize(
@@ -36,7 +35,11 @@ from tests.ttnn.unit_tests.base_functionality.test_bh_20_cores_sharding import s
 def test_model_panoptic_deeplab(device, model_category, model_location_generator):
     """Test PCC comparison between PyTorch and TTNN implementations with fused Conv+BatchNorm."""
 
-    skip_if_not_blackhole_20_cores(device)
+    compute_grid = device.compute_with_storage_grid_size()
+    logger.info(
+        f"Running test on compute grid: {compute_grid.x}x{compute_grid.y} ({compute_grid.x * compute_grid.y} cores)"
+    )
+
     torch.manual_seed(0)
 
     # Get the weights path using the common utility function

--- a/models/experimental/panoptic_deeplab/tests/pcc/test_tt_model.py
+++ b/models/experimental/panoptic_deeplab/tests/pcc/test_tt_model.py
@@ -143,10 +143,9 @@ def test_model_panoptic_deeplab(device, model_category, model_location_generator
         offset_pcc, offset_abs_err, offset_rel_err = 0.990, 10.4, 0.6
     else:
         # PCC values for all-core grid with auto-generated program config
-        # Using very relaxed tolerances
-        semantic_pcc, semantic_abs_err, semantic_rel_err = 0.98, 5.0, 1.0
-        center_pcc, center_abs_err, center_rel_err = 0.81, 10.0, 5.0
-        offset_pcc, offset_abs_err, offset_rel_err = 0.984, 15.0, 2.0
+        semantic_pcc, semantic_abs_err, semantic_rel_err = 0.982, 1.4, 0.5
+        center_pcc, center_abs_err, center_rel_err = 0.811, 0.1, 2.4
+        offset_pcc, offset_abs_err, offset_rel_err = 0.984, 12.2, 0.7
 
     all_passed = []
     all_passed.append(

--- a/models/experimental/panoptic_deeplab/tests/pcc/test_tt_model.py
+++ b/models/experimental/panoptic_deeplab/tests/pcc/test_tt_model.py
@@ -106,7 +106,7 @@ def test_model_panoptic_deeplab(device, model_category, pcc_values, skip_check, 
 
     # Both models have ImageNet normalization fused into conv1 weights
     # so they both receive unnormalized input (no explicit normalization needed)
-    pytorch_input = torch.randn(batch_size, input_channels, input_height, input_width, dtype=torch.float32)
+    pytorch_input = torch.randn(batch_size, input_channels, input_height, input_width, dtype=torch.bfloat16)
 
     # Use proper input preprocessing to avoid OOM (creates HEIGHT SHARDED memory config)
     ttnn_input = preprocess_nchw_input_tensor(device, pytorch_input)
@@ -123,7 +123,7 @@ def test_model_panoptic_deeplab(device, model_category, pcc_values, skip_check, 
             weights_path=complete_weights_path,
             model_category=model_category,
         )
-        pytorch_model = pytorch_model.to(dtype=torch.float32)
+        pytorch_model = pytorch_model.to(dtype=torch.bfloat16)
         pytorch_model.eval()
 
         # Create TTNN parameters from the PyTorch model with loaded weights
@@ -222,5 +222,5 @@ def test_model_panoptic_deeplab(device, model_category, pcc_values, skip_check, 
         )
 
     # Fail test based on PCC results
-    # assert all(all_passed), f"PDL outputs did not pass the PCC and tolerance check {all_passed=}"
+    assert all(all_passed), f"PDL outputs did not pass the PCC and tolerance check {all_passed=}"
     logger.info("All PCC and tolerance tests passed!")

--- a/models/experimental/panoptic_deeplab/tests/test_device_perf_pdl.py
+++ b/models/experimental/panoptic_deeplab/tests/test_device_perf_pdl.py
@@ -34,7 +34,49 @@ from models.experimental.panoptic_deeplab.reference.pytorch_model import DEEPLAB
     ids=["test_panoptic_deeplab", "test_deeplab_v3_plus"],
 )
 @pytest.mark.models_device_performance_bare_metal
-def test_device_perf_pdl(
+def test_device_perf_pdl_20_cores(
+    command, expected_device_perf_ns_per_iteration, subdir, model_name, num_iterations, batch_size, margin, comments
+):
+    run_model_device_perf_test(
+        command=command,
+        expected_device_perf_ns_per_iteration=expected_device_perf_ns_per_iteration,
+        subdir=subdir,
+        model_name=model_name,
+        num_iterations=num_iterations,
+        batch_size=batch_size,
+        margin=margin,
+        comments=comments,
+    )
+
+
+@pytest.mark.parametrize(
+    "command, expected_device_perf_ns_per_iteration, subdir, model_name, num_iterations, batch_size, margin, comments",
+    [
+        (
+            "pytest models/experimental/panoptic_deeplab/tests/pcc/test_tt_model.py::test_model_panoptic_deeplab -k test_panoptic_deeplab",
+            10_000_000,
+            PANOPTIC_DEEPLAB,
+            PANOPTIC_DEEPLAB,
+            1,
+            1,
+            0.5,  # Wide margin until actual perf is measured
+            "",
+        ),
+        (
+            "pytest models/experimental/panoptic_deeplab/tests/pcc/test_tt_model.py::test_model_panoptic_deeplab -k test_deeplab_v3_plus",
+            15_000_000,
+            DEEPLAB_V3_PLUS,
+            DEEPLAB_V3_PLUS,
+            1,
+            1,
+            0.5,  # Wide margin until actual perf is measured
+            "",
+        ),
+    ],
+    ids=["test_panoptic_deeplab", "test_deeplab_v3_plus"],
+)
+@pytest.mark.models_device_performance_bare_metal
+def test_device_perf_pdl_all_cores(
     command, expected_device_perf_ns_per_iteration, subdir, model_name, num_iterations, batch_size, margin, comments
 ):
     run_model_device_perf_test(

--- a/models/experimental/panoptic_deeplab/tests/test_device_perf_pdl.py
+++ b/models/experimental/panoptic_deeplab/tests/test_device_perf_pdl.py
@@ -73,10 +73,10 @@ def test_device_perf_pdl_20_cores(
             "",
         ),
     ],
-    ids=["test_panoptic_deeplab_all_cores", "test_deeplab_v3_plus_all_cores"],
+    ids=["test_panoptic_deeplab_130_cores", "test_deeplab_v3_plus_130_cores"],
 )
 @pytest.mark.models_device_performance_bare_metal
-def test_device_perf_pdl_all_cores(
+def test_device_perf_pdl_130_cores(
     command, expected_device_perf_ns_per_iteration, subdir, model_name, num_iterations, batch_size, margin, comments
 ):
     run_model_device_perf_test(

--- a/models/experimental/panoptic_deeplab/tests/test_device_perf_pdl.py
+++ b/models/experimental/panoptic_deeplab/tests/test_device_perf_pdl.py
@@ -11,7 +11,7 @@ from models.experimental.panoptic_deeplab.reference.pytorch_model import DEEPLAB
     "command, expected_device_perf_ns_per_iteration, subdir, model_name, num_iterations, batch_size, margin, comments",
     [
         (
-            "pytest models/experimental/panoptic_deeplab/tests/pcc/test_tt_model.py::test_model_panoptic_deeplab -k test_panoptic_deeplab",
+            "pytest models/experimental/panoptic_deeplab/tests/pcc/test_tt_model.py::test_model_panoptic_deeplab -k panoptic_deeplab_20_cores",
             30_539_964,
             PANOPTIC_DEEPLAB,
             PANOPTIC_DEEPLAB,
@@ -21,7 +21,7 @@ from models.experimental.panoptic_deeplab.reference.pytorch_model import DEEPLAB
             "",
         ),
         (
-            "pytest models/experimental/panoptic_deeplab/tests/pcc/test_tt_model.py::test_model_panoptic_deeplab -k test_deeplab_v3_plus",
+            "pytest models/experimental/panoptic_deeplab/tests/pcc/test_tt_model.py::test_model_panoptic_deeplab -k deeplab_v3_plus_20_cores",
             21_926_462,
             DEEPLAB_V3_PLUS,
             DEEPLAB_V3_PLUS,
@@ -53,7 +53,7 @@ def test_device_perf_pdl_20_cores(
     "command, expected_device_perf_ns_per_iteration, subdir, model_name, num_iterations, batch_size, margin, comments",
     [
         (
-            "pytest models/experimental/panoptic_deeplab/tests/pcc/test_tt_model.py::test_model_panoptic_deeplab -k test_panoptic_deeplab",
+            "pytest models/experimental/panoptic_deeplab/tests/pcc/test_tt_model.py::test_model_panoptic_deeplab -k panoptic_deeplab_130_cores",
             12_445_978,
             PANOPTIC_DEEPLAB,
             PANOPTIC_DEEPLAB,
@@ -63,7 +63,7 @@ def test_device_perf_pdl_20_cores(
             "",
         ),
         (
-            "pytest models/experimental/panoptic_deeplab/tests/pcc/test_tt_model.py::test_model_panoptic_deeplab -k test_deeplab_v3_plus",
+            "pytest models/experimental/panoptic_deeplab/tests/pcc/test_tt_model.py::test_model_panoptic_deeplab -k deeplab_v3_plus_130_cores",
             8_521_002,
             DEEPLAB_V3_PLUS,
             DEEPLAB_V3_PLUS,

--- a/models/experimental/panoptic_deeplab/tests/test_device_perf_pdl.py
+++ b/models/experimental/panoptic_deeplab/tests/test_device_perf_pdl.py
@@ -31,7 +31,7 @@ from models.experimental.panoptic_deeplab.reference.pytorch_model import DEEPLAB
             "",
         ),
     ],
-    ids=["test_panoptic_deeplab", "test_deeplab_v3_plus"],
+    ids=["test_panoptic_deeplab_20_cores", "test_deeplab_v3_plus_20_cores"],
 )
 @pytest.mark.models_device_performance_bare_metal
 def test_device_perf_pdl_20_cores(
@@ -54,26 +54,26 @@ def test_device_perf_pdl_20_cores(
     [
         (
             "pytest models/experimental/panoptic_deeplab/tests/pcc/test_tt_model.py::test_model_panoptic_deeplab -k test_panoptic_deeplab",
-            10_000_000,
+            12_445_978,
             PANOPTIC_DEEPLAB,
             PANOPTIC_DEEPLAB,
             1,
             1,
-            0.5,  # Wide margin until actual perf is measured
+            0.015,
             "",
         ),
         (
             "pytest models/experimental/panoptic_deeplab/tests/pcc/test_tt_model.py::test_model_panoptic_deeplab -k test_deeplab_v3_plus",
-            15_000_000,
+            8_521_002,
             DEEPLAB_V3_PLUS,
             DEEPLAB_V3_PLUS,
             1,
             1,
-            0.5,  # Wide margin until actual perf is measured
+            0.015,
             "",
         ),
     ],
-    ids=["test_panoptic_deeplab", "test_deeplab_v3_plus"],
+    ids=["test_panoptic_deeplab_all_cores", "test_deeplab_v3_plus_all_cores"],
 )
 @pytest.mark.models_device_performance_bare_metal
 def test_device_perf_pdl_all_cores(

--- a/models/experimental/panoptic_deeplab/tt/tt_insemb.py
+++ b/models/experimental/panoptic_deeplab/tt/tt_insemb.py
@@ -86,41 +86,58 @@ class TtPanopticDeepLabInsEmbedHead(TtDeepLabV3PlusHead):
         # perf wise this makes sense because we dont need to permute to channel last after it
         # we dont need to permute to channel last because this is final output that goes to the host
 
-        # First config
-        final_upsample_mm_config1 = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
-            compute_with_storage_grid_size=(5, 4),
-            in0_block_w=2,
-            out_subblock_h=4,
-            out_subblock_w=2,
-            out_block_h=4,
-            out_block_w=2,
-            per_core_M=4,
-            per_core_N=2,
-            fuse_batch=False,
-            fused_activation=None,
-            mcast_in0=True,
-            gather_in0=False,
-            num_global_cb_receivers=0,
-            untilize_out=False,
-        )
+        # Determine grid configuration based on device compute grid
+        # Use optimized configs for 5x4 grid (20 cores), auto-config for all other grids
+        compute_grid = device.compute_with_storage_grid_size()
+        use_optimized_config = compute_grid.x == 5 and compute_grid.y == 4
 
-        # Second config
-        final_upsample_mm_config2 = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
-            compute_with_storage_grid_size=(5, 4),
-            in0_block_w=2,
-            out_subblock_h=4,
-            out_subblock_w=2,
-            out_block_h=16,
-            out_block_w=2,
-            per_core_M=16,
-            per_core_N=2,
-            fuse_batch=False,
-            fused_activation=None,
-            mcast_in0=True,
-            gather_in0=False,
-            num_global_cb_receivers=0,
-            untilize_out=False,
-        )
+        if use_optimized_config:
+            logger.debug(f"Using optimized matmul configs for 5x4 grid (20 cores)")
+        else:
+            logger.debug(
+                f"Using auto-config for {compute_grid.x}x{compute_grid.y} grid ({compute_grid.x * compute_grid.y} cores)"
+            )
+
+        if use_optimized_config:
+            # Optimized configs for 5x4 grid (20 cores)
+            final_upsample_mm_config1 = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+                compute_with_storage_grid_size=(5, 4),
+                in0_block_w=2,
+                out_subblock_h=4,
+                out_subblock_w=2,
+                out_block_h=4,
+                out_block_w=2,
+                per_core_M=4,
+                per_core_N=2,
+                fuse_batch=False,
+                fused_activation=None,
+                mcast_in0=True,
+                gather_in0=False,
+                num_global_cb_receivers=0,
+                untilize_out=False,
+            )
+
+            final_upsample_mm_config2 = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+                compute_with_storage_grid_size=(5, 4),
+                in0_block_w=2,
+                out_subblock_h=4,
+                out_subblock_w=2,
+                out_block_h=16,
+                out_block_w=2,
+                per_core_M=16,
+                per_core_N=2,
+                fuse_batch=False,
+                fused_activation=None,
+                mcast_in0=True,
+                gather_in0=False,
+                num_global_cb_receivers=0,
+                untilize_out=False,
+            )
+        else:
+            # Auto-config for all other grid sizes (e.g., 12x10 for 120 cores)
+            # TTNN will automatically select optimal configuration based on device capabilities
+            final_upsample_mm_config1 = None
+            final_upsample_mm_config2 = None
 
         self.final_upsample = TtBilinearUpsample(
             device,

--- a/models/experimental/panoptic_deeplab/tt/tt_semseg.py
+++ b/models/experimental/panoptic_deeplab/tt/tt_semseg.py
@@ -387,20 +387,9 @@ class TtPanopticDeepLabSemSegHead(TtDeepLabV3PlusHead):
         # we dont need to permute to channel last because this is final output that goes to the host
         # todo: remove hardcoded values; they should come from infer_ttnn_params in the preprocessing step
 
-        # Determine grid configuration based on device compute grid
-        # Use optimized configs for 5x4 grid (20 cores), auto-config for all other grids
         compute_grid = device.compute_with_storage_grid_size()
-        use_optimized_config = compute_grid.x == 5 and compute_grid.y == 4
 
-        if use_optimized_config:
-            logger.debug(f"Using optimized matmul configs for 5x4 grid (20 cores)")
-        else:
-            logger.debug(
-                f"Using auto-config for {compute_grid.x}x{compute_grid.y} grid ({compute_grid.x * compute_grid.y} cores)"
-            )
-
-        if use_optimized_config:
-            # Optimized configs for 5x4 grid (20 cores)
+        if compute_grid.x == 5 and compute_grid.y == 4:
             final_upsample_mm_config1 = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
                 compute_with_storage_grid_size=(5, 4),
                 in0_block_w=2,
@@ -434,9 +423,16 @@ class TtPanopticDeepLabSemSegHead(TtDeepLabV3PlusHead):
                 num_global_cb_receivers=0,
                 untilize_out=False,
             )
+        elif compute_grid.x == 13 and compute_grid.y == 10:
+            # TODO Optimized configs for 13x10 grid (130 cores) will be added here
+            final_upsample_mm_config1 = None
+            final_upsample_mm_config2 = None
         else:
-            # Auto-config for all other grid sizes (e.g., 12x10 for 120 cores)
+            # Auto-config for all other grid sizes
             # TTNN will automatically select optimal configuration based on device capabilities
+            logger.debug(
+                f"Using auto-config for {compute_grid.x}x{compute_grid.y} grid ({compute_grid.x * compute_grid.y} cores)"
+            )
             final_upsample_mm_config1 = None
             final_upsample_mm_config2 = None
 

--- a/models/experimental/panoptic_deeplab/tt/tt_semseg.py
+++ b/models/experimental/panoptic_deeplab/tt/tt_semseg.py
@@ -387,41 +387,58 @@ class TtPanopticDeepLabSemSegHead(TtDeepLabV3PlusHead):
         # we dont need to permute to channel last because this is final output that goes to the host
         # todo: remove hardcoded values; they should come from infer_ttnn_params in the preprocessing step
 
-        # First config
-        final_upsample_mm_config1 = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
-            compute_with_storage_grid_size=(5, 4),
-            in0_block_w=2,
-            out_subblock_h=4,
-            out_subblock_w=2,
-            out_block_h=4,
-            out_block_w=2,
-            per_core_M=4,
-            per_core_N=2,
-            fuse_batch=False,
-            fused_activation=None,
-            mcast_in0=True,
-            gather_in0=False,
-            num_global_cb_receivers=0,
-            untilize_out=False,
-        )
+        # Determine grid configuration based on device compute grid
+        # Use optimized configs for 5x4 grid (20 cores), auto-config for all other grids
+        compute_grid = device.compute_with_storage_grid_size()
+        use_optimized_config = compute_grid.x == 5 and compute_grid.y == 4
 
-        # Second config
-        final_upsample_mm_config2 = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
-            compute_with_storage_grid_size=(5, 4),
-            in0_block_w=2,
-            out_subblock_h=4,
-            out_subblock_w=2,
-            out_block_h=16,
-            out_block_w=2,
-            per_core_M=16,
-            per_core_N=2,
-            fuse_batch=False,
-            fused_activation=None,
-            mcast_in0=True,
-            gather_in0=False,
-            num_global_cb_receivers=0,
-            untilize_out=False,
-        )
+        if use_optimized_config:
+            logger.debug(f"Using optimized matmul configs for 5x4 grid (20 cores)")
+        else:
+            logger.debug(
+                f"Using auto-config for {compute_grid.x}x{compute_grid.y} grid ({compute_grid.x * compute_grid.y} cores)"
+            )
+
+        if use_optimized_config:
+            # Optimized configs for 5x4 grid (20 cores)
+            final_upsample_mm_config1 = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+                compute_with_storage_grid_size=(5, 4),
+                in0_block_w=2,
+                out_subblock_h=4,
+                out_subblock_w=2,
+                out_block_h=4,
+                out_block_w=2,
+                per_core_M=4,
+                per_core_N=2,
+                fuse_batch=False,
+                fused_activation=None,
+                mcast_in0=True,
+                gather_in0=False,
+                num_global_cb_receivers=0,
+                untilize_out=False,
+            )
+
+            final_upsample_mm_config2 = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+                compute_with_storage_grid_size=(5, 4),
+                in0_block_w=2,
+                out_subblock_h=4,
+                out_subblock_w=2,
+                out_block_h=16,
+                out_block_w=2,
+                per_core_M=16,
+                per_core_N=2,
+                fuse_batch=False,
+                fused_activation=None,
+                mcast_in0=True,
+                gather_in0=False,
+                num_global_cb_receivers=0,
+                untilize_out=False,
+            )
+        else:
+            # Auto-config for all other grid sizes (e.g., 12x10 for 120 cores)
+            # TTNN will automatically select optimal configuration based on device capabilities
+            final_upsample_mm_config1 = None
+            final_upsample_mm_config2 = None
 
         self.final_upsample = TtBilinearUpsample(
             device,


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/33555)

### Problem description
Currently PDL runs only on 20 cores (5x4 grid) which is specific to the client. We want to have it available for running on all cores on Blackhole P150 cards (13x10 grid). 

### What's changed
Most changes are related to adding a conditional for 20-cores vs 130-cores runs and moving PCC/abs/rel err vals to test parameters inside `models/experimental/panoptic_deeplab/tests/pcc`, also for matmul configs in `models/experimental/panoptic_deeplab/tt/tt_semseg.py` to be auto-configured in case of 130-cores. 

CI is also updated, specifically `.github/workflows/blackhole-nightly-tests-impl.yaml` and `.github/workflows/perf-device-models-impl.yaml.` Since `nightly-bh-models` job inside `.github/workflows/blackhole-nightly-tests-impl.yaml` uses old CI where weights can't be found for PDL without dealing with `/mnt/MLPerf,` to avoid making a separate .yaml for CIv2 I added a new job `nightly-bh-models-ci-v2` inside mentioned .yaml. Demo test for 130 cores is also added to`.github/workflows/single-card-demo-tests-impl.yaml`. README for PDL is updated.

### Checklist
- [x] [Blackhole nightly ](https://github.com/tenstorrent/tt-metal/actions/runs/20225137173)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/runs/20261517053)
- [ ] [Blackhole Demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/20239664420) 
- [x] New/Existing tests provide coverage for changes