### PR TITLE
[skip ci] Temporarily skip failing tests to reduce glx queue times in CI

### DIFF
--- a/.github/workflows/galaxy-demo-tests-impl.yaml
+++ b/.github/workflows/galaxy-demo-tests-impl.yaml
@@ -54,7 +54,7 @@ jobs:
           # Yousef Al Rawwash - deepseek
 
           all_tests='[
-            # { "name": "Galaxy Llama3 demo tests", "arch": "wormhole_b0", "model": "llama3", "timeout": 30, "owner_id": "U053W15B6JF" },
+            { "name": "Galaxy Llama3 demo tests", "arch": "wormhole_b0", "model": "llama3", "timeout": 30, "owner_id": "U053W15B6JF" },
             # { "name": "Galaxy Llama3 long context demo tests", "arch": "wormhole_b0", "model": "llama3_long_context", "timeout": 60, "owner_id": "U03PUAKE719" },
             # { "name": "Galaxy Llama3 evals tests", "arch": "wormhole_b0", "model": "llama3_evals", "timeout": 45, "owner_id": "U03PUAKE719" },
             { "name": "Galaxy Llama3 8B data-parallel demo tests", "arch": "wormhole_b0", "model": "llama3_8b_dp", "timeout": 30, "owner_id": "U08BH66EXAL" },

--- a/.github/workflows/galaxy-demo-tests-impl.yaml
+++ b/.github/workflows/galaxy-demo-tests-impl.yaml
@@ -68,7 +68,7 @@ jobs:
             { "name": "Galaxy Motif-Image-6B-Preview demo tests", "arch": "wormhole_b0", "model": "motif", "timeout": 20, "owner_id": "U08TED0JM9D" },
             { "name": "Galaxy Wan2.2 demo tests", "arch": "wormhole_b0", "model": "wan22", "timeout": 25, "owner_id": "U03FJB5TM5Y" },
             { "name": "Galaxy Mochi demo tests", "arch": "wormhole_b0", "model": "mochi", "timeout": 30, "owner_id": "U09ELB03XRU" },
-            # { "name": "Galaxy DeepSeek v3 demo tests", "arch": "wormhole_b0", "model": "deepseek_v3", "timeout": 10, "owner_id": "U08H32XUS9W" }
+            { "name": "Galaxy DeepSeek v3 demo tests", "arch": "wormhole_b0", "model": "deepseek_v3", "timeout": 10, "owner_id": "U08H32XUS9W" }
           ]'
 
           # Filter matrix based on model selection

--- a/.github/workflows/galaxy-demo-tests-impl.yaml
+++ b/.github/workflows/galaxy-demo-tests-impl.yaml
@@ -54,9 +54,9 @@ jobs:
           # Yousef Al Rawwash - deepseek
 
           all_tests='[
-            { "name": "Galaxy Llama3 demo tests", "arch": "wormhole_b0", "model": "llama3", "timeout": 30, "owner_id": "U053W15B6JF" },
-            { "name": "Galaxy Llama3 long context demo tests", "arch": "wormhole_b0", "model": "llama3_long_context", "timeout": 60, "owner_id": "U03PUAKE719" },
-            { "name": "Galaxy Llama3 evals tests", "arch": "wormhole_b0", "model": "llama3_evals", "timeout": 45, "owner_id": "U03PUAKE719" },
+            # { "name": "Galaxy Llama3 demo tests", "arch": "wormhole_b0", "model": "llama3", "timeout": 30, "owner_id": "U053W15B6JF" },
+            # { "name": "Galaxy Llama3 long context demo tests", "arch": "wormhole_b0", "model": "llama3_long_context", "timeout": 60, "owner_id": "U03PUAKE719" },
+            # { "name": "Galaxy Llama3 evals tests", "arch": "wormhole_b0", "model": "llama3_evals", "timeout": 45, "owner_id": "U03PUAKE719" },
             { "name": "Galaxy Llama3 8B data-parallel demo tests", "arch": "wormhole_b0", "model": "llama3_8b_dp", "timeout": 30, "owner_id": "U08BH66EXAL" },
             { "name": "Galaxy Llama3 70B data-parallel demo tests", "arch": "wormhole_b0", "model": "llama3_70b_dp", "timeout": 30, "owner_id": "U08BH66EXAL" },
             { "name": "Galaxy Falcon7b demo tests", "arch": "wormhole_b0", "model": "falcon7b", "timeout": 30, "owner_id": "U05RWH3QUPM" },
@@ -64,11 +64,11 @@ jobs:
             { "name": "Galaxy Whisper demo tests", "arch": "wormhole_b0", "model": "whisper", "timeout": 30, "owner_id": "U08HL8X1ECD" },
             { "name": "Galaxy Stable Diffusion 3.5 Large demo tests", "arch": "wormhole_b0", "model": "sd35", "timeout": 30, "owner_id": "U03FJB5TM5Y" },
             { "name": "Galaxy Flux.1-dev demo tests", "arch": "wormhole_b0", "model": "flux1", "timeout": 30, "owner_id": "U08TED0JM9D" },
-            { "name": "Galaxy GPT-OSS demo tests", "arch": "wormhole_b0", "model": "gpt-oss", "timeout": 30, "owner_id": "U06F3ER8X9A" },
+            # { "name": "Galaxy GPT-OSS demo tests", "arch": "wormhole_b0", "model": "gpt-oss", "timeout": 30, "owner_id": "U06F3ER8X9A" },
             { "name": "Galaxy Motif-Image-6B-Preview demo tests", "arch": "wormhole_b0", "model": "motif", "timeout": 20, "owner_id": "U08TED0JM9D" },
             { "name": "Galaxy Wan2.2 demo tests", "arch": "wormhole_b0", "model": "wan22", "timeout": 25, "owner_id": "U03FJB5TM5Y" },
             { "name": "Galaxy Mochi demo tests", "arch": "wormhole_b0", "model": "mochi", "timeout": 30, "owner_id": "U09ELB03XRU" },
-            { "name": "Galaxy DeepSeek v3 demo tests", "arch": "wormhole_b0", "model": "deepseek_v3", "timeout": 10, "owner_id": "U08H32XUS9W" }
+            # { "name": "Galaxy DeepSeek v3 demo tests", "arch": "wormhole_b0", "model": "deepseek_v3", "timeout": 10, "owner_id": "U08H32XUS9W" }
           ]'
 
           # Filter matrix based on model selection

--- a/.github/workflows/galaxy-frequent-tests-impl.yaml
+++ b/.github/workflows/galaxy-frequent-tests-impl.yaml
@@ -36,13 +36,13 @@ jobs:
         run: |
           # Create full matrix with jq for readability
           FULL_MATRIX=$(jq -n '[
-            {
-              "name": "Galaxy Llama3 frequent tests",
-              "arch": "wormhole_b0",
-              "model": "llama3",
-              "timeout": 70,
-              "owner_id": "U053W15B6JF"
-            }, # Djordje Ivanovic
+            # {
+            #   "name": "Galaxy Llama3 frequent tests",
+            #   "arch": "wormhole_b0",
+            #   "model": "llama3",
+            #   "timeout": 70,
+            #   "owner_id": "U053W15B6JF"
+            # }, # Djordje Ivanovic
             {
               "name": "Galaxy resnet50 frequent tests",
               "arch": "wormhole_b0",

--- a/.github/workflows/galaxy-model-perf-tests-impl.yaml
+++ b/.github/workflows/galaxy-model-perf-tests-impl.yaml
@@ -65,7 +65,17 @@ jobs:
               "timeout": 60,
               "cmd": "FAKE_DEVICE=TG LLAMA_DIR=/mnt/MLPerf/tt_dnn-models/llama/Llama3.3-70B-Instruct/ pytest -n auto models/demos/llama3_70b_galaxy/tests/test_prefill_device_perf.py::test_llama_TG_perf_device --timeout=1000",
               "owner_id": "U03PUAKE719"
-            } # Miguel Tairum
+            }, # Miguel Tairum
+            {
+              "name": "Galaxy Sentence Bert tests",
+              "arch": "wormhole_b0",
+              "model-type": "sentence_bert",
+              "model-name": "sentence_bert",
+              "save-perf-data": false,
+              "cmd": "pytest models/demos/tg/sentence_bert/tests/device_perf_test.py && python3 models/perf/merge_perf_results.py",
+              "timeout": 30,
+              "owner_id": "U088413NP0Q"
+            } # Ashai Reddy
           ]' --compact-output)
 
           ACTIVE_MODELS=$(jq -n '[
@@ -108,16 +118,6 @@ jobs:
               "cmd": "HF_HUB_CACHE=/mnt/MLPerf/huggingface/hub pytest models/experimental/tt_dit/tests/models/motif/test_performance_motif.py -k \"4x8cfg1sp0tp1\"",
               "owner_id": "U08TED0JM9D"
             }, # Samuel Adesoye
-            {
-              "name": "Galaxy Sentence Bert tests",
-              "arch": "wormhole_b0",
-              "model-type": "sentence_bert",
-              "model-name": "sentence_bert",
-              "save-perf-data": false,
-              "cmd": "pytest models/demos/tg/sentence_bert/tests/device_perf_test.py && python3 models/perf/merge_perf_results.py",
-              "timeout": 30,
-              "owner_id": "U088413NP0Q"
-            }, # Ashai Reddy
             {
               "name": "Galaxy DiT Wan2.2 model perf tests",
               "model-type": "Wan2.2",

--- a/.github/workflows/galaxy-nightly-tests-impl.yaml
+++ b/.github/workflows/galaxy-nightly-tests-impl.yaml
@@ -28,15 +28,15 @@ jobs:
       matrix:
         test-group: [
           { name: "Galaxy CCL tests", arch: wormhole_b0, cmd: "pytest tests/nightly/tg/ccl", timeout: 40, owner_id: U05ACKAJTHS}, # Naif Tarafdar
-          { name: "Galaxy Fabric unit tests", arch: wormhole_b0, cmd: build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="NightlyFabric*Fixture.*", timeout: 25, owner_id: U08UBDUKH6Z}, # Neel Nyamagoudar
+          # { name: "Galaxy Fabric unit tests", arch: wormhole_b0, cmd: build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="NightlyFabric*Fixture.*", timeout: 25, owner_id: U08UBDUKH6Z}, # Neel Nyamagoudar
           { name: "Galaxy Fabric 2D Torus Nightly Tests", arch: wormhole_b0, cmd: ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_2d_torus_nightly.yaml, timeout: 45, owner_id: U08UBDUKH6Z}, # Neel Nyamagoudar
-          {
-            name: "Llama Galaxy Accuracy Test",
-            arch: wormhole_b0,
-            cmd: "LLAMA_DIR=/mnt/MLPerf/tt_dnn-models/llama/Llama3.3-70B-Instruct/ FAKE_DEVICE=TG pytest models/demos/llama3_70b_galaxy/tests/test_llama_accuracy.py",
-            timeout: 15,
-            owner_id: U053W15B6JF
-          } # Djordje Ivanovic
+          # {
+          #   name: "Llama Galaxy Accuracy Test",
+          #   arch: wormhole_b0,
+          #   cmd: "LLAMA_DIR=/mnt/MLPerf/tt_dnn-models/llama/Llama3.3-70B-Instruct/ FAKE_DEVICE=TG pytest models/demos/llama3_70b_galaxy/tests/test_llama_accuracy.py",
+          #   timeout: 15,
+          #   owner_id: U053W15B6JF
+          # } # Djordje Ivanovic
         ]
     name: ${{ matrix.test-group.name }}
     runs-on:

--- a/.github/workflows/galaxy-quick-impl.yaml
+++ b/.github/workflows/galaxy-quick-impl.yaml
@@ -74,8 +74,8 @@ jobs:
           TT_MESH_GRAPH_DESC_PATH=tests/tt_metal/tt_fabric/custom_mesh_descriptors/galaxy_1x32_mesh_graph_descriptor.textproto ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2D*Fixture.*"
           TT_MESH_GRAPH_DESC_PATH=tests/tt_metal/tt_fabric/custom_mesh_descriptors/galaxy_1x32_mesh_graph_descriptor.textproto ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric1D*Fixture.*"
           TT_METAL_CLEAR_L1=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ${TT_METAL_HOME}/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_sanity_common.yaml
-          ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ${TT_METAL_HOME}/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_deadlock_stability_6U_galaxy.yaml
-          TT_METAL_CLEAR_L1=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ${TT_METAL_HOME}/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_ubench_6U_galaxy_quick.yaml
+          # ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ${TT_METAL_HOME}/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_deadlock_stability_6U_galaxy.yaml
+          # TT_METAL_CLEAR_L1=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ${TT_METAL_HOME}/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_ubench_6U_galaxy_quick.yaml
       - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
         if: ${{ failure() }}
         with:
@@ -140,7 +140,7 @@ jobs:
         # NOTE: These tests do not automatically get added to upstream tests. Please refer to dockerfile/upstream_test_images/.
         run: |
           ./build/test/tt_metal/tt_fabric/test_system_health --system-topology TORUS_XY
-          pytest models/demos/llama3_70b_galaxy/tests/test_llama_model.py -k "quick";
+          # pytest models/demos/llama3_70b_galaxy/tests/test_llama_model.py -k "quick";
           pytest models/demos/llama3_70b_galaxy/demo/demo_decode.py -k "quick";
           pytest models/demos/llama3_70b_galaxy/tests/unit_tests/test_llama_model_prefill.py;
           # CCL smoke tests - exactly one representative test from each op category

--- a/.github/workflows/galaxy-unit-tests-impl.yaml
+++ b/.github/workflows/galaxy-unit-tests-impl.yaml
@@ -88,8 +88,8 @@ jobs:
         test-group:
           - { name: "Galaxy unit tests", arch: "wormhole_b0", model: "unit", timeout: 30, owner_id: "XXXXX" }  # see issue #29677
           - { name: "Galaxy Fabric tests", arch: "wormhole_b0", model: "fabric", timeout: 25, owner_id: "UJ45FEC7M" } # Allan Liu
-          - { name: "Galaxy Llama3-70b unit tests", arch: "wormhole_b0", model: "llama3-70b", timeout: 30, owner_id: "U053W15B6JF", mlperf: true } # Djordje Ivanovic
-          - { name: "Galaxy DRAM Prefetcher unit tests", arch: "wormhole_b0", model: "prefetcher", timeout: 25, owner_id: "U044T8U8DEF" }  # Johanna Rock, Yu Gao
+          # - { name: "Galaxy Llama3-70b unit tests", arch: "wormhole_b0", model: "llama3-70b", timeout: 30, owner_id: "U053W15B6JF", mlperf: true } # Djordje Ivanovic
+          # - { name: "Galaxy DRAM Prefetcher unit tests", arch: "wormhole_b0", model: "prefetcher", timeout: 25, owner_id: "U044T8U8DEF" }  # Johanna Rock, Yu Gao
           - { name: "Galaxy distributed ops tests", arch: "wormhole_b0", model: "distributed-ops", timeout: 10, owner_id: "U044T8U8DEF" }  # Johanna Rock
           - { name: "Galaxy GPT-OSS unit tests", arch: "wormhole_b0", model: "gpt-oss", timeout: 25, owner_id: "U06F3ER8X9A", mlperf: true }  # Stuti Raizada
     name: ${{ matrix.test-group.name }}


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
In response to the queue times that have been extremely long (due to several CI GLXs going down), Djordje suggested disabling some tests that were already failing. The lack of CI machines were causing queues to be over 12 hours long, preventing several developers from progressing with their tasks. By selectively temporarily skipping model tests that have been failing for a few days, we hope the queue times will lessen. To avoid disabling entire pipelines, this was the first step in potentially restoring the queue times.