### PR TITLE
readability-non-const-parameter

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -133,7 +133,6 @@ Checks: >
   -readability-make-member-function-const,
   -readability-math-missing-parentheses,
   -readability-named-parameter,
-  -readability-non-const-parameter,
   -readability-redundant-casting,
   -readability-static-accessed-through-instance,
   -readability-suspicious-call-argument,

--- a/tt_metal/hw/inc/bit_utils.h
+++ b/tt_metal/hw/inc/bit_utils.h
@@ -17,7 +17,7 @@
 // src_element_bits  - Number of bits in each pakced element (must be LESS than 32)
 // dest_array        - Destination array to store the extracted bits
 // num_dest_elements - Number of elements in the destination array
-inline void extract_bit_array(uint32_t* src_array, int src_element_bits, uint32_t* dest_array, int num_dest_elements) {
+inline void extract_bit_array(const uint32_t* src_array, int src_element_bits, uint32_t* dest_array, int num_dest_elements) {
     int bits_processed = 0;      // Tracks the number of bits processed in the current src_array element
     int src_index = 0;           // Index for the current source element being processed
     uint32_t current_value = 0;  // Temporary storage for the value being extracted
@@ -54,7 +54,7 @@ inline void extract_bit_array(uint32_t* src_array, int src_element_bits, uint32_
 // Given a source array of elements that only use the 'src_element_bits' least significant bits,
 // pack the elements into a destination array of 32-bit elements in a densely-packed manner, where
 // the least significant bits of the destination array elements are filled first and all 32 bits are used.
-inline void pack_bit_array(uint32_t* src_array, int src_element_bits, uint32_t* dest_array, int num_src_elements) {
+inline void pack_bit_array(const uint32_t* src_array, int src_element_bits, uint32_t* dest_array, int num_src_elements) {
     int dest_index = 0;   // Index for the current destination array element being filled
     int bits_filled = 0;  // Tracks the number of bits filled in the current dest_array element
 


### PR DESCRIPTION
### Ticket
NA

### Problem description
The following clang-tidy check is disabled:
https://clang.llvm.org/extra/clang-tidy/checks/readability/non-const-parameter.html

There is only one violation in `tt_metal/hw/inc`
```
/workspace/tt_metal/hw/inc/bit_utils.h:20:41: warning: pointer parameter 'src_array' can be pointer to const [readability-non-const-parameter]
   20 | inline void extract_bit_array(uint32_t* src_array, int src_element_bits, uint32_t* dest_array, int num_dest_elements) {
      |                                         ^
      |                               const
/workspace/tt_metal/hw/inc/bit_utils.h:57:38: warning: pointer parameter 'src_array' can be pointer to const [readability-non-const-parameter]
   57 | inline void pack_bit_array(uint32_t* src_array, int src_element_bits, uint32_t* dest_array, int num_src_elements) {
      |                                      ^
      |                            const
```

### What's changed
- Enable check
- Apply automatic FIXIT to improve two function signatures

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] New/Existing tests provide coverage for changes