### PR TITLE
meta's lib cross attention block replaced to HF equivalent 

### DIFF
--- a/models/tt_transformers/tests/multimodal/test_llama_cross_attention.py
+++ b/models/tt_transformers/tests/multimodal/test_llama_cross_attention.py
@@ -82,7 +82,7 @@ def test_cross_attention_inference(text_seq_len, batch, mesh_device, reset_seeds
     reference_model = MllamaTextCrossAttention(config.text_config, layer_idx=layer_idx)
     # partial loading of HF safetensors to match model graph expected dimensionality of the loaded weights
     partial_state_dict = load_partial_weights(
-        hf_weights_repo_name, "model.language_model.layers.{layer_idx}.cross_attn."
+        hf_weights_repo_name, f"model.language_model.layers.{layer_idx}.cross_attn."
     )
     reference_model.load_state_dict(partial_state_dict)
     num_chunks = 4

--- a/models/tt_transformers/tests/multimodal/test_llama_cross_attention.py
+++ b/models/tt_transformers/tests/multimodal/test_llama_cross_attention.py
@@ -109,7 +109,7 @@ def test_cross_attention_inference(text_seq_len, batch, mesh_device, reset_seeds
     pt_xattn_tokens = (torch.rand(batch, vision_seq_len, dim) * 2) - 1
     tt_xattn_tokens = pt_xattn_tokens.clone()
 
-    # Initially the cache functionality of HF is used with a placeholder tensor of torch.ones to compute only and store the Key and Value projections in memory
+    # Initially the cache functionality of HF is used with a placeholder tensor of torch.ones to compute and store the Key and Value projections in memory
     # see link on how the cache is used: https://github.com/huggingface/transformers/blob/v4.53.0/src/transformers/models/mllama/modeling_mllama.py#L484-L496
     reference_model.forward(
         torch.ones(batch, 1, dim), pt_xattn_tokens, past_key_value=past_key_values, attention_mask=None

--- a/models/tt_transformers/tests/multimodal/test_llama_cross_attention.py
+++ b/models/tt_transformers/tests/multimodal/test_llama_cross_attention.py
@@ -3,16 +3,33 @@
 # SPDX-License-Identifier: Apache-2.0
 import os
 
-import llama_models.llama3.reference_impl.multimodal.model as llama_reference_mod
 import pytest
 import torch
 from loguru import logger
+from transformers import AutoConfig, AutoModelForVision2Seq
+from transformers.cache_utils import DynamicCache
+from transformers.models.mllama.modeling_mllama import MllamaTextCrossAttention
 
 import ttnn
 from models.common.utility_functions import comp_allclose, comp_pcc, nearest_32
 from models.tt_transformers.tt.ccl import TT_CCL
 from models.tt_transformers.tt.model_config import ModelArgs
 from models.tt_transformers.tt.multimodal.llama_cross_attention import TtLlamaCrossAttention
+
+
+def load_partial_weights(weights_path, layer_prefix):
+    partial_state_dict = {}
+    model = AutoModelForVision2Seq.from_pretrained(
+        weights_path, torch_dtype="auto", local_files_only=os.getenv("CI") == "true"
+    )
+    weights = model.state_dict()
+    keys = weights.keys()
+    for key in keys:
+        if layer_prefix in key:
+            # Caution it may cause potential failures. In future versions and different formats the below prefix may change
+            key_name = key[len(layer_prefix) :]
+            partial_state_dict.update({key_name: weights[key]})
+    return partial_state_dict
 
 
 @pytest.mark.parametrize(
@@ -47,20 +64,25 @@ def test_cross_attention_inference(text_seq_len, batch, mesh_device, reset_seeds
 
     # Ref model needs partial state dict, but our models use full state dict keys as cached weight names
     first_layer_prefix = "text_model.cross_attention_layers.0.attention."
-    partial_state_dict = {
-        k[len(first_layer_prefix) :]: v for k, v in state_dict.items() if (k.startswith(first_layer_prefix))
-    }
 
     dim = model_args.dim
     head_dim = model_args.head_dim
     n_heads = model_args.n_heads
     n_kv_heads = model_args.n_kv_heads
     norm_eps = model_args.norm_eps
-    reference_model = llama_reference_mod.CrossAttention(
-        dim=dim, head_dim=head_dim, n_heads=n_heads, n_kv_heads=n_kv_heads, norm_eps=norm_eps
-    )
-    reference_model.load_state_dict(partial_state_dict)
 
+    # Initialization of HF subclass parameters
+    hf_weights_repo_name = os.getenv("HF_MODEL")
+    past_key_values = DynamicCache()
+    config = AutoConfig.from_pretrained(hf_weights_repo_name)
+    config.text_config._attn_implementation = "sdpa"
+    config.text_config.rms_norm_eps = norm_eps
+    # the layer id of the first cross-attention branch that occurs in the nnet needed for cache allocation id
+    layer_idx = config.text_config.cross_attention_layers[0]
+    reference_model = MllamaTextCrossAttention(config.text_config, layer_idx=layer_idx)
+    # partial loading of HF safetensors to match model graph expected dimensionality of the loaded weights
+    partial_state_dict = load_partial_weights(hf_weights_repo_name, "model.language_model.layers.3.cross_attn.")
+    reference_model.load_state_dict(partial_state_dict)
     num_chunks = 4
     vision_seq_len = num_chunks * nearest_32(model_args.vision_chunk_ntok)
 
@@ -88,13 +110,12 @@ def test_cross_attention_inference(text_seq_len, batch, mesh_device, reset_seeds
     """
     Test compute_xattn_kv_cache
     """
-    pt_xattn_cache = reference_model.compute_xattn_kv_cache(pt_xattn_tokens)
-    pt_xattn_cache_chunks = torch.chunk(pt_xattn_cache, 2, dim=0)
-    # slice out repeated KV heads
-    pt_xattn_cache_chunks = [
-        x.view(batch, n_heads, vision_seq_len, head_dim)[:, :: n_heads // n_kv_heads] for x in pt_xattn_cache
-    ]
-
+    # Initially the cache functionality of HF is used with a placeholder tensor of torch.ones to compute only store the Key and Value projections in memory
+    reference_model.forward(
+        torch.ones(batch, 1, dim), pt_xattn_tokens, past_key_value=past_key_values, attention_mask=None
+    )
+    # tt_model expects a list of Key and Value projections
+    pt_xattn_cache_chunks = [past_key_values.key_cache[layer_idx], past_key_values.value_cache[layer_idx]]
     # Preallocate K and V caches
     tt_xattn_cache = [
         ttnn.from_torch(
@@ -111,7 +132,7 @@ def test_cross_attention_inference(text_seq_len, batch, mesh_device, reset_seeds
     """
     Test forward, prefill and decode!
     """
-    n_iter = 10
+    n_iter = 1  # 10
     for i in range(n_iter):
         mode = "prefill" if i == 0 else "decode"
         seq_len = text_seq_len if mode == "prefill" else 1
@@ -146,9 +167,10 @@ def test_cross_attention_inference(text_seq_len, batch, mesh_device, reset_seeds
         full_text_mask = full_text_mask.unsqueeze(1).unsqueeze(-1)
         full_text_mask_expand = full_text_mask.expand(-1, n_heads // model_args.num_devices, -1, head_dim)
 
+        # Key and Values projections are stored in cache thus the cross-attention features are replaced with None and only Query intput is passed to compute its projection and proceed to attention computation.
         pt_out = reference_model.forward(
-            pt_x, xattn_mask=xattn_mask, full_text_row_masked_out_mask=full_text_mask, xattn_cache=pt_xattn_cache
-        )
+            pt_x, None, past_key_value=past_key_values, attention_mask=xattn_mask, cache_position=[layer_idx]
+        )[0] * full_text_mask.squeeze(1)
 
         if mode == "prefill":
             outputs = []

--- a/models/tt_transformers/tests/multimodal/test_llama_cross_attention.py
+++ b/models/tt_transformers/tests/multimodal/test_llama_cross_attention.py
@@ -132,7 +132,7 @@ def test_cross_attention_inference(text_seq_len, batch, mesh_device, reset_seeds
     """
     Test forward, prefill and decode!
     """
-    n_iter = 1  # 10
+    n_iter = 10
     for i in range(n_iter):
         mode = "prefill" if i == 0 else "decode"
         seq_len = text_seq_len if mode == "prefill" else 1


### PR DESCRIPTION
### Ticket
Close https://github.com/tenstorrent/tt-metal/issues/30082

### Problem description
Cross attention applied to text branch using vision's branch features of mulitmodal Llama needs to be migrated from meta lib to HF.

### What's changed
HF internally may use different attention implementations, by default eager mode is always active. This mode uses an attention implementation that if combined with making a continuous block of memory using .contiguous() and nn.Linear layer generates minor numerical deviations in the generated tensor. Thus when testing Llama model attention its implementation is switched to the following "config.text_config._attn_implementation = "sdpa"" to use torch.nn.functional.scaled_dot_product_attention as in meta lib (this diminishes any numerical fluctuations).
Additionally cached key and value projections had replicated values by `.repeat_interleave()`.  These were contracted to the number of KV heads instead of the number of attention heads. That helped reduce cache memory usage and match tt_model expected dimensionality.

### Checklist
- [x] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/runs/20235231058) CI passes  for `test_llama_cross_attention.py` with relevant CI tasks `t3k llama3.2-90b-vision tests`, `t3k n300 mesh llama3.2-11b-vision tests`, `t3k llama3.2-11b-vision tests`
