### PR TITLE
Override HF download for stable diffusion on BAPC

### DIFF
--- a/models/demos/wormhole/stable_diffusion/sd_helper_funcs.py
+++ b/models/demos/wormhole/stable_diffusion/sd_helper_funcs.py
@@ -281,6 +281,16 @@ SD_HF_DOWNLOAD_OVERRIDE = os.getenv("SD_HF_DOWNLOAD_OVERRIDE", "0") == "1"
 
 
 def sd_use_local_files_only(is_ci_env, is_ci_v2_env):
+    """
+    Determines whether to use local files only when loading Stable Diffusion v1.4 model.
+    By default, CI environments use locally cached files. Set SD_HF_DOWNLOAD_OVERRIDE=1
+    to force downloading from HuggingFace even in CI (useful when local cache is unavailable).
+    Args:
+        is_ci_env (bool): Whether running in CI environment.
+        is_ci_v2_env (bool): Whether running in CI V2 environment.
+    Returns:
+        bool: True if should use local files only, False if should download from HuggingFace.
+    """
     return (is_ci_env or is_ci_v2_env) and not SD_HF_DOWNLOAD_OVERRIDE
 
 

--- a/models/demos/wormhole/stable_diffusion/sd_helper_funcs.py
+++ b/models/demos/wormhole/stable_diffusion/sd_helper_funcs.py
@@ -2,6 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+import os
 import warnings
 from dataclasses import dataclass
 from typing import List, Optional, Tuple, Union
@@ -276,6 +277,11 @@ STABLE_DIFFUSION_V1_4_MODEL_LOCATION = "CompVis/stable-diffusion-v1-4"
 CLIP_VIT_LARGE_PATCH14_MODEL_LOCATION = "openai/clip-vit-large-patch14"
 STABLE_DIFFUSION_CIV2_MODEL_LOCATION = "stable-diffusion-v1-4"
 CLIP_VIT_LARGE_PATCH14_CIV2_MODEL_LOCATION = "clip-vit-large-patch14"
+SD_HF_DOWNLOAD_OVERRIDE = os.getenv("SD_HF_DOWNLOAD_OVERRIDE", "0") == "1"
+
+
+def sd_use_local_files_only(is_ci_env, is_ci_v2_env):
+    return (is_ci_env or is_ci_v2_env) and not SD_HF_DOWNLOAD_OVERRIDE
 
 
 def get_reference_vae(is_ci_env, is_ci_v2_env, model_location_generator):
@@ -285,7 +291,7 @@ def get_reference_vae(is_ci_env, is_ci_v2_env, model_location_generator):
     vae = AutoencoderKL.from_pretrained(
         STABLE_DIFFUSION_V1_4_MODEL_LOCATION if not is_ci_v2_env else model_location,
         subfolder="vae" if not is_ci_v2_env else None,
-        local_files_only=is_ci_env or is_ci_v2_env,
+        local_files_only=sd_use_local_files_only(is_ci_env, is_ci_v2_env),
         use_safetensors=True,
     )
     return vae.to("cpu")
@@ -298,7 +304,7 @@ def get_reference_unet(is_ci_env, is_ci_v2_env, model_location_generator):
     unet = UNet2DConditionModel.from_pretrained(
         STABLE_DIFFUSION_V1_4_MODEL_LOCATION if not is_ci_v2_env else model_location,
         subfolder="unet" if not is_ci_v2_env else None,
-        local_files_only=is_ci_env or is_ci_v2_env,
+        local_files_only=sd_use_local_files_only(is_ci_env, is_ci_v2_env),
         use_safetensors=True,
     )
     return unet.to("cpu")
@@ -310,7 +316,7 @@ def get_reference_clip_tokenizer(is_ci_env, is_ci_v2_env, model_location_generat
     )
     tokenizer = CLIPTokenizer.from_pretrained(
         CLIP_VIT_LARGE_PATCH14_MODEL_LOCATION if not is_ci_v2_env else model_location,
-        local_files_only=is_ci_env or is_ci_v2_env,
+        local_files_only=sd_use_local_files_only(is_ci_env, is_ci_v2_env),
         use_safetensors=True,
     )
     return tokenizer
@@ -322,7 +328,7 @@ def get_reference_clip_text_encoder(is_ci_env, is_ci_v2_env, model_location_gene
     )
     text_encoder = CLIPTextModel.from_pretrained(
         CLIP_VIT_LARGE_PATCH14_MODEL_LOCATION if not is_ci_v2_env else model_location,
-        local_files_only=is_ci_env or is_ci_v2_env,
+        local_files_only=sd_use_local_files_only(is_ci_env, is_ci_v2_env),
         use_safetensors=True,
     )
     return text_encoder
@@ -334,7 +340,7 @@ def get_reference_stable_diffusion_pipeline(is_ci_env, is_ci_v2_env, model_locat
     )
     pipeline = StableDiffusionPipeline.from_pretrained(
         STABLE_DIFFUSION_V1_4_MODEL_LOCATION if not is_ci_v2_env else model_location,
-        local_files_only=is_ci_env or is_ci_v2_env,
+        local_files_only=sd_use_local_files_only(is_ci_env, is_ci_v2_env),
         use_safetensors=True,
     )
     return pipeline.to("cpu")

--- a/tests/scripts/run_python_model_tests.sh
+++ b/tests/scripts/run_python_model_tests.sh
@@ -81,8 +81,7 @@ run_python_model_tests_slow_runtime_mode_wormhole_b0() {
 }
 
 run_python_model_tests_blackhole() {
-    # Removing until https://github.com/tenstorrent/tt-metal/issues/33906 is fixed
-    # pytest models/demos/blackhole/stable_diffusion/tests --ignore=models/demos/blackhole/stable_diffusion/tests/test_perf.py
+    SD_HF_DOWNLOAD_OVERRIDE=1 pytest models/demos/blackhole/stable_diffusion/tests --ignore=models/demos/blackhole/stable_diffusion/tests/test_perf.py
 
     # Llama3.1-8B
     llama8b=meta-llama/Llama-3.1-8B-Instruct


### PR DESCRIPTION
### Ticket
closes #33906

### Problem description
The Blackhole APC job doesn't have weka volume mounted and already cached SD weights
got cleaned up causing Stable diffusion to fail because the weight's aren't locally present

### What's changed
- added `SD_HF_DOWNLOAD_OVERRIDE` ENV variable check to override behavior of always expecting local files on CI
- added `SD_HF_DOWNLOAD_OVERRIDE` to blackhole APC job

### Checklist
- [X] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI [models unit tests pass P150](https://github.com/tenstorrent/tt-metal/actions/runs/20029192527/job/57434298287) | [models unit tests pass P100](https://github.com/tenstorrent/tt-metal/actions/runs/20039578836/job/57470467506)