### PR TITLE
Fix SDPA decode for Q heads greater than 32 (GQA support)

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_scaled_dot_product_attention_decode.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_scaled_dot_product_attention_decode.py
@@ -596,6 +596,7 @@ def test_sdpa_decode(device, b, nh, nkv, s, d, dtype, grid_size, q_dtype, single
         [32, 32, 8, 4224, 128, (8, 8)],  # llama3.2 vision encoder on n150
         [8, 16, 4, 4224, 128, (8, 8)],  # llama3.2 vision encoder on n300
         [32, 4, 1, 4224, 128, (8, 8)],  # llama3.2 vision encoder on n300
+        [1, 64, 8, 2048, 128, (8, 8)],  # num q heads greater than 32
     ),
 )
 @pytest.mark.timeout(120)

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/compute_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/compute_common.hpp
@@ -466,10 +466,10 @@ void calculate_fused_max_sub_exp_add_tile(int scale_bf16) {
     }
 }
 
-template <bool SDPA_EXP_APPROX_MODE>
+template <bool SDPA_EXP_APPROX_MODE, int vector_mode = (int)VectorMode::C>
 void fused_max_sub_exp_add_tile(uint32_t idst, int scale_bf16) {
     _llk_math_eltwise_unary_sfpu_params_<false /*APPROXIMATE*/>(
-        calculate_fused_max_sub_exp_add_tile<SDPA_EXP_APPROX_MODE>, idst, (int)VectorMode::C, scale_bf16);
+        calculate_fused_max_sub_exp_add_tile<SDPA_EXP_APPROX_MODE>, idst, vector_mode, scale_bf16);
 }
 #endif
 
@@ -512,7 +512,7 @@ void correction_block(
         copy_tile(cb_worker_max, i, dst_reg_1);
         copy_tile(cb_prev_sum, i, dst_reg_3);
         copy_tile(cb_worker_sum, i, dst_reg_4);
-        MATH((fused_max_sub_exp_add_tile<EXP_APPROX_MODE>(0, scale_bf16)));
+        MATH((fused_max_sub_exp_add_tile<EXP_APPROX_MODE, vector_mode>(0, scale_bf16)));
         pack_tile(dst_reg_0, cb_exp_max_diff);
         pack_tile(dst_reg_1, cb_exp_max_diff_2);
         pack_tile(dst_reg_2, cb_cur_max);

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/sdpa_flash_decode.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/sdpa_flash_decode.cpp
@@ -213,7 +213,6 @@ void MAIN {
 
     // Loop through all heads assigned to core
     for (uint32_t cur_head_work = 0; cur_head_work < num_heads_per_core; ++cur_head_work) {
-
         /******************************************************************************
          *                           FLASH ATTENTION LOOP                             *
          ******************************************************************************/
@@ -476,7 +475,7 @@ void MAIN {
                     // * 5. PREV_SUM *= EXP_MAX_DIFF
                     // * 6. CUR_SUM = PREV_SUM_2 + PREV_SUM
                     // */
-                    correction_block<scale_fp32, (int)VectorMode::C>(
+                    correction_block<scale_fp32, vector_mode>(
                         cb_m_in,        // cb worker max
                         cb_prev_sum_2,  // cb worker sum
                         cb_cur_max,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/dataflow_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/dataflow_common.hpp
@@ -458,32 +458,43 @@ uint32_t write_tiles_to_memory(uint32_t& out_tile_id, const WriterType& out_writ
     return barrier_count;
 }
 
-template <uint32_t cb_out, uint32_t ELEMENT_SIZE, uint32_t barrier_threshold, typename WriterType>
+template <uint32_t cb_out, uint32_t ELEMENT_SIZE, uint32_t barrier_threshold, uint32_t PNHt, typename WriterType>
 uint32_t write_partial_tiles_to_memory(
-    uint32_t& out_tile_id,
+    uint32_t& out_tile_id,  // base tile index in DRAM for this batch
     const WriterType& out_writer,
     uint32_t& barrier_count,
-    uint32_t cur_head,
-    uint32_t num_heads_to_write,
-    uint32_t out_chunk_tiles) {
+    uint32_t cur_head,            // kv-head group index 0..num_kv_heads-1
+    uint32_t num_heads_to_write,  // q-heads per kv-head group, e.g. 8
+    uint32_t out_chunk_tiles) {   // total tiles = PNHt * vDHt
     constexpr uint32_t FACE_HW = 16;
-    constexpr uint32_t FACE_ELEMENT_CNT = FACE_HW * FACE_HW;  // 256
+    constexpr uint32_t TILE_HW = 32;
+    constexpr uint32_t FACE_ELEMENT_CNT = FACE_HW * FACE_HW;
     constexpr uint32_t tile_bytes = get_tile_size(cb_out);
     constexpr uint32_t FACE_LINE_BYTES = FACE_HW * ELEMENT_SIZE;
 
-    for (uint32_t tile = 0; tile < out_chunk_tiles; ++tile) {
-        uint64_t out_writer_noc_addr = get_noc_addr(out_tile_id, out_writer);
-        uint32_t l1_read_addr = get_read_ptr(cb_out) + tile * tile_bytes;
+    const uint32_t num_head_tiles = PNHt;
+    const uint32_t num_hidden_tiles = out_chunk_tiles / PNHt;
 
-        // write partial output for each head
+    uint32_t l1_base_addr = get_read_ptr(cb_out);
+
+    for (uint32_t hidden_tile = 0; hidden_tile < num_hidden_tiles; ++hidden_tile) {
         for (uint32_t head = 0; head < num_heads_to_write; ++head) {
-            uint32_t starting_row = cur_head * num_heads_to_write + head;
-            uint32_t in_tile_offset_by_starting_head =
-                starting_row < FACE_HW
-                    ? starting_row * FACE_LINE_BYTES
-                    : (starting_row + FACE_HW) * FACE_LINE_BYTES;  // Skip the second face which has FACE_HW rows
-            uint64_t out_writer_noc_addr_head = out_writer_noc_addr + in_tile_offset_by_starting_head;
-            uint32_t l1_read_addr_head = l1_read_addr + in_tile_offset_by_starting_head;
+            uint32_t starting_row = cur_head * num_heads_to_write + head;  // 0..63
+            uint32_t tile_row = starting_row % TILE_HW;                    // 0..31
+            uint32_t head_tile = starting_row / TILE_HW;                   // 0 or 1
+
+            uint32_t in_tile_offset = (tile_row < FACE_HW) ? tile_row * FACE_LINE_BYTES
+                                                           : (tile_row + FACE_HW) * FACE_LINE_BYTES;  // skip face
+
+            // 2D -> 1D tile index: [head_tile][hidden_tile]
+            uint32_t tile_index = head_tile * num_hidden_tiles + hidden_tile;
+
+            // L1: cb_out tile layout matches tile_index
+            uint32_t l1_read_addr_head = l1_base_addr + tile_index * tile_bytes + in_tile_offset;
+
+            // DRAM tile: global index = out_tile_id + tile_index
+            uint64_t out_writer_tile_addr = get_noc_addr(out_tile_id + tile_index, out_writer);
+            uint64_t out_writer_noc_addr_head = out_writer_tile_addr + in_tile_offset;
 
             // Write first phase
             noc_async_write(l1_read_addr_head, out_writer_noc_addr_head, FACE_LINE_BYTES);
@@ -499,9 +510,10 @@ uint32_t write_partial_tiles_to_memory(
                 barrier_count = 0;
             }
         }
-
-        ++out_tile_id;
     }
+
+    // We've consumed/written out_chunk_tiles tiles worth of data
+    out_tile_id += out_chunk_tiles;
     return barrier_count;
 }
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/dataflow_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/dataflow_common.hpp
@@ -471,17 +471,15 @@ uint32_t write_partial_tiles_to_memory(
     constexpr uint32_t FACE_ELEMENT_CNT = FACE_HW * FACE_HW;
     constexpr uint32_t tile_bytes = get_tile_size(cb_out);
     constexpr uint32_t FACE_LINE_BYTES = FACE_HW * ELEMENT_SIZE;
-
-    const uint32_t num_head_tiles = PNHt;
     const uint32_t num_hidden_tiles = out_chunk_tiles / PNHt;
 
     uint32_t l1_base_addr = get_read_ptr(cb_out);
 
     for (uint32_t hidden_tile = 0; hidden_tile < num_hidden_tiles; ++hidden_tile) {
         for (uint32_t head = 0; head < num_heads_to_write; ++head) {
-            uint32_t starting_row = cur_head * num_heads_to_write + head;  // 0..63
-            uint32_t tile_row = starting_row % TILE_HW;                    // 0..31
-            uint32_t head_tile = starting_row / TILE_HW;                   // 0 or 1
+            uint32_t starting_row = cur_head * num_heads_to_write + head;
+            uint32_t tile_row = starting_row % TILE_HW;
+            uint32_t head_tile = starting_row / TILE_HW;
 
             uint32_t in_tile_offset = (tile_row < FACE_HW) ? tile_row * FACE_LINE_BYTES
                                                            : (tile_row + FACE_HW) * FACE_LINE_BYTES;  // skip face

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/writer_decode_all.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/writer_decode_all.cpp
@@ -236,7 +236,7 @@ void kernel_main() {
             constexpr uint32_t num_heads_to_write = num_q_heads / num_kv_heads;  // each head is one row in a tile
 
             if (!is_out_sharded) {
-                barrier_count = write_partial_tiles_to_memory<cb_out, ELEMENT_SIZE, barrier_threshold>(
+                barrier_count = write_partial_tiles_to_memory<cb_out, ELEMENT_SIZE, barrier_threshold, PNHt>(
                     out_tile_id, out_writer, barrier_count, cur_head, num_heads_to_write, out_chunk_tiles);
             }
             // sharded out case


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/33440

### Problem description
Previously SDPA decode does not properly handle writing tiles beyond 32 number of q heads.
The issue was that in the following code snippet:
https://github.com/tenstorrent/tt-metal/blob/09e01989505c99103953274ea8bf902f1143d657/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/dataflow_common.hpp#L481

The starting row goes beyond tile size 32, then it indexes outside of expected memory boundaries.
We should only be iterating the outer loop across the hidden dimension then based on the q heads assigned to that core, we change indexing across rows.


### What's changed
- added a test case for SDPA decode non casual 
- added the above mentioned fixes

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/20080649474) 
- [x] [L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/runs/20080874559)
- [x] [SDPA stress tests](https://github.com/tenstorrent/tt-metal/actions/runs/20107442943)


