### PR TITLE
Add fabric inter-mesh cycle test

### DIFF
--- a/tests/tt_metal/distributed/config/wh_galaxy_2x4_rank_bindings.yaml
+++ b/tests/tt_metal/distributed/config/wh_galaxy_2x4_rank_bindings.yaml
@@ -1,0 +1,19 @@
+rank_bindings:
+  - rank: 0
+    mesh_id: 0
+    env_overrides:
+      TT_VISIBLE_DEVICES: "0,1,2,3,4,5,6,7"
+  - rank: 1
+    mesh_id: 1
+    env_overrides:
+      TT_VISIBLE_DEVICES: "16,17,18,19,20,21,22,23"
+  - rank: 2
+    mesh_id: 2
+    env_overrides:
+      TT_VISIBLE_DEVICES: "24,25,26,27,28,29,30,31"
+  - rank: 3
+    mesh_id: 3
+    env_overrides:
+      TT_VISIBLE_DEVICES: "8,9,10,11,12,13,14,15"
+
+mesh_graph_desc_path: "tests/tt_metal/tt_fabric/custom_mesh_descriptors/wh_galaxy_2x4_mesh_graph_descriptor.textproto"

--- a/tests/tt_metal/tt_fabric/custom_mesh_descriptors/wh_galaxy_2x4_mesh_graph_descriptor.textproto
+++ b/tests/tt_metal/tt_fabric/custom_mesh_descriptors/wh_galaxy_2x4_mesh_graph_descriptor.textproto
@@ -1,0 +1,43 @@
+# --- Meshes ---------------------------------------------------------------
+
+mesh_descriptors {
+  name: "MESH"
+  arch: WORMHOLE_B0
+  device_topology { dims: [ 2, 4 ] }
+  host_topology   { dims: [ 1, 1 ] }
+  channels {
+    count: 4
+    policy: RELAXED
+  }
+}
+graph_descriptors {
+  name: "G0"
+  type: "FABRIC"
+  instances { mesh { mesh_descriptor: "MESH" mesh_id: 0 } }
+  instances { mesh { mesh_descriptor: "MESH" mesh_id: 1 } }
+  instances { mesh { mesh_descriptor: "MESH" mesh_id: 2 } }
+  instances { mesh { mesh_descriptor: "MESH" mesh_id: 3 } }
+
+  connections {
+    nodes { mesh { mesh_descriptor: "MESH" mesh_id: 0 device_id: 7} }
+    nodes { mesh { mesh_descriptor: "MESH" mesh_id: 1 device_id: 7} }
+    channels { count: 1 policy: RELAXED }
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "MESH" mesh_id: 2 device_id: 7} }
+    nodes { mesh { mesh_descriptor: "MESH" mesh_id: 3 device_id: 7} }
+    channels { count: 1 policy: RELAXED }
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "MESH" mesh_id: 1 device_id: 4} }
+    nodes { mesh { mesh_descriptor: "MESH" mesh_id: 2 device_id: 4} }
+    channels { count: 1 policy: RELAXED }
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "MESH" mesh_id: 0 device_id: 4} }
+    nodes { mesh { mesh_descriptor: "MESH" mesh_id: 3 device_id: 4} }
+    channels { count: 1 policy: RELAXED }
+  }
+}
+# --- Instantiation ----------------------------------------------------------
+top_level_instance { graph { graph_descriptor: "G0" graph_id: 0 } }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_wh_6u_quad_2x4_acyclic.yaml
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_wh_6u_quad_2x4_acyclic.yaml
@@ -1,0 +1,2106 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+# Run this with the following command:
+# tt-run --rank-binding tests/tt_metal/distributed/config/wh_galaxy_2x4_rank_bindings.yaml --mpi-args "--allow-run-as-root --tag-output" ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_wh_6u_quad_2x4_acyclic.yaml
+#
+Tests:
+  - name: "SimpleUnicastMesh"
+    enable_flow_control: true
+    sync: true
+    fabric_setup:
+      topology: Mesh
+    senders:
+      - device: [0, 0]
+        patterns:
+          - ftype: unicast
+            ntype: unicast_write
+            size: 2048
+            num_packets: 50000
+            destination:
+              device: [0, 1]
+      - device: [1, 0]
+        patterns:
+          - ftype: unicast
+            ntype: unicast_write
+            size: 2048
+            num_packets: 50000
+            destination:
+              device: [1, 1]
+      - device: [2, 0]
+        patterns:
+          - ftype: unicast
+            ntype: unicast_write
+            size: 2048
+            num_packets: 50000
+            destination:
+              device: [2, 1]
+      - device: [3, 0]
+        patterns:
+          - ftype: unicast
+            ntype: unicast_write
+            size: 2048
+            num_packets: 50000
+            destination:
+              device: [3, 1]
+
+  - name: "TestNocSendTypesMesh"
+    enable_flow_control: true
+    sync: true
+    fabric_setup:
+      topology: Mesh
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+    senders:
+      - device: [0, 0]
+        patterns:
+          - ftype: unicast
+            ntype: unicast_write
+            size: 2048
+            num_packets: 50000
+            destination:
+              device: [0, 1]
+      - device: [1, 0]
+        patterns:
+          - ftype: unicast
+            ntype: unicast_write
+            size: 2048
+            num_packets: 50000
+            destination:
+              device: [1, 1]
+      - device: [2, 0]
+        patterns:
+          - ftype: unicast
+            ntype: unicast_write
+            size: 2048
+            num_packets: 50000
+            destination:
+              device: [2, 1]
+      - device: [3, 0]
+        patterns:
+          - ftype: unicast
+            ntype: unicast_write
+            size: 2048
+            num_packets: 50000
+            destination:
+              device: [3, 1]
+
+  - name: "TestNocSendTypesMesh"
+    enable_flow_control: true
+    sync: true
+    fabric_setup:
+      topology: Mesh
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
+    senders:
+      - device: [0, 0]
+        patterns:
+          - ftype: unicast
+            ntype: unicast_write
+            size: 2048
+            num_packets: 50000
+            destination:
+              device: [0, 1]
+      - device: [1, 0]
+        patterns:
+          - ftype: unicast
+            ntype: unicast_write
+            size: 2048
+            num_packets: 50000
+            destination:
+              device: [1, 1]
+      - device: [2, 0]
+        patterns:
+          - ftype: unicast
+            ntype: unicast_write
+            size: 2048
+            num_packets: 50000
+            destination:
+              device: [2, 1]
+      - device: [3, 0]
+        patterns:
+          - ftype: unicast
+            ntype: unicast_write
+            size: 2048
+            num_packets: 50000
+            destination:
+              device: [3, 1]
+
+  - name: TestPacketSizesMesh
+    enable_flow_control: true
+    sync: true
+    fabric_setup:
+      topology: Mesh
+    parametrization_params:
+      size: [1024, 2048, 4096]
+    senders:
+      - device: [0, 0]
+        patterns:
+          - ftype: unicast
+            ntype: unicast_write
+            num_packets: 50000
+            destination:
+              device: [0, 1]
+      - device: [1, 0]
+        patterns:
+          - ftype: unicast
+            ntype: unicast_write
+            num_packets: 50000
+            destination:
+              device: [1, 1]
+      - device: [2, 0]
+        patterns:
+          - ftype: unicast
+            ntype: unicast_write
+            num_packets: 50000
+            destination:
+              device: [2, 1]
+      - device: [3, 0]
+        patterns:
+          - ftype: unicast
+            ntype: unicast_write
+            num_packets: 50000
+            destination:
+              device: [3, 1]
+
+  - name: "InterMeshTestI"
+    fabric_setup:
+      topology: Mesh
+    defaults:
+      size: 2048
+      ftype: unicast
+      ntype: unicast_write
+      num_packets: 1
+    senders:
+      - device: [0, 0]
+        patterns:
+          - destination:
+              device: [0, 5]
+
+  - name: "InterMeshTest"
+    fabric_setup:
+      topology: Mesh
+    defaults:
+      size: 2048
+      ftype: unicast
+      ntype: unicast_write
+      num_packets: 1
+    senders:
+      - device: [0, 0]
+        patterns:
+          - destination:
+              device: [1, 0]
+          - destination:
+              device: [2, 0]
+          - destination:
+              device: [3, 0]
+          - destination:
+              device: [3, 1]
+
+  - name: "InterMeshFourCorners"
+    sync: true
+    enable_flow_control: true
+    fabric_setup:
+      topology: Mesh
+    parametrization_params:
+      size: [2048, 4096]
+    defaults:
+      ftype: unicast
+      ntype: unicast_write
+      num_packets: 50000
+    senders:
+      - device: [0, 0]
+        patterns:
+          - destination:
+              device: [1, 0]
+          - destination:
+              device: [2, 0]
+          - destination:
+              device: [3, 0]
+      - device: [1, 0]
+        patterns:
+          - destination:
+              device: [0, 0]
+          - destination:
+              device: [2, 0]
+          - destination:
+              device: [3, 0]
+      - device: [2, 0]
+        patterns:
+          - destination:
+              device: [1, 0]
+          - destination:
+              device: [0, 0]
+          - destination:
+              device: [3, 0]
+      - device: [3, 0]
+        patterns:
+          - destination:
+              device: [1, 0]
+          - destination:
+              device: [2, 0]
+          - destination:
+              device: [0, 0]
+
+  - name: InterMeshStressTestInside02
+    sync: true
+    enable_flow_control: true
+    fabric_setup:
+      topology: Mesh
+    parametrization_params:
+      size: [2048, 4096]
+    defaults:
+      ftype: unicast
+      ntype: unicast_write
+      num_packets: 50000
+    senders:
+      - device: [0, 4]
+        patterns:
+          - destination:
+              device: [2, 0]
+          - destination:
+              device: [2, 1]
+          - destination:
+              device: [2, 2]
+          - destination:
+              device: [2, 3]
+          - destination:
+              device: [2, 4]
+          - destination:
+              device: [2, 5]
+          - destination:
+              device: [2, 6]
+          - destination:
+              device: [2, 7]
+      - device: [0, 5]
+        patterns:
+          - destination:
+              device: [2, 0]
+          - destination:
+              device: [2, 1]
+          - destination:
+              device: [2, 2]
+          - destination:
+              device: [2, 3]
+          - destination:
+              device: [2, 4]
+          - destination:
+              device: [2, 5]
+          - destination:
+              device: [2, 6]
+          - destination:
+              device: [2, 7]
+      - device: [0, 6]
+        patterns:
+          - destination:
+              device: [2, 0]
+          - destination:
+              device: [2, 1]
+          - destination:
+              device: [2, 2]
+          - destination:
+              device: [2, 3]
+          - destination:
+              device: [2, 4]
+          - destination:
+              device: [2, 5]
+          - destination:
+              device: [2, 6]
+          - destination:
+              device: [2, 7]
+      - device: [0, 7]
+        patterns:
+          - destination:
+              device: [2, 0]
+          - destination:
+              device: [2, 1]
+          - destination:
+              device: [2, 2]
+          - destination:
+              device: [2, 3]
+          - destination:
+              device: [2, 4]
+          - destination:
+              device: [2, 5]
+          - destination:
+              device: [2, 6]
+          - destination:
+              device: [2, 7]
+      - device: [2, 4]
+        patterns:
+          - destination:
+              device: [0, 0]
+          - destination:
+              device: [0, 1]
+          - destination:
+              device: [0, 2]
+          - destination:
+              device: [0, 3]
+          - destination:
+              device: [0, 4]
+          - destination:
+              device: [0, 5]
+          - destination:
+              device: [0, 6]
+          - destination:
+              device: [0, 7]
+      - device: [2, 5]
+        patterns:
+          - destination:
+              device: [0, 0]
+          - destination:
+              device: [0, 1]
+          - destination:
+              device: [0, 2]
+          - destination:
+              device: [0, 3]
+          - destination:
+              device: [0, 4]
+          - destination:
+              device: [0, 5]
+          - destination:
+              device: [0, 6]
+          - destination:
+              device: [0, 7]
+      - device: [2, 6]
+        patterns:
+          - destination:
+              device: [0, 0]
+          - destination:
+              device: [0, 1]
+          - destination:
+              device: [0, 2]
+          - destination:
+              device: [0, 3]
+          - destination:
+              device: [0, 4]
+          - destination:
+              device: [0, 5]
+          - destination:
+              device: [0, 6]
+          - destination:
+              device: [0, 7]
+      - device: [2, 7]
+        patterns:
+          - destination:
+              device: [0, 0]
+          - destination:
+              device: [0, 1]
+          - destination:
+              device: [0, 2]
+          - destination:
+              device: [0, 3]
+          - destination:
+              device: [0, 4]
+          - destination:
+              device: [0, 5]
+          - destination:
+              device: [0, 6]
+          - destination:
+              device: [0, 7]
+
+  - name: InterMeshStressInsideTest13
+    sync: true
+    enable_flow_control: true
+    fabric_setup:
+      topology: Mesh
+    parametrization_params:
+      size: [2048, 4096]
+    defaults:
+      ftype: unicast
+      ntype: unicast_write
+      num_packets: 50000
+    senders:
+      - device: [1, 4]
+        patterns:
+          - destination:
+              device: [3, 0]
+          - destination:
+              device: [3, 1]
+          - destination:
+              device: [3, 2]
+          - destination:
+              device: [3, 3]
+          - destination:
+              device: [3, 4]
+          - destination:
+              device: [3, 5]
+          - destination:
+              device: [3, 6]
+          - destination:
+              device: [3, 7]
+      - device: [1, 5]
+        patterns:
+          - destination:
+              device: [3, 0]
+          - destination:
+              device: [3, 1]
+          - destination:
+              device: [3, 2]
+          - destination:
+              device: [3, 3]
+          - destination:
+              device: [3, 4]
+          - destination:
+              device: [3, 5]
+          - destination:
+              device: [3, 6]
+          - destination:
+              device: [3, 7]
+      - device: [1, 6]
+        patterns:
+          - destination:
+              device: [3, 0]
+          - destination:
+              device: [3, 1]
+          - destination:
+              device: [3, 2]
+          - destination:
+              device: [3, 3]
+          - destination:
+              device: [3, 4]
+          - destination:
+              device: [3, 5]
+          - destination:
+              device: [3, 6]
+          - destination:
+              device: [3, 7]
+      - device: [1, 7]
+        patterns:
+          - destination:
+              device: [3, 0]
+          - destination:
+              device: [3, 1]
+          - destination:
+              device: [3, 2]
+          - destination:
+              device: [3, 3]
+          - destination:
+              device: [3, 4]
+          - destination:
+              device: [3, 5]
+          - destination:
+              device: [3, 6]
+          - destination:
+              device: [3, 7]
+      - device: [3, 4]
+        patterns:
+          - destination:
+              device: [1, 0]
+          - destination:
+              device: [1, 1]
+          - destination:
+              device: [1, 2]
+          - destination:
+              device: [1, 3]
+          - destination:
+              device: [1, 4]
+          - destination:
+              device: [1, 5]
+          - destination:
+              device: [1, 6]
+          - destination:
+              device: [1, 7]
+      - device: [3, 5]
+        patterns:
+          - destination:
+              device: [1, 0]
+          - destination:
+              device: [1, 1]
+          - destination:
+              device: [1, 2]
+          - destination:
+              device: [1, 3]
+          - destination:
+              device: [1, 4]
+          - destination:
+              device: [1, 5]
+          - destination:
+              device: [1, 6]
+          - destination:
+              device: [1, 7]
+      - device: [3, 6]
+        patterns:
+          - destination:
+              device: [1, 0]
+          - destination:
+              device: [1, 1]
+          - destination:
+              device: [1, 2]
+          - destination:
+              device: [1, 3]
+          - destination:
+              device: [1, 4]
+          - destination:
+              device: [1, 5]
+          - destination:
+              device: [1, 6]
+          - destination:
+              device: [1, 7]
+      - device: [3, 7]
+        patterns:
+          - destination:
+              device: [1, 0]
+          - destination:
+              device: [1, 1]
+          - destination:
+              device: [1, 2]
+          - destination:
+              device: [1, 3]
+          - destination:
+              device: [1, 4]
+          - destination:
+              device: [1, 5]
+          - destination:
+              device: [1, 6]
+          - destination:
+              device: [1, 7]
+
+  # Outside chips (0-3) stress test between Mesh 0 and Mesh 2
+  - name: InterMeshStressTestOutside02
+    sync: true
+    enable_flow_control: true
+    fabric_setup:
+      topology: Mesh
+    parametrization_params:
+      size: [2048, 4096]
+    defaults:
+      ftype: unicast
+      ntype: unicast_write
+      num_packets: 50000
+    senders:
+      - device: [0, 0]
+        patterns:
+          - destination:
+              device: [2, 0]
+          - destination:
+              device: [2, 1]
+          - destination:
+              device: [2, 2]
+          - destination:
+              device: [2, 3]
+          - destination:
+              device: [2, 4]
+          - destination:
+              device: [2, 5]
+          - destination:
+              device: [2, 6]
+          - destination:
+              device: [2, 7]
+      - device: [0, 1]
+        patterns:
+          - destination:
+              device: [2, 0]
+          - destination:
+              device: [2, 1]
+          - destination:
+              device: [2, 2]
+          - destination:
+              device: [2, 3]
+          - destination:
+              device: [2, 4]
+          - destination:
+              device: [2, 5]
+          - destination:
+              device: [2, 6]
+          - destination:
+              device: [2, 7]
+      - device: [0, 2]
+        patterns:
+          - destination:
+              device: [2, 0]
+          - destination:
+              device: [2, 1]
+          - destination:
+              device: [2, 2]
+          - destination:
+              device: [2, 3]
+          - destination:
+              device: [2, 4]
+          - destination:
+              device: [2, 5]
+          - destination:
+              device: [2, 6]
+          - destination:
+              device: [2, 7]
+      - device: [0, 3]
+        patterns:
+          - destination:
+              device: [2, 0]
+          - destination:
+              device: [2, 1]
+          - destination:
+              device: [2, 2]
+          - destination:
+              device: [2, 3]
+          - destination:
+              device: [2, 4]
+          - destination:
+              device: [2, 5]
+          - destination:
+              device: [2, 6]
+          - destination:
+              device: [2, 7]
+      - device: [2, 0]
+        patterns:
+          - destination:
+              device: [0, 0]
+          - destination:
+              device: [0, 1]
+          - destination:
+              device: [0, 2]
+          - destination:
+              device: [0, 3]
+          - destination:
+              device: [0, 4]
+          - destination:
+              device: [0, 5]
+          - destination:
+              device: [0, 6]
+          - destination:
+              device: [0, 7]
+      - device: [2, 1]
+        patterns:
+          - destination:
+              device: [0, 0]
+          - destination:
+              device: [0, 1]
+          - destination:
+              device: [0, 2]
+          - destination:
+              device: [0, 3]
+          - destination:
+              device: [0, 4]
+          - destination:
+              device: [0, 5]
+          - destination:
+              device: [0, 6]
+          - destination:
+              device: [0, 7]
+      - device: [2, 2]
+        patterns:
+          - destination:
+              device: [0, 0]
+          - destination:
+              device: [0, 1]
+          - destination:
+              device: [0, 2]
+          - destination:
+              device: [0, 3]
+          - destination:
+              device: [0, 4]
+          - destination:
+              device: [0, 5]
+          - destination:
+              device: [0, 6]
+          - destination:
+              device: [0, 7]
+      - device: [2, 3]
+        patterns:
+          - destination:
+              device: [0, 0]
+          - destination:
+              device: [0, 1]
+          - destination:
+              device: [0, 2]
+          - destination:
+              device: [0, 3]
+          - destination:
+              device: [0, 4]
+          - destination:
+              device: [0, 5]
+          - destination:
+              device: [0, 6]
+          - destination:
+              device: [0, 7]
+
+  # Outside chips (0-3) stress test between Mesh 1 and Mesh 3
+  - name: InterMeshStressTestOutside13
+    sync: true
+    enable_flow_control: true
+    fabric_setup:
+      topology: Mesh
+    parametrization_params:
+      size: [2048, 4096]
+    defaults:
+      ftype: unicast
+      ntype: unicast_write
+      num_packets: 50000
+    senders:
+      - device: [1, 0]
+        patterns:
+          - destination:
+              device: [3, 0]
+          - destination:
+              device: [3, 1]
+          - destination:
+              device: [3, 2]
+          - destination:
+              device: [3, 3]
+          - destination:
+              device: [3, 4]
+          - destination:
+              device: [3, 5]
+          - destination:
+              device: [3, 6]
+          - destination:
+              device: [3, 7]
+      - device: [1, 1]
+        patterns:
+          - destination:
+              device: [3, 0]
+          - destination:
+              device: [3, 1]
+          - destination:
+              device: [3, 2]
+          - destination:
+              device: [3, 3]
+          - destination:
+              device: [3, 4]
+          - destination:
+              device: [3, 5]
+          - destination:
+              device: [3, 6]
+          - destination:
+              device: [3, 7]
+      - device: [1, 2]
+        patterns:
+          - destination:
+              device: [3, 0]
+          - destination:
+              device: [3, 1]
+          - destination:
+              device: [3, 2]
+          - destination:
+              device: [3, 3]
+          - destination:
+              device: [3, 4]
+          - destination:
+              device: [3, 5]
+          - destination:
+              device: [3, 6]
+          - destination:
+              device: [3, 7]
+      - device: [1, 3]
+        patterns:
+          - destination:
+              device: [3, 0]
+          - destination:
+              device: [3, 1]
+          - destination:
+              device: [3, 2]
+          - destination:
+              device: [3, 3]
+          - destination:
+              device: [3, 4]
+          - destination:
+              device: [3, 5]
+          - destination:
+              device: [3, 6]
+          - destination:
+              device: [3, 7]
+      - device: [3, 0]
+        patterns:
+          - destination:
+              device: [1, 0]
+          - destination:
+              device: [1, 1]
+          - destination:
+              device: [1, 2]
+          - destination:
+              device: [1, 3]
+          - destination:
+              device: [1, 4]
+          - destination:
+              device: [1, 5]
+          - destination:
+              device: [1, 6]
+          - destination:
+              device: [1, 7]
+      - device: [3, 1]
+        patterns:
+          - destination:
+              device: [1, 0]
+          - destination:
+              device: [1, 1]
+          - destination:
+              device: [1, 2]
+          - destination:
+              device: [1, 3]
+          - destination:
+              device: [1, 4]
+          - destination:
+              device: [1, 5]
+          - destination:
+              device: [1, 6]
+          - destination:
+              device: [1, 7]
+      - device: [3, 2]
+        patterns:
+          - destination:
+              device: [1, 0]
+          - destination:
+              device: [1, 1]
+          - destination:
+              device: [1, 2]
+          - destination:
+              device: [1, 3]
+          - destination:
+              device: [1, 4]
+          - destination:
+              device: [1, 5]
+          - destination:
+              device: [1, 6]
+          - destination:
+              device: [1, 7]
+      - device: [3, 3]
+        patterns:
+          - destination:
+              device: [1, 0]
+          - destination:
+              device: [1, 1]
+          - destination:
+              device: [1, 2]
+          - destination:
+              device: [1, 3]
+          - destination:
+              device: [1, 4]
+          - destination:
+              device: [1, 5]
+          - destination:
+              device: [1, 6]
+          - destination:
+              device: [1, 7]
+
+  # Full all-to-all between Mesh 0 and Mesh 2 (all devices)
+  - name: InterMeshFullAllToAll02
+    sync: true
+    enable_flow_control: true
+    fabric_setup:
+      topology: Mesh
+    parametrization_params:
+      size: [2048, 4096]
+    defaults:
+      ftype: unicast
+      ntype: unicast_write
+      num_packets: 50000
+    senders:
+      - device: [0, 0]
+        patterns:
+          - destination:
+              device: [2, 0]
+          - destination:
+              device: [2, 1]
+          - destination:
+              device: [2, 2]
+          - destination:
+              device: [2, 3]
+          - destination:
+              device: [2, 4]
+          - destination:
+              device: [2, 5]
+          - destination:
+              device: [2, 6]
+          - destination:
+              device: [2, 7]
+      - device: [0, 1]
+        patterns:
+          - destination:
+              device: [2, 0]
+          - destination:
+              device: [2, 1]
+          - destination:
+              device: [2, 2]
+          - destination:
+              device: [2, 3]
+          - destination:
+              device: [2, 4]
+          - destination:
+              device: [2, 5]
+          - destination:
+              device: [2, 6]
+          - destination:
+              device: [2, 7]
+      - device: [0, 2]
+        patterns:
+          - destination:
+              device: [2, 0]
+          - destination:
+              device: [2, 1]
+          - destination:
+              device: [2, 2]
+          - destination:
+              device: [2, 3]
+          - destination:
+              device: [2, 4]
+          - destination:
+              device: [2, 5]
+          - destination:
+              device: [2, 6]
+          - destination:
+              device: [2, 7]
+      - device: [0, 3]
+        patterns:
+          - destination:
+              device: [2, 0]
+          - destination:
+              device: [2, 1]
+          - destination:
+              device: [2, 2]
+          - destination:
+              device: [2, 3]
+          - destination:
+              device: [2, 4]
+          - destination:
+              device: [2, 5]
+          - destination:
+              device: [2, 6]
+          - destination:
+              device: [2, 7]
+      - device: [0, 4]
+        patterns:
+          - destination:
+              device: [2, 0]
+          - destination:
+              device: [2, 1]
+          - destination:
+              device: [2, 2]
+          - destination:
+              device: [2, 3]
+          - destination:
+              device: [2, 4]
+          - destination:
+              device: [2, 5]
+          - destination:
+              device: [2, 6]
+          - destination:
+              device: [2, 7]
+      - device: [0, 5]
+        patterns:
+          - destination:
+              device: [2, 0]
+          - destination:
+              device: [2, 1]
+          - destination:
+              device: [2, 2]
+          - destination:
+              device: [2, 3]
+          - destination:
+              device: [2, 4]
+          - destination:
+              device: [2, 5]
+          - destination:
+              device: [2, 6]
+          - destination:
+              device: [2, 7]
+      - device: [0, 6]
+        patterns:
+          - destination:
+              device: [2, 0]
+          - destination:
+              device: [2, 1]
+          - destination:
+              device: [2, 2]
+          - destination:
+              device: [2, 3]
+          - destination:
+              device: [2, 4]
+          - destination:
+              device: [2, 5]
+          - destination:
+              device: [2, 6]
+          - destination:
+              device: [2, 7]
+      - device: [0, 7]
+        patterns:
+          - destination:
+              device: [2, 0]
+          - destination:
+              device: [2, 1]
+          - destination:
+              device: [2, 2]
+          - destination:
+              device: [2, 3]
+          - destination:
+              device: [2, 4]
+          - destination:
+              device: [2, 5]
+          - destination:
+              device: [2, 6]
+          - destination:
+              device: [2, 7]
+      - device: [2, 0]
+        patterns:
+          - destination:
+              device: [0, 0]
+          - destination:
+              device: [0, 1]
+          - destination:
+              device: [0, 2]
+          - destination:
+              device: [0, 3]
+          - destination:
+              device: [0, 4]
+          - destination:
+              device: [0, 5]
+          - destination:
+              device: [0, 6]
+          - destination:
+              device: [0, 7]
+      - device: [2, 1]
+        patterns:
+          - destination:
+              device: [0, 0]
+          - destination:
+              device: [0, 1]
+          - destination:
+              device: [0, 2]
+          - destination:
+              device: [0, 3]
+          - destination:
+              device: [0, 4]
+          - destination:
+              device: [0, 5]
+          - destination:
+              device: [0, 6]
+          - destination:
+              device: [0, 7]
+      - device: [2, 2]
+        patterns:
+          - destination:
+              device: [0, 0]
+          - destination:
+              device: [0, 1]
+          - destination:
+              device: [0, 2]
+          - destination:
+              device: [0, 3]
+          - destination:
+              device: [0, 4]
+          - destination:
+              device: [0, 5]
+          - destination:
+              device: [0, 6]
+          - destination:
+              device: [0, 7]
+      - device: [2, 3]
+        patterns:
+          - destination:
+              device: [0, 0]
+          - destination:
+              device: [0, 1]
+          - destination:
+              device: [0, 2]
+          - destination:
+              device: [0, 3]
+          - destination:
+              device: [0, 4]
+          - destination:
+              device: [0, 5]
+          - destination:
+              device: [0, 6]
+          - destination:
+              device: [0, 7]
+      - device: [2, 4]
+        patterns:
+          - destination:
+              device: [0, 0]
+          - destination:
+              device: [0, 1]
+          - destination:
+              device: [0, 2]
+          - destination:
+              device: [0, 3]
+          - destination:
+              device: [0, 4]
+          - destination:
+              device: [0, 5]
+          - destination:
+              device: [0, 6]
+          - destination:
+              device: [0, 7]
+      - device: [2, 5]
+        patterns:
+          - destination:
+              device: [0, 0]
+          - destination:
+              device: [0, 1]
+          - destination:
+              device: [0, 2]
+          - destination:
+              device: [0, 3]
+          - destination:
+              device: [0, 4]
+          - destination:
+              device: [0, 5]
+          - destination:
+              device: [0, 6]
+          - destination:
+              device: [0, 7]
+      - device: [2, 6]
+        patterns:
+          - destination:
+              device: [0, 0]
+          - destination:
+              device: [0, 1]
+          - destination:
+              device: [0, 2]
+          - destination:
+              device: [0, 3]
+          - destination:
+              device: [0, 4]
+          - destination:
+              device: [0, 5]
+          - destination:
+              device: [0, 6]
+          - destination:
+              device: [0, 7]
+      - device: [2, 7]
+        patterns:
+          - destination:
+              device: [0, 0]
+          - destination:
+              device: [0, 1]
+          - destination:
+              device: [0, 2]
+          - destination:
+              device: [0, 3]
+          - destination:
+              device: [0, 4]
+          - destination:
+              device: [0, 5]
+          - destination:
+              device: [0, 6]
+          - destination:
+              device: [0, 7]
+
+  # Full all-to-all between Mesh 1 and Mesh 3 (all devices)
+  - name: InterMeshFullAllToAll13
+    sync: true
+    enable_flow_control: true
+    fabric_setup:
+      topology: Mesh
+    parametrization_params:
+      size: [2048, 4096]
+    defaults:
+      ftype: unicast
+      ntype: unicast_write
+      num_packets: 50000
+    senders:
+      - device: [1, 0]
+        patterns:
+          - destination:
+              device: [3, 0]
+          - destination:
+              device: [3, 1]
+          - destination:
+              device: [3, 2]
+          - destination:
+              device: [3, 3]
+          - destination:
+              device: [3, 4]
+          - destination:
+              device: [3, 5]
+          - destination:
+              device: [3, 6]
+          - destination:
+              device: [3, 7]
+      - device: [1, 1]
+        patterns:
+          - destination:
+              device: [3, 0]
+          - destination:
+              device: [3, 1]
+          - destination:
+              device: [3, 2]
+          - destination:
+              device: [3, 3]
+          - destination:
+              device: [3, 4]
+          - destination:
+              device: [3, 5]
+          - destination:
+              device: [3, 6]
+          - destination:
+              device: [3, 7]
+      - device: [1, 2]
+        patterns:
+          - destination:
+              device: [3, 0]
+          - destination:
+              device: [3, 1]
+          - destination:
+              device: [3, 2]
+          - destination:
+              device: [3, 3]
+          - destination:
+              device: [3, 4]
+          - destination:
+              device: [3, 5]
+          - destination:
+              device: [3, 6]
+          - destination:
+              device: [3, 7]
+      - device: [1, 3]
+        patterns:
+          - destination:
+              device: [3, 0]
+          - destination:
+              device: [3, 1]
+          - destination:
+              device: [3, 2]
+          - destination:
+              device: [3, 3]
+          - destination:
+              device: [3, 4]
+          - destination:
+              device: [3, 5]
+          - destination:
+              device: [3, 6]
+          - destination:
+              device: [3, 7]
+      - device: [1, 4]
+        patterns:
+          - destination:
+              device: [3, 0]
+          - destination:
+              device: [3, 1]
+          - destination:
+              device: [3, 2]
+          - destination:
+              device: [3, 3]
+          - destination:
+              device: [3, 4]
+          - destination:
+              device: [3, 5]
+          - destination:
+              device: [3, 6]
+          - destination:
+              device: [3, 7]
+      - device: [1, 5]
+        patterns:
+          - destination:
+              device: [3, 0]
+          - destination:
+              device: [3, 1]
+          - destination:
+              device: [3, 2]
+          - destination:
+              device: [3, 3]
+          - destination:
+              device: [3, 4]
+          - destination:
+              device: [3, 5]
+          - destination:
+              device: [3, 6]
+          - destination:
+              device: [3, 7]
+      - device: [1, 6]
+        patterns:
+          - destination:
+              device: [3, 0]
+          - destination:
+              device: [3, 1]
+          - destination:
+              device: [3, 2]
+          - destination:
+              device: [3, 3]
+          - destination:
+              device: [3, 4]
+          - destination:
+              device: [3, 5]
+          - destination:
+              device: [3, 6]
+          - destination:
+              device: [3, 7]
+      - device: [1, 7]
+        patterns:
+          - destination:
+              device: [3, 0]
+          - destination:
+              device: [3, 1]
+          - destination:
+              device: [3, 2]
+          - destination:
+              device: [3, 3]
+          - destination:
+              device: [3, 4]
+          - destination:
+              device: [3, 5]
+          - destination:
+              device: [3, 6]
+          - destination:
+              device: [3, 7]
+      - device: [3, 0]
+        patterns:
+          - destination:
+              device: [1, 0]
+          - destination:
+              device: [1, 1]
+          - destination:
+              device: [1, 2]
+          - destination:
+              device: [1, 3]
+          - destination:
+              device: [1, 4]
+          - destination:
+              device: [1, 5]
+          - destination:
+              device: [1, 6]
+          - destination:
+              device: [1, 7]
+      - device: [3, 1]
+        patterns:
+          - destination:
+              device: [1, 0]
+          - destination:
+              device: [1, 1]
+          - destination:
+              device: [1, 2]
+          - destination:
+              device: [1, 3]
+          - destination:
+              device: [1, 4]
+          - destination:
+              device: [1, 5]
+          - destination:
+              device: [1, 6]
+          - destination:
+              device: [1, 7]
+      - device: [3, 2]
+        patterns:
+          - destination:
+              device: [1, 0]
+          - destination:
+              device: [1, 1]
+          - destination:
+              device: [1, 2]
+          - destination:
+              device: [1, 3]
+          - destination:
+              device: [1, 4]
+          - destination:
+              device: [1, 5]
+          - destination:
+              device: [1, 6]
+          - destination:
+              device: [1, 7]
+      - device: [3, 3]
+        patterns:
+          - destination:
+              device: [1, 0]
+          - destination:
+              device: [1, 1]
+          - destination:
+              device: [1, 2]
+          - destination:
+              device: [1, 3]
+          - destination:
+              device: [1, 4]
+          - destination:
+              device: [1, 5]
+          - destination:
+              device: [1, 6]
+          - destination:
+              device: [1, 7]
+      - device: [3, 4]
+        patterns:
+          - destination:
+              device: [1, 0]
+          - destination:
+              device: [1, 1]
+          - destination:
+              device: [1, 2]
+          - destination:
+              device: [1, 3]
+          - destination:
+              device: [1, 4]
+          - destination:
+              device: [1, 5]
+          - destination:
+              device: [1, 6]
+          - destination:
+              device: [1, 7]
+      - device: [3, 5]
+        patterns:
+          - destination:
+              device: [1, 0]
+          - destination:
+              device: [1, 1]
+          - destination:
+              device: [1, 2]
+          - destination:
+              device: [1, 3]
+          - destination:
+              device: [1, 4]
+          - destination:
+              device: [1, 5]
+          - destination:
+              device: [1, 6]
+          - destination:
+              device: [1, 7]
+      - device: [3, 6]
+        patterns:
+          - destination:
+              device: [1, 0]
+          - destination:
+              device: [1, 1]
+          - destination:
+              device: [1, 2]
+          - destination:
+              device: [1, 3]
+          - destination:
+              device: [1, 4]
+          - destination:
+              device: [1, 5]
+          - destination:
+              device: [1, 6]
+          - destination:
+              device: [1, 7]
+      - device: [3, 7]
+        patterns:
+          - destination:
+              device: [1, 0]
+          - destination:
+              device: [1, 1]
+          - destination:
+              device: [1, 2]
+          - destination:
+              device: [1, 3]
+          - destination:
+              device: [1, 4]
+          - destination:
+              device: [1, 5]
+          - destination:
+              device: [1, 6]
+          - destination:
+              device: [1, 7]
+
+  # Combined diagonal test: Mesh 0 <-> Mesh 3 AND Mesh 1 <-> Mesh 2 (inside chips)
+  - name: InterMeshDiagonalInside0312
+    sync: true
+    enable_flow_control: true
+    fabric_setup:
+      topology: Mesh
+    parametrization_params:
+      size: [2048, 4096]
+    defaults:
+      ftype: unicast
+      ntype: unicast_write
+      num_packets: 50000
+    senders:
+      # Mesh 0 -> Mesh 3 (inside chips 4-7)
+      - device: [0, 4]
+        patterns:
+          - destination:
+              device: [3, 0]
+          - destination:
+              device: [3, 1]
+          - destination:
+              device: [3, 2]
+          - destination:
+              device: [3, 3]
+          - destination:
+              device: [3, 4]
+          - destination:
+              device: [3, 5]
+          - destination:
+              device: [3, 6]
+          - destination:
+              device: [3, 7]
+      - device: [0, 5]
+        patterns:
+          - destination:
+              device: [3, 0]
+          - destination:
+              device: [3, 1]
+          - destination:
+              device: [3, 2]
+          - destination:
+              device: [3, 3]
+          - destination:
+              device: [3, 4]
+          - destination:
+              device: [3, 5]
+          - destination:
+              device: [3, 6]
+          - destination:
+              device: [3, 7]
+      - device: [0, 6]
+        patterns:
+          - destination:
+              device: [3, 0]
+          - destination:
+              device: [3, 1]
+          - destination:
+              device: [3, 2]
+          - destination:
+              device: [3, 3]
+          - destination:
+              device: [3, 4]
+          - destination:
+              device: [3, 5]
+          - destination:
+              device: [3, 6]
+          - destination:
+              device: [3, 7]
+      - device: [0, 7]
+        patterns:
+          - destination:
+              device: [3, 0]
+          - destination:
+              device: [3, 1]
+          - destination:
+              device: [3, 2]
+          - destination:
+              device: [3, 3]
+          - destination:
+              device: [3, 4]
+          - destination:
+              device: [3, 5]
+          - destination:
+              device: [3, 6]
+          - destination:
+              device: [3, 7]
+      # Mesh 3 -> Mesh 0 (inside chips 4-7)
+      - device: [3, 4]
+        patterns:
+          - destination:
+              device: [0, 0]
+          - destination:
+              device: [0, 1]
+          - destination:
+              device: [0, 2]
+          - destination:
+              device: [0, 3]
+          - destination:
+              device: [0, 4]
+          - destination:
+              device: [0, 5]
+          - destination:
+              device: [0, 6]
+          - destination:
+              device: [0, 7]
+      - device: [3, 5]
+        patterns:
+          - destination:
+              device: [0, 0]
+          - destination:
+              device: [0, 1]
+          - destination:
+              device: [0, 2]
+          - destination:
+              device: [0, 3]
+          - destination:
+              device: [0, 4]
+          - destination:
+              device: [0, 5]
+          - destination:
+              device: [0, 6]
+          - destination:
+              device: [0, 7]
+      - device: [3, 6]
+        patterns:
+          - destination:
+              device: [0, 0]
+          - destination:
+              device: [0, 1]
+          - destination:
+              device: [0, 2]
+          - destination:
+              device: [0, 3]
+          - destination:
+              device: [0, 4]
+          - destination:
+              device: [0, 5]
+          - destination:
+              device: [0, 6]
+          - destination:
+              device: [0, 7]
+      - device: [3, 7]
+        patterns:
+          - destination:
+              device: [0, 0]
+          - destination:
+              device: [0, 1]
+          - destination:
+              device: [0, 2]
+          - destination:
+              device: [0, 3]
+          - destination:
+              device: [0, 4]
+          - destination:
+              device: [0, 5]
+          - destination:
+              device: [0, 6]
+          - destination:
+              device: [0, 7]
+      # Mesh 1 -> Mesh 2 (inside chips 4-7)
+      - device: [1, 4]
+        patterns:
+          - destination:
+              device: [2, 0]
+          - destination:
+              device: [2, 1]
+          - destination:
+              device: [2, 2]
+          - destination:
+              device: [2, 3]
+          - destination:
+              device: [2, 4]
+          - destination:
+              device: [2, 5]
+          - destination:
+              device: [2, 6]
+          - destination:
+              device: [2, 7]
+      - device: [1, 5]
+        patterns:
+          - destination:
+              device: [2, 0]
+          - destination:
+              device: [2, 1]
+          - destination:
+              device: [2, 2]
+          - destination:
+              device: [2, 3]
+          - destination:
+              device: [2, 4]
+          - destination:
+              device: [2, 5]
+          - destination:
+              device: [2, 6]
+          - destination:
+              device: [2, 7]
+      - device: [1, 6]
+        patterns:
+          - destination:
+              device: [2, 0]
+          - destination:
+              device: [2, 1]
+          - destination:
+              device: [2, 2]
+          - destination:
+              device: [2, 3]
+          - destination:
+              device: [2, 4]
+          - destination:
+              device: [2, 5]
+          - destination:
+              device: [2, 6]
+          - destination:
+              device: [2, 7]
+      - device: [1, 7]
+        patterns:
+          - destination:
+              device: [2, 0]
+          - destination:
+              device: [2, 1]
+          - destination:
+              device: [2, 2]
+          - destination:
+              device: [2, 3]
+          - destination:
+              device: [2, 4]
+          - destination:
+              device: [2, 5]
+          - destination:
+              device: [2, 6]
+          - destination:
+              device: [2, 7]
+      # Mesh 2 -> Mesh 1 (inside chips 4-7)
+      - device: [2, 4]
+        patterns:
+          - destination:
+              device: [1, 0]
+          - destination:
+              device: [1, 1]
+          - destination:
+              device: [1, 2]
+          - destination:
+              device: [1, 3]
+          - destination:
+              device: [1, 4]
+          - destination:
+              device: [1, 5]
+          - destination:
+              device: [1, 6]
+          - destination:
+              device: [1, 7]
+      - device: [2, 5]
+        patterns:
+          - destination:
+              device: [1, 0]
+          - destination:
+              device: [1, 1]
+          - destination:
+              device: [1, 2]
+          - destination:
+              device: [1, 3]
+          - destination:
+              device: [1, 4]
+          - destination:
+              device: [1, 5]
+          - destination:
+              device: [1, 6]
+          - destination:
+              device: [1, 7]
+      - device: [2, 6]
+        patterns:
+          - destination:
+              device: [1, 0]
+          - destination:
+              device: [1, 1]
+          - destination:
+              device: [1, 2]
+          - destination:
+              device: [1, 3]
+          - destination:
+              device: [1, 4]
+          - destination:
+              device: [1, 5]
+          - destination:
+              device: [1, 6]
+          - destination:
+              device: [1, 7]
+      - device: [2, 7]
+        patterns:
+          - destination:
+              device: [1, 0]
+          - destination:
+              device: [1, 1]
+          - destination:
+              device: [1, 2]
+          - destination:
+              device: [1, 3]
+          - destination:
+              device: [1, 4]
+          - destination:
+              device: [1, 5]
+          - destination:
+              device: [1, 6]
+          - destination:
+              device: [1, 7]
+
+  # Combined horizontal test: Mesh 0 <-> Mesh 1 AND Mesh 2 <-> Mesh 3 (inside chips)
+  - name: InterMeshHorizontalInside0123
+    sync: true
+    enable_flow_control: true
+    fabric_setup:
+      topology: Mesh
+    parametrization_params:
+      size: [2048, 4096]
+    defaults:
+      ftype: unicast
+      ntype: unicast_write
+      num_packets: 50000
+    senders:
+      # Mesh 0 -> Mesh 1 (inside chips 0-3)
+      - device: [0, 0]
+        patterns:
+          - destination:
+              device: [1, 0]
+          - destination:
+              device: [1, 1]
+          - destination:
+              device: [1, 2]
+          - destination:
+              device: [1, 3]
+          - destination:
+              device: [1, 4]
+          - destination:
+              device: [1, 5]
+          - destination:
+              device: [1, 6]
+          - destination:
+              device: [1, 7]
+      - device: [0, 1]
+        patterns:
+          - destination:
+              device: [1, 0]
+          - destination:
+              device: [1, 1]
+          - destination:
+              device: [1, 2]
+          - destination:
+              device: [1, 3]
+          - destination:
+              device: [1, 4]
+          - destination:
+              device: [1, 5]
+          - destination:
+              device: [1, 6]
+          - destination:
+              device: [1, 7]
+      - device: [0, 2]
+        patterns:
+          - destination:
+              device: [1, 0]
+          - destination:
+              device: [1, 1]
+          - destination:
+              device: [1, 2]
+          - destination:
+              device: [1, 3]
+          - destination:
+              device: [1, 4]
+          - destination:
+              device: [1, 5]
+          - destination:
+              device: [1, 6]
+          - destination:
+              device: [1, 7]
+      - device: [0, 3]
+        patterns:
+          - destination:
+              device: [1, 0]
+          - destination:
+              device: [1, 1]
+          - destination:
+              device: [1, 2]
+          - destination:
+              device: [1, 3]
+          - destination:
+              device: [1, 4]
+          - destination:
+              device: [1, 5]
+          - destination:
+              device: [1, 6]
+          - destination:
+              device: [1, 7]
+      # Mesh 1 -> Mesh 0 (inside chips 0-3)
+      - device: [1, 0]
+        patterns:
+          - destination:
+              device: [0, 0]
+          - destination:
+              device: [0, 1]
+          - destination:
+              device: [0, 2]
+          - destination:
+              device: [0, 3]
+          - destination:
+              device: [0, 4]
+          - destination:
+              device: [0, 5]
+          - destination:
+              device: [0, 6]
+          - destination:
+              device: [0, 7]
+      - device: [1, 1]
+        patterns:
+          - destination:
+              device: [0, 0]
+          - destination:
+              device: [0, 1]
+          - destination:
+              device: [0, 2]
+          - destination:
+              device: [0, 3]
+          - destination:
+              device: [0, 4]
+          - destination:
+              device: [0, 5]
+          - destination:
+              device: [0, 6]
+          - destination:
+              device: [0, 7]
+      - device: [1, 2]
+        patterns:
+          - destination:
+              device: [0, 0]
+          - destination:
+              device: [0, 1]
+          - destination:
+              device: [0, 2]
+          - destination:
+              device: [0, 3]
+          - destination:
+              device: [0, 4]
+          - destination:
+              device: [0, 5]
+          - destination:
+              device: [0, 6]
+          - destination:
+              device: [0, 7]
+      - device: [1, 3]
+        patterns:
+          - destination:
+              device: [0, 0]
+          - destination:
+              device: [0, 1]
+          - destination:
+              device: [0, 2]
+          - destination:
+              device: [0, 3]
+          - destination:
+              device: [0, 4]
+          - destination:
+              device: [0, 5]
+          - destination:
+              device: [0, 6]
+          - destination:
+              device: [0, 7]
+      # Mesh 2 -> Mesh 3 (inside chips 0-3)
+      - device: [2, 0]
+        patterns:
+          - destination:
+              device: [3, 0]
+          - destination:
+              device: [3, 1]
+          - destination:
+              device: [3, 2]
+          - destination:
+              device: [3, 3]
+          - destination:
+              device: [3, 4]
+          - destination:
+              device: [3, 5]
+          - destination:
+              device: [3, 6]
+          - destination:
+              device: [3, 7]
+      - device: [2, 1]
+        patterns:
+          - destination:
+              device: [3, 0]
+          - destination:
+              device: [3, 1]
+          - destination:
+              device: [3, 2]
+          - destination:
+              device: [3, 3]
+          - destination:
+              device: [3, 4]
+          - destination:
+              device: [3, 5]
+          - destination:
+              device: [3, 6]
+          - destination:
+              device: [3, 7]
+      - device: [2, 2]
+        patterns:
+          - destination:
+              device: [3, 0]
+          - destination:
+              device: [3, 1]
+          - destination:
+              device: [3, 2]
+          - destination:
+              device: [3, 3]
+          - destination:
+              device: [3, 4]
+          - destination:
+              device: [3, 5]
+          - destination:
+              device: [3, 6]
+          - destination:
+              device: [3, 7]
+      - device: [2, 3]
+        patterns:
+          - destination:
+              device: [3, 0]
+          - destination:
+              device: [3, 1]
+          - destination:
+              device: [3, 2]
+          - destination:
+              device: [3, 3]
+          - destination:
+              device: [3, 4]
+          - destination:
+              device: [3, 5]
+          - destination:
+              device: [3, 6]
+          - destination:
+              device: [3, 7]
+      # Mesh 3 -> Mesh 2 (inside chips 0-3)
+      - device: [3, 0]
+        patterns:
+          - destination:
+              device: [2, 0]
+          - destination:
+              device: [2, 1]
+          - destination:
+              device: [2, 2]
+          - destination:
+              device: [2, 3]
+          - destination:
+              device: [2, 4]
+          - destination:
+              device: [2, 5]
+          - destination:
+              device: [2, 6]
+          - destination:
+              device: [2, 7]
+      - device: [3, 1]
+        patterns:
+          - destination:
+              device: [2, 0]
+          - destination:
+              device: [2, 1]
+          - destination:
+              device: [2, 2]
+          - destination:
+              device: [2, 3]
+          - destination:
+              device: [2, 4]
+          - destination:
+              device: [2, 5]
+          - destination:
+              device: [2, 6]
+          - destination:
+              device: [2, 7]
+      - device: [3, 2]
+        patterns:
+          - destination:
+              device: [2, 0]
+          - destination:
+              device: [2, 1]
+          - destination:
+              device: [2, 2]
+          - destination:
+              device: [2, 3]
+          - destination:
+              device: [2, 4]
+          - destination:
+              device: [2, 5]
+          - destination:
+              device: [2, 6]
+          - destination:
+              device: [2, 7]
+      - device: [3, 3]
+        patterns:
+          - destination:
+              device: [2, 0]
+          - destination:
+              device: [2, 1]
+          - destination:
+              device: [2, 2]
+          - destination:
+              device: [2, 3]
+          - destination:
+              device: [2, 4]
+          - destination:
+              device: [2, 5]
+          - destination:
+              device: [2, 6]
+          - destination:
+              device: [2, 7]
+
+  - name: "FlowControlMultiMesh"
+    sync: true
+    enable_flow_control: true
+    fabric_setup:
+      topology: Mesh
+
+    parametrization_params:
+      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
+      size: [1024, 2048, 4096]
+
+    defaults:
+      ftype: unicast
+      num_packets: 10000
+
+    patterns:
+      - type: sequential_all_to_all

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_wh_6u_quad_2x4_acyclic.yaml
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_wh_6u_quad_2x4_acyclic.yaml
@@ -85,47 +85,6 @@ Tests:
             destination:
               device: [3, 1]
 
-  - name: "TestNocSendTypesMesh"
-    enable_flow_control: true
-    sync: true
-    fabric_setup:
-      topology: Mesh
-    parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc]
-    senders:
-      - device: [0, 0]
-        patterns:
-          - ftype: unicast
-            ntype: unicast_write
-            size: 2048
-            num_packets: 50000
-            destination:
-              device: [0, 1]
-      - device: [1, 0]
-        patterns:
-          - ftype: unicast
-            ntype: unicast_write
-            size: 2048
-            num_packets: 50000
-            destination:
-              device: [1, 1]
-      - device: [2, 0]
-        patterns:
-          - ftype: unicast
-            ntype: unicast_write
-            size: 2048
-            num_packets: 50000
-            destination:
-              device: [2, 1]
-      - device: [3, 0]
-        patterns:
-          - ftype: unicast
-            ntype: unicast_write
-            size: 2048
-            num_packets: 50000
-            destination:
-              device: [3, 1]
-
   - name: TestPacketSizesMesh
     enable_flow_control: true
     sync: true
@@ -191,8 +150,6 @@ Tests:
           - destination:
               device: [1, 0]
           - destination:
-              device: [2, 0]
-          - destination:
               device: [3, 0]
           - destination:
               device: [3, 1]
@@ -214,8 +171,6 @@ Tests:
           - destination:
               device: [1, 0]
           - destination:
-              device: [2, 0]
-          - destination:
               device: [3, 0]
       - device: [1, 0]
         patterns:
@@ -223,26 +178,20 @@ Tests:
               device: [0, 0]
           - destination:
               device: [2, 0]
-          - destination:
-              device: [3, 0]
       - device: [2, 0]
         patterns:
           - destination:
               device: [1, 0]
           - destination:
-              device: [0, 0]
-          - destination:
               device: [3, 0]
       - device: [3, 0]
         patterns:
-          - destination:
-              device: [1, 0]
           - destination:
               device: [2, 0]
           - destination:
               device: [0, 0]
 
-  - name: InterMeshStressTestInside02
+  - name: InterMeshStressTest01
     sync: true
     enable_flow_control: true
     fabric_setup:
@@ -257,76 +206,76 @@ Tests:
       - device: [0, 4]
         patterns:
           - destination:
-              device: [2, 0]
+              device: [1, 0]
           - destination:
-              device: [2, 1]
+              device: [1, 1]
           - destination:
-              device: [2, 2]
+              device: [1, 2]
           - destination:
-              device: [2, 3]
+              device: [1, 3]
           - destination:
-              device: [2, 4]
+              device: [1, 4]
           - destination:
-              device: [2, 5]
+              device: [1, 5]
           - destination:
-              device: [2, 6]
+              device: [1, 6]
           - destination:
-              device: [2, 7]
+              device: [1, 7]
       - device: [0, 5]
         patterns:
           - destination:
-              device: [2, 0]
+              device: [1, 0]
           - destination:
-              device: [2, 1]
+              device: [1, 1]
           - destination:
-              device: [2, 2]
+              device: [1, 2]
           - destination:
-              device: [2, 3]
+              device: [1, 3]
           - destination:
-              device: [2, 4]
+              device: [1, 4]
           - destination:
-              device: [2, 5]
+              device: [1, 5]
           - destination:
-              device: [2, 6]
+              device: [1, 6]
           - destination:
-              device: [2, 7]
+              device: [1, 7]
       - device: [0, 6]
         patterns:
           - destination:
-              device: [2, 0]
+              device: [1, 0]
           - destination:
-              device: [2, 1]
+              device: [1, 1]
           - destination:
-              device: [2, 2]
+              device: [1, 2]
           - destination:
-              device: [2, 3]
+              device: [1, 3]
           - destination:
-              device: [2, 4]
+              device: [1, 4]
           - destination:
-              device: [2, 5]
+              device: [1, 5]
           - destination:
-              device: [2, 6]
+              device: [1, 6]
           - destination:
-              device: [2, 7]
+              device: [1, 7]
       - device: [0, 7]
         patterns:
           - destination:
-              device: [2, 0]
+              device: [1, 0]
           - destination:
-              device: [2, 1]
+              device: [1, 1]
           - destination:
-              device: [2, 2]
+              device: [1, 2]
           - destination:
-              device: [2, 3]
+              device: [1, 3]
           - destination:
-              device: [2, 4]
+              device: [1, 4]
           - destination:
-              device: [2, 5]
+              device: [1, 5]
           - destination:
-              device: [2, 6]
+              device: [1, 6]
           - destination:
-              device: [2, 7]
-      - device: [2, 4]
+              device: [1, 7]
+      - device: [1, 4]
         patterns:
           - destination:
               device: [0, 0]
@@ -344,7 +293,7 @@ Tests:
               device: [0, 6]
           - destination:
               device: [0, 7]
-      - device: [2, 5]
+      - device: [1, 5]
         patterns:
           - destination:
               device: [0, 0]
@@ -362,7 +311,7 @@ Tests:
               device: [0, 6]
           - destination:
               device: [0, 7]
-      - device: [2, 6]
+      - device: [1, 6]
         patterns:
           - destination:
               device: [0, 0]
@@ -380,7 +329,7 @@ Tests:
               device: [0, 6]
           - destination:
               device: [0, 7]
-      - device: [2, 7]
+      - device: [1, 7]
         patterns:
           - destination:
               device: [0, 0]
@@ -399,7 +348,7 @@ Tests:
           - destination:
               device: [0, 7]
 
-  - name: InterMeshStressInsideTest13
+  - name: InterMeshStressTest23
     sync: true
     enable_flow_control: true
     fabric_setup:
@@ -411,7 +360,7 @@ Tests:
       ntype: unicast_write
       num_packets: 50000
     senders:
-      - device: [1, 4]
+      - device: [2, 4]
         patterns:
           - destination:
               device: [3, 0]
@@ -429,7 +378,7 @@ Tests:
               device: [3, 6]
           - destination:
               device: [3, 7]
-      - device: [1, 5]
+      - device: [2, 5]
         patterns:
           - destination:
               device: [3, 0]
@@ -447,7 +396,7 @@ Tests:
               device: [3, 6]
           - destination:
               device: [3, 7]
-      - device: [1, 6]
+      - device: [2, 6]
         patterns:
           - destination:
               device: [3, 0]
@@ -465,7 +414,7 @@ Tests:
               device: [3, 6]
           - destination:
               device: [3, 7]
-      - device: [1, 7]
+      - device: [2, 7]
         patterns:
           - destination:
               device: [3, 0]
@@ -486,78 +435,77 @@ Tests:
       - device: [3, 4]
         patterns:
           - destination:
-              device: [1, 0]
+              device: [2, 0]
           - destination:
-              device: [1, 1]
+              device: [2, 1]
           - destination:
-              device: [1, 2]
+              device: [2, 2]
           - destination:
-              device: [1, 3]
+              device: [2, 3]
           - destination:
-              device: [1, 4]
+              device: [2, 4]
           - destination:
-              device: [1, 5]
+              device: [2, 5]
           - destination:
-              device: [1, 6]
+              device: [2, 6]
           - destination:
-              device: [1, 7]
+              device: [2, 7]
       - device: [3, 5]
         patterns:
           - destination:
-              device: [1, 0]
+              device: [2, 0]
           - destination:
-              device: [1, 1]
+              device: [2, 1]
           - destination:
-              device: [1, 2]
+              device: [2, 2]
           - destination:
-              device: [1, 3]
+              device: [2, 3]
           - destination:
-              device: [1, 4]
+              device: [2, 4]
           - destination:
-              device: [1, 5]
+              device: [2, 5]
           - destination:
-              device: [1, 6]
+              device: [2, 6]
           - destination:
-              device: [1, 7]
+              device: [2, 7]
       - device: [3, 6]
         patterns:
           - destination:
-              device: [1, 0]
+              device: [2, 0]
           - destination:
-              device: [1, 1]
+              device: [2, 1]
           - destination:
-              device: [1, 2]
+              device: [2, 2]
           - destination:
-              device: [1, 3]
+              device: [2, 3]
           - destination:
-              device: [1, 4]
+              device: [2, 4]
           - destination:
-              device: [1, 5]
+              device: [2, 5]
           - destination:
-              device: [1, 6]
+              device: [2, 6]
           - destination:
-              device: [1, 7]
+              device: [2, 7]
       - device: [3, 7]
         patterns:
           - destination:
-              device: [1, 0]
+              device: [2, 0]
           - destination:
-              device: [1, 1]
+              device: [2, 1]
           - destination:
-              device: [1, 2]
+              device: [2, 2]
           - destination:
-              device: [1, 3]
+              device: [2, 3]
           - destination:
-              device: [1, 4]
+              device: [2, 4]
           - destination:
-              device: [1, 5]
+              device: [2, 5]
           - destination:
-              device: [1, 6]
+              device: [2, 6]
           - destination:
-              device: [1, 7]
+              device: [2, 7]
 
-  # Outside chips (0-3) stress test between Mesh 0 and Mesh 2
-  - name: InterMeshStressTestOutside02
+  - name: InterMeshStressTest03
     sync: true
     enable_flow_control: true
     fabric_setup:
@@ -572,216 +520,58 @@ Tests:
       - device: [0, 0]
         patterns:
           - destination:
-              device: [2, 0]
+              device: [3, 0]
           - destination:
-              device: [2, 1]
+              device: [3, 1]
           - destination:
-              device: [2, 2]
+              device: [3, 2]
           - destination:
-              device: [2, 3]
+              device: [3, 3]
           - destination:
-              device: [2, 4]
+              device: [3, 4]
           - destination:
-              device: [2, 5]
+              device: [3, 5]
           - destination:
-              device: [2, 6]
+              device: [3, 6]
           - destination:
-              device: [2, 7]
+              device: [3, 7]
       - device: [0, 1]
         patterns:
           - destination:
-              device: [2, 0]
+              device: [3, 0]
           - destination:
-              device: [2, 1]
+              device: [3, 1]
           - destination:
-              device: [2, 2]
+              device: [3, 2]
           - destination:
-              device: [2, 3]
+              device: [3, 3]
           - destination:
-              device: [2, 4]
+              device: [3, 4]
           - destination:
-              device: [2, 5]
+              device: [3, 5]
           - destination:
-              device: [2, 6]
+              device: [3, 6]
           - destination:
-              device: [2, 7]
+              device: [3, 7]
       - device: [0, 2]
         patterns:
           - destination:
-              device: [2, 0]
+              device: [3, 0]
           - destination:
-              device: [2, 1]
+              device: [3, 1]
           - destination:
-              device: [2, 2]
+              device: [3, 2]
           - destination:
-              device: [2, 3]
+              device: [3, 3]
           - destination:
-              device: [2, 4]
+              device: [3, 4]
           - destination:
-              device: [2, 5]
+              device: [3, 5]
           - destination:
-              device: [2, 6]
+              device: [3, 6]
           - destination:
-              device: [2, 7]
+              device: [3, 7]
       - device: [0, 3]
-        patterns:
-          - destination:
-              device: [2, 0]
-          - destination:
-              device: [2, 1]
-          - destination:
-              device: [2, 2]
-          - destination:
-              device: [2, 3]
-          - destination:
-              device: [2, 4]
-          - destination:
-              device: [2, 5]
-          - destination:
-              device: [2, 6]
-          - destination:
-              device: [2, 7]
-      - device: [2, 0]
-        patterns:
-          - destination:
-              device: [0, 0]
-          - destination:
-              device: [0, 1]
-          - destination:
-              device: [0, 2]
-          - destination:
-              device: [0, 3]
-          - destination:
-              device: [0, 4]
-          - destination:
-              device: [0, 5]
-          - destination:
-              device: [0, 6]
-          - destination:
-              device: [0, 7]
-      - device: [2, 1]
-        patterns:
-          - destination:
-              device: [0, 0]
-          - destination:
-              device: [0, 1]
-          - destination:
-              device: [0, 2]
-          - destination:
-              device: [0, 3]
-          - destination:
-              device: [0, 4]
-          - destination:
-              device: [0, 5]
-          - destination:
-              device: [0, 6]
-          - destination:
-              device: [0, 7]
-      - device: [2, 2]
-        patterns:
-          - destination:
-              device: [0, 0]
-          - destination:
-              device: [0, 1]
-          - destination:
-              device: [0, 2]
-          - destination:
-              device: [0, 3]
-          - destination:
-              device: [0, 4]
-          - destination:
-              device: [0, 5]
-          - destination:
-              device: [0, 6]
-          - destination:
-              device: [0, 7]
-      - device: [2, 3]
-        patterns:
-          - destination:
-              device: [0, 0]
-          - destination:
-              device: [0, 1]
-          - destination:
-              device: [0, 2]
-          - destination:
-              device: [0, 3]
-          - destination:
-              device: [0, 4]
-          - destination:
-              device: [0, 5]
-          - destination:
-              device: [0, 6]
-          - destination:
-              device: [0, 7]
-
-  # Outside chips (0-3) stress test between Mesh 1 and Mesh 3
-  - name: InterMeshStressTestOutside13
-    sync: true
-    enable_flow_control: true
-    fabric_setup:
-      topology: Mesh
-    parametrization_params:
-      size: [2048, 4096]
-    defaults:
-      ftype: unicast
-      ntype: unicast_write
-      num_packets: 50000
-    senders:
-      - device: [1, 0]
-        patterns:
-          - destination:
-              device: [3, 0]
-          - destination:
-              device: [3, 1]
-          - destination:
-              device: [3, 2]
-          - destination:
-              device: [3, 3]
-          - destination:
-              device: [3, 4]
-          - destination:
-              device: [3, 5]
-          - destination:
-              device: [3, 6]
-          - destination:
-              device: [3, 7]
-      - device: [1, 1]
-        patterns:
-          - destination:
-              device: [3, 0]
-          - destination:
-              device: [3, 1]
-          - destination:
-              device: [3, 2]
-          - destination:
-              device: [3, 3]
-          - destination:
-              device: [3, 4]
-          - destination:
-              device: [3, 5]
-          - destination:
-              device: [3, 6]
-          - destination:
-              device: [3, 7]
-      - device: [1, 2]
-        patterns:
-          - destination:
-              device: [3, 0]
-          - destination:
-              device: [3, 1]
-          - destination:
-              device: [3, 2]
-          - destination:
-              device: [3, 3]
-          - destination:
-              device: [3, 4]
-          - destination:
-              device: [3, 5]
-          - destination:
-              device: [3, 6]
-          - destination:
-              device: [3, 7]
-      - device: [1, 3]
         patterns:
           - destination:
               device: [3, 0]
@@ -802,78 +592,77 @@ Tests:
       - device: [3, 0]
         patterns:
           - destination:
-              device: [1, 0]
+              device: [0, 0]
           - destination:
-              device: [1, 1]
+              device: [0, 1]
           - destination:
-              device: [1, 2]
+              device: [0, 2]
           - destination:
-              device: [1, 3]
+              device: [0, 3]
           - destination:
-              device: [1, 4]
+              device: [0, 4]
           - destination:
-              device: [1, 5]
+              device: [0, 5]
           - destination:
-              device: [1, 6]
+              device: [0, 6]
           - destination:
-              device: [1, 7]
+              device: [0, 7]
       - device: [3, 1]
         patterns:
           - destination:
-              device: [1, 0]
+              device: [0, 0]
           - destination:
-              device: [1, 1]
+              device: [0, 1]
           - destination:
-              device: [1, 2]
+              device: [0, 2]
           - destination:
-              device: [1, 3]
+              device: [0, 3]
           - destination:
-              device: [1, 4]
+              device: [0, 4]
           - destination:
-              device: [1, 5]
+              device: [0, 5]
           - destination:
-              device: [1, 6]
+              device: [0, 6]
           - destination:
-              device: [1, 7]
+              device: [0, 7]
       - device: [3, 2]
         patterns:
           - destination:
-              device: [1, 0]
+              device: [0, 0]
           - destination:
-              device: [1, 1]
+              device: [0, 1]
           - destination:
-              device: [1, 2]
+              device: [0, 2]
           - destination:
-              device: [1, 3]
+              device: [0, 3]
           - destination:
-              device: [1, 4]
+              device: [0, 4]
           - destination:
-              device: [1, 5]
+              device: [0, 5]
           - destination:
-              device: [1, 6]
+              device: [0, 6]
           - destination:
-              device: [1, 7]
+              device: [0, 7]
       - device: [3, 3]
         patterns:
           - destination:
-              device: [1, 0]
+              device: [0, 0]
           - destination:
-              device: [1, 1]
+              device: [0, 1]
           - destination:
-              device: [1, 2]
+              device: [0, 2]
           - destination:
-              device: [1, 3]
+              device: [0, 3]
           - destination:
-              device: [1, 4]
+              device: [0, 4]
           - destination:
-              device: [1, 5]
+              device: [0, 5]
           - destination:
-              device: [1, 6]
+              device: [0, 6]
           - destination:
-              device: [1, 7]
+              device: [0, 7]
 
-  # Full all-to-all between Mesh 0 and Mesh 2 (all devices)
-  - name: InterMeshFullAllToAll02
+  - name: InterMeshStressTest12
     sync: true
     enable_flow_control: true
     fabric_setup:
@@ -885,7 +674,7 @@ Tests:
       ntype: unicast_write
       num_packets: 50000
     senders:
-      - device: [0, 0]
+      - device: [1, 0]
         patterns:
           - destination:
               device: [2, 0]
@@ -903,7 +692,7 @@ Tests:
               device: [2, 6]
           - destination:
               device: [2, 7]
-      - device: [0, 1]
+      - device: [1, 1]
         patterns:
           - destination:
               device: [2, 0]
@@ -921,7 +710,7 @@ Tests:
               device: [2, 6]
           - destination:
               device: [2, 7]
-      - device: [0, 2]
+      - device: [1, 2]
         patterns:
           - destination:
               device: [2, 0]
@@ -939,79 +728,7 @@ Tests:
               device: [2, 6]
           - destination:
               device: [2, 7]
-      - device: [0, 3]
-        patterns:
-          - destination:
-              device: [2, 0]
-          - destination:
-              device: [2, 1]
-          - destination:
-              device: [2, 2]
-          - destination:
-              device: [2, 3]
-          - destination:
-              device: [2, 4]
-          - destination:
-              device: [2, 5]
-          - destination:
-              device: [2, 6]
-          - destination:
-              device: [2, 7]
-      - device: [0, 4]
-        patterns:
-          - destination:
-              device: [2, 0]
-          - destination:
-              device: [2, 1]
-          - destination:
-              device: [2, 2]
-          - destination:
-              device: [2, 3]
-          - destination:
-              device: [2, 4]
-          - destination:
-              device: [2, 5]
-          - destination:
-              device: [2, 6]
-          - destination:
-              device: [2, 7]
-      - device: [0, 5]
-        patterns:
-          - destination:
-              device: [2, 0]
-          - destination:
-              device: [2, 1]
-          - destination:
-              device: [2, 2]
-          - destination:
-              device: [2, 3]
-          - destination:
-              device: [2, 4]
-          - destination:
-              device: [2, 5]
-          - destination:
-              device: [2, 6]
-          - destination:
-              device: [2, 7]
-      - device: [0, 6]
-        patterns:
-          - destination:
-              device: [2, 0]
-          - destination:
-              device: [2, 1]
-          - destination:
-              device: [2, 2]
-          - destination:
-              device: [2, 3]
-          - destination:
-              device: [2, 4]
-          - destination:
-              device: [2, 5]
-          - destination:
-              device: [2, 6]
-          - destination:
-              device: [2, 7]
-      - device: [0, 7]
+      - device: [1, 3]
         patterns:
           - destination:
               device: [2, 0]
@@ -1032,76 +749,234 @@ Tests:
       - device: [2, 0]
         patterns:
           - destination:
-              device: [0, 0]
+              device: [1, 0]
           - destination:
-              device: [0, 1]
+              device: [1, 1]
           - destination:
-              device: [0, 2]
+              device: [1, 2]
           - destination:
-              device: [0, 3]
+              device: [1, 3]
           - destination:
-              device: [0, 4]
+              device: [1, 4]
           - destination:
-              device: [0, 5]
+              device: [1, 5]
           - destination:
-              device: [0, 6]
+              device: [1, 6]
           - destination:
-              device: [0, 7]
+              device: [1, 7]
       - device: [2, 1]
         patterns:
           - destination:
-              device: [0, 0]
+              device: [1, 0]
           - destination:
-              device: [0, 1]
+              device: [1, 1]
           - destination:
-              device: [0, 2]
+              device: [1, 2]
           - destination:
-              device: [0, 3]
+              device: [1, 3]
           - destination:
-              device: [0, 4]
+              device: [1, 4]
           - destination:
-              device: [0, 5]
+              device: [1, 5]
           - destination:
-              device: [0, 6]
+              device: [1, 6]
           - destination:
-              device: [0, 7]
+              device: [1, 7]
       - device: [2, 2]
         patterns:
           - destination:
-              device: [0, 0]
+              device: [1, 0]
           - destination:
-              device: [0, 1]
+              device: [1, 1]
           - destination:
-              device: [0, 2]
+              device: [1, 2]
           - destination:
-              device: [0, 3]
+              device: [1, 3]
           - destination:
-              device: [0, 4]
+              device: [1, 4]
           - destination:
-              device: [0, 5]
+              device: [1, 5]
           - destination:
-              device: [0, 6]
+              device: [1, 6]
           - destination:
-              device: [0, 7]
+              device: [1, 7]
       - device: [2, 3]
         patterns:
           - destination:
-              device: [0, 0]
+              device: [1, 0]
           - destination:
-              device: [0, 1]
+              device: [1, 1]
           - destination:
-              device: [0, 2]
+              device: [1, 2]
           - destination:
-              device: [0, 3]
+              device: [1, 3]
           - destination:
-              device: [0, 4]
+              device: [1, 4]
           - destination:
-              device: [0, 5]
+              device: [1, 5]
           - destination:
-              device: [0, 6]
+              device: [1, 6]
           - destination:
-              device: [0, 7]
-      - device: [2, 4]
+              device: [1, 7]
+
+  # Full all-to-all between Mesh 0 and Mesh 1 (all devices)
+  - name: InterMeshFullAllToAll01
+    sync: true
+    enable_flow_control: true
+    fabric_setup:
+      topology: Mesh
+    parametrization_params:
+      size: [2048, 4096]
+    defaults:
+      ftype: unicast
+      ntype: unicast_write
+      num_packets: 50000
+    senders:
+      - device: [0, 0]
+        patterns:
+          - destination:
+              device: [1, 0]
+          - destination:
+              device: [1, 1]
+          - destination:
+              device: [1, 2]
+          - destination:
+              device: [1, 3]
+          - destination:
+              device: [1, 4]
+          - destination:
+              device: [1, 5]
+          - destination:
+              device: [1, 6]
+          - destination:
+              device: [1, 7]
+      - device: [0, 1]
+        patterns:
+          - destination:
+              device: [1, 0]
+          - destination:
+              device: [1, 1]
+          - destination:
+              device: [1, 2]
+          - destination:
+              device: [1, 3]
+          - destination:
+              device: [1, 4]
+          - destination:
+              device: [1, 5]
+          - destination:
+              device: [1, 6]
+          - destination:
+              device: [1, 7]
+      - device: [0, 2]
+        patterns:
+          - destination:
+              device: [1, 0]
+          - destination:
+              device: [1, 1]
+          - destination:
+              device: [1, 2]
+          - destination:
+              device: [1, 3]
+          - destination:
+              device: [1, 4]
+          - destination:
+              device: [1, 5]
+          - destination:
+              device: [1, 6]
+          - destination:
+              device: [1, 7]
+      - device: [0, 3]
+        patterns:
+          - destination:
+              device: [1, 0]
+          - destination:
+              device: [1, 1]
+          - destination:
+              device: [1, 2]
+          - destination:
+              device: [1, 3]
+          - destination:
+              device: [1, 4]
+          - destination:
+              device: [1, 5]
+          - destination:
+              device: [1, 6]
+          - destination:
+              device: [1, 7]
+      - device: [0, 4]
+        patterns:
+          - destination:
+              device: [1, 0]
+          - destination:
+              device: [1, 1]
+          - destination:
+              device: [1, 2]
+          - destination:
+              device: [1, 3]
+          - destination:
+              device: [1, 4]
+          - destination:
+              device: [1, 5]
+          - destination:
+              device: [1, 6]
+          - destination:
+              device: [1, 7]
+      - device: [0, 5]
+        patterns:
+          - destination:
+              device: [1, 0]
+          - destination:
+              device: [1, 1]
+          - destination:
+              device: [1, 2]
+          - destination:
+              device: [1, 3]
+          - destination:
+              device: [1, 4]
+          - destination:
+              device: [1, 5]
+          - destination:
+              device: [1, 6]
+          - destination:
+              device: [1, 7]
+      - device: [0, 6]
+        patterns:
+          - destination:
+              device: [1, 0]
+          - destination:
+              device: [1, 1]
+          - destination:
+              device: [1, 2]
+          - destination:
+              device: [1, 3]
+          - destination:
+              device: [1, 4]
+          - destination:
+              device: [1, 5]
+          - destination:
+              device: [1, 6]
+          - destination:
+              device: [1, 7]
+      - device: [0, 7]
+        patterns:
+          - destination:
+              device: [1, 0]
+          - destination:
+              device: [1, 1]
+          - destination:
+              device: [1, 2]
+          - destination:
+              device: [1, 3]
+          - destination:
+              device: [1, 4]
+          - destination:
+              device: [1, 5]
+          - destination:
+              device: [1, 6]
+          - destination:
+              device: [1, 7]
+      - device: [1, 0]
         patterns:
           - destination:
               device: [0, 0]
@@ -1119,7 +994,7 @@ Tests:
               device: [0, 6]
           - destination:
               device: [0, 7]
-      - device: [2, 5]
+      - device: [1, 1]
         patterns:
           - destination:
               device: [0, 0]
@@ -1137,7 +1012,7 @@ Tests:
               device: [0, 6]
           - destination:
               device: [0, 7]
-      - device: [2, 6]
+      - device: [1, 2]
         patterns:
           - destination:
               device: [0, 0]
@@ -1155,7 +1030,79 @@ Tests:
               device: [0, 6]
           - destination:
               device: [0, 7]
-      - device: [2, 7]
+      - device: [1, 3]
+        patterns:
+          - destination:
+              device: [0, 0]
+          - destination:
+              device: [0, 1]
+          - destination:
+              device: [0, 2]
+          - destination:
+              device: [0, 3]
+          - destination:
+              device: [0, 4]
+          - destination:
+              device: [0, 5]
+          - destination:
+              device: [0, 6]
+          - destination:
+              device: [0, 7]
+      - device: [1, 4]
+        patterns:
+          - destination:
+              device: [0, 0]
+          - destination:
+              device: [0, 1]
+          - destination:
+              device: [0, 2]
+          - destination:
+              device: [0, 3]
+          - destination:
+              device: [0, 4]
+          - destination:
+              device: [0, 5]
+          - destination:
+              device: [0, 6]
+          - destination:
+              device: [0, 7]
+      - device: [1, 5]
+        patterns:
+          - destination:
+              device: [0, 0]
+          - destination:
+              device: [0, 1]
+          - destination:
+              device: [0, 2]
+          - destination:
+              device: [0, 3]
+          - destination:
+              device: [0, 4]
+          - destination:
+              device: [0, 5]
+          - destination:
+              device: [0, 6]
+          - destination:
+              device: [0, 7]
+      - device: [1, 6]
+        patterns:
+          - destination:
+              device: [0, 0]
+          - destination:
+              device: [0, 1]
+          - destination:
+              device: [0, 2]
+          - destination:
+              device: [0, 3]
+          - destination:
+              device: [0, 4]
+          - destination:
+              device: [0, 5]
+          - destination:
+              device: [0, 6]
+          - destination:
+              device: [0, 7]
+      - device: [1, 7]
         patterns:
           - destination:
               device: [0, 0]
@@ -1175,7 +1122,7 @@ Tests:
               device: [0, 7]
 
   # Full all-to-all between Mesh 1 and Mesh 3 (all devices)
-  - name: InterMeshFullAllToAll13
+  - name: InterMeshFullAllToAll23
     sync: true
     enable_flow_control: true
     fabric_setup:
@@ -1187,761 +1134,6 @@ Tests:
       ntype: unicast_write
       num_packets: 50000
     senders:
-      - device: [1, 0]
-        patterns:
-          - destination:
-              device: [3, 0]
-          - destination:
-              device: [3, 1]
-          - destination:
-              device: [3, 2]
-          - destination:
-              device: [3, 3]
-          - destination:
-              device: [3, 4]
-          - destination:
-              device: [3, 5]
-          - destination:
-              device: [3, 6]
-          - destination:
-              device: [3, 7]
-      - device: [1, 1]
-        patterns:
-          - destination:
-              device: [3, 0]
-          - destination:
-              device: [3, 1]
-          - destination:
-              device: [3, 2]
-          - destination:
-              device: [3, 3]
-          - destination:
-              device: [3, 4]
-          - destination:
-              device: [3, 5]
-          - destination:
-              device: [3, 6]
-          - destination:
-              device: [3, 7]
-      - device: [1, 2]
-        patterns:
-          - destination:
-              device: [3, 0]
-          - destination:
-              device: [3, 1]
-          - destination:
-              device: [3, 2]
-          - destination:
-              device: [3, 3]
-          - destination:
-              device: [3, 4]
-          - destination:
-              device: [3, 5]
-          - destination:
-              device: [3, 6]
-          - destination:
-              device: [3, 7]
-      - device: [1, 3]
-        patterns:
-          - destination:
-              device: [3, 0]
-          - destination:
-              device: [3, 1]
-          - destination:
-              device: [3, 2]
-          - destination:
-              device: [3, 3]
-          - destination:
-              device: [3, 4]
-          - destination:
-              device: [3, 5]
-          - destination:
-              device: [3, 6]
-          - destination:
-              device: [3, 7]
-      - device: [1, 4]
-        patterns:
-          - destination:
-              device: [3, 0]
-          - destination:
-              device: [3, 1]
-          - destination:
-              device: [3, 2]
-          - destination:
-              device: [3, 3]
-          - destination:
-              device: [3, 4]
-          - destination:
-              device: [3, 5]
-          - destination:
-              device: [3, 6]
-          - destination:
-              device: [3, 7]
-      - device: [1, 5]
-        patterns:
-          - destination:
-              device: [3, 0]
-          - destination:
-              device: [3, 1]
-          - destination:
-              device: [3, 2]
-          - destination:
-              device: [3, 3]
-          - destination:
-              device: [3, 4]
-          - destination:
-              device: [3, 5]
-          - destination:
-              device: [3, 6]
-          - destination:
-              device: [3, 7]
-      - device: [1, 6]
-        patterns:
-          - destination:
-              device: [3, 0]
-          - destination:
-              device: [3, 1]
-          - destination:
-              device: [3, 2]
-          - destination:
-              device: [3, 3]
-          - destination:
-              device: [3, 4]
-          - destination:
-              device: [3, 5]
-          - destination:
-              device: [3, 6]
-          - destination:
-              device: [3, 7]
-      - device: [1, 7]
-        patterns:
-          - destination:
-              device: [3, 0]
-          - destination:
-              device: [3, 1]
-          - destination:
-              device: [3, 2]
-          - destination:
-              device: [3, 3]
-          - destination:
-              device: [3, 4]
-          - destination:
-              device: [3, 5]
-          - destination:
-              device: [3, 6]
-          - destination:
-              device: [3, 7]
-      - device: [3, 0]
-        patterns:
-          - destination:
-              device: [1, 0]
-          - destination:
-              device: [1, 1]
-          - destination:
-              device: [1, 2]
-          - destination:
-              device: [1, 3]
-          - destination:
-              device: [1, 4]
-          - destination:
-              device: [1, 5]
-          - destination:
-              device: [1, 6]
-          - destination:
-              device: [1, 7]
-      - device: [3, 1]
-        patterns:
-          - destination:
-              device: [1, 0]
-          - destination:
-              device: [1, 1]
-          - destination:
-              device: [1, 2]
-          - destination:
-              device: [1, 3]
-          - destination:
-              device: [1, 4]
-          - destination:
-              device: [1, 5]
-          - destination:
-              device: [1, 6]
-          - destination:
-              device: [1, 7]
-      - device: [3, 2]
-        patterns:
-          - destination:
-              device: [1, 0]
-          - destination:
-              device: [1, 1]
-          - destination:
-              device: [1, 2]
-          - destination:
-              device: [1, 3]
-          - destination:
-              device: [1, 4]
-          - destination:
-              device: [1, 5]
-          - destination:
-              device: [1, 6]
-          - destination:
-              device: [1, 7]
-      - device: [3, 3]
-        patterns:
-          - destination:
-              device: [1, 0]
-          - destination:
-              device: [1, 1]
-          - destination:
-              device: [1, 2]
-          - destination:
-              device: [1, 3]
-          - destination:
-              device: [1, 4]
-          - destination:
-              device: [1, 5]
-          - destination:
-              device: [1, 6]
-          - destination:
-              device: [1, 7]
-      - device: [3, 4]
-        patterns:
-          - destination:
-              device: [1, 0]
-          - destination:
-              device: [1, 1]
-          - destination:
-              device: [1, 2]
-          - destination:
-              device: [1, 3]
-          - destination:
-              device: [1, 4]
-          - destination:
-              device: [1, 5]
-          - destination:
-              device: [1, 6]
-          - destination:
-              device: [1, 7]
-      - device: [3, 5]
-        patterns:
-          - destination:
-              device: [1, 0]
-          - destination:
-              device: [1, 1]
-          - destination:
-              device: [1, 2]
-          - destination:
-              device: [1, 3]
-          - destination:
-              device: [1, 4]
-          - destination:
-              device: [1, 5]
-          - destination:
-              device: [1, 6]
-          - destination:
-              device: [1, 7]
-      - device: [3, 6]
-        patterns:
-          - destination:
-              device: [1, 0]
-          - destination:
-              device: [1, 1]
-          - destination:
-              device: [1, 2]
-          - destination:
-              device: [1, 3]
-          - destination:
-              device: [1, 4]
-          - destination:
-              device: [1, 5]
-          - destination:
-              device: [1, 6]
-          - destination:
-              device: [1, 7]
-      - device: [3, 7]
-        patterns:
-          - destination:
-              device: [1, 0]
-          - destination:
-              device: [1, 1]
-          - destination:
-              device: [1, 2]
-          - destination:
-              device: [1, 3]
-          - destination:
-              device: [1, 4]
-          - destination:
-              device: [1, 5]
-          - destination:
-              device: [1, 6]
-          - destination:
-              device: [1, 7]
-
-  # Combined diagonal test: Mesh 0 <-> Mesh 3 AND Mesh 1 <-> Mesh 2 (inside chips)
-  - name: InterMeshDiagonalInside0312
-    sync: true
-    enable_flow_control: true
-    fabric_setup:
-      topology: Mesh
-    parametrization_params:
-      size: [2048, 4096]
-    defaults:
-      ftype: unicast
-      ntype: unicast_write
-      num_packets: 50000
-    senders:
-      # Mesh 0 -> Mesh 3 (inside chips 4-7)
-      - device: [0, 4]
-        patterns:
-          - destination:
-              device: [3, 0]
-          - destination:
-              device: [3, 1]
-          - destination:
-              device: [3, 2]
-          - destination:
-              device: [3, 3]
-          - destination:
-              device: [3, 4]
-          - destination:
-              device: [3, 5]
-          - destination:
-              device: [3, 6]
-          - destination:
-              device: [3, 7]
-      - device: [0, 5]
-        patterns:
-          - destination:
-              device: [3, 0]
-          - destination:
-              device: [3, 1]
-          - destination:
-              device: [3, 2]
-          - destination:
-              device: [3, 3]
-          - destination:
-              device: [3, 4]
-          - destination:
-              device: [3, 5]
-          - destination:
-              device: [3, 6]
-          - destination:
-              device: [3, 7]
-      - device: [0, 6]
-        patterns:
-          - destination:
-              device: [3, 0]
-          - destination:
-              device: [3, 1]
-          - destination:
-              device: [3, 2]
-          - destination:
-              device: [3, 3]
-          - destination:
-              device: [3, 4]
-          - destination:
-              device: [3, 5]
-          - destination:
-              device: [3, 6]
-          - destination:
-              device: [3, 7]
-      - device: [0, 7]
-        patterns:
-          - destination:
-              device: [3, 0]
-          - destination:
-              device: [3, 1]
-          - destination:
-              device: [3, 2]
-          - destination:
-              device: [3, 3]
-          - destination:
-              device: [3, 4]
-          - destination:
-              device: [3, 5]
-          - destination:
-              device: [3, 6]
-          - destination:
-              device: [3, 7]
-      # Mesh 3 -> Mesh 0 (inside chips 4-7)
-      - device: [3, 4]
-        patterns:
-          - destination:
-              device: [0, 0]
-          - destination:
-              device: [0, 1]
-          - destination:
-              device: [0, 2]
-          - destination:
-              device: [0, 3]
-          - destination:
-              device: [0, 4]
-          - destination:
-              device: [0, 5]
-          - destination:
-              device: [0, 6]
-          - destination:
-              device: [0, 7]
-      - device: [3, 5]
-        patterns:
-          - destination:
-              device: [0, 0]
-          - destination:
-              device: [0, 1]
-          - destination:
-              device: [0, 2]
-          - destination:
-              device: [0, 3]
-          - destination:
-              device: [0, 4]
-          - destination:
-              device: [0, 5]
-          - destination:
-              device: [0, 6]
-          - destination:
-              device: [0, 7]
-      - device: [3, 6]
-        patterns:
-          - destination:
-              device: [0, 0]
-          - destination:
-              device: [0, 1]
-          - destination:
-              device: [0, 2]
-          - destination:
-              device: [0, 3]
-          - destination:
-              device: [0, 4]
-          - destination:
-              device: [0, 5]
-          - destination:
-              device: [0, 6]
-          - destination:
-              device: [0, 7]
-      - device: [3, 7]
-        patterns:
-          - destination:
-              device: [0, 0]
-          - destination:
-              device: [0, 1]
-          - destination:
-              device: [0, 2]
-          - destination:
-              device: [0, 3]
-          - destination:
-              device: [0, 4]
-          - destination:
-              device: [0, 5]
-          - destination:
-              device: [0, 6]
-          - destination:
-              device: [0, 7]
-      # Mesh 1 -> Mesh 2 (inside chips 4-7)
-      - device: [1, 4]
-        patterns:
-          - destination:
-              device: [2, 0]
-          - destination:
-              device: [2, 1]
-          - destination:
-              device: [2, 2]
-          - destination:
-              device: [2, 3]
-          - destination:
-              device: [2, 4]
-          - destination:
-              device: [2, 5]
-          - destination:
-              device: [2, 6]
-          - destination:
-              device: [2, 7]
-      - device: [1, 5]
-        patterns:
-          - destination:
-              device: [2, 0]
-          - destination:
-              device: [2, 1]
-          - destination:
-              device: [2, 2]
-          - destination:
-              device: [2, 3]
-          - destination:
-              device: [2, 4]
-          - destination:
-              device: [2, 5]
-          - destination:
-              device: [2, 6]
-          - destination:
-              device: [2, 7]
-      - device: [1, 6]
-        patterns:
-          - destination:
-              device: [2, 0]
-          - destination:
-              device: [2, 1]
-          - destination:
-              device: [2, 2]
-          - destination:
-              device: [2, 3]
-          - destination:
-              device: [2, 4]
-          - destination:
-              device: [2, 5]
-          - destination:
-              device: [2, 6]
-          - destination:
-              device: [2, 7]
-      - device: [1, 7]
-        patterns:
-          - destination:
-              device: [2, 0]
-          - destination:
-              device: [2, 1]
-          - destination:
-              device: [2, 2]
-          - destination:
-              device: [2, 3]
-          - destination:
-              device: [2, 4]
-          - destination:
-              device: [2, 5]
-          - destination:
-              device: [2, 6]
-          - destination:
-              device: [2, 7]
-      # Mesh 2 -> Mesh 1 (inside chips 4-7)
-      - device: [2, 4]
-        patterns:
-          - destination:
-              device: [1, 0]
-          - destination:
-              device: [1, 1]
-          - destination:
-              device: [1, 2]
-          - destination:
-              device: [1, 3]
-          - destination:
-              device: [1, 4]
-          - destination:
-              device: [1, 5]
-          - destination:
-              device: [1, 6]
-          - destination:
-              device: [1, 7]
-      - device: [2, 5]
-        patterns:
-          - destination:
-              device: [1, 0]
-          - destination:
-              device: [1, 1]
-          - destination:
-              device: [1, 2]
-          - destination:
-              device: [1, 3]
-          - destination:
-              device: [1, 4]
-          - destination:
-              device: [1, 5]
-          - destination:
-              device: [1, 6]
-          - destination:
-              device: [1, 7]
-      - device: [2, 6]
-        patterns:
-          - destination:
-              device: [1, 0]
-          - destination:
-              device: [1, 1]
-          - destination:
-              device: [1, 2]
-          - destination:
-              device: [1, 3]
-          - destination:
-              device: [1, 4]
-          - destination:
-              device: [1, 5]
-          - destination:
-              device: [1, 6]
-          - destination:
-              device: [1, 7]
-      - device: [2, 7]
-        patterns:
-          - destination:
-              device: [1, 0]
-          - destination:
-              device: [1, 1]
-          - destination:
-              device: [1, 2]
-          - destination:
-              device: [1, 3]
-          - destination:
-              device: [1, 4]
-          - destination:
-              device: [1, 5]
-          - destination:
-              device: [1, 6]
-          - destination:
-              device: [1, 7]
-
-  # Combined horizontal test: Mesh 0 <-> Mesh 1 AND Mesh 2 <-> Mesh 3 (inside chips)
-  - name: InterMeshHorizontalInside0123
-    sync: true
-    enable_flow_control: true
-    fabric_setup:
-      topology: Mesh
-    parametrization_params:
-      size: [2048, 4096]
-    defaults:
-      ftype: unicast
-      ntype: unicast_write
-      num_packets: 50000
-    senders:
-      # Mesh 0 -> Mesh 1 (inside chips 0-3)
-      - device: [0, 0]
-        patterns:
-          - destination:
-              device: [1, 0]
-          - destination:
-              device: [1, 1]
-          - destination:
-              device: [1, 2]
-          - destination:
-              device: [1, 3]
-          - destination:
-              device: [1, 4]
-          - destination:
-              device: [1, 5]
-          - destination:
-              device: [1, 6]
-          - destination:
-              device: [1, 7]
-      - device: [0, 1]
-        patterns:
-          - destination:
-              device: [1, 0]
-          - destination:
-              device: [1, 1]
-          - destination:
-              device: [1, 2]
-          - destination:
-              device: [1, 3]
-          - destination:
-              device: [1, 4]
-          - destination:
-              device: [1, 5]
-          - destination:
-              device: [1, 6]
-          - destination:
-              device: [1, 7]
-      - device: [0, 2]
-        patterns:
-          - destination:
-              device: [1, 0]
-          - destination:
-              device: [1, 1]
-          - destination:
-              device: [1, 2]
-          - destination:
-              device: [1, 3]
-          - destination:
-              device: [1, 4]
-          - destination:
-              device: [1, 5]
-          - destination:
-              device: [1, 6]
-          - destination:
-              device: [1, 7]
-      - device: [0, 3]
-        patterns:
-          - destination:
-              device: [1, 0]
-          - destination:
-              device: [1, 1]
-          - destination:
-              device: [1, 2]
-          - destination:
-              device: [1, 3]
-          - destination:
-              device: [1, 4]
-          - destination:
-              device: [1, 5]
-          - destination:
-              device: [1, 6]
-          - destination:
-              device: [1, 7]
-      # Mesh 1 -> Mesh 0 (inside chips 0-3)
-      - device: [1, 0]
-        patterns:
-          - destination:
-              device: [0, 0]
-          - destination:
-              device: [0, 1]
-          - destination:
-              device: [0, 2]
-          - destination:
-              device: [0, 3]
-          - destination:
-              device: [0, 4]
-          - destination:
-              device: [0, 5]
-          - destination:
-              device: [0, 6]
-          - destination:
-              device: [0, 7]
-      - device: [1, 1]
-        patterns:
-          - destination:
-              device: [0, 0]
-          - destination:
-              device: [0, 1]
-          - destination:
-              device: [0, 2]
-          - destination:
-              device: [0, 3]
-          - destination:
-              device: [0, 4]
-          - destination:
-              device: [0, 5]
-          - destination:
-              device: [0, 6]
-          - destination:
-              device: [0, 7]
-      - device: [1, 2]
-        patterns:
-          - destination:
-              device: [0, 0]
-          - destination:
-              device: [0, 1]
-          - destination:
-              device: [0, 2]
-          - destination:
-              device: [0, 3]
-          - destination:
-              device: [0, 4]
-          - destination:
-              device: [0, 5]
-          - destination:
-              device: [0, 6]
-          - destination:
-              device: [0, 7]
-      - device: [1, 3]
-        patterns:
-          - destination:
-              device: [0, 0]
-          - destination:
-              device: [0, 1]
-          - destination:
-              device: [0, 2]
-          - destination:
-              device: [0, 3]
-          - destination:
-              device: [0, 4]
-          - destination:
-              device: [0, 5]
-          - destination:
-              device: [0, 6]
-          - destination:
-              device: [0, 7]
-      # Mesh 2 -> Mesh 3 (inside chips 0-3)
       - device: [2, 0]
         patterns:
           - destination:
@@ -2014,7 +1206,78 @@ Tests:
               device: [3, 6]
           - destination:
               device: [3, 7]
-      # Mesh 3 -> Mesh 2 (inside chips 0-3)
+      - device: [2, 4]
+        patterns:
+          - destination:
+              device: [3, 0]
+          - destination:
+              device: [3, 1]
+          - destination:
+              device: [3, 2]
+          - destination:
+              device: [3, 3]
+          - destination:
+              device: [3, 4]
+          - destination:
+              device: [3, 5]
+          - destination:
+              device: [3, 6]
+          - destination:
+              device: [3, 7]
+      - device: [2, 5]
+        patterns:
+          - destination:
+              device: [3, 0]
+          - destination:
+              device: [3, 1]
+          - destination:
+              device: [3, 2]
+          - destination:
+              device: [3, 3]
+          - destination:
+              device: [3, 4]
+          - destination:
+              device: [3, 5]
+          - destination:
+              device: [3, 6]
+          - destination:
+              device: [3, 7]
+      - device: [2, 6]
+        patterns:
+          - destination:
+              device: [3, 0]
+          - destination:
+              device: [3, 1]
+          - destination:
+              device: [3, 2]
+          - destination:
+              device: [3, 3]
+          - destination:
+              device: [3, 4]
+          - destination:
+              device: [3, 5]
+          - destination:
+              device: [3, 6]
+          - destination:
+              device: [3, 7]
+      - device: [2, 7]
+        patterns:
+          - destination:
+              device: [3, 0]
+          - destination:
+              device: [3, 1]
+          - destination:
+              device: [3, 2]
+          - destination:
+              device: [3, 3]
+          - destination:
+              device: [3, 4]
+          - destination:
+              device: [3, 5]
+          - destination:
+              device: [3, 6]
+          - destination:
+              device: [3, 7]
       - device: [3, 0]
         patterns:
           - destination:
@@ -2087,20 +1350,75 @@ Tests:
               device: [2, 6]
           - destination:
               device: [2, 7]
-
-  - name: "FlowControlMultiMesh"
-    sync: true
-    enable_flow_control: true
-    fabric_setup:
-      topology: Mesh
-
-    parametrization_params:
-      ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
-      size: [1024, 2048, 4096]
-
-    defaults:
-      ftype: unicast
-      num_packets: 10000
-
-    patterns:
-      - type: sequential_all_to_all
+      - device: [3, 4]
+        patterns:
+          - destination:
+              device: [2, 0]
+          - destination:
+              device: [2, 1]
+          - destination:
+              device: [2, 2]
+          - destination:
+              device: [2, 3]
+          - destination:
+              device: [2, 4]
+          - destination:
+              device: [2, 5]
+          - destination:
+              device: [2, 6]
+          - destination:
+              device: [2, 7]
+      - device: [3, 5]
+        patterns:
+          - destination:
+              device: [2, 0]
+          - destination:
+              device: [2, 1]
+          - destination:
+              device: [2, 2]
+          - destination:
+              device: [2, 3]
+          - destination:
+              device: [2, 4]
+          - destination:
+              device: [2, 5]
+          - destination:
+              device: [2, 6]
+          - destination:
+              device: [2, 7]
+      - device: [3, 6]
+        patterns:
+          - destination:
+              device: [2, 0]
+          - destination:
+              device: [2, 1]
+          - destination:
+              device: [2, 2]
+          - destination:
+              device: [2, 3]
+          - destination:
+              device: [2, 4]
+          - destination:
+              device: [2, 5]
+          - destination:
+              device: [2, 6]
+          - destination:
+              device: [2, 7]
+      - device: [3, 7]
+        patterns:
+          - destination:
+              device: [2, 0]
+          - destination:
+              device: [2, 1]
+          - destination:
+              device: [2, 2]
+          - destination:
+              device: [2, 3]
+          - destination:
+              device: [2, 4]
+          - destination:
+              device: [2, 5]
+          - destination:
+              device: [2, 6]
+          - destination:
+              device: [2, 7]

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_wh_6u_quad_2x4_cyclic.yaml
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_wh_6u_quad_2x4_cyclic.yaml
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+# Run this with the following command:
+# tt-run --rank-binding tests/tt_metal/distributed/config/wh_galaxy_2x4_rank_bindings.yaml --mpi-args "--allow-run-as-root --tag-output" ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_wh_6u_quad_2x4_cyclic.yaml
+#
+Tests:
+  # ======================================================================================
+  # Inter Mesh Cycle Hang: Inter-Mesh Directed Traffic
+  # ======================================================================================
+  - name: InterMeshCrossTraffic
+    sync: true
+    enable_flow_control: true
+    fabric_setup:
+      topology: Mesh
+    parametrization_params:
+      size: [2048, 4096]
+    defaults:
+      ftype: unicast
+      ntype: unicast_write
+      num_packets: 50000
+    senders:
+      - device: [0, 5]
+        patterns:
+          - destination:
+              device: [2, 4]
+      - device: [2, 5]
+        patterns:
+          - destination:
+              device: [0, 4]
+      - device: [3, 6]
+        patterns:
+          - destination:
+              device: [1, 7]
+      - device: [1, 6]
+        patterns:
+          - destination:
+              device: [3, 7]

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_wh_6u_quad_2x4_cyclic.yaml
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_wh_6u_quad_2x4_cyclic.yaml
@@ -20,19 +20,19 @@ Tests:
       ntype: unicast_write
       num_packets: 50000
     senders:
-      - device: [0, 5]
-        patterns:
-          - destination:
-              device: [2, 4]
-      - device: [2, 5]
-        patterns:
-          - destination:
-              device: [0, 4]
-      - device: [3, 6]
-        patterns:
-          - destination:
-              device: [1, 7]
-      - device: [1, 6]
+      - device: [0, 7]
         patterns:
           - destination:
               device: [3, 7]
+      - device: [3, 4]
+        patterns:
+          - destination:
+              device: [2, 4]
+      - device: [2, 7]
+        patterns:
+          - destination:
+              device: [1, 7]
+      - device: [1, 4]
+        patterns:
+          - destination:
+              device: [0, 4]

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_wh_6u_quad_2x4_cyclic.yaml
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_wh_6u_quad_2x4_cyclic.yaml
@@ -10,7 +10,7 @@ Tests:
   # ======================================================================================
   - name: InterMeshCrossTraffic
     sync: true
-    enable_flow_control: true
+    skip_packet_validation: true
     fabric_setup:
       topology: Mesh
     parametrization_params:

--- a/tt_metal/fabric/hw/inc/tt_fabric_api.h
+++ b/tt_metal/fabric/hw/inc/tt_fabric_api.h
@@ -260,6 +260,9 @@ bool fabric_set_unicast_route(
         } else {
             packet_header->routing_fields.branch_west_offset = turn_point;  // turn to WEST after NS
         }
+    } else if (ns_hops > 0) {
+        packet_header->routing_fields.branch_east_offset = turn_point;
+        packet_header->routing_fields.branch_west_offset = turn_point;
     } else if (ns_hops == 0 && ew_hops > 0) {
         // East/West only routing: branch offset is set at position 1 (start_hop + 1)
         if (ew_direction) {


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/32667)

### Problem description
With the incoming addition of an inter-mesh communication vc aimed to avoid cyclic routing deadlocks, there is a need to have a test that creates such a deadlock for the purpose of testing.
In the process, discovered an issue where if an inter-mesh packet route is determined to be a "turn", but not evaluated as a turn by the worker kernel, the wrong route is occasionally taken depending on start node position

### What's changed
Added a new 2x4 wh galaxy configuration that separates each individual tray in a galaxy into its own 2x4 mesh.
Added a test that creates a cyclic deadlock on said mesh
Added many stress tests that do not create cyclic deadlocks on said mesh
Updated packet routing to support said stress tests
Fixed bug with packet routing from starting node

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/20242376333
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] [cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) job passes
- [ ] New/Existing tests provide coverage for changes