### PR TITLE
Fix profiler events key error

### DIFF
--- a/tools/tracy/process_device_log.py
+++ b/tools/tracy/process_device_log.py
@@ -673,11 +673,10 @@ def timeseries_analysis(riscData, name, analysis):
 
 
 def timeseries_events(riscData, name, analysis):
+    if "events" not in riscData:
+        riscData["events"] = {}
     if analysis["type"] == "event":
-        if "events" not in riscData:
-            riscData["events"] = {name: []}
-        else:
-            riscData["events"][name] = []
+        riscData["events"][name] = []
 
         for index, (timerID, timestamp, attachedData, risc, *_) in enumerate(riscData["timeseries"]):
             if (timerID["type"] == "TS_EVENT" or timerID["type"] == "TS_DATA") and (

--- a/tools/tracy/process_ops_logs.py
+++ b/tools/tracy/process_ops_logs.py
@@ -462,8 +462,10 @@ def append_device_data(ops, traceReplays, logFolder, analyze_noc_traces, device_
             traceOps = {}
 
             # Check if perf counters data is available
-            events = deviceData["devices"][device]["cores"]["DEVICE"]["riscs"]["TENSIX"]["events"]
-            perf_counter_df = extract_perf_counters(events["perf_counter_data"])
+            riscData = deviceData["devices"][device]["cores"]["DEVICE"]["riscs"]["TENSIX"]
+            perf_counter_df = None
+            if "events" in riscData and "perf_counter_data" in riscData["events"]:
+                perf_counter_df = extract_perf_counters(riscData["events"]["perf_counter_data"])
             if perf_counter_df is not None and not perf_counter_df.empty:
                 total_compute_cores = deviceData["deviceInfo"]["max_compute_cores"]
 


### PR DESCRIPTION
### Problem description
Profiler post proc hits key error on some 
### What's changed
Check the existence of the key before accessing it. 

 
### Checklist
- [x] [All post commit- profiler only](https://github.com/tenstorrent/tt-metal/actions/runs/20080095438)
- [x] [T3K Profiler](https://github.com/tenstorrent/tt-metal/actions/runs/20080118357)