### PR TITLE
Make prefill trace optional for GPT-OSS

### DIFF
--- a/models/demos/gpt_oss/demo/text_demo.py
+++ b/models/demos/gpt_oss/demo/text_demo.py
@@ -124,7 +124,9 @@ def prepare_gpt_oss_generator_args(
             4 * 1024,  # max_seq_len
             200,  # max_generated_tokens
             {"page_block_size": 64, "page_max_num_blocks_per_dp": 4 * 1024 // 64},  # page_params
-            {"temperature": 0, "top_p": 0.08},  # sampling_params (greedy decoding)
+            {"temperature": 0, "top_p": 0.08},  # sampling_params (greedy decoding),
+            True,  # enable_decode_trace
+            True,  # enable_prefill_trace
         ),
         (
             "models/tt_transformers/demo/sample_prompts/input_data_long_1k.json",  # input_prompts
@@ -135,6 +137,8 @@ def prepare_gpt_oss_generator_args(
             200,  # max_generated_tokens
             {"page_block_size": 64, "page_max_num_blocks_per_dp": 4 * 1024 // 64},  # page_params
             {"temperature": 0, "top_p": 0.08},  # sampling_params (greedy decoding)
+            True,  # enable_decode_trace
+            True,  # enable_prefill_trace
         ),
         (
             "models/tt_transformers/demo/sample_prompts/input_data_long_4k.json",  # input_prompts
@@ -145,6 +149,8 @@ def prepare_gpt_oss_generator_args(
             200,  # max_generated_tokens
             {"page_block_size": 64, "page_max_num_blocks_per_dp": 4 * 1024 // 64},  # page_params
             {"temperature": 0, "top_p": 0.08},  # sampling_params (greedy decoding)
+            True,  # enable_decode_trace
+            True,  # enable_prefill_trace
         ),
         # (
         #     "models/tt_transformers/demo/sample_prompts/input_data_long_8k.json",  # input_prompts
@@ -221,6 +227,8 @@ def test_gpt_oss_demo(
     max_generated_tokens,
     page_params,
     sampling_params,
+    enable_decode_trace,
+    enable_prefill_trace,
     is_ci_env,
     state_dict,
 ):
@@ -242,9 +250,6 @@ def test_gpt_oss_demo(
     # Validate data parallel configuration (like tt-transformers)
     if data_parallel > num_devices or num_devices % data_parallel != 0:
         raise ValueError(f"Invalid number of DP groups: {data_parallel}, for {num_devices} devices")
-
-    enable_decode_trace = True
-    enable_prefill_trace = True
 
     logger.info(f"Running GPT-OSS demo with tt_transformers generation pipeline")
 

--- a/models/demos/gpt_oss/demo/text_demo.py
+++ b/models/demos/gpt_oss/demo/text_demo.py
@@ -114,7 +114,7 @@ def prepare_gpt_oss_generator_args(
 )
 @run_for_wormhole_b0()
 @pytest.mark.parametrize(
-    "input_prompts, data_parallel, batch_size, repeat_batches, max_seq_len, max_generated_tokens, page_params, sampling_params",
+    "input_prompts, data_parallel, batch_size, repeat_batches, max_seq_len, max_generated_tokens, page_params, sampling_params, enable_decode_trace, enable_prefill_trace",
     [
         (
             "models/demos/gpt_oss/demo/sample_prompts/input_data_questions_prefill_128.json",  # input_prompts

--- a/models/demos/gpt_oss/demo/text_demo.py
+++ b/models/demos/gpt_oss/demo/text_demo.py
@@ -243,7 +243,8 @@ def test_gpt_oss_demo(
     if data_parallel > num_devices or num_devices % data_parallel != 0:
         raise ValueError(f"Invalid number of DP groups: {data_parallel}, for {num_devices} devices")
 
-    enable_trace = True
+    enable_decode_trace = True
+    enable_prefill_trace = False
 
     logger.info(f"Running GPT-OSS demo with tt_transformers generation pipeline")
 
@@ -351,6 +352,7 @@ def test_gpt_oss_demo(
             page_table=page_table,
             kv_cache=tt_kv_cache,
             prompt_lens=decoding_pos,
+            enable_trace=enable_prefill_trace,
         )
         profiler.end(f"compile_prefill", iteration=batch_idx)
         logger.info("Finished prefill warmup")
@@ -362,6 +364,7 @@ def test_gpt_oss_demo(
             page_table=page_table,
             kv_cache=tt_kv_cache,
             prompt_lens=decoding_pos,
+            enable_trace=enable_prefill_trace,
         )
         prefilled_token = torch.argmax(logits, dim=-1)
         profiler.end(f"inference_prefill", iteration=batch_idx)
@@ -394,7 +397,7 @@ def test_gpt_oss_demo(
             logits = generator.decode_forward_text(
                 out_tok,
                 current_pos,
-                enable_trace=enable_trace,
+                enable_trace=enable_decode_trace,
                 page_table=page_table,
                 kv_cache=tt_kv_cache,
             )

--- a/models/demos/gpt_oss/demo/text_demo.py
+++ b/models/demos/gpt_oss/demo/text_demo.py
@@ -244,7 +244,7 @@ def test_gpt_oss_demo(
         raise ValueError(f"Invalid number of DP groups: {data_parallel}, for {num_devices} devices")
 
     enable_decode_trace = True
-    enable_prefill_trace = False
+    enable_prefill_trace = True
 
     logger.info(f"Running GPT-OSS demo with tt_transformers generation pipeline")
 


### PR DESCRIPTION
Minor change to enable toggling of prefill traces from gpt-oss `text_demo.py`