### PR TITLE
Fix for MOE check in Mixtral 8x7B model and config values

### DIFF
--- a/models/demos/t3000/mixtral8x7b/reference/model.py
+++ b/models/demos/t3000/mixtral8x7b/reference/model.py
@@ -177,7 +177,8 @@ class TransformerBlock(nn.Module):
         self.ffn_norm = RMSNorm(args.dim, eps=args.norm_eps)
         self.args = args
         self.feed_forward: nn.Module
-        if args.is_mixture_of_experts is not None:
+        
+        if getattr(args, "is_mixture_of_experts", None) is not None:
             self.feed_forward = MoeLayer(
                 experts=[FeedForward(args=args) for _ in range(args.num_experts)],
                 gate=nn.Linear(args.dim, args.num_experts, bias=False),

--- a/models/demos/t3000/mixtral8x7b/tt/model_config.py
+++ b/models/demos/t3000/mixtral8x7b/tt/model_config.py
@@ -29,7 +29,7 @@ class TtModelArgs:
     # Seqlen < 8k -> Batch_size = 32
     max_batch_size = 8  # Max batch size supported when max_seq_len = 32768
     max_seq_len = 32768  # Maximum supported sequence length
-    moe = True
+    is_mixture_of_experts = True
     num_experts = 8
     num_experts_per_tok = 2
 


### PR DESCRIPTION
### Ticket
No ticket, but the issue was the failing perplexity tests with Mixtral 8x7B model

### Problem description
RUN: [run #62](https://github.com/tenstorrent/tt-metal/actions/runs/19942070633)
FAILING WORKFLOW: t3000-perplexity-tests
FAILING JOB: t3k_mixtral_tests
FAILING TEST: test_mixtral_model_inference[wormhole_b0-True-device_params0-64seqlen]
FAILING RUN: [Run #19805878272 (latest failure, 2025-11-30)](https://github.com/tenstorrent/tt-metal/actions/runs/19805878272/job/56740110942)
CASE: 2
SCENARIO: deterministic_failure_commit_unknown
FAILURE MESSAGE:
AttributeError: 'TtModelArgs' object has no attribute 'is_mixture_of_experts'
Case 2: t3k_mixtral_tests failing with AttributeError - TtModelArgs missing is_mixture_of_experts attribute. 190 commits between last success and first failure prevent pinpointing exact culprit. Fix: Add missing attribute to TtModelArgs class in model_config.py.

### What's changed
The problem was that Model code was updated with changed boolean parameter "is_mixture_of_experts" instead of "moe" that was used before. This was changed and also check for the "is_mixture_of_experts" was changed so that now not defining this parameter defaults the model to the regular dense model.

The perplexity test now passes for the Mixtral model: https://github.com/tenstorrent/tt-metal/actions/runs/20031591715

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] [cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) job passes
- [ ] New/Existing tests provide coverage for changes