### PR TITLE
[skip ci] Revert "Fix variable shadowing in test_waypoint.cpp"

### DIFF
--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_waypoint.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_waypoint.cpp
@@ -200,7 +200,8 @@ void RunTest(MeshWatcherFixture* fixture, const std::shared_ptr<distributed::Mes
                 if (tt::tt_metal::GetNumAvailableDevices() == 1 && !fixture->IsSlowDispatch()) {
                     // blank | prefetch, dispatch
                     int k_id = 1 + 2;
-                    k_id_s = fmt::format("{:3}|{:3}|{:3}", k_id, k_id + 1, k_id + 2);
+                    // NOLINTNEXTLINE(bugprone-unused-local-non-trivial-variable)
+                    std::string k_id_s = fmt::format("{:3}|{:3}|{:3}", k_id, k_id + 1, k_id + 2);
                 } else {
                     k_id_s = "";
                 }


### PR DESCRIPTION
### Ticket
NA

### Problem description
L2 Nightly started failing. Specifically for test_waypoint that was recently changed.

https://github.com/tenstorrent/tt-metal/actions/runs/20053668708/job/57514902092

### What's changed
- Revert change
- Mask LINT complaint

There is some bizarre variable shadowing going on in this test with `k_id_s`, but it is not urgent to fix.

### Checklist
- [x] https://github.com/tenstorrent/tt-metal/actions/runs/20079119263