### PR TITLE
Remove cb_get_tile and cb_release_tile

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_common_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_common_api.h
@@ -45,16 +45,6 @@ inline void llk_math_pack_sync_init() {
     _llk_math_pack_sync_init_<DST_SYNC_MODE, is_fp32_dest_acc_en>();
 }
 
-template <bool mail2math = true, bool mail2pack = true>
-inline void llk_math_get_tile(std::uint32_t operand, std::uint32_t tile_index, std::uint32_t* p_tile) {
-    _llk_math_get_tile_<mail2math, mail2pack>(tile_index, p_tile);
-}
-
-template <bool mail2math = true, bool mail2pack = true>
-inline void llk_math_release_tile(std::uint32_t operand) {
-    _llk_math_release_tile_<mail2math, mail2pack>();
-}
-
 inline void llk_math_debug_dump(std::uint8_t* data, std::uint32_t byte_size) { _llk_math_debug_dump_(data, byte_size); }
 
 inline void llk_math_debug_dump_seek(std::uint8_t offset) { _llk_math_debug_dump_seek_(offset); }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_api.h
@@ -323,15 +323,6 @@ inline void llk_pack_dest_init(const std::uint32_t pack_output = 16) {
     _llk_pack_dest_init_<DST_SYNC_MODE, is_fp32_dest_acc_en, DstTileFaceLayout::RowMajor>(face_r_dim, narrow_tile);
 }
 
-template <bool mail2math = true, bool mail2pack = true>
-inline void llk_pack_get_tile(std::uint32_t output, std::uint32_t tile_index, std::uint32_t* p_tile) {
-    _llk_pack_get_tile_<mail2math, mail2pack>(tile_index, p_tile);
-}
-template <bool mail2math = true, bool mail2pack = true>
-inline void llk_pack_release_tile(std::uint32_t output) {
-    _llk_pack_release_tile_<mail2math, mail2pack>();
-}
-
 inline void llk_pack_debug_dump(std::uint8_t* data, std::uint32_t byte_size) { _llk_pack_debug_dump_(data, byte_size); }
 
 inline void llk_pack_debug_dump_seek(std::uint8_t offset) { _llk_pack_debug_dump_seek_(offset); }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_common_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_common_api.h
@@ -33,20 +33,6 @@ void llk_zero_operand(std::uint32_t operand) {
     _llk_zero_buffer_(fifo_base_addr, size);
 }
 
-template <bool mail2math = true, bool mail2pack = true>
-inline void llk_unpack_get_tile(std::uint32_t operand, std::uint32_t tile_index, std::uint32_t* p_tile) {
-    std::uint32_t operand_id = get_operand_id(operand);
-    std::uint32_t base_address = get_local_cb_interface(operand_id).fifo_rd_ptr - 1;
-    std::uint32_t offset_address = get_local_cb_interface(operand_id).fifo_page_size * tile_index;
-    std::uint32_t address = base_address + offset_address;
-    _llk_unpack_get_tile_<mail2math, mail2pack>(address, p_tile);
-}
-
-template <bool mail2math = true, bool mail2pack = true>
-inline void llk_unpack_release_tile(std::uint32_t operand) {
-    _llk_unpack_release_tile_<mail2math, mail2pack>();
-}
-
 inline void llk_unpack_debug_dump(std::uint8_t* data, std::uint32_t byte_size) {
     _llk_unpack_debug_dump_(data, byte_size);
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_common_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_common_api.h
@@ -33,20 +33,6 @@ void llk_zero_operand(std::uint32_t operand) {
     _llk_zero_buffer_(fifo_base_addr, size);
 }
 
-template <bool mail2math = true, bool mail2pack = true>
-inline void llk_unpack_get_tile(std::uint32_t operand, std::uint32_t tile_index, std::uint32_t* p_tile) {
-    std::uint32_t operand_id = get_operand_id(operand);
-    std::uint32_t base_address = get_local_cb_interface(operand_id).fifo_rd_ptr - 1;
-    std::uint32_t offset_address = get_local_cb_interface(operand_id).fifo_page_size * tile_index;
-    std::uint32_t address = base_address + offset_address;
-    _llk_unpack_get_tile_<mail2math, mail2pack>(address, p_tile);
-}
-
-template <bool mail2math = true, bool mail2pack = true>
-inline void llk_unpack_release_tile(std::uint32_t operand) {
-    _llk_unpack_release_tile_<mail2math, mail2pack>();
-}
-
 inline void llk_unpack_debug_dump(std::uint8_t* data, std::uint32_t byte_size) {
     _llk_unpack_debug_dump_(data, byte_size);
 }

--- a/tt_metal/include/compute_kernel_api/cb_api.h
+++ b/tt_metal/include/compute_kernel_api/cb_api.h
@@ -144,7 +144,7 @@ ALWI uint32_t get_tile_address(uint32_t cb_id, uint32_t tile_index) {
 
     UNPACK({
         uint32_t operand_id = get_operand_id(cb_id);
-        uint32_t base_address = get_local_cb_interface(operand_id).fifo_rd_ptr - 1;
+        uint32_t base_address = get_local_cb_interface(operand_id).fifo_rd_ptr;
         uint32_t offset_address = get_local_cb_interface(operand_id).fifo_page_size * tile_index;
         address = (base_address + offset_address) << 4;  // Convert to byte address
 
@@ -169,7 +169,7 @@ ALWI uint32_t get_tile_address(uint32_t cb_id, uint32_t tile_index) {
  * |----------------|--------------------------------------------|----------|-------------|----------|
  * | cb_id          | The index of the circular buffer (CB)      | uint32_t | 0 to 31     | True     |
  * | tile_index     | The tile index within the CB               | uint32_t | 0 to CB size| True     |
- * | element_offset | The uint32_t element offset within the tile| uint32_t | N/A         | True     |
+ * | element_offset | The uint32_t element offset within the tile| uint32_t | >= 0        | True     |
  */
 // clang-format on
 ALWI uint32_t read_tile_value(uint32_t cb_id, uint32_t tile_index, uint32_t element_offset) {
@@ -177,7 +177,7 @@ ALWI uint32_t read_tile_value(uint32_t cb_id, uint32_t tile_index, uint32_t elem
 
     UNPACK({
         uint32_t operand_id = get_operand_id(cb_id);
-        uint32_t base_address = get_local_cb_interface(operand_id).fifo_rd_ptr - 1;
+        uint32_t base_address = get_local_cb_interface(operand_id).fifo_rd_ptr;
         uint32_t offset_address = get_local_cb_interface(operand_id).fifo_page_size * tile_index;
         uint32_t byte_address = (base_address + offset_address) << 4;  // Convert to byte address
 

--- a/tt_metal/include/compute_kernel_api/cb_api.h
+++ b/tt_metal/include/compute_kernel_api/cb_api.h
@@ -34,10 +34,10 @@ namespace ckernel {
  *
  * | Argument  | Description                          | Type     | Valid Range                                                                                       | Required |
  * |-----------|--------------------------------------|----------|---------------------------------------------------------------------------------------------------|----------|
- * | cb_id     | The index of the cirular buffer (CB) | uint32_t | 0 to 31                                                                                           | True     | 
+ * | cb_id     | The index of the cirular buffer (CB) | uint32_t | 0 to 31                                                                                           | True     |
  * | ntiles    | The number of tiles to wait for      | uint32_t | It must be less or equal than the size of the CB (the total number of tiles that fit into the CB) | True     |
  * */
- // clang-format on
+// clang-format on
 ALWI void cb_wait_front(uint32_t cbid, uint32_t ntiles) { UNPACK((llk_wait_tiles(cbid, ntiles))); }
 
 // clang-format off
@@ -66,10 +66,10 @@ ALWI void cb_wait_front(uint32_t cbid, uint32_t ntiles) { UNPACK((llk_wait_tiles
  *
  * | Argument  | Description                          | Type     | Valid Range                                                                                       | Required |
  * |-----------|--------------------------------------|----------|---------------------------------------------------------------------------------------------------|----------|
- * | cb_id     | The index of the cirular buffer (CB) | uint32_t | 0 to 31                                                                                           | True     | 
+ * | cb_id     | The index of the cirular buffer (CB) | uint32_t | 0 to 31                                                                                           | True     |
  * | ntiles    | The number of tiles to be popped     | uint32_t | It must be less or equal than the size of the CB (the total number of tiles that fit into the CB) | True     |
  */
- // clang-format on
+// clang-format on
 ALWI void cb_pop_front(uint32_t cbid, uint32_t ntiles) { UNPACK((llk_pop_tiles(cbid, ntiles))); }
 
 // clang-format off
@@ -83,10 +83,10 @@ ALWI void cb_pop_front(uint32_t cbid, uint32_t ntiles) { UNPACK((llk_pop_tiles(c
  *
  * | Argument  | Description                          | Type     | Valid Range                                                                                       | Required |
  * |-----------|--------------------------------------|----------|---------------------------------------------------------------------------------------------------|----------|
- * | cb_id     | The index of the cirular buffer (CB) | uint32_t | 0 to 31                                                                                           | True     | 
+ * | cb_id     | The index of the cirular buffer (CB) | uint32_t | 0 to 31                                                                                           | True     |
  * | ntiles    | The number of free tiles to wait for | uint32_t | It must be less or equal than the size of the CB (the total number of tiles that fit into the CB) | True     |
  */
- // clang-format on
+// clang-format on
 ALWI void cb_reserve_back(uint32_t cbid, uint32_t ntiles) {
     PACK((llk_wait_for_free_tiles<false, false, false>(cbid, ntiles)));
 }
@@ -117,53 +117,80 @@ ALWI void cb_reserve_back(uint32_t cbid, uint32_t ntiles) {
  *
  * | Argument  | Description                          | Type     | Valid Range                                                                                       | Required |
  * |-----------|--------------------------------------|----------|---------------------------------------------------------------------------------------------------|----------|
- * | cb_id     | The index of the cirular buffer (CB) | uint32_t | 0 to 31                                                                                           | True     | 
+ * | cb_id     | The index of the cirular buffer (CB) | uint32_t | 0 to 31                                                                                           | True     |
  * | ntiles    | The number of tiles to be pushed     | uint32_t | It must be less or equal than the size of the CB (the total number of tiles that fit into the CB) | True     |
  */
- // clang-format on
+// clang-format on
 ALWI void cb_push_back(uint32_t cbid, uint32_t ntiles) { PACK((llk_push_tiles<false, false>(cbid, ntiles))); }
 
 // clang-format off
 /**
- * Sends the pointer to the given tile index of the specified CB from the UNPACK
- * thread to the MATH and PACK threads, using mailbox writes. Also posts UNPACK_OPERAND_SYNC
- * semaphore for each of these threads.
+ * Gets the L1 address of a tile in the specified circular buffer using mailbox-based
+ * synchronization to ensure all compute threads (UNPACK, MATH, PACK) receive the same address.
  *
- * Return value: None
+ * The UNPACK thread reads the tile address and distributes it to MATH and PACK threads
+ * via mailbox, ensuring consistent values across all threads.
  *
- * | Argument  | Description                          | Type     | Valid Range                                                                                       | Required |
- * |-----------|--------------------------------------|----------|---------------------------------------------------------------------------------------------------|----------|
- * | cb_id     | The index of the cirular buffer (CB) | uint32_t | 0 to 31                                                                                           | True     | 
- * | index     | The tile index within the CB         | uint32_t | It must be less or equal than the size of the CB (the total number of tiles that fit into the CB) | True     | 
- * | p_tile    | The pointer that will be populated   | void*    | N/A                                                                                               | True     |
+ * Return value: The L1 address of the tile (same value on all threads)
+ *
+ * | Argument    | Description                          | Type     | Valid Range | Required |
+ * |-------------|--------------------------------------|----------|-------------|----------|
+ * | cb_id       | The index of the circular buffer (CB)| uint32_t | 0 to 31     | True     |
+ * | tile_index  | The tile index within the CB         | uint32_t | 0 to CB size| True     |
  */
- // clang-format on
-ALWI void cb_get_tile(uint32_t cb_id, uint32_t index, volatile void* p_tile) {
-    UNPACK(llk_unpack_get_tile(cb_id, index, (uint32_t*)p_tile));
+// clang-format on
+ALWI uint32_t get_tile_address(uint32_t cb_id, uint32_t tile_index) {
+    uint32_t address = 0;
 
-    MATH(llk_math_get_tile(cb_id, index, (uint32_t*)p_tile));
+    UNPACK({
+        uint32_t operand_id = get_operand_id(cb_id);
+        uint32_t base_address = get_local_cb_interface(operand_id).fifo_rd_ptr - 1;
+        uint32_t offset_address = get_local_cb_interface(operand_id).fifo_page_size * tile_index;
+        address = (base_address + offset_address) << 4;  // Convert to byte address
 
-    PACK(llk_pack_get_tile(cb_id, index, (uint32_t*)p_tile));
+        mailbox_write(ckernel::ThreadId::MathThreadId, address);
+        mailbox_write(ckernel::ThreadId::PackThreadId, address);
+    })
+
+    MATH(address = mailbox_read(ckernel::ThreadId::UnpackThreadId);)
+    PACK(address = mailbox_read(ckernel::ThreadId::UnpackThreadId);)
+
+    return address;
 }
 
 // clang-format off
 /**
- * Blocks UNPACK thread on UNPACK_OPERAND_SYNC semaphore being decremented by
- * MATH and PACK threads.
+ * Reads a uint32_t value from a tile in the specified circular buffer at a given element offset.
+ * Uses mailbox-based synchronization to ensure all compute threads receive the same value.
  *
- * Return value: None
+ * Return value: The uint32_t value at the specified offset (same value on all threads)
  *
- * | Argument  | Description                          | Type     | Valid Range | Required |
- * |-----------|--------------------------------------|----------|-------------|----------|
- * | cb_id     | The index of the cirular buffer (CB) | uint32_t | 0 to 31     | True     |
+ * | Argument       | Description                                | Type     | Valid Range | Required |
+ * |----------------|--------------------------------------------|----------|-------------|----------|
+ * | cb_id          | The index of the circular buffer (CB)      | uint32_t | 0 to 31     | True     |
+ * | tile_index     | The tile index within the CB               | uint32_t | 0 to CB size| True     |
+ * | element_offset | The uint32_t element offset within the tile| uint32_t | N/A         | True     |
  */
- // clang-format on
-ALWI void cb_release_tile(uint32_t cb_id) {
-    UNPACK(llk_unpack_release_tile(cb_id));
+// clang-format on
+ALWI uint32_t read_tile_value(uint32_t cb_id, uint32_t tile_index, uint32_t element_offset) {
+    uint32_t value = 0;
 
-    MATH(llk_math_release_tile(cb_id));
+    UNPACK({
+        uint32_t operand_id = get_operand_id(cb_id);
+        uint32_t base_address = get_local_cb_interface(operand_id).fifo_rd_ptr - 1;
+        uint32_t offset_address = get_local_cb_interface(operand_id).fifo_page_size * tile_index;
+        uint32_t byte_address = (base_address + offset_address) << 4;  // Convert to byte address
 
-    PACK(llk_pack_release_tile(cb_id));
+        value = reinterpret_cast<volatile uint32_t*>(byte_address)[element_offset];
+
+        mailbox_write(ckernel::ThreadId::MathThreadId, value);
+        mailbox_write(ckernel::ThreadId::PackThreadId, value);
+    })
+
+    MATH(value = mailbox_read(ckernel::ThreadId::UnpackThreadId);)
+    PACK(value = mailbox_read(ckernel::ThreadId::UnpackThreadId);)
+
+    return value;
 }
 
 }  // namespace ckernel

--- a/ttnn/cpp/ttnn/operations/embedding_backward/device/kernels/compute/embedding_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding_backward/device/kernels/compute/embedding_backward.cpp
@@ -22,25 +22,22 @@ void MAIN {
 
     unary_op_init_common(cb_grad, cb_out);
 
+    constexpr uint32_t cb_data_offset = 4;
+
     for (uint32_t i = 0; i < input_height; ++i) {
         cb_wait_front(cb_grad, max_tiles_per_core);
 
-        // Get chunk_count from reader
-        volatile uint32_t* chunk_addr_ptr;
-        cb_get_tile(cb_chunk_count_scratch, 0, &chunk_addr_ptr);
-        uint32_t chunk_count = chunk_addr_ptr[4];  // Need to shift because read ptr is off by 1 << 4 in BBE
-        cb_release_tile(cb_chunk_count_scratch);
+        // Get chunk_count from CB using mailbox-based synchronization (issue #27979)
+        uint32_t chunk_count = read_tile_value(cb_chunk_count_scratch, 0, cb_data_offset);
 
-        for (uint32_t chunk = 0; chunk < chunk_count; ++chunk) {  // chunk_count
+        for (uint32_t chunk = 0; chunk < chunk_count; ++chunk) {
             cb_wait_front(cb_mask, 1);
-            // get cb_index pointer from unpack to math thread
-            volatile uint* idx_addr_ptr;
-            uint32_t tile_to_get = 0;
-            cb_get_tile(cb_mask, tile_to_get, &idx_addr_ptr);
-            uint32_t idx_addr = reinterpret_cast<uint32_t>(idx_addr_ptr);
+
+            // Get idx_addr from CB using mailbox-based synchronization (issue #27979)
+            uint32_t idx_addr = get_tile_address(cb_mask, 0);
 #if defined(ARCH_BLACKHOLE)
             // Workaround for tt-metal issue #11816:
-            // Flush the cache, forces going to L1 to access data of cb_get_tile pointer
+            // Flush the cache, forces going to L1 to access data
             asm volatile("fence");
 #endif
 
@@ -68,7 +65,6 @@ void MAIN {
             cb_push_back(cb_out, max_tiles_per_core);
             cb_pop_front(cb_out_intermed, max_tiles_per_core);
 
-            cb_release_tile(cb_mask);
             cb_pop_front(cb_mask, 1);
         }
 

--- a/ttnn/cpp/ttnn/operations/normalization/kernel_util/compute/memory.h
+++ b/ttnn/cpp/ttnn/operations/normalization/kernel_util/compute/memory.h
@@ -17,8 +17,9 @@ namespace norm::kernel_util::compute::memory {
  * @brief Get a pointer to the underlying CB tile data, reinterpreted
  * as a pointer to given type.
  *
- * @details Uses cb_get_tile(), which uses mailbox writes from
- * UNPACK thread to MATH and PACK threads
+ * @details Uses get_tile_address() with mailbox-based synchronization to ensure
+ * all threads receive the same address. This avoids race conditions due to
+ * Tensix semaphore limitations. See GitHub issue #27979 for details.
  *
  * @tparam To The type to reinterpret the CB pointer as a pointer to
  * @param cb_id The CB containing the tile data
@@ -27,11 +28,10 @@ namespace norm::kernel_util::compute::memory {
  */
 template <typename To>
 ALWI auto get_pointer_to_cb_data(uint32_t cb_id, uint32_t tile_index) -> To* {
-    // Offset to skip metadata
-    constexpr uint32_t cb_data_offset = 4;
+    // Offset to skip metadata (4 uint32_t elements = 16 bytes)
+    constexpr uint32_t cb_data_offset_bytes = 4 * sizeof(uint32_t);
 
-    uint32_t* p_from = nullptr;
-    cb_get_tile(cb_id, tile_index, &p_from);
-    return reinterpret_cast<To*>(p_from + cb_data_offset);
+    uint32_t address = get_tile_address(cb_id, tile_index);
+    return reinterpret_cast<To*>(address + cb_data_offset_bytes);
 }
 }  // namespace norm::kernel_util::compute::memory

--- a/ttnn/cpp/ttnn/operations/normalization/kernel_util/compute/memory.h
+++ b/ttnn/cpp/ttnn/operations/normalization/kernel_util/compute/memory.h
@@ -28,10 +28,6 @@ namespace norm::kernel_util::compute::memory {
  */
 template <typename To>
 ALWI auto get_pointer_to_cb_data(uint32_t cb_id, uint32_t tile_index) -> To* {
-    // Offset to skip metadata (4 uint32_t elements = 16 bytes)
-    constexpr uint32_t cb_data_offset_bytes = 4 * sizeof(uint32_t);
-
-    uint32_t address = get_tile_address(cb_id, tile_index);
-    return reinterpret_cast<To*>(address + cb_data_offset_bytes);
+    return reinterpret_cast<To*>(get_tile_address(cb_id, tile_index));
 }
 }  // namespace norm::kernel_util::compute::memory

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/sdpa_flash_decode.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/sdpa_flash_decode.cpp
@@ -129,10 +129,9 @@ void MAIN {
         } else {
             // Read cur_pos from CB using mailbox-based synchronization (issue #27979)
             constexpr uint32_t cb_index_id = tt::CBIndex::c_8;
-            constexpr uint32_t cb_data_offset = 4;
 
             cb_wait_front(cb_index_id, 1);
-            cur_pos = read_tile_value(cb_index_id, 0, cb_data_offset + (cur_batch / q_heads_parallel_factor));
+            cur_pos = read_tile_value(cb_index_id, 0, cur_batch / q_heads_parallel_factor);
             cb_pop_front(cb_index_id, 1);
         }
         if (cur_pos == UINT32_MAX) {

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/sdpa_flash_decode.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/sdpa_flash_decode.cpp
@@ -127,13 +127,13 @@ void MAIN {
         if (cur_pos_arg != UINT32_MAX) {
             cur_pos = cur_pos_arg;
         } else {
+            // Read cur_pos from CB using mailbox-based synchronization (issue #27979)
             constexpr uint32_t cb_index_id = tt::CBIndex::c_8;
+            constexpr uint32_t cb_data_offset = 4;
+
             cb_wait_front(cb_index_id, 1);
-            volatile uint32_t* index_addr_ptr;
-            cb_get_tile(cb_index_id, 0, &index_addr_ptr);
-            uint32_t cb_get_tile_offset = 4;  // Using cb_get_tile, the first 4 elements do not have the data
-            cur_pos = index_addr_ptr[cb_get_tile_offset + (cur_batch / q_heads_parallel_factor)];
-            cb_release_tile(cb_index_id);
+            cur_pos = read_tile_value(cb_index_id, 0, cb_data_offset + (cur_batch / q_heads_parallel_factor));
+            cb_pop_front(cb_index_id, 1);
         }
         if (cur_pos == UINT32_MAX) {
             // cur_pos of -1 indicates that the user should be skipped


### PR DESCRIPTION
### Ticket
[31490](https://github.com/tenstorrent/tt-metal/issues/31490)

### Problem description
cb_get_tile tile API is dangerous as it can lead to race conditions in case OP is using semaphores for some other use-case (like mcasts).

### What's changed
Replaced cb_get_tile/cb_release_tile compute API abstractions with get_tile_address & read_tile_value, where the later ones are not using semaphores and rely only on mailbox mechanism.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/20005859293)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/20005862446)