### PR TITLE
[skip ci] Update unary operation documentation example tests

### DIFF
--- a/tests/ttnn/docs_examples/test_backward_examples.py
+++ b/tests/ttnn/docs_examples/test_backward_examples.py
@@ -187,17 +187,18 @@ def test_rdiv_bw(device):
     logger.info(f"Reverse Division Backward: {output}")
 
 
-@pytest.mark.skip("Non-working example from the documentation. GH issue: #32364")
 def test_repeat_bw(device):
     # Create sample tensors for backward repeat operation
-    grad_tensor = ttnn.from_torch(
-        torch.tensor([[1, 2], [3, 4]], dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device
-    )
+    # Input tensor that will be repeated
     input_tensor = ttnn.from_torch(
-        torch.tensor([[1, 2], [3, 4]], dtype=torch.bfloat16, requires_grad=True), layout=ttnn.TILE_LAYOUT, device=device
+        torch.rand([1, 1, 32, 32], dtype=torch.bfloat16, requires_grad=True), layout=ttnn.TILE_LAYOUT, device=device
+    )
+    # Grad tensor matching the shape after repeat operation (2x repeat in dim 0)
+    grad_tensor = ttnn.from_torch(
+        torch.rand([2, 1, 32, 32], dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device
     )
     # Define the shape for repeat operation
-    shape = [1, 1, 32, 32]
+    shape = [2, 1, 1, 1]
 
     # Call the repeat_bw function
     output = ttnn.repeat_bw(grad_tensor, input_tensor, shape)
@@ -1043,56 +1044,104 @@ def test_polygamma_bw(device):
 
 
 # Complex backward operations
-@pytest.mark.skip("Non-working example from the documentation. GH issue: #32364")
 def test_polar_bw(device):
     # Create sample tensors for backward polar coordinate operation
-    grad_tensor = ttnn.to_device(ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16)), device=device)
-    tensor = ttnn.to_device(ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16)), device=device)
+    # Create complex input tensor
+    input_real = torch.rand([1, 1, 32, 32], dtype=torch.bfloat16)
+    input_imag = torch.rand([1, 1, 32, 32], dtype=torch.bfloat16)
+    input_tensor = ttnn.complex_tensor(
+        ttnn.Tensor(input_real, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device),
+        ttnn.Tensor(input_imag, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device),
+    )
+
+    # Create complex gradient tensor
+    grad_real = torch.rand([1, 1, 32, 32], dtype=torch.bfloat16)
+    grad_imag = torch.rand([1, 1, 32, 32], dtype=torch.bfloat16)
+    grad_tensor = ttnn.complex_tensor(
+        ttnn.Tensor(grad_real, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device),
+        ttnn.Tensor(grad_imag, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device),
+    )
 
     # Call the polar_bw function
-    output = ttnn.polar_bw(grad_tensor, tensor)
+    output = ttnn.polar_bw(grad_tensor, input_tensor, memory_config=ttnn.DRAM_MEMORY_CONFIG)
     logger.info(f"Polar Backward: {output}")
 
 
-@pytest.mark.skip("Non-working example from the documentation. GH issue: #32364")
 def test_imag_bw(device):
     # Create sample tensors for backward imaginary part operation
-    grad_tensor = ttnn.to_device(ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16)), device=device)
-    tensor = ttnn.to_device(ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16)), device=device)
+    # Create a complex input tensor
+    input_real = torch.rand([1, 1, 32, 32], dtype=torch.bfloat16)
+    input_imag = torch.rand([1, 1, 32, 32], dtype=torch.bfloat16)
+    input_tensor = ttnn.complex_tensor(
+        ttnn.Tensor(input_real, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device),
+        ttnn.Tensor(input_imag, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device),
+    )
+
+    # Gradient tensor for the imaginary part (regular tensor, not complex)
+    grad_data = torch.rand([1, 1, 32, 32], dtype=torch.bfloat16)
+    grad_tensor = ttnn.Tensor(grad_data, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
 
     # Call the imag_bw function
-    output = ttnn.imag_bw(grad_tensor, tensor)
+    output = ttnn.imag_bw(grad_tensor, input_tensor, memory_config=ttnn.DRAM_MEMORY_CONFIG)
     logger.info(f"Imaginary Part Backward: {output}")
 
 
-@pytest.mark.skip("Non-working example from the documentation. GH issue: #32364")
 def test_real_bw(device):
     # Create sample tensors for backward real part operation
-    grad_tensor = ttnn.to_device(ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16)), device=device)
-    tensor = ttnn.to_device(ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16)), device=device)
+    # Create a complex input tensor
+    input_real = torch.rand([1, 1, 32, 32], dtype=torch.bfloat16)
+    input_imag = torch.rand([1, 1, 32, 32], dtype=torch.bfloat16)
+    input_tensor = ttnn.complex_tensor(
+        ttnn.Tensor(input_real, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device),
+        ttnn.Tensor(input_imag, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device),
+    )
+
+    # Gradient tensor for the real part (regular tensor, not complex)
+    grad_data = torch.rand([1, 1, 32, 32], dtype=torch.bfloat16)
+    grad_tensor = ttnn.Tensor(grad_data, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
 
     # Call the real_bw function
-    output = ttnn.real_bw(grad_tensor, tensor)
+    output = ttnn.real_bw(grad_tensor, input_tensor, memory_config=ttnn.DRAM_MEMORY_CONFIG)
     logger.info(f"Real Part Backward: {output}")
 
 
-@pytest.mark.skip("Non-working example from the documentation. GH issue: #32364")
 def test_angle_bw(device):
     # Create sample tensors for backward angle operation
-    grad_tensor = ttnn.to_device(ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16)), device=device)
-    tensor = ttnn.to_device(ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16)), device=device)
+    # Create a complex input tensor
+    input_real = torch.rand([1, 1, 32, 32], dtype=torch.bfloat16)
+    input_imag = torch.rand([1, 1, 32, 32], dtype=torch.bfloat16)
+    input_tensor = ttnn.complex_tensor(
+        ttnn.Tensor(input_real, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device),
+        ttnn.Tensor(input_imag, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device),
+    )
+
+    # Gradient tensor for the angle (regular tensor, not complex)
+    grad_data = torch.rand([1, 1, 32, 32], dtype=torch.bfloat16)
+    grad_tensor = ttnn.Tensor(grad_data, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
 
     # Call the angle_bw function
-    output = ttnn.angle_bw(grad_tensor, tensor)
+    output = ttnn.angle_bw(grad_tensor, input_tensor, memory_config=ttnn.DRAM_MEMORY_CONFIG)
     logger.info(f"Angle Backward: {output}")
 
 
-@pytest.mark.skip("Non-working example from the documentation. GH issue: #32364")
 def test_conj_bw(device):
     # Create sample tensors for backward complex conjugate operation
-    grad_tensor = ttnn.to_device(ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16)), device=device)
-    tensor = ttnn.to_device(ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16)), device=device)
+    # Create a complex input tensor
+    input_real = torch.rand([1, 1, 32, 32], dtype=torch.bfloat16)
+    input_imag = torch.rand([1, 1, 32, 32], dtype=torch.bfloat16)
+    input_tensor = ttnn.complex_tensor(
+        ttnn.Tensor(input_real, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device),
+        ttnn.Tensor(input_imag, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device),
+    )
+
+    # Create complex gradient tensor
+    grad_real = torch.rand([1, 1, 32, 32], dtype=torch.bfloat16)
+    grad_imag = torch.rand([1, 1, 32, 32], dtype=torch.bfloat16)
+    grad_tensor = ttnn.complex_tensor(
+        ttnn.Tensor(grad_real, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device),
+        ttnn.Tensor(grad_imag, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device),
+    )
 
     # Call the conj_bw function
-    output = ttnn.conj_bw(grad_tensor, tensor)
+    output = ttnn.conj_bw(grad_tensor, input_tensor, memory_config=ttnn.DRAM_MEMORY_CONFIG)
     logger.info(f"Complex Conjugate Backward: {output}")

--- a/tests/ttnn/docs_examples/test_complex_unary_examples.py
+++ b/tests/ttnn/docs_examples/test_complex_unary_examples.py
@@ -8,81 +8,112 @@ import torch
 from loguru import logger
 
 
-@pytest.mark.skip("Non-working example from the documentation. GH issue: #32364")
 def test_real(device):
     # Create a complex tensor
-    tensor = ttnn.to_device(ttnn.from_torch(torch.tensor((0, 1), dtype=torch.bfloat16)), device=device)
+    real_part = torch.rand([1, 1, 32, 32], dtype=torch.bfloat16)
+    imag_part = torch.rand([1, 1, 32, 32], dtype=torch.bfloat16)
+    tensor = ttnn.complex_tensor(
+        ttnn.Tensor(real_part, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device),
+        ttnn.Tensor(imag_part, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device),
+    )
 
     # Get the real part
-    output = ttnn.real(tensor)
+    output = ttnn.real(tensor, memory_config=ttnn.DRAM_MEMORY_CONFIG)
     logger.info(f"Real part: {output}")
 
 
-@pytest.mark.skip("Non-working example from the documentation. GH issue: #32364")
 def test_imag(device):
     # Create a complex tensor
-    tensor = ttnn.to_device(ttnn.from_torch(torch.tensor((0, 1), dtype=torch.bfloat16)), device=device)
+    real_part = torch.rand([1, 1, 32, 32], dtype=torch.bfloat16)
+    imag_part = torch.rand([1, 1, 32, 32], dtype=torch.bfloat16)
+    tensor = ttnn.complex_tensor(
+        ttnn.Tensor(real_part, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device),
+        ttnn.Tensor(imag_part, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device),
+    )
 
     # Get the imaginary part
-    output = ttnn.imag(tensor)
+    output = ttnn.imag(tensor, memory_config=ttnn.DRAM_MEMORY_CONFIG)
     logger.info(f"Imaginary part: {output}")
 
 
-@pytest.mark.skip("Non-working example from the documentation. GH issue: #32364")
 def test_angle(device):
     # Create a complex tensor
-    tensor = ttnn.to_device(ttnn.from_torch(torch.tensor((0, 1), dtype=torch.bfloat16)), device=device)
+    real_part = torch.rand([1, 1, 32, 32], dtype=torch.bfloat16)
+    imag_part = torch.rand([1, 1, 32, 32], dtype=torch.bfloat16)
+    tensor = ttnn.complex_tensor(
+        ttnn.Tensor(real_part, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device),
+        ttnn.Tensor(imag_part, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device),
+    )
 
     # Get the angle (phase) of the complex tensor
-    output = ttnn.angle(tensor)
+    output = ttnn.angle(tensor, memory_config=ttnn.DRAM_MEMORY_CONFIG)
     logger.info(f"Angle: {output}")
 
 
-@pytest.mark.skip("Non-working example from the documentation. GH issue: #32364")
 def test_is_imag(device):
-    # Create a complex tensor
-    tensor = ttnn.to_device(ttnn.from_torch(torch.tensor((0, 1), dtype=torch.bfloat16)), device=device)
+    # Create a complex tensor with only imaginary part
+    real_part = torch.zeros([1, 1, 32, 32], dtype=torch.bfloat16)
+    imag_part = torch.rand([1, 1, 32, 32], dtype=torch.bfloat16)
+    tensor = ttnn.complex_tensor(
+        ttnn.Tensor(real_part, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device),
+        ttnn.Tensor(imag_part, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device),
+    )
 
     # Check if tensor values are purely imaginary
-    output = ttnn.is_imag(tensor)
+    output = ttnn.is_imag(tensor, memory_config=ttnn.DRAM_MEMORY_CONFIG)
     logger.info(f"Is imaginary: {output}")
 
 
-@pytest.mark.skip("Non-working example from the documentation. GH issue: #32364")
 def test_is_real(device):
-    # Create a complex tensor
-    tensor = ttnn.to_device(ttnn.from_torch(torch.tensor((0, 1), dtype=torch.bfloat16)), device=device)
+    # Create a complex tensor with only real part
+    real_part = torch.rand([1, 1, 32, 32], dtype=torch.bfloat16)
+    imag_part = torch.zeros([1, 1, 32, 32], dtype=torch.bfloat16)
+    tensor = ttnn.complex_tensor(
+        ttnn.Tensor(real_part, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device),
+        ttnn.Tensor(imag_part, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device),
+    )
 
     # Check if tensor values are purely real
-    output = ttnn.is_real(tensor)
+    output = ttnn.is_real(tensor, memory_config=ttnn.DRAM_MEMORY_CONFIG)
     logger.info(f"Is real: {output}")
 
 
-@pytest.mark.skip("Non-working example from the documentation. GH issue: #32364")
 def test_conj(device):
     # Create a complex tensor
-    tensor = ttnn.to_device(ttnn.from_torch(torch.tensor((0, 1), dtype=torch.bfloat16)), device=device)
+    real_part = torch.rand([1, 1, 32, 32], dtype=torch.bfloat16)
+    imag_part = torch.rand([1, 1, 32, 32], dtype=torch.bfloat16)
+    tensor = ttnn.complex_tensor(
+        ttnn.Tensor(real_part, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device),
+        ttnn.Tensor(imag_part, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device),
+    )
 
     # Get the complex conjugate
-    output = ttnn.conj(tensor)
+    output = ttnn.conj(tensor, memory_config=ttnn.DRAM_MEMORY_CONFIG)
     logger.info(f"Complex conjugate: {output}")
 
 
-@pytest.mark.skip("Non-working example from the documentation. GH issue: #32364")
 def test_polar(device):
-    # Create a complex tensor
-    tensor = ttnn.to_device(ttnn.from_torch(torch.tensor((0, 1), dtype=torch.bfloat16)), device=device)
+    # Create a complex tensor where real=magnitude, imag=angle
+    magnitude = torch.rand([1, 1, 32, 32], dtype=torch.bfloat16)
+    angle = torch.rand([1, 1, 32, 32], dtype=torch.bfloat16) * 2 * 3.14159  # angle in radians
+    tensor = ttnn.complex_tensor(
+        ttnn.Tensor(magnitude, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device),
+        ttnn.Tensor(angle, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device),
+    )
 
-    # Convert to polar form
-    output = ttnn.polar(tensor)
-    logger.info(f"Polar form: {output}")
+    # Convert from polar to Cartesian form
+    output = ttnn.polar(tensor, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+    logger.info(f"Polar to Cartesian: {output}")
 
 
-@pytest.mark.skip("Non-working example from the documentation. GH issue: #32364")
 def test_alt_complex_rotate90(device):
-    # Create a tensor with alternating complex layout
-    tensor = ttnn.rand([2, 2], dtype=torch.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    # Create a tensor with alternating complex layout (even last dimension required)
+    tensor = ttnn.from_torch(
+        torch.rand([1, 1, 32, 64], dtype=torch.bfloat16),
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+    )
 
-    # Rotate complex values by 90 degrees
+    # Rotate complex values by 90 degrees in alternating format
     output = ttnn.alt_complex_rotate90(tensor)
     logger.info(f"Complex rotated by 90 degrees: {output}")

--- a/tests/ttnn/docs_examples/test_eltwise_unary_examples.py
+++ b/tests/ttnn/docs_examples/test_eltwise_unary_examples.py
@@ -1162,59 +1162,45 @@ def test_rdiv(device):
     logger.info(f"Reverse division: {output}")
 
 
-@pytest.mark.skip("Non-working example from the documentation. GH issue: #32364")
 def test_bitwise_left_shift(device):
     # Create tensors with specific integer values
-    tensor1 = ttnn.from_torch(
-        torch.tensor([[1, 2], [3, 4]], dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device
-    )
-    tensor2 = ttnn.from_torch(
-        torch.tensor([[1, 2], [3, 4]], dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device
-    )
+    tensor1 = ttnn.from_torch(torch.tensor([[1, 2], [3, 4]], dtype=torch.int32), layout=ttnn.TILE_LAYOUT, device=device)
+    tensor2 = ttnn.from_torch(torch.tensor([[1, 2], [3, 4]], dtype=torch.int32), layout=ttnn.TILE_LAYOUT, device=device)
 
     # Apply bitwise left shift operation
-    output = ttnn.bitwise_left_shift(tensor1, tensor2)  # CHECK
+    output = ttnn.bitwise_left_shift(tensor1, tensor2)
     logger.info(f"Bitwise left shift: {output}")
 
 
-@pytest.mark.skip("Non-working example from the documentation. GH issue: #32364")
 def test_bitwise_right_shift(device):
     # Create tensors with specific integer values
-    tensor1 = ttnn.from_torch(
-        torch.tensor([[1, 2], [3, 4]], dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device
-    )
-    tensor2 = ttnn.from_torch(
-        torch.tensor([[1, 2], [3, 4]], dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device
-    )
+    tensor1 = ttnn.from_torch(torch.tensor([[1, 2], [3, 4]], dtype=torch.int32), layout=ttnn.TILE_LAYOUT, device=device)
+    tensor2 = ttnn.from_torch(torch.tensor([[1, 2], [3, 4]], dtype=torch.int32), layout=ttnn.TILE_LAYOUT, device=device)
 
     # Apply bitwise right shift operation
     output = ttnn.bitwise_right_shift(tensor1, tensor2)
-    logger.info(f"Bitwise right shift: {output}")  # Check
+    logger.info(f"Bitwise right shift: {output}")
 
 
-@pytest.mark.skip("Non-working example from the documentation. GH issue: #32364")
 def test_prelu(device):
     # Create tensors for PReLU activation function
-    tensor1 = ttnn.from_torch(torch.rand([1, 2, 32, 32], dtype=torch.bfloat16), device=device)
-    tensor2 = ttnn.from_torch(torch.tensor([1, 2], dtype=torch.bfloat16), device=device)
-    scalar = 2.0
+    tensor1 = ttnn.from_torch(torch.rand([1, 1, 32, 32], dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)
+    weight = 0.25
 
-    # Apply PReLU activation function
-    output = ttnn.prelu(tensor1, tensor2 / scalar)
+    # Apply PReLU activation function with scalar weight
+    output = ttnn.prelu(tensor1, weight)
     logger.info(f"PReLU: {output}")
 
 
-@pytest.mark.skip("Non-working example from the documentation. GH issue: #32364")
 def test_remainder(device):
     # Create tensors for remainder operation
     tensor1 = ttnn.from_torch(
-        torch.tensor([[1, 2], [3, 4]], dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device
+        torch.tensor([[5, 7], [9, 11]], dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device
     )
     tensor2 = ttnn.from_torch(
-        torch.tensor([[1, 2], [3, 4]], dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device
+        torch.tensor([[2, 3], [4, 5]], dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device
     )
-    scalar = 2.0
 
     # Compute the remainder of division
-    output = ttnn.remainder(tensor1, tensor2 / scalar)
+    output = ttnn.remainder(tensor1, tensor2)
     logger.info(f"Remainder: {output}")


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/32622

### Problem description
unary op example docs are not functional

### What's changed
- Replaced non-working examples in backward tests with functional implementations using complex tensors.
- Updated tests for `repeat_bw`, `polar_bw`, `imag_bw`, `real_bw`, `angle_bw`, and `conj_bw` to utilize complex input and gradient tensors.
- Modified unary operation tests (`real`, `imag`, `angle`, `is_imag`, `is_real`, `conj`, `polar`) to create complex tensors and added memory configuration.
- Removed deprecated skip markers for tests that are now functional.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] [cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) job passes
- [ ] New/Existing tests provide coverage for changes