### PR TITLE
bugprone-unused-local-non-trivial-variable

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -21,7 +21,6 @@ Checks: >
   -bugprone-sizeof-expression,
   -bugprone-unchecked-optional-access,
   -bugprone-unhandled-self-assignment,
-  -bugprone-unused-local-non-trivial-variable,
   -cert-arr39-c,
   -cert-dcl16-c,
   -cert-dcl21-cpp,

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_waypoint.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_waypoint.cpp
@@ -200,7 +200,7 @@ void RunTest(MeshWatcherFixture* fixture, const std::shared_ptr<distributed::Mes
                 if (tt::tt_metal::GetNumAvailableDevices() == 1 && !fixture->IsSlowDispatch()) {
                     // blank | prefetch, dispatch
                     int k_id = 1 + 2;
-                    std::string k_id_s = fmt::format("{:3}|{:3}|{:3}", k_id, k_id + 1, k_id + 2);
+                    k_id_s = fmt::format("{:3}|{:3}|{:3}", k_id, k_id + 1, k_id + 2);
                 } else {
                     k_id_s = "";
                 }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_mux_bandwidth.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_mux_bandwidth.cpp
@@ -323,7 +323,6 @@ void create_worker_kernel(
 int main(int argc, char** argv) {
     const std::string default_log_file_path =
         std::string(std::getenv("TT_METAL_HOME")) + "/generated/fabric_mux_bandwidth_temp.txt";
-    const std::string default_test_name = "default_mux_ubench";
     const size_t default_num_full_size_channels = 8;
     const size_t default_num_header_only_channels = 0;
     const size_t default_num_buffers_full_size_channel = 8;
@@ -337,7 +336,6 @@ int main(int argc, char** argv) {
     TestParams test_params;
 
     std::string log_file_path = test_args::get_command_option(input_args, "--log_file", default_log_file_path);
-    std::string test_name = test_args::get_command_option(input_args, "--test_name", default_test_name);
     test_params.num_full_size_channels =
         test_args::get_command_option_uint32(input_args, "--num_full_size_channels", default_num_full_size_channels);
     test_params.num_header_only_channels = test_args::get_command_option_uint32(

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_context.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_context.hpp
@@ -620,7 +620,6 @@ public:
     void setup_ci_artifacts() {
         std::filesystem::path tt_metal_home =
             std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir());
-        std::filesystem::path bandwidth_results_path = tt_metal_home / output_dir;
         std::filesystem::path ci_artifacts_path = tt_metal_home / ci_artifacts_dir;
         // Create CI artifacts directory if it doesn't exist
         if (!std::filesystem::exists(ci_artifacts_path)) {

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -978,9 +978,6 @@ void ControlPlane::configure_routing_tables_for_fabric_ethernet_channels(
                     auto host_rank_for_chip =
                         this->topology_mapper_->get_host_rank_for_chip(mesh_id, logical_connected_chip_id);
 
-                    auto neighbor_host = this->topology_mapper_->get_hostname_for_fabric_node_id(
-                        FabricNodeId(mesh_id, logical_connected_chip_id));
-
                     TT_ASSERT(
                         host_rank_for_chip.has_value(),
                         "Mesh {} Chip {} does not have a host rank associated with it",

--- a/tt_metal/impl/debug/watcher_device_reader.cpp
+++ b/tt_metal/impl/debug/watcher_device_reader.cpp
@@ -643,7 +643,6 @@ void WatcherDeviceReader::Core::DumpL1Status() const {
 void WatcherDeviceReader::Core::DumpNocSanitizeStatus(int noc) const {
     auto san = mbox_data_.watcher().sanitize()[noc];
     string error_msg;
-    string error_reason;
 
     switch (san.return_code()) {
         case dev_msgs::DebugSanitizeOK:

--- a/tt_metal/impl/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/impl/profiler/tt_metal_profiler.cpp
@@ -478,7 +478,7 @@ void setSyncInfo(
                 childSyncInfo.second *= syncInfo.first;
                 childSyncInfo.second += syncInfo.second;
                 childSyncInfo.first *= syncInfo.first;
-                setSyncInfo(child_device.first, childSyncInfo, root_sync_info, deviceDeviceSyncInfo, parentInfo);
+                setSyncInfo(child_device.first, childSyncInfo, root_sync_info, deviceDeviceSyncInfo, parentInfoNew);
             }
         }
         detail::setShift(device_id, syncInfo.second, syncInfo.first, root_sync_info);

--- a/tt_metal/jit_build/genfiles.cpp
+++ b/tt_metal/jit_build/genfiles.cpp
@@ -89,11 +89,8 @@ void jit_build_genfiles_triscs_src(
     string math_base = out_dir + "chlkc_math";
     string pack_base = out_dir + "chlkc_pack";
     string unpack_cpp = unpack_base + ".cpp";
-    string unpack_llk_args_h = unpack_base + "_llk_args.h";
     string math_cpp = math_base + ".cpp";
-    string math_llk_args_h = math_base + "_llk_args.h";
     string pack_cpp = pack_base + ".cpp";
-    string pack_llk_args_h = pack_base + "_llk_args.h";
 
     const string& kernel_src_to_include = get_kernel_source_to_include(kernel_src);
 

--- a/ttnn/api/tools/profiler/op_profiler.hpp
+++ b/ttnn/api/tools/profiler/op_profiler.hpp
@@ -288,7 +288,6 @@ static inline json get_kernels_json(ChipId device_id, const Program& program) {
 
 static inline json get_tensor_json(const Tensor& tensor) {
     json ret;
-    std::string tensorStorageStr;
     if (tensor.storage_type() == StorageType::DEVICE) {
         ret["storage_type"]["device_id"] = tensor.device()->id();
         ret["storage_type"]["memory_config"]["buffer_type"] =

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_op.cpp
@@ -20,7 +20,6 @@ void AllGatherAsync::validate_with_output_tensors(
     const auto& layout = input_tensors[0].layout();
     const auto& dtype = input_tensors[0].dtype();
     const auto& page_size = input_tensors[0].buffer()->page_size();
-    std::string arch_name = tt::tt_metal::hal::get_arch_name();
     TT_FATAL(
         (tt::tt_metal::hal::get_arch_name() != "blackhole") ||
             (input_tensor.memory_config().buffer_type() != BufferType::DRAM) ||

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step1/device/moreh_nll_loss_step1_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step1/device/moreh_nll_loss_step1_program_factory.cpp
@@ -24,7 +24,6 @@ MorehNllLossStep1DeviceOperation::Factory::cached_program_t MorehNllLossStep1Dev
     const Tensor& target = tensor_args.target_tensor;
     const std::optional<Tensor>& weight = tensor_args.weight_tensor;
     const Tensor& output = tensor_return_value;
-    const std::string reduction = operation_attributes.reduction;
     const uint32_t ignore_index = operation_attributes.ignore_index;
     const uint32_t channel_size = operation_attributes.channel_size;
     const auto& compute_kernel_config = operation_attributes.compute_kernel_config;


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/22758

### Problem description
Dead code, is confusing code.
We have this clang-tidy check disabled: https://clang.llvm.org/extra/clang-tidy/checks/bugprone/unused-local-non-trivial-variable.html

### What's changed
- rm -rf
- Enable check

[1 tool called]

Only one issue left. Let me check and fix it:

[3 tools called]

No more `bugprone-unused-local-non-trivial-variable` errors! Let me check if there are any other build failures:

[1 tool called]

The build completes successfully now. All `bugprone-unused-local-non-trivial-variable` errors have been fixed.

Here's a summary of all the fixes made:

| File | Fix |
|------|-----|
| `tt_metal/jit_build/genfiles.cpp` | Removed 3 unused variables: `unpack_llk_args_h`, `math_llk_args_h`, `pack_llk_args_h` |
| `tt_metal/impl/debug/watcher_device_reader.cpp` | Removed unused `error_reason` variable |
| `tt_metal/impl/profiler/tt_metal_profiler.cpp` | Fixed bug: `parentInfoNew` was created but `parentInfo` was passed to recursive call instead |
| `tt_metal/fabric/control_plane.cpp` | Removed unused `neighbor_host` variable |
| `ttnn/api/tools/profiler/op_profiler.hpp` | Removed unused `tensorStorageStr` variable |
| `ttnn/cpp/.../all_gather_async_op.cpp` | Removed unused `arch_name` variable |
| `ttnn/cpp/.../moreh_nll_loss_step1_program_factory.cpp` | Removed unused `reduction` variable |
| `tests/.../watcher/test_waypoint.cpp` | Fixed variable shadowing bug: removed redundant `std::string` redeclaration of `k_id_s` |
| `tests/.../tt_fabric_test_context.hpp` | Removed unused `bandwidth_results_path` variable |
| `tests/.../test_tt_fabric_mux_bandwidth.cpp` | Removed unused `test_name` and `default_test_name` |

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/19986384570) CI passes
- [x] New/Existing tests provide coverage for changes