### PR TITLE
[skip-ci] T3000 model perf tests: fix JSON object in generate-matrix steo

### DIFF
--- a/.github/workflows/t3000-model-perf-tests-impl.yaml
+++ b/.github/workflows/t3000-model-perf-tests-impl.yaml
@@ -94,7 +94,7 @@ jobs:
                 "arch": "wormhole_b0",
                 "cmd": "run_t3000_wan22_tests",
                 "timeout": 45,
-                save-perf-data: true,
+                "save-perf-data": true,
                 "owner_id": "U03FJB5TM5Y" # Colman Glagovich
             },
             {


### PR DESCRIPTION
Quick fix.

### Problem description
T3K model perf workflow failed on `generate-matrix` step because of invalid JSON passed to `jq`.

### What's changed
One-line fix for the JSON - missing double quotes around a json object key.

### CI runs
- [ ] https://github.com/tenstorrent/tt-metal/actions/runs/20178188314