### PR TITLE
refactor: avoid branching in hardmish using `sfpi::vec_min_max`

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_hardmish.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_hardmish.h
@@ -6,24 +6,25 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
-#include "sfpu/ckernel_sfpu_converter.h"
 
 namespace ckernel {
 namespace sfpu {
 
+// hardmish(x) = x * clamp(x + 2.8, 0.0, 5.0) / 5
+//             = x * clamp(x + 2.8, 0.0, 5.0) * 0.2
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void hardmish() {
-    // hardmish(x) = x * (x + 2.8).clamp(0.0, 5.0) / 5
     for (int d = 0; d < ITERATIONS; d++) {
-        sfpi::vFloat a = sfpi::dst_reg[0] + 2.8f;
+        sfpi::vFloat x = sfpi::dst_reg[0];
+        sfpi::vFloat a = x + 2.8f;
 
-        v_if(a < 0.0f) { a = 0.0f; }
-        v_endif;
+        // sfpi::vec_min_max(a, b) puts min in a, max in b
+        sfpi::vFloat low_bound = 0.0f;
+        sfpi::vFloat high_bound = 5.0f;
+        sfpi::vec_min_max(low_bound, a);   // a = max(a, 0.0)
+        sfpi::vec_min_max(a, high_bound);  // a = min(a, 5.0)
 
-        v_if(a > 5.0f) { a = 5.0f; }
-        v_endif;
-
-        sfpi::dst_reg[0] = sfpi::dst_reg[0] * a * 0.2f;
+        sfpi::dst_reg[0] = x * a * 0.2f;
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_hardmish.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_hardmish.h
@@ -6,24 +6,25 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
-#include "sfpu/ckernel_sfpu_converter.h"
 
 namespace ckernel {
 namespace sfpu {
 
+// hardmish(x) = x * clamp(x + 2.8, 0.0, 5.0) / 5
+//             = x * clamp(x + 2.8, 0.0, 5.0) * 0.2
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void hardmish() {
-    // hardmish(x) = x * (x + 2.8).clamp(0.0, 5.0) / 5
     for (int d = 0; d < ITERATIONS; d++) {
-        sfpi::vFloat a = sfpi::dst_reg[0] + 2.8f;
+        sfpi::vFloat x = sfpi::dst_reg[0];
+        sfpi::vFloat a = x + 2.8f;
 
-        v_if(a < 0.0f) { a = 0.0f; }
-        v_endif;
+        // sfpi::vec_min_max(a, b) puts min in a, max in b
+        sfpi::vFloat low_bound = 0.0f;
+        sfpi::vFloat high_bound = 5.0f;
+        sfpi::vec_min_max(low_bound, a);   // a = max(a, 0.0)
+        sfpi::vec_min_max(a, high_bound);  // a = min(a, 5.0)
 
-        v_if(a > 5.0f) { a = 5.0f; }
-        v_endif;
-
-        sfpi::dst_reg[0] = sfpi::dst_reg[0] * a * 0.2f;
+        sfpi::dst_reg[0] = x * a * 0.2f;
         sfpi::dst_reg++;
     }
 }


### PR DESCRIPTION
### Ticket
None

### Problem description
I noticed during PR reviews of other PRs that we have a lot of branching in SFPU code that could be avoided in some ways.
This is Part1 of PRs that will make changes in several SFPU ops to avoid branching.

This change was tested on Blackhole by @nmauriceTT. We saw an improvement of 793 -> 601 cycles/tile

### What's changed
Use of `sfpi::vec_min_max` instead of `v_if`s.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/20023878200) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/20023875607) CI with demo tests passes (if applicable)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/runs/20023914354) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/runs/20023932868) CI passes (if applicable)