### PR TITLE
Added FabricConfig warning to Device Manager

### DIFF
--- a/tt_metal/impl/device/device_manager.cpp
+++ b/tt_metal/impl/device/device_manager.cpp
@@ -399,6 +399,9 @@ void DeviceManager::initialize_active_devices() const {
         // Initialize fabric on mmio device
         init_fabric(active_devices);
         log_info(tt::LogMetal, "Fabric Initialized with config {}", fabric_config);
+    } else {
+        log_warning(
+            tt::LogMetal, "Provided FabricConfig is not a supported TT_Fabric Config, skipping fabric initialization");
     }
 
     // Activate FD kernels


### PR DESCRIPTION
### Problem description
While I was adding a new fabric configuration, I found that this `DeviceManager::initialize_active_devices()` only initializes fabric if the fabric configuration is recognized. However, the function provides no warning or error if the provided configuration is not recognized. The function (and fabric) is allowed to continue, potentially causing problems and hangs.

### What's changed
- Added a warning to the function if the provided fabric configuration is unrecognized. 
- I left it as a warning in case fabric can operate without being initialized, but I'm happy to increase its severity to an error if this scenario will always cause issues. 

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Blackhole Nightly](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-nightly-tests.yaml)
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)