### PR TITLE
Enable sharding support in all_to_al_async_generic

### DIFF
--- a/ttnn/cpp/ttnn/operations/ccl/ccl_host_datastructures.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_host_datastructures.cpp
@@ -55,11 +55,9 @@ uint32_t EriscDatamoverConfig::compute_buffer_size(
     return buffer_size;
 }
 
-// TODO: #24600
 CCLOpConfig::CCLOpConfig(
     std::vector<Tensor>& input_tensors, const std::vector<Tensor>& output_tensors, Topology topology) :
     page_size(0),
-    shard_grid_size(output_tensors.at(0).is_sharded() ? input_tensors.at(0).shard_spec()->num_cores() : 0),
     topology(topology),
     input_sharded(input_tensors.at(0).is_sharded()),
     output_sharded(output_tensors.at(0).is_sharded()),
@@ -83,8 +81,6 @@ Topology CCLOpConfig::get_topology() const { return this->topology; }
 bool CCLOpConfig::is_input_sharded() const { return this->input_sharded; }
 
 bool CCLOpConfig::is_output_sharded() const { return this->output_sharded; }
-
-bool CCLOpConfig::get_shard_grid_size() const { return this->shard_grid_size; }
 
 Tensor const& CCLOpConfig::get_input_tensor(std::size_t i) const { return input_tensors->at(i); }
 

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_host_datastructures.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_host_datastructures.hpp
@@ -53,14 +53,12 @@ public:
     Topology get_topology() const;
     bool is_input_sharded() const;
     bool is_output_sharded() const;
-    bool get_shard_grid_size() const;
     Tensor const& get_input_tensor(std::size_t i) const;
     Tensor const& get_output_tensor(std::size_t i) const;
     std::map<std::string, std::string> emit_worker_defines() const;
 
 private:
     uint32_t page_size;
-    uint32_t shard_grid_size;
     Topology topology;
     bool input_sharded;
     bool output_sharded;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/device/all_to_all_async_generic_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/device/all_to_all_async_generic_device_operation.cpp
@@ -35,10 +35,6 @@ void AllToAllAsyncGenericDeviceOperation::validate_on_program_cache_miss(
         "AllToAllAsync: input tensor dimension {} must be divisible by num_devices {}",
         input_shape[operation_attributes.out_dim],
         operation_attributes.num_devices);
-    TT_FATAL(
-        input_tensor.buffer()->buffer_type() == BufferType::DRAM,
-        "AllToAllAsync: Input tensor must be in DRAM, but is in {}",
-        input_tensor.buffer()->buffer_type());
     TT_FATAL(input_tensor.layout() == Layout::TILE, "Unsupported input layout {}.", input_tensor.layout());
 
     // recreate output shape to cover optional output buffer


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Sharded support was not enabled for input and output for all_to_all_async_generic
### What's changed
1. Removed shard_grid_size. This variable is incorrectly initialized and is never used. #24600
2. Removed DRAM buffer type validation in the C++ device operation to allow L1 and sharded memory configurations.
3. Extended all_to_all_async_generic test to validate pairs of sharded/interleaved input and output.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] [cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) job passes
- [ ] New/Existing tests provide coverage for changes