### PR TITLE
fix: include `risc_attribs.h` in `watcher_common.h` to fix `tt_l1_ptr` undefined error

### DIFF
--- a/.github/workflows/llk-auto-uplift-trigger.yaml
+++ b/.github/workflows/llk-auto-uplift-trigger.yaml
@@ -138,25 +138,63 @@ jobs:
           echo "$CHANGED_FILES" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
-          # Generate rich commits table with PR links
-          COMMITS_TABLE="| Commit | Message | Author | PR |"$'\n'
-          COMMITS_TABLE+="|--------|---------|---------|-----|"$'\n'
+          # Generate rich commits table with PR links and Issues
+          # Column order: Issue | PR | Commit | Message | Author
+          COMMITS_TABLE="| Issue | PR | Commit | Message | Author |"$'\n'
+          COMMITS_TABLE+="|-------|-----|--------|---------|--------|"$'\n'
 
           if [ "$COMMIT_COUNT" -gt 0 ]; then
             while IFS='|' read -r short_hash message author full_hash || [ -n "$short_hash" ]; do
               [ -z "$short_hash" ] && continue
 
-              pr_number=$(echo "$message" | grep -oE '\(#[0-9]+\)' | grep -oE '[0-9]+' | head -1)
-              clean_message=$(echo "$message" | sed 's/ *(#[0-9]\+) *$//')
+              pr_number=$(echo "$message" | grep -oE '\(#[0-9]+\)$' | grep -oE '[0-9]+')
+              # Remove trailing PR reference and convert #numbers to tt-llk links
+              clean_message=$(echo "$message" | sed 's/ *(#[0-9]\+) *$//' | sed 's/#\([0-9]\+\)/[#\1](https:\/\/github.com\/tenstorrent\/tt-llk\/pull\/\1)/g')
 
+              # Format PR column
               if [ -n "$pr_number" ]; then
-                COMMITS_TABLE+="| [$short_hash](https://github.com/tenstorrent/tt-llk/commit/$full_hash) | $clean_message | $author | [#$pr_number](https://github.com/tenstorrent/tt-llk/pull/$pr_number) |"$'\n'
+                PR_CELL="[#$pr_number](https://github.com/tenstorrent/tt-llk/pull/$pr_number)"
               else
-                COMMITS_TABLE+="| [$short_hash](https://github.com/tenstorrent/tt-llk/commit/$full_hash) | $clean_message | $author | - |"$'\n'
+                PR_CELL="-"
               fi
+
+              # Parse Ticket section from full commit body
+              COMMIT_BODY=$(git log -1 --format="%b" "$full_hash")
+              TICKET_SECTION=$(echo "$COMMIT_BODY" | sed -n '/### Ticket/,/### /p' | head -n -1 | tail -n +2)
+
+              # Extract issue references for this commit
+              ISSUE_LINKS=""
+              if [ -n "$TICKET_SECTION" ]; then
+                # Check if ticket section is just "None" (case-insensitive, with optional whitespace)
+                TICKET_TRIMMED=$(echo "$TICKET_SECTION" | tr -d '[:space:]' | tr '[:upper:]' '[:lower:]')
+                if [ "$TICKET_TRIMMED" != "none" ] && [ -n "$TICKET_TRIMMED" ]; then
+                  # Extract tt-metal issues - matches both plain URLs and markdown links
+                  METAL_ISSUES=$(echo "$TICKET_SECTION" | grep -oE 'https?://github\.com/tenstorrent/tt-metal/issues/[0-9]+' | grep -oE '[0-9]+$' | sort -u)
+                  for issue_num in $METAL_ISSUES; do
+                    [ -n "$ISSUE_LINKS" ] && ISSUE_LINKS+=", "
+                    ISSUE_LINKS+="[metal#$issue_num](https://github.com/tenstorrent/tt-metal/issues/$issue_num)"
+                  done
+
+                  # Extract tt-llk issues - matches both plain URLs and markdown links
+                  LLK_URL_ISSUES=$(echo "$TICKET_SECTION" | grep -oE 'https?://github\.com/tenstorrent/tt-llk/issues/[0-9]+' | grep -oE '[0-9]+$' | sort -u)
+                  for issue_num in $LLK_URL_ISSUES; do
+                    [ -n "$ISSUE_LINKS" ] && ISSUE_LINKS+=", "
+                    ISSUE_LINKS+="[llk#$issue_num](https://github.com/tenstorrent/tt-llk/issues/$issue_num)"
+                  done
+
+                  # Bare #number format → always tt-llk (commits are from that repo)
+                  BARE_ISSUES=$(echo "$TICKET_SECTION" | sed 's|https\?://[^ ]*||g' | grep -oE '(^|[[:space:]])#[0-9]+' | grep -oE '[0-9]+' | sort -u)
+                  for issue_num in $BARE_ISSUES; do
+                    [ -n "$ISSUE_LINKS" ] && ISSUE_LINKS+=", "
+                    ISSUE_LINKS+="[llk#$issue_num](https://github.com/tenstorrent/tt-llk/issues/$issue_num)"
+                  done
+                fi
+              fi
+
+              COMMITS_TABLE+="| $ISSUE_LINKS | $PR_CELL | [$short_hash](https://github.com/tenstorrent/tt-llk/commit/$full_hash) | $clean_message | $author |"$'\n'
             done < <(git log --pretty=format:"%h|%s|%an|%H" ${OLD_SHA}..${NEW_SHA})
           else
-            COMMITS_TABLE+="| (No commits found) | - | - | - |"$'\n'
+            COMMITS_TABLE+="| | | | (No commits found) | |"$'\n'
           fi
 
           # Determine labels for counts

--- a/.github/workflows/llk-auto-uplift-trigger.yaml
+++ b/.github/workflows/llk-auto-uplift-trigger.yaml
@@ -138,63 +138,25 @@ jobs:
           echo "$CHANGED_FILES" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
-          # Generate rich commits table with PR links and Issues
-          # Column order: Issue | PR | Commit | Message | Author
-          COMMITS_TABLE="| Issue | PR | Commit | Message | Author |"$'\n'
-          COMMITS_TABLE+="|-------|-----|--------|---------|--------|"$'\n'
+          # Generate rich commits table with PR links
+          COMMITS_TABLE="| Commit | Message | Author | PR |"$'\n'
+          COMMITS_TABLE+="|--------|---------|---------|-----|"$'\n'
 
           if [ "$COMMIT_COUNT" -gt 0 ]; then
             while IFS='|' read -r short_hash message author full_hash || [ -n "$short_hash" ]; do
               [ -z "$short_hash" ] && continue
 
-              pr_number=$(echo "$message" | grep -oE '\(#[0-9]+\)$' | grep -oE '[0-9]+')
-              # Remove trailing PR reference and convert #numbers to tt-llk links
-              clean_message=$(echo "$message" | sed 's/ *(#[0-9]\+) *$//' | sed 's/#\([0-9]\+\)/[#\1](https:\/\/github.com\/tenstorrent\/tt-llk\/pull\/\1)/g')
+              pr_number=$(echo "$message" | grep -oE '\(#[0-9]+\)' | grep -oE '[0-9]+' | head -1)
+              clean_message=$(echo "$message" | sed 's/ *(#[0-9]\+) *$//')
 
-              # Format PR column
               if [ -n "$pr_number" ]; then
-                PR_CELL="[#$pr_number](https://github.com/tenstorrent/tt-llk/pull/$pr_number)"
+                COMMITS_TABLE+="| [$short_hash](https://github.com/tenstorrent/tt-llk/commit/$full_hash) | $clean_message | $author | [#$pr_number](https://github.com/tenstorrent/tt-llk/pull/$pr_number) |"$'\n'
               else
-                PR_CELL="-"
+                COMMITS_TABLE+="| [$short_hash](https://github.com/tenstorrent/tt-llk/commit/$full_hash) | $clean_message | $author | - |"$'\n'
               fi
-
-              # Parse Ticket section from full commit body
-              COMMIT_BODY=$(git log -1 --format="%b" "$full_hash")
-              TICKET_SECTION=$(echo "$COMMIT_BODY" | sed -n '/### Ticket/,/### /p' | head -n -1 | tail -n +2)
-
-              # Extract issue references for this commit
-              ISSUE_LINKS=""
-              if [ -n "$TICKET_SECTION" ]; then
-                # Check if ticket section is just "None" (case-insensitive, with optional whitespace)
-                TICKET_TRIMMED=$(echo "$TICKET_SECTION" | tr -d '[:space:]' | tr '[:upper:]' '[:lower:]')
-                if [ "$TICKET_TRIMMED" != "none" ] && [ -n "$TICKET_TRIMMED" ]; then
-                  # Extract tt-metal issues - matches both plain URLs and markdown links
-                  METAL_ISSUES=$(echo "$TICKET_SECTION" | grep -oE 'https?://github\.com/tenstorrent/tt-metal/issues/[0-9]+' | grep -oE '[0-9]+$' | sort -u)
-                  for issue_num in $METAL_ISSUES; do
-                    [ -n "$ISSUE_LINKS" ] && ISSUE_LINKS+=", "
-                    ISSUE_LINKS+="[metal#$issue_num](https://github.com/tenstorrent/tt-metal/issues/$issue_num)"
-                  done
-
-                  # Extract tt-llk issues - matches both plain URLs and markdown links
-                  LLK_URL_ISSUES=$(echo "$TICKET_SECTION" | grep -oE 'https?://github\.com/tenstorrent/tt-llk/issues/[0-9]+' | grep -oE '[0-9]+$' | sort -u)
-                  for issue_num in $LLK_URL_ISSUES; do
-                    [ -n "$ISSUE_LINKS" ] && ISSUE_LINKS+=", "
-                    ISSUE_LINKS+="[llk#$issue_num](https://github.com/tenstorrent/tt-llk/issues/$issue_num)"
-                  done
-
-                  # Bare #number format → always tt-llk (commits are from that repo)
-                  BARE_ISSUES=$(echo "$TICKET_SECTION" | sed 's|https\?://[^ ]*||g' | grep -oE '(^|[[:space:]])#[0-9]+' | grep -oE '[0-9]+' | sort -u)
-                  for issue_num in $BARE_ISSUES; do
-                    [ -n "$ISSUE_LINKS" ] && ISSUE_LINKS+=", "
-                    ISSUE_LINKS+="[llk#$issue_num](https://github.com/tenstorrent/tt-llk/issues/$issue_num)"
-                  done
-                fi
-              fi
-
-              COMMITS_TABLE+="| $ISSUE_LINKS | $PR_CELL | [$short_hash](https://github.com/tenstorrent/tt-llk/commit/$full_hash) | $clean_message | $author |"$'\n'
             done < <(git log --pretty=format:"%h|%s|%an|%H" ${OLD_SHA}..${NEW_SHA})
           else
-            COMMITS_TABLE+="| | | | (No commits found) | |"$'\n'
+            COMMITS_TABLE+="| (No commits found) | - | - | - |"$'\n'
           fi
 
           # Determine labels for counts

--- a/tt_metal/hw/inc/debug/watcher_common.h
+++ b/tt_metal/hw/inc/debug/watcher_common.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "dev_msgs.h"
+#include "risc_attribs.h"
 
 #if defined(WATCHER_ENABLED)
 


### PR DESCRIPTION
### Ticket
None

### Problem description
When running tests with both TT_METAL_WATCHER=1 and TT_METAL_LLK_ASSERTS=1, the TRISC firmware compilation fails with errors like:
```cpp
2025-12-11 13:10:41.901 | critical |          Always | TT_THROW: trisc2 build failed. Log: In file included from /localdev/fvranic/tt-metal/tt_metal/hw/inc/debug/watcher_common.h:7,
                 from /localdev/fvranic/tt-metal/tt_metal/hw/inc/debug/assert.h:7,
                 from /localdev/fvranic/tt-metal/tt_metal/third_party/tt_llk/tt_llk_wormhole_b0/llk_lib/llk_assert.h:26,
                 from /localdev/fvranic/tt-metal/tt_metal/third_party/tt_llk/tt_llk_wormhole_b0/common/inc/ckernel.h:8,
                 from /localdev/fvranic/tt-metal/tt_metal/hw/firmware/src/tt-1xx/trisc.cc:6:
/localdev/fvranic/tt-metal/tt_metal/hw/inc/debug/watcher_common.h: In function 'void clear_previous_launch_message_entry_for_watcher()':
/localdev/fvranic/tt-metal/tt_metal/hw/inc/dev_msgs.h:60:53: error: expected primary-expression before 'tt_l1_ptr'
   60 | #define GET_MAILBOX_ADDRESS_DEV(x) (&(((mailboxes_t tt_l1_ptr*)MEM_MAILBOX_BASE)->x))
      |                                                     ^~~~~~~~~
/localdev/fvranic/tt-metal/tt_metal/hw/inc/debug/watcher_common.h:25:35: note: in expansion of macro 'GET_MAILBOX_ADDRESS_DEV'
   25 |     uint32_t launch_msg_rd_ptr = *GET_MAILBOX_ADDRESS_DEV(launch_msg_rd_ptr);
      |                                   ^~~~~~~~~~~~~~~~~~~~~~~
/localdev/fvranic/tt-metal/tt_metal/hw/inc/dev_msgs.h:60:53: error: expected ')' before 'tt_l1_ptr'
   60 | #define GET_MAILBOX_ADDRESS_DEV(x) (&(((mailboxes_t tt_l1_ptr*)MEM_MAILBOX_BASE)->x))
      |                                        ~            ^~~~~~~~~
/localdev/fvranic/tt-metal/tt_metal/hw/inc/debug/watcher_common.h:25:35: note: in expansion of macro 'GET_MAILBOX_ADDRESS_DEV'
   25 |     uint32_t launch_msg_rd_ptr = *GET_MAILBOX_ADDRESS_DEV(launch_msg_rd_ptr);
      |                                   ^~~~~~~~~~~~~~~~~~~~~~~
/localdev/fvranic/tt-metal/tt_metal/hw/inc/debug/watcher_common.h:25:77: error: expected ')' before ';' token
   25 |     uint32_t launch_msg_rd_ptr = *GET_MAILBOX_ADDRESS_DEV(launch_msg_rd_ptr);
      |                                                                             ^
/localdev/fvranic/tt-metal/tt_metal/hw/inc/dev_msgs.h:60:39: note: to match this '('
   60 | #define GET_MAILBOX_ADDRESS_DEV(x) (&(((mailboxes_t tt_l1_ptr*)MEM_MAILBOX_BASE)->x))
      |                                       ^
/localdev/fvranic/tt-metal/tt_metal/hw/inc/debug/watcher_common.h:25:35: note: in expansion of macro 'GET_MAILBOX_ADDRESS_DEV'
   25 |     uint32_t launch_msg_rd_ptr = *GET_MAILBOX_ADDRESS_DEV(launch_msg_rd_ptr);
      |                                   ^~~~~~~~~~~~~~~~~~~~~~~
/localdev/fvranic/tt-metal/tt_metal/hw/inc/debug/watcher_common.h:25:77: error: expected ')' before ';' token
   25 |     uint32_t launch_msg_rd_ptr = *GET_MAILBOX_ADDRESS_DEV(launch_msg_rd_ptr);
      |                                                                             ^
/localdev/fvranic/tt-metal/tt_metal/hw/inc/dev_msgs.h:60:38: note: to match this '('
   60 | #define GET_MAILBOX_ADDRESS_DEV(x) (&(((mailboxes_t tt_l1_ptr*)MEM_MAILBOX_BASE)->x))
      |                                      ^
```
#### Root cause
The `tt_l1_ptr` type qualifier (defined in `risc_attribs.h`) was not included by the debug headers that use it. The include chain when both flags are enabled:
1. `ckernel.h` includes `llk_assert.h`
2. `llk_assert.h` includes `debug/assert.h` (when `ENABLE_LLK_ASSERT` is defined)
3. `debug/assert.h` includes `watcher_common.h` (when `WATCHER_ENABLED` is defined)
4. `watcher_common.h` includes `dev_msgs.h`
5. `dev_msgs.h` uses `tt_l1_ptr` in the `GET_MAILBOX_ADDRESS_DEV` macro
6. Since `risc_attribs.h` is included later in `ckernel.h` (after `llk_assert.h`), the `tt_l1_ptr` is undefined when `watcher_common.h` is processed.

### What's changed
Added `#include "risc_attribs.h"` to `watcher_common.h` to make it self-contained rather than relying on include ordering from parent files as was the case until now.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] [cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) job passes
- [ ] New/Existing tests provide coverage for changes