### PR TITLE
Add TT_METAL_DISABLE_BACKTRACE env var to skip backtrace generation

### DIFF
--- a/tt_stl/tt_stl/assert.hpp
+++ b/tt_stl/tt_stl/assert.hpp
@@ -102,8 +102,11 @@ template <typename... Args>
         trace_message_ss << fmt::format(args...) << std::endl;
         log_critical(tt::LogAlways, "{}: {}", assert_type, fmt::format(args...));
     }
-    trace_message_ss << "backtrace:\n";
-    trace_message_ss << tt::assert::backtrace_to_string(100, 3, " --- ");
+    static const bool disable_backtrace = std::getenv("TT_METAL_DISABLE_BACKTRACE") != nullptr;
+    if (!disable_backtrace) {
+        trace_message_ss << "backtrace:\n";
+        trace_message_ss << tt::assert::backtrace_to_string(100, 3, " --- ");
+    }
     trace_message_ss << std::flush;
     throw std::runtime_error(trace_message_ss.str());
 }


### PR DESCRIPTION
Backtrace generation in tt_throw_impl is expensive and accounts for ~37% of CPU time during tt-mlir compilation. Adding this environment variable allows users to disable backtrace generation for significant performance improvements (57% faster compilation in Llama benchmarks).

### Ticket
Related to  https://github.com/tenstorrent/tt-mlir/issues/6211

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] [cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) job passes
- [ ] New/Existing tests provide coverage for changes