### PR TITLE
Sanitize eth src and dst addresses

### DIFF
--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_sanitize.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_sanitize.cpp
@@ -55,6 +55,8 @@ enum watcher_features_t {
     SanitizeNOCInlineWriteDram,
     SanitizeNOCLinkedTransaction,
     SanitizeL1Overflow,
+    SanitizeEthSrcL1Overflow,
+    SanitizeEthDestL1Overflow,
 };
 
 tt::tt_metal::HalMemType get_buffer_mem_type_for_test(watcher_features_t feature) {
@@ -121,7 +123,13 @@ void RunTestOnCore(
     } else {
         virtual_core = device->worker_core_from_logical_core(core);
     }
-    log_info(LogTest, "Running test on device {} core {}...", device->id(), virtual_core.str());
+    log_info(
+        LogTest,
+        "Running test on device {} {} core {} (virtual core {})...",
+        device->id(),
+        (is_eth_core) ? "eth" : "worker",
+        core.str(),
+        virtual_core.str());
 
     // Set up dram buffers
     uint32_t single_tile_size = 2 * 1024;
@@ -194,6 +202,8 @@ void RunTestOnCore(
     bool use_inline_dw_write = false;
     bool bad_linked_transaction = false;
     uint32_t l1_overflow_addr = 0;
+    uint32_t eth_src_overflow_addr_words = 0;
+    uint32_t eth_dest_overflow_addr_words = 0;
     switch(feature) {
         case SanitizeNOCAddress:
             output_buf_noc_xy.x = 26;
@@ -216,6 +226,8 @@ void RunTestOnCore(
         case SanitizeNOCInlineWriteDram: use_inline_dw_write = true; break;
         case SanitizeNOCLinkedTransaction: bad_linked_transaction = true; break;
         case SanitizeL1Overflow: l1_overflow_addr = 0xDDDDDDDD; break;
+        case SanitizeEthSrcL1Overflow: eth_src_overflow_addr_words = 0xAAAAAAAA; break;
+        case SanitizeEthDestL1Overflow: eth_dest_overflow_addr_words = 0xBBBBBBBB; break;
         default:
             log_warning(LogTest, "Unrecognized feature to test ({}), skipping...", feature);
             GTEST_SKIP();
@@ -236,7 +248,9 @@ void RunTestOnCore(
          buffer_size,
          use_inline_dw_write,
          bad_linked_transaction,
-         l1_overflow_addr});
+         l1_overflow_addr,
+         eth_src_overflow_addr_words,
+         eth_dest_overflow_addr_words});
 
     // Run the kernel, expect an exception here
     try {
@@ -397,6 +411,30 @@ void RunTestOnCore(
                 risc_name,
                 l1_overflow_addr + sizeof(std::uint32_t),
                 sizeof(std::uint32_t));
+        } break;
+        case SanitizeEthSrcL1Overflow: {
+            expected = fmt::format(
+                "Device {} acteth core(x={:2},y={:2}) virtual(x={:2},y={:2}): erisc core overflowed L1 with access to "
+                "{:#x} "
+                "of length 64 (ethernet send with L1 source overflow).",
+                device->id(),
+                core.x,
+                core.y,
+                virtual_core.x,
+                virtual_core.y,
+                (eth_src_overflow_addr_words << 4));
+        } break;
+        case SanitizeEthDestL1Overflow: {
+            expected = fmt::format(
+                "Device {} acteth core(x={:2},y={:2}) virtual(x={:2},y={:2}): erisc core overflowed L1 with access to "
+                "{:#x} "
+                "of length 64 (ethernet send to core with L1 destination overflow).",
+                device->id(),
+                core.x,
+                core.y,
+                virtual_core.x,
+                virtual_core.y,
+                (eth_dest_overflow_addr_words << 4));
         } break;
         default:
             log_warning(LogTest, "Unrecognized feature to test ({}), skipping...", feature);
@@ -601,6 +639,22 @@ TEST_F(MeshWatcherFixture, ActiveEthTestWatcherSanitizeL1Overflow) {
     this->RunTestOnDevice(
         [](MeshWatcherFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
             RunTestEth(fixture, mesh_device, SanitizeL1Overflow);
+        },
+        this->devices_[0]);
+}
+
+TEST_F(MeshWatcherFixture, ActiveEthTestWatcherSanitizeEthSrcL1Overflow) {
+    this->RunTestOnDevice(
+        [](MeshWatcherFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
+            RunTestEth(fixture, mesh_device, SanitizeEthSrcL1Overflow);
+        },
+        this->devices_[0]);
+}
+
+TEST_F(MeshWatcherFixture, ActiveEthTestWatcherSanitizeEthDestL1Overflow) {
+    this->RunTestOnDevice(
+        [](MeshWatcherFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
+            RunTestEth(fixture, mesh_device, SanitizeEthDestL1Overflow);
         },
         this->devices_[0]);
 }

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dram_copy_to_noc_coord.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dram_copy_to_noc_coord.cpp
@@ -4,6 +4,9 @@
 
 #include <cstdint>
 #include "dataflow_api.h"
+#if defined(COMPILE_FOR_ERISC)
+#include "ethernet/tunneling.h"
+#endif
 
 /**
  * NOC APIs are prefixed w/ "ncrisc" (legacy name) but there's nothing NCRISC specific, they can be used on BRISC or
@@ -26,6 +29,8 @@ void kernel_main() {
     bool use_inline_dw_write = static_cast<bool>(get_arg_val<uint32_t>(8));
     bool bad_linked_transaction = static_cast<bool>(get_arg_val<uint32_t>(9));
     std::uint32_t l1_overflow_addr = get_arg_val<uint32_t>(10);
+    std::uint32_t eth_src_overflow_addr = get_arg_val<uint32_t>(11);
+    std::uint32_t eth_dest_overflow_addr = get_arg_val<uint32_t>(12);
 
 #if defined(SIGNAL_COMPLETION_TO_DISPATCHER)
     // We will assert later. This kernel will hang.
@@ -57,6 +62,13 @@ void kernel_main() {
     if (l1_overflow_addr) {
         experimental::CoreLocalMem<std::uint32_t> l1_overflow_buffer(l1_overflow_addr);
         l1_overflow_buffer[0] = 0xDEADBEEF;
+    }
+
+    if (eth_src_overflow_addr || eth_dest_overflow_addr) {
+        // Destructive if not caught properly
+#if defined(COMPILE_FOR_ERISC)
+        internal_::eth_send_packet(0, eth_src_overflow_addr, eth_dest_overflow_addr, 4);
+#endif
     }
 
     // NOC src address

--- a/tt_metal/hw/inc/dev_msgs.h
+++ b/tt_metal/hw/inc/dev_msgs.h
@@ -282,6 +282,8 @@ enum debug_sanitize_noc_return_code_enum {
     DebugSanitizeNocAddrMailbox = 12,
     DebugSanitizeNocLinkedTransactionViolation = 13,
     DebugSanitizeL1AddrOverflow = 14,
+    DebugSanitizeEthSrcL1AddrOverflow = 15,
+    DebugSanitizeEthDestL1AddrOverflow = 16,
 };
 
 struct debug_assert_msg_t {

--- a/tt_metal/hw/inc/ethernet/tunneling.h
+++ b/tt_metal/hw/inc/ethernet/tunneling.h
@@ -76,8 +76,8 @@ FORCE_INLINE bool eth_txq_is_busy(uint32_t q_num) {
 
 template <bool ctx_switch = true>
 FORCE_INLINE void eth_send_packet(uint32_t q_num, uint32_t src_word_addr, uint32_t dest_word_addr, uint32_t num_words) {
-    WATCHER_CHECK_ETH_LINK_STATUS();
     DEBUG_SANITIZE_ETH(src_word_addr << 4, dest_word_addr << 4, num_words << 4);
+    WATCHER_CHECK_ETH_LINK_STATUS();
     while (eth_txq_is_busy(q_num)) {
         // Note, this is overly eager... Kills perf on allgather
         if constexpr (ctx_switch) {
@@ -92,8 +92,8 @@ FORCE_INLINE void eth_send_packet(uint32_t q_num, uint32_t src_word_addr, uint32
 
 FORCE_INLINE
 void eth_send_packet_unsafe(uint32_t q_num, uint32_t src_word_addr, uint32_t dest_word_addr, uint32_t num_words) {
-    WATCHER_CHECK_ETH_LINK_STATUS();
     DEBUG_SANITIZE_ETH(src_word_addr << 4, dest_word_addr << 4, num_words << 4);
+    WATCHER_CHECK_ETH_LINK_STATUS();
     ASSERT(!eth_txq_is_busy(q_num));
     eth_txq_reg_write(q_num, ETH_TXQ_TRANSFER_START_ADDR, src_word_addr << 4);
     eth_txq_reg_write(q_num, ETH_TXQ_DEST_ADDR, dest_word_addr << 4);
@@ -103,9 +103,9 @@ void eth_send_packet_unsafe(uint32_t q_num, uint32_t src_word_addr, uint32_t des
 
 FORCE_INLINE
 void eth_send_packet_bytes_unsafe(uint32_t q_num, uint32_t src_addr, uint32_t dest_addr, uint32_t num_bytes) {
+    DEBUG_SANITIZE_ETH(src_addr, dest_addr, num_bytes);
     WATCHER_CHECK_ETH_LINK_STATUS();
     ASSERT(eth_txq_reg_read(q_num, ETH_TXQ_CMD) == 0);
-    DEBUG_SANITIZE_ETH(src_addr, dest_addr, num_bytes);
     eth_txq_reg_write(q_num, ETH_TXQ_TRANSFER_START_ADDR, src_addr);
     eth_txq_reg_write(q_num, ETH_TXQ_DEST_ADDR, dest_addr);
     eth_txq_reg_write(q_num, ETH_TXQ_TRANSFER_SIZE_BYTES, num_bytes);

--- a/tt_metal/impl/debug/watcher_device_reader.cpp
+++ b/tt_metal/impl/debug/watcher_device_reader.cpp
@@ -707,6 +707,14 @@ void WatcherDeviceReader::Core::DumpNocSanitizeStatus(int noc) const {
             error_msg = get_l1_target_str(programmable_core_type_, san);
             error_msg += " (read or write past the end of local memory).";
             break;
+        case dev_msgs::DebugSanitizeEthDestL1AddrOverflow:
+            error_msg = get_l1_target_str(programmable_core_type_, san);
+            error_msg += " (ethernet send to core with L1 destination overflow).";
+            break;
+        case dev_msgs::DebugSanitizeEthSrcL1AddrOverflow:
+            error_msg = get_l1_target_str(programmable_core_type_, san);
+            error_msg += " (ethernet send with L1 source overflow).";
+            break;
         default:
             error_msg = fmt::format(
                 "Watcher unexpected data corruption, noc debug state on core {}, unknown failure code: {}",


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/34278

### Problem description
We don't check if Ethernet send source and destination addresses are valid. This was an issue in the Debug-a-thon and what would happen is there will be a hang on the eth core.

### What's changed
- Add a Watcher check so this issue can be caught.
- Add unit test.

### Checklist
All post commit
https://github.com/tenstorrent/tt-metal/actions/runs/20347547565
Blackhole Multi Card (same as main)
https://github.com/tenstorrent/tt-metal/actions/runs/20347550265
Blackhole Nightly (same as main)
https://github.com/tenstorrent/tt-metal/actions/runs/20347555680
cpp-unit-tests (same as main, TLB error)
https://github.com/tenstorrent/tt-metal/actions/runs/20244130614