### PR TITLE
[Reduce APC] Move N150 profiler to L2Nightly

### DIFF
--- a/.github/workflows/all-post-commit-workflows.yaml
+++ b/.github/workflows/all-post-commit-workflows.yaml
@@ -174,7 +174,6 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          { arch: wormhole_b0, runner-label: N150 },
           { arch: wormhole_b0, runner-label: N300 },
         ]
     if: ${{ needs.find-changed-files.outputs.test-everything == 'true' }}

--- a/.github/workflows/tt-metal-l2-nightly.yaml
+++ b/.github/workflows/tt-metal-l2-nightly.yaml
@@ -224,3 +224,21 @@ jobs:
       docker-image: ${{ needs.build-artifact.outputs.basic-ttnn-runtime-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+  run-profiler-regression:
+    needs: [build-artifact, find-changed-files]
+    if: ${{ github.event_name == 'schedule' || inputs.run_bos_tests }}
+    needs: build-artifact
+    strategy:
+      fail-fast: false
+      matrix:
+        test-group: [
+          { arch: wormhole_b0, runner-label: N150 },
+        ]
+    uses: ./.github/workflows/run-profiler-regression.yaml
+    secrets: inherit
+    with:
+      arch: ${{ matrix.test-group.arch}}
+      runner-label: ${{ matrix.test-group.runner-label}}
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}

--- a/.github/workflows/tt-metal-l2-nightly.yaml
+++ b/.github/workflows/tt-metal-l2-nightly.yaml
@@ -65,6 +65,7 @@ jobs:
     secrets: inherit
     with:
       build-wheel: true
+      tracy: true
       skip-tt-train: false
       version: 22.04
   tt-metal-l2-tests:

--- a/.github/workflows/tt-metal-l2-nightly.yaml
+++ b/.github/workflows/tt-metal-l2-nightly.yaml
@@ -225,9 +225,9 @@ jobs:
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
   run-profiler-regression:
-    needs: [build-artifact, find-changed-files]
     if: ${{ github.event_name == 'schedule' || inputs.run_bos_tests }}
     needs: build-artifact
+    secrets: inherit
     strategy:
       fail-fast: false
       matrix:
@@ -235,7 +235,6 @@ jobs:
           { arch: wormhole_b0, runner-label: N150 },
         ]
     uses: ./.github/workflows/run-profiler-regression.yaml
-    secrets: inherit
     with:
       arch: ${{ matrix.test-group.arch}}
       runner-label: ${{ matrix.test-group.runner-label}}

--- a/.github/workflows/tt-metal-l2-nightly.yaml
+++ b/.github/workflows/tt-metal-l2-nightly.yaml
@@ -226,7 +226,7 @@ jobs:
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
   run-profiler-regression:
-    if: ${{ github.event_name == 'schedule' || inputs.run_bos_tests }}
+    if: ${{ github.event_name == 'schedule' || inputs.run_APC_cpp_tests }}
     needs: build-artifact
     secrets: inherit
     strategy:


### PR DESCRIPTION
### What's changed
Move `run-profiler-regression` on N150 from APC over to NightlyL2

### Checklist
- [x] All post commit CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/20146443988
- [x] Nightly L2 passes run-profiler-regression: https://github.com/tenstorrent/tt-metal/actions/runs/20146946943/job/57830371486