### PR TITLE
refactor: avoid branching in hardtanh by using TTI macros directly

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_hardtanh.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_hardtanh.h
@@ -5,20 +5,34 @@
 #pragma once
 
 #include "ckernel.h"
+#include "ckernel_defs.h"
 
 namespace ckernel::sfpu {
 
-template <bool APPROXIMATION_MODE, int ITERATIONS>
 // Hardtanh(x) = max_val if x > max_val, min_val if x < min_val, else x
+// Equivalent to: clamp(x, min_val, max_val) = min(max(x, min_val), max_val)
+template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void calculate_hardtanh(uint param0, uint param1) {
-    sfpi::vFloat min_val = Converter::as_float(param0);
-    sfpi::vFloat max_val = Converter::as_float(param1);
-    // SFPU microcode
+    // Load both params outside the loop for better performance
+    // param0 = min_val -> LREG2, param1 = max_val -> LREG3
+    TT_SFPLOADI(p_sfpu::LREG2, sfpi::SFPLOADI_MOD0_LOWER, param0 & 0xFFFF);
+    TT_SFPLOADI(p_sfpu::LREG2, sfpi::SFPLOADI_MOD0_UPPER, param0 >> 16);
+    TT_SFPLOADI(p_sfpu::LREG3, sfpi::SFPLOADI_MOD0_LOWER, param1 & 0xFFFF);
+    TT_SFPLOADI(p_sfpu::LREG3, sfpi::SFPLOADI_MOD0_UPPER, param1 >> 16);
+#pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
-        sfpi::vFloat val = sfpi::dst_reg[0];
-        v_if(val < min_val) { sfpi::dst_reg[0] = min_val; }
-        v_elseif(val > max_val) { sfpi::dst_reg[0] = max_val; }
-        v_endif;
+        // x = max(x, min_val) using LREG2
+        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 0);
+        TTI_SFPMOV(0, p_sfpu::LREG2, p_sfpu::LREG1, 0);
+        TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG0, 1);
+        TTI_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 0);  // store max
+
+        // x = min(x, max_val) using LREG3
+        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 0);
+        TTI_SFPMOV(0, p_sfpu::LREG3, p_sfpu::LREG1, 0);
+        TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG0, 1);
+        TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 0);  // store min
+
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_hardtanh.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_hardtanh.h
@@ -24,13 +24,13 @@ inline void calculate_hardtanh(uint param0, uint param1) {
         // x = max(x, min_val) using LREG2
         TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 0);
         TTI_SFPMOV(0, p_sfpu::LREG2, p_sfpu::LREG1, 0);
-        TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG0, 1);
+        TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG0, 1 /* smaller value to LREG0 */);
         TTI_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 0);  // store max
 
         // x = min(x, max_val) using LREG3
         TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 0);
         TTI_SFPMOV(0, p_sfpu::LREG3, p_sfpu::LREG1, 0);
-        TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG0, 1);
+        TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG0, 1 /* smaller value to LREG0 */);
         TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 0);  // store min
 
         sfpi::dst_reg++;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_hardtanh.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_hardtanh.h
@@ -24,13 +24,13 @@ inline void calculate_hardtanh(uint param0, uint param1) {
         // x = max(x, min_val) using LREG2
         TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_3, 0);
         TTI_SFPMOV(0, p_sfpu::LREG2, p_sfpu::LREG1, 0);
-        TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG0, 1);
+        TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG0, 1 /* smaller value to LREG0 */);
         TTI_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::DEFAULT, ADDR_MOD_3, 0);  // store max
 
         // x = min(x, max_val) using LREG3
         TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_3, 0);
         TTI_SFPMOV(0, p_sfpu::LREG3, p_sfpu::LREG1, 0);
-        TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG0, 1);
+        TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG0, 1 /* smaller value to LREG0 */);
         TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_3, 0);  // store min
 
         sfpi::dst_reg++;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_hardtanh.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_hardtanh.h
@@ -5,20 +5,34 @@
 #pragma once
 
 #include "ckernel.h"
+#include "ckernel_defs.h"
 
 namespace ckernel::sfpu {
 
-template <bool APPROXIMATION_MODE, int ITERATIONS>
 // Hardtanh(x) = max_val if x > max_val, min_val if x < min_val, else x
+// Equivalent to: clamp(x, min_val, max_val) = min(max(x, min_val), max_val)
+template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void calculate_hardtanh(uint param0, uint param1) {
-    sfpi::vFloat min_val = Converter::as_float(param0);
-    sfpi::vFloat max_val = Converter::as_float(param1);
-    // SFPU microcode
+    // Load both params outside the loop for better performance
+    // param0 = min_val -> LREG2, param1 = max_val -> LREG3
+    TT_SFPLOADI(p_sfpu::LREG2, sfpi::SFPLOADI_MOD0_LOWER, param0 & 0xFFFF);
+    TT_SFPLOADI(p_sfpu::LREG2, sfpi::SFPLOADI_MOD0_UPPER, param0 >> 16);
+    TT_SFPLOADI(p_sfpu::LREG3, sfpi::SFPLOADI_MOD0_LOWER, param1 & 0xFFFF);
+    TT_SFPLOADI(p_sfpu::LREG3, sfpi::SFPLOADI_MOD0_UPPER, param1 >> 16);
+#pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
-        sfpi::vFloat val = sfpi::dst_reg[0];
-        v_if(val < min_val) { sfpi::dst_reg[0] = min_val; }
-        v_elseif(val > max_val) { sfpi::dst_reg[0] = max_val; }
-        v_endif;
+        // x = max(x, min_val) using LREG2
+        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_3, 0);
+        TTI_SFPMOV(0, p_sfpu::LREG2, p_sfpu::LREG1, 0);
+        TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG0, 1);
+        TTI_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::DEFAULT, ADDR_MOD_3, 0);  // store max
+
+        // x = min(x, max_val) using LREG3
+        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_3, 0);
+        TTI_SFPMOV(0, p_sfpu::LREG3, p_sfpu::LREG1, 0);
+        TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG0, 1);
+        TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_3, 0);  // store min
+
         sfpi::dst_reg++;
     }
 }


### PR DESCRIPTION
### Ticket
None

### Problem description
I noticed during PR reviews of other PRs that we have a lot of branching in SFPU code that could be avoided in some ways.
This is Part2 of PRs that will make changes in several SFPU ops to avoid branching.

This change was tested on Blackhole by @nmauriceTT. We saw an improvement of 483 -> 394 [~20% faster]

### What's changed
Use of TTI macros instead of `v_if`s.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/20025768257) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/20025781573) CI with demo tests passes (if applicable)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/runs/20025794147) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/runs/20025805797) CI passes (if applicable)