### PR TITLE
Revert "Remove matmul_batched_weights (#33857)"

### DIFF
--- a/tests/ttnn/unit_tests/operations/prefetcher_common.py
+++ b/tests/ttnn/unit_tests/operations/prefetcher_common.py
@@ -35,6 +35,7 @@ def run_prefetcher_mm(
     dtypes,
     is_functional_test=False,
     enable_performance_mode=False,
+    batch_weights=False,
 ):
     logger.info(f"Running test_run_prefetcher with num_tensors={num_tensors}, num_layers={num_layers}")
     assert len(input_shapes) == len(dtypes)
@@ -270,6 +271,9 @@ def run_prefetcher_mm(
     prev_in0 = torch.randn(prev_shape)
     for shape, shard_shape in zip(in0_shapes, shard_shapes):
         in0 = torch.randn(shape)
+        if batch_weights and prev_shape == shape:
+            in0 = prev_in0
+            prev_shape = shape
         in0_tensors.append(in0)
 
         _, _, M, _ = shape
@@ -337,18 +341,33 @@ def run_prefetcher_mm(
             t = 0
             while t < num_tensors:
                 idx = l * num_tensors + t
-                logger.info(f"running normal matmul for layer {l}, tensor {t}")
-                output_t = ttnn.matmul(
-                    in0_t_tensors[t],
-                    tt_tensors_all[idx],
-                    program_config=program_configs[t],
-                    memory_config=output_mem_configs[t],
-                    compute_kernel_config=compute_kernel_config,
-                    global_cb=global_circular_buffer,
-                    sub_device_id=worker_sub_device_id,
-                )
-                outputs_l1.append(output_t)
-                t += 1
+                if batch_weights and t < num_tensors - 1 and in0_t_tensors[t].shape == in0_t_tensors[t + 1].shape:
+                    logger.info(f"running matmul_batched_weights for layer {l}, tensor {t} and tensor {t+1}")
+                    [output_t1, output_t2] = ttnn.matmul_batched_weights(
+                        in0_t_tensors[t],
+                        [tt_tensors_all[idx], tt_tensors_all[idx + 1]],
+                        program_config=program_configs[t],
+                        memory_config=output_mem_configs[t],
+                        compute_kernel_config=compute_kernel_config,
+                        global_cb=global_circular_buffer,
+                        sub_device_id=worker_sub_device_id,
+                    )
+                    outputs_l1.append(output_t1)
+                    outputs_l1.append(output_t2)
+                    t += 2
+                else:
+                    logger.info(f"running normal matmul for layer {l}, tensor {t}")
+                    output_t = ttnn.matmul(
+                        in0_t_tensors[t],
+                        tt_tensors_all[idx],
+                        program_config=program_configs[t],
+                        memory_config=output_mem_configs[t],
+                        compute_kernel_config=compute_kernel_config,
+                        global_cb=global_circular_buffer,
+                        sub_device_id=worker_sub_device_id,
+                    )
+                    outputs_l1.append(output_t)
+                    t += 1
             # Send outputs to DRAM to so that we don't run out of L1 memory when testing for large number of layers
             for t in range(num_tensors):
                 outputs_dram.append(ttnn.to_memory_config(outputs_l1[t], ttnn.DRAM_MEMORY_CONFIG))

--- a/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_TG.py
+++ b/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_TG.py
@@ -90,6 +90,63 @@ def test_run_prefetcher(
     )
 
 
+@pytest.mark.parametrize(
+    "num_reader_cores, num_tensors, input_shapes, dtypes, num_layers, batch_weights",
+    [
+        (2, 2, [(128, 128), (128, 128)], [ttnn.bfloat4_b] * 2, 2, True),
+        (2, 2, [(256, 1024), (256, 1024)], [ttnn.bfloat4_b] * 2, 5, True),
+        (
+            12,
+            5,
+            [(2304, 1536), (1536, 2304), (2304, 3840), (2304, 3840), (3840, 2304)],
+            [ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat4_b, ttnn.bfloat4_b, ttnn.bfloat8_b],
+            5,
+            True,
+        ),  # qkv + do + ff1 + ff3 + ff2
+        # Takes really long to set up
+        (
+            12,
+            5,
+            [(2048, 1280), (1280, 2048), (2048, 3584), (2048, 3584), (3584, 2048)],
+            [ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat4_b, ttnn.bfloat4_b, ttnn.bfloat8_b],
+            80,
+            True,
+        ),  # qkv + do + ff1 + ff3 + ff2
+    ],
+)
+@pytest.mark.parametrize("mesh_device", [pytest.param((2, 2), id="2x2_grid")], indirect=True)
+@pytest.mark.parametrize(
+    "device_params",
+    [{"dispatch_core_axis": ttnn.DispatchCoreAxis.COL, "trace_region_size": 23887872}],
+    indirect=True,
+)
+def test_run_prefetcher_batched_weights(
+    mesh_device,
+    num_tensors,
+    input_shapes,
+    num_layers,
+    batch_weights,
+    num_reader_cores,
+    dtypes,
+    function_level_defaults,
+):
+    device = mesh_device
+    # Only run these tests on unharvested TG
+    device_grid = (device.compute_with_storage_grid_size().x, device.compute_with_storage_grid_size().y)
+    if device_grid != (7, 10):
+        pytest.skip("Skipping test_run_prefetcher because it only works with a 7x10 grid")
+
+    run_prefetcher_mm(
+        mesh_device,
+        num_tensors,
+        input_shapes,
+        num_layers,
+        num_reader_cores,
+        dtypes,
+        batch_weights=batch_weights,
+    )
+
+
 @pytest.mark.parametrize("mesh_device", [pytest.param((2, 2), id="2x2_grid")], indirect=True)
 @pytest.mark.parametrize(
     "device_params",

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.hpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.hpp
@@ -360,6 +360,13 @@ Tensor matmul(
     const struct Matmul& parameters = Matmul{},
     const std::optional<Tensor>& optional_output_tensor = std::nullopt);
 
+std::vector<Tensor> matmul_batched_weights(
+    const Tensor& input_tensor_a,
+    const std::vector<Tensor>& input_tensors_b,
+    const std::optional<const Tensor>& bias = std::nullopt,
+    const struct Matmul& parameters = Matmul{},
+    const std::optional<Tensor>& optional_output_tensor = std::nullopt);
+
 Tensor sparse_matmul(
     const Tensor& input_tensor_a,
     const Tensor& input_tensor_b,

--- a/ttnn/cpp/ttnn/operations/matmul/matmul.hpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul.hpp
@@ -54,6 +54,24 @@ struct MatmulOperation {
         const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id = std::nullopt);
 };
 
+struct MatmulBatchedWeightsOperation {
+    static std::vector<Tensor> invoke(
+        const Tensor& input_tensor_a,
+        const std::vector<Tensor>& input_tensors_b,
+        bool transpose_a = false,
+        bool transpose_b = false,
+        const std::optional<const MemoryConfig>& memory_config = std::nullopt,
+        std::optional<const DataType> dtype = std::nullopt,
+        const std::optional<const MatmulProgramConfig>& program_config = std::nullopt,
+        const std::optional<const Activation>& activation = std::nullopt,
+        std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
+        std::optional<const CoreGrid> core_grid = std::nullopt,
+        const std::optional<const tt::tt_metal::Tile>& output_tile = std::nullopt,
+        const std::optional<Tensor>& optional_output_tensor = std::nullopt,
+        const std::optional<const GlobalCircularBuffer>& global_cb = std::nullopt,
+        const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id = std::nullopt);
+};
+
 struct LinearOperation {
     static Tensor invoke(
         const Tensor& input_tensor_a,
@@ -114,6 +132,8 @@ struct SparseMatmulOperation {
 
 constexpr auto matmul = ttnn::register_operation<"ttnn::matmul", operations::matmul::MatmulOperation>();
 constexpr auto linear = ttnn::register_operation<"ttnn::linear", operations::matmul::LinearOperation>();
+constexpr auto matmul_batched_weights =
+    ttnn::register_operation<"ttnn::matmul_batched_weights", operations::matmul::MatmulBatchedWeightsOperation>();
 constexpr auto addmm = ttnn::register_operation<"ttnn::addmm", operations::matmul::AddmmOperation>();
 constexpr auto sparse_matmul =
     ttnn::register_operation<"ttnn::sparse_matmul", operations::matmul::SparseMatmulOperation>();

--- a/ttnn/cpp/ttnn/operations/matmul/matmul_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul_pybind.cpp
@@ -732,6 +732,104 @@ void py_module(py::module& module) {
 
     bind_registered_operation(
         module,
+        ::ttnn::matmul_batched_weights,
+        R"doc(
+        DEPRECATED: This is for experimental internal use and is not supported.
+
+        Performs matrix multiplication for a single input tensor a with multiple tensors b, and returns a vector of output tensors.
+
+        Args:
+            input_tensor_a (ttnn.Tensor): the first tensor to be multiplied. Needs to be on the device.
+            input_tensors_b (List of ttnn.Tensor): the tensors to be multiplied. Needs to be on the device.
+
+        Note:
+            The tensors support the following data types and layouts:
+
+            .. list-table:: input_tensor_a
+                :header-rows: 1
+
+                * - dtype
+                  - layout
+                * - BFLOAT8_B, BFLOAT4_B, BFLOAT16, FLOAT32
+                  - TILE
+
+            .. list-table:: input_tensors_b
+                :header-rows: 1
+
+                * - dtype
+                  - layout
+                * - BFLOAT8_B, BFLOAT4_B, BFLOAT16, FLOAT32
+                  - TILE
+
+        Keyword Args:
+            bias (ttnn.Tensor, optional): the bias tensor to be added. If specified, needs to be on the device. Defaults to `None`.
+            transpose_a (bool, optional): Whether to transpose input_tensor_a. Defaults to `False`.
+            transpose_b (bool, optional): Whether to transpose input_tensor_b. Defaults to `False`.
+            memory_config (ttnn.MemoryConfig, optional): the memory configuration of the output tensor. Defaults to `None`, which will result in using `ttnn.DRAM_MEMORY_CONFIG`.
+            dtype (ttnn.DataType, optional): the data type of the output tensor. Defaults to `None`.
+            program_config (MatmulProgramConfig, optional): the program configuration for the matmul operation. Defaults to `None`.
+            activation (str or ttnn.UnaryWithParam, optional): the activation function to be applied. Defaults to `None`. When using sharded tensors, the :attr:`fused_activation` parameter of the :attr:`program_config` should be used instead.
+            compute_kernel_config (ttnn.DeviceComputeKernelConfig, optional): the compute kernel configuration for the matmul operation. Defaults to `None`.
+            core_grid (ttnn.CoreGrid, optional): the grid on which to distribute the sharded tensor on (writes to the cores L1s). Defaults to `None`.
+            output_tile (List of [int], optional): Specifies the output tile configuration. Defaults to `None`.
+            optional_output_tensor (ttnn.Tensor, optional): User provided on-device output tensor where the result of linear is to be written. Defaults to `None`.
+            global_cb (ttnn.GlobalCircularBuffer, optional): the global circular buffer to be used for the matmul operation. Defaults to `None`.
+            sub_device_id (ttnn.SubDeviceId, optional): the sub device id to be used for the matmul operation. Defaults to `None`.
+
+        Returns:
+            List of ttnn.Tensor: the output tensors.
+        )doc",
+        ttnn::pybind_overload_t{
+            [](decltype(::ttnn::matmul_batched_weights)& self,
+               const ttnn::Tensor& input_tensor_a,
+               const std::vector<ttnn::Tensor>& input_tensors_b,
+               const bool transpose_a,
+               const bool transpose_b,
+               const std::optional<const ttnn::MemoryConfig>& memory_config,
+               const std::optional<const DataType> dtype,
+               const std::optional<const MatmulProgramConfig>& program_config,
+               const std::optional<const ::ttnn::Activation>& activation,
+               const std::optional<const DeviceComputeKernelConfig> compute_kernel_config,
+               const std::optional<const ttnn::CoreGrid> core_grid,
+               const std::optional<const tt::tt_metal::Tile>& output_tile,
+               std::optional<Tensor>& optional_output_tensor,
+               const std::optional<const GlobalCircularBuffer>& global_cb,
+               const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id) -> std::vector<ttnn::Tensor> {
+                return self(
+                    input_tensor_a,
+                    input_tensors_b,
+                    transpose_a,
+                    transpose_b,
+                    memory_config,
+                    dtype,
+                    program_config,
+                    activation,
+                    compute_kernel_config,
+                    core_grid,
+                    output_tile,
+                    optional_output_tensor,
+                    global_cb,
+                    sub_device_id);
+            },
+            py::arg("input_tensor_a"),
+            py::arg("input_tensors_b"),
+            py::kw_only(),
+            py::arg("transpose_a") = false,
+            py::arg("transpose_b") = false,
+            py::arg("memory_config") = std::nullopt,
+            py::arg("dtype") = std::nullopt,
+            py::arg("program_config") = std::nullopt,
+            py::arg("activation") = std::nullopt,
+            py::arg("compute_kernel_config") = std::nullopt,
+            py::arg("core_grid") = std::nullopt,
+            py::arg("output_tile") = std::nullopt,
+            py::arg("optional_output_tensor") = std::nullopt,
+            py::arg("global_cb") = std::nullopt,
+            py::arg("sub_device_id") = std::nullopt,
+        });
+
+    bind_registered_operation(
+        module,
         ::ttnn::addmm,
         R"doc(
         Returns a matrix products of tensors mat1_tensor and mat2_tensor. Tensor input_tensor is added to the final result.


### PR DESCRIPTION
This reverts commit d89c1e5c6df9529d3df5cf1ff516beed3d0f0f6c.

### Ticket
Causing failures on Llama 70b galaxy since matmul RS uses the existing codepath for the validation and cannot be removed.

### What's changed
- reverting this commit

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/20078438701) 
- [ ] [Galaxy demo](https://github.com/tenstorrent/tt-metal/actions/runs/20078468475)
- [ ] [Galaxy long context]()
- [ ] [Galaxy frequent tests](https://github.com/tenstorrent/tt-metal/actions/runs/20078514210)