### PR TITLE
modernize-use-bool-literals

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -130,7 +130,6 @@ Checks: >
   -modernize-return-braced-init-list,
   -modernize-type-traits,
   -modernize-use-auto,
-  -modernize-use-bool-literals,
   -modernize-use-constraints,
   -modernize-use-default-member-init,
   -modernize-use-designated-initializers,

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -2018,7 +2018,7 @@ void update_program_dispatch_commands(
                 "Kernel binary size exceeds prefetcher cache size ({}, {})",
                 program_sizeB,
                 max_program_sizeB);
-            bool wraparound_flag = cache_offset != 0 ? 0 : CQ_PREFETCH_PAGED_TO_RING_BUFFER_FLAG_RESET_TO_START;
+            bool wraparound_flag = cache_offset != 0 ? false : CQ_PREFETCH_PAGED_TO_RING_BUFFER_FLAG_RESET_TO_START;
             cached_program_command_sequence.program_binary_setup_prefetcher_cache_command
                 .add_prefetch_paged_to_ringbuffer(CQPrefetchPagedToRingbufferCmd{
                     .flags = uint8_t(wraparound_flag),
@@ -2188,7 +2188,7 @@ void update_traced_program_dispatch_commands(
                 "Kernel binary size exceeds prefetcher cache size ({}, {})",
                 program_sizeB,
                 max_program_sizeB);
-            bool wraparound_flag = cache_offset != 0 ? 0 : CQ_PREFETCH_PAGED_TO_RING_BUFFER_FLAG_RESET_TO_START;
+            bool wraparound_flag = cache_offset != 0 ? false : CQ_PREFETCH_PAGED_TO_RING_BUFFER_FLAG_RESET_TO_START;
             cached_program_command_sequence.program_binary_setup_prefetcher_cache_command
                 .add_prefetch_paged_to_ringbuffer(CQPrefetchPagedToRingbufferCmd{
                     .flags = uint8_t(wraparound_flag),

--- a/tt_metal/tools/mem_bench/context.hpp
+++ b/tt_metal/tools/mem_bench/context.hpp
@@ -47,7 +47,7 @@ struct Context {
     int threads{0};
     int number_reader_kernels{0};
     int number_writer_kernels{0};
-    bool enable_host_copy_with_kernels{0};
+    bool enable_host_copy_with_kernels{false};
     int iterations{0};
 
     Context(

--- a/ttnn/cpp/ttnn/operations/ccl/all_to_all_combine/all_to_all_combine.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_to_all_combine/all_to_all_combine.hpp
@@ -17,7 +17,7 @@ struct ExecuteAllToAllCombine {
         const ttnn::Tensor& input_tensor,
         const ttnn::Tensor& expert_mapping_tensor,
         const ttnn::Tensor& expert_metadata_tensor,
-        bool locally_reduced = 1,
+        bool locally_reduced = true,
         std::optional<uint32_t> num_links = std::nullopt,
         std::optional<tt::tt_fabric::Topology> topology = std::nullopt,
         const std::optional<ttnn::MemoryConfig>& memory_config = std::nullopt,


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/22758

### Problem description
We have this check disabled: https://clang.llvm.org/extra/clang-tidy/checks/modernize/use-bool-literals.html

Boolean literals have existed since C++98. We are a C++20 code base. Lets use bool literals for consistency.

### What's changed
- Enable check
- Apply automatic FIXITs

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/20081716879) CI passes
- [x] New/Existing tests provide coverage for changes