### PR TITLE
Mock device

### DIFF
--- a/run_mock_device_tests.sh
+++ b/run_mock_device_tests.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# Mock Device Test Suite Runner
+# This script runs existing tests with mock device environment variables
+
+set -e
+
+# Check if cluster descriptor is provided
+if [ -z "$1" ]; then
+    echo "Usage: $0 <cluster_descriptor.yaml>"
+    echo "Example: $0 tt_metal/third_party/umd/tests/cluster_descriptor_examples/blackhole_P100.yaml"
+    exit 1
+fi
+
+CLUSTER_DESC="$1"
+
+# Set required environment variables
+export TT_METAL_HOME="$(cd "$(dirname "$0")" && pwd)"
+export TT_METAL_MOCK_CLUSTER_DESC_PATH="$CLUSTER_DESC"
+
+echo "=========================================="
+echo "Running Mock Device Test Suite"
+echo "Cluster Descriptor: $CLUSTER_DESC"
+echo "=========================================="
+
+# Run device pool tests (Basic device operations)
+echo ""
+echo "=== Testing Device Pool and Mesh Device ==="
+./build_Release/test/tt_metal/unit_tests_device --gtest_filter="DevicePool.*:DeviceFixture.CreateMeshDeviceHandle"
+
+# Run dispatch tests
+echo ""
+echo "=== Testing Dispatch (Fast Dispatch) ==="
+./build_Release/test/tt_metal/unit_tests_dispatch --gtest_filter="MeshDispatchFixture.*"
+
+echo ""
+echo "=========================================="
+echo "Mock Device Tests Completed!"
+echo "Summary:"
+echo "  - Device Pool: Basic device operations"
+echo "  - Dispatch: All MeshDispatchFixture tests"
+echo "  - Config: $CLUSTER_DESC"
+echo "=========================================="

--- a/run_mock_device_tests.sh
+++ b/run_mock_device_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Mock Device Test Suite Runner
 # This script runs existing tests with mock device environment variables

--- a/tests/scripts/run_mock_device_tests.sh
+++ b/tests/scripts/run_mock_device_tests.sh
@@ -14,8 +14,7 @@ fi
 
 CLUSTER_DESC="$1"
 
-# Set required environment variables
-export TT_METAL_HOME="$(cd "$(dirname "$0")" && pwd)"
+# Set required environment variable
 export TT_METAL_MOCK_CLUSTER_DESC_PATH="$CLUSTER_DESC"
 
 echo "=========================================="

--- a/tests/tt_metal/tt_metal/device/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/device/CMakeLists.txt
@@ -11,6 +11,7 @@ target_sources(
         test_device.cpp
         test_simulator_device.cpp
         test_galaxy_cluster_api.cpp
+        test_mock_device_api.cpp
 )
 target_include_directories(
     unit_tests_device_smoke

--- a/tests/tt_metal/tt_metal/device/test_mock_device_api.cpp
+++ b/tests/tt_metal/tt_metal/device/test_mock_device_api.cpp
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Test suite for programmatic mock device API
+// This demonstrates how tt-mlir/tt-xla can enable mock mode without environment variables
+
+#include <gtest/gtest.h>
+#include <tt-metalium/experimental/mock_device.hpp>
+#include <umd/device/types/arch.hpp>
+
+#include "impl/context/metal_context.hpp"
+
+namespace tt::tt_metal {
+
+// Test fixture that cleans up mock mode after each test
+class MockDeviceAPIFixture : public ::testing::Test {
+protected:
+    void TearDown() override {
+        // Reset mock mode after each test
+        experimental::disable_mock_mode();
+    }
+};
+
+// Test: Verify configure_mock_mode registers config correctly
+TEST_F(MockDeviceAPIFixture, ConfigureMockModeRegistersConfig) {
+    // Initially, mock mode should not be registered
+    EXPECT_FALSE(experimental::is_mock_mode_registered());
+
+    // Configure mock mode for Blackhole with 1 chip
+    experimental::configure_mock_mode(tt::ARCH::BLACKHOLE, 1);
+
+    // Verify mock mode is now registered
+    EXPECT_TRUE(experimental::is_mock_mode_registered());
+
+    // Verify the config is correct
+    auto config = experimental::get_registered_mock_config();
+    ASSERT_TRUE(config.has_value());
+    EXPECT_EQ(config->arch, tt::ARCH::BLACKHOLE);
+    EXPECT_EQ(config->num_chips, 1);
+}
+
+// Test: Verify configure_mock_mode works for Wormhole with multiple chips
+TEST_F(MockDeviceAPIFixture, ConfigureMockModeWormholeMultiChip) {
+    experimental::configure_mock_mode(tt::ARCH::WORMHOLE_B0, 8);
+
+    EXPECT_TRUE(experimental::is_mock_mode_registered());
+
+    auto config = experimental::get_registered_mock_config();
+    ASSERT_TRUE(config.has_value());
+    EXPECT_EQ(config->arch, tt::ARCH::WORMHOLE_B0);
+    EXPECT_EQ(config->num_chips, 8);
+}
+
+// Test: Verify disable_mock_mode clears the registration
+TEST_F(MockDeviceAPIFixture, DisableMockModeClearsConfig) {
+    // Enable mock mode
+    experimental::configure_mock_mode(tt::ARCH::BLACKHOLE, 1);
+    EXPECT_TRUE(experimental::is_mock_mode_registered());
+
+    // Disable mock mode
+    experimental::disable_mock_mode();
+
+    // Verify it's cleared
+    EXPECT_FALSE(experimental::is_mock_mode_registered());
+    EXPECT_FALSE(experimental::get_registered_mock_config().has_value());
+}
+
+}  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dispatch.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dispatch.cpp
@@ -352,32 +352,36 @@ TEST_F(MeshDispatchFixture, TensixActiveEthTestCBsAcrossDifferentCoreTypes) {
 
             this->RunProgram(mesh_device, workload);
 
-            tt::tt_metal::detail::ReadFromDeviceL1(
-                device,
-                core_coord,
-                program_.impl().get_cb_base_addr(device, core_coord, CoreType::WORKER),
-                cb_config_buffer_size,
-                cb_config_vector);
-
             // ETH core doesn't have CB
             EXPECT_TRUE(program_.impl().get_cb_size(device, core_coord, CoreType::ETH) == 0);
 
-            uint32_t cb_addr = mesh_device->allocator()->get_base_allocator_addr(HalMemType::L1);
-            uint32_t intermediate_index = intermediate_cb * sizeof(uint32_t);
+            // Skip L1 readback validation for mock devices (L1 memory not populated)
+            if (tt::tt_metal::MetalContext::instance().get_cluster().get_target_device_type() !=
+                tt::TargetDevice::Mock) {
+                tt::tt_metal::detail::ReadFromDeviceL1(
+                    device,
+                    core_coord,
+                    program_.impl().get_cb_base_addr(device, core_coord, CoreType::WORKER),
+                    cb_config_buffer_size,
+                    cb_config_vector);
 
-            bool addr_match_intermediate = cb_config_vector.at(intermediate_index) == cb_addr;
-            bool size_match_intermediate = cb_config_vector.at(intermediate_index + 1) == cb_size;
-            bool num_pages_match_intermediate = cb_config_vector.at(intermediate_index + 2) == num_tiles;
-            bool pass_intermediate =
-                (addr_match_intermediate and size_match_intermediate and num_pages_match_intermediate);
-            EXPECT_TRUE(pass_intermediate);
+                uint32_t cb_addr = mesh_device->allocator()->get_base_allocator_addr(HalMemType::L1);
+                uint32_t intermediate_index = intermediate_cb * sizeof(uint32_t);
 
-            uint32_t out_index = out_cb * sizeof(uint32_t);
-            bool addr_match_out = cb_config_vector.at(out_index) == cb_addr;
-            bool size_match_out = cb_config_vector.at(out_index + 1) == cb_size;
-            bool num_pages_match_out = cb_config_vector.at(out_index + 2) == num_tiles;
-            bool pass_out = (addr_match_out and size_match_out and num_pages_match_out);
-            EXPECT_TRUE(pass_out);
+                bool addr_match_intermediate = cb_config_vector.at(intermediate_index) == cb_addr;
+                bool size_match_intermediate = cb_config_vector.at(intermediate_index + 1) == cb_size;
+                bool num_pages_match_intermediate = cb_config_vector.at(intermediate_index + 2) == num_tiles;
+                bool pass_intermediate =
+                    (addr_match_intermediate and size_match_intermediate and num_pages_match_intermediate);
+                EXPECT_TRUE(pass_intermediate);
+
+                uint32_t out_index = out_cb * sizeof(uint32_t);
+                bool addr_match_out = cb_config_vector.at(out_index) == cb_addr;
+                bool size_match_out = cb_config_vector.at(out_index + 1) == cb_size;
+                bool num_pages_match_out = cb_config_vector.at(out_index + 2) == num_tiles;
+                bool pass_out = (addr_match_out and size_match_out and num_pages_match_out);
+                EXPECT_TRUE(pass_out);
+            }
         }
     }
 }

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dispatch.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dispatch.cpp
@@ -368,19 +368,14 @@ TEST_F(MeshDispatchFixture, TensixActiveEthTestCBsAcrossDifferentCoreTypes) {
                 uint32_t cb_addr = mesh_device->allocator()->get_base_allocator_addr(HalMemType::L1);
                 uint32_t intermediate_index = intermediate_cb * sizeof(uint32_t);
 
-                bool addr_match_intermediate = cb_config_vector.at(intermediate_index) == cb_addr;
-                bool size_match_intermediate = cb_config_vector.at(intermediate_index + 1) == cb_size;
-                bool num_pages_match_intermediate = cb_config_vector.at(intermediate_index + 2) == num_tiles;
-                bool pass_intermediate =
-                    (addr_match_intermediate and size_match_intermediate and num_pages_match_intermediate);
-                EXPECT_TRUE(pass_intermediate);
+                EXPECT_EQ(cb_config_vector.at(intermediate_index), cb_addr);
+                EXPECT_EQ(cb_config_vector.at(intermediate_index + 1), cb_size);
+                EXPECT_EQ(cb_config_vector.at(intermediate_index + 2), num_tiles);
 
                 uint32_t out_index = out_cb * sizeof(uint32_t);
-                bool addr_match_out = cb_config_vector.at(out_index) == cb_addr;
-                bool size_match_out = cb_config_vector.at(out_index + 1) == cb_size;
-                bool num_pages_match_out = cb_config_vector.at(out_index + 2) == num_tiles;
-                bool pass_out = (addr_match_out and size_match_out and num_pages_match_out);
-                EXPECT_TRUE(pass_out);
+                EXPECT_EQ(cb_config_vector.at(out_index), cb_addr);
+                EXPECT_EQ(cb_config_vector.at(out_index + 1), cb_size);
+                EXPECT_EQ(cb_config_vector.at(out_index + 2), num_tiles);
             }
         }
     }

--- a/tt_metal/api/tt-metalium/experimental/mock_device.hpp
+++ b/tt_metal/api/tt-metalium/experimental/mock_device.hpp
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <umd/device/types/arch.hpp>
+
+#include <cstdint>
+#include <optional>
+#include <string>
+
+namespace tt::tt_metal::experimental {
+
+// Configuration for mock device mode
+struct MockDeviceConfig {
+    tt::ARCH arch;
+    uint32_t num_chips;
+};
+
+// Configure mock mode programmatically - call BEFORE MeshDevice::create()
+// This allows creating mock devices without setting environment variables.
+// arch: Target architecture (WORMHOLE_B0 or BLACKHOLE)
+// num_chips: Number of chips to simulate (1, 2, 4, 8, 32, etc.)
+void configure_mock_mode(tt::ARCH arch, uint32_t num_chips = 1);
+
+// Configure mock mode by detecting current hardware topology
+void configure_mock_mode_from_hw();
+
+// Disable mock mode (return to hardware mode)
+void disable_mock_mode();
+
+// Check if mock mode has been registered via API
+bool is_mock_mode_registered();
+
+// Internal: Get the registered mock config (used by MetalContext)
+std::optional<MockDeviceConfig> get_registered_mock_config();
+
+// Internal: Convert config to cluster descriptor YAML path
+std::string get_mock_cluster_desc_path(const MockDeviceConfig& config);
+
+}  // namespace tt::tt_metal::experimental

--- a/tt_metal/api/tt-metalium/experimental/mock_device.hpp
+++ b/tt_metal/api/tt-metalium/experimental/mock_device.hpp
@@ -4,6 +4,15 @@
 
 #pragma once
 
+/**
+ * @file mock_device.hpp
+ * @brief Mock Device API for hardware-free testing and development
+ *
+ * Enables running TT-Metal without physical hardware. Useful for graph capture,
+ * allocator testing, and CI/CD pipelines. Configure mock mode before device creation,
+ * then use MeshDevice::create() normally.
+ */
+
 #include <umd/device/types/arch.hpp>
 
 #include <cstdint>
@@ -12,19 +21,12 @@
 
 namespace tt::tt_metal::experimental {
 
-// Configuration for mock device mode
-struct MockDeviceConfig {
-    tt::ARCH arch;
-    uint32_t num_chips;
-};
-
-// Configure mock mode programmatically - call BEFORE MeshDevice::create()
-// This allows creating mock devices without setting environment variables.
 // arch: Target architecture (WORMHOLE_B0 or BLACKHOLE)
 // num_chips: Number of chips to simulate (1, 2, 4, 8, 32, etc.)
 void configure_mock_mode(tt::ARCH arch, uint32_t num_chips = 1);
 
-// Configure mock mode by detecting current hardware topology
+// Auto-detect architecture from hardware and configure mock mode
+// Only works on machines with TT hardware present
 void configure_mock_mode_from_hw();
 
 // Disable mock mode (return to hardware mode)
@@ -33,10 +35,9 @@ void disable_mock_mode();
 // Check if mock mode has been registered via API
 bool is_mock_mode_registered();
 
-// Internal: Get the registered mock config (used by MetalContext)
-std::optional<MockDeviceConfig> get_registered_mock_config();
-
-// Internal: Convert config to cluster descriptor YAML path
-std::string get_mock_cluster_desc_path(const MockDeviceConfig& config);
+// Get the cluster descriptor filename for the registered mock config
+// Returns nullopt if mock mode is not registered
+// Returns just the filename (e.g., "blackhole_P150.yaml"), caller prepends base path
+std::optional<std::string> get_mock_cluster_desc();
 
 }  // namespace tt::tt_metal::experimental

--- a/tt_metal/distributed/fd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.cpp
@@ -130,6 +130,10 @@ FDMeshCommandQueue::FDMeshCommandQueue(
 }
 
 FDMeshCommandQueue::~FDMeshCommandQueue() {
+    // Mock devices don't have actual completion queues, skip validation
+    bool is_mock =
+        tt::tt_metal::MetalContext::instance().get_cluster().get_target_device_type() == tt::TargetDevice::Mock;
+
     if (in_use_) {
         // If the FDMeshCommandQueue is being used, have it clear worker state
         // before going out of scope. This is a blocking operation - it waits
@@ -140,15 +144,17 @@ FDMeshCommandQueue::~FDMeshCommandQueue() {
         this->clear_expected_num_workers_completed();
     }
 
-    TT_FATAL(completion_queue_reads_.empty(), "The completion reader queue must be empty when closing devices.");
+    if (!is_mock) {
+        TT_FATAL(completion_queue_reads_.empty(), "The completion reader queue must be empty when closing devices.");
 
-    for (auto& queue : read_descriptors_) {
-        TT_FATAL(queue.second->empty(), "No buffer read requests should be outstanding when closing devices.");
+        for (auto& queue : read_descriptors_) {
+            TT_FATAL(queue.second->empty(), "No buffer read requests should be outstanding when closing devices.");
+        }
+
+        TT_FATAL(
+            num_outstanding_reads_ == 0,
+            "Mismatch between num_outstanding reads and number of entries in completion reader queue.");
     }
-
-    TT_FATAL(
-        num_outstanding_reads_ == 0,
-        "Mismatch between num_outstanding reads and number of entries in completion reader queue.");
 
     {
         std::lock_guard lock(reader_thread_cv_mutex_);
@@ -159,13 +165,18 @@ FDMeshCommandQueue::~FDMeshCommandQueue() {
 }
 
 void FDMeshCommandQueue::populate_read_descriptor_queue() {
-    for (auto& device : mesh_device_->get_devices()) {
+    for (auto* device : mesh_device_->get_devices()) {
         read_descriptors_.emplace(
             device->id(), std::make_unique<MultiProducerSingleConsumerQueue<CompletionReaderVariant>>());
     }
 }
 
 void FDMeshCommandQueue::populate_virtual_program_dispatch_core() {
+    if (tt::tt_metal::MetalContext::instance().get_cluster().get_target_device_type() == tt::TargetDevice::Mock) {
+        this->dispatch_core_ = CoreCoord{0, 0};
+        return;
+    }
+
     int device_idx = 0;
     for (auto* device : mesh_device_->get_devices()) {
         if (device_idx) {
@@ -184,6 +195,10 @@ CoreCoord FDMeshCommandQueue::virtual_program_dispatch_core() const { return thi
 CoreType FDMeshCommandQueue::dispatch_core_type() const { return this->dispatch_core_type_; }
 
 void FDMeshCommandQueue::clear_expected_num_workers_completed() {
+    if (tt::tt_metal::MetalContext::instance().get_cluster().get_target_device_type() == tt::TargetDevice::Mock) {
+        return;
+    }
+
     auto sub_device_ids = buffer_dispatch::select_sub_device_ids(mesh_device_, {});
     auto& sysmem_manager = this->reference_sysmem_manager();
     auto event =
@@ -458,6 +473,11 @@ void FDMeshCommandQueue::enqueue_read_shard_from_core(
     tt::stl::Span<const SubDeviceId> sub_device_ids) {
     ZoneScoped;
     auto lock = lock_api_function_();
+
+    if (tt::tt_metal::MetalContext::instance().get_cluster().get_target_device_type() == tt::TargetDevice::Mock) {
+        return;
+    }
+
     if (!mesh_device_->impl().is_local(address.device_coord)) {
         return;
     }
@@ -492,6 +512,11 @@ void FDMeshCommandQueue::enqueue_read_shard_from_core(
 
 void FDMeshCommandQueue::finish_nolock(tt::stl::Span<const SubDeviceId> sub_device_ids) {
     ZoneScopedN("FDMeshCommandQueue::finish_nolock");
+
+    if (tt::tt_metal::MetalContext::instance().get_cluster().get_target_device_type() == tt::TargetDevice::Mock) {
+        return;
+    }
+
     auto event = this->enqueue_record_event_to_host_nolock(sub_device_ids);
 
     std::unique_lock<std::mutex> lock(reads_processed_cv_mutex_);
@@ -653,6 +678,11 @@ MeshEvent FDMeshCommandQueue::enqueue_record_event_helper(
     tt::stl::Span<const SubDeviceId> sub_device_ids,
     bool notify_host,
     const std::optional<MeshCoordinateRange>& device_range) {
+    if (tt::tt_metal::MetalContext::instance().get_cluster().get_target_device_type() == tt::TargetDevice::Mock) {
+        // Return a dummy event for mock devices
+        return MeshEvent(0, mesh_device_, id_, device_range.value_or(MeshCoordinateRange(mesh_device_->shape())));
+    }
+
     in_use_ = true;
     TT_FATAL(!trace_id_.has_value(), "Event Synchronization is not supported during trace capture.");
 
@@ -733,6 +763,10 @@ void FDMeshCommandQueue::enqueue_wait_for_event(const MeshEvent& sync_event) {
 }
 
 void FDMeshCommandQueue::read_completion_queue() {
+    if (tt::tt_metal::MetalContext::instance().get_cluster().get_target_device_type() == tt::TargetDevice::Mock) {
+        return;
+    }
+
     while (!thread_exception_state_.load()) {
         try {
             {

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -1109,6 +1109,13 @@ FabricNodeId ControlPlane::get_fabric_node_id_from_physical_chip_id(ChipId physi
             return fabric_node_id;
         }
     }
+
+    // Stub: For mock devices, return a synthetic FabricNodeId for any unmapped chip
+    // Mock devices don't have real fabric topology, so synthesize one based on chip_id
+    if (tt::tt_metal::MetalContext::instance().get_cluster().get_target_device_type() == tt::TargetDevice::Mock) {
+        return FabricNodeId(MeshId{0}, physical_chip_id);
+    }
+
     TT_FATAL(
         false,
         "Physical chip id {} not found in control plane chip mapping. You are calling for a chip outside of the fabric "

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -420,6 +420,12 @@ FabricNodeId ControlPlane::get_fabric_node_id_from_asic_id(uint64_t asic_id) con
         }
     }
 
+    // Stub: For mock devices, synthesize a FabricNodeId for any unmapped ASIC ID
+    // Required for large mock clusters (32+ chips) where fabric config may not be fully populated
+    if (cluster.get_target_device_type() == tt::TargetDevice::Mock) {
+        return FabricNodeId(MeshId{0}, static_cast<ChipId>(asic_id));
+    }
+
     TT_FATAL(false, "FabricNodeId not found for ASIC ID {}", asic_id);
     return FabricNodeId(MeshId{0}, 0);
 }
@@ -1111,7 +1117,7 @@ FabricNodeId ControlPlane::get_fabric_node_id_from_physical_chip_id(ChipId physi
     }
 
     // Stub: For mock devices, return a synthetic FabricNodeId for any unmapped chip
-    // Mock devices don't have real fabric topology, so synthesize one based on chip_id
+    // Required for large mock clusters (32+ chips) where fabric config may not be fully populated
     if (tt::tt_metal::MetalContext::instance().get_cluster().get_target_device_type() == tt::TargetDevice::Mock) {
         return FabricNodeId(MeshId{0}, physical_chip_id);
     }

--- a/tt_metal/impl/CMakeLists.txt
+++ b/tt_metal/impl/CMakeLists.txt
@@ -5,6 +5,7 @@ set(IMPL_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/context/metal_context.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/device/experimental/device.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/device/device.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/device/mock_device.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/device/device_manager.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/device/dispatch.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/buffers/buffer.cpp

--- a/tt_metal/impl/CMakeLists.txt
+++ b/tt_metal/impl/CMakeLists.txt
@@ -22,8 +22,8 @@ set(IMPL_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/data_format/bfloat4.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/data_format/bfloat8.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/data_format/bfloat16.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/data_format/tile.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/data_format/bfloat16_utils.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/data_format/tile.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/data_format/tilize_utils.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/kernels/kernel.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/kernels/kernel_types.cpp

--- a/tt_metal/impl/CMakeLists.txt
+++ b/tt_metal/impl/CMakeLists.txt
@@ -22,8 +22,8 @@ set(IMPL_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/data_format/bfloat4.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/data_format/bfloat8.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/data_format/bfloat16.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/data_format/bfloat16_utils.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/data_format/tile.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/data_format/bfloat16_utils.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/data_format/tilize_utils.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/kernels/kernel.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/kernels/kernel_types.cpp

--- a/tt_metal/impl/buffers/dispatch.cpp
+++ b/tt_metal/impl/buffers/dispatch.cpp
@@ -818,6 +818,11 @@ void issue_read_buffer_dispatch_command_sequence(
         return;
     }
 
+    // Mock devices don't have real hardware to read from, skip actual dispatch
+    if (tt::tt_metal::MetalContext::instance().get_cluster().get_target_device_type() == tt::TargetDevice::Mock) {
+        return;
+    }
+
     const auto& hal = tt::tt_metal::MetalContext::instance().hal();
 
     SystemMemoryManager& sysmem_manager = dispatch_params.device->sysmem_manager();

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -34,6 +34,7 @@
 #include "llrt/get_platform_architecture.hpp"
 #include "llrt/llrt.hpp"
 #include <experimental/fabric/control_plane.hpp>
+#include <experimental/mock_device.hpp>
 #include "device/device_manager.hpp"
 #include <distributed_context.hpp>
 #include <experimental/fabric/fabric.hpp>
@@ -430,6 +431,14 @@ void MetalContext::teardown_base_objects() {
 }
 
 MetalContext::MetalContext() {
+    // Check if mock mode was configured via API (before env vars take effect)
+    auto mock_config = experimental::get_registered_mock_config();
+    if (mock_config.has_value()) {
+        std::string yaml_path = experimental::get_mock_cluster_desc_path(*mock_config);
+        rtoptions_.set_mock_cluster_desc_path(yaml_path);
+        log_info(tt::LogMetal, "Using programmatically configured mock mode: {}", yaml_path);
+    }
+
     // If a custom fabric mesh graph descriptor is specified as an RT Option, use it by default
     // to initialize the control plane.
     if (rtoptions_.is_custom_fabric_mesh_graph_desc_path_specified()) {

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -229,7 +229,13 @@ void Device::configure_command_queue_programs() {
 }
 
 void Device::init_command_queue_host() {
+    // SystemMemoryManager now has internal stubs for mock devices
     sysmem_manager_ = std::make_unique<SystemMemoryManager>(this->id_, this->num_hw_cqs());
+
+    // For mock devices, skip HWCommandQueue creation (they don't need real command queues)
+    if (tt::tt_metal::MetalContext::instance().get_cluster().get_target_device_type() == tt::TargetDevice::Mock) {
+        return;
+    }
 
     auto cq_shared_state = std::make_shared<CQSharedState>();
     cq_shared_state->sub_device_cq_owner.resize(1);
@@ -649,6 +655,15 @@ CommandQueue& Device::command_queue(std::optional<uint8_t> cq_id) {
     return *command_queues_[actual_cq_id];
 }
 
+SystemMemoryManager& Device::sysmem_manager() {
+    // SystemMemoryManager handles mock devices internally with stubs
+    // For mock devices, ensure lazy initialization if not already done
+    if (!sysmem_manager_) {
+        sysmem_manager_ = std::make_unique<SystemMemoryManager>(this->id_, 1);
+    }
+    return *sysmem_manager_;
+}
+
 void Device::enable_program_cache() {
     log_info(tt::LogMetal, "Enabling program cache on device {}", this->id_);
     program_cache_.enable();
@@ -691,6 +706,9 @@ uint8_t Device::noc_data_start_index(SubDeviceId /*sub_device_id*/, bool unicast
 }
 
 CoreCoord Device::virtual_program_dispatch_core(uint8_t cq_id) const {
+    if (this->command_queues_.empty() || cq_id >= this->command_queues_.size() || !this->command_queues_[cq_id]) {
+        return CoreCoord{0, 0};  // Return default for mock devices
+    }
     return this->command_queues_[cq_id]->virtual_enqueue_program_dispatch_core();
 }
 
@@ -759,9 +777,14 @@ std::vector<CoreCoord> Device::get_optimal_dram_bank_to_logical_worker_assignmen
         uint32_t num_dram_banks = this->num_dram_channels();
 
         const auto& hal = MetalContext::instance().hal();
-        bool noc_translation_enabled =
-            tt::tt_metal::MetalContext::instance().get_cluster().get_cluster_desc()->get_noc_translation_table_en().at(
-                this->id());
+        bool noc_translation_enabled = true;
+        if (tt::tt_metal::MetalContext::instance().get_cluster().get_target_device_type() != tt::TargetDevice::Mock) {
+            noc_translation_enabled = tt::tt_metal::MetalContext::instance()
+                                          .get_cluster()
+                                          .get_cluster_desc()
+                                          ->get_noc_translation_table_en()
+                                          .at(this->id());
+        }
         bool dram_is_virtualized =
             noc_translation_enabled && (hal.get_virtualized_core_types().contains(dev_msgs::AddressableCoreType::DRAM));
         const metal_SocDescriptor& soc_d =

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -706,7 +706,7 @@ uint8_t Device::noc_data_start_index(SubDeviceId /*sub_device_id*/, bool unicast
 }
 
 CoreCoord Device::virtual_program_dispatch_core(uint8_t cq_id) const {
-    if (this->command_queues_.empty() || cq_id >= this->command_queues_.size() || !this->command_queues_[cq_id]) {
+    if (cq_id >= this->command_queues_.size() || !this->command_queues_[cq_id]) {
         return CoreCoord{0, 0};  // Return default for mock devices
     }
     return this->command_queues_[cq_id]->virtual_enqueue_program_dispatch_core();

--- a/tt_metal/impl/device/device_impl.hpp
+++ b/tt_metal/impl/device/device_impl.hpp
@@ -109,7 +109,7 @@ public:
     uint32_t get_noc_unicast_encoding(uint8_t noc_index, const CoreCoord& core) const override;
     uint32_t get_noc_multicast_encoding(uint8_t noc_index, const CoreRange& cores) const override;
 
-    SystemMemoryManager& sysmem_manager() override { return *sysmem_manager_; }
+    SystemMemoryManager& sysmem_manager() override;
     CommandQueue& command_queue(std::optional<uint8_t> cq_id = std::nullopt) override;
 
     // Metal trace device capture mode

--- a/tt_metal/impl/device/device_manager.cpp
+++ b/tt_metal/impl/device/device_manager.cpp
@@ -534,8 +534,8 @@ void DeviceManager::activate_device(ChipId id) {
         log_debug(tt::LogMetal, "DeviceManager new device {}", id);
         // For mock devices, these maps may not be populated, use defaults
         int worker_core_thread_core =
-            this->worker_thread_to_cpu_core_map_.count(id) ? this->worker_thread_to_cpu_core_map_.at(id) : -1;
-        int completion_queue_reader_core = this->completion_queue_reader_to_cpu_core_map_.count(id)
+            this->worker_thread_to_cpu_core_map_.contains(id) ? this->worker_thread_to_cpu_core_map_.at(id) : -1;
+        int completion_queue_reader_core = this->completion_queue_reader_to_cpu_core_map_.contains(id)
                                                ? this->completion_queue_reader_to_cpu_core_map_.at(id)
                                                : -1;
         device = new Device(

--- a/tt_metal/impl/device/device_manager.cpp
+++ b/tt_metal/impl/device/device_manager.cpp
@@ -307,7 +307,10 @@ void DeviceManager::initialize_devices(const std::vector<ChipId>& device_ids) {
     // May be called again below
     tt::tt_metal::MetalContext::instance().initialize_fabric_config();
 
-    if (any_remote_devices) {
+    // Mock devices don't support fabric operations
+    bool is_mock =
+        tt::tt_metal::MetalContext::instance().get_cluster().get_target_device_type() == tt::TargetDevice::Mock;
+    if (any_remote_devices && !is_mock) {
         auto fabric_config = tt::tt_metal::MetalContext::instance().get_fabric_config();
         if (fabric_config == tt::tt_fabric::FabricConfig::DISABLED) {
             fabric_config = tt::tt_fabric::FabricConfig::FABRIC_1D;
@@ -398,9 +401,11 @@ void DeviceManager::initialize_active_devices() {
     // Activate fabric (must be before FD)
     tt_fabric::FabricConfig fabric_config = tt::tt_metal::MetalContext::instance().get_fabric_config();
     if (tt_fabric::is_tt_fabric_config(fabric_config)) {
-        if (has_flag(
-                tt::tt_metal::MetalContext::instance().get_fabric_manager(),
-                tt_fabric::FabricManagerMode::INIT_FABRIC)) {
+        if (tt::tt_metal::MetalContext::instance().get_cluster().get_target_device_type() == tt::TargetDevice::Mock) {
+            log_info(tt::LogMetal, "Skipping fabric initialization for mock devices");
+        } else if (has_flag(
+                       tt::tt_metal::MetalContext::instance().get_fabric_manager(),
+                       tt_fabric::FabricManagerMode::INIT_FABRIC)) {
             log_info(tt::LogMetal, "Initializing Fabric");
             tt::tt_metal::MetalContext::instance().get_control_plane().write_routing_tables_to_all_chips();
 
@@ -422,6 +427,11 @@ void DeviceManager::initialize_active_devices() {
     // Activate FD kernels
     // Remaining steps are for setting up FD
     if (!using_fast_dispatch_) {
+        return;
+    }
+
+    // Mock devices don't have real command queues or sysmem managers, skip FD kernel setup
+    if (tt::tt_metal::MetalContext::instance().get_cluster().get_target_device_type() == tt::TargetDevice::Mock) {
         return;
     }
 
@@ -522,8 +532,12 @@ void DeviceManager::activate_device(ChipId id) {
     auto* device = get_device(id);
     if (!device) {
         log_debug(tt::LogMetal, "DeviceManager new device {}", id);
-        int worker_core_thread_core = this->worker_thread_to_cpu_core_map_.at(id);
-        int completion_queue_reader_core = this->completion_queue_reader_to_cpu_core_map_.at(id);
+        // For mock devices, these maps may not be populated, use defaults
+        int worker_core_thread_core =
+            this->worker_thread_to_cpu_core_map_.count(id) ? this->worker_thread_to_cpu_core_map_.at(id) : -1;
+        int completion_queue_reader_core = this->completion_queue_reader_to_cpu_core_map_.count(id)
+                                               ? this->completion_queue_reader_to_cpu_core_map_.at(id)
+                                               : -1;
         device = new Device(
             id,
             this->num_hw_cqs_,
@@ -736,6 +750,12 @@ void DeviceManager::wait_for_fabric_router_sync(uint32_t timeout_ms) const {
 }
 
 void DeviceManager::init_firmware_on_active_devices() {
+    // Skip firmware initialization for mock devices
+    if (tt::tt_metal::MetalContext::instance().get_cluster().get_target_device_type() == tt::TargetDevice::Mock) {
+        log_info(tt::LogMetal, "Skipping firmware initialization for mock devices");
+        return;
+    }
+
     const auto& active_devices = this->get_all_active_devices();
     for (const auto& dev : active_devices) {
         // For Galaxy init, we only need to loop over mmio devices
@@ -827,6 +847,11 @@ std::unordered_map<ChipId, std::vector<uint32_t>> DeviceManager::get_all_command
 
 // NOLINTNEXTLINE(readability-make-member-function-const)
 void DeviceManager::teardown_fd(const std::unordered_set<ChipId>& devices_to_close) {
+    // Mock devices don't have sysmem_manager, skip FD teardown
+    if (tt::tt_metal::MetalContext::instance().get_cluster().get_target_device_type() == tt::TargetDevice::Mock) {
+        return;
+    }
+
     for (const auto& dev_id : devices_to_close) {
         // Device is still active at this point
         auto* dev = this->get_active_device(dev_id);

--- a/tt_metal/impl/device/mock_device.cpp
+++ b/tt_metal/impl/device/mock_device.cpp
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <tt-metalium/experimental/mock_device.hpp>
+
+#include <cstdlib>
+
+#include <tt-logger/tt-logger.hpp>
+#include <tt_stl/assert.hpp>
+
+#include "llrt/get_platform_architecture.hpp"
+
+namespace tt::tt_metal::experimental {
+
+// Static storage for registered mock config
+static std::optional<MockDeviceConfig> g_registered_mock_config = std::nullopt;
+
+void configure_mock_mode(tt::ARCH arch, uint32_t num_chips) {
+    g_registered_mock_config = MockDeviceConfig{arch, num_chips};
+    log_info(tt::LogMetal, "Mock mode configured: arch={}, num_chips={}", static_cast<int>(arch), num_chips);
+}
+
+void configure_mock_mode_from_hw() {
+    tt::ARCH arch = get_physical_architecture();
+    // Default to 1 chip - could be enhanced to detect actual chip count
+    uint32_t num_chips = 1;
+    configure_mock_mode(arch, num_chips);
+}
+
+void disable_mock_mode() {
+    g_registered_mock_config = std::nullopt;
+    log_info(tt::LogMetal, "Mock mode disabled");
+}
+
+bool is_mock_mode_registered() {
+    return g_registered_mock_config.has_value();
+}
+
+std::optional<MockDeviceConfig> get_registered_mock_config() {
+    return g_registered_mock_config;
+}
+
+std::string get_mock_cluster_desc_path(const MockDeviceConfig& config) {
+    // Get root dir from environment variable (set before MetalContext initialization)
+    const char* root_dir = std::getenv("TT_METAL_HOME");
+    if (root_dir == nullptr) {
+        root_dir = std::getenv("TT_METAL_RUNTIME_ROOT");
+    }
+    TT_FATAL(root_dir != nullptr,
+        "TT_METAL_HOME or TT_METAL_RUNTIME_ROOT environment variable must be set for mock device mode");
+
+    std::string base_path = std::string(root_dir) +
+                            "/tt_metal/third_party/umd/tests/cluster_descriptor_examples/";
+
+    if (config.arch == tt::ARCH::WORMHOLE_B0) {
+        switch (config.num_chips) {
+            case 1: return base_path + "wormhole_N150.yaml";
+            case 2: return base_path + "wormhole_N300.yaml";
+            case 4: return base_path + "wormhole_2xN300_unconnected.yaml";
+            case 8: return base_path + "t3k_cluster_desc.yaml";
+            case 32: return base_path + "tg_cluster_desc.yaml";
+            default: break;
+        }
+    } else if (config.arch == tt::ARCH::BLACKHOLE) {
+        switch (config.num_chips) {
+            case 1: return base_path + "blackhole_P100.yaml";
+            case 2: return base_path + "blackhole_P150.yaml";
+            case 4: return base_path + "blackhole_P300_first_mmio.yaml";
+            default: break;
+        }
+    }
+
+    TT_THROW(
+        "Unsupported mock device configuration: arch={}, num_chips={}",
+        static_cast<int>(config.arch),
+        config.num_chips);
+}
+
+}  // namespace tt::tt_metal::experimental

--- a/tt_metal/impl/device/mock_device.cpp
+++ b/tt_metal/impl/device/mock_device.cpp
@@ -4,16 +4,21 @@
 
 #include <tt-metalium/experimental/mock_device.hpp>
 
-#include <cstdlib>
-
 #include <tt-logger/tt-logger.hpp>
 #include <tt_stl/assert.hpp>
-
+#include <unordered_map>
 #include "llrt/get_platform_architecture.hpp"
 
 namespace tt::tt_metal::experimental {
 
-// Static storage for registered mock config
+// Internal configuration struct
+struct MockDeviceConfig {
+    tt::ARCH arch;
+    uint32_t num_chips;
+};
+
+// TODO: Remove this global once MetalContext can be initialized with a config object
+// that includes mock device configuration. See issue #XXXXX for tracking.
 static std::optional<MockDeviceConfig> g_registered_mock_config = std::nullopt;
 
 void configure_mock_mode(tt::ARCH arch, uint32_t num_chips) {
@@ -23,9 +28,8 @@ void configure_mock_mode(tt::ARCH arch, uint32_t num_chips) {
 
 void configure_mock_mode_from_hw() {
     tt::ARCH arch = get_physical_architecture();
-    // Default to 1 chip - could be enhanced to detect actual chip count
-    uint32_t num_chips = 1;
-    configure_mock_mode(arch, num_chips);
+    TT_FATAL(arch != tt::ARCH::Invalid, "No TT hardware detected - cannot auto-detect architecture for mock mode");
+    configure_mock_mode(arch, 1);
 }
 
 void disable_mock_mode() {
@@ -37,37 +41,26 @@ bool is_mock_mode_registered() {
     return g_registered_mock_config.has_value();
 }
 
-std::optional<MockDeviceConfig> get_registered_mock_config() {
-    return g_registered_mock_config;
-}
-
-std::string get_mock_cluster_desc_path(const MockDeviceConfig& config) {
-    // Get root dir from environment variable (set before MetalContext initialization)
-    const char* root_dir = std::getenv("TT_METAL_HOME");
-    if (root_dir == nullptr) {
-        root_dir = std::getenv("TT_METAL_RUNTIME_ROOT");
+std::optional<std::string> get_mock_cluster_desc() {
+    if (!g_registered_mock_config.has_value()) {
+        return std::nullopt;
     }
-    TT_FATAL(root_dir != nullptr,
-        "TT_METAL_HOME or TT_METAL_RUNTIME_ROOT environment variable must be set for mock device mode");
 
-    std::string base_path = std::string(root_dir) +
-                            "/tt_metal/third_party/umd/tests/cluster_descriptor_examples/";
+    static const std::unordered_map<tt::ARCH, std::unordered_map<uint32_t, std::string>> cluster_configs = {
+        {tt::ARCH::WORMHOLE_B0,
+         {{1, "wormhole_N150.yaml"},
+          {2, "wormhole_N300.yaml"},
+          {4, "2x2_n300_cluster_desc.yaml"},
+          {8, "t3k_cluster_desc.yaml"},
+          {32, "tg_cluster_desc.yaml"}}},
+        {tt::ARCH::BLACKHOLE, {{1, "blackhole_P150.yaml"}, {2, "blackhole_P300_both_mmio.yaml"}}}};
 
-    if (config.arch == tt::ARCH::WORMHOLE_B0) {
-        switch (config.num_chips) {
-            case 1: return base_path + "wormhole_N150.yaml";
-            case 2: return base_path + "wormhole_N300.yaml";
-            case 4: return base_path + "wormhole_2xN300_unconnected.yaml";
-            case 8: return base_path + "t3k_cluster_desc.yaml";
-            case 32: return base_path + "tg_cluster_desc.yaml";
-            default: break;
-        }
-    } else if (config.arch == tt::ARCH::BLACKHOLE) {
-        switch (config.num_chips) {
-            case 1: return base_path + "blackhole_P100.yaml";
-            case 2: return base_path + "blackhole_P150.yaml";
-            case 4: return base_path + "blackhole_P300_first_mmio.yaml";
-            default: break;
+    const auto& config = *g_registered_mock_config;
+    auto arch_it = cluster_configs.find(config.arch);
+    if (arch_it != cluster_configs.end()) {
+        auto chip_it = arch_it->second.find(config.num_chips);
+        if (chip_it != arch_it->second.end()) {
+            return std::string(chip_it->second);
         }
     }
 

--- a/tt_metal/impl/dispatch/device_command_calculator.hpp
+++ b/tt_metal/impl/dispatch/device_command_calculator.hpp
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#pragma once
+
 #include <stdint.h>
 #include <type_traits>
 #include <utility>

--- a/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
@@ -82,11 +82,13 @@ void PrefetchKernel::GenerateStaticConfigs() {
         my_dispatch_constants.get_device_command_queue_addr(CommandQueueDeviceAddrType::FABRIC_SYNC_STATUS);
 
     if (static_config_.is_h_variant.value() && this->static_config_.is_d_variant.value()) {
+        bool is_mock =
+            tt::tt_metal::MetalContext::instance().get_cluster().get_target_device_type() == tt::TargetDevice::Mock;
         uint32_t cq_start = my_dispatch_constants.get_host_command_queue_addr(CommandQueueHostAddrType::UNRESERVED);
-        uint32_t cq_size = device_->sysmem_manager().get_cq_size();
+        uint32_t cq_size = is_mock ? 0x10000 : device_->sysmem_manager().get_cq_size();
         uint32_t command_queue_start_addr = get_absolute_cq_offset(channel, cq_id_, cq_size);
         uint32_t issue_queue_start_addr = command_queue_start_addr + cq_start;
-        uint32_t issue_queue_size = device_->sysmem_manager().get_issue_queue_size(cq_id_);
+        uint32_t issue_queue_size = is_mock ? 0x10000 : device_->sysmem_manager().get_issue_queue_size(cq_id_);
 
         static_config_.my_downstream_cb_sem_id = tt::tt_metal::CreateSemaphore(
             *program_, logical_core_, my_dispatch_constants.dispatch_buffer_pages(), GetCoreType());

--- a/tt_metal/impl/dispatch/system_memory_manager.cpp
+++ b/tt_metal/impl/dispatch/system_memory_manager.cpp
@@ -6,6 +6,7 @@
 #include "system_memory_manager.hpp"
 #include <tt-metalium/tt_align.hpp>
 #include <algorithm>
+#include <array>
 #include <atomic>
 #include <chrono>
 #include <cstdlib>
@@ -84,22 +85,22 @@ void loop_and_wait_with_timeout(
 }
 }  // namespace
 
-SystemMemoryManager::SystemMemoryManager(ChipId device_id, uint8_t num_hw_cqs) : device_id(device_id) {
-    this->completion_byte_addrs.resize(num_hw_cqs);
-    this->prefetcher_cores.resize(num_hw_cqs);
+SystemMemoryManager::SystemMemoryManager(ChipId device_id, uint8_t num_hw_cqs) :
+    device_id(device_id),
+    completion_byte_addrs(num_hw_cqs),
+    cq_to_event_locks(num_hw_cqs),
+    prefetcher_cores(num_hw_cqs),
+    prefetch_q_dev_ptrs(num_hw_cqs),
+    prefetch_q_dev_fences(num_hw_cqs) {
     this->prefetch_q_writers.reserve(num_hw_cqs);
     this->completion_q_writers.reserve(num_hw_cqs);
-    this->prefetch_q_dev_ptrs.resize(num_hw_cqs);
-    this->prefetch_q_dev_fences.resize(num_hw_cqs);
 
     if (is_mock_device()) {
-        this->cq_size = 0x10000;
+        this->cq_size = 65536;
         this->cq_sysmem_start = nullptr;
         this->channel_offset = 0;
         this->cq_to_event.resize(num_hw_cqs, 0);
         this->cq_to_last_completed_event.resize(num_hw_cqs, 0);
-        std::vector<std::mutex> temp_mutexes(num_hw_cqs);
-        this->cq_to_event_locks.swap(temp_mutexes);
         for (uint8_t cq_id = 0; cq_id < num_hw_cqs; cq_id++) {
             this->cq_interfaces.emplace_back(0, cq_id, this->cq_size, 0);
         }
@@ -194,8 +195,6 @@ SystemMemoryManager::SystemMemoryManager(ChipId device_id, uint8_t num_hw_cqs) :
             prefetch_q_base + MetalContext::instance().dispatch_mem_map().prefetch_q_entries() *
                                   sizeof(DispatchSettings::prefetch_q_entry_type);
     }
-    std::vector<std::mutex> temp_mutexes(num_hw_cqs);
-    cq_to_event_locks.swap(temp_mutexes);
 }
 
 uint32_t SystemMemoryManager::get_next_event(const uint8_t cq_id) {
@@ -315,28 +314,28 @@ std::vector<uint32_t>& SystemMemoryManager::get_bypass_data() { return this->byp
 
 uint32_t SystemMemoryManager::get_issue_queue_size(const uint8_t cq_id) const {
     if (is_mock_device()) {
-        return 0x10000;
+        return 65536;
     }
     return this->cq_interfaces[cq_id].issue_fifo_size << 4;
 }
 
 uint32_t SystemMemoryManager::get_issue_queue_limit(const uint8_t cq_id) const {
     if (is_mock_device()) {
-        return 0x10000;
+        return 65536;
     }
     return this->cq_interfaces[cq_id].issue_fifo_limit << 4;
 }
 
 uint32_t SystemMemoryManager::get_completion_queue_size(const uint8_t cq_id) const {
     if (is_mock_device()) {
-        return 0x10000;
+        return 65536;
     }
     return this->cq_interfaces[cq_id].completion_fifo_size << 4;
 }
 
 uint32_t SystemMemoryManager::get_completion_queue_limit(const uint8_t cq_id) const {
     if (is_mock_device()) {
-        return 0x10000;
+        return 65536;
     }
     return this->cq_interfaces[cq_id].completion_fifo_limit << 4;
 }
@@ -375,7 +374,7 @@ uint32_t SystemMemoryManager::get_completion_queue_read_toggle(const uint8_t cq_
 
 uint32_t SystemMemoryManager::get_cq_size() const {
     if (is_mock_device()) {
-        return 0x10000;
+        return 65536;
     }
     return this->cq_size;
 }
@@ -386,7 +385,7 @@ std::vector<SystemMemoryCQInterface>& SystemMemoryManager::get_cq_interfaces() {
 
 void* SystemMemoryManager::issue_queue_reserve(uint32_t cmd_size_B, const uint8_t cq_id) {
     if (is_mock_device()) {
-        thread_local static std::vector<char> dummy_buffer(0x10000);
+        thread_local std::array<char, 65536> dummy_buffer{};
         return dummy_buffer.data();
     }
 

--- a/tt_metal/impl/dispatch/system_memory_manager.cpp
+++ b/tt_metal/impl/dispatch/system_memory_manager.cpp
@@ -38,8 +38,13 @@ void on_dispatch_timeout_detected();
 
 namespace {
 
+// Helper to check if running on mock device
+inline bool is_mock_device() {
+    return tt::tt_metal::MetalContext::instance().get_cluster().get_target_device_type() == tt::TargetDevice::Mock;
+}
+
 bool wrap_ge(uint32_t a, uint32_t b) {
-    // SIgned Diff uses 2's Complement to handle wrap
+    // Signed Diff uses 2's Complement to handle wrap
     // Works as long as a and b are 2^31 apart
     int32_t diff = a - b;
     return diff >= 0;
@@ -87,11 +92,26 @@ SystemMemoryManager::SystemMemoryManager(ChipId device_id, uint8_t num_hw_cqs) :
     this->prefetch_q_dev_ptrs.resize(num_hw_cqs);
     this->prefetch_q_dev_fences.resize(num_hw_cqs);
 
-    // Split hugepage into however many pieces as there are CQs
+    if (is_mock_device()) {
+        this->cq_size = 0x10000;
+        this->cq_sysmem_start = nullptr;
+        this->channel_offset = 0;
+        this->cq_to_event.resize(num_hw_cqs, 0);
+        this->cq_to_last_completed_event.resize(num_hw_cqs, 0);
+        std::vector<std::mutex> temp_mutexes(num_hw_cqs);
+        this->cq_to_event_locks.swap(temp_mutexes);
+        for (uint8_t cq_id = 0; cq_id < num_hw_cqs; cq_id++) {
+            this->cq_interfaces.emplace_back(0, cq_id, this->cq_size, 0);
+        }
+        log_debug(tt::LogMetal, "SystemMemoryManager: Initialized with stubs for mock device");
+        return;
+    }
+
+    // Real hardware initialization below
     ChipId mmio_device_id = tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(device_id);
     uint16_t channel = tt::tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(device_id);
-    char* hugepage_start =
-        (char*)tt::tt_metal::MetalContext::instance().get_cluster().host_dma_address(0, mmio_device_id, channel);
+    char* hugepage_start = static_cast<char*>(
+        tt::tt_metal::MetalContext::instance().get_cluster().host_dma_address(0, mmio_device_id, channel));
     hugepage_start += (channel >> 2) * DispatchSettings::MAX_DEV_CHANNEL_SIZE;
     this->cq_sysmem_start = hugepage_start;
 
@@ -179,6 +199,9 @@ SystemMemoryManager::SystemMemoryManager(ChipId device_id, uint8_t num_hw_cqs) :
 }
 
 uint32_t SystemMemoryManager::get_next_event(const uint8_t cq_id) {
+    if (is_mock_device()) {
+        return ++this->cq_to_event[cq_id];
+    }
     cq_to_event_locks[cq_id].lock();
     uint32_t next_event = ++this->cq_to_event[cq_id];  // Event ids start at 1
 
@@ -202,18 +225,30 @@ void SystemMemoryManager::set_current_and_last_completed_event(
 }
 
 void SystemMemoryManager::reset_event_id(const uint8_t cq_id) {
+    if (is_mock_device()) {
+        this->cq_to_event[cq_id] = 0;
+        return;
+    }
     cq_to_event_locks[cq_id].lock();
     this->cq_to_event[cq_id] = 0;
     cq_to_event_locks[cq_id].unlock();
 }
 
 void SystemMemoryManager::increment_event_id(const uint8_t cq_id, const uint32_t val) {
+    if (is_mock_device()) {
+        this->cq_to_event[cq_id] += val;
+        return;
+    }
     cq_to_event_locks[cq_id].lock();
     this->cq_to_event[cq_id] += val;
     cq_to_event_locks[cq_id].unlock();
 }
 
 void SystemMemoryManager::set_last_completed_event(const uint8_t cq_id, const uint32_t event_id) {
+    if (is_mock_device()) {
+        this->cq_to_last_completed_event[cq_id] = event_id;
+        return;
+    }
     TT_ASSERT(
         wrap_ge(event_id, this->cq_to_last_completed_event[cq_id]),
         "Event ID is expected to increase. Wrapping not supported for sync. Completed event {} but last recorded "
@@ -235,6 +270,9 @@ uint32_t SystemMemoryManager::get_current_event(const uint8_t cq_id) {
 }
 
 uint32_t SystemMemoryManager::get_last_completed_event(const uint8_t cq_id) {
+    if (is_mock_device()) {
+        return this->cq_to_last_completed_event[cq_id];
+    }
     cq_to_event_locks[cq_id].lock();
     uint32_t last_completed_event = this->cq_to_last_completed_event[cq_id];
     cq_to_event_locks[cq_id].unlock();
@@ -242,6 +280,10 @@ uint32_t SystemMemoryManager::get_last_completed_event(const uint8_t cq_id) {
 }
 
 void SystemMemoryManager::reset(const uint8_t cq_id) {
+    if (is_mock_device()) {
+        return;
+    }
+
     SystemMemoryCQInterface& cq_interface = this->cq_interfaces[cq_id];
     cq_interface.issue_fifo_wr_ptr = (cq_interface.cq_start + cq_interface.offset) >> 4;  // In 16B words
     cq_interface.issue_fifo_wr_toggle = false;
@@ -250,6 +292,10 @@ void SystemMemoryManager::reset(const uint8_t cq_id) {
 }
 
 void SystemMemoryManager::set_issue_queue_size(const uint8_t cq_id, const uint32_t issue_queue_size) {
+    if (is_mock_device()) {
+        return;
+    }
+
     SystemMemoryCQInterface& cq_interface = this->cq_interfaces[cq_id];
     cq_interface.issue_fifo_size = (issue_queue_size >> 4);
     cq_interface.issue_fifo_limit = (cq_interface.cq_start + cq_interface.offset + issue_queue_size) >> 4;
@@ -268,22 +314,37 @@ bool SystemMemoryManager::get_bypass_mode() const { return this->bypass_enable; 
 std::vector<uint32_t>& SystemMemoryManager::get_bypass_data() { return this->bypass_buffer; }
 
 uint32_t SystemMemoryManager::get_issue_queue_size(const uint8_t cq_id) const {
+    if (is_mock_device()) {
+        return 0x10000;
+    }
     return this->cq_interfaces[cq_id].issue_fifo_size << 4;
 }
 
 uint32_t SystemMemoryManager::get_issue_queue_limit(const uint8_t cq_id) const {
+    if (is_mock_device()) {
+        return 0x10000;
+    }
     return this->cq_interfaces[cq_id].issue_fifo_limit << 4;
 }
 
 uint32_t SystemMemoryManager::get_completion_queue_size(const uint8_t cq_id) const {
+    if (is_mock_device()) {
+        return 0x10000;
+    }
     return this->cq_interfaces[cq_id].completion_fifo_size << 4;
 }
 
 uint32_t SystemMemoryManager::get_completion_queue_limit(const uint8_t cq_id) const {
+    if (is_mock_device()) {
+        return 0x10000;
+    }
     return this->cq_interfaces[cq_id].completion_fifo_limit << 4;
 }
 
 uint32_t SystemMemoryManager::get_issue_queue_write_ptr(const uint8_t cq_id) const {
+    if (is_mock_device()) {
+        return 0;
+    }
     if (this->bypass_enable) {
         return this->bypass_buffer_write_offset;
     }
@@ -291,6 +352,9 @@ uint32_t SystemMemoryManager::get_issue_queue_write_ptr(const uint8_t cq_id) con
 }
 
 uint32_t SystemMemoryManager::get_completion_queue_read_ptr(const uint8_t cq_id) const {
+    if (is_mock_device()) {
+        return 0;
+    }
     return this->cq_interfaces[cq_id].completion_fifo_rd_ptr << 4;
 }
 
@@ -303,17 +367,29 @@ void* SystemMemoryManager::get_completion_queue_ptr(uint8_t cq_id) const {
 }
 
 uint32_t SystemMemoryManager::get_completion_queue_read_toggle(const uint8_t cq_id) const {
+    if (is_mock_device()) {
+        return 0;
+    }
     return this->cq_interfaces[cq_id].completion_fifo_rd_toggle;
 }
 
-uint32_t SystemMemoryManager::get_cq_size() const { return this->cq_size; }
+uint32_t SystemMemoryManager::get_cq_size() const {
+    if (is_mock_device()) {
+        return 0x10000;
+    }
+    return this->cq_size;
+}
 
 ChipId SystemMemoryManager::get_device_id() const { return this->device_id; }
 
 std::vector<SystemMemoryCQInterface>& SystemMemoryManager::get_cq_interfaces() { return this->cq_interfaces; }
 
 void* SystemMemoryManager::issue_queue_reserve(uint32_t cmd_size_B, const uint8_t cq_id) {
-    TT_ASSERT(cmd_size_B > 0, "Command size must be greater than 0");
+    if (is_mock_device()) {
+        thread_local static std::vector<char> dummy_buffer(0x10000);
+        return dummy_buffer.data();
+    }
+
     if (this->bypass_enable) {
         uint32_t curr_size = this->bypass_buffer.size();
         uint32_t new_size = curr_size + (cmd_size_B / sizeof(uint32_t));
@@ -348,6 +424,10 @@ void* SystemMemoryManager::issue_queue_reserve(uint32_t cmd_size_B, const uint8_
 }
 
 void SystemMemoryManager::cq_write(const void* data, uint32_t size_in_bytes, uint32_t write_ptr) {
+    if (is_mock_device()) {
+        return;
+    }
+
     // Currently read / write pointers on host and device assumes contiguous ranges for each channel
     // Device needs absolute offset of a hugepage to access the region of sysmem that holds a particular command
     // queue
@@ -368,7 +448,10 @@ void SystemMemoryManager::cq_write(const void* data, uint32_t size_in_bytes, uin
 
 // TODO: RENAME issue_queue_stride ?
 void SystemMemoryManager::issue_queue_push_back(uint32_t push_size_B, const uint8_t cq_id) {
-    TT_ASSERT(push_size_B > 0, "Push size must be greater than 0");
+    if (is_mock_device()) {
+        return;
+    }
+
     if (this->bypass_enable) {
         this->bypass_buffer_write_offset += push_size_B;
         return;
@@ -405,6 +488,10 @@ void SystemMemoryManager::issue_queue_push_back(uint32_t push_size_B, const uint
 }
 
 void SystemMemoryManager::send_completion_queue_read_ptr(const uint8_t cq_id) const {
+    if (is_mock_device()) {
+        return;
+    }
+
     const SystemMemoryCQInterface& cq_interface = this->cq_interfaces[cq_id];
 
     uint32_t read_ptr_and_toggle = cq_interface.completion_fifo_rd_ptr | (cq_interface.completion_fifo_rd_toggle << 31);
@@ -426,6 +513,10 @@ void SystemMemoryManager::send_completion_queue_read_ptr(const uint8_t cq_id) co
 }
 
 void SystemMemoryManager::fetch_queue_reserve_back(const uint8_t cq_id) {
+    if (is_mock_device()) {
+        return;
+    }
+
     if (this->bypass_enable) {
         return;
     }
@@ -479,6 +570,10 @@ void SystemMemoryManager::fetch_queue_reserve_back(const uint8_t cq_id) {
 
 uint32_t SystemMemoryManager::completion_queue_wait_front(
     const uint8_t cq_id, std::atomic<bool>& exit_condition) const {
+    if (is_mock_device()) {
+        return 0;
+    }
+
     uint32_t write_ptr_and_toggle;
     uint32_t write_ptr;
     uint32_t write_toggle;
@@ -523,6 +618,10 @@ uint32_t SystemMemoryManager::completion_queue_wait_front(
 }
 
 void SystemMemoryManager::wrap_issue_queue_wr_ptr(const uint8_t cq_id) {
+    if (is_mock_device()) {
+        return;
+    }
+
     if (this->bypass_enable) {
         return;
     }
@@ -532,12 +631,20 @@ void SystemMemoryManager::wrap_issue_queue_wr_ptr(const uint8_t cq_id) {
 }
 
 void SystemMemoryManager::wrap_completion_queue_rd_ptr(const uint8_t cq_id) {
+    if (is_mock_device()) {
+        return;
+    }
+
     SystemMemoryCQInterface& cq_interface = this->cq_interfaces[cq_id];
     cq_interface.completion_fifo_rd_ptr = cq_interface.issue_fifo_limit;
     cq_interface.completion_fifo_rd_toggle = not cq_interface.completion_fifo_rd_toggle;
 }
 
 void SystemMemoryManager::completion_queue_pop_front(uint32_t num_pages_read, const uint8_t cq_id) {
+    if (is_mock_device()) {
+        return;
+    }
+
     uint32_t data_read_B = num_pages_read * DispatchSettings::TRANSFER_PAGE_SIZE;
     uint32_t data_read_16B = data_read_B >> 4;
 
@@ -553,6 +660,10 @@ void SystemMemoryManager::completion_queue_pop_front(uint32_t num_pages_read, co
 }
 
 void SystemMemoryManager::fetch_queue_write(uint32_t command_size_B, const uint8_t cq_id, bool stall_prefetcher) {
+    if (is_mock_device()) {
+        return;
+    }
+
     uint32_t max_command_size_B = MetalContext::instance().dispatch_mem_map().max_prefetch_command_size();
     TT_ASSERT(
         command_size_B <= max_command_size_B,

--- a/tt_metal/impl/event/dispatch.cpp
+++ b/tt_metal/impl/event/dispatch.cpp
@@ -175,6 +175,13 @@ void read_events_from_completion_queue(
     uint16_t channel,
     uint8_t cq_id,
     SystemMemoryManager& sysmem_manager) {
+    // For mock devices, the sysmem_manager is a stubbed singleton
+    // Mock cluster.read_sysmem returns zeros, so validate that and handle gracefully
+    if (tt::tt_metal::MetalContext::instance().get_cluster().get_target_device_type() == tt::TargetDevice::Mock) {
+        sysmem_manager.set_last_completed_event(cq_id, event_descriptor.get_global_event_id());
+        return;
+    }
+
     uint32_t read_ptr = sysmem_manager.get_completion_queue_read_ptr(cq_id);
     thread_local static std::vector<uint32_t> dispatch_cmd_and_event(
         (sizeof(CQDispatchCmd) + DispatchSettings::EVENT_PADDED_SIZE) / sizeof(uint32_t));

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -313,6 +313,13 @@ uint32_t finalize_kernel_bins(
     uint32_t base_offset,
     uint32_t& kernel_text_offset,
     uint32_t& kernel_text_size) {
+    // Mock devices don't have real binaries, skip finalization
+    if (tt::tt_metal::MetalContext::instance().get_cluster().get_target_device_type() == tt::TargetDevice::Mock) {
+        kernel_text_offset = base_offset;
+        kernel_text_size = 0;
+        return base_offset;
+    }
+
     const auto& hal = MetalContext::instance().hal();
     uint32_t l1_alignment = hal.get_alignment(HalMemType::L1);
 

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -1071,6 +1071,11 @@ void detail::ProgramImpl::set_cb_tile_dims(const std::vector<CoreRange>& crs, Ji
 }
 
 void detail::ProgramImpl::populate_dispatch_data(IDevice* device) {
+    // Mock devices don't dispatch to hardware, skip dispatch data population
+    if (tt::tt_metal::MetalContext::instance().get_cluster().get_target_device_type() == tt::TargetDevice::Mock) {
+        return;
+    }
+
     auto extract_dst_noc_unicast_info =
         [&device](
             const auto& ranges, const CoreType core_type) -> std::vector<std::pair<transfer_info_cores, uint32_t>> {
@@ -1438,10 +1443,22 @@ void detail::ProgramImpl::compile(IDevice* device, bool force_slow_dispatch) {
                     kernel->set_full_name(kernel_path_suffix);
                     build_options.set_name(kernel_path_suffix);
 
-                    kernel->register_kernel_elf_paths_with_watcher(*device);
+                    if (tt::tt_metal::MetalContext::instance().get_cluster().get_target_device_type() !=
+                        tt::TargetDevice::Mock) {
+                        kernel->register_kernel_elf_paths_with_watcher(*device);
+                    }
+
+                    bool is_mock = tt::tt_metal::MetalContext::instance().get_cluster().get_target_device_type() ==
+                                   tt::TargetDevice::Mock;
 
                     if (detail::HashLookup::inst().add(kernel_hash)) {
-                        GenerateBinaries(device, build_options, kernel);
+                        if (!is_mock) {
+                            GenerateBinaries(device, build_options, kernel);
+                        } else {
+                            // Create empty stub binaries for mock devices
+                            std::vector<const ll_api::memory*> empty_binaries(kernel->expected_num_binaries(), nullptr);
+                            kernel->set_binaries(build_env.build_key(), std::move(empty_binaries));
+                        }
                         detail::HashLookup::inst().add_generated_bin(kernel_hash);
                     }
                     detail::HashLookup::inst().wait_for_bin_generated(kernel_hash);
@@ -1453,12 +1470,17 @@ void detail::ProgramImpl::compile(IDevice* device, bool force_slow_dispatch) {
     }
     sync_build_steps(events);
 
-    for (auto& kernels : kernels_) {
-        for (auto& [id, kernel] : kernels) {
-            launch_build_step([kernel, device] { kernel->read_binaries(device); }, events);
+    // Mock devices don't have binaries to read
+    bool is_mock =
+        tt::tt_metal::MetalContext::instance().get_cluster().get_target_device_type() == tt::TargetDevice::Mock;
+    if (!is_mock) {
+        for (auto& kernels : kernels_) {
+            for (auto& [id, kernel] : kernels) {
+                launch_build_step([kernel, device] { kernel->read_binaries(device); }, events);
+            }
         }
+        sync_build_steps(events);
     }
-    sync_build_steps(events);
     if (detail::MemoryReporter::enabled()) {
         detail::MemoryReporter::inst().flush_program_memory_usage(get_id(), device);
     }

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -1474,8 +1474,9 @@ void detail::ProgramImpl::compile(IDevice* device, bool force_slow_dispatch) {
     bool is_mock =
         tt::tt_metal::MetalContext::instance().get_cluster().get_target_device_type() == tt::TargetDevice::Mock;
     if (!is_mock) {
-        for (auto& kernels : kernels_) {
-            for (auto& [id, kernel] : kernels) {
+        for (const auto& kernels : kernels_) {
+            for (const auto& pair : kernels) {
+                const auto& kernel = pair.second;
                 launch_build_step([kernel, device] { kernel->read_binaries(device); }, events);
             }
         }

--- a/tt_metal/impl/trace/trace_buffer.cpp
+++ b/tt_metal/impl/trace/trace_buffer.cpp
@@ -5,13 +5,13 @@
 #include "trace_buffer.hpp"
 
 #include <device.hpp>
+#include <fmt/ranges.h>
 #include <tt_metal.hpp>
 #include <utility>
 
 #include "buffer.hpp"
 #include <tt-logger/tt-logger.hpp>
 #include <fmt/core.h>
-#include <fmt/ranges.h>
 
 namespace tt::tt_metal {
 

--- a/tt_metal/llrt/core_descriptor.cpp
+++ b/tt_metal/llrt/core_descriptor.cpp
@@ -214,8 +214,12 @@ const core_descriptor_t& get_core_descriptor_config(
 
     CoreCoord grid_size =
         tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(device_id).get_grid_size(CoreType::TENSIX);
-    auto logical_active_eth_cores =
-        tt::tt_metal::MetalContext::instance().get_control_plane().get_active_ethernet_cores(device_id);
+    // For mock devices, control plane doesn't exist, use empty set
+    std::unordered_set<CoreCoord> logical_active_eth_cores;
+    if (tt::tt_metal::MetalContext::instance().get_cluster().get_target_device_type() != tt::TargetDevice::Mock) {
+        logical_active_eth_cores =
+            tt::tt_metal::MetalContext::instance().get_control_plane().get_active_ethernet_cores(device_id);
+    }
 
     for (const auto& core_node : desc_yaml[dispatch_cores_string]) {
         RelativeCoreCoord coord = {};

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -637,10 +637,17 @@ public:
     // Mock cluster accessors
     bool get_mock_enabled() const { return !mock_cluster_desc_path.empty(); }
     const std::string& get_mock_cluster_desc_path() const { return mock_cluster_desc_path; }
-    void set_mock_cluster_desc_path(const std::string& path) {
-        mock_cluster_desc_path = path;
-        // Set target device to Mock if path is provided and simulator is not enabled
-        if (!path.empty() && simulator_path.empty()) {
+    // Set mock cluster descriptor from filename (prepends base path automatically)
+    // NOTE: Must be called before Cluster is created (e.g., in MetalContext constructor).
+    // Path depends on UMD's cluster_descriptor_examples directory structure.
+    void set_mock_cluster_desc(const std::string& filename) {
+        if (filename.empty()) {
+            return;
+        }
+        mock_cluster_desc_path =
+            get_root_dir() + "/tt_metal/third_party/umd/tests/cluster_descriptor_examples/" + filename;
+        // Set target device to Mock if simulator is not enabled
+        if (simulator_path.empty()) {
             runtime_target_device_ = tt::TargetDevice::Mock;
         }
     }

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -637,6 +637,13 @@ public:
     // Mock cluster accessors
     bool get_mock_enabled() const { return !mock_cluster_desc_path.empty(); }
     const std::string& get_mock_cluster_desc_path() const { return mock_cluster_desc_path; }
+    void set_mock_cluster_desc_path(const std::string& path) {
+        mock_cluster_desc_path = path;
+        // Set target device to Mock if path is provided and simulator is not enabled
+        if (!path.empty() && simulator_path.empty()) {
+            runtime_target_device_ = tt::TargetDevice::Mock;
+        }
+    }
 
     // Target device accessor
     TargetDevice get_target_device() const { return runtime_target_device_; }

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -385,7 +385,6 @@ const std::unordered_map<CoreCoord, int32_t>& Cluster::get_virtual_routing_to_pr
 void Cluster::open_driver(const bool& /*skip_driver_allocs*/) {
     std::unique_ptr<tt::umd::Cluster> device_driver;
     std::string sdesc_path = get_soc_description_file(this->arch_, this->target_type_, rtoptions_);
-    std::unique_ptr<umd::ClusterDescriptor> mock_cluster_desc;
     if (this->target_type_ == TargetDevice::Silicon) {
         // This is the target/desired number of mem channels per arch/device.
         // Silicon driver will attempt to open this many hugepages as channels per mmio chip,
@@ -420,7 +419,7 @@ void Cluster::open_driver(const bool& /*skip_driver_allocs*/) {
     } else if (this->target_type_ == TargetDevice::Mock) {
         // If a cluster descriptor was not provided via constructor, and mock is enabled via rtoptions,
         // load it from the YAML path and pass it into UMD for mock initialization.
-        mock_cluster_desc = get_mock_cluster_desc(rtoptions_);
+        auto mock_cluster_desc = get_mock_cluster_desc(rtoptions_);
 
         device_driver = std::make_unique<tt::umd::Cluster>(tt::umd::ClusterOptions{
             .chip_type = tt::umd::ChipType::MOCK,

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -281,7 +281,7 @@ void Cluster::generate_cluster_descriptor() {
             this->rtoptions_.is_custom_fabric_mesh_graph_desc_path_specified(),
             "Custom fabric mesh graph descriptor path must be specified for CUSTOM cluster type");
     }
-    if (this->target_type_ == TargetDevice::Simulator) {
+    if (this->target_type_ == TargetDevice::Simulator || this->target_type_ == TargetDevice::Mock) {
         return;
     }
 
@@ -385,6 +385,7 @@ const std::unordered_map<CoreCoord, int32_t>& Cluster::get_virtual_routing_to_pr
 void Cluster::open_driver(const bool& /*skip_driver_allocs*/) {
     std::unique_ptr<tt::umd::Cluster> device_driver;
     std::string sdesc_path = get_soc_description_file(this->arch_, this->target_type_, rtoptions_);
+    std::unique_ptr<umd::ClusterDescriptor> mock_cluster_desc;
     if (this->target_type_ == TargetDevice::Silicon) {
         // This is the target/desired number of mem channels per arch/device.
         // Silicon driver will attempt to open this many hugepages as channels per mmio chip,
@@ -419,7 +420,7 @@ void Cluster::open_driver(const bool& /*skip_driver_allocs*/) {
     } else if (this->target_type_ == TargetDevice::Mock) {
         // If a cluster descriptor was not provided via constructor, and mock is enabled via rtoptions,
         // load it from the YAML path and pass it into UMD for mock initialization.
-        std::unique_ptr<umd::ClusterDescriptor> mock_cluster_desc = get_mock_cluster_desc(rtoptions_);
+        mock_cluster_desc = get_mock_cluster_desc(rtoptions_);
 
         device_driver = std::make_unique<tt::umd::Cluster>(tt::umd::ClusterOptions{
             .chip_type = tt::umd::ChipType::MOCK,


### PR DESCRIPTION
# Mock Device: 
Issue : https://github.com/tenstorrent/tt-metal/issues/14000
UMD PR: https://github.com/tenstorrent/tt-umd/pull/1705
Passing CI Runs : All-post-commit: https://github.com/tenstorrent/tt-metal/actions/runs/20969272665
                              Merge gate: https://github.com/tenstorrent/tt-metal/actions/runs/20988390171
## Overview

This PR introduces **Mock Device** - a simulation layer that enables testing and development of tt-metal applications without physical Tenstorrent hardware. Mock Device provides a complete software-only implementation of device operations, allowing developers to validate APIs, test workflows, and develop multi-chip applications entirely in software.

### What is Mock Device?

Mock Device is a hardware emulation layer that simulates Tenstorrent accelerator behavior without requiring physical chips. It provides. Multi-chip configurations can also be emulated by specifying a cluster descriptor YAML. 

### Usage

**Environment Variable approach:**
export TT_METAL_MOCK_CLUSTER_DESC_PATH=tt_metal/third_party/umd/tests/cluster_descriptor_examples/blackhole_P150.yaml

**Programmatic API approach:**
#include <tt-metalium/experimental/mock_device.hpp>

// Configure mock mode BEFORE any device creation
tt::tt_metal::experimental::configure_mock_mode(tt::ARCH::BLACKHOLE, 1);

// Now use MeshDevice::create() as normal - it will automatically use mock mode
auto mesh = tt::tt_metal::distributed::MeshDevice::create(mesh_config, mesh_device_options);

// Alternatively, auto-detect architecture from hardware
// (useful when HW is present but you want mock mode for graph capture)
tt::tt_metal::experimental::configure_mock_mode_from_hw();The programmatic API sets the mock configuration before `MetalContext` initializes, so all subsequent device operations (via `MeshDevice::create()`) will use the mock backend transparently.

### Supported Configurations

| Arch | Chips | Descriptor |
|------|-------|------------|
| WORMHOLE_B0 | 1, 2, 4, 8, 32 | N150, N300, 2x2, T3K, TG |
| BLACKHOLE | 1, 2 | P150, P300 |

### Additional Fixes

Fixed pre-existing Unity Build issues: missing `#pragma once` in `device_command_calculator.hpp` 

### Next Steps
- Integration into L2-nightly-pipeline for regression testing