### PR TITLE
MPWI Support for Kernels <=32 Sticks

### DIFF
--- a/tests/ttnn/unit_tests/operations/pool/test_mpwi.py
+++ b/tests/ttnn/unit_tests/operations/pool/test_mpwi.py
@@ -69,6 +69,64 @@ def test_mpwi_20_core_C_dims(device, in_c):
         # Contains following parameters
         # [batch_size, input_channels, input_height, input_width, kernel_height, kernel_width, stride_h, stride_w, pad_h, pad_w, dilation_h, dilation_w, ceil_mode]
         # DILATION / MULTI-BATCH CASES
+        [2, 16, 130, 130, 2, 2, 1, 1, 1, 1, 1, 1, False],
+        [3, 16, 80, 80, 2, 2, 1, 1, 1, 1, 1, 1, False],
+        [4, 16, 50, 60, 2, 2, 1, 1, 1, 1, 1, 1, False],
+        [2, 48, 120, 120, 4, 4, 1, 1, 2, 2, 1, 1, False],
+        [3, 48, 70, 70, 4, 4, 1, 1, 2, 2, 1, 1, False],
+        [4, 48, 40, 50, 4, 4, 1, 1, 2, 2, 1, 1, False],
+        [2, 64, 110, 110, 4, 8, 1, 1, 2, 4, 1, 1, False],
+        [3, 64, 60, 60, 4, 8, 1, 1, 2, 4, 1, 1, False],
+        [4, 64, 30, 40, 4, 8, 1, 1, 2, 4, 1, 1, False],
+    ],
+)
+@pytest.mark.parametrize("ttnn_dtype", [ttnn.bfloat16])
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
+def test_mpwi_kernel_sizes(device, ttnn_dtype, input_spec):
+    (
+        in_n,
+        in_c,
+        in_h,
+        in_w,
+        kernel_h,
+        kernel_w,
+        stride_h,
+        stride_w,
+        pad_h,
+        pad_w,
+        dilation_h,
+        dilation_w,
+        ceil_mode,
+    ) = input_spec
+
+    run_max_pool2d_with_indices(
+        in_n,
+        in_c,
+        in_h,
+        in_w,
+        kernel_h,
+        kernel_w,
+        stride_h,
+        stride_w,
+        pad_h,
+        pad_w,
+        dilation_h,
+        dilation_w,
+        ttnn_dtype,
+        device,
+        sharding=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        ceil_mode=ceil_mode,
+        memory_config=None,
+        run_twice=True,
+    )
+
+
+@pytest.mark.parametrize(
+    "input_spec",
+    [
+        # Contains following parameters
+        # [batch_size, input_channels, input_height, input_width, kernel_height, kernel_width, stride_h, stride_w, pad_h, pad_w, dilation_h, dilation_w, ceil_mode]
+        # DILATION / MULTI-BATCH CASES
         [2, 40, 100, 100, 3, 3, 2, 2, 0, 1, 2, 2, True],
         [3, 56, 85, 85, 3, 3, 3, 3, 1, 0, 2, 2, False],
         [4, 24, 56, 64, 3, 3, 2, 1, 1, 1, 3, 2, True],

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_max_pool_indices.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_max_pool_indices.h
@@ -21,8 +21,16 @@ template <
     int ITERATIONS = 8,
     DataLayout layout = DataLayout::TILE>
 inline void calculate_max_pool_with_indices(uint values_tile_idx, uint indices_tile_idx, uint tile_idx) {
-    _calculate_max_pool_with_indices_<APPROXIMATION_MODE, is_fp32_dest_acc_en, num_rows, ITERATIONS, layout>(
-        values_tile_idx, indices_tile_idx, tile_idx);
+    if constexpr (num_rows <= 9) {
+        _calculate_max_pool_with_indices_<APPROXIMATION_MODE, is_fp32_dest_acc_en, ITERATIONS, layout>(
+            values_tile_idx, indices_tile_idx, tile_idx);
+    } else {
+        static_assert(num_rows <= 32, "num_rows must be <= 32");
+        static_assert(
+            layout == DataLayout::ROW_MAJOR, "generic max pool with indices is only implemented for ROW_MAJOR layout");
+        _calculate_max_pool_with_indices_generic_<APPROXIMATION_MODE, is_fp32_dest_acc_en, ITERATIONS>(
+            values_tile_idx, indices_tile_idx, tile_idx);
+    }
 }
 
 template <bool APPROXIMATION_MODE, DataLayout layout = DataLayout::TILE>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_max_pool_indices.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_max_pool_indices.h
@@ -21,8 +21,16 @@ template <
     int ITERATIONS = 8,
     DataLayout layout = DataLayout::TILE>
 inline void calculate_max_pool_with_indices(uint values_tile_idx, uint indices_tile_idx, uint tile_idx) {
-    _calculate_max_pool_with_indices_<APPROXIMATION_MODE, is_fp32_dest_acc_en, num_rows, ITERATIONS, layout>(
-        values_tile_idx, indices_tile_idx, tile_idx);
+    if constexpr (num_rows <= 9) {
+        _calculate_max_pool_with_indices_<APPROXIMATION_MODE, is_fp32_dest_acc_en, ITERATIONS, layout>(
+            values_tile_idx, indices_tile_idx, tile_idx);
+    } else {
+        static_assert(num_rows <= 32, "num_rows must be <= 32");
+        static_assert(
+            layout == DataLayout::ROW_MAJOR, "generic max pool with indices is only implemented for ROW_MAJOR layout");
+        _calculate_max_pool_with_indices_generic_<APPROXIMATION_MODE, is_fp32_dest_acc_en, ITERATIONS>(
+            values_tile_idx, indices_tile_idx, tile_idx);
+    }
 }
 
 template <bool APPROXIMATION_MODE, DataLayout layout = DataLayout::TILE>

--- a/tt_metal/include/compute_kernel_api.h
+++ b/tt_metal/include/compute_kernel_api.h
@@ -594,8 +594,7 @@ ALWI void topk_tile_init() { MATH((llk_math_eltwise_unary_sfpu_topk_init<true>()
 // clang-format on
 template <int num_rows = 9, ckernel::DataLayout layout = ckernel::DataLayout::TILE, int ITERATIONS = 8>
 ALWI void max_reduce_with_indices(uint32_t idst, uint32_t idst_idx) {
-    // support for num_rows != 9 is tracked here: https://github.com/tenstorrent/tt-metal/issues/17202
-    static_assert(num_rows <= 9, "num_rows must be <= 9");
+    static_assert(num_rows <= 32, "num_rows must be <= 32");
     MATH((llk_math_eltwise_binary_sfpu_max_pool_with_indices<true, DST_ACCUM_MODE, num_rows, ITERATIONS, layout>(
         idst, idst_idx)));
 }

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_pool_2d.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_pool_2d.cpp
@@ -224,7 +224,7 @@ void MAIN {
                     // oversized (equal to 1 tile), and since this CB is filled with padding values in the beginning of
                     // the data movement kernel, it is possible to still use max_reduce_with_indices with kernel sizes
                     // smaller than 9 as the excess sticks are just filled with padding values
-                    constexpr uint32_t max_mpwi_kernel_size = 9;
+                    constexpr uint32_t max_mpwi_kernel_size = window_size_hw <= 9 ? 9 : 32;
                     max_reduce_with_indices<max_mpwi_kernel_size, ckernel::DataLayout::ROW_MAJOR>(
                         data_dst_idx, index_dst_idx);
                 } else {

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/pool_op.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/pool_op.cpp
@@ -47,8 +47,8 @@ void validate_pool2d(
         auto kernel_h = sliding_window_config.window_hw.first;
         auto kernel_w = sliding_window_config.window_hw.second;
         TT_FATAL(
-            kernel_h * kernel_w <= 9,
-            "only kernel sizes less than or equal to 9 are supported, got {}x{}",
+            kernel_h * kernel_w <= 32,
+            "only kernel sizes less than or equal to 32 are supported, got {}x{}",
             kernel_h,
             kernel_w);
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/27845

### Problem description
Currently MPWI only has LLK support for kernel sizes <=9 sticks.

### What's changed
Checks have been updated from <=9 to <=32 and the SFPU calls have been updated to select either the optimized 9 stick MPWI SFPU function or the generic 32 stick version.

### Current Perf Comparison
#### Test Trace Info:
NCHW = [1, 64, 159, 159]
Kernel = [3, 3]
Stride = Pad = Dilation = [1, 1]
Ceil Mode = False
Data Type = BF16
Sharding = Height

#### Results:
| System | Max Pool (us) | MPWI <=9 (us) | MPWI <=32 (us) |
| :------- | :------: | -------: | -------: |
| WH | 63.2 | 493.0 | 1311.3 |
| BH | 50.4 | 181.9 | 418.9 |
| -- | | | | |
| **WH Max Pool Relative:** | **1x** | **7.8x** | **20.7x** | 
| **BH Max Pool Relative:** | **1x** | **3.6x** | **8.3x** | 

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/20310040164
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/20310044002/job/58362903388
failing on main, this PR hits same unrelated error
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/20310076228
failing on main, this PR hits same unrelated error
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/20310071071
failing on main, this PR hits same unrelated error
- [x] [Nightly L2](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/20310054729
https://github.com/tenstorrent/tt-metal/actions/runs/20342472819/job/58465899378 - additional tests requested by @fvranicTT, same tutorial failures as main, unrelated to this PR
- [x] [Nightly Blackhole](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-nightly-tests.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/20310061930
failing on main, this PR hits same unrelated error
- [x] [Frequent model](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/20310082300
failing on main, this PR hits same unrelated error
- [x] New/Existing tests provide coverage for changes