### PR TITLE
E2E demo for Panoptic DeepLab on 20 cores

### DIFF
--- a/models/experimental/panoptic_deeplab/demo/demo.py
+++ b/models/experimental/panoptic_deeplab/demo/demo.py
@@ -29,7 +29,7 @@ from models.experimental.panoptic_deeplab.demo.demo_utils import (
     save_predictions,
     preprocess_input_params,
 )
-from tests.ttnn.utils_for_testing import check_with_pcc
+from models.experimental.panoptic_deeplab.tests.pcc.common import check_ttnn_output
 
 
 def run_panoptic_deeplab_demo(
@@ -147,54 +147,47 @@ def run_panoptic_deeplab_demo(
     logger.info("Running TTNN inference...")
     ttnn_semantic_logits, ttnn_center_logits, ttnn_offset_logits, _ = ttnn_model.forward(ttnn_input)
 
-    # Validate outputs with PCC checks
-    logger.info("Validating outputs with PCC checks...")
+    # Validate outputs with PCC and relative error checks
+    logger.info("Validating outputs with PCC and relative error checks...")
     logger.info("=" * 80)
-    logger.info(f"PCC Values for {os.path.basename(image_path)} ({model_category}):")
+    logger.info(f"Validation Results for {os.path.basename(image_path)} ({model_category}):")
     logger.info("=" * 80)
 
-    def get_pcc_value(pytorch_output, ttnn_output, to_channel_first=False, output_channels=None, exp_pcc=0.95):
-        """Helper function to get PCC value."""
-        ttnn_output_torch = ttnn.to_torch(ttnn_output)
-
-        if to_channel_first:
-            ttnn_output_torch = ttnn_output_torch.permute(0, 3, 1, 2)  # NHWC to NCHW
-
-        if output_channels is not None:
-            ttnn_output_torch = ttnn_output_torch[:, :output_channels, :, :]
-
-        passed, pcc = check_with_pcc(pytorch_output, ttnn_output_torch, exp_pcc)
-        return passed, float(pcc)
-
-    # Check semantic output
-    passed_semantic, pcc_semantic = get_pcc_value(
-        pytorch_semantic_logits,
-        ttnn_semantic_logits,
+    # Check semantic output with PCC and relative errors
+    check_ttnn_output(
+        layer_name="semantic",
+        pytorch_output=pytorch_semantic_logits,
+        ttnn_output=ttnn_semantic_logits,
         to_channel_first=False,
         output_channels=ttnn_model.semantic_head.get_output_channels_for_slicing(),
-        exp_pcc=0.95,
+        exp_pcc=0.958,
+        exp_abs_err=1.769,
+        exp_rel_err=0.150,
     )
-    logger.info(f"  Semantic PCC: {pcc_semantic:.6f} {'✅' if passed_semantic else '❌'}")
 
     # Check instance outputs (only for PANOPTIC_DEEPLAB)
     if model_category == PANOPTIC_DEEPLAB:
-        passed_center, pcc_center = get_pcc_value(
-            pytorch_center_logits,
-            ttnn_center_logits,
+        check_ttnn_output(
+            layer_name="center",
+            pytorch_output=pytorch_center_logits,
+            ttnn_output=ttnn_center_logits,
             to_channel_first=False,
             output_channels=ttnn_model.instance_head.get_center_output_channels_for_slicing(),
-            exp_pcc=0.784,
+            exp_pcc=0.980,
+            exp_abs_err=0.006,
+            exp_rel_err=21.08,
         )
-        logger.info(f"  Center PCC: {pcc_center:.6f} {'✅' if passed_center else '❌'}")
 
-        passed_offset, pcc_offset = get_pcc_value(
-            pytorch_offset_logits,
-            ttnn_offset_logits,
+        check_ttnn_output(
+            layer_name="offset",
+            pytorch_output=pytorch_offset_logits,
+            ttnn_output=ttnn_offset_logits,
             to_channel_first=False,
             output_channels=ttnn_model.instance_head.get_offset_output_channels_for_slicing(),
             exp_pcc=0.984,
+            exp_abs_err=9.630,
+            exp_rel_err=1.675,
         )
-        logger.info(f"  Offset PCC: {pcc_offset:.6f} {'✅' if passed_offset else '❌'}")
 
     logger.info("=" * 80)
 

--- a/models/experimental/panoptic_deeplab/demo/demo_pipeline.py
+++ b/models/experimental/panoptic_deeplab/demo/demo_pipeline.py
@@ -1,0 +1,522 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+from typing import Tuple, List
+import pytest
+import cv2
+import torch
+from loguru import logger
+import ttnn
+from models.experimental.panoptic_deeplab.reference.pytorch_model import PANOPTIC_DEEPLAB, DEEPLAB_V3_PLUS
+from models.experimental.panoptic_deeplab.tt.model_preprocessing import (
+    create_panoptic_deeplab_parameters,
+    fuse_conv_bn_parameters,
+)
+from tests.ttnn.unit_tests.base_functionality.test_bh_20_cores_sharding import skip_if_not_blackhole_20_cores
+from models.experimental.panoptic_deeplab.tt.tt_model import TtPanopticDeepLab
+from models.experimental.panoptic_deeplab.reference.pytorch_model import PytorchPanopticDeepLab
+from models.experimental.panoptic_deeplab.tt.common import (
+    get_panoptic_deeplab_config,
+    PDL_L1_SMALL_SIZE,
+    preprocess_nchw_input_tensor,
+)
+from models.experimental.panoptic_deeplab.tt.model_configs import ModelOptimisations
+from models.common.utility_functions import disable_persistent_kernel_cache
+from models.experimental.panoptic_deeplab.demo.demo_utils import (
+    preprocess_image,
+    create_panoptic_visualization,
+    create_deeplab_v3plus_visualization,
+    save_predictions,
+    preprocess_input_params,
+)
+from models.tt_cnn.tt.pipeline import (
+    PipelineConfig,
+)
+from models.experimental.panoptic_deeplab.tt.tt_custom_pipeline import (
+    CustomTracedModelExecutor,
+    create_pipeline_from_config,
+)
+from models.common.utility_functions import profiler
+from tests.ttnn.utils_for_testing import check_with_pcc
+
+
+def create_model_wrapper(ttnn_model: TtPanopticDeepLab):
+    """
+    Create a model wrapper function for use with pipeline/executor.
+
+    The wrapper takes an L1 input tensor and calls the model's forward method.
+    The executor expects the model to accept L1 tensors and return device tensors.
+
+    Args:
+        ttnn_model: The TtPanopticDeepLab model instance
+
+    Returns:
+        A callable function that takes an L1 input tensor and returns model outputs
+    """
+
+    def model_forward(l1_input_tensor: ttnn.Tensor):
+        """
+        Forward pass wrapper for pipeline executor.
+
+        Args:
+            l1_input_tensor: Input tensor in L1 memory (expected by executor)
+
+        Returns:
+            Tuple of (semantic_logits, center_heatmap, offset_map)
+            For DEEPLAB_V3_PLUS, returns only semantic_logits (not a tuple with None)
+        """
+        assert l1_input_tensor.storage_type() == ttnn.StorageType.DEVICE, "Model expects input tensor to be on device"
+        assert (
+            l1_input_tensor.memory_config().buffer_type == ttnn.BufferType.L1
+        ), "Model expects input tensor to be in L1"
+
+        # Call model forward
+        semantic_logits, center_heatmap, offset_map, _ = ttnn_model.forward(l1_input_tensor, return_features=False)
+
+        # For DEEPLAB_V3_PLUS, center_heatmap and offset_map are None
+        # Return only semantic_logits to avoid None handling issues in executor
+        if ttnn_model.model_category == DEEPLAB_V3_PLUS:
+            return semantic_logits
+        else:
+            # Return as tuple for PANOPTIC_DEEPLAB
+            return (semantic_logits, center_heatmap, offset_map)
+
+    return model_forward
+
+
+def create_host_input_tensors(
+    device: ttnn.Device, image_paths: List[str], target_size: Tuple[int, int]
+) -> Tuple[list, ttnn.MemoryConfig, ttnn.MemoryConfig]:
+    """
+    Create host input tensors for multiple images.
+
+    Args:
+        device: TTNN device
+        image_paths: List of paths to input images
+        target_size: Target size as (height, width)
+
+    Returns:
+        Tuple of (list of host input tensors, dram_memory_config, l1_memory_config)
+    """
+    host_inputs = []
+    dram_memory_config = None
+    l1_memory_config = None
+
+    for i, image_path in enumerate(image_paths):
+        # Preprocess image
+        torch_input = preprocess_image(image_path, target_size)
+        # Preprocess to TTNN format (height-sharded on device)
+        ttnn_input = preprocess_nchw_input_tensor(device, torch_input)
+
+        # Extract memory config from first tensor
+        if i == 0:
+            # Get the L1 memory config from the preprocessed tensor (full grid sharding)
+            original_mem_config = ttnn_input.memory_config()
+            original_shard_spec = original_mem_config.shard_spec
+
+            # Always use interleaved DRAM (no core constraints)
+            # The executor will use to_memory_config to convert from interleaved DRAM to sharded L1
+            dram_memory_config = ttnn.DRAM_MEMORY_CONFIG
+
+            # Use the original L1 sharding (full grid) - to_memory_config will handle conversion
+            l1_memory_config = ttnn.MemoryConfig(
+                original_mem_config.memory_layout,
+                ttnn.BufferType.L1,
+                original_shard_spec,
+            )
+
+        # Convert to host tensor for pipeline
+        host_input = ttnn_input.cpu()
+        host_inputs.append(host_input)
+
+    return host_inputs, dram_memory_config, l1_memory_config
+
+
+def run_panoptic_deeplab_demo_pipeline(
+    device: ttnn.Device,
+    image_paths: List[str],
+    weights_path: str,
+    output_dir: str = "panoptic_deeplab_predictions",
+    target_size: Tuple[int, int] = (512, 1024),
+    center_threshold: float = 0.05,
+    model_category=DEEPLAB_V3_PLUS,
+):
+    """
+    Run Panoptic DeepLab inference on multiple images using pipeline with TracedModelExecutor.
+
+    Args:
+        device: TTNN device
+        image_paths: List of paths to input images
+        weights_path: Path to model weights (.pkl file)
+        output_dir: Directory to save outputs
+        target_size: Input size as (height, width)
+        center_threshold: Center threshold for panoptic segmentation
+        model_category: Model category (PANOPTIC_DEEPLAB or DEEPLAB_V3_PLUS)
+    """
+    disable_persistent_kernel_cache()
+
+    logger.info(f"Running Panoptic DeepLab pipeline demo on {len(image_paths)} images")
+    logger.info(f"Target size: {target_size}")
+
+    # Get model configuration
+    config = get_panoptic_deeplab_config()
+    batch_size = config["batch_size"]
+    num_classes = config["num_classes"]
+    project_channels = config["project_channels"]
+    decoder_channels = config["decoder_channels"]
+    sem_seg_head_channels = config["sem_seg_head_channels"]
+    ins_embed_head_channels = config["ins_embed_head_channels"]
+    common_stride = config["common_stride"]
+
+    # Load original images for visualization
+    original_images = []
+    for image_path in image_paths:
+        original_image = cv2.imread(image_path)
+        if original_image is None:
+            logger.warning(f"Could not load image from {image_path}, skipping...")
+            continue
+        original_image = cv2.cvtColor(original_image, cv2.COLOR_BGR2RGB)
+        original_image = cv2.resize(original_image, (int(target_size[1]), int(target_size[0])))
+        original_images.append((image_path, original_image))
+
+    if len(original_images) == 0:
+        logger.error("No valid images found")
+        return
+
+    try:
+        # Load PyTorch model with weights
+        logger.info("Loading PyTorch model...")
+        pytorch_model = PytorchPanopticDeepLab(
+            num_classes=num_classes,
+            common_stride=common_stride,
+            project_channels=project_channels,
+            decoder_channels=decoder_channels,
+            sem_seg_head_channels=sem_seg_head_channels,
+            ins_embed_head_channels=ins_embed_head_channels,
+            train_size=target_size,
+            weights_path=weights_path,
+            model_category=model_category,
+        )
+        pytorch_model = pytorch_model.to(dtype=torch.bfloat16)
+        pytorch_model.eval()
+
+        # Create TTNN parameters
+        logger.info("Creating TTNN parameters...")
+        ttnn_parameters = create_panoptic_deeplab_parameters(
+            pytorch_model, device, input_height=int(target_size[0]), input_width=int(target_size[1]), batch_size=1
+        )
+
+        # Apply Conv+BatchNorm fusion
+        logger.info("Applying Conv+BatchNorm fusion to parameters...")
+        fused_parameters = fuse_conv_bn_parameters(ttnn_parameters, eps=1e-5)
+
+        # Create model configurations
+        model_configs = ModelOptimisations(
+            conv_act_dtype=ttnn.bfloat8_b,
+            conv_w_dtype=ttnn.bfloat8_b,
+        )
+        model_configs.setup_resnet_backbone()
+        model_configs.setup_aspp()
+        model_configs.setup_decoder()
+        model_configs.setup_heads()
+
+        # Create TTNN model
+        ttnn_model = TtPanopticDeepLab(
+            device=device,
+            parameters=fused_parameters,
+            num_classes=num_classes,
+            common_stride=common_stride,
+            project_channels=project_channels,
+            decoder_channels=decoder_channels,
+            sem_seg_head_channels=sem_seg_head_channels,
+            ins_embed_head_channels=ins_embed_head_channels,
+            train_size=target_size,
+            model_configs=model_configs,
+            model_category=model_category,
+        )
+
+    except FileNotFoundError:
+        logger.error(f"Weights file not found: {weights_path}")
+        logger.error("Please download the Panoptic DeepLab weights and place them at the specified path.")
+        return
+
+    # Create model wrapper for pipeline
+    model_wrapper = create_model_wrapper(ttnn_model)
+
+    # Create host input tensors
+    logger.info("Preprocessing images for TTNN model...")
+    host_inputs, dram_memory_config, l1_memory_config = create_host_input_tensors(
+        device, [path for path, _ in original_images], target_size
+    )
+
+    num_inputs = len(host_inputs)
+
+    # Create pipeline using TracedModelExecutor
+    logger.info("Creating pipeline with TracedModelExecutor...")
+    pipeline_config = PipelineConfig(
+        use_trace=True,
+        num_command_queues=1,
+        all_transfers_on_separate_command_queue=False,
+    )
+
+    pipeline_args = {
+        "config": pipeline_config,
+        "model": model_wrapper,
+        "device": device,
+        "dram_input_memory_config": dram_memory_config,
+        "l1_input_memory_config": l1_memory_config,
+    }
+
+    pipe = create_pipeline_from_config(**pipeline_args)
+
+    # Verify executor type
+    assert isinstance(
+        pipe.executor, CustomTracedModelExecutor
+    ), f"Expected CustomTracedModelExecutor, got {type(pipe.executor).__name__}"
+
+    # Compile pipeline
+    logger.info("Compiling pipeline...")
+    pipe.compile(host_inputs[0])
+
+    # Run pipeline with timing
+    logger.info(f"Running pipeline for {num_inputs} images...")
+    timing_key = f"pipeline_execution_{model_category}"
+
+    profiler.clear()
+    profiler.enable()
+    profiler.start(timing_key)
+    outputs = pipe.enqueue(host_inputs).pop_all()
+    profiler.end(timing_key, PERF_CNT=num_inputs)
+
+    # Store timing results for later printing (after PCC)
+    avg_execution_time = profiler.get(timing_key)
+    total_execution_time = avg_execution_time * num_inputs
+    avg_execution_time_us = avg_execution_time * 1e6  # Convert to microseconds
+    samples_per_second = 1.0 / avg_execution_time if avg_execution_time > 0 else 0
+
+    # Generate reference outputs from PyTorch (after pipeline execution)
+    logger.info("Generating reference outputs from PyTorch model...")
+    reference_outputs = []
+    for host_input in host_inputs:
+        # Convert host input back to torch for reference
+        torch_input = ttnn.to_torch(host_input)
+        # Input is in NHWC format [1, H, W, C] where C=8 (3 original + 5 padding)
+        # We need to remove padding and convert to NCHW for PyTorch model
+        assert torch_input.shape[0] == 1, f"Expected batch size 1, got {torch_input.shape[0]}"
+        # Remove padding: take only first 3 channels
+        torch_input = torch_input[:, :, :, :3]  # [1, H, W, 3]
+        # Convert NHWC -> NCHW
+        torch_input = torch_input.permute(0, 3, 1, 2)  # [1, 3, H, W]
+
+        with torch.no_grad():
+            pytorch_semantic, pytorch_center, pytorch_offset, _ = pytorch_model.forward(torch_input)
+        reference_outputs.append((pytorch_semantic, pytorch_center, pytorch_offset))
+
+    # Validate outputs
+    assert len(outputs) == len(reference_outputs), f"Expected {len(reference_outputs)} outputs, got {len(outputs)}"
+    assert len(outputs) == num_inputs, f"Expected {num_inputs} outputs, got {len(outputs)}"
+
+    # Validate outputs with PCC checks
+    logger.info("Validating outputs with PCC checks...")
+    all_passed = []
+    semantic_pcc_values = []
+    center_pcc_values = []
+    offset_pcc_values = []
+
+    def get_pcc_value(pytorch_output, ttnn_output, to_channel_first=False, output_channels=None, exp_pcc=0.999):
+        """Helper function to get PCC value without logging."""
+        ttnn_output_torch = ttnn.to_torch(ttnn_output)
+
+        if to_channel_first:
+            ttnn_output_torch = ttnn_output_torch.permute(0, 3, 1, 2)  # NHWC to NCHW
+
+        if output_channels is not None:
+            ttnn_output_torch = ttnn_output_torch[:, :output_channels, :, :]
+
+        passed, pcc = check_with_pcc(pytorch_output, ttnn_output_torch, exp_pcc)
+        return passed, float(pcc)
+
+    for i, (ttnn_output, ref_tuple) in enumerate(zip(outputs, reference_outputs)):
+        pytorch_semantic, pytorch_center, pytorch_offset = ref_tuple
+
+        # Handle different output formats based on model category
+        # Note: Pipeline converts tuple outputs to lists, so we check for both
+        if model_category == DEEPLAB_V3_PLUS:
+            # For DEEPLAB_V3_PLUS, output is a single tensor (semantic_logits only)
+            ttnn_semantic = ttnn_output
+            assert isinstance(ttnn_semantic, ttnn.Tensor), f"Semantic output {i} should be ttnn.Tensor"
+            assert ttnn_semantic.storage_type() == ttnn.StorageType.HOST, f"Semantic output {i} should be on host"
+        else:
+            # For PANOPTIC_DEEPLAB, output is a tuple/list of 3 tensors
+            # Pipeline converts tuples to lists, so we accept both
+            assert isinstance(
+                ttnn_output, (tuple, list)
+            ), f"Output {i} should be a tuple or list for PANOPTIC_DEEPLAB, got {type(ttnn_output)}"
+            assert len(ttnn_output) == 3, f"Output {i} should have 3 elements, got {len(ttnn_output)}"
+            ttnn_semantic, ttnn_center, ttnn_offset = ttnn_output
+
+            # Validate output structure
+            assert isinstance(ttnn_semantic, ttnn.Tensor), f"Semantic output {i} should be ttnn.Tensor"
+            assert ttnn_semantic.storage_type() == ttnn.StorageType.HOST, f"Semantic output {i} should be on host"
+            assert isinstance(ttnn_center, ttnn.Tensor), f"Center output {i} should be ttnn.Tensor"
+            assert ttnn_center.storage_type() == ttnn.StorageType.HOST, f"Center output {i} should be on host"
+            assert isinstance(ttnn_offset, ttnn.Tensor), f"Offset output {i} should be ttnn.Tensor"
+            assert ttnn_offset.storage_type() == ttnn.StorageType.HOST, f"Offset output {i} should be on host"
+
+        # Check semantic output
+        passed, pcc = get_pcc_value(
+            pytorch_semantic,
+            ttnn_semantic,
+            to_channel_first=False,
+            output_channels=ttnn_model.semantic_head.get_output_channels_for_slicing(),
+            exp_pcc=0.985,
+        )
+        all_passed.append(passed)
+        semantic_pcc_values.append(pcc)
+
+        # Check instance outputs (only for PANOPTIC_DEEPLAB)
+        if model_category == PANOPTIC_DEEPLAB:
+            passed_center, pcc_center = get_pcc_value(
+                pytorch_center,
+                ttnn_center,
+                to_channel_first=False,
+                output_channels=ttnn_model.instance_head.get_center_output_channels_for_slicing(),
+                exp_pcc=0.784,
+            )
+            all_passed.append(passed_center)
+            center_pcc_values.append(pcc_center)
+
+            passed_offset, pcc_offset = get_pcc_value(
+                pytorch_offset,
+                ttnn_offset,
+                to_channel_first=False,
+                output_channels=ttnn_model.instance_head.get_offset_output_channels_for_slicing(),
+                exp_pcc=0.985,
+            )
+            all_passed.append(passed_offset)
+            offset_pcc_values.append(pcc_offset)
+
+    # Cleanup
+    pipe.cleanup()
+
+    # Calculate and display PCC statistics
+    def print_pcc_stats(pcc_values, output_name):
+        """Helper function to calculate and print PCC statistics."""
+        if pcc_values:
+            min_pcc = min(pcc_values)
+            max_pcc = max(pcc_values)
+            avg_pcc = sum(pcc_values) / len(pcc_values)
+            logger.info(f"  {output_name}: Min: {min_pcc:.6f}, Max: {max_pcc:.6f}, Avg: {avg_pcc:.6f}")
+        else:
+            logger.warning(f"  {output_name}: No PCC values collected!")
+
+    logger.info(f"PCC statistics for {model_category}:")
+    print_pcc_stats(semantic_pcc_values, "Semantic")
+
+    if model_category == PANOPTIC_DEEPLAB:
+        print_pcc_stats(center_pcc_values, "Center")
+        print_pcc_stats(offset_pcc_values, "Offset")
+
+    # Print timing results after PCC statistics
+    logger.info(
+        f"Timing results for {model_category}: "
+        f"Average execution time: {avg_execution_time_us:.2f} μs, "
+        f"Average samples per second: {samples_per_second:.2f}"
+    )
+
+    # Log PCC check results (but don't fail - this is a demo)
+    if not all(all_passed):
+        logger.warning(f"Some outputs did not pass PCC check. Results: {all_passed}")
+    else:
+        logger.info(f"✅ All PCC checks passed for {model_category}!")
+
+    # Process results
+    logger.info("Processing results...")
+    for i, (ttnn_output, (image_path, original_image)) in enumerate(zip(outputs, original_images)):
+        # Handle different output formats based on model category
+        if model_category == DEEPLAB_V3_PLUS:
+            # For DEEPLAB_V3_PLUS, output is a single tensor (semantic_logits only)
+            ttnn_semantic_logits = ttnn_output
+        else:
+            # For PANOPTIC_DEEPLAB, output is a tuple/list of 3 tensors
+            assert isinstance(ttnn_output, (tuple, list)), f"Output {i} should be a tuple or list for PANOPTIC_DEEPLAB"
+            assert len(ttnn_output) == 3, f"Output {i} should have 3 elements, got {len(ttnn_output)}"
+            ttnn_semantic_logits, ttnn_center_logits, ttnn_offset_logits = ttnn_output
+
+        # Handle semantic output - convert from NHWC to NCHW and slice padding if needed
+        ttnn_semantic_torch = ttnn.to_torch(ttnn_semantic_logits)
+        semantic_original_channels = ttnn_model.semantic_head.get_output_channels_for_slicing()
+        if semantic_original_channels is not None:
+            ttnn_semantic_torch = ttnn_semantic_torch[:, :semantic_original_channels, :, :]
+
+        # Convert to numpy in HWC format for visualization
+        semantic_np_ttnn = ttnn_semantic_torch.float().squeeze(0).permute(1, 2, 0).numpy()
+
+        if model_category == PANOPTIC_DEEPLAB:
+            # Handle center output
+            ttnn_center_torch = ttnn.to_torch(ttnn_center_logits)
+            center_original_channels = ttnn_model.instance_head.get_center_output_channels_for_slicing()
+            if center_original_channels is not None:
+                ttnn_center_torch = ttnn_center_torch[:, :center_original_channels, :, :]
+
+            # Handle offset output
+            ttnn_offset_torch = ttnn.to_torch(ttnn_offset_logits)
+            offset_original_channels = ttnn_model.instance_head.get_offset_output_channels_for_slicing()
+            if offset_original_channels is not None:
+                ttnn_offset_torch = ttnn_offset_torch[:, :offset_original_channels, :, :]
+
+            center_np_ttnn = ttnn_center_torch.float().squeeze(0).permute(1, 2, 0).numpy()
+            offset_np_ttnn = ttnn_offset_torch.float().squeeze(0).permute(1, 2, 0).numpy()
+
+            panoptic_vis_ttnn, panoptic_info_ttnn = create_panoptic_visualization(
+                semantic_np_ttnn,
+                center_np_ttnn,
+                offset_np_ttnn,
+                original_image,
+                center_threshold=center_threshold,
+                score_threshold=center_threshold,
+                stuff_area=1,
+                top_k=1000,
+                nms_kernel=11,
+            )
+        else:
+            import time
+
+            start_time = time.time()
+            panoptic_vis_ttnn, panoptic_info_ttnn = create_deeplab_v3plus_visualization(
+                semantic_np_ttnn,
+                original_image=original_image,
+            )
+            end_time = time.time()
+            visualization_duration_us = (end_time - start_time) * 1e6
+            logger.info(f"create_deeplab_v3plus_visualization() duration: {visualization_duration_us:.2f} μs")
+
+        # Save results
+        image_name = os.path.basename(image_path)
+        ttnn_output_dir = os.path.join(output_dir, "ttnn_output")
+        save_predictions(ttnn_output_dir, image_name, original_image, panoptic_vis_ttnn)
+
+        logger.info(f"Processed image {i+1}/{len(outputs)}: {image_name}")
+
+    logger.info(f"Demo completed! Results saved to {output_dir}")
+    logger.info(f"Processed {len(outputs)} images using pipeline with TracedModelExecutor")
+
+
+@pytest.mark.parametrize(
+    "device_params", [{"l1_small_size": PDL_L1_SMALL_SIZE, "trace_region_size": 2000000}], indirect=True
+)
+@pytest.mark.parametrize(
+    "output_dir",
+    [
+        os.path.abspath(os.path.join(os.path.dirname(__file__), "../demo_outputs")),
+    ],
+)
+@pytest.mark.parametrize("model_category", [PANOPTIC_DEEPLAB, DEEPLAB_V3_PLUS])
+def test_panoptic_deeplab_demo_pipeline(device, output_dir, model_category, model_location_generator):
+    skip_if_not_blackhole_20_cores(device)
+    images, weights_path, output_dir = preprocess_input_params(
+        output_dir, model_category, current_dir=__file__, model_location_generator=model_location_generator
+    )
+    # Process all images using pipeline
+    run_panoptic_deeplab_demo_pipeline(device, images, weights_path, output_dir, model_category=model_category)

--- a/models/experimental/panoptic_deeplab/tests/test_pipeline_e2e.py
+++ b/models/experimental/panoptic_deeplab/tests/test_pipeline_e2e.py
@@ -1,0 +1,511 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+End-to-end tests for Panoptic DeepLab using TTNN builder, executor, and pipeline.
+
+This module tests the complete Panoptic DeepLab model using the pipeline/executor
+framework from models/tt_cnn/tt/, enabling testing across different executor
+configurations (traced, multi-CQ, pipelined I/O, etc.).
+
+Note: The model wrapper handles different output formats:
+- For PANOPTIC_DEEPLAB: Returns tuple (semantic_logits, center_heatmap, offset_map)
+- For DEEPLAB_V3_PLUS: Returns single tensor (semantic_logits only)
+This avoids None handling issues in the executor's output schema creation.
+
+Known Issue: There is a bug in models/tt_cnn/tt/builder.py TtConv2d._apply_channel_slicing()
+where the tuple (weight, bias) returned from conv2d with return_weights_and_bias=True
+is incorrectly assigned to self.weight_slices[i], causing subsequent calls to pass
+a tuple as weight_tensor. This needs to be fixed in the builder code.
+"""
+
+import pytest
+import torch
+import ttnn
+from dataclasses import dataclass
+from typing import Callable, Tuple
+from loguru import logger
+
+from models.experimental.panoptic_deeplab.reference.pytorch_model import PANOPTIC_DEEPLAB, DEEPLAB_V3_PLUS
+from models.experimental.panoptic_deeplab.tt.model_preprocessing import (
+    create_panoptic_deeplab_parameters,
+    fuse_conv_bn_parameters,
+)
+from models.experimental.panoptic_deeplab.tt.tt_model import TtPanopticDeepLab
+from models.experimental.panoptic_deeplab.reference.pytorch_model import PytorchPanopticDeepLab
+from models.experimental.panoptic_deeplab.tt.model_configs import ModelOptimisations
+from models.experimental.panoptic_deeplab.tt.common import (
+    PDL_L1_SMALL_SIZE,
+    get_panoptic_deeplab_weights_path,
+    get_panoptic_deeplab_config,
+    preprocess_nchw_input_tensor,
+)
+from models.experimental.panoptic_deeplab.tests.pcc.common import check_ttnn_output
+from models.tt_cnn.tt.executor import (
+    ModelExecutor,
+)
+from models.tt_cnn.tt.pipeline import (
+    PipelineConfig,
+    create_pipeline_from_config,
+)
+from tests.ttnn.unit_tests.base_functionality.test_bh_20_cores_sharding import skip_if_not_blackhole_20_cores
+
+
+@dataclass
+class ExecutorTestConfig:
+    """Configuration for testing different executor types."""
+
+    name: str
+    use_trace: bool
+    num_command_queues: int
+    all_transfers_on_separate_command_queue: bool = False
+    requires_output_config: bool = False
+    requires_minimum_inputs: int = 1
+    expected_executor_type: type = None
+
+
+EXECUTOR_CONFIGS = [
+    ExecutorTestConfig(
+        name="ModelExecutor",
+        use_trace=False,
+        num_command_queues=1,
+        all_transfers_on_separate_command_queue=False,
+        requires_minimum_inputs=1,
+        expected_executor_type=ModelExecutor,
+    ),
+    # ExecutorTestConfig(
+    #     name="TracedModelExecutor",
+    #     use_trace=True,
+    #     num_command_queues=1,
+    #     all_transfers_on_separate_command_queue=False,
+    #     requires_minimum_inputs=1,
+    #     expected_executor_type=TracedModelExecutor,
+    # ),
+    # ExecutorTestConfig(
+    #     name="MultiCQTracedModelOverlappedInputExecutor",
+    #     use_trace=True,
+    #     num_command_queues=2,
+    #     all_transfers_on_separate_command_queue=False,
+    #     requires_minimum_inputs=1,
+    #     expected_executor_type=MultiCQTracedModelOverlappedInputExecutor,
+    # ),
+    # Note: MultiCQTracedModelPipelinedIOExecutor doesn't support tuple outputs,
+    # so we skip it for now. If needed, we'd need to modify the model wrapper
+    # to return a single tensor or modify the executor to support tuples.
+]
+
+
+def create_model_wrapper(ttnn_model: TtPanopticDeepLab) -> Callable:
+    """
+    Create a model wrapper function for use with pipeline/executor.
+
+    The wrapper takes an L1 input tensor and calls the model's forward method.
+    The executor expects the model to accept L1 tensors and return device tensors.
+
+    Args:
+        ttnn_model: The TtPanopticDeepLab model instance
+
+    Returns:
+        A callable function that takes an L1 input tensor and returns model outputs
+    """
+
+    def model_forward(l1_input_tensor: ttnn.Tensor):
+        """
+        Forward pass wrapper for pipeline executor.
+
+        Args:
+            l1_input_tensor: Input tensor in L1 memory (expected by executor)
+
+        Returns:
+            Tuple of (semantic_logits, center_heatmap, offset_map)
+            For DEEPLAB_V3_PLUS, returns only semantic_logits (not a tuple with None)
+        """
+        assert l1_input_tensor.storage_type() == ttnn.StorageType.DEVICE, "Model expects input tensor to be on device"
+        assert (
+            l1_input_tensor.memory_config().buffer_type == ttnn.BufferType.L1
+        ), "Model expects input tensor to be in L1"
+
+        # Call model forward
+        semantic_logits, center_heatmap, offset_map, _ = ttnn_model.forward(l1_input_tensor, return_features=False)
+
+        # For DEEPLAB_V3_PLUS, center_heatmap and offset_map are None
+        # Return only semantic_logits to avoid None handling issues in executor
+        if ttnn_model.model_category == DEEPLAB_V3_PLUS:
+            return semantic_logits
+        else:
+            # Return as tuple for PANOPTIC_DEEPLAB
+            return (semantic_logits, center_heatmap, offset_map)
+
+    return model_forward
+
+
+def create_host_input_tensors(
+    device: ttnn.Device, batch_size: int, input_height: int, input_width: int, num_inputs: int
+) -> Tuple[list, ttnn.MemoryConfig, ttnn.MemoryConfig]:
+    """
+    Create host input tensors for Panoptic DeepLab.
+
+    Args:
+        device: TTNN device
+        batch_size: Batch size (should be 1 for Panoptic DeepLab)
+        input_height: Input image height
+        input_width: Input image width
+        num_inputs: Number of input tensors to create
+
+    Returns:
+        Tuple of (list of host input tensors, dram_memory_config, l1_memory_config)
+        The memory configs are extracted from the first preprocessed tensor
+    """
+    host_inputs = []
+    dram_memory_config = None
+    l1_memory_config = None
+
+    for i in range(num_inputs):
+        # Create random input in NCHW format
+        torch_input = torch.randn(batch_size, 3, input_height, input_width, dtype=torch.bfloat16)
+        # Preprocess to TTNN format (height-sharded on device)
+        ttnn_input = preprocess_nchw_input_tensor(device, torch_input)
+
+        # Extract memory config from first tensor
+        if i == 0:
+            # Get the memory config from the preprocessed tensor
+            # The tensor is already sharded, so we can use its memory config
+            # But we need to create DRAM and L1 versions
+            original_mem_config = ttnn_input.memory_config()
+
+            # Create DRAM version with same sharding
+            dram_memory_config = ttnn.MemoryConfig(
+                original_mem_config.memory_layout,
+                ttnn.BufferType.DRAM,
+                original_mem_config.shard_spec,
+            )
+
+            # Create L1 version with same sharding
+            l1_memory_config = ttnn.MemoryConfig(
+                original_mem_config.memory_layout,
+                ttnn.BufferType.L1,
+                original_mem_config.shard_spec,
+            )
+
+        # Convert to host tensor for pipeline
+        host_input = ttnn_input.cpu()
+        host_inputs.append(host_input)
+
+    return host_inputs, dram_memory_config, l1_memory_config
+
+
+@pytest.mark.parametrize("executor_config", EXECUTOR_CONFIGS, ids=lambda cfg: cfg.name)
+@pytest.mark.parametrize(
+    "model_category",
+    [PANOPTIC_DEEPLAB, DEEPLAB_V3_PLUS],
+    ids=["panoptic_deeplab", "deeplab_v3_plus"],
+)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": PDL_L1_SMALL_SIZE}], indirect=True)
+def test_panoptic_deeplab_pipeline_e2e(
+    device, executor_config: ExecutorTestConfig, model_category: str, model_location_generator
+):
+    """
+    End-to-end test for Panoptic DeepLab using pipeline/executor framework.
+
+    Tests the complete model with different executor configurations and validates
+    outputs against PyTorch reference.
+    """
+    skip_if_not_blackhole_20_cores(device)
+    torch.manual_seed(0)
+
+    # Get model configuration
+    config = get_panoptic_deeplab_config()
+    batch_size = config["batch_size"]
+    num_classes = config["num_classes"]
+    input_height, input_width = config["train_size"]
+
+    # Get weights path
+    complete_weights_path = get_panoptic_deeplab_weights_path(model_location_generator, __file__)
+
+    try:
+        # Create PyTorch reference model
+        pytorch_model = PytorchPanopticDeepLab(
+            num_classes=num_classes,
+            common_stride=config["common_stride"],
+            project_channels=config["project_channels"],
+            decoder_channels=config["decoder_channels"],
+            sem_seg_head_channels=config["sem_seg_head_channels"],
+            ins_embed_head_channels=config["ins_embed_head_channels"],
+            train_size=config["train_size"],
+            weights_path=complete_weights_path,
+            model_category=model_category,
+        )
+        pytorch_model = pytorch_model.to(dtype=torch.bfloat16)
+        pytorch_model.eval()
+
+        # Create TTNN parameters
+        ttnn_parameters = create_panoptic_deeplab_parameters(
+            pytorch_model, device, input_height=input_height, input_width=input_width, batch_size=batch_size
+        )
+
+        # Apply Conv+BatchNorm fusion
+        logger.info("Applying Conv+BatchNorm fusion to parameters...")
+        fused_parameters = fuse_conv_bn_parameters(ttnn_parameters, eps=1e-5)
+
+        # Create model configurations
+        model_configs = ModelOptimisations(
+            conv_act_dtype=ttnn.bfloat8_b,
+            conv_w_dtype=ttnn.bfloat8_b,
+        )
+        model_configs.setup_resnet_backbone()
+        model_configs.setup_aspp()
+        model_configs.setup_decoder()
+        model_configs.setup_heads()
+
+        # Create TTNN model
+        ttnn_model = TtPanopticDeepLab(
+            device=device,
+            parameters=fused_parameters,
+            num_classes=num_classes,
+            common_stride=config["common_stride"],
+            project_channels=config["project_channels"],
+            decoder_channels=config["decoder_channels"],
+            sem_seg_head_channels=config["sem_seg_head_channels"],
+            ins_embed_head_channels=config["ins_embed_head_channels"],
+            train_size=config["train_size"],
+            model_configs=model_configs,
+            model_category=model_category,
+        )
+
+        # Create model wrapper for pipeline
+        model_wrapper = create_model_wrapper(ttnn_model)
+
+        # Determine number of inputs based on executor requirements
+        num_inputs = max(executor_config.requires_minimum_inputs, 3)  # Test with at least 3 inputs
+
+        # Create host input tensors and extract memory configs
+        host_inputs, dram_memory_config, l1_memory_config = create_host_input_tensors(
+            device, batch_size, input_height, input_width, num_inputs
+        )
+
+        # Create pipeline using extracted memory configs
+        config = PipelineConfig(
+            use_trace=executor_config.use_trace,
+            num_command_queues=executor_config.num_command_queues,
+            all_transfers_on_separate_command_queue=executor_config.all_transfers_on_separate_command_queue,
+        )
+
+        pipeline_args = {
+            "config": config,
+            "model": model_wrapper,
+            "device": device,
+            "dram_input_memory_config": dram_memory_config,
+            "l1_input_memory_config": l1_memory_config,
+        }
+
+        pipe = create_pipeline_from_config(**pipeline_args)
+
+        # Verify executor type
+        assert isinstance(
+            pipe.executor, executor_config.expected_executor_type
+        ), f"Expected {executor_config.expected_executor_type.__name__}, got {type(pipe.executor).__name__}"
+
+        # Compile pipeline
+        logger.info(f"Compiling pipeline with {executor_config.name}...")
+        pipe.compile(host_inputs[0])
+
+        # Generate reference outputs from PyTorch
+        reference_outputs = []
+        for host_input in host_inputs:
+            # Convert host input back to torch for reference
+            torch_input = ttnn.to_torch(host_input)
+            # Input is in NHWC format [1, H, W, C] where C=8 (3 original + 5 padding)
+            # We need to remove padding and convert to NCHW for PyTorch model
+            assert torch_input.shape[0] == 1, f"Expected batch size 1, got {torch_input.shape[0]}"
+            h, w, c = torch_input.shape[1], torch_input.shape[2], torch_input.shape[3]
+            # Remove padding: take only first 3 channels
+            torch_input = torch_input[:, :, :, :3]  # [1, H, W, 3]
+            # Convert NHWC -> NCHW
+            torch_input = torch_input.permute(0, 3, 1, 2)  # [1, 3, H, W]
+
+            with torch.no_grad():
+                pytorch_semantic, pytorch_center, pytorch_offset, _ = pytorch_model.forward(torch_input)
+            reference_outputs.append((pytorch_semantic, pytorch_center, pytorch_offset))
+
+        # Run pipeline
+        logger.info(f"Running pipeline with {executor_config.name}...")
+        outputs = pipe.enqueue(host_inputs).pop_all()
+
+        # Validate outputs
+        assert len(outputs) == len(reference_outputs), f"Expected {len(reference_outputs)} outputs, got {len(outputs)}"
+
+        all_passed = []
+        for i, (ttnn_output, ref_tuple) in enumerate(zip(outputs, reference_outputs)):
+            pytorch_semantic, pytorch_center, pytorch_offset = ref_tuple
+
+            # Handle different output formats based on model category
+            # Note: Pipeline converts tuple outputs to lists, so we check for both
+            if model_category == DEEPLAB_V3_PLUS:
+                # For DEEPLAB_V3_PLUS, output is a single tensor (semantic_logits only)
+                ttnn_semantic = ttnn_output
+                assert isinstance(ttnn_semantic, ttnn.Tensor), f"Semantic output {i} should be ttnn.Tensor"
+                assert ttnn_semantic.storage_type() == ttnn.StorageType.HOST, f"Semantic output {i} should be on host"
+            else:
+                # For PANOPTIC_DEEPLAB, output is a tuple/list of 3 tensors
+                # Pipeline converts tuples to lists, so we accept both
+                assert isinstance(
+                    ttnn_output, (tuple, list)
+                ), f"Output {i} should be a tuple or list for PANOPTIC_DEEPLAB, got {type(ttnn_output)}"
+                assert len(ttnn_output) == 3, f"Output {i} should have 3 elements, got {len(ttnn_output)}"
+                ttnn_semantic, ttnn_center, ttnn_offset = ttnn_output
+
+                # Validate output structure
+                assert isinstance(ttnn_semantic, ttnn.Tensor), f"Semantic output {i} should be ttnn.Tensor"
+                assert ttnn_semantic.storage_type() == ttnn.StorageType.HOST, f"Semantic output {i} should be on host"
+                assert isinstance(ttnn_center, ttnn.Tensor), f"Center output {i} should be ttnn.Tensor"
+                assert ttnn_center.storage_type() == ttnn.StorageType.HOST, f"Center output {i} should be on host"
+                assert isinstance(ttnn_offset, ttnn.Tensor), f"Offset output {i} should be ttnn.Tensor"
+                assert ttnn_offset.storage_type() == ttnn.StorageType.HOST, f"Offset output {i} should be on host"
+
+            # Check semantic output
+            all_passed.append(
+                check_ttnn_output(
+                    f"Semantic_{i}",
+                    pytorch_semantic,
+                    ttnn_semantic,
+                    to_channel_first=False,
+                    output_channels=ttnn_model.semantic_head.get_output_channels_for_slicing(),
+                    exp_pcc=0.986,
+                )
+            )
+
+            # Check instance outputs (only for PANOPTIC_DEEPLAB)
+            if model_category == PANOPTIC_DEEPLAB:
+                all_passed.append(
+                    check_ttnn_output(
+                        f"Center_{i}",
+                        pytorch_center,
+                        ttnn_center,
+                        to_channel_first=False,
+                        output_channels=ttnn_model.instance_head.get_center_output_channels_for_slicing(),
+                        exp_pcc=0.805,
+                    )
+                )
+                all_passed.append(
+                    check_ttnn_output(
+                        f"Offset_{i}",
+                        pytorch_offset,
+                        ttnn_offset,
+                        to_channel_first=False,
+                        output_channels=ttnn_model.instance_head.get_offset_output_channels_for_slicing(),
+                        exp_pcc=0.989,
+                    )
+                )
+
+        # Cleanup
+        pipe.cleanup()
+
+        # Fail test if any PCC checks failed
+        assert all(all_passed), f"Some outputs did not pass PCC check. Results: {all_passed}"
+        logger.info(f"✅ All PCC tests passed for {executor_config.name} with {model_category}!")
+
+    except FileNotFoundError:
+        pytest.fail("model_final_bd324a.pkl file not found. Please place the weights file in the weights folder.")
+
+
+@pytest.mark.parametrize("executor_config", EXECUTOR_CONFIGS[:2], ids=lambda cfg: cfg.name)  # Test first 2 executors
+@pytest.mark.parametrize("device_params", [{"l1_small_size": PDL_L1_SMALL_SIZE}], indirect=True)
+def test_panoptic_deeplab_pipeline_multiple_rounds(
+    device, executor_config: ExecutorTestConfig, model_location_generator
+):
+    """
+    Test multiple execution rounds with the pipeline to ensure stability.
+    """
+    skip_if_not_blackhole_20_cores(device)
+    torch.manual_seed(0)
+
+    config = get_panoptic_deeplab_config()
+    batch_size = config["batch_size"]
+    input_height, input_width = config["train_size"]
+
+    complete_weights_path = get_panoptic_deeplab_weights_path(model_location_generator, __file__)
+
+    try:
+        # Setup model (same as main test)
+        pytorch_model = PytorchPanopticDeepLab(
+            num_classes=config["num_classes"],
+            common_stride=config["common_stride"],
+            project_channels=config["project_channels"],
+            decoder_channels=config["decoder_channels"],
+            sem_seg_head_channels=config["sem_seg_head_channels"],
+            ins_embed_head_channels=config["ins_embed_head_channels"],
+            train_size=config["train_size"],
+            weights_path=complete_weights_path,
+            model_category=PANOPTIC_DEEPLAB,
+        )
+        pytorch_model = pytorch_model.to(dtype=torch.bfloat16)
+        pytorch_model.eval()
+
+        ttnn_parameters = create_panoptic_deeplab_parameters(
+            pytorch_model, device, input_height=input_height, input_width=input_width, batch_size=batch_size
+        )
+        fused_parameters = fuse_conv_bn_parameters(ttnn_parameters, eps=1e-5)
+
+        model_configs = ModelOptimisations(conv_act_dtype=ttnn.bfloat8_b, conv_w_dtype=ttnn.bfloat8_b)
+        model_configs.setup_resnet_backbone()
+        model_configs.setup_aspp()
+        model_configs.setup_decoder()
+        model_configs.setup_heads()
+
+        ttnn_model = TtPanopticDeepLab(
+            device=device,
+            parameters=fused_parameters,
+            num_classes=config["num_classes"],
+            common_stride=config["common_stride"],
+            project_channels=config["project_channels"],
+            decoder_channels=config["decoder_channels"],
+            sem_seg_head_channels=config["sem_seg_head_channels"],
+            ins_embed_head_channels=config["ins_embed_head_channels"],
+            train_size=config["train_size"],
+            model_configs=model_configs,
+            model_category=PANOPTIC_DEEPLAB,
+        )
+
+        model_wrapper = create_model_wrapper(ttnn_model)
+
+        # Create pipeline
+        num_inputs_per_round = 2
+        host_inputs_sample, dram_memory_config, l1_memory_config = create_host_input_tensors(
+            device, batch_size, input_height, input_width, 1
+        )
+
+        config = PipelineConfig(
+            use_trace=executor_config.use_trace,
+            num_command_queues=executor_config.num_command_queues,
+            all_transfers_on_separate_command_queue=executor_config.all_transfers_on_separate_command_queue,
+        )
+
+        pipeline_args = {
+            "config": config,
+            "model": model_wrapper,
+            "device": device,
+            "dram_input_memory_config": dram_memory_config,
+            "l1_input_memory_config": l1_memory_config,
+        }
+
+        pipe = create_pipeline_from_config(**pipeline_args)
+        pipe.compile(host_inputs_sample[0])
+
+        # Run multiple rounds
+        total_outputs = []
+        for round_num in range(3):
+            logger.info(f"Running round {round_num + 1}/3...")
+            round_inputs, _, _ = create_host_input_tensors(
+                device, batch_size, input_height, input_width, num_inputs_per_round
+            )
+            round_outputs = pipe.enqueue(round_inputs).pop_all()
+            total_outputs.extend(round_outputs)
+
+        pipe.cleanup()
+
+        # Verify we got expected number of outputs
+        assert len(total_outputs) == 3 * num_inputs_per_round, f"Expected {3 * num_inputs_per_round} outputs"
+        logger.info(f"✅ Multiple rounds test passed for {executor_config.name}!")
+
+    except FileNotFoundError:
+        pytest.fail("model_final_bd324a.pkl file not found. Please place the weights file in the weights folder.")

--- a/models/experimental/panoptic_deeplab/tt/tt_custom_pipeline.py
+++ b/models/experimental/panoptic_deeplab/tt/tt_custom_pipeline.py
@@ -140,14 +140,8 @@ class CustomTracedModelExecutor(Executor):
         """
         Executes the traced model for a single input tensor.
         """
-        # Transfer host input directly to L1, then copy to persistent L1 tensor
-        temp_l1_input = ttnn.to_device(input_tensor, device=self.device, memory_config=self.l1_input_memory_config)
-
-        # Copy data from temporary L1 tensor to persistent L1 tensor using to_memory_config
-        self.l1_input_tensor = ttnn.to_memory_config(
-            temp_l1_input, self.l1_input_memory_config, output_tensor=self.l1_input_tensor
-        )
-        ttnn.deallocate(temp_l1_input)
+        # Transfer host input directly to L1
+        ttnn.copy_host_to_device_tensor(input_tensor, self.l1_input_tensor, cq_id=self.cq_id)
 
         # Validate address consistency with captured trace
         actual_addr = self.l1_input_tensor.buffer_address()

--- a/models/experimental/panoptic_deeplab/tt/tt_custom_pipeline.py
+++ b/models/experimental/panoptic_deeplab/tt/tt_custom_pipeline.py
@@ -1,0 +1,247 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Callable, Iterable, Optional
+
+from loguru import logger
+
+import ttnn
+
+from models.tt_cnn.tt.executor import (
+    Executor,
+    ModelExecutor,
+    MultiCQModelOverlappedInputExecutor,
+    MultiCQTracedModelOverlappedInputExecutor,
+    MultiCQTracedModelPipelinedIOExecutor,
+)
+from models.tt_cnn.tt.pipeline import PipelineConfig, pipeline
+
+
+class CustomTracedModelExecutor(Executor):
+    """
+    Custom TracedModelExecutor that transfers host input directly to L1 memory
+    instead of going through DRAM. This is a custom implementation with modified
+    behavior compared to the standard TracedModelExecutor.
+
+    Runs a model using tracing on a single command-queue.
+
+    This executor compiles the model once to generate optimized kernels, then captures
+    a trace of the execution for efficient repeated runs.
+
+    Best suited for scenarios where input/output transfers are not the bottleneck
+    and simplicity is preferred over maximum throughput.
+    """
+
+    def __init__(self, model: Callable, device, l1_input_memory_config, cq_id=0):
+        self.model = model
+        self.device = device
+        self.cq_id = cq_id
+
+        self.l1_input_memory_config = l1_input_memory_config
+
+        self.l1_input_tensor = None
+        self.output_tensor = None
+        self._compilation_output_tensor = None
+        self.output_schema = None
+
+        self.trace_id = None
+        self.input_trace_addr = None
+
+    def get_output_schema(self):
+        if self.output_schema is None:
+            raise RuntimeError("Executor must be compiled before getting the output schema.")
+        return self.output_schema
+
+    def _create_output_schema(self, output):
+        if isinstance(output, ttnn.Tensor):
+            return (output.shape, output.dtype, output.layout)
+        elif isinstance(output, (list, tuple)):
+            return [self._create_output_schema(t) for t in output]
+        else:
+            raise TypeError(f"Unsupported type in model output: {type(output)}")
+
+    def _deallocate_structured_tensor(self, tensor_struct, force=False):
+        if isinstance(tensor_struct, ttnn.Tensor):
+            if tensor_struct.is_allocated():
+                ttnn.deallocate(tensor_struct, force=force)
+        elif isinstance(tensor_struct, (list, tuple)):
+            for t in tensor_struct:
+                self._deallocate_structured_tensor(t, force=force)
+
+    def get_read_cq(self):
+        return self.cq_id
+
+    def compile(self, host_input):
+        """
+        Compiles the model by running it once and then captures a trace.
+        """
+        self._validate_input(host_input)
+        self._allocate_persistent_tensors(host_input)
+        self._run_model_for_compilation(host_input)
+        self.output_schema = self._create_output_schema(self._compilation_output_tensor)
+        self._capture_execution_trace(host_input)
+        ttnn.synchronize_device(self.device)
+
+    def _validate_input(self, host_input):
+        if host_input.storage_type() != ttnn.StorageType.HOST:
+            raise ValueError("Input tensor must be on host")
+
+    def _allocate_persistent_tensors(self, host_input):
+        # No persistent tensors needed at this stage - L1 tensor allocated after trace capture
+        pass
+
+    def _run_model_for_compilation(self, host_input):
+        l1_input_for_compile = self._prepare_l1_input(host_input)
+        self._compilation_output_tensor = self.model(l1_input_for_compile)
+        ttnn.deallocate(l1_input_for_compile)
+
+    def _capture_execution_trace(self, host_input):
+        l1_input_for_trace, spec = self._prepare_input_for_trace_capture(host_input)
+
+        self.trace_id = ttnn.begin_trace_capture(self.device, cq_id=self.cq_id)
+
+        self.output_tensor = self.model(l1_input_for_trace)
+        ttnn.deallocate(l1_input_for_trace)
+
+        self._validate_trace_address_consistency(spec)
+        ttnn.end_trace_capture(self.device, self.trace_id, cq_id=self.cq_id)
+
+    def _prepare_input_for_trace_capture(self, host_input):
+        l1_input_for_trace = self._prepare_l1_input(host_input)
+        self.input_trace_addr = l1_input_for_trace.buffer_address()
+        spec = l1_input_for_trace.spec
+
+        self._deallocate_structured_tensor(self._compilation_output_tensor, force=True)
+
+        return l1_input_for_trace, spec
+
+    def _validate_trace_address_consistency(self, spec):
+        """
+        Validates that allocating a persistent L1 tensor will use the expected address
+        that was captured during trace recording.
+        """
+        self.l1_input_tensor = ttnn.allocate_tensor_on_device(spec, self.device)
+        actual_addr = self.l1_input_tensor.buffer_address()
+
+        if self.input_trace_addr != actual_addr:
+            raise RuntimeError(
+                f"L1 input tensor address mismatch: trace captured {self.input_trace_addr}, "
+                f"but persistent tensor allocated at {actual_addr}"
+            )
+
+    def _prepare_l1_input(self, host_input):
+        """
+        Transfers host input directly to L1 memory.
+        """
+        return ttnn.to_device(host_input, device=self.device, memory_config=self.l1_input_memory_config)
+
+    def _execute_single(self, input_tensor):
+        """
+        Executes the traced model for a single input tensor.
+        """
+        # Transfer host input directly to L1, then copy to persistent L1 tensor
+        temp_l1_input = ttnn.to_device(input_tensor, device=self.device, memory_config=self.l1_input_memory_config)
+
+        # Copy data from temporary L1 tensor to persistent L1 tensor using to_memory_config
+        self.l1_input_tensor = ttnn.to_memory_config(
+            temp_l1_input, self.l1_input_memory_config, output_tensor=self.l1_input_tensor
+        )
+        ttnn.deallocate(temp_l1_input)
+
+        # Validate address consistency with captured trace
+        actual_addr = self.l1_input_tensor.buffer_address()
+        if actual_addr != self.input_trace_addr:
+            raise RuntimeError(
+                f"L1 input tensor address mismatch during execution: "
+                f"expected {self.input_trace_addr}, got {actual_addr}"
+            )
+
+        ttnn.execute_trace(self.device, self.trace_id, cq_id=self.cq_id, blocking=False)
+        return self.output_tensor
+
+    def execute(self, host_inputs: list) -> Iterable[ttnn.Tensor]:
+        """
+        Executes the traced model for a batch of input tensors.
+        """
+        for host_input in host_inputs:
+            yield self._execute_single(host_input)
+
+    def cleanup(self):
+        if self.trace_id is not None:
+            ttnn.release_trace(self.device, self.trace_id)
+
+
+def create_pipeline_from_config(
+    config: PipelineConfig,
+    model: Callable,
+    device,
+    l1_input_memory_config: ttnn.MemoryConfig,
+    dram_input_memory_config: ttnn.MemoryConfig = None,
+    dram_output_memory_config: Optional[ttnn.MemoryConfig] = None,
+):
+    """
+    Custom create_pipeline_from_config that uses CustomTracedModelExecutor
+    for traced single command queue configurations.
+
+    For other configurations, this falls back to the standard pipeline creation.
+    """
+    logger.debug(f"Creating pipeline from config:\n{config}")
+
+    executor = None
+    if config.num_command_queues == 1:
+        if config.use_trace:
+            logger.debug("Creating CustomTracedModelExecutor with single command queue")
+            executor = CustomTracedModelExecutor(
+                model,
+                device,
+                l1_input_memory_config=l1_input_memory_config,
+            )
+        else:
+            logger.debug("Creating ModelExecutor with single command queue")
+            executor = ModelExecutor(
+                model,
+                device,
+                l1_input_memory_config=l1_input_memory_config,
+            )
+    elif config.num_command_queues == 2:
+        if not config.use_trace:
+            # Non-traced multi-CQ executor that overlaps input transfers
+            if config.all_transfers_on_separate_command_queue:
+                raise ValueError("Pipelined I/O (all_transfers_on_separate_command_queue) requires tracing")
+            if not dram_input_memory_config:
+                raise ValueError("dram_input_memory_config must be provided when using multi-CQ executor")
+            logger.debug("Creating MultiCQModelOverlappedInputExecutor with multiple command queues (non-traced)")
+            executor = MultiCQModelOverlappedInputExecutor(
+                model,
+                device,
+                dram_input_memory_config=dram_input_memory_config,
+                l1_input_memory_config=l1_input_memory_config,
+            )
+        elif config.all_transfers_on_separate_command_queue:
+            if not dram_output_memory_config:
+                raise ValueError(
+                    "dram_output_memory_config must be provided when all_transfers_on_separate_command_queue=True."
+                )
+            executor = MultiCQTracedModelPipelinedIOExecutor(
+                model,
+                device,
+                dram_input_memory_config=dram_input_memory_config,
+                l1_input_memory_config=l1_input_memory_config,
+                dram_output_memory_config=dram_output_memory_config,
+            )
+        else:
+            executor = MultiCQTracedModelOverlappedInputExecutor(
+                model,
+                device,
+                dram_input_memory_config=dram_input_memory_config,
+                l1_input_memory_config=l1_input_memory_config,
+            )
+    else:
+        raise ValueError(f"Unsupported pipeline configuration: {config}")
+
+    if executor is None:
+        raise ValueError(f"Could not create executor for configuration: {config}")
+
+    logger.debug(f"Created executor with type={type(executor).__name__}")
+    return pipeline(executor)

--- a/models/tt_cnn/tt/builder.py
+++ b/models/tt_cnn/tt/builder.py
@@ -629,8 +629,7 @@ class TtConv2d:
             slice_kwargs = self.get_conv2d_kwargs()
             slice_kwargs["in_channels"] = channels_per_slice
 
-
-            output_slice, (weight, bias) = ttnn.conv2d(
+            output_slice, (h_out, w_out), (weight, bias) = ttnn.conv2d(
                 input_tensor=input_slices[i],
                 weight_tensor=self.weight_slices[i],
                 bias_tensor=None,

--- a/models/tt_cnn/tt/builder.py
+++ b/models/tt_cnn/tt/builder.py
@@ -629,7 +629,8 @@ class TtConv2d:
             slice_kwargs = self.get_conv2d_kwargs()
             slice_kwargs["in_channels"] = channels_per_slice
 
-            output_slice, [h_out, w_out], self.weight_slices[i] = ttnn.conv2d(
+
+            output_slice, (weight, bias) = ttnn.conv2d(
                 input_tensor=input_slices[i],
                 weight_tensor=self.weight_slices[i],
                 bias_tensor=None,
@@ -638,6 +639,8 @@ class TtConv2d:
                 compute_config=self.compute_config,
                 **slice_kwargs,
             )
+            # Store only the weight, not the tuple
+            self.weight_slices[i] = weight
             # Without this, some edge case convs OOM
             output_slice = ttnn.move(output_slice)
             if i == 0:

--- a/models/tt_cnn/tt/executor.py
+++ b/models/tt_cnn/tt/executor.py
@@ -210,11 +210,17 @@ class TracedModelExecutor(Executor):
 
     def _prepare_l1_input(self, host_input):
         """
-        Transfers host input to device DRAM and reshards to L1 memory.
+        Transfers host input to device DRAM and converts to L1 memory.
+        Uses to_memory_config if DRAM is interleaved, otherwise uses reshard.
         """
         self._validate_dram_input_tensor()
         ttnn.copy_host_to_device_tensor(host_input, self.dram_input_tensor, cq_id=self.cq_id)
-        return ttnn.reshard(self.dram_input_tensor, self.l1_input_memory_config)
+        # If DRAM is interleaved, use to_memory_config to convert to sharded L1
+        # Otherwise, use reshard for sharded-to-sharded conversion
+        if not self.dram_input_tensor.memory_config().is_sharded():
+            return ttnn.to_memory_config(self.dram_input_tensor, self.l1_input_memory_config)
+        else:
+            return ttnn.reshard(self.dram_input_tensor, self.l1_input_memory_config)
 
     def _validate_dram_input_tensor(self):
         if self.dram_input_tensor is None:
@@ -228,11 +234,19 @@ class TracedModelExecutor(Executor):
         """
         Executes the traced model for a single input tensor.
         """
-        # Transfer input to device and reshard to L1
+        # Transfer input to device and convert to L1
         ttnn.copy_host_to_device_tensor(input_tensor, self.dram_input_tensor, cq_id=self.cq_id)
 
-        # Reuse persistent L1 tensor by resharding in-place
-        self.l1_input_tensor = ttnn.reshard(self.dram_input_tensor, self.l1_input_memory_config, self.l1_input_tensor)
+        # Reuse persistent L1 tensor by converting in-place
+        # If DRAM is interleaved, use to_memory_config, otherwise use reshard
+        if not self.dram_input_tensor.memory_config().is_sharded():
+            self.l1_input_tensor = ttnn.to_memory_config(
+                self.dram_input_tensor, self.l1_input_memory_config, output_tensor=self.l1_input_tensor
+            )
+        else:
+            self.l1_input_tensor = ttnn.reshard(
+                self.dram_input_tensor, self.l1_input_memory_config, self.l1_input_tensor
+            )
 
         # Validate address consistency with captured trace
         actual_addr = self.l1_input_tensor.buffer_address()
@@ -340,9 +354,13 @@ class MultiCQModelOverlappedInputExecutor(Executor):
         ttnn.copy_host_to_device_tensor(host_input, self.dram_input_tensor, cq_id=self.CQ_INPUT_WRITE)
         write_event = ttnn.record_event(self.device, self.CQ_INPUT_WRITE)
 
-        # Reshard to L1 and run model
+        # Convert to L1 and run model
         ttnn.wait_for_event(self.CQ_OPS_AND_OUTPUT_READ, write_event)
-        l1_input_tensor = ttnn.reshard(self.dram_input_tensor, self.l1_input_memory_config)
+        # If DRAM is interleaved, use to_memory_config, otherwise use reshard
+        if not self.dram_input_tensor.memory_config().is_sharded():
+            l1_input_tensor = ttnn.to_memory_config(self.dram_input_tensor, self.l1_input_memory_config)
+        else:
+            l1_input_tensor = ttnn.reshard(self.dram_input_tensor, self.l1_input_memory_config)
         output_tensor = self.model(l1_input_tensor)
         self.op_event = ttnn.record_event(self.device, self.CQ_OPS_AND_OUTPUT_READ)
         if l1_input_tensor.is_allocated():
@@ -361,7 +379,11 @@ class MultiCQModelOverlappedInputExecutor(Executor):
 
         # Execute model
         ttnn.wait_for_event(self.CQ_OPS_AND_OUTPUT_READ, write_event)
-        l1_input_tensor = ttnn.reshard(self.dram_input_tensor, self.l1_input_memory_config)
+        # If DRAM is interleaved, use to_memory_config, otherwise use reshard
+        if not self.dram_input_tensor.memory_config().is_sharded():
+            l1_input_tensor = ttnn.to_memory_config(self.dram_input_tensor, self.l1_input_memory_config)
+        else:
+            l1_input_tensor = ttnn.reshard(self.dram_input_tensor, self.l1_input_memory_config)
         output_tensor = self.model(l1_input_tensor)
         self.op_event = ttnn.record_event(self.device, self.CQ_OPS_AND_OUTPUT_READ)
         if l1_input_tensor.is_allocated():
@@ -467,9 +489,13 @@ class MultiCQTracedModelOverlappedInputExecutor(Executor):
         ttnn.copy_host_to_device_tensor(host_input, self.dram_input_tensor, cq_id=self.CQ_INPUT_WRITE)
         write_event = ttnn.record_event(self.device, self.CQ_INPUT_WRITE)
 
-        # Reshard to L1 and run model
+        # Convert to L1 and run model
         ttnn.wait_for_event(self.CQ_OPS_AND_OUTPUT_READ, write_event)
-        l1_input_tensor = ttnn.reshard(self.dram_input_tensor, self.l1_input_memory_config)
+        # If DRAM is interleaved, use to_memory_config, otherwise use reshard
+        if not self.dram_input_tensor.memory_config().is_sharded():
+            l1_input_tensor = ttnn.to_memory_config(self.dram_input_tensor, self.l1_input_memory_config)
+        else:
+            l1_input_tensor = ttnn.reshard(self.dram_input_tensor, self.l1_input_memory_config)
         self.op_event = ttnn.record_event(self.device, self.CQ_OPS_AND_OUTPUT_READ)
 
         self._compilation_output_tensor = self.model(l1_input_tensor)
@@ -489,7 +515,11 @@ class MultiCQTracedModelOverlappedInputExecutor(Executor):
 
         # Prepare L1 input for trace
         ttnn.wait_for_event(self.CQ_OPS_AND_OUTPUT_READ, write_event)
-        l1_input_tensor = ttnn.reshard(self.dram_input_tensor, self.l1_input_memory_config)
+        # If DRAM is interleaved, use to_memory_config, otherwise use reshard
+        if not self.dram_input_tensor.memory_config().is_sharded():
+            l1_input_tensor = ttnn.to_memory_config(self.dram_input_tensor, self.l1_input_memory_config)
+        else:
+            l1_input_tensor = ttnn.reshard(self.dram_input_tensor, self.l1_input_memory_config)
         ttnn.record_event(self.device, self.CQ_OPS_AND_OUTPUT_READ)
 
         # Record tensor details for validation
@@ -529,7 +559,15 @@ class MultiCQTracedModelOverlappedInputExecutor(Executor):
 
         # Execute traced model
         ttnn.wait_for_event(self.CQ_OPS_AND_OUTPUT_READ, write_event)
-        self.l1_input_tensor = ttnn.reshard(self.dram_input_tensor, self.l1_input_memory_config, self.l1_input_tensor)
+        # If DRAM is interleaved, use to_memory_config, otherwise use reshard
+        if not self.dram_input_tensor.memory_config().is_sharded():
+            self.l1_input_tensor = ttnn.to_memory_config(
+                self.dram_input_tensor, self.l1_input_memory_config, output_tensor=self.l1_input_tensor
+            )
+        else:
+            self.l1_input_tensor = ttnn.reshard(
+                self.dram_input_tensor, self.l1_input_memory_config, self.l1_input_tensor
+            )
         self.op_event = ttnn.record_event(self.device, self.CQ_OPS_AND_OUTPUT_READ)
         ttnn.execute_trace(self.device, self.trace_id, cq_id=self.CQ_OPS_AND_OUTPUT_READ, blocking=False)
 
@@ -653,7 +691,11 @@ class MultiCQTracedModelPipelinedIOExecutor(Executor):
 
         # Execute model and get output shape/dtype
         ttnn.wait_for_event(self.CQ_OPS, self.write_event)
-        l1_input_tensor = ttnn.reshard(self.dram_input_tensor, self.l1_input_memory_config)
+        # If DRAM is interleaved, use to_memory_config, otherwise use reshard
+        if not self.dram_input_tensor.memory_config().is_sharded():
+            l1_input_tensor = ttnn.to_memory_config(self.dram_input_tensor, self.l1_input_memory_config)
+        else:
+            l1_input_tensor = ttnn.reshard(self.dram_input_tensor, self.l1_input_memory_config)
         self.first_op_event = ttnn.record_event(self.device, self.CQ_OPS)
         self._compilation_output_tensor = self.model(l1_input_tensor)
 
@@ -673,12 +715,16 @@ class MultiCQTracedModelPipelinedIOExecutor(Executor):
         Captures a trace of the model execution for efficient repeated runs.
         Sets up persistent L1 input tensor and validates memory addresses.
         """
-        # Transfer input to DRAM and then reshard to L1
+        # Transfer input to DRAM and then convert to L1
         ttnn.wait_for_event(self.CQ_IO, self.first_op_event)
         ttnn.copy_host_to_device_tensor(host_input, self.dram_input_tensor, cq_id=self.CQ_IO)
         self.write_event = ttnn.record_event(self.device, self.CQ_IO)
         ttnn.wait_for_event(self.CQ_OPS, self.write_event)
-        l1_input_tensor = ttnn.reshard(self.dram_input_tensor, self.l1_input_memory_config)
+        # If DRAM is interleaved, use to_memory_config, otherwise use reshard
+        if not self.dram_input_tensor.memory_config().is_sharded():
+            l1_input_tensor = ttnn.to_memory_config(self.dram_input_tensor, self.l1_input_memory_config)
+        else:
+            l1_input_tensor = ttnn.reshard(self.dram_input_tensor, self.l1_input_memory_config)
 
         input_trace_addr = l1_input_tensor.buffer_address()
         spec = l1_input_tensor.spec
@@ -708,7 +754,15 @@ class MultiCQTracedModelPipelinedIOExecutor(Executor):
         This is the core execution step that gets pipelined with I/O operations.
         """
         ttnn.wait_for_event(self.CQ_OPS, self.write_event)
-        self.l1_input_tensor = ttnn.reshard(self.dram_input_tensor, self.l1_input_memory_config, self.l1_input_tensor)
+        # If DRAM is interleaved, use to_memory_config, otherwise use reshard
+        if not self.dram_input_tensor.memory_config().is_sharded():
+            self.l1_input_tensor = ttnn.to_memory_config(
+                self.dram_input_tensor, self.l1_input_memory_config, output_tensor=self.l1_input_tensor
+            )
+        else:
+            self.l1_input_tensor = ttnn.reshard(
+                self.dram_input_tensor, self.l1_input_memory_config, self.l1_input_tensor
+            )
         self.first_op_event = ttnn.record_event(self.device, self.CQ_OPS)
         ttnn.execute_trace(self.device, self.trace_id, cq_id=self.CQ_OPS, blocking=False)
 


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/26274)

### Problem description
Implement E2E demo for PDL using TT CNN pipeline.

### What's changed
- E2E demo
- E2E test with random inputs
- Custom Traced Executor with L1 inputs only
- Minor fix for channel-sliced convolutions in TT-CNN builder

TODO: we need to find a place for E2E perf tests, given that they are currently CIv1 only and we rely on CIv2

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [x] [Blackhole nightly tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-nightly-tests.yaml) CI passes (if applicable)
- [x] New/Existing tests provide coverage for changes