### PR TITLE
refactor: avoid branching in sfpu max/min using `sfpi::vec_min_max`

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_max.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_max.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2023 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -6,21 +6,24 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
-
-using namespace sfpi;
+#include "sfpi.h"
 
 namespace ckernel {
 namespace sfpu {
 
+// max(a, b) where a = dst_reg[0], b = dst_reg[32]
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void calculate_max() {
+#pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
-        vFloat a = dst_reg[0];
-        vFloat b = dst_reg[32];
-        v_if(a < b) { dst_reg[0] = b; }
-        v_endif;
+        sfpi::vFloat a = sfpi::dst_reg[0];
+        sfpi::vFloat b = sfpi::dst_reg[32];
 
-        dst_reg++;
+        // sfpi::vec_min_max puts min in first arg, max in second
+        sfpi::vec_min_max(a, b);  // After: a = min(a,b), b = max(a,b)
+        sfpi::dst_reg[0] = b;
+
+        sfpi::dst_reg++;
     }
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_min.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_min.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2023 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -6,21 +6,24 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
-
-using namespace sfpi;
+#include "sfpi.h"
 
 namespace ckernel {
 namespace sfpu {
 
+// min(a, b) where a = dst_reg[0], b = dst_reg[32]
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void calculate_min() {
+#pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
-        vFloat a = dst_reg[0];
-        vFloat b = dst_reg[32];
-        v_if(a > b) { dst_reg[0] = b; }
-        v_endif;
+        sfpi::vFloat a = sfpi::dst_reg[0];
+        sfpi::vFloat b = sfpi::dst_reg[32];
 
-        dst_reg++;
+        // sfpi::vec_min_max puts min in first arg, max in second
+        sfpi::vec_min_max(a, b);  // After: a = min(a,b), b = max(a,b)
+        sfpi::dst_reg[0] = a;
+
+        sfpi::dst_reg++;
     }
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_min.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_min.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2023 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -6,22 +6,24 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
-#include "noc_nonblocking_api.h"
-
-using namespace sfpi;
+#include "sfpi.h"
 
 namespace ckernel {
 namespace sfpu {
 
+// min(a, b) where a = dst_reg[0], b = dst_reg[32]
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void calculate_min() {
+#pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
-        vFloat a = dst_reg[0];
-        vFloat b = dst_reg[32];
-        v_if(a > b) { dst_reg[0] = b; }
-        v_endif;
+        sfpi::vFloat a = sfpi::dst_reg[0];
+        sfpi::vFloat b = sfpi::dst_reg[32];
 
-        dst_reg++;
+        // sfpi::vec_min_max puts min in first arg, max in second
+        sfpi::vec_min_max(a, b);  // After: a = min(a,b), b = max(a,b)
+        sfpi::dst_reg[0] = a;
+
+        sfpi::dst_reg++;
     }
 }
 


### PR DESCRIPTION
### Ticket
None

### Problem description
I noticed during PR reviews of other PRs that we have a lot of branching in SFPU code that could be avoided in some ways.
This is Part1 of PRs that will make changes in several SFPU ops to avoid branching.

### What's changed
Use of `sfpi::vec_min_max` instead of `v_if`s.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)