### PR TITLE
performance-faster-string-find

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -146,7 +146,6 @@ Checks: >
   -modernize-use-transparent-functors,
   -performance-avoid-endl,
   -performance-enum-size,
-  -performance-faster-string-find,
   -performance-inefficient-string-concatenation,
   -performance-no-int-to-ptr,
   -portability-simd-intrinsics,

--- a/tt_metal/impl/debug/watcher_server.cpp
+++ b/tt_metal/impl/debug/watcher_server.cpp
@@ -247,7 +247,7 @@ void WatcherServer::Impl::read_kernel_ids_from_file() {
     while (getline(&line, &len, f) != -1) {
         std::string s(line);
         s = s.substr(0, s.length() - 1);  // Strip newline
-        kernel_names_.push_back(s.substr(s.find(":") + 2));
+        kernel_names_.push_back(s.substr(s.find(':') + 2));
     }
 }
 

--- a/tt_metal/impl/dispatch/debug_tools.cpp
+++ b/tt_metal/impl/dispatch/debug_tools.cpp
@@ -56,7 +56,7 @@ void match_device_program_data_with_host_program_data(const char* host_file, con
     std::string type;
 
     while (std::getline(host_dispatch_dump_file, line)) {
-        if (line.find("*") != std::string::npos) {
+        if (line.find('*') != std::string::npos) {
             continue;
         } else if (
             line.find("BINARY SPAN") != std::string::npos or line.find("SEM") != std::string::npos or
@@ -64,7 +64,7 @@ void match_device_program_data_with_host_program_data(const char* host_file, con
             type = line;
         } else {
             std::vector<std::string> host_data = {line};
-            while (std::getline(host_dispatch_dump_file, line) and (line.find("*") == std::string::npos)) {
+            while (std::getline(host_dispatch_dump_file, line) and (line.find('*') == std::string::npos)) {
                 host_data.push_back(line);
             }
             host_map.push_back(make_pair(type, std::move(host_data)));

--- a/tt_metal/impl/kernels/kernel.hpp
+++ b/tt_metal/impl/kernels/kernel.hpp
@@ -34,8 +34,8 @@ struct KernelSource {
     std::string name() const {
         std::string name;
         if (this->source_type_ == SourceType::FILE_PATH) {
-            const std::size_t start_pos_of_name = this->source_.rfind("/") + 1;
-            const std::size_t pos_of_dot = this->source_.rfind(".");
+            const std::size_t start_pos_of_name = this->source_.rfind('/') + 1;
+            const std::size_t pos_of_dot = this->source_.rfind('.');
             name = this->source_.substr(start_pos_of_name, (pos_of_dot - start_pos_of_name));
         } else {
             name = "Kernel_Source_Code";

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -361,9 +361,9 @@ JitBuildState::JitBuildState(const JitBuildEnv& env, const JitBuiltStateConfig& 
     // Create the objs from the srcs
     for (const string& src : srcs_) {
         // Lop off the right side from the last "."
-        string stub = src.substr(0, src.find_last_of("."));
+        string stub = src.substr(0, src.find_last_of('.'));
         // Lop off the leading path
-        stub = stub.substr(stub.find_last_of("/") + 1, stub.length());
+        stub = stub.substr(stub.find_last_of('/') + 1, stub.length());
         this->objs_.push_back(stub + ".o");
     }
 

--- a/tt_metal/tools/watcher_dump/watcher_dump.cpp
+++ b/tt_metal/tools/watcher_dump/watcher_dump.cpp
@@ -113,7 +113,7 @@ int main(int argc, char* argv[]) {
             print_usage(argv[0]);
             return 0;
         } else if ((s.rfind("-d=", 0) == 0) || (s.rfind("--devices=", 0) == 0)) {
-            string list = s.substr(s.find("=") + 1);
+            string list = s.substr(s.find('=') + 1);
             // "all" is acceptable, and the same as the default.
             if (list == "all") {
                 continue;
@@ -133,7 +133,7 @@ int main(int argc, char* argv[]) {
                 device_ids.push_back(stoi(item));
             }
         } else if ((s.rfind("-n=", 0) == 0) || (s.rfind("--num-hw-cqs==", 0) == 0)) {
-            string value_str = s.substr(s.find("=") + 1);
+            string value_str = s.substr(s.find('=') + 1);
             num_hw_cqs = std::stoi(value_str);
         } else if (s == "-w" || s == "--dump-watcher") {
             dump_watcher = true;


### PR DESCRIPTION
### Ticket


### Problem description
We have this check disabled:
https://releases.llvm.org/20.1.0/tools/clang/tools/extra/docs/clang-tidy/checks/performance/faster-string-find.html


### What's changed
- Enable check
- Apply automatic FIXITs

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/20059309822) CI passes
- [x] New/Existing tests provide coverage for changes