### PR TITLE
Strip unused `MemoryReporter` out of Runtime Host API

### DIFF
--- a/tt_metal/api/tt-metalium/memory_reporter.hpp
+++ b/tt_metal/api/tt-metalium/memory_reporter.hpp
@@ -1,22 +1,18 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
 
-#include <atomic>
 #include <cstddef>
 #include <cstdint>
-#include <filesystem>
-#include <fstream>
 #include <string>
 #include <unordered_map>
 #include <vector>
 
-#include <tt-metalium/allocator.hpp>
-
 namespace tt::tt_metal {
 enum class BufferType;
+class IDevice;
 }  // namespace tt::tt_metal
 
 namespace tt::tt_metal {
@@ -28,8 +24,6 @@ address: bytes
 size: bytes
 */
 using MemoryBlockTable = std::vector<std::unordered_map<std::string, std::string>>;
-class IDevice;
-class Program;
 
 namespace detail {
 struct MemoryView;
@@ -101,33 +95,6 @@ struct MemoryView {
     size_t total_bytes_free_per_bank = 0;
     size_t largest_contiguous_bytes_free_per_bank = 0;
     MemoryBlockTable block_table;
-};
-
-class MemoryReporter {
-public:
-    MemoryReporter& operator=(const MemoryReporter&) = delete;
-    MemoryReporter& operator=(MemoryReporter&& other) noexcept = delete;
-    MemoryReporter(const MemoryReporter&) = delete;
-    MemoryReporter(MemoryReporter&& other) noexcept = delete;
-
-    void flush_program_memory_usage(uint64_t program_id, const IDevice* device);
-
-    void dump_memory_usage_state(const IDevice* device, const std::string& prefix = "") const;
-
-    MemoryView get_memory_view(const IDevice* device, const BufferType& buffer_type) const;
-
-    static void toggle(bool state);
-    static MemoryReporter& inst();
-    static bool enabled();
-
-private:
-    MemoryReporter() = default;
-    ~MemoryReporter();
-    void init_reports();
-    static std::atomic<bool> is_enabled_;
-    std::ofstream program_l1_usage_summary_report_;
-    std::ofstream program_memory_usage_summary_report_;
-    std::ofstream program_detailed_memory_usage_report_;
 };
 
 }  // namespace detail

--- a/tt_metal/detail/reports/memory_reporter.cpp
+++ b/tt_metal/detail/reports/memory_reporter.cpp
@@ -1,18 +1,20 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <allocator.hpp>
-#include <device.hpp>
-#include <memory_reporter.hpp>
+#include "tt_metal/detail/reports/memory_reporter.hpp"
+
 #include <cstdint>
+#include <stdint.h>
 #include <filesystem>
 #include <map>
 #include <memory>
 #include <utility>
 #include <enchantum/enchantum.hpp>
 
-#include "buffer_types.hpp"
+#include <tt-metalium/allocator.hpp>
+#include <tt-metalium/device.hpp>
+#include <tt-metalium/buffer_types.hpp>
 #include "tt_metal/detail/reports/report_utils.hpp"
 #include "tt_metal/impl/allocator/allocator.hpp"
 

--- a/tt_metal/detail/reports/memory_reporter.cpp
+++ b/tt_metal/detail/reports/memory_reporter.cpp
@@ -5,7 +5,6 @@
 #include "tt_metal/detail/reports/memory_reporter.hpp"
 
 #include <cstdint>
-#include <stdint.h>
 #include <filesystem>
 #include <map>
 #include <memory>

--- a/tt_metal/detail/reports/memory_reporter.hpp
+++ b/tt_metal/detail/reports/memory_reporter.hpp
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <atomic>
+#include <fstream>
+#include <string>
+
+#include <tt-metalium/memory_reporter.hpp>
+
+namespace tt::tt_metal {
+class IDevice;
+enum class BufferType;
+}  // namespace tt::tt_metal
+
+namespace tt::tt_metal::detail {
+
+class MemoryReporter {
+public:
+    MemoryReporter& operator=(const MemoryReporter&) = delete;
+    MemoryReporter& operator=(MemoryReporter&& other) noexcept = delete;
+    MemoryReporter(const MemoryReporter&) = delete;
+    MemoryReporter(MemoryReporter&& other) noexcept = delete;
+
+    void flush_program_memory_usage(uint64_t program_id, const IDevice* device);
+
+    void dump_memory_usage_state(const IDevice* device, const std::string& prefix = "") const;
+
+    MemoryView get_memory_view(const IDevice* device, const BufferType& buffer_type) const;
+
+    static void toggle(bool state);
+    static MemoryReporter& inst();
+    static bool enabled();
+
+private:
+    MemoryReporter() = default;
+    ~MemoryReporter();
+    void init_reports();
+    static std::atomic<bool> is_enabled_;
+    std::ofstream program_l1_usage_summary_report_;
+    std::ofstream program_memory_usage_summary_report_;
+    std::ofstream program_detailed_memory_usage_report_;
+};
+
+}  // namespace tt::tt_metal::detail

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -8,7 +8,7 @@
 #include <device.hpp>
 #include <graph_tracking.hpp>
 #include <enchantum/enchantum.hpp>
-#include <memory_reporter.hpp>
+#include "tt_metal/detail/reports/memory_reporter.hpp"
 #include "impl/buffers/semaphore.hpp"
 #include <tt_align.hpp>
 #include <algorithm>


### PR DESCRIPTION
### Ticket
Closes #34135

### Problem description
Runtime is reducing it's host API surface area to prepare for an upcoming refactoring.
`MemoryReporter` is identified to be an internal construct which is in conflict of the public API folder it sits in.

### What's changed
Moved the `MemoryReporter` class from Runtime Host API into `tt_metal/detail/reports/memory_reporter.hpp` where it's implementation was defined.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/20183647541)
- [x] No external dependency affected
- [x] No mlir dependency affected