### PR TITLE
Don't conditionally dispatch on individual devices during `ttnn.paged_fill_cache`

### DIFF
--- a/models/demos/deepseek_v3/tt/mla/mla1d.py
+++ b/models/demos/deepseek_v3/tt/mla/mla1d.py
@@ -958,9 +958,6 @@ class MLA1D(AbstractModule):
         )
         tt_q = ttnn.experimental.all_gather_async(tt_q, **ccl.populate_all_gather_runtime_args(cfg["wq_a_ag_prefill"]))
 
-        # Bug: https://github.com/tenstorrent/tt-metal/issues/29935
-        # ttnn.synchronize_device(cfg["mesh_device"])
-
         tt_q = RMSNorm.forward_prefill(tt_q, cfg["q_norm"])
         tt_q = ttnn.linear(tt_q, **cfg["wq_b"])
 
@@ -1030,8 +1027,6 @@ class MLA1D(AbstractModule):
             batch_idx=local_batch_idx,
             mesh_coords=set(get_mesh_coords(mesh_shape, row_idx, col_idx)),
         )
-        # Bug: https://github.com/tenstorrent/tt-metal/issues/33589
-        ttnn.synchronize_device(cfg["mesh_device"])
 
         # FlashMLA
         attn_out = ttnn.transformer.flash_mla_prefill(

--- a/models/demos/deepseek_v3/tt/mla/mla1d.py
+++ b/models/demos/deepseek_v3/tt/mla/mla1d.py
@@ -959,7 +959,7 @@ class MLA1D(AbstractModule):
         tt_q = ttnn.experimental.all_gather_async(tt_q, **ccl.populate_all_gather_runtime_args(cfg["wq_a_ag_prefill"]))
 
         # Bug: https://github.com/tenstorrent/tt-metal/issues/29935
-        ttnn.synchronize_device(cfg["mesh_device"])
+        # ttnn.synchronize_device(cfg["mesh_device"])
 
         tt_q = RMSNorm.forward_prefill(tt_q, cfg["q_norm"])
         tt_q = ttnn.linear(tt_q, **cfg["wq_b"])

--- a/tests/ttnn/nightly/unit_tests/operations/transformers/test_paged_update_cache.py
+++ b/tests/ttnn/nightly/unit_tests/operations/transformers/test_paged_update_cache.py
@@ -796,7 +796,6 @@ def test_paged_fill_cache_variants(
     assert cache_block_size % TILE_HEIGHT == 0, "cache_block_size must be multiple of TILE_HEIGHT"
     assert effective_batch_idx_to_test < page_table_batch_size, "effective_batch_idx_to_test out of bounds"
 
-    # Prepare Tensors
     initial_cache_torch = torch.randn(cache_max_blocks, 1, cache_block_size, head_dim).bfloat16() * 100
     input_torch = (
         torch.arange(1 * num_input_heads * input_seq_len * head_dim, dtype=torch.float32)
@@ -854,3 +853,73 @@ def test_paged_fill_cache_variants(
     Passing, Message = comp_equal(output_cache_torch, expected_cache_torch)
     logger.info(Message)  # Log the comparison message regardless
     assert Passing, Message
+
+
+@pytest.mark.parametrize(
+    "num_input_heads, input_seq_len, head_dim, cache_max_blocks, cache_block_size, page_table_batch_size, pt_max_blocks_per_seq, effective_batch_idx_to_test",
+    [
+        (1, 128, 128, 1024, 64, 32, 32, 0),
+        (1, 128, 128, 1024, 64, 32, 32, 15),
+    ],
+)
+def test_paged_fill_cache_mesh_coords(
+    device,
+    num_input_heads,
+    input_seq_len,
+    head_dim,
+    cache_max_blocks,
+    cache_block_size,
+    page_table_batch_size,
+    pt_max_blocks_per_seq,
+    effective_batch_idx_to_test,
+):
+    torch.manual_seed(0)
+    TILE_HEIGHT = 32
+    TILE_WIDTH = 32
+
+    assert head_dim % TILE_WIDTH == 0, "head_dim must be multiple of TILE_WIDTH"
+    assert input_seq_len % TILE_HEIGHT == 0, "input_seq_len must be multiple of TILE_HEIGHT"
+    assert cache_block_size % TILE_HEIGHT == 0, "cache_block_size must be multiple of TILE_HEIGHT"
+    assert effective_batch_idx_to_test < page_table_batch_size, "effective_batch_idx_to_test out of bounds"
+
+    initial_cache_torch = torch.randn(cache_max_blocks, 1, cache_block_size, head_dim).bfloat16() * 100
+    input_torch = (
+        torch.arange(1 * num_input_heads * input_seq_len * head_dim, dtype=torch.float32)
+        .reshape(1, num_input_heads, input_seq_len, head_dim)
+        .bfloat16()
+        / 1000.0
+    )
+
+    page_table_torch_data = []
+    next_block_idx = 0
+    for b in range(page_table_batch_size):
+        row = []
+        for m in range(pt_max_blocks_per_seq):
+            row.append(next_block_idx % cache_max_blocks)
+            next_block_idx += 1
+        page_table_torch_data.append(row)
+    page_table_torch = torch.tensor(page_table_torch_data, dtype=torch.int32)
+
+    cache_tt = ttnn.from_torch(initial_cache_torch, device=device, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16)
+    input_tt = ttnn.from_torch(input_torch, device=device, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16)
+    page_table_tt = ttnn.from_torch(page_table_torch, device=device, layout=ttnn.ROW_MAJOR_LAYOUT, dtype=ttnn.int32)
+
+    # For a single device we can only use coordinate (0, 0)
+    mesh_coords = {ttnn.MeshCoordinate(0, 0)}
+    output_cache_tt = ttnn.experimental.paged_fill_cache(
+        cache_tt,
+        input_tt,
+        page_table_tt,
+        batch_idx=effective_batch_idx_to_test,
+        mesh_coords=mesh_coords,
+    )
+
+    expected_cache_torch = get_expected_paged_fill_cache_output(
+        initial_cache_torch, input_torch, page_table_torch, effective_batch_idx_to_test
+    )
+
+    output_cache_torch = ttnn.to_torch(output_cache_tt)
+
+    passing, message = comp_equal(output_cache_torch, expected_cache_torch)
+    logger.info(message)  # Log the comparison message regardless
+    assert passing, message

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fill_cache/paged_fill_cache_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fill_cache/paged_fill_cache_device_operation.cpp
@@ -78,11 +78,10 @@ tt::stl::hash::hash_t PagedFillCacheDeviceOperation::compute_program_hash(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     auto program_factory = select_program_factory(args, tensor_args);
 
-    // Exclude batch_idx_fallback from hash since it's a runtime-only parameter (used only in runtime args)
+    // Exclude batch_idx_fallback and noop from hash since they're runtime-only parameters (used only in runtime args)
     // Include mesh_coords since it affects program factory selection
-    // Include noop since it affects kernel compilation (early exit logic)
     return operation::hash_operation<PagedFillCacheDeviceOperation>(
-        args.mesh_coords, args.noop, tensor_args, program_factory.index());
+        args.mesh_coords, tensor_args, program_factory.index());
 }
 
 std::tuple<PagedFillCacheDeviceOperation::operation_attributes_t, PagedFillCacheDeviceOperation::tensor_args_t>

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fill_cache/paged_fill_cache_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fill_cache/paged_fill_cache_device_operation.cpp
@@ -80,8 +80,9 @@ tt::stl::hash::hash_t PagedFillCacheDeviceOperation::compute_program_hash(
 
     // Exclude batch_idx_fallback from hash since it's a runtime-only parameter (used only in runtime args)
     // Include mesh_coords since it affects program factory selection
+    // Include noop since it affects kernel compilation (early exit logic)
     return operation::hash_operation<PagedFillCacheDeviceOperation>(
-        args.mesh_coords, tensor_args, program_factory.index());
+        args.mesh_coords, args.noop, tensor_args, program_factory.index());
 }
 
 std::tuple<PagedFillCacheDeviceOperation::operation_attributes_t, PagedFillCacheDeviceOperation::tensor_args_t>

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fill_cache/paged_fill_cache_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fill_cache/paged_fill_cache_device_operation_types.hpp
@@ -13,6 +13,7 @@ namespace ttnn::operations::experimental::paged_cache::fill {
 struct operation_attributes_t {
     const uint32_t batch_idx_fallback;
     const std::optional<std::set<ttnn::MeshCoordinate>> mesh_coords;
+    const bool noop = false;  // When true, kernels early exit
 };
 
 struct tensor_args_t {

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fill_cache/paged_fill_cache_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fill_cache/paged_fill_cache_program_factory.cpp
@@ -268,17 +268,14 @@ PagedFillCacheMeshWorkloadFactory::cached_mesh_workload_t PagedFillCacheMeshWork
         std::set<ttnn::MeshCoordinate> tensor_coords_set(tensor_coords_vector.begin(), tensor_coords_vector.end());
 
         for (const auto& mesh_coord : mesh_coords_set) {
-            if (tensor_coords_set.find(mesh_coord) == tensor_coords_set.end()) {
-                TT_FATAL(
-                    false,
-                    "paged_fill_cache: mesh_coord ({}, {}) is in mesh_coords but not found in tensor_coords. "
-                    "This would result in no program being created for this coordinate, causing potential hang. "
-                    "mesh_coords size: {}, tensor_coords size: {}",
-                    mesh_coord[0],
-                    mesh_coord[1],
-                    mesh_coords_set.size(),
-                    tensor_coords_set.size());
-            }
+            TT_FATAL(
+                tensor_coords_set.find(mesh_coord) != tensor_coords_set.end(),
+                "Mesh coordinate ({}, {}) is in mesh_coords but not found in tensor_coords. "
+                "mesh_coords size: {}, tensor_coords size: {}",
+                mesh_coord[0],
+                mesh_coord[1],
+                mesh_coords_set.size(),
+                tensor_coords_set.size());
         }
         for (const auto& mesh_coord : mesh_coords_set) {
             const ttnn::MeshCoordinateRange single_coord_range{mesh_coord, mesh_coord};

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fill_cache/paged_fill_cache_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fill_cache/paged_fill_cache_program_factory.cpp
@@ -102,7 +102,7 @@ PagedFillCacheProgramFactory::cached_program_t PagedFillCacheProgramFactory::cre
     auto* dst_buffer = cache_tensor.buffer();
     auto* page_table_buffer = page_table_tensor.buffer();
 
-    std::vector<uint32_t> reader_compile_time_args = {(uint32_t)src0_cb_index, Wt};
+    std::vector<uint32_t> reader_compile_time_args = {(uint32_t)src0_cb_index, Wt, (uint32_t)operation_attributes.noop};
     TensorAccessorArgs(src_buffer).append_to(reader_compile_time_args);
 
     std::vector<uint32_t> writer_compile_time_args = {
@@ -116,8 +116,9 @@ PagedFillCacheProgramFactory::cached_program_t PagedFillCacheProgramFactory::cre
         page_table_stick_size_B,
         // New compile-time args for batch_idx_tensor
         (uint32_t)use_batch_idx_tensor,
-        cb_batch_idx_id,        // Meaningful only if use_batch_idx_tensor is true
-        batch_idx_stick_size_B  // Meaningful only if use_batch_idx_tensor is true
+        cb_batch_idx_id,                     // Meaningful only if use_batch_idx_tensor is true
+        batch_idx_stick_size_B,              // Meaningful only if use_batch_idx_tensor is true
+        (uint32_t)operation_attributes.noop  // When true, kernel early exits
     };
     TensorAccessorArgs(dst_buffer).append_to(writer_compile_time_args);
     TensorAccessorArgs(page_table_buffer).append_to(writer_compile_time_args);
@@ -262,34 +263,101 @@ PagedFillCacheMeshWorkloadFactory::cached_mesh_workload_t PagedFillCacheMeshWork
 
     if (mesh_coords_opt.has_value()) {
         log_debug(tt::LogOp, "mesh_coords provided with {} coordinates", mesh_coords_opt.value().size());
+        // Validate that all mesh_coords are present in tensor_coords BEFORE creating programs
+        // This prevents creating an empty workload which could cause hangs
+        const auto& mesh_coords_set = mesh_coords_opt.value();
+        const auto tensor_coords_vector = tensor_coords.coords();
+        std::set<ttnn::MeshCoordinate> tensor_coords_set(tensor_coords_vector.begin(), tensor_coords_vector.end());
+        for (const auto& mesh_coord : mesh_coords_set) {
+            if (tensor_coords_set.find(mesh_coord) == tensor_coords_set.end()) {
+                TT_FATAL(
+                    false,
+                    "paged_fill_cache: mesh_coord ({}, {}) is in mesh_coords but not found in tensor_coords. "
+                    "This would result in no program being created for this coordinate, causing potential hang. "
+                    "mesh_coords size: {}, tensor_coords size: {}",
+                    mesh_coord[0],
+                    mesh_coord[1],
+                    mesh_coords_set.size(),
+                    tensor_coords_set.size());
+            }
+        }
     } else {
         log_debug(tt::LogOp, "mesh_coords not provided, using all tensor_coords");
     }
 
-    // Create programs for each coordinate in tensor_coords (filtered by mesh_coords if provided)
-    for (const auto& mesh_coord_range : tensor_coords.ranges()) {
-        for (const auto& mesh_coord : mesh_coord_range) {
-            // Skip this coordinate if mesh_coords is provided and this coordinate is not in the set
-            if (mesh_coords_opt.has_value()) {
-                const auto& mesh_coords_set = mesh_coords_opt.value();
-                if (mesh_coords_set.find(mesh_coord) == mesh_coords_set.end()) {
-                    log_debug(
-                        tt::LogOp, "Skipping coordinate ({}, {}) - not in mesh_coords", mesh_coord[0], mesh_coord[1]);
-                    continue;  // Skip this coordinate
-                }
-            }
-
-            // Create a program for this specific coordinate using the base factory
-            log_debug(tt::LogOp, "Creating program for coordinate ({}, {})", mesh_coord[0], mesh_coord[1]);
+    // Create programs for coordinates
+    if (mesh_coords_opt.has_value()) {
+        // When mesh_coords is provided, iterate directly over mesh_coords (which have already been validated to be in
+        // tensor_coords)
+        const auto& mesh_coords_set = mesh_coords_opt.value();
+        log_info(tt::LogAlways, "Creating programs for {} mesh_coords", mesh_coords_set.size());
+        for (const auto& mesh_coord : mesh_coords_set) {
+            log_info(tt::LogAlways, "Creating program for coordinate ({}, {})", mesh_coord[0], mesh_coord[1]);
             const ttnn::MeshCoordinateRange single_coord_range{mesh_coord, mesh_coord};
             auto cached_program =
                 PagedFillCacheProgramFactory::create(operation_attributes, tensor_args, tensor_return_value);
             shared_variables[single_coord_range] = std::move(cached_program.shared_variables);
             mesh_workload.add_program(single_coord_range, std::move(cached_program.program));
         }
+        log_info(tt::LogAlways, "Mesh_coords {}", mesh_coord);
+
+        // Create dummy programs for excluded coordinates
+        const auto tensor_coords_vector = tensor_coords.coords();
+        std::set<ttnn::MeshCoordinate> tensor_coords_set(tensor_coords_vector.begin(), tensor_coords_vector.end());
+
+        std::vector<ttnn::MeshCoordinate> dummy_coords;
+        for (const auto& coord : tensor_coords_set) {
+            if (mesh_coords_set.find(coord) == mesh_coords_set.end()) {
+                dummy_coords.push_back(coord);
+            }
+        }
+
+        if (!dummy_coords.empty()) {
+            log_info(
+                tt::LogAlways,
+                "[paged_fill_cache] Creating {} dummy programs for excluded coordinates",
+                dummy_coords.size());
+            for (const auto& mesh_coord : dummy_coords) {
+                const ttnn::MeshCoordinateRange single_coord_range{mesh_coord, mesh_coord};
+                // Create operation attributes with noop=true for dummy programs
+                operation_attributes_t dummy_attrs{
+                    .batch_idx_fallback = operation_attributes.batch_idx_fallback,
+                    .mesh_coords = operation_attributes.mesh_coords,
+                    .noop = true};
+                auto cached_program =
+                    PagedFillCacheProgramFactory::create(dummy_attrs, tensor_args, tensor_return_value);
+                // Store shared_variables for dummy programs (needed for override_runtime_arguments)
+                shared_variables[single_coord_range] = std::move(cached_program.shared_variables);
+                mesh_workload.add_program(single_coord_range, std::move(cached_program.program));
+            }
+        }
+    } else {
+        // When mesh_coords is not provided, iterate over all tensor_coords
+        log_info(tt::LogAlways, "Creating programs for all {} tensor_coord ranges", tensor_coords.ranges().size());
+        for (const auto& mesh_coord_range : tensor_coords.ranges()) {
+            for (const auto& mesh_coord : mesh_coord_range) {
+                log_debug(tt::LogOp, "Creating program for coordinate ({}, {})", mesh_coord[0], mesh_coord[1]);
+                const ttnn::MeshCoordinateRange single_coord_range{mesh_coord, mesh_coord};
+                auto cached_program =
+                    PagedFillCacheProgramFactory::create(operation_attributes, tensor_args, tensor_return_value);
+                shared_variables[single_coord_range] = std::move(cached_program.shared_variables);
+                mesh_workload.add_program(single_coord_range, std::move(cached_program.program));
+            }
+        }
     }
 
-    log_debug(tt::LogOp, "Created mesh workload with {} programs", mesh_workload.get_programs().size());
+    // Final validation: ensure at least one program was created when mesh_coords is provided
+    // (This is a safety check in case the validation above missed something)
+    if (mesh_coords_opt.has_value() && mesh_workload.get_programs().empty()) {
+        TT_FATAL(
+            false,
+            "paged_fill_cache: mesh_coords provided but no programs were created. "
+            "This would result in an empty workload and potential hang. "
+            "mesh_coords size: {}, tensor_coords ranges: {}",
+            mesh_coords_opt.value().size(),
+            tensor_coords.ranges().size());
+    }
+
     return cached_mesh_workload_t{std::move(mesh_workload), std::move(shared_variables)};
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/reader_fill_cache_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/reader_fill_cache_interleaved.cpp
@@ -8,17 +8,17 @@
 void kernel_main() {
     constexpr uint32_t cb_id_in = get_compile_time_arg_val(0);
     constexpr uint32_t Wt = get_compile_time_arg_val(1);
-    constexpr bool noop = get_compile_time_arg_val(2) == 1;
-
-    if constexpr (noop) {
-        return;  // Early exit, no work done
-    }
 
     const uint32_t src_addr = get_arg_val<uint32_t>(0);
     const uint32_t start_tile_id = get_arg_val<uint32_t>(1);
     const uint32_t num_rows = get_arg_val<uint32_t>(2);
+    const uint32_t noop = get_arg_val<uint32_t>(3);
 
-    constexpr auto src_args = TensorAccessorArgs<3>();
+    if (noop == 1) {
+        return;  // Early exit, no work done
+    }
+
+    constexpr auto src_args = TensorAccessorArgs<2>();
 
     const uint32_t tile_bytes = get_tile_size(cb_id_in);
 

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/reader_fill_cache_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/reader_fill_cache_interleaved.cpp
@@ -6,14 +6,19 @@
 #include "dataflow_api.h"
 
 void kernel_main() {
+    constexpr uint32_t cb_id_in = get_compile_time_arg_val(0);
+    constexpr uint32_t Wt = get_compile_time_arg_val(1);
+    constexpr bool noop = get_compile_time_arg_val(2) == 1;
+
+    if constexpr (noop) {
+        return;  // Early exit, no work done
+    }
+
     const uint32_t src_addr = get_arg_val<uint32_t>(0);
     const uint32_t start_tile_id = get_arg_val<uint32_t>(1);
     const uint32_t num_rows = get_arg_val<uint32_t>(2);
 
-    constexpr uint32_t cb_id_in = get_compile_time_arg_val(0);
-    constexpr uint32_t Wt = get_compile_time_arg_val(1);
-
-    constexpr auto src_args = TensorAccessorArgs<2>();
+    constexpr auto src_args = TensorAccessorArgs<3>();
 
     const uint32_t tile_bytes = get_tile_size(cb_id_in);
 

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/writer_fill_cache_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/writer_fill_cache_interleaved.cpp
@@ -43,11 +43,6 @@ void kernel_main() {
     constexpr uint32_t cb_id_batch_idx = get_compile_time_arg_val(9);  // CB for reading from batch_idx_tensor
     constexpr uint32_t batch_idx_stick_size =
         get_compile_time_arg_val(10);  // Expected to be small (e.g., 4 for uint32)
-    constexpr bool noop = get_compile_time_arg_val(11) == 1;
-
-    if constexpr (noop) {
-        return;  // Early exit, no work done
-    }
 
     uint32_t dst_addr = get_arg_val<uint32_t>(0);
     uint32_t page_table_addr = get_arg_val<uint32_t>(1);
@@ -55,8 +50,13 @@ void kernel_main() {
     uint32_t num_rows = get_arg_val<uint32_t>(3);
     // Arg 4 is either batch_idx_tensor_addr or batch_idx_fallback scalar
     uint32_t batch_arg = get_arg_val<uint32_t>(4);
+    uint32_t noop = get_arg_val<uint32_t>(5);
 
-    constexpr auto s0_args = TensorAccessorArgs<12>();
+    if (noop == 1) {
+        return;  // Early exit, no work done
+    }
+
+    constexpr auto s0_args = TensorAccessorArgs<11>();
     constexpr auto page_table_args = TensorAccessorArgs<s0_args.next_compile_time_args_offset()>();
     constexpr auto batch_idx_tensor_args = TensorAccessorArgs<page_table_args.next_compile_time_args_offset()>();
 

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/writer_fill_cache_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/writer_fill_cache_interleaved.cpp
@@ -29,13 +29,6 @@ uint32_t virtual_seq_tile_id_to_physical_tile_id(
 }
 
 void kernel_main() {
-    uint32_t dst_addr = get_arg_val<uint32_t>(0);
-    uint32_t page_table_addr = get_arg_val<uint32_t>(1);
-    uint32_t start_row_num = get_arg_val<uint32_t>(2);
-    uint32_t num_rows = get_arg_val<uint32_t>(3);
-    // Arg 4 is either batch_idx_tensor_addr or batch_idx_fallback scalar
-    uint32_t batch_arg = get_arg_val<uint32_t>(4);
-
     constexpr uint32_t cb_id_in = get_compile_time_arg_val(0);
     constexpr uint32_t cb_id_page_table = get_compile_time_arg_val(1);
     constexpr uint32_t num_heads = get_compile_time_arg_val(2);
@@ -50,8 +43,20 @@ void kernel_main() {
     constexpr uint32_t cb_id_batch_idx = get_compile_time_arg_val(9);  // CB for reading from batch_idx_tensor
     constexpr uint32_t batch_idx_stick_size =
         get_compile_time_arg_val(10);  // Expected to be small (e.g., 4 for uint32)
+    constexpr bool noop = get_compile_time_arg_val(11) == 1;
 
-    constexpr auto s0_args = TensorAccessorArgs<11>();
+    if constexpr (noop) {
+        return;  // Early exit, no work done
+    }
+
+    uint32_t dst_addr = get_arg_val<uint32_t>(0);
+    uint32_t page_table_addr = get_arg_val<uint32_t>(1);
+    uint32_t start_row_num = get_arg_val<uint32_t>(2);
+    uint32_t num_rows = get_arg_val<uint32_t>(3);
+    // Arg 4 is either batch_idx_tensor_addr or batch_idx_fallback scalar
+    uint32_t batch_arg = get_arg_val<uint32_t>(4);
+
+    constexpr auto s0_args = TensorAccessorArgs<12>();
     constexpr auto page_table_args = TensorAccessorArgs<s0_args.next_compile_time_args_offset()>();
     constexpr auto batch_idx_tensor_args = TensorAccessorArgs<page_table_args.next_compile_time_args_offset()>();
 


### PR DESCRIPTION
### Summary
 
This PR updates the paged fill cache operation to dispatch over all devices in the mesh. Previously, we would conditionally dispatch onto devices specified by the `mesh_coords` parameter, but this was found to cause a hang in DeepSeekV3 on dual galaxy. Determination of the root cause of this hang is to-be-determined, but I have verified that this does work on single and dual galaxy demos.

This change was implemented by including all devices in the mesh workload, and passing a runtime argument `noop` to each device that does not need to do any work.

### Future Work
- This operation does not have any multi-device unit tests; we should add these:
    - https://github.com/tenstorrent/tt-metal/issues/34377 
- This approach will not work with tracing; we should update this op to take a `ttnn.Tensor` mask to designate which devices need to be active.
    - https://github.com/tenstorrent/tt-metal/issues/33032

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/20193568025
- [x] [DeepSeekV3 Galaxy Tests](): https://github.com/tenstorrent/tt-metal/actions/runs/20193570108
- [x] [DeepSeekV3 Demo](): https://github.com/tenstorrent/tt-metal/actions/runs/20234648584