### PR TITLE
Revert removal of `get_pcie_alignment` in hal

### DIFF
--- a/tt_metal/api/tt-metalium/hal.hpp
+++ b/tt_metal/api/tt-metalium/hal.hpp
@@ -46,6 +46,13 @@ uint32_t get_dram_alignment();
 uint32_t get_l1_alignment();
 
 /**
+ * @brief Uses the hardware abstraction layer to inform client of architecture specific PCIE alignment.
+ *
+ * @return Alignment requirement in bytes
+ */
+uint32_t get_pcie_alignment();
+
+/**
  * @brief Uses the hardware abstraction layer to inform client of architecture specific address.
  * this address corresponds to the beginning of free space in the ERISC's L1 SRAM
  *

--- a/tt_metal/hal.cpp
+++ b/tt_metal/hal.cpp
@@ -36,6 +36,8 @@ uint32_t get_dram_alignment() { return tt::tt_metal::MetalContext::instance().ha
 
 uint32_t get_l1_alignment() { return tt::tt_metal::MetalContext::instance().hal().get_alignment(HalMemType::L1); }
 
+uint32_t get_pcie_alignment() { return tt::tt_metal::MetalContext::instance().hal().get_alignment(HalMemType::HOST); }
+
 uint32_t get_erisc_l1_unreserved_base() {
     const auto& hal_ref = tt::tt_metal::MetalContext::instance().hal();
     return hal_ref.get_dev_addr(HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::UNRESERVED);


### PR DESCRIPTION
### Ticket
Closes https://github.com/tenstorrent/tt-mlir/issues/6220

### Problem description
`get_pcie_alignment` was removed in #32115 as it was thought that no one is dependent on it.
However this turned out not true as mlir is an active user of the function and the removal has affected their uplift.

### What's changed
Revert removal of `get_pcie_alignment` function in Runtime host api.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/20021231310)