### PR TITLE
[skip ci] make auto triage send nested slack messages

### DIFF
--- a/.github/actions/analyze-workflow-data/lib/reporting.js
+++ b/.github/actions/analyze-workflow-data/lib/reporting.js
@@ -716,6 +716,25 @@ async function enrichRegressions(regressedDetails, filteredGrouped, errorSnippet
       core.warning(`Failed to find first failing run for ${item.name}: ${e.message}`);
     }
   }
+
+  // Manually inject a fake regression for testing purposes
+  regressedDetails.push({
+    name: 'all-post-commit-workflows',
+    workflow_path: '.github/workflows/all-post-commit-workflows.yaml',
+    workflow_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/workflows/all-post-commit-workflows.yaml`,
+    run_id: 'fake-run-id',
+    run_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions`,
+    created_at: new Date().toISOString(),
+    first_failed_run_id: 'fake-run-id',
+    first_failed_run_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions`,
+    first_failed_created_at: new Date().toISOString(),
+    first_failed_head_sha: '0000000000000000000000000000000000000000',
+    first_failed_head_short: '0000000',
+    first_failed_author_name: 'Test User',
+    owners: [],
+    failing_jobs: ['mock-failing-job'],
+    error_snippets: []
+  });
 }
 
 /**
@@ -928,7 +947,6 @@ function buildStayedFailingSection(stayedFailingDetails, context) {
 
   return ['', '## Still Failing (No Recovery)', ...lines, ''].join('\n');
 }
-
 module.exports = {
   getWorkflowLink,
   findGoodBadCommits,

--- a/.github/actions/analyze-workflow-data/lib/reporting.js
+++ b/.github/actions/analyze-workflow-data/lib/reporting.js
@@ -732,7 +732,7 @@ async function enrichRegressions(regressedDetails, filteredGrouped, errorSnippet
     first_failed_head_short: '0000000',
     first_failed_author_name: 'Test User',
     owners: [],
-    failing_jobs: ['mock-failing-job'],
+    failing_jobs: ['tt-train-cpp-unit-tests (wormhole_b0, N150) / tt-train wormhole_b0 N150'],
     error_snippets: []
   });
 }

--- a/.github/actions/analyze-workflow-data/lib/reporting.js
+++ b/.github/actions/analyze-workflow-data/lib/reporting.js
@@ -716,25 +716,6 @@ async function enrichRegressions(regressedDetails, filteredGrouped, errorSnippet
       core.warning(`Failed to find first failing run for ${item.name}: ${e.message}`);
     }
   }
-
-  // Manually inject a fake regression for testing purposes
-  regressedDetails.push({
-    name: 'all-post-commit-workflows',
-    workflow_path: '.github/workflows/all-post-commit-workflows.yaml',
-    workflow_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/workflows/all-post-commit-workflows.yaml`,
-    run_id: 'fake-run-id',
-    run_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions`,
-    created_at: new Date().toISOString(),
-    first_failed_run_id: 'fake-run-id',
-    first_failed_run_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions`,
-    first_failed_created_at: new Date().toISOString(),
-    first_failed_head_sha: '0000000000000000000000000000000000000000',
-    first_failed_head_short: '0000000',
-    first_failed_author_name: 'Test User',
-    owners: [],
-    failing_jobs: ['tt-train-cpp-unit-tests (wormhole_b0, N150) / tt-train wormhole_b0 N150'],
-    error_snippets: []
-  });
 }
 
 /**
@@ -947,6 +928,7 @@ function buildStayedFailingSection(stayedFailingDetails, context) {
 
   return ['', '## Still Failing (No Recovery)', ...lines, ''].join('\n');
 }
+
 module.exports = {
   getWorkflowLink,
   findGoodBadCommits,

--- a/.github/actions/slack-report-analyze-workflow-data/action.yaml
+++ b/.github/actions/slack-report-analyze-workflow-data/action.yaml
@@ -3,13 +3,20 @@ description: "Report the workflow status to Slack to help identify breakages fas
 inputs:
   slack_webhook_url:
     description: "Webhook URL for the Slack channel to be posted to. Generated via slack app!"
-    required: true
+    required: false
+  channel_id:
+    description: "Channel ID for the Slack channel (required if using Bot Token)"
+    required: false
   regressed_workflows:
     description: "JSON array from analyze step output 'regressed_workflows'"
     required: true
   alert_all_message:
     description: "Optional Slack-ready alert text from analyze step output 'alert_all_message'"
     required: false
+outputs:
+  slack_ts:
+    description: "The timestamp of the sent Slack message (only available when using Bot Token)"
+    value: ${{ steps.slack_send.outputs.ts }}
 runs:
   using: "composite"
   steps:
@@ -127,8 +134,11 @@ runs:
 
     - name: Report GitHub Pipeline Status Slack Action
       if: steps.build.outputs.has_regressions == 'true'
+      id: slack_send
       uses: slackapi/slack-github-action@v1.26.0
       with:
         payload: ${{ steps.build.outputs.payload }}
+        channel-id: ${{ inputs.channel_id }}
       env:
         SLACK_WEBHOOK_URL: ${{ inputs.slack_webhook_url }}
+        SLACK_BOT_TOKEN: ${{ env.SLACK_BOT_TOKEN }}

--- a/.github/actions/trigger-auto-triage-for-regressions/action.yml
+++ b/.github/actions/trigger-auto-triage-for-regressions/action.yml
@@ -7,6 +7,9 @@ inputs:
   github_token:
     description: 'GitHub token for triggering workflows'
     required: true
+  slack_ts:
+    description: 'Slack message timestamp for threading replies'
+    required: false
 
 runs:
   using: 'node20'

--- a/.github/actions/trigger-auto-triage-for-regressions/index.js
+++ b/.github/actions/trigger-auto-triage-for-regressions/index.js
@@ -5,11 +5,15 @@ async function run() {
   try {
     const regressedWorkflowsJson = core.getInput('regressed_workflows', { required: true });
     const githubToken = core.getInput('github_token', { required: true });
+    const slackTs = core.getInput('slack_ts') || '';
 
     const regressedWorkflows = JSON.parse(regressedWorkflowsJson);
     const octokit = github.getOctokit(githubToken);
 
     core.info(`Found ${regressedWorkflows.length} regressed workflow(s)`);
+    if (slackTs) {
+      core.info(`Slack timestamp provided: ${slackTs}`);
+    }
 
     for (const workflow of regressedWorkflows) {
       const workflowPath = workflow.workflow_path || workflow.name;
@@ -39,7 +43,8 @@ async function run() {
             ref: 'main',
             inputs: {
               workflow_name: workflowFileName,
-              job_name: jobName
+              job_name: jobName,
+              slack_ts: slackTs
             }
           });
 

--- a/.github/actions/trigger-auto-triage-for-regressions/index.js
+++ b/.github/actions/trigger-auto-triage-for-regressions/index.js
@@ -40,7 +40,7 @@ async function run() {
             owner: github.context.repo.owner,
             repo: github.context.repo.repo,
             workflow_id: 'auto-triage.yml',
-            ref: github.context.ref,
+            ref: 'main',
             inputs: {
               workflow_name: workflowFileName,
               job_name: jobName,

--- a/.github/actions/trigger-auto-triage-for-regressions/index.js
+++ b/.github/actions/trigger-auto-triage-for-regressions/index.js
@@ -40,7 +40,7 @@ async function run() {
             owner: github.context.repo.owner,
             repo: github.context.repo.repo,
             workflow_id: 'auto-triage.yml',
-            ref: 'main',
+            ref: github.context.ref,
             inputs: {
               workflow_name: workflowFileName,
               job_name: jobName,

--- a/.github/workflows/aggregate-workflow-data.yaml
+++ b/.github/workflows/aggregate-workflow-data.yaml
@@ -267,7 +267,7 @@ jobs:
 
   trigger-auto-triage:
     needs: [analyze-data, handle-failures]
-    if: ${{ fromJson(needs.analyze-data.outputs.regressed_workflows) != '[]' }}
+    if: ${{ always() && needs.analyze-data.result == 'success' && fromJson(needs.analyze-data.outputs.regressed_workflows) != '[]' }}
     runs-on: ubuntu-latest
     permissions:
       actions: write

--- a/.github/workflows/aggregate-workflow-data.yaml
+++ b/.github/workflows/aggregate-workflow-data.yaml
@@ -18,262 +18,299 @@ on:
         default: false
 
 jobs:
-  fetch-data:
+  # fetch-data:
+  #   runs-on: ubuntu-latest
+  #   outputs:
+  #     cache-path: ${{ steps.fetch.outputs.cache-path }}
+  #     commits-path: ${{ steps.fetch.outputs.commits-path }}
+  #     annotations-root: ${{ steps.fetch.outputs.annotations-root }}
+  #     annotations-index-path: ${{ steps.fetch.outputs.annotations-index-path }}
+  #     gtest-logs-root: ${{ steps.fetch.outputs.gtest-logs-root }}
+  #     gtest-logs-index-path: ${{ steps.fetch.outputs.gtest-logs-index-path }}
+  #     other-logs-root: ${{ steps.fetch.outputs.other-logs-root }}
+  #     other-logs-index-path: ${{ steps.fetch.outputs.other-logs-index-path }}
+  #     last-success-timestamps-path: ${{ steps.fetch.outputs.last-success-timestamps-path }}
+  #   steps:
+  #     - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 #@v3
+
+  #     - name: Install fetch-workflow-data dependencies
+  #       shell: bash
+  #       working-directory: .github/actions/fetch-workflow-data
+  #       run: npm install
+  #     - name: Fetch workflow data
+  #       id: fetch
+  #       uses: ./.github/actions/fetch-workflow-data
+  #       with:
+  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #         days: ${{ github.event.inputs.days || 15 }}
+  #         force-fresh: ${{ github.event.inputs.force-fresh || false }}
+  #         workflow_ids: |
+  #           [
+  #             ".github/workflows/all-post-commit-workflows.yaml",
+  #             ".github/workflows/blackhole-post-commit.yaml",
+  #             ".github/workflows/blackhole-nightly-tests.yaml",
+  #             ".github/workflows/blackhole-demo-tests.yaml",
+  #             ".github/workflows/galaxy-profiler-tests.yaml",
+  #             ".github/workflows/galaxy-multi-user-isolation-tests.yaml",
+  #             ".github/workflows/galaxy-deepseek-tests.yaml",
+  #             ".github/workflows/galaxy-model-perf-tests.yaml",
+  #             ".github/workflows/galaxy-demo-tests.yaml",
+  #             ".github/workflows/galaxy-unit-tests.yaml",
+  #             ".github/workflows/galaxy-frequent-tests.yaml",
+  #             ".github/workflows/galaxy-stress-tests.yaml",
+  #             ".github/workflows/galaxy-nightly-tests.yaml",
+  #             ".github/workflows/galaxy-quick.yaml",
+  #             ".github/workflows/t3000-model-perf-tests.yaml",
+  #             ".github/workflows/t3000-nightly-tests.yaml",
+  #             ".github/workflows/t3000-frequent-tests.yaml",
+  #             ".github/workflows/t3000-profiler-tests.yaml",
+  #             ".github/workflows/t3000-perplexity-tests.yaml",
+  #             ".github/workflows/t3000-demo-tests.yaml",
+  #             ".github/workflows/t3000-unit-tests.yaml",
+  #             ".github/workflows/fast-dispatch-frequent-tests.yaml",
+  #             ".github/workflows/perf-device-models.yaml",
+  #             ".github/workflows/perf-models.yaml",
+  #             ".github/workflows/fast-dispatch-full-regressions-and-models.yaml",
+  #             ".github/workflows/single-card-demo-tests.yaml",
+  #             ".github/workflows/tt-metal-l2-nightly.yaml",
+  #             ".github/workflows/ttnn-run-sweeps.yaml",
+  #             ".github/workflows/vllm-nightly-tests.yaml",
+  #             ".github/workflows/metal-run-microbenchmarks.yaml",
+  #             ".github/workflows/apc-nightly-debug.yaml",
+  #             ".github/workflows/merge-gate.yaml",
+  #             ".github/workflows/pr-gate.yaml"
+  #           ]
+  #     - name: Upload workflow data
+  #       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #@v4
+  #       with:
+  #         name: workflow-data
+  #         path: ${{ github.workspace }}/workflow-data.json
+  #         retention-days: 1
+
+  #     - name: Upload annotations artifact (if any)
+  #       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #@v4
+  #       with:
+  #         name: workflow-annotations
+  #         path: |
+  #           ${{ steps.fetch.outputs.annotations-root }}/
+  #           ${{ steps.fetch.outputs.annotations-index-path }}
+  #         retention-days: 1
+
+  #     - name: Upload commits artifact
+  #       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #@v4
+  #       with:
+  #         name: commits-main
+  #         path: ${{ steps.fetch.outputs.commits-path }}
+  #         retention-days: 1
+
+  #     - name: Upload gtest logs artifact (if any)
+  #       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #@v4
+  #       with:
+  #         name: workflow-gtest-logs
+  #         path: |
+  #           ${{ steps.fetch.outputs.gtest-logs-root }}/
+  #           ${{ steps.fetch.outputs.gtest-logs-index-path }}
+  #         retention-days: 1
+
+  #     - name: Upload other logs artifact (if any)
+  #       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #@v4
+  #       with:
+  #         name: workflow-other-logs
+  #         path: |
+  #           ${{ steps.fetch.outputs.other-logs-root }}/
+  #           ${{ steps.fetch.outputs.other-logs-index-path }}
+  #         retention-days: 1
+
+  #     - name: Upload last success timestamps artifact
+  #       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #@v4
+  #       with:
+  #         name: last-success-timestamps
+  #         path: ${{ steps.fetch.outputs.last-success-timestamps-path }}
+  #         retention-days: 1
+
+  #     - name: Debug cache file
+  #       run: ls -l ${{ github.workspace }}/workflow-data.json || echo "File not found"
+
+  # analyze-data:
+  #   needs: fetch-data
+  #   runs-on: ubuntu-latest
+  #   outputs:
+  #     failed_workflows: ${{ steps.analyze.outputs.failed_workflows }}
+  #     regressed_workflows: ${{ steps.analyze.outputs.regressed_workflows }}
+  #     alert_all_message: ${{ steps.analyze.outputs.alert_all_message }}
+  #   steps:
+  #     - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 #@v3
+  #     - name: Discover previous successful run id
+  #       id: prev
+  #       uses: actions/github-script@v7
+  #       with:
+  #         script: |
+  #           const owner = context.repo.owner;
+  #           const repo = context.repo.repo;
+  #           const workflow_id = '.github/workflows/aggregate-workflow-data.yaml';
+  #           const resp = await github.request('GET /repos/{owner}/{repo}/actions/workflows/{workflow_id}/runs', {
+  #             owner,
+  #             repo,
+  #             workflow_id,
+  #             branch: 'main',
+  #             status: 'completed',
+  #             per_page: 10
+  #           });
+  #           const runs = (resp.data.workflow_runs || []).filter(r => r.event === 'schedule' && r.conclusion === 'success');
+  #           const run = runs[0];
+  #           const selectedId = run ? String(run.id) : '';
+  #           core.info(`Selected previous run id: ${selectedId || 'none'}`);
+  #           core.setOutput('run_id', selectedId);
+  #     - name: Install analyze-workflow-data dependencies
+  #       shell: bash
+  #       working-directory: .github/actions/analyze-workflow-data
+  #       run: npm install
+  #     - name: Download previous workflow data artifact (if any)
+  #       if: ${{ steps.prev.outputs.run_id != '' }}
+  #       uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0
+  #       with:
+  #         name: workflow-data
+  #         path: ${{ github.workspace }}/prev
+  #         run-id: ${{ steps.prev.outputs.run_id }}
+  #         github-token: ${{ secrets.GITHUB_TOKEN }}
+  #     - name: Echo selected previous run id
+  #       run: |
+  #         echo "Selected previous run id: ${{ steps.prev.outputs.run_id }}"
+  #     - name: List artifacts for selected previous run (debug)
+  #       if: ${{ steps.prev.outputs.run_id != '' }}
+  #       uses: actions/github-script@v7
+  #       with:
+  #         script: |
+  #           const { owner, repo } = context.repo;
+  #           const run_id = Number('${{ steps.prev.outputs.run_id }}');
+  #           const arts = await github.rest.actions.listWorkflowRunArtifacts({ owner, repo, run_id, per_page: 100 });
+  #           core.info(`Artifacts for run ${run_id}:`);
+  #           for (const a of arts.data.artifacts) {
+  #             core.info(`- name=${a.name} id=${a.id} expired=${a.expired} size=${a.size_in_bytes}`);
+  #           }
+  #         github-token: ${{ secrets.GITHUB_TOKEN }}
+
+  #     - name: Download workflow data
+  #       uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0
+  #       with:
+  #         name: workflow-data
+  #         path: ${{ github.workspace }}
+  #     - name: Download annotations (if any)
+  #       uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0
+  #       with:
+  #         name: workflow-annotations
+  #         path: ${{ github.workspace }}/annotations
+  #     - name: Download gtest logs (if any)
+  #       uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0
+  #       with:
+  #         name: workflow-gtest-logs
+  #         path: ${{ github.workspace }}/logs/gtest
+  #     - name: Download other logs (if any)
+  #       uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0
+  #       with:
+  #         name: workflow-other-logs
+  #         path: ${{ github.workspace }}/logs/other
+  #     - name: Download commits index
+  #       uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0
+  #       with:
+  #         name: commits-main
+  #         path: ${{ github.workspace }}
+  #     - name: Download last success timestamps
+  #       uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0
+  #       with:
+  #         name: last-success-timestamps
+  #         path: ${{ github.workspace }}
+  #     - name: Analyze workflow data
+  #       id: analyze
+  #       uses: ./.github/actions/analyze-workflow-data
+  #       with:
+  #         days: ${{ github.event.inputs.days || 15 }}
+  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #         cache-path: ${{ github.workspace }}/workflow-data.json
+  #         previous-cache-path: ${{ github.workspace }}/prev/workflow-data.json
+  #         annotations-index-path: ${{ github.workspace }}/annotations/annotations-index.json
+  #         commits-path: ${{ github.workspace }}/commits-main.json
+  #         gtest-logs-index-path: ${{ github.workspace }}/logs/gtest/gtest-logs-index.json
+  #         other-logs-index-path: ${{ github.workspace }}/logs/other/other-logs-index.json
+  #         last-success-timestamps-path: ${{ github.workspace }}/last-success-timestamps.json
+  #         alert-all: 'false'
+  #     - name: Upload status changes artifact
+  #       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #@v4
+  #       with:
+  #         name: workflow-status-changes
+  #         path: ${{ steps.analyze.outputs.status_changes_path }}
+  #         retention-days: 1
+
+
+  # handle-failures:
+  #   needs: analyze-data
+  #   if: ${{ fromJson(needs.analyze-data.outputs.failed_workflows) != '[]' }}
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 #@v3
+  #     - name: Handle failed workflows
+  #       run: |
+  #         echo "The following workflows have failed:"
+  #         echo '${{ needs.analyze-data.outputs.failed_workflows }}' | jq -r '.[]'
+  #         # Add any additional failure handling steps here
+  #     - name: Post regressions to Slack
+  #       uses: ./.github/actions/slack-report-analyze-workflow-data
+  #       with:
+  #         slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_AGGREGATE_PIPELINE_STATUS_ALERT }}
+  #         regressed_workflows: ${{ needs.analyze-data.outputs.regressed_workflows }}
+  #         alert_all_message: ${{ needs.analyze-data.outputs.alert_all_message }}
+
+  # trigger-auto-triage:
+  #   needs: analyze-data
+  #   if: ${{ fromJson(needs.analyze-data.outputs.regressed_workflows) != '[]' }}
+  #   runs-on: ubuntu-latest
+  #   permissions:
+  #     actions: write
+  #     contents: read
+  #   steps:
+  #     - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 #@v3
+  #     - name: Install dependencies
+  #       working-directory: .github/actions/trigger-auto-triage-for-regressions
+  #       run: npm install
+  #     - name: Trigger auto-triage for regressed jobs
+  #       uses: ./.github/actions/trigger-auto-triage-for-regressions
+  #       with:
+  #         regressed_workflows: ${{ needs.analyze-data.outputs.regressed_workflows }}
+  #         github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  test-slack-threads:
     runs-on: ubuntu-latest
-    outputs:
-      cache-path: ${{ steps.fetch.outputs.cache-path }}
-      commits-path: ${{ steps.fetch.outputs.commits-path }}
-      annotations-root: ${{ steps.fetch.outputs.annotations-root }}
-      annotations-index-path: ${{ steps.fetch.outputs.annotations-index-path }}
-      gtest-logs-root: ${{ steps.fetch.outputs.gtest-logs-root }}
-      gtest-logs-index-path: ${{ steps.fetch.outputs.gtest-logs-index-path }}
-      other-logs-root: ${{ steps.fetch.outputs.other-logs-root }}
-      other-logs-index-path: ${{ steps.fetch.outputs.other-logs-index-path }}
-      last-success-timestamps-path: ${{ steps.fetch.outputs.last-success-timestamps-path }}
+    if: ${{ github.event_name == 'workflow_dispatch' }}
     steps:
-      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 #@v3
-
-      - name: Install fetch-workflow-data dependencies
-        shell: bash
-        working-directory: .github/actions/fetch-workflow-data
-        run: npm install
-      - name: Fetch workflow data
-        id: fetch
-        uses: ./.github/actions/fetch-workflow-data
+      - name: Send Parent Message
+        id: parent
+        uses: slackapi/slack-github-action@v1.26.0
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          days: ${{ github.event.inputs.days || 15 }}
-          force-fresh: ${{ github.event.inputs.force-fresh || false }}
-          workflow_ids: |
-            [
-              ".github/workflows/all-post-commit-workflows.yaml",
-              ".github/workflows/blackhole-post-commit.yaml",
-              ".github/workflows/blackhole-nightly-tests.yaml",
-              ".github/workflows/blackhole-demo-tests.yaml",
-              ".github/workflows/galaxy-profiler-tests.yaml",
-              ".github/workflows/galaxy-multi-user-isolation-tests.yaml",
-              ".github/workflows/galaxy-deepseek-tests.yaml",
-              ".github/workflows/galaxy-model-perf-tests.yaml",
-              ".github/workflows/galaxy-demo-tests.yaml",
-              ".github/workflows/galaxy-unit-tests.yaml",
-              ".github/workflows/galaxy-frequent-tests.yaml",
-              ".github/workflows/galaxy-stress-tests.yaml",
-              ".github/workflows/galaxy-nightly-tests.yaml",
-              ".github/workflows/galaxy-quick.yaml",
-              ".github/workflows/t3000-model-perf-tests.yaml",
-              ".github/workflows/t3000-nightly-tests.yaml",
-              ".github/workflows/t3000-frequent-tests.yaml",
-              ".github/workflows/t3000-profiler-tests.yaml",
-              ".github/workflows/t3000-perplexity-tests.yaml",
-              ".github/workflows/t3000-demo-tests.yaml",
-              ".github/workflows/t3000-unit-tests.yaml",
-              ".github/workflows/fast-dispatch-frequent-tests.yaml",
-              ".github/workflows/perf-device-models.yaml",
-              ".github/workflows/perf-models.yaml",
-              ".github/workflows/fast-dispatch-full-regressions-and-models.yaml",
-              ".github/workflows/single-card-demo-tests.yaml",
-              ".github/workflows/tt-metal-l2-nightly.yaml",
-              ".github/workflows/ttnn-run-sweeps.yaml",
-              ".github/workflows/vllm-nightly-tests.yaml",
-              ".github/workflows/metal-run-microbenchmarks.yaml",
-              ".github/workflows/apc-nightly-debug.yaml",
-              ".github/workflows/merge-gate.yaml",
-              ".github/workflows/pr-gate.yaml"
-            ]
-      - name: Upload workflow data
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #@v4
-        with:
-          name: workflow-data
-          path: ${{ github.workspace }}/workflow-data.json
-          retention-days: 1
-
-      - name: Upload annotations artifact (if any)
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #@v4
-        with:
-          name: workflow-annotations
-          path: |
-            ${{ steps.fetch.outputs.annotations-root }}/
-            ${{ steps.fetch.outputs.annotations-index-path }}
-          retention-days: 1
-
-      - name: Upload commits artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #@v4
-        with:
-          name: commits-main
-          path: ${{ steps.fetch.outputs.commits-path }}
-          retention-days: 1
-
-      - name: Upload gtest logs artifact (if any)
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #@v4
-        with:
-          name: workflow-gtest-logs
-          path: |
-            ${{ steps.fetch.outputs.gtest-logs-root }}/
-            ${{ steps.fetch.outputs.gtest-logs-index-path }}
-          retention-days: 1
-
-      - name: Upload other logs artifact (if any)
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #@v4
-        with:
-          name: workflow-other-logs
-          path: |
-            ${{ steps.fetch.outputs.other-logs-root }}/
-            ${{ steps.fetch.outputs.other-logs-index-path }}
-          retention-days: 1
-
-      - name: Upload last success timestamps artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #@v4
-        with:
-          name: last-success-timestamps
-          path: ${{ steps.fetch.outputs.last-success-timestamps-path }}
-          retention-days: 1
-
-      - name: Debug cache file
-        run: ls -l ${{ github.workspace }}/workflow-data.json || echo "File not found"
-
-  analyze-data:
-    needs: fetch-data
-    runs-on: ubuntu-latest
-    outputs:
-      failed_workflows: ${{ steps.analyze.outputs.failed_workflows }}
-      regressed_workflows: ${{ steps.analyze.outputs.regressed_workflows }}
-      alert_all_message: ${{ steps.analyze.outputs.alert_all_message }}
-    steps:
-      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 #@v3
-      - name: Discover previous successful run id
-        id: prev
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const owner = context.repo.owner;
-            const repo = context.repo.repo;
-            const workflow_id = '.github/workflows/aggregate-workflow-data.yaml';
-            const resp = await github.request('GET /repos/{owner}/{repo}/actions/workflows/{workflow_id}/runs', {
-              owner,
-              repo,
-              workflow_id,
-              branch: 'main',
-              status: 'completed',
-              per_page: 10
-            });
-            const runs = (resp.data.workflow_runs || []).filter(r => r.event === 'schedule' && r.conclusion === 'success');
-            const run = runs[0];
-            const selectedId = run ? String(run.id) : '';
-            core.info(`Selected previous run id: ${selectedId || 'none'}`);
-            core.setOutput('run_id', selectedId);
-      - name: Install analyze-workflow-data dependencies
-        shell: bash
-        working-directory: .github/actions/analyze-workflow-data
-        run: npm install
-      - name: Download previous workflow data artifact (if any)
-        if: ${{ steps.prev.outputs.run_id != '' }}
-        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0
-        with:
-          name: workflow-data
-          path: ${{ github.workspace }}/prev
-          run-id: ${{ steps.prev.outputs.run_id }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Echo selected previous run id
-        run: |
-          echo "Selected previous run id: ${{ steps.prev.outputs.run_id }}"
-      - name: List artifacts for selected previous run (debug)
-        if: ${{ steps.prev.outputs.run_id != '' }}
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const { owner, repo } = context.repo;
-            const run_id = Number('${{ steps.prev.outputs.run_id }}');
-            const arts = await github.rest.actions.listWorkflowRunArtifacts({ owner, repo, run_id, per_page: 100 });
-            core.info(`Artifacts for run ${run_id}:`);
-            for (const a of arts.data.artifacts) {
-              core.info(`- name=${a.name} id=${a.id} expired=${a.expired} size=${a.size_in_bytes}`);
+          payload: |
+            {
+              "text": "Parent message for threading test"
             }
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_TESTING_CHANNEL }}
 
-      - name: Download workflow data
-        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0
+      - name: Send Channel Message (Control)
+        uses: slackapi/slack-github-action@v1.26.0
         with:
-          name: workflow-data
-          path: ${{ github.workspace }}
-      - name: Download annotations (if any)
-        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0
-        with:
-          name: workflow-annotations
-          path: ${{ github.workspace }}/annotations
-      - name: Download gtest logs (if any)
-        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0
-        with:
-          name: workflow-gtest-logs
-          path: ${{ github.workspace }}/logs/gtest
-      - name: Download other logs (if any)
-        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0
-        with:
-          name: workflow-other-logs
-          path: ${{ github.workspace }}/logs/other
-      - name: Download commits index
-        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0
-        with:
-          name: commits-main
-          path: ${{ github.workspace }}
-      - name: Download last success timestamps
-        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0
-        with:
-          name: last-success-timestamps
-          path: ${{ github.workspace }}
-      - name: Analyze workflow data
-        id: analyze
-        uses: ./.github/actions/analyze-workflow-data
-        with:
-          days: ${{ github.event.inputs.days || 15 }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          cache-path: ${{ github.workspace }}/workflow-data.json
-          previous-cache-path: ${{ github.workspace }}/prev/workflow-data.json
-          annotations-index-path: ${{ github.workspace }}/annotations/annotations-index.json
-          commits-path: ${{ github.workspace }}/commits-main.json
-          gtest-logs-index-path: ${{ github.workspace }}/logs/gtest/gtest-logs-index.json
-          other-logs-index-path: ${{ github.workspace }}/logs/other/other-logs-index.json
-          last-success-timestamps-path: ${{ github.workspace }}/last-success-timestamps.json
-          alert-all: 'false'
-      - name: Upload status changes artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #@v4
-        with:
-          name: workflow-status-changes
-          path: ${{ steps.analyze.outputs.status_changes_path }}
-          retention-days: 1
+          payload: |
+            {
+              "text": "Control message in channel (should be separate)"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_TESTING_CHANNEL }}
 
-
-  handle-failures:
-    needs: analyze-data
-    if: ${{ fromJson(needs.analyze-data.outputs.failed_workflows) != '[]' }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 #@v3
-      - name: Handle failed workflows
-        run: |
-          echo "The following workflows have failed:"
-          echo '${{ needs.analyze-data.outputs.failed_workflows }}' | jq -r '.[]'
-          # Add any additional failure handling steps here
-      - name: Post regressions to Slack
-        uses: ./.github/actions/slack-report-analyze-workflow-data
+      - name: Send Thread Reply
+        uses: slackapi/slack-github-action@v1.26.0
         with:
-          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_AGGREGATE_PIPELINE_STATUS_ALERT }}
-          regressed_workflows: ${{ needs.analyze-data.outputs.regressed_workflows }}
-          alert_all_message: ${{ needs.analyze-data.outputs.alert_all_message }}
-
-  trigger-auto-triage:
-    needs: analyze-data
-    if: ${{ fromJson(needs.analyze-data.outputs.regressed_workflows) != '[]' }}
-    runs-on: ubuntu-latest
-    permissions:
-      actions: write
-      contents: read
-    steps:
-      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 #@v3
-      - name: Install dependencies
-        working-directory: .github/actions/trigger-auto-triage-for-regressions
-        run: npm install
-      - name: Trigger auto-triage for regressed jobs
-        uses: ./.github/actions/trigger-auto-triage-for-regressions
-        with:
-          regressed_workflows: ${{ needs.analyze-data.outputs.regressed_workflows }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          # Try threading using the TS from the parent message
+          payload: |
+            {
+              "text": "This is a reply in the thread",
+              "thread_ts": "${{ steps.parent.outputs.ts }}"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_TESTING_CHANNEL }}

--- a/.github/workflows/aggregate-workflow-data.yaml
+++ b/.github/workflows/aggregate-workflow-data.yaml
@@ -18,265 +18,265 @@ on:
         default: false
 
 jobs:
-  # fetch-data:
-  #   runs-on: ubuntu-latest
-  #   outputs:
-  #     cache-path: ${{ steps.fetch.outputs.cache-path }}
-  #     commits-path: ${{ steps.fetch.outputs.commits-path }}
-  #     annotations-root: ${{ steps.fetch.outputs.annotations-root }}
-  #     annotations-index-path: ${{ steps.fetch.outputs.annotations-index-path }}
-  #     gtest-logs-root: ${{ steps.fetch.outputs.gtest-logs-root }}
-  #     gtest-logs-index-path: ${{ steps.fetch.outputs.gtest-logs-index-path }}
-  #     other-logs-root: ${{ steps.fetch.outputs.other-logs-root }}
-  #     other-logs-index-path: ${{ steps.fetch.outputs.other-logs-index-path }}
-  #     last-success-timestamps-path: ${{ steps.fetch.outputs.last-success-timestamps-path }}
-  #   steps:
-  #     - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 #@v3
+  fetch-data:
+    runs-on: ubuntu-latest
+    outputs:
+      cache-path: ${{ steps.fetch.outputs.cache-path }}
+      commits-path: ${{ steps.fetch.outputs.commits-path }}
+      annotations-root: ${{ steps.fetch.outputs.annotations-root }}
+      annotations-index-path: ${{ steps.fetch.outputs.annotations-index-path }}
+      gtest-logs-root: ${{ steps.fetch.outputs.gtest-logs-root }}
+      gtest-logs-index-path: ${{ steps.fetch.outputs.gtest-logs-index-path }}
+      other-logs-root: ${{ steps.fetch.outputs.other-logs-root }}
+      other-logs-index-path: ${{ steps.fetch.outputs.other-logs-index-path }}
+      last-success-timestamps-path: ${{ steps.fetch.outputs.last-success-timestamps-path }}
+    steps:
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 #@v3
 
-  #     - name: Install fetch-workflow-data dependencies
-  #       shell: bash
-  #       working-directory: .github/actions/fetch-workflow-data
-  #       run: npm install
-  #     - name: Fetch workflow data
-  #       id: fetch
-  #       uses: ./.github/actions/fetch-workflow-data
-  #       with:
-  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  #         days: ${{ github.event.inputs.days || 15 }}
-  #         force-fresh: ${{ github.event.inputs.force-fresh || false }}
-  #         workflow_ids: |
-  #           [
-  #             ".github/workflows/all-post-commit-workflows.yaml",
-  #             ".github/workflows/blackhole-post-commit.yaml",
-  #             ".github/workflows/blackhole-nightly-tests.yaml",
-  #             ".github/workflows/blackhole-demo-tests.yaml",
-  #             ".github/workflows/galaxy-profiler-tests.yaml",
-  #             ".github/workflows/galaxy-multi-user-isolation-tests.yaml",
-  #             ".github/workflows/galaxy-deepseek-tests.yaml",
-  #             ".github/workflows/galaxy-model-perf-tests.yaml",
-  #             ".github/workflows/galaxy-demo-tests.yaml",
-  #             ".github/workflows/galaxy-unit-tests.yaml",
-  #             ".github/workflows/galaxy-frequent-tests.yaml",
-  #             ".github/workflows/galaxy-stress-tests.yaml",
-  #             ".github/workflows/galaxy-nightly-tests.yaml",
-  #             ".github/workflows/galaxy-quick.yaml",
-  #             ".github/workflows/t3000-model-perf-tests.yaml",
-  #             ".github/workflows/t3000-nightly-tests.yaml",
-  #             ".github/workflows/t3000-frequent-tests.yaml",
-  #             ".github/workflows/t3000-profiler-tests.yaml",
-  #             ".github/workflows/t3000-perplexity-tests.yaml",
-  #             ".github/workflows/t3000-demo-tests.yaml",
-  #             ".github/workflows/t3000-unit-tests.yaml",
-  #             ".github/workflows/fast-dispatch-frequent-tests.yaml",
-  #             ".github/workflows/perf-device-models.yaml",
-  #             ".github/workflows/perf-models.yaml",
-  #             ".github/workflows/fast-dispatch-full-regressions-and-models.yaml",
-  #             ".github/workflows/single-card-demo-tests.yaml",
-  #             ".github/workflows/tt-metal-l2-nightly.yaml",
-  #             ".github/workflows/ttnn-run-sweeps.yaml",
-  #             ".github/workflows/vllm-nightly-tests.yaml",
-  #             ".github/workflows/metal-run-microbenchmarks.yaml",
-  #             ".github/workflows/apc-nightly-debug.yaml",
-  #             ".github/workflows/merge-gate.yaml",
-  #             ".github/workflows/pr-gate.yaml"
-  #           ]
-  #     - name: Upload workflow data
-  #       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #@v4
-  #       with:
-  #         name: workflow-data
-  #         path: ${{ github.workspace }}/workflow-data.json
-  #         retention-days: 1
+      - name: Install fetch-workflow-data dependencies
+        shell: bash
+        working-directory: .github/actions/fetch-workflow-data
+        run: npm install
+      - name: Fetch workflow data
+        id: fetch
+        uses: ./.github/actions/fetch-workflow-data
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          days: ${{ github.event.inputs.days || 15 }}
+          force-fresh: ${{ github.event.inputs.force-fresh || false }}
+          workflow_ids: |
+            [
+              ".github/workflows/all-post-commit-workflows.yaml",
+              ".github/workflows/blackhole-post-commit.yaml",
+              ".github/workflows/blackhole-nightly-tests.yaml",
+              ".github/workflows/blackhole-demo-tests.yaml",
+              ".github/workflows/galaxy-profiler-tests.yaml",
+              ".github/workflows/galaxy-multi-user-isolation-tests.yaml",
+              ".github/workflows/galaxy-deepseek-tests.yaml",
+              ".github/workflows/galaxy-model-perf-tests.yaml",
+              ".github/workflows/galaxy-demo-tests.yaml",
+              ".github/workflows/galaxy-unit-tests.yaml",
+              ".github/workflows/galaxy-frequent-tests.yaml",
+              ".github/workflows/galaxy-stress-tests.yaml",
+              ".github/workflows/galaxy-nightly-tests.yaml",
+              ".github/workflows/galaxy-quick.yaml",
+              ".github/workflows/t3000-model-perf-tests.yaml",
+              ".github/workflows/t3000-nightly-tests.yaml",
+              ".github/workflows/t3000-frequent-tests.yaml",
+              ".github/workflows/t3000-profiler-tests.yaml",
+              ".github/workflows/t3000-perplexity-tests.yaml",
+              ".github/workflows/t3000-demo-tests.yaml",
+              ".github/workflows/t3000-unit-tests.yaml",
+              ".github/workflows/fast-dispatch-frequent-tests.yaml",
+              ".github/workflows/perf-device-models.yaml",
+              ".github/workflows/perf-models.yaml",
+              ".github/workflows/fast-dispatch-full-regressions-and-models.yaml",
+              ".github/workflows/single-card-demo-tests.yaml",
+              ".github/workflows/tt-metal-l2-nightly.yaml",
+              ".github/workflows/ttnn-run-sweeps.yaml",
+              ".github/workflows/vllm-nightly-tests.yaml",
+              ".github/workflows/metal-run-microbenchmarks.yaml",
+              ".github/workflows/apc-nightly-debug.yaml",
+              ".github/workflows/merge-gate.yaml",
+              ".github/workflows/pr-gate.yaml"
+            ]
+      - name: Upload workflow data
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #@v4
+        with:
+          name: workflow-data
+          path: ${{ github.workspace }}/workflow-data.json
+          retention-days: 1
 
-  #     - name: Upload annotations artifact (if any)
-  #       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #@v4
-  #       with:
-  #         name: workflow-annotations
-  #         path: |
-  #           ${{ steps.fetch.outputs.annotations-root }}/
-  #           ${{ steps.fetch.outputs.annotations-index-path }}
-  #         retention-days: 1
+      - name: Upload annotations artifact (if any)
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #@v4
+        with:
+          name: workflow-annotations
+          path: |
+            ${{ steps.fetch.outputs.annotations-root }}/
+            ${{ steps.fetch.outputs.annotations-index-path }}
+          retention-days: 1
 
-  #     - name: Upload commits artifact
-  #       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #@v4
-  #       with:
-  #         name: commits-main
-  #         path: ${{ steps.fetch.outputs.commits-path }}
-  #         retention-days: 1
+      - name: Upload commits artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #@v4
+        with:
+          name: commits-main
+          path: ${{ steps.fetch.outputs.commits-path }}
+          retention-days: 1
 
-  #     - name: Upload gtest logs artifact (if any)
-  #       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #@v4
-  #       with:
-  #         name: workflow-gtest-logs
-  #         path: |
-  #           ${{ steps.fetch.outputs.gtest-logs-root }}/
-  #           ${{ steps.fetch.outputs.gtest-logs-index-path }}
-  #         retention-days: 1
+      - name: Upload gtest logs artifact (if any)
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #@v4
+        with:
+          name: workflow-gtest-logs
+          path: |
+            ${{ steps.fetch.outputs.gtest-logs-root }}/
+            ${{ steps.fetch.outputs.gtest-logs-index-path }}
+          retention-days: 1
 
-  #     - name: Upload other logs artifact (if any)
-  #       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #@v4
-  #       with:
-  #         name: workflow-other-logs
-  #         path: |
-  #           ${{ steps.fetch.outputs.other-logs-root }}/
-  #           ${{ steps.fetch.outputs.other-logs-index-path }}
-  #         retention-days: 1
+      - name: Upload other logs artifact (if any)
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #@v4
+        with:
+          name: workflow-other-logs
+          path: |
+            ${{ steps.fetch.outputs.other-logs-root }}/
+            ${{ steps.fetch.outputs.other-logs-index-path }}
+          retention-days: 1
 
-  #     - name: Upload last success timestamps artifact
-  #       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #@v4
-  #       with:
-  #         name: last-success-timestamps
-  #         path: ${{ steps.fetch.outputs.last-success-timestamps-path }}
-  #         retention-days: 1
+      - name: Upload last success timestamps artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #@v4
+        with:
+          name: last-success-timestamps
+          path: ${{ steps.fetch.outputs.last-success-timestamps-path }}
+          retention-days: 1
 
-  #     - name: Debug cache file
-  #       run: ls -l ${{ github.workspace }}/workflow-data.json || echo "File not found"
+      - name: Debug cache file
+        run: ls -l ${{ github.workspace }}/workflow-data.json || echo "File not found"
 
-  # analyze-data:
-  #   needs: fetch-data
-  #   runs-on: ubuntu-latest
-  #   outputs:
-  #     failed_workflows: ${{ steps.analyze.outputs.failed_workflows }}
-  #     regressed_workflows: ${{ steps.analyze.outputs.regressed_workflows }}
-  #     alert_all_message: ${{ steps.analyze.outputs.alert_all_message }}
-  #   steps:
-  #     - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 #@v3
-  #     - name: Discover previous successful run id
-  #       id: prev
-  #       uses: actions/github-script@v7
-  #       with:
-  #         script: |
-  #           const owner = context.repo.owner;
-  #           const repo = context.repo.repo;
-  #           const workflow_id = '.github/workflows/aggregate-workflow-data.yaml';
-  #           const resp = await github.request('GET /repos/{owner}/{repo}/actions/workflows/{workflow_id}/runs', {
-  #             owner,
-  #             repo,
-  #             workflow_id,
-  #             branch: 'main',
-  #             status: 'completed',
-  #             per_page: 10
-  #           });
-  #           const runs = (resp.data.workflow_runs || []).filter(r => r.event === 'schedule' && r.conclusion === 'success');
-  #           const run = runs[0];
-  #           const selectedId = run ? String(run.id) : '';
-  #           core.info(`Selected previous run id: ${selectedId || 'none'}`);
-  #           core.setOutput('run_id', selectedId);
-  #     - name: Install analyze-workflow-data dependencies
-  #       shell: bash
-  #       working-directory: .github/actions/analyze-workflow-data
-  #       run: npm install
-  #     - name: Download previous workflow data artifact (if any)
-  #       if: ${{ steps.prev.outputs.run_id != '' }}
-  #       uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0
-  #       with:
-  #         name: workflow-data
-  #         path: ${{ github.workspace }}/prev
-  #         run-id: ${{ steps.prev.outputs.run_id }}
-  #         github-token: ${{ secrets.GITHUB_TOKEN }}
-  #     - name: Echo selected previous run id
-  #       run: |
-  #         echo "Selected previous run id: ${{ steps.prev.outputs.run_id }}"
-  #     - name: List artifacts for selected previous run (debug)
-  #       if: ${{ steps.prev.outputs.run_id != '' }}
-  #       uses: actions/github-script@v7
-  #       with:
-  #         script: |
-  #           const { owner, repo } = context.repo;
-  #           const run_id = Number('${{ steps.prev.outputs.run_id }}');
-  #           const arts = await github.rest.actions.listWorkflowRunArtifacts({ owner, repo, run_id, per_page: 100 });
-  #           core.info(`Artifacts for run ${run_id}:`);
-  #           for (const a of arts.data.artifacts) {
-  #             core.info(`- name=${a.name} id=${a.id} expired=${a.expired} size=${a.size_in_bytes}`);
-  #           }
-  #         github-token: ${{ secrets.GITHUB_TOKEN }}
+  analyze-data:
+    needs: fetch-data
+    runs-on: ubuntu-latest
+    outputs:
+      failed_workflows: ${{ steps.analyze.outputs.failed_workflows }}
+      regressed_workflows: ${{ steps.analyze.outputs.regressed_workflows }}
+      alert_all_message: ${{ steps.analyze.outputs.alert_all_message }}
+    steps:
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 #@v3
+      - name: Discover previous successful run id
+        id: prev
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const workflow_id = '.github/workflows/aggregate-workflow-data.yaml';
+            const resp = await github.request('GET /repos/{owner}/{repo}/actions/workflows/{workflow_id}/runs', {
+              owner,
+              repo,
+              workflow_id,
+              branch: 'main',
+              status: 'completed',
+              per_page: 10
+            });
+            const runs = (resp.data.workflow_runs || []).filter(r => r.event === 'schedule' && r.conclusion === 'success');
+            const run = runs[0];
+            const selectedId = run ? String(run.id) : '';
+            core.info(`Selected previous run id: ${selectedId || 'none'}`);
+            core.setOutput('run_id', selectedId);
+      - name: Install analyze-workflow-data dependencies
+        shell: bash
+        working-directory: .github/actions/analyze-workflow-data
+        run: npm install
+      - name: Download previous workflow data artifact (if any)
+        if: ${{ steps.prev.outputs.run_id != '' }}
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0
+        with:
+          name: workflow-data
+          path: ${{ github.workspace }}/prev
+          run-id: ${{ steps.prev.outputs.run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Echo selected previous run id
+        run: |
+          echo "Selected previous run id: ${{ steps.prev.outputs.run_id }}"
+      - name: List artifacts for selected previous run (debug)
+        if: ${{ steps.prev.outputs.run_id != '' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const run_id = Number('${{ steps.prev.outputs.run_id }}');
+            const arts = await github.rest.actions.listWorkflowRunArtifacts({ owner, repo, run_id, per_page: 100 });
+            core.info(`Artifacts for run ${run_id}:`);
+            for (const a of arts.data.artifacts) {
+              core.info(`- name=${a.name} id=${a.id} expired=${a.expired} size=${a.size_in_bytes}`);
+            }
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
-  #     - name: Download workflow data
-  #       uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0
-  #       with:
-  #         name: workflow-data
-  #         path: ${{ github.workspace }}
-  #     - name: Download annotations (if any)
-  #       uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0
-  #       with:
-  #         name: workflow-annotations
-  #         path: ${{ github.workspace }}/annotations
-  #     - name: Download gtest logs (if any)
-  #       uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0
-  #       with:
-  #         name: workflow-gtest-logs
-  #         path: ${{ github.workspace }}/logs/gtest
-  #     - name: Download other logs (if any)
-  #       uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0
-  #       with:
-  #         name: workflow-other-logs
-  #         path: ${{ github.workspace }}/logs/other
-  #     - name: Download commits index
-  #       uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0
-  #       with:
-  #         name: commits-main
-  #         path: ${{ github.workspace }}
-  #     - name: Download last success timestamps
-  #       uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0
-  #       with:
-  #         name: last-success-timestamps
-  #         path: ${{ github.workspace }}
-  #     - name: Analyze workflow data
-  #       id: analyze
-  #       uses: ./.github/actions/analyze-workflow-data
-  #       with:
-  #         days: ${{ github.event.inputs.days || 15 }}
-  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  #         cache-path: ${{ github.workspace }}/workflow-data.json
-  #         previous-cache-path: ${{ github.workspace }}/prev/workflow-data.json
-  #         annotations-index-path: ${{ github.workspace }}/annotations/annotations-index.json
-  #         commits-path: ${{ github.workspace }}/commits-main.json
-  #         gtest-logs-index-path: ${{ github.workspace }}/logs/gtest/gtest-logs-index.json
-  #         other-logs-index-path: ${{ github.workspace }}/logs/other/other-logs-index.json
-  #         last-success-timestamps-path: ${{ github.workspace }}/last-success-timestamps.json
-  #         alert-all: 'false'
-  #     - name: Upload status changes artifact
-  #       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #@v4
-  #       with:
-  #         name: workflow-status-changes
-  #         path: ${{ steps.analyze.outputs.status_changes_path }}
-  #         retention-days: 1
+      - name: Download workflow data
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0
+        with:
+          name: workflow-data
+          path: ${{ github.workspace }}
+      - name: Download annotations (if any)
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0
+        with:
+          name: workflow-annotations
+          path: ${{ github.workspace }}/annotations
+      - name: Download gtest logs (if any)
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0
+        with:
+          name: workflow-gtest-logs
+          path: ${{ github.workspace }}/logs/gtest
+      - name: Download other logs (if any)
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0
+        with:
+          name: workflow-other-logs
+          path: ${{ github.workspace }}/logs/other
+      - name: Download commits index
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0
+        with:
+          name: commits-main
+          path: ${{ github.workspace }}
+      - name: Download last success timestamps
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0
+        with:
+          name: last-success-timestamps
+          path: ${{ github.workspace }}
+      - name: Analyze workflow data
+        id: analyze
+        uses: ./.github/actions/analyze-workflow-data
+        with:
+          days: ${{ github.event.inputs.days || 15 }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          cache-path: ${{ github.workspace }}/workflow-data.json
+          previous-cache-path: ${{ github.workspace }}/prev/workflow-data.json
+          annotations-index-path: ${{ github.workspace }}/annotations/annotations-index.json
+          commits-path: ${{ github.workspace }}/commits-main.json
+          gtest-logs-index-path: ${{ github.workspace }}/logs/gtest/gtest-logs-index.json
+          other-logs-index-path: ${{ github.workspace }}/logs/other/other-logs-index.json
+          last-success-timestamps-path: ${{ github.workspace }}/last-success-timestamps.json
+          alert-all: 'false'
+      - name: Upload status changes artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #@v4
+        with:
+          name: workflow-status-changes
+          path: ${{ steps.analyze.outputs.status_changes_path }}
+          retention-days: 1
 
 
-  # handle-failures:
-  #   needs: analyze-data
-  #   if: ${{ fromJson(needs.analyze-data.outputs.failed_workflows) != '[]' }}
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 #@v3
-  #     - name: Handle failed workflows
-  #       run: |
-  #         echo "The following workflows have failed:"
-  #         echo '${{ needs.analyze-data.outputs.failed_workflows }}' | jq -r '.[]'
-  #         # Add any additional failure handling steps here
-  #     - name: Post regressions to Slack
-  #       uses: ./.github/actions/slack-report-analyze-workflow-data
-  #       with:
-  #         slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_AGGREGATE_PIPELINE_STATUS_ALERT }}
-  #         regressed_workflows: ${{ needs.analyze-data.outputs.regressed_workflows }}
-  #         alert_all_message: ${{ needs.analyze-data.outputs.alert_all_message }}
+  handle-failures:
+    needs: analyze-data
+    if: ${{ fromJson(needs.analyze-data.outputs.failed_workflows) != '[]' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 #@v3
+      - name: Handle failed workflows
+        run: |
+          echo "The following workflows have failed:"
+          echo '${{ needs.analyze-data.outputs.failed_workflows }}' | jq -r '.[]'
+          # Add any additional failure handling steps here
+      - name: Post regressions to Slack
+        uses: ./.github/actions/slack-report-analyze-workflow-data
+        with:
+          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_AGGREGATE_PIPELINE_STATUS_ALERT }}
+          regressed_workflows: ${{ needs.analyze-data.outputs.regressed_workflows }}
+          alert_all_message: ${{ needs.analyze-data.outputs.alert_all_message }}
 
-  # trigger-auto-triage:
-  #   needs: analyze-data
-  #   if: ${{ fromJson(needs.analyze-data.outputs.regressed_workflows) != '[]' }}
-  #   runs-on: ubuntu-latest
-  #   permissions:
-  #     actions: write
-  #     contents: read
-  #   steps:
-  #     - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 #@v3
-  #     - name: Install dependencies
-  #       working-directory: .github/actions/trigger-auto-triage-for-regressions
-  #       run: npm install
-  #     - name: Trigger auto-triage for regressed jobs
-  #       uses: ./.github/actions/trigger-auto-triage-for-regressions
-  #       with:
-  #         regressed_workflows: ${{ needs.analyze-data.outputs.regressed_workflows }}
-  #         github_token: ${{ secrets.GITHUB_TOKEN }}
+  trigger-auto-triage:
+    needs: analyze-data
+    if: ${{ fromJson(needs.analyze-data.outputs.regressed_workflows) != '[]' }}
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
+    steps:
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 #@v3
+      - name: Install dependencies
+        working-directory: .github/actions/trigger-auto-triage-for-regressions
+        run: npm install
+      - name: Trigger auto-triage for regressed jobs
+        uses: ./.github/actions/trigger-auto-triage-for-regressions
+        with:
+          regressed_workflows: ${{ needs.analyze-data.outputs.regressed_workflows }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
   test-slack-threads:
     runs-on: ubuntu-latest

--- a/.github/workflows/aggregate-workflow-data.yaml
+++ b/.github/workflows/aggregate-workflow-data.yaml
@@ -246,6 +246,8 @@ jobs:
     needs: analyze-data
     if: ${{ fromJson(needs.analyze-data.outputs.failed_workflows) != '[]' }}
     runs-on: ubuntu-latest
+    outputs:
+      slack_ts: ${{ steps.slack-report.outputs.slack_ts }}
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 #@v3
       - name: Handle failed workflows
@@ -254,14 +256,17 @@ jobs:
           echo '${{ needs.analyze-data.outputs.failed_workflows }}' | jq -r '.[]'
           # Add any additional failure handling steps here
       - name: Post regressions to Slack
+        id: slack-report
         uses: ./.github/actions/slack-report-analyze-workflow-data
         with:
-          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_AGGREGATE_PIPELINE_STATUS_ALERT }}
+          channel_id: ${{ secrets.SLACK_TESTING_CHANNEL_ID }}
           regressed_workflows: ${{ needs.analyze-data.outputs.regressed_workflows }}
           alert_all_message: ${{ needs.analyze-data.outputs.alert_all_message }}
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 
   trigger-auto-triage:
-    needs: analyze-data
+    needs: [analyze-data, handle-failures]
     if: ${{ fromJson(needs.analyze-data.outputs.regressed_workflows) != '[]' }}
     runs-on: ubuntu-latest
     permissions:
@@ -277,42 +282,43 @@ jobs:
         with:
           regressed_workflows: ${{ needs.analyze-data.outputs.regressed_workflows }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          slack_ts: ${{ needs.handle-failures.outputs.slack_ts }}
 
-  test-slack-threads:
-    runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'workflow_dispatch' }}
-    steps:
-      - name: Send Parent Message
-        id: parent
-        uses: slackapi/slack-github-action@v1.26.0
-        with:
-          channel-id: ${{ secrets.SLACK_TESTING_CHANNEL_ID }}
-          payload: |
-            {
-              "text": "Parent message for threading test (Bot Token)"
-            }
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+  # test-slack-threads:
+  #   runs-on: ubuntu-latest
+  #   if: ${{ github.event_name == 'workflow_dispatch' }}
+  #   steps:
+  #     - name: Send Parent Message
+  #       id: parent
+  #       uses: slackapi/slack-github-action@v1.26.0
+  #       with:
+  #         channel-id: ${{ secrets.SLACK_TESTING_CHANNEL_ID }}
+  #         payload: |
+  #           {
+  #             "text": "Parent message for threading test (Bot Token)"
+  #           }
+  #       env:
+  #         SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 
-      - name: Send Channel Message (Control)
-        uses: slackapi/slack-github-action@v1.26.0
-        with:
-          channel-id: ${{ secrets.SLACK_TESTING_CHANNEL_ID }}
-          payload: |
-            {
-              "text": "Control message in channel (should be separate)"
-            }
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+  #     - name: Send Channel Message (Control)
+  #       uses: slackapi/slack-github-action@v1.26.0
+  #       with:
+  #         channel-id: ${{ secrets.SLACK_TESTING_CHANNEL_ID }}
+  #         payload: |
+  #           {
+  #             "text": "Control message in channel (should be separate)"
+  #           }
+  #       env:
+  #         SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 
-      - name: Send Thread Reply
-        uses: slackapi/slack-github-action@v1.26.0
-        with:
-          channel-id: ${{ secrets.SLACK_TESTING_CHANNEL_ID }}
-          payload: |
-            {
-              "text": "This is a reply in the thread",
-              "thread_ts": "${{ steps.parent.outputs.ts }}"
-            }
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+  #     - name: Send Thread Reply
+  #       uses: slackapi/slack-github-action@v1.26.0
+  #       with:
+  #         channel-id: ${{ secrets.SLACK_TESTING_CHANNEL_ID }}
+  #         payload: |
+  #           {
+  #             "text": "This is a reply in the thread",
+  #             "thread_ts": "${{ steps.parent.outputs.ts }}"
+  #           }
+  #       env:
+  #         SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/aggregate-workflow-data.yaml
+++ b/.github/workflows/aggregate-workflow-data.yaml
@@ -286,31 +286,33 @@ jobs:
         id: parent
         uses: slackapi/slack-github-action@v1.26.0
         with:
+          channel-id: ${{ secrets.SLACK_TESTING_CHANNEL_ID }}
           payload: |
             {
-              "text": "Parent message for threading test"
+              "text": "Parent message for threading test (Bot Token)"
             }
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_TESTING_CHANNEL }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 
       - name: Send Channel Message (Control)
         uses: slackapi/slack-github-action@v1.26.0
         with:
+          channel-id: ${{ secrets.SLACK_TESTING_CHANNEL_ID }}
           payload: |
             {
               "text": "Control message in channel (should be separate)"
             }
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_TESTING_CHANNEL }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 
       - name: Send Thread Reply
         uses: slackapi/slack-github-action@v1.26.0
         with:
-          # Try threading using the TS from the parent message
+          channel-id: ${{ secrets.SLACK_TESTING_CHANNEL_ID }}
           payload: |
             {
               "text": "This is a reply in the thread",
               "thread_ts": "${{ steps.parent.outputs.ts }}"
             }
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_TESTING_CHANNEL }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/aggregate-workflow-data.yaml
+++ b/.github/workflows/aggregate-workflow-data.yaml
@@ -259,7 +259,7 @@ jobs:
         id: slack-report
         uses: ./.github/actions/slack-report-analyze-workflow-data
         with:
-          channel_id: ${{ secrets.SLACK_TESTING_CHANNEL_ID }}
+          channel_id: ${{ secrets.SLACK_METAL_INFRA_CHANNEL_ID }}
           regressed_workflows: ${{ needs.analyze-data.outputs.regressed_workflows }}
           alert_all_message: ${{ needs.analyze-data.outputs.alert_all_message }}
         env:
@@ -283,42 +283,3 @@ jobs:
           regressed_workflows: ${{ needs.analyze-data.outputs.regressed_workflows }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           slack_ts: ${{ needs.handle-failures.outputs.slack_ts }}
-
-  # test-slack-threads:
-  #   runs-on: ubuntu-latest
-  #   if: ${{ github.event_name == 'workflow_dispatch' }}
-  #   steps:
-  #     - name: Send Parent Message
-  #       id: parent
-  #       uses: slackapi/slack-github-action@v1.26.0
-  #       with:
-  #         channel-id: ${{ secrets.SLACK_TESTING_CHANNEL_ID }}
-  #         payload: |
-  #           {
-  #             "text": "Parent message for threading test (Bot Token)"
-  #           }
-  #       env:
-  #         SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-
-  #     - name: Send Channel Message (Control)
-  #       uses: slackapi/slack-github-action@v1.26.0
-  #       with:
-  #         channel-id: ${{ secrets.SLACK_TESTING_CHANNEL_ID }}
-  #         payload: |
-  #           {
-  #             "text": "Control message in channel (should be separate)"
-  #           }
-  #       env:
-  #         SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-
-  #     - name: Send Thread Reply
-  #       uses: slackapi/slack-github-action@v1.26.0
-  #       with:
-  #         channel-id: ${{ secrets.SLACK_TESTING_CHANNEL_ID }}
-  #         payload: |
-  #           {
-  #             "text": "This is a reply in the thread",
-  #             "thread_ts": "${{ steps.parent.outputs.ts }}"
-  #           }
-  #       env:
-  #         SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/auto-triage.yml
+++ b/.github/workflows/auto-triage.yml
@@ -11,11 +11,7 @@ on:
         description: "Job/subjob name within the workflow"
         required: true
         type: string
-      slack_ts:
-        description: "Slack message timestamp for threading replies"
-        required: false
-        type: string
-        default: ""
+
 
 jobs:
   auto-triage:

--- a/.github/workflows/auto-triage.yml
+++ b/.github/workflows/auto-triage.yml
@@ -11,6 +11,12 @@ on:
         description: "Job/subjob name within the workflow"
         required: true
         type: string
+      slack_ts:
+        description: "Slack message timestamp for threading replies"
+        required: false
+        type: string
+        default: ""
+
 jobs:
   auto-triage:
     runs-on: ubuntu-latest
@@ -25,11 +31,13 @@ jobs:
           fetch-depth: 0
 
       - name: Run auto triage
-        uses: tenstorrent-metal/tt-auto-triage/.github/actions/auto-triage@main
+        uses: tenstorrent-metal/tt-auto-triage/.github/actions/auto-triage@ebanerjee/nesting-slack-messages
         with:
           workflow-name: ${{ inputs.workflow_name }}
           job-name: ${{ inputs.job_name }}
           copilot-pat: ${{ secrets.AUTO_TRIAGE_TOKEN }}
+          slack_ts: ${{ inputs.slack_ts }}
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_TESTING_CHANNEL }}
+          # SLACK_WEBHOOK_URL is removed in favor of SLACK_BOT_TOKEN + channel logic in the action
+          SLACK_CHANNEL_ID: ${{ secrets.SLACK_TESTING_CHANNEL_ID }}

--- a/.github/workflows/auto-triage.yml
+++ b/.github/workflows/auto-triage.yml
@@ -11,6 +11,12 @@ on:
         description: "Job/subjob name within the workflow"
         required: true
         type: string
+      slack_ts:
+        description: "Slack message timestamp for threading replies"
+        required: false
+        default: ""
+        type: string
+
 
 jobs:
   auto-triage:

--- a/.github/workflows/auto-triage.yml
+++ b/.github/workflows/auto-triage.yml
@@ -12,7 +12,6 @@ on:
         required: true
         type: string
 
-
 jobs:
   auto-triage:
     runs-on: ubuntu-latest

--- a/.github/workflows/auto-triage.yml
+++ b/.github/workflows/auto-triage.yml
@@ -27,7 +27,7 @@ jobs:
           fetch-depth: 0
 
       - name: Run auto triage
-        uses: tenstorrent-metal/tt-auto-triage/.github/actions/auto-triage@ebanerjee/nesting-slack-messages
+        uses: tenstorrent-metal/tt-auto-triage/.github/actions/auto-triage@main
         with:
           workflow-name: ${{ inputs.workflow_name }}
           job-name: ${{ inputs.job_name }}
@@ -36,4 +36,4 @@ jobs:
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
           # SLACK_WEBHOOK_URL is removed in favor of SLACK_BOT_TOKEN + channel logic in the action
-          SLACK_CHANNEL_ID: ${{ secrets.SLACK_TESTING_CHANNEL_ID }}
+          SLACK_CHANNEL_ID: ${{ secrets.SLACK_METAL_INFRA_CHANNEL_ID }}


### PR DESCRIPTION
### Ticket
NA

### Problem description
auto triage sends slack messages about regressions separately from where aggregate workflow data sends slack messages.

### What's changed
now auto-triage will send slack messages into a thread under the original slack messages alerting of a regression in metal-infra-pipeline-status (with all notifications/pinging disabled for now).

### Checklist
- [x] [Aggregate Workflow Data](https://github.com/tenstorrent/tt-metal/actions/workflows/aggregate-workflow-data.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/19991072890
- [x] [Auto Triage](https://github.com/tenstorrent/tt-metal/actions/workflows/auto-triage.yml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/19991579916