### PR TITLE
fix kernel compile issue when watcher is enabled

### DIFF
--- a/tt_metal/fabric/hw/inc/edm_fabric/fabric_edm_packet_transmission.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/fabric_edm_packet_transmission.hpp
@@ -352,7 +352,7 @@ FORCE_INLINE
         tt::tt_fabric::EdmToEdmSender<NUM_SENDER_BUFFERS>& downstream_edm_interface,
         uint8_t transaction_id) {
     // TODO: PERF - this should already be getting checked by the caller so this should be redundant make it an ASSERT
-    ASSERT(downstream_edm_interface.edm_has_space_for_packet());  // best effort check
+    ASSERT(downstream_edm_interface.template edm_has_space_for_packet<ENABLE_RISC_CPU_DATA_CACHE>());  // best effort check
 
     // This is a good place to print the packet header for debug if you are trying to inspect packets
     // because it is before we start manipulating the header for forwarding


### PR DESCRIPTION
Recent change broke build when watcher was enabled: https://github.com/tenstorrent/tt-metal/actions/runs/20034558604/job/57453075961

This patches the issue.

### Checklist
- [x] T3K Fast: https://github.com/tenstorrent/tt-metal/actions/runs/20045212291
- [x] T3K Unit: https://github.com/tenstorrent/tt-metal/actions/runs/20045199462 - original failure resolved