### PR TITLE
Fix syntax error in CI configuration file

### DIFF
--- a/.github/workflows/t3000-model-perf-tests-impl.yaml
+++ b/.github/workflows/t3000-model-perf-tests-impl.yaml
@@ -94,7 +94,7 @@ jobs:
                 "arch": "wormhole_b0",
                 "cmd": "run_t3000_wan22_tests",
                 "timeout": 45,
-                save-perf-data: true,
+                "save-perf-data": true,
                 "owner_id": "U03FJB5TM5Y" # Colman Glagovich
             },
             {


### PR DESCRIPTION
### Problem description
The T3K model perf yaml file has a syntax error, maybe introduced in this commit: https://github.com/tenstorrent/tt-metal/commit/ecb9238a48b024a549351a5d1fb8a96f2dba5688

### What's changed
Add quotes around variable name

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/20173413679)
- [x] T3K model perf test generates [matrix](https://github.com/tenstorrent/tt-metal/actions/runs/20172431020)
