### PR TITLE
readability-container-data-pointer

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -120,7 +120,6 @@ Checks: >
   -readability-avoid-nested-conditional-operator,
   -readability-avoid-unconditional-preprocessor-if,
   -readability-container-contains,
-  -readability-container-data-pointer,
   -readability-convert-member-functions-to-static,
   -readability-else-after-return,
   -readability-enum-initial-value,

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_bw_and_latency.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_bw_and_latency.cpp
@@ -424,7 +424,7 @@ int main(int argc, char** argv) {
                             }
                         } else {
                             uint32_t* pcie_addr = ((uint32_t*)pcie_base) + offset;
-                            nt_memcpy((uint8_t*)pcie_addr, (uint8_t*)&blank[0], page_size_g);
+                            nt_memcpy((uint8_t*)pcie_addr, (uint8_t*)blank.data(), page_size_g);
                         }
                         page++;
                     }

--- a/tests/ttnn/unit_tests/gtests/tensor/test_xtensor_adapter.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_xtensor_adapter.cpp
@@ -40,7 +40,7 @@ TEST(XtensorAdapterTest, CopyConstructor) {
     XtensorAdapter<int> adapter2(adapter1);
 
     EXPECT_EQ(adapter1.data().size(), adapter2.data().size());
-    EXPECT_NE(&adapter1.data()[0], &adapter2.data()[0]);
+    EXPECT_NE(adapter1.data().data(), adapter2.data().data());
 
     adapter2.data()[0] = 10;
     EXPECT_EQ(adapter2.expr()(0, 0), 10);

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -1008,23 +1008,23 @@ void MetalContext::initialize_device_bank_to_noc_tables(
         "Size of bank_to_noc table is greater than available space");
 
     cluster_->write_core(
-        &dram_bank_to_noc_xy_[device_id][0],
+        dram_bank_to_noc_xy_[device_id].data(),
         dram_to_noc_sz_in_bytes,
         tt_cxy_pair(device_id, virtual_core),
         mem_bank_to_noc_addr);
     uint64_t l1_noc_addr = mem_bank_to_noc_addr + dram_to_noc_sz_in_bytes;
     cluster_->write_core(
-        &l1_bank_to_noc_xy_[device_id][0], l1_to_noc_sz_in_bytes, tt_cxy_pair(device_id, virtual_core), l1_noc_addr);
+        l1_bank_to_noc_xy_[device_id].data(), l1_to_noc_sz_in_bytes, tt_cxy_pair(device_id, virtual_core), l1_noc_addr);
 
     uint64_t dram_offset_addr = l1_noc_addr + l1_to_noc_sz_in_bytes;
     cluster_->write_core(
-        &dram_bank_offset_map_[device_id][0],
+        dram_bank_offset_map_[device_id].data(),
         dram_offset_sz_in_bytes,
         tt_cxy_pair(device_id, virtual_core),
         dram_offset_addr);
     uint64_t l1_offset_addr = dram_offset_addr + dram_offset_sz_in_bytes;
     cluster_->write_core(
-        &l1_bank_offset_map_[device_id][0],
+        l1_bank_offset_map_[device_id].data(),
         l1_offset_sz_in_bytes,
         tt_cxy_pair(device_id, virtual_core),
         l1_offset_addr);
@@ -1051,7 +1051,7 @@ void MetalContext::initialize_worker_logical_to_virtual_tables(
 
     uint64_t logical_col_to_virtual_col_addr = logical_to_virtual_map_addr;
     cluster_->write_core(
-        &worker_logical_col_to_virtual_col_[device_id][0],
+        worker_logical_col_to_virtual_col_[device_id].data(),
         logical_col_to_virtual_col_sz_in_bytes,
         tt_cxy_pair(device_id, virtual_core),
         logical_col_to_virtual_col_addr);
@@ -1060,7 +1060,7 @@ void MetalContext::initialize_worker_logical_to_virtual_tables(
     // Therefore, we must adjust the address to account for the full grid size.
     uint64_t logical_row_to_virtual_row_addr = logical_to_virtual_map_addr + (firmware_grid_size_x * sizeof(uint8_t));
     cluster_->write_core(
-        &worker_logical_row_to_virtual_row_[device_id][0],
+        worker_logical_row_to_virtual_row_[device_id].data(),
         logical_row_to_virtual_row_sz_in_bytes,
         tt_cxy_pair(device_id, virtual_core),
         logical_row_to_virtual_row_addr);

--- a/tt_stl/tt_stl/assert.hpp
+++ b/tt_stl/tt_stl/assert.hpp
@@ -73,8 +73,8 @@ static std::string demangle(const char* str) {
     size_t size = 0;
     int status = 0;
     std::string rt(256, '\0');
-    if (1 == sscanf(str, "%*[^(]%*[^_]%255[^)+]", &rt[0])) {
-        char* v = abi::__cxa_demangle(&rt[0], nullptr, &size, &status);
+    if (1 == sscanf(str, "%*[^(]%*[^_]%255[^)+]", rt.data())) {
+        char* v = abi::__cxa_demangle(rt.data(), nullptr, &size, &status);
         if (v) {
             std::string result(v);
             free(v);


### PR DESCRIPTION
### Ticket


### Problem description
The following clang-tidy check is disabled: 
https://clang.llvm.org/extra/clang-tidy/checks/readability/container-data-pointer.html

### What's changed
- Enable check
- Apply automatic FIXITs

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] New/Existing tests provide coverage for changes