### PR TITLE
[skip-ci] Fix: Scheduled t3000 tests do not run

### DIFF
--- a/.github/workflows/t3000-demo-tests.yaml
+++ b/.github/workflows/t3000-demo-tests.yaml
@@ -56,5 +56,5 @@ jobs:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-      model: ${{ inputs.model }}
+      model: ${{ inputs.model || 'all' }}
       extra-tag: ${{ inputs.extra-tag || 'in-service' }}

--- a/.github/workflows/t3000-frequent-tests.yaml
+++ b/.github/workflows/t3000-frequent-tests.yaml
@@ -50,4 +50,4 @@ jobs:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-      model:  ${{ inputs.model || 'all' }}
+      model: ${{ inputs.model || 'all' }}

--- a/.github/workflows/t3000-frequent-tests.yaml
+++ b/.github/workflows/t3000-frequent-tests.yaml
@@ -50,4 +50,4 @@ jobs:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-      model: ${{ inputs.model }}
+      model:  ${{ inputs.model || 'all' }}

--- a/.github/workflows/t3000-model-perf-tests.yaml
+++ b/.github/workflows/t3000-model-perf-tests.yaml
@@ -41,5 +41,5 @@ jobs:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-      model: ${{ inputs.model }}
+      model: ${{ inputs.model || 'all' }}
       extra-tag: ${{ inputs.extra-tag || 'in-service' }}

--- a/.github/workflows/t3000-unit-tests.yaml
+++ b/.github/workflows/t3000-unit-tests.yaml
@@ -49,4 +49,4 @@ jobs:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-      model: ${{ inputs.model }}
+      model: ${{ inputs.model || 'all' }}


### PR DESCRIPTION
Urgent fix.

### Problem description
In workflows with model selection, runs triggered on a schedule did not have access to `inputs.model` parameter's default value of `"all"`.

### What's changed
Conditional expression `${{ inputs.model || 'all' }}` guaranteeing the "all" default parameter was reintroduced.

### Checklist