### PR TITLE
#33644: `ttnn.sort` indices not producing `uint32` output fix

### DIFF
--- a/tests/ttnn/unit_tests/operations/data_movement/test_sort.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_sort.py
@@ -105,6 +105,7 @@ def test_sort_prealocated_output(shape, dim, descending, device):
         ([1, 1, 32, 256 * TILE_WIDTH], -1, False),
         ([1, 151936], -1, False),
         ([1, 128256], -1, False),
+        ([1, 16384 * TILE_WIDTH], -1, False),
     ],
 )
 def test_sort_long_tensor(shape, dim, descending, device):

--- a/ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/dataflow/coordinator_single_row_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/dataflow/coordinator_single_row_multi_core.cpp
@@ -53,7 +53,6 @@ void kernel_main() {
     // Semaphore setup
     volatile tt_l1_ptr uint32_t* semaphore_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cores_to_coordinator_semaphore_id);
-    noc_semaphore_set(semaphore_ptr, 0);  // Reset the semaphore
     const uint64_t semaphore_global_multicast_addr = get_noc_multicast_addr(
         start_core_physical_coord_x,
         start_core_physical_coord_y,

--- a/ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/dataflow/sort_dataflow_common.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/dataflow/sort_dataflow_common.hpp
@@ -15,7 +15,7 @@ FORCE_INLINE void generate_index_tile(const uint32_t cb_id, const uint32_t wt) {
     // Writer config
     const uint32_t writer_addr = get_write_ptr(cb_id);
     volatile tt_l1_ptr T* ptr = reinterpret_cast<volatile tt_l1_ptr T*>(writer_addr);
-    const uint16_t w = wt << 5;  // wt * 2^(5)
+    const uint32_t w = wt << 5;  // wt * 2^(5)
 
     // Writer loop
     uint32_t count = 0;

--- a/ttnn/cpp/ttnn/operations/data_movement/sort/device/sort_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sort/device/sort_program_factory.cpp
@@ -656,7 +656,9 @@ uint32_t SortProgramFactoryCrossCoreDataExchange::get_number_of_tiles_per_core(
     switch (slicing_strategy) {
         case CrossCoreDataExchangeSortSlicingStrategy::USE_AS_MANY_CORES: {
             constexpr uint32_t MIN_TILES_PER_CORE = 2;
-            return std::max(Wt / total_number_of_cores, MIN_TILES_PER_CORE);
+            constexpr uint32_t MAX_TILES_PER_CORE = 128;
+            const auto max_val = std::max(Wt / total_number_of_cores, MIN_TILES_PER_CORE);
+            return std::min(MAX_TILES_PER_CORE, max_val);
         }
         case CrossCoreDataExchangeSortSlicingStrategy::FILL_CORES_FIRST:
         default: {

--- a/ttnn/cpp/ttnn/operations/data_movement/sort/device/sort_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sort/device/sort_program_factory.cpp
@@ -647,29 +647,6 @@ void SortProgramFactoryCrossCoreDataExchange::override_runtime_arguments(
     }  // core_range loop
 }
 
-/**
- * @brief Determines the number of tiles to process per core based on slicing strategy and data types.
- *
- * @param total_number_of_cores Total number of cores available for the operation
- * @param Wt Total width in tiles to be processed
- * @param input_dtype Data type of the input tensor
- * @param index_dtype Data type of the index tensor
- * @param slicing_strategy Strategy for distributing work across cores
- *
- * @return Number of tiles to be processed per core
- *
- * @details
- * For USE_AS_MANY_CORES strategy:
- * - Minimum of 2 tiles per core is required because the LLK (Low-Level Kernel) needs at least
- *   two tiles per core to perform sorting operations
- * - Maximum is capped at 128 tiles (power of 2) based on hardware memory constraints, ensuring
- *   that tiles can fit into a single core's available memory
- * - Returns the computed value clamped between these bounds
- *
- * For FILL_CORES_FIRST strategy:
- * - Returns 64 tiles for 32-bit data types (FLOAT32, UINT32, INT32) to account for larger memory footprint
- * - Returns 128 tiles for smaller data types (16-bit) as default
- */
 uint32_t SortProgramFactoryCrossCoreDataExchange::get_number_of_tiles_per_core(
     uint32_t total_number_of_cores,
     uint32_t Wt,


### PR DESCRIPTION
### Ticket

#33644

### Problem description
After fixing #33386, the function began correctly returning the `uint32_t` dtype, but the values inside the tensor still capped at the maximum `uint16_t` range. Additionally, an error occurred when computing the tile values processed by a single core.

### What's changed
- Resolved wrong indices tiles creation for `uint32_t` tiles,
- Resolved issue with computing number of tiles to be processed by single core,
- Added test for ingle row multi core implementation,
- Removed in kernel semaphore reset to avoid race condition (It's initial value is set on host site during semaphore creation).

_Proper test for indices will be added with #27223_ 

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/20022929733

### Output from the script in the ticket
```
Values match: True
Indices match: False
ttnn indices more than 65536:  (tensor([0, 0, 0,  ..., 0, 0, 0]), tensor([     1,      8,      9,  ..., 255997, 255998, 255999]))
torch indices more than 65536:  (tensor([0, 0, 0,  ..., 0, 0, 0]), tensor([     0,      1,      4,  ..., 255996, 255997, 255998])
```