### PR TITLE
Auto slicing in VAE module

### DIFF
--- a/models/experimental/stable_diffusion_xl_base/tests/test_common.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/test_common.py
@@ -22,9 +22,9 @@ from models.experimental.stable_diffusion_xl_base.vae.tt.tt_autoencoder_kl impor
 # For basic SDXL demo, L1 small size of 23000 is enough,
 # but for inpainting/img2img, we need larger L1 small due
 # to having an extra VAE encode call, which increases it.
-# For simplicity, increase both to 30500 as there's enough
+# For simplicity, increase both to 30800 as there's enough
 # space left in base variant as well.
-SDXL_L1_SMALL_SIZE = 30500
+SDXL_L1_SMALL_SIZE = 30800
 SDXL_TRACE_REGION_SIZE = 34000000
 SDXL_BASE_REFINER_TRACE_REGION_SIZE = 51429376
 SDXL_CI_WEIGHTS_PATH = "/mnt/MLPerf/tt_dnn-models/hf_home"

--- a/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
@@ -113,7 +113,7 @@ def test_refiner_unet(
         ),
         (
             "pytest models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_autoencoder_kl.py::test_vae -k 'test_decode'",
-            691_874_774,
+            691_445_943,
             "sdxl_vae",
             "sdxl_vae_decode",
             VAE_DEVICE_TEST_TOTAL_ITERATIONS,

--- a/models/experimental/stable_diffusion_xl_base/vae/tt/tt_decoder.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tt/tt_decoder.py
@@ -7,7 +7,6 @@ from models.common.lightweightmodule import LightweightModule
 from models.experimental.stable_diffusion_xl_base.vae.tt.tt_midblock2d import TtUNetMidBlock2D
 from models.experimental.stable_diffusion_xl_base.vae.tt.tt_upblock2d import TtUpDecoderBlock2D
 from models.experimental.stable_diffusion_xl_base.vae.tt.vae_utility import (
-    get_DRAM_conv_config,
     get_DRAM_GN_config,
     get_DRAM_GN_shape,
 )
@@ -91,7 +90,7 @@ class TtDecoder(LightweightModule):
             conv_in_bias,
             self.conv_in_config.weights_dtype,
         )
-        self.conv_in_slice_config = get_DRAM_conv_config(None, 1)
+        self.conv_in_slice_config = ttnn.Conv2dL1FullSliceConfig  # one slice
 
         self.compute_out_config = model_config.get_conv_compute_config(module_path="decoder.conv_out")
         self.conv_out_config = model_config.get_conv_config(conv_path="decoder.conv_out")
@@ -104,7 +103,7 @@ class TtDecoder(LightweightModule):
             conv_out_bias,
             self.conv_out_config.weights_dtype,
         )
-        self.conv_out_slice_config = get_DRAM_conv_config(None, 2)
+        self.conv_out_slice_config = None  # auto slicing generates 8 slices
         self.conv_output_dtype = model_config.get_conv_output_dtype()
 
     def forward(self, sample, input_shape):

--- a/models/experimental/stable_diffusion_xl_base/vae/tt/tt_decoder.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tt/tt_decoder.py
@@ -103,7 +103,7 @@ class TtDecoder(LightweightModule):
             conv_out_bias,
             self.conv_out_config.weights_dtype,
         )
-        self.conv_out_slice_config = None  # auto slicing generates 8 slices
+        self.conv_out_slice_config = None  # auto slicing
         self.conv_output_dtype = model_config.get_conv_output_dtype()
 
     def forward(self, sample, input_shape):

--- a/models/experimental/stable_diffusion_xl_base/vae/tt/tt_downsample2d.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tt/tt_downsample2d.py
@@ -6,7 +6,6 @@ import ttnn
 
 from models.common.lightweightmodule import LightweightModule
 from models.experimental.stable_diffusion_xl_base.tt.sdxl_utility import prepare_conv_params
-from models.experimental.stable_diffusion_xl_base.vae.tt.vae_utility import get_DRAM_conv_config
 
 
 class TtDownsample2D(LightweightModule):
@@ -33,7 +32,7 @@ class TtDownsample2D(LightweightModule):
             bias,
             self.conv_config.weights_dtype,
         )
-        self.conv_slice_config = get_DRAM_conv_config(module_path, 1)
+        self.conv_slice_config = None  # auto slicing
 
     def forward(self, hidden_states, input_shape):
         B, C, H, W = input_shape

--- a/models/experimental/stable_diffusion_xl_base/vae/tt/tt_encoder.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tt/tt_encoder.py
@@ -101,10 +101,7 @@ class TtEncoder(LightweightModule):
             conv_out_bias,
             self.conv_out_config.weights_dtype,
         )
-        self.conv_out_slice_config = ttnn.Conv2dSliceConfig(
-            slice_type=ttnn.Conv2dDRAMSliceWidth,
-            num_slices=0,
-        )
+        self.conv_out_slice_config = None
         self.conv_output_dtype = model_config.get_conv_output_dtype()
 
     def forward(self, sample, input_shape):
@@ -171,7 +168,7 @@ class TtEncoder(LightweightModule):
                 inplace=False,  # We are working with tiled sharded GN
             )
 
-            if self.conv_out_slice_config is not None:
+            if self.conv_out_slice_config != ttnn.Conv2dL1FullSliceConfig:
                 hidden_states = ttnn.to_memory_config(hidden_states, ttnn.DRAM_MEMORY_CONFIG)
         else:
             hidden_states = ttnn.to_memory_config(hidden_states, ttnn.DRAM_MEMORY_CONFIG)

--- a/models/experimental/stable_diffusion_xl_base/vae/tt/tt_encoder.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tt/tt_encoder.py
@@ -88,7 +88,7 @@ class TtEncoder(LightweightModule):
             conv_in_bias,
             self.conv_in_config.weights_dtype,
         )
-        self.conv_in_slice_config = None
+        self.conv_in_slice_config = None  # auto slicing generates 6 slices; perf improvement expected
 
         self.compute_out_config = model_config.get_conv_compute_config(module_path="encoder.conv_out")
         self.conv_out_config = model_config.get_conv_config(conv_path="encoder.conv_out")
@@ -101,7 +101,9 @@ class TtEncoder(LightweightModule):
             conv_out_bias,
             self.conv_out_config.weights_dtype,
         )
-        self.conv_out_slice_config = get_DRAM_conv_config("encoder", 2)
+        self.conv_out_slice_config = get_DRAM_conv_config(
+            "encoder", 2
+        )  # auto slicing here causes CB to outgrow L1; should be checked
         self.conv_output_dtype = model_config.get_conv_output_dtype()
 
     def forward(self, sample, input_shape):

--- a/models/experimental/stable_diffusion_xl_base/vae/tt/tt_encoder.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tt/tt_encoder.py
@@ -88,7 +88,7 @@ class TtEncoder(LightweightModule):
             conv_in_bias,
             self.conv_in_config.weights_dtype,
         )
-        self.conv_in_slice_config = get_DRAM_conv_config("encoder", 1)
+        self.conv_in_slice_config = None
 
         self.compute_out_config = model_config.get_conv_compute_config(module_path="encoder.conv_out")
         self.conv_out_config = model_config.get_conv_config(conv_path="encoder.conv_out")

--- a/models/experimental/stable_diffusion_xl_base/vae/tt/tt_encoder.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tt/tt_encoder.py
@@ -88,9 +88,7 @@ class TtEncoder(LightweightModule):
             conv_in_bias,
             self.conv_in_config.weights_dtype,
         )
-        # auto slicing reduces number of slices and makes slices take more space in L1 which causes out of memory error: not enough space to allocate L1_SMALL buffer
-        # setting slice_type to ttnn.Conv2dDRAMSliceHeight to avoid this issue
-        self.conv_in_slice_config = ttnn.Conv2dSliceConfig(slice_type=ttnn.Conv2dDRAMSliceHeight, num_slices=0)
+        self.conv_in_slice_config = None
 
         self.compute_out_config = model_config.get_conv_compute_config(module_path="encoder.conv_out")
         self.conv_out_config = model_config.get_conv_config(conv_path="encoder.conv_out")
@@ -103,8 +101,10 @@ class TtEncoder(LightweightModule):
             conv_out_bias,
             self.conv_out_config.weights_dtype,
         )
-        # auto slicing here causes CB to outgrow L1; setting slice_type to ttnn.Conv2dDRAMSliceHeight to avoid this issue
-        self.conv_out_slice_config = ttnn.Conv2dSliceConfig(slice_type=ttnn.Conv2dDRAMSliceHeight, num_slices=0)
+        self.conv_out_slice_config = ttnn.Conv2dSliceConfig(
+            slice_type=ttnn.Conv2dDRAMSliceWidth,
+            num_slices=0,
+        )
         self.conv_output_dtype = model_config.get_conv_output_dtype()
 
     def forward(self, sample, input_shape):

--- a/models/experimental/stable_diffusion_xl_base/vae/tt/tt_encoder.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tt/tt_encoder.py
@@ -88,7 +88,8 @@ class TtEncoder(LightweightModule):
             conv_in_bias,
             self.conv_in_config.weights_dtype,
         )
-        self.conv_in_slice_config = None  # auto slicing generates 6 slices; perf improvement expected
+        # auto slicing reduces number of slices and makes slices take more space in L1 which causes out of memory error: not enough space to allocate L1_SMALL buffer
+        self.conv_in_slice_config = get_DRAM_conv_config("encoder", 1)
 
         self.compute_out_config = model_config.get_conv_compute_config(module_path="encoder.conv_out")
         self.conv_out_config = model_config.get_conv_config(conv_path="encoder.conv_out")

--- a/models/experimental/stable_diffusion_xl_base/vae/tt/tt_resnetblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tt/tt_resnetblock2d.py
@@ -121,7 +121,7 @@ class TtResnetBlock2D(LightweightModule):
             conv_bias_1,
             self.conv1_config.weights_dtype,
         )
-        self.conv1_slice_config = None
+        self.conv1_slice_config = None  # auto slicing
         self.conv_output_dtype = model_config.get_conv_output_dtype()
 
         self.compute2_config = model_config.get_conv_compute_config(module_path=f"{module_path}.conv2")
@@ -135,7 +135,7 @@ class TtResnetBlock2D(LightweightModule):
             conv_bias_2,
             self.conv2_config.weights_dtype,
         )
-        self.conv2_slice_config = None
+        self.conv2_slice_config = None  # auto slicing
 
         if conv_shortcut:
             self.tt_conv3_weights, self.tt_conv3_bias = prepare_linear_params(

--- a/models/experimental/stable_diffusion_xl_base/vae/tt/tt_resnetblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tt/tt_resnetblock2d.py
@@ -12,7 +12,6 @@ from models.experimental.stable_diffusion_xl_base.tt.sdxl_utility import (
     prepare_linear_params,
 )
 from models.experimental.stable_diffusion_xl_base.vae.tt.vae_utility import (
-    get_DRAM_conv_config,
     get_DRAM_GN_config,
     get_DRAM_GN_shape,
 )
@@ -122,7 +121,7 @@ class TtResnetBlock2D(LightweightModule):
             conv_bias_1,
             self.conv1_config.weights_dtype,
         )
-        self.conv1_slice_config = get_DRAM_conv_config(module_path, 1)
+        self.conv1_slice_config = None
         self.conv_output_dtype = model_config.get_conv_output_dtype()
 
         self.compute2_config = model_config.get_conv_compute_config(module_path=f"{module_path}.conv2")
@@ -136,7 +135,7 @@ class TtResnetBlock2D(LightweightModule):
             conv_bias_2,
             self.conv2_config.weights_dtype,
         )
-        self.conv2_slice_config = get_DRAM_conv_config(module_path, 2)
+        self.conv2_slice_config = None
 
         if conv_shortcut:
             self.tt_conv3_weights, self.tt_conv3_bias = prepare_linear_params(

--- a/models/experimental/stable_diffusion_xl_base/vae/tt/tt_resnetblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tt/tt_resnetblock2d.py
@@ -171,7 +171,7 @@ class TtResnetBlock2D(LightweightModule):
                 inplace=False,  # We are working with tiled sharded GN
             )
 
-            if self.conv1_slice_config is not None:
+            if self.conv1_slice_config != ttnn.Conv2dL1FullSliceConfig:
                 hidden_states = ttnn.to_memory_config(hidden_states, ttnn.DRAM_MEMORY_CONFIG)
         else:
             sharded_mem_config = ttnn.create_sharded_memory_config(
@@ -251,7 +251,7 @@ class TtResnetBlock2D(LightweightModule):
                 negative_mask=None,
                 inplace=False,  # We are working with tiled sharded GN
             )
-            if self.conv2_slice_config is not None:
+            if self.conv2_slice_config != ttnn.Conv2dL1FullSliceConfig:
                 hidden_states = ttnn.to_memory_config(hidden_states, ttnn.DRAM_MEMORY_CONFIG)
         else:
             sharded_mem_config = ttnn.create_sharded_memory_config(

--- a/models/experimental/stable_diffusion_xl_base/vae/tt/tt_upsample2d.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tt/tt_upsample2d.py
@@ -8,7 +8,6 @@ from models.common.lightweightmodule import LightweightModule
 from models.experimental.stable_diffusion_xl_base.tt.sdxl_utility import (
     prepare_conv_params,
 )
-from models.experimental.stable_diffusion_xl_base.vae.tt.vae_utility import get_DRAM_conv_config
 
 
 class TtUpsample2D(LightweightModule):
@@ -45,7 +44,7 @@ class TtUpsample2D(LightweightModule):
             bias,
             self.conv_config.weights_dtype,
         )
-        self.conv_slice_config = get_DRAM_conv_config(module_path, 1)
+        self.conv_slice_config = None
         self.conv_output_dtype = model_config.get_conv_output_dtype()
 
     def interpolate(self, hidden_states):

--- a/models/experimental/stable_diffusion_xl_base/vae/tt/tt_upsample2d.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tt/tt_upsample2d.py
@@ -44,7 +44,7 @@ class TtUpsample2D(LightweightModule):
             bias,
             self.conv_config.weights_dtype,
         )
-        self.conv_slice_config = None
+        self.conv_slice_config = None  # auto slicing
         self.conv_output_dtype = model_config.get_conv_output_dtype()
 
     def interpolate(self, hidden_states):

--- a/models/experimental/stable_diffusion_xl_base/vae/tt/vae_utility.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tt/vae_utility.py
@@ -2,8 +2,6 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-import ttnn
-
 
 def get_DRAM_GN_shape(module_path, idx):
     if module_path is None:
@@ -72,72 +70,3 @@ def get_DRAM_GN_config(module_path, idx):
                 num_out_blocks = 32
 
     return core_x, core_y, num_out_blocks
-
-
-def get_DRAM_conv_config(module_path, idx):
-    num_slices = 0
-    is_encoder = True if module_path is not None and "encoder" == module_path else False
-    if module_path is None:
-        if idx == 1:
-            return ttnn.Conv2dL1FullSliceConfig
-        else:
-            num_slices = 8
-    elif is_encoder:
-        if idx == 1:
-            num_slices = 8
-        else:
-            num_slices = 2
-    elif "mid_block" in module_path:
-        return ttnn.Conv2dL1FullSliceConfig
-    else:
-        parts = module_path.split(".")
-        if "down_blocks" in module_path:
-            is_encoder = True
-            block_id = int(parts[parts.index("down_blocks") + 1])
-        else:
-            is_encoder = False
-            block_id = int(parts[parts.index("up_blocks") + 1])
-
-        if block_id == 0:
-            if "downsamplers" in module_path:
-                num_slices = 8
-            elif is_encoder:
-                num_slices = 8
-            elif "upsamplers" not in module_path:
-                return ttnn.Conv2dL1FullSliceConfig
-            else:
-                num_slices = 2
-        if block_id == 1:
-            if is_encoder:
-                num_slices = 4
-            elif "downsamplers" in module_path:
-                num_slices = 4
-            elif "upsamplers" not in module_path:
-                num_slices = 2
-            else:
-                num_slices = 8
-        if block_id == 2:
-            if "downsamplers" in module_path:
-                num_slices = 2
-            elif is_encoder:
-                num_slices = 2
-            elif "upsamplers" not in module_path:
-                if "resnets.0" in module_path and idx == 1:
-                    num_slices = 8
-                else:
-                    num_slices = 4
-            else:
-                num_slices = 16
-        if block_id == 3 and "upsamplers" not in module_path:
-            if is_encoder:
-                return ttnn.Conv2dL1FullSliceConfig
-            if "resnets.0" in module_path and idx == 1:
-                num_slices = 16
-            else:
-                num_slices = 8
-
-    slice_type = ttnn.Conv2dDRAMSliceWidth
-    return ttnn.Conv2dSliceConfig(
-        slice_type=slice_type,
-        num_slices=num_slices,
-    )


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/33544)

### Problem description
The `get_DRAM_conv_config()` function was previously used to determine appropriate Conv2dSliceConfig (number of DRAM slices and slice type) for each block in SDXL VAE module. As there are many specific cases, the function is too complex.
### What's changed
We run some experiments to see if auto slicing feature can be used to calculate number of DRAM slices. To test auto slicing, we measured performance of Conv2D ops from the **test_conv2d_vae_sdxl** unit test. The results are available [here](https://docs.google.com/spreadsheets/d/1bLKhkxdlEhkZa9twJ80x-WbOMWHITjtj/edit?gid=2066747431#gid=2066747431). The table contains device kernel duration for all Conv2D ops from the test, calculated as the sum of device kernel duration of all micro-ops generated by those Conv2D ops.

In most cases, auto slicing offers comparable or better performance than the previous manual configuration. For some specific cases (see the results), it can reduce the number of slices and offer better performance.

This PR removes the `get_DRAM_conv_config()` function and uses auto slicing to determine number of DRAM slices.

### Checklist
- [x] [All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/runs/20505203057) CI passes
- [x] [(Single-card) Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/runs/20505209172) CI passes
- [x] [(Single-card) Demo tests (no perf)](https://github.com/tenstorrent/tt-metal/actions/runs/20505214477) CI passes
- [x] [Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/runs/20505219723) CI passes
- [x] [(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/20505231483) CI passes