### PR TITLE
Dual glx - adding long context seq length testing to Deepseek 671B model

### DIFF
--- a/models/demos/deepseek_v3/demo/test_seq_len.py
+++ b/models/demos/deepseek_v3/demo/test_seq_len.py
@@ -40,6 +40,8 @@ def create_prompt_of_length(target_token_length: int, tokenizer) -> str:
     # Calculate how many repetitions we need
     # Subtract template overhead from target
     content_tokens_needed = target_token_length - template_overhead
+    if tokens_per_repetition <= 0:
+        tokens_per_repetition = 1
     num_repetitions = max(1, content_tokens_needed // tokens_per_repetition)
 
     # Create the prompt
@@ -124,6 +126,7 @@ def test_long_context_input_sequences(target_prompt_tokens):
     print(f"Prefill time: {prefill_time_ms:.2f}ms")
 
     # Verify prompt length is reasonable (within 20% of target)
+    assert target_prompt_tokens > 0, "Target prompt tokens must be greater than 0"
     assert (
         abs(actual_prompt_length - target_prompt_tokens) / target_prompt_tokens < 0.2
     ), f"Prompt length {actual_prompt_length} is not close to target {target_prompt_tokens}"

--- a/models/demos/deepseek_v3/demo/test_seq_len.py
+++ b/models/demos/deepseek_v3/demo/test_seq_len.py
@@ -1,0 +1,129 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC.
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+from pathlib import Path
+
+import pytest
+
+from models.demos.deepseek_v3.demo.demo import run_demo
+from models.demos.deepseek_v3.utils.hf_model_utils import load_tokenizer
+
+MODEL_PATH = Path(os.getenv("DEEPSEEK_V3_HF_MODEL", "/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528"))
+CACHE_DIR = Path(os.getenv("DEEPSEEK_V3_CACHE", "/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-Cache"))
+
+
+def create_prompt_of_length(target_token_length: int, tokenizer) -> str:
+    """
+    Create a prompt that tokenizes to approximately the target token length.
+    Uses a repeating pattern to reach the desired length.
+    """
+    # Base text that will be repeated
+    base_text = (
+        "The quick brown fox jumps over the lazy dog. "
+        "This is a test of long context sequences. "
+        "We need to test how the model handles increasingly longer input prompts. "
+    )
+
+    # First, measure the chat template overhead by tokenizing an empty prompt
+    empty_tokens = tokenizer.apply_chat_template(
+        [{"role": "user", "content": ""}], add_generation_prompt=True, tokenize=True
+    )
+    template_overhead = len(empty_tokens)
+
+    # Tokenize base text to get tokens per repetition (content only)
+    base_tokens = tokenizer.apply_chat_template(
+        [{"role": "user", "content": base_text}], add_generation_prompt=True, tokenize=True
+    )
+    tokens_per_repetition = len(base_tokens) - template_overhead
+
+    # Calculate how many repetitions we need
+    # Subtract template overhead from target
+    content_tokens_needed = target_token_length - template_overhead
+    num_repetitions = max(1, content_tokens_needed // tokens_per_repetition)
+
+    # Create the prompt
+    prompt = base_text * num_repetitions
+
+    # Verify and adjust the actual token length
+    actual_tokens = tokenizer.apply_chat_template(
+        [{"role": "user", "content": prompt}], add_generation_prompt=True, tokenize=True
+    )
+    actual_length = len(actual_tokens)
+
+    # If we're still too short, add more text word by word
+    if actual_length < target_token_length:
+        words = base_text.split()
+        word_idx = 0
+        max_iterations = (target_token_length - actual_length) * 2  # Safety limit
+        iteration = 0
+        while actual_length < target_token_length and iteration < max_iterations:
+            prompt += words[word_idx % len(words)] + " "
+            actual_tokens = tokenizer.apply_chat_template(
+                [{"role": "user", "content": prompt}], add_generation_prompt=True, tokenize=True
+            )
+            actual_length = len(actual_tokens)
+            word_idx += 1
+            iteration += 1
+
+    return prompt
+
+
+@pytest.mark.parametrize("target_prompt_tokens", [128, 256, 512, 999, 1024])
+def test_long_context_input_sequences(target_prompt_tokens):
+    """
+    Test with varying input prompt lengths to test long context sequence handling.
+    Uses progressively longer input prompts to test prefill performance and KV cache management.
+    Generates a fixed small number of output tokens to focus on input sequence length testing.
+    Uses only 5 layers (override_num_layers=5) for faster CI execution.
+    """
+    # Load tokenizer to create prompts of specific lengths
+    tokenizer = load_tokenizer(MODEL_PATH)
+
+    # Create a prompt of approximately the target token length
+    prompt = create_prompt_of_length(target_prompt_tokens, tokenizer)
+
+    # Verify the prompt length is close to target (within 20% tolerance)
+    actual_tokens = tokenizer.apply_chat_template(
+        [{"role": "user", "content": prompt}], add_generation_prompt=True, tokenize=True
+    )
+    actual_prompt_length = len(actual_tokens)
+
+    # Use a fixed small number of output tokens to focus on input length testing
+    max_new_tokens = 32
+
+    # Run demo with long input prompt
+    results = run_demo(
+        prompts=[prompt],
+        model_path=MODEL_PATH,
+        cache_dir=CACHE_DIR,
+        random_weights=False,
+        max_new_tokens=max_new_tokens,
+        override_num_layers=5,
+        repeat_batches=1,
+        early_print_first_user=False,
+    )
+
+    # Verify results are returned
+    assert len(results["generations"]) > 0, "No generations returned"
+    assert (
+        len(results["generations"][0]["tokens"]) == max_new_tokens
+    ), f"Expected {max_new_tokens} tokens generated, got {len(results['generations'][0]['tokens'])}"
+
+    # Verify statistics are present and contain prefill metrics
+    assert "statistics" in results, "Statistics not found in results"
+    stats = results["statistics"]
+    assert "prefill_t/s" in stats, "Prefill tokens/sec metric not found"
+    assert "inference_prefill" in stats, "Prefill inference time not found"
+
+    # Log performance metrics for long context sequences
+    prefill_tps = stats.get("prefill_t/s", 0)
+    prefill_time_ms = stats.get("inference_prefill", 0) * 1000
+    print(f"\nInput prompt length: {actual_prompt_length} tokens (target: {target_prompt_tokens})")
+    print(f"Prefill performance: {prefill_tps:.2f} tokens/sec")
+    print(f"Prefill time: {prefill_time_ms:.2f}ms")
+
+    # Verify prompt length is reasonable (within 20% of target)
+    assert (
+        abs(actual_prompt_length - target_prompt_tokens) / target_prompt_tokens < 0.2
+    ), f"Prompt length {actual_prompt_length} is not close to target {target_prompt_tokens}"

--- a/models/demos/deepseek_v3/demo/test_seq_len.py
+++ b/models/demos/deepseek_v3/demo/test_seq_len.py
@@ -69,7 +69,7 @@ def create_prompt_of_length(target_token_length: int, tokenizer) -> str:
     return prompt
 
 
-@pytest.mark.parametrize("target_prompt_tokens", [128, 256, 512, 999, 1024])
+@pytest.mark.parametrize("target_prompt_tokens", [1024, 2048, 3145, 8192])
 def test_long_context_input_sequences(target_prompt_tokens):
     """
     Test with varying input prompt lengths to test long context sequence handling.

--- a/models/demos/deepseek_v3/tt/generator.py
+++ b/models/demos/deepseek_v3/tt/generator.py
@@ -90,7 +90,7 @@ class DeepseekGenerator:
             hf_config if hf_config is not None else AutoConfig.from_pretrained(self.model_path, trust_remote_code=True)
         )
         # self._ensure_max_seq_len(self.hf_config)
-        self.hf_config.max_seq_len = 8192  # TODO: Change this when needed?
+        self.hf_config.max_seq_len = 32768  # TODO: Change this when needed?
         # Optional overrides for layer counts before building states
         if override_num_layers is not None:
             try:

--- a/models/demos/deepseek_v3/tt/generator.py
+++ b/models/demos/deepseek_v3/tt/generator.py
@@ -90,7 +90,7 @@ class DeepseekGenerator:
             hf_config if hf_config is not None else AutoConfig.from_pretrained(self.model_path, trust_remote_code=True)
         )
         # self._ensure_max_seq_len(self.hf_config)
-        self.hf_config.max_seq_len = 1024  # TODO: Change this when needed?
+        self.hf_config.max_seq_len = 8192  # TODO: Change this when needed?
         # Optional overrides for layer counts before building states
         if override_num_layers is not None:
             try:


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/33963

### Problem description
There is no long context seq length testing for Deepseek 671B model.

### What's changed
Adding long context seq length testing to Deepseek 671B model. 
Tested and passing (in terms of no hangs + no bugs/errors) seq len on dual glx: 128, 256, 512, 999, 1024, 2048, 3145, 8192, 16384, 32768.

Accuracy functionality is yet to be added to deepseek.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] [cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) job passes
- [ ] New/Existing tests provide coverage for changes