### PR TITLE
Add AdjacencyGraph API and helper functions for topology solver

### DIFF
--- a/tt_metal/api/tt-metalium/experimental/fabric/routing_table_generator.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/routing_table_generator.hpp
@@ -20,23 +20,6 @@ class TopologyMapper;
 using RoutingTable =
     std::vector<std::vector<std::vector<RoutingDirection>>>;  // [mesh_id][chip_id][target_chip_or_mesh_id]
 
-// TODO: first pass at switching over MeshId/ChipId to proper struct
-// Need to update the usage in routing table generator
-class FabricNodeId {
-public:
-    explicit FabricNodeId(MeshId mesh_id_val, std::uint32_t chip_id_val);
-    MeshId mesh_id{0};
-    std::uint32_t chip_id = 0;
-};
-
-bool operator==(const FabricNodeId& lhs, const FabricNodeId& rhs);
-bool operator!=(const FabricNodeId& lhs, const FabricNodeId& rhs);
-bool operator<(const FabricNodeId& lhs, const FabricNodeId& rhs);
-bool operator>(const FabricNodeId& lhs, const FabricNodeId& rhs);
-bool operator<=(const FabricNodeId& lhs, const FabricNodeId& rhs);
-bool operator>=(const FabricNodeId& lhs, const FabricNodeId& rhs);
-std::ostream& operator<<(std::ostream& os, const FabricNodeId& fabric_node_id);
-
 class RoutingTableGenerator {
 public:
     explicit RoutingTableGenerator(const TopologyMapper& topology_mapper);
@@ -80,19 +63,3 @@ private:
 };
 
 }  // namespace tt::tt_fabric
-
-namespace std {
-template <>
-struct hash<tt::tt_fabric::FabricNodeId> {
-    size_t operator()(const tt::tt_fabric::FabricNodeId& fabric_node_id) const noexcept {
-        return tt::stl::hash::hash_objects_with_default_seed(fabric_node_id.mesh_id, fabric_node_id.chip_id);
-    }
-};
-}  // namespace std
-
-template <>
-struct fmt::formatter<tt::tt_fabric::FabricNodeId> {
-    constexpr auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.end(); }
-
-    auto format(const tt::tt_fabric::FabricNodeId& node_id, format_context& ctx) const -> format_context::iterator;
-};

--- a/tt_metal/api/tt-metalium/experimental/fabric/topology_solver.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/topology_solver.hpp
@@ -1,0 +1,87 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <map>
+#include <string>
+#include <vector>
+
+#include <tt-metalium/experimental/fabric/mesh_graph.hpp>
+#include <tt-metalium/experimental/fabric/fabric_types.hpp>
+#include <tt-metalium/experimental/fabric/routing_table_generator.hpp>
+
+namespace tt::tt_metal {
+class PhysicalSystemDescriptor;
+}  // namespace tt::tt_metal
+
+namespace tt::tt_fabric {
+
+/**
+ * @brief Generic graph representation with minimal query interface
+ *
+ * AdjacencyGraph provides a generic graph representation that works with any node type.
+ * It provides a minimal interface for querying graph structure: getting all nodes and
+ * getting neighbors of a specific node.
+ *
+ * @tparam NodeId The type used to identify nodes in the graph
+ */
+template <typename NodeId>
+class AdjacencyGraph {
+public:
+    using NodeType = NodeId;
+    using AdjacencyMap = std::map<NodeId, std::vector<NodeId>>;
+
+    /**
+     * @brief Construct empty adjacency graph
+     */
+    AdjacencyGraph() = default;
+
+    /**
+     * @brief Construct adjacency graph from a MeshGraph
+     *
+     * @param mesh_graph The mesh graph to construct the adjacency graph from
+     */
+    explicit AdjacencyGraph(const AdjacencyMap& adjacency_map);
+
+    /**
+     * @brief Get all nodes in the graph
+     *
+     * @return const std::vector<NodeId>& Vector of all node IDs in the graph
+     */
+    const std::vector<NodeId>& get_nodes() const;
+
+    /**
+     * @brief Get neighbors of a specific node
+     *
+     * @param node The node ID to get neighbors for
+     * @return const std::vector<NodeId>& Vector of neighbor node IDs
+     */
+    const std::vector<NodeId>& get_neighbors(NodeId node) const;
+
+    /**
+     * @brief Print adjacency map for debugging
+     *
+     * Prints the graph structure showing each node and its neighbors.
+     * Useful for debugging mapping failures.
+     *
+     * @param graph_name Name to identify this graph in the output
+     */
+    void print_adjacency_map(const std::string& graph_name = "Graph") const;
+
+private:
+    AdjacencyMap adj_map_;
+    std::vector<NodeId> nodes_cache_;
+};
+
+std::map<MeshId, AdjacencyGraph<FabricNodeId>> build_adjacency_map_logical(const MeshGraph& mesh_graph);
+
+std::map<MeshId, AdjacencyGraph<tt::tt_metal::AsicID>> build_adjacency_map_physical(
+    const tt::tt_metal::PhysicalSystemDescriptor& physical_system_descriptor,
+    const std::map<MeshId, std::map<tt::tt_metal::AsicID, MeshHostRankId>>& asic_id_to_mesh_rank);
+
+}  // namespace tt::tt_fabric
+
+// Include template implementations
+#include <tt-metalium/experimental/fabric/topology_solver.tpp>

--- a/tt_metal/api/tt-metalium/experimental/fabric/topology_solver.tpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/topology_solver.tpp
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Template implementation file - included at the end of topology_solver.hpp
+// This allows template implementations to be separated from declarations while
+// still enabling implicit instantiation for any type.
+
+#ifndef TOPOLOGY_SOLVER_TPP
+#define TOPOLOGY_SOLVER_TPP
+
+#include <sstream>
+
+#include <tt-logger/tt-logger.hpp>
+
+namespace tt::tt_fabric {
+
+// AdjacencyGraph template method implementations
+template <typename NodeId>
+AdjacencyGraph<NodeId>::AdjacencyGraph(const AdjacencyMap& adjacency_map) : adj_map_(adjacency_map) {
+    for (const auto& [node, neighbors] : adjacency_map) {
+        nodes_cache_.push_back(node);
+    }
+}
+
+template <typename NodeId>
+const std::vector<NodeId>& AdjacencyGraph<NodeId>::get_nodes() const {
+    return nodes_cache_;
+}
+
+template <typename NodeId>
+const std::vector<NodeId>& AdjacencyGraph<NodeId>::get_neighbors(NodeId node) const {
+    auto it = adj_map_.find(node);
+    if (it != adj_map_.end()) {
+        return it->second;
+    }
+    // Return empty vector if node not found
+    static const std::vector<NodeId> empty_vec;
+    return empty_vec;
+}
+
+template <typename NodeId>
+void AdjacencyGraph<NodeId>::print_adjacency_map(const std::string& graph_name) const {
+    std::stringstream ss;
+    ss << "\n=== " << graph_name << " Adjacency Map ===" << std::endl;
+    ss << "Total nodes: " << nodes_cache_.size() << std::endl;
+
+    for (const auto& node : nodes_cache_) {
+        const auto& neighbors = get_neighbors(node);
+        ss << "  Node " << node << " (degree " << neighbors.size() << "): ";
+        if (neighbors.empty()) {
+            ss << "no neighbors";
+        } else {
+            bool first = true;
+            for (const auto& neighbor : neighbors) {
+                if (!first) {
+                    ss << ", ";
+                }
+                first = false;
+                ss << neighbor;
+            }
+        }
+        ss << std::endl;
+    }
+    ss << "========================================" << std::endl;
+    log_info(tt::LogFabric, "{}", ss.str());
+}
+
+}  // namespace tt::tt_fabric
+
+#endif  // TOPOLOGY_SOLVER_TPP

--- a/tt_metal/fabric/fabric_types.cpp
+++ b/tt_metal/fabric/fabric_types.cpp
@@ -4,6 +4,10 @@
 
 #include <tt-metalium/experimental/fabric/fabric_types.hpp>
 
+#include <enchantum/enchantum.hpp>
+#include <ostream>
+#include <tt_stl/reflection.hpp>
+
 namespace tt::tt_fabric {
 
 FabricType operator|(FabricType lhs, FabricType rhs) {
@@ -16,4 +20,40 @@ FabricType operator&(FabricType lhs, FabricType rhs) {
 
 bool has_flag(FabricType flags, FabricType test) { return (flags & test) == test; }
 
+FabricNodeId::FabricNodeId(MeshId mesh_id_val, std::uint32_t chip_id_val) :
+    mesh_id(mesh_id_val), chip_id(chip_id_val) {}
+
+bool operator==(const FabricNodeId& lhs, const FabricNodeId& rhs) {
+    return lhs.mesh_id == rhs.mesh_id && lhs.chip_id == rhs.chip_id;
+}
+
+bool operator!=(const FabricNodeId& lhs, const FabricNodeId& rhs) { return !(lhs == rhs); }
+
+bool operator<(const FabricNodeId& lhs, const FabricNodeId& rhs) {
+    return lhs.mesh_id < rhs.mesh_id || (lhs.mesh_id == rhs.mesh_id && lhs.chip_id < rhs.chip_id);
+}
+
+bool operator>(const FabricNodeId& lhs, const FabricNodeId& rhs) { return rhs < lhs; }
+
+bool operator<=(const FabricNodeId& lhs, const FabricNodeId& rhs) { return !(rhs > lhs); }
+
+bool operator>=(const FabricNodeId& lhs, const FabricNodeId& rhs) { return !(lhs < rhs); }
+
+std::ostream& operator<<(std::ostream& os, const FabricNodeId& fabric_node_id) {
+    using ::operator<<;  // Enable ADL for StrongType operator<<
+    os << "M" << fabric_node_id.mesh_id << "D" << fabric_node_id.chip_id;
+    return os;
+}
+
 }  // namespace tt::tt_fabric
+
+namespace std {
+size_t hash<tt::tt_fabric::FabricNodeId>::operator()(const tt::tt_fabric::FabricNodeId& fabric_node_id) const noexcept {
+    return tt::stl::hash::hash_objects_with_default_seed(fabric_node_id.mesh_id, fabric_node_id.chip_id);
+}
+}  // namespace std
+
+auto fmt::formatter<tt::tt_fabric::FabricNodeId>::format(
+    const tt::tt_fabric::FabricNodeId& node_id, format_context& ctx) const -> format_context::iterator {
+    return fmt::format_to(ctx.out(), "(M{}, D{})", *node_id.mesh_id, node_id.chip_id);
+}

--- a/tt_metal/fabric/routing_table_generator.cpp
+++ b/tt_metal/fabric/routing_table_generator.cpp
@@ -17,31 +17,7 @@
 #include <tt-logger/tt-logger.hpp>
 #include <tt-metalium/experimental/fabric/topology_mapper.hpp>
 
-auto fmt::formatter<tt::tt_fabric::FabricNodeId>::format(
-    const tt::tt_fabric::FabricNodeId& node_id, format_context& ctx) const -> format_context::iterator {
-    return fmt::format_to(ctx.out(), "(M{}, D{})", *node_id.mesh_id, node_id.chip_id);
-}
-
 namespace tt::tt_fabric {
-
-FabricNodeId::FabricNodeId(MeshId mesh_id_val, std::uint32_t chip_id_val) :
-    mesh_id(mesh_id_val), chip_id(chip_id_val) {}
-
-bool operator==(const FabricNodeId& lhs, const FabricNodeId& rhs) {
-    return lhs.mesh_id == rhs.mesh_id && lhs.chip_id == rhs.chip_id;
-}
-bool operator!=(const FabricNodeId& lhs, const FabricNodeId& rhs) { return !(lhs == rhs); }
-bool operator<(const FabricNodeId& lhs, const FabricNodeId& rhs) {
-    return lhs.mesh_id < rhs.mesh_id || (lhs.mesh_id == rhs.mesh_id && lhs.chip_id < rhs.chip_id);
-}
-bool operator>(const FabricNodeId& lhs, const FabricNodeId& rhs) { return rhs < lhs; }
-bool operator<=(const FabricNodeId& lhs, const FabricNodeId& rhs) { return !(rhs > lhs); }
-bool operator>=(const FabricNodeId& lhs, const FabricNodeId& rhs) { return !(lhs < rhs); }
-std::ostream& operator<<(std::ostream& os, const FabricNodeId& fabric_node_id) {
-    using ::operator<<;  // Enable ADL for StrongType operator<<
-    os << "M" << fabric_node_id.mesh_id << "D" << fabric_node_id.chip_id;
-    return os;
-}
 
 RoutingTableGenerator::RoutingTableGenerator(const TopologyMapper& topology_mapper) :
     topology_mapper_(topology_mapper) {

--- a/tt_metal/fabric/topology_solver.cpp
+++ b/tt_metal/fabric/topology_solver.cpp
@@ -1,0 +1,104 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <unordered_set>
+
+#include <tt-metalium/experimental/fabric/topology_solver.hpp>
+#include <tt-metalium/experimental/fabric/fabric_types.hpp>
+#include "tt_metal/fabric/physical_system_descriptor.hpp"
+#include "tt_metal/impl/context/metal_context.hpp"
+#include <llrt/tt_cluster.hpp>
+
+namespace tt::tt_fabric {
+
+std::map<MeshId, AdjacencyGraph<FabricNodeId>> build_adjacency_map_logical(const MeshGraph& mesh_graph) {
+    std::map<MeshId, AdjacencyGraph<FabricNodeId>> adjacency_map;
+
+    auto get_local_adjacents = [&](FabricNodeId fabric_node_id, MeshId mesh_id) {
+        auto adjacent_map = mesh_graph.get_intra_mesh_connectivity()[*mesh_id][fabric_node_id.chip_id];
+
+        std::vector<FabricNodeId> adjacents;
+        for (const auto& [neighbor_chip_id, edge] : adjacent_map) {
+            // Skip self-connections
+            if (neighbor_chip_id == fabric_node_id.chip_id) {
+                continue;
+            }
+            for (size_t i = 0; i < edge.connected_chip_ids.size(); ++i) {
+                adjacents.push_back(FabricNodeId(mesh_id, neighbor_chip_id));
+            }
+        }
+        return adjacents;
+    };
+
+    // Iterate over all mesh IDs from the mesh graph
+    for (const auto& mesh_id : mesh_graph.get_mesh_ids()) {
+        AdjacencyGraph<FabricNodeId>::AdjacencyMap logical_adjacency_map;
+        for (const auto& [_, chip_id] : mesh_graph.get_chip_ids(mesh_id)) {
+            auto fabric_node_id = FabricNodeId(mesh_id, chip_id);
+            logical_adjacency_map[fabric_node_id] = get_local_adjacents(fabric_node_id, mesh_id);
+        }
+        adjacency_map[mesh_id] = AdjacencyGraph<FabricNodeId>(logical_adjacency_map);
+    }
+
+    return adjacency_map;
+}
+
+std::map<MeshId, AdjacencyGraph<tt::tt_metal::AsicID>> build_adjacency_map_physical(
+    const tt::tt_metal::PhysicalSystemDescriptor& physical_system_descriptor,
+    const std::map<MeshId, std::map<tt::tt_metal::AsicID, MeshHostRankId>>& asic_id_to_mesh_rank) {
+    std::map<MeshId, AdjacencyGraph<tt::tt_metal::AsicID>> adjacency_map;
+
+    // Build a set of ASIC IDs for each mesh based on mesh rank mapping
+    std::map<MeshId, std::unordered_set<tt::tt_metal::AsicID>> mesh_asic_ids;
+    for (const auto& [mesh_id, asic_map] : asic_id_to_mesh_rank) {
+        for (const auto& [asic_id, _] : asic_map) {
+            mesh_asic_ids[mesh_id].insert(asic_id);
+        }
+    }
+
+    for (const auto& [mesh_id, mesh_asics] : mesh_asic_ids) {
+        auto z_channels = std::unordered_set<uint8_t>{8, 9};
+        auto cluster_type = tt::tt_metal::MetalContext::instance().get_cluster().get_cluster_type();
+
+        auto get_local_adjacents = [&](tt::tt_metal::AsicID asic_id,
+                                       const std::unordered_set<tt::tt_metal::AsicID>& mesh_asics) {
+            std::vector<tt::tt_metal::AsicID> adjacents;
+
+            for (const auto& neighbor : physical_system_descriptor.get_asic_neighbors(asic_id)) {
+                // Skip self-connections
+                if (neighbor == asic_id) {
+                    continue;
+                }
+                // Make sure that the neighbor is in the mesh
+                if (mesh_asics.contains(neighbor)) {
+                    // Add each neighbor multiple times based on number of ethernet connections
+                    auto eth_connections = physical_system_descriptor.get_eth_connections(asic_id, neighbor);
+                    for (const auto& eth_connection : eth_connections) {
+                        // NOTE: IGNORE Z channels for Blackhole galaxy in intra mesh connectivity for now since
+                        // they cause issues with uniform mesh mapping since topology mapper algorithm does not prefer
+                        // taking the full connectivity path vs downgrading through z channels for intramesh
+                        // connectivity https://github.com/tenstorrent/tt-metal/issues/31846
+                        if (cluster_type == tt::tt_metal::ClusterType::BLACKHOLE_GALAXY &&
+                            (z_channels.contains(eth_connection.src_chan) ||
+                             z_channels.contains(eth_connection.dst_chan))) {
+                            continue;
+                        }
+                        adjacents.push_back(neighbor);
+                    }
+                }
+            }
+            return adjacents;
+        };
+
+        AdjacencyGraph<tt::tt_metal::AsicID>::AdjacencyMap physical_adjacency_map;
+        for (const auto& asic_id : mesh_asics) {
+            physical_adjacency_map[asic_id] = get_local_adjacents(asic_id, mesh_asics);
+        }
+        adjacency_map[mesh_id] = AdjacencyGraph<tt::tt_metal::AsicID>(physical_adjacency_map);
+    }
+
+    return adjacency_map;
+}
+
+}  // namespace tt::tt_fabric


### PR DESCRIPTION
This PR introduces the foundational AdjacencyGraph API for the topology solver.

## Changes
- Add generic `AdjacencyGraph` template class for graph representation
- Add `build_adjacency_map_logical()` to build graphs from `MeshGraph`
- Add `build_adjacency_map_physical()` to build graphs from `PhysicalSystemDescriptor`
- Move `FabricNodeId` from `routing_table_generator` to `fabric_types`
- Add `FabricNodeId` operators and formatters
- Add `print_adjacency_map()` for debugging

## Purpose
This is the first of 4 PRs that break up the topology solver implementation into logical, reviewable pieces. This PR focuses on the graph representation API that will be used by subsequent PRs.