### PR TITLE
Extend usage of UNITY_BUILD to more projects

### DIFF
--- a/tt_metal/common/CMakeLists.txt
+++ b/tt_metal/common/CMakeLists.txt
@@ -1,6 +1,9 @@
 add_library(common OBJECT)
 add_library(TT::Metalium::Common ALIAS common)
 
+# Enable unity builds for faster compilation
+TT_ENABLE_UNITY_BUILD(common)
+
 target_sources(
     common
     PRIVATE

--- a/tt_metal/distributed/CMakeLists.txt
+++ b/tt_metal/distributed/CMakeLists.txt
@@ -79,6 +79,9 @@ endif()
 
 add_library(distributed OBJECT ${DISTRIBUTED_SRC})
 
+# Enable unity builds for faster compilation
+TT_ENABLE_UNITY_BUILD(distributed)
+
 foreach(FBS_FILE ${FLATBUFFER_SCHEMAS})
     GENERATE_FBS_HEADER(${FBS_FILE} TARGET distributed)
     target_sources(distributed PRIVATE ${FBS_GENERATED_HEADER_FILE})

--- a/tt_metal/distributed/system_mesh.cpp
+++ b/tt_metal/distributed/system_mesh.cpp
@@ -26,14 +26,13 @@
 #include <tt-metalium/experimental/fabric/control_plane.hpp>
 
 namespace tt::tt_metal::distributed {
-namespace {
-
 // Helper type to keep track of device ID and fabric node ID for a given mesh coordinate.
 struct MappedDevice {
     MaybeRemote<int> device_id;
     tt::tt_fabric::FabricNodeId fabric_node_id;
 };
 
+namespace {
 // Initializes a mesh container with MappedDevice objects, with configured fabric node IDs.
 MeshContainer<MappedDevice> initialize_mapped_devices(const tt::tt_fabric::MeshId mesh_id, const MeshShape& shape) {
     std::vector<MappedDevice> system_mesh_devices;

--- a/tt_metal/fabric/CMakeLists.txt
+++ b/tt_metal/fabric/CMakeLists.txt
@@ -1,6 +1,9 @@
 add_library(fabric OBJECT)
 add_library(TT::Metalium::Fabric ALIAS fabric)
 
+# Enable unity builds for faster compilation
+TT_ENABLE_UNITY_BUILD(fabric)
+
 # These headers are for the device, not host; will require cross compiling to lint them (future work).
 set_target_properties(
     fabric
@@ -88,6 +91,14 @@ foreach(PROTO_FILE ${PROTO_SCHEMAS})
     GENERATE_PROTO_FILES(${PROTO_FILE} OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR})
     list(APPEND GENERATED_PROTO_SRCS ${PROTO_SRCS})
 endforeach()
+
+# Exclude protobuf generated files from unity builds (they have conflicting static symbols)
+set_source_files_properties(
+    ${GENERATED_PROTO_SRCS}
+    PROPERTIES
+        SKIP_UNITY_BUILD_INCLUSION
+            TRUE
+)
 
 # Add the generated protobuf files to your target
 target_sources(fabric PRIVATE ${GENERATED_PROTO_SRCS})

--- a/tt_metal/impl/CMakeLists.txt
+++ b/tt_metal/impl/CMakeLists.txt
@@ -156,6 +156,9 @@ endif()
 add_library(impl OBJECT ${IMPL_SRC})
 add_library(Metalium::Metal::Impl ALIAS impl)
 
+# Enable unity builds for faster compilation
+TT_ENABLE_UNITY_BUILD(impl)
+
 target_link_libraries(
     impl
     PUBLIC

--- a/tt_metal/impl/debug/dprint_server.cpp
+++ b/tt_metal/impl/debug/dprint_server.cpp
@@ -61,6 +61,32 @@ using namespace tt;
 
 #define CAST_U8P(p) (reinterpret_cast<uint8_t*>(p))
 
+using RiscKey = std::tuple<ChipId, umd::CoreDescriptor, uint32_t>;  // Chip id, core, risc id
+
+struct RiscKeyComparator {
+    bool operator()(const RiscKey& x, const RiscKey& y) const {
+        const ChipId x_device_id = get<0>(x);
+        const ChipId y_device_id = get<0>(y);
+        const uint32_t x_risc_id = get<2>(x);
+        const uint32_t y_risc_id = get<2>(y);
+        const umd::CoreDescriptor& x_core_desc = get<1>(x);
+        const umd::CoreDescriptor& y_core_desc = get<1>(y);
+
+        if (x_device_id != y_device_id) {
+            return x_device_id < y_device_id;
+        }
+
+        tt::tt_metal::CoreDescriptorComparator core_desc_cmp;
+        if (core_desc_cmp(x_core_desc, y_core_desc)) {
+            return true;
+        }
+        if (core_desc_cmp(y_core_desc, x_core_desc)) {
+            return false;
+        }
+
+        return x_risc_id < y_risc_id;
+    }
+};
 namespace {
 
 string logfile_path = "generated/dprint/";
@@ -102,33 +128,6 @@ public:
 };
 NullBuffer null_buffer;
 std::ostream null_stream(&null_buffer);
-
-using RiscKey = std::tuple<ChipId, umd::CoreDescriptor, uint32_t>;  // Chip id, core, risc id
-
-struct RiscKeyComparator {
-    bool operator()(const RiscKey& x, const RiscKey& y) const {
-        const ChipId x_device_id = get<0>(x);
-        const ChipId y_device_id = get<0>(y);
-        const uint32_t x_risc_id = get<2>(x);
-        const uint32_t y_risc_id = get<2>(y);
-        const umd::CoreDescriptor& x_core_desc = get<1>(x);
-        const umd::CoreDescriptor& y_core_desc = get<1>(y);
-
-        if (x_device_id != y_device_id) {
-            return x_device_id < y_device_id;
-        }
-
-        tt::tt_metal::CoreDescriptorComparator core_desc_cmp;
-        if (core_desc_cmp(x_core_desc, y_core_desc)) {
-            return true;
-        }
-        if (core_desc_cmp(y_core_desc, x_core_desc)) {
-            return false;
-        }
-
-        return x_risc_id < y_risc_id;
-    }
-};
 
 void ResetStream(ostringstream* stream) {
     stream->str("");

--- a/tt_metal/impl/lightmetal/lightmetal_replay_impl.hpp
+++ b/tt_metal/impl/lightmetal/lightmetal_replay_impl.hpp
@@ -22,7 +22,7 @@ struct TraceDescriptor;
 
 // Forward decl for command_generated.h / light_metal_binary_generated.h
 namespace tt::tt_metal::flatbuffer {
-struct Command;
+class Command;
 struct ReplayTraceCommand;
 struct EnqueueTraceCommand;
 struct LoadTraceCommand;

--- a/tt_metal/jit_build/CMakeLists.txt
+++ b/tt_metal/jit_build/CMakeLists.txt
@@ -10,6 +10,10 @@ set(JIT_BUILD_SRCS
 )
 
 add_library(jit_build OBJECT ${JIT_BUILD_SRCS})
+
+# Enable unity builds for faster compilation
+TT_ENABLE_UNITY_BUILD(jit_build)
+
 target_link_libraries(
     jit_build
     PUBLIC

--- a/tt_metal/llrt/CMakeLists.txt
+++ b/tt_metal/llrt/CMakeLists.txt
@@ -14,6 +14,10 @@ set(LLRT_SRC
 
 add_library(llrt OBJECT ${LLRT_SRC})
 add_library(Metalium::Metal::LLRT ALIAS llrt)
+
+# Enable unity builds for faster compilation
+TT_ENABLE_UNITY_BUILD(llrt)
+
 add_subdirectory(hal)
 add_dependencies(llrt hal_generate_dev_msgs_header)
 

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -20,6 +20,9 @@ endif()
 add_library(ttnn_core ${LIB_TYPE})
 add_library(TTNN::Core ALIAS ttnn_core)
 
+# Enable unity builds for faster compilation
+TT_ENABLE_UNITY_BUILD(ttnn_core)
+
 target_compile_definitions(ttnn_core PUBLIC "$<$<CXX_COMPILER_ID:GNU>:DISABLE_NAMESPACE_STATIC_ASSERT>")
 target_precompile_headers(ttnn_core REUSE_FROM TT::CommonPCH)
 


### PR DESCRIPTION
20% e2e build improvement on clean build for default build `./build_metal.sh --release` measured on
AMD Ryzen 5 7600X 6-Core Processor

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/20008696771) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/20008699834) CI with demo tests passes (if applicable)