### PR TITLE
PCC threshold change for the new integral image implementation

### DIFF
--- a/models/experimental/oft/tests/pcc/test_oftnet.py
+++ b/models/experimental/oft/tests/pcc/test_oftnet.py
@@ -37,7 +37,7 @@ from loguru import logger
     "model_dtype, pcc_scores_oft, pcc_positions_oft, pcc_dimensions_oft, pcc_angles_oft",
     # fmt: off
     [
-       ( torch.float32, 0.905, 0.971, 0.999, 0.931)
+       ( torch.float32, 0.905, 0.971, 0.999, 0.927)
     ],
     # fmt: on
     ids=[


### PR DESCRIPTION

### Problem description
OftNet PCC drops after switching to new integral image implementation
https://github.com/tenstorrent/tt-metal/actions/runs/20056329170/job/57522810119


### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole nightly 20 cores tests][(https://github.com/tenstorrent/tt-metal/actions/runs/20100957763)