### PR TITLE
Add MappingConstraints API for topology solver

### DIFF
--- a/tt_metal/api/tt-metalium/experimental/fabric/routing_table_generator.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/routing_table_generator.hpp
@@ -20,23 +20,6 @@ class TopologyMapper;
 using RoutingTable =
     std::vector<std::vector<std::vector<RoutingDirection>>>;  // [mesh_id][chip_id][target_chip_or_mesh_id]
 
-// TODO: first pass at switching over MeshId/ChipId to proper struct
-// Need to update the usage in routing table generator
-class FabricNodeId {
-public:
-    explicit FabricNodeId(MeshId mesh_id_val, std::uint32_t chip_id_val);
-    MeshId mesh_id{0};
-    std::uint32_t chip_id = 0;
-};
-
-bool operator==(const FabricNodeId& lhs, const FabricNodeId& rhs);
-bool operator!=(const FabricNodeId& lhs, const FabricNodeId& rhs);
-bool operator<(const FabricNodeId& lhs, const FabricNodeId& rhs);
-bool operator>(const FabricNodeId& lhs, const FabricNodeId& rhs);
-bool operator<=(const FabricNodeId& lhs, const FabricNodeId& rhs);
-bool operator>=(const FabricNodeId& lhs, const FabricNodeId& rhs);
-std::ostream& operator<<(std::ostream& os, const FabricNodeId& fabric_node_id);
-
 class RoutingTableGenerator {
 public:
     explicit RoutingTableGenerator(const TopologyMapper& topology_mapper);
@@ -80,19 +63,3 @@ private:
 };
 
 }  // namespace tt::tt_fabric
-
-namespace std {
-template <>
-struct hash<tt::tt_fabric::FabricNodeId> {
-    size_t operator()(const tt::tt_fabric::FabricNodeId& fabric_node_id) const noexcept {
-        return tt::stl::hash::hash_objects_with_default_seed(fabric_node_id.mesh_id, fabric_node_id.chip_id);
-    }
-};
-}  // namespace std
-
-template <>
-struct fmt::formatter<tt::tt_fabric::FabricNodeId> {
-    constexpr auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.end(); }
-
-    auto format(const tt::tt_fabric::FabricNodeId& node_id, format_context& ctx) const -> format_context::iterator;
-};

--- a/tt_metal/api/tt-metalium/experimental/fabric/topology_solver.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/topology_solver.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <map>
+#include <set>
 #include <string>
 #include <vector>
 
@@ -80,6 +81,140 @@ std::map<MeshId, AdjacencyGraph<FabricNodeId>> build_adjacency_map_logical(const
 std::map<MeshId, AdjacencyGraph<tt::tt_metal::AsicID>> build_adjacency_map_physical(
     const tt::tt_metal::PhysicalSystemDescriptor& physical_system_descriptor,
     const std::map<MeshId, std::map<tt::tt_metal::AsicID, MeshHostRankId>>& asic_id_to_mesh_rank);
+
+/**
+ * @brief Unified constraint system for topology mapping
+ *
+ * MappingConstraints represents all constraints internally as trait maps. Both trait-based
+ * constraints (one-to-many) and explicit pair constraints (one-to-one) are unified into a
+ * single intersection-based representation.
+ *
+ * @tparam TargetNode The type of nodes in the target graph
+ * @tparam GlobalNode The type of nodes in the global graph
+ */
+template <typename TargetNode, typename GlobalNode>
+class MappingConstraints {
+public:
+    /**
+     * @brief Construct empty constraints
+     */
+    MappingConstraints() = default;
+
+    /**
+     * @brief Constructor from sets of constraint pairs
+     *
+     * Converts pairs into the internal mapping representation.
+     *
+     * @param required_constraints Set of required constraint pairs (target, global)
+     * @param preferred_constraints Set of preferred constraint pairs (target, global)
+     */
+    MappingConstraints(
+        const std::set<std::pair<TargetNode, GlobalNode>>& required_constraints,
+        const std::set<std::pair<TargetNode, GlobalNode>>& preferred_constraints = {});
+
+    /**
+     * @brief Add required trait-based constraint (one-to-many)
+     *
+     * Constrains target nodes with trait value T to only map to global nodes with same trait value T.
+     * All constraints are intersected - a target node must satisfy ALL required constraints simultaneously.
+     * Throws TT_THROW if constraint causes conflicts (empty valid mappings).
+     *
+     * @tparam TraitType The type of the trait value (must be explicitly specified)
+     * @param target_traits Map from target nodes to their trait values
+     * @param global_traits Map from global nodes to their trait values
+     * @throws std::runtime_error If constraint causes empty valid mappings for any target node
+     */
+    template <typename TraitType>
+    void add_required_trait_constraint(
+        const std::map<TargetNode, TraitType>& target_traits, const std::map<GlobalNode, TraitType>& global_traits);
+
+    /**
+     * @brief Add preferred trait-based constraint (one-to-many)
+     *
+     * Constrains target nodes with trait value T to prefer mapping to global nodes with same trait value T.
+     * Preferred constraints guide the solver but don't restrict valid mappings.
+     *
+     * @tparam TraitType The type of the trait value (must be explicitly specified)
+     * @param target_traits Map from target nodes to their trait values
+     * @param global_traits Map from global nodes to their trait values
+     */
+    template <typename TraitType>
+    void add_preferred_trait_constraint(
+        const std::map<TargetNode, TraitType>& target_traits, const std::map<GlobalNode, TraitType>& global_traits);
+
+    /**
+     * @brief Add explicit required constraint (one-to-one)
+     *
+     * Pins a specific target node to a specific global node.
+     * Intersects with existing constraints. Throws TT_THROW if constraint causes conflicts.
+     *
+     * @param target_node The target node to constrain
+     * @param global_node The global node it must map to
+     * @throws std::runtime_error If constraint causes empty valid mappings
+     */
+    void add_required_constraint(TargetNode target_node, GlobalNode global_node);
+
+    /**
+     * @brief Add explicit preferred constraint (one-to-one)
+     *
+     * Suggests a mapping but doesn't restrict valid mappings.
+     * The solver can still choose other nodes if needed.
+     *
+     * @param target_node The target node
+     * @param global_node The preferred global node to map to
+     */
+    void add_preferred_constraint(TargetNode target_node, GlobalNode global_node);
+
+    /**
+     * @brief Get valid mappings for a specific target node
+     *
+     * @param target The target node
+     * @return const std::set<GlobalNode>& Set of global nodes this target can map to
+     */
+    const std::set<GlobalNode>& get_valid_mappings(TargetNode target) const;
+
+    /**
+     * @brief Get preferred mappings for a specific target node
+     *
+     * @param target The target node
+     * @return const std::set<GlobalNode>& Set of preferred global nodes for this target
+     */
+    const std::set<GlobalNode>& get_preferred_mappings(TargetNode target) const;
+
+    /**
+     * @brief Check if a specific mapping is valid
+     *
+     * @param target The target node
+     * @param global The global node
+     * @return true if the mapping satisfies all required constraints, false otherwise
+     */
+    bool is_valid_mapping(TargetNode target, GlobalNode global) const;
+
+    /**
+     * @brief Get all valid mappings (for solver access)
+     *
+     * @return const std::map<TargetNode, std::set<GlobalNode>>& Map of all valid mappings
+     */
+    const std::map<TargetNode, std::set<GlobalNode>>& get_valid_mappings() const;
+
+    /**
+     * @brief Get all preferred mappings (for solver access)
+     *
+     * @return const std::map<TargetNode, std::set<GlobalNode>>& Map of all preferred mappings
+     */
+    const std::map<TargetNode, std::set<GlobalNode>>& get_preferred_mappings() const;
+
+private:
+    // Internal representation: intersection of all constraints
+    std::map<TargetNode, std::set<GlobalNode>> valid_mappings_;      // Required constraints
+    std::map<TargetNode, std::set<GlobalNode>> preferred_mappings_;  // Preferred constraints
+
+    // Helper to intersect two sets
+    static std::set<GlobalNode> intersect_sets(const std::set<GlobalNode>& set1, const std::set<GlobalNode>& set2);
+
+    // Internal validation - throws if invalid
+    void validate_and_throw() const;
+};
 
 }  // namespace tt::tt_fabric
 

--- a/tt_metal/api/tt-metalium/experimental/fabric/topology_solver.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/topology_solver.hpp
@@ -1,0 +1,87 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <map>
+#include <string>
+#include <vector>
+
+#include <tt-metalium/experimental/fabric/mesh_graph.hpp>
+#include <tt-metalium/experimental/fabric/fabric_types.hpp>
+#include <tt-metalium/experimental/fabric/routing_table_generator.hpp>
+
+namespace tt::tt_metal {
+class PhysicalSystemDescriptor;
+}  // namespace tt::tt_metal
+
+namespace tt::tt_fabric {
+
+/**
+ * @brief Generic graph representation with minimal query interface
+ *
+ * AdjacencyGraph provides a generic graph representation that works with any node type.
+ * It provides a minimal interface for querying graph structure: getting all nodes and
+ * getting neighbors of a specific node.
+ *
+ * @tparam NodeId The type used to identify nodes in the graph
+ */
+template <typename NodeId>
+class AdjacencyGraph {
+public:
+    using NodeType = NodeId;
+    using AdjacencyMap = std::map<NodeId, std::vector<NodeId>>;
+
+    /**
+     * @brief Construct empty adjacency graph
+     */
+    AdjacencyGraph() = default;
+
+    /**
+     * @brief Construct adjacency graph from a MeshGraph
+     *
+     * @param mesh_graph The mesh graph to construct the adjacency graph from
+     */
+    explicit AdjacencyGraph(const AdjacencyMap& adjacency_map);
+
+    /**
+     * @brief Get all nodes in the graph
+     *
+     * @return const std::vector<NodeId>& Vector of all node IDs in the graph
+     */
+    const std::vector<NodeId>& get_nodes() const;
+
+    /**
+     * @brief Get neighbors of a specific node
+     *
+     * @param node The node ID to get neighbors for
+     * @return const std::vector<NodeId>& Vector of neighbor node IDs
+     */
+    const std::vector<NodeId>& get_neighbors(NodeId node) const;
+
+    /**
+     * @brief Print adjacency map for debugging
+     *
+     * Prints the graph structure showing each node and its neighbors.
+     * Useful for debugging mapping failures.
+     *
+     * @param graph_name Name to identify this graph in the output
+     */
+    void print_adjacency_map(const std::string& graph_name = "Graph") const;
+
+private:
+    AdjacencyMap adj_map_;
+    std::vector<NodeId> nodes_cache_;
+};
+
+std::map<MeshId, AdjacencyGraph<FabricNodeId>> build_adjacency_map_logical(const MeshGraph& mesh_graph);
+
+std::map<MeshId, AdjacencyGraph<tt::tt_metal::AsicID>> build_adjacency_map_physical(
+    const tt::tt_metal::PhysicalSystemDescriptor& physical_system_descriptor,
+    const std::map<MeshId, std::map<tt::tt_metal::AsicID, MeshHostRankId>>& asic_id_to_mesh_rank);
+
+}  // namespace tt::tt_fabric
+
+// Include template implementations
+#include <tt-metalium/experimental/fabric/topology_solver.tpp>

--- a/tt_metal/api/tt-metalium/experimental/fabric/topology_solver.tpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/topology_solver.tpp
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Template implementation file - included at the end of topology_solver.hpp
+// This allows template implementations to be separated from declarations while
+// still enabling implicit instantiation for any type.
+
+#ifndef TOPOLOGY_SOLVER_TPP
+#define TOPOLOGY_SOLVER_TPP
+
+#include <sstream>
+
+#include <tt-logger/tt-logger.hpp>
+
+namespace tt::tt_fabric {
+
+// AdjacencyGraph template method implementations
+template <typename NodeId>
+AdjacencyGraph<NodeId>::AdjacencyGraph(const AdjacencyMap& adjacency_map) : adj_map_(adjacency_map) {
+    for (const auto& [node, neighbors] : adjacency_map) {
+        nodes_cache_.push_back(node);
+    }
+}
+
+template <typename NodeId>
+const std::vector<NodeId>& AdjacencyGraph<NodeId>::get_nodes() const {
+    return nodes_cache_;
+}
+
+template <typename NodeId>
+const std::vector<NodeId>& AdjacencyGraph<NodeId>::get_neighbors(NodeId node) const {
+    auto it = adj_map_.find(node);
+    if (it != adj_map_.end()) {
+        return it->second;
+    }
+    // Return empty vector if node not found
+    static const std::vector<NodeId> empty_vec;
+    return empty_vec;
+}
+
+template <typename NodeId>
+void AdjacencyGraph<NodeId>::print_adjacency_map(const std::string& graph_name) const {
+    std::stringstream ss;
+    ss << "\n=== " << graph_name << " Adjacency Map ===" << std::endl;
+    ss << "Total nodes: " << nodes_cache_.size() << std::endl;
+
+    for (const auto& node : nodes_cache_) {
+        const auto& neighbors = get_neighbors(node);
+        ss << "  Node " << node << " (degree " << neighbors.size() << "): ";
+        if (neighbors.empty()) {
+            ss << "no neighbors";
+        } else {
+            bool first = true;
+            for (const auto& neighbor : neighbors) {
+                if (!first) {
+                    ss << ", ";
+                }
+                first = false;
+                ss << neighbor;
+            }
+        }
+        ss << std::endl;
+    }
+    ss << "========================================" << std::endl;
+    log_info(tt::LogFabric, "{}", ss.str());
+}
+
+}  // namespace tt::tt_fabric
+
+#endif  // TOPOLOGY_SOLVER_TPP

--- a/tt_metal/api/tt-metalium/experimental/fabric/topology_solver.tpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/topology_solver.tpp
@@ -12,6 +12,7 @@
 #include <sstream>
 
 #include <tt-logger/tt-logger.hpp>
+#include <tt_stl/assert.hpp>
 
 namespace tt::tt_fabric {
 
@@ -64,6 +65,192 @@ void AdjacencyGraph<NodeId>::print_adjacency_map(const std::string& graph_name) 
     }
     ss << "========================================" << std::endl;
     log_info(tt::LogFabric, "{}", ss.str());
+}
+
+// MappingConstraints trait constraint template method implementations
+template <typename TargetNode, typename GlobalNode>
+template <typename TraitType>
+void MappingConstraints<TargetNode, GlobalNode>::add_required_trait_constraint(
+    const std::map<TargetNode, TraitType>& target_traits, const std::map<GlobalNode, TraitType>& global_traits) {
+    // Build reverse map: trait value -> set of global nodes with that trait
+    std::map<TraitType, std::set<GlobalNode>> trait_to_globals;
+    for (const auto& [global_node, trait_value] : global_traits) {
+        trait_to_globals[trait_value].insert(global_node);
+    }
+
+    std::vector<TargetNode> conflicted_targets;
+
+    // Apply trait constraint to valid_mappings_ (required)
+    for (const auto& [target_node, trait_value] : target_traits) {
+        auto trait_it = trait_to_globals.find(trait_value);
+        if (trait_it == trait_to_globals.end()) {
+            // No global nodes with this trait value - clear valid mappings
+            valid_mappings_[target_node].clear();
+            conflicted_targets.push_back(target_node);
+        } else {
+            // Intersect with existing valid mappings
+            if (valid_mappings_[target_node].empty()) {
+                // First constraint: initialize with all nodes with matching trait
+                valid_mappings_[target_node] = trait_it->second;
+            } else {
+                // Intersect with existing constraints
+                auto old_size = valid_mappings_[target_node].size();
+                valid_mappings_[target_node] = intersect_sets(valid_mappings_[target_node], trait_it->second);
+                if (valid_mappings_[target_node].empty() && old_size > 0) {
+                    conflicted_targets.push_back(target_node);
+                }
+            }
+        }
+    }
+
+    // Validate automatically and throw if invalid
+    validate_and_throw();
+}
+
+template <typename TargetNode, typename GlobalNode>
+template <typename TraitType>
+void MappingConstraints<TargetNode, GlobalNode>::add_preferred_trait_constraint(
+    const std::map<TargetNode, TraitType>& target_traits, const std::map<GlobalNode, TraitType>& global_traits) {
+    // Build reverse map: trait value -> set of global nodes with that trait
+    std::map<TraitType, std::set<GlobalNode>> trait_to_globals;
+    for (const auto& [global_node, trait_value] : global_traits) {
+        trait_to_globals[trait_value].insert(global_node);
+    }
+
+    // Apply trait constraint to preferred_mappings_ (preferred)
+    for (const auto& [target_node, trait_value] : target_traits) {
+        auto trait_it = trait_to_globals.find(trait_value);
+        if (trait_it != trait_to_globals.end()) {
+            // Intersect with existing preferred mappings
+            if (preferred_mappings_[target_node].empty()) {
+                // First preferred constraint: initialize with all nodes with matching trait
+                preferred_mappings_[target_node] = trait_it->second;
+            } else {
+                // Intersect with existing preferred constraints
+                preferred_mappings_[target_node] = intersect_sets(preferred_mappings_[target_node], trait_it->second);
+            }
+        }
+    }
+}
+
+// MappingConstraints non-template method implementations
+// These are non-template methods of a template class, so they're implemented here
+// to allow implicit instantiation without explicit instantiations
+template <typename TargetNode, typename GlobalNode>
+MappingConstraints<TargetNode, GlobalNode>::MappingConstraints(
+    const std::set<std::pair<TargetNode, GlobalNode>>& required_constraints,
+    const std::set<std::pair<TargetNode, GlobalNode>>& preferred_constraints) {
+    // Convert required pairs into mapping format
+    for (const auto& [target, global] : required_constraints) {
+        if (valid_mappings_[target].empty()) {
+            valid_mappings_[target].insert(global);
+        } else {
+            std::set<GlobalNode> singleton{global};
+            valid_mappings_[target] = intersect_sets(valid_mappings_[target], singleton);
+        }
+    }
+
+    // Convert preferred pairs into mapping format
+    for (const auto& [target, global] : preferred_constraints) {
+        preferred_mappings_[target].insert(global);
+    }
+
+    // Validate automatically and throw if invalid
+    validate_and_throw();
+}
+
+template <typename TargetNode, typename GlobalNode>
+void MappingConstraints<TargetNode, GlobalNode>::add_required_constraint(
+    TargetNode target_node, GlobalNode global_node) {
+    // Intersect valid_mappings_[target] with {global_node}
+    if (valid_mappings_[target_node].empty()) {
+        // First constraint: initialize with this single node
+        valid_mappings_[target_node].insert(global_node);
+    } else {
+        // Intersect with existing constraints
+        std::set<GlobalNode> singleton{global_node};
+        valid_mappings_[target_node] = intersect_sets(valid_mappings_[target_node], singleton);
+    }
+
+    // Validate automatically and throw if invalid
+    validate_and_throw();
+}
+
+template <typename TargetNode, typename GlobalNode>
+void MappingConstraints<TargetNode, GlobalNode>::add_preferred_constraint(
+    TargetNode target_node, GlobalNode global_node) {
+    // Add to preferred mappings (doesn't restrict valid mappings)
+    preferred_mappings_[target_node].insert(global_node);
+}
+
+template <typename TargetNode, typename GlobalNode>
+void MappingConstraints<TargetNode, GlobalNode>::validate_and_throw() const {
+    // Check if any target node has an empty valid_mappings_ set
+    std::vector<TargetNode> conflicted_targets;
+    for (const auto& [target, valid_set] : valid_mappings_) {
+        if (valid_set.empty()) {
+            conflicted_targets.push_back(target);
+        }
+    }
+
+    if (!conflicted_targets.empty()) {
+        std::ostringstream oss;
+        oss << "Constraint validation failed: " << conflicted_targets.size()
+            << " target node(s) have no valid mappings (overconstrained).";
+        TT_THROW("{}", oss.str());
+    }
+}
+
+template <typename TargetNode, typename GlobalNode>
+const std::set<GlobalNode>& MappingConstraints<TargetNode, GlobalNode>::get_valid_mappings(TargetNode target) const {
+    static const std::set<GlobalNode> empty_set;
+    auto it = valid_mappings_.find(target);
+    if (it != valid_mappings_.end()) {
+        return it->second;
+    }
+    return empty_set;
+}
+
+template <typename TargetNode, typename GlobalNode>
+const std::set<GlobalNode>& MappingConstraints<TargetNode, GlobalNode>::get_preferred_mappings(
+    TargetNode target) const {
+    static const std::set<GlobalNode> empty_set;
+    auto it = preferred_mappings_.find(target);
+    if (it != preferred_mappings_.end()) {
+        return it->second;
+    }
+    return empty_set;
+}
+
+template <typename TargetNode, typename GlobalNode>
+bool MappingConstraints<TargetNode, GlobalNode>::is_valid_mapping(TargetNode target, GlobalNode global) const {
+    // If target is not in the dictionary, assume mapping is valid
+    auto it = valid_mappings_.find(target);
+    if (it == valid_mappings_.end()) {
+        return true;
+    }
+    // Otherwise, check if global node is in the valid mappings set
+    return it->second.find(global) != it->second.end();
+}
+
+template <typename TargetNode, typename GlobalNode>
+const std::map<TargetNode, std::set<GlobalNode>>& MappingConstraints<TargetNode, GlobalNode>::get_valid_mappings()
+    const {
+    return valid_mappings_;
+}
+
+template <typename TargetNode, typename GlobalNode>
+const std::map<TargetNode, std::set<GlobalNode>>& MappingConstraints<TargetNode, GlobalNode>::get_preferred_mappings()
+    const {
+    return preferred_mappings_;
+}
+
+template <typename TargetNode, typename GlobalNode>
+std::set<GlobalNode> MappingConstraints<TargetNode, GlobalNode>::intersect_sets(
+    const std::set<GlobalNode>& set1, const std::set<GlobalNode>& set2) {
+    std::set<GlobalNode> result;
+    std::set_intersection(set1.begin(), set1.end(), set2.begin(), set2.end(), std::inserter(result, result.begin()));
+    return result;
 }
 
 }  // namespace tt::tt_fabric

--- a/tt_metal/fabric/fabric_types.cpp
+++ b/tt_metal/fabric/fabric_types.cpp
@@ -4,6 +4,10 @@
 
 #include <tt-metalium/experimental/fabric/fabric_types.hpp>
 
+#include <enchantum/enchantum.hpp>
+#include <ostream>
+#include <tt_stl/reflection.hpp>
+
 namespace tt::tt_fabric {
 
 FabricType operator|(FabricType lhs, FabricType rhs) {
@@ -16,4 +20,40 @@ FabricType operator&(FabricType lhs, FabricType rhs) {
 
 bool has_flag(FabricType flags, FabricType test) { return (flags & test) == test; }
 
+FabricNodeId::FabricNodeId(MeshId mesh_id_val, std::uint32_t chip_id_val) :
+    mesh_id(mesh_id_val), chip_id(chip_id_val) {}
+
+bool operator==(const FabricNodeId& lhs, const FabricNodeId& rhs) {
+    return lhs.mesh_id == rhs.mesh_id && lhs.chip_id == rhs.chip_id;
+}
+
+bool operator!=(const FabricNodeId& lhs, const FabricNodeId& rhs) { return !(lhs == rhs); }
+
+bool operator<(const FabricNodeId& lhs, const FabricNodeId& rhs) {
+    return lhs.mesh_id < rhs.mesh_id || (lhs.mesh_id == rhs.mesh_id && lhs.chip_id < rhs.chip_id);
+}
+
+bool operator>(const FabricNodeId& lhs, const FabricNodeId& rhs) { return rhs < lhs; }
+
+bool operator<=(const FabricNodeId& lhs, const FabricNodeId& rhs) { return !(rhs > lhs); }
+
+bool operator>=(const FabricNodeId& lhs, const FabricNodeId& rhs) { return !(lhs < rhs); }
+
+std::ostream& operator<<(std::ostream& os, const FabricNodeId& fabric_node_id) {
+    using ::operator<<;  // Enable ADL for StrongType operator<<
+    os << "M" << fabric_node_id.mesh_id << "D" << fabric_node_id.chip_id;
+    return os;
+}
+
 }  // namespace tt::tt_fabric
+
+namespace std {
+size_t hash<tt::tt_fabric::FabricNodeId>::operator()(const tt::tt_fabric::FabricNodeId& fabric_node_id) const noexcept {
+    return tt::stl::hash::hash_objects_with_default_seed(fabric_node_id.mesh_id, fabric_node_id.chip_id);
+}
+}  // namespace std
+
+auto fmt::formatter<tt::tt_fabric::FabricNodeId>::format(
+    const tt::tt_fabric::FabricNodeId& node_id, format_context& ctx) const -> format_context::iterator {
+    return fmt::format_to(ctx.out(), "(M{}, D{})", *node_id.mesh_id, node_id.chip_id);
+}

--- a/tt_metal/fabric/routing_table_generator.cpp
+++ b/tt_metal/fabric/routing_table_generator.cpp
@@ -17,31 +17,7 @@
 #include <tt-logger/tt-logger.hpp>
 #include <tt-metalium/experimental/fabric/topology_mapper.hpp>
 
-auto fmt::formatter<tt::tt_fabric::FabricNodeId>::format(
-    const tt::tt_fabric::FabricNodeId& node_id, format_context& ctx) const -> format_context::iterator {
-    return fmt::format_to(ctx.out(), "(M{}, D{})", *node_id.mesh_id, node_id.chip_id);
-}
-
 namespace tt::tt_fabric {
-
-FabricNodeId::FabricNodeId(MeshId mesh_id_val, std::uint32_t chip_id_val) :
-    mesh_id(mesh_id_val), chip_id(chip_id_val) {}
-
-bool operator==(const FabricNodeId& lhs, const FabricNodeId& rhs) {
-    return lhs.mesh_id == rhs.mesh_id && lhs.chip_id == rhs.chip_id;
-}
-bool operator!=(const FabricNodeId& lhs, const FabricNodeId& rhs) { return !(lhs == rhs); }
-bool operator<(const FabricNodeId& lhs, const FabricNodeId& rhs) {
-    return lhs.mesh_id < rhs.mesh_id || (lhs.mesh_id == rhs.mesh_id && lhs.chip_id < rhs.chip_id);
-}
-bool operator>(const FabricNodeId& lhs, const FabricNodeId& rhs) { return rhs < lhs; }
-bool operator<=(const FabricNodeId& lhs, const FabricNodeId& rhs) { return !(rhs > lhs); }
-bool operator>=(const FabricNodeId& lhs, const FabricNodeId& rhs) { return !(lhs < rhs); }
-std::ostream& operator<<(std::ostream& os, const FabricNodeId& fabric_node_id) {
-    using ::operator<<;  // Enable ADL for StrongType operator<<
-    os << "M" << fabric_node_id.mesh_id << "D" << fabric_node_id.chip_id;
-    return os;
-}
 
 RoutingTableGenerator::RoutingTableGenerator(const TopologyMapper& topology_mapper) :
     topology_mapper_(topology_mapper) {

--- a/tt_metal/fabric/topology_solver.cpp
+++ b/tt_metal/fabric/topology_solver.cpp
@@ -1,0 +1,104 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <unordered_set>
+
+#include <tt-metalium/experimental/fabric/topology_solver.hpp>
+#include <tt-metalium/experimental/fabric/fabric_types.hpp>
+#include "tt_metal/fabric/physical_system_descriptor.hpp"
+#include "tt_metal/impl/context/metal_context.hpp"
+#include <llrt/tt_cluster.hpp>
+
+namespace tt::tt_fabric {
+
+std::map<MeshId, AdjacencyGraph<FabricNodeId>> build_adjacency_map_logical(const MeshGraph& mesh_graph) {
+    std::map<MeshId, AdjacencyGraph<FabricNodeId>> adjacency_map;
+
+    auto get_local_adjacents = [&](FabricNodeId fabric_node_id, MeshId mesh_id) {
+        auto adjacent_map = mesh_graph.get_intra_mesh_connectivity()[*mesh_id][fabric_node_id.chip_id];
+
+        std::vector<FabricNodeId> adjacents;
+        for (const auto& [neighbor_chip_id, edge] : adjacent_map) {
+            // Skip self-connections
+            if (neighbor_chip_id == fabric_node_id.chip_id) {
+                continue;
+            }
+            for (size_t i = 0; i < edge.connected_chip_ids.size(); ++i) {
+                adjacents.push_back(FabricNodeId(mesh_id, neighbor_chip_id));
+            }
+        }
+        return adjacents;
+    };
+
+    // Iterate over all mesh IDs from the mesh graph
+    for (const auto& mesh_id : mesh_graph.get_mesh_ids()) {
+        AdjacencyGraph<FabricNodeId>::AdjacencyMap logical_adjacency_map;
+        for (const auto& [_, chip_id] : mesh_graph.get_chip_ids(mesh_id)) {
+            auto fabric_node_id = FabricNodeId(mesh_id, chip_id);
+            logical_adjacency_map[fabric_node_id] = get_local_adjacents(fabric_node_id, mesh_id);
+        }
+        adjacency_map[mesh_id] = AdjacencyGraph<FabricNodeId>(logical_adjacency_map);
+    }
+
+    return adjacency_map;
+}
+
+std::map<MeshId, AdjacencyGraph<tt::tt_metal::AsicID>> build_adjacency_map_physical(
+    const tt::tt_metal::PhysicalSystemDescriptor& physical_system_descriptor,
+    const std::map<MeshId, std::map<tt::tt_metal::AsicID, MeshHostRankId>>& asic_id_to_mesh_rank) {
+    std::map<MeshId, AdjacencyGraph<tt::tt_metal::AsicID>> adjacency_map;
+
+    // Build a set of ASIC IDs for each mesh based on mesh rank mapping
+    std::map<MeshId, std::unordered_set<tt::tt_metal::AsicID>> mesh_asic_ids;
+    for (const auto& [mesh_id, asic_map] : asic_id_to_mesh_rank) {
+        for (const auto& [asic_id, _] : asic_map) {
+            mesh_asic_ids[mesh_id].insert(asic_id);
+        }
+    }
+
+    for (const auto& [mesh_id, mesh_asics] : mesh_asic_ids) {
+        auto z_channels = std::unordered_set<uint8_t>{8, 9};
+        auto cluster_type = tt::tt_metal::MetalContext::instance().get_cluster().get_cluster_type();
+
+        auto get_local_adjacents = [&](tt::tt_metal::AsicID asic_id,
+                                       const std::unordered_set<tt::tt_metal::AsicID>& mesh_asics) {
+            std::vector<tt::tt_metal::AsicID> adjacents;
+
+            for (const auto& neighbor : physical_system_descriptor.get_asic_neighbors(asic_id)) {
+                // Skip self-connections
+                if (neighbor == asic_id) {
+                    continue;
+                }
+                // Make sure that the neighbor is in the mesh
+                if (mesh_asics.contains(neighbor)) {
+                    // Add each neighbor multiple times based on number of ethernet connections
+                    auto eth_connections = physical_system_descriptor.get_eth_connections(asic_id, neighbor);
+                    for (const auto& eth_connection : eth_connections) {
+                        // NOTE: IGNORE Z channels for Blackhole galaxy in intra mesh connectivity for now since
+                        // they cause issues with uniform mesh mapping since topology mapper algorithm does not prefer
+                        // taking the full connectivity path vs downgrading through z channels for intramesh
+                        // connectivity https://github.com/tenstorrent/tt-metal/issues/31846
+                        if (cluster_type == tt::tt_metal::ClusterType::BLACKHOLE_GALAXY &&
+                            (z_channels.contains(eth_connection.src_chan) ||
+                             z_channels.contains(eth_connection.dst_chan))) {
+                            continue;
+                        }
+                        adjacents.push_back(neighbor);
+                    }
+                }
+            }
+            return adjacents;
+        };
+
+        AdjacencyGraph<tt::tt_metal::AsicID>::AdjacencyMap physical_adjacency_map;
+        for (const auto& asic_id : mesh_asics) {
+            physical_adjacency_map[asic_id] = get_local_adjacents(asic_id, mesh_asics);
+        }
+        adjacency_map[mesh_id] = AdjacencyGraph<tt::tt_metal::AsicID>(physical_adjacency_map);
+    }
+
+    return adjacency_map;
+}
+
+}  // namespace tt::tt_fabric


### PR DESCRIPTION
This PR adds the constraint system API for the topology solver.

## Changes
- Add `MappingConstraints` template class for unified constraint system
- Support required and preferred constraints (both trait-based and explicit pairs)
- Constraints are intersected - target nodes must satisfy ALL required constraints
- Add validation that throws on conflicting constraints
- Add query methods: `get_valid_mappings()`, `get_preferred_mappings()`, `is_valid_mapping()`

## Purpose
This is the second of 4 PRs. It builds on PR #1 (AdjacencyGraph API) and adds the constraint specification system that will be used by the solver in PR #3.