### PR TITLE
Update vllm gen to align with demo gen

### DIFF
--- a/models/demos/deepseek_v3/tt/generator_vllm.py
+++ b/models/demos/deepseek_v3/tt/generator_vllm.py
@@ -9,10 +9,11 @@ import torch
 from loguru import logger
 
 from models.demos.deepseek_v3.tt.generator import DeepseekGenerator
+from models.demos.deepseek_v3.utils.config_helpers import USERS_PER_ROW
 from models.demos.deepseek_v3.utils.hf_model_utils import load_tokenizer
 
 
-def _pad_tokens(tokens: torch.Tensor, pad_value: int = 0, block_size: int = 32) -> torch.Tensor:
+def _pad_tokens(tokens: torch.Tensor, pad_value: int = 0, block_size: int = USERS_PER_ROW) -> torch.Tensor:
     """
     Pad tokens to the nearest multiple of block_size.
 
@@ -76,7 +77,7 @@ class DeepseekV3ForCausalLM(DeepseekGenerator):
 
         tokens = kwargs["tokens"]
         lengths = kwargs["prompt_lens"]
-        tokens = _pad_tokens(tokens, self.tokenizer.pad_token_id, block_size=self.mesh_device.shape[1])
+        tokens = _pad_tokens(tokens, self.tokenizer.pad_token_id, block_size=USERS_PER_ROW)
         num_of_users = tokens.shape[0]
         last_logits = []
         for user_id in range(num_of_users):
@@ -93,7 +94,10 @@ class DeepseekV3ForCausalLM(DeepseekGenerator):
     def decode_forward(self, *args, **kwargs):
         tokens_step = kwargs["tokens"].squeeze(1)
         return_value = (
-            self._decode_step(tokens_step=tokens_step, positions=kwargs["start_pos"]).squeeze(0).squeeze(0).unsqueeze(1)
+            self._decode_step(tokens_step=tokens_step, positions=kwargs["start_pos"], batch_size_per_row=USERS_PER_ROW)
+            .squeeze(0)
+            .squeeze(0)
+            .unsqueeze(1)
         )  # [1,1,B,V] -> [B, 1, V]
         return return_value
 


### PR DESCRIPTION
### Problem description
some of the APIs changes in demo generator class. Update vllm generator class to match it and also use USERS_PER_ROW variable instead of hardcoded value 32 for padding upscale.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] [cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) job passes
- [ ] New/Existing tests provide coverage for changes