### PR TITLE
[skip ci] Disable warmup in smoke tests

### DIFF
--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -62,6 +62,7 @@ jobs:
           mkdir -p /work/coverage
 
       - name: Warmup caches
+        if: false # No need to warmup currently because slow tests will never fail the job
         timeout-minutes: 2
         env:
           GTEST_COLOR: yes


### PR DESCRIPTION
There is no need to do a warmup pass in smoke tests, because we chose to never fail job for slow tests.

So we won't waste 17 seconds every job.