### PR TITLE
🚧 WiP: Expose functionality needed by fabric manager

### DIFF
--- a/tests/tt_metal/tt_fabric/fabric_router/test_routing_tables.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_routing_tables.cpp
@@ -18,7 +18,7 @@
 #include "impl/context/metal_context.hpp"
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/experimental/fabric/topology_mapper.hpp>
-#include "tt_metal/fabric/physical_system_descriptor.hpp"
+#include <tt-metalium/experimental/fabric/physical_system_descriptor.hpp>
 #include <tt-metalium/experimental/fabric/routing_table_generator.hpp>
 
 namespace {

--- a/tests/tt_metal/tt_fabric/fabric_router/test_topology_mapper.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_topology_mapper.cpp
@@ -10,7 +10,7 @@
 #include <memory>
 #include <unordered_set>
 
-#include "tt_metal/fabric/physical_system_descriptor.hpp"
+#include <tt-metalium/experimental/fabric/physical_system_descriptor.hpp>
 #include <tt-metalium/experimental/fabric/topology_mapper.hpp>
 #include "t3k_mesh_descriptor_chip_mappings.hpp"
 #include "utils.hpp"

--- a/tests/tt_metal/tt_fabric/physical_discovery/test_physical_system_descriptor.cpp
+++ b/tests/tt_metal/tt_fabric/physical_discovery/test_physical_system_descriptor.cpp
@@ -13,7 +13,7 @@
 
 #include <tt-logger/tt-logger.hpp>
 #include <tt-metalium/experimental/fabric/control_plane.hpp>
-#include "tt_metal/fabric/physical_system_descriptor.hpp"
+#include <tt-metalium/experimental/fabric/physical_system_descriptor.hpp>
 #include <tt-metalium/experimental/fabric/mesh_graph.hpp>
 #include "distributed_context.hpp"
 #include "impl/context/metal_context.hpp"

--- a/tests/ttnn/unit_tests/gtests/multiprocess/test_send_recv_pipeline.cpp
+++ b/tests/ttnn/unit_tests/gtests/multiprocess/test_send_recv_pipeline.cpp
@@ -13,7 +13,7 @@
 #include "tt_metal/multihost/fabric_tests/multihost_fabric_fixtures.hpp"
 #include <tt-metalium/mesh_socket.hpp>
 #include <tt-metalium/distributed_context.hpp>
-#include "tt_metal/fabric/physical_system_descriptor.hpp"
+#include <tt-metalium/experimental/fabric/physical_system_descriptor.hpp>
 
 namespace tt::tt_metal {
 

--- a/tools/scaleout/validation/run_cluster_validation.cpp
+++ b/tools/scaleout/validation/run_cluster_validation.cpp
@@ -12,7 +12,7 @@
 
 #include <cxxopts.hpp>
 #include <factory_system_descriptor/utils.hpp>
-#include "tt_metal/fabric/physical_system_descriptor.hpp"
+#include <tt-metalium/experimental/fabric/physical_system_descriptor.hpp>
 #include <tt-metalium/distributed.hpp>
 #include "tt_metal/impl/context/metal_context.hpp"
 #include <cabling_generator/cabling_generator.hpp>

--- a/tools/scaleout/validation/utils/cluster_validation_utils.hpp
+++ b/tools/scaleout/validation/utils/cluster_validation_utils.hpp
@@ -10,7 +10,7 @@
 #include <unordered_map>
 #include <memory>
 #include <filesystem>
-#include "tt_metal/fabric/physical_system_descriptor.hpp"
+#include <tt-metalium/experimental/fabric/physical_system_descriptor.hpp>
 #include "tt_metal/impl/context/metal_context.hpp"
 #include "tools/scaleout/validation/utils/ethernet_link_metrics.hpp"
 #include <board/board.hpp>

--- a/tools/scaleout/validation/utils/ethernet_link_metrics.hpp
+++ b/tools/scaleout/validation/utils/ethernet_link_metrics.hpp
@@ -7,7 +7,7 @@
 #include <string>
 #include <vector>
 #include <cstdint>
-#include "tt_metal/fabric/physical_system_descriptor.hpp"
+#include <tt-metalium/experimental/fabric/physical_system_descriptor.hpp>
 #include <tt_stl/reflection.hpp>
 
 struct TrafficParams {

--- a/tools/tests/scaleout/test_link_retraining.cpp
+++ b/tools/tests/scaleout/test_link_retraining.cpp
@@ -4,7 +4,7 @@
 
 #include <tt-metalium/experimental/fabric/control_plane.hpp>
 #include "tools/scaleout/validation/utils/cluster_validation_utils.hpp"
-#include "tt_metal/fabric/physical_system_descriptor.hpp"
+#include <tt-metalium/experimental/fabric/physical_system_descriptor.hpp>
 #include "tt_metal/llrt/tt_cluster.hpp"
 #include <umd/device/types/xy_pair.hpp>
 #include <factory_system_descriptor/utils.hpp>

--- a/tt_metal/CMakeLists.txt
+++ b/tt_metal/CMakeLists.txt
@@ -94,6 +94,7 @@ set(TT_METAL_PUBLIC_API
     api/tt-metalium/queue_id.hpp
     api/tt-metalium/experimental/fabric/routing_table_generator.hpp
     api/tt-metalium/experimental/fabric/topology_mapper_utils.hpp
+    api/tt-metalium/experimental/fabric/physical_system_descriptor.hpp
     api/tt-metalium/runtime_args_data.hpp
     api/tt-metalium/shape.hpp
     api/tt-metalium/shape2d.hpp

--- a/tt_metal/api/tt-metalium/experimental/fabric/mesh_graph.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/mesh_graph.hpp
@@ -101,6 +101,7 @@ class MeshGraph {
 public:
     explicit MeshGraph(
         const std::string& mesh_graph_desc_file_path, std::optional<FabricConfig> fabric_config = std::nullopt);
+    explicit MeshGraph(const MeshGraphDescriptor& mgd, std::optional<FabricConfig> fabric_config = std::nullopt);
     ~MeshGraph() = default;
 
     void print_connectivity() const;

--- a/tt_metal/api/tt-metalium/experimental/fabric/mesh_graph_descriptor.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/mesh_graph_descriptor.hpp
@@ -89,6 +89,7 @@ public:
     // backwards_compatible will enable all checks related to MGD 1.0. This will limit the functionality of MGD 2.0
     explicit MeshGraphDescriptor(const std::string& text_proto, bool backwards_compatible = false);
     explicit MeshGraphDescriptor(const std::filesystem::path& text_proto_file_path, bool backwards_compatible = false);
+    explicit MeshGraphDescriptor(const proto::MeshGraphDescriptor& proto, bool backwards_compatible = false);
     ~MeshGraphDescriptor();
 
     // Debugging/inspection

--- a/tt_metal/api/tt-metalium/experimental/fabric/physical_system_descriptor.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/physical_system_descriptor.hpp
@@ -27,7 +27,7 @@ class Cluster;
 }
 
 namespace tt {
-enum class TargetDevice: std::uint8_t;
+enum class TargetDevice : std::uint8_t;
 }
 
 namespace tt::llrt {

--- a/tt_metal/api/tt-metalium/experimental/fabric/topology_mapper.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/topology_mapper.hpp
@@ -314,18 +314,6 @@ private:
     std::map<MeshId, std::map<tt::tt_metal::AsicID, MeshHostRankId>> build_asic_id_to_mesh_rank_mapping();
 
     /**
-     * @brief Build the mapping between fabric node IDs and host ranks
-     *
-     * This method iterates through all fabric node IDs in the mesh graph and creates mappings
-     * based on the fabric node IDs and host ranks from the local mesh binding, mapping them
-     * to the host ranks of the physical descriptor.
-     *
-     * @return std::map<MeshId, std::map<FabricNodeId, MeshHostRankId>> Map from mesh ID to
-     * fabric node ID to mesh host rank (ordered for deterministic iteration)
-     */
-    std::map<MeshId, std::map<FabricNodeId, MeshHostRankId>> build_fabric_node_id_to_mesh_rank_mapping() const;
-
-    /**
      * @brief Create bidirectional mappings between logical fabric nodes and physical ASIC IDs
      *
      * This function performs the core topology mapping by creating bidirectional mappings between logical fabric nodes

--- a/tt_metal/api/tt-metalium/experimental/fabric/topology_mapper_utils.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/topology_mapper_utils.hpp
@@ -157,4 +157,17 @@ std::map<MeshId, PhysicalAdjacencyMap> build_adjacency_map_physical(
     const tt::tt_metal::PhysicalSystemDescriptor& physical_system_descriptor,
     const std::map<MeshId, std::map<tt::tt_metal::AsicID, MeshHostRankId>>& asic_id_to_mesh_rank);
 
+/**
+ * @brief Build mapping between fabric node IDs and mesh host ranks
+ *
+ * Creates a mapping between fabric node IDs and mesh host ranks based on the mesh graph.
+ * For each fabric node in a mesh, this function identifies its mesh host rank by examining
+ * the mesh graph and creates a mapping of FabricNodeId to its mesh host rank.
+ *
+ * @param mesh_graph Reference to the mesh graph object containing fabric topology
+ * @return std::map<MeshId, std::map<FabricNodeId, MeshHostRankId>> Map from mesh ID to fabric node ID to mesh host rank
+ */
+std::map<MeshId, std::map<FabricNodeId, MeshHostRankId>> build_fabric_node_id_to_mesh_rank_mapping(
+    const ::tt::tt_fabric::MeshGraph& mesh_graph);
+
 }  // namespace tt::tt_metal::experimental::tt_fabric

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -54,7 +54,7 @@
 #include "tt_metal/fabric/fabric_tensix_builder_impl.hpp"
 #include "tt_metal/fabric/serialization/router_port_directions.hpp"
 #include "tt_stl/small_vector.hpp"
-#include "tt_metal/fabric/physical_system_descriptor.hpp"
+#include <tt-metalium/experimental/fabric/physical_system_descriptor.hpp>
 #include "tt_metal/fabric/serialization/port_descriptor_serialization.hpp"
 #include "tt_metal/fabric/serialization/intermesh_connections_serialization.hpp"
 #include <tt-metalium/experimental/fabric/topology_mapper.hpp>

--- a/tt_metal/fabric/mesh_graph.cpp
+++ b/tt_metal/fabric/mesh_graph.cpp
@@ -23,7 +23,7 @@
 #include <tt_stl/caseless_comparison.hpp>
 #include <tt-metalium/mesh_coord.hpp>
 #include <tt-metalium/experimental/fabric/mesh_graph_descriptor.hpp>
-#include "physical_system_descriptor.hpp"
+#include <tt-metalium/experimental/fabric/physical_system_descriptor.hpp>
 #include "protobuf/mesh_graph_descriptor.pb.h"
 #include "impl/context/metal_context.hpp"
 #include <numeric>
@@ -119,6 +119,10 @@ MeshGraph::MeshGraph(const std::string& mesh_graph_desc_file_path, std::optional
             "File provided: {}",
             mesh_graph_desc_file_path);
     }
+}
+
+MeshGraph::MeshGraph(const MeshGraphDescriptor& mgd, std::optional<FabricConfig> fabric_config) {
+    this->initialize_from_mgd(mgd, fabric_config);
 }
 
 void MeshGraph::add_to_connectivity(

--- a/tt_metal/fabric/mesh_graph_descriptor.cpp
+++ b/tt_metal/fabric/mesh_graph_descriptor.cpp
@@ -148,6 +148,13 @@ MeshGraphDescriptor::MeshGraphDescriptor(const std::string& text_proto, const bo
 
     TT_FATAL(parser.ParseFromString(text_proto, &temp_proto), "Failed to parse MeshGraphDescriptor textproto");
 
+    MeshGraphDescriptor(temp_proto, backwards_compatible);
+}
+
+MeshGraphDescriptor::MeshGraphDescriptor(const proto::MeshGraphDescriptor& proto, const bool backwards_compatible) :
+    top_level_id_(static_cast<GlobalNodeId>(-1)) {
+    proto::MeshGraphDescriptor temp_proto = proto;
+
     // Set defaults for missing fields
     set_defaults(temp_proto);
 

--- a/tt_metal/fabric/physical_system_descriptor.cpp
+++ b/tt_metal/fabric/physical_system_descriptor.cpp
@@ -15,7 +15,7 @@
 #include "tt_metal/llrt/tunnels_from_mmio_device.hpp"
 #include "tt_metal/llrt/hal.hpp"
 #include "tt_metal/llrt/rtoptions.hpp"
-#include "tt_metal/fabric/physical_system_descriptor.hpp"
+#include <tt-metalium/experimental/fabric/physical_system_descriptor.hpp>
 #include "tt_metal/fabric/serialization/physical_system_descriptor_serialization.hpp"
 
 namespace tt::tt_metal {

--- a/tt_metal/fabric/serialization/physical_system_descriptor_serialization.cpp
+++ b/tt_metal/fabric/serialization/physical_system_descriptor_serialization.cpp
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "physical_system_descriptor_serialization.hpp"
-#include "tt_metal/fabric/physical_system_descriptor.hpp"
+#include <tt-metalium/experimental/fabric/physical_system_descriptor.hpp>
 #include "protobuf/physical_system_descriptor.pb.h"
 #include <tt-metalium/experimental/fabric/fabric_types.hpp>
 #include <tt_metal/llrt/tt_target_device.hpp>

--- a/tt_metal/fabric/topology_mapper_utils.cpp
+++ b/tt_metal/fabric/topology_mapper_utils.cpp
@@ -13,7 +13,7 @@
 #include <tt-logger/tt-logger.hpp>
 #include <fmt/format.h>
 #include <tt-metalium/experimental/fabric/mesh_graph.hpp>
-#include "tt_metal/fabric/physical_system_descriptor.hpp"
+#include <tt-metalium/experimental/fabric/physical_system_descriptor.hpp>
 #include "tt_metal/impl/context/metal_context.hpp"
 #include <llrt/tt_cluster.hpp>
 
@@ -1016,6 +1016,19 @@ std::map<MeshId, PhysicalAdjacencyMap> build_adjacency_map_physical(
     }
 
     return adjacency_map;
+}
+
+std::map<MeshId, std::map<FabricNodeId, MeshHostRankId>> build_fabric_node_id_to_mesh_rank_mapping(
+    const ::tt::tt_fabric::MeshGraph& mesh_graph) {
+    std::map<MeshId, std::map<FabricNodeId, MeshHostRankId>> mapping;
+    for (const auto& mesh_id : mesh_graph.get_mesh_ids()) {
+        for (const auto& [_, chip_id] : mesh_graph.get_chip_ids(mesh_id)) {
+            auto host_rank = mesh_graph.get_host_rank_for_chip(mesh_id, chip_id);
+            TT_FATAL(host_rank.has_value(), "Fabric node id {} not found", FabricNodeId(mesh_id, chip_id));
+            mapping[mesh_id][FabricNodeId(mesh_id, chip_id)] = host_rank.value();
+        }
+    }
+    return mapping;
 }
 
 }  // namespace tt::tt_metal::experimental::tt_fabric


### PR DESCRIPTION
### Ticket

### Problem description
In order to `map_mesh_to_physical`, Fabric Manager needs to be able to create all the structures required to carry out the MGD->physical mesh resolution. Currently not all of those are included in the public API of tt-metal.

### What's changed
Expose calls and types needed by Fabric Manager to run MGD->physical mesh resolution

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] [cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) job passes
- [ ] New/Existing tests provide coverage for changes