### PR TITLE
Use transaction IDs in kernels with unaligned access

### DIFF
--- a/models/demos/vision/generative/stable_diffusion/wormhole/tests/test_perf.py
+++ b/models/demos/vision/generative/stable_diffusion/wormhole/tests/test_perf.py
@@ -420,7 +420,7 @@ def test_stable_diffusion_perf(
 @pytest.mark.models_device_performance_bare_metal
 @pytest.mark.parametrize(
     "expected_kernel_samples_per_second",
-    ((13.2) if is_wormhole_b0() else (20.0),),
+    ((13.2) if is_wormhole_b0() else (21.0),),
 )
 def test_stable_diffusion_device_perf(expected_kernel_samples_per_second):
     subdir = "ttnn_stable_diffusion"

--- a/models/demos/vision/segmentation/ufld_v2/blackhole/tests/perf/test_ufld_v2_perf.py
+++ b/models/demos/vision/segmentation/ufld_v2/blackhole/tests/perf/test_ufld_v2_perf.py
@@ -14,7 +14,7 @@ from models.perf.device_perf_utils import check_device_perf, prep_device_perf_re
 @pytest.mark.parametrize(
     "batch_size, expected_perf,test",
     [
-        [1, 433, "UFLD-v2"],
+        [1, 495, "UFLD-v2"],
     ],
 )
 @pytest.mark.models_device_performance_bare_metal

--- a/models/demos/vision/segmentation/vgg_unet/blackhole/tests/perf/test_perf_vgg_unet.py
+++ b/models/demos/vision/segmentation/vgg_unet/blackhole/tests/perf/test_perf_vgg_unet.py
@@ -11,7 +11,7 @@ from models.perf.device_perf_utils import check_device_perf, prep_device_perf_re
 @pytest.mark.parametrize(
     "batch_size, expected_perf",
     [
-        [1, 411],
+        [1, 488],
     ],
 )
 @pytest.mark.models_device_performance_bare_metal

--- a/tests/tt_metal/tt_metal/data_movement/interleaved_to_sharded_hardcoded/kernels/reader_unary_stick_layout_sharded_blocks_interleaved_start_id.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/interleaved_to_sharded_hardcoded/kernels/reader_unary_stick_layout_sharded_blocks_interleaved_start_id.cpp
@@ -21,13 +21,13 @@ void kernel_main() {
     constexpr uint32_t stick_size = get_compile_time_arg_val(2);
     constexpr auto src_args = TensorAccessorArgs<3>();
     uint32_t test_id = get_compile_time_arg_val(4);
+    constexpr uint32_t num_trids = get_compile_time_arg_val(5);
 
     const auto s0 = TensorAccessor(src_args, src_addr + aligned_input_width_offset_bytes, stick_size);
     uint32_t stick_id = start_id;
-
     cb_reserve_back(cb_id_in0, block_height);
+    uint32_t dest_write_addr = get_write_ptr(cb_id_in0);
 
-    uint32_t l1_write_addr = get_write_ptr(cb_id_in0);
     DeviceTimestampedData("Number of transactions", block_height);
     DeviceTimestampedData("Transaction size in bytes", block_width_bytes);
     DeviceTimestampedData("Test id", test_id);
@@ -36,26 +36,74 @@ void kernel_main() {
         if (aligned) {
             for (uint32_t h = 0; h < block_height; ++h) {
                 uint64_t src_noc_addr = get_noc_addr(stick_id, s0);
-                noc_async_read(src_noc_addr, l1_write_addr, block_width_bytes);
+                noc_async_read(src_noc_addr, dest_write_addr, block_width_bytes);
                 stick_id++;
-                l1_write_addr += padded_block_width_bytes;
+                dest_write_addr += padded_block_width_bytes;
             }
+            noc_async_read_barrier();
         } else {
-            cb_reserve_back(cb_id_in1, 1);
-            uint32_t scratch_l1_write_addr = get_write_ptr(cb_id_in1);
-            uint64_t scratch_l1_noc_read_addr = get_noc_addr(scratch_l1_write_addr + aligned_offset);
-            for (uint32_t h = 0; h < block_height; ++h) {
-                uint64_t src_noc_addr = get_noc_addr(stick_id, s0);
-                noc_async_read(src_noc_addr, scratch_l1_write_addr, aligned_block_width_bytes);
-                noc_async_read_barrier();
-                noc_async_read(scratch_l1_noc_read_addr, l1_write_addr, block_width_bytes);
-                noc_async_read_barrier();
-                stick_id++;
-                l1_write_addr += padded_block_width_bytes;
+            enum SlotState : uint8_t { IDLE = 0, SRC_PENDING = 1, SCRATCH_READY = 2, SCRATCH_PENDING = 3 };
+
+            constexpr uint32_t trid_base = 1;
+
+            cb_reserve_back(cb_id_in1, num_trids);
+            uint32_t scratch_write_addr_base = get_write_ptr(cb_id_in1);
+            uint32_t scratch_cb_page_size = get_local_cb_interface(cb_id_in1).fifo_page_size;
+            SlotState slot_states[num_trids];
+            uint32_t dest_write_addrs[num_trids];
+            uint32_t scratch_write_addrs[num_trids];
+
+            // Initialize slots
+            for (uint32_t i = 0; i < num_trids; i++) {
+                slot_states[i] = SlotState::IDLE;
+                scratch_write_addrs[i] = scratch_write_addr_base + i * scratch_cb_page_size;
+            }
+
+            uint32_t rows_issued = 0;     // Number of src->scratch transfers started
+            uint32_t rows_completed = 0;  // Number of scratch->dest transfers completed
+
+            while (rows_completed < block_height) {
+                for (uint32_t slot = 0; slot < num_trids; slot++) {
+                    uint32_t active_trid = trid_base + slot;
+
+                    if (slot_states[slot] == SlotState::IDLE && rows_issued < block_height) {
+                        // Start new src->scratch transfer
+                        noc_async_read_set_trid(active_trid);
+                        uint64_t src_noc_addr = get_noc_addr(stick_id, s0);
+                        noc_async_read(src_noc_addr, scratch_write_addrs[slot], aligned_block_width_bytes);
+                        dest_write_addrs[slot] = dest_write_addr;
+                        slot_states[slot] = SlotState::SRC_PENDING;
+
+                        stick_id++;
+                        dest_write_addr += padded_block_width_bytes;
+                        rows_issued++;
+                    }
+                    if (slot_states[slot] == SlotState::SRC_PENDING) {
+                        // Check if src->scratch is complete
+                        if (ncrisc_noc_read_with_transaction_id_flushed(noc_index, active_trid) == 1) {
+                            slot_states[slot] = SlotState::SCRATCH_READY;
+                        }
+                    }
+                    if (slot_states[slot] == SlotState::SCRATCH_READY) {
+                        // Start scratch->dest transfer
+                        noc_async_read_set_trid(active_trid);
+
+                        uint64_t scratch_noc_read_addr = get_noc_addr(scratch_write_addrs[slot] + aligned_offset);
+                        noc_async_read(scratch_noc_read_addr, dest_write_addrs[slot], block_width_bytes);
+
+                        slot_states[slot] = SlotState::SCRATCH_PENDING;
+                    }
+                    if (slot_states[slot] == SlotState::SCRATCH_PENDING) {
+                        // Check if scratch->dest is complete
+                        if (ncrisc_noc_read_with_transaction_id_flushed(noc_index, active_trid) == 1) {
+                            slot_states[slot] = SlotState::IDLE;
+                            rows_completed++;
+                        }
+                    }
+                }
             }
         }
-        noc_async_read_barrier();
     }
-
+    noc_async_read_set_trid(0);
     cb_push_back(cb_id_in0, block_height);
 }

--- a/tests/tt_metal/tt_metal/data_movement/interleaved_to_sharded_hardcoded/test_interleaved_to_sharded_hardcoded.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/interleaved_to_sharded_hardcoded/test_interleaved_to_sharded_hardcoded.cpp
@@ -281,6 +281,8 @@ bool run_dm(const std::shared_ptr<distributed::MeshDevice>& mesh_device, const T
     tt::DataFormat input_cb_data_format = test_config.input_data_format;
     uint32_t output_page_size, num_input_units;
     uint32_t input_cb_index = tt::CBIndex::c_0;
+    uint32_t scratch_cb_index = tt::CBIndex::c_1;
+    uint32_t num_trids = 4;
     uint32_t out_cb_index = input_cb_index;
     output_page_size = 512;
     num_input_units = 128;
@@ -290,6 +292,12 @@ bool run_dm(const std::shared_ptr<distributed::MeshDevice>& mesh_device, const T
         tt::tt_metal::CircularBufferConfig(num_input_units * output_page_size, {{out_cb_index, output_cb_data_format}})
             .set_page_size(out_cb_index, output_page_size);
     tt::tt_metal::CreateCircularBuffer(program, test_config.master_core_coord, output_cb_out_config);
+
+    uint32_t scratch_page_size = output_page_size;
+    tt::tt_metal::CircularBufferConfig scratch_cb_config =
+        tt::tt_metal::CircularBufferConfig(num_trids * output_page_size, {{scratch_cb_index, output_cb_data_format}})
+            .set_page_size(scratch_cb_index, scratch_page_size);
+    tt::tt_metal::CreateCircularBuffer(program, test_config.master_core_coord, scratch_cb_config);
 
     workload.add_program(device_range, std::move(program));
 
@@ -336,6 +344,8 @@ bool run_dm(const std::shared_ptr<distributed::MeshDevice>& mesh_device, const T
     tt::DataFormat input_cb_data_format = test_config.input_data_format;
     uint32_t output_page_size, num_input_units;
     uint32_t input_cb_index = tt::CBIndex::c_0;
+    uint32_t scratch_cb_index = tt::CBIndex::c_1;
+    uint32_t num_trids = 4;
     uint32_t out_cb_index = input_cb_index;
     output_page_size = 512;
     num_input_units = 128;
@@ -345,6 +355,12 @@ bool run_dm(const std::shared_ptr<distributed::MeshDevice>& mesh_device, const T
         tt::tt_metal::CircularBufferConfig(num_input_units * output_page_size, {{out_cb_index, output_cb_data_format}})
             .set_page_size(out_cb_index, output_page_size);
     tt::tt_metal::CreateCircularBuffer(program, test_config.master_core_coord, output_cb_out_config);
+
+    uint32_t scratch_page_size = output_page_size;
+    tt::tt_metal::CircularBufferConfig scratch_cb_config =
+        tt::tt_metal::CircularBufferConfig(num_trids * output_page_size, {{scratch_cb_index, output_cb_data_format}})
+            .set_page_size(scratch_cb_index, scratch_page_size);
+    tt::tt_metal::CreateCircularBuffer(program, test_config.master_core_coord, scratch_cb_config);
 
     workload.add_program(device_range, std::move(program));
 
@@ -546,12 +562,14 @@ TEST_F(MeshDeviceFixture, TensixDataMovementI2SDRAMInterleavedReaderRowMajor) {
     std::vector<uint32_t> compile_args;
     std::vector<uint32_t> runtime_args;
     CoreCoord master_core_coord = {0, 0};
+    uint32_t num_trids = 4;
 
     compile_args.push_back(0);        // input_cb_index
     compile_args.push_back(1);        // scratch_cb_index
     compile_args.push_back(2048);     // num_units_per_row
     compile_args.push_back(2);        // isDram = true
     compile_args.push_back(test_id);  // test_id
+    compile_args.push_back(num_trids);  // num_trids
 
     runtime_args.push_back(2560032);  // src_buffer->address(),
     runtime_args.push_back(2048);     // num_units_per_row,
@@ -589,12 +607,14 @@ TEST_F(MeshDeviceFixture, TensixDataMovementI2SL1InterleavedReaderRowMajor) {
     std::vector<uint32_t> compile_args;
     std::vector<uint32_t> runtime_args;
     CoreCoord master_core_coord = {0, 0};
+    uint32_t num_trids = 4;
 
     compile_args.push_back(0);        // input_cb_index
     compile_args.push_back(1);        // scratch_cb_index
     compile_args.push_back(2048);     // num_units_per_row
     compile_args.push_back(0);        // isDram = false
     compile_args.push_back(test_id);  // test_id
+    compile_args.push_back(num_trids);  // num_trids
 
     runtime_args.push_back(1024);  // src_buffer->address(),
     runtime_args.push_back(2048);  // num_units_per_row,

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/reader_unary_stick_layout_sharded_blocks_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/reader_unary_stick_layout_sharded_blocks_interleaved_start_id.cpp
@@ -76,21 +76,23 @@ void kernel_main() {
                     stick_id++;
                     dest_write_addr += padded_block_width_bytes;
                     rows_issued++;
-
-                } else if (slot_states[slot] == SlotState::SRC_PENDING) {
+                }
+                if (slot_states[slot] == SlotState::SRC_PENDING) {
                     // Check if src->scratch is complete
                     if (ncrisc_noc_read_with_transaction_id_flushed(noc_index, active_trid) == 1) {
                         slot_states[slot] = SlotState::SCRATCH_READY;
                     }
-
-                } else if (slot_states[slot] == SlotState::SCRATCH_READY) {
+                }
+                if (slot_states[slot] == SlotState::SCRATCH_READY) {
                     // Start scratch->dest transfer
                     noc_async_read_set_trid(active_trid);
+
                     uint64_t scratch_noc_read_addr = get_noc_addr(scratch_write_addrs[slot] + aligned_offset);
                     noc_async_read(scratch_noc_read_addr, dest_write_addrs[slot], block_width_bytes);
-                    slot_states[slot] = SlotState::SCRATCH_PENDING;
 
-                } else if (slot_states[slot] == SlotState::SCRATCH_PENDING) {
+                    slot_states[slot] = SlotState::SCRATCH_PENDING;
+                }
+                if (slot_states[slot] == SlotState::SCRATCH_PENDING) {
                     // Check if scratch->dest is complete
                     if (ncrisc_noc_read_with_transaction_id_flushed(noc_index, active_trid) == 1) {
                         slot_states[slot] = SlotState::IDLE;
@@ -99,6 +101,8 @@ void kernel_main() {
                 }
             }
         }
+
     }
+    noc_async_read_set_trid(0);
     cb_push_back(cb_id_in0, block_height);
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/reader_unary_stick_layout_sharded_blocks_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/reader_unary_stick_layout_sharded_blocks_interleaved_start_id.cpp
@@ -20,34 +20,85 @@ void kernel_main() {
     constexpr uint32_t cb_id_in0 = get_compile_time_arg_val(0);
     constexpr uint32_t cb_id_in1 = get_compile_time_arg_val(1);
     constexpr uint32_t stick_size = get_compile_time_arg_val(2);
-    constexpr auto src_args = TensorAccessorArgs<3>();
+    constexpr uint32_t num_trids = get_compile_time_arg_val(3);
+    constexpr auto src_args = TensorAccessorArgs<4>();
 
     const auto s0 = TensorAccessor(src_args, src_addr + aligned_input_width_offset_bytes, stick_size);
-
     uint32_t stick_id = start_id;
     cb_reserve_back(cb_id_in0, block_height);
-    uint32_t l1_write_addr = get_write_ptr(cb_id_in0);
+    uint32_t dest_write_addr = get_write_ptr(cb_id_in0);
     if (aligned) {
         for (uint32_t h = 0; h < block_height; ++h) {
             uint64_t src_noc_addr = get_noc_addr(stick_id, s0);
-            noc_async_read(src_noc_addr, l1_write_addr, block_width_bytes);
+            noc_async_read(src_noc_addr, dest_write_addr, block_width_bytes);
             stick_id++;
-            l1_write_addr += padded_block_width_bytes;
+            dest_write_addr += padded_block_width_bytes;
         }
+        noc_async_read_barrier();
     } else {
-        cb_reserve_back(cb_id_in1, 1);
-        uint32_t scratch_l1_write_addr = get_write_ptr(cb_id_in1);
-        uint64_t scratch_l1_noc_read_addr = get_noc_addr(scratch_l1_write_addr + aligned_offset);
-        for (uint32_t h = 0; h < block_height; ++h) {
-            uint64_t src_noc_addr = get_noc_addr(stick_id, s0);
-            noc_async_read(src_noc_addr, scratch_l1_write_addr, aligned_block_width_bytes);
-            noc_async_read_barrier();
-            noc_async_read(scratch_l1_noc_read_addr, l1_write_addr, block_width_bytes);
-            noc_async_read_barrier();
-            stick_id++;
-            l1_write_addr += padded_block_width_bytes;
+        enum SlotState : uint8_t {
+            IDLE = 0,
+            SRC_PENDING = 1,
+            SCRATCH_READY = 2,
+            SCRATCH_PENDING = 3
+        };
+
+        constexpr uint32_t trid_base = 1;
+
+        cb_reserve_back(cb_id_in1, num_trids);
+        uint32_t scratch_write_addr_base = get_write_ptr(cb_id_in1);
+        uint32_t scratch_cb_page_size = get_local_cb_interface(cb_id_in1).fifo_page_size;
+        SlotState slot_states[num_trids];
+        uint32_t dest_write_addrs[num_trids];
+        uint32_t scratch_write_addrs[num_trids];
+
+        // Initialize slots
+        for (uint32_t i = 0; i < num_trids; i++) {
+            slot_states[i] = SlotState::IDLE;
+            scratch_write_addrs[i] = scratch_write_addr_base + i * scratch_cb_page_size;
+        }
+
+        uint32_t rows_issued = 0;      // Number of src->scratch transfers started
+        uint32_t rows_completed = 0;   // Number of scratch->dest transfers completed
+
+        while (rows_completed < block_height) {
+            for (uint32_t slot = 0; slot < num_trids; slot++) {
+                uint32_t active_trid = trid_base + slot;
+
+                if (slot_states[slot] == SlotState::IDLE && rows_issued < block_height) {
+                    // Start new src->scratch transfer
+                    noc_async_read_set_trid(active_trid);
+                    uint64_t src_noc_addr = get_noc_addr(stick_id, s0);
+                    noc_async_read(src_noc_addr, scratch_write_addrs[slot], aligned_block_width_bytes);
+                    dest_write_addrs[slot] = dest_write_addr;
+                    slot_states[slot] = SlotState::SRC_PENDING;
+
+                    stick_id++;
+                    dest_write_addr += padded_block_width_bytes;
+                    rows_issued++;
+
+                } else if (slot_states[slot] == SlotState::SRC_PENDING) {
+                    // Check if src->scratch is complete
+                    if (ncrisc_noc_read_with_transaction_id_flushed(noc_index, active_trid) == 1) {
+                        slot_states[slot] = SlotState::SCRATCH_READY;
+                    }
+
+                } else if (slot_states[slot] == SlotState::SCRATCH_READY) {
+                    // Start scratch->dest transfer
+                    noc_async_read_set_trid(active_trid);
+                    uint64_t scratch_noc_read_addr = get_noc_addr(scratch_write_addrs[slot] + aligned_offset);
+                    noc_async_read(scratch_noc_read_addr, dest_write_addrs[slot], block_width_bytes);
+                    slot_states[slot] = SlotState::SCRATCH_PENDING;
+
+                } else if (slot_states[slot] == SlotState::SCRATCH_PENDING) {
+                    // Check if scratch->dest is complete
+                    if (ncrisc_noc_read_with_transaction_id_flushed(noc_index, active_trid) == 1) {
+                        slot_states[slot] = SlotState::IDLE;
+                        rows_completed++;
+                    }
+                }
+            }
         }
     }
-    noc_async_read_barrier();
     cb_push_back(cb_id_in0, block_height);
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_program_factory.cpp
@@ -128,7 +128,7 @@ InterleavedToShardedProgramFactory::cached_program_t InterleavedToShardedProgram
     }
     auto cb_output = tt::tt_metal::CreateCircularBuffer(program, all_cores, output_cb_out_config);
     uint32_t dram_alignment = hal::get_dram_alignment();
-    uint32_t num_trids = 2;
+    uint32_t num_trids = 4;
     if ((src_is_dram && (input_unit_size % dram_alignment != 0)) || is_blackhole || keep_l1_aligned) {
         uint32_t scratch_cb_page_size;
         // scratchpad going to be used to align DRAM (64B) to L1 (16B)

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_program_factory.cpp
@@ -133,6 +133,8 @@ InterleavedToShardedProgramFactory::cached_program_t InterleavedToShardedProgram
         uint32_t scratch_cb_page_size;
         // scratchpad going to be used to align DRAM (64B) to L1 (16B)
 
+        // This is done to mitigate the alignment issues.
+        // See issue #34414.
         scratch_cb_page_size = tt::align(input_unit_size + dram_alignment, dram_alignment);
 
         tt::tt_metal::CircularBufferConfig scratch_cb_out_config =

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_program_factory.cpp
@@ -128,16 +128,15 @@ InterleavedToShardedProgramFactory::cached_program_t InterleavedToShardedProgram
     }
     auto cb_output = tt::tt_metal::CreateCircularBuffer(program, all_cores, output_cb_out_config);
     uint32_t dram_alignment = hal::get_dram_alignment();
+    uint32_t num_trids = 4;
     if ((src_is_dram && (input_unit_size % dram_alignment != 0)) || is_blackhole || keep_l1_aligned) {
         uint32_t scratch_cb_page_size;
         // scratchpad going to be used to align DRAM (64B) to L1 (16B)
-        if (is_blackhole) {
-            scratch_cb_page_size = tt::align(input_unit_size, hal::get_l1_alignment());
-        } else {
-            scratch_cb_page_size = tt::align(input_unit_size, dram_alignment);
-        }
+
+        scratch_cb_page_size = tt::align(input_unit_size, dram_alignment);
+
         tt::tt_metal::CircularBufferConfig scratch_cb_out_config =
-            tt::tt_metal::CircularBufferConfig(4 * scratch_cb_page_size, {{scratch_cb_index, input_cb_data_format}})
+            tt::tt_metal::CircularBufferConfig(num_trids * scratch_cb_page_size, {{scratch_cb_index, input_cb_data_format}})
                 .set_page_size(scratch_cb_index, scratch_cb_page_size);
         tt::tt_metal::CreateCircularBuffer(program, all_cores, scratch_cb_out_config);
     }
@@ -154,7 +153,7 @@ InterleavedToShardedProgramFactory::cached_program_t InterleavedToShardedProgram
             all_cores,
             tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
     } else {
-        std::vector<uint32_t> reader_compile_time_args = {input_cb_index, scratch_cb_index, num_units_per_row};
+        std::vector<uint32_t> reader_compile_time_args = {input_cb_index, scratch_cb_index, num_units_per_row, num_trids};
         tt::tt_metal::TensorAccessorArgs(*src_buffer).append_to(reader_compile_time_args);
 
         unary_reader_kernel_id = tt::tt_metal::CreateKernel(

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_program_factory.cpp
@@ -128,12 +128,12 @@ InterleavedToShardedProgramFactory::cached_program_t InterleavedToShardedProgram
     }
     auto cb_output = tt::tt_metal::CreateCircularBuffer(program, all_cores, output_cb_out_config);
     uint32_t dram_alignment = hal::get_dram_alignment();
-    uint32_t num_trids = 4;
+    uint32_t num_trids = 2;
     if ((src_is_dram && (input_unit_size % dram_alignment != 0)) || is_blackhole || keep_l1_aligned) {
         uint32_t scratch_cb_page_size;
         // scratchpad going to be used to align DRAM (64B) to L1 (16B)
 
-        scratch_cb_page_size = tt::align(input_unit_size, dram_alignment);
+        scratch_cb_page_size = tt::align(input_unit_size + dram_alignment, dram_alignment);
 
         tt::tt_metal::CircularBufferConfig scratch_cb_out_config =
             tt::tt_metal::CircularBufferConfig(num_trids * scratch_cb_page_size, {{scratch_cb_index, input_cb_data_format}})

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/device/interleaved_to_sharded_partial_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/device/interleaved_to_sharded_partial_program_factory.cpp
@@ -121,11 +121,13 @@ InterleavedToShardedPartialProgramFactory::cached_program_t InterleavedToSharded
     }
     auto cb_output = tt::tt_metal::CreateCircularBuffer(program, all_cores, output_cb_out_config);
     uint32_t dram_alignment = hal::get_dram_alignment();
-    uint32_t num_trids = 2;
+    uint32_t num_trids = 4;
     if ((src_is_dram && (input_unit_size % dram_alignment != 0)) || is_blackhole || keep_l1_aligned) {
         uint32_t scratch_cb_page_size;
         // scratchpad going to be used to align DRAM (64B) to L1 (16B)
 
+        // This is done to mitigate the alignment issues.
+        // See issue #34414.
         scratch_cb_page_size = tt::align(input_unit_size + dram_alignment, dram_alignment);
 
         tt::tt_metal::CircularBufferConfig scratch_cb_out_config =

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/device/interleaved_to_sharded_partial_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/device/interleaved_to_sharded_partial_program_factory.cpp
@@ -121,16 +121,16 @@ InterleavedToShardedPartialProgramFactory::cached_program_t InterleavedToSharded
     }
     auto cb_output = tt::tt_metal::CreateCircularBuffer(program, all_cores, output_cb_out_config);
     uint32_t dram_alignment = hal::get_dram_alignment();
+    uint32_t num_trids = 4;
     if ((src_is_dram && (input_unit_size % dram_alignment != 0)) || is_blackhole || keep_l1_aligned) {
         uint32_t scratch_cb_page_size;
         // scratchpad going to be used to align DRAM (64B) to L1 (16B)
-        if (is_blackhole) {
-            scratch_cb_page_size = tt::align(input_unit_size, hal::get_l1_alignment());
-        } else {
-            scratch_cb_page_size = tt::align(input_unit_size, dram_alignment);
-        }
+
+        scratch_cb_page_size = tt::align(input_unit_size, dram_alignment);
+
         tt::tt_metal::CircularBufferConfig scratch_cb_out_config =
-            tt::tt_metal::CircularBufferConfig(4 * scratch_cb_page_size, {{scratch_cb_index, input_cb_data_format}})
+            tt::tt_metal::CircularBufferConfig(
+                num_trids * scratch_cb_page_size, {{scratch_cb_index, input_cb_data_format}})
                 .set_page_size(scratch_cb_index, scratch_cb_page_size);
         tt::tt_metal::CreateCircularBuffer(program, all_cores, scratch_cb_out_config);
     }
@@ -147,7 +147,8 @@ InterleavedToShardedPartialProgramFactory::cached_program_t InterleavedToSharded
             all_cores,
             tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
     } else {
-        std::vector<uint32_t> reader_compile_time_args = {input_cb_index, scratch_cb_index, num_units_per_row};
+        std::vector<uint32_t> reader_compile_time_args = {
+            input_cb_index, scratch_cb_index, num_units_per_row, num_trids};
         tt::tt_metal::TensorAccessorArgs(*src_buffer).append_to(reader_compile_time_args);
 
         unary_reader_kernel_id = tt::tt_metal::CreateKernel(

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/device/interleaved_to_sharded_partial_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/device/interleaved_to_sharded_partial_program_factory.cpp
@@ -121,12 +121,12 @@ InterleavedToShardedPartialProgramFactory::cached_program_t InterleavedToSharded
     }
     auto cb_output = tt::tt_metal::CreateCircularBuffer(program, all_cores, output_cb_out_config);
     uint32_t dram_alignment = hal::get_dram_alignment();
-    uint32_t num_trids = 4;
+    uint32_t num_trids = 2;
     if ((src_is_dram && (input_unit_size % dram_alignment != 0)) || is_blackhole || keep_l1_aligned) {
         uint32_t scratch_cb_page_size;
         // scratchpad going to be used to align DRAM (64B) to L1 (16B)
 
-        scratch_cb_page_size = tt::align(input_unit_size, dram_alignment);
+        scratch_cb_page_size = tt::align(input_unit_size + dram_alignment, dram_alignment);
 
         tt::tt_metal::CircularBufferConfig scratch_cb_out_config =
             tt::tt_metal::CircularBufferConfig(

--- a/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/kernels/dataflow/padded_slice_reader_rm_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/kernels/dataflow/padded_slice_reader_rm_interleaved_start_id.cpp
@@ -60,7 +60,6 @@ void kernel_main() {
 #endif
     if constexpr (is_non_aligned) {
         enum SlotState : uint8_t { IDLE = 0, SRC_PENDING = 1, SCRATCH_READY = 2, SCRATCH_PENDING = 3 };
-        constexpr uint32_t num_trids = 2;
         constexpr uint32_t trid_base = 1;
 
         uint32_t scratch_write_addrs[num_trids];

--- a/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/kernels/dataflow/padded_slice_reader_rm_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/kernels/dataflow/padded_slice_reader_rm_interleaved_start_id.cpp
@@ -26,7 +26,8 @@ void kernel_main() {
     constexpr uint32_t is_non_aligned = get_compile_time_arg_val(0);
     constexpr uint32_t cb_id_non_aligned = get_compile_time_arg_val(1);
     constexpr uint32_t src_buffer_alignment = get_compile_time_arg_val(2);
-    constexpr auto src_args = TensorAccessorArgs<3>();
+    constexpr uint32_t num_trids = get_compile_time_arg_val(3);
+    constexpr auto src_args = TensorAccessorArgs<4>();
 
     uint32_t read_size = unpadded_stick_size;
 
@@ -57,42 +58,110 @@ void kernel_main() {
            << num_padded_sticks[2] << " " << num_padded_sticks[3] << " " << ENDL();
     DPRINT << "Out CB Page size: " << get_local_cb_interface(cb_id_in0).fifo_page_size << ENDL();
 #endif
-    const uint32_t base_src_buffer_l1_addr = get_write_ptr(cb_id_in0);
-    const uint64_t base_noc_addr = get_noc_addr(0, s0);
-    uint32_t non_aligned_temp_addr = 0;
     if constexpr (is_non_aligned) {
-        cb_reserve_back(cb_id_non_aligned, 1);
-        non_aligned_temp_addr = get_write_ptr(cb_id_non_aligned);
-    }
-    for (uint32_t iter = 0; iter < num_sticks_per_core_read and sticks_read < num_sticks_per_core; ++iter) {
-        cb_reserve_back(cb_id_in0, num_read_per_barrier);
-        uint32_t src_buffer_l1_addr = get_write_ptr(cb_id_in0);
+        enum SlotState : uint8_t { IDLE = 0, SRC_PENDING = 1, SCRATCH_READY = 2, SCRATCH_PENDING = 3 };
+        constexpr uint32_t num_trids = 2;
+        constexpr uint32_t trid_base = 1;
 
-        for (uint32_t i = 0; i < num_read_per_barrier and sticks_read < num_sticks_per_core; ++i) {
-            sticks_read++;
-            uint64_t src_noc_addr = get_noc_addr(src_stick_id, s0);
-            if constexpr (is_non_aligned) {
-                noc_async_read(src_noc_addr, non_aligned_temp_addr, padded_stick_size + misalignment);
-                noc_async_read_barrier();
-                noc_async_read(
-                    get_noc_addr(non_aligned_temp_addr + misalignment), src_buffer_l1_addr, unpadded_stick_size);
-                noc_async_read_barrier();
-            } else {
-                noc_async_read(src_noc_addr, src_buffer_l1_addr, unpadded_stick_size);
+        uint32_t scratch_write_addrs[num_trids];
+        cb_reserve_back(cb_id_non_aligned, num_trids);
+        uint32_t scratch_write_addr_base = get_write_ptr(cb_id_non_aligned);
+        uint32_t scratch_cb_page_size = get_local_cb_interface(cb_id_non_aligned).fifo_page_size;
+        for (uint32_t i = 0; i < num_trids; i++) {
+            scratch_write_addrs[i] = scratch_write_addr_base + i * scratch_cb_page_size;
+        }
+
+        for (uint32_t iter = 0; iter < num_sticks_per_core_read and sticks_read < num_sticks_per_core; ++iter) {
+            cb_reserve_back(cb_id_in0, num_read_per_barrier);
+            uint32_t src_buffer_l1_addr_base = get_write_ptr(cb_id_in0);
+
+            SlotState slot_states[num_trids];
+            uint32_t dest_write_addrs[num_trids];
+
+            // Initialize slots
+            for (uint32_t i = 0; i < num_trids; i++) {
+                slot_states[i] = SlotState::IDLE;
             }
-            src_buffer_l1_addr += stick_size_offset;
-            src_stick_id++;
-            for (uint32_t j = 0; j < num_dims; j++) {
-                id_per_dim[j]++;
-                if (id_per_dim[j] == num_unpadded_sticks[j]) {
-                    id_per_dim[j] = 0;
-                    src_stick_id += num_padded_sticks[j];
-                } else {
-                    break;
+
+            uint32_t sticks_issued = 0;
+            uint32_t sticks_completed = 0;
+            uint32_t current_src_buffer_l1_addr = src_buffer_l1_addr_base;
+
+            while (sticks_completed < num_read_per_barrier and sticks_read < num_sticks_per_core) {
+                for (uint32_t slot = 0; slot < num_trids; slot++) {
+                    uint32_t active_trid = trid_base + slot;
+
+                    if (slot_states[slot] == SlotState::IDLE && sticks_issued < num_read_per_barrier &&
+                        sticks_read < num_sticks_per_core) {
+                        // Start new src->scratch transfer
+
+                        noc_async_read_set_trid(active_trid);
+                        uint64_t src_noc_addr = get_noc_addr(src_stick_id, s0);
+                        dest_write_addrs[slot] = current_src_buffer_l1_addr;
+                        noc_async_read(src_noc_addr, scratch_write_addrs[slot], padded_stick_size + misalignment);
+                        slot_states[slot] = SlotState::SRC_PENDING;
+
+                        current_src_buffer_l1_addr += stick_size_offset;
+                        src_stick_id++;
+                        for (uint32_t j = 0; j < num_dims; j++) {
+                            id_per_dim[j]++;
+                            if (id_per_dim[j] == num_unpadded_sticks[j]) {
+                                id_per_dim[j] = 0;
+                                src_stick_id += num_padded_sticks[j];
+                            } else {
+                                break;
+                            }
+                        }
+                        sticks_issued++;
+
+                    } else if (slot_states[slot] == SlotState::SRC_PENDING) {
+                        // Check if src->scratch transfer is complete
+                        if (ncrisc_noc_read_with_transaction_id_flushed(noc_index, active_trid) == 1) {
+                            slot_states[slot] = SlotState::SCRATCH_READY;
+                        }
+
+                    } else if (slot_states[slot] == SlotState::SCRATCH_READY) {
+                        // Start scratch->dest transfer
+                        noc_async_read_set_trid(active_trid);
+                        uint64_t scratch_noc_read_addr = get_noc_addr(scratch_write_addrs[slot] + misalignment);
+                        noc_async_read(scratch_noc_read_addr, dest_write_addrs[slot], unpadded_stick_size);
+                        slot_states[slot] = SlotState::SCRATCH_PENDING;
+
+                    } else if (slot_states[slot] == SlotState::SCRATCH_PENDING) {
+                        // Check if scratch->dest transfer is complete
+                        if (ncrisc_noc_read_with_transaction_id_flushed(noc_index, active_trid) == 1) {
+                            slot_states[slot] = SlotState::IDLE;
+                            sticks_read++;
+                            sticks_completed++;
+                        }
+                    }
                 }
             }
+            cb_push_back(cb_id_in0, num_read_per_barrier);
         }
-        noc_async_read_barrier();
-        cb_push_back(cb_id_in0, num_read_per_barrier);
+    } else {
+        for (uint32_t iter = 0; iter < num_sticks_per_core_read and sticks_read < num_sticks_per_core; ++iter) {
+            cb_reserve_back(cb_id_in0, num_read_per_barrier);
+            uint32_t src_buffer_l1_addr = get_write_ptr(cb_id_in0);
+
+            for (uint32_t i = 0; i < num_read_per_barrier and sticks_read < num_sticks_per_core; ++i) {
+                sticks_read++;
+                uint64_t src_noc_addr = get_noc_addr(src_stick_id, s0);
+                noc_async_read(src_noc_addr, src_buffer_l1_addr, unpadded_stick_size);
+                src_buffer_l1_addr += stick_size_offset;
+                src_stick_id++;
+                for (uint32_t j = 0; j < num_dims; j++) {
+                    id_per_dim[j]++;
+                    if (id_per_dim[j] == num_unpadded_sticks[j]) {
+                        id_per_dim[j] = 0;
+                        src_stick_id += num_padded_sticks[j];
+                    } else {
+                        break;
+                    }
+                }
+            }
+            noc_async_read_barrier();
+            cb_push_back(cb_id_in0, num_read_per_barrier);
+        }
     }
 }


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/orgs/tenstorrent/projects/135/views/10?pane=issue&itemId=130117008&issue=tenstorrent%7Ctt-metal%7C29046)

### Problem description
A lot of kernels are currently not utilizing transaction IDs, while they can provide substantial improvements. This PR focuses on the ones that have unaligned cases where we are doing `read->barrier->read->barrier`. 

### What's changed
This PR changes 2 kernels:
1.  `reader_unary_stick_layout_sharded_blocks_interleaved_start_id.cpp`
2. `padded_slice_reader_rm_interleaved_start_id.cpp`

In some cases from the test suite, we are seeing more than 2x performance gain on the unaligned cases.

The 2 changed kernels are randomly chosen from the group of ones with the same pattern. 
More kernels in the repository can benefit from the same optimization.

**An important thing to note is that using transaction IDs in these types of kernels adds a lot of complexity to the code, as we are required to use a state machine to achieve the best results.** 

For the interleaved to sharded unaligned cases, we are observing up to 50% decrease in the `device kernel duration`. The values are averaged across 5 runs. These tests are from `tests/ttnn/unit_tests/operations/data_movement/test_interleaved_to_sharded.py`
| Test config | Main | Current branch |
|--------|--------|--------|
| L1, RM [1,1,64,416]->[1,1,64,512] Width sharded | 23936ns | 14372ns |
| DRAM, RM [1,1,64,416]->[1,1,64,512] Width sharded | 30437ns | 16329ns |
| L1, RM [1,1,416,64]->[1,1,416,64] Height sharded| 45621ns | 28076ns |
| DRAM, RM [1,1,416,64]->[1,1,416,64] Height sharded | 58788ns | 32206ns |
...

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) [Run](https://github.com/tenstorrent/tt-metal/actions/runs/21508964309)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes [Run](https://github.com/tenstorrent/tt-metal/actions/runs/21486366816)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) [Run](https://github.com/tenstorrent/tt-metal/actions/runs/21486701386)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) [Run](https://github.com/tenstorrent/tt-metal/actions/runs/21479952549)
- [x] [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) [Run](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml)
- [x] [L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) [Run](https://github.com/tenstorrent/tt-metal/actions/runs/21495455302)
- [x] [Frequent models](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml) [Run](https://github.com/tenstorrent/tt-metal/actions/runs/21486852118)