### PR TITLE
[skip ci] readability-reference-to-constructed-temporary

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -170,7 +170,6 @@ Checks: >
   -readability-named-parameter,
   -readability-non-const-parameter,
   -readability-redundant-casting,
-  -readability-reference-to-constructed-temporary,
   -readability-static-accessed-through-instance,
   -readability-suspicious-call-argument,
   -readability-uppercase-literal-suffix,


### PR DESCRIPTION
### Ticket
NA

### Problem description
We have this check disabled: https://clang.llvm.org/extra/clang-tidy/checks/readability/reference-to-constructed-temporary.html

However, it seems our code base is clean against this check.

### What's changed
- Enable Check
