### PR TITLE
Add transaction IDs to copy OP

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/copy/device/kernels/reader_unary_stick_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/copy/device/kernels/reader_unary_stick_start_id.cpp
@@ -31,22 +31,56 @@ void kernel_main() {
         experimental::shard_addr_gen_utils::get_shard_map<tensor_shard_info>(get_arg_addr(5));
     experimental::ShardedAddrGen<tensor_shard_info> s0 = {.bank_base_address = src_addr, .shard_array = mapping_table};
 
+    // Transaction ID pattern constants
+    constexpr uint32_t trid_base = 1;
+    constexpr uint32_t num_of_trids = 2;
+    auto cb_interface = get_local_cb_interface(cb_id_in0);
+    uint32_t aligned_page_size = get_local_cb_interface(cb_id_in0).fifo_page_size;
+    uint32_t num_of_transactions = num_sticks * num_shards;
+
+    // Calculate stick indices based on direction
+    auto get_stick_index = [&](uint32_t transaction_idx) -> uint32_t {
 #ifdef BACKWARDS
-    uint32_t end_id = start_id - num_sticks;
-    for (uint32_t i = start_id; i != end_id; --i) {
-        for (uint32_t k = num_shards - 1; k >= 0; k--) {
+        uint32_t i = start_id - (transaction_idx / num_shards);
+        uint32_t k = num_shards - 1 - (transaction_idx % num_shards);
 #else
-    uint32_t end_id = start_id + num_sticks;
-    for (uint32_t i = start_id; i < end_id; ++i) {
-        for (uint32_t k = 0; k < num_shards; k++) {
+        uint32_t i = start_id + (transaction_idx / num_shards);
+        uint32_t k = transaction_idx % num_shards;
 #endif
-            uint32_t stick_index = i * num_shards + k;
-            cb_reserve_back(cb_id_in0, 1);
-            uint32_t l1_write_addr = get_write_ptr(cb_id_in0);
+        return i * num_shards + k;
+    };
+
+    cb_reserve_back(cb_id_in0, num_of_trids);
+    uint32_t base_addr = get_write_ptr(cb_id_in0);
+    uint32_t write_addrs[num_of_trids];
+
+    // Initial pipeline fill
+    for (uint32_t trid = 0; trid < num_of_trids; trid++) {
+        write_addrs[trid] = base_addr + trid * aligned_page_size;
+
+        noc_async_read_set_trid(trid_base + trid);
+        uint32_t stick_index = get_stick_index(trid);
+        uint64_t src_noc_addr = get_noc_addr(stick_index, s0);
+        noc_async_read(src_noc_addr, write_addrs[trid], stick_size);
+    }
+
+    // Pipelined execution
+    uint32_t trid_to_wait = 0;
+    uint32_t trid_to_issue = 0;
+    for (uint32_t i = 0; i < num_of_transactions; i++) {
+        noc_async_read_barrier_with_trid(trid_base + trid_to_wait);
+        cb_push_back(cb_id_in0, 1);
+
+        trid_to_wait = (trid_to_wait + 1) % num_of_trids;
+
+        if (i < num_of_transactions - num_of_trids) {
+            noc_async_read_set_trid(trid_base + trid_to_issue);
+            uint32_t stick_index = get_stick_index(i + num_of_trids);
             uint64_t src_noc_addr = get_noc_addr(stick_index, s0);
-            noc_async_read(src_noc_addr, l1_write_addr, stick_size);
-            noc_async_read_barrier();
-            cb_push_back(cb_id_in0, 1);
+
+            cb_reserve_back(cb_id_in0, num_of_trids);
+            noc_async_read(src_noc_addr, write_addrs[trid_to_issue], stick_size);
+            trid_to_issue = (trid_to_issue + 1) % num_of_trids;
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/copy/device/kernels/writer_unary_stick_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/copy/device/kernels/writer_unary_stick_start_id.cpp
@@ -45,7 +45,7 @@ void kernel_main() {
             uint32_t l1_read_addr = get_read_ptr(cb_id_out0);
             uint64_t dst_noc_addr = get_noc_addr(stick_index, s0);
             noc_async_write(l1_read_addr, dst_noc_addr, stick_size);
-            noc_async_write_barrier();
+            noc_async_writes_flushed();
             cb_pop_front(cb_id_out0, 1);
         }
     }

--- a/ttnn/cpp/ttnn/operations/data_movement/copy/device/kernels/writer_unary_stick_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/copy/device/kernels/writer_unary_stick_start_id.cpp
@@ -49,4 +49,5 @@ void kernel_main() {
             cb_pop_front(cb_id_out0, 1);
         }
     }
+    noc_async_write_barrier();
 }


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/orgs/tenstorrent/projects/135/views/10?pane=issue&itemId=130117008&issue=tenstorrent%7Ctt-metal%7C29046)

### Problem description
A lot of kernels are currently not utilizing transaction IDs, while they can provide substantial improvements. This PR focuses on the most common data movement kernel pattern: 
```cpp
for{  
    cb_reserve_back() / cb_wait_front();
    noc_api_call();
    noc_barrier();
    cb_push_back() / cb_pop_front();
}
```

### What's changed
This PR changes 2 kernels from the copy operation:
1.  `reader_unary_stick_start_id.cpp`
2. `writer_unary_stick_start_id.cpp`

This op/kernels are randomly chosen from the group of ones with the same pattern. 
A lot more kernels in the repository can benefit from the same optimization.

**An important thing to note is that using transaction IDs in these types of kernels adds a lot of complexity to the code.**
This specific example is extra complicated because of the way we are iterating through source/destination addresses. 

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/19930194961) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/runs/19960108383) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes