### PR TITLE
Removed stable_diffusion temporarily from blackhole APC

### DIFF
--- a/tests/scripts/run_python_model_tests.sh
+++ b/tests/scripts/run_python_model_tests.sh
@@ -81,7 +81,8 @@ run_python_model_tests_slow_runtime_mode_wormhole_b0() {
 }
 
 run_python_model_tests_blackhole() {
-    pytest models/demos/blackhole/stable_diffusion/tests --ignore=models/demos/blackhole/stable_diffusion/tests/test_perf.py
+    # Removing until https://github.com/tenstorrent/tt-metal/issues/33906 is fixed
+    # pytest models/demos/blackhole/stable_diffusion/tests --ignore=models/demos/blackhole/stable_diffusion/tests/test_perf.py
 
     # Llama3.1-8B
     llama8b=meta-llama/Llama-3.1-8B-Instruct


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/33906

### Problem description
Stable diffusion can't fetch weights on Blackhole APC CI


### What's changed
- temporarily removed the test from Blackhole APC

### Checklist
- [X] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI [models tests pass](https://github.com/tenstorrent/tt-metal/actions/runs/19968700200)