### PR TITLE
Remove `metal_soc_descriptor.h` from public Runtime API

### DIFF
--- a/tests/tt_metal/test_utils/test_common.hpp
+++ b/tests/tt_metal/test_utils/test_common.hpp
@@ -14,7 +14,7 @@
 #include <vector>
 #include <iostream>
 #include <sstream>
-#include <tt-metalium/metal_soc_descriptor.h>
+#include "llrt/metal_soc_descriptor.hpp"
 
 using namespace tt::tt_metal;  // test only
 

--- a/tests/tt_metal/test_utils/test_common.hpp
+++ b/tests/tt_metal/test_utils/test_common.hpp
@@ -14,7 +14,6 @@
 #include <vector>
 #include <iostream>
 #include <sstream>
-#include "llrt/metal_soc_descriptor.hpp"
 
 using namespace tt::tt_metal;  // test only
 

--- a/tests/tt_metal/tt_metal/api/allocator/test_l1_banking_allocator.cpp
+++ b/tests/tt_metal/tt_metal/api/allocator/test_l1_banking_allocator.cpp
@@ -19,7 +19,7 @@
 #include "device_fixture.hpp"
 #include <tt-metalium/dispatch_core_common.hpp>
 #include <tt-metalium/hal_types.hpp>
-#include <tt-metalium/metal_soc_descriptor.h>
+#include "llrt/metal_soc_descriptor.hpp"
 #include "impl/context/metal_context.hpp"
 
 using namespace tt::tt_metal;

--- a/tests/tt_metal/tt_metal/api/allocator/test_overlapped_bank_manager.cpp
+++ b/tests/tt_metal/tt_metal/api/allocator/test_overlapped_bank_manager.cpp
@@ -13,7 +13,6 @@
 #include <tt-metalium/device.hpp>
 #include "device_fixture.hpp"
 #include <tt-metalium/hal_types.hpp>
-#include "llrt/metal_soc_descriptor.hpp"
 #include "impl/context/metal_context.hpp"
 #include "tt_metal/impl/allocator/bank_manager.hpp"
 

--- a/tests/tt_metal/tt_metal/api/allocator/test_overlapped_bank_manager.cpp
+++ b/tests/tt_metal/tt_metal/api/allocator/test_overlapped_bank_manager.cpp
@@ -13,7 +13,7 @@
 #include <tt-metalium/device.hpp>
 #include "device_fixture.hpp"
 #include <tt-metalium/hal_types.hpp>
-#include <tt-metalium/metal_soc_descriptor.h>
+#include "llrt/metal_soc_descriptor.hpp"
 #include "impl/context/metal_context.hpp"
 #include "tt_metal/impl/allocator/bank_manager.hpp"
 

--- a/tests/tt_metal/tt_metal/api/test_soc_descriptor.cpp
+++ b/tests/tt_metal/tt_metal/api/test_soc_descriptor.cpp
@@ -13,7 +13,7 @@
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/device.hpp>
 #include <tt-logger/tt-logger.hpp>
-#include <tt-metalium/metal_soc_descriptor.h>
+#include "llrt/metal_soc_descriptor.hpp"
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include "impl/context/metal_context.hpp"
 #include "tt_metal.hpp"

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_bw_and_latency.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_bw_and_latency.cpp
@@ -11,7 +11,7 @@
 #include <tt-metalium/event.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_metal.hpp>
-#include <tt-metalium/metal_soc_descriptor.h>
+#include "llrt/metal_soc_descriptor.hpp"
 #include <tt-metalium/tt_metal_profiler.hpp>
 #include <cstdint>
 #include <exception>

--- a/tests/tt_metal/tt_metal/test_stress_noc_mcast.cpp
+++ b/tests/tt_metal/tt_metal/test_stress_noc_mcast.cpp
@@ -11,7 +11,7 @@
 #include <fmt/base.h>
 #include <cstdlib>
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/metal_soc_descriptor.h>
+#include "llrt/metal_soc_descriptor.hpp"
 #include <tt-metalium/tt_metal.hpp>
 #include <algorithm>
 #include <cstdint>

--- a/tt_metal/CMakeLists.txt
+++ b/tt_metal/CMakeLists.txt
@@ -84,7 +84,6 @@ set(TT_METAL_PUBLIC_API
     api/tt-metalium/experimental/sockets/mesh_socket.hpp
     api/tt-metalium/mesh_trace_id.hpp
     api/tt-metalium/mesh_workload.hpp
-    api/tt-metalium/metal_soc_descriptor.h
     api/tt-metalium/profiler_optional_metadata.hpp
     api/tt-metalium/profiler_types.hpp
     api/tt-metalium/program.hpp

--- a/tt_metal/common/CMakeLists.txt
+++ b/tt_metal/common/CMakeLists.txt
@@ -10,7 +10,6 @@ target_sources(
         core_assignment.cpp
         core_coord.cpp
         mesh_coord.cpp
-        metal_soc_descriptor.cpp
         shape.cpp
         shape2d.cpp
         shape_base.cpp

--- a/tt_metal/fabric/compute_mesh_router_builder.cpp
+++ b/tt_metal/fabric/compute_mesh_router_builder.cpp
@@ -12,7 +12,7 @@
 #include "impl/context/metal_context.hpp"
 #include <tt-metalium/experimental/fabric/control_plane.hpp>
 #include "tt_metal/third_party/umd/device/api/umd/device/types/core_coordinates.hpp"
-#include "metal_soc_descriptor.h"
+#include "llrt/metal_soc_descriptor.hpp"
 #include "tt_metal.hpp"
 #include <tt_stl/assert.hpp>
 

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -46,7 +46,7 @@
 #include <tt-logger/tt-logger.hpp>
 #include "mesh_coord.hpp"
 #include <tt-metalium/experimental/fabric/mesh_graph.hpp>
-#include "metal_soc_descriptor.h"
+#include "llrt/metal_soc_descriptor.hpp"
 #include <tt-metalium/experimental/fabric/routing_table_generator.hpp>
 #include <umd/device/types/core_coordinates.hpp>
 #include <umd/device/types/cluster_descriptor_types.hpp>

--- a/tt_metal/fabric/fabric.cpp
+++ b/tt_metal/fabric/fabric.cpp
@@ -11,7 +11,7 @@
 #include "fabric/fabric_edm_packet_header.hpp"
 #include <tt_stl/assert.hpp>
 #include <tt-metalium/experimental/fabric/control_plane.hpp>
-#include <tt-metalium/metal_soc_descriptor.h>
+#include "llrt/metal_soc_descriptor.hpp"
 #include <tt-metalium/mesh_device.hpp>
 #include <tt-metalium/device.hpp>
 #include <umd/device/types/cluster_descriptor_types.hpp>  // ChipId

--- a/tt_metal/fabric/fabric.cpp
+++ b/tt_metal/fabric/fabric.cpp
@@ -11,7 +11,6 @@
 #include "fabric/fabric_edm_packet_header.hpp"
 #include <tt_stl/assert.hpp>
 #include <tt-metalium/experimental/fabric/control_plane.hpp>
-#include "llrt/metal_soc_descriptor.hpp"
 #include <tt-metalium/mesh_device.hpp>
 #include <tt-metalium/device.hpp>
 #include <umd/device/types/cluster_descriptor_types.hpp>  // ChipId

--- a/tt_metal/fabric/fabric_host_utils.cpp
+++ b/tt_metal/fabric/fabric_host_utils.cpp
@@ -11,7 +11,7 @@
 #include <tt-metalium/experimental/fabric/topology_mapper.hpp>
 #include <tt_stl/assert.hpp>
 #include <umd/device/types/cluster_descriptor_types.hpp>  // ChipId
-#include <tt-metalium/metal_soc_descriptor.h>
+#include "llrt/metal_soc_descriptor.hpp"
 #include "impl/context/metal_context.hpp"
 #include "erisc_datamover_builder.hpp"
 #include <set>

--- a/tt_metal/fabric/fabric_host_utils.cpp
+++ b/tt_metal/fabric/fabric_host_utils.cpp
@@ -11,7 +11,6 @@
 #include <tt-metalium/experimental/fabric/topology_mapper.hpp>
 #include <tt_stl/assert.hpp>
 #include <umd/device/types/cluster_descriptor_types.hpp>  // ChipId
-#include "llrt/metal_soc_descriptor.hpp"
 #include "impl/context/metal_context.hpp"
 #include "erisc_datamover_builder.hpp"
 #include <set>

--- a/tt_metal/fabric/fabric_init.cpp
+++ b/tt_metal/fabric/fabric_init.cpp
@@ -10,7 +10,7 @@
 #include "tt_metal/fabric/fabric_builder.hpp"
 #include <tt-metalium/experimental/fabric/control_plane.hpp>
 #include "impl/context/metal_context.hpp"
-#include "metal_soc_descriptor.h"
+#include "llrt/metal_soc_descriptor.hpp"
 
 // hack for test_basic_fabric_apis.cpp
 // https://github.com/tenstorrent/tt-metal/issues/20000

--- a/tt_metal/impl/debug/watcher_device_reader.cpp
+++ b/tt_metal/impl/debug/watcher_device_reader.cpp
@@ -17,7 +17,7 @@
 #include <core_coord.hpp>
 #include <fmt/base.h>
 #include <fmt/ranges.h>
-#include <metal_soc_descriptor.h>
+#include "llrt/metal_soc_descriptor.hpp"
 #include <tt-logger/tt-logger.hpp>
 #include <umd/device/types/core_coordinates.hpp>
 #include <umd/device/types/arch.hpp>

--- a/tt_metal/impl/debug/watcher_server.cpp
+++ b/tt_metal/impl/debug/watcher_server.cpp
@@ -27,7 +27,7 @@
 #include "hal_types.hpp"
 #include "llrt/hal.hpp"
 #include <tt-logger/tt-logger.hpp>
-#include "metal_soc_descriptor.h"
+#include "llrt/metal_soc_descriptor.hpp"
 #include <tt_stl/span.hpp>
 #include "impl/context/metal_context.hpp"
 #include <umd/device/types/core_coordinates.hpp>

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -42,7 +42,7 @@
 #include "lightmetal/lightmetal_capture.hpp"
 #include "llrt.hpp"
 #include <tt-logger/tt-logger.hpp>
-#include "metal_soc_descriptor.h"
+#include "llrt/metal_soc_descriptor.hpp"
 #include "tt-metalium/program.hpp"
 #include <tt_stl/strong_type.hpp>
 #include "dispatch/system_memory_manager.hpp"

--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -31,7 +31,7 @@
 #include "hostdevcommon/profiler_common.h"
 #include "llrt.hpp"
 #include <tt-logger/tt-logger.hpp>
-#include "metal_soc_descriptor.h"
+#include "llrt/metal_soc_descriptor.hpp"
 #include "profiler.hpp"
 #include "profiler_paths.hpp"
 #include "profiler_state.hpp"

--- a/tt_metal/impl/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/impl/profiler/tt_metal_profiler.cpp
@@ -43,7 +43,7 @@
 #include "llrt/hal.hpp"
 #include <tt-logger/tt-logger.hpp>
 #include "mesh_device.hpp"
-#include "metal_soc_descriptor.h"
+#include "llrt/metal_soc_descriptor.hpp"
 #include "profiler_optional_metadata.hpp"
 #include "profiler_analysis.hpp"
 #include "profiler_paths.hpp"

--- a/tt_metal/jit_build/build_env_manager.cpp
+++ b/tt_metal/jit_build/build_env_manager.cpp
@@ -22,7 +22,7 @@
 #include "hal_types.hpp"
 #include "impl/context/metal_context.hpp"
 #include "jit_build/build.hpp"
-#include "metal_soc_descriptor.hpp"
+#include "llrt/metal_soc_descriptor.hpp"
 #include <umd/device/types/core_coordinates.hpp>
 #include <impl/dispatch/dispatch_core_manager.hpp>
 #include <llrt/tt_cluster.hpp>

--- a/tt_metal/jit_build/build_env_manager.cpp
+++ b/tt_metal/jit_build/build_env_manager.cpp
@@ -22,7 +22,7 @@
 #include "hal_types.hpp"
 #include "impl/context/metal_context.hpp"
 #include "jit_build/build.hpp"
-#include "metal_soc_descriptor.h"
+#include "metal_soc_descriptor.hpp"
 #include <umd/device/types/core_coordinates.hpp>
 #include <impl/dispatch/dispatch_core_manager.hpp>
 #include <llrt/tt_cluster.hpp>

--- a/tt_metal/llrt/CMakeLists.txt
+++ b/tt_metal/llrt/CMakeLists.txt
@@ -10,6 +10,7 @@ set(LLRT_SRC
     tt_memory.cpp
     hal.cpp
     tunnels_from_mmio_device.cpp
+    metal_soc_descriptor.cpp
 )
 
 add_library(llrt OBJECT ${LLRT_SRC})

--- a/tt_metal/llrt/core_descriptor.cpp
+++ b/tt_metal/llrt/core_descriptor.cpp
@@ -18,7 +18,7 @@
 #include "common/core_coord.hpp"
 #include "hal.hpp"
 #include "hal_types.hpp"
-#include "metal_soc_descriptor.h"
+#include "llrt/metal_soc_descriptor.hpp"
 #include "common/tt_backend_api_types.hpp"
 #include "impl/context/metal_context.hpp"
 #include <tt-metalium/experimental/fabric/control_plane.hpp>

--- a/tt_metal/llrt/metal_soc_descriptor.cpp
+++ b/tt_metal/llrt/metal_soc_descriptor.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "metal_soc_descriptor.h"
+#include "llrt/metal_soc_descriptor.hpp"
 
 #include <tt_stl/assert.hpp>
 #include <yaml-cpp/yaml.h>

--- a/tt_metal/llrt/metal_soc_descriptor.hpp
+++ b/tt_metal/llrt/metal_soc_descriptor.hpp
@@ -27,7 +27,7 @@ public:
     std::vector<std::vector<CoreCoord>>
         dram_view_worker_cores;                               // per dram view preferred worker endpoints for each noc
     std::vector<std::vector<CoreCoord>> dram_view_eth_cores;  // per dram view preferred eth endpoints for each noc
-    std::vector<size_t> dram_view_address_offsets;  // starting address offset
+    std::vector<size_t> dram_view_address_offsets;            // starting address offset
 
     uint64_t dram_core_size{};
     uint64_t dram_view_size{};

--- a/tt_metal/llrt/tlb_config.cpp
+++ b/tt_metal/llrt/tlb_config.cpp
@@ -12,7 +12,7 @@
 #include <vector>
 
 #include "core_coord.hpp"
-#include "metal_soc_descriptor.h"
+#include "llrt/metal_soc_descriptor.hpp"
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include "common/tt_backend_api_types.hpp"
 #include <umd/device/arch/blackhole_implementation.hpp>

--- a/tt_metal/llrt/tlb_config.hpp
+++ b/tt_metal/llrt/tlb_config.hpp
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include <metal_soc_descriptor.h>
+#include "llrt/metal_soc_descriptor.hpp"
 #include <tt_backend_api_types.hpp>
 #include <unordered_map>
 

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -7,7 +7,7 @@
 
 #include <core_coord.hpp>
 #include <tt-logger/tt-logger.hpp>
-#include <metal_soc_descriptor.h>
+#include "llrt/metal_soc_descriptor.hpp"
 #include <algorithm>
 #include <cstdint>
 #include <cstdlib>

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -6,7 +6,7 @@
 
 #include "hostdevcommon/fabric_common.h"
 #include <tt-metalium/experimental/fabric/fabric_types.hpp>
-#include <tt-metalium/metal_soc_descriptor.h>
+#include "llrt/metal_soc_descriptor.hpp"
 #include <tt-metalium/cluster.hpp>
 #include "llrt/rtoptions.hpp"
 #include "llrt/tt_target_device.hpp"

--- a/tt_metal/tools/memset.cpp
+++ b/tt_metal/tools/memset.cpp
@@ -14,7 +14,7 @@
 #include "fmt/base.h"
 #include "llrt.hpp"
 #include <tt-logger/tt-logger.hpp>
-#include "metal_soc_descriptor.h"
+#include "llrt/metal_soc_descriptor.hpp"
 #include <umd/device/types/core_coordinates.hpp>
 #include <llrt/tt_cluster.hpp>
 


### PR DESCRIPTION
### Ticket
Closes #34134

### Problem description
Runtime is reducing it's public API surface area to prepare for an upcoming API redesign.
`metal_SocDescriptor` is identified as an internal construct that is not meant to be a public API, thus unsuitable to be in the api folder.

### What's changed
- Moved `metal_soc_descriptor.h` into `llrt`, which is more appropriate as a classification for this header and reflects usage pattern.
- Renamed file type from `.h` to `.hpp` for consistency
- Updated all includes to `#include "llrt/metal_soc_descriptor.hpp"`

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/20117076084)
- [x] No Mlir impact