### PR TITLE
[CONV] Relaxing the pcc threshold for the recently regressed test case

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
@@ -346,6 +346,8 @@ def run_conv(
                 pcc = 0.97
         elif math_fidelity == ttnn.MathFidelity.LoFi and output_dtype == ttnn.bfloat8_b:
             pcc = 0.996
+        elif activation is not None and activation.op_type == ttnn.UnaryOpType.SIGMOID:
+            pcc = 0.995
         else:
             pcc = 0.997
 
@@ -678,13 +680,13 @@ def test_conv_features_multi_device(
 @pytest.mark.parametrize(
     "activation",
     [
-        None,
-        ttnn.UnaryWithParam(ttnn.UnaryOpType.RELU),
-        ttnn.UnaryWithParam(ttnn.UnaryOpType.SILU),
+        # None,
+        # ttnn.UnaryWithParam(ttnn.UnaryOpType.RELU),
+        # ttnn.UnaryWithParam(ttnn.UnaryOpType.SILU),
         ttnn.UnaryWithParam(ttnn.UnaryOpType.SIGMOID),
-        ttnn.UnaryWithParam(ttnn.UnaryOpType.TANH),
-        ttnn.UnaryWithParam(ttnn.UnaryOpType.SQRT),
-        ttnn.UnaryWithParam(ttnn.UnaryOpType.GELU),
+        # ttnn.UnaryWithParam(ttnn.UnaryOpType.TANH),
+        # ttnn.UnaryWithParam(ttnn.UnaryOpType.SQRT),
+        # ttnn.UnaryWithParam(ttnn.UnaryOpType.GELU),
     ],
 )
 def test_conv_activation(

--- a/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
@@ -680,13 +680,13 @@ def test_conv_features_multi_device(
 @pytest.mark.parametrize(
     "activation",
     [
-        # None,
-        # ttnn.UnaryWithParam(ttnn.UnaryOpType.RELU),
-        # ttnn.UnaryWithParam(ttnn.UnaryOpType.SILU),
+        None,
+        ttnn.UnaryWithParam(ttnn.UnaryOpType.RELU),
+        ttnn.UnaryWithParam(ttnn.UnaryOpType.SILU),
         ttnn.UnaryWithParam(ttnn.UnaryOpType.SIGMOID),
-        # ttnn.UnaryWithParam(ttnn.UnaryOpType.TANH),
-        # ttnn.UnaryWithParam(ttnn.UnaryOpType.SQRT),
-        # ttnn.UnaryWithParam(ttnn.UnaryOpType.GELU),
+        ttnn.UnaryWithParam(ttnn.UnaryOpType.TANH),
+        ttnn.UnaryWithParam(ttnn.UnaryOpType.SQRT),
+        ttnn.UnaryWithParam(ttnn.UnaryOpType.GELU),
     ],
 )
 def test_conv_activation(

--- a/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
@@ -347,6 +347,9 @@ def run_conv(
         elif math_fidelity == ttnn.MathFidelity.LoFi and output_dtype == ttnn.bfloat8_b:
             pcc = 0.996
         elif activation is not None and activation.op_type == ttnn.UnaryOpType.SIGMOID:
+            # Scale down PCC for sigmoid.
+            # The sigmoid function relies on the exp approximation, which can introduce small discrepancies in output values.
+            # This necessitates a slightly lower PCC threshold, similar to the adjustment for tanh.
             pcc = 0.995
         else:
             pcc = 0.997


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Recent [addition](https://github.com/tenstorrent/tt-metal/commit/f080a17769edcc969da9a24526a95f2014f1b6af) to approximating exp introduced regression in one of test cases of conv activations. This is currently failing as a part of [L2 Nightly pipeline ](https://github.com/tenstorrent/tt-metal/actions/runs/20157921670/job/57864483932)

### What's changed
Pcc threshold was relaxed for this case

### Pipelines 

- [x] [APC](https://github.com/tenstorrent/tt-metal/actions/runs/20169584537)