### PR TITLE
[skip ci] bugfixing pipeline status tracker

### DIFF
--- a/.github/actions/analyze-workflow-data/analyze-workflow-data.js
+++ b/.github/actions/analyze-workflow-data/analyze-workflow-data.js
@@ -158,7 +158,7 @@ async function run() {
     core.info(`Loaded commits index entries: ${Array.isArray(commitsIndex) ? commitsIndex.length : 0}`);
 
     // Filter and process workflows (process all workflows since we only fetched runs for workflows we care about)
-    const { filteredGrouped, filteredPreviousGrouped, failedWorkflows } = filterWorkflowsByConfig(
+    let { filteredGrouped, filteredPreviousGrouped, failedWorkflows } = filterWorkflowsByConfig(
       grouped,
       previousGrouped,
       days
@@ -175,12 +175,84 @@ async function run() {
     // Optional: Build Slack-ready alert message for all failing workflows with owner mentions
     const alertAllMessage = await buildAlertMessage(filteredGrouped, failedWorkflows, alertAll, errorSnippetsCache);
 
+    // [TEST] Add fake regression to test Slack messaging when no failing jobs are found
+    const testWorkflowName = '.github/workflows/all-post-commit-workflows.yaml';
+    const now = new Date();
+    const yesterday = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+    const fakeFailingRunDate = new Date(now.getTime() + 60 * 1000); // 1 minute in future to ensure it's newest
+
+    // Ensure previous data has a successful run as latest
+    if (filteredPreviousGrouped) {
+      const prevRuns = filteredPreviousGrouped.get(testWorkflowName) || [];
+      const fakePrevSuccessRun = {
+        id: 999999997,
+        name: 'All Post-Commit Workflows',
+        head_branch: 'main',
+        head_sha: '0000000000000000000000000000000000000000',
+        path: testWorkflowName,
+        conclusion: 'success',
+        status: 'completed',
+        created_at: yesterday.toISOString(),
+        updated_at: yesterday.toISOString(),
+        run_attempt: 1
+      };
+      const updatedPrevRuns = [fakePrevSuccessRun, ...prevRuns];
+      filteredPreviousGrouped.set(testWorkflowName, updatedPrevRuns);
+      core.info(`[TEST] Added fake successful run to previous data for '${testWorkflowName}': ${updatedPrevRuns.length} total runs`);
+    } else {
+      // Create previous grouped if it doesn't exist
+      const fakePrevSuccessRun = {
+        id: 999999997,
+        name: 'All Post-Commit Workflows',
+        head_branch: 'main',
+        head_sha: '0000000000000000000000000000000000000000',
+        path: testWorkflowName,
+        conclusion: 'success',
+        status: 'completed',
+        created_at: yesterday.toISOString(),
+        updated_at: yesterday.toISOString(),
+        run_attempt: 1
+      };
+      filteredPreviousGrouped = new Map([[testWorkflowName, [fakePrevSuccessRun]]]);
+      core.info(`[TEST] Created previous grouped data with fake successful run for '${testWorkflowName}'`);
+    }
+
+    // Ensure current data has a failing run as latest
+    const currentRuns = filteredGrouped.get(testWorkflowName) || [];
+    const fakeFailingRun = {
+      id: 999999999,
+      name: 'All Post-Commit Workflows',
+      head_branch: 'main',
+      head_sha: '1111111111111111111111111111111111111111',
+      path: testWorkflowName,
+      conclusion: 'failure',
+      status: 'completed',
+      created_at: fakeFailingRunDate.toISOString(),
+      updated_at: fakeFailingRunDate.toISOString(),
+      run_attempt: 1
+    };
+    const updatedCurrentRuns = [fakeFailingRun, ...currentRuns];
+    filteredGrouped.set(testWorkflowName, updatedCurrentRuns);
+    core.info(`[TEST] Added fake failing run to current data for '${testWorkflowName}': ${updatedCurrentRuns.length} total runs (failing run date: ${fakeFailingRunDate.toISOString()})`);
+
+    // Log what we expect to see
+    const prevLatest = filteredPreviousGrouped.get(testWorkflowName)?.[0];
+    const currLatest = filteredGrouped.get(testWorkflowName)?.[0];
+    core.info(`[TEST] Previous latest run: ${prevLatest ? `id=${prevLatest.id}, conclusion=${prevLatest.conclusion}, date=${prevLatest.created_at}` : 'none'}`);
+    core.info(`[TEST] Current latest run: ${currLatest ? `id=${currLatest.id}, conclusion=${currLatest.conclusion}, date=${currLatest.created_at}` : 'none'}`);
+
     // Compute status changes vs previous and write JSON
     const { changes, regressedDetails, stayedFailingDetails } = computeStatusChanges(
       filteredGrouped,
       filteredPreviousGrouped,
       github.context
     );
+
+    // Log regression detection results
+    core.info(`[TEST] Regression detection results: ${regressedDetails.length} regressions found`);
+    for (const reg of regressedDetails) {
+      core.info(`[TEST]   - Regression: ${reg.name}, run_id=${reg.run_id}`);
+    }
 
     // Enrich regressions with first failing run within the window
     await enrichRegressions(regressedDetails, filteredGrouped, errorSnippetsCache, changes, github.context);

--- a/.github/actions/analyze-workflow-data/lib/error-processing.js
+++ b/.github/actions/analyze-workflow-data/lib/error-processing.js
@@ -430,9 +430,9 @@ async function fetchErrorSnippetsForRun(runId, maxSnippets = 50, logsDirPath = u
                   if (parts.length >= 2) {
                     const folderName = parts[1]; // e.g., "1_job-name" or "1_job-name.txt"
                     // Remove leading step number and underscore, then remove .txt suffix if present
-                    let jobName = folderName.replace(/^\d+_/, '').trim();
+                    let jobName = folderName.replace(/^\d+_/, '');
                     // Remove .txt extension if present (GitHub Actions sometimes includes it in folder names)
-                    jobName = jobName.replace(/\.txt$/i, '').trim();
+                    jobName = jobName.replace(/\.txt$/i, '');
                     // Replace " _ " (space-underscore-space) with " / " to match GitHub Actions job name format
                     jobName = jobName.replace(/\s+_\s+/g, ' / ').trim();
                     if (jobName) {

--- a/.github/actions/analyze-workflow-data/lib/error-processing.js
+++ b/.github/actions/analyze-workflow-data/lib/error-processing.js
@@ -410,7 +410,7 @@ async function fetchErrorSnippetsForRun(runId, maxSnippets = 50, logsDirPath = u
                   // Remove .txt suffix if present (shouldn't happen with API names, but be safe)
                   let cleanedName = jobName.trim().replace(/\.txt$/i, '').trim();
                   // Replace " _ " (space-underscore-space) with " / " to match GitHub Actions job name format
-                  cleanedName = cleanedName.replace(/\s+_\s+/g, ' / ').trim();
+                  cleanedName = cleanedName.replace(/\s+_\s+/g, ' / ');
                   if (cleanedName) {
                     jobNamesSet.add(cleanedName);
                   }

--- a/.github/actions/analyze-workflow-data/lib/error-processing.js
+++ b/.github/actions/analyze-workflow-data/lib/error-processing.js
@@ -385,8 +385,8 @@ async function fetchErrorSnippetsForRun(runId, maxSnippets = 50, logsDirPath = u
       core.warning(`Failed gtest log parsing for run ${runId}: ${e.message}`);
     }
 
-    // If other logs (non-gtest) are available for this run, extract job names from file names
-    // Don't parse the logs, just use the file names to determine job names
+    // If other logs (non-gtest) are available for this run, use job names from GitHub API
+    // Don't parse the logs, just use the stored job names from the API
     try {
       const otherLogsDir = getOtherLogsDirForRunId(runId);
       if (otherLogsDir && fs.existsSync(otherLogsDir)) {
@@ -401,25 +401,47 @@ async function fetchErrorSnippetsForRun(runId, maxSnippets = 50, logsDirPath = u
             // Continue to annotations
           }
           if (logsListData) {
-            const files = Array.isArray(logsListData.files) ? logsListData.files : [];
-            core.info(`[OTHER LOGS] Files detected: ${files.length}`);
-
-            // Extract job names from file paths (e.g., "extract/1_job-name/step.txt" -> "job-name")
-            const jobNamesSet = new Set();
-            for (const filePath of files) {
-              try {
-                // Parse the path to extract job name
-                // Expected format: extract/<step>_<job-name>/<file>.txt
-                const parts = filePath.split(path.sep);
-                if (parts.length >= 2) {
-                  const folderName = parts[1]; // e.g., "1_job-name"
-                  // Remove leading step number and underscore
-                  const jobName = folderName.replace(/^\d+_/, '').trim();
-                  if (jobName) {
-                    jobNamesSet.add(jobName);
+            // Use job names from GitHub API if available (preferred method)
+            let jobNamesSet = new Set();
+            if (Array.isArray(logsListData.job_names) && logsListData.job_names.length > 0) {
+              // Use actual job names from GitHub API
+              for (const jobName of logsListData.job_names) {
+                if (jobName && typeof jobName === 'string') {
+                  // Remove .txt suffix if present (shouldn't happen with API names, but be safe)
+                  let cleanedName = jobName.trim().replace(/\.txt$/i, '').trim();
+                  // Replace " _ " (space-underscore-space) with " / " to match GitHub Actions job name format
+                  cleanedName = cleanedName.replace(/\s+_\s+/g, ' / ').trim();
+                  if (cleanedName) {
+                    jobNamesSet.add(cleanedName);
                   }
                 }
-              } catch (_) { /* ignore */ }
+              }
+              core.info(`[OTHER LOGS] Using ${jobNamesSet.size} job name(s) from GitHub API for run ${runId}`);
+            } else {
+              // Fallback: extract job names from file paths (legacy method, less reliable)
+              const files = Array.isArray(logsListData.files) ? logsListData.files : [];
+              core.info(`[OTHER LOGS] No API job names found, falling back to file path extraction: ${files.length} files`);
+              for (const filePath of files) {
+                try {
+                  // Parse the path to extract job name
+                  // Expected format: extract/<step>_<job-name>/<file>.txt
+                  // Note: GitHub Actions folder names sometimes include .txt suffix, sometimes not
+                  const parts = filePath.split(path.sep);
+                  if (parts.length >= 2) {
+                    const folderName = parts[1]; // e.g., "1_job-name" or "1_job-name.txt"
+                    // Remove leading step number and underscore, then remove .txt suffix if present
+                    let jobName = folderName.replace(/^\d+_/, '').trim();
+                    // Remove .txt extension if present (GitHub Actions sometimes includes it in folder names)
+                    jobName = jobName.replace(/\.txt$/i, '').trim();
+                    // Replace " _ " (space-underscore-space) with " / " to match GitHub Actions job name format
+                    jobName = jobName.replace(/\s+_\s+/g, ' / ').trim();
+                    if (jobName) {
+                      jobNamesSet.add(jobName);
+                    }
+                  }
+                } catch (_) { /* ignore */ }
+              }
+              core.info(`[OTHER LOGS] Extracted ${jobNamesSet.size} job name(s) from file paths for run ${runId}`);
             }
 
             // Create snippets with job names, but blank test and informative error message
@@ -441,7 +463,7 @@ async function fetchErrorSnippetsForRun(runId, maxSnippets = 50, logsDirPath = u
               snippets = filterGenericExitSnippets(snippets);
               return snippets;
             } else {
-              core.info(`[OTHER LOGS] No job names extracted from logs for run ${runId}`);
+              core.info(`[OTHER LOGS] No job names found for run ${runId}`);
             }
           }
         }

--- a/.github/actions/fetch-workflow-data/fetch-workflow-data.js
+++ b/.github/actions/fetch-workflow-data/fetch-workflow-data.js
@@ -121,32 +121,6 @@ async function run() {
       }
     }
 
-    // Add fake regression runs to a real workflow (for testing Slack messaging when no failing jobs are found)
-    // This ensures it appears in both current and previous data, making it detectable as a regression
-    // Using a real workflow name so the workflow itself is valid, but with fake runs
-    const testWorkflowNameCached = '.github/workflows/all-post-commit-workflows.yaml';
-    const yesterdayCached = new Date(Date.now() - 24 * 60 * 60 * 1000);
-
-    // Ensure cached data has a successful run as the latest (for regression detection)
-    const existingCachedRuns = cachedGrouped.get(testWorkflowNameCached) || [];
-    const fakeSuccessfulRun = {
-      id: 999999997,
-      name: 'All Post-Commit Workflows',
-      head_branch: 'main',
-      head_sha: '0000000000000000000000000000000000000000',
-      path: testWorkflowNameCached,
-      conclusion: 'success',
-      status: 'completed',
-      created_at: yesterdayCached.toISOString(),
-      updated_at: yesterdayCached.toISOString(),
-      run_attempt: 1
-    };
-
-    // Prepend fake successful run to ensure it's the latest (newest date)
-    // This ensures previous state shows as 'success' for regression detection
-    const updatedCachedRuns = [fakeSuccessfulRun, ...existingCachedRuns];
-    cachedGrouped.set(testWorkflowNameCached, updatedCachedRuns);
-    core.info(`[TEST] Added fake successful run to cached data for workflow: '${testWorkflowNameCached}' (prepended to ${existingCachedRuns.length} existing runs)`);
 
     // Convert cached grouped map to array of runs for merging
     for (const runs of cachedGrouped.values()) {
@@ -204,51 +178,6 @@ async function run() {
       fs.mkdirSync(outputDir, { recursive: true });
     }
 
-    // Add fake regression runs to a real workflow (for testing Slack messaging when no failing jobs are found)
-    // Using a real workflow name so the workflow itself is valid, but injecting fake runs to create a regression
-    const testWorkflowNameCurrent = '.github/workflows/all-post-commit-workflows.yaml';
-    const now = new Date();
-    const yesterdayCurrent = new Date(now.getTime() - 24 * 60 * 60 * 1000);
-    // Use a date slightly in the future to ensure fake failing run is always the most recent
-    const fakeFailingRunDate = new Date(now.getTime() + 60 * 1000); // 1 minute in the future
-
-    // Get existing runs for this workflow, or create empty array
-    const existingRuns = grouped.get(testWorkflowNameCurrent) || [];
-
-    // Add fake runs: one successful (yesterday) and one failing (slightly in future to ensure it's newest)
-    // Use high IDs to avoid conflicts with real runs
-    const fakeRuns = [
-      {
-        id: 999999998,
-        name: 'All Post-Commit Workflows',
-        head_branch: 'main',
-        head_sha: '0000000000000000000000000000000000000000',
-        path: testWorkflowNameCurrent,
-        conclusion: 'success',
-        status: 'completed',
-        created_at: yesterdayCurrent.toISOString(),
-        updated_at: yesterdayCurrent.toISOString(),
-        run_attempt: 1
-      },
-      {
-        id: 999999999,
-        name: 'All Post-Commit Workflows',
-        head_branch: 'main',
-        head_sha: '1111111111111111111111111111111111111111',
-        path: testWorkflowNameCurrent,
-        conclusion: 'failure',
-        status: 'completed',
-        created_at: fakeFailingRunDate.toISOString(),
-        updated_at: fakeFailingRunDate.toISOString(),
-        run_attempt: 1
-      }
-    ];
-
-    // Merge fake runs with existing runs (fake runs first, then existing)
-    // The fake failing run will be sorted to the top by computeLatestConclusion since it has the newest date
-    const testMergedRuns = [...fakeRuns, ...existingRuns];
-    grouped.set(testWorkflowNameCurrent, testMergedRuns);
-    core.info(`[TEST] Added fake regression runs to real workflow '${testWorkflowNameCurrent}' (${fakeRuns.length} fake runs + ${existingRuns.length} existing runs, failing run date: ${fakeFailingRunDate.toISOString()})`);
 
     // Save grouped runs to artifact file
     fs.writeFileSync(outputPath, JSON.stringify(Array.from(grouped.entries())));

--- a/.github/actions/fetch-workflow-data/fetch-workflow-data.js
+++ b/.github/actions/fetch-workflow-data/fetch-workflow-data.js
@@ -126,25 +126,27 @@ async function run() {
     // Using a real workflow name so the workflow itself is valid, but with fake runs
     const testWorkflowNameCached = '.github/workflows/all-post-commit-workflows.yaml';
     const yesterdayCached = new Date(Date.now() - 24 * 60 * 60 * 1000);
-    // Only add to cached if it doesn't already exist (to avoid overwriting real data)
-    if (!cachedGrouped.has(testWorkflowNameCached)) {
-      const fakeCachedRuns = [
-        {
-          id: 999999997,
-          name: 'All Post-Commit Workflows',
-          head_branch: 'main',
-          head_sha: '0000000000000000000000000000000000000000',
-          path: testWorkflowNameCached,
-          conclusion: 'success',
-          status: 'completed',
-          created_at: yesterdayCached.toISOString(),
-          updated_at: yesterdayCached.toISOString(),
-          run_attempt: 1
-        }
-      ];
-      cachedGrouped.set(testWorkflowNameCached, fakeCachedRuns);
-      core.info(`[TEST] Added fake successful run to cached data for workflow: '${testWorkflowNameCached}'`);
-    }
+
+    // Ensure cached data has a successful run as the latest (for regression detection)
+    const existingCachedRuns = cachedGrouped.get(testWorkflowNameCached) || [];
+    const fakeSuccessfulRun = {
+      id: 999999997,
+      name: 'All Post-Commit Workflows',
+      head_branch: 'main',
+      head_sha: '0000000000000000000000000000000000000000',
+      path: testWorkflowNameCached,
+      conclusion: 'success',
+      status: 'completed',
+      created_at: yesterdayCached.toISOString(),
+      updated_at: yesterdayCached.toISOString(),
+      run_attempt: 1
+    };
+
+    // Prepend fake successful run to ensure it's the latest (newest date)
+    // This ensures previous state shows as 'success' for regression detection
+    const updatedCachedRuns = [fakeSuccessfulRun, ...existingCachedRuns];
+    cachedGrouped.set(testWorkflowNameCached, updatedCachedRuns);
+    core.info(`[TEST] Added fake successful run to cached data for workflow: '${testWorkflowNameCached}' (prepended to ${existingCachedRuns.length} existing runs)`);
 
     // Convert cached grouped map to array of runs for merging
     for (const runs of cachedGrouped.values()) {
@@ -207,11 +209,13 @@ async function run() {
     const testWorkflowNameCurrent = '.github/workflows/all-post-commit-workflows.yaml';
     const now = new Date();
     const yesterdayCurrent = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+    // Use a date slightly in the future to ensure fake failing run is always the most recent
+    const fakeFailingRunDate = new Date(now.getTime() + 60 * 1000); // 1 minute in the future
 
     // Get existing runs for this workflow, or create empty array
     const existingRuns = grouped.get(testWorkflowNameCurrent) || [];
 
-    // Add fake runs: one successful (yesterday) and one failing (now)
+    // Add fake runs: one successful (yesterday) and one failing (slightly in future to ensure it's newest)
     // Use high IDs to avoid conflicts with real runs
     const fakeRuns = [
       {
@@ -234,16 +238,17 @@ async function run() {
         path: testWorkflowNameCurrent,
         conclusion: 'failure',
         status: 'completed',
-        created_at: now.toISOString(),
-        updated_at: now.toISOString(),
+        created_at: fakeFailingRunDate.toISOString(),
+        updated_at: fakeFailingRunDate.toISOString(),
         run_attempt: 1
       }
     ];
 
     // Merge fake runs with existing runs (fake runs first, then existing)
+    // The fake failing run will be sorted to the top by computeLatestConclusion since it has the newest date
     const testMergedRuns = [...fakeRuns, ...existingRuns];
     grouped.set(testWorkflowNameCurrent, testMergedRuns);
-    core.info(`[TEST] Added fake regression runs to real workflow '${testWorkflowNameCurrent}' (${fakeRuns.length} fake runs + ${existingRuns.length} existing runs)`);
+    core.info(`[TEST] Added fake regression runs to real workflow '${testWorkflowNameCurrent}' (${fakeRuns.length} fake runs + ${existingRuns.length} existing runs, failing run date: ${fakeFailingRunDate.toISOString()})`);
 
     // Save grouped runs to artifact file
     fs.writeFileSync(outputPath, JSON.stringify(Array.from(grouped.entries())));

--- a/.github/actions/fetch-workflow-data/lib/logs.js
+++ b/.github/actions/fetch-workflow-data/lib/logs.js
@@ -314,7 +314,7 @@ async function processWorkflowLogs(grouped, branch, workspace, cachedAnnotations
           core.info(`[LOGS] Downloaded and indexed gtest logs for run ${targetRun.id} → ${jobsIndex.jobs.length} job(s), ${jobsIndex.jobs.reduce((sum, j) => sum + (j.files || []).length, 0)} files`);
         } else if (!sawAnyFailureAnnotations || annotationsFetchFailed) {
           // Download other logs (non-gtest failures with no annotations, or if annotation fetch failed entirely)
-          // Just download and list files, no detailed indexing
+          // Store actual job names from GitHub API instead of extracting from file paths
           const runLogsZip = await octokit.rest.actions.downloadWorkflowRunLogs({ owner, repo, run_id: targetRun.id });
           const runDir = path.join(otherLogsRoot, String(targetRun.id));
           if (!fs.existsSync(runDir)) fs.mkdirSync(runDir, { recursive: true });
@@ -324,6 +324,25 @@ async function processWorkflowLogs(grouped, branch, workspace, cachedAnnotations
           if (!fs.existsSync(extractDir)) fs.mkdirSync(extractDir, { recursive: true });
           // Extract quietly to avoid ENOBUFS
           execFileSync('unzip', ['-o', zipPath, '-d', extractDir], { stdio: 'ignore' });
+
+          // Fetch actual job names from GitHub API (jobs were already fetched earlier, reuse them)
+          const failingJobNames = new Set();
+          try {
+            // Get jobs for this run - filter for failed jobs
+            const jobsResp = await octokit.rest.actions.listJobsForWorkflowRun({ owner, repo, run_id: targetRun.id, per_page: 100 });
+            const jobs = Array.isArray(jobsResp.data.jobs) ? jobsResp.data.jobs : [];
+            for (const job of jobs) {
+              // Include jobs that failed (conclusion is 'failure' or 'cancelled')
+              const conclusion = (job.conclusion || '').toLowerCase();
+              if (conclusion === 'failure' || conclusion === 'cancelled') {
+                if (job.name) {
+                  failingJobNames.add(String(job.name));
+                }
+              }
+            }
+          } catch (e) {
+            core.warning(`Failed to fetch job names from API for run ${targetRun.id}: ${e.message}`);
+          }
 
           // Build a simple index of all .txt log files (no parsing, just list files)
           const logFiles = [];
@@ -341,11 +360,15 @@ async function processWorkflowLogs(grouped, branch, workspace, cachedAnnotations
               }
             }
           }
+          // Store both file list and actual job names from GitHub API
           const logsListPath = path.join(runDir, 'logs-list.json');
-          fs.writeFileSync(logsListPath, JSON.stringify({ files: logFiles }));
+          fs.writeFileSync(logsListPath, JSON.stringify({
+            files: logFiles,
+            job_names: Array.from(failingJobNames)
+          }));
           const relativeRunDir = path.relative(workspace, runDir) || runDir;
           otherLogsIndex[String(targetRun.id)] = relativeRunDir;
-          core.info(`[LOGS] Downloaded other logs for run ${targetRun.id} → ${logFiles.length} file(s)`);
+          core.info(`[LOGS] Downloaded other logs for run ${targetRun.id} → ${logFiles.length} file(s), ${failingJobNames.size} failing job(s)`);
         }
       } catch (e) {
         core.warning(`Failed to download/index logs for run ${targetRun.id}: ${e.message}`);

--- a/.github/actions/fetch-workflow-data/lib/logs.js
+++ b/.github/actions/fetch-workflow-data/lib/logs.js
@@ -343,7 +343,8 @@ async function processWorkflowLogs(grouped, branch, workspace, cachedAnnotations
                   }
                 }
               }
-              hasMore = jobs.length === 100;
+              // Continue if we got a full page (might have more), stop if we got fewer
+              hasMore = jobs.length >= 100;
               page++;
             }
           } catch (e) {

--- a/.github/actions/fetch-workflow-data/lib/logs.js
+++ b/.github/actions/fetch-workflow-data/lib/logs.js
@@ -325,7 +325,7 @@ async function processWorkflowLogs(grouped, branch, workspace, cachedAnnotations
           // Extract quietly to avoid ENOBUFS
           execFileSync('unzip', ['-o', zipPath, '-d', extractDir], { stdio: 'ignore' });
 
-          // Fetch actual job names from GitHub API (jobs were already fetched earlier, reuse them)
+          // Fetch all failing job names from GitHub API with pagination (separate fetch to ensure all jobs are captured)
           const failingJobNames = new Set();
           try {
             // Get jobs for this run - filter for failed jobs, handle pagination

--- a/.github/actions/trigger-auto-triage-for-regressions/action.yml
+++ b/.github/actions/trigger-auto-triage-for-regressions/action.yml
@@ -10,6 +10,12 @@ inputs:
   slack_ts:
     description: 'Slack message timestamp for threading replies'
     required: false
+  slack_channel_id:
+    description: 'Slack channel ID for sending notifications'
+    required: false
+  slack_bot_token:
+    description: 'Slack bot token for sending messages'
+    required: false
 
 runs:
   using: 'node20'

--- a/.github/actions/trigger-auto-triage-for-regressions/index.js
+++ b/.github/actions/trigger-auto-triage-for-regressions/index.js
@@ -38,7 +38,7 @@ async function sendSlackMessage(channelId, botToken, message, threadTs) {
       res.on('end', () => {
         try {
           const response = JSON.parse(data);
-          if (res.statusCode >= 200 && res.statusCode < 300 && response.ok !== false) {
+          if (res.statusCode >= 200 && res.statusCode < 300 && response.ok === true) {
             core.info(`✓ Successfully sent Slack message`);
             resolve();
           } else {

--- a/.github/actions/trigger-auto-triage-for-regressions/index.js
+++ b/.github/actions/trigger-auto-triage-for-regressions/index.js
@@ -1,11 +1,69 @@
 const core = require('@actions/core');
 const github = require('@actions/github');
+const https = require('https');
+
+/**
+ * Send a Slack message to a thread
+ * @param {string} channelId - Slack channel ID
+ * @param {string} botToken - Slack bot token
+ * @param {string} message - Message text to send
+ * @param {string} threadTs - Thread timestamp to reply to
+ * @returns {Promise<void>}
+ */
+async function sendSlackMessage(channelId, botToken, message, threadTs) {
+  return new Promise((resolve, reject) => {
+    const payload = JSON.stringify({
+      channel: channelId,
+      text: message,
+      thread_ts: threadTs
+    });
+
+    const options = {
+      hostname: 'slack.com',
+      port: 443,
+      path: '/api/chat.postMessage',
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${botToken}`,
+        'Content-Length': Buffer.byteLength(payload)
+      }
+    };
+
+    const req = https.request(options, (res) => {
+      let data = '';
+      res.on('data', (chunk) => {
+        data += chunk;
+      });
+      res.on('end', () => {
+        if (res.statusCode >= 200 && res.statusCode < 300) {
+          core.info(`✓ Successfully sent Slack message`);
+          resolve();
+        } else {
+          const error = new Error(`Slack API error: ${res.statusCode} - ${data}`);
+          core.warning(`Failed to send Slack message: ${error.message}`);
+          reject(error);
+        }
+      });
+    });
+
+    req.on('error', (error) => {
+      core.warning(`Failed to send Slack message: ${error.message}`);
+      reject(error);
+    });
+
+    req.write(payload);
+    req.end();
+  });
+}
 
 async function run() {
   try {
     const regressedWorkflowsJson = core.getInput('regressed_workflows', { required: true });
     const githubToken = core.getInput('github_token', { required: true });
     const slackTs = core.getInput('slack_ts') || '';
+    const slackChannelId = core.getInput('slack_channel_id') || '';
+    const slackBotToken = core.getInput('slack_bot_token') || '';
 
     const regressedWorkflows = JSON.parse(regressedWorkflowsJson);
     const octokit = github.getOctokit(githubToken);
@@ -29,6 +87,17 @@ async function run() {
 
       if (failingJobs.length === 0) {
         core.warning(`No failing jobs found for workflow: ${workflowFileName}`);
+
+        // Send Slack notification if credentials are available
+        if (slackTs && slackChannelId && slackBotToken) {
+          try {
+            const message = `⚠️ Failed to find failing jobs for workflow: \`${workflowFileName}\``;
+            await sendSlackMessage(slackChannelId, slackBotToken, message, slackTs);
+          } catch (error) {
+            // Log but don't fail the workflow if Slack message fails
+            core.warning(`Failed to send Slack notification: ${error.message}`);
+          }
+        }
         continue;
       }
 

--- a/.github/workflows/aggregate-workflow-data.yaml
+++ b/.github/workflows/aggregate-workflow-data.yaml
@@ -265,21 +265,23 @@ jobs:
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 
-  # trigger-auto-triage:
-  #   needs: [analyze-data, handle-failures]
-  #   if: ${{ always() && needs.analyze-data.result == 'success' && fromJson(needs.analyze-data.outputs.regressed_workflows) != '[]' }}
-  #   runs-on: ubuntu-latest
-  #   permissions:
-  #     actions: write
-  #     contents: read
-  #   steps:
-  #     - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 #@v3
-  #     - name: Install dependencies
-  #       working-directory: .github/actions/trigger-auto-triage-for-regressions
-  #       run: npm install
-  #     - name: Trigger auto-triage for regressed jobs
-  #       uses: ./.github/actions/trigger-auto-triage-for-regressions
-  #       with:
-  #         regressed_workflows: ${{ needs.analyze-data.outputs.regressed_workflows }}
-  #         github_token: ${{ secrets.GITHUB_TOKEN }}
-  #         slack_ts: ${{ needs.handle-failures.outputs.slack_ts }}
+  trigger-auto-triage:
+    needs: [analyze-data, handle-failures]
+    if: ${{ always() && needs.analyze-data.result == 'success' && fromJson(needs.analyze-data.outputs.regressed_workflows) != '[]' }}
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
+    steps:
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 #@v3
+      - name: Install dependencies
+        working-directory: .github/actions/trigger-auto-triage-for-regressions
+        run: npm install
+      - name: Trigger auto-triage for regressed jobs
+        uses: ./.github/actions/trigger-auto-triage-for-regressions
+        with:
+          regressed_workflows: ${{ needs.analyze-data.outputs.regressed_workflows }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          slack_ts: ${{ needs.handle-failures.outputs.slack_ts }}
+          slack_channel_id: ${{ secrets.SLACK_TESTING_CHANNEL_ID }}
+          slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/aggregate-workflow-data.yaml
+++ b/.github/workflows/aggregate-workflow-data.yaml
@@ -259,7 +259,7 @@ jobs:
         id: slack-report
         uses: ./.github/actions/slack-report-analyze-workflow-data
         with:
-          channel_id: ${{ secrets.SLACK_TESTING_CHANNEL_ID }}
+          channel_id: ${{ secrets.SLACK_METAL_INFRA_CHANNEL_ID }}
           regressed_workflows: ${{ needs.analyze-data.outputs.regressed_workflows }}
           alert_all_message: ${{ needs.analyze-data.outputs.alert_all_message }}
         env:
@@ -283,5 +283,5 @@ jobs:
           regressed_workflows: ${{ needs.analyze-data.outputs.regressed_workflows }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           slack_ts: ${{ needs.handle-failures.outputs.slack_ts }}
-          slack_channel_id: ${{ secrets.SLACK_TESTING_CHANNEL_ID }}
+          slack_channel_id: ${{ secrets.SLACK_METAL_INFRA_CHANNEL_ID }}
           slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/aggregate-workflow-data.yaml
+++ b/.github/workflows/aggregate-workflow-data.yaml
@@ -259,27 +259,27 @@ jobs:
         id: slack-report
         uses: ./.github/actions/slack-report-analyze-workflow-data
         with:
-          channel_id: ${{ secrets.SLACK_METAL_INFRA_CHANNEL_ID }}
+          channel_id: ${{ secrets.SLACK_TESTING_CHANNEL_ID }}
           regressed_workflows: ${{ needs.analyze-data.outputs.regressed_workflows }}
           alert_all_message: ${{ needs.analyze-data.outputs.alert_all_message }}
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 
-  trigger-auto-triage:
-    needs: [analyze-data, handle-failures]
-    if: ${{ always() && needs.analyze-data.result == 'success' && fromJson(needs.analyze-data.outputs.regressed_workflows) != '[]' }}
-    runs-on: ubuntu-latest
-    permissions:
-      actions: write
-      contents: read
-    steps:
-      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 #@v3
-      - name: Install dependencies
-        working-directory: .github/actions/trigger-auto-triage-for-regressions
-        run: npm install
-      - name: Trigger auto-triage for regressed jobs
-        uses: ./.github/actions/trigger-auto-triage-for-regressions
-        with:
-          regressed_workflows: ${{ needs.analyze-data.outputs.regressed_workflows }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          slack_ts: ${{ needs.handle-failures.outputs.slack_ts }}
+  # trigger-auto-triage:
+  #   needs: [analyze-data, handle-failures]
+  #   if: ${{ always() && needs.analyze-data.result == 'success' && fromJson(needs.analyze-data.outputs.regressed_workflows) != '[]' }}
+  #   runs-on: ubuntu-latest
+  #   permissions:
+  #     actions: write
+  #     contents: read
+  #   steps:
+  #     - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 #@v3
+  #     - name: Install dependencies
+  #       working-directory: .github/actions/trigger-auto-triage-for-regressions
+  #       run: npm install
+  #     - name: Trigger auto-triage for regressed jobs
+  #       uses: ./.github/actions/trigger-auto-triage-for-regressions
+  #       with:
+  #         regressed_workflows: ${{ needs.analyze-data.outputs.regressed_workflows }}
+  #         github_token: ${{ secrets.GITHUB_TOKEN }}
+  #         slack_ts: ${{ needs.handle-failures.outputs.slack_ts }}


### PR DESCRIPTION
### Ticket
Didn't make one this time ._.

### Problem description
sometimes the job names were messed up because the status tracker had to use the names of the logs, which would often have .txt appended to them and/or have " _ " in the name when the github api uses " / " instead. This would mess up the auto-triage job because it wouldn't know what the job was. Also, sometimes when the job wasn't found at all, the auto-triage step within the pipeline status tracker would fail because it wouldn't have a job to pass in, and so no slack message would be sent in the infra channel.

### What's changed
All of these bugs have been addressed by cleaning up the log names (removing .txt and replacing / with _), defaulting to using the github api to get job names directly as opposed to looking at logs (and only looking at logs if the api fails), and adding logic within the auto-triage step to send a slack message in a thread informing when the auto-triage step has failed due to a job not being found.

### Checklist
- [x] [Aggregate Workflow Data](https://github.com/tenstorrent/tt-metal/actions/workflows/aggregate-workflow-data.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/20030242906
- [x] [Aggregate Workflow Data](https://github.com/tenstorrent/tt-metal/actions/workflows/aggregate-workflow-data.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/20031303573
