### PR TITLE
Use prebuilt binaries for TT-Sim

### DIFF
--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -345,7 +345,6 @@ jobs:
             needs.find-changes.outputs.any-code-changed == 'true'
         }}
     needs: [build, find-changes]
-    secrets: inherit
     strategy:
       fail-fast: false
     uses: ./.github/workflows/ttsim.yaml

--- a/.github/workflows/pr-gate.yaml
+++ b/.github/workflows/pr-gate.yaml
@@ -276,7 +276,6 @@ jobs:
     strategy:
       fail-fast: false
     uses: ./.github/workflows/ttsim.yaml
-    secrets: inherit
     with:
       basic-docker-image: ${{ needs.build.outputs.basic-dev-docker-image }}
       test-docker-image: ${{ needs.build.outputs.ci-test-docker-image }}

--- a/.github/workflows/ttsim.yaml
+++ b/.github/workflows/ttsim.yaml
@@ -91,7 +91,7 @@ jobs:
           echo "asset_name=libttsim_${asset_suffix}.so" >> "$GITHUB_OUTPUT"
 
       - name: Download ttsim binary
-        uses: robinraju/release-downloader@v1.10.1
+        uses: robinraju/release-downloader@vdaf26c55d821e836577a15f77d86ddc078948b05 # v1.12
         with:
           repository: tenstorrent/ttsim
           tag: ${{ inputs.ttsim-version }}
@@ -190,7 +190,7 @@ jobs:
           echo "asset_name=libttsim_${asset_suffix}.so" >> "$GITHUB_OUTPUT"
 
       - name: Download ttsim binary
-        uses: robinraju/release-downloader@v1.10.1
+        uses: robinraju/release-downloader@vdaf26c55d821e836577a15f77d86ddc078948b05 # v1.12
         with:
           repository: tenstorrent/ttsim
           tag: ${{ inputs.ttsim-version }}
@@ -340,7 +340,7 @@ jobs:
           echo "asset_name=libttsim_${asset_suffix}.so" >> "$GITHUB_OUTPUT"
 
       - name: Download ttsim binary
-        uses: robinraju/release-downloader@v1.10.1
+        uses: robinraju/release-downloader@vdaf26c55d821e836577a15f77d86ddc078948b05 # v1.12
         with:
           repository: tenstorrent/ttsim
           tag: ${{ inputs.ttsim-version }}
@@ -431,7 +431,7 @@ jobs:
           echo "asset_name=libttsim_${asset_suffix}.so" >> "$GITHUB_OUTPUT"
 
       - name: Download ttsim binary
-        uses: robinraju/release-downloader@v1.10.1
+        uses: robinraju/release-downloader@vdaf26c55d821e836577a15f77d86ddc078948b05 # v1.12
         with:
           repository: tenstorrent/ttsim
           tag: ${{ inputs.ttsim-version }}

--- a/.github/workflows/ttsim.yaml
+++ b/.github/workflows/ttsim.yaml
@@ -91,7 +91,7 @@ jobs:
           echo "asset_name=libttsim_${asset_suffix}.so" >> "$GITHUB_OUTPUT"
 
       - name: Download ttsim binary
-        uses: robinraju/release-downloader@vdaf26c55d821e836577a15f77d86ddc078948b05 # v1.12
+        uses: robinraju/release-downloader@daf26c55d821e836577a15f77d86ddc078948b05 # v1.12
         with:
           repository: tenstorrent/ttsim
           tag: ${{ inputs.ttsim-version }}
@@ -190,7 +190,7 @@ jobs:
           echo "asset_name=libttsim_${asset_suffix}.so" >> "$GITHUB_OUTPUT"
 
       - name: Download ttsim binary
-        uses: robinraju/release-downloader@vdaf26c55d821e836577a15f77d86ddc078948b05 # v1.12
+        uses: robinraju/release-downloader@daf26c55d821e836577a15f77d86ddc078948b05 # v1.12
         with:
           repository: tenstorrent/ttsim
           tag: ${{ inputs.ttsim-version }}
@@ -340,7 +340,7 @@ jobs:
           echo "asset_name=libttsim_${asset_suffix}.so" >> "$GITHUB_OUTPUT"
 
       - name: Download ttsim binary
-        uses: robinraju/release-downloader@vdaf26c55d821e836577a15f77d86ddc078948b05 # v1.12
+        uses: robinraju/release-downloader@daf26c55d821e836577a15f77d86ddc078948b05 # v1.12
         with:
           repository: tenstorrent/ttsim
           tag: ${{ inputs.ttsim-version }}
@@ -431,7 +431,7 @@ jobs:
           echo "asset_name=libttsim_${asset_suffix}.so" >> "$GITHUB_OUTPUT"
 
       - name: Download ttsim binary
-        uses: robinraju/release-downloader@vdaf26c55d821e836577a15f77d86ddc078948b05 # v1.12
+        uses: robinraju/release-downloader@daf26c55d821e836577a15f77d86ddc078948b05 # v1.12
         with:
           repository: tenstorrent/ttsim
           tag: ${{ inputs.ttsim-version }}

--- a/.github/workflows/ttsim.yaml
+++ b/.github/workflows/ttsim.yaml
@@ -304,9 +304,6 @@ jobs:
           - arch: blackhole
             build_suffix: release_bh
             soc_desc: blackhole_140_arch.yaml
-          - arch: quasar
-            build_suffix: release_qsr
-            soc_desc: quasar_1_arch.yaml
     container:
       image: harbor.ci.tenstorrent.net/${{ inputs.test-docker-image || 'docker-image-unresolved!'}}
       volumes:

--- a/.github/workflows/ttsim.yaml
+++ b/.github/workflows/ttsim.yaml
@@ -102,7 +102,7 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p $TT_METAL_SIMULATOR_HOME
-          mv /tmp/ttsim/libttsim.so $TT_METAL_SIMULATOR_HOME/
+          mv /tmp/ttsim/${{ steps.ttsim-asset.outputs.asset_name }} $TT_METAL_SIMULATOR_HOME/libttsim.so
           cp $TT_METAL_HOME/tt_metal/soc_descriptors/${{ matrix.soc_desc }} $TT_METAL_SIMULATOR_HOME/soc_descriptor.yaml
 
       - name: Build and Run Metal Examples
@@ -201,7 +201,7 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p $TT_METAL_SIMULATOR_HOME
-          mv /tmp/ttsim/libttsim.so $TT_METAL_SIMULATOR_HOME/
+          mv /tmp/ttsim/${{ steps.ttsim-asset.outputs.asset_name }} $TT_METAL_SIMULATOR_HOME/libttsim.so
           cp /work/tt_metal/soc_descriptors/${{ matrix.soc_desc }} $TT_METAL_SIMULATOR_HOME/soc_descriptor.yaml
 
       - name: Run TTNN Pytests
@@ -351,7 +351,7 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p $TT_METAL_SIMULATOR_HOME
-          mv /tmp/ttsim/libttsim.so $TT_METAL_SIMULATOR_HOME/
+          mv /tmp/ttsim/${{ steps.ttsim-asset.outputs.asset_name }} $TT_METAL_SIMULATOR_HOME/libttsim.so
           cp /work/tt_metal/soc_descriptors/${{ matrix.soc_desc }} $TT_METAL_SIMULATOR_HOME/soc_descriptor.yaml
 
       - name: C++ tests
@@ -442,7 +442,7 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p $TT_METAL_SIMULATOR_HOME
-          mv /tmp/ttsim/libttsim.so $TT_METAL_SIMULATOR_HOME/
+          mv /tmp/ttsim/${{ steps.ttsim-asset.outputs.asset_name }} $TT_METAL_SIMULATOR_HOME/libttsim.so
           cp /work/tt_metal/soc_descriptors/${{ matrix.soc_desc }} $TT_METAL_SIMULATOR_HOME/soc_descriptor.yaml
 
       - name: C++ tests

--- a/.github/workflows/ttsim.yaml
+++ b/.github/workflows/ttsim.yaml
@@ -83,21 +83,20 @@ jobs:
           apt update
           apt install -y ./pkgs/tt-metalium_*.deb ./pkgs/tt-metalium-jit_*.deb ./pkgs/tt-metalium-dev_*.deb ./pkgs/tt-metalium-examples_*.deb
 
-      - name: Download ttsim binary
+      - name: Compute ttsim asset name
+        id: ttsim-asset
         run: |
-          set -euo pipefail
-          release_tag="${{ inputs.ttsim-version }}"
           asset_suffix="${{ matrix.build_suffix }}"
           asset_suffix="${asset_suffix#release_}"
-          asset_name="libttsim_${asset_suffix}.so"
-          base_url="https://github.com/tenstorrent/ttsim/releases"
-          if [[ "${release_tag}" == "latest" ]]; then
-            download_url="${base_url}/latest/download/${asset_name}"
-          else
-            download_url="${base_url}/download/${release_tag}/${asset_name}"
-          fi
-          mkdir -p /tmp/ttsim
-          curl -fL "${download_url}" -o /tmp/ttsim/libttsim.so
+          echo "asset_name=libttsim_${asset_suffix}.so" >> "$GITHUB_OUTPUT"
+
+      - name: Download ttsim binary
+        uses: robinraju/release-downloader@v1.10.1
+        with:
+          repository: tenstorrent/ttsim
+          tag: ${{ inputs.ttsim-version }}
+          fileName: ${{ steps.ttsim-asset.outputs.asset_name }}
+          out-file-path: /tmp/ttsim
 
       - name: Install ttsim
         run: |
@@ -183,21 +182,20 @@ jobs:
         with:
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
 
-      - name: Download ttsim binary
+      - name: Compute ttsim asset name
+        id: ttsim-asset
         run: |
-          set -euo pipefail
-          release_tag="${{ inputs.ttsim-version }}"
           asset_suffix="${{ matrix.build_suffix }}"
           asset_suffix="${asset_suffix#release_}"
-          asset_name="libttsim_${asset_suffix}.so"
-          base_url="https://github.com/tenstorrent/ttsim/releases"
-          if [[ "${release_tag}" == "latest" ]]; then
-            download_url="${base_url}/latest/download/${asset_name}"
-          else
-            download_url="${base_url}/download/${release_tag}/${asset_name}"
-          fi
-          mkdir -p /tmp/ttsim
-          curl -fL "${download_url}" -o /tmp/ttsim/libttsim.so
+          echo "asset_name=libttsim_${asset_suffix}.so" >> "$GITHUB_OUTPUT"
+
+      - name: Download ttsim binary
+        uses: robinraju/release-downloader@v1.10.1
+        with:
+          repository: tenstorrent/ttsim
+          tag: ${{ inputs.ttsim-version }}
+          fileName: ${{ steps.ttsim-asset.outputs.asset_name }}
+          out-file-path: /tmp/ttsim
 
       - name: Install ttsim
         run: |
@@ -334,21 +332,20 @@ jobs:
           build-artifact-name: ${{ inputs.build-artifact-name }}
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
 
-      - name: Download ttsim binary
+      - name: Compute ttsim asset name
+        id: ttsim-asset
         run: |
-          set -euo pipefail
-          release_tag="${{ inputs.ttsim-version }}"
           asset_suffix="${{ matrix.build_suffix }}"
           asset_suffix="${asset_suffix#release_}"
-          asset_name="libttsim_${asset_suffix}.so"
-          base_url="https://github.com/tenstorrent/ttsim/releases"
-          if [[ "${release_tag}" == "latest" ]]; then
-            download_url="${base_url}/latest/download/${asset_name}"
-          else
-            download_url="${base_url}/download/${release_tag}/${asset_name}"
-          fi
-          mkdir -p /tmp/ttsim
-          curl -fL "${download_url}" -o /tmp/ttsim/libttsim.so
+          echo "asset_name=libttsim_${asset_suffix}.so" >> "$GITHUB_OUTPUT"
+
+      - name: Download ttsim binary
+        uses: robinraju/release-downloader@v1.10.1
+        with:
+          repository: tenstorrent/ttsim
+          tag: ${{ inputs.ttsim-version }}
+          fileName: ${{ steps.ttsim-asset.outputs.asset_name }}
+          out-file-path: /tmp/ttsim
 
       - name: Install ttsim
         run: |
@@ -426,21 +423,20 @@ jobs:
           build-artifact-name: ${{ inputs.build-artifact-name }}
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
 
-      - name: Download ttsim binary
+      - name: Compute ttsim asset name
+        id: ttsim-asset
         run: |
-          set -euo pipefail
-          release_tag="${{ inputs.ttsim-version }}"
           asset_suffix="${{ matrix.build_suffix }}"
           asset_suffix="${asset_suffix#release_}"
-          asset_name="libttsim_${asset_suffix}.so"
-          base_url="https://github.com/tenstorrent/ttsim/releases"
-          if [[ "${release_tag}" == "latest" ]]; then
-            download_url="${base_url}/latest/download/${asset_name}"
-          else
-            download_url="${base_url}/download/${release_tag}/${asset_name}"
-          fi
-          mkdir -p /tmp/ttsim
-          curl -fL "${download_url}" -o /tmp/ttsim/libttsim.so
+          echo "asset_name=libttsim_${asset_suffix}.so" >> "$GITHUB_OUTPUT"
+
+      - name: Download ttsim binary
+        uses: robinraju/release-downloader@v1.10.1
+        with:
+          repository: tenstorrent/ttsim
+          tag: ${{ inputs.ttsim-version }}
+          fileName: ${{ steps.ttsim-asset.outputs.asset_name }}
+          out-file-path: /tmp/ttsim
 
       - name: Install ttsim
         run: |

--- a/.github/workflows/ttsim.yaml
+++ b/.github/workflows/ttsim.yaml
@@ -18,10 +18,10 @@ on:
       build-artifact-name:
         required: false
         type: string
-      ttsim-ref:
+      ttsim-version:
         required: false
         type: string
-        default: "cf36a157613fadebe1f205bd065aa384a4ab2b30"
+        default: "v1.0.0"
       job-timeout:
         required: false
         type: number
@@ -83,28 +83,27 @@ jobs:
           apt update
           apt install -y ./pkgs/tt-metalium_*.deb ./pkgs/tt-metalium-jit_*.deb ./pkgs/tt-metalium-dev_*.deb ./pkgs/tt-metalium-examples_*.deb
 
-      - name: Install System Packages
+      - name: Download ttsim binary
         run: |
-          apt update
-          apt install -y git
-
-      - name: Checkout ttsim
-        uses: actions/checkout@v4
-        with:
-          repository: tenstorrent/ttsim-private
-          ref: ${{ inputs.ttsim-ref }}
-          path: docker-job/ttsim
-          token: ${{ secrets.TTSIM_TOKEN }}
-
-      - name: Build ttsim
-        run: |
-          cd /work/ttsim
-          ./make.py src/_out/${{ matrix.build_suffix }}/libttsim.so
+          set -euo pipefail
+          release_tag="${{ inputs.ttsim-version }}"
+          asset_suffix="${{ matrix.build_suffix }}"
+          asset_suffix="${asset_suffix#release_}"
+          asset_name="libttsim_${asset_suffix}.so"
+          base_url="https://github.com/tenstorrent/ttsim/releases"
+          if [[ "${release_tag}" == "latest" ]]; then
+            download_url="${base_url}/latest/download/${asset_name}"
+          else
+            download_url="${base_url}/download/${release_tag}/${asset_name}"
+          fi
+          mkdir -p /tmp/ttsim
+          curl -fL "${download_url}" -o /tmp/ttsim/libttsim.so
 
       - name: Install ttsim
         run: |
+          set -euo pipefail
           mkdir -p $TT_METAL_SIMULATOR_HOME
-          cp /work/ttsim/src/_out/${{ matrix.build_suffix }}/libttsim.so $TT_METAL_SIMULATOR_HOME/
+          mv /tmp/ttsim/libttsim.so $TT_METAL_SIMULATOR_HOME/
           cp $TT_METAL_HOME/tt_metal/soc_descriptors/${{ matrix.soc_desc }} $TT_METAL_SIMULATOR_HOME/soc_descriptor.yaml
 
       - name: Build and Run Metal Examples
@@ -184,23 +183,27 @@ jobs:
         with:
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
 
-      - name: Checkout ttsim
-        uses: actions/checkout@v4
-        with:
-          repository: tenstorrent/ttsim-private
-          ref: ${{ inputs.ttsim-ref }}
-          path: docker-job/ttsim
-          token: ${{ secrets.TTSIM_TOKEN }}
-
-      - name: Build ttsim
+      - name: Download ttsim binary
         run: |
-          cd /work/ttsim
-          ./make.py src/_out/${{ matrix.build_suffix }}/libttsim.so
+          set -euo pipefail
+          release_tag="${{ inputs.ttsim-version }}"
+          asset_suffix="${{ matrix.build_suffix }}"
+          asset_suffix="${asset_suffix#release_}"
+          asset_name="libttsim_${asset_suffix}.so"
+          base_url="https://github.com/tenstorrent/ttsim/releases"
+          if [[ "${release_tag}" == "latest" ]]; then
+            download_url="${base_url}/latest/download/${asset_name}"
+          else
+            download_url="${base_url}/download/${release_tag}/${asset_name}"
+          fi
+          mkdir -p /tmp/ttsim
+          curl -fL "${download_url}" -o /tmp/ttsim/libttsim.so
 
       - name: Install ttsim
         run: |
+          set -euo pipefail
           mkdir -p $TT_METAL_SIMULATOR_HOME
-          cp /work/ttsim/src/_out/${{ matrix.build_suffix }}/libttsim.so $TT_METAL_SIMULATOR_HOME/
+          mv /tmp/ttsim/libttsim.so $TT_METAL_SIMULATOR_HOME/
           cp /work/tt_metal/soc_descriptors/${{ matrix.soc_desc }} $TT_METAL_SIMULATOR_HOME/soc_descriptor.yaml
 
       - name: Run TTNN Pytests
@@ -331,23 +334,27 @@ jobs:
           build-artifact-name: ${{ inputs.build-artifact-name }}
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
 
-      - name: Checkout ttsim
-        uses: actions/checkout@v4
-        with:
-          repository: tenstorrent/ttsim-private
-          ref: ${{ inputs.ttsim-ref }}
-          path: docker-job/ttsim
-          token: ${{ secrets.TTSIM_TOKEN }}
-
-      - name: Build ttsim
+      - name: Download ttsim binary
         run: |
-          cd /work/ttsim
-          ./make.py src/_out/${{ matrix.build_suffix }}/libttsim.so
+          set -euo pipefail
+          release_tag="${{ inputs.ttsim-version }}"
+          asset_suffix="${{ matrix.build_suffix }}"
+          asset_suffix="${asset_suffix#release_}"
+          asset_name="libttsim_${asset_suffix}.so"
+          base_url="https://github.com/tenstorrent/ttsim/releases"
+          if [[ "${release_tag}" == "latest" ]]; then
+            download_url="${base_url}/latest/download/${asset_name}"
+          else
+            download_url="${base_url}/download/${release_tag}/${asset_name}"
+          fi
+          mkdir -p /tmp/ttsim
+          curl -fL "${download_url}" -o /tmp/ttsim/libttsim.so
 
       - name: Install ttsim
         run: |
+          set -euo pipefail
           mkdir -p $TT_METAL_SIMULATOR_HOME
-          cp /work/ttsim/src/_out/${{ matrix.build_suffix }}/libttsim.so $TT_METAL_SIMULATOR_HOME/
+          mv /tmp/ttsim/libttsim.so $TT_METAL_SIMULATOR_HOME/
           cp /work/tt_metal/soc_descriptors/${{ matrix.soc_desc }} $TT_METAL_SIMULATOR_HOME/soc_descriptor.yaml
 
       - name: C++ tests
@@ -355,7 +362,7 @@ jobs:
         run: |
           if [[ "${{ matrix.arch }}" == "quasar" ]]; then
             # ToDo: Re-enable this test once tt-sim supports NOC
-            # GH issue for tt-sim NOC support: https://github.com/tenstorrent/ttsim-private/issues/24
+            # GH issue for tt-sim NOC support: https://github.com/tenstorrent/ttsim/issues/24
             # ./build/test/tt_metal/test_single_dm_l1_write
             :
           else
@@ -419,23 +426,27 @@ jobs:
           build-artifact-name: ${{ inputs.build-artifact-name }}
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
 
-      - name: Checkout ttsim
-        uses: actions/checkout@v4
-        with:
-          repository: tenstorrent/ttsim-private
-          ref: ${{ inputs.ttsim-ref }}
-          path: docker-job/ttsim
-          token: ${{ secrets.TTSIM_TOKEN }}
-
-      - name: Build ttsim
+      - name: Download ttsim binary
         run: |
-          cd /work/ttsim
-          ./make.py src/_out/${{ matrix.build_suffix }}/libttsim.so
+          set -euo pipefail
+          release_tag="${{ inputs.ttsim-version }}"
+          asset_suffix="${{ matrix.build_suffix }}"
+          asset_suffix="${asset_suffix#release_}"
+          asset_name="libttsim_${asset_suffix}.so"
+          base_url="https://github.com/tenstorrent/ttsim/releases"
+          if [[ "${release_tag}" == "latest" ]]; then
+            download_url="${base_url}/latest/download/${asset_name}"
+          else
+            download_url="${base_url}/download/${release_tag}/${asset_name}"
+          fi
+          mkdir -p /tmp/ttsim
+          curl -fL "${download_url}" -o /tmp/ttsim/libttsim.so
 
       - name: Install ttsim
         run: |
+          set -euo pipefail
           mkdir -p $TT_METAL_SIMULATOR_HOME
-          cp /work/ttsim/src/_out/${{ matrix.build_suffix }}/libttsim.so $TT_METAL_SIMULATOR_HOME/
+          mv /tmp/ttsim/libttsim.so $TT_METAL_SIMULATOR_HOME/
           cp /work/tt_metal/soc_descriptors/${{ matrix.soc_desc }} $TT_METAL_SIMULATOR_HOME/soc_descriptor.yaml
 
       - name: C++ tests


### PR DESCRIPTION
### Ticket
N/A

### Problem description
The old way required a PAT which doesn't work for PRs from forks.

### What's changed
Use the pre-built binaries that are available sans PAT.