### PR TITLE
[skip ci] ci: provide more information when doing the llk uplift (added issue information)

### DIFF
--- a/.github/workflows/llk-auto-uplift-trigger.yaml
+++ b/.github/workflows/llk-auto-uplift-trigger.yaml
@@ -144,28 +144,12 @@ jobs:
           COMMITS_TABLE+="|-------|-----|--------|---------|--------|"$'\n'
 
           if [ "$COMMIT_COUNT" -gt 0 ]; then
-            # Fetch all commit data in one git log call
-            # Format: short_hash|subject|author|full_hash<<<BODY>>>body<<<END>>>
-            COMMIT_DATA=$(git log --pretty=format:"%h|%s|%an|%H<<<BODY>>>%b<<<END>>>" ${OLD_SHA}..${NEW_SHA})
-
-            # Process each commit
-            while IFS= read -r -d '>' commit_record; do
-              # Skip empty records
-              [[ "$commit_record" != *"<<<END"* ]] && continue
-              commit_record="${commit_record%<<<END}"
-
-              # Split header and body
-              header="${commit_record%%<<<BODY>>>*}"
-              COMMIT_BODY="${commit_record#*<<<BODY>>>}"
-
-              # Parse header fields
-              IFS='|' read -r short_hash message author full_hash <<< "$header"
+            while IFS='|' read -r short_hash message author full_hash || [ -n "$short_hash" ]; do
               [ -z "$short_hash" ] && continue
 
               pr_number=$(echo "$message" | grep -oE '\(#[0-9]+\)$' | grep -oE '[0-9]+')
               # Remove trailing PR reference and convert #numbers to tt-llk links
-              # Using /issues/ URL which auto-redirects to /pull/ if it's a PR
-              clean_message=$(echo "$message" | sed 's/ *(#[0-9]\+) *$//' | sed 's/#\([0-9]\+\)/[#\1](https:\/\/github.com\/tenstorrent\/tt-llk\/issues\/\1)/g')
+              clean_message=$(echo "$message" | sed 's/ *(#[0-9]\+) *$//' | sed 's/#\([0-9]\+\)/[#\1](https:\/\/github.com\/tenstorrent\/tt-llk\/pull\/\1)/g')
 
               # Format PR column
               if [ -n "$pr_number" ]; then
@@ -174,7 +158,8 @@ jobs:
                 PR_CELL="-"
               fi
 
-              # Parse Ticket section from commit body
+              # Parse Ticket section from full commit body
+              COMMIT_BODY=$(git log -1 --format="%b" "$full_hash")
               TICKET_SECTION=$(echo "$COMMIT_BODY" | sed -n '/### Ticket/,/### /p' | head -n -1 | tail -n +2)
 
               # Extract issue references for this commit
@@ -187,23 +172,27 @@ jobs:
                   METAL_ISSUES=$(echo "$TICKET_SECTION" | grep -oE 'https?://github\.com/tenstorrent/tt-metal/issues/[0-9]+' | grep -oE '[0-9]+$' | sort -u)
                   for issue_num in $METAL_ISSUES; do
                     [ -n "$ISSUE_LINKS" ] && ISSUE_LINKS+=", "
-                    ISSUE_LINKS+="[metal#${issue_num}](https://github.com/tenstorrent/tt-metal/issues/${issue_num})"
+                    ISSUE_LINKS+="[metal#$issue_num](https://github.com/tenstorrent/tt-metal/issues/$issue_num)"
                   done
 
-                  # Extract tt-llk issues from both URL and bare #number formats, deduplicate
-                  LLK_URL_ISSUES=$(echo "$TICKET_SECTION" | grep -oE 'https?://github\.com/tenstorrent/tt-llk/issues/[0-9]+' | grep -oE '[0-9]+$')
-                  BARE_ISSUES=$(echo "$TICKET_SECTION" | sed 's|https\?://\S*||g' | grep -oE '(^|[[:space:]])#[0-9]+' | grep -oE '[0-9]+')
-                  # Combine and deduplicate
-                  LLK_ALL_ISSUES=$(echo -e "$LLK_URL_ISSUES\n$BARE_ISSUES" | awk 'NF' | sort -u)
-                  for issue_num in $LLK_ALL_ISSUES; do
+                  # Extract tt-llk issues - matches both plain URLs and markdown links
+                  LLK_URL_ISSUES=$(echo "$TICKET_SECTION" | grep -oE 'https?://github\.com/tenstorrent/tt-llk/issues/[0-9]+' | grep -oE '[0-9]+$' | sort -u)
+                  for issue_num in $LLK_URL_ISSUES; do
                     [ -n "$ISSUE_LINKS" ] && ISSUE_LINKS+=", "
-                    ISSUE_LINKS+="[llk#${issue_num}](https://github.com/tenstorrent/tt-llk/issues/${issue_num})"
+                    ISSUE_LINKS+="[llk#$issue_num](https://github.com/tenstorrent/tt-llk/issues/$issue_num)"
+                  done
+
+                  # Bare #number format → always tt-llk (commits are from that repo)
+                  BARE_ISSUES=$(echo "$TICKET_SECTION" | sed 's|https\?://[^ ]*||g' | grep -oE '(^|[[:space:]])#[0-9]+' | grep -oE '[0-9]+' | sort -u)
+                  for issue_num in $BARE_ISSUES; do
+                    [ -n "$ISSUE_LINKS" ] && ISSUE_LINKS+=", "
+                    ISSUE_LINKS+="[llk#$issue_num](https://github.com/tenstorrent/tt-llk/issues/$issue_num)"
                   done
                 fi
               fi
 
               COMMITS_TABLE+="| $ISSUE_LINKS | $PR_CELL | [$short_hash](https://github.com/tenstorrent/tt-llk/commit/$full_hash) | $clean_message | $author |"$'\n'
-            done <<< "$COMMIT_DATA"
+            done < <(git log --pretty=format:"%h|%s|%an|%H" ${OLD_SHA}..${NEW_SHA})
           else
             COMMITS_TABLE+="| | | | (No commits found) | |"$'\n'
           fi

--- a/.github/workflows/llk-auto-uplift-trigger.yaml
+++ b/.github/workflows/llk-auto-uplift-trigger.yaml
@@ -148,7 +148,8 @@ jobs:
               [ -z "$short_hash" ] && continue
 
               pr_number=$(echo "$message" | grep -oE '\(#[0-9]+\)$' | grep -oE '[0-9]+')
-              clean_message=$(echo "$message" | sed 's/ *(#[0-9]\+) *$//')
+              # Remove trailing PR reference and convert #numbers to tt-llk links
+              clean_message=$(echo "$message" | sed 's/ *(#[0-9]\+) *$//' | sed 's/#\([0-9]\+\)/[#\1](https:\/\/github.com\/tenstorrent\/tt-llk\/pull\/\1)/g')
 
               # Format PR column
               if [ -n "$pr_number" ]; then

--- a/.github/workflows/llk-auto-uplift-trigger.yaml
+++ b/.github/workflows/llk-auto-uplift-trigger.yaml
@@ -147,7 +147,7 @@ jobs:
             while IFS='|' read -r short_hash message author full_hash || [ -n "$short_hash" ]; do
               [ -z "$short_hash" ] && continue
 
-              pr_number=$(echo "$message" | grep -oE '\(#[0-9]+\)' | grep -oE '[0-9]+' | head -1)
+              pr_number=$(echo "$message" | grep -oE '\(#[0-9]+\)$' | grep -oE '[0-9]+')
               clean_message=$(echo "$message" | sed 's/ *(#[0-9]\+) *$//')
 
               # Format PR column

--- a/.github/workflows/llk-auto-uplift-trigger.yaml
+++ b/.github/workflows/llk-auto-uplift-trigger.yaml
@@ -144,12 +144,28 @@ jobs:
           COMMITS_TABLE+="|-------|-----|--------|---------|--------|"$'\n'
 
           if [ "$COMMIT_COUNT" -gt 0 ]; then
-            while IFS='|' read -r short_hash message author full_hash || [ -n "$short_hash" ]; do
+            # Fetch all commit data in one git log call
+            # Format: short_hash|subject|author|full_hash<<<BODY>>>body<<<END>>>
+            COMMIT_DATA=$(git log --pretty=format:"%h|%s|%an|%H<<<BODY>>>%b<<<END>>>" ${OLD_SHA}..${NEW_SHA})
+
+            # Process each commit
+            while IFS= read -r -d '>' commit_record; do
+              # Skip empty records
+              [[ "$commit_record" != *"<<<END"* ]] && continue
+              commit_record="${commit_record%<<<END}"
+
+              # Split header and body
+              header="${commit_record%%<<<BODY>>>*}"
+              COMMIT_BODY="${commit_record#*<<<BODY>>>}"
+
+              # Parse header fields
+              IFS='|' read -r short_hash message author full_hash <<< "$header"
               [ -z "$short_hash" ] && continue
 
               pr_number=$(echo "$message" | grep -oE '\(#[0-9]+\)$' | grep -oE '[0-9]+')
               # Remove trailing PR reference and convert #numbers to tt-llk links
-              clean_message=$(echo "$message" | sed 's/ *(#[0-9]\+) *$//' | sed 's/#\([0-9]\+\)/[#\1](https:\/\/github.com\/tenstorrent\/tt-llk\/pull\/\1)/g')
+              # Using /issues/ URL which auto-redirects to /pull/ if it's a PR
+              clean_message=$(echo "$message" | sed 's/ *(#[0-9]\+) *$//' | sed 's/#\([0-9]\+\)/[#\1](https:\/\/github.com\/tenstorrent\/tt-llk\/issues\/\1)/g')
 
               # Format PR column
               if [ -n "$pr_number" ]; then
@@ -158,8 +174,7 @@ jobs:
                 PR_CELL="-"
               fi
 
-              # Parse Ticket section from full commit body
-              COMMIT_BODY=$(git log -1 --format="%b" "$full_hash")
+              # Parse Ticket section from commit body
               TICKET_SECTION=$(echo "$COMMIT_BODY" | sed -n '/### Ticket/,/### /p' | head -n -1 | tail -n +2)
 
               # Extract issue references for this commit
@@ -172,27 +187,23 @@ jobs:
                   METAL_ISSUES=$(echo "$TICKET_SECTION" | grep -oE 'https?://github\.com/tenstorrent/tt-metal/issues/[0-9]+' | grep -oE '[0-9]+$' | sort -u)
                   for issue_num in $METAL_ISSUES; do
                     [ -n "$ISSUE_LINKS" ] && ISSUE_LINKS+=", "
-                    ISSUE_LINKS+="[metal#$issue_num](https://github.com/tenstorrent/tt-metal/issues/$issue_num)"
+                    ISSUE_LINKS+="[metal#${issue_num}](https://github.com/tenstorrent/tt-metal/issues/${issue_num})"
                   done
 
-                  # Extract tt-llk issues - matches both plain URLs and markdown links
-                  LLK_URL_ISSUES=$(echo "$TICKET_SECTION" | grep -oE 'https?://github\.com/tenstorrent/tt-llk/issues/[0-9]+' | grep -oE '[0-9]+$' | sort -u)
-                  for issue_num in $LLK_URL_ISSUES; do
+                  # Extract tt-llk issues from both URL and bare #number formats, deduplicate
+                  LLK_URL_ISSUES=$(echo "$TICKET_SECTION" | grep -oE 'https?://github\.com/tenstorrent/tt-llk/issues/[0-9]+' | grep -oE '[0-9]+$')
+                  BARE_ISSUES=$(echo "$TICKET_SECTION" | sed 's|https\?://\S*||g' | grep -oE '(^|[[:space:]])#[0-9]+' | grep -oE '[0-9]+')
+                  # Combine and deduplicate
+                  LLK_ALL_ISSUES=$(echo -e "$LLK_URL_ISSUES\n$BARE_ISSUES" | awk 'NF' | sort -u)
+                  for issue_num in $LLK_ALL_ISSUES; do
                     [ -n "$ISSUE_LINKS" ] && ISSUE_LINKS+=", "
-                    ISSUE_LINKS+="[llk#$issue_num](https://github.com/tenstorrent/tt-llk/issues/$issue_num)"
-                  done
-
-                  # Bare #number format → always tt-llk (commits are from that repo)
-                  BARE_ISSUES=$(echo "$TICKET_SECTION" | sed 's|https\?://[^ ]*||g' | grep -oE '(^|[[:space:]])#[0-9]+' | grep -oE '[0-9]+' | sort -u)
-                  for issue_num in $BARE_ISSUES; do
-                    [ -n "$ISSUE_LINKS" ] && ISSUE_LINKS+=", "
-                    ISSUE_LINKS+="[llk#$issue_num](https://github.com/tenstorrent/tt-llk/issues/$issue_num)"
+                    ISSUE_LINKS+="[llk#${issue_num}](https://github.com/tenstorrent/tt-llk/issues/${issue_num})"
                   done
                 fi
               fi
 
               COMMITS_TABLE+="| $ISSUE_LINKS | $PR_CELL | [$short_hash](https://github.com/tenstorrent/tt-llk/commit/$full_hash) | $clean_message | $author |"$'\n'
-            done < <(git log --pretty=format:"%h|%s|%an|%H" ${OLD_SHA}..${NEW_SHA})
+            done <<< "$COMMIT_DATA"
           else
             COMMITS_TABLE+="| | | | (No commits found) | |"$'\n'
           fi

--- a/.github/workflows/llk-auto-uplift-trigger.yaml
+++ b/.github/workflows/llk-auto-uplift-trigger.yaml
@@ -138,9 +138,10 @@ jobs:
           echo "$CHANGED_FILES" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
-          # Generate rich commits table with PR links
-          COMMITS_TABLE="| Commit | Message | Author | PR |"$'\n'
-          COMMITS_TABLE+="|--------|---------|---------|-----|"$'\n'
+          # Generate rich commits table with PR links and Issues
+          # Column order: Issue | PR | Commit | Message | Author
+          COMMITS_TABLE="| Issue | PR | Commit | Message | Author |"$'\n'
+          COMMITS_TABLE+="|-------|-----|--------|---------|--------|"$'\n'
 
           if [ "$COMMIT_COUNT" -gt 0 ]; then
             while IFS='|' read -r short_hash message author full_hash || [ -n "$short_hash" ]; do
@@ -149,14 +150,50 @@ jobs:
               pr_number=$(echo "$message" | grep -oE '\(#[0-9]+\)' | grep -oE '[0-9]+' | head -1)
               clean_message=$(echo "$message" | sed 's/ *(#[0-9]\+) *$//')
 
+              # Format PR column
               if [ -n "$pr_number" ]; then
-                COMMITS_TABLE+="| [$short_hash](https://github.com/tenstorrent/tt-llk/commit/$full_hash) | $clean_message | $author | [#$pr_number](https://github.com/tenstorrent/tt-llk/pull/$pr_number) |"$'\n'
+                PR_CELL="[#$pr_number](https://github.com/tenstorrent/tt-llk/pull/$pr_number)"
               else
-                COMMITS_TABLE+="| [$short_hash](https://github.com/tenstorrent/tt-llk/commit/$full_hash) | $clean_message | $author | - |"$'\n'
+                PR_CELL="-"
               fi
+
+              # Parse Ticket section from full commit body
+              COMMIT_BODY=$(git log -1 --format="%b" "$full_hash")
+              TICKET_SECTION=$(echo "$COMMIT_BODY" | sed -n '/### Ticket/,/### /p' | head -n -1 | tail -n +2)
+
+              # Extract issue references for this commit
+              ISSUE_LINKS=""
+              if [ -n "$TICKET_SECTION" ]; then
+                # Check if ticket section is just "None" (case-insensitive, with optional whitespace)
+                TICKET_TRIMMED=$(echo "$TICKET_SECTION" | tr -d '[:space:]' | tr '[:upper:]' '[:lower:]')
+                if [ "$TICKET_TRIMMED" != "none" ] && [ -n "$TICKET_TRIMMED" ]; then
+                  # Extract tt-metal issues - matches both plain URLs and markdown links
+                  METAL_ISSUES=$(echo "$TICKET_SECTION" | grep -oE 'https?://github\.com/tenstorrent/tt-metal/issues/[0-9]+' | grep -oE '[0-9]+$' | sort -u)
+                  for issue_num in $METAL_ISSUES; do
+                    [ -n "$ISSUE_LINKS" ] && ISSUE_LINKS+=", "
+                    ISSUE_LINKS+="[metal#$issue_num](https://github.com/tenstorrent/tt-metal/issues/$issue_num)"
+                  done
+
+                  # Extract tt-llk issues - matches both plain URLs and markdown links
+                  LLK_URL_ISSUES=$(echo "$TICKET_SECTION" | grep -oE 'https?://github\.com/tenstorrent/tt-llk/issues/[0-9]+' | grep -oE '[0-9]+$' | sort -u)
+                  for issue_num in $LLK_URL_ISSUES; do
+                    [ -n "$ISSUE_LINKS" ] && ISSUE_LINKS+=", "
+                    ISSUE_LINKS+="[llk#$issue_num](https://github.com/tenstorrent/tt-llk/issues/$issue_num)"
+                  done
+
+                  # Bare #number format → always tt-llk (commits are from that repo)
+                  BARE_ISSUES=$(echo "$TICKET_SECTION" | sed 's|https\?://[^ ]*||g' | grep -oE '(^|[[:space:]])#[0-9]+' | grep -oE '[0-9]+' | sort -u)
+                  for issue_num in $BARE_ISSUES; do
+                    [ -n "$ISSUE_LINKS" ] && ISSUE_LINKS+=", "
+                    ISSUE_LINKS+="[llk#$issue_num](https://github.com/tenstorrent/tt-llk/issues/$issue_num)"
+                  done
+                fi
+              fi
+
+              COMMITS_TABLE+="| $ISSUE_LINKS | $PR_CELL | [$short_hash](https://github.com/tenstorrent/tt-llk/commit/$full_hash) | $clean_message | $author |"$'\n'
             done < <(git log --pretty=format:"%h|%s|%an|%H" ${OLD_SHA}..${NEW_SHA})
           else
-            COMMITS_TABLE+="| (No commits found) | - | - | - |"$'\n'
+            COMMITS_TABLE+="| | | | (No commits found) | |"$'\n'
           fi
 
           # Determine labels for counts


### PR DESCRIPTION
### Ticket
None

### Problem description
At present, table that gets generated from LLK commits does not contain information on the issue number. Since GH links these with PRs, it'd be a nice thing to have, as that way we could track on the issue itself if it got all the way to metal or it's still stuck somewhere in between.

### What's changed
With this change, we now add information about the issue directly in the changelog table. That way GH does the tracking automatically and links the change with metal uplift PR.