### PR TITLE
Accurate fp32 log1p

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_log.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_log.h
@@ -198,7 +198,9 @@ inline void calculate_log(uint log_base_scale_factor) {
 template <bool APPROXIMATION_MODE, bool FAST_APPROX, bool is_fp32_dest_acc_en>
 inline void log_init() {
     if constexpr (!is_fp32_dest_acc_en) {
-        log_init<APPROXIMATION_MODE, FAST_APPROX, is_fp32_dest_acc_en>();
+        sfpi::vConstFloatPrgm0 = 0.693147182464599609375;  // ln(2)
+        sfpi::vConstFloatPrgm1 = -2.0069785118103027;
+        sfpi::vConstFloatPrgm2 = 3.767500400543213;
     } else {
         // _init_sfpu_reciprocal_ sets vConstFloatPrgm0 to 2.0f
         _init_sfpu_reciprocal_</*approximation_mode*/ false>();

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_log.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_log.h
@@ -198,9 +198,7 @@ inline void calculate_log(uint log_base_scale_factor) {
 template <bool APPROXIMATION_MODE, bool FAST_APPROX, bool is_fp32_dest_acc_en>
 inline void log_init() {
     if constexpr (!is_fp32_dest_acc_en) {
-        sfpi::vConstFloatPrgm0 = 0.693147182464599609375;  // ln(2)
-        sfpi::vConstFloatPrgm1 = -2.0069785118103027;
-        sfpi::vConstFloatPrgm2 = 3.767500400543213;
+        log_init<APPROXIMATION_MODE, FAST_APPROX, is_fp32_dest_acc_en>();
     } else {
         // _init_sfpu_reciprocal_ sets vConstFloatPrgm0 to 2.0f
         _init_sfpu_reciprocal_</*approximation_mode*/ false>();

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_log1p.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_log1p.h
@@ -6,33 +6,32 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
-
-using namespace sfpi;
+#include "ckernel_sfpu_recip.h"
 
 namespace ckernel {
 namespace sfpu {
 
-template <bool APPROXIMATION_MODE, bool FAST_APPROX, int ITERATIONS = 8>
+template <bool APPROXIMATION_MODE, bool FAST_APPROX, bool is_fp32_dest_acc_en, int ITERATIONS = 8>
 inline void calculate_log1p() {
-    vFloat a = vConstFloatPrgm1;
-    vFloat b = vConstFloatPrgm2;
-    vFloat vConstLn2 = vConstFloatPrgm0;
+    sfpi::vFloat a = sfpi::vConstFloatPrgm1;
+    sfpi::vFloat b = sfpi::vConstFloatPrgm2;
+    sfpi::vFloat vConstLn2 = sfpi::vConstFloatPrgm0;
 
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
-        vFloat in = dst_reg[0];
+        sfpi::vFloat in = sfpi::dst_reg[0];
         in = in + 1.0f;
-        vFloat x = setexp(in, 127);  // Normalize to [1, 2] range
+        sfpi::vFloat x = sfpi::setexp(in, 127);  // Normalize to [1, 2] range
 
         // Cheby Approximation using Horner Form Multiplication: 3rd Order
-        vFloat series_result = x * (x * (x * a + b) + 2.0871) + -1.4753f;
+        sfpi::vFloat series_result = x * (x * (x * a + b) + 2.0871) + -1.4753f;
 
-        vInt exp = exexp(in);
-        v_if(exp < 0) { exp = setsgn(~exp + 1, 1); }
+        sfpi::vInt exp = sfpi::exexp(in);
+        v_if(exp < 0) { exp = sfpi::setsgn(~exp + 1, 1); }
         v_endif;
 
-        vFloat expf = int32_to_float(exp, 0);
-        vFloat result = expf * vConstLn2 + series_result;
+        sfpi::vFloat expf = sfpi::int32_to_float(exp, 0);
+        sfpi::vFloat result = expf * vConstLn2 + series_result;
 
         v_if(in == 0.0F) { result = -std::numeric_limits<float>::infinity(); }
         v_endif;
@@ -44,16 +43,178 @@ inline void calculate_log1p() {
             v_endif;
         }
 
-        dst_reg[0] = result;
-        ++dst_reg;
+        if constexpr (!is_fp32_dest_acc_en) {
+            result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
+        }
+
+        sfpi::dst_reg[0] = result;
+        ++sfpi::dst_reg;
     }
 }
 
-template <bool APPROXIMATION_MODE, bool FAST_APPROX>
+/*
+ * This function implements ln(1+x) with accurate computation for small x.
+ * Algorithm based on log1p_fp32 from operations.py:
+ * 1. Handle special cases (x < -1, x == -1, infinity, NaN)
+ * 2. For |x| < 0.3: Use 13-term Taylor series to avoid catastrophic cancellation
+ * 3. For |x| >= 0.3: Use standard ln(1+x) computation
+ *
+ * The threshold of 0.3 and 13 terms were chosen through systematic optimization
+ * to minimize maximum ULP error across the entire domain.
+ *
+ * @param val The input value (vFloat vector), can be any floating point number > -1
+ * @return vFloat Result of ln(1+val)
+ */
+template <bool is_fp32_dest_acc_en>
+sfpi_inline sfpi::vFloat calculate_log1p_fp32(sfpi::vFloat val) {
+    sfpi::vFloat result = sfpi::vConst0;
+
+    // Constants
+    constexpr float THRESHOLD = 0.3f;
+    constexpr float NEG_ONE = -1.0f;
+    constexpr float LN2 = 0.6931471805599453f;
+    constexpr float SQRT2 = 1.4142135623730951f;
+    constexpr float HALF = 0.5f;
+    constexpr float ONE = 1.0f;
+    constexpr float TWO = 2.0f;
+
+    // Check for special cases using IEEE 754 bit patterns
+    sfpi::vInt exp_bits = sfpi::exexp(val);   // Get debiased exponent
+    sfpi::vInt man_bits = sfpi::exman9(val);  // Get mantissa bits (without implicit bit)
+
+    // NaN check: debiased exponent == 128 (original exp = 255) and mantissa != 0
+    v_if(exp_bits == 128 && man_bits != 0) { result = std::numeric_limits<float>::quiet_NaN(); }
+    v_elseif(val < NEG_ONE) {
+        // Domain error: ln(1+x) undefined for x < -1
+        result = std::numeric_limits<float>::quiet_NaN();
+    }
+    v_elseif(val == NEG_ONE) {
+        // ln(0) = -infinity
+        result = -std::numeric_limits<float>::infinity();
+    }
+    v_elseif(exp_bits == 128 && man_bits == 0 && val > sfpi::vConst0) {
+        // Positive infinity: ln(+inf) = +inf
+        result = std::numeric_limits<float>::infinity();
+    }
+    v_else {
+        // Normal computation
+        sfpi::vFloat abs_val = sfpi::abs(val);
+
+        v_if(abs_val < THRESHOLD) {
+            // For |x| < 0.3, use 13-term Taylor series to avoid catastrophic cancellation
+            // ln(1+x) = x - x²/2 + x³/3 - x⁴/4 + ... + x¹³/13
+            // Using PolynomialEvaluator with coefficients in ascending order:
+            // ln(1+x) = 0 + x*(1 + x*(-1/2 + x*(1/3 + x*(-1/4 + ...))))
+            result = sfpi::PolynomialEvaluator::eval(
+                val,
+                sfpi::vConst0,  // c0 = 0
+                sfpi::vConst1,  // c1 = 1
+                -0.5f,          // c2 = -1/2
+                1.0f / 3.0f,    // c3 = 1/3
+                -0.25f,         // c4 = -1/4
+                0.2f,           // c5 = 1/5
+                -1.0f / 6.0f,   // c6 = -1/6
+                1.0f / 7.0f,    // c7 = 1/7
+                -0.125f,        // c8 = -1/8
+                1.0f / 9.0f,    // c9 = 1/9
+                -0.1f,          // c10 = -1/10
+                1.0f / 11.0f,   // c11 = 1/11
+                -1.0f / 12.0f,  // c12 = -1/12
+                1.0f / 13.0f    // c13 = 1/13
+            );
+        }
+        v_else {
+            // For |x| >= 0.3, use standard ln(1+x) computation
+            // Apply the same algorithm as log-claude.cpp but on (1+x)
+            sfpi::vFloat one_plus_x = sfpi::vConst1 + val;
+
+            // Extract exponent (debiased) from (1+x)
+            sfpi::vInt exp = sfpi::exexp(one_plus_x);
+
+            // Extract mantissa and construct m in [1, 2)
+            // Use setexp to normalize to [1, 2) range by setting exponent to 127 (bias)
+            sfpi::vFloat m = sfpi::setexp(one_plus_x, 127);
+
+            // Range reduction: if m >= sqrt(2), divide by 2 and increment exponent
+            // This ensures m is in [sqrt(2)/2, sqrt(2)] ≈ [0.707, 1.414]
+            v_if(m >= SQRT2) {
+                m = m * HALF;
+                exp = exp + 1;
+            }
+            v_endif;
+
+            // Transform to z = (m - 1) / (m + 1)
+            // This maps m ∈ [0.707, 1.414] to z ∈ [-0.172, 0.172]
+            // ln(m) = 2 × (z + z³/3 + z⁵/5 + z⁷/7 + ...)
+            sfpi::vFloat m_minus_1 = m - ONE;
+            sfpi::vFloat m_plus_1 = m + ONE;
+
+            // Compute z = (m - 1) / (m + 1) using reciprocal
+            sfpi::vFloat m_plus_1_recip = ckernel::sfpu::_sfpu_reciprocal_<2>(m_plus_1);
+            sfpi::vFloat z = m_minus_1 * m_plus_1_recip;
+
+            // Compute z² for polynomial evaluation
+            sfpi::vFloat z2 = z * z;
+
+            // Polynomial approximation using odd powers
+            // ln(m) = 2z(1 + z²/3 + z⁴/5 + z⁶/7 + z⁸/9 + z¹⁰/11)
+            // Using Horner's method on z² with coefficients
+            constexpr float c11 = 1.0f / 11.0f;
+            constexpr float c9 = 1.0f / 9.0f;
+            constexpr float c7 = 1.0f / 7.0f;
+            constexpr float c5 = 0.2f;
+            constexpr float c3 = 1.0f / 3.0f;
+
+            sfpi::vFloat p = sfpi::PolynomialEvaluator::eval(
+                z2,
+                sfpi::vConst1,  // c0 = 1
+                c3,             // c1 = 1/3
+                c5,             // c2 = 1/5
+                c7,             // c3 = 1/7
+                c9,             // c4 = 1/9
+                c11             // c5 = 1/11
+            );
+
+            // Final computation: ln(m) = 2 * z * p
+            sfpi::vFloat ln_m = TWO * z * p;
+
+            // Combine: ln(1+x) = exp×ln(2) + ln(m)
+            // Convert exponent to float using sign-magnitude format
+            sfpi::vInt exp_for_convert = exp;
+
+            // Convert negative exponents to sign-magnitude format
+            v_if(exp < 0) {
+                sfpi::vInt exp_abs = ~exp + 1;               // Two's complement negation
+                exp_for_convert = sfpi::setsgn(exp_abs, 1);  // Set sign bit for negative
+            }
+            v_endif;
+
+            sfpi::vFloat expf = sfpi::int32_to_float(exp_for_convert, 0);
+
+            result = expf * LN2 + ln_m;
+        }
+        v_endif;
+    }
+    v_endif;
+
+    if constexpr (!is_fp32_dest_acc_en) {
+        // Convert to bfloat16 if needed using round-to-nearest-even
+        result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
+    }
+
+    return result;
+}
+
+template <bool APPROXIMATION_MODE, bool FAST_APPROX, bool is_fp32_dest_acc_en>
 inline void log1p_init() {
-    vConstFloatPrgm0 = 0.692871f;  // ln2
-    vConstFloatPrgm1 = 0.1058f;
-    vConstFloatPrgm2 = -0.7166f;
+    if constexpr (!is_fp32_dest_acc_en) {
+        sfpi::vConstFloatPrgm0 = 0.692871f;  // ln2
+        sfpi::vConstFloatPrgm1 = 0.1058f;
+        sfpi::vConstFloatPrgm2 = -0.7166f;
+    } else {
+        // Initialize reciprocal kernel for division operations in the ln computation path
+        _init_reciprocal_</*approximation_mode*/ false, /*legacy_compat*/ false>();
+    }
 }
 
 }  // namespace sfpu

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_log1p.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_log1p.h
@@ -77,7 +77,8 @@ sfpi_inline sfpi::vFloat calculate_log1p_fp32(sfpi::vFloat val) {
 
         constexpr float THRESHOLD = 0.3f;
         v_if(abs_val < THRESHOLD) {
-            // For |x| < 0.3, use 9-term polynomial series to avoid catastrophic cancellation
+            // For |x| < 0.3, use 9-term polynomial series (with 10 coefficients  including constant term)
+            // to avoid catastrophic cancellation
             // Coefficients were computed using Sollya with the following command:
             // > fpminimax(log(x+1), [|1,2,3,4,5,6,7,8,9|], [|single...|], [-0.3; -2^(-20)] + [2^(-20); 0.3], relative);
             result = PolynomialEvaluator::eval(

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_log1p.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_log1p.h
@@ -110,7 +110,7 @@ sfpi_inline sfpi::vFloat calculate_log1p_fp32(sfpi::vFloat val) {
             // This ensures m is in [sqrt(2)/2, sqrt(2)] ≈ [0.707, 1.414]
             // Use vConstFloatPrgm1 which is set to sqrt(2) in log_init
             v_if(m >= sfpi::vConstFloatPrgm1) {
-                Cnay m = m * 0.5f;  // Divide by 2
+                m = m * 0.5f;   // Divide by 2
                 exp = exp + 1;  // Increment exponent
             }
             v_endif;

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_log1p.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_log1p.h
@@ -22,9 +22,16 @@ namespace sfpu {
  */
 template <bool FAST_APPROX, bool is_fp32_dest_acc_en>
 sfpi_inline sfpi::vFloat calculate_log1p_bf16(sfpi::vFloat val) {
-    sfpi::vFloat in = val + sfpi::vConst1;
-    sfpi::vFloat result =
-        calculate_log_body<FAST_APPROX, /*HAS_BASE_SCALING*/ false, /*is_fp32_dest_acc_en*/ true>(in, 0);
+    sfpi::vFloat abs_x = sfpi::abs(val);
+    sfpi::vFloat result;
+    v_if(abs_x < 0.0078125) {  // use 2^(-7) as threshold value
+        result = val;          // log(1+x) ~ x for x < 0.01
+    }
+    v_else {
+        sfpi::vFloat in = val + sfpi::vConst1;
+        result = calculate_log_body<FAST_APPROX, /*HAS_BASE_SCALING*/ false, /*is_fp32_dest_acc_en*/ true>(in, 0);
+    }
+    v_endif;
 
     if constexpr (!is_fp32_dest_acc_en) {
         result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
@@ -70,27 +77,21 @@ sfpi_inline sfpi::vFloat calculate_log1p_fp32(sfpi::vFloat val) {
 
         constexpr float THRESHOLD = 0.3f;
         v_if(abs_val < THRESHOLD) {
-            // For |x| < 0.3, use 13-term Taylor series to avoid catastrophic cancellation
-            // ln(1+x) = x - x²/2 + x³/3 - x⁴/4 + ... + x¹³/13
-            // Using PolynomialEvaluator with coefficients in ascending order:
-            // ln(1+x) = 0 + x*(1 + x*(-1/2 + x*(1/3 + x*(-1/4 + ...))))
+            // For |x| < 0.3, use 10-term polynomial series to avoid catastrophic cancellation
+            // Coefficients were computed using Sollya with the following command:
+            // > fpminimax(log(x+1), [|1,2,3,4,5,6,7,8,9|], [|single...|], [-0.3; -2^(-20)] + [2^(-20); 0.3], relative);
             result = PolynomialEvaluator::eval(
                 val,
-                sfpi::vConst0,  // c0 = 0
-                sfpi::vConst1,  // c1 = 1
-                -0.5f,          // c2 = -1/2
-                1.0f / 3.0f,    // c3 = 1/3
-                -0.25f,         // c4 = -1/4
-                0.2f,           // c5 = 1/5
-                -1.0f / 6.0f,   // c6 = -1/6
-                1.0f / 7.0f,    // c7 = 1/7
-                -0.125f,        // c8 = -1/8
-                1.0f / 9.0f,    // c9 = 1/9
-                -0.1f,          // c10 = -1/10
-                1.0f / 11.0f,   // c11 = 1/11
-                -1.0f / 12.0f,  // c12 = -1/12
-                1.0f / 13.0f    // c13 = 1/13
-            );
+                sfpi::vConst0,
+                sfpi::vConst1,
+                -0.4999997317790985107421875f,
+                0.333332836627960205078125f,
+                -0.250040113925933837890625f,
+                0.20005328953266143798828125f,
+                -0.1650786101818084716796875f,
+                0.14109231531620025634765625f,
+                -0.14774705469608306884765625f,
+                0.133655369281768798828125);
         }
         v_else {
             // For |x| >= 0.3, use standard ln(1+x) computation

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_log1p.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_log1p.h
@@ -10,15 +10,16 @@
 
 namespace ckernel {
 
-template <bool APPROXIMATE, bool FAST_APPROX>
+template <bool APPROXIMATE, bool FAST_APPROX, bool is_fp32_dest_acc_en>
 inline void llk_math_eltwise_unary_sfpu_log1p_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::log1p, APPROXIMATE>(sfpu::log1p_init<APPROXIMATE, FAST_APPROX>);
+    llk_math_eltwise_unary_sfpu_init<SfpuType::log1p, APPROXIMATE>(
+        sfpu::log1p_init<APPROXIMATE, FAST_APPROX, is_fp32_dest_acc_en>);
 }
 
-template <bool APPROXIMATE, bool FAST_APPROX>
+template <bool APPROXIMATE, bool FAST_APPROX, bool is_fp32_dest_acc_en>
 inline void llk_math_eltwise_unary_sfpu_log1p(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_log1p<APPROXIMATE, FAST_APPROX>, dst_index, vector_mode);
+        ckernel::sfpu::calculate_log1p<APPROXIMATE, FAST_APPROX, is_fp32_dest_acc_en>, dst_index, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_log1p.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_log1p.h
@@ -42,8 +42,8 @@ sfpi_inline sfpi::vFloat calculate_log1p_bf16(sfpi::vFloat val) {
  * 2. For |x| < 0.3: Use 13-term Taylor series to avoid catastrophic cancellation
  * 3. For |x| >= 0.3: Use standard ln(1+x) computation
  *
- * The threshold of 0.3 and 13 terms were chosen through systematic optimization
- * to minimize maximum ULP error across the entire domain.
+ * The threshold of 0.3 and 13 terms work well enough to provide good accuracy
+ * across the entire domain.
  *
  * @param val The input value (sfpi::vFloat vector), can be any floating point number > -1
  * @return sfpi::vFloat Result of ln(1+val)
@@ -63,7 +63,7 @@ sfpi_inline sfpi::vFloat calculate_log1p_fp32(sfpi::vFloat val) {
         result = std::numeric_limits<float>::quiet_NaN();  // returns nan
     }
     v_elseif(val == -1.f) {
-        // Zero input -> -inf
+        // x = -1 input -> -inf
         result = -std::numeric_limits<float>::infinity();
     }
     v_else {
@@ -96,12 +96,11 @@ sfpi_inline sfpi::vFloat calculate_log1p_fp32(sfpi::vFloat val) {
         }
         v_else {
             // The following is the same approximation as calculate_log_f32_body from ckernel_sfpu_log.h.
-            // Ideally, we would like to call calculate_log_f32_body() directoyl.
-            // However, doing do lead to 'register spilling errors' due to interaction with the
+            // Ideally, we would like to call calculate_log_f32_body() directly.
+            // However, doing so leads to 'register spilling errors' due to interaction with the
             // polynomial evaluation near 0.
 
             // For |x| >= 0.3, use standard ln(1+x) computation
-            // Apply the same algorithm as log-claude.cpp but on (1+x)
             sfpi::vFloat one_plus_x = sfpi::vConst1 + val;
 
             // Extract exponent (debiased) from (1+x)

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_log1p.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_log1p.h
@@ -77,7 +77,8 @@ sfpi_inline sfpi::vFloat calculate_log1p_fp32(sfpi::vFloat val) {
 
         constexpr float THRESHOLD = 0.3f;
         v_if(abs_val < THRESHOLD) {
-            // For |x| < 0.3, use 9-term polynomial series to avoid catastrophic cancellation
+            // For |x| < 0.3, use 9-term polynomial series (with 10 coefficients including constant term)
+            // to avoid catastrophic cancellation
             // Coefficients were computed using Sollya with the following command:
             // > fpminimax(log(x+1), [|1,2,3,4,5,6,7,8,9|], [|single...|], [-0.3; -2^(-20)] + [2^(-20); 0.3], relative);
             result = PolynomialEvaluator::eval(

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_log1p.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_log1p.h
@@ -6,54 +6,211 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
-
-using namespace sfpi;
+#include "ckernel_sfpu_log.h"
 
 namespace ckernel {
 namespace sfpu {
 
-template <bool APPROXIMATION_MODE, bool FAST_APPROX, int ITERATIONS = 8>
-inline void calculate_log1p() {
-    vFloat a = vConstFloatPrgm1;
-    vFloat b = vConstFloatPrgm2;
-    vFloat vConstLn2 = vConstFloatPrgm0;
+/*
+ * This function implements ln(1+x) using Chebyshev approximation for bfloat16.
+ * Uses 3rd order Chebyshev polynomial approximation with range reduction.
+ *
+ * @tparam FAST_APPROX If true, skip NaN check for negative inputs
+ * @tparam is_fp32_dest_acc_en If false, round result to bfloat16
+ * @param val The input value x
+ * @return Result of ln(1+val)
+ */
+template <bool FAST_APPROX, bool is_fp32_dest_acc_en>
+sfpi_inline sfpi::vFloat calculate_log1p_bf16(sfpi::vFloat val) {
+    // Read programmable constants
 
-#pragma GCC unroll 8
-    for (int d = 0; d < ITERATIONS; d++) {
-        vFloat in = dst_reg[0];
-        in = in + 1.0f;
-        vFloat x = setexp(in, 127);  // Normalize to [1, 2] range
+    sfpi::vFloat in = val + sfpi::vConst1;
+    sfpi::vFloat result =
+        calculate_log_body<FAST_APPROX, /*HAS_BASE_SCALING*/ false, /*is_fp32_dest_acc_en*/ true>(in, 0);
 
-        // Cheby Approximation using Horner Form Multiplication: 3rd Order
-        vFloat series_result = x * (x * (x * a + b) + 2.0871) + -1.4753f;
+    if constexpr (!is_fp32_dest_acc_en) {
+        result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
+    }
 
-        vInt exp = exexp(in);
-        v_if(exp < 0) { exp = setsgn(~exp + 1, 1); }
-        v_endif;
+    return result;
+}
 
-        vFloat expf = int32_to_float(exp, 0);
-        vFloat result = expf * vConstLn2 + series_result;
+/*
+ * This function implements ln(1+x) with accurate computation for small x.
+ * Algorithm based on log1p_fp32 from operations.py:
+ * 1. Handle special cases (x < -1, x == -1, infinity, NaN)
+ * 2. For |x| < 0.3: Use 13-term Taylor series to avoid catastrophic cancellation
+ * 3. For |x| >= 0.3: Use standard ln(1+x) computation
+ *
+ * The threshold of 0.3 and 13 terms were chosen through systematic optimization
+ * to minimize maximum ULP error across the entire domain.
+ *
+ * @param val The input value (sfpi::vFloat vector), can be any floating point number > -1
+ * @return sfpi::vFloat Result of ln(1+val)
+ */
+template <bool is_fp32_dest_acc_en>
+sfpi_inline sfpi::vFloat calculate_log1p_fp32(sfpi::vFloat val) {
+    sfpi::vFloat result = sfpi::vConst0;
 
-        v_if(in == 0.0F) { result = -std::numeric_limits<float>::infinity(); }
-        v_endif;
+    // Check for special cases
+    sfpi::vInt exp = sfpi::exexp(val);  // Get debiased exponent
 
-        if constexpr (!FAST_APPROX) {
-            v_if(in < 0.0F) {
-                result = std::numeric_limits<float>::quiet_NaN();  // returns nan for fp32 and inf for bf16
+    v_if(sfpi::reinterpret<sfpi::vInt>(val) == 0x7F800000) {
+        // If input is infinity, return infinity
+        result = std::numeric_limits<float>::infinity();
+    }
+    v_elseif(exp == 128 || val < -1.f) {                   // NaN or negative input -> NaN
+        result = std::numeric_limits<float>::quiet_NaN();  // returns nan
+    }
+    v_elseif(val == -1.f) {
+        // Zero input -> -inf
+        result = -std::numeric_limits<float>::infinity();
+    }
+    v_else {
+        // Normal computation
+        sfpi::vFloat abs_val = sfpi::abs(val);
+
+        constexpr float THRESHOLD = 0.3f;
+        v_if(abs_val < THRESHOLD) {
+            // For |x| < 0.3, use 13-term Taylor series to avoid catastrophic cancellation
+            // ln(1+x) = x - x²/2 + x³/3 - x⁴/4 + ... + x¹³/13
+            // Using PolynomialEvaluator with coefficients in ascending order:
+            // ln(1+x) = 0 + x*(1 + x*(-1/2 + x*(1/3 + x*(-1/4 + ...))))
+            result = PolynomialEvaluator::eval(
+                val,
+                sfpi::vConst0,  // c0 = 0
+                sfpi::vConst1,  // c1 = 1
+                -0.5f,          // c2 = -1/2
+                1.0f / 3.0f,    // c3 = 1/3
+                -0.25f,         // c4 = -1/4
+                0.2f,           // c5 = 1/5
+                -1.0f / 6.0f,   // c6 = -1/6
+                1.0f / 7.0f,    // c7 = 1/7
+                -0.125f,        // c8 = -1/8
+                1.0f / 9.0f,    // c9 = 1/9
+                -0.1f,          // c10 = -1/10
+                1.0f / 11.0f,   // c11 = 1/11
+                -1.0f / 12.0f,  // c12 = -1/12
+                1.0f / 13.0f    // c13 = 1/13
+            );
+        }
+        v_else {
+            // The following is the same approximation as calculate_log_f32_body from ckernel_sfpu_log.h.
+            // Ideally, we would like to call calculate_log_f32_body() directoyl.
+            // However, doing do lead to 'register spilling errors' due to interaction with the
+            // polynomial evaluation near 0.
+
+            // For |x| >= 0.3, use standard ln(1+x) computation
+            // Apply the same algorithm as log-claude.cpp but on (1+x)
+            sfpi::vFloat one_plus_x = sfpi::vConst1 + val;
+
+            // Extract exponent (debiased) from (1+x)
+            exp = sfpi::exexp(one_plus_x);
+
+            // Extract mantissa and construct m in [1, 2)
+            // Use setexp to normalize to [1, 2) range by setting exponent to 127 (bias)
+            sfpi::vFloat m = sfpi::setexp(one_plus_x, 127);
+
+            // Step 2: Range reduction
+            // If m >= sqrt(2), divide by 2 and increment exponent
+            // This ensures m is in [sqrt(2)/2, sqrt(2)] ≈ [0.707, 1.414]
+            constexpr float SQRT2 = 1.4142135381698608f;  // sqrt(2)
+            v_if(m >= SQRT2) {
+                // m = m * 0.5f;  // Divide by 2
+                m = m * 0.5f;
+                exp = exp + 1;  // Increment exponent
             }
             v_endif;
-        }
 
-        dst_reg[0] = result;
-        ++dst_reg;
+            // Transform to z = (m - 1) / (m + 1)
+            // This maps m ∈ [0.707, 1.414] to z ∈ [-0.172, 0.172]
+            // ln(m) = 2 × (z + z³/3 + z⁵/5 + z⁷/7 + ...)
+            sfpi::vFloat m_minus_1 = m - sfpi::vConst1;
+            sfpi::vFloat m_plus_1 = m + sfpi::vConst1;
+
+            // Compute z = (m - 1) / (m + 1) using reciprocal
+            // z = m_minus_1 * (1 / m_plus_1)
+            sfpi::vFloat m_plus_1_recip = ckernel::sfpu::_sfpu_reciprocal_<2>(m_plus_1);
+            sfpi::vFloat z = m_minus_1 * m_plus_1_recip;
+
+            // Compute z**2 for polynomial evaluation
+            sfpi::vFloat z2 = z * z;
+
+            // Step 4: Polynomial approximation using odd powers
+            // ln(m) = 2z(1 + (z**2)/3 + (z**4)/5 + (z**6)/7 + (z**8)/9 + (z**10)/11)
+            // Using Horner's method: p = 1 + z**2 * (c3 + z**2 * (c5 + z**2 * (c7 + z**2 * (c9 + z**2 * c11))))
+
+            // Polynomial coefficients for ln(m) where m in [sqrt(2)/2, sqrt(2)]
+            // ln(m) = 2z(1 + z²/3 + z⁴/5 + z⁶/7 + z⁸/9 + z¹⁰/11)
+            // where z = (m - 1) / (m + 1)
+            sfpi::vFloat p = PolynomialEvaluator::eval(
+                z2,
+                sfpi::vConst1,
+                0.3333333333333333f,
+                0.2f,
+                0.14285714285714285f,
+                0.1111111111111111f,
+                .09090909090909091f);
+
+            // Final computation: ln(m) = 2 * z * p
+            sfpi::vFloat ln_m = 2.f * z * p;
+
+            // Combine: ln(1+x) = exp×ln(2) + ln(m)
+            // Convert exponent to float using sign-magnitude format
+            sfpi::vInt exp_for_convert = exp;
+
+            // We want to convert exponent to floating point using int32 -> float conversion.
+            // However, int32_to_float takes a sign-magnitude
+            // This is not an issue for positive numbers (same representation)
+            // For negative numbers, we need to explicitly convert to sign-magnitude format
+            v_if(exp < 0) {
+                sfpi::vInt exp_abs = ~exp + 1;  // Two's complement negation
+                // Convert to sign-magnitude negative: setsgn(value, 1) sets MSB to 1
+                exp_for_convert = sfpi::setsgn(exp_abs, 1);
+            }
+            v_endif;
+
+            sfpi::vFloat expf = sfpi::int32_to_float(exp_for_convert, 0);
+
+            // Step 5: Combine: ln(x) = exp×ln(2) + ln(m)
+            constexpr float LN2 = 0.69314718246459961f;  // log(2)
+            result = expf * LN2 + ln_m;                  // log(x) = log2(x) / log(2)
+        }
+        v_endif;
+    }
+    v_endif;
+
+    if constexpr (!is_fp32_dest_acc_en) {
+        // Convert to bfloat16 if needed using round-to-nearest-even
+        result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
+    }
+
+    return result;
+}
+
+template <bool APPROXIMATION_MODE, bool FAST_APPROX, bool is_fp32_dest_acc_en, int ITERATIONS = 8>
+inline void calculate_log1p() {
+#pragma GCC unroll 8
+    for (int d = 0; d < ITERATIONS; d++) {
+        sfpi::vFloat in = sfpi::dst_reg[0];
+        sfpi::vFloat result;
+        if constexpr (is_fp32_dest_acc_en) {
+            result = calculate_log1p_fp32<is_fp32_dest_acc_en>(in);
+        } else {
+            result = calculate_log1p_bf16<FAST_APPROX, is_fp32_dest_acc_en>(in);
+        }
+        sfpi::dst_reg[0] = result;
+        sfpi::dst_reg++;
     }
 }
 
-template <bool APPROXIMATION_MODE, bool FAST_APPROX>
+template <bool APPROXIMATION_MODE, bool FAST_APPROX, bool is_fp32_dest_acc_en>
 inline void log1p_init() {
-    vConstFloatPrgm0 = 0.692871f;  // ln2
-    vConstFloatPrgm1 = 0.1058f;
-    vConstFloatPrgm2 = -0.7166f;
+    if constexpr (!is_fp32_dest_acc_en) {
+        log_init<APPROXIMATION_MODE, FAST_APPROX, is_fp32_dest_acc_en>();
+    } else {
+        _init_reciprocal_</*approximation_mode*/ false, /*legacy_compat*/ false>();
+    }
 }
 
 }  // namespace sfpu

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_log1p.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_log1p.h
@@ -10,15 +10,16 @@
 
 namespace ckernel {
 
-template <bool APPROXIMATE, bool FAST_APPROX>
+template <bool APPROXIMATE, bool FAST_APPROX, bool is_fp32_dest_acc_en>
 inline void llk_math_eltwise_unary_sfpu_log1p_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::log1p, APPROXIMATE>(sfpu::log1p_init<APPROXIMATE, FAST_APPROX>);
+    llk_math_eltwise_unary_sfpu_init<SfpuType::log1p, APPROXIMATE>(
+        sfpu::log1p_init<APPROXIMATE, FAST_APPROX, is_fp32_dest_acc_en>);
 }
 
-template <bool APPROXIMATE, bool FAST_APPROX>
+template <bool APPROXIMATE, bool FAST_APPROX, bool is_fp32_dest_acc_en>
 inline void llk_math_eltwise_unary_sfpu_log1p(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_log1p<APPROXIMATE, FAST_APPROX>, dst_index, vector_mode);
+        ckernel::sfpu::calculate_log1p<APPROXIMATE, FAST_APPROX, is_fp32_dest_acc_en>, dst_index, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/include/compute_kernel_api/eltwise_unary/log1p.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_unary/log1p.h
@@ -16,7 +16,7 @@ namespace ckernel {
  */
 template <bool fast_and_approx = false>
 ALWI void log1p_tile_init() {
-    MATH((llk_math_eltwise_unary_sfpu_log1p_init<APPROX, fast_and_approx>()));
+    MATH((llk_math_eltwise_unary_sfpu_log1p_init<APPROX, fast_and_approx, DST_ACCUM_MODE>()));
 }
 
 // clang-format off
@@ -35,7 +35,7 @@ ALWI void log1p_tile_init() {
 // clang-format on
 template <bool fast_and_approx = false>
 ALWI void log1p_tile(uint32_t idst) {
-    MATH((llk_math_eltwise_unary_sfpu_log1p<APPROX, fast_and_approx>(idst)));
+    MATH((llk_math_eltwise_unary_sfpu_log1p<APPROX, fast_and_approx, DST_ACCUM_MODE>(idst)));
 }
 
 }  // namespace ckernel


### PR DESCRIPTION
### Ticket
#33752 

### Problem description

We would like to fix accuracy of log1p as it is currently inaccurate. 

### What's changed

- Add flag to switch bfloat16 and float32 version of log1p. 
- Each version calls its log equivalent
- float32 version of log1p uses piecewise polynomial near 0 to mitigate errors. 

#### Accuracy evaluation

Maximum error of log1p is 4 ULP on float32. 

| Type | Name | Max ULP error |
| - | - | - |
| bfloat16 | main | 60 |
| bfloat16 | new | 1 |
| float32 | main | > 10M |
| float32 | new | 4 |

<img width="692" height="1510" alt="log1p-accurate-bfloat16" src="https://github.com/user-attachments/assets/1d246a09-6ee1-4d09-ac01-d8395162cfe1" />


<img width="845" height="378" alt="log1p-accurate-float32" src="https://github.com/user-attachments/assets/727fbfad-e8b1-49fc-a967-8f92eecea96d" />




#### Performance evaluation

These new approximations have a noticeable overhead due to using more polynomial coefficients and piecewise approximations. 

Wormhole:

Type | Branch | Cycles/Datum | Cycles/Tile
-- | -- | -- | --
bfloat16 | main | 0.88 | 905
bfloat16 | new | 1.90 | 1942
float32 | main | 1.00 | 1026
float32 | new | 5.10 |  5223


### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes [OK](https://github.com/tenstorrent/tt-metal/actions/runs/20180243390)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable) [OK, failures in main](https://github.com/tenstorrent/tt-metal/actions/runs/20179971154)
- [x] L2 Nightly [OK, failures in main/unrelated](https://github.com/tenstorrent/tt-metal/actions/runs/20180223525)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable) [OK](https://github.com/tenstorrent/tt-metal/actions/runs/20179982344)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable) [OK, failures in main](https://github.com/tenstorrent/tt-metal/actions/runs/20179951099)
- [x] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models). [OK, failures in  main or unrelated](https://github.com/tenstorrent/tt-metal/actions/runs/20179951099)
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] [cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) job passes
- [ ] New/Existing tests provide coverage for changes