### PR TITLE
feat: support LLK_ASSERT via rtoptions

### DIFF
--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -252,6 +252,10 @@ void JitBuildEnv::init(
         this->defines_ += "-DLIGHTWEIGHT_KERNEL_ASSERTS ";
     }
 
+    if (rtoptions.get_llk_asserts_enabled()) {
+        this->defines_ += "-DENABLE_LLK_ASSERT ";
+    }
+
     // Includes
     // TODO(pgk) this list is insane
     std::vector<std::string> includeDirs = {

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -252,7 +252,7 @@ void JitBuildEnv::init(
         this->defines_ += "-DLIGHTWEIGHT_KERNEL_ASSERTS ";
     }
 
-    if (rtoptions.get_llk_asserts_enabled()) {
+    if (rtoptions.get_llk_asserts()) {
         this->defines_ += "-DENABLE_LLK_ASSERT ";
     }
 

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -170,6 +170,11 @@ enum class EnvVarID {
     TT_METAL_LIGHTWEIGHT_KERNEL_ASSERTS,  // Enable lightweight kernel asserts
 
     // ========================================
+    // LLK ASSERTIONS
+    // ========================================
+    TT_METAL_LLK_ASSERTS,  // Enable LLK assertions
+
+    // ========================================
     // DEVICE MANAGER
     // ========================================
     TT_METAL_NUMA_BASED_AFFINITY,
@@ -1179,6 +1184,12 @@ void RunTimeOptions::HandleEnvVar(EnvVarID id, const char* value) {
         // Default: false (disabled)
         // Usage: export TT_METAL_LIGHTWEIGHT_KERNEL_ASSERTS=1
         case EnvVarID::TT_METAL_LIGHTWEIGHT_KERNEL_ASSERTS: this->lightweight_kernel_asserts = true; break;
+
+        // TT_METAL_LLK_ASSERTS
+        // Enables LLK assertions. If watcher asserts are enabled, they take precedence.
+        // Default: false (disabled)
+        // Usage: export TT_METAL_LLK_ASSERTS=1
+        case EnvVarID::TT_METAL_LLK_ASSERTS: this->llk_asserts_enabled = true; break;
 
         // ========================================
         // DEVICE MANAGER

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -1189,7 +1189,7 @@ void RunTimeOptions::HandleEnvVar(EnvVarID id, const char* value) {
         // Enables LLK assertions. If watcher asserts are enabled, they take precedence.
         // Default: false (disabled)
         // Usage: export TT_METAL_LLK_ASSERTS=1
-        case EnvVarID::TT_METAL_LLK_ASSERTS: this->llk_asserts_enabled = true; break;
+        case EnvVarID::TT_METAL_LLK_ASSERTS: this->enable_llk_asserts = true; break;
 
         // ========================================
         // DEVICE MANAGER

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -358,8 +358,8 @@ public:
     bool get_lightweight_kernel_asserts() const { return lightweight_kernel_asserts; }
     void set_lightweight_kernel_asserts(bool enabled) { lightweight_kernel_asserts = enabled; }
 
-    bool get_llk_asserts() const { return llk_asserts_enabled; }
-    void set_llk_asserts(bool enabled) { llk_asserts_enabled = enabled; }
+    bool get_llk_asserts() const { return enable_llk_asserts; }
+    void set_llk_asserts(bool enabled) { enable_llk_asserts = enabled; }
 
     // Info from inspector environment variables, setters included so that user
     // can override with a SW call.

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -152,7 +152,7 @@ class RunTimeOptions {
 
     bool lightweight_kernel_asserts = false;
 
-    bool llk_asserts_enabled = false;
+    bool enable_llk_asserts = false;
 
     // Fabric profiling settings
     struct FabricProfilingSettings {
@@ -358,8 +358,8 @@ public:
     bool get_lightweight_kernel_asserts() const { return lightweight_kernel_asserts; }
     void set_lightweight_kernel_asserts(bool enabled) { lightweight_kernel_asserts = enabled; }
 
-    bool get_llk_asserts_enabled() const { return llk_asserts_enabled; }
-    void set_llk_asserts_enabled(bool enabled) { llk_asserts_enabled = enabled; }
+    bool get_llk_asserts() const { return llk_asserts_enabled; }
+    void set_llk_asserts(bool enabled) { llk_asserts_enabled = enabled; }
 
     // Info from inspector environment variables, setters included so that user
     // can override with a SW call.

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -152,6 +152,8 @@ class RunTimeOptions {
 
     bool lightweight_kernel_asserts = false;
 
+    bool llk_asserts_enabled = false;
+
     // Fabric profiling settings
     struct FabricProfilingSettings {
         bool enable_rx_ch_fwd = false;
@@ -355,6 +357,9 @@ public:
 
     bool get_lightweight_kernel_asserts() const { return lightweight_kernel_asserts; }
     void set_lightweight_kernel_asserts(bool enabled) { lightweight_kernel_asserts = enabled; }
+
+    bool get_llk_asserts_enabled() const { return llk_asserts_enabled; }
+    void set_llk_asserts_enabled(bool enabled) { llk_asserts_enabled = enabled; }
 
     // Info from inspector environment variables, setters included so that user
     // can override with a SW call.


### PR DESCRIPTION
### Ticket
None

### Problem description
We recently started adding LLK asserts, but for the time being they are disabled by default.
This change provides a way to enable them.


### What's changed
Added LLK_ASSERT enabling through rtoptions.