### PR TITLE
Integrate watcher sanitize into safe L1 accessor

### DIFF
--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_sanitize.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_sanitize.cpp
@@ -396,7 +396,7 @@ void RunTestOnCore(
                 virtual_core.y,
                 risc_name,
                 l1_overflow_addr,
-                1);
+                sizeof(std::uint32_t));
         } break;
         default:
             log_warning(LogTest, "Unrecognized feature to test ({}), skipping...", feature);

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_sanitize.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_sanitize.cpp
@@ -395,7 +395,7 @@ void RunTestOnCore(
                 virtual_core.x,
                 virtual_core.y,
                 risc_name,
-                l1_overflow_addr,
+                l1_overflow_addr + sizeof(std::uint32_t),
                 sizeof(std::uint32_t));
         } break;
         default:

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dram_copy_to_noc_coord.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dram_copy_to_noc_coord.cpp
@@ -55,7 +55,8 @@ void kernel_main() {
 #endif
 
     if (l1_overflow_addr) {
-        debug_sanitize_l1_access(l1_overflow_addr, 1);
+        experimental::CoreLocalMem<std::uint32_t> l1_overflow_buffer(l1_overflow_addr);
+        l1_overflow_buffer[0] = 0xDEADBEEF;
     }
 
     // NOC src address

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -3536,7 +3536,6 @@ public:
      * @return Reference to the element at the given index
      */
     T& operator[](uint32_t index) const {
-        // TODO: To be moved to a Watcher sanitize check. Fix for eth cores.
         DEBUG_SANITIZE_L1_ADDR(address_ + (index + 1) * sizeof(T), sizeof(T));
         return get_unsafe_ptr()[index];
     }

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -28,6 +28,7 @@
 #include "dev_msgs.h"
 #include "accessor/tensor_accessor.h"
 #include "tools/profiler/kernel_profiler.hpp"
+#include "debug/sanitize.h"
 
 // clang-format off
 /**
@@ -3536,7 +3537,7 @@ public:
      */
     T& operator[](uint32_t index) const {
         // TODO: To be moved to a Watcher sanitize check. Fix for eth cores.
-        ASSERT(address_ + (index + 1) * sizeof(T) <= MEM_L1_SIZE);
+        DEBUG_SANITIZE_L1_ADDR(address_ + (index + 1) * sizeof(T), sizeof(T));
         return get_unsafe_ptr()[index];
     }
 
@@ -3545,8 +3546,7 @@ public:
      * @return Reference to the value at the address
      */
     T& operator*() const {
-        // TODO: To be moved to a Watcher sanitize check. Fix for eth cores.
-        ASSERT(address_ + sizeof(T) <= MEM_L1_SIZE);
+        DEBUG_SANITIZE_L1_ADDR(address_, sizeof(T));
         return get_unsafe_ptr()[0];
     }
 
@@ -3555,8 +3555,7 @@ public:
      * @return Pointer to the structure in the core's local memory
      */
     tt_l1_ptr T* operator->() const {
-        // TODO: To be moved to a Watcher sanitize check. Fix for eth cores.
-        ASSERT(address_ + sizeof(T) <= MEM_L1_SIZE);
+        DEBUG_SANITIZE_L1_ADDR(address_, sizeof(T));
         return get_unsafe_ptr();
     }
 

--- a/tt_metal/hw/inc/debug/sanitize.h
+++ b/tt_metal/hw/inc/debug/sanitize.h
@@ -598,7 +598,7 @@ void debug_sanitize_l1_access(uint64_t addr, uint32_t len) {
 #define DEBUG_SANITIZE_NO_DRAM_ADDR(noc_id, addr, l) debug_throw_on_dram_addr(noc_id, addr, l)
 #define DEBUG_SANITIZE_NO_LINKED_TRANSACTION(noc_id, multicast) \
     debug_sanitize_check_linked_transactions(noc_id, 0, 0, 0, multicast, DEBUG_SANITIZE_NOC_WRITE);
-#define DEBUG_SANITIZE_L1_ADDR(addr, l) debug_sanitize_l1_addr(addr, l) debug_sanitize_l1_access(addr, l);
+#define DEBUG_SANITIZE_L1_ADDR(addr, l) debug_sanitize_l1_access(addr, l);
 
 // Delay for debugging purposes
 inline void debug_insert_delay(uint8_t transaction_type) {


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/32949

### Problem description
Safe L1 access functions were using asserts which do not provide that much information.
They did not take into account if the kernel was on Ethernet or Tensix

### What's changed
Update them to use the L1 sanitize functions which will show a informative error message when an invalid L1 address is accessed. This watcher check compiles with the correct max L1 address depending on if it's Eth or Tensix

### Checklist
All Post Commit
https://github.com/tenstorrent/tt-metal/actions/runs/20177145271
Blackhole Post Commit
https://github.com/tenstorrent/tt-metal/actions/runs/20177143525