### PR TITLE
bugprone-forwarding-reference-overload

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -41,7 +41,6 @@ Checks: >
   -bugprone-crtp-constructor-accessibility,
   -bugprone-easily-swappable-parameters,
   -bugprone-exception-escape,
-  -bugprone-forwarding-reference-overload,
   -bugprone-implicit-widening-of-multiplication-result,
   -bugprone-integer-division,
   -bugprone-narrowing-conversions,

--- a/tt_metal/hw/inc/accessor/helpers.h
+++ b/tt_metal/hw/inc/accessor/helpers.h
@@ -7,6 +7,7 @@
 #include <utility>
 #include <cstddef>
 #include <cstdint>
+#include <type_traits>
 
 #include "compile_time_args.h"
 
@@ -24,11 +25,11 @@ template <bool Enable, typename T = void>
 struct ConditionalField {
     T value;
     // Constructor that forwards a single argument
-    template <typename T_>
+    template <typename T_, std::enable_if_t<!std::is_same_v<std::decay_t<T_>, ConditionalField>, int> = 0>
     ConditionalField(T_&& val) : value(std::forward<T_>(val)) {}
 
     // Variadic constructor that forwards multiple arguments to T's constructor
-    template <typename... Args>
+    template <typename... Args, std::enable_if_t<sizeof...(Args) != 1, int> = 0>
     ConditionalField(Args&&... args) : value(std::forward<Args>(args)...) {}
 
     ConditionalField() = default;
@@ -38,11 +39,11 @@ struct ConditionalField {
 template <typename T>
 struct ConditionalField<false, T> {
     // Constructor that ignores a single argument
-    template <typename T_>
+    template <typename T_, std::enable_if_t<!std::is_same_v<std::decay_t<T_>, ConditionalField>, int> = 0>
     ConditionalField(T_&& val) {}  // Ignore value if passed to constructor
 
     // Variadic constructor that ignores all arguments
-    template <typename... Args>
+    template <typename... Args, std::enable_if_t<sizeof...(Args) != 1, int> = 0>
     ConditionalField(Args&&... args) {}  // Ignore all arguments if passed to constructor
 
     ConditionalField() = default;

--- a/tt_stl/tt_stl/reflection.hpp
+++ b/tt_stl/tt_stl/reflection.hpp
@@ -149,7 +149,10 @@ struct Attribute final {
     std::size_t to_hash() const { return this->implementations.to_hash_impl_(this->type_erased_storage); }
     nlohmann::json to_json() const { return this->implementations.to_json_impl_(this->type_erased_storage); }
 
-    template <typename Type, typename BaseType = std::decay_t<Type>>
+    template <
+        typename Type,
+        typename BaseType = std::decay_t<Type>,
+        std::enable_if_t<!std::is_same_v<BaseType, Attribute>, int> = 0>
     Attribute(Type&& object) :
         pointer{new(&type_erased_storage) BaseType{std::forward<Type>(object)}},
         delete_storage{[](storage_t& self) { reinterpret_cast<BaseType*>(&self)->~BaseType(); }},

--- a/tt_stl/tt_stl/unique_any.hpp
+++ b/tt_stl/tt_stl/unique_any.hpp
@@ -15,7 +15,10 @@ template <auto MAX_STORAGE_SIZE, auto ALIGNMENT>
 struct unique_any final {
     using storage_t = std::array<std::byte, MAX_STORAGE_SIZE>;
 
-    template <typename Type, typename BaseType = std::decay_t<Type>>
+    template <
+        typename Type,
+        typename BaseType = std::decay_t<Type>,
+        std::enable_if_t<!std::is_same_v<BaseType, unique_any>, int> = 0>
     unique_any(Type&& object) :
         pointer{new(&type_erased_storage) BaseType{std::forward<Type>(object)}},
         delete_storage{[](storage_t& self) { reinterpret_cast<BaseType*>(&self)->~BaseType(); }},


### PR DESCRIPTION
### Ticket
NA

### Problem description
We have this clang-tidy check disabled:
https://clang.llvm.org/extra/clang-tidy/checks/bugprone/forwarding-reference-overload.html

Fix things like this:
```
/workspace/tt_metal/hw/inc/accessor/helpers.h:28:5: error: constructor accepting a forwarding reference can hide the copy and move constructors [bugprone-forwarding-reference-overload,-warnings-as-errors]
   28 |     ConditionalField(T_&& val) : value(std::forward<T_>(val)) {}
      |     ^
/workspace/tt_metal/hw/inc/accessor/helpers.h:42:5: error: constructor accepting a forwarding reference can hide the copy and move constructors [bugprone-forwarding-reference-overload,-warnings-as-errors]
   42 |     ConditionalField(T_&& val) {}  // Ignore value if passed to constructor
      |     ^
/workspace/tt_metal/hw/inc/accessor/helpers.h:39:8: note: copy constructor declared here
   39 | struct ConditionalField<false, T> {
      |        ^
/workspace/tt_metal/hw/inc/accessor/helpers.h:39:8: note: move constructor declared here
```

### What's changed
- Enable check
- Use Claude to fix

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] New/Existing tests provide coverage for changes