### PR TITLE
Pool2D Race Condition

### DIFF
--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_pool_2d.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_pool_2d.cpp
@@ -270,7 +270,7 @@ void MAIN {
 
                         cb_push_back(out_cb_id, in_ntiles_c);
                         cb_pop_front(pre_tilize_cb_id, TILE_HEIGHT * in_ntiles_c);
-                        cb_reserve_back(pre_tilize_cb_id, in_ntiles_c * TILE_HEIGHT);
+                        cb_reserve_back(pre_tilize_cb_id, TILE_HEIGHT * in_ntiles_c);
 
                         if constexpr (is_output_block_format) {
                             pack_reconfig_data_format(pre_tilize_cb_id);

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_pool_2d.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_pool_2d.cpp
@@ -251,6 +251,7 @@ void MAIN {
                     tile_regs_release();
 
                     if (tilize_stick_counter == TILE_HEIGHT) {
+                        cb_wait_front(pre_tilize_cb_id, TILE_HEIGHT * in_ntiles_c);
                         PACK((pack_untilize_uninit(pre_tilize_cb_id)));
 
                         // Workaround until #27504 is not closed
@@ -268,6 +269,8 @@ void MAIN {
                         fast_tilize_uninit(pre_tilize_cb_id, out_cb_id);
 
                         cb_push_back(out_cb_id, in_ntiles_c);
+                        cb_pop_front(pre_tilize_cb_id, TILE_HEIGHT * in_ntiles_c);
+                        cb_reserve_back(pre_tilize_cb_id, in_ntiles_c * TILE_HEIGHT);
 
                         if constexpr (is_output_block_format) {
                             pack_reconfig_data_format(pre_tilize_cb_id);


### PR DESCRIPTION
### Ticket
N/A

### Problem description
The Pool2D compute kernel has a potential race condition for tiled output formats because there is no synchronization logic around the `pre_tilize_cb_id`.  This means it is possible for `UNPACK` to race ahead and begin changing initialization states before `PACK` is done executing `fast_tilize`.

### What's changed
Wait, Reserve and Pop CB synchronization logic has been added around `pre_tilize_cb_id` where appropriate to ensure proper synchronization between `PACK` and `UNPACK`.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/20081187537
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/20081189802
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/20081206664
Failing on main, this PR hits same unrelated error
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/20081204142
Failing on main, this PR hits same unrelated error
- [x] [Nightly L2](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/20081192580
- [ ] [Nightly Blackhole](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-nightly-tests.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/20081195878
- [x] [Frequent model](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/20081199861
- [x] New/Existing tests provide coverage for changes