### PR TITLE
Fix sdpa reduce copy init parameter issue on BH

### DIFF
--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
@@ -23,8 +23,14 @@
 ALWI void sdpa_reduce_copy_tile_to_dst_init_short(uint32_t cbid, uint32_t transpose = 0) {
     UNPACK((llk_unpack_A_init<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, UnpackToDestEn>(
         transpose, true /*transpose within 16x16 face*/, cbid)));
-    MATH((llk_math_eltwise_unary_datacopy_init<A2D, DST_ACCUM_MODE, BroadcastType::NONE>(
-        false /*transpose of faces*/, false /*transpose within 16x16 face*/, cbid)));
+
+    MATH((llk_math_eltwise_unary_datacopy_init<
+          A2D,
+          DST_ACCUM_MODE,
+          BroadcastType::NONE,
+          false,  // is_int_fpu_en
+          false   // tilize
+          >(cbid)));
 }
 
 template <uint32_t num_tiles>


### PR DESCRIPTION
### Ticket
NA

### Problem description
BH multi card demo CI was failing because of a incorrect parameter issue: https://github.com/tenstorrent/tt-metal/actions/runs/20117634283/job/57731379647 caused by a recent SDPA optimization change with this [PR](https://github.com/tenstorrent/tt-metal/pull/34092)

### What's changed
- fixed the template parameters of the llk_math_eltwise_unary_datacopy_init
### Checklist
- [ ] [BH multi card demo](https://github.com/tenstorrent/tt-metal/actions/runs/20120093172) failures are irrelevant to SDPA and are pre-existing due to other issues
- [ ] [vLLM nightly](https://github.com/tenstorrent/tt-metal/actions/runs/20121130980)