### PR TITLE
Inline [] operator in ShapeBase

### DIFF
--- a/tt_metal/api/tt-metalium/shape_base.hpp
+++ b/tt_metal/api/tt-metalium/shape_base.hpp
@@ -4,12 +4,33 @@
 
 #pragma once
 
+#include <cstdint>
 #include <vector>
 
 #include <tt_stl/small_vector.hpp>
 #include <tt_stl/span.hpp>
 
 namespace tt::tt_metal {
+
+// Inline implementation of operator[] index normalization to enable compiler optimization.
+// This allows the compiler to optimize hot loops that repeatedly index shapes, eliminating
+// function call overhead.
+namespace detail {
+[[noreturn]] void normalized_index_out_of_range(int32_t index, int32_t full_size, int32_t orig_size);
+
+inline int32_t normalized_index(int32_t index, size_t original_size, size_t container_size) {
+    const int32_t orig_size = static_cast<int32_t>(original_size);
+    const int32_t full_size = static_cast<int32_t>(container_size);
+
+    if (index < -full_size || index >= orig_size) {
+        normalized_index_out_of_range(index, full_size, orig_size);
+    }
+
+    const int32_t is_nonneg = index >= 0;
+    const int32_t adjust = full_size - is_nonneg * orig_size;
+    return index + adjust;
+}
+}  // namespace detail
 
 // Container wrapper that allows negative indexing
 class ShapeBase {
@@ -36,8 +57,15 @@ public:
     bool operator==(const Container& other) const;
     bool operator==(const std::vector<uint32_t>& other) const;
 
-    uint32_t operator[](int32_t index) const;
-    uint32_t& operator[](int32_t index);
+    uint32_t operator[](int32_t index) const {
+        auto norm_index = detail::normalized_index(index, original_size_, value_.size());
+        return value_[norm_index];
+    }
+
+    uint32_t& operator[](int32_t index) {
+        auto norm_index = detail::normalized_index(index, original_size_, value_.size());
+        return value_[norm_index];
+    }
 
     Container::const_iterator cbegin() const;
     Container::const_iterator cend() const;

--- a/tt_metal/common/shape_base.cpp
+++ b/tt_metal/common/shape_base.cpp
@@ -2,41 +2,20 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <stdint.h>
 #include <algorithm>
-#include <cstddef>
-#include <iterator>
-#include <type_traits>
 #include <vector>
 
-#include <tt_stl/assert.hpp>
 #include "shape_base.hpp"
+#include <tt_stl/assert.hpp>
 #include <tt_stl/span.hpp>
 
 namespace tt::tt_metal {
 
-namespace {
-namespace CMAKE_UNIQUE_NAMESPACE {
-
-int32_t normalized_index(int32_t index, size_t original_size, size_t container_size) {
-    int32_t orig_size = static_cast<int32_t>(original_size);
-    int32_t full_size = static_cast<int32_t>(container_size);
-
-    int fixed_index = index;
-    if (fixed_index < 0) {
-        fixed_index += full_size;
-    } else {
-        fixed_index += full_size - orig_size;
-    }
-
-    if (fixed_index < 0 || fixed_index >= full_size) {
-        TT_THROW("ShapeBase[] index out of range. {} not in [{}, {})", index, -full_size, orig_size);
-    }
-
-    return fixed_index;
+namespace detail {
+[[gnu::noinline]] void normalized_index_out_of_range(int32_t index, int32_t full_size, int32_t orig_size) {
+    TT_THROW("ShapeBase[] index out of range. {} not in [{}, {})", index, -full_size, orig_size);
 }
-}  // namespace CMAKE_UNIQUE_NAMESPACE
-}  // namespace
+}  // namespace detail
 
 void ShapeBase::init() {
     original_size_ = value_.size();
@@ -64,16 +43,6 @@ bool ShapeBase::operator==(const Container& other) const {
 bool ShapeBase::operator==(const std::vector<uint32_t>& other) const {
     auto original_view = view();
     return std::equal(original_view.begin(), original_view.end(), other.begin(), other.end());
-}
-
-uint32_t ShapeBase::operator[](int32_t index) const {
-    auto norm_index = CMAKE_UNIQUE_NAMESPACE::normalized_index(index, original_size_, value_.size());
-    return value_[norm_index];
-}
-
-uint32_t& ShapeBase::operator[](int32_t index) {
-    auto norm_index = CMAKE_UNIQUE_NAMESPACE::normalized_index(index, original_size_, value_.size());
-    return value_[norm_index];
 }
 
 ShapeBase::Container::const_iterator ShapeBase::cbegin() const {


### PR DESCRIPTION
Move operator[] implementation from shape_base.cpp to shape_base.hpp as an inline function. This allows the compiler to optimize hot loops that repeatedly index shapes, eliminating function call overhead.

This optimization targets ~19% speedup for EfficientNet compilation where shape indexing was consuming 33.59% of CPU samples.

### Ticket
Related to https://github.com/tenstorrent/tt-mlir/issues/6211

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] [cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) job passes
- [ ] New/Existing tests provide coverage for changes