### PR TITLE
add z-router support to fabric builder

### DIFF
--- a/tests/tt_metal/tt_fabric/CMakeLists.txt
+++ b/tests/tt_metal/tt_fabric/CMakeLists.txt
@@ -6,6 +6,7 @@ set(UNIT_TESTS_FABRIC_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/fabric_router/test_topology_mapper_utils.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/fabric_router/test_custom_routing_tables.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/fabric_router/test_multi_host.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/fabric_router/test_connection_registry.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/fabric_data_movement/test_basic_fabric_apis.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/fabric_data_movement/test_basic_1d_fabric.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/fabric_data_movement/test_basic_fabric_mux.cpp

--- a/tests/tt_metal/tt_fabric/CMakeLists.txt
+++ b/tests/tt_metal/tt_fabric/CMakeLists.txt
@@ -7,6 +7,15 @@ set(UNIT_TESTS_FABRIC_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/fabric_router/test_custom_routing_tables.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/fabric_router/test_multi_host.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/fabric_router/test_connection_registry.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/fabric_router/test_router_channel_mapping.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/fabric_router/test_router_connections.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/fabric_router/test_router_connection_mapping.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/fabric_router/test_router_archetypes.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/fabric_router/test_builder_connection_mapping.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/fabric_router/test_connection_mapping_logic.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/fabric_router/test_fabric_builder_local_connections.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/fabric_router/test_z_router_integration.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/fabric_router/test_z_router_device_detection.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/fabric_data_movement/test_basic_fabric_apis.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/fabric_data_movement/test_basic_1d_fabric.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/fabric_data_movement/test_basic_fabric_mux.cpp

--- a/tests/tt_metal/tt_fabric/fabric_router/test_builder_connection_mapping.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_builder_connection_mapping.cpp
@@ -79,7 +79,7 @@ TEST_F(BuilderConnectionMappingTest, MeshRouter_2D_WithZ_MappingCreation) {
     // Verify mapping has expected structure: receiver channel 0 has 4 targets (3 INTRA_MESH + 1 MESH_TO_Z)
     EXPECT_EQ(conn_mapping.get_total_sender_count(), 4);
     EXPECT_TRUE(conn_mapping.has_targets(0, 0));
-    
+
     auto targets = conn_mapping.get_downstream_targets(0, 0);
     ASSERT_EQ(targets.size(), 4);
 
@@ -104,10 +104,10 @@ TEST_F(BuilderConnectionMappingTest, ZRouter_MappingCreation) {
     // Verify mapping has expected structure: receiver channel 0 on VC1 has 4 targets
     EXPECT_EQ(conn_mapping.get_total_sender_count(), 4);
     EXPECT_TRUE(conn_mapping.has_targets(1, 0));
-    
+
     auto targets = conn_mapping.get_downstream_targets(1, 0);
     ASSERT_EQ(targets.size(), 4);
-    
+
     // Verify all are Z_TO_MESH
     for (const auto& target : targets) {
         EXPECT_EQ(target.type, ConnectionType::Z_TO_MESH);
@@ -141,7 +141,7 @@ TEST_F(BuilderConnectionMappingTest, MeshRouter_ChannelAndConnectionMapping_Cons
         if (num_senders > 0) {
             EXPECT_TRUE(conn_mapping.has_targets(vc, 0))
                 << "VC" << vc << " receiver channel 0 should have targets";
-            
+
             auto targets = conn_mapping.get_downstream_targets(vc, 0);
             EXPECT_EQ(targets.size(), num_senders)
                 << "VC" << vc << " receiver channel 0 should have " << num_senders << " targets";
@@ -170,7 +170,7 @@ TEST_F(BuilderConnectionMappingTest, ZRouter_ChannelAndConnectionMapping_Consist
     // VC1 receiver channel 0 should have 4 targets
     EXPECT_TRUE(conn_mapping.has_targets(1, 0))
         << "Z router VC1 receiver channel 0 should have connection targets";
-    
+
     auto targets = conn_mapping.get_downstream_targets(1, 0);
     EXPECT_EQ(targets.size(), vc1_senders)
         << "Z router VC1 receiver channel 0 should have " << vc1_senders << " targets";
@@ -231,9 +231,9 @@ TEST_F(BuilderConnectionMappingTest, FactoryMethod_AllMeshConfigurations) {
         // Receiver channel 0 should have targets
         EXPECT_TRUE(mapping.has_targets(0, 0))
             << "Receiver channel 0 should have targets";
-        
+
         auto targets = mapping.get_downstream_targets(0, 0);
-        
+
         // If has_z, should have MESH_TO_Z target
         if (has_z) {
             auto mesh_to_z_it = std::find_if(targets.begin(), targets.end(),
@@ -252,7 +252,7 @@ TEST_F(BuilderConnectionMappingTest, FactoryMethod_ZRouter) {
 
     auto targets = mapping.get_downstream_targets(1, 0);
     ASSERT_EQ(targets.size(), 4);
-    
+
     // All should be Z_TO_MESH type
     for (const auto& target : targets) {
         EXPECT_EQ(target.type, ConnectionType::Z_TO_MESH);

--- a/tests/tt_metal/tt_fabric/fabric_router/test_builder_connection_mapping.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_builder_connection_mapping.cpp
@@ -1,0 +1,297 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+
+#include "tt_metal/fabric/builder/router_connection_mapping.hpp"
+#include "tt_metal/fabric/fabric_router_channel_mapping.hpp"
+#include "tt_metal/fabric/fabric_context.hpp"
+
+namespace tt::tt_fabric {
+
+/**
+ * Builder Connection Mapping Tests
+ *
+ * These tests validate that RouterConnectionMapping integrates correctly
+ * with the builder infrastructure:
+ * - Connection mappings are created correctly for different router types
+ * - Mappings are consistent with channel mappings
+ * - Factory methods produce correct configurations
+ * - Builder can query and use connection mappings
+ *
+ * Test Coverage Summary:
+ * ┌──────────────────────────────────────────────────────────────────────────────────────────┐
+ * │ Category                        │ Test Name                                  │ Focus      │
+ * ├─────────────────────────────────┼────────────────────────────────────────────┼────────────┤
+ * │ Connection Mapping Creation     │ MeshRouter_1D_NoZ_MappingCreation          │ 1D mesh    │
+ * │                                 │ MeshRouter_2D_WithZ_MappingCreation        │ 2D mesh+Z  │
+ * │                                 │ ZRouter_MappingCreation                    │ Z router   │
+ * ├─────────────────────────────────┼────────────────────────────────────────────┼────────────┤
+ * │ Channel + Connection Consistency│ MeshRouter_ChannelAndConnectionMapping_... │ Mesh sync  │
+ * │                                 │ ZRouter_ChannelAndConnectionMapping_...    │ Z sync     │
+ * ├─────────────────────────────────┼────────────────────────────────────────────┼────────────┤
+ * │ Factory Method Validation       │ FactoryMethod_MeshRouter_ProducesCorrect...│ Mesh API   │
+ * │                                 │ FactoryMethod_ZRouter_ProducesCorrectType  │ Z API      │
+ * ├─────────────────────────────────┼────────────────────────────────────────────┼────────────┤
+ * │ Builder Query Interface         │ BuilderQuery_GetDownstreamTargets_Works   │ Query API  │
+ * │                                 │ BuilderQuery_HasTargets_Works              │ Check API  │
+ * │                                 │ BuilderQuery_GetTotalSenderCount_Accurate  │ Count API  │
+ * └─────────────────────────────────┴────────────────────────────────────────────┴────────────┘
+ *
+ * Total: 11 tests across 4 categories
+ */
+class BuilderConnectionMappingTest : public ::testing::Test {
+protected:
+    void SetUp() override {}
+    void TearDown() override {}
+};
+
+// ============================================================================
+// Connection Mapping Creation Tests
+// ============================================================================
+
+TEST_F(BuilderConnectionMappingTest, MeshRouter_1D_NoZ_MappingCreation) {
+    // Simulate what build() does for a 1D mesh router without Z
+    Topology topology = Topology::Linear;
+    RoutingDirection direction = RoutingDirection::N;
+    bool has_z = false;
+
+    // Create connection mapping
+    auto conn_mapping = RouterConnectionMapping::for_mesh_router(topology, direction, has_z);
+
+    // Verify mapping has expected structure
+    EXPECT_EQ(conn_mapping.get_total_sender_count(), 1);  // Only channel 1
+    EXPECT_TRUE(conn_mapping.has_targets(0, 1));
+    EXPECT_FALSE(conn_mapping.has_targets(0, 2));  // No MESH_TO_Z channel
+}
+
+TEST_F(BuilderConnectionMappingTest, MeshRouter_2D_WithZ_MappingCreation) {
+    // Simulate what build() does for a 2D mesh router with Z
+    Topology topology = Topology::Mesh;
+    RoutingDirection direction = RoutingDirection::E;
+    bool has_z = true;
+
+    // Create connection mapping
+    auto conn_mapping = RouterConnectionMapping::for_mesh_router(topology, direction, has_z);
+
+    // Verify mapping has expected structure
+    EXPECT_EQ(conn_mapping.get_total_sender_count(), 4);  // Channels 1-3 + MESH_TO_Z
+
+    // Verify INTRA_MESH channels
+    EXPECT_TRUE(conn_mapping.has_targets(0, 1));
+    EXPECT_TRUE(conn_mapping.has_targets(0, 2));
+    EXPECT_TRUE(conn_mapping.has_targets(0, 3));
+
+    // Verify MESH_TO_Z channel
+    EXPECT_TRUE(conn_mapping.has_targets(0, 4));
+    auto z_targets = conn_mapping.get_downstream_targets(0, 4);
+    ASSERT_EQ(z_targets.size(), 1);
+    EXPECT_EQ(z_targets[0].type, ConnectionType::MESH_TO_Z);
+}
+
+TEST_F(BuilderConnectionMappingTest, ZRouter_MappingCreation) {
+    // Simulate what build() does for a Z router
+    auto conn_mapping = RouterConnectionMapping::for_z_router();
+
+    // Verify mapping has expected structure
+    EXPECT_EQ(conn_mapping.get_total_sender_count(), 4);  // VC1 channels 0-3
+
+    // Verify all Z_TO_MESH channels
+    for (uint32_t ch = 0; ch < 4; ++ch) {
+        EXPECT_TRUE(conn_mapping.has_targets(1, ch));
+        auto targets = conn_mapping.get_downstream_targets(1, ch);
+        ASSERT_EQ(targets.size(), 1);
+        EXPECT_EQ(targets[0].type, ConnectionType::Z_TO_MESH);
+    }
+}
+
+// ============================================================================
+// Channel Mapping + Connection Mapping Consistency Tests
+// ============================================================================
+
+TEST_F(BuilderConnectionMappingTest, MeshRouter_ChannelAndConnectionMapping_Consistent) {
+    // Create both mappings as build() would
+    Topology topology = Topology::Mesh;
+    RoutingDirection routing_dir = RoutingDirection::N;
+    bool has_tensix = false;
+    bool has_z = true;
+    RouterVariant variant = RouterVariant::MESH;
+
+    // Phase 1: Channel mapping
+    FabricRouterChannelMapping channel_mapping(topology, has_tensix, variant, nullptr);
+
+    // Phase 2: Connection mapping
+    RouterConnectionMapping conn_mapping = RouterConnectionMapping::for_mesh_router(topology, routing_dir, has_z);
+
+    // Verify consistency: every sender channel in channel mapping should have connection targets
+    uint32_t num_vcs = channel_mapping.get_num_virtual_channels();
+    for (uint32_t vc = 0; vc < num_vcs; ++vc) {
+        uint32_t num_senders = channel_mapping.get_num_sender_channels_for_vc(vc);
+
+        // For mesh router VC0, channels 1-4 should have targets (channel 0 is reserved)
+        for (uint32_t ch = 1; ch <= num_senders && ch <= 4; ++ch) {
+            bool has_channel_mapping = true;  // Channel mapping exists
+            bool has_conn_targets = conn_mapping.has_targets(vc, ch);
+
+            EXPECT_EQ(has_channel_mapping, has_conn_targets)
+                << "VC" << vc << " channel " << ch << " consistency mismatch";
+        }
+    }
+}
+
+TEST_F(BuilderConnectionMappingTest, ZRouter_ChannelAndConnectionMapping_Consistent) {
+    // Create both mappings as build() would for Z router
+    Topology topology = Topology::Mesh;
+    bool has_tensix = false;
+    RouterVariant variant = RouterVariant::Z_ROUTER;
+    auto intermesh_config = IntermeshVCConfig::full_mesh();
+
+    // Phase 1: Channel mapping
+    FabricRouterChannelMapping channel_mapping(topology, has_tensix, variant, &intermesh_config);
+
+    // Phase 2: Connection mapping
+    RouterConnectionMapping conn_mapping = RouterConnectionMapping::for_z_router();
+
+    // Verify VC1 consistency
+    EXPECT_EQ(channel_mapping.get_num_virtual_channels(), 2);
+    uint32_t vc1_senders = channel_mapping.get_num_sender_channels_for_vc(1);
+    EXPECT_EQ(vc1_senders, 4);
+
+    // All VC1 sender channels should have connection targets
+    for (uint32_t ch = 0; ch < vc1_senders; ++ch) {
+        EXPECT_TRUE(conn_mapping.has_targets(1, ch))
+            << "Z router VC1 channel " << ch << " should have connection targets";
+    }
+}
+
+// ============================================================================
+// Variant Detection Tests
+// ============================================================================
+
+TEST_F(BuilderConnectionMappingTest, VariantDetection_MeshRouter) {
+    // Test that mesh routers are correctly identified
+    std::vector<RoutingDirection> mesh_directions = {
+        RoutingDirection::N,
+        RoutingDirection::E,
+        RoutingDirection::S,
+        RoutingDirection::W
+    };
+
+    for (auto dir : mesh_directions) {
+        RouterVariant variant = (dir == RoutingDirection::Z) ? RouterVariant::Z_ROUTER : RouterVariant::MESH;
+
+        EXPECT_EQ(variant, RouterVariant::MESH)
+            << "Direction " << static_cast<int>(dir) << " should be MESH variant";
+    }
+}
+
+TEST_F(BuilderConnectionMappingTest, VariantDetection_ZRouter) {
+    // Test that Z router is correctly identified
+    RoutingDirection dir = RoutingDirection::Z;
+    RouterVariant variant = (dir == RoutingDirection::Z) ? RouterVariant::Z_ROUTER : RouterVariant::MESH;
+
+    EXPECT_EQ(variant, RouterVariant::Z_ROUTER);
+}
+
+// ============================================================================
+// Factory Method Tests
+// ============================================================================
+
+TEST_F(BuilderConnectionMappingTest, FactoryMethod_AllMeshConfigurations) {
+    // Test all valid mesh router configurations
+    std::vector<std::tuple<Topology, RoutingDirection, bool>> configs = {
+        {Topology::Linear, RoutingDirection::N, false},
+        {Topology::Linear, RoutingDirection::S, false},
+        {Topology::Linear, RoutingDirection::N, true},
+        {Topology::Mesh, RoutingDirection::N, false},
+        {Topology::Mesh, RoutingDirection::E, false},
+        {Topology::Mesh, RoutingDirection::N, true},
+        {Topology::Mesh, RoutingDirection::W, true},
+    };
+
+    for (const auto& [topology, direction, has_z] : configs) {
+        auto mapping = RouterConnectionMapping::for_mesh_router(topology, direction, has_z);
+
+        // Basic validation
+        EXPECT_GT(mapping.get_total_sender_count(), 0)
+            << "Mapping should have at least one sender channel";
+
+        // If has_z, should have MESH_TO_Z target
+        if (has_z) {
+            uint32_t z_channel = (topology == Topology::Linear) ? 2 : 4;
+            EXPECT_TRUE(mapping.has_targets(0, z_channel))
+                << "Should have MESH_TO_Z channel";
+        }
+    }
+}
+
+TEST_F(BuilderConnectionMappingTest, FactoryMethod_ZRouter) {
+    auto mapping = RouterConnectionMapping::for_z_router();
+
+    // Z router should have exactly 4 sender channels on VC1
+    EXPECT_EQ(mapping.get_total_sender_count(), 4);
+
+    // All should be Z_TO_MESH type
+    for (uint32_t ch = 0; ch < 4; ++ch) {
+        auto targets = mapping.get_downstream_targets(1, ch);
+        ASSERT_EQ(targets.size(), 1);
+        EXPECT_EQ(targets[0].type, ConnectionType::Z_TO_MESH);
+    }
+}
+
+// ============================================================================
+// Integration Scenario Tests
+// ============================================================================
+
+TEST_F(BuilderConnectionMappingTest, Scenario_FullDevice_4Mesh1Z) {
+    // Simulate full device initialization with 4 mesh + 1 Z router
+
+    std::vector<RoutingDirection> mesh_dirs = {
+        RoutingDirection::N,
+        RoutingDirection::E,
+        RoutingDirection::S,
+        RoutingDirection::W
+    };
+
+    // Create mesh router mappings
+    std::vector<RouterConnectionMapping> mesh_mappings;
+    for (auto dir : mesh_dirs) {
+        mesh_mappings.push_back(
+            RouterConnectionMapping::for_mesh_router(Topology::Mesh, dir, true));
+    }
+
+    // Create Z router mapping
+    auto z_mapping = RouterConnectionMapping::for_z_router();
+
+    // Verify each mesh router has MESH_TO_Z capability
+    for (const auto& mapping : mesh_mappings) {
+        EXPECT_TRUE(mapping.has_targets(0, 4))  // Channel 4 is MESH_TO_Z
+            << "Mesh router should have MESH_TO_Z target";
+    }
+
+    // Verify Z router has Z_TO_MESH capability for all 4 directions
+    EXPECT_EQ(z_mapping.get_total_sender_count(), 4);
+}
+
+TEST_F(BuilderConnectionMappingTest, Scenario_EdgeDevice_2Mesh1Z) {
+    // Simulate edge device with only 2 mesh routers + Z
+
+    std::vector<RoutingDirection> mesh_dirs = {
+        RoutingDirection::N,
+        RoutingDirection::E
+    };
+
+    // Create mesh router mappings
+    for (auto dir : mesh_dirs) {
+        auto mapping = RouterConnectionMapping::for_mesh_router(Topology::Mesh, dir, true);
+        EXPECT_TRUE(mapping.has_targets(0, 4))
+            << "Mesh router should have MESH_TO_Z target";
+    }
+
+    // Z router still has intent for all 4 directions
+    auto z_mapping = RouterConnectionMapping::for_z_router();
+    EXPECT_EQ(z_mapping.get_total_sender_count(), 4)
+        << "Z router should have intent for all 4 directions";
+}
+
+}  // namespace tt::tt_fabric

--- a/tests/tt_metal/tt_fabric/fabric_router/test_connection_mapping_logic.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_connection_mapping_logic.cpp
@@ -117,11 +117,9 @@ TEST_F(RouterConnectionMappingTest, MappingDriven_Z_TO_MESH_Connections) {
 
     // Verify all expected directions are present
     for (const auto& expected_dir : expected_directions) {
-        auto it = std::find_if(targets.begin(), targets.end(),
-            [expected_dir](const ConnectionTarget& t) {
-                return t.target_direction.has_value() && 
-                       t.target_direction.value() == expected_dir;
-            });
+        auto it = std::find_if(targets.begin(), targets.end(), [expected_dir](const ConnectionTarget& t) {
+            return t.target_direction.has_value() && t.target_direction.value() == expected_dir;
+        });
         ASSERT_NE(it, targets.end()) << "Missing direction: " << static_cast<int>(expected_dir);
         EXPECT_EQ(it->type, ConnectionType::Z_TO_MESH);
         EXPECT_EQ(it->target_vc, 1);  // Z VC1 → Mesh VC1
@@ -152,7 +150,7 @@ TEST_F(RouterConnectionMappingTest, AsymmetricConnections_MeshToZ_vs_ZToMesh) {
     // Z_TO_MESH: Z VC1 receiver channel 0 has 4 targets (all mesh directions) → Mesh VC1
     auto z_targets = z_mapping.get_downstream_targets(1, 0);
     ASSERT_EQ(z_targets.size(), builder_config::num_mesh_directions_2d);
-    
+
     for (const auto& target : z_targets) {
         EXPECT_EQ(target.type, ConnectionType::Z_TO_MESH);
         EXPECT_EQ(target.target_vc, 1);  // Different VC!
@@ -199,7 +197,7 @@ TEST_F(RouterConnectionMappingTest, EdgeDevice_TwoMeshRouters_ZMapping) {
     // Receiver channel 0 on VC1 has all mesh direction targets (intent)
     auto targets = z_mapping.get_downstream_targets(1, 0);
     EXPECT_EQ(targets.size(), builder_config::num_mesh_directions_2d);
-    
+
     for (const auto& target : targets) {
         EXPECT_EQ(target.type, ConnectionType::Z_TO_MESH);
     }
@@ -369,11 +367,9 @@ TEST_F(RouterConnectionMappingTest, DirectionBased_ZRouter_ChannelToDirection) {
 
     // Verify each expected direction is present
     for (const auto& [channel_idx, expected_dir] : expected) {
-        auto it = std::find_if(targets.begin(), targets.end(),
-            [expected_dir](const ConnectionTarget& t) {
-                return t.target_direction.has_value() && 
-                       t.target_direction.value() == expected_dir;
-            });
+        auto it = std::find_if(targets.begin(), targets.end(), [expected_dir](const ConnectionTarget& t) {
+            return t.target_direction.has_value() && t.target_direction.value() == expected_dir;
+        });
         ASSERT_NE(it, targets.end());
         EXPECT_EQ(it->target_direction.value(), expected_dir);
     }

--- a/tests/tt_metal/tt_fabric/fabric_router/test_connection_mapping_logic.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_connection_mapping_logic.cpp
@@ -1,0 +1,425 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+#include "tt_metal/fabric/builder/connection_registry.hpp"
+#include "tt_metal/fabric/builder/router_connection_mapping.hpp"
+#include "tt_metal/fabric/builder/fabric_builder_config.hpp"
+#include <tt-metalium/experimental/fabric/mesh_graph.hpp>
+#include <tt-metalium/experimental/fabric/fabric_edm_types.hpp>
+
+using namespace tt::tt_fabric;
+
+/**
+ * RouterConnectionMapping Tests
+ *
+ * These tests validate that:
+ * 1. Connection mapping drives connection establishment
+ * 2. configure_local_connections() handles Z↔mesh connections correctly
+ * 3. Asymmetric connections (MESH_TO_Z vs Z_TO_MESH) work properly
+ * 4. Edge cases (2-3 mesh routers) are handled gracefully
+ *
+ * Test Coverage Summary:
+ * ┌────────────────────────────────────────────────────────────────────────────────────┐
+ * │ Category                │ Test Name                                  │ Focus        │
+ * ├─────────────────────────┼────────────────────────────────────────────┼──────────────┤
+ * │ Mapping-Driven Logic    │ MappingDriven_INTRA_MESH_Connections       │ Mesh VC0     │
+ * │                         │ MappingDriven_MESH_TO_Z_Connection         │ Mesh→Z       │
+ * │                         │ MappingDriven_Z_TO_MESH_Connections        │ Z→Mesh       │
+ * ├─────────────────────────┼────────────────────────────────────────────┼──────────────┤
+ * │ Asymmetric Connections  │ AsymmetricConnections_MeshToZ_vs_ZToMesh   │ Bidirectional│
+ * │                         │ AsymmetricConnections_VCAssignments        │ VC routing   │
+ * ├─────────────────────────┼────────────────────────────────────────────┼──────────────┤
+ * │ Edge Device Scenarios   │ EdgeDevice_TwoMeshRouters_ZMapping         │ 2-router     │
+ * │                         │ EdgeDevice_ThreeMeshRouters_MappingIntent  │ 3-router     │
+ * ├─────────────────────────┼────────────────────────────────────────────┼──────────────┤
+ * │ Connection Filtering    │ ConnectionTypeFiltering_INTRA_MESH_Only    │ Type counts  │
+ * │                         │ ConnectionTypeFiltering_LocalOnly          │ Z isolation  │
+ * ├─────────────────────────┼────────────────────────────────────────────┼──────────────┤
+ * │ Multi-VC Scenarios      │ MultiVC_MeshRouter_VC0_and_VC1             │ Mesh VCs     │
+ * │                         │ MultiVC_ZRouter_VC0_and_VC1                │ Z VCs        │
+ * ├─────────────────────────┼────────────────────────────────────────────┼──────────────┤
+ * │ Direction-Based Routing │ DirectionBased_ZRouter_ChannelToDirection  │ Z channels   │
+ * │                         │ DirectionBased_MeshRouter_MeshToZ          │ Z direction  │
+ * ├─────────────────────────┼────────────────────────────────────────────┼──────────────┤
+ * │ Regression Tests        │ Regression_MeshToMesh_StillWorks           │ Basic mesh   │
+ * │                         │ Regression_1D_Topology_StillWorks          │ 1D topology  │
+ * └─────────────────────────┴────────────────────────────────────────────┴──────────────┘
+ *
+ * Total: 15 tests across 7 categories
+ */
+
+class RouterConnectionMappingTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        registry_ = std::make_shared<ConnectionRegistry>();
+    }
+
+    std::shared_ptr<ConnectionRegistry> registry_;
+};
+
+// ============================================================================
+// Test 1: Mapping-Driven Connection Logic
+// ============================================================================
+
+TEST_F(RouterConnectionMappingTest, MappingDriven_INTRA_MESH_Connections) {
+    // Verify that INTRA_MESH connections are established based on connection mapping
+    // This is a conceptual test - actual connection establishment requires builders
+
+    auto mesh_mapping = RouterConnectionMapping::for_mesh_router(
+        Topology::Mesh,
+        RoutingDirection::N,
+        false);  // No Z router
+
+    // 2D Mesh router: channel 0 (local), channels 1-3 (peers N/E/S/W)
+    // Channel 0: local, no downstream
+    auto local_targets = mesh_mapping.get_downstream_targets(0, 0);
+    EXPECT_EQ(local_targets.size(), 0);
+
+    // Channels 1-3: peer channels with INTRA_MESH targets
+    for (uint32_t sender_ch = 1; sender_ch <= builder_config::num_downstream_edms_2d_vc0; ++sender_ch) {
+        auto targets = mesh_mapping.get_downstream_targets(0, sender_ch);
+        EXPECT_EQ(targets.size(), 1);
+        EXPECT_EQ(targets[0].type, ConnectionType::INTRA_MESH);
+    }
+}
+
+TEST_F(RouterConnectionMappingTest, MappingDriven_MESH_TO_Z_Connection) {
+    // Verify MESH_TO_Z connection is in the mapping
+    auto mesh_mapping = RouterConnectionMapping::for_mesh_router(
+        Topology::Mesh,
+        RoutingDirection::N,
+        true);  // Has Z router
+
+    // MESH_TO_Z channel (channel after mesh directions) should have MESH_TO_Z target
+    auto targets = mesh_mapping.get_downstream_targets(0, builder_config::num_sender_channels_2d_mesh);
+
+    ASSERT_EQ(targets.size(), 1);
+    EXPECT_EQ(targets[0].type, ConnectionType::MESH_TO_Z);
+    EXPECT_EQ(targets[0].target_vc, 0);  // Mesh VC0 → Z VC0
+    ASSERT_TRUE(targets[0].target_direction.has_value());
+    EXPECT_EQ(targets[0].target_direction.value(), RoutingDirection::Z);
+}
+
+TEST_F(RouterConnectionMappingTest, MappingDriven_Z_TO_MESH_Connections) {
+    // Verify Z_TO_MESH connections are in the mapping
+    auto z_mapping = RouterConnectionMapping::for_z_router();
+
+    // Z router VC1 should have Z_TO_MESH targets for all mesh directions (N/E/S/W intent)
+    std::vector<RoutingDirection> expected_directions = {
+        RoutingDirection::N,
+        RoutingDirection::E,
+        RoutingDirection::S,
+        RoutingDirection::W
+    };
+
+    for (size_t i = 0; i < builder_config::num_mesh_directions_2d; ++i) {
+        auto targets = z_mapping.get_downstream_targets(1, i);
+
+        ASSERT_EQ(targets.size(), 1);
+        EXPECT_EQ(targets[0].type, ConnectionType::Z_TO_MESH);
+        EXPECT_EQ(targets[0].target_vc, 1);  // Z VC1 → Mesh VC1
+        ASSERT_TRUE(targets[0].target_direction.has_value());
+        EXPECT_EQ(targets[0].target_direction.value(), expected_directions[i]);
+    }
+}
+
+// ============================================================================
+// Test 2: Asymmetric Connection Validation
+// ============================================================================
+
+TEST_F(RouterConnectionMappingTest, AsymmetricConnections_MeshToZ_vs_ZToMesh) {
+    // Verify that MESH_TO_Z and Z_TO_MESH are properly asymmetric
+
+    auto mesh_mapping = RouterConnectionMapping::for_mesh_router(
+        Topology::Mesh,
+        RoutingDirection::N,
+        true);
+
+    auto z_mapping = RouterConnectionMapping::for_z_router();
+
+    // MESH_TO_Z: Mesh VC0 channel (after mesh directions) → Z VC0
+    auto mesh_to_z = mesh_mapping.get_downstream_targets(0, builder_config::num_sender_channels_2d_mesh);
+    ASSERT_EQ(mesh_to_z.size(), 1);
+    EXPECT_EQ(mesh_to_z[0].type, ConnectionType::MESH_TO_Z);
+    EXPECT_EQ(mesh_to_z[0].target_vc, 0);
+
+    // Z_TO_MESH: Z VC1 channels (all mesh directions) → Mesh VC1
+    for (uint32_t ch = 0; ch < builder_config::num_mesh_directions_2d; ++ch) {
+        auto z_to_mesh = z_mapping.get_downstream_targets(1, ch);
+        ASSERT_EQ(z_to_mesh.size(), 1);
+        EXPECT_EQ(z_to_mesh[0].type, ConnectionType::Z_TO_MESH);
+        EXPECT_EQ(z_to_mesh[0].target_vc, 1);  // Different VC!
+    }
+
+    // Key insight: Different VCs, different directions, different connection types
+}
+
+TEST_F(RouterConnectionMappingTest, AsymmetricConnections_VCAssignments) {
+    // Validate VC assignments are correct for asymmetric connections
+
+    // Mesh VC0 → Z VC0 (MESH_TO_Z)
+    auto mesh_mapping = RouterConnectionMapping::for_mesh_router(
+        Topology::Mesh,
+        RoutingDirection::E,
+        true);
+
+    auto mesh_targets = mesh_mapping.get_downstream_targets(0, builder_config::num_sender_channels_2d_mesh);
+    ASSERT_EQ(mesh_targets.size(), 1);
+    EXPECT_EQ(mesh_targets[0].target_vc, 0);
+
+    // Z VC1 → Mesh VC1 (distribution)
+    auto z_mapping = RouterConnectionMapping::for_z_router();
+
+    auto z_targets = z_mapping.get_downstream_targets(1, 0);
+    ASSERT_EQ(z_targets.size(), 1);
+    EXPECT_EQ(z_targets[0].target_vc, 1);
+}
+
+// ============================================================================
+// Test 3: Edge Device Scenarios (2-3 Mesh Routers)
+// ============================================================================
+
+TEST_F(RouterConnectionMappingTest, EdgeDevice_TwoMeshRouters_ZMapping) {
+    // Z router mapping specifies intent for all mesh directions
+    // configure_local_connections() will skip non-existent routers
+
+    auto z_mapping = RouterConnectionMapping::for_z_router();
+
+    // Mapping always specifies all mesh directions (intent)
+    for (uint32_t ch = 0; ch < builder_config::num_mesh_directions_2d; ++ch) {
+        auto targets = z_mapping.get_downstream_targets(1, ch);
+        EXPECT_EQ(targets.size(), 1);
+        EXPECT_EQ(targets[0].type, ConnectionType::Z_TO_MESH);
+    }
+
+    // FabricBuilder will check if routers exist before connecting
+    // This test validates the mapping is correct regardless of actual router count
+}
+
+TEST_F(RouterConnectionMappingTest, EdgeDevice_ThreeMeshRouters_MappingIntent) {
+    // Validate that Z router mapping is consistent regardless of device position
+
+    auto z_mapping_center = RouterConnectionMapping::for_z_router();
+
+    // All mesh direction sender channels should have targets (N/E/S/W)
+    for (uint32_t ch = 0; ch < builder_config::num_mesh_directions_2d; ++ch) {
+        EXPECT_TRUE(z_mapping_center.has_targets(1, ch));
+    }
+
+    // configure_local_connections() will gracefully skip missing routers
+}
+
+// ============================================================================
+// Test 4: Connection Type Filtering
+// ============================================================================
+
+TEST_F(RouterConnectionMappingTest, ConnectionTypeFiltering_INTRA_MESH_Only) {
+    // configure_connection() should only handle INTRA_MESH
+    // configure_local_connections() should only handle MESH_TO_Z and Z_TO_MESH
+
+    auto mesh_mapping = RouterConnectionMapping::for_mesh_router(
+        Topology::Mesh,
+        RoutingDirection::N,
+        true);
+
+    // Count connection types
+    int intra_mesh_count = 0;
+    int mesh_to_z_count = 0;
+
+    // Check all VC0 sender channels (mesh directions + Z)
+    for (uint32_t ch = 0; ch < builder_config::num_sender_channels_2d_mesh + 1; ++ch) {
+        auto targets = mesh_mapping.get_downstream_targets(0, ch);
+        for (const auto& target : targets) {
+            if (target.type == ConnectionType::INTRA_MESH) {
+                intra_mesh_count++;
+            } else if (target.type == ConnectionType::MESH_TO_Z) {
+                mesh_to_z_count++;
+            }
+        }
+    }
+
+    EXPECT_GT(intra_mesh_count, 0);  // Has INTRA_MESH connections
+    EXPECT_EQ(mesh_to_z_count, 1);   // Has exactly 1 MESH_TO_Z connection
+}
+
+TEST_F(RouterConnectionMappingTest, ConnectionTypeFiltering_LocalOnly) {
+    // Z router should only have local connections (Z_TO_MESH)
+    // No INTRA_MESH connections
+
+    auto z_mapping = RouterConnectionMapping::for_z_router();
+
+    int z_to_mesh_count = 0;
+    int intra_mesh_count = 0;
+
+    // Check VC0 (should be empty or reserved)
+    for (uint32_t ch = 0; ch < builder_config::num_sender_channels_z_router_vc0; ++ch) {
+        auto vc0_targets = z_mapping.get_downstream_targets(0, ch);
+        EXPECT_EQ(vc0_targets.size(), 0);  // VC0 unused for Z router
+    }
+
+    // Check VC1 (should have Z_TO_MESH for all mesh directions)
+    for (uint32_t ch = 0; ch < builder_config::num_sender_channels_z_router_vc1; ++ch) {
+        auto vc1_targets = z_mapping.get_downstream_targets(1, ch);
+        for (const auto& target : vc1_targets) {
+            if (target.type == ConnectionType::Z_TO_MESH) {
+                z_to_mesh_count++;
+            } else if (target.type == ConnectionType::INTRA_MESH) {
+                intra_mesh_count++;
+            }
+        }
+    }
+
+    EXPECT_EQ(z_to_mesh_count, static_cast<int>(builder_config::num_mesh_directions_2d));   // Z_TO_MESH for all mesh directions
+    EXPECT_EQ(intra_mesh_count, 0);  // No INTRA_MESH connections
+}
+
+// ============================================================================
+// Test 5: Multi-VC Connection Scenarios
+// ============================================================================
+
+TEST_F(RouterConnectionMappingTest, MultiVC_MeshRouter_VC0_and_VC1) {
+    // Mesh routers use VC0 for INTRA_MESH and MESH_TO_Z
+    // VC1 receives from Z router (but no outgoing VC1 connections for mesh)
+
+    auto mesh_mapping = RouterConnectionMapping::for_mesh_router(
+        Topology::Mesh,
+        RoutingDirection::W,
+        true);
+
+    // VC0 should have targets (mesh directions + Z)
+    bool has_vc0_targets = false;
+    for (uint32_t ch = 0; ch < builder_config::num_sender_channels_2d_mesh + 1; ++ch) {
+        if (mesh_mapping.has_targets(0, ch)) {
+            has_vc0_targets = true;
+            break;
+        }
+    }
+    EXPECT_TRUE(has_vc0_targets);
+
+    // VC1 should have no sender targets (mesh doesn't send on VC1)
+    bool has_vc1_targets = false;
+    for (uint32_t ch = 0; ch < builder_config::num_sender_channels_2d_mesh + 1; ++ch) {
+        if (mesh_mapping.has_targets(1, ch)) {
+            has_vc1_targets = true;
+            break;
+        }
+    }
+    EXPECT_FALSE(has_vc1_targets);
+}
+
+TEST_F(RouterConnectionMappingTest, MultiVC_ZRouter_VC0_and_VC1) {
+    // Z router uses VC0 for receiving from mesh (no senders)
+    // Z router uses VC1 for sending to mesh
+
+    auto z_mapping = RouterConnectionMapping::for_z_router();
+
+    // VC0 should have no sender targets (Z receives on VC0, doesn't send)
+    bool has_vc0_targets = false;
+    for (uint32_t ch = 0; ch < builder_config::num_sender_channels_z_router_vc0; ++ch) {
+        if (z_mapping.has_targets(0, ch)) {
+            has_vc0_targets = true;
+            break;
+        }
+    }
+    EXPECT_FALSE(has_vc0_targets);
+
+    // VC1 should have sender targets (Z sends on VC1)
+    bool has_vc1_targets = false;
+    for (uint32_t ch = 0; ch < builder_config::num_sender_channels_z_router_vc1; ++ch) {
+        if (z_mapping.has_targets(1, ch)) {
+            has_vc1_targets = true;
+            break;
+        }
+    }
+    EXPECT_TRUE(has_vc1_targets);
+}
+
+// ============================================================================
+// Test 6: Direction-Based Routing
+// ============================================================================
+
+TEST_F(RouterConnectionMappingTest, DirectionBased_ZRouter_ChannelToDirection) {
+    // Validate Z router VC1 channel-to-direction mapping
+    auto z_mapping = RouterConnectionMapping::for_z_router();
+
+    std::vector<std::pair<uint32_t, RoutingDirection>> expected = {
+        {0, RoutingDirection::N},
+        {1, RoutingDirection::E},
+        {2, RoutingDirection::S},
+        {3, RoutingDirection::W}
+    };
+
+    // Verify all mesh directions are mapped correctly
+    TT_FATAL(expected.size() == builder_config::num_mesh_directions_2d, "Test configuration mismatch");
+
+    for (const auto& [channel, expected_dir] : expected) {
+        auto targets = z_mapping.get_downstream_targets(1, channel);
+        ASSERT_EQ(targets.size(), 1);
+        ASSERT_TRUE(targets[0].target_direction.has_value());
+        EXPECT_EQ(targets[0].target_direction.value(), expected_dir);
+    }
+}
+
+TEST_F(RouterConnectionMappingTest, DirectionBased_MeshRouter_MeshToZ) {
+    // Validate mesh router MESH_TO_Z channel targets Z direction
+    auto mesh_mapping = RouterConnectionMapping::for_mesh_router(
+        Topology::Mesh,
+        RoutingDirection::S,
+        true);
+
+    auto targets = mesh_mapping.get_downstream_targets(0, builder_config::num_sender_channels_2d_mesh);
+    ASSERT_EQ(targets.size(), 1);
+    EXPECT_EQ(targets[0].type, ConnectionType::MESH_TO_Z);
+    ASSERT_TRUE(targets[0].target_direction.has_value());
+    EXPECT_EQ(targets[0].target_direction.value(), RoutingDirection::Z);
+}
+
+// ============================================================================
+// Test 7: Regression Tests (Ensure Old Behavior Preserved)
+// ============================================================================
+
+TEST_F(RouterConnectionMappingTest, Regression_MeshToMesh_StillWorks) {
+    // Verify that basic mesh-to-mesh connections still work after refactor
+    auto mesh_n = RouterConnectionMapping::for_mesh_router(
+        Topology::Mesh,
+        RoutingDirection::N,
+        false);
+
+    auto mesh_s = RouterConnectionMapping::for_mesh_router(
+        Topology::Mesh,
+        RoutingDirection::S,
+        false);
+
+    // Both should have INTRA_MESH targets
+    bool n_has_targets = false;
+    bool s_has_targets = false;
+
+    // Check all mesh direction channels (skip local channel 0)
+    for (uint32_t ch = 1; ch <= builder_config::num_sender_channels_2d_mesh; ++ch) {
+        if (mesh_n.has_targets(0, ch)) {
+            n_has_targets = true;
+        }
+        if (mesh_s.has_targets(0, ch)) {
+            s_has_targets = true;
+        }
+    }
+
+    EXPECT_TRUE(n_has_targets);
+    EXPECT_TRUE(s_has_targets);
+}
+
+TEST_F(RouterConnectionMappingTest, Regression_1D_Topology_StillWorks) {
+    // Verify 1D topology connections work after refactor
+    auto mesh_1d = RouterConnectionMapping::for_mesh_router(
+        Topology::Linear,
+        RoutingDirection::E,
+        false);
+
+    // 1D should have fewer channels than 2D
+    // Channel 1 should have INTRA_MESH target
+    auto targets = mesh_1d.get_downstream_targets(0, 1);
+    EXPECT_EQ(targets.size(), 1);
+    EXPECT_EQ(targets[0].type, ConnectionType::INTRA_MESH);
+}

--- a/tests/tt_metal/tt_fabric/fabric_router/test_connection_registry.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_connection_registry.cpp
@@ -653,8 +653,8 @@ TEST_F(ConnectionRegistryTest, Phase2_MeshRouter_1D_ConnectionMapping) {
         false);  // No Z router
 
     // Verify mapping has expected targets
-    constexpr uint32_t sender_channel = 1;
-    auto targets = mapping.get_downstream_targets(0, sender_channel);
+    constexpr uint32_t receiver_channel = 0;
+    auto targets = mapping.get_downstream_targets(0, receiver_channel);
     ASSERT_EQ(targets.size(), 1);
     EXPECT_EQ(targets[0].type, ConnectionType::INTRA_MESH);
     EXPECT_EQ(targets[0].target_direction.value(), RoutingDirection::S);
@@ -669,7 +669,7 @@ TEST_F(ConnectionRegistryTest, Phase2_MeshRouter_1D_ConnectionMapping) {
             .source_direction = RoutingDirection::N,
             .source_eth_chan = 0,
             .source_vc = 0,
-            .source_receiver_channel = sender_channel,
+            .source_receiver_channel = receiver_channel,
             .dest_node = dest,
             .dest_direction = target.target_direction.value(),
             .dest_eth_chan = 0,
@@ -925,7 +925,7 @@ TEST_F(ConnectionRegistryTest, Phase2_EdgeDevice_2MeshRouters_MappingDriven) {
         FabricNodeId source(MeshId{0}, i);
 
         // Record MESH_TO_Z connection
-        auto z_targets = mapping.get_downstream_targets(0, 4);
+        auto z_targets = mapping.get_downstream_targets(0, 0);
         ASSERT_EQ(z_targets.size(), 1);
 
         RouterConnectionRecord z_record{

--- a/tests/tt_metal/tt_fabric/fabric_router/test_connection_registry.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_connection_registry.cpp
@@ -79,12 +79,12 @@ TEST_F(ConnectionRegistryTest, RecordSingleConnection) {
         .source_direction = RoutingDirection::N,
         .source_eth_chan = 0,
         .source_vc = 0,
-        .source_sender_channel = 1,
+        .source_receiver_channel = 1,
         .dest_node = FabricNodeId(MeshId{0}, 1),
         .dest_direction = RoutingDirection::S,
         .dest_eth_chan = 0,
         .dest_vc = 0,
-        .dest_receiver_channel = 1,
+        .dest_sender_channel = 1,
         .connection_type = ConnectionType::INTRA_MESH
     };
 
@@ -100,12 +100,12 @@ TEST_F(ConnectionRegistryTest, RecordSingleConnection) {
     EXPECT_EQ(retrieved.source_direction, record.source_direction);
     EXPECT_EQ(retrieved.source_eth_chan, record.source_eth_chan);
     EXPECT_EQ(retrieved.source_vc, record.source_vc);
-    EXPECT_EQ(retrieved.source_sender_channel, record.source_sender_channel);
+    EXPECT_EQ(retrieved.source_receiver_channel, record.source_receiver_channel);
     EXPECT_EQ(retrieved.dest_node, record.dest_node);
     EXPECT_EQ(retrieved.dest_direction, record.dest_direction);
     EXPECT_EQ(retrieved.dest_eth_chan, record.dest_eth_chan);
     EXPECT_EQ(retrieved.dest_vc, record.dest_vc);
-    EXPECT_EQ(retrieved.dest_receiver_channel, record.dest_receiver_channel);
+    EXPECT_EQ(retrieved.dest_sender_channel, record.dest_sender_channel);
     EXPECT_EQ(retrieved.connection_type, record.connection_type);
 }
 
@@ -118,12 +118,12 @@ TEST_F(ConnectionRegistryTest, RecordMultipleConnections) {
             .source_direction = RoutingDirection::N,
             .source_eth_chan = static_cast<uint8_t>(i),
             .source_vc = 0,
-            .source_sender_channel = 1,
+            .source_receiver_channel = 1,
             .dest_node = FabricNodeId(MeshId{0}, i + 1),
             .dest_direction = RoutingDirection::S,
             .dest_eth_chan = static_cast<uint8_t>(i),
             .dest_vc = 0,
-            .dest_receiver_channel = 1,
+            .dest_sender_channel = 1,
             .connection_type = ConnectionType::INTRA_MESH
         };
         registry_->record_connection(record);
@@ -142,12 +142,12 @@ TEST_F(ConnectionRegistryTest, ClearRemovesAllConnections) {
             .source_direction = RoutingDirection::E,
             .source_eth_chan = static_cast<uint8_t>(i),
             .source_vc = 0,
-            .source_sender_channel = 0,
+            .source_receiver_channel = 0,
             .dest_node = FabricNodeId(MeshId{0}, i + 1),
             .dest_direction = RoutingDirection::W,
             .dest_eth_chan = static_cast<uint8_t>(i),
             .dest_vc = 0,
-            .dest_receiver_channel = 0,
+            .dest_sender_channel = 0,
             .connection_type = ConnectionType::INTRA_MESH
         };
         registry_->record_connection(record);
@@ -173,12 +173,12 @@ TEST_F(ConnectionRegistryTest, GetConnectionsFromSource_SingleMatch) {
         .source_direction = source_dir,
         .source_eth_chan = 0,
         .source_vc = 0,
-        .source_sender_channel = 1,
+        .source_receiver_channel = 1,
         .dest_node = FabricNodeId(MeshId{0}, 1),
         .dest_direction = RoutingDirection::S,
         .dest_eth_chan = 0,
         .dest_vc = 0,
-        .dest_receiver_channel = 1,
+        .dest_sender_channel = 1,
         .connection_type = ConnectionType::INTRA_MESH
     };
     registry_->record_connection(target);
@@ -189,12 +189,12 @@ TEST_F(ConnectionRegistryTest, GetConnectionsFromSource_SingleMatch) {
         .source_direction = RoutingDirection::E,
         .source_eth_chan = 1,
         .source_vc = 0,
-        .source_sender_channel = 0,
+        .source_receiver_channel = 0,
         .dest_node = FabricNodeId(MeshId{0}, 3),
         .dest_direction = RoutingDirection::W,
         .dest_eth_chan = 1,
         .dest_vc = 0,
-        .dest_receiver_channel = 0,
+        .dest_sender_channel = 0,
         .connection_type = ConnectionType::INTRA_MESH
     };
     registry_->record_connection(noise);
@@ -218,12 +218,12 @@ TEST_F(ConnectionRegistryTest, GetConnectionsFromSource_MultipleMatches) {
             .source_direction = source_dir,
             .source_eth_chan = 0,
             .source_vc = 0,
-            .source_sender_channel = static_cast<uint32_t>(i),
+            .source_receiver_channel = static_cast<uint32_t>(i),
             .dest_node = FabricNodeId(MeshId{0}, i + 1),
             .dest_direction = RoutingDirection::S,
             .dest_eth_chan = static_cast<uint8_t>(i),
             .dest_vc = 0,
-            .dest_receiver_channel = static_cast<uint32_t>(i),
+            .dest_sender_channel = static_cast<uint32_t>(i),
             .connection_type = ConnectionType::INTRA_MESH
         };
         registry_->record_connection(record);
@@ -245,12 +245,12 @@ TEST_F(ConnectionRegistryTest, GetConnectionsFromSource_NoMatches) {
         .source_direction = RoutingDirection::N,
         .source_eth_chan = 0,
         .source_vc = 0,
-        .source_sender_channel = 1,
+        .source_receiver_channel = 1,
         .dest_node = FabricNodeId(MeshId{0}, 1),
         .dest_direction = RoutingDirection::S,
         .dest_eth_chan = 0,
         .dest_vc = 0,
-        .dest_receiver_channel = 1,
+        .dest_sender_channel = 1,
         .connection_type = ConnectionType::INTRA_MESH
     };
     registry_->record_connection(record);
@@ -273,12 +273,12 @@ TEST_F(ConnectionRegistryTest, GetConnectionsToDest_SingleMatch) {
         .source_direction = RoutingDirection::N,
         .source_eth_chan = 0,
         .source_vc = 0,
-        .source_sender_channel = 1,
+        .source_receiver_channel = 1,
         .dest_node = dest_node,
         .dest_direction = dest_dir,
         .dest_eth_chan = 0,
         .dest_vc = 0,
-        .dest_receiver_channel = 1,
+        .dest_sender_channel = 1,
         .connection_type = ConnectionType::INTRA_MESH
     };
     registry_->record_connection(target);
@@ -302,12 +302,12 @@ TEST_F(ConnectionRegistryTest, GetConnectionsToDest_MultipleMatches) {
             .source_direction = static_cast<RoutingDirection>(i),
             .source_eth_chan = static_cast<uint8_t>(i),
             .source_vc = 1,
-            .source_sender_channel = static_cast<uint32_t>(i),
+            .source_receiver_channel = static_cast<uint32_t>(i),
             .dest_node = dest_node,
             .dest_direction = dest_dir,
             .dest_eth_chan = 0,
             .dest_vc = 0,
-            .dest_receiver_channel = static_cast<uint32_t>(i),
+            .dest_sender_channel = static_cast<uint32_t>(i),
             .connection_type = ConnectionType::Z_TO_MESH
         };
         registry_->record_connection(record);
@@ -332,12 +332,12 @@ TEST_F(ConnectionRegistryTest, GetConnectionsByType_IntraMesh) {
             .source_direction = RoutingDirection::N,
             .source_eth_chan = static_cast<uint8_t>(i),
             .source_vc = 0,
-            .source_sender_channel = 1,
+            .source_receiver_channel = 1,
             .dest_node = FabricNodeId(MeshId{0}, i + 1),
             .dest_direction = RoutingDirection::S,
             .dest_eth_chan = static_cast<uint8_t>(i),
             .dest_vc = 0,
-            .dest_receiver_channel = 1,
+            .dest_sender_channel = 1,
             .connection_type = ConnectionType::INTRA_MESH
         };
         registry_->record_connection(record);
@@ -349,12 +349,12 @@ TEST_F(ConnectionRegistryTest, GetConnectionsByType_IntraMesh) {
         .source_direction = RoutingDirection::N,
         .source_eth_chan = 0,
         .source_vc = 0,
-        .source_sender_channel = 2,
+        .source_receiver_channel = 2,
         .dest_node = FabricNodeId(MeshId{0}, 0),
         .dest_direction = RoutingDirection::Z,
         .dest_eth_chan = 4,
         .dest_vc = 1,
-        .dest_receiver_channel = 0,
+        .dest_sender_channel = 0,
         .connection_type = ConnectionType::MESH_TO_Z
     };
     registry_->record_connection(mesh_to_z);
@@ -379,12 +379,12 @@ TEST_F(ConnectionRegistryTest, GetConnectionsByType_AllTypes) {
         .source_direction = RoutingDirection::N,
         .source_eth_chan = 0,
         .source_vc = 0,
-        .source_sender_channel = 1,
+        .source_receiver_channel = 1,
         .dest_node = FabricNodeId(MeshId{0}, 1),
         .dest_direction = RoutingDirection::S,
         .dest_eth_chan = 0,
         .dest_vc = 0,
-        .dest_receiver_channel = 1,
+        .dest_sender_channel = 1,
         .connection_type = ConnectionType::INTRA_MESH
     };
     registry_->record_connection(intra_mesh);
@@ -394,12 +394,12 @@ TEST_F(ConnectionRegistryTest, GetConnectionsByType_AllTypes) {
         .source_direction = RoutingDirection::N,
         .source_eth_chan = 0,
         .source_vc = 0,
-        .source_sender_channel = 2,
+        .source_receiver_channel = 2,
         .dest_node = FabricNodeId(MeshId{0}, 0),
         .dest_direction = RoutingDirection::Z,
         .dest_eth_chan = 4,
         .dest_vc = 1,
-        .dest_receiver_channel = 0,
+        .dest_sender_channel = 0,
         .connection_type = ConnectionType::MESH_TO_Z
     };
     registry_->record_connection(mesh_to_z);
@@ -409,12 +409,12 @@ TEST_F(ConnectionRegistryTest, GetConnectionsByType_AllTypes) {
         .source_direction = RoutingDirection::Z,
         .source_eth_chan = 4,
         .source_vc = 1,
-        .source_sender_channel = 0,
+        .source_receiver_channel = 0,
         .dest_node = FabricNodeId(MeshId{0}, 0),
         .dest_direction = RoutingDirection::N,
         .dest_eth_chan = 0,
         .dest_vc = 0,
-        .dest_receiver_channel = 2,
+        .dest_sender_channel = 2,
         .connection_type = ConnectionType::Z_TO_MESH
     };
     registry_->record_connection(z_to_mesh);
@@ -432,12 +432,12 @@ TEST_F(ConnectionRegistryTest, GetConnectionsByType_NoMatches) {
         .source_direction = RoutingDirection::N,
         .source_eth_chan = 0,
         .source_vc = 0,
-        .source_sender_channel = 1,
+        .source_receiver_channel = 1,
         .dest_node = FabricNodeId(MeshId{0}, 1),
         .dest_direction = RoutingDirection::S,
         .dest_eth_chan = 0,
         .dest_vc = 0,
-        .dest_receiver_channel = 1,
+        .dest_sender_channel = 1,
         .connection_type = ConnectionType::INTRA_MESH
     };
     registry_->record_connection(record);
@@ -469,12 +469,12 @@ TEST_F(ConnectionRegistryTest, ComplexScenario_MixedConnections) {
             .source_direction = mesh_dirs[i],
             .source_eth_chan = static_cast<uint8_t>(i),
             .source_vc = 0,
-            .source_sender_channel = 1,
+            .source_receiver_channel = 1,
             .dest_node = FabricNodeId(MeshId{0}, 1),
             .dest_direction = mesh_dirs[(i + 1) % 4],
             .dest_eth_chan = static_cast<uint8_t>((i + 1) % 4),
             .dest_vc = 0,
-            .dest_receiver_channel = 1,
+            .dest_sender_channel = 1,
             .connection_type = ConnectionType::INTRA_MESH
         };
         registry_->record_connection(record);
@@ -488,12 +488,12 @@ TEST_F(ConnectionRegistryTest, ComplexScenario_MixedConnections) {
             .source_direction = mesh_dirs[i],
             .source_eth_chan = static_cast<uint8_t>(i),
             .source_vc = 0,
-            .source_sender_channel = 2,
+            .source_receiver_channel = 2,
             .dest_node = device_node,
             .dest_direction = RoutingDirection::Z,
             .dest_eth_chan = 4,
             .dest_vc = 1,
-            .dest_receiver_channel = static_cast<uint32_t>(i),
+            .dest_sender_channel = static_cast<uint32_t>(i),
             .connection_type = ConnectionType::MESH_TO_Z
         };
         registry_->record_connection(record);
@@ -506,12 +506,12 @@ TEST_F(ConnectionRegistryTest, ComplexScenario_MixedConnections) {
             .source_direction = RoutingDirection::Z,
             .source_eth_chan = 4,
             .source_vc = 1,
-            .source_sender_channel = static_cast<uint32_t>(i),
+            .source_receiver_channel = static_cast<uint32_t>(i),
             .dest_node = device_node,
             .dest_direction = mesh_dirs[i],
             .dest_eth_chan = static_cast<uint8_t>(i),
             .dest_vc = 0,
-            .dest_receiver_channel = 2,
+            .dest_sender_channel = 2,
             .connection_type = ConnectionType::Z_TO_MESH
         };
         registry_->record_connection(record);
@@ -559,12 +559,12 @@ TEST_F(ConnectionRegistryTest, Phase1_5_MultiTargetReceiver_SameDestination) {
             .source_direction = mesh_dirs[i],
             .source_eth_chan = static_cast<uint8_t>(i),
             .source_vc = 0,
-            .source_sender_channel = 2,
+            .source_receiver_channel = 2,
             .dest_node = device0,
             .dest_direction = z_dir,
             .dest_eth_chan = z_eth_chan,
             .dest_vc = z_vc,
-            .dest_receiver_channel = z_receiver_ch,  // SAME for all!
+            .dest_sender_channel = z_receiver_ch,  // SAME for all!
             .connection_type = ConnectionType::MESH_TO_Z
         };
         registry_->record_connection(record);
@@ -578,7 +578,7 @@ TEST_F(ConnectionRegistryTest, Phase1_5_MultiTargetReceiver_SameDestination) {
 
     // Verify all target the same receiver channel (multi-target)
     for (const auto& conn : to_z) {
-        EXPECT_EQ(conn.dest_receiver_channel, z_receiver_ch);
+        EXPECT_EQ(conn.dest_sender_channel, z_receiver_ch);
         EXPECT_EQ(conn.dest_vc, z_vc);
     }
 
@@ -603,12 +603,12 @@ TEST_F(ConnectionRegistryTest, Phase1_5_QueryMultiTargetByType) {
             .source_direction = static_cast<RoutingDirection>(i),
             .source_eth_chan = static_cast<uint8_t>(i),
             .source_vc = 0,
-            .source_sender_channel = 2,
+            .source_receiver_channel = 2,
             .dest_node = device0,
             .dest_direction = RoutingDirection::Z,
             .dest_eth_chan = 4,
             .dest_vc = 1,
-            .dest_receiver_channel = 0,  // Same receiver
+            .dest_sender_channel = 0,  // Same receiver
             .connection_type = ConnectionType::MESH_TO_Z
         };
         registry_->record_connection(record);
@@ -620,12 +620,12 @@ TEST_F(ConnectionRegistryTest, Phase1_5_QueryMultiTargetByType) {
         .source_direction = RoutingDirection::N,
         .source_eth_chan = 0,
         .source_vc = 0,
-        .source_sender_channel = 1,
+        .source_receiver_channel = 1,
         .dest_node = FabricNodeId(MeshId{0}, 1),
         .dest_direction = RoutingDirection::S,
         .dest_eth_chan = 0,
         .dest_vc = 0,
-        .dest_receiver_channel = 1,
+        .dest_sender_channel = 1,
         .connection_type = ConnectionType::INTRA_MESH
     };
     registry_->record_connection(intra_mesh);
@@ -639,7 +639,7 @@ TEST_F(ConnectionRegistryTest, Phase1_5_QueryMultiTargetByType) {
 
     // Verify MESH_TO_Z connections all target same receiver
     for (const auto& conn : mesh_to_z) {
-        EXPECT_EQ(conn.dest_receiver_channel, 0);
+        EXPECT_EQ(conn.dest_sender_channel, 0);
     }
 }
 
@@ -669,12 +669,12 @@ TEST_F(ConnectionRegistryTest, Phase2_MeshRouter_1D_ConnectionMapping) {
             .source_direction = RoutingDirection::N,
             .source_eth_chan = 0,
             .source_vc = 0,
-            .source_sender_channel = sender_channel,
+            .source_receiver_channel = sender_channel,
             .dest_node = dest,
             .dest_direction = target.target_direction.value(),
             .dest_eth_chan = 0,
             .dest_vc = target.target_vc,
-            .dest_receiver_channel = 0,
+            .dest_sender_channel = 0,
             .connection_type = target.type
         };
         registry_->record_connection(record);
@@ -713,12 +713,12 @@ TEST_F(ConnectionRegistryTest, Phase2_MeshRouter_2D_WithZ_MultipleTargets) {
             .source_direction = RoutingDirection::N,
             .source_eth_chan = 0,
             .source_vc = 0,
-            .source_sender_channel = ch,
+            .source_receiver_channel = ch,
             .dest_node = FabricNodeId(MeshId{0}, ch),
             .dest_direction = targets[0].target_direction.value(),
             .dest_eth_chan = 0,
             .dest_vc = 0,
-            .dest_receiver_channel = 0,
+            .dest_sender_channel = 0,
             .connection_type = ConnectionType::INTRA_MESH
         };
         registry_->record_connection(record);
@@ -735,12 +735,12 @@ TEST_F(ConnectionRegistryTest, Phase2_MeshRouter_2D_WithZ_MultipleTargets) {
         .source_direction = RoutingDirection::N,
         .source_eth_chan = 0,
         .source_vc = 0,
-        .source_sender_channel = mesh_to_z_channel,
+        .source_receiver_channel = mesh_to_z_channel,
         .dest_node = FabricNodeId(MeshId{0}, 100),  // Z router
         .dest_direction = RoutingDirection::Z,
         .dest_eth_chan = 0,
         .dest_vc = 0,
-        .dest_receiver_channel = 0,
+        .dest_sender_channel = 0,
         .connection_type = ConnectionType::MESH_TO_Z
     };
     registry_->record_connection(z_record);
@@ -784,12 +784,12 @@ TEST_F(ConnectionRegistryTest, Phase2_ZRouter_VC1_FourTargets) {
             .source_direction = RoutingDirection::Z,
             .source_eth_chan = 0,
             .source_vc = 1,
-            .source_sender_channel = ch,
+            .source_receiver_channel = ch,
             .dest_node = FabricNodeId(MeshId{0}, ch),
             .dest_direction = expected_directions[ch],
             .dest_eth_chan = 0,
             .dest_vc = 0,
-            .dest_receiver_channel = 0,
+            .dest_sender_channel = 0,
             .connection_type = ConnectionType::Z_TO_MESH
         };
         registry_->record_connection(record);
@@ -837,12 +837,12 @@ TEST_F(ConnectionRegistryTest, Phase2_FullDevice_MappingDriven) {
                     .source_direction = mesh_directions[i],
                     .source_eth_chan = static_cast<uint8_t>(i),
                     .source_vc = 0,
-                    .source_sender_channel = ch,
+                    .source_receiver_channel = ch,
                     .dest_node = FabricNodeId(MeshId{0}, (i + ch) % 4),
                     .dest_direction = targets[0].target_direction.value(),
                     .dest_eth_chan = 0,
                     .dest_vc = 0,
-                    .dest_receiver_channel = 0,
+                    .dest_sender_channel = 0,
                     .connection_type = ConnectionType::INTRA_MESH
                 };
                 registry_->record_connection(record);
@@ -858,12 +858,12 @@ TEST_F(ConnectionRegistryTest, Phase2_FullDevice_MappingDriven) {
             .source_direction = mesh_directions[i],
             .source_eth_chan = static_cast<uint8_t>(i),
             .source_vc = 0,
-            .source_sender_channel = 4,
+            .source_receiver_channel = 4,
             .dest_node = FabricNodeId(MeshId{0}, 100),  // Z router
             .dest_direction = RoutingDirection::Z,
             .dest_eth_chan = 0,
             .dest_vc = 0,
-            .dest_receiver_channel = 0,
+            .dest_sender_channel = 0,
             .connection_type = ConnectionType::MESH_TO_Z
         };
         registry_->record_connection(z_record);
@@ -882,12 +882,12 @@ TEST_F(ConnectionRegistryTest, Phase2_FullDevice_MappingDriven) {
             .source_direction = RoutingDirection::Z,
             .source_eth_chan = 0,
             .source_vc = 1,
-            .source_sender_channel = ch,
+            .source_receiver_channel = ch,
             .dest_node = FabricNodeId(MeshId{0}, ch),
             .dest_direction = targets[0].target_direction.value(),
             .dest_eth_chan = 0,
             .dest_vc = 0,
-            .dest_receiver_channel = 0,
+            .dest_sender_channel = 0,
             .connection_type = ConnectionType::Z_TO_MESH
         };
         registry_->record_connection(record);
@@ -933,12 +933,12 @@ TEST_F(ConnectionRegistryTest, Phase2_EdgeDevice_2MeshRouters_MappingDriven) {
             .source_direction = mesh_directions[i],
             .source_eth_chan = static_cast<uint8_t>(i),
             .source_vc = 0,
-            .source_sender_channel = 4,
+            .source_receiver_channel = 4,
             .dest_node = FabricNodeId(MeshId{0}, 100),
             .dest_direction = RoutingDirection::Z,
             .dest_eth_chan = 0,
             .dest_vc = 0,
-            .dest_receiver_channel = 0,
+            .dest_sender_channel = 0,
             .connection_type = ConnectionType::MESH_TO_Z
         };
         registry_->record_connection(z_record);
@@ -966,12 +966,12 @@ TEST_F(ConnectionRegistryTest, Phase2_EdgeDevice_2MeshRouters_MappingDriven) {
                 .source_direction = RoutingDirection::Z,
                 .source_eth_chan = 0,
                 .source_vc = 1,
-                .source_sender_channel = ch,
+                .source_receiver_channel = ch,
                 .dest_node = FabricNodeId(MeshId{0}, ch),
                 .dest_direction = targets[0].target_direction.value(),
                 .dest_eth_chan = 0,
                 .dest_vc = 0,
-                .dest_receiver_channel = 0,
+                .dest_sender_channel = 0,
                 .connection_type = ConnectionType::Z_TO_MESH
             };
             registry_->record_connection(record);

--- a/tests/tt_metal/tt_fabric/fabric_router/test_connection_registry.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_connection_registry.cpp
@@ -697,7 +697,7 @@ TEST_F(ConnectionRegistryTest, Phase2_MeshRouter_2D_WithZ_MultipleTargets) {
     constexpr uint32_t num_intra_mesh_targets = builder_config::num_downstream_edms_2d_vc0;
     constexpr uint32_t num_mesh_to_z_targets = 1;
     constexpr uint32_t total_targets = num_intra_mesh_targets + num_mesh_to_z_targets;
-    
+
     auto targets = mapping.get_downstream_targets(0, 0);  // VC0, receiver channel 0
     ASSERT_EQ(targets.size(), total_targets);
 
@@ -725,14 +725,13 @@ TEST_F(ConnectionRegistryTest, Phase2_MeshRouter_2D_WithZ_MultipleTargets) {
             .source_eth_chan = 0,
             .source_vc = 0,
             .source_receiver_channel = 0,
-            .dest_node = (target.type == ConnectionType::MESH_TO_Z) ? 
-                         FabricNodeId(MeshId{0}, 100) : FabricNodeId(MeshId{0}, static_cast<uint32_t>(i)),
+            .dest_node = (target.type == ConnectionType::MESH_TO_Z) ? FabricNodeId(MeshId{0}, 100)
+                                                                    : FabricNodeId(MeshId{0}, static_cast<uint32_t>(i)),
             .dest_direction = target.target_direction.value(),
             .dest_eth_chan = 0,
             .dest_vc = target.target_vc,
             .dest_sender_channel = target.target_sender_channel,
-            .connection_type = target.type
-        };
+            .connection_type = target.type};
         registry_->record_connection(record);
     }
 
@@ -752,7 +751,7 @@ TEST_F(ConnectionRegistryTest, Phase2_ZRouter_VC1_FourTargets) {
 
     // Verify mapping: receiver channel 0 on VC1 has 4 downstream targets
     constexpr uint32_t num_z_targets = builder_config::num_sender_channels_z_router_vc1;
-    
+
     auto targets = mapping.get_downstream_targets(1, 0);  // VC1, receiver channel 0
     ASSERT_EQ(targets.size(), num_z_targets);
 
@@ -825,7 +824,7 @@ TEST_F(ConnectionRegistryTest, Phase2_FullDevice_MappingDriven) {
 
         // Get all targets from receiver channel 0
         auto targets = mapping.get_downstream_targets(0, 0);
-        
+
         // Record all connections from receiver channel 0
         for (size_t t = 0; t < targets.size(); ++t) {
             const auto& target = targets[t];
@@ -906,7 +905,7 @@ TEST_F(ConnectionRegistryTest, Phase2_EdgeDevice_2MeshRouters_MappingDriven) {
 
         // Get all targets from receiver channel 0
         auto targets = mapping.get_downstream_targets(0, 0);
-        
+
         // Find and record MESH_TO_Z connection
         for (const auto& target : targets) {
             if (target.type == ConnectionType::MESH_TO_Z) {

--- a/tests/tt_metal/tt_fabric/fabric_router/test_connection_registry.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_connection_registry.cpp
@@ -1,0 +1,497 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+#include "tt_metal/fabric/builder/connection_registry.hpp"
+#include <tt-metalium/experimental/fabric/mesh_graph.hpp>
+#include <tt-metalium/experimental/fabric/routing_table_generator.hpp>
+
+namespace tt::tt_fabric {
+
+/**
+ * Test fixture for ConnectionRegistry
+ * 
+ * These tests validate Phase 0 functionality:
+ * - Basic registry operations (record, query, clear)
+ * - Connection filtering by source, destination, and type
+ * - Data structure correctness
+ */
+class ConnectionRegistryTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        registry_ = std::make_shared<ConnectionRegistry>();
+    }
+
+    void TearDown() override {
+        registry_.reset();
+    }
+
+    std::shared_ptr<ConnectionRegistry> registry_;
+};
+
+// ============ Basic Operations Tests ============
+
+TEST_F(ConnectionRegistryTest, EmptyRegistryHasZeroSize) {
+    EXPECT_EQ(registry_->size(), 0);
+    EXPECT_TRUE(registry_->get_all_connections().empty());
+}
+
+TEST_F(ConnectionRegistryTest, RecordSingleConnection) {
+    RouterConnectionRecord record{
+        .source_node = FabricNodeId(MeshId{0}, 0),
+        .source_direction = RoutingDirection::N,
+        .source_eth_chan = 0,
+        .source_vc = 0,
+        .source_sender_channel = 1,
+        .dest_node = FabricNodeId(MeshId{0}, 1),
+        .dest_direction = RoutingDirection::S,
+        .dest_eth_chan = 0,
+        .dest_vc = 0,
+        .dest_receiver_channel = 1,
+        .connection_type = ConnectionType::INTRA_MESH
+    };
+
+    registry_->record_connection(record);
+
+    EXPECT_EQ(registry_->size(), 1);
+    
+    const auto& connections = registry_->get_all_connections();
+    ASSERT_EQ(connections.size(), 1);
+    
+    const auto& retrieved = connections[0];
+    EXPECT_EQ(retrieved.source_node, record.source_node);
+    EXPECT_EQ(retrieved.source_direction, record.source_direction);
+    EXPECT_EQ(retrieved.source_eth_chan, record.source_eth_chan);
+    EXPECT_EQ(retrieved.source_vc, record.source_vc);
+    EXPECT_EQ(retrieved.source_sender_channel, record.source_sender_channel);
+    EXPECT_EQ(retrieved.dest_node, record.dest_node);
+    EXPECT_EQ(retrieved.dest_direction, record.dest_direction);
+    EXPECT_EQ(retrieved.dest_eth_chan, record.dest_eth_chan);
+    EXPECT_EQ(retrieved.dest_vc, record.dest_vc);
+    EXPECT_EQ(retrieved.dest_receiver_channel, record.dest_receiver_channel);
+    EXPECT_EQ(retrieved.connection_type, record.connection_type);
+}
+
+TEST_F(ConnectionRegistryTest, RecordMultipleConnections) {
+    // Record 3 different connections
+    for (int i = 0; i < 3; ++i) {
+        RouterConnectionRecord record{
+            .source_node = FabricNodeId(MeshId{0}, i),
+            .source_direction = RoutingDirection::N,
+            .source_eth_chan = static_cast<uint8_t>(i),
+            .source_vc = 0,
+            .source_sender_channel = 1,
+            .dest_node = FabricNodeId(MeshId{0}, i + 1),
+            .dest_direction = RoutingDirection::S,
+            .dest_eth_chan = static_cast<uint8_t>(i),
+            .dest_vc = 0,
+            .dest_receiver_channel = 1,
+            .connection_type = ConnectionType::INTRA_MESH
+        };
+        registry_->record_connection(record);
+    }
+
+    EXPECT_EQ(registry_->size(), 3);
+    EXPECT_EQ(registry_->get_all_connections().size(), 3);
+}
+
+TEST_F(ConnectionRegistryTest, ClearRemovesAllConnections) {
+    // Add some connections
+    for (int i = 0; i < 5; ++i) {
+        RouterConnectionRecord record{
+            .source_node = FabricNodeId(MeshId{0}, i),
+            .source_direction = RoutingDirection::E,
+            .source_eth_chan = static_cast<uint8_t>(i),
+            .source_vc = 0,
+            .source_sender_channel = 0,
+            .dest_node = FabricNodeId(MeshId{0}, i + 1),
+            .dest_direction = RoutingDirection::W,
+            .dest_eth_chan = static_cast<uint8_t>(i),
+            .dest_vc = 0,
+            .dest_receiver_channel = 0,
+            .connection_type = ConnectionType::INTRA_MESH
+        };
+        registry_->record_connection(record);
+    }
+
+    EXPECT_EQ(registry_->size(), 5);
+
+    registry_->clear();
+
+    EXPECT_EQ(registry_->size(), 0);
+    EXPECT_TRUE(registry_->get_all_connections().empty());
+}
+
+// ============ Query by Source Tests ============
+
+TEST_F(ConnectionRegistryTest, GetConnectionsFromSource_SingleMatch) {
+    FabricNodeId source_node(MeshId{0}, 0);
+    RoutingDirection source_dir = RoutingDirection::N;
+
+    // Add target connection
+    RouterConnectionRecord target{
+        .source_node = source_node,
+        .source_direction = source_dir,
+        .source_eth_chan = 0,
+        .source_vc = 0,
+        .source_sender_channel = 1,
+        .dest_node = FabricNodeId(MeshId{0}, 1),
+        .dest_direction = RoutingDirection::S,
+        .dest_eth_chan = 0,
+        .dest_vc = 0,
+        .dest_receiver_channel = 1,
+        .connection_type = ConnectionType::INTRA_MESH
+    };
+    registry_->record_connection(target);
+
+    // Add noise connection (different source)
+    RouterConnectionRecord noise{
+        .source_node = FabricNodeId(MeshId{0}, 2),
+        .source_direction = RoutingDirection::E,
+        .source_eth_chan = 1,
+        .source_vc = 0,
+        .source_sender_channel = 0,
+        .dest_node = FabricNodeId(MeshId{0}, 3),
+        .dest_direction = RoutingDirection::W,
+        .dest_eth_chan = 1,
+        .dest_vc = 0,
+        .dest_receiver_channel = 0,
+        .connection_type = ConnectionType::INTRA_MESH
+    };
+    registry_->record_connection(noise);
+
+    auto results = registry_->get_connections_from_source(source_node, source_dir);
+
+    ASSERT_EQ(results.size(), 1);
+    EXPECT_EQ(results[0].source_node, source_node);
+    EXPECT_EQ(results[0].source_direction, source_dir);
+}
+
+TEST_F(ConnectionRegistryTest, GetConnectionsFromSource_MultipleMatches) {
+    FabricNodeId source_node(MeshId{0}, 0);
+    RoutingDirection source_dir = RoutingDirection::N;
+
+    // Add 3 connections from same source
+    for (int i = 0; i < 3; ++i) {
+        RouterConnectionRecord record{
+            .source_node = source_node,
+            .source_direction = source_dir,
+            .source_eth_chan = 0,
+            .source_vc = 0,
+            .source_sender_channel = static_cast<uint32_t>(i),
+            .dest_node = FabricNodeId(MeshId{0}, i + 1),
+            .dest_direction = RoutingDirection::S,
+            .dest_eth_chan = static_cast<uint8_t>(i),
+            .dest_vc = 0,
+            .dest_receiver_channel = static_cast<uint32_t>(i),
+            .connection_type = ConnectionType::INTRA_MESH
+        };
+        registry_->record_connection(record);
+    }
+
+    auto results = registry_->get_connections_from_source(source_node, source_dir);
+
+    EXPECT_EQ(results.size(), 3);
+    for (const auto& conn : results) {
+        EXPECT_EQ(conn.source_node, source_node);
+        EXPECT_EQ(conn.source_direction, source_dir);
+    }
+}
+
+TEST_F(ConnectionRegistryTest, GetConnectionsFromSource_NoMatches) {
+    // Add a connection
+    RouterConnectionRecord record{
+        .source_node = FabricNodeId(MeshId{0}, 0),
+        .source_direction = RoutingDirection::N,
+        .source_eth_chan = 0,
+        .source_vc = 0,
+        .source_sender_channel = 1,
+        .dest_node = FabricNodeId(MeshId{0}, 1),
+        .dest_direction = RoutingDirection::S,
+        .dest_eth_chan = 0,
+        .dest_vc = 0,
+        .dest_receiver_channel = 1,
+        .connection_type = ConnectionType::INTRA_MESH
+    };
+    registry_->record_connection(record);
+
+    // Query for non-existent source
+    auto results = registry_->get_connections_from_source(
+        FabricNodeId(MeshId{0}, 99), RoutingDirection::E);
+
+    EXPECT_TRUE(results.empty());
+}
+
+// ============ Query by Destination Tests ============
+
+TEST_F(ConnectionRegistryTest, GetConnectionsToDest_SingleMatch) {
+    FabricNodeId dest_node(MeshId{0}, 1);
+    RoutingDirection dest_dir = RoutingDirection::S;
+
+    RouterConnectionRecord target{
+        .source_node = FabricNodeId(MeshId{0}, 0),
+        .source_direction = RoutingDirection::N,
+        .source_eth_chan = 0,
+        .source_vc = 0,
+        .source_sender_channel = 1,
+        .dest_node = dest_node,
+        .dest_direction = dest_dir,
+        .dest_eth_chan = 0,
+        .dest_vc = 0,
+        .dest_receiver_channel = 1,
+        .connection_type = ConnectionType::INTRA_MESH
+    };
+    registry_->record_connection(target);
+
+    auto results = registry_->get_connections_to_dest(dest_node, dest_dir);
+
+    ASSERT_EQ(results.size(), 1);
+    EXPECT_EQ(results[0].dest_node, dest_node);
+    EXPECT_EQ(results[0].dest_direction, dest_dir);
+}
+
+TEST_F(ConnectionRegistryTest, GetConnectionsToDest_MultipleMatches) {
+    FabricNodeId dest_node(MeshId{0}, 5);
+    RoutingDirection dest_dir = RoutingDirection::W;
+
+    // Add 4 connections to same destination (simulating Z router scenario)
+    for (int i = 0; i < 4; ++i) {
+        RouterConnectionRecord record{
+            .source_node = FabricNodeId(MeshId{0}, i),
+            .source_direction = static_cast<RoutingDirection>(i),
+            .source_eth_chan = static_cast<uint8_t>(i),
+            .source_vc = 1,
+            .source_sender_channel = static_cast<uint32_t>(i),
+            .dest_node = dest_node,
+            .dest_direction = dest_dir,
+            .dest_eth_chan = 0,
+            .dest_vc = 0,
+            .dest_receiver_channel = static_cast<uint32_t>(i),
+            .connection_type = ConnectionType::Z_TO_MESH
+        };
+        registry_->record_connection(record);
+    }
+
+    auto results = registry_->get_connections_to_dest(dest_node, dest_dir);
+
+    EXPECT_EQ(results.size(), 4);
+    for (const auto& conn : results) {
+        EXPECT_EQ(conn.dest_node, dest_node);
+        EXPECT_EQ(conn.dest_direction, dest_dir);
+    }
+}
+
+// ============ Query by Connection Type Tests ============
+
+TEST_F(ConnectionRegistryTest, GetConnectionsByType_IntraMesh) {
+    // Add 2 INTRA_MESH connections
+    for (int i = 0; i < 2; ++i) {
+        RouterConnectionRecord record{
+            .source_node = FabricNodeId(MeshId{0}, i),
+            .source_direction = RoutingDirection::N,
+            .source_eth_chan = static_cast<uint8_t>(i),
+            .source_vc = 0,
+            .source_sender_channel = 1,
+            .dest_node = FabricNodeId(MeshId{0}, i + 1),
+            .dest_direction = RoutingDirection::S,
+            .dest_eth_chan = static_cast<uint8_t>(i),
+            .dest_vc = 0,
+            .dest_receiver_channel = 1,
+            .connection_type = ConnectionType::INTRA_MESH
+        };
+        registry_->record_connection(record);
+    }
+
+    // Add 1 MESH_TO_Z connection
+    RouterConnectionRecord mesh_to_z{
+        .source_node = FabricNodeId(MeshId{0}, 0),
+        .source_direction = RoutingDirection::N,
+        .source_eth_chan = 0,
+        .source_vc = 0,
+        .source_sender_channel = 2,
+        .dest_node = FabricNodeId(MeshId{0}, 0),
+        .dest_direction = RoutingDirection::Z,
+        .dest_eth_chan = 4,
+        .dest_vc = 1,
+        .dest_receiver_channel = 0,
+        .connection_type = ConnectionType::MESH_TO_Z
+    };
+    registry_->record_connection(mesh_to_z);
+
+    auto intra_mesh_results = registry_->get_connections_by_type(ConnectionType::INTRA_MESH);
+    auto mesh_to_z_results = registry_->get_connections_by_type(ConnectionType::MESH_TO_Z);
+
+    EXPECT_EQ(intra_mesh_results.size(), 2);
+    EXPECT_EQ(mesh_to_z_results.size(), 1);
+
+    for (const auto& conn : intra_mesh_results) {
+        EXPECT_EQ(conn.connection_type, ConnectionType::INTRA_MESH);
+    }
+
+    EXPECT_EQ(mesh_to_z_results[0].connection_type, ConnectionType::MESH_TO_Z);
+}
+
+TEST_F(ConnectionRegistryTest, GetConnectionsByType_AllTypes) {
+    // Add one of each connection type
+    RouterConnectionRecord intra_mesh{
+        .source_node = FabricNodeId(MeshId{0}, 0),
+        .source_direction = RoutingDirection::N,
+        .source_eth_chan = 0,
+        .source_vc = 0,
+        .source_sender_channel = 1,
+        .dest_node = FabricNodeId(MeshId{0}, 1),
+        .dest_direction = RoutingDirection::S,
+        .dest_eth_chan = 0,
+        .dest_vc = 0,
+        .dest_receiver_channel = 1,
+        .connection_type = ConnectionType::INTRA_MESH
+    };
+    registry_->record_connection(intra_mesh);
+
+    RouterConnectionRecord mesh_to_z{
+        .source_node = FabricNodeId(MeshId{0}, 0),
+        .source_direction = RoutingDirection::N,
+        .source_eth_chan = 0,
+        .source_vc = 0,
+        .source_sender_channel = 2,
+        .dest_node = FabricNodeId(MeshId{0}, 0),
+        .dest_direction = RoutingDirection::Z,
+        .dest_eth_chan = 4,
+        .dest_vc = 1,
+        .dest_receiver_channel = 0,
+        .connection_type = ConnectionType::MESH_TO_Z
+    };
+    registry_->record_connection(mesh_to_z);
+
+    RouterConnectionRecord z_to_mesh{
+        .source_node = FabricNodeId(MeshId{0}, 0),
+        .source_direction = RoutingDirection::Z,
+        .source_eth_chan = 4,
+        .source_vc = 1,
+        .source_sender_channel = 0,
+        .dest_node = FabricNodeId(MeshId{0}, 0),
+        .dest_direction = RoutingDirection::N,
+        .dest_eth_chan = 0,
+        .dest_vc = 0,
+        .dest_receiver_channel = 2,
+        .connection_type = ConnectionType::Z_TO_MESH
+    };
+    registry_->record_connection(z_to_mesh);
+
+    EXPECT_EQ(registry_->size(), 3);
+    EXPECT_EQ(registry_->get_connections_by_type(ConnectionType::INTRA_MESH).size(), 1);
+    EXPECT_EQ(registry_->get_connections_by_type(ConnectionType::MESH_TO_Z).size(), 1);
+    EXPECT_EQ(registry_->get_connections_by_type(ConnectionType::Z_TO_MESH).size(), 1);
+}
+
+TEST_F(ConnectionRegistryTest, GetConnectionsByType_NoMatches) {
+    // Add only INTRA_MESH connections
+    RouterConnectionRecord record{
+        .source_node = FabricNodeId(MeshId{0}, 0),
+        .source_direction = RoutingDirection::N,
+        .source_eth_chan = 0,
+        .source_vc = 0,
+        .source_sender_channel = 1,
+        .dest_node = FabricNodeId(MeshId{0}, 1),
+        .dest_direction = RoutingDirection::S,
+        .dest_eth_chan = 0,
+        .dest_vc = 0,
+        .dest_receiver_channel = 1,
+        .connection_type = ConnectionType::INTRA_MESH
+    };
+    registry_->record_connection(record);
+
+    // Query for Z_TO_MESH (should be empty)
+    auto results = registry_->get_connections_by_type(ConnectionType::Z_TO_MESH);
+    EXPECT_TRUE(results.empty());
+}
+
+// ============ Complex Scenario Tests ============
+
+TEST_F(ConnectionRegistryTest, ComplexScenario_MixedConnections) {
+    // Simulate a device with 4 mesh routers and 1 Z router
+    // Each mesh router connects to 2 other mesh routers (INTRA_MESH)
+    // Each mesh router connects to Z router (MESH_TO_Z)
+    // Z router connects to all 4 mesh routers (Z_TO_MESH)
+
+    FabricNodeId device_node(MeshId{0}, 0);
+
+    // 4 mesh routers: N, E, S, W
+    std::vector<RoutingDirection> mesh_dirs = {
+        RoutingDirection::N, RoutingDirection::E, RoutingDirection::S, RoutingDirection::W
+    };
+
+    // Add INTRA_MESH connections (simplified - just a few)
+    for (size_t i = 0; i < 2; ++i) {
+        RouterConnectionRecord record{
+            .source_node = device_node,
+            .source_direction = mesh_dirs[i],
+            .source_eth_chan = static_cast<uint8_t>(i),
+            .source_vc = 0,
+            .source_sender_channel = 1,
+            .dest_node = FabricNodeId(MeshId{0}, 1),
+            .dest_direction = mesh_dirs[(i + 1) % 4],
+            .dest_eth_chan = static_cast<uint8_t>((i + 1) % 4),
+            .dest_vc = 0,
+            .dest_receiver_channel = 1,
+            .connection_type = ConnectionType::INTRA_MESH
+        };
+        registry_->record_connection(record);
+    }
+
+    // Add MESH_TO_Z connections (4 mesh routers → Z router)
+    for (size_t i = 0; i < 4; ++i) {
+        RouterConnectionRecord record{
+            .source_node = device_node,
+            .source_direction = mesh_dirs[i],
+            .source_eth_chan = static_cast<uint8_t>(i),
+            .source_vc = 0,
+            .source_sender_channel = 2,
+            .dest_node = device_node,
+            .dest_direction = RoutingDirection::Z,
+            .dest_eth_chan = 4,
+            .dest_vc = 1,
+            .dest_receiver_channel = static_cast<uint32_t>(i),
+            .connection_type = ConnectionType::MESH_TO_Z
+        };
+        registry_->record_connection(record);
+    }
+
+    // Add Z_TO_MESH connections (Z router → 4 mesh routers)
+    for (size_t i = 0; i < 4; ++i) {
+        RouterConnectionRecord record{
+            .source_node = device_node,
+            .source_direction = RoutingDirection::Z,
+            .source_eth_chan = 4,
+            .source_vc = 1,
+            .source_sender_channel = static_cast<uint32_t>(i),
+            .dest_node = device_node,
+            .dest_direction = mesh_dirs[i],
+            .dest_eth_chan = static_cast<uint8_t>(i),
+            .dest_vc = 0,
+            .dest_receiver_channel = 2,
+            .connection_type = ConnectionType::Z_TO_MESH
+        };
+        registry_->record_connection(record);
+    }
+
+    // Verify totals
+    EXPECT_EQ(registry_->size(), 10);  // 2 INTRA_MESH + 4 MESH_TO_Z + 4 Z_TO_MESH
+
+    // Verify by type
+    EXPECT_EQ(registry_->get_connections_by_type(ConnectionType::INTRA_MESH).size(), 2);
+    EXPECT_EQ(registry_->get_connections_by_type(ConnectionType::MESH_TO_Z).size(), 4);
+    EXPECT_EQ(registry_->get_connections_by_type(ConnectionType::Z_TO_MESH).size(), 4);
+
+    // Verify Z router has 4 outgoing connections
+    auto z_outgoing = registry_->get_connections_from_source(device_node, RoutingDirection::Z);
+    EXPECT_EQ(z_outgoing.size(), 4);
+
+    // Verify Z router has 4 incoming connections
+    auto z_incoming = registry_->get_connections_to_dest(device_node, RoutingDirection::Z);
+    EXPECT_EQ(z_incoming.size(), 4);
+}
+
+}  // namespace tt::tt_fabric
+

--- a/tests/tt_metal/tt_fabric/fabric_router/test_fabric_builder_local_connections.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_fabric_builder_local_connections.cpp
@@ -1,0 +1,537 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+#include "tt_metal/fabric/builder/connection_registry.hpp"
+#include "tt_metal/fabric/builder/router_connection_mapping.hpp"
+#include "tt_metal/fabric/fabric_router_channel_mapping.hpp"
+#include "tt_metal/fabric/fabric_context.hpp"
+#include <tt-metalium/experimental/fabric/mesh_graph.hpp>
+#include <tt-metalium/experimental/fabric/fabric_edm_types.hpp>
+
+using namespace tt::tt_fabric;
+
+/**
+ * FabricBuilder Local Connection Tests
+ *
+ * These tests validate FabricBuilder's establishment of local mesh↔Z connections:
+ * 1. Z router detection on a device
+ * 2. Local mesh↔Z connection establishment
+ * 3. Variable mesh router count handling (2-4 routers)
+ * 4. Connection registry validation for full device scenarios
+ *
+ * Note: These are conceptual tests simulating FabricBuilder connection logic
+ * without requiring actual device/UMD initialization.
+ *
+ * Test Coverage Summary:
+ * ┌──────────────────────────────────────────────────────────────────────────────────────┐
+ * │ Category                    │ Test Name                                │ Focus        │
+ * ├─────────────────────────────┼──────────────────────────────────────────┼──────────────┤
+ * │ Z Router Detection          │ DetectZRouter_FullDevice                 │ Has Z        │
+ * │                             │ DetectZRouter_NoZRouter                  │ No Z         │
+ * ├─────────────────────────────┼──────────────────────────────────────────┼──────────────┤
+ * │ Full Device (4 Mesh + Z)    │ FullDevice_4Mesh1Z_AllConnections        │ All conns    │
+ * ├─────────────────────────────┼──────────────────────────────────────────┼──────────────┤
+ * │ Edge Device (2-3 Mesh + Z)  │ EdgeDevice_2Mesh1Z_Connections           │ 2 routers    │
+ * │                             │ EdgeDevice_3Mesh1Z_Connections           │ 3 routers    │
+ * ├─────────────────────────────┼──────────────────────────────────────────┼──────────────┤
+ * │ VC Assignment (Positive)    │ VCAssignment_MeshToZ_VC0                 │ Mesh→Z VC0   │
+ * │                             │ VCAssignment_ZToMesh_VC1                 │ Z→Mesh VC1   │
+ * ├─────────────────────────────┼──────────────────────────────────────────┼──────────────┤
+ * │ VC Assignment (Negative)    │ VCAssignment_MeshToZ_VC1_Negative        │ No VC1       │
+ * │                             │ VCAssignment_ZToMesh_VC0_Negative        │ No VC0       │
+ * ├─────────────────────────────┼──────────────────────────────────────────┼──────────────┤
+ * │ Connection Validation       │ ZRouter_ConnectsToCorrectDirections      │ Directions   │
+ * │                             │ NoDuplicateConnections                   │ No dupes     │
+ * │                             │ ConnectionOrder_ZFirst                   │ Order indep  │
+ * │                             │ ConnectionOrder_MeshFirst                │ Order indep  │
+ * └─────────────────────────────┴──────────────────────────────────────────┴──────────────┘
+ *
+ * Total: 13 tests across 6 categories
+ */
+
+class FabricBuilderLocalConnectionsTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        registry_ = std::make_shared<ConnectionRegistry>();
+    }
+
+    // Helper to simulate router creation
+    struct MockRouter {
+        FabricNodeId node_id;
+        RoutingDirection direction;
+        FabricRouterChannelMapping channel_mapping;
+        RouterConnectionMapping connection_mapping;
+    };
+
+    MockRouter create_mock_mesh_router(RoutingDirection dir, uint32_t router_id, bool has_z) {
+        return MockRouter{
+            .node_id = FabricNodeId(MeshId{0}, router_id),
+            .direction = dir,
+            .channel_mapping = FabricRouterChannelMapping(
+                Topology::Mesh,
+                false,  // No tensix
+                RouterVariant::MESH,
+                nullptr),  // No intermesh config for mock
+            .connection_mapping = RouterConnectionMapping::for_mesh_router(
+                Topology::Mesh,
+                dir,
+                has_z)
+        };
+    }
+
+    MockRouter create_mock_z_router(uint32_t router_id) {
+        static auto intermesh_config = IntermeshVCConfig::full_mesh();
+        return MockRouter{
+            .node_id = FabricNodeId(MeshId{0}, router_id),
+            .direction = RoutingDirection::Z,
+            .channel_mapping = FabricRouterChannelMapping(
+                Topology::Mesh,
+                false,
+                RouterVariant::Z_ROUTER,
+                &intermesh_config),  // Z routers require intermesh config
+            .connection_mapping = RouterConnectionMapping::for_z_router()
+        };
+    }
+
+    // Helper to simulate local connection establishment
+    void establish_local_connections(MockRouter& source, const std::map<RoutingDirection, MockRouter*>& targets) {
+        // Iterate through all sender keys in connection mapping
+        auto all_sender_keys = source.connection_mapping.get_all_sender_keys();
+
+        for (const auto& key : all_sender_keys) {
+            auto conn_targets = source.connection_mapping.get_downstream_targets(key.vc, key.sender_channel);
+
+            for (const auto& target : conn_targets) {
+                if (target.type == ConnectionType::MESH_TO_Z || target.type == ConnectionType::Z_TO_MESH) {
+                    TT_ASSERT(target.target_direction.has_value());
+                    auto target_dir = target.target_direction.value();
+
+                    if (targets.count(target_dir) == 0) {
+                        continue;  // Target doesn't exist (edge device)
+                    }
+
+                    auto* dest_router = targets.at(target_dir);
+
+                    // Record connection
+                    RouterConnectionRecord record{
+                        .source_node = source.node_id,
+                        .source_direction = source.direction,
+                        .source_eth_chan = 0,
+                        .source_vc = key.vc,
+                        .source_sender_channel = key.sender_channel,
+                        .dest_node = dest_router->node_id,
+                        .dest_direction = dest_router->direction,
+                        .dest_eth_chan = 0,
+                        .dest_vc = target.target_vc,
+                        .dest_receiver_channel = 0,
+                        .connection_type = target.type
+                    };
+
+                    registry_->record_connection(record);
+                }
+            }
+        }
+    }
+
+    std::shared_ptr<ConnectionRegistry> registry_;
+};
+
+// ============================================================================
+// Test 1: Z Router Detection
+// ============================================================================
+
+TEST_F(FabricBuilderLocalConnectionsTest, DetectZRouter_FullDevice) {
+    // Simulate device with 4 mesh routers + 1 Z router
+    std::vector<MockRouter> routers;
+
+    routers.push_back(create_mock_mesh_router(RoutingDirection::N, 0, true));
+    routers.push_back(create_mock_mesh_router(RoutingDirection::E, 1, true));
+    routers.push_back(create_mock_mesh_router(RoutingDirection::S, 2, true));
+    routers.push_back(create_mock_mesh_router(RoutingDirection::W, 3, true));
+    routers.push_back(create_mock_z_router(100));
+
+    // Count Z routers
+    int z_count = 0;
+    for (const auto& router : routers) {
+        if (router.direction == RoutingDirection::Z) {
+            z_count++;
+        }
+    }
+
+    EXPECT_EQ(z_count, 1);
+}
+
+TEST_F(FabricBuilderLocalConnectionsTest, DetectZRouter_NoZRouter) {
+    // Simulate device with only mesh routers
+    std::vector<MockRouter> routers;
+
+    routers.push_back(create_mock_mesh_router(RoutingDirection::N, 0, false));
+    routers.push_back(create_mock_mesh_router(RoutingDirection::E, 1, false));
+    routers.push_back(create_mock_mesh_router(RoutingDirection::S, 2, false));
+    routers.push_back(create_mock_mesh_router(RoutingDirection::W, 3, false));
+
+    // Count Z routers
+    int z_count = 0;
+    for (const auto& router : routers) {
+        if (router.direction == RoutingDirection::Z) {
+            z_count++;
+        }
+    }
+
+    EXPECT_EQ(z_count, 0);
+}
+
+// ============================================================================
+// Test 2: Full Device Connection Establishment (4 Mesh + 1 Z)
+// ============================================================================
+
+TEST_F(FabricBuilderLocalConnectionsTest, FullDevice_4Mesh1Z_AllConnections) {
+    // Create routers
+    auto mesh_n = create_mock_mesh_router(RoutingDirection::N, 0, true);
+    auto mesh_e = create_mock_mesh_router(RoutingDirection::E, 1, true);
+    auto mesh_s = create_mock_mesh_router(RoutingDirection::S, 2, true);
+    auto mesh_w = create_mock_mesh_router(RoutingDirection::W, 3, true);
+    auto z_router = create_mock_z_router(100);
+
+    // Build local router maps
+    std::map<RoutingDirection, MockRouter*> mesh_routers = {
+        {RoutingDirection::N, &mesh_n},
+        {RoutingDirection::E, &mesh_e},
+        {RoutingDirection::S, &mesh_s},
+        {RoutingDirection::W, &mesh_w}
+    };
+
+    std::map<RoutingDirection, MockRouter*> z_map = {
+        {RoutingDirection::Z, &z_router}
+    };
+
+    // Establish Z→mesh connections
+    establish_local_connections(z_router, mesh_routers);
+
+    // Establish mesh→Z connections
+    for (auto& [dir, mesh_router] : mesh_routers) {
+        establish_local_connections(*mesh_router, z_map);
+    }
+
+    // Verify total connections: 4 Z_TO_MESH + 4 MESH_TO_Z = 8
+    EXPECT_EQ(registry_->size(), 8);
+
+    auto z_to_mesh = registry_->get_connections_by_type(ConnectionType::Z_TO_MESH);
+    auto mesh_to_z = registry_->get_connections_by_type(ConnectionType::MESH_TO_Z);
+
+    EXPECT_EQ(z_to_mesh.size(), 4);
+    EXPECT_EQ(mesh_to_z.size(), 4);
+
+    // Verify Z router connects to all 4 mesh routers
+    auto z_outgoing = registry_->get_connections_by_source_node(z_router.node_id);
+    EXPECT_EQ(z_outgoing.size(), 4);
+
+    // Verify all mesh routers connect to Z
+    for (const auto& [dir, mesh_router] : mesh_routers) {
+        auto mesh_outgoing = registry_->get_connections_by_source_node(mesh_router->node_id);
+
+        // Should have exactly 1 MESH_TO_Z connection
+        int mesh_to_z_count = 0;
+        for (const auto& conn : mesh_outgoing) {
+            if (conn.connection_type == ConnectionType::MESH_TO_Z) {
+                mesh_to_z_count++;
+                EXPECT_EQ(conn.dest_node, z_router.node_id);
+            }
+        }
+        EXPECT_EQ(mesh_to_z_count, 1);
+    }
+}
+
+// ============================================================================
+// Test 3: Edge Device Scenarios (2-3 Mesh Routers)
+// ============================================================================
+
+TEST_F(FabricBuilderLocalConnectionsTest, EdgeDevice_2Mesh1Z_Connections) {
+    // Edge device with only N and E mesh routers
+    auto mesh_n = create_mock_mesh_router(RoutingDirection::N, 0, true);
+    auto mesh_e = create_mock_mesh_router(RoutingDirection::E, 1, true);
+    auto z_router = create_mock_z_router(100);
+
+    std::map<RoutingDirection, MockRouter*> mesh_routers = {
+        {RoutingDirection::N, &mesh_n},
+        {RoutingDirection::E, &mesh_e}
+    };
+
+    std::map<RoutingDirection, MockRouter*> z_map = {
+        {RoutingDirection::Z, &z_router}
+    };
+
+    // Establish connections
+    establish_local_connections(z_router, mesh_routers);
+
+    for (auto& [dir, mesh_router] : mesh_routers) {
+        establish_local_connections(*mesh_router, z_map);
+    }
+
+    // Verify: 2 Z_TO_MESH + 2 MESH_TO_Z = 4 total
+    EXPECT_EQ(registry_->size(), 4);
+
+    auto z_to_mesh = registry_->get_connections_by_type(ConnectionType::Z_TO_MESH);
+    auto mesh_to_z = registry_->get_connections_by_type(ConnectionType::MESH_TO_Z);
+
+    EXPECT_EQ(z_to_mesh.size(), 2);  // Only N and E
+    EXPECT_EQ(mesh_to_z.size(), 2);
+
+    // Verify Z router only connects to existing mesh routers
+    auto z_outgoing = registry_->get_connections_by_source_node(z_router.node_id);
+    EXPECT_EQ(z_outgoing.size(), 2);
+
+    // Check that S and W directions were skipped
+    std::set<RoutingDirection> connected_dirs;
+    for (const auto& conn : z_outgoing) {
+        connected_dirs.insert(conn.dest_direction);
+    }
+
+    EXPECT_TRUE(connected_dirs.count(RoutingDirection::N) > 0);
+    EXPECT_TRUE(connected_dirs.count(RoutingDirection::E) > 0);
+    EXPECT_FALSE(connected_dirs.count(RoutingDirection::S) > 0);
+    EXPECT_FALSE(connected_dirs.count(RoutingDirection::W) > 0);
+}
+
+TEST_F(FabricBuilderLocalConnectionsTest, EdgeDevice_3Mesh1Z_Connections) {
+    // Edge device with N, E, and S mesh routers
+    auto mesh_n = create_mock_mesh_router(RoutingDirection::N, 0, true);
+    auto mesh_e = create_mock_mesh_router(RoutingDirection::E, 1, true);
+    auto mesh_s = create_mock_mesh_router(RoutingDirection::S, 2, true);
+    auto z_router = create_mock_z_router(100);
+
+    std::map<RoutingDirection, MockRouter*> mesh_routers = {
+        {RoutingDirection::N, &mesh_n},
+        {RoutingDirection::E, &mesh_e},
+        {RoutingDirection::S, &mesh_s}
+    };
+
+    std::map<RoutingDirection, MockRouter*> z_map = {
+        {RoutingDirection::Z, &z_router}
+    };
+
+    // Establish connections
+    establish_local_connections(z_router, mesh_routers);
+
+    for (auto& [dir, mesh_router] : mesh_routers) {
+        establish_local_connections(*mesh_router, z_map);
+    }
+
+    // Verify: 3 Z_TO_MESH + 3 MESH_TO_Z = 6 total
+    EXPECT_EQ(registry_->size(), 6);
+
+    auto z_to_mesh = registry_->get_connections_by_type(ConnectionType::Z_TO_MESH);
+    auto mesh_to_z = registry_->get_connections_by_type(ConnectionType::MESH_TO_Z);
+
+    EXPECT_EQ(z_to_mesh.size(), 3);
+    EXPECT_EQ(mesh_to_z.size(), 3);
+}
+
+// ============================================================================
+// Test 4: VC Assignment Validation
+// ============================================================================
+
+TEST_F(FabricBuilderLocalConnectionsTest, VCAssignment_MeshToZ_VC0) {
+    auto mesh_n = create_mock_mesh_router(RoutingDirection::N, 0, true);
+    auto z_router = create_mock_z_router(100);
+
+    std::map<RoutingDirection, MockRouter*> z_map = {
+        {RoutingDirection::Z, &z_router}
+    };
+
+    establish_local_connections(mesh_n, z_map);
+
+    auto connections = registry_->get_all_connections();
+    ASSERT_EQ(connections.size(), 1);
+
+    // Mesh VC0 → Z VC0
+    EXPECT_EQ(connections[0].source_vc, 0);
+    EXPECT_EQ(connections[0].dest_vc, 0);
+    EXPECT_EQ(connections[0].connection_type, ConnectionType::MESH_TO_Z);
+}
+
+TEST_F(FabricBuilderLocalConnectionsTest, VCAssignment_ZToMesh_VC1) {
+    auto mesh_n = create_mock_mesh_router(RoutingDirection::N, 0, true);
+    auto z_router = create_mock_z_router(100);
+
+    std::map<RoutingDirection, MockRouter*> mesh_routers = {
+        {RoutingDirection::N, &mesh_n}
+    };
+
+    establish_local_connections(z_router, mesh_routers);
+
+    auto connections = registry_->get_all_connections();
+    ASSERT_EQ(connections.size(), 1);
+
+    // Z VC1 → Mesh VC1
+    EXPECT_EQ(connections[0].source_vc, 1);
+    EXPECT_EQ(connections[0].dest_vc, 1);
+    EXPECT_EQ(connections[0].connection_type, ConnectionType::Z_TO_MESH);
+}
+
+// Negative test: MESH_TO_Z should never use VC1
+TEST_F(FabricBuilderLocalConnectionsTest, VCAssignment_MeshToZ_VC1_Negative) {
+    auto mesh_n = create_mock_mesh_router(RoutingDirection::N, 0, true);
+    auto z_router = create_mock_z_router(100);
+
+    std::map<RoutingDirection, MockRouter*> z_map = {
+        {RoutingDirection::Z, &z_router}
+    };
+
+    establish_local_connections(mesh_n, z_map);
+
+    auto connections = registry_->get_all_connections();
+
+    // Verify no MESH_TO_Z connections use VC1
+    for (const auto& conn : connections) {
+        if (conn.connection_type == ConnectionType::MESH_TO_Z) {
+            EXPECT_NE(conn.source_vc, 1) << "MESH_TO_Z should never use VC1";
+            EXPECT_NE(conn.dest_vc, 1) << "MESH_TO_Z should never target VC1";
+        }
+    }
+}
+
+// Negative test: Z_TO_MESH should never use VC0
+TEST_F(FabricBuilderLocalConnectionsTest, VCAssignment_ZToMesh_VC0_Negative) {
+    auto mesh_n = create_mock_mesh_router(RoutingDirection::N, 0, true);
+    auto z_router = create_mock_z_router(100);
+
+    std::map<RoutingDirection, MockRouter*> mesh_routers = {
+        {RoutingDirection::N, &mesh_n}
+    };
+
+    establish_local_connections(z_router, mesh_routers);
+
+    auto connections = registry_->get_all_connections();
+
+    // Verify no Z_TO_MESH connections use VC0
+    for (const auto& conn : connections) {
+        if (conn.connection_type == ConnectionType::Z_TO_MESH) {
+            EXPECT_NE(conn.source_vc, 0) << "Z_TO_MESH should never use VC0";
+            EXPECT_NE(conn.dest_vc, 0) << "Z_TO_MESH should never target VC0";
+        }
+    }
+}
+
+// ============================================================================
+// Test 5: Connection Direction Validation
+// ============================================================================
+
+TEST_F(FabricBuilderLocalConnectionsTest, ZRouter_ConnectsToCorrectDirections) {
+    auto mesh_n = create_mock_mesh_router(RoutingDirection::N, 0, true);
+    auto mesh_e = create_mock_mesh_router(RoutingDirection::E, 1, true);
+    auto mesh_s = create_mock_mesh_router(RoutingDirection::S, 2, true);
+    auto mesh_w = create_mock_mesh_router(RoutingDirection::W, 3, true);
+    auto z_router = create_mock_z_router(100);
+
+    std::map<RoutingDirection, MockRouter*> mesh_routers = {
+        {RoutingDirection::N, &mesh_n},
+        {RoutingDirection::E, &mesh_e},
+        {RoutingDirection::S, &mesh_s},
+        {RoutingDirection::W, &mesh_w}
+    };
+
+    establish_local_connections(z_router, mesh_routers);
+
+    auto z_outgoing = registry_->get_connections_by_source_node(z_router.node_id);
+    ASSERT_EQ(z_outgoing.size(), 4);
+
+    // Verify each direction is connected exactly once
+    std::map<RoutingDirection, int> direction_counts;
+    for (const auto& conn : z_outgoing) {
+        direction_counts[conn.dest_direction]++;
+    }
+
+    EXPECT_EQ(direction_counts[RoutingDirection::N], 1);
+    EXPECT_EQ(direction_counts[RoutingDirection::E], 1);
+    EXPECT_EQ(direction_counts[RoutingDirection::S], 1);
+    EXPECT_EQ(direction_counts[RoutingDirection::W], 1);
+}
+
+// ============================================================================
+// Test 6: No Duplicate Connections
+// ============================================================================
+
+TEST_F(FabricBuilderLocalConnectionsTest, NoDuplicateConnections) {
+    auto mesh_n = create_mock_mesh_router(RoutingDirection::N, 0, true);
+    auto z_router = create_mock_z_router(100);
+
+    std::map<RoutingDirection, MockRouter*> mesh_routers = {
+        {RoutingDirection::N, &mesh_n}
+    };
+
+    std::map<RoutingDirection, MockRouter*> z_map = {
+        {RoutingDirection::Z, &z_router}
+    };
+
+    // Establish connections
+    establish_local_connections(z_router, mesh_routers);
+    establish_local_connections(mesh_n, z_map);
+
+    // Should have exactly 2 connections (1 each direction)
+    EXPECT_EQ(registry_->size(), 2);
+
+    // Verify no duplicates by checking unique (source, dest, vc) tuples
+    std::set<std::tuple<FabricNodeId, FabricNodeId, uint32_t>> unique_conns;
+    for (const auto& conn : registry_->get_all_connections()) {
+        unique_conns.insert({conn.source_node, conn.dest_node, conn.source_vc});
+    }
+
+    EXPECT_EQ(unique_conns.size(), 2);
+}
+
+// ============================================================================
+// Test 7: Connection Order Independence
+// ============================================================================
+
+TEST_F(FabricBuilderLocalConnectionsTest, ConnectionOrder_ZFirst) {
+    auto mesh_n = create_mock_mesh_router(RoutingDirection::N, 0, true);
+    auto z_router = create_mock_z_router(100);
+
+    std::map<RoutingDirection, MockRouter*> mesh_routers = {
+        {RoutingDirection::N, &mesh_n}
+    };
+
+    std::map<RoutingDirection, MockRouter*> z_map = {
+        {RoutingDirection::Z, &z_router}
+    };
+
+    // Z first, then mesh
+    establish_local_connections(z_router, mesh_routers);
+    establish_local_connections(mesh_n, z_map);
+
+    EXPECT_EQ(registry_->size(), 2);
+
+    auto z_to_mesh = registry_->get_connections_by_type(ConnectionType::Z_TO_MESH);
+    auto mesh_to_z = registry_->get_connections_by_type(ConnectionType::MESH_TO_Z);
+
+    EXPECT_EQ(z_to_mesh.size(), 1);
+    EXPECT_EQ(mesh_to_z.size(), 1);
+}
+
+TEST_F(FabricBuilderLocalConnectionsTest, ConnectionOrder_MeshFirst) {
+    auto mesh_n = create_mock_mesh_router(RoutingDirection::N, 0, true);
+    auto z_router = create_mock_z_router(100);
+
+    std::map<RoutingDirection, MockRouter*> mesh_routers = {
+        {RoutingDirection::N, &mesh_n}
+    };
+
+    std::map<RoutingDirection, MockRouter*> z_map = {
+        {RoutingDirection::Z, &z_router}
+    };
+
+    // Mesh first, then Z
+    establish_local_connections(mesh_n, z_map);
+    establish_local_connections(z_router, mesh_routers);
+
+    EXPECT_EQ(registry_->size(), 2);
+
+    auto z_to_mesh = registry_->get_connections_by_type(ConnectionType::Z_TO_MESH);
+    auto mesh_to_z = registry_->get_connections_by_type(ConnectionType::MESH_TO_Z);
+
+    EXPECT_EQ(z_to_mesh.size(), 1);
+    EXPECT_EQ(mesh_to_z.size(), 1);
+}

--- a/tests/tt_metal/tt_fabric/fabric_router/test_fabric_builder_local_connections.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_fabric_builder_local_connections.cpp
@@ -98,10 +98,10 @@ protected:
     // Helper to simulate local connection establishment
     void establish_local_connections(MockRouter& source, const std::map<RoutingDirection, MockRouter*>& targets) {
         // Iterate through all sender keys in connection mapping
-        auto all_sender_keys = source.connection_mapping.get_all_sender_keys();
+        auto all_receiver_keys = source.connection_mapping.get_all_receiver_keys();
 
-        for (const auto& key : all_sender_keys) {
-            auto conn_targets = source.connection_mapping.get_downstream_targets(key.vc, key.sender_channel);
+        for (const auto& key : all_receiver_keys) {
+            auto conn_targets = source.connection_mapping.get_downstream_targets(key.vc, key.receiver_channel);
 
             for (const auto& target : conn_targets) {
                 if (target.type == ConnectionType::MESH_TO_Z || target.type == ConnectionType::Z_TO_MESH) {
@@ -120,12 +120,12 @@ protected:
                         .source_direction = source.direction,
                         .source_eth_chan = 0,
                         .source_vc = key.vc,
-                        .source_sender_channel = key.sender_channel,
+                        .source_receiver_channel = key.receiver_channel,
                         .dest_node = dest_router->node_id,
                         .dest_direction = dest_router->direction,
                         .dest_eth_chan = 0,
                         .dest_vc = target.target_vc,
-                        .dest_receiver_channel = 0,
+                        .dest_sender_channel = 0,
                         .connection_type = target.type
                     };
 

--- a/tests/tt_metal/tt_fabric/fabric_router/test_fabric_builder_local_connections.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_fabric_builder_local_connections.cpp
@@ -6,7 +6,7 @@
 #include "tt_metal/fabric/builder/connection_registry.hpp"
 #include "tt_metal/fabric/builder/router_connection_mapping.hpp"
 #include "tt_metal/fabric/fabric_router_channel_mapping.hpp"
-#include "tt_metal/fabric/fabric_context.hpp"
+#include "tt_metal/fabric/fabric_builder_context.hpp"
 #include <tt-metalium/experimental/fabric/mesh_graph.hpp>
 #include <tt-metalium/experimental/fabric/fabric_edm_types.hpp>
 

--- a/tests/tt_metal/tt_fabric/fabric_router/test_router_archetypes.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_router_archetypes.cpp
@@ -1,0 +1,854 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+
+#include "tt_metal/fabric/builder/connection_registry.hpp"
+#include "tt_metal/fabric/builder/router_connection_mapping.hpp"
+#include "tt_metal/fabric/fabric_router_channel_mapping.hpp"
+#include "tt_metal/fabric/fabric_context.hpp"
+
+namespace tt::tt_fabric {
+
+/**
+ * Test fixture for router archetypes and connection manager patterns
+ *
+ * These tests validate that we can create connection manager archetypes
+ * for different router types and verify all connection scenarios:
+ * - Non-Z → Non-Z (INTRA_MESH)
+ * - Non-Z → Z (MESH_TO_Z)
+ * - Z → Non-Z (Z_TO_MESH)
+ * - Full device connection establishment
+ *
+ * Test Coverage Summary:
+ * ┌──────────────────────────────────────────────────────────────────────────────────────┐
+ * │ Category                    │ Test Name                                │ Focus        │
+ * ├─────────────────────────────┼──────────────────────────────────────────┼──────────────┤
+ * │ Archetype Creation          │ CreateMeshRouterArchetype_1D             │ 1D mesh      │
+ * │                             │ CreateMeshRouterArchetype_2D_NoZ         │ 2D mesh      │
+ * │                             │ CreateMeshRouterArchetype_2D_WithZ       │ 2D mesh+Z    │
+ * │                             │ CreateZRouterArchetype                   │ Z router     │
+ * ├─────────────────────────────┼──────────────────────────────────────────┼──────────────┤
+ * │ Connection Establishment    │ EstablishConnection_MeshToMesh           │ Mesh↔Mesh    │
+ * │                             │ EstablishConnection_MeshToZ              │ Mesh→Z       │
+ * │                             │ EstablishConnection_ZToMesh              │ Z→Mesh       │
+ * ├─────────────────────────────┼──────────────────────────────────────────┼──────────────┤
+ * │ Full Device Scenarios       │ FullDevice_4Mesh1Z_AllArchetypes         │ Complete     │
+ * │                             │ FullDevice_4Mesh1Z_AllConnections        │ All conns    │
+ * │                             │ FullDevice_4Mesh1Z_VerifyRegistry        │ Registry     │
+ * ├─────────────────────────────┼──────────────────────────────────────────┼──────────────┤
+ * │ Edge Device Scenarios       │ EdgeDevice_2Mesh1Z_LimitedArchetypes     │ 2 routers    │
+ * │                             │ EdgeDevice_2Mesh1Z_PartialConnections    │ Partial      │
+ * ├─────────────────────────────┼──────────────────────────────────────────┼──────────────┤
+ * │ Archetype Validation        │ ValidateArchetype_ChannelMapping         │ Channels     │
+ * │                             │ ValidateArchetype_ConnectionMapping      │ Connections  │
+ * │                             │ ValidateArchetype_Consistency            │ Consistency  │
+ * └─────────────────────────────┴──────────────────────────────────────────┴──────────────┘
+ *
+ * Total: 15 tests across 5 categories
+ */
+class RouterArchetypesTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        registry_ = std::make_shared<ConnectionRegistry>();
+    }
+
+    void TearDown() override {
+        registry_.reset();
+    }
+
+    std::shared_ptr<ConnectionRegistry> registry_;
+
+    /**
+     * @brief Router archetype encapsulating channel mapping + connection mapping
+     */
+    struct RouterArchetype {
+        FabricRouterChannelMapping channel_mapping;
+        RouterConnectionMapping connection_mapping;
+        FabricNodeId node_id;
+        RoutingDirection direction;
+        uint8_t eth_chan;
+
+        RouterArchetype(
+            FabricRouterChannelMapping ch_map,
+            RouterConnectionMapping conn_map,
+            FabricNodeId node,
+            RoutingDirection dir,
+            uint8_t eth)
+            : channel_mapping(std::move(ch_map)),
+              connection_mapping(std::move(conn_map)),
+              node_id(node),
+              direction(dir),
+              eth_chan(eth) {}
+    };
+
+    /**
+     * @brief Create a mesh router archetype
+     */
+    RouterArchetype create_mesh_router_archetype(
+        Topology topology, RoutingDirection direction, bool has_z, FabricNodeId node_id, uint8_t eth_chan = 0) {
+        // Channel mapping
+        FabricRouterChannelMapping channel_mapping(
+            topology,
+            false,  // no tensix for now
+            RouterVariant::MESH, nullptr);
+
+        // Connection mapping
+        RouterConnectionMapping connection_mapping =
+            RouterConnectionMapping::for_mesh_router(topology, direction, has_z);
+
+        return RouterArchetype(
+            std::move(channel_mapping),
+            std::move(connection_mapping),
+            node_id,
+            direction,
+            eth_chan);
+    }
+
+    /**
+     * @brief Create a Z router archetype
+     */
+    RouterArchetype create_z_router_archetype(
+        FabricNodeId node_id,
+        uint8_t eth_chan = 0) {
+        static auto intermesh_config = IntermeshVCConfig::full_mesh();
+
+        // Channel mapping
+        FabricRouterChannelMapping channel_mapping(
+            Topology::Mesh,
+            false,  // no tensix
+            RouterVariant::Z_ROUTER, &intermesh_config);
+
+        // Connection mapping
+        RouterConnectionMapping connection_mapping = RouterConnectionMapping::for_z_router();
+
+        return RouterArchetype(
+            std::move(channel_mapping),
+            std::move(connection_mapping),
+            node_id,
+            RoutingDirection::Z,
+            eth_chan);
+    }
+
+    /**
+     * @brief Helper to record a connection between two archetypes
+     */
+    void record_archetype_connection(
+        const RouterArchetype& source,
+        uint32_t source_vc,
+        uint32_t source_sender_ch,
+        const RouterArchetype& dest,
+        uint32_t dest_vc,
+        uint32_t dest_receiver_ch,
+        ConnectionType conn_type) {
+        RouterConnectionRecord record{
+            .source_node = source.node_id,
+            .source_direction = source.direction,
+            .source_eth_chan = source.eth_chan,
+            .source_vc = source_vc,
+            .source_sender_channel = source_sender_ch,
+            .dest_node = dest.node_id,
+            .dest_direction = dest.direction,
+            .dest_eth_chan = dest.eth_chan,
+            .dest_vc = dest_vc,
+            .dest_receiver_channel = dest_receiver_ch,
+            .connection_type = conn_type
+        };
+
+        registry_->record_connection(record);
+    }
+};
+
+// ============================================================================
+// Router Archetype Creation Tests
+// ============================================================================
+
+TEST_F(RouterArchetypesTest, CreateMeshRouterArchetype_1D_NoZ) {
+    auto router = create_mesh_router_archetype(
+        Topology::Linear,
+        RoutingDirection::N,
+        false,  // No Z router
+        FabricNodeId(MeshId{0}, 0));
+
+    // Verify channel mapping
+    EXPECT_EQ(router.channel_mapping.get_num_virtual_channels(), 1);
+    EXPECT_FALSE(router.channel_mapping.is_z_router());
+
+    // Verify connection mapping
+    EXPECT_EQ(router.connection_mapping.get_total_sender_count(), 1);
+    EXPECT_TRUE(router.connection_mapping.has_targets(0, 1));
+
+    auto targets = router.connection_mapping.get_downstream_targets(0, 1);
+    ASSERT_EQ(targets.size(), 1);
+    EXPECT_EQ(targets[0].type, ConnectionType::INTRA_MESH);
+}
+
+TEST_F(RouterArchetypesTest, CreateMeshRouterArchetype_2D_WithZ) {
+    auto router = create_mesh_router_archetype(
+        Topology::Mesh,
+        RoutingDirection::E,
+        true,  // Has Z router
+        FabricNodeId(MeshId{0}, 1));
+
+    // Verify channel mapping
+    EXPECT_EQ(router.channel_mapping.get_num_virtual_channels(), 1);
+    EXPECT_FALSE(router.channel_mapping.is_z_router());
+
+    // Verify connection mapping has 4 sender channels (3 INTRA_MESH + 1 MESH_TO_Z)
+    EXPECT_EQ(router.connection_mapping.get_total_sender_count(), 4);
+
+    // Verify MESH_TO_Z connection on channel 4
+    auto z_targets = router.connection_mapping.get_downstream_targets(0, 4);
+    ASSERT_EQ(z_targets.size(), 1);
+    EXPECT_EQ(z_targets[0].type, ConnectionType::MESH_TO_Z);
+    EXPECT_EQ(z_targets[0].target_direction.value(), RoutingDirection::Z);
+}
+
+TEST_F(RouterArchetypesTest, CreateZRouterArchetype) {
+    auto router = create_z_router_archetype(
+        FabricNodeId(MeshId{0}, 100));
+
+    // Verify channel mapping
+    EXPECT_EQ(router.channel_mapping.get_num_virtual_channels(), 2);
+    EXPECT_TRUE(router.channel_mapping.is_z_router());
+
+    // Verify VC1 has 4 sender channels
+    EXPECT_EQ(router.channel_mapping.get_num_sender_channels_for_vc(1), 4);
+
+    // Verify connection mapping has 4 Z_TO_MESH targets
+    EXPECT_EQ(router.connection_mapping.get_total_sender_count(), 4);
+
+    // Verify each channel maps to correct direction
+    std::vector<RoutingDirection> expected_dirs = {
+        RoutingDirection::N,
+        RoutingDirection::E,
+        RoutingDirection::S,
+        RoutingDirection::W
+    };
+
+    for (uint32_t ch = 0; ch < 4; ++ch) {
+        auto targets = router.connection_mapping.get_downstream_targets(1, ch);
+        ASSERT_EQ(targets.size(), 1);
+        EXPECT_EQ(targets[0].type, ConnectionType::Z_TO_MESH);
+        EXPECT_EQ(targets[0].target_direction.value(), expected_dirs[ch]);
+    }
+}
+
+// ============================================================================
+// Non-Z → Non-Z Connection Tests (INTRA_MESH)
+// ============================================================================
+
+TEST_F(RouterArchetypesTest, NonZToNonZ_1D_Bidirectional) {
+    // Create two 1D mesh routers
+    auto north_router = create_mesh_router_archetype(
+        Topology::Linear,
+        RoutingDirection::N,
+        false,
+        FabricNodeId(MeshId{0}, 0));
+
+    auto south_router = create_mesh_router_archetype(
+        Topology::Linear,
+        RoutingDirection::S,
+        false,
+        FabricNodeId(MeshId{0}, 1));
+
+    // North → South connection (driven by connection mapping)
+    auto north_targets = north_router.connection_mapping.get_downstream_targets(0, 1);
+    ASSERT_EQ(north_targets.size(), 1);
+    EXPECT_EQ(north_targets[0].target_direction.value(), RoutingDirection::S);
+
+    record_archetype_connection(
+        north_router, 0, 1,
+        south_router, 0, 0,
+        ConnectionType::INTRA_MESH);
+
+    // South → North connection
+    auto south_targets = south_router.connection_mapping.get_downstream_targets(0, 1);
+    ASSERT_EQ(south_targets.size(), 1);
+    EXPECT_EQ(south_targets[0].target_direction.value(), RoutingDirection::N);
+
+    record_archetype_connection(
+        south_router, 0, 1,
+        north_router, 0, 0,
+        ConnectionType::INTRA_MESH);
+
+    // Verify bidirectional connection
+    EXPECT_EQ(registry_->size(), 2);
+
+    auto intra_mesh = registry_->get_connections_by_type(ConnectionType::INTRA_MESH);
+    EXPECT_EQ(intra_mesh.size(), 2);
+}
+
+TEST_F(RouterArchetypesTest, NonZToNonZ_2D_MultipleDirections) {
+    // Create 4 mesh routers in 2D configuration
+    std::vector<RoutingDirection> directions = {
+        RoutingDirection::N,
+        RoutingDirection::E,
+        RoutingDirection::S,
+        RoutingDirection::W
+    };
+
+    std::vector<RouterArchetype> routers;
+    for (size_t i = 0; i < 4; ++i) {
+        routers.push_back(create_mesh_router_archetype(
+            Topology::Mesh,
+            directions[i],
+            false,  // No Z router
+            FabricNodeId(MeshId{0}, i)));
+    }
+
+    // Each router connects to 3 others (opposite + 2 cross directions)
+    // For simplicity, just verify NORTH router connections
+    auto& north_router = routers[0];
+
+    // NORTH router channel 1 → SOUTH (opposite)
+    auto ch1_targets = north_router.connection_mapping.get_downstream_targets(0, 1);
+    ASSERT_EQ(ch1_targets.size(), 1);
+    EXPECT_EQ(ch1_targets[0].target_direction.value(), RoutingDirection::S);
+
+    record_archetype_connection(
+        north_router, 0, 1,
+        routers[2], 0, 0,  // SOUTH router
+        ConnectionType::INTRA_MESH);
+
+    // NORTH router channels 2-3 → EAST/WEST (cross directions)
+    auto ch2_targets = north_router.connection_mapping.get_downstream_targets(0, 2);
+    auto ch3_targets = north_router.connection_mapping.get_downstream_targets(0, 3);
+
+    ASSERT_EQ(ch2_targets.size(), 1);
+    ASSERT_EQ(ch3_targets.size(), 1);
+
+    // Record cross connections (exact mapping depends on implementation)
+    if (ch2_targets[0].target_direction.value() == RoutingDirection::E) {
+        record_archetype_connection(north_router, 0, 2, routers[1], 0, 0, ConnectionType::INTRA_MESH);
+        record_archetype_connection(north_router, 0, 3, routers[3], 0, 0, ConnectionType::INTRA_MESH);
+    } else {
+        record_archetype_connection(north_router, 0, 2, routers[3], 0, 0, ConnectionType::INTRA_MESH);
+        record_archetype_connection(north_router, 0, 3, routers[1], 0, 0, ConnectionType::INTRA_MESH);
+    }
+
+    // Verify 3 connections from NORTH router
+    auto north_out = registry_->get_connections_by_source_node(north_router.node_id);
+    EXPECT_EQ(north_out.size(), 3);
+}
+
+// ============================================================================
+// Non-Z → Z Connection Tests (MESH_TO_Z)
+// ============================================================================
+
+TEST_F(RouterArchetypesTest, NonZToZ_SingleMeshRouter) {
+    // Create mesh router with Z
+    auto mesh_router = create_mesh_router_archetype(
+        Topology::Mesh,
+        RoutingDirection::N,
+        true,  // Has Z router
+        FabricNodeId(MeshId{0}, 0));
+
+    // Create Z router
+    auto z_router = create_z_router_archetype(
+        FabricNodeId(MeshId{0}, 100));
+
+    // Verify mesh router has MESH_TO_Z target on channel 4
+    auto z_targets = mesh_router.connection_mapping.get_downstream_targets(0, 4);
+    ASSERT_EQ(z_targets.size(), 1);
+    EXPECT_EQ(z_targets[0].type, ConnectionType::MESH_TO_Z);
+    EXPECT_EQ(z_targets[0].target_direction.value(), RoutingDirection::Z);
+
+    // Record MESH_TO_Z connection
+    record_archetype_connection(
+        mesh_router, 0, 4,
+        z_router, 0, 0,
+        ConnectionType::MESH_TO_Z);
+
+    EXPECT_EQ(registry_->size(), 1);
+
+    auto mesh_to_z = registry_->get_connections_by_type(ConnectionType::MESH_TO_Z);
+    EXPECT_EQ(mesh_to_z.size(), 1);
+    EXPECT_EQ(mesh_to_z[0].source_sender_channel, 4);
+    EXPECT_EQ(mesh_to_z[0].dest_direction, RoutingDirection::Z);
+}
+
+TEST_F(RouterArchetypesTest, NonZToZ_FourMeshRouters) {
+    // Create 4 mesh routers, all with Z
+    std::vector<RoutingDirection> directions = {
+        RoutingDirection::N,
+        RoutingDirection::E,
+        RoutingDirection::S,
+        RoutingDirection::W
+    };
+
+    std::vector<RouterArchetype> mesh_routers;
+    for (size_t i = 0; i < 4; ++i) {
+        mesh_routers.push_back(create_mesh_router_archetype(
+            Topology::Mesh,
+            directions[i],
+            true,  // Has Z router
+            FabricNodeId(MeshId{0}, i)));
+    }
+
+    // Create Z router
+    auto z_router = create_z_router_archetype(
+        FabricNodeId(MeshId{0}, 100));
+
+    // Each mesh router connects to Z on channel 4
+    for (auto& mesh_router : mesh_routers) {
+        auto z_targets = mesh_router.connection_mapping.get_downstream_targets(0, 4);
+        ASSERT_EQ(z_targets.size(), 1);
+        EXPECT_EQ(z_targets[0].type, ConnectionType::MESH_TO_Z);
+
+        record_archetype_connection(
+            mesh_router, 0, 4,
+            z_router, 0, 0,
+            ConnectionType::MESH_TO_Z);
+    }
+
+    // Verify 4 MESH_TO_Z connections
+    EXPECT_EQ(registry_->size(), 4);
+
+    auto mesh_to_z = registry_->get_connections_by_type(ConnectionType::MESH_TO_Z);
+    EXPECT_EQ(mesh_to_z.size(), 4);
+
+    // Verify Z router receives from all 4 mesh routers
+    auto z_incoming = registry_->get_connections_by_dest_node(z_router.node_id);
+    EXPECT_EQ(z_incoming.size(), 4);
+
+    // All should target Z router VC0, receiver channel 0 (multi-target receiver)
+    for (const auto& conn : z_incoming) {
+        EXPECT_EQ(conn.dest_vc, 0);
+        EXPECT_EQ(conn.dest_receiver_channel, 0);
+    }
+}
+
+TEST_F(RouterArchetypesTest, NonZToZ_FourMeshRouters_VC1_Connections) {
+    // Test: 4 non-Z routers VC1 → Z router VC1
+    // This tests the reverse direction from Z_TO_MESH
+
+    // Create 4 mesh routers, all with Z
+    std::vector<RoutingDirection> directions = {
+        RoutingDirection::N,
+        RoutingDirection::E,
+        RoutingDirection::S,
+        RoutingDirection::W
+    };
+
+    std::vector<RouterArchetype> mesh_routers;
+    mesh_routers.reserve(4);
+    for (size_t i = 0; i < 4; ++i) {
+        mesh_routers.push_back(create_mesh_router_archetype(
+            Topology::Mesh,
+            directions[i],
+            true,  // Has Z router
+            FabricNodeId(MeshId{0}, i)));
+    }
+
+    // Create Z router
+    auto z_router = create_z_router_archetype(
+        FabricNodeId(MeshId{0}, 100));
+
+    // Each mesh router connects VC1 → Z VC1
+    // Note: Mesh routers have VC1 for receiving from Z, but can also send on VC1
+    for (size_t i = 0; i < 4; ++i) {
+        record_archetype_connection(
+            mesh_routers[i], 1, 0,  // Mesh VC1, sender channel 0
+            z_router, 1, static_cast<uint32_t>(i),  // Z VC1, receiver channel i
+            ConnectionType::MESH_TO_Z);
+    }
+
+    // Verify 4 MESH_TO_Z connections on VC1
+    EXPECT_EQ(registry_->size(), 4);
+
+    auto mesh_to_z = registry_->get_connections_by_type(ConnectionType::MESH_TO_Z);
+    EXPECT_EQ(mesh_to_z.size(), 4);
+
+    // Verify all connections use VC1
+    for (const auto& conn : mesh_to_z) {
+        EXPECT_EQ(conn.source_vc, 1);  // Mesh VC1
+        EXPECT_EQ(conn.dest_vc, 1);    // Z VC1
+    }
+
+    // Verify Z router receives from all 4 mesh routers on VC1
+    auto z_incoming = registry_->get_connections_by_dest_node(z_router.node_id);
+    EXPECT_EQ(z_incoming.size(), 4);
+
+    // Each should target a different Z VC1 receiver channel (0-3)
+    std::set<uint32_t> receiver_channels;
+    for (const auto& conn : z_incoming) {
+        EXPECT_EQ(conn.dest_vc, 1);
+        receiver_channels.insert(conn.dest_receiver_channel);
+    }
+    EXPECT_EQ(receiver_channels.size(), 4);  // All 4 channels used
+}
+
+TEST_F(RouterArchetypesTest, NonZToZ_FiveMeshRouters_VC1_ShouldFail) {
+    // Negative test: 5 non-Z routers VC1 → Z router VC1 should fail
+    // Z router VC1 only has 4 receiver channels (0-3)
+
+    // Create 5 mesh routers
+    std::vector<RouterArchetype> mesh_routers;
+    for (size_t i = 0; i < 5; ++i) {
+        mesh_routers.push_back(create_mesh_router_archetype(
+            Topology::Mesh,
+            RoutingDirection::N,
+            true,
+            FabricNodeId(MeshId{0}, i)));
+    }
+
+    // Create Z router
+    auto z_router = create_z_router_archetype(
+        FabricNodeId(MeshId{0}, 100));
+
+    // Successfully connect first 4 mesh routers to Z VC1 channels 0-3
+    for (size_t i = 0; i < 4; ++i) {
+        record_archetype_connection(
+            mesh_routers[i], 1, 0,
+            z_router, 1, static_cast<uint32_t>(i),
+            ConnectionType::MESH_TO_Z);
+    }
+
+    EXPECT_EQ(registry_->size(), 4);
+
+    // Attempting to connect 5th mesh router should fail
+    // Z router VC1 only has receiver channels 0-3 (4 total)
+    // This would require receiver channel 4, which doesn't exist
+
+    // In a real implementation, this would be caught by:
+    // 1. Channel mapping validation (no receiver channel available)
+    // 2. Connection establishment logic checking available channels
+    // 3. Multi-target receiver capacity limits
+
+    // Verify that Z router VC1 has exactly 4 sender channels (for Z_TO_MESH)
+    EXPECT_EQ(z_router.channel_mapping.get_num_sender_channels_for_vc(1), 4);
+
+    // All 4 sender channels are already mapped to specific directions (N/E/S/W)
+    for (uint32_t ch = 0; ch < 4; ++ch) {
+        auto targets = z_router.connection_mapping.get_downstream_targets(1, ch);
+        EXPECT_EQ(targets.size(), 1);  // Each channel has exactly one target direction
+    }
+
+    // The 5th mesh router would need to send to Z VC1, but:
+    // - Z VC1 only has 1 receiver channel (for multi-target from 4 mesh routers)
+    // - That receiver is already handling 4 connections (at capacity)
+    // - No additional receiver channels exist on Z VC1
+    // In production connection logic, this should be detected and rejected
+}
+
+// ============================================================================
+// Z → Non-Z Connection Tests (Z_TO_MESH)
+// ============================================================================
+
+TEST_F(RouterArchetypesTest, ZToNonZ_SingleMeshRouter) {
+    // Create Z router
+    auto z_router = create_z_router_archetype(
+        FabricNodeId(MeshId{0}, 100));
+
+    // Create mesh router
+    auto mesh_router = create_mesh_router_archetype(
+        Topology::Mesh,
+        RoutingDirection::N,
+        true,
+        FabricNodeId(MeshId{0}, 0));
+
+    // Z router channel 0 → NORTH mesh router
+    auto targets = z_router.connection_mapping.get_downstream_targets(1, 0);
+    ASSERT_EQ(targets.size(), 1);
+    EXPECT_EQ(targets[0].type, ConnectionType::Z_TO_MESH);
+    EXPECT_EQ(targets[0].target_direction.value(), RoutingDirection::N);
+
+    // Record Z_TO_MESH connection (Z VC1 → mesh VC1)
+    record_archetype_connection(
+        z_router, 1, 0,
+        mesh_router, 1, 0,
+        ConnectionType::Z_TO_MESH);
+
+    EXPECT_EQ(registry_->size(), 1);
+
+    auto z_to_mesh = registry_->get_connections_by_type(ConnectionType::Z_TO_MESH);
+    EXPECT_EQ(z_to_mesh.size(), 1);
+    EXPECT_EQ(z_to_mesh[0].source_vc, 1);  // Z router VC1
+    EXPECT_EQ(z_to_mesh[0].dest_vc, 1);    // Mesh router VC1
+}
+
+TEST_F(RouterArchetypesTest, ZToNonZ_FourMeshRouters_AllDirections) {
+    // Create Z router
+    auto z_router = create_z_router_archetype(
+        FabricNodeId(MeshId{0}, 100));
+
+    // Create 4 mesh routers
+    std::vector<RoutingDirection> directions = {
+        RoutingDirection::N,
+        RoutingDirection::E,
+        RoutingDirection::S,
+        RoutingDirection::W
+    };
+
+    std::vector<RouterArchetype> mesh_routers;
+    for (size_t i = 0; i < 4; ++i) {
+        mesh_routers.push_back(create_mesh_router_archetype(
+            Topology::Mesh,
+            directions[i],
+            true,
+            FabricNodeId(MeshId{0}, i)));
+    }
+
+    // Z router connects to all 4 mesh routers via VC1 channels 0-3 → mesh VC1
+    for (uint32_t ch = 0; ch < 4; ++ch) {
+        auto targets = z_router.connection_mapping.get_downstream_targets(1, ch);
+        ASSERT_EQ(targets.size(), 1);
+        EXPECT_EQ(targets[0].type, ConnectionType::Z_TO_MESH);
+        EXPECT_EQ(targets[0].target_direction.value(), directions[ch]);
+
+        record_archetype_connection(
+            z_router, 1, ch,
+            mesh_routers[ch], 1, 0,
+            ConnectionType::Z_TO_MESH);
+    }
+
+    // Verify 4 Z_TO_MESH connections
+    EXPECT_EQ(registry_->size(), 4);
+
+    auto z_to_mesh = registry_->get_connections_by_type(ConnectionType::Z_TO_MESH);
+    EXPECT_EQ(z_to_mesh.size(), 4);
+
+    // Verify Z router sends to all 4 mesh routers
+    auto z_outgoing = registry_->get_connections_by_source_node(z_router.node_id);
+    EXPECT_EQ(z_outgoing.size(), 4);
+
+    // All should use VC1 and different sender channels
+    std::set<uint32_t> sender_channels;
+    for (const auto& conn : z_outgoing) {
+        EXPECT_EQ(conn.source_vc, 1);
+        sender_channels.insert(conn.source_sender_channel);
+    }
+    EXPECT_EQ(sender_channels.size(), 4);  // Channels 0, 1, 2, 3
+}
+
+TEST_F(RouterArchetypesTest, ZToNonZ_EdgeDevice_TwoMeshRouters) {
+    // Edge device: Z router + 2 mesh routers (NORTH and EAST only)
+
+    // Create Z router
+    auto z_router = create_z_router_archetype(
+        FabricNodeId(MeshId{0}, 100));
+
+    // Create 2 mesh routers
+    auto north_router = create_mesh_router_archetype(
+        Topology::Mesh,
+        RoutingDirection::N,
+        true,
+        FabricNodeId(MeshId{0}, 0));
+
+    auto east_router = create_mesh_router_archetype(
+        Topology::Mesh,
+        RoutingDirection::E,
+        true,
+        FabricNodeId(MeshId{0}, 1));
+
+    // Z router has intent for all 4 directions, but only 2 exist
+    std::map<RoutingDirection, RouterArchetype*> existing_routers = {
+        {RoutingDirection::N, &north_router},
+        {RoutingDirection::E, &east_router}
+    };
+
+    // Iterate through all Z router channels, only connect to existing routers
+    for (uint32_t ch = 0; ch < 4; ++ch) {
+        auto targets = z_router.connection_mapping.get_downstream_targets(1, ch);
+        ASSERT_EQ(targets.size(), 1);
+
+        auto target_dir = targets[0].target_direction.value();
+
+        // Only record if target router exists (FabricBuilder connection logic)
+        if (existing_routers.count(target_dir)) {
+            record_archetype_connection(
+                z_router, 1, ch,
+                *existing_routers[target_dir], 1, 0,
+                ConnectionType::Z_TO_MESH);
+        }
+    }
+
+    // Verify only 2 Z_TO_MESH connections (NORTH and EAST)
+    EXPECT_EQ(registry_->size(), 2);
+
+    auto z_to_mesh = registry_->get_connections_by_type(ConnectionType::Z_TO_MESH);
+    EXPECT_EQ(z_to_mesh.size(), 2);
+}
+
+// ============================================================================
+// Full Device Connection Tests
+// ============================================================================
+
+TEST_F(RouterArchetypesTest, FullDevice_4MeshRouters_1ZRouter_AllConnections) {
+    // Create complete device with all connection types
+
+    // Create 4 mesh routers
+    std::vector<RoutingDirection> directions = {
+        RoutingDirection::N,
+        RoutingDirection::E,
+        RoutingDirection::S,
+        RoutingDirection::W
+    };
+
+    std::vector<RouterArchetype> mesh_routers;
+    for (size_t i = 0; i < 4; ++i) {
+        mesh_routers.push_back(create_mesh_router_archetype(
+            Topology::Mesh,
+            directions[i],
+            true,  // Has Z router
+            FabricNodeId(MeshId{0}, i),
+            static_cast<uint8_t>(i)));
+    }
+
+    // Create Z router
+    auto z_router = create_z_router_archetype(
+        FabricNodeId(MeshId{0}, 100));
+
+    // Step 1: MESH_TO_Z connections (4 mesh routers → Z router)
+    for (auto& mesh_router : mesh_routers) {
+        auto z_targets = mesh_router.connection_mapping.get_downstream_targets(0, 4);
+        ASSERT_EQ(z_targets.size(), 1);
+
+        record_archetype_connection(
+            mesh_router, 0, 4,
+            z_router, 0, 0,
+            ConnectionType::MESH_TO_Z);
+    }
+
+    // Step 2: Z_TO_MESH connections (Z router → 4 mesh routers)
+    for (uint32_t ch = 0; ch < 4; ++ch) {
+        auto targets = z_router.connection_mapping.get_downstream_targets(1, ch);
+        ASSERT_EQ(targets.size(), 1);
+
+        record_archetype_connection(
+            z_router, 1, ch,
+            mesh_routers[ch], 1, 0,
+            ConnectionType::Z_TO_MESH);
+    }
+
+    // Verify total connections: 4 MESH_TO_Z + 4 Z_TO_MESH = 8
+    EXPECT_EQ(registry_->size(), 8);
+
+    auto mesh_to_z = registry_->get_connections_by_type(ConnectionType::MESH_TO_Z);
+    auto z_to_mesh = registry_->get_connections_by_type(ConnectionType::Z_TO_MESH);
+
+    EXPECT_EQ(mesh_to_z.size(), 4);
+    EXPECT_EQ(z_to_mesh.size(), 4);
+
+    // Verify Z router connectivity
+    auto z_incoming = registry_->get_connections_by_dest_node(z_router.node_id);
+    auto z_outgoing = registry_->get_connections_by_source_node(z_router.node_id);
+
+    EXPECT_EQ(z_incoming.size(), 4);  // Receives from all 4 mesh routers
+    EXPECT_EQ(z_outgoing.size(), 4);  // Sends to all 4 mesh routers
+
+    // Verify each mesh router has bidirectional Z connection
+    for (const auto& mesh_router : mesh_routers) {
+        auto mesh_out = registry_->get_connections_by_source_node(mesh_router.node_id);
+        auto mesh_in = registry_->get_connections_by_dest_node(mesh_router.node_id);
+
+        // Each mesh router sends to Z (1 MESH_TO_Z)
+        auto mesh_to_z_conns = std::count_if(
+            mesh_out.begin(), mesh_out.end(),
+            [](const auto& c) { return c.connection_type == ConnectionType::MESH_TO_Z; });
+        EXPECT_EQ(mesh_to_z_conns, 1);
+
+        // Each mesh router receives from Z (1 Z_TO_MESH)
+        auto z_to_mesh_conns = std::count_if(
+            mesh_in.begin(), mesh_in.end(),
+            [](const auto& c) { return c.connection_type == ConnectionType::Z_TO_MESH; });
+        EXPECT_EQ(z_to_mesh_conns, 1);
+    }
+}
+
+TEST_F(RouterArchetypesTest, FullDevice_WithINTRA_MESH_And_ZConnections) {
+    // Complete device with INTRA_MESH + MESH_TO_Z + Z_TO_MESH
+
+    // Create 4 mesh routers
+    std::vector<RoutingDirection> directions = {
+        RoutingDirection::N,
+        RoutingDirection::E,
+        RoutingDirection::S,
+        RoutingDirection::W
+    };
+
+    std::vector<RouterArchetype> mesh_routers;
+    for (size_t i = 0; i < 4; ++i) {
+        mesh_routers.push_back(create_mesh_router_archetype(
+            Topology::Mesh,
+            directions[i],
+            true,
+            FabricNodeId(MeshId{0}, i)));
+    }
+
+    // Create Z router
+    auto z_router = create_z_router_archetype(
+        FabricNodeId(MeshId{0}, 100));
+
+    // Step 1: INTRA_MESH connections (simplified - just opposite pairs)
+    // NORTH ↔ SOUTH
+    record_archetype_connection(mesh_routers[0], 0, 1, mesh_routers[2], 0, 0, ConnectionType::INTRA_MESH);
+    record_archetype_connection(mesh_routers[2], 0, 1, mesh_routers[0], 0, 0, ConnectionType::INTRA_MESH);
+
+    // EAST ↔ WEST
+    record_archetype_connection(mesh_routers[1], 0, 1, mesh_routers[3], 0, 0, ConnectionType::INTRA_MESH);
+    record_archetype_connection(mesh_routers[3], 0, 1, mesh_routers[1], 0, 0, ConnectionType::INTRA_MESH);
+
+    // Step 2: MESH_TO_Z connections
+    for (auto& mesh_router : mesh_routers) {
+        record_archetype_connection(mesh_router, 0, 4, z_router, 0, 0, ConnectionType::MESH_TO_Z);
+    }
+
+    // Step 3: Z_TO_MESH connections (Z VC1 → mesh VC1)
+    for (uint32_t ch = 0; ch < 4; ++ch) {
+        record_archetype_connection(z_router, 1, ch, mesh_routers[ch], 1, 0, ConnectionType::Z_TO_MESH);
+    }
+
+    // Verify total: 4 INTRA_MESH + 4 MESH_TO_Z + 4 Z_TO_MESH = 12
+    EXPECT_EQ(registry_->size(), 12);
+
+    auto intra_mesh = registry_->get_connections_by_type(ConnectionType::INTRA_MESH);
+    auto mesh_to_z = registry_->get_connections_by_type(ConnectionType::MESH_TO_Z);
+    auto z_to_mesh = registry_->get_connections_by_type(ConnectionType::Z_TO_MESH);
+
+    EXPECT_EQ(intra_mesh.size(), 4);
+    EXPECT_EQ(mesh_to_z.size(), 4);
+    EXPECT_EQ(z_to_mesh.size(), 4);
+}
+
+TEST_F(RouterArchetypesTest, Archetype_ChannelMapping_ConnectionMapping_Consistency) {
+    // Verify archetype's channel mapping and connection mapping are consistent
+
+    // Test mesh router archetype
+    auto mesh_router = create_mesh_router_archetype(
+        Topology::Mesh,
+        RoutingDirection::N,
+        true,
+        FabricNodeId(MeshId{0}, 0));
+
+    // For each sender channel in channel mapping, verify connection mapping has targets
+    uint32_t num_vcs = mesh_router.channel_mapping.get_num_virtual_channels();
+
+    for (uint32_t vc = 0; vc < num_vcs; ++vc) {
+        uint32_t num_senders = mesh_router.channel_mapping.get_num_sender_channels_for_vc(vc);
+
+        // Connection mapping should have targets for active channels
+        // (Channel 0 is reserved, channels 1-4 are active)
+        for (uint32_t ch = 1; ch <= num_senders && ch <= 4; ++ch) {
+            bool has_targets = mesh_router.connection_mapping.has_targets(vc, ch);
+            EXPECT_TRUE(has_targets)
+                << "VC" << vc << " channel " << ch << " should have connection targets";
+        }
+    }
+
+    // Test Z router archetype
+    auto z_router = create_z_router_archetype(
+        FabricNodeId(MeshId{0}, 100));
+
+    // VC1 should have 4 sender channels with targets
+    uint32_t vc1_senders = z_router.channel_mapping.get_num_sender_channels_for_vc(1);
+    EXPECT_EQ(vc1_senders, 4);
+
+    for (uint32_t ch = 0; ch < vc1_senders; ++ch) {
+        EXPECT_TRUE(z_router.connection_mapping.has_targets(1, ch))
+            << "Z router VC1 channel " << ch << " should have connection targets";
+    }
+}
+
+}  // namespace tt::tt_fabric

--- a/tests/tt_metal/tt_fabric/fabric_router/test_router_archetypes.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_router_archetypes.cpp
@@ -146,12 +146,12 @@ protected:
             .source_direction = source.direction,
             .source_eth_chan = source.eth_chan,
             .source_vc = source_vc,
-            .source_sender_channel = source_sender_ch,
+            .source_receiver_channel = source_sender_ch,
             .dest_node = dest.node_id,
             .dest_direction = dest.direction,
             .dest_eth_chan = dest.eth_chan,
             .dest_vc = dest_vc,
-            .dest_receiver_channel = dest_receiver_ch,
+            .dest_sender_channel = dest_receiver_ch,
             .connection_type = conn_type
         };
 
@@ -364,7 +364,7 @@ TEST_F(RouterArchetypesTest, NonZToZ_SingleMeshRouter) {
 
     auto mesh_to_z = registry_->get_connections_by_type(ConnectionType::MESH_TO_Z);
     EXPECT_EQ(mesh_to_z.size(), 1);
-    EXPECT_EQ(mesh_to_z[0].source_sender_channel, 4);
+    EXPECT_EQ(mesh_to_z[0].source_receiver_channel, 4);
     EXPECT_EQ(mesh_to_z[0].dest_direction, RoutingDirection::Z);
 }
 
@@ -415,7 +415,7 @@ TEST_F(RouterArchetypesTest, NonZToZ_FourMeshRouters) {
     // All should target Z router VC0, receiver channel 0 (multi-target receiver)
     for (const auto& conn : z_incoming) {
         EXPECT_EQ(conn.dest_vc, 0);
-        EXPECT_EQ(conn.dest_receiver_channel, 0);
+        EXPECT_EQ(conn.dest_sender_channel, 0);
     }
 }
 
@@ -474,7 +474,7 @@ TEST_F(RouterArchetypesTest, NonZToZ_FourMeshRouters_VC1_Connections) {
     std::set<uint32_t> receiver_channels;
     for (const auto& conn : z_incoming) {
         EXPECT_EQ(conn.dest_vc, 1);
-        receiver_channels.insert(conn.dest_receiver_channel);
+        receiver_channels.insert(conn.dest_sender_channel);
     }
     EXPECT_EQ(receiver_channels.size(), 4);  // All 4 channels used
 }
@@ -617,7 +617,7 @@ TEST_F(RouterArchetypesTest, ZToNonZ_FourMeshRouters_AllDirections) {
     std::set<uint32_t> sender_channels;
     for (const auto& conn : z_outgoing) {
         EXPECT_EQ(conn.source_vc, 1);
-        sender_channels.insert(conn.source_sender_channel);
+        sender_channels.insert(conn.source_receiver_channel);
     }
     EXPECT_EQ(sender_channels.size(), 4);  // Channels 0, 1, 2, 3
 }

--- a/tests/tt_metal/tt_fabric/fabric_router/test_router_archetypes.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_router_archetypes.cpp
@@ -200,7 +200,7 @@ TEST_F(RouterArchetypesTest, CreateMeshRouterArchetype_2D_WithZ) {
     // Verify MESH_TO_Z target exists in receiver channel 0
     auto all_targets = router.connection_mapping.get_downstream_targets(0, 0);
     ASSERT_EQ(all_targets.size(), 4);
-    
+
     auto z_target_it = std::find_if(all_targets.begin(), all_targets.end(),
         [](const ConnectionTarget& t) { return t.type == ConnectionType::MESH_TO_Z; });
     ASSERT_NE(z_target_it, all_targets.end());
@@ -233,10 +233,9 @@ TEST_F(RouterArchetypesTest, CreateZRouterArchetype) {
     };
 
     for (const auto& expected_dir : expected_dirs) {
-        auto it = std::find_if(targets.begin(), targets.end(),
-            [expected_dir](const ConnectionTarget& t) { 
-                return t.target_direction == expected_dir; 
-            });
+        auto it = std::find_if(targets.begin(), targets.end(), [expected_dir](const ConnectionTarget& t) {
+            return t.target_direction == expected_dir;
+        });
         ASSERT_NE(it, targets.end()) << "Missing direction: " << static_cast<int>(expected_dir);
         EXPECT_EQ(it->type, ConnectionType::Z_TO_MESH);
     }
@@ -313,7 +312,7 @@ TEST_F(RouterArchetypesTest, NonZToNonZ_2D_MultipleDirections) {
     // NORTH router receiver channel 0 has 3 targets
     auto targets = north_router.connection_mapping.get_downstream_targets(0, 0);
     ASSERT_EQ(targets.size(), 3);
-    
+
     // Find SOUTH target (opposite)
     auto south_it = std::find_if(targets.begin(), targets.end(),
         [](const ConnectionTarget& t) { return t.target_direction == RoutingDirection::S; });
@@ -390,7 +389,7 @@ TEST_F(RouterArchetypesTest, NonZToZ_FourMeshRouters) {
     };
 
     std::vector<RouterArchetype> mesh_routers;
-    mesh_routers.reserve(4);    
+    mesh_routers.reserve(4);
     for (size_t i = 0; i < 4; ++i) {
         mesh_routers.push_back(create_mesh_router_archetype(
             Topology::Mesh,
@@ -566,7 +565,7 @@ TEST_F(RouterArchetypesTest, ZToNonZ_SingleMeshRouter) {
     // Z router receiver channel 0 has 4 targets, find NORTH
     auto targets = z_router.connection_mapping.get_downstream_targets(1, 0);
     ASSERT_EQ(targets.size(), 4);
-    
+
     auto north_it = std::find_if(targets.begin(), targets.end(),
         [](const ConnectionTarget& t) { return t.target_direction == RoutingDirection::N; });
     ASSERT_NE(north_it, targets.end());
@@ -854,7 +853,7 @@ TEST_F(RouterArchetypesTest, Archetype_ChannelMapping_ConnectionMapping_Consiste
             // Receiver channel 0 should have targets
             EXPECT_TRUE(mesh_router.connection_mapping.has_targets(vc, 0))
                 << "VC" << vc << " receiver channel 0 should have connection targets";
-            
+
             auto targets = mesh_router.connection_mapping.get_downstream_targets(vc, 0);
             EXPECT_EQ(targets.size(), num_senders)
                 << "VC" << vc << " receiver channel 0 should have " << num_senders << " targets";
@@ -871,7 +870,7 @@ TEST_F(RouterArchetypesTest, Archetype_ChannelMapping_ConnectionMapping_Consiste
 
     EXPECT_TRUE(z_router.connection_mapping.has_targets(1, 0))
         << "Z router VC1 receiver channel 0 should have connection targets";
-    
+
     auto z_targets = z_router.connection_mapping.get_downstream_targets(1, 0);
     EXPECT_EQ(z_targets.size(), vc1_senders)
         << "Z router VC1 receiver channel 0 should have " << vc1_senders << " targets";

--- a/tests/tt_metal/tt_fabric/fabric_router/test_router_channel_mapping.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_router_channel_mapping.cpp
@@ -4,7 +4,7 @@
 
 #include <gtest/gtest.h>
 #include "tt_metal/fabric/fabric_router_channel_mapping.hpp"
-#include "tt_metal/fabric/fabric_context.hpp"
+#include "tt_metal/fabric/fabric_builder_context.hpp"
 #include <tt-metalium/experimental/fabric/fabric_edm_types.hpp>
 #include <hostdevcommon/fabric_common.h>
 

--- a/tests/tt_metal/tt_fabric/fabric_router/test_router_channel_mapping.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_router_channel_mapping.cpp
@@ -1,0 +1,539 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+#include "tt_metal/fabric/fabric_router_channel_mapping.hpp"
+#include "tt_metal/fabric/fabric_context.hpp"
+#include <tt-metalium/experimental/fabric/fabric_edm_types.hpp>
+#include <hostdevcommon/fabric_common.h>
+
+namespace tt::tt_fabric {
+
+/**
+ * Test fixture for FabricRouterChannelMapping
+ *
+ * These tests validate channel mapping functionality:
+ * - RouterVariant enum support (MESH vs Z_ROUTER)
+ * - VC1 channel mapping for Z routers
+ * - VC1 channel mapping for standard mesh routers
+ * - Correct virtual channel counts
+ * - Correct sender channel counts per VC
+ *
+ * Test Coverage Summary:
+ * ┌──────────────────────────────────────────────────────────────────────────────────────┐
+ * │ Category                    │ Test Name                                │ Focus        │
+ * ├─────────────────────────────┼──────────────────────────────────────────┼──────────────┤
+ * │ Basic Mesh (Regression)     │ MeshRouter_1D_Linear_VC0Only             │ 1D VC0       │
+ * │                             │ MeshRouter_2D_Mesh_VC0Only               │ 2D VC0       │
+ * │                             │ MeshRouter_2D_Torus_VC0Only              │ Torus VC0    │
+ * │                             │ MeshRouter_Ring_VC0Only                  │ Ring VC0     │
+ * ├─────────────────────────────┼──────────────────────────────────────────┼──────────────┤
+ * │ Z Router                    │ ZRouter_HasTwoVCs                        │ 2 VCs        │
+ * │                             │ ZRouter_VC0_FourSenderChannels           │ VC0 channels │
+ * │                             │ ZRouter_VC1_FourSenderChannels           │ VC1 channels │
+ * │                             │ ZRouter_VC0_OneReceiverChannel           │ VC0 receiver │
+ * │                             │ ZRouter_VC1_OneReceiverChannel           │ VC1 receiver │
+ * │                             │ ZRouter_AllChannelsMapped                │ All mapped   │
+ * ├─────────────────────────────┼──────────────────────────────────────────┼──────────────┤
+ * │ Mesh with Intermesh VC      │ MeshRouter_WithIntermeshVC_HasVC1        │ VC1 enabled  │
+ * │                             │ MeshRouter_WithIntermeshVC_VC1Senders    │ VC1 senders  │
+ * │                             │ MeshRouter_WithIntermeshVC_VC1Receiver   │ VC1 receiver │
+ * ├─────────────────────────────┼──────────────────────────────────────────┼──────────────┤
+ * │ Variant Detection           │ VariantDetection_MeshRouter              │ MESH variant │
+ * │                             │ VariantDetection_ZRouter                 │ Z variant    │
+ * ├─────────────────────────────┼──────────────────────────────────────────┼──────────────┤
+ * │ Channel Count Queries       │ ChannelCount_GetNumVirtualChannels       │ VC count     │
+ * │                             │ ChannelCount_GetNumSendersPerVC          │ Sender count │
+ * │                             │ ChannelCount_TotalSenderChannels         │ Total        │
+ * ├─────────────────────────────┼──────────────────────────────────────────┼──────────────┤
+ * │ Mapping Retrieval           │ MappingRetrieval_GetSenderMapping        │ Sender map   │
+ * │                             │ MappingRetrieval_GetReceiverMapping      │ Receiver map │
+ * │                             │ MappingRetrieval_GetAllSenderMappings    │ All senders  │
+ * ├─────────────────────────────┼──────────────────────────────────────────┼──────────────┤
+ * │ Edge Cases                  │ EdgeCase_InvalidVCQuery                  │ Invalid VC   │
+ * │                             │ EdgeCase_InvalidChannelQuery             │ Invalid ch   │
+ * │                             │ EdgeCase_EmptyMapping                    │ Empty        │
+ * ├─────────────────────────────┼──────────────────────────────────────────┼──────────────┤
+ * │ Intermesh Config            │ IntermeshConfig_EdgeOnly                 │ Edge only    │
+ * │                             │ IntermeshConfig_FullMesh                 │ Full mesh    │
+ * │                             │ IntermeshConfig_Disabled                 │ Disabled     │
+ * │                             │ IntermeshConfig_ZIntermesh_4Channels     │ Z 4 channels │
+ * │                             │ IntermeshConfig_XYIntermesh_3Channels    │ XY 3 channels│
+ * └─────────────────────────────┴──────────────────────────────────────────┴──────────────┘
+ *
+ * Total: 31 tests across 8 categories
+ */
+class RouterChannelMappingTest : public ::testing::Test {
+protected:
+    void SetUp() override {}
+    void TearDown() override {}
+};
+
+// ============ Basic Mesh Router Tests (Regression) ============
+
+TEST_F(RouterChannelMappingTest, MeshRouter_1D_Linear_VC0Only) {
+    FabricRouterChannelMapping mapping(
+        Topology::Linear,
+        false,  // no tensix
+        RouterVariant::MESH,
+        nullptr);  // no intermesh config
+
+    // 1D routers only have VC0
+    EXPECT_EQ(mapping.get_num_virtual_channels(), 1);
+
+    // VC0 has 2 sender channels in 1D
+    EXPECT_EQ(mapping.get_num_sender_channels_for_vc(0), 2);
+
+    // VC1 should have 0 channels in 1D
+    EXPECT_EQ(mapping.get_num_sender_channels_for_vc(1), 0);
+
+    // Verify VC0 mappings
+    auto vc0_ch0 = mapping.get_sender_mapping(0, 0);
+    EXPECT_EQ(vc0_ch0.builder_type, BuilderType::ERISC);
+    EXPECT_EQ(vc0_ch0.internal_sender_channel_id, 0);
+
+    auto vc0_ch1 = mapping.get_sender_mapping(0, 1);
+    EXPECT_EQ(vc0_ch1.builder_type, BuilderType::ERISC);
+    EXPECT_EQ(vc0_ch1.internal_sender_channel_id, 1);
+}
+
+TEST_F(RouterChannelMappingTest, MeshRouter_2D_Mesh_VC0Only) {
+    FabricRouterChannelMapping mapping(
+        Topology::Mesh,
+        false,  // no tensix
+        RouterVariant::MESH,
+        nullptr);  // no intermesh config
+
+    // 2D mesh routers currently only expose VC0 (VC1 not fully enabled yet)
+    EXPECT_EQ(mapping.get_num_virtual_channels(), 1);
+
+    // VC0 has 4 sender channels in 2D
+    EXPECT_EQ(mapping.get_num_sender_channels_for_vc(0), 4);
+
+    // Verify all 4 VC0 channels map correctly
+    for (uint32_t i = 0; i < 4; ++i) {
+        auto mapping_result = mapping.get_sender_mapping(0, i);
+        EXPECT_EQ(mapping_result.builder_type, BuilderType::ERISC);
+        EXPECT_EQ(mapping_result.internal_sender_channel_id, i);
+    }
+}
+
+TEST_F(RouterChannelMappingTest, MeshRouter_2D_Torus_VC0Only) {
+    FabricRouterChannelMapping mapping(
+        Topology::Torus,
+        false,  // no tensix
+        RouterVariant::MESH,
+        nullptr);  // no intermesh config
+
+    EXPECT_EQ(mapping.get_num_virtual_channels(), 1);
+    EXPECT_EQ(mapping.get_num_sender_channels_for_vc(0), 4);
+}
+
+// ============ Z Router Tests (New Functionality) ============
+
+TEST_F(RouterChannelMappingTest, ZRouter_Has2VirtualChannels) {
+    auto intermesh_config = IntermeshVCConfig::full_mesh();
+    FabricRouterChannelMapping mapping(
+        Topology::Mesh,  // Z routers use 2D topology
+        false,  // no tensix
+        RouterVariant::Z_ROUTER,
+        &intermesh_config);  // Z routers require intermesh config
+
+    // Z routers have both VC0 and VC1
+    EXPECT_EQ(mapping.get_num_virtual_channels(), 2);
+}
+
+TEST_F(RouterChannelMappingTest, ZRouter_VC0_Has4SenderChannels) {
+    auto intermesh_config = IntermeshVCConfig::full_mesh();
+    FabricRouterChannelMapping mapping(
+        Topology::Mesh,
+        false,
+        RouterVariant::Z_ROUTER,
+        &intermesh_config);  // Z routers require intermesh config
+
+    // VC0 should have 4 sender channels (same as 2D mesh)
+    EXPECT_EQ(mapping.get_num_sender_channels_for_vc(0), 4);
+
+    // Verify VC0 channels map to erisc 0-3
+    for (uint32_t i = 0; i < 4; ++i) {
+        auto mapping_result = mapping.get_sender_mapping(0, i);
+        EXPECT_EQ(mapping_result.builder_type, BuilderType::ERISC);
+        EXPECT_EQ(mapping_result.internal_sender_channel_id, i);
+    }
+}
+
+TEST_F(RouterChannelMappingTest, ZRouter_VC1_Has4SenderChannels) {
+    auto intermesh_config = IntermeshVCConfig::full_mesh();
+    FabricRouterChannelMapping mapping(
+        Topology::Mesh,
+        false,
+        RouterVariant::Z_ROUTER,
+        &intermesh_config);  // Z routers require intermesh config
+
+    // VC1 should have 4 sender channels (Z→mesh, one per direction)
+    EXPECT_EQ(mapping.get_num_sender_channels_for_vc(1), 4);
+}
+
+TEST_F(RouterChannelMappingTest, ZRouter_VC1_SenderChannels_MapToErisc4Through7) {
+    auto intermesh_config = IntermeshVCConfig::full_mesh();
+    FabricRouterChannelMapping mapping(
+        Topology::Mesh,
+        false,
+        RouterVariant::Z_ROUTER,
+        &intermesh_config);  // Z routers require intermesh config
+
+    // VC1 sender channels 0-3 should map to erisc internal channels 4-7
+    for (uint32_t i = 0; i < 4; ++i) {
+        auto mapping_result = mapping.get_sender_mapping(1, i);
+        EXPECT_EQ(mapping_result.builder_type, BuilderType::ERISC);
+        EXPECT_EQ(mapping_result.internal_sender_channel_id, 4 + i);
+    }
+}
+
+TEST_F(RouterChannelMappingTest, ZRouterNoTensix_VC0_VC1_ReceiverChannel_MapsToErisc) {
+    auto intermesh_config = IntermeshVCConfig::full_mesh();
+    FabricRouterChannelMapping mapping(
+        Topology::Mesh,
+        false,
+        RouterVariant::Z_ROUTER,
+        &intermesh_config);  // Z routers require intermesh config
+
+
+    EXPECT_EQ(mapping.get_num_virtual_channels(), 2);
+    EXPECT_EQ(mapping.get_num_sender_channels_for_vc(0), 4);
+    EXPECT_EQ(mapping.get_num_sender_channels_for_vc(1), 4);
+
+    // VC0 receiver channel should still map to erisc receiver 0
+    for (auto vc = 0; vc < 2; ++vc) {
+        auto vc_r = mapping.get_receiver_mapping(vc, 0);
+        EXPECT_EQ(vc_r.builder_type, BuilderType::ERISC);
+        EXPECT_EQ(vc_r.internal_receiver_channel_id, vc);
+    }
+}
+
+
+// ============ Mesh Router with Tensix Extension ============
+
+TEST_F(RouterChannelMappingTest, MeshRouter_WithTensix_VC0_MapsToTensix) {
+    FabricRouterChannelMapping mapping(
+        Topology::Mesh,
+        true,  // has tensix
+        RouterVariant::MESH,
+        nullptr);  // no intermesh config
+
+    // With tensix extension, VC0 channels should map to TENSIX builder
+    for (uint32_t i = 0; i < 4; ++i) {
+        auto mapping_result = mapping.get_sender_mapping(0, i);
+        EXPECT_EQ(mapping_result.builder_type, BuilderType::TENSIX);
+        EXPECT_EQ(mapping_result.internal_sender_channel_id, i);
+    }
+
+    // Receiver should still be ERISC
+    auto receiver_mapping = mapping.get_receiver_mapping(0, 0);
+    EXPECT_EQ(receiver_mapping.builder_type, BuilderType::ERISC);
+}
+
+// ============ Standard Mesh Router VC1 with IntermeshVCConfig ============
+
+TEST_F(RouterChannelMappingTest, MeshRouter_2D_VC1_WithoutIntermesh) {
+    // Without intermesh config, VC1 should not be created
+    FabricRouterChannelMapping mapping(
+        Topology::Mesh,
+        false,
+        RouterVariant::MESH,
+        nullptr);  // No intermesh config
+
+    EXPECT_EQ(mapping.get_num_virtual_channels(), 1);  // Only VC0
+    EXPECT_EQ(mapping.get_num_sender_channels_for_vc(1), 0);  // VC1 not created
+}
+
+TEST_F(RouterChannelMappingTest, MeshRouter_2D_VC1_WithIntermeshEdgeOnly) {
+    // With intermesh config (edge only), VC1 should be created
+    auto intermesh_config = IntermeshVCConfig::edge_only();
+    FabricRouterChannelMapping mapping(
+        Topology::Mesh,
+        false,
+        RouterVariant::MESH,
+        &intermesh_config);
+
+    EXPECT_EQ(mapping.get_num_virtual_channels(), 2);  // VC0 + VC1
+    EXPECT_EQ(mapping.get_num_sender_channels_for_vc(1), 3);  // VC1 created
+
+    // Verify VC1 mappings exist
+    auto vc1_ch0 = mapping.get_sender_mapping(1, 0);
+    EXPECT_EQ(vc1_ch0.builder_type, BuilderType::ERISC);
+    EXPECT_EQ(vc1_ch0.internal_sender_channel_id, 4);  // After VC0 channels 0-3
+}
+
+TEST_F(RouterChannelMappingTest, MeshRouter_2D_VC1_WithIntermeshFullMesh) {
+    // With intermesh config (full mesh), VC1 should be created
+    auto intermesh_config = IntermeshVCConfig::full_mesh();
+    FabricRouterChannelMapping mapping(
+        Topology::Mesh,
+        false,
+        RouterVariant::MESH,
+        &intermesh_config);
+
+    EXPECT_EQ(mapping.get_num_virtual_channels(), 2);  // VC0 + VC1
+    EXPECT_EQ(mapping.get_num_sender_channels_for_vc(1), 3);  // VC1 created
+}
+
+TEST_F(RouterChannelMappingTest, MeshRouter_2D_VC1_WithIntermeshFullMeshPassThrough) {
+    // With intermesh config (full mesh with pass-through), VC1 should be created
+    auto intermesh_config = IntermeshVCConfig::full_mesh_with_pass_through();
+    FabricRouterChannelMapping mapping(
+        Topology::Mesh,
+        false,
+        RouterVariant::MESH,
+        &intermesh_config);
+
+    EXPECT_EQ(mapping.get_num_virtual_channels(), 2);  // VC0 + VC1
+    EXPECT_EQ(mapping.get_num_sender_channels_for_vc(1), 3);  // VC1 created
+    // All modes that require VC1 create the same mappings
+}
+
+// ============ IntermeshVCConfig Tests ============
+
+TEST_F(RouterChannelMappingTest, IntermeshVCConfig_Disabled) {
+    auto config = IntermeshVCConfig::disabled();
+    EXPECT_EQ(config.mode, IntermeshVCMode::DISABLED);
+    EXPECT_FALSE(config.requires_vc1);
+    EXPECT_FALSE(config.requires_vc1_full_mesh);
+    EXPECT_FALSE(config.requires_vc1_mesh_pass_through);
+}
+
+TEST_F(RouterChannelMappingTest, IntermeshVCConfig_EdgeOnly) {
+    auto config = IntermeshVCConfig::edge_only();
+    EXPECT_EQ(config.mode, IntermeshVCMode::EDGE_ONLY);
+    EXPECT_TRUE(config.requires_vc1);
+    EXPECT_FALSE(config.requires_vc1_full_mesh);
+    EXPECT_FALSE(config.requires_vc1_mesh_pass_through);
+}
+
+TEST_F(RouterChannelMappingTest, IntermeshVCConfig_FullMesh) {
+    auto config = IntermeshVCConfig::full_mesh();
+    EXPECT_EQ(config.mode, IntermeshVCMode::FULL_MESH);
+    EXPECT_TRUE(config.requires_vc1);
+    EXPECT_TRUE(config.requires_vc1_full_mesh);
+    EXPECT_FALSE(config.requires_vc1_mesh_pass_through);
+}
+
+TEST_F(RouterChannelMappingTest, IntermeshVCConfig_FullMeshWithPassThrough) {
+    auto config = IntermeshVCConfig::full_mesh_with_pass_through();
+    EXPECT_EQ(config.mode, IntermeshVCMode::FULL_MESH_WITH_PASS_THROUGH);
+    EXPECT_TRUE(config.requires_vc1);
+    EXPECT_TRUE(config.requires_vc1_full_mesh);
+    EXPECT_TRUE(config.requires_vc1_mesh_pass_through);
+}
+
+TEST_F(RouterChannelMappingTest, IntermeshVCConfig_DefaultInitialization) {
+    IntermeshVCConfig config;
+    EXPECT_EQ(config.mode, IntermeshVCMode::DISABLED);
+    EXPECT_FALSE(config.requires_vc1);
+    EXPECT_FALSE(config.requires_vc1_full_mesh);
+    EXPECT_FALSE(config.requires_vc1_mesh_pass_through);
+}
+
+// ============ IntermeshVCConfig Mode Comparison Tests ============
+
+TEST_F(RouterChannelMappingTest, IntermeshVCConfig_AllModesCreateVC1WhenRequired) {
+    // All three intermesh modes should enable VC1
+    std::vector<IntermeshVCConfig> configs = {
+        IntermeshVCConfig::edge_only(),
+        IntermeshVCConfig::full_mesh(),
+        IntermeshVCConfig::full_mesh_with_pass_through()
+    };
+
+    for (const auto& config : configs) {
+        FabricRouterChannelMapping mapping(
+            Topology::Mesh,
+            false,
+            RouterVariant::MESH,
+            &config);
+
+        EXPECT_EQ(mapping.get_num_virtual_channels(), 2)
+            << "Mode " << static_cast<int>(config.mode) << " should enable VC1";
+        EXPECT_EQ(mapping.get_num_sender_channels_for_vc(1), 3)
+            << "Mode " << static_cast<int>(config.mode) << " should have 3 VC1 channels";
+    }
+}
+
+TEST_F(RouterChannelMappingTest, IntermeshVCConfig_EdgeOnly_FlagsCorrect) {
+    auto config = IntermeshVCConfig::edge_only();
+
+    // EDGE_ONLY: VC1 enabled, but not full mesh, not pass-through
+    EXPECT_TRUE(config.requires_vc1) << "EDGE_ONLY requires VC1";
+    EXPECT_FALSE(config.requires_vc1_full_mesh) << "EDGE_ONLY does not require full mesh";
+    EXPECT_FALSE(config.requires_vc1_mesh_pass_through) << "EDGE_ONLY does not support pass-through";
+}
+
+TEST_F(RouterChannelMappingTest, IntermeshVCConfig_FullMesh_FlagsCorrect) {
+    auto config = IntermeshVCConfig::full_mesh();
+
+    // FULL_MESH: VC1 enabled throughout mesh, but not pass-through
+    EXPECT_TRUE(config.requires_vc1) << "FULL_MESH requires VC1";
+    EXPECT_TRUE(config.requires_vc1_full_mesh) << "FULL_MESH requires VC1 throughout mesh";
+    EXPECT_FALSE(config.requires_vc1_mesh_pass_through) << "FULL_MESH does not support inter-mesh pass-through";
+}
+
+TEST_F(RouterChannelMappingTest, IntermeshVCConfig_FullMeshWithPassThrough_FlagsCorrect) {
+    auto config = IntermeshVCConfig::full_mesh_with_pass_through();
+
+    // FULL_MESH_WITH_PASS_THROUGH: All flags enabled
+    EXPECT_TRUE(config.requires_vc1) << "FULL_MESH_WITH_PASS_THROUGH requires VC1";
+    EXPECT_TRUE(config.requires_vc1_full_mesh) << "FULL_MESH_WITH_PASS_THROUGH requires VC1 throughout mesh";
+    EXPECT_TRUE(config.requires_vc1_mesh_pass_through) << "FULL_MESH_WITH_PASS_THROUGH supports inter-mesh pass-through";
+}
+
+TEST_F(RouterChannelMappingTest, IntermeshVCConfig_ModeProgression) {
+    // Verify that modes form a logical progression in capabilities
+    auto disabled = IntermeshVCConfig::disabled();
+    auto edge_only = IntermeshVCConfig::edge_only();
+    auto full_mesh = IntermeshVCConfig::full_mesh();
+    auto full_mesh_pass = IntermeshVCConfig::full_mesh_with_pass_through();
+
+    // DISABLED: No VC1
+    EXPECT_FALSE(disabled.requires_vc1);
+
+    // EDGE_ONLY: VC1 on edges only
+    EXPECT_TRUE(edge_only.requires_vc1);
+    EXPECT_FALSE(edge_only.requires_vc1_full_mesh);
+
+    // FULL_MESH: VC1 throughout mesh (superset of EDGE_ONLY)
+    EXPECT_TRUE(full_mesh.requires_vc1);
+    EXPECT_TRUE(full_mesh.requires_vc1_full_mesh);
+    EXPECT_FALSE(full_mesh.requires_vc1_mesh_pass_through);
+
+    // FULL_MESH_WITH_PASS_THROUGH: All capabilities (superset of FULL_MESH)
+    EXPECT_TRUE(full_mesh_pass.requires_vc1);
+    EXPECT_TRUE(full_mesh_pass.requires_vc1_full_mesh);
+    EXPECT_TRUE(full_mesh_pass.requires_vc1_mesh_pass_through);
+}
+
+// ============ Error Cases ============
+
+TEST_F(RouterChannelMappingTest, InvalidVC_ThrowsError) {
+    FabricRouterChannelMapping mapping(
+        Topology::Mesh,
+        false,
+        RouterVariant::MESH,
+        nullptr);
+
+    // Accessing invalid VC should throw
+    EXPECT_THROW(mapping.get_sender_mapping(5, 0), std::exception);
+}
+
+TEST_F(RouterChannelMappingTest, InvalidSenderChannel_ThrowsError) {
+    FabricRouterChannelMapping mapping(
+        Topology::Mesh,
+        false,
+        RouterVariant::MESH,
+        nullptr);
+
+    // Accessing out-of-range sender channel should throw
+    EXPECT_THROW(mapping.get_sender_mapping(0, 10), std::exception);
+}
+
+TEST_F(RouterChannelMappingTest, InvalidReceiverChannel_ThrowsError) {
+    auto intermesh_config = IntermeshVCConfig::full_mesh();
+    FabricRouterChannelMapping mapping(
+        Topology::Mesh,
+        false,
+        RouterVariant::Z_ROUTER,
+        &intermesh_config);
+
+    // Accessing invalid receiver channel should throw
+    EXPECT_THROW(mapping.get_receiver_mapping(1, 5), std::exception);
+}
+
+// ============ Comprehensive Z Router Scenario ============
+
+TEST_F(RouterChannelMappingTest, ZRouter_CompleteChannelLayout) {
+    auto intermesh_config = IntermeshVCConfig::full_mesh();
+    FabricRouterChannelMapping mapping(
+        Topology::Mesh,
+        false,
+        RouterVariant::Z_ROUTER,
+        &intermesh_config);
+
+    // Verify complete channel layout for Z router
+
+    // VC0: 4 sender channels → erisc 0-3
+    EXPECT_EQ(mapping.get_num_sender_channels_for_vc(0), 4);
+    for (uint32_t i = 0; i < 4; ++i) {
+        auto s = mapping.get_sender_mapping(0, i);
+        EXPECT_EQ(s.builder_type, BuilderType::ERISC);
+        EXPECT_EQ(s.internal_sender_channel_id, i);
+    }
+
+    // VC0: 1 receiver channel → erisc 0
+    auto vc0_r = mapping.get_receiver_mapping(0, 0);
+    EXPECT_EQ(vc0_r.builder_type, BuilderType::ERISC);
+    EXPECT_EQ(vc0_r.internal_receiver_channel_id, 0);
+
+    // VC1: 4 sender channels → erisc 4-7
+    EXPECT_EQ(mapping.get_num_sender_channels_for_vc(1), 4);
+    for (uint32_t i = 0; i < 4; ++i) {
+        auto s = mapping.get_sender_mapping(1, i);
+        EXPECT_EQ(s.builder_type, BuilderType::ERISC);
+        EXPECT_EQ(s.internal_sender_channel_id, 4 + i);
+    }
+
+    // VC1: 1 receiver channel → erisc 1
+    auto vc1_r = mapping.get_receiver_mapping(1, 0);
+    EXPECT_EQ(vc1_r.builder_type, BuilderType::ERISC);
+    EXPECT_EQ(vc1_r.internal_receiver_channel_id, 1);
+
+    // Total: 8 sender channels, 2 receiver channels
+    EXPECT_EQ(mapping.get_num_virtual_channels(), 2);
+}
+
+// ============ get_all_sender_mappings Tests ============
+
+TEST_F(RouterChannelMappingTest, GetAllSenderMappings_MeshRouter) {
+    FabricRouterChannelMapping mapping(
+        Topology::Mesh,
+        false,
+        RouterVariant::MESH,
+        nullptr);
+
+    auto all_mappings = mapping.get_all_sender_mappings();
+
+    // Mesh router with VC0 only: 4 channels
+    EXPECT_EQ(all_mappings.size(), 4);
+
+    // Verify they're in order
+    for (size_t i = 0; i < 4; ++i) {
+        EXPECT_EQ(all_mappings[i].builder_type, BuilderType::ERISC);
+        EXPECT_EQ(all_mappings[i].internal_sender_channel_id, i);
+    }
+}
+
+TEST_F(RouterChannelMappingTest, GetAllSenderMappings_ZRouter) {
+    auto intermesh_config = IntermeshVCConfig::full_mesh();
+    FabricRouterChannelMapping mapping(
+        Topology::Mesh,
+        false,
+        RouterVariant::Z_ROUTER,
+        &intermesh_config);
+
+    auto all_mappings = mapping.get_all_sender_mappings();
+
+    // Z router: VC0 (4 channels) + VC1 (4 channels) = 8 total
+    EXPECT_EQ(all_mappings.size(), 8);
+
+    // First 4 should be VC0 → erisc 0-3
+    for (size_t i = 0; i < 4; ++i) {
+        EXPECT_EQ(all_mappings[i].builder_type, BuilderType::ERISC);
+        EXPECT_EQ(all_mappings[i].internal_sender_channel_id, i);
+    }
+
+    // Next 4 should be VC1 → erisc 4-7
+    for (size_t i = 0; i < 4; ++i) {
+        EXPECT_EQ(all_mappings[4 + i].builder_type, BuilderType::ERISC);
+        EXPECT_EQ(all_mappings[4 + i].internal_sender_channel_id, 4 + i);
+    }
+}
+
+}  // namespace tt::tt_fabric

--- a/tests/tt_metal/tt_fabric/fabric_router/test_router_connection_mapping.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_router_connection_mapping.cpp
@@ -103,7 +103,7 @@ TEST_F(RouterConnectionMappingTest, GetAllSenderKeys_ReturnsCorrectKeys) {
     // Verify the key is VC1, channel 0
     EXPECT_EQ(keys[0].vc, 1);
     EXPECT_EQ(keys[0].receiver_channel, 0);
-    
+
     // Verify it has 4 downstream targets
     auto targets = mapping.get_downstream_targets(1, 0);
     EXPECT_EQ(targets.size(), 4);
@@ -136,7 +136,7 @@ TEST_F(RouterConnectionMappingTest, MeshRouter_1D_WithZ_TwoConnections) {
     // Receiver channel 0 has 2 targets: INTRA_MESH (WEST) + MESH_TO_Z
     auto targets = mapping.get_downstream_targets(0, 0);
     ASSERT_EQ(targets.size(), 2);
-    
+
     // Find INTRA_MESH target
     auto intra_mesh_it = std::find_if(targets.begin(), targets.end(),
         [](const ConnectionTarget& t) { return t.type == ConnectionType::INTRA_MESH; });
@@ -241,7 +241,7 @@ TEST_F(RouterConnectionMappingTest, MeshRouter_2D_EastRouter_CorrectDirections) 
     // EAST router receiver channel 0 should have 3 targets: WEST (opposite), NORTH, SOUTH
     auto targets = mapping.get_downstream_targets(0, 0);
     ASSERT_EQ(targets.size(), 3);
-    
+
     // Find each expected direction
     auto west_it = std::find_if(targets.begin(), targets.end(),
         [](const ConnectionTarget& t) { return t.target_direction == RoutingDirection::W; });
@@ -249,11 +249,11 @@ TEST_F(RouterConnectionMappingTest, MeshRouter_2D_EastRouter_CorrectDirections) 
         [](const ConnectionTarget& t) { return t.target_direction == RoutingDirection::N; });
     auto south_it = std::find_if(targets.begin(), targets.end(),
         [](const ConnectionTarget& t) { return t.target_direction == RoutingDirection::S; });
-    
+
     ASSERT_NE(west_it, targets.end());
     ASSERT_NE(north_it, targets.end());
     ASSERT_NE(south_it, targets.end());
-    
+
     // Verify all are INTRA_MESH to VC0
     for (const auto& target : targets) {
         verify_target(target, ConnectionType::INTRA_MESH, 0);
@@ -295,10 +295,9 @@ TEST_F(RouterConnectionMappingTest, ZRouter_VC1_CorrectDirectionMapping) {
     };
 
     for (const auto& expected_dir : expected_directions) {
-        auto it = std::find_if(targets.begin(), targets.end(),
-            [expected_dir](const ConnectionTarget& t) { 
-                return t.target_direction == expected_dir; 
-            });
+        auto it = std::find_if(targets.begin(), targets.end(), [expected_dir](const ConnectionTarget& t) {
+            return t.target_direction == expected_dir;
+        });
         ASSERT_NE(it, targets.end()) << "Missing direction: " << static_cast<int>(expected_dir);
         verify_target(*it, ConnectionType::Z_TO_MESH, 1, expected_dir);
     }
@@ -310,7 +309,7 @@ TEST_F(RouterConnectionMappingTest, ZRouter_AllTargets_SameVC) {
     // All Z router VC1 targets should go to mesh router VC1
     auto targets = mapping.get_downstream_targets(1, 0);
     ASSERT_EQ(targets.size(), 4);
-    
+
     for (const auto& target : targets) {
         EXPECT_EQ(target.target_vc, 1);  // Z VC1 → mesh VC1
         EXPECT_EQ(target.type, ConnectionType::Z_TO_MESH);

--- a/tests/tt_metal/tt_fabric/fabric_router/test_router_connection_mapping.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_router_connection_mapping.cpp
@@ -1,0 +1,507 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+
+#include "tt_metal/fabric/builder/router_connection_mapping.hpp"
+
+using namespace tt::tt_fabric;
+
+/**
+ * RouterConnectionMapping Tests
+ *
+ * These tests validate connection mapping functionality:
+ * - Factory methods for mesh and Z routers
+ * - Downstream target specifications
+ * - Connection type assignments
+ * - Direction-based routing
+ * - VC assignments for different connection types
+ *
+ * Test Coverage Summary:
+ * ┌──────────────────────────────────────────────────────────────────────────────────────┐
+ * │ Category                    │ Test Name                                │ Focus        │
+ * ├─────────────────────────────┼──────────────────────────────────────────┼──────────────┤
+ * │ Basic Functionality         │ EmptyMapping_NoTargets                   │ Empty        │
+ * │                             │ GetAllSenderKeys_ReturnsCorrectKeys      │ Key query    │
+ * ├─────────────────────────────┼──────────────────────────────────────────┼──────────────┤
+ * │ Mesh Router - 1D            │ MeshRouter_1D_NoZ_SingleConnection       │ 1D no Z      │
+ * │                             │ MeshRouter_1D_WithZ_HasMeshToZ           │ 1D with Z    │
+ * ├─────────────────────────────┼──────────────────────────────────────────┼──────────────┤
+ * │ Mesh Router - 2D            │ MeshRouter_2D_NoZ_ThreeConnections       │ 2D no Z      │
+ * │                             │ MeshRouter_2D_WithZ_FourConnections      │ 2D with Z    │
+ * │                             │ MeshRouter_2D_AllDirections              │ All dirs     │
+ * ├─────────────────────────────┼──────────────────────────────────────────┼──────────────┤
+ * │ Z Router                    │ ZRouter_VC1_FourConnections              │ VC1 4 conns  │
+ * │                             │ ZRouter_VC0_NoConnections                │ VC0 empty    │
+ * │                             │ ZRouter_AllDirections_Mapped             │ All dirs     │
+ * ├─────────────────────────────┼──────────────────────────────────────────┼──────────────┤
+ * │ Connection Types            │ ConnectionType_INTRA_MESH                │ Intra-mesh   │
+ * │                             │ ConnectionType_MESH_TO_Z                 │ Mesh→Z       │
+ * │                             │ ConnectionType_Z_TO_MESH                 │ Z→Mesh       │
+ * ├─────────────────────────────┼──────────────────────────────────────────┼──────────────┤
+ * │ VC Assignments              │ VCAssignment_IntraMesh_VC0               │ VC0 routing  │
+ * │                             │ VCAssignment_MeshToZ_VC0                 │ Mesh→Z VC0   │
+ * │                             │ VCAssignment_ZToMesh_VC1                 │ Z→Mesh VC1   │
+ * ├─────────────────────────────┼──────────────────────────────────────────┼──────────────┤
+ * │ Direction Mapping           │ DirectionMapping_OppositeDirections      │ Opposites    │
+ * │                             │ DirectionMapping_ZDirection              │ Z direction  │
+ * │                             │ DirectionMapping_AllCardinalDirections   │ N/E/S/W      │
+ * ├─────────────────────────────┼──────────────────────────────────────────┼──────────────┤
+ * │ Query Interface             │ QueryInterface_HasTargets                │ Has check    │
+ * │                             │ QueryInterface_GetTotalSenderCount       │ Count        │
+ * │                             │ QueryInterface_GetAllSenderKeys          │ All keys     │
+ * └─────────────────────────────┴──────────────────────────────────────────┴──────────────┘
+ *
+ * Total: 22 tests across 8 categories
+ */
+
+// ============================================================================
+// Test Fixture
+// ============================================================================
+
+class RouterConnectionMappingTest : public ::testing::Test {
+protected:
+    void SetUp() override {}
+    void TearDown() override {}
+
+    // Helper to verify a single target
+    void verify_target(
+        const ConnectionTarget& target,
+        ConnectionType expected_type,
+        uint32_t expected_vc,
+        std::optional<RoutingDirection> expected_dir = std::nullopt) {
+        EXPECT_EQ(target.type, expected_type);
+        EXPECT_EQ(target.target_vc, expected_vc);
+        if (expected_dir.has_value()) {
+            ASSERT_TRUE(target.target_direction.has_value());
+            EXPECT_EQ(target.target_direction.value(), expected_dir.value());
+        }
+    }
+};
+
+// ============================================================================
+// Basic Functionality Tests
+// ============================================================================
+
+TEST_F(RouterConnectionMappingTest, EmptyMapping_NoTargets) {
+    RouterConnectionMapping mapping;
+
+    auto targets = mapping.get_downstream_targets(0, 0);
+    EXPECT_TRUE(targets.empty());
+    EXPECT_FALSE(mapping.has_targets(0, 0));
+    EXPECT_EQ(mapping.get_total_sender_count(), 0);
+}
+
+TEST_F(RouterConnectionMappingTest, GetAllSenderKeys_ReturnsCorrectKeys) {
+    RouterConnectionMapping mapping = RouterConnectionMapping::for_z_router();
+
+    auto keys = mapping.get_all_sender_keys();
+
+    // Z router has 4 sender channels on VC1
+    EXPECT_EQ(keys.size(), 4);
+
+    // Verify all keys are VC1, channels 0-3
+    for (const auto& key : keys) {
+        EXPECT_EQ(key.vc, 1);
+        EXPECT_GE(key.sender_channel, 0);
+        EXPECT_LE(key.sender_channel, 3);
+    }
+}
+
+// ============================================================================
+// Mesh Router Tests - 1D Topology
+// ============================================================================
+
+TEST_F(RouterConnectionMappingTest, MeshRouter_1D_NoZ_SingleConnection) {
+    auto mapping = RouterConnectionMapping::for_mesh_router(
+        Topology::Linear,
+        RoutingDirection::N,
+        false);  // No Z router
+
+    // Channel 0: Reserved (no targets)
+    EXPECT_FALSE(mapping.has_targets(0, 0));
+
+    // Channel 1: Connects to opposite direction (SOUTH)
+    ASSERT_TRUE(mapping.has_targets(0, 1));
+    auto targets = mapping.get_downstream_targets(0, 1);
+    ASSERT_EQ(targets.size(), 1);
+
+    verify_target(targets[0], ConnectionType::INTRA_MESH, 0, RoutingDirection::S);
+}
+
+TEST_F(RouterConnectionMappingTest, MeshRouter_1D_WithZ_TwoConnections) {
+    auto mapping = RouterConnectionMapping::for_mesh_router(
+        Topology::Linear,
+        RoutingDirection::E,
+        true);  // Has Z router
+
+    // Channel 1: INTRA_MESH to opposite direction (WEST)
+    auto targets_ch1 = mapping.get_downstream_targets(0, 1);
+    ASSERT_EQ(targets_ch1.size(), 1);
+    verify_target(targets_ch1[0], ConnectionType::INTRA_MESH, 0, RoutingDirection::W);
+
+    // Channel 2: MESH_TO_Z connection
+    auto targets_ch2 = mapping.get_downstream_targets(0, 2);
+    ASSERT_EQ(targets_ch2.size(), 1);
+    verify_target(targets_ch2[0], ConnectionType::MESH_TO_Z, 0, RoutingDirection::Z);
+}
+
+TEST_F(RouterConnectionMappingTest, MeshRouter_1D_AllDirections_OppositeMapping) {
+    // Test all 4 directions to verify opposite calculation
+    std::vector<std::pair<RoutingDirection, RoutingDirection>> direction_pairs = {
+        {RoutingDirection::N, RoutingDirection::S},
+        {RoutingDirection::S, RoutingDirection::N},
+        {RoutingDirection::E, RoutingDirection::W},
+        {RoutingDirection::W, RoutingDirection::E}
+    };
+
+    for (const auto& [my_dir, expected_opposite] : direction_pairs) {
+        auto mapping = RouterConnectionMapping::for_mesh_router(
+            Topology::Linear, my_dir, false);
+
+        auto targets = mapping.get_downstream_targets(0, 1);
+        ASSERT_EQ(targets.size(), 1);
+        EXPECT_EQ(targets[0].target_direction.value(), expected_opposite)
+            << "Direction " << static_cast<int>(my_dir) << " should connect to " << static_cast<int>(expected_opposite);
+    }
+}
+
+// ============================================================================
+// Mesh Router Tests - 2D Topology
+// ============================================================================
+
+TEST_F(RouterConnectionMappingTest, MeshRouter_2D_NoZ_ThreeConnections) {
+    auto mapping = RouterConnectionMapping::for_mesh_router(
+        Topology::Mesh,
+        RoutingDirection::N,
+        false);
+
+    // Channel 0: Reserved (no targets)
+    EXPECT_FALSE(mapping.has_targets(0, 0));
+
+    // Channels 1-3: Connect to 3 directions (opposite + 2 cross)
+    // NORTH router connects to: SOUTH (ch1), EAST (ch2), WEST (ch3)
+
+    auto targets_ch1 = mapping.get_downstream_targets(0, 1);
+    ASSERT_EQ(targets_ch1.size(), 1);
+    verify_target(targets_ch1[0], ConnectionType::INTRA_MESH, 0, RoutingDirection::S);
+
+    auto targets_ch2 = mapping.get_downstream_targets(0, 2);
+    ASSERT_EQ(targets_ch2.size(), 1);
+    verify_target(targets_ch2[0], ConnectionType::INTRA_MESH, 0);
+    // Cross direction (EAST or WEST)
+    EXPECT_TRUE(
+        targets_ch2[0].target_direction == RoutingDirection::E ||
+        targets_ch2[0].target_direction == RoutingDirection::W);
+
+    auto targets_ch3 = mapping.get_downstream_targets(0, 3);
+    ASSERT_EQ(targets_ch3.size(), 1);
+    verify_target(targets_ch3[0], ConnectionType::INTRA_MESH, 0);
+    // Other cross direction
+    EXPECT_TRUE(
+        targets_ch3[0].target_direction == RoutingDirection::E ||
+        targets_ch3[0].target_direction == RoutingDirection::W);
+
+    // Verify channels 2 and 3 have different directions
+    EXPECT_NE(targets_ch2[0].target_direction, targets_ch3[0].target_direction);
+}
+
+TEST_F(RouterConnectionMappingTest, MeshRouter_2D_WithZ_FourConnections) {
+    auto mapping = RouterConnectionMapping::for_mesh_router(
+        Topology::Mesh,
+        RoutingDirection::E,
+        true);  // Has Z router
+
+    // Channels 1-3: INTRA_MESH
+    EXPECT_TRUE(mapping.has_targets(0, 1));
+    EXPECT_TRUE(mapping.has_targets(0, 2));
+    EXPECT_TRUE(mapping.has_targets(0, 3));
+
+    // Channel 4: MESH_TO_Z connection
+    auto targets_ch4 = mapping.get_downstream_targets(0, 4);
+    ASSERT_EQ(targets_ch4.size(), 1);
+    verify_target(targets_ch4[0], ConnectionType::MESH_TO_Z, 0, RoutingDirection::Z);
+}
+
+TEST_F(RouterConnectionMappingTest, MeshRouter_2D_EastRouter_CorrectDirections) {
+    auto mapping = RouterConnectionMapping::for_mesh_router(
+        Topology::Mesh,
+        RoutingDirection::E,
+        false);
+
+    // EAST router should connect to: WEST (opposite), NORTH, SOUTH
+    auto targets_ch1 = mapping.get_downstream_targets(0, 1);
+    ASSERT_EQ(targets_ch1.size(), 1);
+    verify_target(targets_ch1[0], ConnectionType::INTRA_MESH, 0, RoutingDirection::W);
+
+    // Channels 2-3 should be NORTH and SOUTH (in some order)
+    auto targets_ch2 = mapping.get_downstream_targets(0, 2);
+    auto targets_ch3 = mapping.get_downstream_targets(0, 3);
+
+    std::set<RoutingDirection> cross_dirs = {
+        targets_ch2[0].target_direction.value(),
+        targets_ch3[0].target_direction.value()
+    };
+
+    EXPECT_TRUE(cross_dirs.count(RoutingDirection::N));
+    EXPECT_TRUE(cross_dirs.count(RoutingDirection::S));
+}
+
+// ============================================================================
+// Z Router Tests
+// ============================================================================
+
+TEST_F(RouterConnectionMappingTest, ZRouter_VC1_FourSenderChannels) {
+    auto mapping = RouterConnectionMapping::for_z_router();
+
+    // VC0: No connections (reserved for future use)
+    EXPECT_FALSE(mapping.has_targets(0, 0));
+    EXPECT_FALSE(mapping.has_targets(0, 1));
+
+    // VC1: 4 sender channels (0-3)
+    EXPECT_TRUE(mapping.has_targets(1, 0));
+    EXPECT_TRUE(mapping.has_targets(1, 1));
+    EXPECT_TRUE(mapping.has_targets(1, 2));
+    EXPECT_TRUE(mapping.has_targets(1, 3));
+
+    // Total sender count = 4 (VC1 channels 0-3)
+    EXPECT_EQ(mapping.get_total_sender_count(), 4);
+}
+
+TEST_F(RouterConnectionMappingTest, ZRouter_VC1_CorrectDirectionMapping) {
+    auto mapping = RouterConnectionMapping::for_z_router();
+
+    // Sender channel 0 → NORTH
+    auto targets_ch0 = mapping.get_downstream_targets(1, 0);
+    ASSERT_EQ(targets_ch0.size(), 1);
+    verify_target(targets_ch0[0], ConnectionType::Z_TO_MESH, 1, RoutingDirection::N);
+
+    // Sender channel 1 → EAST
+    auto targets_ch1 = mapping.get_downstream_targets(1, 1);
+    ASSERT_EQ(targets_ch1.size(), 1);
+    verify_target(targets_ch1[0], ConnectionType::Z_TO_MESH, 1, RoutingDirection::E);
+
+    // Sender channel 2 → SOUTH
+    auto targets_ch2 = mapping.get_downstream_targets(1, 2);
+    ASSERT_EQ(targets_ch2.size(), 1);
+    verify_target(targets_ch2[0], ConnectionType::Z_TO_MESH, 1, RoutingDirection::S);
+
+    // Sender channel 3 → WEST
+    auto targets_ch3 = mapping.get_downstream_targets(1, 3);
+    ASSERT_EQ(targets_ch3.size(), 1);
+    verify_target(targets_ch3[0], ConnectionType::Z_TO_MESH, 1, RoutingDirection::W);
+}
+
+TEST_F(RouterConnectionMappingTest, ZRouter_AllTargets_SameVC) {
+    auto mapping = RouterConnectionMapping::for_z_router();
+
+    // All Z router VC1 targets should go to mesh router VC1
+    for (uint32_t ch = 0; ch < 4; ++ch) {
+        auto targets = mapping.get_downstream_targets(1, ch);
+        ASSERT_EQ(targets.size(), 1);
+        EXPECT_EQ(targets[0].target_vc, 1);  // Z VC1 → mesh VC1
+        EXPECT_EQ(targets[0].type, ConnectionType::Z_TO_MESH);
+    }
+}
+
+// ============================================================================
+// Edge Case Tests
+// ============================================================================
+
+TEST_F(RouterConnectionMappingTest, MeshRouter_InvalidVC_NoTargets) {
+    auto mapping = RouterConnectionMapping::for_mesh_router(
+        Topology::Mesh,
+        RoutingDirection::N,
+        false);
+
+    // VC1 not configured for mesh routers
+    EXPECT_FALSE(mapping.has_targets(1, 0));
+    EXPECT_TRUE(mapping.get_downstream_targets(1, 0).empty());
+}
+
+TEST_F(RouterConnectionMappingTest, ZRouter_InvalidChannel_NoTargets) {
+    auto mapping = RouterConnectionMapping::for_z_router();
+
+    // VC1 only has channels 0-3
+    EXPECT_FALSE(mapping.has_targets(1, 4));
+    EXPECT_FALSE(mapping.has_targets(1, 5));
+    EXPECT_TRUE(mapping.get_downstream_targets(1, 4).empty());
+}
+
+TEST_F(RouterConnectionMappingTest, ConnectionTarget_Construction) {
+    ConnectionTarget target(
+        ConnectionType::MESH_TO_Z,
+        1,  // VC1
+        2,  // Channel 2
+        RoutingDirection::Z);
+
+    EXPECT_EQ(target.type, ConnectionType::MESH_TO_Z);
+    EXPECT_EQ(target.target_vc, 1);
+    EXPECT_EQ(target.target_sender_channel, 2);
+    ASSERT_TRUE(target.target_direction.has_value());
+    EXPECT_EQ(target.target_direction.value(), RoutingDirection::Z);
+}
+
+TEST_F(RouterConnectionMappingTest, SenderChannelKey_Comparison) {
+    SenderChannelKey key1{0, 1};
+    SenderChannelKey key2{0, 2};
+    SenderChannelKey key3{1, 0};
+    SenderChannelKey key4{0, 1};
+
+    // Ordering
+    EXPECT_TRUE(key1 < key2);  // Same VC, lower channel
+    EXPECT_TRUE(key1 < key3);  // Lower VC
+    EXPECT_FALSE(key2 < key1);
+
+    // Equality
+    EXPECT_TRUE(key1 == key4);
+    EXPECT_FALSE(key1 == key2);
+}
+
+// ============================================================================
+// Integration Scenario Tests
+// ============================================================================
+
+TEST_F(RouterConnectionMappingTest, Scenario_2DMesh_WithZ_FullDevice) {
+    // Simulate a full device with 4 mesh routers + 1 Z router
+
+    // Create mesh routers for all 4 directions
+    auto north_mapping = RouterConnectionMapping::for_mesh_router(
+        Topology::Mesh, RoutingDirection::N, true);
+    auto east_mapping = RouterConnectionMapping::for_mesh_router(
+        Topology::Mesh, RoutingDirection::E, true);
+    auto south_mapping = RouterConnectionMapping::for_mesh_router(
+        Topology::Mesh, RoutingDirection::S, true);
+    auto west_mapping = RouterConnectionMapping::for_mesh_router(
+        Topology::Mesh, RoutingDirection::W, true);
+
+    // Create Z router
+    auto z_mapping = RouterConnectionMapping::for_z_router();
+
+    // Verify each mesh router has 4 connections (3 INTRA_MESH + 1 MESH_TO_Z)
+    EXPECT_EQ(north_mapping.get_total_sender_count(), 4);
+    EXPECT_EQ(east_mapping.get_total_sender_count(), 4);
+    EXPECT_EQ(south_mapping.get_total_sender_count(), 4);
+    EXPECT_EQ(west_mapping.get_total_sender_count(), 4);
+
+    // Verify Z router has 4 connections (all Z_TO_MESH)
+    EXPECT_EQ(z_mapping.get_total_sender_count(), 4);
+
+    // Verify each mesh router has MESH_TO_Z on channel 4
+    EXPECT_TRUE(north_mapping.has_targets(0, 4));
+    EXPECT_TRUE(east_mapping.has_targets(0, 4));
+    EXPECT_TRUE(south_mapping.has_targets(0, 4));
+    EXPECT_TRUE(west_mapping.has_targets(0, 4));
+}
+
+TEST_F(RouterConnectionMappingTest, Scenario_EdgeDevice_2MeshRouters_WithZ) {
+    // Edge device with only 2 mesh routers (e.g., NORTH and EAST)
+    auto north_mapping = RouterConnectionMapping::for_mesh_router(
+        Topology::Mesh, RoutingDirection::N, true);
+    auto east_mapping = RouterConnectionMapping::for_mesh_router(
+        Topology::Mesh, RoutingDirection::E, true);
+
+    auto z_mapping = RouterConnectionMapping::for_z_router();
+
+    // Z router still has intent for all 4 directions
+    // FabricBuilder will skip SOUTH and WEST if routers don't exist
+    EXPECT_EQ(z_mapping.get_total_sender_count(), 4);
+
+    // Mesh routers still have MESH_TO_Z connections
+    auto north_targets = north_mapping.get_downstream_targets(0, 4);
+    ASSERT_EQ(north_targets.size(), 1);
+    EXPECT_EQ(north_targets[0].type, ConnectionType::MESH_TO_Z);
+
+    auto east_targets = east_mapping.get_downstream_targets(0, 4);
+    ASSERT_EQ(east_targets.size(), 1);
+    EXPECT_EQ(east_targets[0].type, ConnectionType::MESH_TO_Z);
+}
+
+TEST_F(RouterConnectionMappingTest, Scenario_1DMesh_NoZ_Bidirectional) {
+    // Simple 1D mesh with 2 routers (NORTH and SOUTH)
+    auto north_mapping = RouterConnectionMapping::for_mesh_router(
+        Topology::Linear, RoutingDirection::N, false);
+    auto south_mapping = RouterConnectionMapping::for_mesh_router(
+        Topology::Linear, RoutingDirection::S, false);
+
+    // NORTH router channel 1 → SOUTH
+    auto north_targets = north_mapping.get_downstream_targets(0, 1);
+    ASSERT_EQ(north_targets.size(), 1);
+    EXPECT_EQ(north_targets[0].target_direction.value(), RoutingDirection::S);
+
+    // SOUTH router channel 1 → NORTH
+    auto south_targets = south_mapping.get_downstream_targets(0, 1);
+    ASSERT_EQ(south_targets.size(), 1);
+    EXPECT_EQ(south_targets[0].target_direction.value(), RoutingDirection::N);
+}
+
+// ============================================================================
+// Negative Tests: Invalid Channel Access and Overflow
+// ============================================================================
+
+TEST_F(RouterConnectionMappingTest, ZRouter_VC1_OnlyFourDirections) {
+    // Validate that Z router VC1 only defines connections for 4 directions (N/E/S/W)
+    auto mapping = RouterConnectionMapping::for_z_router();
+
+    // VC1 should have exactly 4 sender channels (0-3)
+    for (uint32_t ch = 0; ch < 4; ++ch) {
+        auto targets = mapping.get_downstream_targets(1, ch);
+        EXPECT_EQ(targets.size(), 1) << "Z VC1 sender " << ch << " should have 1 target";
+    }
+
+    // Channel 4 and beyond should have no targets
+    for (uint32_t ch = 4; ch < 10; ++ch) {
+        auto targets = mapping.get_downstream_targets(1, ch);
+        EXPECT_TRUE(targets.empty()) << "Z VC1 sender " << ch << " should have no targets (doesn't exist)";
+        EXPECT_FALSE(mapping.has_targets(1, ch));
+    }
+}
+
+TEST_F(RouterConnectionMappingTest, MeshRouter_InvalidVC_ReturnsEmpty) {
+    // Mesh router only has VC0, querying VC1+ should return empty
+    auto mapping = RouterConnectionMapping::for_mesh_router(
+        Topology::Mesh, RoutingDirection::N, false);
+
+    // VC1 should have no targets (not enabled for standard mesh)
+    for (uint32_t ch = 0; ch < 5; ++ch) {
+        auto targets = mapping.get_downstream_targets(1, ch);
+        EXPECT_TRUE(targets.empty()) << "Mesh router VC1 channel " << ch << " should have no targets";
+    }
+
+    // VC2+ definitely don't exist
+    auto targets = mapping.get_downstream_targets(2, 0);
+    EXPECT_TRUE(targets.empty());
+}
+
+TEST_F(RouterConnectionMappingTest, MeshRouter_InvalidSenderChannel_ReturnsEmpty) {
+    // Mesh router VC0 has 4 sender channels (0-3), querying beyond should return empty
+    auto mapping = RouterConnectionMapping::for_mesh_router(
+        Topology::Mesh, RoutingDirection::N, false);
+
+    // Channel 0 is reserved for local/internal use (no INTRA_MESH targets)
+    EXPECT_FALSE(mapping.has_targets(0, 0));
+
+    // Channels 1-3 are forwarding channels (should have targets)
+    EXPECT_TRUE(mapping.has_targets(0, 1));
+    EXPECT_TRUE(mapping.has_targets(0, 2));
+    EXPECT_TRUE(mapping.has_targets(0, 3));
+
+    // Invalid channels (beyond 3) should have no targets
+    for (uint32_t ch = 10; ch < 20; ++ch) {
+        auto targets = mapping.get_downstream_targets(0, ch);
+        EXPECT_TRUE(targets.empty()) << "Mesh router VC0 channel " << ch << " should have no targets (doesn't exist)";
+        EXPECT_FALSE(mapping.has_targets(0, ch));
+    }
+}
+
+TEST_F(RouterConnectionMappingTest, ZRouter_VC0_NoOutgoingTargets) {
+    // Z router VC0 senders should have no downstream targets (reserved)
+    auto mapping = RouterConnectionMapping::for_z_router();
+
+    // All VC0 sender channels should have no targets
+    for (uint32_t ch = 0; ch < 4; ++ch) {
+        auto targets = mapping.get_downstream_targets(0, ch);
+        EXPECT_TRUE(targets.empty()) << "Z router VC0 sender " << ch << " should have no targets";
+        EXPECT_FALSE(mapping.has_targets(0, ch));
+    }
+}

--- a/tests/tt_metal/tt_fabric/fabric_router/test_router_connection_mapping.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_router_connection_mapping.cpp
@@ -95,7 +95,7 @@ TEST_F(RouterConnectionMappingTest, EmptyMapping_NoTargets) {
 TEST_F(RouterConnectionMappingTest, GetAllSenderKeys_ReturnsCorrectKeys) {
     RouterConnectionMapping mapping = RouterConnectionMapping::for_z_router();
 
-    auto keys = mapping.get_all_sender_keys();
+    auto keys = mapping.get_all_receiver_keys();
 
     // Z router has 4 sender channels on VC1
     EXPECT_EQ(keys.size(), 4);
@@ -103,8 +103,8 @@ TEST_F(RouterConnectionMappingTest, GetAllSenderKeys_ReturnsCorrectKeys) {
     // Verify all keys are VC1, channels 0-3
     for (const auto& key : keys) {
         EXPECT_EQ(key.vc, 1);
-        EXPECT_GE(key.sender_channel, 0);
-        EXPECT_LE(key.sender_channel, 3);
+        EXPECT_GE(key.receiver_channel, 0);
+        EXPECT_LE(key.receiver_channel, 3);
     }
 }
 
@@ -342,11 +342,11 @@ TEST_F(RouterConnectionMappingTest, ConnectionTarget_Construction) {
     EXPECT_EQ(target.target_direction.value(), RoutingDirection::Z);
 }
 
-TEST_F(RouterConnectionMappingTest, SenderChannelKey_Comparison) {
-    SenderChannelKey key1{0, 1};
-    SenderChannelKey key2{0, 2};
-    SenderChannelKey key3{1, 0};
-    SenderChannelKey key4{0, 1};
+TEST_F(RouterConnectionMappingTest, ReceiverChannelKey_Comparison) {
+    ReceiverChannelKey key1{0, 1};
+    ReceiverChannelKey key2{0, 2};
+    ReceiverChannelKey key3{1, 0};
+    ReceiverChannelKey key4{0, 1};
 
     // Ordering
     EXPECT_TRUE(key1 < key2);  // Same VC, lower channel

--- a/tests/tt_metal/tt_fabric/fabric_router/test_router_connections.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_router_connections.cpp
@@ -1,0 +1,1077 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+#include "tt_metal/fabric/builder/connection_registry.hpp"
+#include "tt_metal/fabric/builder/router_connection_mapping.hpp"
+#include "tt_metal/fabric/fabric_router_channel_mapping.hpp"
+#include "tt_metal/fabric/fabric_context.hpp"
+#include <tt-metalium/experimental/fabric/mesh_graph.hpp>
+#include <tt-metalium/experimental/fabric/routing_table_generator.hpp>
+#include <tt-metalium/experimental/fabric/fabric_edm_types.hpp>
+
+namespace tt::tt_fabric {
+
+/**
+ * Test fixture for router connection scenarios
+ *
+ * These tests validate router connection integration:
+ * - Non-Z router connecting to non-Z router (INTRA_MESH)
+ * - Non-Z router connecting to Z router (MESH_TO_Z)
+ * - Z router connecting to non-Z router (Z_TO_MESH)
+ * - Channel mapping correctness for each scenario
+ *
+ * Test Coverage Summary:
+ * ┌──────────────────────────────────────────────────────────────────────────────────────┐
+ * │ Category                    │ Test Name                                │ Focus        │
+ * ├─────────────────────────────┼──────────────────────────────────────────┼──────────────┤
+ * │ Mesh↔Mesh (INTRA_MESH)      │ MeshToMesh_VC0_Connection                │ Basic mesh   │
+ * │                             │ MeshToMesh_1D_Linear                     │ 1D topology  │
+ * │                             │ MeshToMesh_2D_AllDirections              │ All dirs     │
+ * │                             │ MeshToMesh_MultipleDevices               │ Multi-device │
+ * ├─────────────────────────────┼──────────────────────────────────────────┼──────────────┤
+ * │ Mesh→Z (MESH_TO_Z)          │ MeshToZ_VC0_Connection                   │ Basic M→Z    │
+ * │                             │ MeshToZ_AllMeshRouters_ToSameZ           │ 4→1          │
+ * │                             │ MeshToZ_ChannelMapping_Correct           │ Channels     │
+ * │                             │ MeshToZ_MultiTargetReceiver              │ Multi-target │
+ * ├─────────────────────────────┼──────────────────────────────────────────┼──────────────┤
+ * │ Z→Mesh (Z_TO_MESH)          │ ZToMesh_VC1_Connection                   │ Basic Z→M    │
+ * │                             │ ZToMesh_FourDirections                   │ 4 directions │
+ * │                             │ ZToMesh_ChannelMapping_Correct           │ Channels     │
+ * │                             │ ZToMesh_TargetVC_Correct                 │ Target VC    │
+ * ├─────────────────────────────┼──────────────────────────────────────────┼──────────────┤
+ * │ Full Device Integration     │ FullDevice_4Mesh1Z_AllConnectionTypes    │ All types    │
+ * │                             │ FullDevice_4Mesh1Z_VerifyRegistry        │ Registry     │
+ * │                             │ FullDevice_4Mesh1Z_ConnectionCounts      │ Counts       │
+ * ├─────────────────────────────┼──────────────────────────────────────────┼──────────────┤
+ * │ Edge Device Scenarios       │ EdgeDevice_2Mesh1Z_PartialConnections    │ 2 routers    │
+ * │                             │ EdgeDevice_3Mesh1Z_AsymmetricTopology    │ 3 routers    │
+ * ├─────────────────────────────┼──────────────────────────────────────────┼──────────────┤
+ * │ Connection Validation       │ ValidateConnection_VCAssignments         │ VCs          │
+ * │                             │ ValidateConnection_DirectionMapping      │ Directions   │
+ * │                             │ ValidateConnection_ChannelConsistency    │ Consistency  │
+ * └─────────────────────────────┴──────────────────────────────────────────┴──────────────┘
+ *
+ * Total: 20 tests across 6 categories
+ */
+class RouterConnectionsTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        registry_ = std::make_shared<ConnectionRegistry>();
+    }
+
+    void TearDown() override {
+        registry_.reset();
+    }
+
+    std::shared_ptr<ConnectionRegistry> registry_;
+};
+
+// ============ Helper Functions ============
+
+// Simulate recording a connection between two routers
+void record_test_connection(
+    std::shared_ptr<ConnectionRegistry> registry,
+    FabricNodeId source_node,
+    RoutingDirection source_dir,
+    uint8_t source_eth_chan,
+    uint32_t source_vc,
+    uint32_t source_sender_ch,
+    FabricNodeId dest_node,
+    RoutingDirection dest_dir,
+    uint8_t dest_eth_chan,
+    uint32_t dest_vc,
+    uint32_t dest_receiver_ch,
+    ConnectionType conn_type) {
+    RouterConnectionRecord record{
+        .source_node = source_node,
+        .source_direction = source_dir,
+        .source_eth_chan = source_eth_chan,
+        .source_vc = source_vc,
+        .source_sender_channel = source_sender_ch,
+        .dest_node = dest_node,
+        .dest_direction = dest_dir,
+        .dest_eth_chan = dest_eth_chan,
+        .dest_vc = dest_vc,
+        .dest_receiver_channel = dest_receiver_ch,
+        .connection_type = conn_type
+    };
+
+    registry->record_connection(record);
+}
+
+// ============ Non-Z to Non-Z Router Tests (INTRA_MESH) ============
+
+TEST_F(RouterConnectionsTest, MeshToMesh_VC0_Connection) {
+    // Setup: Two mesh routers on different devices
+    FabricNodeId device0(MeshId{0}, 0);
+    FabricNodeId device1(MeshId{0}, 1);
+
+    // Create channel mappings for both routers
+    FabricRouterChannelMapping router0_mapping(
+        Topology::Mesh,
+        false,  // no tensix
+        RouterVariant::MESH, nullptr);
+
+    FabricRouterChannelMapping router1_mapping(
+        Topology::Mesh,
+        false,  // no tensix
+        RouterVariant::MESH, nullptr);
+
+    // Verify both routers have VC0 only
+    EXPECT_EQ(router0_mapping.get_num_virtual_channels(), 1);
+    EXPECT_EQ(router1_mapping.get_num_virtual_channels(), 1);
+
+    // Simulate connection: router0 (EAST) → router1 (WEST), VC0 channel 1
+    record_test_connection(
+        registry_,
+        device0, RoutingDirection::E, 0,  // source
+        0, 1,  // VC0, sender channel 1
+        device1, RoutingDirection::W, 0,  // dest
+        0, 1,  // VC0, receiver channel (mapped to internal 1)
+        ConnectionType::INTRA_MESH);
+
+    // Verify connection was recorded
+    EXPECT_EQ(registry_->size(), 1);
+
+    auto connections = registry_->get_connections_by_type(ConnectionType::INTRA_MESH);
+    ASSERT_EQ(connections.size(), 1);
+
+    const auto& conn = connections[0];
+    EXPECT_EQ(conn.source_node, device0);
+    EXPECT_EQ(conn.source_direction, RoutingDirection::E);
+    EXPECT_EQ(conn.source_vc, 0);
+    EXPECT_EQ(conn.dest_node, device1);
+    EXPECT_EQ(conn.dest_direction, RoutingDirection::W);
+    EXPECT_EQ(conn.dest_vc, 0);
+    EXPECT_EQ(conn.connection_type, ConnectionType::INTRA_MESH);
+}
+
+TEST_F(RouterConnectionsTest, MeshToMesh_Bidirectional_VC0) {
+    // Setup: Two mesh routers with bidirectional connection
+    FabricNodeId device0(MeshId{0}, 0);
+    FabricNodeId device1(MeshId{0}, 1);
+
+    // Connection 1: device0 → device1
+    record_test_connection(
+        registry_,
+        device0, RoutingDirection::N, 0,
+        0, 1,
+        device1, RoutingDirection::S, 0,
+        0, 1,
+        ConnectionType::INTRA_MESH);
+
+    // Connection 2: device1 → device0 (reverse)
+    record_test_connection(
+        registry_,
+        device1, RoutingDirection::S, 0,
+        0, 1,
+        device0, RoutingDirection::N, 0,
+        0, 1,
+        ConnectionType::INTRA_MESH);
+
+    EXPECT_EQ(registry_->size(), 2);
+
+    // Verify both connections are INTRA_MESH
+    auto intra_mesh = registry_->get_connections_by_type(ConnectionType::INTRA_MESH);
+    EXPECT_EQ(intra_mesh.size(), 2);
+
+    // Verify device0 has 1 outgoing connection
+    auto device0_out = registry_->get_connections_from_source(device0, RoutingDirection::N);
+    EXPECT_EQ(device0_out.size(), 1);
+
+    // Verify device0 has 1 incoming connection
+    auto device0_in = registry_->get_connections_to_dest(device0, RoutingDirection::N);
+    EXPECT_EQ(device0_in.size(), 1);
+}
+
+TEST_F(RouterConnectionsTest, MeshToMesh_2D_MultipleChannels) {
+    // Setup: 2D mesh router connecting to multiple neighbors
+    FabricNodeId center(MeshId{0}, 4);  // Center of 3x3 grid
+    FabricNodeId north(MeshId{0}, 1);
+    FabricNodeId east(MeshId{0}, 5);
+    FabricNodeId south(MeshId{0}, 7);
+    FabricNodeId west(MeshId{0}, 3);
+
+    // Center router connects to all 4 neighbors via VC0
+    record_test_connection(registry_, center, RoutingDirection::N, 0, 0, 1,
+                          north, RoutingDirection::S, 0, 0, 1, ConnectionType::INTRA_MESH);
+    record_test_connection(registry_, center, RoutingDirection::E, 1, 0, 1,
+                          east, RoutingDirection::W, 1, 0, 1, ConnectionType::INTRA_MESH);
+    record_test_connection(registry_, center, RoutingDirection::S, 2, 0, 1,
+                          south, RoutingDirection::N, 2, 0, 1, ConnectionType::INTRA_MESH);
+    record_test_connection(registry_, center, RoutingDirection::W, 3, 0, 1,
+                          west, RoutingDirection::E, 3, 0, 1, ConnectionType::INTRA_MESH);
+
+    EXPECT_EQ(registry_->size(), 4);
+
+    // Verify all are INTRA_MESH
+    auto intra_mesh = registry_->get_connections_by_type(ConnectionType::INTRA_MESH);
+    EXPECT_EQ(intra_mesh.size(), 4);
+}
+
+// ============ Non-Z to Z Router Tests (MESH_TO_Z) ============
+
+TEST_F(RouterConnectionsTest, MeshToZ_VC0_Connection) {
+    // Setup: Mesh router connecting to Z router on same device
+    auto intermesh_config = IntermeshVCConfig::full_mesh();
+    FabricNodeId device0(MeshId{0}, 0);
+
+    // Mesh router (North direction)
+    FabricRouterChannelMapping mesh_mapping(
+        Topology::Mesh,
+        false,
+        RouterVariant::MESH, nullptr);
+
+    // Z router
+    FabricRouterChannelMapping z_mapping(
+        Topology::Mesh,
+        false,
+        RouterVariant::Z_ROUTER, &intermesh_config);
+
+    // Verify Z router has 2 VCs
+    EXPECT_EQ(z_mapping.get_num_virtual_channels(), 2);
+    EXPECT_EQ(z_mapping.get_num_sender_channels_for_vc(1), 4);
+
+    // Simulate connection: mesh (VC0, sender ch 2) → Z (VC1, receiver ch 0)
+    // Mesh router uses VC0 sender channel 2 to send to Z router
+    // Z router receives on VC1 receiver channel 0 (mapped to erisc receiver 1)
+    record_test_connection(
+        registry_,
+        device0, RoutingDirection::N, 0,  // mesh router
+        0, 2,  // VC0, sender channel 2
+        device0, RoutingDirection::Z, 4,  // Z router (eth_chan 4)
+        1, 0,  // VC1, receiver channel 0
+        ConnectionType::MESH_TO_Z);
+
+    EXPECT_EQ(registry_->size(), 1);
+
+    auto mesh_to_z = registry_->get_connections_by_type(ConnectionType::MESH_TO_Z);
+    ASSERT_EQ(mesh_to_z.size(), 1);
+
+    const auto& conn = mesh_to_z[0];
+    EXPECT_EQ(conn.source_direction, RoutingDirection::N);
+    EXPECT_EQ(conn.source_vc, 0);
+    EXPECT_EQ(conn.dest_direction, RoutingDirection::Z);
+    EXPECT_EQ(conn.dest_vc, 1);
+    EXPECT_EQ(conn.connection_type, ConnectionType::MESH_TO_Z);
+
+    // Verify Z router's VC1 receiver channel 0 maps to erisc receiver 1
+    auto z_receiver_mapping = z_mapping.get_receiver_mapping(1, 0);
+    EXPECT_EQ(z_receiver_mapping.builder_type, BuilderType::ERISC);
+    EXPECT_EQ(z_receiver_mapping.internal_receiver_channel_id, 1);
+}
+
+TEST_F(RouterConnectionsTest, MeshToZ_MultipleMeshRouters) {
+    // Setup: 4 mesh routers connecting to 1 Z router (typical device layout)
+    FabricNodeId device0(MeshId{0}, 0);
+
+    std::vector<RoutingDirection> mesh_dirs = {
+        RoutingDirection::N, RoutingDirection::E, RoutingDirection::S, RoutingDirection::W
+    };
+
+    // Each mesh router connects to Z router via VC0 sender channel 2
+    for (size_t i = 0; i < 4; ++i) {
+        record_test_connection(
+            registry_,
+            device0, mesh_dirs[i], static_cast<uint8_t>(i),  // mesh router
+            0, 2,  // VC0, sender channel 2
+            device0, RoutingDirection::Z, 4,  // Z router
+            1, 0,  // VC1, receiver channel 0 (same for all - multi-target)
+            ConnectionType::MESH_TO_Z);
+    }
+
+    EXPECT_EQ(registry_->size(), 4);
+
+    auto mesh_to_z = registry_->get_connections_by_type(ConnectionType::MESH_TO_Z);
+    EXPECT_EQ(mesh_to_z.size(), 4);
+
+    // Verify Z router receives from all 4 mesh routers
+    auto z_incoming = registry_->get_connections_to_dest(device0, RoutingDirection::Z);
+    EXPECT_EQ(z_incoming.size(), 4);
+
+    // All should target VC1 receiver channel 0 (multi-target receiver)
+    for (const auto& conn : z_incoming) {
+        EXPECT_EQ(conn.dest_vc, 1);
+        EXPECT_EQ(conn.dest_receiver_channel, 0);  // All target same receiver
+        EXPECT_EQ(conn.connection_type, ConnectionType::MESH_TO_Z);
+    }
+
+    // Verify Z router VC1 receiver can handle multiple sources
+    // This is the multi-target receiver scenario
+    std::set<RoutingDirection> source_dirs;
+    for (const auto& conn : z_incoming) {
+        source_dirs.insert(conn.source_direction);
+    }
+    EXPECT_EQ(source_dirs.size(), 4);  // 4 different source directions
+}
+
+// ============ Z to Non-Z Router Tests (Z_TO_MESH) ============
+
+TEST_F(RouterConnectionsTest, ZToMesh_VC1_Connection) {
+    // Setup: Z router connecting to mesh router on same device
+    auto intermesh_config = IntermeshVCConfig::full_mesh();
+    FabricNodeId device0(MeshId{0}, 0);
+
+    // Z router
+    FabricRouterChannelMapping z_mapping(
+        Topology::Mesh,
+        false,
+        RouterVariant::Z_ROUTER, &intermesh_config);
+
+    // Mesh router
+    FabricRouterChannelMapping mesh_mapping(
+        Topology::Mesh,
+        false,
+        RouterVariant::MESH, nullptr);
+
+    // Verify Z router VC1 has 4 sender channels
+    EXPECT_EQ(z_mapping.get_num_sender_channels_for_vc(1), 4);
+
+    // Verify Z router VC1 sender channels map to erisc 4-7
+    for (uint32_t i = 0; i < 4; ++i) {
+        auto sender_mapping = z_mapping.get_sender_mapping(1, i);
+        EXPECT_EQ(sender_mapping.builder_type, BuilderType::ERISC);
+        EXPECT_EQ(sender_mapping.internal_sender_channel_id, 4 + i);
+    }
+
+    // Simulate connection: Z (VC1, sender ch 0) → mesh North (VC1, receiver)
+    record_test_connection(
+        registry_,
+        device0, RoutingDirection::Z, 4,  // Z router
+        1, 0,  // VC1, sender channel 0 (maps to erisc 4)
+        device0, RoutingDirection::N, 0,  // mesh router
+        1, 0,  // VC1, receiver channel 0
+        ConnectionType::Z_TO_MESH);
+
+    EXPECT_EQ(registry_->size(), 1);
+
+    auto z_to_mesh = registry_->get_connections_by_type(ConnectionType::Z_TO_MESH);
+    ASSERT_EQ(z_to_mesh.size(), 1);
+
+    const auto& conn = z_to_mesh[0];
+    EXPECT_EQ(conn.source_direction, RoutingDirection::Z);
+    EXPECT_EQ(conn.source_vc, 1);
+    EXPECT_EQ(conn.source_sender_channel, 0);
+    EXPECT_EQ(conn.dest_direction, RoutingDirection::N);
+    EXPECT_EQ(conn.dest_vc, 1);
+    EXPECT_EQ(conn.connection_type, ConnectionType::Z_TO_MESH);
+}
+
+TEST_F(RouterConnectionsTest, ZToMesh_AllFourDirections) {
+    // Setup: Z router connecting to all 4 mesh routers
+    FabricNodeId device0(MeshId{0}, 0);
+
+    std::vector<RoutingDirection> mesh_dirs = {
+        RoutingDirection::N, RoutingDirection::E, RoutingDirection::S, RoutingDirection::W
+    };
+
+    // Z router uses VC1 sender channels 0-3 to connect to 4 mesh routers VC1
+    for (size_t i = 0; i < 4; ++i) {
+        record_test_connection(
+            registry_,
+            device0, RoutingDirection::Z, 4,  // Z router
+            1, static_cast<uint32_t>(i),  // VC1, sender channel i
+            device0, mesh_dirs[i], static_cast<uint8_t>(i),  // mesh router
+            1, 0,  // VC1, receiver channel 0
+            ConnectionType::Z_TO_MESH);
+    }
+
+    EXPECT_EQ(registry_->size(), 4);
+
+    auto z_to_mesh = registry_->get_connections_by_type(ConnectionType::Z_TO_MESH);
+    EXPECT_EQ(z_to_mesh.size(), 4);
+
+    // Verify Z router has 4 outgoing connections
+    auto z_outgoing = registry_->get_connections_from_source(device0, RoutingDirection::Z);
+    EXPECT_EQ(z_outgoing.size(), 4);
+
+    // Each should use a different sender channel (0-3)
+    std::set<uint32_t> sender_channels;
+    for (const auto& conn : z_outgoing) {
+        EXPECT_EQ(conn.source_vc, 1);
+        sender_channels.insert(conn.source_sender_channel);
+    }
+    EXPECT_EQ(sender_channels.size(), 4);  // All 4 channels used
+}
+
+TEST_F(RouterConnectionsTest, ZToMesh_VariableRouterCount) {
+    // Setup: Z router connecting to only 2 mesh routers (edge device scenario)
+    FabricNodeId device0(MeshId{0}, 0);
+
+    // Only North and East mesh routers present
+    record_test_connection(
+        registry_,
+        device0, RoutingDirection::Z, 4,
+        1, 0,  // VC1, sender channel 0
+        device0, RoutingDirection::N, 0,
+        1, 0,  // VC1, receiver channel 0
+        ConnectionType::Z_TO_MESH);
+
+    record_test_connection(
+        registry_,
+        device0, RoutingDirection::Z, 4,
+        1, 1,  // VC1, sender channel 1
+        device0, RoutingDirection::E, 1,
+        1, 0,  // VC1, receiver channel 0
+        ConnectionType::Z_TO_MESH);
+
+    EXPECT_EQ(registry_->size(), 2);
+
+    auto z_to_mesh = registry_->get_connections_by_type(ConnectionType::Z_TO_MESH);
+    EXPECT_EQ(z_to_mesh.size(), 2);
+
+    // Verify only 2 connections from Z router
+    auto z_outgoing = registry_->get_connections_from_source(device0, RoutingDirection::Z);
+    EXPECT_EQ(z_outgoing.size(), 2);
+}
+
+// ============ Complete Device Scenario ============
+
+TEST_F(RouterConnectionsTest, CompleteDevice_WithZRouter) {
+    // Setup: Complete device with 4 mesh routers and 1 Z router
+    // - Mesh routers connect to each other (INTRA_MESH)
+    // - Mesh routers connect to Z router (MESH_TO_Z)
+    // - Z router connects to mesh routers (Z_TO_MESH)
+
+    FabricNodeId device0(MeshId{0}, 0);
+    FabricNodeId device1(MeshId{0}, 1);  // External device
+
+    // 1. INTRA_MESH: device0 North router → device1 South router
+    record_test_connection(
+        registry_,
+        device0, RoutingDirection::N, 0,
+        0, 1,
+        device1, RoutingDirection::S, 0,
+        0, 1,
+        ConnectionType::INTRA_MESH);
+
+    // 2. MESH_TO_Z: device0 North router → device0 Z router
+    record_test_connection(
+        registry_,
+        device0, RoutingDirection::N, 0,
+        0, 2,
+        device0, RoutingDirection::Z, 4,
+        1, 0,
+        ConnectionType::MESH_TO_Z);
+
+    // 3. Z_TO_MESH: device0 Z router VC1 → device0 North router VC1
+    record_test_connection(
+        registry_,
+        device0, RoutingDirection::Z, 4,
+        1, 0,
+        device0, RoutingDirection::N, 0,
+        1, 0,
+        ConnectionType::Z_TO_MESH);
+
+    EXPECT_EQ(registry_->size(), 3);
+
+    // Verify connection types
+    EXPECT_EQ(registry_->get_connections_by_type(ConnectionType::INTRA_MESH).size(), 1);
+    EXPECT_EQ(registry_->get_connections_by_type(ConnectionType::MESH_TO_Z).size(), 1);
+    EXPECT_EQ(registry_->get_connections_by_type(ConnectionType::Z_TO_MESH).size(), 1);
+
+    // Verify North router has 2 outgoing connections (INTRA_MESH + MESH_TO_Z)
+    auto north_out = registry_->get_connections_from_source(device0, RoutingDirection::N);
+    EXPECT_EQ(north_out.size(), 2);
+
+    // Verify Z router has 1 outgoing and 1 incoming
+    auto z_out = registry_->get_connections_from_source(device0, RoutingDirection::Z);
+    auto z_in = registry_->get_connections_to_dest(device0, RoutingDirection::Z);
+    EXPECT_EQ(z_out.size(), 1);
+    EXPECT_EQ(z_in.size(), 1);
+}
+
+TEST_F(RouterConnectionsTest, FullMesh_4Routers_WithZ) {
+    // Setup: Complete device topology
+    // 4 mesh routers (N, E, S, W) + 1 Z router
+    // Each mesh connects to 2 adjacent mesh routers + Z router
+    // Z router connects to all 4 mesh routers
+
+    FabricNodeId device0(MeshId{0}, 0);
+
+    // INTRA_MESH connections (simplified - just a few)
+    record_test_connection(registry_, device0, RoutingDirection::N, 0, 0, 1,
+                          device0, RoutingDirection::E, 1, 0, 1, ConnectionType::INTRA_MESH);
+    record_test_connection(registry_, device0, RoutingDirection::E, 1, 0, 1,
+                          device0, RoutingDirection::S, 2, 0, 1, ConnectionType::INTRA_MESH);
+
+    // MESH_TO_Z connections (all 4 mesh routers → Z)
+    std::vector<RoutingDirection> dirs = {
+        RoutingDirection::N, RoutingDirection::E, RoutingDirection::S, RoutingDirection::W
+    };
+    for (size_t i = 0; i < 4; ++i) {
+        record_test_connection(
+            registry_,
+            device0, dirs[i], static_cast<uint8_t>(i),
+            0, 2,
+            device0, RoutingDirection::Z, 4,
+            1, 0,
+            ConnectionType::MESH_TO_Z);
+    }
+
+    // Z_TO_MESH connections (Z VC1 → all 4 mesh routers VC1)
+    for (size_t i = 0; i < 4; ++i) {
+        record_test_connection(
+            registry_,
+            device0, RoutingDirection::Z, 4,
+            1, static_cast<uint32_t>(i),
+            device0, dirs[i], static_cast<uint8_t>(i),
+            1, 0,
+            ConnectionType::Z_TO_MESH);
+    }
+
+    // Total: 2 INTRA_MESH + 4 MESH_TO_Z + 4 Z_TO_MESH = 10 connections
+    EXPECT_EQ(registry_->size(), 10);
+    EXPECT_EQ(registry_->get_connections_by_type(ConnectionType::INTRA_MESH).size(), 2);
+    EXPECT_EQ(registry_->get_connections_by_type(ConnectionType::MESH_TO_Z).size(), 4);
+    EXPECT_EQ(registry_->get_connections_by_type(ConnectionType::Z_TO_MESH).size(), 4);
+
+    // Verify Z router connectivity
+    auto z_out = registry_->get_connections_from_source(device0, RoutingDirection::Z);
+    auto z_in = registry_->get_connections_to_dest(device0, RoutingDirection::Z);
+    EXPECT_EQ(z_out.size(), 4);  // Z → 4 mesh routers
+    EXPECT_EQ(z_in.size(), 4);   // 4 mesh routers → Z
+}
+
+// ============ Multi-Target Receiver Validation ============
+
+TEST_F(RouterConnectionsTest, Phase1_5_ZRouter_MultiTargetReceiver_Validation) {
+    // This test validates the multi-target receiver scenario:
+    // Z router VC1 receiver channel 0 receives from 4 different mesh routers
+    // This was previously impossible due to fixed array overwriting
+
+    auto intermesh_config = IntermeshVCConfig::full_mesh();
+    FabricNodeId device0(MeshId{0}, 0);
+
+    // Z router channel mapping
+    FabricRouterChannelMapping z_mapping(
+        Topology::Mesh,
+        false,
+        RouterVariant::Z_ROUTER, &intermesh_config);
+
+    // Verify Z router has correct VC1 layout
+    EXPECT_EQ(z_mapping.get_num_virtual_channels(), 2);
+    EXPECT_EQ(z_mapping.get_num_sender_channels_for_vc(1), 4);
+
+    // Verify VC1 receiver channel 0 maps to erisc receiver 1
+    auto vc1_receiver = z_mapping.get_receiver_mapping(1, 0);
+    EXPECT_EQ(vc1_receiver.builder_type, BuilderType::ERISC);
+    EXPECT_EQ(vc1_receiver.internal_receiver_channel_id, 1);
+
+    // Record 4 MESH_TO_Z connections, all targeting same receiver
+    std::vector<RoutingDirection> mesh_dirs = {
+        RoutingDirection::N, RoutingDirection::E, RoutingDirection::S, RoutingDirection::W
+    };
+
+    for (size_t i = 0; i < 4; ++i) {
+        // Create mesh router mapping
+        FabricRouterChannelMapping mesh_mapping(
+            Topology::Mesh,
+            false,
+            RouterVariant::MESH, nullptr);
+
+        // Verify mesh router VC0 sender channel 2 exists
+        EXPECT_GE(mesh_mapping.get_num_sender_channels_for_vc(0), 3);
+
+        // Record connection: mesh VC0 ch2 → Z VC1 ch0
+        record_test_connection(
+            registry_,
+            device0, mesh_dirs[i], static_cast<uint8_t>(i),
+            0, 2,  // VC0, sender channel 2
+            device0, RoutingDirection::Z, 4,
+            1, 0,  // VC1, receiver channel 0 (SAME for all 4)
+            ConnectionType::MESH_TO_Z);
+    }
+
+    // Validate multi-target receiver scenario
+    auto z_incoming = registry_->get_connections_to_dest(device0, RoutingDirection::Z);
+    ASSERT_EQ(z_incoming.size(), 4);
+
+    // Critical validation: All 4 connections target the SAME receiver
+    for (const auto& conn : z_incoming) {
+        EXPECT_EQ(conn.dest_vc, 1);
+        EXPECT_EQ(conn.dest_receiver_channel, 0);  // Same receiver for all!
+        EXPECT_EQ(conn.dest_direction, RoutingDirection::Z);
+    }
+
+    // Verify all 4 source directions are present
+    std::set<RoutingDirection> sources;
+    for (const auto& conn : z_incoming) {
+        sources.insert(conn.source_direction);
+    }
+    EXPECT_EQ(sources.size(), 4);
+    EXPECT_TRUE(sources.count(RoutingDirection::N) > 0);
+    EXPECT_TRUE(sources.count(RoutingDirection::E) > 0);
+    EXPECT_TRUE(sources.count(RoutingDirection::S) > 0);
+    EXPECT_TRUE(sources.count(RoutingDirection::W) > 0);
+}
+
+TEST_F(RouterConnectionsTest, Phase1_5_EdgeDevice_VariableTargetCount) {
+    // Multi-target receiver supports variable target counts (2-4 mesh routers)
+    // This test validates an edge device with only 2 mesh routers
+
+    FabricNodeId device0(MeshId{0}, 0);
+
+    // Only North and East mesh routers present (edge device)
+    record_test_connection(
+        registry_,
+        device0, RoutingDirection::N, 0,
+        0, 2,
+        device0, RoutingDirection::Z, 4,
+        1, 0,  // Same receiver channel
+        ConnectionType::MESH_TO_Z);
+
+    record_test_connection(
+        registry_,
+        device0, RoutingDirection::E, 1,
+        0, 2,
+        device0, RoutingDirection::Z, 4,
+        1, 0,  // Same receiver channel
+        ConnectionType::MESH_TO_Z);
+
+    auto z_incoming = registry_->get_connections_to_dest(device0, RoutingDirection::Z);
+    EXPECT_EQ(z_incoming.size(), 2);
+
+    // Both target same receiver (multi-target with count=2)
+    for (const auto& conn : z_incoming) {
+        EXPECT_EQ(conn.dest_receiver_channel, 0);
+    }
+}
+
+TEST_F(RouterConnectionsTest, Phase1_5_Bidirectional_ZAndMesh) {
+    // Comprehensive test: Z router both receives from and sends to mesh routers
+    // This validates both MESH_TO_Z (multi-target receiver) and Z_TO_MESH
+
+    FabricNodeId device0(MeshId{0}, 0);
+
+    // 4 mesh routers
+    std::vector<RoutingDirection> mesh_dirs = {
+        RoutingDirection::N, RoutingDirection::E, RoutingDirection::S, RoutingDirection::W
+    };
+
+    // MESH_TO_Z: All 4 mesh routers → Z router VC1 receiver 0 (multi-target)
+    for (size_t i = 0; i < 4; ++i) {
+        record_test_connection(
+            registry_,
+            device0, mesh_dirs[i], static_cast<uint8_t>(i),
+            0, 2,  // mesh VC0 sender 2
+            device0, RoutingDirection::Z, 4,
+            1, 0,  // Z VC1 receiver 0 (SAME for all)
+            ConnectionType::MESH_TO_Z);
+    }
+
+    // Z_TO_MESH: Z router VC1 senders 0-3 → 4 mesh routers (one-to-one)
+    for (size_t i = 0; i < 4; ++i) {
+        record_test_connection(
+            registry_,
+            device0, RoutingDirection::Z, 4,
+            1, static_cast<uint32_t>(i),  // Z VC1 sender i
+            device0, mesh_dirs[i], static_cast<uint8_t>(i),
+            1, 0,  // mesh VC1 receiver
+            ConnectionType::Z_TO_MESH);
+    }
+
+    // Validate counts
+    EXPECT_EQ(registry_->size(), 8);
+    EXPECT_EQ(registry_->get_connections_by_type(ConnectionType::MESH_TO_Z).size(), 4);
+    EXPECT_EQ(registry_->get_connections_by_type(ConnectionType::Z_TO_MESH).size(), 4);
+
+    // Validate Z router connectivity
+    auto z_in = registry_->get_connections_to_dest(device0, RoutingDirection::Z);
+    auto z_out = registry_->get_connections_from_source(device0, RoutingDirection::Z);
+
+    EXPECT_EQ(z_in.size(), 4);   // 4 incoming (multi-target receiver)
+    EXPECT_EQ(z_out.size(), 4);  // 4 outgoing (one per sender channel)
+
+    // All incoming target same receiver (multi-target)
+    for (const auto& conn : z_in) {
+        EXPECT_EQ(conn.dest_receiver_channel, 0);
+    }
+
+    // All outgoing use different sender channels
+    std::set<uint32_t> sender_channels;
+    for (const auto& conn : z_out) {
+        sender_channels.insert(conn.source_sender_channel);
+    }
+    EXPECT_EQ(sender_channels.size(), 4);  // Channels 0, 1, 2, 3
+}
+
+// ============ Mapping-Driven Connection Tests ============
+
+TEST_F(RouterConnectionsTest, Phase2_MappingDriven_MeshToMesh_1D) {
+    // Use connection mapping to drive connection setup
+
+    // Create mappings for two 1D mesh routers
+    auto north_mapping = RouterConnectionMapping::for_mesh_router(
+        Topology::Linear,
+        RoutingDirection::N,
+        false);
+
+    auto south_mapping = RouterConnectionMapping::for_mesh_router(
+        Topology::Linear,
+        RoutingDirection::S,
+        false);
+
+    FabricNodeId north_node(MeshId{0}, 0);
+    FabricNodeId south_node(MeshId{0}, 1);
+
+    // North router connects to South (driven by mapping)
+    auto north_targets = north_mapping.get_downstream_targets(0, 1);
+    ASSERT_EQ(north_targets.size(), 1);
+    EXPECT_EQ(north_targets[0].target_direction.value(), RoutingDirection::S);
+
+    record_test_connection(
+        registry_,
+        north_node, RoutingDirection::N, 0,
+        0, 1,  // VC0, sender channel 1
+        south_node, RoutingDirection::S, 0,
+        0, 0,  // VC0, receiver channel 0
+        ConnectionType::INTRA_MESH);
+
+    // South router connects to North (driven by mapping)
+    auto south_targets = south_mapping.get_downstream_targets(0, 1);
+    ASSERT_EQ(south_targets.size(), 1);
+    EXPECT_EQ(south_targets[0].target_direction.value(), RoutingDirection::N);
+
+    record_test_connection(
+        registry_,
+        south_node, RoutingDirection::S, 0,
+        0, 1,  // VC0, sender channel 1
+        north_node, RoutingDirection::N, 0,
+        0, 0,  // VC0, receiver channel 0
+        ConnectionType::INTRA_MESH);
+
+    // Verify bidirectional connection
+    EXPECT_EQ(registry_->size(), 2);
+
+    auto north_out = registry_->get_connections_by_source_node(north_node);
+    auto south_out = registry_->get_connections_by_source_node(south_node);
+
+    EXPECT_EQ(north_out.size(), 1);
+    EXPECT_EQ(south_out.size(), 1);
+}
+
+TEST_F(RouterConnectionsTest, Phase2_MappingDriven_MeshToMesh_2D) {
+    // Use connection mapping for 2D mesh
+
+    // Create mapping for NORTH router in 2D mesh
+    auto north_mapping = RouterConnectionMapping::for_mesh_router(
+        Topology::Mesh,
+        RoutingDirection::N,
+        false);
+
+    FabricNodeId north_node(MeshId{0}, 0);
+
+    // NORTH router should have 3 sender channels (1-3) for INTRA_MESH
+    EXPECT_EQ(north_mapping.get_total_sender_count(), 3);
+
+    // Verify channel 1 → SOUTH (opposite)
+    auto ch1_targets = north_mapping.get_downstream_targets(0, 1);
+    ASSERT_EQ(ch1_targets.size(), 1);
+    EXPECT_EQ(ch1_targets[0].target_direction.value(), RoutingDirection::S);
+    EXPECT_EQ(ch1_targets[0].type, ConnectionType::INTRA_MESH);
+
+    // Verify channels 2-3 → cross directions (EAST/WEST)
+    auto ch2_targets = north_mapping.get_downstream_targets(0, 2);
+    auto ch3_targets = north_mapping.get_downstream_targets(0, 3);
+
+    ASSERT_EQ(ch2_targets.size(), 1);
+    ASSERT_EQ(ch3_targets.size(), 1);
+
+    std::set<RoutingDirection> cross_dirs = {
+        ch2_targets[0].target_direction.value(),
+        ch3_targets[0].target_direction.value()
+    };
+
+    EXPECT_TRUE(cross_dirs.count(RoutingDirection::E));
+    EXPECT_TRUE(cross_dirs.count(RoutingDirection::W));
+
+    // Record all connections
+    FabricNodeId south_node(MeshId{0}, 1);
+    FabricNodeId east_node(MeshId{0}, 2);
+    FabricNodeId west_node(MeshId{0}, 3);
+
+    record_test_connection(
+        registry_,
+        north_node, RoutingDirection::N, 0,
+        0, 1,
+        south_node, RoutingDirection::S, 0,
+        0, 0,
+        ConnectionType::INTRA_MESH);
+
+    record_test_connection(
+        registry_,
+        north_node, RoutingDirection::N, 0,
+        0, 2,
+        east_node, RoutingDirection::E, 0,
+        0, 0,
+        ConnectionType::INTRA_MESH);
+
+    record_test_connection(
+        registry_,
+        north_node, RoutingDirection::N, 0,
+        0, 3,
+        west_node, RoutingDirection::W, 0,
+        0, 0,
+        ConnectionType::INTRA_MESH);
+
+    EXPECT_EQ(registry_->size(), 3);
+}
+
+TEST_F(RouterConnectionsTest, Phase2_MappingDriven_MeshToZ) {
+    // Use connection mapping to set up MESH_TO_Z connection
+
+    // Create mapping for mesh router with Z
+    auto mesh_mapping = RouterConnectionMapping::for_mesh_router(
+        Topology::Mesh,
+        RoutingDirection::N,
+        true);  // Has Z router
+
+    FabricNodeId mesh_node(MeshId{0}, 0);
+    FabricNodeId z_node(MeshId{0}, 100);
+
+    // Verify mapping has 4 sender channels (3 INTRA_MESH + 1 MESH_TO_Z)
+    EXPECT_EQ(mesh_mapping.get_total_sender_count(), 4);
+
+    // Channel 4 should be MESH_TO_Z
+    auto z_targets = mesh_mapping.get_downstream_targets(0, 4);
+    ASSERT_EQ(z_targets.size(), 1);
+    EXPECT_EQ(z_targets[0].type, ConnectionType::MESH_TO_Z);
+    EXPECT_EQ(z_targets[0].target_direction.value(), RoutingDirection::Z);
+
+    // Record MESH_TO_Z connection
+    record_test_connection(
+        registry_,
+        mesh_node, RoutingDirection::N, 0,
+        0, 4,  // VC0, MESH_TO_Z channel 4
+        z_node, RoutingDirection::Z, 0,
+        0, 0,  // Z router VC0, receiver channel 0
+        ConnectionType::MESH_TO_Z);
+
+    EXPECT_EQ(registry_->size(), 1);
+
+    auto mesh_to_z = registry_->get_connections_by_type(ConnectionType::MESH_TO_Z);
+    EXPECT_EQ(mesh_to_z.size(), 1);
+    EXPECT_EQ(mesh_to_z[0].source_sender_channel, 4);
+}
+
+TEST_F(RouterConnectionsTest, Phase2_MappingDriven_ZToMesh_AllDirections) {
+    // Use connection mapping to set up Z_TO_MESH connections
+
+    // Create mapping for Z router
+    auto z_mapping = RouterConnectionMapping::for_z_router();
+
+    FabricNodeId z_node(MeshId{0}, 100);
+
+    // Z router should have 4 sender channels on VC1
+    EXPECT_EQ(z_mapping.get_total_sender_count(), 4);
+
+    // Verify each channel maps to correct direction
+    std::vector<std::pair<uint32_t, RoutingDirection>> expected_mappings = {
+        {0, RoutingDirection::N},
+        {1, RoutingDirection::E},
+        {2, RoutingDirection::S},
+        {3, RoutingDirection::W}
+    };
+
+    for (const auto& [channel, expected_dir] : expected_mappings) {
+        auto targets = z_mapping.get_downstream_targets(1, channel);
+        ASSERT_EQ(targets.size(), 1);
+        EXPECT_EQ(targets[0].type, ConnectionType::Z_TO_MESH);
+        EXPECT_EQ(targets[0].target_direction.value(), expected_dir);
+        EXPECT_EQ(targets[0].target_vc, 1);  // Target mesh router VC1
+
+        // Record connection
+        FabricNodeId mesh_node(MeshId{0}, channel);
+        record_test_connection(
+            registry_,
+            z_node, RoutingDirection::Z, 0,
+            1, channel,  // VC1, sender channel
+            mesh_node, expected_dir, 0,
+            1, 0,  // Mesh router VC1
+            ConnectionType::Z_TO_MESH);
+    }
+
+    EXPECT_EQ(registry_->size(), 4);
+
+    auto z_to_mesh = registry_->get_connections_by_type(ConnectionType::Z_TO_MESH);
+    EXPECT_EQ(z_to_mesh.size(), 4);
+
+    // Verify all use VC1 (Z VC1 → mesh VC1)
+    for (const auto& conn : z_to_mesh) {
+        EXPECT_EQ(conn.source_vc, 1);
+        EXPECT_EQ(conn.dest_vc, 1);
+    }
+}
+
+TEST_F(RouterConnectionsTest, Phase2_MappingDriven_FullDevice_Connections) {
+    // Simulate FabricBuilder connection establishment using connection mappings
+    // Full device: 4 mesh routers + 1 Z router
+
+    std::vector<RoutingDirection> mesh_directions = {
+        RoutingDirection::N,
+        RoutingDirection::E,
+        RoutingDirection::S,
+        RoutingDirection::W
+    };
+
+    FabricNodeId z_node(MeshId{0}, 100);
+
+    // Step 1: Create mesh router mappings and record MESH_TO_Z connections
+    for (size_t i = 0; i < 4; ++i) {
+        auto mesh_mapping = RouterConnectionMapping::for_mesh_router(
+            Topology::Mesh,
+            mesh_directions[i],
+            true);  // Has Z router
+
+        FabricNodeId mesh_node(MeshId{0}, i);
+
+        // Record MESH_TO_Z connection (channel 4)
+        auto z_targets = mesh_mapping.get_downstream_targets(0, 4);
+        ASSERT_EQ(z_targets.size(), 1);
+
+        record_test_connection(
+            registry_,
+            mesh_node, mesh_directions[i], static_cast<uint8_t>(i),
+            0, 4,
+            z_node, RoutingDirection::Z, 0,
+            0, 0,
+            ConnectionType::MESH_TO_Z);
+    }
+
+    // Step 2: Create Z router mapping and record Z_TO_MESH connections
+    auto z_mapping = RouterConnectionMapping::for_z_router();
+
+    for (uint32_t ch = 0; ch < 4; ++ch) {
+        auto targets = z_mapping.get_downstream_targets(1, ch);
+        ASSERT_EQ(targets.size(), 1);
+
+        FabricNodeId mesh_node(MeshId{0}, ch);
+
+        record_test_connection(
+            registry_,
+            z_node, RoutingDirection::Z, 0,
+            1, ch,
+            mesh_node, mesh_directions[ch], static_cast<uint8_t>(ch),
+            1, 0,
+            ConnectionType::Z_TO_MESH);
+    }
+
+    // Verify total connections: 4 MESH_TO_Z + 4 Z_TO_MESH = 8
+    EXPECT_EQ(registry_->size(), 8);
+
+    auto mesh_to_z = registry_->get_connections_by_type(ConnectionType::MESH_TO_Z);
+    auto z_to_mesh = registry_->get_connections_by_type(ConnectionType::Z_TO_MESH);
+
+    EXPECT_EQ(mesh_to_z.size(), 4);
+    EXPECT_EQ(z_to_mesh.size(), 4);
+
+    // Verify Z router receives from all 4 mesh routers
+    auto z_incoming = registry_->get_connections_by_dest_node(z_node);
+    EXPECT_EQ(z_incoming.size(), 4);
+
+    // Verify Z router sends to all 4 mesh routers
+    auto z_outgoing = registry_->get_connections_by_source_node(z_node);
+    EXPECT_EQ(z_outgoing.size(), 4);
+}
+
+TEST_F(RouterConnectionsTest, Phase2_MappingDriven_EdgeDevice_DynamicSizing) {
+    // Edge device with only 2 mesh routers (NORTH and EAST) + Z router
+    // Demonstrates dynamic sizing: Z mapping has 4 intents, only 2 realized
+
+    std::vector<RoutingDirection> existing_mesh = {
+        RoutingDirection::N,
+        RoutingDirection::E
+    };
+
+    FabricNodeId z_node(MeshId{0}, 100);
+
+    // Step 1: Mesh routers connect to Z
+    for (size_t i = 0; i < 2; ++i) {
+        auto mesh_mapping = RouterConnectionMapping::for_mesh_router(
+            Topology::Mesh,
+            existing_mesh[i],
+            true);
+
+        FabricNodeId mesh_node(MeshId{0}, i);
+
+        auto z_targets = mesh_mapping.get_downstream_targets(0, 4);
+        ASSERT_EQ(z_targets.size(), 1);
+
+        record_test_connection(
+            registry_,
+            mesh_node, existing_mesh[i], static_cast<uint8_t>(i),
+            0, 4,
+            z_node, RoutingDirection::Z, 0,
+            0, 0,
+            ConnectionType::MESH_TO_Z);
+    }
+
+    // Step 2: Z router connects to mesh (only existing ones)
+    auto z_mapping = RouterConnectionMapping::for_z_router();
+
+    // Z mapping has 4 intents, but we only realize 2
+    std::set<RoutingDirection> existing_set(existing_mesh.begin(), existing_mesh.end());
+
+    for (uint32_t ch = 0; ch < 4; ++ch) {
+        auto targets = z_mapping.get_downstream_targets(1, ch);
+        ASSERT_EQ(targets.size(), 1);
+
+        // Only record if target router exists (FabricBuilder connection logic)
+        if (existing_set.count(targets[0].target_direction.value())) {
+            FabricNodeId mesh_node(MeshId{0}, ch);
+
+            record_test_connection(
+                registry_,
+                z_node, RoutingDirection::Z, 0,
+                1, ch,
+                mesh_node, targets[0].target_direction.value(), static_cast<uint8_t>(ch),
+                1, 0,
+                ConnectionType::Z_TO_MESH);
+        }
+    }
+
+    // Verify connections: 2 MESH_TO_Z + 2 Z_TO_MESH = 4
+    EXPECT_EQ(registry_->size(), 4);
+
+    auto mesh_to_z = registry_->get_connections_by_type(ConnectionType::MESH_TO_Z);
+    auto z_to_mesh = registry_->get_connections_by_type(ConnectionType::Z_TO_MESH);
+
+    EXPECT_EQ(mesh_to_z.size(), 2);
+    EXPECT_EQ(z_to_mesh.size(), 2);
+}
+
+TEST_F(RouterConnectionsTest, Phase2_ChannelMapping_And_ConnectionMapping_Consistency) {
+    // Verify channel mapping and connection mapping are consistent
+
+    // Create Z router channel mapping
+    auto intermesh_config = IntermeshVCConfig::full_mesh();
+    FabricRouterChannelMapping z_channel_mapping(
+        Topology::Mesh,
+        false,
+        RouterVariant::Z_ROUTER,         &intermesh_config);
+
+    // Create Z router connection mapping
+    auto z_conn_mapping = RouterConnectionMapping::for_z_router();
+
+    // Verify VC1 sender channel count matches
+    uint32_t channel_map_senders = z_channel_mapping.get_num_sender_channels_for_vc(1);
+    uint32_t conn_map_senders = z_conn_mapping.get_total_sender_count();
+
+    EXPECT_EQ(channel_map_senders, 4);
+    EXPECT_EQ(conn_map_senders, 4);
+
+    // Verify each sender channel in channel mapping has connection targets
+    for (uint32_t ch = 0; ch < channel_map_senders; ++ch) {
+        EXPECT_TRUE(z_conn_mapping.has_targets(1, ch))
+            << "Channel " << ch << " should have connection targets";
+
+        auto targets = z_conn_mapping.get_downstream_targets(1, ch);
+        EXPECT_EQ(targets.size(), 1)
+            << "Channel " << ch << " should have exactly 1 target";
+    }
+}
+
+}  // namespace tt::tt_fabric

--- a/tests/tt_metal/tt_fabric/fabric_router/test_router_connections.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_router_connections.cpp
@@ -89,12 +89,12 @@ void record_test_connection(
         .source_direction = source_dir,
         .source_eth_chan = source_eth_chan,
         .source_vc = source_vc,
-        .source_sender_channel = source_sender_ch,
+        .source_receiver_channel = source_sender_ch,
         .dest_node = dest_node,
         .dest_direction = dest_dir,
         .dest_eth_chan = dest_eth_chan,
         .dest_vc = dest_vc,
-        .dest_receiver_channel = dest_receiver_ch,
+        .dest_sender_channel = dest_receiver_ch,
         .connection_type = conn_type
     };
 
@@ -294,7 +294,7 @@ TEST_F(RouterConnectionsTest, MeshToZ_MultipleMeshRouters) {
     // All should target VC1 receiver channel 0 (multi-target receiver)
     for (const auto& conn : z_incoming) {
         EXPECT_EQ(conn.dest_vc, 1);
-        EXPECT_EQ(conn.dest_receiver_channel, 0);  // All target same receiver
+        EXPECT_EQ(conn.dest_sender_channel, 0);  // All target same receiver
         EXPECT_EQ(conn.connection_type, ConnectionType::MESH_TO_Z);
     }
 
@@ -353,7 +353,7 @@ TEST_F(RouterConnectionsTest, ZToMesh_VC1_Connection) {
     const auto& conn = z_to_mesh[0];
     EXPECT_EQ(conn.source_direction, RoutingDirection::Z);
     EXPECT_EQ(conn.source_vc, 1);
-    EXPECT_EQ(conn.source_sender_channel, 0);
+    EXPECT_EQ(conn.source_receiver_channel, 0);
     EXPECT_EQ(conn.dest_direction, RoutingDirection::N);
     EXPECT_EQ(conn.dest_vc, 1);
     EXPECT_EQ(conn.connection_type, ConnectionType::Z_TO_MESH);
@@ -391,7 +391,7 @@ TEST_F(RouterConnectionsTest, ZToMesh_AllFourDirections) {
     std::set<uint32_t> sender_channels;
     for (const auto& conn : z_outgoing) {
         EXPECT_EQ(conn.source_vc, 1);
-        sender_channels.insert(conn.source_sender_channel);
+        sender_channels.insert(conn.source_receiver_channel);
     }
     EXPECT_EQ(sender_channels.size(), 4);  // All 4 channels used
 }
@@ -592,7 +592,7 @@ TEST_F(RouterConnectionsTest, Phase1_5_ZRouter_MultiTargetReceiver_Validation) {
     // Critical validation: All 4 connections target the SAME receiver
     for (const auto& conn : z_incoming) {
         EXPECT_EQ(conn.dest_vc, 1);
-        EXPECT_EQ(conn.dest_receiver_channel, 0);  // Same receiver for all!
+        EXPECT_EQ(conn.dest_sender_channel, 0);  // Same receiver for all!
         EXPECT_EQ(conn.dest_direction, RoutingDirection::Z);
     }
 
@@ -636,7 +636,7 @@ TEST_F(RouterConnectionsTest, Phase1_5_EdgeDevice_VariableTargetCount) {
 
     // Both target same receiver (multi-target with count=2)
     for (const auto& conn : z_incoming) {
-        EXPECT_EQ(conn.dest_receiver_channel, 0);
+        EXPECT_EQ(conn.dest_sender_channel, 0);
     }
 }
 
@@ -687,13 +687,13 @@ TEST_F(RouterConnectionsTest, Phase1_5_Bidirectional_ZAndMesh) {
 
     // All incoming target same receiver (multi-target)
     for (const auto& conn : z_in) {
-        EXPECT_EQ(conn.dest_receiver_channel, 0);
+        EXPECT_EQ(conn.dest_sender_channel, 0);
     }
 
     // All outgoing use different sender channels
     std::set<uint32_t> sender_channels;
     for (const auto& conn : z_out) {
-        sender_channels.insert(conn.source_sender_channel);
+        sender_channels.insert(conn.source_receiver_channel);
     }
     EXPECT_EQ(sender_channels.size(), 4);  // Channels 0, 1, 2, 3
 }
@@ -854,7 +854,7 @@ TEST_F(RouterConnectionsTest, Phase2_MappingDriven_MeshToZ) {
 
     auto mesh_to_z = registry_->get_connections_by_type(ConnectionType::MESH_TO_Z);
     EXPECT_EQ(mesh_to_z.size(), 1);
-    EXPECT_EQ(mesh_to_z[0].source_sender_channel, 4);
+    EXPECT_EQ(mesh_to_z[0].source_receiver_channel, 4);
 }
 
 TEST_F(RouterConnectionsTest, Phase2_MappingDriven_ZToMesh_AllDirections) {

--- a/tests/tt_metal/tt_fabric/fabric_router/test_z_router_device_detection.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_z_router_device_detection.cpp
@@ -146,8 +146,11 @@ TEST_F(ZRouterDeviceDetectionTest, MeshRouter_WithZ_CorrectChannelCounts) {
     uint32_t intra_mesh_count = 0;
     uint32_t mesh_to_z_count = 0;
     for (const auto& target : targets) {
-        if (target.type == ConnectionType::INTRA_MESH) intra_mesh_count++;
-        else if (target.type == ConnectionType::MESH_TO_Z) mesh_to_z_count++;
+        if (target.type == ConnectionType::INTRA_MESH) {
+            intra_mesh_count++;
+        } else if (target.type == ConnectionType::MESH_TO_Z) {
+            mesh_to_z_count++;
+        }
     }
     EXPECT_EQ(intra_mesh_count, 3);
     EXPECT_EQ(mesh_to_z_count, 1);

--- a/tests/tt_metal/tt_fabric/fabric_router/test_z_router_device_detection.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_z_router_device_detection.cpp
@@ -1,0 +1,271 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+#include "tt_metal/fabric/builder/router_connection_mapping.hpp"
+#include "tt_metal/fabric/builder/connection_registry.hpp"
+#include <tt-metalium/experimental/fabric/fabric_edm_types.hpp>
+
+namespace tt::tt_fabric {
+
+/**
+ * Test fixture for Z router device detection and connection mapping
+ *
+ * These tests validate that:
+ * - Mesh routers without Z create only INTRA_MESH connections
+ * - Mesh routers with Z create INTRA_MESH + MESH_TO_Z connections
+ * - Z routers create Z_TO_MESH connections on VC1
+ * - Connection targets have correct VCs and directions
+ *
+ * All tests are pure unit tests - no devices required.
+ *
+ * Test Coverage Summary:
+ * ┌──────────────────────────────────────────────────────────────────────────────────────┐
+ * │ Category                    │ Test Name                                │ Focus        │
+ * ├─────────────────────────────┼──────────────────────────────────────────┼──────────────┤
+ * │ Mesh Router Without Z       │ MeshRouter_NoZ_OnlyIntraMeshConnections  │ Basic mesh   │
+ * │                             │ MeshRouter_NoZ_AllDirections             │ All dirs     │
+ * │                             │ MeshRouter_NoZ_1D_NoExtraChannel         │ 1D topology  │
+ * ├─────────────────────────────┼──────────────────────────────────────────┼──────────────┤
+ * │ Mesh Router With Z          │ MeshRouter_WithZ_HasMeshToZConnection    │ Z connection │
+ * │                             │ MeshRouter_WithZ_AllDirections           │ All dirs+Z   │
+ * │                             │ MeshRouter_WithZ_TargetsZDirection       │ Z targeting  │
+ * ├─────────────────────────────┼──────────────────────────────────────────┼──────────────┤
+ * │ Z Router                    │ ZRouter_VC1_HasZToMeshConnections        │ VC1 senders  │
+ * │                             │ ZRouter_VC0_NoSenderConnections          │ VC0 receivers│
+ * │                             │ ZRouter_AllDirections_TargetMeshVC1      │ All dirs     │
+ * ├─────────────────────────────┼──────────────────────────────────────────┼──────────────┤
+ * │ Comparison Tests            │ Compare_MeshWithZ_vs_MeshWithoutZ        │ Diff analysis│
+ * │                             │ Compare_ZRouter_vs_MeshRouter            │ Type diff    │
+ * │                             │ Compare_AllThreeConfigurations           │ Full matrix  │
+ * └─────────────────────────────┴──────────────────────────────────────────┴──────────────┘
+ *
+ * Total: 12 tests across 4 categories
+ */
+class ZRouterDeviceDetectionTest : public ::testing::Test {
+protected:
+    void SetUp() override {}
+    void TearDown() override {}
+};
+
+// ============ Mesh Router Without Z Tests ============
+
+TEST_F(ZRouterDeviceDetectionTest, MeshRouter_NoZ_OnlyIntraMeshConnections) {
+    // Mesh router without Z connections (typical mesh router)
+    auto mapping = RouterConnectionMapping::for_mesh_router(
+        Topology::Mesh, RoutingDirection::E, false);
+
+    // Verify only INTRA_MESH connections exist on VC0
+    // EAST router connects to: WEST (ch1), NORTH (ch2), SOUTH (ch3)
+    for (uint32_t ch = 1; ch <= 3; ++ch) {
+        auto targets = mapping.get_downstream_targets(0, ch);
+        ASSERT_FALSE(targets.empty()) << "Channel " << ch << " should have targets";
+        EXPECT_EQ(targets[0].type, ConnectionType::INTRA_MESH);
+        EXPECT_EQ(targets[0].target_vc, 0) << "INTRA_MESH should target VC0";
+    }
+
+    // Channel 4 should not exist (no Z connection)
+    auto ch4_targets = mapping.get_downstream_targets(0, 4);
+    EXPECT_TRUE(ch4_targets.empty()) << "Channel 4 should not exist without Z";
+}
+
+TEST_F(ZRouterDeviceDetectionTest, MeshRouter_NoZ_AllDirections) {
+    // Test all 4 mesh directions without Z
+    std::vector<RoutingDirection> directions = {
+        RoutingDirection::N, RoutingDirection::E, RoutingDirection::S, RoutingDirection::W};
+
+    for (auto direction : directions) {
+        auto mapping = RouterConnectionMapping::for_mesh_router(
+            Topology::Mesh, direction, false);
+
+        // Each direction should have 3 INTRA_MESH connections
+        for (uint32_t ch = 1; ch <= 3; ++ch) {
+            auto targets = mapping.get_downstream_targets(0, ch);
+            ASSERT_FALSE(targets.empty()) << "Direction " << static_cast<int>(direction) << " channel " << ch;
+            EXPECT_EQ(targets[0].type, ConnectionType::INTRA_MESH);
+        }
+
+        // No Z connection
+        EXPECT_TRUE(mapping.get_downstream_targets(0, 4).empty());
+    }
+}
+
+TEST_F(ZRouterDeviceDetectionTest, MeshRouter_NoZ_1D_NoExtraChannel) {
+    // 1D mesh router without Z
+    auto mapping = RouterConnectionMapping::for_mesh_router(
+        Topology::Linear, RoutingDirection::E, false);
+
+    // 1D has only 1 INTRA_MESH connection
+    auto targets = mapping.get_downstream_targets(0, 1);
+    ASSERT_FALSE(targets.empty());
+    EXPECT_EQ(targets[0].type, ConnectionType::INTRA_MESH);
+
+    // No Z connection in 1D either
+    EXPECT_TRUE(mapping.get_downstream_targets(0, 2).empty());
+}
+
+// ============ Mesh Router With Z Tests ============
+
+TEST_F(ZRouterDeviceDetectionTest, MeshRouter_WithZ_HasMeshToZConnection) {
+    // Mesh router WITH Z connections (device with vertical stacking)
+    auto mapping = RouterConnectionMapping::for_mesh_router(
+        Topology::Mesh, RoutingDirection::E, true);
+
+    // Verify INTRA_MESH connections still exist (channels 1-3)
+    for (uint32_t ch = 1; ch <= 3; ++ch) {
+        auto targets = mapping.get_downstream_targets(0, ch);
+        ASSERT_FALSE(targets.empty()) << "Channel " << ch << " should have targets";
+        EXPECT_EQ(targets[0].type, ConnectionType::INTRA_MESH);
+        EXPECT_EQ(targets[0].target_vc, 0) << "INTRA_MESH should target VC0";
+    }
+
+    // Channel 4 should have MESH_TO_Z connection
+    auto z_targets = mapping.get_downstream_targets(0, 4);
+    ASSERT_EQ(z_targets.size(), 1) << "Channel 4 should have exactly one Z target";
+    EXPECT_EQ(z_targets[0].type, ConnectionType::MESH_TO_Z);
+    EXPECT_EQ(z_targets[0].target_direction.value(), RoutingDirection::Z);
+    EXPECT_EQ(z_targets[0].target_vc, 0) << "MESH_TO_Z should target Z router VC0";
+}
+
+TEST_F(ZRouterDeviceDetectionTest, MeshRouter_WithZ_CorrectChannelCounts) {
+    auto mapping = RouterConnectionMapping::for_mesh_router(
+        Topology::Mesh, RoutingDirection::E, true);
+
+    // Verify we have targets for channels 1, 2, 3 (mesh) and 4 (Z)
+    EXPECT_FALSE(mapping.get_downstream_targets(0, 1).empty()) << "Channel 1 (mesh)";
+    EXPECT_FALSE(mapping.get_downstream_targets(0, 2).empty()) << "Channel 2 (mesh)";
+    EXPECT_FALSE(mapping.get_downstream_targets(0, 3).empty()) << "Channel 3 (mesh)";
+    EXPECT_FALSE(mapping.get_downstream_targets(0, 4).empty()) << "Channel 4 (Z)";
+
+    // Channel 5 should not exist
+    EXPECT_TRUE(mapping.get_downstream_targets(0, 5).empty()) << "Channel 5 should not exist";
+}
+
+TEST_F(ZRouterDeviceDetectionTest, MeshRouter_WithZ_AllDirections) {
+    // Test all 4 mesh directions with Z
+    std::vector<RoutingDirection> directions = {
+        RoutingDirection::N, RoutingDirection::E, RoutingDirection::S, RoutingDirection::W};
+
+    for (auto direction : directions) {
+        auto mapping = RouterConnectionMapping::for_mesh_router(
+            Topology::Mesh, direction, true);
+
+        // Each direction should have 3 INTRA_MESH + 1 MESH_TO_Z
+        for (uint32_t ch = 1; ch <= 3; ++ch) {
+            auto targets = mapping.get_downstream_targets(0, ch);
+            ASSERT_FALSE(targets.empty()) << "Direction " << static_cast<int>(direction) << " channel " << ch;
+            EXPECT_EQ(targets[0].type, ConnectionType::INTRA_MESH);
+        }
+
+        // Z connection on channel 4
+        auto z_targets = mapping.get_downstream_targets(0, 4);
+        ASSERT_FALSE(z_targets.empty()) << "Direction " << static_cast<int>(direction) << " should have Z";
+        EXPECT_EQ(z_targets[0].type, ConnectionType::MESH_TO_Z);
+        EXPECT_EQ(z_targets[0].target_direction.value(), RoutingDirection::Z);
+    }
+}
+
+TEST_F(ZRouterDeviceDetectionTest, MeshRouter_WithZ_1D_HasZConnection) {
+    // 1D mesh router with Z
+    auto mapping = RouterConnectionMapping::for_mesh_router(
+        Topology::Linear, RoutingDirection::E, true);
+
+    // 1D has 1 INTRA_MESH connection
+    auto mesh_targets = mapping.get_downstream_targets(0, 1);
+    ASSERT_FALSE(mesh_targets.empty());
+    EXPECT_EQ(mesh_targets[0].type, ConnectionType::INTRA_MESH);
+
+    // Z connection on channel 2 (after the 1 mesh channel)
+    auto z_targets = mapping.get_downstream_targets(0, 2);
+    ASSERT_FALSE(z_targets.empty());
+    EXPECT_EQ(z_targets[0].type, ConnectionType::MESH_TO_Z);
+    EXPECT_EQ(z_targets[0].target_direction.value(), RoutingDirection::Z);
+}
+
+// ============ Z Router Tests ============
+
+TEST_F(ZRouterDeviceDetectionTest, ZRouter_VC1_FourDirectionalConnections) {
+    auto mapping = RouterConnectionMapping::for_z_router();
+
+    // Z router VC1 should connect to all 4 mesh directions
+    std::vector<RoutingDirection> expected_directions = {
+        RoutingDirection::N,  // Sender channel 0
+        RoutingDirection::E,  // Sender channel 1
+        RoutingDirection::S,  // Sender channel 2
+        RoutingDirection::W   // Sender channel 3
+    };
+
+    for (size_t ch = 0; ch < 4; ++ch) {
+        auto targets = mapping.get_downstream_targets(1, ch);
+        ASSERT_EQ(targets.size(), 1) << "VC1 channel " << ch << " should have one target";
+        EXPECT_EQ(targets[0].type, ConnectionType::Z_TO_MESH);
+        EXPECT_EQ(targets[0].target_vc, 1) << "Z_TO_MESH should target mesh router VC1";
+        EXPECT_EQ(targets[0].target_direction.value(), expected_directions[ch]);
+    }
+}
+
+TEST_F(ZRouterDeviceDetectionTest, ZRouter_VC0_NoConnections) {
+    auto mapping = RouterConnectionMapping::for_z_router();
+
+    // Z router VC0 is currently unused/reserved
+    // Check that no connections are defined on VC0
+    for (uint32_t ch = 0; ch < 4; ++ch) {
+        auto targets = mapping.get_downstream_targets(0, ch);
+        EXPECT_TRUE(targets.empty()) << "Z router VC0 channel " << ch << " should have no connections";
+    }
+}
+
+TEST_F(ZRouterDeviceDetectionTest, ZRouter_VC1_CorrectTargetVCs) {
+    auto mapping = RouterConnectionMapping::for_z_router();
+
+    // All Z_TO_MESH connections should target VC1 on mesh routers
+    for (uint32_t ch = 0; ch < 4; ++ch) {
+        auto targets = mapping.get_downstream_targets(1, ch);
+        ASSERT_FALSE(targets.empty());
+        EXPECT_EQ(targets[0].target_vc, 1) << "Z traffic should target mesh router VC1, not VC0";
+    }
+}
+
+// ============ Comparison Tests ============
+
+TEST_F(ZRouterDeviceDetectionTest, Comparison_MeshWithZ_vs_MeshWithoutZ) {
+    auto mapping_no_z = RouterConnectionMapping::for_mesh_router(
+        Topology::Mesh, RoutingDirection::E, false);
+    auto mapping_with_z = RouterConnectionMapping::for_mesh_router(
+        Topology::Mesh, RoutingDirection::E, true);
+
+    // Both should have same INTRA_MESH connections (channels 1-3)
+    for (uint32_t ch = 1; ch <= 3; ++ch) {
+        auto targets_no_z = mapping_no_z.get_downstream_targets(0, ch);
+        auto targets_with_z = mapping_with_z.get_downstream_targets(0, ch);
+
+        ASSERT_FALSE(targets_no_z.empty());
+        ASSERT_FALSE(targets_with_z.empty());
+        EXPECT_EQ(targets_no_z[0].type, targets_with_z[0].type);
+    }
+
+    // Only mapping_with_z should have channel 4
+    EXPECT_TRUE(mapping_no_z.get_downstream_targets(0, 4).empty());
+    EXPECT_FALSE(mapping_with_z.get_downstream_targets(0, 4).empty());
+}
+
+TEST_F(ZRouterDeviceDetectionTest, Comparison_2D_vs_1D_WithZ) {
+    auto mapping_2d = RouterConnectionMapping::for_mesh_router(
+        Topology::Mesh, RoutingDirection::E, true);
+    auto mapping_1d = RouterConnectionMapping::for_mesh_router(
+        Topology::Linear, RoutingDirection::E, true);
+
+    // 2D: 3 mesh + 1 Z = 4 channels
+    EXPECT_FALSE(mapping_2d.get_downstream_targets(0, 1).empty());
+    EXPECT_FALSE(mapping_2d.get_downstream_targets(0, 2).empty());
+    EXPECT_FALSE(mapping_2d.get_downstream_targets(0, 3).empty());
+    EXPECT_FALSE(mapping_2d.get_downstream_targets(0, 4).empty());
+
+    // 1D: 1 mesh + 1 Z = 2 channels
+    EXPECT_FALSE(mapping_1d.get_downstream_targets(0, 1).empty());
+    EXPECT_FALSE(mapping_1d.get_downstream_targets(0, 2).empty());
+    EXPECT_TRUE(mapping_1d.get_downstream_targets(0, 3).empty());
+}
+
+}  // namespace tt::tt_fabric

--- a/tests/tt_metal/tt_fabric/fabric_router/test_z_router_device_detection.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_z_router_device_detection.cpp
@@ -60,7 +60,7 @@ TEST_F(ZRouterDeviceDetectionTest, MeshRouter_NoZ_OnlyIntraMeshConnections) {
     // EAST router receiver channel 0 connects to: WEST, NORTH, SOUTH
     auto targets = mapping.get_downstream_targets(0, 0);
     ASSERT_EQ(targets.size(), 3) << "Receiver channel 0 should have 3 targets";
-    
+
     for (const auto& target : targets) {
         EXPECT_EQ(target.type, ConnectionType::INTRA_MESH);
         EXPECT_EQ(target.target_vc, 0) << "INTRA_MESH should target VC0";
@@ -82,7 +82,7 @@ TEST_F(ZRouterDeviceDetectionTest, MeshRouter_NoZ_AllDirections) {
         // Receiver channel 0 should have 3 INTRA_MESH targets
         auto targets = mapping.get_downstream_targets(0, 0);
         ASSERT_EQ(targets.size(), 3) << "Direction " << static_cast<int>(direction);
-        
+
         for (const auto& target : targets) {
             EXPECT_EQ(target.type, ConnectionType::INTRA_MESH);
         }
@@ -119,7 +119,7 @@ TEST_F(ZRouterDeviceDetectionTest, MeshRouter_WithZ_HasMeshToZConnection) {
 
     uint32_t intra_mesh_count = 0;
     uint32_t mesh_to_z_count = 0;
-    
+
     for (const auto& target : targets) {
         if (target.type == ConnectionType::INTRA_MESH) {
             intra_mesh_count++;
@@ -130,7 +130,7 @@ TEST_F(ZRouterDeviceDetectionTest, MeshRouter_WithZ_HasMeshToZConnection) {
             EXPECT_EQ(target.target_vc, 0) << "MESH_TO_Z should target Z router VC0";
         }
     }
-    
+
     EXPECT_EQ(intra_mesh_count, 3);
     EXPECT_EQ(mesh_to_z_count, 1);
 }
@@ -171,7 +171,7 @@ TEST_F(ZRouterDeviceDetectionTest, MeshRouter_WithZ_AllDirections) {
 
         uint32_t intra_mesh_count = 0;
         uint32_t mesh_to_z_count = 0;
-        
+
         for (const auto& target : targets) {
             if (target.type == ConnectionType::INTRA_MESH) {
                 intra_mesh_count++;
@@ -180,7 +180,7 @@ TEST_F(ZRouterDeviceDetectionTest, MeshRouter_WithZ_AllDirections) {
                 EXPECT_EQ(target.target_direction.value(), RoutingDirection::Z);
             }
         }
-        
+
         EXPECT_EQ(intra_mesh_count, 3);
         EXPECT_EQ(mesh_to_z_count, 1);
     }
@@ -220,13 +220,12 @@ TEST_F(ZRouterDeviceDetectionTest, ZRouter_VC1_FourDirectionalConnections) {
 
     auto targets = mapping.get_downstream_targets(1, 0);
     ASSERT_EQ(targets.size(), 4) << "VC1 receiver channel 0 should have 4 targets";
-    
+
     // Verify all expected directions are present
     for (const auto& expected_dir : expected_directions) {
-        auto it = std::find_if(targets.begin(), targets.end(),
-            [expected_dir](const ConnectionTarget& t) { 
-                return t.target_direction == expected_dir; 
-            });
+        auto it = std::find_if(targets.begin(), targets.end(), [expected_dir](const ConnectionTarget& t) {
+            return t.target_direction == expected_dir;
+        });
         ASSERT_NE(it, targets.end()) << "Missing direction: " << static_cast<int>(expected_dir);
         EXPECT_EQ(it->type, ConnectionType::Z_TO_MESH);
         EXPECT_EQ(it->target_vc, 1) << "Z_TO_MESH should target mesh router VC1";
@@ -250,7 +249,7 @@ TEST_F(ZRouterDeviceDetectionTest, ZRouter_VC1_CorrectTargetVCs) {
     // All Z_TO_MESH connections from receiver channel 0 should target VC1 on mesh routers
     auto targets = mapping.get_downstream_targets(1, 0);
     ASSERT_EQ(targets.size(), 4);
-    
+
     for (const auto& target : targets) {
         EXPECT_EQ(target.target_vc, 1) << "Z traffic should target mesh router VC1, not VC0";
     }
@@ -276,7 +275,7 @@ TEST_F(ZRouterDeviceDetectionTest, Comparison_MeshWithZ_vs_MeshWithoutZ) {
         [](const ConnectionTarget& t) { return t.type == ConnectionType::INTRA_MESH; });
     uint32_t intra_mesh_with_z = std::count_if(targets_with_z.begin(), targets_with_z.end(),
         [](const ConnectionTarget& t) { return t.type == ConnectionType::INTRA_MESH; });
-    
+
     EXPECT_EQ(intra_mesh_no_z, 3);
     EXPECT_EQ(intra_mesh_with_z, 3);
 

--- a/tests/tt_metal/tt_fabric/fabric_router/test_z_router_integration.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_z_router_integration.cpp
@@ -46,12 +46,12 @@ protected:
             .source_direction = src_dir,
             .source_eth_chan = src_chan,
             .source_vc = src_vc,
-            .source_sender_channel = src_sender,
+            .source_receiver_channel = src_sender,
             .dest_node = dst_node,
             .dest_direction = dst_dir,
             .dest_eth_chan = dst_chan,
             .dest_vc = dst_vc,
-            .dest_receiver_channel = dst_receiver,
+            .dest_sender_channel = dst_receiver,
             .connection_type = type
         });
     }
@@ -123,7 +123,7 @@ TEST_F(ZRouterIntegrationTest, FullDevice_4Mesh1Z_BidirectionalConnectivity) {
     // Validate multi-target receiver: all MESH_TO_Z target same Z receiver
     for (const auto& conn : mesh_to_z) {
         EXPECT_EQ(conn.dest_vc, 0) << "MESH_TO_Z should target Z VC0";
-        EXPECT_EQ(conn.dest_receiver_channel, 0) << "All MESH_TO_Z should target same receiver (multi-target)";
+        EXPECT_EQ(conn.dest_sender_channel, 0) << "All MESH_TO_Z should target same receiver (multi-target)";
     }
 
     // Validate Z_TO_MESH uses VC1
@@ -259,12 +259,12 @@ TEST_F(ZRouterIntegrationTest, VariableMeshCount_AllConfigurations) {
                 .source_direction = all_dirs[i],
                 .source_eth_chan = static_cast<uint8_t>(i),
                 .source_vc = 0,
-                .source_sender_channel = builder_config::num_sender_channels_2d_mesh,
+                .source_receiver_channel = builder_config::num_sender_channels_2d_mesh,
                 .dest_node = device0,
                 .dest_direction = RoutingDirection::Z,
                 .dest_eth_chan = 4,
                 .dest_vc = 0,
-                .dest_receiver_channel = 0,
+                .dest_sender_channel = 0,
                 .connection_type = ConnectionType::MESH_TO_Z
             });
 
@@ -274,12 +274,12 @@ TEST_F(ZRouterIntegrationTest, VariableMeshCount_AllConfigurations) {
                 .source_direction = RoutingDirection::Z,
                 .source_eth_chan = 4,
                 .source_vc = 1,
-                .source_sender_channel = static_cast<uint32_t>(i),
+                .source_receiver_channel = static_cast<uint32_t>(i),
                 .dest_node = device0,
                 .dest_direction = all_dirs[i],
                 .dest_eth_chan = static_cast<uint8_t>(i),
                 .dest_vc = 1,
-                .dest_receiver_channel = 0,
+                .dest_sender_channel = 0,
                 .connection_type = ConnectionType::Z_TO_MESH
             });
         }
@@ -471,10 +471,10 @@ TEST_F(ZRouterIntegrationTest, ZRouter_VC0_NoDownstreamReceiverConnections) {
 
     const auto& conn = connections[0];
     EXPECT_EQ(conn.dest_vc, 0) << "MESH_TO_Z should target Z VC0";
-    EXPECT_EQ(conn.dest_receiver_channel, 0) << "Should target receiver channel, not sender";
+    EXPECT_EQ(conn.dest_sender_channel, 0) << "Should target receiver channel, not sender";
 
     // Note: There's no explicit "sender vs receiver" flag in the connection record,
-    // but the semantic is clear: dest_receiver_channel refers to the receiver side
+    // but the semantic is clear: dest_sender_channel refers to the receiver side
 }
 
 TEST_F(ZRouterIntegrationTest, MultiTargetReceiver_SingleZReceiverChannel) {
@@ -500,7 +500,7 @@ TEST_F(ZRouterIntegrationTest, MultiTargetReceiver_SingleZReceiverChannel) {
     // All should target same receiver
     for (const auto& conn : mesh_to_z) {
         EXPECT_EQ(conn.dest_vc, 0);
-        EXPECT_EQ(conn.dest_receiver_channel, 0);
+        EXPECT_EQ(conn.dest_sender_channel, 0);
     }
 }
 

--- a/tests/tt_metal/tt_fabric/fabric_router/test_z_router_integration.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_z_router_integration.cpp
@@ -1,0 +1,620 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Phase 7: Z Router Integration Tests
+ *
+ * End-to-end validation of Z router connectivity without requiring actual Z hardware.
+ * Tests focus on connection logic, variable mesh counts, and edge cases.
+ */
+
+#include <gtest/gtest.h>
+#include "tt_metal/fabric/builder/connection_registry.hpp"
+#include "tt_metal/fabric/builder/router_connection_mapping.hpp"
+#include "tt_metal/fabric/fabric_router_channel_mapping.hpp"
+#include "tt_metal/fabric/fabric_context.hpp"
+#include "tt_metal/fabric/builder/fabric_builder_config.hpp"
+#include <tt-metalium/experimental/fabric/mesh_graph.hpp>
+#include <tt-metalium/experimental/fabric/fabric_edm_types.hpp>
+
+using namespace tt::tt_fabric;
+namespace builder_config = tt::tt_fabric::builder_config;
+
+class ZRouterIntegrationTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        registry_ = std::make_shared<ConnectionRegistry>();
+    }
+
+    std::shared_ptr<ConnectionRegistry> registry_;
+
+    // Helper to record a connection
+    void record_connection(
+        FabricNodeId src_node,
+        RoutingDirection src_dir,
+        uint8_t src_chan,
+        uint32_t src_vc,
+        uint32_t src_sender,
+        FabricNodeId dst_node,
+        RoutingDirection dst_dir,
+        uint8_t dst_chan,
+        uint32_t dst_vc,
+        uint32_t dst_receiver,
+        ConnectionType type) {
+        registry_->record_connection(RouterConnectionRecord{
+            .source_node = src_node,
+            .source_direction = src_dir,
+            .source_eth_chan = src_chan,
+            .source_vc = src_vc,
+            .source_sender_channel = src_sender,
+            .dest_node = dst_node,
+            .dest_direction = dst_dir,
+            .dest_eth_chan = dst_chan,
+            .dest_vc = dst_vc,
+            .dest_receiver_channel = dst_receiver,
+            .connection_type = type
+        });
+    }
+};
+
+// ============================================================================
+// Basic Connectivity Tests
+// ============================================================================
+
+TEST_F(ZRouterIntegrationTest, FullDevice_4Mesh1Z_BidirectionalConnectivity) {
+    // Comprehensive test: Full device with 4 mesh routers + 1 Z router
+    // Validates both MESH_TO_Z and Z_TO_MESH connections
+
+    FabricNodeId device0(MeshId{0}, 0);
+    std::vector<RoutingDirection> mesh_dirs = {
+        RoutingDirection::N, RoutingDirection::E, RoutingDirection::S, RoutingDirection::W
+    };
+
+    // MESH_TO_Z: All 4 mesh routers → Z router VC0 (multi-target receiver)
+    for (size_t i = 0; i < 4; ++i) {
+        record_connection(
+            device0, mesh_dirs[i], static_cast<uint8_t>(i),
+            0, builder_config::num_sender_channels_2d_mesh,  // VC0, MESH_TO_Z channel
+            device0, RoutingDirection::Z, 4,
+            0, 0,  // Z VC0 receiver 0 (SAME for all - multi-target)
+            ConnectionType::MESH_TO_Z);
+    }
+
+    // Z_TO_MESH: Z router VC1 senders 0-3 → 4 mesh routers (one-to-one)
+    for (size_t i = 0; i < 4; ++i) {
+        record_connection(
+            device0, RoutingDirection::Z, 4,
+            1, static_cast<uint32_t>(i),  // Z VC1 sender i
+            device0, mesh_dirs[i], static_cast<uint8_t>(i),
+            1, 0,  // mesh VC1 receiver
+            ConnectionType::Z_TO_MESH);
+    }
+
+    // Validate total connections
+    EXPECT_EQ(registry_->size(), 8) << "Should have 8 total connections (4 MESH_TO_Z + 4 Z_TO_MESH)";
+
+    // Validate by type
+    auto mesh_to_z = registry_->get_connections_by_type(ConnectionType::MESH_TO_Z);
+    auto z_to_mesh = registry_->get_connections_by_type(ConnectionType::Z_TO_MESH);
+
+    EXPECT_EQ(mesh_to_z.size(), 4) << "Should have 4 MESH_TO_Z connections";
+    EXPECT_EQ(z_to_mesh.size(), 4) << "Should have 4 Z_TO_MESH connections";
+
+    // Validate Z router connectivity
+    auto z_incoming = registry_->get_connections_by_dest_node(device0);
+    auto z_outgoing = registry_->get_connections_by_source_node(device0);
+
+    // Filter to Z router only
+    size_t z_in_count = 0, z_out_count = 0;
+    for (const auto& conn : z_incoming) {
+        if (conn.dest_direction == RoutingDirection::Z) {
+            z_in_count++;
+        }
+    }
+    for (const auto& conn : z_outgoing) {
+        if (conn.source_direction == RoutingDirection::Z) {
+            z_out_count++;
+        }
+    }
+
+    EXPECT_EQ(z_in_count, 4) << "Z router should have 4 incoming connections";
+    EXPECT_EQ(z_out_count, 4) << "Z router should have 4 outgoing connections";
+
+    // Validate multi-target receiver: all MESH_TO_Z target same Z receiver
+    for (const auto& conn : mesh_to_z) {
+        EXPECT_EQ(conn.dest_vc, 0) << "MESH_TO_Z should target Z VC0";
+        EXPECT_EQ(conn.dest_receiver_channel, 0) << "All MESH_TO_Z should target same receiver (multi-target)";
+    }
+
+    // Validate Z_TO_MESH uses VC1
+    for (const auto& conn : z_to_mesh) {
+        EXPECT_EQ(conn.source_vc, 1) << "Z_TO_MESH should use Z VC1";
+        EXPECT_EQ(conn.dest_vc, 1) << "Z_TO_MESH should target mesh VC1";
+    }
+}
+
+TEST_F(ZRouterIntegrationTest, ConnectionMapping_ZRouter_AllDirections) {
+    // Test that Z router connection mapping specifies all 4 directions
+    auto mapping = RouterConnectionMapping::for_z_router();
+
+    // Z router VC1 should have 4 sender channels (0-3) for N/E/S/W
+    std::vector<RoutingDirection> expected_dirs = {
+        RoutingDirection::N, RoutingDirection::E, RoutingDirection::S, RoutingDirection::W
+    };
+
+    for (size_t i = 0; i < 4; ++i) {
+        auto targets = mapping.get_downstream_targets(1, i);
+        ASSERT_EQ(targets.size(), 1) << "Z VC1 sender " << i << " should have 1 target";
+
+        const auto& target = targets[0];
+        EXPECT_EQ(target.type, ConnectionType::Z_TO_MESH);
+        EXPECT_EQ(target.target_vc, 1) << "Should target mesh VC1";
+        EXPECT_TRUE(target.target_direction.has_value());
+        EXPECT_EQ(target.target_direction.value(), expected_dirs[i])
+            << "Sender " << i << " should target direction " << static_cast<int>(expected_dirs[i]);
+    }
+}
+
+TEST_F(ZRouterIntegrationTest, ConnectionMapping_MeshWithZ_HasMeshToZTarget) {
+    // Test that mesh routers with Z have MESH_TO_Z connection
+    auto mapping = RouterConnectionMapping::for_mesh_router(
+        Topology::Mesh, RoutingDirection::N, true);  // has_z = true
+
+    // MESH_TO_Z channel is after base channels (channel 4 for 2D)
+    uint32_t mesh_to_z_channel = builder_config::num_sender_channels_2d_mesh;
+    auto targets = mapping.get_downstream_targets(0, mesh_to_z_channel);
+
+    ASSERT_EQ(targets.size(), 1) << "MESH_TO_Z channel should have 1 target";
+
+    const auto& target = targets[0];
+    EXPECT_EQ(target.type, ConnectionType::MESH_TO_Z);
+    EXPECT_EQ(target.target_vc, 0) << "Should target Z VC0";
+    EXPECT_TRUE(target.target_direction.has_value());
+    EXPECT_EQ(target.target_direction.value(), RoutingDirection::Z);
+}
+
+// ============================================================================
+// Variable Mesh Count Tests
+// ============================================================================
+
+TEST_F(ZRouterIntegrationTest, EdgeDevice_2Mesh1Z_MinimalConfiguration) {
+    // Edge device with only 2 mesh routers (e.g., corner device with N+E only)
+    FabricNodeId device0(MeshId{0}, 0);
+
+    std::vector<RoutingDirection> mesh_dirs = {RoutingDirection::N, RoutingDirection::E};
+
+    // MESH_TO_Z: 2 mesh routers → Z router
+    for (size_t i = 0; i < 2; ++i) {
+        record_connection(
+            device0, mesh_dirs[i], static_cast<uint8_t>(i),
+            0, builder_config::num_sender_channels_2d_mesh,
+            device0, RoutingDirection::Z, 4,
+            0, 0,
+            ConnectionType::MESH_TO_Z);
+    }
+
+    // Z_TO_MESH: Z router → 2 mesh routers (only N and E)
+    for (size_t i = 0; i < 2; ++i) {
+        record_connection(
+            device0, RoutingDirection::Z, 4,
+            1, static_cast<uint32_t>(i),  // Z uses senders 0 (N) and 1 (E)
+            device0, mesh_dirs[i], static_cast<uint8_t>(i),
+            1, 0,
+            ConnectionType::Z_TO_MESH);
+    }
+
+    EXPECT_EQ(registry_->size(), 4) << "Should have 4 total connections (2 each direction)";
+    EXPECT_EQ(registry_->get_connections_by_type(ConnectionType::MESH_TO_Z).size(), 2);
+    EXPECT_EQ(registry_->get_connections_by_type(ConnectionType::Z_TO_MESH).size(), 2);
+}
+
+TEST_F(ZRouterIntegrationTest, EdgeDevice_3Mesh1Z_PartialConfiguration) {
+    // Edge device with 3 mesh routers (e.g., N+E+S)
+    FabricNodeId device0(MeshId{0}, 0);
+
+    std::vector<RoutingDirection> mesh_dirs = {
+        RoutingDirection::N, RoutingDirection::E, RoutingDirection::S
+    };
+
+    // MESH_TO_Z: 3 mesh routers → Z router
+    for (size_t i = 0; i < 3; ++i) {
+        record_connection(
+            device0, mesh_dirs[i], static_cast<uint8_t>(i),
+            0, builder_config::num_sender_channels_2d_mesh,
+            device0, RoutingDirection::Z, 4,
+            0, 0,
+            ConnectionType::MESH_TO_Z);
+    }
+
+    // Z_TO_MESH: Z router → 3 mesh routers
+    for (size_t i = 0; i < 3; ++i) {
+        record_connection(
+            device0, RoutingDirection::Z, 4,
+            1, static_cast<uint32_t>(i),
+            device0, mesh_dirs[i], static_cast<uint8_t>(i),
+            1, 0,
+            ConnectionType::Z_TO_MESH);
+    }
+
+    EXPECT_EQ(registry_->size(), 6) << "Should have 6 total connections (3 each direction)";
+    EXPECT_EQ(registry_->get_connections_by_type(ConnectionType::MESH_TO_Z).size(), 3);
+    EXPECT_EQ(registry_->get_connections_by_type(ConnectionType::Z_TO_MESH).size(), 3);
+}
+
+TEST_F(ZRouterIntegrationTest, VariableMeshCount_AllConfigurations) {
+    // Test all valid mesh router counts (2, 3, 4)
+    for (size_t num_mesh = 2; num_mesh <= 4; ++num_mesh) {
+        auto local_registry = std::make_shared<ConnectionRegistry>();
+        FabricNodeId device0(MeshId{0}, 0);
+
+        std::vector<RoutingDirection> all_dirs = {
+            RoutingDirection::N, RoutingDirection::E, RoutingDirection::S, RoutingDirection::W
+        };
+
+        // Create connections for num_mesh routers
+        for (size_t i = 0; i < num_mesh; ++i) {
+            // MESH_TO_Z
+            local_registry->record_connection(RouterConnectionRecord{
+                .source_node = device0,
+                .source_direction = all_dirs[i],
+                .source_eth_chan = static_cast<uint8_t>(i),
+                .source_vc = 0,
+                .source_sender_channel = builder_config::num_sender_channels_2d_mesh,
+                .dest_node = device0,
+                .dest_direction = RoutingDirection::Z,
+                .dest_eth_chan = 4,
+                .dest_vc = 0,
+                .dest_receiver_channel = 0,
+                .connection_type = ConnectionType::MESH_TO_Z
+            });
+
+            // Z_TO_MESH
+            local_registry->record_connection(RouterConnectionRecord{
+                .source_node = device0,
+                .source_direction = RoutingDirection::Z,
+                .source_eth_chan = 4,
+                .source_vc = 1,
+                .source_sender_channel = static_cast<uint32_t>(i),
+                .dest_node = device0,
+                .dest_direction = all_dirs[i],
+                .dest_eth_chan = static_cast<uint8_t>(i),
+                .dest_vc = 1,
+                .dest_receiver_channel = 0,
+                .connection_type = ConnectionType::Z_TO_MESH
+            });
+        }
+
+        EXPECT_EQ(local_registry->size(), num_mesh * 2)
+            << "With " << num_mesh << " mesh routers, should have " << (num_mesh * 2) << " connections";
+        EXPECT_EQ(local_registry->get_connections_by_type(ConnectionType::MESH_TO_Z).size(), num_mesh);
+        EXPECT_EQ(local_registry->get_connections_by_type(ConnectionType::Z_TO_MESH).size(), num_mesh);
+    }
+}
+
+// ============================================================================
+// Channel Mapping Tests
+// ============================================================================
+
+TEST_F(ZRouterIntegrationTest, ChannelMapping_ZRouter_VC0AndVC1) {
+    // Verify Z router has 2 VCs with correct channel counts
+    auto intermesh_config = IntermeshVCConfig::full_mesh();
+    auto mapping = FabricRouterChannelMapping(
+        Topology::Mesh,
+        false,  // no tensix
+        RouterVariant::Z_ROUTER,
+        &intermesh_config);  // Z routers require intermesh config
+
+    EXPECT_EQ(mapping.get_num_virtual_channels(), 2) << "Z router should have 2 VCs";
+
+    // VC0: Standard mesh forwarding (4 channels for 2D)
+    EXPECT_EQ(mapping.get_num_sender_channels_for_vc(0), builder_config::num_sender_channels_z_router_vc0);
+
+    // VC1: Z-specific traffic (4 channels for N/E/S/W)
+    EXPECT_EQ(mapping.get_num_sender_channels_for_vc(1), builder_config::num_sender_channels_z_router_vc1);
+}
+
+TEST_F(ZRouterIntegrationTest, ChannelMapping_MeshRouter_VC0Only) {
+    // Verify standard mesh router has only VC0 when no intermesh config provided
+    auto mapping = FabricRouterChannelMapping(
+        Topology::Mesh,
+        false,  // no tensix
+        RouterVariant::MESH,
+        nullptr);  // no intermesh config
+
+    EXPECT_EQ(mapping.get_num_virtual_channels(), 1) << "Standard mesh router should have 1 VC (VC0 only) without intermesh";
+    EXPECT_EQ(mapping.get_num_sender_channels_for_vc(0), builder_config::num_sender_channels_2d_mesh);
+    EXPECT_EQ(mapping.get_num_sender_channels_for_vc(1), 0) << "VC1 should not be created without intermesh config";
+}
+
+TEST_F(ZRouterIntegrationTest, ChannelMapping_ZRouter_InternalChannels) {
+    // Verify Z router VC1 maps to correct internal erisc channels (4-7)
+    auto intermesh_config = IntermeshVCConfig::full_mesh();
+    auto mapping = FabricRouterChannelMapping(
+        Topology::Mesh,
+        false,
+        RouterVariant::Z_ROUTER,
+        &intermesh_config);  // Z routers require intermesh config
+
+    // VC1 sender channels 0-3 should map to erisc internal channels 4-7
+    for (uint32_t i = 0; i < 4; ++i) {
+        auto sender_mapping = mapping.get_sender_mapping(1, i);
+        EXPECT_EQ(sender_mapping.builder_type, BuilderType::ERISC);
+        EXPECT_EQ(sender_mapping.internal_sender_channel_id, 4 + i)
+            << "Z VC1 sender " << i << " should map to erisc channel " << (4 + i);
+    }
+
+    // VC1 receiver channel 0 should map to erisc internal channel 1
+    auto receiver_mapping = mapping.get_receiver_mapping(1, 0);
+    EXPECT_EQ(receiver_mapping.builder_type, BuilderType::ERISC);
+    EXPECT_EQ(receiver_mapping.internal_receiver_channel_id, 1);
+}
+
+// ============================================================================
+// Edge Cases and Error Handling
+// ============================================================================
+
+TEST_F(ZRouterIntegrationTest, NoZRouter_NoMeshToZConnections) {
+    // Device without Z router should have no MESH_TO_Z connections
+    FabricNodeId device0(MeshId{0}, 0);
+
+    // Only INTRA_MESH connections
+    record_connection(
+        device0, RoutingDirection::N, 0,
+        0, 1,
+        device0, RoutingDirection::S, 2,
+        0, 1,
+        ConnectionType::INTRA_MESH);
+
+    record_connection(
+        device0, RoutingDirection::E, 1,
+        0, 1,
+        device0, RoutingDirection::W, 3,
+        0, 1,
+        ConnectionType::INTRA_MESH);
+
+    EXPECT_EQ(registry_->size(), 2);
+    EXPECT_EQ(registry_->get_connections_by_type(ConnectionType::MESH_TO_Z).size(), 0);
+    EXPECT_EQ(registry_->get_connections_by_type(ConnectionType::Z_TO_MESH).size(), 0);
+    EXPECT_EQ(registry_->get_connections_by_type(ConnectionType::INTRA_MESH).size(), 2);
+}
+
+TEST_F(ZRouterIntegrationTest, ConnectionMapping_MeshWithoutZ_NoMeshToZ) {
+    // Mesh router without Z should not have MESH_TO_Z target
+    auto mapping = RouterConnectionMapping::for_mesh_router(
+        Topology::Mesh, RoutingDirection::N, false);  // has_z = false
+
+    // Check all sender channels - none should have MESH_TO_Z
+    for (uint32_t ch = 0; ch < 5; ++ch) {
+        auto targets = mapping.get_downstream_targets(0, ch);
+        for (const auto& target : targets) {
+            EXPECT_NE(target.type, ConnectionType::MESH_TO_Z)
+                << "Mesh router without Z should not have MESH_TO_Z connections";
+        }
+    }
+}
+
+TEST_F(ZRouterIntegrationTest, ConnectionMapping_ZRouter_VC0_CannotBeDownstreamTarget) {
+    // Validate that Z router connection mapping never specifies Z VC0 as a downstream target
+    // Z VC0 senders don't forward anywhere, so no router should target them
+
+    auto z_mapping = RouterConnectionMapping::for_z_router();
+
+    // Check all Z router sender channels (VC0 and VC1)
+    constexpr uint32_t num_z_router_sender_channels_per_vc = 4;
+    for (uint32_t vc = 0; vc < 2; ++vc) {
+        for (uint32_t ch = 0; ch < num_z_router_sender_channels_per_vc; ++ch) {
+            auto targets = z_mapping.get_downstream_targets(vc, ch);
+
+            // For each target, verify it's not pointing to a Z router VC0
+            for (const auto& target : targets) {
+                // Z_TO_MESH should target mesh VC1, not Z VC0
+                if (target.type == ConnectionType::Z_TO_MESH) {
+                    EXPECT_EQ(target.target_vc, 1) << "Z_TO_MESH should target mesh VC1, not VC0";
+                    EXPECT_TRUE(target.target_direction.has_value());
+                    EXPECT_NE(target.target_direction.value(), RoutingDirection::Z)
+                        << "Z router should not target another Z router";
+                }
+            }
+        }
+    }
+
+    // Also check mesh router mappings - they should target Z VC0 receiver, not sender
+    auto mesh_mapping = RouterConnectionMapping::for_mesh_router(
+        Topology::Mesh, RoutingDirection::N, true);  // has_z = true
+
+    uint32_t mesh_to_z_channel = builder_config::num_sender_channels_2d_mesh;
+    auto mesh_targets = mesh_mapping.get_downstream_targets(0, mesh_to_z_channel);
+
+    ASSERT_EQ(mesh_targets.size(), 1);
+    const auto& target = mesh_targets[0];
+    EXPECT_EQ(target.type, ConnectionType::MESH_TO_Z);
+    EXPECT_EQ(target.target_vc, 0) << "MESH_TO_Z should target Z VC0 (receiver)";
+    EXPECT_EQ(target.target_direction.value(), RoutingDirection::Z);
+
+    // The mapping specifies VC0, which implicitly means the receiver side
+    // (since Z VC0 senders have no downstream connections)
+}
+
+TEST_F(ZRouterIntegrationTest, ZRouter_VC0_NoOutgoingConnections) {
+    // Z router VC0 should have no outgoing connections (reserved for future use)
+    auto mapping = RouterConnectionMapping::for_z_router();
+
+    // Check all VC0 sender channels - none should have downstream targets
+    for (uint32_t ch = 0; ch < 4; ++ch) {
+        auto targets = mapping.get_downstream_targets(0, ch);
+        EXPECT_TRUE(targets.empty()) << "Z router VC0 sender " << ch << " should have no downstream connections";
+    }
+}
+
+TEST_F(ZRouterIntegrationTest, ZRouter_VC0_NoDownstreamReceiverConnections) {
+    // Validate that no downstream router should connect TO a Z router VC0 sender channel
+    // Z router VC0 senders don't forward anywhere, so connecting to them would be invalid
+
+    FabricNodeId device0(MeshId{0}, 0);
+
+    // Attempt to create invalid connection: mesh router → Z router VC0 sender
+    // This should never happen in practice, but we validate the constraint
+
+    // Valid: MESH_TO_Z targets Z VC0 receiver (not sender)
+    record_connection(
+        device0, RoutingDirection::N, 0,
+        0, builder_config::num_sender_channels_2d_mesh,  // mesh VC0 MESH_TO_Z channel
+        device0, RoutingDirection::Z, 4,
+        0, 0,  // Z VC0 receiver 0 (CORRECT)
+        ConnectionType::MESH_TO_Z);
+
+    EXPECT_EQ(registry_->size(), 1);
+
+    // Verify the connection targets the receiver, not a sender
+    auto connections = registry_->get_connections_by_type(ConnectionType::MESH_TO_Z);
+    ASSERT_EQ(connections.size(), 1);
+
+    const auto& conn = connections[0];
+    EXPECT_EQ(conn.dest_vc, 0) << "MESH_TO_Z should target Z VC0";
+    EXPECT_EQ(conn.dest_receiver_channel, 0) << "Should target receiver channel, not sender";
+
+    // Note: There's no explicit "sender vs receiver" flag in the connection record,
+    // but the semantic is clear: dest_receiver_channel refers to the receiver side
+}
+
+TEST_F(ZRouterIntegrationTest, MultiTargetReceiver_SingleZReceiverChannel) {
+    // Verify that all MESH_TO_Z connections target the same Z receiver (multi-target)
+    FabricNodeId device0(MeshId{0}, 0);
+
+    std::vector<RoutingDirection> mesh_dirs = {
+        RoutingDirection::N, RoutingDirection::E, RoutingDirection::S, RoutingDirection::W
+    };
+
+    for (size_t i = 0; i < 4; ++i) {
+        record_connection(
+            device0, mesh_dirs[i], static_cast<uint8_t>(i),
+            0, builder_config::num_sender_channels_2d_mesh,
+            device0, RoutingDirection::Z, 4,
+            0, 0,  // All target same receiver
+            ConnectionType::MESH_TO_Z);
+    }
+
+    auto mesh_to_z = registry_->get_connections_by_type(ConnectionType::MESH_TO_Z);
+    ASSERT_EQ(mesh_to_z.size(), 4);
+
+    // All should target same receiver
+    for (const auto& conn : mesh_to_z) {
+        EXPECT_EQ(conn.dest_vc, 0);
+        EXPECT_EQ(conn.dest_receiver_channel, 0);
+    }
+}
+
+// ============================================================================
+// Topology Compatibility Tests
+// ============================================================================
+
+TEST_F(ZRouterIntegrationTest, AllTopologies_MeshMappingWorks) {
+    // Test that mesh router mapping works for all topologies
+    std::vector<Topology> topologies = {
+        Topology::Linear, Topology::Ring, Topology::Mesh, Topology::Torus
+    };
+
+    for (auto topology : topologies) {
+        auto mapping = RouterConnectionMapping::for_mesh_router(
+            topology, RoutingDirection::N, false);
+
+        // Should be able to create mapping without errors
+        EXPECT_NO_THROW({
+            auto targets = mapping.get_downstream_targets(0, 1);
+        }) << "Topology " << static_cast<int>(topology) << " should create valid mapping";
+    }
+}
+
+TEST_F(ZRouterIntegrationTest, LinearTopology_NoMeshToZ) {
+    // Linear topology with Z should still work (though unusual configuration)
+    auto mapping = RouterConnectionMapping::for_mesh_router(
+        Topology::Linear, RoutingDirection::N, true);  // has_z = true
+
+    // Linear has MESH_TO_Z channel at position 2 (after channel 0=worker, 1=peer)
+    uint32_t mesh_to_z_channel = builder_config::num_sender_channels_1d_linear;
+    auto targets = mapping.get_downstream_targets(0, mesh_to_z_channel);
+
+    ASSERT_EQ(targets.size(), 1);
+    EXPECT_EQ(targets[0].type, ConnectionType::MESH_TO_Z);
+}
+
+// ============================================================================
+// Negative Tests: Connection Overflow and Invalid Configurations
+// ============================================================================
+
+TEST_F(ZRouterIntegrationTest, ZRouter_VC1_ExceedsMaxMeshRouters) {
+    // Negative test: Z router VC1 receiver should not accept more than 4 connections
+    // (one per mesh router direction: N, E, S, W)
+
+    FabricNodeId device0(MeshId{0}, 0);
+
+    // Try to add 5 connections (invalid - only 4 mesh routers max)
+    std::vector<RoutingDirection> invalid_dirs = {
+        RoutingDirection::N,
+        RoutingDirection::E,
+        RoutingDirection::S,
+        RoutingDirection::W,
+        RoutingDirection::N  // Duplicate N (invalid)
+    };
+
+    for (size_t i = 0; i < 5; ++i) {
+        record_connection(
+            device0, invalid_dirs[i], static_cast<uint8_t>(i % 4),
+            0, builder_config::num_sender_channels_2d_mesh,
+            device0, RoutingDirection::Z, 4,
+            0, 0,  // All target same receiver (multi-target)
+            ConnectionType::MESH_TO_Z);
+    }
+
+    // Should have 5 connections recorded
+    EXPECT_EQ(registry_->size(), 5);
+
+    // But this is invalid - Z router VC1 receiver can only accept 4 unique directions
+    auto mesh_to_z = registry_->get_connections_by_type(ConnectionType::MESH_TO_Z);
+    EXPECT_EQ(mesh_to_z.size(), 5);
+
+    // TODO: Add validation in ConnectionRegistry or builder to detect duplicate directions
+    // and reject > 4 MESH_TO_Z connections to the same Z router
+    // For now, this test documents the overflow behavior
+}
+
+TEST_F(ZRouterIntegrationTest, MeshRouter_ConnectToNonExistentVC) {
+    // Negative test: Mesh router should not be able to connect to non-existent VC
+
+    auto mapping = RouterConnectionMapping::for_mesh_router(
+        Topology::Mesh, RoutingDirection::N, false);
+
+    // Try to query VC2 (doesn't exist)
+    auto targets = mapping.get_downstream_targets(2, 0);
+
+    // Should return empty (no targets for non-existent VC)
+    EXPECT_TRUE(targets.empty()) << "Non-existent VC should have no targets";
+}
+
+TEST_F(ZRouterIntegrationTest, MeshRouter_ConnectToNonExistentSenderChannel) {
+    // Negative test: Mesh router should not be able to connect to non-existent sender channel
+
+    auto mapping = RouterConnectionMapping::for_mesh_router(
+        Topology::Mesh, RoutingDirection::N, false);
+
+    // Mesh VC0 has 4 sender channels (0-3), try to query channel 10
+    auto targets = mapping.get_downstream_targets(0, 10);
+
+    // Should return empty (no targets for non-existent channel)
+    EXPECT_TRUE(targets.empty()) << "Non-existent sender channel should have no targets";
+}
+
+TEST_F(ZRouterIntegrationTest, ZRouter_QueryInvalidVC) {
+    // Negative test: Z router has 2 VCs (0-1), querying VC2+ should return empty
+
+    auto mapping = RouterConnectionMapping::for_z_router();
+
+    // Try to query VC2 (doesn't exist)
+    auto targets = mapping.get_downstream_targets(2, 0);
+
+    EXPECT_TRUE(targets.empty()) << "Z router VC2 should have no targets (doesn't exist)";
+
+    // Try VC3
+    targets = mapping.get_downstream_targets(3, 0);
+    EXPECT_TRUE(targets.empty()) << "Z router VC3 should have no targets (doesn't exist)";
+}

--- a/tests/tt_metal/tt_fabric/fabric_router/test_z_router_integration.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_z_router_integration.cpp
@@ -147,10 +147,9 @@ TEST_F(ZRouterIntegrationTest, ConnectionMapping_ZRouter_AllDirections) {
 
     // Verify all expected directions are present
     for (const auto& expected_dir : expected_dirs) {
-        auto it = std::find_if(targets.begin(), targets.end(),
-            [expected_dir](const ConnectionTarget& t) { 
-                return t.target_direction == expected_dir; 
-            });
+        auto it = std::find_if(targets.begin(), targets.end(), [expected_dir](const ConnectionTarget& t) {
+            return t.target_direction == expected_dir;
+        });
         ASSERT_NE(it, targets.end()) << "Missing direction: " << static_cast<int>(expected_dir);
         EXPECT_EQ(it->type, ConnectionType::Z_TO_MESH);
         EXPECT_EQ(it->target_vc, 1) << "Should target mesh VC1";
@@ -430,7 +429,7 @@ TEST_F(ZRouterIntegrationTest, ConnectionMapping_ZRouter_VC0_CannotBeDownstreamT
     auto mesh_to_z_it = std::find_if(mesh_targets.begin(), mesh_targets.end(),
         [](const ConnectionTarget& t) { return t.type == ConnectionType::MESH_TO_Z; });
     ASSERT_NE(mesh_to_z_it, mesh_targets.end());
-    
+
     EXPECT_EQ(mesh_to_z_it->target_vc, 0) << "MESH_TO_Z should target Z VC0 (receiver)";
     EXPECT_EQ(mesh_to_z_it->target_direction.value(), RoutingDirection::Z);
 

--- a/tt_metal/api/tt-metalium/experimental/fabric/fabric_edm_types.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/fabric_edm_types.hpp
@@ -11,13 +11,9 @@ namespace tt::tt_fabric {
 enum class Topology { NeighborExchange = 0, Linear = 1, Ring = 2, Mesh = 3, Torus = 4 };
 
 // Topology classification utilities
-inline constexpr bool is_2D_topology(Topology topology) {
-    return topology == Topology::Mesh || topology == Topology::Torus;
-}
+constexpr bool is_2D_topology(Topology topology) { return topology == Topology::Mesh || topology == Topology::Torus; }
 
-inline constexpr bool is_ring_or_torus(Topology topology) {
-    return topology == Topology::Ring || topology == Topology::Torus;
-}
+constexpr bool is_ring_or_torus(Topology topology) { return topology == Topology::Ring || topology == Topology::Torus; }
 
 struct WorkerXY {
     uint16_t x;

--- a/tt_metal/api/tt-metalium/experimental/fabric/fabric_edm_types.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/fabric_edm_types.hpp
@@ -10,6 +10,15 @@ namespace tt::tt_fabric {
 
 enum class Topology { NeighborExchange = 0, Linear = 1, Ring = 2, Mesh = 3, Torus = 4 };
 
+// Topology classification utilities
+inline constexpr bool is_2D_topology(Topology topology) {
+    return topology == Topology::Mesh || topology == Topology::Torus;
+}
+
+inline constexpr bool is_ring_or_torus(Topology topology) {
+    return topology == Topology::Ring || topology == Topology::Torus;
+}
+
 struct WorkerXY {
     uint16_t x;
     uint16_t y;

--- a/tt_metal/fabric/CMakeLists.txt
+++ b/tt_metal/fabric/CMakeLists.txt
@@ -54,6 +54,7 @@ target_sources(
         builder/channel_to_pool_mapping.cpp
         builder/multi_pool_channel_allocator.cpp
         builder/connection_registry.cpp
+        builder/router_connection_mapping.cpp
         fabric.cpp
         fabric_init.cpp
         fabric_host_utils.cpp

--- a/tt_metal/fabric/CMakeLists.txt
+++ b/tt_metal/fabric/CMakeLists.txt
@@ -53,6 +53,7 @@ target_sources(
         builder/fabric_router_recipe.cpp
         builder/channel_to_pool_mapping.cpp
         builder/multi_pool_channel_allocator.cpp
+        builder/connection_registry.cpp
         fabric.cpp
         fabric_init.cpp
         fabric_host_utils.cpp

--- a/tt_metal/fabric/builder/connection_registry.cpp
+++ b/tt_metal/fabric/builder/connection_registry.cpp
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "connection_registry.hpp"
+#include <algorithm>
+
+namespace tt::tt_fabric {
+
+void ConnectionRegistry::record_connection(const RouterConnectionRecord& record) {
+    connections_.push_back(record);
+}
+
+const std::vector<RouterConnectionRecord>& ConnectionRegistry::get_all_connections() const {
+    return connections_;
+}
+
+std::vector<RouterConnectionRecord> ConnectionRegistry::get_connections_from_source(
+    FabricNodeId source_node,
+    RoutingDirection source_direction) const {
+    std::vector<RouterConnectionRecord> result;
+    std::copy_if(
+        connections_.begin(),
+        connections_.end(),
+        std::back_inserter(result),
+        [&](const RouterConnectionRecord& record) {
+            return record.source_node == source_node && record.source_direction == source_direction;
+        });
+    return result;
+}
+
+std::vector<RouterConnectionRecord> ConnectionRegistry::get_connections_to_dest(
+    FabricNodeId dest_node,
+    RoutingDirection dest_direction) const {
+    std::vector<RouterConnectionRecord> result;
+    std::copy_if(
+        connections_.begin(),
+        connections_.end(),
+        std::back_inserter(result),
+        [&](const RouterConnectionRecord& record) {
+            return record.dest_node == dest_node && record.dest_direction == dest_direction;
+        });
+    return result;
+}
+
+std::vector<RouterConnectionRecord> ConnectionRegistry::get_connections_by_type(ConnectionType type) const {
+    std::vector<RouterConnectionRecord> result;
+    std::copy_if(
+        connections_.begin(),
+        connections_.end(),
+        std::back_inserter(result),
+        [&](const RouterConnectionRecord& record) {
+            return record.connection_type == type;
+        });
+    return result;
+}
+
+void ConnectionRegistry::clear() {
+    connections_.clear();
+}
+
+size_t ConnectionRegistry::size() const {
+    return connections_.size();
+}
+
+}  // namespace tt::tt_fabric
+

--- a/tt_metal/fabric/builder/connection_registry.cpp
+++ b/tt_metal/fabric/builder/connection_registry.cpp
@@ -55,6 +55,30 @@ std::vector<RouterConnectionRecord> ConnectionRegistry::get_connections_by_type(
     return result;
 }
 
+std::vector<RouterConnectionRecord> ConnectionRegistry::get_connections_by_source_node(FabricNodeId source_node) const {
+    std::vector<RouterConnectionRecord> result;
+    std::copy_if(
+        connections_.begin(),
+        connections_.end(),
+        std::back_inserter(result),
+        [&](const RouterConnectionRecord& record) {
+            return record.source_node == source_node;
+        });
+    return result;
+}
+
+std::vector<RouterConnectionRecord> ConnectionRegistry::get_connections_by_dest_node(FabricNodeId dest_node) const {
+    std::vector<RouterConnectionRecord> result;
+    std::copy_if(
+        connections_.begin(),
+        connections_.end(),
+        std::back_inserter(result),
+        [&](const RouterConnectionRecord& record) {
+            return record.dest_node == dest_node;
+        });
+    return result;
+}
+
 void ConnectionRegistry::clear() {
     connections_.clear();
 }
@@ -64,4 +88,3 @@ size_t ConnectionRegistry::size() const {
 }
 
 }  // namespace tt::tt_fabric
-

--- a/tt_metal/fabric/builder/connection_registry.hpp
+++ b/tt_metal/fabric/builder/connection_registry.hpp
@@ -23,7 +23,7 @@ enum class ConnectionType {
 
 /**
  * RouterConnectionRecord - Records a single connection between routers
- * 
+ *
  * This structure captures all relevant information about a connection
  * for testing and validation purposes.
  */
@@ -34,25 +34,25 @@ struct RouterConnectionRecord {
     chan_id_t source_eth_chan;
     uint32_t source_vc;
     uint32_t source_sender_channel;
-    
+
     // Destination router information
     FabricNodeId dest_node;
     RoutingDirection dest_direction;
     chan_id_t dest_eth_chan;
     uint32_t dest_vc;
     uint32_t dest_receiver_channel;
-    
+
     // Connection metadata
     ConnectionType connection_type;
 };
 
 /**
  * ConnectionRegistry - Records all router connections for testing/validation
- * 
+ *
  * This registry provides visibility into the connection graph between routers.
  * It's used during Phase 0 to add testing infrastructure and will be extended
  * in later phases to support Z router connections.
- * 
+ *
  * Usage:
  *   auto registry = std::make_shared<ConnectionRegistry>();
  *   // Pass to builders during construction
@@ -62,24 +62,24 @@ struct RouterConnectionRecord {
 class ConnectionRegistry {
 public:
     ConnectionRegistry() = default;
-    
+
     /**
      * Record a connection between two routers
-     * 
+     *
      * @param record The connection record to store
      */
     void record_connection(const RouterConnectionRecord& record);
-    
+
     /**
      * Get all recorded connections
-     * 
+     *
      * @return Vector of all connection records
      */
     const std::vector<RouterConnectionRecord>& get_all_connections() const;
-    
+
     /**
      * Get connections from a specific source router
-     * 
+     *
      * @param source_node The source fabric node
      * @param source_direction The source router direction
      * @return Vector of connections from this source
@@ -87,10 +87,10 @@ public:
     std::vector<RouterConnectionRecord> get_connections_from_source(
         FabricNodeId source_node,
         RoutingDirection source_direction) const;
-    
+
     /**
      * Get connections to a specific destination router
-     * 
+     *
      * @param dest_node The destination fabric node
      * @param dest_direction The destination router direction
      * @return Vector of connections to this destination
@@ -98,23 +98,39 @@ public:
     std::vector<RouterConnectionRecord> get_connections_to_dest(
         FabricNodeId dest_node,
         RoutingDirection dest_direction) const;
-    
+
     /**
      * Get connections of a specific type
-     * 
+     *
      * @param type The connection type to filter by
      * @return Vector of connections of the specified type
      */
     std::vector<RouterConnectionRecord> get_connections_by_type(ConnectionType type) const;
-    
+
+    /**
+     * Get connections by source node (all routers on that node)
+     *
+     * @param source_node The source fabric node
+     * @return Vector of connections from this node
+     */
+    std::vector<RouterConnectionRecord> get_connections_by_source_node(FabricNodeId source_node) const;
+
+    /**
+     * Get connections by destination node (all routers on that node)
+     *
+     * @param dest_node The destination fabric node
+     * @return Vector of connections to this node
+     */
+    std::vector<RouterConnectionRecord> get_connections_by_dest_node(FabricNodeId dest_node) const;
+
     /**
      * Clear all recorded connections
      */
     void clear();
-    
+
     /**
      * Get the total number of recorded connections
-     * 
+     *
      * @return Number of connections
      */
     size_t size() const;
@@ -124,4 +140,3 @@ private:
 };
 
 }  // namespace tt::tt_fabric
-

--- a/tt_metal/fabric/builder/connection_registry.hpp
+++ b/tt_metal/fabric/builder/connection_registry.hpp
@@ -16,6 +16,7 @@ namespace tt::tt_fabric {
  * ConnectionType - Categorizes the type of connection between routers
  */
 enum class ConnectionType {
+    INVALID,
     INTRA_MESH,   // Connection between mesh routers on different devices
     MESH_TO_Z,    // Connection from mesh router to Z router (same device)
     Z_TO_MESH,    // Connection from Z router to mesh router (same device)
@@ -30,20 +31,20 @@ enum class ConnectionType {
 struct RouterConnectionRecord {
     // Source router information
     FabricNodeId source_node;
-    RoutingDirection source_direction;
-    chan_id_t source_eth_chan;
-    uint32_t source_vc;
-    uint32_t source_sender_channel;
+    RoutingDirection source_direction = RoutingDirection::NONE;
+    chan_id_t source_eth_chan = -1;
+    uint32_t source_vc = -1;
+    uint32_t source_receiver_channel = -1;
 
     // Destination router information
     FabricNodeId dest_node;
-    RoutingDirection dest_direction;
-    chan_id_t dest_eth_chan;
-    uint32_t dest_vc;
-    uint32_t dest_receiver_channel;
+    RoutingDirection dest_direction = RoutingDirection::NONE;
+    chan_id_t dest_eth_chan = -1;
+    uint32_t dest_vc = -1;
+    uint32_t dest_sender_channel = -1;
 
     // Connection metadata
-    ConnectionType connection_type;
+    ConnectionType connection_type = ConnectionType::INVALID;
 };
 
 /**

--- a/tt_metal/fabric/builder/connection_registry.hpp
+++ b/tt_metal/fabric/builder/connection_registry.hpp
@@ -5,7 +5,6 @@
 #pragma once
 
 #include <vector>
-#include <memory>
 #include <tt-metalium/experimental/fabric/mesh_graph.hpp>
 #include <tt-metalium/experimental/fabric/routing_table_generator.hpp>
 #include <hostdevcommon/fabric_common.h>

--- a/tt_metal/fabric/builder/connection_registry.hpp
+++ b/tt_metal/fabric/builder/connection_registry.hpp
@@ -1,0 +1,127 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <vector>
+#include <memory>
+#include <tt-metalium/experimental/fabric/mesh_graph.hpp>
+#include <tt-metalium/experimental/fabric/routing_table_generator.hpp>
+#include <hostdevcommon/fabric_common.h>
+
+namespace tt::tt_fabric {
+
+/**
+ * ConnectionType - Categorizes the type of connection between routers
+ */
+enum class ConnectionType {
+    INTRA_MESH,   // Connection between mesh routers on different devices
+    MESH_TO_Z,    // Connection from mesh router to Z router (same device)
+    Z_TO_MESH,    // Connection from Z router to mesh router (same device)
+};
+
+/**
+ * RouterConnectionRecord - Records a single connection between routers
+ * 
+ * This structure captures all relevant information about a connection
+ * for testing and validation purposes.
+ */
+struct RouterConnectionRecord {
+    // Source router information
+    FabricNodeId source_node;
+    RoutingDirection source_direction;
+    chan_id_t source_eth_chan;
+    uint32_t source_vc;
+    uint32_t source_sender_channel;
+    
+    // Destination router information
+    FabricNodeId dest_node;
+    RoutingDirection dest_direction;
+    chan_id_t dest_eth_chan;
+    uint32_t dest_vc;
+    uint32_t dest_receiver_channel;
+    
+    // Connection metadata
+    ConnectionType connection_type;
+};
+
+/**
+ * ConnectionRegistry - Records all router connections for testing/validation
+ * 
+ * This registry provides visibility into the connection graph between routers.
+ * It's used during Phase 0 to add testing infrastructure and will be extended
+ * in later phases to support Z router connections.
+ * 
+ * Usage:
+ *   auto registry = std::make_shared<ConnectionRegistry>();
+ *   // Pass to builders during construction
+ *   // Query connections for testing
+ *   auto connections = registry->get_all_connections();
+ */
+class ConnectionRegistry {
+public:
+    ConnectionRegistry() = default;
+    
+    /**
+     * Record a connection between two routers
+     * 
+     * @param record The connection record to store
+     */
+    void record_connection(const RouterConnectionRecord& record);
+    
+    /**
+     * Get all recorded connections
+     * 
+     * @return Vector of all connection records
+     */
+    const std::vector<RouterConnectionRecord>& get_all_connections() const;
+    
+    /**
+     * Get connections from a specific source router
+     * 
+     * @param source_node The source fabric node
+     * @param source_direction The source router direction
+     * @return Vector of connections from this source
+     */
+    std::vector<RouterConnectionRecord> get_connections_from_source(
+        FabricNodeId source_node,
+        RoutingDirection source_direction) const;
+    
+    /**
+     * Get connections to a specific destination router
+     * 
+     * @param dest_node The destination fabric node
+     * @param dest_direction The destination router direction
+     * @return Vector of connections to this destination
+     */
+    std::vector<RouterConnectionRecord> get_connections_to_dest(
+        FabricNodeId dest_node,
+        RoutingDirection dest_direction) const;
+    
+    /**
+     * Get connections of a specific type
+     * 
+     * @param type The connection type to filter by
+     * @return Vector of connections of the specified type
+     */
+    std::vector<RouterConnectionRecord> get_connections_by_type(ConnectionType type) const;
+    
+    /**
+     * Clear all recorded connections
+     */
+    void clear();
+    
+    /**
+     * Get the total number of recorded connections
+     * 
+     * @return Number of connections
+     */
+    size_t size() const;
+
+private:
+    std::vector<RouterConnectionRecord> connections_;
+};
+
+}  // namespace tt::tt_fabric
+

--- a/tt_metal/fabric/builder/connection_writer_adapter.hpp
+++ b/tt_metal/fabric/builder/connection_writer_adapter.hpp
@@ -59,6 +59,7 @@ public:
     virtual void add_downstream_connection(
         const SenderWorkerAdapterSpec& adapter_spec,
         uint32_t inbound_vc_idx,
+        uint32_t sender_channel_idx,
         eth_chan_directions downstream_direction,
         CoreCoord downstream_noc_xy,
         bool is_2D_routing) = 0;
@@ -96,6 +97,7 @@ public:
     void add_downstream_connection(
         const SenderWorkerAdapterSpec& adapter_spec,
         uint32_t inbound_vc_idx,
+        uint32_t sender_channel_idx,
         eth_chan_directions downstream_direction,
         CoreCoord downstream_noc_xy,
         bool is_2D_routing) override;

--- a/tt_metal/fabric/builder/fabric_builder_config.cpp
+++ b/tt_metal/fabric/builder/fabric_builder_config.cpp
@@ -18,31 +18,6 @@ uint32_t get_receiver_channel_count(const bool is_2D_routing) {
     return is_2D_routing ? builder_config::num_receiver_channels_2d : builder_config::num_receiver_channels_1d;
 }
 
-std::array<uint32_t, 2> get_sender_channel_count_per_vc(const Topology topology) {
-    const bool is_2D_routing = FabricContext::is_2D_topology(topology);
-    if (is_2D_routing) {
-        // 2D routing: VC0 has 4 sender channels (0-3), VC1 has 3 sender channels (4-6)
-        // Channel 7 is reserved for future Z-axis routing
-        // Total = 7 channels
-        return {4, 3};
-    } else {
-        // 1D routing: All sender channels are allocated to VC0
-        return {get_num_used_sender_channel_count(topology), 0};
-    }
-}
-
-std::array<uint32_t, 2> get_receiver_channel_count_per_vc(const Topology topology) {
-    const bool is_2D_routing = FabricContext::is_2D_topology(topology);
-    if (is_2D_routing) {
-        // 2D routing: VC0 has 1 receiver, VC1 has 1 receiver
-        // Total = 2 receivers
-        return {1, 1};
-    } else {
-        // 1D routing: VC0 has 1 receiver, VC1 has 0
-        return {builder_config::num_receiver_channels_1d, 0};
-    }
-}
-
 uint32_t get_num_used_sender_channel_count(const Topology topology) {
     switch (topology) {
         case Topology::NeighborExchange: return builder_config::num_sender_channels_1d_neighbor_exchange;

--- a/tt_metal/fabric/builder/fabric_builder_config.hpp
+++ b/tt_metal/fabric/builder/fabric_builder_config.hpp
@@ -11,6 +11,7 @@
 #include <tt-metalium/experimental/fabric/fabric_edm_types.hpp>
 #include "tt_metal/hostdevcommon/api/hostdevcommon/fabric_common.h"
 #include <vector>
+#include <algorithm>
 
 namespace tt::tt_fabric {
 

--- a/tt_metal/fabric/builder/fabric_builder_config.hpp
+++ b/tt_metal/fabric/builder/fabric_builder_config.hpp
@@ -50,31 +50,38 @@ static constexpr std::size_t num_sender_channels_1d_neighbor_exchange = 1;
 static constexpr std::size_t num_sender_channels_1d_linear = 2;
 static constexpr std::size_t num_sender_channels_2d_mesh = 4;
 
+// Z router channel counts
+// VC0: 4 channels (same as 2D mesh for consistency)
+// VC1: 4 sender channels (Z→mesh, one per direction), 1 receiver channel (mesh→Z)
+static constexpr std::size_t num_sender_channels_z_router_vc0 = 4;
+static constexpr std::size_t num_sender_channels_z_router_vc1 = 4;
+static constexpr std::size_t num_sender_channels_z_router = num_sender_channels_z_router_vc0 + num_sender_channels_z_router_vc1;
+static constexpr std::size_t num_receiver_channels_z_router = 2;  // 1 for VC0, 1 for VC1
+
 static constexpr std::size_t num_sender_channels_1d = 2;
 // VC0: Worker + 3 of [N/E/S/W] = 4 channels
 // VC1: Up to 3 of [N/E/S/W] for inter-mesh = 3 channels
 // Total 2D: 4 + 3 = 7 channels (channel 7 reserved for future Z-axis)
 static constexpr std::size_t num_sender_channels_2d = 8;
-static constexpr std::size_t num_max_sender_channels = 8;  // Reserve space for future expansion (Z-axis channel)
+static constexpr std::size_t num_max_sender_channels = std::max({num_sender_channels_1d, num_sender_channels_2d, num_sender_channels_z_router, num_sender_channels_2d});
 static constexpr std::size_t num_receiver_channels_1d = 1;
 static constexpr std::size_t num_receiver_channels_2d = 2;
-static constexpr std::size_t num_max_receiver_channels = std::max(num_receiver_channels_1d, num_receiver_channels_2d);
+static constexpr std::size_t num_max_receiver_channels = std::max({num_receiver_channels_1d, num_receiver_channels_2d, num_receiver_channels_z_router});
 
 static constexpr std::size_t num_downstream_edms_vc0 = 1;
 static constexpr std::size_t num_downstream_edms_2d_vc0 = 3;
-static constexpr std::size_t num_downstream_edms_2d_vc1 = 3;
+static constexpr std::size_t num_downstream_edms_2d_vc1 = 3;  // XY intermesh: 3 mesh directions
+static constexpr std::size_t num_downstream_edms_2d_vc1_with_z = 4;  // Z intermesh: 3 mesh + Z
 static constexpr std::size_t num_downstream_edms_1d = num_downstream_edms_vc0;
 static constexpr std::size_t num_downstream_edms_2d = num_downstream_edms_2d_vc0 + num_downstream_edms_2d_vc1;
-static constexpr std::size_t max_downstream_edms = std::max(num_downstream_edms_1d, num_downstream_edms_2d);
+static constexpr std::size_t max_downstream_edms = std::max({num_downstream_edms_1d, num_downstream_edms_2d, num_downstream_edms_2d_vc1_with_z});
+
+// 2D mesh directions (N, E, S, W)
+static constexpr uint32_t num_mesh_directions_2d = 4;
 
 uint32_t get_sender_channel_count(bool is_2D_routing);
 
 uint32_t get_receiver_channel_count(bool is_2D_routing);
-
-// Per-VC channel counts (index 0 = VC0, index 1 = VC1)
-std::array<uint32_t, 2> get_sender_channel_count_per_vc(Topology topology);
-
-std::array<uint32_t, 2> get_receiver_channel_count_per_vc(Topology topology);
 
 uint32_t get_num_used_sender_channel_count(Topology topology);
 

--- a/tt_metal/fabric/builder/fabric_builder_helpers.hpp
+++ b/tt_metal/fabric/builder/fabric_builder_helpers.hpp
@@ -85,11 +85,19 @@ inline uint32_t get_downstream_edm_sender_channel(
     return 1 + downstream_compact_index_for_upstream;
 }
 
-// A receiver channel has 3 downstream EDMs
+// A receiver channel has up to 4 downstream EDMs (3 mesh directions + optional Z)
 // This helper returns the index at which the receiver channel should store the downstream EDMs information.
-// The index is 0, 1, 2 and depends on the downstream direction relative to the my direction.
+// The index is 0-2 for mesh directions (N/E/S/W excluding own direction), 3 for Z direction.
 inline size_t get_receiver_channel_compact_index(
     const eth_chan_directions receiver_direction, const eth_chan_directions downstream_direction) {
+    // TODO: Add Z direction support when eth_chan_directions::Z is added to fabric_common.h
+    // Z direction will get compact index 3 (after the 3 mesh directions)
+    // For now, Z is not yet defined in eth_chan_directions enum
+    // if (downstream_direction == eth_chan_directions::Z) {
+    //     return 3;
+    // }
+
+    // Mesh directions (N/E/S/W) get compact indices 0-2
     size_t compact_index;
     if (receiver_direction == 0) {
         compact_index = downstream_direction - 1;

--- a/tt_metal/fabric/builder/fabric_static_sized_channels_allocator.cpp
+++ b/tt_metal/fabric/builder/fabric_static_sized_channels_allocator.cpp
@@ -325,7 +325,10 @@ void FabricStaticSizedChannelsAllocator::configure_buffer_slots_helper(
                 {4, 8, 0, 0},   // Option 3: VC0 only
                 {4, 8, 2, 4},   // Option 4: supports both VCs
                 {4, 8, 2, 2},   // Option 5: supports both VCs, smaller VC1 receiver
-                {2, 4, 2, 2}    // Option 6: supports both VCs, smaller overall
+                {2, 4, 2, 2},   // Option 6: supports both VCs, smaller overall
+                {2, 4, 1, 1},   // Option 7: supports both VCs, smaller overall
+                {2, 2, 1, 1},   // Option 8: supports both VCs, smaller overall
+                {1, 1, 1, 1}    // Option 9: supports both VCs, smaller overall
             }};
         static const std::vector<std::vector<PerVcBufferSlots>> other_buffer_slot_options = {
             // WORMHOLE_B0

--- a/tt_metal/fabric/builder/fabric_static_sized_channels_allocator.cpp
+++ b/tt_metal/fabric/builder/fabric_static_sized_channels_allocator.cpp
@@ -316,7 +316,11 @@ void FabricStaticSizedChannelsAllocator::configure_buffer_slots_helper(
                 {4, 8, 0, 0},   // Option 2: VC0 only, smaller
                 {4, 8, 2, 4},   // Option 3: supports both VCs
                 {4, 8, 2, 2},   // Option 4: supports both VCs, smaller VC1 receiver
-                {2, 4, 2, 2}    // Option 5: supports both VCs, smaller overall
+                {2, 4, 2, 2},   // Option 5: supports both VCs, smaller overall
+                {2, 4, 1, 1},   // Option 6: supports both VCs, smaller overall
+                {2, 2, 1, 1},   // Option 7: supports both VCs, smaller overall
+                {1, 1, 1, 1}    // Option 8: supports both VCs, smaller overall
+
             },
             // BLACKHOLE
             {

--- a/tt_metal/fabric/builder/fabric_static_sized_channels_allocator.cpp
+++ b/tt_metal/fabric/builder/fabric_static_sized_channels_allocator.cpp
@@ -301,7 +301,11 @@ void FabricStaticSizedChannelsAllocator::configure_buffer_slots_helper(
             {16, 16, 0, 0},  // Option 1
             {8, 16, 0, 0},   // Option 2
             {8, 8, 0, 0},    // Option 3
-            {4, 8, 0, 0}     // Option 4
+            {4, 8, 0, 0},    // Option 4
+            {4, 8, 4, 4},    // Option 4
+            {4, 8, 2, 2},    // Option 4
+            {4, 4, 2, 2},    // Option 4
+            {2, 2, 2, 2}     // Option 4
         },
         // BLACKHOLE
         {{32, 32, 0, 0}, {16, 32, 0, 0}, {16, 16, 0, 0}, {8, 16, 0, 0}, {8, 8, 0, 0}}};

--- a/tt_metal/fabric/builder/router_connection_mapping.cpp
+++ b/tt_metal/fabric/builder/router_connection_mapping.cpp
@@ -1,0 +1,190 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tt_metal/fabric/builder/router_connection_mapping.hpp"
+#include "tt_metal/fabric/builder/fabric_builder_config.hpp"
+
+#include <tt-logger/tt-logger.hpp>
+
+namespace tt::tt_fabric {
+
+std::vector<ConnectionTarget> RouterConnectionMapping::get_downstream_targets(
+    uint32_t vc, uint32_t sender_channel) const {
+    SenderChannelKey key{vc, sender_channel};
+    auto it = sender_to_targets_.find(key);
+
+    if (it != sender_to_targets_.end()) {
+        return it->second;
+    }
+
+    return {};  // No targets for this sender channel
+}
+
+bool RouterConnectionMapping::has_targets(uint32_t vc, uint32_t sender_channel) const {
+    SenderChannelKey key{vc, sender_channel};
+    return sender_to_targets_.find(key) != sender_to_targets_.end();
+}
+
+std::vector<SenderChannelKey> RouterConnectionMapping::get_all_sender_keys() const {
+    std::vector<SenderChannelKey> keys;
+    keys.reserve(sender_to_targets_.size());
+
+    for (const auto& [key, _] : sender_to_targets_) {
+        keys.push_back(key);
+    }
+
+    return keys;
+}
+
+void RouterConnectionMapping::add_target(uint32_t vc, uint32_t sender_channel, const ConnectionTarget& target) {
+    SenderChannelKey key{vc, sender_channel};
+    sender_to_targets_[key].push_back(target);
+}
+
+RoutingDirection RouterConnectionMapping::get_opposite_direction(RoutingDirection dir) {
+    switch (dir) {
+        case RoutingDirection::N: return RoutingDirection::S;
+        case RoutingDirection::S: return RoutingDirection::N;
+        case RoutingDirection::E: return RoutingDirection::W;
+        case RoutingDirection::W: return RoutingDirection::E;
+        default:
+            TT_FATAL(false, "Invalid routing direction for opposite calculation: {}", static_cast<int>(dir));
+            return dir;  // Unreachable
+    }
+}
+
+RouterConnectionMapping RouterConnectionMapping::for_mesh_router(
+    Topology topology, RoutingDirection direction, bool has_z) {
+    RouterConnectionMapping mapping;
+
+    // VC0 sender channels for mesh routers
+    // Channel 0: Reserved for local/internal use
+    // Channel 1: Primary inter-router connection (opposite direction)
+    // Channels 2-3: Additional directions for 2D topology
+
+    if (topology == Topology::Linear || topology == Topology::Ring) {
+        // 1D topology: Only channel 1 connects to opposite direction peer
+        // Ring is also 1D but with wrap-around (handled by FabricBuilder connection logic)
+        RoutingDirection opposite = get_opposite_direction(direction);
+        mapping.add_target(
+            0,  // VC0
+            1,  // Sender channel 1
+            ConnectionTarget(
+                ConnectionType::INTRA_MESH,
+                0,  // Target VC0
+                0,  // Target sender channel (will be resolved by peer)
+                opposite));
+
+    } else if (topology == Topology::Mesh || topology == Topology::Torus) {
+        // 2D topology: Channels 1-3 connect to opposite direction peers
+        // Channel 1: Primary direction (opposite of this router's direction)
+        // Channels 2-3: Cross directions
+
+        // Compute the 3 outbound directions for a 2D mesh router
+        // For NORTH router: sends to SOUTH (primary), EAST, WEST
+        // For EAST router: sends to WEST (primary), NORTH, SOUTH
+        // For SOUTH router: sends to NORTH (primary), EAST, WEST
+        // For WEST router: sends to EAST (primary), NORTH, SOUTH
+
+        std::vector<RoutingDirection> outbound_directions;
+        RoutingDirection opposite = get_opposite_direction(direction);
+        outbound_directions.push_back(opposite);  // Primary (channel 1)
+
+        // Add cross directions (channels 2-3)
+        std::vector<RoutingDirection> all_directions = {
+            RoutingDirection::N,
+            RoutingDirection::E,
+            RoutingDirection::S,
+            RoutingDirection::W
+        };
+
+        for (auto dir : all_directions) {
+            if (dir != direction && dir != opposite) {
+                outbound_directions.push_back(dir);
+            }
+        }
+
+        // Map sender channels 1-3 to outbound directions
+        //
+        // IMPORTANT: INTRA_MESH connections are hardcoded to use VC0 only.
+        // This is the intended behavior for the following reasons:
+        //
+        // 1. VC0 is reserved for intra-mesh traffic (mesh-to-mesh communication within a single mesh)
+        // 2. VC1 is reserved for inter-mesh traffic (mesh-to-Z, Z-to-mesh, or mesh-to-mesh across different meshes)
+        // 3. This separation ensures proper traffic isolation and prevents deadlocks in multi-mesh systems
+        // 4. Even when VC1 is enabled on mesh routers (via IntermeshVCConfig), INTRA_MESH connections
+        //    continue to use VC0, while inter-mesh connections use VC1
+        // 5. The VC assignment is determined by the connection type, not the router capabilities
+        //
+        // Future work: If VC1 needs to support intra-mesh traffic (e.g., for QoS or priority routing),
+        // a new ConnectionType would need to be introduced (e.g., INTRA_MESH_VC1) to explicitly
+        // distinguish it from standard INTRA_MESH (VC0) connections.
+        for (size_t i = 0; i < outbound_directions.size() && i < 3; ++i) {
+            mapping.add_target(
+                0,  // VC0 - hardcoded for INTRA_MESH (see documentation above)
+                1 + i,  // Sender channels 1, 2, 3
+                ConnectionTarget(
+                    ConnectionType::INTRA_MESH,
+                    0,  // Target VC0 - hardcoded for INTRA_MESH (see documentation above)
+                    0,  // Target sender channel (resolved by peer)
+                    outbound_directions[i]));
+        }
+    }
+
+    // If this device has a Z router, add MESH_TO_Z connection
+    if (has_z) {
+        // Mesh routers use the next available sender channel (after base mesh channels) for MESH_TO_Z
+        // 1D: base channels from builder_config::num_sender_channels_1d_linear
+        // 2D: base channels from builder_config::num_sender_channels_2d_mesh
+        uint32_t base_channels = (topology == Topology::Linear || topology == Topology::Ring)
+                                     ? builder_config::num_sender_channels_1d_linear
+                                     : builder_config::num_sender_channels_2d_mesh;
+        uint32_t mesh_to_z_channel = base_channels;
+
+        mapping.add_target(
+            0,  // VC0
+            mesh_to_z_channel,
+            ConnectionTarget(
+                ConnectionType::MESH_TO_Z,
+                0,  // Target Z router VC0
+                0,  // Target sender channel (resolved by Z router)
+                RoutingDirection::Z));  // Target is Z router
+    }
+
+    return mapping;
+}
+
+RouterConnectionMapping RouterConnectionMapping::for_z_router() {
+    RouterConnectionMapping mapping;
+
+    // VC0: Standard mesh forwarding (if Z router participates in mesh routing)
+    // For now, Z routers primarily use VC1, so VC0 may be unused or reserved
+    // This can be extended later if needed
+
+    // VC1: Multi-target Z_TO_MESH connections
+    // Sender channels 0-3 map to N/E/S/W mesh routers
+    // Each sender channel has intent to connect to a specific direction
+    // FabricBuilder will skip non-existent directions (2-4 mesh routers on edge devices)
+
+    std::vector<RoutingDirection> mesh_directions = {
+        RoutingDirection::N,   // Sender channel 0
+        RoutingDirection::E,    // Sender channel 1
+        RoutingDirection::S,   // Sender channel 2
+        RoutingDirection::W     // Sender channel 3
+    };
+
+    for (size_t i = 0; i < mesh_directions.size(); ++i) {
+        mapping.add_target(
+            1,  // VC1
+            i,  // Sender channels 0-3
+            ConnectionTarget(
+                ConnectionType::Z_TO_MESH,
+                1,  // Target mesh router VC1
+                0,  // Target receiver channel (resolved by mesh router)
+                mesh_directions[i]));
+    }
+
+    return mapping;
+}
+
+}  // namespace tt::tt_fabric

--- a/tt_metal/fabric/builder/router_connection_mapping.cpp
+++ b/tt_metal/fabric/builder/router_connection_mapping.cpp
@@ -123,8 +123,8 @@ RouterConnectionMapping RouterConnectionMapping::for_mesh_router(
                 0,  // Receiver channel 0
                 ConnectionTarget(
                     ConnectionType::INTRA_MESH,
-                    0,  // Target VC0 - hardcoded for INTRA_MESH (see documentation above)
-                    i + 1,  // Target sender channel 
+                    0,      // Target VC0 - hardcoded for INTRA_MESH (see documentation above)
+                    i + 1,  // Target sender channel
                     outbound_directions[i]));
         }
     }

--- a/tt_metal/fabric/builder/router_connection_mapping.hpp
+++ b/tt_metal/fabric/builder/router_connection_mapping.hpp
@@ -76,10 +76,10 @@ public:
      * @brief Get downstream connection targets for a receiver channel
      *
      * @param vc Virtual channel index
-     * @param sender_channel Sender channel index within the VC
+     * @param receiver_channel Sender channel index within the VC
      * @return Vector of connection targets (may be empty if no connections)
      */
-    std::vector<ConnectionTarget> get_downstream_targets(uint32_t vc, uint32_t sender_channel) const;
+    std::vector<ConnectionTarget> get_downstream_targets(uint32_t vc, uint32_t receiver_channel) const;
 
     /**
      * @brief Factory method for mesh router connection mapping
@@ -118,7 +118,7 @@ public:
     /**
      * @brief Get total number of configured sender channels across all VCs
      */
-    size_t get_total_sender_count() const { return receiver_to_targets_.size(); }
+    size_t get_total_sender_count() const { return std::accumulate(receiver_to_targets_.begin(), receiver_to_targets_.end(), 0, [](size_t sum, const auto& pair) { return sum + pair.second.size(); }); }
 
     /**
      * @brief Get all receiver channel keys (for iteration/testing)

--- a/tt_metal/fabric/builder/router_connection_mapping.hpp
+++ b/tt_metal/fabric/builder/router_connection_mapping.hpp
@@ -15,9 +15,9 @@
 namespace tt::tt_fabric {
 
 /**
- * @brief Represents a single downstream connection target for a sender channel
+ * @brief Represents a single downstream connection target for a receiver channel
  *
- * This struct defines where a sender channel should connect to, including:
+ * This struct defines where a receiver channel should connect to, including:
  * - The connection type (INTRA_MESH, MESH_TO_Z, Z_TO_MESH)
  * - The target virtual channel (VC)
  * - The target sender channel index
@@ -41,40 +41,39 @@ struct ConnectionTarget {
 };
 
 /**
- * @brief Key for identifying a sender channel (VC + channel index)
+ * @brief Key for identifying a receiver channel (VC + channel index)
  */
-struct SenderChannelKey {
+struct ReceiverChannelKey {
     uint32_t vc;
-    uint32_t sender_channel;
+    uint32_t receiver_channel;
 
-    bool operator<(const SenderChannelKey& other) const {
-        if (vc != other.vc) return vc < other.vc;
-        return sender_channel < other.sender_channel;
+    bool operator<(const ReceiverChannelKey& other) const {
+        if (vc != other.vc) {
+            return vc < other.vc;
+        }
+        return receiver_channel < other.receiver_channel;
     }
 
-    bool operator==(const SenderChannelKey& other) const {
-        return vc == other.vc && sender_channel == other.sender_channel;
+    bool operator==(const ReceiverChannelKey& other) const {
+        return vc == other.vc && receiver_channel == other.receiver_channel;
     }
 };
 
 /**
- * @brief Defines sender channel to downstream target mappings for a router
+ * @brief Defines receiver channel to downstream target mappings for a router
  *
- * This class encapsulates the connection logic for routers, mapping each sender
+ * This class encapsulates the connection logic for routers, mapping each receiver
  * channel to its downstream connection targets. It supports:
  * - Mesh routers with 1D/2D topologies
  * - Mesh routers with MESH_TO_Z connections (when Z router present on device)
  * - Z routers with multi-target VC1 connections
- *
- * Key insight: Mapping is for SENDER channels, not receivers. A sender channel
- * may have multiple downstream targets (e.g., Z router VC1 connecting to 2-4 mesh routers).
  */
 class RouterConnectionMapping {
 public:
     RouterConnectionMapping() = default;
 
     /**
-     * @brief Get downstream connection targets for a sender channel
+     * @brief Get downstream connection targets for a receiver channel
      *
      * @param vc Virtual channel index
      * @param sender_channel Sender channel index within the VC
@@ -112,28 +111,28 @@ public:
     static RouterConnectionMapping for_z_router();
 
     /**
-     * @brief Check if a sender channel has any downstream targets
+     * @brief Check if a receiver channel has any downstream targets
      */
-    bool has_targets(uint32_t vc, uint32_t sender_channel) const;
+    bool has_targets(uint32_t vc, uint32_t receiver_channel) const;
 
     /**
      * @brief Get total number of configured sender channels across all VCs
      */
-    size_t get_total_sender_count() const { return sender_to_targets_.size(); }
+    size_t get_total_sender_count() const { return receiver_to_targets_.size(); }
 
     /**
-     * @brief Get all sender channel keys (for iteration/testing)
+     * @brief Get all receiver channel keys (for iteration/testing)
      */
-    std::vector<SenderChannelKey> get_all_sender_keys() const;
+    std::vector<ReceiverChannelKey> get_all_receiver_keys() const;
 
 private:
     // Maps (VC, sender_channel) → list of downstream targets
-    std::map<SenderChannelKey, std::vector<ConnectionTarget>> sender_to_targets_;
+    std::map<ReceiverChannelKey, std::vector<ConnectionTarget>> receiver_to_targets_;
 
     /**
-     * @brief Add a connection target for a sender channel
+     * @brief Add a connection target for a receiver channel
      */
-    void add_target(uint32_t vc, uint32_t sender_channel, const ConnectionTarget& target);
+    void add_target(uint32_t vc, uint32_t receiver_channel, const ConnectionTarget& target);
 
     /**
      * @brief Helper to compute opposite direction for mesh routers

--- a/tt_metal/fabric/builder/router_connection_mapping.hpp
+++ b/tt_metal/fabric/builder/router_connection_mapping.hpp
@@ -1,0 +1,144 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include <map>
+#include <optional>
+#include <vector>
+
+#include "tt_metal/fabric/builder/connection_registry.hpp"
+#include <tt-metalium/experimental/fabric/mesh_graph.hpp>
+#include <tt-metalium/experimental/fabric/fabric_edm_types.hpp>
+
+namespace tt::tt_fabric {
+
+/**
+ * @brief Represents a single downstream connection target for a sender channel
+ *
+ * This struct defines where a sender channel should connect to, including:
+ * - The connection type (INTRA_MESH, MESH_TO_Z, Z_TO_MESH)
+ * - The target virtual channel (VC)
+ * - The target sender channel index
+ * - Optional target direction (for local connections)
+ */
+struct ConnectionTarget {
+    ConnectionType type;
+    uint32_t target_vc;
+    uint32_t target_sender_channel;
+    std::optional<RoutingDirection> target_direction;  // Used for MESH_TO_Z and Z_TO_MESH
+
+    ConnectionTarget(
+        ConnectionType type_,
+        uint32_t target_vc_,
+        uint32_t target_sender_channel_,
+        std::optional<RoutingDirection> target_direction_ = std::nullopt)
+        : type(type_),
+          target_vc(target_vc_),
+          target_sender_channel(target_sender_channel_),
+          target_direction(target_direction_) {}
+};
+
+/**
+ * @brief Key for identifying a sender channel (VC + channel index)
+ */
+struct SenderChannelKey {
+    uint32_t vc;
+    uint32_t sender_channel;
+
+    bool operator<(const SenderChannelKey& other) const {
+        if (vc != other.vc) return vc < other.vc;
+        return sender_channel < other.sender_channel;
+    }
+
+    bool operator==(const SenderChannelKey& other) const {
+        return vc == other.vc && sender_channel == other.sender_channel;
+    }
+};
+
+/**
+ * @brief Defines sender channel to downstream target mappings for a router
+ *
+ * This class encapsulates the connection logic for routers, mapping each sender
+ * channel to its downstream connection targets. It supports:
+ * - Mesh routers with 1D/2D topologies
+ * - Mesh routers with MESH_TO_Z connections (when Z router present on device)
+ * - Z routers with multi-target VC1 connections
+ *
+ * Key insight: Mapping is for SENDER channels, not receivers. A sender channel
+ * may have multiple downstream targets (e.g., Z router VC1 connecting to 2-4 mesh routers).
+ */
+class RouterConnectionMapping {
+public:
+    RouterConnectionMapping() = default;
+
+    /**
+     * @brief Get downstream connection targets for a sender channel
+     *
+     * @param vc Virtual channel index
+     * @param sender_channel Sender channel index within the VC
+     * @return Vector of connection targets (may be empty if no connections)
+     */
+    std::vector<ConnectionTarget> get_downstream_targets(uint32_t vc, uint32_t sender_channel) const;
+
+    /**
+     * @brief Factory method for mesh router connection mapping
+     *
+     * Creates a mapping for a standard mesh router based on topology and direction.
+     *
+     * @param topology Mesh topology (1D or 2D)
+     * @param direction Router's direction (NORTH, EAST, SOUTH, WEST)
+     * @param has_z Whether this device has a Z router (enables MESH_TO_Z connections)
+     * @return Configured RouterConnectionMapping for mesh router
+     */
+    static RouterConnectionMapping for_mesh_router(
+        Topology topology,
+        RoutingDirection direction,
+        bool has_z);
+
+    /**
+     * @brief Factory method for Z router connection mapping
+     *
+     * Creates a mapping for a Z router with:
+     * - VC0: Standard mesh forwarding (if applicable)
+     * - VC1: Multi-target Z_TO_MESH connections (N/E/S/W intent)
+     *
+     * Note: Mapping specifies all 4 directions as intent. FabricBuilder
+     * will skip non-existent directions based on device position (2-4 mesh routers).
+     *
+     * @return Configured RouterConnectionMapping for Z router
+     */
+    static RouterConnectionMapping for_z_router();
+
+    /**
+     * @brief Check if a sender channel has any downstream targets
+     */
+    bool has_targets(uint32_t vc, uint32_t sender_channel) const;
+
+    /**
+     * @brief Get total number of configured sender channels across all VCs
+     */
+    size_t get_total_sender_count() const { return sender_to_targets_.size(); }
+
+    /**
+     * @brief Get all sender channel keys (for iteration/testing)
+     */
+    std::vector<SenderChannelKey> get_all_sender_keys() const;
+
+private:
+    // Maps (VC, sender_channel) → list of downstream targets
+    std::map<SenderChannelKey, std::vector<ConnectionTarget>> sender_to_targets_;
+
+    /**
+     * @brief Add a connection target for a sender channel
+     */
+    void add_target(uint32_t vc, uint32_t sender_channel, const ConnectionTarget& target);
+
+    /**
+     * @brief Helper to compute opposite direction for mesh routers
+     */
+    static RoutingDirection get_opposite_direction(RoutingDirection dir);
+};
+
+}  // namespace tt::tt_fabric

--- a/tt_metal/fabric/builder/static_sized_channel_connection_writer_adapter.cpp
+++ b/tt_metal/fabric/builder/static_sized_channel_connection_writer_adapter.cpp
@@ -21,9 +21,11 @@ StaticSizedChannelConnectionWriterAdapter::StaticSizedChannelConnectionWriterAda
 void StaticSizedChannelConnectionWriterAdapter::add_downstream_connection(
     const SenderWorkerAdapterSpec& adapter_spec,
     uint32_t inbound_vc_idx,
+    uint32_t /*sender_channel_idx*/,
     eth_chan_directions downstream_direction,
     CoreCoord downstream_noc_xy,
     bool is_2D_routing) {
+    // Track connections per VC for packing
     downstream_edms_connected_by_vc.at(inbound_vc_idx).push_back(
         {downstream_direction, CoreCoord(downstream_noc_xy.x, downstream_noc_xy.y)});
 
@@ -38,6 +40,8 @@ void StaticSizedChannelConnectionWriterAdapter::add_downstream_connection(
         this->downstream_edms_connected |= (1 << compact_index);
 
         // Store addresses indexed by [vc_idx][compact_index]
+        // NOTE: For INTRA_MESH connections, this works fine (one connection per compact_index)
+        // For Z router multi-target, we'll use vc_to_downstreams_ instead
         this->downstream_edm_buffer_base_addresses.at(inbound_vc_idx).at(compact_index) =
             adapter_spec.edm_buffer_base_addr;
         this->downstream_edm_worker_registration_addresses.at(inbound_vc_idx).at(compact_index) =
@@ -84,14 +88,30 @@ void StaticSizedChannelConnectionWriterAdapter::add_local_tensix_connection(
 
 void StaticSizedChannelConnectionWriterAdapter::pack_inbound_channel_rt_args(
     uint32_t vc_idx, std::vector<uint32_t>& args_out) const {
+    // Standard packing for all connection types
+    //
+    // IMPORTANT: All connections on the same VC share the same downstream buffer address.
+    // This is a fundamental constraint of the fabric architecture:
+    // - For INTRA_MESH: Each sender channel connects to one downstream router
+    // - For Z_TO_MESH: Multiple sender channels (one per direction) each connect to one downstream router
+    // - All connections on a VC write to the same receiver channel buffer on their respective targets
+    //
+    // Because of this constraint, the standard packing path (which stores one buffer address per VC)
+    // is sufficient for all connection types, including multi-target scenarios.
     if (is_2D_routing) {
-        // For 2D: Temporary, until support for VC1 is added
-        TT_FATAL(vc_idx == 0, "VC1 is not supported for 2D routing");
-        // Get the appropriate downstream EDM count based on VC index
-        uint32_t num_downstream_edms = (vc_idx == 0) ? builder_config::get_vc0_downstream_edm_count(is_2D_routing)
-                                                     : builder_config::get_vc1_downstream_edm_count(is_2D_routing);
+        // For 2D: Use fixed slot count based on VC (kernel expects fixed-size arrays)
+        // VC0: 3 slots (mesh directions)
+        // VC1: 3 slots (XY intermesh) or 4 slots (Z intermesh) - determined by actual connections
+        size_t num_downstream_edms;
+        if (vc_idx == 0) {
+            num_downstream_edms = builder_config::get_vc0_downstream_edm_count(is_2D_routing);
+        } else {
+            // VC1: Use actual connection count (3 for XY, 4 for Z)
+            // This is safe because VC1 channels are only created when intermesh is configured
+            num_downstream_edms = downstream_edms_connected_by_vc[vc_idx].size();
+        }
 
-        // Pack connection mask (3-bit mask for 3 downstream EDMs)
+        // Pack connection mask (bit mask indicating which slots are valid)
         args_out.push_back(this->downstream_edms_connected);
 
         // Pack buffer base addresses (one per compact index)
@@ -190,18 +210,16 @@ uint32_t StaticSizedChannelConnectionWriterAdapter::encode_noc_ord_for_2d(
         downstream_edms_connected_by_vc,
     uint32_t vc_idx,
     const std::function<uint32_t(CoreCoord)>& get_noc_ord) const {
-    if (vc_idx == 1) {
-        // DELETEME (non-vc0 code) Issue #33360
-        return 0;
-    }
     if (!is_2D_routing) {
+        // 1D routing: single downstream connection
         if (downstream_edms_connected_by_vc[vc_idx].empty()) {
             return 0; // no connection here
         }
-        TT_FATAL(downstream_edms_connected_by_vc[vc_idx].size() == 1, "Downstream edms connected by vc should be 1 for vc1 or non-2D routing. vc_idx: {}, size: {}", vc_idx, downstream_edms_connected_by_vc[vc_idx].size());
+        TT_FATAL(downstream_edms_connected_by_vc[vc_idx].size() == 1, "Downstream edms connected by vc should be 1 for non-2D routing. vc_idx: {}, size: {}", vc_idx, downstream_edms_connected_by_vc[vc_idx].size());
         auto ord = get_noc_ord(downstream_edms_connected_by_vc[vc_idx].front().second);
         return ord;
     } else {
+        // 2D routing: encode NOC coordinates using compact index (works for both VC0 and VC1)
         uint32_t ord = 0;
         for (const auto& [direction, noc_xy] : downstream_edms_connected_by_vc[vc_idx]) {
             // Calculate compact index based on direction relative to my_direction

--- a/tt_metal/fabric/compute_mesh_router_builder.cpp
+++ b/tt_metal/fabric/compute_mesh_router_builder.cpp
@@ -490,7 +490,7 @@ void ComputeMeshRouterBuilder::configure_connection(
 }
 
 void ComputeMeshRouterBuilder::configure_local_connections(
-    const std::map<RoutingDirection, ComputeMeshRouterBuilder*>& local_routers) {
+    const std::map<RoutingDirection, FabricRouterBuilder*>& local_routers) {
     // Establish local connections (MESH_TO_Z or Z_TO_MESH) to routers on same device
     // We need to look up target routers by direction from the map
     auto local_connection_filter = [](ConnectionType type) {
@@ -530,7 +530,9 @@ void ComputeMeshRouterBuilder::configure_local_connections(
                 // Establish connections to this target router (if not already done)
                 if (connected_targets.find(target_dir) == connected_targets.end()) {
                     auto* local_router = local_routers.at(target_dir);
-                    establish_connections_to_router(*local_router, local_connection_filter);
+                    auto* local_compute_router = dynamic_cast<ComputeMeshRouterBuilder*>(local_router);
+                    TT_FATAL(local_compute_router != nullptr, "Local router must be a ComputeMeshRouterBuilder");
+                    establish_connections_to_router(*local_compute_router, local_connection_filter);
                     connected_targets.insert(target_dir);
                 }
             }

--- a/tt_metal/fabric/compute_mesh_router_builder.cpp
+++ b/tt_metal/fabric/compute_mesh_router_builder.cpp
@@ -70,7 +70,7 @@ std::unique_ptr<ComputeMeshRouterBuilder> ComputeMeshRouterBuilder::build(
 
     // Create channel mapping EARLY (needed for computing injection flags)
     RouterVariant variant = (location.direction == RoutingDirection::Z) ? RouterVariant::Z_ROUTER : RouterVariant::MESH;
-    const auto& intermesh_config = fabric_context.get_intermesh_vc_config();
+    const auto& intermesh_config = fabric_context.get_builder_context().get_intermesh_vc_config();
     auto channel_mapping = FabricRouterChannelMapping(topology, downstream_is_tensix_builder, variant, &intermesh_config);
 
     // Create connection mapping (Phase 3)

--- a/tt_metal/fabric/compute_mesh_router_builder.cpp
+++ b/tt_metal/fabric/compute_mesh_router_builder.cpp
@@ -25,11 +25,13 @@ ComputeMeshRouterBuilder::ComputeMeshRouterBuilder(
     std::unique_ptr<FabricEriscDatamoverBuilder> erisc_builder,
     std::optional<FabricTensixDatamoverBuilder> tensix_builder,
     FabricRouterChannelMapping channel_mapping,
+    RouterConnectionMapping connection_mapping,
     std::shared_ptr<ConnectionRegistry> connection_registry) :
     FabricRouterBuilder(local_node, location),
     erisc_builder_(std::move(erisc_builder)),
     tensix_builder_(std::move(tensix_builder)),
     channel_mapping_(std::move(channel_mapping)),
+    connection_mapping_(std::move(connection_mapping)),
     connection_registry_(std::move(connection_registry)) {
     TT_FATAL(erisc_builder_ != nullptr, "Erisc builder cannot be null");
 }
@@ -68,7 +70,20 @@ std::unique_ptr<ComputeMeshRouterBuilder> ComputeMeshRouterBuilder::build(
     const auto& edm_config = builder_context.get_fabric_router_config(tensix_config_for_lookup, eth_direction);
 
     // Create channel mapping EARLY (needed for computing injection flags)
-    auto channel_mapping = FabricRouterChannelMapping(topology, eth_direction, downstream_is_tensix_builder);
+    RouterVariant variant = (location.direction == RoutingDirection::Z) ? RouterVariant::Z_ROUTER : RouterVariant::MESH;
+    const auto& intermesh_config = fabric_context.get_intermesh_vc_config();
+    auto channel_mapping = FabricRouterChannelMapping(topology, downstream_is_tensix_builder, variant, &intermesh_config);
+
+    // Create connection mapping (Phase 3)
+    RouterConnectionMapping connection_mapping;
+    if (variant == RouterVariant::Z_ROUTER) {
+        connection_mapping = RouterConnectionMapping::for_z_router();
+    } else {
+        // Check if this device has a Z router
+        bool has_z = fabric_context.has_z_router_on_device(device->id());
+        connection_mapping = RouterConnectionMapping::for_mesh_router(topology, location.direction, has_z);
+    }
+
     // Compute injection channel flags at router level BEFORE creating builders
     // Injection semantics are per-VC, so compute for each VC and flatten into router-level vector
     // Injection channel status flags are used by sender channels to understand if that channel must
@@ -112,7 +127,15 @@ std::unique_ptr<ComputeMeshRouterBuilder> ComputeMeshRouterBuilder::build(
             router_injection_flags, tensix_to_router_channel_map);
     }
 
-    // NOW create erisc builder with computed injection flags
+    // Compute actual per-VC channel counts for this router
+    std::array<std::size_t, builder_config::MAX_NUM_VCS> actual_sender_channels_per_vc{};
+    std::array<std::size_t, builder_config::MAX_NUM_VCS> actual_receiver_channels_per_vc{};
+    for (uint32_t vc = 0; vc < num_vcs; ++vc) {
+        actual_sender_channels_per_vc[vc] = channel_mapping.get_num_sender_channels_for_vc(vc);
+        actual_receiver_channels_per_vc[vc] = 1;  // Always 1 receiver per VC
+    }
+
+    // NOW create erisc builder with computed injection flags and actual channel counts
     auto edm_builder = std::make_unique<FabricEriscDatamoverBuilder>(FabricEriscDatamoverBuilder::build(
         device,
         program,
@@ -123,7 +146,9 @@ std::unique_ptr<ComputeMeshRouterBuilder> ComputeMeshRouterBuilder::build(
         std::move(erisc_injection_flags),
         false, /* build_in_worker_connection_mode */
         eth_direction,
-        downstream_is_tensix_builder));
+        downstream_is_tensix_builder,
+        actual_sender_channels_per_vc,
+        actual_receiver_channels_per_vc));
 
     if (tt::tt_metal::MetalContext::instance().get_cluster().arch() == tt::ARCH::BLACKHOLE &&
         tt::tt_metal::MetalContext::instance().rtoptions().get_enable_2_erisc_mode()) {
@@ -148,7 +173,7 @@ std::unique_ptr<ComputeMeshRouterBuilder> ComputeMeshRouterBuilder::build(
 
     // Use unique_ptr constructor directly since ComputeMeshRouterBuilder constructor is private
     auto router_builder = std::unique_ptr<ComputeMeshRouterBuilder>(new ComputeMeshRouterBuilder(
-        local_node, location, std::move(edm_builder), std::move(tensix_builder_opt), std::move(channel_mapping), connection_registry));
+        local_node, location, std::move(edm_builder), std::move(tensix_builder_opt), std::move(channel_mapping), std::move(connection_mapping), connection_registry));
 
     // Setup the local relay kernel connection if in UDM mode
     if (fabric_tensix_extension_udm_mode && router_builder->has_tensix_builder()) {
@@ -156,89 +181,6 @@ std::unique_ptr<ComputeMeshRouterBuilder> ComputeMeshRouterBuilder::build(
     }
 
     return router_builder;
-}
-
-void ComputeMeshRouterBuilder::connect_to_downstream_router_over_noc(ComputeMeshRouterBuilder& other, uint32_t vc) {
-    auto connect_vc = [&](uint32_t vc_index,
-                          FabricDatamoverBuilderBase* downstream_builder,
-                          uint32_t logical_sender_channel_idx) {
-        log_debug(
-            tt::LogTest,
-            "Router at x={}, y={}, Direction={}, FabricNodeId={} :: Connecting VC{} to downstream router at x={}, "
-            "y={}, Direction={}",
-            get_noc_x(),
-            get_noc_y(),
-            get_eth_direction(),
-            local_node_,
-            vc_index,
-            downstream_builder->get_noc_x(),
-            downstream_builder->get_noc_y(),
-            downstream_builder->get_direction());
-
-        // auto send_chan = get_sender_channel(is_2D_routing, this->get_direction(), vc_index);
-        auto downstream_mapping = other.channel_mapping_.get_sender_mapping(vc_index, logical_sender_channel_idx);
-        uint32_t internal_channel_id = downstream_mapping.internal_sender_channel_id;
-
-        // Need to call the templated method with the correct derived type
-        // NOTE: erisc_builder_ is hardcoded here because there is currently no scenario where tensix forwards to tensix
-        //       however when that is enabled, this code should be updated to point to the src builder dynamically
-        if (auto* downstream_erisc_builder = dynamic_cast<FabricEriscDatamoverBuilder*>(downstream_builder)) {
-            erisc_builder_->setup_downstream_vc_connection(downstream_erisc_builder, vc_index, internal_channel_id);
-        } else if (auto* downstream_tensix_builder = dynamic_cast<FabricTensixDatamoverBuilder*>(downstream_builder)) {
-            erisc_builder_->setup_downstream_vc_connection(downstream_tensix_builder, vc_index, internal_channel_id);
-        }
-    };
-
-    auto get_downstream_builder_for_vc = [&](uint32_t vc_index,
-                                             uint32_t sender_channel_idx) -> FabricDatamoverBuilderBase* {
-        auto mapping = other.channel_mapping_.get_sender_mapping(vc_index, sender_channel_idx);
-
-        if (mapping.builder_type == BuilderType::TENSIX) {
-            TT_FATAL(
-                other.tensix_builder_.has_value(),
-                "Channel mapping requires TENSIX builder for VC{} channel {}, but tensix builder not present",
-                vc_index,
-                sender_channel_idx);
-            return &other.tensix_builder_.value();
-        } else {
-            return other.erisc_builder_.get();
-        }
-    };
-
-    const auto& fabric_context = tt::tt_metal::MetalContext::instance().get_control_plane().get_fabric_context();
-    const bool is_2D_routing = fabric_context.is_2D_routing_enabled();
-    if (vc == 0) {
-        TT_FATAL(
-            !erisc_builder_->build_in_worker_connection_mode,
-            "Tried to connect router to downstream in worker connection mode");
-
-        // Helper to get the downstream builder for a specific VC based on channel mapping
-        uint32_t sender_channel_idx = get_downstream_sender_channel(is_2D_routing, other.get_eth_direction());
-        // Connect VC0
-        connect_vc(0, get_downstream_builder_for_vc(0, sender_channel_idx), sender_channel_idx);
-        
-        // Record connection in registry if present
-        if (connection_registry_) {
-            // Determine receiver channel (for now, assume same as sender for INTRA_MESH)
-            auto downstream_mapping = other.channel_mapping_.get_sender_mapping(vc, sender_channel_idx);
-            
-            RouterConnectionRecord record{
-                .source_node = local_node_,
-                .source_direction = location_.direction,
-                .source_eth_chan = location_.eth_chan,
-                .source_vc = vc,
-                .source_sender_channel = sender_channel_idx,
-                .dest_node = other.local_node_,
-                .dest_direction = other.location_.direction,
-                .dest_eth_chan = other.location_.eth_chan,
-                .dest_vc = vc,
-                .dest_receiver_channel = downstream_mapping.internal_sender_channel_id,
-                .connection_type = ConnectionType::INTRA_MESH
-            };
-            
-            connection_registry_->record_connection(record);
-        }
-    }
 }
 
 SenderWorkerAdapterSpec ComputeMeshRouterBuilder::build_connection_to_fabric_channel(
@@ -434,10 +376,89 @@ void ComputeMeshRouterBuilder::connect_to_local_tensix_builder(FabricTensixDatam
     tensix_builder.append_relay_router_noc_xy(erisc_builder_->get_noc_x(), erisc_builder_->get_noc_y());
 }
 
+void ComputeMeshRouterBuilder::establish_connections_to_router(
+    ComputeMeshRouterBuilder& downstream_router, const std::function<bool(ConnectionType)>& connection_type_filter) {
+    // Iterate through all VCs and sender channels
+    uint32_t num_vcs = channel_mapping_.get_num_virtual_channels();
+
+    for (uint32_t vc = 0; vc < num_vcs; ++vc) {
+        uint32_t num_senders = channel_mapping_.get_num_sender_channels_for_vc(vc);
+
+        for (uint32_t sender_ch = 0; sender_ch < num_senders; ++sender_ch) {
+            auto targets = connection_mapping_.get_downstream_targets(vc, sender_ch);
+
+            for (const auto& target : targets) {
+                // Apply connection type filter
+                if (!connection_type_filter(target.type)) {
+                    continue;
+                }
+
+                // Compute the correct target sender channel based on router directions
+                // The target sender channel depends on THIS router's direction relative to the downstream router
+                const auto& fabric_context = tt::tt_metal::MetalContext::instance().get_control_plane().get_fabric_context();
+                const bool is_2D_routing = fabric_context.is_2D_routing_enabled();
+                uint32_t actual_target_sender_channel = get_downstream_sender_channel(is_2D_routing, downstream_router.get_eth_direction());
+
+                // Get target builder using the computed sender channel
+                auto* downstream_builder = downstream_router.get_builder_for_vc_channel(
+                    target.target_vc, actual_target_sender_channel);
+
+                // Get downstream internal channel mapping
+                auto downstream_mapping = downstream_router.channel_mapping_.get_sender_mapping(
+                    target.target_vc, actual_target_sender_channel);
+                uint32_t internal_channel_id = downstream_mapping.internal_sender_channel_id;
+
+                // Setup producer → consumer connection
+                if (auto* downstream_erisc_builder = dynamic_cast<FabricEriscDatamoverBuilder*>(downstream_builder)) {
+                    erisc_builder_->setup_downstream_vc_connection(
+                        downstream_erisc_builder, target.target_vc, internal_channel_id);
+                } else if (auto* downstream_tensix_builder = dynamic_cast<FabricTensixDatamoverBuilder*>(downstream_builder)) {
+                    erisc_builder_->setup_downstream_vc_connection(
+                        downstream_tensix_builder, target.target_vc, internal_channel_id);
+                }
+
+                // Record connection in registry if present
+                if (connection_registry_) {
+                    RouterConnectionRecord record{
+                        .source_node = local_node_,
+                        .source_direction = location_.direction,
+                        .source_eth_chan = location_.eth_chan,
+                        .source_vc = vc,
+                        .source_sender_channel = sender_ch,
+                        .dest_node = downstream_router.local_node_,
+                        .dest_direction = downstream_router.location_.direction,
+                        .dest_eth_chan = downstream_router.location_.eth_chan,
+                        .dest_vc = target.target_vc,
+                        .dest_receiver_channel = internal_channel_id,
+                        .connection_type = target.type
+                    };
+
+                    connection_registry_->record_connection(record);
+                }
+
+                log_debug(
+                    tt::LogTest,
+                    "Router at x={}, y={}, Direction={}, FabricNodeId={} :: Connecting VC{} sender_ch={} to downstream "
+                    "router at x={}, y={}, Direction={}, VC{}, internal_ch={}",
+                    get_noc_x(),
+                    get_noc_y(),
+                    get_eth_direction(),
+                    local_node_,
+                    vc,
+                    sender_ch,
+                    downstream_builder->get_noc_x(),
+                    downstream_builder->get_noc_y(),
+                    downstream_builder->get_direction(),
+                    target.target_vc,
+                    internal_channel_id);
+            }
+        }
+    }
+}
+
 void ComputeMeshRouterBuilder::configure_connection(
     FabricRouterBuilder& peer, uint32_t link_idx, uint32_t num_links, Topology topology, bool is_galaxy) {
     // Validate invariant: FabricBuilder guarantees all routers on a device are the same concrete type
-    // This is enforced by the factory method which determines router type based on mesh_id
     auto* peer_compute_ptr = dynamic_cast<ComputeMeshRouterBuilder*>(&peer);
     TT_FATAL(
         peer_compute_ptr != nullptr,
@@ -445,9 +466,15 @@ void ComputeMeshRouterBuilder::configure_connection(
         "This indicates a bug in FabricBuilder::create_routers()");
     auto& peer_compute = *peer_compute_ptr;
 
-    // Establish bidirectional VC0 connections
-    this->connect_to_downstream_router_over_noc(peer_compute, 0);
-    peer_compute.connect_to_downstream_router_over_noc(*this, 0);
+    TT_FATAL(
+        !erisc_builder_->build_in_worker_connection_mode,
+        "Tried to connect router to downstream in worker connection mode");
+
+    // Establish INTRA_MESH connections between the two routers (bidirectional)
+    auto intra_mesh_filter = [](ConnectionType type) { return type == ConnectionType::INTRA_MESH; };
+
+    establish_connections_to_router(peer_compute, intra_mesh_filter);
+    peer_compute.establish_connections_to_router(*this, intra_mesh_filter);
 
     // Configure NOC VC based on link index (must be same for both routers)
     auto edm_noc_vc = erisc_builder_->config.DEFAULT_NOC_VC + (link_idx % erisc_builder_->config.NUM_EDM_NOC_VCS);
@@ -461,6 +488,55 @@ void ComputeMeshRouterBuilder::configure_connection(
         .num_links = num_links,
     };
     core_placement::apply_core_placement_optimizations(cctx, *erisc_builder_, *peer_compute.erisc_builder_, link_idx);
+}
+
+void ComputeMeshRouterBuilder::configure_local_connections(
+    const std::map<RoutingDirection, ComputeMeshRouterBuilder*>& local_routers) {
+    // Establish local connections (MESH_TO_Z or Z_TO_MESH) to routers on same device
+    // We need to look up target routers by direction from the map
+    auto local_connection_filter = [](ConnectionType type) {
+        return type == ConnectionType::MESH_TO_Z || type == ConnectionType::Z_TO_MESH;
+    };
+
+    // Track which target routers we've already connected to (to avoid redundant calls)
+    std::set<RoutingDirection> connected_targets;
+
+    // Iterate through all sender channels to find local connection targets
+    uint32_t num_vcs = channel_mapping_.get_num_virtual_channels();
+
+    for (uint32_t vc = 0; vc < num_vcs; ++vc) {
+        uint32_t num_sender_channels = channel_mapping_.get_num_sender_channels_for_vc(vc);
+
+        for (uint32_t sender_ch = 0; sender_ch < num_sender_channels; ++sender_ch) {
+            auto targets = connection_mapping_.get_downstream_targets(vc, sender_ch);
+
+            for (const auto& target : targets) {
+                // Only handle local connections
+                if (!local_connection_filter(target.type)) {
+                    continue;
+                }
+
+                // Check if target direction exists (handles 2-4 router configs)
+                TT_FATAL(
+                    target.target_direction.has_value(),
+                    "Local connection target must have direction specified");
+
+                auto target_dir = target.target_direction.value();
+                if (local_routers.count(target_dir) == 0) {
+                    // Target router doesn't exist (e.g., edge device with only 2-3 mesh routers)
+                    // This is expected for Z routers on edge devices
+                    continue;
+                }
+
+                // Establish connections to this target router (if not already done)
+                if (connected_targets.find(target_dir) == connected_targets.end()) {
+                    auto* local_router = local_routers.at(target_dir);
+                    establish_connections_to_router(*local_router, local_connection_filter);
+                    connected_targets.insert(target_dir);
+                }
+            }
+        }
+    }
 }
 
 void ComputeMeshRouterBuilder::configure_for_dispatch() {
@@ -539,6 +615,15 @@ void ComputeMeshRouterBuilder::create_kernel(tt::tt_metal::Program& program, con
         eth_chan,
         get_eth_direction(),
         eth_chan == ctx.master_router_chan);
+}
+
+FabricDatamoverBuilderBase* ComputeMeshRouterBuilder::get_builder_for_vc_channel(uint32_t vc, uint32_t channel) const {
+    auto mapping = channel_mapping_.get_sender_mapping(vc, channel);
+    if (mapping.builder_type == BuilderType::TENSIX) {
+        TT_FATAL(tensix_builder_.has_value(), "Tensix builder required but not present");
+        return const_cast<FabricTensixDatamoverBuilder*>(&tensix_builder_.value());
+    }
+    return erisc_builder_.get();
 }
 
 }  // namespace tt::tt_fabric

--- a/tt_metal/fabric/compute_mesh_router_builder.cpp
+++ b/tt_metal/fabric/compute_mesh_router_builder.cpp
@@ -15,7 +15,6 @@
 #include "metal_soc_descriptor.h"
 #include "tt_metal.hpp"
 #include <tt_stl/assert.hpp>
-#include <algorithm>
 
 namespace tt::tt_fabric {
 

--- a/tt_metal/fabric/compute_mesh_router_builder.cpp
+++ b/tt_metal/fabric/compute_mesh_router_builder.cpp
@@ -173,7 +173,7 @@ std::unique_ptr<ComputeMeshRouterBuilder> ComputeMeshRouterBuilder::build(
 
     // Use unique_ptr constructor directly since ComputeMeshRouterBuilder constructor is private
     auto router_builder = std::unique_ptr<ComputeMeshRouterBuilder>(new ComputeMeshRouterBuilder(
-        local_node, location, std::move(edm_builder), std::move(tensix_builder_opt), std::move(channel_mapping), std::move(connection_mapping), connection_registry));
+        local_node, location, std::move(edm_builder), std::move(tensix_builder_opt), std::move(channel_mapping), std::move(connection_mapping), std::move(connection_registry)));
 
     // Setup the local relay kernel connection if in UDM mode
     if (fabric_tensix_extension_udm_mode && router_builder->has_tensix_builder()) {
@@ -424,12 +424,12 @@ void ComputeMeshRouterBuilder::establish_connections_to_router(
                         .source_direction = location_.direction,
                         .source_eth_chan = location_.eth_chan,
                         .source_vc = vc,
-                        .source_sender_channel = sender_ch,
+                        .source_receiver_channel = sender_ch,
                         .dest_node = downstream_router.local_node_,
                         .dest_direction = downstream_router.location_.direction,
                         .dest_eth_chan = downstream_router.location_.eth_chan,
                         .dest_vc = target.target_vc,
-                        .dest_receiver_channel = internal_channel_id,
+                        .dest_sender_channel = internal_channel_id,
                         .connection_type = target.type
                     };
 

--- a/tt_metal/fabric/compute_mesh_router_builder.hpp
+++ b/tt_metal/fabric/compute_mesh_router_builder.hpp
@@ -10,6 +10,7 @@
 #include "tt_metal/fabric/erisc_datamover_builder.hpp"
 #include "tt_metal/fabric/fabric_tensix_builder.hpp"
 #include "tt_metal/fabric/fabric_router_channel_mapping.hpp"
+#include "tt_metal/fabric/builder/connection_registry.hpp"
 
 namespace tt::tt_fabric {
 
@@ -32,13 +33,15 @@ public:
      * @param program The fabric program
      * @param local_node The local fabric node ID
      * @param location Router location (eth_chan, remote_node, direction, is_dispatch)
+     * @param connection_registry Optional registry to record connections for testing
      * @return A unique_ptr to the constructed ComputeMeshRouterBuilder
      */
     static std::unique_ptr<ComputeMeshRouterBuilder> build(
         tt::tt_metal::IDevice* device,
         tt::tt_metal::Program& program,
         FabricNodeId local_node,
-        const RouterLocation& location);
+        const RouterLocation& location,
+        std::shared_ptr<ConnectionRegistry> connection_registry = nullptr);
 
     // ============ FabricRouterBuilder Interface Implementation ============
 
@@ -91,7 +94,8 @@ private:
         const RouterLocation& location,
         std::unique_ptr<FabricEriscDatamoverBuilder> erisc_builder,
         std::optional<FabricTensixDatamoverBuilder> tensix_builder,
-        FabricRouterChannelMapping channel_mapping);
+        FabricRouterChannelMapping channel_mapping,
+        std::shared_ptr<ConnectionRegistry> connection_registry);
 
     /**
      * Compute which sender channels are traffic injection channels for a specific VC.
@@ -162,6 +166,7 @@ private:
     std::unique_ptr<FabricEriscDatamoverBuilder> erisc_builder_;
     std::optional<FabricTensixDatamoverBuilder> tensix_builder_;
     FabricRouterChannelMapping channel_mapping_;
+    std::shared_ptr<ConnectionRegistry> connection_registry_;
 };
 
 }  // namespace tt::tt_fabric

--- a/tt_metal/fabric/compute_mesh_router_builder.hpp
+++ b/tt_metal/fabric/compute_mesh_router_builder.hpp
@@ -57,8 +57,7 @@ public:
      *
      * @param local_routers Map of direction → router builder for all routers on this device
      */
-    void configure_local_connections(
-        const std::map<RoutingDirection, ComputeMeshRouterBuilder*>& local_routers);
+    void configure_local_connections(const std::map<RoutingDirection, FabricRouterBuilder*>& local_routers) override;
 
     void configure_for_dispatch() override;
 

--- a/tt_metal/fabric/compute_mesh_router_builder.hpp
+++ b/tt_metal/fabric/compute_mesh_router_builder.hpp
@@ -11,8 +11,12 @@
 #include "tt_metal/fabric/fabric_tensix_builder.hpp"
 #include "tt_metal/fabric/fabric_router_channel_mapping.hpp"
 #include "tt_metal/fabric/builder/connection_registry.hpp"
+#include "tt_metal/fabric/builder/router_connection_mapping.hpp"
 
 namespace tt::tt_fabric {
+
+// Forward declarations
+class FabricDatamoverBuilderBase;
 
 /**
  * ComputeMeshRouterBuilder
@@ -48,6 +52,14 @@ public:
     void configure_connection(
         FabricRouterBuilder& peer, uint32_t link_idx, uint32_t num_links, Topology topology, bool is_galaxy) override;
 
+    /**
+     * Configure local connections between routers on the same device (e.g., mesh↔Z)
+     *
+     * @param local_routers Map of direction → router builder for all routers on this device
+     */
+    void configure_local_connections(
+        const std::map<RoutingDirection, ComputeMeshRouterBuilder*>& local_routers);
+
     void configure_for_dispatch() override;
 
     void compile_ancillary_kernels(tt::tt_metal::Program& program) override;
@@ -72,6 +84,16 @@ public:
     size_t get_noc_y() const;
     size_t get_configured_risc_count() const;
 
+    /**
+     * Get the builder for a specific VC/channel combination
+     * Encapsulates channel mapping + builder resolution
+     *
+     * @param vc Virtual channel index
+     * @param channel Sender channel index within the VC
+     * @return Pointer to the appropriate builder (erisc or tensix)
+     */
+    FabricDatamoverBuilderBase* get_builder_for_vc_channel(uint32_t vc, uint32_t channel) const;
+
     // ============ Compute-Mesh Specific Accessors ============
 
     FabricEriscDatamoverBuilder& get_erisc_builder() { return *erisc_builder_; }
@@ -95,7 +117,19 @@ private:
         std::unique_ptr<FabricEriscDatamoverBuilder> erisc_builder,
         std::optional<FabricTensixDatamoverBuilder> tensix_builder,
         FabricRouterChannelMapping channel_mapping,
+        RouterConnectionMapping connection_mapping,
         std::shared_ptr<ConnectionRegistry> connection_registry);
+
+    /**
+     * Generic helper to establish connections from this router to a downstream router.
+     * Iterates through all VCs and sender channels, applying the provided connection type filter.
+     *
+     * @param downstream_router The target router to connect to
+     * @param connection_type_filter Function that returns true for connection types to establish
+     */
+    void establish_connections_to_router(
+        ComputeMeshRouterBuilder& downstream_router,
+        const std::function<bool(ConnectionType)>& connection_type_filter);
 
     /**
      * Compute which sender channels are traffic injection channels for a specific VC.
@@ -151,21 +185,11 @@ private:
      */
     void connect_to_local_tensix_builder(FabricTensixDatamoverBuilder& tensix_builder);
 
-    /**
-     * Connect the downstream router over noc or Ethernet. Iterates through all VCs and channels
-     * between the routers and connects them.
-     *
-     * Establishes one-way connection
-     *
-     * @param other The other router builder to connect to
-     * @param vc Virtual channel ID
-     */
-    void connect_to_downstream_router_over_noc(ComputeMeshRouterBuilder& other, uint32_t vc);
-
     // Compute-mesh specific state
     std::unique_ptr<FabricEriscDatamoverBuilder> erisc_builder_;
     std::optional<FabricTensixDatamoverBuilder> tensix_builder_;
     FabricRouterChannelMapping channel_mapping_;
+    RouterConnectionMapping connection_mapping_;
     std::shared_ptr<ConnectionRegistry> connection_registry_;
 };
 

--- a/tt_metal/fabric/erisc_datamover_builder.cpp
+++ b/tt_metal/fabric/erisc_datamover_builder.cpp
@@ -150,7 +150,7 @@ size_t get_num_riscv_cores() {
 bool should_risc_service_sender_channels(size_t risc_id) {
     auto arch = tt::tt_metal::MetalContext::instance().hal().get_arch();
     size_t num_riscv_cores = get_num_riscv_cores();
-    
+
     if (arch == tt::ARCH::BLACKHOLE && num_riscv_cores == 2) {
         return risc_id == 0;  // Only ERISC0 services senders
     }
@@ -163,7 +163,7 @@ bool should_risc_service_sender_channels(size_t risc_id) {
 bool should_risc_service_receiver_channels(size_t risc_id) {
     auto arch = tt::tt_metal::MetalContext::instance().hal().get_arch();
     size_t num_riscv_cores = get_num_riscv_cores();
-    
+
     if (arch == tt::ARCH::BLACKHOLE && num_riscv_cores == 2) {
         return risc_id == 1;  // Only ERISC1 services receivers
     }
@@ -195,7 +195,7 @@ FabricRiscConfig::FabricRiscConfig(uint32_t risc_id) :
     enable_context_switch_(true),
     enable_interrupts_(true) {
     auto arch = tt::tt_metal::MetalContext::instance().hal().get_arch();
-    
+
     configure_risc_settings(
         get_num_riscv_cores(),
         risc_id,
@@ -688,21 +688,20 @@ FabricEriscDatamoverBuilder::FabricEriscDatamoverBuilder(
     // Initialize per-RISC channel servicing flags
     const auto& sender_counts = actual_sender_channels_per_vc.value_or(this->config.num_used_sender_channels_per_vc);
     const auto& receiver_counts = actual_receiver_channels_per_vc.value_or(this->config.num_used_receiver_channels_per_vc);
-    
-    bool is_mux_mode = has_tensix_extension && 
-                       (tt::tt_metal::MetalContext::instance().get_fabric_tensix_config() == 
-                        tt::tt_fabric::FabricTensixConfig::MUX);
-    
+
+    bool is_mux_mode = has_tensix_extension && (tt::tt_metal::MetalContext::instance().get_fabric_tensix_config() ==
+                                                tt::tt_fabric::FabricTensixConfig::MUX);
+
     size_t num_riscv_cores = this->config.risc_configs.size();
     for (size_t risc_id = 0; risc_id < num_riscv_cores; ++risc_id) {
         this->is_sender_channel_serviced_[risc_id].fill(false);
         this->is_receiver_channel_serviced_[risc_id].fill(false);
-        
+
         if (is_mux_mode) {
             // MUX mode: Only worker channel serviced for senders
             uint32_t worker_channel = get_worker_connected_sender_channel();
             this->is_sender_channel_serviced_[risc_id][worker_channel] = true;
-            
+
             // All receiver channels serviced in MUX mode
             size_t receiver_offset = 0;
             for (size_t vc = 0; vc < builder_config::MAX_NUM_VCS; ++vc) {
@@ -716,7 +715,7 @@ FabricEriscDatamoverBuilder::FabricEriscDatamoverBuilder(
             // Normal mode: Enable channels based on per-VC counts AND this RISC's responsibility
             bool services_senders = should_risc_service_sender_channels(risc_id);
             bool services_receivers = should_risc_service_receiver_channels(risc_id);
-            
+
             if (services_senders) {
                 size_t sender_offset = 0;
                 for (size_t vc = 0; vc < builder_config::MAX_NUM_VCS; ++vc) {
@@ -727,7 +726,7 @@ FabricEriscDatamoverBuilder::FabricEriscDatamoverBuilder(
                     sender_offset += num_channels;
                 }
             }
-            
+
             if (services_receivers) {
                 size_t receiver_offset = 0;
                 for (size_t vc = 0; vc < builder_config::MAX_NUM_VCS; ++vc) {

--- a/tt_metal/fabric/erisc_datamover_builder.cpp
+++ b/tt_metal/fabric/erisc_datamover_builder.cpp
@@ -32,7 +32,6 @@
 #include "tt_metal/fabric/builder/multi_pool_channel_allocator.hpp"
 
 #include "impl/context/metal_context.hpp"
-#include "tt_metal/fabric/fabric_context.hpp"
 #include "core_coord.hpp"
 #include <tt-metalium/experimental/fabric/fabric_edm_types.hpp>
 #include <tt-logger/tt-logger.hpp>
@@ -97,29 +96,24 @@ bool is_fabric_two_erisc_enabled() {
     // Issue [#32419](https://github.com/tenstorrent/tt-metal/issues/32419)
     return arch_bh && !tensix_extensions_enabled && !single_erisc_dispatch;
 }
+
 void configure_risc_settings(
     size_t num_riscv_cores,
     size_t risc_id,
     tt::ARCH arch,
     bool& enable_handshake,
     bool& enable_context_switch,
-    bool& enable_interrupts,
-    std::array<bool, builder_config::num_max_sender_channels>& is_sender_channel_serviced,
-    std::array<bool, builder_config::num_max_receiver_channels>& is_receiver_channel_serviced) {
+    bool& enable_interrupts) {
     if (arch == tt::ARCH::WORMHOLE_B0) {
         // Wormhole: All RISC cores handle both sender and receiver channels
         enable_handshake = true;
         enable_context_switch = true;
         enable_interrupts = false;
-        is_sender_channel_serviced.fill(true);
-        is_receiver_channel_serviced.fill(true);
     } else if (arch == tt::ARCH::BLACKHOLE) {
         if (num_riscv_cores == 1) {
             enable_handshake = true;
             enable_context_switch = tt::tt_metal::MetalContext::instance().rtoptions().get_enable_2_erisc_mode();
             enable_interrupts = false;
-            is_sender_channel_serviced.fill(true);
-            is_receiver_channel_serviced.fill(true);
         } else {
             // Blackhole: Distribute sender/receiver across two RISC cores
             if (risc_id == 0) {
@@ -127,54 +121,17 @@ void configure_risc_settings(
                 enable_handshake = true;
                 enable_context_switch = true;
                 enable_interrupts = false;
-                is_sender_channel_serviced.fill(true);
-                is_receiver_channel_serviced.fill(false);
             } else if (risc_id == 1) {
                 // ERISC1: Handle receiver channels only
                 enable_handshake = false;
                 enable_context_switch = false;
                 enable_interrupts = false;
-                is_sender_channel_serviced.fill(false);
-                is_receiver_channel_serviced.fill(true);
             } else {
                 TT_THROW("Invalid RISC ID {} for BLACKHOLE architecture", risc_id);
             }
         }
     } else {
         TT_THROW("Unsupported architecture for RISC configuration: {}", enchantum::to_string(arch));
-    }
-}
-
-// for fabric with tensix extension, for linear/mesh/ring/torus topology, only one sender channel is used, and all
-// other sender channels are marked as skipped.
-// In Neighbor Exchange topology, only messages from local workers are serviced, and thus all other channels are
-// skipped.
-void update_sender_channel_servicing(
-    tt::tt_fabric::FabricTensixConfig fabric_tensix_config,
-    std::vector<FabricRiscConfig>& risc_configs,
-    Topology topology) {
-    TT_FATAL(
-        fabric_tensix_config == tt::tt_fabric::FabricTensixConfig::MUX || topology == Topology::NeighborExchange,
-        "ERROR: Sender channels should only be disabled when Tensixes are used in Mux mode or Neighbor Exchange "
-        "Topology is used");
-
-    // Determine which channel corresponds to the current direction
-    uint32_t target_channel = get_worker_connected_sender_channel();
-    auto arch = tt::tt_metal::MetalContext::instance().hal().get_arch();
-    if (arch == tt::ARCH::WORMHOLE_B0) {
-        for (auto& risc_config : risc_configs) {
-            risc_config.reset_sender_channel_serviced();
-            // Set the channel corresponding to the current direction
-            for (size_t i = 0; i < builder_config::num_max_sender_channels; i++) {
-                risc_config.set_sender_channel_serviced(i, i == target_channel);
-            }
-        }
-    } else if (arch == tt::ARCH::BLACKHOLE) {
-        risc_configs[0].reset_sender_channel_serviced();
-        // Set the channel corresponding to the current direction
-        for (size_t i = 0; i < builder_config::num_max_sender_channels; i++) {
-            risc_configs[0].set_sender_channel_serviced(i, i == target_channel);
-        }
     }
 }
 
@@ -185,6 +142,32 @@ size_t get_num_riscv_cores() {
         return nriscs;
     }
     return 1;
+}
+
+// Helper to determine if a RISC core should service sender channels
+// On Blackhole with 2 ERISCs: ERISC0 services senders, ERISC1 does not
+// On Wormhole or Blackhole with 1 ERISC: all RISCs service both
+bool should_risc_service_sender_channels(size_t risc_id) {
+    auto arch = tt::tt_metal::MetalContext::instance().hal().get_arch();
+    size_t num_riscv_cores = get_num_riscv_cores();
+    
+    if (arch == tt::ARCH::BLACKHOLE && num_riscv_cores == 2) {
+        return risc_id == 0;  // Only ERISC0 services senders
+    }
+    return true;  // Wormhole or single-ERISC mode: all service senders
+}
+
+// Helper to determine if a RISC core should service receiver channels
+// On Blackhole with 2 ERISCs: ERISC1 services receivers, ERISC0 does not
+// On Wormhole or Blackhole with 1 ERISC: all RISCs service both
+bool should_risc_service_receiver_channels(size_t risc_id) {
+    auto arch = tt::tt_metal::MetalContext::instance().hal().get_arch();
+    size_t num_riscv_cores = get_num_riscv_cores();
+    
+    if (arch == tt::ARCH::BLACKHOLE && num_riscv_cores == 2) {
+        return risc_id == 1;  // Only ERISC1 services receivers
+    }
+    return true;  // Wormhole or single-ERISC mode: all service receivers
 }
 
 
@@ -212,16 +195,14 @@ FabricRiscConfig::FabricRiscConfig(uint32_t risc_id) :
     enable_context_switch_(true),
     enable_interrupts_(true) {
     auto arch = tt::tt_metal::MetalContext::instance().hal().get_arch();
-
+    
     configure_risc_settings(
         get_num_riscv_cores(),
         risc_id,
         arch,
         this->enable_handshake_,
         this->enable_context_switch_,
-        this->enable_interrupts_,
-        this->is_sender_channel_serviced_,
-        this->is_receiver_channel_serviced_);
+        this->enable_interrupts_);
 }
 
 namespace {
@@ -236,7 +217,7 @@ bool requires_forced_assignment_to_noc1() {
 }  // anonymous namespace
 
 FabricEriscDatamoverConfig::FabricEriscDatamoverConfig(Topology topology) : topology(topology) {
-    const bool is_2D_routing = FabricContext::is_2D_topology(topology);
+    const bool is_2D_routing = is_2D_topology(topology);
     uint32_t num_sender_channels = builder_config::get_sender_channel_count(is_2D_routing);
     uint32_t num_downstream_edms = builder_config::get_downstream_edm_count(is_2D_routing);
     // Global
@@ -373,88 +354,30 @@ FabricEriscDatamoverConfig::FabricEriscDatamoverConfig(Topology topology) : topo
 }
 
 FabricEriscDatamoverConfig::FabricEriscDatamoverConfig(
-    std::size_t channel_buffer_size_bytes, Topology topology, FabricEriscDatamoverOptions options) :
+    std::size_t channel_buffer_size_bytes,
+    Topology topology,
+    FabricEriscDatamoverOptions options,
+    const std::array<std::size_t, builder_config::MAX_NUM_VCS>& sender_channels_per_vc,
+    const std::array<std::size_t, builder_config::MAX_NUM_VCS>& receiver_channels_per_vc) :
     FabricEriscDatamoverConfig(topology) {
-    // Only 1 sender channel in each router is used when Tensixes are used in Mux Mode, or the NeighborExchange topology
-    // is used.
-    if (options.fabric_tensix_config == tt::tt_fabric::FabricTensixConfig::MUX ||
-        topology == Topology::NeighborExchange) {
-        update_sender_channel_servicing(options.fabric_tensix_config, this->risc_configs, topology);
-    }
-
-    const bool is_2D_routing = FabricContext::is_2D_topology(topology);
 
     this->channel_buffer_size_bytes = channel_buffer_size_bytes;
 
-    // Determine if VC1 is needed based on mesh count
-    // VC1 is required for inter-mesh routing (when mesh_count > 1)
-    // Note: is_2D_routing already checks for Mesh/Torus topology, so no need to check topology again
-    // However, MUX mode always uses VC0 only (no VC1)
-    const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
-    auto user_mesh_ids = control_plane.get_mesh_graph().get_mesh_ids();
-    size_t mesh_count = user_mesh_ids.size();
-    bool needs_vc1 = is_2D_routing && (mesh_count > 1);
-
-    // MUX mode always uses VC0 only, disable VC1
-    if (options.fabric_tensix_config == tt::tt_fabric::FabricTensixConfig::MUX) {
-        needs_vc1 = false;
-        log_trace(tt::LogFabric, "MUX mode detected: Disabling VC1 (VC0 only)");
-    }
-
-    // Get per-VC channel counts based on routing type
-    auto sender_channels_per_vc = builder_config::get_sender_channel_count_per_vc(topology);
-    auto receiver_channels_per_vc = builder_config::get_receiver_channel_count_per_vc(topology);
-
-    // Distribute channels between VC0 and VC1 based on mesh count
-    if (needs_vc1) {
-        // Multi-mesh: Use both VC0 and VC1
-        this->num_used_sender_channels_per_vc[0] = sender_channels_per_vc[0];  // VC0 (intra-mesh)
-        this->num_used_sender_channels_per_vc[1] = sender_channels_per_vc[1];  // VC1 (inter-mesh)
-
-        this->num_used_receiver_channels_per_vc[0] = receiver_channels_per_vc[0];  // VC0 receiver
-        this->num_used_receiver_channels_per_vc[1] = receiver_channels_per_vc[1];  // VC1 receiver
-
-        log_debug(tt::LogFabric, "Multi-mesh topology (mesh_count={}): Allocating VC0 and VC1 channels", mesh_count);
+    // Set channel counts from parameters
+    for (size_t vc = 0; vc < builder_config::MAX_NUM_VCS; ++vc) {
+        this->num_used_sender_channels_per_vc[vc] = sender_channels_per_vc[vc];
+        this->num_used_receiver_channels_per_vc[vc] = receiver_channels_per_vc[vc];
         log_debug(
             tt::LogFabric,
-            "  VC0: {} senders, {} receivers (intra-mesh)",
-            this->num_used_sender_channels_per_vc[0],
-            this->num_used_receiver_channels_per_vc[0]);
-        log_debug(
-            tt::LogFabric,
-            "  VC1: {} senders, {} receivers (inter-mesh)",
-            this->num_used_sender_channels_per_vc[1],
-            this->num_used_receiver_channels_per_vc[1]);
-    } else {
-        // Single mesh or 1D: All channels in VC0, no VC1
-        this->num_used_sender_channels_per_vc[0] = sender_channels_per_vc[0];
-        this->num_used_sender_channels_per_vc[1] = 0;
-
-        this->num_used_receiver_channels_per_vc[0] = receiver_channels_per_vc[0];
-        this->num_used_receiver_channels_per_vc[1] = 0;
-
-        log_debug(tt::LogFabric, "Single-mesh or 1D topology (mesh_count={}): All channels in VC0", mesh_count);
-        log_debug(
-            tt::LogFabric,
-            "  VC0: {} senders, {} receivers",
-            this->num_used_sender_channels_per_vc[0],
-            this->num_used_receiver_channels_per_vc[0]);
+            "  VC{}: {} senders, {} receivers",
+            vc,
+            this->num_used_sender_channels_per_vc[vc],
+            this->num_used_receiver_channels_per_vc[vc]);
     }
 
     // Set total counts for backward compatibility
-    this->num_used_sender_channels =
-        this->num_used_sender_channels_per_vc[0] + this->num_used_sender_channels_per_vc[1];
-    this->num_used_receiver_channels =
-        this->num_used_receiver_channels_per_vc[0] + this->num_used_receiver_channels_per_vc[1];
-
-    // Update is_sender_channel_serviced_ to mark unused channels as false
-    // Used channels (0 to num_used_sender_channels - 1) are set by update_sender_channel_servicing in MUX mode,
-    // and by configure_risc_settings in non-MUX modes. Unused channels (num_used_sender_channels to num_max_sender_channels - 1) should be false.
-    for (auto& risc_config : this->risc_configs) {
-        for (size_t i = this->num_used_sender_channels; i < builder_config::num_max_sender_channels; i++) {
-            risc_config.set_sender_channel_serviced(i, false);
-        }
-    }
+    this->num_used_sender_channels = std::accumulate(this->num_used_sender_channels_per_vc.begin(), this->num_used_sender_channels_per_vc.end(), 0);
+    this->num_used_receiver_channels = std::accumulate(this->num_used_receiver_channels_per_vc.begin(), this->num_used_receiver_channels_per_vc.end(), 0);
 
     // num_fwd_paths = total sender channels - 1 (worker channel)
     this->num_fwd_paths = this->num_used_sender_channels - 1;
@@ -725,7 +648,9 @@ FabricEriscDatamoverBuilder::FabricEriscDatamoverBuilder(
     eth_chan_directions direction,
     std::vector<bool>&& sender_channel_injection_flags,
     bool build_in_worker_connection_mode,
-    bool has_tensix_extension) :
+    bool has_tensix_extension,
+    std::optional<std::array<std::size_t, builder_config::MAX_NUM_VCS>> actual_sender_channels_per_vc,
+    std::optional<std::array<std::size_t, builder_config::MAX_NUM_VCS>> actual_receiver_channels_per_vc) :
     FabricDatamoverBuilderBase(my_noc_x, my_noc_y, direction),
     my_eth_core_logical(my_eth_core_logical),
     my_eth_channel(my_eth_core_logical.y),
@@ -759,6 +684,62 @@ FabricEriscDatamoverBuilder::FabricEriscDatamoverBuilder(
         "Internal error: injection_flags vector size {} does not match num_used_sender_channels {}",
         sender_channel_is_traffic_injection_channel_array.size(),
         config.num_used_sender_channels);
+
+    // Initialize per-RISC channel servicing flags
+    const auto& sender_counts = actual_sender_channels_per_vc.value_or(this->config.num_used_sender_channels_per_vc);
+    const auto& receiver_counts = actual_receiver_channels_per_vc.value_or(this->config.num_used_receiver_channels_per_vc);
+    
+    bool is_mux_mode = has_tensix_extension && 
+                       (tt::tt_metal::MetalContext::instance().get_fabric_tensix_config() == 
+                        tt::tt_fabric::FabricTensixConfig::MUX);
+    
+    size_t num_riscv_cores = this->config.risc_configs.size();
+    for (size_t risc_id = 0; risc_id < num_riscv_cores; ++risc_id) {
+        this->is_sender_channel_serviced_[risc_id].fill(false);
+        this->is_receiver_channel_serviced_[risc_id].fill(false);
+        
+        if (is_mux_mode) {
+            // MUX mode: Only worker channel serviced for senders
+            uint32_t worker_channel = get_worker_connected_sender_channel();
+            this->is_sender_channel_serviced_[risc_id][worker_channel] = true;
+            
+            // All receiver channels serviced in MUX mode
+            size_t receiver_offset = 0;
+            for (size_t vc = 0; vc < builder_config::MAX_NUM_VCS; ++vc) {
+                size_t num_channels = receiver_counts[vc];
+                for (size_t i = 0; i < num_channels; ++i) {
+                    this->is_receiver_channel_serviced_[risc_id][receiver_offset + i] = true;
+                }
+                receiver_offset += num_channels;
+            }
+        } else {
+            // Normal mode: Enable channels based on per-VC counts AND this RISC's responsibility
+            bool services_senders = should_risc_service_sender_channels(risc_id);
+            bool services_receivers = should_risc_service_receiver_channels(risc_id);
+            
+            if (services_senders) {
+                size_t sender_offset = 0;
+                for (size_t vc = 0; vc < builder_config::MAX_NUM_VCS; ++vc) {
+                    size_t num_channels = sender_counts[vc];
+                    for (size_t i = 0; i < num_channels; ++i) {
+                        this->is_sender_channel_serviced_[risc_id][sender_offset + i] = true;
+                    }
+                    sender_offset += num_channels;
+                }
+            }
+            
+            if (services_receivers) {
+                size_t receiver_offset = 0;
+                for (size_t vc = 0; vc < builder_config::MAX_NUM_VCS; ++vc) {
+                    size_t num_channels = receiver_counts[vc];
+                    for (size_t i = 0; i < num_channels; ++i) {
+                        this->is_receiver_channel_serviced_[risc_id][receiver_offset + i] = true;
+                    }
+                    receiver_offset += num_channels;
+                }
+            }
+        }
+    }
 
     std::fill(
         sender_channel_connection_liveness_check_disable_array.begin(),
@@ -910,7 +891,7 @@ std::vector<uint32_t> FabricEriscDatamoverBuilder::get_compile_time_args(uint32_
 
     const auto& fabric_context = control_plane.get_fabric_context();
     const auto topology = fabric_context.get_fabric_topology();
-    const bool is_2D_routing = FabricContext::is_2D_topology(topology);
+    const bool is_2D_routing = is_2D_topology(topology);
 
     auto sender_channel_to_check = get_worker_connected_sender_channel();
 
@@ -1009,16 +990,16 @@ std::vector<uint32_t> FabricEriscDatamoverBuilder::get_compile_time_args(uint32_
         config.notify_worker_of_read_counter_update_src_address,
         0x7a9b3c4d,  // DELETEME Issue #33360 special tag marker to catch incorrect ct args
 
-        config.risc_configs[risc_id].is_sender_channel_serviced(0),
-        config.risc_configs[risc_id].is_sender_channel_serviced(1),
-        config.risc_configs[risc_id].is_sender_channel_serviced(2),
-        config.risc_configs[risc_id].is_sender_channel_serviced(3),
-        config.risc_configs[risc_id].is_sender_channel_serviced(4),
-        config.risc_configs[risc_id].is_sender_channel_serviced(5),
-        config.risc_configs[risc_id].is_sender_channel_serviced(6),
-        config.risc_configs[risc_id].is_sender_channel_serviced(7),
-        config.risc_configs[risc_id].is_receiver_channel_serviced(0),
-        config.risc_configs[risc_id].is_receiver_channel_serviced(1),
+        this->is_sender_channel_serviced_[risc_id][0],
+        this->is_sender_channel_serviced_[risc_id][1],
+        this->is_sender_channel_serviced_[risc_id][2],
+        this->is_sender_channel_serviced_[risc_id][3],
+        this->is_sender_channel_serviced_[risc_id][4],
+        this->is_sender_channel_serviced_[risc_id][5],
+        this->is_sender_channel_serviced_[risc_id][6],
+        this->is_sender_channel_serviced_[risc_id][7],
+        this->is_receiver_channel_serviced_[risc_id][0],
+        this->is_receiver_channel_serviced_[risc_id][1],
         config.risc_configs[risc_id].enable_handshake(),
         config.risc_configs[risc_id].enable_context_switch(),
         config.risc_configs[risc_id].enable_interrupts(),
@@ -1214,7 +1195,9 @@ FabricEriscDatamoverBuilder FabricEriscDatamoverBuilder::build(
     std::vector<bool>&& sender_channel_injection_flags,
     bool build_in_worker_connection_mode,
     eth_chan_directions direction,
-    bool has_tensix_extension) {
+    bool has_tensix_extension,
+    std::optional<std::array<std::size_t, builder_config::MAX_NUM_VCS>> actual_sender_channels_per_vc,
+    std::optional<std::array<std::size_t, builder_config::MAX_NUM_VCS>> actual_receiver_channels_per_vc) {
     const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
     log_debug(
         tt::LogFabric,
@@ -1235,7 +1218,9 @@ FabricEriscDatamoverBuilder FabricEriscDatamoverBuilder::build(
         std::move(sender_channel_injection_flags),
         build_in_worker_connection_mode,
         direction,
-        has_tensix_extension);
+        has_tensix_extension,
+        actual_sender_channels_per_vc,
+        actual_receiver_channels_per_vc);
 }
 
 FabricEriscDatamoverBuilder FabricEriscDatamoverBuilder::build(
@@ -1248,7 +1233,9 @@ FabricEriscDatamoverBuilder FabricEriscDatamoverBuilder::build(
     std::vector<bool>&& sender_channel_injection_flags,
     bool build_in_worker_connection_mode,
     eth_chan_directions direction,
-    bool has_tensix_extension) {
+    bool has_tensix_extension,
+    std::optional<std::array<std::size_t, builder_config::MAX_NUM_VCS>> actual_sender_channels_per_vc,
+    std::optional<std::array<std::size_t, builder_config::MAX_NUM_VCS>> actual_receiver_channels_per_vc) {
     std::array<size_t, builder_config::num_max_sender_channels> sender_channels_buffer_index_semaphore_id{};
     std::array<size_t, builder_config::num_max_sender_channels> sender_channels_flow_control_semaphore_id{};
     std::array<size_t, builder_config::num_max_sender_channels> sender_channels_connection_semaphore_id{};
@@ -1334,7 +1321,9 @@ FabricEriscDatamoverBuilder FabricEriscDatamoverBuilder::build(
         direction,
         std::move(sender_channel_injection_flags),
         build_in_worker_connection_mode,
-        has_tensix_extension);
+        has_tensix_extension,
+        actual_sender_channels_per_vc,
+        actual_receiver_channels_per_vc);
 }
 
 SenderWorkerAdapterSpec FabricEriscDatamoverBuilder::build_connection_to_fabric_channel(uint32_t ds_edm) const {
@@ -1439,7 +1428,7 @@ void FabricEriscDatamoverBuilder::setup_downstream_vc_connection(
     TT_FATAL(static_channel_allocator != nullptr, "Channel allocator must be a FabricStaticSizedChannelsAllocator.");
     auto* adapter_ptr = this->receiver_channel_to_downstream_adapter.get();
     TT_FATAL(adapter_ptr != nullptr, "Adapter is not set. Failed to build TT-Fabric router. Internal error.");
-    adapter_ptr->add_downstream_connection(adapter_spec, vc_idx, ds_dir, CoreCoord(ds_noc_x, ds_noc_y), is_2D_routing);
+    adapter_ptr->add_downstream_connection(adapter_spec, vc_idx, channel_id, ds_dir, CoreCoord(ds_noc_x, ds_noc_y), is_2D_routing);
 }
 
 size_t FabricEriscDatamoverBuilder::get_configured_risc_count() const { return this->config.risc_configs.size(); }

--- a/tt_metal/fabric/erisc_datamover_builder.cpp
+++ b/tt_metal/fabric/erisc_datamover_builder.cpp
@@ -376,8 +376,8 @@ FabricEriscDatamoverConfig::FabricEriscDatamoverConfig(
     }
 
     // Set total counts for backward compatibility
-    this->num_used_sender_channels = std::accumulate(this->num_used_sender_channels_per_vc.begin(), this->num_used_sender_channels_per_vc.end(), 0);
-    this->num_used_receiver_channels = std::accumulate(this->num_used_receiver_channels_per_vc.begin(), this->num_used_receiver_channels_per_vc.end(), 0);
+    this->num_used_sender_channels = std::accumulate(this->num_used_sender_channels_per_vc.begin(), this->num_used_sender_channels_per_vc.end(), size_t{0});
+    this->num_used_receiver_channels = std::accumulate(this->num_used_receiver_channels_per_vc.begin(), this->num_used_receiver_channels_per_vc.end(), size_t{0});
 
     // num_fwd_paths = total sender channels - 1 (worker channel)
     this->num_fwd_paths = this->num_used_sender_channels - 1;

--- a/tt_metal/fabric/erisc_datamover_builder.cpp
+++ b/tt_metal/fabric/erisc_datamover_builder.cpp
@@ -150,7 +150,7 @@ size_t get_num_riscv_cores() {
 bool should_risc_service_sender_channels(size_t risc_id) {
     auto arch = tt::tt_metal::MetalContext::instance().hal().get_arch();
     size_t num_riscv_cores = get_num_riscv_cores();
-    
+
     if (arch == tt::ARCH::BLACKHOLE && num_riscv_cores == 2) {
         return risc_id == 0;  // Only ERISC0 services senders
     }
@@ -163,7 +163,7 @@ bool should_risc_service_sender_channels(size_t risc_id) {
 bool should_risc_service_receiver_channels(size_t risc_id) {
     auto arch = tt::tt_metal::MetalContext::instance().hal().get_arch();
     size_t num_riscv_cores = get_num_riscv_cores();
-    
+
     if (arch == tt::ARCH::BLACKHOLE && num_riscv_cores == 2) {
         return risc_id == 1;  // Only ERISC1 services receivers
     }
@@ -195,7 +195,7 @@ FabricRiscConfig::FabricRiscConfig(uint32_t risc_id) :
     enable_context_switch_(true),
     enable_interrupts_(true) {
     auto arch = tt::tt_metal::MetalContext::instance().hal().get_arch();
-    
+
     configure_risc_settings(
         get_num_riscv_cores(),
         risc_id,
@@ -688,21 +688,21 @@ FabricEriscDatamoverBuilder::FabricEriscDatamoverBuilder(
     // Initialize per-RISC channel servicing flags
     const auto& sender_counts = actual_sender_channels_per_vc.value_or(this->config.num_used_sender_channels_per_vc);
     const auto& receiver_counts = actual_receiver_channels_per_vc.value_or(this->config.num_used_receiver_channels_per_vc);
-    
-    bool is_mux_mode = has_tensix_extension && 
-                       (tt::tt_metal::MetalContext::instance().get_fabric_tensix_config() == 
+
+    bool is_mux_mode = has_tensix_extension &&
+                       (tt::tt_metal::MetalContext::instance().get_fabric_tensix_config() ==
                         tt::tt_fabric::FabricTensixConfig::MUX);
-    
+
     size_t num_riscv_cores = this->config.risc_configs.size();
     for (size_t risc_id = 0; risc_id < num_riscv_cores; ++risc_id) {
         this->is_sender_channel_serviced_[risc_id].fill(false);
         this->is_receiver_channel_serviced_[risc_id].fill(false);
-        
+
         if (is_mux_mode) {
             // MUX mode: Only worker channel serviced for senders
             uint32_t worker_channel = get_worker_connected_sender_channel();
             this->is_sender_channel_serviced_[risc_id][worker_channel] = true;
-            
+
             // All receiver channels serviced in MUX mode
             size_t receiver_offset = 0;
             for (size_t vc = 0; vc < builder_config::MAX_NUM_VCS; ++vc) {
@@ -716,7 +716,7 @@ FabricEriscDatamoverBuilder::FabricEriscDatamoverBuilder(
             // Normal mode: Enable channels based on per-VC counts AND this RISC's responsibility
             bool services_senders = should_risc_service_sender_channels(risc_id);
             bool services_receivers = should_risc_service_receiver_channels(risc_id);
-            
+
             if (services_senders) {
                 size_t sender_offset = 0;
                 for (size_t vc = 0; vc < builder_config::MAX_NUM_VCS; ++vc) {
@@ -727,7 +727,7 @@ FabricEriscDatamoverBuilder::FabricEriscDatamoverBuilder(
                     sender_offset += num_channels;
                 }
             }
-            
+
             if (services_receivers) {
                 size_t receiver_offset = 0;
                 for (size_t vc = 0; vc < builder_config::MAX_NUM_VCS; ++vc) {

--- a/tt_metal/fabric/erisc_datamover_builder.cpp
+++ b/tt_metal/fabric/erisc_datamover_builder.cpp
@@ -150,7 +150,7 @@ size_t get_num_riscv_cores() {
 bool should_risc_service_sender_channels(size_t risc_id) {
     auto arch = tt::tt_metal::MetalContext::instance().hal().get_arch();
     size_t num_riscv_cores = get_num_riscv_cores();
-
+    
     if (arch == tt::ARCH::BLACKHOLE && num_riscv_cores == 2) {
         return risc_id == 0;  // Only ERISC0 services senders
     }
@@ -163,7 +163,7 @@ bool should_risc_service_sender_channels(size_t risc_id) {
 bool should_risc_service_receiver_channels(size_t risc_id) {
     auto arch = tt::tt_metal::MetalContext::instance().hal().get_arch();
     size_t num_riscv_cores = get_num_riscv_cores();
-
+    
     if (arch == tt::ARCH::BLACKHOLE && num_riscv_cores == 2) {
         return risc_id == 1;  // Only ERISC1 services receivers
     }
@@ -195,7 +195,7 @@ FabricRiscConfig::FabricRiscConfig(uint32_t risc_id) :
     enable_context_switch_(true),
     enable_interrupts_(true) {
     auto arch = tt::tt_metal::MetalContext::instance().hal().get_arch();
-
+    
     configure_risc_settings(
         get_num_riscv_cores(),
         risc_id,
@@ -688,21 +688,21 @@ FabricEriscDatamoverBuilder::FabricEriscDatamoverBuilder(
     // Initialize per-RISC channel servicing flags
     const auto& sender_counts = actual_sender_channels_per_vc.value_or(this->config.num_used_sender_channels_per_vc);
     const auto& receiver_counts = actual_receiver_channels_per_vc.value_or(this->config.num_used_receiver_channels_per_vc);
-
-    bool is_mux_mode = has_tensix_extension &&
-                       (tt::tt_metal::MetalContext::instance().get_fabric_tensix_config() ==
+    
+    bool is_mux_mode = has_tensix_extension && 
+                       (tt::tt_metal::MetalContext::instance().get_fabric_tensix_config() == 
                         tt::tt_fabric::FabricTensixConfig::MUX);
-
+    
     size_t num_riscv_cores = this->config.risc_configs.size();
     for (size_t risc_id = 0; risc_id < num_riscv_cores; ++risc_id) {
         this->is_sender_channel_serviced_[risc_id].fill(false);
         this->is_receiver_channel_serviced_[risc_id].fill(false);
-
+        
         if (is_mux_mode) {
             // MUX mode: Only worker channel serviced for senders
             uint32_t worker_channel = get_worker_connected_sender_channel();
             this->is_sender_channel_serviced_[risc_id][worker_channel] = true;
-
+            
             // All receiver channels serviced in MUX mode
             size_t receiver_offset = 0;
             for (size_t vc = 0; vc < builder_config::MAX_NUM_VCS; ++vc) {
@@ -716,7 +716,7 @@ FabricEriscDatamoverBuilder::FabricEriscDatamoverBuilder(
             // Normal mode: Enable channels based on per-VC counts AND this RISC's responsibility
             bool services_senders = should_risc_service_sender_channels(risc_id);
             bool services_receivers = should_risc_service_receiver_channels(risc_id);
-
+            
             if (services_senders) {
                 size_t sender_offset = 0;
                 for (size_t vc = 0; vc < builder_config::MAX_NUM_VCS; ++vc) {
@@ -727,7 +727,7 @@ FabricEriscDatamoverBuilder::FabricEriscDatamoverBuilder(
                     sender_offset += num_channels;
                 }
             }
-
+            
             if (services_receivers) {
                 size_t receiver_offset = 0;
                 for (size_t vc = 0; vc < builder_config::MAX_NUM_VCS; ++vc) {

--- a/tt_metal/fabric/fabric_builder.hpp
+++ b/tt_metal/fabric/fabric_builder.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <map>
 #include <memory>
 #include <unordered_map>
 #include <unordered_set>
@@ -101,7 +102,9 @@ private:
      *
      * Called by connect_routers() after inter-device connections are established.
      */
-    void configure_local_connections();
+    void configure_local_connections(
+        const std::map<FabricRouterBuilder*, std::map<RoutingDirection, FabricRouterBuilder*>>&
+            routers_by_direction_map);
 
     /**
      * Compile kernels for directions that have no router/eth channel.

--- a/tt_metal/fabric/fabric_builder.hpp
+++ b/tt_metal/fabric/fabric_builder.hpp
@@ -91,6 +91,19 @@ private:
     std::vector<RouterConnectionPair> get_router_connection_pairs() const;
 
     /**
+     * Configure local connections between routers on this device.
+     *
+     * Generic connection establishment: iterates through all routers and
+     * establishes connections to local targets based on their connection mappings.
+     * Each router's mapping determines which local routers to connect to.
+     *
+     * Handles variable router configurations (e.g., 2-4 mesh routers on edge devices).
+     *
+     * Called by connect_routers() after inter-device connections are established.
+     */
+    void configure_local_connections();
+
+    /**
      * Compile kernels for directions that have no router/eth channel.
      *
      * In UDM mode, edge devices (e.g., corner of a mesh) don't have neighbors

--- a/tt_metal/fabric/fabric_builder_context.cpp
+++ b/tt_metal/fabric/fabric_builder_context.cpp
@@ -6,7 +6,6 @@
 #include "tt_metal/fabric/fabric_context.hpp"
 #include "tt_metal/fabric/fabric_router_channel_mapping.hpp"
 #include "impl/context/metal_context.hpp"
-#include "tt_metal/fabric/fabric_builder_context.hpp"
 #include <tt-metalium/experimental/fabric/control_plane.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt_stl/assert.hpp>

--- a/tt_metal/fabric/fabric_builder_context.hpp
+++ b/tt_metal/fabric/fabric_builder_context.hpp
@@ -168,7 +168,7 @@ private:
 
     const FabricContext& fabric_context_;
 
-    IntermeshVCConfig intermesh_vc_config_{};
+    IntermeshVCConfig intermesh_vc_config_;
 
     // Computed max channel counts based on actual router types in this fabric
     std::array<std::size_t, builder_config::MAX_NUM_VCS> max_sender_channels_per_vc_{};

--- a/tt_metal/fabric/fabric_builder_context.hpp
+++ b/tt_metal/fabric/fabric_builder_context.hpp
@@ -52,6 +52,14 @@ public:
         FabricTensixConfig fabric_tensix_config = FabricTensixConfig::DISABLED,
         eth_chan_directions direction = eth_chan_directions::EAST) const;
 
+    // ============ Max Channel Counts ============
+    const std::array<std::size_t, builder_config::MAX_NUM_VCS>& get_max_sender_channels_per_vc() const {
+        return max_sender_channels_per_vc_;
+    }
+    const std::array<std::size_t, builder_config::MAX_NUM_VCS>& get_max_receiver_channels_per_vc() const {
+        return max_receiver_channels_per_vc_;
+    }
+
     // ============ Tensix Config ============
     void initialize_tensix_config();
     FabricTensixDatamoverConfig& get_tensix_config() const;
@@ -75,6 +83,10 @@ private:
 
     const FabricContext& fabric_context_;
 
+    // Computed max channel counts based on actual router types in this fabric
+    std::array<std::size_t, builder_config::MAX_NUM_VCS> max_sender_channels_per_vc_;
+    std::array<std::size_t, builder_config::MAX_NUM_VCS> max_receiver_channels_per_vc_;
+
     // Pre-built EDM config templates
     std::unique_ptr<FabricEriscDatamoverConfig> router_config_;
     // Router config with mux extension for each direction (E, W, N, S)
@@ -94,6 +106,9 @@ private:
     std::unique_ptr<FabricEriscDatamoverConfig> create_edm_config(
         FabricTensixConfig fabric_tensix_config = FabricTensixConfig::DISABLED,
         eth_chan_directions direction = eth_chan_directions::EAST) const;
+
+    // Helper to compute max channel counts for this fabric instance
+    void compute_max_channel_counts();
 };
 
 }  // namespace tt::tt_fabric

--- a/tt_metal/fabric/fabric_builder_context.hpp
+++ b/tt_metal/fabric/fabric_builder_context.hpp
@@ -84,8 +84,8 @@ private:
     const FabricContext& fabric_context_;
 
     // Computed max channel counts based on actual router types in this fabric
-    std::array<std::size_t, builder_config::MAX_NUM_VCS> max_sender_channels_per_vc_;
-    std::array<std::size_t, builder_config::MAX_NUM_VCS> max_receiver_channels_per_vc_;
+    std::array<std::size_t, builder_config::MAX_NUM_VCS> max_sender_channels_per_vc_{};
+    std::array<std::size_t, builder_config::MAX_NUM_VCS> max_receiver_channels_per_vc_{};
 
     // Pre-built EDM config templates
     std::unique_ptr<FabricEriscDatamoverConfig> router_config_;

--- a/tt_metal/fabric/fabric_builder_context.hpp
+++ b/tt_metal/fabric/fabric_builder_context.hpp
@@ -19,6 +19,82 @@ namespace tt::tt_fabric {
 
 class FabricContext;
 
+
+/**
+ * IntermeshVCMode - Defines intermesh VC requirements
+ */
+ enum class IntermeshVCMode : uint8_t {
+    DISABLED,                      // No intermesh VC (single mesh or no intermesh connectivity)
+    EDGE_ONLY,                     // Intermesh VC on edge nodes only (traffic sinks at mesh boundary)
+    FULL_MESH,                     // Intermesh VC throughout mesh (traffic can traverse nodes within mesh)
+    FULL_MESH_WITH_PASS_THROUGH    // Intermesh VC with inter-mesh pass-through (e.g., A→B→C routing)
+};
+
+/**
+ * IntermeshRouterType - Distinguishes types of intermesh routers
+ *
+ * Different intermesh router types have different channel requirements:
+ * - Z_INTERMESH: Vertical device stacking, requires 4 VC1 sender channels (3 mesh + Z)
+ * - XY_INTERMESH: Horizontal inter-mesh, requires 3 VC1 sender channels (mesh only)
+ */
+enum class IntermeshRouterType : uint8_t {
+    NONE,          // No intermesh connectivity
+    Z_INTERMESH,   // Z routers (vertical device stacking)
+    XY_INTERMESH   // XY intermesh routers (horizontal inter-mesh)
+};
+
+/**
+ * IntermeshVCConfig - System-level intermesh VC configuration
+ *
+ * Determined during FabricContext initialization based on:
+ * - Number of meshes in MeshGraph
+ * - Intermesh connectivity topology
+ * - Whether traffic traverses within meshes or passes through intermediate meshes
+ *
+ * Modes:
+ * - DISABLED: No intermesh connectivity
+ * - EDGE_ONLY: VC1 on edge nodes only, traffic sinks at mesh boundary
+ * - FULL_MESH: VC1 throughout mesh, traffic can traverse nodes within target mesh
+ * - FULL_MESH_WITH_PASS_THROUGH: VC1 with inter-mesh routing (A→B→C)
+ */
+struct IntermeshVCConfig {
+    IntermeshVCMode mode = IntermeshVCMode::DISABLED;
+    IntermeshRouterType router_type = IntermeshRouterType::NONE;  // Type of intermesh router (Z vs XY)
+    bool requires_vc1 = false;                      // True if VC1 needed for intermesh
+    bool requires_vc1_full_mesh = false;            // True if VC1 needed throughout mesh (not just edges)
+    bool requires_vc1_mesh_pass_through = false;    // True if VC1 must support inter-mesh pass-through
+
+    IntermeshVCConfig() = default;
+
+    static IntermeshVCConfig disabled() {
+        return IntermeshVCConfig();
+    }
+
+    static IntermeshVCConfig edge_only() {
+        IntermeshVCConfig config;
+        config.mode = IntermeshVCMode::EDGE_ONLY;
+        config.requires_vc1 = true;
+        return config;
+    }
+
+    static IntermeshVCConfig full_mesh() {
+        IntermeshVCConfig config;
+        config.mode = IntermeshVCMode::FULL_MESH;
+        config.requires_vc1 = true;
+        config.requires_vc1_full_mesh = true;
+        return config;
+    }
+
+    static IntermeshVCConfig full_mesh_with_pass_through() {
+        IntermeshVCConfig config;
+        config.mode = IntermeshVCMode::FULL_MESH_WITH_PASS_THROUGH;
+        config.requires_vc1 = true;
+        config.requires_vc1_full_mesh = true;
+        config.requires_vc1_mesh_pass_through = true;
+        return config;
+    }
+};
+
 /**
  * FabricBuilderContext
  *
@@ -78,10 +154,21 @@ public:
     std::optional<std::pair<uint32_t, EDMStatus>> get_fabric_router_ready_address_and_signal() const;
     std::pair<uint32_t, uint32_t> get_fabric_router_termination_address_and_signal() const;
 
+    // ============ Intermesh VC Configuration ============
+    const IntermeshVCConfig& get_intermesh_vc_config() const { return intermesh_vc_config_; }
+    bool requires_intermesh_vc() const { return intermesh_vc_config_.requires_vc1; }
+    bool requires_intermesh_vc_full_mesh() const { return intermesh_vc_config_.requires_vc1_full_mesh; }
+    bool requires_intermesh_vc_mesh_pass_through() const { return intermesh_vc_config_.requires_vc1_mesh_pass_through; }
+
 private:
+
+    IntermeshVCConfig compute_intermesh_vc_config() const;
+
     friend class FabricContext;
 
     const FabricContext& fabric_context_;
+
+    IntermeshVCConfig intermesh_vc_config_{};
 
     // Computed max channel counts based on actual router types in this fabric
     std::array<std::size_t, builder_config::MAX_NUM_VCS> max_sender_channels_per_vc_{};

--- a/tt_metal/fabric/fabric_context.cpp
+++ b/tt_metal/fabric/fabric_context.cpp
@@ -218,9 +218,13 @@ IntermeshVCConfig FabricContext::compute_intermesh_vc_config() const {
                     break;
                 }
             }
-            if (has_z_routers) break;
+            if (has_z_routers) {
+                break;
+            }
         }
-        if (has_z_routers) break;
+        if (has_z_routers) {
+            break;
+        }
     }
 
     // Default to FULL_MESH when intermesh exists

--- a/tt_metal/fabric/fabric_context.cpp
+++ b/tt_metal/fabric/fabric_context.cpp
@@ -56,10 +56,6 @@ tt::tt_fabric::Topology FabricContext::get_topology_from_config(tt::tt_fabric::F
     return tt::tt_fabric::Topology::Linear;
 }
 
-bool FabricContext::is_2D_topology(tt::tt_fabric::Topology topology) {
-    return topology == tt::tt_fabric::Topology::Mesh || topology == tt::tt_fabric::Topology::Torus;
-}
-
 size_t FabricContext::compute_packet_header_size_bytes() const {
     bool udm_enabled =
         tt::tt_metal::MetalContext::instance().get_fabric_udm_mode() == tt::tt_fabric::FabricUDMMode::ENABLED;
@@ -93,8 +89,8 @@ FabricContext::FabricContext(tt::tt_fabric::FabricConfig fabric_config) {
     this->wrap_around_mesh_ = this->check_for_wrap_around_mesh();
     this->topology_ = this->get_topology_from_config(fabric_config);
 
-    this->is_2D_routing_enabled_ = this->is_2D_topology(this->topology_);
-    this->bubble_flow_control_enabled_ = (this->topology_ == Topology::Ring || this->topology_ == Topology::Torus);
+    this->is_2D_routing_enabled_ = is_2D_topology(this->topology_);
+    this->bubble_flow_control_enabled_ = is_ring_or_torus(this->topology_);
 
     this->packet_header_size_bytes_ = this->compute_packet_header_size_bytes();
     this->max_payload_size_bytes_ = this->compute_max_payload_size_bytes();
@@ -103,6 +99,9 @@ FabricContext::FabricContext(tt::tt_fabric::FabricConfig fabric_config) {
     // Query tensix config from MetalContext at init time
     auto fabric_tensix_config = tt::tt_metal::MetalContext::instance().get_fabric_tensix_config();
     this->tensix_enabled_ = (fabric_tensix_config != tt::tt_fabric::FabricTensixConfig::DISABLED);
+
+    // Compute intermesh VC configuration (requires ControlPlane to be initialized)
+    this->intermesh_vc_config_ = this->compute_intermesh_vc_config();
 
     // Builder context will be lazy-initialized on first access
     builder_context_ = nullptr;
@@ -127,6 +126,32 @@ bool FabricContext::is_switch_mesh(MeshId mesh_id) const {
     // Stub: returns false for now (all meshes are compute meshes)
     // TODO: Implement when switch mesh support lands - delegate to ControlPlane
     (void)mesh_id;  // Unused for now
+    return false;
+}
+
+bool FabricContext::has_z_router_on_device(ChipId device_id) const {
+    const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+    const auto& mesh_graph = control_plane.get_mesh_graph();
+    const auto& inter_mesh_connectivity = mesh_graph.get_inter_mesh_connectivity();
+
+    // Iterate through all meshes to find which one contains this device
+    const auto& mesh_ids = mesh_graph.get_mesh_ids();
+    for (const auto& mesh_id : mesh_ids) {
+        const auto& mesh_connections = inter_mesh_connectivity[*mesh_id];
+
+        // Check if this device ID is within this mesh's connectivity map
+        if (device_id < mesh_connections.size()) {
+            const auto& chip_connections = mesh_connections[device_id];
+
+            // Check if any connection from this chip uses Z direction
+            for (const auto& [dst_mesh_id, router_edge] : chip_connections) {
+                if (router_edge.port_direction == RoutingDirection::Z) {
+                    return true;
+                }
+            }
+        }
+    }
+
     return false;
 }
 
@@ -163,6 +188,54 @@ bool FabricContext::need_deadlock_avoidance_support(eth_chan_directions directio
     }
 
     return false;
+}
+
+IntermeshVCConfig FabricContext::compute_intermesh_vc_config() const {
+    const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+    const auto& mesh_graph = control_plane.get_mesh_graph();
+
+    // Check if multiple meshes exist
+    const auto& mesh_ids = mesh_graph.get_mesh_ids();
+    constexpr size_t single_mesh_count = 1;
+    if (mesh_ids.size() <= single_mesh_count) {
+        return IntermeshVCConfig::disabled();
+    }
+
+    // Check if intermesh connections exist
+    const auto& intermesh_connections = mesh_graph.get_requested_intermesh_connections();
+    if (intermesh_connections.empty()) {
+        return IntermeshVCConfig::disabled();
+    }
+
+    // Detect Z vs XY intermesh by checking for Z-direction connections in inter-mesh connectivity
+    bool has_z_routers = false;
+    const auto& inter_mesh_connectivity = mesh_graph.get_inter_mesh_connectivity();
+    for (const auto& mesh_connections : inter_mesh_connectivity) {
+        for (const auto& chip_connections : mesh_connections) {
+            for (const auto& [dst_mesh_id, router_edge] : chip_connections) {
+                if (router_edge.port_direction == RoutingDirection::Z) {
+                    has_z_routers = true;
+                    break;
+                }
+            }
+            if (has_z_routers) break;
+        }
+        if (has_z_routers) break;
+    }
+
+    // Default to FULL_MESH when intermesh exists
+    // TODO: Implement detection logic for:
+    //   - EDGE_ONLY: Check if workload only needs edge nodes (optimization)
+    //   - FULL_MESH_WITH_PASS_THROUGH: Check if any mesh forwards traffic between other meshes
+    constexpr bool needs_mesh_pass_through = false;
+
+    auto config =
+        needs_mesh_pass_through ? IntermeshVCConfig::full_mesh_with_pass_through() : IntermeshVCConfig::full_mesh();
+
+    // Set router type based on detection
+    config.router_type = has_z_routers ? IntermeshRouterType::Z_INTERMESH : IntermeshRouterType::XY_INTERMESH;
+
+    return config;
 }
 
 }  // namespace tt::tt_fabric

--- a/tt_metal/fabric/fabric_context.hpp
+++ b/tt_metal/fabric/fabric_context.hpp
@@ -20,80 +20,6 @@ namespace tt::tt_fabric {
 // Forward declaration
 class FabricBuilderContext;
 
-/**
- * IntermeshVCMode - Defines intermesh VC requirements
- */
-enum class IntermeshVCMode : uint8_t {
-    DISABLED,                      // No intermesh VC (single mesh or no intermesh connectivity)
-    EDGE_ONLY,                     // Intermesh VC on edge nodes only (traffic sinks at mesh boundary)
-    FULL_MESH,                     // Intermesh VC throughout mesh (traffic can traverse nodes within mesh)
-    FULL_MESH_WITH_PASS_THROUGH    // Intermesh VC with inter-mesh pass-through (e.g., A→B→C routing)
-};
-
-/**
- * IntermeshRouterType - Distinguishes types of intermesh routers
- *
- * Different intermesh router types have different channel requirements:
- * - Z_INTERMESH: Vertical device stacking, requires 4 VC1 sender channels (3 mesh + Z)
- * - XY_INTERMESH: Horizontal inter-mesh, requires 3 VC1 sender channels (mesh only)
- */
-enum class IntermeshRouterType : uint8_t {
-    NONE,          // No intermesh connectivity
-    Z_INTERMESH,   // Z routers (vertical device stacking)
-    XY_INTERMESH   // XY intermesh routers (horizontal inter-mesh)
-};
-
-/**
- * IntermeshVCConfig - System-level intermesh VC configuration
- *
- * Determined during FabricContext initialization based on:
- * - Number of meshes in MeshGraph
- * - Intermesh connectivity topology
- * - Whether traffic traverses within meshes or passes through intermediate meshes
- *
- * Modes:
- * - DISABLED: No intermesh connectivity
- * - EDGE_ONLY: VC1 on edge nodes only, traffic sinks at mesh boundary
- * - FULL_MESH: VC1 throughout mesh, traffic can traverse nodes within target mesh
- * - FULL_MESH_WITH_PASS_THROUGH: VC1 with inter-mesh routing (A→B→C)
- */
-struct IntermeshVCConfig {
-    IntermeshVCMode mode = IntermeshVCMode::DISABLED;
-    IntermeshRouterType router_type = IntermeshRouterType::NONE;  // Type of intermesh router (Z vs XY)
-    bool requires_vc1 = false;                      // True if VC1 needed for intermesh
-    bool requires_vc1_full_mesh = false;            // True if VC1 needed throughout mesh (not just edges)
-    bool requires_vc1_mesh_pass_through = false;    // True if VC1 must support inter-mesh pass-through
-
-    IntermeshVCConfig() = default;
-
-    static IntermeshVCConfig disabled() {
-        return IntermeshVCConfig();
-    }
-
-    static IntermeshVCConfig edge_only() {
-        IntermeshVCConfig config;
-        config.mode = IntermeshVCMode::EDGE_ONLY;
-        config.requires_vc1 = true;
-        return config;
-    }
-
-    static IntermeshVCConfig full_mesh() {
-        IntermeshVCConfig config;
-        config.mode = IntermeshVCMode::FULL_MESH;
-        config.requires_vc1 = true;
-        config.requires_vc1_full_mesh = true;
-        return config;
-    }
-
-    static IntermeshVCConfig full_mesh_with_pass_through() {
-        IntermeshVCConfig config;
-        config.mode = IntermeshVCMode::FULL_MESH_WITH_PASS_THROUGH;
-        config.requires_vc1 = true;
-        config.requires_vc1_full_mesh = true;
-        config.requires_vc1_mesh_pass_through = true;
-        return config;
-    }
-};
 
 /**
  * FabricContext
@@ -142,12 +68,6 @@ public:
     // Queried from MetalContext at init time
     bool is_tensix_enabled() const { return tensix_enabled_; }
 
-    // ============ Intermesh VC Configuration ============
-    const IntermeshVCConfig& get_intermesh_vc_config() const { return intermesh_vc_config_; }
-    bool requires_intermesh_vc() const { return intermesh_vc_config_.requires_vc1; }
-    bool requires_intermesh_vc_full_mesh() const { return intermesh_vc_config_.requires_vc1_full_mesh; }
-    bool requires_intermesh_vc_mesh_pass_through() const { return intermesh_vc_config_.requires_vc1_mesh_pass_through; }
-
     // ============ Packet Specs ============
     size_t get_fabric_packet_header_size_bytes() const { return packet_header_size_bytes_; }
     size_t get_fabric_max_payload_size_bytes() const { return max_payload_size_bytes_; }
@@ -167,7 +87,6 @@ private:
     std::unordered_map<MeshId, bool> check_for_wrap_around_mesh() const;
     size_t compute_packet_header_size_bytes() const;
     size_t compute_max_payload_size_bytes() const;
-    IntermeshVCConfig compute_intermesh_vc_config() const;
 
     tt::tt_fabric::FabricConfig fabric_config_{};
     tt::tt_fabric::Topology topology_{};
@@ -181,8 +100,6 @@ private:
     size_t packet_header_size_bytes_ = 0;
     size_t max_payload_size_bytes_ = 0;
     size_t channel_buffer_size_bytes_ = 0;
-
-    IntermeshVCConfig intermesh_vc_config_{};
 
     // Builder context (lazy init on first access)
     mutable std::unique_ptr<FabricBuilderContext> builder_context_;

--- a/tt_metal/fabric/fabric_context.hpp
+++ b/tt_metal/fabric/fabric_context.hpp
@@ -21,6 +21,81 @@ namespace tt::tt_fabric {
 class FabricBuilderContext;
 
 /**
+ * IntermeshVCMode - Defines intermesh VC requirements
+ */
+enum class IntermeshVCMode : uint8_t {
+    DISABLED,                      // No intermesh VC (single mesh or no intermesh connectivity)
+    EDGE_ONLY,                     // Intermesh VC on edge nodes only (traffic sinks at mesh boundary)
+    FULL_MESH,                     // Intermesh VC throughout mesh (traffic can traverse nodes within mesh)
+    FULL_MESH_WITH_PASS_THROUGH    // Intermesh VC with inter-mesh pass-through (e.g., A→B→C routing)
+};
+
+/**
+ * IntermeshRouterType - Distinguishes types of intermesh routers
+ *
+ * Different intermesh router types have different channel requirements:
+ * - Z_INTERMESH: Vertical device stacking, requires 4 VC1 sender channels (3 mesh + Z)
+ * - XY_INTERMESH: Horizontal inter-mesh, requires 3 VC1 sender channels (mesh only)
+ */
+enum class IntermeshRouterType : uint8_t {
+    NONE,          // No intermesh connectivity
+    Z_INTERMESH,   // Z routers (vertical device stacking)
+    XY_INTERMESH   // XY intermesh routers (horizontal inter-mesh)
+};
+
+/**
+ * IntermeshVCConfig - System-level intermesh VC configuration
+ *
+ * Determined during FabricContext initialization based on:
+ * - Number of meshes in MeshGraph
+ * - Intermesh connectivity topology
+ * - Whether traffic traverses within meshes or passes through intermediate meshes
+ *
+ * Modes:
+ * - DISABLED: No intermesh connectivity
+ * - EDGE_ONLY: VC1 on edge nodes only, traffic sinks at mesh boundary
+ * - FULL_MESH: VC1 throughout mesh, traffic can traverse nodes within target mesh
+ * - FULL_MESH_WITH_PASS_THROUGH: VC1 with inter-mesh routing (A→B→C)
+ */
+struct IntermeshVCConfig {
+    IntermeshVCMode mode = IntermeshVCMode::DISABLED;
+    IntermeshRouterType router_type = IntermeshRouterType::NONE;  // Type of intermesh router (Z vs XY)
+    bool requires_vc1 = false;                      // True if VC1 needed for intermesh
+    bool requires_vc1_full_mesh = false;            // True if VC1 needed throughout mesh (not just edges)
+    bool requires_vc1_mesh_pass_through = false;    // True if VC1 must support inter-mesh pass-through
+
+    IntermeshVCConfig() = default;
+
+    static IntermeshVCConfig disabled() {
+        return IntermeshVCConfig();
+    }
+
+    static IntermeshVCConfig edge_only() {
+        IntermeshVCConfig config;
+        config.mode = IntermeshVCMode::EDGE_ONLY;
+        config.requires_vc1 = true;
+        return config;
+    }
+
+    static IntermeshVCConfig full_mesh() {
+        IntermeshVCConfig config;
+        config.mode = IntermeshVCMode::FULL_MESH;
+        config.requires_vc1 = true;
+        config.requires_vc1_full_mesh = true;
+        return config;
+    }
+
+    static IntermeshVCConfig full_mesh_with_pass_through() {
+        IntermeshVCConfig config;
+        config.mode = IntermeshVCMode::FULL_MESH_WITH_PASS_THROUGH;
+        config.requires_vc1 = true;
+        config.requires_vc1_full_mesh = true;
+        config.requires_vc1_mesh_pass_through = true;
+        return config;
+    }
+};
+
+/**
  * FabricContext
  *
  * Query interface for fabric topology and configuration.
@@ -56,10 +131,22 @@ public:
     // TODO: Implement when switch mesh support lands
     bool is_switch_mesh(MeshId mesh_id) const;
 
+    // ============ Z Router Queries ============
+    // Check if a device has a Z router
+    // Stub for Phase 3: returns false (will be implemented in Phase 5)
+    // TODO(Phase 5): Implement proper Z router detection
+    bool has_z_router_on_device(ChipId device_id) const;
+
     // ============ Tensix Config Query ============
     // Returns true if tensix is enabled (MUX or UDM mode)
     // Queried from MetalContext at init time
     bool is_tensix_enabled() const { return tensix_enabled_; }
+
+    // ============ Intermesh VC Configuration ============
+    const IntermeshVCConfig& get_intermesh_vc_config() const { return intermesh_vc_config_; }
+    bool requires_intermesh_vc() const { return intermesh_vc_config_.requires_vc1; }
+    bool requires_intermesh_vc_full_mesh() const { return intermesh_vc_config_.requires_vc1_full_mesh; }
+    bool requires_intermesh_vc_mesh_pass_through() const { return intermesh_vc_config_.requires_vc1_mesh_pass_through; }
 
     // ============ Packet Specs ============
     size_t get_fabric_packet_header_size_bytes() const { return packet_header_size_bytes_; }
@@ -75,12 +162,12 @@ public:
 
     // ============ Static Utilities ============
     static tt::tt_fabric::Topology get_topology_from_config(tt::tt_fabric::FabricConfig fabric_config);
-    static bool is_2D_topology(tt::tt_fabric::Topology topology);
 
 private:
     std::unordered_map<MeshId, bool> check_for_wrap_around_mesh() const;
     size_t compute_packet_header_size_bytes() const;
     size_t compute_max_payload_size_bytes() const;
+    IntermeshVCConfig compute_intermesh_vc_config() const;
 
     tt::tt_fabric::FabricConfig fabric_config_{};
     tt::tt_fabric::Topology topology_{};
@@ -94,6 +181,8 @@ private:
     size_t packet_header_size_bytes_ = 0;
     size_t max_payload_size_bytes_ = 0;
     size_t channel_buffer_size_bytes_ = 0;
+
+    IntermeshVCConfig intermesh_vc_config_{};
 
     // Builder context (lazy init on first access)
     mutable std::unique_ptr<FabricBuilderContext> builder_context_;

--- a/tt_metal/fabric/fabric_init.cpp
+++ b/tt_metal/fabric/fabric_init.cpp
@@ -26,7 +26,7 @@ std::unique_ptr<tt::tt_metal::Program> create_and_compile_tt_fabric_program(tt::
     const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
     auto& fabric_context = control_plane.get_fabric_context();
 
-    // Use FabricBuilder to orchestrate the build
+    // Use FabricBuilder to coordinate the build phases
     FabricBuilder builder(device, *fabric_program_ptr, fabric_context);
 
     // Execute build phases

--- a/tt_metal/fabric/fabric_router_builder.hpp
+++ b/tt_metal/fabric/fabric_router_builder.hpp
@@ -102,6 +102,14 @@ public:
         FabricRouterBuilder& peer, uint32_t link_idx, uint32_t num_links, Topology topology, bool is_galaxy) = 0;
 
     /**
+     * Configure local connections between routers on the same device (e.g., mesh↔Z)
+     *
+     * @param local_routers Map of direction → router builder for all routers on this device
+     */
+     virtual void configure_local_connections(
+        const std::map<RoutingDirection, FabricRouterBuilder*>& local_routers) = 0;
+
+    /**
      * Configure this router for dispatch link operation.
      * Dispatch links require specific settings (e.g., higher context switching frequency).
      * Each router type decides how (or if) to configure for dispatch.

--- a/tt_metal/fabric/fabric_router_channel_mapping.cpp
+++ b/tt_metal/fabric/fabric_router_channel_mapping.cpp
@@ -4,7 +4,7 @@
 
 #include "fabric_router_channel_mapping.hpp"
 #include "tt_metal/fabric/builder/fabric_builder_config.hpp"
-#include "tt_metal/fabric/fabric_context.hpp"
+#include "tt_metal/fabric/fabric_builder_context.hpp"
 #include <tt_stl/assert.hpp>
 
 #include <vector>

--- a/tt_metal/fabric/fabric_router_channel_mapping.cpp
+++ b/tt_metal/fabric/fabric_router_channel_mapping.cpp
@@ -4,14 +4,21 @@
 
 #include "fabric_router_channel_mapping.hpp"
 #include "tt_metal/fabric/builder/fabric_builder_config.hpp"
+#include "tt_metal/fabric/fabric_context.hpp"
 #include <tt_stl/assert.hpp>
 
 #include <vector>
 namespace tt::tt_fabric {
 
 FabricRouterChannelMapping::FabricRouterChannelMapping(
-    Topology topology, eth_chan_directions direction, bool downstream_is_tensix_builder) :
-    topology_(topology), direction_(direction), downstream_is_tensix_builder_(downstream_is_tensix_builder) {
+    Topology topology,
+    bool downstream_is_tensix_builder,
+    RouterVariant variant,
+    const IntermeshVCConfig* intermesh_config) :
+    topology_(topology),
+    downstream_is_tensix_builder_(downstream_is_tensix_builder),
+    variant_(variant),
+    intermesh_vc_config_(intermesh_config) {
     initialize_mappings();
 }
 
@@ -21,15 +28,14 @@ void FabricRouterChannelMapping::initialize_mappings() {
 }
 
 void FabricRouterChannelMapping::initialize_vc0_mappings() {
-    const bool is_2d = is_2d_topology();
+    const bool is_2d = is_2D_topology(topology_);
 
     if (is_2d) {
         // 2D topology VC0 has 4 sender channels (relative indices within VC0):
         //   [0] = local worker channel
         //   [1-3] = forwarding channels from upstream routers
         // The mapping of which upstream router uses which channel depends on the downstream router's direction
-        constexpr size_t max_2d_vc0_channels = 4;
-        for (uint32_t i = 0; i < max_2d_vc0_channels; ++i) {
+        for (uint32_t i = 0; i < builder_config::num_sender_channels_2d_mesh; ++i) {
             // When mux extension is enabled, ALL VC0 channels go to TENSIX mux
             BuilderType builder_type = downstream_is_tensix_builder_ ? BuilderType::TENSIX : BuilderType::ERISC;
             sender_channel_map_[LogicalSenderChannelKey{0, i}] =
@@ -57,34 +63,68 @@ void FabricRouterChannelMapping::initialize_vc0_mappings() {
 }
 
 void FabricRouterChannelMapping::initialize_vc1_mappings() {
-    const bool is_2d = is_2d_topology();
+    const bool is_2d = is_2D_topology(topology_);
     if (!is_2d) {
-        // VC1 (intermesh) only exists for 2D topologies
+        // VC1 (intermesh) only exists for 2D topologies and Z routers
         return;
     }
 
-    // VC2: [0-2] for 2D, [0-3] for 2D+Z
-    // For now, we'll map to erisc/tensix builder channels
-    // The exact mapping depends on intermesh implementation details
-    // This is a placeholder - actual implementation may vary
-    uint32_t num_vc1_channels = 3;  // Default for 2D, could be 4 for 2D+Z
+    if (is_z_router()) {
+        // Z routers exist only for intermesh connectivity - validate config
+        TT_FATAL(
+            intermesh_vc_config_ != nullptr,
+            "Z router requires intermesh VC config (Z routers only exist for intermesh connectivity)");
+        TT_FATAL(
+            intermesh_vc_config_->requires_vc1,
+            "Z router requires intermesh VC to be enabled (requires_vc1 must be true)");
 
-    for (uint32_t i = 0; i < num_vc1_channels; ++i) {
-        // Map to erisc builder for now - tensix mapping would be added if needed
-        sender_channel_map_[LogicalSenderChannelKey{2, i}] =
-            InternalSenderChannelMapping{BuilderType::ERISC, i};  // VC2 is externally-facing (intermesh)
+        // Z Router VC1 layout:
+        // - Sender channels 0-3: Map to erisc internal channels 4-7 (Z→mesh traffic)
+        // - Receiver channel 0: Maps to erisc internal channel 1 (mesh→Z traffic)
 
-        receiver_channel_map_[LogicalReceiverChannelKey{2, i}] =
-            InternalReceiverChannelMapping{BuilderType::ERISC, i};
+        constexpr uint32_t z_router_vc1_sender_count = builder_config::num_sender_channels_z_router_vc1;
+        constexpr uint32_t z_router_vc1_base_sender_channel = builder_config::num_sender_channels_z_router_vc0;
+        constexpr uint32_t z_router_vc1_receiver_channel = 1;
+
+        for (uint32_t i = 0; i < z_router_vc1_sender_count; ++i) {
+            sender_channel_map_[LogicalSenderChannelKey{1, i}] =
+                InternalSenderChannelMapping{BuilderType::ERISC, z_router_vc1_base_sender_channel + i};
+        }
+
+        receiver_channel_map_[LogicalReceiverChannelKey{1, 0}] =
+            InternalReceiverChannelMapping{BuilderType::ERISC, z_router_vc1_receiver_channel};
+    } else {
+        // Standard mesh router VC1: only create if intermesh VC is required
+        if (intermesh_vc_config_ && intermesh_vc_config_->requires_vc1) {
+            // Determine sender count based on intermesh router type
+            // XY intermesh: 3 sender channels (mesh directions only)
+            // Z intermesh: 4 sender channels (3 mesh directions + Z)
+            uint32_t mesh_vc1_sender_count = builder_config::num_downstream_edms_2d_vc1;  // default 3
+
+            if (intermesh_vc_config_->router_type == IntermeshRouterType::Z_INTERMESH) {
+                mesh_vc1_sender_count = 4;  // 3 mesh directions + Z
+            }
+
+            constexpr uint32_t mesh_vc1_base_sender_channel = builder_config::num_sender_channels_2d_mesh;
+            constexpr uint32_t mesh_vc1_receiver_channel = 1;
+
+            // Create sender channels (3 or 4 depending on router type)
+            for (uint32_t i = 0; i < mesh_vc1_sender_count; ++i) {
+                sender_channel_map_[LogicalSenderChannelKey{1, i}] =
+                    InternalSenderChannelMapping{BuilderType::ERISC, mesh_vc1_base_sender_channel + i};
+            }
+
+            // Create ONE receiver channel for VC1 (not N)
+            // A receiver channel forwards to multiple downstream sender channels
+            receiver_channel_map_[LogicalReceiverChannelKey{1, 0}] =
+                InternalReceiverChannelMapping{BuilderType::ERISC, mesh_vc1_receiver_channel};
+        }
+        // If intermesh VC not required, don't create mappings
     }
 }
 
-bool FabricRouterChannelMapping::is_2d_topology() const {
-    return topology_ == Topology::Mesh || topology_ == Topology::Torus;
-}
-
-bool FabricRouterChannelMapping::is_ring_or_torus() const {
-    return topology_ == Topology::Ring || topology_ == Topology::Torus;
+bool FabricRouterChannelMapping::is_z_router() const {
+    return variant_ == RouterVariant::Z_ROUTER;
 }
 
 InternalSenderChannelMapping FabricRouterChannelMapping::get_sender_mapping(
@@ -105,18 +145,51 @@ InternalReceiverChannelMapping FabricRouterChannelMapping::get_receiver_mapping(
 }
 
 uint32_t FabricRouterChannelMapping::get_num_virtual_channels() const {
-    // For now, only handle VC0
-    // intermesh vc suport not added yet (Issue https://github.com/tenstorrent/tt-metal/issues/32561)
+    // Z routers always have 2 VCs: VC0 (mesh traffic) and VC1 (Z traffic)
+    if (is_z_router()) {
+        return 2;
+    }
+
+    // Standard mesh routers: expose VC1 if intermesh VC is required
+    if (intermesh_vc_config_ && intermesh_vc_config_->requires_vc1) {
+        return 2;  // VC0 + VC1 for intermesh
+    }
+
     return 1;  // VC0 only
 }
 
 uint32_t FabricRouterChannelMapping::get_num_sender_channels_for_vc(uint32_t vc) const {
+    constexpr uint32_t vc1_index = 1;
+    constexpr uint32_t no_channels = 0;
+
     switch (vc) {
         case 0:  // VC0
             return builder_config::get_num_used_sender_channel_count(get_topology());
+        case 1:  // VC1
+            if (is_z_router()) {
+                return builder_config::num_sender_channels_z_router_vc1;
+            } else if (is_2D_topology(topology_)) {
+                // Check if VC1 mappings were actually created in initialize_vc1_mappings()
+                // Count how many sender channels exist for VC1
+                LogicalSenderChannelKey test_key{vc1_index, 0};
+                if (sender_channel_map_.find(test_key) == sender_channel_map_.end()) {
+                    return no_channels;  // VC1 not enabled (no mappings created)
+                }
+
+                // Count actual sender channels (3 for XY intermesh, 4 for Z intermesh)
+                uint32_t count = 0;
+                for (uint32_t i = 0; i < builder_config::num_downstream_edms_2d_vc1_with_z; ++i) {
+                    if (sender_channel_map_.find(LogicalSenderChannelKey{vc1_index, i}) != sender_channel_map_.end()) {
+                        count++;
+                    } else {
+                        break;  // Channels are created sequentially, so stop at first missing
+                    }
+                }
+                return count;
+            }
+            return no_channels;  // 1D topologies don't have VC1
         default:
-            // intermesh vc support not added yet (Issue https://github.com/tenstorrent/tt-metal/issues/32561)
-            return 0;
+            return no_channels;
     }
 }
 

--- a/tt_metal/fabric/fabric_router_channel_mapping.hpp
+++ b/tt_metal/fabric/fabric_router_channel_mapping.hpp
@@ -13,9 +13,23 @@
 
 namespace tt::tt_fabric {
 
+// Forward declaration
+struct IntermeshVCConfig;
+
 enum class BuilderType : uint8_t {
     ERISC = 0,
     TENSIX = 1,
+};
+
+/**
+ * RouterVariant - Distinguishes between mesh and Z routers
+ *
+ * MESH: Standard mesh router (N/E/S/W directions)
+ * Z_ROUTER: Vertical Z router for inter-device connectivity
+ */
+enum class RouterVariant : uint8_t {
+    MESH = 0,
+    Z_ROUTER = 1,
 };
 
 struct LogicalSenderChannelKey {
@@ -56,19 +70,21 @@ struct InternalReceiverChannelMapping {
  * FabricRouterChannelMapping
  *
  * Defines the mapping from logical channels (VC + relative channel index within VC) to internal builder channels.
- * This mapping is computed based on topology, direction, and tensix extension mode.
+ * This mapping is computed based on topology, direction, router variant, and tensix extension mode.
  *
  * Channel indices are relative to each VC:
  * - VC0 (1D): [0] = local worker, [1] = forwarding from upstream
  * - VC0 (2D): [0] = local worker, [1-3] = forwarding from upstream routers
- * - VC1: [0-2] or [0-3] = intermesh channels (2D/2D+Z only)
+ * - VC1 (2D): [0-2] = intermesh channels (standard 2D)
+ * - VC1 (Z router): [0-3] = Z→mesh channels (4 sender channels mapping to 2-4 mesh routers)
  */
 class FabricRouterChannelMapping {
 public:
     FabricRouterChannelMapping(
         Topology topology,
-        eth_chan_directions direction,
-        bool has_tensix_extension = false);
+        bool has_tensix_extension,
+        RouterVariant variant,
+        const IntermeshVCConfig* intermesh_config);
 
     /**
      * Get the internal sender channel mapping for a logical sender channel
@@ -91,11 +107,16 @@ public:
 
     std::vector<InternalSenderChannelMapping> get_all_sender_mappings() const;
 
+    /**
+     * Check if this is a Z router
+     */
+    bool is_z_router() const;
+
 private:
     Topology topology_;
-    // will become used when Z-link support is added
-    [[maybe_unused]] eth_chan_directions direction_;
     bool downstream_is_tensix_builder_;
+    RouterVariant variant_;
+    const IntermeshVCConfig* intermesh_vc_config_ = nullptr;
 
     std::map<LogicalSenderChannelKey, InternalSenderChannelMapping> sender_channel_map_;
     std::map<LogicalReceiverChannelKey, InternalReceiverChannelMapping> receiver_channel_map_;
@@ -103,8 +124,6 @@ private:
     void initialize_mappings();
     void initialize_vc0_mappings();
     void initialize_vc1_mappings();
-    bool is_2d_topology() const;
-    bool is_ring_or_torus() const;
 };
 
 }  // namespace tt::tt_fabric


### PR DESCRIPTION
this change is only concerned with adding the necessary builder code to construct Z routers. Z routers are not enabled with this change. Note also that this change is not final. It does not incorporate the most optimal implementations for Z routers (e.g. it specifies 2 receiver channels for Z routers, even though they have only one). This will materialize as inefficient L1 usage, but should not limit functionality. Optimizations will be considered future work.

Some relatively large rework was done with the fabric builder flow to accommodate the required changes. At a very high level, the builder moves towards configuration driven construction: different router types are defined and in combination with the fabric topology, a `FabricRouterChannelMapping` is generated. This object defines how channels are organized/enumerated in a router. For example, specifying the sender and receiver channel counts, and which VC each one maps to. 

This is useful for enabling a more configurable fabric builder code base. Additionally, it is required since Z routers are the first time in the fabric code-base where one router can have a meaningfully different micro-architecture than other ones in the same fabric:
- different sender channel and receiver channel counts
- different sender -> receiver channel mapping
- different number of receiver -> downstream connections

### Important New Types
- RouterConnectionMapping: defines VC -> channel mappings per router (for externally exposed channels)
- IntermeshVCConfig: defines how intermesh VCs are managed across the full fabric

#### Enums:
- `RouterVariant`: specifies the high-level router type (MESH or Z_ROUTER)
- `IntermeshVCMode`: specifies how intermesh flows are implemented in the system:
  - DISABLED: no intermesh
  - EDGE_ONLY: Intermesh VC on edge nodes only (traffic sinks at mesh boundary), no additional hops after switch over mesh boundary
  - FULL_MESH: The intermesh VC spans the full mesh, but forces traffic to sink into the dest mesh. Hopping through intermediate meshes is not allowed
  - FULL_MESH_WITH_PASS_THROUGH: above, but routing through intermediate meshes is allowed
- `IntermeshRouterType`: defines how to implement a given intermesh router: Z mode or XY mode

### Note
To facilitate host side testing, a new component (`ConnectionRegistry`) was added. This was created purely for adding visibility into the fabric router builders for easier unit testing without device. This type was added to boot-strap this work but is now kept in place to simplify future change testing.

let's get that big training going boi


### Checklist
- [x] APC: https://github.com/tenstorrent/tt-metal/actions/runs/20146514946
- [x] BH Multicard Unit Test: https://github.com/tenstorrent/tt-metal/actions/runs/20138157974
- [x] T3K Nightly: https://github.com/tenstorrent/tt-metal/actions/runs/20138164553
- [x] T3K Frequent: https://github.com/tenstorrent/tt-metal/actions/runs/20138166586
- [x] Galaxy Unit: https://github.com/tenstorrent/tt-metal/actions/runs/20138226731
  - stuck waiting all day in queues. Ran locally instead successully
- [x] Galaxy Quick: https://github.com/tenstorrent/tt-metal/actions/runs/20138162282
  - stuck waiting all day in queues. Ran locally instead successully