### PR TITLE
cppcoreguidelines-pro-type-const-cast

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -63,7 +63,6 @@ Checks: >
   -cppcoreguidelines-pro-bounds-array-to-pointer-decay,
   -cppcoreguidelines-pro-bounds-constant-array-index,
   -cppcoreguidelines-pro-bounds-pointer-arithmetic,
-  -cppcoreguidelines-pro-type-const-cast,
   -cppcoreguidelines-pro-type-cstyle-cast,
   -cppcoreguidelines-pro-type-reinterpret-cast,
   -cppcoreguidelines-pro-type-union-access,

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
@@ -272,6 +272,7 @@ void EnqueueWriteMeshSubBuffer(
     bool blocking) {
     auto shard_data_transfer = distributed::MeshCommandQueue::ShardDataTransfer{
         .shard_coord = distributed::MeshCoordinate(0, 0),
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
         .host_data = static_cast<void*>(const_cast<uint32_t*>(src.data())),
         .region = region,
     };

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_allocator.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_allocator.hpp
@@ -770,6 +770,7 @@ private:
                 const auto& dest = pattern.destination.value();
 
                 if (dest.hops.has_value()) {
+                    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
                     auto dst_node_ids = route_manager_.get_dst_node_ids_from_hops(
                         sender.device,
                         const_cast<std::unordered_map<RoutingDirection, uint32_t>&>(dest.hops.value()),

--- a/tests/ttnn/unit_tests/gtests/multiprocess/test_send_recv_pipeline.cpp
+++ b/tests/ttnn/unit_tests/gtests/multiprocess/test_send_recv_pipeline.cpp
@@ -54,6 +54,7 @@ std::unordered_map<tt::tt_metal::AsicID, distributed::MeshCoordinate> generate_a
                 tt::stl::Span<std::byte>(reinterpret_cast<std::byte*>(&num_entries), sizeof(num_entries)),
                 distributed::multihost::Rank{rank});
             for (auto& [asic_id, mesh_coord] : asic_id_to_mesh_coord_map) {
+                // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
                 distributed_context->broadcast(
                     tt::stl::Span<std::byte>(
                         reinterpret_cast<std::byte*>(const_cast<tt_metal::AsicID*>(&asic_id)), sizeof(asic_id)),

--- a/tt_metal/fabric/routing_table_generator.cpp
+++ b/tt_metal/fabric/routing_table_generator.cpp
@@ -318,6 +318,7 @@ void RoutingTableGenerator::generate_intermesh_routing_table(
 
 void RoutingTableGenerator::load_intermesh_connections(const AnnotatedIntermeshConnections& intermesh_connections) {
     const auto& mesh_graph = topology_mapper_.get_mesh_graph();
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
     const_cast<MeshGraph&>(mesh_graph).load_intermesh_connections(intermesh_connections);
     this->generate_intermesh_routing_table(
         mesh_graph.get_inter_mesh_connectivity(), mesh_graph.get_intra_mesh_connectivity());

--- a/tt_metal/fabric/topology_mapper.cpp
+++ b/tt_metal/fabric/topology_mapper.cpp
@@ -346,6 +346,7 @@ TopologyMapper::TopologyMapper(
         std::vector<std::uint32_t> counts(world_size, 0);
         all_gather_with_timeout(
             global_context,
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
             ttsl::Span<std::byte>(
                 reinterpret_cast<std::byte*>(const_cast<std::uint32_t*>(&local_count)), sizeof(std::uint32_t)),
             ttsl::as_writable_bytes(ttsl::Span<std::uint32_t>(counts.data(), counts.size())),
@@ -548,6 +549,7 @@ std::map<MeshId, std::map<tt::tt_metal::AsicID, MeshHostRankId>> TopologyMapper:
     std::vector<std::uint32_t> counts(world_size, 0);
     all_gather_with_timeout(
         global_context,
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
         ttsl::Span<std::byte>(
             reinterpret_cast<std::byte*>(const_cast<std::uint32_t*>(&local_count)), sizeof(std::uint32_t)),
         ttsl::as_writable_bytes(ttsl::Span<std::uint32_t>(counts.data(), counts.size())),

--- a/tt_metal/impl/allocator/bank_manager.cpp
+++ b/tt_metal/impl/allocator/bank_manager.cpp
@@ -209,6 +209,7 @@ allocator::Algorithm* BankManager::get_allocator_from_id(BankManager::AllocatorD
 
 const allocator::Algorithm* BankManager::get_allocator_from_id(
     BankManager::AllocatorDependencies::AllocatorID allocator_id) const {
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
     return const_cast<BankManager*>(this)->get_allocator_from_id(allocator_id);
 }
 

--- a/tt_stl/tt_stl/llvm/llvm_small_vector.hpp
+++ b/tt_stl/tt_stl/llvm/llvm_small_vector.hpp
@@ -140,6 +140,7 @@ protected:
     /// with small-size of 0 for T with lots of alignment, it's important that
     /// SmallVectorStorage is properly-aligned even for small-size of 0.
     void* getFirstEl() const {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
         return const_cast<void*>(reinterpret_cast<const void*>(
             reinterpret_cast<const char*>(this) + offsetof(SmallVectorAlignmentAndSize<T>, FirstEl)));
     }

--- a/ttnn/core/tensor/tensor.cpp
+++ b/ttnn/core/tensor/tensor.cpp
@@ -541,6 +541,7 @@ void memcpy(
     TT_FATAL(queue.device()->num_devices() == 1, "memcpy only supports single device mesh");
     std::vector<distributed::MeshCommandQueue::ShardDataTransfer> shard_data_transfers = {{
         .shard_coord = *distributed::MeshCoordinateRange(queue.device()->shape()).begin(),
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
         .host_data = const_cast<void*>(src),
         .region = region,
     }};

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.cpp
@@ -375,6 +375,7 @@ const CBInfo& get_cb_info_by_name(const std::vector<CBInfo>& cb_info, Conv2dCb c
     return *it;
 }
 CBInfo& access_cb_info_by_name(const std::vector<CBInfo>& cb_info, Conv2dCb cb_name) {
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
     return const_cast<CBInfo&>(get_cb_info_by_name(cb_info, cb_name));
 }
 


### PR DESCRIPTION
### Ticket
NA

### Problem description
The following clang-tidy check is disabled:
https://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/pro-type-const-cast.html

```
Modifying a variable that has been declared as const in C++ is generally considered undefined behavior, and this remains true even when using const_cast.
```

### What's changed
- Enable check
- Ignore existing violations for now

### Impact
- Future PRs will be discouraged from adding more const_cast.


### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] [cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) job passes
- [ ] New/Existing tests provide coverage for changes