### PR TITLE
Change the way sequence lengths are padded in `tt_transformers` + model warmup sequence length changes

### DIFF
--- a/models/demos/gemma3/tt/model_config.py
+++ b/models/demos/gemma3/tt/model_config.py
@@ -14,6 +14,7 @@ from models.common.utility_functions import is_blackhole, is_wormhole_b0, neares
 from models.demos.gemma3.tt.load_checkpoints import convert_vision_hf_to_meta, convert_vision_meta_to_hf
 from models.tt_transformers.tt.common import (
     calculate_prefill_warmup_seq_lens,
+    cap_seq_lens_to_max_prefill_chunk_size,
     get_out_subblock_w,
     num_to_core_range_set,
 )
@@ -874,7 +875,7 @@ class ModelArgs(TTModelArgs):
         self.trace_prefill_supported_seq_lens = self.get_trace_prefill_supported_seq_lens()
 
     def get_warmup_prefill_supported_seq_lens(self):
-        DEFAULT_VALUE = 8192
+        DEFAULT_VALUE = self.max_prefill_chunk_size
         # This dictionary is used to override the default ceil warmup prefill value
         model_specific_ceil_warmup_lengths = {
             # e.g. "gemma-3-4b": 4096
@@ -883,7 +884,7 @@ class ModelArgs(TTModelArgs):
         max_seq_len_to_warmup = model_specific_ceil_warmup_lengths.get(self.base_model_name, DEFAULT_VALUE)
 
         to_warmup_seq_lens = calculate_prefill_warmup_seq_lens(
-            max_seq_len_to_warmup, self.trace_prefill_supported_seq_lens, self.max_seq_len
+            max_seq_len_to_warmup, self.trace_prefill_supported_seq_lens, self.max_prefill_chunk_size
         )
 
         to_warmup_seq_lens = self.filter_warmup_seq_lens(to_warmup_seq_lens)
@@ -909,7 +910,7 @@ class ModelArgs(TTModelArgs):
         # TODO: should be empty until https://github.com/tenstorrent/tt-metal/issues/33041 is fixed
         model_specific_supported_seq_lens = {
             # EXAMPLE: "gemma-3-4b": {
-            #     "N150": [128, 256, 512, 1024, 2048],
+            #     "N150": [128, 1024, 2048],
             # }
         }
 
@@ -919,12 +920,12 @@ class ModelArgs(TTModelArgs):
         # Try model-specific sequence lengths first
         result = model_specific_supported_seq_lens.get(model_name, {}).get(device_name)
         if result:
-            return result
+            return cap_seq_lens_to_max_prefill_chunk_size(result, self.max_prefill_chunk_size)
 
         # Fall back to default sequence lengths
         result = default_supported_seq_lens.get(device_name)
         if result:
-            return result
+            return cap_seq_lens_to_max_prefill_chunk_size(result, self.max_prefill_chunk_size)
 
         # No supported sequence lengths found, return empty list
         return []

--- a/models/demos/gpt_oss/tt/model_config.py
+++ b/models/demos/gpt_oss/tt/model_config.py
@@ -16,7 +16,11 @@ from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer
 
 import ttnn
 from models.common.utility_functions import is_blackhole, is_wormhole_b0
-from models.tt_transformers.tt.common import calculate_prefill_warmup_seq_lens, get_base_model_name
+from models.tt_transformers.tt.common import (
+    calculate_prefill_warmup_seq_lens,
+    cap_seq_lens_to_max_prefill_chunk_size,
+    get_base_model_name,
+)
 from models.tt_transformers.tt.load_checkpoints import convert_hf_qkv_to_meta_format
 
 
@@ -100,7 +104,7 @@ class ModelArgs:
         self.trace_prefill_supported_seq_lens = self.get_trace_prefill_supported_seq_lens()
 
     def get_warmup_prefill_supported_seq_lens(self):
-        DEFAULT_VALUE = 8192
+        DEFAULT_VALUE = self.max_prefill_chunk_size
         # This dictionary is used to override the default ceil warmup prefill value
         model_specific_ceil_warmup_lengths = {
             # e.g. "gpt-oss-120b": 4096
@@ -109,7 +113,7 @@ class ModelArgs:
         max_seq_len_to_warmup = model_specific_ceil_warmup_lengths.get(self.base_model_name, DEFAULT_VALUE)
 
         to_warmup_seq_lens = calculate_prefill_warmup_seq_lens(
-            max_seq_len_to_warmup, self.trace_prefill_supported_seq_lens, self.max_seq_len
+            max_seq_len_to_warmup, self.trace_prefill_supported_seq_lens, self.max_prefill_chunk_size
         )
 
         to_warmup_seq_lens = self.filter_warmup_seq_lens(to_warmup_seq_lens)
@@ -161,12 +165,12 @@ class ModelArgs:
         # Try model-specific sequence lengths first
         result = model_specific_supported_seq_lens.get(model_name, {}).get(device_name)
         if result:
-            return result
+            return cap_seq_lens_to_max_prefill_chunk_size(result, self.max_prefill_chunk_size)
 
         # Fall back to default sequence lengths
         result = default_supported_seq_lens.get(device_name)
         if result:
-            return result
+            return cap_seq_lens_to_max_prefill_chunk_size(result, self.max_prefill_chunk_size)
 
         # No supported sequence lengths found, return empty list
         return []

--- a/models/tt_transformers/tt/common.py
+++ b/models/tt_transformers/tt/common.py
@@ -545,7 +545,6 @@ def get_padded_prefill_len(seq_len: int) -> int:
     Get the padded prefill length for a given sequence length.
     This is used to pad the sequence length to the nearest power of 2.
     """
-    # Changed for UF release purposes
     # TODO: https://github.com/tenstorrent/tt-metal/issues/34117
     if seq_len <= 128:
         return 128

--- a/models/tt_transformers/tt/common.py
+++ b/models/tt_transformers/tt/common.py
@@ -542,29 +542,32 @@ def sample_host(tt_input, temperature=0.6, top_p=0.08, on_host=True):
 
 def get_padded_prefill_len(seq_len: int) -> int:
     """
-    If seq_len is less than 128, pad to 128
-    If seq_len is more than 128, pad to whichever is smaller: a power of 2 or a multiple of 2048
-    TODO: Generalize for max_mm_seq_len different from 2048
+    Get the padded prefill length for a given sequence length.
+    This is used to pad the sequence length to the nearest power of 2.
     """
+    # Changed for UF release purposes
+    # TODO: https://github.com/tenstorrent/tt-metal/issues/34117
     if seq_len <= 128:
         return 128
-    pow_2_pad = nearest_pow_2(seq_len)
-    mult_2048_pad = 2048 * math.ceil(seq_len / 2048)
-    min_extended_pad = min(pow_2_pad, mult_2048_pad)
-    return min_extended_pad
+    if seq_len <= 1024:
+        return 1024
+    else:
+        # return next power of 2 greater than seq_len
+        return 2 ** (seq_len - 1).bit_length()
 
 
-def get_all_padded_prefill_lengths(max_len: int = 8192):
-    # Powers of 2 up to max_length (but max 2048)
-    padded_lengths = [v for v in (1 << n for n in range(7, 12)) if v <= max_len]
+def get_all_padded_prefill_lengths(max_len):
+    lengths = [128]
+    k = 0
+    while (v := (1 << k) * 1024) <= max_len:
+        lengths.append(v)
+        k += 1
+    return lengths
 
-    # Multiples of 2048 up to max_len (skip dup 2048)
-    padded_lengths += [v for v in range(2048, max_len + 1, 2048) if v not in padded_lengths]
 
-    return sorted(list(padded_lengths))
-
-
-def calculate_prefill_warmup_seq_lens(max_seq_len_to_warmup, trace_supported_seq_lens, model_args_max_seq_len):
+def calculate_prefill_warmup_seq_lens(
+    max_seq_len_to_warmup, trace_supported_seq_lens, model_args_max_prefill_chunk_size
+):
     max_seq_len_to_warmup = get_padded_prefill_len(max_seq_len_to_warmup)
     to_warmup_seq_lens = get_all_padded_prefill_lengths(max_seq_len_to_warmup)
     for trace_supported_seq_len in trace_supported_seq_lens:
@@ -572,12 +575,15 @@ def calculate_prefill_warmup_seq_lens(max_seq_len_to_warmup, trace_supported_seq
             to_warmup_seq_lens.append(trace_supported_seq_len)
     to_warmup_seq_lens.sort()
 
-    for seq_len in to_warmup_seq_lens:
-        if seq_len > model_args_max_seq_len:
-            to_warmup_seq_lens = to_warmup_seq_lens[: to_warmup_seq_lens.index(seq_len)]
-            break
+    return cap_seq_lens_to_max_prefill_chunk_size(to_warmup_seq_lens, model_args_max_prefill_chunk_size)
 
-    return to_warmup_seq_lens
+
+def cap_seq_lens_to_max_prefill_chunk_size(seq_lens, max_prefill_chunk_size):
+    for seq_len in seq_lens:
+        if seq_len > max_prefill_chunk_size:
+            seq_lens = seq_lens[: seq_lens.index(seq_len)]
+            break
+    return seq_lens
 
 
 def get_block_size(kv_cache):

--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -18,6 +18,7 @@ from models.common.utility_functions import is_blackhole, is_wormhole_b0, neares
 from models.tt_transformers.tt.common import (
     calculate_hidden_dim,
     calculate_prefill_warmup_seq_lens,
+    cap_seq_lens_to_max_prefill_chunk_size,
     encode_prompt_hf,
     get_base_model_name,
     get_out_subblock_w,
@@ -1308,7 +1309,7 @@ class ModelArgs:
         self.trace_prefill_supported_seq_lens = self.get_trace_prefill_supported_seq_lens()
 
     def get_warmup_prefill_supported_seq_lens(self):
-        DEFAULT_VALUE = 8192
+        DEFAULT_VALUE = self.max_prefill_chunk_size
         # This dictionary is used to override the default ceil warmup prefill value
         model_specific_ceil_warmup_lengths = {
             # e.g. "Llama-3.1-8B": 4096
@@ -1317,7 +1318,7 @@ class ModelArgs:
         max_seq_len_to_warmup = model_specific_ceil_warmup_lengths.get(self.base_model_name, DEFAULT_VALUE)
 
         to_warmup_seq_lens = calculate_prefill_warmup_seq_lens(
-            max_seq_len_to_warmup, self.trace_prefill_supported_seq_lens, self.max_seq_len
+            max_seq_len_to_warmup, self.trace_prefill_supported_seq_lens, self.max_prefill_chunk_size
         )
 
         to_warmup_seq_lens = self.filter_warmup_seq_lens(to_warmup_seq_lens)
@@ -1338,28 +1339,28 @@ class ModelArgs:
 
     def get_trace_prefill_supported_seq_lens(self):
         default_supported_seq_lens = {
-            "N150": [128, 256, 512],
-            "N300": [128, 256, 512, 1024],
-            "T3K": [128, 256, 512, 1024],
-            "TG": [128, 256, 512, 1024],
+            "N150": [128],
+            "N300": [128, 1024],
+            "T3K": [128, 1024],
+            "TG": [128, 1024],
         }
 
         # TODO: If no specific sequence lengths are listed for a model and device, the default one will be used (from the default_supported_seq_lens dictionary)
         model_specific_supported_seq_lens = {
             "Llama-3.1-8B": {
-                "P100": [128, 256, 512, 1024],
-                "N150": [128, 256, 512, 1024],
-                "N300": [128, 256, 512, 1024, 2048, 4096, 8192],
-                "T3K": [128, 256, 512, 1024, 2048, 4096, 8192],
-                "TG": [128, 256, 512, 1024, 2048, 4096, 8192],
+                "P100": [128, 1024],
+                "N150": [128, 1024],
+                "N300": [128, 1024, 2048, 4096, 8192],
+                "T3K": [128, 1024, 2048, 4096, 8192],
+                "TG": [128, 1024, 2048, 4096, 8192],
             },
             "Llama-3.1-70B": {
-                "T3K": [128, 256, 512, 1024, 2048, 4096, 8192],
-                "TG": [128, 256, 512, 1024, 2048, 4096, 8192],
+                "T3K": [128, 1024, 2048, 4096, 8192],
+                "TG": [128, 1024, 2048, 4096, 8192],
             },
             "Llama-3.3-70B": {
-                "T3K": [128, 256, 512, 1024, 2048, 4096, 8192],
-                "TG": [128, 256, 512, 1024, 2048, 4096, 8192],
+                "T3K": [128, 1024, 2048, 4096, 8192],
+                "TG": [128, 1024, 2048, 4096, 8192],
             },
         }
 
@@ -1369,12 +1370,12 @@ class ModelArgs:
         # Try model-specific sequence lengths first
         result = model_specific_supported_seq_lens.get(model_name, {}).get(device_name)
         if result:
-            return result
+            return cap_seq_lens_to_max_prefill_chunk_size(result, self.max_prefill_chunk_size)
 
         # Fall back to default sequence lengths
         result = default_supported_seq_lens.get(device_name)
         if result:
-            return result
+            return cap_seq_lens_to_max_prefill_chunk_size(result, self.max_prefill_chunk_size)
 
         # No supported sequence lengths found, return empty list
         return []


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/34117)

### Problem description
Explained in the linked issue

### Checklist
- [x] (For models and ops writers) [Single-card demo tests] https://github.com/tenstorrent/tt-metal/actions/runs/20081175443
- [ ] [Galaxy demo tests, for Llama] https://github.com/tenstorrent/tt-metal/actions/runs/20081180723
- [x] (For runtime and ops writers) [T3000 unit tests] https://github.com/tenstorrent/tt-metal/actions/runs/20081185155
- [x] (For models and ops writers) [T3000 demo tests] https://github.com/tenstorrent/tt-metal/actions/runs/20081916337
- [x] (Blackhole demo tests) https://github.com/tenstorrent/tt-metal/actions/runs/20081217413
- [ ] (vLLM nightly) https://github.com/tenstorrent/tt-metal/actions/runs/20081929651