### PR TITLE
Fix ttnn nightly L2 moreh tests 

### DIFF
--- a/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm/device/kernels/writer_moreh_layer_norm.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm/device/kernels/writer_moreh_layer_norm.cpp
@@ -17,6 +17,7 @@ void write_mean_rstd(
     uint32_t Ht,
     uint32_t Wt,
     T addrg) {
+    using namespace tt::constants;
     constexpr uint32_t onetile = 1;
 
     const uint32_t cb_tile_bytes = get_tile_size(cb_id);
@@ -85,6 +86,7 @@ void write_mean_rstd(
 }
 
 void kernel_main() {
+    using namespace tt::constants;
     const auto output_addr = get_arg_val<uint32_t>(0);
     const auto mean_addr = get_arg_val<uint32_t>(1);
     const auto rstd_addr = get_arg_val<uint32_t>(2);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/kernels/reader_moreh_layer_norm_backward_gamma_beta_grad.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/kernels/reader_moreh_layer_norm_backward_gamma_beta_grad.cpp
@@ -15,6 +15,7 @@ void read_mean_rstd(
     uint32_t Ht,
     uint32_t Wt,
     T addrg) {
+    using namespace tt::constants;
     constexpr uint32_t onetile = 1;
 
     const uint32_t cb_tile_bytes = get_tile_size(cb_id);
@@ -86,6 +87,7 @@ void read_mean_rstd(
 }
 
 void kernel_main() {
+    using namespace tt::constants;
     const auto output_grad_addr = get_arg_val<uint32_t>(0);
     const auto input_addr = get_arg_val<uint32_t>(1);
     const auto mean_addr = get_arg_val<uint32_t>(2);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/kernels/reader_moreh_layer_norm_backward_input_grad_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/kernels/reader_moreh_layer_norm_backward_input_grad_large.cpp
@@ -15,6 +15,7 @@ void read_mean_rstd(
     uint32_t Ht,
     uint32_t Wt,
     T addrg) {
+    using namespace tt::constants;
     constexpr uint32_t onetile = 1;
 
     const uint32_t cb_tile_bytes = get_tile_size(cb_id);
@@ -86,6 +87,7 @@ void read_mean_rstd(
 }
 
 void kernel_main() {
+    using namespace tt::constants;
     const auto output_grad_addr = get_arg_val<uint32_t>(0);
     const auto input_addr = get_arg_val<uint32_t>(1);
     const auto mean_addr = get_arg_val<uint32_t>(2);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/kernels/reader_moreh_layer_norm_backward_input_grad_small.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/kernels/reader_moreh_layer_norm_backward_input_grad_small.cpp
@@ -15,6 +15,7 @@ void read_mean_rstd(
     uint32_t Ht,
     uint32_t Wt,
     T addrg) {
+    using namespace tt::constants;
     constexpr uint32_t onetile = 1;
 
     const uint32_t cb_tile_bytes = get_tile_size(cb_id);
@@ -86,6 +87,7 @@ void read_mean_rstd(
 }
 
 void kernel_main() {
+    using namespace tt::constants;
     const auto output_grad_addr = get_arg_val<uint32_t>(0);
     const auto input_addr = get_arg_val<uint32_t>(1);
     const auto mean_addr = get_arg_val<uint32_t>(2);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step1/device/kernels/reader_moreh_nll_loss_step1_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step1/device/kernels/reader_moreh_nll_loss_step1_large.cpp
@@ -5,6 +5,7 @@
 #include "ttnn/deprecated/tt_dnn/kernels/dataflow/moreh_common.hpp"
 
 void kernel_main() {
+    using namespace tt::constants;
     uint32_t i = 0;
     auto target_addr = get_arg_val<uint32_t>(i++);
     auto weight_addr = get_arg_val<uint32_t>(i++);


### PR DESCRIPTION
### Ticket
Link to Github Issue #34005

### Problem description
During recent cleanup in 76140ca431ffc92191e8b52ee4aca581817373bb some files were not updated because the relevant L2 tests were not part of the testing suite. 

### What's changed
Added missing `using` statements that were missed.
Ran previously failing nightly tests locally and confirmed they are passing.
Ran moreh part of the L2 pipeline, and it's passing: https://github.com/tenstorrent/tt-metal/actions/runs/20040039663

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/20038530505
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes: https://github.com/tenstorrent/tt-metal/actions/runs/20038542204/job/57477487338
(One test will be rerun - the failure doesn't look related - will not merge until it passes or I'm confident the failure is unrelated)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] [cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) job passes
- [x] New/Existing tests provide coverage for changes