### PR TITLE
[skip ci] New Preset to export clang-tidy fixes in parallel

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -40,6 +40,15 @@
         }
       },
       {
+        "name": "clang-tidy-fix-parallel",
+        "inherits": "clang-tidy",
+        "description": "Run Clang Tidy in parallel and export fixes to YAML files (apply with clang-apply-replacements)",
+        "binaryDir": "${sourceDir}/.build/clang-tidy-fix-parallel",
+        "cacheVariables": {
+          "CMAKE_CXX_CLANG_TIDY": {"value": "${sourceDir}/cmake/clang-tidy-export-fixes-wrapper.sh;${sourceDir}/.build/clang-tidy-fix-parallel/fixes"}
+        }
+      },
+      {
         "name": "gcc",
         "inherits": "default",
         "description": "Build with GCC",
@@ -95,6 +104,13 @@
       {
         "name": "clang-tidy-fix",
         "configurePreset": "clang-tidy-fix",
+        "configuration": "RelWithDebInfo",
+        "targets": ["all", "all_verify_interface_header_sets"],
+        "nativeToolOptions": ["-k0"]
+      },
+      {
+        "name": "clang-tidy-fix-parallel",
+        "configurePreset": "clang-tidy-fix-parallel",
         "configuration": "RelWithDebInfo",
         "targets": ["all", "all_verify_interface_header_sets"],
         "nativeToolOptions": ["-k0"]

--- a/cmake/clang-tidy-export-fixes-wrapper.sh
+++ b/cmake/clang-tidy-export-fixes-wrapper.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Wrapper script for clang-tidy that exports fixes to unique YAML files
+# Usage: clang-tidy-export-fixes-wrapper.sh <fixes-dir> <clang-tidy-args...>
+#
+# This script invokes clang-tidy and exports fixes to a unique file based on
+# the hash of the source file path, allowing parallel execution without conflicts.
+
+FIXES_DIR="$1"
+shift
+
+# Create the fixes directory if it doesn't exist
+mkdir -p "$FIXES_DIR"
+
+# Find the source file from the arguments (last argument that's a file)
+SOURCE_FILE=""
+for arg in "$@"; do
+    if [[ -f "$arg" && "$arg" != -* ]]; then
+        SOURCE_FILE="$arg"
+    fi
+done
+
+if [[ -z "$SOURCE_FILE" ]]; then
+    # If no source file found, just run clang-tidy without export-fixes
+    exec clang-tidy-20 "$@"
+fi
+
+# Generate a unique filename based on the source file path
+HASH=$(echo "$SOURCE_FILE" | md5sum | cut -d' ' -f1)
+BASENAME=$(basename "$SOURCE_FILE")
+FIXES_FILE="${FIXES_DIR}/${BASENAME}-${HASH}.yaml"
+
+exec clang-tidy-20 --export-fixes="$FIXES_FILE" "$@"

--- a/cmake/clang-tidy-export-fixes-wrapper.sh
+++ b/cmake/clang-tidy-export-fixes-wrapper.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 # Wrapper script for clang-tidy that exports fixes to unique YAML files
 # Usage: clang-tidy-export-fixes-wrapper.sh <fixes-dir> <clang-tidy-args...>
 #
@@ -14,7 +15,7 @@ mkdir -p "$FIXES_DIR"
 # Find the source file from the arguments (last argument that's a file)
 SOURCE_FILE=""
 for arg in "$@"; do
-    if [[ -f "$arg" && "$arg" != -* ]]; then
+    if [[ "$arg" != -* ]]; then
         SOURCE_FILE="$arg"
     fi
 done
@@ -24,8 +25,9 @@ if [[ -z "$SOURCE_FILE" ]]; then
     exec clang-tidy-20 "$@"
 fi
 
-# Generate a unique filename based on the source file path
-HASH=$(echo "$SOURCE_FILE" | md5sum | cut -d' ' -f1)
+# Generate a unique filename based on the absolute source file path
+SOURCE_FILE_ABS=$(realpath "$SOURCE_FILE")
+HASH=$(echo "$SOURCE_FILE_ABS" | md5sum | cut -d' ' -f1)
 BASENAME=$(basename "$SOURCE_FILE")
 FIXES_FILE="${FIXES_DIR}/${BASENAME}-${HASH}.yaml"
 


### PR DESCRIPTION
### Ticket
NA

### Problem description

The existing `clang-tidy-fix` preset applies fixes immediately using `--fix`, which causes race conditions when running in parallel. When multiple clang-tidy processes analyze different source files that include the same header, they can simultaneously attempt to modify that header, corrupting it. The current workaround documented in `contributing/ClangTidy.md` is to run `ninja -j1`, which doesn't utilize available CPU cores effectively.

### What's changed

Added a new `clang-tidy-fix-parallel` CMake preset that enables fully parallel clang-tidy fix generation across all available cores.

**Approach:**
- Instead of applying fixes immediately (`--fix`), each clang-tidy invocation exports its fixes to a unique YAML file using `--export-fixes`
- A wrapper script (`cmake/clang-tidy-export-fixes-wrapper.sh`) generates unique filenames using an MD5 hash of the source file path, preventing conflicts when multiple files share the same basename
- After the parallel build completes, fixes are applied atomically using `clang-apply-replacements`, which deduplicates identical fixes and merges non-conflicting changes

**Usage:**
```bash
cmake --preset clang-tidy-fix-parallel
cmake --build --preset clang-tidy-fix-parallel -j$(nproc)
clang-apply-replacements-20 .build/clang-tidy-fix-parallel/fixes/
```

**Impact:**
- Enables full utilization of available cores (e.g., 96 cores) for clang-tidy fix generation
- Eliminates race conditions that previously corrupted header files during parallel builds
- Maintains compatibility with existing `clang-tidy-fix` preset for users who prefer the single-threaded approach