### PR TITLE
[skip ci] turn on pinging for auto-triage

### DIFF
--- a/.github/workflows/auto-triage.yml
+++ b/.github/workflows/auto-triage.yml
@@ -38,6 +38,7 @@ jobs:
           job-name: ${{ inputs.job_name }}
           copilot-pat: ${{ secrets.AUTO_TRIAGE_TOKEN }}
           slack_ts: ${{ inputs.slack_ts }}
+          allow-pings: true
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
           # SLACK_WEBHOOK_URL is removed in favor of SLACK_BOT_TOKEN + channel logic in the action


### PR DESCRIPTION
This makes it so developers will be pinged whenever one of their commits is flagged as breaking a pipeline.