### PR TITLE
performance-avoid-endl

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -145,7 +145,6 @@ Checks: >
   -modernize-use-std-numbers,
   -modernize-use-trailing-return-type,
   -modernize-use-transparent-functors,
-  -performance-avoid-endl,
   -performance-enum-size,
   -performance-faster-string-find,
   -performance-inefficient-string-concatenation,

--- a/tests/tt_metal/distributed/multiprocess/test_visible_devices_mp.cpp
+++ b/tests/tt_metal/distributed/multiprocess/test_visible_devices_mp.cpp
@@ -28,11 +28,11 @@ TEST(VisibleDevicesMPTest, ValidateDeviceRatio) {
     const char* visible_devices_env = std::getenv("TT_VISIBLE_DEVICES");
     std::string visible_devices = visible_devices_env ? visible_devices_env : "<not set>";
 
-    std::cout << "Device configuration summary:" << std::endl;
-    std::cout << "  TT_VISIBLE_DEVICES: " << visible_devices << std::endl;
-    std::cout << "  PCIe devices: " << num_pcie << std::endl;
-    std::cout << "  Total available devices: " << num_available << std::endl;
-    std::cout << "  Ratio: " << (num_pcie > 0 ? static_cast<double>(num_available) / num_pcie : 0) << std::endl;
+    std::cout << "Device configuration summary:" << '\n';
+    std::cout << "  TT_VISIBLE_DEVICES: " << visible_devices << '\n';
+    std::cout << "  PCIe devices: " << num_pcie << '\n';
+    std::cout << "  Total available devices: " << num_available << '\n';
+    std::cout << "  Ratio: " << (num_pcie > 0 ? static_cast<double>(num_available) / num_pcie : 0) << '\n';
 }
 
 }  // namespace

--- a/tests/tt_metal/distributed/multiprocess/test_visible_devices_mp.cpp
+++ b/tests/tt_metal/distributed/multiprocess/test_visible_devices_mp.cpp
@@ -28,7 +28,7 @@ TEST(VisibleDevicesMPTest, ValidateDeviceRatio) {
     const char* visible_devices_env = std::getenv("TT_VISIBLE_DEVICES");
     std::string visible_devices = visible_devices_env ? visible_devices_env : "<not set>";
 
-    std::cout << "Device configuration summary:" << '\n';
+    std::cout << "Device configuration summary:\n";
     std::cout << "  TT_VISIBLE_DEVICES: " << visible_devices << '\n';
     std::cout << "  PCIe devices: " << num_pcie << '\n';
     std::cout << "  Total available devices: " << num_available << '\n';

--- a/tests/tt_metal/test_utils/deprecated/tensor.hpp
+++ b/tests/tt_metal/test_utils/deprecated/tensor.hpp
@@ -61,13 +61,13 @@ void print(const Tensor<T>& tensor) {
                                (tensor_shape[3] * tensor_shape[2] * tensor_shape[1] * w);
                     std::cout << tensor_data[idx] << ",";
                 }
-                std::cout << "]" << '\n';
+                std::cout << "]\n";
             }
-            std::cout << "]" << '\n';
+            std::cout << "]\n";
         }
-        std::cout << "]" << '\n';
+        std::cout << "]\n";
     }
-    std::cout << "]" << '\n';
+    std::cout << "]\n";
 }
 
 template <class T>

--- a/tests/tt_metal/test_utils/deprecated/tensor.hpp
+++ b/tests/tt_metal/test_utils/deprecated/tensor.hpp
@@ -61,13 +61,13 @@ void print(const Tensor<T>& tensor) {
                                (tensor_shape[3] * tensor_shape[2] * tensor_shape[1] * w);
                     std::cout << tensor_data[idx] << ",";
                 }
-                std::cout << "]" << std::endl;
+                std::cout << "]" << '\n';
             }
-            std::cout << "]" << std::endl;
+            std::cout << "]" << '\n';
         }
-        std::cout << "]" << std::endl;
+        std::cout << "]" << '\n';
     }
-    std::cout << "]" << std::endl;
+    std::cout << "]" << '\n';
 }
 
 template <class T>

--- a/tests/tt_metal/test_utils/print_helpers.hpp
+++ b/tests/tt_metal/test_utils/print_helpers.hpp
@@ -14,7 +14,7 @@ void print_vector(const std::vector<T>& vec) {
     for (int i = 0; i < vec.size(); i++) {
         std::cout << vec.at(i) << ", ";
     }
-    std::cout << std::endl;
+    std::cout << '\n';
 }
 /// @brief generic vector printer with fixed numel per row
 /// @tparam T
@@ -23,11 +23,11 @@ template <typename T>
 void print_vector_fixed_numel_per_row(const std::vector<T>& vec, const unsigned int numel_per_row) {
     for (int i = 0; i < vec.size(); i++) {
         if ((i % numel_per_row) == 0) {
-            std::cout << std::endl;
+            std::cout << '\n';
         }
         std::cout << vec.at(i) << ", ";
     }
-    std::cout << std::endl;
+    std::cout << '\n';
 }
 }  // namespace test_utils
 }  // namespace tt

--- a/tests/tt_metal/test_utils/test_common.hpp
+++ b/tests/tt_metal/test_utils/test_common.hpp
@@ -239,7 +239,7 @@ inline void validate_remaining_args(const std::vector<std::string>& remaining_ar
         // Only executable is left, so all good
         return;
     }
-    std::cout << "Remaining test_args:" << '\n';
+    std::cout << "Remaining test_args:\n";
     for (int i = 1; i < remaining_args.size(); i++) {
         std::cout << "\t" << remaining_args.at(i) << '\n';
     }

--- a/tests/tt_metal/test_utils/test_common.hpp
+++ b/tests/tt_metal/test_utils/test_common.hpp
@@ -239,9 +239,9 @@ inline void validate_remaining_args(const std::vector<std::string>& remaining_ar
         // Only executable is left, so all good
         return;
     }
-    std::cout << "Remaining test_args:" << std::endl;
+    std::cout << "Remaining test_args:" << '\n';
     for (int i = 1; i < remaining_args.size(); i++) {
-        std::cout << "\t" << remaining_args.at(i) << std::endl;
+        std::cout << "\t" << remaining_args.at(i) << '\n';
     }
     throw std::runtime_error("Not all test_args were parsed");
 }

--- a/tests/tt_metal/tt_fabric/system_health/test_system_health.cpp
+++ b/tests/tt_metal/tt_fabric/system_health/test_system_health.cpp
@@ -264,7 +264,7 @@ TEST(Cluster, ReportSystemHealth) {
             unique_chip_ids[chip_id] = chip_id;
         }
     }
-    ss << "Found " << unique_chip_ids.size() << " chips in cluster:" << '\n';
+    ss << "Found " << unique_chip_ids.size() << " chips in cluster:\n";
 
     auto cluster_type = cluster.get_cluster_type();
 

--- a/tests/tt_metal/tt_fabric/system_health/test_system_health.cpp
+++ b/tests/tt_metal/tt_fabric/system_health/test_system_health.cpp
@@ -264,7 +264,7 @@ TEST(Cluster, ReportSystemHealth) {
             unique_chip_ids[chip_id] = chip_id;
         }
     }
-    ss << "Found " << unique_chip_ids.size() << " chips in cluster:" << std::endl;
+    ss << "Found " << unique_chip_ids.size() << " chips in cluster:" << '\n';
 
     auto cluster_type = cluster.get_cluster_type();
 
@@ -277,7 +277,7 @@ TEST(Cluster, ReportSystemHealth) {
         if (not physical_loc.empty()) {
             chip_id_ss << " " << physical_loc;
         }
-        ss << chip_id_ss.str() << std::endl;
+        ss << chip_id_ss.str() << '\n';
         for (const auto& [eth_core, chan] : soc_desc.logical_eth_core_to_chan_map) {
             if (get_connector_type(chip_id, eth_core, chan, cluster_type) == ConnectorType::UNUSED) {
                 continue;
@@ -331,9 +331,9 @@ TEST(Cluster, ReportSystemHealth) {
                 eth_ss << " link DOWN/unconnected " << connection_type;
                 unexpected_system_states.push_back(chip_id_ss.str() + eth_ss.str());
             }
-            ss << eth_ss.str() << std::endl;
+            ss << eth_ss.str() << '\n';
         }
-        ss << std::endl;
+        ss << '\n';
     }
     log_info(tt::LogTest, "{}", ss.str());
 

--- a/tests/tt_metal/tt_metal/api/test_direct.cpp
+++ b/tests/tt_metal/tt_metal/api/test_direct.cpp
@@ -105,7 +105,7 @@ bool reader_only(
     tt_metal::detail::ReadFromDeviceL1(device, reader_core, l1_byte_address, byte_size, dest_core_data);
     pass &= (dest_core_data == inputs);
     if (not pass) {
-        std::cout << "Mismatch at Core: " << reader_core.str() << std::endl;
+        std::cout << "Mismatch at Core: " << reader_core.str() << '\n';
     }
     return pass;
 }
@@ -174,7 +174,7 @@ bool writer_only(
     tt_metal::detail::ReadFromBuffer(output_dram_buffer, dest_buffer_data);
     pass &= (dest_buffer_data == inputs);
     if (not pass) {
-        std::cout << "Mismatch at Core: " << writer_core.str() << std::endl;
+        std::cout << "Mismatch at Core: " << writer_core.str() << '\n';
     }
     return pass;
 }

--- a/tests/tt_metal/tt_metal/api/test_semaphores.cpp
+++ b/tests/tt_metal/tt_metal/api/test_semaphores.cpp
@@ -142,7 +142,7 @@ void try_creating_more_than_max_num_semaphores(
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     auto& program = workload.get_programs().at(device_range);
     create_and_read_max_num_semaphores(std::move(mesh_device), workload, core_range);
-    std::cout << "created max num semaphores" << '\n';
+    std::cout << "created max num semaphores\n";
     constexpr static uint32_t val = 5;
     ASSERT_ANY_THROW(tt_metal::CreateSemaphore(program, core_range, val));
 }

--- a/tests/tt_metal/tt_metal/api/test_semaphores.cpp
+++ b/tests/tt_metal/tt_metal/api/test_semaphores.cpp
@@ -142,7 +142,7 @@ void try_creating_more_than_max_num_semaphores(
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     auto& program = workload.get_programs().at(device_range);
     create_and_read_max_num_semaphores(std::move(mesh_device), workload, core_range);
-    std::cout << "created max num semaphores" << std::endl;
+    std::cout << "created max num semaphores" << '\n';
     constexpr static uint32_t val = 5;
     ASSERT_ANY_THROW(tt_metal::CreateSemaphore(program, core_range, val));
 }

--- a/tests/tt_metal/tt_metal/common/matmul_test_utils.hpp
+++ b/tests/tt_metal/tt_metal/common/matmul_test_utils.hpp
@@ -67,14 +67,14 @@ inline std::vector<bfloat16> get_col_slice(
 }
 
 inline void print_faces(std::vector<bfloat16> data, const std::string& name) {
-    std::cout << name << ": " << std::endl;
+    std::cout << name << ": " << '\n';
 
     int tile_index = 0;
     int face_index = 0;
     for (int i = 0; i < data.size(); i++) {
         if (i % 256 == 0) {
-            std::cout << "Tile " << tile_index / 4 << std::endl;
-            std::cout << "Face = " << face_index << std::endl;
+            std::cout << "Tile " << tile_index / 4 << '\n';
+            std::cout << "Face = " << face_index << '\n';
             face_index++;
             tile_index++;
             if (face_index == 4) {
@@ -83,10 +83,10 @@ inline void print_faces(std::vector<bfloat16> data, const std::string& name) {
         }
         std::cout << static_cast<float>(data.at(i)) << ", ";
         if ((i + 1) % 16 == 0) {
-            std::cout << std::endl;
+            std::cout << '\n';
         }
     }
-    std::cout << std::endl;
+    std::cout << '\n';
 }
 
 // Transpose 2D matrix of tiles so that its column major of tiles instead of row major.

--- a/tests/tt_metal/tt_metal/common/matmul_test_utils.hpp
+++ b/tests/tt_metal/tt_metal/common/matmul_test_utils.hpp
@@ -67,7 +67,7 @@ inline std::vector<bfloat16> get_col_slice(
 }
 
 inline void print_faces(std::vector<bfloat16> data, const std::string& name) {
-    std::cout << name << ": " << '\n';
+    std::cout << name << ": \n";
 
     int tile_index = 0;
     int face_index = 0;

--- a/tests/tt_metal/tt_metal/debug_tools/debug_tools_test_utils.hpp
+++ b/tests/tt_metal/tt_metal/debug_tools/debug_tools_test_utils.hpp
@@ -238,7 +238,7 @@ inline bool DeleteLinesStartingWith(const std::string& file_name, const std::str
     }
     log_file.close();
     if (!OpenFile(file_name, log_file, std::fstream::out | std::fstream::trunc)) {
-        std::cout << "Could not open file " << file_name << " for writing!" << std::endl;
+        std::cout << "Could not open file " << file_name << " for writing!" << '\n';
         return false;
     }
     log_file << content;

--- a/tests/tt_metal/tt_metal/debug_tools/debug_tools_test_utils.hpp
+++ b/tests/tt_metal/tt_metal/debug_tools/debug_tools_test_utils.hpp
@@ -238,7 +238,7 @@ inline bool DeleteLinesStartingWith(const std::string& file_name, const std::str
     }
     log_file.close();
     if (!OpenFile(file_name, log_file, std::fstream::out | std::fstream::trunc)) {
-        std::cout << "Could not open file " << file_name << " for writing!" << '\n';
+        std::cout << "Could not open file " << file_name << " for writing!\n";
         return false;
     }
     log_file << content;

--- a/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_tensix_dest.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_tensix_dest.cpp
@@ -78,7 +78,7 @@ public:
             }
             print_datum(ss, data[i]);
         }
-        ss << std::endl;
+        ss << '\n';
     }
 
     virtual size_t get_elements_per_line() const = 0;
@@ -90,10 +90,10 @@ protected:
 
     void print_new_line(std::stringstream& ss, uint32_t i) {
         if (i > 0) {
-            ss << std::endl;
+            ss << '\n';
         }
         if (i % get_elements_per_tile() == 0) {
-            ss << "Tile ID = " << i / get_elements_per_tile() << std::endl;
+            ss << "Tile ID = " << i / get_elements_per_tile() << '\n';
         }
     }
 };

--- a/tests/tt_metal/tt_metal/device/test_device.cpp
+++ b/tests/tt_metal/tt_metal/device/test_device.cpp
@@ -107,7 +107,7 @@ bool dram_ping(
         tt_metal::detail::ReadFromDeviceDRAMChannel(device, channel, dram_byte_address, byte_size, dest_channel_data);
         pass &= (dest_channel_data == inputs);
         if (not pass) {
-            std::cout << "Mismatch at Channel: " << channel << std::endl;
+            std::cout << "Mismatch at Channel: " << channel << '\n';
         }
     }
     return pass;

--- a/tests/tt_metal/tt_metal/device/test_galaxy_cluster_api.cpp
+++ b/tests/tt_metal/tt_metal/device/test_galaxy_cluster_api.cpp
@@ -121,13 +121,13 @@ TEST_F(GalaxyFixture, DISABLED_ActiveEthValidateLinksBetweenMMIOAndGalaxyChips) 
             }
             ASSERT_TRUE(num_mmio_chips_that_curr_chip_is_linked_to <= 1)
                 << "Detected " << num_mmio_chips_that_curr_chip_is_linked_to << " MMIO chips that chip " << device_id
-                << " is linked to" << '\n';
+                << " is linked to\n";
         } else {
             const uint32_t num_chips_that_curr_chip_is_linked_to = connected_device_ids.size();
             const bool do_both_links_go_to_separate_devices = num_chips_that_curr_chip_is_linked_to == 2;
             ASSERT_TRUE(do_both_links_go_to_separate_devices)
                 << "Detected " << num_chips_that_curr_chip_is_linked_to << " chips that chip " << device_id
-                << " is linked to" << '\n';
+                << " is linked to\n";
 
             bool do_both_links_go_to_galaxy_devices = true;
             for (const ChipId connected_device_id : connected_device_ids) {
@@ -176,12 +176,12 @@ TEST_F(GalaxyFixture, DISABLED_ValidateAllMMIOChipsHaveSingleRowHarvested) {
 
 TEST_F(TGFixture, ValidateNumMMIOChips) {
     const size_t num_mmio_chips = tt::tt_metal::MetalContext::instance().get_cluster().number_of_pci_devices();
-    ASSERT_TRUE(num_mmio_chips == 4) << "Detected " << num_mmio_chips << " MMIO chips" << '\n';
+    ASSERT_TRUE(num_mmio_chips == 4) << "Detected " << num_mmio_chips << " MMIO chips\n";
 }
 
 TEST_F(TGFixture, ValidateNumGalaxyChips) {
     const size_t num_galaxy_chips = tt::tt_metal::MetalContext::instance().get_cluster().number_of_user_devices();
-    ASSERT_TRUE(num_galaxy_chips == 32) << "Detected " << num_galaxy_chips << " Galaxy chips" << '\n';
+    ASSERT_TRUE(num_galaxy_chips == 32) << "Detected " << num_galaxy_chips << " Galaxy chips\n";
 }
 
 // Validate that there are 4 N150 chips and 32 Galaxy chips
@@ -197,8 +197,8 @@ TEST_F(TGFixture, ValidateChipBoardTypes) {
             num_n150_chips++;
         }
     }
-    ASSERT_TRUE(num_galaxy_chips == 32) << "Detected " << num_galaxy_chips << " Galaxy chips" << '\n';
-    ASSERT_TRUE(num_n150_chips == 4) << "Detected " << num_n150_chips << " N150 chips" << '\n';
+    ASSERT_TRUE(num_galaxy_chips == 32) << "Detected " << num_galaxy_chips << " Galaxy chips\n";
+    ASSERT_TRUE(num_n150_chips == 4) << "Detected " << num_n150_chips << " N150 chips\n";
 }
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/device/test_galaxy_cluster_api.cpp
+++ b/tests/tt_metal/tt_metal/device/test_galaxy_cluster_api.cpp
@@ -98,7 +98,7 @@ TEST_F(TGFixture, ActiveEthValidateNumLinksBetweenAdjacentGalaxyChips) {
 
             for (const auto& [connected_device_id, num_links_found] : connected_devices_to_num_links_found) {
                 ASSERT_TRUE(num_links_found == 4) << "Detected " << num_links_found << " links between chip "
-                                                  << device_id << " and chip " << connected_device_id << std::endl;
+                                                  << device_id << " and chip " << connected_device_id << '\n';
             }
         }
     }
@@ -121,13 +121,13 @@ TEST_F(GalaxyFixture, DISABLED_ActiveEthValidateLinksBetweenMMIOAndGalaxyChips) 
             }
             ASSERT_TRUE(num_mmio_chips_that_curr_chip_is_linked_to <= 1)
                 << "Detected " << num_mmio_chips_that_curr_chip_is_linked_to << " MMIO chips that chip " << device_id
-                << " is linked to" << std::endl;
+                << " is linked to" << '\n';
         } else {
             const uint32_t num_chips_that_curr_chip_is_linked_to = connected_device_ids.size();
             const bool do_both_links_go_to_separate_devices = num_chips_that_curr_chip_is_linked_to == 2;
             ASSERT_TRUE(do_both_links_go_to_separate_devices)
                 << "Detected " << num_chips_that_curr_chip_is_linked_to << " chips that chip " << device_id
-                << " is linked to" << std::endl;
+                << " is linked to" << '\n';
 
             bool do_both_links_go_to_galaxy_devices = true;
             for (const ChipId connected_device_id : connected_device_ids) {
@@ -136,7 +136,7 @@ TEST_F(GalaxyFixture, DISABLED_ActiveEthValidateLinksBetweenMMIOAndGalaxyChips) 
             }
             ASSERT_TRUE(do_both_links_go_to_galaxy_devices)
                 << "Detected links from chip " << device_id << " to chip " << *(connected_device_ids.begin())
-                << " and chip " << *(++connected_device_ids.begin()) << std::endl;
+                << " and chip " << *(++connected_device_ids.begin()) << '\n';
         }
     }
 }
@@ -149,8 +149,7 @@ TEST_F(GalaxyFixture, ValidateAllGalaxyChipsAreUnharvested) {
         if (is_galaxy_device(device_id)) {
             const uint32_t harvest_mask =
                 tt::tt_metal::MetalContext::instance().get_cluster().get_harvesting_mask(device_id);
-            ASSERT_TRUE(harvest_mask == 0)
-                << "Harvest mask for chip " << device_id << ": " << harvest_mask << std::endl;
+            ASSERT_TRUE(harvest_mask == 0) << "Harvest mask for chip " << device_id << ": " << harvest_mask << '\n';
         }
     }
 }
@@ -170,19 +169,19 @@ TEST_F(GalaxyFixture, DISABLED_ValidateAllMMIOChipsHaveSingleRowHarvested) {
                 harvest_mask = harvest_mask >> 1;
             }
             ASSERT_TRUE(num_rows_harvested == 1)
-                << "Detected " << num_rows_harvested << " harvested rows for chip " << device_id << std::endl;
+                << "Detected " << num_rows_harvested << " harvested rows for chip " << device_id << '\n';
         }
     }
 }
 
 TEST_F(TGFixture, ValidateNumMMIOChips) {
     const size_t num_mmio_chips = tt::tt_metal::MetalContext::instance().get_cluster().number_of_pci_devices();
-    ASSERT_TRUE(num_mmio_chips == 4) << "Detected " << num_mmio_chips << " MMIO chips" << std::endl;
+    ASSERT_TRUE(num_mmio_chips == 4) << "Detected " << num_mmio_chips << " MMIO chips" << '\n';
 }
 
 TEST_F(TGFixture, ValidateNumGalaxyChips) {
     const size_t num_galaxy_chips = tt::tt_metal::MetalContext::instance().get_cluster().number_of_user_devices();
-    ASSERT_TRUE(num_galaxy_chips == 32) << "Detected " << num_galaxy_chips << " Galaxy chips" << std::endl;
+    ASSERT_TRUE(num_galaxy_chips == 32) << "Detected " << num_galaxy_chips << " Galaxy chips" << '\n';
 }
 
 // Validate that there are 4 N150 chips and 32 Galaxy chips
@@ -198,8 +197,8 @@ TEST_F(TGFixture, ValidateChipBoardTypes) {
             num_n150_chips++;
         }
     }
-    ASSERT_TRUE(num_galaxy_chips == 32) << "Detected " << num_galaxy_chips << " Galaxy chips" << std::endl;
-    ASSERT_TRUE(num_n150_chips == 4) << "Detected " << num_n150_chips << " N150 chips" << std::endl;
+    ASSERT_TRUE(num_galaxy_chips == 32) << "Detected " << num_galaxy_chips << " Galaxy chips" << '\n';
+    ASSERT_TRUE(num_n150_chips == 4) << "Detected " << num_n150_chips << " N150 chips" << '\n';
 }
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_ringbuffer_cache.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_ringbuffer_cache.cpp
@@ -166,24 +166,24 @@ TEST_P(RingbufferCacheRandomizedTestsFixture, RandomizedQueries) {
             ASSERT_TRUE((result->offset + pgm_size) % params.cache_size_blocks == get_next_block_offset())
                 << "Failed check (iter:" << i << "): cache size: " << params.cache_size_blocks << ", pgm_id: " << pgm_id
                 << ", pgm_size: " << pgm_size << ", offset: " << result->offset
-                << ", next_block_offset: " << get_next_block_offset() << std::endl;
+                << ", next_block_offset: " << get_next_block_offset() << '\n';
         }
         ASSERT_GE(get_manager_entry_size(), std::min(params.initial_manager_size, params.cache_size_blocks))
             << "Manager size: " << get_manager_entry_size() << ", cache size: " << params.cache_size_blocks
             << ", initial manager size: " << params.initial_manager_size << ", oldest_idx: " << get_oldest_idx()
             << ", next_index: " << get_next_idx() << ", oldest_block_offset: " << get_oldest_block_offset()
-            << ", next_block_offset: " << get_next_block_offset() << std::endl;
+            << ", next_block_offset: " << get_next_block_offset() << '\n';
         if (result->is_cached) {
             ++hits_count;
         }
     }
     auto end_rbcache = std::chrono::high_resolution_clock::now();
     auto duration_rbcache = std::chrono::duration_cast<std::chrono::milliseconds>(end_rbcache - start_rbcache).count();
-    std::cout << "Ringbuffer cache runtime: " << duration_rbcache << " ms, hits: " << hits_count << std::endl;
+    std::cout << "Ringbuffer cache runtime: " << duration_rbcache << " ms, hits: " << hits_count << '\n';
     ASSERT_LE(get_manager_entry_size(), params.cache_size_blocks)
-        << "Manager size: " << get_manager_entry_size() << ", cache size: " << params.cache_size_blocks << std::endl;
+        << "Manager size: " << get_manager_entry_size() << ", cache size: " << params.cache_size_blocks << '\n';
     std::cout << "Cache size: " << params.cache_size_blocks << ", initial manager size: " << params.initial_manager_size
-              << ", final manager size: " << get_manager_entry_size() << std::endl;
+              << ", final manager size: " << get_manager_entry_size() << '\n';
 }
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/eth/test_basic_eth.cpp
+++ b/tests/tt_metal/tt_metal/eth/test_basic_eth.cpp
@@ -131,7 +131,7 @@ bool reader_kernel_no_send(
         device->id(), eth_noc_xy, eth_l1_byte_address, byte_size);
     pass &= (readback_vec == inputs);
     if (not pass) {
-        std::cout << "Mismatch at Core: " << eth_noc_xy.str() << std::endl;
+        std::cout << "Mismatch at Core: " << eth_noc_xy.str() << '\n';
     }
     return pass;
 }
@@ -206,7 +206,7 @@ bool writer_kernel_no_receive(
     fixture->ReadBuffer(mesh_device, output_dram_buffer, readback_vec);
     pass &= (readback_vec == inputs);
     if (not pass) {
-        std::cout << "Mismatch" << std::endl;
+        std::cout << "Mismatch" << '\n';
     }
     return pass;
 }

--- a/tests/tt_metal/tt_metal/eth/test_basic_eth.cpp
+++ b/tests/tt_metal/tt_metal/eth/test_basic_eth.cpp
@@ -206,7 +206,7 @@ bool writer_kernel_no_receive(
     fixture->ReadBuffer(mesh_device, output_dram_buffer, readback_vec);
     pass &= (readback_vec == inputs);
     if (not pass) {
-        std::cout << "Mismatch" << '\n';
+        std::cout << "Mismatch\n";
     }
     return pass;
 }

--- a/tests/tt_metal/tt_metal/eth/test_buffer_movement_kernels.cpp
+++ b/tests/tt_metal/tt_metal/eth/test_buffer_movement_kernels.cpp
@@ -208,7 +208,7 @@ bool chip_to_chip_dram_buffer_transfer(
     fixture->ReadBuffer(receiver_mesh_device, output_dram_buffer, dest_dram_data);
     pass &= (dest_dram_data == inputs);
     if (not pass) {
-        std::cout << "Mismatch" << '\n';
+        std::cout << "Mismatch\n";
         std::cout << dest_dram_data[0] << '\n';
     }
     return pass;

--- a/tests/tt_metal/tt_metal/eth/test_buffer_movement_kernels.cpp
+++ b/tests/tt_metal/tt_metal/eth/test_buffer_movement_kernels.cpp
@@ -208,8 +208,8 @@ bool chip_to_chip_dram_buffer_transfer(
     fixture->ReadBuffer(receiver_mesh_device, output_dram_buffer, dest_dram_data);
     pass &= (dest_dram_data == inputs);
     if (not pass) {
-        std::cout << "Mismatch" << std::endl;
-        std::cout << dest_dram_data[0] << std::endl;
+        std::cout << "Mismatch" << '\n';
+        std::cout << dest_dram_data[0] << '\n';
     }
     return pass;
 }

--- a/tests/tt_metal/tt_metal/eth/test_erisc_app_direct_send.cpp
+++ b/tests/tt_metal/tt_metal/eth/test_erisc_app_direct_send.cpp
@@ -197,8 +197,8 @@ bool eth_direct_sender_receiver_kernels(
         byte_size);
     pass &= (readback_vec == inputs);
     if (not pass) {
-        std::cout << "Mismatch at Core: " << eth_receiver_core.str() << std::endl;
-        std::cout << readback_vec[0] << std::endl;
+        std::cout << "Mismatch at Core: " << eth_receiver_core.str() << '\n';
+        std::cout << readback_vec[0] << '\n';
     }
     return pass;
 }

--- a/tests/tt_metal/tt_metal/integration/test_flatten.cpp
+++ b/tests/tt_metal/tt_metal/integration/test_flatten.cpp
@@ -192,10 +192,10 @@ bool flatten(
     pass &= (golden == result_vec);
 
     if (not pass) {
-        std::cout << "GOLDEN" << std::endl;
+        std::cout << "GOLDEN" << '\n';
         print_vec_of_uint32_as_packed_bfloat16(golden, num_tiles * 32);
 
-        std::cout << "RESULT" << std::endl;
+        std::cout << "RESULT" << '\n';
         print_vec_of_uint32_as_packed_bfloat16(result_vec, num_tiles * 32);
     }
     return pass;
@@ -306,10 +306,10 @@ bool flatten_stress(
         pass &= (golden == result_vec);
 
         if (not pass) {
-            std::cout << "GOLDEN" << std::endl;
+            std::cout << "GOLDEN" << '\n';
             print_vec_of_uint32_as_packed_bfloat16(golden, num_tiles * 32);
 
-            std::cout << "RESULT" << std::endl;
+            std::cout << "RESULT" << '\n';
             print_vec_of_uint32_as_packed_bfloat16(result_vec, num_tiles * 32);
         }
     }

--- a/tests/tt_metal/tt_metal/integration/test_flatten.cpp
+++ b/tests/tt_metal/tt_metal/integration/test_flatten.cpp
@@ -192,10 +192,10 @@ bool flatten(
     pass &= (golden == result_vec);
 
     if (not pass) {
-        std::cout << "GOLDEN" << '\n';
+        std::cout << "GOLDEN\n";
         print_vec_of_uint32_as_packed_bfloat16(golden, num_tiles * 32);
 
-        std::cout << "RESULT" << '\n';
+        std::cout << "RESULT\n";
         print_vec_of_uint32_as_packed_bfloat16(result_vec, num_tiles * 32);
     }
     return pass;
@@ -306,10 +306,10 @@ bool flatten_stress(
         pass &= (golden == result_vec);
 
         if (not pass) {
-            std::cout << "GOLDEN" << '\n';
+            std::cout << "GOLDEN\n";
             print_vec_of_uint32_as_packed_bfloat16(golden, num_tiles * 32);
 
-            std::cout << "RESULT" << '\n';
+            std::cout << "RESULT\n";
             print_vec_of_uint32_as_packed_bfloat16(result_vec, num_tiles * 32);
         }
     }

--- a/tests/tt_metal/tt_metal/llk/test_untilize_tilize.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_untilize_tilize.cpp
@@ -323,9 +323,9 @@ void run_single_core_tilize_program(
     }
 
     if (not pass) {
-        std::cout << "GOLDEN " << '\n';
+        std::cout << "GOLDEN \n";
         print_vector(unpack_vector<bfloat16, uint32_t>(golden));
-        std::cout << "RESULTS " << '\n';
+        std::cout << "RESULTS \n";
         print_vector(unpack_vector<bfloat16, uint32_t>(result_vec));
     }
     log_info(

--- a/tests/tt_metal/tt_metal/llk/test_untilize_tilize.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_untilize_tilize.cpp
@@ -323,9 +323,9 @@ void run_single_core_tilize_program(
     }
 
     if (not pass) {
-        std::cout << "GOLDEN " << std::endl;
+        std::cout << "GOLDEN " << '\n';
         print_vector(unpack_vector<bfloat16, uint32_t>(golden));
-        std::cout << "RESULTS " << std::endl;
+        std::cout << "RESULTS " << '\n';
         print_vector(unpack_vector<bfloat16, uint32_t>(result_vec));
     }
     log_info(

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_all_ethernet_links.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_all_ethernet_links.cpp
@@ -489,7 +489,7 @@ void dump_eth_link_stats(
         log_file << fmt::format(
                         ",Receiver Device ID,Receiver Eth,R Retrain Count,R CRC Errs,R PCS Faults,R Total "
                         "Corr,R Total Uncorr,R Retrain by PCS,R Retrain by CRC")
-                 << std::endl;
+                 << '\n';
     } else {
         log_file.open(log_path, std::ios_base::app);
     }
@@ -583,7 +583,7 @@ void dump_eth_link_stats(
                             r.total_uncorr_cw,
                             r.retrains_triggered_by_pcs,
                             r.retrains_triggered_by_crcs)
-                     << std::endl;
+                     << '\n';
         }
     }
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_link_ping_latency_no_edm.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_link_ping_latency_no_edm.cpp
@@ -185,7 +185,7 @@ void run(
         tt::tt_metal::distributed::EnqueueMeshWorkload(device0->mesh_command_queue(), mesh_workload0, false);
         tt::tt_metal::distributed::EnqueueMeshWorkload(device1->mesh_command_queue(), mesh_workload1, false);
 
-        std::cout << "Calling Finish" << std::endl;
+        std::cout << "Calling Finish" << '\n';
         tt::tt_metal::distributed::Finish(device0->mesh_command_queue());
         tt::tt_metal::distributed::Finish(device1->mesh_command_queue());
     }
@@ -235,9 +235,9 @@ int main(int argc, char** argv) {
         return 0;
     }
 
-    std::cout << "setting up test fixture" << std::endl;
+    std::cout << "setting up test fixture" << '\n';
     N300TestDevice test_fixture;
-    std::cout << "done setting up test fixture" << std::endl;
+    std::cout << "done setting up test fixture" << '\n';
 
     const auto& device_0 = test_fixture.devices_.at(0);
     const auto& active_eth_cores = device_0->get_devices()[0]->get_active_ethernet_cores(true);
@@ -265,7 +265,7 @@ int main(int argc, char** argv) {
     // Add more configurations here until proper argc parsing added
     bool success = false;
     success = true;
-    std::cout << "STARTING" << std::endl;
+    std::cout << "STARTING" << '\n';
     try {
         for (auto num_samples : sample_counts) {
             for (auto sample_page_size : sample_sizes) {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_link_ping_latency_no_edm.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_link_ping_latency_no_edm.cpp
@@ -185,7 +185,7 @@ void run(
         tt::tt_metal::distributed::EnqueueMeshWorkload(device0->mesh_command_queue(), mesh_workload0, false);
         tt::tt_metal::distributed::EnqueueMeshWorkload(device1->mesh_command_queue(), mesh_workload1, false);
 
-        std::cout << "Calling Finish" << '\n';
+        std::cout << "Calling Finish\n";
         tt::tt_metal::distributed::Finish(device0->mesh_command_queue());
         tt::tt_metal::distributed::Finish(device1->mesh_command_queue());
     }
@@ -235,9 +235,9 @@ int main(int argc, char** argv) {
         return 0;
     }
 
-    std::cout << "setting up test fixture" << '\n';
+    std::cout << "setting up test fixture\n";
     N300TestDevice test_fixture;
-    std::cout << "done setting up test fixture" << '\n';
+    std::cout << "done setting up test fixture\n";
 
     const auto& device_0 = test_fixture.devices_.at(0);
     const auto& active_eth_cores = device_0->get_devices()[0]->get_active_ethernet_cores(true);
@@ -265,7 +265,7 @@ int main(int argc, char** argv) {
     // Add more configurations here until proper argc parsing added
     bool success = false;
     success = true;
-    std::cout << "STARTING" << '\n';
+    std::cout << "STARTING\n";
     try {
         for (auto num_samples : sample_counts) {
             for (auto sample_page_size : sample_sizes) {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/noc/test_noc_read_global_l1.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/noc/test_noc_read_global_l1.cpp
@@ -299,7 +299,7 @@ int main(int argc, char** argv) {
 
                 if (debug) {
                     std::cout << c << "," << r << " " << l1_buffer_offset << " " << num_blocks << " " << cb_n << " "
-                              << cb_n * single_tile_size << std::endl;
+                              << cb_n * single_tile_size << '\n';
                 }
                 tt_metal::SetRuntimeArgs(
                     program, mm_reader_kernel, core, {l1_buffer_addr, l1_buffer_offset, num_blocks, cb_n});

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_config.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_config.hpp
@@ -1395,7 +1395,7 @@ public:
 
         out << YAML::EndMap;
 
-        fout << out.c_str() << std::endl;
+        fout << out.c_str() << '\n';
     }
 
     static void dump(const AllocatorPolicies& policies, std::ofstream& fout) {
@@ -1408,7 +1408,7 @@ public:
 
         out << YAML::EndMap;
 
-        fout << out.c_str() << std::endl;
+        fout << out.c_str() << '\n';
     }
 
     static void dump(const std::vector<TestConfig>& test_configs, std::ofstream& fout) {
@@ -1426,7 +1426,7 @@ public:
 
         out << YAML::EndMap;
 
-        fout << out.c_str() << std::endl;
+        fout << out.c_str() << '\n';
     }
 
 private:

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_progress_monitor.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_progress_monitor.cpp
@@ -52,7 +52,7 @@ void TestProgressMonitor::poll_until_complete() {
     }
 
     // Always print newline after final progress update
-    std::cout << std::endl;
+    std::cout << '\n';
 }
 
 std::unordered_map<tt::tt_fabric::FabricNodeId, DeviceProgress> TestProgressMonitor::poll_devices() {

--- a/tests/tt_metal/tt_metal/test_dram_copy_sticks_multi_core.cpp
+++ b/tests/tt_metal/tt_metal/test_dram_copy_sticks_multi_core.cpp
@@ -120,7 +120,7 @@ int main(int argc, char** argv) {
             dram_buffer_size, 100, std::chrono::system_clock::now().time_since_epoch().count());
         tt_metal::detail::WriteToBuffer(src_dram_buffer, src_vec);
 
-        std::cout << "Num cores " << num_cores_r * num_cores_c << std::endl;
+        std::cout << "Num cores " << num_cores_r * num_cores_c << '\n';
         uint32_t core_index = 0;
         for (int i = start_core.y; i < start_core.y + num_cores_r; i++) {
             for (int j = start_core.x; j < start_core.x + num_cores_c; j++) {

--- a/tests/tt_metal/tt_metal/test_generic_binary_reader_matmul_large_block.cpp
+++ b/tests/tt_metal/tt_metal/test_generic_binary_reader_matmul_large_block.cpp
@@ -76,7 +76,7 @@ std::vector<std::uint32_t> transpose_tiles(
 }
 
 void print_faces(std::vector<bfloat16> data, const std::string& name) {
-    std::cout << name << ": " << '\n';
+    std::cout << name << ": \n";
 
     int tile_index = 0;
     int face_index = 0;

--- a/tests/tt_metal/tt_metal/test_generic_binary_reader_matmul_large_block.cpp
+++ b/tests/tt_metal/tt_metal/test_generic_binary_reader_matmul_large_block.cpp
@@ -76,14 +76,14 @@ std::vector<std::uint32_t> transpose_tiles(
 }
 
 void print_faces(std::vector<bfloat16> data, const std::string& name) {
-    std::cout << name << ": " << std::endl;
+    std::cout << name << ": " << '\n';
 
     int tile_index = 0;
     int face_index = 0;
     for (int i = 0; i < data.size(); i++) {
         if (i % 256 == 0) {
-            std::cout << "Tile " << tile_index / 4 << std::endl;
-            std::cout << "Face = " << face_index << std::endl;
+            std::cout << "Tile " << tile_index / 4 << '\n';
+            std::cout << "Face = " << face_index << '\n';
             face_index++;
             tile_index++;
             if (face_index == 4) {
@@ -92,10 +92,10 @@ void print_faces(std::vector<bfloat16> data, const std::string& name) {
         }
         std::cout << static_cast<float>(data.at(i)) << ", ";
         if ((i + 1) % 16 == 0) {
-            std::cout << std::endl;
+            std::cout << '\n';
         }
     }
-    std::cout << std::endl;
+    std::cout << '\n';
 }
 
 int main(int argc, char** argv) {

--- a/tests/tt_metal/tt_metal/test_interleaved_layouts.cpp
+++ b/tests/tt_metal/tt_metal/test_interleaved_layouts.cpp
@@ -229,10 +229,10 @@ bool interleaved_stick_reader_single_bank_tilized_writer_datacopy_test(const tt:
         pass &= (src_vec == result_vec);
 
         if (not pass) {
-            std::cout << "GOLDEN" << '\n';
+            std::cout << "GOLDEN\n";
             print_vec_of_uint32_as_packed_bfloat16(src_vec, num_output_tiles);
 
-            std::cout << "RESULT" << '\n';
+            std::cout << "RESULT\n";
             print_vec_of_uint32_as_packed_bfloat16(result_vec, num_output_tiles);
         }
 
@@ -395,10 +395,10 @@ bool interleaved_tilized_reader_interleaved_stick_writer_datacopy_test(const tt:
         pass &= (src_vec == result_vec);
 
         if (not pass) {
-            std::cout << "GOLDEN" << '\n';
+            std::cout << "GOLDEN\n";
             print_vec_of_uint32_as_packed_bfloat16(src_vec, num_output_tiles);
 
-            std::cout << "RESULT" << '\n';
+            std::cout << "RESULT\n";
             print_vec_of_uint32_as_packed_bfloat16(result_vec, num_output_tiles);
         }
 

--- a/tests/tt_metal/tt_metal/test_interleaved_layouts.cpp
+++ b/tests/tt_metal/tt_metal/test_interleaved_layouts.cpp
@@ -229,10 +229,10 @@ bool interleaved_stick_reader_single_bank_tilized_writer_datacopy_test(const tt:
         pass &= (src_vec == result_vec);
 
         if (not pass) {
-            std::cout << "GOLDEN" << std::endl;
+            std::cout << "GOLDEN" << '\n';
             print_vec_of_uint32_as_packed_bfloat16(src_vec, num_output_tiles);
 
-            std::cout << "RESULT" << std::endl;
+            std::cout << "RESULT" << '\n';
             print_vec_of_uint32_as_packed_bfloat16(result_vec, num_output_tiles);
         }
 
@@ -395,10 +395,10 @@ bool interleaved_tilized_reader_interleaved_stick_writer_datacopy_test(const tt:
         pass &= (src_vec == result_vec);
 
         if (not pass) {
-            std::cout << "GOLDEN" << std::endl;
+            std::cout << "GOLDEN" << '\n';
             print_vec_of_uint32_as_packed_bfloat16(src_vec, num_output_tiles);
 
-            std::cout << "RESULT" << std::endl;
+            std::cout << "RESULT" << '\n';
             print_vec_of_uint32_as_packed_bfloat16(result_vec, num_output_tiles);
         }
 

--- a/tests/tt_metal/tt_metal/test_single_dm_l1_write.cpp
+++ b/tests/tt_metal/tt_metal/test_single_dm_l1_write.cpp
@@ -27,23 +27,23 @@ int main() {
     if (env_var == nullptr) {
         std::cerr << "WARNING: Please set the environment variable TT_METAL_DPRINT_CORES to 0,0 to see the output of "
                      "the Data Movement kernels."
-                  << std::endl;
-        std::cerr << "WARNING: For example, export TT_METAL_DPRINT_CORES=0,0" << std::endl;
+                  << '\n';
+        std::cerr << "WARNING: For example, export TT_METAL_DPRINT_CORES=0,0" << '\n';
     }
     env_var = std::getenv("TT_METAL_SIMULATOR");
     if (env_var == nullptr) {
         std::cerr
             << "ERROR: This test can only be run using a simulator. Please set Environment Variable TT_METAL_SIMULATOR"
-            << std::endl;
-        std::cerr << "ERROR: with a valid simulator path" << std::endl;
+            << '\n';
+        std::cerr << "ERROR: with a valid simulator path" << '\n';
         return 1;
     }
     env_var = std::getenv("TT_METAL_SLOW_DISPATCH_MODE");
     if (env_var == nullptr) {
         std::cerr << "ERROR: This test can only be run in slow dispatch mode. Please set Environment Variable "
                      "TT_METAL_SLOW_DISPATCH_MODE"
-                  << std::endl;
-        std::cerr << "ERROR: using export TT_METAL_SLOW_DISPATCH_MODE=1" << std::endl;
+                  << '\n';
+        std::cerr << "ERROR: using export TT_METAL_SLOW_DISPATCH_MODE=1" << '\n';
         return 1;
     }
 
@@ -74,7 +74,7 @@ int main() {
     SetRuntimeArgs(program, data_movement_kernel_0, core, {address});
     SetCommonRuntimeArgs(program, data_movement_kernel_0, {value});
     std::cout << "Hello, Core {0, 0} on Device 0, Please start execution. I will standby for your communication."
-              << std::endl;
+              << '\n';
 
     workload.add_program(device_range, std::move(program));
     distributed::EnqueueMeshWorkload(cq, workload, true);
@@ -82,10 +82,10 @@ int main() {
     mesh_device->close();
 
     if (outputs[0] == value) {
-        std::cout << "Test passed!" << std::endl;
+        std::cout << "Test passed!" << '\n';
         return 0;
     } else {
-        std::cout << "Test failed! Got the value " << std::hex << outputs[0] << " instead of " << value << std::endl;
+        std::cout << "Test failed! Got the value " << std::hex << outputs[0] << " instead of " << value << '\n';
         return 1;
     }
 }

--- a/tests/tt_metal/tt_metal/test_single_dm_l1_write.cpp
+++ b/tests/tt_metal/tt_metal/test_single_dm_l1_write.cpp
@@ -28,14 +28,13 @@ int main() {
         std::cerr << "WARNING: Please set the environment variable TT_METAL_DPRINT_CORES to 0,0 to see the output of "
                      "the Data Movement kernels."
                   << '\n';
-        std::cerr << "WARNING: For example, export TT_METAL_DPRINT_CORES=0,0" << '\n';
+        std::cerr << "WARNING: For example, export TT_METAL_DPRINT_CORES=0,0\n";
     }
     env_var = std::getenv("TT_METAL_SIMULATOR");
     if (env_var == nullptr) {
         std::cerr
-            << "ERROR: This test can only be run using a simulator. Please set Environment Variable TT_METAL_SIMULATOR"
-            << '\n';
-        std::cerr << "ERROR: with a valid simulator path" << '\n';
+            << "ERROR: This test can only be run using a simulator. Please set Environment Variable TT_METAL_SIMULATOR\n";
+        std::cerr << "ERROR: with a valid simulator path\n";
         return 1;
     }
     env_var = std::getenv("TT_METAL_SLOW_DISPATCH_MODE");
@@ -43,7 +42,7 @@ int main() {
         std::cerr << "ERROR: This test can only be run in slow dispatch mode. Please set Environment Variable "
                      "TT_METAL_SLOW_DISPATCH_MODE"
                   << '\n';
-        std::cerr << "ERROR: using export TT_METAL_SLOW_DISPATCH_MODE=1" << '\n';
+        std::cerr << "ERROR: using export TT_METAL_SLOW_DISPATCH_MODE=1\n";
         return 1;
     }
 
@@ -73,8 +72,7 @@ int main() {
     // Set Runtime Arguments for the Data Movement Kernel (memory address to write to)
     SetRuntimeArgs(program, data_movement_kernel_0, core, {address});
     SetCommonRuntimeArgs(program, data_movement_kernel_0, {value});
-    std::cout << "Hello, Core {0, 0} on Device 0, Please start execution. I will standby for your communication."
-              << '\n';
+    std::cout << "Hello, Core {0, 0} on Device 0, Please start execution. I will standby for your communication.\n";
 
     workload.add_program(device_range, std::move(program));
     distributed::EnqueueMeshWorkload(cq, workload, true);
@@ -82,7 +80,7 @@ int main() {
     mesh_device->close();
 
     if (outputs[0] == value) {
-        std::cout << "Test passed!" << '\n';
+        std::cout << "Test passed!\n";
         return 0;
     } else {
         std::cout << "Test failed! Got the value " << std::hex << outputs[0] << " instead of " << value << '\n';

--- a/tests/tt_metal/tt_metal/test_single_dm_l1_write.cpp
+++ b/tests/tt_metal/tt_metal/test_single_dm_l1_write.cpp
@@ -40,8 +40,7 @@ int main() {
     env_var = std::getenv("TT_METAL_SLOW_DISPATCH_MODE");
     if (env_var == nullptr) {
         std::cerr << "ERROR: This test can only be run in slow dispatch mode. Please set Environment Variable "
-                     "TT_METAL_SLOW_DISPATCH_MODE"
-                  << '\n';
+                     "TT_METAL_SLOW_DISPATCH_MODE\n";
         std::cerr << "ERROR: using export TT_METAL_SLOW_DISPATCH_MODE=1\n";
         return 1;
     }

--- a/tests/ttnn/tracy/cpp/test_get_programs_perf_data.cpp
+++ b/tests/ttnn/tracy/cpp/test_get_programs_perf_data.cpp
@@ -115,7 +115,7 @@ protected:
             json_programs_perf_data_list.push_back(programs_perf_data);
         }
         std::ofstream file(get_profiler_logs_dir() + file_name);
-        file << std::setw(4) << json_programs_perf_data_list << std::endl;
+        file << std::setw(4) << json_programs_perf_data_list << '\n';
     }
 
 private:

--- a/tests/ttnn/unit_tests/gtests/test_graph_basic.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_graph_basic.cpp
@@ -125,7 +125,7 @@ TEST_P(BufferTestFixture, BufferTest) {
         EXPECT_EQ(params.shape_b.volume() * 2, size_b);
 
         // Print the trace for reference
-        std::cout << trace << std::endl;
+        std::cout << trace << '\n';
     }
 }
 
@@ -177,7 +177,7 @@ TEST_F(TestScopedGraphCapture, ScopedGraphCapture) {
         ref_calltrace = ttnn::graph::extract_calltrace(ref_json_trace);
     }
     for (const auto& call : ref_calltrace) {
-        std::cout << call << std::endl;
+        std::cout << call << '\n';
     }
 
     // with manual exception in the nested loop

--- a/tools/scaleout/cabling_generator/cabling_generator.cpp
+++ b/tools/scaleout/cabling_generator/cabling_generator.cpp
@@ -518,8 +518,7 @@ void CablingGenerator::emit_cabling_guide_csv(const std::string& output_path, bo
     if (loc_info) {
         output_file << "Source,,,,,,,,,Destination,,,,,,,,,Cable Length,Cable Type\n";
         output_file << "Hostname,Hall,Aisle,Rack,Shelf U,Tray,Port,Label,Node Type,Hostname,Hall,Aisle,Rack,Shelf "
-                       "U,Tray,Port,Label,Node Type,,"
-                    << '\n';
+                       "U,Tray,Port,Label,Node Type,,\n";
     } else {
         output_file << "Source,,,,Destination,,,\n";
         output_file << "Hostname,Tray,Port,Node Type,Hostname,Tray,Port,Node Type\n";

--- a/tools/scaleout/cabling_generator/cabling_generator.cpp
+++ b/tools/scaleout/cabling_generator/cabling_generator.cpp
@@ -516,13 +516,13 @@ void CablingGenerator::emit_cabling_guide_csv(const std::string& output_path, bo
     CablingGenerator::get_all_connections_of_type(root_instance_, {PortType::QSFP_DD}, conn_list);
     output_file.fill('0');
     if (loc_info) {
-        output_file << "Source,,,,,,,,,Destination,,,,,,,,,Cable Length,Cable Type" << std::endl;
+        output_file << "Source,,,,,,,,,Destination,,,,,,,,,Cable Length,Cable Type" << '\n';
         output_file << "Hostname,Hall,Aisle,Rack,Shelf U,Tray,Port,Label,Node Type,Hostname,Hall,Aisle,Rack,Shelf "
                        "U,Tray,Port,Label,Node Type,,"
-                    << std::endl;
+                    << '\n';
     } else {
-        output_file << "Source,,,,Destination,,," << std::endl;
-        output_file << "Hostname,Tray,Port,Node Type,Hostname,Tray,Port,Node Type" << std::endl;
+        output_file << "Source,,,,Destination,,," << '\n';
+        output_file << "Hostname,Tray,Port,Node Type,Hostname,Tray,Port,Node Type" << '\n';
     }
     for (const auto& [start, end] : conn_list) {
         auto host_id1 = std::get<0>(start).get();
@@ -573,10 +573,10 @@ void CablingGenerator::emit_cabling_guide_csv(const std::string& output_path, bo
                         << host2.shelf_u << "-" << tray_id2 << "-" << port_id2 << "," << host2_node_type << ",";
 
             output_file << ",";        // Length blank, leaving up to technician
-            output_file << std::endl;  // Type blank, leaving up to technician
+            output_file << '\n';       // Type blank, leaving up to technician
         } else {
             output_file << host1.hostname << "," << tray_id1 << "," << port_id1 << "," << host1_node_type << ",";
-            output_file << host2.hostname << "," << tray_id2 << "," << port_id2 << "," << host2_node_type << std::endl;
+            output_file << host2.hostname << "," << tray_id2 << "," << port_id2 << "," << host2_node_type << '\n';
         }
     }
 

--- a/tools/scaleout/cabling_generator/cabling_generator.cpp
+++ b/tools/scaleout/cabling_generator/cabling_generator.cpp
@@ -516,13 +516,13 @@ void CablingGenerator::emit_cabling_guide_csv(const std::string& output_path, bo
     CablingGenerator::get_all_connections_of_type(root_instance_, {PortType::QSFP_DD}, conn_list);
     output_file.fill('0');
     if (loc_info) {
-        output_file << "Source,,,,,,,,,Destination,,,,,,,,,Cable Length,Cable Type" << '\n';
+        output_file << "Source,,,,,,,,,Destination,,,,,,,,,Cable Length,Cable Type\n";
         output_file << "Hostname,Hall,Aisle,Rack,Shelf U,Tray,Port,Label,Node Type,Hostname,Hall,Aisle,Rack,Shelf "
                        "U,Tray,Port,Label,Node Type,,"
                     << '\n';
     } else {
-        output_file << "Source,,,,Destination,,," << '\n';
-        output_file << "Hostname,Tray,Port,Node Type,Hostname,Tray,Port,Node Type" << '\n';
+        output_file << "Source,,,,Destination,,,\n";
+        output_file << "Hostname,Tray,Port,Node Type,Hostname,Tray,Port,Node Type\n";
     }
     for (const auto& [start, end] : conn_list) {
         auto host_id1 = std::get<0>(start).get();

--- a/tools/scaleout/factory_system_descriptor/utils.cpp
+++ b/tools/scaleout/factory_system_descriptor/utils.cpp
@@ -443,7 +443,7 @@ std::set<PhysicalChannelConnection> validate_fsd_against_gsd_impl(
             oss << "  - " << conn.first << " <-> " << conn.second << "\n";
         }
         if (log_output) {
-            std::cout << oss.str() << std::endl;
+            std::cout << oss.str() << '\n';
         }
     }
 
@@ -465,7 +465,7 @@ std::set<PhysicalChannelConnection> validate_fsd_against_gsd_impl(
             oss << "  - " << conn.first << " <-> " << conn.second << "\n";
         }
         if (log_output) {
-            std::cout << oss.str() << std::endl;
+            std::cout << oss.str() << '\n';
         }
     }
 
@@ -481,10 +481,10 @@ std::set<PhysicalChannelConnection> validate_fsd_against_gsd_impl(
         if (log_output) {
             if (strict_validation) {
                 std::cout << "All connections match between FSD and GSD (" << generated_connections.size()
-                          << " connections)" << std::endl;
+                          << " connections)" << '\n';
             } else {
                 std::cout << "All GSD connections found in FSD (" << discovered_connections.size()
-                          << " connections checked)" << std::endl;
+                          << " connections checked)" << '\n';
             }
         }
     }

--- a/tools/scaleout/factory_system_descriptor/utils.cpp
+++ b/tools/scaleout/factory_system_descriptor/utils.cpp
@@ -481,10 +481,10 @@ std::set<PhysicalChannelConnection> validate_fsd_against_gsd_impl(
         if (log_output) {
             if (strict_validation) {
                 std::cout << "All connections match between FSD and GSD (" << generated_connections.size()
-                          << " connections)" << '\n';
+                          << " connections)\n";
             } else {
                 std::cout << "All GSD connections found in FSD (" << discovered_connections.size()
-                          << " connections checked)" << '\n';
+                          << " connections checked)\n";
             }
         }
     }

--- a/tools/scaleout/src/2d_big_mesh_cabling_gen.cpp
+++ b/tools/scaleout/src/2d_big_mesh_cabling_gen.cpp
@@ -37,7 +37,7 @@ InputConfig parse_arguments(int argc, char** argv) {
         auto result = options.parse(argc, argv);
 
         if (result.count("help")) {
-            std::cout << options.help() << std::endl;
+            std::cout << options.help() << '\n';
             exit(0);
         }
 
@@ -113,8 +113,8 @@ InputConfig parse_arguments(int argc, char** argv) {
         return config;
 
     } catch (const cxxopts::exceptions::exception& e) {
-        std::cerr << "Error parsing arguments: " << e.what() << std::endl;
-        std::cerr << options.help() << std::endl;
+        std::cerr << "Error parsing arguments: " << e.what() << '\n';
+        std::cerr << options.help() << '\n';
         exit(1);
     }
 }
@@ -287,10 +287,10 @@ int main(int argc, char** argv) {
         output_file << output_string;
         output_file.close();
 
-        std::cout << "Successfully generated cluster descriptor: " << output_path << std::endl;
+        std::cout << "Successfully generated cluster descriptor: " << output_path << '\n';
 
     } catch (const std::exception& e) {
-        std::cerr << "Error: " << e.what() << std::endl;
+        std::cerr << "Error: " << e.what() << '\n';
         return 1;
     }
 

--- a/tools/scaleout/src/generate_cluster_descriptor.cpp
+++ b/tools/scaleout/src/generate_cluster_descriptor.cpp
@@ -41,26 +41,26 @@ InputConfig parse_arguments(int argc, char** argv) {
         auto result = options.parse(argc, argv);
 
         if (result.count("help") || argc == 1) {
-            std::cout << options.help() << std::endl;
-            std::cout << "\nDescription:" << std::endl;
+            std::cout << options.help() << '\n';
+            std::cout << "\nDescription:" << '\n';
             std::cout << "  This tool generates cluster descriptor YAML files from a Factory System Descriptor."
-                      << std::endl;
+                      << '\n';
             std::cout << "  It automatically detects single-host vs multi-host systems and generates appropriate files."
-                      << std::endl;
-            std::cout << "\nOutput files:" << std::endl;
-            std::cout << "  Single-host system:" << std::endl;
-            std::cout << "    - {output_dir}/{base_filename}.yaml" << std::endl;
-            std::cout << "\n  Multi-host system:" << std::endl;
-            std::cout << "    - {output_dir}/{base_filename}_rank_0.yaml" << std::endl;
-            std::cout << "    - {output_dir}/{base_filename}_rank_1.yaml" << std::endl;
-            std::cout << "    - ... (one per host)" << std::endl;
-            std::cout << "    - {output_dir}/{base_filename}_mapping.yaml" << std::endl;
-            std::cout << "\nExamples:" << std::endl;
-            std::cout << "  " << argv[0] << " --fsd my_fsd.textproto" << std::endl;
-            std::cout << "  # Generates cluster descriptor(s) in out/scaleout/ with default naming" << std::endl;
+                      << '\n';
+            std::cout << "\nOutput files:" << '\n';
+            std::cout << "  Single-host system:" << '\n';
+            std::cout << "    - {output_dir}/{base_filename}.yaml" << '\n';
+            std::cout << "\n  Multi-host system:" << '\n';
+            std::cout << "    - {output_dir}/{base_filename}_rank_0.yaml" << '\n';
+            std::cout << "    - {output_dir}/{base_filename}_rank_1.yaml" << '\n';
+            std::cout << "    - ... (one per host)" << '\n';
+            std::cout << "    - {output_dir}/{base_filename}_mapping.yaml" << '\n';
+            std::cout << "\nExamples:" << '\n';
+            std::cout << "  " << argv[0] << " --fsd my_fsd.textproto" << '\n';
+            std::cout << "  # Generates cluster descriptor(s) in out/scaleout/ with default naming" << '\n';
             std::cout << "\n  " << argv[0]
-                      << " --fsd my_fsd.textproto --output-dir /tmp/cluster --base-filename my_cluster" << std::endl;
-            std::cout << "  # Generates cluster descriptor(s) in /tmp/cluster/ with custom naming" << std::endl;
+                      << " --fsd my_fsd.textproto --output-dir /tmp/cluster --base-filename my_cluster" << '\n';
+            std::cout << "  # Generates cluster descriptor(s) in /tmp/cluster/ with custom naming" << '\n';
             exit(0);
         }
 
@@ -81,7 +81,7 @@ InputConfig parse_arguments(int argc, char** argv) {
         // Validate file extension
         if (!config.fsd_path.ends_with(".textproto")) {
             std::cerr << "Warning: FSD file should typically have .textproto extension: '" << config.fsd_path << "'"
-                      << std::endl;
+                      << '\n';
         }
 
         // Check for invalid filename characters in base_filename
@@ -96,8 +96,8 @@ InputConfig parse_arguments(int argc, char** argv) {
         return config;
 
     } catch (const cxxopts::exceptions::exception& e) {
-        std::cerr << "Error parsing arguments: " << e.what() << std::endl;
-        std::cerr << options.help() << std::endl;
+        std::cerr << "Error parsing arguments: " << e.what() << '\n';
+        std::cerr << options.help() << '\n';
         exit(1);
     }
 }
@@ -106,28 +106,28 @@ int main(int argc, char** argv) {
     try {
         InputConfig config = parse_arguments(argc, argv);
 
-        std::cout << "Generating cluster descriptor(s) from FSD..." << std::endl;
-        std::cout << "  FSD file: " << config.fsd_path << std::endl;
-        std::cout << "  Output directory: " << config.output_dir << std::endl;
-        std::cout << "  Base filename: " << config.base_filename << std::endl;
+        std::cout << "Generating cluster descriptor(s) from FSD..." << '\n';
+        std::cout << "  FSD file: " << config.fsd_path << '\n';
+        std::cout << "  Output directory: " << config.output_dir << '\n';
+        std::cout << "  Base filename: " << config.base_filename << '\n';
 
         // Ensure output directory exists
         std::filesystem::create_directories(config.output_dir);
 
-        std::cout << "Processing FSD and generating cluster descriptor(s)..." << std::endl;
+        std::cout << "Processing FSD and generating cluster descriptor(s)..." << '\n';
         std::string output_file =
             generate_cluster_descriptor_from_fsd(config.fsd_path, config.output_dir, config.base_filename);
 
-        std::cout << "\nSuccessfully generated cluster descriptor(s)!" << std::endl;
-        std::cout << "  Main output file: " << output_file << std::endl;
+        std::cout << "\nSuccessfully generated cluster descriptor(s)!" << '\n';
+        std::cout << "  Main output file: " << output_file << '\n';
 
         // Check if this is a multi-host mapping file to provide additional info
         if (output_file.find("_mapping.yaml") != std::string::npos) {
-            std::cout << "  (Multi-host system detected - individual rank files also generated)" << std::endl;
+            std::cout << "  (Multi-host system detected - individual rank files also generated)" << '\n';
         }
 
     } catch (const std::exception& e) {
-        std::cerr << "Error: " << e.what() << std::endl;
+        std::cerr << "Error: " << e.what() << '\n';
         return 1;
     }
 

--- a/tools/scaleout/src/generate_cluster_descriptor.cpp
+++ b/tools/scaleout/src/generate_cluster_descriptor.cpp
@@ -42,25 +42,23 @@ InputConfig parse_arguments(int argc, char** argv) {
 
         if (result.count("help") || argc == 1) {
             std::cout << options.help() << '\n';
-            std::cout << "\nDescription:" << '\n';
-            std::cout << "  This tool generates cluster descriptor YAML files from a Factory System Descriptor."
-                      << '\n';
-            std::cout << "  It automatically detects single-host vs multi-host systems and generates appropriate files."
-                      << '\n';
-            std::cout << "\nOutput files:" << '\n';
-            std::cout << "  Single-host system:" << '\n';
-            std::cout << "    - {output_dir}/{base_filename}.yaml" << '\n';
-            std::cout << "\n  Multi-host system:" << '\n';
-            std::cout << "    - {output_dir}/{base_filename}_rank_0.yaml" << '\n';
-            std::cout << "    - {output_dir}/{base_filename}_rank_1.yaml" << '\n';
-            std::cout << "    - ... (one per host)" << '\n';
-            std::cout << "    - {output_dir}/{base_filename}_mapping.yaml" << '\n';
-            std::cout << "\nExamples:" << '\n';
-            std::cout << "  " << argv[0] << " --fsd my_fsd.textproto" << '\n';
-            std::cout << "  # Generates cluster descriptor(s) in out/scaleout/ with default naming" << '\n';
+            std::cout << "\nDescription:\n";
+            std::cout << "  This tool generates cluster descriptor YAML files from a Factory System Descriptor.\n";
+            std::cout << "  It automatically detects single-host vs multi-host systems and generates appropriate files.\n";
+            std::cout << "\nOutput files:\n";
+            std::cout << "  Single-host system:\n";
+            std::cout << "    - {output_dir}/{base_filename}.yaml\n";
+            std::cout << "\n  Multi-host system:\n";
+            std::cout << "    - {output_dir}/{base_filename}_rank_0.yaml\n";
+            std::cout << "    - {output_dir}/{base_filename}_rank_1.yaml\n";
+            std::cout << "    - ... (one per host)\n";
+            std::cout << "    - {output_dir}/{base_filename}_mapping.yaml\n";
+            std::cout << "\nExamples:\n";
+            std::cout << "  " << argv[0] << " --fsd my_fsd.textproto\n";
+            std::cout << "  # Generates cluster descriptor(s) in out/scaleout/ with default naming\n";
             std::cout << "\n  " << argv[0]
-                      << " --fsd my_fsd.textproto --output-dir /tmp/cluster --base-filename my_cluster" << '\n';
-            std::cout << "  # Generates cluster descriptor(s) in /tmp/cluster/ with custom naming" << '\n';
+                      << " --fsd my_fsd.textproto --output-dir /tmp/cluster --base-filename my_cluster\n";
+            std::cout << "  # Generates cluster descriptor(s) in /tmp/cluster/ with custom naming\n";
             exit(0);
         }
 
@@ -80,8 +78,7 @@ InputConfig parse_arguments(int argc, char** argv) {
 
         // Validate file extension
         if (!config.fsd_path.ends_with(".textproto")) {
-            std::cerr << "Warning: FSD file should typically have .textproto extension: '" << config.fsd_path << "'"
-                      << '\n';
+            std::cerr << "Warning: FSD file should typically have .textproto extension: '" << config.fsd_path << "'\n";
         }
 
         // Check for invalid filename characters in base_filename
@@ -106,7 +103,7 @@ int main(int argc, char** argv) {
     try {
         InputConfig config = parse_arguments(argc, argv);
 
-        std::cout << "Generating cluster descriptor(s) from FSD..." << '\n';
+        std::cout << "Generating cluster descriptor(s) from FSD...\n";
         std::cout << "  FSD file: " << config.fsd_path << '\n';
         std::cout << "  Output directory: " << config.output_dir << '\n';
         std::cout << "  Base filename: " << config.base_filename << '\n';
@@ -114,16 +111,16 @@ int main(int argc, char** argv) {
         // Ensure output directory exists
         std::filesystem::create_directories(config.output_dir);
 
-        std::cout << "Processing FSD and generating cluster descriptor(s)..." << '\n';
+        std::cout << "Processing FSD and generating cluster descriptor(s)...\n";
         std::string output_file =
             generate_cluster_descriptor_from_fsd(config.fsd_path, config.output_dir, config.base_filename);
 
-        std::cout << "\nSuccessfully generated cluster descriptor(s)!" << '\n';
+        std::cout << "\nSuccessfully generated cluster descriptor(s)!\n";
         std::cout << "  Main output file: " << output_file << '\n';
 
         // Check if this is a multi-host mapping file to provide additional info
         if (output_file.find("_mapping.yaml") != std::string::npos) {
-            std::cout << "  (Multi-host system detected - individual rank files also generated)" << '\n';
+            std::cout << "  (Multi-host system detected - individual rank files also generated)\n";
         }
 
     } catch (const std::exception& e) {

--- a/tools/scaleout/src/run_cabling_generator.cpp
+++ b/tools/scaleout/src/run_cabling_generator.cpp
@@ -48,19 +48,18 @@ InputConfig parse_arguments(int argc, char** argv) {
 
         if (result.count("help") || argc == 1) {
             std::cout << options.help() << '\n';
-            std::cout << "\nOutput files:" << '\n';
-            std::cout << "  - out/scaleout/factory_system_descriptor_<output_name>.textproto" << '\n';
-            std::cout << "  - out/scaleout/cabling_guide_<output_name>.csv" << '\n';
-            std::cout << "\nExamples:" << '\n';
-            std::cout << "  " << argv[0] << " --cabling cabling.textproto --deployment deployment.textproto" << '\n';
-            std::cout << "  # Generates files with default names (no suffix)" << '\n';
+            std::cout << "\nOutput files:\n";
+            std::cout << "  - out/scaleout/factory_system_descriptor_<output_name>.textproto\n";
+            std::cout << "  - out/scaleout/cabling_guide_<output_name>.csv\n";
+            std::cout << "\nExamples:\n";
+            std::cout << "  " << argv[0] << " --cabling cabling.textproto --deployment deployment.textproto\n";
+            std::cout << "  # Generates files with default names (no suffix)\n";
             std::cout << "  " << argv[0]
-                      << " --cabling cabling.textproto --deployment deployment.textproto --output test" << '\n';
-            std::cout << "  # Generates detailed CSV with rack/shelf information" << '\n';
+                      << " --cabling cabling.textproto --deployment deployment.textproto --output test\n";
+            std::cout << "  # Generates detailed CSV with rack/shelf information\n";
             std::cout << "  " << argv[0]
-                      << " --cabling cabling.textproto --deployment deployment.textproto --output test --simple"
-                      << '\n';
-            std::cout << "  # Generates simple CSV with hostname information only" << '\n';
+                      << " --cabling cabling.textproto --deployment deployment.textproto --output test --simple\n";
+            std::cout << "  # Generates simple CSV with hostname information only\n";
             exit(0);
         }
 
@@ -122,12 +121,12 @@ int main(int argc, char** argv) {
     try {
         InputConfig config = parse_arguments(argc, argv);
 
-        std::cout << "Generating cabling configuration..." << '\n';
+        std::cout << "Generating cabling configuration...\n";
         std::cout << "  Cabling descriptor: " << config.cabling_descriptor_path << '\n';
         std::cout << "  Deployment descriptor: " << config.deployment_descriptor_path << '\n';
         std::cout << "  Output name suffix: " << config.output_name << '\n';
 
-        std::cout << "Loading descriptors and initializing generator..." << '\n';
+        std::cout << "Loading descriptors and initializing generator...\n";
         CablingGenerator cabling_generator(config.cabling_descriptor_path, config.deployment_descriptor_path);
 
         std::string factory_output = "out/scaleout/factory_system_descriptor" + config.output_name + ".textproto";
@@ -136,15 +135,15 @@ int main(int argc, char** argv) {
         // Ensure output directory exists
         std::filesystem::create_directories("out/scaleout");
 
-        std::cout << "Generating factory system descriptor..." << '\n';
+        std::cout << "Generating factory system descriptor...\n";
         cabling_generator.emit_factory_system_descriptor(factory_output);
 
-        std::cout << "Generating cabling guide CSV..." << '\n';
+        std::cout << "Generating cabling guide CSV...\n";
         std::cout << "  CSV format: " << (config.loc_info ? "detailed (with location info)" : "simple (hostname-based)")
                   << '\n';
         cabling_generator.emit_cabling_guide_csv(cabling_output, config.loc_info);
 
-        std::cout << "Successfully generated:" << '\n';
+        std::cout << "Successfully generated:\n";
         std::cout << "  - " << factory_output << '\n';
         std::cout << "  - " << cabling_output << '\n';
 

--- a/tools/scaleout/src/run_cabling_generator.cpp
+++ b/tools/scaleout/src/run_cabling_generator.cpp
@@ -47,21 +47,20 @@ InputConfig parse_arguments(int argc, char** argv) {
         auto result = options.parse(argc, argv);
 
         if (result.count("help") || argc == 1) {
-            std::cout << options.help() << std::endl;
-            std::cout << "\nOutput files:" << std::endl;
-            std::cout << "  - out/scaleout/factory_system_descriptor_<output_name>.textproto" << std::endl;
-            std::cout << "  - out/scaleout/cabling_guide_<output_name>.csv" << std::endl;
-            std::cout << "\nExamples:" << std::endl;
-            std::cout << "  " << argv[0] << " --cabling cabling.textproto --deployment deployment.textproto"
-                      << std::endl;
-            std::cout << "  # Generates files with default names (no suffix)" << std::endl;
+            std::cout << options.help() << '\n';
+            std::cout << "\nOutput files:" << '\n';
+            std::cout << "  - out/scaleout/factory_system_descriptor_<output_name>.textproto" << '\n';
+            std::cout << "  - out/scaleout/cabling_guide_<output_name>.csv" << '\n';
+            std::cout << "\nExamples:" << '\n';
+            std::cout << "  " << argv[0] << " --cabling cabling.textproto --deployment deployment.textproto" << '\n';
+            std::cout << "  # Generates files with default names (no suffix)" << '\n';
             std::cout << "  " << argv[0]
-                      << " --cabling cabling.textproto --deployment deployment.textproto --output test" << std::endl;
-            std::cout << "  # Generates detailed CSV with rack/shelf information" << std::endl;
+                      << " --cabling cabling.textproto --deployment deployment.textproto --output test" << '\n';
+            std::cout << "  # Generates detailed CSV with rack/shelf information" << '\n';
             std::cout << "  " << argv[0]
                       << " --cabling cabling.textproto --deployment deployment.textproto --output test --simple"
-                      << std::endl;
-            std::cout << "  # Generates simple CSV with hostname information only" << std::endl;
+                      << '\n';
+            std::cout << "  # Generates simple CSV with hostname information only" << '\n';
             exit(0);
         }
 
@@ -113,8 +112,8 @@ InputConfig parse_arguments(int argc, char** argv) {
         return config;
 
     } catch (const cxxopts::exceptions::exception& e) {
-        std::cerr << "Error parsing arguments: " << e.what() << std::endl;
-        std::cerr << options.help() << std::endl;
+        std::cerr << "Error parsing arguments: " << e.what() << '\n';
+        std::cerr << options.help() << '\n';
         exit(1);
     }
 }
@@ -123,12 +122,12 @@ int main(int argc, char** argv) {
     try {
         InputConfig config = parse_arguments(argc, argv);
 
-        std::cout << "Generating cabling configuration..." << std::endl;
-        std::cout << "  Cabling descriptor: " << config.cabling_descriptor_path << std::endl;
-        std::cout << "  Deployment descriptor: " << config.deployment_descriptor_path << std::endl;
-        std::cout << "  Output name suffix: " << config.output_name << std::endl;
+        std::cout << "Generating cabling configuration..." << '\n';
+        std::cout << "  Cabling descriptor: " << config.cabling_descriptor_path << '\n';
+        std::cout << "  Deployment descriptor: " << config.deployment_descriptor_path << '\n';
+        std::cout << "  Output name suffix: " << config.output_name << '\n';
 
-        std::cout << "Loading descriptors and initializing generator..." << std::endl;
+        std::cout << "Loading descriptors and initializing generator..." << '\n';
         CablingGenerator cabling_generator(config.cabling_descriptor_path, config.deployment_descriptor_path);
 
         std::string factory_output = "out/scaleout/factory_system_descriptor" + config.output_name + ".textproto";
@@ -137,19 +136,20 @@ int main(int argc, char** argv) {
         // Ensure output directory exists
         std::filesystem::create_directories("out/scaleout");
 
-        std::cout << "Generating factory system descriptor..." << std::endl;
+        std::cout << "Generating factory system descriptor..." << '\n';
         cabling_generator.emit_factory_system_descriptor(factory_output);
 
-        std::cout << "Generating cabling guide CSV..." << std::endl;
-        std::cout << "  CSV format: " << (config.loc_info ? "detailed (with location info)" : "simple (hostname-based)") << std::endl;
+        std::cout << "Generating cabling guide CSV..." << '\n';
+        std::cout << "  CSV format: " << (config.loc_info ? "detailed (with location info)" : "simple (hostname-based)")
+                  << '\n';
         cabling_generator.emit_cabling_guide_csv(cabling_output, config.loc_info);
 
-        std::cout << "Successfully generated:" << std::endl;
-        std::cout << "  - " << factory_output << std::endl;
-        std::cout << "  - " << cabling_output << std::endl;
+        std::cout << "Successfully generated:" << '\n';
+        std::cout << "  - " << factory_output << '\n';
+        std::cout << "  - " << cabling_output << '\n';
 
     } catch (const std::exception& e) {
-        std::cerr << "Error: " << e.what() << std::endl;
+        std::cerr << "Error: " << e.what() << '\n';
         return 1;
     }
 

--- a/tools/scaleout/validation/run_cluster_validation.cpp
+++ b/tools/scaleout/validation/run_cluster_validation.cpp
@@ -325,8 +325,8 @@ void print_usage_info(CommandMode mode = CommandMode::VALIDATE) {
     } else {
         auto options = create_validation_options();
         std::cout << options.help() << '\n';
-        std::cout << "link_reset Subcommand:" << '\n';
-        std::cout << "  Use 'run_cluster_validation link_reset --help' for link_reset options." << '\n';
+        std::cout << "link_reset Subcommand:\n";
+        std::cout << "  Use 'run_cluster_validation link_reset --help' for link_reset options.\n";
     }
 }
 

--- a/tools/scaleout/validation/run_cluster_validation.cpp
+++ b/tools/scaleout/validation/run_cluster_validation.cpp
@@ -140,8 +140,8 @@ void parse_link_reset_args(int argc, char* argv[], InputArgs& input_args) {
                 false, "All link_reset parameters must be specified: --host, --tray-id, --asic-location, --channel");
         }
     } catch (const cxxopts::exceptions::exception& e) {
-        std::cerr << "Error parsing link_reset arguments: " << e.what() << std::endl;
-        std::cerr << options.help() << std::endl;
+        std::cerr << "Error parsing link_reset arguments: " << e.what() << '\n';
+        std::cerr << options.help() << '\n';
         exit(1);
     }
 }
@@ -223,8 +223,8 @@ void parse_validation_args(int argc, char* argv[], InputArgs& input_args) {
             input_args.cabling_descriptor_path.has_value() || input_args.fsd_path.has_value();
 
     } catch (const cxxopts::exceptions::exception& e) {
-        std::cerr << "Error parsing arguments: " << e.what() << std::endl;
-        std::cerr << options.help() << std::endl;
+        std::cerr << "Error parsing arguments: " << e.what() << '\n';
+        std::cerr << options.help() << '\n';
         exit(1);
     }
 }
@@ -321,12 +321,12 @@ AsicTopology run_connectivity_validation(
 void print_usage_info(CommandMode mode = CommandMode::VALIDATE) {
     if (mode == CommandMode::LINK_RETRAIN) {
         auto options = create_link_reset_options();
-        std::cout << options.help() << std::endl;
+        std::cout << options.help() << '\n';
     } else {
         auto options = create_validation_options();
-        std::cout << options.help() << std::endl;
-        std::cout << "link_reset Subcommand:" << std::endl;
-        std::cout << "  Use 'run_cluster_validation link_reset --help' for link_reset options." << std::endl;
+        std::cout << options.help() << '\n';
+        std::cout << "link_reset Subcommand:" << '\n';
+        std::cout << "  Use 'run_cluster_validation link_reset --help' for link_reset options." << '\n';
     }
 }
 

--- a/tools/scaleout/validation/utils/cluster_validation_utils.cpp
+++ b/tools/scaleout/validation/utils/cluster_validation_utils.cpp
@@ -681,10 +681,8 @@ void print_ethernet_connectivity(
                 }
 
                 // Print port type header
-                std::cout << '\n'
-                          << "             ---------------------- Port Type: " << port_type
-                          << " ---------------------- \n"
-                          << '\n';
+                std::cout << "\n             ---------------------- Port Type: " << port_type
+                          << " ---------------------- \n\n";
 
                 // Print all connections for this port type
                 for (const auto& conn : connections) {

--- a/tools/scaleout/validation/utils/cluster_validation_utils.cpp
+++ b/tools/scaleout/validation/utils/cluster_validation_utils.cpp
@@ -658,11 +658,9 @@ void print_ethernet_connectivity(
         // Print connection type header
         std::cout << '\n';
         if (is_cross_host) {
-            std::cout << " ============================== CROSS-HOST CONNECTIONS =============================== "
-                      << '\n';
+            std::cout << " ============================== CROSS-HOST CONNECTIONS =============================== \n";
         } else {
-            std::cout << " ============================== HOST-LOCAL CONNECTIONS =============================== "
-                      << '\n';
+            std::cout << " ============================== HOST-LOCAL CONNECTIONS =============================== \n";
         }
 
         // Iterate through hostnames
@@ -674,7 +672,7 @@ void print_ethernet_connectivity(
             // Print hostname header
             std::cout << '\n'
                       << "  =============================== Hostname: " << hostname
-                      << " =============================== " << '\n';
+                      << " =============================== \n";
 
             // Iterate through port types
             for (const auto& [port_type, connections] : port_types_map) {
@@ -685,7 +683,7 @@ void print_ethernet_connectivity(
                 // Print port type header
                 std::cout << '\n'
                           << "             ---------------------- Port Type: " << port_type
-                          << " ---------------------- " << '\n'
+                          << " ---------------------- \n"
                           << '\n';
 
                 // Print all connections for this port type
@@ -800,19 +798,15 @@ void log_link_metrics(
 
     // Print console table
     std::cout << '\n';
-    std::cout << "╔═══════════════════════════════════════════════════════════════════════════════════════════════════╗"
-              << '\n';
+    std::cout << "╔═══════════════════════════════════════════════════════════════════════════════════════════════════╗\n";
     if (log_ethernet_metrics) {
         std::cout
-            << "║                          ETHERNET METRICS REPORT                                                  ║"
-            << '\n';
+            << "║                          ETHERNET METRICS REPORT                                                  ║\n";
     } else {
         std::cout
-            << "║                              FAULTY LINKS REPORT                                                  ║"
-            << '\n';
+            << "║                              FAULTY LINKS REPORT                                                  ║\n";
     }
-    std::cout << "╚═══════════════════════════════════════════════════════════════════════════════════════════════════╝"
-              << '\n';
+    std::cout << "╚═══════════════════════════════════════════════════════════════════════════════════════════════════╝\n";
     if (log_ethernet_metrics) {
         std::cout << "Total Links: " << link_metrics.size() << '\n';
         std::cout << "Total Metric Entries: " << metric_rows.size() << '\n' << '\n';
@@ -830,7 +824,7 @@ void log_link_metrics(
         std::cout << std::setw(40) << "Failure Type";
     }
 
-    std::cout << std::setw(12) << "Pkt Size" << std::setw(12) << "Data Size" << '\n';
+    std::cout << std::setw(12) << "Pkt Size" << std::setw(12) << "Data Size\n";
 
     std::cout << std::string(log_ethernet_metrics ? 177 : 217, '-') << '\n';
 
@@ -896,8 +890,7 @@ void log_link_metrics(
             csv_file << ",Failure_Type";
         }
         csv_file << ",Packet_Size_Bytes,Data_Size_Bytes,"
-                 << "Retrain_Count,CRC_Error_Count,Corrected_Codeword_Count,Uncorrected_Codeword_Count,Mismatched_Words"
-                 << '\n';
+                 << "Retrain_Count,CRC_Error_Count,Corrected_Codeword_Count,Uncorrected_Codeword_Count,Mismatched_Words\n";
 
         // CSV rows
         for (const auto& row : metric_rows) {

--- a/tools/scaleout/validation/utils/cluster_validation_utils.cpp
+++ b/tools/scaleout/validation/utils/cluster_validation_utils.cpp
@@ -656,13 +656,13 @@ void print_ethernet_connectivity(
         }
 
         // Print connection type header
-        std::cout << std::endl;
+        std::cout << '\n';
         if (is_cross_host) {
             std::cout << " ============================== CROSS-HOST CONNECTIONS =============================== "
-                      << std::endl;
+                      << '\n';
         } else {
             std::cout << " ============================== HOST-LOCAL CONNECTIONS =============================== "
-                      << std::endl;
+                      << '\n';
         }
 
         // Iterate through hostnames
@@ -672,9 +672,9 @@ void print_ethernet_connectivity(
             }
 
             // Print hostname header
-            std::cout << std::endl
+            std::cout << '\n'
                       << "  =============================== Hostname: " << hostname
-                      << " =============================== " << std::endl;
+                      << " =============================== " << '\n';
 
             // Iterate through port types
             for (const auto& [port_type, connections] : port_types_map) {
@@ -683,23 +683,23 @@ void print_ethernet_connectivity(
                 }
 
                 // Print port type header
-                std::cout << std::endl
+                std::cout << '\n'
                           << "             ---------------------- Port Type: " << port_type
-                          << " ---------------------- " << std::endl
-                          << std::endl;
+                          << " ---------------------- " << '\n'
+                          << '\n';
 
                 // Print all connections for this port type
                 for (const auto& conn : connections) {
                     std::cout << " [" << conn.host << "] Unique ID: " << std::hex << *conn.asic_id
                               << " Tray: " << std::dec << *conn.tray_id << ", ASIC Location: " << std::dec
                               << *conn.asic_location << ", Ethernet Channel: " << std::dec << +conn.channel
-                              << ", Port ID: " << std::dec << *conn.port_id << std::endl;
+                              << ", Port ID: " << std::dec << *conn.port_id << '\n';
 
                     std::cout << "\tConnected to [" << conn.connected_host << "] Unique ID: " << std::hex
                               << *conn.connected_asic_id << " Tray: " << std::dec << *conn.connected_tray_id
                               << ", ASIC Location: " << std::dec << *conn.connected_asic_location
-                              << ", Ethernet Channel: " << std::dec << +conn.connected_channel << std::endl;
-                    std::cout << std::endl;
+                              << ", Ethernet Channel: " << std::dec << +conn.connected_channel << '\n';
+                    std::cout << '\n';
                 }
             }
         }
@@ -799,25 +799,25 @@ void log_link_metrics(
     }
 
     // Print console table
-    std::cout << std::endl;
+    std::cout << '\n';
     std::cout << "╔═══════════════════════════════════════════════════════════════════════════════════════════════════╗"
-              << std::endl;
+              << '\n';
     if (log_ethernet_metrics) {
         std::cout
             << "║                          ETHERNET METRICS REPORT                                                  ║"
-            << std::endl;
+            << '\n';
     } else {
         std::cout
             << "║                              FAULTY LINKS REPORT                                                  ║"
-            << std::endl;
+            << '\n';
     }
     std::cout << "╚═══════════════════════════════════════════════════════════════════════════════════════════════════╝"
-              << std::endl;
+              << '\n';
     if (log_ethernet_metrics) {
-        std::cout << "Total Links: " << link_metrics.size() << std::endl;
-        std::cout << "Total Metric Entries: " << metric_rows.size() << std::endl << std::endl;
+        std::cout << "Total Links: " << link_metrics.size() << '\n';
+        std::cout << "Total Metric Entries: " << metric_rows.size() << '\n' << '\n';
     } else {
-        std::cout << "Total Faulty Links: " << link_metrics.size() << std::endl << std::endl;
+        std::cout << "Total Faulty Links: " << link_metrics.size() << '\n' << '\n';
     }
 
     // Table header
@@ -830,9 +830,9 @@ void log_link_metrics(
         std::cout << std::setw(40) << "Failure Type";
     }
 
-    std::cout << std::setw(12) << "Pkt Size" << std::setw(12) << "Data Size" << std::endl;
+    std::cout << std::setw(12) << "Pkt Size" << std::setw(12) << "Data Size" << '\n';
 
-    std::cout << std::string(log_ethernet_metrics ? 177 : 217, '-') << std::endl;
+    std::cout << std::string(log_ethernet_metrics ? 177 : 217, '-') << '\n';
 
     // Table rows
     for (const auto& row : metric_rows) {
@@ -879,10 +879,10 @@ void log_link_metrics(
         }
 
         std::cout << std::setw(12) << (std::to_string(row.traffic_params.packet_size_bytes) + " B") << std::setw(12)
-                  << (std::to_string(row.traffic_params.data_size) + " B") << std::endl;
+                  << (std::to_string(row.traffic_params.data_size) + " B") << '\n';
     }
 
-    std::cout << std::string(log_ethernet_metrics ? 177 : 217, '-') << std::endl << std::endl;
+    std::cout << std::string(log_ethernet_metrics ? 177 : 217, '-') << '\n' << '\n';
 
     // Write CSV file
     std::filesystem::path csv_path =
@@ -897,7 +897,7 @@ void log_link_metrics(
         }
         csv_file << ",Packet_Size_Bytes,Data_Size_Bytes,"
                  << "Retrain_Count,CRC_Error_Count,Corrected_Codeword_Count,Uncorrected_Codeword_Count,Mismatched_Words"
-                 << std::endl;
+                 << '\n';
 
         // CSV rows
         for (const auto& row : metric_rows) {
@@ -914,7 +914,7 @@ void log_link_metrics(
                      << "0x" << std::hex << row.crc_error_count << std::dec << ","
                      << "0x" << std::hex << row.corrected_codeword_count << std::dec << ","
                      << "0x" << std::hex << row.uncorrected_codeword_count << std::dec << ","
-                     << row.num_mismatched_words << std::endl;
+                     << row.num_mismatched_words << '\n';
         }
 
         csv_file.close();

--- a/tools/scaleout/validation/utils/cluster_validation_utils.cpp
+++ b/tools/scaleout/validation/utils/cluster_validation_utils.cpp
@@ -809,7 +809,7 @@ void log_link_metrics(
         std::cout << "Total Links: " << link_metrics.size() << '\n';
         std::cout << "Total Metric Entries: " << metric_rows.size() << '\n' << '\n';
     } else {
-        std::cout << "Total Faulty Links: " << link_metrics.size() << '\n' << '\n';
+        std::cout << "Total Faulty Links: " << link_metrics.size() << "\n\n";
     }
 
     // Table header
@@ -874,7 +874,7 @@ void log_link_metrics(
                   << (std::to_string(row.traffic_params.data_size) + " B") << '\n';
     }
 
-    std::cout << std::string(log_ethernet_metrics ? 177 : 217, '-') << '\n' << '\n';
+    std::cout << std::string(log_ethernet_metrics ? 177 : 217, '-') << "\n\n";
 
     // Write CSV file
     std::filesystem::path csv_path =

--- a/tools/tests/scaleout/test_factory_system_descriptor.cpp
+++ b/tools/tests/scaleout/test_factory_system_descriptor.cpp
@@ -151,7 +151,7 @@ TEST(Cluster, TestFactorySystemDescriptor5WHGalaxyYTorus) {
                     "tools/tests/scaleout/global_system_descriptors/"
                     "5_wh_galaxy_y_torus_physical_desc.yaml");
             } catch (const std::runtime_error& e) {
-                std::cout << e.what() << std::endl;
+                std::cout << e.what() << '\n';
                 throw;
             }
         },
@@ -185,7 +185,7 @@ TEST(Cluster, TestGenerateClusterDescriptorFromFSD) {
     EXPECT_TRUE(std::filesystem::exists(result_file));
     EXPECT_GT(std::filesystem::file_size(result_file), 0);
 
-    std::cout << "Generated cluster descriptor written to: " << result_file << std::endl;
+    std::cout << "Generated cluster descriptor written to: " << result_file << '\n';
 }
 
 TEST(Cluster, TestGenerateMultiHostClusterDescriptorFromFSD) {

--- a/tt_metal/api/tt-metalium/runtime_args_data.hpp
+++ b/tt_metal/api/tt-metalium/runtime_args_data.hpp
@@ -26,7 +26,7 @@ struct RuntimeArgsData {
     bool in_bounds(std::size_t index) const noexcept {
         if (index >= rt_args_count) {
             std::cerr << "TT_FATAL: Index " << index << " is larger than runtime args size " << rt_args_count << " at "
-                      << __FILE__ << ":" << __LINE__ << std::endl;
+                      << __FILE__ << ":" << __LINE__ << '\n';
             return false;
         }
         return true;

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -1857,9 +1857,9 @@ void ControlPlane::print_routing_tables() const {
     this->print_ethernet_channels();
 
     std::stringstream ss;
-    ss << "Control Plane: IntraMesh Routing Tables" << '\n';
+    ss << "Control Plane: IntraMesh Routing Tables\n";
     for (const auto& [fabric_node_id, chip_routing_table] : this->intra_mesh_routing_tables_) {
-        ss << fabric_node_id << ":" << '\n';
+        ss << fabric_node_id << ":\n";
         for (int eth_chan = 0; eth_chan < chip_routing_table.size(); eth_chan++) {
             ss << "   Eth Chan " << eth_chan << ": ";
             for (const auto& dst_chan_id : chip_routing_table[eth_chan]) {
@@ -1871,10 +1871,10 @@ void ControlPlane::print_routing_tables() const {
 
     log_debug(tt::LogFabric, "{}", ss.str());
     ss.str(std::string());
-    ss << "Control Plane: InterMesh Routing Tables" << '\n';
+    ss << "Control Plane: InterMesh Routing Tables\n";
 
     for (const auto& [fabric_node_id, chip_routing_table] : this->inter_mesh_routing_tables_) {
-        ss << fabric_node_id << ":" << '\n';
+        ss << fabric_node_id << ":\n";
         for (int eth_chan = 0; eth_chan < chip_routing_table.size(); eth_chan++) {
             ss << "   Eth Chan " << eth_chan << ": ";
             for (const auto& dst_chan_id : chip_routing_table[eth_chan]) {
@@ -1888,9 +1888,9 @@ void ControlPlane::print_routing_tables() const {
 
 void ControlPlane::print_ethernet_channels() const {
     std::stringstream ss;
-    ss << "Control Plane: Physical eth channels in each direction" << '\n';
+    ss << "Control Plane: Physical eth channels in each direction\n";
     for (const auto& [fabric_node_id, fabric_eth_channels] : this->router_port_directions_to_physical_eth_chan_map_) {
-        ss << fabric_node_id << ": " << '\n';
+        ss << fabric_node_id << ": \n";
         for (const auto& [direction, eth_chans] : fabric_eth_channels) {
             ss << "   " << enchantum::to_string(direction) << ":";
             for (const auto& eth_chan : eth_chans) {

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -1857,30 +1857,30 @@ void ControlPlane::print_routing_tables() const {
     this->print_ethernet_channels();
 
     std::stringstream ss;
-    ss << "Control Plane: IntraMesh Routing Tables" << std::endl;
+    ss << "Control Plane: IntraMesh Routing Tables" << '\n';
     for (const auto& [fabric_node_id, chip_routing_table] : this->intra_mesh_routing_tables_) {
-        ss << fabric_node_id << ":" << std::endl;
+        ss << fabric_node_id << ":" << '\n';
         for (int eth_chan = 0; eth_chan < chip_routing_table.size(); eth_chan++) {
             ss << "   Eth Chan " << eth_chan << ": ";
             for (const auto& dst_chan_id : chip_routing_table[eth_chan]) {
                 ss << (std::uint16_t)dst_chan_id << " ";
             }
-            ss << std::endl;
+            ss << '\n';
         }
     }
 
     log_debug(tt::LogFabric, "{}", ss.str());
     ss.str(std::string());
-    ss << "Control Plane: InterMesh Routing Tables" << std::endl;
+    ss << "Control Plane: InterMesh Routing Tables" << '\n';
 
     for (const auto& [fabric_node_id, chip_routing_table] : this->inter_mesh_routing_tables_) {
-        ss << fabric_node_id << ":" << std::endl;
+        ss << fabric_node_id << ":" << '\n';
         for (int eth_chan = 0; eth_chan < chip_routing_table.size(); eth_chan++) {
             ss << "   Eth Chan " << eth_chan << ": ";
             for (const auto& dst_chan_id : chip_routing_table[eth_chan]) {
                 ss << (std::uint16_t)dst_chan_id << " ";
             }
-            ss << std::endl;
+            ss << '\n';
         }
     }
     log_debug(tt::LogFabric, "{}", ss.str());
@@ -1888,15 +1888,15 @@ void ControlPlane::print_routing_tables() const {
 
 void ControlPlane::print_ethernet_channels() const {
     std::stringstream ss;
-    ss << "Control Plane: Physical eth channels in each direction" << std::endl;
+    ss << "Control Plane: Physical eth channels in each direction" << '\n';
     for (const auto& [fabric_node_id, fabric_eth_channels] : this->router_port_directions_to_physical_eth_chan_map_) {
-        ss << fabric_node_id << ": " << std::endl;
+        ss << fabric_node_id << ": " << '\n';
         for (const auto& [direction, eth_chans] : fabric_eth_channels) {
             ss << "   " << enchantum::to_string(direction) << ":";
             for (const auto& eth_chan : eth_chans) {
                 ss << " " << (std::uint16_t)eth_chan;
             }
-            ss << std::endl;
+            ss << '\n';
         }
     }
     log_debug(tt::LogFabric, "{}", ss.str());

--- a/tt_metal/fabric/mesh_graph.cpp
+++ b/tt_metal/fabric/mesh_graph.cpp
@@ -601,9 +601,9 @@ const std::vector<std::unordered_map<port_id_t, ChipId, hash_pair>>& MeshGraph::
 
 void MeshGraph::print_connectivity() const {
     std::stringstream ss;
-    ss << " Mesh Graph:  Intra Mesh Connectivity: " << '\n';
+    ss << " Mesh Graph:  Intra Mesh Connectivity: \n";
     for (uint32_t mesh_id_val = 0; mesh_id_val < this->intra_mesh_connectivity_.size(); mesh_id_val++) {
-        ss << "M" << mesh_id_val << ":" << '\n';
+        ss << "M" << mesh_id_val << ":\n";
         for (uint32_t chip_id = 0; chip_id < this->intra_mesh_connectivity_[mesh_id_val].size(); chip_id++) {
             ss << "   D" << chip_id << ": ";
             for (auto [connected_chip_id, edge] : this->intra_mesh_connectivity_[mesh_id_val][chip_id]) {
@@ -617,9 +617,9 @@ void MeshGraph::print_connectivity() const {
     }
     log_debug(tt::LogFabric, "{}", ss.str());
     ss.str(std::string());
-    ss << " Mesh Graph:  Inter Mesh Connectivity: " << '\n';
+    ss << " Mesh Graph:  Inter Mesh Connectivity: \n";
     for (uint32_t mesh_id_val = 0; mesh_id_val < this->inter_mesh_connectivity_.size(); mesh_id_val++) {
-        ss << "M" << mesh_id_val << ":" << '\n';
+        ss << "M" << mesh_id_val << ":\n";
         for (uint32_t chip_id = 0; chip_id < this->inter_mesh_connectivity_[mesh_id_val].size(); chip_id++) {
             ss << "   D" << chip_id << ": ";
             for (auto [connected_mesh_id, edge] : this->inter_mesh_connectivity_[mesh_id_val][chip_id]) {

--- a/tt_metal/fabric/mesh_graph.cpp
+++ b/tt_metal/fabric/mesh_graph.cpp
@@ -601,9 +601,9 @@ const std::vector<std::unordered_map<port_id_t, ChipId, hash_pair>>& MeshGraph::
 
 void MeshGraph::print_connectivity() const {
     std::stringstream ss;
-    ss << " Mesh Graph:  Intra Mesh Connectivity: " << std::endl;
+    ss << " Mesh Graph:  Intra Mesh Connectivity: " << '\n';
     for (uint32_t mesh_id_val = 0; mesh_id_val < this->intra_mesh_connectivity_.size(); mesh_id_val++) {
-        ss << "M" << mesh_id_val << ":" << std::endl;
+        ss << "M" << mesh_id_val << ":" << '\n';
         for (uint32_t chip_id = 0; chip_id < this->intra_mesh_connectivity_[mesh_id_val].size(); chip_id++) {
             ss << "   D" << chip_id << ": ";
             for (auto [connected_chip_id, edge] : this->intra_mesh_connectivity_[mesh_id_val][chip_id]) {
@@ -612,14 +612,14 @@ void MeshGraph::print_connectivity() const {
                        << edge.weight << ") ";
                 }
             }
-            ss << std::endl;
+            ss << '\n';
         }
     }
     log_debug(tt::LogFabric, "{}", ss.str());
     ss.str(std::string());
-    ss << " Mesh Graph:  Inter Mesh Connectivity: " << std::endl;
+    ss << " Mesh Graph:  Inter Mesh Connectivity: " << '\n';
     for (uint32_t mesh_id_val = 0; mesh_id_val < this->inter_mesh_connectivity_.size(); mesh_id_val++) {
-        ss << "M" << mesh_id_val << ":" << std::endl;
+        ss << "M" << mesh_id_val << ":" << '\n';
         for (uint32_t chip_id = 0; chip_id < this->inter_mesh_connectivity_[mesh_id_val].size(); chip_id++) {
             ss << "   D" << chip_id << ": ";
             for (auto [connected_mesh_id, edge] : this->inter_mesh_connectivity_[mesh_id_val][chip_id]) {
@@ -628,7 +628,7 @@ void MeshGraph::print_connectivity() const {
                        << enchantum::to_string(edge.port_direction) << ", " << edge.weight << ") ";
                 }
             }
-            ss << std::endl;
+            ss << '\n';
         }
     }
     log_debug(tt::LogFabric, "{}", ss.str());

--- a/tt_metal/fabric/mesh_graph_descriptor.cpp
+++ b/tt_metal/fabric/mesh_graph_descriptor.cpp
@@ -1408,17 +1408,17 @@ void MeshGraphDescriptor::print_node(GlobalNodeId id, int indent_level) {
 
     const auto it = instances_.find(id);
     if (it == instances_.end()) {
-        ss << indent << "Unknown instance id: " << id << std::endl;
+        ss << indent << "Unknown instance id: " << id << '\n';
         log_debug(tt::LogFabric, "{}", ss.str());
         return;
     }
 
     const InstanceData & inst = it->second;
     if (inst.kind == NodeKind::Mesh) {
-        ss << indent << "=== MESH INSTANCE ===" << std::endl;
-        ss << indent << "Global ID: " << id << std::endl;
-        ss << indent << "Local ID: " << inst.local_id << std::endl;
-        ss << indent << "Name: " << inst.name << std::endl;
+        ss << indent << "=== MESH INSTANCE ===" << '\n';
+        ss << indent << "Global ID: " << id << '\n';
+        ss << indent << "Local ID: " << inst.local_id << '\n';
+        ss << indent << "Name: " << inst.name << '\n';
         const auto* mesh_desc = std::get<const proto::MeshDescriptor*>(inst.desc);
         ss << indent << "Device Topology Dimensions: [";
         for (int i = 0; i < mesh_desc->device_topology().dims_size(); ++i) {
@@ -1427,7 +1427,7 @@ void MeshGraphDescriptor::print_node(GlobalNodeId id, int indent_level) {
             }
             ss << mesh_desc->device_topology().dims(i);
         }
-        ss << "]" << std::endl;
+        ss << "]" << '\n';
         ss << indent << "Host Topology Dimensions: [";
         for (int i = 0; i < mesh_desc->host_topology().dims_size(); ++i) {
             if (i > 0) {
@@ -1435,11 +1435,11 @@ void MeshGraphDescriptor::print_node(GlobalNodeId id, int indent_level) {
             }
             ss << mesh_desc->host_topology().dims(i);
         }
-        ss << "]" << std::endl;
-        ss << indent << "Channel Count: " << mesh_desc->channels().count() << std::endl;
-        ss << indent << "Express Connections: " << mesh_desc->express_connections_size() << std::endl;
+        ss << "]" << '\n';
+        ss << indent << "Channel Count: " << mesh_desc->channels().count() << '\n';
+        ss << indent << "Express Connections: " << mesh_desc->express_connections_size() << '\n';
         if (!inst.sub_instances.empty()) {
-            ss << indent << "Devices:" << std::endl;
+            ss << indent << "Devices:" << '\n';
             log_debug(tt::LogFabric, "{}", ss.str());
             ss.str(std::string());
             // Print devices in ascending local_id order
@@ -1455,19 +1455,19 @@ void MeshGraphDescriptor::print_node(GlobalNodeId id, int indent_level) {
             return; // children already printed with their own trailing separators
         }
     } else if (inst.kind == NodeKind::Graph) {
-        ss << indent << "=== GRAPH INSTANCE ===" << std::endl;
-        ss << indent << "Global ID: " << id << std::endl;
-        ss << indent << "Local ID: " << inst.local_id << std::endl;
-        ss << indent << "Name: " << inst.name << std::endl;
-        ss << indent << "Type: " << inst.type << std::endl;
+        ss << indent << "=== GRAPH INSTANCE ===" << '\n';
+        ss << indent << "Global ID: " << id << '\n';
+        ss << indent << "Local ID: " << inst.local_id << '\n';
+        ss << indent << "Name: " << inst.name << '\n';
+        ss << indent << "Type: " << inst.type << '\n';
         const auto* graph_desc = std::get<const proto::GraphDescriptor*>(inst.desc);
-        ss << indent << "Total Instances in Descriptor: " << graph_desc->instances_size() << std::endl;
-        ss << indent << "Connections: " << graph_desc->connections_size() << std::endl;
+        ss << indent << "Total Instances in Descriptor: " << graph_desc->instances_size() << '\n';
+        ss << indent << "Connections: " << graph_desc->connections_size() << '\n';
         if (graph_desc->has_graph_topology()) {
-            ss << indent << "Has Graph Topology: Yes" << std::endl;
+            ss << indent << "Has Graph Topology: Yes" << '\n';
         }
         if (!inst.sub_instances.empty()) {
-            ss << indent << "Sub-instances:" << std::endl;
+            ss << indent << "Sub-instances:" << '\n';
             log_debug(tt::LogFabric, "{}", ss.str());
             ss.str(std::string());
             // Print children in ascending local_id order
@@ -1483,25 +1483,25 @@ void MeshGraphDescriptor::print_node(GlobalNodeId id, int indent_level) {
             return; // children already printed with their own trailing separators
         }
     } else if (inst.kind == NodeKind::Device) {
-        ss << indent << "=== DEVICE INSTANCE ===" << std::endl;
-        ss << indent << "Global ID: " << id << std::endl;
-        ss << indent << "Local ID: " << inst.local_id << std::endl;
-        ss << indent << "Name: " << inst.name << std::endl;
-        ss << indent << "Hierarchy Depth: " << inst.hierarchy.size() << std::endl;
+        ss << indent << "=== DEVICE INSTANCE ===" << '\n';
+        ss << indent << "Global ID: " << id << '\n';
+        ss << indent << "Local ID: " << inst.local_id << '\n';
+        ss << indent << "Name: " << inst.name << '\n';
+        ss << indent << "Hierarchy Depth: " << inst.hierarchy.size() << '\n';
     } else {
-        ss << indent << "=== UNKNOWN NODE TYPE ===" << std::endl;
-        ss << indent << "Global ID: " << id << std::endl;
+        ss << indent << "=== UNKNOWN NODE TYPE ===" << '\n';
+        ss << indent << "Global ID: " << id << '\n';
     }
 
-    ss << indent << "---" << std::endl;
+    ss << indent << "---" << '\n';
     log_debug(tt::LogFabric, "{}", ss.str());
 }
 
 void MeshGraphDescriptor::print_all_nodes() {
     std::stringstream ss;
-    ss << "\n=== PRINTING ALL NODE INSTANCES (recursive from top-level) ===" << std::endl;
-    ss << "Total instances: " << instances_.size() << std::endl;
-    ss << "=====================================" << std::endl;
+    ss << "\n=== PRINTING ALL NODE INSTANCES (recursive from top-level) ===" << '\n';
+    ss << "Total instances: " << instances_.size() << '\n';
+    ss << "=====================================" << '\n';
     log_debug(tt::LogFabric, "{}", ss.str());
 
     // Start from top-level and recursively print in local-id order

--- a/tt_metal/fabric/mesh_graph_descriptor.cpp
+++ b/tt_metal/fabric/mesh_graph_descriptor.cpp
@@ -1415,7 +1415,7 @@ void MeshGraphDescriptor::print_node(GlobalNodeId id, int indent_level) {
 
     const InstanceData & inst = it->second;
     if (inst.kind == NodeKind::Mesh) {
-        ss << indent << "=== MESH INSTANCE ===" << '\n';
+        ss << indent << "=== MESH INSTANCE ===\n";
         ss << indent << "Global ID: " << id << '\n';
         ss << indent << "Local ID: " << inst.local_id << '\n';
         ss << indent << "Name: " << inst.name << '\n';
@@ -1427,7 +1427,7 @@ void MeshGraphDescriptor::print_node(GlobalNodeId id, int indent_level) {
             }
             ss << mesh_desc->device_topology().dims(i);
         }
-        ss << "]" << '\n';
+        ss << "]\n";
         ss << indent << "Host Topology Dimensions: [";
         for (int i = 0; i < mesh_desc->host_topology().dims_size(); ++i) {
             if (i > 0) {
@@ -1435,11 +1435,11 @@ void MeshGraphDescriptor::print_node(GlobalNodeId id, int indent_level) {
             }
             ss << mesh_desc->host_topology().dims(i);
         }
-        ss << "]" << '\n';
+        ss << "]\n";
         ss << indent << "Channel Count: " << mesh_desc->channels().count() << '\n';
         ss << indent << "Express Connections: " << mesh_desc->express_connections_size() << '\n';
         if (!inst.sub_instances.empty()) {
-            ss << indent << "Devices:" << '\n';
+            ss << indent << "Devices:\n";
             log_debug(tt::LogFabric, "{}", ss.str());
             ss.str(std::string());
             // Print devices in ascending local_id order
@@ -1455,7 +1455,7 @@ void MeshGraphDescriptor::print_node(GlobalNodeId id, int indent_level) {
             return; // children already printed with their own trailing separators
         }
     } else if (inst.kind == NodeKind::Graph) {
-        ss << indent << "=== GRAPH INSTANCE ===" << '\n';
+        ss << indent << "=== GRAPH INSTANCE ===\n";
         ss << indent << "Global ID: " << id << '\n';
         ss << indent << "Local ID: " << inst.local_id << '\n';
         ss << indent << "Name: " << inst.name << '\n';
@@ -1464,10 +1464,10 @@ void MeshGraphDescriptor::print_node(GlobalNodeId id, int indent_level) {
         ss << indent << "Total Instances in Descriptor: " << graph_desc->instances_size() << '\n';
         ss << indent << "Connections: " << graph_desc->connections_size() << '\n';
         if (graph_desc->has_graph_topology()) {
-            ss << indent << "Has Graph Topology: Yes" << '\n';
+            ss << indent << "Has Graph Topology: Yes\n";
         }
         if (!inst.sub_instances.empty()) {
-            ss << indent << "Sub-instances:" << '\n';
+            ss << indent << "Sub-instances:\n";
             log_debug(tt::LogFabric, "{}", ss.str());
             ss.str(std::string());
             // Print children in ascending local_id order
@@ -1483,25 +1483,25 @@ void MeshGraphDescriptor::print_node(GlobalNodeId id, int indent_level) {
             return; // children already printed with their own trailing separators
         }
     } else if (inst.kind == NodeKind::Device) {
-        ss << indent << "=== DEVICE INSTANCE ===" << '\n';
+        ss << indent << "=== DEVICE INSTANCE ===\n";
         ss << indent << "Global ID: " << id << '\n';
         ss << indent << "Local ID: " << inst.local_id << '\n';
         ss << indent << "Name: " << inst.name << '\n';
         ss << indent << "Hierarchy Depth: " << inst.hierarchy.size() << '\n';
     } else {
-        ss << indent << "=== UNKNOWN NODE TYPE ===" << '\n';
+        ss << indent << "=== UNKNOWN NODE TYPE ===\n";
         ss << indent << "Global ID: " << id << '\n';
     }
 
-    ss << indent << "---" << '\n';
+    ss << indent << "---\n";
     log_debug(tt::LogFabric, "{}", ss.str());
 }
 
 void MeshGraphDescriptor::print_all_nodes() {
     std::stringstream ss;
-    ss << "\n=== PRINTING ALL NODE INSTANCES (recursive from top-level) ===" << '\n';
+    ss << "\n=== PRINTING ALL NODE INSTANCES (recursive from top-level) ===\n";
     ss << "Total instances: " << instances_.size() << '\n';
-    ss << "=====================================" << '\n';
+    ss << "=====================================\n";
     log_debug(tt::LogFabric, "{}", ss.str());
 
     // Start from top-level and recursively print in local-id order

--- a/tt_metal/fabric/physical_system_descriptor.cpp
+++ b/tt_metal/fabric/physical_system_descriptor.cpp
@@ -594,7 +594,7 @@ void PhysicalSystemDescriptor::dump_to_yaml(const std::optional<std::string>& pa
             TT_THROW("Failed to write YAML content to file: {}", path_to_yaml.value());
         }
     } else {
-        std::cout << root << std::endl;
+        std::cout << root << '\n';
     }
 }
 

--- a/tt_metal/fabric/routing_table_generator.cpp
+++ b/tt_metal/fabric/routing_table_generator.cpp
@@ -325,9 +325,9 @@ void RoutingTableGenerator::load_intermesh_connections(const AnnotatedIntermeshC
 
 void RoutingTableGenerator::print_routing_tables() const {
     std::stringstream ss;
-    ss << "Routing Table Generator: IntraMesh Routing Tables" << std::endl;
+    ss << "Routing Table Generator: IntraMesh Routing Tables" << '\n';
     for (std::uint32_t mesh_id_val = 0; mesh_id_val < this->intra_mesh_table_.size(); mesh_id_val++) {
-        ss << "M" << mesh_id_val << ":" << std::endl;
+        ss << "M" << mesh_id_val << ":" << '\n';
         for (ChipId src_chip_id = 0; src_chip_id < this->intra_mesh_table_[mesh_id_val].size(); src_chip_id++) {
             ss << "   D" << src_chip_id << ": ";
             for (ChipId dst_chip_or_mesh_id = 0;
@@ -336,14 +336,14 @@ void RoutingTableGenerator::print_routing_tables() const {
                 auto direction = this->intra_mesh_table_[mesh_id_val][src_chip_id][dst_chip_or_mesh_id];
                 ss << dst_chip_or_mesh_id << "(" << enchantum::to_string(direction) << ") ";
             }
-            ss << std::endl;
+            ss << '\n';
         }
     }
     log_debug(tt::LogFabric, "{}", ss.str());
     ss.str(std::string());
-    ss << "Routing Table Generator: InterMesh Routing Tables" << std::endl;
+    ss << "Routing Table Generator: InterMesh Routing Tables" << '\n';
     for (std::uint32_t mesh_id_val = 0; mesh_id_val < this->inter_mesh_table_.size(); mesh_id_val++) {
-        ss << "M" << mesh_id_val << ":" << std::endl;
+        ss << "M" << mesh_id_val << ":" << '\n';
         for (ChipId src_chip_id = 0; src_chip_id < this->inter_mesh_table_[mesh_id_val].size(); src_chip_id++) {
             ss << "   D" << src_chip_id << ": ";
             for (ChipId dst_chip_or_mesh_id = 0;
@@ -352,7 +352,7 @@ void RoutingTableGenerator::print_routing_tables() const {
                 auto direction = this->inter_mesh_table_[mesh_id_val][src_chip_id][dst_chip_or_mesh_id];
                 ss << dst_chip_or_mesh_id << "(" << enchantum::to_string(direction) << ") ";
             }
-            ss << std::endl;
+            ss << '\n';
         }
     }
     log_debug(tt::LogFabric, "{}", ss.str());

--- a/tt_metal/fabric/routing_table_generator.cpp
+++ b/tt_metal/fabric/routing_table_generator.cpp
@@ -325,9 +325,9 @@ void RoutingTableGenerator::load_intermesh_connections(const AnnotatedIntermeshC
 
 void RoutingTableGenerator::print_routing_tables() const {
     std::stringstream ss;
-    ss << "Routing Table Generator: IntraMesh Routing Tables" << '\n';
+    ss << "Routing Table Generator: IntraMesh Routing Tables\n";
     for (std::uint32_t mesh_id_val = 0; mesh_id_val < this->intra_mesh_table_.size(); mesh_id_val++) {
-        ss << "M" << mesh_id_val << ":" << '\n';
+        ss << "M" << mesh_id_val << ":\n";
         for (ChipId src_chip_id = 0; src_chip_id < this->intra_mesh_table_[mesh_id_val].size(); src_chip_id++) {
             ss << "   D" << src_chip_id << ": ";
             for (ChipId dst_chip_or_mesh_id = 0;
@@ -341,9 +341,9 @@ void RoutingTableGenerator::print_routing_tables() const {
     }
     log_debug(tt::LogFabric, "{}", ss.str());
     ss.str(std::string());
-    ss << "Routing Table Generator: InterMesh Routing Tables" << '\n';
+    ss << "Routing Table Generator: InterMesh Routing Tables\n";
     for (std::uint32_t mesh_id_val = 0; mesh_id_val < this->inter_mesh_table_.size(); mesh_id_val++) {
-        ss << "M" << mesh_id_val << ":" << '\n';
+        ss << "M" << mesh_id_val << ":\n";
         for (ChipId src_chip_id = 0; src_chip_id < this->inter_mesh_table_[mesh_id_val].size(); src_chip_id++) {
             ss << "   D" << src_chip_id << ": ";
             for (ChipId dst_chip_or_mesh_id = 0;

--- a/tt_metal/fabric/serialization/physical_system_descriptor_serialization.cpp
+++ b/tt_metal/fabric/serialization/physical_system_descriptor_serialization.cpp
@@ -293,7 +293,7 @@ void emit_physical_system_descriptor_to_text_proto(
         file << text_proto;
         file.close();
     } else {
-        std::cout << text_proto << std::endl;
+        std::cout << text_proto << '\n';
     }
 }
 

--- a/tt_metal/impl/allocator/algorithms/free_list_opt.cpp
+++ b/tt_metal/impl/allocator/algorithms/free_list_opt.cpp
@@ -435,8 +435,8 @@ Statistics FreeListOpt::get_statistics() const {
 }
 
 void FreeListOpt::dump_blocks(std::ostream& out) const {
-    out << "FreeListOpt allocator info:" << std::endl;
-    out << "segregated free blocks by size:" << std::endl;
+    out << "FreeListOpt allocator info:" << '\n';
+    out << "segregated free blocks by size:" << '\n';
     for (size_t i = 0; i < free_blocks_segregated_by_size_.size(); i++) {
         if (i != free_blocks_segregated_by_size_.size() - 1) {
             out << "  Size class " << i << ": (" << size_t(size_segregated_base * (size_t{1} << i)) << " - "
@@ -449,16 +449,16 @@ void FreeListOpt::dump_blocks(std::ostream& out) const {
             out << free_blocks_segregated_by_size_[i][j] << " ";
         }
 
-        out << std::endl;
+        out << '\n';
     }
 
     out << "Free slots in block table: ";
     for (size_t i = 0; i < free_meta_block_indices_.size(); i++) {
         out << free_meta_block_indices_[i] << " ";
     }
-    out << std::endl;
+    out << '\n';
 
-    out << "Block table:" << std::endl;
+    out << "Block table:" << '\n';
     auto leftpad = [](std::string str, size_t width) {
         if (str.size() >= width) {
             return str;
@@ -477,7 +477,7 @@ void FreeListOpt::dump_blocks(std::ostream& out) const {
     for (auto& header : headers) {
         out << leftpad(header, pad) << " ";
     }
-    out << std::endl;
+    out << '\n';
     for (size_t i = 0; i < block_address_.size(); i++) {
         if (!meta_block_is_allocated_[i]) {
             continue;
@@ -485,7 +485,7 @@ void FreeListOpt::dump_blocks(std::ostream& out) const {
         out << leftpad_num(i, pad) << " " << leftpad_num(block_address_[i], pad) << " "
             << leftpad_num(block_size_[i], pad) << " " << leftpad_num(block_prev_block_[i], pad) << " "
             << leftpad_num(block_next_block_[i], pad) << " " << leftpad(block_is_allocated_[i] ? "yes" : "no", pad)
-            << std::endl;
+            << '\n';
     }
 }
 

--- a/tt_metal/impl/allocator/algorithms/free_list_opt.cpp
+++ b/tt_metal/impl/allocator/algorithms/free_list_opt.cpp
@@ -435,8 +435,8 @@ Statistics FreeListOpt::get_statistics() const {
 }
 
 void FreeListOpt::dump_blocks(std::ostream& out) const {
-    out << "FreeListOpt allocator info:" << '\n';
-    out << "segregated free blocks by size:" << '\n';
+    out << "FreeListOpt allocator info:\n";
+    out << "segregated free blocks by size:\n";
     for (size_t i = 0; i < free_blocks_segregated_by_size_.size(); i++) {
         if (i != free_blocks_segregated_by_size_.size() - 1) {
             out << "  Size class " << i << ": (" << size_t(size_segregated_base * (size_t{1} << i)) << " - "
@@ -458,7 +458,7 @@ void FreeListOpt::dump_blocks(std::ostream& out) const {
     }
     out << '\n';
 
-    out << "Block table:" << '\n';
+    out << "Block table:\n";
     auto leftpad = [](std::string str, size_t width) {
         if (str.size() >= width) {
             return str;

--- a/tt_metal/impl/data_format/bfloat16.cpp
+++ b/tt_metal/impl/data_format/bfloat16.cpp
@@ -365,7 +365,7 @@ bool packed_uint32_t_vector_comparison(
     const std::function<bool(float, float)>& comparison_function,
     int* argfail) {
     if (vec_a.size() != vec_b.size()) {
-        std::cout << "Sizes don't match, returning false" << '\n';
+        std::cout << "Sizes don't match, returning false\n";
         return false;
     }
 

--- a/tt_metal/impl/data_format/bfloat16.cpp
+++ b/tt_metal/impl/data_format/bfloat16.cpp
@@ -117,7 +117,7 @@ std::vector<std::uint32_t> create_arange_vector_of_bfloat16(size_t num_bytes, bo
             std::cout << "num_1_float: " << num_1_float << ", num_1_bfloat16 : " << static_cast<float>(num_1_bfloat16)
                       << ", \t\t";
             std::cout << "num_2_float: " << num_2_float << ", num_2_bfloat16 : " << static_cast<float>(num_2_bfloat16)
-                      << std::endl;
+                      << '\n';
         }
 
         // pack 2 uint16 into uint32
@@ -241,7 +241,7 @@ void print_vec_of_uint32_as_packed_bfloat16(
     const std::vector<std::uint32_t>& vec, int num_tiles, const std::string& name, int tile_print_offset) {
     int idx = 0;
     for (int i = 0; i < num_tiles; i++) {
-        std::cout << name << " tile " << i + tile_print_offset << std::endl;
+        std::cout << name << " tile " << i + tile_print_offset << '\n';
         for (int j = 0; j < 32; j++) {
             for (int k = 0; k < 32; k += 2) {
                 uint32_t uint32_data = vec.at(idx);
@@ -250,9 +250,9 @@ void print_vec_of_uint32_as_packed_bfloat16(
                           << ", ";
                 idx++;
             }
-            std::cout << std::endl;
+            std::cout << '\n';
         }
-        std::cout << std::endl;
+        std::cout << '\n';
     }
 }
 
@@ -260,30 +260,30 @@ void print_vec_of_bfloat16(
     const std::vector<bfloat16>& vec, int num_tiles, const std::string& name, int tile_print_offset) {
     int idx = 0;
     for (int i = 0; i < num_tiles; i++) {
-        std::cout << name << " tile " << i + tile_print_offset << std::endl;
+        std::cout << name << " tile " << i + tile_print_offset << '\n';
         for (int j = 0; j < 32; j++) {
             for (int k = 0; k < 32; k++) {
                 std::cout << static_cast<float>(vec.at(idx)) << ", ";
                 idx++;
             }
-            std::cout << std::endl;
+            std::cout << '\n';
         }
-        std::cout << std::endl;
+        std::cout << '\n';
     }
 }
 
 void print_vec(const std::vector<uint32_t>& vec, int num_tiles, const std::string& name, int tile_print_offset) {
     int idx = 0;
     for (int i = 0; i < num_tiles; i++) {
-        std::cout << name << " tile " << i + tile_print_offset << std::endl;
+        std::cout << name << " tile " << i + tile_print_offset << '\n';
         for (int j = 0; j < 32; j++) {
             for (int k = 0; k < 32; k++) {
                 std::cout << vec.at(idx) << ", ";
                 idx++;
             }
-            std::cout << std::endl;
+            std::cout << '\n';
         }
-        std::cout << std::endl;
+        std::cout << '\n';
     }
 }
 
@@ -329,7 +329,7 @@ bool equal_within_n_sig_figs(float a, float b, int n) {
                 num_correct_sig_figs++;
             }
         } else {
-            std::cout << "Floats being compared: A: " << a << ", B: " << b << std::endl;
+            std::cout << "Floats being compared: A: " << a << ", B: " << b << '\n';
             return false;
         }
 
@@ -352,9 +352,9 @@ bool is_close(float a, float b, float rtol, float atol) {
     auto reldenom = fmaxf(fabsf(a), fabsf(b));
     auto result = (absdiff <= atol) || (absdiff <= rtol * reldenom);
     if (!result) {
-        std::cout << "Discrepacy: A = " << a << " B = " << b << std::endl;
-        std::cout << "   absdiff = " << absdiff << std::endl;
-        std::cout << "   reldiff = " << absdiff / (reldenom + 1e-6f) << std::endl;
+        std::cout << "Discrepacy: A = " << a << " B = " << b << '\n';
+        std::cout << "   absdiff = " << absdiff << '\n';
+        std::cout << "   reldiff = " << absdiff / (reldenom + 1e-6f) << '\n';
     }
     return result;
 }
@@ -365,7 +365,7 @@ bool packed_uint32_t_vector_comparison(
     const std::function<bool(float, float)>& comparison_function,
     int* argfail) {
     if (vec_a.size() != vec_b.size()) {
-        std::cout << "Sizes don't match, returning false" << std::endl;
+        std::cout << "Sizes don't match, returning false" << '\n';
         return false;
     }
 
@@ -382,10 +382,10 @@ bool packed_uint32_t_vector_comparison(
         if (not(comparison_function(a1, b1) and comparison_function(a2, b2))) {
             if (argfail) {
                 *argfail = i;
-                std::cout << "a1 = " << std::hex << a1 << std::endl;
-                std::cout << "b1 = " << std::hex << b1 << std::endl;
-                std::cout << "a2 = " << std::hex << a2 << std::endl;
-                std::cout << "b2 = " << std::hex << b2 << std::endl;
+                std::cout << "a1 = " << std::hex << a1 << '\n';
+                std::cout << "b1 = " << std::hex << b1 << '\n';
+                std::cout << "a2 = " << std::hex << a2 << '\n';
+                std::cout << "b2 = " << std::hex << b2 << '\n';
             }
             return false;
         }

--- a/tt_metal/impl/dispatch/debug_tools.cpp
+++ b/tt_metal/impl/dispatch/debug_tools.cpp
@@ -368,7 +368,7 @@ void dump_completion_queue_entries(
                     page_addr - DispatchSettings::TRANSFER_PAGE_SIZE >= (completion_read_ptr)) {
                     cq_file << fmt::format(" << read_ptr (0x{:08x})", completion_read_ptr);
                 }
-                cq_file << std::endl;
+                cq_file << '\n';
             }
             uint32_t stride = dump_dispatch_cmd(cmd, page_addr, cq_file);
             // Completion Q is page-aligned
@@ -381,7 +381,7 @@ void dump_completion_queue_entries(
             if (page_addr == completion_read_ptr) {
                 cq_file << fmt::format(" << read_ptr (0x{:08x})", completion_read_ptr);
             }
-            cq_file << std::endl;
+            cq_file << '\n';
 
             // Show which pages have data if present.
             if (cmd_pages > 2) {
@@ -408,7 +408,7 @@ void dump_completion_queue_entries(
         cq_file << fmt::format(
             "{:#010x}-{:#010x}: No valid dispatch commands detected.", last_span_start, base_addr + completion_q_bytes);
     }
-    std::cout << std::endl;
+    std::cout << '\n';
 }
 
 void dump_issue_queue_entries(
@@ -477,7 +477,7 @@ void dump_issue_queue_entries(
                     curr_addr - hal.get_alignment(HalMemType::HOST) >= (issue_read_ptr)) {
                     iq_file << fmt::format(" << read_ptr (0x{:08x})", issue_read_ptr);
                 }
-                iq_file << std::endl;
+                iq_file << '\n';
             }
 
             uint32_t cmd_stride = dump_prefetch_cmd(cmd, curr_addr, iq_file);
@@ -495,7 +495,7 @@ void dump_issue_queue_entries(
             if (curr_addr == issue_read_ptr) {
                 iq_file << fmt::format(" << read_ptr (0x{:08x})", issue_read_ptr);
             }
-            iq_file << std::endl;
+            iq_file << '\n';
 
             // If it's a RELAY_INLINE command, then the data inside is dispatch commands, show them.
             if ((cmd->base.cmd_id == CQ_PREFETCH_CMD_RELAY_INLINE ||
@@ -521,7 +521,7 @@ void dump_issue_queue_entries(
                         uint32_t dispatch_cmd_stride =
                             dump_dispatch_cmd(dispatch_cmd, issue_q_base_addr + dispatch_offset, iq_file);
                         dispatch_offset += dispatch_cmd_stride;
-                        iq_file << std::endl;
+                        iq_file << '\n';
                     } else {
                         dispatch_offset += sizeof(CQDispatchCmd);
                     }
@@ -546,7 +546,7 @@ void dump_issue_queue_entries(
             last_span_start,
             issue_q_base_addr + issue_q_bytes);
     }
-    std::cout << std::endl;
+    std::cout << '\n';
 }
 
 // Define a queue type, for when they're interchangeable.
@@ -593,7 +593,7 @@ void dump_command_queue_raw_data(
     // Read out in pages
     std::vector<uint8_t> read_data;
     read_data.resize(DispatchSettings::TRANSFER_PAGE_SIZE);
-    out_file << std::endl;
+    out_file << '\n';
     out_file << fmt::format(
                     "Device {}, CQ {}, {} Queue Raw Data:\n",
                     sysmem_manager.get_device_id(),
@@ -635,10 +635,10 @@ void dump_command_queue_raw_data(
             if (line_addr == read_ptr) {
                 out_file << fmt::format(" << read_ptr (0x{:08x})", read_ptr);
             }
-            out_file << std::endl;
+            out_file << '\n';
         }
     }
-    std::cout << std::endl;
+    std::cout << '\n';
 }
 
 void dump_cqs(std::ofstream& cq_file, std::ofstream& iq_file, SystemMemoryManager& sysmem_manager, bool dump_raw_data) {

--- a/tt_metal/impl/lightmetal/lightmetal_replay_impl.cpp
+++ b/tt_metal/impl/lightmetal/lightmetal_replay_impl.cpp
@@ -28,7 +28,7 @@ namespace tt::tt_metal {
 
 TraceDescriptor from_flatbuffer(const flatbuffer::TraceDescriptor* fb_desc) {
     if (!fb_desc) {
-        std::cerr << "TraceDescriptor is null." << std::endl;
+        std::cerr << "TraceDescriptor is null." << '\n';
         return {};
     }
 
@@ -128,14 +128,14 @@ const tt::tt_metal::flatbuffer::LightMetalBinary* LightMetalReplayImpl::parse_fl
         // Verify the FlatBuffer data.
         flatbuffers::Verifier verifier(data_ptr, size);
         if (!tt::tt_metal::flatbuffer::VerifyLightMetalBinaryBuffer(verifier)) {
-            std::cerr << "Failed to verify FlatBuffer data." << std::endl;
+            std::cerr << "Failed to verify FlatBuffer data." << '\n';
             return nullptr;
         }
 
         // Parse and return the FlatBuffer object.
         return tt::tt_metal::flatbuffer::GetLightMetalBinary(data_ptr);
     } catch (const std::exception& e) {
-        std::cerr << "Exception while parsing FlatBuffer binary: " << e.what() << std::endl;
+        std::cerr << "Exception while parsing FlatBuffer binary: " << e.what() << '\n';
         return nullptr;
     }
 }
@@ -150,7 +150,7 @@ std::optional<TraceDescriptor> LightMetalReplayImpl::get_trace_by_id(uint32_t ta
         }
     }
 
-    std::cerr << "Failed to find trace_id: " << target_trace_id << " in binary." << std::endl;
+    std::cerr << "Failed to find trace_id: " << target_trace_id << " in binary." << '\n';
     return std::nullopt;
 }
 
@@ -679,7 +679,7 @@ void LightMetalReplayImpl::execute(const ::tt::tt_metal::flatbuffer::LightMetalC
 // Main entry point to execute a light metal binary blob, return true if pass.
 bool LightMetalReplayImpl::run() {
     if (!fb_binary_) {
-        std::cerr << "Cannot Replay empty/uninitialized Light Metal Binary." << std::endl;
+        std::cerr << "Cannot Replay empty/uninitialized Light Metal Binary." << '\n';
         return false;
     }
 
@@ -689,7 +689,7 @@ bool LightMetalReplayImpl::run() {
         const auto* trace_descs = fb_binary_->trace_descriptors();
         const auto* commands = fb_binary_->commands();
         if (!commands) {
-            std::cerr << "Nothing to run, no commands in binary." << std::endl;
+            std::cerr << "Nothing to run, no commands in binary." << '\n';
             return false;
         }
 

--- a/tt_metal/impl/lightmetal/lightmetal_replay_impl.cpp
+++ b/tt_metal/impl/lightmetal/lightmetal_replay_impl.cpp
@@ -28,7 +28,7 @@ namespace tt::tt_metal {
 
 TraceDescriptor from_flatbuffer(const flatbuffer::TraceDescriptor* fb_desc) {
     if (!fb_desc) {
-        std::cerr << "TraceDescriptor is null." << '\n';
+        std::cerr << "TraceDescriptor is null.\n";
         return {};
     }
 
@@ -128,7 +128,7 @@ const tt::tt_metal::flatbuffer::LightMetalBinary* LightMetalReplayImpl::parse_fl
         // Verify the FlatBuffer data.
         flatbuffers::Verifier verifier(data_ptr, size);
         if (!tt::tt_metal::flatbuffer::VerifyLightMetalBinaryBuffer(verifier)) {
-            std::cerr << "Failed to verify FlatBuffer data." << '\n';
+            std::cerr << "Failed to verify FlatBuffer data.\n";
             return nullptr;
         }
 
@@ -150,7 +150,7 @@ std::optional<TraceDescriptor> LightMetalReplayImpl::get_trace_by_id(uint32_t ta
         }
     }
 
-    std::cerr << "Failed to find trace_id: " << target_trace_id << " in binary." << '\n';
+    std::cerr << "Failed to find trace_id: " << target_trace_id << " in binary.\n";
     return std::nullopt;
 }
 
@@ -679,7 +679,7 @@ void LightMetalReplayImpl::execute(const ::tt::tt_metal::flatbuffer::LightMetalC
 // Main entry point to execute a light metal binary blob, return true if pass.
 bool LightMetalReplayImpl::run() {
     if (!fb_binary_) {
-        std::cerr << "Cannot Replay empty/uninitialized Light Metal Binary." << '\n';
+        std::cerr << "Cannot Replay empty/uninitialized Light Metal Binary.\n";
         return false;
     }
 
@@ -689,7 +689,7 @@ bool LightMetalReplayImpl::run() {
         const auto* trace_descs = fb_binary_->trace_descriptors();
         const auto* commands = fb_binary_->commands();
         if (!commands) {
-            std::cerr << "Nothing to run, no commands in binary." << '\n';
+            std::cerr << "Nothing to run, no commands in binary.\n";
             return false;
         }
 

--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -116,7 +116,7 @@ void populateZoneSrcLocations(
         auto ret = hash_to_zone_src_locations.emplace(hash_16bit, details);
         if (ret.second && push_new) {
             std::ofstream log_file_write(log_name, std::ios::app);
-            log_file_write << line << std::endl;
+            log_file_write << line << '\n';
             log_file_write.close();
         }
     }
@@ -924,10 +924,10 @@ void writeCSVHeader(
     std::ofstream& log_file_ofs, tt::ARCH device_architecture, int device_core_frequency, uint32_t max_compute_cores) {
     log_file_ofs << "ARCH: " << get_string_lowercase(device_architecture)
                  << ", CHIP_FREQ[MHz]: " << device_core_frequency << ", Max Compute Cores: " << max_compute_cores
-                 << std::endl;
+                 << '\n';
     log_file_ofs << "PCIe slot, core_x, core_y, RISC processor type, timer_id, time[cycles since reset], data, run "
                     "host ID, trace id, trace id counter, zone name, type, source line, source file, meta data"
-                 << std::endl;
+                 << '\n';
 }
 
 void dumpDeviceResultsToCSV(

--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -926,8 +926,7 @@ void writeCSVHeader(
                  << ", CHIP_FREQ[MHz]: " << device_core_frequency << ", Max Compute Cores: " << max_compute_cores
                  << '\n';
     log_file_ofs << "PCIe slot, core_x, core_y, RISC processor type, timer_id, time[cycles since reset], data, run "
-                    "host ID, trace id, trace id counter, zone name, type, source line, source file, meta data"
-                 << '\n';
+                    "host ID, trace id, trace id counter, zone name, type, source line, source file, meta data\n";
 }
 
 void dumpDeviceResultsToCSV(

--- a/tt_metal/impl/profiler/profiler_analysis.cpp
+++ b/tt_metal/impl/profiler/profiler_analysis.cpp
@@ -390,7 +390,7 @@ void writeProgramsPerfResultsToCSV(
             }
         }
 
-        log_file_ofs << header_string << std::endl;
+        log_file_ofs << header_string << '\n';
     }
 
     for (const auto& [_, results_string] : results_string_per_program_execution_uid) {

--- a/tt_metal/impl/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/impl/profiler/tt_metal_profiler.cpp
@@ -236,7 +236,7 @@ void syncDeviceHost(IDevice* device, CoreCoord logical_core, bool doHeader) {
                         "device id,core_x, "
                         "core_y,device,host_tracy,host_real,write_overhead,host_start,delay,frequency,tracy_ratio,"
                         "tracy_base_time,device_frequency_ratio,device_shift")
-                 << std::endl;
+                 << '\n';
     } else {
         log_file.open(log_path, std::ios_base::app);
     }
@@ -257,7 +257,7 @@ void syncDeviceHost(IDevice* device, CoreCoord logical_core, bool doHeader) {
                         frequencyFit,
                         tracyToSecRatio,
                         tracyBaseTime)
-                 << std::endl;
+                 << '\n';
     }
     log_file.close();
     log_info(
@@ -303,7 +303,7 @@ void setShift(int device_id, int64_t shift, double scale, const SyncInfo& root_s
         std::filesystem::path log_path = output_dir / "sync_device_info.csv";
         std::ofstream log_file;
         log_file.open(log_path, std::ios_base::app);
-        log_file << fmt::format("{:5},,,,,,,,,,,,{:20.15f},{:20}", device_id, scale, shift) << std::endl;
+        log_file << fmt::format("{:5},,,,,,,,,,,,{:20.15f},{:20}", device_id, scale, shift) << '\n';
         log_file.close();
     }
 }

--- a/tt_metal/impl/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/impl/profiler/tt_metal_profiler.cpp
@@ -235,8 +235,7 @@ void syncDeviceHost(IDevice* device, CoreCoord logical_core, bool doHeader) {
         log_file << fmt::format(
                         "device id,core_x, "
                         "core_y,device,host_tracy,host_real,write_overhead,host_start,delay,frequency,tracy_ratio,"
-                        "tracy_base_time,device_frequency_ratio,device_shift")
-                 << '\n';
+                        "tracy_base_time,device_frequency_ratio,device_shift\n");
     } else {
         log_file.open(log_path, std::ios_base::app);
     }

--- a/tt_metal/impl/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/impl/profiler/tt_metal_profiler.cpp
@@ -244,7 +244,7 @@ void syncDeviceHost(IDevice* device, CoreCoord logical_core, bool doHeader) {
     int init = profiler_state_manager->device_host_time_pair.at(device_id).size() - sampleCount;
     for (int i = init; i < profiler_state_manager->device_host_time_pair.at(device_id).size(); i++) {
         log_file << fmt::format(
-                        "{:5},{:5},{:5},{:20},{:20},{:20.2f},{:20},{:20},{:20.2f},{:20.15f},{:20.15f},{:20},1.0,0",
+                        "{:5},{:5},{:5},{:20},{:20},{:20.2f},{:20},{:20},{:20.2f},{:20.15f},{:20.15f},{:20},1.0,0\n",
                         device_id,
                         phys_core.x,
                         phys_core.y,
@@ -256,8 +256,7 @@ void syncDeviceHost(IDevice* device, CoreCoord logical_core, bool doHeader) {
                         delay,
                         frequencyFit,
                         tracyToSecRatio,
-                        tracyBaseTime)
-                 << '\n';
+                        tracyBaseTime);
     }
     log_file.close();
     log_info(
@@ -303,7 +302,7 @@ void setShift(int device_id, int64_t shift, double scale, const SyncInfo& root_s
         std::filesystem::path log_path = output_dir / "sync_device_info.csv";
         std::ofstream log_file;
         log_file.open(log_path, std::ios_base::app);
-        log_file << fmt::format("{:5},,,,,,,,,,,,{:20.15f},{:20}", device_id, scale, shift) << '\n';
+        log_file << fmt::format("{:5},,,,,,,,,,,,{:20.15f},{:20}\n", device_id, scale, shift);
         log_file.close();
     }
 }

--- a/tt_metal/jit_build/genfiles.cpp
+++ b/tt_metal/jit_build/genfiles.cpp
@@ -122,7 +122,7 @@ void jit_build_genfiles_triscs_src(
     string generated_defines_fname = out_dir + "/defines_generated.h";
     gen_defines_file.open(generated_defines_fname, std::ios_base::out);
     settings.process_defines([&gen_defines_file](const string& define, const string& value) {
-        gen_defines_file << "#define " << define << " " << value << endl;
+        gen_defines_file << "#define " << define << " " << value << '\n';
     });
 }
 
@@ -140,9 +140,9 @@ std::string create_formats_array_string(
     const std::string& array_type, const std::string& array_name, int array_size, const std::string& array_data) {
     stringstream str_stream;
 
-    str_stream << array_type << " " << array_name << "[" << array_size << "] = {" << endl;
-    str_stream << "    " << array_data << endl;
-    str_stream << "};" << endl;
+    str_stream << array_type << " " << array_name << "[" << array_size << "] = {" << '\n';
+    str_stream << "    " << array_data << '\n';
+    str_stream << "};" << '\n';
 
     return str_stream.str();
 }
@@ -359,9 +359,9 @@ void generate_dst_accum_mode_descriptor(JitBuildOptions& options) {
     file_stream.open(dst_accum_format_descriptor);
 
     if (options.fp32_dest_acc_en == 0) {
-        file_stream << "constexpr bool DST_ACCUM_MODE = false;" << endl;
+        file_stream << "constexpr bool DST_ACCUM_MODE = false;" << '\n';
     } else {
-        file_stream << "constexpr bool DST_ACCUM_MODE = true;" << endl;
+        file_stream << "constexpr bool DST_ACCUM_MODE = true;" << '\n';
     }
 
     file_stream.close();
@@ -375,9 +375,9 @@ void generate_dst_sync_mode_descriptor(JitBuildOptions& options) {
     file_stream.open(dst_sync_mode_descriptor);
 
     if (options.dst_full_sync_en) {
-        file_stream << "#define DST_SYNC_MODE DstSync::SyncFull" << endl;
+        file_stream << "#define DST_SYNC_MODE DstSync::SyncFull" << '\n';
     } else {
-        file_stream << "#define DST_SYNC_MODE DstSync::SyncHalf" << endl;
+        file_stream << "#define DST_SYNC_MODE DstSync::SyncHalf" << '\n';
     }
 
     file_stream.close();
@@ -391,7 +391,7 @@ void generate_math_fidelity_descriptor(JitBuildOptions& options) {
     ofstream file_stream;
 
     file_stream.open(math_fidelity_descriptor);
-    file_stream << "constexpr std::int32_t MATH_FIDELITY = " << (int)desc.get_hlk_math_fidelity() << ";" << endl;
+    file_stream << "constexpr std::int32_t MATH_FIDELITY = " << (int)desc.get_hlk_math_fidelity() << ";" << '\n';
     file_stream.close();
 }
 
@@ -404,7 +404,7 @@ void generate_math_approx_mode_descriptor(JitBuildOptions& options) {
     ofstream file_stream;
 
     file_stream.open(approx_descriptor);
-    file_stream << "constexpr bool APPROX = " << std::boolalpha << desc.get_hlk_math_approx_mode() << ";" << endl;
+    file_stream << "constexpr bool APPROX = " << std::boolalpha << desc.get_hlk_math_approx_mode() << ";" << '\n';
     file_stream.close();
 }
 
@@ -430,7 +430,7 @@ void jit_build_genfiles_descriptors(const JitBuildEnv& env, JitBuildOptions& opt
         tf.join();
         ts.join();
     } catch (std::runtime_error& ex) {
-        std::cerr << "EXCEPTION FROM THREADING IN GENERATE_DESCRIPTORS: " << ex.what() << std::endl;
+        std::cerr << "EXCEPTION FROM THREADING IN GENERATE_DESCRIPTORS: " << ex.what() << '\n';
     }
 }
 // clang-format on

--- a/tt_metal/jit_build/genfiles.cpp
+++ b/tt_metal/jit_build/genfiles.cpp
@@ -140,9 +140,9 @@ std::string create_formats_array_string(
     const std::string& array_type, const std::string& array_name, int array_size, const std::string& array_data) {
     stringstream str_stream;
 
-    str_stream << array_type << " " << array_name << "[" << array_size << "] = {" << '\n';
+    str_stream << array_type << " " << array_name << "[" << array_size << "] = {\n";
     str_stream << "    " << array_data << '\n';
-    str_stream << "};" << '\n';
+    str_stream << "};\n";
 
     return str_stream.str();
 }
@@ -359,9 +359,9 @@ void generate_dst_accum_mode_descriptor(JitBuildOptions& options) {
     file_stream.open(dst_accum_format_descriptor);
 
     if (options.fp32_dest_acc_en == 0) {
-        file_stream << "constexpr bool DST_ACCUM_MODE = false;" << '\n';
+        file_stream << "constexpr bool DST_ACCUM_MODE = false;\n";
     } else {
-        file_stream << "constexpr bool DST_ACCUM_MODE = true;" << '\n';
+        file_stream << "constexpr bool DST_ACCUM_MODE = true;\n";
     }
 
     file_stream.close();
@@ -375,9 +375,9 @@ void generate_dst_sync_mode_descriptor(JitBuildOptions& options) {
     file_stream.open(dst_sync_mode_descriptor);
 
     if (options.dst_full_sync_en) {
-        file_stream << "#define DST_SYNC_MODE DstSync::SyncFull" << '\n';
+        file_stream << "#define DST_SYNC_MODE DstSync::SyncFull\n";
     } else {
-        file_stream << "#define DST_SYNC_MODE DstSync::SyncHalf" << '\n';
+        file_stream << "#define DST_SYNC_MODE DstSync::SyncHalf\n";
     }
 
     file_stream.close();
@@ -391,7 +391,7 @@ void generate_math_fidelity_descriptor(JitBuildOptions& options) {
     ofstream file_stream;
 
     file_stream.open(math_fidelity_descriptor);
-    file_stream << "constexpr std::int32_t MATH_FIDELITY = " << (int)desc.get_hlk_math_fidelity() << ";" << '\n';
+    file_stream << "constexpr std::int32_t MATH_FIDELITY = " << (int)desc.get_hlk_math_fidelity() << ";\n";
     file_stream.close();
 }
 
@@ -404,7 +404,7 @@ void generate_math_approx_mode_descriptor(JitBuildOptions& options) {
     ofstream file_stream;
 
     file_stream.open(approx_descriptor);
-    file_stream << "constexpr bool APPROX = " << std::boolalpha << desc.get_hlk_math_approx_mode() << ";" << '\n';
+    file_stream << "constexpr bool APPROX = " << std::boolalpha << desc.get_hlk_math_approx_mode() << ";\n";
     file_stream.close();
 }
 

--- a/tt_metal/jit_build/jit_build_utils.cpp
+++ b/tt_metal/jit_build/jit_build_utils.cpp
@@ -22,8 +22,8 @@ bool run_command(const std::string& cmd, const std::string& log_file, const bool
     if (getenv("TT_METAL_BACKEND_DUMP_RUN_CMD") or verbose) {
         {
             std::lock_guard<std::mutex> lk(io_mutex);
-            std::cout << "===== RUNNING SYSTEM COMMAND:" << std::endl;
-            std::cout << cmd << std::endl << std::endl;
+            std::cout << "===== RUNNING SYSTEM COMMAND:" << '\n';
+            std::cout << cmd << '\n' << '\n';
         }
         ret = system(cmd.c_str());
         // {

--- a/tt_metal/jit_build/jit_build_utils.cpp
+++ b/tt_metal/jit_build/jit_build_utils.cpp
@@ -22,7 +22,7 @@ bool run_command(const std::string& cmd, const std::string& log_file, const bool
     if (getenv("TT_METAL_BACKEND_DUMP_RUN_CMD") or verbose) {
         {
             std::lock_guard<std::mutex> lk(io_mutex);
-            std::cout << "===== RUNNING SYSTEM COMMAND:" << '\n';
+            std::cout << "===== RUNNING SYSTEM COMMAND:\n";
             std::cout << cmd << '\n' << '\n';
         }
         ret = system(cmd.c_str());

--- a/tt_metal/jit_build/jit_build_utils.cpp
+++ b/tt_metal/jit_build/jit_build_utils.cpp
@@ -23,7 +23,7 @@ bool run_command(const std::string& cmd, const std::string& log_file, const bool
         {
             std::lock_guard<std::mutex> lk(io_mutex);
             std::cout << "===== RUNNING SYSTEM COMMAND:\n";
-            std::cout << cmd << '\n' << '\n';
+            std::cout << cmd << "\n\n";
         }
         ret = system(cmd.c_str());
         // {

--- a/tt_metal/programming_examples/add_2_integers_in_riscv/add_2_integers_in_riscv.cpp
+++ b/tt_metal/programming_examples/add_2_integers_in_riscv/add_2_integers_in_riscv.cpp
@@ -121,16 +121,16 @@ int main() {
     std::vector<uint32_t> result_vec;
     distributed::EnqueueReadMeshBuffer(cq, result_vec, dst_dram_buffer, /*blocking=*/true);
     if (result_vec.size() != 1) {
-        std::cout << "Error: Expected result vector size of 1, got " << result_vec.size() << std::endl;
+        std::cout << "Error: Expected result vector size of 1, got " << result_vec.size() << '\n';
         mesh_device->close();
         return -1;
     }
     if (result_vec[0] != 21) {
-        std::cout << "Error: Expected result of 21, got " << result_vec[0] << std::endl;
+        std::cout << "Error: Expected result of 21, got " << result_vec[0] << '\n';
         mesh_device->close();
         return -1;
     }
 
-    std::cout << "Success: Result is " << result_vec[0] << std::endl;
+    std::cout << "Success: Result is " << result_vec[0] << '\n';
     mesh_device->close();
 }

--- a/tt_metal/programming_examples/contributed/vecadd/vecadd.cpp
+++ b/tt_metal/programming_examples/contributed/vecadd/vecadd.cpp
@@ -69,7 +69,7 @@ CBHandle MakeCircularBufferBFP16(Program& program, const CoreSpec& core, tt::CBI
 
 std::string next_arg(int& i, int argc, char** argv) {
     if (i + 1 >= argc) {
-        std::cerr << "Expected argument after " << argv[i] << std::endl;
+        std::cerr << "Expected argument after " << argv[i] << '\n';
         exit(1);
     }
     return argv[++i];
@@ -103,7 +103,7 @@ int main(int argc, char** argv) {
             help(argv[0]);
             return 0;
         } else {
-            std::cout << "Unknown argument: " << arg << std::endl;
+            std::cout << "Unknown argument: " << arg << '\n';
             help(argv[0]);
         }
     }
@@ -196,7 +196,7 @@ int main(int argc, char** argv) {
     workload.add_program(device_range, std::move(program));
     distributed::EnqueueMeshWorkload(cq, workload, true);
     // distributed::Finish(cq);
-    std::cout << "Kernel execution finished" << std::endl;
+    std::cout << "Kernel execution finished" << '\n';
 
     // Read the output buffer.
     std::vector<uint32_t> c_data;

--- a/tt_metal/programming_examples/contributed/vecadd/vecadd.cpp
+++ b/tt_metal/programming_examples/contributed/vecadd/vecadd.cpp
@@ -196,7 +196,7 @@ int main(int argc, char** argv) {
     workload.add_program(device_range, std::move(program));
     distributed::EnqueueMeshWorkload(cq, workload, true);
     // distributed::Finish(cq);
-    std::cout << "Kernel execution finished" << '\n';
+    std::cout << "Kernel execution finished\n";
 
     // Read the output buffer.
     std::vector<uint32_t> c_data;

--- a/tt_metal/programming_examples/distributed/4_distributed_trace_and_events/distributed_trace_and_events.cpp
+++ b/tt_metal/programming_examples/distributed/4_distributed_trace_and_events/distributed_trace_and_events.cpp
@@ -279,10 +279,10 @@ int main() {
     }
     mesh_device->release_mesh_trace(trace_id);
     if (pass) {
-        std::cout << "Running EltwiseBinary MeshTraces on 2 MeshCQs Passed!" << std::endl;
+        std::cout << "Running EltwiseBinary MeshTraces on 2 MeshCQs Passed!" << '\n';
         return 0;
     } else {
-        std::cout << "Running EltwiseBinary MeshTraces on 2 MeshCQs Failed with Incorrect Outputs!" << std::endl;
+        std::cout << "Running EltwiseBinary MeshTraces on 2 MeshCQs Failed with Incorrect Outputs!" << '\n';
         return 1;
     }
 }

--- a/tt_metal/programming_examples/distributed/4_distributed_trace_and_events/distributed_trace_and_events.cpp
+++ b/tt_metal/programming_examples/distributed/4_distributed_trace_and_events/distributed_trace_and_events.cpp
@@ -279,10 +279,10 @@ int main() {
     }
     mesh_device->release_mesh_trace(trace_id);
     if (pass) {
-        std::cout << "Running EltwiseBinary MeshTraces on 2 MeshCQs Passed!" << '\n';
+        std::cout << "Running EltwiseBinary MeshTraces on 2 MeshCQs Passed!\n";
         return 0;
     } else {
-        std::cout << "Running EltwiseBinary MeshTraces on 2 MeshCQs Failed with Incorrect Outputs!" << '\n';
+        std::cout << "Running EltwiseBinary MeshTraces on 2 MeshCQs Failed with Incorrect Outputs!\n";
         return 1;
     }
 }

--- a/tt_metal/programming_examples/hello_world_datamovement_kernel/hello_world_datamovement_kernel.cpp
+++ b/tt_metal/programming_examples/hello_world_datamovement_kernel/hello_world_datamovement_kernel.cpp
@@ -17,8 +17,7 @@ int main() {
     char* env_var = std::getenv("TT_METAL_DPRINT_CORES");
     if (env_var == nullptr) {
         std::cerr << "WARNING: Please set the environment variable TT_METAL_DPRINT_CORES to 0,0 to see the output of "
-                     "the Data Movement kernels."
-                  << '\n';
+                     "the Data Movement kernels.\n";
         std::cerr << "WARNING: For example, export TT_METAL_DPRINT_CORES=0,0\n";
     }
 

--- a/tt_metal/programming_examples/hello_world_datamovement_kernel/hello_world_datamovement_kernel.cpp
+++ b/tt_metal/programming_examples/hello_world_datamovement_kernel/hello_world_datamovement_kernel.cpp
@@ -19,7 +19,7 @@ int main() {
         std::cerr << "WARNING: Please set the environment variable TT_METAL_DPRINT_CORES to 0,0 to see the output of "
                      "the Data Movement kernels."
                   << '\n';
-        std::cerr << "WARNING: For example, export TT_METAL_DPRINT_CORES=0,0" << '\n';
+        std::cerr << "WARNING: For example, export TT_METAL_DPRINT_CORES=0,0\n";
     }
 
     // Initialize mesh device (1x1), command queue, workload, device range, and program.
@@ -52,8 +52,7 @@ int main() {
     // Set Runtime Arguments for the Data Movement Kernels (none in this case and execute the program)
     SetRuntimeArgs(program, data_movement_kernel_0, core, {});
     SetRuntimeArgs(program, data_movement_kernel_1, core, {});
-    std::cout << "Hello, Core {0, 0} on Device 0, Please start execution. I will standby for your communication."
-              << '\n';
+    std::cout << "Hello, Core {0, 0} on Device 0, Please start execution. I will standby for your communication.\n";
 
     workload.add_program(device_range, std::move(program));
     distributed::EnqueueMeshWorkload(cq, workload, false);
@@ -72,7 +71,7 @@ int main() {
     // NC: - Data Movement core 1
     // BR: - Data Movement core 0
 
-    std::cout << "Thank you, Core {0, 0} on Device 0, for the completed task." << '\n';
+    std::cout << "Thank you, Core {0, 0} on Device 0, for the completed task.\n";
     mesh_device->close();
     return 0;
 }

--- a/tt_metal/programming_examples/hello_world_datamovement_kernel/hello_world_datamovement_kernel.cpp
+++ b/tt_metal/programming_examples/hello_world_datamovement_kernel/hello_world_datamovement_kernel.cpp
@@ -18,8 +18,8 @@ int main() {
     if (env_var == nullptr) {
         std::cerr << "WARNING: Please set the environment variable TT_METAL_DPRINT_CORES to 0,0 to see the output of "
                      "the Data Movement kernels."
-                  << std::endl;
-        std::cerr << "WARNING: For example, export TT_METAL_DPRINT_CORES=0,0" << std::endl;
+                  << '\n';
+        std::cerr << "WARNING: For example, export TT_METAL_DPRINT_CORES=0,0" << '\n';
     }
 
     // Initialize mesh device (1x1), command queue, workload, device range, and program.
@@ -53,7 +53,7 @@ int main() {
     SetRuntimeArgs(program, data_movement_kernel_0, core, {});
     SetRuntimeArgs(program, data_movement_kernel_1, core, {});
     std::cout << "Hello, Core {0, 0} on Device 0, Please start execution. I will standby for your communication."
-              << std::endl;
+              << '\n';
 
     workload.add_program(device_range, std::move(program));
     distributed::EnqueueMeshWorkload(cq, workload, false);
@@ -72,7 +72,7 @@ int main() {
     // NC: - Data Movement core 1
     // BR: - Data Movement core 0
 
-    std::cout << "Thank you, Core {0, 0} on Device 0, for the completed task." << std::endl;
+    std::cout << "Thank you, Core {0, 0} on Device 0, for the completed task." << '\n';
     mesh_device->close();
     return 0;
 }

--- a/tt_metal/programming_examples/vecadd_multi_core/vecadd_multi_core.cpp
+++ b/tt_metal/programming_examples/vecadd_multi_core/vecadd_multi_core.cpp
@@ -247,7 +247,7 @@ int main(int argc, char** argv) {
     workload.add_program(device_range, std::move(program));
     distributed::EnqueueMeshWorkload(cq, workload, false);
 
-    std::cout << "Kernel execution finished" << '\n';
+    std::cout << "Kernel execution finished\n";
 
     // Read the output buffer.
     std::vector<bfloat16> c_data;

--- a/tt_metal/programming_examples/vecadd_multi_core/vecadd_multi_core.cpp
+++ b/tt_metal/programming_examples/vecadd_multi_core/vecadd_multi_core.cpp
@@ -70,7 +70,7 @@ CBHandle MakeCircularBufferBFP16(Program& program, const CoreSpec& core, tt::CBI
 
 std::string next_arg(int& i, int argc, char** argv) {
     if (i + 1 >= argc) {
-        std::cerr << "Expected argument after " << argv[i] << std::endl;
+        std::cerr << "Expected argument after " << argv[i] << '\n';
         exit(1);
     }
     return argv[++i];
@@ -100,7 +100,7 @@ int main(int argc, char** argv) {
             help(argv[0]);
             return 0;
         } else {
-            std::cout << "Unknown argument: " << arg << std::endl;
+            std::cout << "Unknown argument: " << arg << '\n';
             help(argv[0]);
         }
     }
@@ -247,7 +247,7 @@ int main(int argc, char** argv) {
     workload.add_program(device_range, std::move(program));
     distributed::EnqueueMeshWorkload(cq, workload, false);
 
-    std::cout << "Kernel execution finished" << std::endl;
+    std::cout << "Kernel execution finished" << '\n';
 
     // Read the output buffer.
     std::vector<bfloat16> c_data;

--- a/tt_metal/programming_examples/vecadd_sharding/vecadd_sharding.cpp
+++ b/tt_metal/programming_examples/vecadd_sharding/vecadd_sharding.cpp
@@ -71,7 +71,7 @@ CBHandle MakeCircularBufferBFP16(
 
 std::string next_arg(int& i, int argc, char** argv) {
     if (i + 1 >= argc) {
-        std::cerr << "Expected argument after " << argv[i] << std::endl;
+        std::cerr << "Expected argument after " << argv[i] << '\n';
         exit(1);
     }
     return argv[++i];
@@ -130,12 +130,12 @@ int main(int argc, char** argv) {
         } else if (arg == "--sharding_type" || arg == "-s") {
             sharding_type = next_arg(i, argc, argv);
             if (not test_configs.contains(sharding_type)) {
-                std::cout << "Invalid sharding type: " << sharding_type << std::endl;
+                std::cout << "Invalid sharding type: " << sharding_type << '\n';
                 help(argv[0]);
                 return 1;
             }
         } else {
-            std::cout << "Unknown argument: " << arg << std::endl;
+            std::cout << "Unknown argument: " << arg << '\n';
             help(argv[0]);
         }
     }
@@ -253,7 +253,7 @@ int main(int argc, char** argv) {
                 static_cast<float>(b_data[i]),
                 static_cast<float>(c_data[i]));
         }
-        std::cout << std::endl;
+        std::cout << '\n';
         core_idx++;
     }
 

--- a/tt_metal/tools/mem_bench/host_utils.cpp
+++ b/tt_metal/tools/mem_bench/host_utils.cpp
@@ -59,7 +59,7 @@ std::vector<int> get_mmio_device_ids(int number_of_devices, int numa_node) {
         auto associated_node = cluster.get_numa_node_for_device(device_id);
         if (numa_node == -1 || associated_node == numa_node) {
             device_ids.push_back(device_id);
-            std::cout << "Using Device: " << device_id << std::endl;
+            std::cout << "Using Device: " << device_id << '\n';
         }
     }
 
@@ -76,7 +76,7 @@ std::vector<int> get_mmio_device_ids_unique_nodes(int number_of_devices) {
 
         auto associated_node = cluster.get_numa_node_for_device(device_id);
         if (!numa_nodes.contains(associated_node)) {
-            std::cout << "Using Device: " << device_id << std::endl;
+            std::cout << "Using Device: " << device_id << '\n';
             device_ids.push_back(device_id);
             numa_nodes.insert(associated_node);
         }
@@ -107,7 +107,7 @@ std::vector<int> get_device_ids_for_single_device(std::optional<int> override_de
         if (!is_valid_mmio_device(device_id)) {
             throw std::runtime_error("Invalid or non-MMIO device ID: " + std::to_string(device_id));
         }
-        std::cout << "Using Device: " << device_id << std::endl;
+        std::cout << "Using Device: " << device_id << '\n';
         return {device_id};
     }
     return get_mmio_device_ids(1, -1);
@@ -119,7 +119,7 @@ std::vector<int> get_device_ids_for_multi_device_same_node(std::optional<int> ov
         if (!is_valid_mmio_device(device_id)) {
             throw std::runtime_error("Invalid or non-MMIO device ID: " + std::to_string(device_id));
         }
-        std::cout << "Using Device: " << device_id << std::endl;
+        std::cout << "Using Device: " << device_id << '\n';
         return {device_id};
     }
     return get_mmio_device_ids(get_number_of_mmio_devices(), 0);
@@ -131,7 +131,7 @@ std::vector<int> get_device_ids_for_multi_device_different_nodes(std::optional<i
         if (!is_valid_mmio_device(device_id)) {
             throw std::runtime_error("Invalid or non-MMIO device ID: " + std::to_string(device_id));
         }
-        std::cout << "Using Device: " << device_id << std::endl;
+        std::cout << "Using Device: " << device_id << '\n';
         return {device_id};
     }
     return get_mmio_device_ids_unique_nodes(get_number_of_mmio_devices());

--- a/tt_metal/tools/mem_bench/mem_bench.cpp
+++ b/tt_metal/tools/mem_bench/mem_bench.cpp
@@ -564,7 +564,7 @@ std::optional<int> get_device_id_from_args(const std::vector<std::string>& input
             try {
                 return std::stoi(device_id_str);
             } catch (const std::exception&) {
-                std::cerr << "Invalid device ID: " << device_id_str << std::endl;
+                std::cerr << "Invalid device ID: " << device_id_str << '\n';
                 return std::nullopt;
             }
         }
@@ -582,7 +582,7 @@ int main(int argc, char* argv[]) {
     // Parse device ID if specified
     g_user_device_id = get_device_id_from_args(input_args);
     if (g_user_device_id.has_value()) {
-        std::cout << "Using device ID: " << g_user_device_id.value() << std::endl;
+        std::cout << "Using device ID: " << g_user_device_id.value() << '\n';
     }
 
     // Force TT_METAL options

--- a/tt_metal/tools/watcher_dump/watcher_dump.cpp
+++ b/tt_metal/tools/watcher_dump/watcher_dump.cpp
@@ -57,7 +57,7 @@ void dump_data(
             id, num_hw_cqs, DispatchCoreConfig{eth_dispatch ? DispatchCoreType::ETH : DispatchCoreType::WORKER});
         devices.push_back(std::unique_ptr<IDevice>(device));
         if (dump_cqs) {
-            cout << "Dumping Command Queues into: " << cq_dir.string() << endl;
+            cout << "Dumping Command Queues into: " << cq_dir.string() << '\n';
             std::unique_ptr<SystemMemoryManager> sysmem_manager = std::make_unique<SystemMemoryManager>(id, num_hw_cqs);
             internal::dump_cqs(cq_file, iq_file, *sysmem_manager, dump_cqs_raw_data);
         }
@@ -65,7 +65,7 @@ void dump_data(
 
     // Watcher doesn't have kernel ids since we didn't create them here, need to read from file.
     if (dump_watcher) {
-        cout << "Dumping Watcher Log into: " << MetalContext::instance().watcher_server()->log_file_name() << endl;
+        cout << "Dumping Watcher Log into: " << MetalContext::instance().watcher_server()->log_file_name() << '\n';
         MetalContext::instance().watcher_server()->isolated_dump(device_ids);
     }
 
@@ -76,25 +76,25 @@ void dump_data(
 }
 
 void print_usage(const char* exec_name) {
-    cout << "Usage: " << exec_name << " [OPTION]" << endl;
-    cout << "\t-h, --help: Display this message." << endl;
+    cout << "Usage: " << exec_name << " [OPTION]" << '\n';
+    cout << "\t-h, --help: Display this message." << '\n';
     cout << "\t-d=LIST, --devices=LIST: Device IDs of chips to dump, LIST is comma separated list (\"0,2,3\") or "
             "\"all\"."
-         << endl;
-    cout << "\t-n=INT, --num-hw-cqs=INT: Number of CQs, should match the original program." << endl;
-    cout << "\t-c, --dump-cqs: Dump Command Queue data." << endl;
-    cout << "\t--dump-cqs-data: Dump Command Queue raw data (bytes), this can take minutes per CQ." << endl;
+         << '\n';
+    cout << "\t-n=INT, --num-hw-cqs=INT: Number of CQs, should match the original program." << '\n';
+    cout << "\t-c, --dump-cqs: Dump Command Queue data." << '\n';
+    cout << "\t--dump-cqs-data: Dump Command Queue raw data (bytes), this can take minutes per CQ." << '\n';
     cout << "\t-w, --dump-watcher: Dump watcher data, available data depends on whether watcher was enabled for "
             "original program."
-         << endl;
+         << '\n';
     cout << "\t--dump-noc-transfer-data: Dump NOC transfer data. Data is only available if previous run had "
             "TT_METAL_RECORD_NOC_TRANSFER_DATA defined."
-         << endl;
-    cout << "\t--eth-dispatch: Assume eth dispatch, should match previous run." << endl;
+         << '\n';
+    cout << "\t--eth-dispatch: Assume eth dispatch, should match previous run." << '\n';
 }
 
 int main(int argc, char* argv[]) {
-    cout << "Running watcher dump tool..." << endl;
+    cout << "Running watcher dump tool..." << '\n';
     // Default devices is all of them.
     vector<ChipId> device_ids;
     auto num_devices = tt::tt_metal::GetNumAvailableDevices();
@@ -126,7 +126,7 @@ int main(int argc, char* argv[]) {
             while (std::getline(iss, item, ',')) {
                 if (stoi(item) >= num_devices) {
                     cout << "Error: illegal device (" << stoi(item) << "), allowed range is [0, " << num_devices << ")"
-                         << endl;
+                         << '\n';
                     print_usage(argv[0]);
                     return 1;
                 }
@@ -138,10 +138,10 @@ int main(int argc, char* argv[]) {
         } else if (s == "-w" || s == "--dump-watcher") {
             dump_watcher = true;
         } else if (s == "-c" || s == "--dump-cqs") {
-            cout << "CQ dumping currently disabled" << endl;
+            cout << "CQ dumping currently disabled" << '\n';
             // dump_cqs = true;
         } else if (s == "--dump-cqs-data") {
-            cout << "CQ raw data dumping currently disabled" << endl;
+            cout << "CQ raw data dumping currently disabled" << '\n';
             // dump_cqs_raw_data = true;
         } else if (s == "--dump-noc-transfer-data") {
             tt::tt_metal::MetalContext::instance().rtoptions().set_record_noc_transfers(true);
@@ -149,7 +149,7 @@ int main(int argc, char* argv[]) {
         } else if (s == "--eth-dispatch") {
             eth_dispatch = true;
         } else {
-            cout << "Error: unrecognized command line argument: " << s << endl;
+            cout << "Error: unrecognized command line argument: " << s << '\n';
             print_usage(argv[0]);
             return 1;
         }
@@ -157,5 +157,5 @@ int main(int argc, char* argv[]) {
 
     // Call dump function with user config.
     dump_data(device_ids, dump_watcher, dump_cqs, dump_cqs_raw_data, dump_noc_xfers, eth_dispatch, num_hw_cqs);
-    std::cout << "Watcher dump tool finished." << std::endl;
+    std::cout << "Watcher dump tool finished." << '\n';
 }

--- a/tt_metal/tools/watcher_dump/watcher_dump.cpp
+++ b/tt_metal/tools/watcher_dump/watcher_dump.cpp
@@ -88,8 +88,7 @@ void print_usage(const char* exec_name) {
             "original program."
          << '\n';
     cout << "\t--dump-noc-transfer-data: Dump NOC transfer data. Data is only available if previous run had "
-            "TT_METAL_RECORD_NOC_TRANSFER_DATA defined."
-         << '\n';
+            "TT_METAL_RECORD_NOC_TRANSFER_DATA defined.\n";
     cout << "\t--eth-dispatch: Assume eth dispatch, should match previous run.\n";
 }
 

--- a/tt_metal/tools/watcher_dump/watcher_dump.cpp
+++ b/tt_metal/tools/watcher_dump/watcher_dump.cpp
@@ -76,25 +76,25 @@ void dump_data(
 }
 
 void print_usage(const char* exec_name) {
-    cout << "Usage: " << exec_name << " [OPTION]" << '\n';
-    cout << "\t-h, --help: Display this message." << '\n';
+    cout << "Usage: " << exec_name << " [OPTION]\n";
+    cout << "\t-h, --help: Display this message.\n";
     cout << "\t-d=LIST, --devices=LIST: Device IDs of chips to dump, LIST is comma separated list (\"0,2,3\") or "
             "\"all\"."
          << '\n';
-    cout << "\t-n=INT, --num-hw-cqs=INT: Number of CQs, should match the original program." << '\n';
-    cout << "\t-c, --dump-cqs: Dump Command Queue data." << '\n';
-    cout << "\t--dump-cqs-data: Dump Command Queue raw data (bytes), this can take minutes per CQ." << '\n';
+    cout << "\t-n=INT, --num-hw-cqs=INT: Number of CQs, should match the original program.\n";
+    cout << "\t-c, --dump-cqs: Dump Command Queue data.\n";
+    cout << "\t--dump-cqs-data: Dump Command Queue raw data (bytes), this can take minutes per CQ.\n";
     cout << "\t-w, --dump-watcher: Dump watcher data, available data depends on whether watcher was enabled for "
             "original program."
          << '\n';
     cout << "\t--dump-noc-transfer-data: Dump NOC transfer data. Data is only available if previous run had "
             "TT_METAL_RECORD_NOC_TRANSFER_DATA defined."
          << '\n';
-    cout << "\t--eth-dispatch: Assume eth dispatch, should match previous run." << '\n';
+    cout << "\t--eth-dispatch: Assume eth dispatch, should match previous run.\n";
 }
 
 int main(int argc, char* argv[]) {
-    cout << "Running watcher dump tool..." << '\n';
+    cout << "Running watcher dump tool...\n";
     // Default devices is all of them.
     vector<ChipId> device_ids;
     auto num_devices = tt::tt_metal::GetNumAvailableDevices();
@@ -125,8 +125,7 @@ int main(int argc, char* argv[]) {
             string item;
             while (std::getline(iss, item, ',')) {
                 if (stoi(item) >= num_devices) {
-                    cout << "Error: illegal device (" << stoi(item) << "), allowed range is [0, " << num_devices << ")"
-                         << '\n';
+                    cout << "Error: illegal device (" << stoi(item) << "), allowed range is [0, " << num_devices << ")\n";
                     print_usage(argv[0]);
                     return 1;
                 }
@@ -138,10 +137,10 @@ int main(int argc, char* argv[]) {
         } else if (s == "-w" || s == "--dump-watcher") {
             dump_watcher = true;
         } else if (s == "-c" || s == "--dump-cqs") {
-            cout << "CQ dumping currently disabled" << '\n';
+            cout << "CQ dumping currently disabled\n";
             // dump_cqs = true;
         } else if (s == "--dump-cqs-data") {
-            cout << "CQ raw data dumping currently disabled" << '\n';
+            cout << "CQ raw data dumping currently disabled\n";
             // dump_cqs_raw_data = true;
         } else if (s == "--dump-noc-transfer-data") {
             tt::tt_metal::MetalContext::instance().rtoptions().set_record_noc_transfers(true);
@@ -157,5 +156,5 @@ int main(int argc, char* argv[]) {
 
     // Call dump function with user config.
     dump_data(device_ids, dump_watcher, dump_cqs, dump_cqs_raw_data, dump_noc_xfers, eth_dispatch, num_hw_cqs);
-    std::cout << "Watcher dump tool finished." << '\n';
+    std::cout << "Watcher dump tool finished.\n";
 }

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -427,17 +427,17 @@ void print_page(
     uint32_t l1_address,
     uint32_t bank_id,
     const std::vector<uint32_t>& page) {
-    std::cout << "dev_page_index " << dev_page_id << " on core " << core.str() << std::endl;
-    std::cout << "host_page_index " << host_page_id << std::endl;
-    std::cout << "noc coordinates " << noc_coordinates.str() << std::endl;
-    std::cout << "l1_address " << l1_address << std::endl;
-    std::cout << "bank id " << bank_id << std::endl;
+    std::cout << "dev_page_index " << dev_page_id << " on core " << core.str() << '\n';
+    std::cout << "host_page_index " << host_page_id << '\n';
+    std::cout << "noc coordinates " << noc_coordinates.str() << '\n';
+    std::cout << "l1_address " << l1_address << '\n';
+    std::cout << "bank id " << bank_id << '\n';
 
     std::cout << "0x";
     for (auto entry : page) {
         std::cout << std::hex << entry << std::dec;
     }
-    std::cout << std::dec << std::endl;
+    std::cout << std::dec << '\n';
 }
 
 void WriteToDeviceSharded(Buffer& buffer, tt::stl::Span<const uint8_t> host_buffer) {

--- a/tt_stl/tt_stl/assert.hpp
+++ b/tt_stl/tt_stl/assert.hpp
@@ -39,7 +39,7 @@ inline std::vector<std::string> backtrace(int size = 64, int skip = 1) {
     size_t s = ::backtrace(array, size);
     char** strings = backtrace_symbols(array, s);
     if (strings == nullptr) {
-        std::cout << "backtrace_symbols error." << std::endl;
+        std::cout << "backtrace_symbols error." << '\n';
         return bt;
     }
     for (size_t i = skip; i < s; ++i) {
@@ -96,9 +96,9 @@ template <typename... Args>
     }
 
     std::stringstream trace_message_ss = {};
-    trace_message_ss << assert_type << " @ " << file << ":" << line << ": " << condition_str << std::endl;
+    trace_message_ss << assert_type << " @ " << file << ":" << line << ": " << condition_str << '\n';
     if constexpr (sizeof...(args) > 0) {
-        trace_message_ss << "info:" << std::endl;
+        trace_message_ss << "info:" << '\n';
         trace_message_ss << fmt::format(args...) << std::endl;
         log_critical(tt::LogAlways, "{}: {}", assert_type, fmt::format(args...));
     }

--- a/tt_stl/tt_stl/assert.hpp
+++ b/tt_stl/tt_stl/assert.hpp
@@ -39,7 +39,7 @@ inline std::vector<std::string> backtrace(int size = 64, int skip = 1) {
     size_t s = ::backtrace(array, size);
     char** strings = backtrace_symbols(array, s);
     if (strings == nullptr) {
-        std::cout << "backtrace_symbols error." << '\n';
+        std::cout << "backtrace_symbols error.\n";
         return bt;
     }
     for (size_t i = skip; i < s; ++i) {
@@ -98,7 +98,7 @@ template <typename... Args>
     std::stringstream trace_message_ss = {};
     trace_message_ss << assert_type << " @ " << file << ":" << line << ": " << condition_str << '\n';
     if constexpr (sizeof...(args) > 0) {
-        trace_message_ss << "info:" << '\n';
+        trace_message_ss << "info:\n";
         trace_message_ss << fmt::format(args...) << std::endl;
         log_critical(tt::LogAlways, "{}: {}", assert_type, fmt::format(args...));
     }

--- a/tt_stl/tt_stl/assert.hpp
+++ b/tt_stl/tt_stl/assert.hpp
@@ -104,7 +104,6 @@ template <typename... Args>
     }
     trace_message_ss << "backtrace:\n";
     trace_message_ss << tt::assert::backtrace_to_string(100, 3, " --- ");
-    trace_message_ss << std::flush;
     throw std::runtime_error(trace_message_ss.str());
 }
 

--- a/ttnn/core/core.cpp
+++ b/ttnn/core/core.cpp
@@ -34,7 +34,7 @@ void segfault_handler(int sig) {
 
 void dump_stack_trace_on_segfault() {
     if (std::signal(SIGSEGV, segfault_handler) == SIG_ERR) {
-        std::cerr << "Error: cannot handle SIGSEGV" << '\n';
+        std::cerr << "Error: cannot handle SIGSEGV\n";
         exit(EXIT_FAILURE);
     }
 }

--- a/ttnn/core/core.cpp
+++ b/ttnn/core/core.cpp
@@ -28,13 +28,13 @@ void set_printoptions(TensorPrintProfile print_profile, SciMode sci_mode, int pr
 }
 
 void segfault_handler(int sig) {
-    std::cerr << tt::assert::backtrace_to_string() << std::endl;
+    std::cerr << tt::assert::backtrace_to_string() << '\n';
     exit(EXIT_FAILURE);
 }
 
 void dump_stack_trace_on_segfault() {
     if (std::signal(SIGSEGV, segfault_handler) == SIG_ERR) {
-        std::cerr << "Error: cannot handle SIGSEGV" << std::endl;
+        std::cerr << "Error: cannot handle SIGSEGV" << '\n';
         exit(EXIT_FAILURE);
     }
 }

--- a/ttnn/core/tensor/tensor_impl.cpp
+++ b/ttnn/core/tensor/tensor_impl.cpp
@@ -478,7 +478,7 @@ std::string to_string_impl(const Tensor& tensor) {
                 for (size_t i = 0; i < buffers.size(); i++) {
                     detail::to_string(ss, buffers[i].view_as<T>(), shape, strides, tensor.dtype(), tensor.layout());
                     if (i + 1 != buffers.size()) {
-                        ss << std::endl;
+                        ss << '\n';
                     }
                 }
                 return ss.str();
@@ -505,11 +505,11 @@ std::string to_string_impl(const Tensor& tensor) {
                 for (size_t i = 0; i < buffers.size(); i++) {
                     const distributed::MeshCoordinate coord = *coords_it++;
                     if (mesh_device->is_local(coord)) {
-                        ss << "device_id: " << mesh_device->get_device(coord)->id() << ", " << coord << std::endl;
+                        ss << "device_id: " << mesh_device->get_device(coord)->id() << ", " << coord << '\n';
                         detail::to_string(ss, buffers[i].view_as<T>(), shape, strides, tensor.dtype(), tensor.layout());
                     }
                     if (i + 1 != buffers.size()) {
-                        ss << std::endl;
+                        ss << '\n';
                     }
                 }
                 return ss.str();

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/concat.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/concat.cpp
@@ -29,7 +29,7 @@ constexpr bool debug_concat = false;
 inline void concat_db_print(bool condition, const std::string& msg) {
     if constexpr (debug_concat) {
         if (condition) {
-            std::cout << "[DEBUG] concat: " << msg << std::endl;
+            std::cout << "[DEBUG] concat: " << msg << '\n';
         }
     }
 }


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/22758

### Problem description
We have this check disabled. https://clang.llvm.org/extra/clang-tidy/checks/performance/avoid-endl.html

While its unlikely that we are printing things in hot paths, lets be sure.
Also, I am hopeful that this change can speed up our tools, and our tests.

### What's changed
- Enable check
- Apply automatic FIXITs

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/19986210981) CI passes
- [x] New/Existing tests provide coverage for changes