### PR TITLE
Remove pointer constification shim

### DIFF
--- a/tt_metal/hw/firmware/src/tt-1xx/brisck.cc
+++ b/tt_metal/hw/firmware/src/tt-1xx/brisck.cc
@@ -24,25 +24,18 @@
 #endif
 
 namespace ckernel {
-// Transition shim
-#if defined(__PTR_CONST)
-#define PTR_CONST const
-#else
-#define PTR_CONST
-#endif
-volatile tt_reg_ptr uint* PTR_CONST regfile = reinterpret_cast<volatile uint*>(REGFILE_BASE);
-volatile tt_reg_ptr uint* PTR_CONST pc_buf_base = reinterpret_cast<volatile uint*>(PC_BUF_BASE);
+volatile tt_reg_ptr uint* const regfile = reinterpret_cast<volatile uint*>(REGFILE_BASE);
+volatile tt_reg_ptr uint* const pc_buf_base = reinterpret_cast<volatile uint*>(PC_BUF_BASE);
 
 // There are 16 mailboxes within each Tensix tile, one from each of RISCV (B, T0, T1, T2) to each of RISCV (B, T0, T1,
 // T2). Note that there are no mailboxes to or from RISCV NC. The 16 mailboxes are referenced using 4 particular address
 // ranges starting from bases listed below. Which particular mailbox is being referenced depends on the address, the
 // issuing RISCV, and whether the access is a read or a write.
-volatile tt_reg_ptr uint* PTR_CONST mailbox_base[4] = {
+volatile tt_reg_ptr uint* const mailbox_base[4] = {
     reinterpret_cast<volatile uint tt_reg_ptr*>(TENSIX_MAILBOX0_BASE),
     reinterpret_cast<volatile uint tt_reg_ptr*>(TENSIX_MAILBOX1_BASE),
     reinterpret_cast<volatile uint tt_reg_ptr*>(TENSIX_MAILBOX2_BASE),
     reinterpret_cast<volatile uint tt_reg_ptr*>(TENSIX_MAILBOX3_BASE)};
-#undef PTR_CONST
 }  // namespace ckernel
 
 extern "C" [[gnu::section(".start")]]

--- a/tt_metal/hw/firmware/src/tt-1xx/trisc.cc
+++ b/tt_metal/hw/firmware/src/tt-1xx/trisc.cc
@@ -42,16 +42,9 @@ uint8_t my_relative_y_ __attribute__((used));
 namespace ckernel {
 
 enum class ttRiscCores : std::uint32_t { Unpack = 0, Math = 1, Pack = 2, Brisc = 3, Nrisc = 4 };
-// Transition shim
-#if defined(__PTR_CONST)
-#define PTR_CONST const
-#else
-#define PTR_CONST
-#endif
-volatile tt_reg_ptr uint* PTR_CONST reg_base = reinterpret_cast<volatile uint*>(0xFFB10000);
-volatile tt_reg_ptr uint* PTR_CONST pc_buf_base = reinterpret_cast<volatile uint*>(PC_BUF_BASE);
-volatile tt_reg_ptr uint* PTR_CONST regfile = reinterpret_cast<volatile uint*>(REGFILE_BASE);
-#undef PTR_CONST
+volatile tt_reg_ptr uint* const reg_base = reinterpret_cast<volatile uint*>(0xFFB10000);
+volatile tt_reg_ptr uint* const pc_buf_base = reinterpret_cast<volatile uint*>(PC_BUF_BASE);
+volatile tt_reg_ptr uint* const regfile = reinterpret_cast<volatile uint*>(REGFILE_BASE);
 #if defined(__INSTRN_BUFFER_TOS)
 volatile tt_reg_ptr uint32_t* const instrn_buffer = reinterpret_cast<volatile uint32_t*>(INSTRN_BUF_BASE);
 #endif

--- a/tt_metal/hw/firmware/src/tt-1xx/trisck.cc
+++ b/tt_metal/hw/firmware/src/tt-1xx/trisck.cc
@@ -27,23 +27,16 @@ uint32_t gl_alu_format_spec_reg = 0;
 uint32_t op_info_offset = 0;
 
 namespace ckernel {
-// Transition shim
-#if defined(__PTR_CONST)
-#define PTR_CONST const
-#else
-#define PTR_CONST
-#endif
-volatile tt_reg_ptr uint* PTR_CONST regfile = reinterpret_cast<volatile uint*>(REGFILE_BASE);
-volatile tt_reg_ptr uint* PTR_CONST pc_buf_base = reinterpret_cast<volatile uint*>(PC_BUF_BASE);
+volatile tt_reg_ptr uint* const regfile = reinterpret_cast<volatile uint*>(REGFILE_BASE);
+volatile tt_reg_ptr uint* const pc_buf_base = reinterpret_cast<volatile uint*>(PC_BUF_BASE);
 #if defined(__INSTRN_BUFFER_TOS)
 volatile tt_reg_ptr uint32_t* const instrn_buffer = reinterpret_cast<volatile uint32_t*>(INSTRN_BUF_BASE);
 #endif
-volatile tt_reg_ptr uint* PTR_CONST mailbox_base[4] = {
+volatile tt_reg_ptr uint* const mailbox_base[4] = {
     reinterpret_cast<volatile uint tt_reg_ptr*>(TENSIX_MAILBOX0_BASE),
     reinterpret_cast<volatile uint tt_reg_ptr*>(TENSIX_MAILBOX1_BASE),
     reinterpret_cast<volatile uint tt_reg_ptr*>(TENSIX_MAILBOX2_BASE),
     reinterpret_cast<volatile uint tt_reg_ptr*>(TENSIX_MAILBOX3_BASE)};
-#undef PTR_CONST
 }  // namespace ckernel
 
 extern "C" [[gnu::section(".start")]]


### PR DESCRIPTION
### Ticket
NA

### Problem description
We should constify the global pointer objects themselves.  This is the 2nd part of https://github.com/tenstorrent/tt-metal/pull/34015

### What's changed
Remove the temporary shim.  tt-llk has been updated

### Checklist
- [YES] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [YES] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] [cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) job passes
- [ ] New/Existing tests provide coverage for changes