### PR TITLE
TT-Fabric Intermesh Traffic VC (VC1) Support [4/4]

### DIFF
--- a/tt_metal/fabric/builder/connection_writer_adapter.hpp
+++ b/tt_metal/fabric/builder/connection_writer_adapter.hpp
@@ -148,7 +148,8 @@ private:
         builder_config::num_max_receiver_channels>
         downstream_edm_buffer_base_addresses = {};
 
-    uint32_t downstream_edms_connected = 0;
+    // Per-VC connection mask: bitmask indicating which downstream EDMs are connected for each VC
+    std::array<uint32_t, builder_config::num_max_receiver_channels> downstream_edms_connected_by_vc_mask = {};
 
     std::array<
         std::array<std::optional<size_t>, builder_config::max_downstream_edms>,

--- a/tt_metal/fabric/builder/fabric_builder_config.hpp
+++ b/tt_metal/fabric/builder/fabric_builder_config.hpp
@@ -75,7 +75,7 @@ static constexpr std::size_t num_downstream_edms_2d_vc1 = 3;  // XY intermesh: 3
 static constexpr std::size_t num_downstream_edms_2d_vc1_with_z = 4;  // Z intermesh: 3 mesh + Z
 static constexpr std::size_t num_downstream_edms_1d = num_downstream_edms_vc0;
 static constexpr std::size_t num_downstream_edms_2d = num_downstream_edms_2d_vc0 + num_downstream_edms_2d_vc1;
-static constexpr std::size_t max_downstream_edms = std::max({num_downstream_edms_1d, num_downstream_edms_2d, num_downstream_edms_2d_vc1_with_z});
+static constexpr std::size_t max_downstream_edms = 8;
 
 // 2D mesh directions (N, E, S, W)
 static constexpr uint32_t num_mesh_directions_2d = 4;

--- a/tt_metal/fabric/builder/fabric_static_sized_channels_allocator.cpp
+++ b/tt_metal/fabric/builder/fabric_static_sized_channels_allocator.cpp
@@ -498,6 +498,16 @@ void FabricStaticSizedChannelsAllocator::emit_ct_args(std::vector<uint32_t>& ct_
             ct_args.push_back(this->sender_channels_num_buffers[vc][i]);
             ct_args.push_back(static_cast<uint32_t>(this->remote_sender_channels_base_address[vc][i]));
             ct_args.push_back(this->remote_sender_channels_num_buffers[vc][i]);
+            log_debug(
+                LogFabric,
+                "VC{} Sender Channel[{}]: base_addr=0x{:x} num_buffers={} remote_base_addr=0x{:x} "
+                "remote_num_buffers={}",
+                vc,
+                i,
+                this->sender_channels_base_address[vc][i],
+                this->sender_channels_num_buffers[vc][i],
+                this->remote_sender_channels_base_address[vc][i],
+                this->remote_sender_channels_num_buffers[vc][i]);
         }
     }
 
@@ -508,6 +518,16 @@ void FabricStaticSizedChannelsAllocator::emit_ct_args(std::vector<uint32_t>& ct_
             ct_args.push_back(this->receiver_channels_num_buffers[vc][i]);
             ct_args.push_back(static_cast<uint32_t>(this->remote_receiver_channels_base_address[vc][i]));
             ct_args.push_back(this->remote_receiver_channels_num_buffers[vc][i]);
+            log_debug(
+                LogFabric,
+                "VC{} Receiver Channel[{}]: base_addr=0x{:x} num_buffers={} remote_base_addr=0x{:x} "
+                "remote_num_buffers={}",
+                vc,
+                i,
+                this->receiver_channels_base_address[vc][i],
+                this->receiver_channels_num_buffers[vc][i],
+                this->remote_receiver_channels_base_address[vc][i],
+                this->remote_receiver_channels_num_buffers[vc][i]);
         }
     }
 }

--- a/tt_metal/fabric/builder/fabric_static_sized_channels_allocator.cpp
+++ b/tt_metal/fabric/builder/fabric_static_sized_channels_allocator.cpp
@@ -498,16 +498,6 @@ void FabricStaticSizedChannelsAllocator::emit_ct_args(std::vector<uint32_t>& ct_
             ct_args.push_back(this->sender_channels_num_buffers[vc][i]);
             ct_args.push_back(static_cast<uint32_t>(this->remote_sender_channels_base_address[vc][i]));
             ct_args.push_back(this->remote_sender_channels_num_buffers[vc][i]);
-            log_debug(
-                LogFabric,
-                "VC{} Sender Channel[{}]: base_addr=0x{:x} num_buffers={} remote_base_addr=0x{:x} "
-                "remote_num_buffers={}",
-                vc,
-                i,
-                this->sender_channels_base_address[vc][i],
-                this->sender_channels_num_buffers[vc][i],
-                this->remote_sender_channels_base_address[vc][i],
-                this->remote_sender_channels_num_buffers[vc][i]);
         }
     }
 
@@ -518,16 +508,6 @@ void FabricStaticSizedChannelsAllocator::emit_ct_args(std::vector<uint32_t>& ct_
             ct_args.push_back(this->receiver_channels_num_buffers[vc][i]);
             ct_args.push_back(static_cast<uint32_t>(this->remote_receiver_channels_base_address[vc][i]));
             ct_args.push_back(this->remote_receiver_channels_num_buffers[vc][i]);
-            log_debug(
-                LogFabric,
-                "VC{} Receiver Channel[{}]: base_addr=0x{:x} num_buffers={} remote_base_addr=0x{:x} "
-                "remote_num_buffers={}",
-                vc,
-                i,
-                this->receiver_channels_base_address[vc][i],
-                this->receiver_channels_num_buffers[vc][i],
-                this->remote_receiver_channels_base_address[vc][i],
-                this->remote_receiver_channels_num_buffers[vc][i]);
         }
     }
 }

--- a/tt_metal/fabric/builder/router_connection_mapping.cpp
+++ b/tt_metal/fabric/builder/router_connection_mapping.cpp
@@ -54,7 +54,7 @@ RoutingDirection RouterConnectionMapping::get_opposite_direction(RoutingDirectio
 }
 
 RouterConnectionMapping RouterConnectionMapping::for_mesh_router(
-    Topology topology, RoutingDirection direction, bool has_z) {
+    Topology topology, RoutingDirection direction, bool has_z, bool enable_vc1) {
     RouterConnectionMapping mapping;
 
     // VC0 receiver_channel channels for mesh routers
@@ -139,15 +139,17 @@ RouterConnectionMapping RouterConnectionMapping::for_mesh_router(
         // Add VC1 targets for intra-mesh routers (to forward inter-mesh traffic)
         // VC1 connections are only for intra-mesh routers in multi-mesh topologies
         // They forward inter-mesh traffic that was received via VC1
-        for (size_t i = 0; i < outbound_directions.size(); ++i) {
-            mapping.add_target(
-                1,  // VC1 - for inter-mesh traffic forwarding
-                0,  // Receiver channel 0 (VC1 only has one receiver channel)
-                ConnectionTarget(
-                    ConnectionType::INTRA_MESH,
-                    1,      // Target VC1
-                    i,      // Target sender channel (0-2 for VC1)
-                    outbound_directions[i]));
+        if (enable_vc1) {
+            for (size_t i = 0; i < outbound_directions.size(); ++i) {
+                mapping.add_target(
+                    1,  // VC1 - for inter-mesh traffic forwarding
+                    0,  // Receiver channel 0 (VC1 only has one receiver channel)
+                    ConnectionTarget(
+                        ConnectionType::INTRA_MESH,
+                        1,  // Target VC1
+                        i,  // Target sender channel (0-2 for VC1)
+                        outbound_directions[i]));
+            }
         }
     }
 

--- a/tt_metal/fabric/builder/router_connection_mapping.hpp
+++ b/tt_metal/fabric/builder/router_connection_mapping.hpp
@@ -92,9 +92,7 @@ public:
      * @return Configured RouterConnectionMapping for mesh router
      */
     static RouterConnectionMapping for_mesh_router(
-        Topology topology,
-        RoutingDirection direction,
-        bool has_z);
+        Topology topology, RoutingDirection direction, bool has_z, bool enable_vc1 = false);
 
     /**
      * @brief Factory method for Z router connection mapping

--- a/tt_metal/fabric/builder/static_sized_channel_connection_writer_adapter.cpp
+++ b/tt_metal/fabric/builder/static_sized_channel_connection_writer_adapter.cpp
@@ -8,8 +8,21 @@
 #include "tt_metal/fabric/fabric_context.hpp"
 #include "tt_metal/fabric/fabric_builder_context.hpp"
 #include "tt_metal/fabric/fabric_tensix_builder.hpp"
+#include <tt-logger/tt-logger.hpp>
 
 namespace tt::tt_fabric {
+
+namespace {
+const char* direction_to_string(eth_chan_directions direction) {
+    switch (direction) {
+        case eth_chan_directions::EAST: return "EAST";
+        case eth_chan_directions::WEST: return "WEST";
+        case eth_chan_directions::NORTH: return "NORTH";
+        case eth_chan_directions::SOUTH: return "SOUTH";
+        default: return "UNKNOWN";
+    }
+}
+}  // namespace
 
 StaticSizedChannelConnectionWriterAdapter::StaticSizedChannelConnectionWriterAdapter(
     FabricStaticSizedChannelsAllocator& /*allocator*/,
@@ -37,7 +50,7 @@ void StaticSizedChannelConnectionWriterAdapter::add_downstream_connection(
         // For NORTH router (my_direction=2): EAST(0)→0, WEST(1)→1, SOUTH(3)→2
         // For SOUTH router (my_direction=3): EAST(0)→0, WEST(1)→1, NORTH(2)→2
         size_t compact_index = get_receiver_channel_compact_index(my_direction, downstream_direction);
-        this->downstream_edms_connected |= (1 << compact_index);
+        this->downstream_edms_connected_by_vc_mask.at(inbound_vc_idx) |= (1 << compact_index);
 
         // Store addresses indexed by [vc_idx][compact_index]
         // NOTE: For INTRA_MESH connections, this works fine (one connection per compact_index)
@@ -51,7 +64,7 @@ void StaticSizedChannelConnectionWriterAdapter::add_downstream_connection(
         this->downstream_edm_buffer_index_semaphore_addresses.at(inbound_vc_idx).at(compact_index) =
             adapter_spec.buffer_index_semaphore_id;
     } else {
-        this->downstream_edms_connected = 1;
+        this->downstream_edms_connected_by_vc_mask.at(inbound_vc_idx) = 1;
 
         // For 1D, store at compact index 0
         this->downstream_edm_buffer_base_addresses.at(inbound_vc_idx).at(0) = adapter_spec.edm_buffer_base_addr;
@@ -98,12 +111,15 @@ void StaticSizedChannelConnectionWriterAdapter::pack_inbound_channel_rt_args(
     //
     // Because of this constraint, the standard packing path (which stores one buffer address per VC)
     // is sufficient for all connection types, including multi-target scenarios.
+    // Record the starting size to track what we're adding
+    size_t args_start_size = args_out.size();
     if (is_2D_routing) {
         // For 2D: Use fixed slot count based on VC (kernel expects fixed-size arrays)
         // VC0: 3 slots (mesh directions)
         // VC1: 3 slots (XY intermesh) or 4 slots (Z intermesh) - determined by actual connections
         size_t num_downstream_edms;
         if (vc_idx == 0) {
+            // This should probably also be based on the actual connection count
             num_downstream_edms = builder_config::get_vc0_downstream_edm_count(is_2D_routing);
         } else {
             // VC1: Use actual connection count (3 for XY, 4 for Z)
@@ -112,7 +128,7 @@ void StaticSizedChannelConnectionWriterAdapter::pack_inbound_channel_rt_args(
         }
 
         // Pack connection mask (bit mask indicating which slots are valid)
-        args_out.push_back(this->downstream_edms_connected);
+        args_out.push_back(this->downstream_edms_connected_by_vc_mask.at(vc_idx));
 
         // Pack buffer base addresses (one per compact index)
         for (size_t compact_idx = 0; compact_idx < num_downstream_edms; compact_idx++) {
@@ -141,7 +157,7 @@ void StaticSizedChannelConnectionWriterAdapter::pack_inbound_channel_rt_args(
     } else {
         // For 1D: single downstream connection (only VC0 supported)
         TT_FATAL(vc_idx == 0, "VC1 is not supported for 1D routing");
-        bool has_connection = this->downstream_edms_connected != 0;
+        bool has_connection = this->downstream_edms_connected_by_vc_mask.at(vc_idx) != 0;
 
         uint32_t buffer_addr = this->downstream_edm_buffer_base_addresses[vc_idx][0].value_or(0);
 
@@ -158,6 +174,90 @@ void StaticSizedChannelConnectionWriterAdapter::pack_inbound_channel_rt_args(
         args_out.reserve(args_out.size() + rt_args.size());
         std::copy(rt_args.begin(), rt_args.end(), std::back_inserter(args_out));
     }
+
+    // Log the packed runtime arguments
+    size_t num_packed_args = args_out.size() - args_start_size;
+    std::string packed_values_str;
+
+    // Calculate indices for NOC X and Y based on routing type
+    size_t noc_x_idx = 0;
+    size_t noc_y_idx = 0;
+    uint32_t num_downstream_edms = 0;
+
+    if (is_2D_routing) {
+        num_downstream_edms = (vc_idx == 0) ? builder_config::get_vc0_downstream_edm_count(is_2D_routing)
+                                            : builder_config::get_vc1_downstream_edm_count(is_2D_routing);
+        // Structure: [mask(1), buffer_addrs(num_downstream_edms), noc_x(1), noc_y(1), ...]
+        noc_x_idx = args_start_size + 1 + num_downstream_edms;
+        noc_y_idx = args_start_size + 2 + num_downstream_edms;
+    } else {
+        // Structure: [has_connection(1), buffer_addr(1), noc_x(1), noc_y(1), ...]
+        noc_x_idx = args_start_size + 2;
+        noc_y_idx = args_start_size + 3;
+        num_downstream_edms = 1;  // 1D routing has single downstream EDM
+    }
+
+    for (size_t i = args_start_size; i < args_out.size(); i++) {
+        if (i > args_start_size) {
+            packed_values_str += ", ";
+        }
+
+        // Special formatting for NOC X and Y coordinates
+        if (i == noc_x_idx) {
+            // Extract 8-bit values from packed NOC X (one byte per downstream EDM)
+            uint32_t packed_x = args_out[i];
+            std::string x_coords;
+            for (uint32_t byte_idx = 0; byte_idx < num_downstream_edms && byte_idx < 4; byte_idx++) {
+                uint8_t x_val = (packed_x >> (byte_idx * 8)) & 0xFF;
+                if (!x_coords.empty()) {
+                    x_coords += ", ";
+                }
+                x_coords += std::to_string(x_val);
+            }
+            packed_values_str += "NOC_X[" + x_coords + "]";
+        } else if (i == noc_y_idx) {
+            // Extract 8-bit values from packed NOC Y (one byte per downstream EDM)
+            uint32_t packed_y = args_out[i];
+            std::string y_coords;
+            for (uint32_t byte_idx = 0; byte_idx < num_downstream_edms && byte_idx < 4; byte_idx++) {
+                uint8_t y_val = (packed_y >> (byte_idx * 8)) & 0xFF;
+                if (!y_coords.empty()) {
+                    y_coords += ", ";
+                }
+                y_coords += std::to_string(y_val);
+            }
+            packed_values_str += "NOC_Y[" + y_coords + "]";
+        } else {
+            packed_values_str += std::to_string(args_out[i]);
+        }
+    }
+
+    // Extract and format NOC coordinates as (x, y) pairs
+    std::string noc_pairs_str;
+    if (noc_x_idx < args_out.size() && noc_y_idx < args_out.size()) {
+        uint32_t packed_x = args_out[noc_x_idx];
+        uint32_t packed_y = args_out[noc_y_idx];
+
+        for (uint32_t byte_idx = 0; byte_idx < num_downstream_edms && byte_idx < 4; byte_idx++) {
+            uint8_t x_val = (packed_x >> (byte_idx * 8)) & 0xFF;
+            uint8_t y_val = (packed_y >> (byte_idx * 8)) & 0xFF;
+
+            if (!noc_pairs_str.empty()) {
+                noc_pairs_str += ", ";
+            }
+            noc_pairs_str += "(" + std::to_string(x_val) + "," + std::to_string(y_val) + ")";
+        }
+    }
+
+    log_info(
+        tt::LogFabric,
+        "pack_inbound_channel_rt_args: VC={}, EDM_direction={}, num_packed_args={}, packed_values=[{}], "
+        "NOC_coords=[{}]",
+        vc_idx,
+        direction_to_string(this->my_direction),
+        num_packed_args,
+        packed_values_str,
+        noc_pairs_str);
 }
 
 void StaticSizedChannelConnectionWriterAdapter::pack_adaptor_to_relay_rt_args(std::vector<uint32_t>& args_out) const {
@@ -192,9 +292,15 @@ void StaticSizedChannelConnectionWriterAdapter::pack_adaptor_to_relay_rt_args(st
     }
 }
 
-uint32_t StaticSizedChannelConnectionWriterAdapter::get_downstream_edms_connected() const {
-    return this->downstream_edms_connected;
-}
+// uint32_t StaticSizedChannelConnectionWriterAdapter::get_downstream_edms_connected() const {
+//     // Return combined mask for backward compatibility (sum of all VC masks)
+//     // Note: This may not be accurate if multiple VCs have overlapping compact indices
+//     uint32_t combined = 0;
+//     for (size_t vc_idx = 0; vc_idx < builder_config::num_max_receiver_channels; vc_idx++) {
+//         combined |= this->downstream_edms_connected_by_vc_mask.at(vc_idx);
+//     }
+//     return combined;
+// }
 
 uint32_t StaticSizedChannelConnectionWriterAdapter::pack_downstream_noc_y_rt_arg(uint32_t vc_idx) const {
     return encode_noc_ord_for_2d(
@@ -233,15 +339,26 @@ uint32_t StaticSizedChannelConnectionWriterAdapter::encode_noc_ord_for_2d(
     }
 }
 
-void StaticSizedChannelConnectionWriterAdapter::emit_ct_args(std::vector<uint32_t>& ct_args_out, size_t num_fwd_paths) const {
+void StaticSizedChannelConnectionWriterAdapter::emit_ct_args(
+    std::vector<uint32_t>& ct_args_out, size_t /*num_fwd_paths*/) const {
+    // Always emit MAX_NUM_RECEIVER_CHANNELS elements (one per VC) to match device side array size
     ct_args_out.insert(
         ct_args_out.end(),
         this->downstream_sender_channels_num_buffers.begin(),
-        this->downstream_sender_channels_num_buffers.begin() + num_fwd_paths);
+        this->downstream_sender_channels_num_buffers.begin() + builder_config::num_max_receiver_channels);
+    log_debug(LogFabric, "downstream_sender_channels_num_buffers:");
+    for (size_t i = 0; i < this->downstream_sender_channels_num_buffers.size(); ++i) {
+        log_debug(LogFabric, "  [{}]: {}", i, this->downstream_sender_channels_num_buffers[i]);
+    }
 
-    for (size_t i = 0; i < num_fwd_paths; i++) {
-        if (this->downstream_edms_connected_by_vc_set.find(i) != this->downstream_edms_connected_by_vc_set.end()) {
-            TT_FATAL(this->downstream_sender_channels_num_buffers[i] != 0, "Downstream sender channels num buffers must be greater than 0 for vc_idx: {}", i);
+    // Validate that all connected VCs have non-zero buffer counts
+    // downstream_sender_channels_num_buffers is indexed by VC (receiver channel), not by sender channel
+    for (size_t vc_idx = 0; vc_idx < builder_config::num_max_receiver_channels; vc_idx++) {
+        if (this->downstream_edms_connected_by_vc_set.find(vc_idx) != this->downstream_edms_connected_by_vc_set.end()) {
+            TT_FATAL(
+                this->downstream_sender_channels_num_buffers[vc_idx] != 0,
+                "Downstream sender channels num buffers must be greater than 0 for vc_idx: {}",
+                vc_idx);
         }
     }
 }

--- a/tt_metal/fabric/builder/static_sized_channel_connection_writer_adapter.cpp
+++ b/tt_metal/fabric/builder/static_sized_channel_connection_writer_adapter.cpp
@@ -106,9 +106,8 @@ void StaticSizedChannelConnectionWriterAdapter::pack_inbound_channel_rt_args(
         if (vc_idx == 0) {
             num_downstream_edms = builder_config::get_vc0_downstream_edm_count(is_2D_routing);
         } else {
-            // VC1: Use actual connection count (3 for XY, 4 for Z)
-            // This is safe because VC1 channels are only created when intermesh is configured
-            num_downstream_edms = downstream_edms_connected_by_vc[vc_idx].size();
+            // VC1: Use fixed count based on 2D routing (3 for XY, 4 for Z intermesh)
+            num_downstream_edms = builder_config::get_vc1_downstream_edm_count(is_2D_routing);
         }
 
         // Pack connection mask (bit mask indicating which slots are valid)

--- a/tt_metal/fabric/builder/static_sized_channel_connection_writer_adapter.cpp
+++ b/tt_metal/fabric/builder/static_sized_channel_connection_writer_adapter.cpp
@@ -8,21 +8,8 @@
 #include "tt_metal/fabric/fabric_context.hpp"
 #include "tt_metal/fabric/fabric_builder_context.hpp"
 #include "tt_metal/fabric/fabric_tensix_builder.hpp"
-#include <tt-logger/tt-logger.hpp>
 
 namespace tt::tt_fabric {
-
-namespace {
-const char* direction_to_string(eth_chan_directions direction) {
-    switch (direction) {
-        case eth_chan_directions::EAST: return "EAST";
-        case eth_chan_directions::WEST: return "WEST";
-        case eth_chan_directions::NORTH: return "NORTH";
-        case eth_chan_directions::SOUTH: return "SOUTH";
-        default: return "UNKNOWN";
-    }
-}
-}  // namespace
 
 StaticSizedChannelConnectionWriterAdapter::StaticSizedChannelConnectionWriterAdapter(
     FabricStaticSizedChannelsAllocator& /*allocator*/,
@@ -111,15 +98,12 @@ void StaticSizedChannelConnectionWriterAdapter::pack_inbound_channel_rt_args(
     //
     // Because of this constraint, the standard packing path (which stores one buffer address per VC)
     // is sufficient for all connection types, including multi-target scenarios.
-    // Record the starting size to track what we're adding
-    size_t args_start_size = args_out.size();
     if (is_2D_routing) {
         // For 2D: Use fixed slot count based on VC (kernel expects fixed-size arrays)
         // VC0: 3 slots (mesh directions)
         // VC1: 3 slots (XY intermesh) or 4 slots (Z intermesh) - determined by actual connections
         size_t num_downstream_edms;
         if (vc_idx == 0) {
-            // This should probably also be based on the actual connection count
             num_downstream_edms = builder_config::get_vc0_downstream_edm_count(is_2D_routing);
         } else {
             // VC1: Use actual connection count (3 for XY, 4 for Z)
@@ -174,90 +158,6 @@ void StaticSizedChannelConnectionWriterAdapter::pack_inbound_channel_rt_args(
         args_out.reserve(args_out.size() + rt_args.size());
         std::copy(rt_args.begin(), rt_args.end(), std::back_inserter(args_out));
     }
-
-    // Log the packed runtime arguments
-    size_t num_packed_args = args_out.size() - args_start_size;
-    std::string packed_values_str;
-
-    // Calculate indices for NOC X and Y based on routing type
-    size_t noc_x_idx = 0;
-    size_t noc_y_idx = 0;
-    uint32_t num_downstream_edms = 0;
-
-    if (is_2D_routing) {
-        num_downstream_edms = (vc_idx == 0) ? builder_config::get_vc0_downstream_edm_count(is_2D_routing)
-                                            : builder_config::get_vc1_downstream_edm_count(is_2D_routing);
-        // Structure: [mask(1), buffer_addrs(num_downstream_edms), noc_x(1), noc_y(1), ...]
-        noc_x_idx = args_start_size + 1 + num_downstream_edms;
-        noc_y_idx = args_start_size + 2 + num_downstream_edms;
-    } else {
-        // Structure: [has_connection(1), buffer_addr(1), noc_x(1), noc_y(1), ...]
-        noc_x_idx = args_start_size + 2;
-        noc_y_idx = args_start_size + 3;
-        num_downstream_edms = 1;  // 1D routing has single downstream EDM
-    }
-
-    for (size_t i = args_start_size; i < args_out.size(); i++) {
-        if (i > args_start_size) {
-            packed_values_str += ", ";
-        }
-
-        // Special formatting for NOC X and Y coordinates
-        if (i == noc_x_idx) {
-            // Extract 8-bit values from packed NOC X (one byte per downstream EDM)
-            uint32_t packed_x = args_out[i];
-            std::string x_coords;
-            for (uint32_t byte_idx = 0; byte_idx < num_downstream_edms && byte_idx < 4; byte_idx++) {
-                uint8_t x_val = (packed_x >> (byte_idx * 8)) & 0xFF;
-                if (!x_coords.empty()) {
-                    x_coords += ", ";
-                }
-                x_coords += std::to_string(x_val);
-            }
-            packed_values_str += "NOC_X[" + x_coords + "]";
-        } else if (i == noc_y_idx) {
-            // Extract 8-bit values from packed NOC Y (one byte per downstream EDM)
-            uint32_t packed_y = args_out[i];
-            std::string y_coords;
-            for (uint32_t byte_idx = 0; byte_idx < num_downstream_edms && byte_idx < 4; byte_idx++) {
-                uint8_t y_val = (packed_y >> (byte_idx * 8)) & 0xFF;
-                if (!y_coords.empty()) {
-                    y_coords += ", ";
-                }
-                y_coords += std::to_string(y_val);
-            }
-            packed_values_str += "NOC_Y[" + y_coords + "]";
-        } else {
-            packed_values_str += std::to_string(args_out[i]);
-        }
-    }
-
-    // Extract and format NOC coordinates as (x, y) pairs
-    std::string noc_pairs_str;
-    if (noc_x_idx < args_out.size() && noc_y_idx < args_out.size()) {
-        uint32_t packed_x = args_out[noc_x_idx];
-        uint32_t packed_y = args_out[noc_y_idx];
-
-        for (uint32_t byte_idx = 0; byte_idx < num_downstream_edms && byte_idx < 4; byte_idx++) {
-            uint8_t x_val = (packed_x >> (byte_idx * 8)) & 0xFF;
-            uint8_t y_val = (packed_y >> (byte_idx * 8)) & 0xFF;
-
-            if (!noc_pairs_str.empty()) {
-                noc_pairs_str += ", ";
-            }
-            noc_pairs_str += "(" + std::to_string(x_val) + "," + std::to_string(y_val) + ")";
-        }
-    }
-
-    log_info(
-        tt::LogFabric,
-        "pack_inbound_channel_rt_args: VC={}, EDM_direction={}, num_packed_args={}, packed_values=[{}], "
-        "NOC_coords=[{}]",
-        vc_idx,
-        direction_to_string(this->my_direction),
-        num_packed_args,
-        packed_values_str,
-        noc_pairs_str);
 }
 
 void StaticSizedChannelConnectionWriterAdapter::pack_adaptor_to_relay_rt_args(std::vector<uint32_t>& args_out) const {
@@ -291,16 +191,6 @@ void StaticSizedChannelConnectionWriterAdapter::pack_adaptor_to_relay_rt_args(st
         std::copy(relay_rt_args.begin(), relay_rt_args.end(), std::back_inserter(args_out));
     }
 }
-
-// uint32_t StaticSizedChannelConnectionWriterAdapter::get_downstream_edms_connected() const {
-//     // Return combined mask for backward compatibility (sum of all VC masks)
-//     // Note: This may not be accurate if multiple VCs have overlapping compact indices
-//     uint32_t combined = 0;
-//     for (size_t vc_idx = 0; vc_idx < builder_config::num_max_receiver_channels; vc_idx++) {
-//         combined |= this->downstream_edms_connected_by_vc_mask.at(vc_idx);
-//     }
-//     return combined;
-// }
 
 uint32_t StaticSizedChannelConnectionWriterAdapter::pack_downstream_noc_y_rt_arg(uint32_t vc_idx) const {
     return encode_noc_ord_for_2d(
@@ -346,10 +236,6 @@ void StaticSizedChannelConnectionWriterAdapter::emit_ct_args(
         ct_args_out.end(),
         this->downstream_sender_channels_num_buffers.begin(),
         this->downstream_sender_channels_num_buffers.begin() + builder_config::num_max_receiver_channels);
-    log_debug(LogFabric, "downstream_sender_channels_num_buffers:");
-    for (size_t i = 0; i < this->downstream_sender_channels_num_buffers.size(); ++i) {
-        log_debug(LogFabric, "  [{}]: {}", i, this->downstream_sender_channels_num_buffers[i]);
-    }
 
     // Validate that all connected VCs have non-zero buffer counts
     // downstream_sender_channels_num_buffers is indexed by VC (receiver channel), not by sender channel

--- a/tt_metal/fabric/compute_mesh_router_builder.cpp
+++ b/tt_metal/fabric/compute_mesh_router_builder.cpp
@@ -131,7 +131,6 @@ std::unique_ptr<ComputeMeshRouterBuilder> ComputeMeshRouterBuilder::build(
     // Compute actual per-VC channel counts for this router
     std::array<std::size_t, builder_config::MAX_NUM_VCS> actual_sender_channels_per_vc{};
     std::array<std::size_t, builder_config::MAX_NUM_VCS> actual_receiver_channels_per_vc{};
-
     for (uint32_t vc = 0; vc < num_vcs; ++vc) {
         actual_sender_channels_per_vc[vc] = channel_mapping.get_num_sender_channels_for_vc(vc);
         actual_receiver_channels_per_vc[vc] = 1;  // Always 1 receiver per VC (when VC exists)
@@ -184,162 +183,6 @@ std::unique_ptr<ComputeMeshRouterBuilder> ComputeMeshRouterBuilder::build(
 
     return router_builder;
 }
-
-// void ComputeMeshRouterBuilder::connect_to_downstream_router_over_noc(ComputeMeshRouterBuilder& other, uint32_t vc) {
-//     auto connect_vc = [&](uint32_t upstream_vc_index,
-//                           uint32_t downstream_vc_index,
-//                           FabricDatamoverBuilderBase* downstream_builder,
-//                           uint32_t logical_sender_channel_idx) {
-//         log_debug(
-//             tt::LogTest,
-//             "Router at x={}, y={}, Direction={}, FabricNodeId={} :: Connecting VC{} to downstream router VC{} at x={}, "
-//             "y={}, Direction={}",
-//             get_noc_x(),
-//             get_noc_y(),
-//             get_eth_direction(),
-//             local_node_,
-//             upstream_vc_index,
-//             downstream_vc_index,
-//             downstream_builder->get_noc_x(),
-//             downstream_builder->get_noc_y(),
-//             downstream_builder->get_direction());
-
-//         // auto send_chan = get_sender_channel(is_2D_routing, this->get_direction(), vc_index);
-//         auto downstream_mapping =
-//             other.channel_mapping_.get_sender_mapping(downstream_vc_index, logical_sender_channel_idx);
-//         uint32_t internal_channel_id = downstream_mapping.internal_sender_channel_id;
-
-//         // Need to call the templated method with the correct derived type
-//         // NOTE: erisc_builder_ is hardcoded here because there is currently no scenario where tensix forwards to tensix
-//         //       however when that is enabled, this code should be updated to point to the src builder dynamically
-//         if (auto* downstream_erisc_builder = dynamic_cast<FabricEriscDatamoverBuilder*>(downstream_builder)) {
-//             erisc_builder_->setup_downstream_vc_connection(
-//                 downstream_erisc_builder, upstream_vc_index, downstream_vc_index, internal_channel_id);
-//         } else if (auto* downstream_tensix_builder = dynamic_cast<FabricTensixDatamoverBuilder*>(downstream_builder)) {
-//             erisc_builder_->setup_downstream_vc_connection(
-//                 downstream_tensix_builder, upstream_vc_index, downstream_vc_index, internal_channel_id);
-//         }
-//     };
-
-//     auto get_downstream_builder_for_vc = [&](uint32_t vc_index,
-//                                              uint32_t sender_channel_idx) -> FabricDatamoverBuilderBase* {
-//         auto mapping = other.channel_mapping_.get_sender_mapping(vc_index, sender_channel_idx);
-
-//         if (mapping.builder_type == BuilderType::TENSIX) {
-//             TT_FATAL(
-//                 other.tensix_builder_.has_value(),
-//                 "Channel mapping requires TENSIX builder for VC{} channel {}, but tensix builder not present",
-//                 vc_index,
-//                 sender_channel_idx);
-//             return &other.tensix_builder_.value();
-//         } else {
-//             return other.erisc_builder_.get();
-//         }
-//     };
-
-//     const auto& fabric_context = tt::tt_metal::MetalContext::instance().get_control_plane().get_fabric_context();
-//     const bool is_2D_routing = fabric_context.is_2D_routing_enabled();
-
-//     if (vc == 0) {
-//         TT_FATAL(
-//             !erisc_builder_->build_in_worker_connection_mode,
-//             "Tried to connect router to downstream in worker connection mode");
-
-//         // Helper to get the downstream builder for a specific VC based on channel mapping
-//         uint32_t sender_channel_idx = get_downstream_sender_channel(is_2D_routing, other.get_eth_direction());
-
-//         // Special case: Inter-mesh router VC0 crosses over to downstream intra-mesh router VC1
-//         // This routes inter-mesh traffic into the appropriate VC on the intra-mesh side
-//         bool is_inter_to_intra_crossover = erisc_builder_->isInterMesh && !other.erisc_builder_->isInterMesh;
-
-//         if (is_inter_to_intra_crossover && is_2D_routing) {
-//             // Inter-mesh VC0 receiver → Intra-mesh VC1 sender
-//             // Map VC0 sender channels 1-3 to VC1 logical channels 0-2
-//             TT_FATAL(
-//                 sender_channel_idx >= 1 && sender_channel_idx <= 3,
-//                 "Inter-mesh router VC0 sender channel {} invalid for crossover to intra-mesh VC1. Expected 1-3.",
-//                 sender_channel_idx);
-//             uint32_t vc1_logical_channel_idx = sender_channel_idx - 1;
-//             log_info(
-//                 tt::LogFabric,
-//                 "Inter-mesh to intra-mesh crossover: upstream VC0 → downstream VC1 (VC0 ch{} → VC1 ch{})",
-//                 sender_channel_idx,
-//                 vc1_logical_channel_idx);
-//             // Pass upstream_vc=0, downstream_vc=1 for crossover
-//             connect_vc(0, 1, get_downstream_builder_for_vc(1, vc1_logical_channel_idx), vc1_logical_channel_idx);
-//         } else {
-//             // Normal VC0 → VC0 connection
-//             connect_vc(0, 0, get_downstream_builder_for_vc(0, sender_channel_idx), sender_channel_idx);
-//         }
-//     } else if (vc == 1) {
-//         // VC1 is only needed for 2D routing
-//         if (!is_2D_routing) {
-//             log_debug(tt::LogFabric, "VC1 not needed (1D routing), skipping VC1 connection setup");
-//             return;
-//         }
-
-//         // Inter-mesh routers don't have VC1 (they only have VC0)
-//         if (erisc_builder_->isInterMesh) {
-//             log_debug(tt::LogFabric, "VC1 not needed (inter-mesh router has no VC1), skipping VC1 connection setup");
-//             return;
-//         }
-
-//         // Intra-mesh VC1 does not connect to inter-mesh routers (inter-mesh uses VC0 only)
-//         if (other.erisc_builder_->isInterMesh) {
-//             log_debug(
-//                 tt::LogFabric,
-//                 "VC1 not needed (downstream is inter-mesh router, no VC1 on inter-mesh), skipping VC1 connection "
-//                 "setup");
-//             return;
-//         }
-
-//         // Check if VC1 is actually configured (multi-mesh topology)
-//         bool needs_vc1 = erisc_builder_->config.num_used_receiver_channels_per_vc[1] > 0;
-//         if (!needs_vc1) {
-//             log_debug(tt::LogFabric, "VC1 not configured (single-mesh topology), skipping VC1 connection setup");
-//             return;
-//         }
-
-//         TT_FATAL(
-//             !erisc_builder_->build_in_worker_connection_mode,
-//             "Tried to connect router to downstream in worker connection mode");
-
-//         // For VC1, use the same logical channel mapping as VC0
-//         // VC1 uses logical channels 0-2 (which map to physical channels 4-6) for inter-mesh routing
-//         // The channel mapping uses logical indices within each VC, so we use the same relative index
-//         // as VC0 (1-3) but map to VC1 logical channels (0-2)
-//         // VC0 channel 1-3 correspond to VC1 channels 0-2 for inter-mesh
-//         uint32_t vc0_sender_channel_idx = get_downstream_sender_channel(is_2D_routing, other.get_eth_direction());
-//         // VC0 channels 1-3 map to VC1 logical channels 0-2 (subtract 1)
-//         // VC0 channel 0 (worker) doesn't exist in VC1
-//         TT_FATAL(
-//             vc0_sender_channel_idx >= 1 && vc0_sender_channel_idx <= 3,
-//             "VC0 sender channel {} is invalid for VC1 mapping. VC1 only supports channels 1-3 from VC0 (mapped to VC1 "
-//             "logical channels 0-2).",
-//             vc0_sender_channel_idx);
-//         uint32_t vc1_logical_channel_idx = vc0_sender_channel_idx - 1;  // Map VC0 [1-3] to VC1 [0-2]
-
-//         // Connect VC1 → VC1 (normal intra-mesh connection)
-//         connect_vc(1, 1, get_downstream_builder_for_vc(1, vc1_logical_channel_idx), vc1_logical_channel_idx);
-//     }
-// }
-
-// SenderWorkerAdapterSpec ComputeMeshRouterBuilder::build_connection_to_fabric_channel(
-//     uint32_t vc, uint32_t sender_channel_idx) {
-//     // This method returns connection info for a sender channel, which can be used by
-//     // downstream routers to connect to this sender channel
-//     auto sender_mapping = channel_mapping_.get_sender_mapping(vc, sender_channel_idx);
-
-//     if (sender_mapping.builder_type == BuilderType::ERISC) {
-//         // Pass VC and VC-relative channel ID to translate to absolute sender channel index
-//         return erisc_builder_->build_connection_to_fabric_channel(vc, sender_mapping.internal_sender_channel_id);
-//     } else if (sender_mapping.builder_type == BuilderType::TENSIX) {
-//         TT_FATAL(tensix_builder_.has_value(), "Tensix builder not available but mapping requires it");
-//         return tensix_builder_->build_connection_to_fabric_channel(sender_mapping.internal_sender_channel_id);
-//     } else {
-//         TT_FATAL(false, "Unknown builder type");
-//     }
-// }
 
 uint32_t ComputeMeshRouterBuilder::get_downstream_sender_channel(
     const bool is_2D_routing, const eth_chan_directions downstream_direction) const {
@@ -548,22 +391,9 @@ void ComputeMeshRouterBuilder::establish_connections_to_router(
         }
 
         uint32_t num_senders = channel_mapping_.get_num_sender_channels_for_vc(vc);
-        log_info(
-            tt::LogFabric,
-            "Router NodeId={} VC={} has {} sender channels",
-            local_node_,
-            vc,
-            num_senders);
 
         for (uint32_t sender_ch = 0; sender_ch < num_senders; ++sender_ch) {
             auto targets = connection_mapping_.get_downstream_targets(vc, sender_ch);
-            log_info(
-                tt::LogFabric,
-                "Router NodeId={} VC={} sender_ch={} has {} targets",
-                local_node_,
-                vc,
-                sender_ch,
-                targets.size());
 
             for (const auto& target : targets) {
                 // Apply connection type filter
@@ -598,12 +428,6 @@ void ComputeMeshRouterBuilder::establish_connections_to_router(
                         "VC0 sender channel {} is invalid for VC1 mapping. Expected 1-3.",
                         actual_target_sender_channel);
                     actual_target_sender_channel -= 1;  // Map VC0 [1-3] to VC1 [0-2]
-                    log_info(
-                        tt::LogFabric,
-                        "Adjusted sender channel for VC1: upstream VC={} → downstream VC={} ch={}",
-                        upstream_vc,
-                        downstream_vc,
-                        actual_target_sender_channel);
                 }
 
                 // Get target builder using the adjusted sender channel
@@ -617,15 +441,10 @@ void ComputeMeshRouterBuilder::establish_connections_to_router(
 
                 // Setup producer → consumer connection
                 if (auto* downstream_erisc_builder = dynamic_cast<FabricEriscDatamoverBuilder*>(downstream_builder)) {
-                    // log_info(
-                    //     tt::LogFabric,
-                    //     "Setting up downstream VC connection: upstream VC={} → downstream VC={} → internal channel={}",
-                    //     upstream_vc,
-                    //     downstream_vc,
-                    //     internal_channel_id);
                     erisc_builder_->setup_downstream_vc_connection(
                         downstream_erisc_builder, upstream_vc, downstream_vc, internal_channel_id);
-                } else if (auto* downstream_tensix_builder = dynamic_cast<FabricTensixDatamoverBuilder*>(downstream_builder)) {
+                } else if (
+                    auto* downstream_tensix_builder = dynamic_cast<FabricTensixDatamoverBuilder*>(downstream_builder)) {
                     erisc_builder_->setup_downstream_vc_connection(
                         downstream_tensix_builder, upstream_vc, downstream_vc, internal_channel_id);
                 }
@@ -649,7 +468,7 @@ void ComputeMeshRouterBuilder::establish_connections_to_router(
                     connection_registry_->record_connection(record);
                 }
 
-                log_info(
+                log_debug(
                     tt::LogTest,
                     "Router at x={}, y={}, Direction={}, FabricNodeId={} :: Connecting VC{} sender_ch={} to downstream "
                     "router at x={}, y={}, Direction={}, VC{}, internal_ch={}",

--- a/tt_metal/fabric/compute_mesh_router_builder.cpp
+++ b/tt_metal/fabric/compute_mesh_router_builder.cpp
@@ -395,11 +395,8 @@ void ComputeMeshRouterBuilder::establish_connections_to_router(
         uint32_t internal_channel_id = downstream_mapping.internal_sender_channel_id;
 
         // Setup producer → consumer connection
-        if (auto* downstream_erisc_builder = dynamic_cast<FabricEriscDatamoverBuilder*>(downstream_builder)) {
-            erisc_builder_->setup_downstream_vc_connection(downstream_erisc_builder, vc, vc, internal_channel_id);
-        } else if (auto* downstream_tensix_builder = dynamic_cast<FabricTensixDatamoverBuilder*>(downstream_builder)) {
-            erisc_builder_->setup_downstream_vc_connection(downstream_tensix_builder, vc, vc, internal_channel_id);
-        }
+        // setup_downstream_vc_connection handles type checking internally
+        erisc_builder_->setup_downstream_vc_connection(downstream_builder, vc, vc, internal_channel_id);
         // Record connection in registry if present
         if (connection_registry_) {
             RouterConnectionRecord record{

--- a/tt_metal/fabric/compute_mesh_router_builder.hpp
+++ b/tt_metal/fabric/compute_mesh_router_builder.hpp
@@ -190,6 +190,7 @@ private:
     FabricRouterChannelMapping channel_mapping_;
     RouterConnectionMapping connection_mapping_;
     std::shared_ptr<ConnectionRegistry> connection_registry_;
+    bool is_inter_mesh_;  // True if this router connects different meshes
 };
 
 }  // namespace tt::tt_fabric

--- a/tt_metal/fabric/compute_mesh_router_builder.hpp
+++ b/tt_metal/fabric/compute_mesh_router_builder.hpp
@@ -76,7 +76,8 @@ public:
      */
     SenderWorkerAdapterSpec build_connection_to_fabric_channel(uint32_t vc, uint32_t sender_channel_idx);
 
-    uint32_t get_downstream_sender_channel(bool is_2D_routing, eth_chan_directions downstream_direction) const;
+    uint32_t get_downstream_sender_channel(
+        bool is_2D_routing, eth_chan_directions downstream_direction, uint32_t vc) const;
 
     eth_chan_directions get_eth_direction() const;
     size_t get_noc_x() const;

--- a/tt_metal/fabric/erisc_datamover_builder.cpp
+++ b/tt_metal/fabric/erisc_datamover_builder.cpp
@@ -1435,40 +1435,6 @@ SenderWorkerAdapterSpec FabricEriscDatamoverBuilder::build_connection_to_fabric_
     return build_connection_to_fabric_channel(0, channel_id);  // Default to VC0
 }
 
-// Internal implementation for connect_to_downstream_edm
-// Note: this can be deleted after fabric latency tests are ported to new test infrastructure
-// void FabricEriscDatamoverBuilder::connect_to_downstream_edm_impl(FabricDatamoverBuilderBase* downstream_builder) {
-//     TT_FATAL(
-//         !this->build_in_worker_connection_mode, "Tried to connect EDM to downstream builder in worker connection
-//         mode");
-
-//     eth_chan_directions ds_dir = downstream_builder->get_direction();
-
-//     log_debug(
-//         tt::LogTest,
-//         "EDM at x={}, y={}, Direction={}, FabricNodeId={} :: Connecting to downstream EDM at x={}, y={}, "
-//         "Direction={}",
-//         this->get_noc_x(),
-//         this->get_noc_y(),
-//         this->get_direction(),
-//         local_fabric_node_id,
-//         downstream_builder->get_noc_x(),
-//         downstream_builder->get_noc_y(),
-//         ds_dir);
-
-//     const auto& fabric_context = tt::tt_metal::MetalContext::instance().get_control_plane().get_fabric_context();
-//     const bool is_2D_routing = fabric_context.is_2D_routing_enabled();
-
-//     // Setup VC0 connection
-//     constexpr uint32_t ds_vc0_index = 0;
-//     auto ds_vc0_send_chan = get_downstream_edm_sender_channel(is_2D_routing, this->get_direction(), ds_dir);
-//     setup_downstream_vc_connection(downstream_builder, ds_vc0_index, ds_vc0_send_chan);
-// }
-
-// void FabricEriscDatamoverBuilder::connect_to_downstream_edm(FabricDatamoverBuilderBase* downstream_builder) {
-//     connect_to_downstream_edm_impl(downstream_builder);
-// }
-
 // TODO: take the downstream sender channel, based on the VC index, and use it to construct our
 // `to_sender_channel_adapter` The `to_sender_channel_adapter` type is resolved based on the type of the downstream
 // sender channel it is connecting to.

--- a/tt_metal/fabric/erisc_datamover_builder.cpp
+++ b/tt_metal/fabric/erisc_datamover_builder.cpp
@@ -959,8 +959,8 @@ std::vector<uint32_t> FabricEriscDatamoverBuilder::get_compile_time_args(uint32_
     uint32_t num_vc0_downstream_edms = builder_config::get_vc0_downstream_edm_count(is_2D_routing);
 
     // Determine NUM_VCS: 2 if VC1 runtime args are being passed, otherwise 1
-    // VC1 runtime args are passed when VC1 is needed (2D routing AND not an inter-mesh router)
-    bool needs_vc1 = config.num_used_receiver_channels_per_vc[1] > 0 && !isInterMesh;
+    // VC1 runtime args are passed when VC1 is configured (both inter-mesh and intra-mesh have VC1)
+    bool needs_vc1 = config.num_used_receiver_channels_per_vc[1] > 0;
 
     // Get the VC1 downstream EDM count (only relevant for multi-mesh 2D routing)
     uint32_t num_vc1_downstream_edms =
@@ -1176,9 +1176,9 @@ std::vector<uint32_t> FabricEriscDatamoverBuilder::get_runtime_args() const {
     // Pack VC0 runtime args
     receiver_channel_to_downstream_adapter->pack_inbound_channel_rt_args(0, rt_args);
 
-    // Pack VC1 runtime args if VC1 is needed (2D routing AND not an inter-mesh router)
-    // VC1 connections are only made for intra-mesh routers in multi-mesh topologies
-    bool needs_vc1 = config.num_used_receiver_channels_per_vc[1] > 0 && !isInterMesh;
+    // Pack VC1 runtime args if VC1 is configured
+    // Both inter-mesh and intra-mesh routers have VC1 in multi-mesh topologies
+    bool needs_vc1 = config.num_used_receiver_channels_per_vc[1] > 0;
     if (needs_vc1) {
         receiver_channel_to_downstream_adapter->pack_inbound_channel_rt_args(1, rt_args);
     }
@@ -1498,12 +1498,8 @@ void FabricEriscDatamoverBuilder::setup_downstream_vc_connection(
         TT_FATAL(is_2D_routing, "VC1 is only supported for 2D routing");
     }
 
-    // Validate upstream VC1 usage (only intra-mesh routers have VC1 receiver)
+    // Validate upstream VC1 usage
     if (upstream_vc_idx == 1) {
-        TT_FATAL(
-            !isInterMesh,
-            "Upstream VC1 connections require intra-mesh router (inter-mesh has no VC1 receiver). Got isInterMesh: {}",
-            isInterMesh);
         TT_FATAL(
             config.num_used_receiver_channels_per_vc[1] > 0,
             "VC1 receiver channels not configured on upstream router.");

--- a/tt_metal/fabric/erisc_datamover_builder.cpp
+++ b/tt_metal/fabric/erisc_datamover_builder.cpp
@@ -1383,7 +1383,8 @@ SenderWorkerAdapterSpec FabricEriscDatamoverBuilder::build_connection_to_fabric_
         vc);
 
     // Convert to VC-relative for allocator calls (which expect VC-relative indices)
-    uint32_t vc0_sender_count = is_2D_routing ? 4 : 2;
+    uint32_t vc0_sender_count =
+        is_2D_routing ? builder_config::num_sender_channels_2d_mesh : builder_config::num_sender_channels_1d_linear;
     uint32_t vc_relative_channel_id = 0;
 
     if (vc == 0) {
@@ -1395,7 +1396,7 @@ SenderWorkerAdapterSpec FabricEriscDatamoverBuilder::build_connection_to_fabric_
             vc0_sender_count);
     } else if (vc == 1) {
         vc_relative_channel_id = ds_edm - vc0_sender_count;  // VC1: subtract VC0 channels (4-6 → 0-2)
-        uint32_t vc1_sender_count = is_2D_routing ? 3 : 0;
+        uint32_t vc1_sender_count = is_2D_routing ? builder_config::num_downstream_edms_2d_vc1 : 0;
         TT_FATAL(
             vc_relative_channel_id < vc1_sender_count,
             "VC1 channel index {} exceeds maximum channels ({})",

--- a/tt_metal/fabric/erisc_datamover_builder.cpp
+++ b/tt_metal/fabric/erisc_datamover_builder.cpp
@@ -661,7 +661,7 @@ FabricEriscDatamoverBuilder::FabricEriscDatamoverBuilder(
     config(config),
     local_fabric_node_id(local_fabric_node_id),
     peer_fabric_node_id(peer_fabric_node_id),
-    isInterMesh(local_fabric_node_id.mesh_id != peer_fabric_node_id.mesh_id),
+    is_inter_mesh(local_fabric_node_id.mesh_id != peer_fabric_node_id.mesh_id),
     handshake_address(tt::round_up(
         tt::tt_metal::hal::get_erisc_l1_unreserved_base(), FabricEriscDatamoverConfig::eth_channel_sync_size)),
     channel_buffer_size(config.channel_buffer_size_bytes),
@@ -977,7 +977,7 @@ std::vector<uint32_t> FabricEriscDatamoverBuilder::get_compile_time_args(uint32_
         static_cast<uint32_t>(this->firmware_context_switch_interval),
         this->fuse_receiver_flush_and_completion_ptr,
         fabric_context.need_deadlock_avoidance_support(this->direction_),
-        this->isInterMesh,  // Whether this router connects different meshes (determines VC crossover)
+        this->is_inter_mesh,  // Whether this router connects different meshes (determines VC crossover)
         is_handshake_master,
         static_cast<uint32_t>(this->handshake_address),
         static_cast<uint32_t>(this->channel_buffer_size),

--- a/tt_metal/fabric/erisc_datamover_builder.cpp
+++ b/tt_metal/fabric/erisc_datamover_builder.cpp
@@ -1272,24 +1272,6 @@ FabricEriscDatamoverBuilder FabricEriscDatamoverBuilder::build(
     auto remote_multi_pool_allocator = std::make_shared<tt::tt_fabric::MultiPoolChannelAllocator>(
         std::move(remote_pool_allocators), std::move(remote_pool_types));
 
-    if (local_fabric_node_id.mesh_id == peer_fabric_node_id.mesh_id) {
-        log_info(
-            tt::LogFabric,
-            "INTRAMESH: M={},D={} eth=(x={},y={})",
-            local_fabric_node_id.mesh_id.get(),
-            local_fabric_node_id.chip_id,
-            ethernet_core.x,
-            ethernet_core.y);
-    } else {
-        log_info(
-            tt::LogFabric,
-            "INTERMESH: M={},D={} eth=(x={},y={})",
-            local_fabric_node_id.mesh_id.get(),
-            local_fabric_node_id.chip_id,
-            ethernet_core.x,
-            ethernet_core.y);
-    }
-
     log_debug(
         tt::LogFabric,
         "FABRIC NODE ID: M={},D={} eth=(x={},y={})\n"
@@ -1391,7 +1373,7 @@ SenderWorkerAdapterSpec FabricEriscDatamoverBuilder::build_connection_to_fabric_
     // NOTE: ds_edm is an ABSOLUTE sender channel index (flattened across VCs)
     // It comes from internal_sender_channel_id in the mapping, which stores absolute indices
     uint32_t absolute_sender_channel_index = ds_edm;
-    
+
     // Validate absolute index
     TT_FATAL(
         absolute_sender_channel_index < builder_config::num_max_sender_channels,
@@ -1403,7 +1385,7 @@ SenderWorkerAdapterSpec FabricEriscDatamoverBuilder::build_connection_to_fabric_
     // Convert to VC-relative for allocator calls (which expect VC-relative indices)
     uint32_t vc0_sender_count = is_2D_routing ? 4 : 2;
     uint32_t vc_relative_channel_id = 0;
-    
+
     if (vc == 0) {
         vc_relative_channel_id = ds_edm;  // VC0: absolute == VC-relative
         TT_FATAL(

--- a/tt_metal/fabric/erisc_datamover_builder.cpp
+++ b/tt_metal/fabric/erisc_datamover_builder.cpp
@@ -982,7 +982,8 @@ std::vector<uint32_t> FabricEriscDatamoverBuilder::get_compile_time_args(uint32_
         static_cast<uint32_t>(this->handshake_address),
         static_cast<uint32_t>(this->channel_buffer_size),
         this->has_tensix_extension,
-        this->enable_first_level_ack,
+        this->enable_first_level_ack,  // VC0 first level ack (for Ring/Torus)
+        false,                         // VC1 first level ack (always false - VC1 doesn't use bubble flow control)
         enable_risc_cpu_data_cache};
 
     const std::vector<uint32_t> main_args_part2 = {

--- a/tt_metal/fabric/erisc_datamover_builder.hpp
+++ b/tt_metal/fabric/erisc_datamover_builder.hpp
@@ -504,7 +504,7 @@ public:
 
     FabricNodeId local_fabric_node_id = FabricNodeId(MeshId{0}, 0);
     FabricNodeId peer_fabric_node_id = FabricNodeId(MeshId{0}, 0);
-    bool isInterMesh = false;  // True if this data mover connects to a different mesh (inter-mesh router)
+    bool is_inter_mesh = false;  // True if this data mover connects to a different mesh (inter-mesh router)
     size_t handshake_address = 0;
     size_t channel_buffer_size = 0;
 

--- a/tt_metal/fabric/fabric_builder_context.cpp
+++ b/tt_metal/fabric/fabric_builder_context.cpp
@@ -197,15 +197,23 @@ IntermeshVCConfig FabricBuilderContext::compute_intermesh_vc_config() const {
         return IntermeshVCConfig::disabled();
     }
 
-    // Check if intermesh connections exist
-    const auto& intermesh_connections = mesh_graph.get_requested_intermesh_connections();
-    if (intermesh_connections.empty()) {
+    // Check if intermesh connections exist (use inter_mesh_connectivity which has actual parsed connections)
+    const auto& inter_mesh_connectivity = mesh_graph.get_inter_mesh_connectivity();
+
+    // Count total intermesh connections across all meshes
+    size_t total_intermesh_connections = 0;
+    for (const auto& mesh_connections : inter_mesh_connectivity) {
+        for (const auto& chip_connections : mesh_connections) {
+            total_intermesh_connections += chip_connections.size();
+        }
+    }
+
+    if (total_intermesh_connections == 0) {
         return IntermeshVCConfig::disabled();
     }
 
     // Detect Z vs XY intermesh by checking for Z-direction connections in inter-mesh connectivity
     bool has_z_routers = false;
-    const auto& inter_mesh_connectivity = mesh_graph.get_inter_mesh_connectivity();
     for (const auto& mesh_connections : inter_mesh_connectivity) {
         for (const auto& chip_connections : mesh_connections) {
             for (const auto& [dst_mesh_id, router_edge] : chip_connections) {

--- a/tt_metal/fabric/fabric_router_channel_mapping.cpp
+++ b/tt_metal/fabric/fabric_router_channel_mapping.cpp
@@ -108,6 +108,7 @@ void FabricRouterChannelMapping::initialize_vc1_mappings() {
             constexpr uint32_t mesh_vc1_base_sender_channel = builder_config::num_sender_channels_2d_mesh;
             constexpr uint32_t mesh_vc1_receiver_channel = 1;
 
+            // TODO: Should these be VC relative? If so, we don't need to add the base sender channel.
             // Create sender channels (3 or 4 depending on router type)
             for (uint32_t i = 0; i < mesh_vc1_sender_count; ++i) {
                 sender_channel_map_[LogicalSenderChannelKey{1, i}] =

--- a/tt_metal/fabric/fabric_router_channel_mapping.cpp
+++ b/tt_metal/fabric/fabric_router_channel_mapping.cpp
@@ -149,13 +149,19 @@ InternalReceiverChannelMapping FabricRouterChannelMapping::get_receiver_mapping(
 
 uint32_t FabricRouterChannelMapping::get_num_virtual_channels() const {
     // Inter-mesh routers only have VC0 (no VC1 if not a pass through mode)
-    if (is_inter_mesh_router_ && intermesh_vc_config_ && intermesh_vc_config_->mode == IntermeshVCMode::FULL_MESH) {
-        return 1;  // Only VC0 for inter-mesh
+    if (intermesh_vc_config_ && intermesh_vc_config_->mode == IntermeshVCMode::FULL_MESH) {
+        if (is_inter_mesh_router_) {
+            // Inter-mesh routers only have VC0 (no VC1 if not a pass through mode)
+            return 1;
+        } else {
+            // Intra-mesh routers have VC0 and VC1
+            return 2;
+        }
     }
 
-    // Intra-mesh routers: expose VC1 if intermesh VC is required
-    if (intermesh_vc_config_ && intermesh_vc_config_->mode == IntermeshVCMode::FULL_MESH) {
-        return 2;  // VC0 + VC1 for intra-mesh in multi-mesh topology
+    // In pass through mode, all routers have VC0 and VC1
+    if (intermesh_vc_config_ && intermesh_vc_config_->mode == IntermeshVCMode::FULL_MESH_WITH_PASS_THROUGH) {
+        return 2;
     }
 
     return 1;  // VC0 only (single-mesh or 1D)

--- a/tt_metal/fabric/fabric_router_channel_mapping.cpp
+++ b/tt_metal/fabric/fabric_router_channel_mapping.cpp
@@ -109,7 +109,6 @@ void FabricRouterChannelMapping::initialize_vc1_mappings() {
             constexpr uint32_t mesh_vc1_base_sender_channel = builder_config::num_sender_channels_2d_mesh;
             constexpr uint32_t mesh_vc1_receiver_channel = 1;
 
-            // TODO: Should these be VC relative? If so, we don't need to add the base sender channel.
             // Create sender channels (3 or 4 depending on router type)
             for (uint32_t i = 0; i < mesh_vc1_sender_count; ++i) {
                 sender_channel_map_[LogicalSenderChannelKey{1, i}] =

--- a/tt_metal/fabric/fabric_router_channel_mapping.hpp
+++ b/tt_metal/fabric/fabric_router_channel_mapping.hpp
@@ -81,11 +81,7 @@ struct InternalReceiverChannelMapping {
 class FabricRouterChannelMapping {
 public:
     FabricRouterChannelMapping(
-        Topology topology,
-        bool has_tensix_extension,
-        RouterVariant variant,
-        const IntermeshVCConfig* intermesh_config,
-        bool is_inter_mesh_router = false);
+        Topology topology, bool has_tensix_extension, RouterVariant variant, const IntermeshVCConfig* intermesh_config);
 
     /**
      * Get the internal sender channel mapping for a logical sender channel
@@ -118,7 +114,6 @@ private:
     bool downstream_is_tensix_builder_;
     RouterVariant variant_;
     const IntermeshVCConfig* intermesh_vc_config_ = nullptr;
-    bool is_inter_mesh_router_ = false;
 
     std::map<LogicalSenderChannelKey, InternalSenderChannelMapping> sender_channel_map_;
     std::map<LogicalReceiverChannelKey, InternalReceiverChannelMapping> receiver_channel_map_;

--- a/tt_metal/fabric/fabric_router_channel_mapping.hpp
+++ b/tt_metal/fabric/fabric_router_channel_mapping.hpp
@@ -85,7 +85,7 @@ public:
         bool has_tensix_extension,
         RouterVariant variant,
         const IntermeshVCConfig* intermesh_config,
-        bool is_inter_mesh = false);
+        bool is_inter_mesh_router = false);
 
     /**
      * Get the internal sender channel mapping for a logical sender channel

--- a/tt_metal/fabric/fabric_router_channel_mapping.hpp
+++ b/tt_metal/fabric/fabric_router_channel_mapping.hpp
@@ -84,7 +84,8 @@ public:
         Topology topology,
         bool has_tensix_extension,
         RouterVariant variant,
-        const IntermeshVCConfig* intermesh_config);
+        const IntermeshVCConfig* intermesh_config,
+        bool is_inter_mesh = false);
 
     /**
      * Get the internal sender channel mapping for a logical sender channel
@@ -117,6 +118,7 @@ private:
     bool downstream_is_tensix_builder_;
     RouterVariant variant_;
     const IntermeshVCConfig* intermesh_vc_config_ = nullptr;
+    bool is_inter_mesh_router_ = false;
 
     std::map<LogicalSenderChannelKey, InternalSenderChannelMapping> sender_channel_map_;
     std::map<LogicalReceiverChannelKey, InternalReceiverChannelMapping> receiver_channel_map_;

--- a/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_router_ct_args.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_router_ct_args.hpp
@@ -155,10 +155,11 @@ constexpr size_t channel_buffer_size = get_compile_time_arg_val(MAIN_CT_ARGS_STA
 constexpr bool fabric_tensix_extension_mux_mode = get_compile_time_arg_val(MAIN_CT_ARGS_START_IDX + 7);
 constexpr bool skip_src_ch_id_update = fabric_tensix_extension_mux_mode;
 
-constexpr bool ENABLE_FIRST_LEVEL_ACK = get_compile_time_arg_val(MAIN_CT_ARGS_START_IDX + 8);
-constexpr bool ENABLE_RISC_CPU_DATA_CACHE = get_compile_time_arg_val(MAIN_CT_ARGS_START_IDX + 9);
+constexpr bool ENABLE_FIRST_LEVEL_ACK_VC0 = get_compile_time_arg_val(MAIN_CT_ARGS_START_IDX + 8);
+constexpr bool ENABLE_FIRST_LEVEL_ACK_VC1 = get_compile_time_arg_val(MAIN_CT_ARGS_START_IDX + 9);
+constexpr bool ENABLE_RISC_CPU_DATA_CACHE = get_compile_time_arg_val(MAIN_CT_ARGS_START_IDX + 10);
 
-constexpr size_t REMOTE_CHANNEL_INFO_START_IDX = MAIN_CT_ARGS_START_IDX + 10;
+constexpr size_t REMOTE_CHANNEL_INFO_START_IDX = MAIN_CT_ARGS_START_IDX + 11;
 constexpr size_t remote_worker_sender_channel =
     conditional_get_compile_time_arg<skip_src_ch_id_update, REMOTE_CHANNEL_INFO_START_IDX>();
 

--- a/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_router_ct_args.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_router_ct_args.hpp
@@ -96,7 +96,9 @@ constexpr size_t NUM_FORWARDING_PATHS_CT_ARG_IDX = NUM_RECEIVER_CHANNELS_CT_ARG_
 constexpr size_t NUM_DOWNSTREAM_CHANNELS = get_compile_time_arg_val(NUM_FORWARDING_PATHS_CT_ARG_IDX);
 constexpr size_t NUM_DOWNSTREAM_SENDERS_VC0_CT_ARG_IDX = NUM_FORWARDING_PATHS_CT_ARG_IDX + 1;
 constexpr size_t NUM_DOWNSTREAM_SENDERS_VC0 = get_compile_time_arg_val(NUM_DOWNSTREAM_SENDERS_VC0_CT_ARG_IDX);
-constexpr size_t wait_for_host_signal_IDX = NUM_DOWNSTREAM_SENDERS_VC0_CT_ARG_IDX + 1;
+constexpr size_t NUM_DOWNSTREAM_SENDERS_VC1_CT_ARG_IDX = NUM_DOWNSTREAM_SENDERS_VC0_CT_ARG_IDX + 1;
+constexpr size_t NUM_DOWNSTREAM_SENDERS_VC1 = get_compile_time_arg_val(NUM_DOWNSTREAM_SENDERS_VC1_CT_ARG_IDX);
+constexpr size_t wait_for_host_signal_IDX = NUM_DOWNSTREAM_SENDERS_VC1_CT_ARG_IDX + 1;
 constexpr bool wait_for_host_signal = get_compile_time_arg_val(wait_for_host_signal_IDX);
 constexpr size_t MAIN_CT_ARGS_START_IDX = wait_for_host_signal_IDX + 1;
 
@@ -110,16 +112,18 @@ static_assert(
     NUM_SENDER_CHANNELS <= MAX_NUM_SENDER_CHANNELS,
     "NUM_SENDER_CHANNELS must be less than or equal to MAX_NUM_SENDER_CHANNELS");
 static_assert(
-    wait_for_host_signal_IDX == 39,
-    "wait_for_host_signal_IDX must be 39 (31 stream IDs + 1 marker + 2 max channel counts + 1 tensix connections + 4 "
-    "config args)");
+    wait_for_host_signal_IDX == 40,
+    "wait_for_host_signal_IDX must be 40 (31 stream IDs + 1 marker + 2 max channel counts + 1 tensix connections + 6 "
+    "config args: num_sender_channels, num_receiver_channels, num_fwd_paths, num_downstream_senders_vc0, "
+    "num_downstream_senders_vc1, wait_for_host_signal)");
 static_assert(
     get_compile_time_arg_val(wait_for_host_signal_IDX) == 0 || get_compile_time_arg_val(wait_for_host_signal_IDX) == 1,
     "wait_for_host_signal must be 0 or 1");
 static_assert(
-    MAIN_CT_ARGS_START_IDX == 40,
-    "MAIN_CT_ARGS_START_IDX must be 40 (31 stream IDs + 1 marker + 2 max channel counts + 1 tensix connections + 5 "
-    "config args)");
+    MAIN_CT_ARGS_START_IDX == 41,
+    "MAIN_CT_ARGS_START_IDX must be 41 (31 stream IDs + 1 marker + 2 max channel counts + 1 tensix connections + 6 "
+    "config args: num_sender_channels, num_receiver_channels, num_fwd_paths, num_downstream_senders_vc0, "
+    "num_downstream_senders_vc1, wait_for_host_signal)");
 
 constexpr uint32_t SWITCH_INTERVAL =
 #ifndef DEBUG_PRINT_ENABLED
@@ -136,6 +140,7 @@ constexpr size_t handshake_addr = get_compile_time_arg_val(MAIN_CT_ARGS_START_ID
 static_assert(fuse_receiver_flush_and_completion_ptr == 1, "fuse_receiver_flush_and_completion_ptr must be 0");
 
 constexpr size_t VC0_RECEIVER_CHANNEL = 0;
+constexpr size_t VC1_RECEIVER_CHANNEL = 1;
 
 // Doesn't REALLY matter but for consistency I picked the next available ID
 constexpr size_t worker_info_offset_past_connection_semaphore = 32;
@@ -241,16 +246,16 @@ static_assert(
     "DOWNSTREAM_SENDER_NUM_BUFFERS_SPECIAL_TAG_IDX not found. This implies some arguments were misaligned between host and device. Double check the CT args.");
 
 // Downstream sender num buffers comes after channel mappings
+// Sized to MAX_NUM_RECEIVER_CHANNELS (one per VC) to match host side array
 constexpr size_t DOWNSTREAM_SENDER_NUM_BUFFERS_IDX = DOWNSTREAM_SENDER_NUM_BUFFERS_SPECIAL_TAG_IDX + 1;
-constexpr std::array<size_t, NUM_DOWNSTREAM_CHANNELS> DOWNSTREAM_SENDER_NUM_BUFFERS_ARRAY =
-    fill_array_with_next_n_args<size_t, DOWNSTREAM_SENDER_NUM_BUFFERS_IDX, NUM_DOWNSTREAM_CHANNELS>();
+constexpr std::array<size_t, MAX_NUM_RECEIVER_CHANNELS> DOWNSTREAM_SENDER_NUM_BUFFERS_ARRAY =
+    fill_array_with_next_n_args<size_t, DOWNSTREAM_SENDER_NUM_BUFFERS_IDX, MAX_NUM_RECEIVER_CHANNELS>();
 // TODO: remove DOWNSTREAM_SENDER_NUM_BUFFERS and use TMP on downstream sender channels.
-// Add an edge case for NeighborExchange topology, which contains no downstream sender channels
-constexpr size_t DOWNSTREAM_SENDER_NUM_BUFFERS_VC0 =
-    (NUM_DOWNSTREAM_CHANNELS > 0) ? DOWNSTREAM_SENDER_NUM_BUFFERS_ARRAY[0] : 0;
+constexpr size_t DOWNSTREAM_SENDER_NUM_BUFFERS_VC0 = DOWNSTREAM_SENDER_NUM_BUFFERS_ARRAY[0];
+constexpr size_t DOWNSTREAM_SENDER_NUM_BUFFERS_VC1 = DOWNSTREAM_SENDER_NUM_BUFFERS_ARRAY[1];
 
 constexpr size_t ANOTHER_SPECIAL_TAG_2 = 0xabaddad9;
-constexpr size_t ANOTHER_SPECIAL_TAG_2_IDX = DOWNSTREAM_SENDER_NUM_BUFFERS_IDX + NUM_DOWNSTREAM_CHANNELS;
+constexpr size_t ANOTHER_SPECIAL_TAG_2_IDX = DOWNSTREAM_SENDER_NUM_BUFFERS_IDX + MAX_NUM_RECEIVER_CHANNELS;
 static_assert(
     get_compile_time_arg_val(ANOTHER_SPECIAL_TAG_2_IDX) == ANOTHER_SPECIAL_TAG_2,
     "ANOTHER_SPECIAL_TAG_2 not found. This implies some arguments were misaligned between host and device. Double check the CT args.");

--- a/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
+++ b/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
@@ -2657,8 +2657,9 @@ void kernel_main() {
 #if defined(FABRIC_2D)
                         // Inter-mesh routers cross over to intra-mesh VC1, so use VC1 stream IDs
                         // Intra-mesh routers connect to VC0 normally
-                        is_intermesh_router ? get_vc1_downstream_sender_channel_free_slots_stream_id(compact_index)
-                                            : get_vc0_downstream_sender_channel_free_slots_stream_id(compact_index),
+                        is_intermesh_router_on_edge
+                            ? get_vc1_downstream_sender_channel_free_slots_stream_id(compact_index)
+                            : get_vc0_downstream_sender_channel_free_slots_stream_id(compact_index),
 #else
                         // Issue #33360 TODO: Create a new array for explicitly holding downstream receiver stream IDs
                         // so we can remove this hack.

--- a/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
+++ b/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
@@ -370,6 +370,27 @@ constexpr uint32_t get_vc0_downstream_sender_channel_free_slots_stream_id(uint32
         return sender_channel_free_slots_stream_ids[(1 + my_direction)];
     }
 }
+
+// VC1 downstream sender channel mapping (for inter-mesh routing)
+// Compact indices 0, 1, 2 map to sender channels 4, 5, 6 (VC1 channels)
+// Direction rules are identical to VC0, but offset by 3 to skip VC0's channels 1-3
+//
+// VC1 sender channel mapping:
+//   [4] → VC1 channel 0 (compact index varies by direction)
+//   [5] → VC1 channel 1 (compact index varies by direction)
+//   [6] → VC1 channel 2 (compact index varies by direction)
+constexpr uint32_t get_vc1_downstream_sender_channel_free_slots_stream_id(uint32_t compact_index) {
+    auto ds_edm_direction = edm_index_to_edm_direction[my_direction][compact_index];
+    if (my_direction > ds_edm_direction) {
+        // downstream sender channel = 3 + my_direction (maps to channels 4-6)
+        // stream id = sender_channel_free_slots_stream_ids[downstream sender channel]
+        return sender_channel_free_slots_stream_ids[3 + my_direction];
+    } else {
+        // downstream sender channel = 4 + my_direction (maps to channels 4-6)
+        // stream id = sender_channel_free_slots_stream_ids[downstream sender channel]
+        return sender_channel_free_slots_stream_ids[4 + my_direction];
+    }
+}
 #endif
 
 FORCE_INLINE constexpr eth_chan_directions map_compact_index_to_direction(size_t compact_index) {
@@ -433,6 +454,12 @@ static constexpr std::array<uint32_t, NUM_ROUTER_CARDINAL_DIRECTIONS> vc_0_free_
     vc_0_free_slots_from_downstream_edge_3_stream_id,
     0};
 
+static constexpr std::array<uint32_t, NUM_ROUTER_CARDINAL_DIRECTIONS> vc_1_free_slots_stream_ids = {
+    vc_1_free_slots_from_downstream_edge_1_stream_id,
+    vc_1_free_slots_from_downstream_edge_2_stream_id,
+    vc_1_free_slots_from_downstream_edge_3_stream_id,
+    0};
+
 enum PacketLocalForwardType : uint8_t {
     PACKET_FORWARD_INVALID = 0x0,
     PACKET_FORWARD_LOCAL_ONLY = 0x1,
@@ -454,7 +481,11 @@ template <uint8_t SENDER_CHANNEL_INDEX>
 FORCE_INLINE void update_packet_header_before_eth_send(volatile tt_l1_ptr PACKET_HEADER_TYPE* packet_header) {
 #if defined(FABRIC_2D)
     constexpr bool IS_FORWARDED_TRAFFIC_FROM_ROUTER = SENDER_CHANNEL_INDEX != 0;
-    constexpr bool IS_TURN = sender_channels_turn_status[SENDER_CHANNEL_INDEX];
+    // For VC1 sender channels, we need to adjust the index to map the channel index back to corresponding VC0 channel
+    // index for turn status checking.
+    constexpr bool IS_TURN = SENDER_CHANNEL_INDEX < MAX_NUM_SENDER_CHANNELS_VC0
+                                 ? sender_channels_turn_status[SENDER_CHANNEL_INDEX]
+                                 : sender_channels_turn_status[SENDER_CHANNEL_INDEX - MAX_NUM_SENDER_CHANNELS_VC0 + 1];
     static_assert(
         my_direction == eth_chan_directions::EAST || my_direction == eth_chan_directions::WEST ||
         my_direction == eth_chan_directions::NORTH || my_direction == eth_chan_directions::SOUTH);
@@ -780,13 +811,17 @@ FORCE_INLINE void forward_to_local_destination(
 
 // !!!WARNING!!! - MAKE SURE CONSUMER HAS SPACE BEFORE CALLING
 template <uint8_t rx_channel_id, typename DownstreamSenderVC0T, typename LocalRelayInterfaceT>
-FORCE_INLINE __attribute__((optimize("jump-tables"))) void receiver_forward_packet(
-    tt_l1_ptr PACKET_HEADER_TYPE* packet_start,
-    ROUTING_FIELDS_TYPE cached_routing_fields,
-    std::array<DownstreamSenderVC0T, NUM_DOWNSTREAM_SENDERS_VC0>& downstream_edm_interfaces_vc0,
-    LocalRelayInterfaceT& local_relay_interface,
-    uint8_t transaction_id,
-    uint32_t hop_cmd) {
+#if !defined(FABRIC_2D_VC1_ACTIVE)
+FORCE_INLINE
+#endif
+    __attribute__((optimize("jump-tables"))) void
+    receiver_forward_packet(
+        tt_l1_ptr PACKET_HEADER_TYPE* packet_start,
+        ROUTING_FIELDS_TYPE cached_routing_fields,
+        std::array<DownstreamSenderVC0T, NUM_DOWNSTREAM_SENDERS_VC0>& downstream_edm_interfaces_vc0,
+        LocalRelayInterfaceT& local_relay_interface,
+        uint8_t transaction_id,
+        uint32_t hop_cmd) {
     uint16_t payload_size_bytes = packet_start->payload_size_bytes;
 
     using eth_chan_directions::EAST;
@@ -1363,16 +1398,20 @@ template <
     typename ReceiverPointersT,
     typename ReceiverChannelT,
     typename LocalTelemetryT>
-FORCE_INLINE bool run_sender_channel_step_impl(
-    SenderChannelT& local_sender_channel,
-    WorkerInterfaceT& local_sender_channel_worker_interface,
-    ReceiverPointersT& outbound_to_receiver_channel_pointers,
-    ReceiverChannelT& remote_receiver_channel,
-    bool& channel_connection_established,
-    uint32_t sender_channel_free_slots_stream_id,
-    SenderChannelFromReceiverCredits& sender_channel_from_receiver_credits,
-    PerfTelemetryRecorder& perf_telemetry_recorder,
-    LocalTelemetryT& local_fabric_telemetry) {
+#if !defined(FABRIC_2D_VC1_ACTIVE)
+FORCE_INLINE
+#endif
+    bool
+    run_sender_channel_step_impl(
+        SenderChannelT& local_sender_channel,
+        WorkerInterfaceT& local_sender_channel_worker_interface,
+        ReceiverPointersT& outbound_to_receiver_channel_pointers,
+        ReceiverChannelT& remote_receiver_channel,
+        bool& channel_connection_established,
+        uint32_t sender_channel_free_slots_stream_id,
+        SenderChannelFromReceiverCredits& sender_channel_from_receiver_credits,
+        PerfTelemetryRecorder& perf_telemetry_recorder,
+        LocalTelemetryT& local_fabric_telemetry) {
     bool progress = false;
     // If the receiver has space, and we have one or more packets unsent from producer, then send one
     // TODO: convert to loop to send multiple packets back to back (or support sending multiple packets in one shot)
@@ -1471,16 +1510,20 @@ template <
     typename ReceiverPointersT,
     size_t NUM_SENDER_CHANNELS,
     typename LocalTelemetryT>
-FORCE_INLINE bool run_sender_channel_step(
-    EthSenderChannels& local_sender_channels,
-    EdmChannelWorkerIFs& local_sender_channel_worker_interfaces,
-    ReceiverPointersT& outbound_to_receiver_channel_pointers,
-    RemoteEthReceiverChannels& remote_receiver_channels,
-    std::array<bool, NUM_SENDER_CHANNELS>& channel_connection_established,
-    std::array<uint32_t, NUM_SENDER_CHANNELS>& local_sender_channel_free_slots_stream_ids,
-    std::array<SenderChannelFromReceiverCredits, NUM_SENDER_CHANNELS>& sender_channel_from_receiver_credits,
-    PerfTelemetryRecorder& perf_telemetry_recorder,
-    LocalTelemetryT& local_fabric_telemetry) {
+#if !defined(FABRIC_2D_VC1_ACTIVE)
+FORCE_INLINE
+#endif
+    bool
+    run_sender_channel_step(
+        EthSenderChannels& local_sender_channels,
+        EdmChannelWorkerIFs& local_sender_channel_worker_interfaces,
+        ReceiverPointersT& outbound_to_receiver_channel_pointers,
+        RemoteEthReceiverChannels& remote_receiver_channels,
+        std::array<bool, NUM_SENDER_CHANNELS>& channel_connection_established,
+        std::array<uint32_t, NUM_SENDER_CHANNELS>& local_sender_channel_free_slots_stream_ids,
+        std::array<SenderChannelFromReceiverCredits, NUM_SENDER_CHANNELS>& sender_channel_from_receiver_credits,
+        PerfTelemetryRecorder& perf_telemetry_recorder,
+        LocalTelemetryT& local_fabric_telemetry) {
     if constexpr (is_sender_channel_serviced[sender_channel_index]) {
         // the cache is invalidated here because the channel will read some
         // L1 locations to see if it can make progress
@@ -1751,22 +1794,32 @@ FORCE_INLINE bool run_receiver_channel_step(
 template <
     size_t NUM_RECEIVER_CHANNELS,
     typename DownstreamSenderVC0T,
+    typename DownstreamSenderVC1T,
     typename LocalRelayInterfaceT,
     size_t NUM_SENDER_CHANNELS,
     typename EthSenderChannels,
     typename EthReceiverChannels,
     typename RemoteEthReceiverChannels,
     typename EdmChannelWorkerIFs,
-    typename TransactionIdTrackerCH0>
+    typename TransactionIdTrackerCH0
+#if defined(FABRIC_2D_VC1_ACTIVE)
+    ,
+    typename TransactionIdTrackerCH1
+#endif  // FABRIC_2D_VC1_ACTIVE
+    >
 FORCE_INLINE void run_fabric_edm_main_loop(
     EthReceiverChannels& local_receiver_channels,
     EthSenderChannels& local_sender_channels,
     EdmChannelWorkerIFs& local_sender_channel_worker_interfaces,
     std::array<DownstreamSenderVC0T, NUM_DOWNSTREAM_SENDERS_VC0>& downstream_edm_noc_interfaces_vc0,
+    std::array<DownstreamSenderVC1T, NUM_DOWNSTREAM_SENDERS_VC1>& downstream_edm_noc_interfaces_vc1,
     LocalRelayInterfaceT& local_relay_interface,
     RemoteEthReceiverChannels& remote_receiver_channels,
     volatile tt::tt_fabric::TerminationSignal* termination_signal_ptr,
     TransactionIdTrackerCH0& receiver_channel_0_trid_tracker,
+#if defined(FABRIC_2D_VC1_ACTIVE)
+    TransactionIdTrackerCH1& receiver_channel_1_trid_tracker,
+#endif  // FABRIC_2D_VC1_ACTIVE
     std::array<uint8_t, num_eth_ports>& port_direction_table,
     std::array<uint32_t, NUM_SENDER_CHANNELS>& local_sender_channel_free_slots_stream_ids) {
     size_t did_nothing_count = 0;
@@ -1793,6 +1846,16 @@ FORCE_INLINE void run_fabric_edm_main_loop(
     // Workaround the perf regression in RingAsLinear test.
     auto receiver_channel_pointers_ch0 = receiver_channel_pointers.template get<0>();
     receiver_channel_pointers_ch0.reset();
+
+#if defined(FABRIC_2D_VC1_ACTIVE)
+    // VC1 receiver channel pointer for inter-mesh routing
+    auto outbound_to_receiver_channel_pointer_ch1 =
+        outbound_to_receiver_channel_pointers.template get<VC1_RECEIVER_CHANNEL>();
+
+    auto receiver_channel_pointers_ch1 = receiver_channel_pointers.template get<1>();
+    receiver_channel_pointers_ch1.reset();
+#endif  // FABRIC_2D_VC1_ACTIVE
+
     if constexpr (skip_src_ch_id_update) {
         receiver_channel_pointers_ch0.set_src_chan_id(BufferIndex{0}, remote_worker_sender_channel);
     }
@@ -1883,6 +1946,48 @@ FORCE_INLINE void run_fabric_edm_main_loop(
                     sender_channel_from_receiver_credits,
                     inner_loop_perf_telemetry_collector,
                     local_fabric_telemetry);
+#if defined(FABRIC_2D_VC1_ACTIVE)
+                tx_progress |= run_sender_channel_step<VC1_RECEIVER_CHANNEL, 4>(
+                    local_sender_channels,
+                    local_sender_channel_worker_interfaces,
+                    outbound_to_receiver_channel_pointer_ch1,
+                    remote_receiver_channels,
+                    channel_connection_established,
+                    local_sender_channel_free_slots_stream_ids,
+                    sender_channel_from_receiver_credits,
+                    inner_loop_perf_telemetry_collector,
+                    local_fabric_telemetry);
+                tx_progress |= run_sender_channel_step<VC1_RECEIVER_CHANNEL, 5>(
+                    local_sender_channels,
+                    local_sender_channel_worker_interfaces,
+                    outbound_to_receiver_channel_pointer_ch1,
+                    remote_receiver_channels,
+                    channel_connection_established,
+                    local_sender_channel_free_slots_stream_ids,
+                    sender_channel_from_receiver_credits,
+                    inner_loop_perf_telemetry_collector,
+                    local_fabric_telemetry);
+                tx_progress |= run_sender_channel_step<VC1_RECEIVER_CHANNEL, 6>(
+                    local_sender_channels,
+                    local_sender_channel_worker_interfaces,
+                    outbound_to_receiver_channel_pointer_ch1,
+                    remote_receiver_channels,
+                    channel_connection_established,
+                    local_sender_channel_free_slots_stream_ids,
+                    sender_channel_from_receiver_credits,
+                    inner_loop_perf_telemetry_collector,
+                    local_fabric_telemetry);
+                rx_progress |= run_receiver_channel_step<1, DownstreamSenderVC1T, decltype(local_relay_interface)>(
+                    local_receiver_channels,
+                    downstream_edm_noc_interfaces_vc1,
+                    local_relay_interface,
+                    receiver_channel_pointers_ch1,
+                    receiver_channel_1_trid_tracker,
+                    port_direction_table,
+                    receiver_channel_response_credit_senders,
+                    routing_table,
+                    local_fabric_telemetry);
+#endif  // FABRIC_2D_VC1_ACTIVE
             }
         }
 
@@ -2028,17 +2133,19 @@ void
             local_sender_channel_worker_interfaces);
     }
 #ifdef FABRIC_2D
+    // Use compile-time loop to initialize remaining sender channels (2-6) for code size optimization
     if constexpr (NUM_SENDER_CHANNELS > 2) {
-        init_sender_channel_worker_interface<2, NUM_SENDER_CHANNELS>(
-            local_sender_connection_live_semaphore_addresses,
-            local_sender_connection_info_addresses,
-            local_sender_channel_worker_interfaces);
-    }
-    if constexpr (NUM_SENDER_CHANNELS > 3) {
-        init_sender_channel_worker_interface<3, NUM_SENDER_CHANNELS>(
-            local_sender_connection_live_semaphore_addresses,
-            local_sender_connection_info_addresses,
-            local_sender_channel_worker_interfaces);
+        [&]<size_t... Is>(std::index_sequence<Is...>) {
+            (([&]<size_t I>() {
+                 if constexpr (NUM_SENDER_CHANNELS > I) {
+                     init_sender_channel_worker_interface<I, NUM_SENDER_CHANNELS>(
+                         local_sender_connection_live_semaphore_addresses,
+                         local_sender_connection_info_addresses,
+                         local_sender_channel_worker_interfaces);
+                 }
+             }.template operator()<Is + 2>()),
+             ...);
+        }(std::make_index_sequence<5>{});  // Indices 0-4 map to channels 2-6
     }
 #endif
 }
@@ -2080,15 +2187,30 @@ FORCE_INLINE void teardown(
     WriteTransactionIdTracker<
         RECEIVER_NUM_BUFFERS_ARRAY[0],
         NUM_TRANSACTION_IDS,
-        0,
+        RX_CH_TRID_STARTS[0],
         edm_to_local_chip_noc,
-        edm_to_downstream_noc> receiver_channel_0_trid_tracker) {
+        edm_to_downstream_noc> receiver_channel_0_trid_tracker
+#if defined(FABRIC_2D_VC1_ACTIVE)
+    ,
+    WriteTransactionIdTracker<
+        RECEIVER_NUM_BUFFERS_ARRAY[1],
+        NUM_TRANSACTION_IDS,
+        RX_CH_TRID_STARTS[1],
+        edm_to_local_chip_noc,
+        edm_to_downstream_noc> receiver_channel_1_trid_tracker
+#endif
+) {
     if constexpr (NUM_ACTIVE_ERISCS > 1) {
         wait_for_other_local_erisc();
     }
     if constexpr (is_receiver_channel_serviced[0]) {
         receiver_channel_0_trid_tracker.all_buffer_slot_transactions_acked();
     }
+#if defined(FABRIC_2D_VC1_ACTIVE)
+    if constexpr (is_receiver_channel_serviced[1]) {
+        receiver_channel_1_trid_tracker.all_buffer_slot_transactions_acked();
+    }
+#endif
 
     // at minimum, the below call must be updated because in dynamic noc mode, the counters would be shared, so you'd
     // want a sync before this and coordination about which erisc should do the reset (only one of them should do it)
@@ -2266,9 +2388,33 @@ void kernel_main() {
     const auto downstream_edm_vc0_buffer_index_semaphore_address = get_arg_val<uint32_t>(arg_idx++);
 #endif
 
+#if defined(FABRIC_2D_VC1_ACTIVE)
+    const auto has_downstream_edm_vc1_buffer_connection = get_arg_val<uint32_t>(arg_idx++);
+    std::array<uint32_t, NUM_DOWNSTREAM_SENDERS_VC1> downstream_edm_vc1_buffer_base_addresses;
+    for (size_t i = 0; i < NUM_DOWNSTREAM_SENDERS_VC1; i++) {
+        downstream_edm_vc1_buffer_base_addresses[i] = get_arg_val<uint32_t>(arg_idx++);
+    }
+
+    const auto downstream_edm_vc1_noc_x = get_arg_val<uint32_t>(arg_idx++);
+    const auto downstream_edm_vc1_noc_y = get_arg_val<uint32_t>(arg_idx++);
+
+    std::array<uint32_t, NUM_DOWNSTREAM_SENDERS_VC1> downstream_edm_vc1_worker_registration_ids;
+    std::array<uint32_t, NUM_DOWNSTREAM_SENDERS_VC1> downstream_edm_vc1_worker_location_info_addresses;
+    std::array<uint32_t, NUM_DOWNSTREAM_SENDERS_VC1> downstream_edm_vc1_buffer_index_semaphore_addresses;
+    for (size_t i = 0; i < NUM_DOWNSTREAM_SENDERS_VC1; i++) {
+        downstream_edm_vc1_worker_registration_ids[i] = get_arg_val<uint32_t>(arg_idx++);
+    }
+    for (size_t i = 0; i < NUM_DOWNSTREAM_SENDERS_VC1; i++) {
+        downstream_edm_vc1_worker_location_info_addresses[i] = get_arg_val<uint32_t>(arg_idx++);
+    }
+    for (size_t i = 0; i < NUM_DOWNSTREAM_SENDERS_VC1; i++) {
+        downstream_edm_vc1_buffer_index_semaphore_addresses[i] = get_arg_val<uint32_t>(arg_idx++);
+    }
+#endif  // FABRIC_2D_VC1_ACTIVE
     // unused - to be deleted
     [[maybe_unused]]
     const auto downstream_vc0_noc_interface_buffer_index_local_addr = 0;
+    const auto downstream_vc1_noc_interface_buffer_index_local_addr = 0;
 
     // Read MAX_NUM_SENDER_CHANNELS teardown semaphores (host packs builder_config::num_max_sender_channels = 8)
     const auto my_sem_for_teardown_from_edm_0 = get_arg_val<uint32_t>(arg_idx++);
@@ -2509,7 +2655,10 @@ void kernel_main() {
                                                                                // read dest.
 
 #if defined(FABRIC_2D)
-                        get_vc0_downstream_sender_channel_free_slots_stream_id(compact_index),
+                        // Inter-mesh routers cross over to intra-mesh VC1, so use VC1 stream IDs
+                        // Intra-mesh routers connect to VC0 normally
+                        is_intermesh_router ? get_vc1_downstream_sender_channel_free_slots_stream_id(compact_index)
+                                            : get_vc0_downstream_sender_channel_free_slots_stream_id(compact_index),
 #else
                         // Issue #33360 TODO: Create a new array for explicitly holding downstream receiver stream IDs
                         // so we can remove this hack.
@@ -2532,6 +2681,52 @@ void kernel_main() {
             has_downstream_edm >>= 1;
         }
     }
+
+    std::array<RouterToRouterSender<DOWNSTREAM_SENDER_NUM_BUFFERS_VC1>, NUM_DOWNSTREAM_SENDERS_VC1>
+        downstream_edm_noc_interfaces_vc1;
+#if defined(FABRIC_2D_VC1_ACTIVE)
+    if (has_downstream_edm_vc1_buffer_connection) {
+        uint32_t has_downstream_edm = has_downstream_edm_vc1_buffer_connection & 0x7;  // 3-bit mask
+        uint32_t compact_index = 0;
+        while (has_downstream_edm) {
+            if (has_downstream_edm & 0x1) {
+                const auto teardown_sem_address =
+                    local_sem_for_teardown_from_downstream_edm[compact_index + NUM_DOWNSTREAM_SENDERS_VC0];
+                // reset the handshake addresses to 0 (this is for router -> router handshake for connections over
+                // noc)
+                *reinterpret_cast<volatile uint32_t* const>(teardown_sem_address) = 0;
+                auto receiver_channel_free_slots_stream_id = StreamId{vc_1_free_slots_stream_ids[compact_index]};
+                new (&downstream_edm_noc_interfaces_vc1[compact_index])
+                    RouterToRouterSender<DOWNSTREAM_SENDER_NUM_BUFFERS_VC1>(
+                        is_persistent_fabric,
+                        (downstream_edm_vc1_noc_x >> (compact_index * 8)) & 0xFF,
+                        (downstream_edm_vc1_noc_y >> (compact_index * 8)) & 0xFF,
+                        downstream_edm_vc1_buffer_base_addresses[compact_index],
+                        DOWNSTREAM_SENDER_NUM_BUFFERS_VC1,
+                        downstream_edm_vc1_worker_registration_ids[compact_index],
+                        downstream_edm_vc1_worker_location_info_addresses[compact_index],
+                        channel_buffer_size,
+                        downstream_edm_vc1_buffer_index_semaphore_addresses[compact_index],
+                        0,
+                        reinterpret_cast<volatile uint32_t* const>(teardown_sem_address),
+                        downstream_vc1_noc_interface_buffer_index_local_addr,
+                        get_vc1_downstream_sender_channel_free_slots_stream_id(compact_index),
+                        receiver_channel_free_slots_stream_id,
+                        receiver_channel_forwarding_data_cmd_buf_ids[1],
+                        receiver_channel_forwarding_sync_cmd_buf_ids[1]);
+                // Only receiver channel servicing cores should be setting up the noc cmd buf.
+                if constexpr (NUM_ACTIVE_ERISCS == 1 && !FORCE_ALL_PATHS_TO_USE_SAME_NOC) {
+                    downstream_edm_noc_interfaces_vc1[compact_index]
+                        .template setup_edm_noc_cmd_buf<
+                            tt::tt_fabric::edm_to_downstream_noc,
+                            tt::tt_fabric::forward_and_local_write_noc_vc>();
+                }
+            }
+            compact_index++;
+            has_downstream_edm >>= 1;
+        }
+    }
+#endif  // FABRIC_2D_VC1_ACTIVE
 
     // Setup local tensix relay connection (UDM mode only)
     // This is a separate connection path from downstream EDM connections
@@ -2607,11 +2802,22 @@ void kernel_main() {
     WriteTransactionIdTracker<
         RECEIVER_NUM_BUFFERS_ARRAY[0],
         NUM_TRANSACTION_IDS,
-        0,
+        RX_CH_TRID_STARTS[0],
         edm_to_local_chip_noc,
         edm_to_downstream_noc>
         receiver_channel_0_trid_tracker;
     receiver_channel_0_trid_tracker.init();
+
+#if defined(FABRIC_2D_VC1_ACTIVE)
+    WriteTransactionIdTracker<
+        RECEIVER_NUM_BUFFERS_ARRAY[1],
+        NUM_TRANSACTION_IDS,
+        RX_CH_TRID_STARTS[1],
+        edm_to_local_chip_noc,
+        edm_to_downstream_noc>
+        receiver_channel_1_trid_tracker;
+    receiver_channel_1_trid_tracker.init();
+#endif  // FABRIC_2D_VC1_ACTIVE
 
 #ifdef ARCH_BLACKHOLE
     // A Blackhole hardware bug requires all noc inline writes to be non-posted so we hardcode to false here
@@ -2689,22 +2895,32 @@ void kernel_main() {
     }
 
     if constexpr (is_2d_fabric) {
-        uint32_t has_downstream_edm = has_downstream_edm_vc0_buffer_connection & 0x7;  // 3-bit mask
-        uint32_t edm_index = 0;
-        if constexpr (is_receiver_channel_serviced[0]) {
-            while (has_downstream_edm) {
-                if (has_downstream_edm & 0x1) {
-                    // open connections with available downstream edms
-                    downstream_edm_noc_interfaces_vc0[edm_index]
-                        .template open<
-                            false,
-                            use_posted_writes_for_connection_open,
-                            tt::tt_fabric::worker_handshake_noc>();
+        // Helper function to open downstream EDM connections, works for both VC0 and VC1
+        auto open_downstream_edm_connections =
+            [](auto& downstream_edm_noc_interfaces, uint32_t has_downstream_edm, int receiver_channel_idx) {
+                uint32_t edm_index = 0;
+                if (is_receiver_channel_serviced[receiver_channel_idx]) {
+                    while (has_downstream_edm) {
+                        if (has_downstream_edm & 0x1) {
+                            // open connections with available downstream edms
+                            downstream_edm_noc_interfaces[edm_index]
+                                .template open<
+                                    false,
+                                    use_posted_writes_for_connection_open,
+                                    tt::tt_fabric::worker_handshake_noc>();
+                        }
+                        edm_index++;
+                        has_downstream_edm >>= 1;
+                    }
                 }
-                edm_index++;
-                has_downstream_edm >>= 1;
-            }
-        }
+            };
+
+        open_downstream_edm_connections(
+            downstream_edm_noc_interfaces_vc0, has_downstream_edm_vc0_buffer_connection & 0x7, 0);
+#if defined(FABRIC_2D_VC1_ACTIVE)
+        open_downstream_edm_connections(
+            downstream_edm_noc_interfaces_vc1, has_downstream_edm_vc1_buffer_connection & 0x7, 1);
+#endif
         if constexpr (udm_mode) {
             if (has_local_tensix_relay_connection) {
                 // open connection here to relay kernel
@@ -2749,6 +2965,28 @@ void kernel_main() {
             }
         }
     }
+#if defined(FABRIC_2D_VC1_ACTIVE)
+    if constexpr (is_receiver_channel_serviced[1] and NUM_ACTIVE_ERISCS > 1) {
+        // Two erisc mode requires us to reorder the cmd buf programming/state setting
+        // because we need to reshuffle some of our cmd_buf/noc assignments around for
+        // just the fabric bringup phase. These calls are also located earlier for the
+        // single erisc mode
+        if constexpr (!FORCE_ALL_PATHS_TO_USE_SAME_NOC) {
+            uint32_t has_downstream_edm = has_downstream_edm_vc1_buffer_connection & 0x7;  // 3-bit mask
+            uint32_t edm_index = 0;
+            while (has_downstream_edm) {
+                if (has_downstream_edm & 0x1) {
+                    downstream_edm_noc_interfaces_vc1[edm_index]
+                        .template setup_edm_noc_cmd_buf<
+                            tt::tt_fabric::edm_to_downstream_noc,
+                            tt::tt_fabric::forward_and_local_write_noc_vc>();
+                }
+                edm_index++;
+                has_downstream_edm >>= 1;
+            }
+        }
+    }
+#endif  // FABRIC_2D_VC1_ACTIVE
     std::array<uint8_t, num_eth_ports> port_direction_table;
 
     if constexpr (NUM_ACTIVE_ERISCS > 1) {
@@ -2771,16 +3009,21 @@ void kernel_main() {
     run_fabric_edm_main_loop<
         NUM_RECEIVER_CHANNELS,
         RouterToRouterSender<DOWNSTREAM_SENDER_NUM_BUFFERS_VC0>,
+        RouterToRouterSender<DOWNSTREAM_SENDER_NUM_BUFFERS_VC1>,
         RouterToRouterSender<LOCAL_RELAY_NUM_BUFFERS>>(
         local_receiver_channels,
         local_sender_channels,
         local_sender_channel_worker_interfaces,
         downstream_edm_noc_interfaces_vc0,
+        downstream_edm_noc_interfaces_vc1,
         // pass in the relay adpator
         local_relay_interface,
         remote_receiver_channels,
         termination_signal_ptr,
         receiver_channel_0_trid_tracker,
+#if defined(FABRIC_2D_VC1_ACTIVE)
+        receiver_channel_1_trid_tracker,
+#endif  // FABRIC_2D_VC1_ACTIVE
         port_direction_table,
         local_sender_channel_free_slots_stream_ids);
     WAYPOINT("LPDN");
@@ -2793,7 +3036,15 @@ void kernel_main() {
     *sender0_worker_semaphore_ptr = 99;
 
     // make sure all the noc transactions are acked before re-init the noc counters
-    teardown(termination_signal_ptr, edm_status_ptr, receiver_channel_0_trid_tracker);
+    teardown(
+        termination_signal_ptr,
+        edm_status_ptr,
+        receiver_channel_0_trid_tracker
+#if defined(FABRIC_2D_VC1_ACTIVE)
+        ,
+        receiver_channel_1_trid_tracker
+#endif
+    );
 
     set_l1_data_cache<false>();
     WAYPOINT("DONE");

--- a/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
+++ b/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
@@ -2065,11 +2065,9 @@ void
         if (!sender_ch_live_check_skip[sender_channel_idx]) {
             return;
         }
-        DPRINT << "wait for conn " << sender_channel_idx << ENDL();
         while (!connect_is_requested(*interface.connection_live_semaphore)) {
             router_invalidate_l1_cache<ENABLE_RISC_CPU_DATA_CACHE>();
         }
-        DPRINT << "conn established " << sender_channel_idx << ENDL();
         establish_edm_connection(interface, local_sender_channel_free_slots_stream_ids[sender_channel_idx]);
     };
     if constexpr (multi_txq_enabled) {


### PR DESCRIPTION
This PR connects the VC1 specific EDMs in fabric router together to enable data movement on VC1.

Extend downstream edms connected in StaticSizedChannelConnectionWriterAdapter to be VC specific.


### Ticket
https://github.com/tenstorrent/tt-metal/issues/32580
https://github.com/tenstorrent/tt-metal/issues/32561

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [x] [T3000 nightly tests] https://github.com/tenstorrent/tt-metal/actions/runs/20247362157 https://github.com/tenstorrent/tt-metal/actions/runs/20250522173
- [x] [T3000 unit tests] https://github.com/tenstorrent/tt-metal/actions/runs/20250521809
- [x] [All post commit] https://github.com/tenstorrent/tt-metal/actions/runs/20247361144
- [x] [Galaxy quick] https://github.com/tenstorrent/tt-metal/actions/runs/20247775348 https://github.com/tenstorrent/tt-metal/actions/runs/20255509910
- [X] [BH post commit] https://github.com/tenstorrent/tt-metal/actions/runs/20255487228

### Local Testing
#### WH Galaxy
- [x] tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_sanity_common.yaml
- [x] tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_stability_6U_galaxy.yaml
- [x] tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_deadlock_stability_6U_galaxy.yaml
- [x] tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_ubench_6U_galaxy_quick.yaml (Some tests already fail on main. No regression from this PR)
- [x] tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_ubench_2d_torus_6U_galaxy.yaml (Some tests already fail on main. No regression from this PR)

#### BH Galaxy
- [x] tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_sanity_common.yaml
- [x] tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_stability_6U_galaxy.yaml
- [x] tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_deadlock_stability_bh_6U_galaxy.yaml

#### WH LB
- [x] tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_sanity_common.yaml
- [x] tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_stability.yaml
- [x] tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_ubench_at_least_2x2_mesh.yaml
- [x]  ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="\*Fabric\*Fixture.*"