### PR TITLE
fix: adjust const char* size checks using strlen for assertions

### DIFF
--- a/tests/tt_metal/tt_metal/test_kernels/misc/print_buffering.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/print_buffering.cpp
@@ -5,6 +5,7 @@
 #include "dataflow_api.h"
 #include "debug/dprint.h"
 #include "debug/assert.h"
+#include <cstring>
 
 void kernel_main() {
     uint32_t core_x = get_arg_val<uint32_t>(0);
@@ -14,7 +15,7 @@ void kernel_main() {
     const char* msg2 = "Adding the alphabet to extend the size of this message: ABCDEFGHIJKLMNOPQRSTUVWXYZ.";
     const char* msg3 = "Now, in reverse, to make it even longer: ZYXWVUTSRQPONMLKJIHGFEDCBA.";
 
-    ASSERT(msg1.size() + msg2.size() + msg3.size() > DPRINT_BUFFER_SIZE);
+    ASSERT(strlen(msg1) + strlen(msg2) + strlen(msg3) > DPRINT_BUFFER_SIZE);
     DPRINT << "(" << core_x << "," << core_y << "): " << msg1 << " (" << core_x << "," << core_y << "): " << msg2
            << " (" << core_x << "," << core_y << "): " << msg3 << ENDL();
 
@@ -26,7 +27,7 @@ void kernel_main() {
         "ability to talk to all creatures. From that day on, Tim helped others, becoming a hero in the animal kingdom. "
         "And so, the little mouse learned that bravery and kindness can change the world.";
 
-    ASSERT(large_msg > DPRINT_BUFFER_SIZE);
+    ASSERT(strlen(large_msg) > DPRINT_BUFFER_SIZE);
     DPRINT << "(" << core_x << "," << core_y << "): " << large_msg << ENDL();
 
     const char* msg_with_newlines =


### PR DESCRIPTION
### Ticket
None

### Problem description
File contains errors preventing it from compiling when the asserts are turned on. This was never compiling, but it wasn't caught because no checks were run.
```
/work/tests/tt_metal/tt_metal/test_kernels/misc/print_buffering.cpp: In function 'void kernel_main()':
/work/tests/tt_metal/tt_metal/test_kernels/misc/print_buffering.cpp:17:17: error: request for member 'size' in 'msg1', which is of non-class type 'const char*'
   17 |     ASSERT(msg1.size() + msg2.size() + msg3.size() > DPRINT_BUFFER_SIZE);
      |                 ^~~~
/work/tt_metal/hw/inc/debug/assert.h:58:15: note: in definition of macro 'ASSERT'
   58 |         if (!(condition))              \
      |               ^~~~~~~~~
/work/tests/tt_metal/tt_metal/test_kernels/misc/print_buffering.cpp:17:31: error: request for member 'size' in 'msg2', which is of non-class type 'const char*'
   17 |     ASSERT(msg1.size() + msg2.size() + msg3.size() > DPRINT_BUFFER_SIZE);
      |                               ^~~~
/work/tt_metal/hw/inc/debug/assert.h:58:15: note: in definition of macro 'ASSERT'
   58 |         if (!(condition))              \
      |               ^~~~~~~~~
/work/tests/tt_metal/tt_metal/test_kernels/misc/print_buffering.cpp:17:45: error: request for member 'size' in 'msg3', which is of non-class type 'const char*'
   17 |     ASSERT(msg1.size() + msg2.size() + msg3.size() > DPRINT_BUFFER_SIZE);
      |                                             ^~~~
/work/tt_metal/hw/inc/debug/assert.h:58:15: note: in definition of macro 'ASSERT'
   58 |         if (!(condition))              \
      |               ^~~~~~~~~
/work/tests/tt_metal/tt_metal/test_kernels/misc/print_buffering.cpp:29:22: error: ISO C++ forbids comparison between pointer and integer [-fpermissive]
   29 |     ASSERT(large_msg > DPRINT_BUFFER_SIZE);
```
See the full error log [here](https://github.com/tenstorrent/tt-metal/actions/runs/20168258225/job/57897480697).

### What's changed
Fixed compilation errors where `.size()` was incorrectly called on `const char*` pointers. Replaced with proper `strlen()` calls to get string lengths.