### PR TITLE
fix(sweeps): propagate device architecture to individual test records

### DIFF
--- a/tests/sweep_framework/framework/result_destination.py
+++ b/tests/sweep_framework/framework/result_destination.py
@@ -402,7 +402,19 @@ class FileResultDestination(ResultDestination):
                 op_params=None,
                 git_sha=git_hash,
                 status=mapped_status,
-                card_type="n/a",
+                # Propagate device architecture (wormhole_b0/blackhole) captured at run-level into each test record.
+                # Prefer any per-test field if present; otherwise fall back to run metadata.
+                card_type=str(
+                    raw.get("card_type")
+                    or raw.get("device")
+                    or header.get("card_type")
+                    or header.get("device")
+                    or run_context.get("card_type")
+                    or run_context.get("device")
+                    or (self._run_metadata.get("device") if self._run_metadata else None)
+                    or (self._run_metadata.get("card_type") if self._run_metadata else None)
+                    or "unknown"
+                ),
                 backend="n/a",
                 data_source="ttnn op test",
                 input_hash=raw.get("input_hash"),


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/31683

### Problem description
The sweep framework captures device architecture (wormhole_b0 or blackhole) at the run level (OpRun.card_type) from the ARCH_NAME environment variable, but individual test records (OpTest.card_type) were hardcoded to "n/a". This prevents filtering and analysis by architecture at the test level, even though the architecture is known for the entire run.


### What's changed
- Updated tests/sweep_framework/framework/result_destination.py to propagate card_type from run metadata to each OpTest record.
- Replaced the hardcoded card_type="n/a" with a fallback chain that checks:

1. Per-test result fields (raw.get("card_type"), raw.get("device"))
2. Header metadata (header.get("card_type"), header.get("device"))
3. Run context (run_context.get("card_type"), run_context.get("device"))
4. Run metadata (self._run_metadata.get("card_type"), self._run_metadata.get("device"))
5. Defaults to "unknown" if none found

This ensures each test record inherits the architecture from the run-level metadata (set by sweeps_runner.py from ARCH_NAME), enabling downstream analysis and filtering by device architecture at the test level.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/docs/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] [cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) job passes
- [ ] New/Existing tests provide coverage for changes