### PR TITLE
Bilinear upsample performance improvements

### DIFF
--- a/models/demos/segformer/tests/perf/test_perf_device_segformer.py
+++ b/models/demos/segformer/tests/perf/test_perf_device_segformer.py
@@ -11,7 +11,7 @@ import models.perf.device_perf_utils as perf_utils
 @pytest.mark.parametrize(
     "batch_size, expected_perf",
     [
-        [1, 155.4],
+        [1, 172],
     ],
 )
 def test_perf_device_segformer_segmentation(batch_size, expected_perf, model_location_generator):

--- a/ttnn/cpp/ttnn/operations/pool/upsample/device/kernels/compute/bilinear.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/device/kernels/compute/bilinear.cpp
@@ -9,10 +9,11 @@
 #include "compute_kernel_api/pack_untilize.h"
 #include "circular_buffer.h"
 
-// Push N tiles to stream buffer (increment write pointer)
-inline void llk_push_tiles_bilinear(const std::int32_t operand, const std::int32_t num_tiles) {
+// Push 1 stick or partial stick to a cb (a (partial) stick consists of num_pages pages, in our case, size of a page is
+// the width of a tile (setup in program factory))
+inline void llk_push_pages_bilinear(const std::int32_t operand, const std::int32_t num_pages) {
     std::uint32_t output = operand;
-    std::uint32_t num_words = num_tiles * get_local_cb_interface(operand).fifo_page_size;
+    std::uint32_t num_words = num_pages * get_local_cb_interface(operand).fifo_page_size;
 
     get_local_cb_interface(output).fifo_wr_ptr += num_words;
     get_local_cb_interface(output).fifo_wr_tile_ptr = 0;
@@ -27,24 +28,30 @@ inline void reduce_h_fused(const uint32_t in_cb_id, const uint32_t in_scalar_cb_
     // cb_reserve_back(out_cb_id, tiles_per_reduction);
     tile_regs_acquire();
     cb_wait_front(in_cb_id, 4);
-    unpack_tilizeA_B_block<false, true, false, true>(
-        in_cb_id,
-        in_scalar_cb_id,
-        tiles_per_reduction,
-        0 /*tile idx for Src b is 0 because only 1 tile of constants is loaded*/,
-        2 /* unpack 2 faces ) */,
-        unpA_face_r_dim);
+
+    // Template parameters for unpack_tilizeA_B_block:
+    constexpr bool use_neginf_srcA = false;  // Don't use negative infinity for source A
+    constexpr bool reload_srcB = true;       // Reload source B (bilinear weights) for each operation
+    constexpr bool zero_srcA = false;        // Don't zero source A
+    constexpr bool zero_srcA_reduce = true;  // Zero source A for reduce operation
+
+    // Function parameters:
+    constexpr uint32_t scalar_tile_idx = 0;  // Tile index for scalar CB (only 1 tile of weights loaded)
+    constexpr uint32_t num_faces = 2;  // Unpack 2 faces (top faces contain 4 rows needed for bilinear interpolation)
+
+    unpack_tilizeA_B_block<use_neginf_srcA, reload_srcB, zero_srcA, zero_srcA_reduce>(
+        in_cb_id, in_scalar_cb_id, tiles_per_reduction, scalar_tile_idx, num_faces, unpA_face_r_dim);
     for (uint32_t c_i = 0; c_i < tiles_per_reduction; ++c_i) {
-        reduce_tile_math(c_i, 2 /* reduce 2 faces */);
+        reduce_tile_math(c_i, num_faces);  // Reduce the 2 faces (containing 4 rows for bilinear interpolation)
     }
     cb_pop_front(in_cb_id, 4);
 
     tile_regs_wait();
     tile_regs_commit();
-    pack_untilize_dest<tiles_per_reduction>(out_cb_id, 1, 0, 1, 2); /* pack 1 row (1x32) */
+    pack_untilize_dest<tiles_per_reduction>(out_cb_id, 1, 0, 1, num_faces); /* pack 1 row (1x32) from 2 faces */
     tile_regs_release();
 
-    PACK(llk_push_tiles_bilinear(out_cb_id, tiles_per_reduction));
+    PACK(llk_push_pages_bilinear(out_cb_id, tiles_per_reduction));
 }
 
 namespace NAMESPACE {
@@ -70,8 +77,18 @@ void MAIN {
         in_ntiles_c % MAX_TILES_PER_REDUCTION == 0 ? max_tiles_per_iter : in_ntiles_c % MAX_TILES_PER_REDUCTION;
 
     constexpr uint32_t num_output_tiles = out_ntiles_c;  //* nblocks;
-    tilizeA_B_reduce_init<false, true>(in_cb_id1, in_scalar_cb_id1, max_tiles_per_iter, out_cb_id, 2, 4);
-    pack_untilize_dest_init<max_tiles_per_iter>(out_cb_id, 1, 2); /* pack 1 row (1x32) */
+
+    // Template parameters for tilizeA_B_reduce_init:
+    constexpr bool use_neginf_srcA = false;  // Don't use negative infinity for source A
+    constexpr bool zero_srcA_reduce = true;  // Zero source A for reduce operation
+
+    // Function parameters:
+    constexpr uint32_t num_faces = 2;   // Use 2 faces (top faces contain 4 rows for bilinear interpolation)
+    constexpr uint32_t face_r_dim = 4;  // 4 rows per face (sufficient for bilinear interpolation)
+
+    tilizeA_B_reduce_init<use_neginf_srcA, zero_srcA_reduce>(
+        in_cb_id1, in_scalar_cb_id1, max_tiles_per_iter, out_cb_id, num_faces, face_r_dim);
+    pack_untilize_dest_init<max_tiles_per_iter>(out_cb_id, 1, num_faces); /* pack 1 row (1x32) from 2 faces */
     for (uint32_t i = 0; i < nsticks_per_core_by_nblocks; i++) {
         const uint32_t cb_id = (i % 2 == 0) ? in_cb_id1 : in_cb_id2;
         const uint32_t scalar_cb_id = (i % 2 == 0) ? in_scalar_cb_id1 : in_scalar_cb_id2;

--- a/ttnn/cpp/ttnn/operations/pool/upsample/device/kernels/compute/bilinear.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/device/kernels/compute/bilinear.cpp
@@ -25,7 +25,6 @@ inline void llk_push_pages_bilinear(const std::int32_t operand, const std::int32
 
 template <uint32_t tiles_per_reduction, uint32_t unpA_face_r_dim>
 inline void reduce_h_fused(const uint32_t in_cb_id, const uint32_t in_scalar_cb_id, const uint32_t out_cb_id) {
-    // cb_reserve_back(out_cb_id, tiles_per_reduction);
     tile_regs_acquire();
     cb_wait_front(in_cb_id, 4);
 
@@ -48,7 +47,8 @@ inline void reduce_h_fused(const uint32_t in_cb_id, const uint32_t in_scalar_cb_
 
     tile_regs_wait();
     tile_regs_commit();
-    pack_untilize_dest<tiles_per_reduction>(out_cb_id, 1, 0, 1, num_faces); /* pack 1 row (1x32) from 2 faces */
+    pack_untilize_dest<tiles_per_reduction>(
+        out_cb_id, 1, 0, 1, num_faces); /* pack 1 row (1x (32 * tiles_per_reduction)) from 2 faces */
     tile_regs_release();
 
     PACK(llk_push_pages_bilinear(out_cb_id, tiles_per_reduction));
@@ -56,8 +56,8 @@ inline void reduce_h_fused(const uint32_t in_cb_id, const uint32_t in_scalar_cb_
 
 namespace NAMESPACE {
 void MAIN {
-    constexpr uint32_t in_cb_id1 = get_compile_time_arg_val(0);
-    constexpr uint32_t in_cb_id2 = get_compile_time_arg_val(1);
+    constexpr uint32_t tilize_reduce_cb_0 = get_compile_time_arg_val(0);
+    constexpr uint32_t tilize_reduce_cb_1 = get_compile_time_arg_val(1);
     constexpr uint32_t in_scalar_cb_id1 = get_compile_time_arg_val(2);
     constexpr uint32_t in_scalar_cb_id2 = get_compile_time_arg_val(3);
     constexpr uint32_t out_cb_id = get_compile_time_arg_val(4);
@@ -78,19 +78,16 @@ void MAIN {
 
     constexpr uint32_t num_output_tiles = out_ntiles_c;  //* nblocks;
 
-    // Template parameters for tilizeA_B_reduce_init:
     constexpr bool use_neginf_srcA = false;  // Don't use negative infinity for source A
     constexpr bool zero_srcA_reduce = true;  // Zero source A for reduce operation
-
-    // Function parameters:
     constexpr uint32_t num_faces = 2;   // Use 2 faces (top faces contain 4 rows for bilinear interpolation)
     constexpr uint32_t face_r_dim = 4;  // 4 rows per face (sufficient for bilinear interpolation)
 
     tilizeA_B_reduce_init<use_neginf_srcA, zero_srcA_reduce>(
-        in_cb_id1, in_scalar_cb_id1, max_tiles_per_iter, out_cb_id, num_faces, face_r_dim);
+        tilize_reduce_cb_0, in_scalar_cb_id1, max_tiles_per_iter, out_cb_id, num_faces, face_r_dim);
     pack_untilize_dest_init<max_tiles_per_iter>(out_cb_id, 1, num_faces); /* pack 1 row (1x32) from 2 faces */
     for (uint32_t i = 0; i < nsticks_per_core_by_nblocks; i++) {
-        const uint32_t cb_id = (i % 2 == 0) ? in_cb_id1 : in_cb_id2;
+        const uint32_t cb_id = (i % 2 == 0) ? tilize_reduce_cb_0 : tilize_reduce_cb_1;
         const uint32_t scalar_cb_id = (i % 2 == 0) ? in_scalar_cb_id1 : in_scalar_cb_id2;
 
         for (uint32_t j = 0; j < blocks - 1; j++) {

--- a/ttnn/cpp/ttnn/operations/pool/upsample/device/kernels/dataflow/fixed_point_arithmetic.h
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/device/kernels/dataflow/fixed_point_arithmetic.h
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#define ALWI inline __attribute__((always_inline))
+
+// Fixed-point math constants and helpers for Q16.16 format
+constexpr int32_t FIXED_POINT_SHIFT = 16;
+constexpr int32_t FIXED_ONE = 1 << FIXED_POINT_SHIFT;         // 1.0 in Q16.16
+constexpr int32_t FIXED_HALF = 1 << (FIXED_POINT_SHIFT - 1);  // 0.5 in Q16.16
+
+// Extract integer part from fixed-point
+ALWI constexpr int32_t fixed_to_int(int32_t fixed) { return fixed >> FIXED_POINT_SHIFT; }
+
+// Extract fractional part from fixed-point (0 to FIXED_ONE)
+ALWI constexpr int32_t fixed_frac(int32_t fixed) { return fixed & ((1 << FIXED_POINT_SHIFT) - 1); }
+
+// Multiply two fixed-point numbers
+ALWI constexpr int32_t fixed_mul(int32_t a, int32_t b) { return ((int64_t)a * b) >> FIXED_POINT_SHIFT; }
+
+ALWI uint16_t float_to_bfloat16_non_constexpr(float val) {
+    const uint32_t* p = reinterpret_cast<const uint32_t*>(&val);
+    return uint16_t(*p >> 16);
+}
+
+// Convert fixed-point to bfloat16 for weight values
+ALWI uint16_t fixed_to_bfloat16(int32_t fixed) {
+    float fval = (float)fixed / FIXED_ONE;
+    return float_to_bfloat16_non_constexpr(fval);
+}

--- a/ttnn/cpp/ttnn/operations/pool/upsample/device/kernels/dataflow/fixed_point_arithmetic.h
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/device/kernels/dataflow/fixed_point_arithmetic.h
@@ -1,6 +1,8 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
+
+#pragma once
 
 #define ALWI inline __attribute__((always_inline))
 

--- a/ttnn/cpp/ttnn/operations/pool/upsample/device/kernels/dataflow/reader_bilinear_multi_core_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/device/kernels/dataflow/reader_bilinear_multi_core_sharded.cpp
@@ -75,7 +75,6 @@ void kernel_main() {
                                      // in_h (corresponding to the height of a single batch) +
                                      // 2 (corresponding to the 2 skipped padding rows)
 
-    noc_async_read_one_packet_set_state(get_noc_addr(l1_read_addr), input_block_size_bytes);
     constexpr uint32_t img2_stick_bytes = in_w * stick_nbytes;
     constexpr uint32_t num_outer_loops = in_image_rows_per_core * scale_h;
 
@@ -279,22 +278,26 @@ void kernel_main() {
                 uint32_t l1_write_addr = get_write_ptr(out_cb_id);
                 uint32_t l1_read_addr_temp = y1_base + x1_offset + block_offset;
                 // 1st stick
-                noc_async_read_one_packet_with_state<true>(l1_read_addr_temp, l1_write_addr);
+                uint64_t src_noc_addr = get_noc_addr(l1_read_addr_temp);
+                noc_async_read(src_noc_addr, l1_write_addr, input_block_size_bytes);
                 l1_write_addr += input_block_size_bytes;
 
                 // 2nd stick
                 l1_read_addr_temp = y1_base + x2_offset + block_offset;
-                noc_async_read_one_packet_with_state<true>(l1_read_addr_temp, l1_write_addr);
+                src_noc_addr = get_noc_addr(l1_read_addr_temp);
+                noc_async_read(src_noc_addr, l1_write_addr, input_block_size_bytes);
                 l1_write_addr += input_block_size_bytes;
 
                 // 3rd stick
                 l1_read_addr_temp = y2_base + x1_offset + block_offset;
-                noc_async_read_one_packet_with_state<true>(l1_read_addr_temp, l1_write_addr);
+                src_noc_addr = get_noc_addr(l1_read_addr_temp);
+                noc_async_read(src_noc_addr, l1_write_addr, input_block_size_bytes);
                 l1_write_addr += input_block_size_bytes;
 
                 // 4th stick
                 l1_read_addr_temp = y2_base + x2_offset + block_offset;
-                noc_async_read_one_packet_with_state<true>(l1_read_addr_temp, l1_write_addr);
+                src_noc_addr = get_noc_addr(l1_read_addr_temp);
+                noc_async_read(src_noc_addr, l1_write_addr, input_block_size_bytes);
                 l1_write_addr += input_block_size_bytes;
 
                 fill_four_val(get_write_ptr(in_scalar_cb_id), p1_bf16, p2_bf16, p3_bf16, p4_bf16);

--- a/ttnn/cpp/ttnn/operations/pool/upsample/device/kernels/dataflow/reader_bilinear_multi_core_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/device/kernels/dataflow/reader_bilinear_multi_core_sharded.cpp
@@ -15,71 +15,102 @@ ALWI void fill_four_val(uint32_t begin_addr, uint16_t val, uint16_t val1, uint16
     ptr[1] = (val2 | (val3 << 16));
 }
 
-ALWI float uint32_to_float(uint32_t f) {
-    float ret;
-    std::memcpy(&ret, &f, sizeof(float));
-    return ret;
+// Fixed-point math constants and helpers for Q16.16 format
+constexpr int32_t FIXED_POINT_SHIFT = 16;
+constexpr int32_t FIXED_ONE = 1 << FIXED_POINT_SHIFT;         // 1.0 in Q16.16
+constexpr int32_t FIXED_HALF = 1 << (FIXED_POINT_SHIFT - 1);  // 0.5 in Q16.16
+
+// Extract integer part from fixed-point
+ALWI constexpr int32_t fixed_to_int(int32_t fixed) { return fixed >> FIXED_POINT_SHIFT; }
+
+// Extract fractional part from fixed-point (0 to FIXED_ONE)
+ALWI constexpr int32_t fixed_frac(int32_t fixed) { return fixed & ((1 << FIXED_POINT_SHIFT) - 1); }
+
+// Multiply two fixed-point numbers
+ALWI constexpr int32_t fixed_mul(int32_t a, int32_t b) { return ((int64_t)a * b) >> FIXED_POINT_SHIFT; }
+
+ALWI uint16_t float_to_bfloat16_non_constexpr(float val) {
+    const uint32_t* p = reinterpret_cast<const uint32_t*>(&val);
+    return uint16_t(*p >> 16);
+}
+
+// Convert fixed-point to bfloat16 for weight values
+ALWI uint16_t fixed_to_bfloat16(int32_t fixed) {
+    float fval = (float)fixed / FIXED_ONE;
+    return float_to_bfloat16_non_constexpr(fval);
 }
 
 void kernel_main() {
-    uint32_t stick_nbytes = get_arg_val<uint32_t>(0);
-    uint32_t in_image_rows_per_core = get_arg_val<uint32_t>(1);
-    uint32_t scale_h = get_arg_val<uint32_t>(2);
-    uint32_t scale_w = get_arg_val<uint32_t>(3);
-    uint32_t in_w = get_arg_val<uint32_t>(4);
-    uint32_t out_w = get_arg_val<uint32_t>(5);
-    uint32_t start_input_row_in_image_id = get_arg_val<uint32_t>(6);
-    uint32_t in_h = get_arg_val<uint32_t>(7);
+    // Only runtime argument - which row in the image this core starts processing
+    uint32_t start_input_row_in_image_id = get_arg_val<uint32_t>(0);
+
+    // Moved to compile-time arguments
+    constexpr uint32_t stick_nbytes = get_compile_time_arg_val(0);
+    constexpr uint32_t in_image_rows_per_core = get_compile_time_arg_val(1);
+    constexpr uint32_t scale_h = get_compile_time_arg_val(2);
+    constexpr uint32_t scale_w = get_compile_time_arg_val(3);
+    constexpr uint32_t in_w = get_compile_time_arg_val(4);
+    constexpr uint32_t out_w = get_compile_time_arg_val(5);
+    constexpr uint32_t in_h = get_compile_time_arg_val(6);
+
+    // Existing compile-time arguments (shifted indices)
+    constexpr uint32_t in_cb_id = get_compile_time_arg_val(7);
+    constexpr uint32_t out_cb_id = get_compile_time_arg_val(8);
+    constexpr uint32_t in_scalar_cb_id = get_compile_time_arg_val(9);
+    // These are now already in fixed-point format from the host
+    constexpr uint32_t scale_h_inv_fixed_u32 = get_compile_time_arg_val(10);
+    constexpr uint32_t scale_w_inv_fixed_u32 = get_compile_time_arg_val(11);
+    constexpr uint32_t y_starting_coordinate_fixed_u32 = get_compile_time_arg_val(12);
+    constexpr uint32_t x_starting_coordinate_fixed_u32 = get_compile_time_arg_val(13);
+    constexpr uint32_t is_reader = get_compile_time_arg_val(14);
+    constexpr uint32_t blocks = get_compile_time_arg_val(15);
+    constexpr uint32_t input_block_size_bytes = get_compile_time_arg_val(16);
 
     constexpr bool src1_is_dram = false;
-    constexpr uint32_t in_cb_id = get_compile_time_arg_val(0);
-    constexpr uint32_t out_cb_id = get_compile_time_arg_val(1);
-    constexpr uint32_t in_scalar_cb_id = get_compile_time_arg_val(2);
-    // constexpr uint32_t is_reader = get_compile_time_arg_val(2);
-    constexpr uint32_t scale_h_inv_comp = get_compile_time_arg_val(3);
-    constexpr uint32_t scale_w_inv_comp = get_compile_time_arg_val(4);
-    constexpr uint32_t y_starting_coordinate_u32 = get_compile_time_arg_val(5);
-    constexpr uint32_t x_starting_coordinate_u32 = get_compile_time_arg_val(6);
-    constexpr uint32_t is_reader = get_compile_time_arg_val(7);
-    constexpr uint32_t blocks = get_compile_time_arg_val(8);
-    constexpr uint32_t input_block_size_bytes = get_compile_time_arg_val(9);
     uint32_t l1_read_addr = get_read_ptr(in_cb_id);
-    uint32_t total_nsticks_to_process = in_w * scale_w;
+    constexpr uint32_t total_nsticks_to_process = in_w * scale_w;
     // Calculate the number of sticks to process per core by dividing the total number of sticks (in width direction)
     // by 2.
-    uint32_t nsticks_to_process_on_core =
+    constexpr uint32_t nsticks_reader =
         (total_nsticks_to_process % 2) ? total_nsticks_to_process / 2 + 1 : total_nsticks_to_process / 2;
+    constexpr uint32_t nsticks_writer =
+        (total_nsticks_to_process % 2) ? total_nsticks_to_process / 2 : total_nsticks_to_process / 2;
+    constexpr uint32_t nsticks_to_process_on_core = is_reader ? nsticks_reader : nsticks_writer;
     // assuming shard begins with a new row. TODO: generalize?
-    float scale_h_inv = uint32_to_float(scale_h_inv_comp);
-    float scale_w_inv = uint32_to_float(scale_w_inv_comp);
-    float y_coordinate,
+    // Values are already in fixed-point format from host, just cast them
+    constexpr int32_t scale_h_inv = static_cast<int32_t>(scale_h_inv_fixed_u32);
+    constexpr int32_t scale_w_inv = static_cast<int32_t>(scale_w_inv_fixed_u32);
+    constexpr int32_t scale_w_inv_x2 = scale_w_inv << 1;  // scale_w_inv * 2, used frequently
+    int32_t y_coordinate,
         x_coordinate;  // x and y coordinate of the output pixel, as if it had existed in the input image
-    float x;           // helper variable to avoid out of bound reads in the x direction
-    float dx,
+    int32_t x;         // helper variable to avoid out of bound reads in the x direction
+    int32_t dx,
         dy;  // distance between the output pixel and its closest pixel with lower coordinates (up and to the left)
-    y_coordinate = uint32_to_float(y_starting_coordinate_u32);
-    float x_starting_coordinate = uint32_to_float(x_starting_coordinate_u32);
+    constexpr int32_t y_starting_coordinate_fixed = static_cast<int32_t>(y_starting_coordinate_fixed_u32);
+    constexpr int32_t x_starting_coordinate_fixed = static_cast<int32_t>(x_starting_coordinate_fixed_u32);
+
+    y_coordinate = y_starting_coordinate_fixed;
 
     // If the current core is a writer core, adjust the x_starting_coordinate to start from the correct position.
-
-    if (!is_reader) {
-        x_starting_coordinate += scale_w_inv;
-        // If the total number of sticks is odd, process one less stick.
-        nsticks_to_process_on_core =
-            (total_nsticks_to_process % 2) ? nsticks_to_process_on_core - 1 : nsticks_to_process_on_core;
-    }
+    constexpr int32_t x_starting_coordinate =
+        (!is_reader) ? x_starting_coordinate_fixed + scale_w_inv : x_starting_coordinate_fixed;
     int32_t accumulated_offset = 0;  // offset used to calculate the position of row in batch
                                      // every time we encounter a boundary between images, it is increased by
                                      // in_h (corresponding to height of a single batch) +
                                      // 2 (corresponding to the 2 skipped padding rows)
 
-    for (uint32_t image_row = 0; image_row < in_image_rows_per_core * scale_h; ++image_row) {
+    noc_async_read_one_packet_set_state(get_noc_addr(l1_read_addr), input_block_size_bytes);
+    constexpr uint32_t img2_stick_bytes = in_w * stick_nbytes;
+    // DPRINT << "num outer loops: " << in_image_rows_per_core * scale_h << ENDL();
+    // DPRINT << "scale_h: " << scale_h << ENDL();
+    constexpr uint32_t num_outer_loops = in_image_rows_per_core * scale_h;
+    for (uint32_t image_row = 0; image_row < num_outer_loops; ++image_row) {
         x_coordinate = x_starting_coordinate;
 
         // These variables are for referencing the appropriate input rows, specifically
         // Their coordinates in the halo shard
 
-        uint32_t y1 = int(y_coordinate);
+        uint32_t y1 = fixed_to_int(y_coordinate);
         uint32_t y2 = y1 + 1;
 
         // These two variables represent the indices of the rows referenced by y1 and y2
@@ -90,7 +121,7 @@ void kernel_main() {
         int32_t in_batch_index_y1 = int32_t(y1) - 1 + start_input_row_in_image_id - accumulated_offset;
         int32_t in_batch_index_y2 = int32_t(y2) - 1 + start_input_row_in_image_id - accumulated_offset;
 
-        dy = y_coordinate - y1;
+        dy = fixed_frac(y_coordinate);
 
         // In no circumstance should the padding rows have weights greater than 0.5
 
@@ -101,7 +132,7 @@ void kernel_main() {
             // Entering this case means that in_batch_index_y1 (the "upper" row) corresponds to a padding row
             // (specifically the top padding row) Reduce the padding row's weight to 0 and put full weight on the row
             // below it
-            dy = 1;
+            dy = FIXED_ONE;
         }
 
         if (in_batch_index_y2 == int(in_h)) {
@@ -111,8 +142,8 @@ void kernel_main() {
             // Entering this case means that in_batch_index_y2 (the "lower row") corresponds to a padding
             // row(specifically the bottom padding row)
 
-            if (dy > 0.5) {  // Due to math behind bilinear upsampling, dy could never be exactly 0.5, so this check
-                             // should be numerically safe
+            if (dy > FIXED_HALF) {  // Due to math behind bilinear upsampling, dy could never be exactly 0.5, so this
+                                    // check should be numerically safe
 
                 // In this case, a padding row has weight higher than 0.5.
                 // This means we  are actually done with the current batch,
@@ -120,8 +151,8 @@ void kernel_main() {
                 // previous image) The iteration that enters this case outputs the first row of the next batch
                 y1 += 2;
                 y2 += 2;
-                y_coordinate += 2;
-                dy = 1;
+                y_coordinate += (2 << FIXED_POINT_SHIFT);  // Add 2.0 in fixed-point
+                dy = FIXED_ONE;
                 accumulated_offset += 2 + in_h;
             } else {
                 // In this case, we handle the rows on the bottom border of the image
@@ -130,58 +161,178 @@ void kernel_main() {
                 dy = 0;
             }
         }
+        // DPRINT << "x increment: " << scale_w_inv * 2 << ENDL();
+        // DPRINT << "nsticks_to_process_on_core: " << nsticks_to_process_on_core << ENDL();
+
+        // Check if we can use the optimization for pre-computed weights
+        // The optimization only works when dx alternates between at most 2 values
+        // This happens when scale_w is 1, 2, or 4
+        constexpr bool use_precomputed_weights = (scale_w == 1 || scale_w == 2 || scale_w == 4);
+
+        int32_t one_minus_dy = FIXED_ONE - dy;
+
+        // Pre-compute row base addresses (constant for entire row)
+        uint32_t y1_base = l1_read_addr + y1 * img2_stick_bytes;
+        uint32_t y2_base = l1_read_addr + y2 * img2_stick_bytes;
+
+        // Variables for pre-computed weights (only used when optimization is enabled)
+        // These are only used when use_precomputed_weights is true, so we can avoid
+        // initializing them otherwise
+        [[maybe_unused]] int32_t dx_a, dx_b;
+        [[maybe_unused]] bool has_special_first;
+        [[maybe_unused]] uint16_t p1_bf16_set_a, p2_bf16_set_a, p3_bf16_set_a, p4_bf16_set_a;
+        [[maybe_unused]] uint16_t p1_bf16_set_b, p2_bf16_set_b, p3_bf16_set_b, p4_bf16_set_b;
+        [[maybe_unused]] uint16_t p1_bf16_zero, p2_bf16_zero, p3_bf16_zero, p4_bf16_zero;
+
+        if constexpr (use_precomputed_weights) {
+            // Pre-calculate bilinear interpolation weights for the two alternating dx values
+            // Since dy is constant for this row and dx alternates between two values,
+            // we can pre-compute the weights and avoid expensive floating-point operations
+
+            // Pre-compute dx values for the alternating pattern
+            // When x increments by scale_w_inv*2, we get a repeating pattern
+            // Handle special case when starting x is negative (gets clamped to 0)
+            has_special_first = (x_coordinate < 0);
+
+            // Calculate the two alternating dx values based on the actual increment
+            // For reader core, after any special first value, dx alternates between two values
+            if (has_special_first) {
+                // First position is special (dx=0), calculate next two
+                int32_t x1 = x_coordinate + (scale_w_inv_x2);  // scale_w_inv * 2
+                dx_a = fixed_frac(x1);                         // This will be the first regular dx
+                int32_t x2 = x1 + (scale_w_inv_x2);            // x1 + scale_w_inv * 2
+                dx_b = fixed_frac(x2);                         // This will be the second regular dx
+            } else {
+                // No special first, calculate the two alternating values
+                int32_t x1 = x_coordinate;
+                dx_a = fixed_frac(x1);
+                int32_t x2 = x1 + (scale_w_inv_x2);  // x1 + scale_w_inv * 2
+                dx_b = fixed_frac(x2);
+            }
+
+            // Pre-compute weights for the two alternating dx values
+            int32_t one_minus_dx_a = FIXED_ONE - dx_a;
+            int32_t one_minus_dx_b = FIXED_ONE - dx_b;
+
+            // Weight set A
+            int32_t p1_set_a = fixed_mul(one_minus_dx_a, one_minus_dy);
+            int32_t p2_set_a = fixed_mul(dx_a, one_minus_dy);
+            int32_t p3_set_a = fixed_mul(one_minus_dx_a, dy);
+            int32_t p4_set_a = fixed_mul(dx_a, dy);
+
+            // Weight set B
+            int32_t p1_set_b = fixed_mul(one_minus_dx_b, one_minus_dy);
+            int32_t p2_set_b = fixed_mul(dx_b, one_minus_dy);
+            int32_t p3_set_b = fixed_mul(one_minus_dx_b, dy);
+            int32_t p4_set_b = fixed_mul(dx_b, dy);
+
+            // Convert weights to bfloat16 once
+            p1_bf16_set_a = fixed_to_bfloat16(p1_set_a);
+            p2_bf16_set_a = fixed_to_bfloat16(p2_set_a);
+            p3_bf16_set_a = fixed_to_bfloat16(p3_set_a);
+            p4_bf16_set_a = fixed_to_bfloat16(p4_set_a);
+
+            p1_bf16_set_b = fixed_to_bfloat16(p1_set_b);
+            p2_bf16_set_b = fixed_to_bfloat16(p2_set_b);
+            p3_bf16_set_b = fixed_to_bfloat16(p3_set_b);
+            p4_bf16_set_b = fixed_to_bfloat16(p4_set_b);
+
+            // Special case weights for dx=0 (only used when x starts negative)
+            // Formula: p1=(1-dx)*(1-dy), p2=dx*(1-dy), p3=(1-dx)*dy, p4=dx*dy
+            // When dx=0: p1=(1-dy), p2=0, p3=dy, p4=0
+            p1_bf16_zero = fixed_to_bfloat16(one_minus_dy);
+            p2_bf16_zero = 0;
+            p3_bf16_zero = fixed_to_bfloat16(dy);
+            p4_bf16_zero = 0;
+        }
+
         for (uint32_t j = 0; j < nsticks_to_process_on_core; j++) {
+            // Calculate x position and indices (needed for memory addressing)
+            x = x_coordinate < 0 ? 0 : x_coordinate;
+
+            // Select or compute weights based on optimization mode
+            uint16_t p1_bf16, p2_bf16, p3_bf16, p4_bf16;
+
+            if constexpr (use_precomputed_weights) {
+                // Use pre-computed weights for optimized scale factors
+                if (has_special_first && j == 0) {
+                    // Special first case where x was negative and clamped to 0
+                    p1_bf16 = p1_bf16_zero;
+                    p2_bf16 = p2_bf16_zero;
+                    p3_bf16 = p3_bf16_zero;
+                    p4_bf16 = p4_bf16_zero;
+                } else {
+                    // Regular alternating pattern
+                    bool use_set_a;
+                    if (has_special_first) {
+                        use_set_a = ((j - 1) % 2) == 0;
+                    } else {
+                        // No special first, simple alternation
+                        use_set_a = (j % 2) == 0;
+                    }
+
+                    if (use_set_a) {
+                        p1_bf16 = p1_bf16_set_a;
+                        p2_bf16 = p2_bf16_set_a;
+                        p3_bf16 = p3_bf16_set_a;
+                        p4_bf16 = p4_bf16_set_a;
+                    } else {
+                        p1_bf16 = p1_bf16_set_b;
+                        p2_bf16 = p2_bf16_set_b;
+                        p3_bf16 = p3_bf16_set_b;
+                        p4_bf16 = p4_bf16_set_b;
+                    }
+                }
+            } else {
+                // Calculate weights dynamically for other scale factors
+                dx = fixed_frac(x);
+                int32_t one_minus_dx = FIXED_ONE - dx;
+                p1_bf16 = fixed_to_bfloat16(fixed_mul(one_minus_dx, one_minus_dy));
+                p2_bf16 = fixed_to_bfloat16(fixed_mul(dx, one_minus_dy));
+                p3_bf16 = fixed_to_bfloat16(fixed_mul(one_minus_dx, dy));
+                p4_bf16 = fixed_to_bfloat16(fixed_mul(dx, dy));
+            }
+            uint32_t x1 = fixed_to_int(x);
+            uint32_t x2 = (x1 + 1) < (in_w - 1) ? (x1 + 1) : (in_w - 1);
+
+            // Pre-compute column offsets (hoist multiplications out of blocks loop)
+            uint32_t x1_offset = x1 * stick_nbytes;
+            uint32_t x2_offset = x2 * stick_nbytes;
+
+            uint32_t block_offset = 0;
             for (uint32_t i = 0; i < blocks; i++) {
                 cb_reserve_back(out_cb_id, 4);
-                cb_reserve_back(in_scalar_cb_id, 1);
-
-                x = x_coordinate < 0 ? 0 : x_coordinate;
-                dx = x - int(x);
-                uint32_t x1 = int(x);
-                uint32_t x2 = (x1 + 1) < (in_w - 1) ? (x1 + 1) : (in_w - 1);
-
-                fill_four_val(
-                    get_write_ptr(in_scalar_cb_id),
-                    float_to_bfloat16((1 - dx) * (1 - dy)),
-                    float_to_bfloat16(dx * (1 - dy)),
-                    float_to_bfloat16((1 - dx) * dy),
-                    float_to_bfloat16(dx * dy));
 
                 uint32_t l1_write_addr = get_write_ptr(out_cb_id);
-                uint32_t l1_read_addr_temp =
-                    l1_read_addr + x1 * stick_nbytes + y1 * in_w * stick_nbytes + i * input_block_size_bytes;
+                uint32_t l1_read_addr_temp = y1_base + x1_offset + block_offset;
                 // 1st tile
-                uint64_t src_noc_addr = get_noc_addr(l1_read_addr_temp);
-                noc_async_read(src_noc_addr, l1_write_addr, input_block_size_bytes);
+                noc_async_read_one_packet_with_state<true>(l1_read_addr_temp, l1_write_addr);
                 l1_write_addr += input_block_size_bytes;
 
                 // 2nd tile
-                l1_read_addr_temp =
-                    l1_read_addr + y1 * in_w * stick_nbytes + x2 * stick_nbytes + i * input_block_size_bytes;
-                src_noc_addr = get_noc_addr(l1_read_addr_temp);
-                noc_async_read(src_noc_addr, l1_write_addr, input_block_size_bytes);
+                l1_read_addr_temp = y1_base + x2_offset + block_offset;
+                noc_async_read_one_packet_with_state<true>(l1_read_addr_temp, l1_write_addr);
                 l1_write_addr += input_block_size_bytes;
 
                 // 3rd tile
-                l1_read_addr_temp =
-                    l1_read_addr + y2 * in_w * stick_nbytes + x1 * stick_nbytes + i * input_block_size_bytes;
-                src_noc_addr = get_noc_addr(l1_read_addr_temp);
-                noc_async_read(src_noc_addr, l1_write_addr, input_block_size_bytes);
+                l1_read_addr_temp = y2_base + x1_offset + block_offset;
+                noc_async_read_one_packet_with_state<true>(l1_read_addr_temp, l1_write_addr);
                 l1_write_addr += input_block_size_bytes;
 
                 // 4th tile
-                l1_read_addr_temp =
-                    l1_read_addr + y2 * in_w * stick_nbytes + x2 * stick_nbytes + i * input_block_size_bytes;
-                src_noc_addr = get_noc_addr(l1_read_addr_temp);
-                noc_async_read(src_noc_addr, l1_write_addr, input_block_size_bytes);
+                l1_read_addr_temp = y2_base + x2_offset + block_offset;
+                noc_async_read_one_packet_with_state<true>(l1_read_addr_temp, l1_write_addr);
                 l1_write_addr += input_block_size_bytes;
+
+                fill_four_val(get_write_ptr(in_scalar_cb_id), p1_bf16, p2_bf16, p3_bf16, p4_bf16);
+                cb_push_back(in_scalar_cb_id, 1);
 
                 // push scaler and data into cb.
                 noc_async_read_barrier();
                 cb_push_back(out_cb_id, 4);
-                cb_push_back(in_scalar_cb_id, 1);
+                block_offset += input_block_size_bytes;
             }
-            x_coordinate += scale_w_inv * 2;
+            x_coordinate += (scale_w_inv_x2);  // scale_w_inv * 2 in fixed-point
         }
         y_coordinate += scale_h_inv;
     }

--- a/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_bilinear_program_factory_multicore.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_bilinear_program_factory_multicore.cpp
@@ -220,6 +220,7 @@ UpsampleBilinearProgramFactory::cached_program_t UpsampleBilinearProgramFactory:
     // Kernels
     // computation needed for the bilinear kernel. Passing them as an argument.
     // Convert to fixed-point Q16.16 format on host for better compile-time optimization in kernel
+    // NOTE: These constants must match those in fixed_point_arithmetic.h to ensure consistency
     constexpr int32_t FIXED_POINT_SHIFT = 16;
     constexpr int32_t FIXED_ONE = 1 << FIXED_POINT_SHIFT;
 


### PR DESCRIPTION
### Ticket
#31042

### Problem description
Bilinear upsample had low performance. This was caused by the fact that bilinear interpolation weights, as well the coordinates at which sampling would take place, were calculated on the reader cores (NCRISC and BRISC) using floating point arithmetic. Floating point arithmetic is not supported on the RISC cores, so the fp instructions had to be emulated.

### What's changed
Instead of emulating fp arithmetic, fixed point arithmetic (Q16.16) is introduced for calculations on the risc cores. These calculations are significantly faster and still yield great pcc results. 

For scale factors 1, 2 and 4 additional optimization through constexpr parameters is added.

155.4 -> 172 FPS increase on the segformer model

### Checklist
- [x] [All post commit] https://github.com/tenstorrent/tt-metal/actions/runs/20137731889
- [x] [Blackhole Post commit] https://github.com/tenstorrent/tt-metal/actions/runs/20137747826
- [x] [Single card demo] https://github.com/tenstorrent/tt-metal/actions/runs/20138176766
- [x] [L2 nightly] https://github.com/tenstorrent/tt-metal/actions/runs/20166440422/job/57891406086

### Remaining issues

The sharding restriction mentioned in #18236 is still in place, causing problems from both performance and memory aspects. Removing this restriction and / or adding support for block sharding could help