### PR TITLE
Fix pack untilize for cache update for ct dim > 8 to use regular untilize

### DIFF
--- a/ttnn/cpp/ttnn/operations/kv_cache/device/kernels/compute/update_cache.cpp
+++ b/ttnn/cpp/ttnn/operations/kv_cache/device/kernels/compute/update_cache.cpp
@@ -7,6 +7,7 @@
 #include "compute_kernel_api/common.h"
 #include "compute_kernel_api/pack_untilize.h"
 #include "compute_kernel_api/tilize.h"
+#include "compute_kernel_api/untilize.h"
 
 namespace NAMESPACE {
 void MAIN {
@@ -22,28 +23,48 @@ void MAIN {
     constexpr uint32_t u_count = get_compile_time_arg_val(9);
 
     compute_kernel_hw_startup(in_cb, untilized_in_cb);
-    pack_untilize_init<Wt>(in_cb, untilized_in_cb);
+    if constexpr (Wt > 8) {
+        untilize_init(in_cb);
+    } else {
+        pack_untilize_init<Wt>(in_cb, untilized_in_cb);
+    }
 
     for (uint32_t h = 0; h < num_batched_heads; ++h) {
         cb_wait_front(in_cb, Wt);
         cb_reserve_back(untilized_in_cb, Wt);
-        pack_untilize_block<Wt>(in_cb, 1, untilized_in_cb);
+        if constexpr (Wt > 8) {
+            untilize_block(in_cb, Wt, untilized_in_cb);
+        } else {
+            pack_untilize_block<Wt>(in_cb, 1, untilized_in_cb);
+        }
         cb_push_back(untilized_in_cb, Wt);
         cb_pop_front(in_cb, Wt);
 
         reconfig_data_format_srca(in_cb, cache_cb);
         for (uint32_t u = 0; u < u_count; ++u) {
-            pack_untilize_init<Wt>(cache_cb, untilized_cache_cb);
+            if constexpr (Wt > 8) {
+                untilize_init(cache_cb);
+            } else {
+                pack_untilize_init<Wt>(cache_cb, untilized_cache_cb);
+            }
 
             for (uint32_t g = 0; g < granularity; ++g) {
                 // Untilize a block from the cache
                 cb_wait_front(cache_cb, Wt);
                 cb_reserve_back(untilized_cache_cb, Wt);
-                pack_untilize_block<Wt>(cache_cb, 1, untilized_cache_cb);
+                if constexpr (Wt > 8) {
+                    untilize_block(cache_cb, 1, untilized_cache_cb);
+                } else {
+                    pack_untilize_block<Wt>(cache_cb, 1, untilized_cache_cb);
+                }
                 cb_push_back(untilized_cache_cb, Wt);
                 cb_pop_front(cache_cb, Wt);
             }
-            pack_untilize_uninit(untilized_cache_cb);
+            if constexpr (Wt > 8) {
+                untilize_uninit(untilized_cache_cb);
+            } else {
+                pack_untilize_uninit(untilized_cache_cb);
+            }
 
             reconfig_data_format_srca(cache_cb, untilized_cache2_cb);
             pack_reconfig_data_format(untilized_cache_cb, out_cb);
@@ -63,7 +84,11 @@ void MAIN {
             pack_reconfig_data_format(out_cb, untilized_cache_cb);
         }
         reconfig_data_format_srca(cache_cb, in_cb);
-        pack_untilize_init<Wt>(in_cb, untilized_in_cb);
+        if constexpr (Wt > 8) {
+            untilize_init(in_cb);
+        } else {
+            pack_untilize_init<Wt>(in_cb, untilized_in_cb);
+        }
     }
 }
 }  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/kv_cache/device/kernels/compute/update_cache.cpp
+++ b/ttnn/cpp/ttnn/operations/kv_cache/device/kernels/compute/update_cache.cpp
@@ -35,7 +35,7 @@ void MAIN {
         if constexpr (Wt > 8) {
             untilize_block(in_cb, Wt, untilized_in_cb);
         } else {
-            pack_untilize_block<Wt>(in_cb, 1, untilized_in_cb);
+            pack_untilize_block<Wt>(in_cb, Wt, untilized_in_cb);
         }
         cb_push_back(untilized_in_cb, Wt);
         cb_pop_front(in_cb, Wt);


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/25249

### Problem description
- hitting asserts because ct dim supported on BH is less than 8, if greater than 8 we use default untilize block

### Checklist
- [x] [APC](https://github.com/tenstorrent/tt-metal/actions/runs/19978609687) CI passes 
- [x] [BH APC](https://github.com/tenstorrent/tt-metal/actions/runs/20072279505)
Note:
- This is a quick fix though im not sure if WH enables using ct dim > 8 in pack untilize so it could slightly impact perf on WH if its using that op, though i dont think this op is really used in a lot of the models we care about anymore, but its functional with the changes in this PR
