### PR TITLE
[skip ci] Add TT_TRIAGE_JOB_HANG failure signature for device timeout detection

### DIFF
--- a/infra/data_collection/github/utils.py
+++ b/infra/data_collection/github/utils.py
@@ -102,6 +102,7 @@ def get_job_failure_signature_(github_job, failure_description, workflow_outputs
         "No space left on device": str(InfraErrorV1.DISK_SPACE_FAILURE),
         "API rate limit exceeded": str(InfraErrorV1.API_RATE_LIMIT_FAILURE),
         "Tenstorrent cards seem to be in use": str(InfraErrorV1.RUNNER_CARD_IN_USE_FAILURE),
+        "device timeout, potential hang detected, the device is unrecoverable": str(InfraErrorV1.TT_TRIAGE_JOB_HANG),
     }
 
     # Check the mapping dictionary for specific failure signature types

--- a/infra/data_collection/models.py
+++ b/infra/data_collection/models.py
@@ -12,6 +12,7 @@ class InfraErrorV1(enum.Enum):
     API_RATE_LIMIT_FAILURE = enum.auto()
     RUNNER_CARD_IN_USE_FAILURE = enum.auto()
     JOB_HANG = enum.auto()
+    TT_TRIAGE_JOB_HANG = enum.auto()
 
 
 class TestErrorV1(enum.Enum):


### PR DESCRIPTION
### Problem description
Now that we have `tt-triage` enabled in APC those failures are mapped to `InfraErrorV1.GENERIC_FAILURE`

### What's changed
Add `TT_TRIAGE_JOB_HANG` enum and corresponding string to be searched in logs