### PR TITLE
reduce 120b glx ttft

### DIFF
--- a/models/demos/gpt_oss/perf_targets.json
+++ b/models/demos/gpt_oss/perf_targets.json
@@ -41,7 +41,7 @@
                 "decode_tok_s": 2200
             },
             "GLX_gpt-oss-120b": {
-                "TTFT": [1600, 1.2],
+                "TTFT": [1300, 1.2],
                 "decode_tok_s_u": 6.5,
                 "decode_tok_s": 2200
             }


### PR DESCRIPTION
### Problem description
GPT-OSS failing perf checks on TTFT. Target is too high. 


### What's changed
Lower target TTFT to 1300ms

GPT-OSS demo tests: https://github.com/tenstorrent/tt-metal/actions/runs/20071965057