### PR TITLE
TT-Fabric Intermesh Traffic VC (VC1) Support [3/n]

### DIFF
--- a/tt_metal/fabric/builder/fabric_builder_config.cpp
+++ b/tt_metal/fabric/builder/fabric_builder_config.cpp
@@ -18,6 +18,29 @@ uint32_t get_receiver_channel_count(const bool is_2D_routing) {
     return is_2D_routing ? builder_config::num_receiver_channels_2d : builder_config::num_receiver_channels_1d;
 }
 
+std::array<uint32_t, 2> get_sender_channel_count_per_vc(const bool is_2D_routing) {
+    if (is_2D_routing) {
+        // 2D routing: VC0 has 4 sender channels (0-3), VC1 has 3 sender channels (4-6)
+        // Channel 7 is reserved for future Z-axis routing
+        // Total = 7 channels
+        return {4, 3};
+    } else {
+        // 1D routing: VC0 has 2 sender channels, VC1 has 0
+        return {builder_config::num_sender_channels_1d, 0};
+    }
+}
+
+std::array<uint32_t, 2> get_receiver_channel_count_per_vc(const bool is_2D_routing) {
+    if (is_2D_routing) {
+        // 2D routing: VC0 has 1 receiver, VC1 has 1 receiver
+        // Total = 2 receivers
+        return {1, 1};
+    } else {
+        // 1D routing: VC0 has 1 receiver, VC1 has 0
+        return {builder_config::num_receiver_channels_1d, 0};
+    }
+}
+
 uint32_t get_num_tensix_sender_channels(Topology topology, tt::tt_fabric::FabricTensixConfig fabric_tensix_config) {
     // TODO: once we support inserting tensix as downstream in UDM mode, add back the channel count for UDM mode
     TT_FATAL(

--- a/tt_metal/fabric/builder/fabric_builder_config.hpp
+++ b/tt_metal/fabric/builder/fabric_builder_config.hpp
@@ -39,6 +39,9 @@ struct FabricEriscDatamoverOptions {
 };
 
 namespace builder_config {
+// Number of Virtual Channels supported (VC0 and VC1)
+static constexpr std::size_t MAX_NUM_VCS = 2;
+
 // linear/mesh/ring/torus: for fabric with tensix extension, only one sender channel will be present on fabric router
 static constexpr std::size_t num_sender_channels_with_tensix_config = 1;
 

--- a/tt_metal/fabric/builder/fabric_builder_config.hpp
+++ b/tt_metal/fabric/builder/fabric_builder_config.hpp
@@ -47,10 +47,11 @@ static constexpr std::size_t num_sender_channels_1d_linear = 2;
 static constexpr std::size_t num_sender_channels_2d_mesh = 4;
 
 static constexpr std::size_t num_sender_channels_1d = 2;
-// VC0: Up to Worker + 3 of [N/E/S/W]
-// VC1: Z + Up to 3 of [N/E/S/W]
+// VC0: Worker + 3 of [N/E/S/W] = 4 channels
+// VC1: Up to 3 of [N/E/S/W] for inter-mesh = 3 channels
+// Total 2D: 4 + 3 = 7 channels (channel 7 reserved for future Z-axis)
 static constexpr std::size_t num_sender_channels_2d = 8;
-static constexpr std::size_t num_max_sender_channels = std::max(num_sender_channels_1d, num_sender_channels_2d);
+static constexpr std::size_t num_max_sender_channels = 8;  // Reserve space for future expansion (Z-axis channel)
 static constexpr std::size_t num_receiver_channels_1d = 1;
 static constexpr std::size_t num_receiver_channels_2d = 2;
 static constexpr std::size_t num_max_receiver_channels = std::max(num_receiver_channels_1d, num_receiver_channels_2d);
@@ -65,6 +66,11 @@ static constexpr std::size_t max_downstream_edms = std::max(num_downstream_edms_
 uint32_t get_sender_channel_count(bool is_2D_routing);
 
 uint32_t get_receiver_channel_count(bool is_2D_routing);
+
+// Per-VC channel counts (index 0 = VC0, index 1 = VC1)
+std::array<uint32_t, 2> get_sender_channel_count_per_vc(bool is_2D_routing);
+
+std::array<uint32_t, 2> get_receiver_channel_count_per_vc(bool is_2D_routing);
 
 uint32_t get_num_tensix_sender_channels(Topology topology, tt::tt_fabric::FabricTensixConfig fabric_tensix_config);
 

--- a/tt_metal/fabric/builder/fabric_remote_channels_allocator.cpp
+++ b/tt_metal/fabric/builder/fabric_remote_channels_allocator.cpp
@@ -15,9 +15,15 @@ FabricRemoteChannelsAllocator::FabricRemoteChannelsAllocator(
     FabricChannelAllocator(static_allocator.topology_, static_allocator.options_, static_allocator.memory_regions_),
     num_used_receiver_channels_(builder_config::num_max_receiver_channels) {
     // Extract remote receiver channel information from the static allocator
+    // For now, only VC0 is used (all channels in VC0, none in VC1)
+    // TODO: Review this code.
+    // UC: FIXME.
+    constexpr size_t vc_id = 0;
     for (size_t i = 0; i < builder_config::num_max_receiver_channels; i++) {
-        this->remote_receiver_channels_base_address_[i] = static_allocator.remote_receiver_channels_base_address[i];
-        this->remote_receiver_channels_num_buffers_[i] = static_allocator.remote_receiver_channels_num_buffers[i];
+        this->remote_receiver_channels_base_address_[i] =
+            static_allocator.remote_receiver_channels_base_address[vc_id][i];
+        this->remote_receiver_channels_num_buffers_[i] =
+            static_allocator.remote_receiver_channels_num_buffers[vc_id][i];
     }
 }
 

--- a/tt_metal/fabric/builder/fabric_remote_channels_allocator.cpp
+++ b/tt_metal/fabric/builder/fabric_remote_channels_allocator.cpp
@@ -12,18 +12,16 @@ namespace tt::tt_fabric {
 
 FabricRemoteChannelsAllocator::FabricRemoteChannelsAllocator(
     const FabricStaticSizedChannelsAllocator& static_allocator) :
-    FabricChannelAllocator(static_allocator.topology_, static_allocator.options_, static_allocator.memory_regions_),
-    num_used_receiver_channels_(builder_config::num_max_receiver_channels) {
-    // Extract remote receiver channel information from the static allocator
-    // For now, only VC0 is used (all channels in VC0, none in VC1)
-    // TODO: Review this code.
-    // UC: FIXME.
-    constexpr size_t vc_id = 0;
-    for (size_t i = 0; i < builder_config::num_max_receiver_channels; i++) {
-        this->remote_receiver_channels_base_address_[i] =
-            static_allocator.remote_receiver_channels_base_address[vc_id][i];
-        this->remote_receiver_channels_num_buffers_[i] =
-            static_allocator.remote_receiver_channels_num_buffers[vc_id][i];
+    FabricChannelAllocator(static_allocator.topology_, static_allocator.options_, static_allocator.memory_regions_) {
+    // Extract remote receiver channel information from the static allocator for all VCs
+    for (size_t vc = 0; vc < builder_config::MAX_NUM_VCS; ++vc) {
+        this->num_used_receiver_channels_per_vc_[vc] = static_allocator.num_used_receiver_channels_per_vc[vc];
+        for (size_t i = 0; i < static_allocator.num_used_receiver_channels_per_vc[vc]; i++) {
+            this->remote_receiver_channels_base_address_[vc][i] =
+                static_allocator.remote_receiver_channels_base_address[vc][i];
+            this->remote_receiver_channels_num_buffers_[vc][i] =
+                static_allocator.remote_receiver_channels_num_buffers[vc][i];
+        }
     }
 }
 
@@ -31,33 +29,53 @@ void FabricRemoteChannelsAllocator::emit_ct_args(std::vector<uint32_t>& ct_args)
     // This is now called by MultiPoolChannelAllocator, which handles num_pools and pool_type emission.
     // We only emit the pool data itself.
 
-    // Emit pool data in StaticChannelPool format
-    // Format: for each receiver channel: (base_address, num_buffers, remote_address, remote_num_buffers)
-    // Note: remote_address and remote_num_buffers are unused but required for StaticChannelPool  ct arg format
-    for (size_t i = 0; i < this->num_used_receiver_channels_; ++i) {
-        ct_args.push_back(static_cast<uint32_t>(this->remote_receiver_channels_base_address_[i]));
-        ct_args.push_back(static_cast<uint32_t>(this->remote_receiver_channels_num_buffers_[i]));
-        ct_args.push_back(0);  // remote_address (unused for remote pools)
-        ct_args.push_back(0);  // remote_num_buffers (unused for remote pools)
+    // Emit pool data in StaticChannelPool format for all VCs sequentially (VC0 first, then VC1)
+    // Format: for each receiver channel per VC: (base_address, num_buffers, remote_address, remote_num_buffers)
+    // Note: remote_address and remote_num_buffers are unused but required for StaticChannelPool ct arg format
+    for (size_t vc = 0; vc < builder_config::MAX_NUM_VCS; ++vc) {
+        for (size_t i = 0; i < this->num_used_receiver_channels_per_vc_[vc]; ++i) {
+            ct_args.push_back(static_cast<uint32_t>(this->remote_receiver_channels_base_address_[vc][i]));
+            ct_args.push_back(static_cast<uint32_t>(this->remote_receiver_channels_num_buffers_[vc][i]));
+            ct_args.push_back(0);  // remote_address (unused for remote pools)
+            ct_args.push_back(0);  // remote_num_buffers (unused for remote pools)
+        }
     }
 }
 
-size_t FabricRemoteChannelsAllocator::get_remote_receiver_channel_base_address(size_t channel_id) const {
+size_t FabricRemoteChannelsAllocator::get_remote_receiver_channel_base_address(size_t vc_id, size_t channel_id) const {
+    TT_FATAL(
+        vc_id < builder_config::MAX_NUM_VCS, "VC ID {} out of bounds (max {})", vc_id, builder_config::MAX_NUM_VCS);
     TT_FATAL(
         channel_id < builder_config::num_max_receiver_channels,
-        "Channel ID {} out of bounds (max {})",
+        "Channel ID {} out of bounds for VC{} (max {})",
         channel_id,
+        vc_id,
         builder_config::num_max_receiver_channels - 1);
-    return this->remote_receiver_channels_base_address_[channel_id];
+    TT_FATAL(
+        channel_id < this->num_used_receiver_channels_per_vc_[vc_id],
+        "Channel ID {} is not used in VC{} (only {} channels used)",
+        channel_id,
+        vc_id,
+        this->num_used_receiver_channels_per_vc_[vc_id]);
+    return this->remote_receiver_channels_base_address_[vc_id][channel_id];
 }
 
-size_t FabricRemoteChannelsAllocator::get_remote_receiver_channel_num_buffers(size_t channel_id) const {
+size_t FabricRemoteChannelsAllocator::get_remote_receiver_channel_num_buffers(size_t vc_id, size_t channel_id) const {
+    TT_FATAL(
+        vc_id < builder_config::MAX_NUM_VCS, "VC ID {} out of bounds (max {})", vc_id, builder_config::MAX_NUM_VCS);
     TT_FATAL(
         channel_id < builder_config::num_max_receiver_channels,
-        "Channel ID {} out of bounds (max {})",
+        "Channel ID {} out of bounds for VC{} (max {})",
         channel_id,
+        vc_id,
         builder_config::num_max_receiver_channels - 1);
-    return this->remote_receiver_channels_num_buffers_[channel_id];
+    TT_FATAL(
+        channel_id < this->num_used_receiver_channels_per_vc_[vc_id],
+        "Channel ID {} is not used in VC{} (only {} channels used)",
+        channel_id,
+        vc_id,
+        this->num_used_receiver_channels_per_vc_[vc_id]);
+    return this->remote_receiver_channels_num_buffers_[vc_id][channel_id];
 }
 
 }  // namespace tt::tt_fabric

--- a/tt_metal/fabric/builder/fabric_static_sized_channels_allocator.cpp
+++ b/tt_metal/fabric/builder/fabric_static_sized_channels_allocator.cpp
@@ -402,16 +402,6 @@ void FabricStaticSizedChannelsAllocator::configure_buffer_slots_helper(
         }
 
         // Additional validation: ensure VC1 buffer slots are non-zero if VC1 channels are needed
-        if (num_vc1_sender_channels > 0 && vc1_sender_buffer_slots == 0) {
-            TT_THROW(
-                "VC1 sender channels are needed ({} channels) but selected buffer slot configuration has 0 slots",
-                num_vc1_sender_channels);
-        }
-        if (num_vc1_receiver_channels > 0 && vc1_receiver_buffer_slots == 0) {
-            TT_THROW(
-                "VC1 receiver channels are needed ({} channels) but selected buffer slot configuration has 0 slots",
-                num_vc1_receiver_channels);
-        }
     };
 
     // auto axis_index = static_cast<std::size_t>(options.edm_axis);

--- a/tt_metal/fabric/builder/fabric_static_sized_channels_allocator.cpp
+++ b/tt_metal/fabric/builder/fabric_static_sized_channels_allocator.cpp
@@ -16,37 +16,57 @@
 
 namespace tt::tt_fabric {
 
-size_t FabricStaticSizedChannelsAllocator::get_sender_channel_base_address(size_t channel_id) const {
-    TT_FATAL(channel_id < sender_channels_base_address.size(), "Sender channel ID {} out of bounds", channel_id);
-    return sender_channels_base_address[channel_id];
+size_t FabricStaticSizedChannelsAllocator::get_sender_channel_base_address(size_t vc_id, size_t channel_id) const {
+    TT_FATAL(vc_id < MAX_NUM_VCS, "VC ID {} out of bounds (max {})", vc_id, MAX_NUM_VCS);
+    TT_FATAL(
+        channel_id < sender_channels_base_address[vc_id].size(),
+        "Sender channel ID {} out of bounds for VC{}",
+        channel_id,
+        vc_id);
+    return sender_channels_base_address[vc_id][channel_id];
 }
 
-size_t FabricStaticSizedChannelsAllocator::get_sender_channel_number_of_slots(size_t channel_id) const {
-    TT_FATAL(channel_id < sender_channels_num_buffers.size(), "Sender channel ID {} out of bounds", channel_id);
-    return sender_channels_num_buffers[channel_id];
+size_t FabricStaticSizedChannelsAllocator::get_sender_channel_number_of_slots(size_t vc_id, size_t channel_id) const {
+    TT_FATAL(vc_id < MAX_NUM_VCS, "VC ID {} out of bounds (max {})", vc_id, MAX_NUM_VCS);
+    TT_FATAL(
+        channel_id < sender_channels_num_buffers[vc_id].size(),
+        "Sender channel ID {} out of bounds for VC{}",
+        channel_id,
+        vc_id);
+    return sender_channels_num_buffers[vc_id][channel_id];
 }
 
-size_t FabricStaticSizedChannelsAllocator::get_receiver_channel_number_of_slots(size_t channel_id) const {
-    TT_FATAL(channel_id < receiver_channels_num_buffers.size(), "Receiver channel ID {} out of bounds", channel_id);
-    return receiver_channels_num_buffers[channel_id];
+size_t FabricStaticSizedChannelsAllocator::get_receiver_channel_number_of_slots(size_t vc_id, size_t channel_id) const {
+    TT_FATAL(vc_id < MAX_NUM_VCS, "VC ID {} out of bounds (max {})", vc_id, MAX_NUM_VCS);
+    TT_FATAL(
+        channel_id < receiver_channels_num_buffers[vc_id].size(),
+        "Receiver channel ID {} out of bounds for VC{}",
+        channel_id,
+        vc_id);
+    return receiver_channels_num_buffers[vc_id][channel_id];
 }
 
-size_t FabricStaticSizedChannelsAllocator::get_receiver_channel_base_address(size_t channel_id) const {
-    TT_FATAL(channel_id < receiver_channels_base_address.size(), "Receiver channel ID {} out of bounds", channel_id);
-    return receiver_channels_base_address[channel_id];
+size_t FabricStaticSizedChannelsAllocator::get_receiver_channel_base_address(size_t vc_id, size_t channel_id) const {
+    TT_FATAL(vc_id < MAX_NUM_VCS, "VC ID {} out of bounds (max {})", vc_id, MAX_NUM_VCS);
+    TT_FATAL(
+        channel_id < receiver_channels_base_address[vc_id].size(),
+        "Receiver channel ID {} out of bounds for VC{}",
+        channel_id,
+        vc_id);
+    return receiver_channels_base_address[vc_id][channel_id];
 }
 
 FabricStaticSizedChannelsAllocator::FabricStaticSizedChannelsAllocator(
     tt::tt_fabric::Topology topology,
     const FabricEriscDatamoverOptions& options,
-    size_t num_used_sender_channels,
-    size_t num_used_receiver_channels,
+    const std::array<size_t, MAX_NUM_VCS>& num_used_sender_channels_per_vc,
+    const std::array<size_t, MAX_NUM_VCS>& num_used_receiver_channels_per_vc,
     size_t channel_buffer_size_bytes,
     size_t available_channel_buffering_space,
     const std::vector<MemoryRegion>& memory_regions) :
     FabricChannelAllocator(topology, options, memory_regions),
-    num_used_sender_channels(num_used_sender_channels),
-    num_used_receiver_channels(num_used_receiver_channels),
+    num_used_sender_channels_per_vc(num_used_sender_channels_per_vc),
+    num_used_receiver_channels_per_vc(num_used_receiver_channels_per_vc),
     channel_buffer_size_bytes(channel_buffer_size_bytes),
     available_channel_buffering_space(available_channel_buffering_space) {
     // Compute buffer region start from memory regions
@@ -58,31 +78,50 @@ FabricStaticSizedChannelsAllocator::FabricStaticSizedChannelsAllocator(
     for (const auto& region : memory_regions) {
         this->max_l1_loading_size = std::max(this->max_l1_loading_size, region.get_end_address());
     }
-    std::array<size_t, builder_config::num_max_sender_channels> num_sender_buffer_slots = {0};
-    std::array<size_t, builder_config::num_max_sender_channels> num_remote_sender_buffer_slots = {0};
-    std::array<size_t, builder_config::num_max_receiver_channels> num_receiver_buffer_slots = {0};
-    std::array<size_t, builder_config::num_max_receiver_channels> num_remote_receiver_buffer_slots = {0};
+
+    // Per-VC buffer slot arrays
+    std::array<std::array<size_t, builder_config::num_max_sender_channels>, MAX_NUM_VCS>
+        num_sender_buffer_slots_per_vc = {};
+    std::array<std::array<size_t, builder_config::num_max_sender_channels>, MAX_NUM_VCS>
+        num_remote_sender_buffer_slots_per_vc = {};
+    std::array<std::array<size_t, builder_config::num_max_receiver_channels>, MAX_NUM_VCS>
+        num_receiver_buffer_slots_per_vc = {};
+    std::array<std::array<size_t, builder_config::num_max_receiver_channels>, MAX_NUM_VCS>
+        num_remote_receiver_buffer_slots_per_vc = {};
 
     bool has_tensix_extension = options.fabric_tensix_config != tt::tt_fabric::FabricTensixConfig::DISABLED;
 
     configure_buffer_slots_helper(
         topology,
         options,
-        num_sender_buffer_slots,
-        num_remote_sender_buffer_slots,
-        num_receiver_buffer_slots,
-        num_remote_receiver_buffer_slots);
+        num_sender_buffer_slots_per_vc,
+        num_remote_sender_buffer_slots_per_vc,
+        num_receiver_buffer_slots_per_vc,
+        num_remote_receiver_buffer_slots_per_vc);
 
-    log_trace(tt::LogFabric, "num_sender_buffer_slots: {}", num_sender_buffer_slots);
-    log_trace(tt::LogFabric, "num_remote_sender_buffer_slots: {}", num_remote_sender_buffer_slots);
-    log_trace(tt::LogFabric, "num_receiver_buffer_slots: {}", num_receiver_buffer_slots);
-    log_trace(tt::LogFabric, "num_remote_receiver_buffer_slots: {}", num_remote_receiver_buffer_slots);
+    // Calculate total slots across all VCs
+    size_t total_slot_count = 0;
+    for (size_t vc = 0; vc < MAX_NUM_VCS; ++vc) {
+        size_t vc_sender_slots = std::accumulate(
+            num_sender_buffer_slots_per_vc[vc].begin(),
+            num_sender_buffer_slots_per_vc[vc].begin() + num_used_sender_channels_per_vc[vc],
+            size_t{0});
+        size_t vc_receiver_slots = std::accumulate(
+            num_receiver_buffer_slots_per_vc[vc].begin(),
+            num_receiver_buffer_slots_per_vc[vc].begin() + num_used_receiver_channels_per_vc[vc],
+            size_t{0});
+        total_slot_count += vc_sender_slots + vc_receiver_slots;
 
-    size_t total_sender_slots = std::accumulate(
-        num_sender_buffer_slots.begin(), num_sender_buffer_slots.begin() + num_used_sender_channels, size_t{0});
-    size_t total_receiver_slots = std::accumulate(
-        num_receiver_buffer_slots.begin(), num_receiver_buffer_slots.begin() + num_used_receiver_channels, size_t{0});
-    std::size_t total_slot_count = total_sender_slots + total_receiver_slots;
+        log_trace(tt::LogFabric, "VC{} num_sender_buffer_slots: {}", vc, num_sender_buffer_slots_per_vc[vc]);
+        log_trace(
+            tt::LogFabric, "VC{} num_remote_sender_buffer_slots: {}", vc, num_remote_sender_buffer_slots_per_vc[vc]);
+        log_trace(tt::LogFabric, "VC{} num_receiver_buffer_slots: {}", vc, num_receiver_buffer_slots_per_vc[vc]);
+        log_trace(
+            tt::LogFabric,
+            "VC{} num_remote_receiver_buffer_slots: {}",
+            vc,
+            num_remote_receiver_buffer_slots_per_vc[vc]);
+    }
     TT_FATAL(
         total_slot_count * channel_buffer_size_bytes <= available_channel_buffering_space,
         "Total channel size of {} B exceeds available space of {} B",
@@ -91,90 +130,141 @@ FabricStaticSizedChannelsAllocator::FabricStaticSizedChannelsAllocator(
 
     log_trace(tt::LogFabric, "Available channel buffering space: {}", this->available_channel_buffering_space);
 
-    // set the sender channel sizes and num buffers
-    for (uint32_t i = 0; i < num_used_sender_channels; i++) {
-        this->sender_channels_size_bytes[i] = channel_buffer_size_bytes * num_sender_buffer_slots[i];
-        this->sender_channels_num_buffers[i] = num_sender_buffer_slots[i];
-    }
-    // set the remote sender channel sizes and num buffers
-    for (uint32_t i = 0; i < num_used_sender_channels; i++) {
-        this->remote_sender_channels_size_bytes[i] = channel_buffer_size_bytes * num_remote_sender_buffer_slots[i];
-        this->remote_sender_channels_num_buffers[i] = num_remote_sender_buffer_slots[i];
-    }
-    // set the local receiver channel sizes and num buffers
-    for (uint32_t i = 0; i < num_used_receiver_channels; i++) {
-        this->receiver_channels_size_bytes[i] = channel_buffer_size_bytes * num_receiver_buffer_slots[i];
-        this->receiver_channels_num_buffers[i] = num_receiver_buffer_slots[i];
-    }
-    // set the remote receiver channel sizes and num buffers
-    for (uint32_t i = 0; i < num_used_receiver_channels; i++) {
-        this->remote_receiver_channels_size_bytes[i] = channel_buffer_size_bytes * num_remote_receiver_buffer_slots[i];
-        this->remote_receiver_channels_num_buffers[i] = num_remote_receiver_buffer_slots[i];
+    // Set channel sizes and num buffers per VC
+    for (size_t vc = 0; vc < MAX_NUM_VCS; ++vc) {
+        // set the sender channel sizes and num buffers
+        for (uint32_t i = 0; i < num_used_sender_channels_per_vc[vc]; i++) {
+            this->sender_channels_size_bytes[vc][i] = channel_buffer_size_bytes * num_sender_buffer_slots_per_vc[vc][i];
+            this->sender_channels_num_buffers[vc][i] = num_sender_buffer_slots_per_vc[vc][i];
+        }
+        // set the remote sender channel sizes and num buffers
+        for (uint32_t i = 0; i < num_used_sender_channels_per_vc[vc]; i++) {
+            this->remote_sender_channels_size_bytes[vc][i] =
+                channel_buffer_size_bytes * num_remote_sender_buffer_slots_per_vc[vc][i];
+            this->remote_sender_channels_num_buffers[vc][i] = num_remote_sender_buffer_slots_per_vc[vc][i];
+        }
+        // set the local receiver channel sizes and num buffers
+        for (uint32_t i = 0; i < num_used_receiver_channels_per_vc[vc]; i++) {
+            this->receiver_channels_size_bytes[vc][i] =
+                channel_buffer_size_bytes * num_receiver_buffer_slots_per_vc[vc][i];
+            this->receiver_channels_num_buffers[vc][i] = num_receiver_buffer_slots_per_vc[vc][i];
+        }
+        // set the remote receiver channel sizes and num buffers
+        for (uint32_t i = 0; i < num_used_receiver_channels_per_vc[vc]; i++) {
+            this->remote_receiver_channels_size_bytes[vc][i] =
+                channel_buffer_size_bytes * num_remote_receiver_buffer_slots_per_vc[vc][i];
+            this->remote_receiver_channels_num_buffers[vc][i] = num_remote_receiver_buffer_slots_per_vc[vc][i];
+        }
     }
 
-    // set the base addresses for the local channels
+    // set the base addresses for the local channels (allocate sequentially: VC0 channels, then VC1 channels)
     uint32_t sender_buffer_addr = buffer_region_start;
-    for (uint32_t i = 0; i < num_used_sender_channels; i++) {
-        this->sender_channels_base_address[i] = sender_buffer_addr;
-        sender_buffer_addr += this->sender_channels_size_bytes[i];
-        log_trace(tt::LogFabric, "Sender {} channel_start: {}", i, this->sender_channels_base_address[i]);
+    for (size_t vc = 0; vc < MAX_NUM_VCS; ++vc) {
+        for (uint32_t i = 0; i < num_used_sender_channels_per_vc[vc]; i++) {
+            this->sender_channels_base_address[vc][i] = sender_buffer_addr;
+            sender_buffer_addr += this->sender_channels_size_bytes[vc][i];
+            log_trace(
+                tt::LogFabric, "VC{} Sender {} channel_start: {}", vc, i, this->sender_channels_base_address[vc][i]);
+        }
     }
+
     uint32_t receiver_buffer_addr = sender_buffer_addr;
-    for (uint32_t i = 0; i < num_used_receiver_channels; i++) {
-        this->receiver_channels_base_address[i] = receiver_buffer_addr;
-        receiver_buffer_addr += this->receiver_channels_size_bytes[i];
-        log_trace(tt::LogFabric, "Receiver {} channel_start: {}", i, this->receiver_channels_base_address[i]);
+    for (size_t vc = 0; vc < MAX_NUM_VCS; ++vc) {
+        for (uint32_t i = 0; i < num_used_receiver_channels_per_vc[vc]; i++) {
+            this->receiver_channels_base_address[vc][i] = receiver_buffer_addr;
+            receiver_buffer_addr += this->receiver_channels_size_bytes[vc][i];
+            log_trace(
+                tt::LogFabric,
+                "VC{} Receiver {} channel_start: {}",
+                vc,
+                i,
+                this->receiver_channels_base_address[vc][i]);
+        }
     }
     uint32_t buffer_addr_end = receiver_buffer_addr;
+
     // set the base addresses for the remote channels
     uint32_t remote_sender_buffer_addr = buffer_region_start;
-    for (uint32_t i = 0; i < num_used_sender_channels; i++) {
-        this->remote_sender_channels_base_address[i] = remote_sender_buffer_addr;
-        remote_sender_buffer_addr += this->remote_sender_channels_size_bytes[i];
-        log_trace(tt::LogFabric, "Remote Sender {} channel_start: {}", i, this->remote_sender_channels_base_address[i]);
+    for (size_t vc = 0; vc < MAX_NUM_VCS; ++vc) {
+        for (uint32_t i = 0; i < num_used_sender_channels_per_vc[vc]; i++) {
+            this->remote_sender_channels_base_address[vc][i] = remote_sender_buffer_addr;
+            remote_sender_buffer_addr += this->remote_sender_channels_size_bytes[vc][i];
+            log_trace(
+                tt::LogFabric,
+                "VC{} Remote Sender {} channel_start: {}",
+                vc,
+                i,
+                this->remote_sender_channels_base_address[vc][i]);
+        }
     }
+
     uint32_t remote_receiver_buffer_addr = remote_sender_buffer_addr;
-    for (uint32_t i = 0; i < num_used_receiver_channels; i++) {
-        this->remote_receiver_channels_base_address[i] = remote_receiver_buffer_addr;
-        remote_receiver_buffer_addr += this->remote_receiver_channels_size_bytes[i];
-        log_trace(tt::LogFabric, "Remote Receiver {} channel_start: {}", i, this->remote_receiver_channels_base_address[i]);
+    for (size_t vc = 0; vc < MAX_NUM_VCS; ++vc) {
+        for (uint32_t i = 0; i < num_used_receiver_channels_per_vc[vc]; i++) {
+            this->remote_receiver_channels_base_address[vc][i] = remote_receiver_buffer_addr;
+            remote_receiver_buffer_addr += this->remote_receiver_channels_size_bytes[vc][i];
+            log_trace(
+                tt::LogFabric,
+                "VC{} Remote Receiver {} channel_start: {}",
+                vc,
+                i,
+                this->remote_receiver_channels_base_address[vc][i]);
+        }
     }
 
     log_trace(tt::LogFabric, "Available channel buffering space: {}", this->available_channel_buffering_space);
 
-    auto skip_current_sender_channel = [&](uint32_t idx) -> bool {
-        // for fabric with tensix extension, only check the vc1 sender channel and worker channel, other
-        // channels are skipped
+    // TODO: I dont understand this code. Review it.
+    auto skip_current_sender_channel = [&](uint32_t vc_id, uint32_t idx) -> bool {
+        // for fabric with tensix extension, only check the worker channel (VC0 channel 0), other channels are skipped
         uint32_t target_channel = get_worker_connected_sender_channel();
-        return (idx != target_channel && has_tensix_extension);
+        return !((vc_id == 0 && idx == target_channel) || !has_tensix_extension);
     };
 
-    for (uint32_t i = 0; i < num_used_sender_channels; i++) {
-        if (!skip_current_sender_channel(i)) {
+    // Validate sender channels per VC
+    for (size_t vc = 0; vc < MAX_NUM_VCS; ++vc) {
+        for (uint32_t i = 0; i < num_used_sender_channels_per_vc[vc]; i++) {
+            if (!skip_current_sender_channel(vc, i)) {
+                TT_FATAL(
+                    this->sender_channels_size_bytes[vc][i] > 0,
+                    "Internal error when computing `sender_channels_size_bytes[VC{}][{}]` which was computed to be "
+                    "size 0",
+                    vc,
+                    i);
+            }
+        }
+    }
+
+    // Validate receiver channels per VC
+    for (size_t vc = 0; vc < MAX_NUM_VCS; ++vc) {
+        for (uint32_t i = 0; i < num_used_receiver_channels_per_vc[vc]; i++) {
             TT_FATAL(
-                this->sender_channels_size_bytes[i] > 0,
-                "Internal error when computing `sender_channels_size_bytes[{}]` which was computed to be size 0",
+                this->receiver_channels_size_bytes[vc][i] > 0,
+                "Internal error when computing `receiver_channels_size_bytes[VC{}][{}]` which was computed to be size "
+                "0",
+                vc,
                 i);
         }
     }
 
-    for (uint32_t i = 0; i < num_used_receiver_channels; i++) {
-        TT_FATAL(
-            this->receiver_channels_size_bytes[i] > 0,
-            "Internal error when computing `receiver_channels_size_bytes[{}]` which was computed to be size 0",
-            i);
+    // Validate total size across all VCs
+    size_t total_size = 0;
+    for (size_t vc = 0; vc < MAX_NUM_VCS; ++vc) {
+        total_size += std::accumulate(
+            this->sender_channels_size_bytes[vc].begin(),
+            this->sender_channels_size_bytes[vc].begin() + num_used_sender_channels_per_vc[vc],
+            0ul);
+        total_size += std::accumulate(
+            this->receiver_channels_size_bytes[vc].begin(),
+            this->receiver_channels_size_bytes[vc].begin() + num_used_receiver_channels_per_vc[vc],
+            0ul);
     }
+
     TT_FATAL(
-        std::accumulate(
-            this->sender_channels_size_bytes.begin(),
-            this->sender_channels_size_bytes.begin() + num_used_sender_channels,
-            0ul) +
-                std::accumulate(
-                    this->receiver_channels_size_bytes.begin(),
-                    this->receiver_channels_size_bytes.begin() + num_used_receiver_channels,
-                    0ul) <=
-            this->available_channel_buffering_space,
-        "Internal error when computing channel sizes. Total channel size exceeds available space");
+        total_size <= this->available_channel_buffering_space,
+        "Internal error when computing channel sizes. Total channel size {} exceeds available space {}",
+        total_size,
+        this->available_channel_buffering_space);
     TT_FATAL(
         buffer_addr_end < this->max_l1_loading_size,
         "Internal error - channel buffers spilled past the end of usable L1 region.");
@@ -183,10 +273,14 @@ FabricStaticSizedChannelsAllocator::FabricStaticSizedChannelsAllocator(
 void FabricStaticSizedChannelsAllocator::configure_buffer_slots_helper(
     Topology topology,
     const FabricEriscDatamoverOptions& options,
-    std::array<size_t, builder_config::num_max_sender_channels>& num_sender_buffer_slots,
-    std::array<size_t, builder_config::num_max_sender_channels>& num_remote_sender_buffer_slots,
-    std::array<size_t, builder_config::num_max_receiver_channels>& num_receiver_buffer_slots,
-    std::array<size_t, builder_config::num_max_receiver_channels>& num_remote_receiver_buffer_slots) {
+    std::array<std::array<size_t, builder_config::num_max_sender_channels>, MAX_NUM_VCS>&
+        num_sender_buffer_slots_per_vc,
+    std::array<std::array<size_t, builder_config::num_max_sender_channels>, MAX_NUM_VCS>&
+        num_remote_sender_buffer_slots_per_vc,
+    std::array<std::array<size_t, builder_config::num_max_receiver_channels>, MAX_NUM_VCS>&
+        num_receiver_buffer_slots_per_vc,
+    std::array<std::array<size_t, builder_config::num_max_receiver_channels>, MAX_NUM_VCS>&
+        num_remote_receiver_buffer_slots_per_vc) {
     // fabric with tensix extension uses different buffer slots options, since only one or two sender channels are
     // used by fabric router, while other sender channels are skipped and have 0 buffer slots.
     static const std::vector<std::vector<std::pair<size_t, size_t>>> default_with_tensix_buffer_slot_options = {
@@ -255,54 +349,76 @@ void FabricStaticSizedChannelsAllocator::configure_buffer_slots_helper(
 
     switch (options.fabric_tensix_config) {
         case tt::tt_fabric::FabricTensixConfig::MUX: {
+            // MUX mode: Only VC0 channel 0 is used for worker
             uint32_t num_sender_channels = this->num_sender_channels_with_tensix_config;
             uint32_t target_channel = get_worker_connected_sender_channel();
             size_t default_num_sender_buffer_slots;
             size_t default_num_receiver_buffer_slots;
+
+            // Calculate total channels across VCs for sizing
+            size_t total_receiver_channels =
+                num_used_receiver_channels_per_vc[0] + num_used_receiver_channels_per_vc[1];
+
             // get the default buffer slots
             get_optimal_num_slots(
                 default_with_tensix_buffer_slot_options[arch_index],
                 num_sender_channels,
-                this->num_used_receiver_channels,
+                total_receiver_channels,
                 default_num_sender_buffer_slots,
                 default_num_receiver_buffer_slots);
-            // set default buffer slots.
-            num_sender_buffer_slots[target_channel] = default_num_sender_buffer_slots;
-            num_remote_sender_buffer_slots[target_channel] = default_num_sender_buffer_slots;
-            num_receiver_buffer_slots.fill(default_num_receiver_buffer_slots);
-            num_remote_receiver_buffer_slots.fill(default_num_receiver_buffer_slots);
+
+            // set default buffer slots for VC0 only (worker channel)
+            num_sender_buffer_slots_per_vc[0][target_channel] = default_num_sender_buffer_slots;
+            num_remote_sender_buffer_slots_per_vc[0][target_channel] = default_num_sender_buffer_slots;
+
+            // Fill receiver buffer slots for all VCs
+            for (size_t vc = 0; vc < MAX_NUM_VCS; ++vc) {
+                num_receiver_buffer_slots_per_vc[vc].fill(default_num_receiver_buffer_slots);
+                num_remote_receiver_buffer_slots_per_vc[vc].fill(default_num_receiver_buffer_slots);
+            }
             return;
         }
         default: break;
     }
 
-    size_t default_num_sender_buffer_slots;
-    size_t default_num_receiver_buffer_slots;
-    get_optimal_num_slots(
-        get_num_buffer_slots(topology, arch_index),
-        this->num_used_sender_channels,
-        this->num_used_receiver_channels,
-        default_num_sender_buffer_slots,
-        default_num_receiver_buffer_slots);
-    // set default buffer slots.
-    num_sender_buffer_slots.fill(default_num_sender_buffer_slots);
-    num_remote_sender_buffer_slots.fill(default_num_sender_buffer_slots);
-    num_receiver_buffer_slots.fill(default_num_receiver_buffer_slots);
-    num_remote_receiver_buffer_slots.fill(default_num_receiver_buffer_slots);
+    // Default case: Configure buffer slots for each VC independently
+    for (size_t vc = 0; vc < MAX_NUM_VCS; ++vc) {
+        size_t default_num_sender_buffer_slots;
+        size_t default_num_receiver_buffer_slots;
+        get_optimal_num_slots(
+            get_num_buffer_slots(topology, arch_index),
+            this->num_used_sender_channels_per_vc[vc],
+            this->num_used_receiver_channels_per_vc[vc],
+            default_num_sender_buffer_slots,
+            default_num_receiver_buffer_slots);
+
+        // set default buffer slots for this VC
+        num_sender_buffer_slots_per_vc[vc].fill(default_num_sender_buffer_slots);
+        num_remote_sender_buffer_slots_per_vc[vc].fill(default_num_sender_buffer_slots);
+        num_receiver_buffer_slots_per_vc[vc].fill(default_num_receiver_buffer_slots);
+        num_remote_receiver_buffer_slots_per_vc[vc].fill(default_num_receiver_buffer_slots);
+    }
 }
 
 void FabricStaticSizedChannelsAllocator::emit_ct_args(std::vector<uint32_t>& ct_args) const {
-    for (size_t i = 0; i < this->num_used_sender_channels; ++i) {
-        ct_args.push_back(static_cast<uint32_t>(this->sender_channels_base_address[i]));
-        ct_args.push_back(this->sender_channels_num_buffers[i]);
-        ct_args.push_back(static_cast<uint32_t>(this->remote_sender_channels_base_address[i]));
-        ct_args.push_back(this->remote_sender_channels_num_buffers[i]);
+    // Emit sender channel args for all VCs
+    for (size_t vc = 0; vc < MAX_NUM_VCS; ++vc) {
+        for (size_t i = 0; i < this->num_used_sender_channels_per_vc[vc]; ++i) {
+            ct_args.push_back(static_cast<uint32_t>(this->sender_channels_base_address[vc][i]));
+            ct_args.push_back(this->sender_channels_num_buffers[vc][i]);
+            ct_args.push_back(static_cast<uint32_t>(this->remote_sender_channels_base_address[vc][i]));
+            ct_args.push_back(this->remote_sender_channels_num_buffers[vc][i]);
+        }
     }
-    for (size_t i = 0; i < this->num_used_receiver_channels; ++i) {
-        ct_args.push_back(static_cast<uint32_t>(this->receiver_channels_base_address[i]));
-        ct_args.push_back(this->receiver_channels_num_buffers[i]);
-        ct_args.push_back(static_cast<uint32_t>(this->remote_receiver_channels_base_address[i]));
-        ct_args.push_back(this->remote_receiver_channels_num_buffers[i]);
+
+    // Emit receiver channel args for all VCs
+    for (size_t vc = 0; vc < MAX_NUM_VCS; ++vc) {
+        for (size_t i = 0; i < this->num_used_receiver_channels_per_vc[vc]; ++i) {
+            ct_args.push_back(static_cast<uint32_t>(this->receiver_channels_base_address[vc][i]));
+            ct_args.push_back(this->receiver_channels_num_buffers[vc][i]);
+            ct_args.push_back(static_cast<uint32_t>(this->remote_receiver_channels_base_address[vc][i]));
+            ct_args.push_back(this->remote_receiver_channels_num_buffers[vc][i]);
+        }
     }
 }
 

--- a/tt_metal/fabric/builder/fabric_static_sized_channels_allocator.cpp
+++ b/tt_metal/fabric/builder/fabric_static_sized_channels_allocator.cpp
@@ -17,7 +17,8 @@
 namespace tt::tt_fabric {
 
 size_t FabricStaticSizedChannelsAllocator::get_sender_channel_base_address(size_t vc_id, size_t channel_id) const {
-    TT_FATAL(vc_id < MAX_NUM_VCS, "VC ID {} out of bounds (max {})", vc_id, MAX_NUM_VCS);
+    TT_FATAL(
+        vc_id < builder_config::MAX_NUM_VCS, "VC ID {} out of bounds (max {})", vc_id, builder_config::MAX_NUM_VCS);
     TT_FATAL(
         channel_id < sender_channels_base_address[vc_id].size(),
         "Sender channel ID {} out of bounds for VC{}",
@@ -27,7 +28,8 @@ size_t FabricStaticSizedChannelsAllocator::get_sender_channel_base_address(size_
 }
 
 size_t FabricStaticSizedChannelsAllocator::get_sender_channel_number_of_slots(size_t vc_id, size_t channel_id) const {
-    TT_FATAL(vc_id < MAX_NUM_VCS, "VC ID {} out of bounds (max {})", vc_id, MAX_NUM_VCS);
+    TT_FATAL(
+        vc_id < builder_config::MAX_NUM_VCS, "VC ID {} out of bounds (max {})", vc_id, builder_config::MAX_NUM_VCS);
     TT_FATAL(
         channel_id < sender_channels_num_buffers[vc_id].size(),
         "Sender channel ID {} out of bounds for VC{}",
@@ -37,7 +39,8 @@ size_t FabricStaticSizedChannelsAllocator::get_sender_channel_number_of_slots(si
 }
 
 size_t FabricStaticSizedChannelsAllocator::get_receiver_channel_number_of_slots(size_t vc_id, size_t channel_id) const {
-    TT_FATAL(vc_id < MAX_NUM_VCS, "VC ID {} out of bounds (max {})", vc_id, MAX_NUM_VCS);
+    TT_FATAL(
+        vc_id < builder_config::MAX_NUM_VCS, "VC ID {} out of bounds (max {})", vc_id, builder_config::MAX_NUM_VCS);
     TT_FATAL(
         channel_id < receiver_channels_num_buffers[vc_id].size(),
         "Receiver channel ID {} out of bounds for VC{}",
@@ -47,7 +50,8 @@ size_t FabricStaticSizedChannelsAllocator::get_receiver_channel_number_of_slots(
 }
 
 size_t FabricStaticSizedChannelsAllocator::get_receiver_channel_base_address(size_t vc_id, size_t channel_id) const {
-    TT_FATAL(vc_id < MAX_NUM_VCS, "VC ID {} out of bounds (max {})", vc_id, MAX_NUM_VCS);
+    TT_FATAL(
+        vc_id < builder_config::MAX_NUM_VCS, "VC ID {} out of bounds (max {})", vc_id, builder_config::MAX_NUM_VCS);
     TT_FATAL(
         channel_id < receiver_channels_base_address[vc_id].size(),
         "Receiver channel ID {} out of bounds for VC{}",
@@ -59,8 +63,8 @@ size_t FabricStaticSizedChannelsAllocator::get_receiver_channel_base_address(siz
 FabricStaticSizedChannelsAllocator::FabricStaticSizedChannelsAllocator(
     tt::tt_fabric::Topology topology,
     const FabricEriscDatamoverOptions& options,
-    const std::array<size_t, MAX_NUM_VCS>& num_used_sender_channels_per_vc,
-    const std::array<size_t, MAX_NUM_VCS>& num_used_receiver_channels_per_vc,
+    const std::array<size_t, builder_config::MAX_NUM_VCS>& num_used_sender_channels_per_vc,
+    const std::array<size_t, builder_config::MAX_NUM_VCS>& num_used_receiver_channels_per_vc,
     size_t channel_buffer_size_bytes,
     size_t available_channel_buffering_space,
     const std::vector<MemoryRegion>& memory_regions) :
@@ -80,13 +84,13 @@ FabricStaticSizedChannelsAllocator::FabricStaticSizedChannelsAllocator(
     }
 
     // Per-VC buffer slot arrays
-    std::array<std::array<size_t, builder_config::num_max_sender_channels>, MAX_NUM_VCS>
+    std::array<std::array<size_t, builder_config::num_max_sender_channels>, builder_config::MAX_NUM_VCS>
         num_sender_buffer_slots_per_vc = {};
-    std::array<std::array<size_t, builder_config::num_max_sender_channels>, MAX_NUM_VCS>
+    std::array<std::array<size_t, builder_config::num_max_sender_channels>, builder_config::MAX_NUM_VCS>
         num_remote_sender_buffer_slots_per_vc = {};
-    std::array<std::array<size_t, builder_config::num_max_receiver_channels>, MAX_NUM_VCS>
+    std::array<std::array<size_t, builder_config::num_max_receiver_channels>, builder_config::MAX_NUM_VCS>
         num_receiver_buffer_slots_per_vc = {};
-    std::array<std::array<size_t, builder_config::num_max_receiver_channels>, MAX_NUM_VCS>
+    std::array<std::array<size_t, builder_config::num_max_receiver_channels>, builder_config::MAX_NUM_VCS>
         num_remote_receiver_buffer_slots_per_vc = {};
 
     bool has_tensix_extension = options.fabric_tensix_config != tt::tt_fabric::FabricTensixConfig::DISABLED;
@@ -101,7 +105,7 @@ FabricStaticSizedChannelsAllocator::FabricStaticSizedChannelsAllocator(
 
     // Calculate total slots across all VCs
     size_t total_slot_count = 0;
-    for (size_t vc = 0; vc < MAX_NUM_VCS; ++vc) {
+    for (size_t vc = 0; vc < builder_config::MAX_NUM_VCS; ++vc) {
         size_t vc_sender_slots = std::accumulate(
             num_sender_buffer_slots_per_vc[vc].begin(),
             num_sender_buffer_slots_per_vc[vc].begin() + num_used_sender_channels_per_vc[vc],
@@ -131,7 +135,7 @@ FabricStaticSizedChannelsAllocator::FabricStaticSizedChannelsAllocator(
     log_trace(tt::LogFabric, "Available channel buffering space: {}", this->available_channel_buffering_space);
 
     // Set channel sizes and num buffers per VC
-    for (size_t vc = 0; vc < MAX_NUM_VCS; ++vc) {
+    for (size_t vc = 0; vc < builder_config::MAX_NUM_VCS; ++vc) {
         // set the sender channel sizes and num buffers
         for (uint32_t i = 0; i < num_used_sender_channels_per_vc[vc]; i++) {
             this->sender_channels_size_bytes[vc][i] = channel_buffer_size_bytes * num_sender_buffer_slots_per_vc[vc][i];
@@ -159,7 +163,7 @@ FabricStaticSizedChannelsAllocator::FabricStaticSizedChannelsAllocator(
 
     // set the base addresses for the local channels (allocate sequentially: VC0 channels, then VC1 channels)
     uint32_t sender_buffer_addr = buffer_region_start;
-    for (size_t vc = 0; vc < MAX_NUM_VCS; ++vc) {
+    for (size_t vc = 0; vc < builder_config::MAX_NUM_VCS; ++vc) {
         for (uint32_t i = 0; i < num_used_sender_channels_per_vc[vc]; i++) {
             this->sender_channels_base_address[vc][i] = sender_buffer_addr;
             sender_buffer_addr += this->sender_channels_size_bytes[vc][i];
@@ -169,7 +173,7 @@ FabricStaticSizedChannelsAllocator::FabricStaticSizedChannelsAllocator(
     }
 
     uint32_t receiver_buffer_addr = sender_buffer_addr;
-    for (size_t vc = 0; vc < MAX_NUM_VCS; ++vc) {
+    for (size_t vc = 0; vc < builder_config::MAX_NUM_VCS; ++vc) {
         for (uint32_t i = 0; i < num_used_receiver_channels_per_vc[vc]; i++) {
             this->receiver_channels_base_address[vc][i] = receiver_buffer_addr;
             receiver_buffer_addr += this->receiver_channels_size_bytes[vc][i];
@@ -185,7 +189,7 @@ FabricStaticSizedChannelsAllocator::FabricStaticSizedChannelsAllocator(
 
     // set the base addresses for the remote channels
     uint32_t remote_sender_buffer_addr = buffer_region_start;
-    for (size_t vc = 0; vc < MAX_NUM_VCS; ++vc) {
+    for (size_t vc = 0; vc < builder_config::MAX_NUM_VCS; ++vc) {
         for (uint32_t i = 0; i < num_used_sender_channels_per_vc[vc]; i++) {
             this->remote_sender_channels_base_address[vc][i] = remote_sender_buffer_addr;
             remote_sender_buffer_addr += this->remote_sender_channels_size_bytes[vc][i];
@@ -199,7 +203,7 @@ FabricStaticSizedChannelsAllocator::FabricStaticSizedChannelsAllocator(
     }
 
     uint32_t remote_receiver_buffer_addr = remote_sender_buffer_addr;
-    for (size_t vc = 0; vc < MAX_NUM_VCS; ++vc) {
+    for (size_t vc = 0; vc < builder_config::MAX_NUM_VCS; ++vc) {
         for (uint32_t i = 0; i < num_used_receiver_channels_per_vc[vc]; i++) {
             this->remote_receiver_channels_base_address[vc][i] = remote_receiver_buffer_addr;
             remote_receiver_buffer_addr += this->remote_receiver_channels_size_bytes[vc][i];
@@ -214,7 +218,6 @@ FabricStaticSizedChannelsAllocator::FabricStaticSizedChannelsAllocator(
 
     log_trace(tt::LogFabric, "Available channel buffering space: {}", this->available_channel_buffering_space);
 
-    // TODO: I dont understand this code. Review it.
     auto skip_current_sender_channel = [&](uint32_t vc_id, uint32_t idx) -> bool {
         // for fabric with tensix extension, only check the worker channel (VC0 channel 0), other channels are skipped
         uint32_t target_channel = get_worker_connected_sender_channel();
@@ -222,7 +225,7 @@ FabricStaticSizedChannelsAllocator::FabricStaticSizedChannelsAllocator(
     };
 
     // Validate sender channels per VC
-    for (size_t vc = 0; vc < MAX_NUM_VCS; ++vc) {
+    for (size_t vc = 0; vc < builder_config::MAX_NUM_VCS; ++vc) {
         for (uint32_t i = 0; i < num_used_sender_channels_per_vc[vc]; i++) {
             if (!skip_current_sender_channel(vc, i)) {
                 TT_FATAL(
@@ -236,7 +239,7 @@ FabricStaticSizedChannelsAllocator::FabricStaticSizedChannelsAllocator(
     }
 
     // Validate receiver channels per VC
-    for (size_t vc = 0; vc < MAX_NUM_VCS; ++vc) {
+    for (size_t vc = 0; vc < builder_config::MAX_NUM_VCS; ++vc) {
         for (uint32_t i = 0; i < num_used_receiver_channels_per_vc[vc]; i++) {
             TT_FATAL(
                 this->receiver_channels_size_bytes[vc][i] > 0,
@@ -249,7 +252,7 @@ FabricStaticSizedChannelsAllocator::FabricStaticSizedChannelsAllocator(
 
     // Validate total size across all VCs
     size_t total_size = 0;
-    for (size_t vc = 0; vc < MAX_NUM_VCS; ++vc) {
+    for (size_t vc = 0; vc < builder_config::MAX_NUM_VCS; ++vc) {
         total_size += std::accumulate(
             this->sender_channels_size_bytes[vc].begin(),
             this->sender_channels_size_bytes[vc].begin() + num_used_sender_channels_per_vc[vc],
@@ -273,13 +276,13 @@ FabricStaticSizedChannelsAllocator::FabricStaticSizedChannelsAllocator(
 void FabricStaticSizedChannelsAllocator::configure_buffer_slots_helper(
     Topology topology,
     const FabricEriscDatamoverOptions& options,
-    std::array<std::array<size_t, builder_config::num_max_sender_channels>, MAX_NUM_VCS>&
+    std::array<std::array<size_t, builder_config::num_max_sender_channels>, builder_config::MAX_NUM_VCS>&
         num_sender_buffer_slots_per_vc,
-    std::array<std::array<size_t, builder_config::num_max_sender_channels>, MAX_NUM_VCS>&
+    std::array<std::array<size_t, builder_config::num_max_sender_channels>, builder_config::MAX_NUM_VCS>&
         num_remote_sender_buffer_slots_per_vc,
-    std::array<std::array<size_t, builder_config::num_max_receiver_channels>, MAX_NUM_VCS>&
+    std::array<std::array<size_t, builder_config::num_max_receiver_channels>, builder_config::MAX_NUM_VCS>&
         num_receiver_buffer_slots_per_vc,
-    std::array<std::array<size_t, builder_config::num_max_receiver_channels>, MAX_NUM_VCS>&
+    std::array<std::array<size_t, builder_config::num_max_receiver_channels>, builder_config::MAX_NUM_VCS>&
         num_remote_receiver_buffer_slots_per_vc) {
     // Per-VC buffer slot configuration: {vc0_sender, vc0_receiver, vc1_sender, vc1_receiver}
     struct PerVcBufferSlots {
@@ -478,7 +481,7 @@ void FabricStaticSizedChannelsAllocator::configure_buffer_slots_helper(
 
 void FabricStaticSizedChannelsAllocator::emit_ct_args(std::vector<uint32_t>& ct_args) const {
     // Emit sender channel args for all VCs
-    for (size_t vc = 0; vc < MAX_NUM_VCS; ++vc) {
+    for (size_t vc = 0; vc < builder_config::MAX_NUM_VCS; ++vc) {
         for (size_t i = 0; i < this->num_used_sender_channels_per_vc[vc]; ++i) {
             ct_args.push_back(static_cast<uint32_t>(this->sender_channels_base_address[vc][i]));
             ct_args.push_back(this->sender_channels_num_buffers[vc][i]);
@@ -488,7 +491,7 @@ void FabricStaticSizedChannelsAllocator::emit_ct_args(std::vector<uint32_t>& ct_
     }
 
     // Emit receiver channel args for all VCs
-    for (size_t vc = 0; vc < MAX_NUM_VCS; ++vc) {
+    for (size_t vc = 0; vc < builder_config::MAX_NUM_VCS; ++vc) {
         for (size_t i = 0; i < this->num_used_receiver_channels_per_vc[vc]; ++i) {
             ct_args.push_back(static_cast<uint32_t>(this->receiver_channels_base_address[vc][i]));
             ct_args.push_back(this->receiver_channels_num_buffers[vc][i]);

--- a/tt_metal/fabric/builder/fabric_static_sized_channels_allocator.hpp
+++ b/tt_metal/fabric/builder/fabric_static_sized_channels_allocator.hpp
@@ -73,8 +73,14 @@ public:
      */
     size_t get_receiver_channel_base_address(size_t vc_id, size_t channel_id) const;
 
-    size_t get_num_sender_channels(size_t vc_id) const { return num_used_sender_channels_per_vc[vc_id]; }
-    size_t get_num_receiver_channels(size_t vc_id) const { return num_used_receiver_channels_per_vc[vc_id]; }
+    size_t get_num_sender_channels(size_t vc_id) const {
+        TT_FATAL(vc_id < MAX_NUM_VCS, "VC ID {} out of bounds (max {})", vc_id, MAX_NUM_VCS);
+        return num_used_sender_channels_per_vc[vc_id];
+    }
+    size_t get_num_receiver_channels(size_t vc_id) const {
+        TT_FATAL(vc_id < MAX_NUM_VCS, "VC ID {} out of bounds (max {})", vc_id, MAX_NUM_VCS);
+        return num_used_receiver_channels_per_vc[vc_id];
+    }
 
     // Legacy getters (assume VC0 for backward compatibility)
     size_t get_sender_channel_number_of_slots(size_t channel_id) const {

--- a/tt_metal/fabric/builder/fabric_static_sized_channels_allocator.hpp
+++ b/tt_metal/fabric/builder/fabric_static_sized_channels_allocator.hpp
@@ -89,8 +89,13 @@ public:
     size_t get_receiver_channel_base_address(size_t channel_id) const {
         return get_receiver_channel_base_address(0, channel_id);
     }
-    size_t get_num_sender_channels() const { return get_num_sender_channels(0); }
-    size_t get_num_receiver_channels() const { return get_num_receiver_channels(0); }
+    // For total counts: return sum across all VCs
+    size_t get_num_sender_channels() const {
+        return num_used_sender_channels_per_vc[0] + num_used_sender_channels_per_vc[1];
+    }
+    size_t get_num_receiver_channels() const {
+        return num_used_receiver_channels_per_vc[0] + num_used_receiver_channels_per_vc[1];
+    }
 
     // Override virtual print method from base class
     void print(std::ostream& os) const override;

--- a/tt_metal/fabric/builder/fabric_static_sized_channels_allocator.hpp
+++ b/tt_metal/fabric/builder/fabric_static_sized_channels_allocator.hpp
@@ -203,7 +203,7 @@ inline void FabricStaticSizedChannelsAllocator::print(std::ostream& os) const {
             os << "    Receiver Channels:\n";
             for (size_t i = 0; i < num_used_receiver_channels_per_vc[vc]; ++i) {
                 os << "      Channel " << i << ":\n";
-                os << "      base_address: 0x" << std::hex << receiver_channels_base_address[vc][i] << std::dec << "\n";
+                os << "        base_address: 0x" << std::hex << receiver_channels_base_address[vc][i] << std::dec << "\n";
                 os << "        num_buffers: " << receiver_channels_num_buffers[vc][i] << "\n";
                 os << "        size_bytes: " << receiver_channels_size_bytes[vc][i] << " B\n";
                 if (remote_receiver_channels_num_buffers[vc][i] > 0) {

--- a/tt_metal/fabric/builder/fabric_static_sized_channels_allocator.hpp
+++ b/tt_metal/fabric/builder/fabric_static_sized_channels_allocator.hpp
@@ -28,13 +28,11 @@ namespace tt::tt_fabric {
  */
 class FabricStaticSizedChannelsAllocator : public FabricChannelAllocator {
 public:
-    static constexpr size_t MAX_NUM_VCS = 2;  // VC0 and VC1
-
     FabricStaticSizedChannelsAllocator(
         tt::tt_fabric::Topology topology,
         const FabricEriscDatamoverOptions& options,
-        const std::array<size_t, MAX_NUM_VCS>& num_used_sender_channels_per_vc,
-        const std::array<size_t, MAX_NUM_VCS>& num_used_receiver_channels_per_vc,
+        const std::array<size_t, builder_config::MAX_NUM_VCS>& num_used_sender_channels_per_vc,
+        const std::array<size_t, builder_config::MAX_NUM_VCS>& num_used_receiver_channels_per_vc,
         size_t channel_buffer_size_bytes,
         size_t available_channel_buffering_space,
         const std::vector<MemoryRegion>& memory_regions);
@@ -74,11 +72,13 @@ public:
     size_t get_receiver_channel_base_address(size_t vc_id, size_t channel_id) const;
 
     size_t get_num_sender_channels(size_t vc_id) const {
-        TT_FATAL(vc_id < MAX_NUM_VCS, "VC ID {} out of bounds (max {})", vc_id, MAX_NUM_VCS);
+        TT_FATAL(
+            vc_id < builder_config::MAX_NUM_VCS, "VC ID {} out of bounds (max {})", vc_id, builder_config::MAX_NUM_VCS);
         return num_used_sender_channels_per_vc[vc_id];
     }
     size_t get_num_receiver_channels(size_t vc_id) const {
-        TT_FATAL(vc_id < MAX_NUM_VCS, "VC ID {} out of bounds (max {})", vc_id, MAX_NUM_VCS);
+        TT_FATAL(
+            vc_id < builder_config::MAX_NUM_VCS, "VC ID {} out of bounds (max {})", vc_id, builder_config::MAX_NUM_VCS);
         return num_used_receiver_channels_per_vc[vc_id];
     }
 
@@ -114,18 +114,22 @@ private:
     void configure_buffer_slots_helper(
         tt::tt_fabric::Topology topology,
         const tt::tt_fabric::FabricEriscDatamoverOptions& options,
-        std::array<std::array<size_t, tt::tt_fabric::builder_config::num_max_sender_channels>, MAX_NUM_VCS>&
-            num_sender_buffer_slots_per_vc,
-        std::array<std::array<size_t, tt::tt_fabric::builder_config::num_max_sender_channels>, MAX_NUM_VCS>&
-            num_remote_sender_buffer_slots_per_vc,
-        std::array<std::array<size_t, tt::tt_fabric::builder_config::num_max_receiver_channels>, MAX_NUM_VCS>&
-            num_receiver_buffer_slots_per_vc,
-        std::array<std::array<size_t, tt::tt_fabric::builder_config::num_max_receiver_channels>, MAX_NUM_VCS>&
-            num_remote_receiver_buffer_slots_per_vc);
+        std::array<
+            std::array<size_t, tt::tt_fabric::builder_config::num_max_sender_channels>,
+            builder_config::MAX_NUM_VCS>& num_sender_buffer_slots_per_vc,
+        std::array<
+            std::array<size_t, tt::tt_fabric::builder_config::num_max_sender_channels>,
+            builder_config::MAX_NUM_VCS>& num_remote_sender_buffer_slots_per_vc,
+        std::array<
+            std::array<size_t, tt::tt_fabric::builder_config::num_max_receiver_channels>,
+            builder_config::MAX_NUM_VCS>& num_receiver_buffer_slots_per_vc,
+        std::array<
+            std::array<size_t, tt::tt_fabric::builder_config::num_max_receiver_channels>,
+            builder_config::MAX_NUM_VCS>& num_remote_receiver_buffer_slots_per_vc);
 
     // Configuration parameters
-    std::array<size_t, MAX_NUM_VCS> num_used_sender_channels_per_vc = {0, 0};
-    std::array<size_t, MAX_NUM_VCS> num_used_receiver_channels_per_vc = {0, 0};
+    std::array<size_t, builder_config::MAX_NUM_VCS> num_used_sender_channels_per_vc = {0, 0};
+    std::array<size_t, builder_config::MAX_NUM_VCS> num_used_receiver_channels_per_vc = {0, 0};
     size_t channel_buffer_size_bytes = 0;
     size_t available_channel_buffering_space = 0;
     size_t max_l1_loading_size = 0;
@@ -136,35 +140,35 @@ private:
         builder_config::num_sender_channels_with_tensix_config;
 
     // Channel size and buffer information per VC (VC × channel)
-    std::array<std::array<std::size_t, builder_config::num_max_sender_channels>, MAX_NUM_VCS>
+    std::array<std::array<std::size_t, builder_config::num_max_sender_channels>, builder_config::MAX_NUM_VCS>
         sender_channels_size_bytes = {};
-    std::array<std::array<std::size_t, builder_config::num_max_receiver_channels>, MAX_NUM_VCS>
+    std::array<std::array<std::size_t, builder_config::num_max_receiver_channels>, builder_config::MAX_NUM_VCS>
         receiver_channels_size_bytes = {};
-    std::array<std::array<size_t, builder_config::num_max_sender_channels>, MAX_NUM_VCS> sender_channels_num_buffers =
-        {};
-    std::array<std::array<size_t, builder_config::num_max_receiver_channels>, MAX_NUM_VCS>
+    std::array<std::array<size_t, builder_config::num_max_sender_channels>, builder_config::MAX_NUM_VCS>
+        sender_channels_num_buffers = {};
+    std::array<std::array<size_t, builder_config::num_max_receiver_channels>, builder_config::MAX_NUM_VCS>
         receiver_channels_num_buffers = {};
 
     // Remote channels sizes, used to calculate the remote buffer addresses.
-    std::array<std::array<std::size_t, builder_config::num_max_sender_channels>, MAX_NUM_VCS>
+    std::array<std::array<std::size_t, builder_config::num_max_sender_channels>, builder_config::MAX_NUM_VCS>
         remote_sender_channels_size_bytes = {};
-    std::array<std::array<std::size_t, builder_config::num_max_receiver_channels>, MAX_NUM_VCS>
+    std::array<std::array<std::size_t, builder_config::num_max_receiver_channels>, builder_config::MAX_NUM_VCS>
         remote_receiver_channels_size_bytes = {};
     // Remote recv channels number of buffers, use by the local sender channel to check free slots.
-    std::array<std::array<std::size_t, builder_config::num_max_sender_channels>, MAX_NUM_VCS>
+    std::array<std::array<std::size_t, builder_config::num_max_sender_channels>, builder_config::MAX_NUM_VCS>
         remote_sender_channels_num_buffers = {};
-    std::array<std::array<size_t, builder_config::num_max_receiver_channels>, MAX_NUM_VCS>
+    std::array<std::array<size_t, builder_config::num_max_receiver_channels>, builder_config::MAX_NUM_VCS>
         remote_receiver_channels_num_buffers = {};
 
     // Base addresses per VC
-    std::array<std::array<size_t, builder_config::num_max_sender_channels>, MAX_NUM_VCS> sender_channels_base_address =
-        {};
-    std::array<std::array<size_t, builder_config::num_max_receiver_channels>, MAX_NUM_VCS>
+    std::array<std::array<size_t, builder_config::num_max_sender_channels>, builder_config::MAX_NUM_VCS>
+        sender_channels_base_address = {};
+    std::array<std::array<size_t, builder_config::num_max_receiver_channels>, builder_config::MAX_NUM_VCS>
         receiver_channels_base_address = {};
     // the base addr per remote channel, used by local channels.
-    std::array<std::array<size_t, builder_config::num_max_sender_channels>, MAX_NUM_VCS>
+    std::array<std::array<size_t, builder_config::num_max_sender_channels>, builder_config::MAX_NUM_VCS>
         remote_sender_channels_base_address = {};
-    std::array<std::array<size_t, builder_config::num_max_receiver_channels>, MAX_NUM_VCS>
+    std::array<std::array<size_t, builder_config::num_max_receiver_channels>, builder_config::MAX_NUM_VCS>
         remote_receiver_channels_base_address = {};
 };
 
@@ -184,7 +188,7 @@ inline void FabricStaticSizedChannelsAllocator::print(std::ostream& os) const {
     os << "    max_l1_loading_size: 0x" << std::hex << max_l1_loading_size << std::dec << "\n";
 
     // Per-VC channel information
-    for (size_t vc = 0; vc < MAX_NUM_VCS; ++vc) {
+    for (size_t vc = 0; vc < builder_config::MAX_NUM_VCS; ++vc) {
         os << "  VC" << vc << ":\n";
 
         // Sender channels for this VC

--- a/tt_metal/fabric/builder/fabric_static_sized_channels_allocator.hpp
+++ b/tt_metal/fabric/builder/fabric_static_sized_channels_allocator.hpp
@@ -23,14 +23,18 @@ namespace tt::tt_fabric {
  * memory.
  *
  * Each channel is a sequence of 1 or more buffer slots (i.e. packet slots)
+ *
+ * Supports multiple Virtual Channels (VCs) where each VC has its own set of sender/receiver channels.
  */
 class FabricStaticSizedChannelsAllocator : public FabricChannelAllocator {
 public:
+    static constexpr size_t MAX_NUM_VCS = 2;  // VC0 and VC1
+
     FabricStaticSizedChannelsAllocator(
         tt::tt_fabric::Topology topology,
         const FabricEriscDatamoverOptions& options,
-        size_t num_used_sender_channels,
-        size_t num_used_receiver_channels,
+        const std::array<size_t, MAX_NUM_VCS>& num_used_sender_channels_per_vc,
+        const std::array<size_t, MAX_NUM_VCS>& num_used_receiver_channels_per_vc,
         size_t channel_buffer_size_bytes,
         size_t available_channel_buffering_space,
         const std::vector<MemoryRegion>& memory_regions);
@@ -38,35 +42,55 @@ public:
     void emit_ct_args(std::vector<uint32_t>& ct_args) const override;
 
     /**
-     * Get the number of slots for a specific sender channel.
-     * @param channel_id Channel ID
+     * Get the number of slots for a specific sender channel in a VC.
+     * @param vc_id Virtual Channel ID (0 or 1)
+     * @param channel_id Channel ID within the VC
      * @return Number of slots
      */
-    size_t get_sender_channel_number_of_slots(size_t channel_id) const;
+    size_t get_sender_channel_number_of_slots(size_t vc_id, size_t channel_id) const;
 
     /**
-     * Get the base address for a specific sender channel.
-     * @param channel_id Channel ID
+     * Get the base address for a specific sender channel in a VC.
+     * @param vc_id Virtual Channel ID (0 or 1)
+     * @param channel_id Channel ID within the VC
      * @return Base address
      */
-    size_t get_sender_channel_base_address(size_t channel_id) const;
+    size_t get_sender_channel_base_address(size_t vc_id, size_t channel_id) const;
 
     /**
-     * Get the number of slots for a specific receiver channel.
-     * @param channel_id Channel ID
+     * Get the number of slots for a specific receiver channel in a VC.
+     * @param vc_id Virtual Channel ID (0 or 1)
+     * @param channel_id Channel ID within the VC
      * @return Number of slots
      */
-    size_t get_receiver_channel_number_of_slots(size_t channel_id) const;
+    size_t get_receiver_channel_number_of_slots(size_t vc_id, size_t channel_id) const;
 
     /**
-     * Get the base address for a specific receiver channel.
-     * @param channel_id Channel ID
+     * Get the base address for a specific receiver channel in a VC.
+     * @param vc_id Virtual Channel ID (0 or 1)
+     * @param channel_id Channel ID within the VC
      * @return Base address
      */
-    size_t get_receiver_channel_base_address(size_t channel_id) const;
+    size_t get_receiver_channel_base_address(size_t vc_id, size_t channel_id) const;
 
-    size_t get_num_sender_channels() const { return num_used_sender_channels; }
-    size_t get_num_receiver_channels() const { return num_used_receiver_channels; }
+    size_t get_num_sender_channels(size_t vc_id) const { return num_used_sender_channels_per_vc[vc_id]; }
+    size_t get_num_receiver_channels(size_t vc_id) const { return num_used_receiver_channels_per_vc[vc_id]; }
+
+    // Legacy getters (assume VC0 for backward compatibility)
+    size_t get_sender_channel_number_of_slots(size_t channel_id) const {
+        return get_sender_channel_number_of_slots(0, channel_id);
+    }
+    size_t get_sender_channel_base_address(size_t channel_id) const {
+        return get_sender_channel_base_address(0, channel_id);
+    }
+    size_t get_receiver_channel_number_of_slots(size_t channel_id) const {
+        return get_receiver_channel_number_of_slots(0, channel_id);
+    }
+    size_t get_receiver_channel_base_address(size_t channel_id) const {
+        return get_receiver_channel_base_address(0, channel_id);
+    }
+    size_t get_num_sender_channels() const { return get_num_sender_channels(0); }
+    size_t get_num_receiver_channels() const { return get_num_receiver_channels(0); }
 
     // Override virtual print method from base class
     void print(std::ostream& os) const override;
@@ -74,19 +98,23 @@ public:
 private:
     friend class FabricRemoteChannelsAllocator;
     /*
-     * Helper function that decides the number of buffer slots for each channel.
-    */
+     * Helper function that decides the number of buffer slots for each channel per VC.
+     */
     void configure_buffer_slots_helper(
         tt::tt_fabric::Topology topology,
         const tt::tt_fabric::FabricEriscDatamoverOptions& options,
-        std::array<size_t, tt::tt_fabric::builder_config::num_max_sender_channels>& num_sender_buffer_slots,
-        std::array<size_t, tt::tt_fabric::builder_config::num_max_sender_channels>& num_remote_sender_buffer_slots,
-        std::array<size_t, tt::tt_fabric::builder_config::num_max_receiver_channels>& num_receiver_buffer_slots,
-        std::array<size_t, tt::tt_fabric::builder_config::num_max_receiver_channels>& num_remote_receiver_buffer_slots);
+        std::array<std::array<size_t, tt::tt_fabric::builder_config::num_max_sender_channels>, MAX_NUM_VCS>&
+            num_sender_buffer_slots_per_vc,
+        std::array<std::array<size_t, tt::tt_fabric::builder_config::num_max_sender_channels>, MAX_NUM_VCS>&
+            num_remote_sender_buffer_slots_per_vc,
+        std::array<std::array<size_t, tt::tt_fabric::builder_config::num_max_receiver_channels>, MAX_NUM_VCS>&
+            num_receiver_buffer_slots_per_vc,
+        std::array<std::array<size_t, tt::tt_fabric::builder_config::num_max_receiver_channels>, MAX_NUM_VCS>&
+            num_remote_receiver_buffer_slots_per_vc);
 
     // Configuration parameters
-    size_t num_used_sender_channels = 0;
-    size_t num_used_receiver_channels = 0;
+    std::array<size_t, MAX_NUM_VCS> num_used_sender_channels_per_vc = {0, 0};
+    std::array<size_t, MAX_NUM_VCS> num_used_receiver_channels_per_vc = {0, 0};
     size_t channel_buffer_size_bytes = 0;
     size_t available_channel_buffering_space = 0;
     size_t max_l1_loading_size = 0;
@@ -96,25 +124,37 @@ private:
     static constexpr size_t num_sender_channels_with_tensix_config =
         builder_config::num_sender_channels_with_tensix_config;
 
-    // Channel size and buffer information
-    std::array<std::size_t, builder_config::num_max_sender_channels> sender_channels_size_bytes = {};
-    std::array<std::size_t, builder_config::num_max_receiver_channels> receiver_channels_size_bytes = {};
-    std::array<size_t, builder_config::num_max_sender_channels> sender_channels_num_buffers = {};
-    std::array<size_t, builder_config::num_max_receiver_channels> receiver_channels_num_buffers = {};
+    // Channel size and buffer information per VC (VC × channel)
+    std::array<std::array<std::size_t, builder_config::num_max_sender_channels>, MAX_NUM_VCS>
+        sender_channels_size_bytes = {};
+    std::array<std::array<std::size_t, builder_config::num_max_receiver_channels>, MAX_NUM_VCS>
+        receiver_channels_size_bytes = {};
+    std::array<std::array<size_t, builder_config::num_max_sender_channels>, MAX_NUM_VCS> sender_channels_num_buffers =
+        {};
+    std::array<std::array<size_t, builder_config::num_max_receiver_channels>, MAX_NUM_VCS>
+        receiver_channels_num_buffers = {};
 
     // Remote channels sizes, used to calculate the remote buffer addresses.
-    std::array<std::size_t, builder_config::num_max_sender_channels> remote_sender_channels_size_bytes = {};
-    std::array<std::size_t, builder_config::num_max_receiver_channels> remote_receiver_channels_size_bytes = {};
+    std::array<std::array<std::size_t, builder_config::num_max_sender_channels>, MAX_NUM_VCS>
+        remote_sender_channels_size_bytes = {};
+    std::array<std::array<std::size_t, builder_config::num_max_receiver_channels>, MAX_NUM_VCS>
+        remote_receiver_channels_size_bytes = {};
     // Remote recv channels number of buffers, use by the local sender channel to check free slots.
-    std::array<std::size_t, builder_config::num_max_sender_channels> remote_sender_channels_num_buffers = {};
-    std::array<size_t, builder_config::num_max_receiver_channels> remote_receiver_channels_num_buffers = {};
-    // Downstream sender channels number of buffers, used by the local receiver channel to check free slots.
+    std::array<std::array<std::size_t, builder_config::num_max_sender_channels>, MAX_NUM_VCS>
+        remote_sender_channels_num_buffers = {};
+    std::array<std::array<size_t, builder_config::num_max_receiver_channels>, MAX_NUM_VCS>
+        remote_receiver_channels_num_buffers = {};
 
-    std::array<size_t, builder_config::num_max_sender_channels> sender_channels_base_address = {};
-    std::array<size_t, builder_config::num_max_receiver_channels> receiver_channels_base_address = {};
+    // Base addresses per VC
+    std::array<std::array<size_t, builder_config::num_max_sender_channels>, MAX_NUM_VCS> sender_channels_base_address =
+        {};
+    std::array<std::array<size_t, builder_config::num_max_receiver_channels>, MAX_NUM_VCS>
+        receiver_channels_base_address = {};
     // the base addr per remote channel, used by local channels.
-    std::array<size_t, builder_config::num_max_sender_channels> remote_sender_channels_base_address = {};
-    std::array<size_t, builder_config::num_max_receiver_channels> remote_receiver_channels_base_address = {};
+    std::array<std::array<size_t, builder_config::num_max_sender_channels>, MAX_NUM_VCS>
+        remote_sender_channels_base_address = {};
+    std::array<std::array<size_t, builder_config::num_max_receiver_channels>, MAX_NUM_VCS>
+        remote_receiver_channels_base_address = {};
 };
 
 // Implementation of virtual print method
@@ -123,43 +163,50 @@ inline void FabricStaticSizedChannelsAllocator::print(std::ostream& os) const {
 
     // Configuration parameters
     os << "  Configuration:\n";
-    os << "    num_used_sender_channels: " << num_used_sender_channels << "\n";
-    os << "    num_used_receiver_channels: " << num_used_receiver_channels << "\n";
+    os << "    num_used_sender_channels_per_vc: [" << num_used_sender_channels_per_vc[0] << ", "
+       << num_used_sender_channels_per_vc[1] << "]\n";
+    os << "    num_used_receiver_channels_per_vc: [" << num_used_receiver_channels_per_vc[0] << ", "
+       << num_used_receiver_channels_per_vc[1] << "]\n";
     os << "    channel_buffer_size_bytes: " << channel_buffer_size_bytes << " B\n";
     os << "    available_channel_buffering_space: " << available_channel_buffering_space << " B\n";
     os << "    buffer_region_start: 0x" << std::hex << buffer_region_start << std::dec << "\n";
     os << "    max_l1_loading_size: 0x" << std::hex << max_l1_loading_size << std::dec << "\n";
 
-    // Sender channels
-    if (num_used_sender_channels > 0) {
-        os << "  Sender Channels:\n";
-        for (size_t i = 0; i < num_used_sender_channels; ++i) {
-            os << "    Channel " << i << ":\n";
-            os << "      base_address: 0x" << std::hex << sender_channels_base_address[i] << std::dec << "\n";
-            os << "      num_buffers: " << sender_channels_num_buffers[i] << "\n";
-            os << "      size_bytes: " << sender_channels_size_bytes[i] << " B\n";
-            if (remote_sender_channels_num_buffers[i] > 0) {
-                os << "      remote_base_address: 0x" << std::hex << remote_sender_channels_base_address[i] << std::dec
-                   << "\n";
-                os << "      remote_num_buffers: " << remote_sender_channels_num_buffers[i] << "\n";
-                os << "      remote_size_bytes: " << remote_sender_channels_size_bytes[i] << " B\n";
+    // Per-VC channel information
+    for (size_t vc = 0; vc < MAX_NUM_VCS; ++vc) {
+        os << "  VC" << vc << ":\n";
+
+        // Sender channels for this VC
+        if (num_used_sender_channels_per_vc[vc] > 0) {
+            os << "    Sender Channels:\n";
+            for (size_t i = 0; i < num_used_sender_channels_per_vc[vc]; ++i) {
+                os << "      Channel " << i << ":\n";
+                os << "        base_address: 0x" << std::hex << sender_channels_base_address[vc][i] << std::dec << "\n";
+                os << "        num_buffers: " << sender_channels_num_buffers[vc][i] << "\n";
+                os << "        size_bytes: " << sender_channels_size_bytes[vc][i] << " B\n";
+                if (remote_sender_channels_num_buffers[vc][i] > 0) {
+                    os << "        remote_base_address: 0x" << std::hex << remote_sender_channels_base_address[vc][i]
+                       << std::dec << "\n";
+                    os << "        remote_num_buffers: " << remote_sender_channels_num_buffers[vc][i] << "\n";
+                    os << "        remote_size_bytes: " << remote_sender_channels_size_bytes[vc][i] << " B\n";
+                }
             }
         }
-    }
 
-    // Receiver channels
-    if (num_used_receiver_channels > 0) {
-        os << "  Receiver Channels:\n";
-        for (size_t i = 0; i < num_used_receiver_channels; ++i) {
-            os << "    Channel " << i << ":\n";
-            os << "      base_address: 0x" << std::hex << receiver_channels_base_address[i] << std::dec << "\n";
-            os << "      num_buffers: " << receiver_channels_num_buffers[i] << "\n";
-            os << "      size_bytes: " << receiver_channels_size_bytes[i] << " B\n";
-            if (remote_receiver_channels_num_buffers[i] > 0) {
-                os << "      remote_base_address: 0x" << std::hex << remote_receiver_channels_base_address[i]
-                   << std::dec << "\n";
-                os << "      remote_num_buffers: " << remote_receiver_channels_num_buffers[i] << "\n";
-                os << "      remote_size_bytes: " << remote_receiver_channels_size_bytes[i] << " B\n";
+        // Receiver channels for this VC
+        if (num_used_receiver_channels_per_vc[vc] > 0) {
+            os << "    Receiver Channels:\n";
+            for (size_t i = 0; i < num_used_receiver_channels_per_vc[vc]; ++i) {
+                os << "      Channel " << i << ":\n";
+                os << "      base_address: 0x" << std::hex << receiver_channels_base_address[vc][i] << std::dec << "\n";
+                os << "        num_buffers: " << receiver_channels_num_buffers[vc][i] << "\n";
+                os << "        size_bytes: " << receiver_channels_size_bytes[vc][i] << " B\n";
+                if (remote_receiver_channels_num_buffers[vc][i] > 0) {
+                    os << "        remote_base_address: 0x" << std::hex << remote_receiver_channels_base_address[vc][i]
+                       << std::dec << "\n";
+                    os << "        remote_num_buffers: " << remote_receiver_channels_num_buffers[vc][i] << "\n";
+                    os << "        remote_size_bytes: " << remote_receiver_channels_size_bytes[vc][i] << " B\n";
+                }
             }
         }
     }

--- a/tt_metal/fabric/erisc_datamover_builder.cpp
+++ b/tt_metal/fabric/erisc_datamover_builder.cpp
@@ -387,11 +387,12 @@ FabricEriscDatamoverConfig::FabricEriscDatamoverConfig(
 
     // Determine if VC1 is needed based on mesh count
     // VC1 is required for inter-mesh routing (when mesh_count > 1)
+    // Note: is_2D_routing already checks for Mesh/Torus topology, so no need to check topology again
     // However, MUX mode always uses VC0 only (no VC1)
     const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
     auto user_mesh_ids = control_plane.get_mesh_graph().get_mesh_ids();
     size_t mesh_count = user_mesh_ids.size();
-    bool needs_vc1 = (topology == Topology::Mesh || topology == Topology::Torus) && is_2D_routing && (mesh_count > 1);
+    bool needs_vc1 = is_2D_routing && (mesh_count > 1);
 
     // MUX mode always uses VC0 only, disable VC1
     if (options.fabric_tensix_config == tt::tt_fabric::FabricTensixConfig::MUX) {

--- a/tt_metal/fabric/erisc_datamover_builder.cpp
+++ b/tt_metal/fabric/erisc_datamover_builder.cpp
@@ -384,24 +384,62 @@ FabricEriscDatamoverConfig::FabricEriscDatamoverConfig(
     const bool is_2D_routing = FabricContext::is_2D_topology(topology);
 
     this->channel_buffer_size_bytes = channel_buffer_size_bytes;
-    this->num_used_sender_channels = builder_config::get_sender_channel_count(is_2D_routing);
-    this->num_used_receiver_channels = builder_config::get_receiver_channel_count(is_2D_routing);
 
-    // Default, assuming deadlock avoidance is enabled
-    // -1 to discount for the tensix worker channel
-    this->num_fwd_paths = this->num_used_sender_channels - 1;
+    // Determine if VC1 is needed based on mesh count
+    // VC1 is required for inter-mesh routing (when mesh_count > 1)
+    const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+    auto user_mesh_ids = control_plane.get_user_physical_mesh_ids();
+    size_t mesh_count = user_mesh_ids.size();
+    bool needs_vc1 = (topology == Topology::Mesh || topology == Topology::Torus) && is_2D_routing && (mesh_count > 1);
 
-    // TODO: https://github.com/tenstorrent/tt-metal/issues/32561
-    // Remove VC1 adjustments once VC1 sender/receiver channels are fully implemented
-    // For 2D routing (Mesh/Torus), VC1 channels (sender channels 4-6, receiver channel 1) are not yet implemented
-    // so we exclude them from allocation
-    // Also diccount for the Z edge channel
-    if ((topology == Topology::Mesh || topology == Topology::Torus) && is_2D_routing) {
-        // discount vc1 and z channels.
-        this->num_used_sender_channels -= builder_config::get_vc1_downstream_edm_count(is_2D_routing) + 1;
-        this->num_used_receiver_channels = 1;  // Only VC0 receiver implemented
-        this->num_fwd_paths -= builder_config::get_vc1_downstream_edm_count(is_2D_routing) + 1;
+    // Get per-VC channel counts based on routing type
+    auto sender_channels_per_vc = builder_config::get_sender_channel_count_per_vc(is_2D_routing);
+    auto receiver_channels_per_vc = builder_config::get_receiver_channel_count_per_vc(is_2D_routing);
+
+    // Distribute channels between VC0 and VC1 based on mesh count
+    if (needs_vc1) {
+        // Multi-mesh: Use both VC0 and VC1
+        this->num_used_sender_channels_per_vc[0] = sender_channels_per_vc[0];  // VC0 (intra-mesh)
+        this->num_used_sender_channels_per_vc[1] = sender_channels_per_vc[1];  // VC1 (inter-mesh)
+
+        this->num_used_receiver_channels_per_vc[0] = receiver_channels_per_vc[0];  // VC0 receiver
+        this->num_used_receiver_channels_per_vc[1] = receiver_channels_per_vc[1];  // VC1 receiver
+
+        log_debug(tt::LogFabric, "Multi-mesh topology (mesh_count={}): Allocating VC0 and VC1 channels", mesh_count);
+        log_debug(
+            tt::LogFabric,
+            "  VC0: {} senders, {} receivers (intra-mesh)",
+            this->num_used_sender_channels_per_vc[0],
+            this->num_used_receiver_channels_per_vc[0]);
+        log_debug(
+            tt::LogFabric,
+            "  VC1: {} senders, {} receivers (inter-mesh)",
+            this->num_used_sender_channels_per_vc[1],
+            this->num_used_receiver_channels_per_vc[1]);
+    } else {
+        // Single mesh or 1D: All channels in VC0, no VC1
+        this->num_used_sender_channels_per_vc[0] = sender_channels_per_vc[0];
+        this->num_used_sender_channels_per_vc[1] = 0;
+
+        this->num_used_receiver_channels_per_vc[0] = receiver_channels_per_vc[0];
+        this->num_used_receiver_channels_per_vc[1] = 0;
+
+        log_debug(tt::LogFabric, "Single-mesh or 1D topology (mesh_count={}): All channels in VC0", mesh_count);
+        log_debug(
+            tt::LogFabric,
+            "  VC0: {} senders, {} receivers",
+            this->num_used_sender_channels_per_vc[0],
+            this->num_used_receiver_channels_per_vc[0]);
     }
+
+    // Set total counts for backward compatibility
+    this->num_used_sender_channels =
+        this->num_used_sender_channels_per_vc[0] + this->num_used_sender_channels_per_vc[1];
+    this->num_used_receiver_channels =
+        this->num_used_receiver_channels_per_vc[0] + this->num_used_receiver_channels_per_vc[1];
+
+    // num_fwd_paths = total sender channels - 1 (worker channel)
+    this->num_fwd_paths = this->num_used_sender_channels - 1;
 
     for (uint32_t i = 0; i < this->num_used_sender_channels; i++) {
         TT_FATAL(
@@ -459,18 +497,12 @@ FabricEriscDatamoverConfig::FabricEriscDatamoverConfig(
     auto remote_channels_recipe = tt::tt_fabric::FabricRouterRecipe::create_default_single_static_pool_recipe(
         0, this->num_used_receiver_channels);
 
-    // Create the single static pool allocator
-    // For now, assign all channels to VC0, VC1 gets 0 channels (future: distribute based on topology)
-    std::array<size_t, tt::tt_fabric::FabricStaticSizedChannelsAllocator::MAX_NUM_VCS> num_sender_channels_per_vc = {
-        this->num_used_sender_channels, 0};
-    std::array<size_t, tt::tt_fabric::FabricStaticSizedChannelsAllocator::MAX_NUM_VCS> num_receiver_channels_per_vc = {
-        this->num_used_receiver_channels, 0};
-
+    // Create the single static pool allocator with per-VC channel distribution
     auto static_allocator = std::make_shared<tt::tt_fabric::FabricStaticSizedChannelsAllocator>(
         topology,
         options,
-        num_sender_channels_per_vc,
-        num_receiver_channels_per_vc,
+        this->num_used_sender_channels_per_vc,
+        this->num_used_receiver_channels_per_vc,
         this->channel_buffer_size_bytes,
         available_channel_buffering_space,
         this->available_buffer_memory_regions);

--- a/tt_metal/fabric/erisc_datamover_builder.cpp
+++ b/tt_metal/fabric/erisc_datamover_builder.cpp
@@ -460,11 +460,17 @@ FabricEriscDatamoverConfig::FabricEriscDatamoverConfig(
         0, this->num_used_receiver_channels);
 
     // Create the single static pool allocator
+    // For now, assign all channels to VC0, VC1 gets 0 channels (future: distribute based on topology)
+    std::array<size_t, tt::tt_fabric::FabricStaticSizedChannelsAllocator::MAX_NUM_VCS> num_sender_channels_per_vc = {
+        this->num_used_sender_channels, 0};
+    std::array<size_t, tt::tt_fabric::FabricStaticSizedChannelsAllocator::MAX_NUM_VCS> num_receiver_channels_per_vc = {
+        this->num_used_receiver_channels, 0};
+
     auto static_allocator = std::make_shared<tt::tt_fabric::FabricStaticSizedChannelsAllocator>(
         topology,
         options,
-        this->num_used_sender_channels,
-        this->num_used_receiver_channels,
+        num_sender_channels_per_vc,
+        num_receiver_channels_per_vc,
         this->channel_buffer_size_bytes,
         available_channel_buffering_space,
         this->available_buffer_memory_regions);

--- a/tt_metal/fabric/erisc_datamover_builder.cpp
+++ b/tt_metal/fabric/erisc_datamover_builder.cpp
@@ -446,8 +446,8 @@ FabricEriscDatamoverConfig::FabricEriscDatamoverConfig(
         this->num_used_receiver_channels_per_vc[0] + this->num_used_receiver_channels_per_vc[1];
 
     // Update is_sender_channel_serviced_ to mark unused channels as false
-    // Used channels (0 to num_used_sender_channels - 1) are already set by update_sender_channel_servicing
-    // Unused channels (num_used_sender_channels to num_max_sender_channels - 1) should be false
+    // Used channels (0 to num_used_sender_channels - 1) are set by update_sender_channel_servicing in MUX mode,
+    // and by configure_risc_settings in non-MUX modes. Unused channels (num_used_sender_channels to num_max_sender_channels - 1) should be false.
     for (auto& risc_config : this->risc_configs) {
         for (size_t i = this->num_used_sender_channels; i < builder_config::num_max_sender_channels; i++) {
             risc_config.set_sender_channel_serviced(i, false);

--- a/tt_metal/fabric/erisc_datamover_builder.hpp
+++ b/tt_metal/fabric/erisc_datamover_builder.hpp
@@ -286,8 +286,10 @@ struct FabricEriscDatamoverConfig {
 
     std::size_t channel_buffer_size_bytes = 0;
 
-    std::size_t num_used_sender_channels = 0;   // duplicate in allocator... don't modify
-    std::size_t num_used_receiver_channels = 0; // duplicate in allocator... don't modify
+    std::size_t num_used_sender_channels = 0;    // Total across all VCs (duplicate in allocator... don't modify)
+    std::size_t num_used_receiver_channels = 0;  // Total across all VCs (duplicate in allocator... don't modify)
+    std::array<std::size_t, 2> num_used_sender_channels_per_vc = {0, 0};    // Per-VC sender channel counts
+    std::array<std::size_t, 2> num_used_receiver_channels_per_vc = {0, 0};  // Per-VC receiver channel counts
     std::size_t num_fwd_paths = 0;
     std::size_t sender_txq_id = 0;
     std::size_t receiver_txq_id = 0;

--- a/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_router_ct_args.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_router_ct_args.hpp
@@ -183,8 +183,6 @@ constexpr size_t CHANNEL_POOL_COLLECTION_IDX = ANOTHER_SPECIAL_TAG_IDX + 1;
 using channel_pools_args =
     ChannelPoolCollection<CHANNEL_POOL_COLLECTION_IDX, NUM_SENDER_CHANNELS, NUM_RECEIVER_CHANNELS>;
 constexpr size_t NUM_POOLS = channel_pools_args::num_channel_pools;
-static_assert(NUM_SENDER_CHANNELS <= 5, "NUM_SENDER_CHANNELS must be less than or equal to 5");
-static_assert(NUM_RECEIVER_CHANNELS <= 2, "NUM_RECEIVER_CHANNELS must be less than or equal to 2");
 // Parse channel-to-pool mappings (after all pool data)
 constexpr size_t CHANNEL_MAPPINGS_START_SPECIAL_TAG_IDX  = CHANNEL_POOL_COLLECTION_IDX + channel_pools_args::GET_NUM_ARGS_CONSUMED();
 static_assert(


### PR DESCRIPTION
Update static channel allocator to be VC aware and allocate channel buffers per VC.
This is necessary to support different number of buffers for sender/receiver channels per VC.
Enable VC1 for multi-mesh topologies.

### Ticket
https://github.com/tenstorrent/tt-metal/issues/32580

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist

- [x] [T3000 nightly tests] https://github.com/tenstorrent/tt-metal/actions/runs/20040893105
- [x] [T3000 unit tests] https://github.com/tenstorrent/tt-metal/actions/runs/20040892696
- [x] [All post commit] https://github.com/tenstorrent/tt-metal/actions/runs/20040892179
- [x] [Blackhole Post commit] https://github.com/tenstorrent/tt-metal/actions/runs/20040892522
- [x] [Galaxy quick] https://github.com/tenstorrent/tt-metal/actions/runs/20043885035

### Local Testing
#### WH Galaxy
- [x] tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_sanity_common.yaml
- [x] tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_stability_6U_galaxy.yaml
- [x] tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_deadlock_stability_6U_galaxy.yaml
- [x] tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_ubench_6U_galaxy_quick.yaml
- [x] tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_ubench_2d_torus_6U_galaxy.yaml

#### BH Galaxy
- [x] tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_sanity_common.yaml
- [x] tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_stability_6U_galaxy.yaml
- [x] tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_deadlock_stability_bh_6U_galaxy.yaml

#### WH LB
- [x] tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_sanity_common.yaml
- [x] tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_stability.yaml
- [x] tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_ubench_at_least_2x2_mesh.yaml
- [x]  ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="\*Fabric\*Fixture.*"
