### PR TITLE
Making test clone compatible with the blackhole grid selection

### DIFF
--- a/tests/ttnn/unit_tests/operations/data_movement/test_clone.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_clone.py
@@ -315,8 +315,13 @@ def test_clone_sharded_tilized(
     torch.manual_seed(2024)
 
     compute_grid_size = device.compute_with_storage_grid_size()
-
-    shard_grid = ttnn.CoreGrid(y=compute_grid_size.y, x=compute_grid_size.x)
+    x_grid_size = compute_grid_size.x
+    y_grid_size = compute_grid_size.x
+    while shape[-1] % x_grid_size != 0:
+        x_grid_size = x_grid_size - 1
+    while shape[-2] % y_grid_size != 0:
+        y_grid_size = y_grid_size - 1
+    shard_grid = ttnn.CoreGrid(y=y_grid_size, x=x_grid_size)
 
     shard_memory_config = ttnn.create_sharded_memory_config(
         shape=shape,
@@ -369,8 +374,14 @@ def test_clone_sharded_row_major(
     torch.manual_seed(2024)
 
     compute_grid_size = device.compute_with_storage_grid_size()
+    x_grid_size = compute_grid_size.x
+    y_grid_size = compute_grid_size.x
+    while shape[-1] % x_grid_size != 0:
+        x_grid_size = x_grid_size - 1
+    while shape[-2] % y_grid_size != 0:
+        y_grid_size = y_grid_size - 1
 
-    shard_grid = ttnn.CoreGrid(y=compute_grid_size.y, x=compute_grid_size.x)
+    shard_grid = ttnn.CoreGrid(y=y_grid_size, x=x_grid_size)
 
     shard_memory_config = ttnn.create_sharded_memory_config(
         shape=shape,
@@ -413,7 +424,14 @@ def test_clone_sharded_dtype_conversion(
 
     compute_grid_size = device.compute_with_storage_grid_size()
 
-    shard_grid = ttnn.CoreGrid(y=compute_grid_size.y, x=compute_grid_size.x)
+    x_grid_size = compute_grid_size.x
+    y_grid_size = compute_grid_size.x
+    while shape[-1] % x_grid_size != 0:
+        x_grid_size = x_grid_size - 1
+    while shape[-2] % y_grid_size != 0:
+        y_grid_size = y_grid_size - 1
+
+    shard_grid = ttnn.CoreGrid(y=y_grid_size, x=x_grid_size)
 
     shard_memory_config = ttnn.create_sharded_memory_config(
         shape=shape,

--- a/tests/ttnn/unit_tests/operations/data_movement/test_clone.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_clone.py
@@ -316,7 +316,7 @@ def test_clone_sharded_tilized(
 
     compute_grid_size = device.compute_with_storage_grid_size()
     x_grid_size = compute_grid_size.x
-    y_grid_size = compute_grid_size.x
+    y_grid_size = compute_grid_size.y
     while shape[-1] % x_grid_size != 0:
         x_grid_size = x_grid_size - 1
     while shape[-2] % y_grid_size != 0:
@@ -375,7 +375,7 @@ def test_clone_sharded_row_major(
 
     compute_grid_size = device.compute_with_storage_grid_size()
     x_grid_size = compute_grid_size.x
-    y_grid_size = compute_grid_size.x
+    y_grid_size = compute_grid_size.y
     while shape[-1] % x_grid_size != 0:
         x_grid_size = x_grid_size - 1
     while shape[-2] % y_grid_size != 0:
@@ -425,7 +425,7 @@ def test_clone_sharded_dtype_conversion(
     compute_grid_size = device.compute_with_storage_grid_size()
 
     x_grid_size = compute_grid_size.x
-    y_grid_size = compute_grid_size.x
+    y_grid_size = compute_grid_size.y
     while shape[-1] % x_grid_size != 0:
         x_grid_size = x_grid_size - 1
     while shape[-2] % y_grid_size != 0:


### PR DESCRIPTION
Test clone pytest was built hardcoded for wormhole but the test is run in blackhole post commit. In particular the sharding shape used did not account for the fact that blackhole has a different core grid available. This PR modifies the test to make it compatible with any arbitrary core grid including the grid used in blackhole products

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/20071097981
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/20071202355