### PR TITLE
Const qualify global pointers

### DIFF
--- a/tt_metal/hw/firmware/src/tt-1xx/brisck.cc
+++ b/tt_metal/hw/firmware/src/tt-1xx/brisck.cc
@@ -24,18 +24,25 @@
 #endif
 
 namespace ckernel {
-volatile tt_reg_ptr uint* regfile = reinterpret_cast<volatile uint*>(REGFILE_BASE);
-volatile tt_reg_ptr uint* pc_buf_base = reinterpret_cast<volatile uint*>(PC_BUF_BASE);
+// Transition shim
+#if defined(__PTR_CONST)
+#define PTR_CONST const
+#else
+#define PTR_CONST
+#endif
+volatile tt_reg_ptr uint* PTR_CONST regfile = reinterpret_cast<volatile uint*>(REGFILE_BASE);
+volatile tt_reg_ptr uint* PTR_CONST pc_buf_base = reinterpret_cast<volatile uint*>(PC_BUF_BASE);
 
 // There are 16 mailboxes within each Tensix tile, one from each of RISCV (B, T0, T1, T2) to each of RISCV (B, T0, T1,
 // T2). Note that there are no mailboxes to or from RISCV NC. The 16 mailboxes are referenced using 4 particular address
 // ranges starting from bases listed below. Which particular mailbox is being referenced depends on the address, the
 // issuing RISCV, and whether the access is a read or a write.
-volatile tt_reg_ptr uint* mailbox_base[4] = {
+volatile tt_reg_ptr uint* PTR_CONST mailbox_base[4] = {
     reinterpret_cast<volatile uint tt_reg_ptr*>(TENSIX_MAILBOX0_BASE),
     reinterpret_cast<volatile uint tt_reg_ptr*>(TENSIX_MAILBOX1_BASE),
     reinterpret_cast<volatile uint tt_reg_ptr*>(TENSIX_MAILBOX2_BASE),
     reinterpret_cast<volatile uint tt_reg_ptr*>(TENSIX_MAILBOX3_BASE)};
+#undef PTR_CONST
 }  // namespace ckernel
 
 extern "C" [[gnu::section(".start")]]

--- a/tt_metal/hw/firmware/src/tt-1xx/trisc.cc
+++ b/tt_metal/hw/firmware/src/tt-1xx/trisc.cc
@@ -42,11 +42,16 @@ uint8_t my_relative_y_ __attribute__((used));
 namespace ckernel {
 
 enum class ttRiscCores : std::uint32_t { Unpack = 0, Math = 1, Pack = 2, Brisc = 3, Nrisc = 4 };
-
-volatile tt_reg_ptr uint* reg_base = reinterpret_cast<volatile uint*>(0xFFB10000);
-volatile tt_reg_ptr uint* pc_buf_base = reinterpret_cast<volatile uint*>(PC_BUF_BASE);
-volatile tt_reg_ptr uint* regfile = reinterpret_cast<volatile uint*>(REGFILE_BASE);
-tt_reg_ptr uint* regmem = reinterpret_cast<tt_reg_ptr uint*>(REGFILE_BASE);
+// Transition shim
+#if defined(__PTR_CONST)
+#define PTR_CONST const
+#else
+#define PTR_CONST
+#endif
+volatile tt_reg_ptr uint* PTR_CONST reg_base = reinterpret_cast<volatile uint*>(0xFFB10000);
+volatile tt_reg_ptr uint* PTR_CONST pc_buf_base = reinterpret_cast<volatile uint*>(PC_BUF_BASE);
+volatile tt_reg_ptr uint* PTR_CONST regfile = reinterpret_cast<volatile uint*>(REGFILE_BASE);
+#undef PTR_CONST
 
 uint32_t cfg_state_id __attribute__((used)) = 0;    // Flip between 0 and 1 to keep state between kernel calls
 uint32_t dest_offset_id __attribute__((used)) = 0;  // Flip between 0 and 1 to keep dest pointer between kernel calls

--- a/tt_metal/hw/firmware/src/tt-1xx/trisck.cc
+++ b/tt_metal/hw/firmware/src/tt-1xx/trisck.cc
@@ -27,13 +27,20 @@ uint32_t gl_alu_format_spec_reg = 0;
 uint32_t op_info_offset = 0;
 
 namespace ckernel {
-volatile tt_reg_ptr uint* regfile = reinterpret_cast<volatile uint*>(REGFILE_BASE);
-volatile tt_reg_ptr uint* pc_buf_base = reinterpret_cast<volatile uint*>(PC_BUF_BASE);
-volatile tt_reg_ptr uint* mailbox_base[4] = {
+// Transition shim
+#if defined(__PTR_CONST)
+#define PTR_CONST const
+#else
+#define PTR_CONST
+#endif
+volatile tt_reg_ptr uint* PTR_CONST regfile = reinterpret_cast<volatile uint*>(REGFILE_BASE);
+volatile tt_reg_ptr uint* PTR_CONST pc_buf_base = reinterpret_cast<volatile uint*>(PC_BUF_BASE);
+volatile tt_reg_ptr uint* PTR_CONST mailbox_base[4] = {
     reinterpret_cast<volatile uint tt_reg_ptr*>(TENSIX_MAILBOX0_BASE),
     reinterpret_cast<volatile uint tt_reg_ptr*>(TENSIX_MAILBOX1_BASE),
     reinterpret_cast<volatile uint tt_reg_ptr*>(TENSIX_MAILBOX2_BASE),
     reinterpret_cast<volatile uint tt_reg_ptr*>(TENSIX_MAILBOX3_BASE)};
+#undef PTR_CONST
 }  // namespace ckernel
 
 extern "C" [[gnu::section(".start")]]


### PR DESCRIPTION
### Ticket
NA

### Problem description
tt-llk declares some global pointers that should be marked const.
The pointers are defined in tt-metal, which is awkward.

### What's changed
tt-llk temporarily defines __PTR_CONST to indicate it's declaring them const.  Adjus the definitions to use const as appropriate.  When both metal and llk are updated we can remove this shim.

### Checklist
- [YES] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [YES] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] [cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) job passes
- [ ] New/Existing tests provide coverage for changes