### PR TITLE
[skip ci] Speedup tt-metalium-validation-smoke tests

### DIFF
--- a/tests/tt_metal/tt_metal/api/distribution_spec/test_buffer_distribution_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/distribution_spec/test_buffer_distribution_spec.cpp
@@ -38,7 +38,7 @@ protected:
             tt::tt_metal::distributed::MeshDeviceConfig(system_mesh_shape, std::nullopt),
             DEFAULT_L1_SMALL_SIZE,
             DEFAULT_TRACE_REGION_SIZE,
-            /*num_cqs=*/1,
+            /*num_command_queues=*/1,
             core_type,
             {},
             DEFAULT_WORKER_L1_SIZE);

--- a/tests/tt_metal/tt_metal/api/distribution_spec/test_buffer_distribution_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/distribution_spec/test_buffer_distribution_spec.cpp
@@ -17,6 +17,51 @@ namespace distribution_spec_tests {
 using tt::tt_metal::BufferDistributionSpec;  // NOLINT(misc-unused-using-decls)
 constexpr uint32_t PADDING = tt::tt_metal::UncompressedBufferPageMapping::PADDING;
 
+// Shared fixture that creates the MeshDevice once per test suite instead of per test case.
+// This significantly speeds up parameterized tests by avoiding repeated device setup/teardown.
+class BufferDistributionSpecFixture : public ::testing::Test {
+public:
+    inline static std::shared_ptr<tt::tt_metal::distributed::MeshDevice> mesh_device_;
+
+protected:
+    static void SetUpTestSuite() {
+        auto* slow_dispatch = getenv("TT_METAL_SLOW_DISPATCH_MODE");
+        if (slow_dispatch) {
+            // Cannot skip in SetUpTestSuite, will be handled in SetUp
+            return;
+        }
+
+        const auto system_mesh_shape = tt::tt_metal::distributed::SystemMesh::instance().shape();
+        auto core_type = tt::tt_metal::DispatchCoreType::WORKER;
+
+        mesh_device_ = tt::tt_metal::distributed::MeshDevice::create(
+            tt::tt_metal::distributed::MeshDeviceConfig(system_mesh_shape, std::nullopt),
+            DEFAULT_L1_SMALL_SIZE,
+            DEFAULT_TRACE_REGION_SIZE,
+            /*num_cqs=*/1,
+            core_type,
+            {},
+            DEFAULT_WORKER_L1_SIZE);
+    }
+
+    static void TearDownTestSuite() {
+        if (mesh_device_) {
+            mesh_device_->close();
+            mesh_device_.reset();
+        }
+    }
+
+    void SetUp() override {
+        auto* slow_dispatch = getenv("TT_METAL_SLOW_DISPATCH_MODE");
+        if (slow_dispatch) {
+            GTEST_SKIP() << "Skipping test suite, since it can only be run in Fast Dispatch Mode.";
+        }
+        if (!mesh_device_) {
+            GTEST_SKIP() << "MeshDevice not initialized.";
+        }
+    }
+};
+
 struct BufferDistributionSpecInputs {
     tt::tt_metal::Shape physical_tensor_shape;
     tt::tt_metal::Shape physical_shard_shape;
@@ -81,7 +126,7 @@ std::shared_ptr<tt::tt_metal::distributed::MeshBuffer> create_replicated_mesh_bu
 using namespace distribution_spec_tests;
 using namespace tt::tt_metal;
 
-class MeshBufferAllocationTests : public GenericMeshDeviceFixture,
+class MeshBufferAllocationTests : public BufferDistributionSpecFixture,
                                   public ::testing::WithParamInterface<BufferAllocationParams> {};
 
 TEST_P(MeshBufferAllocationTests, Allocation) {
@@ -203,7 +248,7 @@ INSTANTIATE_TEST_SUITE_P(
 );
 // clang-format on
 
-class MeshBufferReadWriteTests : public GenericMeshDeviceFixture,
+class MeshBufferReadWriteTests : public BufferDistributionSpecFixture,
                                  public ::testing::WithParamInterface<std::tuple<bool, bool, BufferReadWriteParams>> {};
 
 TEST_P(MeshBufferReadWriteTests, WriteReadLoopback) {


### PR DESCRIPTION
### Ticket
NA

### Problem description
Smoke tests are supposed to be blazing fast, but this group of unit tests each take more than a second each.

### What's changed
Share device across these parameterized tests to avoid setup / tear-down.

#### BufferDistributionSpec Test Performance Results

### Summary

| Metric | Before | After | Improvement |
|--------|--------|-------|-------------|
| **Total Runtime** | ~97.5 s | 22.8 s | **4.3x faster (76% reduction)** |
| **Allocation Tests (4 tests)** | 4,083 ms | 0 ms | ~1,000 ms saved per test |
| **ReadWrite Tests (20 tests)** | 93,453 ms | 15,479 ms | ~3,900 ms saved per test |

### Detailed Comparison

#### MeshBufferAllocationTests

| Test Case | Before (ms) | After (ms) | Saved (ms) |
|-----------|-------------|------------|------------|
| Allocation/0 | 1,026 | 0 | 1,026 |
| Allocation/1 | 1,031 | 0 | 1,031 |
| Allocation/2 | 1,008 | 0 | 1,008 |
| Allocation/3 | 1,018 | 0 | 1,018 |
| **Subtotal** | **4,083** | **0** | **4,083** |

#### MeshBufferReadWriteTests

| Test Case | Before (ms) | After (ms) | Saved (ms) |
|-----------|-------------|------------|------------|
| WriteReadLoopback/0 | 5,012 | 790 | 4,222 |
| WriteReadLoopback/1 | 4,568 | 779 | 3,789 |
| WriteReadLoopback/2 | 4,497 | 779 | 3,718 |
| WriteReadLoopback/3 | 4,613 | 776 | 3,837 |
| WriteReadLoopback/4 | 5,266 | 771 | 4,495 |
| WriteReadLoopback/5 | 4,556 | 778 | 3,778 |
| WriteReadLoopback/6 | 4,533 | 770 | 3,763 |
| WriteReadLoopback/7 | 4,503 | 774 | 3,729 |
| WriteReadLoopback/8 | 4,587 | 769 | 3,818 |
| WriteReadLoopback/9 | 4,664 | 770 | 3,894 |
| WriteReadLoopback/10 | 4,570 | 771 | 3,799 |
| WriteReadLoopback/11 | 4,623 | 773 | 3,850 |
| WriteReadLoopback/12 | 4,587 | 771 | 3,816 |
| WriteReadLoopback/13 | 4,597 | 773 | 3,824 |
| WriteReadLoopback/14 | 4,796 | 778 | 4,018 |
| WriteReadLoopback/15 | 4,641 | 774 | 3,867 |
| WriteReadLoopback/16 | 4,763 | 771 | 3,992 |
| WriteReadLoopback/17 | 4,652 | 771 | 3,881 |
| WriteReadLoopback/18 | 4,685 | 767 | 3,918 |
| WriteReadLoopback/19 | 4,740 | 766 | 3,974 |
| **Subtotal** | **93,453** | **15,479** | **77,974** |

### Optimization Applied

**Technique**: Suite-level device fixture using `SetUpTestSuite()` / `TearDownTestSuite()`

- Created `BufferDistributionSpecFixture` with `inline static` mesh device
- Device initialized once before all 24 tests run
- Device closed once after all tests complete
- Eliminates ~1 second device setup overhead per test case

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes