### PR TITLE
Move DeviceManager to MetalContext

### DIFF
--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -77,7 +77,7 @@ void MetalContext::initialize_device_manager(
     bool init_profiler,
     bool initialize_fabric_and_dispatch_fw) {
     initialize(dispatch_core_config, num_hw_cqs, {l1_bank_remap.begin(), l1_bank_remap.end()}, worker_l1_size);
-    DeviceManager::initialize(
+    device_manager_->initialize(
         device_ids,
         num_hw_cqs,
         l1_small_size,
@@ -416,6 +416,8 @@ MetalContext::MetalContext() {
         worker_logical_row_to_virtual_row_.emplace(device_id, std::vector<uint8_t>{});
     }
 
+    device_manager_ = std::make_unique<DeviceManager>();
+
     // We do need to call Cluster teardown at the end of the program, use atexit temporarily until we have clarity on
     // how MetalContext lifetime will work through the API.
     std::atexit([]() { MetalContext::instance().~MetalContext(); });
@@ -431,7 +433,10 @@ std::shared_ptr<distributed::multihost::DistributedContext> MetalContext::get_di
     return distributed_context_;
 }
 
-MetalContext::~MetalContext() { teardown_base_objects(); }
+MetalContext::~MetalContext() {
+    device_manager_.reset();
+    teardown_base_objects();
+}
 
 llrt::RunTimeOptions& MetalContext::rtoptions() { return rtoptions_; }
 
@@ -562,7 +567,7 @@ void MetalContext::set_custom_fabric_topology(
     const std::string& mesh_graph_desc_file,
     const std::map<tt_fabric::FabricNodeId, ChipId>& logical_mesh_chip_id_to_physical_chip_id_mapping) {
     TT_FATAL(
-        !DeviceManager::is_initialized() || DeviceManager::instance().get_all_active_devices().empty(),
+        !device_manager_->is_initialized() || device_manager_->get_all_active_devices().empty(),
         "Modifying control plane requires no devices to be active");
     // Set the user specified mesh graph descriptor file and FabricNodeID to physical chip mapping.
     this->logical_mesh_chip_id_to_physical_chip_id_mapping_ = logical_mesh_chip_id_to_physical_chip_id_mapping;
@@ -572,7 +577,7 @@ void MetalContext::set_custom_fabric_topology(
 
 void MetalContext::set_default_fabric_topology() {
     TT_FATAL(
-        !DeviceManager::is_initialized() || DeviceManager::instance().get_all_active_devices().empty(),
+        !device_manager_->is_initialized() || device_manager_->get_all_active_devices().empty(),
         "Modifying control plane requires no devices to be active");
     // Reset the control plane, since it was initialized with custom parameters.
     control_plane_.reset();
@@ -1620,7 +1625,5 @@ bool MetalContext::is_coord_in_range(CoreCoord coord, CoreType core_type) {
     CoreCoord virtual_coord = cluster_->get_virtual_coordinate_from_logical_coordinates(id, coord, core_type);
     return cluster_->is_ethernet_core(virtual_coord, id) || cluster_->is_worker_core(virtual_coord, id);
 }
-
-DeviceManager* MetalContext::device_manager() { return &(DeviceManager::instance()); }
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/context/metal_context.hpp
+++ b/tt_metal/impl/context/metal_context.hpp
@@ -68,7 +68,7 @@ public:
 
     std::unique_ptr<ProfilerStateManager>& profiler_state_manager() { return profiler_state_manager_; }
     std::unique_ptr<DataCollector>& data_collector() { return data_collector_; }
-    DeviceManager* device_manager();
+    std::unique_ptr<DeviceManager>& device_manager() { return device_manager_; }
 
     void initialize_device_manager(
         const std::vector<ChipId>& device_ids,
@@ -205,6 +205,7 @@ private:
     std::unique_ptr<WatcherServer> watcher_server_;
     std::unique_ptr<ProfilerStateManager> profiler_state_manager_;
     std::unique_ptr<DataCollector> data_collector_;
+    std::unique_ptr<DeviceManager> device_manager_;
 
     std::array<std::unique_ptr<DispatchMemMap>, static_cast<size_t>(CoreType::COUNT)> dispatch_mem_map_;
     std::unique_ptr<tt::tt_fabric::ControlPlane> control_plane_;

--- a/tt_metal/impl/device/device_manager.hpp
+++ b/tt_metal/impl/device/device_manager.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -10,25 +10,17 @@
 #include <vector>
 #include <hostdevcommon/common_values.hpp>
 #include "umd/device/types/cluster_descriptor_types.hpp"
-#include <tt_stl/assert.hpp>
 
 namespace tt::tt_metal {
 class IDevice;
 class DeviceManager {
 public:
-    DeviceManager& operator=(const DeviceManager&) = delete;
-    DeviceManager& operator=(DeviceManager&& other) noexcept = delete;
-    DeviceManager(const DeviceManager&) = delete;
-    DeviceManager(DeviceManager&& other) noexcept = delete;
+    ~DeviceManager();
+    DeviceManager();
 
-    static bool is_initialized() { return _inst != nullptr; }
+    bool is_initialized() { return is_initialized_; }
 
-    static DeviceManager& instance() noexcept {
-        TT_ASSERT(DeviceManager::is_initialized(), "Trying to get DeviceManager without initializing it");
-        return *_inst;
-    }
-
-    static void initialize(
+    void initialize(
         const std::vector<ChipId>& device_ids,
         uint8_t num_hw_cqs,
         size_t l1_small_size,
@@ -38,63 +30,62 @@ public:
         bool init_profiler = true,
         bool initialize_fabric_and_dispatch_fw = true);
 
-    tt_metal::IDevice* get_active_device(ChipId device_id) const;
-    std::vector<tt_metal::IDevice*> get_all_active_devices() const;
+    IDevice* get_active_device(ChipId device_id) const;
+    std::vector<IDevice*> get_all_active_devices() const;
     bool close_device(ChipId device_id);
     std::vector<ChipId> get_all_active_device_ids() const;
     std::unordered_map<ChipId, std::vector<uint32_t>> get_all_command_queue_event_infos() const;
-    bool close_devices(const std::vector<tt_metal::IDevice*>& devices, bool skip_synchronize = false);
+    bool close_devices(const std::vector<IDevice*>& devices, bool skip_synchronize = false);
     bool is_device_active(ChipId id) const;
     // True if dispatch firmware is active on this device pool
     bool is_dispatch_firmware_active() const;
     void init_profiler() const;
-    void initialize_fabric_and_dispatch_fw() const;
+    void initialize_fabric_and_dispatch_fw();
     // API needed due to Issue #19729
     std::size_t get_max_num_eth_cores_across_all_devices() const;
 
 private:
-    ~DeviceManager();
-    DeviceManager();
-    uint8_t num_hw_cqs{};
-    size_t l1_small_size{};
-    size_t trace_region_size{};
-    size_t worker_l1_size{};
-    std::vector<uint32_t> l1_bank_remap;
+    uint8_t num_hw_cqs_{};
+    size_t l1_small_size_{};
+    size_t trace_region_size_{};
+    size_t worker_l1_size_{};
+    std::vector<uint32_t> l1_bank_remap_;
     bool using_fast_dispatch_ = false;
     bool init_profiler_ = true;
     bool initialize_fabric_and_dispatch_fw_ = false;
     // This variable tracks the state of dispatch firmware on device.
     // It is set to true when dispatch firmware is launched, and reset
-    // after the terimnate command is sent.
+    // after the terminate command is sent.
     bool dispatch_firmware_active_ = false;
+    bool is_initialized_ = false;
 
-    mutable std::mutex lock;
-    std::vector<std::unique_ptr<tt_metal::IDevice>> devices;
+    mutable std::mutex lock_;
+    std::vector<std::unique_ptr<tt_metal::IDevice>> devices_;
 
-    bool skip_remote_devices{};
-    std::unordered_set<uint32_t> firmware_built_keys;
+    bool skip_remote_devices_{};
 
     // Determine which CPU cores the worker threads need to be placed on for each device
-    std::unordered_map<uint32_t, uint32_t> worker_thread_to_cpu_core_map;
-    std::unordered_map<uint32_t, uint32_t> completion_queue_reader_to_cpu_core_map;
-    void init_firmware_on_active_devices() const;
+    std::unordered_map<uint32_t, uint32_t> worker_thread_to_cpu_core_map_;
+    std::unordered_map<uint32_t, uint32_t> completion_queue_reader_to_cpu_core_map_;
+    void init_firmware_on_active_devices();
     void activate_device(ChipId id);
 
+    // Initialize DeviceManager
+    void initialize_devices(const std::vector<ChipId>& device_ids);
+
     // Initialize state on the host for this device
-    void initialize_host(tt_metal::IDevice* dev) const;
+    void initialize_host(IDevice* dev) const;
 
     // Initialize state for activated devices
-    void init_fabric(const std::vector<tt_metal::IDevice*>& active_devices) const;
-    void initialize_active_devices() const;
+    void init_fabric(const std::vector<IDevice*>& active_devices) const;
+    void initialize_active_devices();
     void add_devices_to_pool(const std::vector<ChipId>& device_ids);
     void wait_for_fabric_router_sync(uint32_t timeout_ms = 5000) const;
-    tt_metal::IDevice* get_device(ChipId id) const;
+    IDevice* get_device(ChipId id) const;
     void teardown_fd(const std::unordered_set<ChipId>& devices_to_close);
 
     // Retrieves the fabric router sync timeout value from configuration or returns a default
     static uint32_t get_fabric_router_sync_timeout_ms();
-
-    static DeviceManager* _inst;
 };
 
 }  // namespace tt::tt_metal


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/25036

Problem description
Move init/teardown flow from Device/DevicePool to MetalContext

What's changed
Made DeviceManager not a singleton

### Checklist
All Post Commit
https://github.com/tenstorrent/tt-metal/actions/runs/20144735362
Blackhole Post Commit
https://github.com/tenstorrent/tt-metal/actions/runs/20144737938
Galaxy Multi User Isolation
https://github.com/tenstorrent/tt-metal/actions/runs/20147270798
Multi Host Deployment Physical
https://github.com/tenstorrent/tt-metal/actions/runs/20147265503
Blackhole Nightly -- main is broken
https://github.com/tenstorrent/tt-metal/actions/runs/20147268168
Galaxy Demo Test -- main is broken
https://github.com/tenstorrent/tt-metal/actions/runs/20147269686