### PR TITLE
Fix Qwen prefetcher perf tests in Llama galaxy unit test CI (overflowed global cb max num pages)

### DIFF
--- a/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_TG.py
+++ b/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_TG.py
@@ -13,7 +13,7 @@ from tests.ttnn.unit_tests.operations.prefetcher_common import run_prefetcher_mm
 LLAMA_INPUT_SHAPES = [(2304, 1536), (1536, 2304), (2304, 3840), (2304, 3840), (3840, 2304)]
 LLAMA_INPUT_DTYPES = [ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat4_b, ttnn.bfloat4_b, ttnn.bfloat8_b]
 QWEN_INPUT_SHAPES = [(1536, 1536), (1536, 1536), (1536, 3840), (1536, 3840), (3840, 1536)]
-QWEN_INPUT_DTYPES = [ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat16, ttnn.bfloat16, ttnn.bfloat16]
+QWEN_INPUT_DTYPES = [ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat4_b, ttnn.bfloat4_b, ttnn.bfloat8_b]
 
 
 @pytest.mark.skipif(is_grayskull(), reason="GS not supported")


### PR DESCRIPTION
### Ticket
NA

### Problem description
Galaxy prefetcher unit test was failing due to following issue:
```
FAILED tests/ttnn/unit_tests/operations/transformers/test_prefetcher_TG.py::test_run_prefetcher_qwen_perf[silicon_arch_name=wormhole_b0-device_params={'dispatch_core_axis': <DispatchCoreAxis.COL: 1>, 'trace_region_size': 23887872}-2x2_grid] - RuntimeError: TT_FATAL @ /project/tt_metal/impl/buffers/circular_buffer.cpp:133: num_pages <= max_num_cb_pages
info:
For buffer index 31, number of CB pages 76800 is greater than 65535. Would cause wraparound in the CB calculations.
```
Example failure here: https://github.com/tenstorrent/tt-metal/actions/runs/20126290837/job/57757058541#step:9:4595

The unit test did not seem to have the correct data type since llama mlp (shared with Qwen MLP module) does not use bf16 weights, we either use bfp4 or bfp8 

### What's changed
- change the dtype to be same as llama dtypes


### Checklist
- [x] [Galaxy unit test](https://github.com/tenstorrent/tt-metal/actions/runs/20159684854)