### PR TITLE
Implement Config Tensor-based Fold Operation with Native Padding Support

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_device_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_device_op.cpp
@@ -34,10 +34,13 @@ void validate_fold(
             "Fold: Only height-sharded input tensors are supported.");
 
         auto shard_shape = input_tensor.shard_spec().value().shape;
-        TT_FATAL(
-            shard_shape[0] % (input_shape[2] * stride_h) == 0,
-            "Fold: Shard height must be divisible by input width times stride_h for proper folding operation.");
         TT_FATAL(input_tensor.layout() == Layout::ROW_MAJOR, "Fold: Expect sharded input tensor in row-major layout.");
+        TT_FATAL(
+            shard_shape[0] % (stride_h * stride_w) == 0,
+            "Fold: Shard height must be divisible by stride_h * stride_w.",
+            shard_shape[0],
+            stride_h,
+            stride_w);
     } else if (is_dram_interleaved) {
         TT_FATAL(input_shape[1] % stride_h == 0, "Fold: Input height must be divisible by stride_h.");
         TT_FATAL(input_shape[2] % stride_w == 0, "Fold: Input width must be divisible by stride_w.");

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_device_op.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_device_op.hpp
@@ -20,6 +20,11 @@ struct Fold {
         uint32_t stride_w{};
         bool is_sharded{};
         bool is_dram_interleaved = false;
+        // Padding: [pad_top, pad_bottom, pad_left, pad_right]
+        uint32_t pad_top = 0;
+        uint32_t pad_bottom = 0;
+        uint32_t pad_left = 0;
+        uint32_t pad_right = 0;
     };
 
     struct tensor_args_t {
@@ -106,7 +111,11 @@ struct Fold {
         const std::optional<const ttnn::Shape>& output_shape,
         uint32_t pad_c,
         uint32_t pad_h,
-        uint32_t pad_w);
+        uint32_t pad_w,
+        uint32_t pad_top,
+        uint32_t pad_bottom,
+        uint32_t pad_left,
+        uint32_t pad_right);
 };
 
 }  // namespace ttnn::operations::data_movement

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_multi_core_program_factory.cpp
@@ -15,6 +15,113 @@ using namespace tt::tt_metal;
 
 namespace ttnn::operations::data_movement {
 
+struct FoldTransfer {
+    uint16_t src_noc_x;
+    uint16_t src_noc_y;
+    uint16_t src_local_idx;
+    uint16_t length = 1;
+};
+
+std::vector<std::vector<FoldTransfer>> generate_fold_transfers(
+    const Tensor& input, uint32_t stride_h, uint32_t stride_w) {
+    auto input_shape = input.logical_shape();
+    auto input_shard_spec = input.shard_spec();
+
+    uint32_t N = input_shape[0];
+    uint32_t H = input_shape[1];
+    uint32_t W = input_shape[2];
+
+    uint32_t input_shard_height = input_shard_spec->shape[0];
+    uint32_t num_cores = input_shard_spec->grid.num_cores();
+
+    uint32_t out_H = H / stride_h;
+    uint32_t out_W = W / stride_w;
+
+    uint32_t output_shard_height = input_shard_height / (stride_h * stride_w);
+
+    auto logical_cores = tt::tt_metal::corerange_to_cores(
+        input_shard_spec->grid, num_cores, input_shard_spec->orientation == ShardOrientation::ROW_MAJOR);
+
+    std::vector<CoreCoord> noc_coords;
+    for (const auto& core : logical_cores) {
+        noc_coords.push_back(input.device()->worker_core_from_logical_core(core));
+    }
+
+    std::vector<std::vector<FoldTransfer>> per_core_transfers(num_cores);
+
+    uint32_t output_pixel = 0;
+    for (uint32_t n = 0; n < N; n++) {
+        for (uint32_t h = 0; h < out_H; h++) {
+            for (uint32_t w = 0; w < out_W; w++) {
+                uint32_t dst_core_idx = output_pixel / output_shard_height;
+                for (uint32_t s_h = 0; s_h < stride_h; s_h++) {
+                    for (uint32_t s_w = 0; s_w < stride_w; s_w++) {
+                        uint32_t in_h = h * stride_h + s_h;
+                        uint32_t in_w = w * stride_w + s_w;
+                        uint32_t in_idx = (n * H * W) + (in_h * W) + in_w;
+
+                        uint32_t input_core_id = in_idx / input_shard_height;
+                        uint32_t src_local_idx = in_idx % input_shard_height;
+
+                        auto [src_noc_x, src_noc_y] = noc_coords[input_core_id];
+
+                        per_core_transfers[dst_core_idx].push_back(
+                            {static_cast<uint16_t>(src_noc_x),
+                             static_cast<uint16_t>(src_noc_y),
+                             static_cast<uint16_t>(src_local_idx),
+                             1});
+                    }
+                }
+                output_pixel++;
+            }
+        }
+    }
+    return per_core_transfers;
+}
+
+uint32_t get_max_transfers_per_core(const std::vector<std::vector<FoldTransfer>>& per_core_transfers) {
+    uint32_t max_entries = 0;
+    for (const auto& core_transfers : per_core_transfers) {
+        max_entries = std::max(max_entries, static_cast<uint32_t>(core_transfers.size()));
+    }
+    return max_entries;
+}
+
+Tensor create_fold_transfers_tensor(
+    const std::vector<std::vector<FoldTransfer>>& per_core_transfers,
+    const CoreRangeSet& core_grid,
+    ShardOrientation orientation,
+    const Tensor& input_tensor) {
+    uint32_t num_cores = core_grid.num_cores();
+    uint32_t max_entries = get_max_transfers_per_core(per_core_transfers);
+
+    uint32_t config_shard_width = max_entries * 4;
+
+    // Flatten the transfers into a single vector
+    std::vector<uint16_t> flattened_data;
+    for (auto core_transfers : per_core_transfers) {
+        for (auto transfer : core_transfers) {
+            flattened_data.push_back(transfer.src_noc_x);
+            flattened_data.push_back(transfer.src_noc_y);
+            flattened_data.push_back(transfer.src_local_idx);
+            flattened_data.push_back(transfer.length);
+        }
+        uint32_t padding = (max_entries - core_transfers.size()) * 4;
+        for (uint32_t i = 0; i < padding; i++) {
+            flattened_data.push_back(0);
+        }
+    }
+    ttnn::Shape config_shape({num_cores, config_shard_width});
+    auto config_buffer = HostBuffer(std::move(flattened_data));
+    Tensor host_tensor(std::move(config_buffer), config_shape, DataType::UINT16, Layout::ROW_MAJOR);
+
+    ShardSpec config_shard_spec = ShardSpec(core_grid, {1, config_shard_width}, orientation);
+
+    MemoryConfig config_memory_config =
+        MemoryConfig(TensorMemoryLayout::HEIGHT_SHARDED, BufferType::L1_SMALL, config_shard_spec);
+    return host_tensor.to_device(input_tensor.device(), config_memory_config);
+}
+
 Fold::MultiCore::cached_program_t fold_multi_core(
     const Tensor& input, const Tensor& output, uint32_t stride_h, uint32_t stride_w) {
     Program program = CreateProgram();
@@ -29,11 +136,8 @@ Fold::MultiCore::cached_program_t fold_multi_core(
     uint32_t num_dst_pixels = num_pixels / (stride_h * stride_w);
 
     // chunk consists of channel values of stride_w neighboring pixels along the W dimension
-    uint32_t width = input.padded_shape()[2];
     uint32_t chunk_size = stride_w * pixel_size;
     uint32_t dst_pixel_size = stride_h * chunk_size;
-    uint32_t num_dst_rows = num_pixels / (width * stride_h);
-    uint32_t pixels_per_dst_row = stride_h * width;
 
     // input CB
     uint32_t cb_src0_index = tt::CBIndex::c_0;
@@ -52,38 +156,39 @@ Fold::MultiCore::cached_program_t fold_multi_core(
             .set_globally_allocated_address(*output.buffer());
     auto cb_dst0 = CreateCircularBuffer(program, all_cores, dst_cb_config);
 
+    auto per_core_transfers = generate_fold_transfers(input, stride_h, stride_w);
+    auto config_tensor = create_fold_transfers_tensor(
+        per_core_transfers, output.shard_spec()->grid, input.shard_spec()->orientation, input);
+
+    uint32_t config_cb_index = tt::CBIndex::c_1;
+    uint32_t config_page_size = get_max_transfers_per_core(per_core_transfers) * 4 * sizeof(uint16_t);
+    auto config_cb_config = CircularBufferConfig(config_page_size, {{config_cb_index, tt::DataFormat::UInt16}})
+                                .set_page_size(config_cb_index, config_page_size)
+                                .set_globally_allocated_address(*config_tensor.buffer());
+    CreateCircularBuffer(program, all_cores, config_cb_config);
+
+    uint32_t num_transfers = get_max_transfers_per_core(per_core_transfers);
+
     std::vector<uint32_t> compile_time_args = {
-        cb_src0_index,
-        cb_dst0_index,
-        pixel_size,
-        aligned_pixel_size,
-        aligned_dst_pixel_size,
-        stride_w * aligned_pixel_size,
-        width * aligned_pixel_size,
-        stride_h,
-        stride_w,
-        num_dst_rows,
-        width / stride_w,
-        pixels_per_dst_row * aligned_pixel_size,
-        input.element_size(),
-        true,
+        cb_src0_index,       // 0: input CB
+        cb_dst0_index,       // 1: output CB
+        config_cb_index,     // 2: config CB
+        pixel_size,          // 3: bytes per pixel
+        aligned_pixel_size,  // 4: aligned pixel size
+        num_transfers,       // 5: number of transfers per core
     };
-    // Setup kernel
-    // Set build optimization level to Os. O2 was slower.
-    tt::tt_metal::KernelHandle writer_kernel_id = tt::tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/writer_cb2s_row_major.cpp",
-        all_cores,
-        WriterDataMovementConfig(compile_time_args, {}, {}, tt::tt_metal::KernelBuildOptLevel::Os));
 
-    compile_time_args[13] = false;  // is_reader = false for writer
-    tt::tt_metal::KernelHandle reader_kernel_id = tt::tt_metal::CreateKernel(
+    // Single kernel for fold with config tensor
+    tt::tt_metal::KernelHandle kernel_id = tt::tt_metal::CreateKernel(
         program,
-        "ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/writer_cb2s_row_major.cpp",
+        "ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/fold_with_config.cpp",
         all_cores,
-        ReaderDataMovementConfig(compile_time_args, {}, {}, tt::tt_metal::KernelBuildOptLevel::Os));
+        DataMovementConfig{
+            .processor = DataMovementProcessor::RISCV_0,
+            .noc = NOC::RISCV_0_default,
+            .compile_args = compile_time_args});
 
-    return {std::move(program), {reader_kernel_id, writer_kernel_id, stride_h, stride_w, cb_src0, cb_dst0}};
+    return {std::move(program), {kernel_id, kernel_id, stride_h, stride_w, cb_src0, cb_dst0}};
 }
 
 Fold::MultiCore::cached_program_t Fold::MultiCore::create(

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/fold_with_config.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/fold_with_config.cpp
@@ -38,10 +38,10 @@ void kernel_main() {
         uint16_t length = config_data[i * 4 + 3];
 
         // Debug: print first few transfers
-        if (i < 4) {
-            DPRINT << "  Transfer[" << i << "]: noc=(" << src_noc_x << "," << src_noc_y
-                   << ") local_idx=" << src_local_idx << " len=" << length << ENDL();
-        }
+        // if (i < 4) {
+        //     DPRINT << "  Transfer[" << i << "]: noc=(" << src_noc_x << "," << src_noc_y
+        //            << ") local_idx=" << src_local_idx << " len=" << length << ENDL();
+        // }
 
         // Skip if length is 0 (padding entry)
         if (length == 0) {

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/fold_with_config.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/fold_with_config.cpp
@@ -48,8 +48,8 @@ void kernel_main() {
             continue;
         }
 
-        // Calculate source NOC address
-        uint32_t src_offset = src_local_idx * aligned_pixel_size;
+        // Calculate source NOC address (use pixel_size for ROW_MAJOR memory layout)
+        uint32_t src_offset = src_local_idx * pixel_size;
         uint64_t src_noc_addr = get_noc_addr(src_noc_x, src_noc_y, input_l1_addr + src_offset);
 
         // Calculate destination L1 address

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/fold_with_config.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/fold_with_config.cpp
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include "dataflow_api.h"
+#include "debug/dprint.h"
+
+void kernel_main() {
+    // Compile-time args
+    constexpr uint32_t input_cb_index = get_compile_time_arg_val(0);
+    constexpr uint32_t output_cb_index = get_compile_time_arg_val(1);
+    constexpr uint32_t config_cb_index = get_compile_time_arg_val(2);
+    constexpr uint32_t pixel_size = get_compile_time_arg_val(3);
+    constexpr uint32_t aligned_pixel_size = get_compile_time_arg_val(4);
+    constexpr uint32_t num_transfers = get_compile_time_arg_val(5);
+
+    // Get CB addresses
+    const uint32_t input_l1_addr = get_read_ptr(input_cb_index);
+    const uint32_t output_l1_addr = get_write_ptr(output_cb_index);
+    const uint32_t config_l1_addr = get_read_ptr(config_cb_index);
+
+    DPRINT << "fold_with_config: num_transfers=" << num_transfers << " pixel_size=" << pixel_size
+           << " aligned_pixel_size=" << aligned_pixel_size << ENDL();
+    DPRINT << "  input_l1=" << input_l1_addr << " output_l1=" << output_l1_addr << " config_l1=" << config_l1_addr
+           << ENDL();
+
+    // Cast config to uint16_t pointer
+    volatile tt_l1_ptr uint16_t* config_data = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(config_l1_addr);
+
+    // Process each transfer entry from config tensor
+    uint32_t dst_offset = 0;
+    for (uint32_t i = 0; i < num_transfers; ++i) {
+        // Read config entry: src_noc_x, src_noc_y, src_local_idx, length
+        uint16_t src_noc_x = config_data[i * 4 + 0];
+        uint16_t src_noc_y = config_data[i * 4 + 1];
+        uint16_t src_local_idx = config_data[i * 4 + 2];
+        uint16_t length = config_data[i * 4 + 3];
+
+        // Debug: print first few transfers
+        if (i < 4) {
+            DPRINT << "  Transfer[" << i << "]: noc=(" << src_noc_x << "," << src_noc_y
+                   << ") local_idx=" << src_local_idx << " len=" << length << ENDL();
+        }
+
+        // Skip if length is 0 (padding entry)
+        if (length == 0) {
+            continue;
+        }
+
+        // Calculate source NOC address
+        uint32_t src_offset = src_local_idx * aligned_pixel_size;
+        uint64_t src_noc_addr = get_noc_addr(src_noc_x, src_noc_y, input_l1_addr + src_offset);
+
+        // Calculate destination L1 address
+        uint32_t dst_l1_addr = output_l1_addr + dst_offset;
+
+        // Perform NOC read (read from remote core to local output buffer)
+        uint32_t read_size = length * pixel_size;
+        noc_async_read(src_noc_addr, dst_l1_addr, read_size);
+
+        // Advance destination offset
+        dst_offset += length * pixel_size;
+    }
+
+    // Wait for all reads to complete
+    noc_async_read_barrier();
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/fold.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/fold.cpp
@@ -316,75 +316,76 @@ static void validate_height_sharding(const Tensor& tensor) {
     }
 }
 
-// Helper function to apply halo padding to sharded tensors
-static Tensor apply_halo_padding(
-    const Tensor& input_tensor, uint32_t pad_top, uint32_t pad_bottom, uint32_t pad_left, uint32_t pad_right) {
-    using namespace ttnn::operations::sliding_window;
+// // Helper function to apply halo padding to sharded tensors
+// static Tensor apply_halo_padding(
+//     const Tensor& input_tensor, uint32_t pad_top, uint32_t pad_bottom, uint32_t pad_left, uint32_t pad_right) {
+//     using namespace ttnn::operations::sliding_window;
 
-    auto input_shape = input_tensor.logical_shape();
-    auto shard_spec = input_tensor.shard_spec().value();
+//     auto input_shape = input_tensor.logical_shape();
+//     auto shard_spec = input_tensor.shard_spec().value();
 
-    SlidingWindowConfig sliding_window_config{
-        .batch_size = input_shape[0],
-        .input_hw = {input_shape[1], input_shape[2]},
-        .window_hw = {1, 1},
-        .stride_hw = {1, 1},
-        .padding = {pad_top, pad_bottom, pad_left, pad_right},
-        .dilation_hw = {1, 1},
-        .num_cores_nhw = static_cast<uint32_t>(shard_spec.grid.num_cores()),
-        .num_cores_c = 1,
-        .core_range_set = shard_spec.grid,
-        .snap_to_tile = false};
+//     SlidingWindowConfig sliding_window_config{
+//         .batch_size = input_shape[0],
+//         .input_hw = {input_shape[1], input_shape[2]},
+//         .window_hw = {1, 1},
+//         .stride_hw = {1, 1},
+//         .padding = {pad_top, pad_bottom, pad_left, pad_right},
+//         .dilation_hw = {1, 1},
+//         .num_cores_nhw = static_cast<uint32_t>(shard_spec.grid.num_cores()),
+//         .num_cores_c = 1,
+//         .core_range_set = shard_spec.grid,
+//         .snap_to_tile = false};
 
-    ttnn::Shape new_shape({1, 1, input_shape[0] * input_shape[1] * input_shape[2], input_shape[3]});
-    auto reshaped_tensor = ttnn::reshape(input_tensor, new_shape);
+//     ttnn::Shape new_shape({1, 1, input_shape[0] * input_shape[1] * input_shape[2], input_shape[3]});
+//     auto reshaped_tensor = ttnn::reshape(input_tensor, new_shape);
 
-    auto halo_output =
-        ttnn::halo(reshaped_tensor, sliding_window_config, 0, false, false, reshaped_tensor.memory_config(), false);
+//     auto halo_output =
+//         ttnn::halo(reshaped_tensor, sliding_window_config, 0, false, false, reshaped_tensor.memory_config(), false);
 
-    // Reshape back to padded original dimensions
-    ttnn::Shape padded_shape(
-        {input_shape[0], input_shape[1] + pad_top + pad_bottom, input_shape[2] + pad_left + pad_right, input_shape[3]});
-    return ttnn::reshape(halo_output, padded_shape);
-}
+//     // Reshape back to padded original dimensions
+//     ttnn::Shape padded_shape(
+//         {input_shape[0], input_shape[1] + pad_top + pad_bottom, input_shape[2] + pad_left + pad_right,
+//         input_shape[3]});
+//     return ttnn::reshape(halo_output, padded_shape);
+// }
 
-// Each core needs to process multiple of (stride_h * input_width) rows to ensure that
-// the fold operation can be performed locally and do not need to read from remote cores.
-// This function checks if the current shard height is divisible by (stride_h * input_width).
-// If not, it calculates an optimal number of cores and corresponding shard height
-// to enable efficient fold computation across the tensor dimensions.
-Tensor reshard_if_needed(const Tensor& input, const uint32_t stride_h, const uint32_t stride_w) {
-    ttnn::Shape input_shape = input.logical_shape();
-    uint32_t input_width = input_shape[2];
-    uint32_t pixels_per_compute_row = stride_h * input_width;
-    uint32_t current_shard_height = input.shard_spec().value().shape[0];
-    const CoreCoord& compute_grid_size = input.device()->compute_with_storage_grid_size();
-    if (current_shard_height % pixels_per_compute_row != 0) {
-        uint32_t max_cores = compute_grid_size.x * compute_grid_size.y;
-        uint32_t total_height = input_shape[0] * input_shape[1] * input_shape[2];
+// // Each core needs to process multiple of (stride_h * input_width) rows to ensure that
+// // the fold operation can be performed locally and do not need to read from remote cores.
+// // This function checks if the current shard height is divisible by (stride_h * input_width).
+// // If not, it calculates an optimal number of cores and corresponding shard height
+// // to enable efficient fold computation across the tensor dimensions.
+// Tensor reshard_if_needed(const Tensor& input, const uint32_t stride_h, const uint32_t stride_w) {
+//     ttnn::Shape input_shape = input.logical_shape();
+//     uint32_t input_width = input_shape[2];
+//     uint32_t pixels_per_compute_row = stride_h * input_width;
+//     uint32_t current_shard_height = input.shard_spec().value().shape[0];
+//     const CoreCoord& compute_grid_size = input.device()->compute_with_storage_grid_size();
+//     if (current_shard_height % pixels_per_compute_row != 0) {
+//         uint32_t max_cores = compute_grid_size.x * compute_grid_size.y;
+//         uint32_t total_height = input_shape[0] * input_shape[1] * input_shape[2];
 
-        uint32_t num_cores = max_cores;
-        while (num_cores > 0 && (total_height / pixels_per_compute_row) % num_cores != 0) {
-            num_cores--;
-        }
+//         uint32_t num_cores = max_cores;
+//         while (num_cores > 0 && (total_height / pixels_per_compute_row) % num_cores != 0) {
+//             num_cores--;
+//         }
 
-        TT_ASSERT(num_cores != 0, "Could not find suitable number of cores for resharing the input tensor");
+//         TT_ASSERT(num_cores != 0, "Could not find suitable number of cores for resharing the input tensor");
 
-        uint32_t optimal_shard_height = tt::round_up(total_height / num_cores, pixels_per_compute_row);
+//         uint32_t optimal_shard_height = tt::round_up(total_height / num_cores, pixels_per_compute_row);
 
-        auto new_shard_spec = input.shard_spec().value();
-        new_shard_spec.shape[0] = optimal_shard_height;
+//         auto new_shard_spec = input.shard_spec().value();
+//         new_shard_spec.shape[0] = optimal_shard_height;
 
-        // Create new core range set using the calculated number of cores
-        CoreRangeSet new_core_range = tt::tt_metal::num_cores_to_corerangeset(num_cores, compute_grid_size, true);
-        new_shard_spec.grid = new_core_range;
+//         // Create new core range set using the calculated number of cores
+//         CoreRangeSet new_core_range = tt::tt_metal::num_cores_to_corerangeset(num_cores, compute_grid_size, true);
+//         new_shard_spec.grid = new_core_range;
 
-        auto new_mem_config = input.memory_config().with_shard_spec(new_shard_spec);
-        // need to reshard
-        return ttnn::reshard(input, new_mem_config, std::nullopt);
-    }
-    return input;
-}
+//         auto new_mem_config = input.memory_config().with_shard_spec(new_shard_spec);
+//         // need to reshard
+//         return ttnn::reshard(input, new_mem_config, std::nullopt);
+//     }
+//     return input;
+// }
 
 Tensor FoldOperation::invoke(
     const ttnn::Tensor& input_tensor_,
@@ -437,29 +438,29 @@ Tensor FoldOperation::invoke(
 
         Tensor processed_tensor = input_tensor;
 
-        // Apply H,W padding using halo if needed
-        if (has_hw_padding) {
-            processed_tensor = apply_halo_padding(processed_tensor, pad_top, pad_bottom, pad_left, pad_right);
-        }
+        // // Apply H,W padding using halo if needed
+        // if (has_hw_padding) {
+        //     processed_tensor = apply_halo_padding(processed_tensor, pad_top, pad_bottom, pad_left, pad_right);
+        // }
 
-        // Apply channel padding separately if needed
-        if (has_c_padding) {
-            const auto current_shape = processed_tensor.logical_shape();
-            const tt::tt_metal::Array4D padded_shape = {
-                static_cast<uint32_t>(current_shape[0]),
-                static_cast<uint32_t>(current_shape[1]),
-                static_cast<uint32_t>(current_shape[2]),
-                static_cast<uint32_t>(current_shape[3] + pad_c_front + pad_c_back)};
-            processed_tensor =
-                ttnn::pad(processed_tensor, padded_shape, tt::tt_metal::Array4D({0, 0, 0, pad_c_front}), 0);
-        }
+        // // Apply channel padding separately if needed
+        // if (has_c_padding) {
+        //     const auto current_shape = processed_tensor.logical_shape();
+        //     const tt::tt_metal::Array4D padded_shape = {
+        //         static_cast<uint32_t>(current_shape[0]),
+        //         static_cast<uint32_t>(current_shape[1]),
+        //         static_cast<uint32_t>(current_shape[2]),
+        //         static_cast<uint32_t>(current_shape[3] + pad_c_front + pad_c_back)};
+        //     processed_tensor =
+        //         ttnn::pad(processed_tensor, padded_shape, tt::tt_metal::Array4D({0, 0, 0, pad_c_front}), 0);
+        // }
 
         // If processed tensor is tiled, convert to row-major.
         if (processed_tensor.layout() == Layout::TILE) {
             processed_tensor = ttnn::to_layout(processed_tensor, Layout::ROW_MAJOR);
         }
-        // Reshard if needed for optimal fold computation
-        processed_tensor = reshard_if_needed(processed_tensor, stride_h, stride_w);
+        // // Reshard if needed for optimal fold computation
+        // processed_tensor = reshard_if_needed(processed_tensor, stride_h, stride_w);
 
         return ttnn::prim::fold(processed_tensor, stride_h, stride_w, output_shape, 0, 0, 0);
     }


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/pull/21689

### Problem description
The current fold operation for sharded tensors requires 3 OPs.

1. halo -  apply H/W padding
2. reshard - reshards tensor to ensure shard height is divisible by `stride_h * input_width`.
3. fold - fold sharded tensor on local core.

These operations create intermediate tensors and can add significant overhead.

### What's changed
Reimplemented fold using a config tensor architecture where:

- Each output core receives a config tensor containing transfer instructions: {src_noc_x, src_noc_y, src_local_idx, length}
- Kernels run on destination cores and pull data from source cores via NOC reads.
- Padding is handled natively in the kernel using MEM_ZEROS_BASE for efficient zero-filling

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes