### PR TITLE
Test system health enable visible devices

### DIFF
--- a/.github/workflows/galaxy-quick-impl.yaml
+++ b/.github/workflows/galaxy-quick-impl.yaml
@@ -65,6 +65,7 @@ jobs:
         # NOTE: These tests do not automatically get added to upstream tests. Please refer to dockerfile/upstream_test_images/.
         run: |
           ./build/test/tt_metal/tt_fabric/test_system_health --system-topology TORUS_XY
+          for i in {0..31}; do TT_VISIBLE_DEVICES="$i" ./build/test/tt_metal/tt_fabric/test_system_health --gtest_filter=Cluster.ReportSystemHealth; done
           TT_METAL_SKIP_ETH_CORES_WITH_RETRAIN=1 ./build/test/tt_metal/unit_tests_dispatch --gtest_filter="UnitMeshCQSingleCardFixture.*";
           TT_METAL_SKIP_ETH_CORES_WITH_RETRAIN=1 ./build/test/tt_metal/unit_tests_dispatch --gtest_filter="UnitMeshCQSingleCardProgramFixture.*";
           TT_METAL_SKIP_ETH_CORES_WITH_RETRAIN=1 ./build/test/tt_metal/unit_tests_dispatch --gtest_filter="UnitMeshCQSingleCardBufferFixture.ShardedBufferLarge*ReadWrites";

--- a/tests/tt_metal/tt_fabric/system_health/test_system_health.cpp
+++ b/tests/tt_metal/tt_fabric/system_health/test_system_health.cpp
@@ -301,7 +301,9 @@ TEST(Cluster, ReportSystemHealth) {
             if (cluster.is_ethernet_link_up(chip_id, eth_core)) {
                 eth_ss << " link UP " << connection_type;
                 CoreCoord connected_eth_core = CoreCoord{0, 0};
-                if (eth_connections.at(chip_id).find(chan) != eth_connections.at(chip_id).end()) {
+                auto eth_conn_it = eth_connections.find(chip_id);
+                if (eth_conn_it != eth_connections.end() &&
+                    eth_conn_it->second.find(chan) != eth_conn_it->second.end()) {
                     ChipId connected_chip_id = 0;
                     std::tie(connected_chip_id, connected_eth_core) =
                         cluster.get_connected_ethernet_core(std::make_tuple(chip_id, eth_core));


### PR DESCRIPTION
### Ticket
#33764

### Problem description
Unable to map chips from /dev/tenstorrent/<id> to mesh in order to pick connected pairs. This is require to enable TP=2 multiprocess model configuration on galaxy with `tt-media-server` and is P0 issue for release. 


### What's changed

Allowing `./build/test/tt_metal/tt_fabric/test_system_health --gtest_filter=Cluster.ReportSystemHealth` to run with `TT_VISIBLE_DEVICES` to enable workaround where we run test_system_health for each ` /dev/tenstorrent/<id>` in order to understand its mapping to tray location and create connected pairs. 

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) https://github.com/tenstorrent/tt-metal/actions/runs/20044705980
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) https://github.com/tenstorrent/tt-metal/actions/runs/20044713907