### PR TITLE
[skip ci] Make Auto-Triage Automatically Run on Regressions

### DIFF
--- a/.github/actions/analyze-workflow-data/lib/reporting.js
+++ b/.github/actions/analyze-workflow-data/lib/reporting.js
@@ -599,19 +599,6 @@ function computeStatusChanges(filteredGrouped, filteredPreviousGrouped, context)
     }
   }
 
-  // MOCK INJECTION
-  const mockName = 'galaxy-quick';
-  if (!regressedDetails.some(r => r.name === mockName)) {
-    regressedDetails.push({
-      name: mockName,
-      workflow_path: '.github/workflows/galaxy-quick.yaml',
-      run_id: 123456,
-      run_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions`,
-      created_at: new Date().toISOString(),
-      failing_jobs: ['quick-bh-glx-health'] // Pre-populated for trigger logic
-    });
-  }
-
   return { changes, regressedDetails, stayedFailingDetails };
 }
 

--- a/.github/actions/analyze-workflow-data/lib/reporting.js
+++ b/.github/actions/analyze-workflow-data/lib/reporting.js
@@ -553,11 +553,6 @@ function computeStatusChanges(filteredGrouped, filteredPreviousGrouped, context)
       const commitUrl = info?.head_sha ? `https://github.com/${context.repo.owner}/${context.repo.repo}/commit/${info.head_sha}` : undefined;
       const commitShort = info?.head_sha ? info.head_sha.substring(0, SHA_SHORT_LENGTH) : undefined;
 
-      // MOCK REGRESSION FOR TESTING
-      if (name === 'galaxy-quick') {
-         change = 'success_to_fail';
-      }
-
       changes.push({
         name,
         previous,
@@ -602,6 +597,19 @@ function computeStatusChanges(filteredGrouped, filteredPreviousGrouped, context)
         });
       }
     }
+  }
+
+  // MOCK INJECTION
+  const mockName = 'galaxy-quick';
+  if (!regressedDetails.some(r => r.name === mockName)) {
+    regressedDetails.push({
+      name: mockName,
+      workflow_path: '.github/workflows/galaxy-quick.yaml',
+      run_id: 123456,
+      run_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions`,
+      created_at: new Date().toISOString(),
+      failing_jobs: ['quick-bh-glx-health'] // Pre-populated for trigger logic
+    });
   }
 
   return { changes, regressedDetails, stayedFailingDetails };
@@ -694,11 +702,6 @@ async function enrichRegressions(regressedDetails, filteredGrouped, errorSnippet
           })();
           item.failing_jobs = failingJobNames;
         } catch (_) { /* ignore */ }
-
-        // MOCK REGRESSION FOR TESTING
-        if (item.name === 'galaxy-quick') {
-           item.failing_jobs = ['quick-bh-glx-health'];
-        }
 
         item.repeated_errors = [];
         const changeRef = changes.find(c => c.name === item.name && c.change === 'success_to_fail');

--- a/.github/actions/analyze-workflow-data/lib/reporting.js
+++ b/.github/actions/analyze-workflow-data/lib/reporting.js
@@ -552,6 +552,12 @@ function computeStatusChanges(filteredGrouped, filteredPreviousGrouped, context)
       const aggregateRunUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
       const commitUrl = info?.head_sha ? `https://github.com/${context.repo.owner}/${context.repo.repo}/commit/${info.head_sha}` : undefined;
       const commitShort = info?.head_sha ? info.head_sha.substring(0, SHA_SHORT_LENGTH) : undefined;
+
+      // MOCK REGRESSION FOR TESTING
+      if (name === 'galaxy-quick') {
+         change = 'success_to_fail';
+      }
+
       changes.push({
         name,
         previous,
@@ -688,6 +694,12 @@ async function enrichRegressions(regressedDetails, filteredGrouped, errorSnippet
           })();
           item.failing_jobs = failingJobNames;
         } catch (_) { /* ignore */ }
+
+        // MOCK REGRESSION FOR TESTING
+        if (item.name === 'galaxy-quick') {
+           item.failing_jobs = ['quick-bh-glx-health'];
+        }
+
         item.repeated_errors = [];
         const changeRef = changes.find(c => c.name === item.name && c.change === 'success_to_fail');
         if (changeRef) {

--- a/.github/actions/trigger-auto-triage-for-regressions/action.yml
+++ b/.github/actions/trigger-auto-triage-for-regressions/action.yml
@@ -1,0 +1,13 @@
+name: 'Trigger Auto-Triage for Regressions'
+description: 'Triggers auto-triage workflow for each regressed job'
+inputs:
+  regressed_workflows:
+    description: 'JSON array of regressed workflows with failing jobs'
+    required: true
+  github_token:
+    description: 'GitHub token for triggering workflows'
+    required: true
+
+runs:
+  using: 'node20'
+  main: 'index.js'

--- a/.github/actions/trigger-auto-triage-for-regressions/index.js
+++ b/.github/actions/trigger-auto-triage-for-regressions/index.js
@@ -1,0 +1,63 @@
+const core = require('@actions/core');
+const github = require('@actions/github');
+
+async function run() {
+  try {
+    const regressedWorkflowsJson = core.getInput('regressed_workflows', { required: true });
+    const githubToken = core.getInput('github_token', { required: true });
+
+    const regressedWorkflows = JSON.parse(regressedWorkflowsJson);
+    const octokit = github.getOctokit(githubToken);
+
+    core.info(`Found ${regressedWorkflows.length} regressed workflow(s)`);
+
+    for (const workflow of regressedWorkflows) {
+      const workflowPath = workflow.workflow_path || workflow.name;
+
+      // Extract workflow file name (remove .github/workflows/ prefix and .yaml extension)
+      const workflowFileName = workflowPath
+        .replace(/^\.github\/workflows\//, '')
+        .replace(/\.ya?ml$/i, '');
+
+      const failingJobs = workflow.failing_jobs || [];
+
+      core.info(`Processing workflow: ${workflowFileName} with ${failingJobs.length} failing job(s)`);
+
+      if (failingJobs.length === 0) {
+        core.warning(`No failing jobs found for workflow: ${workflowFileName}`);
+        continue;
+      }
+
+      for (const jobName of failingJobs) {
+        core.info(`Triggering auto-triage for workflow: ${workflowFileName}, job: ${jobName}`);
+
+        try {
+          await octokit.rest.actions.createWorkflowDispatch({
+            owner: github.context.repo.owner,
+            repo: github.context.repo.repo,
+            workflow_id: 'auto-triage.yml',
+            ref: 'main',
+            inputs: {
+              workflow_name: workflowFileName,
+              job_name: jobName
+            }
+          });
+
+          core.info(`✓ Successfully triggered auto-triage for ${workflowFileName} / ${jobName}`);
+
+          // Add a small delay to avoid rate limiting
+          await new Promise(resolve => setTimeout(resolve, 1000));
+
+        } catch (error) {
+          core.error(`Failed to trigger auto-triage for ${workflowFileName} / ${jobName}: ${error.message}`);
+          // Continue with other jobs even if one fails
+        }
+      }
+    }
+
+  } catch (error) {
+    core.setFailed(error.message);
+  }
+}
+
+run();

--- a/.github/actions/trigger-auto-triage-for-regressions/package.json
+++ b/.github/actions/trigger-auto-triage-for-regressions/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "trigger-auto-triage-for-regressions",
+  "version": "1.0.0",
+  "description": "Triggers auto-triage for regressed workflows",
+  "main": "index.js",
+  "dependencies": {
+    "@actions/core": "^1.10.0",
+    "@actions/github": "^5.1.1"
+  }
+}

--- a/.github/workflows/aggregate-workflow-data.yaml
+++ b/.github/workflows/aggregate-workflow-data.yaml
@@ -256,7 +256,7 @@ jobs:
       - name: Post regressions to Slack
         uses: ./.github/actions/slack-report-analyze-workflow-data
         with:
-          slack_webhook_url: ${{ secrets.SLACK_TESTING_CHANNEL }}
+          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_AGGREGATE_PIPELINE_STATUS_ALERT }}
           regressed_workflows: ${{ needs.analyze-data.outputs.regressed_workflows }}
           alert_all_message: ${{ needs.analyze-data.outputs.alert_all_message }}
 

--- a/.github/workflows/aggregate-workflow-data.yaml
+++ b/.github/workflows/aggregate-workflow-data.yaml
@@ -256,7 +256,7 @@ jobs:
       - name: Post regressions to Slack
         uses: ./.github/actions/slack-report-analyze-workflow-data
         with:
-          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_AGGREGATE_PIPELINE_STATUS_ALERT }}
+          slack_webhook_url: ${{ secrets.SLACK_TESTING_CHANNEL }}
           regressed_workflows: ${{ needs.analyze-data.outputs.regressed_workflows }}
           alert_all_message: ${{ needs.analyze-data.outputs.alert_all_message }}
 

--- a/.github/workflows/aggregate-workflow-data.yaml
+++ b/.github/workflows/aggregate-workflow-data.yaml
@@ -259,3 +259,21 @@ jobs:
           slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_AGGREGATE_PIPELINE_STATUS_ALERT }}
           regressed_workflows: ${{ needs.analyze-data.outputs.regressed_workflows }}
           alert_all_message: ${{ needs.analyze-data.outputs.alert_all_message }}
+
+  trigger-auto-triage:
+    needs: analyze-data
+    if: ${{ fromJson(needs.analyze-data.outputs.regressed_workflows) != '[]' }}
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
+    steps:
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 #@v3
+      - name: Install dependencies
+        working-directory: .github/actions/trigger-auto-triage-for-regressions
+        run: npm install
+      - name: Trigger auto-triage for regressed jobs
+        uses: ./.github/actions/trigger-auto-triage-for-regressions
+        with:
+          regressed_workflows: ${{ needs.analyze-data.outputs.regressed_workflows }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/33900

### Problem description
We want failures in CI to be automatically triaged without requiring developers from metal-infra to manually run the auto triage tool.

### What's changed
Now whenever a regression is detected by Aggregate-Workflow-Data, Auto-Triage will run on the failing workflow. For now the output is just sent to a testing channel but once we're more confident in the output, we'll have Auto-Triage send message to either the pipelines channel or the metal infra status channel

### Checklist
- [x] [Aggregate Workflow Data](https://github.com/tenstorrent/tt-metal/actions/workflows/aggregate-workflow-data.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/19968390939
- [x] [Auto Triage](https://github.com/tenstorrent/tt-metal/actions/workflows/auto-triage.yml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/19969330602