### PR TITLE
Adding env variable to ensure CI passes for deepseek-demo

### DIFF
--- a/.github/workflows/galaxy-demo-tests-impl.yaml
+++ b/.github/workflows/galaxy-demo-tests-impl.yaml
@@ -297,6 +297,7 @@ jobs:
         env:
           DEEPSEEK_V3_HF_MODEL: /mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528
           DEEPSEEK_V3_CACHE: /mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-Cache
+          MESH_DEVICE: TG
         run: |
           pytest models/demos/deepseek_v3/demo/test_demo.py --timeout 600
       - uses: tenstorrent/tt-metal/.github/actions/slack-report@main

--- a/.github/workflows/galaxy-demo-tests.yaml
+++ b/.github/workflows/galaxy-demo-tests.yaml
@@ -26,6 +26,7 @@ on:
           - mochi
           - qwen3_32b
           - qwen3_32b_long_context
+          - deepseek_v3
   # Disabled till 15. Dec 2025 due to UF release
   # schedule:
   #   - cron: "0 0 * * *" # This cron schedule runs demo tests every day at 12am UTC


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
CI is currently failing due to another PR being merged that requires a new env variable.

### What's changed
Added MESH_DEVICE env variable to get Deepseek demo CI to pass

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/20071945461) CI passes
- [x] [Deepseek demo](https://github.com/tenstorrent/tt-metal/actions/runs/20071899330) CI passes