### PR TITLE
[TT-Transformers] Fix long context test cases with max_seq_len override

### DIFF
--- a/.github/workflows/t3000-demo-tests-impl.yaml
+++ b/.github/workflows/t3000-demo-tests-impl.yaml
@@ -28,28 +28,28 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          # { name: "t3k_mixtral_tests", arch: wormhole_b0, cmd: run_t3000_mixtral_tests, timeout: 50, owner_id: U03PUAKE719}, # Harry Zhou
-          # { name: "t3k_falcon40b_tests", arch: wormhole_b0, cmd: run_t3000_falcon40b_tests, timeout: 50, owner_id: U053W15B6JF}, #Djordje Ivanovic
-          # { name: "t3k_llama3_tests", arch: wormhole_b0, cmd: run_t3000_llama3_tests, timeout: 60, owner_id: U03PUAKE719}, # Miguel Tairum
-          # { name: "t3k_qwen25_tests", arch: wormhole_b0, cmd: run_t3000_qwen25_tests, timeout: 60, owner_id: U03HY7MK4BT}, # Mark O'Connor
-          # { name: "t3k_llama3_vision_tests", arch: wormhole_b0, cmd: run_t3000_llama3_vision_tests, timeout: 45, owner_id: U03FJB5TM5Y}, #Colman Glagovich
-          # { name: "t3k_llama3_90b_vision_tests", arch: wormhole_b0, cmd: run_t3000_llama3_90b_vision_tests, timeout: 20, owner_id: U07RY6B5FLJ},  #Gongyu Wang
-          # { name: "t3k_llama3_70b_tests", arch: wormhole_b0, cmd: run_t3000_llama3_70b_tests, timeout: 60, owner_id: U03FJB5TM5Y}, #Colman Glagovich
-          # { name: "t3k_falcon7b_tests", arch: wormhole_b0, cmd: run_t3000_falcon7b_tests, timeout: 90, owner_id: U05RWH3QUPM}, #Salar Hosseini
-          # { name: "t3k_resnet50_tests", arch: wormhole_b0, cmd: run_t3000_resnet50_tests, timeout: 50, owner_id: U0837MYG788}, # Marko Radosavljevic
-          # { name: "t3k_sentence_bert_tests", arch: wormhole_b0, cmd: run_t3000_sentence_bert_tests, timeout: 75, owner_id: U045U3DEKM4}, # Mohamed Bahnas (Aniruddha Tupe)
-          # { name: "t3k sd35_large tests", arch: wormhole_b0, cmd: run_t3000_sd35large_tests, timeout: 60, owner_id: U03FJB5TM5Y}, #Colman Glagovich
-          # { name: "t3k flux1-dev tests", arch: wormhole_b0, cmd: run_t3000_flux1_tests, timeout: 60, owner_id: U08TED0JM9D}, #Samuel Adesoye
-          # { name: "t3k motif tests", arch: wormhole_b0, cmd: run_t3000_motif_tests, timeout: 25, owner_id: U08TED0JM9D}, #Samuel Adesoye
+          { name: "t3k_mixtral_tests", arch: wormhole_b0, cmd: run_t3000_mixtral_tests, timeout: 50, owner_id: U03PUAKE719}, # Harry Zhou
+          { name: "t3k_falcon40b_tests", arch: wormhole_b0, cmd: run_t3000_falcon40b_tests, timeout: 50, owner_id: U053W15B6JF}, #Djordje Ivanovic
+          { name: "t3k_llama3_tests", arch: wormhole_b0, cmd: run_t3000_llama3_tests, timeout: 60, owner_id: U03PUAKE719}, # Miguel Tairum
+          { name: "t3k_qwen25_tests", arch: wormhole_b0, cmd: run_t3000_qwen25_tests, timeout: 60, owner_id: U03HY7MK4BT}, # Mark O'Connor
+          { name: "t3k_llama3_vision_tests", arch: wormhole_b0, cmd: run_t3000_llama3_vision_tests, timeout: 45, owner_id: U03FJB5TM5Y}, #Colman Glagovich
+          { name: "t3k_llama3_90b_vision_tests", arch: wormhole_b0, cmd: run_t3000_llama3_90b_vision_tests, timeout: 20, owner_id: U07RY6B5FLJ},  #Gongyu Wang
+          { name: "t3k_llama3_70b_tests", arch: wormhole_b0, cmd: run_t3000_llama3_70b_tests, timeout: 60, owner_id: U03FJB5TM5Y}, #Colman Glagovich
+          { name: "t3k_falcon7b_tests", arch: wormhole_b0, cmd: run_t3000_falcon7b_tests, timeout: 90, owner_id: U05RWH3QUPM}, #Salar Hosseini
+          { name: "t3k_resnet50_tests", arch: wormhole_b0, cmd: run_t3000_resnet50_tests, timeout: 50, owner_id: U0837MYG788}, # Marko Radosavljevic
+          { name: "t3k_sentence_bert_tests", arch: wormhole_b0, cmd: run_t3000_sentence_bert_tests, timeout: 75, owner_id: U045U3DEKM4}, # Mohamed Bahnas (Aniruddha Tupe)
+          { name: "t3k sd35_large tests", arch: wormhole_b0, cmd: run_t3000_sd35large_tests, timeout: 60, owner_id: U03FJB5TM5Y}, #Colman Glagovich
+          { name: "t3k flux1-dev tests", arch: wormhole_b0, cmd: run_t3000_flux1_tests, timeout: 60, owner_id: U08TED0JM9D}, #Samuel Adesoye
+          { name: "t3k motif tests", arch: wormhole_b0, cmd: run_t3000_motif_tests, timeout: 25, owner_id: U08TED0JM9D}, #Samuel Adesoye
           { name: "t3k_mistral_tests", arch: wormhole_b0, cmd: run_t3000_mistral_tests, timeout: 90, owner_id: U0896VBAKFC}, # Pratikkumar Prajapati
-          # { name: "t3k_whisper_tests", arch: wormhole_b0, cmd: run_t3000_whisper_tests, timeout: 90, owner_id: U088413NP0Q}, # Ashai Reddy
-          # # Temporary: Run Qwen 3 tests last as they update to a newer transformers version.
-          # # This requirements and comment removed when https://github.com/tenstorrent/tt-metal/pull/22608 merges.
-          # { name: "t3k_qwen3_tests", arch: wormhole_b0, cmd: run_t3000_qwen3_tests, timeout: 60, owner_id: U03HY7MK4BT}, # Mark O'Connor
-          # { name: "t3k_qwen25_vl_tests", arch: wormhole_b0, cmd: run_t3000_qwen25_vl_tests, timeout: 30, owner_id: U07RY6B5FLJ},  #Gongyu Wang
-          # { name: "t3k_gemma3_tests", arch: wormhole_b0, cmd: run_t3000_gemma3_tests, timeout: 30, owner_id: U08TJ70UFRT},  # Harry Andrews
-          # { name: "t3k_wan2.2_tests", arch: wormhole_b0, cmd: run_t3000_wan22_tests, timeout: 45, owner_id: U03FJB5TM5Y},  #Colman Glagovich
-          # { name: "t3k_mochi_tests", arch: wormhole_b0, cmd: run_t3000_mochi_tests, timeout: 60, owner_id: U09ELB03XRU}, # Stephen Osborne
+          { name: "t3k_whisper_tests", arch: wormhole_b0, cmd: run_t3000_whisper_tests, timeout: 90, owner_id: U088413NP0Q}, # Ashai Reddy
+          # Temporary: Run Qwen 3 tests last as they update to a newer transformers version.
+          # This requirements and comment removed when https://github.com/tenstorrent/tt-metal/pull/22608 merges.
+          { name: "t3k_qwen3_tests", arch: wormhole_b0, cmd: run_t3000_qwen3_tests, timeout: 60, owner_id: U03HY7MK4BT}, # Mark O'Connor
+          { name: "t3k_qwen25_vl_tests", arch: wormhole_b0, cmd: run_t3000_qwen25_vl_tests, timeout: 30, owner_id: U07RY6B5FLJ},  #Gongyu Wang
+          { name: "t3k_gemma3_tests", arch: wormhole_b0, cmd: run_t3000_gemma3_tests, timeout: 30, owner_id: U08TJ70UFRT},  # Harry Andrews
+          { name: "t3k_wan2.2_tests", arch: wormhole_b0, cmd: run_t3000_wan22_tests, timeout: 45, owner_id: U03FJB5TM5Y},  #Colman Glagovich
+          { name: "t3k_mochi_tests", arch: wormhole_b0, cmd: run_t3000_mochi_tests, timeout: 60, owner_id: U09ELB03XRU}, # Stephen Osborne
         ]
 
     name: ${{ matrix.test-group.name }}

--- a/.github/workflows/t3000-demo-tests-impl.yaml
+++ b/.github/workflows/t3000-demo-tests-impl.yaml
@@ -28,28 +28,28 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          { name: "t3k_mixtral_tests", arch: wormhole_b0, cmd: run_t3000_mixtral_tests, timeout: 50, owner_id: U03PUAKE719}, # Harry Zhou
-          { name: "t3k_falcon40b_tests", arch: wormhole_b0, cmd: run_t3000_falcon40b_tests, timeout: 50, owner_id: U053W15B6JF}, #Djordje Ivanovic
-          { name: "t3k_llama3_tests", arch: wormhole_b0, cmd: run_t3000_llama3_tests, timeout: 60, owner_id: U03PUAKE719}, # Miguel Tairum
-          { name: "t3k_qwen25_tests", arch: wormhole_b0, cmd: run_t3000_qwen25_tests, timeout: 60, owner_id: U03HY7MK4BT}, # Mark O'Connor
-          { name: "t3k_llama3_vision_tests", arch: wormhole_b0, cmd: run_t3000_llama3_vision_tests, timeout: 45, owner_id: U03FJB5TM5Y}, #Colman Glagovich
-          { name: "t3k_llama3_90b_vision_tests", arch: wormhole_b0, cmd: run_t3000_llama3_90b_vision_tests, timeout: 20, owner_id: U07RY6B5FLJ},  #Gongyu Wang
-          { name: "t3k_llama3_70b_tests", arch: wormhole_b0, cmd: run_t3000_llama3_70b_tests, timeout: 60, owner_id: U03FJB5TM5Y}, #Colman Glagovich
-          { name: "t3k_falcon7b_tests", arch: wormhole_b0, cmd: run_t3000_falcon7b_tests, timeout: 90, owner_id: U05RWH3QUPM}, #Salar Hosseini
-          { name: "t3k_resnet50_tests", arch: wormhole_b0, cmd: run_t3000_resnet50_tests, timeout: 50, owner_id: U0837MYG788}, # Marko Radosavljevic
-          { name: "t3k_sentence_bert_tests", arch: wormhole_b0, cmd: run_t3000_sentence_bert_tests, timeout: 75, owner_id: U045U3DEKM4}, # Mohamed Bahnas (Aniruddha Tupe)
-          { name: "t3k sd35_large tests", arch: wormhole_b0, cmd: run_t3000_sd35large_tests, timeout: 60, owner_id: U03FJB5TM5Y}, #Colman Glagovich
-          { name: "t3k flux1-dev tests", arch: wormhole_b0, cmd: run_t3000_flux1_tests, timeout: 60, owner_id: U08TED0JM9D}, #Samuel Adesoye
-          { name: "t3k motif tests", arch: wormhole_b0, cmd: run_t3000_motif_tests, timeout: 25, owner_id: U08TED0JM9D}, #Samuel Adesoye
+          # { name: "t3k_mixtral_tests", arch: wormhole_b0, cmd: run_t3000_mixtral_tests, timeout: 50, owner_id: U03PUAKE719}, # Harry Zhou
+          # { name: "t3k_falcon40b_tests", arch: wormhole_b0, cmd: run_t3000_falcon40b_tests, timeout: 50, owner_id: U053W15B6JF}, #Djordje Ivanovic
+          # { name: "t3k_llama3_tests", arch: wormhole_b0, cmd: run_t3000_llama3_tests, timeout: 60, owner_id: U03PUAKE719}, # Miguel Tairum
+          # { name: "t3k_qwen25_tests", arch: wormhole_b0, cmd: run_t3000_qwen25_tests, timeout: 60, owner_id: U03HY7MK4BT}, # Mark O'Connor
+          # { name: "t3k_llama3_vision_tests", arch: wormhole_b0, cmd: run_t3000_llama3_vision_tests, timeout: 45, owner_id: U03FJB5TM5Y}, #Colman Glagovich
+          # { name: "t3k_llama3_90b_vision_tests", arch: wormhole_b0, cmd: run_t3000_llama3_90b_vision_tests, timeout: 20, owner_id: U07RY6B5FLJ},  #Gongyu Wang
+          # { name: "t3k_llama3_70b_tests", arch: wormhole_b0, cmd: run_t3000_llama3_70b_tests, timeout: 60, owner_id: U03FJB5TM5Y}, #Colman Glagovich
+          # { name: "t3k_falcon7b_tests", arch: wormhole_b0, cmd: run_t3000_falcon7b_tests, timeout: 90, owner_id: U05RWH3QUPM}, #Salar Hosseini
+          # { name: "t3k_resnet50_tests", arch: wormhole_b0, cmd: run_t3000_resnet50_tests, timeout: 50, owner_id: U0837MYG788}, # Marko Radosavljevic
+          # { name: "t3k_sentence_bert_tests", arch: wormhole_b0, cmd: run_t3000_sentence_bert_tests, timeout: 75, owner_id: U045U3DEKM4}, # Mohamed Bahnas (Aniruddha Tupe)
+          # { name: "t3k sd35_large tests", arch: wormhole_b0, cmd: run_t3000_sd35large_tests, timeout: 60, owner_id: U03FJB5TM5Y}, #Colman Glagovich
+          # { name: "t3k flux1-dev tests", arch: wormhole_b0, cmd: run_t3000_flux1_tests, timeout: 60, owner_id: U08TED0JM9D}, #Samuel Adesoye
+          # { name: "t3k motif tests", arch: wormhole_b0, cmd: run_t3000_motif_tests, timeout: 25, owner_id: U08TED0JM9D}, #Samuel Adesoye
           { name: "t3k_mistral_tests", arch: wormhole_b0, cmd: run_t3000_mistral_tests, timeout: 90, owner_id: U0896VBAKFC}, # Pratikkumar Prajapati
-          { name: "t3k_whisper_tests", arch: wormhole_b0, cmd: run_t3000_whisper_tests, timeout: 90, owner_id: U088413NP0Q}, # Ashai Reddy
-          # Temporary: Run Qwen 3 tests last as they update to a newer transformers version.
-          # This requirements and comment removed when https://github.com/tenstorrent/tt-metal/pull/22608 merges.
-          { name: "t3k_qwen3_tests", arch: wormhole_b0, cmd: run_t3000_qwen3_tests, timeout: 60, owner_id: U03HY7MK4BT}, # Mark O'Connor
-          { name: "t3k_qwen25_vl_tests", arch: wormhole_b0, cmd: run_t3000_qwen25_vl_tests, timeout: 30, owner_id: U07RY6B5FLJ},  #Gongyu Wang
-          { name: "t3k_gemma3_tests", arch: wormhole_b0, cmd: run_t3000_gemma3_tests, timeout: 30, owner_id: U08TJ70UFRT},  # Harry Andrews
-          { name: "t3k_wan2.2_tests", arch: wormhole_b0, cmd: run_t3000_wan22_tests, timeout: 45, owner_id: U03FJB5TM5Y},  #Colman Glagovich
-          { name: "t3k_mochi_tests", arch: wormhole_b0, cmd: run_t3000_mochi_tests, timeout: 60, owner_id: U09ELB03XRU}, # Stephen Osborne
+          # { name: "t3k_whisper_tests", arch: wormhole_b0, cmd: run_t3000_whisper_tests, timeout: 90, owner_id: U088413NP0Q}, # Ashai Reddy
+          # # Temporary: Run Qwen 3 tests last as they update to a newer transformers version.
+          # # This requirements and comment removed when https://github.com/tenstorrent/tt-metal/pull/22608 merges.
+          # { name: "t3k_qwen3_tests", arch: wormhole_b0, cmd: run_t3000_qwen3_tests, timeout: 60, owner_id: U03HY7MK4BT}, # Mark O'Connor
+          # { name: "t3k_qwen25_vl_tests", arch: wormhole_b0, cmd: run_t3000_qwen25_vl_tests, timeout: 30, owner_id: U07RY6B5FLJ},  #Gongyu Wang
+          # { name: "t3k_gemma3_tests", arch: wormhole_b0, cmd: run_t3000_gemma3_tests, timeout: 30, owner_id: U08TJ70UFRT},  # Harry Andrews
+          # { name: "t3k_wan2.2_tests", arch: wormhole_b0, cmd: run_t3000_wan22_tests, timeout: 45, owner_id: U03FJB5TM5Y},  #Colman Glagovich
+          # { name: "t3k_mochi_tests", arch: wormhole_b0, cmd: run_t3000_mochi_tests, timeout: 60, owner_id: U09ELB03XRU}, # Stephen Osborne
         ]
 
     name: ${{ matrix.test-group.name }}

--- a/models/tt_transformers/README.md
+++ b/models/tt_transformers/README.md
@@ -184,6 +184,8 @@ pytest models/tt_transformers/demo/simple_text_demo.py -k "performance and long"
 
 The above examples are run in `ModelOptimizations.performance` mode. You can override this by setting the `optimizations` or the `decoder_config_file` argument in the demo. To use instead the accuracy mode you can call the above tests with `-k "accuracy and ..."` instead of performance.
 
+NOTE: for models that are not listed in [`get_supported_trace_region_size` function](demo/trace_region_config.py#L79), the default trace region size will be used as set in the [`demo/simple_text_demo.py` script](demo/simple_text_demo.py#L704). The default trace region size may not be sufficent for such a model and there will be a helpful error message that informs the required trace region size, which can be overridden by setting the `trace_region_size` argument in the demo.
+
 ## Details
 
 ### Extra compatibility settings for non-Llama models

--- a/models/tt_transformers/README.md
+++ b/models/tt_transformers/README.md
@@ -184,7 +184,7 @@ pytest models/tt_transformers/demo/simple_text_demo.py -k "performance and long"
 
 The above examples are run in `ModelOptimizations.performance` mode. You can override this by setting the `optimizations` or the `decoder_config_file` argument in the demo. To use instead the accuracy mode you can call the above tests with `-k "accuracy and ..."` instead of performance.
 
-NOTE: for models that are not listed in [`get_supported_trace_region_size` function](demo/trace_region_config.py#L79), the default trace region size will be used as set in the [`demo/simple_text_demo.py` script](demo/simple_text_demo.py#L704). The default trace region size may not be sufficent for such a model and there will be a helpful error message that informs the required trace region size, which can be overridden by setting the `trace_region_size` argument in the demo.
+NOTE: for models that are not listed in [`get_supported_trace_region_size` function](demo/trace_region_config.py#L79), the default trace region size will be used as set in the [`demo/simple_text_demo.py` script](demo/simple_text_demo.py#L704). The default trace region size may not be sufficient for such a model and there will be a helpful error message that informs the required trace region size, which can be overridden by setting the `trace_region_size` argument in the demo.
 
 ## Details
 

--- a/models/tt_transformers/demo/simple_text_demo.py
+++ b/models/tt_transformers/demo/simple_text_demo.py
@@ -667,6 +667,25 @@ def prepare_generator_args(
             10,  # num_layers, if None -> defaults to all layers
             "prefill",  # mode
         ),
+        (  # [CI only] Long-context-16k run - Single user, long prompt (may vary based on the model's tokenizer)
+            "models/tt_transformers/demo/sample_prompts/input_data_long_16k.json",  # input_prompts
+            True,  # instruct mode
+            1,  # repeat_batches
+            32 * 1024,  # max_seq_len
+            1,  # batch_size
+            200,  # max_generated_tokens
+            True,  # paged_attention
+            {"page_block_size": 32, "page_max_num_blocks_per_dp": 1024},  # page_params
+            {"temperature": 0, "top_p": 0.08, "top_k": 32},  # sampling_params (argmax)
+            True,  # stop_at_eos
+            True,  # ci_only
+            1,  # data_parallel
+            False,  # token_accuracy
+            False,  # stress_test
+            True,  # enable_trace
+            None,  # num_layers, if None -> defaults to all layers
+            "full",  # performs both prefill and decode
+        ),
     ],
     ids=[
         "batch-1",  # latency
@@ -688,6 +707,7 @@ def prepare_generator_args(
         "ci-token-matching",  # CI performs token accuracy matching with reference procomputed tokens
         "ci-eval-1",  # CI 6 repeat batches with output comparison
         "ci-eval-32",  # CI batch 32 with 3 repeat batches and output comparison
+        "ci-long-context-16k",  # 16k context, max_seq_len=32k, used for testing --max_seq_len=16k override
         "device-perf",  # Device perf
     ],
 )

--- a/models/tt_transformers/tt/common.py
+++ b/models/tt_transformers/tt/common.py
@@ -155,7 +155,9 @@ def preprocess_inputs_prefill(
 
     # we need to make room for the generated tokens in the total token budget
     max_prefill_len -= max_generated_tokens
-    assert max_prefill_len > 0, f"max_prefill_len ({max_prefill_len + max_generated_tokens}) must be greater than max_generated_tokens ({max_generated_tokens})"
+    assert (
+        max_prefill_len > 0
+    ), f"max_prefill_len ({max_prefill_len + max_generated_tokens}) must be greater than max_generated_tokens ({max_generated_tokens})"
 
     encoded_prompts = [
         model_args[idx % len(model_args)].encode_prompt(prompt, instruct=instruct)

--- a/models/tt_transformers/tt/common.py
+++ b/models/tt_transformers/tt/common.py
@@ -149,12 +149,12 @@ def preprocess_inputs_prefill(
     # To avoid going out of memory, clip the max prefill length by the maximum number of tokens that will be generated
 
     for m_args in model_args:
-        if max_prefill_len >= m_args.max_context_len:
-            max_prefill_len -= max_generated_tokens
-            # all model_args should have the same max_context_len as
-            # it's assumed that all models are the same. break out of the loop once we find the first one
-            # with the max_prefill_len >= max_context_len
-            break
+        assert (
+            max_prefill_len <= m_args.max_context_len
+        ), f"max_prefill_len {max_prefill_len} cannot exceed max_context_len {m_args.max_context_len}"
+
+    # we need to make room for the generated tokens in the total token budget
+    max_prefill_len -= max_generated_tokens
 
     encoded_prompts = [
         model_args[idx % len(model_args)].encode_prompt(prompt, instruct=instruct)

--- a/models/tt_transformers/tt/common.py
+++ b/models/tt_transformers/tt/common.py
@@ -155,6 +155,7 @@ def preprocess_inputs_prefill(
 
     # we need to make room for the generated tokens in the total token budget
     max_prefill_len -= max_generated_tokens
+    assert max_prefill_len > 0, f"max_prefill_len ({max_prefill_len + max_generated_tokens}) must be greater than max_generated_tokens ({max_generated_tokens})"
 
     encoded_prompts = [
         model_args[idx % len(model_args)].encode_prompt(prompt, instruct=instruct)

--- a/tests/scripts/t3000/run_t3000_demo_tests.sh
+++ b/tests/scripts/t3000/run_t3000_demo_tests.sh
@@ -235,8 +235,8 @@ run_t3000_mistral_tests() {
   hf_model="mistralai/Mistral-7B-Instruct-v0.3"
   tt_cache_path=$TT_CACHE_HOME/$hf_model
   TT_CACHE_PATH=$tt_cache_path HF_MODEL=$hf_model pytest models/tt_transformers/demo/simple_text_demo.py --timeout 10800 -k "not performance-ci-stress-1"
-  # test max_seq_len overrides -- needs to CI=false to avoid skipping the long-context-16k test case
-  CI=false TT_CACHE_PATH=$tt_cache_path HF_MODEL=$hf_model pytest models/tt_transformers/demo/simple_text_demo.py --timeout 300 -k "performance and long-context-16k" --max_seq_len=16384
+  # test max_seq_len overrides
+  TT_CACHE_PATH=$tt_cache_path HF_MODEL=$hf_model pytest models/tt_transformers/demo/simple_text_demo.py --timeout 120 -k "ci-long-context-16k" --max_seq_len=16384
 
 }
 

--- a/tests/scripts/t3000/run_t3000_demo_tests.sh
+++ b/tests/scripts/t3000/run_t3000_demo_tests.sh
@@ -235,6 +235,8 @@ run_t3000_mistral_tests() {
   hf_model="mistralai/Mistral-7B-Instruct-v0.3"
   tt_cache_path=$TT_CACHE_HOME/$hf_model
   TT_CACHE_PATH=$tt_cache_path HF_MODEL=$hf_model pytest models/tt_transformers/demo/simple_text_demo.py --timeout 10800 -k "not performance-ci-stress-1"
+  # test max_seq_len overrides -- needs to CI=false to avoid skipping the long-context-16k test case
+  CI=false TT_CACHE_PATH=$tt_cache_path HF_MODEL=$hf_model pytest models/tt_transformers/demo/simple_text_demo.py --timeout 300 -k "performance and long-context-16k" --max_seq_len=16384
 
 }
 


### PR DESCRIPTION
### Ticket
Close https://github.com/tenstorrent/tt-metal/issues/33853

### Problem description
Summarized information from the issue:

Running `pytest models/tt_transformers/demo/simple_text_demo.py -k "long-context" --max_seq_len=16384` incorrectly gives error:
```
FAILED models/tt_transformers/demo/simple_text_demo.py::test_demo_text[blackhole-4-device_params0-performance-long-context-64k] - AssertionError: Prompt prefill tokens (16384) + maximum number of decoded iterations (200) needs to be <= than max_seq_len (16384)
assert (200 + 16384) <= 16384
FAILED models/tt_transformers/demo/simple_text_demo.py::test_demo_text[blackhole-4-device_params0-performance-long-context-32k] - AssertionError: Prompt prefill tokens (16384) + maximum number of decoded iterations (200) needs to be <= than max_seq_len (16384)
assert (200 + 16384) <= 16384
FAILED models/tt_transformers/demo/simple_text_demo.py::test_demo_text[blackhole-4-device_params0-performance-long-context-16k] - AssertionError: Prompt prefill tokens (16199) + maximum number of decoded iterations (200) needs to be <= than max_seq_len (16384)
assert (200 + 16199) <= 16384
FAILED models/tt_transformers/demo/simple_text_demo.py::test_demo_text[blackhole-4-device_params0-accuracy-long-context-64k] - AssertionError: Prompt prefill tokens (16384) + maximum number of decoded iterations (200) needs to be <= than max_seq_len (16384)
assert (200 + 16384) <= 16384
FAILED models/tt_transformers/demo/simple_text_demo.py::test_demo_text[blackhole-4-device_params0-accuracy-long-context-32k] - AssertionError: Prompt prefill tokens (16384) + maximum number of decoded iterations (200) needs to be <= than max_seq_len (16384)
assert (200 + 16384) <= 16384
FAILED models/tt_transformers/demo/simple_text_demo.py::test_demo_text[blackhole-4-device_params0-accuracy-long-context-16k] - AssertionError: Prompt prefill tokens (16199) + maximum number of decoded iterations (200) needs to be <= than max_seq_len (16384)
assert (200 + 16199) <= 16384
```

The expected result is that the test clips the prompt sequence if its length exceeds the `max_seq_len` passed on the command line (e.g., `16384` in the issue), reserves space for the to-be-generated tokens in the total token budget (represented by `max_seq_len`), and then successfully finish the text generation test.

This test failure can be seen on both WH and BH devices. 

### What's changed
This PR fix the bug that caused the above failed test cases by correctly reserve space in the context for the generated tokens. 

The bug is in the beginning of the `preprocess_inputs_prefill` function in `models/tt_transformers/tt/common.py`:
- `max_prefill_len` is the override-able total token budget (i.e., `max_seq_len` as passed in from `simple_text_demo.py`)
- `max_context_len` is the model's maximum context length as specified by the model creators (e.g, from HF's `config.json` of a model)
- `max_prefill_len <= max_context_len` must be true (there is actually [a check for this](https://github.com/tenstorrent/tt-metal/blob/9ca166977b524a70ec0f8ba75c36a8107c7428fe/models/tt_transformers/demo/simple_text_demo.py#L893-L896) in `simple_text_demo.py`)
- Thus it is incorrect that the existing `if max_prefill_len >= m_args.max_context_len:` prevents the reservation of space (through `max_prefill_len -= max_generated_tokens`) for the generated tokens in the `max_seq_len` token budget.

Using this fix, `pytest models/tt_transformers/demo/simple_text_demo.py -k "long-context" --max_seq_len=16384` ran successfully with tests running on IRD machines, e.g. with `mistralai/Mistral-7B-Instruct-v0.3` on P150 machine:

- overly long input sequence is clipped correctly, leaving space for the generated tokens (200 in length in this test case)
```bash
2025-12-10 07:26:46.277 | INFO     | models.tt_transformers.tt.common:preprocess_inputs_prefill:165 - Encoded prompt lengths:69164
2025-12-10 07:26:46.277 | INFO     | models.tt_transformers.tt.common:preprocess_inputs_prefill:173 - Left-clipping prompts to 16184
```

- all test cases are successful
```bash
================================================================= short test summary info ==================================================================
PASSED models/tt_transformers/demo/simple_text_demo.py::test_demo_text[blackhole-mesh_device0-device_params0-performance-long-context-64k]
PASSED models/tt_transformers/demo/simple_text_demo.py::test_demo_text[blackhole-mesh_device0-device_params0-performance-long-context-32k]
PASSED models/tt_transformers/demo/simple_text_demo.py::test_demo_text[blackhole-mesh_device0-device_params0-performance-long-context-16k]
PASSED models/tt_transformers/demo/simple_text_demo.py::test_demo_text[blackhole-mesh_device0-device_params0-accuracy-long-context-64k]
PASSED models/tt_transformers/demo/simple_text_demo.py::test_demo_text[blackhole-mesh_device0-device_params0-accuracy-long-context-32k]
PASSED models/tt_transformers/demo/simple_text_demo.py::test_demo_text[blackhole-mesh_device0-device_params0-accuracy-long-context-16k]
================================================= 6 passed, 34 deselected, 4 warnings in 851.45s (0:14:11) =================================================
2025-12-10 07:35:45.329 | info     |          Device | Closing user mode device drivers (tt_cluster.cpp:446)
```


### Checklist
**Tests to check regressions**
- [x] Black demo tests CI passes
  - https://github.com/tenstorrent/tt-metal/actions/runs/20090540893 -- failed test cases not due to this PR
- [x] Single-card demo tests CI passes
  - https://github.com/tenstorrent/tt-metal/actions/runs/20090561065 -- failed test cases not due to this PR
- [x] T3000 demo tests
  - https://github.com/tenstorrent/tt-metal/actions/runs/20090576280 -- failed test cases not due to this PR

**Added new test case** to mistral CI to catch regression of `pytest models/tt_transformers/demo/simple_text_demo.py -k "long-context" --max_seq_len=16384` (we just need `"performance and long-context-16k" -- max_seq_len=16384`)
- [x] https://github.com/tenstorrent/tt-metal/actions/runs/20091495905 -- saw "Left-clipping prompts to 16184" in [the log
](https://github.com/tenstorrent/tt-metal/actions/runs/20091495905/job/57640250312#step:7:6162)

**Before merging:**
- [x] revert ff200f1fa2d82899cb9b232371b7b1b8232db040
  - through [f4fe051](https://github.com/tenstorrent/tt-metal/pull/34136/commits/f4fe0511ed5becfb9f88dfe1d782d94fba5a5028) 

**Test again after addressing review comments**
- [x] https://github.com/tenstorrent/tt-metal/actions/runs/20138158787

**Before merging**
- [x] revert bbe06896cb990b218924af7b6000e77313c01309
  - through 0c30227b9aee73cf6ec163fa5fd3eb2aebcdc011 