### PR TITLE
Enable half tile for BH and dynamic chunk sizes in SDPA decode 

### DIFF
--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -933,8 +933,8 @@ class ModelArgs:
             self.model_config["SDPA_DECODE_PROGCFG"] = ttnn.SDPAProgramConfig(
                 compute_with_storage_grid_size=(8, 8),
                 exp_approx_mode=False,
-                q_chunk_size=128 if is_blackhole() else 256,
-                k_chunk_size=128 if is_blackhole() else 256,
+                q_chunk_size=0,
+                k_chunk_size=0,
             )
 
             self.model_config["SDPA_DECODE_COMPUTE_PROGCFG"] = ttnn.WormholeComputeKernelConfig(

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/compute_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/compute_common.hpp
@@ -622,7 +622,6 @@ ALWI void cb_matmul_blocks(
                 for (uint32_t i = 0; i < out_subblock_num_tiles; i++) {
                     add_tiles(zero_cb, mask_cb, 0, i, i);
                 }
-                cb_pop_front(mask_cb, out_subblock_num_tiles);
             }
             tile_regs_commit();
             tile_regs_wait();

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_program_factory.cpp
@@ -403,9 +403,7 @@ SdpaDecodeProgramFactory::cached_program_t SdpaDecodeProgramFactory::create(
     // - In non-causal mode, mask can be an input tensor which needs proper handling to read as 16x32 tiles
     // - Only support Float16_b since block float w/ shared exp needs special handling to read as 16x32 tiles
     // In compute, need to find a proper way to get num_faces for sfpu functions
-    const bool use_half_tile =
-        (is_causal and num_q_heads <= 16 and q_df == tt::DataFormat::Float16_b and
-         device->arch() == tt::ARCH::WORMHOLE_B0);
+    const bool use_half_tile = (is_causal and num_q_heads <= 16 and q_df == tt::DataFormat::Float16_b);
 
     if (use_half_tile) {
         q_tile = half_tile;


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/32652
https://github.com/tenstorrent/tt-metal/issues/33977

### Problem description
- we disabled half tiles for BH in sdpa decode because it was previously not supported, this PR turns it back on
- we switch to using dynamic chunk sizes for sdpa decode, k chunk size is set to 0
- previously there was a hang for batch 32 when dynamic chunk sizes is used, the hang was due to incorrect popping of mask cb when `add_mask_fusion` is used for cases when we loop the kv heads dim multiple iterations, since the mask cb was popped, when we try to wait front on it on the 2nd head the resource is exhausted, causing a hang. The fix was to not pop it at all, so the mask can be used for all kv heads.

Perf improvements recorded from Qwen-3-32B shapes (Note that these improvements apply to all models llama 8b and 70b and others), the percentage speed up should be roughly the same.

| Configuration \ Position | 0 | 32 | 64 | 128 | 256 | 512 |
| ------------------------ | - | -- | -- | --- | --- | --- | 
|  **Dynamic chunks**     | -  |  7216  | 7527 | 8495  | 10514  |  14140   | 
| **Fixed chunk (128)**       | - | 8402 | 8938  | 8843  | 11860  | 16869  |

To reproduce these measurements, run:
```
pytest models/demos/llama3_70b_galaxy/tests/tg_perf_unit_tests/test_llama_ops_perf_TG_llama.py
```

and modify `test_llama_tg_ScaledDotProductAttentionDecode` in `test_llama_ops.py` with the appropriate parameters (n_q=16, n_kv=2, b=1, s=1024*64, d=128)

### What's changed
- mentioned above

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/20704774527) 
- [x] [BH post commit](https://github.com/tenstorrent/tt-metal/actions/runs/20704777747)
- [x] [L2 nightly](https://github.com/tenstorrent/tt-metal/actions/runs/20704857444)
- [x] [T3K demo](https://github.com/tenstorrent/tt-metal/actions/runs/20704793608)
- [x] [BH single card demo](https://github.com/tenstorrent/tt-metal/actions/runs/20704782365)
- [x] [BH multi card demo](https://github.com/tenstorrent/tt-metal/actions/runs/20704786238)
