### PR TITLE
DPRINT logs to go to /tmp/tt-metalium/generated/dprint

### DIFF
--- a/docs/source/tt-metalium/tools/kernel_print.rst
+++ b/docs/source/tt-metalium/tools/kernel_print.rst
@@ -27,7 +27,7 @@ Note that the core coordinates are logical coordinates, so worker cores and ethe
     export TT_METAL_DPRINT_RISCVS=BR                    # optional, default is all RISCs. Use a subset of BR,NC,TR0,TR1,TR2,TR*,ER0,ER1,ER*
     export TT_METAL_DPRINT_FILE=log.txt                 # optional, default is to print to the screen
     export TT_METAL_DPRINT_PREPEND_DEVICE_CORE_RISC=0   # optional, enabled by default. Prepends prints with <device id>:(<core x>, <core y>):<RISC>:.
-    export TT_METAL_DPRINT_ONE_FILE_PER_RISC=1          # optional, splits DPRINT data on a per-RISC basis into files under $TT_METAL_HOME/generated/dprint/. Overrides TT_METAL_DPRINT_FILE and disables TT_METAL_DPRINT_PREPEND_DEVICE_CORE_RISC.
+    export TT_METAL_DPRINT_ONE_FILE_PER_RISC=1          # optional, splits DPRINT data on a per-RISC basis into files under /tmp/tt-metalium/generated/dprint/. Overrides TT_METAL_DPRINT_FILE and disables TT_METAL_DPRINT_PREPEND_DEVICE_CORE_RISC.
 
 To generate kernel debug prints on the device, include the ``debug/dprint.h`` header and use the APIs defined there.
 An example with the different features available is shown below:

--- a/tests/tt_metal/tt_metal/debug_tools/debug_tools_fixture.hpp
+++ b/tests/tt_metal/tt_metal/debug_tools/debug_tools_fixture.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <gtest/gtest.h>
+#include <filesystem>
 #include "tt_metal/tt_metal/common/mesh_dispatch_fixture.hpp"
 
 #include "debug_tools_test_utils.hpp"
@@ -126,7 +127,8 @@ public:
             if (!enabled_processors.contains(HalProgrammableCoreType::TENSIX, i)) {
                 continue;
             }
-            auto filename = fmt::format("generated/dprint/device-0_worker-core-0-0_{}.txt", suffixes[i]);
+            auto filename = (std::filesystem::temp_directory_path() / "tt-metalium" /
+                fmt::format("generated/dprint/device-0_worker-core-0-0_{}.txt", suffixes[i])).string();
             EXPECT_TRUE(FilesMatchesString(filename, expected[i]));
         }
     }


### PR DESCRIPTION
### Ticket
NA

### Problem description
When working from an installed tt-metalium package, the root_dir is `/usr/libexec/tt-metalium/`.

A `non root` user will not be able to write this location.
```
C++ exception with description "filesystem error: cannot create directories: Permission denied [/usr/libexec/tt-metalium/generated/dprint/]" thrown in SetUp().
```

We need to decouple DPRINT Logs from `root_dir`.

### What's changed
DPRINT logs will be written to `/tmp/tt-metalium/generated/dprint/`.

If that location is for some reason not writable, a warning will be emitted, and `/dev/null` will be the log path. 

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/20046022292) CI passes
- [x] New/Existing tests provide coverage for changes