### PR TITLE
#0: Pow binary testing 

### DIFF
--- a/binary_pow_test_explanation.txt
+++ b/binary_pow_test_explanation.txt
@@ -1,0 +1,109 @@
+================================================================================
+                    BINARY POWER TEST EXPLANATION
+================================================================================
+
+TEST FILE: tests/ttnn/unit_tests/operations/eltwise/test_unary_pow.py
+FUNCTION: test_binary_pow_sweep(device)
+
+--------------------------------------------------------------------------------
+WHAT THE TEST DOES
+--------------------------------------------------------------------------------
+
+This test exhaustively validates the binary power operation (A^B) on the
+Tenstorrent device by testing across ALL possible bfloat16 (bf16) values.
+
+The test:
+1. Generates tensor A containing all possible bf16 bit patterns
+2. Iterates through each value in tensor A as the exponent B
+3. For each B value, computes A^B on device and compares against PyTorch golden
+4. Measures ULP (Units of Least Precision) error
+5. Logs any failures (ULP > 1) to a CSV file
+
+--------------------------------------------------------------------------------
+TENSOR A
+--------------------------------------------------------------------------------
+
+Tensor A contains: 65,536 values (2^16)
+
+This is because bfloat16 is a 16-bit floating point format:
+- 1 bit for sign
+- 8 bits for exponent
+- 7 bits for mantissa
+- Total: 16 bits = 2^16 = 65,536 unique bit patterns
+
+SPECIAL VALUES MASKED:
+The following special values are replaced with 1.0 to avoid undefined behavior:
+- NaN (Not a Number)
+- -0.0 (Negative zero)
+- +inf (Positive infinity)
+- -inf (Negative infinity)
+
+After masking, tensor A still has 65,536 elements, but special values are
+replaced with 1.0.
+
+--------------------------------------------------------------------------------
+TESTING
+--------------------------------------------------------------------------------
+
+ALL possible bf16 values are tested comprehensively:
+
+For TENSOR A (base values):
+- All 65,536 bf16 bit patterns are included
+- Special values (NaN, ±inf, -0.0) are masked to 1.0
+- Every element of A is tested in EVERY iteration
+
+For TENSOR B (exponent values):
+- The test iterates through ALL 65,536 values from tensor A
+- Each iteration uses ONE value from A as the exponent
+- That value is broadcast across all 65,536 elements of tensor B
+
+--------------------------------------------------------------------------------
+TOTAL TEST COVERAGE
+--------------------------------------------------------------------------------
+
+Number of iterations:           65,536 (one per B value)
+Operations per iteration:       65,536 (one A^B per element)
+Total power operations tested:  65,536 × 65,536 = 4,294,967,296 (~4.3 BILLION)
+
+This means the test covers:
+- Every possible bf16 base value (A)
+- Against every possible bf16 exponent value (B)
+- = Complete coverage of the bf16 × bf16 power operation space
+
+--------------------------------------------------------------------------------
+OUTPUT FILES
+--------------------------------------------------------------------------------
+
+1. CSV FILE: binary_pow_results.csv
+   - Only contains entries where ULP > 1 (failures)
+   - Columns: Input_B, Max_ULP, Failing_Values
+   - Failing_Values includes: file path to mismatch details + failing range
+
+2. MISMATCH FOLDER: binary_pow_ulp_mismatches/
+   - Contains detailed mismatch files for each failing B value
+   - Filename format: ulp_mismatches_b_{value}.txt
+   - Each file lists: Input A value, Calculated result, Golden result, ULP error
+
+--------------------------------------------------------------------------------
+EXAMPLE ITERATION
+--------------------------------------------------------------------------------
+
+Iteration i=1000:
+- B value = tensor_a[1000] (e.g., 3.5)
+- Tensor B = [3.5, 3.5, 3.5, ..., 3.5] (65,536 elements, all 3.5)
+- Tensor A = [val_0, val_1, val_2, ..., val_65535] (all bf16 values)
+- Compute: A^B = [val_0^3.5, val_1^3.5, val_2^3.5, ..., val_65535^3.5]
+- Compare against PyTorch golden result
+- If max ULP > 1: log to CSV and save mismatch details
+
+--------------------------------------------------------------------------------
+HOW TO RUN
+--------------------------------------------------------------------------------
+
+As pytest:
+    pytest test_unary_pow.py::test_binary_pow_sweep -v
+
+As standalone script:
+    python test_unary_pow.py
+
+================================================================================

--- a/models/common/utility_functions.py
+++ b/models/common/utility_functions.py
@@ -619,36 +619,24 @@ def ulp(x: Union[ttnn.Tensor, torch.Tensor]) -> Union[ttnn.Tensor, torch.Tensor]
     return ulp_value
 
 
-def comp_ulp_check(
-    input, golden, calculated, ulp_threshold, allow_nonfinite=False, input_b=None, output_dir="ulp_mismatches"
-):
+def comp_ulp_check(golden, calculated, allow_nonfinite=False):
     """
-    Compute absolute error between two tensors in Units of Least Precision (ULP)
+    Compute maximum ULP error between two tensors in Units of Least Precision (ULP)
 
     Args:
-        input: Input tensor A
         golden: Golden reference tensor
         calculated: Calculated tensor from device
-        ulp_threshold: ULP threshold for comparison
         allow_nonfinite: Whether to allow non-finite values
-        input_b: Optional input B - can be:
-                 - scalar value for binary operations with broadcast B
-                 - tensor (same shape as input) for element-wise binary operations where A==B
-                 - None for unary operations
-        output_dir: Directory to save mismatch files (default: "ulp_mismatches")
 
     Returns:
-        tuple: (max_ulp, file_path or None, failing_range or None)
+        float: Maximum ULP error between the tensors
     """
-    import os
-
-    # If both tensors are empty, then we can return True
+    # If both tensors are empty, return 0
     if torch.numel(golden) == 0 and torch.numel(calculated) == 0:
-        return 0.0, None, None
+        return 0.0
 
-    # nonfinite elments can intefere with ULP error calculation
+    # nonfinite elements can interfere with ULP error calculation
     # To avoid this, replace nan, +inf, -inf with 0
-    # (we have already checked that both tensors have the same nonfinite elements)
     mask_finite = ~torch.isfinite(golden)
     golden = golden.clone()
     calculated = calculated.clone()
@@ -659,8 +647,6 @@ def comp_ulp_check(
     # In most cases, data type of golden tensor should be the same as calculated tensor.
     # However, in some cases, we may want to measure < 1 ULP differences, which requires golden tensor
     # to have higher precision than calculated tensor.
-    # If we passed golden tensor to ulp() as is, we would get ULP of higher precision.
-    # e.g. ulp of float32 rather bfloat16 calculation, which would give us a wrong value.
     ulp_value = ulp(golden.type(calculated.dtype))
 
     if golden.dtype != calculated.dtype:  # Note: assumes that golden has higher precision than calculated tensor
@@ -668,80 +654,9 @@ def comp_ulp_check(
         ulp_value = ulp_value.type(golden.dtype)  # Convert ULP to higher precision (for sub-1 ULP measurements)
 
     ULP_Cond = torch.abs(calculated - golden) / ulp_value
-    mask = (ULP_Cond > 1.0) | torch.isnan(ULP_Cond)
+    max_ulp = torch.max(ULP_Cond).item()
 
-    ulp_delta = torch.max(ULP_Cond).item()
-    file_path = None
-    failing_range = None
-
-    # Determine if input_b is a scalar or a tensor (same shape as input means A==B case)
-    input_b_is_scalar = False
-    input_b_scalar_val = None
-    if input_b is not None:
-        if hasattr(input_b, "numel"):
-            # It's a tensor
-            if input_b.numel() == 1:
-                # Single element tensor - treat as scalar
-                input_b_is_scalar = True
-                input_b_scalar_val = input_b.item()
-            # else: Full tensor (A==B case) - don't use in filename
-        else:
-            # It's a Python scalar
-            input_b_is_scalar = True
-            input_b_scalar_val = input_b
-
-    if mask.any():
-        indices = torch.nonzero(mask, as_tuple=False)
-        output_lines = []
-        output_lines.append(f"Found {indices.shape[0]} values with ULP > 1:\n")
-
-        seen_inputs = set()
-        min_input = float("inf")
-        max_input = float("-inf")
-
-        for idx in indices:
-            idx_tuple = tuple(idx.tolist())
-            inp_val = input[idx_tuple].item()
-            # Update min and max
-            if inp_val < min_input:
-                min_input = inp_val
-            if inp_val > max_input:
-                max_input = inp_val
-
-            if inp_val in seen_inputs:
-                continue
-            seen_inputs.add(inp_val)
-
-            calc_val = calculated[idx_tuple].item()
-            golden_val = golden[idx_tuple].item()
-            ulp_val = ULP_Cond[idx_tuple].item()
-
-            # For A==B case, input value is used for both A and B
-            line = f"Input: {inp_val}, Calculated: {calc_val}, Golden: {golden_val}, ULP: {ulp_val}"
-            output_lines.append(line)
-
-        # Create output directory if it doesn't exist
-        os.makedirs(output_dir, exist_ok=True)
-
-        # Generate filename based on input_b if it's a scalar
-        if input_b_is_scalar and input_b_scalar_val is not None:
-            # Sanitize the value for use in filename (replace dots and minus signs)
-            sanitized_val = str(input_b_scalar_val).replace(".", "p").replace("-", "neg")
-            file_path = os.path.join(output_dir, f"ulp_mismatches_b_{sanitized_val}.txt")
-        else:
-            # For A==B case or no input_b, use generic filename
-            file_path = os.path.join(output_dir, "ulp_mismatches.txt")
-
-        with open(file_path, "w") as f:
-            f.write("\n".join(output_lines))
-
-        failing_range = f"({min_input}, {max_input})"
-        print(f"\nSaved mismatch details to {file_path}")
-        print(f"Failing range : {failing_range}")
-    else:
-        print("No values with ULP > 1 found.")
-
-    return ulp_delta, file_path, failing_range
+    return max_ulp
 
 
 def comp_ulp(golden, calculated, ulp_threshold, allow_nonfinite=False):

--- a/tests/ttnn/unit_tests/operations/eltwise/test_pow_special_values.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_pow_special_values.py
@@ -21,21 +21,22 @@ SPECIAL_VALUES = [
     0.0,
 ]
 
-# Names for special values (for CSV readability)
-SPECIAL_VALUE_NAMES = {
-    float("inf"): "inf",
-    float("-inf"): "-inf",
-    -0.0: "minus 0.0",
-    1.0: "1.0",
-    0.0: "0.0",
-}
-
 
 def get_value_name(val):
     """Get readable name for a special value."""
     if math.isnan(val):
         return "nan"
-    return SPECIAL_VALUE_NAMES.get(val, str(val))
+    elif math.isinf(val):
+        return "inf" if val > 0 else "-inf"
+    elif val == 0.0:
+        # Check for negative zero using copysign
+        # Note: -0.0 == 0.0 is True in Python, so we need copysign to distinguish
+        if math.copysign(1.0, val) < 0:
+            return "minus 0.0"
+        return "0.0"
+    elif val == 1.0:
+        return "1.0"
+    return str(val)
 
 
 def format_result(val):

--- a/tests/ttnn/unit_tests/operations/eltwise/test_pow_special_values.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_pow_special_values.py
@@ -1,0 +1,287 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import pytest
+import ttnn
+import csv
+import math
+import itertools
+from datetime import datetime
+
+
+# Special values to test
+SPECIAL_VALUES = [
+    float("inf"),
+    float("nan"),
+    float("-inf"),
+    -0.0,
+    1.0,
+    0.0,
+]
+
+# Names for special values (for CSV readability)
+SPECIAL_VALUE_NAMES = {
+    float("inf"): "inf",
+    float("-inf"): "-inf",
+    -0.0: "minus 0.0",
+    1.0: "1.0",
+    0.0: "0.0",
+}
+
+
+def get_value_name(val):
+    """Get readable name for a special value."""
+    if math.isnan(val):
+        return "nan"
+    return SPECIAL_VALUE_NAMES.get(val, str(val))
+
+
+def format_result(val):
+    """Format result value for CSV output."""
+    if isinstance(val, torch.Tensor):
+        val = val.item()
+    if math.isnan(val):
+        return "nan"
+    elif math.isinf(val):
+        return "inf" if val > 0 else "-inf"
+    elif val == 0.0:
+        # Check for negative zero
+        if math.copysign(1.0, val) < 0:
+            return "minus 0.0"
+        return "0.0"
+    return str(val)
+
+
+def test_binary_pow_special_values(device):
+    """
+    Test binary pow with all combinations of special values.
+    Tests: bf16, bf16-improved, fp32, fp32-improved
+    Each with check_fractional_ulp True and False.
+
+    Output CSV columns:
+    - case: test configuration (e.g., bf16-false, fp32-improved-true)
+    - input_a: input A value
+    - input_b: input B value
+    - ttnn_result: TTNN computed result
+    - golden_result: Torch golden reference result
+    - error: exception message if operation failed
+    """
+    csv_file_path = "binary_pow_special_values.csv"
+
+    # Generate all combinations of special values for A and B
+    combinations = list(itertools.product(SPECIAL_VALUES, SPECIAL_VALUES))
+
+    print(f"Testing binary pow with {len(combinations)} special value combinations...")
+    print(f"Special values: {[get_value_name(v) for v in SPECIAL_VALUES]}")
+
+    # Test configurations
+    test_configs = [
+        ("bf16-false", ttnn.bfloat16, torch.bfloat16, False, False),
+        ("bf16-true", ttnn.bfloat16, torch.bfloat16, True, False),
+        ("bf16-improved-false", ttnn.bfloat16, torch.bfloat16, False, True),
+        ("bf16-improved-true", ttnn.bfloat16, torch.bfloat16, True, True),
+        ("fp32-false", ttnn.float32, torch.float32, False, False),
+        ("fp32-true", ttnn.float32, torch.float32, True, False),
+        ("fp32-improved-false", ttnn.float32, torch.float32, False, True),
+        ("fp32-improved-true", ttnn.float32, torch.float32, True, True),
+    ]
+
+    with open(csv_file_path, "w", newline="") as csvfile:
+        fieldnames = ["case", "input_a", "input_b", "ttnn_result", "golden_result", "error"]
+        writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
+        writer.writeheader()
+
+        total_cases = 0
+        for case_name, ttnn_dtype, torch_dtype, check_fractional_ulp, use_improved in test_configs:
+            print(f"Testing case: {case_name}")
+
+            for a_val, b_val in combinations:
+                a_name = get_value_name(a_val)
+                b_name = get_value_name(b_val)
+
+                # Create tensors with single value (tile-sized for TTNN)
+                tensor_a = torch.full((1, 1, 32, 32), a_val, dtype=torch_dtype)
+                tensor_b = torch.full((1, 1, 32, 32), b_val, dtype=torch_dtype)
+
+                # Calculate golden result
+                if check_fractional_ulp:
+                    if torch_dtype == torch.bfloat16:
+                        golden = torch.pow(tensor_a.to(torch.float32), tensor_b.to(torch.float32))
+                    else:
+                        golden = torch.pow(tensor_a.to(torch.float64), tensor_b.to(torch.float64))
+                else:
+                    golden = torch.pow(tensor_a, tensor_b)
+
+                golden_val = golden[0, 0, 0, 0].item()
+
+                try:
+                    # Convert to TTNN tensors
+                    tt_a = ttnn.from_torch(
+                        tensor_a,
+                        dtype=ttnn_dtype,
+                        device=device,
+                        layout=ttnn.TILE_LAYOUT,
+                        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                    )
+                    tt_b = ttnn.from_torch(
+                        tensor_b,
+                        dtype=ttnn_dtype,
+                        device=device,
+                        layout=ttnn.TILE_LAYOUT,
+                        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                    )
+
+                    if use_improved:
+                        # Improved version using exp(b * log(a))
+                        tt_result = ttnn.multiply(
+                            tt_a,
+                            tt_b,
+                            input_tensor_a_activations=[ttnn.UnaryWithParam(ttnn.UnaryOpType.LOG)],
+                            activations=[ttnn.UnaryWithParam(ttnn.UnaryOpType.EXP, False)],
+                            use_legacy=False,
+                        )
+                    else:
+                        # Standard binary pow
+                        tt_result = ttnn.pow(tt_a, tt_b)
+
+                    result = ttnn.to_torch(tt_result)
+                    ttnn_val = result[0, 0, 0, 0].item()
+                    error_msg = ""
+
+                except Exception as e:
+                    ttnn_val = "ERROR"
+                    error_msg = str(e)
+
+                writer.writerow(
+                    {
+                        "case": case_name,
+                        "input_a": a_name,
+                        "input_b": b_name,
+                        "ttnn_result": format_result(ttnn_val) if ttnn_val != "ERROR" else "ERROR",
+                        "golden_result": format_result(golden_val),
+                        "error": error_msg,
+                    }
+                )
+                total_cases += 1
+
+    print(f"\nResults saved to {csv_file_path}")
+    print(f"Total test cases: {total_cases}")
+
+
+def test_unary_pow_special_values(device):
+    """
+    Test unary pow (scalar exponent) with all combinations of special values.
+    Tests: bf16, bf16-improved, fp32, fp32-improved
+    Each with check_fractional_ulp True and False.
+
+    Note: Unary pow with negative exponents is not supported and will raise an error.
+    This is documented in binary_composite_op.cpp:742: "works for positive exponents only"
+
+    Output CSV columns:
+    - case: test configuration (e.g., bf16-false, fp32-improved-true)
+    - input_a: input A tensor value
+    - input_b_scalar: input B scalar exponent value
+    - ttnn_result: TTNN computed result
+    - golden_result: Torch golden reference result
+    - error: exception message if operation failed (e.g., "UNSUPPORTED: works for positive exponents only")
+    """
+    csv_file_path = "unary_pow_special_values.csv"
+
+    # Generate all combinations of special values for A (tensor) and B (scalar)
+    combinations = list(itertools.product(SPECIAL_VALUES, SPECIAL_VALUES))
+
+    print(f"Testing unary pow with {len(combinations)} special value combinations...")
+    print(f"Special values: {[get_value_name(v) for v in SPECIAL_VALUES]}")
+    print("Note: Negative exponents are not supported for unary pow")
+
+    # Test configurations
+    test_configs = [
+        ("bf16-false", ttnn.bfloat16, torch.bfloat16, False, False),
+        ("bf16-true", ttnn.bfloat16, torch.bfloat16, True, False),
+        ("bf16-improved-false", ttnn.bfloat16, torch.bfloat16, False, True),
+        ("bf16-improved-true", ttnn.bfloat16, torch.bfloat16, True, True),
+        ("fp32-false", ttnn.float32, torch.float32, False, False),
+        ("fp32-true", ttnn.float32, torch.float32, True, False),
+        ("fp32-improved-false", ttnn.float32, torch.float32, False, True),
+        ("fp32-improved-true", ttnn.float32, torch.float32, True, True),
+    ]
+
+    with open(csv_file_path, "w", newline="") as csvfile:
+        fieldnames = ["case", "input_a", "input_b_scalar", "ttnn_result", "golden_result", "error"]
+        writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
+        writer.writeheader()
+
+        total_cases = 0
+        for case_name, ttnn_dtype, torch_dtype, check_fractional_ulp, use_improved in test_configs:
+            print(f"Testing case: {case_name}")
+
+            for a_val, b_scalar in combinations:
+                a_name = get_value_name(a_val)
+                b_name = get_value_name(b_scalar)
+
+                # Create tensor with single value (tile-sized for TTNN)
+                tensor_a = torch.full((1, 1, 32, 32), a_val, dtype=torch_dtype)
+
+                # Calculate golden result
+                if check_fractional_ulp:
+                    if torch_dtype == torch.bfloat16:
+                        golden = torch.pow(tensor_a.to(torch.float32), b_scalar)
+                    else:
+                        golden = torch.pow(tensor_a.to(torch.float64), b_scalar)
+                else:
+                    golden = torch.pow(tensor_a, b_scalar)
+
+                golden_val = golden[0, 0, 0, 0].item()
+
+                try:
+                    # Convert to TTNN tensor
+                    tt_a = ttnn.from_torch(
+                        tensor_a,
+                        dtype=ttnn_dtype,
+                        device=device,
+                        layout=ttnn.TILE_LAYOUT,
+                        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                    )
+
+                    if use_improved:
+                        # Improved version using exp(b * log(a))
+                        tt_result = ttnn.multiply(
+                            tt_a,
+                            b_scalar,
+                            input_tensor_a_activations=[ttnn.UnaryWithParam(ttnn.UnaryOpType.LOG)],
+                            activations=[ttnn.UnaryWithParam(ttnn.UnaryOpType.EXP, False)],
+                            use_legacy=False,
+                        )
+                    else:
+                        # Standard unary pow with scalar exponent
+                        # Note: This will raise TT_FATAL for negative exponents
+                        # Error message: "works for positive exponents only"
+                        tt_result = ttnn.pow(tt_a, b_scalar)
+
+                    result = ttnn.to_torch(tt_result)
+                    ttnn_val = result[0, 0, 0, 0].item()
+                    error_msg = ""
+
+                except Exception as e:
+                    ttnn_val = "ERROR"
+                    error_msg = str(e)
+                    # Check if it's the negative exponent error
+                    if "positive exponents only" in str(e):
+                        error_msg = "UNSUPPORTED: works for positive exponents only"
+
+                writer.writerow(
+                    {
+                        "case": case_name,
+                        "input_a": a_name,
+                        "input_b_scalar": b_name,
+                        "ttnn_result": format_result(ttnn_val) if ttnn_val != "ERROR" else "ERROR",
+                        "golden_result": format_result(golden_val),
+                        "error": error_msg,
+                    }
+                )
+                total_cases += 1
+
+    print(f"\nResults saved to {csv_file_path}")
+    print(f"Total test cases: {total_cases}")

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary_pow.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary_pow.py
@@ -6,9 +6,197 @@ import torch
 import pytest
 import ttnn
 import csv
-import os
+import math
+from datetime import datetime
 from tests.ttnn.utils_for_testing import assert_with_ulp
 from models.common.utility_functions import comp_ulp_check
+
+
+def _generate_summary_report(results, summary_file_path, test_name, data_type, num_a_values, num_b_values):
+    """
+    Generate a detailed summary report for binary power ULP analysis.
+
+    Args:
+        results: List of tuples (input_b, max_ulp)
+        summary_file_path: Path to save the summary report
+        test_name: Name of the test (e.g., "Binary Power (BF16)")
+        data_type: Data type used (e.g., "BFloat16", "Float32")
+        num_a_values: Number of A values tested
+        num_b_values: Number of B values tested
+    """
+    if not results:
+        return
+
+    # Separate results into three categories: finite, infinite, and NaN
+    finite_results = [(b, ulp) for b, ulp in results if math.isfinite(ulp)]
+    inf_results = [(b, ulp) for b, ulp in results if math.isinf(ulp)]
+    nan_results = [(b, ulp) for b, ulp in results if math.isnan(ulp)]
+
+    total_tests = len(results)
+    num_finite = len(finite_results)
+    num_inf = len(inf_results)
+    num_nan = len(nan_results)
+
+    # Calculate statistics for finite values only
+    if finite_results:
+        finite_ulp_values = [ulp for _, ulp in finite_results]
+        max_ulp_finite = max(finite_ulp_values)
+        min_ulp_finite = min(finite_ulp_values)
+
+        # Count values in different ULP ranges (finite only)
+        ulp_0 = sum(1 for ulp in finite_ulp_values if ulp == 0)
+        ulp_0_to_1 = sum(1 for ulp in finite_ulp_values if 0 < ulp <= 1)
+        ulp_1_to_2 = sum(1 for ulp in finite_ulp_values if 1 < ulp <= 2)
+        ulp_2_to_5 = sum(1 for ulp in finite_ulp_values if 2 < ulp <= 5)
+        ulp_5_to_10 = sum(1 for ulp in finite_ulp_values if 5 < ulp <= 10)
+        ulp_10_to_100 = sum(1 for ulp in finite_ulp_values if 10 < ulp <= 100)
+        ulp_above_100 = sum(1 for ulp in finite_ulp_values if ulp > 100)
+
+        # Find worst cases (top 10 highest finite ULP values)
+        sorted_finite_results = sorted(finite_results, key=lambda x: x[1], reverse=True)
+        worst_cases = sorted_finite_results[:10]
+    else:
+        max_ulp_finite = min_ulp_finite = 0
+        ulp_0 = ulp_0_to_1 = ulp_1_to_2 = ulp_2_to_5 = ulp_5_to_10 = ulp_10_to_100 = ulp_above_100 = 0
+        worst_cases = []
+
+    # Calculate pass rate (ULP <= 1 is typically considered passing, finite only)
+    pass_count_finite = ulp_0 + ulp_0_to_1
+    pass_rate_finite = (pass_count_finite / num_finite * 100) if num_finite > 0 else 0
+    # Overall pass rate considers inf and nan as failures
+    pass_rate_overall = (pass_count_finite / total_tests * 100) if total_tests > 0 else 0
+
+    # Generate report
+    with open(summary_file_path, "w") as f:
+        f.write("=" * 80 + "\n")
+        f.write(f"         BINARY POWER OPERATION - ULP ACCURACY ANALYSIS REPORT\n")
+        f.write("=" * 80 + "\n\n")
+
+        f.write(f"Report Generated: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n")
+        f.write(f"Test Name: {test_name}\n")
+        f.write(f"Data Type: {data_type}\n\n")
+
+        f.write("-" * 80 + "\n")
+        f.write("                           TEST CONFIGURATION\n")
+        f.write("-" * 80 + "\n")
+        f.write(f"  Input A Tensor Size:     {num_a_values:,} values\n")
+        f.write(f"  Input B Values Tested:   {num_b_values:,} values\n")
+        f.write(f"  Total Comparisons:       {total_tests:,}\n")
+        f.write(f"  Operation:               A^B (element-wise power)\n\n")
+
+        f.write("-" * 80 + "\n")
+        f.write("                        ULP CATEGORY BREAKDOWN\n")
+        f.write("-" * 80 + "\n")
+        f.write(f"  Finite ULP Cases:        {num_finite:>10,} ({(num_finite/total_tests)*100:>6.2f}%)\n")
+        f.write(f"  Infinite ULP Cases:      {num_inf:>10,} ({(num_inf/total_tests)*100:>6.2f}%)\n")
+        f.write(f"  NaN ULP Cases:           {num_nan:>10,} ({(num_nan/total_tests)*100:>6.2f}%)\n")
+        f.write(f"  {'─'*50}\n")
+        f.write(f"  Total:                   {total_tests:>10,} (100.00%)\n\n")
+
+        if num_finite > 0:
+            f.write("-" * 80 + "\n")
+            f.write("                    FINITE ULP STATISTICS\n")
+            f.write("-" * 80 + "\n")
+            f.write(f"  Maximum ULP Error:       {max_ulp_finite:.6f}\n")
+            f.write(f"  Minimum ULP Error:       {min_ulp_finite:.6f}\n")
+            f.write(f"  Percentage of ULP <= 1 : \n")
+            f.write(f"  - Finite cases only:     {pass_rate_finite:.2f}%\n")
+            f.write(f"  - Incl non-finite cases: {pass_rate_overall:.2f}%\n\n")
+
+            f.write("-" * 80 + "\n")
+            f.write("                    FINITE ULP DISTRIBUTION\n")
+            f.write("-" * 80 + "\n")
+            f.write(f"  ULP = 0 (Exact Match):   {ulp_0:>10,} ({(ulp_0/num_finite)*100:>6.2f}%)\n")
+            f.write(f"  0 < ULP <= 1:            {ulp_0_to_1:>10,} ({(ulp_0_to_1/num_finite)*100:>6.2f}%)\n")
+            f.write(f"  1 < ULP <= 2:            {ulp_1_to_2:>10,} ({(ulp_1_to_2/num_finite)*100:>6.2f}%)\n")
+            f.write(f"  2 < ULP <= 5:            {ulp_2_to_5:>10,} ({(ulp_2_to_5/num_finite)*100:>6.2f}%)\n")
+            f.write(f"  5 < ULP <= 10:           {ulp_5_to_10:>10,} ({(ulp_5_to_10/num_finite)*100:>6.2f}%)\n")
+            f.write(f"  10 < ULP <= 100:         {ulp_10_to_100:>10,} ({(ulp_10_to_100/num_finite)*100:>6.2f}%)\n")
+            f.write(f"  ULP > 100:               {ulp_above_100:>10,} ({(ulp_above_100/num_finite)*100:>6.2f}%)\n\n")
+
+        if num_inf > 0:
+            f.write("-" * 80 + "\n")
+            f.write("                    INFINITE ULP CASES\n")
+            f.write("-" * 80 + "\n")
+            f.write(f"  Total Infinite Cases:    {num_inf:,}\n\n")
+            # Format as comma-separated list on one line
+            sample_b_values = [f"{b_val:.10g}" for b_val, _ in inf_results[:20]]
+            b_list_str = " , ".join(sample_b_values)
+            if len(inf_results) > 20:
+                f.write(f"  For Input b = {b_list_str} and {len(inf_results) - 20} more\n\n")
+            else:
+                f.write(f"  For Input b = {b_list_str}\n\n")
+
+        if num_nan > 0:
+            f.write("-" * 80 + "\n")
+            f.write("                    NaN ULP CASES\n")
+            f.write("-" * 80 + "\n")
+            f.write(f"  Total NaN Cases:         {num_nan:,}\n\n")
+            # Format as comma-separated list on one line
+            sample_b_values = [f"{b_val:.10g}" for b_val, _ in nan_results[:20]]
+            b_list_str = " , ".join(sample_b_values)
+            if len(nan_results) > 20:
+                f.write(f"  For Input b = {b_list_str} and {len(nan_results) - 20} more\n\n")
+            else:
+                f.write(f"  For Input b = {b_list_str}\n\n")
+
+        if worst_cases:
+            f.write("-" * 80 + "\n")
+            f.write("                    WORST FINITE CASES (Highest ULP)\n")
+            f.write("-" * 80 + "\n")
+            f.write(f"  {'Rank':<6} {'Input B':<25} {'Max ULP':<20}\n")
+            f.write(f"  {'-'*6} {'-'*25} {'-'*20}\n")
+            for i, (b_val, ulp_val) in enumerate(worst_cases, 1):
+                f.write(f"  {i:<6} {b_val:<25.10g} {ulp_val:<20.6f}\n")
+            f.write("\n")
+
+        f.write("-" * 80 + "\n")
+        f.write("                              CONCLUSION\n")
+        f.write("-" * 80 + "\n")
+
+        # Determine status based on overall metrics
+        has_issues = num_inf > 0 or num_nan > 0
+        if pass_rate_overall >= 99.0 and not has_issues:
+            status = "EXCELLENT"
+            description = "The binary power operation demonstrates excellent numerical accuracy."
+        elif pass_rate_overall >= 95.0 and num_inf + num_nan < total_tests * 0.01:
+            status = "GOOD"
+            description = "The binary power operation shows good numerical accuracy with minor deviations."
+        elif pass_rate_overall >= 90.0:
+            status = "ACCEPTABLE"
+            description = "The binary power operation shows acceptable accuracy but some edge cases may need attention."
+        else:
+            status = "NEEDS IMPROVEMENT"
+            description = (
+                "The binary power operation shows significant numerical errors that may require investigation."
+            )
+
+        f.write(f"\n  Overall Status: {status}\n\n")
+        f.write(f"  {description}\n\n")
+        f.write(f"  Key Findings:\n")
+        f.write(f"    - {pass_count_finite:,} out of {total_tests:,} test cases passed (ULP <= 1)\n")
+        if num_finite > 0:
+            f.write(f"    - Maximum observed finite ULP error: {max_ulp_finite:.6f}\n")
+        if num_inf > 0:
+            f.write(f"    - {num_inf:,} cases produced Infinite ULP (possible overflow or undefined result)\n")
+        if num_nan > 0:
+            f.write(f"    - {num_nan:,} cases produced NaN ULP (possible invalid computation)\n")
+        if ulp_above_100 > 0:
+            f.write(f"    - {ulp_above_100:,} cases with finite ULP > 100 may indicate edge case issues\n")
+        if ulp_0 > 0:
+            f.write(f"    - {ulp_0:,} cases achieved exact match (ULP = 0)\n")
+
+        if num_inf > 0 or num_nan > 0:
+            f.write(f"\n  Recommendations:\n")
+            if num_inf > 0:
+                f.write(f"    - Review {num_inf:,} Infinite ULP cases for potential overflow conditions\n")
+            if num_nan > 0:
+                f.write(f"    - Investigate {num_nan:,} NaN ULP cases for invalid input combinations\n")
+        f.write("\n")
+
+        f.write("=" * 80 + "\n")
+        f.write("                           END OF REPORT\n")
+        f.write("=" * 80 + "\n")
 
 
 @pytest.mark.parametrize("exponent", [0.0, 1.0, 2.0, 3.0])
@@ -50,16 +238,13 @@ def test_pow_arange_masking_binary(device):
     tt_result = ttnn.pow(tt_in, tt_in)
     result = ttnn.to_torch(tt_result)
 
-    # Run comp_ulp_check to get ULP and mismatch info
-    max_ulp, mismatch_file_path, failing_range = comp_ulp_check(
-        input=tt_input,
+    # Run comp_ulp_check to get max ULP
+    max_ulp = comp_ulp_check(
         golden=golden,
         calculated=result,
-        ulp_threshold=1,
         allow_nonfinite=True,
-        input_b=tt_input,
-        output_dir="binary_pow_mismatches.txt",
     )
+    print(f"Max ULP: {max_ulp}")
 
     assert_with_ulp(golden, result, 1, allow_nonfinite=True)
 
@@ -83,26 +268,27 @@ def generate_clean_bf16_tensor(dtype=torch.bfloat16):
     return fp32.to(dtype)
 
 
-def test_binary_pow_sweep_BF16_test(device):
+@pytest.mark.parametrize("check_fractional_ulp", [True, False])
+def test_binary_pow_sweep_BF16_test(device, check_fractional_ulp):
     # Generate clean bf16 tensor (tensor A)
-    # tensor_a = generate_clean_bf16_tensor() # bf16 vs bf16
-    tensor_a = generate_clean_bf16_tensor(torch.float32)  # bf16 vs fp32
+    tensor_a = generate_clean_bf16_tensor()
     num_values = tensor_a.numel()
 
-    # Output directory for mismatch files
-    output_dir = "binary_pow_ulp_mismatches"
-    os.makedirs(output_dir, exist_ok=True)
+    # CSV and summary file paths based on check_fractional_ulp parameter
+    fractional_suffix = "true" if check_fractional_ulp else "false"
+    csv_file_path = f"binary_pow_bf16_results_{fractional_suffix}.csv"
+    summary_file_path = f"binary_pow_bf16_summary_{fractional_suffix}.txt"
 
-    # CSV file path
-    csv_file_path = "binary_pow_results.csv"
-
-    print(f"Testing binary pow with {num_values} B values...")
+    print(f"Testing binary pow (BF16) with {num_values} B values...")
     print(f"Each iteration tests {num_values} element-wise A^B operations")
+
+    # Collect results for summary
+    all_results = []
 
     # Open CSV file for writing results
     with open(csv_file_path, "w", newline="") as csvfile:
         csv_writer = csv.writer(csvfile)
-        csv_writer.writerow(["Input_B", "Max_ULP", "Failing_Values"])
+        csv_writer.writerow(["Input_B", "Max_ULP"])
 
         # Iterate through each value in tensor_a as the B value
         for i in range(num_values):
@@ -111,19 +297,18 @@ def test_binary_pow_sweep_BF16_test(device):
             b_scalar = b_val.item()
 
             # Create tensor B filled with this single value
-            # tensor_b = torch.full_like(tensor_a, b_scalar, dtype=torch.bfloat16) # bf16 vs bf16
-            tensor_b = torch.full_like(tensor_a, b_scalar, dtype=torch.float32)  # bf16 vs fp32
+            tensor_b = torch.full_like(tensor_a, b_scalar, dtype=torch.bfloat16)
 
             # Convert to ttnn tensors
             tt_a = ttnn.from_torch(
-                tensor_a.to(torch.bfloat16),
+                tensor_a,
                 dtype=ttnn.bfloat16,
                 device=device,
                 layout=ttnn.TILE_LAYOUT,
                 memory_config=ttnn.DRAM_MEMORY_CONFIG,
             )
             tt_b = ttnn.from_torch(
-                tensor_b.to(torch.bfloat16),
+                tensor_b,
                 dtype=ttnn.bfloat16,
                 device=device,
                 layout=ttnn.TILE_LAYOUT,
@@ -131,61 +316,65 @@ def test_binary_pow_sweep_BF16_test(device):
             )
 
             # Calculate golden result using torch
-            golden = torch.pow(tensor_a, tensor_b)
+            if not check_fractional_ulp:
+                golden = torch.pow(tensor_a, tensor_b)  # bf16 vs bf16
+            else:
+                golden = torch.pow(tensor_a.to(torch.float32), tensor_b.to(torch.float32))  # bf16 vs fp32
 
             # Run ttnn binary pow
             tt_result = ttnn.pow(tt_a, tt_b)
             result = ttnn.to_torch(tt_result)
 
-            # Run comp_ulp_check to get ULP and mismatch info
-            max_ulp, mismatch_file_path, failing_range = comp_ulp_check(
-                input=tensor_a,
+            # Run comp_ulp_check to get max ULP
+            max_ulp = comp_ulp_check(
                 golden=golden,
                 calculated=result,
-                ulp_threshold=1,
                 allow_nonfinite=True,
-                input_b=b_val,
-                output_dir=output_dir,
             )
 
-            # Only write to CSV if ULP > 1
-            if max_ulp > 1:
-                # Format failing values column
-                if mismatch_file_path is not None and failing_range is not None:
-                    failing_values = f"File: {mismatch_file_path}, Range: {failing_range}"
-                else:
-                    failing_values = "No mismatches"
+            # Write to CSV
+            csv_writer.writerow([b_scalar, max_ulp])
+            all_results.append((b_scalar, max_ulp))
 
-                # Write to CSV
-                csv_writer.writerow([b_scalar, max_ulp, failing_values])
-
-            # Print progress every 1000000 iterations
-            if (i + 1) % 1000000 == 0:
+            # Print progress every 1000 iterations
+            if (i + 1) % 1000 == 0:
                 print(f"Processed {i + 1}/{num_values} B values...")
 
+    # Generate summary report
+    _generate_summary_report(
+        results=all_results,
+        summary_file_path=summary_file_path,
+        test_name="Binary Power (BF16)",
+        data_type="BFloat16",
+        num_a_values=num_values,
+        num_b_values=num_values,
+    )
+
     print(f"\nResults saved to {csv_file_path}")
-    print(f"ULP mismatch details saved to {output_dir}/")
+    print(f"Summary report saved to {summary_file_path}")
 
 
-def test_binary_pow_sweep_FP32_test(device):
+@pytest.mark.parametrize("check_fractional_ulp", [True, False])
+def test_binary_pow_sweep_FP32_test(device, check_fractional_ulp):
     # Generate clean bf16 tensor (tensor A)
     tensor_a = generate_clean_bf16_tensor(torch.float32)
     num_values = tensor_a.numel()
 
-    # Output directory for mismatch files
-    output_dir = "binary_pow_ulp_mismatches"
-    os.makedirs(output_dir, exist_ok=True)
+    # CSV and summary file paths based on check_fractional_ulp parameter
+    fractional_suffix = "true" if check_fractional_ulp else "false"
+    csv_file_path = f"binary_pow_fp32_results_{fractional_suffix}.csv"
+    summary_file_path = f"binary_pow_fp32_summary_{fractional_suffix}.txt"
 
-    # CSV file path
-    csv_file_path = "binary_pow_results.csv"
-
-    print(f"Testing binary pow with {num_values} B values...")
+    print(f"Testing binary pow (FP32) with {num_values} B values...")
     print(f"Each iteration tests {num_values} element-wise A^B operations")
+
+    # Collect results for summary
+    all_results = []
 
     # Open CSV file for writing results
     with open(csv_file_path, "w", newline="") as csvfile:
         csv_writer = csv.writer(csvfile)
-        csv_writer.writerow(["Input_B", "Max_ULP", "Failing_Values"])
+        csv_writer.writerow(["Input_B", "Max_ULP"])
 
         # Iterate through each value in tensor_a as the B value
         for i in range(num_values):
@@ -212,39 +401,273 @@ def test_binary_pow_sweep_FP32_test(device):
                 memory_config=ttnn.DRAM_MEMORY_CONFIG,
             )
 
-            # Calculate golden result using torch
-            golden = torch.pow(tensor_a, tensor_b)  # fp32 vs fp32
-            # golden = torch.pow(tensor_a.to(torch.float64), tensor_b.to(torch.float64)) # fp32 vs fp64
+            # Calculate golden result using torch (fp64 for higher precision reference)
+            if not check_fractional_ulp:
+                golden = torch.pow(tensor_a, tensor_b)  # fp32 vs fp32
+            else:
+                golden = torch.pow(tensor_a.to(torch.float64), tensor_b.to(torch.float64))  # fp32 vs fp64
 
             # Run ttnn binary pow
             tt_result = ttnn.pow(tt_a, tt_b)
             result = ttnn.to_torch(tt_result)
 
-            # Run comp_ulp_check to get ULP and mismatch info
-            max_ulp, mismatch_file_path, failing_range = comp_ulp_check(
-                input=tensor_a,
+            # Run comp_ulp_check to get max ULP
+            max_ulp = comp_ulp_check(
                 golden=golden,
                 calculated=result,
-                ulp_threshold=1,
                 allow_nonfinite=True,
-                input_b=b_val,
-                output_dir=output_dir,
             )
 
-            # Only write to CSV if ULP > 1
-            if max_ulp > 1:
-                # Format failing values column
-                if mismatch_file_path is not None and failing_range is not None:
-                    failing_values = f"File: {mismatch_file_path}, Range: {failing_range}"
-                else:
-                    failing_values = "No mismatches"
+            # Write to CSV
+            csv_writer.writerow([b_scalar, max_ulp])
+            all_results.append((b_scalar, max_ulp))
 
-                # Write to CSV
-                csv_writer.writerow([b_scalar, max_ulp, failing_values])
-
-            # Print progress every 1000000 iterations
-            if (i + 1) % 1000000 == 0:
+            # Print progress every 1000 iterations
+            if (i + 1) % 1000 == 0:
                 print(f"Processed {i + 1}/{num_values} B values...")
 
+    # Generate summary report
+    _generate_summary_report(
+        results=all_results,
+        summary_file_path=summary_file_path,
+        test_name="Binary Power (FP32)",
+        data_type="Float32",
+        num_a_values=num_values,
+        num_b_values=num_values,
+    )
+
     print(f"\nResults saved to {csv_file_path}")
-    print(f"ULP mismatch details saved to {output_dir}/")
+    print(f"Summary report saved to {summary_file_path}")
+
+
+# **************************************************
+# **************************************************
+
+# Check with new exp, log
+# Exp Improved for fp32
+# Log improved for both dtypes
+
+# **************************************************
+# **************************************************
+
+
+def test_pow_arange_masking_binary_improved(device):
+    # Generate all possible bit pattern for bf16
+    tt_input = generate_clean_bf16_tensor()
+
+    tt_in = ttnn.from_torch(
+        tt_input,
+        dtype=ttnn.bfloat16,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    golden = torch.pow(tt_input, tt_input)
+
+    # tt_result = ttnn.pow(tt_in, tt_in)
+    tt_result = ttnn.multiply(
+        tt_in,
+        tt_in,
+        input_tensor_a_activations=[ttnn.UnaryWithParam(ttnn.UnaryOpType.LOG)],
+        activations=[ttnn.UnaryWithParam(ttnn.UnaryOpType.EXP, False)],
+        use_legacy=False,
+    )
+    result = ttnn.to_torch(tt_result)
+    print(f"Result: {result}")
+
+    # Run comp_ulp_check to get max ULP
+    max_ulp = comp_ulp_check(
+        golden=golden,
+        calculated=result,
+        allow_nonfinite=True,
+    )
+    print(f"Max ULP: {max_ulp}")
+
+    assert_with_ulp(golden, result, 1, allow_nonfinite=True)
+
+
+@pytest.mark.parametrize("check_fractional_ulp", [True, False])
+def test_binary_pow_sweep_BF16_test_improved(device, check_fractional_ulp):
+    # Generate clean bf16 tensor (tensor A)
+    tensor_a = generate_clean_bf16_tensor()
+    num_values = tensor_a.numel()
+
+    # CSV and summary file paths based on check_fractional_ulp parameter
+    fractional_suffix = "true" if check_fractional_ulp else "false"
+    csv_file_path = f"binary_pow_bf16_improved_results_{fractional_suffix}.csv"
+    summary_file_path = f"binary_pow_bf16_improved_summary_{fractional_suffix}.txt"
+
+    print(f"Testing binary pow (BF16) with {num_values} B values...")
+    print(f"Each iteration tests {num_values} element-wise A^B operations")
+
+    # Collect results for summary
+    all_results = []
+
+    # Open CSV file for writing results
+    with open(csv_file_path, "w", newline="") as csvfile:
+        csv_writer = csv.writer(csvfile)
+        csv_writer.writerow(["Input_B", "Max_ULP"])
+
+        # Iterate through each value in tensor_a as the B value
+        for i in range(num_values):
+            # Get the i-th value from tensor_a to use as B
+            b_val = tensor_a[i]
+            b_scalar = b_val.item()
+
+            # Create tensor B filled with this single value
+            tensor_b = torch.full_like(tensor_a, b_scalar, dtype=torch.bfloat16)
+
+            # Convert to ttnn tensors
+            tt_a = ttnn.from_torch(
+                tensor_a,
+                dtype=ttnn.bfloat16,
+                device=device,
+                layout=ttnn.TILE_LAYOUT,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            )
+            tt_b = ttnn.from_torch(
+                tensor_b,
+                dtype=ttnn.bfloat16,
+                device=device,
+                layout=ttnn.TILE_LAYOUT,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            )
+
+            # Calculate golden result using torch
+            if not check_fractional_ulp:
+                golden = torch.pow(tensor_a, tensor_b)  # bf16 vs bf16
+            else:
+                golden = torch.pow(tensor_a.to(torch.float32), tensor_b.to(torch.float32))  # bf16 vs fp32
+
+            # Run ttnn binary pow
+            # tt_result = ttnn.pow(tt_a, tt_b)
+            tt_result = ttnn.multiply(
+                tt_a,
+                tt_b,
+                input_tensor_a_activations=[ttnn.UnaryWithParam(ttnn.UnaryOpType.LOG)],
+                activations=[ttnn.UnaryWithParam(ttnn.UnaryOpType.EXP, False)],
+                use_legacy=False,
+            )
+            result = ttnn.to_torch(tt_result)
+
+            # Run comp_ulp_check to get max ULP
+            max_ulp = comp_ulp_check(
+                golden=golden,
+                calculated=result,
+                allow_nonfinite=True,
+            )
+
+            # Write to CSV
+            csv_writer.writerow([b_scalar, max_ulp])
+            all_results.append((b_scalar, max_ulp))
+
+            # Print progress every 1000 iterations
+            if (i + 1) % 1000 == 0:
+                print(f"Processed {i + 1}/{num_values} B values...")
+
+    # Generate summary report
+    _generate_summary_report(
+        results=all_results,
+        summary_file_path=summary_file_path,
+        test_name="Binary Power (BF16)",
+        data_type="BFloat16",
+        num_a_values=num_values,
+        num_b_values=num_values,
+    )
+
+    print(f"\nResults saved to {csv_file_path}")
+    print(f"Summary report saved to {summary_file_path}")
+
+
+@pytest.mark.parametrize("check_fractional_ulp", [True, False])
+def test_binary_pow_sweep_FP32_test_improved(device, check_fractional_ulp):
+    # Generate clean bf16 tensor (tensor A)
+    tensor_a = generate_clean_bf16_tensor(torch.float32)
+    num_values = tensor_a.numel()
+
+    # CSV and summary file paths based on check_fractional_ulp parameter
+    fractional_suffix = "true" if check_fractional_ulp else "false"
+    csv_file_path = f"binary_pow_fp32_improved_results_{fractional_suffix}.csv"
+    summary_file_path = f"binary_pow_fp32_improved_summary_{fractional_suffix}.txt"
+
+    print(f"Testing binary pow (FP32) with {num_values} B values...")
+    print(f"Each iteration tests {num_values} element-wise A^B operations")
+
+    # Collect results for summary
+    all_results = []
+
+    # Open CSV file for writing results
+    with open(csv_file_path, "w", newline="") as csvfile:
+        csv_writer = csv.writer(csvfile)
+        csv_writer.writerow(["Input_B", "Max_ULP"])
+
+        # Iterate through each value in tensor_a as the B value
+        for i in range(num_values):
+            # Get the i-th value from tensor_a to use as B
+            b_val = tensor_a[i]
+            b_scalar = b_val.item()
+
+            # Create tensor B filled with this single value
+            tensor_b = torch.full_like(tensor_a, b_scalar, dtype=torch.float32)
+
+            # Convert to ttnn tensors
+            tt_a = ttnn.from_torch(
+                tensor_a,
+                dtype=ttnn.float32,
+                device=device,
+                layout=ttnn.TILE_LAYOUT,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            )
+            tt_b = ttnn.from_torch(
+                tensor_b,
+                dtype=ttnn.float32,
+                device=device,
+                layout=ttnn.TILE_LAYOUT,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            )
+
+            # Calculate golden result using torch (fp64 for higher precision reference)
+            if not check_fractional_ulp:
+                golden = torch.pow(tensor_a, tensor_b)  # fp32 vs fp32
+            else:
+                golden = torch.pow(tensor_a.to(torch.float64), tensor_b.to(torch.float64))  # fp32 vs fp64
+
+            # Run ttnn binary pow
+            # tt_result = ttnn.pow(tt_a, tt_b)
+            tt_result = ttnn.multiply(
+                tt_a,
+                tt_b,
+                input_tensor_a_activations=[ttnn.UnaryWithParam(ttnn.UnaryOpType.LOG)],
+                activations=[ttnn.UnaryWithParam(ttnn.UnaryOpType.EXP, False)],
+                use_legacy=False,
+            )
+            result = ttnn.to_torch(tt_result)
+
+            # Run comp_ulp_check to get max ULP
+            max_ulp = comp_ulp_check(
+                golden=golden,
+                calculated=result,
+                allow_nonfinite=True,
+            )
+
+            # Write to CSV
+            csv_writer.writerow([b_scalar, max_ulp])
+            all_results.append((b_scalar, max_ulp))
+
+            # Print progress every 1000 iterations
+            if (i + 1) % 1000 == 0:
+                print(f"Processed {i + 1}/{num_values} B values...")
+
+    # Generate summary report
+    _generate_summary_report(
+        results=all_results,
+        summary_file_path=summary_file_path,
+        test_name="Binary Power (FP32)",
+        data_type="Float32",
+        num_a_values=num_values,
+        num_b_values=num_values,
+    )
+
+    print(f"\nResults saved to {csv_file_path}")
+    print(f"Summary report saved to {summary_file_path}")

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary_pow.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary_pow.py
@@ -727,11 +727,20 @@ def test_unary_pow_sweep_BF16_scalar_test(device, check_fractional_ulp):
     # Collect results for summary
     all_results = []
 
+    # Filter to only positive exponents
+    positive_count = 0
+
     # Iterate through each value in tensor_a as the scalar B value
     for i in range(num_values):
         # Get the i-th value from tensor_a to use as scalar B
         b_val = tensor_a[i]
         b_scalar = b_val.item()
+
+        # Skip negative exponents
+        if b_scalar < 0:
+            continue
+
+        positive_count += 1
 
         # Convert to ttnn tensor
         tt_a = ttnn.from_torch(
@@ -762,14 +771,16 @@ def test_unary_pow_sweep_BF16_scalar_test(device, check_fractional_ulp):
         all_results.append((b_scalar, max_ulp))
 
         # Print progress every 1000 iterations
-        if (i + 1) % 1000 == 0:
-            print(f"Processed {i + 1}/{num_values} B values...")
+        if positive_count % 1000 == 0:
+            print(f"Processed {positive_count} positive B values...")
+
+    print(f"Total positive exponents tested: {positive_count}")
 
     # Generate summary report
     _generate_summary_report(
         results=all_results,
         summary_file_path=summary_file_path,
-        test_name="Unary Power (BF16) - Scalar Exponent",
+        test_name="Unary Power (BF16) - Scalar Exponent (Positive Only)",
         data_type="BFloat16",
         num_a_values=num_values,
         num_b_values=num_values,
@@ -794,11 +805,20 @@ def test_unary_pow_sweep_FP32_scalar_test(device, check_fractional_ulp):
     # Collect results for summary
     all_results = []
 
+    # Filter to only positive exponents
+    positive_count = 0
+
     # Iterate through each value in tensor_a as the scalar B value
     for i in range(num_values):
         # Get the i-th value from tensor_a to use as scalar B
         b_val = tensor_a[i]
         b_scalar = b_val.item()
+
+        # Skip negative exponents
+        if b_scalar < 0:
+            continue
+
+        positive_count += 1
 
         # Convert to ttnn tensor
         tt_a = ttnn.from_torch(
@@ -829,14 +849,16 @@ def test_unary_pow_sweep_FP32_scalar_test(device, check_fractional_ulp):
         all_results.append((b_scalar, max_ulp))
 
         # Print progress every 1000 iterations
-        if (i + 1) % 1000 == 0:
-            print(f"Processed {i + 1}/{num_values} B values...")
+        if positive_count % 1000 == 0:
+            print(f"Processed {positive_count} positive B values...")
+
+    print(f"Total positive exponents tested: {positive_count}")
 
     # Generate summary report
     _generate_summary_report(
         results=all_results,
         summary_file_path=summary_file_path,
-        test_name="Unary Power (FP32) - Scalar Exponent",
+        test_name="Unary Power (FP32) - Scalar Exponent (Positive Only)",
         data_type="Float32",
         num_a_values=num_values,
         num_b_values=num_values,

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary_pow.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary_pow.py
@@ -1,0 +1,182 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import pytest
+import ttnn
+import csv
+import os
+from tests.ttnn.utils_for_testing import assert_with_ulp
+from models.common.utility_functions import comp_ulp_check
+
+
+@pytest.mark.parametrize("exponent", [0.0, 1.0, 2.0, 3.0])
+def test_pow_arange_masking_unary(exponent, device):
+    # Generate all possible bit pattern for bf16
+    tt_input = generate_clean_bf16_tensor()
+
+    tt_in = ttnn.from_torch(
+        tt_input,
+        dtype=ttnn.bfloat16,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    golden_function = ttnn.get_golden_function(ttnn.pow)
+    golden = golden_function(tt_input, exponent, device=device)
+
+    tt_result = ttnn.pow(tt_in, exponent)
+    result = ttnn.to_torch(tt_result)
+
+    assert_with_ulp(golden, result, 1, allow_nonfinite=True)
+
+
+def test_pow_arange_masking_binary(device):
+    # Generate all possible bit pattern for bf16
+    tt_input = generate_clean_bf16_tensor()
+
+    tt_in = ttnn.from_torch(
+        tt_input,
+        dtype=ttnn.bfloat16,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    golden = torch.pow(tt_input, tt_input)
+
+    tt_result = ttnn.pow(tt_in, tt_in)
+    result = ttnn.to_torch(tt_result)
+
+    # Run comp_ulp_check to get ULP and mismatch info
+    max_ulp, mismatch_file_path, failing_range = comp_ulp_check(
+        input=tt_input,
+        golden=golden,
+        calculated=result,
+        ulp_threshold=1,
+        allow_nonfinite=True,
+        input_b=tt_input,
+        output_dir="binary_pow_mismatches.txt",
+    )
+
+    assert_with_ulp(golden, result, 1, allow_nonfinite=True)
+
+
+def generate_clean_bf16_tensor(dtype=torch.bfloat16):
+    all_bitpatterns = torch.arange(0, 2**16, dtype=torch.int32).to(torch.uint16)
+    input_tensor = all_bitpatterns.view(torch.bfloat16)  # 65536 values
+    fp32 = input_tensor.to(torch.float32)
+
+    # Remove special values (NaN, -0.0, +inf, -inf, subnormals)
+    neg_zero_mask = (fp32 == 0.0) & torch.signbit(fp32)
+    tiny = torch.finfo(torch.bfloat16).tiny  # 2**-126
+    good_mask = torch.isfinite(fp32) & ~neg_zero_mask & (fp32.abs() >= tiny)
+    fp32 = fp32[good_mask]  # 65024 values
+
+    # Filter bf16 values to [±1e-15, ±1e15]
+    abs_fp32 = fp32.abs()
+    mask = (abs_fp32 >= 1e-15) & (abs_fp32 <= 1e15)
+    fp32 = fp32[mask]  # 25510 values
+
+    return fp32.to(dtype)
+
+
+def test_binary_pow_sweep(device):
+    # Generate clean bf16 tensor (tensor A) - contains ~65k values (2^16 bf16 bit patterns)
+    tensor_a = generate_clean_bf16_tensor()
+    num_values = tensor_a.numel()  # Should be 65536 (2^16)
+
+    # Output directory for mismatch files
+    output_dir = "binary_pow_ulp_mismatches"
+    os.makedirs(output_dir, exist_ok=True)
+
+    # CSV file path
+    csv_file_path = "binary_pow_results.csv"
+
+    print(f"Testing binary pow with {num_values} B values...")
+    print(f"Each iteration tests {num_values} element-wise A^B operations")
+
+    # Open CSV file for writing results
+    with open(csv_file_path, "w", newline="") as csvfile:
+        csv_writer = csv.writer(csvfile)
+        csv_writer.writerow(["Input_B", "Max_ULP", "Failing_Values"])
+
+        # Iterate through each value in tensor_a as the B value
+        for i in range(num_values):
+            # Get the i-th value from tensor_a to use as B
+            b_val = tensor_a[i]
+            b_scalar = b_val.item()
+
+            # Create tensor B filled with this single value (same shape as A: 65k elements)
+            tensor_b = torch.full_like(tensor_a, b_scalar, dtype=torch.bfloat16)
+
+            # Convert to ttnn tensors
+            tt_a = ttnn.from_torch(
+                tensor_a,
+                dtype=ttnn.bfloat16,
+                device=device,
+                layout=ttnn.TILE_LAYOUT,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            )
+            tt_b = ttnn.from_torch(
+                tensor_b,
+                dtype=ttnn.bfloat16,
+                device=device,
+                layout=ttnn.TILE_LAYOUT,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            )
+
+            # Calculate golden result using torch
+            golden = torch.pow(tensor_a, tensor_b)
+
+            # Run ttnn binary pow
+            tt_result = ttnn.pow(tt_a, tt_b)
+            result = ttnn.to_torch(tt_result)
+
+            # Run comp_ulp_check to get ULP and mismatch info
+            max_ulp, mismatch_file_path, failing_range = comp_ulp_check(
+                input=tensor_a,
+                golden=golden,
+                calculated=result,
+                ulp_threshold=1,
+                allow_nonfinite=True,
+                input_b=b_val,
+                output_dir=output_dir,
+            )
+
+            # Only write to CSV if ULP > 1
+            if max_ulp > 1:
+                # Format failing values column
+                if mismatch_file_path is not None and failing_range is not None:
+                    failing_values = f"File: {mismatch_file_path}, Range: {failing_range}"
+                else:
+                    failing_values = "No mismatches"
+
+                # Write to CSV
+                csv_writer.writerow([b_scalar, max_ulp, failing_values])
+
+            # Print progress every 1000 iterations
+            if (i + 1) % 1000 == 0:
+                print(f"Processed {i + 1}/{num_values} B values...")
+
+    print(f"\nResults saved to {csv_file_path}")
+    print(f"ULP mismatch details saved to {output_dir}/")
+
+
+def main():
+    """Main function to run binary pow sweep test standalone."""
+    import ttnn
+
+    # Initialize device
+    device = ttnn.open_device(device_id=0)
+
+    try:
+        test_binary_pow_sweep(device)
+    finally:
+        ttnn.close_device(device)
+
+
+if __name__ == "__main__":
+    main()

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
@@ -292,7 +292,6 @@ void calculate_exponential(const uint exp_base_scale_factor = p_sfpu::kCONST_1_F
             }
             sfpi::vFloat result = _sfpu_exp_improved_<is_fp32_dest_acc_en>(val);
             sfpi::dst_reg[0] = result;
-
             sfpi::dst_reg++;
         }
     }


### PR DESCRIPTION
### Binary Pow Operation – Test Summary

- Validated the precision of the TTNN binary pow operation against PyTorch reference implementations using ULP
- **Test Configurations**

<google-sheets-html-origin><!--td {border: 1px solid #cccccc;}br {mso-data-placement:same-cell;}-->
Config Type | TTNN | Torch | Purpose
-- | -- | -- | --
BF16 vs BF16 | BF16 | BF16 | Baseline (same precision)
BF16 vs BF16 Improved | BF16 | BF16 | With new (Improved) version of log , exp
BF16 vs FP32 | BF16 | FP32 | Higher-precision reference for fractional ULP analysis
BF16 vs FP32 Improved | BF16 | FP32 | With new (Improved) version of log , exp
FP32 vs FP32 | FP32 | FP32 | Baseline (same precision)
FP32 vs FP32 Improved | FP32 | FP32 | With new (Improved) version of log , exp
FP32 vs FP64 | FP32 | FP64 | Higher-precision reference for fractional ULP analysis
FP32 vs FP64 Improved | FP32 | FP64 | With new (Improved) version of log , exp

- **Testing categories** : The test is split into 3 sections for detailed numerical analysis
  - Note : Subnormal values(< 2⁻¹²⁶) are excluded as they are not supported by the hardware (510 values)

<meta charset="utf-8"><b style="font-weight:normal;" id="docs-internal-guid-880b754d-7fff-b8f0-27f6-af198a2fbfe3"><div dir="ltr" style="margin-left:0pt;" align="center">
Category | Input values | Purpose
-- | -- | --
Stable finite values | Finite BF16 values , excluding subnormal , special values | Numerical accuracy
Special Input Values | NaN, +Inf, −Inf, and −0.0. | Check edge case behavior

</div></b>

- **Testing Methodology**
  - Performed an exhaustive sweep over all valid BF16-representable values (65,024).
  - For each exponent B, I've evaluated A^B for all base values A.
  - Total evaluations: 65,024 * 65,024 = 4228120576
  - **Note** : For FP32, Since the combinations are much higher than bf16, I've used the same bf16 values for testing by converting to fp32
  - Special values are tested seperately

- Results : Drive [Link](https://drive.google.com/drive/folders/18VedMzkbsPDBtEn31voWlvu8O-8Hi2-1)
  - Each combinations contains `binary_pow_results.csv` - Summary of max ULP for each exponent value ( for ULP > 1)
  - Folder `binary_pow_ulp_mismatches/` - Detailed mismatch records for future analysis

Report generation : `pytest tests/ttnn/unit_tests/operations/eltwise/test_unary_pow.py::test_binary_pow_sweep_BF16_test tests/ttnn/unit_tests/operations/eltwise/test_unary_pow.py::test_binary_pow_sweep_FP32_test -v` , `pytest tests/ttnn/unit_tests/operations/eltwise/test_unary_pow.py::test_binary_pow_sweep_BF16_test_improved tests/ttnn/unit_tests/operations/eltwise/test_unary_pow.py::test_binary_pow_sweep_FP32_test_improved -v`