### PR TITLE
Unify LLK HW Configs

### DIFF
--- a/tests/tt_metal/tt_metal/test_kernels/compute/3T/matmul_large_block_zm/zm_3m_math.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/3T/matmul_large_block_zm/zm_3m_math.cpp
@@ -75,7 +75,7 @@ void math_main() {
     constexpr bool spill = num_blocks > 1U;
     bool enable_reload = false;
 
-    llk_math_hw_configure_disaggregated(0, 1);
+    llk_math_hw_configure(0, 1);
 
     for (uint32_t block = 0U; block < num_blocks; block++) {
         bool last_out = block == num_blocks - 1U;

--- a/tests/tt_metal/tt_metal/test_kernels/compute/3T/matmul_large_block_zm/zm_3m_pack.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/3T/matmul_large_block_zm/zm_3m_pack.cpp
@@ -92,7 +92,7 @@ void pack_main() {
     uint32_t in0_block_w = get_compile_time_arg_val(0);
     llk_pack_init();
     llk_pack_dest_init<DST_ACCUM_MODE, false>();
-    llk_init_packer_dest_offset_registers<DstTileFaceLayout::RowMajor, false>();
+    llk_init_packer_dest_offset_registers<false>();
     llk_pack_hw_configure_disaggregated<DST_ACCUM_MODE, false>(16);
     // inner block size in tiles
     uint32_t in0_num_subblocks = get_compile_time_arg_val(1);

--- a/tests/tt_metal/tt_metal/test_kernels/compute/3T/matmul_large_block_zm/zm_3m_unpack.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/3T/matmul_large_block_zm/zm_3m_unpack.cpp
@@ -160,7 +160,7 @@ void unpack_main() {
         matmul_out_intermediate_cb_id = 25;  // Given 24 is no longer available, we use 25 instead
     }
 
-    llk_unpack_hw_configure(0, 1);
+    llk_unpack_hw_configure<false>(0, 1);
 
     uint32_t reblock_cb_id = 26;
 

--- a/tests/tt_metal/tt_metal/test_kernels/compute/3T/matmul_large_block_zm/zm_3m_unpack.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/3T/matmul_large_block_zm/zm_3m_unpack.cpp
@@ -160,7 +160,7 @@ void unpack_main() {
         matmul_out_intermediate_cb_id = 25;  // Given 24 is no longer available, we use 25 instead
     }
 
-    llk_unpack_AB_matmul_hw_configure_disaggregated(0, 1, 0);
+    llk_unpack_hw_configure(0, 1);
 
     uint32_t reblock_cb_id = 26;
 

--- a/tests/tt_metal/tt_metal/test_kernels/compute/3T/untilize_A_and_eltwise_binary/chlkc_math.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/3T/untilize_A_and_eltwise_binary/chlkc_math.cpp
@@ -15,7 +15,7 @@ void math_main() {
     uint32_t per_core_block_c_tiles = get_compile_time_arg_val(2);
 
     llk_math_pack_sync_init<DST_ACCUM_MODE>();
-    llk_math_hw_configure_disaggregated(0, 1);
+    llk_math_hw_configure(0, 1);
     for (uint32_t block = 0; block < per_core_num_blocks; block++) {
         for (uint32_t r = 0; r < per_core_block_r_tiles; r++) {
             // Untilize

--- a/tests/tt_metal/tt_metal/test_kernels/compute/3T/untilize_A_and_eltwise_binary/chlkc_unpack.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/3T/untilize_A_and_eltwise_binary/chlkc_unpack.cpp
@@ -15,7 +15,6 @@ void unpack_main() {
     uint32_t per_core_block_c_tiles = get_compile_time_arg_val(2);
 
     llk_unpack_hw_configure<DST_ACCUM_MODE>(0, 1);
-    // llk_unpack_untilize_hw_configure_disaggregated(0);
 
     // llk_unpack_untilize_init(0);
     for (uint32_t block = 0U; block < per_core_num_blocks; ++block) {

--- a/tests/tt_metal/tt_metal/test_kernels/compute/3T/untilize_A_and_eltwise_binary/chlkc_unpack.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/3T/untilize_A_and_eltwise_binary/chlkc_unpack.cpp
@@ -14,7 +14,7 @@ void unpack_main() {
     uint32_t per_core_block_r_tiles = get_compile_time_arg_val(1);
     uint32_t per_core_block_c_tiles = get_compile_time_arg_val(2);
 
-    llk_unpack_AB_hw_configure_disaggregated<DST_ACCUM_MODE>(0, 1);
+    llk_unpack_hw_configure<DST_ACCUM_MODE>(0, 1);
     // llk_unpack_untilize_hw_configure_disaggregated(0);
 
     // llk_unpack_untilize_init(0);

--- a/tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy_3m.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy_3m.cpp
@@ -53,7 +53,7 @@ void pack_main() {
 void unpack_main() {
     int __outer_loop_iter;
     UNPACK((llk_unpack_A_init<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE>()));
-    UNPACK((llk_unpack_A_hw_configure_disaggregated<DST_ACCUM_MODE>(0)));
+    UNPACK((llk_unpack_hw_configure<DST_ACCUM_MODE>(0, 0)));
     constexpr uint32_t per_core_tile_cnt = get_compile_time_arg_val(0);
     for (uint32_t b = 0; b < per_core_tile_cnt; ++b) {
         llk_wait_tiles(0, 1);

--- a/tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy_3m.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy_3m.cpp
@@ -53,7 +53,7 @@ void pack_main() {
 void unpack_main() {
     int __outer_loop_iter;
     UNPACK((llk_unpack_A_init<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE>()));
-    UNPACK((llk_unpack_hw_configure<DST_ACCUM_MODE>(0, 0)));
+    UNPACK((llk_unpack_hw_configure<DST_ACCUM_MODE>(0)));
     constexpr uint32_t per_core_tile_cnt = get_compile_time_arg_val(0);
     for (uint32_t b = 0; b < per_core_tile_cnt; ++b) {
         llk_wait_tiles(0, 1);

--- a/tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy_3m.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy_3m.cpp
@@ -19,7 +19,7 @@ void math_main() {
     int __outer_loop_iter;
     MATH((llk_math_eltwise_unary_datacopy_init<A2D, DST_ACCUM_MODE, BroadcastType::NONE>(0)));
     llk_math_pack_sync_init<DST_ACCUM_MODE>();
-    llk_math_hw_configure_disaggregated(0, 0);
+    llk_math_hw_configure(0, 0);
     constexpr uint32_t per_core_tile_cnt = get_compile_time_arg_val(0);
     for (uint32_t b = 0; b < per_core_tile_cnt; ++b) {
         llk_math_wait_for_dest_available();

--- a/tests/tt_metal/tt_metal/test_kernels/compute/untilA_elwbin_3m.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/untilA_elwbin_3m.cpp
@@ -58,7 +58,7 @@ void unpack_main() {
     uint32_t per_core_block_r_tiles = get_compile_time_arg_val(1);
     uint32_t per_core_block_c_tiles = get_compile_time_arg_val(2);
 
-    llk_unpack_AB_hw_configure_disaggregated<DST_ACCUM_MODE>(0, 1);
+    llk_unpack_hw_configure<DST_ACCUM_MODE>(0, 1);
     // llk_unpack_untilize_hw_configure_disaggregated(0);
 
     // llk_unpack_untilize_init(0);

--- a/tests/tt_metal/tt_metal/test_kernels/compute/untilA_elwbin_3m.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/untilA_elwbin_3m.cpp
@@ -59,7 +59,6 @@ void unpack_main() {
     uint32_t per_core_block_c_tiles = get_compile_time_arg_val(2);
 
     llk_unpack_hw_configure<DST_ACCUM_MODE>(0, 1);
-    // llk_unpack_untilize_hw_configure_disaggregated(0);
 
     // llk_unpack_untilize_init(0);
     for (uint32_t block = 0U; block < per_core_num_blocks; ++block) {

--- a/tests/tt_metal/tt_metal/test_kernels/compute/untilA_elwbin_3m.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/untilA_elwbin_3m.cpp
@@ -25,7 +25,7 @@ void math_main() {
     uint32_t per_core_block_c_tiles = get_compile_time_arg_val(2);
 
     llk_math_pack_sync_init<DST_ACCUM_MODE>();
-    llk_math_hw_configure_disaggregated(0, 1);
+    llk_math_hw_configure(0, 1);
     for (uint32_t block = 0; block < per_core_num_blocks; block++) {
         for (uint32_t r = 0; r < per_core_block_r_tiles; r++) {
             // Untilize

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_common_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_common_api.h
@@ -21,13 +21,13 @@
 /*************************************************************************
  * LLK MATH COMMON
  *************************************************************************/
-template <bool untilize_en = false, bool skip_inputs = false>
-inline void llk_math_hw_configure_disaggregated(const std::uint32_t srca_operand, const std::uint32_t srcb_operand) {
+inline void llk_math_hw_configure(const std::uint32_t srca_operand, const std::uint32_t srcb_operand) {
     std::uint32_t srca_operand_id = get_operand_id(srca_operand);
     std::uint32_t srcb_operand_id = get_operand_id(srcb_operand);
-    _llk_math_hw_configure_<untilize_en, skip_inputs>(
-        unpack_dst_format[srca_operand_id], unpack_dst_format[srcb_operand_id]);
+    _llk_math_hw_configure_(unpack_dst_format[srca_operand_id], unpack_dst_format[srcb_operand_id]);
 }
+
+inline void llk_math_reconfig_remap(const bool remap_enable) { _llk_math_reconfig_remap_(remap_enable); }
 
 inline void llk_math_wait_for_dest_available() {
     WAYPOINT("MWDW");

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_matmul_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_matmul_api.h
@@ -25,7 +25,7 @@ inline void llk_math_matmul_init(
     const std::uint32_t in1_tile_r_dim = get_operand_tile_r_dim(in1_id);
     const std::uint32_t in1_tile_c_dim = get_operand_tile_c_dim(in1_id);
 
-    const bool partial_face = (in0_tile_r_dim < FACE_R_DIM) || (in0_tile_c_dim < FACE_C_DIM);
+    const bool partial_face = (in0_tile_r_dim < FACE_R_DIM);
 
     _llk_math_matmul_init_<NUM_FIDELITY_PHASES, THROTTLE_LEVEL>(
         in0_tile_r_dim, in0_tile_c_dim, in1_tile_r_dim, in1_tile_c_dim, partial_face, transpose, ct_dim, rt_dim);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_matmul_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_matmul_api.h
@@ -29,11 +29,11 @@ inline void llk_math_matmul_init(
     const std::uint32_t in1_tile_r_dim = get_operand_tile_r_dim(in1_id);
     const std::uint32_t in1_tile_c_dim = get_operand_tile_c_dim(in1_id);
 
-    _llk_math_matmul_init_<NUM_FIDELITY_PHASES, DstTileFaceLayout::RowMajor, THROTTLE_LEVEL>(
+    _llk_math_matmul_init_<NUM_FIDELITY_PHASES, THROTTLE_LEVEL>(
         in0_tile_r_dim, in0_tile_c_dim, in1_tile_r_dim, in1_tile_c_dim, partial_face, transpose, ct_dim, rt_dim);
 }
 
 template <int NUM_FIDELITY_PHASES, int THROTTLE_LEVEL = 0, uint32_t num_faces = 4 /*not used*/>
 inline void llk_math_matmul(const uint dst_index, const std::uint32_t ct_dim = 1, const std::uint32_t rt_dim = 1) {
-    _llk_math_matmul_<NUM_FIDELITY_PHASES, DstTileFaceLayout::RowMajor, THROTTLE_LEVEL>(dst_index, ct_dim, rt_dim);
+    _llk_math_matmul_<NUM_FIDELITY_PHASES, THROTTLE_LEVEL>(dst_index, ct_dim, rt_dim);
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_matmul_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_matmul_api.h
@@ -20,14 +20,20 @@ inline void llk_math_matmul_init(
     const std::uint32_t in0_id = get_operand_id(operandA);
     const std::uint32_t in1_id = get_operand_id(operandB);
 
-    // Issue #31387: this flag is only for computing 8x32 tile shape, although current impl assumes the in0 tile is
-    // still 16x32. We should remove this flag in the future and add impl for 8x32 input tile shape
-    const bool partial_face = 0;
-
     const std::uint32_t in0_tile_r_dim = get_operand_tile_r_dim(in0_id);
     const std::uint32_t in0_tile_c_dim = get_operand_tile_c_dim(in0_id);
     const std::uint32_t in1_tile_r_dim = get_operand_tile_r_dim(in1_id);
     const std::uint32_t in1_tile_c_dim = get_operand_tile_c_dim(in1_id);
+
+    // Determine if we have partial faces (tiny tiles)
+    // The matmul operation is D = B*A where in0->srcB and in1->srcA
+    // A partial face occurs when tile has non-standard face dimensions (row or col dim != 16)
+    // For matmul address mode configuration, we specifically need to check if in0 (srcB) has partial faces
+    // Example: 8x32 tile has 8<16 rows and 32>16 cols, requiring special address mode handling
+    const bool is_in0_16x32 = (in0_tile_r_dim <= 16) && (in0_tile_c_dim > 16);
+    const bool is_in0_32x16 = (in0_tile_r_dim > 16) && (in0_tile_c_dim <= 16);
+    // A tile is partial face if it's not the standard 32x32 AND has mismatched dimensions (one dim <=16, other >16)
+    const bool partial_face = (is_in0_16x32 || is_in0_32x16);
 
     _llk_math_matmul_init_<NUM_FIDELITY_PHASES, THROTTLE_LEVEL>(
         in0_tile_r_dim, in0_tile_c_dim, in1_tile_r_dim, in1_tile_c_dim, partial_face, transpose, ct_dim, rt_dim);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_matmul_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_matmul_api.h
@@ -25,11 +25,7 @@ inline void llk_math_matmul_init(
     const std::uint32_t in1_tile_r_dim = get_operand_tile_r_dim(in1_id);
     const std::uint32_t in1_tile_c_dim = get_operand_tile_c_dim(in1_id);
 
-    // Determine if we have partial faces (tiny tiles)
-    // A partial face has a dimension < 16 (FACE_R_DIM or FACE_C_DIM)
-    // Examples: 8x32 has 8<16 rows (partial), 16x32 has full 16x16 faces (not partial)
-    //           32x16 has full 16x16 faces (not partial)
-    const bool partial_face = (in0_tile_r_dim < 16) || (in0_tile_c_dim < 16);
+    const bool partial_face = (in0_tile_r_dim < FACE_R_DIM) || (in0_tile_c_dim < FACE_C_DIM);
 
     _llk_math_matmul_init_<NUM_FIDELITY_PHASES, THROTTLE_LEVEL>(
         in0_tile_r_dim, in0_tile_c_dim, in1_tile_r_dim, in1_tile_c_dim, partial_face, transpose, ct_dim, rt_dim);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_matmul_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_matmul_api.h
@@ -26,14 +26,10 @@ inline void llk_math_matmul_init(
     const std::uint32_t in1_tile_c_dim = get_operand_tile_c_dim(in1_id);
 
     // Determine if we have partial faces (tiny tiles)
-    // The matmul operation is D = B*A where in0->srcB and in1->srcA
-    // A partial face occurs when tile has non-standard face dimensions (row or col dim != 16)
-    // For matmul address mode configuration, we specifically need to check if in0 (srcB) has partial faces
-    // Example: 8x32 tile has 8<16 rows and 32>16 cols, requiring special address mode handling
-    const bool is_in0_16x32 = (in0_tile_r_dim <= 16) && (in0_tile_c_dim > 16);
-    const bool is_in0_32x16 = (in0_tile_r_dim > 16) && (in0_tile_c_dim <= 16);
-    // A tile is partial face if it's not the standard 32x32 AND has mismatched dimensions (one dim <=16, other >16)
-    const bool partial_face = (is_in0_16x32 || is_in0_32x16);
+    // A partial face has a dimension < 16 (FACE_R_DIM or FACE_C_DIM)
+    // Examples: 8x32 has 8<16 rows (partial), 16x32 has full 16x16 faces (not partial)
+    //           32x16 has full 16x16 faces (not partial)
+    const bool partial_face = (in0_tile_r_dim < 16) || (in0_tile_c_dim < 16);
 
     _llk_math_matmul_init_<NUM_FIDELITY_PHASES, THROTTLE_LEVEL>(
         in0_tile_r_dim, in0_tile_c_dim, in1_tile_r_dim, in1_tile_c_dim, partial_face, transpose, ct_dim, rt_dim);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_api.h
@@ -291,7 +291,7 @@ inline void llk_init_packer_dest_offset_registers(const std::uint32_t pack_outpu
     const std::uint32_t face_r_dim = get_output_face_r_dim(output_id);
     const bool narrow_tile = get_output_narrow_tile(output_id);
 
-    _llk_init_packer_dest_offset_registers_<DST_SYNC_MODE, false>(face_r_dim, narrow_tile);
+    _llk_init_packer_dest_offset_registers_<DST_SYNC_MODE>(face_r_dim, narrow_tile);
 }
 
 template <bool is_fp32_dest_acc_en, bool untilize = false>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_api.h
@@ -22,6 +22,7 @@
  * LLK PACK
  *************************************************************************/
 
+// TODO NC: can be removed altogether:
 template <bool untilize = false, bool zero_output = false, bool tilize = false>
 inline void llk_pack_mop_config(const uint32_t output) {
     const std::uint32_t output_id = get_output_id(output);
@@ -162,7 +163,7 @@ inline void llk_pack_init(const std::uint32_t pack_output = 16) {
     const bool partial_face = get_output_partial_face(output_id);
     const bool narrow_tile = get_output_narrow_tile(output_id);
 
-    _llk_pack_init_<untilize, zero_output, false, tilize>(
+    _llk_pack_init_<untilize, zero_output, tilize>(
         pack_src_format[output_id], pack_dst_format[output_id], face_r_dim, tile_c_dim, num_faces, partial_face, narrow_tile);
 }
 
@@ -315,7 +316,7 @@ inline void llk_pack_reconfig_data_format(const std::uint32_t new_output) {
     const bool partial_face = get_output_partial_face(output_id);
     const bool narrow_tile = get_output_narrow_tile(output_id);
 
-    _llk_pack_reconfig_data_format_<is_fp32_dest_acc_en, is_tile_dim_reconfig_en, false, false>(
+    _llk_pack_reconfig_data_format_<is_fp32_dest_acc_en, is_tile_dim_reconfig_en>(
         pack_src_format[output_id],
         pack_dst_format[output_id],
         get_local_cb_interface(output_id).fifo_page_size,

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_api.h
@@ -31,7 +31,7 @@ inline void llk_pack_mop_config(const uint32_t output) {
     const bool partial_face = get_output_partial_face(output_id) && IS_BFP_FORMAT((uint)pack_dst_format[output_id]);
     const bool narrow_tile = get_output_narrow_tile(output_id);
 
-    _llk_pack_mop_config_<untilize, zero_output, DstTileFaceLayout::RowMajor, tilize>(
+    _llk_pack_mop_config_<untilize, zero_output, tilize>(
         pack_dst_format[output_id], face_r_dim, tile_c_dim, num_faces, partial_face, narrow_tile);
 }
 
@@ -162,7 +162,7 @@ inline void llk_pack_init(const std::uint32_t pack_output = 16) {
     const bool partial_face = get_output_partial_face(output_id);
     const bool narrow_tile = get_output_narrow_tile(output_id);
 
-    _llk_pack_init_<untilize, zero_output, DstTileFaceLayout::RowMajor, false, tilize>(
+    _llk_pack_init_<untilize, zero_output, false, tilize>(
         pack_src_format[output_id], pack_dst_format[output_id], face_r_dim, tile_c_dim, num_faces, partial_face, narrow_tile);
 }
 
@@ -290,7 +290,7 @@ inline void llk_init_packer_dest_offset_registers(const std::uint32_t pack_outpu
     const std::uint32_t face_r_dim = get_output_face_r_dim(output_id);
     const bool narrow_tile = get_output_narrow_tile(output_id);
 
-    _llk_init_packer_dest_offset_registers_<DST_SYNC_MODE, DstTileFaceLayout::RowMajor>(face_r_dim, narrow_tile);
+    _llk_init_packer_dest_offset_registers_<DST_SYNC_MODE, false>(face_r_dim, narrow_tile);
 }
 
 template <bool is_fp32_dest_acc_en, bool untilize = false>
@@ -299,7 +299,7 @@ inline void llk_pack_dest_init(const std::uint32_t pack_output = 16) {
     const std::uint32_t face_r_dim = get_output_face_r_dim(output_id);
     const bool narrow_tile = get_output_narrow_tile(output_id);
 
-    _llk_pack_dest_init_<DST_SYNC_MODE, is_fp32_dest_acc_en, DstTileFaceLayout::RowMajor>(face_r_dim, narrow_tile);
+    _llk_pack_dest_init_<DST_SYNC_MODE, is_fp32_dest_acc_en, false>(face_r_dim, narrow_tile);
 }
 
 inline void llk_pack_debug_dump(std::uint8_t* data, std::uint32_t byte_size) { _llk_pack_debug_dump_(data, byte_size); }
@@ -315,7 +315,7 @@ inline void llk_pack_reconfig_data_format(const std::uint32_t new_output) {
     const bool partial_face = get_output_partial_face(output_id);
     const bool narrow_tile = get_output_narrow_tile(output_id);
 
-    _llk_pack_reconfig_data_format_<is_fp32_dest_acc_en, is_tile_dim_reconfig_en, DstTileFaceLayout::RowMajor, false>(
+    _llk_pack_reconfig_data_format_<is_fp32_dest_acc_en, is_tile_dim_reconfig_en, false, false>(
         pack_src_format[output_id],
         pack_dst_format[output_id],
         get_local_cb_interface(output_id).fifo_page_size,

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_api.h
@@ -116,43 +116,6 @@ inline void llk_pack_untilize_hw_configure_disaggregated(
     llk_pack_untilize_hw_configure<is_fp32_dest_acc_en, untilize, tilize>(&llk_pack_params, face_r_dim, num_faces);
 }
 
-template <PoolType type, ReduceDim dim, bool is_fp32_dest_acc_en, bool untilize = false>
-inline void llk_pack_reduce_hw_configure(const llk_pack_params_t* pack_params) {
-    const std::uint32_t output_id = get_output_id(pack_params->pack_output);
-    const std::uint32_t face_r_dim = get_output_face_r_dim(output_id);
-    const std::uint32_t tile_c_dim = get_output_tile_c_dim(output_id);
-    const std::uint32_t num_faces = get_output_num_faces(output_id);
-    const bool partial_face = get_output_partial_face(output_id);
-    const bool narrow_tile = get_output_narrow_tile(output_id);
-
-    const std::uint32_t tile_size = get_local_cb_interface(output_id).fifo_page_size;
-
-    _llk_pack_reduce_hw_configure_<type, dim, is_fp32_dest_acc_en, untilize>(
-        pack_src_format[output_id],
-        pack_dst_format[output_id],
-        tile_size,
-        face_r_dim,
-        tile_c_dim,
-        num_faces,
-        partial_face,
-        narrow_tile,
-        pack_params->relu_config.val);
-}
-
-template <
-    PoolType type,
-    ReduceDim dim,
-    bool is_fp32_dest_acc_en,
-    bool untilize = false,
-    ReluType relu_type = ReluType::NO_RELU,
-    std::uint32_t relu_threshold = 0>
-inline void llk_pack_reduce_hw_configure_disaggregated(std::uint32_t pack_output) {
-    llk_pack_params_t llk_pack_params = {
-        .pack_output = pack_output,
-        .relu_config = {.f = {.ApplyRelu = (std::uint32_t)relu_type, .Threshold = relu_threshold}}};
-    llk_pack_reduce_hw_configure<type, dim, is_fp32_dest_acc_en, untilize>(&llk_pack_params);
-}
-
 template <bool untilize = false, bool zero_output = false, bool tilize = false>
 inline void llk_pack_init(const std::uint32_t pack_output = 16) {
     // TODO (https://github.com/tenstorrent/tt-metal/issues/18948): Revisit for narrow_tile

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_api.h
@@ -263,7 +263,7 @@ inline void llk_pack_dest_init(const std::uint32_t pack_output = 16) {
     const std::uint32_t face_r_dim = get_output_face_r_dim(output_id);
     const bool narrow_tile = get_output_narrow_tile(output_id);
 
-    _llk_pack_dest_init_<DST_SYNC_MODE, is_fp32_dest_acc_en, false>(face_r_dim, narrow_tile);
+    _llk_pack_dest_init_<DST_SYNC_MODE, is_fp32_dest_acc_en>(face_r_dim, narrow_tile);
 }
 
 inline void llk_pack_debug_dump(std::uint8_t* data, std::uint32_t byte_size) { _llk_pack_debug_dump_(data, byte_size); }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_api.h
@@ -290,6 +290,7 @@ inline void llk_pack_reconfig_data_format(const std::uint32_t new_output) {
         narrow_tile);
 }
 
+// TODO NC: Clean up as the part of tt-metal#34499
 template <bool is_fp32_dest_acc_en, bool is_tile_dim_reconfig_en = false>
 inline void llk_pack_reconfig_data_format(const std::uint32_t old_output, const std::uint32_t new_output) {
     std::uint32_t old_output_id = get_output_id(old_output);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_api.h
@@ -22,7 +22,7 @@
  * LLK PACK
  *************************************************************************/
 
-// TODO NC: can be removed altogether:
+// TODO NC: Remove as the part of tt-metal#34499
 template <bool untilize = false, bool zero_output = false, bool tilize = false>
 inline void llk_pack_mop_config(const uint32_t output) {
     const std::uint32_t output_id = get_output_id(output);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_api.h
@@ -10,37 +10,6 @@
  * LLK UNPACK AB
  *************************************************************************/
 
-template <bool is_fp32_dest_acc_en, StochRndType stoch_rnd_mode = StochRndType::None>
-inline void llk_unpack_AB_hw_configure(
-    const llk_unpack_AB_params_t* unpack_AB_params, const int within_face_16x16_transpose = 0) {
-    // In0 -> unpA
-    // In1 -> unpB
-    const uint32_t unpA_operand_id = get_operand_id(unpack_AB_params->unpA_operand);
-    const uint32_t unpB_operand_id = get_operand_id(unpack_AB_params->unpB_operand);
-
-    // unpA -> srcA
-    // unpB -> srcB
-    const uint32_t num_faces = get_operand_num_faces(unpA_operand_id);    // num faces in unpA and unpB are the same
-    const uint32_t face_r_dim = get_operand_face_r_dim(unpA_operand_id);  // face r dim in unpA and unpB are the same
-
-    _llk_unpack_AB_hw_configure_<is_fp32_dest_acc_en, stoch_rnd_mode>(
-        unpack_src_format[unpA_operand_id],
-        unpack_src_format[unpB_operand_id],
-        unpack_dst_format[unpA_operand_id],
-        unpack_dst_format[unpB_operand_id],
-        face_r_dim,
-        within_face_16x16_transpose,
-        num_faces);
-}
-
-template <bool is_fp32_dest_acc_en, StochRndType stoch_rnd_mode = StochRndType::None>
-inline void llk_unpack_AB_hw_configure_disaggregated(
-    const std::uint32_t unpA_operand, const std::uint32_t unpB_operand, const int within_face_16x16_transpose = 0) {
-    const llk_unpack_AB_params_t unpack_AB_params = {.unpA_operand = unpA_operand, .unpB_operand = unpB_operand};
-
-    llk_unpack_AB_hw_configure<is_fp32_dest_acc_en, stoch_rnd_mode>(&unpack_AB_params, within_face_16x16_transpose);
-}
-
 template <BroadcastType BType = BroadcastType::NONE>
 inline void llk_unpack_AB_mop_config(const bool transpose_of_faces = false, const std::uint32_t operand_id = 0) {
     const std::uint32_t num_faces = get_operand_num_faces(operand_id);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_matmul_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_matmul_api.h
@@ -40,11 +40,6 @@ __attribute__((always_inline)) inline void llk_unpack_AB_matmul_init(
     const uint32_t unpB_num_faces =
         partial_face_b ? 1 : get_operand_num_faces(operandB_id);  // if partial face -> unpack face by face
 
-    // Currently, there is a constraint that tile size is equal to the fifo page size
-    // Should be removed and tile size should be computed in the LLK instead, as the part of #34495
-    const uint32_t unpA_tile_size_in_bytes = get_local_cb_interface(operandA_id).fifo_page_size;
-    const uint32_t unpB_tile_size_in_bytes = get_local_cb_interface(operandB_id).fifo_page_size;
-
     _llk_unpack_AB_matmul_init_(
         transpose,
         ct_dim,
@@ -55,9 +50,7 @@ __attribute__((always_inline)) inline void llk_unpack_AB_matmul_init(
         unpA_num_faces,
         unpB_num_faces,
         partial_face_a,
-        partial_face_b,
-        unpA_tile_size_in_bytes,
-        unpB_tile_size_in_bytes);
+        partial_face_b);
 }
 
 inline void llk_unpack_AB_matmul(

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_matmul_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_matmul_api.h
@@ -40,8 +40,10 @@ __attribute__((always_inline)) inline void llk_unpack_AB_matmul_init(
     const uint32_t unpB_num_faces =
         partial_face_b ? 1 : get_operand_num_faces(operandB_id);  // if partial face -> unpack face by face
 
-    const uint32_t unpA_tile_size = get_local_cb_interface(operandA_id).fifo_page_size;
-    const uint32_t unpB_tile_size = get_local_cb_interface(operandB_id).fifo_page_size;
+    // Currently, there is a constraint that tile size is equal to the fifo page size
+    // Should be removed and tile size should be computed in the LLK instead, as the part of #34495
+    const uint32_t unpA_tile_size_in_bytes = get_local_cb_interface(operandA_id).fifo_page_size;
+    const uint32_t unpB_tile_size_in_bytes = get_local_cb_interface(operandB_id).fifo_page_size;
 
     _llk_unpack_AB_matmul_init_(
         transpose,
@@ -54,8 +56,8 @@ __attribute__((always_inline)) inline void llk_unpack_AB_matmul_init(
         unpB_num_faces,
         partial_face_a,
         partial_face_b,
-        unpA_tile_size,
-        unpB_tile_size);
+        unpA_tile_size_in_bytes,
+        unpB_tile_size_in_bytes);
 }
 
 inline void llk_unpack_AB_matmul(

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_A_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_A_api.h
@@ -30,12 +30,12 @@ template <
     BroadcastType BType = BroadcastType::NONE,
     bool acc_to_dest = false,
     EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE,
-    bool unpack_to_dest = false>
+    bool unpack_to_dest = false,
+    bool disable_src_zero_flag = false>
 inline void llk_unpack_A_init(
     const std::uint32_t transpose_of_faces = 0,
     const std::uint32_t within_face_16x16_transpose = 0,
     const std::uint32_t operand = 0) {
-
     const std::uint32_t operand_id = get_operand_id(operand);
     const std::uint32_t face_r_dim = get_operand_face_r_dim(operand_id);
     const std::uint32_t num_faces = get_operand_num_faces(operand_id);
@@ -52,7 +52,8 @@ inline void llk_unpack_A_init(
         face_r_dim,
         num_faces,
         operand_unpack_src_format,
-        operand_unpack_dst_format);
+        operand_unpack_dst_format,
+        disable_src_zero_flag);
 }
 
 template <

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_A_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_A_api.h
@@ -11,35 +11,6 @@
  *************************************************************************/
 
 template <
-    bool is_fp32_dest_acc_en,
-    StochRndType stoch_rnd_mode = StochRndType::None,
-    bool disable_src_zero_flag = false>
-inline void llk_unpack_A_hw_configure(
-    const llk_unpack_A_params_t* unpack_A_params, const int within_face_16x16_transpose = 0) {
-    const uint32_t unpA_operand_id = get_operand_id(unpack_A_params->unpA_operand);
-    const uint32_t unpA_num_faces = get_operand_num_faces(unpA_operand_id);
-    const uint32_t unpA_face_r_dim = get_operand_face_r_dim(unpA_operand_id);
-
-    _llk_unpack_A_hw_configure_<is_fp32_dest_acc_en, stoch_rnd_mode, disable_src_zero_flag>(
-        unpack_src_format[unpA_operand_id],
-        unpack_dst_format[unpA_operand_id],
-        unpA_face_r_dim,
-        within_face_16x16_transpose,
-        unpA_num_faces);
-}
-
-template <
-    bool is_fp32_dest_acc_en,
-    StochRndType stoch_rnd_mode = StochRndType::None,
-    bool disable_src_zero_flag = false>
-inline void llk_unpack_A_hw_configure_disaggregated(
-    const std::uint32_t unpA_operand, const int within_face_16x16_transpose = 0) {
-    const llk_unpack_A_params_t unpack_A_params = {.unpA_operand = unpA_operand};
-    llk_unpack_A_hw_configure<is_fp32_dest_acc_en, stoch_rnd_mode, disable_src_zero_flag>(
-        &unpack_A_params, within_face_16x16_transpose);
-}
-
-template <
     BroadcastType BType = BroadcastType::NONE,
     bool acc_to_dest = false,
     EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE,

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_A_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_A_api.h
@@ -30,8 +30,7 @@ template <
     BroadcastType BType = BroadcastType::NONE,
     bool acc_to_dest = false,
     EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE,
-    bool unpack_to_dest = false,
-    bool disable_src_zero_flag = false>
+    bool unpack_to_dest = false>
 inline void llk_unpack_A_init(
     const std::uint32_t transpose_of_faces = 0,
     const std::uint32_t within_face_16x16_transpose = 0,
@@ -52,8 +51,7 @@ inline void llk_unpack_A_init(
         face_r_dim,
         num_faces,
         operand_unpack_src_format,
-        operand_unpack_dst_format,
-        disable_src_zero_flag);
+        operand_unpack_dst_format);
 }
 
 template <

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_common_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_common_api.h
@@ -20,7 +20,7 @@
  * LLK UNPACK COMMON
  *************************************************************************/
 
-template <bool is_fp32_dest_acc_en>
+template <bool is_fp32_dest_acc_en, bool disable_src_zero_flag = false>
 inline void llk_unpack_hw_configure(const std::uint32_t unpA_operand, const std::uint32_t unpB_operand) {
     // In0 -> unpA
     // In1 -> unpB
@@ -34,7 +34,7 @@ inline void llk_unpack_hw_configure(const std::uint32_t unpA_operand, const std:
     const uint32_t unpB_num_faces = get_operand_num_faces(unpB_operand_id);
     const uint32_t unpB_face_r_dim = get_operand_face_r_dim(unpB_operand_id);
 
-    _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
+    _llk_unpack_hw_configure_<is_fp32_dest_acc_en, disable_src_zero_flag>(
         unpack_src_format[unpA_operand_id],
         unpack_src_format[unpB_operand_id],
         unpack_dst_format[unpA_operand_id],
@@ -45,9 +45,9 @@ inline void llk_unpack_hw_configure(const std::uint32_t unpA_operand, const std:
         unpB_num_faces);
 }
 
-template <bool is_fp32_dest_acc_en>
+template <bool is_fp32_dest_acc_en, bool disable_src_zero_flag = false>
 inline void llk_unpack_hw_configure(const std::uint32_t unpA_operand) {
-    llk_unpack_hw_configure<is_fp32_dest_acc_en>(unpA_operand, unpA_operand);
+    llk_unpack_hw_configure<is_fp32_dest_acc_en, disable_src_zero_flag>(unpA_operand, unpA_operand);
 }
 
 inline bool should_reconfigure_cbs(std::uint32_t old_operand, std::uint32_t new_operand) {

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_common_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_common_api.h
@@ -29,16 +29,21 @@ inline void llk_unpack_hw_configure(const std::uint32_t unpA_operand, const std:
 
     // unpA -> srcA
     // unpB -> srcB
-    const uint32_t num_faces = get_operand_num_faces(unpA_operand_id);    // num faces in unpA and unpB are the same
-    const uint32_t face_r_dim = get_operand_face_r_dim(unpA_operand_id);  // face r dim in unpA and unpB are the same
+    // Note: For matmul with tiny tiles, operands can have different face dimensions
+    const uint32_t unpA_num_faces = get_operand_num_faces(unpA_operand_id);
+    const uint32_t unpA_face_r_dim = get_operand_face_r_dim(unpA_operand_id);
+    const uint32_t unpB_num_faces = get_operand_num_faces(unpB_operand_id);
+    const uint32_t unpB_face_r_dim = get_operand_face_r_dim(unpB_operand_id);
 
     _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
         unpack_src_format[unpA_operand_id],
         unpack_src_format[unpB_operand_id],
         unpack_dst_format[unpA_operand_id],
         unpack_dst_format[unpB_operand_id],
-        face_r_dim,
-        num_faces);
+        unpA_face_r_dim,
+        unpB_face_r_dim,
+        unpA_num_faces,
+        unpB_num_faces);
 }
 
 inline bool should_reconfigure_cbs(std::uint32_t old_operand, std::uint32_t new_operand) {

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_common_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_common_api.h
@@ -20,12 +20,6 @@
  * LLK UNPACK COMMON
  *************************************************************************/
 
-// Overloaded function for single operand unpack
-template <bool is_fp32_dest_acc_en>
-inline void llk_unpack_hw_configure(const std::uint32_t unpA_operand) {
-    llk_unpack_hw_configure<is_fp32_dest_acc_en>(unpA_operand, unpA_operand);
-}
-
 template <bool is_fp32_dest_acc_en>
 inline void llk_unpack_hw_configure(const std::uint32_t unpA_operand, const std::uint32_t unpB_operand) {
     // In0 -> unpA
@@ -49,6 +43,11 @@ inline void llk_unpack_hw_configure(const std::uint32_t unpA_operand, const std:
         unpB_face_r_dim,
         unpA_num_faces,
         unpB_num_faces);
+}
+
+template <bool is_fp32_dest_acc_en>
+inline void llk_unpack_hw_configure(const std::uint32_t unpA_operand) {
+    llk_unpack_hw_configure<is_fp32_dest_acc_en>(unpA_operand, unpA_operand);
 }
 
 inline bool should_reconfigure_cbs(std::uint32_t old_operand, std::uint32_t new_operand) {

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_common_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_common_api.h
@@ -35,7 +35,7 @@ inline void llk_unpack_hw_configure(const std::uint32_t unpA_operand, const std:
     const uint32_t unpB_face_r_dim = get_operand_face_r_dim(unpB_operand_id);
 
     // Currently, there is a constraint that tile size is equal to the fifo page size
-    // Should be removed and tile size should be computed in the LLK instead, as the part of #34495
+    // TODO NC: tile size should be computed in the LLK instead, as the part of #34495
     const uint32_t unpA_tile_size = get_local_cb_interface(unpA_operand_id).fifo_page_size;
     const uint32_t unpB_tile_size = get_local_cb_interface(unpB_operand_id).fifo_page_size;
 
@@ -68,6 +68,9 @@ inline void llk_unpack_reconfig_data_format_srca(const std::uint32_t srca_new_op
     const std::uint32_t srca_operand_id = get_operand_id(srca_new_operand);
     const std::uint32_t num_faces = get_operand_num_faces(srca_operand_id);
     const std::uint32_t face_r_dim = get_operand_face_r_dim(srca_operand_id);
+
+    // Currently, there is a constraint that tile size is equal to the fifo page size
+    // TODO NC: tile size should be computed in the LLK instead, as the part of #34495
     const std::uint32_t tile_size = get_local_cb_interface(srca_operand_id).fifo_page_size;
     _llk_unpack_reconfig_data_format_srca_impl_<is_fp32_dest_acc_en, to_from_int8>(
         unpack_src_format[srca_operand_id], unpack_dst_format[srca_operand_id], tile_size);
@@ -79,6 +82,9 @@ inline void llk_unpack_reconfig_data_format_srcb(const std::uint32_t srcb_new_op
     std::uint32_t srcb_operand_id = get_operand_id(srcb_new_operand);
     const std::uint32_t num_faces = get_operand_num_faces(srcb_operand_id);
     const std::uint32_t face_r_dim = get_operand_face_r_dim(srcb_operand_id);
+
+    // Currently, there is a constraint that tile size is equal to the fifo page size
+    // TODO NC: tile size should be computed in the LLK instead, as the part of #34495
     const std::uint32_t tile_size = get_local_cb_interface(srcb_operand_id).fifo_page_size;
     _llk_unpack_reconfig_data_format_srcb_impl_<is_fp32_dest_acc_en, to_from_int8>(
         unpack_src_format[srcb_operand_id], unpack_dst_format[srcb_operand_id], tile_size);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_common_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_common_api.h
@@ -55,16 +55,6 @@ inline bool should_reconfigure_cbs(std::uint32_t old_operand, std::uint32_t new_
            (unpack_dst_format[old_operand] != unpack_dst_format[new_operand]);
 }
 
-void llk_zero_operand(std::uint32_t operand) {
-    std::uint32_t operand_id = get_operand_id(operand);
-    std::uint32_t fifo_base_addr =
-        (get_local_cb_interface(operand_id).fifo_limit + 1) - get_local_cb_interface(operand_id).fifo_size;
-    std::uint32_t size = get_local_cb_interface(operand_id).fifo_size;
-    _llk_zero_buffer_(fifo_base_addr, size);
-}
-
-inline void llk_unpack_debug_dump_seek(std::uint8_t offset) { _llk_unpack_debug_dump_seek_(offset); }
-
 // TODO NC: Clean up as the part of tt-metal#34499
 template <bool is_fp32_dest_acc_en, bool to_from_int8 = false, bool is_tile_dim_reconfig_en = false>
 inline void llk_unpack_reconfig_data_format_srca(const std::uint32_t srca_new_operand) {

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_common_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_common_api.h
@@ -23,7 +23,7 @@
 // Overloaded function for single operand unpack
 template <bool is_fp32_dest_acc_en>
 inline void llk_unpack_hw_configure(const std::uint32_t unpA_operand) {
-    llk_unpack_hw_configure<is_fp32_dest_acc_en>(unpA_operand, unpB_operand);
+    llk_unpack_hw_configure<is_fp32_dest_acc_en>(unpA_operand, unpA_operand);
 }
 
 template <bool is_fp32_dest_acc_en>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_common_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_common_api.h
@@ -20,6 +20,27 @@
  * LLK UNPACK COMMON
  *************************************************************************/
 
+template <bool is_fp32_dest_acc_en>
+inline void llk_unpack_hw_configure(const std::uint32_t unpA_operand, const std::uint32_t unpB_operand) {
+    // In0 -> unpA
+    // In1 -> unpB
+    const uint32_t unpA_operand_id = get_operand_id(unpA_operand);
+    const uint32_t unpB_operand_id = get_operand_id(unpB_operand);
+
+    // unpA -> srcA
+    // unpB -> srcB
+    const uint32_t num_faces = get_operand_num_faces(unpA_operand_id);    // num faces in unpA and unpB are the same
+    const uint32_t face_r_dim = get_operand_face_r_dim(unpA_operand_id);  // face r dim in unpA and unpB are the same
+
+    _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
+        unpack_src_format[unpA_operand_id],
+        unpack_src_format[unpB_operand_id],
+        unpack_dst_format[unpA_operand_id],
+        unpack_dst_format[unpB_operand_id],
+        face_r_dim,
+        num_faces);
+}
+
 inline bool should_reconfigure_cbs(std::uint32_t old_operand, std::uint32_t new_operand) {
     return (unpack_src_format[old_operand] != unpack_src_format[new_operand]) ||
            (unpack_dst_format[old_operand] != unpack_dst_format[new_operand]);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_common_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_common_api.h
@@ -62,9 +62,7 @@ inline void llk_unpack_reconfig_data_format_srca(const std::uint32_t srca_new_op
     const std::uint32_t num_faces = get_operand_num_faces(srca_operand_id);
     const std::uint32_t face_r_dim = get_operand_face_r_dim(srca_operand_id);
     _llk_unpack_reconfig_data_format_srca_impl_<is_fp32_dest_acc_en, to_from_int8>(
-        unpack_src_format[srca_operand_id],
-        unpack_dst_format[srca_operand_id],
-        get_local_cb_interface(srca_operand_id).fifo_page_size);
+        unpack_src_format[srca_operand_id], unpack_dst_format[srca_operand_id]);
 }
 
 // TODO NC: Clean up as the part of tt-metal#34499
@@ -74,9 +72,7 @@ inline void llk_unpack_reconfig_data_format_srcb(const std::uint32_t srcb_new_op
     const std::uint32_t num_faces = get_operand_num_faces(srcb_operand_id);
     const std::uint32_t face_r_dim = get_operand_face_r_dim(srcb_operand_id);
     _llk_unpack_reconfig_data_format_srcb_impl_<is_fp32_dest_acc_en, to_from_int8>(
-        unpack_src_format[srcb_operand_id],
-        unpack_dst_format[srcb_operand_id],
-        get_local_cb_interface(srcb_operand_id).fifo_page_size);
+        unpack_src_format[srcb_operand_id], unpack_dst_format[srcb_operand_id]);
 }
 
 // TODO NC: Clean up as the part of tt-metal#34499

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_common_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_common_api.h
@@ -29,7 +29,6 @@ inline void llk_unpack_hw_configure(const std::uint32_t unpA_operand, const std:
 
     // unpA -> srcA
     // unpB -> srcB
-    // Note: For matmul with tiny tiles, operands can have different face dimensions
     const uint32_t unpA_num_faces = get_operand_num_faces(unpA_operand_id);
     const uint32_t unpA_face_r_dim = get_operand_face_r_dim(unpA_operand_id);
     const uint32_t unpB_num_faces = get_operand_num_faces(unpB_operand_id);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_common_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_common_api.h
@@ -33,6 +33,8 @@ inline void llk_unpack_hw_configure(const std::uint32_t unpA_operand, const std:
     const uint32_t unpA_face_r_dim = get_operand_face_r_dim(unpA_operand_id);
     const uint32_t unpB_num_faces = get_operand_num_faces(unpB_operand_id);
     const uint32_t unpB_face_r_dim = get_operand_face_r_dim(unpB_operand_id);
+    const uint32_t unpA_tile_size = get_local_cb_interface(unpA_operand_id).fifo_page_size;
+    const uint32_t unpB_tile_size = get_local_cb_interface(unpB_operand_id).fifo_page_size;
 
     _llk_unpack_hw_configure_<is_fp32_dest_acc_en, disable_src_zero_flag>(
         unpack_src_format[unpA_operand_id],
@@ -42,7 +44,9 @@ inline void llk_unpack_hw_configure(const std::uint32_t unpA_operand, const std:
         unpA_face_r_dim,
         unpB_face_r_dim,
         unpA_num_faces,
-        unpB_num_faces);
+        unpB_num_faces,
+        unpA_tile_size,
+        unpB_tile_size);
 }
 
 template <bool is_fp32_dest_acc_en, bool disable_src_zero_flag = false>
@@ -61,8 +65,9 @@ inline void llk_unpack_reconfig_data_format_srca(const std::uint32_t srca_new_op
     const std::uint32_t srca_operand_id = get_operand_id(srca_new_operand);
     const std::uint32_t num_faces = get_operand_num_faces(srca_operand_id);
     const std::uint32_t face_r_dim = get_operand_face_r_dim(srca_operand_id);
+    const std::uint32_t tile_size = get_local_cb_interface(srca_operand_id).fifo_page_size;
     _llk_unpack_reconfig_data_format_srca_impl_<is_fp32_dest_acc_en, to_from_int8>(
-        unpack_src_format[srca_operand_id], unpack_dst_format[srca_operand_id]);
+        unpack_src_format[srca_operand_id], unpack_dst_format[srca_operand_id], tile_size);
 }
 
 // TODO NC: Clean up as the part of tt-metal#34499
@@ -71,8 +76,9 @@ inline void llk_unpack_reconfig_data_format_srcb(const std::uint32_t srcb_new_op
     std::uint32_t srcb_operand_id = get_operand_id(srcb_new_operand);
     const std::uint32_t num_faces = get_operand_num_faces(srcb_operand_id);
     const std::uint32_t face_r_dim = get_operand_face_r_dim(srcb_operand_id);
+    const std::uint32_t tile_size = get_local_cb_interface(srcb_operand_id).fifo_page_size;
     _llk_unpack_reconfig_data_format_srcb_impl_<is_fp32_dest_acc_en, to_from_int8>(
-        unpack_src_format[srcb_operand_id], unpack_dst_format[srcb_operand_id]);
+        unpack_src_format[srcb_operand_id], unpack_dst_format[srcb_operand_id], tile_size);
 }
 
 // TODO NC: Clean up as the part of tt-metal#34499

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_common_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_common_api.h
@@ -20,6 +20,12 @@
  * LLK UNPACK COMMON
  *************************************************************************/
 
+// Overloaded function for single operand unpack
+template <bool is_fp32_dest_acc_en>
+inline void llk_unpack_hw_configure(const std::uint32_t unpA_operand) {
+    llk_unpack_hw_configure<is_fp32_dest_acc_en>(unpA_operand, unpB_operand);
+}
+
 template <bool is_fp32_dest_acc_en>
 inline void llk_unpack_hw_configure(const std::uint32_t unpA_operand, const std::uint32_t unpB_operand) {
     // In0 -> unpA

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_common_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_common_api.h
@@ -33,6 +33,9 @@ inline void llk_unpack_hw_configure(const std::uint32_t unpA_operand, const std:
     const uint32_t unpA_face_r_dim = get_operand_face_r_dim(unpA_operand_id);
     const uint32_t unpB_num_faces = get_operand_num_faces(unpB_operand_id);
     const uint32_t unpB_face_r_dim = get_operand_face_r_dim(unpB_operand_id);
+
+    // Currently, there is a constraint that tile size is equal to the fifo page size
+    // Should be removed and tile size should be computed in the LLK instead, as the part of #34495
     const uint32_t unpA_tile_size = get_local_cb_interface(unpA_operand_id).fifo_page_size;
     const uint32_t unpB_tile_size = get_local_cb_interface(unpB_operand_id).fifo_page_size;
 
@@ -137,24 +140,3 @@ inline void llk_unpack_reconfig_data_format(
 inline void llk_unpack_dbg_feature_disable() { _llk_unpack_dbg_feature_disable_(); }
 
 inline void llk_unpack_set_srcb_dummy_valid() { _llk_unpack_set_srcb_dummy_valid_(); }
-
-// All TILE_SIZE related functions were deprecared in BBE for WH.  The following is needed for pack_shifted so just
-// keeping here.
-// FIXME: Need to review and adjust accordingly
-constexpr static std::int32_t MUL_HEADERLESS_TILE_SIZE_AND_INDEX(uint format, uint index) {
-    switch (format & 0x1F) {
-        case ((uint8_t)DataFormat::Float32): return ((index << 8));
-        case ((uint8_t)DataFormat::Float16):
-        case ((uint8_t)DataFormat::Float16_b): return ((index << 7));
-        case ((uint8_t)DataFormat::Bfp8):
-        case ((uint8_t)DataFormat::Bfp8_b): return ((index << 6) + (index << 2));
-        case ((uint8_t)DataFormat::Bfp4):
-        case ((uint8_t)DataFormat::Bfp4_b): return ((index << 5) + (index << 2));
-        case ((uint8_t)DataFormat::Bfp2):
-        case ((uint8_t)DataFormat::Bfp2_b): return ((index << 4) + (index << 2));
-        case ((uint8_t)DataFormat::Int8):
-        case ((uint8_t)DataFormat::Lf8): return ((index << 6));
-        // Keep default as Bfp8?
-        default: return ((index << 6) + (index << 2));
-    };
-}

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_common_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_common_api.h
@@ -58,12 +58,9 @@ void llk_zero_operand(std::uint32_t operand) {
     _llk_zero_buffer_(fifo_base_addr, size);
 }
 
-inline void llk_unpack_debug_dump(std::uint8_t* data, std::uint32_t byte_size) {
-    _llk_unpack_debug_dump_(data, byte_size);
-}
-
 inline void llk_unpack_debug_dump_seek(std::uint8_t offset) { _llk_unpack_debug_dump_seek_(offset); }
 
+// TODO NC: Clean up as the part of tt-metal#34499
 template <bool is_fp32_dest_acc_en, bool to_from_int8 = false, bool is_tile_dim_reconfig_en = false>
 inline void llk_unpack_reconfig_data_format_srca(const std::uint32_t srca_new_operand) {
     const std::uint32_t srca_operand_id = get_operand_id(srca_new_operand);
@@ -75,6 +72,7 @@ inline void llk_unpack_reconfig_data_format_srca(const std::uint32_t srca_new_op
         get_local_cb_interface(srca_operand_id).fifo_page_size);
 }
 
+// TODO NC: Clean up as the part of tt-metal#34499
 template <bool is_fp32_dest_acc_en, bool to_from_int8 = false, bool is_tile_dim_reconfig_en = false>
 inline void llk_unpack_reconfig_data_format_srcb(const std::uint32_t srcb_new_operand) {
     std::uint32_t srcb_operand_id = get_operand_id(srcb_new_operand);
@@ -86,6 +84,7 @@ inline void llk_unpack_reconfig_data_format_srcb(const std::uint32_t srcb_new_op
         get_local_cb_interface(srcb_operand_id).fifo_page_size);
 }
 
+// TODO NC: Clean up as the part of tt-metal#34499
 template <bool is_fp32_dest_acc_en, bool to_from_int8 = false, bool is_tile_dim_reconfig_en = false>
 inline void llk_unpack_reconfig_data_format_srca(
     const std::uint32_t srca_old_operand, const std::uint32_t srca_new_operand) {
@@ -101,6 +100,7 @@ inline void llk_unpack_reconfig_data_format_srca(
     }
 }
 
+// TODO NC: Clean up as the part of tt-metal#34499
 template <bool is_fp32_dest_acc_en, bool to_from_int8 = false, bool is_tile_dim_reconfig_en = false>
 inline void llk_unpack_reconfig_data_format_srcb(
     const std::uint32_t srcb_old_operand, const std::uint32_t srcb_new_operand) {
@@ -116,6 +116,7 @@ inline void llk_unpack_reconfig_data_format_srcb(
     }
 }
 
+// TODO NC: Clean up as the part of tt-metal#34499
 template <bool is_fp32_dest_acc_en, bool to_from_int8 = false, bool is_tile_dim_reconfig_en = false>
 inline void llk_unpack_reconfig_data_format(
     const std::uint32_t srca_new_operand, const std::uint32_t srcb_new_operand) {
@@ -123,6 +124,7 @@ inline void llk_unpack_reconfig_data_format(
     llk_unpack_reconfig_data_format_srcb<is_fp32_dest_acc_en, to_from_int8, is_tile_dim_reconfig_en>(srcb_new_operand);
 }
 
+// TODO NC: Clean up as the part of tt-metal#34499
 template <bool is_fp32_dest_acc_en, bool to_from_int8 = false, bool is_tile_dim_reconfig_en = false>
 inline void llk_unpack_reconfig_data_format(
     const std::uint32_t srca_old_operand,
@@ -136,9 +138,6 @@ inline void llk_unpack_reconfig_data_format(
 }
 
 inline void llk_unpack_dbg_feature_disable() { _llk_unpack_dbg_feature_disable_(); }
-inline void llk_unpack_clear_dbg_feature_disable() { _llk_unpack_clear_dbg_feature_disable_(); }
-
-inline void llk_enable_int8_fpu_math() { _llk_enable_int8_fpu_math_(); }
 
 inline void llk_unpack_set_srcb_dummy_valid() { _llk_unpack_set_srcb_dummy_valid_(); }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_reduce_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_reduce_api.h
@@ -10,41 +10,6 @@
  * LLK UNPACK REDUCE
  *************************************************************************/
 
-template <PoolType type, ReduceDim dim, bool is_fp32_dest_acc_en, StochRndType stoch_rnd_mode = StochRndType::None>
-inline void llk_unpack_reduce_hw_configure(
-    const llk_unpack_reduce_params_t* unpack_reduce_params, const float const_mult) {
-    constexpr bool within_face_16x16_transpose = (ReduceDim::REDUCE_ROW == dim);
-
-    const std::uint32_t unpA_operand_id = get_operand_id(unpack_reduce_params->unpA_operand);
-    const std::uint32_t unpA_num_faces = get_operand_num_faces(unpA_operand_id);
-    const std::uint32_t unpA_face_r_dim = get_operand_face_r_dim(unpA_operand_id);
-
-    constexpr std::uint32_t unpB_src_format = (std::uint32_t)DataFormat::Float32;
-    const std::uint32_t unpB_dst_format =
-        ((std::uint32_t)unpack_dst_format[unpA_operand_id] == (std::uint32_t)DataFormat::Int8)
-            ? (std::uint32_t)DataFormat::Float16
-            :  // Int8 is treated as fp16_a
-            ((((std::uint32_t)unpack_dst_format[unpA_operand_id] >> 2) & 0x1) ? (std::uint32_t)DataFormat::Float16_b
-                                                                              : (std::uint32_t)DataFormat::Float16);
-
-    _llk_unpack_reduce_hw_configure_<is_fp32_dest_acc_en, stoch_rnd_mode>(
-        unpack_src_format[unpA_operand_id],
-        unpB_src_format,
-        unpack_dst_format[unpA_operand_id],
-        unpB_dst_format,
-        unpA_face_r_dim,
-        unpA_face_r_dim,
-        within_face_16x16_transpose,
-        unpA_num_faces,
-        unpA_num_faces);
-}
-
-template <PoolType type, ReduceDim dim, bool is_fp32_dest_acc_en, StochRndType stoch_rnd_mode = StochRndType::None>
-inline void llk_unpack_reduce_hw_configure_disaggregated(const std::uint32_t unpA_operand, const float mult) {
-    const llk_unpack_reduce_params_t unpack_reduce_params = {.unpA_operand = unpA_operand};
-    llk_unpack_reduce_hw_configure<type, dim, is_fp32_dest_acc_en, stoch_rnd_mode>(&unpack_reduce_params, mult);
-}
-
 template <PoolType type, ReduceDim dim>
 inline void llk_unpack_reduce_mop_config() {
     _llk_unpack_reduce_mop_config_<type, dim>();

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_tilize_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_tilize_api.h
@@ -78,42 +78,6 @@ inline void llk_unpack_tilize_block(std::uint32_t operand, std::uint32_t block_c
  * LLK UNPACK TILIZE SRC A, UNPACK SRC B
  *************************************************************************/
 
-template <bool is_fp32_dest_acc_en, StochRndType stoch_rnd_mode = StochRndType::None>
-inline void llk_unpack_tilizeA_B_hw_configure(
-    const llk_unpack_AB_params_t *unpack_tilizeA_B_params, const int within_face_16x16_transpose = 0) {
-    // In0 -> unpA
-    // In1 -> unpB
-    const uint32_t unpA_operand_id = get_operand_id(unpack_tilizeA_B_params->unpA_operand);
-    const uint32_t unpB_operand_id = get_operand_id(unpack_tilizeA_B_params->unpB_operand);
-
-    // unpA -> srcA
-    // Unpack only 1x16 row of datums to SrcA per UNPACK instruction
-    const uint32_t num_faces_a = get_operand_num_faces(unpA_operand_id);
-    const uint32_t face_r_dim_a = get_operand_face_r_dim(unpA_operand_id);
-
-    // unpB -> srcB
-    const uint32_t num_faces_b = get_operand_num_faces(unpB_operand_id);
-    const uint32_t face_r_dim_b = get_operand_face_r_dim(unpB_operand_id);
-    configure_unpack_AB<is_fp32_dest_acc_en, false, false, false>(
-        unpack_src_format[unpA_operand_id],
-        unpack_src_format[unpB_operand_id],
-        unpack_dst_format[unpA_operand_id],
-        unpack_dst_format[unpB_operand_id],
-        face_r_dim_a,
-        face_r_dim_b,
-        within_face_16x16_transpose,
-        num_faces_a,
-        num_faces_b);
-}
-
-template <bool is_fp32_dest_acc_en, StochRndType stoch_rnd_mode = StochRndType::None>
-inline void llk_unpack_tilizeA_B_hw_configure_disaggregated(
-    const std::uint32_t unpA_operand, const std::uint32_t unpB_operand, const int within_face_16x16_transpose = 0) {
-    const llk_unpack_AB_params_t unpack_tilizeA_B_params = {.unpA_operand = unpA_operand, .unpB_operand = unpB_operand};
-    llk_unpack_tilizeA_B_hw_configure<is_fp32_dest_acc_en, stoch_rnd_mode>(
-        &unpack_tilizeA_B_params, within_face_16x16_transpose);
-}
-
 // TODO: add support for all the template parameters
 template <bool neginf_srcA = false, std::uint32_t reload_srcB = false, bool zero_srcA = false, bool zero_srcA_reduce = false>
 inline void llk_unpack_tilizeA_B_mop_config(const bool narrow_tile = false, const std::uint32_t num_faces = 4) {

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_tilize_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_tilize_api.h
@@ -11,29 +11,6 @@
  * LLK UNPACK TILIZE
  *************************************************************************/
 
-template <bool is_fp32_dest_acc_en>
-inline void llk_unpack_tilize_hw_configure(const llk_unpack_A_params_t *unpack_tilize_params) {
-    constexpr bool within_face_16x16_transpose = false;
-    constexpr StochRndType stoch_rnd_mode = StochRndType::None;
-
-    const uint32_t unpA_operand_id = get_operand_id(unpack_tilize_params->unpA_operand);
-    const uint32_t unpA_num_faces = get_operand_num_faces(unpA_operand_id);
-    const uint32_t unpA_face_r_dim = get_operand_face_r_dim(unpA_operand_id);
-
-    _llk_unpack_tilize_hw_configure_<is_fp32_dest_acc_en, stoch_rnd_mode>(
-        unpack_src_format[unpA_operand_id],
-        unpack_dst_format[unpA_operand_id],
-        unpA_face_r_dim,
-        within_face_16x16_transpose,
-        unpA_num_faces);
-}
-
-template <bool is_fp32_dest_acc_en>
-inline void llk_unpack_tilize_hw_configure_disaggregated(const std::uint32_t unpA_operand) {
-    const llk_unpack_A_params_t unpack_tilize_params = {.unpA_operand = unpA_operand};
-    llk_unpack_tilize_hw_configure<is_fp32_dest_acc_en>(&unpack_tilize_params);
-}
-
 inline void llk_unpack_tilize_mop_config(const std::uint32_t operand) {
     std::uint32_t operand_id = get_operand_id(operand);
     const bool narrow_tile = get_operand_narrow_tile(operand_id);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_untilize_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_untilize_api.h
@@ -9,31 +9,6 @@
 /*************************************************************************
  * LLK UNPACK UNTILIZE
  *************************************************************************/
-template <bool is_fp32_dest_acc_en>
-inline void llk_unpack_untilize_hw_configure(const llk_unpack_A_params_t* unpack_untilize_params) {
-    constexpr bool is_row_pool = false;
-    constexpr bool within_face_16x16_transpose = false;
-    constexpr StochRndType stoch_rnd_mode = StochRndType::None;
-
-    const uint32_t unpA_operand_id = get_operand_id(unpack_untilize_params->unpA_operand);
-    const uint32_t unpA_num_faces = 4;
-    const uint32_t unpA_face_r_dim = FACE_R_DIM;
-
-    _llk_unpack_untilize_hw_configure_<is_fp32_dest_acc_en, stoch_rnd_mode>(
-        unpack_src_format[unpA_operand_id],
-        unpack_dst_format[unpA_operand_id],
-        unpA_face_r_dim,
-        within_face_16x16_transpose,
-        unpA_num_faces);
-}
-
-template <bool is_fp32_dest_acc_en>
-inline void llk_unpack_untilize_hw_configure_disaggregated(const std::uint32_t unpA_operand) {
-    const llk_unpack_A_params_t unpack_untilize_params = {
-        .unpA_operand = unpA_operand,
-    };
-    llk_unpack_untilize_hw_configure<is_fp32_dest_acc_en>(&unpack_untilize_params);
-}
 
 inline void llk_unpack_untilize_mop_config() { _llk_unpack_untilize_mop_config_(); }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_common_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_common_api.h
@@ -21,13 +21,10 @@
 /*************************************************************************
  * LLK MATH COMMON
  *************************************************************************/
-template <bool untilize_en = false, bool skip_inputs = false>
-inline void llk_math_hw_configure_disaggregated(const std::uint32_t srca_operand, const std::uint32_t srcb_operand) {
-    if constexpr (skip_inputs == false) {
-        std::uint32_t srca_operand_id = get_operand_id(srca_operand);
-        std::uint32_t srcb_operand_id = get_operand_id(srcb_operand);
-        _llk_math_hw_configure_<untilize_en>(unpack_dst_format[srca_operand_id], unpack_dst_format[srcb_operand_id]);
-    }
+inline void llk_math_hw_configure(const std::uint32_t srca_operand, const std::uint32_t srcb_operand) {
+    std::uint32_t srca_operand_id = get_operand_id(srca_operand);
+    std::uint32_t srcb_operand_id = get_operand_id(srcb_operand);
+    _llk_math_hw_configure_(unpack_dst_format[srca_operand_id], unpack_dst_format[srcb_operand_id]);
 }
 
 inline void llk_math_wait_for_dest_available() {

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_matmul_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_matmul_api.h
@@ -25,7 +25,7 @@ inline void llk_math_matmul_init(
     const std::uint32_t in1_tile_r_dim = get_operand_tile_r_dim(in1_id);
     const std::uint32_t in1_tile_c_dim = get_operand_tile_c_dim(in1_id);
 
-    const bool partial_face = (in0_tile_r_dim < FACE_R_DIM) || (in0_tile_c_dim < FACE_C_DIM);
+    const bool partial_face = (in0_tile_r_dim < FACE_R_DIM);
 
     _llk_math_matmul_init_<NUM_FIDELITY_PHASES, THROTTLE_LEVEL>(
         in0_tile_r_dim, in0_tile_c_dim, in1_tile_r_dim, in1_tile_c_dim, partial_face, transpose, ct_dim, rt_dim);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_matmul_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_matmul_api.h
@@ -29,11 +29,11 @@ inline void llk_math_matmul_init(
     const std::uint32_t in1_tile_r_dim = get_operand_tile_r_dim(in1_id);
     const std::uint32_t in1_tile_c_dim = get_operand_tile_c_dim(in1_id);
 
-    _llk_math_matmul_init_<NUM_FIDELITY_PHASES, DstTileFaceLayout::RowMajor, THROTTLE_LEVEL>(
+    _llk_math_matmul_init_<NUM_FIDELITY_PHASES, THROTTLE_LEVEL>(
         in0_tile_r_dim, in0_tile_c_dim, in1_tile_r_dim, in1_tile_c_dim, partial_face, transpose, ct_dim, rt_dim);
 }
 
 template <int NUM_FIDELITY_PHASES, int THROTTLE_LEVEL = 0, uint32_t num_faces = 4 /*not used*/>
 inline void llk_math_matmul(const uint dst_index, const std::uint32_t ct_dim = 1, const std::uint32_t rt_dim = 1) {
-    _llk_math_matmul_<NUM_FIDELITY_PHASES, DstTileFaceLayout::RowMajor, THROTTLE_LEVEL>(dst_index, ct_dim, rt_dim);
+    _llk_math_matmul_<NUM_FIDELITY_PHASES, THROTTLE_LEVEL>(dst_index, ct_dim, rt_dim);
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_matmul_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_matmul_api.h
@@ -26,14 +26,10 @@ inline void llk_math_matmul_init(
     const std::uint32_t in1_tile_c_dim = get_operand_tile_c_dim(in1_id);
 
     // Determine if we have partial faces (tiny tiles)
-    // The matmul operation is D = B*A where in0->srcB and in1->srcA
-    // A partial face occurs when tile has non-standard face dimensions (row or col dim != 16)
-    // For matmul address mode configuration, we specifically need to check if in0 (srcB) has partial faces
-    // Example: 8x32 tile has 8<=16 rows and 32>16 cols, requiring special address mode handling
-    const bool is_in0_16x32 = (in0_tile_r_dim <= 16) && (in0_tile_c_dim > 16);
-    const bool is_in0_32x16 = (in0_tile_r_dim > 16) && (in0_tile_c_dim <= 16);
-    // A tile is partial face if it's not the standard 32x32 AND has mismatched dimensions (one dim <=16, other >16)
-    const bool partial_face = (is_in0_16x32 || is_in0_32x16);
+    // A partial face has a dimension < 16 (FACE_R_DIM or FACE_C_DIM)
+    // Examples: 8x32 has 8<16 rows (partial), 16x32 has full 16x16 faces (not partial)
+    //           32x16 has full 16x16 faces (not partial)
+    const bool partial_face = (in0_tile_r_dim < 16) || (in0_tile_c_dim < 16);
 
     _llk_math_matmul_init_<NUM_FIDELITY_PHASES, THROTTLE_LEVEL>(
         in0_tile_r_dim, in0_tile_c_dim, in1_tile_r_dim, in1_tile_c_dim, partial_face, transpose, ct_dim, rt_dim);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_matmul_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_matmul_api.h
@@ -25,11 +25,7 @@ inline void llk_math_matmul_init(
     const std::uint32_t in1_tile_r_dim = get_operand_tile_r_dim(in1_id);
     const std::uint32_t in1_tile_c_dim = get_operand_tile_c_dim(in1_id);
 
-    // Determine if we have partial faces (tiny tiles)
-    // A partial face has a dimension < 16 (FACE_R_DIM or FACE_C_DIM)
-    // Examples: 8x32 has 8<16 rows (partial), 16x32 has full 16x16 faces (not partial)
-    //           32x16 has full 16x16 faces (not partial)
-    const bool partial_face = (in0_tile_r_dim < 16) || (in0_tile_c_dim < 16);
+    const bool partial_face = (in0_tile_r_dim < FACE_R_DIM) || (in0_tile_c_dim < FACE_C_DIM);
 
     _llk_math_matmul_init_<NUM_FIDELITY_PHASES, THROTTLE_LEVEL>(
         in0_tile_r_dim, in0_tile_c_dim, in1_tile_r_dim, in1_tile_c_dim, partial_face, transpose, ct_dim, rt_dim);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h
@@ -346,7 +346,7 @@ inline void llk_init_packer_dest_offset_registers(const std::uint32_t pack_outpu
     const std::uint32_t face_r_dim = get_output_face_r_dim(output_id);
     const bool narrow_tile = get_output_narrow_tile(output_id);
 
-    _llk_init_packer_dest_offset_registers_<DST_SYNC_MODE, untilize, diagonal>(face_r_dim, narrow_tile);
+    _llk_init_packer_dest_offset_registers_<DST_SYNC_MODE, untilize>(face_r_dim, narrow_tile);
 }
 
 template <bool is_fp32_dest_acc_en, bool untilize = false>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h
@@ -355,6 +355,7 @@ inline void llk_pack_reconfig_data_format(const std::uint32_t new_output) {
         narrow_tile);
 }
 
+// TODO NC: Clean up as the part of tt-metal#34499
 template <bool is_fp32_dest_acc_en, bool is_tile_dim_reconfig_en = false>
 inline void llk_pack_reconfig_data_format(const std::uint32_t old_output, const std::uint32_t new_output) {
     std::uint32_t old_output_id = get_output_id(old_output);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h
@@ -23,6 +23,7 @@
  * LLK PACK
  *************************************************************************/
 
+// TODO NC: can be removed altogether:
 template <bool untilize = false, bool zero_output = false>
 inline void llk_pack_mop_config(const uint32_t output) {
     const std::uint32_t output_id = get_output_id(output);
@@ -31,7 +32,7 @@ inline void llk_pack_mop_config(const uint32_t output) {
     const bool partial_face = get_output_partial_face(output_id) && IS_BFP_FORMAT((uint)pack_dst_format[output_id]);
     const bool narrow_tile = get_output_narrow_tile(output_id);
 
-    _llk_pack_mop_config_<untilize, zero_output, false>(
+    _llk_pack_mop_config_<untilize, zero_output>(
         pack_dst_format[output_id], face_r_dim, num_faces, partial_face, narrow_tile);
 }
 
@@ -154,7 +155,7 @@ inline void llk_pack_init(const std::uint32_t pack_output = 16) {
     const bool partial_face = get_output_partial_face(output_id);
     const bool narrow_tile = get_output_narrow_tile(output_id);
 
-    _llk_pack_init_<untilize, zero_output, false>(
+    _llk_pack_init_<untilize, zero_output>(
         pack_dst_format[output_id], pack_src_format[output_id], face_r_dim, num_faces, partial_face, narrow_tile, true);
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h
@@ -31,7 +31,7 @@ inline void llk_pack_mop_config(const uint32_t output) {
     const bool partial_face = get_output_partial_face(output_id) && IS_BFP_FORMAT((uint)pack_dst_format[output_id]);
     const bool narrow_tile = get_output_narrow_tile(output_id);
 
-    _llk_pack_mop_config_<untilize, zero_output, DstTileFaceLayout::RowMajor, false>(
+    _llk_pack_mop_config_<untilize, zero_output, false>(
         pack_dst_format[output_id], face_r_dim, num_faces, partial_face, narrow_tile);
 }
 
@@ -154,7 +154,7 @@ inline void llk_pack_init(const std::uint32_t pack_output = 16) {
     const bool partial_face = get_output_partial_face(output_id);
     const bool narrow_tile = get_output_narrow_tile(output_id);
 
-    _llk_pack_init_<untilize, zero_output, DstTileFaceLayout::RowMajor, false>(
+    _llk_pack_init_<untilize, zero_output, false>(
         pack_dst_format[output_id], pack_src_format[output_id], face_r_dim, num_faces, partial_face, narrow_tile, true);
 }
 
@@ -345,8 +345,7 @@ inline void llk_init_packer_dest_offset_registers(const std::uint32_t pack_outpu
     const std::uint32_t face_r_dim = get_output_face_r_dim(output_id);
     const bool narrow_tile = get_output_narrow_tile(output_id);
 
-    _llk_init_packer_dest_offset_registers_<DST_SYNC_MODE, DstTileFaceLayout::RowMajor, untilize, diagonal>(
-        face_r_dim, narrow_tile);
+    _llk_init_packer_dest_offset_registers_<DST_SYNC_MODE, untilize, diagonal>(face_r_dim, narrow_tile);
 }
 
 template <bool is_fp32_dest_acc_en, bool untilize = false>
@@ -355,8 +354,7 @@ inline void llk_pack_dest_init(const std::uint32_t pack_output = 16) {
     const std::uint32_t face_r_dim = get_output_face_r_dim(output_id);
     const bool narrow_tile = get_output_narrow_tile(output_id);
 
-    _llk_pack_dest_init_<DST_SYNC_MODE, is_fp32_dest_acc_en, DstTileFaceLayout::RowMajor, untilize>(
-        face_r_dim, narrow_tile);
+    _llk_pack_dest_init_<DST_SYNC_MODE, is_fp32_dest_acc_en, untilize>(face_r_dim, narrow_tile);
 }
 
 template <bool mail2math = true, bool mail2pack = true>
@@ -381,7 +379,7 @@ inline void llk_pack_reconfig_data_format(const std::uint32_t new_output) {
     const bool partial_face = get_output_partial_face(output_id);
     const bool narrow_tile = get_output_narrow_tile(output_id);
 
-    _llk_pack_reconfig_data_format_<is_fp32_dest_acc_en, is_tile_dim_reconfig_en, DstTileFaceLayout::RowMajor>(
+    _llk_pack_reconfig_data_format_<is_fp32_dest_acc_en, is_tile_dim_reconfig_en>(
         pack_src_format[output_id],
         pack_dst_format[output_id],
         get_local_cb_interface(output_id).fifo_page_size,

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h
@@ -112,41 +112,6 @@ inline void llk_pack_untilize_hw_configure_disaggregated(
     llk_pack_untilize_hw_configure<is_fp32_dest_acc_en, untilize>(&llk_pack_params, face_r_dim, num_faces);
 }
 
-template <PoolType type, ReduceDim dim, bool is_fp32_dest_acc_en, bool untilize = false>
-inline void llk_pack_reduce_hw_configure(const llk_pack_params_t* pack_params) {
-    const std::uint32_t output_id = get_output_id(pack_params->pack_output);
-    const std::uint32_t face_r_dim = get_output_face_r_dim(output_id);
-    const std::uint32_t num_faces = get_output_num_faces(output_id);
-    const bool partial_face = get_output_partial_face(output_id);
-    const bool narrow_tile = get_output_narrow_tile(output_id);
-
-    const std::uint32_t tile_size = get_local_cb_interface(output_id).fifo_page_size;
-
-    _llk_pack_reduce_hw_configure_<type, dim, is_fp32_dest_acc_en, untilize>(
-        pack_src_format[output_id],
-        pack_dst_format[output_id],
-        tile_size,
-        face_r_dim,
-        num_faces,
-        partial_face,
-        narrow_tile,
-        pack_params->relu_config.val);
-}
-
-template <
-    PoolType type,
-    ReduceDim dim,
-    bool is_fp32_dest_acc_en,
-    bool untilize = false,
-    ReluType relu_type = ReluType::NO_RELU,
-    std::uint32_t relu_threshold = 0>
-inline void llk_pack_reduce_hw_configure_disaggregated(std::uint32_t pack_output) {
-    llk_pack_params_t llk_pack_params = {
-        .pack_output = pack_output,
-        .relu_config = {.f = {.ApplyRelu = (std::uint32_t)relu_type, .Threshold = relu_threshold}}};
-    llk_pack_reduce_hw_configure<type, dim, is_fp32_dest_acc_en, untilize>(&llk_pack_params);
-}
-
 template <bool untilize = false, bool zero_output = false, bool tilize = false /*unused*/>
 inline void llk_pack_init(const std::uint32_t pack_output = 16) {
     const std::uint32_t output_id = get_output_id(pack_output);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h
@@ -23,7 +23,7 @@
  * LLK PACK
  *************************************************************************/
 
-// TODO NC: can be removed altogether:
+// TODO NC: Remove as the part of tt-metal#34499
 template <bool untilize = false, bool zero_output = false>
 inline void llk_pack_mop_config(const uint32_t output) {
     const std::uint32_t output_id = get_output_id(output);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_AB_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_AB_api.h
@@ -10,37 +10,6 @@
  * LLK UNPACK AB
  *************************************************************************/
 
-template <bool is_fp32_dest_acc_en, StochRndType stoch_rnd_mode = StochRndType::None>
-inline void llk_unpack_AB_hw_configure(
-    const llk_unpack_AB_params_t* unpack_AB_params, const int within_face_16x16_transpose = 0) {
-    // In0 -> unpA
-    // In1 -> unpB
-    const uint32_t unpA_operand_id = get_operand_id(unpack_AB_params->unpA_operand);
-    const uint32_t unpB_operand_id = get_operand_id(unpack_AB_params->unpB_operand);
-
-    // unpA -> srcA
-    // unpB -> srcB
-    const uint32_t num_faces = get_operand_num_faces(unpA_operand_id);    // num faces in unpA and unpB are the same
-    const uint32_t face_r_dim = get_operand_face_r_dim(unpA_operand_id);  // face r dim in unpA and unpB are the same
-
-    _llk_unpack_AB_hw_configure_<is_fp32_dest_acc_en, stoch_rnd_mode>(
-        unpack_src_format[unpA_operand_id],
-        unpack_src_format[unpB_operand_id],
-        unpack_dst_format[unpA_operand_id],
-        unpack_dst_format[unpB_operand_id],
-        face_r_dim,
-        within_face_16x16_transpose,
-        num_faces);
-}
-
-template <bool is_fp32_dest_acc_en, StochRndType stoch_rnd_mode = StochRndType::None>
-inline void llk_unpack_AB_hw_configure_disaggregated(
-    const std::uint32_t unpA_operand, const std::uint32_t unpB_operand, const int within_face_16x16_transpose = 0) {
-    const llk_unpack_AB_params_t unpack_AB_params = {.unpA_operand = unpA_operand, .unpB_operand = unpB_operand};
-
-    llk_unpack_AB_hw_configure<is_fp32_dest_acc_en, stoch_rnd_mode>(&unpack_AB_params, within_face_16x16_transpose);
-}
-
 template <BroadcastType BType = BroadcastType::NONE>
 inline void llk_unpack_AB_mop_config(const bool transpose_of_faces = false, const std::uint32_t operand_id = 0) {
     const std::uint32_t num_faces = get_operand_num_faces(operand_id);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_AB_matmul_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_AB_matmul_api.h
@@ -40,11 +40,6 @@ __attribute__((always_inline)) inline void llk_unpack_AB_matmul_init(
     const uint32_t unpB_num_faces =
         partial_face_b ? 1 : get_operand_num_faces(operandB_id);  // if partial face -> unpack face by face
 
-    // Currently, there is a constraint that tile size is equal to the fifo page size
-    // Should be removed and tile size should be computed in the LLK instead, as the part of #34495
-    const uint32_t unpA_tile_size_in_bytes = get_local_cb_interface(operandA_id).fifo_page_size;
-    const uint32_t unpB_tile_size_in_bytes = get_local_cb_interface(operandB_id).fifo_page_size;
-
     _llk_unpack_AB_matmul_init_(
         transpose,
         ct_dim,
@@ -55,9 +50,7 @@ __attribute__((always_inline)) inline void llk_unpack_AB_matmul_init(
         unpA_num_faces,
         unpB_num_faces,
         partial_face_a,
-        partial_face_b,
-        unpA_tile_size_in_bytes,
-        unpB_tile_size_in_bytes);
+        partial_face_b);
 }
 
 inline void llk_unpack_AB_matmul(

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_AB_matmul_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_AB_matmul_api.h
@@ -40,8 +40,10 @@ __attribute__((always_inline)) inline void llk_unpack_AB_matmul_init(
     const uint32_t unpB_num_faces =
         partial_face_b ? 1 : get_operand_num_faces(operandB_id);  // if partial face -> unpack face by face
 
-    const uint32_t unpA_tile_size = get_local_cb_interface(operandA_id).fifo_page_size;
-    const uint32_t unpB_tile_size = get_local_cb_interface(operandB_id).fifo_page_size;
+    // Currently, there is a constraint that tile size is equal to the fifo page size
+    // Should be removed and tile size should be computed in the LLK instead, as the part of #34495
+    const uint32_t unpA_tile_size_in_bytes = get_local_cb_interface(operandA_id).fifo_page_size;
+    const uint32_t unpB_tile_size_in_bytes = get_local_cb_interface(operandB_id).fifo_page_size;
 
     _llk_unpack_AB_matmul_init_(
         transpose,
@@ -54,8 +56,8 @@ __attribute__((always_inline)) inline void llk_unpack_AB_matmul_init(
         unpB_num_faces,
         partial_face_a,
         partial_face_b,
-        unpA_tile_size,
-        unpB_tile_size);
+        unpA_tile_size_in_bytes,
+        unpB_tile_size_in_bytes);
 }
 
 inline void llk_unpack_AB_matmul(

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_A_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_A_api.h
@@ -30,12 +30,12 @@ template <
     BroadcastType BType = BroadcastType::NONE,
     bool acc_to_dest = false,
     EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE,
-    bool unpack_to_dest = false>
+    bool unpack_to_dest = false,
+    bool disable_src_zero_flag = false>
 inline void llk_unpack_A_init(
     const std::uint32_t transpose_of_faces = 0,
     const std::uint32_t within_face_16x16_transpose = 0,
     const std::uint32_t operand = 0) {
-
     const std::uint32_t operand_id = get_operand_id(operand);
     const std::uint32_t face_r_dim = get_operand_face_r_dim(operand_id);
     const std::uint32_t num_faces = get_operand_num_faces(operand_id);
@@ -52,7 +52,8 @@ inline void llk_unpack_A_init(
         face_r_dim,
         num_faces,
         operand_unpack_src_format,
-        operand_unpack_dst_format);
+        operand_unpack_dst_format,
+        disable_src_zero_flag);
 }
 
 template <

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_A_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_A_api.h
@@ -11,35 +11,6 @@
  *************************************************************************/
 
 template <
-    bool is_fp32_dest_acc_en,
-    StochRndType stoch_rnd_mode = StochRndType::None,
-    bool disable_src_zero_flag = false>
-inline void llk_unpack_A_hw_configure(
-    const llk_unpack_A_params_t* unpack_A_params, const int within_face_16x16_transpose = 0) {
-    const uint32_t unpA_operand_id = get_operand_id(unpack_A_params->unpA_operand);
-    const uint32_t unpA_num_faces = get_operand_num_faces(unpA_operand_id);
-    const uint32_t unpA_face_r_dim = get_operand_face_r_dim(unpA_operand_id);
-
-    _llk_unpack_A_hw_configure_<is_fp32_dest_acc_en, stoch_rnd_mode, disable_src_zero_flag>(
-        unpack_src_format[unpA_operand_id],
-        unpack_dst_format[unpA_operand_id],
-        unpA_face_r_dim,
-        within_face_16x16_transpose,
-        unpA_num_faces);
-}
-
-template <
-    bool is_fp32_dest_acc_en,
-    StochRndType stoch_rnd_mode = StochRndType::None,
-    bool disable_src_zero_flag = false>
-inline void llk_unpack_A_hw_configure_disaggregated(
-    const std::uint32_t unpA_operand, const int within_face_16x16_transpose = 0) {
-    const llk_unpack_A_params_t unpack_A_params = {.unpA_operand = unpA_operand};
-    llk_unpack_A_hw_configure<is_fp32_dest_acc_en, stoch_rnd_mode, disable_src_zero_flag>(
-        &unpack_A_params, within_face_16x16_transpose);
-}
-
-template <
     BroadcastType BType = BroadcastType::NONE,
     bool acc_to_dest = false,
     EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE,

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_A_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_A_api.h
@@ -30,8 +30,7 @@ template <
     BroadcastType BType = BroadcastType::NONE,
     bool acc_to_dest = false,
     EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE,
-    bool unpack_to_dest = false,
-    bool disable_src_zero_flag = false>
+    bool unpack_to_dest = false>
 inline void llk_unpack_A_init(
     const std::uint32_t transpose_of_faces = 0,
     const std::uint32_t within_face_16x16_transpose = 0,
@@ -52,8 +51,7 @@ inline void llk_unpack_A_init(
         face_r_dim,
         num_faces,
         operand_unpack_src_format,
-        operand_unpack_dst_format,
-        disable_src_zero_flag);
+        operand_unpack_dst_format);
 }
 
 template <

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_common_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_common_api.h
@@ -20,7 +20,7 @@
  * LLK UNPACK COMMON
  *************************************************************************/
 
-template <bool is_fp32_dest_acc_en>
+template <bool is_fp32_dest_acc_en, bool disable_src_zero_flag = false>
 inline void llk_unpack_hw_configure(const std::uint32_t unpA_operand, const std::uint32_t unpB_operand) {
     // In0 -> unpA
     // In1 -> unpB
@@ -34,7 +34,7 @@ inline void llk_unpack_hw_configure(const std::uint32_t unpA_operand, const std:
     const uint32_t unpB_num_faces = get_operand_num_faces(unpB_operand_id);
     const uint32_t unpB_face_r_dim = get_operand_face_r_dim(unpB_operand_id);
 
-    _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
+    _llk_unpack_hw_configure_<is_fp32_dest_acc_en, disable_src_zero_flag>(
         unpack_src_format[unpA_operand_id],
         unpack_src_format[unpB_operand_id],
         unpack_dst_format[unpA_operand_id],
@@ -45,9 +45,9 @@ inline void llk_unpack_hw_configure(const std::uint32_t unpA_operand, const std:
         unpB_num_faces);
 }
 
-template <bool is_fp32_dest_acc_en>
+template <bool is_fp32_dest_acc_en, bool disable_src_zero_flag = false>
 inline void llk_unpack_hw_configure(const std::uint32_t unpA_operand) {
-    llk_unpack_hw_configure<is_fp32_dest_acc_en>(unpA_operand, unpA_operand);
+    llk_unpack_hw_configure<is_fp32_dest_acc_en, disable_src_zero_flag>(unpA_operand, unpA_operand);
 }
 
 inline bool should_reconfigure_cbs(std::uint32_t old_operand, std::uint32_t new_operand) {

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_common_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_common_api.h
@@ -54,7 +54,6 @@ inline bool should_reconfigure_cbs(std::uint32_t old_operand, std::uint32_t new_
     return (unpack_src_format[old_operand] != unpack_src_format[new_operand]) ||
            (unpack_dst_format[old_operand] != unpack_dst_format[new_operand]);
 }
-}
 
 // TODO NC: Clean up as the part of tt-metal#34499
 template <bool is_fp32_dest_acc_en, bool to_from_int8 = false, bool is_tile_dim_reconfig_en = false>
@@ -63,9 +62,7 @@ inline void llk_unpack_reconfig_data_format_srca(const std::uint32_t srca_new_op
     const std::uint32_t num_faces = get_operand_num_faces(srca_operand_id);
     const std::uint32_t face_r_dim = get_operand_face_r_dim(srca_operand_id);
     _llk_unpack_reconfig_data_format_srca_impl_<is_fp32_dest_acc_en, to_from_int8>(
-        unpack_src_format[srca_operand_id],
-        unpack_dst_format[srca_operand_id],
-        get_local_cb_interface(srca_operand_id).fifo_page_size);
+        unpack_src_format[srca_operand_id], unpack_dst_format[srca_operand_id]);
 }
 
 // TODO NC: Clean up as the part of tt-metal#34499
@@ -75,9 +72,7 @@ inline void llk_unpack_reconfig_data_format_srcb(const std::uint32_t srcb_new_op
     const std::uint32_t num_faces = get_operand_num_faces(srcb_operand_id);
     const std::uint32_t face_r_dim = get_operand_face_r_dim(srcb_operand_id);
     _llk_unpack_reconfig_data_format_srcb_impl_<is_fp32_dest_acc_en, to_from_int8>(
-        unpack_src_format[srcb_operand_id],
-        unpack_dst_format[srcb_operand_id],
-        get_local_cb_interface(srcb_operand_id).fifo_page_size);
+        unpack_src_format[srcb_operand_id], unpack_dst_format[srcb_operand_id]);
 }
 
 // TODO NC: Clean up as the part of tt-metal#34499

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_common_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_common_api.h
@@ -29,16 +29,21 @@ inline void llk_unpack_hw_configure(const std::uint32_t unpA_operand, const std:
 
     // unpA -> srcA
     // unpB -> srcB
-    const uint32_t num_faces = get_operand_num_faces(unpA_operand_id);    // num faces in unpA and unpB are the same
-    const uint32_t face_r_dim = get_operand_face_r_dim(unpA_operand_id);  // face r dim in unpA and unpB are the same
+    // Note: For matmul with tiny tiles, operands can have different face dimensions
+    const uint32_t unpA_num_faces = get_operand_num_faces(unpA_operand_id);
+    const uint32_t unpA_face_r_dim = get_operand_face_r_dim(unpA_operand_id);
+    const uint32_t unpB_num_faces = get_operand_num_faces(unpB_operand_id);
+    const uint32_t unpB_face_r_dim = get_operand_face_r_dim(unpB_operand_id);
 
     _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
         unpack_src_format[unpA_operand_id],
         unpack_src_format[unpB_operand_id],
         unpack_dst_format[unpA_operand_id],
         unpack_dst_format[unpB_operand_id],
-        face_r_dim,
-        num_faces);
+        unpA_face_r_dim,
+        unpB_face_r_dim,
+        unpA_num_faces,
+        unpB_num_faces);
 }
 
 inline bool should_reconfigure_cbs(std::uint32_t old_operand, std::uint32_t new_operand) {

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_common_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_common_api.h
@@ -20,12 +20,6 @@
  * LLK UNPACK COMMON
  *************************************************************************/
 
-// Overloaded function for single operand unpack
-template <bool is_fp32_dest_acc_en>
-inline void llk_unpack_hw_configure(const std::uint32_t unpA_operand) {
-    llk_unpack_hw_configure<is_fp32_dest_acc_en>(unpA_operand, unpA_operand);
-}
-
 template <bool is_fp32_dest_acc_en>
 inline void llk_unpack_hw_configure(const std::uint32_t unpA_operand, const std::uint32_t unpB_operand) {
     // In0 -> unpA
@@ -49,6 +43,11 @@ inline void llk_unpack_hw_configure(const std::uint32_t unpA_operand, const std:
         unpB_face_r_dim,
         unpA_num_faces,
         unpB_num_faces);
+}
+
+template <bool is_fp32_dest_acc_en>
+inline void llk_unpack_hw_configure(const std::uint32_t unpA_operand) {
+    llk_unpack_hw_configure<is_fp32_dest_acc_en>(unpA_operand, unpA_operand);
 }
 
 inline bool should_reconfigure_cbs(std::uint32_t old_operand, std::uint32_t new_operand) {

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_common_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_common_api.h
@@ -23,7 +23,7 @@
 // Overloaded function for single operand unpack
 template <bool is_fp32_dest_acc_en>
 inline void llk_unpack_hw_configure(const std::uint32_t unpA_operand) {
-    llk_unpack_hw_configure<is_fp32_dest_acc_en>(unpA_operand, unpB_operand);
+    llk_unpack_hw_configure<is_fp32_dest_acc_en>(unpA_operand, unpA_operand);
 }
 
 template <bool is_fp32_dest_acc_en>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_common_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_common_api.h
@@ -20,6 +20,27 @@
  * LLK UNPACK COMMON
  *************************************************************************/
 
+template <bool is_fp32_dest_acc_en>
+inline void llk_unpack_hw_configure(const std::uint32_t unpA_operand, const std::uint32_t unpB_operand) {
+    // In0 -> unpA
+    // In1 -> unpB
+    const uint32_t unpA_operand_id = get_operand_id(unpA_operand);
+    const uint32_t unpB_operand_id = get_operand_id(unpB_operand);
+
+    // unpA -> srcA
+    // unpB -> srcB
+    const uint32_t num_faces = get_operand_num_faces(unpA_operand_id);    // num faces in unpA and unpB are the same
+    const uint32_t face_r_dim = get_operand_face_r_dim(unpA_operand_id);  // face r dim in unpA and unpB are the same
+
+    _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
+        unpack_src_format[unpA_operand_id],
+        unpack_src_format[unpB_operand_id],
+        unpack_dst_format[unpA_operand_id],
+        unpack_dst_format[unpB_operand_id],
+        face_r_dim,
+        num_faces);
+}
+
 inline bool should_reconfigure_cbs(std::uint32_t old_operand, std::uint32_t new_operand) {
     return (unpack_src_format[old_operand] != unpack_src_format[new_operand]) ||
            (unpack_dst_format[old_operand] != unpack_dst_format[new_operand]);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_common_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_common_api.h
@@ -33,6 +33,9 @@ inline void llk_unpack_hw_configure(const std::uint32_t unpA_operand, const std:
     const uint32_t unpA_face_r_dim = get_operand_face_r_dim(unpA_operand_id);
     const uint32_t unpB_num_faces = get_operand_num_faces(unpB_operand_id);
     const uint32_t unpB_face_r_dim = get_operand_face_r_dim(unpB_operand_id);
+
+    // Currently, there is a constraint that tile size is equal to the fifo page size
+    // TODO NC: tile size should be computed in the LLK instead, as the part of #34495
     const uint32_t unpA_tile_size = get_local_cb_interface(unpA_operand_id).fifo_page_size;
     const uint32_t unpB_tile_size = get_local_cb_interface(unpB_operand_id).fifo_page_size;
 
@@ -65,6 +68,9 @@ inline void llk_unpack_reconfig_data_format_srca(const std::uint32_t srca_new_op
     const std::uint32_t srca_operand_id = get_operand_id(srca_new_operand);
     const std::uint32_t num_faces = get_operand_num_faces(srca_operand_id);
     const std::uint32_t face_r_dim = get_operand_face_r_dim(srca_operand_id);
+
+    // Currently, there is a constraint that tile size is equal to the fifo page size
+    // TODO NC: tile size should be computed in the LLK instead, as the part of #34495
     const std::uint32_t tile_size = get_local_cb_interface(srca_operand_id).fifo_page_size;
     _llk_unpack_reconfig_data_format_srca_impl_<is_fp32_dest_acc_en, to_from_int8>(
         unpack_src_format[srca_operand_id], unpack_dst_format[srca_operand_id], tile_size);
@@ -76,6 +82,9 @@ inline void llk_unpack_reconfig_data_format_srcb(const std::uint32_t srcb_new_op
     std::uint32_t srcb_operand_id = get_operand_id(srcb_new_operand);
     const std::uint32_t num_faces = get_operand_num_faces(srcb_operand_id);
     const std::uint32_t face_r_dim = get_operand_face_r_dim(srcb_operand_id);
+
+    // Currently, there is a constraint that tile size is equal to the fifo page size
+    // TODO NC: tile size should be computed in the LLK instead, as the part of #34495
     const std::uint32_t tile_size = get_local_cb_interface(srcb_operand_id).fifo_page_size;
     _llk_unpack_reconfig_data_format_srcb_impl_<is_fp32_dest_acc_en, to_from_int8>(
         unpack_src_format[srcb_operand_id], unpack_dst_format[srcb_operand_id], tile_size);
@@ -137,24 +146,3 @@ inline void llk_unpack_reconfig_data_format(
 inline void llk_unpack_dbg_feature_disable() { _llk_unpack_dbg_feature_disable_(); }
 
 inline void llk_unpack_set_srcb_dummy_valid() { _llk_unpack_set_srcb_dummy_valid_(); }
-
-// All TILE_SIZE related functions were deprecared in BBE for WH.  The following is needed for pack_shifted so just
-// keeping here.
-// FIXME: Need to review and adjust accordingly
-constexpr static std::int32_t MUL_HEADERLESS_TILE_SIZE_AND_INDEX(uint format, uint index) {
-    switch (format & 0x1F) {
-        case ((uint8_t)DataFormat::Float32): return ((index << 8));
-        case ((uint8_t)DataFormat::Float16):
-        case ((uint8_t)DataFormat::Float16_b): return ((index << 7));
-        case ((uint8_t)DataFormat::Bfp8):
-        case ((uint8_t)DataFormat::Bfp8_b): return ((index << 6) + (index << 2));
-        case ((uint8_t)DataFormat::Bfp4):
-        case ((uint8_t)DataFormat::Bfp4_b): return ((index << 5) + (index << 2));
-        case ((uint8_t)DataFormat::Bfp2):
-        case ((uint8_t)DataFormat::Bfp2_b): return ((index << 4) + (index << 2));
-        case ((uint8_t)DataFormat::Int8):
-        case ((uint8_t)DataFormat::Lf8): return ((index << 6));
-        // Keep default as Bfp8?
-        default: return ((index << 6) + (index << 2));
-    };
-}

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_common_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_common_api.h
@@ -29,7 +29,6 @@ inline void llk_unpack_hw_configure(const std::uint32_t unpA_operand, const std:
 
     // unpA -> srcA
     // unpB -> srcB
-    // Note: For matmul with tiny tiles, operands can have different face dimensions
     const uint32_t unpA_num_faces = get_operand_num_faces(unpA_operand_id);
     const uint32_t unpA_face_r_dim = get_operand_face_r_dim(unpA_operand_id);
     const uint32_t unpB_num_faces = get_operand_num_faces(unpB_operand_id);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_common_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_common_api.h
@@ -33,6 +33,8 @@ inline void llk_unpack_hw_configure(const std::uint32_t unpA_operand, const std:
     const uint32_t unpA_face_r_dim = get_operand_face_r_dim(unpA_operand_id);
     const uint32_t unpB_num_faces = get_operand_num_faces(unpB_operand_id);
     const uint32_t unpB_face_r_dim = get_operand_face_r_dim(unpB_operand_id);
+    const uint32_t unpA_tile_size = get_local_cb_interface(unpA_operand_id).fifo_page_size;
+    const uint32_t unpB_tile_size = get_local_cb_interface(unpB_operand_id).fifo_page_size;
 
     _llk_unpack_hw_configure_<is_fp32_dest_acc_en, disable_src_zero_flag>(
         unpack_src_format[unpA_operand_id],
@@ -42,7 +44,9 @@ inline void llk_unpack_hw_configure(const std::uint32_t unpA_operand, const std:
         unpA_face_r_dim,
         unpB_face_r_dim,
         unpA_num_faces,
-        unpB_num_faces);
+        unpB_num_faces,
+        unpA_tile_size,
+        unpB_tile_size);
 }
 
 template <bool is_fp32_dest_acc_en, bool disable_src_zero_flag = false>
@@ -61,8 +65,9 @@ inline void llk_unpack_reconfig_data_format_srca(const std::uint32_t srca_new_op
     const std::uint32_t srca_operand_id = get_operand_id(srca_new_operand);
     const std::uint32_t num_faces = get_operand_num_faces(srca_operand_id);
     const std::uint32_t face_r_dim = get_operand_face_r_dim(srca_operand_id);
+    const std::uint32_t tile_size = get_local_cb_interface(srca_operand_id).fifo_page_size;
     _llk_unpack_reconfig_data_format_srca_impl_<is_fp32_dest_acc_en, to_from_int8>(
-        unpack_src_format[srca_operand_id], unpack_dst_format[srca_operand_id]);
+        unpack_src_format[srca_operand_id], unpack_dst_format[srca_operand_id], tile_size);
 }
 
 // TODO NC: Clean up as the part of tt-metal#34499
@@ -71,8 +76,9 @@ inline void llk_unpack_reconfig_data_format_srcb(const std::uint32_t srcb_new_op
     std::uint32_t srcb_operand_id = get_operand_id(srcb_new_operand);
     const std::uint32_t num_faces = get_operand_num_faces(srcb_operand_id);
     const std::uint32_t face_r_dim = get_operand_face_r_dim(srcb_operand_id);
+    const std::uint32_t tile_size = get_local_cb_interface(srcb_operand_id).fifo_page_size;
     _llk_unpack_reconfig_data_format_srcb_impl_<is_fp32_dest_acc_en, to_from_int8>(
-        unpack_src_format[srcb_operand_id], unpack_dst_format[srcb_operand_id]);
+        unpack_src_format[srcb_operand_id], unpack_dst_format[srcb_operand_id], tile_size);
 }
 
 // TODO NC: Clean up as the part of tt-metal#34499

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_common_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_common_api.h
@@ -20,6 +20,12 @@
  * LLK UNPACK COMMON
  *************************************************************************/
 
+// Overloaded function for single operand unpack
+template <bool is_fp32_dest_acc_en>
+inline void llk_unpack_hw_configure(const std::uint32_t unpA_operand) {
+    llk_unpack_hw_configure<is_fp32_dest_acc_en>(unpA_operand, unpB_operand);
+}
+
 template <bool is_fp32_dest_acc_en>
 inline void llk_unpack_hw_configure(const std::uint32_t unpA_operand, const std::uint32_t unpB_operand) {
     // In0 -> unpA

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_common_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_common_api.h
@@ -54,16 +54,7 @@ inline bool should_reconfigure_cbs(std::uint32_t old_operand, std::uint32_t new_
     return (unpack_src_format[old_operand] != unpack_src_format[new_operand]) ||
            (unpack_dst_format[old_operand] != unpack_dst_format[new_operand]);
 }
-
-void llk_zero_operand(std::uint32_t operand) {
-    std::uint32_t operand_id = get_operand_id(operand);
-    std::uint32_t fifo_base_addr =
-        (get_local_cb_interface(operand_id).fifo_limit + 1) - get_local_cb_interface(operand_id).fifo_size;
-    std::uint32_t size = get_local_cb_interface(operand_id).fifo_size;
-    _llk_zero_buffer_(fifo_base_addr, size);
 }
-
-inline void llk_unpack_debug_dump_seek(std::uint8_t offset) { _llk_unpack_debug_dump_seek_(offset); }
 
 // TODO NC: Clean up as the part of tt-metal#34499
 template <bool is_fp32_dest_acc_en, bool to_from_int8 = false, bool is_tile_dim_reconfig_en = false>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_common_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_common_api.h
@@ -58,12 +58,9 @@ void llk_zero_operand(std::uint32_t operand) {
     _llk_zero_buffer_(fifo_base_addr, size);
 }
 
-inline void llk_unpack_debug_dump(std::uint8_t* data, std::uint32_t byte_size) {
-    _llk_unpack_debug_dump_(data, byte_size);
-}
-
 inline void llk_unpack_debug_dump_seek(std::uint8_t offset) { _llk_unpack_debug_dump_seek_(offset); }
 
+// TODO NC: Clean up as the part of tt-metal#34499
 template <bool is_fp32_dest_acc_en, bool to_from_int8 = false, bool is_tile_dim_reconfig_en = false>
 inline void llk_unpack_reconfig_data_format_srca(const std::uint32_t srca_new_operand) {
     const std::uint32_t srca_operand_id = get_operand_id(srca_new_operand);
@@ -75,6 +72,7 @@ inline void llk_unpack_reconfig_data_format_srca(const std::uint32_t srca_new_op
         get_local_cb_interface(srca_operand_id).fifo_page_size);
 }
 
+// TODO NC: Clean up as the part of tt-metal#34499
 template <bool is_fp32_dest_acc_en, bool to_from_int8 = false, bool is_tile_dim_reconfig_en = false>
 inline void llk_unpack_reconfig_data_format_srcb(const std::uint32_t srcb_new_operand) {
     std::uint32_t srcb_operand_id = get_operand_id(srcb_new_operand);
@@ -86,6 +84,7 @@ inline void llk_unpack_reconfig_data_format_srcb(const std::uint32_t srcb_new_op
         get_local_cb_interface(srcb_operand_id).fifo_page_size);
 }
 
+// TODO NC: Clean up as the part of tt-metal#34499
 template <bool is_fp32_dest_acc_en, bool to_from_int8 = false, bool is_tile_dim_reconfig_en = false>
 inline void llk_unpack_reconfig_data_format_srca(
     const std::uint32_t srca_old_operand, const std::uint32_t srca_new_operand) {
@@ -101,6 +100,7 @@ inline void llk_unpack_reconfig_data_format_srca(
     }
 }
 
+// TODO NC: Clean up as the part of tt-metal#34499
 template <bool is_fp32_dest_acc_en, bool to_from_int8 = false, bool is_tile_dim_reconfig_en = false>
 inline void llk_unpack_reconfig_data_format_srcb(
     const std::uint32_t srcb_old_operand, const std::uint32_t srcb_new_operand) {
@@ -116,6 +116,7 @@ inline void llk_unpack_reconfig_data_format_srcb(
     }
 }
 
+// TODO NC: Clean up as the part of tt-metal#34499
 template <bool is_fp32_dest_acc_en, bool to_from_int8 = false, bool is_tile_dim_reconfig_en = false>
 inline void llk_unpack_reconfig_data_format(
     const std::uint32_t srca_new_operand, const std::uint32_t srcb_new_operand) {
@@ -123,6 +124,7 @@ inline void llk_unpack_reconfig_data_format(
     llk_unpack_reconfig_data_format_srcb<is_fp32_dest_acc_en, to_from_int8, is_tile_dim_reconfig_en>(srcb_new_operand);
 }
 
+// TODO NC: Clean up as the part of tt-metal#34499
 template <bool is_fp32_dest_acc_en, bool to_from_int8 = false, bool is_tile_dim_reconfig_en = false>
 inline void llk_unpack_reconfig_data_format(
     const std::uint32_t srca_old_operand,
@@ -136,9 +138,6 @@ inline void llk_unpack_reconfig_data_format(
 }
 
 inline void llk_unpack_dbg_feature_disable() { _llk_unpack_dbg_feature_disable_(); }
-inline void llk_unpack_clear_dbg_feature_disable() { _llk_unpack_clear_dbg_feature_disable_(); }
-
-inline void llk_enable_int8_fpu_math() { _llk_enable_int8_fpu_math_(); }
 
 inline void llk_unpack_set_srcb_dummy_valid() { _llk_unpack_set_srcb_dummy_valid_(); }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_reduce_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_reduce_api.h
@@ -10,49 +10,6 @@
  * LLK UNPACK REDUCE
  *************************************************************************/
 
-template <
-    PoolType type,
-    ReduceDim dim,
-    bool is_fp32_dest_acc_en,
-    StochRndType stoch_rnd_mode = StochRndType::None>
-inline void llk_unpack_reduce_hw_configure(
-    const llk_unpack_reduce_params_t* unpack_reduce_params, const float const_mult) {
-    constexpr bool within_face_16x16_transpose = (ReduceDim::REDUCE_ROW == dim);
-
-    const std::uint32_t unpA_operand_id = get_operand_id(unpack_reduce_params->unpA_operand);
-    const std::uint32_t unpA_num_faces = get_operand_num_faces(unpA_operand_id);
-    const std::uint32_t unpA_face_r_dim = get_operand_face_r_dim(unpA_operand_id);
-
-    constexpr std::uint32_t unpB_src_format = (std::uint32_t)DataFormat::Float32;
-    const std::uint32_t unpB_dst_format =
-        ((std::uint32_t)unpack_dst_format[unpA_operand_id] == (std::uint32_t)DataFormat::Int8)
-            ? (std::uint32_t)DataFormat::Float16
-            :  // Int8 is treated as fp16_a
-            ((((std::uint32_t)unpack_dst_format[unpA_operand_id] >> 2) & 0x1) ? (std::uint32_t)DataFormat::Float16_b
-                                                                              : (std::uint32_t)DataFormat::Float16);
-
-    _llk_unpack_reduce_hw_configure_<is_fp32_dest_acc_en, stoch_rnd_mode>(
-        unpack_src_format[unpA_operand_id],
-        unpB_src_format,
-        unpack_dst_format[unpA_operand_id],
-        unpB_dst_format,
-        unpA_face_r_dim,
-        unpA_face_r_dim,
-        within_face_16x16_transpose,
-        unpA_num_faces,
-        unpA_num_faces);
-}
-
-template <
-    PoolType type,
-    ReduceDim dim,
-    bool is_fp32_dest_acc_en,
-    StochRndType stoch_rnd_mode = StochRndType::None>
-inline void llk_unpack_reduce_hw_configure_disaggregated(const std::uint32_t unpA_operand, const float mult) {
-    const llk_unpack_reduce_params_t unpack_reduce_params = {.unpA_operand = unpA_operand};
-    llk_unpack_reduce_hw_configure<type, dim, is_fp32_dest_acc_en, stoch_rnd_mode>(&unpack_reduce_params, mult);
-}
-
 template <PoolType type, ReduceDim dim>
 inline void llk_unpack_reduce_mop_config() {
     _llk_unpack_reduce_mop_config_<type, dim>();

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_tilize_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_tilize_api.h
@@ -123,13 +123,12 @@ inline void llk_unpack_tilizeA_B_hw_configure(
 
     const uint32_t face_r_dim = get_operand_face_r_dim(unpA_operand_id);  // face r dim in unpA and unpB are the same
 
-    _llk_unpack_AB_hw_configure_<is_fp32_dest_acc_en, stoch_rnd_mode>(
+    _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
         unpack_src_format[unpA_operand_id],
         unpack_src_format[unpB_operand_id],
         unpack_dst_format[unpA_operand_id],
         unpack_dst_format[unpB_operand_id],
         face_r_dim,
-        within_face_16x16_transpose,
         num_faces);
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_tilize_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_tilize_api.h
@@ -86,37 +86,6 @@ inline void llk_unpack_tilize_block(
  * LLK UNPACK TILIZE SRC A, UNPACK SRC B
  *************************************************************************/
 
-template <bool is_fp32_dest_acc_en, StochRndType stoch_rnd_mode = StochRndType::None>
-inline void llk_unpack_tilizeA_B_hw_configure(
-    const llk_unpack_AB_params_t* unpack_tilizeA_B_params, const int within_face_16x16_transpose = 0) {
-    // In0 -> unpA
-    // In1 -> unpB
-    const uint32_t unpA_operand_id = get_operand_id(unpack_tilizeA_B_params->unpA_operand);
-    const uint32_t unpB_operand_id = get_operand_id(unpack_tilizeA_B_params->unpB_operand);
-
-    // unpA -> srcA
-    // unpB -> srcB
-    const uint32_t num_faces = get_operand_num_faces(unpA_operand_id);  // num faces in unpA and unpB are the same
-
-    const uint32_t face_r_dim = get_operand_face_r_dim(unpA_operand_id);  // face r dim in unpA and unpB are the same
-
-    _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
-        unpack_src_format[unpA_operand_id],
-        unpack_src_format[unpB_operand_id],
-        unpack_dst_format[unpA_operand_id],
-        unpack_dst_format[unpB_operand_id],
-        face_r_dim,
-        num_faces);
-}
-
-template <bool is_fp32_dest_acc_en, StochRndType stoch_rnd_mode = StochRndType::None>
-inline void llk_unpack_tilizeA_B_hw_configure_disaggregated(
-    const std::uint32_t unpA_operand, const std::uint32_t unpB_operand, const int within_face_16x16_transpose = 0) {
-    const llk_unpack_AB_params_t unpack_tilizeA_B_params = {.unpA_operand = unpA_operand, .unpB_operand = unpB_operand};
-    llk_unpack_tilizeA_B_hw_configure<is_fp32_dest_acc_en, stoch_rnd_mode>(
-        &unpack_tilizeA_B_params, within_face_16x16_transpose);
-}
-
 template <
     bool neginf_srcA = false,
     std::uint32_t reload_srcB = false,

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_tilize_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_tilize_api.h
@@ -11,29 +11,6 @@
  * LLK UNPACK TILIZE
  *************************************************************************/
 
-template <bool is_fp32_dest_acc_en>
-inline void llk_unpack_tilize_hw_configure(const llk_unpack_A_params_t* unpack_tilize_params) {
-    constexpr bool within_face_16x16_transpose = false;
-    constexpr StochRndType stoch_rnd_mode = StochRndType::None;
-
-    const uint32_t unpA_operand_id = get_operand_id(unpack_tilize_params->unpA_operand);
-    const uint32_t unpA_num_faces = get_operand_num_faces(unpA_operand_id);
-    const uint32_t unpA_face_r_dim = get_operand_face_r_dim(unpA_operand_id);
-
-    _llk_unpack_tilize_hw_configure_<is_fp32_dest_acc_en, stoch_rnd_mode>(
-        unpack_src_format[unpA_operand_id],
-        unpack_dst_format[unpA_operand_id],
-        unpA_face_r_dim,
-        within_face_16x16_transpose,
-        unpA_num_faces);
-}
-
-template <bool is_fp32_dest_acc_en>
-inline void llk_unpack_tilize_hw_configure_disaggregated(const std::uint32_t unpA_operand) {
-    const llk_unpack_A_params_t unpack_tilize_params = {.unpA_operand = unpA_operand};
-    llk_unpack_tilize_hw_configure<is_fp32_dest_acc_en>(&unpack_tilize_params);
-}
-
 inline void llk_unpack_tilize_mop_config(const std::uint32_t operand) {
     std::uint32_t operand_id = get_operand_id(operand);
     const bool narrow_tile = get_operand_narrow_tile(operand_id);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_tilize_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_tilize_api.h
@@ -209,21 +209,6 @@ inline void llk_unpack_tilizeA_B_block(
  * LLK UNPACK FAST TILIZE SRC A
  *************************************************************************/
 
-template <bool is_fp32_dest_acc_en>
-inline void llk_unpack_fast_tilize_hw_configure(const llk_unpack_A_params_t* unpack_tilize_params) {
-    const uint32_t unpA_operand_id = get_operand_id(unpack_tilize_params->unpA_operand);
-
-    _llk_unpack_fast_tilize_hw_configure_<is_fp32_dest_acc_en>(
-        unpack_src_format[unpA_operand_id], unpack_dst_format[unpA_operand_id]);
-}
-
-template <bool is_fp32_dest_acc_en>
-inline void llk_unpack_fast_tilize_hw_configure_disaggregated(const std::uint32_t unpA_operand) {
-    const llk_unpack_A_params_t unpack_tilize_params = {.unpA_operand = unpA_operand};
-
-    llk_unpack_fast_tilize_hw_configure<is_fp32_dest_acc_en>(&unpack_tilize_params);
-}
-
 inline void llk_unpack_fast_tilize_init(const std::uint32_t operand, std::uint32_t full_dim) {
     const std::uint32_t operand_id = get_operand_id(operand);
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_untilize_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_untilize_api.h
@@ -9,31 +9,6 @@
 /*************************************************************************
  * LLK UNPACK UNTILIZE
  *************************************************************************/
-template <bool is_fp32_dest_acc_en>
-inline void llk_unpack_untilize_hw_configure(const llk_unpack_A_params_t* unpack_untilize_params) {
-    constexpr bool is_row_pool = false;
-    constexpr bool within_face_16x16_transpose = false;
-    constexpr StochRndType stoch_rnd_mode = StochRndType::None;
-
-    const uint32_t unpA_operand_id = get_operand_id(unpack_untilize_params->unpA_operand);
-    const uint32_t unpA_num_faces = 4;
-    const uint32_t unpA_face_r_dim = FACE_R_DIM;
-
-    _llk_unpack_untilize_hw_configure_<is_fp32_dest_acc_en, stoch_rnd_mode>(
-        unpack_src_format[unpA_operand_id],
-        unpack_dst_format[unpA_operand_id],
-        unpA_face_r_dim,
-        within_face_16x16_transpose,
-        unpA_num_faces);
-}
-
-template <bool is_fp32_dest_acc_en>
-inline void llk_unpack_untilize_hw_configure_disaggregated(const std::uint32_t unpA_operand) {
-    const llk_unpack_A_params_t unpack_untilize_params = {
-        .unpA_operand = unpA_operand,
-    };
-    llk_unpack_untilize_hw_configure<is_fp32_dest_acc_en>(&unpack_untilize_params);
-}
 
 inline void llk_unpack_untilize_mop_config() { _llk_unpack_untilize_mop_config_(); }
 

--- a/tt_metal/include/compute_kernel_api/bcast.h
+++ b/tt_metal/include/compute_kernel_api/bcast.h
@@ -206,11 +206,6 @@ void init_bcast(uint32_t icb0, uint32_t icb1, uint32_t ocb) {
 
     UNPACK((llk_unpack_hw_configure<DST_ACCUM_MODE>(icb0, icb1)));
     UNPACK((llk_unpack_AB_init<tBcastDim>(icb0, icb1)));
-    // TODO(AP): running this specific init after common AB init causes a hang
-
-    // clone of general init for AB TODO(AP): commonize
-    // UNPACK(( llk_unpack_AB_init<BroadcastType::NONE>() ));
-    // UNPACK(( llk_unpack_hw_configure<DST_ACCUM_MODE>(icb0, icb1) ));
 
     PACK((llk_pack_hw_configure_disaggregated<DST_ACCUM_MODE, false>(ocb)));
     PACK((llk_pack_init(ocb)));

--- a/tt_metal/include/compute_kernel_api/bcast.h
+++ b/tt_metal/include/compute_kernel_api/bcast.h
@@ -35,7 +35,7 @@ ALWI void unary_bcast_init(uint32_t icb, uint32_t ocb) {
 
     MATH((llk_math_eltwise_unary_datacopy_init<data_copy_type, DST_ACCUM_MODE, bcast_type>(icb)));
     MATH((llk_math_pack_sync_init<DST_ACCUM_MODE>()));
-    MATH((llk_math_hw_configure_disaggregated(icb, icb)));
+    MATH((llk_math_hw_configure(icb, icb)));
 
     PACK((llk_pack_hw_configure_disaggregated<DST_ACCUM_MODE, false>(ocb)));
     PACK((llk_pack_init<false>(ocb)));
@@ -77,7 +77,7 @@ void reconfigure_unary_bcast(uint32_t old_icb, uint32_t new_icb, uint32_t old_oc
     }
 
     if (unpacker_dst_format_change) {
-        MATH((llk_math_hw_configure_disaggregated(new_icb, new_icb)));
+        MATH((llk_math_hw_configure(new_icb, new_icb)));
     }
 
     if (unpacker_dst_format_change || bcast_type_change) {
@@ -216,7 +216,7 @@ void init_bcast(uint32_t icb0, uint32_t icb1, uint32_t ocb) {
     PACK((llk_pack_dest_init<DST_ACCUM_MODE, false>()));
 
     MATH((llk_math_pack_sync_init<DST_ACCUM_MODE>()));
-    MATH((llk_math_hw_configure_disaggregated(icb0, icb1)));
+    MATH((llk_math_hw_configure(icb0, icb1)));
 }
 
 /*

--- a/tt_metal/include/compute_kernel_api/bcast.h
+++ b/tt_metal/include/compute_kernel_api/bcast.h
@@ -14,6 +14,7 @@
 #ifdef TRISC_UNPACK
 #include "llk_unpack_AB_api.h"
 #include "llk_unpack_A_api.h"
+#include "llk_unpack_common_api.h"
 #endif
 #ifdef TRISC_PACK
 #include "llk_pack.h"
@@ -203,13 +204,13 @@ void init_bcast(uint32_t icb0, uint32_t icb1, uint32_t ocb) {
         MATH((llk_math_eltwise_binary_init<tBcastOp, tBcastDim>()));
     }
 
-    UNPACK((llk_unpack_AB_hw_configure_disaggregated<DST_ACCUM_MODE>(icb0, icb1)));
+    UNPACK((llk_unpack_hw_configure<DST_ACCUM_MODE>(icb0, icb1)));
     UNPACK((llk_unpack_AB_init<tBcastDim>(icb0, icb1)));
     // TODO(AP): running this specific init after common AB init causes a hang
 
     // clone of general init for AB TODO(AP): commonize
     // UNPACK(( llk_unpack_AB_init<BroadcastType::NONE>() ));
-    // UNPACK(( llk_unpack_AB_hw_configure_disaggregated<DST_ACCUM_MODE>(icb0, icb1) ));
+    // UNPACK(( llk_unpack_hw_configure<DST_ACCUM_MODE>(icb0, icb1) ));
 
     PACK((llk_pack_hw_configure_disaggregated<DST_ACCUM_MODE, false>(ocb)));
     PACK((llk_pack_init(ocb)));

--- a/tt_metal/include/compute_kernel_api/bcast.h
+++ b/tt_metal/include/compute_kernel_api/bcast.h
@@ -30,7 +30,7 @@ ALWI void unary_bcast_init(uint32_t icb, uint32_t ocb) {
     const bool enable_unpack_to_dest = data_copy_type == A2D;
 
     // Will configure A & B in similar way
-    UNPACK((llk_unpack_hw_configure<DST_ACCUM_MODE>(icb, icb)));
+    UNPACK((llk_unpack_hw_configure<DST_ACCUM_MODE>(icb)));
     UNPACK((llk_unpack_A_init<bcast_type, false, EltwiseBinaryReuseDestType::NONE, enable_unpack_to_dest>(
         false, false /*transpose within 16x16 face*/, icb)));
 
@@ -69,7 +69,7 @@ void reconfigure_unary_bcast(uint32_t old_icb, uint32_t new_icb, uint32_t old_oc
 
     if (unpacker_src_format_change || unpacker_dst_format_change) {
         // Will configure A & B in similar way
-        UNPACK((llk_unpack_hw_configure<DST_ACCUM_MODE>(new_icb, new_icb)));
+        UNPACK((llk_unpack_hw_configure<DST_ACCUM_MODE>(new_icb)));
     }
 
     if (unpacker_src_format_change || unpacker_dst_format_change || bcast_type_change) {

--- a/tt_metal/include/compute_kernel_api/bcast.h
+++ b/tt_metal/include/compute_kernel_api/bcast.h
@@ -30,7 +30,7 @@ ALWI void unary_bcast_init(uint32_t icb, uint32_t ocb) {
     const bool enable_unpack_to_dest = data_copy_type == A2D;
 
     // Will configure A & B in similar way
-    UNPACK((llk_unpack_A_hw_configure_disaggregated<DST_ACCUM_MODE>(icb)));
+    UNPACK((llk_unpack_hw_configure<DST_ACCUM_MODE>(icb, icb)));
     UNPACK((llk_unpack_A_init<bcast_type, false, EltwiseBinaryReuseDestType::NONE, enable_unpack_to_dest>(
         false, false /*transpose within 16x16 face*/, icb)));
 
@@ -69,7 +69,7 @@ void reconfigure_unary_bcast(uint32_t old_icb, uint32_t new_icb, uint32_t old_oc
 
     if (unpacker_src_format_change || unpacker_dst_format_change) {
         // Will configure A & B in similar way
-        UNPACK((llk_unpack_A_hw_configure_disaggregated<DST_ACCUM_MODE>(new_icb)));
+        UNPACK((llk_unpack_hw_configure<DST_ACCUM_MODE>(new_icb, new_icb)));
     }
 
     if (unpacker_src_format_change || unpacker_dst_format_change || bcast_type_change) {

--- a/tt_metal/include/compute_kernel_api/compute_kernel_hw_startup.h
+++ b/tt_metal/include/compute_kernel_api/compute_kernel_hw_startup.h
@@ -41,7 +41,7 @@ ALWI void compute_kernel_hw_startup(uint32_t icb0, uint32_t icb1, uint32_t ocb) 
     UNPACK((llk_unpack_AB_hw_configure_disaggregated<DST_ACCUM_MODE>(icb0, icb1)));
 
     MATH((llk_math_pack_sync_init<DST_ACCUM_MODE>()));
-    MATH((llk_math_hw_configure_disaggregated<false /*untilize*/, false /*skip_inputs*/>(icb0, icb1)));
+    MATH((llk_math_hw_configure(icb0, icb1)));
 
     PACK((llk_pack_init<false /*untilize*/, false /*zero_output*/, false /*tilize*/>(ocb)));
     PACK((llk_pack_hw_configure_disaggregated<

--- a/tt_metal/include/compute_kernel_api/compute_kernel_hw_startup.h
+++ b/tt_metal/include/compute_kernel_api/compute_kernel_hw_startup.h
@@ -7,7 +7,7 @@
 #include "compute_kernel_api/common.h"
 
 #ifdef TRISC_UNPACK
-#include "llk_unpack_AB_api.h"
+#include "llk_unpack_common_api.h"
 #endif
 
 namespace ckernel {
@@ -38,7 +38,7 @@ namespace ckernel {
  */
 // clang-format on
 ALWI void compute_kernel_hw_startup(uint32_t icb0, uint32_t icb1, uint32_t ocb) {
-    UNPACK((llk_unpack_AB_hw_configure_disaggregated<DST_ACCUM_MODE>(icb0, icb1)));
+    UNPACK((llk_unpack_hw_configure<DST_ACCUM_MODE>(icb0, icb1)));
 
     MATH((llk_math_pack_sync_init<DST_ACCUM_MODE>()));
     MATH((llk_math_hw_configure(icb0, icb1)));

--- a/tt_metal/include/compute_kernel_api/eltwise_binary.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_binary.h
@@ -28,7 +28,7 @@ namespace ckernel {
  */
 // clang-format on
 ALWI void binary_op_init_common(uint32_t icb0, uint32_t icb1, uint32_t ocb) {
-    UNPACK((llk_unpack_AB_hw_configure_disaggregated<DST_ACCUM_MODE>(icb0, icb1)));
+    UNPACK((llk_unpack_hw_configure<DST_ACCUM_MODE>(icb0, icb1)));
     UNPACK((llk_unpack_AB_init<BroadcastType::NONE>(icb0, icb1)));
 
     MATH((llk_math_pack_sync_init<DST_ACCUM_MODE>()));

--- a/tt_metal/include/compute_kernel_api/eltwise_binary.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_binary.h
@@ -32,7 +32,7 @@ ALWI void binary_op_init_common(uint32_t icb0, uint32_t icb1, uint32_t ocb) {
     UNPACK((llk_unpack_AB_init<BroadcastType::NONE>(icb0, icb1)));
 
     MATH((llk_math_pack_sync_init<DST_ACCUM_MODE>()));
-    MATH((llk_math_hw_configure_disaggregated(icb0, icb1)));
+    MATH((llk_math_hw_configure(icb0, icb1)));
 
     PACK((llk_pack_hw_configure_disaggregated<DST_ACCUM_MODE, false>(ocb)));
     PACK((llk_pack_init(ocb)));

--- a/tt_metal/include/compute_kernel_api/eltwise_unary/eltwise_unary.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_unary/eltwise_unary.h
@@ -15,7 +15,6 @@
 namespace ckernel {
 
 ALWI void unary_op_init_common(uint32_t icb, uint32_t ocb) {
-    // TODO NC: used to pass disable_src_zero_flag to hw configure
     UNPACK((llk_unpack_hw_configure<DST_ACCUM_MODE>(icb, icb)));
     UNPACK((llk_unpack_A_init<
             BroadcastType::NONE,
@@ -41,7 +40,6 @@ ALWI void unary_op_init_common(uint32_t icb, uint32_t ocb) {
  */
 // clang-format on
 ALWI void unary_op_init_common_no_pack(uint32_t icb) {
-    // TODO NC: used to pass disable_src_zero_flag to hw configure
     UNPACK((llk_unpack_hw_configure<DST_ACCUM_MODE>(icb, icb)));
     UNPACK((llk_unpack_A_init<
             BroadcastType::NONE,

--- a/tt_metal/include/compute_kernel_api/eltwise_unary/eltwise_unary.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_unary/eltwise_unary.h
@@ -15,13 +15,9 @@
 namespace ckernel {
 
 ALWI void unary_op_init_common(uint32_t icb, uint32_t ocb) {
-    UNPACK((llk_unpack_hw_configure<DST_ACCUM_MODE>(icb)));
-    UNPACK((llk_unpack_A_init<
-            BroadcastType::NONE,
-            false,
-            EltwiseBinaryReuseDestType::NONE,
-            UnpackToDestEn,
-            true /*disable_src_zero_flag*/>(false /*transpose of faces*/, false /*transpose within 16x16 face*/, icb)));
+    UNPACK((llk_unpack_hw_configure<DST_ACCUM_MODE, true>(icb)));
+    UNPACK((llk_unpack_A_init<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, UnpackToDestEn>(
+        false /*transpose of faces*/, false /*transpose within 16x16 face*/, icb)));
 
     PACK((llk_pack_hw_configure_disaggregated<DST_ACCUM_MODE, false>(ocb)));
     PACK((llk_pack_init<false>(ocb)));
@@ -40,13 +36,9 @@ ALWI void unary_op_init_common(uint32_t icb, uint32_t ocb) {
  */
 // clang-format on
 ALWI void unary_op_init_common_no_pack(uint32_t icb) {
-    UNPACK((llk_unpack_hw_configure<DST_ACCUM_MODE>(icb)));
-    UNPACK((llk_unpack_A_init<
-            BroadcastType::NONE,
-            false,
-            EltwiseBinaryReuseDestType::NONE,
-            UnpackToDestEn,
-            true /*disable_src_zero_flag*/>(false /*transpose of faces*/, false /*transpose within 16x16 face*/, icb)));
+    UNPACK((llk_unpack_hw_configure<DST_ACCUM_MODE, true>(icb)));
+    UNPACK((llk_unpack_A_init<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, UnpackToDestEn>(
+        false /*transpose of faces*/, false /*transpose within 16x16 face*/, icb)));
 
     MATH((llk_math_eltwise_unary_datacopy_init<A2D, DST_ACCUM_MODE, BroadcastType::NONE>(icb)));
     MATH((llk_math_hw_configure(icb, icb)));

--- a/tt_metal/include/compute_kernel_api/eltwise_unary/eltwise_unary.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_unary/eltwise_unary.h
@@ -17,8 +17,12 @@ namespace ckernel {
 ALWI void unary_op_init_common(uint32_t icb, uint32_t ocb) {
     // TODO NC: used to pass disable_src_zero_flag to hw configure
     UNPACK((llk_unpack_hw_configure<DST_ACCUM_MODE>(icb, icb)));
-    UNPACK((llk_unpack_A_init<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, UnpackToDestEn>(
-        false /*transpose of faces*/, false /*transpose within 16x16 face*/, icb)));
+    UNPACK((llk_unpack_A_init<
+            BroadcastType::NONE,
+            false,
+            EltwiseBinaryReuseDestType::NONE,
+            UnpackToDestEn,
+            true /*disable_src_zero_flag*/>(false /*transpose of faces*/, false /*transpose within 16x16 face*/, icb)));
 
     PACK((llk_pack_hw_configure_disaggregated<DST_ACCUM_MODE, false>(ocb)));
     PACK((llk_pack_init<false>(ocb)));
@@ -39,8 +43,12 @@ ALWI void unary_op_init_common(uint32_t icb, uint32_t ocb) {
 ALWI void unary_op_init_common_no_pack(uint32_t icb) {
     // TODO NC: used to pass disable_src_zero_flag to hw configure
     UNPACK((llk_unpack_hw_configure<DST_ACCUM_MODE>(icb, icb)));
-    UNPACK((llk_unpack_A_init<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, UnpackToDestEn>(
-        false /*transpose of faces*/, false /*transpose within 16x16 face*/, icb)));
+    UNPACK((llk_unpack_A_init<
+            BroadcastType::NONE,
+            false,
+            EltwiseBinaryReuseDestType::NONE,
+            UnpackToDestEn,
+            true /*disable_src_zero_flag*/>(false /*transpose of faces*/, false /*transpose within 16x16 face*/, icb)));
 
     MATH((llk_math_eltwise_unary_datacopy_init<A2D, DST_ACCUM_MODE, BroadcastType::NONE>(icb)));
     MATH((llk_math_hw_configure(icb, icb)));

--- a/tt_metal/include/compute_kernel_api/eltwise_unary/eltwise_unary.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_unary/eltwise_unary.h
@@ -15,7 +15,8 @@
 namespace ckernel {
 
 ALWI void unary_op_init_common(uint32_t icb, uint32_t ocb) {
-    UNPACK((llk_unpack_A_hw_configure_disaggregated<DST_ACCUM_MODE, StochRndType::None, true>(icb)));
+    // TODO NC: used to pass disable_src_zero_flag to hw configure
+    UNPACK((llk_unpack_hw_configure<DST_ACCUM_MODE>(icb, icb)));
     UNPACK((llk_unpack_A_init<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, UnpackToDestEn>(
         false /*transpose of faces*/, false /*transpose within 16x16 face*/, icb)));
 
@@ -36,7 +37,8 @@ ALWI void unary_op_init_common(uint32_t icb, uint32_t ocb) {
  */
 // clang-format on
 ALWI void unary_op_init_common_no_pack(uint32_t icb) {
-    UNPACK((llk_unpack_A_hw_configure_disaggregated<DST_ACCUM_MODE, StochRndType::None, true>(icb)));
+    // TODO NC: used to pass disable_src_zero_flag to hw configure
+    UNPACK((llk_unpack_hw_configure<DST_ACCUM_MODE>(icb, icb)));
     UNPACK((llk_unpack_A_init<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, UnpackToDestEn>(
         false /*transpose of faces*/, false /*transpose within 16x16 face*/, icb)));
 

--- a/tt_metal/include/compute_kernel_api/eltwise_unary/eltwise_unary.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_unary/eltwise_unary.h
@@ -15,7 +15,7 @@
 namespace ckernel {
 
 ALWI void unary_op_init_common(uint32_t icb, uint32_t ocb) {
-    UNPACK((llk_unpack_hw_configure<DST_ACCUM_MODE>(icb, icb)));
+    UNPACK((llk_unpack_hw_configure<DST_ACCUM_MODE>(icb)));
     UNPACK((llk_unpack_A_init<
             BroadcastType::NONE,
             false,
@@ -40,7 +40,7 @@ ALWI void unary_op_init_common(uint32_t icb, uint32_t ocb) {
  */
 // clang-format on
 ALWI void unary_op_init_common_no_pack(uint32_t icb) {
-    UNPACK((llk_unpack_hw_configure<DST_ACCUM_MODE>(icb, icb)));
+    UNPACK((llk_unpack_hw_configure<DST_ACCUM_MODE>(icb)));
     UNPACK((llk_unpack_A_init<
             BroadcastType::NONE,
             false,

--- a/tt_metal/include/compute_kernel_api/eltwise_unary/eltwise_unary.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_unary/eltwise_unary.h
@@ -25,7 +25,7 @@ ALWI void unary_op_init_common(uint32_t icb, uint32_t ocb) {
 
     MATH((llk_math_eltwise_unary_datacopy_init<A2D, DST_ACCUM_MODE, BroadcastType::NONE>(icb)));
     MATH((llk_math_pack_sync_init<DST_ACCUM_MODE>()));
-    MATH((llk_math_hw_configure_disaggregated(icb, icb)));
+    MATH((llk_math_hw_configure(icb, icb)));
 }
 
 // clang-format off
@@ -41,7 +41,7 @@ ALWI void unary_op_init_common_no_pack(uint32_t icb) {
         false /*transpose of faces*/, false /*transpose within 16x16 face*/, icb)));
 
     MATH((llk_math_eltwise_unary_datacopy_init<A2D, DST_ACCUM_MODE, BroadcastType::NONE>(icb)));
-    MATH((llk_math_hw_configure_disaggregated(icb, icb)));
+    MATH((llk_math_hw_configure(icb, icb)));
 }
 
 ALWI void init_sfpu(uint32_t icb, uint32_t ocb) { unary_op_init_common(icb, ocb); }

--- a/tt_metal/include/compute_kernel_api/matmul.h
+++ b/tt_metal/include/compute_kernel_api/matmul.h
@@ -92,7 +92,7 @@ ALWI void mm_init(uint32_t in0_cb_id, uint32_t in1_cb_id, uint32_t out_cb_id, co
 
     MATH((llk_math_matmul_init<MATH_FIDELITY, MM_THROTTLE>(in0_cb_id, in1_cb_id, transpose)));
     MATH((llk_math_pack_sync_init<DST_ACCUM_MODE>()));
-    MATH((llk_math_hw_configure_disaggregated(in0_cb_id, in1_cb_id)));
+    MATH((llk_math_hw_configure(in0_cb_id, in1_cb_id)));
 
     PACK((llk_pack_hw_configure_disaggregated<DST_ACCUM_MODE, false>(out_cb_id)));
     PACK((llk_pack_init(out_cb_id)));
@@ -212,7 +212,7 @@ ALWI void mm_block_init(
 
     MATH((llk_math_matmul_init<MATH_FIDELITY, MM_THROTTLE>(in0_cb_id, in1_cb_id, transpose, ct_dim, rt_dim)));
     MATH((llk_math_pack_sync_init<DST_ACCUM_MODE>()));
-    MATH((llk_math_hw_configure_disaggregated(in0_cb_id, in1_cb_id)));
+    MATH((llk_math_hw_configure(in0_cb_id, in1_cb_id)));
 #ifdef ARCH_BLACKHOLE
     // Dynamic throttling is only available on Blackhole architecture
     MATH((throttled_mop_status = 0));

--- a/tt_metal/include/compute_kernel_api/matmul.h
+++ b/tt_metal/include/compute_kernel_api/matmul.h
@@ -88,7 +88,9 @@ ALWI void matmul_block_math_dynamic_throttle(
  */
 // clang-format on
 ALWI void mm_init(uint32_t in0_cb_id, uint32_t in1_cb_id, uint32_t out_cb_id, const uint32_t transpose = 0) {
-    // Note: in0_cb_id and in1_cb_id are swapped here because of the way matmul works:
+    // Note: in0_cb_id and in1_cb_id are swapped here because internally,
+    // matmul maps in0 to srcB and in1 to srcA, so the arguments must be swapped
+    // to ensure the correct operand mapping for the hardware implementation.
     UNPACK((llk_unpack_hw_configure<DST_ACCUM_MODE>(in1_cb_id, in0_cb_id)));
     UNPACK((llk_unpack_AB_matmul_init(in0_cb_id, in1_cb_id, transpose)));
 

--- a/tt_metal/include/compute_kernel_api/matmul.h
+++ b/tt_metal/include/compute_kernel_api/matmul.h
@@ -10,6 +10,7 @@
 #endif
 #ifdef TRISC_UNPACK
 #include "llk_unpack_AB_matmul_api.h"
+#include "llk_unpack_common_api.h"
 #endif
 // defines the default throttle level for matmul kernels (default 0)
 #ifndef MM_THROTTLE
@@ -87,7 +88,8 @@ ALWI void matmul_block_math_dynamic_throttle(
  */
 // clang-format on
 ALWI void mm_init(uint32_t in0_cb_id, uint32_t in1_cb_id, uint32_t out_cb_id, const uint32_t transpose = 0) {
-    UNPACK((llk_unpack_AB_matmul_hw_configure_disaggregated<DST_ACCUM_MODE>(in0_cb_id, in1_cb_id)));
+    // Note: in0_cb_id and in1_cb_id are swapped here because of the way matmul works:
+    UNPACK((llk_unpack_hw_configure<DST_ACCUM_MODE>(in1_cb_id, in0_cb_id)));
     UNPACK((llk_unpack_AB_matmul_init(in0_cb_id, in1_cb_id, transpose)));
 
     MATH((llk_math_matmul_init<MATH_FIDELITY, MM_THROTTLE>(in0_cb_id, in1_cb_id, transpose)));
@@ -207,7 +209,8 @@ ALWI void mm_block_init(
     uint32_t ct_dim = 1,
     uint32_t rt_dim = 1,
     uint32_t kt_dim = 1) {
-    UNPACK((llk_unpack_AB_matmul_hw_configure_disaggregated<DST_ACCUM_MODE>(in0_cb_id, in1_cb_id)));
+    // Note: in0_cb_id and in1_cb_id are swapped here because of the way matmul works:
+    UNPACK((llk_unpack_hw_configure<DST_ACCUM_MODE>(in1_cb_id, in0_cb_id)));
     UNPACK((llk_unpack_AB_matmul_init(in0_cb_id, in1_cb_id, transpose, ct_dim, rt_dim, kt_dim)));
 
     MATH((llk_math_matmul_init<MATH_FIDELITY, MM_THROTTLE>(in0_cb_id, in1_cb_id, transpose, ct_dim, rt_dim)));

--- a/tt_metal/include/compute_kernel_api/pack_untilize.h
+++ b/tt_metal/include/compute_kernel_api/pack_untilize.h
@@ -61,7 +61,7 @@ template <
 ALWI void pack_untilize_dest_init(uint32_t ocb, uint32_t face_r_dim = 16, uint32_t num_faces = 4) {
 #ifdef ARCH_BLACKHOLE
     // Needed for setting swizzle_32b:
-    MATH((llk_math_hw_configure_disaggregated<true, true>(0, 0)));
+    MATH((llk_math_reconfig_remap(true)));
 #endif
     // A workaround for tt-metal#17132. Should be addressed more systematically.
     PACK(

--- a/tt_metal/include/compute_kernel_api/tilize.h
+++ b/tt_metal/include/compute_kernel_api/tilize.h
@@ -38,7 +38,7 @@ ALWI void tilize_init(uint32_t icb, uint32_t block, uint32_t ocb) {
           false /*is_int_en*/,
           true /*tilize en*/>(icb)));
 #ifdef ARCH_BLACKHOLE
-    PACK((llk_pack_init<false /*untilize*/, false /*skip_inputs*/, true /*tilize en*/>(ocb)));
+    PACK((llk_pack_init<false /*untilize*/, false /*zero output*/, true /*tilize en*/>(ocb)));
 #endif
 }
 
@@ -300,7 +300,7 @@ ALWI void unpack_tilizeA_B_block(
 ALWI void tilize_uninit(uint32_t icb, uint32_t ocb) {
     UNPACK((llk_unpack_tilize_uninit(icb)));
 #ifdef ARCH_BLACKHOLE
-    PACK((llk_pack_init<false /*untilize*/, false /*skip_inputs*/, false /*tilize en*/>(ocb)));
+    PACK((llk_pack_init<false /*untilize*/, false /*zero output*/, false /*tilize en*/>(ocb)));
 #endif
 }
 

--- a/tt_metal/include/compute_kernel_api/tilize.h
+++ b/tt_metal/include/compute_kernel_api/tilize.h
@@ -101,7 +101,7 @@ ALWI void tilizeA_B_reduce_init(
 
     MATH((llk_math_reduce_init<REDUCE_OP, REDUCE_DIM, DST_ACCUM_MODE, MATH_FIDELITY>()));
     MATH((llk_math_pack_sync_init<DST_ACCUM_MODE>()));
-    MATH((llk_math_hw_configure_disaggregated(icb0, icb1_scaler)));
+    MATH((llk_math_hw_configure(icb0, icb1_scaler)));
 
     PACK((llk_pack_hw_configure_disaggregated<DST_ACCUM_MODE, false>(ocb)));
     PACK((llk_pack_init(ocb)));

--- a/tt_metal/include/compute_kernel_api/tilize.h
+++ b/tt_metal/include/compute_kernel_api/tilize.h
@@ -173,7 +173,7 @@ ALWI void tilize_init_short_with_dt_no_pack(uint32_t old_icb, uint32_t new_icb, 
 // while the *_no_pack variants do not configure the packer, testing has shown that this call is
 // still necessary to ensure the data type is properly updated
 #ifdef ARCH_BLACKHOLE
-    PACK((_llk_pack_init_<false, false, DstTileFaceLayout::RowMajor, false, true>(
+    PACK((_llk_pack_init_<false, false, false, true>(
         pack_dst_format[new_icb],
         get_output_face_r_dim(new_icb),
         get_output_tile_c_dim(new_icb),

--- a/tt_metal/include/compute_kernel_api/tilize.h
+++ b/tt_metal/include/compute_kernel_api/tilize.h
@@ -12,6 +12,7 @@
 #endif
 #ifdef TRISC_UNPACK
 #include "llk_unpack_tilize_api.h"
+#include "llk_unpack_common_api.h"
 #endif
 
 namespace ckernel {
@@ -95,7 +96,7 @@ ALWI void tilizeA_B_reduce_init(
     uint32_t ocb,
     uint32_t num_faces = 4,
     uint32_t face_r_dim = 16) {
-    UNPACK((llk_unpack_tilizeA_B_hw_configure_disaggregated<DST_ACCUM_MODE>(icb0, icb1_scaler)));
+    UNPACK((llk_unpack_hw_configure<DST_ACCUM_MODE>(icb0, icb1_scaler)));
     UNPACK((llk_unpack_tilizeA_B_init<neginf_srcA, true, false, zero_srcA_reduce>(
         icb0, icb1_scaler, block, num_faces, face_r_dim, 1)));
 

--- a/tt_metal/include/compute_kernel_api/tilize.h
+++ b/tt_metal/include/compute_kernel_api/tilize.h
@@ -173,7 +173,7 @@ ALWI void tilize_init_short_with_dt_no_pack(uint32_t old_icb, uint32_t new_icb, 
 // while the *_no_pack variants do not configure the packer, testing has shown that this call is
 // still necessary to ensure the data type is properly updated
 #ifdef ARCH_BLACKHOLE
-    PACK((_llk_pack_init_<false, false, false, true>(
+    PACK((_llk_pack_init_<false, false, true>(
         pack_dst_format[new_icb],
         get_output_face_r_dim(new_icb),
         get_output_tile_c_dim(new_icb),

--- a/tt_metal/include/compute_kernel_api/transpose_wh.h
+++ b/tt_metal/include/compute_kernel_api/transpose_wh.h
@@ -33,13 +33,14 @@ ALWI void transpose_wh_init(uint32_t icb, uint32_t ocb) {
     const bool is_int32 = (src_format & 0xf) == (std::uint32_t)DataFormat::Int32;
 
     if (is_int32) {
-        UNPACK((llk_unpack_A_hw_configure_disaggregated<DST_ACCUM_MODE, StochRndType::None, true>(icb, false)));
+        // TODO NC: used to pass disable_src_zero_flag to hw configure
+        UNPACK((llk_unpack_hw_configure<DST_ACCUM_MODE>(icb, icb)));
         UNPACK((llk_unpack_A_init<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, UnpackToDestEn>(
             true, false, icb)));
         MATH((llk_math_eltwise_unary_datacopy_init<A2D, DST_ACCUM_MODE, BroadcastType::NONE>(icb)));
         MATH((llk_math_transpose_dest_init<false, true>()));
     } else {
-        UNPACK((llk_unpack_A_hw_configure_disaggregated<DST_ACCUM_MODE, StochRndType::None, false>(icb, true)));
+        UNPACK((llk_unpack_hw_configure<DST_ACCUM_MODE>(icb, icb)));
         UNPACK((llk_unpack_A_init<BroadcastType::NONE, true, EltwiseBinaryReuseDestType::NONE>(true, true, icb)));
         MATH((llk_math_eltwise_unary_datacopy_init<A2D, DST_ACCUM_MODE, BroadcastType::NONE>(icb)));
     }

--- a/tt_metal/include/compute_kernel_api/transpose_wh.h
+++ b/tt_metal/include/compute_kernel_api/transpose_wh.h
@@ -33,7 +33,7 @@ ALWI void transpose_wh_init(uint32_t icb, uint32_t ocb) {
     const bool is_int32 = (src_format & 0xf) == (std::uint32_t)DataFormat::Int32;
 
     if (is_int32) {
-        UNPACK((llk_unpack_hw_configure<DST_ACCUM_MODE>(icb, icb)));
+        UNPACK((llk_unpack_hw_configure<DST_ACCUM_MODE>(icb)));
         UNPACK((llk_unpack_A_init<
                 BroadcastType::NONE,
                 false,
@@ -43,7 +43,7 @@ ALWI void transpose_wh_init(uint32_t icb, uint32_t ocb) {
         MATH((llk_math_eltwise_unary_datacopy_init<A2D, DST_ACCUM_MODE, BroadcastType::NONE>(icb)));
         MATH((llk_math_transpose_dest_init<false, true>()));
     } else {
-        UNPACK((llk_unpack_hw_configure<DST_ACCUM_MODE>(icb, icb)));
+        UNPACK((llk_unpack_hw_configure<DST_ACCUM_MODE>(icb)));
         UNPACK((llk_unpack_A_init<BroadcastType::NONE, true, EltwiseBinaryReuseDestType::NONE>(true, true, icb)));
         MATH((llk_math_eltwise_unary_datacopy_init<A2D, DST_ACCUM_MODE, BroadcastType::NONE>(icb)));
     }

--- a/tt_metal/include/compute_kernel_api/transpose_wh.h
+++ b/tt_metal/include/compute_kernel_api/transpose_wh.h
@@ -33,13 +33,9 @@ ALWI void transpose_wh_init(uint32_t icb, uint32_t ocb) {
     const bool is_int32 = (src_format & 0xf) == (std::uint32_t)DataFormat::Int32;
 
     if (is_int32) {
-        UNPACK((llk_unpack_hw_configure<DST_ACCUM_MODE>(icb)));
-        UNPACK((llk_unpack_A_init<
-                BroadcastType::NONE,
-                false,
-                EltwiseBinaryReuseDestType::NONE,
-                UnpackToDestEn,
-                true /*disable_src_zero_flag*/>(true, false, icb)));
+        UNPACK((llk_unpack_hw_configure<DST_ACCUM_MODE, true>(icb)));
+        UNPACK((llk_unpack_A_init<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, UnpackToDestEn>(
+            true, false, icb)));
         MATH((llk_math_eltwise_unary_datacopy_init<A2D, DST_ACCUM_MODE, BroadcastType::NONE>(icb)));
         MATH((llk_math_transpose_dest_init<false, true>()));
     } else {
@@ -66,12 +62,8 @@ ALWI void transpose_wh_init_short(uint32_t icb) {
     const bool is_int32 = (src_format & 0xf) == (std::uint32_t)DataFormat::Int32;
 
     if (is_int32) {
-        UNPACK((llk_unpack_A_init<
-                BroadcastType::NONE,
-                false,
-                EltwiseBinaryReuseDestType::NONE,
-                UnpackToDestEn,
-                true /*disable_src_zero_flag*/>(true, false, icb)));
+        UNPACK((llk_unpack_A_init<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, UnpackToDestEn>(
+            true, false, icb)));
         MATH((llk_math_eltwise_unary_datacopy_init<A2D, DST_ACCUM_MODE, BroadcastType::NONE>(icb)));
         MATH((llk_math_transpose_dest_init<false, true>()));
     } else {

--- a/tt_metal/include/compute_kernel_api/transpose_wh.h
+++ b/tt_metal/include/compute_kernel_api/transpose_wh.h
@@ -44,7 +44,7 @@ ALWI void transpose_wh_init(uint32_t icb, uint32_t ocb) {
         MATH((llk_math_eltwise_unary_datacopy_init<A2D, DST_ACCUM_MODE, BroadcastType::NONE>(icb)));
     }
     MATH((llk_math_pack_sync_init<DST_ACCUM_MODE>()));
-    MATH((llk_math_hw_configure_disaggregated(icb, icb)));
+    MATH((llk_math_hw_configure(icb, icb)));
 #endif
 
     PACK((llk_pack_hw_configure_disaggregated<DST_ACCUM_MODE, false>(ocb)));

--- a/tt_metal/include/compute_kernel_api/transpose_wh.h
+++ b/tt_metal/include/compute_kernel_api/transpose_wh.h
@@ -35,8 +35,12 @@ ALWI void transpose_wh_init(uint32_t icb, uint32_t ocb) {
     if (is_int32) {
         // TODO NC: used to pass disable_src_zero_flag to hw configure
         UNPACK((llk_unpack_hw_configure<DST_ACCUM_MODE>(icb, icb)));
-        UNPACK((llk_unpack_A_init<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, UnpackToDestEn>(
-            true, false, icb)));
+        UNPACK((llk_unpack_A_init<
+                BroadcastType::NONE,
+                false,
+                EltwiseBinaryReuseDestType::NONE,
+                UnpackToDestEn,
+                true /*disable_src_zero_flag*/>(true, false, icb)));
         MATH((llk_math_eltwise_unary_datacopy_init<A2D, DST_ACCUM_MODE, BroadcastType::NONE>(icb)));
         MATH((llk_math_transpose_dest_init<false, true>()));
     } else {
@@ -63,8 +67,12 @@ ALWI void transpose_wh_init_short(uint32_t icb) {
     const bool is_int32 = (src_format & 0xf) == (std::uint32_t)DataFormat::Int32;
 
     if (is_int32) {
-        UNPACK((llk_unpack_A_init<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, UnpackToDestEn>(
-            true, false, icb)));
+        UNPACK((llk_unpack_A_init<
+                BroadcastType::NONE,
+                false,
+                EltwiseBinaryReuseDestType::NONE,
+                UnpackToDestEn,
+                true /*disable_src_zero_flag*/>(true, false, icb)));
         MATH((llk_math_eltwise_unary_datacopy_init<A2D, DST_ACCUM_MODE, BroadcastType::NONE>(icb)));
         MATH((llk_math_transpose_dest_init<false, true>()));
     } else {

--- a/tt_metal/include/compute_kernel_api/transpose_wh.h
+++ b/tt_metal/include/compute_kernel_api/transpose_wh.h
@@ -33,7 +33,6 @@ ALWI void transpose_wh_init(uint32_t icb, uint32_t ocb) {
     const bool is_int32 = (src_format & 0xf) == (std::uint32_t)DataFormat::Int32;
 
     if (is_int32) {
-        // TODO NC: used to pass disable_src_zero_flag to hw configure
         UNPACK((llk_unpack_hw_configure<DST_ACCUM_MODE>(icb, icb)));
         UNPACK((llk_unpack_A_init<
                 BroadcastType::NONE,

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_pool_2d.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_pool_2d.cpp
@@ -298,7 +298,7 @@ void MAIN {
                         MATH((llk_math_reduce_init<REDUCE_OP, REDUCE_DIM, DST_ACCUM_MODE, MATH_FIDELITY>()));
 #ifdef ARCH_BLACKHOLE
                         // need this on BH to set swizzle bit before pack untilize dest
-                        MATH((llk_math_hw_configure_disaggregated<true, true>(0, 0)));
+                        MATH((llk_math_reconfig_remap(true)));
 #endif
                         PACK((llk_pack_untilize_init<max_tiles_per_iter, max_tiles_per_iter, false, false, TILE_C_DIM>(
                             pre_tilize_cb_id, 1, num_faces_in_output_tile)));


### PR DESCRIPTION
### Ticket
#33824 

### Problem description
We have many different llk-api HW configs for different threads doing the same thing.

What's changed
This unification effort consolidates multiple specialized HW configuration functions into three main functions:

1. **`llk_math_hw_configure`**: Configures math unit data formats and INT8 math mode
2. **`llk_pack_hw_configure`**: Configures packer with comprehensive tile and format settings  
3. **`llk_unpack_hw_configure`**: Configures both unpackers with format and dimension settings

**Key Benefits:**
- **Reduced LLK API complexity**: Fewer HW configuration calls required
- **Cleaner interface**: Consolidated parameters with sensible defaults
- **Full backward compatibility**: All existing functionality preserved

**Specialized functions** handle specific features:
- **`llk_unpack_configure_stoch_rnd`**: Stochastic rounding configuration (both architectures)
- **`llk_math_reconfig_remap`**: Address remapping for untilize operations (BH only)

This provides a cleaner, more maintainable LLK API while preserving full functionality across both WH and BH architectures.

Apart from necessary API headers, the PR touches the places of the old specialized HW configure calls. All functionality has been preserved.

See tt-llk PR for more details: https://github.com/tenstorrent/tt-llk/pull/926

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes - https://github.com/tenstorrent/tt-metal/actions/runs/20414887942
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable) - https://github.com/tenstorrent/tt-metal/actions/runs/20407507689
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable) - https://github.com/tenstorrent/tt-metal/actions/runs/20415564396/ 
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable) - https://github.com/tenstorrent/tt-metal/actions/runs/20414891270 
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] New/Existing tests provide coverage for changes