### PR TITLE
28564: set runtime args for all cores in override_runtime_args_mc_hc_tiled_interleaved

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_tiled_interleaved_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_tiled_interleaved_program_factory.cpp
@@ -24,7 +24,8 @@ void set_runtime_args_hc_tiled_interleaved(
     KernelHandle writer_kernel_id,
     const Tensor& input_tensor,
     Tensor& output_tensor,
-    bool is_create) {
+    bool is_create,
+    const CoreRange& total_cores) {
     auto* input_buffer = input_tensor.buffer();
     auto* output_buffer = output_tensor.buffer();
 
@@ -55,7 +56,8 @@ void set_runtime_args_hc_tiled_interleaved(
 
     uint32_t start_idx = 0;
     uint32_t padded_start_idx = 0;
-    for (const auto& core : cores) {
+    // Need to set runtime args for all cores, not just the ones doing work.
+    for (const auto& core : total_cores) {
         uint32_t num_tiles_per_core;
         uint32_t padded_tiles_per_core;
 
@@ -202,7 +204,7 @@ TransposeHCTiledInterleavedProgramFactory::cached_program_t TransposeHCTiledInte
         WriterDataMovementConfig(writer_compile_time_args));
 
     set_runtime_args_hc_tiled_interleaved(
-        program, reader_kernel_id, writer_kernel_id, input_tensor, output_tensor, true);
+        program, reader_kernel_id, writer_kernel_id, input_tensor, output_tensor, true, total_cores);
 
     return {std::move(program), {.reader_kernel_id = reader_kernel_id, .writer_kernel_id = writer_kernel_id}};
 }
@@ -214,6 +216,10 @@ void TransposeHCTiledInterleavedProgramFactory::override_runtime_arguments(
     transpose::tensor_return_value_t& tensor_return_value) {
     auto& program = cached_program.program;
     auto& shared_variables = cached_program.shared_variables;
+    auto compute_with_storage_grid_size = tensor_args.input.device()->compute_with_storage_grid_size();
+    uint32_t num_cores_x = compute_with_storage_grid_size.x;
+    uint32_t num_cores_y = compute_with_storage_grid_size.y;
+    CoreRange total_cores({0, 0}, {num_cores_x - 1, num_cores_y - 1});
 
     set_runtime_args_hc_tiled_interleaved(
         program,
@@ -221,7 +227,8 @@ void TransposeHCTiledInterleavedProgramFactory::override_runtime_arguments(
         shared_variables.writer_kernel_id,
         tensor_args.input,
         tensor_return_value,
-        false);
+        false,
+        total_cores);
 }
 
 }  // namespace ttnn::operations::data_movement::transpose::program


### PR DESCRIPTION
### Ticket
Link to Github Issue #28564 

### Problem description
transpose HC was creating kernels on the entire core grid and only setting the runtime args on the cores where work was being done. With regular dispatch that worked ok because the values were zeros, leading to no work being done. However, in certain scenarios, such as with slow dispatch, the values are not zero, leading to ttsim and watcher reporting errors.

### What's changed
Set runtime args for all cores

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/20169305021
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable) between https://github.com/tenstorrent/tt-metal/actions/runs/20169307940/job/57901125183 and https://github.com/tenstorrent/tt-metal/actions/runs/20145411579 everything passes
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] [cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) job passes
- [ ] New/Existing tests provide coverage for changes