### PR TITLE
[skip ci] adding option to disable slack pinging

### DIFF
--- a/.github/workflows/aggregate-workflow-data.yaml
+++ b/.github/workflows/aggregate-workflow-data.yaml
@@ -285,3 +285,4 @@ jobs:
           slack_ts: ${{ needs.handle-failures.outputs.slack_ts }}
           slack_channel_id: ${{ secrets.SLACK_METAL_INFRA_CHANNEL_ID }}
           slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
+          send-slack-message: true

--- a/.github/workflows/auto-triage.yml
+++ b/.github/workflows/auto-triage.yml
@@ -16,6 +16,11 @@ on:
         required: false
         default: ""
         type: string
+      send-slack-message:
+        description: "Send slack message"
+        required: false
+        default: false
+        type: boolean
 
 
 jobs:
@@ -39,6 +44,7 @@ jobs:
           copilot-pat: ${{ secrets.AUTO_TRIAGE_TOKEN }}
           slack_ts: ${{ inputs.slack_ts }}
           allow-pings: true
+          send-slack-message: ${{ inputs.send-slack-message }}
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
           # SLACK_WEBHOOK_URL is removed in favor of SLACK_BOT_TOKEN + channel logic in the action


### PR DESCRIPTION
Now auto-triage has an option to not send a slack notification. Sending a slack notification is off by default, but automatically on when aggregate workflow data triggers an auto-triage run automatically.