### PR TITLE
#0: Fix test_distributed_layernorm_pre_allgather.py 

### DIFF
--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_pre_all_gather_2d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_pre_all_gather_2d_program_factory.cpp
@@ -52,6 +52,7 @@ LayerNormPreAllGather2DProgramFactory::cached_program_t LayerNormPreAllGather2DP
     using namespace CMAKE_UNIQUE_NAMESPACE;
 
     const auto& a = tensor_args.input;
+    const bool is_rmsnorm = operation_attributes.norm_type == LayerNormDistributedType::RMSNORM;
     const auto& shape = a.padded_shape();
     const uint32_t W = shape[-1], H = shape[-2];
     const uint32_t HW = H * W;
@@ -86,7 +87,7 @@ LayerNormPreAllGather2DProgramFactory::cached_program_t LayerNormPreAllGather2DP
     const uint32_t in1_tiles = 1;  // reduce scalar
 
     const uint32_t intermed0_tiles = Wt * double_buffer_constant;  // xˆ2
-    uint32_t out0_tiles = 1;
+    uint32_t out0_tiles = is_rmsnorm ? 1 : 2;
 
     TT_FATAL(
         W <= TILE_WIDTH * in0_tiles,

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_pre_all_gather_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_pre_all_gather_program_factory.cpp
@@ -88,7 +88,7 @@ LayerNormPreAllGatherProgramFactory::cached_program_t LayerNormPreAllGatherProgr
     const uint32_t in1_tiles = 1;  // reduce scalar
 
     const uint32_t intermed0_tiles = Wt * double_buffer_constant;  // xˆ2
-    uint32_t out0_tiles = 1;
+    uint32_t out0_tiles = is_rmsnorm ? 1 : 2;
 
     TT_FATAL(
         W <= TILE_WIDTH * in0_tiles,


### PR DESCRIPTION
### Ticket
N/A

### Problem description
[test_distributed_layernorm_pre_allgather.py](https://github.com/tenstorrent/tt-metal/actions/runs/20018364147/job/57400633440) was failing due to getting an output tensor full of 0s

### What's changed

- Added logic for out tiles that was omitted during the migration to TMP infra

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passesv([link to run](https://github.com/tenstorrent/tt-metal/actions/runs/20038225099))
- [x] L2 nightly SDXL and BOS tests ([link to run](https://github.com/tenstorrent/tt-metal/actions/runs/20038255476))
- [x] L2 nightly cpp tests ([link to run](https://github.com/tenstorrent/tt-metal/actions/runs/20038255476))
- [x] New/Existing tests provide coverage for changes