### PR TITLE
feat: start using fix: use `calculate_square` from tt-llk

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_square.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_square.h
@@ -6,7 +6,7 @@
 
 #include "sfpi.h"
 // NOTE: The following header is from the external 'tt-llk' dependency.
-// The implementation of '_calculate_square_' is provided by 'tt-llk' and not defined in tt-metal 
+// The implementation of '_calculate_square_' is provided by 'tt-llk' and not defined in tt-metal
 #include "sfpu/ckernel_sfpu_square.h"
 
 namespace ckernel::sfpu {

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_square.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_square.h
@@ -5,8 +5,7 @@
 #pragma once
 
 #include "sfpi.h"
-// NOTE: The following header is from the external 'tt-llk' dependency.
-// The implementation of '_calculate_square_' is provided by 'tt-llk' and not defined in tt-metal
+// NOTE: The following header is from the external tt-llk and not defined in tt-metal
 #include "sfpu/ckernel_sfpu_square.h"
 
 namespace ckernel::sfpu {

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_square.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_square.h
@@ -6,9 +6,7 @@
 
 #include "sfpi.h"
 // NOTE: The following header is from the external 'tt-llk' dependency.
-// The implementation of '_calculate_square_' is provided by 'tt-llk' and not defined locally.
-// This represents an architectural change from an inline/local implementation to delegation to an external dependency.
-// Ensure that 'tt-llk' is available and up to date when building or modifying this code.
+// The implementation of '_calculate_square_' is provided by 'tt-llk' and not defined in tt-metal 
 #include "sfpu/ckernel_sfpu_square.h"
 
 namespace ckernel::sfpu {

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_square.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_square.h
@@ -5,6 +5,10 @@
 #pragma once
 
 #include "sfpi.h"
+// NOTE: The following header is from the external 'tt-llk' dependency.
+// The implementation of '_calculate_square_' is provided by 'tt-llk' and not defined locally.
+// This represents an architectural change from an inline/local implementation to delegation to an external dependency.
+// Ensure that 'tt-llk' is available and up to date when building or modifying this code.
 #include "sfpu/ckernel_sfpu_square.h"
 
 namespace ckernel::sfpu {

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_square.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_square.h
@@ -5,20 +5,13 @@
 #pragma once
 
 #include "sfpi.h"
+#include "sfpu/ckernel_sfpu_square.h"
 
 namespace ckernel::sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void calculate_square() {
-#pragma GCC unroll 8
-    for (int d = 0; d < ITERATIONS; d++) {
-        sfpi::vFloat in = sfpi::dst_reg[0];
-        sfpi::vFloat result = in * in;
-
-        sfpi::dst_reg[0] = result;
-
-        sfpi::dst_reg++;
-    }
+    _calculate_square_<APPROXIMATION_MODE, ITERATIONS>();
 }
 
 }  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_square.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_square.h
@@ -5,6 +5,9 @@
 #pragma once
 
 #include "sfpi.h"
+// NOTE: The following header is from the external tt-llk dependency.
+// It provides the implementation of `_calculate_square_`, which is used below.
+// Any changes to the square kernel implementation should be made in tt-llk.
 #include "sfpu/ckernel_sfpu_square.h"
 
 namespace ckernel::sfpu {

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_square.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_square.h
@@ -5,7 +5,7 @@
 #pragma once
 
 #include "sfpi.h"
-// NOTE: The following header is from the external tt-llk and not defined in tt-metal 
+// NOTE: The following header is from the external tt-llk and not defined in tt-metal
 #include "sfpu/ckernel_sfpu_square.h"
 
 namespace ckernel::sfpu {

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_square.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_square.h
@@ -5,9 +5,7 @@
 #pragma once
 
 #include "sfpi.h"
-// NOTE: The following header is from the external tt-llk dependency.
-// It provides the implementation of `_calculate_square_`, which is used below.
-// Any changes to the square kernel implementation should be made in tt-llk.
+// NOTE: The following header is from the external tt-llk and not defined in tt-metal 
 #include "sfpu/ckernel_sfpu_square.h"
 
 namespace ckernel::sfpu {

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_square.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_square.h
@@ -5,20 +5,13 @@
 #pragma once
 
 #include "sfpi.h"
+#include "sfpu/ckernel_sfpu_square.h"
 
 namespace ckernel::sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void calculate_square() {
-#pragma GCC unroll 8
-    for (int d = 0; d < ITERATIONS; d++) {
-        sfpi::vFloat in = sfpi::dst_reg[0];
-        sfpi::vFloat result = in * in;
-
-        sfpi::dst_reg[0] = result;
-
-        sfpi::dst_reg++;
-    }
+    _calculate_square_<APPROXIMATION_MODE, ITERATIONS>();
 }
 
 }  // namespace ckernel::sfpu


### PR DESCRIPTION
### Ticket
None

### Problem description
calculate_square from tt-llk is using TTIs directly instead of vectorized C++, which makes it easily portable to Quasar.

### What's changed
Replaced metal version of the function with the one from tt-llk.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/20129580598) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/20129583400) CI passes
- [x] [L2 Nightly C++ tests](https://github.com/tenstorrent/tt-metal/actions/runs/20129576663) CI fails with the same error as in main