### PR TITLE
Add sub grid support to many of the to-layout conditions and to tilize with padding, untilize, untilize with unpadding

### DIFF
--- a/tests/ttnn/unit_tests/base_functionality/test_to_layout.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_to_layout.py
@@ -187,6 +187,10 @@ def test_untilize_with_unpadding_W_16(device, in_dtype, use_multicore, use_pack_
 def test_to_layout_subcore(device, h, w, input_layout, output_layout, sub_core_grids):
     torch.manual_seed(2005)
     for i in range(3):
+        # We have found 3 as effective to uncover program cache issues. 2 usually works but given the short runtime of test we are running 3 to be safe
+        # Typically run 1 gets hashed and in the case of trace is when things like persistent semaphores are allocated if applicable
+        # Typically run 2 is where trace selects the final position of all the tensors (run 1 if no persistents)
+        # Therefore run 3 is the first where we truly are in full trace mode (run 2 if no persistents)
         torch_input_tensor = torch_random((h, w), -0.1, 0.1, dtype=torch.bfloat16)
         input_tensor = ttnn.from_torch(torch_input_tensor, device=device, dtype=ttnn.bfloat16, layout=input_layout)
         new_layout_tensor = ttnn.to_layout(input_tensor, layout=output_layout, sub_core_grids=sub_core_grids)

--- a/tests/ttnn/unit_tests/base_functionality/test_to_layout.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_to_layout.py
@@ -167,6 +167,34 @@ def test_untilize_with_unpadding_W_16(device, in_dtype, use_multicore, use_pack_
 
 @pytest.mark.parametrize("h", [1, 18, 65])
 @pytest.mark.parametrize("w", [1, 15, 17, 29, 33, 49, 63, 65])
+@pytest.mark.parametrize("input_layout", [ttnn.TILE_LAYOUT])
+@pytest.mark.parametrize("output_layout", [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT])
+@pytest.mark.parametrize(
+    "sub_core_grids",
+    (
+        # single core
+        ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(1, 0))]),
+        # multiple disjoint cores
+        ttnn.CoreRangeSet(
+            [
+                ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(3, 6)),
+                ttnn.CoreRange(ttnn.CoreCoord(5, 0), ttnn.CoreCoord(6, 6)),
+            ]
+        ),
+    ),
+)
+def test_untilize_subcore(device, h, w, input_layout, output_layout, sub_core_grids):
+    torch.manual_seed(2005)
+    torch_input_tensor = torch_random((h, w), -0.1, 0.1, dtype=torch.bfloat16)
+    input_tensor = ttnn.from_torch(torch_input_tensor, device=device, dtype=ttnn.bfloat16, layout=input_layout)
+    new_layout_tensor = ttnn.to_layout(input_tensor, layout=output_layout, sub_core_grids=sub_core_grids)
+    torch_brought_back = ttnn.to_torch(new_layout_tensor)
+
+    assert_with_pcc(torch_input_tensor, torch_brought_back)
+
+
+@pytest.mark.parametrize("h", [1, 18, 65])
+@pytest.mark.parametrize("w", [1, 15, 17, 29, 33, 49, 63, 65])
 @pytest.mark.parametrize("input_layout", [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT])
 @pytest.mark.parametrize("output_layout", [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT])
 def test_to_layout_device(device, h, w, input_layout, output_layout):

--- a/tests/ttnn/unit_tests/base_functionality/test_to_layout.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_to_layout.py
@@ -166,7 +166,7 @@ def test_untilize_with_unpadding_W_16(device, in_dtype, use_multicore, use_pack_
 
 
 @pytest.mark.parametrize("h", [1, 18, 65])
-@pytest.mark.parametrize("w", [1, 15, 17, 29, 33, 49, 63, 65])
+@pytest.mark.parametrize("w", [1, 17, 65])
 @pytest.mark.parametrize("input_layout", [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT])
 @pytest.mark.parametrize("output_layout", [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT])
 @pytest.mark.parametrize(
@@ -181,6 +181,7 @@ def test_untilize_with_unpadding_W_16(device, in_dtype, use_multicore, use_pack_
                 ttnn.CoreRange(ttnn.CoreCoord(5, 0), ttnn.CoreCoord(6, 6)),
             ]
         ),
+        None,
     ),
 )
 def test_to_layout_subcore(device, h, w, input_layout, output_layout, sub_core_grids):
@@ -191,20 +192,6 @@ def test_to_layout_subcore(device, h, w, input_layout, output_layout, sub_core_g
         new_layout_tensor = ttnn.to_layout(input_tensor, layout=output_layout, sub_core_grids=sub_core_grids)
         torch_brought_back = ttnn.to_torch(new_layout_tensor)
         assert_with_pcc(torch_input_tensor, torch_brought_back)
-
-
-@pytest.mark.parametrize("h", [1, 18, 65])
-@pytest.mark.parametrize("w", [1, 17, 65])
-@pytest.mark.parametrize("input_layout", [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT])
-@pytest.mark.parametrize("output_layout", [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT])
-def test_to_layout_device(device, h, w, input_layout, output_layout):
-    torch.manual_seed(2005)
-    torch_input_tensor = torch_random((h, w), -0.1, 0.1, dtype=torch.bfloat16)
-    input_tensor = ttnn.from_torch(torch_input_tensor, device=device, dtype=ttnn.bfloat16, layout=input_layout)
-    new_layout_tensor = ttnn.to_layout(input_tensor, layout=output_layout)
-    torch_brought_back = ttnn.to_torch(new_layout_tensor)
-
-    assert_with_pcc(torch_input_tensor, torch_brought_back)
 
 
 @pytest.mark.parametrize("shape", [[3, 50, 1, 3, 768], [3, 1370, 1, 32, 1280]])

--- a/tests/ttnn/unit_tests/base_functionality/test_to_layout.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_to_layout.py
@@ -167,7 +167,7 @@ def test_untilize_with_unpadding_W_16(device, in_dtype, use_multicore, use_pack_
 
 @pytest.mark.parametrize("h", [1, 18, 65])
 @pytest.mark.parametrize("w", [1, 15, 17, 29, 33, 49, 63, 65])
-@pytest.mark.parametrize("input_layout", [ttnn.TILE_LAYOUT])
+@pytest.mark.parametrize("input_layout", [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT])
 @pytest.mark.parametrize("output_layout", [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT])
 @pytest.mark.parametrize(
     "sub_core_grids",
@@ -183,18 +183,18 @@ def test_untilize_with_unpadding_W_16(device, in_dtype, use_multicore, use_pack_
         ),
     ),
 )
-def test_untilize_subcore(device, h, w, input_layout, output_layout, sub_core_grids):
+def test_to_layout_subcore(device, h, w, input_layout, output_layout, sub_core_grids):
     torch.manual_seed(2005)
-    torch_input_tensor = torch_random((h, w), -0.1, 0.1, dtype=torch.bfloat16)
-    input_tensor = ttnn.from_torch(torch_input_tensor, device=device, dtype=ttnn.bfloat16, layout=input_layout)
-    new_layout_tensor = ttnn.to_layout(input_tensor, layout=output_layout, sub_core_grids=sub_core_grids)
-    torch_brought_back = ttnn.to_torch(new_layout_tensor)
-
-    assert_with_pcc(torch_input_tensor, torch_brought_back)
+    for i in range(3):
+        torch_input_tensor = torch_random((h, w), -0.1, 0.1, dtype=torch.bfloat16)
+        input_tensor = ttnn.from_torch(torch_input_tensor, device=device, dtype=ttnn.bfloat16, layout=input_layout)
+        new_layout_tensor = ttnn.to_layout(input_tensor, layout=output_layout, sub_core_grids=sub_core_grids)
+        torch_brought_back = ttnn.to_torch(new_layout_tensor)
+        assert_with_pcc(torch_input_tensor, torch_brought_back)
 
 
 @pytest.mark.parametrize("h", [1, 18, 65])
-@pytest.mark.parametrize("w", [1, 15, 17, 29, 33, 49, 63, 65])
+@pytest.mark.parametrize("w", [1, 17, 65])
 @pytest.mark.parametrize("input_layout", [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT])
 @pytest.mark.parametrize("output_layout", [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT])
 def test_to_layout_device(device, h, w, input_layout, output_layout):

--- a/ttnn/cpp/ttnn/operations/core/to_layout/to_layout_op.cpp
+++ b/ttnn/cpp/ttnn/operations/core/to_layout/to_layout_op.cpp
@@ -134,11 +134,15 @@ Tensor to_layout_impl(
             for (int index = -1; index >= -logical_rank; --index) {
                 output_tensor_end[index] = tensor.logical_shape()[index] - 1;
             }
-            TT_FATAL(
-                !sub_core_grids.has_value(), "Untilize with unpadding OP does not currently support sub core grid");
-            tensor =
-                ttnn::untilize_with_unpadding(tensor, output_tensor_end, output_memory_config, use_multicore_untilize);
-            return ttnn::reshape(tensor, ttnn::Shape{output_shape});
+            tensor = ttnn::untilize_with_unpadding(
+                tensor, output_tensor_end, output_memory_config, use_multicore_untilize, true, sub_core_grids);
+            return ttnn::reshape(
+                tensor,
+                ttnn::Shape{output_shape},
+                std::nullopt /*Memory Config*/,
+                std::nullopt /*pad value*/,
+                TileReshapeMapMode::CACHE,
+                sub_core_grids);
 
         } else if (layout == ttnn::TILE_LAYOUT) {
             if (tensor.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED) {

--- a/ttnn/cpp/ttnn/operations/core/to_layout/to_layout_op.cpp
+++ b/ttnn/cpp/ttnn/operations/core/to_layout/to_layout_op.cpp
@@ -168,15 +168,14 @@ Tensor to_layout_impl(
                 } else {
                     pad_value_variant = (uint32_t)0;
                 }
-                TT_FATAL(
-                    !sub_core_grids.has_value(), "Tilize with Val Padding OP does not currently support sub core grid");
                 tensor = ttnn::tilize_with_val_padding(
                     tensor,
                     Shape(padded_output_shape),
                     pad_value_variant,
                     output_memory_config,
                     dtype,
-                    use_multicore_tilize);
+                    use_multicore_tilize,
+                    sub_core_grids);
             }
             if (original_rank == 1) {
                 return ttnn::reshape(

--- a/ttnn/cpp/ttnn/operations/core/to_layout/to_layout_op.cpp
+++ b/ttnn/cpp/ttnn/operations/core/to_layout/to_layout_op.cpp
@@ -96,8 +96,8 @@ Tensor to_layout_impl(
         if (not requires_padding_change(tensor, layout)) {
             if (layout == ttnn::ROW_MAJOR_LAYOUT) {
                 TT_ASSERT(not dtype.has_value(), "dtype cannot be specified when converting to ROW_MAJOR_LAYOUT!");
-                TT_FATAL(!sub_core_grids.has_value(), "Untilize OP does not currently support sub core grid");
-                return ttnn::untilize(tensor, output_memory_config, use_multicore_untilize);
+                return ttnn::untilize(
+                    tensor, output_memory_config, use_multicore_untilize, true /*use_pack_untilize*/, sub_core_grids);
             } else if (layout == ttnn::TILE_LAYOUT) {
                 if (tensor.is_sharded()) {
                     const auto tensor_tile = tensor.tensor_spec().tile();
@@ -135,7 +135,12 @@ Tensor to_layout_impl(
                 output_tensor_end[index] = tensor.logical_shape()[index] - 1;
             }
             tensor = ttnn::untilize_with_unpadding(
-                tensor, output_tensor_end, output_memory_config, use_multicore_untilize, true, sub_core_grids);
+                tensor,
+                output_tensor_end,
+                output_memory_config,
+                use_multicore_untilize,
+                true /*use_pack_untilize*/,
+                sub_core_grids);
             return ttnn::reshape(
                 tensor,
                 ttnn::Shape{output_shape},

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_op.cpp
@@ -128,17 +128,20 @@ operation::ProgramWithCallbacks TilizeWithValPadding::create_program(
     const auto& input_tensor_a = input_tensors.at(0);
     auto& output_tensor = output_tensors.at(0);
     if (input_tensor_a.memory_config().is_sharded()) {
+        TT_FATAL(!this->sub_core_grids.has_value(), "Sharded tilize does not support sub core grid specification");
         return detail::tilize_with_val_padding_multi_core_sharded(input_tensor_a, output_tensor, this->pad_value);
     }
     if (!this->enough_space_height) {
         return detail::tilize_with_val_padding_multi_core_block_interleaved(
-            input_tensor_a, output_tensor, this->pad_value);
+            input_tensor_a, output_tensor, this->pad_value, this->sub_core_grids);
     }
     if (!this->use_multicore) {
-        return detail::tilize_with_val_padding_single_core(input_tensor_a, output_tensor, this->pad_value);
+        return detail::tilize_with_val_padding_single_core(
+            input_tensor_a, output_tensor, this->pad_value, this->sub_core_grids);
     }
 
-    return detail::tilize_with_val_padding_multi_core_interleaved(input_tensor_a, output_tensor, this->pad_value);
+    return detail::tilize_with_val_padding_multi_core_interleaved(
+        input_tensor_a, output_tensor, this->pad_value, this->sub_core_grids);
 }
 
 }  // namespace ttnn::operations::data_movement

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_op.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_op.hpp
@@ -19,6 +19,7 @@ struct TilizeWithValPadding {
     const bool use_multicore;
     const bool enough_space_width;
     const bool enough_space_height;
+    const std::optional<CoreRangeSet> sub_core_grids;
 
     void validate(const std::vector<Tensor>& input_tensors) const;
     std::vector<ttnn::TensorSpec> compute_output_specs(const std::vector<Tensor>& input_tensors) const;

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_program_factory.cpp
@@ -60,10 +60,14 @@ uint32_t get_packed_value(const Tensor tensor, const tt::tt_metal::PadValue pad_
 }
 
 operation::ProgramWithCallbacks tilize_with_val_padding_single_core(
-    const Tensor& a, Tensor& output, const tt::tt_metal::PadValue pad_value) {
+    const Tensor& a,
+    Tensor& output,
+    const tt::tt_metal::PadValue pad_value,
+    const std::optional<CoreRangeSet>& sub_core_grids) {
     tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
 
-    CoreRange core({0, 0}, {0, 0});
+    CoreRange default_core({0, 0}, {0, 0});
+    CoreRange core = sub_core_grids.has_value() ? corerange_to_cores(sub_core_grids.value()).at(0) : default_core;
 
     // This should allocate a DRAM buffer on the device
 
@@ -213,35 +217,38 @@ operation::ProgramWithCallbacks tilize_with_val_padding_single_core(
 
     tt::tt_metal::SetRuntimeArgs(
         program, unary_writer_kernel_id, core, {dst_buffer->address(), (uint32_t)num_tiles, 0});
-    auto override_runtime_args_callback = [reader_kernel_id = unary_reader_kernel_id,
-                                           writer_kernel_id = unary_writer_kernel_id](
-                                              const void* operation,
-                                              Program& program,
-                                              const std::vector<Tensor>& input_tensors,
-                                              const std::vector<std::optional<const Tensor>>& optional_tensors,
-                                              const std::vector<Tensor>& output_tensors) {
-        auto* src_buffer = input_tensors.at(0).buffer();
+    auto override_runtime_args_callback =
+        [reader_kernel_id = unary_reader_kernel_id, writer_kernel_id = unary_writer_kernel_id, core = core](
+            const void* operation,
+            Program& program,
+            const std::vector<Tensor>& input_tensors,
+            const std::vector<std::optional<const Tensor>>& optional_tensors,
+            const std::vector<Tensor>& output_tensors) {
+            auto* src_buffer = input_tensors.at(0).buffer();
 
-        auto* dst_buffer = output_tensors.at(0).buffer();
+            auto* dst_buffer = output_tensors.at(0).buffer();
 
-        CoreCoord core = {0, 0};
+            CoreCoord core_0 = corerange_to_cores(core).at(0);
 
-        {
-            auto& runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
-            runtime_args[0] = src_buffer->address();
-        }
+            {
+                auto& runtime_args = GetRuntimeArgs(program, reader_kernel_id, core_0);
+                runtime_args[0] = src_buffer->address();
+            }
 
-        {
-            auto& runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
-            runtime_args[0] = dst_buffer->address();
-        }
-    };
+            {
+                auto& runtime_args = GetRuntimeArgs(program, writer_kernel_id, core_0);
+                runtime_args[0] = dst_buffer->address();
+            }
+        };
 
     return {std::move(program), override_runtime_args_callback};
 }
 
 operation::ProgramWithCallbacks tilize_with_val_padding_multi_core_block_interleaved(
-    const Tensor& a, Tensor& output, const tt::tt_metal::PadValue pad_value) {
+    const Tensor& a,
+    Tensor& output,
+    const tt::tt_metal::PadValue pad_value,
+    const std::optional<CoreRangeSet>& sub_core_grids) {
     tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
 
     tt::DataFormat input_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(a.dtype());
@@ -253,6 +260,9 @@ operation::ProgramWithCallbacks tilize_with_val_padding_multi_core_block_interle
 
     IDevice* device = a.device();
     CoreCoord grid_size = device->compute_with_storage_grid_size();
+    CoreRange default_cores({0, 0}, {grid_size.x - 1, grid_size.y - 1});
+    CoreRangeSet default_grid(default_cores);
+    CoreRangeSet available_grid = sub_core_grids.has_value() ? sub_core_grids.value() : default_grid;
 
     uint32_t num_tiles_per_col = output.padded_shape()[-2] / TILE_HEIGHT;
     uint32_t num_tiles_per_row = output.padded_shape()[-1] / TILE_WIDTH;
@@ -274,7 +284,7 @@ operation::ProgramWithCallbacks tilize_with_val_padding_multi_core_block_interle
          has_cliff_col,
          full_cores_per_row,
          full_cores_per_col] =
-            ttnn::split_blocks_for_tilize_wh(grid_size, num_blocks, num_tiles_per_row, num_tiles_per_col);
+            ttnn::split_blocks_for_tilize_wh(available_grid, num_blocks, num_tiles_per_row, num_tiles_per_col);
 
     uint32_t total_tiles_per_row =
         (full_cores_per_row * single_block_size) + (has_cliff_row * single_block_size_cliff_row);
@@ -430,7 +440,7 @@ operation::ProgramWithCallbacks tilize_with_val_padding_multi_core_block_interle
     }
 
     // RUNTIME ARGS
-    const auto& cores = grid_to_cores(ncores, grid_size.x, grid_size.y, true);
+    const auto cores = corerange_to_cores(available_grid);
     uint32_t start_row_id = 0;
     uint32_t start_column_id = 0;
     uint32_t tile_start_id = 0;
@@ -493,35 +503,41 @@ operation::ProgramWithCallbacks tilize_with_val_padding_multi_core_block_interle
         }
     }
 
-    auto override_runtime_args_callback =
-        [reader_kernel_id = unary_reader_kernel_id, writer_kernel_id = unary_writer_kernel_id, cores = cores](
-            const void* operation,
-            Program& program,
-            const std::vector<Tensor>& input_tensors,
-            const std::vector<std::optional<const Tensor>>& optional_tensors,
-            const std::vector<Tensor>& output_tensors) {
-            auto* src_buffer = input_tensors.at(0).buffer();
-            auto* dst_buffer = output_tensors.at(0).buffer();
+    auto override_runtime_args_callback = [reader_kernel_id = unary_reader_kernel_id,
+                                           writer_kernel_id = unary_writer_kernel_id,
+                                           cores = cores,
+                                           ncores = ncores](
+                                              const void* operation,
+                                              Program& program,
+                                              const std::vector<Tensor>& input_tensors,
+                                              const std::vector<std::optional<const Tensor>>& optional_tensors,
+                                              const std::vector<Tensor>& output_tensors) {
+        auto* src_buffer = input_tensors.at(0).buffer();
+        auto* dst_buffer = output_tensors.at(0).buffer();
 
-            auto& reader_runtime_args_by_core = GetRuntimeArgs(program, reader_kernel_id);
-            auto& writer_runtime_args_by_core = GetRuntimeArgs(program, writer_kernel_id);
-            for (const auto& core : cores) {
-                {
-                    auto& runtime_args = reader_runtime_args_by_core[core.x][core.y];
-                    runtime_args[0] = src_buffer->address();
-                }
-                {
-                    auto& runtime_args = writer_runtime_args_by_core[core.x][core.y];
-                    runtime_args[0] = dst_buffer->address();
-                }
+        auto& reader_runtime_args_by_core = GetRuntimeArgs(program, reader_kernel_id);
+        auto& writer_runtime_args_by_core = GetRuntimeArgs(program, writer_kernel_id);
+        for (uint32_t i = 0; i < ncores; ++i) {
+            const auto& core = cores[i];
+            {
+                auto& runtime_args = reader_runtime_args_by_core[core.x][core.y];
+                runtime_args[0] = src_buffer->address();
             }
-        };
+            {
+                auto& runtime_args = writer_runtime_args_by_core[core.x][core.y];
+                runtime_args[0] = dst_buffer->address();
+            }
+        }
+    };
 
     return {std::move(program), override_runtime_args_callback};
 }
 
 operation::ProgramWithCallbacks tilize_with_val_padding_multi_core_interleaved(
-    const Tensor& a, Tensor& output, const tt::tt_metal::PadValue pad_value) {
+    const Tensor& a,
+    Tensor& output,
+    const tt::tt_metal::PadValue pad_value,
+    const std::optional<CoreRangeSet>& sub_core_grids) {
     tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
 
     tt::DataFormat input_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(a.dtype());
@@ -533,13 +549,15 @@ operation::ProgramWithCallbacks tilize_with_val_padding_multi_core_interleaved(
 
     IDevice* device = a.device();
     CoreCoord grid_size = device->compute_with_storage_grid_size();
-
+    CoreRange default_cores({0, 0}, {grid_size.x - 1, grid_size.y - 1});
+    CoreRangeSet default_grid(default_cores);
+    CoreRangeSet available_grid = sub_core_grids.has_value() ? sub_core_grids.value() : default_grid;
     uint32_t num_blocks = output.physical_volume() / output.padded_shape()[-1] / TILE_HEIGHT;
     uint32_t num_tiles_per_row = output.padded_shape()[-1] / TILE_WIDTH;
 
     uint32_t num_tiles_per_col = output.padded_shape()[-2] / TILE_HEIGHT;
     auto [ncores, all_cores, core_range, core_range_cliff, nblocks_per_core, nblocks_per_core_cliff] =
-        ttnn::split_blocks_for_tilize(grid_size, num_blocks);
+        ttnn::split_blocks_for_tilize(available_grid, num_blocks);
 
     constexpr uint32_t threshold_row_block = 32;
     if (num_tiles_per_row > threshold_row_block) {
@@ -561,9 +579,10 @@ operation::ProgramWithCallbacks tilize_with_val_padding_multi_core_interleaved(
                  has_cliff_col,
                  full_cores_per_row,
                  full_cores_per_col] =
-                    ttnn::split_blocks_for_tilize_wh(grid_size, num_blocks_block, num_tiles_per_row, num_tiles_per_col);
+                    ttnn::split_blocks_for_tilize_wh(
+                        available_grid, num_blocks_block, num_tiles_per_row, num_tiles_per_col);
             if (ncores < ncores_block) {
-                return tilize_with_val_padding_multi_core_block_interleaved(a, output, pad_value);
+                return tilize_with_val_padding_multi_core_block_interleaved(a, output, pad_value, sub_core_grids);
             }
         }
     }
@@ -645,7 +664,7 @@ operation::ProgramWithCallbacks tilize_with_val_padding_multi_core_interleaved(
     uint32_t tile_start_id = 0;
     uint32_t row_start_id = 0;
 
-    const auto& cores = grid_to_cores(ncores, grid_size.x, grid_size.y, true);
+    const auto cores = corerange_to_cores(available_grid);
     for (uint32_t i = 0; i < ncores; ++i) {
         const auto& core = cores[i];
         const std::vector<BlockRep>& assignment = core_assignments.at(i);
@@ -696,29 +715,32 @@ operation::ProgramWithCallbacks tilize_with_val_padding_multi_core_interleaved(
         tile_start_id += num_tiles_per_core;
     }
 
-    auto override_runtime_args_callback =
-        [reader_kernel_id = unary_reader_kernel_id, writer_kernel_id = unary_writer_kernel_id, cores = cores](
-            const void* operation,
-            Program& program,
-            const std::vector<Tensor>& input_tensors,
-            const std::vector<std::optional<const Tensor>>& optional_tensors,
-            const std::vector<Tensor>& output_tensors) {
-            auto* src_buffer = input_tensors.at(0).buffer();
-            auto* dst_buffer = output_tensors.at(0).buffer();
+    auto override_runtime_args_callback = [reader_kernel_id = unary_reader_kernel_id,
+                                           writer_kernel_id = unary_writer_kernel_id,
+                                           cores = cores,
+                                           ncores = ncores](
+                                              const void* operation,
+                                              Program& program,
+                                              const std::vector<Tensor>& input_tensors,
+                                              const std::vector<std::optional<const Tensor>>& optional_tensors,
+                                              const std::vector<Tensor>& output_tensors) {
+        auto* src_buffer = input_tensors.at(0).buffer();
+        auto* dst_buffer = output_tensors.at(0).buffer();
 
-            auto& reader_runtime_args_by_core = GetRuntimeArgs(program, reader_kernel_id);
-            auto& writer_runtime_args_by_core = GetRuntimeArgs(program, writer_kernel_id);
-            for (const auto& core : cores) {
-                {
-                    auto& runtime_args = reader_runtime_args_by_core[core.x][core.y];
-                    runtime_args[0] = src_buffer->address();
-                }
-                {
-                    auto& runtime_args = writer_runtime_args_by_core[core.x][core.y];
-                    runtime_args[0] = dst_buffer->address();
-                }
+        auto& reader_runtime_args_by_core = GetRuntimeArgs(program, reader_kernel_id);
+        auto& writer_runtime_args_by_core = GetRuntimeArgs(program, writer_kernel_id);
+        for (uint32_t i = 0; i < ncores; ++i) {
+            const CoreCoord& core = cores[i];
+            {
+                auto& runtime_args = reader_runtime_args_by_core[core.x][core.y];
+                runtime_args[0] = src_buffer->address();
             }
-        };
+            {
+                auto& runtime_args = writer_runtime_args_by_core[core.x][core.y];
+                runtime_args[0] = dst_buffer->address();
+            }
+        }
+    };
 
     return {std::move(program), override_runtime_args_callback};
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_program_factory.hpp
@@ -8,18 +8,30 @@
 
 namespace ttnn::operations::data_movement::detail {
 tt::tt_metal::operation::ProgramWithCallbacks tilize_with_val_padding_single_core(
-    const Tensor& a, Tensor& output, tt::tt_metal::PadValue pad_value);
+    const Tensor& a,
+    Tensor& output,
+    tt::tt_metal::PadValue pad_value,
+    const std::optional<CoreRangeSet>& sub_core_grids);
 
 tt::tt_metal::operation::ProgramWithCallbacks tilize_with_val_padding_multi_core_interleaved(
-    const Tensor& a, Tensor& output, tt::tt_metal::PadValue pad_value);
+    const Tensor& a,
+    Tensor& output,
+    tt::tt_metal::PadValue pad_value,
+    const std::optional<CoreRangeSet>& sub_core_grids);
 
 tt::tt_metal::operation::ProgramWithCallbacks tilize_with_val_padding_multi_core_sharded(
     const Tensor& a, Tensor& output, tt::tt_metal::PadValue pad_value);
 
 tt::tt_metal::operation::ProgramWithCallbacks tilize_with_val_padding_multi_core_col_interleaved(
-    const Tensor& a, Tensor& output, tt::tt_metal::PadValue pad_value);
+    const Tensor& a,
+    Tensor& output,
+    tt::tt_metal::PadValue pad_value,
+    const std::optional<CoreRangeSet>& sub_core_grids);
 
 tt::tt_metal::operation::ProgramWithCallbacks tilize_with_val_padding_multi_core_block_interleaved(
-    const Tensor& a, Tensor& output, tt::tt_metal::PadValue pad_value);
+    const Tensor& a,
+    Tensor& output,
+    tt::tt_metal::PadValue pad_value,
+    const std::optional<CoreRangeSet>& sub_core_grids);
 
 }  // namespace ttnn::operations::data_movement::detail

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/tilize_with_val_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/tilize_with_val_padding.cpp
@@ -19,17 +19,19 @@ using BaseTilizeValType = std::function<ttnn::Tensor(const ttnn::Tensor&)>;
 using MassagedTilizeVal = MassagedOperation<ttnn::Tensor, const ttnn::Tensor&>;
 using MassagedTilizeValParams = MassagedOperationParams<ttnn::Tensor, const ttnn::Tensor&>;
 
-MassagedTilizeVal build_ndiml_tilize_val(BaseTilizeValType base_tilize) {
+MassagedTilizeVal build_ndiml_tilize_val(
+    BaseTilizeValType base_tilize, const std::optional<CoreRangeSet>& sub_core_grids) {
     auto original_shape = std::make_shared<Shape>();
     return MassagedTilizeVal(MassagedTilizeValParams{
         .predicate = [](const ttnn::Tensor& input_tensor) -> bool { return input_tensor.logical_shape().rank() > 4; },
         .pre_transform = [=](const ttnn::Tensor& input_tensor) -> OwnedTilizeValArgs {
             *original_shape = input_tensor.logical_shape();
-            ttnn::Tensor squeezed_tensor = squeeze_from_ND_to_4D(input_tensor);
+            ttnn::Tensor squeezed_tensor = squeeze_from_ND_to_4D(input_tensor, sub_core_grids);
             return std::make_tuple(squeezed_tensor);
         },
         .post_transform = [=](const ttnn::Tensor& output) -> ttnn::Tensor {
-            auto unsqueezed_tensor = ttnn::reshape(output, *original_shape);
+            auto unsqueezed_tensor = ttnn::reshape(
+                output, *original_shape, std::nullopt, std::nullopt, TileReshapeMapMode::CACHE, sub_core_grids);
             return unsqueezed_tensor;
         },
         .operation = std::move(base_tilize)});
@@ -57,7 +59,8 @@ ttnn::Tensor ExecuteTilizeWithValPadding::invoke(
     const PadValue pad_value,
     const std::optional<MemoryConfig>& memory_config,
     std::optional<DataType> output_dtype,
-    bool use_multicore) {
+    bool use_multicore,
+    const std::optional<CoreRangeSet>& sub_core_grids) {
     if (input_tensor.layout() == Layout::TILE) {
         return input_tensor;
     }
@@ -98,13 +101,14 @@ ttnn::Tensor ExecuteTilizeWithValPadding::invoke(
                 output_dtype.value_or(input_tensor.dtype()),
                 use_multicore,
                 enough_space_width,
-                enough_space_height},
+                enough_space_height,
+                sub_core_grids},
             {input_tensor},
             {},
             {})[0];
     };
 
-    return build_ndiml_tilize_val(base_tilize)(input_tensor);
+    return build_ndiml_tilize_val(base_tilize, sub_core_grids)(input_tensor);
 }
 
 ttnn::Tensor ExecuteTilizeWithValPadding::invoke(
@@ -113,7 +117,8 @@ ttnn::Tensor ExecuteTilizeWithValPadding::invoke(
     const PadValue pad_value,
     const std::optional<MemoryConfig>& memory_config,
     std::optional<DataType> output_dtype,
-    bool use_multicore) {
+    bool use_multicore,
+    const std::optional<CoreRangeSet>& sub_core_grids) {
     // Handle empty tensors - no tiling needed for tensors with no data
     if (input_tensor.physical_volume() == 0) {
         // Create output tensor with same properties
@@ -127,14 +132,21 @@ ttnn::Tensor ExecuteTilizeWithValPadding::invoke(
     }
 
     return invoke(
-        input_tensor, ttnn::Shape{output_padded_shape}, pad_value, memory_config, output_dtype, use_multicore);
+        input_tensor,
+        ttnn::Shape{output_padded_shape},
+        pad_value,
+        memory_config,
+        output_dtype,
+        use_multicore,
+        sub_core_grids);
 }
 
 ttnn::Tensor ExecuteTilizeWithZeroPadding::invoke(
     const ttnn::Tensor& input_tensor,
     const std::optional<MemoryConfig>& memory_config,
     std::optional<DataType> output_dtype,
-    bool use_multicore) {
+    bool use_multicore,
+    const std::optional<CoreRangeSet>& sub_core_grids) {
     using namespace tt::constants;
     auto padded_shape = input_tensor.padded_shape();
 
@@ -163,7 +175,7 @@ ttnn::Tensor ExecuteTilizeWithZeroPadding::invoke(
         pad_value = (uint32_t)0;
     }
     return ExecuteTilizeWithValPadding::invoke(
-        input_tensor, padded_shape, pad_value, memory_config, output_dtype, use_multicore);
+        input_tensor, padded_shape, pad_value, memory_config, output_dtype, use_multicore, sub_core_grids);
 }
 
 }  // namespace ttnn::operations::data_movement

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/tilize_with_val_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/tilize_with_val_padding.cpp
@@ -31,7 +31,12 @@ MassagedTilizeVal build_ndiml_tilize_val(
         },
         .post_transform = [=](const ttnn::Tensor& output) -> ttnn::Tensor {
             auto unsqueezed_tensor = ttnn::reshape(
-                output, *original_shape, std::nullopt, std::nullopt, TileReshapeMapMode::CACHE, sub_core_grids);
+                output,
+                *original_shape,
+                std::nullopt /*Memory Config*/,
+                std::nullopt /*pad value*/,
+                TileReshapeMapMode::CACHE,
+                sub_core_grids);
             return unsqueezed_tensor;
         },
         .operation = std::move(base_tilize)});

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/tilize_with_val_padding.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/tilize_with_val_padding.hpp
@@ -20,7 +20,8 @@ struct ExecuteTilizeWithValPadding {
         tt::tt_metal::PadValue pad_value,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         std::optional<DataType> output_dtype = std::nullopt,
-        bool use_multicore = true);
+        bool use_multicore = true,
+        const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
 
     static ttnn::Tensor invoke(
         const ttnn::Tensor& input_tensor,
@@ -28,7 +29,8 @@ struct ExecuteTilizeWithValPadding {
         tt::tt_metal::PadValue pad_value,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         std::optional<DataType> output_dtype = std::nullopt,
-        bool use_multicore = true);
+        bool use_multicore = true,
+        const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
 };
 
 struct ExecuteTilizeWithZeroPadding {
@@ -36,7 +38,8 @@ struct ExecuteTilizeWithZeroPadding {
         const ttnn::Tensor& input_tensor,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         std::optional<DataType> output_dtype = std::nullopt,
-        bool use_multicore = true);
+        bool use_multicore = true,
+        const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
 };
 
 }  // namespace operations::data_movement

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/tilize_with_val_padding_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/tilize_with_val_padding_pybind.cpp
@@ -91,12 +91,16 @@ void bind_tilize_with_zero_padding(py::module& module) {
                const ttnn::Tensor& input_tensor,
                const std::optional<MemoryConfig>& memory_config,
                std::optional<DataType> output_dtype,
-               bool use_multicore) { return self(input_tensor, memory_config, output_dtype, use_multicore); },
+               bool use_multicore,
+               const std::optional<CoreRangeSet>& sub_core_grids) {
+                return self(input_tensor, memory_config, output_dtype, use_multicore, sub_core_grids);
+            },
             py::arg("input_tensor"),
             py::kw_only(),
             py::arg("memory_config") = std::nullopt,
             py::arg("output_dtype") = std::nullopt,
-            py::arg("use_multicore") = true});
+            py::arg("use_multicore") = true,
+            py::arg("sub_core_grids") = std::nullopt});
 }
 
 }  // namespace ttnn::operations::data_movement::detail

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_op.cpp
@@ -175,7 +175,7 @@ operation::ProgramWithCallbacks UntilizeWithUnpadding::create_program(
     const auto& input_tensor_a = input_tensors.at(0);
     auto& output_tensor = output_tensors.at(0);
     if (input_tensors.at(0).memory_config().is_sharded()) {
-        TT_FATAL(!this->sub_core_grids.has_value(), "Sharded tilize does not support sub core grid specification");
+        TT_FATAL(!this->sub_core_grids.has_value(), "Sharded untilize does not support sub core grid specification");
         return detail::untilize_with_unpadding_multi_core_sharded(
             input_tensor_a, output_tensor, this->use_pack_untilize, this->fp32_dest_acc_en);
     }

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_op.cpp
@@ -175,19 +175,20 @@ operation::ProgramWithCallbacks UntilizeWithUnpadding::create_program(
     const auto& input_tensor_a = input_tensors.at(0);
     auto& output_tensor = output_tensors.at(0);
     if (input_tensors.at(0).memory_config().is_sharded()) {
+        TT_FATAL(!this->sub_core_grids.has_value(), "Sharded tilize does not support sub core grid specification");
         return detail::untilize_with_unpadding_multi_core_sharded(
             input_tensor_a, output_tensor, this->use_pack_untilize, this->fp32_dest_acc_en);
     }
     if (!this->use_multicore) {
         return detail::untilize_with_unpadding_single_core(
-            input_tensor_a, output_tensor, this->use_pack_untilize, this->fp32_dest_acc_en);
+            input_tensor_a, output_tensor, this->use_pack_untilize, this->fp32_dest_acc_en, this->sub_core_grids);
     }
     if (!this->enough_space_height) {
         return detail::untilize_with_unpadding_multi_core_block_interleaved(
-            input_tensor_a, output_tensor, this->use_pack_untilize, this->fp32_dest_acc_en);
+            input_tensor_a, output_tensor, this->use_pack_untilize, this->fp32_dest_acc_en, this->sub_core_grids);
     }
     return detail::untilize_with_unpadding_multi_core_interleaved(
-        input_tensor_a, output_tensor, this->use_pack_untilize, this->fp32_dest_acc_en);
+        input_tensor_a, output_tensor, this->use_pack_untilize, this->fp32_dest_acc_en, this->sub_core_grids);
 }
 
 }  // namespace ttnn::operations::data_movement

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_op.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_op.hpp
@@ -19,6 +19,7 @@ struct UntilizeWithUnpadding {
     const bool fp32_dest_acc_en;
     const bool enough_space_width;
     const bool enough_space_height;
+    const std::optional<CoreRangeSet> sub_core_grids;
 
     void validate(const std::vector<Tensor>& input_tensors) const;
     std::vector<ttnn::TensorSpec> compute_output_specs(const std::vector<Tensor>& input_tensors) const;

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_program_factory.cpp
@@ -22,13 +22,18 @@ using namespace tt::tt_metal;
 namespace ttnn::operations::data_movement::detail {
 
 operation::ProgramWithCallbacks untilize_with_unpadding_single_core(
-    const Tensor& a, Tensor& output, bool use_pack_untilize, bool fp32_dest_acc_en) {
+    const Tensor& a,
+    Tensor& output,
+    bool use_pack_untilize,
+    bool fp32_dest_acc_en,
+    const std::optional<CoreRangeSet>& sub_core_grids) {
     const auto& input_shape = a.padded_shape();
     const auto& output_shape = output.padded_shape();
 
     tt::tt_metal::Program program{};
 
-    CoreRange core({0, 0}, {0, 0});
+    CoreRange default_core({0, 0}, {0, 0});
+    CoreRange core = sub_core_grids.has_value() ? corerange_to_cores(sub_core_grids.value()).at(0) : default_core;
 
     tt::DataFormat input_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(a.dtype());
     uint32_t input_single_tile_size = tt::tile_size(input_cb_data_format);
@@ -185,34 +190,37 @@ operation::ProgramWithCallbacks untilize_with_unpadding_single_core(
 
     tt::tt_metal::SetRuntimeArgs(program, unary_writer_kernel_id, core, writer_kernel_args);
 
-    auto override_runtime_args_callback = [reader_kernel_id = unary_reader_kernel_id,
-                                           writer_kernel_id = unary_writer_kernel_id](
-                                              const void* operation,
-                                              Program& program,
-                                              const std::vector<Tensor>& input_tensors,
-                                              const std::vector<std::optional<const Tensor>>& optional_tensors,
-                                              const std::vector<Tensor>& output_tensors) {
-        auto* src_buffer = input_tensors.at(0).buffer();
-        auto* dst_buffer = output_tensors.at(0).buffer();
+    auto override_runtime_args_callback =
+        [reader_kernel_id = unary_reader_kernel_id, writer_kernel_id = unary_writer_kernel_id, core = core](
+            const void* operation,
+            Program& program,
+            const std::vector<Tensor>& input_tensors,
+            const std::vector<std::optional<const Tensor>>& optional_tensors,
+            const std::vector<Tensor>& output_tensors) {
+            auto* src_buffer = input_tensors.at(0).buffer();
+            auto* dst_buffer = output_tensors.at(0).buffer();
+            CoreCoord core_0 = corerange_to_cores(core).at(0);
+            {
+                auto& runtime_args = GetRuntimeArgs(program, reader_kernel_id, core_0);
+                runtime_args[0] = src_buffer->address();
+            }
 
-        CoreCoord core = {0, 0};
-
-        {
-            auto& runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
-            runtime_args[0] = src_buffer->address();
-        }
-
-        {
-            auto& runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
-            runtime_args[0] = dst_buffer->address();
-        }
-    };
+            {
+                auto& runtime_args = GetRuntimeArgs(program, writer_kernel_id, core_0);
+                runtime_args[0] = dst_buffer->address();
+            }
+        };
 
     return {std::move(program), override_runtime_args_callback};
 }
 
 operation::ProgramWithCallbacks untilize_with_unpadding_multi_core_block_interleaved(
-    const Tensor& a, Tensor& output, bool use_pack_untilize, bool fp32_dest_acc_en) {
+    const Tensor& a,
+    Tensor& output,
+    bool use_pack_untilize,
+    bool fp32_dest_acc_en,
+    const std::optional<CoreRangeSet>& sub_core_grids) {
+    // TODO
     tt::tt_metal::Program program{};
 
     tt::DataFormat input_cb_data_format = datatype_to_dataformat_converter(a.dtype());
@@ -225,6 +233,9 @@ operation::ProgramWithCallbacks untilize_with_unpadding_multi_core_block_interle
 
     IDevice* device = a.device();
     CoreCoord grid_size = device->compute_with_storage_grid_size();
+    CoreRange default_cores({0, 0}, {grid_size.x - 1, grid_size.y - 1});
+    CoreRangeSet default_grid(default_cores);
+    CoreRangeSet available_grid = sub_core_grids.has_value() ? sub_core_grids.value() : default_grid;
 
     uint32_t num_tiles_per_row = a.padded_shape()[-1] / TILE_WIDTH;
     uint32_t num_tiles_per_col = a.padded_shape()[-2] / TILE_HEIGHT;
@@ -246,7 +257,7 @@ operation::ProgramWithCallbacks untilize_with_unpadding_multi_core_block_interle
          has_cliff_col,
          full_cores_per_row,
          full_cores_per_col] =
-            ttnn::split_blocks_for_tilize_wh(grid_size, num_blocks, num_tiles_per_row, num_tiles_per_col);
+            ttnn::split_blocks_for_tilize_wh(available_grid, num_blocks, num_tiles_per_row, num_tiles_per_col);
 
     uint32_t total_tiles_per_row =
         (full_cores_per_row * single_block_size) + (has_cliff_row * single_block_size_cliff_row);
@@ -413,7 +424,7 @@ operation::ProgramWithCallbacks untilize_with_unpadding_multi_core_block_interle
     }
 
     // RUNTIME ARGS
-    const auto& cores = grid_to_cores(ncores, grid_size.x, grid_size.y, true);
+    const auto& cores = corerange_to_cores(available_grid);
     uint32_t start_row_id = 0;
     uint32_t start_column_id = 0;
     uint32_t tile_start_id = 0;
@@ -476,36 +487,43 @@ operation::ProgramWithCallbacks untilize_with_unpadding_multi_core_block_interle
         }
     }
 
-    auto override_runtime_args_callback =
-        [reader_kernel_id = unary_reader_kernel_id, writer_kernel_id = unary_writer_kernel_id, cores = cores](
-            const void* operation,
-            Program& program,
-            const std::vector<Tensor>& input_tensors,
-            const std::vector<std::optional<const Tensor>>& optional_tensors,
-            const std::vector<Tensor>& output_tensors) {
-            auto* src_buffer = input_tensors.at(0).buffer();
-            auto* dst_buffer = output_tensors.at(0).buffer();
+    auto override_runtime_args_callback = [reader_kernel_id = unary_reader_kernel_id,
+                                           writer_kernel_id = unary_writer_kernel_id,
+                                           cores = cores,
+                                           ncores = ncores](
+                                              const void* operation,
+                                              Program& program,
+                                              const std::vector<Tensor>& input_tensors,
+                                              const std::vector<std::optional<const Tensor>>& optional_tensors,
+                                              const std::vector<Tensor>& output_tensors) {
+        auto* src_buffer = input_tensors.at(0).buffer();
+        auto* dst_buffer = output_tensors.at(0).buffer();
 
-            auto& reader_runtime_args_by_core = GetRuntimeArgs(program, reader_kernel_id);
-            auto& writer_runtime_args_by_core = GetRuntimeArgs(program, writer_kernel_id);
+        auto& reader_runtime_args_by_core = GetRuntimeArgs(program, reader_kernel_id);
+        auto& writer_runtime_args_by_core = GetRuntimeArgs(program, writer_kernel_id);
 
-            for (const auto& core : cores) {
-                {
-                    auto& runtime_args = reader_runtime_args_by_core[core.x][core.y];
-                    runtime_args[0] = src_buffer->address();
-                }
-                {
-                    auto& runtime_args = writer_runtime_args_by_core[core.x][core.y];
-                    runtime_args[0] = dst_buffer->address();
-                }
+        for (uint32_t i = 0; i < ncores; ++i) {
+            const auto& core = cores[i];
+            {
+                auto& runtime_args = reader_runtime_args_by_core[core.x][core.y];
+                runtime_args[0] = src_buffer->address();
             }
-        };
+            {
+                auto& runtime_args = writer_runtime_args_by_core[core.x][core.y];
+                runtime_args[0] = dst_buffer->address();
+            }
+        }
+    };
 
     return {std::move(program), override_runtime_args_callback};
 }
 
 operation::ProgramWithCallbacks untilize_with_unpadding_multi_core_col_interleaved(
-    const Tensor& a, Tensor& output, bool use_pack_untilize, bool fp32_dest_acc_en) {
+    const Tensor& a,
+    Tensor& output,
+    bool use_pack_untilize,
+    bool fp32_dest_acc_en,
+    const std::optional<CoreRangeSet>& sub_core_grids) {
     tt::tt_metal::Program program{};
 
     tt::DataFormat input_cb_data_format = datatype_to_dataformat_converter(a.dtype());
@@ -518,13 +536,16 @@ operation::ProgramWithCallbacks untilize_with_unpadding_multi_core_col_interleav
 
     IDevice* device = a.device();
     CoreCoord grid_size = device->compute_with_storage_grid_size();
+    CoreRange default_cores({0, 0}, {grid_size.x - 1, grid_size.y - 1});
+    CoreRangeSet default_grid(default_cores);
+    CoreRangeSet available_grid = sub_core_grids.has_value() ? sub_core_grids.value() : default_grid;
 
     uint32_t num_blocks = input_shape[-1] / TILE_WIDTH;
     uint32_t num_tiles_per_row = a.padded_shape()[-1] / TILE_WIDTH;
     uint32_t num_tiles_per_col = a.padded_shape()[-2] / TILE_HEIGHT;
 
     auto [ncores, all_cores, core_range, core_range_cliff, nblocks_per_core, nblocks_per_core_cliff] =
-        ttnn::split_blocks_for_tilize(grid_size, num_blocks);
+        ttnn::split_blocks_for_tilize(available_grid, num_blocks);
 
     bool has_cliff = !core_range_cliff.empty();
 
@@ -601,7 +622,7 @@ operation::ProgramWithCallbacks untilize_with_unpadding_multi_core_col_interleav
     }
 
     // RUNTIME ARGS
-    const auto& cores = grid_to_cores(ncores, grid_size.x, grid_size.y, true);
+    const auto cores = corerange_to_cores(available_grid);
     uint32_t number_blocks_per_core;
     for (uint32_t i = 0; i < ncores; ++i) {
         const auto& core = cores[i];
@@ -628,36 +649,44 @@ operation::ProgramWithCallbacks untilize_with_unpadding_multi_core_col_interleav
         SetRuntimeArgs(program, unary_writer_kernel_id, core, writer_rt_args);
     }
 
-    auto override_runtime_args_callback =
-        [reader_kernel_id = unary_reader_kernel_id, writer_kernel_id = unary_writer_kernel_id, cores = cores](
-            const void* operation,
-            Program& program,
-            const std::vector<Tensor>& input_tensors,
-            const std::vector<std::optional<const Tensor>>& optional_tensors,
-            const std::vector<Tensor>& output_tensors) {
-            auto* src_buffer = input_tensors.at(0).buffer();
-            auto* dst_buffer = output_tensors.at(0).buffer();
+    auto override_runtime_args_callback = [reader_kernel_id = unary_reader_kernel_id,
+                                           writer_kernel_id = unary_writer_kernel_id,
+                                           cores = cores,
+                                           ncores = ncores](
+                                              const void* operation,
+                                              Program& program,
+                                              const std::vector<Tensor>& input_tensors,
+                                              const std::vector<std::optional<const Tensor>>& optional_tensors,
+                                              const std::vector<Tensor>& output_tensors) {
+        auto* src_buffer = input_tensors.at(0).buffer();
+        auto* dst_buffer = output_tensors.at(0).buffer();
 
-            auto& reader_runtime_args_by_core = GetRuntimeArgs(program, reader_kernel_id);
-            auto& writer_runtime_args_by_core = GetRuntimeArgs(program, writer_kernel_id);
+        auto& reader_runtime_args_by_core = GetRuntimeArgs(program, reader_kernel_id);
+        auto& writer_runtime_args_by_core = GetRuntimeArgs(program, writer_kernel_id);
 
-            for (const auto& core : cores) {
-                {
-                    auto& runtime_args = reader_runtime_args_by_core[core.x][core.y];
-                    runtime_args[0] = src_buffer->address();
-                }
-                {
-                    auto& runtime_args = writer_runtime_args_by_core[core.x][core.y];
-                    runtime_args[0] = dst_buffer->address();
-                }
+        for (uint32_t i = 0; i < ncores; ++i) {
+            const CoreCoord& core = cores[i];
+            {
+                auto& runtime_args = reader_runtime_args_by_core[core.x][core.y];
+                runtime_args[0] = src_buffer->address();
             }
-        };
+            {
+                auto& runtime_args = writer_runtime_args_by_core[core.x][core.y];
+                runtime_args[0] = dst_buffer->address();
+            }
+        }
+    };
 
     return {std::move(program), override_runtime_args_callback};
 }
 
 operation::ProgramWithCallbacks untilize_with_unpadding_multi_core_interleaved(
-    const Tensor& a, Tensor& output, bool use_pack_untilize, bool fp32_dest_acc_en) {
+    const Tensor& a,
+    Tensor& output,
+    bool use_pack_untilize,
+    bool fp32_dest_acc_en,
+    const std::optional<CoreRangeSet>& sub_core_grids) {
+    // TODO
     tt::tt_metal::Program program{};
 
     tt::DataFormat input_cb_data_format = datatype_to_dataformat_converter(a.dtype());
@@ -670,6 +699,9 @@ operation::ProgramWithCallbacks untilize_with_unpadding_multi_core_interleaved(
 
     IDevice* device = a.device();
     CoreCoord grid_size = device->compute_with_storage_grid_size();
+    CoreRange default_cores({0, 0}, {grid_size.x - 1, grid_size.y - 1});
+    CoreRangeSet default_grid(default_cores);
+    CoreRangeSet available_grid = sub_core_grids.has_value() ? sub_core_grids.value() : default_grid;
 
     uint32_t num_blocks = input_shape[-1] == 0 ? 0 : a.physical_volume() / input_shape[-1] / TILE_HEIGHT;
     uint32_t num_tiles_per_row = a.padded_shape()[-1] / TILE_WIDTH;
@@ -677,7 +709,7 @@ operation::ProgramWithCallbacks untilize_with_unpadding_multi_core_interleaved(
     uint32_t num_tiles_per_col = a.padded_shape()[-2] / TILE_HEIGHT;
 
     auto [ncores, all_cores, core_range, core_range_cliff, nblocks_per_core, nblocks_per_core_cliff] =
-        ttnn::split_blocks_for_tilize(grid_size, num_blocks);
+        ttnn::split_blocks_for_tilize(available_grid, num_blocks);
 
     constexpr uint32_t threshold_row_block = 32;
     if (num_tiles_per_row > threshold_row_block) {
@@ -699,10 +731,11 @@ operation::ProgramWithCallbacks untilize_with_unpadding_multi_core_interleaved(
                  has_cliff_col,
                  full_cores_per_row,
                  full_cores_per_col] =
-                    ttnn::split_blocks_for_tilize_wh(grid_size, num_blocks_block, num_tiles_per_row, num_tiles_per_col);
+                    ttnn::split_blocks_for_tilize_wh(
+                        available_grid, num_blocks_block, num_tiles_per_row, num_tiles_per_col);
             if (ncores < ncores_block) {
                 return untilize_with_unpadding_multi_core_block_interleaved(
-                    a, output, use_pack_untilize, fp32_dest_acc_en);
+                    a, output, use_pack_untilize, fp32_dest_acc_en, sub_core_grids);
             }
         }
     }
@@ -794,7 +827,7 @@ operation::ProgramWithCallbacks untilize_with_unpadding_multi_core_interleaved(
     uint32_t tile_start_id = 0;
     uint32_t row_start_id = 0;
 
-    const auto& cores = grid_to_cores(ncores, grid_size.x, grid_size.y, true);
+    const auto& cores = corerange_to_cores(available_grid);
     for (uint32_t i = 0; i < ncores; ++i) {
         const auto& core = cores[i];
         const std::vector<BlockRep>& assignment = core_assignments.at(i);
@@ -845,30 +878,33 @@ operation::ProgramWithCallbacks untilize_with_unpadding_multi_core_interleaved(
         tile_start_id += num_tiles_per_core;
     }
 
-    auto override_runtime_args_callback =
-        [reader_kernel_id = unary_reader_kernel_id, writer_kernel_id = unary_writer_kernel_id, cores = cores](
-            const void* operation,
-            Program& program,
-            const std::vector<Tensor>& input_tensors,
-            const std::vector<std::optional<const Tensor>>& optional_tensors,
-            const std::vector<Tensor>& output_tensors) {
-            auto* src_buffer = input_tensors.at(0).buffer();
-            auto* dst_buffer = output_tensors.at(0).buffer();
+    auto override_runtime_args_callback = [reader_kernel_id = unary_reader_kernel_id,
+                                           writer_kernel_id = unary_writer_kernel_id,
+                                           cores = cores,
+                                           ncores = ncores](
+                                              const void* operation,
+                                              Program& program,
+                                              const std::vector<Tensor>& input_tensors,
+                                              const std::vector<std::optional<const Tensor>>& optional_tensors,
+                                              const std::vector<Tensor>& output_tensors) {
+        auto* src_buffer = input_tensors.at(0).buffer();
+        auto* dst_buffer = output_tensors.at(0).buffer();
 
-            auto& reader_runtime_args_by_core = GetRuntimeArgs(program, reader_kernel_id);
-            auto& writer_runtime_args_by_core = GetRuntimeArgs(program, writer_kernel_id);
+        auto& reader_runtime_args_by_core = GetRuntimeArgs(program, reader_kernel_id);
+        auto& writer_runtime_args_by_core = GetRuntimeArgs(program, writer_kernel_id);
 
-            for (const auto& core : cores) {
-                {
-                    auto& runtime_args = reader_runtime_args_by_core[core.x][core.y];
-                    runtime_args[0] = src_buffer->address();
-                }
-                {
-                    auto& runtime_args = writer_runtime_args_by_core[core.x][core.y];
-                    runtime_args[0] = dst_buffer->address();
-                }
+        for (uint32_t i = 0; i < ncores; ++i) {
+            const CoreCoord& core = cores[i];
+            {
+                auto& runtime_args = reader_runtime_args_by_core[core.x][core.y];
+                runtime_args[0] = src_buffer->address();
             }
-        };
+            {
+                auto& runtime_args = writer_runtime_args_by_core[core.x][core.y];
+                runtime_args[0] = dst_buffer->address();
+            }
+        }
+    };
 
     return {std::move(program), override_runtime_args_callback};
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_program_factory.cpp
@@ -220,7 +220,6 @@ operation::ProgramWithCallbacks untilize_with_unpadding_multi_core_block_interle
     bool use_pack_untilize,
     bool fp32_dest_acc_en,
     const std::optional<CoreRangeSet>& sub_core_grids) {
-    // TODO
     tt::tt_metal::Program program{};
 
     tt::DataFormat input_cb_data_format = datatype_to_dataformat_converter(a.dtype());
@@ -686,7 +685,6 @@ operation::ProgramWithCallbacks untilize_with_unpadding_multi_core_interleaved(
     bool use_pack_untilize,
     bool fp32_dest_acc_en,
     const std::optional<CoreRangeSet>& sub_core_grids) {
-    // TODO
     tt::tt_metal::Program program{};
 
     tt::DataFormat input_cb_data_format = datatype_to_dataformat_converter(a.dtype());

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_program_factory.hpp
@@ -9,19 +9,35 @@
 namespace ttnn::operations::data_movement::detail {
 
 tt::tt_metal::operation::ProgramWithCallbacks untilize_with_unpadding_single_core(
-    const Tensor& a, Tensor& output, bool use_pack_untilize, bool fp32_dest_acc_en);
+    const Tensor& a,
+    Tensor& output,
+    bool use_pack_untilize,
+    bool fp32_dest_acc_en,
+    const std::optional<CoreRangeSet>& sub_core_grids);
 
 tt::tt_metal::operation::ProgramWithCallbacks untilize_with_unpadding_multi_core_interleaved(
-    const Tensor& a, Tensor& output, bool use_pack_untilize, bool fp32_dest_acc_en);
+    const Tensor& a,
+    Tensor& output,
+    bool use_pack_untilize,
+    bool fp32_dest_acc_en,
+    const std::optional<CoreRangeSet>& sub_core_grids);
 
 // This purely supports input block shard -> output interleaved for now
 tt::tt_metal::operation::ProgramWithCallbacks untilize_with_unpadding_multi_core_sharded(
     const Tensor& a, Tensor& output, bool use_pack_untilize, bool fp32_dest_acc_en);
 
 tt::tt_metal::operation::ProgramWithCallbacks untilize_with_unpadding_multi_core_col_interleaved(
-    const Tensor& a, Tensor& output, bool use_pack_untilize, bool fp32_dest_acc_en);
+    const Tensor& a,
+    Tensor& output,
+    bool use_pack_untilize,
+    bool fp32_dest_acc_en,
+    const std::optional<CoreRangeSet>& sub_core_grids);
 
 tt::tt_metal::operation::ProgramWithCallbacks untilize_with_unpadding_multi_core_block_interleaved(
-    const Tensor& a, Tensor& output, bool use_pack_untilize, bool fp32_dest_acc_en);
+    const Tensor& a,
+    Tensor& output,
+    bool use_pack_untilize,
+    bool fp32_dest_acc_en,
+    const std::optional<CoreRangeSet>& sub_core_grids);
 
 }  // namespace ttnn::operations::data_movement::detail

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/untilize_with_unpadding.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/untilize_with_unpadding.cpp
@@ -50,7 +50,12 @@ MassagedUntilizeVal build_ndiml_untilize_val(
         },
         .post_transform = [=](const ttnn::Tensor& output) -> ttnn::Tensor {
             auto unsqueezed_tensor = ttnn::reshape(
-                output, *original_shape, std::nullopt, std::nullopt, TileReshapeMapMode::CACHE, sub_core_grids);
+                output,
+                *original_shape,
+                std::nullopt,              /*Memory Config*/
+                std::nullopt,              /*Pad value*/
+                TileReshapeMapMode::CACHE, /*Reshape map mode*/
+                sub_core_grids);
             return unsqueezed_tensor;
         },
         .operation = std::move(base_untilize)});

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/untilize_with_unpadding.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/untilize_with_unpadding.cpp
@@ -37,18 +37,20 @@ using BaseUntilizeValType = std::function<ttnn::Tensor(const ttnn::Tensor&)>;
 using MassagedUntilizeVal = MassagedOperation<ttnn::Tensor, const ttnn::Tensor&>;
 using MassagedUntilizeValParams = MassagedOperationParams<ttnn::Tensor, const ttnn::Tensor&>;
 
-MassagedUntilizeVal build_ndiml_untilize_val(BaseUntilizeValType base_untilize) {
+MassagedUntilizeVal build_ndiml_untilize_val(
+    BaseUntilizeValType base_untilize, const std::optional<CoreRangeSet>& sub_core_grids) {
     auto original_shape = std::make_shared<Shape>();
 
     return MassagedUntilizeVal(MassagedUntilizeValParams{
         .predicate = [](const ttnn::Tensor& input_tensor) -> bool { return input_tensor.logical_shape().rank() > 4; },
         .pre_transform = [=](const ttnn::Tensor& input_tensor) -> OwnedUntilizeValArgs {
             *original_shape = input_tensor.logical_shape();
-            ttnn::Tensor squeezed_tensor = squeeze_from_ND_to_4D(input_tensor);
+            ttnn::Tensor squeezed_tensor = squeeze_from_ND_to_4D(input_tensor, sub_core_grids);
             return std::make_tuple(squeezed_tensor);
         },
         .post_transform = [=](const ttnn::Tensor& output) -> ttnn::Tensor {
-            auto unsqueezed_tensor = ttnn::reshape(output, *original_shape);
+            auto unsqueezed_tensor = ttnn::reshape(
+                output, *original_shape, std::nullopt, std::nullopt, TileReshapeMapMode::CACHE, sub_core_grids);
             return unsqueezed_tensor;
         },
         .operation = std::move(base_untilize)});
@@ -59,7 +61,8 @@ ttnn::Tensor ExecuteUntilizeWithUnpadding::invoke(
     const ttnn::Shape& output_tensor_end,
     const std::optional<MemoryConfig>& memory_config,
     bool use_multicore,
-    bool use_pack_untilize) {
+    bool use_pack_untilize,
+    const std::optional<CoreRangeSet>& sub_core_grids) {
     bool fp32_dest_acc_en = input_tensor.dtype() == DataType::UINT32 || input_tensor.dtype() == DataType::FLOAT32;
 
     ttnn::SmallVector<uint32_t> output_end_vector;
@@ -98,13 +101,14 @@ ttnn::Tensor ExecuteUntilizeWithUnpadding::invoke(
                                   use_pack_untilize,
                                   fp32_dest_acc_en,
                                   enough_space_width,
-                                  enough_space_height},
+                                  enough_space_height,
+                                  sub_core_grids},
             {input_tensor},
             {},
             {})[0];
     };
 
-    return build_ndiml_untilize_val(base_untilize)(input_tensor);
+    return build_ndiml_untilize_val(base_untilize, sub_core_grids)(input_tensor);
 }
 
 }  // namespace ttnn::operations::data_movement

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/untilize_with_unpadding.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/untilize_with_unpadding.hpp
@@ -15,7 +15,8 @@ struct ExecuteUntilizeWithUnpadding {
         const ttnn::Shape& output_tensor_end,
         const std::optional<MemoryConfig>& memory_config,
         bool use_multicore = true,
-        bool use_pack_untilize = true);
+        bool use_pack_untilize = true,
+        const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
 };
 
 }  // namespace operations::data_movement

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/untilize_with_unpadding_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/untilize_with_unpadding_pybind.cpp
@@ -46,15 +46,18 @@ void bind_untilize_with_unpadding(py::module& module) {
                const ttnn::Shape& output_tensor_end,
                const std::optional<MemoryConfig>& memory_config,
                bool use_multicore,
-               bool use_pack_untilize) {
-                return self(input_tensor, output_tensor_end, memory_config, use_multicore, use_pack_untilize);
+               bool use_pack_untilize,
+               const std::optional<CoreRangeSet>& sub_core_grids) {
+                return self(
+                    input_tensor, output_tensor_end, memory_config, use_multicore, use_pack_untilize, sub_core_grids);
             },
             py::arg("input_tensor"),
             py::arg("output_tensor_end"),
             py::kw_only(),
             py::arg("memory_config") = std::nullopt,
             py::arg("use_multicore") = true,
-            py::arg("use_pack_untilize") = true});
+            py::arg("use_pack_untilize") = true,
+            py::arg("sub_core_grids") = std::nullopt});
 }
 
 }  // namespace ttnn::operations::data_movement::detail


### PR DESCRIPTION
### Ticket
Adds the sub grid support as required by Llama 70b

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/20148754819
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/20148773693
- [x] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/20148817006
- [x] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/20148838220